### PR TITLE
Phse2-hgx364V Provide a method to extract thicknesses of depleted layers of different types of silicon wafers

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
+++ b/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
@@ -67,6 +67,7 @@ public:
   inline std::pair<double, double> cellSizeTrap(int type, int irad) const {
     return std::make_pair(hgpar_->radiusLayer_[type][irad - 1], hgpar_->radiusLayer_[type][irad]);
   }
+  std::vector<double> cellThickness() const;
   double cellThickness(int layer, int waferU, int waferV) const;
   int32_t cellType(int type, int waferU, int waferV, int iz, int fwdBack, int orient) const;
   double distFromEdgeHex(double x, double y, double z) const;

--- a/Geometry/HGCalCommonData/interface/HGCalGeomParameters.h
+++ b/Geometry/HGCalCommonData/interface/HGCalGeomParameters.h
@@ -86,6 +86,7 @@ public:
   void loadCellParsHexagon(const cms::DDVectorsMap& vmap, HGCalParameters& php);
   void loadCellParsHexagon(const HGCalParameters& php);
   void loadCellTrapezoid(HGCalParameters& php);
+  static void rescale(std::vector<double>&, const double s);
 
   struct layerParameters {
     double rmin, rmax, zpos;
@@ -153,7 +154,6 @@ private:
                                          int wafer,
                                          double xx,
                                          double yy);
-  void rescale(std::vector<double>&, const double s);
   void resetZero(std::vector<double>&);
 
   constexpr static double tan30deg_ = 0.5773502693;

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -407,6 +407,18 @@ bool HGCalDDDConstants::cellInLayer(int waferU, int waferV, int cellU, int cellV
   }
 }
 
+std::vector<double> HGCalDDDConstants::cellThickness() const {
+  std::vector<double> thick;
+  if (waferHexagon8()) {
+    thick = hgpar_->cellThickness_;
+    HGCalGeomParameters::rescale(thick, 10000.0); //cm to micron
+  } else if (waferHexagon6()) {
+    for (int k = 0; k < 3; ++k)
+      thick.emplace_back(100.0 * (k + 1));
+  }
+  return thick;
+}
+
 double HGCalDDDConstants::cellThickness(int layer, int waferU, int waferV) const {
   double thick(-1);
   int type = waferType(layer, waferU, waferV, false);

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -411,7 +411,7 @@ std::vector<double> HGCalDDDConstants::cellThickness() const {
   std::vector<double> thick;
   if (waferHexagon8()) {
     thick = hgpar_->cellThickness_;
-    HGCalGeomParameters::rescale(thick, 10000.0); //cm to micron
+    HGCalGeomParameters::rescale(thick, 10000.0);  //cm to micron
   } else if (waferHexagon6()) {
     for (int k = 0; k < 3; ++k)
       thick.emplace_back(100.0 * (k + 1));

--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -2633,6 +2633,10 @@ std::vector<double> HGCalGeomParameters::getDDDArray(const std::string& str, con
   }
 }
 
+void HGCalGeomParameters::rescale(std::vector<double>& v, const double s) {
+  std::for_each(v.begin(), v.end(), [s](double& n) { n *= s; });
+}
+
 std::pair<double, double> HGCalGeomParameters::cellPosition(
     const std::vector<HGCalGeomParameters::cellParameters>& wafers,
     std::vector<HGCalGeomParameters::cellParameters>::const_iterator& itrf,
@@ -2658,10 +2662,6 @@ std::pair<double, double> HGCalGeomParameters::cellPosition(
       dy = 0;
   }
   return std::make_pair(dx, dy);
-}
-
-void HGCalGeomParameters::rescale(std::vector<double>& v, const double s) {
-  std::for_each(v.begin(), v.end(), [s](double& n) { n *= s; });
 }
 
 void HGCalGeomParameters::resetZero(std::vector<double>& v) {

--- a/Geometry/HGCalGeometry/test/HGCalGeometryDump.cc
+++ b/Geometry/HGCalGeometry/test/HGCalGeometryDump.cc
@@ -57,7 +57,7 @@ void HGCalGeometryDump::analyze(const edm::Event& /*iEvent*/, const edm::EventSe
     for (unsigned int k = 0; k < thick.size(); ++k)
       st1 << " : " << thick[k];
     edm::LogVerbatim("HGCalGeomX") << st1.str() << std::endl;
-    
+
     const std::vector<DetId>& ids = geom->getValidDetIds();
     edm::LogVerbatim("HGCalGeomX") << ids.size() << " valid Ids for detector " << names_[k];
     int nall(0);

--- a/Geometry/HGCalGeometry/test/HGCalGeometryDump.cc
+++ b/Geometry/HGCalGeometry/test/HGCalGeometryDump.cc
@@ -10,6 +10,7 @@
 #include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
 #include <iostream>
+#include <sstream>
 
 class HGCalGeometryDump : public edm::one::EDAnalyzer<> {
 public:
@@ -49,6 +50,14 @@ void HGCalGeometryDump::analyze(const edm::Event& /*iEvent*/, const edm::EventSe
   for (unsigned int k = 0; k < names_.size(); ++k) {
     const auto& geomR = iSetup.getData(geomTokens_[k]);
     const HGCalGeometry* geom = &geomR;
+
+    std::vector<double> thick = geom->topology().dddConstants().cellThickness();
+    std::ostringstream st1;
+    st1 << "Geometry has " << thick.size() << " wafers of thickness (micron)";
+    for (unsigned int k = 0; k < thick.size(); ++k)
+      st1 << " : " << thick[k];
+    edm::LogVerbatim("HGCalGeomX") << st1.str() << std::endl;
+    
     const std::vector<DetId>& ids = geom->getValidDetIds();
     edm::LogVerbatim("HGCalGeomX") << ids.size() << " valid Ids for detector " << names_[k];
     int nall(0);

--- a/Geometry/HGCalGeometry/test/python/testHGCalCellDumpDDD_cfg.py
+++ b/Geometry/HGCalGeometry/test/python/testHGCalCellDumpDDD_cfg.py
@@ -46,7 +46,7 @@ process.load("Geometry.HGCalGeometry.hgcalGeometryDump_cfi")
 process.load('FWCore.MessageService.MessageLogger_cfi')
 
 if hasattr(process,'MessageLogger'):
-    process.MessageLogger.HGCalGeom=dict()
+    process.MessageLogger.HGCalGeomX=dict()
 
 process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet(


### PR DESCRIPTION
#### PR description:

Provide a method to extract the thicknesses of depleted layers of different types of silicon wafers

#### PR validation:

This is tested by the script testHGCalCellDumpDDD_cfg.py in the area Geometry/HGCalGeometry/test/python

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special