### PR TITLE
Remove Run2 procModifier from Run3 ReMINI relval workflows and fix BTV MINIAOD DQM

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4516,7 +4516,7 @@ steps['REMININANO_data2022'] = merge([{'-s' : 'PAT,NANO,DQM:@nanoAODDQM',
                                        '--datatier' : 'MINIAOD,NANOAOD,DQMIO'
                                        }])
 # reMINI 2024
-steps['REMINIAOD_data2024'] = merge([{'--era' : 'Run3_2024', '--conditions' : 'auto:run3_data'}, steps['REMINIAOD_data2018UL']])
+steps['REMINIAOD_data2024'] = merge([{'--era' : 'Run3_2024', '--conditions' : 'auto:run3_data'}, remove(steps['REMINIAOD_data2018UL'], '--procModifiers')])
 
 
 # Not sure whether the customisations are in the dict as "--customise" or "--era" so try to
@@ -4549,7 +4549,7 @@ steps['REMINIAOD_mc2016UL_postVFP']=merge([{'--conditions':'auto:run2_mc','--era
 steps['REMINIAOD_mc2017UL']=merge([{'--era':'Run2_2017','--procModifiers':'run2_miniAOD_UL_preSummer20'},steps['REMINIAOD_mc2017']])
 steps['REMINIAOD_mc2018UL']=merge([{'--conditions':'auto:phase1_2018_realistic','--era':'Run2_2018','--procModifiers':'run2_miniAOD_UL_preSummer20'},steps['REMINIAOD_mc2017']])
 # reMINI 2024
-steps['REMINIAOD_mc2024'] = merge([{'--conditions': 'auto:phase1_2024_realistic', '--era': 'Run3'}, steps['REMINIAOD_mc2018UL']])
+steps['REMINIAOD_mc2024'] = merge([{'--conditions': 'auto:phase1_2024_realistic', '--era': 'Run3'}, remove(steps['REMINIAOD_mc2018UL'], '--procModifiers')])
 
 #steps['MINIAODDATA']       =merge([stepMiniAODData])
 #steps['MINIAODDreHLT']     =merge([{'--conditions':'auto:run1_data_%s'%menu},stepMiniAODData])

--- a/DQMOffline/RecoB/python/bTagMiniDQM_cff.py
+++ b/DQMOffline/RecoB/python/bTagMiniDQM_cff.py
@@ -62,11 +62,11 @@ Etaregions = {
 
 
 # For DQM
-bTagMiniDQMSource = cms.Sequence(bTagSVDQM, patJetsSVInfoTask)
+bTagMiniDQMSource = cms.Sequence()
 bTagMiniDQMHarvesting = cms.Sequence()
 
 # For Validation
-bTagMiniValidationSource = cms.Sequence(bTagSVDQM, patJetsSVInfoTask)
+bTagMiniValidationSource = cms.Sequence()
 bTagMiniValidationHarvesting = cms.Sequence()
 
 #####################################################################################
@@ -193,18 +193,13 @@ bTagMiniValidationSource += patJetsPuppiForwardTagInfoAnalyzerValidation
 #
 #####################################################################################
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-from Configuration.ProcessModifiers.miniAOD_skip_trackExtras_cff import miniAOD_skip_trackExtras
 
 toExcludeDQMSource_pp_on_AA = [
-    bTagSVDQM,
-    patJetsSVInfoTask,
     patJetsPuppiTagInfoAnalyzerDQM,
     patJetsPuppiForwardTagInfoAnalyzerDQM,
 ]
 
 toExcludeValidationSource_pp_on_AA = [
-    bTagSVDQM,
-    patJetsSVInfoTask,
     patJetsPuppiTagInfoAnalyzerValidation,
     patJetsPuppiTagInfoAnalyzerBJetsValidation,
     patJetsPuppiTagInfoAnalyzerCJetsValidation,
@@ -212,7 +207,7 @@ toExcludeValidationSource_pp_on_AA = [
     patJetsPuppiForwardTagInfoAnalyzerValidation
 ]
 
-_mAOD = (pp_on_AA | miniAOD_skip_trackExtras)
+_mAOD = (pp_on_AA)
 _mAOD.toReplaceWith(bTagMiniDQMSource, bTagMiniDQMSource.copyAndExclude(toExcludeDQMSource_pp_on_AA))
 _mAOD.toReplaceWith(bTagMiniValidationSource, bTagMiniValidationSource.copyAndExclude(toExcludeValidationSource_pp_on_AA))
 


### PR DESCRIPTION
#### PR description:

This PR removes the `run2_miniAOD_UL_preSummer20` procModifier, which leaked into the Run3 ReMINI relval workflows (2500.2601,2500.2701) when cloning the relval steps from Run2_UL configs.

When fixing this, it revealed an outdated configuration in the BTV MINIAOD DQM, which by default includes the `bTagSVDQM` module that relies on `pfSecondaryVertexTagInfos`. However, with the removal of CSVv2 from MINIAOD, the `pfSecondaryVertexTagInfos ` collection is no longer produced in the MINIAOD step, so the `bTagSVDQM ` module  would crash. 

This problem has not been revealed so far because in `bTagMiniDQM_cff.py`, the `miniAOD_skip_trackExtras` (part of `run2_miniAOD_UL_preSummer20`) modifier was used to exclude the `bTagSVDQM` module. However, since the default MINIAOD no longer has `pfSecondaryVertexTagInfos`, the `bTagSVDQM` module should also be removed in the default configuration too. 

#### PR validation:

Tested with `runTheMatrix.py -w nano --ibeos -l 2500.2601,2500.2701`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 150X.