### PR TITLE
RandomNumberGeneratorService properly does consumes

### DIFF
--- a/FWCore/AbstractServices/interface/RandomNumberGenerator.h
+++ b/FWCore/AbstractServices/interface/RandomNumberGenerator.h
@@ -138,7 +138,7 @@ namespace CLHEP {
 
 namespace edm {
 
-  class ConsumesCollector;
+  class EDConsumerBase;
   class Event;
   class LuminosityBlock;
   class LuminosityBlockIndex;
@@ -203,7 +203,8 @@ namespace edm {
     virtual std::vector<RandomEngineState> const& getEventCache(StreamID const&) const = 0;
     virtual std::vector<RandomEngineState> const& getLumiCache(LuminosityBlockIndex const&) const = 0;
 
-    virtual void consumes(ConsumesCollector&& iC) const = 0;
+    //Can be nullptr if the service is not consuming anything. The object is owned by the service.
+    virtual EDConsumerBase* consumer() = 0;
 
     /// For debugging purposes only.
     virtual void print(std::ostream& os) const = 0;

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -710,6 +710,20 @@ namespace edm {
         firstException = std::current_exception();
       }
     }
+    if (!firstException) {
+      CMS_SA_ALLOW try {
+        edm::Service<edm::RandomNumberGenerator> rng;
+        if (rng.isAvailable()) {
+          auto consumer = rng->consumer();
+          if (consumer) {
+            consumer->updateLookup(InLumi, *preg_->productLookup(InLumi), true);
+            consumer->updateLookup(InEvent, *preg_->productLookup(InEvent), true);
+          }
+        }
+      } catch (...) {
+        firstException = std::current_exception();
+      }
+    }
     if (firstException) {
       std::rethrow_exception(firstException);
     }
@@ -1649,6 +1663,7 @@ namespace edm {
                         Service<RandomNumberGenerator> rng;
                         if (rng.isAvailable()) {
                           LuminosityBlock lb(lumiPrincipal, ModuleDescription(), nullptr, false);
+                          lb.setConsumer(rng->consumer());
                           rng->preBeginLumi(lb);
                         }
 
@@ -2274,6 +2289,7 @@ namespace edm {
     Service<RandomNumberGenerator> rng;
     if (rng.isAvailable()) {
       Event ev(*pep, ModuleDescription(), nullptr);
+      ev.setConsumer(rng->consumer());
       rng->postEventRead(ev);
     }
 

--- a/FWCore/Services/interface/ExternalRandomNumberGeneratorService.h
+++ b/FWCore/Services/interface/ExternalRandomNumberGeneratorService.h
@@ -46,7 +46,7 @@ namespace edm {
     std::vector<RandomEngineState> const& getEventCache(StreamID const&) const final;
     std::vector<RandomEngineState> const& getLumiCache(LuminosityBlockIndex const&) const final;
 
-    void consumes(ConsumesCollector&& iC) const final;
+    EDConsumerBase* consumer() final;
 
     /// For debugging purposes only.
     void print(std::ostream& os) const final;

--- a/FWCore/Services/src/ExternalRandomNumberGeneratorService.cc
+++ b/FWCore/Services/src/ExternalRandomNumberGeneratorService.cc
@@ -85,7 +85,7 @@ std::vector<RandomEngineState> const& ExternalRandomNumberGeneratorService::getL
   return s_dummyStates;
 }
 
-void ExternalRandomNumberGeneratorService::consumes(ConsumesCollector&& iC) const {}
+EDConsumerBase* ExternalRandomNumberGeneratorService::consumer() { return nullptr; }
 
 /// For debugging purposes only.
 void ExternalRandomNumberGeneratorService::print(std::ostream& os) const {}

--- a/IOMC/RandomEngine/plugins/RandomNumberGeneratorService.h
+++ b/IOMC/RandomEngine/plugins/RandomNumberGeneratorService.h
@@ -13,7 +13,9 @@
 
 #include "FWCore/AbstractServices/interface/RandomNumberGenerator.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistryfwd.h"
+#include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include <atomic>
@@ -45,15 +47,16 @@ namespace edm {
   class ParameterSet;
   class StreamContext;
   class StreamID;
+  class RandomEngineStates;
 
   namespace service {
 
     class SystemBounds;
 
-    class RandomNumberGeneratorService : public RandomNumberGenerator {
+    class RandomNumberGeneratorService : public RandomNumberGenerator, public EDConsumerBase {
     public:
       RandomNumberGeneratorService(ParameterSet const& pset, ActivityRegistry& activityRegistry);
-      ~RandomNumberGeneratorService() override;
+      ~RandomNumberGeneratorService() noexcept(true) override;
 
       RandomNumberGeneratorService(RandomNumberGeneratorService const&) = delete;
       RandomNumberGeneratorService const& operator=(RandomNumberGeneratorService const&) = delete;
@@ -122,7 +125,7 @@ namespace edm {
       std::vector<RandomEngineState> const& getLumiCache(LuminosityBlockIndex const&) const override;
       std::vector<RandomEngineState> const& getEventCache(StreamID const&) const override;
 
-      void consumes(ConsumesCollector&& iC) const override;
+      EDConsumerBase* consumer() override;
 
       /// For debugging
       void print(std::ostream& os) const override;
@@ -231,6 +234,9 @@ namespace edm {
       // then the service does not try to restore the random numbers.
       edm::InputTag restoreStateTag_;
       edm::InputTag restoreStateBeginLumiTag_;
+
+      edm::EDGetTokenT<RandomEngineStates> restoreStateToken_;
+      edm::EDGetTokenT<RandomEngineStates> restoreStateBeginLumiToken_;
 
       std::vector<std::vector<RandomEngineState>> eventCache_;  // streamID, sorted by module label
       std::vector<std::vector<RandomEngineState>> lumiCache_;   // luminosityBlockIndex, sorted by module label

--- a/Mixing/Base/src/PileupRandomNumberGenerator.cc
+++ b/Mixing/Base/src/PileupRandomNumberGenerator.cc
@@ -67,7 +67,7 @@ std::vector<RandomEngineState> const& PileupRandomNumberGenerator::getLumiCache(
   return s_dummy;
 }
 
-void PileupRandomNumberGenerator::consumes(edm::ConsumesCollector&& iC) const {}
+edm::EDConsumerBase* PileupRandomNumberGenerator::consumer() { return nullptr; }
 
 void PileupRandomNumberGenerator::print(std::ostream& os) const {}
 

--- a/Mixing/Base/src/PileupRandomNumberGenerator.h
+++ b/Mixing/Base/src/PileupRandomNumberGenerator.h
@@ -54,7 +54,7 @@ private:
   std::vector<RandomEngineState> const& getEventCache(edm::StreamID const&) const final;
   std::vector<RandomEngineState> const& getLumiCache(edm::LuminosityBlockIndex const&) const final;
 
-  void consumes(edm::ConsumesCollector&& iC) const final;
+  edm::EDConsumerBase* consumer() final;
 
   /// For debugging purposes only.
   void print(std::ostream& os) const final;


### PR DESCRIPTION
#### PR description:

This allows the service to use EDGetTokens

#### PR validation:

Framework unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/1509