### PR TITLE
Fix use of UPC era modifiers

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2023_UPC_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2023_UPC_cff.py
@@ -5,5 +5,6 @@ from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_low
 from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
 from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
+from Configuration.Eras.Modifier_run3_upc_2023_cff import run3_upc_2023
 
-Run3_2023_UPC = cms.ModifierChain(Run3_2023, egamma_lowPt_exclusive, highBetaStar, dedx_lfit, run3_upc)
+Run3_2023_UPC = cms.ModifierChain(Run3_2023, egamma_lowPt_exclusive, highBetaStar, dedx_lfit, run3_upc, run3_upc_2023)

--- a/Configuration/Eras/python/Era_Run3_2024_UPC_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2024_UPC_cff.py
@@ -5,5 +5,6 @@ from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_low
 from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
 from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
+from Configuration.Eras.Modifier_run3_upc_2024_cff import run3_upc_2024
 
-Run3_2024_UPC = cms.ModifierChain(Run3_2024, egamma_lowPt_exclusive, highBetaStar, dedx_lfit, run3_upc)
+Run3_2024_UPC = cms.ModifierChain(Run3_2024, egamma_lowPt_exclusive, highBetaStar, dedx_lfit, run3_upc, run3_upc_2024)

--- a/Configuration/Eras/python/Era_Run3_2025_UPC_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_UPC_cff.py
@@ -5,5 +5,6 @@ from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_low
 from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
 from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
+from Configuration.Eras.Modifier_run3_upc_2025_cff import run3_upc_2025
 
-Run3_2025_UPC = cms.ModifierChain(Run3_2025, egamma_lowPt_exclusive, highBetaStar, dedx_lfit, run3_upc)
+Run3_2025_UPC = cms.ModifierChain(Run3_2025, egamma_lowPt_exclusive, highBetaStar, dedx_lfit, run3_upc, run3_upc_2025)

--- a/Configuration/Eras/python/Modifier_run3_upc_2023_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_upc_2023_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_upc_2023 =cms.Modifier()

--- a/Configuration/Eras/python/Modifier_run3_upc_2024_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_upc_2024_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_upc_2024 =cms.Modifier()

--- a/Configuration/Eras/python/Modifier_run3_upc_2025_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_upc_2025_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_upc_2025 =cms.Modifier()

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -28,8 +28,8 @@ egamma_lowPt_exclusive.toModify(particleFlowSuperClusterECAL,
                                 thresh_PFClusterSeedBarrel = 0.5,
                                 thresh_PFClusterSeedEndcap = 0.5)
 
-from Configuration.Eras.Era_Run3_2023_UPC_cff import Run3_2023_UPC
-(egamma_lowPt_exclusive & Run3_2023_UPC).toModify(particleFlowSuperClusterECAL, regressionConfig = dict(
+from Configuration.Eras.Modifier_run3_upc_2023_cff import run3_upc_2023
+(egamma_lowPt_exclusive & run3_upc_2023).toModify(particleFlowSuperClusterECAL, regressionConfig = dict(
     regressionKeyEB  = 'pfscecal_ebCorrection_offline_v2',
     uncertaintyKeyEB = 'pfscecal_ebUncertainty_offline_v2',
     regressionKeyEE  = 'pfscecal_eeCorrection_offline_v2',

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectrons_cfi.py
@@ -70,9 +70,9 @@ _lowPtRegressionModifierUPC = regressionModifier103XLowPtPho.clone(
         )
     ),
 )
-from Configuration.Eras.Era_Run3_2023_UPC_cff import Run3_2023_UPC
+from Configuration.Eras.Modifier_run3_upc_2023_cff import run3_upc_2023
 from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
-(egamma_lowPt_exclusive & Run3_2023_UPC).toReplaceWith(lowPtRegressionModifier,_lowPtRegressionModifierUPC)
+(egamma_lowPt_exclusive & run3_upc_2023).toReplaceWith(lowPtRegressionModifier,_lowPtRegressionModifierUPC)
 
 from RecoEgamma.EgammaElectronProducers.lowPtGsfElectronFinalizer_cfi import lowPtGsfElectronFinalizer
 lowPtGsfElectrons = lowPtGsfElectronFinalizer.clone(

--- a/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
+++ b/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
@@ -266,9 +266,9 @@ regressionModifierRun3 = regressionModifierRun2.clone(
 from Configuration.Eras.Modifier_run3_egamma_cff import run3_egamma
 run3_egamma.toReplaceWith(regressionModifier,regressionModifierRun3)
 
-from Configuration.Eras.Era_Run3_2023_UPC_cff import Run3_2023_UPC
+from Configuration.Eras.Modifier_run3_upc_2023_cff import run3_upc_2023
 from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
-(run3_egamma_2023 & Run3_2023_UPC).toModify(regressionModifier103XLowPtPho,
+(run3_egamma_2023 & run3_upc_2023).toModify(regressionModifier103XLowPtPho,
     eleRegs = dict(
         ecalOnlyMean = dict(
             rangeMinHighEt = 0.2,

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cff.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cff.py
@@ -42,18 +42,18 @@ from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
 pp_on_PbPb_run3.toModify(HcalTPGCoderULUT, FG_HF_thresholds = [14, 19])
 
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_2023_cff import pp_on_PbPb_run3_2023
-from Configuration.Eras.Era_Run3_2023_UPC_cff import Run3_2023_UPC
-(pp_on_PbPb_run3_2023 | Run3_2023_UPC).toModify(HcalTPGCoderULUT, FG_HF_thresholds = [16, 19])
+from Configuration.Eras.Modifier_run3_upc_2023_cff import run3_upc_2023
+(pp_on_PbPb_run3_2023 | run3_upc_2023).toModify(HcalTPGCoderULUT, FG_HF_thresholds = [16, 19])
 
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_2024_cff import pp_on_PbPb_run3_2024
-from Configuration.Eras.Era_Run3_2024_UPC_cff import Run3_2024_UPC
-(pp_on_PbPb_run3_2024 | Run3_2024_UPC).toModify(HcalTPGCoderULUT, FG_HF_thresholds = [16, 19])
+from Configuration.Eras.Modifier_run3_upc_2024_cff import run3_upc_2024
+(pp_on_PbPb_run3_2024 | run3_upc_2024).toModify(HcalTPGCoderULUT, FG_HF_thresholds = [16, 19])
 
 #placedholder values for 2025, copied from 2024
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_2025_cff import pp_on_PbPb_run3_2025
 from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
-from Configuration.Eras.Era_Run3_2025_UPC_cff import Run3_2025_UPC
-(pp_on_PbPb_run3_2025 | run3_oxygen | Run3_2025_UPC).toModify(HcalTPGCoderULUT, FG_HF_thresholds = [14, 16])
+from Configuration.Eras.Modifier_run3_upc_2025_cff import run3_upc_2025
+(pp_on_PbPb_run3_2025 | run3_oxygen | run3_upc_2025).toModify(HcalTPGCoderULUT, FG_HF_thresholds = [14, 16])
 #add NeNe configuration
 from Configuration.Eras.Modifier_run3_neon_cff import run3_neon
 (run3_neon).toModify(HcalTPGCoderULUT, FG_HF_thresholds = [14, 12])


### PR DESCRIPTION
#### PR description:

This PR replaces the use of the Era with its corresponding era modifier when modifying settings.
Addresses issue https://github.com/cms-sw/cmssw/issues/48622

#### PR validation:

Tested with workflows 180,180.1,181,181.1,182,182.1,141.901,141.902,142.901,142.902,143.901,143.902

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
