### PR TITLE
LST: Modifying LST to create efficiency plots for jets

### DIFF
--- a/RecoTracker/LSTCore/standalone/analysis/jets/myjets.py
+++ b/RecoTracker/LSTCore/standalone/analysis/jets/myjets.py
@@ -1,0 +1,103 @@
+###############################################
+#
+#   Library of functions used when dealing 
+#   with jets, especially reformat_jets.py
+#
+###############################################
+
+import fastjet
+from pyjet import cluster
+from particle import Particle
+import numpy as np
+import awkward as ak
+import vector
+
+
+# Takes an entry from a tree and extracts lists of key parameters.
+def getLists(entry, hardSc = False, pTcut=True):
+        # This applies to the entire event
+        pdgidList = entry.sim_pdgId
+        evLen = len(pdgidList)
+
+        pTList = np.ones(evLen, dtype=np.float64)*-999
+        etaList = np.ones(evLen, dtype=np.float64)*-999
+        phiList = np.ones(evLen, dtype=np.float64)*-999
+        massList = np.ones(evLen, dtype=np.float64)*-999
+
+        # Putting the data in the right format
+        for j in range(evLen):#range(len(simEvnp)):
+                if (hardSc and entry.sim_event[j] !=0 ): 
+                        # print(f"event != 0 {entry.sim_event[j]}")
+                        continue
+                if(pTcut and entry.sim_q[j] != 0 and entry.sim_pt[j] < 0.75 ):
+                        continue
+                vtxX = entry.simvtx_x[entry.sim_parentVtxIdx[j]]
+                vtxY = entry.simvtx_y[entry.sim_parentVtxIdx[j]]
+                if(np.sqrt(vtxX**2 + vtxY**2)>10):
+                        continue
+                pdgid = pdgidList[j]
+                massList[j] = Particle.from_pdgid(pdgid).mass/1000.
+
+                pTList[j] = entry.sim_pt[j]
+                etaList[j] = entry.sim_eta[j]
+                phiList[j] = entry.sim_phi[j]
+
+        massList = massList[massList != -999]
+        pTList = pTList[pTList != -999]
+        etaList = etaList[etaList != -999]
+        phiList = phiList[phiList != -999]
+
+        return pTList, etaList, phiList, massList
+
+
+# Takes an entry from a tree and extracts particles from it. Uses
+# those particles to create jets, which it returns.
+def createJets(pTList, etaList, phiList, massList):
+
+        jetdef = fastjet.JetDefinition(fastjet.antikt_algorithm, 0.4)
+
+        length = np.size(pTList)
+        fjs = []
+
+        for j in range(length):
+                f=fastjet.PseudoJet(pseudojet_from_pt_eta_phi_m(pTList[j], etaList[j], phiList[j], massList[j]))
+                fjs.append(f)
+
+        cluster = fastjet.ClusterSequence(fjs, jetdef)
+        jets = cluster.inclusive_jets(ptmin=20)
+
+        return cluster, jets
+
+def plotOneJet(jet, name):
+    const = jet.constituents_array()
+    plt.scatter(const["eta"], const["phi"], c='green')
+    plt.scatter([jet.eta], [jet.phi], c="red")
+    plt.xlabel(r'$\eta$')
+    plt.ylabel(r'$\phi$')
+    plt.savefig(name)
+    plt.clf()
+
+def matchArr(jetArrpT, jetArreta, jetArrphi, treeArrpT, treeArreta, treeArrphi, evnum, jetnum):
+        indexArr = np.ones(len(jetArrpT))*-999
+
+        for i in range(len(jetArrpT)):
+                for j in range(len(treeArrpT)):
+                        if(np.abs(jetArrpT[i]-treeArrpT[j])<0.00001 and np.abs(jetArreta[i]-treeArreta[j])<0.00001 
+                                and np.abs(np.cos(jetArrphi[i])-np.cos(treeArrphi[j]))<0.00001):
+                                if(indexArr[i]!=-999): 
+                                       print(f"Error: double matched at Event={evnum}, Jet={jetnum} i={i}")
+                                       continue 
+                                indexArr[i] = j
+        if(indexArr[i]==-999.0):
+                print(f"Error: Event={evnum}, Jet={jetnum} i={i}, pT = {jetArrpT[i]}, eta = {jetArreta[i]}, phi = {jetArrphi[i]}")
+
+        return indexArr
+
+def pseudojet_from_pt_eta_phi_m(pt, eta, phi, mass):
+    # Convert (pt, eta, phi, mass) to (px, py, pz, E) and create a PseudoJet.
+    px = pt * np.cos(phi)
+    py = pt * np.sin(phi)
+    pz = pt * np.sinh(eta)
+    energy = np.sqrt(px**2 + py**2 + pz**2 + mass**2)
+    
+    return fastjet.PseudoJet(px, py, pz, energy)

--- a/RecoTracker/LSTCore/standalone/analysis/jets/reformat_jets.py
+++ b/RecoTracker/LSTCore/standalone/analysis/jets/reformat_jets.py
@@ -1,0 +1,160 @@
+##########################################################
+#
+# The file trackingNtuple.root has the data I need.
+# I can section it off into jets.
+# I then put these jets into a new n-tuple, 
+#
+##########################################################
+
+import matplotlib.pyplot as plt
+import ROOT
+from ROOT import TFile
+from myjets import getLists, createJets, matchArr
+import numpy as np
+
+# Load existing tree
+file =  TFile("/data2/segmentlinking/CMSSW_12_2_0_pre2/trackingNtuple_ttbar_PU200.root")
+# file = TFile("trackingNtuple100.root")
+old_tree = file["trackingNtuple"]["tree"]
+
+# Create a new ROOT file to store the new TTree
+new_file = ROOT.TFile("new_tree_temp.root", "RECREATE")
+
+# Create a new subdirectory in the new file
+new_directory = new_file.mkdir("trackingNtuple")
+
+# Change the current directory to the new subdirectory
+new_directory.cd()
+
+# Create a new TTree with the same structure as the old one but empty
+new_tree = old_tree.CloneTree(0)  
+
+# Account for bug in 12_2_X branch
+new_tree.SetBranchStatus("ph2_bbxi", False) 
+
+# Create a variable to hold the new leaves' data (a list of floats)
+new_leaf_deltaEta = ROOT.std.vector('float')()
+new_leaf_deltaPhi = ROOT.std.vector('float')()
+new_leaf_deltaR = ROOT.std.vector('float')()
+new_leaf_jet_eta = ROOT.std.vector('float')()
+new_leaf_jet_phi = ROOT.std.vector('float')()
+new_leaf_jet_pt = ROOT.std.vector('float')()
+
+
+# Create a new branch in the tree
+new_tree.Branch("sim_deltaEta", new_leaf_deltaEta)
+new_tree.Branch("sim_deltaPhi", new_leaf_deltaPhi)
+new_tree.Branch("sim_deltaR", new_leaf_deltaR)
+new_tree.Branch("sim_jet_eta", new_leaf_jet_eta)
+new_tree.Branch("sim_jet_phi", new_leaf_jet_phi)
+new_tree.Branch("sim_jet_pt", new_leaf_jet_pt)
+
+# Loop over entries in the old tree
+for ind in range(old_tree.GetEntries()):
+    old_tree.GetEntry(ind)
+
+    # Clear the vector to start fresh for this entry
+    new_leaf_deltaEta.clear()
+    new_leaf_deltaPhi.clear()
+    new_leaf_deltaR.clear()
+    new_leaf_jet_eta.clear()
+    new_leaf_jet_phi.clear()
+    new_leaf_jet_pt.clear()
+
+    # Creates the lists that will fill the leaves
+    pTList, etaList, phiList, massList = getLists(old_tree, hardSc=True, pTcut=True)
+    cluster, jets = createJets(pTList, etaList, phiList, massList)
+    
+    jetIndex = np.array([])
+    eta_diffs = np.array([])
+    phi_diffs = np.array([])
+    deltaRs = np.array([])
+    jet_eta = np.array([])
+    jet_phi = np.array([])
+    jet_pt = np.array([])
+
+    for j, jet in enumerate(jets):
+        const = jet.constituents()
+        c_len = len(const)
+        c_pts = np.zeros(c_len)
+        c_etas = np.zeros(c_len)
+        c_phis = np.zeros(c_len)
+
+        for k in range(c_len):
+            c_pts[k] = const[k].pt()
+            c_etas[k] = const[k].eta()
+            c_phis[k] = const[k].phi()
+
+        # Reorder particles within jet (jet clustering does not respect original index)
+        jetIndex = np.append(jetIndex, matchArr(c_pts, c_etas, c_phis, 
+                                                np.array(old_tree.sim_pt), np.array(old_tree.sim_eta), np.array(old_tree.sim_phi), 
+                                                ind, j)) # order restored by matching pT
+        jetIndex = jetIndex.astype(int)
+
+        # Compute the distance to jet
+        etaval = c_etas-jet.eta()
+        phival = c_phis-jet.phi()
+        eta_diffs = np.append(eta_diffs, etaval)
+        phi_diffs = np.append(phi_diffs, phival)
+
+        rval = np.sqrt(etaval**2 + np.arccos(np.cos(phival))**2)
+        deltaRs = np.append(deltaRs, rval)
+
+        # Save values of closest jet
+        jet_eta_val = np.ones(c_len)*jet.eta()
+        jet_eta = np.append(jet_eta, jet_eta_val)
+        jet_phi_val = np.ones(c_len)*jet.phi()
+        jet_phi = np.append(jet_phi, jet_phi_val)
+        jet_pt_val = np.ones(c_len)*jet.pt()
+        jet_pt = np.append(jet_pt, jet_pt_val)
+    
+    # Reordering branches appropriately
+    length = len(np.array(old_tree.sim_pt))
+
+    re_eta_diffs = np.ones(length)*(-999)
+    re_phi_diffs = np.ones(length)*(-999)
+    re_deltaRs = np.ones(length)*(-999)
+    re_jet_eta = np.ones(length)*(-999)
+    re_jet_phi = np.ones(length)*(-999)
+    re_jet_pt = np.ones(length)*(-999)
+
+    for i in range(len(jetIndex)):
+        re_eta_diffs[jetIndex[i]] = eta_diffs[i]
+        re_phi_diffs[jetIndex[i]] = phi_diffs[i]
+        re_deltaRs[jetIndex[i]] = deltaRs[i]
+        re_jet_eta[jetIndex[i]] = jet_eta[i]
+        re_jet_phi[jetIndex[i]] = jet_phi[i]
+        re_jet_pt[jetIndex[i]] = jet_pt[i]
+
+    # Add the list elements to the vector
+    for value in re_eta_diffs:
+        new_leaf_deltaEta.push_back(value)
+    for value in re_phi_diffs:
+        new_leaf_deltaPhi.push_back(value)
+    for value in re_deltaRs:
+        new_leaf_deltaR.push_back(value)
+    for value in re_jet_eta:
+        new_leaf_jet_eta.push_back(value)
+    for value in re_jet_phi:
+        new_leaf_jet_phi.push_back(value)
+    for value in re_jet_pt:
+        new_leaf_jet_pt.push_back(value)
+
+    # Fill the tree with the new values
+    new_tree.Fill()
+
+    # break # Just for testing purposes
+
+# new_tree.Scan("sim_pt@.size():sim_jet_pt@.size()")
+
+# Write the tree back to the file
+new_tree.Write()
+
+# Debugging: print new_tree events
+# new_tree.GetEntry(0) # only look at first event
+# for i in range(3): # only look at first 3 tracks in event
+#     print(f"Track {i}: sim_phi = {new_tree.sim_phi[i]}\t sim_eta = {new_tree.sim_eta[i]} \t sim_pt = {new_tree.sim_pt[i]} \t sim_deltaR = {new_tree.sim_deltaR[i]}") 
+
+new_file.Close()
+file.Close()
+

--- a/RecoTracker/LSTCore/standalone/bin/lst.cc
+++ b/RecoTracker/LSTCore/standalone/bin/lst.cc
@@ -70,7 +70,8 @@ int main(int argc, char **argv) {
       "I,job_index",
       "job_index of split jobs (--nsplit_jobs must be set. index starts from 0. i.e. 0, 1, 2, 3, etc...)",
       cxxopts::value<int>())("3,tc_pls_triplets", "Allow triplet pLSs in TC collection")(
-      "2,no_pls_dupclean", "Disable pLS duplicate cleaning (both steps)")("h,help", "Print help");
+      "2,no_pls_dupclean", "Disable pLS duplicate cleaning (both steps)")("h,help", "Print help")(
+      "J,jet_branches", "Accounts for specific jet branches in input root file for testing");
 
   auto result = options.parse(argc, argv);
 
@@ -91,6 +92,7 @@ int main(int argc, char **argv) {
 
   // A default value one
   TString TrackingNtupleDir = gSystem->Getenv("TRACKINGNTUPLEDIR");
+
   if (ana.input_raw_string.EqualTo("muonGun"))
     ana.input_file_list_tstring = TString::Format("%s/trackingNtuple_10mu_pt_0p5_2.root", TrackingNtupleDir.Data());
   else if (ana.input_raw_string.EqualTo("muonGun_highPt"))
@@ -260,6 +262,10 @@ int main(int argc, char **argv) {
   //_______________________________________________________________________________
   // --no_pls_dupclean
   ana.no_pls_dupclean = result["no_pls_dupclean"].as<bool>();
+
+  //_______________________________________________________________________________
+  // --jet_branches
+  ana.jet_branches = result["jet_branches"].as<bool>();
 
   // Printing out the option settings overview
   std::cout << "=========================================================" << std::endl;

--- a/RecoTracker/LSTCore/standalone/code/core/AnalysisConfig.h
+++ b/RecoTracker/LSTCore/standalone/code/core/AnalysisConfig.h
@@ -131,6 +131,9 @@ public:
 
   // Boolean to disable pLS duplicate cleaning
   bool no_pls_dupclean;
+
+  // Boolean to enable jet branches
+  bool jet_branches;
 };
 
 extern AnalysisConfig ana;

--- a/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
@@ -28,6 +28,15 @@ void fillOutputBranches(LSTEvent* event) {
 //________________________________________________________________________________________________________________________________
 void createRequiredOutputBranches() {
   // Setup output TTree
+
+  if (ana.jet_branches) {
+    ana.tx->createBranch<std::vector<float>>("sim_deltaEta");
+    ana.tx->createBranch<std::vector<float>>("sim_deltaPhi");
+    ana.tx->createBranch<std::vector<float>>("sim_deltaR");
+    ana.tx->createBranch<std::vector<float>>("sim_jet_eta");
+    ana.tx->createBranch<std::vector<float>>("sim_jet_phi");
+    ana.tx->createBranch<std::vector<float>>("sim_jet_pt");
+  }
   ana.tx->createBranch<std::vector<float>>("sim_pt");
   ana.tx->createBranch<std::vector<float>>("sim_eta");
   ana.tx->createBranch<std::vector<float>>("sim_phi");
@@ -310,35 +319,83 @@ void setOutputBranches(LSTEvent* event) {
   auto const& trk_simhit_simTrkIdx = trk.getVI("simhit_simTrkIdx");
   auto const& trk_ph2_simHitIdx = trk.getVVI("ph2_simHitIdx");
   auto const& trk_pix_simHitIdx = trk.getVVI("pix_simHitIdx");
-  for (unsigned int isimtrk = 0; isimtrk < trk_sim_pt.size(); ++isimtrk) {
-    // Skip out-of-time pileup
-    if (trk_sim_bunchCrossing[isimtrk] != 0)
-      continue;
 
-    // Skip non-hard-scatter
-    if (trk_sim_event[isimtrk] != 0)
-      continue;
+  if (ana.jet_branches) {
+    auto const& trk_sim_deltaEta = trk.getVF("sim_deltaEta");
+    auto const& trk_sim_deltaPhi = trk.getVF("sim_deltaPhi");
+    auto const& trk_sim_deltaR = trk.getVF("sim_deltaR");
+    auto const& trk_sim_jet_eta = trk.getVF("sim_jet_eta");
+    auto const& trk_sim_jet_phi = trk.getVF("sim_jet_phi");
+    auto const& trk_sim_jet_pt = trk.getVF("sim_jet_pt");
 
-    ana.tx->pushbackToBranch<float>("sim_pt", trk_sim_pt[isimtrk]);
-    ana.tx->pushbackToBranch<float>("sim_eta", trk_sim_eta[isimtrk]);
-    ana.tx->pushbackToBranch<float>("sim_phi", trk_sim_phi[isimtrk]);
-    ana.tx->pushbackToBranch<float>("sim_pca_dxy", trk_sim_pca_dxy[isimtrk]);
-    ana.tx->pushbackToBranch<float>("sim_pca_dz", trk_sim_pca_dz[isimtrk]);
-    ana.tx->pushbackToBranch<int>("sim_q", trk_sim_q[isimtrk]);
-    ana.tx->pushbackToBranch<int>("sim_event", trk_sim_event[isimtrk]);
-    ana.tx->pushbackToBranch<int>("sim_pdgId", trk_sim_pdgId[isimtrk]);
+    for (unsigned int isimtrk = 0; isimtrk < trk_sim_pt.size(); ++isimtrk) {
+      // Skip out-of-time pileup
+      if (trk_sim_bunchCrossing[isimtrk] != 0)
+        continue;
 
-    // For vertex we need to look it up from simvtx info
-    int vtxidx = trk_sim_parentVtxIdx[isimtrk];
-    ana.tx->pushbackToBranch<float>("sim_vx", trk_simvtx_x[vtxidx]);
-    ana.tx->pushbackToBranch<float>("sim_vy", trk_simvtx_y[vtxidx]);
-    ana.tx->pushbackToBranch<float>("sim_vz", trk_simvtx_z[vtxidx]);
+      // Skip non-hard-scatter
+      if (trk_sim_event[isimtrk] != 0)
+        continue;
 
-    // The trkNtupIdx is the idx in the trackingNtuple
-    ana.tx->pushbackToBranch<float>("sim_trkNtupIdx", isimtrk);
+      ana.tx->pushbackToBranch<float>("sim_deltaEta", trk_sim_deltaEta[isimtrk]);
+      ana.tx->pushbackToBranch<float>("sim_deltaPhi", trk_sim_deltaPhi[isimtrk]);
+      ana.tx->pushbackToBranch<float>("sim_deltaR", trk_sim_deltaR[isimtrk]);
+      ana.tx->pushbackToBranch<float>("sim_jet_eta", trk_sim_jet_eta[isimtrk]);
+      ana.tx->pushbackToBranch<float>("sim_jet_phi", trk_sim_jet_phi[isimtrk]);
+      ana.tx->pushbackToBranch<float>("sim_jet_pt", trk_sim_jet_pt[isimtrk]);
 
-    // Increase the counter for accepted simtrk
-    n_accepted_simtrk++;
+      ana.tx->pushbackToBranch<float>("sim_pt", trk_sim_pt[isimtrk]);
+      ana.tx->pushbackToBranch<float>("sim_eta", trk_sim_eta[isimtrk]);
+      ana.tx->pushbackToBranch<float>("sim_phi", trk_sim_phi[isimtrk]);
+      ana.tx->pushbackToBranch<float>("sim_pca_dxy", trk_sim_pca_dxy[isimtrk]);
+      ana.tx->pushbackToBranch<float>("sim_pca_dz", trk_sim_pca_dz[isimtrk]);
+      ana.tx->pushbackToBranch<int>("sim_q", trk_sim_q[isimtrk]);
+      ana.tx->pushbackToBranch<int>("sim_event", trk_sim_event[isimtrk]);
+      ana.tx->pushbackToBranch<int>("sim_pdgId", trk_sim_pdgId[isimtrk]);
+
+      // For vertex we need to look it up from simvtx info
+      int vtxidx = trk_sim_parentVtxIdx[isimtrk];
+      ana.tx->pushbackToBranch<float>("sim_vx", trk_simvtx_x[vtxidx]);
+      ana.tx->pushbackToBranch<float>("sim_vy", trk_simvtx_y[vtxidx]);
+      ana.tx->pushbackToBranch<float>("sim_vz", trk_simvtx_z[vtxidx]);
+
+      // The trkNtupIdx is the idx in the trackingNtuple
+      ana.tx->pushbackToBranch<float>("sim_trkNtupIdx", isimtrk);
+
+      // Increase the counter for accepted simtrk
+      n_accepted_simtrk++;
+    }
+  } else {
+    for (unsigned int isimtrk = 0; isimtrk < trk_sim_pt.size(); ++isimtrk) {
+      // Skip out-of-time pileup
+      if (trk_sim_bunchCrossing[isimtrk] != 0)
+        continue;
+
+      // Skip non-hard-scatter
+      if (trk_sim_event[isimtrk] != 0)
+        continue;
+
+      ana.tx->pushbackToBranch<float>("sim_pt", trk_sim_pt[isimtrk]);
+      ana.tx->pushbackToBranch<float>("sim_eta", trk_sim_eta[isimtrk]);
+      ana.tx->pushbackToBranch<float>("sim_phi", trk_sim_phi[isimtrk]);
+      ana.tx->pushbackToBranch<float>("sim_pca_dxy", trk_sim_pca_dxy[isimtrk]);
+      ana.tx->pushbackToBranch<float>("sim_pca_dz", trk_sim_pca_dz[isimtrk]);
+      ana.tx->pushbackToBranch<int>("sim_q", trk_sim_q[isimtrk]);
+      ana.tx->pushbackToBranch<int>("sim_event", trk_sim_event[isimtrk]);
+      ana.tx->pushbackToBranch<int>("sim_pdgId", trk_sim_pdgId[isimtrk]);
+
+      // For vertex we need to look it up from simvtx info
+      int vtxidx = trk_sim_parentVtxIdx[isimtrk];
+      ana.tx->pushbackToBranch<float>("sim_vx", trk_simvtx_x[vtxidx]);
+      ana.tx->pushbackToBranch<float>("sim_vy", trk_simvtx_y[vtxidx]);
+      ana.tx->pushbackToBranch<float>("sim_vz", trk_simvtx_z[vtxidx]);
+
+      // The trkNtupIdx is the idx in the trackingNtuple
+      ana.tx->pushbackToBranch<float>("sim_trkNtupIdx", isimtrk);
+
+      // Increase the counter for accepted simtrk
+      n_accepted_simtrk++;
+    }
   }
 
   // Intermediate variables to keep track of matched track candidates for a given sim track

--- a/RecoTracker/LSTCore/standalone/efficiency/python/lst_plot_performance.py
+++ b/RecoTracker/LSTCore/standalone/efficiency/python/lst_plot_performance.py
@@ -9,7 +9,7 @@ from math import sqrt
 
 sel_choices = ["base", "loweta", "xtr", "vtr", "none"]
 metric_choices = ["eff", "fakerate", "duplrate"]
-variable_choices = ["pt", "ptmtv", "ptlow", "eta", "phi", "dxy", "dz", "vxy"]
+variable_choices = ["pt", "ptmtv", "ptlow", "eta", "phi", "dxy", "dz", "vxy", "deltaEta", "deltaPhi", "deltaR", "jet_eta", "jet_phi", "jet_pt"]
 objecttype_choices = ["TC", "pT5", "T5", "pT3", "pLS", "pT5_lower", "pT3_lower", "T5_lower"]
 #lowerObjectType = ["pT5_lower", "pT3_lower", "T5_lower"]
 
@@ -36,6 +36,7 @@ parser.add_argument('--pt_cut'      ,        dest='pt_cut'      , type=float    
 parser.add_argument('--eta_cut'     ,        dest='eta_cut'     , type=float          , default=4.5, help='pseudorapidity cut [DEFAULT=4.5]')
 parser.add_argument('--compare'     , '-C' , dest='compare'     , action="store_true" , help='plot comparisons of input files')
 parser.add_argument('--comp_labels' , '-L' , dest='comp_labels' , type=str            , help='comma separated legend labels for comparison plots (e.g. reference,pT5_update')
+parser.add_argument('--jet_branches' , '-j', dest='jet_branches', action="store_true" , help='Accounts for specific jet branches in input root file for testing')
 
 
 #______________________________________________________________________________________________________
@@ -413,6 +414,18 @@ def get_chargestr(charge):
 def set_label(eff, output_name, raw_number):
     if "phi" in output_name:
         title = "#phi"
+    elif "_deltaEta" in output_name:
+        title = "#eta diffs"
+    elif "_deltaPhi" in output_name:
+        title = "#phi diffs"
+    elif "_deltaR" in output_name:
+        title = "#Delta R"
+    elif "_jet_eta" in output_name:
+        title = "jet #eta"
+    elif "_jet_phi" in output_name:
+        title = "jet #phi"
+    elif "_jet_pt" in output_name:
+        title = "jet pT"
     elif "_dz" in output_name:
         title = "z [cm]"
     elif "_dxy" in output_name:
@@ -532,8 +545,6 @@ def draw_plot(effs, nums, dens, params):
         c1.SetLogx()
 
     # Set title
-    # print(output_name)
-    # print(parse_plot_name(output_name))
     effs[0].SetTitle(parse_plot_name(output_name))
 
     # Draw the efficiency graphs
@@ -644,11 +655,13 @@ def plot_standard_performance_plots(args):
     # Efficiency plots
     metrics = metric_choices
     yzooms = [False, True]
+
     variables = {
             "eff": ["pt", "ptlow", "ptmtv", "eta", "phi", "dxy", "dz", "vxy"],
             "fakerate": ["pt", "ptlow", "ptmtv", "eta", "phi"],
             "duplrate": ["pt", "ptlow", "ptmtv", "eta", "phi"],
             }
+    if (args.jet_branches): variables["eff"] = ["pt", "ptlow", "ptmtv", "eta", "phi", "dxy", "dz", "vxy", "deltaEta", "deltaPhi", "deltaR", "jet_eta", "jet_phi", "jet_pt"]
     sels = {
             "eff": ["base", "loweta"],
             "fakerate": ["none"],
@@ -662,8 +675,16 @@ def plot_standard_performance_plots(args):
             "phi": [False, True],
             "dxy": [False, True],
             "vxy": [False, True],
-            "dz": [False, True],
+            "dz": [False, True]
             }
+    if (args.jet_branches): 
+        xcoarses["deltaEta"] = [False, True]
+        xcoarses["deltaPhi"] = [False, True]
+        xcoarses["deltaR"] = [False, True]
+        xcoarses["jet_eta"] = [False, True]
+        xcoarses["jet_phi"] = [False, True]
+        xcoarses["jet_pt"] = [False, True]
+
     types = objecttype_choices
     breakdowns = {
             "eff":{

--- a/RecoTracker/LSTCore/standalone/efficiency/src/helper.cc
+++ b/RecoTracker/LSTCore/standalone/efficiency/src/helper.cc
@@ -30,8 +30,9 @@ void parseArguments(int argc, char** argv) {
       "g,pdgid", "additional pdgid filtering to use (must be comma separated)", cxxopts::value<std::string>())(
       "p,pt_cut", "Transverse momentum cut", cxxopts::value<float>()->default_value("0.9"))(
       "e,eta_cut", "Pseudorapidity cut", cxxopts::value<float>()->default_value("4.5"))(
-      "d,debug", "Run debug job. i.e. overrides output option to 'debug.root' and 'recreate's the file.")("h,help",
-                                                                                                          "Print help");
+      "d,debug", "Run debug job. i.e. overrides output option to 'debug.root' and 'recreate's the file.")(
+      "J,jet_branches", "Accounts for specific jet branches in input root file for testing")(
+      "h,help", "Print help");
 
   auto result = options.parse(argc, argv);
 
@@ -129,6 +130,10 @@ void parseArguments(int argc, char** argv) {
   } else {
     ana.job_index = -1;
   }
+
+  //_______________________________________________________________________________
+  // --jet_branches
+  ana.jet_branches = result["jet_branches"].as<bool>();
 
   // Sanity check for split jobs (if one is set the other must be set too)
   if (result.count("job_index") or result.count("nsplit_jobs")) {

--- a/RecoTracker/LSTCore/standalone/efficiency/src/helper.cc
+++ b/RecoTracker/LSTCore/standalone/efficiency/src/helper.cc
@@ -31,8 +31,7 @@ void parseArguments(int argc, char** argv) {
       "p,pt_cut", "Transverse momentum cut", cxxopts::value<float>()->default_value("0.9"))(
       "e,eta_cut", "Pseudorapidity cut", cxxopts::value<float>()->default_value("4.5"))(
       "d,debug", "Run debug job. i.e. overrides output option to 'debug.root' and 'recreate's the file.")(
-      "J,jet_branches", "Accounts for specific jet branches in input root file for testing")(
-      "h,help", "Print help");
+      "J,jet_branches", "Accounts for specific jet branches in input root file for testing")("h,help", "Print help");
 
   auto result = options.parse(argc, argv);
 

--- a/RecoTracker/LSTCore/standalone/efficiency/src/helper.h
+++ b/RecoTracker/LSTCore/standalone/efficiency/src/helper.h
@@ -62,6 +62,9 @@ public:
   // do lower level
   bool do_lower_level;
 
+  // Boolean to enable jet branches
+  bool jet_branches;
+
   AnalysisConfig();
 };
 

--- a/RecoTracker/LSTCore/standalone/efficiency/src/performance.cc
+++ b/RecoTracker/LSTCore/standalone/efficiency/src/performance.cc
@@ -351,8 +351,119 @@ void bookEfficiencySets(std::vector<SimTrackSetDefinition>& effsets) {
 void bookEfficiencySet(SimTrackSetDefinition& effset) {
   TString category_name = TString::Format("%s_%d_%d", effset.set_name.Data(), effset.pdgid, effset.q);
 
-  // Denominator tracks' quantities
+  // Lines for deltaEta
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_deltaEta");
+  ana.histograms.addVecHistogram(category_name + "_ef_denom_deltaEta", 180, -4.5, 4.5, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_deltaEta");
+  });
+
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_deltaEta");
+  ana.histograms.addVecHistogram(category_name + "_ef_numer_deltaEta", 180, -4.5, 4.5, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_deltaEta");
+  });
+
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_deltaEta");
+  ana.histograms.addVecHistogram(category_name + "_ie_numer_deltaEta", 180, -4.5, 4.5, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_deltaEta");
+  });
+
+  // Lines for deltaPhi
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_deltaPhi");
+  ana.histograms.addVecHistogram(category_name + "_ef_denom_deltaPhi", 180, -4.5, 4.5, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_deltaPhi");
+  });
+
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_deltaPhi");
+  ana.histograms.addVecHistogram(category_name + "_ef_numer_deltaPhi", 180, -4.5, 4.5, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_deltaPhi");
+  });
+
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_deltaPhi");
+  ana.histograms.addVecHistogram(category_name + "_ie_numer_deltaPhi", 180, -4.5, 4.5, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_deltaPhi");
+  });
+
+  // Lines for deltaR
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_deltaR");
+  ana.histograms.addVecHistogram(category_name + "_ef_denom_deltaR", 50, 0, 0.1, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_deltaR");
+  });
+
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_deltaR");
+  ana.histograms.addVecHistogram(category_name + "_ef_numer_deltaR", 50, 0, 0.1, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_deltaR");
+  });
+
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_deltaR");
+  ana.histograms.addVecHistogram(category_name + "_ie_numer_deltaR", 50, 0, 0.1, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_deltaR");
+  });
+
+  // Lines for jet_eta
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_jet_eta");
+  ana.histograms.addVecHistogram(category_name + "_ef_denom_jet_eta", 180, -4.5, 4.5, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_jet_eta");
+  });
+
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_jet_eta");
+  ana.histograms.addVecHistogram(category_name + "_ef_numer_jet_eta", 180, -4.5, 4.5, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_jet_eta");
+  });
+
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_jet_eta");
+  ana.histograms.addVecHistogram(category_name + "_ie_numer_jet_eta", 180, -4.5, 4.5, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_jet_eta");
+  });
+
+  // Lines for jet_phi
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_jet_phi");
+  ana.histograms.addVecHistogram(category_name + "_ef_denom_jet_phi", 180, -4.5, 4.5, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_jet_phi");
+  });
+
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_jet_phi");
+  ana.histograms.addVecHistogram(category_name + "_ef_numer_jet_phi", 180, -4.5, 4.5, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_jet_phi");
+  });
+
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_jet_phi");
+  ana.histograms.addVecHistogram(category_name + "_ie_numer_jet_phi", 180, -4.5, 4.5, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_jet_phi");
+  });
+
+  // Lines for jet_pt
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_jet_pt");
+  ana.histograms.addVecHistogram(category_name + "_ef_denom_jet_pt", 50, 50, 1000, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_jet_pt");
+  });
+
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_jet_pt");
+  ana.histograms.addVecHistogram(category_name + "_ef_numer_jet_pt", 50, 50, 1000, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_jet_pt");
+  });
+
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_jet_pt");
+  ana.histograms.addVecHistogram(category_name + "_ie_numer_jet_pt", 50, 50, 1000, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_jet_pt");
+  });
+
+  // Moving the standard pT code up here for convenience
   ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_pt");
+  ana.histograms.addVecHistogram(category_name + "_ef_denom_pt", getPtBounds(0), [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_pt");
+  });
+
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_pt");
+  ana.histograms.addVecHistogram(category_name + "_ef_numer_pt", getPtBounds(0), [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_pt");
+  });
+
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_pt");
+  ana.histograms.addVecHistogram(category_name + "_ie_numer_pt", getPtBounds(0), [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_pt");
+  });
+
+  // Denominator tracks' quantities
   ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_eta");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_dxy");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_vxy");
@@ -360,7 +471,6 @@ void bookEfficiencySet(SimTrackSetDefinition& effset) {
   ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_phi");
 
   // Numerator tracks' quantities
-  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_pt");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_eta");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_dxy");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_vxy");
@@ -368,16 +478,12 @@ void bookEfficiencySet(SimTrackSetDefinition& effset) {
   ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_phi");
 
   // Inefficiencies
-  ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_pt");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_eta");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_dxy");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_vxy");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_dz");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_phi");
 
-  ana.histograms.addVecHistogram(category_name + "_ef_denom_pt", getPtBounds(0), [&, category_name]() {
-    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_pt");
-  });
   ana.histograms.addVecHistogram(category_name + "_ef_denom_ptlow", getPtBounds(4), [&, category_name]() {
     return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_pt");
   });
@@ -403,9 +509,6 @@ void bookEfficiencySet(SimTrackSetDefinition& effset) {
     return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_phi");
   });
 
-  ana.histograms.addVecHistogram(category_name + "_ef_numer_pt", getPtBounds(0), [&, category_name]() {
-    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_pt");
-  });
   ana.histograms.addVecHistogram(category_name + "_ef_numer_ptlow", getPtBounds(4), [&, category_name]() {
     return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_pt");
   });
@@ -431,9 +534,6 @@ void bookEfficiencySet(SimTrackSetDefinition& effset) {
     return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_phi");
   });
 
-  ana.histograms.addVecHistogram(category_name + "_ie_numer_pt", getPtBounds(0), [&, category_name]() {
-    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_pt");
-  });
   ana.histograms.addVecHistogram(category_name + "_ie_numer_ptlow", getPtBounds(4), [&, category_name]() {
     return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_pt");
   });
@@ -587,25 +687,212 @@ void fillEfficiencySets(std::vector<SimTrackSetDefinition>& effsets) {
   std::vector<float> const& vtx_y = lstEff.getVF("sim_vy");
   std::vector<float> const& vtx_z = lstEff.getVF("sim_vz");
 
-  for (auto& effset : effsets) {
-    for (unsigned int isimtrk = 0; isimtrk < lstEff.getVF("sim_pt").size(); ++isimtrk) {
-      fillEfficiencySet(isimtrk,
-                        effset,
-                        pt.at(isimtrk),
-                        eta.at(isimtrk),
-                        dz.at(isimtrk),
-                        dxy.at(isimtrk),
-                        phi.at(isimtrk),
-                        pdgidtrk.at(isimtrk),
-                        q.at(isimtrk),
-                        vtx_x.at(isimtrk),
-                        vtx_y.at(isimtrk),
-                        vtx_z.at(isimtrk));
+  if (ana.jet_branches) {
+    std::vector<float> const& deltaEta = lstEff.getVF("sim_deltaEta");
+    std::vector<float> const& deltaPhi = lstEff.getVF("sim_deltaPhi");
+    std::vector<float> const& deltaR = lstEff.getVF("sim_deltaR");
+    std::vector<float> const& jet_eta = lstEff.getVF("sim_jet_eta");
+    std::vector<float> const& jet_phi = lstEff.getVF("sim_jet_phi");
+    std::vector<float> const& jet_pt = lstEff.getVF("sim_jet_pt");
+
+    for (auto& effset : effsets) {
+      for (unsigned int isimtrk = 0; isimtrk < lstEff.getVF("sim_pt").size(); ++isimtrk) {
+        fillEfficiencySet(isimtrk,
+                          effset,
+                          pt.at(isimtrk),
+                          eta.at(isimtrk),
+                          dz.at(isimtrk),
+                          dxy.at(isimtrk),
+                          phi.at(isimtrk),
+                          pdgidtrk.at(isimtrk),
+                          q.at(isimtrk),
+                          vtx_x.at(isimtrk),
+                          vtx_y.at(isimtrk),
+                          vtx_z.at(isimtrk),
+                          deltaEta.at(isimtrk),
+                          deltaPhi.at(isimtrk),
+                          deltaR.at(isimtrk),
+                          jet_eta.at(isimtrk),
+                          jet_phi.at(isimtrk),
+                          jet_pt.at(isimtrk));
+      }
+    }
+  } else {
+    for (auto& effset : effsets) {
+      for (unsigned int isimtrk = 0; isimtrk < lstEff.getVF("sim_pt").size(); ++isimtrk) {
+        fillEfficiencySet(isimtrk,
+                          effset,
+                          pt.at(isimtrk),
+                          eta.at(isimtrk),
+                          dz.at(isimtrk),
+                          dxy.at(isimtrk),
+                          phi.at(isimtrk),
+                          pdgidtrk.at(isimtrk),
+                          q.at(isimtrk),
+                          vtx_x.at(isimtrk),
+                          vtx_y.at(isimtrk),
+                          vtx_z.at(isimtrk));
+      }
     }
   }
 }
 
 //__________________________________________________________________________________________________________________________________________________________________________
+void fillEfficiencySet(int isimtrk,
+                       SimTrackSetDefinition& effset,
+                       float pt,
+                       float eta,
+                       float dz,
+                       float dxy,
+                       float phi,
+                       int pdgidtrk,
+                       int q,
+                       float vtx_x,
+                       float vtx_y,
+                       float vtx_z,
+                       float deltaEta,
+                       float deltaPhi,
+                       float deltaR,
+                       float jet_eta,
+                       float jet_phi,
+                       float jet_pt) {
+  //=========================================================
+  // NOTE: The following is not applied as the LSTNtuple no longer writes this.
+  // const int &bunch = lstEff.getVI("sim_bunchCrossing")[isimtrk];
+  // const int &event = lstEff.getVI("sim_event")[isimtrk];
+  // if (bunch != 0)
+  //     return;
+  // if (event != 0)
+  //     return;
+  //=========================================================
+
+  const float vtx_perp = sqrt(vtx_x * vtx_x + vtx_y * vtx_y);
+  bool pass = effset.pass(isimtrk);
+  bool sel = effset.sel(isimtrk);
+
+  if (effset.pdgid != 0) {
+    if (std::abs(pdgidtrk) != std::abs(effset.pdgid))
+      return;
+  }
+
+  if (effset.q != 0) {
+    if (q != effset.q)
+      return;
+  }
+
+  if (effset.pdgid == 0 and q == 0)
+    return;
+
+  if (not sel)
+    return;
+
+  TString category_name = TString::Format("%s_%d_%d", effset.set_name.Data(), effset.pdgid, effset.q);
+
+  // https://github.com/cms-sw/cmssw/blob/7cbdb18ec6d11d5fd17ca66c1153f0f4e869b6b0/SimTracker/Common/python/trackingParticleSelector_cfi.py
+  // https://github.com/cms-sw/cmssw/blob/7cbdb18ec6d11d5fd17ca66c1153f0f4e869b6b0/SimTracker/Common/interface/TrackingParticleSelector.h#L122-L124
+  const float vtx_z_thresh = 30;
+  const float vtx_perp_thresh = 2.5;
+
+  if (pt > 0 && jet_eta < 140 && jet_eta > -140 && (jet_eta > -999 && deltaEta > -999)) {
+    // N minus eta cut
+    if (pt > ana.pt_cut and std::abs(vtx_z) < vtx_z_thresh and std::abs(vtx_perp) < vtx_perp_thresh) {
+      // vs. eta plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_eta", eta);
+      if (pass)
+        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_eta", eta);
+      else
+        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_eta", eta);
+    }
+
+    // N minus pt cut
+    if (std::abs(eta) < ana.eta_cut and std::abs(vtx_z) < vtx_z_thresh and std::abs(vtx_perp) < vtx_perp_thresh) {
+      // vs. pt plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_pt", pt);
+      if (pass)
+        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_pt", pt);
+      else
+        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_pt", pt);
+    }
+
+    // N minus dxy cut
+    if (std::abs(eta) < ana.eta_cut and pt > ana.pt_cut and std::abs(vtx_z) < vtx_z_thresh) {
+      // vs. dxy plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_dxy", dxy);
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_vxy", vtx_perp);
+      if (pass) {
+        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_dxy", dxy);
+        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_vxy", vtx_perp);
+      } else {
+        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_dxy", dxy);
+        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_vxy", vtx_perp);
+      }
+    }
+
+    // N minus dz cut
+    if (std::abs(eta) < ana.eta_cut and pt > ana.pt_cut and std::abs(vtx_perp) < vtx_perp_thresh) {
+      // vs. dz plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_dz", dz);
+      if (pass)
+        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_dz", dz);
+      else
+        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_dz", dz);
+    }
+
+    // All phase-space cuts
+    if (std::abs(eta) < ana.eta_cut and pt > ana.pt_cut and std::abs(vtx_z) < vtx_z_thresh and
+        std::abs(vtx_perp) < vtx_perp_thresh) {
+      // vs. Phi plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_phi", phi);
+      if (pass)
+        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_phi", phi);
+      else
+        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_phi", phi);
+
+      // vs. deltaEta plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_deltaEta", deltaEta);
+      if (pass)
+        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_deltaEta", deltaEta);
+      else
+        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_deltaEta", deltaEta);
+
+      // vs. deltaPhi plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_deltaPhi", deltaPhi);
+      if (pass)
+        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_deltaPhi", deltaPhi);
+      else
+        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_deltaPhi", deltaPhi);
+
+      // vs. deltaR plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_deltaR", deltaR);
+      if (pass)
+        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_deltaR", deltaR);
+      else
+        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_deltaR", deltaR);
+
+      // vs. jet_eta plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_jet_eta", jet_eta);
+      if (pass)
+        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_jet_eta", jet_eta);
+      else
+        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_jet_eta", jet_eta);
+
+      // vs. jet_phi plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_jet_phi", jet_phi);
+      if (pass)
+        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_jet_phi", jet_phi);
+      else
+        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_jet_phi", jet_phi);
+
+      // vs. jet_pt plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_jet_pt", jet_pt);
+      if (pass)
+        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_jet_pt", jet_pt);
+      else
+        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_jet_pt", jet_pt);
+    }
+  }
+}
+
 void fillEfficiencySet(int isimtrk,
                        SimTrackSetDefinition& effset,
                        float pt,

--- a/RecoTracker/LSTCore/standalone/efficiency/src/performance.h
+++ b/RecoTracker/LSTCore/standalone/efficiency/src/performance.h
@@ -14,6 +14,25 @@ void bookDuplicateRateSets(std::vector<RecoTrackSetDefinition>& DRset);
 void bookDuplicateRateSet(RecoTrackSetDefinition& DRset);
 
 void fillEfficiencySets(std::vector<SimTrackSetDefinition>& effset);
+
+void fillEfficiencySet(int isimtrk,
+                       SimTrackSetDefinition& effset,
+                       float pt,
+                       float eta,
+                       float dz,
+                       float dxy,
+                       float phi,
+                       int pdgidtrk,
+                       int q,
+                       float vtx_x,
+                       float vtx_y,
+                       float vtx_z,
+                       float deltaEta,
+                       float deltaPhi,
+                       float deltaR,
+                       float jet_eta,
+                       float jet_phi,
+                       float jet_pt);
 void fillEfficiencySet(int isimtrk,
                        SimTrackSetDefinition& effset,
                        float pt,
@@ -26,6 +45,7 @@ void fillEfficiencySet(int isimtrk,
                        float vtx_x,
                        float vtx_y,
                        float vtx_z);
+
 void fillFakeRateSets(std::vector<RecoTrackSetDefinition>& FRset);
 void fillFakeRateSet(int isimtrk, RecoTrackSetDefinition& FRset, float pt, float eta, float phi);
 void fillDuplicateRateSets(std::vector<RecoTrackSetDefinition>& DRset);


### PR DESCRIPTION
My goal was to examine the efficiency of LST close to the center of jets. To do this, I generated a trackingNtuple.root file and clustered it into jets. The trackingNtuple.root file is too large to upload here, but the code I used to create the jets is in reformat_jets.py and myjets.py. Currently, these files are configured to read in the usual ttbar sample.

Those two files add six branches to the original trackingNtuple.root file. These branches are sim_deltaEta, sim_deltaPhi, sim_deltaR, (formerly sim_etadiffs, sim_rjetdiffs, sim_rjet), sim_jet_eta, sim_jet_phi, and sim_jet_pt). The sim_deltaR branch is the most relevant– here ΔR is the eta-phi distance between a track and the center of the closest jet.

In order to create efficiency plots for this, I modified the existing LST files to include my branches. This mostly involved copying lines of code and changing the relevant branch names. In a few places, I have included cuts or edits to how the efficiency plots are produced. (Everywhere I have made a change I also added a comment to the effect of "Added by Kasia", but this was only so that I could find my own changes quickly when I need them.) The only change to the original LST output under this configuration is that if a track is not part of a jet, it is not included. However, if the input root file does not contain my six custom branches, LST will not compile. This pull request is mainly to demonstrate what I have done.

Here is the indico link to the presentation I gave to the LST group on 3/18/25:
https://indico.cern.ch/event/1496305/contributions/6303105/attachments/3034297/5358002/Jet%20Efficiencies.pdf

EDIT 6/16/25:
To enable/disable the code responsible for reading in the branches I added, I added a flag -J. This flag needs to be included both with the lst_BACKEND command and with createPerfNumDenHists. For example:

lst_make_tracklooper -mcC;
lst_cpu -J -s 32 -i "new_tree.root" -l -o LSTNtuple.root;
createPerfNumDenHists -J -i LSTNtuple.root -o LSTNumDen.root;
Without this -J flag, LST is unaffected by my changes. With the -J flag, all that changes is that new efficiency plots are produced that group existing sim tracks together based on their position within a jet.
