### PR TITLE
Phase2-hgx364U Add a few more utility methoods in RecHitTools which depend on the chosen detector geometry scenario

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -24,7 +24,8 @@ namespace hgcal {
   public:
     struct siliconWaferInfo {
       int32_t type, partialType, orientation, placementIndex, cassette;
-      siliconWaferInfo(int32_t t = 0, int32_t p = 0, int32_t o = 0, int32_t i = 0, int32_t c = 0) : type(t), partialType(p), orientation(o), placementIndex(i), cassette(c) {}
+      siliconWaferInfo(int32_t t = 0, int32_t p = 0, int32_t o = 0, int32_t i = 0, int32_t c = 0)
+          : type(t), partialType(p), orientation(o), placementIndex(i), cassette(c) {}
     };
     struct scintillatorTileInfo {
       int32_t type, sipm, cassette;
@@ -86,7 +87,7 @@ namespace hgcal {
     float getPhi(const DetId& id) const;
     float getPt(const DetId& id, const float& hitEnergy, const float& vertex_z = 0.) const;
     int getScintMaxIphi(const DetId& id) const;
- 
+
     inline const CaloGeometry* getGeometry() const { return geom_; };
     unsigned int lastLayerEE(bool nose = false) const { return (nose ? HFNoseDetId::HFNoseLayerEEmax : fhOffset_); }
     unsigned int lastLayerFH() const { return fhLastLayer_; }
@@ -106,6 +107,7 @@ namespace hgcal {
     // Informaion of the wafer/tile
     siliconWaferInfo getWaferInfo(const DetId& id) const;
     scintillatorTileInfo getTileInfo(const DetId& id) const;
+
   private:
     const CaloGeometry* geom_;
     unsigned int eeOffset_, fhOffset_, bhFirstLayer_, bhLastLayer_, bhOffset_, fhLastLayer_, noseLastLayer_;

--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -22,6 +22,14 @@ namespace edm {
 namespace hgcal {
   class RecHitTools {
   public:
+    struct siliconWaferInfo {
+      int32_t type, partialType, orientation, placementIndex, cassette;
+      siliconWaferInfo(int32_t t = 0, int32_t p = 0, int32_t o = 0, int32_t i = 0, int32_t c = 0) : type(t), partialType(p), orientation(o), placementIndex(i), cassette(c) {}
+    };
+    struct scintillatorTileInfo {
+      int32_t type, sipm, cassette;
+      scintillatorTileInfo(int32_t t = 0, int32_t s = 0, int32_t c = 0) : type(t), sipm(s), cassette(c) {}
+    };
     RecHitTools()
         : geom_(nullptr),
           eeOffset_(0),
@@ -63,6 +71,7 @@ namespace hgcal {
 
     bool isSilicon(const DetId&) const;
     bool isScintillator(const DetId&) const;
+    bool isScintillatorFine(const DetId& id) const;
     bool isBarrel(const DetId&) const;
 
     bool isOnlySilicon(const unsigned int layer) const;
@@ -76,7 +85,8 @@ namespace hgcal {
     float getEta(const DetId& id, const float& vertex_z = 0.) const;
     float getPhi(const DetId& id) const;
     float getPt(const DetId& id, const float& hitEnergy, const float& vertex_z = 0.) const;
-
+    int getScintMaxIphi(const DetId& id) const;
+ 
     inline const CaloGeometry* getGeometry() const { return geom_; };
     unsigned int lastLayerEE(bool nose = false) const { return (nose ? HFNoseDetId::HFNoseLayerEEmax : fhOffset_); }
     unsigned int lastLayerFH() const { return fhLastLayer_; }
@@ -93,6 +103,9 @@ namespace hgcal {
     inline int getGeometryType() const { return geometryType_; }
     bool maskCell(const DetId& id, int corners = 3) const;
 
+    // Informaion of the wafer/tile
+    siliconWaferInfo getWaferInfo(const DetId& id) const;
+    scintillatorTileInfo getTileInfo(const DetId& id) const;
   private:
     const CaloGeometry* geom_;
     unsigned int eeOffset_, fhOffset_, bhFirstLayer_, bhLastLayer_, bhOffset_, fhLastLayer_, noseLastLayer_;

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -40,6 +40,13 @@ namespace {
     return ddd;
   }
 
+  inline const HGCalDDDConstants* get_ddd(const CaloSubdetectorGeometry* geom, const HGCScintillatorDetId& detid) {
+    const HGCalGeometry* hg = static_cast<const HGCalGeometry*>(geom);
+    const HGCalDDDConstants* ddd = &(hg->topology().dddConstants());
+    check_ddd(ddd);
+    return ddd;
+  }
+
   inline const HGCalDDDConstants* get_ddd(const CaloSubdetectorGeometry* geom, const HGCSiliconDetId& detid) {
     const HGCalGeometry* hg = static_cast<const HGCalGeometry*>(geom);
     const HGCalDDDConstants* ddd = &(hg->topology().dddConstants());
@@ -496,6 +503,14 @@ bool RecHitTools::isSilicon(const DetId& id) const {
 
 bool RecHitTools::isScintillator(const DetId& id) const { return (id.det() == DetId::HGCalHSc); }
 
+bool RecHitTools::isScintillatorFine(const DetId& id) const {
+  if (id.det() == DetId::HGCalHSc) {
+    auto hg = static_cast<const HGCalGeometry*>(getSubdetectorGeometry(id));
+    return hg->topology().dddConstants().scintFine(HGCScintillatorDetId(id).layer());
+  } else {
+    return false;
+  }
+}
 bool RecHitTools::isBarrel(const DetId& id) const { return (id.det() == DetId::Ecal || id.det() == DetId::Hcal); }
 bool RecHitTools::isOnlySilicon(const unsigned int layer) const {
   // HFnose TODO
@@ -538,6 +553,15 @@ float RecHitTools::getPt(const DetId& id, const float& hitEnergy, const float& v
   return pt;
 }
 
+int RecHitTools::getScintMaxIphi(const DetId& id) const {
+  if (id.det() == DetId::HGCalHSc) {
+    auto hg = static_cast<const HGCalGeometry*>(getSubdetectorGeometry(id));
+    return hg->topology().dddConstants().maxCells(HGCScintillatorDetId(id).layer(), true);
+  } else {
+    return 0;
+  }
+}
+
 std::pair<uint32_t, uint32_t> RecHitTools::firstAndLastLayer(DetId::Detector det, int subdet) const {
   if ((det == DetId::HGCalEE) || ((det == DetId::Forward) && (subdet == HGCEE))) {
     return std::make_pair(eeOffset_ + 1, fhOffset_);
@@ -557,4 +581,34 @@ bool RecHitTools::maskCell(const DetId& id, int corners) const {
     auto hg = static_cast<const HGCalGeometry*>(getSubdetectorGeometry(id));
     return hg->topology().dddConstants().maskCell(id, corners);
   }
+}
+
+RecHitTools::siliconWaferInfo RecHitTools::getWaferInfo(const DetId& id) const {
+  RecHitTools::siliconWaferInfo info;
+  if ((id.det() == DetId::HGCalEE) || (id.det() == DetId::HGCalHSi)) {
+    auto geom = getSubdetectorGeometry(id);
+    HGCSiliconDetId hid(id);
+    auto ddd = get_ddd(geom, hid);
+    HGCalParameters::waferInfo info2 = ddd->waferInfo(hid.layer(), hid.waferU(), hid.waferV());
+    info.type = info2.type;
+    info.partialType = info2.part;
+    info.orientation = info2.orient;
+    info.cassette = info2.cassette;
+    info.placementIndex = ddd->placementIndex(hid);
+  }
+  return info;
+}
+
+RecHitTools::scintillatorTileInfo RecHitTools::getTileInfo(const DetId& id) const {
+  RecHitTools::scintillatorTileInfo info;
+  if (isScintillator(id)) {
+    auto geom = getSubdetectorGeometry(id);
+    HGCScintillatorDetId hid(id);
+    auto ddd = get_ddd(geom, hid);
+    HGCalParameters::tileInfo info2 = ddd->tileInfo(hid.zside(), hid.layer(), hid.ring());
+    info.type = info2.type;
+    info.sipm = info2.sipm;
+    info.cassette = info2.cassette;
+  }
+  return info;
 }


### PR DESCRIPTION
#### PR description:

Add a few more utility methoods in RecHitTools which depend on the chosen detector geometry scenario:
 isScinitllatorFine: If the layer has fine or coarse tiles
 getScintMaxIphi: the largest tile iphi index in the layer 
 getWaferInfo: returns various information of the wafer, its type, partial type, orientation, placement index, cassette index
getTileInfo: returns various tile information: its type, SipM size, cassette index

#### PR validation:

Tested in the HGCalConsData tests

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special