### PR TITLE
Fix for missing GTT test vector files

### DIFF
--- a/L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc
+++ b/L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc
@@ -245,6 +245,8 @@ void GTTFileWriter::endJob() {
   // Writing pending events to file before exiting
   fileWriterInputTracks_.flush();
   fileWriterConvertedTracks_.flush();
+  fileWriterSelectedTracks_.flush();
+  fileWriterVertexAssociatedTracks_.flush();
   fileWriterOutputToCorrelator_.flush();
   fileWriterOutputToGlobalTrigger_.flush();
 }


### PR DESCRIPTION
#### PR description:

This tiny PR ensures all `BoardDataWriter` objects are flushed at the end of a job in the `GTTFileWriter`. This fixes an issue where the files corresponding to the un-flushed `BoardDataWriter` objects were missing in the output.

#### PR validation:

With this fix, the previously missing files are indeed now in the output.