### PR TITLE
Fix the list of modules in regional digi morphing

### DIFF
--- a/RecoLocalTracker/SiPixelDigiReProducers/plugins/SiPixelDigiMorphing.cc
+++ b/RecoLocalTracker/SiPixelDigiReProducers/plugins/SiPixelDigiMorphing.cc
@@ -113,7 +113,7 @@ void SiPixelDigiMorphing::fillDescriptions(edm::ConfigurationDescriptions& descr
 
   desc.add<edm::InputTag>("src", edm::InputTag("siPixelDigis"));
   // LAYER,LADDER,MODULE (coordinates can also be specified as a range FIRST-LAST where appropriate)
-  desc.add<std::vector<std::string>>("barrelRegions", {"1,1-12,1-2", "1,1-12,7-8", "2,1-28,1", "1,1-28,8"});
+  desc.add<std::vector<std::string>>("barrelRegions", {"1,1-12,1-2", "1,1-12,7-8", "2,1-28,1", "2,1-28,8"});
   // DISK,BLADE,SIDE,PANEL (coordinates can also be specified as a range FIRST-LAST where appropriate)
   desc.add<std::vector<std::string>>("endcapRegions", {});
   desc.add<int32_t>("nrows", 160);


### PR DESCRIPTION
#### PR description:

The fourth module in the following line of `RecoLocalTracker/SiPixelDigiReProducers/plugins/SiPixelDigiMorphing.cc` 
```
 // LAYER,LADDER,MODULE (coordinates can also be specified as a range FIRST-LAST where appropriate)
  desc.add<std::vector<std::string>>("barrelRegions", {"1,1-12,1-2", "1,1-12,7-8", "2,1-28,1", "1,1-28,8"});
  ```
incorrectly refers to L1, while it should be L2. This PR corrects it. This only concerns the wfs with digi morphing turned on. Since it is turned off by default, we expect no changes. 

#### PR validation:

Code compiles. `runTheMatrix.py -l limited -i all --ibeos` is running and result will be reported here. Since this is a very simple change, we are opening the PR before these finish in the interest of time.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 150X.
