### PR TITLE
register `HGCalLayerClusterPluginFactory` only once

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/plugins/SealModules.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/SealModules.cc
@@ -3,10 +3,8 @@
 #include "RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h"
 #include "RecoLocalCalo/HGCalRecProducers/interface/HGCalImagingAlgo.h"
 #include "RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h"
-#include "FWCore/ParameterSet/interface/ValidatedPluginFactoryMacros.h"
 #include "FWCore/ParameterSet/interface/ValidatedPluginMacros.h"
 
-EDM_REGISTER_VALIDATED_PLUGINFACTORY(HGCalLayerClusterAlgoFactory, "HGCalLayerClusterAlgoFactory");
 DEFINE_EDM_VALIDATED_PLUGIN(HGCalLayerClusterAlgoFactory, HGCalImagingAlgo, "Imaging");
 DEFINE_EDM_VALIDATED_PLUGIN(HGCalLayerClusterAlgoFactory, HGCalSiCLUEAlgo, "SiCLUE");
 DEFINE_EDM_VALIDATED_PLUGIN(HGCalLayerClusterAlgoFactory, HGCalSciCLUEAlgo, "SciCLUE");

--- a/RecoLocalCalo/HGCalRecProducers/src/HGCalLayerClusterPluginFactory.cc
+++ b/RecoLocalCalo/HGCalRecProducers/src/HGCalLayerClusterPluginFactory.cc
@@ -1,0 +1,4 @@
+#include "RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerClusterAlgoFactory.h"
+#include "FWCore/ParameterSet/interface/ValidatedPluginFactoryMacros.h"
+
+EDM_REGISTER_VALIDATED_PLUGINFACTORY(HGCalLayerClusterAlgoFactory, "HGCalLayerClusterAlgoFactory");

--- a/RecoParticleFlow/PFClusterProducer/BuildFile.xml
+++ b/RecoParticleFlow/PFClusterProducer/BuildFile.xml
@@ -15,6 +15,7 @@
 <use name="CalibCalorimetry/EcalTPGTools"/>
 <use name="DataFormats/HGCRecHit"/>
 <use name="RecoLocalCalo/HGCalRecAlgos"/>
+<use name="RecoLocalCalo/HGCalRecProducers"/>
 <use name="vdt_headers"/>
 <use name="rootmath"/>
 <use name="root"/>

--- a/RecoParticleFlow/PFClusterProducer/plugins/SealModules.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SealModules.cc
@@ -1,9 +1,7 @@
 #include "RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerClusterAlgoFactory.h"
 #include "RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h"
 #include "RecoParticleFlow/PFClusterProducer/plugins/BarrelCLUEAlgo.h"
-#include "FWCore/ParameterSet/interface/ValidatedPluginFactoryMacros.h"
 #include "FWCore/ParameterSet/interface/ValidatedPluginMacros.h"
 
-EDM_REGISTER_VALIDATED_PLUGINFACTORY(HGCalLayerClusterAlgoFactory, "HGCalLayerClusterAlgoFactory");
 DEFINE_EDM_VALIDATED_PLUGIN(HGCalLayerClusterAlgoFactory, EBCLUEAlgo, "EBCLUE");
 DEFINE_EDM_VALIDATED_PLUGIN(HGCalLayerClusterAlgoFactory, HBCLUEAlgo, "HBCLUE");


### PR DESCRIPTION
#### PR description:
Remove duplicate registration of `HGCalLayerClusterPluginFactory` introduced by https://github.com/cms-sw/cmssw/pull/47859. 
As described in https://github.com/cms-sw/cmssw/issues/48560, RelVal wf `29634.758` was failing in the CLANG-flavoured IBs.

#### PR validation:
Workflow `29634.758` runs without errors in `CMSSW_15_1_CLANG_X_2025-07-16-2300`.