### PR TITLE
Removed call to TH1::SetDefaultSumw2 found in harvesting step

### DIFF
--- a/DQMOffline/PFTau/plugins/PFClient.h
+++ b/DQMOffline/PFTau/plugins/PFClient.h
@@ -20,7 +20,8 @@ private:
   void doProjection(DQMStore::IBooker &, DQMStore::IGetter &);
   void doProfiles(DQMStore::IBooker &, DQMStore::IGetter &);
   void createResolutionPlots(DQMStore::IBooker &, DQMStore::IGetter &, std::string &folder, std::string &name);
-  void getHistogramParameters(MonitorElement *me_slice, double &avarage, double &rms, double &mean, double &sigma);
+  void getHistogramParameters(
+      TH1F &th_slice, unsigned int nNonZeroBins, double &avarage, double &rms, double &mean, double &sigma);
   void createEfficiencyPlots(DQMStore::IBooker &, DQMStore::IGetter &, std::string &folder, std::string &name);
 
   void createProjectionPlots(DQMStore::IBooker &, DQMStore::IGetter &, std::string &folder, std::string &name);


### PR DESCRIPTION
#### PR description:

- Removed call to TH1::SetDefaultSumw2 from TnPEfficiencyClient which was causing fit failures in PFClient
- Made PFClient fitting more robust to avoid an exception in the case where too few non-zero bins were in the histogram.

#### PR validation:

Tested by running workflow 10224.0 with the change from #48519 which was previously showing changes in the histogram. With this change the histograms are now as expected.

resolves https://github.com/cms-sw/framework-team/issues/1463