### PR TITLE
Disable HIP/ROCm device-side error tests [15.0.x]

### DIFF
--- a/DataFormats/SoATemplate/test/SoALayoutAndView_t.hip.cc
+++ b/DataFormats/SoATemplate/test/SoALayoutAndView_t.hip.cc
@@ -306,6 +306,8 @@ int main(void) {
   }
 
   // Validation of range checking in a kernel
+  // Disable this test until ROCm provides a non-fatal way to assert in device code
+#if 0
   // Get a view like the default one, except for range checking
   RangeCheckingHostDeviceView soa1viewRangeChecking(d_soahdLayout);
 
@@ -320,6 +322,7 @@ int main(void) {
   } catch (const std::runtime_error&) {
     std::cout << "Pass: expected range-check exception caught while executing the kernel." << std::endl;
   }
+#endif
 
   std::cout << "OK" << std::endl;
 }

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testBuffer.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testBuffer.dev.cc
@@ -14,6 +14,8 @@ using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 namespace {
   constexpr size_t SIZE = 32;
 
+// Disable this test for HIP/ROCm until ROCm or alpaka provide a non-fatal way to assert in device code.
+#ifndef ALPAKA_ACC_GPU_HIP_ENABLED
   void testDeviceSideError(Device const& device) {
     auto queue = Queue(device);
     auto buf_h = cms::alpakatools::make_host_buffer<int[]>(queue, SIZE);
@@ -43,6 +45,7 @@ namespace {
       alpaka::wait(queue);
     }
   }
+#endif  // ALPAKA_ACC_GPU_HIP_ENABLED
 }  // namespace
 
 TEST_CASE("Test alpaka buffers for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend",
@@ -83,9 +86,12 @@ TEST_CASE("Test alpaka buffers for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESP
     }
   }
 
+// Disable this test for HIP/ROCm until ROCm or alpaka provide a non-fatal way to assert in device code.
+#ifndef ALPAKA_ACC_GPU_HIP_ENABLED
   SECTION("Buffer destruction after a device-side error") {
     for (auto const& device : devices) {
       REQUIRE_THROWS_AS(testDeviceSideError(device), std::runtime_error);
     }
   }
+#endif  // ALPAKA_ACC_GPU_HIP_ENABLED
 }


### PR DESCRIPTION
#### PR description:

Disable HIP/ROCm device-side error tests until ROCm or alpaka provide a non-fatal way to assert in device code.

#### PR validation:

Unit tests pass.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #48563 to 15.0.x to fix the ROCm unit tests.