### PR TITLE
miscellaneous updates to `hltPhase2UpgradeIntegrationTests`

### DIFF
--- a/HLTrigger/Configuration/scripts/hltPhase2UpgradeIntegrationTests
+++ b/HLTrigger/Configuration/scripts/hltPhase2UpgradeIntegrationTests
@@ -158,7 +158,7 @@ subprocess.run(base_cmsdriver_command, shell=True, cwd=output_dir)
 # Step 2: Use edmConfigDump to dump the full configuration
 print(f"Dumping the full configuration using edmConfigDump to {dumped_config_file}")
 with open(dumped_config_file, "w") as dump_file, open(log_file, "w") as log:
-    subprocess.run(f"edmConfigDump {base_config_file}", shell=True, stdout=dump_file, stderr=log)
+    subprocess.run(f"edmConfigDump --prune {base_config_file}", shell=True, stdout=dump_file, stderr=log)
 
 # Step 3: Extract the list of HLT paths from the dumped configuration
 print(f"Extracting HLT paths from {dumped_config_file}...")
@@ -168,7 +168,7 @@ with open(dumped_config_file, "r") as f:
     config_content = f.read()
 
 # Use regex to find all HLT and L1T paths defined in process.schedule
-unsorted_hlt_paths = re.findall(r"process\.(HLT_[A-Za-z0-9_]+|L1T_[A-Za-z0-9_]+|DST_[A-Za-z0-9_]+)", config_content)
+unsorted_hlt_paths = re.findall(r"process\.(HLT_[A-Za-z0-9_]+|L1T_[A-Za-z0-9_]+|DST_[A-Za-z0-9_]+|MC_[A-Za-z0-9_]+)", config_content)
 
 # Remove duplicates and sort alphabetically
 hlt_paths = sorted(set(unsorted_hlt_paths))
@@ -228,7 +228,7 @@ for path_name in hlt_paths:
     def replace_hlt_paths(match):
         all_paths = match.group(2).split(", ")
         # Keep non-HLT/L1T paths and include only the current HLT or L1T path
-        filtered_paths = [path for path in all_paths if not re.match(r"process\.(HLT_|L1T_)", path) or f"process.{path_name}" in path]
+        filtered_paths = [path for path in all_paths if not re.match(r"process\.(HLT_|L1T_|DST_|MC_)", path) or f"process.{path_name}" in path]
         return match.group(1) + ", ".join(filtered_paths) + match.group(3)
 
     # Apply the regex to remove all HLT and L1T paths except the current one
@@ -332,7 +332,10 @@ print("All cmsRun jobs submitted.")
 # Step 9: Compare all HLT root files using hltDiff
 def compare_hlt_results(input_dir, num_events, max_workers=4):
     # List all root files starting with "HLT_" or "L1T_" in the output directory
-    root_files = [f for f in os.listdir(input_dir) if f.endswith(".root") and (f.startswith("HLT_") or f.startswith("L1T_"))]
+    root_files = [f for f in os.listdir(input_dir) if f.endswith(".root") and (f.startswith("HLT_") \
+                                                                               or f.startswith("L1T_") \
+                                                                               or f.startswith("DST_") \
+                                                                               or f.startswith("MC_"))]
 
     # Base file (hltrun output) to compare against
     base_root_file = os.path.join(input_dir, "hlt.root")


### PR DESCRIPTION
#### PR description:

Title says it all.
- use `--prune` for `edmConfigDump` (see https://github.com/cms-sw/cmssw/pull/48706#discussion_r2267520688)
- accept also DST_* and MC_* paths

#### PR validation:

Run successfully:

```
hltPhase2UpgradeIntegrationTests --menu 75e33 --cachedInput /store/relval/CMSSW_15_1_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_150X_mcRun4_realistic_v1_STD_Run4D110_PU-v1/2580000/012dcc7c-fc39-45ad-b603-7cb987156456.root --parallelJobs 4
```

and

```
hltPhase2UpgradeIntegrationTests --menu NGTScouting --cachedInput /store/relval/CMSSW_15_1_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_150X_mcRun4_realistic_v1_STD_Run4D110_PU-v1/2580000/012dcc7c-fc39-45ad-b603-7cb987156456.root --parallelJobs 4
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A