### PR TITLE
Enable secondary vertices in PbPb eras

### DIFF
--- a/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexing_cff.py
+++ b/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexing_cff.py
@@ -64,7 +64,7 @@ pp_on_XeXe_2017.toModify(inclusiveCandidateVertexFinder, minHits = 10, minPt = 1
 pp_on_XeXe_2017.toModify(inclusiveCandidateVertexFinderCvsL, minHits = 10, minPt = 1.0)
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 pp_on_AA.toModify(inclusiveVertexFinder, minHits = 999, minPt = 999.0)
-pp_on_AA.toModify(inclusiveCandidateVertexFinder, minHits = 999, minPt = 999.0)
+pp_on_AA.toModify(inclusiveCandidateVertexFinder, minHits = 10, minPt = 1.0)
 pp_on_AA.toModify(inclusiveCandidateVertexFinderCvsL, minHits = 999, minPt = 999.0)
 
 


### PR DESCRIPTION
#### PR description:

This PR enables the secondary vertices in PbPb eras which is needed for b-tagging algorithms (such as unified particle transformer). So far we were rerunning the secondary vertices at analysis level but it would be better to have it directly in prompt reco.

[Performance studies](https://docs.google.com/presentation/d/1srExpFKLPW9QMUdoL3L98ohc51q_AwyHHgwM8lFAeHs/edit?usp=sharing)


#### PR validation:

Tested with workflows 160,160.02,160.03,160.1,160.2,160.3,160.4,161,161.02,161.03,161.1,161.2,161.3,161.4

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
