### PR TITLE
Restore removal of all duplicate pixel hits in Phase-1 pixel raw to cluster

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
@@ -238,11 +238,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
         constexpr bool isPhase2 = std::is_base_of<pixelTopology::Phase2, TrackerTraits>::value;
         if constexpr (not isPhase2) {
           // packed words array used to store the pixelStatus of each pixel
-          auto& status = alpaka::declareSharedVar<uint32_t[pixelStatus::size], __COUNTER__>(acc);
+          auto& image = alpaka::declareSharedVar<uint32_t[pixelStatus::size], __COUNTER__>(acc);
 
           if (lastPixel > 1) {
             for (uint32_t i : cms::alpakatools::independent_group_elements(acc, pixelStatus::size)) {
-              status[i] = 0;
+              image[i] = 0;
             }
             alpaka::syncBlockThreads(acc);
 
@@ -250,7 +250,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
               // skip invalid pixels
               if (digi_view[i].moduleId() == ::pixelClustering::invalidModuleId)
                 continue;
-              pixelStatus::promote(acc, status, digi_view[i].xx(), digi_view[i].yy());
+              pixelStatus::promote(acc, image, digi_view[i].xx(), digi_view[i].yy());
             }
             alpaka::syncBlockThreads(acc);
 
@@ -258,7 +258,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
               // skip invalid pixels
               if (digi_view[i].moduleId() == ::pixelClustering::invalidModuleId)
                 continue;
-              if (pixelStatus::isDuplicate(status, digi_view[i].xx(), digi_view[i].yy())) {
+              if (pixelStatus::isDuplicate(image, digi_view[i].xx(), digi_view[i].yy())) {
                 digi_view[i].moduleId() = ::pixelClustering::invalidModuleId;
                 digi_view[i].rawIdArr() = 0;
               }


### PR DESCRIPTION
#### PR description:
This PR introduces back the removal of all duplicate pixel hits. This was recently changed, and discussed, in [PR#48580](https://github.com/cms-sw/cmssw/pull/48580#issuecomment-3104757100). Small changes in Phase-1 workflows are expected.

To be backported to 15.0.X, either with the modification of [PR#48581](https://github.com/cms-sw/cmssw/pull/48581) or a new PR.

#### PR validation:

 The standard battery of tests reported
```
44 29 27 24 7 0 0 0 0 0 0 tests passed, 6 14 1 0 0 0 0 0 0 0 0 failed
```
I believe all the failed tests are due to eos issues. All the (failed) logs contain messages such as:
```
Exception Message:
Failed to open the file 'root://xrootd-cms.infn.it//store/data/Run2011A/MinimumBias/RAW/v1/000/165/121/18E0AF9F-BA7F-E011-AC1C-001D09F24259.root'
```