### PR TITLE
Implement `PathStateCapture` and `PathStateRelease`

### DIFF
--- a/DataFormats/Common/README.md
+++ b/DataFormats/Common/README.md
@@ -2,9 +2,26 @@
 
 ## `edm::TriggerResults`
 
-The class `edm::TriggerResults` is part of the RAW data, and any changes must be backwards compatible. In order to ensure it can be read by all future CMSSW releases, there is a `TestTriggerResultsFormat` unit test, which makes use of the `TestReadTriggerResults` analyzer and the `TestWriteTriggerResults` producer. The unit test checks that the object can be read properly from
+The class `edm::TriggerResults` is part of the RAW data, and any changes must be backwards compatible. In order to
+ensure it can be read by all future CMSSW releases, there is a `TestTriggerResultsFormat` unit test, which makes use of
+the `TestReadTriggerResults` analyzer and the `TestWriteTriggerResults` producer. The unit test checks that the object
+can be read properly from
 
 * a file in the same release as it was written
 * files written by (some) earlier releases can be read
 
-If the persistent format of class `edm::TriggerResults` gets changed in the future, please adjust the `TestReadTriggerResults` and `TestWriteTriggerResults` modules accordingly. It is important that every member container has some content in this test. Please also add a new file to [https://github.com/cms-data/DataFormats-Common/](https://github.com/cms-data/DataFormats-Common/) repository, and update the `TestTriggerResultsFormat` unit test to read the newly created file. The file name should contain the release or pre-release with which it was written.`
+If the persistent format of class `edm::TriggerResults` gets changed in the future, please adjust the
+`TestReadTriggerResults` and `TestWriteTriggerResults` modules accordingly. It is important that every member container
+has some content in this test. Please also add a new file to
+[https://github.com/cms-data/DataFormats-Common/](https://github.com/cms-data/DataFormats-Common/) repository, and
+update the `TestTriggerResultsFormat` unit test to read the newly created file. The file name should contain the release
+or pre-release with which it was written.`
+
+
+## `edm::PathStateToken`
+
+The type `edm::PathStateToken` is an empty struct; it is used to communicate the status (active or not) of an
+`edm::Path` at a given point where an `edm::PathStateCapture` module is scheduled: if the path is active, the module
+runs and produces the token; if the path is not active the module does not run and does not produce the token. While any
+product would work, the use of a dedicated empty type is more explicit. An `edm::PathStateToken` may be consumed by
+an `edm::PathStateRelease`, an `EDFilter` with a result of `true` if the token is present, `false` otherwise.

--- a/DataFormats/Common/interface/PathStateToken.h
+++ b/DataFormats/Common/interface/PathStateToken.h
@@ -1,0 +1,10 @@
+#ifndef DataFormats_Common_interface_PathStateToken_h
+#define DataFormats_Common_interface_PathStateToken_h
+
+namespace edm {
+
+  struct PathStateToken {};
+
+}  // namespace edm
+
+#endif  // DataFormats_Common_interface_PathStateToken_h

--- a/DataFormats/Common/src/classes.h
+++ b/DataFormats/Common/src/classes.h
@@ -16,6 +16,7 @@
 #include "DataFormats/Common/interface/IntValues.h"
 #include "DataFormats/Common/interface/MergeableCounter.h"
 #include "DataFormats/Common/interface/OwnVector.h"
+#include "DataFormats/Common/interface/PathStateToken.h"
 #include "DataFormats/Common/interface/Ptr.h"
 #include "DataFormats/Common/interface/PtrVector.h"
 #include "DataFormats/Common/interface/PtrVectorBase.h"

--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -208,4 +208,9 @@
  <class name="edm::StdArray<short, 4>"/>
  <class name="edm::StdArray<unsigned short, 11>"/>
  <class name="edm::StdArray<unsigned int, 4>"/>
+
+ <class name="edm::PathStateToken" ClassVersion="3">
+   <version ClassVersion="3" checksum="2219165191"/>
+ </class>
+ <class name="edm::Wrapper<edm::PathStateToken>"/>
 </lcgdict>

--- a/FWCore/Modules/src/PathStateCapture.cc
+++ b/FWCore/Modules/src/PathStateCapture.cc
@@ -1,0 +1,31 @@
+#include "DataFormats/Common/interface/PathStateToken.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+namespace edm {
+  class PathStateCapture : public global::EDProducer<> {
+  public:
+    explicit PathStateCapture(ParameterSet const& config) : token_(produces()) {}
+
+    void produce(StreamID sid, Event& event, EventSetup const& setup) const final { event.emplace(token_); }
+
+    static void fillDescriptions(ConfigurationDescriptions& descriptions);
+
+  private:
+    const edm::EDPutTokenT<PathStateToken> token_;
+  };
+
+  void PathStateCapture::fillDescriptions(ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    descriptions.addWithDefaultLabel(desc);
+    descriptions.setComment("This EDProducer produces an edm::PathStateToken.");
+  }
+}  // namespace edm
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+using edm::PathStateCapture;
+DEFINE_FWK_MODULE(PathStateCapture);

--- a/FWCore/Modules/src/PathStateRelease.cc
+++ b/FWCore/Modules/src/PathStateRelease.cc
@@ -1,0 +1,39 @@
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/PathStateToken.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+namespace edm {
+  class PathStateRelease : public global::EDFilter<> {
+  public:
+    explicit PathStateRelease(ParameterSet const& config)
+        : token_(consumes(config.getParameter<edm::InputTag>("state"))) {}
+
+    bool filter(StreamID sid, Event& event, EventSetup const& setup) const final {
+      return event.getHandle(token_).isValid();
+    }
+
+    static void fillDescriptions(ConfigurationDescriptions& descriptions);
+
+  private:
+    const edm::EDGetTokenT<PathStateToken> token_;
+  };
+
+  void PathStateRelease::fillDescriptions(ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("state", {"pathStateCapture"});
+    descriptions.addWithDefaultLabel(desc);
+    descriptions.setComment(
+        "This EDFilter tries to consume an edm::PathStateToken: if it finds it, it returns \"true\", otherwise "
+        "\"false\".");
+  }
+}  // namespace edm
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+using edm::PathStateRelease;
+DEFINE_FWK_MODULE(PathStateRelease);

--- a/FWCore/Modules/test/BuildFile.xml
+++ b/FWCore/Modules/test/BuildFile.xml
@@ -6,6 +6,8 @@
 
 <test name="TestFWCoreModulesEmptySourceFromEventIDs" command="cmsRun ${LOCALTOP}/src/FWCore/Modules/test/testEmptySourceFromEventIDs_cfg.py"/>
 
+<test name="testFWCoreModulesPathStateCaptureRelease" command="cmsRun ${LOCALTOP}/src/FWCore/Modules/test/testPathStateCaptureRelease_cfg.py"/>
+
 <test name="testGenericConsumer" command="${LOCALTOP}/src/FWCore/Modules/test/testGenericConsumer.sh"/>
 
 <bin file="test_catch2_*.cc" name="TestFWCoreModulesTP">

--- a/FWCore/Modules/test/testPathStateCaptureRelease_cfg.py
+++ b/FWCore/Modules/test/testPathStateCaptureRelease_cfg.py
@@ -1,0 +1,64 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1
+
+from FWCore.Modules.modules import EmptySource
+process.source = EmptySource()
+
+process.maxEvents.input = 20
+
+# accept one event out of two
+from FWCore.Modules.modules import Prescaler
+process.filter = Prescaler(
+    prescaleFactor = 2,
+    prescaleOffset = 0
+)
+
+# produce a PathStateToken when run, to indicate that its path is active for the current event
+from FWCore.Modules.modules import PathStateCapture
+process.pathStateCapture = PathStateCapture()
+
+# try to consume a PathStateToken: if it is found accept the event, otherwise reject it
+from FWCore.Modules.modules import PathStateRelease
+process.pathStateRelease = PathStateRelease(
+    state = 'pathStateCapture'
+)
+
+# select one event out of two and record the path's activity
+process.captured = cms.Path(
+    process.filter +
+    process.pathStateCapture
+)
+
+# replicate the activity of the original path
+process.released = cms.Path(
+    process.pathStateRelease
+)
+
+# compare the results of the "captured" and "released" paths
+from FWCore.Modules.modules import PathStatusFilter
+process.compare = PathStatusFilter(
+    logicalExpression = '(captured and released) or (not captured and not released)'
+)
+
+# schedule the comparison
+process.correct = cms.Path(
+    process.compare
+)
+
+# require that the comparison has been successful for every event
+from FWCore.Framework.modules import SewerModule
+process.require = SewerModule(
+    name = cms.string('require'),
+    shouldPass = process.maxEvents.input.value(),
+    SelectEvents = dict(
+        SelectEvents = 'correct'
+    )
+)
+
+process.endpath = cms.EndPath(
+    process.require
+)


### PR DESCRIPTION
#### PR description:

An `edm::PathStateCapture` produces an `edm::PathStateToken` when run.

The `edm::PathStateToken` is an empty struct, and acts as a "token"; it is used to communicate the status (active or not) of an `edm::Path` at a given point where an `edm::PathStateCapture` module is scheduled:
  - if the path is active, the module runs and produces the token;
  - if the path is not active the module does not run or produce the token.

While any product would work, the use of a dedicated empty type is more explicit.

An `edm::PathStateToken` may be consumed by an `edm::PathStateRelease`, an
`EDFilter` with a result of `true` if the token is present, `false` otherwise.

#### PR validation:

The new unit test passes.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport expected.