### PR TITLE
Muon DPG custom-NANO updates enabling additional studies

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -265,7 +265,7 @@ steps['scoutingNANO_withPrompt_data14.0'] = merge([{'-s': 'NANO:@Prompt+@ScoutMo
 steps['muDPGNANO_data14.0'] = merge([{'-s': 'RAW2DIGI,NANO:@MUDPG', '-n': '100'},
                                      steps['NANO_data14.0']])
 
-steps['muDPGNANOBkg_data14.0'] = merge([{'-s': 'RAW2DIGI,NANO:@MUDPGBKG', '-n': '100'},
+steps['muDPGNANOBkg_data14.0'] = merge([{'-s': 'RAW2DIGI,RECO:localreco,NANO:@MUDPGBKG', '-n': '100'},
                                         steps['NANO_data14.0']])
 
 steps['hcalDPGNANO_data14.0'] = merge([{'-s': 'RAW2DIGI,RECO,NANO:@HCAL', '-n': '100',

--- a/DPGAnalysis/MuonTools/plugins/BuildFile.xml
+++ b/DPGAnalysis/MuonTools/plugins/BuildFile.xml
@@ -1,5 +1,6 @@
 <library name="DPGAnalysisMuonToolsPlugin" file="*.cc">
   <use name="DataFormats/RPCRecHit"/>
+  <use name="DataFormats/TCDS"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/PluginManager"/>
   <use name="FWCore/ParameterSet"/>

--- a/DPGAnalysis/MuonTools/plugins/MuDTSegmentExtTableProducer.cc
+++ b/DPGAnalysis/MuonTools/plugins/MuDTSegmentExtTableProducer.cc
@@ -146,6 +146,8 @@ void MuDTSegmentExtTableProducer::fillTable(edm::Event& ev) {
   std::vector<float> seg4D_hitsExpPos;
   std::vector<float> seg4D_hitsExpPosCh;
   std::vector<int16_t> seg4D_hitsExpWire;
+  std::vector<int16_t> seg4D_hitsExpLayer;
+  std::vector<int16_t> seg4D_hitsExpSuperLayer;
 
   // rec-hits vectors, filled if m_fillHits == true
   unsigned int nHits{0};
@@ -258,6 +260,9 @@ void MuDTSegmentExtTableProducer::fillTable(edm::Event& ev) {
 
             bool success{ppt.first};  // check for failure
 
+            seg4D_hitsExpSuperLayer.push_back(iSL);
+            seg4D_hitsExpLayer.push_back(iL);
+
             auto expPos{DEFAULT_DOUBLE_VAL};
             auto expPosCh{DEFAULT_DOUBLE_VAL};
             auto expWire{DEFAULT_INT_VAL_POS};
@@ -352,17 +357,20 @@ void MuDTSegmentExtTableProducer::fillTable(edm::Event& ev) {
 
     tabExtr->setDoc("Size of DT segment *_extr_* vectors");
     addColumn(tabExtr,
+              "ExpSuperLayer",
+              seg4D_hitsExpSuperLayer,
+              "expected superlayer of an extrapolated segment - [1:3] range");
+    addColumn(tabExtr, "ExpLayer", seg4D_hitsExpLayer, "expected layer of an extrapolated segment - [1:4] range");
+    addColumn(tabExtr,
               "ExpPos",
               seg4D_hitsExpPos,
               "expected position of segment extrapolated"
               "<br />to a given layer in layer local coordinates - cm");
-
     addColumn(tabExtr,
               "ExpPosCh",
               seg4D_hitsExpPosCh,
               "expected position of segment extrapolated"
               "<br />to a given layer in chhamber local coordinates - cm");
-
     addColumn(tabExtr,
               "ExpWire",
               seg4D_hitsExpWire,

--- a/DPGAnalysis/MuonTools/plugins/MuGEML1FETableProducer.cc
+++ b/DPGAnalysis/MuonTools/plugins/MuGEML1FETableProducer.cc
@@ -1,0 +1,77 @@
+/** \class MuGEML1FETableProducer MuGEML1FETableProducer.cc DPGAnalysis/MuonTools/src/MuGEML1FETableProducer.cc
+ *  
+ * Helper class : FlatTableProducer for GEM Flower Event (reading FED RAW Data)
+ *
+ * \author Jeewon Heo
+ * based on code written by C.Battilana (INFN BO)
+ *
+ */
+
+//#include "FWCore/ParameterSet/interface/allowedValues.h"
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include <iostream>
+#include <vector>
+
+#include "DPGAnalysis/MuonTools/interface/MuBaseFlatTableProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "DataFormats/TCDS/interface/TCDSRecord.h"
+
+class MuGEML1FETableProducer : public MuBaseFlatTableProducer {
+public:
+  /// Constructor
+  MuGEML1FETableProducer(const edm::ParameterSet&);
+
+  /// Fill descriptors
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+protected:
+  /// Fill tree branches for a given event
+  void fillTable(edm::Event&) final;
+
+  /// Get info from the ES by run
+  void getFromES(const edm::Run&, const edm::EventSetup&) final;
+
+private:
+  nano_mu::EDTokenHandle<TCDSRecord> m_token;
+  static constexpr int BX_IN_ORBIT = 3564;
+};
+
+MuGEML1FETableProducer::MuGEML1FETableProducer(const edm::ParameterSet& config)
+    : MuBaseFlatTableProducer{config}, m_token{config, consumesCollector(), "src"} {
+  produces<nanoaod::FlatTable>();
+}
+
+void MuGEML1FETableProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<std::string>("name", "l1aHistory");
+  desc.add<edm::InputTag>("src", edm::InputTag{"tcdsDigis:tcdsRecord"});
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+void MuGEML1FETableProducer::getFromES(const edm::Run& run, const edm::EventSetup& environment) {}
+
+void MuGEML1FETableProducer::fillTable(edm::Event& ev) {
+  std::vector<int> bxDiffs;
+
+  auto record = m_token.conditionalGet(ev);
+
+  // in Heavy Ion Physics the getL1aHistoryEntry is not saved ...
+  // comment out and use this as proxy to inquire BX,Orbit and Lumi
+  for (const auto l1aEntry : record->getFullL1aHistory()) {
+    int bxDiff = BX_IN_ORBIT * (record->getOrbitNr() - l1aEntry.getOrbitNr()) + record->getBXID() - l1aEntry.getBXID();
+    bxDiffs.push_back(bxDiff);
+  }
+
+  auto table = std::make_unique<nanoaod::FlatTable>(bxDiffs.size(), m_name, false, false);
+  addColumn(table, "bxDiffs", bxDiffs, "BX differences between event and L1As");
+
+  ev.put(std::move(table));
+}
+
+DEFINE_FWK_MODULE(MuGEML1FETableProducer);

--- a/DPGAnalysis/MuonTools/python/muNtupleProducerBkg_cff.py
+++ b/DPGAnalysis/MuonTools/python/muNtupleProducerBkg_cff.py
@@ -4,9 +4,12 @@ from PhysicsTools.NanoAOD.common_cff import *
 
 from DPGAnalysis.MuonTools.nano_mu_global_cff import *
 from DPGAnalysis.MuonTools.nano_mu_digi_cff import *
+from DPGAnalysis.MuonTools.nano_mu_local_reco_cff import *
+from DPGAnalysis.MuonTools.nano_mu_reco_cff import *
 
 muDPGNanoProducerBkg = cms.Sequence(globalTables
-                                   + muDigiTablesBkg)
+                                   + muDigiTablesBkg
+                                   + muLocalRecoTablesBkg)
 
 def muDPGNanoBkgCustomize(process) :
 

--- a/DPGAnalysis/MuonTools/python/nano_mu_global_cff.py
+++ b/DPGAnalysis/MuonTools/python/nano_mu_global_cff.py
@@ -9,8 +9,13 @@ lumiTable = cms.EDProducer("SimpleOnlineLuminosityFlatTableProducer",
     doc  = cms.string("Online luminosity information"),
     variables = cms.PSet(
         instLumi = Var( "instLumi()", "double", doc = "Instantaneous luminosity"),
-        avgPileUp = Var( "avgPileUp()", "double", doc = "Average PU")
+        avgPileUp = Var( "avgPileUp()", "double", doc = "Average PU"),
+        timestamp = Var( "timestamp().unixTime()", "uint", doc = "Time Stamp")
     )
 )
 
-globalTables = cms.Sequence(lumiTable + lhcInfoTable)
+from DPGAnalysis.MuonTools.muGEML1FETableProducer_cfi import muGEML1FETableProducer
+
+muGEML1FETable = muGEML1FETableProducer.clone()
+
+globalTables = cms.Sequence(lumiTable + lhcInfoTable + muGEML1FETable)

--- a/DPGAnalysis/MuonTools/python/nano_mu_local_reco_cff.py
+++ b/DPGAnalysis/MuonTools/python/nano_mu_local_reco_cff.py
@@ -231,3 +231,8 @@ muLocalRecoTables = cms.Sequence(rpcRecHitFlatTable
                                  + muDTSegmentExtTable
                                  + gemSegmentFlatTable
                                 )
+
+muLocalRecoTablesBkg = cms.Sequence(rpcRecHitFlatTable
+                                 + gemRecHitFlatTable
+                                 + dtSegmentFlatTable
+                                )

--- a/PhysicsTools/NanoAOD/plugins/LHCInfoProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/LHCInfoProducer.cc
@@ -70,6 +70,7 @@ public:
     out->addFloat("crossingAngle", "LHC crossing angle", lhcInfoCombined.crossingAngle());
     out->addFloat("betaStar", "LHC beta star", lhcInfoCombined.betaStarX);
     out->addFloat("energy", "LHC beam energy", lhcInfoCombined.energy);
+    out->addInt("fill", "LHC fill number", lhcInfoCombined.fillNumber);
     iLumi.put(std::move(out));
   }
 


### PR DESCRIPTION
#### PR description:

This pull-request add information to both the **ZMu** and the **ZeroBias** flavours of the Muon DPG custom-NANO.

Results from the validation of the **ZMu** ntuples are reported in the google-doc from [this DT DPG meeting](https://docs.google.com/document/d/1Jt0UPgnyG99Sx3AzBuwMTWXzttqWDtnB/edit#heading=h.gjdgxs). 

The changes imply a ~1% increase in the ntuple event-size.

Results validating the additions to the **ZeroBias** ntuples are scattered in meetings of the [Muon Background Studies Group](https://indico.cern.ch/category/16135/). 

The ntuple **event-size get roughly doubled** because of this this update, but it has to be noted that **ZeroBias** ntuples are never produced in central workflows, hence event-size  is "just" a muon DPGO matter.

#### PR validation:

Beyond performance studies the ntuples were validated issuing `runTheMatrix.py -l 2500.2402,2500.2403`.
