### PR TITLE
Add dEdx lfit to PbPb eras

### DIFF
--- a/Configuration/Eras/python/Era_Run3_pp_on_PbPb_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_pp_on_PbPb_2025_cff.py
@@ -4,5 +4,6 @@ from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_2024_cff import pp_on_PbPb_run3_2024
+from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
 
-Run3_pp_on_PbPb_2025 = cms.ModifierChain(Run3_2025, pp_on_AA, pp_on_PbPb_run3, pp_on_PbPb_run3_2024)
+Run3_pp_on_PbPb_2025 = cms.ModifierChain(Run3_2025, dedx_lfit, pp_on_AA, pp_on_PbPb_run3, pp_on_PbPb_run3_2024)

--- a/Configuration/Eras/python/Era_Run3_pp_on_PbPb_approxSiStripClusters_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_pp_on_PbPb_approxSiStripClusters_2025_cff.py
@@ -4,5 +4,6 @@ from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA 
 from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
 
-Run3_pp_on_PbPb_approxSiStripClusters_2025 = cms.ModifierChain(Run3_2025, pp_on_AA, approxSiStripClusters, pp_on_PbPb_run3)   
+Run3_pp_on_PbPb_approxSiStripClusters_2025 = cms.ModifierChain(Run3_2025, dedx_lfit, pp_on_AA, approxSiStripClusters, pp_on_PbPb_run3)

--- a/PhysicsTools/PatAlgos/plugins/DeDxEstimatorRekeyer.cc
+++ b/PhysicsTools/PatAlgos/plugins/DeDxEstimatorRekeyer.cc
@@ -29,6 +29,7 @@ private:
 
   // ----------member data ---------------------------
   const edm::EDGetTokenT<reco::TrackCollection> tracksToken_;
+  const bool rekey_dedxHits_;
   const edm::EDGetTokenT<reco::DeDxHitInfoAss> dedxHitAssToken_;
   const edm::EDGetTokenT<edm::ValueMap<std::vector<float>>> dedxHitMomToken_;
   const std::map<std::string, edm::EDGetTokenT<edm::ValueMap<reco::DeDxData>>> dedxEstimatorsTokens_;
@@ -39,8 +40,8 @@ private:
 void DeDxEstimatorRekeyer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("tracks", {"generalTracks"});
-  desc.add<edm::InputTag>("dedxHits", {"dedxHitInfo"});
-  desc.add<edm::InputTag>("dedxMomentum", {"dedxHitInfo:momentumAtHit"});
+  desc.add<edm::InputTag>("dedxHits", {});
+  desc.add<edm::InputTag>("dedxMomentum", {});
   desc.add<std::vector<edm::InputTag>>(
       "packedCandidates",
       {edm::InputTag("packedPFCandidates"), edm::InputTag("lostTracks"), edm::InputTag("lostTracks:eleTracks")});
@@ -51,6 +52,7 @@ void DeDxEstimatorRekeyer::fillDescriptions(edm::ConfigurationDescriptions& desc
 
 DeDxEstimatorRekeyer::DeDxEstimatorRekeyer(const edm::ParameterSet& iConfig)
     : tracksToken_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"))),
+      rekey_dedxHits_(not iConfig.getParameter<edm::InputTag>("dedxHits").label().empty()),
       dedxHitAssToken_(consumes<reco::DeDxHitInfoAss>(iConfig.getParameter<edm::InputTag>("dedxHits"))),
       dedxHitMomToken_(
           consumes<edm::ValueMap<std::vector<float>>>(iConfig.getParameter<edm::InputTag>("dedxMomentum"))),
@@ -62,9 +64,11 @@ DeDxEstimatorRekeyer::DeDxEstimatorRekeyer(const edm::ParameterSet& iConfig)
           iConfig.getParameter<std::vector<edm::InputTag>>("packedCandidates"))) {
   for (const auto& d : dedxEstimatorsTokens_)
     produces<edm::ValueMap<reco::DeDxData>>(d.first);
-  produces<reco::DeDxHitInfoCollection>();
-  produces<reco::DeDxHitInfoAss>();
-  produces<edm::ValueMap<std::vector<float>>>("momentumAtHit");
+  if (rekey_dedxHits_) {
+    produces<reco::DeDxHitInfoCollection>();
+    produces<reco::DeDxHitInfoAss>();
+    produces<edm::ValueMap<std::vector<float>>>("momentumAtHit");
+  }
 }
 
 void DeDxEstimatorRekeyer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
@@ -107,6 +111,8 @@ void DeDxEstimatorRekeyer::produce(edm::StreamID, edm::Event& iEvent, const edm:
   }
 
   // Rekey dEdx hit info
+  if (not rekey_dedxHits_)
+    return;
   const auto& dedxHitMom = iEvent.get(dedxHitMomToken_);
   const auto& dedxHitAss = iEvent.get(dedxHitAssToken_);
   const auto& dedxHitInfoHandle = iEvent.getRefBeforePut<reco::DeDxHitInfoCollection>();

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -173,6 +173,10 @@ _upc_extraCommands = [
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 run3_upc.toModify(MicroEventContent, outputCommands = MicroEventContent.outputCommands + _upc_extraCommands)
 
+_dedx_extraCommands = ["keep recoDeDxDataedmValueMap_dedxEstimator_*_*"]
+from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
+dedx_lfit.toModify(MicroEventContent, outputCommands = MicroEventContent.outputCommands + _dedx_extraCommands)
+
 _ppRef_extraCommands = [
     'keep floatedmValueMap_*TrackChi2_*_*',
     'keep recoClusterCompatibility_hiClusterCompatibility_*_*',

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -125,9 +125,11 @@ from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
 from PhysicsTools.PatAlgos.modules import DeDxEstimatorRekeyer
 dedxEstimator = DeDxEstimatorRekeyer()
 dedx_lfit.toModify(dedxEstimator, dedxEstimators = ["dedxPixelLikelihood", "dedxStripLikelihood", "dedxAllLikelihood"])
+dedx_lfit.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), dedxEstimator))
 
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
-run3_upc.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), hiPixelTracks, packedPFCandidateTrackChi2, lostTrackChi2, dedxEstimator))
+run3_upc.toModify(dedxEstimator, dedxHits  = "dedxHitInfo", dedxMomentum = "dedxHitInfo:momentumAtHit")
+run3_upc.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), hiPixelTracks, packedPFCandidateTrackChi2, lostTrackChi2))
 
 from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
 run3_oxygen.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), hiPixelTracks, hiEvtPlane, hiEvtPlaneFlat, packedPFCandidateTrackChi2, lostTrackChi2, centralityBin))


### PR DESCRIPTION
#### PR description:

This PR adds the dEdx likelihood fit estimators to the 2025 PbPb eras and stores the value maps in MiniAOD.

@mandrenguyen 

#### PR validation:

Tested with 182,182.1,143.901,143.902 and also with the workflows introduced in PR https://github.com/cms-sw/cmssw/pull/48634 ( 162,162.02,162.03,162.1,162.2,162.3,162.4 )

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
