### PR TITLE
filling time variable when the hit is cleaned : 15_0_X

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalBarrelRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalBarrelRecHitCreator.h
@@ -88,11 +88,9 @@ public:
           keep = false;
         }
       }
-
-      if (keep) {
-        rh.setTime(time);
-        rh.setDepth(1);
-      } else {
+      rh.setTime(time);
+      rh.setDepth(1);
+      if (!keep) {
         if (rcleaned)
           cleaned->push_back(std::move(out->back()));
         out->pop_back();

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
@@ -91,10 +91,10 @@ public:
         }
       }
 
-      if (keep) {
-        rh.setTime(time);
-        rh.setDepth(1);
-      } else {
+      rh.setTime(time);
+      rh.setDepth(1);
+
+      if (!keep) {
         if (rcleaned)
           cleaned->push_back(std::move(out->back()));
         out->pop_back();


### PR DESCRIPTION
#### PR description:

This PR fills the time variable for PFRecHits that have been "cleaned" . ie are rejected from the cleaned collection.

Its motivated by https://github.com/cms-sw/cmssw/pull/48583 which saves the cleaned hits in scouting and I would like the time stored as well as it could be useful and thus needs to be in 15_0_X to run in the HLT

#### PR validation:

Time is now in the cleaned rechits

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport of https://github.com/cms-sw/cmssw/pull/48602

@cms-sw/hlt-l2 FYI