### PR TITLE
Improve the Phase-1 pixel raw to cluster [15.0.x]

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
@@ -621,18 +621,21 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         auto moduleStartFirstElement = cms::alpakatools::make_device_view(queue, clusters_d->view().moduleStart(), 1u);
         alpaka::memcpy(queue, nModules_Clusters_h, moduleStartFirstElement);
 
-        const auto elementsPerBlockFindClus = FindClus<TrackerTraits>::maxElementsPerBlock;
-        const auto workDivMaxNumModules =
-            cms::alpakatools::make_workdiv<Acc1D>(numberOfModules, elementsPerBlockFindClus);
+        {
+          const int blocks = 64;
+          const auto elementsPerBlockFindClus = FindClus<TrackerTraits>::maxElementsPerBlock;
+          const auto workDivMaxNumModules = cms::alpakatools::make_workdiv<Acc1D>(blocks, elementsPerBlockFindClus);
+
 #ifdef GPU_DEBUG
-        std::cout << " FindClus kernel launch with " << numberOfModules << " blocks of " << elementsPerBlockFindClus
-                  << " threadsPerBlockOrElementsPerThread\n";
+          std::cout << " FindClus kernel launch with " << numberOfModules << " blocks of " << elementsPerBlockFindClus
+                    << " threadsPerBlockOrElementsPerThread\n";
 #endif
-        alpaka::exec<Acc1D>(
-            queue, workDivMaxNumModules, FindClus<TrackerTraits>{}, digis_d->view(), clusters_d->view(), wordCounter);
+          alpaka::exec<Acc1D>(
+              queue, workDivMaxNumModules, FindClus<TrackerTraits>{}, digis_d->view(), clusters_d->view(), wordCounter);
 #ifdef GPU_DEBUG
-        alpaka::wait(queue);
+          alpaka::wait(queue);
 #endif
+        }
 
         constexpr auto threadsPerBlockChargeCut = 256;
         const auto workDivChargeCut = cms::alpakatools::make_workdiv<Acc1D>(numberOfModules, threadsPerBlockChargeCut);


### PR DESCRIPTION
#### PR description:

Fix a bug in the heterogeneous pixel raw-to-cluster module:
  - include in the output the last pixel of each module. The current implementation ignores the last pixel of each module, and nobody seems to know why.

Implement a few small optimisations:
  - use only 64 groups, instead of one per module;
  - adjust the number of nearest neighbours after duplicate removal;
  - restrict the domain of atomic operations to per-block;
  - remove an unnecessary synchronisation.

The cumulative effect is to speed up the pixel local reconstruction by 7%.

machine type | `CMSSW_15_0_10_patch2` | with #48581 | relative difference
---|---|---|---
2022 HLT node (2× Milan 7763, 2× T4) | 2495 ± 3 ev/s | 2670 ± 6 ev/s | +7%
2024 HLT node (2× Bergamo 9754, 3× L4) | 11598 ± 23 ev/s | 12447 ± 25 ev/s | +7%

The performance of the full HLT menu is not affected, as it is limited by the CPU part.

#### PR validation:

Technical validation performed on top of CMSSW 15.0.10 running over 10k events from Run2025C.
Physics validation is required, though no changes are expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #48580, #48609 and #48644 to 15.0.x for the 2025 data taking.