### PR TITLE
[DAQ] DAQSource read-only mode and processing specific lumis in file discovery mode (Phase-2)

### DIFF
--- a/EventFilter/Utilities/doc/README-DTH.md
+++ b/EventFilter/Utilities/doc/README-DTH.md
@@ -44,6 +44,8 @@ Example file name for this mode is `run123456_ls000_index000000_source01234.raw`
 
 It is possible that another DAQ-specific header will be added to both file and per-orbit to better encapsulate data (similar is done for Run2/3 FRD files), to provide additional metadata to improve integrity and completeness checks after aggregation of data in DAQ. At present, only RAW DTH is supported by the "DTH" module.
 
+Additional parameters were added **for file discovery mode only** to allow only specific lumisection range to be processed, `overrideRangeLS = cms.untracked.vuint32($N,$M)`, and to keep input read only, `keepRawFiles = cms.untracked.bool(True)`
+
 # DAQ file formats
 Documentation:
 https://twiki.cern.ch/twiki/bin/view/CMS/FFFMetafileFormats

--- a/EventFilter/Utilities/interface/DAQSource.h
+++ b/EventFilter/Utilities/interface/DAQSource.h
@@ -126,6 +126,9 @@ private:
   const bool fileListLoopMode_;
   unsigned int loopModeIterationInc_ = 0;
 
+  std::vector<unsigned int> overrideRangeLS_;
+  bool keepRawFiles_;
+
   edm::RunNumber_t runNumber_;
   std::string fuOutputDir_;
 

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -187,6 +187,11 @@ namespace evf {
     bool fileListMode() const { return fileListMode_; }
     unsigned int lsWithFilesOpen(unsigned int ls) const;
 
+    void setDiscoveryRange(int minDiscoveryLS, bool readOnly) {
+      minDiscoveryLS_ = minDiscoveryLS;
+      discoveryReadOnly_ = readOnly;
+    }
+
   private:
     void createLumiSectionFiles(const uint32_t lumiSection,
                                 const uint32_t currentLumiSection,
@@ -314,6 +319,9 @@ namespace evf {
     std::string discard_ls_filestem_;
     bool fileListMode_ = false;
     std::pair<unsigned, int> lastFileIdx_ = std::make_pair<unsigned, int>(0, -1);
+
+    int minDiscoveryLS_ = -1;
+    bool discoveryReadOnly_ = false;
   };
 }  // namespace evf
 

--- a/EventFilter/Utilities/src/DAQSourceModelsDTH.cc
+++ b/EventFilter/Utilities/src/DAQSourceModelsDTH.cc
@@ -476,8 +476,7 @@ int DataModeDTH::eventCounterCallback(
   if ((rawFd = ::open(name.c_str(), O_RDONLY)) < 0) {
     assert(rawFd == -1);
     found = false;
-    edm::LogError("EvFDaqDirector") << "parseFRDFileHeader - failed to open input file -: " << name << " : "
-                                    << strerror(errno);
+    edm::LogError("EvFDaqDirector") << "rawCounter - failed to open input file -: " << name << " : " << strerror(errno);
     return -1;
   }
   found = true;


### PR DESCRIPTION
#### PR description:

Adding two features for DAQSource in file discovery mode:
- abiity to start from specified lumisection and end with specified lumisection
- read-only mode which does not rename or delete raw files

Two new DAQSource parameters were added, intended only for tests i.e. no fillDescriptions for those.

#### PR validation:

Tested manually with modified unit test files and in DAQ test cluster

PR will not be backported.