### PR TITLE
Replace deprecated constants for compression level in `OrbitNanoAODOutputModule`

### DIFF
--- a/L1TriggerScouting/Utilities/plugins/OrbitNanoAODOutputModule.cc
+++ b/L1TriggerScouting/Utilities/plugins/OrbitNanoAODOutputModule.cc
@@ -306,13 +306,13 @@ void OrbitNanoAODOutputModule::openFile(edm::FileBlock const&) {
                                    std::vector<std::string>());
 
   if (m_compressionAlgorithm == std::string("ZLIB")) {
-    m_file->SetCompressionAlgorithm(ROOT::kZLIB);
+    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kZLIB);
   } else if (m_compressionAlgorithm == std::string("LZMA")) {
-    m_file->SetCompressionAlgorithm(ROOT::kLZMA);
+    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kLZMA);
   } else if (m_compressionAlgorithm == std::string("ZSTD")) {
-    m_file->SetCompressionAlgorithm(ROOT::kZSTD);
+    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kZSTD);
   } else if (m_compressionAlgorithm == std::string("LZ4")) {
-    m_file->SetCompressionAlgorithm(ROOT::kLZ4);
+    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kLZ4);
   } else {
     throw cms::Exception("Configuration")
         << "OrbitNanoAODOutputModule configured with unknown compression algorithm '" << m_compressionAlgorithm << "'\n"


### PR DESCRIPTION
#### PR description:

The newly added (https://github.com/cms-sw/cmssw/pull/48163) `OrbitNanoAODOutputModule` failed to compile against ROOT master in https://github.com/cms-sw/root/pull/222#issuecomment-3176437336. This PR repeats https://github.com/cms-sw/cmssw/pull/46635 for that code.

Resolves https://github.com/cms-sw/framework-team/issues/1524

#### PR validation:

None