### PR TITLE
Dynamic Memory Caps for LS, T3, T5 Objects in LST

### DIFF
--- a/RecoTracker/LSTCore/interface/MiniDoubletsSoA.h
+++ b/RecoTracker/LSTCore/interface/MiniDoubletsSoA.h
@@ -39,7 +39,8 @@ namespace lst {
                       SOA_COLUMN(float, outerHighEdgeX),
                       SOA_COLUMN(float, outerHighEdgeY),
                       SOA_COLUMN(float, outerLowEdgeX),
-                      SOA_COLUMN(float, outerLowEdgeY))
+                      SOA_COLUMN(float, outerLowEdgeY),
+                      SOA_COLUMN(unsigned int, connectedMax))
 
   GENERATE_SOA_LAYOUT(MiniDoubletsOccupancySoALayout,
                       SOA_COLUMN(unsigned int, nMDs),

--- a/RecoTracker/LSTCore/interface/SegmentsSoA.h
+++ b/RecoTracker/LSTCore/interface/SegmentsSoA.h
@@ -19,7 +19,8 @@ namespace lst {
                       SOA_COLUMN(uint16_t, outerLowerModuleIndices),
                       SOA_COLUMN(Params_LS::ArrayUxLayers, mdIndices),
                       SOA_COLUMN(unsigned int, innerMiniDoubletAnchorHitIndices),
-                      SOA_COLUMN(unsigned int, outerMiniDoubletAnchorHitIndices))
+                      SOA_COLUMN(unsigned int, outerMiniDoubletAnchorHitIndices),
+                      SOA_COLUMN(unsigned int, connectedMax))
 
   GENERATE_SOA_LAYOUT(SegmentsOccupancySoALayout,
                       SOA_COLUMN(unsigned int, nSegments),  //number of segments per inner lower module

--- a/RecoTracker/LSTCore/interface/TripletsSoA.h
+++ b/RecoTracker/LSTCore/interface/TripletsSoA.h
@@ -13,13 +13,14 @@ namespace lst {
                       SOA_COLUMN(Params_T3::ArrayU16xLayers, lowerModuleIndices),  // lower module index in each layer
                       SOA_COLUMN(Params_T3::ArrayU8xLayers, logicalLayers),        // layer ID
                       SOA_COLUMN(Params_T3::ArrayUxHits, hitIndices),              // hit indices
-                      SOA_COLUMN(FPX, betaIn),            // beta/chord angle of the inner segment
-                      SOA_COLUMN(float, centerX),         // lower/anchor-hit based circle center x
-                      SOA_COLUMN(float, centerY),         // lower/anchor-hit based circle center y
-                      SOA_COLUMN(float, radius),          // lower/anchor-hit based circle radius
-                      SOA_COLUMN(float, fakeScore),       // DNN confidence score for fake t3
-                      SOA_COLUMN(float, promptScore),     // DNN confidence score for real (prompt) t3
-                      SOA_COLUMN(float, displacedScore),  // DNN confidence score for real (displaced) t3
+                      SOA_COLUMN(FPX, betaIn),                 // beta/chord angle of the inner segment
+                      SOA_COLUMN(float, centerX),              // lower/anchor-hit based circle center x
+                      SOA_COLUMN(float, centerY),              // lower/anchor-hit based circle center y
+                      SOA_COLUMN(float, radius),               // lower/anchor-hit based circle radius
+                      SOA_COLUMN(float, fakeScore),            // DNN confidence score for fake t3
+                      SOA_COLUMN(float, promptScore),          // DNN confidence score for real (prompt) t3
+                      SOA_COLUMN(float, displacedScore),       // DNN confidence score for real (displaced) t3
+                      SOA_COLUMN(unsigned int, connectedMax),  // number of outer-triplets that pass the MD-equality cut
 #ifdef CUT_VALUE_DEBUG
                       SOA_COLUMN(float, zOut),
                       SOA_COLUMN(float, rtOut),

--- a/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
@@ -1697,6 +1697,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                   ObjectRangesConst ranges,
                                   uint16_t nEligibleT5Modules,
                                   const float ptCut) const {
+      ALPAKA_ASSERT_ACC((alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[1] == 1) &&
+                        (alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[2] == 1));
       for (int iter : cms::alpakatools::uniform_elements_z(acc, nEligibleT5Modules)) {
         uint16_t lowerModule1 = ranges.indicesOfEligibleT5Modules()[iter];
         short layer2_adjustment;
@@ -1833,6 +1835,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                   Triplets triplets,
                                   TripletsOccupancyConst tripletsOcc,
                                   ObjectRangesConst ranges) const {
+      // The atomicAdd below with hierarchy::Threads{} requires one block in x, y dimensions.
+      ALPAKA_ASSERT_ACC((alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[1] == 1) &&
+                        (alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[2] == 1));
       const auto& mdIndices = segments.mdIndices();
       const auto& segIdx = triplets.segmentIndices();
       const auto& lmIdx = triplets.lowerModuleIndices();

--- a/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
@@ -1699,7 +1699,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                   const float ptCut) const {
       ALPAKA_ASSERT_ACC((alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[1] == 1) &&
                         (alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[2] == 1));
-      for (int iter : cms::alpakatools::uniform_elements_z(acc, nEligibleT5Modules)) {
+      for (int iter : cms::alpakatools::uniform_groups_z(acc, nEligibleT5Modules)) {
         uint16_t lowerModule1 = ranges.indicesOfEligibleT5Modules()[iter];
         short layer2_adjustment;
         int layer = modules.layers()[lowerModule1];
@@ -1843,7 +1843,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
       const auto& lmIdx = triplets.lowerModuleIndices();
       const auto& tripIdx = ranges.tripletModuleIndices();
 
-      for (uint16_t lowerModule1 : cms::alpakatools::uniform_elements_z(acc, modules.nLowerModules())) {
+      for (uint16_t lowerModule1 : cms::alpakatools::uniform_groups_z(acc, modules.nLowerModules())) {
         if (!isValidQuintRegion(modules, lowerModule1))
           continue;
 

--- a/RecoTracker/LSTCore/src/alpaka/Segment.h
+++ b/RecoTracker/LSTCore/src/alpaka/Segment.h
@@ -616,6 +616,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                   SegmentsOccupancy segmentsOccupancy,
                                   ObjectRangesConst ranges,
                                   const float ptCut) const {
+      ALPAKA_ASSERT_ACC((alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[1] == 1) &&
+                        (alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[2] == 1));
       for (uint16_t innerLowerModuleIndex : cms::alpakatools::uniform_elements_z(acc, modules.nLowerModules())) {
         unsigned int nInnerMDs = mdsOccupancy.nMDs()[innerLowerModuleIndex];
         if (nInnerMDs == 0)
@@ -635,8 +637,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           for (unsigned int hitIndex : cms::alpakatools::uniform_elements_x(acc, limit)) {
             unsigned int innerMDArrayIdx = hitIndex / nOuterMDs;
             unsigned int outerMDArrayIdx = hitIndex % nOuterMDs;
-            if (outerMDArrayIdx >= nOuterMDs)
-              continue;
 
             unsigned int innerMDIndex = ranges.mdRanges()[innerLowerModuleIndex][0] + innerMDArrayIdx;
             unsigned int outerMDIndex = ranges.mdRanges()[outerLowerModuleIndex][0] + outerMDArrayIdx;
@@ -727,6 +727,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                   MiniDoubletsOccupancyConst mdsOccupancy,
                                   ObjectRangesConst ranges,
                                   const float ptCut) const {
+      // The atomicAdd below with hierarchy::Threads{} requires one block in x, y dimensions.
+      ALPAKA_ASSERT_ACC((alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[1] == 1) &&
+                        (alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[2] == 1));
       const auto& mdRanges = ranges.mdRanges();
 
       for (uint16_t innerLowerModuleIndex : cms::alpakatools::uniform_elements_z(acc, modules.nLowerModules())) {
@@ -749,8 +752,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           for (unsigned int hitIndex : cms::alpakatools::uniform_elements_x(acc, limit)) {
             const unsigned int innerMDArrayIdx = hitIndex / nOuterMDs;
             const unsigned int outerMDArrayIdx = hitIndex % nOuterMDs;
-            if (outerMDArrayIdx >= nOuterMDs)
-              continue;
 
             const unsigned int innerMDIndex = mdRanges[innerLowerModuleIndex][0] + innerMDArrayIdx;
             const unsigned int outerMDIndex = mdRanges[outerLowerModuleIndex][0] + outerMDArrayIdx;

--- a/RecoTracker/LSTCore/src/alpaka/Segment.h
+++ b/RecoTracker/LSTCore/src/alpaka/Segment.h
@@ -618,7 +618,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                   const float ptCut) const {
       ALPAKA_ASSERT_ACC((alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[1] == 1) &&
                         (alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[2] == 1));
-      for (uint16_t innerLowerModuleIndex : cms::alpakatools::uniform_elements_z(acc, modules.nLowerModules())) {
+      for (uint16_t innerLowerModuleIndex : cms::alpakatools::uniform_groups_z(acc, modules.nLowerModules())) {
         unsigned int nInnerMDs = mdsOccupancy.nMDs()[innerLowerModuleIndex];
         if (nInnerMDs == 0)
           continue;
@@ -732,7 +732,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                         (alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[2] == 1));
       const auto& mdRanges = ranges.mdRanges();
 
-      for (uint16_t innerLowerModuleIndex : cms::alpakatools::uniform_elements_z(acc, modules.nLowerModules())) {
+      for (uint16_t innerLowerModuleIndex : cms::alpakatools::uniform_groups_z(acc, modules.nLowerModules())) {
         const unsigned int nInnerMDs = mdsOccupancy.nMDs()[innerLowerModuleIndex];
         if (nInnerMDs == 0)
           continue;

--- a/RecoTracker/LSTCore/src/alpaka/Triplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Triplet.h
@@ -722,6 +722,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                   uint16_t* index_gpu,
                                   uint16_t nonZeroModules,
                                   const float ptCut) const {
+      ALPAKA_ASSERT_ACC((alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[1] == 1) &&
+                        (alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[2] == 1));
       for (uint16_t innerLowerModuleArrayIdx : cms::alpakatools::uniform_elements_z(acc, nonZeroModules)) {
         uint16_t innerInnerLowerModuleIndex = index_gpu[innerLowerModuleArrayIdx];
         if (innerInnerLowerModuleIndex >= modules.nLowerModules())
@@ -824,6 +826,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                   Segments segments,
                                   SegmentsOccupancyConst segOcc,
                                   ObjectRangesConst ranges) const {
+      // The atomicAdd below with hierarchy::Threads{} requires one block in x, y dimensions.
+      ALPAKA_ASSERT_ACC((alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[1] == 1) &&
+                        (alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[2] == 1));
       const auto& mdIndices = segments.mdIndices();
       const auto& outerLowerModuleIndices = segments.outerLowerModuleIndices();
       const auto& segmentRanges = ranges.segmentRanges();

--- a/RecoTracker/LSTCore/src/alpaka/Triplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Triplet.h
@@ -724,7 +724,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                   const float ptCut) const {
       ALPAKA_ASSERT_ACC((alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[1] == 1) &&
                         (alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[2] == 1));
-      for (uint16_t innerLowerModuleArrayIdx : cms::alpakatools::uniform_elements_z(acc, nonZeroModules)) {
+      for (uint16_t innerLowerModuleArrayIdx : cms::alpakatools::uniform_groups_z(acc, nonZeroModules)) {
         uint16_t innerInnerLowerModuleIndex = index_gpu[innerLowerModuleArrayIdx];
         if (innerInnerLowerModuleIndex >= modules.nLowerModules())
           continue;
@@ -833,7 +833,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
       const auto& outerLowerModuleIndices = segments.outerLowerModuleIndices();
       const auto& segmentRanges = ranges.segmentRanges();
 
-      for (uint16_t innerLowerModuleArrayIdx : cms::alpakatools::uniform_elements_z(acc, modules.nLowerModules())) {
+      for (uint16_t innerLowerModuleArrayIdx : cms::alpakatools::uniform_groups_z(acc, modules.nLowerModules())) {
         const unsigned int nInnerSegments = segOcc.nSegments()[innerLowerModuleArrayIdx];
         if (nInnerSegments == 0)
           continue;


### PR DESCRIPTION
#### PR description:
This PR introduces dynamic memory caps for the LS, T3, and T5 objects, reducing LST's memory footprint and eliminating truncation of LST track primitives due to underallocation.

### Memory Reduction (0.8 GeV, 10 event average)
The numbers below are the average sums over 10 events of the memory caps for all modules in an event. Previously, most space that was allocated was not used to avoid possible truncation (eg, only O(6k) T5's are created per event, but 500k elements were allocated in the T5 arrays using the constant caps). This PR fixes this approach by first doing quick counts using a subset of the cuts in the actual creation kernels to get a better estimate of how much space needs to be allocated per module.

First number is using only the static caps (ie prior to https://github.com/cms-sw/cmssw/pull/47232), second is current, third is this PR.

T5's - 502,000 -> 120,000 -> 57,000 (89% decrease)
T3's - 1,980,000 -> 737,000 -> 409,000 (79% decrease)
LS's - 1,931,000 -> 858,000 -> 532,000 (72% decrease)

### Truncation Reduction (0.8 GeV, 10 event sum)

First number is current, second is this PR.

T5's - 0 -> 0 (current limits are already set very high)
T3's - 1,349 -> 0
LS's - 16,488 -> 0

Timing increases on GPU by ~14% (3.6 ms -> 4.1 ms) for single stream and ~6% (1.7 ms -> 1.8 ms) for 8 streams. Most of the timing increase on GPU is from reduced truncation (i.e. more objects being produced by LST, causing more computation downstream) rather than overhead from the new kernels that calculate dynamic caps for memory allocation. Timing with CPU backend increases by a similar 6-7%.

c.c. @slava77 