### PR TITLE
Disabling irradiation bias correction from 2025 onward

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
@@ -8,6 +8,10 @@ PixelCPEGenericESProducer = _generic_default.clone()
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(PixelCPEGenericESProducer, IrradiationBiasCorrection = True)
 
+# This disables the IrradiationBiasCorrection in the Pixel CPE generic reconstruction from 2025 onward
+from Configuration.Eras.Modifier_run3_SiPixel_2025_cff import run3_SiPixel_2025
+run3_SiPixel_2025.toModify(PixelCPEGenericESProducer, IrradiationBiasCorrection = False)
+
 # customize the Pixel CPE generic producer for phase2
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(PixelCPEGenericESProducer,


### PR DESCRIPTION
#### PR description:

This PR disables the irradiation bias correction in the generic pixel CPE from 2025 onward.

#### PR validation:

Validation results: https://its.cern.ch/jira/browse/CMSALCA-331

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to CMSSW_15_0_X

