### PR TITLE
Add access to dEdx error

### DIFF
--- a/Configuration/Eras/python/Era_Run2_2016_UPC_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2016_UPC_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
 from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
 from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
+from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 
-Run2_2016_UPC = cms.ModifierChain(Run2_2016, egamma_lowPt_exclusive, highBetaStar, run3_upc)
+Run2_2016_UPC = cms.ModifierChain(Run2_2016, egamma_lowPt_exclusive, highBetaStar, dedx_lfit, run3_upc)

--- a/Configuration/Eras/python/Era_Run3_2023_UPC_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2023_UPC_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Run3_2023_cff import Run3_2023
 from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
 from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
+from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 
-Run3_2023_UPC = cms.ModifierChain(Run3_2023, egamma_lowPt_exclusive, highBetaStar, run3_upc)
+Run3_2023_UPC = cms.ModifierChain(Run3_2023, egamma_lowPt_exclusive, highBetaStar, dedx_lfit, run3_upc)

--- a/Configuration/Eras/python/Era_Run3_2024_UPC_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2024_UPC_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
 from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
 from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
+from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 
-Run3_2024_UPC = cms.ModifierChain(Run3_2024, egamma_lowPt_exclusive, highBetaStar, run3_upc)
+Run3_2024_UPC = cms.ModifierChain(Run3_2024, egamma_lowPt_exclusive, highBetaStar, dedx_lfit, run3_upc)

--- a/Configuration/Eras/python/Era_Run3_2025_OXY_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_OXY_cff.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
+from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
 
-Run3_2025_OXY = cms.ModifierChain(Run3_2025, run3_upc, run3_oxygen)
+Run3_2025_OXY = cms.ModifierChain(Run3_2025, dedx_lfit, run3_upc, run3_oxygen)

--- a/Configuration/Eras/python/Era_Run3_2025_UPC_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_UPC_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
 from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
 from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
+from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 
-Run3_2025_UPC = cms.ModifierChain(Run3_2025, egamma_lowPt_exclusive, highBetaStar, run3_upc)
+Run3_2025_UPC = cms.ModifierChain(Run3_2025, egamma_lowPt_exclusive, highBetaStar, dedx_lfit, run3_upc)

--- a/Configuration/Eras/python/Modifier_dedx_lfit_cff.py
+++ b/Configuration/Eras/python/Modifier_dedx_lfit_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+dedx_lfit =cms.Modifier()

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3570,6 +3570,7 @@ steps['REMINIAODHI2022PPRECOMB']=merge([{'-s':'PAT,VALIDATION:@miniAODValidation
                                          '-n':100,
                                          '--era':'Run3_pp_on_PbPb',
                                          '--procModifiers':'genJetSubEvent',
+                                         '--customise':'IOPool/Input/fixReading_12_4_X_Files.fixReading_12_4_X_Files'
                                      },hiDefaults2022_ppReco,step3Up2015Defaults])
 
 steps['ALCARECOHI2022PPRECO']=merge([hiDefaults2022_ppReco,{'-s':'ALCA:TkAlMinBias+SiStripCalMinBias',

--- a/DataFormats/TrackReco/interface/DeDxData.h
+++ b/DataFormats/TrackReco/interface/DeDxData.h
@@ -8,7 +8,8 @@ namespace reco {
   class DeDxData {
   public:
     DeDxData();
-    DeDxData(float val, float er, unsigned int num);
+    DeDxData(float val, int nsat, unsigned int num);
+    DeDxData(float val, float er, int sat, unsigned int num);
     virtual ~DeDxData();
     float dEdx() const;
     float dEdxError() const;
@@ -19,6 +20,7 @@ namespace reco {
     float value_;
     float error_;
     unsigned int numberOfMeasurements_;
+    int numberOfSatMeasurements_;
   };
 
   //Association Track -> float estimator

--- a/DataFormats/TrackReco/src/DeDxData.cc
+++ b/DataFormats/TrackReco/src/DeDxData.cc
@@ -2,19 +2,24 @@
 
 using namespace reco;
 
-DeDxData::DeDxData() : value_(0.), error_(0.), numberOfMeasurements_(0) { ; }
+DeDxData::DeDxData() : value_(0.), error_(0.), numberOfMeasurements_(0), numberOfSatMeasurements_(0) { ; }
 
-DeDxData::DeDxData(float val, float er, unsigned int num) : value_(val), error_(er), numberOfMeasurements_(num) { ; }
+DeDxData::DeDxData(float val, int sat, unsigned int num)
+    : value_(val), error_(-1.), numberOfMeasurements_(num), numberOfSatMeasurements_(sat) {
+  ;
+}
+
+DeDxData::DeDxData(float val, float er, int sat, unsigned int num)
+    : value_(val), error_(er), numberOfMeasurements_(num), numberOfSatMeasurements_(sat) {
+  ;
+}
 
 DeDxData::~DeDxData() { ; }
 
 float DeDxData::dEdx() const { return value_; }
 
-float DeDxData::dEdxError() const {
-  return -1;
-  /*error_;*/
-}
+float DeDxData::dEdxError() const { return error_; }
 
 unsigned int DeDxData::numberOfMeasurements() const { return numberOfMeasurements_; }
 
-int DeDxData::numberOfSaturatedMeasurements() const { return error_ >= 0 ? (int)error_ : 0; }
+int DeDxData::numberOfSaturatedMeasurements() const { return numberOfSatMeasurements_; }

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -426,7 +426,8 @@
   </class>
   <class name="std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,std::vector<reco::DeDxHit> >" />
      <!--   <class name="reco::DeDxDataCollection"/> -->
-     <class name="reco::DeDxData" ClassVersion="10">
+     <class name="reco::DeDxData" ClassVersion="11">
+      <version ClassVersion="11" checksum="30657010"/>
       <version ClassVersion="10" checksum="204721063"/>
      </class>
      <class name="reco::DeDxDataCollection"/>

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastTrackDeDxProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastTrackDeDxProducer.cc
@@ -231,10 +231,7 @@ void FastTrackDeDxProducer::produce(edm::Event& iEvent, const edm::EventSetup&) 
 
     sort(dedxHits.begin(), dedxHits.end(), less<DeDxHit>());
     std::pair<float, float> val_and_error = m_estimator->dedx(dedxHits);
-    //WARNING: Since the dEdX Error is not properly computed for the moment
-    //It was decided to store the number of saturating cluster in that dataformat
-    val_and_error.second = NClusterSaturating;
-    dedxEstimate[j] = DeDxData(val_and_error.first, val_and_error.second, dedxHits.size());
+    dedxEstimate[j] = DeDxData(val_and_error.first, val_and_error.second, NClusterSaturating, dedxHits.size());
   }
 
   filler.insert(trackCollectionHandle, dedxEstimate.begin(), dedxEstimate.end());

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -121,14 +121,15 @@ from PhysicsTools.PatAlgos.slimming.patPhotonDRNCorrector_cfi import patPhotonsD
 from Configuration.ProcessModifiers.photonDRN_cff import _photonDRN
 _photonDRN.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), patPhotonsDRN))
 
-from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
+from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
 from PhysicsTools.PatAlgos.modules import DeDxEstimatorRekeyer
 dedxEstimator = DeDxEstimatorRekeyer()
-run3_upc.toModify(dedxEstimator, dedxEstimators = ["dedxHarmonic2", "dedxPixelHarmonic2", "dedxPixelLikelihood", "dedxStripLikelihood", "dedxAllLikelihood"])
+dedx_lfit.toModify(dedxEstimator, dedxEstimators = ["dedxPixelLikelihood", "dedxStripLikelihood", "dedxAllLikelihood"])
+
+from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 run3_upc.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), hiPixelTracks, packedPFCandidateTrackChi2, lostTrackChi2, dedxEstimator))
 
 from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
-run3_oxygen.toModify(dedxEstimator, dedxEstimators = ["dedxPixelLikelihood", "dedxStripLikelihood", "dedxAllLikelihood"])
 run3_oxygen.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), hiPixelTracks, hiEvtPlane, hiEvtPlaneFlat, packedPFCandidateTrackChi2, lostTrackChi2, centralityBin))
 
 from Configuration.Eras.Modifier_ppRef_2024_cff import ppRef_2024

--- a/RecoTracker/Configuration/python/RecoTracker_EventContent_cff.py
+++ b/RecoTracker/Configuration/python/RecoTracker_EventContent_cff.py
@@ -23,7 +23,8 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 (pp_on_AA | run3_upc).toModify( RecoTrackerAOD.outputCommands,
                    func=lambda outputCommands: outputCommands.extend(['keep recoTracks_hiConformalPixelTracks_*_*'])
 )
-run3_upc.toModify( RecoTrackerAOD.outputCommands,
+from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
+dedx_lfit.toModify( RecoTrackerAOD.outputCommands,
         func=lambda outputCommands: outputCommands.extend([
             'keep *_dedxPixelLikelihood_*_*',
             'keep *_dedxStripLikelihood_*_*',

--- a/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.cc
+++ b/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.cc
@@ -156,10 +156,7 @@ void DeDxEstimatorProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
     sort(dedxHits.begin(), dedxHits.end(), less<DeDxHit>());
     std::pair<float, float> val_and_error = m_estimator->dedx(dedxHits);
 
-    //WARNING: Since the dEdX Error is not properly computed for the moment
-    //It was decided to store the number of saturating cluster in that dataformat
-    val_and_error.second = NClusterSaturating;
-    dedxEstimate[j] = DeDxData(val_and_error.first, val_and_error.second, dedxHits.size());
+    dedxEstimate[j] = DeDxData(val_and_error.first, val_and_error.second, NClusterSaturating, dedxHits.size());
   }
   ///////////////////////////////////////
 

--- a/RecoTracker/DeDx/python/dedxEstimators_cff.py
+++ b/RecoTracker/DeDx/python/dedxEstimators_cff.py
@@ -117,5 +117,5 @@ dedxAllLikelihood = _mod.DeDxEstimatorProducer.clone(
 dedxPixelLikelihood = dedxAllLikelihood.clone(UseStrip = False, UsePixel = True)
 dedxStripLikelihood = dedxAllLikelihood.clone(UseStrip = True,  UsePixel = False)
 
-from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
-run3_upc.toReplaceWith(doAlldEdXEstimatorsTask, cms.Task(doAlldEdXEstimatorsTask.copy(), dedxAllHitInfo, dedxHitCalibrator, dedxStripLikelihood, dedxPixelLikelihood, dedxAllLikelihood))
+from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
+dedx_lfit.toReplaceWith(doAlldEdXEstimatorsTask, cms.Task(doAlldEdXEstimatorsTask.copy(), dedxAllHitInfo, dedxHitCalibrator, dedxStripLikelihood, dedxPixelLikelihood, dedxAllLikelihood))


### PR DESCRIPTION
#### PR description:

This PR provides the option to access the error of the dEdx estimate derived from the loglikelihood dEdx estimator. In addition, it decouples the loglikelihood dEdx estimator from the UPC eras, by using a dedicated era modifier dedx_lfit.

@mandrenguyen @sikler 

#### PR validation:

tested with 141.901,141.902,142.901,142.902,142.903,143.901,143.902,143.911,143.912,143.921

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
