### PR TITLE
added new miniAODDQMBtagOnly sequence to OfflineDQM

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -276,5 +276,6 @@ from Validation.RecoParticleFlow.DQMForPF_MiniAOD_cff import *
 from DQMOffline.RecoB.bTagMiniDQM_cff import *
 
 DQMHarvestMiniAOD = cms.Sequence( dataCertificationJetMETSequence * muonQualityTests_miniAOD * DQMHarvestPF * bTagMiniDQMHarvesting)
+DQMHarvestMiniAODBTagOnly = cms.Sequence(bTagMiniDQMHarvesting)
 DQMHarvestNanoAOD = cms.Sequence( nanoHarvest )
 

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -302,6 +302,7 @@ from DQMOffline.Muon.miniAOD_cff import *
 from DQM.Physics.DQMTopMiniAOD_cff import *
 
 DQMOfflineMiniAOD = cms.Sequence(jetMETDQMOfflineRedoProductsMiniAOD*bTagMiniDQMSource*muonMonitors_miniAOD*MuonMiniAOD*DQMOfflinePF)
+DQMOfflineMiniAODBTagOnly = cms.Sequence(bTagMiniDQMSource)
 
 #Post sequences are automatically placed in the EndPath by ConfigBuilder if PAT is run.
 #miniAOD DQM sequences need to access the filter results.

--- a/DQMOffline/Configuration/python/autoDQM.py
+++ b/DQMOffline/Configuration/python/autoDQM.py
@@ -202,6 +202,10 @@ autoDQM = { 'DQMMessageLogger': ['DQMMessageLoggerSeq',
                            'PostDQMOfflineMiniAOD',
                            'DQMHarvestMiniAOD'],
 
+            'miniAODDQMBTagOnly': ['DQMOfflineMiniAODBTagOnly',
+                            'PostDQMOfflineMiniAOD',
+                           'DQMHarvestMiniAODBTagOnly'],  
+
             'nanoAODDQM': ['DQMOfflineNanoAOD',
                            'PostDQMOffline',
                            'DQMHarvestNanoAOD'],


### PR DESCRIPTION
#### PR description:

Added a new sequence named ```miniAODDQMBTagOnly``` in ```autoDQM.py```, which runs solely the bTag part of the ```miniAODDQM``` sequence. This sequence is implemented so that it may be run at Tier-0 with the tag ```@miniAODDQMBTagOnly``` monitoring of bTag DQM quantities on Tier-0 datasets. 

#### PR validation:

The PR was validated by running a T0 wrapper for the DQM sequence with the new ```@miniAODDQMBTagOnly``` tag. The output was inspected to verify that the relevant bTag histograms were correctly produced in the resulting DQM file. 
