### PR TITLE
[GDB] Added unit tests for gdb and running cmsTraceFunction

### DIFF
--- a/Utilities/ReleaseScripts/test/BuildFile.xml
+++ b/Utilities/ReleaseScripts/test/BuildFile.xml
@@ -1,6 +1,12 @@
 <test name="TestSCRAM" command="run.sh"/>
 <test name="SCRAM_TestPass" command="true"/>
 <test name="SCRAM_TestFail" command="! false"/>
+<test name="test-gdb-python" command="gdb/test-gdb-python.sh">
+  <use name="gdb"/>
+</test>
+<test name="test-cmsTraceFunction-setenv" command="gdb/test-cmsTraceFunction-setenv.sh">
+  <use name="gdb"/>
+</test>
 <test name="test-clang-tidy" command="test-clang-tidy.sh">
   <use name="llvm"/>
 </test>

--- a/Utilities/ReleaseScripts/test/gdb/test-cmsTraceFunction-setenv.cpp
+++ b/Utilities/ReleaseScripts/test/gdb/test-cmsTraceFunction-setenv.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+#include <cstdlib>
+#include <stdlib.h>
+
+class ScheduleItems {
+public:
+  ScheduleItems() {}
+  void initMisc();
+};
+
+void ScheduleItems::initMisc() { std::cout << "ScheduleItems::initMisc() called" << std::endl; }
+
+void my_setenv(const char* env, const char* value) {
+  setenv(env, value, 1);
+  std::cout << "setenv() called" << std::endl;
+  std::cout << env << "=" << std::getenv(env) << std::endl;
+}
+
+int main() {
+  my_setenv("FOO", "1");
+  ScheduleItems obj;
+  obj.initMisc();
+  my_setenv("FOO", "2");
+  my_setenv("FOO", "3");
+  return 0;
+}

--- a/Utilities/ReleaseScripts/test/gdb/test-cmsTraceFunction-setenv.sh
+++ b/Utilities/ReleaseScripts/test/gdb/test-cmsTraceFunction-setenv.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -ex
+g++ -o test-cmsTraceFunction-setenv $(dirname $0)/test-cmsTraceFunction-setenv.cpp
+cmsTraceFunction --startAfterFunction ScheduleItems::initMisc setenv ./test-cmsTraceFunction-setenv 2>&1 | grep setenv > setenv.log
+rm -f test-cmsTraceFunction-setenv
+setenv_count=$(grep '^setenv() called' setenv.log | wc -l)
+break_setenv=$(grep 'Breakpoint .* in setenv ()' setenv.log | wc -l)
+if [ ${setenv_count} != 3 ] || [ ${break_setenv} != 2 ] ; then
+  exit 1
+fi

--- a/Utilities/ReleaseScripts/test/gdb/test-gdb-python.sh
+++ b/Utilities/ReleaseScripts/test/gdb/test-gdb-python.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -ex
+gdb_python=$(gdb -q -ex 'python exec("import sys;print(sys.executable)")' -ex quit)
+cmssw_python=$(scram tool tag python3 PYTHON3_BASE)/bin/python
+if [ "${gdb_python}" != "${cmssw_python}" ] ; then
+  echo "python used by GDB and CMSSW are not same"
+  exit 1
+else
+  echo "CMSSW/GDB python OK"
+fi

--- a/Utilities/ReleaseScripts/test/gdb/test-gdb-python.sh
+++ b/Utilities/ReleaseScripts/test/gdb/test-gdb-python.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -ex
 gdb_python=$(gdb -q -ex 'python exec("import sys;print(sys.executable)")' -ex quit)
-cmssw_python=$(scram tool tag python3 PYTHON3_BASE)/bin/python
+cmssw_python=$(scram tool tag python3 PYTHON3_BASE)/bin
+cmssw_python=$(realpath ${cmssw_python})/python
 if [ "${gdb_python}" != "${cmssw_python}" ] ; then
   echo "python used by GDB and CMSSW are not same"
   exit 1


### PR DESCRIPTION
This PR proposes to add couple of unit tests to make sure a working GDB python
- `test-gdb-python` :  This unit test makes sure the python used by GDB is same as the one configured in cmssw. This will work once https://github.com/cms-sw/cmsdist/pull/10009 is merged
-  `test-cmsTraceFunction-setenv` : It run `cmsTraceFunction --startAfterFunction ScheduleItems::initMisc setenv`  to make sure gdp is properly breaking at `setenv` after `ScheduleItems::initMisc` has been called. We can extend it test other options of `cmsTraceFunction`


FYI @makortel 