### PR TITLE
Cache EDGetToken in InputTag

### DIFF
--- a/CalibTracker/SiStripCommon/plugins/ShallowDigisProducer.h
+++ b/CalibTracker/SiStripCommon/plugins/ShallowDigisProducer.h
@@ -3,9 +3,12 @@
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "CondFormats/DataRecord/interface/SiStripNoisesRcd.h"
 #include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
 
 class ShallowDigisProducer : public edm::stream::EDProducer<> {
 public:
@@ -13,11 +16,11 @@ public:
 
 private:
   struct products {
-    std::unique_ptr<std::vector<unsigned> > id;
-    std::unique_ptr<std::vector<unsigned> > subdet;
-    std::unique_ptr<std::vector<unsigned> > strip;
-    std::unique_ptr<std::vector<unsigned> > adc;
-    std::unique_ptr<std::vector<float> > noise;
+    std::unique_ptr<std::vector<unsigned>> id;
+    std::unique_ptr<std::vector<unsigned>> subdet;
+    std::unique_ptr<std::vector<unsigned>> strip;
+    std::unique_ptr<std::vector<unsigned>> adc;
+    std::unique_ptr<std::vector<float>> noise;
     products()
         : id(new std::vector<unsigned>()),
           subdet(new std::vector<unsigned>()),
@@ -25,12 +28,13 @@ private:
           adc(new std::vector<unsigned>()),
           noise(new std::vector<float>()) {}
   };
-  std::vector<edm::InputTag> inputTags;
+  std::vector<edm::EDGetTokenT<edm::DetSetVector<SiStripDigi>>> oldTokens_;
+  std::vector<edm::EDGetTokenT<edmNew::DetSetVector<SiStripDigi>>> newTokens_;
   edm::ESGetToken<SiStripNoises, SiStripNoisesRcd> noisesToken_;
 
   void produce(edm::Event &, const edm::EventSetup &) override;
   template <class T>
-  bool findInput(edm::Handle<T> &, const edm::Event &);
+  bool findInput(edm::Handle<T> &, std::vector<edm::EDGetTokenT<T>> const &, const edm::Event &);
   template <class T>
   void recordDigis(const T &, products &, const SiStripNoises &noises);
   void insert(products &, edm::Event &);

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
@@ -67,7 +67,8 @@ namespace SingleTopTChannelLepton {
       }
 
       if (elecExtras.existsAs<std::string>("rho")) {
-        rhoTag = elecExtras.getParameter<edm::InputTag>("rho");
+        auto rhoTag = elecExtras.getParameter<edm::InputTag>("rho");
+        rhoToken_ = iC.consumes(rhoTag);
       }
       // electronId is optional; in case it's not found the
       // InputTag will remain empty
@@ -356,7 +357,9 @@ namespace SingleTopTChannelLepton {
     edm::Handle<edm::View<reco::GsfElectron>> elecs;
     reco::GsfElectron e;
     edm::Handle<double> _rhoHandle;
-    event.getByLabel(rhoTag, _rhoHandle);
+    if (!rhoToken_.isUninitialized()) {
+      _rhoHandle = event.getHandle(rhoToken_);
+    }
     if (!event.getByToken(elecs_, elecs))
       return;
 

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM.h
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM.h
@@ -150,7 +150,7 @@ namespace SingleTopTChannelLepton {
     std::string elecIso_;
     /// extra selection on electrons
     std::unique_ptr<StringCutObjectSelector<reco::GsfElectron>> elecSelect_;
-    edm::InputTag rhoTag;
+    edm::EDGetTokenT<double> rhoToken_;
 
     /// extra selection on primary vertices; meant to investigate the pile-up
     /// effect

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
@@ -69,7 +69,8 @@ namespace SingleTopTChannelLepton_miniAOD {
       }
 
       if (elecExtras.existsAs<std::string>("rho")) {
-        rhoTag = elecExtras.getParameter<edm::InputTag>("rho");
+        auto rhoTag = elecExtras.getParameter<edm::InputTag>("rho");
+        rhoToken_ = iC.consumes(rhoTag);
       }
       // electronId is optional; in case it's not found the
       // InputTag will remain empty
@@ -416,8 +417,9 @@ namespace SingleTopTChannelLepton_miniAOD {
       return;
 
     edm::Handle<double> _rhoHandle;
-    event.getByLabel(rhoTag, _rhoHandle);
-    //if (!event.getByToken(elecs_, elecs)) return;
+    if (!rhoToken_.isUninitialized()) {
+      _rhoHandle = event.getHandle(rhoToken_);
+    }
 
     // check availability of electron id
     edm::Handle<edm::ValueMap<float>> electronId;

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.h
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.h
@@ -94,7 +94,7 @@ namespace SingleTopTChannelLepton_miniAOD {
     /// to be of form signalPath:MonitorPath
     std::vector<std::string> triggerPaths_;
 
-    edm::InputTag rhoTag;
+    edm::EDGetTokenT<double> rhoToken_;
 
     /// electronId label
     edm::EDGetTokenT<edm::ValueMap<float> > electronId_;

--- a/DQM/Physics/src/TopSingleLeptonDQM.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM.cc
@@ -61,7 +61,8 @@ namespace TopSingleLepton {
       }
 
       if (elecExtras.existsAs<std::string>("rho")) {
-        rhoTag = elecExtras.getParameter<edm::InputTag>("rho");
+        auto rhoTag = elecExtras.getParameter<edm::InputTag>("rho");
+        rhoToken_ = iC.consumes(rhoTag);
       }
       // electronId is optional; in case it's not found the
       // InputTag will remain empty
@@ -371,8 +372,6 @@ namespace TopSingleLepton {
 
     // fill monitoring plots for electrons
     edm::Handle<edm::View<reco::GsfElectron>> elecs;
-    edm::Handle<double> _rhoHandle;
-    event.getByLabel(rhoTag, _rhoHandle);
     if (!event.getByToken(elecs_, elecs))
       return;
 
@@ -382,6 +381,10 @@ namespace TopSingleLepton {
       if (!event.getByToken(electronId_, electronId)) {
         return;
       }
+    }
+    edm::Handle<double> _rhoHandle;
+    if (!rhoToken_.isUninitialized()) {
+      _rhoHandle = event.getHandle(rhoToken_);
     }
     // loop electron collection
     unsigned int eMult = 0, eMultIso = 0;

--- a/DQM/Physics/src/TopSingleLeptonDQM.h
+++ b/DQM/Physics/src/TopSingleLeptonDQM.h
@@ -137,7 +137,7 @@ namespace TopSingleLepton {
     double eidCutValue_;
     // electron ISO things
 
-    edm::InputTag rhoTag;
+    edm::EDGetTokenT<double> rhoToken_;
 
     /// extra selection on electrons
 

--- a/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
@@ -70,7 +70,8 @@ namespace TopSingleLepton_miniAOD {
       }
 
       if (elecExtras.existsAs<std::string>("rho")) {
-        rhoTag = elecExtras.getParameter<edm::InputTag>("rho");
+        auto rhoTag = elecExtras.getParameter<edm::InputTag>("rho");
+        rhoToken_ = iC.consumes(rhoTag);
       }
       // electronId is optional; in case it's not found the
       // InputTag will remain empty
@@ -406,8 +407,9 @@ namespace TopSingleLepton_miniAOD {
       return;
 
     edm::Handle<double> _rhoHandle;
-    event.getByLabel(rhoTag, _rhoHandle);
-    //if (!event.getByToken(elecs_, elecs)) return;
+    if (!rhoToken_.isUninitialized()) {
+      _rhoHandle = event.getHandle(rhoToken_);
+    }
 
     // check availability of electron id
     edm::Handle<edm::ValueMap<float>> electronId;

--- a/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.h
+++ b/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.h
@@ -94,7 +94,7 @@ namespace TopSingleLepton_miniAOD {
     /// to be of form signalPath:MonitorPath
     std::vector<std::string> triggerPaths_;
 
-    edm::InputTag rhoTag;
+    edm::EDGetTokenT<double> rhoToken_;
 
     /// electronId label
     edm::EDGetTokenT<edm::ValueMap<float> > electronId_;

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -90,6 +90,15 @@ namespace edm {
     // ---------- const member functions ---------------------
     ProductResolverIndexAndSkipBit indexFrom(EDGetToken, BranchType, TypeID const&) const;
     ProductResolverIndexAndSkipBit uncheckedIndexFrom(EDGetToken) const;
+    /**returns edm::ProductResolverIndexInvalid if type and branch do not match the index
+     this can happen if the same InputTag is used for different products */
+    ProductResolverIndexAndSkipBit indexFromIfExactMatch(EDGetToken, BranchType, TypeID const&) const;
+    EDGetToken getRegisteredToken(TypeID const& typeID,
+                                  std::string const& label,
+                                  std::string const& instance,
+                                  std::string const& processName,
+                                  BranchType branchType,
+                                  bool skipCurrentProcess) const;
 
     void itemsToGet(BranchType, std::vector<ProductResolverIndexAndSkipBit>&) const;
     void itemsMayGet(BranchType, std::vector<ProductResolverIndexAndSkipBit>&) const;

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -107,6 +107,7 @@ edm::Ref<AppleCollection> ref(refApples, index);
 #include "FWCore/Utilities/interface/ProductLabels.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/Utilities/interface/Transition.h"
+#include "FWCore/Utilities/interface/ProductResolverIndex.h"
 
 namespace edm {
 

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -402,8 +402,7 @@ void EDConsumerBase::throwBadToken(edm::TypeID const& iType, EDGetToken iToken) 
       << "A get using a EDGetToken with the C++ type '" << iType.className() << "' was made using a token with a value "
       << iToken.index()
       << " which is beyond the range used by this module.\n Please check that the variable is being initialized from "
-         "a "
-         "'consumes' call from this module.\n You can not share EDGetToken values between modules.";
+         "a 'consumes' call from this module.\n You can not share EDGetToken values between modules.";
 }
 
 void EDConsumerBase::throwConsumesCallAfterFrozen(TypeToGet const& typeToGet, InputTag const& inputTag) const {

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -450,8 +450,27 @@ namespace edm {
                                                    ModuleCallingContext const* mcc) const {
     bool skipCurrentProcess = inputTag.willSkipCurrentProcess();
 
-    ProductResolverIndex index = inputTag.indexFor(typeID, branchType(), &productRegistry());
+    auto token = inputTag.cachedToken();
 
+    if (token.isUninitialized() and consumer) {
+      std::string const* processName = &inputTag.process();
+      if (inputTag.process() == InputTag::kCurrentProcess) {
+        processName = &processConfiguration_->processName();
+      }
+      token = consumer->getRegisteredToken(
+          typeID, inputTag.label(), inputTag.instance(), *processName, branchType(), skipCurrentProcess);
+      if (token.isUninitialized()) {
+        failedToRegisterConsumes(kindOfType,
+                                 typeID,
+                                 inputTag.label(),
+                                 inputTag.instance(),
+                                 appendCurrentProcessIfAlias(inputTag.process(), processConfiguration_->processName()));
+      }
+      inputTag.cacheToken(token);
+    }
+    //check that the InputTag is not being used for a different type/Principal than the first call
+    auto index = consumer ? consumer->indexFromIfExactMatch(token, branchType(), typeID).productResolverIndex()
+                          : ProductResolverIndexInvalid;
     if (index == ProductResolverIndexInvalid) {
       char const* processName = inputTag.process().c_str();
       if (skipCurrentProcess) {
@@ -459,7 +478,6 @@ namespace edm {
       } else if (inputTag.process() == InputTag::kCurrentProcess) {
         processName = processConfiguration_->processName().c_str();
       }
-
       index =
           productLookup().index(kindOfType, typeID, inputTag.label().c_str(), inputTag.instance().c_str(), processName);
 
@@ -490,14 +508,6 @@ namespace edm {
         }
         return nullptr;
       }
-      inputTag.tryToCacheIndex(index, typeID, branchType(), &productRegistry());
-    }
-    if (UNLIKELY(consumer and (not consumer->registeredToConsume(index, skipCurrentProcess, branchType())))) {
-      failedToRegisterConsumes(kindOfType,
-                               typeID,
-                               inputTag.label(),
-                               inputTag.instance(),
-                               appendCurrentProcessIfAlias(inputTag.process(), processConfiguration_->processName()));
     }
 
     auto const& productResolver = productResolvers_[index];

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -452,6 +452,8 @@ namespace edm {
 
     auto token = inputTag.cachedToken();
 
+    // a null consumer can happen for tests and RandomNumberGeneratorService which calls getByLabel
+    // without setting a EDConsumerBase
     if (token.isUninitialized() and consumer) {
       std::string const* processName = &inputTag.process();
       if (inputTag.process() == InputTag::kCurrentProcess) {

--- a/FWCore/Utilities/interface/InputTag.h
+++ b/FWCore/Utilities/interface/InputTag.h
@@ -5,10 +5,7 @@
 #include <iosfwd>
 #include <string>
 
-#include "FWCore/Utilities/interface/TypeID.h"
-#include "FWCore/Utilities/interface/BranchType.h"
-#include "FWCore/Utilities/interface/ProductResolverIndex.h"
-#include "FWCore/Utilities/interface/thread_safety_macros.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 namespace edm {
 
@@ -43,12 +40,9 @@ namespace edm {
 
     bool operator==(InputTag const& tag) const;
 
-    ProductResolverIndex indexFor(TypeID const& typeID, BranchType branchType, void const* productRegistry) const;
+    EDGetToken cachedToken() const { return token_; }
 
-    void tryToCacheIndex(ProductResolverIndex index,
-                         TypeID const& typeID,
-                         BranchType branchType,
-                         void const* productRegistry) const;
+    void cacheToken(EDGetToken) const;
 
     static const std::string kSkipCurrentProcess;
     static const std::string kCurrentProcess;
@@ -60,12 +54,7 @@ namespace edm {
     std::string instance_;
     std::string process_;
 
-    CMS_THREAD_GUARD(index_) mutable TypeID typeID_;
-    CMS_THREAD_GUARD(index_) mutable void const* productRegistry_;
-
-    mutable std::atomic<unsigned int> index_;
-
-    CMS_THREAD_GUARD(index_) mutable char branchType_;
+    mutable std::atomic<EDGetToken> token_;
 
     bool skipCurrentProcess_;
   };

--- a/FWCore/Utilities/src/InputTag.cc
+++ b/FWCore/Utilities/src/InputTag.cc
@@ -8,45 +8,23 @@ namespace edm {
   const std::string InputTag::kCurrentProcess("@currentProcess");
   static std::string const separator(":");
 
-  InputTag::InputTag()
-      : label_(),
-        instance_(),
-        process_(),
-        typeID_(),
-        productRegistry_(nullptr),
-        index_(ProductResolverIndexInvalid),
-        branchType_(NumBranchTypes),
-        skipCurrentProcess_(false) {}
+  InputTag::InputTag() : label_(), instance_(), process_(), token_(), skipCurrentProcess_(false) {}
 
   InputTag::InputTag(std::string const& label, std::string const& instance, std::string const& processName)
       : label_(label),
         instance_(instance),
         process_(processName),
-        typeID_(),
-        productRegistry_(nullptr),
-        index_(ProductResolverIndexInvalid),
-        branchType_(NumBranchTypes),
+        token_(),
         skipCurrentProcess_(calcSkipCurrentProcess()) {}
 
   InputTag::InputTag(char const* label, char const* instance, char const* processName)
       : label_(label),
         instance_(instance),
         process_(processName),
-        typeID_(),
-        productRegistry_(nullptr),
-        index_(ProductResolverIndexInvalid),
-        branchType_(NumBranchTypes),
+        token_(),
         skipCurrentProcess_(calcSkipCurrentProcess()) {}
 
-  InputTag::InputTag(std::string const& s)
-      : label_(),
-        instance_(),
-        process_(),
-        typeID_(),
-        productRegistry_(nullptr),
-        index_(ProductResolverIndexInvalid),
-        branchType_(NumBranchTypes),
-        skipCurrentProcess_(false) {
+  InputTag::InputTag(std::string const& s) : label_(), instance_(), process_(), token_(), skipCurrentProcess_(false) {
     // string is delimited by colons
     std::vector<std::string> tokens = tokenize(s, separator);
     size_t nwords = tokens.size();
@@ -68,37 +46,15 @@ namespace edm {
       : label_(other.label()),
         instance_(other.instance()),
         process_(other.process()),
-        typeID_(),
-        productRegistry_(nullptr),
-        index_(ProductResolverIndexInvalid),
-        branchType_(NumBranchTypes),
-        skipCurrentProcess_(other.willSkipCurrentProcess()) {
-    ProductResolverIndex otherIndex = other.index_.load();
-    if (otherIndex < ProductResolverIndexInitializing) {
-      branchType_ = other.branchType_;
-      typeID_ = other.typeID_;
-      productRegistry_ = other.productRegistry_;
-      index_.store(otherIndex);
-    }
-  }
+        token_(other.token_.load()),
+        skipCurrentProcess_(other.willSkipCurrentProcess()) {}
 
   InputTag::InputTag(InputTag&& other)
       : label_(std::move(other.label_)),
         instance_(std::move(other.instance_)),
         process_(std::move(other.process_)),
-        typeID_(),
-        productRegistry_(nullptr),
-        index_(ProductResolverIndexInvalid),
-        branchType_(NumBranchTypes),
-        skipCurrentProcess_(other.willSkipCurrentProcess()) {
-    ProductResolverIndex otherIndex = other.index_.load();
-    if (otherIndex < ProductResolverIndexInitializing) {
-      branchType_ = other.branchType_;
-      typeID_ = other.typeID_;
-      productRegistry_ = other.productRegistry_;
-      index_.store(otherIndex);
-    }
-  }
+        token_(other.token_.load()),
+        skipCurrentProcess_(other.willSkipCurrentProcess()) {}
 
   InputTag& InputTag::operator=(InputTag const& other) {
     if (this != &other) {
@@ -106,19 +62,7 @@ namespace edm {
       instance_ = other.instance_;
       process_ = other.process_;
       skipCurrentProcess_ = other.skipCurrentProcess_;
-
-      ProductResolverIndex otherIndex = other.index_.load();
-      if (otherIndex < ProductResolverIndexInitializing) {
-        branchType_ = other.branchType_;
-        typeID_ = other.typeID_;
-        productRegistry_ = other.productRegistry_;
-        index_.store(otherIndex);
-      } else {
-        branchType_ = NumBranchTypes;
-        typeID_ = TypeID();
-        productRegistry_ = nullptr;
-        index_.store(ProductResolverIndexInvalid);
-      }
+      token_.store(other.token_.load());
     }
     return *this;
   }
@@ -129,19 +73,7 @@ namespace edm {
       instance_ = std::move(other.instance_);
       process_ = std::move(other.process_);
       skipCurrentProcess_ = other.skipCurrentProcess_;
-
-      ProductResolverIndex otherIndex = other.index_.load();
-      if (otherIndex < ProductResolverIndexInitializing) {
-        branchType_ = other.branchType_;
-        typeID_ = other.typeID_;
-        productRegistry_ = other.productRegistry_;
-        index_.store(otherIndex);
-      } else {
-        branchType_ = NumBranchTypes;
-        typeID_ = TypeID();
-        productRegistry_ = nullptr;
-        index_.store(ProductResolverIndexInvalid);
-      }
+      token_.store(other.token_.load());
     }
     return *this;
   }
@@ -174,30 +106,7 @@ namespace edm {
     return (label_ == tag.label_) && (instance_ == tag.instance_) && (process_ == tag.process_);
   }
 
-  ProductResolverIndex InputTag::indexFor(TypeID const& typeID,
-                                          BranchType branchType,
-                                          void const* productRegistry) const {
-    ProductResolverIndex index = index_.load();
-
-    if (index < ProductResolverIndexInitializing && typeID_ == typeID && branchType_ == branchType &&
-        productRegistry_ == productRegistry) {
-      return index;
-    }
-    return ProductResolverIndexInvalid;
-  }
-
-  void InputTag::tryToCacheIndex(ProductResolverIndex index,
-                                 TypeID const& typeID,
-                                 BranchType branchType,
-                                 void const* productRegistry) const {
-    unsigned int invalidValue = static_cast<unsigned int>(ProductResolverIndexInvalid);
-    if (index_.compare_exchange_strong(invalidValue, static_cast<unsigned int>(ProductResolverIndexInitializing))) {
-      typeID_ = typeID;
-      branchType_ = branchType;
-      productRegistry_ = productRegistry;
-      index_.store(index);
-    }
-  }
+  void InputTag::cacheToken(EDGetToken token) const { token_.store(token); }
 
   std::ostream& operator<<(std::ostream& ost, InputTag const& tag) {
     static std::string const process(", process = ");

--- a/FWCore/Utilities/test/InputTag_t.cpp
+++ b/FWCore/Utilities/test/InputTag_t.cpp
@@ -10,21 +10,15 @@
 #include <string>
 
 namespace edm {
-  class ProductRegistry;
-}
+  class TestEDGetToken {
+  public:
+    static EDGetToken makeEDGetToken(unsigned int iValue) { return EDGetToken(iValue); }
+  };
+
+}  // namespace edm
 
 // This is just for the test. Do not dereference the pointers.
 // They points to nothing legal.
-edm::ProductRegistry* reg1 = reinterpret_cast<edm::ProductRegistry*>(1);
-edm::ProductRegistry* reg2 = reinterpret_cast<edm::ProductRegistry*>(2);
-
-class TypeToTestInputTag1 {};
-class TypeToTestInputTag2 {};
-TypeToTestInputTag1 typeToTestInputTag1;
-TypeToTestInputTag2 typeToTestInputTag2;
-
-edm::TypeID testTypeID1(typeToTestInputTag1);
-edm::TypeID testTypeID2(typeToTestInputTag2);
 
 class InputTagModifier {
   edm::InputTag* inputTag;
@@ -35,20 +29,20 @@ public:
   void operator()(oneapi::tbb::blocked_range<int> const& r) const {
     for (int i = r.begin(); i != r.end(); i++) {
       for (unsigned int j = 0; j < 10000; ++j) {
-        unsigned int index = inputTag->indexFor(testTypeID1, edm::InRun, reg1);
-        if (index != 5 && index != edm::ProductResolverIndexInvalid)
+        unsigned int index = inputTag->cachedToken().index();
+        if (index != 5 && index != edm::EDGetToken().index())
           abort();
         // std::cout << "a\n";
       }
       for (unsigned int j = 0; j < 100; ++j) {
-        inputTag->tryToCacheIndex(5, testTypeID1, edm::InRun, reg1);
+        inputTag->cacheToken(edm::TestEDGetToken::makeEDGetToken(5));
         // std::cout << "b\n";
       }
       for (unsigned int j = 0; j < 1000; ++j) {
-        unsigned int index = inputTag->indexFor(testTypeID1, edm::InRun, reg1);
+        unsigned int index = inputTag->cachedToken().index();
         // if (index != 5) abort(); // This can fail!
         // std::cout << index << " c\n";
-        if (index != 5 && index != edm::ProductResolverIndexInvalid)
+        if (index != 5 && index != edm::EDGetToken().index())
           abort();
       }
     }

--- a/FWCore/Utilities/test/test_catch2_InputTag.cc
+++ b/FWCore/Utilities/test/test_catch2_InputTag.cc
@@ -8,7 +8,12 @@
 
 namespace edm {
   class ProductRegistry;
-}
+
+  class TestEDGetToken {
+  public:
+    static EDGetToken makeEDGetToken(unsigned int iValue) { return EDGetToken(iValue); }
+  };
+}  // namespace edm
 
 namespace {
   class TypeToTestInputTag1 {};
@@ -161,25 +166,15 @@ TEST_CASE("test edm::InputTag", "[InputTag]") {
       REQUIRE(not tag15.willSkipCurrentProcess());
     }
   }
-  SECTION("indexFor") {
-    // This is just for the test. Do not dereference the pointers.
-    // They points to nothing legal.
-    edm::ProductRegistry* reg1 = reinterpret_cast<edm::ProductRegistry*>(1);
-    edm::ProductRegistry* reg2 = reinterpret_cast<edm::ProductRegistry*>(2);
-
+  SECTION("cachedToken") {
     edm::InputTag tag5("g:h");
 
-    unsigned int index = tag5.indexFor(testTypeID1, edm::InRun, reg1);
-    REQUIRE(index == edm::ProductResolverIndexInvalid);
+    auto token = tag5.cachedToken();
+    REQUIRE(token.index() == edm::EDGetToken().index());
 
-    tag5.tryToCacheIndex(5, testTypeID1, edm::InRun, reg1);
-    tag5.tryToCacheIndex(6, testTypeID1, edm::InRun, reg1);
-
-    index = tag5.indexFor(testTypeID1, edm::InRun, reg1);
-    REQUIRE(index == 5);
-
-    REQUIRE(tag5.indexFor(testTypeID1, edm::InLumi, reg1) == edm::ProductResolverIndexInvalid);
-    REQUIRE(tag5.indexFor(testTypeID1, edm::InRun, reg2) == edm::ProductResolverIndexInvalid);
-    REQUIRE(tag5.indexFor(testTypeID2, edm::InRun, reg1) == edm::ProductResolverIndexInvalid);
+    tag5.cacheToken(edm::TestEDGetToken::makeEDGetToken(5));
+    REQUIRE(tag5.cachedToken().index() == 5);
+    tag5.cacheToken(edm::TestEDGetToken::makeEDGetToken(6));
+    REQUIRE(tag5.cachedToken().index() == 6);
   }
 }


### PR DESCRIPTION
#### PR description:

Formerly, the InputTag cached the ProductResolverIndex along with all quantities to double check the cached item was being used (in case the same InputTag is being used to retrieve multiple related data products). Now the code caches a EDGetToken and uses the information already available in the EDConsumerBase to verify the correctness of the cached value for the request.

#### PR validation:

All framework unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/1502