### PR TITLE
Add a relval test for the NGT scouting menu with multiple process modifiers

### DIFF
--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -66,7 +66,9 @@ The offsets currently in use are:
 * 0.758 HLT phase-2 timing menu ticl_barrel variant
 * 0.759: HLT phase-2 timing menu, with NANO:@Phase2HLT
 * 0.77: HLT phase-2 NGT Scouting menu
-* 0.771: HLT phase-2 NGT Scouting menu, with NANO:@NGTScouting
+* 0.771: HLT phase-2 NGT Scouting menu, Alpaka, TICL-v5, TICL-Barrel
+* 0.772: HLT phase-2 NGT Scouting menu, with NANO:@NGTScouting
+* 0.773: HLT phase-2 NGT Scouting menu, with NANO:@NGTScoutingVal
 * 0.778 L3 Tracker Muons reconstruction Outside-In first, HLT Muon NanoAOD
 * 0.78: Complete L1 workflow
 * 0.781: Complete L1 workflow, producing FEVT and NANO output L1/P2GT objects

--- a/Configuration/PyReleaseValidation/python/relval_Run4.py
+++ b/Configuration/PyReleaseValidation/python/relval_Run4.py
@@ -80,8 +80,9 @@ numWFIB.extend([prefixDet+34.757]) # HLTTiming75e33, alpaka,singleIterPatatrack,
 numWFIB.extend([prefixDet+34.758]) # HLTTiming75e33, ticl_barrel
 numWFIB.extend([prefixDet+34.759]) # HLTTiming75e33 + NANO
 numWFIB.extend([prefixDet+34.77])  # NGTScouting
-numWFIB.extend([prefixDet+34.771]) # NGTScouting + NANO
-numWFIB.extend([prefixDet+34.772]) # NGTScouting + NANO (including validation)
+numWFIB.extend([prefixDet+34.771]) # NGTScouting + alpaka + TICL-v5 + TICL-Barrel
+numWFIB.extend([prefixDet+34.772]) # NGTScouting + NANO
+numWFIB.extend([prefixDet+34.773]) # NGTScouting + NANO (including validation)
 
 for numWF in numWFIB:
     workflows[numWF] = _upgrade_workflows[numWF]

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2046,7 +2046,7 @@ upgradeWFs['HLTPhaseWithNano'].step2 = {
 
 upgradeWFs['NGTScoutingWithNano'] = deepcopy(upgradeWFs['HLTPhaseWithNano'])
 upgradeWFs['NGTScoutingWithNano'].suffix = '_NGTScoutingWithNano'
-upgradeWFs['NGTScoutingWithNano'].offset = 0.771
+upgradeWFs['NGTScoutingWithNano'].offset = 0.772
 upgradeWFs['NGTScoutingWithNano'].step2 = {
     '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:NGTScouting,NANO:@NGTScouting',
     '--datatier':'GEN-SIM-DIGI-RAW,NANOAODSIM',
@@ -2056,7 +2056,7 @@ upgradeWFs['NGTScoutingWithNano'].step2 = {
 
 upgradeWFs['NGTScoutingWithNanoValid'] = deepcopy(upgradeWFs['HLTPhaseWithNano'])
 upgradeWFs['NGTScoutingWithNanoValid'].suffix = '_NGTScoutingWithNanoVal'
-upgradeWFs['NGTScoutingWithNanoValid'].offset = 0.772
+upgradeWFs['NGTScoutingWithNanoValid'].offset = 0.773
 upgradeWFs['NGTScoutingWithNanoValid'].step2 = {
     '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:NGTScouting,VALIDATION:@hltValidation,NANO:@NGTScoutingVal',
     '--datatier':'GEN-SIM-DIGI-RAW,NANOAODSIM',
@@ -2124,6 +2124,20 @@ upgradeWFs['NGTScouting'].step2 = {
 }
 upgradeWFs['NGTScouting'].step3 = {
     '--procModifiers': 'ngtScouting',
+    '-s':'HARVESTING:@hltValidation'
+}
+
+upgradeWFs['NGTScoutingAll'] = deepcopy(upgradeWFs['NGTScouting'])
+upgradeWFs['NGTScoutingAll'].suffix = '_NGTScoutingAll'
+upgradeWFs['NGTScoutingAll'].offset = 0.771
+upgradeWFs['NGTScoutingAll'].step2 = {
+    '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:NGTScouting,VALIDATION:@hltValidation',
+    '--procModifiers': 'ngtScouting,alpaka,ticl_v5,ticl_barrel',
+    '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
+    '--eventcontent':'FEVTDEBUGHLT,DQMIO'
+}
+upgradeWFs['NGTScoutingAll'].step3 = {
+    '--procModifiers': 'ngtScouting,alpaka,ticl_v5,ticl_barrel',
     '-s':'HARVESTING:@hltValidation'
 }
 

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -165,8 +165,9 @@ if __name__ == '__main__':
                      29634.758,   # HLT phase-2 timing menu ticl_barrel variant
                      29634.759,   # HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + CKF building variant
                      29634.77,    # HLT phase-2 NGT Scouting menu
-                     29634.771,   # HLT phase-2 NGT Scouting menu, with NANO:@NGTScouting
-                     29634.772]   # HLT phase-2 NGT Scouting menu, with NANO:@NGTScoutingVal
+                     29634.771,   # HLT phase-2 NGT Scouting menu, Alpaka, TICL-v5, TICL-Barrel
+                     29634.772,   # HLT phase-2 NGT Scouting menu, with NANO:@NGTScouting
+                     29634.773]   # HLT phase-2 NGT Scouting menu, with NANO:@NGTScoutingVal
     }
 
     predefinedSet['limited'] = (


### PR DESCRIPTION
#### PR description:

Added a new offset to test multiple process modifiers combined: ```ticl_barrel```, ```ticl_v5```, ```ngtScouting``` and ```alpaka```. All the other configuration options mimic the existing ```.77```.

##### Tests

```runTheMatrix.py -w upgrade --show -e -l 29634.771```
