### PR TITLE
Run 3 FastSim refinement for PUPPI jets 

### DIFF
--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -224,3 +224,100 @@ jetPuppiTask = cms.Task(jetPuppiCorrFactorsNano,updatedJetsPuppi,jetPuppiUserDat
 
 #after cross linkining
 jetPuppiTablesTask = cms.Task(jetPuppiTable)
+
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+from PhysicsTools.NanoAOD.common_cff import ExtVar
+
+def nanoAOD_refineFastSim_puppiJet(process):
+    process.puppiJetRefineNN = cms.EDProducer(
+        "JetBaseMVAValueMapProducer",
+        backend             = cms.string("ONNX"),
+        batch_eval          = cms.bool(True),
+        disableONNXGraphOpt = cms.bool(True),
+        src                 = cms.InputTag("updatedJetsPuppi"),  # <<< HERE
+        weightFile          = cms.FileInPath("model_refinement_regression_20250320_dynamic.onnx"),
+        name                = cms.string("puppiJetRefineNN"),
+        variables = cms.VPSet(
+            cms.PSet(name=cms.string("GenJet_pt"),            expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().pt():pt")),
+            cms.PSet(name=cms.string("GenJet_eta"),           expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().eta():eta")),
+            cms.PSet(name=cms.string("Jet_hadronFlavour"),    expr=cms.string("hadronFlavour()")),
+            cms.PSet(name=cms.string("Jet_pt"),               expr=cms.string("pt()")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavB"),    expr=cms.string("bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavCvB"),  expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')):-1")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavCvL"),  expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')):-1")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavQG"),   expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds'))>0?bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')):-1")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4B"),    expr=cms.string("bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4CvB"),  expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'):-1")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4CvL"),  expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'):-1")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4QvG"),  expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'):-1")),
+        ),
+        inputTensorName  = cms.string("input"),
+        outputTensorName = cms.string("output"),
+        outputNames      = cms.vstring([
+            "ptrefined","btagDeepFlavBrefined","btagDeepFlavCvBrefined","btagDeepFlavCvLrefined",
+            "btagDeepFlavQGrefined","btagUParTAK4Brefined","btagUParTAK4CvBrefined",
+            "btagUParTAK4CvLrefined","btagUParTAK4QvGrefined"
+        ]),
+        outputFormulas   = cms.vstring([f"at({i})" for i in range(9)]),
+    )
+
+    # schedule it in the jet-building chain
+    fastSim.toModify(process.jetPuppiTask, process.jetPuppiTask.add(process.puppiJetRefineNN))
+
+    #
+    # 1) now stuff those 9 refined scalars into the existing PATJetUserDataEmbedder
+    #
+    fastSim.toModify(process.updatedJetsPuppiWithUserData.userFloats,
+        ptRefined              = cms.InputTag("puppiJetRefineNN","ptrefined"),
+        btagDeepFlavBrefined   = cms.InputTag("puppiJetRefineNN","btagDeepFlavBrefined"),
+        btagDeepFlavCvBrefined = cms.InputTag("puppiJetRefineNN","btagDeepFlavCvBrefined"),
+        btagDeepFlavCvLrefined = cms.InputTag("puppiJetRefineNN","btagDeepFlavCvLrefined"),
+        btagDeepFlavQGrefined  = cms.InputTag("puppiJetRefineNN","btagDeepFlavQGrefined"),
+        btagUParTAK4Brefined   = cms.InputTag("puppiJetRefineNN","btagUParTAK4Brefined"),
+        btagUParTAK4CvBrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4CvBrefined"),
+        btagUParTAK4CvLrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4CvLrefined"),
+        btagUParTAK4QvGrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4QvGrefined"),
+    )
+
+    #
+    # 2) backup all 9 originals in the NanoAOD table as *_unrefined
+    #
+    fastSim.toModify(process.jetPuppiTable.variables,
+        pt_unrefined               = process.jetPuppiTable.variables.pt.clone(),
+        btagDeepFlavB_unrefined    = process.jetPuppiTable.variables.btagDeepFlavB.clone(),
+        btagDeepFlavCvB_unrefined  = process.jetPuppiTable.variables.btagDeepFlavCvB.clone(),
+        btagDeepFlavCvL_unrefined  = process.jetPuppiTable.variables.btagDeepFlavCvL.clone(),
+        btagDeepFlavQG_unrefined   = process.jetPuppiTable.variables.btagDeepFlavQG.clone(),
+        btagUParTAK4B_unrefined    = process.jetPuppiTable.variables.btagUParTAK4B.clone(),
+        btagUParTAK4CvB_unrefined  = process.jetPuppiTable.variables.btagUParTAK4CvB.clone(),
+        btagUParTAK4CvL_unrefined  = process.jetPuppiTable.variables.btagUParTAK4CvL.clone(),
+        btagUParTAK4QvG_unrefined  = process.jetPuppiTable.variables.btagUParTAK4QvG.clone(),
+    )
+    # drop them so we can redefine
+    fastSim.toModify(process.jetPuppiTable.variables,
+        pt=None, btagDeepFlavB=None, btagDeepFlavCvB=None,
+        btagDeepFlavCvL=None, btagDeepFlavQG=None,
+        btagUParTAK4B=None, btagUParTAK4CvB=None,
+        btagUParTAK4CvL=None, btagUParTAK4QvG=None,
+    )
+
+    #
+    # 3) re‑define each branch with a FastSim‑only mask ternary
+    #
+    mask = "(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')>0)"
+
+    fastSim.toModify(process.jetPuppiTable.variables,
+        pt              = Var(f"?{mask}?userFloat('ptRefined'):pt()",              float, precision=10, doc="refined pT or original"),
+        btagDeepFlavB   = Var(f"?{mask}?userFloat('btagDeepFlavBrefined'):(bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))", float, precision=10),
+        btagDeepFlavCvB = Var(f"?{mask}?userFloat('btagDeepFlavCvBrefined'):(?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')):-1)", float, precision=10),
+        btagDeepFlavCvL = Var(f"?{mask}?userFloat('btagDeepFlavCvLrefined'):(?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')):-1)", float, precision=10),
+        btagDeepFlavQG  = Var(f"?{mask}?userFloat('btagDeepFlavQGrefined'):(?(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds'))>0?bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')):-1)", float, precision=10),
+        btagUParTAK4B   = Var(f"?{mask}?userFloat('btagUParTAK4Brefined'):(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll'))", float, precision=10),
+        btagUParTAK4CvB = Var(f"?{mask}?userFloat('btagUParTAK4CvBrefined'):(?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'):-1)", float, precision=10),
+        btagUParTAK4CvL = Var(f"?{mask}?userFloat('btagUParTAK4CvLrefined'):(?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'):-1)", float, precision=10),
+        btagUParTAK4QvG = Var(f"?{mask}?userFloat('btagUParTAK4QvGrefined'):(?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'):-1)", float, precision=10),
+    )
+
+    return process
+
+nanoAOD_refineFastSim_puppiJet = nanoAOD_refineFastSim_puppiJet

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -222,55 +222,15 @@ jetPuppiTablesTask = cms.Task(jetPuppiTable)
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 from PhysicsTools.NanoAOD.common_cff import ExtVar
 
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+from PhysicsTools.NanoAOD.common_cff import Var
+
+from PhysicsTools.NanoAOD.common_cff import Var, ExtVar
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+
 def nanoAOD_refineFastSim_puppiJet(process):
-    process.puppiJetRefineNN = cms.EDProducer(
-        "JetBaseMVAValueMapProducer",
-        backend             = cms.string("ONNX"),
-        batch_eval          = cms.bool(True),
-        disableONNXGraphOpt = cms.bool(True),
-        src                 = cms.InputTag("updatedJetsPuppi"),  # <<< HERE
-        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/fastSimPuppiJetRefineNN_31July2025.onnx"),
-        name                = cms.string("puppiJetRefineNN"),
-        variables = cms.VPSet(
-            cms.PSet(name=cms.string("GenJet_pt"),            expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().pt():pt")),
-            cms.PSet(name=cms.string("GenJet_eta"),           expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().eta():eta")),
-            cms.PSet(name=cms.string("Jet_hadronFlavour"),    expr=cms.string("hadronFlavour()")),
-            cms.PSet(name=cms.string("Jet_pt"),               expr=cms.string("pt()")),
-            cms.PSet(name=cms.string("Jet_btagDeepFlavB"),    expr=cms.string("bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')")),
-            cms.PSet(name=cms.string("Jet_btagDeepFlavCvB"),  expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')):-1")),
-            cms.PSet(name=cms.string("Jet_btagDeepFlavCvL"),  expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')):-1")),
-            cms.PSet(name=cms.string("Jet_btagDeepFlavQG"),   expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds'))>0?bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')):-1")),
-            cms.PSet(name=cms.string("Jet_btagUParTAK4B"),    expr=cms.string("bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')")),
-            cms.PSet(name=cms.string("Jet_btagUParTAK4CvB"),  expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'):-1")),
-            cms.PSet(name=cms.string("Jet_btagUParTAK4CvL"),  expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'):-1")),
-            cms.PSet(name=cms.string("Jet_btagUParTAK4QvG"),  expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'):-1")),
-        ),
-        inputTensorName  = cms.string("input"),
-        outputTensorName = cms.string("output"),
-        outputNames      = cms.vstring([
-            "ptrefined","btagDeepFlavBrefined","btagDeepFlavCvBrefined","btagDeepFlavCvLrefined",
-            "btagDeepFlavQGrefined","btagUParTAK4Brefined","btagUParTAK4CvBrefined",
-            "btagUParTAK4CvLrefined","btagUParTAK4QvGrefined"
-        ]),
-        outputFormulas   = cms.vstring([f"at({i})" for i in range(9)]),
-    )
 
-    fastSim.toModify(process.jetPuppiTask, process.jetPuppiTask.add(process.puppiJetRefineNN))
-
-    # 1) now stuff the 9 refined scalars into the existing PATJetUserDataEmbedder
-    fastSim.toModify(process.updatedJetsPuppiWithUserData.userFloats,
-        ptRefined              = cms.InputTag("puppiJetRefineNN","ptrefined"),
-        btagDeepFlavBrefined   = cms.InputTag("puppiJetRefineNN","btagDeepFlavBrefined"),
-        btagDeepFlavCvBrefined = cms.InputTag("puppiJetRefineNN","btagDeepFlavCvBrefined"),
-        btagDeepFlavCvLrefined = cms.InputTag("puppiJetRefineNN","btagDeepFlavCvLrefined"),
-        btagDeepFlavQGrefined  = cms.InputTag("puppiJetRefineNN","btagDeepFlavQGrefined"),
-        btagUParTAK4Brefined   = cms.InputTag("puppiJetRefineNN","btagUParTAK4Brefined"),
-        btagUParTAK4CvBrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4CvBrefined"),
-        btagUParTAK4CvLrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4CvLrefined"),
-        btagUParTAK4QvGrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4QvGrefined"),
-    )
-
-    # 2) backup all 9 originals in the NanoAOD table as *_unrefined
     fastSim.toModify(process.jetPuppiTable.variables,
         pt_unrefined               = process.jetPuppiTable.variables.pt.clone(),
         btagDeepFlavB_unrefined    = process.jetPuppiTable.variables.btagDeepFlavB.clone(),
@@ -282,29 +242,63 @@ def nanoAOD_refineFastSim_puppiJet(process):
         btagUParTAK4CvL_unrefined  = process.jetPuppiTable.variables.btagUParTAK4CvL.clone(),
         btagUParTAK4QvG_unrefined  = process.jetPuppiTable.variables.btagUParTAK4QvG.clone(),
     )
-    # drop them so we can redefine
-    fastSim.toModify(process.jetPuppiTable.variables,
-        pt=None, btagDeepFlavB=None, btagDeepFlavCvB=None,
-        btagDeepFlavCvL=None, btagDeepFlavQG=None,
-        btagUParTAK4B=None, btagUParTAK4CvB=None,
-        btagUParTAK4CvL=None, btagUParTAK4QvG=None,
-    )
-
-    # 3) re‑define each branch with a FastSim‑only mask ternary
-    mask = "(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')>0)"
 
     fastSim.toModify(process.jetPuppiTable.variables,
-        pt              = Var(f"?{mask}?userFloat('ptRefined'):pt()",              float, precision=10, doc="refined pT or original"),
-        btagDeepFlavB   = Var(f"?{mask}?userFloat('btagDeepFlavBrefined'):(bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))", float, precision=10),
-        btagDeepFlavCvB = Var(f"?{mask}?userFloat('btagDeepFlavCvBrefined'):(?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')):-1)", float, precision=10),
-        btagDeepFlavCvL = Var(f"?{mask}?userFloat('btagDeepFlavCvLrefined'):(?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')):-1)", float, precision=10),
-        btagDeepFlavQG  = Var(f"?{mask}?userFloat('btagDeepFlavQGrefined'):(?(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds'))>0?bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')):-1)", float, precision=10),
-        btagUParTAK4B   = Var(f"?{mask}?userFloat('btagUParTAK4Brefined'):(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll'))", float, precision=10),
-        btagUParTAK4CvB = Var(f"?{mask}?userFloat('btagUParTAK4CvBrefined'):(?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'):-1)", float, precision=10),
-        btagUParTAK4CvL = Var(f"?{mask}?userFloat('btagUParTAK4CvLrefined'):(?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'):-1)", float, precision=10),
-        btagUParTAK4QvG = Var(f"?{mask}?userFloat('btagUParTAK4QvGrefined'):(?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'):-1)", float, precision=10),
+        pt=None, btagDeepFlavB=None, btagDeepFlavCvB=None, btagDeepFlavCvL=None, btagDeepFlavQG=None,
+        btagUParTAK4B=None, btagUParTAK4CvB=None, btagUParTAK4CvL=None, btagUParTAK4QvG=None,
     )
+
+    process.puppiJetRefineNN = cms.EDProducer(
+        "JetBaseMVAValueMapProducer",
+        backend             = cms.string("ONNX"),
+        batch_eval          = cms.bool(True),
+        disableONNXGraphOpt = cms.bool(True),
+        src                 = cms.InputTag("linkedObjects","jets"),
+        weightFile          = cms.FileInPath("PhysicsTools/NanoAOD/data/fastSimPuppiJetRefineNN_31July2025.onnx"),
+        name                = cms.string("puppiJetRefineNN"),
+        variables = cms.VPSet(
+            cms.PSet(name=cms.string("GenJet_pt"),           expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().pt():pt")),
+            cms.PSet(name=cms.string("GenJet_eta"),          expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().eta():eta")),
+            cms.PSet(name=cms.string("Jet_hadronFlavour"),   expr=cms.string("hadronFlavour()")),
+            cms.PSet(name=cms.string("Jet_pt"),              expr=cms.string("pt()")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavB"),   expr=cms.string("bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavCvB"), expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')):-1")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavCvL"), expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')):-1")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavQG"),  expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds'))>0?bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')):-1")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4B"),   expr=cms.string("bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4CvB"), expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'):-1")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4CvL"), expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'):-1")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4QvG"), expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'):-1")),
+        ),
+        inputTensorName  = cms.string("input"),
+        outputTensorName = cms.string("output"),
+        outputNames      = cms.vstring(
+            "ptrefined",
+            "btagDeepFlavBrefined","btagDeepFlavCvBrefined","btagDeepFlavCvLrefined","btagDeepFlavQGrefined",
+            "btagUParTAK4Brefined","btagUParTAK4CvBrefined","btagUParTAK4CvLrefined","btagUParTAK4QvGrefined",
+        ),
+        outputFormulas   = cms.vstring("at(0)","at(1)","at(2)","at(3)","at(4)","at(5)","at(6)","at(7)","at(8)"),
+    )
+
+    #publish refined values directly under the plain names (FastSim only) via externalVariables
+    #originals still available as *_unrefined 
+    fastSim.toModify(process.jetPuppiTable.externalVariables,
+        pt              = ExtVar(cms.InputTag("puppiJetRefineNN","ptrefined"),                 float, precision=10, doc="Refined pT (FastSim only)"),
+        btagDeepFlavB   = ExtVar(cms.InputTag("puppiJetRefineNN","btagDeepFlavBrefined"),      float, precision=10, doc="DeepJet b+bb+lepb (refined)"),
+        btagDeepFlavCvB = ExtVar(cms.InputTag("puppiJetRefineNN","btagDeepFlavCvBrefined"),    float, precision=10, doc="DeepJet c vs b+bb+lepb (refined)"),
+        btagDeepFlavCvL = ExtVar(cms.InputTag("puppiJetRefineNN","btagDeepFlavCvLrefined"),    float, precision=10, doc="DeepJet c vs udsg (refined)"),
+        btagDeepFlavQG  = ExtVar(cms.InputTag("puppiJetRefineNN","btagDeepFlavQGrefined"),     float, precision=10, doc="DeepJet g vs uds (refined)"),
+        btagUParTAK4B   = ExtVar(cms.InputTag("puppiJetRefineNN","btagUParTAK4Brefined"),      float, precision=10, doc="UParT BvsAll (refined)"),
+        btagUParTAK4CvB = ExtVar(cms.InputTag("puppiJetRefineNN","btagUParTAK4CvBrefined"),    float, precision=10, doc="UParT CvsB (refined)"),
+        btagUParTAK4CvL = ExtVar(cms.InputTag("puppiJetRefineNN","btagUParTAK4CvLrefined"),    float, precision=10, doc="UParT CvsL (refined)"),
+        btagUParTAK4QvG = ExtVar(cms.InputTag("puppiJetRefineNN","btagUParTAK4QvGrefined"),    float, precision=10, doc="UParT QvsG (refined)"),
+    )
+
+    fastSim.toModify(process.jetPuppiTablesTask, process.jetPuppiTablesTask.add(process.puppiJetRefineNN))
 
     return process
+
+
+
 
 nanoAOD_refineFastSim_puppiJet = nanoAOD_refineFastSim_puppiJet

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -215,14 +215,8 @@ jetPuppiTable.variables.muonSubtrDeltaEta = Var("userFloat('muonSubtrRawEta') - 
 jetPuppiTable.variables.muonSubtrDeltaPhi = Var("userFloat('muonSubtrRawPhi') - phi()",float,doc="muon-subtracted raw phi - phi",precision=10)
 
 jetPuppiForMETTask =  cms.Task(basicJetsPuppiForMetForT1METNano,corrT1METJetPuppiTable)
-
-#before cross linking
 jetPuppiUserDataTask = cms.Task(hfJetPuppiShowerShapeforNanoAOD)
-
-#before cross linking
 jetPuppiTask = cms.Task(jetPuppiCorrFactorsNano,updatedJetsPuppi,jetPuppiUserDataTask,updatedJetsPuppiWithUserData,finalJetsPuppi)
-
-#after cross linkining
 jetPuppiTablesTask = cms.Task(jetPuppiTable)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
@@ -261,12 +255,9 @@ def nanoAOD_refineFastSim_puppiJet(process):
         outputFormulas   = cms.vstring([f"at({i})" for i in range(9)]),
     )
 
-    # schedule it in the jet-building chain
     fastSim.toModify(process.jetPuppiTask, process.jetPuppiTask.add(process.puppiJetRefineNN))
 
-    #
-    # 1) now stuff those 9 refined scalars into the existing PATJetUserDataEmbedder
-    #
+    # 1) now stuff the 9 refined scalars into the existing PATJetUserDataEmbedder
     fastSim.toModify(process.updatedJetsPuppiWithUserData.userFloats,
         ptRefined              = cms.InputTag("puppiJetRefineNN","ptrefined"),
         btagDeepFlavBrefined   = cms.InputTag("puppiJetRefineNN","btagDeepFlavBrefined"),
@@ -279,9 +270,7 @@ def nanoAOD_refineFastSim_puppiJet(process):
         btagUParTAK4QvGrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4QvGrefined"),
     )
 
-    #
     # 2) backup all 9 originals in the NanoAOD table as *_unrefined
-    #
     fastSim.toModify(process.jetPuppiTable.variables,
         pt_unrefined               = process.jetPuppiTable.variables.pt.clone(),
         btagDeepFlavB_unrefined    = process.jetPuppiTable.variables.btagDeepFlavB.clone(),
@@ -301,9 +290,7 @@ def nanoAOD_refineFastSim_puppiJet(process):
         btagUParTAK4CvL=None, btagUParTAK4QvG=None,
     )
 
-    #
     # 3) re‑define each branch with a FastSim‑only mask ternary
-    #
     mask = "(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')>0)"
 
     fastSim.toModify(process.jetPuppiTable.variables,

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -315,13 +315,13 @@ def nanoAOD_refineFastSim_puppiJet(process):
     fastSim.toModify(process.jetPuppiTable.variables,
         pt = Var(f"?{_mask}?userFloat('ptrefined'):pt()", float, precision=10),
         btagDeepFlavB = Var(f"?{_mask}?userFloat('btagDeepFlavBrefined'):(bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))", float, precision=10),
-        btagDeepFlavCvB = Var(f"?{_mask}?userFloat('btagDeepFlavCvBrefined'):bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))", float, precision=10),
-        btagDeepFlavCvL = Var(f"?{_mask}?userFloat('btagDeepFlavCvLrefined'):bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg'))", float, precision=10),
-        btagDeepFlavQG = Var(f"?{_mask}?userFloat('btagDeepFlavQGrefined'):bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds'))", float, precision=10),
-        btagUParTAK4B = Var(f"?{_mask}?userFloat('btagUParTAK4Brefined'):bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')", float, precision=12),
-        btagUParTAK4CvB = Var(f"?{_mask}?userFloat('btagUParTAK4CvBrefined'):bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB')", float, precision=12),
-        btagUParTAK4CvL = Var(f"?{_mask}?userFloat('btagUParTAK4CvLrefined'):bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL')", float, precision=12),
-        btagUParTAK4QvG = Var(f"?{_mask}?userFloat('btagUParTAK4QvGrefined'):bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')", float, precision=12),        
+        btagDeepFlavCvB = Var(f"?{_mask}?userFloat('btagDeepFlavCvBrefined'):max(bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')),-1)", float, precision=10),#max(x,-1) safety because double-ternary not allowed 
+        btagDeepFlavCvL = Var(f"?{_mask}?userFloat('btagDeepFlavCvLrefined'):max(bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')),-1)", float, precision=10),#max(x,-1) safety because double-ternary not allowed 
+        btagDeepFlavQG = Var(f"?{_mask}?userFloat('btagDeepFlavQGrefined'):max(bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')),-1)", float, precision=10),#max(x,-1) safety because double-ternary not allowed 
+        btagUParTAK4B = Var(f"?{_mask}?userFloat('btagUParTAK4Brefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll'),-1)", float, precision=12),
+        btagUParTAK4CvB = Var(f"?{_mask}?userFloat('btagUParTAK4CvBrefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'),-1)", float, precision=12),
+        btagUParTAK4CvL = Var(f"?{_mask}?userFloat('btagUParTAK4CvLrefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'),-1)", float, precision=12),
+        btagUParTAK4QvG = Var(f"?{_mask}?userFloat('btagUParTAK4QvGrefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'),-1)", float, precision=12),        
     )
     return process
 

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -229,7 +229,7 @@ def nanoAOD_refineFastSim_puppiJet(process):
         batch_eval          = cms.bool(True),
         disableONNXGraphOpt = cms.bool(True),
         src                 = cms.InputTag("updatedJetsPuppi"),  # <<< HERE
-        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/model_refinement_regression_31July_long_opset11.onnx"),
+        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/model_fastsimrefine_puppi_31July2025.onnx"),
         name                = cms.string("puppiJetRefineNN"),
         variables = cms.VPSet(
             cms.PSet(name=cms.string("GenJet_pt"),            expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().pt():pt")),

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -229,7 +229,7 @@ def nanoAOD_refineFastSim_puppiJet(process):
         batch_eval          = cms.bool(True),
         disableONNXGraphOpt = cms.bool(True),
         src                 = cms.InputTag("updatedJetsPuppi"),  # <<< HERE
-        weightFile          = cms.FileInPath("model_refinement_regression_20250320_dynamic.onnx"),
+        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/model_fastsimrefine_puppi_31July2025.onnx"),
         name                = cms.string("puppiJetRefineNN"),
         variables = cms.VPSet(
             cms.PSet(name=cms.string("GenJet_pt"),            expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().pt():pt")),

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -229,7 +229,7 @@ def nanoAOD_refineFastSim_puppiJet(process):
         batch_eval          = cms.bool(True),
         disableONNXGraphOpt = cms.bool(True),
         src                 = cms.InputTag("updatedJetsPuppi"),  # <<< HERE
-        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/model_fastsimrefine_puppi_31July2025.onnx"),
+        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/fastSimPuppiJetRefineNN_31July2025.onnx"),
         name                = cms.string("puppiJetRefineNN"),
         variables = cms.VPSet(
             cms.PSet(name=cms.string("GenJet_pt"),            expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().pt():pt")),

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -310,7 +310,7 @@ def nanoAOD_refineFastSim_puppiJet(process):
 
     process.jetPuppiTable.src = cms.InputTag("finalJetsPuppiWithRefined")
 
-    #mask jets we shouldn't be refining - WARNING: the -1 safety in the definitions of the original flavor taggers cannot be implemented in the following. Multiple nested ternaries either crash the parser or confuse the logic and mess up the default values. 
+    #mask jets we shouldn't be refining - Note: the -1 safety in the definitions of the original flavor taggers cannot be implemented in the following, because nested ternaries either crash the parser or confuse the logic and mess up the default values. The max(x,-1) is used as an alternative. 
     _mask = "bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')>0"
     fastSim.toModify(process.jetPuppiTable.variables,
         pt = Var(f"?{_mask}?userFloat('ptrefined'):pt()", float, precision=10),

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -229,7 +229,7 @@ def nanoAOD_refineFastSim_puppiJet(process):
         batch_eval          = cms.bool(True),
         disableONNXGraphOpt = cms.bool(True),
         src                 = cms.InputTag("updatedJetsPuppi"),  # <<< HERE
-        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/model_fastsimrefine_puppi_31July2025.onnx"),
+        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/model_refinement_regression_31July_long_opset11.onnx"),
         name                = cms.string("puppiJetRefineNN"),
         variables = cms.VPSet(
             cms.PSet(name=cms.string("GenJet_pt"),            expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().pt():pt")),

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -305,10 +305,12 @@ def nanoAOD_customizeCommon(process):
         nanoAOD_boostedTau_switch, idsToAdd=["boostedDeepTauRunIIv2p0"]
     )
     nanoAOD_addBoostedTauIds(process, nanoAOD_boostedTau_switch.idsToAdd.value())
-
-    # Add lepton time-life info
+    
     from PhysicsTools.NanoAOD.leptonTimeLifeInfo_common_cff import addTimeLifeInfoBase
     process = addTimeLifeInfoBase(process)
+    
+    process = nanoAOD_refineFastSim_puppiJet(process)
+    process = nanoAOD_refineFastSim_bTagDeepFlav(process)
 
     return process
 


### PR DESCRIPTION
This PR accompanies a cms-data PR https://github.com/cms-data/PhysicsTools-NanoAOD/pull/20 containing the .onnx file.

This PR is the Run 3 version of an earlier Run 2 PR: https://github.com/cms-sw/cmssw/pull/40553, applying a correction to PUPPI jets in NANOAOD (previously was CHS jets for Run 2 UL). The PR effects only NANOAOD and NANOEDM files. 

We update the nano-config file needed for regression-based refinement are included for FastSim Run 3 ak4 PUPPI jet variables, effecting only the NANO-level collections: 

Jet_pt
Jet_btagDeepFlavB
Jet_btagDeepFlavCvB
Jet_btagDeepFlavCvL
Jet_btagDeepFlavQG
Jet_btagUParTAK4B
Jet_btagUParTAK4CvB
Jet_btagUParTAK4CvL
Jet_btagUParTAK4QvG

The results of the refinement compare the refined FastSim, original FastSim, and FullSim distributions for these variables:
https://www.desy.de/~beinsam/FastSim/Refinement/Jets/figs31July_long/index.html

The PR also adds 9 backup branches 

Jet_ptunrefined
Jet_btagDeepFlavBunrefined
Jet_btagDeepFlavCvBunrefined
Jet_btagDeepFlavCvLunrefined
Jet_btagDeepFlavQGunrefined
Jet_btagUParTAK4Bunrefined
Jet_btagUParTAK4CvBunrefined
Jet_btagUParTAK4CvLunrefined
Jet_btagUParTAK4QvGunrefined

which store the original values, as a temporary measure for risk mitigation. The preliminary version of these results were approved for CHEP24 and discussed in numerous FastSim meetings, e.g., 

https://indico.cern.ch/event/1545175/

and at the PAGs Jamboree: https://indico.cern.ch/event/1519600/contributions/6444135/attachments/3056422/5403783/Run3FastSimPagJamboree.pdf

