### PR TITLE
LST: allow OT tracker hits on the input seeds

### DIFF
--- a/RecoTracker/LST/plugins/alpaka/LSTInputProducer.cc
+++ b/RecoTracker/LST/plugins/alpaka/LSTInputProducer.cc
@@ -158,14 +158,21 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
         std::vector<int> hitIdx;
         for (auto const& hit : seed.recHits()) {
+          auto det = hit.geographicalId().det();
           int subid = hit.geographicalId().subdetId();
-          if (subid == (int)PixelSubdetector::PixelBarrel || subid == (int)PixelSubdetector::PixelEndcap) {
+          if (det == DetId::Tracker) {
             const BaseTrackerRecHit* bhit = dynamic_cast<const BaseTrackerRecHit*>(&hit);
             const auto& clusterRef = bhit->firstClusterRef();
-            const auto clusterKey = clusterRef.cluster_pixel().key();
-            hitIdx.push_back(clusterKey);
+            if (subid == (int)PixelSubdetector::PixelBarrel || subid == (int)PixelSubdetector::PixelEndcap) {
+              const auto clusterKey = clusterRef.cluster_pixel().key();
+              hitIdx.push_back(clusterKey);
+            } else if (clusterRef.isPhase2()) {
+              hitIdx.push_back(clusterRef.rawIndex());
+            } else {
+              throw cms::Exception("LSTInputProducer") << "Unknown tracker hit type found!";
+            }
           } else {
-            throw cms::Exception("LSTInputProducer") << "Not pixel hits found!";
+            throw cms::Exception("LSTInputProducer") << "Not tracker hit found!";
           }
         }
 


### PR DESCRIPTION
needed to get the CA extension track loading to work, otherwise an exception is thrown on reading CA extension seeds.

I didn't do anything special on the internal LST side to deal with the OT hits.
The part that uses hit indices for cross-cleaning should work by means of loading the OT hit index as `OmniClusterRef::rawIndex()` (instead of a more direct cluster collection index as would be with `OmniClusterRef::cluster_phase2OT().key()`), this is done to avoid index collisions between the IT and the OT clusters. The `rawIndex` sets high bits based on the cluster type on top of the `key` already for a somewhat similar purpose (disambiguation).

No changes are expected (confirmed in LST CI tests) with regular IT-only seed inputs.

@VourMa 