### PR TITLE
Add needed dependencies between some DQMEDHarvesters

### DIFF
--- a/DQM/DTMonitorClient/python/dtCertificationSummary_cfi.py
+++ b/DQM/DTMonitorClient/python/dtCertificationSummary_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
-dtCertificationSummary = DQMEDHarvester('DTCertificationSummary')
+dtCertificationSummary = DQMEDHarvester('DTCertificationSummary',
+                                        inputMEs = cms.untracked.VInputTag(("dtChamberEfficiencyClient"), ("dtResolutionAnalysisTest"), ("segmentTest")))
 
 

--- a/DQM/DTMonitorClient/src/DTCertificationSummary.cc
+++ b/DQM/DTMonitorClient/src/DTCertificationSummary.cc
@@ -18,9 +18,16 @@
 using namespace std;
 using namespace edm;
 
-DTCertificationSummary::DTCertificationSummary(const ParameterSet& pset) {}
+DTCertificationSummary::DTCertificationSummary(const ParameterSet& pset) : DQMEDHarvester(pset) {}
 
 DTCertificationSummary::~DTCertificationSummary() {}
+
+void DTCertificationSummary::fillDescriptions(edm::ConfigurationDescriptions& iConfig) {
+  edm::ParameterSetDescription pset;
+  DQMEDHarvester::fillDescription(pset);
+
+  iConfig.addDefault(pset);
+}
 
 void DTCertificationSummary::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker,
                                                    DQMStore::IGetter& igetter,

--- a/DQM/DTMonitorClient/src/DTCertificationSummary.h
+++ b/DQM/DTMonitorClient/src/DTCertificationSummary.h
@@ -8,6 +8,7 @@
  */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 
@@ -22,6 +23,7 @@ public:
   ~DTCertificationSummary() override;
 
   // Operations
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 protected:
 private:

--- a/DQM/EcalMonitorClient/plugins/EcalDQMonitorClient.cc
+++ b/DQM/EcalMonitorClient/plugins/EcalDQMonitorClient.cc
@@ -20,7 +20,7 @@
 #include <fstream>
 
 EcalDQMonitorClient::EcalDQMonitorClient(edm::ParameterSet const& _ps)
-    : DQMEDHarvester(),
+    : DQMEDHarvester(_ps),
       ecaldqm::EcalDQMonitor(_ps),
       iEvt_(0),
       cStHndl(esConsumes<edm::Transition::BeginRun>()),
@@ -52,6 +52,7 @@ EcalDQMonitorClient::~EcalDQMonitorClient() {}
 /*static*/
 void EcalDQMonitorClient::fillDescriptions(edm::ConfigurationDescriptions& _descs) {
   edm::ParameterSetDescription desc;
+  DQMEDHarvester::fillDescription(desc);
   ecaldqm::EcalDQMonitor::fillDescriptions(desc);
 
   edm::ParameterSetDescription clientParameters;

--- a/DQM/EcalMonitorClient/python/EcalCertification_cfi.py
+++ b/DQM/EcalMonitorClient/python/EcalCertification_cfi.py
@@ -16,5 +16,6 @@ ecalCertification = DQMEDHarvester("EcalDQMonitorClient",
         CertificationClient = ecalCertificationClient.clone()
     ),
     commonParameters = ecalCommonParams.clone(willConvertToEDM = False),
+    inputMEs = cms.untracked.VInputTag(("ecalDaqInfoTask"), ("ecalMonitorClient"), ("ecalDcsInfoTask"), ("ecalSummaryClient")),
     verbosity = cms.untracked.int32(0)
 )

--- a/DQMServices/Core/interface/DQMEDHarvester.h
+++ b/DQMServices/Core/interface/DQMEDHarvester.h
@@ -13,6 +13,7 @@
 #include "FWCore/Framework/interface/GetterOfProducts.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/EDPutToken.h"
 
 #include "DataFormats/Histograms/interface/DQMToken.h"
@@ -62,6 +63,15 @@ protected:
   edm::EDPutTokenT<DQMToken> lumiToken_;
   edm::EDPutTokenT<DQMToken> runToken_;
   edm::EDPutTokenT<DQMToken> jobToken_;
+
+  static void fillDescription(edm::ParameterSetDescription &iDesc) {
+    iDesc.addUntracked<std::string>("inputGeneration", "DQMGenerationReco");
+    iDesc.addUntracked<std::string>("outputGeneration", "DQMGenerationHarvesting");
+    iDesc.addUntracked<std::vector<edm::InputTag>>("inputMEs", std::vector<edm::InputTag>())
+        ->setComment(
+            "DQM tokens to read from other modules. Used to form dependencies between MonitorElements created by other "
+            "modules.");
+  }
 
 public:
   DQMEDHarvester(edm::ParameterSet const &iConfig) {

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -89,7 +89,7 @@ namespace dqm::implementation {
     // However, it is easier to do that in putME().
 
     MonitorElement* me = store_->findME(path);
-    store_->printTrace("Booking " + std::string(name) + (me ? " (existing)" : " (new)"));
+    store_->printTrace("Booking " + fullpath + (me ? " (existing)" : " (new)"));
 
     if (me == nullptr) {
       // no existing global ME found. We need to instantiate one, and put it


### PR DESCRIPTION
#### PR description:

- Extended the modules to be able to use the DQMEDHarvester base class parameters which allow specify dependencies
- Added dependencies for two modules

#### PR validation:

Tested under #48519 which had showed problems before this change.

Resolves https://github.com/cms-sw/framework-team/issues/1464