### PR TITLE
Update `ScoutingCollectionMonitor` to allow monitoring of ECal and HCal PF rechits

### DIFF
--- a/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
+++ b/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
@@ -1267,15 +1267,15 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   tk_PV_dxy_hist = ibook.book1DD("tk_PV_dxy", "Track dxy w.r.t. PV; Track dxy w.r.t. PV; Entries", 100, -0.15, 0.15);
 
   ibook.setCurrentFolder(topfoldername_ + "/CaloRecHits");
-  ebRecHitsNumber = ibook.book1D("ebRechitsN", "number of eb RecHits; number of EB recHits; events", 100, 0.0, 1000.0);
-  ebRecHits_energy_hist = ibook.book1D("ebRechits_energy", "Energy spectrum of eb RecHits; Energy of EB recHits; events", 100, 0.0, 1000.0);
-  ebRecHits_time_hist = ibook.book1D("ebRechits_time", "Time of eb RecHits; Energy of EB recHits; events", 100, 0.0, 1000.0);
-  eeRecHitsNumber = ibook.book1D("eeRechitsN", "number of ee RecHits; number of EE recHits; events", 100, 0.0, 1000.0);
-  eeRecHits_energy_hist = ibook.book1D("eeRechits_energy", "Energy spectrum of ee RecHits; Energy of EE recHits; events", 100, 0.0, 1000.0);
-  eeRecHits_time_hist = ibook.book1D("eeRechits_time", "Time of ee RecHits; Energy of EE recHits; events", 100, 0.0, 1000.0);
+  ebRecHitsNumber = ibook.book1D("ebRechitsN", "Number of eb RecHits; number of EB recHits; Entries", 100, 0.0, 1000.0);
+  ebRecHits_energy_hist = ibook.book1D("ebRechits_energy", "Energy spectrum of eb RecHits; Energy of EB recHits (Gev); Entries", 100, 0.0, 500.0);
+  ebRecHits_time_hist = ibook.book1D("ebRechits_time", "Time of eb RecHits; Energy of EB recHits (ps); Entries", 100, 0.0, 1000.0);
+  eeRecHitsNumber = ibook.book1D("eeRechitsN", "Number of ee RecHits; number of EE recHits; Entries", 100, 0.0, 1000.0);
+  eeRecHits_energy_hist = ibook.book1D("eeRechits_energy", "Energy spectrum of ee RecHits; Energy of EE recHits (GeV); Entries", 100, 0.0, 1000.0);
+  eeRecHits_time_hist = ibook.book1D("eeRechits_time", "Time of ee RecHits; Time of EE recHits (ps); Entries", 100, 0.0, 1000.0);
   hbheRecHitsNumber =
-      ibook.book1D("hbheRechitsN", "number of hbhe RecHits; number of HBHE recHits; events", 100, 0.0, 1000.0);
-  hbheRecHits_energy_hist = ibook.book1D("hbheRechits_energy", "Energy spectrum of hbhe RecHits; Energy of HBHE recHits; events", 100, 0.0, 1000.0);
+      ibook.book1D("hbheRechitsN", "number of hbhe RecHits; Number of HBHE recHits; Entries", 100, 0.0, 2000.0);
+  hbheRecHits_energy_hist = ibook.book1D("hbheRechits_energy", "Energy spectrum of hbhe RecHits; Energy of HBHE recHits (GeV); Entries", 100, 0.0, 200.0);
 }
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 

--- a/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
+++ b/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
@@ -1296,9 +1296,9 @@ void ScoutingCollectionMonitor::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<edm::InputTag>("pfMetPhi", edm::InputTag("hltScoutingPFPacker", "pfMetPhi"));
   desc.add<edm::InputTag>("rho", edm::InputTag("hltScoutingPFPacker", "rho"));
   desc.add<edm::InputTag>("onlineMetaDataDigis", edm::InputTag("onlineMetaDataDigis"));
-  desc.add<edm::InputTag>("pfRecHitsEB", edm::InputTag(""));
-  desc.add<edm::InputTag>("pfRecHitsEE", edm::InputTag(""));
-  desc.add<edm::InputTag>("pfRecHitsHBHE", edm::InputTag(""));
+  desc.add<edm::InputTag>("pfRecHitsEB", edm::InputTag("hltScoutingRecHitPacker","EB"));
+  desc.add<edm::InputTag>("pfRecHitsEE", edm::InputTag("hltScoutingRecHitPacker","EE"));
+  desc.add<edm::InputTag>("pfRecHitsHBHE", edm::InputTag("hltScoutingRecHitPacker","HBHE"));
   desc.add<std::string>("topfoldername", "HLT/ScoutingOffline/Miscellaneous");
   descriptions.addWithDefaultLabel(desc);
 }

--- a/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
+++ b/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
@@ -419,6 +419,8 @@ private:
   dqm::reco::MonitorElement* hbheRecHitsNumber_hist;
   dqm::reco::MonitorElement* hbheRecHits_energy_hist;
   dqm::reco::MonitorElement* hbheRecHitsEtaPhiMap;
+  dqm::reco::MonitorElement* hbRecHitsEtaPhiMap;
+  dqm::reco::MonitorElement* heRecHitsEtaPhiMap;
 };
 
 //
@@ -903,6 +905,12 @@ void ScoutingCollectionMonitor::analyze(const edm::Event& iEvent, const edm::Eve
       hbheRecHits_energy_hist->Fill(hbheRecHit.energy());
       HcalDetId hcalid(hbheRecHit.detId());
       hbheRecHitsEtaPhiMap->Fill(hcalid.ieta(), hcalid.iphi());
+      const auto& subdet = hcalid.subdetId();
+      if (subdet == 1) {  // HB
+        hbRecHitsEtaPhiMap->Fill(hcalid.ieta(), hcalid.iphi());
+      } else {  // HE
+        heRecHitsEtaPhiMap->Fill(hcalid.ieta(), hcalid.iphi());
+      }
     }
   }
 }
@@ -1348,7 +1356,7 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
         "eeRechits_time" + sfx, "Time of EE RecHits (" + lbl + "); Time of EE recHits (ps); Entries", 100, 0.0, 1000.0);
 
     ebRecHitsEtaPhiMap[i] = ibook.book2D("ebRecHitsEtaPhitMap" + sfx,
-                                         "Occupancy map of EB rechit (" + lbl + ");ieta;iphi;Entries",
+                                         "Occupancy map of EB rechits (" + lbl + ");ieta;iphi;Entries",
                                          171,
                                          -85.5,
                                          85.5,
@@ -1359,7 +1367,7 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
     ebRecHitsEtaPhiMap[i]->setOption("colz");
 
     eePlusRecHitsXYMap[i] = ibook.book2D("eePlusRecHitsEtaPhitMap" + sfx,
-                                         "Occupancy map of EE+ rechit (" + lbl + ");ix;iy;Entries",
+                                         "Occupancy map of EE+ rechits (" + lbl + ");ix;iy;Entries",
                                          100,
                                          1,
                                          101,
@@ -1370,7 +1378,7 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
     eePlusRecHitsXYMap[i]->setOption("colz");
 
     eeMinusRecHitsXYMap[i] = ibook.book2D("eeMinusRecHitsEtaPhitMap" + sfx,
-                                          "Occupancy map of EE- rechit (" + lbl + ");ix;iy;Entries",
+                                          "Occupancy map of EE- rechits (" + lbl + ");ix;iy;Entries",
                                           100,
                                           1,
                                           101,
@@ -1388,8 +1396,16 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
       "hbheRechits_energy", "Energy spectrum of hbhe RecHits; Energy of HBHE recHits (GeV); Entries", 100, 0.0, 200.0);
 
   hbheRecHitsEtaPhiMap = ibook.book2D(
-      "hbheRecHitsEtaPhitMap", "Occupancy map of HBHE rechit;ieta;iphi;Entries", 61, -30.5, 30.5, 74, -0.5, 73.5);
+      "hbheRecHitsEtaPhitMap", "Occupancy map of HBHE rechits;ieta;iphi;Entries", 61, -30.5, 30.5, 74, -0.5, 73.5);
   hbheRecHitsEtaPhiMap->setOption("colz");
+
+  hbRecHitsEtaPhiMap = ibook.book2D(
+      "hbRecHitsEtaPhitMap", "Occupancy map of HB rechits;ieta;iphi;Entries", 83, -41.5, 41.5, 72, 0.5, 72.5);
+  hbRecHitsEtaPhiMap->setOption("colz");
+
+  heRecHitsEtaPhiMap = ibook.book2D(
+      "heRecHitsEtaPhitMap", "Occupancy map of HE rechits;ieta;iphi;Entries", 83, -41.5, 41.5, 72, 0.5, 72.5);
+  heRecHitsEtaPhiMap->setOption("colz");
 }
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 

--- a/DQM/HLTEvF/python/ScoutingCollectionMonitor_cfi.py
+++ b/DQM/HLTEvF/python/ScoutingCollectionMonitor_cfi.py
@@ -18,7 +18,7 @@ scoutingCollectionMonitor = DQMEDAnalyzer('ScoutingCollectionMonitor',
                                           pfMetPhi               = cms.InputTag("hltScoutingPFPacker","pfMetPhi"),
                                           rho                    = cms.InputTag("hltScoutingPFPacker","rho"),
                                           topfoldername          = cms.string("HLT/ScoutingOffline/Miscellaneous"),
-                                          pfRecHitsEB            = cms.InputTag(""),
-                                          pfRecHitsEE            = cms.InputTag(""),
-                                          pfRecHitsHBHE          = cms.InputTag(""))
+                                          pfRecHitsEB            = cms.InputTag("hltScoutingRecHitPacker", "EB"),
+                                          pfRecHitsEE            = cms.InputTag("hltScoutingRecHitPacker", "EE"),
+                                          pfRecHitsHBHE          = cms.InputTag("hltScoutingRecHitPacker", "HBHE"))
 

--- a/DQM/HLTEvF/python/ScoutingCollectionMonitor_cfi.py
+++ b/DQM/HLTEvF/python/ScoutingCollectionMonitor_cfi.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
 scoutingCollectionMonitor = DQMEDAnalyzer('ScoutingCollectionMonitor',
-                                          onlyScouting = cms.bool(False),
+                                          topfoldername          = cms.string("HLT/ScoutingOffline/Miscellaneous"),
+                                          onlyScouting           = cms.bool(False),
                                           onlineMetaDataDigis    = cms.InputTag("onlineMetaDataDigis"),
                                           muons                  = cms.InputTag("hltScoutingMuonPackerNoVtx"),
                                           muonsVtx               = cms.InputTag("hltScoutingMuonPackerVtx"),
@@ -17,8 +18,9 @@ scoutingCollectionMonitor = DQMEDAnalyzer('ScoutingCollectionMonitor',
                                           pfMetPt                = cms.InputTag("hltScoutingPFPacker","pfMetPt"),
                                           pfMetPhi               = cms.InputTag("hltScoutingPFPacker","pfMetPhi"),
                                           rho                    = cms.InputTag("hltScoutingPFPacker","rho"),
-                                          topfoldername          = cms.string("HLT/ScoutingOffline/Miscellaneous"),
                                           pfRecHitsEB            = cms.InputTag("hltScoutingRecHitPacker", "EB"),
                                           pfRecHitsEE            = cms.InputTag("hltScoutingRecHitPacker", "EE"),
+                                          pfCleanedRecHitsEB     = cms.InputTag("hltScoutingRecHitPacker", "EBCleaned"),
+                                          pfCleanedRecHitsEE     = cms.InputTag("hltScoutingRecHitPacker", "EECleaned"),
                                           pfRecHitsHBHE          = cms.InputTag("hltScoutingRecHitPacker", "HBHE"))
 

--- a/DQM/HLTEvF/python/ScoutingCollectionMonitor_cfi.py
+++ b/DQM/HLTEvF/python/ScoutingCollectionMonitor_cfi.py
@@ -17,6 +17,8 @@ scoutingCollectionMonitor = DQMEDAnalyzer('ScoutingCollectionMonitor',
                                           pfMetPt                = cms.InputTag("hltScoutingPFPacker","pfMetPt"),
                                           pfMetPhi               = cms.InputTag("hltScoutingPFPacker","pfMetPhi"),
                                           rho                    = cms.InputTag("hltScoutingPFPacker","rho"),
-                                          topfoldername          = cms.string("HLT/ScoutingOffline/Miscellaneous")
-                                          )
+                                          topfoldername          = cms.string("HLT/ScoutingOffline/Miscellaneous"),
+                                          pfRecHitsEB            = cms.InputTag(""),
+                                          pfRecHitsEE            = cms.InputTag(""),
+                                          pfRecHitsHBHE          = cms.InputTag(""))
 


### PR DESCRIPTION
#### PR description:

There has been a recent addition of the PF Calo Rechits to the HLT Scouting Event Content for the rest of 2025 data-taking after the deployment of the HLT menu V1.3 (see https://github.com/cms-sw/cmssw/pull/48583). 
In order to properly monitor the new scouting collections both in the `ScoutingPFMonitor` (offline) and in the `DQMOnlineScouting` (online), the class `ScoutingCollectionMonitor` is updated to support monitoring of the several Ecal (cleaned, uncleaned) and Hcal PF rechits collection.
This PR has been developed in collaboration with @jprendi and it's accompanied by a corresponding cms-data PR https://github.com/cms-data/DQM-Integration/pull/12 to include a suitable input file for testing.

#### PR validation:

Used the input files at https://github.com/cms-data/DQM-Integration/pull/12/ by copying them inside the `DQM/Integration/data/run392642` folder and then running:

```
cmsRun DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py runInputDir=DQM/Integration/data/ runNumber=392642 scanOnce=True
```

followed by subsquent inspection of the output histograms.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but it will be backported to CMSSW_15_0_X for 2025 data-taking operations.

FYI: @silviodonato @elfontan @patinkaew 