### PR TITLE
Add non-corrected timing plots in ECAL DQM

### DIFF
--- a/DQM/EcalMonitorTasks/interface/TimingTask.h
+++ b/DQM/EcalMonitorTasks/interface/TimingTask.h
@@ -36,6 +36,7 @@ namespace ecaldqm {
     bool splashSwitch_;
 
     MESet* meTimeMapByLS;
+    MESet* meTimeMapByLS_nonCorr;
   };
 
   inline bool TimingTask::analyze(void const* _p, Collections _collection) {

--- a/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
@@ -62,6 +62,18 @@ ecalTimingTask = cms.untracked.PSet(
             btype = cms.untracked.string('Crystal'),
             description = cms.untracked.string('2D distribution of the mean rec hit timing. Only hits with GOOD or OUT_OF_TIME reconstruction flags and energy above threshold are used. Hits with |t| > ' + str(timeWindow) + ' ns are discarded. The energy thresholds are ' + ('%f and %f' % (energyThresholdEB, energyThresholdEE)) + ' for EB and EE respectively.')
         ),
+        TimeMap_nonCorr = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/nonCorrectedTime/%(prefix)sTMT timing %(sm)s'),
+            kind = cms.untracked.string('TProfile2D'),
+            zaxis = cms.untracked.PSet(
+                high = cms.untracked.double(timeWindow),
+                low = cms.untracked.double(-timeWindow),
+                title = cms.untracked.string('time (ns)')
+            ),
+            otype = cms.untracked.string('SM'),
+            btype = cms.untracked.string('Crystal'),
+            description = cms.untracked.string('2D distribution of the mean rec hit non-corrected timing. Only hits with GOOD or OUT_OF_TIME reconstruction flags and energy above threshold are used. Hits with |t| > ' + str(timeWindow) + ' ns are discarded. The energy thresholds are ' + ('%f and %f' % (energyThresholdEB, energyThresholdEE)) + ' for EB and EE respectively.')
+        ),
         TimeMapByLS = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/%(prefix)sTMT timing by LS %(sm)s'),
             kind = cms.untracked.string('TProfile2D'),
@@ -73,6 +85,18 @@ ecalTimingTask = cms.untracked.PSet(
             otype = cms.untracked.string('SM'),
             btype = cms.untracked.string('Crystal'),
             description = cms.untracked.string('2D distribution of the mean rec hit timing. Only hits with GOOD or OUT_OF_TIME reconstruction flags and energy above threshold are used. Hits with |t| > ' + str(timeWindow) + ' ns are discarded. The energy thresholds are ' + ('%f and %f' % (energyThresholdEB, energyThresholdEE)) + ' for EB and EE respectively.')
+        ),
+        TimeMapByLS_nonCorr = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/nonCorrectedTime/%(prefix)sTMT timing by LS %(sm)s'),
+            kind = cms.untracked.string('TProfile2D'),
+            zaxis = cms.untracked.PSet(
+                high = cms.untracked.double(timeWindow),
+                low = cms.untracked.double(-timeWindow),
+                title = cms.untracked.string('time (ns)')
+            ),
+            otype = cms.untracked.string('SM'),
+            btype = cms.untracked.string('Crystal'),
+            description = cms.untracked.string('2D distribution of the mean rec hit non-corrected timing. Only hits with GOOD or OUT_OF_TIME reconstruction flags and energy above threshold are used. Hits with |t| > ' + str(timeWindow) + ' ns are discarded. The energy thresholds are ' + ('%f and %f' % (energyThresholdEB, energyThresholdEE)) + ' for EB and EE respectively.')
         ),
         TimeAll = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/%(prefix)sTMT timing 1D summary%(suffix)s'),
@@ -87,6 +111,19 @@ ecalTimingTask = cms.untracked.PSet(
             btype = cms.untracked.string('User'),
             description = cms.untracked.string('Distribution of the mean rec hit timing. Only hits with GOOD or OUT_OF_TIME reconstruction flags and energy above threshold are used. The energy thresholds are ' + ('%f and %f' % (energyThresholdEB, energyThresholdEE)) + ' for EB and EE respectively.')
         ),
+        TimeAll_nonCorr = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/nonCorrectedTime/%(prefix)sTMT timing 1D summary%(suffix)s'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal3P'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(timeWindow),
+                nbins = cms.untracked.int32(100),
+                low = cms.untracked.double(-timeWindow),
+                title = cms.untracked.string('time (ns)')
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Distribution of the mean rec hit non-corrected timing. Only hits with GOOD or OUT_OF_TIME reconstruction flags and energy above threshold are used. The energy thresholds are ' + ('%f and %f' % (energyThresholdEB, energyThresholdEE)) + ' for EB and EE respectively.')
+        ),
         TimeAllMap = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/%(prefix)sTMT timing map%(suffix)s'),
             kind = cms.untracked.string('TProfile2D'),
@@ -98,6 +135,18 @@ ecalTimingTask = cms.untracked.PSet(
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('SuperCrystal'),
             description = cms.untracked.string('2D distribution of the mean rec hit timing. Only hits with GOOD or OUT_OF_TIME reconstruction flags and energy above threshold are used. Hits with |t| > ' + str(summaryTimeWindow) + ' ns are discarded. The energy thresholds are ' + ('%f and %f' % (energyThresholdEB, energyThresholdEE)) + ' for EB and EE respectively.')
+        ),
+        TimeAllMap_nonCorr = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/nonCorrectedTime/%(prefix)sTMT timing map%(suffix)s'),
+            kind = cms.untracked.string('TProfile2D'),
+            zaxis = cms.untracked.PSet(
+                high = cms.untracked.double(summaryTimeWindow),
+                low = cms.untracked.double(-summaryTimeWindow),
+                title = cms.untracked.string('time (ns)')
+            ),
+            otype = cms.untracked.string('Ecal3P'),
+            btype = cms.untracked.string('SuperCrystal'),
+            description = cms.untracked.string('2D distribution of the mean rec hit non-corrected timing. Only hits with GOOD or OUT_OF_TIME reconstruction flags and energy above threshold are used. Hits with |t| > ' + str(summaryTimeWindow) + ' ns are discarded. The energy thresholds are ' + ('%f and %f' % (energyThresholdEB, energyThresholdEE)) + ' for EB and EE respectively.')
         ),
         TimeAmpAll = cms.untracked.PSet(
             kind = cms.untracked.string('TH2F'),
@@ -116,6 +165,23 @@ ecalTimingTask = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/%(prefix)sTMT timing vs amplitude summary%(suffix)s'),
             description = cms.untracked.string('Correlation between hit timing and energy. Only hits with GOOD or OUT_OF_TIME reconstruction flags are used.')
         ),
+        TimeAmpAll_nonCorr = cms.untracked.PSet(
+            kind = cms.untracked.string('TH2F'),
+            yaxis = cms.untracked.PSet(
+                high = cms.untracked.double(50.0),
+                nbins = cms.untracked.int32(200),
+                low = cms.untracked.double(-50.0),
+                title = cms.untracked.string('time (ns)')
+            ),
+            otype = cms.untracked.string('Ecal3P'),
+            xaxis = cms.untracked.PSet(
+                edges = cms.untracked.vdouble(EaxisEdges),
+                title = cms.untracked.string('energy (GeV)')
+            ),
+            btype = cms.untracked.string('User'),
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/nonCorrectedTime/%(prefix)sTMT timing vs amplitude summary%(suffix)s'),
+            description = cms.untracked.string('Correlation between non-corrected hit timing and energy. Only hits with GOOD or OUT_OF_TIME reconstruction flags are used.')
+        ),
         TimeAmp = cms.untracked.PSet(
             kind = cms.untracked.string('TH2F'),
             yaxis = cms.untracked.PSet(
@@ -132,6 +198,23 @@ ecalTimingTask = cms.untracked.PSet(
             btype = cms.untracked.string('User'),
             path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/%(prefix)sTMT timing vs amplitude %(sm)s'),
             description = cms.untracked.string('Correlation between hit timing and energy. Only hits with GOOD or OUT_OF_TIME reconstruction flags are used.')
+        ),
+        TimeAmp_nonCorr = cms.untracked.PSet(
+            kind = cms.untracked.string('TH2F'),
+            yaxis = cms.untracked.PSet(
+                high = cms.untracked.double(50.0),
+                nbins = cms.untracked.int32(200),
+                low = cms.untracked.double(-50.0),
+                title = cms.untracked.string('time (ns)')
+            ),
+            otype = cms.untracked.string('SM'),
+            xaxis = cms.untracked.PSet(
+                edges = cms.untracked.vdouble(EaxisEdges),
+                title = cms.untracked.string('energy (GeV)')
+            ),
+            btype = cms.untracked.string('User'),
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/nonCorrectedTime/%(prefix)sTMT timing vs amplitude %(sm)s'),
+            description = cms.untracked.string('Correlation between non-corrected hit timing and energy. Only hits with GOOD or OUT_OF_TIME reconstruction flags are used.')
         ),
         BarrelTimingVsBX = cms.untracked.PSet(
             path = cms.untracked.string('EcalBarrel/EBTimingTask/EBTMT Timing vs BX'),
@@ -150,7 +233,24 @@ ecalTimingTask = cms.untracked.PSet(
             btype = cms.untracked.string('User'),
             description = cms.untracked.string('Average hit timing in EB as a function of BX number. BX ids start at 1. Only events with energy above 2.02 GeV and chi2 less than 16 are used.')
         ),
-        BarrelTimingVsBXFineBinned = cms.untracked.PSet(
+        BarrelTimingVsBX_nonCorr = cms.untracked.PSet(
+            path = cms.untracked.string('EcalBarrel/EBTimingTask/nonCorrectedTime/EBTMT Timing vs BX'),
+            kind = cms.untracked.string('TProfile'),
+            otype = cms.untracked.string('EB'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(1.0*nBXBins),
+                nbins = cms.untracked.int32(nBXBins),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('BX Id'),
+                labels = cms.untracked.vstring(bxBinLabels)
+            ),
+            yaxis = cms.untracked.PSet(
+                title = cms.untracked.string('Timing (ns)')
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Average hit non-corrected timing in EB as a function of BX number. BX ids start at 1. Only events with energy above 2.02 GeV and chi2 less than 16 are used.')
+        ),
+         BarrelTimingVsBXFineBinned = cms.untracked.PSet(
             path = cms.untracked.string('EcalBarrel/EBTimingTask/EBTMT Timing vs Finely Binned BX'),
             kind = cms.untracked.string('TProfile'),
             otype = cms.untracked.string('EB'),
@@ -166,6 +266,23 @@ ecalTimingTask = cms.untracked.PSet(
             ),
             btype = cms.untracked.string('User'),
             description = cms.untracked.string('Average hit timing in EB as a finely binned function of BX number. BX ids start at 1. Only events with energy above 2.02 GeV and chi2 less than 16 are used. The Customize button can be used to zoom in.')
+        ),
+         BarrelTimingVsBXFineBinned_nonCorr = cms.untracked.PSet(
+            path = cms.untracked.string('EcalBarrel/EBTimingTask/nonCorrectedTime/EBTMT Timing vs Finely Binned BX'),
+            kind = cms.untracked.string('TProfile'),
+            otype = cms.untracked.string('EB'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(1.0*nBXBinsFine),
+                nbins = cms.untracked.int32(nBXBinsFine),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('BX Id'),
+                labels = cms.untracked.vstring(bxBinLabelsFine)
+            ),
+            yaxis = cms.untracked.PSet(
+                title = cms.untracked.string('Timing (ns)')
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Average hit non-corrected timing in EB as a finely binned function of BX number. BX ids start at 1. Only events with energy above 2.02 GeV and chi2 less than 16 are used. The Customize button can be used to zoom in.')
         ),
         TimeAmpBXm = cms.untracked.PSet(
             kind = cms.untracked.string('TH2F'),
@@ -217,6 +334,19 @@ ecalTimingTask = cms.untracked.PSet(
             ),
             btype = cms.untracked.string('User'),
             description = cms.untracked.string('Distribution of the mean rec hit timing. Only hits with GOOD or OUT_OF_TIME reconstruction flags and energy above threshold are used. The energy thresholds are ' + ('%f and %f' % (energyThresholdEB, energyThresholdEE)) + ' for EB and EE respectively.')
+        ),
+        Time1D_nonCorr = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/nonCorrectedTime/%(prefix)sTMT timing 1D %(sm)s'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('SM'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(timeWindow),
+                nbins = cms.untracked.int32(100),
+                low = cms.untracked.double(-timeWindow),
+                title = cms.untracked.string('time (ns)')
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Distribution of the mean rec hit non-corrected timing. Only hits with GOOD or OUT_OF_TIME reconstruction flags and energy above threshold are used. The energy thresholds are ' + ('%f and %f' % (energyThresholdEB, energyThresholdEE)) + ' for EB and EE respectively.')
         ),
         Chi2 = cms.untracked.PSet(
             path = cms.untracked.string("%(subdet)s/%(prefix)sTimingTask/%(prefix)sTMT %(subdetshortsig)s Chi2"),

--- a/DQM/EcalMonitorTasks/src/TimingTask.cc
+++ b/DQM/EcalMonitorTasks/src/TimingTask.cc
@@ -76,10 +76,12 @@ namespace ecaldqm {
     // timing with cross-correlation (cc) algo
     MESet& meTimeAmp_nonCorr(MEs_.at("TimeAmp_nonCorr"));
     MESet& meTimeAmpAll_nonCorr(MEs_.at("TimeAmpAll_nonCorr"));
-    MESet& meTimingVsBX_nonCorr(onlineMode_ ? MEs_.at("BarrelTimingVsBX_nonCorr") : MEs_.at("BarrelTimingVsBXFineBinned_nonCorr"));
+    MESet& meTimingVsBX_nonCorr(onlineMode_ ? MEs_.at("BarrelTimingVsBX_nonCorr")
+                                            : MEs_.at("BarrelTimingVsBXFineBinned_nonCorr"));
     MESet& meTimeAll_nonCorr(MEs_.at("TimeAll_nonCorr"));
     MESet& meTimeAllMap_nonCorr(MEs_.at("TimeAllMap_nonCorr"));
-    MESet& meTimeMap_nonCorr(MEs_.at("TimeMap_nonCorr"));  // contains cumulative run stats => not suitable for Trend plots
+    MESet& meTimeMap_nonCorr(
+        MEs_.at("TimeMap_nonCorr"));  // contains cumulative run stats => not suitable for Trend plots
     MESet& meTime1D_nonCorr(MEs_.at("Time1D_nonCorr"));
 
     uint32_t goodOROOTBits(0x1 << EcalRecHit::kGood | 0x1 << EcalRecHit::kOutOfTime);


### PR DESCRIPTION
#### PR description:

This PR adds a set of new plots for ECAL DQM workspace (non-corrected timing plots).  

#### PR validation:

PR is validated by running the ECAL online DQM configuration and verifying the plots on a test DQM GUI.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is the master PR. Backports to `150X` are made in #48523. 