### PR TITLE
Use ScheduleBuilder to handle module construction

### DIFF
--- a/FWCore/Framework/interface/GlobalSchedule.h
+++ b/FWCore/Framework/interface/GlobalSchedule.h
@@ -3,7 +3,6 @@
 
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/Common/interface/FWCoreCommonFwd.h"
-#include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/ExceptionActions.h"
 #include "FWCore/Framework/interface/ExceptionHelpers.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -13,7 +12,6 @@
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/Framework/interface/WorkerManager.h"
 #include "FWCore/Framework/interface/maker/Worker.h"
-#include "FWCore/Framework/interface/SignallingProductRegistryFiller.h"
 #include "FWCore/MessageLogger/interface/ExceptionMessages.h"
 #include "FWCore/ServiceRegistry/interface/GlobalContext.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
@@ -46,24 +44,25 @@ namespace edm {
   class PathStatusInserter;
   class EndPathStatusInserter;
 
+  namespace maker {
+    class ModuleHolder;
+  }
+
   class GlobalSchedule {
   public:
-    typedef std::vector<std::string> vstring;
-    typedef std::vector<Worker*> AllWorkers;
-    typedef std::shared_ptr<Worker> WorkerPtr;
-    typedef std::vector<Worker*> Workers;
+    using vstring = std::vector<std::string>;
+    using AllWorkers = std::vector<Worker*>;
+    using WorkerPtr = std::shared_ptr<Worker>;
+    using Wokers = std::vector<Worker*>;
 
     GlobalSchedule(std::shared_ptr<TriggerResultInserter> inserter,
                    std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters,
                    std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>>& endPathStatusInserters,
                    std::shared_ptr<ModuleRegistry> modReg,
                    std::vector<edm::ModuleDescription const*> const& modulesToUse,
-                   ParameterSet& proc_pset,
-                   SignallingProductRegistryFiller& pregistry,
                    PreallocationConfiguration const& prealloc,
                    ExceptionToActionTable const& actions,
                    std::shared_ptr<ActivityRegistry> areg,
-                   std::shared_ptr<ProcessConfiguration const> processConfiguration,
                    ProcessContext const* processContext);
     GlobalSchedule(GlobalSchedule const&) = delete;
 

--- a/FWCore/Framework/interface/GlobalSchedule.h
+++ b/FWCore/Framework/interface/GlobalSchedule.h
@@ -57,7 +57,7 @@ namespace edm {
                    std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters,
                    std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>>& endPathStatusInserters,
                    std::shared_ptr<ModuleRegistry> modReg,
-                   std::vector<std::string> const& modulesToUse,
+                   std::vector<edm::ModuleDescription const*> const& modulesToUse,
                    ParameterSet& proc_pset,
                    SignallingProductRegistryFiller& pregistry,
                    PreallocationConfiguration const& prealloc,

--- a/FWCore/Framework/interface/ModuleInPath.h
+++ b/FWCore/Framework/interface/ModuleInPath.h
@@ -1,0 +1,21 @@
+#ifndef FWCore_Framework_ModuleInPath_h
+#define FWCore_Framework_ModuleInPath_h
+
+/** Class used to hold the traits for how a module should be handled in a Path
+ */
+
+#include "FWCore/Framework/interface/WorkerInPath.h"
+
+namespace edm {
+  class ModuleDescription;
+
+  struct ModuleInPath {
+    ModuleInPath(ModuleDescription const* iDesc, WorkerInPath::FilterAction iAct, unsigned int iPlace, bool iConcurrent)
+        : description_(iDesc), placeInPath_(iPlace), action_(iAct), runConcurrently_(iConcurrent) {}
+    ModuleDescription const* description_;
+    unsigned int placeInPath_;
+    WorkerInPath::FilterAction action_;
+    bool runConcurrently_;
+  };
+}  // namespace edm
+#endif

--- a/FWCore/Framework/interface/ModuleRegistry.h
+++ b/FWCore/Framework/interface/ModuleRegistry.h
@@ -36,6 +36,7 @@ namespace edm {
   struct MakeModuleParams;
   class ModuleDescription;
   class PreallocationConfiguration;
+  class SignallingProductRegistryFiller;
 
   class ModuleRegistry {
   public:

--- a/FWCore/Framework/interface/ModuleRegistry.h
+++ b/FWCore/Framework/interface/ModuleRegistry.h
@@ -104,6 +104,14 @@ namespace edm {
       }
     }
 
+    template <typename F>
+    void forAllModuleHolders(F iFunc) const {
+      for (auto& labelMod : labelToModule_) {
+        maker::ModuleHolder const* t = labelMod.second.get();
+        iFunc(t);
+      }
+    }
+
     unsigned int maxModuleID() const { return maxModuleID_; }
 
   private:

--- a/FWCore/Framework/interface/OutputModuleCore.h
+++ b/FWCore/Framework/interface/OutputModuleCore.h
@@ -208,7 +208,6 @@ namespace edm {
       void doOpenFile(FileBlock const& fb);
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
-      void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 
       /// Tell the OutputModule that is must end the current file.
       void doCloseFile();

--- a/FWCore/Framework/interface/OutputModuleCore.h
+++ b/FWCore/Framework/interface/OutputModuleCore.h
@@ -208,7 +208,6 @@ namespace edm {
       void doOpenFile(FileBlock const& fb);
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
-      void doRespondToCloseOutputFile() {}
       void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 
       /// Tell the OutputModule that is must end the current file.

--- a/FWCore/Framework/interface/PathsAndConsumesOfModules.h
+++ b/FWCore/Framework/interface/PathsAndConsumesOfModules.h
@@ -29,9 +29,13 @@
 namespace edm {
 
   class ModuleDescription;
+  class ModuleRegistry;
   class ProductRegistry;
   class Schedule;
 
+  namespace maker {
+    class ModuleHolder;
+  }  // namespace maker
   namespace eventsetup {
     struct ComponentDescription;
     class ESProductResolverProvider;
@@ -96,9 +100,8 @@ namespace edm {
     std::vector<std::vector<ModuleDescription const*>> modulesOnPaths_;
     std::vector<std::vector<ModuleDescription const*>> modulesOnEndPaths_;
 
-    // Gives a translation from the module ID to the index into the
-    // following data member
-    std::vector<std::pair<unsigned int, unsigned int>> moduleIDToIndex_;
+    // Gives a translation from the module ID to the holder
+    std::vector<edm::maker::ModuleHolder const*> moduleIDToHolder_;
 
     std::array<std::vector<std::vector<ModuleDescription const*>>, NumBranchTypes> modulesWhoseProductsAreConsumedBy_;
 
@@ -114,6 +117,7 @@ namespace edm {
     std::vector<std::vector<eventsetup::ComponentDescription const*>> esModulesWhoseProductsAreConsumedByESModule_;
 
     Schedule const* schedule_ = nullptr;
+    ModuleRegistry const* moduleRegistry_ = nullptr;
     ProducedByESModule producedByESModule_;
     std::shared_ptr<ProductRegistry const> preg_;
     bool eventSetupInfoInitialized_ = false;

--- a/FWCore/Framework/interface/PathsAndConsumesOfModules.h
+++ b/FWCore/Framework/interface/PathsAndConsumesOfModules.h
@@ -117,7 +117,6 @@ namespace edm {
     std::vector<std::vector<eventsetup::ComponentDescription const*>> esModulesWhoseProductsAreConsumedByESModule_;
 
     Schedule const* schedule_ = nullptr;
-    ModuleRegistry const* moduleRegistry_ = nullptr;
     ProducedByESModule producedByESModule_;
     std::shared_ptr<ProductRegistry const> preg_;
     bool eventSetupInfoInitialized_ = false;

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -306,7 +306,7 @@ namespace edm {
     std::shared_ptr<ModuleRegistry const> moduleRegistrySharedPtr() const {
       return get_underlying_safe(moduleRegistry_);
     }
-    std::shared_ptr<ModuleRegistry>& moduleRegistry() { return get_underlying_safe(moduleRegistry_); }
+    std::shared_ptr<ModuleRegistry>& moduleRegistrySharedPtr() { return get_underlying_safe(moduleRegistry_); }
 
     edm::propagate_const<std::shared_ptr<ModuleRegistry>> moduleRegistry_;
     edm::propagate_const<std::shared_ptr<TriggerResultInserter>> resultsInserter_;

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -289,6 +289,8 @@ namespace edm {
     /// returns the collection of pointers to workers
     AllWorkers const& allWorkers() const;
 
+    ModuleRegistry const& moduleRegistry() const { return *moduleRegistry_; }
+
     /// Convert "@currentProcess" in InputTag process names to the actual current process name.
     void convertCurrentProcessAlias(std::string const& processName);
 
@@ -301,7 +303,9 @@ namespace edm {
       return get_underlying_safe(resultsInserter_);
     }
     std::shared_ptr<TriggerResultInserter>& resultsInserter() { return get_underlying_safe(resultsInserter_); }
-    std::shared_ptr<ModuleRegistry const> moduleRegistry() const { return get_underlying_safe(moduleRegistry_); }
+    std::shared_ptr<ModuleRegistry const> moduleRegistrySharedPtr() const {
+      return get_underlying_safe(moduleRegistry_);
+    }
     std::shared_ptr<ModuleRegistry>& moduleRegistry() { return get_underlying_safe(moduleRegistry_); }
 
     edm::propagate_const<std::shared_ptr<ModuleRegistry>> moduleRegistry_;

--- a/FWCore/Framework/interface/StreamSchedule.h
+++ b/FWCore/Framework/interface/StreamSchedule.h
@@ -253,6 +253,7 @@ namespace edm {
 
     std::vector<Worker*> tryToPlaceConditionalModules(
         Worker*,
+        ModuleRegistry& iRegistry,
         std::unordered_set<std::string>& conditionalModules,
         std::unordered_multimap<std::string, edm::ProductDescription const*> const& conditionalModuleBranches,
         std::unordered_multimap<std::string, AliasInfo> const& aliasMap,
@@ -261,6 +262,7 @@ namespace edm {
         PreallocationConfiguration const* prealloc,
         std::shared_ptr<ProcessConfiguration const> processConfiguration);
     PathWorkers fillWorkers(ParameterSet& proc_pset,
+                            ModuleRegistry& moduleRegistry,
                             SignallingProductRegistryFiller& preg,
                             PreallocationConfiguration const* prealloc,
                             std::shared_ptr<ProcessConfiguration const> processConfiguration,
@@ -270,6 +272,7 @@ namespace edm {
                             ConditionalTaskHelper const& conditionalTaskHelper,
                             std::unordered_set<std::string>& allConditionalModules);
     void fillTrigPath(ParameterSet& proc_pset,
+                      ModuleRegistry& moduleRegistry,
                       SignallingProductRegistryFiller& preg,
                       PreallocationConfiguration const* prealloc,
                       std::shared_ptr<ProcessConfiguration const> processConfiguration,
@@ -280,6 +283,7 @@ namespace edm {
                       ConditionalTaskHelper const& conditionalTaskHelper,
                       std::unordered_set<std::string>& allConditionalModules);
     void fillEndPath(ParameterSet& proc_pset,
+                     ModuleRegistry& moduleRegistry,
                      SignallingProductRegistryFiller& preg,
                      PreallocationConfiguration const* prealloc,
                      std::shared_ptr<ProcessConfiguration const> processConfiguration,

--- a/FWCore/Framework/interface/StreamSchedule.h
+++ b/FWCore/Framework/interface/StreamSchedule.h
@@ -64,10 +64,10 @@
 #include "FWCore/Framework/interface/ExceptionHelpers.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/OccurrenceTraits.h"
-#include "FWCore/Framework/interface/UnscheduledCallProducer.h"
 #include "FWCore/Framework/interface/WorkerManager.h"
 #include "FWCore/Framework/interface/Path.h"
 #include "FWCore/Framework/interface/TransitionInfoTypes.h"
+#include "FWCore/Framework/interface/ModuleInPath.h"
 #include "FWCore/Framework/interface/maker/Worker.h"
 #include "FWCore/Framework/interface/EarlyDeleteHelper.h"
 #include "FWCore/MessageLogger/interface/ExceptionMessages.h"
@@ -109,7 +109,6 @@ namespace edm {
   class ExceptionCollector;
   class ExceptionToActionTable;
   class OutputModuleCommunicator;
-  class UnscheduledCallProducer;
   class WorkerInPath;
   class ModuleRegistry;
   class TriggerResultInserter;
@@ -134,14 +133,30 @@ namespace edm {
 
     typedef std::vector<WorkerInPath> PathWorkers;
 
-    StreamSchedule(std::shared_ptr<TriggerResultInserter> inserter,
-                   std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters,
-                   std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>>& endPathStatusInserters,
+    struct PathInfo {
+      PathInfo(std::string name, std::vector<edm::ModuleInPath> modules, std::shared_ptr<PathStatusInserter> inserter)
+          : name_(std::move(name)), modules_(std::move(modules)), inserter_(std::move(inserter)) {}
+      std::string name_;
+      std::vector<edm::ModuleInPath> modules_;
+      std::shared_ptr<PathStatusInserter> inserter_;
+    };
+    struct EndPathInfo {
+      EndPathInfo(std::string name,
+                  std::vector<edm::ModuleInPath> modules,
+                  std::shared_ptr<EndPathStatusInserter> inserter)
+          : name_(std::move(name)), modules_(std::move(modules)), inserter_(std::move(inserter)) {}
+      std::string name_;
+      std::vector<edm::ModuleInPath> modules_;
+      std::shared_ptr<EndPathStatusInserter> inserter_;
+    };
+
+    StreamSchedule(std::vector<PathInfo> const& paths,
+                   std::vector<EndPathInfo> const& endPaths,
+                   std::vector<ModuleDescription const*> const& unscheduledModules,
+                   std::shared_ptr<TriggerResultInserter> inserter,
                    std::shared_ptr<ModuleRegistry>,
                    ParameterSet& proc_pset,
-                   service::TriggerNamesService const& tns,
                    PreallocationConfiguration const& prealloc,
-                   SignallingProductRegistryFiller& pregistry,
                    ExceptionToActionTable const& actions,
                    std::shared_ptr<ActivityRegistry> areg,
                    std::shared_ptr<ProcessConfiguration const> processConfiguration,
@@ -232,13 +247,6 @@ namespace edm {
 
     StreamContext const& context() const { return streamContext_; }
 
-    struct AliasInfo {
-      std::string friendlyClassName;
-      std::string instanceLabel;
-      std::string originalInstanceLabel;
-      std::string originalModuleLabel;
-    };
-
   private:
     /// returns the action table
     ExceptionToActionTable const& actionTable() const { return workerManagerLumisAndEvents_.actionTable(); }
@@ -251,59 +259,14 @@ namespace edm {
 
     void reportSkipped(EventPrincipal const& ep) const;
 
-    std::vector<Worker*> tryToPlaceConditionalModules(
-        Worker*,
-        ModuleRegistry& iRegistry,
-        std::unordered_set<std::string>& conditionalModules,
-        std::unordered_multimap<std::string, edm::ProductDescription const*> const& conditionalModuleBranches,
-        std::unordered_multimap<std::string, AliasInfo> const& aliasMap,
-        ParameterSet& proc_pset,
-        SignallingProductRegistryFiller& preg,
-        PreallocationConfiguration const* prealloc,
-        std::shared_ptr<ProcessConfiguration const> processConfiguration);
-    PathWorkers fillWorkers(ParameterSet& proc_pset,
-                            ModuleRegistry& moduleRegistry,
-                            SignallingProductRegistryFiller& preg,
-                            PreallocationConfiguration const* prealloc,
-                            std::shared_ptr<ProcessConfiguration const> processConfiguration,
-                            std::string const& name,
-                            bool ignoreFilters,
-                            std::vector<std::string> const& endPathNames,
-                            ConditionalTaskHelper const& conditionalTaskHelper,
-                            std::unordered_set<std::string>& allConditionalModules);
-    void fillTrigPath(ParameterSet& proc_pset,
-                      ModuleRegistry& moduleRegistry,
-                      SignallingProductRegistryFiller& preg,
-                      PreallocationConfiguration const* prealloc,
-                      std::shared_ptr<ProcessConfiguration const> processConfiguration,
-                      int bitpos,
-                      std::string const& name,
-                      TrigResPtr,
-                      std::vector<std::string> const& endPathNames,
-                      ConditionalTaskHelper const& conditionalTaskHelper,
-                      std::unordered_set<std::string>& allConditionalModules);
-    void fillEndPath(ParameterSet& proc_pset,
-                     ModuleRegistry& moduleRegistry,
-                     SignallingProductRegistryFiller& preg,
-                     PreallocationConfiguration const* prealloc,
-                     std::shared_ptr<ProcessConfiguration const> processConfiguration,
-                     int bitpos,
-                     std::string const& name,
-                     std::vector<std::string> const& endPathNames,
-                     ConditionalTaskHelper const& conditionalTaskHelper,
-                     std::unordered_set<std::string>& allConditionalModules);
-
-    void addToAllWorkers(Worker* w);
+    PathWorkers fillWorkers(std::vector<ModuleInPath> const&);
+    void fillTrigPath(PathInfo const&, int bitpos, TrigResPtr);
+    void fillEndPath(EndPathInfo const&, int bitpos);
 
     void resetEarlyDelete();
 
     TrigResConstPtr results() const { return get_underlying_safe(results_); }
     TrigResPtr& results() { return get_underlying_safe(results_); }
-
-    void makePathStatusInserters(
-        std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters,
-        std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>>& endPathStatusInserters,
-        ExceptionToActionTable const& actions);
 
     template <typename T>
     void preScheduleSignal(StreamContext const*) const;

--- a/FWCore/Framework/interface/StreamSchedule.h
+++ b/FWCore/Framework/interface/StreamSchedule.h
@@ -48,12 +48,6 @@
   The order of the paths from the input configuration is
   preserved in the main paths list.
 
-  ------------------------
-
-  The StreamSchedule uses the TriggerNamesService to get the names of the
-  trigger paths and end paths. When a TriggerResults object is created
-  the results are stored in the same order as the trigger names from
-  TriggerNamesService.
 
 */
 
@@ -114,24 +108,22 @@ namespace edm {
   class TriggerResultInserter;
   class PathStatusInserter;
   class EndPathStatusInserter;
-  class PreallocationConfiguration;
-  class ConditionalTaskHelper;
 
-  namespace service {
-    class TriggerNamesService;
+  namespace maker {
+    class ModuleHolder;
   }
 
   class StreamSchedule {
   public:
-    typedef std::vector<std::string> vstring;
-    typedef std::vector<Path> TrigPaths;
-    typedef std::shared_ptr<HLTGlobalStatus> TrigResPtr;
-    typedef std::shared_ptr<HLTGlobalStatus const> TrigResConstPtr;
-    typedef std::vector<Worker*> AllWorkers;
+    using vstring = std::vector<std::string>;
+    using TrigPaths = std::vector<Path>;
+    using TrigResPtr = std::shared_ptr<HLTGlobalStatus>;
+    using TrigResConstPtr = std::shared_ptr<HLTGlobalStatus const>;
+    using AllWorkers = std::vector<Worker*>;
 
-    typedef std::vector<Worker*> Workers;
+    using Workers = std::vector<Worker*>;
 
-    typedef std::vector<WorkerInPath> PathWorkers;
+    using PathWorkers = std::vector<WorkerInPath>;
 
     struct PathInfo {
       PathInfo(std::string name, std::vector<edm::ModuleInPath> modules, std::shared_ptr<PathStatusInserter> inserter)
@@ -155,11 +147,8 @@ namespace edm {
                    std::vector<ModuleDescription const*> const& unscheduledModules,
                    std::shared_ptr<TriggerResultInserter> inserter,
                    std::shared_ptr<ModuleRegistry>,
-                   ParameterSet& proc_pset,
-                   PreallocationConfiguration const& prealloc,
                    ExceptionToActionTable const& actions,
                    std::shared_ptr<ActivityRegistry> areg,
-                   std::shared_ptr<ProcessConfiguration const> processConfiguration,
                    StreamID streamID,
                    ProcessContext const* processContext);
 

--- a/FWCore/Framework/interface/WorkerManager.h
+++ b/FWCore/Framework/interface/WorkerManager.h
@@ -42,14 +42,6 @@ namespace edm {
 
     void addToUnscheduledWorkers(ModuleDescription const& iDescription);
 
-    void addToUnscheduledWorkers(ParameterSet& pset,
-                                 SignallingProductRegistryFiller& preg,
-                                 PreallocationConfiguration const* prealloc,
-                                 std::shared_ptr<ProcessConfiguration const> processConfiguration,
-                                 std::string label,
-                                 std::set<std::string>& unscheduledLabels,
-                                 std::vector<std::string>& shouldBeUsedLabels);
-
     template <typename T, typename U>
     void processOneOccurrenceAsync(WaitingTaskHolder,
                                    typename T::TransitionInfoType&,
@@ -75,13 +67,6 @@ namespace edm {
     void addToAllWorkers(Worker* w);
 
     ExceptionToActionTable const& actionTable() const { return *actionTable_; }
-
-    Worker* getWorker(ParameterSet& pset,
-                      SignallingProductRegistryFiller& preg,
-                      PreallocationConfiguration const* prealloc,
-                      std::shared_ptr<ProcessConfiguration const> processConfiguration,
-                      std::string const& label,
-                      bool addToAllWorkers = true);
 
     template <typename T>
       requires requires(T const& x) { x.moduleDescription(); }

--- a/FWCore/Framework/interface/WorkerManager.h
+++ b/FWCore/Framework/interface/WorkerManager.h
@@ -18,11 +18,8 @@
 #include <vector>
 
 namespace edm {
-  class ExceptionCollector;
   class ExceptionToActionTable;
   class ModuleRegistry;
-  class ModuleTypeResolverMaker;
-  class PreallocationConfiguration;
   class Worker;
   namespace eventsetup {
     class ESRecordsToProductResolverIndices;

--- a/FWCore/Framework/interface/WorkerManager.h
+++ b/FWCore/Framework/interface/WorkerManager.h
@@ -40,6 +40,8 @@ namespace edm {
 
     void deleteModuleIfExists(std::string const& moduleLabel);
 
+    void addToUnscheduledWorkers(ModuleDescription const& iDescription);
+
     void addToUnscheduledWorkers(ParameterSet& pset,
                                  SignallingProductRegistryFiller& preg,
                                  PreallocationConfiguration const* prealloc,
@@ -82,12 +84,21 @@ namespace edm {
                       bool addToAllWorkers = true);
 
     template <typename T>
+      requires requires(T const& x) { x.moduleDescription(); }
     Worker* getWorkerForModule(T const& module) {
       auto* worker = getWorkerForExistingModule(module.moduleDescription().moduleLabel());
       assert(worker != nullptr);
       assert(worker->matchesBaseClassPointer(static_cast<typename T::ModuleType const*>(&module)));
       return worker;
     }
+
+    Worker* getWorkerForModule(edm::ModuleDescription const& iDescription) {
+      auto* worker = getWorkerForExistingModule(iDescription.moduleLabel());
+      assert(worker != nullptr);
+      assert(worker->description() == &iDescription);
+      return worker;
+    }
+
     void resetAll();
 
   private:

--- a/FWCore/Framework/interface/WorkerRegistry.h
+++ b/FWCore/Framework/interface/WorkerRegistry.h
@@ -21,13 +21,7 @@ namespace edm {
   class Worker;
   class ActivityRegistry;
   class ModuleRegistry;
-  class ModuleTypeResolverMaker;
-  class ParameterSet;
   class ExceptionToActionTable;
-  namespace maker {
-    class ModuleHolder;
-  }
-
   /**
      \class WorkerRegistry WorkerRegistry.h "edm/WorkerRegistry.h"
 

--- a/FWCore/Framework/interface/WorkerRegistry.h
+++ b/FWCore/Framework/interface/WorkerRegistry.h
@@ -20,7 +20,6 @@ namespace edm {
 
   class Worker;
   class ActivityRegistry;
-  struct WorkerParams;
   class ModuleRegistry;
   class ModuleTypeResolverMaker;
   class ParameterSet;
@@ -46,17 +45,13 @@ namespace edm {
     WorkerRegistry(WorkerRegistry const&) = delete;             // Disallow copying and moving
     WorkerRegistry& operator=(WorkerRegistry const&) = delete;  // Disallow copying and moving
 
-    /// Retrieve the particular instance of the worker
-    /** If the worker with that set of parameters does not exist,
-        create it
-        @note Workers are owned by this class, do not delete them*/
-    Worker* getWorker(WorkerParams const& p, std::string const& moduleLabel);
-
     /// Retrieve particular instance of the worker without creating it
     /// If one doesn't exist, returns nullptr
     Worker const* get(std::string const& moduleLabel) const;
 
-    //Creates worker if needed
+    /** Creates worker if doesn't already exist
+     * @note Workers are owned by this class, do not delete them
+     */
     Worker* getWorkerFromExistingModule(std::string const& moduleLabel, ExceptionToActionTable const* actions);
 
     /// Deletes the module of the Worker, but the Worker continues to exist.

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -100,7 +100,6 @@ namespace edm {
       void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
       void doRespondToCloseOutputFile() { clearInputProcessBlockCaches(); }
-      void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 
       void registerProductsAndCallbacks(EDAnalyzerBase* module, SignallingProductRegistryFiller* reg);
 

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -99,8 +99,6 @@ namespace edm {
       void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
       void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
-      void doRespondToOpenInputFile(FileBlock const&) {}
-      void doRespondToCloseInputFile(FileBlock const&) {}
       void doRespondToCloseOutputFile() { clearInputProcessBlockCaches(); }
       void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -106,8 +106,6 @@ namespace edm {
       void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
       void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
-      void doRespondToOpenInputFile(FileBlock const&) {}
-      void doRespondToCloseInputFile(FileBlock const&) {}
       void doRespondToCloseOutputFile() { clearInputProcessBlockCaches(); }
       void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -107,7 +107,6 @@ namespace edm {
       void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
       void doRespondToCloseOutputFile() { clearInputProcessBlockCaches(); }
-      void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 
       void registerProductsAndCallbacks(EDFilterBase* module, SignallingProductRegistryFiller* reg) {
         registerProducts(module, reg, moduleDescription_);

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -104,7 +104,6 @@ namespace edm {
       void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
       void doRespondToCloseOutputFile() { clearInputProcessBlockCaches(); }
-      void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 
       void registerProductsAndCallbacks(EDProducerBase* module, SignallingProductRegistryFiller* reg) {
         registerProducts(module, reg, moduleDescription_);

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -103,8 +103,6 @@ namespace edm {
       void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
       void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
-      void doRespondToOpenInputFile(FileBlock const&) {}
-      void doRespondToCloseInputFile(FileBlock const&) {}
       void doRespondToCloseOutputFile() { clearInputProcessBlockCaches(); }
       void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 

--- a/FWCore/Framework/interface/limited/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzerBase.h
@@ -105,7 +105,6 @@ namespace edm {
       void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
       void doRespondToCloseOutputFile() { clearInputProcessBlockCaches(); }
-      void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 
       void registerProductsAndCallbacks(EDAnalyzerBase* module, SignallingProductRegistryFiller* reg);
 

--- a/FWCore/Framework/interface/limited/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzerBase.h
@@ -104,8 +104,6 @@ namespace edm {
       void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
       void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
-      void doRespondToOpenInputFile(FileBlock const&) {}
-      void doRespondToCloseInputFile(FileBlock const&) {}
       void doRespondToCloseOutputFile() { clearInputProcessBlockCaches(); }
       void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 

--- a/FWCore/Framework/interface/limited/EDFilterBase.h
+++ b/FWCore/Framework/interface/limited/EDFilterBase.h
@@ -110,8 +110,6 @@ namespace edm {
       void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
       void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
-      void doRespondToOpenInputFile(FileBlock const&) {}
-      void doRespondToCloseInputFile(FileBlock const&) {}
       void doRespondToCloseOutputFile() { clearInputProcessBlockCaches(); }
       void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 

--- a/FWCore/Framework/interface/limited/EDFilterBase.h
+++ b/FWCore/Framework/interface/limited/EDFilterBase.h
@@ -111,7 +111,6 @@ namespace edm {
       void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
       void doRespondToCloseOutputFile() { clearInputProcessBlockCaches(); }
-      void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 
       void registerProductsAndCallbacks(EDFilterBase* module, SignallingProductRegistryFiller* reg) {
         registerProducts(module, reg, moduleDescription_);

--- a/FWCore/Framework/interface/limited/EDProducerBase.h
+++ b/FWCore/Framework/interface/limited/EDProducerBase.h
@@ -108,7 +108,6 @@ namespace edm {
       void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
       void doRespondToCloseOutputFile() { clearInputProcessBlockCaches(); }
-      void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 
       void registerProductsAndCallbacks(EDProducerBase* module, SignallingProductRegistryFiller* reg) {
         registerProducts(module, reg, moduleDescription_);

--- a/FWCore/Framework/interface/limited/EDProducerBase.h
+++ b/FWCore/Framework/interface/limited/EDProducerBase.h
@@ -107,9 +107,6 @@ namespace edm {
       void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
       void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
-      //For now, the following are just dummy implemenations with no ability for users to override
-      void doRespondToOpenInputFile(FileBlock const&) {}
-      void doRespondToCloseInputFile(FileBlock const&) {}
       void doRespondToCloseOutputFile() { clearInputProcessBlockCaches(); }
       void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 

--- a/FWCore/Framework/interface/maker/ModuleHolder.h
+++ b/FWCore/Framework/interface/maker/ModuleHolder.h
@@ -50,6 +50,9 @@ namespace edm {
       virtual std::unique_ptr<Worker> makeWorker(ExceptionToActionTable const* actions) const = 0;
 
       virtual ModuleDescription const& moduleDescription() const = 0;
+      virtual std::vector<ModuleConsumesInfo> moduleConsumesInfos() const = 0;
+      virtual std::vector<ModuleConsumesMinimalESInfo> moduleConsumesMinimalESInfos() const = 0;
+
       virtual void finishModuleInitialization(ModuleDescription const& iDesc,
                                               PreallocationConfiguration const& iPrealloc,
                                               SignallingProductRegistryFiller* iReg) = 0;
@@ -112,6 +115,8 @@ namespace edm {
         }
       };
       ModuleDescription const& moduleDescription() const final { return m_mod->moduleDescription(); }
+      std::vector<ModuleConsumesInfo> moduleConsumesInfos() const final;
+      std::vector<ModuleConsumesMinimalESInfo> moduleConsumesMinimalESInfos() const final;
 
       void finishModuleInitialization(ModuleDescription const& iDesc,
                                       PreallocationConfiguration const& iPrealloc,

--- a/FWCore/Framework/interface/maker/ModuleHolder.h
+++ b/FWCore/Framework/interface/maker/ModuleHolder.h
@@ -60,6 +60,10 @@ namespace edm {
       virtual void beginStream(StreamID) = 0;
       virtual void endStream(StreamID) = 0;
 
+      void respondToOpenInputFile(FileBlock const& fb) { implRespondToOpenInputFile(fb); }
+      void respondToCloseInputFile(FileBlock const& fb) { implRespondToCloseInputFile(fb); }
+      void respondToCloseOutputFile() { implRespondToCloseOutputFile(); }
+
       virtual std::unique_ptr<OutputModuleCommunicator> createOutputModuleCommunicator() = 0;
 
       void registerThinnedAssociations(ProductRegistry const& registry, ThinnedAssociationsHelper& helper);
@@ -77,6 +81,9 @@ namespace edm {
     private:
       virtual void implRegisterThinnedAssociations(ProductRegistry const& registry,
                                                    ThinnedAssociationsHelper& helper) = 0;
+      virtual void implRespondToOpenInputFile(FileBlock const& fb) = 0;
+      virtual void implRespondToCloseInputFile(FileBlock const& fb) = 0;
+      virtual void implRespondToCloseOutputFile() = 0;
     };
 
     template <typename T>
@@ -132,6 +139,10 @@ namespace edm {
 
     private:
       void implRegisterThinnedAssociations(ProductRegistry const& registry, ThinnedAssociationsHelper& helper) final;
+
+      void implRespondToOpenInputFile(FileBlock const& fb) final;
+      void implRespondToCloseInputFile(FileBlock const& fb) final;
+      void implRespondToCloseOutputFile() final;
 
       std::shared_ptr<T> m_mod;
     };

--- a/FWCore/Framework/interface/maker/ModuleHolder.h
+++ b/FWCore/Framework/interface/maker/ModuleHolder.h
@@ -53,6 +53,12 @@ namespace edm {
       virtual std::vector<ModuleConsumesInfo> moduleConsumesInfos() const = 0;
       virtual std::vector<ModuleConsumesMinimalESInfo> moduleConsumesMinimalESInfos() const = 0;
 
+      enum class Type { kAnalyzer, kFilter, kProducer, kOutputModule };
+      enum class Concurrency { kGlobal, kLimited, kOne, kStream };
+
+      virtual Type moduleType() const = 0;
+      virtual Concurrency moduleConcurrencyType() const = 0;
+
       virtual void finishModuleInitialization(ModuleDescription const& iDesc,
                                               PreallocationConfiguration const& iPrealloc,
                                               SignallingProductRegistryFiller* iReg) = 0;
@@ -117,6 +123,8 @@ namespace edm {
       ModuleDescription const& moduleDescription() const final { return m_mod->moduleDescription(); }
       std::vector<ModuleConsumesInfo> moduleConsumesInfos() const final;
       std::vector<ModuleConsumesMinimalESInfo> moduleConsumesMinimalESInfos() const final;
+      Type moduleType() const final;
+      Concurrency moduleConcurrencyType() const final;
 
       void finishModuleInitialization(ModuleDescription const& iDesc,
                                       PreallocationConfiguration const& iPrealloc,

--- a/FWCore/Framework/interface/maker/ModuleHolder.h
+++ b/FWCore/Framework/interface/maker/ModuleHolder.h
@@ -41,7 +41,8 @@ namespace edm {
   class ProductResolverIndexAndSkipBit;
   class ProductRegistry;
   class ThinnedAssociationsHelper;
-
+  class ModuleConsumesInfo;
+  class ModuleConsumesMinimalESInfo;
   namespace maker {
     class ModuleHolder {
     public:

--- a/FWCore/Framework/interface/maker/ModuleHolder.h
+++ b/FWCore/Framework/interface/maker/ModuleHolder.h
@@ -42,7 +42,7 @@ namespace edm {
   class ProductRegistry;
   class ThinnedAssociationsHelper;
   class ModuleConsumesInfo;
-  class ModuleConsumesMinimalESInfo;
+  struct ModuleConsumesMinimalESInfo;
   namespace maker {
     class ModuleHolder {
     public:

--- a/FWCore/Framework/interface/maker/ModuleSignalSentry.h
+++ b/FWCore/Framework/interface/maker/ModuleSignalSentry.h
@@ -2,7 +2,8 @@
 #define FWCore_Framework_ModuleSignalSentry_h
 
 #include "FWCore/Utilities/interface/ConvertException.h"
-
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 namespace edm {
   class ActivityRegistry;
   class ModuleCallingContext;

--- a/FWCore/Framework/interface/maker/Worker.h
+++ b/FWCore/Framework/interface/maker/Worker.h
@@ -206,9 +206,6 @@ namespace edm {
 
     void setEarlyDeleteHelper(EarlyDeleteHelper* iHelper);
 
-    virtual std::vector<ModuleConsumesInfo> moduleConsumesInfos() const = 0;
-    virtual std::vector<ModuleConsumesMinimalESInfo> moduleConsumesMinimalESInfos() const = 0;
-
     virtual Types moduleType() const = 0;
     virtual ConcurrencyTypes moduleConcurrencyType() const = 0;
 

--- a/FWCore/Framework/interface/maker/Worker.h
+++ b/FWCore/Framework/interface/maker/Worker.h
@@ -31,7 +31,6 @@ the worker is reset().
 #include "FWCore/Framework/interface/ModuleContextSentry.h"
 #include "FWCore/Framework/interface/OccurrenceTraits.h"
 #include "FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h"
-#include "FWCore/Framework/interface/ModuleConsumesMinimalESInfo.h"
 #include "FWCore/Concurrency/interface/WaitingTask.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Concurrency/interface/WaitingTaskList.h"
@@ -41,8 +40,6 @@ the worker is reset().
 #include "FWCore/ServiceRegistry/interface/InternalContext.h"
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
-#include "FWCore/ServiceRegistry/interface/PathContext.h"
-#include "FWCore/ServiceRegistry/interface/PlaceInPathContext.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistryfwd.h"
 #include "FWCore/Concurrency/interface/SerialTaskQueueChain.h"
@@ -75,10 +72,7 @@ namespace edm {
   class EventPrincipal;
   class EventSetupImpl;
   class EarlyDeleteHelper;
-  class ProductResolverIndexHelper;
   class ProductResolverIndexAndSkipBit;
-  class ProductRegistry;
-  class ThinnedAssociationsHelper;
 
   namespace workerhelper {
     template <typename O>

--- a/FWCore/Framework/interface/maker/Worker.h
+++ b/FWCore/Framework/interface/maker/Worker.h
@@ -184,10 +184,6 @@ namespace edm {
     // Called if filter earlier in the path has failed.
     void skipOnPath(EventPrincipal const& iEvent);
 
-    void respondToOpenInputFile(FileBlock const& fb) { implRespondToOpenInputFile(fb); }
-    void respondToCloseInputFile(FileBlock const& fb) { implRespondToCloseInputFile(fb); }
-    void respondToCloseOutputFile() { implRespondToCloseOutputFile(); }
-
     void reset() {
       cached_exception_ = std::exception_ptr();
       state_ = Ready;
@@ -293,10 +289,6 @@ namespace edm {
     virtual void preActionBeforeRunEventAsync(WaitingTaskHolder iTask,
                                               ModuleCallingContext const& moduleCallingContext,
                                               Principal const& iPrincipal) const noexcept = 0;
-
-    virtual void implRespondToOpenInputFile(FileBlock const& fb) = 0;
-    virtual void implRespondToCloseInputFile(FileBlock const& fb) = 0;
-    virtual void implRespondToCloseOutputFile() = 0;
 
     virtual TaskQueueAdaptor serializeRunModule() = 0;
 

--- a/FWCore/Framework/interface/maker/WorkerT.h
+++ b/FWCore/Framework/interface/maker/WorkerT.h
@@ -108,9 +108,6 @@ namespace edm {
     bool implDoStreamBegin(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*) override;
     bool implDoStreamEnd(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*) override;
     bool implDoEnd(LumiTransitionInfo const&, ModuleCallingContext const*) override;
-    void implRespondToOpenInputFile(FileBlock const& fb) override;
-    void implRespondToCloseInputFile(FileBlock const& fb) override;
-    void implRespondToCloseOutputFile() override;
     TaskQueueAdaptor serializeRunModule() override;
 
     std::vector<ModuleConsumesInfo> moduleConsumesInfos() const override;

--- a/FWCore/Framework/interface/maker/WorkerT.h
+++ b/FWCore/Framework/interface/maker/WorkerT.h
@@ -110,11 +110,6 @@ namespace edm {
     bool implDoEnd(LumiTransitionInfo const&, ModuleCallingContext const*) override;
     TaskQueueAdaptor serializeRunModule() override;
 
-    std::vector<ModuleConsumesInfo> moduleConsumesInfos() const override;
-    std::vector<ModuleConsumesMinimalESInfo> moduleConsumesMinimalESInfos() const final {
-      return module_->moduleConsumesMinimalESInfos();
-    }
-
     void itemsToGet(BranchType branchType, std::vector<ProductResolverIndexAndSkipBit>& indexes) const override {
       module_->itemsToGet(branchType, indexes);
     }

--- a/FWCore/Framework/interface/one/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/one/EDAnalyzerBase.h
@@ -95,8 +95,6 @@ namespace edm {
       void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
       void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
-      void doRespondToOpenInputFile(FileBlock const&) {}
-      void doRespondToCloseInputFile(FileBlock const&) {}
       void doRespondToCloseOutputFile() { clearInputProcessBlockCaches(); }
       void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 

--- a/FWCore/Framework/interface/one/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/one/EDAnalyzerBase.h
@@ -96,7 +96,6 @@ namespace edm {
       void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
       void doRespondToCloseOutputFile() { clearInputProcessBlockCaches(); }
-      void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 
       void registerProductsAndCallbacks(EDAnalyzerBase const* module, SignallingProductRegistryFiller* reg);
 

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -102,8 +102,6 @@ namespace edm {
       void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
       void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
-      void doRespondToOpenInputFile(FileBlock const&) {}
-      void doRespondToCloseInputFile(FileBlock const&) {}
       void doRespondToCloseOutputFile() { clearInputProcessBlockCaches(); }
       void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -103,7 +103,6 @@ namespace edm {
       void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
       void doRespondToCloseOutputFile() { clearInputProcessBlockCaches(); }
-      void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 
       void registerProductsAndCallbacks(EDFilterBase* module, SignallingProductRegistryFiller* reg) {
         registerProducts(module, reg, moduleDescription_);

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -102,8 +102,6 @@ namespace edm {
       void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
       void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
-      void doRespondToOpenInputFile(FileBlock const&) {}
-      void doRespondToCloseInputFile(FileBlock const&) {}
       void doRespondToCloseOutputFile() { clearInputProcessBlockCaches(); }
       void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -103,7 +103,6 @@ namespace edm {
       void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
       void doRespondToCloseOutputFile() { clearInputProcessBlockCaches(); }
-      void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 
       void registerProductsAndCallbacks(EDProducerBase* module, SignallingProductRegistryFiller* reg) {
         registerProducts(module, reg, moduleDescription_);

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -163,8 +163,6 @@ namespace edm {
       virtual void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*) = 0;
       virtual void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*) = 0;
 
-      void doRespondToOpenInputFile(FileBlock const&) {}
-      void doRespondToCloseInputFile(FileBlock const&) {}
       virtual void doRespondToCloseOutputFile() = 0;
       void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -164,7 +164,6 @@ namespace edm {
       virtual void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*) = 0;
 
       virtual void doRespondToCloseOutputFile() = 0;
-      void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 
       bool hasAcquire() const noexcept { return false; }
       bool hasAccumulator() const noexcept { return false; }

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -191,8 +191,6 @@ namespace edm {
       virtual void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*) = 0;
       virtual void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*) = 0;
 
-      void doRespondToOpenInputFile(FileBlock const&) {}
-      void doRespondToCloseInputFile(FileBlock const&) {}
       virtual void doRespondToCloseOutputFile() = 0;
       void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&);
 

--- a/FWCore/Framework/src/GlobalSchedule.cc
+++ b/FWCore/Framework/src/GlobalSchedule.cc
@@ -7,8 +7,6 @@
 #include "FWCore/Framework/interface/ModuleRegistry.h"
 #include "FWCore/Framework/interface/ModuleRegistryUtilities.h"
 
-#include "DataFormats/Provenance/interface/ProcessConfiguration.h"
-#include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
@@ -34,12 +32,9 @@ namespace edm {
       std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>>& endPathStatusInserters,
       std::shared_ptr<ModuleRegistry> modReg,
       std::vector<edm::ModuleDescription const*> const& iModulesToUse,
-      ParameterSet& proc_pset,
-      SignallingProductRegistryFiller& pregistry,
       PreallocationConfiguration const& prealloc,
       ExceptionToActionTable const& actions,
       std::shared_ptr<ActivityRegistry> areg,
-      std::shared_ptr<ProcessConfiguration const> processConfiguration,
       ProcessContext const* processContext)
       : actReg_(areg),
         processContext_(processContext),

--- a/FWCore/Framework/src/GlobalSchedule.cc
+++ b/FWCore/Framework/src/GlobalSchedule.cc
@@ -33,7 +33,7 @@ namespace edm {
       std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters,
       std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>>& endPathStatusInserters,
       std::shared_ptr<ModuleRegistry> modReg,
-      std::vector<std::string> const& iModulesToUse,
+      std::vector<edm::ModuleDescription const*> const& iModulesToUse,
       ParameterSet& proc_pset,
       SignallingProductRegistryFiller& pregistry,
       PreallocationConfiguration const& prealloc,
@@ -51,17 +51,10 @@ namespace edm {
     for (unsigned int i = 0; i < nManagers; ++i) {
       workerManagers_.emplace_back(modReg, areg, actions);
     }
-    for (auto const& moduleLabel : iModulesToUse) {
-      bool isTracked;
-      ParameterSet* modpset = proc_pset.getPSetForUpdate(moduleLabel, isTracked);
-      if (modpset != nullptr) {  // It will be null for PathStatusInserters, it should
-                                 // be impossible to be null for anything else
-        assert(isTracked);
-
-        //side effect keeps this module around
-        for (auto& wm : workerManagers_) {
-          (void)wm.getWorker(*modpset, pregistry, &prealloc, processConfiguration, moduleLabel);
-        }
+    for (auto const& module : iModulesToUse) {
+      //side effect keeps this module around
+      for (auto& wm : workerManagers_) {
+        (void)wm.getWorkerForModule(*module);
       }
     }
     if (inserter) {

--- a/FWCore/Framework/src/ModuleHolderT.cc
+++ b/FWCore/Framework/src/ModuleHolderT.cc
@@ -244,6 +244,134 @@ namespace edm::maker {
     return m_mod->moduleConsumesMinimalESInfos();
   }
 
+  template <>
+  ModuleHolder::Type ModuleHolderT<edm::one::EDProducerBase>::moduleType() const {
+    return Type::kProducer;
+  }
+  template <>
+  ModuleHolder::Type ModuleHolderT<edm::one::EDFilterBase>::moduleType() const {
+    return Type::kFilter;
+  }
+  template <>
+  ModuleHolder::Type ModuleHolderT<edm::one::EDAnalyzerBase>::moduleType() const {
+    return Type::kAnalyzer;
+  }
+  template <>
+  ModuleHolder::Type ModuleHolderT<edm::one::OutputModuleBase>::moduleType() const {
+    return Type::kOutputModule;
+  }
+
+  template <>
+  ModuleHolder::Type ModuleHolderT<edm::global::EDProducerBase>::moduleType() const {
+    return Type::kProducer;
+  }
+  template <>
+  ModuleHolder::Type ModuleHolderT<edm::global::EDFilterBase>::moduleType() const {
+    return Type::kFilter;
+  }
+  template <>
+  ModuleHolder::Type ModuleHolderT<edm::global::EDAnalyzerBase>::moduleType() const {
+    return Type::kAnalyzer;
+  }
+  template <>
+  ModuleHolder::Type ModuleHolderT<edm::global::OutputModuleBase>::moduleType() const {
+    return Type::kOutputModule;
+  }
+
+  template <>
+  ModuleHolder::Type ModuleHolderT<edm::limited::EDProducerBase>::moduleType() const {
+    return Type::kProducer;
+  }
+  template <>
+  ModuleHolder::Type ModuleHolderT<edm::limited::EDFilterBase>::moduleType() const {
+    return Type::kFilter;
+  }
+  template <>
+  ModuleHolder::Type ModuleHolderT<edm::limited::EDAnalyzerBase>::moduleType() const {
+    return Type::kAnalyzer;
+  }
+  template <>
+  ModuleHolder::Type ModuleHolderT<edm::limited::OutputModuleBase>::moduleType() const {
+    return Type::kOutputModule;
+  }
+
+  template <>
+  ModuleHolder::Type ModuleHolderT<edm::stream::EDProducerAdaptorBase>::moduleType() const {
+    return Type::kProducer;
+  }
+  template <>
+  ModuleHolder::Type ModuleHolderT<edm::stream::EDFilterAdaptorBase>::moduleType() const {
+    return Type::kFilter;
+  }
+  template <>
+  ModuleHolder::Type ModuleHolderT<edm::stream::EDAnalyzerAdaptorBase>::moduleType() const {
+    return Type::kAnalyzer;
+  }
+
+  template <>
+  ModuleHolder::Concurrency ModuleHolderT<edm::one::EDProducerBase>::moduleConcurrencyType() const {
+    return Concurrency::kOne;
+  }
+  template <>
+  ModuleHolder::Concurrency ModuleHolderT<edm::one::EDFilterBase>::moduleConcurrencyType() const {
+    return Concurrency::kOne;
+  }
+  template <>
+  ModuleHolder::Concurrency ModuleHolderT<edm::one::EDAnalyzerBase>::moduleConcurrencyType() const {
+    return Concurrency::kOne;
+  }
+  template <>
+  ModuleHolder::Concurrency ModuleHolderT<edm::one::OutputModuleBase>::moduleConcurrencyType() const {
+    return Concurrency::kOne;
+  }
+
+  template <>
+  ModuleHolder::Concurrency ModuleHolderT<edm::global::EDProducerBase>::moduleConcurrencyType() const {
+    return Concurrency::kGlobal;
+  }
+  template <>
+  ModuleHolder::Concurrency ModuleHolderT<edm::global::EDFilterBase>::moduleConcurrencyType() const {
+    return Concurrency::kGlobal;
+  }
+  template <>
+  ModuleHolder::Concurrency ModuleHolderT<edm::global::EDAnalyzerBase>::moduleConcurrencyType() const {
+    return Concurrency::kGlobal;
+  }
+  template <>
+  ModuleHolder::Concurrency ModuleHolderT<edm::global::OutputModuleBase>::moduleConcurrencyType() const {
+    return Concurrency::kGlobal;
+  }
+
+  template <>
+  ModuleHolder::Concurrency ModuleHolderT<edm::limited::EDProducerBase>::moduleConcurrencyType() const {
+    return Concurrency::kLimited;
+  }
+  template <>
+  ModuleHolder::Concurrency ModuleHolderT<edm::limited::EDFilterBase>::moduleConcurrencyType() const {
+    return Concurrency::kLimited;
+  }
+  template <>
+  ModuleHolder::Concurrency ModuleHolderT<edm::limited::EDAnalyzerBase>::moduleConcurrencyType() const {
+    return Concurrency::kLimited;
+  }
+  template <>
+  ModuleHolder::Concurrency ModuleHolderT<edm::limited::OutputModuleBase>::moduleConcurrencyType() const {
+    return Concurrency::kLimited;
+  }
+
+  template <>
+  ModuleHolder::Concurrency ModuleHolderT<edm::stream::EDProducerAdaptorBase>::moduleConcurrencyType() const {
+    return Concurrency::kStream;
+  }
+  template <>
+  ModuleHolder::Concurrency ModuleHolderT<edm::stream::EDFilterAdaptorBase>::moduleConcurrencyType() const {
+    return Concurrency::kStream;
+  }
+  template <>
+  ModuleHolder::Concurrency ModuleHolderT<edm::stream::EDAnalyzerAdaptorBase>::moduleConcurrencyType() const {
+    return Concurrency::kStream;
+  }
+
   //Explicitly instantiate our needed templates to avoid having the compiler
   // instantiate them in all of our libraries
   template class ModuleHolderT<one::EDProducerBase>;

--- a/FWCore/Framework/src/ModuleHolderT.cc
+++ b/FWCore/Framework/src/ModuleHolderT.cc
@@ -20,10 +20,20 @@
 #include "FWCore/Framework/interface/OutputModuleCommunicatorT.h"
 
 namespace edm::maker {
+  namespace {
+    template <typename T>
+    concept HasRegisterThinnedAssociationsFunction =
+        requires(T mod, ProductRegistry reg, ThinnedAssociationsHelper helper) {
+          { mod.doRegisterThinnedAssociations(reg, helper) } -> std::same_as<void>;
+        };
+  }  // namespace
+
   template <typename T>
   inline void ModuleHolderT<T>::implRegisterThinnedAssociations(ProductRegistry const& registry,
                                                                 ThinnedAssociationsHelper& helper) {
-    m_mod->doRegisterThinnedAssociations(registry, helper);
+    if constexpr (HasRegisterThinnedAssociationsFunction<T>) {
+      m_mod->doRegisterThinnedAssociations(registry, helper);
+    }
   }
 
   template <typename T>

--- a/FWCore/Framework/src/ModuleHolderT.cc
+++ b/FWCore/Framework/src/ModuleHolderT.cc
@@ -235,6 +235,15 @@ namespace edm::maker {
     resolvePutIndiciesImpl(m_mod.get(), iBranchType, iIndicies, moduleDescription().moduleLabel());
   }
 
+  template <typename T>
+  std::vector<ModuleConsumesInfo> ModuleHolderT<T>::moduleConsumesInfos() const {
+    return m_mod->moduleConsumesInfos();
+  }
+  template <typename T>
+  std::vector<ModuleConsumesMinimalESInfo> ModuleHolderT<T>::moduleConsumesMinimalESInfos() const {
+    return m_mod->moduleConsumesMinimalESInfos();
+  }
+
   //Explicitly instantiate our needed templates to avoid having the compiler
   // instantiate them in all of our libraries
   template class ModuleHolderT<one::EDProducerBase>;

--- a/FWCore/Framework/src/ModuleHolderT.cc
+++ b/FWCore/Framework/src/ModuleHolderT.cc
@@ -59,6 +59,41 @@ namespace edm::maker {
       m_mod->doEndStream(iID);
     }
   }
+
+  namespace {
+    template <typename T>
+    concept HasRespondToInputFileFunctions = requires(T mod, FileBlock fb) {
+      { mod.doRespondToOpenInputFile(fb) } -> std::same_as<void>;
+      { mod.doRespondToCloseInputFile(fb) } -> std::same_as<void>;
+    };
+
+    template <typename T>
+    concept HasRespondToCloseOutputFileFunction = requires(T mod) {
+      { mod.doRespondToCloseOutputFile() } -> std::same_as<void>;
+    };
+  }  // namespace
+
+  template <typename T>
+  inline void ModuleHolderT<T>::implRespondToOpenInputFile(FileBlock const& fb) {
+    if constexpr (HasRespondToInputFileFunctions<T>) {
+      m_mod->doRespondToOpenInputFile(fb);
+    }
+  }
+
+  template <typename T>
+  inline void ModuleHolderT<T>::implRespondToCloseInputFile(FileBlock const& fb) {
+    if constexpr (HasRespondToInputFileFunctions<T>) {
+      m_mod->doRespondToCloseInputFile(fb);
+    }
+  }
+
+  template <typename T>
+  void ModuleHolderT<T>::implRespondToCloseOutputFile() {
+    if constexpr (HasRespondToCloseOutputFileFunction<T>) {
+      m_mod->doRespondToCloseOutputFile();
+    }
+  }
+
   namespace {
     template <typename T>
     bool mustPrefetchMayGet();

--- a/FWCore/Framework/src/PathsAndConsumesOfModules.cc
+++ b/FWCore/Framework/src/PathsAndConsumesOfModules.cc
@@ -143,6 +143,7 @@ namespace edm {
         modulesWhoseProductsAreConsumedBy[iBranchType].clear();
       }
 
+      //The maxModuleID will be used as an index so we need the +1 to accomodate that
       allModuleDescriptions.reserve(moduleRegistry.maxModuleID() + 1);
       moduleIDToHolder.resize(moduleRegistry.maxModuleID() + 1);
       for (auto iBranchType = 0U; iBranchType < NumBranchTypes; ++iBranchType) {

--- a/FWCore/Framework/src/PathsAndConsumesOfModules.cc
+++ b/FWCore/Framework/src/PathsAndConsumesOfModules.cc
@@ -8,6 +8,7 @@
 #include "FWCore/Framework/interface/ModuleRegistry.h"
 #include "FWCore/Framework/interface/ESModuleProducesInfo.h"
 #include "FWCore/Framework/interface/ESModuleConsumesMinimalInfo.h"
+#include "FWCore/Framework/interface/ModuleConsumesMinimalESInfo.h"
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
 #include "FWCore/ServiceRegistry/interface/ESModuleConsumesInfo.h"
 #include "FWCore/ServiceRegistry/interface/ModuleConsumesESInfo.h"

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -455,12 +455,9 @@ namespace edm {
                                                                                endpaths,
                                                                                builder.unscheduledModules_,
                                                                                resultsInserter(),
-                                                                               moduleRegistry(),
-                                                                               proc_pset,
-                                                                               prealloc,
+                                                                               moduleRegistrySharedPtr(),
                                                                                actions,
                                                                                areg,
-                                                                               processConfiguration,
                                                                                StreamID{i},
                                                                                processContext));
     }
@@ -468,14 +465,11 @@ namespace edm {
     globalSchedule_ = std::make_unique<GlobalSchedule>(resultsInserter(),
                                                        pathStatusInserters_,
                                                        endPathStatusInserters_,
-                                                       moduleRegistry(),
+                                                       moduleRegistrySharedPtr(),
                                                        builder.allNeededModules_,
-                                                       proc_pset,
-                                                       preg,
                                                        prealloc,
                                                        actions,
                                                        areg,
-                                                       processConfiguration,
                                                        processContext);
   }
 
@@ -1162,8 +1156,7 @@ namespace edm {
                                        std::vector<std::string> const& modulesToSkip,
                                        edm::ProductRegistry const& preg) {
     for (auto& stream : streamSchedules_) {
-      stream->initializeEarlyDelete(
-          *moduleRegistry(), branchesToDeleteEarly, referencesToBranches, modulesToSkip, preg);
+      stream->initializeEarlyDelete(*moduleRegistry_, branchesToDeleteEarly, referencesToBranches, modulesToSkip, preg);
     }
   }
 

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -1029,9 +1029,7 @@ namespace edm {
   void Schedule::closeOutputFiles() {
     using std::placeholders::_1;
     for_all(all_output_communicators_, std::bind(&OutputModuleCommunicator::closeFile, _1));
-    for (auto& worker : allWorkers()) {
-      worker->respondToCloseOutputFile();
-    }
+    moduleRegistry_->forAllModuleHolders([](maker::ModuleHolder* iHolder) { iHolder->respondToCloseOutputFile(); });
   }
 
   void Schedule::openOutputFiles(FileBlock& fb) {
@@ -1141,13 +1139,11 @@ namespace edm {
   }
 
   void Schedule::respondToOpenInputFile(FileBlock const& fb) {
-    using std::placeholders::_1;
-    for_all(allWorkers(), std::bind(&Worker::respondToOpenInputFile, _1, std::cref(fb)));
+    moduleRegistry_->forAllModuleHolders([&fb](maker::ModuleHolder* iHolder) { iHolder->respondToOpenInputFile(fb); });
   }
 
   void Schedule::respondToCloseInputFile(FileBlock const& fb) {
-    using std::placeholders::_1;
-    for_all(allWorkers(), std::bind(&Worker::respondToCloseInputFile, _1, std::cref(fb)));
+    moduleRegistry_->forAllModuleHolders([&fb](maker::ModuleHolder* iHolder) { iHolder->respondToCloseInputFile(fb); });
   }
 
   void Schedule::beginJob(ProductRegistry const& iRegistry,

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -423,8 +423,6 @@ namespace edm {
         *moduleRegistry_, proc_pset, *pathNames_, *endPathNames_, prealloc, preg, *areg, processConfiguration);
     resultsInserter_ = std::move(builder.resultsInserter_);
     assert(builder.pathStatusInserters_.size() == builder.pathNameAndModules_.size());
-    assert(builder.endPathStatusInserters_.size() == builder.endpathNameAndModules_.size() or
-           (builder.endpathNameAndModules_.size() == 1 and builder.endPathStatusInserters_.empty()));
     pathStatusInserters_ = std::move(builder.pathStatusInserters_);
     endPathStatusInserters_ = std::move(builder.endPathStatusInserters_);
 
@@ -437,15 +435,17 @@ namespace edm {
     }
     std::vector<StreamSchedule::EndPathInfo> endpaths;
     endpaths.reserve(builder.endpathNameAndModules_.size());
-    index = 0;
-    for (auto& path : builder.endpathNameAndModules_) {
-      if (endPathStatusInserters_.empty()) {
-        endpaths.emplace_back(path.first, std::move(path.second), std::shared_ptr<EndPathStatusInserter>());
-
-      } else {
+    if (builder.endpathNameAndModules_.size() == 1) {
+      assert(endPathStatusInserters_.empty());
+      auto& path = builder.endpathNameAndModules_.front();
+      endpaths.emplace_back(path.first, std::move(path.second), std::shared_ptr<EndPathStatusInserter>());
+    } else {
+      assert(endPathStatusInserters_.size() == builder.endpathNameAndModules_.size());
+      index = 0;
+      for (auto& path : builder.endpathNameAndModules_) {
         endpaths.emplace_back(path.first, std::move(path.second), get_underlying_safe(endPathStatusInserters_[index]));
+        ++index;
       }
-      ++index;
     }
 
     assert(0 < prealloc.numberOfStreams());

--- a/FWCore/Framework/src/ScheduleBuilder.cc
+++ b/FWCore/Framework/src/ScheduleBuilder.cc
@@ -462,7 +462,7 @@ namespace edm {
                                 iProcessConfiguration);
         if (module == nullptr) {
           std::string pathType("endpath");
-          if (std::count(iEndPathNames.begin(), iEndPathNames.end(), iPathName) == 0) {
+          if (std::find(iEndPathNames.begin(), iEndPathNames.end(), iPathName) == iEndPathNames.end()) {
             pathType = std::string("path");
           }
           throw Exception(errors::Configuration)
@@ -476,8 +476,8 @@ namespace edm {
           // See if the filter is allowed.
           std::vector<std::string> allowed_filters =
               ioProcessPSet.getUntrackedParameter<std::vector<std::string>>("@filters_on_endpaths");
-          if (std::count(allowed_filters.begin(), allowed_filters.end(), module->moduleDescription().moduleName()) ==
-              0) {
+          if (std::find(allowed_filters.begin(), allowed_filters.end(), module->moduleDescription().moduleName()) ==
+              allowed_filters.end()) {
             // Filter is not allowed. Ignore the result, and issue a warning.
             filterAction = WorkerInPath::Ignore;
             LogWarning("FilterOnEndPath")
@@ -686,15 +686,17 @@ namespace edm {
         }
       }
       if (!shouldBeUsedLabels.empty()) {
-        std::ostringstream unusedStream;
-        unusedStream << "'" << shouldBeUsedLabels.front() << "'";
-        for (std::vector<std::string>::iterator itLabel = shouldBeUsedLabels.begin() + 1,
-                                                itLabelEnd = shouldBeUsedLabels.end();
-             itLabel != itLabelEnd;
-             ++itLabel) {
-          unusedStream << ",'" << *itLabel << "'";
-        }
-        LogInfo("path") << "The following module labels are not assigned to any path:\n" << unusedStream.str() << "\n";
+        LogInfo("path").log([&shouldBeUsedLabels](auto& l) {
+          l << "The following module labels are not assigned to any path:\n";
+          l << "'" << shouldBeUsedLabels.front() << "'";
+          for (std::vector<std::string>::iterator itLabel = shouldBeUsedLabels.begin() + 1,
+                                                  itLabelEnd = shouldBeUsedLabels.end();
+               itLabel != itLabelEnd;
+               ++itLabel) {
+            l << ",'" << *itLabel << "'";
+          }
+          l << "\n";
+        });
       }
     }
 

--- a/FWCore/Framework/src/ScheduleBuilder.cc
+++ b/FWCore/Framework/src/ScheduleBuilder.cc
@@ -699,31 +699,6 @@ namespace edm {
         });
       }
     }
-
-    // Print conditional modules that were not consumed in any of their associated Paths
-    if (not conditionalModules.empty()) {
-      // Intersection of unscheduled and ConditionalTask modules gives
-      // directly the set of conditional modules that were not
-      // consumed by anything in the Paths associated to the
-      // corresponding ConditionalTask.
-      std::vector<std::string_view> labelsToPrint;
-      std::copy_if(
-          unscheduledLabels.begin(),
-          unscheduledLabels.end(),
-          std::back_inserter(labelsToPrint),
-          [&conditionalModules](auto const& lab) { return conditionalModules.find(lab) != conditionalModules.end(); });
-
-      if (not labelsToPrint.empty()) {
-        edm::LogWarning log("NonConsumedConditionalModules");
-        log << "The following modules were part of some ConditionalTask, but were not\n"
-            << "consumed by any other module in any of the Paths to which the ConditionalTask\n"
-            << "was associated. Perhaps they should be either removed from the\n"
-            << "job, or moved to a Task to make it explicit they are unscheduled.\n";
-        for (auto const& modLabel : labelsToPrint) {
-          log.format("\n {}", modLabel);
-        }
-      }
-    }
     //we want the unscheduled modules at the beginning of the allNeededModules list
     allNeededModules_.insert(allNeededModules_.begin(), unscheduledModules_.begin(), unscheduledModules_.end());
   }

--- a/FWCore/Framework/src/ScheduleBuilder.cc
+++ b/FWCore/Framework/src/ScheduleBuilder.cc
@@ -1,0 +1,730 @@
+#include "FWCore/Framework/src/ScheduleBuilder.h"
+#include "FWCore/Framework/interface/PreallocationConfiguration.h"
+#include "FWCore/Framework/interface/SignallingProductRegistryFiller.h"
+#include "FWCore/Framework/interface/maker/MakeModuleParams.h"
+#include "FWCore/Framework/src/processEDAliases.h"
+#include "FWCore/Framework/src/TriggerResultInserter.h"
+#include "FWCore/Framework/src/PathStatusInserter.h"
+#include "FWCore/Framework/src/EndPathStatusInserter.h"
+#include "FWCore/Framework/interface/TriggerNamesService.h"
+#include "FWCore/Framework/interface/WorkerInPath.h"
+#include "FWCore/Framework/interface/ModuleRegistry.h"
+#include "FWCore/Framework/interface/maker/ModuleHolder.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ModuleConsumesInfo.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Provenance/interface/ProcessConfiguration.h"
+#include "DataFormats/Provenance/interface/ProductResolverIndexHelper.h"
+
+//DEBUG
+#include <iostream>
+namespace edm {
+
+  namespace {
+    // Here we make the trigger results inserter directly.  This should
+    // probably be a utility in the WorkerRegistry or elsewhere.
+
+    std::shared_ptr<TriggerResultInserter> makeInserter(
+        ParameterSet& ioProcessPSet,
+        PreallocationConfiguration const& iPrealloc,
+        SignallingProductRegistryFiller& ioProductRegistry,
+        ActivityRegistry& iActivityRegistry,
+        std::shared_ptr<ProcessConfiguration const> iProcessConfiguration,
+        ModuleRegistry& ioModuleRegistry) {
+      ParameterSet* trig_pset = ioProcessPSet.getPSetForUpdate("@trigger_paths");
+      trig_pset->registerIt();
+
+      ModuleDescription md(trig_pset->id(),
+                           "TriggerResultInserter",
+                           "TriggerResults",
+                           iProcessConfiguration.get(),
+                           ModuleDescription::getUniqueID());
+
+      return ioModuleRegistry.makeExplicitModule<TriggerResultInserter>(md,
+                                                                        iPrealloc,
+                                                                        &ioProductRegistry,
+                                                                        iActivityRegistry.preModuleConstructionSignal_,
+                                                                        iActivityRegistry.postModuleConstructionSignal_,
+                                                                        *trig_pset,
+                                                                        iPrealloc.numberOfStreams());
+    }
+
+    template <typename T>
+    std::vector<edm::propagate_const<std::shared_ptr<T>>> makePathStatusInserters(
+        std::vector<std::string> const& iPathNames,
+        PreallocationConfiguration const& iPrealloc,
+        SignallingProductRegistryFiller& ioProductRegistry,
+        ActivityRegistry& iActivityRegistry,
+        std::shared_ptr<ProcessConfiguration const> iProcessConfiguration,
+        ModuleRegistry& ioModuleRegistry,
+        std::string const& iModuleTypeName) {
+      ParameterSet pset;
+      pset.addParameter<std::string>("@module_type", iModuleTypeName);
+      pset.addParameter<std::string>("@module_edm_type", "EDProducer");
+      pset.registerIt();
+
+      std::vector<edm::propagate_const<std::shared_ptr<T>>> pathStatusInserters;
+      pathStatusInserters.reserve(iPathNames.size());
+
+      for (auto const& pathName : iPathNames) {
+        ModuleDescription md(
+            pset.id(), iModuleTypeName, pathName, iProcessConfiguration.get(), ModuleDescription::getUniqueID());
+        auto module = ioModuleRegistry.makeExplicitModule<T>(md,
+                                                             iPrealloc,
+                                                             &ioProductRegistry,
+                                                             iActivityRegistry.preModuleConstructionSignal_,
+                                                             iActivityRegistry.postModuleConstructionSignal_,
+                                                             iPrealloc.numberOfStreams());
+        pathStatusInserters.emplace_back(std::move(module));
+      }
+      return pathStatusInserters;
+    }
+
+    struct AliasInfo {
+      std::string friendlyClassName;
+      std::string instanceLabel;
+      std::string originalInstanceLabel;
+      std::string originalModuleLabel;
+    };
+
+    // If ConditionalTask modules exist in the container of module
+    // names, returns the range (std::pair) for the modules. The range
+    // excludes the special markers '#' (right before the
+    // ConditionalTask modules) and '@' (last element).
+    // If the module name container does not contain ConditionalTask
+    // modules, returns std::pair of end iterators.
+    template <typename T>
+    auto findConditionalTaskModulesRange(T const& modnames) {
+      auto beg = std::find(modnames.begin(), modnames.end(), "#");
+      if (beg == modnames.end()) {
+        return std::pair(modnames.end(), modnames.end());
+      }
+      return std::pair(beg + 1, std::prev(modnames.end()));
+    }
+
+    std::optional<std::string> findBestMatchingAlias(
+        std::unordered_multimap<std::string, edm::ProductDescription const*> const& conditionalModuleBranches,
+        std::unordered_multimap<std::string, AliasInfo> const& aliasMap,
+        std::string const& productModuleLabel,
+        ModuleConsumesInfo const& consumesInfo) {
+      std::optional<std::string> best;
+      int wildcardsInBest = std::numeric_limits<int>::max();
+      bool bestIsAmbiguous = false;
+
+      auto updateBest = [&best, &wildcardsInBest, &bestIsAmbiguous](
+                            std::string const& label, bool instanceIsWildcard, bool typeIsWildcard) {
+        int const wildcards = static_cast<int>(instanceIsWildcard) + static_cast<int>(typeIsWildcard);
+        if (wildcards == 0) {
+          bestIsAmbiguous = false;
+          return true;
+        }
+        if (not best or wildcards < wildcardsInBest) {
+          best = label;
+          wildcardsInBest = wildcards;
+          bestIsAmbiguous = false;
+        } else if (best and *best != label and wildcardsInBest == wildcards) {
+          bestIsAmbiguous = true;
+        }
+        return false;
+      };
+
+      auto findAlias = aliasMap.equal_range(productModuleLabel);
+      for (auto it = findAlias.first; it != findAlias.second; ++it) {
+        std::string const& aliasInstanceLabel =
+            it->second.instanceLabel != "*" ? it->second.instanceLabel : it->second.originalInstanceLabel;
+        bool const instanceIsWildcard = (aliasInstanceLabel == "*");
+        if (instanceIsWildcard or consumesInfo.instance() == aliasInstanceLabel) {
+          bool const typeIsWildcard = it->second.friendlyClassName == "*";
+          if (typeIsWildcard or (consumesInfo.type().friendlyClassName() == it->second.friendlyClassName)) {
+            if (updateBest(it->second.originalModuleLabel, instanceIsWildcard, typeIsWildcard)) {
+              return it->second.originalModuleLabel;
+            }
+          } else if (consumesInfo.kindOfType() == ELEMENT_TYPE) {
+            //consume is a View so need to do more intrusive search
+            //find matching branches in module
+            auto branches = conditionalModuleBranches.equal_range(productModuleLabel);
+            for (auto itBranch = branches.first; itBranch != branches.second; ++it) {
+              if (typeIsWildcard or itBranch->second->productInstanceName() == it->second.originalInstanceLabel) {
+                if (productholderindexhelper::typeIsViewCompatible(consumesInfo.type(),
+                                                                   TypeID(itBranch->second->wrappedType().typeInfo()),
+                                                                   itBranch->second->className())) {
+                  if (updateBest(it->second.originalModuleLabel, instanceIsWildcard, typeIsWildcard)) {
+                    return it->second.originalModuleLabel;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      if (bestIsAmbiguous) {
+        throw Exception(errors::UnimplementedFeature)
+            << "Encountered ambiguity when trying to find a best-matching alias for\n"
+            << " friendly class name " << consumesInfo.type().friendlyClassName() << "\n"
+            << " module label " << productModuleLabel << "\n"
+            << " product instance name " << consumesInfo.instance() << "\n"
+            << "when processing EDAliases for modules in ConditionalTasks. Two aliases have the same number of "
+               "wildcards ("
+            << wildcardsInBest << ")";
+      }
+      return best;
+    }
+
+    class ConditionalTaskHelper {
+    public:
+      ConditionalTaskHelper(ParameterSet& ioProcessPSet,
+                            SignallingProductRegistryFiller& ioProductRegistry,
+                            PreallocationConfiguration const* iPrealloc,
+                            std::shared_ptr<ProcessConfiguration const> iProcessConfiguration,
+                            ModuleRegistry& ioModuleRegistry,
+                            ActivityRegistry& iActivityRegistry,
+                            std::vector<std::string> const& iTrigPathNames) {
+        std::unordered_set<std::string> allConditionalMods;
+        for (auto const& pathName : iTrigPathNames) {
+          auto const modnames = ioProcessPSet.getParameter<std::vector<std::string>>(pathName);
+
+          //Pull out ConditionalTask modules
+          auto condRange = findConditionalTaskModulesRange(modnames);
+          if (condRange.first == condRange.second)
+            continue;
+
+          //the last entry should be ignored since it is required to be "@"
+          allConditionalMods.insert(condRange.first, condRange.second);
+        }
+
+        for (auto const& cond : allConditionalMods) {
+          //force the creation of the conditional modules so alias check can work
+          // must be sure this is not added to the list of all workers else the system will hang in case the
+          // module is not used.
+          bool isTracked = false;
+          ParameterSet* modpset = ioProcessPSet.getPSetForUpdate(cond, isTracked);
+          assert(modpset != nullptr);
+          assert(isTracked);
+
+          MakeModuleParams params(modpset, ioProductRegistry, iPrealloc, iProcessConfiguration);
+          (void)ioModuleRegistry.getModule(params,
+                                           cond,
+                                           iActivityRegistry.preModuleConstructionSignal_,
+                                           iActivityRegistry.postModuleConstructionSignal_);
+        }
+
+        fillAliasMap(ioProcessPSet, allConditionalMods);
+        processSwitchEDAliases(ioProcessPSet, ioProductRegistry, *iProcessConfiguration, allConditionalMods);
+
+        //find branches created by the conditional modules
+        for (auto const& prod : ioProductRegistry.registry().productList()) {
+          if (allConditionalMods.find(prod.first.moduleLabel()) != allConditionalMods.end()) {
+            conditionalModsBranches_.emplace(prod.first.moduleLabel(), &prod.second);
+          }
+        }
+      }
+
+      std::unordered_multimap<std::string, AliasInfo> const& aliasMap() const { return aliasMap_; }
+
+      std::unordered_multimap<std::string, edm::ProductDescription const*> conditionalModuleBranches(
+          std::unordered_set<std::string> const& conditionalmods) const {
+        std::unordered_multimap<std::string, edm::ProductDescription const*> ret;
+        for (auto const& mod : conditionalmods) {
+          auto range = conditionalModsBranches_.equal_range(mod);
+          ret.insert(range.first, range.second);
+        }
+        return ret;
+      }
+
+    private:
+      void fillAliasMap(ParameterSet const& ioProcessPSet,
+                        std::unordered_set<std::string> const& iAllConditionalModules) {
+        auto aliases = ioProcessPSet.getParameter<std::vector<std::string>>("@all_aliases");
+        std::string const star("*");
+        for (auto const& alias : aliases) {
+          auto info = ioProcessPSet.getParameter<edm::ParameterSet>(alias);
+          auto aliasedToModuleLabels = info.getParameterNames();
+          for (auto const& mod : aliasedToModuleLabels) {
+            if (not mod.empty() and mod[0] != '@' and
+                iAllConditionalModules.find(mod) != iAllConditionalModules.end()) {
+              auto aliasVPSet = info.getParameter<std::vector<edm::ParameterSet>>(mod);
+              for (auto const& aliasPSet : aliasVPSet) {
+                std::string type = star;
+                std::string instance = star;
+                std::string originalInstance = star;
+                if (aliasPSet.exists("type")) {
+                  type = aliasPSet.getParameter<std::string>("type");
+                }
+                if (aliasPSet.exists("toProductInstance")) {
+                  instance = aliasPSet.getParameter<std::string>("toProductInstance");
+                }
+                if (aliasPSet.exists("fromProductInstance")) {
+                  originalInstance = aliasPSet.getParameter<std::string>("fromProductInstance");
+                }
+                aliasMap_.emplace(alias, AliasInfo{type, instance, originalInstance, mod});
+              }
+            }
+          }
+        }
+      }
+
+      void processSwitchEDAliases(ParameterSet const& ioProcessPSet,
+                                  SignallingProductRegistryFiller& ioProductRegistry,
+                                  ProcessConfiguration const& iProcessConfiguration,
+                                  std::unordered_set<std::string> const& iAllConditionalModules) {
+        auto const& all_modules = ioProcessPSet.getParameter<std::vector<std::string>>("@all_modules");
+        std::vector<std::string> switchEDAliases;
+        for (auto const& module : all_modules) {
+          auto const& mod_pset = ioProcessPSet.getParameter<edm::ParameterSet>(module);
+          if (mod_pset.getParameter<std::string>("@module_type") == "SwitchProducer") {
+            auto const& all_cases = mod_pset.getParameter<std::vector<std::string>>("@all_cases");
+            for (auto const& case_label : all_cases) {
+              auto range = aliasMap_.equal_range(case_label);
+              if (range.first != range.second) {
+                switchEDAliases.push_back(case_label);
+              }
+            }
+          }
+        }
+        detail::processEDAliases(switchEDAliases,
+                                 iAllConditionalModules,
+                                 ioProcessPSet,
+                                 iProcessConfiguration.processName(),
+                                 ioProductRegistry);
+      }
+
+      std::unordered_multimap<std::string, AliasInfo> aliasMap_;
+      std::unordered_multimap<std::string, edm::ProductDescription const*> conditionalModsBranches_;
+    };
+
+    std::shared_ptr<edm::maker::ModuleHolder const> getModule(
+        ParameterSet& ioProcessPSet,
+        std::string const& iModuleLabel,
+        ModuleRegistry& ioModuleRegistry,
+        SignallingProductRegistryFiller& ioProductRegistry,
+        ActivityRegistry& iActivityRegistry,
+        PreallocationConfiguration const* iPrealloc,
+        std::shared_ptr<ProcessConfiguration const> iProcessConfiguration) {
+      bool isTracked = false;
+      ParameterSet* modpset = ioProcessPSet.getPSetForUpdate(iModuleLabel, isTracked);
+      assert(modpset != nullptr);
+      assert(isTracked);
+
+      MakeModuleParams params(modpset, ioProductRegistry, iPrealloc, iProcessConfiguration);
+      return ioModuleRegistry.getModule(params,
+                                        iModuleLabel,
+                                        iActivityRegistry.preModuleConstructionSignal_,
+                                        iActivityRegistry.postModuleConstructionSignal_);
+    }
+
+    std::vector<ModuleDescription const*> tryToPlaceConditionalModules(
+        maker::ModuleHolder const* iModule,
+        ModuleRegistry& iModuleRegistry,
+        std::unordered_set<std::string>& ioConditionalModules,
+        std::unordered_multimap<std::string, edm::ProductDescription const*> const& iConditionalModuleProducts,
+        std::unordered_multimap<std::string, AliasInfo> const& iAliasMap,
+        ParameterSet& ioProcessPSet,
+        SignallingProductRegistryFiller& ioProductRegistry,
+        ActivityRegistry& iActivityRegistry,
+        PreallocationConfiguration const* iPrealloc,
+        std::shared_ptr<ProcessConfiguration const> iProcessConfiguration) {
+      std::vector<ModuleDescription const*> returnValue;
+      //auto const& consumesInfo = worker->moduleConsumesInfos();
+      auto const& consumesInfo = iModule->moduleConsumesInfos();
+      using namespace productholderindexhelper;
+      for (auto const& ci : consumesInfo) {
+        if (not ci.skipCurrentProcess() and
+            (ci.process().empty() or ci.process() == iProcessConfiguration->processName())) {
+          auto productModuleLabel = std::string(ci.label());
+          bool productFromConditionalModule = false;
+          auto itFound = ioConditionalModules.find(productModuleLabel);
+          if (itFound == ioConditionalModules.end()) {
+            //Check to see if this was an alias
+            //note that aliasMap was previously filtered so only the conditional modules remain there
+            auto foundAlias = findBestMatchingAlias(iConditionalModuleProducts, iAliasMap, productModuleLabel, ci);
+            if (foundAlias) {
+              productModuleLabel = *foundAlias;
+              productFromConditionalModule = true;
+              itFound = ioConditionalModules.find(productModuleLabel);
+              //check that the alias-for conditional module has not been used
+              if (itFound == ioConditionalModules.end()) {
+                continue;
+              }
+            }
+          } else {
+            //need to check the rest of the data product info
+            auto findBranches = iConditionalModuleProducts.equal_range(productModuleLabel);
+            for (auto itBranch = findBranches.first; itBranch != findBranches.second; ++itBranch) {
+              if (itBranch->second->productInstanceName() == ci.instance()) {
+                if (ci.kindOfType() == PRODUCT_TYPE) {
+                  if (ci.type() == itBranch->second->unwrappedTypeID()) {
+                    productFromConditionalModule = true;
+                    break;
+                  }
+                } else {
+                  //this is a view
+                  if (typeIsViewCompatible(ci.type(),
+                                           TypeID(itBranch->second->wrappedType().typeInfo()),
+                                           itBranch->second->className())) {
+                    productFromConditionalModule = true;
+                    break;
+                  }
+                }
+              }
+            }
+          }
+          if (productFromConditionalModule) {
+            auto condModule = getModule(ioProcessPSet,
+                                        productModuleLabel,
+                                        iModuleRegistry,
+                                        ioProductRegistry,
+                                        iActivityRegistry,
+                                        iPrealloc,
+                                        iProcessConfiguration);
+            assert(condModule);
+
+            ioConditionalModules.erase(itFound);
+
+            auto dependents = tryToPlaceConditionalModules(condModule.get(),
+                                                           iModuleRegistry,
+                                                           ioConditionalModules,
+                                                           iConditionalModuleProducts,
+                                                           iAliasMap,
+                                                           ioProcessPSet,
+                                                           ioProductRegistry,
+                                                           iActivityRegistry,
+                                                           iPrealloc,
+                                                           iProcessConfiguration);
+            returnValue.insert(returnValue.end(), dependents.begin(), dependents.end());
+            returnValue.emplace_back(&condModule->moduleDescription());
+          }
+        }
+      }
+      return returnValue;
+    }
+
+    std::vector<ModuleInPath> fillModulesInPath(ParameterSet& ioProcessPSet,
+                                                ModuleRegistry& ioModuleRegistry,
+                                                SignallingProductRegistryFiller& ioProductRegistry,
+                                                ActivityRegistry& iActivityRegistry,
+                                                PreallocationConfiguration const* iPrealloc,
+                                                std::shared_ptr<ProcessConfiguration const> iProcessConfiguration,
+                                                std::string const& iPathName,
+                                                bool iIgnoreFilters,
+                                                std::vector<std::string> const& iEndPathNames,
+                                                ConditionalTaskHelper const& iConditionalTaskHelper,
+                                                std::unordered_set<std::string>& oAllConditionalModules) {
+      auto modnames = ioProcessPSet.getParameter<std::vector<std::string>>(iPathName);
+      std::vector<ModuleInPath> tmpworkers;
+
+      //Pull out ConditionalTask modules
+      auto condRange = findConditionalTaskModulesRange(modnames);
+
+      std::unordered_set<std::string> conditionalmods;
+      //An EDAlias may be redirecting to a module on a ConditionalTask
+      std::unordered_multimap<std::string, edm::ProductDescription const*> conditionalModsBranches;
+      std::unordered_map<std::string, unsigned int> conditionalModOrder;
+      if (condRange.first != condRange.second) {
+        for (auto it = condRange.first; it != condRange.second; ++it) {
+          // ordering needs to skip the # token in the path list
+          conditionalModOrder.emplace(*it, it - modnames.begin() - 1);
+        }
+        //the last entry should be ignored since it is required to be "@"
+        conditionalmods = std::unordered_set<std::string>(std::make_move_iterator(condRange.first),
+                                                          std::make_move_iterator(condRange.second));
+
+        conditionalModsBranches = iConditionalTaskHelper.conditionalModuleBranches(conditionalmods);
+        modnames.erase(std::prev(condRange.first), modnames.end());
+
+        // Make a union of all conditional modules from all Paths
+        oAllConditionalModules.insert(conditionalmods.begin(), conditionalmods.end());
+      }
+
+      unsigned int placeInPath = 0;
+      for (auto const& name : modnames) {
+        //Modules except EDFilters are set to run concurrently by default
+        bool doNotRunConcurrently = false;
+        WorkerInPath::FilterAction filterAction = WorkerInPath::Normal;
+        if (name[0] == '!') {
+          filterAction = WorkerInPath::Veto;
+        } else if (name[0] == '-' or name[0] == '+') {
+          filterAction = WorkerInPath::Ignore;
+        }
+        if (name[0] == '|' or name[0] == '+') {
+          //cms.wait was specified so do not run concurrently
+          doNotRunConcurrently = true;
+        }
+
+        std::string moduleLabel = name;
+        if (filterAction != WorkerInPath::Normal or name[0] == '|') {
+          moduleLabel.erase(0, 1);
+        }
+
+        auto module = getModule(ioProcessPSet,
+                                moduleLabel,
+                                ioModuleRegistry,
+                                ioProductRegistry,
+                                iActivityRegistry,
+                                iPrealloc,
+                                iProcessConfiguration);
+        if (module == nullptr) {
+          std::string pathType("endpath");
+          if (std::count(iEndPathNames.begin(), iEndPathNames.end(), iPathName) == 0) {
+            pathType = std::string("path");
+          }
+          throw Exception(errors::Configuration)
+              << "The unknown module label \"" << moduleLabel << "\" appears in " << pathType << " \"" << iPathName
+              << "\"\n please check spelling or remove that label from the path.";
+        }
+
+        if (iIgnoreFilters && filterAction != WorkerInPath::Ignore &&
+            module->moduleType() == maker::ModuleHolder::Type::kFilter) {
+          // We have a filter on an end path, and the filter is not explicitly ignored.
+          // See if the filter is allowed.
+          std::vector<std::string> allowed_filters =
+              ioProcessPSet.getUntrackedParameter<std::vector<std::string>>("@filters_on_endpaths");
+          if (std::count(allowed_filters.begin(), allowed_filters.end(), module->moduleDescription().moduleName()) ==
+              0) {
+            // Filter is not allowed. Ignore the result, and issue a warning.
+            filterAction = WorkerInPath::Ignore;
+            LogWarning("FilterOnEndPath")
+                << "The EDFilter '" << module->moduleDescription().moduleName() << "' with module label '"
+                << moduleLabel << "' appears on EndPath '" << iPathName << "'.\n"
+                << "The return value of the filter will be ignored.\n"
+                << "To suppress this warning, either remove the filter from the endpath,\n"
+                << "or explicitly ignore it in the configuration by using cms.ignore().\n";
+          }
+        }
+        bool runConcurrently = not doNotRunConcurrently;
+        if (runConcurrently && module->moduleType() == maker::ModuleHolder::Type::kFilter and
+            filterAction != WorkerInPath::Ignore) {
+          runConcurrently = false;
+        }
+
+        auto condModules = tryToPlaceConditionalModules(module.get(),
+                                                        ioModuleRegistry,
+                                                        conditionalmods,
+                                                        conditionalModsBranches,
+                                                        iConditionalTaskHelper.aliasMap(),
+                                                        ioProcessPSet,
+                                                        ioProductRegistry,
+                                                        iActivityRegistry,
+                                                        iPrealloc,
+                                                        iProcessConfiguration);
+        for (auto condMod : condModules) {
+          tmpworkers.emplace_back(condMod, WorkerInPath::Ignore, conditionalModOrder[condMod->moduleLabel()], true);
+        }
+
+        tmpworkers.emplace_back(&module->moduleDescription(), filterAction, placeInPath, runConcurrently);
+        ++placeInPath;
+      }
+
+      return tmpworkers;
+    }
+
+    std::vector<ModuleInPath> fillTrigPath(ParameterSet& ioProcessPSet,
+                                           ModuleRegistry& ioModuleRegistry,
+                                           SignallingProductRegistryFiller& ioProductRegistry,
+                                           ActivityRegistry& iActivityRegistry,
+                                           PreallocationConfiguration const* iPrealloc,
+                                           std::shared_ptr<ProcessConfiguration const> iProcessConfiguration,
+                                           std::string const& iName,
+                                           std::vector<std::string> const& iEndPathNames,
+                                           ConditionalTaskHelper const& iConditionalTaskHelper,
+                                           std::unordered_set<std::string>& oAllConditionalModules) {
+      return fillModulesInPath(ioProcessPSet,
+                               ioModuleRegistry,
+                               ioProductRegistry,
+                               iActivityRegistry,
+                               iPrealloc,
+                               iProcessConfiguration,
+                               iName,
+                               false,
+                               iEndPathNames,
+                               iConditionalTaskHelper,
+                               oAllConditionalModules);
+    }
+
+    std::vector<ModuleInPath> fillEndPath(ParameterSet& ioProcessPSet,
+                                          ModuleRegistry& ioModuleRegistry,
+                                          SignallingProductRegistryFiller& ioProductRegistry,
+                                          ActivityRegistry& iActivityRegistry,
+                                          PreallocationConfiguration const* iPrealloc,
+                                          std::shared_ptr<ProcessConfiguration const> iProcessConfiguration,
+                                          std::string const& iName,
+                                          std::vector<std::string> const& iEndPathNames,
+                                          ConditionalTaskHelper const& iConditionalTaskHelper,
+                                          std::unordered_set<std::string>& oAllConditionalModules) {
+      return fillModulesInPath(ioProcessPSet,
+                               ioModuleRegistry,
+                               ioProductRegistry,
+                               iActivityRegistry,
+                               iPrealloc,
+                               iProcessConfiguration,
+                               iName,
+                               true,
+                               iEndPathNames,
+                               iConditionalTaskHelper,
+                               oAllConditionalModules);
+    }
+
+    static const std::string kFilterType("EDFilter");
+    static const std::string kProducerType("EDProducer");
+
+  }  // namespace
+  ScheduleBuilder::ScheduleBuilder(ModuleRegistry& iModuleRegistry,
+                                   ParameterSet& ioProcessPSet,
+                                   std::vector<std::string> const& iPathNames,
+                                   std::vector<std::string> const& iEndPathNames,
+                                   PreallocationConfiguration const& iPrealloc,
+                                   SignallingProductRegistryFiller& ioProductRegistry,
+                                   ActivityRegistry& iActivityRegistry,
+                                   std::shared_ptr<ProcessConfiguration const> iProcessConfiguration)
+      : resultsInserter_{iPathNames.empty() ? std::shared_ptr<TriggerResultInserter>{}
+                                            : makeInserter(ioProcessPSet,
+                                                           iPrealloc,
+                                                           ioProductRegistry,
+                                                           iActivityRegistry,
+                                                           iProcessConfiguration,
+                                                           iModuleRegistry)} {
+    pathStatusInserters_ = makePathStatusInserters<PathStatusInserter>(iPathNames,
+                                                                       iPrealloc,
+                                                                       ioProductRegistry,
+                                                                       iActivityRegistry,
+                                                                       iProcessConfiguration,
+                                                                       iModuleRegistry,
+                                                                       std::string("PathStatusInserter"));
+
+    if (iEndPathNames.size() > 1) {
+      endPathStatusInserters_ = makePathStatusInserters<EndPathStatusInserter>(iEndPathNames,
+                                                                               iPrealloc,
+                                                                               ioProductRegistry,
+                                                                               iActivityRegistry,
+                                                                               iProcessConfiguration,
+                                                                               iModuleRegistry,
+                                                                               std::string("EndPathStatusInserter"));
+    }
+
+    std::set<std::string> modulesInPaths;
+    //inject inserters
+    iModuleRegistry.forAllModuleHolders(
+        [&](auto const* holder) { modulesInPaths.insert(holder->moduleDescription().moduleLabel()); });
+
+    ConditionalTaskHelper conditionalTaskHelper(ioProcessPSet,
+                                                ioProductRegistry,
+                                                &iPrealloc,
+                                                iProcessConfiguration,
+                                                iModuleRegistry,
+                                                iActivityRegistry,
+                                                iPathNames);
+    std::unordered_set<std::string> conditionalModules;
+
+    pathNameAndModules_.reserve(iPathNames.size());
+    for (auto const& trig_name : iPathNames) {
+      pathNameAndModules_.emplace_back(trig_name,
+                                       fillTrigPath(ioProcessPSet,
+                                                    iModuleRegistry,
+                                                    ioProductRegistry,
+                                                    iActivityRegistry,
+                                                    &iPrealloc,
+                                                    iProcessConfiguration,
+                                                    trig_name,
+                                                    iEndPathNames,
+                                                    conditionalTaskHelper,
+                                                    conditionalModules));
+      for (auto const& path : pathNameAndModules_.back().second) {
+        modulesInPaths.insert(path.description_->moduleLabel());
+      }
+    }
+
+    // fill normal endpaths
+    endpathNameAndModules_.reserve(iEndPathNames.size());
+    for (auto const& end_path_name : iEndPathNames) {
+      endpathNameAndModules_.emplace_back(end_path_name,
+                                          fillEndPath(ioProcessPSet,
+                                                      iModuleRegistry,
+                                                      ioProductRegistry,
+                                                      iActivityRegistry,
+                                                      &iPrealloc,
+                                                      iProcessConfiguration,
+                                                      end_path_name,
+                                                      iEndPathNames,
+                                                      conditionalTaskHelper,
+                                                      conditionalModules));
+      for (auto const& path : endpathNameAndModules_.back().second) {
+        modulesInPaths.insert(path.description_->moduleLabel());
+      }
+    }
+
+    allNeededModules_.reserve(modulesInPaths.size());
+    iModuleRegistry.forAllModuleHolders([&](auto const* holder) {
+      if (modulesInPaths.find(holder->moduleDescription().moduleLabel()) != modulesInPaths.end()) {
+        allNeededModules_.emplace_back(&holder->moduleDescription());
+      }
+    });
+
+    std::vector<std::string> modulesInConfig(ioProcessPSet.getParameter<std::vector<std::string>>("@all_modules"));
+    std::set<std::string> modulesInConfigSet(modulesInConfig.begin(), modulesInConfig.end());
+    std::vector<std::string> unusedLabels;
+    set_difference(modulesInConfigSet.begin(),
+                   modulesInConfigSet.end(),
+                   modulesInPaths.begin(),
+                   modulesInPaths.end(),
+                   back_inserter(unusedLabels));
+    std::set<std::string> unscheduledLabels;
+    std::vector<std::string> shouldBeUsedLabels;
+    if (!unusedLabels.empty()) {
+      for (auto const& label : unusedLabels) {
+        auto modType =
+            ioProcessPSet.getParameter<edm::ParameterSet>(label).getParameter<std::string>("@module_edm_type");
+        if (modType == kProducerType || modType == kFilterType) {
+          auto module = getModule(ioProcessPSet,
+                                  label,
+                                  iModuleRegistry,
+                                  ioProductRegistry,
+                                  iActivityRegistry,
+                                  &iPrealloc,
+                                  iProcessConfiguration);
+
+          unscheduledModules_.push_back(&module->moduleDescription());
+          unscheduledLabels.emplace(label);
+        } else {
+          shouldBeUsedLabels.push_back(label);
+        }
+      }
+      if (!shouldBeUsedLabels.empty()) {
+        std::ostringstream unusedStream;
+        unusedStream << "'" << shouldBeUsedLabels.front() << "'";
+        for (std::vector<std::string>::iterator itLabel = shouldBeUsedLabels.begin() + 1,
+                                                itLabelEnd = shouldBeUsedLabels.end();
+             itLabel != itLabelEnd;
+             ++itLabel) {
+          unusedStream << ",'" << *itLabel << "'";
+        }
+        LogInfo("path") << "The following module labels are not assigned to any path:\n" << unusedStream.str() << "\n";
+      }
+    }
+
+    // Print conditional modules that were not consumed in any of their associated Paths
+    if (not conditionalModules.empty()) {
+      // Intersection of unscheduled and ConditionalTask modules gives
+      // directly the set of conditional modules that were not
+      // consumed by anything in the Paths associated to the
+      // corresponding ConditionalTask.
+      std::vector<std::string_view> labelsToPrint;
+      std::copy_if(
+          unscheduledLabels.begin(),
+          unscheduledLabels.end(),
+          std::back_inserter(labelsToPrint),
+          [&conditionalModules](auto const& lab) { return conditionalModules.find(lab) != conditionalModules.end(); });
+
+      if (not labelsToPrint.empty()) {
+        edm::LogWarning log("NonConsumedConditionalModules");
+        log << "The following modules were part of some ConditionalTask, but were not\n"
+            << "consumed by any other module in any of the Paths to which the ConditionalTask\n"
+            << "was associated. Perhaps they should be either removed from the\n"
+            << "job, or moved to a Task to make it explicit they are unscheduled.\n";
+        for (auto const& modLabel : labelsToPrint) {
+          log.format("\n {}", modLabel);
+        }
+      }
+    }
+    //we want the unscheduled modules at the beginning of the allNeededModules list
+    allNeededModules_.insert(allNeededModules_.begin(), unscheduledModules_.begin(), unscheduledModules_.end());
+  }
+}  // namespace edm

--- a/FWCore/Framework/src/ScheduleBuilder.cc
+++ b/FWCore/Framework/src/ScheduleBuilder.cc
@@ -16,8 +16,6 @@
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/Provenance/interface/ProductResolverIndexHelper.h"
 
-//DEBUG
-#include <iostream>
 namespace edm {
 
   namespace {

--- a/FWCore/Framework/src/ScheduleBuilder.cc
+++ b/FWCore/Framework/src/ScheduleBuilder.cc
@@ -563,8 +563,8 @@ namespace edm {
                                oAllConditionalModules);
     }
 
-    static const std::string kFilterType("EDFilter");
-    static const std::string kProducerType("EDProducer");
+    const std::string kFilterType("EDFilter");
+    const std::string kProducerType("EDProducer");
 
   }  // namespace
   ScheduleBuilder::ScheduleBuilder(ModuleRegistry& iModuleRegistry,

--- a/FWCore/Framework/src/ScheduleBuilder.h
+++ b/FWCore/Framework/src/ScheduleBuilder.h
@@ -1,0 +1,49 @@
+#ifndef FWCore_Framework_ScheduleBuilder_h
+#define FWCore_Framework_ScheduleBuilder_h
+
+#include "FWCore/Framework/interface/ModuleRegistry.h"
+#include "FWCore/Framework/interface/ModuleInPath.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
+
+#include <memory>
+#include <vector>
+#include <string_view>
+#include <set>
+namespace edm {
+  class ParameterSet;
+  class PreallocationConfiguration;
+  class SignallingProductRegistryFiller;
+  class ModuleDescription;
+  class TriggerResultInserter;
+  class PathStatusInserter;
+  class EndPathStatusInserter;
+
+  namespace service {
+    class TriggerNamesService;
+  }
+
+  struct ScheduleBuilder {
+  public:
+    ScheduleBuilder(ModuleRegistry& iModuleRegistry,
+                    ParameterSet& ioProcessPSet,
+                    std::vector<std::string> const& iPathNames,
+                    std::vector<std::string> const& iEndPathNames,
+                    PreallocationConfiguration const& iPrealloc,
+                    SignallingProductRegistryFiller& oProductRegistry,
+                    ActivityRegistry& iActivityRegistry,
+                    std::shared_ptr<ProcessConfiguration const> iProcessConfiguration);
+
+    //the order matches the order from iPathNames and iEndPathNames
+    std::vector<std::pair<std::string, std::vector<ModuleInPath>>> pathNameAndModules_;
+    std::vector<std::pair<std::string, std::vector<ModuleInPath>>> endpathNameAndModules_;
+
+    std::vector<edm::ModuleDescription const*> allNeededModules_;
+    std::vector<edm::ModuleDescription const*> unscheduledModules_;
+
+    std::shared_ptr<TriggerResultInserter> resultsInserter_;
+    std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>> pathStatusInserters_;
+    std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>> endPathStatusInserters_;
+  };
+}  // namespace edm
+#endif

--- a/FWCore/Framework/src/ScheduleBuilder.h
+++ b/FWCore/Framework/src/ScheduleBuilder.h
@@ -8,8 +8,7 @@
 
 #include <memory>
 #include <vector>
-#include <string_view>
-#include <set>
+#include <string>
 namespace edm {
   class ParameterSet;
   class PreallocationConfiguration;
@@ -18,6 +17,7 @@ namespace edm {
   class TriggerResultInserter;
   class PathStatusInserter;
   class EndPathStatusInserter;
+  class ProcessConfiguration;
 
   namespace service {
     class TriggerNamesService;

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -156,7 +156,7 @@ namespace edm {
       : workerManagerRuns_(modReg, areg, actions),
         workerManagerLumisAndEvents_(modReg, areg, actions),
         actReg_(areg),
-        results_(new HLTGlobalStatus(paths.size())),
+        results_(std::make_shared<HLTGlobalStatus>(paths.size())),
         results_inserter_(),
         trig_paths_(),
         end_paths_(),
@@ -245,7 +245,6 @@ namespace edm {
       }
       //determine if this module could read a branch we want to delete early
       auto consumes = modReg.getExistingModule(w->description()->moduleLabel())->moduleConsumesInfos();
-      //auto consumes = w->moduleConsumesInfos();
       if (not consumes.empty()) {
         bool foundAtLeastOneMatchingBranch = false;
         for (auto const& product : consumes) {

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -2,12 +2,9 @@
 
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/EventID.h"
-#include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/Provenance/interface/ProductResolverIndexHelper.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
-#include "FWCore/Framework/interface/SignallingProductRegistryFiller.h"
 #include "FWCore/Framework/src/OutputModuleDescription.h"
-#include "FWCore/Framework/interface/TriggerNamesService.h"
 #include "FWCore/Framework/src/TriggerReport.h"
 #include "FWCore/Framework/src/TriggerTimingReport.h"
 #include "FWCore/Framework/src/ModuleHolderFactory.h"
@@ -17,7 +14,6 @@
 #include "FWCore/Framework/src/EndPathStatusInserter.h"
 #include "FWCore/Framework/interface/WorkerInPath.h"
 #include "FWCore/Framework/interface/maker/ModuleHolder.h"
-#include "FWCore/Framework/interface/maker/WorkerT.h"
 #include "FWCore/Framework/interface/ModuleRegistry.h"
 #include "FWCore/Framework/interface/ModuleRegistryUtilities.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -33,7 +29,6 @@
 #include "FWCore/Utilities/interface/RunIndex.h"
 
 #include "LuminosityBlockProcessingStatus.h"
-#include "processEDAliases.h"
 
 #include <algorithm>
 #include <cassert>
@@ -154,11 +149,8 @@ namespace edm {
                                  std::vector<ModuleDescription const*> const& unscheduledModules,
                                  std::shared_ptr<TriggerResultInserter> inserter,
                                  std::shared_ptr<ModuleRegistry> modReg,
-                                 ParameterSet& proc_pset,
-                                 PreallocationConfiguration const& prealloc,
                                  ExceptionToActionTable const& actions,
                                  std::shared_ptr<ActivityRegistry> areg,
-                                 std::shared_ptr<ProcessConfiguration const> processConfiguration,
                                  StreamID streamID,
                                  ProcessContext const* processContext)
       : workerManagerRuns_(modReg, areg, actions),

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -1,21 +1,14 @@
 #include "FWCore/Framework/interface/WorkerManager.h"
 #include "UnscheduledConfigurator.h"
 
-#include "DataFormats/Provenance/interface/ProductRegistry.h"
-#include "DataFormats/Provenance/interface/ProductResolverIndexHelper.h"
 #include "FWCore/Framework/interface/maker/Worker.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/Utilities/interface/ExceptionCollector.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include <exception>
 #include <functional>
-
-static const std::string kFilterType("EDFilter");
-static const std::string kProducerType("EDProducer");
 
 namespace edm {
   // -----------------------------

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -38,20 +38,6 @@ namespace edm {
     }
   }
 
-  Worker* WorkerManager::getWorker(ParameterSet& pset,
-                                   SignallingProductRegistryFiller& preg,
-                                   PreallocationConfiguration const* prealloc,
-                                   std::shared_ptr<ProcessConfiguration const> processConfiguration,
-                                   std::string const& label,
-                                   bool addToAll) {
-    WorkerParams params(&pset, preg, prealloc, processConfiguration, *actionTable_);
-    auto worker = workerReg_.getWorker(params, label);
-    if (nullptr != worker and addToAll) {
-      addToAllWorkers(worker);
-    }
-    return worker;
-  }
-
   Worker* WorkerManager::getWorkerForExistingModule(std::string const& label) {
     auto worker = workerReg_.getWorkerFromExistingModule(label, actionTable_);
     if (nullptr != worker) {
@@ -67,29 +53,6 @@ namespace edm {
     unscheduled_.addWorker(newWorker);
     //add to list so it gets reset each new event
     addToAllWorkers(newWorker);
-  }
-
-  void WorkerManager::addToUnscheduledWorkers(ParameterSet& pset,
-                                              SignallingProductRegistryFiller& preg,
-                                              PreallocationConfiguration const* prealloc,
-                                              std::shared_ptr<ProcessConfiguration const> processConfiguration,
-                                              std::string label,
-                                              std::set<std::string>& unscheduledLabels,
-                                              std::vector<std::string>& shouldBeUsedLabels) {
-    //Need to
-    // 1) create worker
-    // 2) if it is a WorkerT<EDProducer>, add it to our list
-    auto modType = pset.getParameter<std::string>("@module_edm_type");
-    if (modType == kProducerType || modType == kFilterType) {
-      Worker* newWorker = getWorker(pset, preg, prealloc, processConfiguration, label);
-      assert(newWorker->moduleType() == Worker::kProducer || newWorker->moduleType() == Worker::kFilter);
-      unscheduledLabels.insert(label);
-      unscheduled_.addWorker(newWorker);
-      //add to list so it gets reset each new event
-      addToAllWorkers(newWorker);
-    } else {
-      shouldBeUsedLabels.push_back(label);
-    }
   }
 
   void WorkerManager::resetAll() { for_all(allWorkers_, std::bind(&Worker::reset, std::placeholders::_1)); }

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -60,6 +60,15 @@ namespace edm {
     return worker;
   }
 
+  void WorkerManager::addToUnscheduledWorkers(ModuleDescription const& iDescription) {
+    auto newWorker = workerReg_.getWorkerFromExistingModule(iDescription.moduleLabel(), actionTable_);
+    assert(nullptr != newWorker);
+    assert(newWorker->moduleType() == Worker::kProducer || newWorker->moduleType() == Worker::kFilter);
+    unscheduled_.addWorker(newWorker);
+    //add to list so it gets reset each new event
+    addToAllWorkers(newWorker);
+  }
+
   void WorkerManager::addToUnscheduledWorkers(ParameterSet& pset,
                                               SignallingProductRegistryFiller& preg,
                                               PreallocationConfiguration const* prealloc,

--- a/FWCore/Framework/src/WorkerRegistry.cc
+++ b/FWCore/Framework/src/WorkerRegistry.cc
@@ -22,26 +22,6 @@ namespace edm {
 
   void WorkerRegistry::clear() { m_workerMap.clear(); }
 
-  Worker* WorkerRegistry::getWorker(WorkerParams const& p, std::string const& moduleLabel) {
-    WorkerMap::iterator workerIt = m_workerMap.find(moduleLabel);
-
-    // if the worker is not there, make it
-    if (workerIt == m_workerMap.end()) {
-      MakeModuleParams mmp(p.pset_, *p.reg_, p.preallocate_, p.processConfiguration_);
-      auto modulePtr = modRegistry_->getModule(
-          mmp, moduleLabel, actReg_->preModuleConstructionSignal_, actReg_->postModuleConstructionSignal_);
-      auto workerPtr = modulePtr->makeWorker(p.actions_);
-
-      workerPtr->setActivityRegistry(actReg_);
-
-      // Transfer ownership of worker to the registry
-      m_workerMap[moduleLabel] =
-          std::shared_ptr<Worker>(workerPtr.release());  // propagate_const<T> has no reset() function
-      return m_workerMap[moduleLabel].get();
-    }
-    return (workerIt->second.get());
-  }
-
   Worker const* WorkerRegistry::get(std::string const& moduleLabel) const {
     WorkerMap::const_iterator workerIt = m_workerMap.find(moduleLabel);
     if (workerIt != m_workerMap.end()) {

--- a/FWCore/Framework/src/WorkerRegistry.cc
+++ b/FWCore/Framework/src/WorkerRegistry.cc
@@ -9,7 +9,6 @@
 #include "FWCore/Framework/interface/WorkerRegistry.h"
 #include "FWCore/Framework/interface/maker/Worker.h"
 #include "FWCore/Framework/interface/maker/ModuleHolder.h"
-#include "FWCore/Framework/interface/maker/MakeModuleParams.h"
 #include "FWCore/Framework/interface/ModuleRegistry.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -737,11 +737,6 @@ namespace edm {
     return Worker::kStream;
   }
 
-  template <typename T>
-  std::vector<ModuleConsumesInfo> WorkerT<T>::moduleConsumesInfos() const {
-    return module_->moduleConsumesInfos();
-  }
-
   //Explicitly instantiate our needed templates to avoid having the compiler
   // instantiate them in all of our libraries
   template class WorkerT<one::EDProducerBase>;

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -573,21 +573,6 @@ namespace edm {
   }
 
   template <typename T>
-  inline void WorkerT<T>::implRespondToOpenInputFile(FileBlock const& fb) {
-    module_->doRespondToOpenInputFile(fb);
-  }
-
-  template <typename T>
-  inline void WorkerT<T>::implRespondToCloseInputFile(FileBlock const& fb) {
-    module_->doRespondToCloseInputFile(fb);
-  }
-
-  template <typename T>
-  void WorkerT<T>::implRespondToCloseOutputFile() {
-    module_->doRespondToCloseOutputFile();
-  }
-
-  template <typename T>
   inline Worker::TaskQueueAdaptor WorkerT<T>::serializeRunModule() {
     return Worker::TaskQueueAdaptor{};
   }

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -387,6 +387,12 @@
   <use name="FWCore/Utilities"/>
 </bin>
 
+<bin file="test_catch2_main.cc,test_catch2_ScheduleBuilder.cc" name="TestFWCoreFrameworkScheduleBuilder">
+  <use name="catch2"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/Utilities"/>
+</bin>
+
 <test name="testFWCoreFrameworkCmsRunParsing" command="run_cmsRun_parsing.sh"/>
 <test name="testFWCoreFrameworkCmsRunVarparsing" command="run_cmsRun_varparsing.sh"/>
 <test name="testFWCoreFrameworkCmsRunArgparse" command="run_cmsRun_argparse.sh"/>

--- a/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
@@ -13,6 +13,7 @@
 #include "FWCore/Framework/interface/OutputModuleCommunicatorT.h"
 #include "FWCore/Framework/interface/TransitionInfoTypes.h"
 #include "FWCore/Framework/interface/maker/WorkerT.h"
+#include "FWCore/Framework/interface/maker/ModuleHolder.h"
 #include "FWCore/Framework/interface/OccurrenceTraits.h"
 #include "FWCore/Framework/interface/ProductResolversFactory.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
@@ -71,7 +72,8 @@ public:
   typedef std::vector<Trans> Expectations;
 
 private:
-  std::map<Trans, std::function<void(edm::Worker*, edm::OutputModuleCommunicator*)>> m_transToFunc;
+  std::map<Trans, std::function<void(edm::Worker*, edm::maker::ModuleHolder*, edm::OutputModuleCommunicator*)>>
+      m_transToFunc;
 
   edm::ProcessConfiguration m_procConfig;
   edm::PreallocationConfiguration m_preallocConfig;
@@ -187,30 +189,33 @@ testGlobalOutputModule::testGlobalOutputModule()
   m_actReg.reset(new edm::ActivityRegistry);
 
   //For each transition, bind a lambda which will call the proper method of the Worker
-  m_transToFunc[Trans::kGlobalOpenInputFile] = [](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
-    edm::FileBlock fb;
-    iBase->respondToOpenInputFile(fb);
-  };
+  m_transToFunc[Trans::kGlobalOpenInputFile] =
+      [](edm::Worker* iBase, edm::maker::ModuleHolder* iHolder, edm::OutputModuleCommunicator*) {
+        edm::FileBlock fb;
+        iHolder->respondToOpenInputFile(fb);
+      };
 
-  m_transToFunc[Trans::kGlobalBeginRun] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
-    typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
-    edm::GlobalContext gc(edm::GlobalContext::Transition::kBeginRun, nullptr);
-    edm::ParentContext parentContext(&gc);
-    iBase->setActivityRegistry(m_actReg);
-    edm::RunTransitionInfo info(*m_rp, *m_es);
-    doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
-  };
+  m_transToFunc[Trans::kGlobalBeginRun] =
+      [this](edm::Worker* iBase, edm::maker::ModuleHolder*, edm::OutputModuleCommunicator*) {
+        typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
+        edm::GlobalContext gc(edm::GlobalContext::Transition::kBeginRun, nullptr);
+        edm::ParentContext parentContext(&gc);
+        iBase->setActivityRegistry(m_actReg);
+        edm::RunTransitionInfo info(*m_rp, *m_es);
+        doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
+      };
 
-  m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
-    typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
-    edm::GlobalContext gc(edm::GlobalContext::Transition::kBeginLuminosityBlock, nullptr);
-    edm::ParentContext parentContext(&gc);
-    iBase->setActivityRegistry(m_actReg);
-    edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
-  };
+  m_transToFunc[Trans::kGlobalBeginLuminosityBlock] =
+      [this](edm::Worker* iBase, edm::maker::ModuleHolder*, edm::OutputModuleCommunicator*) {
+        typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
+        edm::GlobalContext gc(edm::GlobalContext::Transition::kBeginLuminosityBlock, nullptr);
+        edm::ParentContext parentContext(&gc);
+        iBase->setActivityRegistry(m_actReg);
+        edm::LumiTransitionInfo info(*m_lbp, *m_es);
+        doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
+      };
 
-  m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
+  m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase, edm::maker::ModuleHolder*, edm::OutputModuleCommunicator*) {
     typedef edm::OccurrenceTraits<edm::EventPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::StreamContext streamContext(s_streamID0, nullptr);
     edm::ParentContext parentContext(&streamContext);
@@ -219,36 +224,39 @@ testGlobalOutputModule::testGlobalOutputModule()
     doWork<Traits>(iBase, info, s_streamID0, parentContext);
   };
 
-  m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator* iComm) {
-    typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
-    edm::GlobalContext gc(edm::GlobalContext::Transition::kEndLuminosityBlock, nullptr);
-    edm::ParentContext parentContext(&gc);
-    iBase->setActivityRegistry(m_actReg);
-    edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
-    oneapi::tbb::task_group group;
-    edm::FinalWaitingTask task{group};
-    iComm->writeLumiAsync(edm::WaitingTaskHolder(group, &task), *m_lbp, nullptr, &activityRegistry);
-    task.wait();
-  };
+  m_transToFunc[Trans::kGlobalEndLuminosityBlock] =
+      [this](edm::Worker* iBase, edm::maker::ModuleHolder*, edm::OutputModuleCommunicator* iComm) {
+        typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
+        edm::GlobalContext gc(edm::GlobalContext::Transition::kEndLuminosityBlock, nullptr);
+        edm::ParentContext parentContext(&gc);
+        iBase->setActivityRegistry(m_actReg);
+        edm::LumiTransitionInfo info(*m_lbp, *m_es);
+        doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
+        oneapi::tbb::task_group group;
+        edm::FinalWaitingTask task{group};
+        iComm->writeLumiAsync(edm::WaitingTaskHolder(group, &task), *m_lbp, nullptr, &activityRegistry);
+        task.wait();
+      };
 
-  m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator* iComm) {
-    typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
-    edm::GlobalContext gc(edm::GlobalContext::Transition::kEndRun, nullptr);
-    edm::ParentContext parentContext(&gc);
-    iBase->setActivityRegistry(m_actReg);
-    edm::RunTransitionInfo info(*m_rp, *m_es);
-    doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
-    oneapi::tbb::task_group group;
-    edm::FinalWaitingTask task{group};
-    iComm->writeRunAsync(edm::WaitingTaskHolder(group, &task), *m_rp, nullptr, &activityRegistry, nullptr);
-    task.wait();
-  };
+  m_transToFunc[Trans::kGlobalEndRun] =
+      [this](edm::Worker* iBase, edm::maker::ModuleHolder*, edm::OutputModuleCommunicator* iComm) {
+        typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
+        edm::GlobalContext gc(edm::GlobalContext::Transition::kEndRun, nullptr);
+        edm::ParentContext parentContext(&gc);
+        iBase->setActivityRegistry(m_actReg);
+        edm::RunTransitionInfo info(*m_rp, *m_es);
+        doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
+        oneapi::tbb::task_group group;
+        edm::FinalWaitingTask task{group};
+        iComm->writeRunAsync(edm::WaitingTaskHolder(group, &task), *m_rp, nullptr, &activityRegistry, nullptr);
+        task.wait();
+      };
 
-  m_transToFunc[Trans::kGlobalCloseInputFile] = [](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
-    edm::FileBlock fb;
-    iBase->respondToCloseInputFile(fb);
-  };
+  m_transToFunc[Trans::kGlobalCloseInputFile] =
+      [](edm::Worker* iBase, edm::maker::ModuleHolder* iHolder, edm::OutputModuleCommunicator*) {
+        edm::FileBlock fb;
+        iHolder->respondToCloseInputFile(fb);
+      };
 
   // We want to create the TriggerNamesService because it is used in
   // the tests.  We do that here, but first we need to build a minimal
@@ -275,14 +283,16 @@ testGlobalOutputModule::testGlobalOutputModule()
 
 namespace {
   template <typename T>
-  void testTransition(std::shared_ptr<T> iMod,
-                      edm::Worker* iWorker,
-                      edm::OutputModuleCommunicator* iComm,
-                      testGlobalOutputModule::Trans iTrans,
-                      testGlobalOutputModule::Expectations const& iExpect,
-                      std::function<void(edm::Worker*, edm::OutputModuleCommunicator*)> iFunc) {
+  void testTransition(
+      std::shared_ptr<T> iMod,
+      edm::Worker* iWorker,
+      edm::maker::ModuleHolder* iHolder,
+      edm::OutputModuleCommunicator* iComm,
+      testGlobalOutputModule::Trans iTrans,
+      testGlobalOutputModule::Expectations const& iExpect,
+      std::function<void(edm::Worker*, edm::maker::ModuleHolder*, edm::OutputModuleCommunicator*)> iFunc) {
     assert(0 == iMod->m_count);
-    iFunc(iWorker, iComm);
+    iFunc(iWorker, iHolder, iComm);
     auto count = std::count(iExpect.begin(), iExpect.end(), iTrans);
     if (count != iMod->m_count) {
       std::cout << "For trans " << static_cast<std::underlying_type<testGlobalOutputModule::Trans>::type>(iTrans)
@@ -303,8 +313,9 @@ void testGlobalOutputModule::testTransitions(std::shared_ptr<T> iMod, Expectatio
     iMod->doPreallocate(m_preallocConfig);
     edm::WorkerT<edm::global::OutputModuleBase> w{iMod, m_desc, m_params.actions_};
     edm::OutputModuleCommunicatorT<edm::global::OutputModuleBase> comm(iMod.get());
+    edm::maker::ModuleHolderT<edm::global::OutputModuleBase> h(iMod);
     for (auto& keyVal : m_transToFunc) {
-      testTransition(iMod, &w, &comm, keyVal.first, iExpect, keyVal.second);
+      testTransition(iMod, &w, &h, &comm, keyVal.first, iExpect, keyVal.second);
     }
   });
 }

--- a/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
@@ -15,6 +15,7 @@
 #include "FWCore/Framework/interface/maker/WorkerT.h"
 #include "FWCore/Framework/interface/OccurrenceTraits.h"
 #include "FWCore/Framework/interface/ProductResolversFactory.h"
+#include "FWCore/Framework/interface/maker/ModuleHolder.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
@@ -71,7 +72,8 @@ public:
   typedef std::vector<Trans> Expectations;
 
 private:
-  std::map<Trans, std::function<void(edm::Worker*, edm::OutputModuleCommunicator*)>> m_transToFunc;
+  std::map<Trans, std::function<void(edm::Worker*, edm::maker::ModuleHolder*, edm::OutputModuleCommunicator*)>>
+      m_transToFunc;
 
   edm::ProcessConfiguration m_procConfig;
   edm::PreallocationConfiguration m_preallocConfig;
@@ -186,30 +188,33 @@ testLimitedOutputModule::testLimitedOutputModule()
   m_actReg.reset(new edm::ActivityRegistry);
 
   //For each transition, bind a lambda which will call the proper method of the Worker
-  m_transToFunc[Trans::kGlobalOpenInputFile] = [](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
-    edm::FileBlock fb;
-    iBase->respondToOpenInputFile(fb);
-  };
+  m_transToFunc[Trans::kGlobalOpenInputFile] =
+      [](edm::Worker* iBase, edm::maker::ModuleHolder* iHolder, edm::OutputModuleCommunicator*) {
+        edm::FileBlock fb;
+        iHolder->respondToOpenInputFile(fb);
+      };
 
-  m_transToFunc[Trans::kGlobalBeginRun] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
-    typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
-    edm::GlobalContext gc(edm::GlobalContext::Transition::kBeginRun, nullptr);
-    edm::ParentContext parentContext(&gc);
-    iBase->setActivityRegistry(m_actReg);
-    edm::RunTransitionInfo info(*m_rp, *m_es);
-    doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
-  };
+  m_transToFunc[Trans::kGlobalBeginRun] =
+      [this](edm::Worker* iBase, edm::maker::ModuleHolder*, edm::OutputModuleCommunicator*) {
+        typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
+        edm::GlobalContext gc(edm::GlobalContext::Transition::kBeginRun, nullptr);
+        edm::ParentContext parentContext(&gc);
+        iBase->setActivityRegistry(m_actReg);
+        edm::RunTransitionInfo info(*m_rp, *m_es);
+        doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
+      };
 
-  m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
-    typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
-    edm::GlobalContext gc(edm::GlobalContext::Transition::kBeginLuminosityBlock, nullptr);
-    edm::ParentContext parentContext(&gc);
-    iBase->setActivityRegistry(m_actReg);
-    edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
-  };
+  m_transToFunc[Trans::kGlobalBeginLuminosityBlock] =
+      [this](edm::Worker* iBase, edm::maker::ModuleHolder*, edm::OutputModuleCommunicator*) {
+        typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
+        edm::GlobalContext gc(edm::GlobalContext::Transition::kBeginLuminosityBlock, nullptr);
+        edm::ParentContext parentContext(&gc);
+        iBase->setActivityRegistry(m_actReg);
+        edm::LumiTransitionInfo info(*m_lbp, *m_es);
+        doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
+      };
 
-  m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
+  m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase, edm::maker::ModuleHolder*, edm::OutputModuleCommunicator*) {
     typedef edm::OccurrenceTraits<edm::EventPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::StreamContext streamContext(s_streamID0, nullptr);
     edm::ParentContext parentContext(&streamContext);
@@ -218,36 +223,39 @@ testLimitedOutputModule::testLimitedOutputModule()
     doWork<Traits>(iBase, info, s_streamID0, parentContext);
   };
 
-  m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator* iComm) {
-    typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
-    edm::GlobalContext gc(edm::GlobalContext::Transition::kEndLuminosityBlock, nullptr);
-    edm::ParentContext parentContext(&gc);
-    iBase->setActivityRegistry(m_actReg);
-    edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
-    oneapi::tbb::task_group group;
-    edm::FinalWaitingTask task{group};
-    iComm->writeLumiAsync(edm::WaitingTaskHolder(group, &task), *m_lbp, nullptr, &activityRegistry);
-    task.wait();
-  };
+  m_transToFunc[Trans::kGlobalEndLuminosityBlock] =
+      [this](edm::Worker* iBase, edm::maker::ModuleHolder*, edm::OutputModuleCommunicator* iComm) {
+        typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
+        edm::GlobalContext gc(edm::GlobalContext::Transition::kEndLuminosityBlock, nullptr);
+        edm::ParentContext parentContext(&gc);
+        iBase->setActivityRegistry(m_actReg);
+        edm::LumiTransitionInfo info(*m_lbp, *m_es);
+        doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
+        oneapi::tbb::task_group group;
+        edm::FinalWaitingTask task{group};
+        iComm->writeLumiAsync(edm::WaitingTaskHolder(group, &task), *m_lbp, nullptr, &activityRegistry);
+        task.wait();
+      };
 
-  m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator* iComm) {
-    typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
-    edm::GlobalContext gc(edm::GlobalContext::Transition::kEndRun, nullptr);
-    edm::ParentContext parentContext(&gc);
-    iBase->setActivityRegistry(m_actReg);
-    edm::RunTransitionInfo info(*m_rp, *m_es);
-    doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
-    oneapi::tbb::task_group group;
-    edm::FinalWaitingTask task{group};
-    iComm->writeRunAsync(edm::WaitingTaskHolder(group, &task), *m_rp, nullptr, &activityRegistry, nullptr);
-    task.wait();
-  };
+  m_transToFunc[Trans::kGlobalEndRun] =
+      [this](edm::Worker* iBase, edm::maker::ModuleHolder*, edm::OutputModuleCommunicator* iComm) {
+        typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
+        edm::GlobalContext gc(edm::GlobalContext::Transition::kEndRun, nullptr);
+        edm::ParentContext parentContext(&gc);
+        iBase->setActivityRegistry(m_actReg);
+        edm::RunTransitionInfo info(*m_rp, *m_es);
+        doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
+        oneapi::tbb::task_group group;
+        edm::FinalWaitingTask task{group};
+        iComm->writeRunAsync(edm::WaitingTaskHolder(group, &task), *m_rp, nullptr, &activityRegistry, nullptr);
+        task.wait();
+      };
 
-  m_transToFunc[Trans::kGlobalCloseInputFile] = [](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
-    edm::FileBlock fb;
-    iBase->respondToCloseInputFile(fb);
-  };
+  m_transToFunc[Trans::kGlobalCloseInputFile] =
+      [](edm::Worker* iBase, edm::maker::ModuleHolder* iHolder, edm::OutputModuleCommunicator*) {
+        edm::FileBlock fb;
+        iHolder->respondToCloseInputFile(fb);
+      };
 
   // We want to create the TriggerNamesService because it is used in
   // the tests.  We do that here, but first we need to build a minimal
@@ -274,14 +282,16 @@ testLimitedOutputModule::testLimitedOutputModule()
 
 namespace {
   template <typename T>
-  void testTransition(std::shared_ptr<T> iMod,
-                      edm::Worker* iWorker,
-                      edm::OutputModuleCommunicator* iComm,
-                      testLimitedOutputModule::Trans iTrans,
-                      testLimitedOutputModule::Expectations const& iExpect,
-                      std::function<void(edm::Worker*, edm::OutputModuleCommunicator*)> iFunc) {
+  void testTransition(
+      std::shared_ptr<T> iMod,
+      edm::Worker* iWorker,
+      edm::OutputModuleCommunicator* iComm,
+      testLimitedOutputModule::Trans iTrans,
+      testLimitedOutputModule::Expectations const& iExpect,
+      std::function<void(edm::Worker*, edm::maker::ModuleHolder*, edm::OutputModuleCommunicator*)> iFunc) {
     assert(0 == iMod->m_count);
-    iFunc(iWorker, iComm);
+    edm::maker::ModuleHolderT<edm::limited::OutputModuleBase> h(iMod);
+    iFunc(iWorker, &h, iComm);
     auto count = std::count(iExpect.begin(), iExpect.end(), iTrans);
     if (count != iMod->m_count) {
       std::cout << "For trans " << static_cast<std::underlying_type<testLimitedOutputModule::Trans>::type>(iTrans)

--- a/FWCore/Framework/test/test_catch2_ScheduleBuilder.cc
+++ b/FWCore/Framework/test/test_catch2_ScheduleBuilder.cc
@@ -1,0 +1,247 @@
+#include "catch.hpp"
+
+#include "FWCore/Framework/src/ScheduleBuilder.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/ModuleRegistry.h"
+#include "FWCore/Framework/interface/PreallocationConfiguration.h"
+#include "FWCore/Framework/interface/SignallingProductRegistryFiller.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Provenance/interface/ProcessConfiguration.h"
+
+#include <vector>
+#include <string_view>
+namespace edm::test::sb {
+  class SBIntProducer : public edm::global::EDProducer<> {
+  public:
+    explicit SBIntProducer(std::vector<edm::InputTag> const& iConsumes) {
+      for (auto const& tag : iConsumes) {
+        consumes<int>(tag);
+      }
+      produces<int>();
+    }
+    void produce(StreamID, edm::Event&, edm::EventSetup const&) const final {}
+  };
+}  // namespace edm::test::sb
+
+namespace {
+  struct ModuleInfo {
+    std::string label_;
+    std::string type_;
+    std::string edmType_;
+  };
+  enum class EdmType { kProducer, kFilter, kAnalyzer, kSwitchProducer, kOutputModule };
+
+  struct ConfigBuilder {
+    void addModule(std::string const& iLabel, std::string const& iType, EdmType iEdmType) {
+      ModuleInfo info = {.label_ = iLabel, .type_ = iType, .edmType_ = enumToName(iEdmType)};
+      modules_.emplace_back(std::move(info));
+    }
+    std::string enumToName(EdmType iType) {
+      switch (iType) {
+        case EdmType::kProducer:
+          return "EDProducer";
+        case EdmType::kFilter:
+          return "EDFilter";
+        case EdmType::kAnalyzer:
+          return "EDAnalyzer";
+        case EdmType::kOutputModule:
+          return "OutputModule";
+        case EdmType::kSwitchProducer:
+          return "SwitchProducer";
+      }
+      return "";
+    }
+    void addPath(std::string iName, std::vector<std::string> iModuleLabels) {
+      paths_.emplace_back(std::move(iName), std::move(iModuleLabels));
+    }
+    void addEndPath(std::string iName, std::vector<std::string> iModuleLabels) {
+      endpaths_.emplace_back(std::move(iName), std::move(iModuleLabels));
+    }
+    void addAllowedFilterOnEndPath(std::string iLabel) { allowedFiltersOnEndPaths_.emplace_back(std::move(iLabel)); }
+
+    edm::ParameterSet buildConfig() {
+      edm::ParameterSet config;
+      config.addParameter<std::vector<std::string>>("@all_aliases", std::vector<std::string>());
+      std::vector<std::string> pathNames;
+      for (auto const& pathInfo : paths_) {
+        pathNames.emplace_back(pathInfo.first);
+        config.addParameter<std::vector<std::string>>(pathInfo.first, pathInfo.second);
+      }
+      for (auto const& pathInfo : endpaths_) {
+        config.addParameter<std::vector<std::string>>(pathInfo.first, pathInfo.second);
+      }
+      edm::ParameterSet trigPaths;
+      trigPaths.addParameter<std::vector<std::string>>("@trigger_paths", pathNames);
+      config.addParameter<edm::ParameterSet>("@trigger_paths", trigPaths);
+      std::vector<std::string> moduleLabels;
+      moduleLabels.reserve(modules_.size());
+      for (auto const& moduleInfo : modules_) {
+        moduleLabels.emplace_back(moduleInfo.label_);
+        edm::ParameterSet moduleConfig;
+        moduleConfig.addParameter<std::string>("@module_type", moduleInfo.type_);
+        moduleConfig.addParameter<std::string>("@module_edm_type", moduleInfo.edmType_);
+        config.addParameter<edm::ParameterSet>(moduleInfo.label_, moduleConfig);
+      }
+      config.addParameter<std::vector<std::string>>("@all_modules", moduleLabels);
+      config.addUntrackedParameter<std::vector<std::string>>("@filters_on_endpaths", allowedFiltersOnEndPaths_);
+
+      return config;
+    }
+
+    std::vector<std::string> paths() {
+      std::vector<std::string> ret;
+      for (auto const& p : paths_) {
+        ret.push_back(p.first);
+      }
+      return ret;
+    }
+
+    std::vector<std::string> endpaths() {
+      std::vector<std::string> ret;
+      for (auto const& p : endpaths_) {
+        ret.push_back(p.first);
+      }
+      return ret;
+    }
+
+  private:
+    std::vector<ModuleInfo> modules_;
+    std::vector<std::pair<std::string, std::vector<std::string>>> paths_;
+    std::vector<std::pair<std::string, std::vector<std::string>>> endpaths_;
+    std::vector<std::string> allowedFiltersOnEndPaths_;
+  };
+}  // namespace
+
+TEST_CASE("test edm::ScheduleBuilder", "[ScheduleBuilder]") {
+  edm::HardwareResourcesDescription hardware;
+  auto const processConfig = std::make_shared<edm::ProcessConfiguration const>("TEST", "CMSSW_X_Y_Z", hardware);
+  edm::PreallocationConfiguration prealloc;
+  SECTION("empty schedule") {
+    edm::ModuleRegistry moduleRegistry;
+    edm::SignallingProductRegistryFiller productRegistry;
+    edm::ActivityRegistry activityRegistry;
+
+    ConfigBuilder confBuilder;
+    auto config = confBuilder.buildConfig();
+    edm::ScheduleBuilder builder(moduleRegistry,
+                                 config,
+                                 confBuilder.paths(),
+                                 confBuilder.endpaths(),
+                                 prealloc,
+                                 productRegistry,
+                                 activityRegistry,
+                                 processConfig);
+
+    REQUIRE(builder.endpathNameAndModules_.empty());
+    REQUIRE(builder.pathNameAndModules_.empty());
+    REQUIRE(builder.allNeededModules_.empty());
+    REQUIRE(builder.unscheduledModules_.empty());
+    REQUIRE(builder.pathStatusInserters_.empty());
+    REQUIRE(not builder.resultsInserter_);
+  }
+  SECTION("one module on path") {
+    edm::SignallingProductRegistryFiller productRegistry;
+    edm::ActivityRegistry activityRegistry;
+
+    edm::ModuleRegistry moduleRegistry;
+    edm::ParameterSet pset;
+    pset.addParameter<std::string>("@module_type", "edm::test::sb::SBIntProducer");
+    pset.addParameter<std::string>("@module_edm_type", "EDProducer");
+    pset.registerIt();
+
+    edm::ModuleDescription desc(
+        pset.id(), "edm::test::sb::SBIntProducer", "prod1", processConfig.get(), edm::ModuleDescription::getUniqueID());
+    moduleRegistry.makeExplicitModule<edm::test::sb::SBIntProducer>(desc,
+                                                                    prealloc,
+                                                                    &productRegistry,
+                                                                    activityRegistry.preModuleConstructionSignal_,
+                                                                    activityRegistry.postModuleConstructionSignal_,
+                                                                    std::vector<edm::InputTag>());
+
+    ConfigBuilder confBuilder;
+    confBuilder.addModule("prod1", "edm::test::sb::SBIntProducer", EdmType::kProducer);
+    confBuilder.addPath("p1", {{"prod1"}});
+    auto config = confBuilder.buildConfig();
+    edm::ScheduleBuilder builder(moduleRegistry,
+                                 config,
+                                 confBuilder.paths(),
+                                 confBuilder.endpaths(),
+                                 prealloc,
+                                 productRegistry,
+                                 activityRegistry,
+                                 processConfig);
+
+    REQUIRE(builder.endpathNameAndModules_.empty());
+    REQUIRE(builder.pathNameAndModules_.size() == 1);
+    REQUIRE(builder.pathNameAndModules_.front().first == "p1");
+    REQUIRE(builder.pathNameAndModules_.front().second.size() == 1);
+    auto moduleInfo = builder.pathNameAndModules_.front().second.front();
+    REQUIRE(moduleInfo.description_->moduleLabel() == "prod1");
+    REQUIRE(moduleInfo.description_->moduleName() == "edm::test::sb::SBIntProducer");
+    REQUIRE(moduleInfo.action_ == edm::WorkerInPath::Normal);
+    REQUIRE(moduleInfo.placeInPath_ == 0);
+    REQUIRE(moduleInfo.runConcurrently_ == true);
+    REQUIRE(builder.allNeededModules_.size() == 3);
+    REQUIRE(std::find_if(builder.allNeededModules_.begin(), builder.allNeededModules_.end(), [&desc](auto const* el) {
+              return *el == desc;
+            }) != builder.allNeededModules_.end());
+    REQUIRE(builder.unscheduledModules_.empty());
+    REQUIRE(builder.pathStatusInserters_.size() == 1);
+    REQUIRE(builder.endPathStatusInserters_.empty());
+    REQUIRE(builder.resultsInserter_);
+  }
+
+  SECTION("one module on endpath") {
+    //If there is only one endpath no end path status inserter is added to the system
+    edm::SignallingProductRegistryFiller productRegistry;
+    edm::ActivityRegistry activityRegistry;
+
+    edm::ModuleRegistry moduleRegistry;
+    edm::ParameterSet pset;
+    pset.addParameter<std::string>("@module_type", "edm::test::sb::SBIntProducer");
+    pset.addParameter<std::string>("@module_edm_type", "EDProducer");
+    pset.registerIt();
+
+    edm::ModuleDescription desc(
+        pset.id(), "edm::test::sb::SBIntProducer", "prod1", processConfig.get(), edm::ModuleDescription::getUniqueID());
+    moduleRegistry.makeExplicitModule<edm::test::sb::SBIntProducer>(desc,
+                                                                    prealloc,
+                                                                    &productRegistry,
+                                                                    activityRegistry.preModuleConstructionSignal_,
+                                                                    activityRegistry.postModuleConstructionSignal_,
+                                                                    std::vector<edm::InputTag>());
+
+    ConfigBuilder confBuilder;
+    confBuilder.addModule("prod1", "edm::test::sb::SBIntProducer", EdmType::kProducer);
+    confBuilder.addEndPath("e", {{"prod1"}});
+    auto config = confBuilder.buildConfig();
+    edm::ScheduleBuilder builder(moduleRegistry,
+                                 config,
+                                 confBuilder.paths(),
+                                 confBuilder.endpaths(),
+                                 prealloc,
+                                 productRegistry,
+                                 activityRegistry,
+                                 processConfig);
+
+    REQUIRE(builder.endpathNameAndModules_.size() == 1);
+    REQUIRE(builder.endpathNameAndModules_.front().first == "e");
+    REQUIRE(builder.endpathNameAndModules_.front().second.size() == 1);
+    auto moduleInfo = builder.endpathNameAndModules_.front().second.front();
+    REQUIRE(moduleInfo.description_->moduleLabel() == "prod1");
+    REQUIRE(moduleInfo.description_->moduleName() == "edm::test::sb::SBIntProducer");
+    REQUIRE(moduleInfo.action_ == edm::WorkerInPath::Normal);
+    REQUIRE(moduleInfo.placeInPath_ == 0);
+    REQUIRE(moduleInfo.runConcurrently_ == true);
+    REQUIRE(builder.pathNameAndModules_.empty());
+    REQUIRE(builder.allNeededModules_.size() == 1);
+    REQUIRE(std::find_if(builder.allNeededModules_.begin(), builder.allNeededModules_.end(), [&desc](auto const* el) {
+              return *el == desc;
+            }) != builder.allNeededModules_.end());
+    REQUIRE(builder.unscheduledModules_.empty());
+    REQUIRE(builder.pathStatusInserters_.empty());
+    REQUIRE(builder.endPathStatusInserters_.empty());
+    REQUIRE(not builder.resultsInserter_);
+  }
+}

--- a/FWCore/Integration/test/testSwitchProducerTask_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerTask_cfg.py
@@ -104,3 +104,6 @@ else:
     process.p = cms.Path(process.t)
 
 process.e = cms.EndPath(process.out)
+
+from FWCore.Services.modules import Tracer
+process.add_(Tracer())

--- a/FWCore/Integration/test/testSwitchProducerTask_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerTask_cfg.py
@@ -104,6 +104,3 @@ else:
     process.p = cms.Path(process.t)
 
 process.e = cms.EndPath(process.out)
-
-from FWCore.Services.modules import Tracer
-process.add_(Tracer())

--- a/FWCore/Integration/test/unit_test_outputs/testConsumesInfo_1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testConsumesInfo_1.log
@@ -50,10 +50,10 @@ modules on endpath p1ep2:
 All modules and modules in the current process whose products they consume:
 (This does not include modules from previous processes or the source)
 (Exclusively considers consumed Event and EventSetup products, not Run, Lumi, or ProcessBlock products)
-  IntProducer/'intProducerA'
-  IntProducer/'intProducerU'
-  IntVectorProducer/'intVectorProducer'
-  IntProducer/'intProducer'
+  TriggerResultInserter/'TriggerResults'
+  WhatsItAnalyzer/'WhatsItAnalyzer'
+    consumes products during Event from these EventSetup modules:
+      WhatsItESProducer/'' ESProducer
   TestFindProduct/'a1'
   TestFindProduct/'a2'
     consumes products from these modules:
@@ -64,21 +64,47 @@ All modules and modules in the current process whose products they consume:
   TestFindProduct/'a4'
     consumes products from these modules:
       IntProducer/'intProducerA'
-  TestContextAnalyzer/'test'
-  TestFindProduct/'testView1'
-    consumes products from these modules:
-      IntVectorProducer/'intVectorProducer'
-  IntProducer/'testStreamingProducer'
-  ConsumingStreamAnalyzer/'testStreamingAnalyzer'
-    consumes products from these modules:
-      IntProducer/'testStreamingProducer'
-  IntProducerBeginProcessBlock/'intProducerBeginProcessBlock'
-  IntProducerEndProcessBlock/'intProducerEndProcessBlock'
-  TestFindProduct/'processBlockTest1'
+  ConcurrentIOVAnalyzer/'concurrentIOVAnalyzer'
+    consumes products during Event from these EventSetup modules:
+      ConcurrentIOVESSource/'concurrentIOVESSource' ESSource
+      ConcurrentIOVESProducer/'concurrentIOVESProducer' ESProducer
+  ConsumeIOVTestInfoAnalyzer/'consumeIOVTestInfoAnalyzer'
+    consumes products during Event from these EventSetup modules:
+      MayConsumeWhatsIt/'mayConsumeWhatsIt' ESProducer
+  ConsumeIOVTestInfoAnalyzer/'consumeIOVTestInfoAnalyzer2'
+    consumes products during Event from these EventSetup modules:
+      MayConsumeWhatsIt/'mayConsumeWhatsIt' ESProducer
+  EndPathStatusInserter/'e'
+  IntProducer/'intProducer'
+  IntProducer/'intProducerA'
   IntProducer/'intProducerB'
+  IntProducerBeginProcessBlock/'intProducerBeginProcessBlock'
   IntProducer/'intProducerC'
   IntProducer/'intProducerD'
   IntProducer/'intProducerE'
+  IntProducerEndProcessBlock/'intProducerEndProcessBlock'
+  IntProducer/'intProducerU'
+  IntVectorProducer/'intVectorProducer'
+  PoolOutputModule/'out'
+    consumes products from these modules:
+      TriggerResultInserter/'TriggerResults'
+      IntProducer/'intProducerA'
+      IntProducer/'intProducer'
+      IntProducer/'intProducerU'
+      ConsumingIntProducer/'testManyConsumingProducer'
+      IntProducer/'testStreamingProducer'
+      IntVectorProducer/'intVectorProducer'
+  PathStatusInserter/'p'
+  PathStatusInserter/'p11'
+  EndPathStatusInserter/'p1ep2'
+  PathStatusInserter/'p2'
+  PathStatusInserter/'p3'
+  TestFindProduct/'processBlockTest1'
+  TestContextAnalyzer/'test'
+  PathStatusInserter/'testEventSetupPath'
+  ConsumingIntProducer/'testManyConsumingProducer'
+    consumes products from these modules:
+      TriggerResultInserter/'TriggerResults'
   RunLumiESAnalyzer/'testReadLumiESSource'
     consumes products during Event from these EventSetup modules:
       RunLumiESSource/'runLumiESSource' ESSource
@@ -109,39 +135,13 @@ All modules and modules in the current process whose products they consume:
   RunLumiESAnalyzer/'testReadLumiESSource3'
     consumes products during Event from these EventSetup modules:
       RunLumiESSource/'runLumiESSource' ESSource
-  ConcurrentIOVAnalyzer/'concurrentIOVAnalyzer'
-    consumes products during Event from these EventSetup modules:
-      ConcurrentIOVESSource/'concurrentIOVESSource' ESSource
-      ConcurrentIOVESProducer/'concurrentIOVESProducer' ESProducer
-  WhatsItAnalyzer/'WhatsItAnalyzer'
-    consumes products during Event from these EventSetup modules:
-      WhatsItESProducer/'' ESProducer
-  ConsumeIOVTestInfoAnalyzer/'consumeIOVTestInfoAnalyzer'
-    consumes products during Event from these EventSetup modules:
-      MayConsumeWhatsIt/'mayConsumeWhatsIt' ESProducer
-  ConsumeIOVTestInfoAnalyzer/'consumeIOVTestInfoAnalyzer2'
-    consumes products during Event from these EventSetup modules:
-      MayConsumeWhatsIt/'mayConsumeWhatsIt' ESProducer
-  ConsumingIntProducer/'testManyConsumingProducer'
+  ConsumingStreamAnalyzer/'testStreamingAnalyzer'
     consumes products from these modules:
-      TriggerResultInserter/'TriggerResults'
-  PoolOutputModule/'out'
-    consumes products from these modules:
-      TriggerResultInserter/'TriggerResults'
-      IntProducer/'intProducerA'
-      IntProducer/'intProducer'
-      IntProducer/'intProducerU'
-      ConsumingIntProducer/'testManyConsumingProducer'
       IntProducer/'testStreamingProducer'
+  IntProducer/'testStreamingProducer'
+  TestFindProduct/'testView1'
+    consumes products from these modules:
       IntVectorProducer/'intVectorProducer'
-  TriggerResultInserter/'TriggerResults'
-  PathStatusInserter/'p'
-  PathStatusInserter/'p2'
-  PathStatusInserter/'p3'
-  PathStatusInserter/'p11'
-  PathStatusInserter/'testEventSetupPath'
-  EndPathStatusInserter/'e'
-  EndPathStatusInserter/'p1ep2'
 All EventSetup modules:
   RunLumiESSource/'runLumiESSource'
   ConcurrentIOVESProducer/'concurrentIOVESProducer'
@@ -173,10 +173,14 @@ and the module type and module label of the EventSetup module producing the prod
 Next is the produceMethodID (counts setWhatProduced calls in ESProducers, otherwise 0).
 If the requested module label was specified, then there is a remark in parentheses
 stating whether it matched the actual module label of the producer.
-  IntProducer/'intProducerA'
-  IntProducer/'intProducerU'
-  IntVectorProducer/'intVectorProducer'
-  IntProducer/'intProducer'
+  TriggerResultInserter/'TriggerResults'
+  WhatsItAnalyzer/'WhatsItAnalyzer'
+    consumes from EventSetup:
+      GadgetRcd edmtest::WhatsIt '' Event ESProducer WhatsItESProducer/'WhatsItESProducer' 0
+      GadgetRcd edmtest::WhatsIt 'A' Event ESProducer WhatsItESProducer/'WhatsItESProducer' 1
+      GadgetRcd edmtest::WhatsIt 'B' Event ESProducer WhatsItESProducer/'WhatsItESProducer' 2
+      GadgetRcd edmtest::WhatsIt 'C' Event ESProducer WhatsItESProducer/'WhatsItESProducer' 3
+      GadgetRcd edmtest::WhatsIt 'D' Event ESProducer WhatsItESProducer/'WhatsItESProducer' 4
   TestFindProduct/'a1'
     consumes:
       edmtest::IntProduct 'source' '' ''
@@ -192,26 +196,59 @@ stating whether it matched the actual module label of the producer.
   TestFindProduct/'a4'
     consumes:
       edmtest::IntProduct 'intProducerA' '' 'PROD1'
-  TestContextAnalyzer/'test'
-  TestFindProduct/'testView1'
-    consumes:
-      int 'intVectorProducer' '' 'PROD1', element type
-  IntProducer/'testStreamingProducer'
-  ConsumingStreamAnalyzer/'testStreamingAnalyzer'
-    consumes:
-      edmtest::IntProduct 'testStreamingProducer' '' '', may consume
+  ConcurrentIOVAnalyzer/'concurrentIOVAnalyzer'
+    consumes from EventSetup:
+      ESTestRecordI edmtest::IOVTestInfo '' Event ESSource ConcurrentIOVESSource/'concurrentIOVESSource' 0
+      ESTestRecordI edmtest::IOVTestInfo 'fromESProducer' Event ESProducer ConcurrentIOVESProducer/'concurrentIOVESProducer' 0
+  ConsumeIOVTestInfoAnalyzer/'consumeIOVTestInfoAnalyzer'
+    consumes from EventSetup:
+      GadgetRcd edmtest::IOVTestInfo 'DependsOnMayConsume' Event ESProducer MayConsumeWhatsIt/'mayConsumeWhatsIt' 0
+  ConsumeIOVTestInfoAnalyzer/'consumeIOVTestInfoAnalyzer2'
+    consumes from EventSetup:
+      GadgetRcd edmtest::IOVTestInfo 'DependsOnMayConsume2' Event ESProducer MayConsumeWhatsIt/'mayConsumeWhatsIt' 1
+  EndPathStatusInserter/'e'
+  IntProducer/'intProducer'
+  IntProducer/'intProducerA'
+  IntProducer/'intProducerB'
   IntProducerBeginProcessBlock/'intProducerBeginProcessBlock'
+  IntProducer/'intProducerC'
+  IntProducer/'intProducerD'
+  IntProducer/'intProducerE'
   IntProducerEndProcessBlock/'intProducerEndProcessBlock'
+  IntProducer/'intProducerU'
+  IntVectorProducer/'intVectorProducer'
+  PoolOutputModule/'out'
+    consumes:
+      edm::TriggerResults 'TriggerResults' '' 'PROD1'
+      edmtest::IntProduct 'aliasForInt' '' 'PROD1'
+      edmtest::IntProduct 'intProducer' '' 'PROD1'
+      edmtest::IntProduct 'intProducerBeginProcessBlock' '' 'PROD1', processBlock
+      edmtest::IntProduct 'intProducerEndProcessBlock' '' 'PROD1', processBlock
+      edmtest::IntProduct 'intProducerEndProcessBlock' 'four' 'PROD1', processBlock
+      edmtest::IntProduct 'intProducerEndProcessBlock' 'three' 'PROD1', processBlock
+      edmtest::IntProduct 'intProducerEndProcessBlock' 'two' 'PROD1', processBlock
+      edmtest::IntProduct 'intProducerU' '' 'PROD1'
+      edmtest::IntProduct 'source' '' 'PROD1'
+      edmtest::IntProduct 'testManyConsumingProducer' '' 'PROD1'
+      edmtest::IntProduct 'testStreamingProducer' '' 'PROD1'
+      std::vector<int> 'intVectorProducer' '' 'PROD1'
+  PathStatusInserter/'p'
+  PathStatusInserter/'p11'
+  EndPathStatusInserter/'p1ep2'
+  PathStatusInserter/'p2'
+  PathStatusInserter/'p3'
   TestFindProduct/'processBlockTest1'
     consumes:
       edmtest::IntProduct 'intProducerBeginProcessBlock' '' '', processBlock
       edmtest::IntProduct 'intProducerBeginProcessBlock' '' 'PROD1', processBlock
       edmtest::IntProduct 'intProducerEndProcessBlock' '' '', processBlock
       edmtest::IntProduct 'intProducerEndProcessBlock' '' 'PROD1', processBlock
-  IntProducer/'intProducerB'
-  IntProducer/'intProducerC'
-  IntProducer/'intProducerD'
-  IntProducer/'intProducerE'
+  TestContextAnalyzer/'test'
+  PathStatusInserter/'testEventSetupPath'
+  ConsumingIntProducer/'testManyConsumingProducer'
+    consumes:
+      edm::TriggerResults 'TriggerResults' '' ''
+      edm::TriggerResults 'TriggerResults' '' 'PROD1'
   RunLumiESAnalyzer/'testReadLumiESSource'
     consumes from EventSetup:
       ESTestRecordC edmtest::IOVTestInfo '' Event ESSource RunLumiESSource/'runLumiESSource' 0
@@ -246,50 +283,13 @@ stating whether it matched the actual module label of the producer.
       ESTestRecordC edmtest::IOVTestInfo '' BeginLuminosityBlock, EventSetup module label mismatch, requested 'moduleLabelThatDoesNotMatch'
       ESTestRecordC edmtest::IOVTestInfo '' EndLuminosityBlock, EventSetup module label mismatch, requested 'moduleLabelThatDoesNotMatch'
       ESTestRecordC edmtest::IOVTestInfo '' EndRun, EventSetup module label mismatch, requested 'moduleLabelThatDoesNotMatch'
-  ConcurrentIOVAnalyzer/'concurrentIOVAnalyzer'
-    consumes from EventSetup:
-      ESTestRecordI edmtest::IOVTestInfo '' Event ESSource ConcurrentIOVESSource/'concurrentIOVESSource' 0
-      ESTestRecordI edmtest::IOVTestInfo 'fromESProducer' Event ESProducer ConcurrentIOVESProducer/'concurrentIOVESProducer' 0
-  WhatsItAnalyzer/'WhatsItAnalyzer'
-    consumes from EventSetup:
-      GadgetRcd edmtest::WhatsIt '' Event ESProducer WhatsItESProducer/'WhatsItESProducer' 0
-      GadgetRcd edmtest::WhatsIt 'A' Event ESProducer WhatsItESProducer/'WhatsItESProducer' 1
-      GadgetRcd edmtest::WhatsIt 'B' Event ESProducer WhatsItESProducer/'WhatsItESProducer' 2
-      GadgetRcd edmtest::WhatsIt 'C' Event ESProducer WhatsItESProducer/'WhatsItESProducer' 3
-      GadgetRcd edmtest::WhatsIt 'D' Event ESProducer WhatsItESProducer/'WhatsItESProducer' 4
-  ConsumeIOVTestInfoAnalyzer/'consumeIOVTestInfoAnalyzer'
-    consumes from EventSetup:
-      GadgetRcd edmtest::IOVTestInfo 'DependsOnMayConsume' Event ESProducer MayConsumeWhatsIt/'mayConsumeWhatsIt' 0
-  ConsumeIOVTestInfoAnalyzer/'consumeIOVTestInfoAnalyzer2'
-    consumes from EventSetup:
-      GadgetRcd edmtest::IOVTestInfo 'DependsOnMayConsume2' Event ESProducer MayConsumeWhatsIt/'mayConsumeWhatsIt' 1
-  ConsumingIntProducer/'testManyConsumingProducer'
+  ConsumingStreamAnalyzer/'testStreamingAnalyzer'
     consumes:
-      edm::TriggerResults 'TriggerResults' '' ''
-      edm::TriggerResults 'TriggerResults' '' 'PROD1'
-  PoolOutputModule/'out'
+      edmtest::IntProduct 'testStreamingProducer' '' '', may consume
+  IntProducer/'testStreamingProducer'
+  TestFindProduct/'testView1'
     consumes:
-      edm::TriggerResults 'TriggerResults' '' 'PROD1'
-      edmtest::IntProduct 'aliasForInt' '' 'PROD1'
-      edmtest::IntProduct 'intProducer' '' 'PROD1'
-      edmtest::IntProduct 'intProducerBeginProcessBlock' '' 'PROD1', processBlock
-      edmtest::IntProduct 'intProducerEndProcessBlock' '' 'PROD1', processBlock
-      edmtest::IntProduct 'intProducerEndProcessBlock' 'four' 'PROD1', processBlock
-      edmtest::IntProduct 'intProducerEndProcessBlock' 'three' 'PROD1', processBlock
-      edmtest::IntProduct 'intProducerEndProcessBlock' 'two' 'PROD1', processBlock
-      edmtest::IntProduct 'intProducerU' '' 'PROD1'
-      edmtest::IntProduct 'source' '' 'PROD1'
-      edmtest::IntProduct 'testManyConsumingProducer' '' 'PROD1'
-      edmtest::IntProduct 'testStreamingProducer' '' 'PROD1'
-      std::vector<int> 'intVectorProducer' '' 'PROD1'
-  TriggerResultInserter/'TriggerResults'
-  PathStatusInserter/'p'
-  PathStatusInserter/'p2'
-  PathStatusInserter/'p3'
-  PathStatusInserter/'p11'
-  PathStatusInserter/'testEventSetupPath'
-  EndPathStatusInserter/'e'
-  EndPathStatusInserter/'p1ep2'
+      int 'intVectorProducer' '' 'PROD1', element type
 All EventSetup modules (listed by class and label) and all their consumed products.
 These modules can only consume EventSetup products. These are listed by record type,
 data type, product label, whether the module is ESSource, ESProducer, or ESProducerLooper,

--- a/Mixing/Base/src/SecondaryEventProvider.h
+++ b/Mixing/Base/src/SecondaryEventProvider.h
@@ -11,6 +11,7 @@
 
 namespace edm {
   class ModuleCallingContext;
+  class ExceptionCollector;
 
   class SecondaryEventProvider {
   public:


### PR DESCRIPTION
#### PR description:

Moved construction to modules to a separate step from building the various Workers used to handle running the actual schedule. Workers are now just used to homogenize calls to modules on transition changes. All initialization of modules is handled via the ModuleHolder class.

#### PR validation:

All framework unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/1433