### PR TITLE
Add previous scouting dataformat in AOD and MINIAOD

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -100,8 +100,6 @@ from HLTrigger.Configuration.HLTScouting_EventContent_cff import HLTScoutingAll
 HLTriggerMINIAOD.outputCommands.extend(HLTScoutingAll.outputCommands)
 HLTriggerAOD.outputCommands.extend(HLTScoutingAll.outputCommands)
 HLTriggerRECO.outputCommands.extend(HLTScoutingAll.outputCommands)
-HLTriggerRAW.outputCommands.extend(HLTScoutingAll.outputCommands)
-HLTDebugRAW.outputCommands.extend(HLTScoutingAll.outputCommands)
 HLTDebugFEVT.outputCommands.extend(HLTScoutingAll.outputCommands)
 #
 # DQM

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -95,7 +95,14 @@ from L1Trigger.Configuration.L1Trigger_EventContent_cff import *
 #
 #
 from HLTrigger.Configuration.HLTrigger_EventContent_cff import *
-#
+from HLTrigger.Configuration.HLTScouting_EventContent_cff import HLTScoutingAll
+# Extend HLT dataformats to the previous scouting objects, to keep them when running on old data/MC
+HLTriggerMINIAOD.outputCommands.extend(HLTScoutingAll.outputCommands)
+HLTriggerAOD.outputCommands.extend(HLTScoutingAll.outputCommands)
+HLTriggerRECO.outputCommands.extend(HLTScoutingAll.outputCommands)
+HLTriggerRAW.outputCommands.extend(HLTScoutingAll.outputCommands)
+HLTDebugRAW.outputCommands.extend(HLTScoutingAll.outputCommands)
+HLTDebugFEVT.outputCommands.extend(HLTScoutingAll.outputCommands)
 #
 # DQM
 #

--- a/HLTrigger/Configuration/python/HLTScouting_EventContent_cff.py
+++ b/HLTrigger/Configuration/python/HLTScouting_EventContent_cff.py
@@ -26,6 +26,3 @@ HLTScoutingAll = cms.PSet(
         'keep *_hltScoutingPrimaryVertexPackerCaloMuon_*_*', # added  w/ PR#20739, removed w/  PR#37114
     ) )
 )
-
-
-

--- a/HLTrigger/Configuration/python/HLTScouting_EventContent_cff.py
+++ b/HLTrigger/Configuration/python/HLTScouting_EventContent_cff.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+
+# EventContent for HLT Scouting products.
+
+# This file keep track of all the scouting objects used since Run-2 
+# HLTScoutingAll is used in Configuration/EventContent to keep all scouting objects available in all AOD/MINIAOD[SIM]
+
+HLTScoutingAll = cms.PSet(
+    outputCommands = cms.vstring( *(
+        ## Current scouting objects (from 2024)
+        'keep *_hltFEDSelectorL1_*_*',  # PR#20739
+        'keep *_hltScoutingEgammaPacker_*_*', # PR#20739
+        'keep *_hltScoutingMuonPackerNoVtx_*_*', # PR#44302
+        'keep *_hltScoutingMuonPackerVtx_*_*',  # PR#44302
+        'keep *_hltScoutingPFPacker_*_*', # PR#20739
+        'keep *_hltScoutingPrimaryVertexPacker_*_*',  # PR#20739
+        'keep *_hltScoutingTrackPacker_*_*', # PR #23077
+        
+        ## Previous scouting objects
+        # Run3 (2022-23)
+        'keep *_hltScoutingMuonPacker_*_*', # added w/ PR#20739, removed w/ PR#44302
+        
+        # Run2 only
+        'keep *_hltScoutingCaloPacker_*_*',  # added  w/ PR#20739, removed w/ PR#37114
+        'keep *_hltScoutingMuonPackerCalo_*_*', # added  w/ PR#20739, removed w/  PR#37114
+        'keep *_hltScoutingPrimaryVertexPackerCaloMuon_*_*', # added  w/ PR#20739, removed w/  PR#37114
+    ) )
+)
+
+
+


### PR DESCRIPTION
Scouting collections have been added to AOD since Run-2 [1] and to MINIAOD since 2024 data/MC (13_3_X) [2] [3].
Scouting collections are defined [/HLTrigger/Configuration/python/HLTrigger_EventContent_cff.py](https://github.com/cms-sw/cmssw/blob/master/HLTrigger/Configuration/python/HLTrigger_EventContent_cff.py). However `HLTrigger_EventContent_cff.py` is produced semi-automatically from the HLT menu used by TSG.

This means that currently AOD and MINIAOD know only the current scouting collections, and therefore running reMINI from Run-2 data we might loose the Run-2 scouting collections.

This issue have been already discussed in [CMSHLT-3593](https://its.cern.ch/jira/browse/CMSHLT-3593) and https://github.com/cms-sw/cmssw/pull/48465 , as in 2024 we replaced `hltScoutingMuonPacker` collection with `hltScoutingMuonPackerVtx` and `hltScoutingMuonPackerNoVtx` collections

This PR adds a new file `HLTrigger/Configuration/python/HLTScouting_EventContent_cff.py` with the definition of all scouting collections used since Run-2. This file is used in `Configuration/EventContent/python/EventContent_cff.py` to include the scouting collections to all HLT event contents.

Note: for Phase-2, this approach will allow use to reprocess Run-3 data with scouting collection.

I tested this PR in two ways:
- I checked the diff of all PSet produced by  `Configuration/EventContent/python/EventContent_cff.py` , and I see that the previous scouting objects are added proper collection 
```
'HLTriggerAOD': cms.PSet(
     outputCommands = cms.vstring(
@@ -2089,7 +2111,18 @@
     outputCommands = cms.vstring(
         'drop *_hlt*_*_*',
         'keep FEDRawDataCollection_rawDataCollector_*_*',
@@ -2059,7 +2059,18 @@
         'keep *_hltScoutingPFPacker_*_*',
         'keep *_hltScoutingPrimaryVertexPacker_*_*',
         'keep *_hltScoutingTrackPacker_*_*',
-        'keep edmTriggerResults_*_*_*'
+        'keep edmTriggerResults_*_*_*',
+        'keep *_hltFEDSelectorL1_*_*',
+        'keep *_hltScoutingEgammaPacker_*_*',
+        'keep *_hltScoutingMuonPackerNoVtx_*_*',
+        'keep *_hltScoutingMuonPackerVtx_*_*',
+        'keep *_hltScoutingPFPacker_*_*',
+        'keep *_hltScoutingPrimaryVertexPacker_*_*',
+        'keep *_hltScoutingTrackPacker_*_*',
+        'keep *_hltScoutingMuonPacker_*_*',
+        'keep *_hltScoutingCaloPacker_*_*',
+        'keep *_hltScoutingMuonPackerCalo_*_*',
+        'keep *_hltScoutingPrimaryVertexPackerCaloMuon_*_*'
     )
```
- I ran a reMini from Run-2 data 
`cmsDriver.py step2  -s PAT,VALIDATION:@miniAODValidation,DQM:@miniAODDQM --era Run2_2018 -n 100 --process PAT --conditions auto:phase1_2018_realistic --mc  --scenario pp --eventcontent MINIAODSIM,DQM --datatier MINIAODSIM,DQMIO --procModifiers run2_miniAOD_UL_preSummer20 --filein root://eoscms.cern.ch//store/user/cmsbuild/store/relval/CMSSW_10_6_4/RelValProdTTbar_13_pmx25ns/AODSIM/PUpmx25ns_106X_upgrade2018_realistic_v9-v1/10000/4440FA53-897B-9A4B-AD76-D1337B591A2F.root --fileout file:step2.root  --number 1`  
(taken from `runTheMatrix.py -l 2500.024`)
with and without the PR.
The diff of `edmDumpEventContent` of the two files is:
```
> double                                "hltScoutingCaloPacker"     "caloMetPhi"      "HLT"     
> double                                "hltScoutingCaloPacker"     "caloMetPt"       "HLT"     
> double                                "hltScoutingCaloPacker"     "rho"             "HLT"     
> vector<ScoutingCaloJet>               "hltScoutingCaloPacker"     ""                "HLT"     
> vector<ScoutingMuon>                  "hltScoutingMuonPacker"     ""                "HLT"     
> vector<ScoutingMuon>                  "hltScoutingMuonPackerCalo"   ""                "HLT"     
> vector<ScoutingVertex>                "hltScoutingMuonPacker"     "displacedVtx"    "HLT"     
> vector<ScoutingVertex>                "hltScoutingMuonPackerCalo"   "displacedVtx"    "HLT"     
> vector<ScoutingVertex>                "hltScoutingPrimaryVertexPackerCaloMuon"   "primaryVtx"      "HLT" 
```
as expected.

cc: @cms-sw/hlt-l2 @missirol @elfontan @patinkaew @cms-sw/pdmv-l2 

[1] #21295
[2] #42863
[3] #43327