### PR TITLE
[15_0_X] Remove EGM Scale and Smearing for Run2 reprocessing

### DIFF
--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -231,17 +231,6 @@ run2_egamma.toModify(slimmedElectronsWithUserData.userFloats,
         toModify(slimmedElectronsWithUserData.userInts,
                  VIDNestedWPBitmap = None)
 
-run2_egamma.toModify(
-    slimmedElectronsWithUserData.userFloats,
-    ecalTrkEnergyErrPostCorrNew = cms.InputTag("calibratedPatElectronsNano","ecalTrkEnergyErrPostCorr"),
-    ecalTrkEnergyPreCorrNew     = cms.InputTag("calibratedPatElectronsNano","ecalTrkEnergyPreCorr"),
-    ecalTrkEnergyPostCorrNew    = cms.InputTag("calibratedPatElectronsNano","ecalTrkEnergyPostCorr"),
-    energyScaleUpNew            = cms.InputTag("calibratedPatElectronsNano","energyScaleUp"),
-    energyScaleDownNew          = cms.InputTag("calibratedPatElectronsNano","energyScaleDown"),
-    energySigmaUpNew            = cms.InputTag("calibratedPatElectronsNano","energySigmaUp"),
-    energySigmaDownNew          = cms.InputTag("calibratedPatElectronsNano","energySigmaDown")
-)
-
 (run2_egamma_2016).toModify(
     slimmedElectronsWithUserData.userFloats,
     mvaHZZIso = "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Summer16ULIdIsoValues"
@@ -453,16 +442,7 @@ _eleVarsExtra = cms.PSet(
 )
 
 (run2_egamma).toModify(
-        # energy scale/smearing: only for Run2
         electronTable.variables,
-        pt = Var("pt*userFloat('ecalTrkEnergyPostCorrNew')/userFloat('ecalTrkEnergyPreCorrNew')", float, precision=-1, doc="p_{T}"),
-        energyErr = Var("userFloat('ecalTrkEnergyErrPostCorrNew')", float, precision=6, doc="energy error of the cluster-track combination"),
-        ptPreCorr = Var("pt", float, doc="pt of the electron before energy corrections"),
-        scEtOverPt = Var("(superCluster().energy()/(pt*userFloat('ecalTrkEnergyPostCorrNew')/userFloat('ecalTrkEnergyPreCorrNew')*cosh(superCluster().eta())))-1",float,doc="(supercluster transverse energy)/pt-1",precision=8),
-        dEscaleUp=Var("userFloat('ecalTrkEnergyPostCorrNew')-userFloat('energyScaleUpNew')", float,  doc="ecal energy scale shifted 1 sigma up(adding gain/stat/syst in quadrature)", precision=8),
-        dEscaleDown=Var("userFloat('ecalTrkEnergyPostCorrNew')-userFloat('energyScaleDownNew')", float,  doc="ecal energy scale shifted 1 sigma down (adding gain/stat/syst in quadrature)", precision=8),
-        dEsigmaUp=Var("userFloat('ecalTrkEnergyPostCorrNew')-userFloat('energySigmaUpNew')", float, doc="ecal energy smearing value shifted 1 sigma up", precision=8),
-        dEsigmaDown=Var("userFloat('ecalTrkEnergyPostCorrNew')-userFloat('energySigmaDownNew')", float,  doc="ecal energy smearing value shifted 1 sigma up", precision=8),
         # Fall17V2 IDs and isolations are only for Run2. The names of these IDs and isolations are same as in Run3. 
         mvaIso = Var("userFloat('mvaIso_Fall17V2')",float,doc="MVA Iso ID score, Fall17V2"),
         mvaIso_WP80 = Var("userInt('mvaIso_Fall17V2_WP80')",bool,doc="MVA Iso ID WP80, Fall17V2"),
@@ -529,14 +509,13 @@ electronMCTable = cms.EDProducer("CandMCMatchTableProducer",
     genparticles     = cms.InputTag("finalGenParticles"),
 )
 
-electronTask = cms.Task(bitmapVIDForEle,bitmapVIDForEleFall17V2,bitmapVIDForEleHEEP,isoForEle,isoForEleFall17V2,ptRatioRelForEle,seedGainEle,calibratedPatElectronsNano,slimmedElectronsWithUserData,finalElectrons)
+electronTask = cms.Task(bitmapVIDForEle,bitmapVIDForEleFall17V2,bitmapVIDForEleHEEP,isoForEle,isoForEleFall17V2,ptRatioRelForEle,seedGainEle,slimmedElectronsWithUserData,finalElectrons)
 electronTablesTask = cms.Task(electronPROMPTMVA, electronTable)
 electronMCTask = cms.Task(tautaggerForMatching, matchingElecPhoton, electronsMCMatchForTable, electronsMCMatchForTableAlt, electronMCTable)
 
 _electronTask_Run2 = electronTask.copy()
 _electronTask_Run2.remove(bitmapVIDForEle)
 _electronTask_Run2.remove(isoForEle)
-_electronTask_Run2.add(calibratedPatElectronsNano)
 run2_egamma.toReplaceWith(electronTask, _electronTask_Run2)
 
 # Revert back to AK4 CHS jets for Run2 inputs

--- a/PhysicsTools/NanoAOD/python/photons_cff.py
+++ b/PhysicsTools/NanoAOD/python/photons_cff.py
@@ -166,17 +166,6 @@ run2_egamma.toModify(slimmedPhotonsWithUserData.userFloats,
                 toModify(slimmedPhotonsWithUserData.userInts,
                          VIDNestedWPBitmap = None)
 
-run2_egamma.toModify(
-    slimmedPhotonsWithUserData.userFloats,
-    ecalEnergyErrPostCorrNew = cms.InputTag("calibratedPatPhotonsNano","ecalEnergyErrPostCorr"),
-    ecalEnergyPreCorrNew     = cms.InputTag("calibratedPatPhotonsNano","ecalEnergyPreCorr"),
-    ecalEnergyPostCorrNew    = cms.InputTag("calibratedPatPhotonsNano","ecalEnergyPostCorr"),
-    energyScaleUpNew            = cms.InputTag("calibratedPatPhotonsNano","energyScaleUp"),
-    energyScaleDownNew          = cms.InputTag("calibratedPatPhotonsNano","energyScaleDown"),
-    energySigmaUpNew            = cms.InputTag("calibratedPatPhotonsNano","energySigmaUp"),
-    energySigmaDownNew          = cms.InputTag("calibratedPatPhotonsNano","energySigmaDown"),
-)
-
 
 finalPhotons = cms.EDFilter("PATPhotonRefSelector",
     src = cms.InputTag("slimmedPhotonsWithUserData"),
@@ -281,9 +270,6 @@ _phoVarsExtra = cms.PSet(
 #these eras need to make the energy correction, hence the "New". Also save only Fall17V2 IDS in Run2, No Run3 Winter22V1 and quadratic iso in Run2 
 run2_egamma.toModify(
     photonTable.variables,
-    pt = Var("pt*userFloat('ecalEnergyPostCorrNew')/userFloat('ecalEnergyPreCorrNew')", float, precision=-1, doc="p_{T}"),
-    energyErr = Var("userFloat('ecalEnergyErrPostCorrNew')",float,doc="energy error of the cluster from regression",precision=6),
-    ptPreCorr = Var("pt",float,doc="pt of the photon before energy corrections"),
     cutBased = Var(
             "userInt('cutBasedID_Fall17V2_loose')+userInt('cutBasedID_Fall17V2_medium')+userInt('cutBasedID_Fall17V2_tight')",
             "uint8",
@@ -325,15 +311,6 @@ photonMCTable = cms.EDProducer("CandMCMatchTableProducer",
     docString = cms.string("MC matching to status==1 photons or electrons"),
 )
 
-#adding 4 most imp scale & smearing variables to table
-run2_egamma.toModify(
-    photonTable.variables,
-    dEscaleUp=Var("userFloat('ecalEnergyPostCorrNew') - userFloat('energyScaleUpNew')", float, doc="ecal energy scale shifted 1 sigma up (adding gain/stat/syst in quadrature)", precision=8),
-    dEscaleDown=Var("userFloat('ecalEnergyPostCorrNew') - userFloat('energyScaleDownNew')", float, doc="ecal energy scale shifted 1 sigma down (adding gain/stat/syst in quadrature)", precision=8),
-    dEsigmaUp=Var("userFloat('ecalEnergyPostCorrNew') - userFloat('energySigmaUpNew')", float, doc="ecal energy smearing value shifted 1 sigma up", precision=8),
-    dEsigmaDown=Var("userFloat('ecalEnergyPostCorrNew') - userFloat('energySigmaDownNew')", float, doc="ecal energy smearing value shifted 1 sigma up", precision=8),
-)
-
 
 photonTask = cms.Task(bitmapVIDForPho, bitmapVIDForPhoRun2, isoForPho, hOverEForPho, isoForPhoFall17V2, seedGainPho, slimmedPhotonsWithUserData, finalPhotons)
 
@@ -344,5 +321,4 @@ _photonTask_Run2 = photonTask.copy()
 _photonTask_Run2.remove(bitmapVIDForPho)
 _photonTask_Run2.remove(isoForPho)
 _photonTask_Run2.remove(hOverEForPho)
-_photonTask_Run2.add(calibratedPatPhotonsNano)
 run2_egamma.toReplaceWith(photonTask, _photonTask_Run2)

--- a/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
+++ b/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
@@ -31,36 +31,36 @@ calibratedEgammaPatSettings = calibratedEgammaSettings.clone(
     recHitCollectionEE = 'reducedEgamma:reducedEERecHits'
     )
 
+# This is now the same configuration as the one used in the Egamma regression v3 in 106XUL 
 ecalTrkCombinationRegression = cms.PSet(
     ecalTrkRegressionConfig = cms.PSet(
-        rangeMinLowEt = cms.double(-1.),
-        rangeMaxLowEt = cms.double(3.0),
-        rangeMinHighEt = cms.double(-1.),
-        rangeMaxHighEt = cms.double(3.0),
-        lowEtHighEtBoundary = cms.double(50.),
+        rangeMinLowEt = cms.double(0.2),
+        rangeMaxLowEt = cms.double(2.0),
+        rangeMinHighEt = cms.double(0.2),
+        rangeMaxHighEt = cms.double(2.0),
+        lowEtHighEtBoundary = cms.double(999999.),
         forceHighEnergyTrainingIfSaturated = cms.bool(False),
-        ebLowEtForestName = cms.ESInputTag('', 'electron_eb_ECALTRK_lowpt'),
-        ebHighEtForestName = cms.ESInputTag('', 'electron_eb_ECALTRK'),
-        eeLowEtForestName = cms.ESInputTag('', 'electron_ee_ECALTRK_lowpt'),
-        eeHighEtForestName = cms.ESInputTag('', 'electron_ee_ECALTRK')
+        ebLowEtForestName = cms.ESInputTag("", 'electron_eb_ecalTrk_1To300_0p2To2_mean'),
+        ebHighEtForestName = cms.ESInputTag("", 'electron_eb_ecalTrk_1To300_0p2To2_mean'),
+        eeLowEtForestName = cms.ESInputTag("", 'electron_ee_ecalTrk_1To300_0p2To2_mean'),
+        eeHighEtForestName = cms.ESInputTag("", 'electron_ee_ecalTrk_1To300_0p2To2_mean'),
         ),
     ecalTrkRegressionUncertConfig = cms.PSet(
         rangeMinLowEt = cms.double(0.0002),
         rangeMaxLowEt = cms.double(0.5),
         rangeMinHighEt = cms.double(0.0002),
         rangeMaxHighEt = cms.double(0.5),
-        lowEtHighEtBoundary = cms.double(50.),  
+        lowEtHighEtBoundary = cms.double(999999.),  
         forceHighEnergyTrainingIfSaturated = cms.bool(False),
-        ebLowEtForestName = cms.ESInputTag('', 'electron_eb_ECALTRK_lowpt_var'),
-        ebHighEtForestName = cms.ESInputTag('', 'electron_eb_ECALTRK_var'),
-        eeLowEtForestName = cms.ESInputTag('', 'electron_ee_ECALTRK_lowpt_var'),
-        eeHighEtForestName = cms.ESInputTag('', 'electron_ee_ECALTRK_var')
+        ebLowEtForestName = cms.ESInputTag("", 'electron_eb_ecalTrk_1To300_0p0002To0p5_sigma'),
+        ebHighEtForestName = cms.ESInputTag("", 'electron_eb_ecalTrk_1To300_0p0002To0p5_sigma'),
+        eeLowEtForestName = cms.ESInputTag("", 'electron_ee_ecalTrk_1To300_0p0002To0p5_sigma'),
+        eeHighEtForestName = cms.ESInputTag("", 'electron_ee_ecalTrk_1To300_0p0002To0p5_sigma'),
         ),
     maxEcalEnergyForComb=cms.double(200.),
     minEOverPForComb=cms.double(0.025),
     maxEPDiffInSigmaForComb=cms.double(15.),
-    maxRelTrkMomErrForComb=cms.double(10.),
-    
+    maxRelTrkMomErrForComb=cms.double(10.),                
 )
 
 import RecoEgamma.EgammaTools.calibratedElectronProducer_cfi as _mod_ele


### PR DESCRIPTION
## PR description:

- Remove EGM Scale and Smearing for Run2 reprocessing. The Scale and Smearing will be apply offline on the Ecal-Tracker combined energy (instead of the Ecal energy and redo the combination for electrons) as it is done in Run3.
- Update EPcombination parameters used for combination when applying S&S on the Ecal energy. Not used anymore (see first bullet) but the wrong set of parameters was used.

## PR validation:

Tested using https://github.com/cms-sw/cmssw/pull/48176#issuecomment-2909918885

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is backport of https://github.com/cms-sw/cmssw/pull/48539 as is intended to be used for the Run2 reprocessing.
