### PR TITLE
[15.0.X] `TkAlHLTTracks*`: futher amendments of Event Content

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracksZMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracksZMuMu_Output_cff.py
@@ -14,11 +14,24 @@ OutALCARECOTkAlHLTTracksZMuMu_noDrop = cms.PSet(
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep *_TriggerResults_*_*',
         'keep *_hltPixelVertices_*_*',
-        'keep *_ALCARECOTkAlHLTPixelZMuMuVertexTracks_*_*',
+        'keep recoTracks_ALCARECOTkAlHLTPixelZMuMuVertexTracks_*_*',
+        'keep recoTrackExtras_ALCARECOTkAlHLTPixelZMuMuVertexTracks_*_*',
+        'keep TrackingRecHitsOwned_ALCARECOTkAlHLTPixelZMuMuVertexTracks_*_*',
+        'keep SiPixelClusteredmNewDetSetVector_ALCARECOTkAlHLTPixelZMuMuVertexTracks_*_*',
 	'keep *_hltVerticesPFFilter_*_*',
-        'keep *_hltOnlineBeamSpot_*_*'
+        'keep *_hltOnlineBeamSpot_*_*',
+        'keep DCSRecord_onlineMetaDataDigis_*_*'
     )
 )
+
+# in Phase2, remove the SiStrip clusters and keep the OT ones instead
+_phase2_common_removedCommands = OutALCARECOTkAlHLTTracksZMuMu_noDrop.outputCommands.copy()
+_phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlHLTTracksZMuMu_*_*')
+
+_phase2_common_extraCommands = ['keep Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOTkAlHLTTracksZMuMu_*_*']
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(OutALCARECOTkAlHLTTracksZMuMu_noDrop, outputCommands = _phase2_common_removedCommands + _phase2_common_extraCommands )
 
 OutALCARECOTkAlHLTTracksZMuMu = OutALCARECOTkAlHLTTracksZMuMu_noDrop.clone()
 OutALCARECOTkAlHLTTracksZMuMu.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracks_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracks_Output_cff.py
@@ -15,8 +15,19 @@ OutALCARECOTkAlHLTTracks_noDrop = cms.PSet(
         'keep *_TriggerResults_*_*',
         'keep *_hltPixelVertices_*_*',
         'keep *_hltVerticesPFFilter_*_*',
-        'keep *_hltOnlineBeamSpot_*_*')
+        'keep *_hltOnlineBeamSpot_*_*',
+        'keep DCSRecord_onlineMetaDataDigis_*_*'
+    )
 )
+
+# in Phase2, remove the SiStrip clusters and keep the OT ones instead
+_phase2_common_removedCommands = OutALCARECOTkAlHLTTracks_noDrop.outputCommands.copy()
+_phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlHLTTracks_*_*')
+
+_phase2_common_extraCommands = ['keep Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOTkAlHLTTracks_*_*']
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(OutALCARECOTkAlHLTTracks_noDrop, outputCommands = _phase2_common_removedCommands + _phase2_common_extraCommands )
 
 OutALCARECOTkAlHLTTracks = OutALCARECOTkAlHLTTracks_noDrop.clone()
 OutALCARECOTkAlHLTTracks.outputCommands.insert(0, "drop *")


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/48533

#### PR description:

This PR is a simple follow-up to https://github.com/cms-sw/cmssw/pull/48486.
While reviewing the event content of the `TkAlHLTTracks*` samples produced in the Tier0 replay of  `CMSSW_15_0_10`  (see this https://github.com/dmwm/T0/pull/5105#issuecomment-3056329997), I noticed the presence of a `edmNew::DetSetVector<Phase2TrackerCluster1D>` among the saved collections.  
While the collection *per se* is empty, this is a bit inelegant for Run 3 data-production. 
The goal of this PR is to refine the selection of data-products to keep for `ALCARECOTkAlHLTPixelZMuMuVertexTracks`, by explicitly matching all products that need to be saved. 
I profit of this to add `DCSRecord_onlineMetaDataDigis_*_*` to event content. The increase in data-size should be negligible, thus I did not measure it.

#### PR validation:

Run

```bash
#!/bin/bash -ex

cmsDriver.py testReAlCaHLT \
	     -s ALCA:TkAlHLTTracks+TkAlHLTTracksZMuMu  \
	     --conditions 150X_dataRun3_HLT_v1 \
	     --scenario pp \
	     --data \
	     --era Run3_2025 \
	     --datatier ALCARECO \
	     --eventcontent ALCARECO \
	     --processName=ReAlCa \
	     -n 10000 \
	     --dasquery='file dataset=/HLTMonitor/Run2025C-Express-v2/FEVTHLTALL site=T2_CH_CERN' \
	     --nThreads 4 >& ReAlCa.log
```

and inspectied the resulting event content.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/48533. 
As we are going to have soon an era change at Tier0 following up to the deployment of the HLT menu to V1.3 (due to [CMSHLT-3607](https://its.cern.ch/jira/browse/CMSHLT-3607), see also PR https://github.com/cms-sw/cmssw/pull/48613) I think we can couple that with a change of secondary datasets as well.