### PR TITLE
L1Calo , fix Zero Suppression  producer position to get it consistent with o2o definition

### DIFF
--- a/L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h
+++ b/L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h
@@ -75,9 +75,9 @@ namespace l1t {
       metHFPhiCalibration = 49,
       layer1HCalFBUpper = 50,
       layer1HCalFBLower = 51,
-      hiZDC = 52,
-      layer1ECalZS = 53,
-      layer1HCalZS = 54,
+      layer1ECalZS = 52,
+      layer1HCalZS = 53,
+      hiZDC = 54,
       NUM_CALOPARAMNODES = 55
     };
 


### PR DESCRIPTION


Changing position of ECAL and HCAL ZS to synchronise with  L1TriggerConfig/L1TConfigProducers/src/CaloParamsHelperO2O.h file. Now positions for ECAL and HCAL ZS 52 and 53 are consistently used

