### PR TITLE
[15_0_X] HCALDQM: Revise of calibration tasks

### DIFF
--- a/DQM/HcalCommon/interface/Constants.h
+++ b/DQM/HcalCommon/interface/Constants.h
@@ -324,6 +324,15 @@ namespace hcaldqm {
       tUnknown = 19,
       nOrbitGapType = 20,
     };
+    enum uHTRType {
+      uUnknown = 0,
+      uPhysics = 1,
+      uPedestal = 2,
+      uLED = 3,
+      uHFRaddam = 4,
+      uLaser = 5,
+      nHTRType = 6,
+    };
   }  // namespace constants
 }  // namespace hcaldqm
 

--- a/DQM/HcalCommon/interface/Utilities.h
+++ b/DQM/HcalCommon/interface/Utilities.h
@@ -194,6 +194,7 @@ namespace hcaldqm {
  *	Orbit Gap Related
  */
     std::string ogtype2string(constants::OrbitGapType type);
+    std::string uhtrtype2string(constants::uHTRType type);
 
     int getRBX(uint32_t iphi);
   }  // namespace utilities

--- a/DQM/HcalCommon/interface/ValueQuantity.h
+++ b/DQM/HcalCommon/interface/ValueQuantity.h
@@ -562,6 +562,50 @@ namespace hcaldqm {
         return new EventType(vtypes);
       }
     };
+
+    class uHTRType : public ValueQuantity {
+    public:
+      uHTRType() {}
+      uHTRType(std::vector<uint32_t> const &vtypes) : ValueQuantity(fN) { this->setup(vtypes); }
+      ~uHTRType() override {}
+
+      virtual void setup(std::vector<uint32_t> const &vtypes) {
+        std::cout << "SIZE = " << vtypes.size() << std::endl;
+        for (uint32_t i = 0; i < vtypes.size(); i++)
+          _types.insert(std::make_pair((uint32_t)vtypes[i], i));
+      }
+      int getValue(int v) override { return _types[(uint32_t)v]; }
+      uint32_t getBin(int v) override { return getValue(v) + 1; }
+
+      int nbins() override { return _types.size(); }
+      double min() override { return 0; }
+      double max() override { return _types.size(); }
+      std::string name() override { return "uHTR Type"; }
+
+    protected:
+      typedef std::unordered_map<uint32_t, int> TypeMap;
+      TypeMap _types;
+
+    public:
+      std::vector<std::string> getLabels() override {
+        std::vector<std::string> labels(_types.size());
+        std::cout << "SIZE = " << _types.size() << std::endl;
+        for (auto const &v : _types) {
+          labels[v.second] = utilities::uhtrtype2string((constants::uHTRType)v.first);
+        }
+        return labels;
+      }
+      uHTRType *makeCopy() override {
+        std::vector<uint32_t> vtypes;
+        for (auto const &p : _types) {
+          vtypes.push_back(p.first);
+        }
+
+        std::sort(vtypes.begin(), vtypes.end());
+        return new uHTRType(vtypes);
+      }
+    };
+
   }  // namespace quantity
 }  // namespace hcaldqm
 

--- a/DQM/HcalCommon/src/Utilities.cc
+++ b/DQM/HcalCommon/src/Utilities.cc
@@ -238,7 +238,24 @@ namespace hcaldqm {
           return "Null";
       }
     }
-
+    std::string uhtrtype2string(uHTRType type) {
+      switch (type) {
+        case uUnknown:
+          return "Unknown";
+        case uPhysics:
+          return "Physics";
+        case uPedestal:
+          return "Pedestal";
+        case uLED:
+          return "LED";
+        case uHFRaddam:
+          return "HFRaddam";
+        case uLaser:
+          return "Laser";
+        default:
+          return "Unknown";
+      }
+    }
     int getRBX(uint32_t iphi) { return (((iphi + 2) % 72) + 4 - 1) / 4; }
 
   }  // namespace utilities

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -23,6 +23,7 @@
 #include "DQM/HcalCommon/interface/ContainerProf2D.h"
 #include "DQM/HcalCommon/interface/ContainerSingle1D.h"
 #include "DQM/HcalCommon/interface/ContainerSingle2D.h"
+#include "DQM/HcalCommon/interface/ContainerSingleProf1D.h"
 #include "DQM/HcalCommon/interface/ContainerSingleProf2D.h"
 #include "DQM/HcalCommon/interface/ContainerXXX.h"
 
@@ -55,7 +56,18 @@ protected:
       _HFSumMeanofSumQForEachEvent;
   //	flag vector
   std::vector<hcaldqm::flag::Flag> _vflags;
-  enum DigiFlag { fDigiSize = 0, fUni = 1, fNChsHF = 2, fUnknownIds = 3, fLED = 4, fCapId = 5, nDigiFlag = 6 };
+  enum DigiFlag {
+    fDigiSize = 0,
+    fUni = 1,
+    fNChsHF = 2,
+    fUnknownIds = 3,
+    fLED = 4,
+    fRADDAM = 5,
+    fLASER = 6,
+    fPinDiode = 7,
+    fCapId = 8,
+    nDigiFlag = 9
+  };
 
   //	hashes/FED vectors
   std::vector<uint32_t> _vhashFEDs;
@@ -191,13 +203,34 @@ protected:
 
   std::map<HcalSubdetector, short> _capidmbx;  // Expected (capid - BX) % 4 for each subdet
 
-  // LED monitoring stuff
+  // CU LED monitoring stuff
   double _thresh_led;
   std::map<HcalSubdetector, std::vector<HcalDetId> > _ledCalibrationChannels;
-
   hcaldqm::Container1D _LED_CUCountvsLS_Subdet;       // Misfire count vs LS
   hcaldqm::Container1D _LED_CUCountvsLSmod60_Subdet;  // Misfire count vs LS
   hcaldqm::Container2D _LED_ADCvsBX_Subdet;           // Pin diode amplitude vs BX
+  hcaldqm::Container2D _LED_ADCvsTS_Subdet;           // Pin diode amplitude vs TS for online DQM
+
+  // CU laser monitoring stuff
+  double _thresh_laser;
+  std::map<HcalSubdetector, std::vector<HcalDetId> > _laserCalibrationChannels;
+  hcaldqm::Container1D _LASER_CUCountvsLS_Subdet;       // Misfire count vs LS
+  hcaldqm::Container1D _LASER_CUCountvsLSmod60_Subdet;  // Misfire count vs LS
+  hcaldqm::Container2D _LASER_ADCvsBX_Subdet;           // Pin diode amplitude vs BX
+  hcaldqm::Container2D _LASER_ADCvsTS_Subdet;           // Pin diode amplitude vs TS for online DQM
+
+  // CU Raddam monitoring stuff
+  double _thresh_raddam;
+  std::map<HcalSubdetector, std::vector<HcalDetId> > _raddamCalibrationChannels;
+  hcaldqm::ContainerSingle1D _Raddam_CUCountvsLS;       // Misfire count vs LS
+  hcaldqm::ContainerSingle1D _Raddam_CUCountvsLSmod60;  // Misfire count vs LS
+  hcaldqm::ContainerSingle2D _Raddam_ADCvsBX;           // Raddam amplitude vs BX
+  hcaldqm::ContainerSingle2D _Raddam_ADCvsTS;           // Raddam amplitude vs TS for online DQM
+
+  // Laser monitoring for pin diode channel (0, 31, 0)
+  hcaldqm::ContainerSingleProf1D _cSumQvsBX_PinDiode;
+  hcaldqm::ContainerSingleProf1D _cSumQvsLS_PinDiode;
+  hcaldqm::ContainerSingle2D _cADCvsTS_PinDiode;
 };
 
 #endif

--- a/DQM/HcalTasks/interface/HFRaddamTask.h
+++ b/DQM/HcalTasks/interface/HFRaddamTask.h
@@ -14,6 +14,7 @@
 #include "DQM/HcalCommon/interface/ContainerProf1D.h"
 #include "DQM/HcalCommon/interface/ContainerProf2D.h"
 #include "DQM/HcalCommon/interface/ContainerSingle1D.h"
+#include "DQM/HcalCommon/interface/ContainerSingle2D.h"
 
 class HFRaddamTask : public hcaldqm::DQTask {
 public:
@@ -31,12 +32,14 @@ protected:
   edm::InputTag _tagHF;
   edm::InputTag _taguMN;
   edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
+  edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDbServiceToken_;
   edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
 
   edm::InputTag _tagFEDs;
   edm::EDGetTokenT<FEDRawDataCollection> _tokFEDs;
 
   uint32_t _laserType;
+  int _nevents;
 
   //	vector of Detector Ids for RadDam
   std::vector<HcalDetId> _vDetIds;
@@ -47,6 +50,11 @@ protected:
 
   //	1D
   std::vector<hcaldqm::ContainerSingle1D> _vcShape;
+
+  // For monitoring CU Raddam firing: ADC vs TS
+  std::map<HcalSubdetector, std::vector<HcalDetId> > _raddamCalibrationChannels;
+  hcaldqm::ContainerSingle2D _Raddam_ADCvsTS;   // Raddam amplitude vs TS for online DQM
+  hcaldqm::ContainerSingle2D _Raddam_ADCvsEvn;  // Raddam amplitude vs Evn for local DQM
 };
 
 #endif

--- a/DQM/HcalTasks/interface/LEDTask.h
+++ b/DQM/HcalTasks/interface/LEDTask.h
@@ -101,9 +101,9 @@ protected:
   hcaldqm::ContainerProf2D _cTDCTime_depth;
   hcaldqm::ContainerSingle2D _cLowSignal_CrateSlot;
 
-  // For monitoring LED firing: ADC vs BX
+  // For monitoring CU LED firing: ADC vs TS
   std::map<HcalSubdetector, std::vector<HcalDetId> > _ledCalibrationChannels;
-  hcaldqm::Container2D _LED_ADCvsBX_Subdet;   // Pin diode amplitude vs BX for online DQM
+  hcaldqm::Container2D _LED_ADCvsTS_Subdet;   // Pin diode amplitude vs TS for online DQM
   hcaldqm::Container2D _LED_ADCvsEvn_Subdet;  // Pin diode amplitude vs Evn for local DQM
 };
 

--- a/DQM/HcalTasks/interface/LaserTask.h
+++ b/DQM/HcalTasks/interface/LaserTask.h
@@ -151,9 +151,16 @@ protected:
   hcaldqm::ContainerProf2D _cTimingDiffLS_SubdetPM;
   hcaldqm::ContainerProf2D _cTimingDiffEvent_SubdetPM;
 
+  hcaldqm::ContainerSingle2D _cLaserMonADC_TS;
+
   //	Summaries
   hcaldqm::Container2D _cSummaryvsLS_FED;
   hcaldqm::ContainerSingle2D _cSummaryvsLS;
+
+  // For monitoring CU laser firing: ADC vs TS
+  std::map<HcalSubdetector, std::vector<HcalDetId>> _laserCalibrationChannels;
+  hcaldqm::Container2D _Laser_ADCvsTS_Subdet;   // Pin diode amplitude vs TS for online DQM
+  hcaldqm::Container2D _Laser_ADCvsEvn_Subdet;  // Pin diode amplitude vs Evn for local DQM
 };
 
 #endif

--- a/DQM/HcalTasks/interface/UMNioTask.h
+++ b/DQM/HcalTasks/interface/UMNioTask.h
@@ -42,8 +42,10 @@ protected:
 
   // Get index of a particular OrbitGapType in the vector, which is used as the value for filling the histogram
   int getOrbitGapIndex(uint8_t eventType, uint32_t laserType);
+  int getUHTRType(uint8_t eventType);
 
   std::vector<uint32_t> _eventtypes;
+  std::vector<uint32_t> _uHTRtypes;
 
   //	tags and tokens
   edm::InputTag taguMN_;
@@ -74,5 +76,7 @@ protected:
   // 1D histograms for uHTR eventType and uMNio eventType
   hcaldqm::ContainerSingle1D _cEventType_uMNio;
   hcaldqm::ContainerSingle1D _cEventType_uHTR;
+  // 2D histogram for UHTRType (analogous to _cEventType)
+  hcaldqm::ContainerSingle2D _cUHTRType;
 };
 #endif

--- a/DQM/HcalTasks/plugins/HFRaddamTask.cc
+++ b/DQM/HcalTasks/plugins/HFRaddamTask.cc
@@ -5,7 +5,8 @@ using namespace hcaldqm;
 using namespace hcaldqm::constants;
 using namespace hcaldqm::filter;
 
-HFRaddamTask::HFRaddamTask(edm::ParameterSet const& ps) : DQTask(ps) {
+HFRaddamTask::HFRaddamTask(edm::ParameterSet const& ps)
+    : DQTask(ps), hcalDbServiceToken_(esConsumes<HcalDbService, HcalDbRecord, edm::Transition::BeginRun>()) {
   //	List all the DetIds
   _vDetIds.push_back(HcalDetId(HcalForward, -30, 35, 1));
   _vDetIds.push_back(HcalDetId(HcalForward, -30, 71, 1));
@@ -75,6 +76,7 @@ HFRaddamTask::HFRaddamTask(edm::ParameterSet const& ps) : DQTask(ps) {
   _tokFEDs = consumes<FEDRawDataCollection>(_tagFEDs);
 
   _laserType = (uint32_t)ps.getUntrackedParameter<uint32_t>("laserType");
+  _nevents = ps.getUntrackedParameter<int>("nevents", 2000);
 }
 
 /* virtual */ void HFRaddamTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
@@ -92,6 +94,67 @@ HFRaddamTask::HFRaddamTask(edm::ParameterSet const& ps) : DQTask(ps) {
     sprintf(aux, "ieta%diphi%dd%d", _vDetIds[i].ieta(), _vDetIds[i].iphi(), _vDetIds[i].depth());
     _vcShape[i].book(ib, _subsystem, aux);
   }
+
+  // Book Raddam monitoring containers
+  if (_ptype == fOnline) {
+    _Raddam_ADCvsTS.initialize(_name + "/CU_Raddam",
+                               "CU_Raddam_ADCvsTS",
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                               0);
+    _Raddam_ADCvsTS.book(ib, _subsystem);
+  } else if (_ptype == fLocal) {
+    _Raddam_ADCvsEvn.initialize(_name + "/CU_Raddam",
+                                "CU_Raddam_ADCvsEvn",
+                                new hcaldqm::quantity::EventNumber(_nevents),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_256_4),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                0);
+    _Raddam_ADCvsEvn.book(ib, _subsystem);
+  }
+
+  // Extract Raddam calibration channels from emap
+  edm::ESHandle<HcalDbService> dbService = es.getHandle(hcalDbServiceToken_);
+  _emap = dbService->getHcalMapping();
+  std::vector<HcalElectronicsId> eids = _emap->allElectronicsId();
+  for (unsigned i = 0; i < eids.size(); i++) {
+    HcalElectronicsId eid = eids[i];
+    DetId id = _emap->lookup(eid);
+    if (HcalGenericDetId(id.rawId()).isHcalCalibDetId()) {
+      HcalCalibDetId calibId(id);
+      if (calibId.calibFlavor() == HcalCalibDetId::CalibrationBox) {
+        auto cUch = calibId.cboxChannel();
+        bool isRAD(false);
+        HcalSubdetector this_subdet = HcalEmpty;
+
+        switch (calibId.hcalSubdet()) {
+          case HcalBarrel:
+            this_subdet = HcalBarrel;
+            break;
+          case HcalEndcap:
+            this_subdet = HcalEndcap;
+            break;
+          case HcalOuter:
+            this_subdet = HcalOuter;
+            break;
+          case HcalForward:
+            this_subdet = HcalForward;
+            if (cUch == 9) {
+              isRAD = true;
+            }
+            break;
+          default:
+            this_subdet = HcalEmpty;
+            break;
+        }
+
+        if (isRAD) {
+          _raddamCalibrationChannels[this_subdet].push_back(HcalDetId(id.rawId()));
+        }
+      }
+    }
+  }
 }
 
 /* virtual */ void HFRaddamTask::_process(edm::Event const& e, edm::EventSetup const& es) {
@@ -104,9 +167,26 @@ HFRaddamTask::HFRaddamTask(edm::ParameterSet const& ps) : DQTask(ps) {
   for (QIE10DigiCollection::const_iterator it = chf->begin(); it != chf->end(); ++it) {
     const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
     HcalDetId const& did = digi.detid();
-    if (did.subdet() != HcalForward)
+    if (did.subdet() != HcalForward) {
+      // Raddam monitoring from calibration channels
+      if (did.subdet() == HcalOther) {
+        HcalOtherDetId hodid(digi.detid());
+        if (hodid.subdet() == HcalCalibration) {
+          if (std::find(_raddamCalibrationChannels[HcalForward].begin(),
+                        _raddamCalibrationChannels[HcalForward].end(),
+                        did) != _raddamCalibrationChannels[HcalForward].end()) {
+            for (int i = 0; i < digi.samples(); i++) {
+              if (_ptype == fOnline) {
+                _Raddam_ADCvsTS.fill(i, digi[i].adc());
+              } else if (_ptype == fLocal) {
+                _Raddam_ADCvsEvn.fill((int)e.eventAuxiliary().id().event(), digi[i].adc());
+              }
+            }
+          }
+        }
+      }
       continue;
-
+    }
     CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE10DataFrame>(_dbService, did, digi);
 
     for (unsigned int i = 0; i < _vDetIds.size(); i++)
@@ -127,9 +207,9 @@ HFRaddamTask::HFRaddamTask(edm::ParameterSet const& ps) : DQTask(ps) {
 
     // Below we are requiring both laser type equals 24 and uHTR event type from crate:slot 22:01 equals 14 to confirm this is a HFRaddam laser signal
     //  laser type check
-    uint32_t laserType = cumn->valueUserWord(0);
-    if (laserType != _laserType)
-      return false;
+    //uint32_t laserType = cumn->valueUserWord(0);
+    //if (laserType != _laserType)
+    //  return false;
 
     // uHTR event type check from crate:slot 22:01 for HF Raddam
     bool eventflag_uHTR = false;
@@ -153,7 +233,7 @@ HFRaddamTask::HFRaddamTask(edm::ParameterSet const& ps) : DQTask(ps) {
       for (int iamc = 0; iamc < hamc13->NAMC(); iamc++) {
         HcalUHTRData uhtr(hamc13->AMCPayload(iamc), hamc13->AMCSize(iamc));
         if (static_cast<int>(uhtr.crateId()) == 22 && static_cast<int>(uhtr.slot()) == 1)
-          if (uhtr.getEventType() == constants::EVENTTYPE_LASER) {
+          if (uhtr.getEventType() == constants::EVENTTYPE_HFRADDAM) {
             eventflag_uHTR = true;
             break;
           }

--- a/DQM/HcalTasks/plugins/LaserTask.cc
+++ b/DQM/HcalTasks/plugins/LaserTask.cc
@@ -65,6 +65,52 @@ LaserTask::LaserTask(edm::ParameterSet const& ps)
   edm::ESHandle<HcalDbService> dbService = es.getHandle(hcalDbServiceToken_);
   _emap = dbService->getHcalMapping();
 
+  // Book laser calibration channels from emap
+  std::vector<HcalElectronicsId> eids = _emap->allElectronicsId();
+  for (unsigned i = 0; i < eids.size(); i++) {
+    HcalElectronicsId eid = eids[i];
+    DetId id = _emap->lookup(eid);
+    if (HcalGenericDetId(id.rawId()).isHcalCalibDetId()) {
+      HcalCalibDetId calibId(id);
+      if (calibId.calibFlavor() == HcalCalibDetId::CalibrationBox) {
+        auto cUch = calibId.cboxChannel();
+        bool isLAS(false);
+        HcalSubdetector this_subdet = HcalEmpty;
+
+        switch (calibId.hcalSubdet()) {
+          case HcalBarrel:
+            this_subdet = HcalBarrel;
+            if (cUch == 2) {
+              isLAS = true;
+            }
+            break;
+          case HcalEndcap:
+            this_subdet = HcalEndcap;
+            if (cUch == 3 || cUch == 5) {
+              isLAS = true;
+            }
+            break;
+          case HcalOuter:
+            this_subdet = HcalOuter;
+            break;
+          case HcalForward:
+            this_subdet = HcalForward;
+            if (cUch == 0 || cUch == 8) {
+              isLAS = true;
+            }
+            break;
+          default:
+            this_subdet = HcalEmpty;
+            break;
+        }
+
+        if (isLAS) {
+          _laserCalibrationChannels[this_subdet].push_back(HcalDetId(id.rawId()));
+        }
+      }
+    }
+  }
+
   std::vector<uint32_t> vhashVME;
   std::vector<uint32_t> vhashuTCA;
   std::vector<uint32_t> vhashC36;
@@ -244,27 +290,33 @@ LaserTask::LaserTask(edm::ParameterSet const& ps)
 
   // LaserMon containers
   if (_ptype == fOnline || _ptype == fLocal) {
-    _cLaserMonSumQ.initialize(_name,
-                              "LaserMonSumQ",
+    _cLaserMonSumQ.initialize(_name + "/LaserMon",
+                              "SumQ",
                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_1000000),
                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
                               0);
     _cLaserMonSumQ.showOverflowX(true);
 
-    _cLaserMonTiming.initialize(_name,
-                                "LaserMonTiming",
+    _cLaserMonTiming.initialize(_name + "/LaserMon",
+                                "Timing",
                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
                                 0);
     _cLaserMonTiming.showOverflowX(true);
 
+    _cLaserMonADC_TS.initialize(_name + "/LaserMon",
+                                "ADCvsTS",
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                0);
     if (_ptype == fOnline) {
-      _cLaserMonSumQ_LS.initialize(_name,
-                                   "LaserMonSumQ_LS",
+      _cLaserMonSumQ_LS.initialize(_name + "/LaserMon",
+                                   "SumQ_LS",
                                    new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_1000000));
-      _cLaserMonTiming_LS.initialize(_name,
-                                     "LaserMonTiming_LS",
+      _cLaserMonTiming_LS.initialize(_name + "/LaserMon",
+                                     "Timing_LS",
                                      new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_100TS));
       _cTimingDiffLS_SubdetPM.initialize(_name,
@@ -276,12 +328,12 @@ LaserTask::LaserTask(edm::ParameterSet const& ps)
                                          0);
       _cTimingDiffLS_SubdetPM.showOverflowY(true);
     } else if (_ptype == fLocal) {
-      _cLaserMonSumQ_Event.initialize(_name,
-                                      "LaserMonSumQ_Event",
+      _cLaserMonSumQ_Event.initialize(_name + "/LaserMon",
+                                      "SumQ_Event",
                                       new hcaldqm::quantity::EventNumber(_nevents),
                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_1000000));
-      _cLaserMonTiming_Event.initialize(_name,
-                                        "LaserMonTiming_Event",
+      _cLaserMonTiming_Event.initialize(_name + "/LaserMon",
+                                        "Timing_Event",
                                         new hcaldqm::quantity::EventNumber(_nevents),
                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_100TS));
       _cTimingDiffEvent_SubdetPM.initialize(_name,
@@ -295,7 +347,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps)
     }
     _cTiming_DigivsLaserMon_SubdetPM.initialize(
         _name,
-        "Timing_DigivsLaserMon",
+        "Timing_DigiMinusLaserMon",
         hcaldqm::hashfunctions::fSubdetPM,
         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250_coarse),
         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250_coarse),
@@ -335,6 +387,25 @@ LaserTask::LaserTask(edm::ParameterSet const& ps)
                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),
                              0);
   }  // End if (_ptype == fOnline || _ptype == fLocal) {
+
+  // Initialize laser firing monitoring histograms
+  if (_ptype == fOnline) {
+    _Laser_ADCvsTS_Subdet.initialize(_name + "/CU_Laser",
+                                     "CU_ADCvsTS",
+                                     hcaldqm::hashfunctions::fSubdet,
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                     0);
+  } else if (_ptype == fLocal) {
+    _Laser_ADCvsEvn_Subdet.initialize(_name + "/CU_Laser",
+                                      "CU_ADCvsEvn",
+                                      hcaldqm::hashfunctions::fSubdet,
+                                      new hcaldqm::quantity::EventNumber(_nevents),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_256_4),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                      0);
+  }
 
   //	BOOK
   _cSignalMean_Subdet.book(ib, _emap, _subsystem);
@@ -379,6 +450,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps)
     _cADCvsTS_SubdetPM.book(ib, _emap, _subsystem);
     _cLaserMonSumQ.book(ib, _subsystem);
     _cLaserMonTiming.book(ib, _subsystem);
+    _cLaserMonADC_TS.book(ib, _subsystem);
     if (_ptype == fOnline) {
       _cLaserMonSumQ_LS.book(ib, _subsystem);
       _cLaserMonTiming_LS.book(ib, _subsystem);
@@ -395,6 +467,13 @@ LaserTask::LaserTask(edm::ParameterSet const& ps)
     _xNChs.book(_emap);
     _cSummaryvsLS_FED.book(ib, _emap, _subsystem);
     _cSummaryvsLS.book(ib, _subsystem);
+  }
+
+  // Book laser firing monitoring histograms
+  if (_ptype == fOnline) {
+    _Laser_ADCvsTS_Subdet.book(ib, _emap, _subsystem);
+  } else if (_ptype == fLocal) {
+    _Laser_ADCvsEvn_Subdet.book(ib, _emap, _subsystem);
   }
 
   _ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
@@ -548,7 +627,13 @@ LaserTask::LaserTask(edm::ParameterSet const& ps)
   QIE11DataFrame laserMonDigi;
   processLaserMon(c_QIE11, laserMonDigi);
 
-  double laserMonSumQ = hcaldqm::utilities::sumQ_v10<QIE11DataFrame>(laserMonDigi, 0, 0, laserMonDigi.samples() - 1);
+  // Calculate minimum of ADC values converted to fC
+  double minAdc2fC = constants::adc2fC[laserMonDigi[0].adc()];
+  for (int i = 1; i < laserMonDigi.samples(); i++) {
+    minAdc2fC = std::min(minAdc2fC, constants::adc2fC[laserMonDigi[i].adc()]);
+  }
+  double laserMonSumQ =
+      hcaldqm::utilities::sumQ_v10<QIE11DataFrame>(laserMonDigi, minAdc2fC, 0, laserMonDigi.samples() - 1);
   double laserMonTiming = 0.;
 
   if (laserMonSumQ > 0.) {
@@ -560,6 +645,9 @@ LaserTask::LaserTask(edm::ParameterSet const& ps)
   if (laserMonSumQ > _laserMonThreshold) {
     _cLaserMonSumQ.fill(laserMonSumQ);
     _cLaserMonTiming.fill(laserMonTiming);
+    for (int i = 0; i < laserMonDigi.samples(); i++) {
+      _cLaserMonADC_TS.fill(i, laserMonDigi[i].adc());
+    }
     if (_ptype == fOnline) {
       _cLaserMonSumQ_LS.fill(_currentLS, laserMonSumQ);
       _cLaserMonTiming_LS.fill(_currentLS, laserMonTiming);
@@ -574,6 +662,35 @@ LaserTask::LaserTask(edm::ParameterSet const& ps)
     const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
     HcalDetId const& did = digi.detid();
     if ((did.subdet() != HcalBarrel) && (did.subdet() != HcalEndcap)) {
+      // Laser monitoring from calibration channels
+      if (did.subdet() == HcalOther) {
+        HcalOtherDetId hodid(digi.detid());
+        if (hodid.subdet() == HcalCalibration) {
+          if (std::find(_laserCalibrationChannels[HcalEndcap].begin(),
+                        _laserCalibrationChannels[HcalEndcap].end(),
+                        did) != _laserCalibrationChannels[HcalEndcap].end()) {
+            for (int i = 0; i < digi.samples(); i++) {
+              if (_ptype == fOnline) {
+                _Laser_ADCvsTS_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), i, digi[i].adc());
+              } else if (_ptype == fLocal) {
+                int currentEvent = e.eventAuxiliary().id().event();
+                _Laser_ADCvsEvn_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), currentEvent, digi[i].adc());
+              }
+            }
+          } else if (std::find(_laserCalibrationChannels[HcalBarrel].begin(),
+                               _laserCalibrationChannels[HcalBarrel].end(),
+                               did) != _laserCalibrationChannels[HcalBarrel].end()) {
+            for (int i = 0; i < digi.samples(); i++) {
+              if (_ptype == fOnline) {
+                _Laser_ADCvsTS_Subdet.fill(HcalDetId(HcalBarrel, 1, 1, 1), i, digi[i].adc());
+              } else if (_ptype == fLocal) {
+                int currentEvent = e.eventAuxiliary().id().event();
+                _Laser_ADCvsEvn_Subdet.fill(HcalDetId(HcalBarrel, 1, 1, 1), currentEvent, digi[i].adc());
+              }
+            }
+          }
+        }
+      }
       continue;
     }
     uint32_t rawid = _ehashmap.lookup(did);
@@ -628,10 +745,31 @@ LaserTask::LaserTask(edm::ParameterSet const& ps)
   }
   for (HODigiCollection::const_iterator it = c_ho->begin(); it != c_ho->end(); ++it) {
     const HODataFrame digi = (const HODataFrame)(*it);
+    HcalDetId did = digi.id();
+    if (did.subdet() != HcalOuter) {
+      // Laser monitoring from calibration channels (HO)
+      if (did.subdet() == HcalOther) {
+        HcalOtherDetId hodid(did);
+        if (hodid.subdet() == HcalCalibration) {
+          if (std::find(_laserCalibrationChannels[HcalOuter].begin(),
+                        _laserCalibrationChannels[HcalOuter].end(),
+                        did) != _laserCalibrationChannels[HcalOuter].end()) {
+            for (int i = 0; i < digi.size(); i++) {
+              if (_ptype == fOnline) {
+                _Laser_ADCvsTS_Subdet.fill(HcalDetId(HcalOuter, 1, 1, 4), i, digi[i].adc());
+              } else if (_ptype == fLocal) {
+                int currentEvent = e.eventAuxiliary().id().event();
+                _Laser_ADCvsEvn_Subdet.fill(HcalDetId(HcalOuter, 1, 1, 4), currentEvent, digi[i].adc());
+              }
+            }
+          }
+        }
+      }
+      continue;
+    }
     double sumQ = hcaldqm::utilities::sumQ<HODataFrame>(digi, 8.5, 0, digi.size() - 1);
     if (sumQ < _lowHO)
       continue;
-    HcalDetId did = digi.id();
     HcalElectronicsId eid = digi.elecId();
 
     double aveTS = hcaldqm::utilities::aveTS<HODataFrame>(digi, 8.5, 0, digi.size() - 1);
@@ -677,6 +815,24 @@ LaserTask::LaserTask(edm::ParameterSet const& ps)
     const QIE10DataFrame digi = (const QIE10DataFrame)(*it);
     HcalDetId did = digi.detid();
     if (did.subdet() != HcalForward) {
+      // Laser monitoring from calibration channels (HF)
+      if (did.subdet() == HcalOther) {
+        HcalOtherDetId hodid(digi.detid());
+        if (hodid.subdet() == HcalCalibration) {
+          if (std::find(_laserCalibrationChannels[HcalForward].begin(),
+                        _laserCalibrationChannels[HcalForward].end(),
+                        did) != _laserCalibrationChannels[HcalForward].end()) {
+            for (int i = 0; i < digi.samples(); i++) {
+              if (_ptype == fOnline) {
+                _Laser_ADCvsTS_Subdet.fill(HcalDetId(HcalForward, 29, 1, 1), i, digi[i].adc());
+              } else if (_ptype == fLocal) {
+                int currentEvent = e.eventAuxiliary().id().event();
+                _Laser_ADCvsEvn_Subdet.fill(HcalDetId(HcalForward, 29, 1, 1), currentEvent, digi[i].adc());
+              }
+            }
+          }
+        }
+      }
       continue;
     }
     HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(did));

--- a/DQM/HcalTasks/python/DigiTask_cfi.py
+++ b/DQM/HcalTasks/python/DigiTask_cfi.py
@@ -30,6 +30,8 @@ digiTask = DQMEDAnalyzer(
 	#	ratio thresholds
 	thresh_unifh = cms.untracked.double(0.2),
 	thresh_led = cms.untracked.double(20),
+    thresh_laser = cms.untracked.double(20),
+	thresh_raddam = cms.untracked.double(20),
 
 	qie10InConditions = cms.untracked.bool(False),
 

--- a/DQM/HcalTasks/python/DigiTask_cfi.py
+++ b/DQM/HcalTasks/python/DigiTask_cfi.py
@@ -30,7 +30,7 @@ digiTask = DQMEDAnalyzer(
 	#	ratio thresholds
 	thresh_unifh = cms.untracked.double(0.2),
 	thresh_led = cms.untracked.double(20),
-    thresh_laser = cms.untracked.double(20),
+    thresh_laser = cms.untracked.double(60),
 	thresh_raddam = cms.untracked.double(20),
 
 	qie10InConditions = cms.untracked.bool(False),

--- a/DQM/HcalTasks/python/HFRaddamTask_cfi.py
+++ b/DQM/HcalTasks/python/HFRaddamTask_cfi.py
@@ -14,6 +14,7 @@ hfRaddamTask = DQMEDAnalyzer(
 	subsystem = cms.untracked.string('HcalCalib'),
 
     laserType = cms.untracked.uint32(0),
+	nevents = cms.untracked.int32(2000),
 
 	#	tags
 	tagHF = cms.untracked.InputTag("hcalDigis"),

--- a/DQM/HcalTasks/python/LEDTask_cfi.py
+++ b/DQM/HcalTasks/python/LEDTask_cfi.py
@@ -16,6 +16,7 @@ ledTask = DQMEDAnalyzer(
 	ptype = cms.untracked.int32(0),
 	mtype = cms.untracked.bool(True),
 	subsystem = cms.untracked.string("HcalCalib"),
+	nevents = cms.untracked.int32(2000),
 
 	#	tags
 	tagHBHE = cms.untracked.InputTag("hcalDigis"),

--- a/DQM/HcalTasks/src/DigiRunSummary.cc
+++ b/DQM/HcalTasks/src/DigiRunSummary.cc
@@ -185,9 +185,9 @@ namespace hcaldqm {
       else
         vtmpflags[fUnknownIds]._state = flag::fGOOD;
 
-      if ((did.subdet() == HcalBarrel) || (did.subdet() == HcalBarrel) || (did.subdet() == HcalBarrel) ||
-          (did.subdet() == HcalBarrel)) {
-        std::string ledHistName = _subsystem + "/" + _taskname + "/LED_CUCountvsLS/Subdet/";
+      if ((did.subdet() == HcalBarrel) || (did.subdet() == HcalEndcap) || (did.subdet() == HcalOuter) ||
+          (did.subdet() == HcalForward)) {
+        std::string ledHistName = _subsystem + "/" + _taskname + "/CU_LED/CU_LED_CUCountvsLS/Subdet/";
         if (did.subdet() == HcalBarrel) {
           ledHistName += "HB";
         } else if (did.subdet() == HcalEndcap) {

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -21,6 +21,7 @@ errorstr     = "### HcalDQM::cfg::ERROR:"
 useOfflineGT = False
 useFileInput = False
 useMap       = False
+usetxtMap    = False
 
 unitTest = False
 if 'unitTest=True' in sys.argv:
@@ -73,6 +74,18 @@ process.load("EventFilter.HcalRawToDigi.HcalRawToDigi_cfi")
 process.load('EventFilter.CastorRawToDigi.CastorRawToDigi_cff')
 process.load("SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff")
 
+if usetxtMap:
+    process.es_ascii = cms.ESSource(
+                'HcalTextCalibrations',
+                input = cms.VPSet(
+                        cms.PSet(
+                                object = cms.string('ElectronicsMap'),
+                                file = cms.FileInPath("ElectronicsMap_Run394200_new.txt")
+                        )
+                )
+        )
+    process.es_prefer = cms.ESPrefer('HcalTextCalibrations', 'es_ascii')
+	
 #-------------------------------------
 #	CMSSW/Hcal non-DQM Related Module Settings
 #	-> runType


### PR DESCRIPTION
#### PR description:

Backport of PR48679. Working together with @akhukhun , we have revised the DQM monitoring of calibration channels.

#### PR validation:

Tested in [private GUI](https://cmsweb.cern.ch/dqm/hcal-online/start?runnr=395298;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=HCALcalib;size=M;root=HcalCalib/HFRaddamTask/CU_Raddam/CU_Raddam_ADCvsTS;focus=HcalCalib/HFRaddamTask/CU_Raddam/CU_Raddam_ADCvsTS/CU_Raddam_ADCvsTS;zoom=yes;) and all plots filled as expected.