### PR TITLE
Add missing dictionary to `SimDataFormats/Associations`

### DIFF
--- a/DataFormats/HGCalReco/src/classes_def.xml
+++ b/DataFormats/HGCalReco/src/classes_def.xml
@@ -12,6 +12,8 @@
     <version ClassVersion="3" checksum="3878166595"/>
   </class>
   <class name="std::vector<ticl::Trackster>" />
+  <class name="edm::RefProd<std::vector<ticl::Trackster> >"/>
+  <class name="std::pair<edm::RefProd<std::vector<ticl::Trackster> >, edm::RefProd<std::vector<ticl::Trackster> > >"/>
   <class name="edm::Wrapper<ticl::Trackster>" />
   <class name="edm::Wrapper<std::vector<ticl::Trackster> >" />
 

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -20,6 +20,7 @@
     <version ClassVersion="3" checksum="1942695459"/>
   </class>
   <class name="std::vector<reco::HGCalMultiCluster>"/>
+  <class name="edm::RefProd<vector<reco::HGCalMultiCluster> >" />
   <class name="edm::Wrapper<std::vector<reco::HGCalMultiCluster> >"/>  
 
   <class name="std::pair<edm::Ptr<reco::CaloCluster>::key_type,edm::Ptr<reco::PFCluster> >"/>

--- a/DataFormats/StdDictionaries/src/classes_def_others.xml
+++ b/DataFormats/StdDictionaries/src/classes_def_others.xml
@@ -25,4 +25,5 @@
  <class name="std::set<std::basic_string<char> >"/>
  <class name="std::atomic<int>"/>
  <class name="std::__atomic_base<int>"/>
+ <class name="std::monostate"/>
 </lcgdict>

--- a/DataFormats/StdDictionaries/src/classes_others.h
+++ b/DataFormats/StdDictionaries/src/classes_others.h
@@ -7,3 +7,4 @@
 #include <vector>
 #include <functional>
 #include <atomic>
+#include <variant>

--- a/SimDataFormats/Associations/src/classes_def.xml
+++ b/SimDataFormats/Associations/src/classes_def.xml
@@ -52,10 +52,7 @@
   <class name="std::vector<ticl::AssociationElement<std::pair<ticl::SharedEnergyType, float> > >"/>
   <class name="std::vector<std::vector<ticl::AssociationElement<std::pair<ticl::SharedEnergyType, float> > > >"/>
   
-  <class name="edm::RefProd<std::vector<ticl::Trackster> >"/>
   <class name="std::pair<edm::RefProd<std::vector<reco::CaloCluster> >,edm::RefProd<std::vector<ticl::Trackster> > >"/>
-  <class name="std::pair<edm::RefProd<std::vector<ticl::Trackster> >, edm::RefProd<std::vector<ticl::Trackster> > >"/>
-  <class name="std::pair<edm::RefProd<std::vector<SimCluster> >, edm::RefProd<std::vector<CaloParticle> > >"/>
 
   <!-- For one-to-many map with FractionType -->
   <class name="ticl::AssociationMap<ticl::mapWithFraction, std::vector<reco::CaloCluster>, std::vector<ticl::Trackster> >"/>
@@ -126,7 +123,6 @@
   </class>
   <class name="edm::Wrapper<ticl::RecoToSimCollectionWithSimClusters>" />
 
-  <class name="edm::RefProd<vector<ticl::Trackster> >" />
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<SimCluster> >, edm::RefProd<vector<ticl::Trackster> > >" />
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<ticl::Trackster> >, edm::RefProd<vector<SimCluster> > >" />
 
@@ -170,7 +166,6 @@
   </class>
   <class name="edm::Wrapper<hgcal::RecoToSimCollectionWithMultiClusters>" />
 
-  <class name="edm::RefProd<vector<reco::HGCalMultiCluster> >" />
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<CaloParticle> >,edm::RefProd<vector<reco::HGCalMultiCluster> > >" />
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::HGCalMultiCluster> >,edm::RefProd<vector<CaloParticle> > >" />
 

--- a/SimDataFormats/Associations/src/classes_def.xml
+++ b/SimDataFormats/Associations/src/classes_def.xml
@@ -52,7 +52,6 @@
   <class name="std::vector<ticl::AssociationElement<std::pair<ticl::SharedEnergyType, float> > >"/>
   <class name="std::vector<std::vector<ticl::AssociationElement<std::pair<ticl::SharedEnergyType, float> > > >"/>
   
-  <class name="std::monostate"/>
   <class name="edm::RefProd<std::vector<ticl::Trackster> >"/>
   <class name="std::pair<edm::RefProd<std::vector<reco::CaloCluster> >,edm::RefProd<std::vector<ticl::Trackster> > >"/>
   <class name="std::pair<edm::RefProd<std::vector<ticl::Trackster> >, edm::RefProd<std::vector<ticl::Trackster> > >"/>

--- a/SimDataFormats/Associations/src/classes_def.xml
+++ b/SimDataFormats/Associations/src/classes_def.xml
@@ -54,6 +54,7 @@
   
   <class name="std::monostate"/>
   <class name="edm::RefProd<std::vector<ticl::Trackster> >"/>
+  <class name="std::pair<edm::RefProd<std::vector<reco::CaloCluster> >,edm::RefProd<std::vector<ticl::Trackster> > >"/>
   <class name="std::pair<edm::RefProd<std::vector<ticl::Trackster> >, edm::RefProd<std::vector<ticl::Trackster> > >"/>
   <class name="std::pair<edm::RefProd<std::vector<SimCluster> >, edm::RefProd<std::vector<CaloParticle> > >"/>
 

--- a/SimDataFormats/CaloAnalysis/src/classes_def.xml
+++ b/SimDataFormats/CaloAnalysis/src/classes_def.xml
@@ -32,6 +32,8 @@
   <class name="SimClusterRefProd"/>
   <class name="SimClusterContainer"/>
 
+  <class name="std::pair<edm::RefProd<std::vector<SimCluster> >, edm::RefProd<std::vector<CaloParticle> > >"/>
+
   <class name="MtdSimCluster" ClassVersion="6">
     <version ClassVersion="6" checksum="3803328692"/>
     <version ClassVersion="5" checksum="3108339619"/>


### PR DESCRIPTION
#### PR description:

This missing dictionary were found in https://github.com/root-project/root/pull/18402#issuecomment-3164704662

In addition move dictionary of `std::monostate` to `DataFormats/StdDictionaries`. In addition move a few other dictionary definitions to their correct packages.

Resolves https://github.com/cms-sw/framework-team/issues/1510

#### PR validation:

With a developer area created from https://github.com/cms-sw/root/pull/222#issuecomment-3134654219 the  failed in the test succeeded with these changes.