### PR TITLE
Update the L1T Menu, L1TMuonEndCapParams and L1TCaloParams in 2025 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -102,11 +102,11 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for ppRef5TeV
     'phase1_2024_realistic_ppRef5TeV' : '141X_mcRun3_2024_realistic_ppRef5TeV_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2025
-    'phase1_2025_design'           :    '150X_mcRun3_2025_design_v3',
+    'phase1_2025_design'           :    '150X_mcRun3_2025_design_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2025
-    'phase1_2025_realistic'        :    '151X_mcRun3_2025_realistic_v3',
+    'phase1_2025_realistic'        :    '151X_mcRun3_2025_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2025, Strip tracker in DECO mode
-    'phase1_2025_cosmics'          :    '150X_mcRun3_2025cosmics_realistic_deco_v3',
+    'phase1_2025_cosmics'          :    '150X_mcRun3_2025cosmics_realistic_deco_v4',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '150X_mcRun4_realistic_v1'
 }

--- a/Configuration/AlCa/python/autoCondModifiers.py
+++ b/Configuration/AlCa/python/autoCondModifiers.py
@@ -115,7 +115,7 @@ def autoCondRelValForRun3(autoCond):
 
     GlobalTagRelValForRun3 = {}
     L1GtTriggerMenuForRelValForRun3 =    ','.join( ['L1Menu_Collisions2015_25nsStage1_v5' , "L1GtTriggerMenuRcd",             connectionString, "", "2023-01-28 12:00:00.000"] )
-    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2025_v1_2_0_xml'    , "L1TUtmTriggerMenuRcd",           connectionString, "", "2025-06-13 12:00:00.000"] )
+    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2025_v1_3_0_xml'    , "L1TUtmTriggerMenuRcd",           connectionString, "", "2025-07-24 05:13:35.000"] )
 
     for key,val in autoCond.items():
         if 'run3_data' in key or 'run3_hlt' in key :


### PR DESCRIPTION

#### PR description:

Update in the 2025 MC GTs with:
- the L1T Menu tag to use the new L1T menu for the 2025 data taking L1Menu_Collisions2025_v1_3_0_xml, see https://cms-talk.web.cern.ch/t/update-of-the-gt-with-the-new-2025-l1t-menu-tag-l1menu-collisions2025-v1-3-0-xml/127751

Moreover, the 'phase1_2025_realistic' GT was updated with
-  L1TMuonEndCapParams as in https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/29 
- L1TCaloParams as in https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/31

In particular, these are the GTs that are going to be updated
- 'phase1_2025_realistic': [151X_mcRun3_2025_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/151X_mcRun3_2025_realistic_v4) (diff wrt previous _v3 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/151X_mcRun3_2025_realistic_v4/151X_mcRun3_2025_realistic_v3))
- 'phase1_2025_design': [150X_mcRun3_2025_design_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_mcRun3_2025_design_v4) (diff wrt previous _v3 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/150X_mcRun3_2025_design_v4/150X_mcRun3_2025_design_v3))
- 'phase1_2025_cosmics'.  [150X_mcRun3_2025cosmics_realistic_deco_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_mcRun3_2025cosmics_realistic_deco_v4) (diff wrt previous _v3 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/150X_mcRun3_2025cosmics_realistic_deco_v4/150X_mcRun3_2025cosmics_realistic_deco_v3))


#### PR validation:


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

It will be backported to CMSSW_15_0_X