### PR TITLE
LHCInfo* printing utilities 

### DIFF
--- a/CondTools/RunInfo/plugins/BuildFile.xml
+++ b/CondTools/RunInfo/plugins/BuildFile.xml
@@ -51,7 +51,15 @@
   <flags EDM_PLUGIN="1"/>
 </library>  
 
+<library file="LHCInfoPerLSWriter.cc" name="LHCInfoPerLSWriter">
+  <flags EDM_PLUGIN="1"/>
+</library>
+
 <library file="LHCInfoPerLSAnalyzer.cc" name="LHCInfoPerLSAnalyzer">
+  <flags EDM_PLUGIN="1"/>
+</library>
+
+<library file="LHCInfoPerLSTester.cc" name="LHCInfoPerLSTester">
   <flags EDM_PLUGIN="1"/>
 </library>
 
@@ -64,6 +72,14 @@
 </library>
 
 <library file="LHCInfoPerFillAnalyzer.cc" name="LHCInfoPerFillAnalyzer">
+  <flags EDM_PLUGIN="1"/>
+</library>
+
+<library file="LHCInfoPerFillTester.cc" name="LHCInfoPerFillTester">
+  <flags EDM_PLUGIN="1"/>
+</library>
+
+<library file="LHCInfoAnalyzer.cc" name="LHCInfoAnalyzer">
   <flags EDM_PLUGIN="1"/>
 </library>
 

--- a/CondTools/RunInfo/plugins/LHCInfoAnalyzer.cc
+++ b/CondTools/RunInfo/plugins/LHCInfoAnalyzer.cc
@@ -1,0 +1,43 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+
+#include "CondFormats/RunInfo/interface/LHCInfo.h"
+#include "CondFormats/DataRecord/interface/LHCInfoRcd.h"
+
+#include <memory>
+#include <iostream>
+
+class LHCInfoAnalyzer : public edm::one::EDAnalyzer<> {
+public:
+  explicit LHCInfoAnalyzer(const edm::ParameterSet&) : tokenInfo_(esConsumes<LHCInfo, LHCInfoRcd>()) {}
+
+private:
+  void beginJob() override {}
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override {}
+
+  edm::ESWatcher<LHCInfoRcd> InfoWatcher_;
+
+  edm::ESGetToken<LHCInfo, LHCInfoRcd> tokenInfo_;
+};
+
+void LHCInfoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // get Info
+  if (InfoWatcher_.check(iSetup)) {
+    const auto& lhcInfo = iSetup.getData(tokenInfo_);
+    std::cout << "LHCInfo;" << iEvent.time().unixTime() << ";" << lhcInfo.lumiSection() << ";"
+              << lhcInfo.crossingAngle() << ";" << lhcInfo.betaStar() << ";" << lhcInfo.delivLumi() << ";" << std::endl;
+  }
+}
+
+DEFINE_FWK_MODULE(LHCInfoAnalyzer);

--- a/CondTools/RunInfo/plugins/LHCInfoPerFillAnalyzer.cc
+++ b/CondTools/RunInfo/plugins/LHCInfoPerFillAnalyzer.cc
@@ -1,3 +1,4 @@
+#include "CondFormats/Common/interface/Time.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -15,8 +16,9 @@
 
 class LHCInfoPerFillAnalyzer : public edm::one::EDAnalyzer<> {
 public:
-  explicit LHCInfoPerFillAnalyzer(const edm::ParameterSet&)
-      : tokenInfoPerFill_(esConsumes<LHCInfoPerFill, LHCInfoPerFillRcd>()) {}
+  explicit LHCInfoPerFillAnalyzer(const edm::ParameterSet& pset)
+      : tokenInfoPerFill_(esConsumes<LHCInfoPerFill, LHCInfoPerFillRcd>()),
+        iov_(pset.getUntrackedParameter<cond::Time_t>("iov")) {}
 
 private:
   void beginJob() override {}
@@ -26,39 +28,15 @@ private:
   edm::ESWatcher<LHCInfoPerFillRcd> infoPerFillWatcher_;
 
   edm::ESGetToken<LHCInfoPerFill, LHCInfoPerFillRcd> tokenInfoPerFill_;
+  const cond::Time_t iov_;
 };
 
 void LHCInfoPerFillAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   assert(infoPerFillWatcher_.check(iSetup));
 
-  LHCInfoPerFill lhcInfoPerFill = iSetup.getData(tokenInfoPerFill_);
-  const float EPS = 1E-4;
-  assert(lhcInfoPerFill.fillNumber() == 3);
-  assert(lhcInfoPerFill.bunchesInBeam1() == 10);
-  assert(lhcInfoPerFill.bunchesInBeam2() == 8);
-  assert(lhcInfoPerFill.collidingBunches() == 5);
-  assert(lhcInfoPerFill.targetBunches() == 4);
-  assert(lhcInfoPerFill.fillType() == lhcInfoPerFill.PROTONS);
-  assert(lhcInfoPerFill.particleTypeForBeam1() == lhcInfoPerFill.PROTON);
-  assert(lhcInfoPerFill.particleTypeForBeam2() == lhcInfoPerFill.PROTON);
-  assert(abs(lhcInfoPerFill.intensityForBeam1() - 1016.5) < EPS);
-  assert(abs(lhcInfoPerFill.intensityForBeam2() - 1096.66) < EPS);
-  assert(abs(lhcInfoPerFill.energy() - 7000) < EPS);
-  assert(abs(lhcInfoPerFill.delivLumi() - 2E-07) < EPS);
-  assert(abs(lhcInfoPerFill.recLumi() - 2E-07) < EPS);
-  assert(abs(lhcInfoPerFill.instLumi() - 0) < EPS);
-  assert(abs(lhcInfoPerFill.instLumiError() - 0) < EPS);
-  assert(lhcInfoPerFill.createTime() == 6561530930997627120);
-  assert(lhcInfoPerFill.beginTime() == 6561530930997627120);
-  assert(lhcInfoPerFill.endTime() == 6561530930997627120);
-  assert(lhcInfoPerFill.injectionScheme() == "None");
-  assert(lhcInfoPerFill.lumiPerBX().size() == 2);
-  assert(abs(lhcInfoPerFill.lumiPerBX()[0] - 0.000114139) < EPS);
-  assert(abs(lhcInfoPerFill.lumiPerBX()[1] - 0.000114139) < EPS);
-  assert(lhcInfoPerFill.lhcState() == "some lhcState");
-  assert(lhcInfoPerFill.lhcComment() == "some lhcComment");
-  assert(lhcInfoPerFill.ctppsStatus() == "some ctppsStatus");
-  edm::LogInfo("LHCInfoPerFillAnalyzer") << "LHCInfoPerFill retrieved:\n" << lhcInfoPerFill;
+  const LHCInfoPerFill& lhcInfoPerFill = iSetup.getData(tokenInfoPerFill_);
+
+  std::cout << "IOV " << iov_ << "\nLHCInfoPerFill retrieved:\n" << lhcInfoPerFill;
 }
 
 DEFINE_FWK_MODULE(LHCInfoPerFillAnalyzer);

--- a/CondTools/RunInfo/plugins/LHCInfoPerFillTester.cc
+++ b/CondTools/RunInfo/plugins/LHCInfoPerFillTester.cc
@@ -1,0 +1,64 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "CondFormats/RunInfo/interface/LHCInfoPerFill.h"
+#include "CondFormats/DataRecord/interface/LHCInfoPerFillRcd.h"
+
+#include <memory>
+#include <iostream>
+#include <vector>
+#include <cassert>
+
+class LHCInfoPerFillTester : public edm::one::EDAnalyzer<> {
+public:
+  explicit LHCInfoPerFillTester(const edm::ParameterSet&)
+      : tokenInfoPerFill_(esConsumes<LHCInfoPerFill, LHCInfoPerFillRcd>()) {}
+
+private:
+  void beginJob() override {}
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override {}
+
+  edm::ESWatcher<LHCInfoPerFillRcd> infoPerFillWatcher_;
+
+  edm::ESGetToken<LHCInfoPerFill, LHCInfoPerFillRcd> tokenInfoPerFill_;
+};
+
+void LHCInfoPerFillTester::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  assert(infoPerFillWatcher_.check(iSetup));
+
+  const LHCInfoPerFill& lhcInfoPerFill = iSetup.getData(tokenInfoPerFill_);
+  const float EPS = 1E-4;
+  assert(lhcInfoPerFill.fillNumber() == 3);
+  assert(lhcInfoPerFill.bunchesInBeam1() == 10);
+  assert(lhcInfoPerFill.bunchesInBeam2() == 8);
+  assert(lhcInfoPerFill.collidingBunches() == 5);
+  assert(lhcInfoPerFill.targetBunches() == 4);
+  assert(lhcInfoPerFill.fillType() == lhcInfoPerFill.PROTONS);
+  assert(lhcInfoPerFill.particleTypeForBeam1() == lhcInfoPerFill.PROTON);
+  assert(lhcInfoPerFill.particleTypeForBeam2() == lhcInfoPerFill.PROTON);
+  assert(abs(lhcInfoPerFill.intensityForBeam1() - 1016.5) < EPS);
+  assert(abs(lhcInfoPerFill.intensityForBeam2() - 1096.66) < EPS);
+  assert(abs(lhcInfoPerFill.energy() - 7000) < EPS);
+  assert(abs(lhcInfoPerFill.delivLumi() - 2E-07) < EPS);
+  assert(abs(lhcInfoPerFill.recLumi() - 2E-07) < EPS);
+  assert(abs(lhcInfoPerFill.instLumi() - 0) < EPS);
+  assert(abs(lhcInfoPerFill.instLumiError() - 0) < EPS);
+  assert(lhcInfoPerFill.createTime() == 6561530930997627120);
+  assert(lhcInfoPerFill.beginTime() == 6561530930997627120);
+  assert(lhcInfoPerFill.endTime() == 6561530930997627120);
+  assert(lhcInfoPerFill.injectionScheme() == "None");
+  assert(lhcInfoPerFill.lumiPerBX().size() == 2);
+  assert(abs(lhcInfoPerFill.lumiPerBX()[0] - 0.000114139) < EPS);
+  assert(abs(lhcInfoPerFill.lumiPerBX()[1] - 0.000114139) < EPS);
+  assert(lhcInfoPerFill.lhcState() == "some lhcState");
+  assert(lhcInfoPerFill.lhcComment() == "some lhcComment");
+  assert(lhcInfoPerFill.ctppsStatus() == "some ctppsStatus");
+  edm::LogInfo("LHCInfoPerFillTester") << "LHCInfoPerFill retrieved:\n" << lhcInfoPerFill;
+}
+
+DEFINE_FWK_MODULE(LHCInfoPerFillTester);

--- a/CondTools/RunInfo/plugins/LHCInfoPerLSAnalyzer.cc
+++ b/CondTools/RunInfo/plugins/LHCInfoPerLSAnalyzer.cc
@@ -1,9 +1,12 @@
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "CondFormats/Common/interface/Time.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "CondFormats/RunInfo/interface/LHCInfoPerLS.h"
 #include "CondFormats/DataRecord/interface/LHCInfoPerLSRcd.h"
@@ -14,8 +17,14 @@
 
 class LHCInfoPerLSAnalyzer : public edm::one::EDAnalyzer<> {
 public:
-  explicit LHCInfoPerLSAnalyzer(const edm::ParameterSet&)
-      : tokenInfoPerLS_(esConsumes<LHCInfoPerLS, LHCInfoPerLSRcd>()) {}
+  explicit LHCInfoPerLSAnalyzer(const edm::ParameterSet& pset)
+      : tokenInfoPerLS_(esConsumes<LHCInfoPerLS, LHCInfoPerLSRcd>()),
+        csvFormat_(pset.getUntrackedParameter<bool>("csvFormat")),
+        header_(pset.getUntrackedParameter<bool>("header")),
+        iov_(pset.getUntrackedParameter<cond::Time_t>("iov")),
+        separator_(pset.getUntrackedParameter<std::string>("separator")) {}
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   void beginJob() override {}
@@ -24,22 +33,39 @@ private:
 
   edm::ESWatcher<LHCInfoPerLSRcd> infoPerLSWatcher_;
 
-  edm::ESGetToken<LHCInfoPerLS, LHCInfoPerLSRcd> tokenInfoPerLS_;
+  const edm::ESGetToken<LHCInfoPerLS, LHCInfoPerLSRcd> tokenInfoPerLS_;
+  const bool csvFormat_;
+  const bool header_;
+  const cond::Time_t iov_;
+  const std::string separator_;
 };
+
+void LHCInfoPerLSAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.addUntracked<bool>("csvFormat", false);
+  desc.addUntracked<bool>("header", false);
+  desc.addUntracked<std::string>("separator", ",");
+  desc.addUntracked<cond::Time_t>("iov", 0);
+  descriptions.add("LHCInfoPerLSAnalyzer", desc);
+}
 
 void LHCInfoPerLSAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // get InfoPerLS
   assert(infoPerLSWatcher_.check(iSetup));
   const LHCInfoPerLS& infoPerLS = iSetup.getData(tokenInfoPerLS_);
 
-  assert(infoPerLS.fillNumber() == 7066);
-  assert(infoPerLS.lumiSection() == 1);
-  assert(infoPerLS.crossingAngleX() == 170);
-  assert(infoPerLS.crossingAngleY() == 170);
-  assert(infoPerLS.betaStarX() == 11);
-  assert(infoPerLS.betaStarY() == 11);
-  assert(infoPerLS.runNumber() == 301765);
-  edm::LogInfo("LHCInfoPerLSAnalyzer") << "LHCInfoPerLS retrieved:\n" << infoPerLS;
+  if (csvFormat_) {
+    auto s = separator_;
+    if (header_) {
+      std::cout << "IOV" << s << "class" << s << "timestamp" << s << "runNumber" << s << "LS" << s << "xangleX" << s
+                << "xangleY" << s << "beta*X" << s << "beta*Y" << s << std::endl;
+    }
+    std::cout << iov_ << s << "LHCInfoPerLS" << s << iEvent.time().unixTime() << s << infoPerLS.runNumber() << s
+              << infoPerLS.lumiSection() << s << infoPerLS.crossingAngleX() << s << infoPerLS.crossingAngleY() << s
+              << infoPerLS.betaStarX() << s << infoPerLS.betaStarY() << s << std::endl;
+  } else {
+    std::cout << infoPerLS << std::endl;
+  }
 }
 
 DEFINE_FWK_MODULE(LHCInfoPerLSAnalyzer);

--- a/CondTools/RunInfo/plugins/LHCInfoPerLSTester.cc
+++ b/CondTools/RunInfo/plugins/LHCInfoPerLSTester.cc
@@ -1,0 +1,45 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "CondFormats/RunInfo/interface/LHCInfoPerLS.h"
+#include "CondFormats/DataRecord/interface/LHCInfoPerLSRcd.h"
+
+#include <memory>
+#include <iostream>
+#include <cassert>
+
+class LHCInfoPerLSTester : public edm::one::EDAnalyzer<> {
+public:
+  explicit LHCInfoPerLSTester(const edm::ParameterSet&)
+      : tokenInfoPerLS_(esConsumes<LHCInfoPerLS, LHCInfoPerLSRcd>()) {}
+
+private:
+  void beginJob() override {}
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override {}
+
+  edm::ESWatcher<LHCInfoPerLSRcd> infoPerLSWatcher_;
+
+  edm::ESGetToken<LHCInfoPerLS, LHCInfoPerLSRcd> tokenInfoPerLS_;
+};
+
+void LHCInfoPerLSTester::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // get InfoPerLS
+  assert(infoPerLSWatcher_.check(iSetup));
+  const LHCInfoPerLS& infoPerLS = iSetup.getData(tokenInfoPerLS_);
+
+  assert(infoPerLS.fillNumber() == 7066);
+  assert(infoPerLS.lumiSection() == 1);
+  assert(infoPerLS.crossingAngleX() == 170);
+  assert(infoPerLS.crossingAngleY() == 170);
+  assert(infoPerLS.betaStarX() == 11);
+  assert(infoPerLS.betaStarY() == 11);
+  assert(infoPerLS.runNumber() == 301765);
+  edm::LogInfo("LHCInfoPerLSTester") << "LHCInfoPerLS retrieved:\n" << infoPerLS;
+}
+
+DEFINE_FWK_MODULE(LHCInfoPerLSTester);

--- a/CondTools/RunInfo/python/LHCInfoAnalyzer_cfg.py
+++ b/CondTools/RunInfo/python/LHCInfoAnalyzer_cfg.py
@@ -1,0 +1,65 @@
+import sys
+
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+process = cms.Process('test')
+
+options = VarParsing.VarParsing()
+options.register( 'source'
+                , 'sqlite_file:lhcinfo_pop_test.db' #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Connection string to the DB where payloads are going to be read from"
+                  )
+options.register( 'tag'
+                , 'LHCInfo_PopCon_test'
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag to read from in source"
+                  )
+options.register( 'timestamp'
+                , 7133428598295232512
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.int
+                , "Timestamp to which payload with relavant IOV will be read"
+                  )
+options.parseArguments()
+
+# minimum logging
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('ERROR')
+    )
+)
+
+process.source = cms.Source('EmptyIOVSource',
+    timetype = cms.string('timestamp'),
+    firstValue = cms.uint64(options.timestamp),
+    lastValue = cms.uint64(options.timestamp),
+    interval = cms.uint64(1)
+)
+
+# load info from database
+process.load('CondCore.CondDB.CondDB_cfi')
+process.CondDB.connect= options.source # SQLite input
+
+process.PoolDBESSource = cms.ESSource('PoolDBESSource',
+    process.CondDB,
+    DumpStats = cms.untracked.bool(True),
+    toGet = cms.VPSet(
+        cms.PSet(
+            record = cms.string('LHCInfoRcd'),
+            tag = cms.string(options.tag)
+        )
+    )
+)
+
+process.LHCInfoAnalyzer = cms.EDAnalyzer('LHCInfoAnalyzer')
+
+process.path = cms.Path(
+    process.LHCInfoAnalyzer
+)

--- a/CondTools/RunInfo/test/LHCInfoPerFillAnalyzer_cfg.py
+++ b/CondTools/RunInfo/test/LHCInfoPerFillAnalyzer_cfg.py
@@ -1,6 +1,43 @@
 import FWCore.ParameterSet.Config as cms
 
+import FWCore.ParameterSet.VarParsing as VarParsing
 process = cms.Process('test')
+
+options = VarParsing.VarParsing()
+supported_timetypes = {"timestamp", "lumiid"}
+options.register( 'db'
+                , 'frontier://FrontierProd/CMS_CONDITIONS' #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Connection string to the DB where payloads are going to be read from"
+                  )
+options.register( 'tag'
+                , None #default value is None because this argument is required
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag to read from in source db"
+                  )
+options.register( 'iov'
+                , 1
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.int
+                , "IOV: specifies the point in time to read the payload at"
+                  )
+options.register( 'timetype'
+                , 'timestamp' #default
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , f"timetype of the provided IOV, accepted values: {supported_timetypes}"
+                  )
+options.parseArguments()
+
+if options.tag == None:
+  print(f"Please specify the tag by adding to the command: tag=<tag to be printed>", file=sys.stderr)
+  exit(1)
+
+if options.timetype not in supported_timetypes:
+  print(f"Provided timetype '{options.timetype}' is not supported (accepted values: {supported_timetypes})", file=sys.stderr)
+  exit(1)
 
 # minimum logging
 process.MessageLogger = cms.Service("MessageLogger",
@@ -9,33 +46,34 @@ process.MessageLogger = cms.Service("MessageLogger",
     ),
     cout = cms.untracked.PSet(
         enable = cms.untracked.bool(True),
-        threshold = cms.untracked.string('INFO')
+        threshold = cms.untracked.string('ERROR')
     )
 )
 
 process.source = cms.Source('EmptyIOVSource',
-    timetype = cms.string('runnumber'),
-    firstValue = cms.uint64(1),
-    lastValue = cms.uint64(1),
+    timetype = cms.string(options.timetype),
+    firstValue = cms.uint64(options.iov),
+    lastValue = cms.uint64(options.iov),
     interval = cms.uint64(1)
 )
-
 # load info from database
 process.load('CondCore.CondDB.CondDB_cfi')
-process.CondDB.connect = 'sqlite_file:LHCInfoPerFill.sqlite' # SQLite input
+process.CondDB.connect= options.db # SQLite input
 
 process.PoolDBESSource = cms.ESSource('PoolDBESSource',
     process.CondDB,
-    DumpStat = cms.untracked.bool(True),
+    DumpStat = cms.untracked.bool(False),
     toGet = cms.VPSet(
         cms.PSet(
             record = cms.string('LHCInfoPerFillRcd'),
-            tag = cms.string('LHCInfoPerFillFake')
+            tag = cms.string(options.tag)
         )
     )
 )
 
-process.LHCInfoPerFillAnalyzer = cms.EDAnalyzer('LHCInfoPerFillAnalyzer')
+process.LHCInfoPerFillAnalyzer = cms.EDAnalyzer('LHCInfoPerFillAnalyzer',
+                                                iov = cms.untracked.uint64(options.iov)
+)
 
 process.path = cms.Path(
     process.LHCInfoPerFillAnalyzer

--- a/CondTools/RunInfo/test/LHCInfoPerFillTester_cfg.py
+++ b/CondTools/RunInfo/test/LHCInfoPerFillTester_cfg.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('test')
+
+# minimum logging
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
+)
+
+process.source = cms.Source('EmptyIOVSource',
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(1),
+    lastValue = cms.uint64(1),
+    interval = cms.uint64(1)
+)
+
+# load info from database
+process.load('CondCore.CondDB.CondDB_cfi')
+process.CondDB.connect = 'sqlite_file:LHCInfoPerFill.sqlite' # SQLite input
+
+process.PoolDBESSource = cms.ESSource('PoolDBESSource',
+    process.CondDB,
+    toGet = cms.VPSet(
+        cms.PSet(
+            record = cms.string('LHCInfoPerFillRcd'),
+            tag = cms.string('LHCInfoPerFillFake')
+        )
+    )
+)
+
+process.LHCInfoPerFillTester = cms.EDAnalyzer('LHCInfoPerFillTester')
+
+process.path = cms.Path(
+    process.LHCInfoPerFillTester
+)

--- a/CondTools/RunInfo/test/LHCInfoPerLSAnalyzer_cfg.py
+++ b/CondTools/RunInfo/test/LHCInfoPerLSAnalyzer_cfg.py
@@ -1,6 +1,62 @@
 import FWCore.ParameterSet.Config as cms
 
+import FWCore.ParameterSet.VarParsing as VarParsing
 process = cms.Process('test')
+
+options = VarParsing.VarParsing()
+supported_timetypes = {"timestamp", "lumiid"}
+options.register( 'db'
+                , 'frontier://FrontierProd/CMS_CONDITIONS' #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Connection string to the DB where payloads are going to be read from"
+                  )
+options.register( 'tag'
+                , None #default value is None because this argument is required
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag to read from in source db"
+                  )
+options.register( 'iov'
+                , 1
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.int
+                , "IOV: specifies the point in time to read the payload at"
+                  )
+options.register( 'timetype'
+                , 'timestamp' #default
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , f"timetype of the provided IOV, accepted values: {supported_timetypes}"
+                  )
+options.register( 'csv'
+                , False
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.bool
+                , "Whether or not to print the values in csv format"
+                  )
+options.register( 'header'
+                , False
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.bool
+                , "Whether or not to print header for the csv, works only when csv=True"
+                  )
+options.register( 'separator'
+                , ','
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "separator for the csv format, works only when csv=True"
+                  )
+options.parseArguments()
+
+if options.tag == None:
+  print(f"Please specify the tag by adding to the command: tag=<tag to be printed>", file=sys.stderr)
+  exit(1)
+
+if options.timetype not in supported_timetypes:
+  print(f"Provided timetype '{options.timetype}' is not supported (accepted values: {supported_timetypes})", file=sys.stderr)
+  exit(1)
+
 
 # minimum logging
 process.MessageLogger = cms.Service("MessageLogger",
@@ -9,33 +65,39 @@ process.MessageLogger = cms.Service("MessageLogger",
     ),
     cout = cms.untracked.PSet(
         enable = cms.untracked.bool(True),
-        threshold = cms.untracked.string('INFO')
+        threshold = cms.untracked.string('ERROR')
     )
 )
 
 process.source = cms.Source('EmptyIOVSource',
-    timetype = cms.string('runnumber'),
-    firstValue = cms.uint64(1),
-    lastValue = cms.uint64(1),
+    timetype = cms.string(options.timetype),
+    firstValue = cms.uint64(options.iov),
+    lastValue = cms.uint64(options.iov),
     interval = cms.uint64(1)
 )
 
 # load info from database
 process.load('CondCore.CondDB.CondDB_cfi')
-process.CondDB.connect = 'sqlite_file:LHCInfoPerLS.sqlite' # SQLite input
+process.CondDB.connect = options.db # SQLite input
 
 process.PoolDBESSource = cms.ESSource('PoolDBESSource',
     process.CondDB,
-    DumpStat = cms.untracked.bool(True),
+    DumpStat = cms.untracked.bool(False),
     toGet = cms.VPSet(
         cms.PSet(
             record = cms.string('LHCInfoPerLSRcd'),
-            tag = cms.string('LHCInfoPerLSFake')
+            tag = cms.string(options.tag)
         )
     )
 )
 
-process.LHCInfoPerLSAnalyzer = cms.EDAnalyzer('LHCInfoPerLSAnalyzer')
+process.LHCInfoPerLSAnalyzer = cms.EDAnalyzer('LHCInfoPerLSAnalyzer',
+                                              csvFormat = cms.untracked.bool(options.csv),
+                                              header = cms.untracked.bool(options.header),
+                                              iov = cms.untracked.uint64(options.iov),
+                                              separator = cms.untracked.string(options.separator),
+                                              
+)
 
 process.path = cms.Path(
     process.LHCInfoPerLSAnalyzer

--- a/CondTools/RunInfo/test/LHCInfoPerLSTester_cfg.py
+++ b/CondTools/RunInfo/test/LHCInfoPerLSTester_cfg.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('test')
+
+# minimum logging
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
+)
+
+process.source = cms.Source('EmptyIOVSource',
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(1),
+    lastValue = cms.uint64(1),
+    interval = cms.uint64(1)
+)
+
+# load info from database
+process.load('CondCore.CondDB.CondDB_cfi')
+process.CondDB.connect = 'sqlite_file:LHCInfoPerLS.sqlite' # SQLite input
+
+process.PoolDBESSource = cms.ESSource('PoolDBESSource',
+    process.CondDB,
+    toGet = cms.VPSet(
+        cms.PSet(
+            record = cms.string('LHCInfoPerLSRcd'),
+            tag = cms.string('LHCInfoPerLSFake')
+        )
+    )
+)
+
+process.LHCInfoPerLSTester = cms.EDAnalyzer('LHCInfoPerLSTester')
+
+process.path = cms.Path(
+    process.LHCInfoPerLSTester
+)

--- a/CondTools/RunInfo/test/printLHCInfoPerPayloads.py
+++ b/CondTools/RunInfo/test/printLHCInfoPerPayloads.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+import os
+import sys
+
+process = cms.Process('dumpLHCInfoPerPyalods')
+
+TEST_DIR = os.environ['CMSSW_BASE'] + "/src/CondTools/RunInfo/test"
+
+
+options = VarParsing.VarParsing()
+supported_records = {"LHCInfoPerLS", "LHCInfoPerFill"}
+csv_supported_records = {"LHCInfoPerLS"}
+supported_timetypes = {"timestamp", "lumiid"}
+options.register( 'record'
+                , None #default value is None because this argument is required
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , f"the class to analyze, accepted values: {supported_records}"
+                  )
+options.register( 'db'
+                , 'frontier://FrontierProd/CMS_CONDITIONS' #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Connection string to the DB where payloads are going to be read from"
+                  )
+options.register( 'tag'
+                , None #default value is None because this argument is required
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag to read from in source"
+                  )
+options.register( 'timetype'
+                , 'timestamp' #default
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , f"timetype of the provided IOVs, accepted values: {supported_timetypes}"
+                  )
+options.register( 'csv'
+                , False
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.bool
+                , f"Whether or not to print the values in csv format, supported only for records: {csv_supported_records}"
+                  )
+options.register( 'header'
+                , False
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.bool
+                , "Whether or not to print header for the csv, works only when csv=True"
+                  )
+options.register( 'separator'
+                , ','
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "separator for the csv format, works only when csv=True"
+                  )
+options.parseArguments()
+
+if options.record is None:
+  print(f"Please specify the record name argument (accepted values: {supported_records})", file=sys.stderr)
+  exit(1)
+if options.record not in supported_records:
+  print(f"Provided record name '{options.record}' is not supported (accepted values: {supported_records})", file=sys.stderr)
+  exit(1)
+
+if options.tag is None:
+  print(f"Please specify the tag by adding to the command: tag=<tag to be printed>", file=sys.stderr)
+  exit(1)
+
+if options.timetype not in supported_timetypes:
+  print(f"Provided timetype '{options.timetype}' is not supported (accepted values: {supported_timetypes})", file=sys.stderr)
+  exit(1)
+
+for line in map(str.rstrip, sys.stdin):
+    for iov in line.split():
+        csv_arguments = f" csv={options.csv} header={options.header} separator={options.separator} " 
+        arguments = f"db={options.db} tag={options.tag} iov={iov} timetype={options.timetype} " + \
+            (csv_arguments if options.record in csv_supported_records else "")
+
+        if options.record == "LHCInfoPerLS":
+            os.system(f"cmsRun {TEST_DIR}/LHCInfoPerLSAnalyzer_cfg.py {arguments}")
+        elif options.record == "LHCInfoPerFill":
+            os.system(f"cmsRun {TEST_DIR}/LHCInfoPerFillAnalyzer_cfg.py {arguments}")
+
+        options.header = False

--- a/CondTools/RunInfo/test/summarizePerLSPopConValidityLogs.sh
+++ b/CondTools/RunInfo/test/summarizePerLSPopConValidityLogs.sh
@@ -1,7 +1,7 @@
 LOG_FILE=$1
 echo "Number of invalid payloads found in the logs"
 for CONDITION in "crossingAngle == 0 for both X and Y" "crossingAngle != 0 for both X and Y" \
-                 "negative crossingAngle: " "negative betaStar" "Number of records from PPS DB with fillNumber different from OMS" \
+                 "negative crossingAngle" "negative betaStar" "Number of records from PPS DB with fillNumber different from OMS" \
                  "Number of stable beam LS in OMS without corresponding record in PPS DB" ; do
     echo -n "$CONDITION:  max in one fill: "
     (cat $LOG_FILE | grep -E "$CONDITION" | awk '{print $NF}' ; echo 0) | sort -gr | head -n 1

--- a/CondTools/RunInfo/test/test_lhcInfo.sh
+++ b/CondTools/RunInfo/test/test_lhcInfo.sh
@@ -5,7 +5,7 @@ LOCAL_TEST_DIR=$CMSSW_BASE/src/CondTools/RunInfo/test
 function die { echo Failure $1: status $2 ; exit $2 ; }
 
 cmsRun ${LOCAL_TEST_DIR}/LHCInfoPerFillWriter_cfg.py || die "cmsRun LHCInfoPerFillWriter_cfg.py" $?
-cmsRun ${LOCAL_TEST_DIR}/LHCInfoPerFillAnalyzer_cfg.py || die "cmsRun LHCInfoPerFillAnalyzer_cfg.py" $?
+cmsRun ${LOCAL_TEST_DIR}/LHCInfoPerFillTester_cfg.py || die "cmsRun LHCInfoPerFillTester_cfg.py" $?
 
 cmsRun ${LOCAL_TEST_DIR}/LHCInfoPerLSWriter_cfg.py   || die "cmsRun LHCInfoPerLSWriter_cfg.py" $?
-cmsRun ${LOCAL_TEST_DIR}/LHCInfoPerLSAnalyzer_cfg.py || die "cmsRun LHCInfoPerLSAnalyzer_cfg.py" $?
+cmsRun ${LOCAL_TEST_DIR}/LHCInfoPerLSTester_cfg.py || die "cmsRun LHCInfoPerLSTester_cfg.py" $?


### PR DESCRIPTION
#### PR description:

The PR contains modules for printing the contents of LHCInfoPerLS, LHCInfoPerFill and LHCInfo contents. For LHCInfoPerLS it supports csv format. More info and instructions on how to use it: https://cms-ppd.docs.cern.ch/ts/software/ExternalO2Os/user_guide/analyze_lhcinfo_payload.html


#### PR validation:

Tested using the commands in https://cms-ppd.docs.cern.ch/ts/software/ExternalO2Os/user_guide/analyze_lhcinfo_payload.html


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:


