### PR TITLE
[15.0.X] Adapt ClusterTPAssociationProducer to deal with two strip cluster product IDs

### DIFF
--- a/HLTriggerOffline/Egamma/python/HLTmultiTrackValidatorGsfTracks_cff.py
+++ b/HLTriggerOffline/Egamma/python/HLTmultiTrackValidatorGsfTracks_cff.py
@@ -1,6 +1,17 @@
 import FWCore.ParameterSet.Config as cms
 
-from Validation.RecoTrack.HLTmultiTrackValidator_cfi import *
+from Validation.RecoTrack.associators_cff import hltTPClusterProducer, hltTrackAssociatorByHits
+from Validation.RecoTrack.HLTmultiTrackValidator_cfi import hltMultiTrackValidator
+from Validation.RecoTrack.TrackValidation_cff import trackingParticlesElectron
+
+hltTPClusterOnDemandProducer = hltTPClusterProducer.clone(
+    stripClusterSrc = "hltSiStripRawToClustersFacilityOnDemand"
+)
+
+hltGsfTrackAssociatorByHits = hltTrackAssociatorByHits.clone(
+    cluster2TPSrc = "hltTPClusterOnDemandProducer"
+)
+
 hltGsfTrackValidator = hltMultiTrackValidator.clone(
     label = [
         "hltEgammaGsfTracks",
@@ -20,13 +31,13 @@ hltGsfTrackValidator = hltMultiTrackValidator.clone(
     ),
     maxRapidityTP =  3.0,
     minRapidityTP = -3.0,
+    associators = ['hltGsfTrackAssociatorByHits']
 )
 
-from Validation.RecoTrack.TrackValidation_cff import trackingParticlesElectron
 hltMultiTrackValidationGsfTracksTask = cms.Task(
-   hltTPClusterProducer
-   , hltTrackAssociatorByHits
-   , trackingParticlesElectron
+    hltTPClusterOnDemandProducer,
+    hltGsfTrackAssociatorByHits,
+    trackingParticlesElectron
  )
 hltMultiTrackValidationGsfTracks = cms.Sequence(
     hltGsfTrackValidator,

--- a/SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h
+++ b/SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h
@@ -86,7 +86,7 @@ private:
   }
 
   map_type map_;
-  edm::VecArray<edm::ProductID, 2> keyProductIDs_;
+  std::vector<edm::ProductID> keyProductIDs_;
   edm::ProductID mappedProductId_;
 };
 

--- a/SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h
+++ b/SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h
@@ -4,7 +4,6 @@
 #include "DataFormats/Provenance/interface/ProductID.h"
 #include "DataFormats/Common/interface/HandleBase.h"
 #include "DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h"
-#include "FWCore/Utilities/interface/VecArray.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 

--- a/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
+++ b/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
@@ -68,6 +68,8 @@ private:
   edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > siphase2OTSimLinksToken_;
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > pixelClustersToken_;
   edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > stripClustersToken_;
+  const edm::InputTag otherStripClusterTag_;
+  edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > stripClustersOtherToken_;
   edm::EDGetTokenT<edmNew::DetSetVector<Phase2TrackerCluster1D> > phase2OTClustersToken_;
   edm::EDGetTokenT<TrackingParticleCollection> trackingParticleToken_;
   bool throwOnMissingCollections_;
@@ -84,6 +86,8 @@ ClusterTPAssociationProducer::ClusterTPAssociationProducer(const edm::ParameterS
           consumes<edmNew::DetSetVector<SiPixelCluster> >(cfg.getParameter<edm::InputTag>("pixelClusterSrc"))),
       stripClustersToken_(
           consumes<edmNew::DetSetVector<SiStripCluster> >(cfg.getParameter<edm::InputTag>("stripClusterSrc"))),
+      otherStripClusterTag_(cfg.getParameter<edm::InputTag>("stripClusterOtherSrc")),
+      stripClustersOtherToken_(consumes<edmNew::DetSetVector<SiStripCluster> >(otherStripClusterTag_)),
       phase2OTClustersToken_(consumes<edmNew::DetSetVector<Phase2TrackerCluster1D> >(
           cfg.getParameter<edm::InputTag>("phase2OTClusterSrc"))),
       trackingParticleToken_(
@@ -100,6 +104,7 @@ void ClusterTPAssociationProducer::fillDescriptions(edm::ConfigurationDescriptio
   desc.add<edm::InputTag>("phase2OTSimLinkSrc", edm::InputTag("simSiPixelDigis", "Tracker"));
   desc.add<edm::InputTag>("pixelClusterSrc", edm::InputTag("siPixelClusters"));
   desc.add<edm::InputTag>("stripClusterSrc", edm::InputTag("siStripClusters"));
+  desc.add<edm::InputTag>("stripClusterOtherSrc", edm::InputTag(""));
   desc.add<edm::InputTag>("phase2OTClusterSrc", edm::InputTag("siPhase2Clusters"));
   desc.add<edm::InputTag>("trackingParticleSrc", edm::InputTag("mix", "MergedTrackTruth"));
   desc.add<bool>("throwOnMissingCollections", true);
@@ -115,6 +120,12 @@ void ClusterTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, co
   edm::Handle<edmNew::DetSetVector<SiStripCluster> > stripClusters;
   bool foundStripClusters = iEvent.getByToken(stripClustersToken_, stripClusters);
 
+  // Strip Cluster (other product, if there)
+  bool foundOtherStripClusters = false;
+  edm::Handle<edmNew::DetSetVector<SiStripCluster> > stripClustersOther;
+  if (otherStripClusterTag_ != edm::InputTag(""))
+    foundOtherStripClusters = iEvent.getByToken(stripClustersOtherToken_, stripClustersOther);
+
   // Phase2 Cluster
   edm::Handle<edmNew::DetSetVector<Phase2TrackerCluster1D> > phase2OTClusters;
   bool foundPhase2OTClusters = iEvent.getByToken(phase2OTClustersToken_, phase2OTClusters);
@@ -129,9 +140,10 @@ void ClusterTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, co
   }
 
   // SiStrip DigiSimLink
+  bool foundAnyStripClusters = (foundStripClusters || foundOtherStripClusters);
   edm::Handle<edm::DetSetVector<StripDigiSimLink> > sistripSimLinks;
   auto stripSimLinksFound = iEvent.getByToken(sistripSimLinksToken_, sistripSimLinks);
-  if (not throwOnMissingCollections_ and foundStripClusters and not stripSimLinksFound) {
+  if (not throwOnMissingCollections_ and foundAnyStripClusters and not stripSimLinksFound) {
     auto clusterTPList = std::make_unique<ClusterTPAssociation>();
     iEvent.put(std::move(clusterTPList));
     return;
@@ -223,6 +235,43 @@ void ClusterTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, co
       for (edmNew::DetSet<SiStripCluster>::const_iterator di = link_strip.begin(); di != link_strip.end(); di++) {
         const SiStripCluster& cluster = (*di);
         edm::Ref<edmNew::DetSetVector<SiStripCluster>, SiStripCluster> c_ref = edmNew::makeRefTo(stripClusters, di);
+
+        simTkIds.clear();
+        int first = cluster.firstStrip();
+        int last = first + cluster.amplitudes().size();
+
+        for (int istr = first; istr < last; ++istr) {
+          trkid.clear();
+          getSimTrackId<StripDigiSimLink>(trkid, sistripSimLinks, detId, istr);
+          simTkIds.insert(trkid.begin(), trkid.end());
+        }
+        for (auto iset = simTkIds.begin(); iset != simTkIds.end(); iset++) {
+          auto ipos = mapping.find(*iset);
+          if (ipos != mapping.end()) {
+            //std::cout << "cluster in detid: " << detid << " from tp: " << ipos->second.key() << " " << iset->first << std::endl;
+            clusterTPList->emplace_back(OmniClusterRef(c_ref), ipos->second);
+          }
+        }
+      }
+    }
+  }
+
+  if (foundOtherStripClusters) {
+    // Strip Clusters (other product, if there)
+    clusterTPList->addKeyID(stripClustersOther.id());
+    for (edmNew::DetSetVector<SiStripCluster>::const_iterator iter = stripClustersOther->begin(false),
+                                                              eter = stripClustersOther->end(false);
+         iter != eter;
+         ++iter) {
+      if (!(*iter).isValid())
+        continue;
+      uint32_t detid = iter->id();
+      DetId detId(detid);
+      edmNew::DetSet<SiStripCluster> link_strip = (*iter);
+      for (edmNew::DetSet<SiStripCluster>::const_iterator di = link_strip.begin(); di != link_strip.end(); di++) {
+        const SiStripCluster& cluster = (*di);
+        edm::Ref<edmNew::DetSetVector<SiStripCluster>, SiStripCluster> c_ref =
+            edmNew::makeRefTo(stripClustersOther, di);
 
         simTkIds.clear();
         int first = cluster.firstStrip();

--- a/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
+++ b/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
@@ -10,13 +10,20 @@ hltMultiPVanalysis = vertexAnalysis.clone(
     trackAssociatorMap    = "trackingParticleRecoTrackAsssociation",
     vertexAssociator      = "VertexAssociatorByPositionAndTracks"
 )
-from Validation.RecoTrack.associators_cff import hltTrackAssociatorByHits, tpToHLTpixelTrackAssociation
+from Validation.RecoTrack.associators_cff import hltTPClusterProducer, hltTrackAssociatorByHits, tpToHLTpixelTrackAssociation
 from SimTracker.VertexAssociation.VertexAssociatorByPositionAndTracks_cfi import VertexAssociatorByPositionAndTracks as _VertexAssociatorByPositionAndTracks
 vertexAssociatorByPositionAndTracks4pixelTracks = _VertexAssociatorByPositionAndTracks.clone(
     trackAssociation = "tpToHLTpixelTrackAssociation"
 )
+hltOtherTPClusterProducer = hltTPClusterProducer.clone(
+    stripClusterOtherSrc = "hltSiStripRawToClustersFacilityOnDemand"
+)
+hltOtherTrackAssociatorByHits = hltTrackAssociatorByHits.clone(
+    cluster2TPSrc = cms.InputTag("hltOtherTPClusterProducer")
+)
 tpToHLTpfMuonMergingTrackAssociation = tpToHLTpixelTrackAssociation.clone(
-    label_tr = "hltPFMuonMerging"
+    label_tr = "hltPFMuonMerging",
+    associator = cms.InputTag('hltOtherTrackAssociatorByHits')
 )
 vertexAssociatorByPositionAndTracks4pfMuonMergingTracks = _VertexAssociatorByPositionAndTracks.clone(
     trackAssociation = "tpToHLTpfMuonMergingTrackAssociation"
@@ -62,7 +69,9 @@ def _modifyFullPVanalysisForPhase2(pvanalysis):
 phase2_tracker.toModify(hltPVanalysis, _modifyFullPVanalysisForPhase2)
 
 hltMultiPVAssociations = cms.Task(
+    hltOtherTPClusterProducer,
     hltTrackAssociatorByHits,
+    hltOtherTrackAssociatorByHits,
     tpToHLTpixelTrackAssociation,
     vertexAssociatorByPositionAndTracks4pixelTracks,
     tpToHLTpfMuonMergingTrackAssociation,


### PR DESCRIPTION
### PR description:

Backport of #48701.

As per title, this PR aims at adapting the ClusterTPAssociationProducer to deal with two strip cluster product IDs, following #48684 and its backport #48685, in view of the next HLT menu for 2025.
In addition, all relevant HLT validation modules are adapted for the foreseen changes.

NOTE: this should ideally be included together with the PR that will introduce the new menu, foreseen for next week.

### PR validation:

The PR was validated with the updated HLT menu foreseen for August 18.

FYI: @cms-sw/tracking-pog-l2, @missirol, @mmusich 