### PR TITLE
Update of strip overlap check for different product ID

### DIFF
--- a/DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h
+++ b/DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h
@@ -70,11 +70,14 @@ public:
       return false;
     const auto& tc = stripCluster();
     const uint16_t tf = tc.firstStrip();
-    const uint16_t tl = tf + tc.amplitudes().size();
+    const uint16_t tl = tf + tc.amplitudes().size() - 1;
     const auto& oc = lh.stripCluster();
     const uint16_t of = oc.firstStrip();
-    const uint16_t ol = of + oc.amplitudes().size();
+    const uint16_t ol = of + oc.amplitudes().size() - 1;
     // By default, include edge overlaps
+    // For single-strip clusters with non-matching edges, edge overlaps are excluded
+    if (((tl - tf) <= 1 || (ol - of) <= 1) && (tf != of || tl != ol))
+      includeEdges = false;
     const auto e = includeEdges ? 1 : 0;
     // Check that last strip of "other" cluster is within first and last strip of "this", or viceversa
     // Edge strips are considered for determining overlap (e=1) if includeEdges = true (default)

--- a/DataFormats/TrackerRecHit2D/interface/TrackerSingleRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/TrackerSingleRecHit.h
@@ -69,11 +69,10 @@ public:
   bool sharesInput(const TrackingRecHit* other, SharedInputType what) const final;
 
   bool sharesInput(TrackerSingleRecHit const& other) const {
-    //auto const& otherClus = reinterpret_cast<const BaseTrackerRecHit*>(other)->firstClusterRef();
     if (cluster_.id() == other.cluster_.id())
       return (cluster_ == other.cluster_);
     else {
-      const bool sameDetId = (geographicalId() == other.geographicalId());
+      const bool sameDetId = sameDetModule(other);
       return (sameDetId) ? other.cluster_.stripOverlap(cluster_) : false;
     }
   }

--- a/DataFormats/TrackerRecHit2D/interface/TrackerSingleRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/TrackerSingleRecHit.h
@@ -72,7 +72,7 @@ public:
     if (cluster_.id() == other.cluster_.id())
       return (cluster_ == other.cluster_);
     else {
-      const bool sameDetId = sameDetModule(other);
+      const bool sameDetId = (geographicalId() == other.geographicalId());
       return (sameDetId) ? other.cluster_.stripOverlap(cluster_) : false;
     }
   }

--- a/DataFormats/TrackerRecHit2D/src/SiStripMatchedRecHit2D.cc
+++ b/DataFormats/TrackerRecHit2D/src/SiStripMatchedRecHit2D.cc
@@ -22,7 +22,7 @@ bool SiStripMatchedRecHit2D::sharesInput(const TrackingRecHit* other, SharedInpu
   if (monoClusterRef().id() == otherClus.id() || stereoClusterRef().id() == otherClus.id())
     return (otherClus == stereoClusterRef()) || (otherClus == monoClusterRef());
   else {
-    const bool sameDetId = (geographicalId() == other->geographicalId());
+    const bool sameDetId = sameDetModule(*other);
     bool stereoOverlap = (sameDetId) ? otherClus.stripOverlap(stereoClusterRef()) : false;
     bool monoOverlap = (sameDetId) ? otherClus.stripOverlap(monoClusterRef()) : false;
     return (stereoOverlap || monoOverlap);
@@ -34,7 +34,7 @@ bool SiStripMatchedRecHit2D::sharesInput(TrackerSingleRecHit const& other) const
   if (monoClusterRef().id() == otherClus.id() || stereoClusterRef().id() == otherClus.id())
     return (otherClus == stereoClusterRef()) || (otherClus == monoClusterRef());
   else {
-    const bool sameDetId = (geographicalId() == other.geographicalId());
+    const bool sameDetId = sameDetModule(other);
     bool stereoOverlap = (sameDetId) ? otherClus.stripOverlap(stereoClusterRef()) : false;
     bool monoOverlap = (sameDetId) ? otherClus.stripOverlap(monoClusterRef()) : false;
     return (stereoOverlap || monoOverlap);

--- a/DataFormats/TrackerRecHit2D/src/SiStripMatchedRecHit2D.cc
+++ b/DataFormats/TrackerRecHit2D/src/SiStripMatchedRecHit2D.cc
@@ -22,9 +22,8 @@ bool SiStripMatchedRecHit2D::sharesInput(const TrackingRecHit* other, SharedInpu
   if (monoClusterRef().id() == otherClus.id() || stereoClusterRef().id() == otherClus.id())
     return (otherClus == stereoClusterRef()) || (otherClus == monoClusterRef());
   else {
-    const bool sameDetId = sameDetModule(*other);
-    bool stereoOverlap = (sameDetId) ? otherClus.stripOverlap(stereoClusterRef()) : false;
-    bool monoOverlap = (sameDetId) ? otherClus.stripOverlap(monoClusterRef()) : false;
+    bool stereoOverlap = otherClus.stripOverlap(stereoClusterRef());
+    bool monoOverlap = otherClus.stripOverlap(monoClusterRef());
     return (stereoOverlap || monoOverlap);
   }
 }

--- a/DataFormats/TrackerRecHit2D/src/VectorHit.cc
+++ b/DataFormats/TrackerRecHit2D/src/VectorHit.cc
@@ -76,12 +76,8 @@ bool VectorHit::sharesInput(const TrackingRecHit* other, SharedInputType what) c
   if (lowerClusterRef().id() == otherClus.id() || upperClusterRef().id() == otherClus.id())
     return (otherClus == lowerClusterRef()) || (otherClus == upperClusterRef());
   else {
-    bool lowerOverlap = false;
-    bool upperOverlap = false;
-    if (sameDetModule(*other)) {
-      lowerOverlap = otherClus.stripOverlap(lowerClusterRef());
-      upperOverlap = otherClus.stripOverlap(upperClusterRef());
-    }
+    bool lowerOverlap = otherClus.stripOverlap(lowerClusterRef());
+    bool upperOverlap = otherClus.stripOverlap(upperClusterRef());
     return (lowerOverlap || upperOverlap);
   }
 }

--- a/DataFormats/TrackerRecHit2D/src/VectorHit.cc
+++ b/DataFormats/TrackerRecHit2D/src/VectorHit.cc
@@ -78,7 +78,7 @@ bool VectorHit::sharesInput(const TrackingRecHit* other, SharedInputType what) c
   else {
     bool lowerOverlap = false;
     bool upperOverlap = false;
-    if (geographicalId() == other->geographicalId()) {
+    if (sameDetModule(*other)) {
       lowerOverlap = otherClus.stripOverlap(lowerClusterRef());
       upperOverlap = otherClus.stripOverlap(upperClusterRef());
     }
@@ -93,7 +93,7 @@ bool VectorHit::sharesClusters(VectorHit const& other, SharedInputType what) con
     const bool upperIdentity = this->upperClusterRef() == other.upperClusterRef();
     return (what == TrackingRecHit::all) ? (lowerIdentity && upperIdentity) : (lowerIdentity || upperIdentity);
   } else {
-    const bool sameDetId = (geographicalId() == other.geographicalId());
+    const bool sameDetId = sameDetModule(other);
     bool lowerOverlap = (sameDetId) ? other.lowerClusterRef().stripOverlap(this->lowerClusterRef()) : false;
     bool upperOverlap = (sameDetId) ? other.upperClusterRef().stripOverlap(this->upperClusterRef()) : false;
     return (what == TrackingRecHit::all) ? (lowerOverlap && upperOverlap) : (lowerOverlap || upperOverlap);


### PR DESCRIPTION
### PR description:

As follow-up to to [HLT JIRA 3534](https://its.cern.ch/jira/browse/CMSHLT-3534), PR https://github.com/cms-sw/cmssw/pull/48403 (and specifically to https://github.com/cms-sw/cmssw/pull/48403/#discussion_r2255199103, by @slava77), this PR aims at using `sameDetModule` in place of `geographicalId` to better deal with 2D hits, to ensure that the overlap check introduced in PR #48403 is closer to the identity-based method used for strips with the same product ID (impact was estimated ~1e-5 in [HLT JIRA 3534](https://its.cern.ch/jira/browse/CMSHLT-3534)).

#### PR validation:

This was checked with https://github.com/missirol/hltScripts/blob/a89bc26a7d18c6e8f8582878ef489883cf84bd7a/hltTests/testCMSHLT3534.sh provided by @missirol

After the change, the number of hltPFMuonMerging tracks found in this event is indeed identical (111).

A backport to 150X will follow.

FYI: @missirol, @slava77, @cms-sw/tracking-pog-l2  