### PR TITLE
[Phase-2 L1T] fixing Phase2L1CaloPFClusterEmulator for ASAN_X IB

### DIFF
--- a/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h
+++ b/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h
@@ -288,16 +288,21 @@ namespace gctpf {
     GCTint_t regionMax = getPeakPosition(region);
 
     float pfcluster_et = getEt(temporary, regionMax.eta, regionMax.phi);
+    float pfcluster_eta = regionMax.eta - 2 + etaoffset;
+    float pfcluster_phi = regionMax.phi - 2 + phioffset;
 
     RemoveTmp(temporary, regionMax.eta, regionMax.phi);
 
     if (!(regionMax.eta >= 2 && regionMax.eta < (nTowerEtaSLR - 2) && regionMax.phi >= 2 &&
-          regionMax.phi < (nTowerPhiSLR - 2)))
-      pfcluster_et = 0;
+          regionMax.phi < (nTowerPhiSLR - 2))) {
+      pfcluster_et = 0;   // set energy to be zero if maximum energy tower is not within the unique region
+      pfcluster_eta = 2;  // choose the default to be at one corner of the unique region
+      pfcluster_phi = 2;  // choose the default to be at one corner of the unique region
+    }
 
     pfclusterReturn.et = pfcluster_et;
-    pfclusterReturn.eta = regionMax.eta - 2 + etaoffset;
-    pfclusterReturn.phi = regionMax.phi - 2 + phioffset;
+    pfclusterReturn.eta = pfcluster_eta;
+    pfclusterReturn.phi = pfcluster_phi;
 
     return pfclusterReturn;
   }

--- a/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloPFClusterEmulator.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloPFClusterEmulator.cc
@@ -229,10 +229,20 @@ void Phase2L1CaloPFClusterEmulator::produce(edm::Event& iEvent, const edm::Event
       hfTowers[2 * ieta + 1][iphi] = et / 8;
       hfTowers[2 * ieta][iphi + 1] = et / 8;
       hfTowers[2 * ieta + 1][iphi + 1] = et / 8;
-      hfTowers[2 * ieta][iphi + 2] = et / 8;
-      hfTowers[2 * ieta + 1][iphi + 2] = et / 8;
-      hfTowers[2 * ieta][iphi + 3] = et / 8;
-      hfTowers[2 * ieta + 1][iphi + 3] = et / 8;
+      if (iphi + 2 < nHfPhi) {
+        hfTowers[2 * ieta][iphi + 2] = et / 8;
+        hfTowers[2 * ieta + 1][iphi + 2] = et / 8;
+      } else {
+        hfTowers[2 * ieta][iphi + 2 - nHfPhi] = et / 8;
+        hfTowers[2 * ieta + 1][iphi + 2 - nHfPhi] = et / 8;
+      }
+      if (iphi + 3 < nHfPhi) {
+        hfTowers[2 * ieta][iphi + 3] = et / 8;
+        hfTowers[2 * ieta + 1][iphi + 3] = et / 8;
+      } else {
+        hfTowers[2 * ieta][iphi + 3 - nHfPhi] = et / 8;
+        hfTowers[2 * ieta + 1][iphi + 3 - nHfPhi] = et / 8;
+      }
     } else if ((ieta >= 2 && ieta < nHfEta - 2) && iphi % 2 == 0) {
       hfTowers[2 * ieta][iphi] = et / 4;
       hfTowers[2 * ieta + 1][iphi] = et / 4;


### PR DESCRIPTION
#### PR description:

Fixing error described in https://github.com/cms-sw/cmssw/issues/48368

#### PR validation:
Ran local checks using the following instructions:
```
cmssw-el8
scram project CMSSW_15_1_ASAN_X_2025-07-08-1100
cd CMSSW_15_1_ASAN_X_2025-07-08-1100/src
cmsenv
runTheMatrix.py -i all -t 4 -l 29661.0 --ibeos
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport
