### PR TITLE
Use 13_2_15_HLT in 23 PbPb production test

### DIFF
--- a/Configuration/PyReleaseValidation/test/BuildFile.xml
+++ b/Configuration/PyReleaseValidation/test/BuildFile.xml
@@ -42,7 +42,7 @@
 
 <ifarchitecture name="el8_amd64">
   <!-- Run this test for production arch of CMSSW_13_2_14 release only -->
-  <test name="test_MC_PbPb_23_setup" command="${CMSSW_BASE}/src/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup.sh auto:phase1_2023_realistic_hi Run3_pp_on_PbPb_2023 HIon CMSSW_13_2_14 132X_mcRun3_2023_realistic_HI_v10 Realistic2023PbPbCollision Pythia8_GammaNucleus_5p36TeV_cfi Run3_2023_UPC" />
+  <test name="test_MC_PbPb_23_setup" command="CMSSW_MC_SETUP_TEST_CATCH_HLT=0 ${CMSSW_BASE}/src/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup.sh auto:phase1_2023_realistic_hi Run3_pp_on_PbPb_2023 HIon CMSSW_13_2_15_HLT 132X_mcRun3_2023_realistic_HI_v10 Realistic2023PbPbCollision Pythia8_GammaNucleus_5p36TeV_cfi Run3_2023_UPC" />
 </ifarchitecture>
 
 <!--


### PR DESCRIPTION
#### PR description:

This PR updates the 23 PbPb production test to use the 13_2_15_HLT release for the HLT step. That release includes the backport https://github.com/cms-sw/cmssw/pull/48639 that allow that release to read a ROOT file produced with 14_1_X.

Resolves https://github.com/cms-sw/cmssw/issues/48481
Resolves https://github.com/cms-sw/framework-team/issues/1481

#### PR validation:

Unit tests pass