### PR TITLE
[15_0_X] [L1T] L1 Scouting multi-BX Online Selection based on BMTF stubs

### DIFF
--- a/L1TriggerScouting/OnlineProcessing/plugins/BMTFStubMultiBxSelector.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/BMTFStubMultiBxSelector.cc
@@ -1,0 +1,152 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/Span.h"
+
+// L1 scouting
+#include "DataFormats/L1Scouting/interface/L1ScoutingBMTFStub.h"
+#include "DataFormats/L1Scouting/interface/OrbitCollection.h"
+#include "L1TriggerScouting/Utilities/interface/conversion.h"
+
+#include <iostream>
+#include <memory>
+#include <utility>
+#include <vector>
+#include <string>
+#include <numeric>
+#include <set>
+
+using namespace l1ScoutingRun3;
+
+class BMTFStubMultiBxSelector : public edm::stream::EDProducer<> {
+public:
+  explicit BMTFStubMultiBxSelector(const edm::ParameterSet&);
+  ~BMTFStubMultiBxSelector() override {}
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  bool windowHasCloseWheels(const std::vector<std::set<int>>& sets, int threshold = 1);
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  // tokens for scouting data
+  edm::EDGetTokenT<OrbitCollection<l1ScoutingRun3::BMTFStub>> stubsTokenData_;
+
+  // Condition
+  std::string condition_;
+
+  // Selection thresholds
+  unsigned bxWindowLength_;
+  unsigned minNBMTFStub_;
+};
+
+BMTFStubMultiBxSelector::BMTFStubMultiBxSelector(const edm::ParameterSet& iPSet)
+    : stubsTokenData_(consumes(iPSet.getParameter<edm::InputTag>("stubsTag"))),
+      condition_(iPSet.getParameter<std::string>("condition")),
+      bxWindowLength_(iPSet.getParameter<unsigned>("bxWindowLength")),
+      minNBMTFStub_(iPSet.getParameter<unsigned>("minNBMTFStub"))
+{
+  std::vector<std::string> vConditions = {"simple", "wheel"};
+  if (std::find(vConditions.begin(), vConditions.end(), condition_) == vConditions.end())
+    throw cms::Exception("BMTFStubMultiBxSelector::BMTFStubMultiBxSelector")
+      << "Condition '" << condition_ << "' not supported or not found";
+
+  produces<std::vector<unsigned>>("SelBx").setBranchAlias("MultiBxStubsSelectedBx");
+}
+
+// ------------ method called for each ORBIT  ------------
+void BMTFStubMultiBxSelector::produce(edm::Event& iEvent, const edm::EventSetup&) {
+  edm::Handle<OrbitCollection<l1ScoutingRun3::BMTFStub>> stubsCollection;
+
+  iEvent.getByToken(stubsTokenData_, stubsCollection);
+
+  // This is necessary to have a clean MultiBxStubsSelectedBx collection
+  // Indeed, if there is overlap betweem two valid windows, there will be duplicated BXs
+  std::unique_ptr<std::set<unsigned>> uniqueStubSelectedBxs(new std::set<unsigned>);
+
+  // Loop over valid bunch crossings
+  for (const unsigned& bx : stubsCollection->getFilledBxs()) {
+    if (bx < bxWindowLength_) continue;
+
+    // Get number of stubs in every BX of the window and place in vector
+    unsigned numStubsWindow = 0;
+    std::vector<int> vNumStubBx(bxWindowLength_, 0);
+    for (unsigned i = 0; i < bxWindowLength_; ++i)
+      vNumStubBx[i] = stubsCollection->getBxSize(bx-i);
+
+    // Sum elements of nStub vector
+    numStubsWindow = std::reduce(vNumStubBx.begin(), vNumStubBx.end());
+
+    // Not enough stubs in window, whatever the condition.
+    if (numStubsWindow < minNBMTFStub_)
+      continue;
+
+    // Simple condition: just number of stubs (already checked)
+    if (condition_=="simple") {
+      for (unsigned i = 0; i < bxWindowLength_; ++i)
+        uniqueStubSelectedBxs->insert(bx-i);
+    }
+    // Wheel condition: enough longitudinally "neighbouring" stubs
+    else if (condition_=="wheel") {
+      bool validWindow = false;
+
+      // Find unique values for wheels in all BXs of window
+      std::vector<std::set<int>> vWheelBx(bxWindowLength_);
+
+      // Fill vector of sets of wheels (one element/set per BX in window)
+      for (unsigned i = 0; i < bxWindowLength_; ++i)
+        for (const auto& s : stubsCollection->bxIterator(bx-i)) vWheelBx[i].insert(s.wheel());
+
+      // Check if there are stubs in different BXs with neighbouring wheels
+      // For example (with window of 3 BXs, neighbouring condition abs(wheel_pair) <= 1)
+      // BX-2         BX-1        BX0
+      // s0(wh = 2)   s0(wh=0)    s1(wh=-2)
+      // s1(wh = 1)
+      //
+      // => valid window! (neighbouring stubs s1 in BX-2 and s0 in BX-1)
+      validWindow = windowHasCloseWheels(vWheelBx, 1);
+
+      // If window is valid, add BXs of window to
+      if (validWindow) {
+        for (unsigned i = 0; i < bxWindowLength_; ++i)
+          uniqueStubSelectedBxs->insert(bx-i);
+      }
+    }
+  }  // end orbit loop
+
+  // Convert set of selected BXs to a vector and put collection in event content
+  std::unique_ptr<std::vector<unsigned>> stubSelectedBx = std::make_unique<std::vector<unsigned>>(uniqueStubSelectedBxs->begin(), uniqueStubSelectedBxs->end());
+  iEvent.put(std::move(stubSelectedBx), "SelBx");
+}
+
+bool BMTFStubMultiBxSelector::windowHasCloseWheels(const std::vector<std::set<int>>& sets, int threshold) {
+  for (size_t i = 0; i < sets.size(); ++i) {
+    for (size_t j = i + 1; j < sets.size(); ++j) {
+      for (int iWh : sets[i]) {
+        for (int jWh : sets[j]) {
+          if (std::abs(iWh - jWh) <= threshold) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+
+void BMTFStubMultiBxSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+DEFINE_FWK_MODULE(BMTFStubMultiBxSelector);

--- a/L1TriggerScouting/OnlineProcessing/plugins/BMTFStubMultiBxSelector.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/BMTFStubMultiBxSelector.cc
@@ -32,8 +32,8 @@ public:
   ~BMTFStubMultiBxSelector() override {}
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
-  unsigned makeWheelPattern(const edm::Handle<OrbitCollection<l1ScoutingRun3::BMTFStub>>& stubs, unsigned bx);
-  bool windowHasCloseWheels(const std::vector<unsigned>& bxs);
+  unsigned int makeWheelPattern(const edm::Handle<OrbitCollection<l1ScoutingRun3::BMTFStub>>& stubs, unsigned int bx);
+  bool windowHasCloseWheels(const std::vector<unsigned int>& bxs);
 
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
@@ -45,14 +45,14 @@ private:
   l1ScoutingRun3::BMTFSelectorConditionType condition_;
 
   // Selection thresholds
-  unsigned bxWindowLength_;
-  unsigned minNBMTFStub_;
+  unsigned int bxWindowLength_;
+  unsigned int minNBMTFStub_;
 };
 
 BMTFStubMultiBxSelector::BMTFStubMultiBxSelector(const edm::ParameterSet& iPSet)
     : stubsTokenData_(consumes(iPSet.getParameter<edm::InputTag>("stubsTag"))),
-      bxWindowLength_(iPSet.getParameter<unsigned>("bxWindowLength")),
-      minNBMTFStub_(iPSet.getParameter<unsigned>("minNBMTFStub")) {
+      bxWindowLength_(iPSet.getParameter<unsigned int>("bxWindowLength")),
+      minNBMTFStub_(iPSet.getParameter<unsigned int>("minNBMTFStub")) {
   std::string conditionStr = iPSet.getParameter<std::string>("condition");
   if (conditionStr == "simple")
     condition_ = l1ScoutingRun3::Simple;
@@ -62,7 +62,7 @@ BMTFStubMultiBxSelector::BMTFStubMultiBxSelector(const edm::ParameterSet& iPSet)
     throw cms::Exception("BMTFStubMultiBxSelector::BMTFStubMultiBxSelector")
         << "Condition '" << conditionStr << "' not supported or not found";
 
-  produces<std::vector<unsigned>>("SelBx").setBranchAlias("MultiBxStubsSelectedBx");
+  produces<std::vector<unsigned int>>("SelBx").setBranchAlias("MultiBxStubsSelectedBx");
 }
 
 // ------------ method called for each ORBIT  ------------
@@ -73,31 +73,31 @@ void BMTFStubMultiBxSelector::produce(edm::Event& iEvent, const edm::EventSetup&
 
   // This is necessary to have a clean 'MultiBxStubsSelectedBx' collection
   // Indeed, if there is overlap betweem two valid windows, there will be duplicated BXs
-  std::unique_ptr<std::set<unsigned>> uniqueStubSelectedBxs(new std::set<unsigned>);
+  std::unique_ptr<std::set<unsigned int>> uniqueStubSelectedBxs = std::make_unique<std::set<unsigned int>>();
 
   // Loop over valid bunch crossings
-  std::vector<unsigned> vNumStubBx(bxWindowLength_, 0);
-  std::vector<unsigned> vWheelPatternBx(bxWindowLength_, 0);
-  for (const unsigned& bx : stubsCollection->getFilledBxs()) {
+  std::vector<unsigned int> vNumStubBx(bxWindowLength_, 0);
+  std::vector<unsigned int> vWheelPatternBx(bxWindowLength_, 0);
+  for (const unsigned int& bx : stubsCollection->getFilledBxs()) {
     // Get number of stubs in current window of size 'ws': [BX-ws+1, BX]
-    for (unsigned i = 0; i < std::min(bxWindowLength_, bx); ++i)
+    for (unsigned int i = 0; i < std::min(bxWindowLength_, bx); ++i)
       vNumStubBx[i] = stubsCollection->getBxSize(bx - i);
 
     // Get number of stubs in current BX (last of the window) and enque
-    unsigned numStubsWindow = std::reduce(vNumStubBx.begin(), vNumStubBx.end());
+    unsigned int numStubsWindow = std::reduce(vNumStubBx.begin(), vNumStubBx.end());
 
     // Simple condition: just number of stubs (already checked)
     if (condition_ == l1ScoutingRun3::Simple) {
       // If there are enough stubs in window...
       if (numStubsWindow >= minNBMTFStub_) {
         // ...loop over window to add BXs (std::min to include edge case of first BXs)
-        for (unsigned i = 0; i < std::min(bxWindowLength_, bx); ++i)
+        for (unsigned int i = 0; i < std::min(bxWindowLength_, bx); ++i)
           uniqueStubSelectedBxs->insert(bx - i);
       }
     }
     // Wheel condition: enough longitudinally "neighbouring" stubs
     else if (condition_ == l1ScoutingRun3::Wheel) {
-      for (unsigned i = 0; i < std::min(bxWindowLength_, bx); ++i) {
+      for (unsigned int i = 0; i < std::min(bxWindowLength_, bx); ++i) {
         // Prepare pattern and add to window vector
         vWheelPatternBx[i] = makeWheelPattern(stubsCollection, bx - i);
       }
@@ -114,31 +114,31 @@ void BMTFStubMultiBxSelector::produce(edm::Event& iEvent, const edm::EventSetup&
       // If window is valid....
       if (validWindow) {
         // ...loop over window to add BXs (std::min to include edge case of first BXs)
-        for (unsigned i = 0; i < std::min(bxWindowLength_, bx); ++i)
+        for (unsigned int i = 0; i < std::min(bxWindowLength_, bx); ++i)
           uniqueStubSelectedBxs->insert(bx - i);
       }
     }
   }  // end orbit loop
 
   // Convert set of selected BXs to a vector and put collection in event content
-  std::unique_ptr<std::vector<unsigned>> stubSelectedBx =
-      std::make_unique<std::vector<unsigned>>(uniqueStubSelectedBxs->begin(), uniqueStubSelectedBxs->end());
+  std::unique_ptr<std::vector<unsigned int>> stubSelectedBx =
+      std::make_unique<std::vector<unsigned int>>(uniqueStubSelectedBxs->begin(), uniqueStubSelectedBxs->end());
   iEvent.put(std::move(stubSelectedBx), "SelBx");
 }
 
-unsigned BMTFStubMultiBxSelector::makeWheelPattern(const edm::Handle<OrbitCollection<l1ScoutingRun3::BMTFStub>>& stubs,
-                                                   unsigned bx) {
+unsigned int BMTFStubMultiBxSelector::makeWheelPattern(
+    const edm::Handle<OrbitCollection<l1ScoutingRun3::BMTFStub>>& stubs, unsigned int bx) {
   // 5 wheel numbers + 2 to handle boundaries in a more comfortable way:
   // 0b         0   X   X   X   X   X   0
   // wheels   bnd  +2  +1   0  -1  -2 bnd
   // position   6   5   4   3   2   1   0
-  unsigned wheelPatternBx = 0;
+  unsigned int wheelPatternBx = 0;
   for (const auto& s : stubs->bxIterator(bx))
     wheelPatternBx |= (1 << (s.wheel() + 3));
   return wheelPatternBx;
 }
 
-bool BMTFStubMultiBxSelector::windowHasCloseWheels(const std::vector<unsigned>& bxs) {
+bool BMTFStubMultiBxSelector::windowHasCloseWheels(const std::vector<unsigned int>& bxs) {
   for (size_t i = 0; i < std::size(bxs); ++i) {
     for (size_t j = i + 1; j < std::size(bxs); ++j) {
       // Assume for example that we have the following patterns
@@ -149,7 +149,7 @@ bool BMTFStubMultiBxSelector::windowHasCloseWheels(const std::vector<unsigned>& 
       // BX-2 : 0b0010000
       // BX-1 : 0b0011100
       //            bsb   (s = stub wheel, b = boundary wheels)
-      unsigned compare = bxs[i] & ((bxs[j] << 1) | bxs[j] | (bxs[j] >> 1));
+      unsigned int compare = bxs[i] & ((bxs[j] << 1) | bxs[j] | (bxs[j] >> 1));
       bool checkWindow = compare & 0b0111110;
       if (checkWindow)
         return true;
@@ -160,8 +160,12 @@ bool BMTFStubMultiBxSelector::windowHasCloseWheels(const std::vector<unsigned>& 
 
 void BMTFStubMultiBxSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
-  descriptions.addDefault(desc);
+  desc.add<edm::InputTag>("stubsTag")->setComment("input BMTF stubs orbit collection");
+  desc.add<unsigned int>("bxWindowLength")->setComment("number of consecutive bunch crossings of window to analyse");
+  desc.add<unsigned int>("minNBMTFStub")
+      ->setComment("minimum number of stubs that should be in bunch crossings window");
+  desc.add<std::string>("condition")->setComment("condition to apply for bunch crossing window selection");
+  descriptions.add("BMTFStubMultiBxSelector", desc);
 }
 
 DEFINE_FWK_MODULE(BMTFStubMultiBxSelector);

--- a/L1TriggerScouting/OnlineProcessing/plugins/BMTFStubMultiBxSelector.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/BMTFStubMultiBxSelector.cc
@@ -10,7 +10,6 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/StreamID.h"
-#include "FWCore/Utilities/interface/Span.h"
 
 // L1 scouting
 #include "DataFormats/L1Scouting/interface/L1ScoutingBMTFStub.h"
@@ -129,8 +128,8 @@ void BMTFStubMultiBxSelector::produce(edm::Event& iEvent, const edm::EventSetup&
 }
 
 bool BMTFStubMultiBxSelector::windowHasCloseWheels(const std::vector<std::set<int>>& sets, int threshold) {
-  for (size_t i = 0; i < sets.size(); ++i) {
-    for (size_t j = i + 1; j < sets.size(); ++j) {
+  for (size_t i = 0; i < std::size(sets); ++i) {
+    for (size_t j = i + 1; j < std::size(sets); ++j) {
       for (int iWh : sets[i]) {
         for (int jWh : sets[j]) {
           if (std::abs(iWh - jWh) <= threshold) {

--- a/L1TriggerScouting/OnlineProcessing/test/L1ScoutingSelector.py
+++ b/L1TriggerScouting/OnlineProcessing/test/L1ScoutingSelector.py
@@ -109,13 +109,29 @@ process.MuTagJetEt30Dr0p4 = cms.EDProducer("MuTagJetBxSelector",
     maxDR            = cms.vdouble(0.4),
 )
 
+process.Stubs3BxWindowSimpleCond = cms.EDProducer("BMTFStubMultiBxSelector",
+    stubsTag         = cms.InputTag("l1ScBMTFUnpacker", "BMTFStub"),
+    condition        = cms.string("simple"),
+    bxWindowLength   = cms.uint32(3),
+    minNBMTFStub     = cms.uint32(2)
+)
+
+process.Stubs3BxWindowWheelCond = cms.EDProducer("BMTFStubMultiBxSelector",
+    stubsTag         = cms.InputTag("l1ScBMTFUnpacker", "BMTFStub"),
+    condition        = cms.string("wheel"),
+    bxWindowLength   = cms.uint32(3),
+    minNBMTFStub     = cms.uint32(2)
+)
+
 process.FinalBxSelector = cms.EDFilter("FinalBxSelector",
     analysisLabels   = cms.VInputTag(
         cms.InputTag("DijetEt30", "SelBx"),
         cms.InputTag("SingleMuPt0BMTF", "SelBx"),
         cms.InputTag("DoubleMuPt0Qual8", "SelBx"),
         cms.InputTag("HMJetMult4Et20", "SelBx"),
-        cms.InputTag("MuTagJetEt30Dr0p4", "SelBx")
+        cms.InputTag("MuTagJetEt30Dr0p4", "SelBx"),
+        cms.InputTag("Stubs3BxWindowSimpleCond", "SelBx"),
+        cms.InputTag("Stubs3BxWindowWheelCond", "SelBx")
     ),
 )
 
@@ -125,6 +141,8 @@ process.bxSelectors = cms.Sequence(
     process.SingleMuPt0BMTF +
     process.DoubleMuPt0Qual8 +
     process.MuTagJetEt30Dr0p4
+    process.Stubs3BxWindowSimpleCond +
+    process.Stubs3BxWindowWheelCond
 )
 
 # Final collection producers
@@ -158,12 +176,19 @@ process.FinalBxSelectorBxSums = cms.EDProducer("MaskOrbitBxScoutingBxSums",
     productLabel = cms.string("EtSum")
 )
 
+process.FinalBxSelectorBMTFStub = cms.EDProducer("MaskOrbitBxScoutingBMTFStub",
+    dataTag = cms.InputTag("l1ScBMTFUnpacker", "BMTFStub"),
+    selectBxs = cms.InputTag("FinalBxSelector", "SelBx"),
+    productLabel = cms.string("BMTFStub")
+)
+
 process.MaskedCollections = cms.Sequence(
     process.FinalBxSelectorMuon +
     process.FinalBxSelectorJet +
     process.FinalBxSelectorEGamma +
     process.FinalBxSelectorTau +
-    process.FinalBxSelectorBxSums
+    process.FinalBxSelectorBxSums +
+    process.FinalBxSelectorBMTFStub
 )
 
 process.pL1ScoutingSelected = cms.Path(process.bxSelectors + process.FinalBxSelector+process.MaskedCollections)
@@ -180,6 +205,8 @@ process.hltOutputL1ScoutingSelection = cms.OutputModule("PoolOutputModule",
         'keep *_SingleMuPt0BMTF_*_*',
         'keep *_DoubleMuPt0Qual8_*_*',
         'keep *_MuTagJetEt30Dr0p4_*_*',
+        'keep *_Stubs3BxWindowSimpleCond_*_*',
+        'keep *_Stubs3BxWindowWheelCond_*_*',
         'keep *_FinalBxSelector*_*_*',
     )
 )

--- a/L1TriggerScouting/OnlineProcessing/test/L1ScoutingSelector.py
+++ b/L1TriggerScouting/OnlineProcessing/test/L1ScoutingSelector.py
@@ -186,7 +186,7 @@ process.MaskedCollections = cms.Sequence(
     process.FinalBxSelectorMuon +
     process.FinalBxSelectorJet +
     process.FinalBxSelectorEGamma +
-    # process.FinalBxSelectorTau +
+    process.FinalBxSelectorTau +
     process.FinalBxSelectorBxSums +
     process.FinalBxSelectorBMTFStub
 )

--- a/L1TriggerScouting/OnlineProcessing/test/L1ScoutingSelector.py
+++ b/L1TriggerScouting/OnlineProcessing/test/L1ScoutingSelector.py
@@ -140,7 +140,7 @@ process.bxSelectors = cms.Sequence(
     process.HMJetMult4Et20 +
     process.SingleMuPt0BMTF +
     process.DoubleMuPt0Qual8 +
-    process.MuTagJetEt30Dr0p4
+    process.MuTagJetEt30Dr0p4 +
     process.Stubs3BxWindowSimpleCond +
     process.Stubs3BxWindowWheelCond
 )
@@ -186,7 +186,7 @@ process.MaskedCollections = cms.Sequence(
     process.FinalBxSelectorMuon +
     process.FinalBxSelectorJet +
     process.FinalBxSelectorEGamma +
-    process.FinalBxSelectorTau +
+    # process.FinalBxSelectorTau +
     process.FinalBxSelectorBxSums +
     process.FinalBxSelectorBMTFStub
 )


### PR DESCRIPTION
#### PR description:

This PR introduces an additional online selector module for L1 Scouting to target Heavy Stable Charged Particles signatures leaving BMTF stubs in multiple consecutive bunch crossings ([e.g. link](https://indico.cern.ch/event/1517653/contributions/6386999/attachments/3032202/5353484/SlowScouting_EXOL3_Mar25.pdf)). The special thing of this module with respect to the others, existing in L1TriggerScouting/OnlineProcessing, is that its processing logic targets a BX window rather than single BXs. The original work has been done by @EltonSh and cleaned for this PR.

#### PR validation:

The PR has been validate using files collected in the "Zero Bias" stream, e.g.

```
cmsRun L1TriggerScouting/OnlineProcessing/test/L1ScoutingSelector.py inFile=root://cms-xrd-global.cern.ch//store/data/Run2024G/L1Scouting/L1SCOUT/v1/000/383/996/00001/4c1c76a1-bf29-4bfb-ae13-1e51a064fd69.root outFile=file:selection_4c1c76a1-bf29-4bfb-ae13-1e51a064fd69.root numOrbits=100
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/48289
This PR will be needed in order to have this new L1 Scouting selection stream available in a data taking release for the rest of 2025 pp collisions
