### PR TITLE
Improve TestFWCoreServicesDriver_AsyncService test

### DIFF
--- a/FWCore/Services/test/AsyncServiceTester.cc
+++ b/FWCore/Services/test/AsyncServiceTester.cc
@@ -2,6 +2,7 @@
 #include "FWCore/Concurrency/interface/chain_first.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -194,6 +195,7 @@ namespace edmtest {
           std::move(holder),
           [this, testService]() {
             auto callGuard = globalCache()->makeRunCallGuard(0);
+            edm::LogPrint("AsyncServiceWaitingTester") << "Running async function for stream " << *streamId_;
             if (testService and waitStreamEndRun_) {
               testService->wait();
             }

--- a/FWCore/Services/test/AsyncServiceTester.cc
+++ b/FWCore/Services/test/AsyncServiceTester.cc
@@ -18,11 +18,18 @@ namespace edmtest {
   public:
     AsyncServiceTesterService(edm::ParameterSet const& iConfig, edm::ActivityRegistry& iRegistry) : continue_{false} {
       if (iConfig.getParameter<bool>("watchEarlyTermination")) {
-        iRegistry.watchPreSourceEarlyTermination([this](edm::TerminationOrigin) { release(); });
-        iRegistry.watchPreGlobalEarlyTermination(
-            [this](edm::GlobalContext const&, edm::TerminationOrigin) { release(); });
-        iRegistry.watchPreStreamEarlyTermination(
-            [this](edm::StreamContext const&, edm::TerminationOrigin) { release(); });
+        iRegistry.watchPreSourceEarlyTermination([this](edm::TerminationOrigin) {
+          edm::LogPrint("AsyncServiceTester") << "Received PreSourceEarlyTermination signal";
+          release();
+        });
+        iRegistry.watchPreGlobalEarlyTermination([this](edm::GlobalContext const&, edm::TerminationOrigin) {
+          edm::LogPrint("AsyncServiceTester") << "Received PreGlobalEarlyTermination signal";
+          release();
+        });
+        iRegistry.watchPreStreamEarlyTermination([this](edm::StreamContext const&, edm::TerminationOrigin) {
+          edm::LogPrint("AsyncServiceTester") << "Received PreStreamEarlyTermination signal";
+          release();
+        });
       }
       if (iConfig.getParameter<bool>("watchStreamEndRun")) {
         // StreamEndRun is the last stream transition in the data
@@ -138,12 +145,42 @@ namespace edmtest {
     std::atomic<int> status_ = 0;
   };
 
+  class AsyncServiceWaitingTesterCache {
+  public:
+    using RunGuard = AsyncServiceTesterCache::RunGuard;
+    RunGuard makeRunCallGuard(int inc) const { return testerCache_.makeRunCallGuard(inc); }
+
+    auto outstandingRunCalls() const { return testerCache_.outstandingRunCalls.load(); }
+
+    void waitInThrowingStream() const {
+      std::unique_lock lk(mutex_);
+      if (not continue_) {
+        cond_.wait(lk, [this]() { return continue_; });
+      }
+    }
+
+    void throwingStreamCanContinue() const {
+      std::unique_lock lk(mutex_);
+      if (not continue_) {
+        continue_ = true;
+        cond_.notify_all();
+      }
+    }
+
+  private:
+    AsyncServiceTesterCache testerCache_;
+
+    mutable std::mutex mutex_;
+    mutable std::condition_variable cond_;
+    CMS_THREAD_GUARD(mutex_) mutable bool continue_ = false;
+  };
+
   class AsyncServiceWaitingTester : public edm::stream::EDProducer<edm::ExternalWork,
-                                                                   edm::GlobalCache<AsyncServiceTesterCache>,
+                                                                   edm::GlobalCache<AsyncServiceWaitingTesterCache>,
                                                                    edm::stream::WatchLuminosityBlocks,
                                                                    edm::stream::WatchRuns> {
   public:
-    AsyncServiceWaitingTester(edm::ParameterSet const& iConfig, AsyncServiceTesterCache const*)
+    AsyncServiceWaitingTester(edm::ParameterSet const& iConfig, AsyncServiceWaitingTesterCache const*)
         : throwingStream_(iConfig.getUntrackedParameter<unsigned int>("throwingStream")),
           waitEarlyTermination_(iConfig.getUntrackedParameter<bool>("waitEarlyTermination")),
           waitStreamEndRun_(iConfig.getUntrackedParameter<bool>("waitStreamEndRun")) {
@@ -173,7 +210,9 @@ namespace edmtest {
       descriptions.setComment("One of 'waitEarlyTermination' and 'waitStreamEndRun' must be set to 'True'");
     }
 
-    static auto initializeGlobalCache(edm::ParameterSet const&) { return std::make_unique<AsyncServiceTesterCache>(); }
+    static auto initializeGlobalCache(edm::ParameterSet const&) {
+      return std::make_unique<AsyncServiceWaitingTesterCache>();
+    }
 
     void beginStream(edm::StreamID id) { streamId_ = id; }
 
@@ -181,6 +220,10 @@ namespace edmtest {
       bool const waitOnThisStream = *streamId_ != throwingStream_;
       AsyncServiceTesterService* testService = nullptr;
       if (waitOnThisStream) {
+        // Signal from non-throwing stream that the module in the throwing stream can continue
+        // Must be done before the testService->wait()
+        globalCache()->throwingStreamCanContinue();
+
         edm::Service<AsyncServiceTesterService> tsh;
         testService = &*tsh;
         if (waitEarlyTermination_)
@@ -195,7 +238,7 @@ namespace edmtest {
           std::move(holder),
           [this, testService]() {
             auto callGuard = globalCache()->makeRunCallGuard(0);
-            edm::LogPrint("AsyncServiceWaitingTester") << "Running async function for stream " << *streamId_;
+            edm::LogPrint("AsyncServiceTester") << "Running async function for stream " << *streamId_;
             if (testService and waitStreamEndRun_) {
               testService->wait();
             }
@@ -214,6 +257,13 @@ namespace edmtest {
         throw cms::Exception("Assert") << "In analyze: status_ was " << status_ << ", expected 1";
       }
       status_ = 0;
+
+      // Wait in the modules's Event transition in the throwing stream
+      // until the module's Event transition has started in some other
+      // stream
+      if (*streamId_ == throwingStream_) {
+        globalCache()->waitInThrowingStream();
+      }
     }
 
     void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) final {
@@ -232,9 +282,9 @@ namespace edmtest {
       }
     }
 
-    static void globalEndJob(AsyncServiceTesterCache* cache) {
-      if (cache->outstandingRunCalls != 0) {
-        throw cms::Exception("Assert") << "In globalEndJob: " << cache->outstandingRunCalls
+    static void globalEndJob(AsyncServiceWaitingTesterCache* cache) {
+      if (cache->outstandingRunCalls() != 0) {
+        throw cms::Exception("Assert") << "In globalEndJob: " << cache->outstandingRunCalls()
                                        << " runAsync() calls outstanding, expected 0";
       }
     }

--- a/FWCore/Services/test/BuildFile.xml
+++ b/FWCore/Services/test/BuildFile.xml
@@ -18,6 +18,7 @@
   <flags EDM_PLUGIN="1"/>
   <use name="FWCore/Concurrency"/>
   <use name="FWCore/Framework"/>
+  <use name="FWCore/MessageLogger"/>
   <use name="FWCore/ServiceRegistry"/>
   <use name="FWCore/Utilities"/>
 </library>

--- a/FWCore/Services/test/test_asyncservice.sh
+++ b/FWCore/Services/test/test_asyncservice.sh
@@ -1,36 +1,26 @@
 #!/bin/bash
 
-function die { cat log.txt; echo $1: status $2 ;  exit $2; }
+function die { cat $1; echo $2: status $3 ;  exit 32; }
 
 CONF=${SCRAM_TEST_PATH}/test_asyncservice_cfg.py
 # Normal behavior
 echo "cmsRun ${CONF}"
-cmsRun ${CONF} > log.txt 2>&1 || die "Failure using ${CONF}" $?
+cmsRun ${CONF} > log_normal.txt 2>&1 || die log_normal.txt "Failure using ${CONF}" $?
 
 # Framework emits early termination signal, AsyncService should disallow run() calls
 echo "cmsRun ${CONF} --earlyTermination"
-cmsRun ${CONF} --earlyTermination > log.txt 2>&1
-RET=$?
-if [ "${RET}" == "0" ]; then
-    cat log.txt
-    die "${CONF} --earlyTermination succeeded while it was expected to fail" 1
-fi
-grep -q "ZombieKillerService" log.txt && die "${CONF} --earlyTermination was killed by ZombieKillerService, while the job should have failed by itself" 1
-grep -q "AsyncCallNotAllowed" log.txt || die "${CONF} --earlyTermination did not fail with AsyncCallNotAllowed" $?
-grep -q "Framework is shutting down, further run() calls are not allowed" log.txt || die "${CONF} --earlyTermination did not contain expected earlyTermination message" $?
+cmsRun ${CONF} --earlyTermination > log_earlyTermination.txt 2>&1 && die log_earlytermination.txt "${CONF} --earlyTermination succeeded while it was expected to fail" 1
+grep -q "ZombieKillerService" log_earlyTermination.txt && die log_earlyTermination.txt "${CONF} --earlyTermination was killed by ZombieKillerService, while the job should have failed by itself" 1
+grep -q "AsyncCallNotAllowed" log_earlyTermination.txt || die log_earlyTermination.txt "${CONF} --earlyTermination did not fail with AsyncCallNotAllowed" $?
+grep -q "Framework is shutting down, further run() calls are not allowed" log_earlyTermination.txt || die log_earlyTermination.txt "${CONF} --earlyTermination did not contain expected earlyTermination message" $?
 
 # Another module throws an exception while an asynchronous function is
 # running, ensure the framework to keep the data processing open until
 # all asynchronous functions have returned
 echo "cmsRun ${CONF} --exception"
-cmsRun ${CONF} --exception > log.txt 2>&1
-RET=$?
-if [ "${RET}" == "0" ]; then
-    cat log.txt
-    die "${CONF} --exception succeeded while it was expected to fail" 1
-fi
-grep -q "ZombieKillerService" log.txt && die "${CONF} --exception was killed by ZombieKillerService" 1
-grep -q "MoreExceptions:  AfterModEndJob" log.txt && die "${CONF} --exception threw an unexpected exception in EndJob" 1
-grep -q "Intentional 'NotFound' exception for testing purposes" log.txt || die "${CONF} --exception failed in unexpected way" $?
+cmsRun ${CONF} --exception > log_exception.txt 2>&1 && die log_exception.txt "${CONF} --exception succeeded while it was expected to fail" 1
+grep -q "ZombieKillerService" log_exception.txt && die log_exception.txt "${CONF} --exception was killed by ZombieKillerService" 1
+grep -q "MoreExceptions:  AfterModEndJob" log_exception.txt && die log_exception.txt "${CONF} --exception threw an unexpected exception in EndJob" 1
+grep -q "Intentional 'NotFound' exception for testing purposes" log_exception.txt || die log_exception.txt "${CONF} --exception failed in unexpected way" $?
 
 exit 0


### PR DESCRIPTION
#### PR description:

This PR improves the TestFWCoreServicesDriver_AsyncService to require that at least one other stream than the stream where an exception is thrown starts the Event transition. This should prevent the failure reported in https://github.com/cms-sw/cmssw/issues/48627 .

Resolves https://github.com/cms-sw/cmssw/issues/48627
Resolves https://github.com/cms-sw/framework-team/issues/1474

#### PR validation:

The test succeeds (althou