### PR TITLE
Added SoABlocks feature

### DIFF
--- a/DataFormats/Portable/interface/PortableCollectionCommon.h
+++ b/DataFormats/Portable/interface/PortableCollectionCommon.h
@@ -98,6 +98,10 @@ namespace portablecollection {
   template <typename T, typename... Args>
   inline constexpr std::size_t typeIndex = TypeIndex<T, Args...>::value;
 
+  // concept to check if a Layout has a static member blocksNumber
+  template <class L>
+  concept hasBlocksNumber = requires { L::blocksNumber; };
+
 }  // namespace portablecollection
 
 #endif  // DataFormats_Portable_interface_PortableCollectionCommon_h

--- a/DataFormats/Portable/test/BuildFile.xml
+++ b/DataFormats/Portable/test/BuildFile.xml
@@ -1,15 +1,24 @@
 <bin name="TestDataFormatsPortableOnHost" file="test_catch2_*.cc">
-  <use name="DataFormats/Portable"/>
-  <use name="DataFormats/SoATemplate"/>
   <use name="catch2"/>
   <use name="eigen"/>
+  <use name="DataFormats/Portable"/>
+  <use name="DataFormats/SoATemplate"/>
 </bin>
 
 <bin name="TestDataFormatsPortableHeterogenous" file="alpaka/test_catch2_heterogeneousDeepCopy.dev.cc">
-  <use name="DataFormats/Portable"/>
-  <use name="DataFormats/SoATemplate"/>
   <use name="catch2"/>
   <use name="eigen"/>
+  <use name="DataFormats/Portable"/>
+  <use name="DataFormats/SoATemplate"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <flags ALPAKA_BACKENDS="1"/>
+</bin>
+
+<bin name="TestDataFormatsPortableSoABlocks" file="alpaka/test_catch2_heterogeneousSoABlocks.dev.cc">
+  <use name="catch2"/>
+  <use name="eigen"/>
+  <use name="DataFormats/Portable"/>
+  <use name="DataFormats/SoATemplate"/>
   <use name="HeterogeneousCore/AlpakaInterface"/>
   <flags ALPAKA_BACKENDS="1"/>
 </bin>

--- a/DataFormats/Portable/test/alpaka/test_catch2_heterogeneousSoABlocks.dev.cc
+++ b/DataFormats/Portable/test/alpaka/test_catch2_heterogeneousSoABlocks.dev.cc
@@ -1,0 +1,161 @@
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+#include <alpaka/alpaka.hpp>
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_all.hpp>
+
+#include "DataFormats/SoATemplate/interface/SoABlocks.h"
+#include "DataFormats/Portable/interface/PortableCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+
+using namespace ALPAKA_ACCELERATOR_NAMESPACE;
+
+// This test checks the correctness of using SoABlocks with PortableCollections.
+
+GENERATE_SOA_LAYOUT(NodesT, SOA_COLUMN(int, id), SOA_SCALAR(int, count))
+
+using Nodes = NodesT<>;
+
+GENERATE_SOA_LAYOUT(EdgesT, SOA_COLUMN(int, src), SOA_COLUMN(int, dst), SOA_COLUMN(float, cost), SOA_SCALAR(int, count))
+
+using Edges = EdgesT<>;
+
+GENERATE_SOA_BLOCKS(GraphT, SOA_BLOCK(nodes, NodesT), SOA_BLOCK(edges, EdgesT))
+
+using Graph = GraphT<>;
+using GraphView = Graph::View;
+using GraphConstView = Graph::ConstView;
+
+// Fill SoAs
+struct FillSoAs {
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, Nodes::View nodes, Edges::View edges) const {
+    const int N = static_cast<int>(nodes.metadata().size());
+    const int E = static_cast<int>(edges.metadata().size());
+
+    // Fill nodes with the indexes
+    for (auto i : cms::alpakatools::uniform_elements(acc, nodes.metadata().size())) {
+      nodes[i].id() = static_cast<int>(i);
+    }
+    if (cms::alpakatools::once_per_grid(acc)) {
+      nodes.count() = N;
+    }
+
+    // Fill edges with some arbitrary but deterministic values
+    for (auto j : cms::alpakatools::uniform_elements(acc, edges.metadata().size())) {
+      int src = static_cast<int>(j % N);
+      int dst = static_cast<int>((j * 7 + 3) % N);
+      edges[j].src() = src;
+      edges[j].dst() = dst;
+      edges[j].cost() = 0.5f * float(src + dst);
+    }
+    if (cms::alpakatools::once_per_grid(acc)) {
+      edges.count() = E;
+    }
+  }
+};
+
+// Fill SoABlocks
+struct FillBlocks {
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, GraphView blocksView) const {
+    const int N = static_cast<int>(blocksView.nodes().metadata().size());
+    const int E = static_cast<int>(blocksView.edges().metadata().size());
+
+    // Fill nodes with the indexes
+    for (auto i : cms::alpakatools::uniform_elements(acc, blocksView.nodes().metadata().size())) {
+      blocksView.nodes()[i].id() = static_cast<int>(i);
+    }
+    if (cms::alpakatools::once_per_grid(acc)) {
+      blocksView.nodes().count() = N;
+    }
+
+    // Fill edges with some arbitrary but deterministic values
+    for (auto j : cms::alpakatools::uniform_elements(acc, blocksView.edges().metadata().size())) {
+      int src = static_cast<int>(j % N);
+      int dst = static_cast<int>((j * 7 + 3) % N);
+      blocksView.edges()[j].src() = src;
+      blocksView.edges()[j].dst() = dst;
+      blocksView.edges()[j].cost() = 0.5f * float(src + dst);
+    }
+    if (cms::alpakatools::once_per_grid(acc)) {
+      blocksView.edges().count() = E;
+    }
+  }
+};
+
+TEST_CASE("SoABlocks minimal graph in heterogeneous environment") {
+  auto const& devices = cms::alpakatools::devices<Platform>();
+  if (devices.empty()) {
+    std::cout << "No devices available for the " << EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE)
+              << " backend, skipping.\n";
+    return;
+  }
+
+  for (auto const& device : devices) {
+    std::cout << "Running on " << alpaka::getName(device) << std::endl;
+    Queue queue(device);
+
+    // Number of elements
+    const int N = 50;
+    const int E = 120;
+
+    // Portable Collections for SoAs
+    PortableCollection<Nodes, Device> nodesCollection(N, queue);
+    PortableCollection<Edges, Device> edgesCollection(E, queue);
+    Nodes::View& nodesCollectionView = nodesCollection.view();
+    Edges::View& edgesCollectionView = edgesCollection.view();
+
+    // Portable Collection for SoABlocks
+    PortableCollection<Graph, Device> graphCollection(queue, N, E);
+    GraphView& graphCollectionView = graphCollection.view();
+
+    // Work division
+    const std::size_t blockSize = 256;
+    const std::size_t maxElems = std::max<std::size_t>(N, E);
+    const std::size_t numberOfBlocks = cms::alpakatools::divide_up_by(maxElems, blockSize);
+    const auto workDiv = cms::alpakatools::make_workdiv<Acc1D>(numberOfBlocks, blockSize);
+
+    // Fill: separate e blocks
+    alpaka::exec<Acc1D>(queue, workDiv, FillSoAs{}, nodesCollectionView, edgesCollectionView);
+    alpaka::exec<Acc1D>(queue, workDiv, FillBlocks{}, graphCollectionView);
+    alpaka::wait(queue);
+
+    // Check results on host
+    PortableHostCollection<Nodes> nodesHost(N, cms::alpakatools::host());
+    PortableHostCollection<Edges> edgesHost(E, cms::alpakatools::host());
+    PortableHostCollection<Graph> graphHost(cms::alpakatools::host(), N, E);
+
+    alpaka::memcpy(queue, nodesHost.buffer(), nodesCollection.buffer());
+    alpaka::memcpy(queue, edgesHost.buffer(), edgesCollection.buffer());
+    alpaka::memcpy(queue, graphHost.buffer(), graphCollection.buffer());
+    alpaka::wait(queue);
+
+    const Nodes::ConstView nodesHostView = nodesHost.const_view();
+    const Edges::ConstView edgesHostView = edgesHost.const_view();
+    const GraphConstView graphHostView = graphHost.const_view();
+
+    // Nodes
+    REQUIRE(graphHostView.nodes().count() == N);
+    for (int i = 0; i < N; ++i) {
+      REQUIRE(graphHostView.nodes()[i].id() == nodesHostView[i].id());
+      REQUIRE(graphHostView.nodes()[i].id() == i);
+    }
+
+    // Edges
+    REQUIRE(graphHostView.edges().count() == E);
+    for (int j = 0; j < E; ++j) {
+      REQUIRE(graphHostView.edges()[j].src() == edgesHostView[j].src());
+      REQUIRE(graphHostView.edges()[j].dst() == edgesHostView[j].dst());
+      REQUIRE(graphHostView.edges()[j].cost() == edgesHostView[j].cost());
+
+      int src = j % N;
+      int dst = (j * 7 + 3) % N;
+      REQUIRE(graphHostView.edges()[j].src() == src);
+      REQUIRE(graphHostView.edges()[j].dst() == dst);
+      REQUIRE_THAT(graphHostView.edges()[j].cost(), Catch::Matchers::WithinAbs(0.5f * float(src + dst), 1e-6));
+    }
+  }
+}

--- a/DataFormats/Portable/test/test_catch2_blocks.cc
+++ b/DataFormats/Portable/test/test_catch2_blocks.cc
@@ -1,0 +1,119 @@
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+#include <catch2/catch_all.hpp>
+
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/SoATemplate/interface/SoABlocks.h"
+
+// This test checks the main functionalities SoABlocks for PortableCollections.
+// In particular, the deepCopy function from a SoABlocks View/ConstView is tested.
+
+GENERATE_SOA_LAYOUT(SoAPositionTemplate,
+                    SOA_COLUMN(float, x),
+                    SOA_COLUMN(float, y),
+                    SOA_COLUMN(float, z),
+                    SOA_SCALAR(int, detectorType))
+
+using SoAPosition = SoAPositionTemplate<>;
+
+GENERATE_SOA_LAYOUT(SoAPCATemplate,
+                    SOA_COLUMN(float, vector_1),
+                    SOA_COLUMN(float, vector_2),
+                    SOA_COLUMN(float, vector_3),
+                    SOA_EIGEN_COLUMN(Eigen::Vector3d, candidateDirection))
+
+using SoAPCA = SoAPCATemplate<>;
+
+GENERATE_SOA_BLOCKS(SoAGenericBlocksTemplate, SOA_BLOCK(position, SoAPositionTemplate), SOA_BLOCK(pca, SoAPCATemplate))
+
+using SoAGenericBlocks = SoAGenericBlocksTemplate<>;
+
+TEST_CASE("Deep copy from SoABlocks Generic View") {
+  // different number of elements for the SoAs
+  const std::size_t elemsPos = 10;
+  const std::size_t elemsPCA = 20;
+
+  // Portable Collections
+  PortableHostCollection<SoAPosition> positionCollection(elemsPos, cms::alpakatools::host());
+  PortableHostCollection<SoAPCA> pcaCollection(elemsPCA, cms::alpakatools::host());
+
+  // Portable Collection Views
+  SoAPosition::View& positionCollectionView = positionCollection.view();
+  SoAPCA::View& pcaCollectionView = pcaCollection.view();
+  // Portable Collection ConstViews
+  const SoAPosition::ConstView& positionCollectionConstView = positionCollection.const_view();
+  const SoAPCA::ConstView& pcaCollectionConstView = pcaCollection.const_view();
+
+  // fill up
+  for (size_t i = 0; i < elemsPos; i++) {
+    positionCollectionView[i] = {i * 1.0f, i * 2.0f, i * 3.0f};
+  }
+  positionCollectionView.detectorType() = 1;
+
+  float time = 0.01;
+  for (size_t i = 0; i < elemsPCA; i++) {
+    pcaCollectionView[i].vector_1() = (i * 1.0f) / time;
+    pcaCollectionView[i].vector_2() = (i * 2.0f) / time;
+    pcaCollectionView[i].vector_3() = (i * 3.0f) / time;
+    pcaCollectionView[i].candidateDirection()(0) = (i * 1.0) / time;
+    pcaCollectionView[i].candidateDirection()(1) = (i * 2.0) / time;
+    pcaCollectionView[i].candidateDirection()(2) = (i * 3.0) / time;
+  }
+
+  SECTION("Deep copy the BlocksView") {
+    // building the SoABlocks View, there is no need for runtime check for the size since they are different
+    SoAGenericBlocks::View genericBlocksView{positionCollectionView, pcaCollectionView};
+
+    // Check for equality of memory addresses
+    REQUIRE(genericBlocksView.position().metadata().addressOf_x() == positionCollectionView.metadata().addressOf_x());
+    REQUIRE(genericBlocksView.position().metadata().addressOf_y() == positionCollectionView.metadata().addressOf_y());
+    REQUIRE(genericBlocksView.position().metadata().addressOf_z() == positionCollectionView.metadata().addressOf_z());
+    REQUIRE(genericBlocksView.pca().metadata().addressOf_candidateDirection() ==
+            pcaCollectionView.metadata().addressOf_candidateDirection());
+
+    // PortableHostCollection that will host the aggregated columns
+    std::array<cms::soa::size_type, 2> sizes{{elemsPos, elemsPCA}};
+    PortableHostCollection<SoAGenericBlocks> genericCollection(cms::alpakatools::host(), sizes);
+    genericCollection.deepCopy(genericBlocksView);
+
+    // Check for inequality of memory addresses
+    REQUIRE(genericCollection.view().position().metadata().addressOf_x() !=
+            positionCollectionView.metadata().addressOf_x());
+    REQUIRE(genericCollection.view().position().metadata().addressOf_y() !=
+            positionCollectionView.metadata().addressOf_y());
+    REQUIRE(genericCollection.view().position().metadata().addressOf_z() !=
+            positionCollectionView.metadata().addressOf_z());
+    REQUIRE(genericCollection.view().pca().metadata().addressOf_candidateDirection() !=
+            pcaCollectionView.metadata().addressOf_candidateDirection());
+  }
+
+  SECTION("Deep copy the BlocksConstView") {
+    // building the SoABlocks View, there is no need for runtime check for the size since they are different
+    SoAGenericBlocks::ConstView genericBlocksConstView{positionCollectionConstView, pcaCollectionConstView};
+
+    // Check for equality of memory addresses
+    REQUIRE(genericBlocksConstView.position().metadata().addressOf_x() ==
+            positionCollectionConstView.metadata().addressOf_x());
+    REQUIRE(genericBlocksConstView.position().metadata().addressOf_y() ==
+            positionCollectionConstView.metadata().addressOf_y());
+    REQUIRE(genericBlocksConstView.position().metadata().addressOf_z() ==
+            positionCollectionConstView.metadata().addressOf_z());
+    REQUIRE(genericBlocksConstView.pca().metadata().addressOf_candidateDirection() ==
+            pcaCollectionConstView.metadata().addressOf_candidateDirection());
+
+    // PortableHostCollection that will host the aggregated columns
+    PortableHostCollection<SoAGenericBlocks> genericCollection(cms::alpakatools::host(), elemsPos, elemsPCA);
+    genericCollection.deepCopy(genericBlocksConstView);
+
+    // Check for inequality of memory addresses
+    REQUIRE(genericCollection.const_view().position().metadata().addressOf_x() !=
+            positionCollectionConstView.metadata().addressOf_x());
+    REQUIRE(genericCollection.const_view().position().metadata().addressOf_y() !=
+            positionCollectionConstView.metadata().addressOf_y());
+    REQUIRE(genericCollection.const_view().position().metadata().addressOf_z() !=
+            positionCollectionConstView.metadata().addressOf_z());
+    REQUIRE(genericCollection.const_view().pca().metadata().addressOf_candidateDirection() !=
+            pcaCollectionConstView.metadata().addressOf_candidateDirection());
+  }
+}

--- a/DataFormats/Portable/test/test_catch2_deepCopyOnHost.cc
+++ b/DataFormats/Portable/test/test_catch2_deepCopyOnHost.cc
@@ -18,10 +18,9 @@ using SoAPositionView = SoAPosition::View;
 using SoAPositionConstView = SoAPosition::ConstView;
 
 GENERATE_SOA_LAYOUT(SoAPCATemplate,
-                    SOA_COLUMN(float, eigenvalues),
-                    SOA_COLUMN(float, eigenvector_1),
-                    SOA_COLUMN(float, eigenvector_2),
-                    SOA_COLUMN(float, eigenvector_3),
+                    SOA_COLUMN(float, vector_1),
+                    SOA_COLUMN(float, vector_2),
+                    SOA_COLUMN(float, vector_3),
                     SOA_EIGEN_COLUMN(Eigen::Vector3d, candidateDirection))
 
 using SoAPCA = SoAPCATemplate<>;
@@ -61,9 +60,9 @@ TEST_CASE("Deep copy from SoA Generic View") {
 
   float time = 0.01;
   for (size_t i = 0; i < elems; i++) {
-    pcaCollectionView[i].eigenvector_1() = positionCollectionView[i].x() / time;
-    pcaCollectionView[i].eigenvector_2() = positionCollectionView[i].y() / time;
-    pcaCollectionView[i].eigenvector_3() = positionCollectionView[i].z() / time;
+    pcaCollectionView[i].vector_1() = positionCollectionView[i].x() / time;
+    pcaCollectionView[i].vector_2() = positionCollectionView[i].y() / time;
+    pcaCollectionView[i].vector_3() = positionCollectionView[i].z() / time;
     pcaCollectionView[i].candidateDirection()(0) = positionCollectionView[i].x() / time;
     pcaCollectionView[i].candidateDirection()(1) = positionCollectionView[i].y() / time;
     pcaCollectionView[i].candidateDirection()(2) = positionCollectionView[i].z() / time;
@@ -116,10 +115,13 @@ TEST_CASE("Deep copy from SoA Generic View") {
     genericCollection.deepCopy(genericConstView);
 
     // Check for inequality of memory addresses
-    REQUIRE(genericCollection.view().metadata().addressOf_xPos() != positionCollectionView.metadata().addressOf_x());
-    REQUIRE(genericCollection.view().metadata().addressOf_yPos() != positionCollectionView.metadata().addressOf_y());
-    REQUIRE(genericCollection.view().metadata().addressOf_zPos() != positionCollectionView.metadata().addressOf_z());
-    REQUIRE(genericCollection.view().metadata().addressOf_candidateDirection() !=
+    REQUIRE(genericCollection.const_view().metadata().addressOf_xPos() !=
+            positionCollectionView.metadata().addressOf_x());
+    REQUIRE(genericCollection.const_view().metadata().addressOf_yPos() !=
+            positionCollectionView.metadata().addressOf_y());
+    REQUIRE(genericCollection.const_view().metadata().addressOf_zPos() !=
+            positionCollectionView.metadata().addressOf_z());
+    REQUIRE(genericCollection.const_view().metadata().addressOf_candidateDirection() !=
             pcaCollectionView.metadata().addressOf_candidateDirection());
   }
 }

--- a/DataFormats/SoATemplate/README.md
+++ b/DataFormats/SoATemplate/README.md
@@ -41,7 +41,7 @@ interface where scalar elements are accessed with an `operator()`: `soa.scalar()
 accessed via a array of structure (AoS) -like syntax: `soa[index].x()`. The "struct" object returned by `operator[]`
 can be used as a shortcut: `auto si = soa[index]; si.z() = si.x() + si.y();`
 
-A view can be instanciated by being passed the corresponding layout or passing from the [Metarecords subclass](#metarecords-subclass). 
+A view can be instanciated by being passed the corresponding layout or passing from the [Metarecords subclass](#metarecords-subclass).
 This view can point to data belonging to different SoAs and thus not contiguous in memory.
 
 ## Descriptor
@@ -75,6 +75,24 @@ and to build a generic `View` as described in [View](#view).
 It is possible to generate methods inside the `element` and `const_element` nested structs using the `SOA_ELEMENT_METHODS`
 and `SOA_CONST_ELEMENT_METHODS` macros. Each of these macros can be called only once, and can define multiple methods. 
 [An example is showed below.](#examples)
+
+## Blocks
+
+`SoABlocks` is a macro-generated templated class that enables structured composition of multiple `SoALayouts` into a single
+container, referred to as "blocks". Each block is a Layout, and the structure itself looks like multiple contigous memory 
+buffers of different sizes. The alignment is ensured to be the same for every block. 
+`SoABlocks` also supports `View` and `ConstView` classes, mirroring the structure of the underlying structs. The blocks 
+are built via composition and access to individual layouts and views is provided by name.
+
+It is also possible to generate methods inside `View` and `ConstView` using the `SOA_VIEW_METHODS` and 
+`SOA_CONST_VIEW_METHODS` in the same way as described in [Customized methods](#customized-methods).
+
+TODOs:
+- Add introspection utilities to print the structure and layout of a `SoABlocks` instance.
+- Extend support for fully templated `View`/`ConstView` classes beyond the default parameters.
+- Implement support for heterogeneous `deepCopy()` operations between different but compatible `SoABlocks` configurations.
+
+[An example of utilization is showed below.](#examples)
 
 ## ROOT serialization and de-serialization
 
@@ -226,6 +244,67 @@ template<size_t ALIGNMENT = cms::soa::CacheLineSize::defaultSize,
 struct SoA1Layout::ConstViewTemplateFreeParams;
 ```
 
+The SoA by blocks can be created in this way:
+
+```C++
+GENERATE_SOA_LAYOUT(SoAPositionTemplate,
+                    SOA_COLUMN(float, x),
+                    SOA_COLUMN(float, y),
+                    SOA_COLUMN(float, z),
+                    SOA_SCALAR(int, detectorType))
+
+GENERATE_SOA_LAYOUT(SoAPCATemplate,
+                    SOA_COLUMN(float, eigenvector_1),
+                    SOA_COLUMN(float, eigenvector_2),
+                    SOA_COLUMN(float, eigenvector_3),
+                    SOA_EIGEN_COLUMN(Eigen::Vector3d, candidateDirection))
+
+GENERATE_SOA_LAYOUT(SoATemplate,
+                    SOA_SCALAR(int, id),
+                    SOA_SCALAR(int, type),
+                    SOA_SCALAR(float, energy))
+
+GENERATE_SOA_BLOCKS(SoABlocksTemplate,
+                    SOA_BLOCK(position, SoAPositionTemplate),
+                    SOA_BLOCK(pca, SoAPCATemplate),
+                    SOA_BLOCK(scalars, SoATemplate))
+
+using SoABlocks = SoABlocksTemplate<>;
+using SoABlocksView = SoABlocks::View;
+using SoABlocksConstView = SoABlocks::ConstView;                      
+```                   
+
+and the corresponding Views/ConstViews can be accessed like this:
+
+```C++
+// Create a SoABlocks instance with three blocks of different sizes
+std::array<cms::soa::size_type, 3> sizes{{10, 20, 1}};
+const std::size_t blocksBufferSize = SoABlocks::computeDataSize(sizes);
+
+std::unique_ptr<std::byte, decltype(std::free) *> buffer{
+    reinterpret_cast<std::byte *>(aligned_alloc(SoABlocks::alignment, blocksBufferSize)), std::free};
+
+SoABlocks blocks(buffer.get(), sizes);    
+SoABlocksView blocksView{blocks};
+SoABlocksConstView blocksConstView{blocks};
+
+// Fill the blocks with some data
+blocksView.position().detectorType() = 1;
+for (int i = 0; i < blocksView.position().metadata().size(); ++i) {
+    blocksView.position()[i] = { 0.1f, 0.2f, 0.3f };
+}
+for (int i = 0; i < blocksView.metadata().size()[1]; ++i) {
+    blocksView.pca()[i].eigenvector_1() = 0.0f;
+    blocksView.pca()[i].eigenvector_2() = 0.0f;
+    blocksView.pca()[i].eigenvector_3() = 1.0f;
+    blocksView.pca()[i].candidateDirection() = Eigen::Vector3d(1.0, 0.0, 0.0);
+}
+blocksView.scalars().id() = 42;
+blocksView.scalars().type() = 1;
+blocksView.scalars().energy() = 100.0f;
+
+```
+                   
 ## Current status and further improvements
 
 ### Available features

--- a/DataFormats/SoATemplate/interface/SoABlocks.h
+++ b/DataFormats/SoATemplate/interface/SoABlocks.h
@@ -1,0 +1,479 @@
+#ifndef DataFormats_SoATemplate_interface_SoABlocks_h
+#define DataFormats_SoATemplate_interface_SoABlocks_h
+
+/*
+ * SoA Blocks: collection of SoA layouts (blocks) that can be accessed in a structured way.
+ */
+
+#include "SoALayout.h"
+#include "SoACommon.h"
+
+/*
+ * Declare accessors for the View of each block
+ */
+#define _DECLARE_ACCESSORS_VIEW_BLOCKS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME)                \
+  SOA_HOST_DEVICE SOA_INLINE LAYOUT_NAME<ALIGNMENT>::View NAME() {                        \
+    return LAYOUT_NAME<ALIGNMENT>::const_cast_View(base_type::BOOST_PP_CAT(NAME, View_)); \
+  }
+
+#define _DECLARE_ACCESSORS_VIEW_BLOCKS(R, DATA, NAME)                            \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_DECLARE_ACCESSORS_VIEW_BLOCKS_IMPL NAME))
+
+/*
+ * Declare parameters for contructing the View of an SoA by blocks
+ * using different views for each block
+ */
+#define _DECLARE_VIEW_CONSTRUCTOR_BLOCKS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) (LAYOUT_NAME<ALIGNMENT>::View NAME)
+
+#define _DECLARE_VIEW_CONSTRUCTOR_BLOCKS(R, DATA, NAME)                          \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_DECLARE_VIEW_CONSTRUCTOR_BLOCKS_IMPL NAME))
+
+/*
+ * Build the View of each block
+ */
+#define _INITIALIZE_MEMBER_VIEW_BLOCKS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) (NAME)
+
+#define _INITIALIZE_MEMBER_VIEW_BLOCKS(R, DATA, NAME)                            \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_INITIALIZE_MEMBER_VIEW_BLOCKS_IMPL NAME))
+
+/**
+ * Pointers to blocks for referencing by name
+ */
+#define _DECLARE_BLOCKS_POINTERS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME)              \
+  SOA_HOST_DEVICE SOA_INLINE auto const* BOOST_PP_CAT(addressOf_, NAME)() const { \
+    return parent_.BOOST_PP_CAT(NAME, _).metadata().data();                       \
+  }                                                                               \
+  SOA_HOST_DEVICE SOA_INLINE auto* BOOST_PP_CAT(addressOf_, NAME)() {             \
+    return parent_.BOOST_PP_CAT(NAME, _).metadata().data();                       \
+  }
+
+#define _DECLARE_BLOCKS_POINTERS(R, DATA, TYPE_NAME)                                  \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, TYPE_NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                       \
+              BOOST_PP_EXPAND(_DECLARE_BLOCKS_POINTERS_IMPL TYPE_NAME))
+
+/*
+ * Declare accessors for the ConstView of each block
+ */
+#define _DECLARE_ACCESSORS_CONST_VIEW_BLOCKS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) \
+  SOA_HOST_DEVICE SOA_INLINE const LAYOUT_NAME<ALIGNMENT>::ConstView NAME() const { return BOOST_PP_CAT(NAME, View_); }
+
+#define _DECLARE_ACCESSORS_CONST_VIEW_BLOCKS(R, DATA, NAME)                      \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_DECLARE_ACCESSORS_CONST_VIEW_BLOCKS_IMPL NAME))
+
+/*
+ * Build the ConstView of each block from the corresponding Layout
+ */
+#define _DECLARE_MEMBER_CONST_VIEW_CONSTRUCTION_BLOCKS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) \
+  (BOOST_PP_CAT(NAME, View_)(blocks.BOOST_PP_CAT(NAME, _)))
+
+#define _DECLARE_MEMBER_CONST_VIEW_CONSTRUCTION_BLOCKS(R, DATA, NAME)            \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_DECLARE_MEMBER_CONST_VIEW_CONSTRUCTION_BLOCKS_IMPL NAME))
+
+/*
+ * Declare parameters for contructing the ConstView of an SoA by blocks
+ * using different const views for each block
+ */
+#define _DECLARE_CONST_VIEW_CONSTRUCTOR_BLOCKS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) \
+  (LAYOUT_NAME<ALIGNMENT>::ConstView NAME)
+
+#define _DECLARE_CONST_VIEW_CONSTRUCTOR_BLOCKS(R, DATA, NAME)                    \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_DECLARE_CONST_VIEW_CONSTRUCTOR_BLOCKS_IMPL NAME))
+
+/*
+ * Build the ConstView of each block
+ */
+#define _INITIALIZE_MEMBER_CONST_VIEW_BLOCKS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) (BOOST_PP_CAT(NAME, View_){NAME})
+
+#define _INITIALIZE_MEMBER_CONST_VIEW_BLOCKS(R, DATA, NAME)                      \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_INITIALIZE_MEMBER_CONST_VIEW_BLOCKS_IMPL NAME))
+
+/*
+ * Initialize the array of sizes for the View of an SoA by blocks
+ */
+#define _DECLARE_CONST_VIEW_SIZES_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) (BOOST_PP_CAT(NAME, View_).metadata().size())
+
+#define _DECLARE_CONST_VIEW_SIZES(R, DATA, NAME)                                 \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_DECLARE_CONST_VIEW_SIZES_IMPL NAME))
+
+/*
+ * Declare the data members for the ConstView of the SoA by blocks
+ */
+#define _DECLARE_MEMBERS_CONST_VIEW_BLOCKS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) \
+  LAYOUT_NAME<ALIGNMENT>::ConstView BOOST_PP_CAT(NAME, View_);
+
+#define _DECLARE_MEMBERS_CONST_VIEW_BLOCKS(R, DATA, NAME)                        \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_DECLARE_MEMBERS_CONST_VIEW_BLOCKS_IMPL NAME))
+
+/*
+ * Declare accessors for the Layout of each block
+ */
+#define _DECLARE_LAYOUTS_ACCESSORS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) \
+  LAYOUT_NAME<ALIGNMENT> NAME() { return BOOST_PP_CAT(NAME, _); }
+
+#define _DECLARE_LAYOUTS_ACCESSORS(R, DATA, NAME)                                \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_DECLARE_LAYOUTS_ACCESSORS_IMPL NAME))
+
+/*
+ * Computation of the size for each block
+ */
+#define _ACCUMULATE_SOA_BLOCKS_SIZE_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME)   \
+  _soa_impl_ret += LAYOUT_NAME<ALIGNMENT>::computeDataSize(sizes[index]); \
+  index++;
+
+#define _ACCUMULATE_SOA_BLOCKS_SIZE(R, DATA, NAME)                               \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_ACCUMULATE_SOA_BLOCKS_SIZE_IMPL NAME))
+
+/*
+ * Computation of the block location in the memory layout (at SoA by blocks construction time)
+ */
+#define _DECLARE_MEMBER_CONSTRUCTION_BLOCKS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) \
+  BOOST_PP_CAT(NAME, _) = LAYOUT_NAME<ALIGNMENT>(mem + offset, sizes_[index]);  \
+  offset += LAYOUT_NAME<ALIGNMENT>::computeDataSize(sizes_[index]);             \
+  index++;
+
+#define _DECLARE_MEMBER_CONSTRUCTION_BLOCKS(R, DATA, NAME)                       \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_DECLARE_MEMBER_CONSTRUCTION_BLOCKS_IMPL NAME))
+
+/*
+ * Call default constructor for each block
+ */
+#define _DECLARE_MEMBER_TRIVIAL_CONSTRUCTION_BLOCKS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) (BOOST_PP_CAT(NAME, _)())
+
+#define _DECLARE_MEMBER_TRIVIAL_CONSTRUCTION_BLOCKS(R, DATA, NAME)               \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_DECLARE_MEMBER_TRIVIAL_CONSTRUCTION_BLOCKS_IMPL NAME))
+
+/*
+ * Computate number of blocks
+ */
+#define _COUNT_SOA_BLOCKS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) soa_blocks_count += 1;
+
+#define _COUNT_SOA_BLOCKS(R, DATA, NAME)                                         \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_COUNT_SOA_BLOCKS_IMPL NAME))
+
+/*
+ * Call the copy constructor for each block
+ */
+#define _DECLARE_BLOCK_MEMBER_COPY_CONSTRUCTION_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) \
+  (BOOST_PP_CAT(NAME, _)(_soa_impl_other.BOOST_PP_CAT(NAME, _)))
+
+#define _DECLARE_BLOCK_MEMBER_COPY_CONSTRUCTION(R, DATA, NAME)                   \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_DECLARE_BLOCK_MEMBER_COPY_CONSTRUCTION_IMPL NAME))
+
+/*
+ * Call the assignment operator for each block
+ */
+#define _DECLARE_BLOCKS_MEMBER_ASSIGNMENT_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) \
+  BOOST_PP_CAT(NAME, _) = _soa_impl_other.BOOST_PP_CAT(NAME, _);
+
+#define _DECLARE_BLOCKS_MEMBER_ASSIGNMENT(R, DATA, NAME)                         \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_DECLARE_BLOCKS_MEMBER_ASSIGNMENT_IMPL NAME))
+
+/*
+ * Check the equality of sizes for each block
+ */
+#define _CHECK_VIEW_SIZES_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME, CLASS_NAME)                                             \
+  if (sizes_[index] < view.NAME().metadata().size()) {                                                                \
+    throw std::runtime_error("In " #CLASS_NAME "::deepCopy method: number of elements mismatch for block " #NAME ""); \
+  }                                                                                                                   \
+  index++;
+
+#define _CHECK_VIEW_SIZES(R, DATA, NAME)                                         \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_CHECK_VIEW_SIZES_IMPL BOOST_PP_TUPLE_PUSH_BACK(NAME, DATA)))
+
+/*
+ * Call the deepCopy method for each block
+ */
+#define _DEEP_COPY_VIEW_COLUMNS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) BOOST_PP_CAT(NAME, _).deepCopy(view.NAME());
+
+#define _DEEP_COPY_VIEW_COLUMNS(R, DATA, NAME)                                   \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_DEEP_COPY_VIEW_COLUMNS_IMPL NAME))
+
+/*
+ * Call ROOTReadstreamer for each block.
+ */
+#define _STREAMER_READ_SOA_BLOCK_DATA_MEMBER_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) \
+  BOOST_PP_CAT(NAME, _).ROOTReadStreamer(onfile);
+
+#define _STREAMER_READ_SOA_BLOCK_DATA_MEMBER(R, DATA, NAME)                      \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_STREAMER_READ_SOA_BLOCK_DATA_MEMBER_IMPL NAME))
+
+/*
+ * Call ROOTStreamerCleaner for each block.
+ */
+#define _ROOT_FREE_SOA_BLOCK_COLUMN_OR_SCALAR_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) \
+  BOOST_PP_CAT(NAME, _).ROOTStreamerCleaner();
+
+#define _ROOT_FREE_SOA_BLOCK_COLUMN_OR_SCALAR(R, DATA, NAME)                     \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_ROOT_FREE_SOA_BLOCK_COLUMN_OR_SCALAR_IMPL NAME))
+
+#define _DECLARE_MEMBERS_BLOCKS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) LAYOUT_NAME<ALIGNMENT> BOOST_PP_CAT(NAME, _);
+
+/*
+ * Declare the data members for the SoA by blocks
+ */
+#define _DECLARE_MEMBERS_BLOCKS(R, DATA, NAME)                                   \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_DECLARE_MEMBERS_BLOCKS_IMPL NAME))
+
+/*
+ * A macro defining a SoA by blocks layout (collection of SoA layouts)
+ */
+// clang-format off
+#define GENERATE_SOA_BLOCKS(CLASS, ...)                                                                                \
+  template <CMS_SOA_BYTE_SIZE_TYPE ALIGNMENT = cms::soa::CacheLineSize::defaultSize,                                   \
+            bool ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::relaxed>                                      \
+  struct CLASS {                                                                                                       \
+    using size_type = cms::soa::size_type;                                                                             \
+    using byte_size_type = cms::soa::byte_size_type;                                                                   \
+    constexpr static byte_size_type alignment = ALIGNMENT;                                                             \
+                                                                                                                       \
+    struct ConstView;                                                                                                  \
+    struct View;                                                                                                       \
+                                                                                                                       \
+    /* Helper function to compute the total number of blocks */                                                        \
+    static constexpr size_type computeBlocksNumber() {                                                                 \
+      size_type soa_blocks_count = 0;                                                                                  \
+      _ITERATE_ON_ALL(_COUNT_SOA_BLOCKS, ~, __VA_ARGS__)                                                               \
+      return soa_blocks_count;                                                                                         \
+    }                                                                                                                  \
+                                                                                                                       \
+    static constexpr size_type blocksNumber = computeBlocksNumber();                                                   \
+                                                                                                                       \
+    /* Helper function used by caller to externally allocate the storage */                                            \
+    static constexpr byte_size_type computeDataSize(std::array<size_type, blocksNumber> sizes) {                       \
+      byte_size_type _soa_impl_ret = 0;                                                                                \
+      size_type index = 0;                                                                                             \
+      _ITERATE_ON_ALL(_ACCUMULATE_SOA_BLOCKS_SIZE, ~, __VA_ARGS__)                                                     \
+      return _soa_impl_ret;                                                                                            \
+    }                                                                                                                  \
+                                                                                                                       \
+    /**                                                                                                                \
+     * Helper/friend class allowing SoA by blocks introspection.                                                       \
+     */                                                                                                                \
+    struct Metadata {                                                                                                  \
+      friend CLASS;                                                                                                    \
+      SOA_HOST_DEVICE SOA_INLINE std::array<size_type, blocksNumber> size() const { return parent_.sizes_; }           \
+      SOA_HOST_DEVICE SOA_INLINE byte_size_type byteSize() const { return CLASS::computeDataSize(parent_.sizes_); }    \
+      SOA_HOST_DEVICE SOA_INLINE byte_size_type alignment() const { return CLASS::alignment; }                         \
+      SOA_HOST_DEVICE SOA_INLINE CLASS cloneToNewAddress(std::byte* _soa_impl_addr) const {                            \
+        return CLASS(_soa_impl_addr, parent_.sizes_);                                                                  \
+      }                                                                                                                \
+                                                                                                                       \
+      /* Pointers to each block */                                                                                     \
+      _ITERATE_ON_ALL(_DECLARE_BLOCKS_POINTERS, ~, __VA_ARGS__)                                                        \
+                                                                                                                       \
+      Metadata& operator=(const Metadata&) = delete;                                                                   \
+      Metadata(const Metadata&) = delete;                                                                              \
+                                                                                                                       \
+      private:                                                                                                         \
+        SOA_HOST_DEVICE SOA_INLINE Metadata(const CLASS& _soa_impl_parent) : parent_(_soa_impl_parent) {}              \
+        const CLASS& parent_;                                                                                          \
+    };                                                                                                                 \
+                                                                                                                       \
+    friend Metadata;                                                                                                   \
+                                                                                                                       \
+    SOA_HOST_DEVICE SOA_INLINE const Metadata metadata() const { return Metadata(*this); }                             \
+    SOA_HOST_DEVICE SOA_INLINE Metadata metadata() { return Metadata(*this); }                                         \
+                                                                                                                       \
+    _ITERATE_ON_ALL(_DECLARE_LAYOUTS_ACCESSORS, ~, __VA_ARGS__)                                                        \
+                                                                                                                       \
+    struct ConstView {                                                                                                 \
+      friend struct View;                                                                                              \
+      /* Helper/friend class allowing SoA by blocks ConstView introspection. */                                        \
+      struct Metadata {                                                                                                \
+        friend ConstView;                                                                                              \
+        SOA_HOST_DEVICE SOA_INLINE std::array<size_type, blocksNumber> size() const { return parent_.sizes_; }         \
+                                                                                                                       \
+        /* Forbid copying to avoid const correctness evasion */                                                        \
+        Metadata& operator=(const Metadata&) = delete;                                                                 \
+        Metadata(const Metadata&) = delete;                                                                            \
+                                                                                                                       \
+      private:                                                                                                         \
+        SOA_HOST_DEVICE SOA_INLINE Metadata(const ConstView& _soa_impl_parent)                                         \
+          : parent_(_soa_impl_parent) {}                                                                               \
+        const ConstView& parent_;                                                                                      \
+      };                                                                                                               \
+                                                                                                                       \
+      friend Metadata;                                                                                                 \
+      SOA_HOST_DEVICE SOA_INLINE const Metadata metadata() const { return Metadata(*this); }                           \
+                                                                                                                       \
+      /* Trivial constuctor */                                                                                         \
+      ConstView() = default;                                                                                           \
+                                                                                                                       \
+      /* Copiable */                                                                                                   \
+      ConstView(ConstView const&) = default;                                                                           \
+      ConstView& operator=(ConstView const&) = default;                                                                \
+                                                                                                                       \
+      /* Movable */                                                                                                    \
+      ConstView(ConstView &&) = default;                                                                               \
+      ConstView& operator=(ConstView &&) = default;                                                                    \
+                                                                                                                       \
+      /* Trivial destuctor */                                                                                          \
+      ~ConstView() = default;                                                                                          \
+                                                                                                                       \
+      /* Constructor relying on user provided Layout by blocks */                                                      \
+      SOA_HOST_ONLY ConstView(CLASS& blocks)                                                                           \
+          : _ITERATE_ON_ALL_COMMA(_DECLARE_MEMBER_CONST_VIEW_CONSTRUCTION_BLOCKS, ~, __VA_ARGS__),                     \
+            sizes_{blocks.sizes_} {}                                                                                   \
+                                                                                                                       \
+      /* Constructor relying on user provided const views for each block */                                            \
+      SOA_HOST_ONLY ConstView(_ITERATE_ON_ALL_COMMA(_DECLARE_CONST_VIEW_CONSTRUCTOR_BLOCKS, ~, __VA_ARGS__))           \
+          : _ITERATE_ON_ALL_COMMA(_INITIALIZE_MEMBER_CONST_VIEW_BLOCKS, ~, __VA_ARGS__),                               \
+            sizes_{{_ITERATE_ON_ALL_COMMA(_DECLARE_CONST_VIEW_SIZES, ~, __VA_ARGS__)}} {}                              \
+                                                                                                                       \
+      /* Accessors for the const views for each block */                                                               \
+      _ITERATE_ON_ALL(_DECLARE_ACCESSORS_CONST_VIEW_BLOCKS, ~, __VA_ARGS__)                                            \
+                                                                                                                       \
+      private:                                                                                                         \
+        _ITERATE_ON_ALL(_DECLARE_MEMBERS_CONST_VIEW_BLOCKS, ~, __VA_ARGS__)                                            \
+        std::array<size_type, blocksNumber> sizes_;                                                                    \
+    };                                                                                                                 \
+                                                                                                                       \
+    struct View : ConstView {                                                                                          \
+      using base_type = ConstView;                                                                                     \
+      /* Helper/friend class allowing SoA by blocks View introspection. */                                             \
+      struct Metadata {                                                                                                \
+        friend View;                                                                                                   \
+        SOA_HOST_DEVICE SOA_INLINE std::array<size_type, blocksNumber> size() const { return parent_.sizes_; }         \
+                                                                                                                       \
+        /* Forbid copying to avoid const correctness evasion */                                                        \
+        Metadata& operator=(const Metadata&) = delete;                                                                 \
+        Metadata(const Metadata&) = delete;                                                                            \
+                                                                                                                       \
+      private:                                                                                                         \
+        SOA_HOST_DEVICE SOA_INLINE Metadata(const View& _soa_impl_parent)                                              \
+          : parent_(_soa_impl_parent) {}                                                                               \
+        const View& parent_;                                                                                           \
+      };                                                                                                               \
+                                                                                                                       \
+      friend Metadata;                                                                                                 \
+      SOA_HOST_DEVICE SOA_INLINE const Metadata metadata() const { return Metadata(*this); }                           \
+      SOA_HOST_DEVICE SOA_INLINE Metadata metadata() { return Metadata(*this); }                                       \
+                                                                                                                       \
+      /* Trivial constuctor */                                                                                         \
+      View() = default;                                                                                                \
+                                                                                                                       \
+      /* Copiable */                                                                                                   \
+      View(View const&) = default;                                                                                     \
+      View& operator=(View const&) = default;                                                                          \
+                                                                                                                       \
+      /* Movable */                                                                                                    \
+      View(View &&) = default;                                                                                         \
+      View& operator=(View &&) = default;                                                                              \
+                                                                                                                       \
+      /* Trivial destuctor */                                                                                          \
+      ~View() = default;                                                                                               \
+                                                                                                                       \
+      /* Constructor relying on user provided Layout by blocks */                                                      \
+      SOA_HOST_ONLY View(CLASS& blocks)                                                                                \
+          : base_type{blocks} {}                                                                                       \
+                                                                                                                       \
+      /* Constructor relying on user provided views for each block */                                                  \
+      SOA_HOST_ONLY View(_ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_CONSTRUCTOR_BLOCKS, ~, __VA_ARGS__)) :                    \
+        base_type{_ITERATE_ON_ALL_COMMA(_INITIALIZE_MEMBER_VIEW_BLOCKS, ~, __VA_ARGS__)} {}                            \
+                                                                                                                       \
+      /* Accessors for the views for each block */                                                                     \
+      _ITERATE_ON_ALL(_DECLARE_ACCESSORS_VIEW_BLOCKS, ~, __VA_ARGS__)                                                  \
+                                                                                                                       \
+       /* Data members inherited from the ConstView */                                                                 \
+    };                                                                                                                 \
+                                                                                                                       \
+    /* TODO: implement Descriptor and ConstDescriptor for Blocks to enable heterogeneous deepCopy */                   \
+    struct Descriptor;                                                                                                 \
+    struct ConstDescriptor;                                                                                            \
+                                                                                                                       \
+    /* Trivial constuctor */                                                                                           \
+    CLASS()                                                                                                            \
+        : sizes_{},                                                                                                    \
+          _ITERATE_ON_ALL_COMMA(_DECLARE_MEMBER_TRIVIAL_CONSTRUCTION_BLOCKS, ~, __VA_ARGS__) {}                        \
+                                                                                                                       \
+    /* Constructor relying on user provided storage and array of sizes */                                              \
+    SOA_HOST_ONLY CLASS(std::byte* mem, std::array<size_type, blocksNumber> elements) : sizes_(elements) {             \
+      byte_size_type offset = 0;                                                                                       \
+      size_type index = 0;                                                                                             \
+      _ITERATE_ON_ALL(_DECLARE_MEMBER_CONSTRUCTION_BLOCKS, ~, __VA_ARGS__)                                             \
+    }                                                                                                                  \
+                                                                                                                       \
+    /* Explicit copy constructor and assignment operator */                                                            \
+    SOA_HOST_ONLY CLASS(CLASS const& _soa_impl_other)                                                                  \
+        : sizes_(_soa_impl_other.sizes_),                                                                              \
+          _ITERATE_ON_ALL_COMMA(_DECLARE_BLOCK_MEMBER_COPY_CONSTRUCTION, ~, __VA_ARGS__) {}                            \
+                                                                                                                       \
+    SOA_HOST_ONLY CLASS& operator=(CLASS const& _soa_impl_other) {                                                     \
+      sizes_ = _soa_impl_other.sizes_;                                                                                 \
+      _ITERATE_ON_ALL(_DECLARE_BLOCKS_MEMBER_ASSIGNMENT, ~, __VA_ARGS__)                                               \
+      return *this;                                                                                                    \
+    }                                                                                                                  \
+                                                                                                                       \
+    /*                                                                                                                 \
+     * Method for copying the data from a generic ConstView by blocks to a memory blob.                                \
+     * Host-only data can be handled by this method.                                                                   \
+     */                                                                                                                \
+    SOA_HOST_ONLY void deepCopy(ConstView const& view) {                                                               \
+      size_type index = 0;                                                                                             \
+      _ITERATE_ON_ALL(_CHECK_VIEW_SIZES, CLASS, __VA_ARGS__)                                                           \
+      _ITERATE_ON_ALL(_DEEP_COPY_VIEW_COLUMNS, ~, __VA_ARGS__)                                                         \
+    }                                                                                                                  \
+                                                                                                                       \
+    /* ROOT read streamer */                                                                                           \
+    template <typename T>                                                                                              \
+    void ROOTReadStreamer(T & onfile) {                                                                                \
+      _ITERATE_ON_ALL(_STREAMER_READ_SOA_BLOCK_DATA_MEMBER, ~, __VA_ARGS__)                                            \
+    }                                                                                                                  \
+                                                                                                                       \
+    /* ROOT allocation cleanup */                                                                                      \
+    void ROOTStreamerCleaner() {                                                                                       \
+      /* This function should only be called from the PortableCollection ROOT streamer */                              \
+      _ITERATE_ON_ALL(_ROOT_FREE_SOA_BLOCK_COLUMN_OR_SCALAR, ~, __VA_ARGS__)                                           \
+    }                                                                                                                  \
+                                                                                                                       \
+    private:                                                                                                           \
+      /* Data members */                                                                                               \
+      std::array<size_type, blocksNumber> sizes_;                                                                      \
+      _ITERATE_ON_ALL(_DECLARE_MEMBERS_BLOCKS, ~, __VA_ARGS__)                                                         \
+  }; \
+  // clang-format on
+
+#endif  // DataFormats_SoATemplate_interface_SoABlocks_h

--- a/DataFormats/SoATemplate/interface/SoACommon.h
+++ b/DataFormats/SoATemplate/interface/SoACommon.h
@@ -58,6 +58,9 @@
 #define _VALUE_TYPE_EIGEN_COLUMN 2
 #define _VALUE_TYPE_METHOD 3
 #define _VALUE_TYPE_CONST_METHOD 4
+#define _VALUE_TYPE_BLOCK 5
+#define _VALUE_TYPE_VIEW_METHOD 6
+#define _VALUE_TYPE_CONST_VIEW_METHOD 7
 
 /* declare the value of last valid column */
 #define _VALUE_LAST_COLUMN_TYPE _VALUE_TYPE_EIGEN_COLUMN
@@ -616,6 +619,9 @@ namespace cms::soa {
 #define SOA_EIGEN_COLUMN(TYPE, NAME) (_VALUE_TYPE_EIGEN_COLUMN, TYPE, NAME, ~)
 #define SOA_ELEMENT_METHODS(...) (_VALUE_TYPE_METHOD, _, _, (__VA_ARGS__))
 #define SOA_CONST_ELEMENT_METHODS(...) (_VALUE_TYPE_CONST_METHOD, _, _, (__VA_ARGS__))
+#define SOA_BLOCK(NAME, LAYOUT_NAME) (_VALUE_TYPE_BLOCK, NAME, LAYOUT_NAME)
+#define SOA_VIEW_METHODS(...) (_VALUE_TYPE_VIEW_METHOD, _, (__VA_ARGS__))
+#define SOA_CONST_VIEW_METHODS(...) (_VALUE_TYPE_CONST_VIEW_METHOD, _, (__VA_ARGS__))
 
 /* Macro generating customized methods for the element */
 #define GENERATE_METHODS(R, DATA, FIELD)                                         \
@@ -627,6 +633,18 @@ namespace cms::soa {
 #define GENERATE_CONST_METHODS(R, DATA, FIELD)                                         \
   BOOST_PP_IF(BOOST_PP_EQUAL(BOOST_PP_TUPLE_ELEM(0, FIELD), _VALUE_TYPE_CONST_METHOD), \
               BOOST_PP_TUPLE_ELEM(3, FIELD),                                           \
+              BOOST_PP_EMPTY())
+
+/* Macro generating customized methods for the element */
+#define GENERATE_VIEW_METHODS(R, DATA, FIELD)                                         \
+  BOOST_PP_IF(BOOST_PP_EQUAL(BOOST_PP_TUPLE_ELEM(0, FIELD), _VALUE_TYPE_VIEW_METHOD), \
+              BOOST_PP_TUPLE_ELEM(2, FIELD),                                          \
+              BOOST_PP_EMPTY())
+
+/* Macro generating customized methods for the const element*/
+#define GENERATE_CONST_VIEW_METHODS(R, DATA, FIELD)                                         \
+  BOOST_PP_IF(BOOST_PP_EQUAL(BOOST_PP_TUPLE_ELEM(0, FIELD), _VALUE_TYPE_CONST_VIEW_METHOD), \
+              BOOST_PP_TUPLE_ELEM(2, FIELD),                                                \
               BOOST_PP_EMPTY())
 
 /* Preprocessing loop for managing functions generation: only macros containing valid content are expanded */

--- a/DataFormats/SoATemplate/test/AssociationMapSoA_t.cc
+++ b/DataFormats/SoATemplate/test/AssociationMapSoA_t.cc
@@ -1,0 +1,121 @@
+#include <Eigen/Core>
+#include <Eigen/Dense>
+#include <span>
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_all.hpp>
+
+#include "DataFormats/SoATemplate/interface/SoABlocks.h"
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+
+// A very simple association map using SoABlocks is defined here, with two blocks:
+// - indexes: a block containing the indexes of the elements
+// - offsets: a block containing the offsets of the elements
+// The free functions are getters that return a std::span of the indexes for a given offset.
+
+// N.B. SOA_VIEW_METHODS and SOA_CONST_VIEW_METHODS macros should make possible to inject
+// methods within SoA backend. This functionality is disabled until a solution for the possible
+// dependency on alpaka for the custom methods is found.
+
+GENERATE_SOA_LAYOUT(SoAIndexesTemplate, SOA_COLUMN(std::size_t, indexes))
+
+GENERATE_SOA_LAYOUT(SoAOffsetsTemplate, SOA_COLUMN(std::size_t, offsets))
+
+GENERATE_SOA_BLOCKS(SoABlocksTemplate, SOA_BLOCK(indexes, SoAIndexesTemplate), SOA_BLOCK(offsets, SoAOffsetsTemplate))
+
+using SoABlocks = SoABlocksTemplate<>;
+using SoABlocksView = SoABlocks::View;
+using SoABlocksConstView = SoABlocks::ConstView;
+
+std::span<std::size_t> get(SoABlocksView& view, std::size_t i) {
+  std::size_t start = view.offsets()[i].offsets();
+  std::size_t end = (i + 1 < static_cast<std::size_t>(view.offsets().metadata().size()))
+                        ? view.offsets()[i + 1].offsets()
+                        : view.indexes().metadata().size();
+  return {view.indexes().indexes().data() + start, view.indexes().indexes().data() + end};
+}
+
+std::span<const std::size_t> get(const SoABlocksConstView& view, std::size_t i) {
+  std::size_t start = view.offsets()[i].offsets();
+  std::size_t end = (i + 1 < static_cast<std::size_t>(view.offsets().metadata().size()))
+                        ? view.offsets()[i + 1].offsets()
+                        : view.indexes().metadata().size();
+  return {view.indexes().indexes().data() + start, view.indexes().indexes().data() + end};
+}
+
+TEST_CASE("SoABlocks methods for the (Const)View") {
+  // Create a SoABlocks instance with three blocks of different sizes
+  std::array<cms::soa::size_type, 2> sizes{{20, 3}};
+
+  const std::size_t blocksBufferSize = SoABlocks::computeDataSize(sizes);
+
+  std::unique_ptr<std::byte, decltype(std::free)*> buffer{
+      reinterpret_cast<std::byte*>(aligned_alloc(SoABlocks::alignment, blocksBufferSize)), std::free};
+
+  SoABlocks blocks(buffer.get(), sizes);
+  SoABlocksView blocksView{blocks};
+  SoABlocksConstView blocksConstView{blocks};
+
+  // Fill the blocks with some data
+  for (int i = 0; i < blocksView.indexes().metadata().size(); ++i) {
+    blocksView.indexes()[i].indexes() = i;
+  }
+
+  blocksView.offsets()[0].offsets() = 0;
+  blocksView.offsets()[1].offsets() = 5;
+  blocksView.offsets()[2].offsets() = 10;
+
+  SECTION("std::span map with View") {
+    // Access the ranges of indexes using the get free function
+    std::span<std::size_t> values_first = get(blocksView, 0);
+    std::span<std::size_t> values_second = get(blocksView, 1);
+    std::span<std::size_t> values_third = get(blocksView, 2);
+
+    // Verify the values
+    for (std::size_t i = 0; i < values_first.size(); ++i) {
+      REQUIRE(values_first[i] == i);
+    }
+
+    for (std::size_t i = 0; i < values_second.size(); ++i) {
+      REQUIRE(values_second[i] == i + 5);
+    }
+
+    for (std::size_t i = 0; i < values_third.size(); ++i) {
+      REQUIRE(values_third[i] == i + 10);
+    }
+
+    // Swap the contents of the first and second spans
+    for (std::size_t i = 0; i < values_first.size(); ++i) {
+      std::swap(values_first[i], values_second[i]);
+    }
+
+    // Verify the values
+    for (std::size_t i = 0; i < values_first.size(); ++i) {
+      REQUIRE(values_first[i] == i + 5);
+    }
+
+    for (std::size_t i = 0; i < values_second.size(); ++i) {
+      REQUIRE(values_second[i] == i);
+    }
+  }
+
+  SECTION("std::span map with ConstView") {
+    // Access the ranges of indexes using the get free function
+    std::span<const std::size_t> values_first = get(blocksConstView, 0);
+    std::span<const std::size_t> values_second = get(blocksConstView, 1);
+    std::span<const std::size_t> values_third = get(blocksConstView, 2);
+
+    // Verify the values
+    for (std::size_t i = 0; i < values_first.size(); ++i) {
+      REQUIRE(values_first[i] == i);
+    }
+
+    for (std::size_t i = 0; i < values_second.size(); ++i) {
+      REQUIRE(values_second[i] == i + 5);
+    }
+
+    for (std::size_t i = 0; i < values_third.size(); ++i) {
+      REQUIRE(values_third[i] == i + 10);
+    }
+  }
+}

--- a/DataFormats/SoATemplate/test/BuildFile.xml
+++ b/DataFormats/SoATemplate/test/BuildFile.xml
@@ -37,6 +37,28 @@
   <use name="DataFormats/SoATemplate"/>
 </bin>
 
+<bin file="SoABlocks_t.cc" name="SoABlocks_t">
+  <use name="boost"/>
+  <use name="catch2"/>
+  <use name="eigen"/>
+  <use name="DataFormats/SoATemplate"/>
+</bin>
+
+<bin file="SoAGenericBlocksView_t.cc" name="SoAGenericBlocks_t">
+  <use name="boost"/>
+  <use name="catch2"/>
+  <use name="eigen"/>
+  <use name="DataFormats/SoATemplate"/>
+</bin>
+
+<bin file="AssociationMapSoA_t.cc" name="SoAMap">
+  <use name="boost"/>
+  <use name="catch2"/>
+  <use name="eigen"/>
+  <use name="DataFormats/SoATemplate"/>
+  <use name="DataFormats/Portable"/>
+</bin>
+
 <!-- This test triggers a bug in ROOT, so it's kept disabled
 <bin file="SoAStreamer_t.cpp" name="SoAStreamer_t">
   <use name="root"/>

--- a/DataFormats/SoATemplate/test/SoABlocks_t.cc
+++ b/DataFormats/SoATemplate/test/SoABlocks_t.cc
@@ -1,0 +1,145 @@
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_all.hpp>
+
+#include "DataFormats/SoATemplate/interface/SoABlocks.h"
+
+// This file tests the main properties of SoABlocks
+
+GENERATE_SOA_LAYOUT(SoAPositionTemplate,
+                    SOA_COLUMN(float, x),
+                    SOA_COLUMN(float, y),
+                    SOA_COLUMN(float, z),
+                    SOA_SCALAR(int, detectorType))
+
+GENERATE_SOA_LAYOUT(SoAPCATemplate,
+                    SOA_COLUMN(float, vector_1),
+                    SOA_COLUMN(float, vector_2),
+                    SOA_COLUMN(float, vector_3),
+                    SOA_EIGEN_COLUMN(Eigen::Vector3d, candidateDirection))
+
+GENERATE_SOA_LAYOUT(SoATemplate, SOA_SCALAR(int, id), SOA_SCALAR(int, type), SOA_SCALAR(float, energy))
+
+GENERATE_SOA_BLOCKS(SoABlocksTemplate,
+                    SOA_BLOCK(position, SoAPositionTemplate),
+                    SOA_BLOCK(pca, SoAPCATemplate),
+                    SOA_BLOCK(scalars, SoATemplate))
+
+using SoABlocks = SoABlocksTemplate<>;
+// TODO: Implement template version of View and ConstView (ViewTemplate and ConstViewTemplate)
+using SoABlocksView = SoABlocks::View;
+using SoABlocksConstView = SoABlocks::ConstView;
+
+TEST_CASE("SoABlocks") {
+  // Create a SoABlocks instance with three blocks of different sizes
+  std::array<cms::soa::size_type, 3> sizes{{10, 20, 1}};
+  const std::size_t blocksBufferSize = SoABlocks::computeDataSize(sizes);
+
+  std::unique_ptr<std::byte, decltype(std::free) *> buffer{
+      reinterpret_cast<std::byte *>(aligned_alloc(SoABlocks::alignment, blocksBufferSize)), std::free};
+
+  SoABlocks blocks(buffer.get(), sizes);
+  SoABlocksView blocksView{blocks};
+  SoABlocksConstView blocksConstView{blocks};
+
+  // Verify position data
+  REQUIRE(blocks.position().metadata().nextByte() == blocks.metadata().addressOf_pca());
+  REQUIRE(blocks.pca().metadata().nextByte() == blocks.metadata().addressOf_scalars());
+
+  // Fill the blocks with some data
+  blocksView.position().detectorType() = 1;
+  for (int i = 0; i < blocksView.position().metadata().size(); ++i) {
+    blocksView.position()[i] = {0.1f, 0.2f, 0.3f};
+  }
+  for (int i = 0; i < blocksView.metadata().size()[1]; ++i) {
+    blocksView.pca()[i].vector_1() = 0.0f;
+    blocksView.pca()[i].vector_2() = 0.0f;
+    blocksView.pca()[i].vector_3() = 1.0f;
+    blocksView.pca()[i].candidateDirection() = Eigen::Vector3d(1.0, 0.0, 0.0);
+  }
+  blocksView.scalars().id() = 42;
+  blocksView.scalars().type() = 1;
+  blocksView.scalars().energy() = 100.0f;
+
+  SECTION("SoABlocks View") {
+    // Verify metadata
+    REQUIRE(blocksView.metadata().size()[0] == 10);
+    REQUIRE(blocksView.position().metadata().size() == 10);
+    REQUIRE(blocksView.metadata().size()[1] == 20);
+    REQUIRE(blocksView.pca().metadata().size() == 20);
+    REQUIRE(blocksView.metadata().size()[2] == 1);
+    REQUIRE(blocksView.scalars().metadata().size() == 1);
+
+    // Verify data
+    for (int i = 0; i < blocksView.position().metadata().size(); ++i) {
+      auto pos = blocksView.position()[i];
+      REQUIRE(pos.x() == 0.1f);
+      REQUIRE(pos.y() == 0.2f);
+      REQUIRE(pos.z() == 0.3f);
+    }
+    for (int i = 0; i < blocksView.pca().metadata().size(); ++i) {
+      auto pca = blocksView.pca()[i];
+      REQUIRE(pca.vector_1() == 0.0f);
+      REQUIRE(pca.vector_2() == 0.0f);
+      REQUIRE(pca.vector_3() == 1.0f);
+      REQUIRE(pca.candidateDirection()(0) == 1.0);
+      REQUIRE(pca.candidateDirection()(1) == 0.0);
+      REQUIRE(pca.candidateDirection()(2) == 0.0);
+    }
+  }
+
+  SECTION("SoABlocks ConstView") {
+    // Verify metadata
+    REQUIRE(blocksConstView.metadata().size()[0] == 10);
+    REQUIRE(blocksConstView.position().metadata().size() == 10);
+    REQUIRE(blocksConstView.metadata().size()[1] == 20);
+    REQUIRE(blocksConstView.pca().metadata().size() == 20);
+    REQUIRE(blocksConstView.metadata().size()[2] == 1);
+    REQUIRE(blocksConstView.scalars().metadata().size() == 1);
+
+    // Verify data
+    for (int i = 0; i < blocksConstView.position().metadata().size(); ++i) {
+      auto pos = blocksConstView.position()[i];
+      REQUIRE(pos.x() == 0.1f);
+      REQUIRE(pos.y() == 0.2f);
+      REQUIRE(pos.z() == 0.3f);
+    }
+    for (int i = 0; i < blocksConstView.pca().metadata().size(); ++i) {
+      auto pca = blocksConstView.pca()[i];
+      REQUIRE(pca.vector_1() == 0.0f);
+      REQUIRE(pca.vector_2() == 0.0f);
+      REQUIRE(pca.vector_3() == 1.0f);
+      REQUIRE(pca.candidateDirection()(0) == 1.0);
+      REQUIRE(pca.candidateDirection()(1) == 0.0);
+      REQUIRE(pca.candidateDirection()(2) == 0.0);
+    }
+  }
+
+  SECTION("Range checking View") {
+    // Range checking is enabled by default
+    // TODO: give possibility to disable range checking
+    int underflow = -1;
+    int overflow = blocksView.position().metadata().size();
+    // Check for under-and overflow in the row accessor
+    REQUIRE_THROWS_AS(blocksView.position()[underflow], std::out_of_range);
+    REQUIRE_THROWS_AS(blocksView.position()[overflow], std::out_of_range);
+    // Check for under-and overflow in the element accessors
+    REQUIRE_THROWS_AS(blocksView.position().x(underflow), std::out_of_range);
+    REQUIRE_THROWS_AS(blocksView.position().x(overflow), std::out_of_range);
+  }
+
+  SECTION("Range checking ConstView") {
+    // Range checking is enabled by default
+    // TODO: give possibility to disable range checking
+    int underflow = -1;
+    int overflow = blocksConstView.pca().metadata().size();
+    // Check for under-and overflow in the row accessor
+    REQUIRE_THROWS_AS(blocksConstView.pca()[underflow], std::out_of_range);
+    REQUIRE_THROWS_AS(blocksConstView.pca()[overflow], std::out_of_range);
+    // Check for under-and overflow in the element accessors
+    REQUIRE_THROWS_AS(blocksConstView.pca().vector_1(underflow), std::out_of_range);
+    REQUIRE_THROWS_AS(blocksConstView.pca().vector_1(overflow), std::out_of_range);
+  }
+}

--- a/DataFormats/SoATemplate/test/SoAGenericBlocksView_t.cc
+++ b/DataFormats/SoATemplate/test/SoAGenericBlocksView_t.cc
@@ -1,0 +1,246 @@
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_all.hpp>
+
+#include "DataFormats/SoATemplate/interface/SoABlocks.h"
+
+// This file tests the possibility to build a SoABlocks View/ConstView starting from
+// existing Views/ConstViews of other SoAs. It is also possible then to deepCopy these
+// Views/ConstViews into a SoABlocks instance. This can be considered as the expansion of
+// the SoAGenericView_t.cc test to the case of blocks.
+// N.B. It is also possible to build a SoAGenericBlocksView/ConstView starting from
+// a SoAGenericView, but this behaviour is not tested here.
+
+constexpr float step = 0.01;
+
+GENERATE_SOA_LAYOUT(SoAPositionTemplate,
+                    SOA_COLUMN(float, x),
+                    SOA_COLUMN(float, y),
+                    SOA_COLUMN(float, z),
+                    SOA_SCALAR(int, detectorType))
+
+using SoAPosition = SoAPositionTemplate<>;
+using SoAPositionView = SoAPosition::View;
+using SoAPositionConstView = SoAPosition::ConstView;
+
+GENERATE_SOA_LAYOUT(SoAPCATemplate,
+                    SOA_COLUMN(float, vector_1),
+                    SOA_COLUMN(float, vector_2),
+                    SOA_COLUMN(float, vector_3),
+                    SOA_EIGEN_COLUMN(Eigen::Vector3d, candidateDirection))
+
+using SoAPCA = SoAPCATemplate<>;
+using SoAPCAView = SoAPCA::View;
+using SoAPCAConstView = SoAPCA::ConstView;
+
+GENERATE_SOA_BLOCKS(SoAGenericBlocksTemplate, SOA_BLOCK(position, SoAPositionTemplate), SOA_BLOCK(pca, SoAPCATemplate))
+
+using SoAGenericBlocks = SoAGenericBlocksTemplate<>;
+using SoAGenericBlocksView = SoAGenericBlocks::View;
+using SoAGenericBlocksConstView = SoAGenericBlocks::ConstView;
+
+TEST_CASE("SoAGenericBlocks") {
+  // different number of elements for the SoAs
+  const std::size_t elemsPos = 10;
+  const std::size_t elemsPCA = 20;
+
+  // buffer sizes
+  const std::size_t positionBufferSize = SoAPosition::computeDataSize(elemsPos);
+  const std::size_t pcaBufferSize = SoAPCA::computeDataSize(elemsPCA);
+
+  // memory buffer for the SoA of positions
+  std::unique_ptr<std::byte, decltype(std::free) *> bufferPos{
+      reinterpret_cast<std::byte *>(aligned_alloc(SoAPosition::alignment, positionBufferSize)), std::free};
+  // memory buffer for the SoA of the PCA
+  std::unique_ptr<std::byte, decltype(std::free) *> bufferPCA{
+      reinterpret_cast<std::byte *>(aligned_alloc(SoAPCA::alignment, pcaBufferSize)), std::free};
+
+  // SoA Layouts
+  SoAPosition position{bufferPos.get(), elemsPos};
+  SoAPCA pca{bufferPCA.get(), elemsPCA};
+
+  // SoA Views
+  SoAPositionView positionView{position};
+  SoAPositionConstView positionConstView{position};
+  SoAPCAView pcaView{pca};
+  SoAPCAConstView pcaConstView{pca};
+
+  // fill up
+  for (size_t i = 0; i < elemsPos; i++) {
+    positionView[i] = {i * 1.0f, i * 2.0f, i * 3.0f};
+  }
+  positionView.detectorType() = 1;
+
+  for (size_t i = 0; i < elemsPCA; i++) {
+    pcaView[i].vector_1() = (i * 1.0f) / step;
+    pcaView[i].vector_2() = (i * 2.0f) / step;
+    pcaView[i].vector_3() = (i * 3.0f) / step;
+    pcaView[i].candidateDirection()(0) = (i * 1.0) / step;
+    pcaView[i].candidateDirection()(1) = (i * 2.0) / step;
+    pcaView[i].candidateDirection()(2) = (i * 3.0) / step;
+  }
+
+  SECTION("GenericBlocks View") {
+    // building the SoABlocks View, there is no need for runtime check for the size since they are different
+    SoAGenericBlocksView genericBlocksView{positionView, pcaView};
+
+    // Verify metadata
+    REQUIRE(genericBlocksView.metadata().size()[0] == elemsPos);
+    REQUIRE(genericBlocksView.position().metadata().size() == elemsPos);
+    REQUIRE(genericBlocksView.metadata().size()[1] == elemsPCA);
+    REQUIRE(genericBlocksView.pca().metadata().size() == elemsPCA);
+
+    // Check for equality of memory addresses
+    REQUIRE(genericBlocksView.position().metadata().addressOf_x() == positionView.metadata().addressOf_x());
+    REQUIRE(genericBlocksView.position().metadata().addressOf_y() == positionView.metadata().addressOf_y());
+    REQUIRE(genericBlocksView.position().metadata().addressOf_z() == positionView.metadata().addressOf_z());
+    REQUIRE(genericBlocksView.pca().metadata().addressOf_candidateDirection() ==
+            pcaView.metadata().addressOf_candidateDirection());
+
+    // Verify data
+    for (int i = 0; i < genericBlocksView.position().metadata().size(); ++i) {
+      auto pos = genericBlocksView.position()[i];
+      REQUIRE(pos.x() == static_cast<float>(i));
+      REQUIRE(pos.y() == static_cast<float>(i * 2.0f));
+      REQUIRE(pos.z() == static_cast<float>(i * 3.0f));
+    }
+    for (int i = 0; i < genericBlocksView.pca().metadata().size(); ++i) {
+      auto pca = genericBlocksView.pca()[i];
+      REQUIRE(pca.vector_1() == static_cast<float>(i) / step);
+      REQUIRE(pca.vector_2() == static_cast<float>(i * 2.0f) / step);
+      REQUIRE(pca.vector_3() == static_cast<float>(i * 3.0f) / step);
+      REQUIRE(pca.candidateDirection()(0) == static_cast<double>(i) / step);
+      REQUIRE(pca.candidateDirection()(1) == static_cast<double>(i * 2.0) / step);
+      REQUIRE(pca.candidateDirection()(2) == static_cast<double>(i * 3.0) / step);
+    }
+  }
+
+  SECTION("GenericBlocks ConstView") {
+    // building the SoABlocks View, there is no need for runtime check for the size since they are different
+    SoAGenericBlocksConstView genericBlocksConstView{positionConstView, pcaConstView};
+
+    // Verify metadata
+    REQUIRE(genericBlocksConstView.metadata().size()[0] == elemsPos);
+    REQUIRE(genericBlocksConstView.position().metadata().size() == elemsPos);
+    REQUIRE(genericBlocksConstView.metadata().size()[1] == elemsPCA);
+    REQUIRE(genericBlocksConstView.pca().metadata().size() == elemsPCA);
+
+    // Check for equality of memory addresses
+    REQUIRE(genericBlocksConstView.position().metadata().addressOf_x() == positionConstView.metadata().addressOf_x());
+    REQUIRE(genericBlocksConstView.position().metadata().addressOf_y() == positionConstView.metadata().addressOf_y());
+    REQUIRE(genericBlocksConstView.position().metadata().addressOf_z() == positionConstView.metadata().addressOf_z());
+    REQUIRE(genericBlocksConstView.pca().metadata().addressOf_candidateDirection() ==
+            pcaConstView.metadata().addressOf_candidateDirection());
+
+    // Verify data
+    for (int i = 0; i < genericBlocksConstView.position().metadata().size(); ++i) {
+      auto pos = genericBlocksConstView.position()[i];
+      REQUIRE(pos.x() == static_cast<float>(i));
+      REQUIRE(pos.y() == static_cast<float>(i * 2.0f));
+      REQUIRE(pos.z() == static_cast<float>(i * 3.0f));
+    }
+    for (int i = 0; i < genericBlocksConstView.pca().metadata().size(); ++i) {
+      auto pca = genericBlocksConstView.pca()[i];
+      REQUIRE(pca.vector_1() == static_cast<float>(i) / step);
+      REQUIRE(pca.vector_2() == static_cast<float>(i * 2.0f) / step);
+      REQUIRE(pca.vector_3() == static_cast<float>(i * 3.0f) / step);
+      REQUIRE(pca.candidateDirection()(0) == static_cast<double>(i) / step);
+      REQUIRE(pca.candidateDirection()(1) == static_cast<double>(i * 2.0) / step);
+      REQUIRE(pca.candidateDirection()(2) == static_cast<double>(i * 3.0) / step);
+    }
+  }
+
+  SECTION("GenericBlocks ConstView from Views") {
+    // building the SoABlocks ConstView, there is no need for runtime check for the size since they are different
+    SoAGenericBlocksConstView genericBlocksConstView{positionView, pcaView};
+
+    // Verify data
+    for (int i = 0; i < genericBlocksConstView.position().metadata().size(); ++i) {
+      auto pos = genericBlocksConstView.position()[i];
+      REQUIRE(pos.x() == static_cast<float>(i));
+      REQUIRE(pos.y() == static_cast<float>(i * 2.0f));
+      REQUIRE(pos.z() == static_cast<float>(i * 3.0f));
+    }
+    for (int i = 0; i < genericBlocksConstView.pca().metadata().size(); ++i) {
+      auto pca = genericBlocksConstView.pca()[i];
+      REQUIRE(pca.vector_1() == static_cast<float>(i) / step);
+      REQUIRE(pca.vector_2() == static_cast<float>(i * 2.0f) / step);
+      REQUIRE(pca.vector_3() == static_cast<float>(i * 3.0f) / step);
+      REQUIRE(pca.candidateDirection()(0) == static_cast<double>(i) / step);
+      REQUIRE(pca.candidateDirection()(1) == static_cast<double>(i * 2.0) / step);
+      REQUIRE(pca.candidateDirection()(2) == static_cast<double>(i * 3.0) / step);
+    }
+
+    // Check for reference to original SoA - it is possible to modify the ConstView by reference modifying the Views
+    positionView[3].x() = 0.;
+    REQUIRE(genericBlocksConstView.position()[3].x() == positionView[3].x());
+  }
+
+  SECTION("Deep copy the GeenericBlocks View") {
+    // building the SoABlocks View, there is no need for runtime check for the size since they are different
+    SoAGenericBlocksView genericBlocksView{positionView, pcaView};
+
+    // Instantiate a SoABlocks
+    std::array<cms::soa::size_type, 2> sizes{{elemsPos, elemsPCA}};
+    const std::size_t blocksBufferSize = SoAGenericBlocks::computeDataSize(sizes);
+    std::unique_ptr<std::byte, decltype(std::free) *> bufferBlocks{
+        reinterpret_cast<std::byte *>(aligned_alloc(SoAGenericBlocks::alignment, blocksBufferSize)), std::free};
+
+    SoAGenericBlocks genericBlocks{bufferBlocks.get(), sizes};
+
+    genericBlocks.deepCopy(genericBlocksView);
+
+    SoAGenericBlocksView genericSoABlocksView{genericBlocks};
+    // Check for inequality of memory addresses
+    REQUIRE(genericSoABlocksView.position().metadata().addressOf_x() != positionConstView.metadata().addressOf_x());
+    REQUIRE(genericSoABlocksView.position().metadata().addressOf_y() != positionConstView.metadata().addressOf_y());
+    REQUIRE(genericSoABlocksView.position().metadata().addressOf_z() != positionConstView.metadata().addressOf_z());
+    REQUIRE(genericSoABlocksView.pca().metadata().addressOf_candidateDirection() !=
+            pcaConstView.metadata().addressOf_candidateDirection());
+
+    // Check for contiguity of columns
+    REQUIRE(reinterpret_cast<std::byte *>(genericSoABlocksView.position().metadata().addressOf_x()) +
+                cms::soa::alignSize(elemsPos * sizeof(float), SoAGenericBlocks::alignment) ==
+            reinterpret_cast<std::byte *>(genericSoABlocksView.position().metadata().addressOf_y()));
+    REQUIRE(reinterpret_cast<std::byte *>(genericSoABlocksView.position().metadata().addressOf_y()) +
+                cms::soa::alignSize(elemsPos * sizeof(float), SoAGenericBlocks::alignment) ==
+            reinterpret_cast<std::byte *>(genericSoABlocksView.position().metadata().addressOf_z()));
+    REQUIRE(reinterpret_cast<std::byte *>(genericSoABlocksView.position().metadata().addressOf_z()) +
+                cms::soa::alignSize(elemsPos * sizeof(float), SoAGenericBlocks::alignment) ==
+            reinterpret_cast<std::byte *>(genericSoABlocksView.position().metadata().addressOf_detectorType()));
+    REQUIRE(reinterpret_cast<std::byte *>(genericSoABlocksView.position().metadata().addressOf_detectorType()) +
+                cms::soa::alignSize(sizeof(int), SoAGenericBlocks::alignment) ==
+            reinterpret_cast<std::byte *>(genericSoABlocksView.pca().metadata().addressOf_vector_1()));
+    REQUIRE(reinterpret_cast<std::byte *>(genericSoABlocksView.pca().metadata().addressOf_vector_1()) +
+                cms::soa::alignSize(elemsPCA * sizeof(float), SoAGenericBlocks::alignment) ==
+            reinterpret_cast<std::byte *>(genericSoABlocksView.pca().metadata().addressOf_vector_2()));
+    REQUIRE(reinterpret_cast<std::byte *>(genericSoABlocksView.pca().metadata().addressOf_vector_2()) +
+                cms::soa::alignSize(elemsPCA * sizeof(float), SoAGenericBlocks::alignment) ==
+            reinterpret_cast<std::byte *>(genericSoABlocksView.pca().metadata().addressOf_vector_3()));
+    REQUIRE(reinterpret_cast<std::byte *>(genericSoABlocksView.pca().metadata().addressOf_vector_3()) +
+                cms::soa::alignSize(elemsPCA * sizeof(float), SoAGenericBlocks::alignment) ==
+            reinterpret_cast<std::byte *>(genericSoABlocksView.pca().metadata().addressOf_candidateDirection()));
+
+    // Ckeck the correctness of the copy
+    for (size_t i = 0; i < elemsPos; i++) {
+      REQUIRE(genericSoABlocksView.position()[i].x() == positionConstView[i].x());
+      REQUIRE(genericSoABlocksView.position()[i].y() == positionConstView[i].y());
+      REQUIRE(genericSoABlocksView.position()[i].z() == positionConstView[i].z());
+    }
+    REQUIRE(genericSoABlocksView.position().detectorType() == positionConstView.detectorType());
+    for (size_t i = 0; i < elemsPCA; i++) {
+      REQUIRE(genericSoABlocksView.pca()[i].vector_1() == pcaConstView[i].vector_1());
+      REQUIRE(genericSoABlocksView.pca()[i].vector_2() == pcaConstView[i].vector_2());
+      REQUIRE(genericSoABlocksView.pca()[i].vector_3() == pcaConstView[i].vector_3());
+      REQUIRE(genericSoABlocksView.pca()[i].candidateDirection()(0) == pcaConstView[i].candidateDirection()(0));
+      REQUIRE(genericSoABlocksView.pca()[i].candidateDirection()(1) == pcaConstView[i].candidateDirection()(1));
+      REQUIRE(genericSoABlocksView.pca()[i].candidateDirection()(2) == pcaConstView[i].candidateDirection()(2));
+    }
+
+    // Check for the independency of the aggregated SoA
+    genericSoABlocksView.position()[3].x() = 0.;
+    REQUIRE(genericSoABlocksView.position()[3].x() != positionView[3].x());
+  }
+}

--- a/DataFormats/SoATemplate/test/SoAGenericView_t.cc
+++ b/DataFormats/SoATemplate/test/SoAGenericView_t.cc
@@ -17,7 +17,6 @@ using SoAPositionView = SoAPosition::View;
 using SoAPositionConstView = SoAPosition::ConstView;
 
 GENERATE_SOA_LAYOUT(SoAPCATemplate,
-                    SOA_COLUMN(float, eigenvalues),
                     SOA_COLUMN(float, eigenvector_1),
                     SOA_COLUMN(float, eigenvector_2),
                     SOA_COLUMN(float, eigenvector_3),


### PR DESCRIPTION
#### PR description:

This PR extends the concept of `SoA`, introducing `SoABlocks`, i.e., a collection of SoA `Layout`s, with the corresponding `View`s and `ConstView`s. Both the memory abstraction and accessors to elements have been built by composition of multiple traditional SoAs. One of the purpose of `SoABlocks` is to substitute the role of `PortableMultiCollection`. For this reason, new constructors for `PortableHostCollection` and `PortableDeviceCollection` have been added.

The implementation of `SoABlocks` aims to mirror the design of the traditional `SoALayout`, so it has been written using macros. For a complete overview of the PR, the expanded code of the `SoAGenericBlocksView_t.cc` is taken as an example and attached to the description of this PR, in a separate comment (only `SoAPCATemplate` and `SoAGenericBlocksTemplate`, because `SoAPosition` is totally equivalent to `SoAPCATemplate`).

TODOs:
- Provide a suitable method to print information about `SoABlocks`
- Implement fully templated `View` and `ConstView`
- Enable heterogeneous `deepCopy()` method for `SoABlocks`

#### PR validation:

For the validation four different tests have been added:
- `SoABlocks_t.cc` tests the main properties of `SoABlocks` and its general utilization
- `SoAGenericBlocksView_t.cc` can be seen as the extension of `SoAGenericView_t.cc` and tests the possibility to build the `View` or `ConstView` of an `SoABlocks` starting from `View`s or `ConstView`s of existing SoAs, and then deepCopy these Views in a contigous memory blob, that in this case is an `SoABlocks` instance
- `AssociationMapSoA.cc` is a simple use case of the `SoABlocks`: an association map implemented using two SoA blocks where one gives the access to the other using `SOA_VIEW_METHODS(...)` and `SOA_CONST_VIEW_METHODS(...)` macros.
- `test_catch2_blocks.cc` that tests the correct behaviour of `SoABlocks` instatiated using `PortableHostCollection`

FYI @felicepantaleo 