### PR TITLE
filling time variable when the hit is cleaned

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalBarrelRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalBarrelRecHitCreator.h
@@ -88,11 +88,9 @@ public:
           keep = false;
         }
       }
-
-      if (keep) {
-        rh.setTime(time);
-        rh.setDepth(1);
-      } else {
+      rh.setTime(time);
+      rh.setDepth(1);
+      if (!keep) {
         if (rcleaned)
           cleaned->push_back(std::move(out->back()));
         out->pop_back();

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
@@ -91,10 +91,10 @@ public:
         }
       }
 
-      if (keep) {
-        rh.setTime(time);
-        rh.setDepth(1);
-      } else {
+      rh.setTime(time);
+      rh.setDepth(1);
+
+      if (!keep) {
         if (rcleaned)
           cleaned->push_back(std::move(out->back()));
         out->pop_back();


### PR DESCRIPTION
#### PR description:

This PR fills the time variable for PFRecHits that have been "cleaned" . ie are rejected from the cleaned collection.

Its really not clear to me why one wouldnt do this in the first place, I cant think of a reason why you would want the time to be zero.   I'm guessing a bug as I cant think why you would want this. So far all the reasons I've come up with are werid.

Its motivated by https://github.com/cms-sw/cmssw/pull/48583  which saves the cleaned hits in scouting and I would like the time stored as well as it could be useful.  


As such this will be a backport to 15_0_X to run in the HLT and it does of course make a change to event output although I would argue its a bug fix.

If people insist,  I could adjust things to have the old behaviour in 15_0 by adding a parameter to enable/disable. But it seems clunky. 

So before this merges, I would like to understand what people want for the 15_0 behaviour. 

#### PR validation:

Cleaned hits now have the time variable

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This will be back ported to 15_0_X in a seperate PR

