### PR TITLE
Fix stack-use-after-scope in HLTGenResHistColl::fillHists

### DIFF
--- a/Validation/HLTrigger/src/HLTGenResHistColl.cc
+++ b/Validation/HLTrigger/src/HLTGenResHistColl.cc
@@ -1,4 +1,5 @@
 #include "Validation/HLTrigger/interface/HLTGenResHistColl.h"
+#include <optional>
 
 namespace {
   // function to get the trigger objects of a specific collection
@@ -141,20 +142,20 @@ void HLTGenResHistColl::bookHists(DQMStore::IBooker& iBooker) {
 void HLTGenResHistColl::fillHists(const HLTGenValObject& obj, edm::Handle<trigger::TriggerEvent>& triggerEvent) {
   // get the trigger objects of the collection
   auto keyRange = getTrigObjIndicesOfCollection(*triggerEvent, collectionName_, hltProcessName_);
-  const trigger::TriggerObject* bestMatch = nullptr;
+  std::optional<trigger::TriggerObject> bestMatch;
   float bestDR2 = dR2limit_;
   for (trigger::size_type key = keyRange.first; key < keyRange.second; ++key) {
     if (passFilterSelection(key, *triggerEvent)) {
       const trigger::TriggerObject objTrig = triggerEvent->getObjects().at(key);
       if (isEventLevelVariable_) {
         bestDR2 = 0;
-        bestMatch = &objTrig;
+        bestMatch = objTrig;
         break;
       } else {
         float dR2 = reco::deltaR2(obj, objTrig);
         if (dR2 < bestDR2) {
           bestDR2 = dR2;
-          bestMatch = &objTrig;
+          bestMatch = objTrig;
         }
       }
     }


### PR DESCRIPTION
#### PR description:

Fixes a stack-use-after-scope [reported](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_15_1_ASAN_X_2025-07-22-1100/pyRelValMatrixLogs/run/29834.999_TTbar_14TeV+Run4D110PU_PMXS1S2PR/step4_TTbar_14TeV+Run4D110PU_PMXS1S2PR.log#/98-98) by AddressSanitizer in `HLTGenResHistColl::fillHists` :

```
=================================================================
==3204981==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7ffe9b614500 at pc 0x153285b401c8 bp 0x7ffe9b6143b0 sp 0x7ffe9b6143a8
READ of size 20 at 0x7ffe9b614500 thread T0
    #0 0x153285b401c7 in HLTGenResHistColl::fillHists(HLTGenValObject const&, edm::Handle<trigger::TriggerEvent>&) (/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02899/el8_amd64_gcc12/cms/cmssw/CMSSW_15_1_ASAN_X_2025-07-22-1100/lib/el8_amd64_gcc12/libValidationHLTrigger.so+0x211c7)
    #1 0x153285f477aa in HLTGenResSource::analyze(edm::Event const&, edm::EventSetup const&) (/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02899/el8_amd64_gcc12/cms/cmssw/CMSSW_15_1_ASAN_X_2025-07-22-1100/lib/el8_amd64_gcc12/pluginValidationHLTriggerAuto.so+0x297aa)
    #2 0x15333f09d7a5 in edm::stream::EDProducerAdaptorBase::doEvent(edm::EventTransitionInfo const&, edm::ActivityRegistry*, edm::ModuleCallingContext const*) (/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02899/el8_amd64_gcc12/cms/cmssw/CMSSW_15_1_ASAN_X_2025-07-22-1100/lib/el8_amd64_gcc12/libFWCoreFramework.so+0xa9d7a5)
    #3 0x15333effb878 in edm::WorkerT<edm::stream::EDProducerAdaptorBase>::implDo(edm::EventTransitionInfo const&, edm::ModuleCallingContext const*) (/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02899/el8_amd64_gcc12/cms/cmssw/CMSSW_15_1_ASAN_X_2025-07-22-1100/lib/el8_amd64_gcc12/libFWCoreFramework.so+0x9fb878)
    #4 0x15333ec52399 in decltype ({parm#1}()) edm::convertException::wrap<edm::Worker::runModule<edm::OccurrenceTraits<edm::EventPrincipal, (edm::BranchActionType)1> >(edm::OccurrenceTraits<edm::EventPrincipal, (edm::BranchActionType)1>::TransitionInfoType const&, edm::StreamID, edm::ParentContext const&, edm::OccurrenceTraits<edm::EventPrincipal, (edm::BranchActionType)1>::Context const*)::{lambda()#1}>(edm::Worker::runModule<edm::OccurrenceTraits<edm::EventPrincipal, (edm::BranchActionType)1> >(edm::OccurrenceTraits<edm::EventPrincipal, (edm::BranchActionType)1>::TransitionInfoType const&, edm::StreamID, edm::ParentContext const&, edm::OccurrenceTraits<edm::EventPrincipal, (edm::BranchActionType)1>::Context const*)::{lambda()#1}) (/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02899/el8_amd64_gcc12/cms/cmssw/CMSSW_15_1_ASAN_X_2025-07-22-1100/lib/el8_amd64_gcc12/libFWCoreFramework.so+0x652399)
    #5 0x15333ec52a9b in std::__exception_ptr::exception_ptr edm::Worker::runModuleAfterAsyncPrefetch<edm::OccurrenceTraits<edm::EventPrincipal, (edm::BranchActionType)1> >(std::__exception_ptr::exception_ptr, edm::OccurrenceTraits<edm::EventPrincipal, (edm::BranchActionType)1>::TransitionInfoType const&, edm::StreamID, edm::ParentContext const&, edm::OccurrenceTraits<edm::EventPrincipal, (edm::BranchActionType)1>::Context const*) (/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02899/el8_amd64_gcc12/cms/cmssw/CMSSW_15_1_ASAN_X_2025-07-22-1100/lib/el8_amd64_gcc12/libFWCoreFramework.so+0x652a9b)
    #6 0x15333ec635ec in edm::Worker::RunModuleTask<edm::OccurrenceTraits<edm::EventPrincipal, (edm::BranchActionType)1> >::execute() (/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02899/el8_amd64_gcc12/cms/cmssw/CMSSW_15_1_ASAN_X_2025-07-22-1100/lib/el8_amd64_gcc12/libFWCoreFramework.so+0x6635ec)
    #7 0x15333fac2e92 in tbb::detail::d2::function_task<edm::WaitingTaskList::announce()::{lambda()#1}>::execute(tbb::detail::d1::execution_data&) (/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02899/el8_amd64_gcc12/cms/cmssw/CMSSW_15_1_ASAN_X_2025-07-22-1100/lib/el8_amd64_gcc12/libFWCoreConcurrency.so+0x16e92)
    #8 0x15333f2c287a in tbb::detail::d1::task* tbb::detail::r1::task_dispatcher::local_wait_for_all<false, tbb::detail::r1::external_waiter>(tbb::detail::d1::task*, tbb::detail::r1::external_waiter&) /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2022.0.0-79b5a917b0c13f831cd534a5b9f53a95/tbb-v2022.0.0/src/tbb/task_dispatcher.h:334
    #9 0x15333f2c287a in tbb::detail::d1::task* tbb::detail::r1::task_dispatcher::local_wait_for_all<tbb::detail::r1::external_waiter>(tbb::detail::d1::task*, tbb::detail::r1::external_waiter&) /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2022.0.0-79b5a917b0c13f831cd534a5b9f53a95/tbb-v2022.0.0/src/tbb/task_dispatcher.h:470
    #10 0x15333f2c287a in tbb::detail::r1::task_dispatcher::execute_and_wait(tbb::detail::d1::task*, tbb::detail::d1::wait_context&, tbb::detail::d1::task_group_context&) /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2022.0.0-79b5a917b0c13f831cd534a5b9f53a95/tbb-v2022.0.0/src/tbb/task_dispatcher.cpp:168
    #11 0x15333e97b14c in edm::FinalWaitingTask::wait() (/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02899/el8_amd64_gcc12/cms/cmssw/CMSSW_15_1_ASAN_X_2025-07-22-1100/lib/el8_amd64_gcc12/libFWCoreFramework.so+0x37b14c)
    #12 0x15333e9284dc in edm::EventProcessor::processRuns() (/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02899/el8_amd64_gcc12/cms/cmssw/CMSSW_15_1_ASAN_X_2025-07-22-1100/lib/el8_amd64_gcc12/libFWCoreFramework.so+0x3284dc)
    #13 0x15333e9542bd in edm::EventProcessor::runToCompletion() (/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02899/el8_amd64_gcc12/cms/cmssw/CMSSW_15_1_ASAN_X_2025-07-22-1100/lib/el8_amd64_gcc12/libFWCoreFramework.so+0x3542bd)
    #14 0x40ceb4 in tbb::detail::d1::task_arena_function<main::{lambda()#1}::operator()() const::{lambda()#1}, void>::operator()() const (/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02899/el8_amd64_gcc12/cms/cmssw/CMSSW_15_1_ASAN_X_2025-07-22-1100/bin/el8_amd64_gcc12/cmsRun+0x40ceb4)
    #15 0x15333f2b0f70 in tbb::detail::r1::task_arena_impl::execute(tbb::detail::d1::task_arena_base&, tbb::detail::d1::delegate_base&) /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2022.0.0-79b5a917b0c13f831cd534a5b9f53a95/tbb-v2022.0.0/src/tbb/arena.cpp:821
    #16 0x414958 in main::{lambda()#1}::operator()() const (/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02899/el8_amd64_gcc12/cms/cmssw/CMSSW_15_1_ASAN_X_2025-07-22-1100/bin/el8_amd64_gcc12/cmsRun+0x414958)
    #17 0x4087d6 in main (/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02899/el8_amd64_gcc12/cms/cmssw/CMSSW_15_1_ASAN_X_2025-07-22-1100/bin/el8_amd64_gcc12/cmsRun+0x4087d6)
    #18 0x15333d2637e4 in __libc_start_main (/lib64/libc.so.6+0x3a7e4)
    #19 0x408b8d in _start (/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02899/el8_amd64_gcc12/cms/cmssw/CMSSW_15_1_ASAN_X_2025-07-22-1100/bin/el8_amd64_gcc12/cmsRun+0x408b8d)

Address 0x7ffe9b614500 is located in stack of thread T0 at offset 192 in frame
    #0 0x153285b3eaef in HLTGenResHistColl::fillHists(HLTGenValObject const&, edm::Handle<trigger::TriggerEvent>&) (/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02899/el8_amd64_gcc12/cms/cmssw/CMSSW_15_1_ASAN_X_2025-07-22-1100/lib/el8_amd64_gcc12/libValidationHLTrigger.so+0x1faef)

  This frame has 11 object(s):
    [32, 33) '<unknown>'
    [48, 52) '<unknown>'
    [64, 72) '__for_begin' (line 165)
    [96, 104) '__for_end' (line 165)
    [128, 136) '<unknown>'
    [160, 168) '<unknown>'
    [192, 212) 'objTrig' (line 148) <== Memory access at offset 192 is inside this variable
    [256, 288) 'collection' (line 10)
    [320, 408) 'objWithTrig' (line 162)
    [448, 568) '<unknown>'
    [608, 728) '<unknown>'
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-use-after-scope (/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02899/el8_amd64_gcc12/cms/cmssw/CMSSW_15_1_ASAN_X_2025-07-22-1100/lib/el8_amd64_gcc12/libValidationHLTrigger.so+0x211c7) in HLTGenResHistColl::fillHists(HLTGenValObject const&, edm::Handle<trigger::TriggerEvent>&)
Shadow bytes around the buggy address:
  0x1000536ba850: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1000536ba860: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1000536ba870: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1000536ba880: 00 00 00 00 00 00 00 00 f1 f1 f1 f1 f8 f2 f8 f2
  0x1000536ba890: 00 f2 f2 f2 00 f2 f2 f2 00 f2 f2 f2 00 f2 f2 f2
=>0x1000536ba8a0:[f8]f8 f8 f2 f2 f2 f2 f2 f8 f8 f8 f8 f2 f2 f2 f2
  0x1000536ba8b0: 00 00 00 00 00 00 00 00 00 00 00 f2 f2 f2 f2 f2
  0x1000536ba8c0: f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f2
  0x1000536ba8d0: f2 f2 f2 f2 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8
  0x1000536ba8e0: f8 f8 f8 f3 f3 f3 f3 f3 00 00 00 00 00 00 00 00
  0x1000536ba8f0: 00 00 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==3204981==ABORTING
```

The issue was due to storing a pointer to a temporary TriggerObject created inside a loop.
This PR replaces the raw pointer with a `std::optional<trigger::TriggerObject>` to ensure proper object lifetime and avoid undefined behavior.
No changes are expected in the output.

#### PR validation:

Local tests.
