### PR TITLE
[15_0_X]: Add NeNe Era modifier for the HF FG bit thresholds.

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2025_NEON_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_NEON_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
+from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
+from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
+from Configuration.Eras.Modifier_run3_neon_cff import run3_neon
+
+Run3_2025_NEON = cms.ModifierChain(Run3_2025, run3_upc, run3_oxygen, run3_neon)

--- a/Configuration/Eras/python/Modifier_run3_neon_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_neon_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_neon =cms.Modifier()

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cff.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cff.py
@@ -54,3 +54,6 @@ from Configuration.Eras.Modifier_pp_on_PbPb_run3_2025_cff import pp_on_PbPb_run3
 from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
 from Configuration.Eras.Era_Run3_2025_UPC_cff import Run3_2025_UPC
 (pp_on_PbPb_run3_2025 | run3_oxygen | Run3_2025_UPC).toModify(HcalTPGCoderULUT, FG_HF_thresholds = [14, 16])
+#add NeNe configuration
+from Configuration.Eras.Modifier_run3_neon_cff import run3_neon
+(run3_neon).toModify(HcalTPGCoderULUT, FG_HF_thresholds = [14, 12])


### PR DESCRIPTION
#### PR description:

This PR creates a NeNe era with modified HF FG bit thresholds for Ne data-taking as a part of the light ion run of 2025.

#### PR validation:

This PR has been tested by printing out values from the HcaluLUTcoder to validate the modified values for the thresholds. This is described in this [dropbox paper](https://paper.dropbox.com/doc/NeNe-Era--CqLk9oR5ErDj1LDDhKbwtm1sAQ-kCMu8ZmXXGYdTTuSoOi7o).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/48597

Tagging HIN colleagues: @boundino @stahlleiton @mandrenguyen @Cristian-Baldenegro
Tagging HCAL colleagues: @JHiltbrand @abdoulline @akhukhun

