### PR TITLE
Make `edm::Hash` compatible with `std::ranges::less`

### DIFF
--- a/DataFormats/Provenance/test/BuildFile.xml
+++ b/DataFormats/Provenance/test/BuildFile.xml
@@ -3,7 +3,7 @@
 <use name="DataFormats/Provenance"/>
 </bin>
 
-<bin name="testDataFormatsProvenanceCatch2" file="ElementID_t.cpp,Parentage_t.cpp,StoredProcessBlockHelper_t.cpp,CompactHash_t.cpp,HardwareResourcesDescription_t.cpp,ProductNamePattern_t.cpp">
+<bin name="testDataFormatsProvenanceCatch2" file="ElementID_t.cpp,Parentage_t.cpp,StoredProcessBlockHelper_t.cpp,CompactHash_t.cpp,Hash_t.cpp,HardwareResourcesDescription_t.cpp,ProductNamePattern_t.cpp">
   <use name="DataFormats/Provenance"/>
   <use name="catch2"/>
 </bin>

--- a/DataFormats/Provenance/test/Hash_t.cpp
+++ b/DataFormats/Provenance/test/Hash_t.cpp
@@ -1,0 +1,62 @@
+#include "catch.hpp"
+
+#include <algorithm>
+#include <ranges>
+#include <vector>
+
+#include "DataFormats/Provenance/interface/Hash.h"
+#include "FWCore/Utilities/interface/Digest.h"
+
+namespace {
+  using TestHash = edm::Hash<100>;
+}
+
+TEST_CASE("Hash", "[Hash]") {
+  SECTION("Default construction is invalid") { REQUIRE(TestHash{}.isValid() == false); }
+
+  SECTION("Basic operations") {
+    cms::Digest d("foo");
+    auto result = d.digest().toString();
+
+    TestHash id{result};
+    REQUIRE(id.isValid() == true);
+    {
+      std::string idString;
+      id.toString(idString);
+      REQUIRE(idString == result);
+    }
+
+    TestHash id2 = id;
+    REQUIRE(id2.isValid() == true);
+    {
+      std::string id2String;
+      id2.toString(id2String);
+      REQUIRE(id2String == result);
+    }
+
+    cms::Digest b("bar");
+    auto diffResult = b.digest().toString();
+    REQUIRE(id2 == TestHash{result});
+    REQUIRE(id2 != TestHash{diffResult});
+
+    REQUIRE(id2 > TestHash{diffResult});
+    REQUIRE(TestHash{diffResult} < id2);
+
+    REQUIRE(not(id2 < id2));
+  }
+
+  SECTION("std::ranges::sort") {
+    std::vector<TestHash> container{TestHash{cms::Digest("foo").digest().toString()},
+                                    TestHash{cms::Digest("bar").digest().toString()},
+                                    TestHash{cms::Digest("fred").digest().toString()},
+                                    TestHash{cms::Digest("wilma").digest().toString()}};
+    CHECK(container[0] > container[1]);
+    CHECK(container[1] < container[2]);
+    CHECK(container[2] > container[3]);
+
+    std::ranges::sort(container);
+    CHECK(container[0] < container[1]);
+    CHECK(container[1] < container[2]);
+    CHECK(container[2] < container[3]);
+  }
+}


### PR DESCRIPTION
#### PR description:

Supporting `std::ranges::less` allows `std::ranges::sort()` to be used with `edm::Hash`. The `std::ranges::less` requires all six comparison operators to be defined. I decided to use the three-way comparison operator as the base implementation because of why not. The equality and non-equality operators had to be defined explicitly because the three-way comparison operator is custom.

Motivated by wanting to use `std::ranges::sort()` in https://github.com/cms-sw/cmssw/pull/48562

Resolves https://github.com/cms-sw/framework-team/issues/1484

#### PR validation:

Unit test passes
