### PR TITLE
Add NeNe to photon flux options for pythia.

### DIFF
--- a/Configuration/Generator/python/Pythia8PhotonFluxSettings_cfi.py
+++ b/Configuration/Generator/python/Pythia8PhotonFluxSettings_cfi.py
@@ -20,6 +20,17 @@ PhotonFlux_OO = cms.PSet(
     zB = cms.untracked.int32(8)
 )
 
+# configuration for photon flux in NeNe
+# upon consultation from PYTHIA authors, as a first guess, use same radius as OO
+PhotonFlux_NeNe = cms.PSet(
+    beamTypeA = cms.int32(1000100200),
+    beamTypeB = cms.int32(1000100200),
+    radiusA = cms.untracked.double(3.02),
+    radiusB = cms.untracked.double(3.02),
+    zA = cms.untracked.int32(10),
+    zB = cms.untracked.int32(10)
+)
+
 # configuration for photon flux in XeXe
 # radius from charged particle raa: https://arxiv.org/pdf/1809.00201.pdf
 PhotonFlux_XeXe = cms.PSet(


### PR DESCRIPTION
#### PR description:
This PR updates the existing PYTHIA 8 configuration in order to add NeNe to the optional photon flux options. Useful for the production of MC used to study the recent small systems run. 

#### PR validation:

This PR was validated by generating a soft QCD sample using this option. Details for the NeNe tests using standard CMS driver commands (as well as the OO running) can be found in [this dropbox paper.](https://paper.dropbox.com/doc/OO-MC-Sample--CpzSMQPfNjhOEvA5m1k3saJYAQ-5oQWgcDnV9PM22rQ5ZYDC) 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR will be useful for producing MC samples for the recent NeNe data-taking period and therefore will require a backport to 15_0_X. 

Tagging @mandrenguyen and @stahlleiton 
