### PR TITLE
Include the HLT menu in the name of the output directory.

### DIFF
--- a/HLTrigger/Configuration/scripts/hltPhase2UpgradeIntegrationTests
+++ b/HLTrigger/Configuration/scripts/hltPhase2UpgradeIntegrationTests
@@ -111,7 +111,7 @@ else:
 print("=" * 40)
 
 # Directory where all test configurations will be stored
-output_dir = "hlt_test_configs"
+output_dir = "hlt_test_configs_HLTMENU_" + menu
 # If the directory exists, remove it first
 if os.path.exists(output_dir):
     shutil.rmtree(output_dir)


### PR DESCRIPTION
#### PR description:

Needed because of [this cms-bot PR](https://github.com/cms-sw/cms-bot/pull/2545), where the ```hltPhase2UpgradeIntegrationTests``` script will be run with various HLT flavours via the ```--menu``` option (introduced in #48664).