### PR TITLE
HLT:75e33_trackingOnly and a related reference workflow

### DIFF
--- a/Configuration/HLT/python/autoHLT.py
+++ b/Configuration/HLT/python/autoHLT.py
@@ -16,6 +16,7 @@ autoHLT = {
   'relval2025'          : '2025v12',
   'relvalRun4'          : '75e33',
   'relvalRun4_timing'   : '75e33_timing',
+  'relvalRun4_trk'      : '75e33_trackingOnly',
   'relvalRun4_scouting' : 'NGTScouting',    
   'test'                : 'GRun',
 }

--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -54,6 +54,7 @@ The offsets currently in use are:
 * 0.703: LST tracking (Phase-2 only), initialStep+HighPtTripletStep only, on CPU
 * 0.704: LST tracking (Phase-2 only), initialStep+HighPtTripletStep only, on GPU (if available)
 * 0.75: HLT phase-2 timing menu
+* 0.7501: HLT phase-2 tracking-only menu
 * 0.751: HLT phase-2 timing menu Alpaka variant
 * 0.752: HLT phase-2 timing menu ticl_v5 variant
 * 0.753: HLT phase-2 timing menu Alpaka, single tracking iteration variant

--- a/Configuration/PyReleaseValidation/python/relval_Run4.py
+++ b/Configuration/PyReleaseValidation/python/relval_Run4.py
@@ -68,6 +68,7 @@ numWFIB.extend([prefixDet+234.703])  #LST tracking on CPU (initialStep+HighPtTri
 numWFIB.extend([24834.911]) #D98 XML, to monitor instability of DD4hep
 
 # Phase-2 HLT tests
+numWFIB.extend([prefixDet+34.7501])# HLTTrackingOnly75e33
 numWFIB.extend([prefixDet+34.751]) # HLTTiming75e33, alpaka
 numWFIB.extend([prefixDet+34.752]) # HLTTiming75e33, ticl_v5
 numWFIB.extend([prefixDet+34.753]) # HLTTiming75e33, alpaka,singleIterPatatrack

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1890,6 +1890,15 @@ upgradeWFs['HLTTiming75e33Alpaka'].step3 = {
     '-s':'HARVESTING:@hltValidation'
 }
 
+upgradeWFs['HLTTrackingOnly75e33'] = deepcopy(upgradeWFs['HLTTiming75e33'])
+upgradeWFs['HLTTrackingOnly75e33'].suffix = '_HLT75e33TrackingOnly'
+upgradeWFs['HLTTrackingOnly75e33'].offset = 0.7501
+upgradeWFs['HLTTrackingOnly75e33'].step2 = {
+    '-s':'DIGI:pdigi_valid,DIGI2RAW,L1TrackTrigger,L1,L1P2GT,HLT:75e33_trackingOnly,VALIDATION::hltMultiTrackValidation+hltMultiPVValidation',
+    '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
+    '--eventcontent':'FEVTDEBUGHLT,DQMIO'
+}
+
 upgradeWFs['HLTTiming75e33TiclV5'] = deepcopy(upgradeWFs['HLTTiming75e33'])
 upgradeWFs['HLTTiming75e33TiclV5'].suffix = '_HLT75e33TimingTiclV5'
 upgradeWFs['HLTTiming75e33TiclV5'].offset = 0.752

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -153,6 +153,7 @@ if __name__ == '__main__':
         'muonmc' : [5.1, 124.4, 124.5, 20, 21, 22, 23, 25, 30], #MC
 
         'ph2_hlt' : [29634.75,    # HLT phase-2 timing menu
+                     29634.7501,  # HLT phase-2 tracking-only menu
                      29634.751,   # HLT phase-2 timing menu Alpaka variant
                      29634.752,   # HLT phase-2 timing menu ticl_v5 variant
                      29634.753,   # HLT phase-2 timing menu Alpaka, single tracking iteration variant

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/MC_TRK_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/MC_TRK_cfi.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..sequences.HLTHgcalLocalRecoSequence_cfi import *
+from ..sequences.HLTAK4PFPuppiJetsReconstruction_cfi import *
+from ..sequences.HLTBeginSequence_cfi import *
+from ..sequences.HLTBtagDeepCSVSequencePFPuppi_cfi import *
+from ..sequences.HLTBtagDeepFlavourSequencePFPuppi_cfi import *
+from ..sequences.HLTMuonsSequence_cfi import *
+from ..sequences.HLTParticleFlowSequence_cfi import *
+from ..sequences.HLTTrackingSequence_cfi import *
+from ..sequences.HLTLocalrecoSequence_cfi import *
+from ..sequences.HLTRawToDigiSequence_cfi import *
+
+MC_TRK = cms.Path(
+    HLTBeginSequence
+    + HLTTrackingSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/MC_TRK_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/MC_TRK_cfi.py
@@ -1,15 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from ..sequences.HLTHgcalLocalRecoSequence_cfi import *
-from ..sequences.HLTAK4PFPuppiJetsReconstruction_cfi import *
 from ..sequences.HLTBeginSequence_cfi import *
-from ..sequences.HLTBtagDeepCSVSequencePFPuppi_cfi import *
-from ..sequences.HLTBtagDeepFlavourSequencePFPuppi_cfi import *
-from ..sequences.HLTMuonsSequence_cfi import *
-from ..sequences.HLTParticleFlowSequence_cfi import *
 from ..sequences.HLTTrackingSequence_cfi import *
-from ..sequences.HLTLocalrecoSequence_cfi import *
-from ..sequences.HLTRawToDigiSequence_cfi import *
 
 MC_TRK = cms.Path(
     HLTBeginSequence

--- a/HLTrigger/Configuration/python/HLT_75e33_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_cff.py
@@ -134,6 +134,7 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/paths/MC_BTV_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/MC_Ele5_Open_L1Seeded_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/MC_Ele5_Open_Unseeded_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/MC_JME_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/paths/MC_TRK_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/psets/CkfBaseTrajectoryFilter_block_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/psets/ckfBaseTrajectoryFilterP5_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/psets/CkfTrajectoryBuilder_cfi")
@@ -365,6 +366,7 @@ fragment.schedule = cms.Schedule(*[
 
     fragment.MC_JME,
     fragment.MC_BTV,
+    fragment.MC_TRK,
     fragment.MC_Ele5_Open_Unseeded,
     fragment.MC_Ele5_Open_L1Seeded,
 

--- a/HLTrigger/Configuration/python/HLT_75e33_trackingOnly_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_trackingOnly_cff.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+from .HLT_75e33_cff import fragment
+
+fragment.load("HLTrigger/Configuration/HLT_75e33/paths/MC_TRK_cfi")
+
+fragment.schedule = cms.Schedule(*[
+    fragment.MC_TRK,
+    fragment.HLTriggerFinalPath,
+    fragment.HLTAnalyzerEndpath,
+])

--- a/HLTrigger/Configuration/python/HLT_75e33_trackingOnly_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_trackingOnly_cff.py
@@ -2,7 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 from .HLT_75e33_cff import fragment
 
-fragment.load("HLTrigger/Configuration/HLT_75e33/paths/MC_TRK_cfi")
+
+for p in dir(fragment):
+    att = getattr(fragment, p)
+    if isinstance(att, cms.Path) and p not in ["MC_TRK", "HLTriggerFinalPath", "HLTAnalyzerEndpath"]:
+        delattr(fragment, p)
+    del att
 
 fragment.schedule = cms.Schedule(*[
     fragment.MC_TRK,


### PR DESCRIPTION
new `MC_TRK` path with tracking sequence only in phase-2 HLT, is going to be available as a `75e33_trackingOnly` table and as `@relvalRun4_trk` in autoHLT.
A reference workflow is .7501

@VourMa @cms-sw/tracking-pog-l2 

Edit (post-submission): the topic branch name is a misnomer, it's not 15.1.0.pre4 anymore, since I had to rebase