### PR TITLE
Improve the Phase 1 pixel raw to cluster (part 2)

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
@@ -565,18 +565,21 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         auto moduleStartFirstElement = cms::alpakatools::make_device_view(queue, clusters_d->view().moduleStart(), 1u);
         alpaka::memcpy(queue, nModules_Clusters_h, moduleStartFirstElement);
 
-        const auto elementsPerBlockFindClus = FindClus<TrackerTraits>::maxElementsPerBlock;
-        const auto workDivMaxNumModules =
-            cms::alpakatools::make_workdiv<Acc1D>(numberOfModules, elementsPerBlockFindClus);
+        {
+          const int blocks = 64;
+          const auto elementsPerBlockFindClus = FindClus<TrackerTraits>::maxElementsPerBlock;
+          const auto workDivMaxNumModules = cms::alpakatools::make_workdiv<Acc1D>(blocks, elementsPerBlockFindClus);
+
 #ifdef GPU_DEBUG
-        std::cout << " FindClus kernel launch with " << numberOfModules << " blocks of " << elementsPerBlockFindClus
-                  << " threadsPerBlockOrElementsPerThread\n";
+          std::cout << " FindClus kernel launch with " << numberOfModules << " blocks of " << elementsPerBlockFindClus
+                    << " threadsPerBlockOrElementsPerThread\n";
 #endif
-        alpaka::exec<Acc1D>(
-            queue, workDivMaxNumModules, FindClus<TrackerTraits>{}, digis_d->view(), clusters_d->view(), wordCounter);
+          alpaka::exec<Acc1D>(
+              queue, workDivMaxNumModules, FindClus<TrackerTraits>{}, digis_d->view(), clusters_d->view(), wordCounter);
 #ifdef GPU_DEBUG
-        alpaka::wait(queue);
+          alpaka::wait(queue);
 #endif
+        }
 
         constexpr auto threadsPerBlockChargeCut = 256;
         const auto workDivChargeCut = cms::alpakatools::make_workdiv<Acc1D>(numberOfModules, threadsPerBlockChargeCut);


### PR DESCRIPTION
#### PR description:

Implement a few small optimisations:
  - use only 64 groups, instead of one per module;
  - restrict the domain of atomic operations to per-block.

Together with #48580 (minus the changes reverted in #48609) these changes give 7% speed up to the pixel local reconstruction:

machine type | `CMSSW_15_0_10_patch2` | with #48581 | relative difference
---|---|---|---
2022 HLT node (2× Milan 7763, 2× T4) | 2495 ± 3 ev/s | 2670 ± 6 ev/s | +7%
2024 HLT node (2× Bergamo 9754, 3× L4) | 11598 ± 23 ev/s | 12447 ± 25 ev/s | +7%

The performance of the full HLT menu is not affected, as it is limited by the CPU part.

#### PR validation:

None.

No changes expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 15.0.x for the 2025 data taking.