### PR TITLE
 Add previous scouting dataformat in AOD, MINIAOD, FEVT and RECO (150X backport)

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -95,6 +95,12 @@ from L1Trigger.Configuration.L1Trigger_EventContent_cff import *
 #
 #
 from HLTrigger.Configuration.HLTrigger_EventContent_cff import *
+from HLTrigger.Configuration.HLTScouting_EventContent_cff import HLTScoutingAll
+# Extend HLT dataformats to the previous scouting objects, to keep them when running on old data/MC
+HLTriggerMINIAOD.outputCommands.extend(HLTScoutingAll.outputCommands)
+HLTriggerAOD.outputCommands.extend(HLTScoutingAll.outputCommands)
+HLTriggerRECO.outputCommands.extend(HLTScoutingAll.outputCommands)
+HLTDebugFEVT.outputCommands.extend(HLTScoutingAll.outputCommands)
 #
 #
 # DQM

--- a/HLTrigger/Configuration/python/HLTScouting_EventContent_cff.py
+++ b/HLTrigger/Configuration/python/HLTScouting_EventContent_cff.py
@@ -1,0 +1,28 @@
+import FWCore.ParameterSet.Config as cms
+
+# EventContent for HLT Scouting products.
+
+# This file keep track of all the scouting objects used since Run-2 
+# HLTScoutingAll is used in Configuration/EventContent to keep all scouting objects available in all AOD/MINIAOD[SIM]
+
+HLTScoutingAll = cms.PSet(
+    outputCommands = cms.vstring( *(
+        ## Current scouting objects (from 2024)
+        'keep *_hltFEDSelectorL1_*_*',  # PR#20739
+        'keep *_hltScoutingEgammaPacker_*_*', # PR#20739
+        'keep *_hltScoutingMuonPackerNoVtx_*_*', # PR#44302
+        'keep *_hltScoutingMuonPackerVtx_*_*',  # PR#44302
+        'keep *_hltScoutingPFPacker_*_*', # PR#20739
+        'keep *_hltScoutingPrimaryVertexPacker_*_*',  # PR#20739
+        'keep *_hltScoutingTrackPacker_*_*', # PR #23077
+
+        ## Previous scouting objects
+        # Run3 (2022-23)
+        'keep *_hltScoutingMuonPacker_*_*', # added w/ PR#20739, removed w/ PR#44302
+
+        # Run2 only
+        'keep *_hltScoutingCaloPacker_*_*',  # added  w/ PR#20739, removed w/ PR#37114
+        'keep *_hltScoutingMuonPackerCalo_*_*', # added  w/ PR#20739, removed w/  PR#37114
+        'keep *_hltScoutingPrimaryVertexPackerCaloMuon_*_*', # added  w/ PR#20739, removed w/  PR#37114
+    ) )
+)


### PR DESCRIPTION
#### PR description:

Scouting collections have been added to AOD since Run-2 [1] and to MINIAOD since 2024 data/MC (13_3_X) [2] [3].
Scouting collections are defined in [/HLTrigger/Configuration/python/HLTrigger_EventContent_cff.py](https://github.com/cms-sw/cmssw/blob/master/HLTrigger/Configuration/python/HLTrigger_EventContent_cff.py). However HLTrigger_EventContent_cff.py is produced semi-automatically from the HLT menu used by TSG.

This means that currently AOD and MINIAOD know only the current scouting collections, and therefore running reMINI from Run-2 data we might loose the Run-2 scouting collections.
Past scouting objects are also added in FEVT and RECO dataformat, in case one wants to reprocess the some old RAW data/simulation

This issue have been already discussed in [CMSHLT-3593](https://its.cern.ch/jira/browse/CMSHLT-3593) and https://github.com/cms-sw/cmssw/pull/48465 , as in 2024 we replaced hltScoutingMuonPacker collection with hltScoutingMuonPackerVtx and hltScoutingMuonPackerNoVtx collections

This PR adds a new file HLTrigger/Configuration/python/HLTScouting_EventContent_cff.py with the definition of all scouting collections used since Run-2. This file is used in Configuration/EventContent/python/EventContent_cff.py to include the scouting collections to all HLT event contents.

Note: for Phase-2, this approach will allow use to reprocess Run-3 data with scouting collection.

#### PR validation:
`cmsDriver.py step2  -s PAT,VALIDATION:@miniAODValidation,DQM:@miniAODDQM --era Run2_2018 -n 100 --process PAT --conditions auto:phase1_2018_realistic --mc  --scenario pp --eventcontent MINIAODSIM,DQM --datatier MINIAODSIM,DQMIO --procModifiers run2_miniAOD_UL_preSummer20 --filein root://eoscms.cern.ch//store/user/cmsbuild/store/relval/CMSSW_10_6_4/RelValProdTTbar_13_pmx25ns/AODSIM/PUpmx25ns_106X_upgrade2018_realistic_v9-v1/10000/4440FA53-897B-9A4B-AD76-D1337B591A2F.root --fileout file:step2.root  --number 1`  
(taken from `runTheMatrix.py -l 2500.024`)
with the PR, checking that it contains the Run-2 scouting objects.

#### If this PR is a backport please specify the original PR and why you need 

Backport of #48630
We need to fix this for possible future production done in 15_0_X. This is important to be able to process 2023 data in 15_0_X. With the current code we would loose `hltScoutingMuonPacker` because it has been renamed to `hltScoutingMuonPackerNoVtx` and `hltScoutingMuonPackerVtx`

We might ask a backport of this PR also in other release in the future, in case of a reReco or reMini of Run-2 RAW or AOD data or simulation.

[1] #21295
[2] #42863
[3] #43327