### PR TITLE
minor improvements and bug-fixes to `LHCInfo` PayloadInspector

### DIFF
--- a/CondCore/RunInfoPlugins/plugins/LHCInfoPerFill_PayloadInspector.cc
+++ b/CondCore/RunInfoPlugins/plugins/LHCInfoPerFill_PayloadInspector.cc
@@ -3,6 +3,7 @@
 #include "CondFormats/RunInfo/interface/LHCInfoPerFill.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "utils.h"  // local
 #include <sstream>
 #include <memory>
 #include "TLatex.h"
@@ -10,10 +11,12 @@
 
 namespace {
 
-  class LHCInfoPerFill_Display : public cond::payloadInspector::PlotImage<LHCInfoPerFill> {
+  class LHCInfoPerFill_Display
+      : public cond::payloadInspector::PlotImage<LHCInfoPerFill, cond::payloadInspector::SINGLE_IOV> {
   public:
     LHCInfoPerFill_Display()
-        : cond::payloadInspector::PlotImage<LHCInfoPerFill>("LHCInfoPerFill Inspector - Display") {}
+        : cond::payloadInspector::PlotImage<LHCInfoPerFill, cond::payloadInspector::SINGLE_IOV>(
+              "LHCInfoPerFill Inspector - Display") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -64,9 +67,16 @@ namespace {
       t1.DrawLatex(0.1, 0.18, "LHCInfo parameters:");
       t1.DrawLatex(0.1, 0.15, "payload:");
 
+      auto runLS = lhcInfo::unpack(std::get<0>(iov));
+
       t1.SetTextFont(42);
       t1.SetTextColor(4);
-      t1.DrawLatex(0.37, 0.182, Form("IOV %s", std::to_string(+std::get<0>(iov)).c_str()));
+      t1.DrawLatex(0.37,
+                   0.182,
+                   Form("IOV %s (#color[2]{%s , %s})",
+                        std::to_string(+std::get<0>(iov)).c_str(),
+                        std::to_string(runLS.first).c_str(),
+                        std::to_string(runLS.second).c_str()));
       t1.DrawLatex(0.21, 0.152, Form(" %s", (std::get<1>(iov)).c_str()));
 
       std::string fileName(m_imageFileName);

--- a/CondCore/RunInfoPlugins/plugins/LHCInfoPerLS_PayloadInspector.cc
+++ b/CondCore/RunInfoPlugins/plugins/LHCInfoPerLS_PayloadInspector.cc
@@ -3,6 +3,7 @@
 #include "CondFormats/RunInfo/interface/LHCInfoPerLS.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "utils.h"  // local
 #include <sstream>
 #include <memory>
 #include "TLatex.h"
@@ -10,9 +11,12 @@
 
 namespace {
 
-  class LHCInfoPerLS_Display : public cond::payloadInspector::PlotImage<LHCInfoPerLS> {
+  class LHCInfoPerLS_Display
+      : public cond::payloadInspector::PlotImage<LHCInfoPerLS, cond::payloadInspector::SINGLE_IOV> {
   public:
-    LHCInfoPerLS_Display() : cond::payloadInspector::PlotImage<LHCInfoPerLS>("LHCInfoPerLS Inspector - Display") {}
+    LHCInfoPerLS_Display()
+        : cond::payloadInspector::PlotImage<LHCInfoPerLS, cond::payloadInspector::SINGLE_IOV>(
+              "LHCInfoPerLS Inspector - Display") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -64,9 +68,16 @@ namespace {
       t1.DrawLatex(0.1, 0.18, "LHCInfo parameters:");
       t1.DrawLatex(0.1, 0.15, "payload:");
 
+      auto runLS = lhcInfo::unpack(std::get<0>(iov));
+
       t1.SetTextFont(42);
       t1.SetTextColor(4);
-      t1.DrawLatex(0.37, 0.182, Form("IOV %s", std::to_string(+std::get<0>(iov)).c_str()));
+      t1.DrawLatex(0.37,
+                   0.182,
+                   Form("IOV %s (#color[2]{%s , %s})",
+                        std::to_string(+std::get<0>(iov)).c_str(),
+                        std::to_string(runLS.first).c_str(),
+                        std::to_string(runLS.second).c_str()));
       t1.DrawLatex(0.21, 0.152, Form(" %s", (std::get<1>(iov)).c_str()));
 
       std::string fileName(m_imageFileName);

--- a/CondCore/RunInfoPlugins/plugins/utils.h
+++ b/CondCore/RunInfoPlugins/plugins/utils.h
@@ -1,0 +1,15 @@
+#ifndef CondCore_RunInfoPlugins_utils_H
+#define CondCore_RunInfoPlugins_utils_H
+
+#include "CondCore/CondDB/interface/Time.h"
+
+namespace lhcInfo {
+  inline std::pair<unsigned int, unsigned int> unpack(cond::Time_t since) {
+    auto kLowMask = 0XFFFFFFFF;
+    auto run = (since >> 32);
+    auto lumi = (since & kLowMask);
+    return std::make_pair(run, lumi);
+  }
+}  // namespace lhcInfo
+
+#endif


### PR DESCRIPTION
#### PR description:

Title says it all, this is a follow-up PR to https://github.com/cms-sw/cmssw/pull/48451.
I noticed in the condDB browser that the plots introduced in that PR despite targeting single IoV-s required the selection of a range of IoVs to display. This is corrected by adding the `cond::payloadInspector::SINGLE_IOV` template specification.
I profit of the PR to add a slightly improved display of the IoV since (including the run number and LS of the `cond::Time_t since`).

#### PR validation:

The unit tests of this package run correctly.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, not meant to be backported.
