### PR TITLE
protect online DQM clients when running in `inputFiles` mode against meaningless customizations

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -43,6 +43,9 @@ else:
     process.load("DQM.Integration.config.fileinputsource_cfi")
     from DQM.Integration.config.fileinputsource_cfi import options
 
+if (options.inputFiles):
+  useLockRecords = False
+
 #--------------------------
 # HLT Filter
 process.hltTriggerTypeFilter = cms.EDFilter("HLTTriggerTypeFilter",
@@ -377,18 +380,15 @@ process.dqmBeamMonitor.hltResults = "TriggerResults::HLT"
 
 #---------
 # Upload BeamSpotOnlineObject (LegacyRcd) to CondDB
-if unitTest == False:
-    process.OnlineDBOutputService = cms.Service("OnlineDBOutputService",
-
+if (not unitTest) and (not options.inputFiles):
+  process.OnlineDBOutputService = cms.Service("OnlineDBOutputService",
         DBParameters = cms.PSet(
-                                messageLevel = cms.untracked.int32(0),
-                                authenticationPath = cms.untracked.string('.')
-                            ),
-
+          messageLevel = cms.untracked.int32(0),
+          authenticationPath = cms.untracked.string('.')
+        ),
         # Upload to CondDB
         connect = cms.string('oracle://cms_orcon_prod/CMS_CONDITIONS'),
         preLoadConnectionString = cms.untracked.string('frontier://FrontierProd/CMS_CONDITIONS'),
-
         runNumber = cms.untracked.uint64(options.runNumber),
         omsServiceUrl = cms.untracked.string(BSOnlineOmsServiceUrl),
         latency = cms.untracked.uint32(2),
@@ -405,13 +405,11 @@ if unitTest == False:
     )
 
 else:
-    process.OnlineDBOutputService = cms.Service("OnlineDBOutputService",
-
+  process.OnlineDBOutputService = cms.Service("OnlineDBOutputService",
         DBParameters = cms.PSet(
-                                messageLevel = cms.untracked.int32(0),
-                                authenticationPath = cms.untracked.string('.')
-                            ),
-
+          messageLevel = cms.untracked.int32(0),
+          authenticationPath = cms.untracked.string('.')
+        ),
         # Upload to CondDB
         connect = cms.string('sqlite_file:BeamSpotOnlineLegacy.db'),
         preLoadConnectionString = cms.untracked.string('sqlite_file:BeamSpotOnlineLegacy.db'),

--- a/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
@@ -40,7 +40,7 @@ process.dqmSaver.runNumber = options.runNumber
 
 #Enable HLT*Mu* filtering to monitor on Muon events
 #OR HLT_Physics* to monitor FEDs in commissioning runs
-if not unitTest:
+if (not unitTest) and (not options.inputFiles):
     process.source.SelectEvents = cms.untracked.vstring("HLT*Mu*","HLT_*Physics*")
 
 # DT reco and DQM sequences

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -60,7 +60,7 @@ process = customise(process)
 process.DQMStore.verbose = 0
 
 
-if not unitTest and not useFileInput :
+if (not unitTest) and (not useFileInput) and (not options.inputFiles):
   if not options.BeamSplashRun :
     process.source.minEventsPerLumi = 100
 

--- a/DQM/Integration/python/clients/hcalreco_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalreco_dqm_sourceclient-live_cfg.py
@@ -67,7 +67,7 @@ process.dqmSaver.runNumber = options.runNumber
 # process.dqmSaverPB.runNumber = options.runNumber
 process = customise(process)
 process.DQMStore.verbose = 0
-if not unitTest and not useFileInput:
+if (not unitTest) and (not useFileInput) and (not options.inputFiles):
   if not options.BeamSplashRun :
     process.source.minEventsPerLumi = 5
 

--- a/DQM/Integration/python/clients/pixellumi_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixellumi_dqm_sourceclient-live_cfg.py
@@ -50,11 +50,11 @@ process.dqmSaver.runNumber = options.runNumber
 # process.dqmSaverPB.tag = "PixelLumi"
 # process.dqmSaverPB.runNumber = options.runNumber
 
-if not unitTest:
+if (not unitTest) and (not options.inputFiles):
     process.source.SelectEvents = cms.untracked.vstring("HLT_ZeroBias*","HLT_L1AlwaysTrue*", "HLT_PAZeroBias*", "HLT_PAL1AlwaysTrue*")
 #if (process.runType.getRunType() == process.runType.hi_run):
 
-if (process.runType.getRunType() == process.runType.cosmic_run and not unitTest):
+if (process.runType.getRunType() == process.runType.cosmic_run and (not unitTest) and (not options.inputFiles)):
     process.source.SelectEvents = ['HLT*SingleMu*']
 
 #----------------------------
@@ -103,7 +103,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.load('Configuration.StandardSequences.RawToDigi_Repacked_cff')
     process.siPixelDigis.InputLabel = "rawDataRepacker"
 
-    if not unitTest:
+    if not unitTest and (not options.inputFiles):
         process.source.SelectEvents = ['HLT_HIL1MinimumBiasHF2AND*']
 
 

--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -245,7 +245,7 @@ process.SiStripMonitorDigi.TotalNumberOfDigisFailure.subdetswitchon = False
 ### COSMIC RUN SETTING
 if (process.runType.getRunType() == process.runType.cosmic_run or process.runType.getRunType() == process.runType.cosmic_run_stage1):
     # event selection for cosmic data
-    if ((process.runType.getRunType() == process.runType.cosmic_run) and live): process.source.SelectEvents = ['HLT*SingleMu*','HLT_L1*']
+    if ((process.runType.getRunType() == process.runType.cosmic_run) and live and (not options.inputFiles)): process.source.SelectEvents = ['HLT*SingleMu*','HLT_L1*']
     # Reference run for cosmic
     # Source config for cosmic data
     process.SiStripSources_TrkReco_cosmic = cms.Sequence(process.SiStripMonitorTrack_ckf*process.TrackMon_ckf)
@@ -304,7 +304,7 @@ if (process.runType.getRunType() == process.runType.cosmic_run or process.runTyp
 ### COMMISSIONING RUN SETTINGS
 if (process.runType.getRunType() == process.runType.commissioning_run):
     #event selection for commissioning runs
-    if ((process.runType.getRunType() == process.runType.commissioning_run) and live):
+    if ((process.runType.getRunType() == process.runType.commissioning_run) and live and (not options.inputFiles)):
         process.source.SelectEvents = ['HLT_*']
 
     process.SiStripFedMonitor = cms.Sequence(process.siStripFEDMonitor)
@@ -318,7 +318,7 @@ if (process.runType.getRunType() == process.runType.commissioning_run):
 ### pp COLLISION SETTING
 if (process.runType.getRunType() == process.runType.pp_run or process.runType.getRunType() == process.runType.pp_run_stage1):
     #event selection for pp collisions
-    if ((process.runType.getRunType() == process.runType.pp_run) and live):
+    if ((process.runType.getRunType() == process.runType.pp_run) and live and (not options.inputFiles)):
         process.source.SelectEvents = [
             'HLT_L1*',
             'HLT_Jet*',
@@ -550,7 +550,7 @@ if process.runType.getRunType() == process.runType.hi_run:
     process.siStripFEDMonitor.RawDataTag = rawDataRepackerLabel
     process.tcdsDigis.InputLabel = rawDataRepackerLabel
 
-    if ((process.runType.getRunType() == process.runType.hi_run) and live):
+    if ((process.runType.getRunType() == process.runType.hi_run) and live and (not options.inputFiles)):
         process.source.SelectEvents = [
 #            'HLT_HICentralityVeto*', # present in 2018 and 2022 HIon menus
             'HLT_HIMinimumBias*',     # replaced HLT_HICentralityVeto starting from the 2023 HIon menu

--- a/DQM/Integration/python/clients/visualization-live_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live_cfg.py
@@ -65,7 +65,7 @@ if unitTest:
 
 process.source = source
 
-if not unitTest:
+if not unitTest and (not options.inputFiles):
     process.source.inputFileTransitionsEachEvent = True
     process.source.skipFirstLumis                = True
     process.source.minEventsPerLumi              = 0


### PR DESCRIPTION
#### PR description:

Title says it all. 
When developing a test for [CMSHLT-3534](https://its.cern.ch/jira/browse/CMSHLT-3534) I realized that certain online client configurations customize the event source as if it was a `DQMStreamerReader` even in the case it which `options.inputFiles` is not null. In that case as per this code here:

https://github.com/cms-sw/cmssw/blob/6a7da0e1aa9caba35aa222c5e6f3437af17be008/DQM/Integration/python/config/inputsource_cfi.py#L125-L132

the source gets changed to a traditional `PoolSource` and the customization doesn't make sense, hence leading to runtime errors.
This PR introduces protections to circumvent the issue.

#### PR validation:

Run successfully the following script in `CMSSW_15_0_12` on a file produced with the `GRun` menu proposed in [CMSHLT-3534](https://its.cern.ch/jira/browse/CMSHLT-3534). 

```bash
#!/bin/bash

echo "starting to run the DQM tests"

cd CMSSW_15_0_12/src/
# Input ROOT file (adjust if needed)
INPUT_FILE="../../testCMSHLT3534_hlt.root"

# Directory containing the DQM client config files
CFG_DIR="DQM/Integration/python/clients"

# List of client config filenames
CLIENTS=(
    beam_dqm_sourceclient-live_cfg.py
    beampixel_dqm_sourceclient-live_cfg.py
    beamspotdip_dqm_sourceclient-live_cfg.py
    csc_dqm_sourceclient-live_cfg.py
    ctpps_dqm_sourceclient-live_cfg.py
    #dt4ml_dqm_sourceclient-live_cfg.py
    dt_dqm_sourceclient-live_cfg.py
    ecal_dqm_sourceclient-live_cfg.py
    es_dqm_sourceclient-live_cfg.py
    fed_dqm_sourceclient-live_cfg.py
    gem_dqm_sourceclient-live_cfg.py
    hcal_dqm_sourceclient-live_cfg.py
    hcalreco_dqm_sourceclient-live_cfg.py
    hlt_dqm_sourceclient-live_cfg.py
    info_dqm_sourceclient-live_cfg.py
    l1tstage2_dqm_sourceclient-live_cfg.py
    l1tstage2emulator_dqm_sourceclient-live_cfg.py
    mutracking_dqm_sourceclient-live_cfg.py
    onlinebeammonitor_dqm_sourceclient-live_cfg.py
    pixel_dqm_sourceclient-live_cfg.py
    pixellumi_dqm_sourceclient-live_cfg.py
    rpc_dqm_sourceclient-live_cfg.py
    sistrip_dqm_sourceclient-live_cfg.py
    visualization-live_cfg.py
)

# Make a logs directory if not present
mkdir -p logs

for client in "${CLIENTS[@]}"; do
    echo "Running $client..."

    LOGFILE="logs/${client%.py}.log"

    cmsRun "$CFG_DIR/$client" inputFiles="$INPUT_FILE" > "$LOGFILE" 2>&1

    if [ $? -ne 0 ]; then
        echo "$client FAILED. Check $CMSSW_BASE/src/$LOGFILE"
    else
        echo "$client completed successfully."
    fi
done
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A