### PR TITLE
Add missing dictionaries to `DataFormats/L1TrackTrigger`

### DIFF
--- a/DataFormats/L1TrackTrigger/src/classes_def.xml
+++ b/DataFormats/L1TrackTrigger/src/classes_def.xml
@@ -38,6 +38,10 @@
   <class name="std::vector<TTTrack_TrackWord>"/>
   <class name="edm::Wrapper<std::vector<TTTrack_TrackWord> >"/>
   <class name="edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
+  <class name="tt::FrameStub"/>
+  <class name="tt::FrameTrack"/>
+  <class name="tt::StreamStub"/>
+  <class name="tt::StreamTrack"/>
   <class name="tt::StreamsStub"/>
   <class name="tt::StreamsTrack"/>
   <class name="tt::Streams"/>


### PR DESCRIPTION
#### PR description:

These missing dictionaries were found in https://github.com/root-project/root/pull/18402#issuecomment-3136116268

Resolves https://github.com/cms-sw/framework-team/issues/1492

#### PR validation:

With a developer area created from https://github.com/cms-sw/root/pull/222#issuecomment-3134654219 the workflows that failed in the test succeeded with these changes.