### PR TITLE
update a vertex smearing parameters for 2025 OO MC

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -1,6 +1,7 @@
 VtxSmeared = {
     'DBdesign':                      'IOMC.EventVertexGenerators.VtxSmearedDesign_cfi',
     'DBrealistic':                   'IOMC.EventVertexGenerators.VtxSmearedRealistic_cfi',
+    'DBrealisticHLLHC':              'IOMC.EventVertexGenerators.VtxSmearedRealisticHLLHC_cfi',
     'NoSmear':                       'Configuration.StandardSequences.VtxSmearedNoSmear_cff',              
     'BetafuncEarlyCollision':        'IOMC.EventVertexGenerators.VtxSmearedBetafuncEarlyCollision_cfi',    
     'BeamProfile':                   'IOMC.EventVertexGenerators.VtxSmearedBeamProfile_cfi',               
@@ -42,8 +43,6 @@ VtxSmeared = {
     'HGCALCloseBy'  :                'IOMC.EventVertexGenerators.VtxSmearedHGCALCloseBy_cfi',
     'HLLHC'  :                       'IOMC.EventVertexGenerators.VtxSmearedHLLHC_cfi',
     'HLLHC14TeV'  :                  'IOMC.EventVertexGenerators.VtxSmearedHLLHC14TeV_cfi',
-    'HLLHC_CK'  :                    'IOMC.EventVertexGenerators.VtxSmearedHLLHCCrabKissing_cfi',
-    'HLLHC_CK14TeV'  :               'IOMC.EventVertexGenerators.VtxSmearedHLLHCCrabKissing14TeV_cfi',
     'ShiftedCollision2015'  :        'IOMC.EventVertexGenerators.VtxSmearedShiftedCollision2015_cfi',
     'Shifted5mmCollision2015'  :     'IOMC.EventVertexGenerators.VtxSmearedShifted5mmCollision2015_cfi',
     'Shifted15mmCollision2015'  :    'IOMC.EventVertexGenerators.VtxSmearedShifted15mmCollision2015_cfi',

--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -80,5 +80,4 @@ VtxSmeared = {
     'Realistic2025pOCollision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic2025pOCollision_cfi',
     'Realistic2025OOCollision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic2025OOCollision_cfi', 
 }
-VtxSmearedDefaultKey='Realistic50ns13TeVCollision'
-VtxSmearedHIDefaultKey='RealisticPbPbCollision2018'
+VtxSmearedDefaultKey='DBrealistic'

--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -1,7 +1,6 @@
 VtxSmeared = {
     'DBdesign':                      'IOMC.EventVertexGenerators.VtxSmearedDesign_cfi',
     'DBrealistic':                   'IOMC.EventVertexGenerators.VtxSmearedRealistic_cfi',
-    'DBrealisticHLLHC':              'IOMC.EventVertexGenerators.VtxSmearedRealisticHLLHC_cfi',
     'NoSmear':                       'Configuration.StandardSequences.VtxSmearedNoSmear_cff',              
     'BetafuncEarlyCollision':        'IOMC.EventVertexGenerators.VtxSmearedBetafuncEarlyCollision_cfi',    
     'BeamProfile':                   'IOMC.EventVertexGenerators.VtxSmearedBeamProfile_cfi',               
@@ -43,6 +42,8 @@ VtxSmeared = {
     'HGCALCloseBy'  :                'IOMC.EventVertexGenerators.VtxSmearedHGCALCloseBy_cfi',
     'HLLHC'  :                       'IOMC.EventVertexGenerators.VtxSmearedHLLHC_cfi',
     'HLLHC14TeV'  :                  'IOMC.EventVertexGenerators.VtxSmearedHLLHC14TeV_cfi',
+    'HLLHC_CK'  :                    'IOMC.EventVertexGenerators.VtxSmearedHLLHCCrabKissing_cfi',
+    'HLLHC_CK14TeV'  :               'IOMC.EventVertexGenerators.VtxSmearedHLLHCCrabKissing14TeV_cfi',
     'ShiftedCollision2015'  :        'IOMC.EventVertexGenerators.VtxSmearedShiftedCollision2015_cfi',
     'Shifted5mmCollision2015'  :     'IOMC.EventVertexGenerators.VtxSmearedShifted5mmCollision2015_cfi',
     'Shifted15mmCollision2015'  :    'IOMC.EventVertexGenerators.VtxSmearedShifted15mmCollision2015_cfi',
@@ -77,5 +78,7 @@ VtxSmeared = {
     'Realistic2024PbPbCollision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic2024PbPbCollision_cfi',
     'Nominal2025OOCollision' : 'IOMC.EventVertexGenerators.VtxSmearedNominal2025OOCollision_cfi',
     'Realistic2025pOCollision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic2025pOCollision_cfi',
+    'Realistic2025OOCollision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic2025OOCollision_cfi', 
 }
-VtxSmearedDefaultKey='DBrealistic'
+VtxSmearedDefaultKey='Realistic50ns13TeVCollision'
+VtxSmearedHIDefaultKey='RealisticPbPbCollision2018'

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -1123,6 +1123,19 @@ Realistic2025pOCollisionVtxSmearingParameters = cms.PSet(
     Z0 = cms.double(0.569058)
 )
 
+# From 2025 OO data runs 394153-394217, exluding runs with VdM scans, i.e 394154 and 394217
+Realistic2025OOCollisionVtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(50),
+    Emittance = cms.double(6.684e-08),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(5.2929),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(0.0158483),
+    Y0 = cms.double(-0.00652439),
+    Z0 = cms.double(0.557563)
+)
+
 # Parameters for HL-LHC operation at 13TeV
 HLLHCVtxSmearingParameters = cms.PSet(
     MeanXIncm = cms.double(0.),
@@ -1140,4 +1153,24 @@ HLLHCVtxSmearingParameters = cms.PSet(
     BunchLengthInm = cms.double(0.090),
     CrabbingAngleCrossingInurad = cms.double(380.0),
     CrabbingAngleSeparationInurad = cms.double(0.0)
+)
+
+# Parameters for HL-LHC Crab-kissing operation 13 TeV
+HLLHCCrabKissingVtxSmearingParameters = cms.PSet(
+    MeanXIncm = cms.double(0.),
+    MeanYIncm = cms.double(0.),
+    MeanZIncm = cms.double(0.),
+    TimeOffsetInns = cms.double(0.0),
+    EprotonInGeV = cms.double(6500.0),
+    HalfCrossingAngleInurad = cms.double(200.0),
+    CrabAngleCrossingPlaneInurad = cms.double(200.0),
+    CrabFrequencyCrossingPlaneInMHz = cms.double(400.0),
+    NormalizedEmittanceCrossingPlaneInum = cms.double(2.5),
+    BetaStarCrossingPlaneInm = cms.double(0.30),
+    CrabAngleParallelPlaneInurad = cms.double(100.0),
+    CrabFrequencyParallelPlaneInMHz = cms.double(400.0),
+    NormalizedEmittanceParallelPlaneInum = cms.double(2.5),
+    BetaStarParallelPlaneInm = cms.double(0.075),
+    ZsizeInm = cms.double(0.15),
+    BeamProfile=cms.string("Flat")
 )

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -1155,22 +1155,3 @@ HLLHCVtxSmearingParameters = cms.PSet(
     CrabbingAngleSeparationInurad = cms.double(0.0)
 )
 
-# Parameters for HL-LHC Crab-kissing operation 13 TeV
-HLLHCCrabKissingVtxSmearingParameters = cms.PSet(
-    MeanXIncm = cms.double(0.),
-    MeanYIncm = cms.double(0.),
-    MeanZIncm = cms.double(0.),
-    TimeOffsetInns = cms.double(0.0),
-    EprotonInGeV = cms.double(6500.0),
-    HalfCrossingAngleInurad = cms.double(200.0),
-    CrabAngleCrossingPlaneInurad = cms.double(200.0),
-    CrabFrequencyCrossingPlaneInMHz = cms.double(400.0),
-    NormalizedEmittanceCrossingPlaneInum = cms.double(2.5),
-    BetaStarCrossingPlaneInm = cms.double(0.30),
-    CrabAngleParallelPlaneInurad = cms.double(100.0),
-    CrabFrequencyParallelPlaneInMHz = cms.double(400.0),
-    NormalizedEmittanceParallelPlaneInum = cms.double(2.5),
-    BetaStarParallelPlaneInm = cms.double(0.075),
-    ZsizeInm = cms.double(0.15),
-    BeamProfile=cms.string("Flat")
-)

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -1154,4 +1154,3 @@ HLLHCVtxSmearingParameters = cms.PSet(
     CrabbingAngleCrossingInurad = cms.double(380.0),
     CrabbingAngleSeparationInurad = cms.double(0.0)
 )
-

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic2023PbPbCollision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic2023PbPbCollision_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Realistic2023PbPbCollisionVtxSmearingParameters,VtxSmearedCommon
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Realistic2025OOCollisionVtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
-    Realistic2023PbPbCollisionVtxSmearingParameters,
+    Realistic2025OOCollisionVtxSmearingParameters,
     VtxSmearedCommon
 )


### PR DESCRIPTION
#### PR description:

This PR adds a vertex smearing for 2025 OO MC. Beamspot position derived from runs 394153-394217, excluding runs with VdM scans, i.e 394154 and 394217. BPIX barycentre locations are officially provided by Tracker Alignment Group ([twiki](https://twiki.cern.ch/twiki/bin/view/CMS/TkAlignmentPixelPosition#Run2025_OO))

#### PR validation:

This PR has been modeled after a similar PR for 2025 pO collisions: https://github.com/cms-sw/cmssw/pull/48480

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

We will need a backport for CMSSW_15_0_X
