### PR TITLE
[15.0.X] Restore removal of all duplicate pixel hits in Phase-1 pixel raw to cluster

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
@@ -17,6 +17,34 @@
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/warpsize.h"
 
+// TODO move to HeterogeneousCore/AlpakaInterface or upstream to alpaka
+template <typename TAcc, typename T>
+ALPAKA_FN_ACC inline T atomicLoadFromShared(TAcc const& acc [[maybe_unused]], T* arg) {
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) or defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+  // GPU backend, use a volatile read to force a non-cached acess
+  return *reinterpret_cast<volatile T*>(arg);
+#elif defined(ALPAKA_ACC_SYCL_ENABLED)
+  // SYCL backend, use an atomic load
+  sycl::atomic_ref<uint32_t,
+                   sycl::memory_order::relaxed,
+                   sycl::memory_scope::work_group,
+                   sycl::access::address_space::local_space>
+      ref{*arg};
+  return ref.load();
+#elif defined(ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED) or defined(ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED)
+  // CPU backend with multiple threads per block, use an atomic load
+  std::atomic_ref<uint32_t> ref{*arg};
+  return ref.load();
+#elif defined(ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED) or defined(ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED) or \
+    defined(ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED)
+  // CPU backend with one thread per block, use a standard read
+  return *arg;
+#else
+#error "Unsupported alpaka backend"
+  return T{};
+#endif
+}
+
 //#define GPU_DEBUG
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
@@ -27,15 +55,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
 
   namespace pixelStatus {
     // Phase-1 pixel modules
-    constexpr uint32_t pixelSizeX = pixelTopology::Phase1::numRowsInModule;
-    constexpr uint32_t pixelSizeY = pixelTopology::Phase1::numColsInModule;
+    constexpr uint32_t pixelSizeX = pixelTopology::Phase1::numRowsInModule;  // 2 x 80 = 160
+    constexpr uint32_t pixelSizeY = pixelTopology::Phase1::numColsInModule;  // 8 x 52 = 416
 
-    // Use 0x00, 0x01, 0x03 so each can be OR'ed on top of the previous ones
     enum Status : uint32_t { kEmpty = 0x00, kFound = 0x01, kDuplicate = 0x03 };
 
     constexpr uint32_t bits = 2;
     constexpr uint32_t mask = (0x01 << bits) - 1;
-    constexpr uint32_t valuesPerWord = sizeof(uint32_t) * 8 / bits;
+    constexpr uint32_t valuesPerWord = sizeof(uint32_t) * 8 / bits;  // 16 values per 32-bit word
     constexpr uint32_t size = pixelSizeX * pixelSizeY / valuesPerWord;
 
     ALPAKA_FN_ACC ALPAKA_FN_INLINE constexpr uint32_t getIndex(uint16_t x, uint16_t y) {
@@ -43,9 +70,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
     }
 
     ALPAKA_FN_ACC ALPAKA_FN_INLINE constexpr uint32_t getShift(uint16_t x, uint16_t y) {
-      return (x % valuesPerWord) * 2;
+      return (x % valuesPerWord) * bits;
     }
 
+    // Return the current status of a pixel based on its coordinates.
     ALPAKA_FN_ACC ALPAKA_FN_INLINE constexpr Status getStatus(uint32_t const* __restrict__ status,
                                                               uint16_t x,
                                                               uint16_t y) {
@@ -54,38 +82,28 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
       return Status{(status[index] >> shift) & mask};
     }
 
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE constexpr bool isDuplicate(uint32_t const* __restrict__ status,
-                                                              uint16_t x,
-                                                              uint16_t y) {
-      return getStatus(status, x, y) == kDuplicate;
-    }
-
-    /* FIXME
-       * In the more general case (e.g. a multithreaded CPU backend) there is a potential race condition
-       * between the read of status[index] at line NNN and the atomicCas at line NNN.
-       * We should investigate:
-       *   - if `status` should be read through a `volatile` pointer (CUDA/ROCm)
-       *   - if `status` should be read with an atomic load (CPU)
-       */
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE constexpr void promote(Acc1D const& acc,
-                                                          uint32_t* __restrict__ status,
-                                                          const uint16_t x,
-                                                          const uint16_t y) {
+    // Record a pixel at the given coordinates and return the updated status.
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE Status promote(Acc1D const& acc,
+                                                  uint32_t* status,
+                                                  const uint16_t x,
+                                                  const uint16_t y) {
       uint32_t index = getIndex(x, y);
       uint32_t shift = getShift(x, y);
-      uint32_t old_word = status[index];
-      uint32_t expected = old_word;
+      uint32_t old_word = atomicLoadFromShared(acc, status + index);
+      uint32_t expected;
+      Status new_status;
       do {
         expected = old_word;
         Status old_status{(old_word >> shift) & mask};
         if (kDuplicate == old_status) {
-          // nothing to do
-          return;
+          // this pixel has already been marked as duplicate
+          return kDuplicate;
         }
-        Status new_status = (kEmpty == old_status) ? kFound : kDuplicate;
+        new_status = (kEmpty == old_status) ? kFound : kDuplicate;
         uint32_t new_word = old_word | (static_cast<uint32_t>(new_status) << shift);
         old_word = alpaka::atomicCas(acc, &status[index], expected, new_word, alpaka::hierarchy::Blocks{});
       } while (expected != old_word);
+      return new_status;
     }
 
   }  // namespace pixelStatus
@@ -214,27 +232,21 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
         constexpr bool isPhase2 = std::is_base_of<pixelTopology::Phase2, TrackerTraits>::value;
         if constexpr (not isPhase2) {
           // packed words array used to store the pixelStatus of each pixel
-          auto& status = alpaka::declareSharedVar<uint32_t[pixelStatus::size], __COUNTER__>(acc);
+          auto& image = alpaka::declareSharedVar<uint32_t[pixelStatus::size], __COUNTER__>(acc);
 
           if (lastPixel > 1) {
             for (uint32_t i : cms::alpakatools::independent_group_elements(acc, pixelStatus::size)) {
-              status[i] = 0;
+              image[i] = 0;
             }
             alpaka::syncBlockThreads(acc);
 
-            for (uint32_t i : cms::alpakatools::independent_group_elements(acc, firstPixel, lastPixel - 1)) {
+            for (uint32_t i : cms::alpakatools::independent_group_elements(acc, firstPixel, lastPixel)) {
               // skip invalid pixels
               if (digi_view[i].moduleId() == ::pixelClustering::invalidModuleId)
                 continue;
-              pixelStatus::promote(acc, status, digi_view[i].xx(), digi_view[i].yy());
-            }
-            alpaka::syncBlockThreads(acc);
-
-            for (uint32_t i : cms::alpakatools::independent_group_elements(acc, firstPixel, lastPixel - 1)) {
-              // skip invalid pixels
-              if (digi_view[i].moduleId() == ::pixelClustering::invalidModuleId)
-                continue;
-              if (pixelStatus::isDuplicate(status, digi_view[i].xx(), digi_view[i].yy())) {
+              auto status = pixelStatus::promote(acc, image, digi_view[i].xx(), digi_view[i].yy());
+              if (pixelStatus::kDuplicate == status) {
+                // mark the duplicate pixel as invalid
                 digi_view[i].moduleId() = ::pixelClustering::invalidModuleId;
                 digi_view[i].rawIdArr() = 0;
               }
@@ -253,7 +265,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
 #endif
           }
         }
-        alpaka::syncBlockThreads(acc);  // FIXME this can be removed
         for (uint32_t i : cms::alpakatools::independent_group_elements(acc, warpSize)) {
           ws[i] = 0;  // used by prefix scan...
         }
@@ -310,8 +321,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
         constexpr unsigned int maxIter = maxIterGPU * maxElements;
 
         // nearest neighbours (nn)
-        // allocate space for duplicate pixels: a pixel can appear more than once with different charge in the same event
-        constexpr int maxNeighbours = 10;
+        constexpr int maxNeighbours = 8;
         uint16_t nn[maxIter][maxNeighbours];
         uint8_t nnn[maxIter];  // number of nn
         for (uint32_t k = 0; k < maxIter; ++k) {
@@ -350,16 +360,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
         // when two valid pixels within +/- 1 in x or y are found, set their id to the minimum;
         // after the loop, all the pixel in each cluster should have the id equeal to the lowest
         // pixel in the cluster ( clus[i] == i ).
-        bool more = true;
-        /*
-          int nloops = 0;
-          */
-        while (alpaka::syncBlockThreadsPredicate<alpaka::BlockOr>(acc, more)) {
-          /*
-            if (nloops % 2 == 0) {
-              // even iterations of the outer loop
-            */
-          more = false;
+        bool done = false;
+        while (alpaka::syncBlockThreadsPredicate<alpaka::BlockOr>(acc, not done)) {
+          done = true;
           uint32_t k = 0;
           for (uint32_t j : cms::alpakatools::independent_group_elements(acc, hist.size())) {
             ALPAKA_ASSERT_ACC(k < maxIter);
@@ -369,22 +372,17 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
               auto l = nn[k][kk];
               auto m = l + firstPixel;
               ALPAKA_ASSERT_ACC(m != i);
-              // FIXME ::Threads ?
-              auto old = alpaka::atomicMin(acc, &digi_view[m].clus(), digi_view[i].clus(), alpaka::hierarchy::Blocks{});
+              // the algorithm processes one module per block, so the atomic operation's scope is "Threads" (all threads in the current block)
+              auto old =
+                  alpaka::atomicMin(acc, &digi_view[m].clus(), digi_view[i].clus(), alpaka::hierarchy::Threads{});
               if (old != digi_view[i].clus()) {
                 // end the loop only if no changes were applied
-                more = true;
+                done = false;
               }
-              // FIXME ::Threads ?
-              alpaka::atomicMin(acc, &digi_view[i].clus(), old, alpaka::hierarchy::Blocks{});
+              alpaka::atomicMin(acc, &digi_view[i].clus(), old, alpaka::hierarchy::Threads{});
             }  // neighbours loop
             ++k;
           }  // pixel loop
-          /*
-              // use the outer loop to force a synchronisation
-            } else {
-              // odd iterations of the outer loop
-            */
           alpaka::syncBlockThreads(acc);
           for (uint32_t j : cms::alpakatools::independent_group_elements(acc, hist.size())) {
             auto p = hist.begin() + j;
@@ -394,23 +392,19 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
               m = digi_view[m].clus();
             digi_view[i].clus() = m;
           }
-          /*
-            }
-            ++nloops;
-            */
         }  // end while
 
         /*
-            // check that all threads in the block have executed the same number of iterations
-            auto& n0 = alpaka::declareSharedVar<int, __COUNTER__>(acc);
-            if (cms::alpakatools::once_per_block(acc))
-              n0 = nloops;
-            alpaka::syncBlockThreads(acc);
-            ALPAKA_ASSERT_ACC(alpaka::syncBlockThreadsPredicate<alpaka::BlockAnd>(acc, nloops == n0));
-            if (thisModuleId % 100 == 1)
-              if (cms::alpakatools::once_per_block(acc))
-                printf("# loops %d\n", nloops);
-          */
+        // check that all threads in the block have executed the same number of iterations
+        auto& n0 = alpaka::declareSharedVar<int, __COUNTER__>(acc);
+        if (cms::alpakatools::once_per_block(acc))
+          n0 = nloops;
+        alpaka::syncBlockThreads(acc);
+        ALPAKA_ASSERT_ACC(alpaka::syncBlockThreadsPredicate<alpaka::BlockAnd>(acc, nloops == n0));
+        if (thisModuleId % 100 == 1)
+          if (cms::alpakatools::once_per_block(acc))
+            printf("# loops %d\n", nloops);
+        */
 
         auto& foundClusters = alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
         foundClusters = 0;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
@@ -238,11 +238,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
         constexpr bool isPhase2 = std::is_base_of<pixelTopology::Phase2, TrackerTraits>::value;
         if constexpr (not isPhase2) {
           // packed words array used to store the pixelStatus of each pixel
-          auto& status = alpaka::declareSharedVar<uint32_t[pixelStatus::size], __COUNTER__>(acc);
+          auto& image = alpaka::declareSharedVar<uint32_t[pixelStatus::size], __COUNTER__>(acc);
 
           if (lastPixel > 1) {
             for (uint32_t i : cms::alpakatools::independent_group_elements(acc, pixelStatus::size)) {
-              status[i] = 0;
+              image[i] = 0;
             }
             alpaka::syncBlockThreads(acc);
 
@@ -250,7 +250,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
               // skip invalid pixels
               if (digi_view[i].moduleId() == ::pixelClustering::invalidModuleId)
                 continue;
-              pixelStatus::promote(acc, status, digi_view[i].xx(), digi_view[i].yy());
+              pixelStatus::promote(acc, image, digi_view[i].xx(), digi_view[i].yy());
             }
             alpaka::syncBlockThreads(acc);
 
@@ -258,7 +258,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
               // skip invalid pixels
               if (digi_view[i].moduleId() == ::pixelClustering::invalidModuleId)
                 continue;
-              if (pixelStatus::isDuplicate(status, digi_view[i].xx(), digi_view[i].yy())) {
+              if (pixelStatus::isDuplicate(image, digi_view[i].xx(), digi_view[i].yy())) {
                 digi_view[i].moduleId() = ::pixelClustering::invalidModuleId;
                 digi_view[i].rawIdArr() = 0;
               }


### PR DESCRIPTION
#### PR description:

Fixes a bug in the heterogeneous pixel raw-to-cluster module:
 - Include in the output the last pixel of each module. The current implementation ignores the last pixel of each module, and nobody seems to know why.

Implements a few small optimisations:
- Adjust the number of nearest neighbours after duplicate removal.
- Remove an unnecessary synchronisation.

Small changes in Phase-1 workflows are expected.

#### PR validation:

`runTheMatrix` tests are finished with

```
49 44 42 38 18 1 1 1 1 1 1 tests passed, 1 4 0 0 0 0 0 0 0 0 0 failed
```

The failed wfs all failed because of eos issues with errors such as
```
Exception Message:
Failed to open the file 'root://xrootd-cms.infn.it//store/relval/CMSSW_10_6_0/RelValMinBias_13/GEN-SIM/106X_upgrade2018_realistic_v4-v1/10000/48654250-08E9-1D43-AE35-5DF5D6101B2F.root'
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of [#48580](https://github.com/cms-sw/cmssw/pull/48580) and [#48609](https://github.com/cms-sw/cmssw/pull/48609).

The backport of [#48580](https://github.com/cms-sw/cmssw/pull/48580) was previously attempted in [#48581](https://github.com/cms-sw/cmssw/pull/48581), but was blocked after the original PR had already been merged to master. The reason was that it would allow the first instances of duplicate pixel hits to be clustered.

This issue was addressed by [#48609](https://github.com/cms-sw/cmssw/pull/48609), which effectively reverts that part of [#48580](https://github.com/cms-sw/cmssw/pull/48580).

This PR backports both PRs together, to maintain consistency with master while avoiding the unintended behavior from [#48580](https://github.com/cms-sw/cmssw/pull/48580) alone.
