### PR TITLE
reset the list of trigger paths used for `ScoutingMuonTriggerAnalyzer` in presence of `Special` menus

### DIFF
--- a/HLTriggerOffline/Scouting/python/ScoutingMuonTriggerAnalyzer_cfi.py
+++ b/HLTriggerOffline/Scouting/python/ScoutingMuonTriggerAnalyzer_cfi.py
@@ -30,12 +30,13 @@ SingleMuL1 = ["L1_SingleMu11_SQ14_BMTF","L1_SingleMu10_SQ14_BMTF"]
 ScoutingMuonTriggerAnalysis_DoubleMu = DQMEDAnalyzer('ScoutingMuonTriggerAnalyzer',
     OutputInternalPath = cms.string('/HLT/ScoutingOffline/Muons/L1Efficiency/DoubleMu'), #Output of the root file
     ScoutingMuonCollection = cms.InputTag('hltScoutingMuonPackerVtx'),
-    triggerSelection = cms.vstring(["DST_PFScouting_ZeroBias*", "DST_PFScouting_DoubleEG_v*", "DST_PFScouting_JetHT_v*"]), #Denominator
+    triggerSelection = cms.vstring(["DST_PFScouting_ZeroBias_v*", "DST_PFScouting_DoubleEG_v*", "DST_PFScouting_JetHT_v*"]), #Denominator
+    special_HLT_Menus = cms.vstring(["LumiScan"]), # list of menus to use to reset the trigge selections
     triggerConfiguration = cms.PSet(
         hltResults            = cms.InputTag('TriggerResults','','HLT'),
         l1tResults            = cms.InputTag('','',''),
         l1tIgnoreMaskAndPrescale = cms.bool(False),
-        throw                 = cms.bool(False),
+        throw                 = cms.bool(True),
         usePathStatus = cms.bool(False),
     ),
     AlgInputTag = cms.InputTag("gtStage2Digis"),


### PR DESCRIPTION
#### PR description:

This PR is an alternative implementation of https://github.com/cms-sw/cmssw/pull/48529. 
It undoes commit 0eb0948bf55854908129546765eb3472877b4d06, restoring the *status quo ante* and solves the problem of not existing trigger expressions in the special menus, by means of resetting the list of trigger expressions to check in presence of certain table names in the HLT menu (specifically for the time being only for `LumiScan` as it's the only table that uses scouting other than `GRun`).

#### PR validation:

Run the following command (using the data from the most recent VdM scan in Jul 2025):

```
cmsRun DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py runInputDir=/eos/user/d/dpapagia/data runNumber=394413 scanOnce=True
```

successfully (no errors or warnings). 
In the log file I find the following (expected) message:

```bash
%MSG-w ScoutingMuonTriggerAnalyzer:   ScoutingMuonTriggerAnalyzer:ScoutingMuonTriggerAnalysis_DoubleMu@streamBeginRun  30-Jul-2025 09:26:22 CEST Run: 394413 Stream: 0
Detected LumiScan in HLT Config tableName(): /cdaq/special/2025/LumiScan/v1.2.0/HLT/V2; the list of trigger expressions is going to be overriden!
%MSG
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, might be backported if necessary.
