### PR TITLE
Avoid relying on header parsing in ProductRegistry unit test

### DIFF
--- a/FWCore/Framework/test/productregistry.cppunit.cc
+++ b/FWCore/Framework/test/productregistry.cppunit.cc
@@ -110,18 +110,18 @@ void testProductRegistry::setUp() {
       std::make_shared<edm::ProductDescription>(edm::InEvent,
                                                 "labelovsimple",
                                                 "PROD",
-                                                "edm::OwnVector<edmtest::Simple>",
+                                                edm::TypeID(typeid(edm::OwnVector<edmtest::Simple>)).userClassName(),
                                                 "edmtestSimplesOwned",
                                                 "ovsimple",
                                                 edm::TypeWithDict(typeid(edm::OwnVector<edmtest::Simple>)));
-  simpleDerivedVecBranch_ =
-      std::make_shared<edm::ProductDescription>(edm::InEvent,
-                                                "labelovsimplederived",
-                                                "PROD",
-                                                "edm::OwnVector<edmtest::SimpleDerived>",
-                                                "edmtestSimpleDerivedsOwned",
-                                                "ovsimplederived",
-                                                edm::TypeWithDict(typeid(edm::OwnVector<edmtest::SimpleDerived>)));
+  simpleDerivedVecBranch_ = std::make_shared<edm::ProductDescription>(
+      edm::InEvent,
+      "labelovsimplederived",
+      "PROD",
+      edm::TypeID(typeid(edm::OwnVector<edmtest::SimpleDerived>)).userClassName(),
+      "edmtestSimpleDerivedsOwned",
+      "ovsimplederived",
+      edm::TypeWithDict(typeid(edm::OwnVector<edmtest::SimpleDerived>)));
 }
 
 namespace {


### PR DESCRIPTION
#### PR description:

Found in https://github.com/root-project/root/pull/18402#issuecomment-3136116268 (see https://github.com/root-project/root/pull/18402#issuecomment-3141360819).

Resolves https://github.com/cms-sw/framework-team/issues/1491

#### PR validation:

Unit test passes with the build of https://github.com/cms-sw/root/pull/222#issuecomment-3134654219