### PR TITLE
[15.0.X] Update `ScoutingMuonTriggerAnalyzer` trigger selections

### DIFF
--- a/HLTriggerOffline/Scouting/python/ScoutingMuonTriggerAnalyzer_cfi.py
+++ b/HLTriggerOffline/Scouting/python/ScoutingMuonTriggerAnalyzer_cfi.py
@@ -30,12 +30,12 @@ SingleMuL1 = ["L1_SingleMu11_SQ14_BMTF","L1_SingleMu10_SQ14_BMTF"]
 ScoutingMuonTriggerAnalysis_DoubleMu = DQMEDAnalyzer('ScoutingMuonTriggerAnalyzer',
     OutputInternalPath = cms.string('/HLT/ScoutingOffline/Muons/L1Efficiency/DoubleMu'), #Output of the root file
     ScoutingMuonCollection = cms.InputTag('hltScoutingMuonPackerVtx'),
-    triggerSelection = cms.vstring(["DST_PFScouting_ZeroBias_v*", "DST_PFScouting_DoubleEG_v*", "DST_PFScouting_JetHT_v*"]), #Denominator
+    triggerSelection = cms.vstring(["DST_PFScouting_ZeroBias*", "DST_PFScouting_DoubleEG_v*", "DST_PFScouting_JetHT_v*"]), #Denominator
     triggerConfiguration = cms.PSet(
         hltResults            = cms.InputTag('TriggerResults','','HLT'),
         l1tResults            = cms.InputTag('','',''),
         l1tIgnoreMaskAndPrescale = cms.bool(False),
-        throw                 = cms.bool(True),
+        throw                 = cms.bool(False),
         usePathStatus = cms.bool(False),
     ),
     AlgInputTag = cms.InputTag("gtStage2Digis"),


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/48529

#### PR description:

**TL;DR**:

Title says it all:
- do not throw if a trigger expression is not in the list;
- use any `DST_PFScouting_ZeroBias*` for VdM scans

**Executive summary**:

During the VdM scan fill [10821](https://cmsoms.cern.ch/cms/fills/report?cms_fill=10821) on Jul 10th, 2025, we identified an issue with the DQM for scouting. Specifically, one of the modules in the sequence filters based on a set of trigger expressions that are normally present in the pp menu but are missing from the `LumiScan` menu. This caused the DQM client to crash during run 394413 (see [log](https://cmsweb.cern.ch/dqm/dqm-square/api/get_logs?id=dqm-source-state-run394413-hostdqmfu-c2b03-45-01-pid3452657&db=production) for details).

The online DQM team applied a patch to the DQM online client, so the online side is now functioning correctly. However, the same sequence is also used in the Prompt reconstruction for `ScoutingPFMonitor`, so we expect that all runs acquired with the `LumiScan` menu will also crash.

*PS*:
Preparing a patch release for Tier0 in time for the impending prompt of fill [10821](https://cmsoms.cern.ch/cms/fills/report?cms_fill=10821) seems impractical. As a temporary workaround, we suggested the ORM @mpresill asking Tier-0 to remove the `@hltScouting` DQM sequence from the 

`"dqm_seq": "@common,@hltScouting"`

 of the `ScoutingPFMonitor` Prompt Reconstruction configuration.

#### PR validation:

Executed the `scouting_dqm_sourceclient-live_cfg.py` using data from run 394413 (kindly collected by @nothingface0) using:

```
cmsRun scouting_dqm_sourceclient-live_cfg.py runInputDir=/eos/user/d/dpapagia/data runNumber=394413 scanOnce=True
```

without issues.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/48529 for 2025 data-taking operations.