### PR TITLE
Alpaka math vector

### DIFF
--- a/HeterogeneousCore/AlpakaMath/interface/Vector.h
+++ b/HeterogeneousCore/AlpakaMath/interface/Vector.h
@@ -32,7 +32,7 @@ namespace cms::alpakatools::math {
 
     template <typename... U,
               typename = std::enable_if_t<(sizeof...(U) == maxSize) and (std::conjunction_v<std::is_same<T, U>...>)>>
-    constexpr Vector(U... args) : m_data{args...}{}
+    constexpr Vector(U... args) : m_data{args...} {}
 
     Vector(const Vector<T, maxSize> &) = default;
     Vector(Vector<T, maxSize> &&) = default;
@@ -135,7 +135,7 @@ namespace cms::alpakatools::math {
   }
 
   template <typename U, typename T, int N>
-  requires std::convertible_to<U, typename Vector<T, N>::value_type>
+    requires std::convertible_to<U, typename Vector<T, N>::value_type>
   inline constexpr Vector<T, N> scale(const U a, const Vector<T, N> &x) {
     Vector<T, N> res;
 
@@ -159,7 +159,7 @@ namespace cms::alpakatools::math {
     return res;
   }
 
-  template <typename T, int N>	  
+  template <typename T, int N>
   inline constexpr Vector<T, N> sub(const Vector<T, N> &x, const Vector<T, N> &y) {
     Vector<T, N> res;
 
@@ -172,7 +172,7 @@ namespace cms::alpakatools::math {
   }
 
   template <typename U, typename T, int N>
-  requires std::convertible_to<U, typename Vector<T, N>::value_type>	  
+    requires std::convertible_to<U, typename Vector<T, N>::value_type>
   inline constexpr Vector<T, N> axpy(const U a, const Vector<T, N> &x, const Vector<T, N> &y) {
     Vector<T, N> res;
 

--- a/HeterogeneousCore/AlpakaMath/interface/Vector.h
+++ b/HeterogeneousCore/AlpakaMath/interface/Vector.h
@@ -1,0 +1,302 @@
+#ifndef HeterogeneousCore_AlpakaMath_interface_Vector_h
+#define HeterogeneousCore_AlpakaMath_interface_Vector_h
+
+// Modified and extended version based on VecArray (author: Felice Pantaleo, CERN)
+// Author: Alexei Strelchenko, FNAL
+//
+
+#include <utility>
+#include <type_traits>
+
+#include <alpaka/alpaka.hpp>
+
+#include "FWCore/Utilities/interface/CMSUnrollLoop.h"
+
+namespace cms::alpakatools::math {
+
+  template <typename T>
+  constexpr std::enable_if_t<std::is_arithmetic_v<T>, T> zero() {
+    return static_cast<T>(0);
+  }
+
+  template <typename T, typename U>
+  constexpr std::enable_if_t<std::is_arithmetic_v<T> and std::is_arithmetic_v<U>, T> set(U x) {
+    return static_cast<T>(x);
+  }
+
+  template <class T, int maxSize>
+  class Vector {
+  public:
+    // same notations as std::vector/array
+    using value_type = T;
+    static constexpr int N = maxSize;
+
+    constexpr int push_back_unsafe(const T &element) {
+      if (m_size < maxSize) {
+        const auto prev_size = m_size;
+        m_data[m_size] = element;
+        m_size += 1;
+        return prev_size;
+      } 
+      return -1;
+    }
+
+    template <class... Ts>
+    constexpr int emplace_back_unsafe(Ts &&...args) {
+      if (m_size < maxSize) {
+        const auto prev_size = m_size;
+        m_data[m_size] = T(std::forward<Ts>(args)...);
+        m_size += 1;
+        return prev_size;
+      } 
+      return -1;
+    }
+
+    constexpr T const &back() const {
+      assert(m_size > 0 && "Vector::back() on empty vector");
+      return m_data[m_size - 1];
+    }
+
+    constexpr T &back() {
+      assert(m_size > 0 && "Vector::back() on empty vector");
+      return m_data[m_size - 1];
+    }
+
+    // thread-safe version of the vector, when used in a kernel
+    template <typename TAcc>
+    ALPAKA_FN_ACC int push_back(const TAcc &acc, const T &element) {
+      const auto previousSize = alpaka::atomicAdd(acc, &m_size, 1, alpaka::hierarchy::Blocks{});
+      if (previousSize < maxSize) {
+        m_data[previousSize] = element;
+        return previousSize;
+      } else {
+        alpaka::atomicSub(acc, &m_size, 1, alpaka::hierarchy::Blocks{});
+        return -1;
+      }
+    }
+
+    template <typename TAcc, class... Ts>
+    ALPAKA_FN_ACC int emplace_back(const TAcc &acc, Ts &&...args) {
+      const auto previousSize = alpaka::atomicAdd(acc, &m_size, 1, alpaka::hierarchy::Blocks{});
+      if (previousSize < maxSize) {
+        m_data[previousSize] = T(std::forward<Ts>(args)...);
+        return previousSize;
+      } else {
+        alpaka::atomicSub(acc, &m_size, 1, alpaka::hierarchy::Blocks{});
+        return -1;
+      }
+    }
+
+    constexpr T pop_back() {
+      if (m_size > 0) {
+        auto previousSize = m_size--;
+        return m_data[previousSize - 1];
+      } else
+        return T();
+    }
+
+    constexpr Vector() : m_data{}, m_size(maxSize) { };
+
+    constexpr explicit Vector(const T &value) : m_data{}, m_size(maxSize) {
+      CMS_UNROLL_LOOP
+      for (int i = 0; i < maxSize; i++) {
+        m_data[i] = value;
+      }
+    }
+
+    template<typename... U, typename = std::enable_if_t<(sizeof...(U) == maxSize) and (std::conjunction_v<std::is_same<T, U>...>)>>
+    constexpr Vector(U... args) : m_data{ args... }, m_size(sizeof...(U)) {}
+
+    Vector(const Vector<T, maxSize> &) = default;
+    Vector(Vector<T, maxSize> &&) = default;
+
+    Vector<T, maxSize> &operator=(const Vector<T, maxSize> &) = default;
+    Vector<T, maxSize> &operator=(Vector<T, maxSize> &&) = default;
+
+    constexpr T const *begin() const { return m_data; }
+    constexpr T const *end() const { return m_data + m_size; }
+    constexpr T *begin() { return m_data; }
+    constexpr T *end() { return m_data + m_size; }
+    constexpr int size() const { return m_size; }
+    constexpr T &operator[](int i) { return m_data[i]; }
+    constexpr const T &operator[](int i) const { return m_data[i]; }
+    constexpr void reset() { m_size = 0; }
+    static constexpr int capacity() { return maxSize; }
+    constexpr T const *data() const { return m_data; }
+    constexpr void resize(int size) { m_size = size; }
+    constexpr bool empty() const { return 0 == m_size; }
+    constexpr bool full() const { return maxSize == m_size; }
+
+    constexpr void zero() {
+      CMS_UNROLL_LOOP
+      for (int i = 0; i < maxSize; i++)
+        m_data[i] = zero<T>();
+    }
+
+    constexpr T norm2() const {
+      T res{0};	    
+      CMS_UNROLL_LOOP
+      for (int i = 0; i < maxSize; i++) {
+        res += m_data[i]*m_data[i];
+      }
+      return res;
+    }
+
+
+    template<unsigned int n>
+    constexpr T partial_norm2() const {
+      constexpr int reduced_size = n > maxSize ? maxSize : n;
+
+      T res{0};
+      CMS_UNROLL_LOOP
+      for (int i = 0; i < reduced_size; i++) {
+        res += m_data[i]*m_data[i];
+      }
+
+      return res;
+    }
+    
+    constexpr Vector<T, maxSize>& operator*=(const T& scale) {
+      CMS_UNROLL_LOOP
+      for (int i = 0; i < maxSize; ++i) {
+        m_data[i] *= scale;
+      }
+      return *this;
+    }
+
+    constexpr Vector<T, maxSize>& operator+=(const Vector<T, maxSize>& rhs) {
+      CMS_UNROLL_LOOP
+      for (int i = 0; i < maxSize; ++i) {
+        m_data[i] += rhs[i];
+      }
+      return *this;
+    }    
+
+    template <typename TAcc >
+    ALPAKA_FN_ACC T norm( const TAcc &acc ) const {
+      const T nrm2 = norm2();
+      return alpaka::math::sqrt(acc, nrm2);
+    }    
+
+    template <typename TAcc, unsigned int n >
+    ALPAKA_FN_ACC T partial_norm( const TAcc &acc) const {
+
+      const T partial_nrm2 = partial_norm2<n>();
+      return alpaka::math::sqrt(acc, partial_nrm2);
+    }
+
+    template <typename TAcc>
+    ALPAKA_FN_ACC void normalize( const TAcc &acc) const {
+
+      const T nrm = norm(acc);
+
+      if (nrm == static_cast<T>(0)) return;
+
+      CMS_UNROLL_LOOP
+      for (int i = 0; i < maxSize; i++) {
+        m_data[i] /= nrm;
+      }
+    }
+
+  private:
+    T m_data[maxSize];
+
+    int m_size;
+  };
+
+  template <typename T>
+  struct is_Vector : std::false_type {};
+
+  template <typename T, int N>
+  struct is_Vector<cms::alpakatools::math::Vector<T, N>> : std::true_type {};
+
+  template <typename T>
+  inline constexpr bool is_Vector_v = is_Vector<T>::value;
+
+  template <typename VectorN, std::enable_if_t<is_Vector_v<VectorN>, int> = 0>
+  inline constexpr VectorN zero(){
+    VectorN res;
+
+    CMS_UNROLL_LOOP
+    for (int i = 0; i < VectorN::N; i++) {
+      res[i] = zero<typename VectorN::value_type>();
+    }
+
+    return res;
+  } 
+
+  template <typename VectorN, std::enable_if_t<is_Vector_v<VectorN>, int> = 0>
+  inline constexpr VectorN ax(const typename VectorN::value_type a, const VectorN& x){
+    VectorN res;
+
+    CMS_UNROLL_LOOP
+    for (int i = 0; i < x.size(); i++) {
+      res[i] = a*x[i];
+    }
+
+    return res;
+  }  
+
+  template <typename VectorN, std::enable_if_t<is_Vector_v<VectorN>, int> = 0>
+  inline constexpr VectorN xpy( const VectorN& x, const VectorN& y ){
+    VectorN res;
+
+    CMS_UNROLL_LOOP
+    for (int i = 0; i < x.size(); i++) {
+      res[i] = x[i] + y[i];
+    }
+
+    return res;
+  }
+
+  template <typename VectorN, std::enable_if_t<is_Vector_v<VectorN>, int> = 0>
+  inline constexpr VectorN xmy( const VectorN& x, const VectorN& y ){
+    VectorN res;
+
+    CMS_UNROLL_LOOP
+    for (int i = 0; i < x.size(); i++) {
+      res[i] = x[i] - y[i];
+    }
+
+    return res;
+  }
+
+  template <typename VectorN, std::enable_if_t<is_Vector_v<VectorN>, int> = 0>
+  inline constexpr VectorN axpy( const typename VectorN::value_type a, const VectorN& x, const VectorN& y ){
+    VectorN res;
+
+    CMS_UNROLL_LOOP
+    for (int i = 0; i < x.size(); i++) {
+      res[i] = a * x[i] + y[i];
+    }
+
+    return res;
+  }
+
+  template <typename VectorN, std::enable_if_t<is_Vector_v<VectorN>, int> = 0>
+  inline constexpr VectorN::value_type dot( const VectorN& x, const VectorN& y ){
+    typename VectorN::value_type res{0};
+
+    CMS_UNROLL_LOOP
+    for (int i = 0; i < x.size(); i++) {
+      res += x[i] * y[i];
+    }
+
+    return res;
+  }  
+
+  template <typename VectorN, std::enable_if_t<is_Vector_v<VectorN>, int> = 0>
+  inline constexpr VectorN::value_type diff2( const VectorN& x, const VectorN& y ){
+    typename VectorN::value_type res{0};
+
+    CMS_UNROLL_LOOP
+    for (int i = 0; i < x.size(); i++) {
+      const typename VectorN::value_type tmp = x[i] - y[i];
+      res += tmp*tmp;
+    }
+    return res;
+  }
+
+}  // namespace cms::alpakatools::math
+
+#endif  // HeterogeneousCore_AlpakaMath_interface_Vector_h

--- a/HeterogeneousCore/AlpakaMath/interface/Vector.h
+++ b/HeterogeneousCore/AlpakaMath/interface/Vector.h
@@ -15,12 +15,12 @@
 namespace cms::alpakatools::math {
 
   template <typename T>
-  constexpr std::enable_if_t<std::is_arithmetic_v<T>, T> zero() {
+  constexpr std::enable_if_t<std::is_arithmetic_v<T>, T> zero_() {
     return static_cast<T>(0);
   }
 
   template <typename T, typename U>
-  constexpr std::enable_if_t<std::is_arithmetic_v<T> and std::is_arithmetic_v<U>, T> set(U x) {
+  constexpr std::enable_if_t<std::is_arithmetic_v<T> and std::is_arithmetic_v<U>, T> set_(U x) {
     return static_cast<T>(x);
   }
 
@@ -130,7 +130,7 @@ namespace cms::alpakatools::math {
     constexpr void zero() {
       CMS_UNROLL_LOOP
       for (int i = 0; i < maxSize; i++)
-        m_data[i] = zero<T>();
+        m_data[i] = zero_<T>();
     }
 
     constexpr T norm2() const {
@@ -186,7 +186,7 @@ namespace cms::alpakatools::math {
     }
 
     template <typename TAcc>
-    ALPAKA_FN_ACC void normalize( const TAcc &acc) const {
+    ALPAKA_FN_ACC void normalize( const TAcc &acc) {
 
       const T nrm = norm(acc);
 
@@ -230,7 +230,7 @@ namespace cms::alpakatools::math {
     VectorN res;
 
     CMS_UNROLL_LOOP
-    for (int i = 0; i < x.size(); i++) {
+    for (int i = 0; i < VectorN::N; i++) {
       res[i] = a*x[i];
     }
 
@@ -242,7 +242,7 @@ namespace cms::alpakatools::math {
     VectorN res;
 
     CMS_UNROLL_LOOP
-    for (int i = 0; i < x.size(); i++) {
+    for (int i = 0; i < VectorN::N; i++) {
       res[i] = x[i] + y[i];
     }
 
@@ -254,7 +254,7 @@ namespace cms::alpakatools::math {
     VectorN res;
 
     CMS_UNROLL_LOOP
-    for (int i = 0; i < x.size(); i++) {
+    for (int i = 0; i < VectorN::N; i++) {
       res[i] = x[i] - y[i];
     }
 
@@ -266,7 +266,7 @@ namespace cms::alpakatools::math {
     VectorN res;
 
     CMS_UNROLL_LOOP
-    for (int i = 0; i < x.size(); i++) {
+    for (int i = 0; i < VectorN::N; i++) {
       res[i] = a * x[i] + y[i];
     }
 
@@ -278,7 +278,7 @@ namespace cms::alpakatools::math {
     typename VectorN::value_type res{0};
 
     CMS_UNROLL_LOOP
-    for (int i = 0; i < x.size(); i++) {
+    for (int i = 0; i < VectorN::N; i++) {
       res += x[i] * y[i];
     }
 
@@ -290,7 +290,7 @@ namespace cms::alpakatools::math {
     typename VectorN::value_type res{0};
 
     CMS_UNROLL_LOOP
-    for (int i = 0; i < x.size(); i++) {
+    for (int i = 0; i < VectorN::N; i++) {
       const typename VectorN::value_type tmp = x[i] - y[i];
       res += tmp*tmp;
     }

--- a/HeterogeneousCore/AlpakaMath/interface/Vector.h
+++ b/HeterogeneousCore/AlpakaMath/interface/Vector.h
@@ -37,7 +37,7 @@ namespace cms::alpakatools::math {
         m_data[m_size] = element;
         m_size += 1;
         return prev_size;
-      } 
+      }
       return -1;
     }
 
@@ -48,7 +48,7 @@ namespace cms::alpakatools::math {
         m_data[m_size] = T(std::forward<Ts>(args)...);
         m_size += 1;
         return prev_size;
-      } 
+      }
       return -1;
     }
 
@@ -95,7 +95,7 @@ namespace cms::alpakatools::math {
         return T();
     }
 
-    constexpr Vector() : m_data{}, m_size(maxSize) { };
+    constexpr Vector() : m_data{}, m_size(maxSize) {};
 
     constexpr explicit Vector(const T &value) : m_data{}, m_size(maxSize) {
       CMS_UNROLL_LOOP
@@ -104,8 +104,9 @@ namespace cms::alpakatools::math {
       }
     }
 
-    template<typename... U, typename = std::enable_if_t<(sizeof...(U) == maxSize) and (std::conjunction_v<std::is_same<T, U>...>)>>
-    constexpr Vector(U... args) : m_data{ args... }, m_size(sizeof...(U)) {}
+    template <typename... U,
+              typename = std::enable_if_t<(sizeof...(U) == maxSize) and (std::conjunction_v<std::is_same<T, U>...>)>>
+    constexpr Vector(U... args) : m_data{args...}, m_size(sizeof...(U)) {}
 
     Vector(const Vector<T, maxSize> &) = default;
     Vector(Vector<T, maxSize> &&) = default;
@@ -134,29 +135,28 @@ namespace cms::alpakatools::math {
     }
 
     constexpr T norm2() const {
-      T res{0};	    
+      T res{0};
       CMS_UNROLL_LOOP
       for (int i = 0; i < maxSize; i++) {
-        res += m_data[i]*m_data[i];
+        res += m_data[i] * m_data[i];
       }
       return res;
     }
 
-
-    template<unsigned int n>
+    template <unsigned int n>
     constexpr T partial_norm2() const {
       constexpr int reduced_size = n > maxSize ? maxSize : n;
 
       T res{0};
       CMS_UNROLL_LOOP
       for (int i = 0; i < reduced_size; i++) {
-        res += m_data[i]*m_data[i];
+        res += m_data[i] * m_data[i];
       }
 
       return res;
     }
-    
-    constexpr Vector<T, maxSize>& operator*=(const T& scale) {
+
+    constexpr Vector<T, maxSize> &operator*=(const T &scale) {
       CMS_UNROLL_LOOP
       for (int i = 0; i < maxSize; ++i) {
         m_data[i] *= scale;
@@ -164,33 +164,32 @@ namespace cms::alpakatools::math {
       return *this;
     }
 
-    constexpr Vector<T, maxSize>& operator+=(const Vector<T, maxSize>& rhs) {
+    constexpr Vector<T, maxSize> &operator+=(const Vector<T, maxSize> &rhs) {
       CMS_UNROLL_LOOP
       for (int i = 0; i < maxSize; ++i) {
         m_data[i] += rhs[i];
       }
       return *this;
-    }    
+    }
 
-    template <typename TAcc >
-    ALPAKA_FN_ACC T norm( const TAcc &acc ) const {
+    template <typename TAcc>
+    ALPAKA_FN_ACC T norm(const TAcc &acc) const {
       const T nrm2 = norm2();
       return alpaka::math::sqrt(acc, nrm2);
-    }    
+    }
 
-    template <typename TAcc, unsigned int n >
-    ALPAKA_FN_ACC T partial_norm( const TAcc &acc) const {
-
+    template <typename TAcc, unsigned int n>
+    ALPAKA_FN_ACC T partial_norm(const TAcc &acc) const {
       const T partial_nrm2 = partial_norm2<n>();
       return alpaka::math::sqrt(acc, partial_nrm2);
     }
 
     template <typename TAcc>
-    ALPAKA_FN_ACC void normalize( const TAcc &acc) {
-
+    ALPAKA_FN_ACC void normalize(const TAcc &acc) {
       const T nrm = norm(acc);
 
-      if (nrm == static_cast<T>(0)) return;
+      if (nrm == static_cast<T>(0))
+        return;
 
       CMS_UNROLL_LOOP
       for (int i = 0; i < maxSize; i++) {
@@ -214,7 +213,7 @@ namespace cms::alpakatools::math {
   inline constexpr bool is_Vector_v = is_Vector<T>::value;
 
   template <typename VectorN, std::enable_if_t<is_Vector_v<VectorN>, int> = 0>
-  inline constexpr VectorN zero(){
+  inline constexpr VectorN zero() {
     VectorN res;
 
     CMS_UNROLL_LOOP
@@ -223,22 +222,22 @@ namespace cms::alpakatools::math {
     }
 
     return res;
-  } 
+  }
 
   template <typename VectorN, std::enable_if_t<is_Vector_v<VectorN>, int> = 0>
-  inline constexpr VectorN ax(const typename VectorN::value_type a, const VectorN& x){
+  inline constexpr VectorN ax(const typename VectorN::value_type a, const VectorN &x) {
     VectorN res;
 
     CMS_UNROLL_LOOP
     for (int i = 0; i < VectorN::N; i++) {
-      res[i] = a*x[i];
+      res[i] = a * x[i];
     }
 
     return res;
-  }  
+  }
 
   template <typename VectorN, std::enable_if_t<is_Vector_v<VectorN>, int> = 0>
-  inline constexpr VectorN xpy( const VectorN& x, const VectorN& y ){
+  inline constexpr VectorN xpy(const VectorN &x, const VectorN &y) {
     VectorN res;
 
     CMS_UNROLL_LOOP
@@ -250,7 +249,7 @@ namespace cms::alpakatools::math {
   }
 
   template <typename VectorN, std::enable_if_t<is_Vector_v<VectorN>, int> = 0>
-  inline constexpr VectorN xmy( const VectorN& x, const VectorN& y ){
+  inline constexpr VectorN xmy(const VectorN &x, const VectorN &y) {
     VectorN res;
 
     CMS_UNROLL_LOOP
@@ -262,7 +261,7 @@ namespace cms::alpakatools::math {
   }
 
   template <typename VectorN, std::enable_if_t<is_Vector_v<VectorN>, int> = 0>
-  inline constexpr VectorN axpy( const typename VectorN::value_type a, const VectorN& x, const VectorN& y ){
+  inline constexpr VectorN axpy(const typename VectorN::value_type a, const VectorN &x, const VectorN &y) {
     VectorN res;
 
     CMS_UNROLL_LOOP
@@ -274,7 +273,7 @@ namespace cms::alpakatools::math {
   }
 
   template <typename VectorN, std::enable_if_t<is_Vector_v<VectorN>, int> = 0>
-  inline constexpr VectorN::value_type dot( const VectorN& x, const VectorN& y ){
+  inline constexpr VectorN::value_type dot(const VectorN &x, const VectorN &y) {
     typename VectorN::value_type res{0};
 
     CMS_UNROLL_LOOP
@@ -283,16 +282,16 @@ namespace cms::alpakatools::math {
     }
 
     return res;
-  }  
+  }
 
   template <typename VectorN, std::enable_if_t<is_Vector_v<VectorN>, int> = 0>
-  inline constexpr VectorN::value_type diff2( const VectorN& x, const VectorN& y ){
+  inline constexpr VectorN::value_type diff2(const VectorN &x, const VectorN &y) {
     typename VectorN::value_type res{0};
 
     CMS_UNROLL_LOOP
     for (int i = 0; i < VectorN::N; i++) {
       const typename VectorN::value_type tmp = x[i] - y[i];
-      res += tmp*tmp;
+      res += tmp * tmp;
     }
     return res;
   }

--- a/HeterogeneousCore/AlpakaMath/test/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaMath/test/BuildFile.xml
@@ -4,3 +4,10 @@
   <use name="HeterogeneousCore/AlpakaInterface"/>
   <flags ALPAKA_BACKENDS="1"/>
 </bin>
+<bin name="alpakaTestVector" file="alpaka/testVector.dev.cc">
+  <use name="alpaka"/>
+  <use name="catch2"/>
+  <use name="HeterogeneousCore/AlpakaMath"/>
+  <flags ALPAKA_BACKENDS="1"/>
+</bin>
+

--- a/HeterogeneousCore/AlpakaMath/test/alpaka/testVector.dev.cc
+++ b/HeterogeneousCore/AlpakaMath/test/alpaka/testVector.dev.cc
@@ -16,9 +16,9 @@ using namespace cms::alpakatools::math;
 using namespace cms::alpakatools;
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
-using Vec3d    = cms::alpakatools::math::Vector<double, 3>;
-using data_t   = typename Vec3d::value_type;
-using scalar_t = data_t; 
+using Vec3d = cms::alpakatools::math::Vector<double, 3>;
+using data_t = typename Vec3d::value_type;
+using scalar_t = data_t;
 
 constexpr int len{1 << 12};
 constexpr int nSrc{Vec3d::N};
@@ -28,108 +28,102 @@ struct scaleKernel {
   const scalar_t a;
 
   constexpr scaleKernel() : a(s) {}
- 
+
   ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, data_t* z) const {
     for (auto i : uniform_elements(acc)) {
-      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
+      const Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
 
       const Vec3d zvec = cms::alpakatools::math::scale(a, xvec);
 
       CMS_UNROLL_LOOP
-      for(int n = 0; n < nSrc; n++) {
-        z[i+n*len] = zvec[n];
+      for (int n = 0; n < nSrc; n++) {
+        z[i + n * len] = zvec[n];
       }
     }
   }
 };
 
 struct addKernel {
-  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x ,const data_t* y, data_t* z) const {
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, const data_t* y, data_t* z) const {
     for (auto i : uniform_elements(acc)) {
-      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
-      const Vec3d yvec(y[i], y[i+len], y[i+len*2]);
+      const Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
+      const Vec3d yvec(y[i], y[i + len], y[i + len * 2]);
 
       const Vec3d zvec = cms::alpakatools::math::add(xvec, yvec);
 
       CMS_UNROLL_LOOP
-      for(int n = 0; n < nSrc; n++) {	      
-        z[i+n*len] = zvec[n];
+      for (int n = 0; n < nSrc; n++) {
+        z[i + n * len] = zvec[n];
       }
     }
   }
 };
 
 struct subKernel {
-  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x ,const data_t* y, data_t* z) const {
-    for (auto i : uniform_elements(acc)){
-      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
-      const Vec3d yvec(y[i], y[i+len], y[i+len*2]);
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, const data_t* y, data_t* z) const {
+    for (auto i : uniform_elements(acc)) {
+      const Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
+      const Vec3d yvec(y[i], y[i + len], y[i + len * 2]);
 
       const Vec3d zvec = cms::alpakatools::math::sub(xvec, yvec);
 
       CMS_UNROLL_LOOP
-      for(int n = 0; n < nSrc; n++) {
-        z[i+n*len] = zvec[n];
+      for (int n = 0; n < nSrc; n++) {
+        z[i + n * len] = zvec[n];
       }
     }
   }
 };
-
 
 struct axpyKernel {
   const scalar_t a;
 
   constexpr axpyKernel() : a(s) {}
 
-  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x , const data_t* y, data_t* z) const {
-    for (auto i : uniform_elements(acc)){
-      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
-      const Vec3d yvec(y[i], y[i+len], y[i+len*2]);
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, const data_t* y, data_t* z) const {
+    for (auto i : uniform_elements(acc)) {
+      const Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
+      const Vec3d yvec(y[i], y[i + len], y[i + len * 2]);
 
       const Vec3d zvec = cms::alpakatools::math::axpy(a, xvec, yvec);
 
       CMS_UNROLL_LOOP
-      for(int n = 0; n < nSrc; n++) {
-        z[i+n*len] = zvec[n];
+      for (int n = 0; n < nSrc; n++) {
+        z[i + n * len] = zvec[n];
       }
     }
   }
 };
 
-
 struct normalizeKernel {
   ALPAKA_FN_ACC void operator()(Acc1D const& acc, data_t* x) const {
-    for (auto i : uniform_elements(acc)){
-      Vec3d xvec(x[i], x[i+len], x[i+len*2]);
+    for (auto i : uniform_elements(acc)) {
+      Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
 
       xvec.normalize(acc);
 
       CMS_UNROLL_LOOP
-      for(int n = 0; n < nSrc; n++) {
-        x[i+n*len] = xvec[n];
+      for (int n = 0; n < nSrc; n++) {
+        x[i + n * len] = xvec[n];
       }
     }
   }
 };
 
-
 struct normKernel {
-
   ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, data_t* r) const {
-    for (auto i : uniform_elements(acc)){
-      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
+    for (auto i : uniform_elements(acc)) {
+      const Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
 
       r[i] = xvec.norm(acc);
     }
   }
 };
 
-
 struct partialNormKernel {
-
   ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, data_t* r) const {
-    for (auto i : uniform_elements(acc)){
-      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
+    for (auto i : uniform_elements(acc)) {
+      const Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
 
       r[i] = xvec.template partial_norm<Acc1D, 2>(acc);
     }
@@ -137,17 +131,15 @@ struct partialNormKernel {
 };
 
 struct dotKernel {
-
   ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, const data_t* y, data_t* r) const {
-    for (auto i : uniform_elements(acc)){
-      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
-      const Vec3d yvec(y[i], y[i+len], y[i+len*2]);
+    for (auto i : uniform_elements(acc)) {
+      const Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
+      const Vec3d yvec(y[i], y[i + len], y[i + len * 2]);
 
       r[i] = cms::alpakatools::math::dot(xvec, yvec);
     }
   }
 };
-
 
 int main() {
   // get the list of devices on the current platform
@@ -162,10 +154,9 @@ int main() {
 
   // run the test on each device
   for (auto const& device : devices) {
-    
     auto queue = Queue(device);
     auto const host_platform = alpaka::PlatformCpu{};
-    auto const host_device   = alpaka::getDevByIdx(host_platform, 0);
+    auto const host_device = alpaka::getDevByIdx(host_platform, 0);
 
     auto x_h = make_host_buffer<data_t[]>(queue, N * nSrc);
     auto x_d = make_device_buffer<data_t[]>(queue, N * nSrc);
@@ -188,11 +179,11 @@ int main() {
     auto result_view = alpaka::createView(host_device, result_h.data(), extent1D);
 
     // Initialize random number generator
-    std::random_device rd; 
-    std::mt19937 gen(rd()); 
-    std::normal_distribution<data_t> distr(0.0, 1.0); 
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::normal_distribution<data_t> distr(0.0, 1.0);
 
-    for(int i = 0; i < N * nSrc; i++) {
+    for (int i = 0; i < N * nSrc; i++) {
       x_view[i] = distr(gen);
       y_view[i] = distr(gen);
     }
@@ -204,7 +195,7 @@ int main() {
     alpaka::wait(queue);
 
     const int numBlocks = 4;
-    const int numThreadsPerBlock = len / numBlocks ;
+    const int numThreadsPerBlock = len / numBlocks;
 
     const auto workDiv = make_workdiv<Acc1D>(numBlocks, numThreadsPerBlock);
 
@@ -215,16 +206,17 @@ int main() {
     alpaka::wait(queue);
 
     int fails = 0;
-    constexpr data_t epsilon = 1e-12; 
+    constexpr data_t epsilon = 1e-12;
 
-    for( int i = 0; i < len*nSrc; i++) {
+    for (int i = 0; i < len * nSrc; i++) {
       const data_t res = s * x_view[i];
       //
       const data_t r = res - z_view[i];
       //
-      if (std::abs(r) > epsilon) fails++;
-    }   
-  
+      if (std::abs(r) > epsilon)
+        fails++;
+    }
+
     assert(fails == 0);
 
     alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, addKernel(), x_d.data(), y_d.data(), z_d.data()));
@@ -233,13 +225,14 @@ int main() {
 
     alpaka::wait(queue);
 
-    for( int i = 0; i < len*nSrc; i++) {
+    for (int i = 0; i < len * nSrc; i++) {
       const data_t res = x_view[i] + y_view[i];
       //
       const data_t r = res - z_view[i];
       //
-      if (std::abs(r) > epsilon) fails++;
-    }  
+      if (std::abs(r) > epsilon)
+        fails++;
+    }
 
     assert(fails == 0);
 
@@ -249,12 +242,13 @@ int main() {
 
     alpaka::wait(queue);
 
-    for( int i = 0; i < len*nSrc; i++) {
+    for (int i = 0; i < len * nSrc; i++) {
       const data_t res = x_view[i] - y_view[i];
       //
       const data_t r = res - z_view[i];
       //
-      if (std::abs(r) > epsilon) fails++;
+      if (std::abs(r) > epsilon)
+        fails++;
     }
 
     assert(fails == 0);
@@ -265,32 +259,36 @@ int main() {
 
     alpaka::wait(queue);
 
-    for( int i = 0; i < len*nSrc; i++) {
+    for (int i = 0; i < len * nSrc; i++) {
       const data_t res = s * x_view[i] + y_view[i];
       //
       const data_t r = res - z_view[i];
       //
-      if (std::abs(r) > epsilon) fails++;
+      if (std::abs(r) > epsilon)
+        fails++;
     }
 
     assert(fails == 0);
 
-    alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, dotKernel(), x_d.data(), y_d.data(), result_d.data()));
+    alpaka::enqueue(queue,
+                    alpaka::createTaskKernel<Acc1D>(workDiv, dotKernel(), x_d.data(), y_d.data(), result_d.data()));
 
     alpaka::memcpy(queue, result_h, result_d);
 
     alpaka::wait(queue);
 
-    for( int i = 0; i < len; i++) {
+    for (int i = 0; i < len; i++) {
       data_t res = x_view[i] * y_view[i];
-      for (int j = 1; j < nSrc; j++) res += x_view[i+j*len] * y_view[i+j*len];
+      for (int j = 1; j < nSrc; j++)
+        res += x_view[i + j * len] * y_view[i + j * len];
       //
       const data_t r = res - result_view[i];
       //
-      if (std::abs(r) > epsilon) fails++;
+      if (std::abs(r) > epsilon)
+        fails++;
     }
 
-    assert(fails == 0);    
+    assert(fails == 0);
   }
   std::cout << "TEST PASSED" << std::endl;
   return 0;

--- a/HeterogeneousCore/AlpakaMath/test/alpaka/testVector.dev.cc
+++ b/HeterogeneousCore/AlpakaMath/test/alpaka/testVector.dev.cc
@@ -1,0 +1,269 @@
+#include <cassert>
+#include <cstdlib>
+#include <iostream>
+#include <new>
+
+#include <alpaka/alpaka.hpp>
+
+#include "FWCore/Utilities/interface/stringize.h"
+#include "HeterogeneousCore/AlpakaMath/interface/Vector.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+
+using namespace cms::alpakatools::math;
+using namespace ALPAKA_ACCELERATOR_NAMESPACE;
+
+using Vec3d  = cms::alpakatools::math::Vector<double, 3>;
+using data_t = typename Vec3d::value_type;
+
+constexpr int len{1 << 12};
+constexpr int nSrc{Vec3d::N};
+constexpr data_t c{3.14};
+
+struct ax {
+  const data_t a;
+
+  constexpr ax() : a(c) {}
+ 
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, data_t* z) const {
+    for (auto i : uniform_elements(acc)) {
+      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
+
+      const Vec3d zvec = cms::alpakatools::math::ax(a, xvec);
+
+      CMS_LOOP_UNROLL
+      for(int n = 0; n < nSrc; n++) {
+        z[i+n*len] = zvec[n];
+      }
+    }
+  }
+};
+
+struct xpy {
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x ,const data_t* y, data_t* z) const {
+    for (auto i : uniform_elements(acc)) {
+      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
+      const Vec3d yvec(y[i], y[i+len], y[i+len*2]);
+
+      const Vec3d zvec = cms::alpakatools::math::xpy(xvec, yvec);
+
+      CMS_LOOP_UNROLL
+      for(int n = 0; n < nSrc; n++) {
+        z[i+n*len] = zvec[n];
+      }
+    }
+  }
+};
+
+struct xmy {
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x ,const data_t* y, data_t* z) const {
+    for (auto i : uniform_elements(acc)){
+      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
+      const Vec3d yvec(y[i], y[i+len], y[i+len*2]);
+
+      const Vec3d zvec = cms::alpakatools::math::xmy(xvec, yvec);
+
+      CMS_LOOP_UNROLL
+      for(int n = 0; n < nSrc; n++) {
+        z[i+n*len] = zvec[n];
+      }
+    }
+  }
+};
+
+
+struct axpy {
+  const data_t a;
+
+  constexpr axpy() : a(c) {}
+
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x , const data_t* y, data_t* z) const {
+    for (auto i : uniform_elements(acc)){
+      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
+      const Vec3d yvec(y[i], y[i+len], y[i+len*2]);
+
+      const Vec3d zvec = cms::alpakatools::math::axpy(a, xvec, yvec);
+
+      CMS_LOOP_UNROLL
+      for(int n = 0; n < nSrc; n++) {
+        z[i+n*len] = zvec[n];
+      }
+    }
+  }
+};
+
+
+struct normalized {
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, data_t* x) const {
+    for (auto i : uniform_elements(acc)){
+      Vec3d xvec(x[i], x[i+len], x[i+len*2]);
+
+      xvec.normalized();
+
+      CMS_LOOP_UNROLL
+      for(int n = 0; n < nSrc; n++) {
+        x[i+n*len] = xvec[n];
+      }
+    }
+  }
+};
+
+
+struct norm {
+
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, data_t* r) const {
+    for (auto i : uniform_elements(acc)){
+      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
+
+      r[i] = xvec.norm(acc);
+    }
+  }
+};
+
+
+struct partial_norm {
+
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, data_t* r) const {
+    for (auto i : uniform_elements(acc)){
+      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
+
+      r[i] = xvec.template partial_norm<Acc1D, 2>(acc);
+    }
+  }
+};
+
+struct dot {
+
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, const data_t* y, data_t* r) const {
+    for (auto i : uniform_elements(acc)){
+      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
+      const Vec3d yvec(y[i], y[i+len], y[i+len*2]);
+
+      r[i] = cms::alpakatools::math::dot(xvec, yvec);
+    }
+  }
+};
+
+
+int main() {
+  // get the list of devices on the current platform
+  auto const& devices = cms::alpakatools::devices<Platform>();
+  if (devices.empty()) {
+    std::cerr << "No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+      "the test will be skipped.\n";
+    exit(EXIT_FAILURE);
+  }
+
+  using data_t = double;
+
+  constexpr int N = 1 << 12;
+  constexpr int nSrc = 3;
+
+  // run the test on each device
+  for (auto const& device : devices) {
+
+    auto const platformHost = alpaka::PlatformCpu{};
+    auto const devHost      = alpaka::getDevByIdx(platformHost, 0);
+    auto const platformAcc  = alpaka::Platform<Acc1D>{};    
+    
+    auto queue = Queue(device);
+
+    auto x_h = make_host_buffer<data_t[]>(queue, N * nSrc);
+    auto x_d = make_device_buffer<data_t[]>(queue, N * nSrc);
+
+    auto y_h = make_host_buffer<data_t[]>(queue, N * nSrc);
+    auto y_d = make_device_buffer<data_t[]>(queue, N * nSrc);
+
+    auto z_h = make_host_buffer<data_t[]>(queue, N * nSrc);
+    auto z_d = make_device_buffer<data_t[]>(queue, N * nSrc);
+
+    auto result_d = make_device_buffer<data_t[]>(queue, N);
+    
+    // Initialize random number generator
+    std::random_device rd; 
+    std::mt19937 gen(rd()); 
+    std::normal_distribution<data_t> distr(0.0, 1.0); 
+
+    for(int i = 0; i < N * nSrc; i++) {
+      x_h[i] = distr(gen);
+      y_h[i] = distr(gen);
+    }
+
+    // copy the object to the device.
+    alpaka::memcpy(queue, x_d, x_h);
+    alpaka::memcpy(queue, y_d, y_h);
+    alpaka::wait(queue);
+
+    const int numBlocks = 4;
+    const int numThreadsPerBlock = len / numBlocks ;
+
+    const auto workDiv = make_workdiv<Acc1D>(numBlocks, numThreadsPerBlock);
+
+    alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, ax(), x_d.data()));
+    alpaka::wait(queue); 
+
+    alpaka::memcpy(queue, z_h, x_d);
+
+    int fails = 0;
+    constexpr data_t epsilon = 1e-16; 
+
+    for( int i = 0; i < len*nSrc; i++) {
+      x_h[i] = c * x_h[i];
+      //
+      const data_t diff r = x_h[i] - z_h[i];
+      //
+      if (std::abs(r) > epsilon) fails++;
+    }   
+  
+    assert(fails);
+
+    alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, xpy(), x_d.data(), y_d.data(), z_d.data()));
+    alpaka::wait(queue);
+
+    alpaka::memcpy(queue, z_h, z_d);
+
+    for( int i = 0; i < len*nSrc; i++) {
+      const data_t res = x_h[i] + y_h[i];
+      //
+      const data_t diff r = res - z_h[i];
+      //
+      if (std::abs(r) > epsilon) fails++;
+    }  
+
+    assert(fails);
+
+    alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, xmy(), x_d.data(), y_d.data(), z_d.data()));
+    alpaka::wait(queue);
+
+    alpaka::memcpy(queue, z_h, z_d);
+
+    for( int i = 0; i < len*nSrc; i++) {
+      const data_t res = x_h[i] - y_h[i];
+      //
+      const data_t diff r = res - z_h[i];
+      //
+      if (std::abs(r) > epsilon) fails++;
+    }
+
+    assert(fails);
+
+    alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, axpy(), x_d.data(), y_d.data(), z_d.data()));
+    alpaka::wait(queue);
+
+    alpaka::memcpy(queue, z_h, z_d);
+
+    for( int i = 0; i < len*nSrc; i++) {
+      const data_t res = c * x_h[i] + y_h[i];
+      //
+      const data_t diff r = res - z_h[i];
+      //
+      if (std::abs(r) > epsilon) fails++;
+    }
+
+    assert(fails);
+  }
+  std::cout << "TEST PASSED" << std::endl;
+  return 0;
+}

--- a/HeterogeneousCore/AlpakaMath/test/alpaka/testVector.dev.cc
+++ b/HeterogeneousCore/AlpakaMath/test/alpaka/testVector.dev.cc
@@ -16,7 +16,7 @@ using namespace cms::alpakatools::math;
 using namespace cms::alpakatools;
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
-using Vec3d  = cms::alpakatools::math::Vector<double, 3>;
+using Vec3d = cms::alpakatools::math::Vector<double, 3>;
 using data_t = typename Vec3d::value_type;
 
 constexpr int len{1 << 12};
@@ -27,108 +27,102 @@ struct axKernel {
   const data_t a;
 
   constexpr axKernel() : a(c) {}
- 
+
   ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, data_t* z) const {
     for (auto i : uniform_elements(acc)) {
-      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
+      const Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
 
       const Vec3d zvec = cms::alpakatools::math::ax(a, xvec);
 
       CMS_UNROLL_LOOP
-      for(int n = 0; n < nSrc; n++) {
-        z[i+n*len] = zvec[n];
+      for (int n = 0; n < nSrc; n++) {
+        z[i + n * len] = zvec[n];
       }
     }
   }
 };
 
 struct xpyKernel {
-  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x ,const data_t* y, data_t* z) const {
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, const data_t* y, data_t* z) const {
     for (auto i : uniform_elements(acc)) {
-      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
-      const Vec3d yvec(y[i], y[i+len], y[i+len*2]);
+      const Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
+      const Vec3d yvec(y[i], y[i + len], y[i + len * 2]);
 
       const Vec3d zvec = cms::alpakatools::math::xpy(xvec, yvec);
 
       CMS_UNROLL_LOOP
-      for(int n = 0; n < nSrc; n++) {
-        z[i+n*len] = zvec[n];
+      for (int n = 0; n < nSrc; n++) {
+        z[i + n * len] = zvec[n];
       }
     }
   }
 };
 
 struct xmyKernel {
-  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x ,const data_t* y, data_t* z) const {
-    for (auto i : uniform_elements(acc)){
-      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
-      const Vec3d yvec(y[i], y[i+len], y[i+len*2]);
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, const data_t* y, data_t* z) const {
+    for (auto i : uniform_elements(acc)) {
+      const Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
+      const Vec3d yvec(y[i], y[i + len], y[i + len * 2]);
 
       const Vec3d zvec = cms::alpakatools::math::xmy(xvec, yvec);
 
       CMS_UNROLL_LOOP
-      for(int n = 0; n < nSrc; n++) {
-        z[i+n*len] = zvec[n];
+      for (int n = 0; n < nSrc; n++) {
+        z[i + n * len] = zvec[n];
       }
     }
   }
 };
-
 
 struct axpyKernel {
   const data_t a;
 
   constexpr axpyKernel() : a(c) {}
 
-  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x , const data_t* y, data_t* z) const {
-    for (auto i : uniform_elements(acc)){
-      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
-      const Vec3d yvec(y[i], y[i+len], y[i+len*2]);
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, const data_t* y, data_t* z) const {
+    for (auto i : uniform_elements(acc)) {
+      const Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
+      const Vec3d yvec(y[i], y[i + len], y[i + len * 2]);
 
       const Vec3d zvec = cms::alpakatools::math::axpy(a, xvec, yvec);
 
       CMS_UNROLL_LOOP
-      for(int n = 0; n < nSrc; n++) {
-        z[i+n*len] = zvec[n];
+      for (int n = 0; n < nSrc; n++) {
+        z[i + n * len] = zvec[n];
       }
     }
   }
 };
 
-
 struct normalizeKernel {
   ALPAKA_FN_ACC void operator()(Acc1D const& acc, data_t* x) const {
-    for (auto i : uniform_elements(acc)){
-      Vec3d xvec(x[i], x[i+len], x[i+len*2]);
+    for (auto i : uniform_elements(acc)) {
+      Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
 
       xvec.normalize(acc);
 
       CMS_UNROLL_LOOP
-      for(int n = 0; n < nSrc; n++) {
-        x[i+n*len] = xvec[n];
+      for (int n = 0; n < nSrc; n++) {
+        x[i + n * len] = xvec[n];
       }
     }
   }
 };
 
-
 struct normKernel {
-
   ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, data_t* r) const {
-    for (auto i : uniform_elements(acc)){
-      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
+    for (auto i : uniform_elements(acc)) {
+      const Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
 
       r[i] = xvec.norm(acc);
     }
   }
 };
 
-
 struct partialNormKernel {
-
   ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, data_t* r) const {
-    for (auto i : uniform_elements(acc)){
-      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
+    for (auto i : uniform_elements(acc)) {
+      const Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
 
       r[i] = xvec.template partial_norm<Acc1D, 2>(acc);
     }
@@ -136,17 +130,15 @@ struct partialNormKernel {
 };
 
 struct dotKernel {
-
   ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, const data_t* y, data_t* r) const {
-    for (auto i : uniform_elements(acc)){
-      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
-      const Vec3d yvec(y[i], y[i+len], y[i+len*2]);
+    for (auto i : uniform_elements(acc)) {
+      const Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
+      const Vec3d yvec(y[i], y[i + len], y[i + len * 2]);
 
       r[i] = cms::alpakatools::math::dot(xvec, yvec);
     }
   }
 };
-
 
 int main() {
   // get the list of devices on the current platform
@@ -164,7 +156,6 @@ int main() {
 
   // run the test on each device
   for (auto const& device : devices) {
-    
     auto queue = Queue(device);
 
     auto x_h = make_host_buffer<data_t[]>(queue, N * nSrc);
@@ -177,17 +168,17 @@ int main() {
     auto z_d = make_device_buffer<data_t[]>(queue, N * nSrc);
 
     auto result_d = make_device_buffer<data_t[]>(queue, N);
-    
+
     auto _x = x_h.data();
     auto _y = y_h.data();
     auto _z = z_h.data();
 
     // Initialize random number generator
-    std::random_device rd; 
-    std::mt19937 gen(rd()); 
-    std::normal_distribution<data_t> distr(0.0, 1.0); 
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::normal_distribution<data_t> distr(0.0, 1.0);
 
-    for(int i = 0; i < N * nSrc; i++) {
+    for (int i = 0; i < N * nSrc; i++) {
       _x[i] = distr(gen);
       _y[i] = distr(gen);
     }
@@ -198,26 +189,27 @@ int main() {
     alpaka::wait(queue);
 
     const int numBlocks = 4;
-    const int numThreadsPerBlock = len / numBlocks ;
+    const int numThreadsPerBlock = len / numBlocks;
 
     const auto workDiv = make_workdiv<Acc1D>(numBlocks, numThreadsPerBlock);
 
     alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, axKernel{}, x_d.data(), z_d.data()));
-    alpaka::wait(queue); 
+    alpaka::wait(queue);
 
     alpaka::memcpy(queue, z_h, z_d);
 
     int fails = 0;
-    constexpr data_t epsilon = 1e-16; 
+    constexpr data_t epsilon = 1e-16;
 
-    for( int i = 0; i < len*nSrc; i++) {
+    for (int i = 0; i < len * nSrc; i++) {
       _x[i] = c * _x[i];
       //
       const data_t r = _x[i] - _z[i];
       //
-      if (std::abs(r) > epsilon) fails++;
-    }   
-  
+      if (std::abs(r) > epsilon)
+        fails++;
+    }
+
     assert(fails == 0);
 
     alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, xpyKernel(), x_d.data(), y_d.data(), z_d.data()));
@@ -225,13 +217,14 @@ int main() {
 
     alpaka::memcpy(queue, z_h, z_d);
 
-    for( int i = 0; i < len*nSrc; i++) {
+    for (int i = 0; i < len * nSrc; i++) {
       const data_t res = _x[i] + _y[i];
       //
       const data_t r = res - _z[i];
       //
-      if (std::abs(r) > epsilon) fails++;
-    }  
+      if (std::abs(r) > epsilon)
+        fails++;
+    }
 
     assert(fails == 0);
 
@@ -240,12 +233,13 @@ int main() {
 
     alpaka::memcpy(queue, z_h, z_d);
 
-    for( int i = 0; i < len*nSrc; i++) {
+    for (int i = 0; i < len * nSrc; i++) {
       const data_t res = _x[i] - _y[i];
       //
       const data_t r = res - _z[i];
       //
-      if (std::abs(r) > epsilon) fails++;
+      if (std::abs(r) > epsilon)
+        fails++;
     }
 
     assert(fails == 0);
@@ -255,12 +249,13 @@ int main() {
 
     alpaka::memcpy(queue, z_h, z_d);
 
-    for( int i = 0; i < len*nSrc; i++) {
+    for (int i = 0; i < len * nSrc; i++) {
       const data_t res = c * _x[i] + _y[i];
       //
       const data_t r = res - _z[i];
       //
-      if (std::abs(r) > epsilon) fails++;
+      if (std::abs(r) > epsilon)
+        fails++;
     }
 
     assert(fails == 0);

--- a/HeterogeneousCore/AlpakaMath/test/alpaka/testVector.dev.cc
+++ b/HeterogeneousCore/AlpakaMath/test/alpaka/testVector.dev.cc
@@ -218,7 +218,7 @@ int main() {
       if (std::abs(r) > epsilon) fails++;
     }   
   
-    assert(fails);
+    assert(fails == 0);
 
     alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, xpyKernel(), x_d.data(), y_d.data(), z_d.data()));
     alpaka::wait(queue);
@@ -233,7 +233,7 @@ int main() {
       if (std::abs(r) > epsilon) fails++;
     }  
 
-    assert(fails);
+    assert(fails == 0);
 
     alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, xmyKernel(), x_d.data(), y_d.data(), z_d.data()));
     alpaka::wait(queue);
@@ -248,7 +248,7 @@ int main() {
       if (std::abs(r) > epsilon) fails++;
     }
 
-    assert(fails);
+    assert(fails == 0);
 
     alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, axpyKernel(), x_d.data(), y_d.data(), z_d.data()));
     alpaka::wait(queue);
@@ -263,7 +263,7 @@ int main() {
       if (std::abs(r) > epsilon) fails++;
     }
 
-    assert(fails);
+    assert(fails == 0);
   }
   std::cout << "TEST PASSED" << std::endl;
   return 0;

--- a/HeterogeneousCore/AlpakaMath/test/alpaka/testVector.dev.cc
+++ b/HeterogeneousCore/AlpakaMath/test/alpaka/testVector.dev.cc
@@ -16,113 +16,120 @@ using namespace cms::alpakatools::math;
 using namespace cms::alpakatools;
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
-using Vec3d = cms::alpakatools::math::Vector<double, 3>;
-using data_t = typename Vec3d::value_type;
+using Vec3d    = cms::alpakatools::math::Vector<double, 3>;
+using data_t   = typename Vec3d::value_type;
+using scalar_t = data_t; 
 
 constexpr int len{1 << 12};
 constexpr int nSrc{Vec3d::N};
-constexpr data_t c{3.14};
+constexpr scalar_t s{3.14};
 
-struct axKernel {
-  const data_t a;
+struct scaleKernel {
+  const scalar_t a;
 
-  constexpr axKernel() : a(c) {}
-
+  constexpr scaleKernel() : a(s) {}
+ 
   ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, data_t* z) const {
     for (auto i : uniform_elements(acc)) {
-      const Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
+      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
 
-      const Vec3d zvec = cms::alpakatools::math::ax(a, xvec);
+      const Vec3d zvec = cms::alpakatools::math::scale(a, xvec);
 
       CMS_UNROLL_LOOP
-      for (int n = 0; n < nSrc; n++) {
-        z[i + n * len] = zvec[n];
+      for(int n = 0; n < nSrc; n++) {
+        z[i+n*len] = zvec[n];
       }
     }
   }
 };
 
-struct xpyKernel {
-  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, const data_t* y, data_t* z) const {
+struct addKernel {
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x ,const data_t* y, data_t* z) const {
     for (auto i : uniform_elements(acc)) {
-      const Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
-      const Vec3d yvec(y[i], y[i + len], y[i + len * 2]);
+      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
+      const Vec3d yvec(y[i], y[i+len], y[i+len*2]);
 
-      const Vec3d zvec = cms::alpakatools::math::xpy(xvec, yvec);
+      const Vec3d zvec = cms::alpakatools::math::add(xvec, yvec);
 
       CMS_UNROLL_LOOP
-      for (int n = 0; n < nSrc; n++) {
-        z[i + n * len] = zvec[n];
+      for(int n = 0; n < nSrc; n++) {	      
+        z[i+n*len] = zvec[n];
       }
     }
   }
 };
 
-struct xmyKernel {
-  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, const data_t* y, data_t* z) const {
-    for (auto i : uniform_elements(acc)) {
-      const Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
-      const Vec3d yvec(y[i], y[i + len], y[i + len * 2]);
+struct subKernel {
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x ,const data_t* y, data_t* z) const {
+    for (auto i : uniform_elements(acc)){
+      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
+      const Vec3d yvec(y[i], y[i+len], y[i+len*2]);
 
-      const Vec3d zvec = cms::alpakatools::math::xmy(xvec, yvec);
+      const Vec3d zvec = cms::alpakatools::math::sub(xvec, yvec);
 
       CMS_UNROLL_LOOP
-      for (int n = 0; n < nSrc; n++) {
-        z[i + n * len] = zvec[n];
+      for(int n = 0; n < nSrc; n++) {
+        z[i+n*len] = zvec[n];
       }
     }
   }
 };
+
 
 struct axpyKernel {
-  const data_t a;
+  const scalar_t a;
 
-  constexpr axpyKernel() : a(c) {}
+  constexpr axpyKernel() : a(s) {}
 
-  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, const data_t* y, data_t* z) const {
-    for (auto i : uniform_elements(acc)) {
-      const Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
-      const Vec3d yvec(y[i], y[i + len], y[i + len * 2]);
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x , const data_t* y, data_t* z) const {
+    for (auto i : uniform_elements(acc)){
+      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
+      const Vec3d yvec(y[i], y[i+len], y[i+len*2]);
 
       const Vec3d zvec = cms::alpakatools::math::axpy(a, xvec, yvec);
 
       CMS_UNROLL_LOOP
-      for (int n = 0; n < nSrc; n++) {
-        z[i + n * len] = zvec[n];
+      for(int n = 0; n < nSrc; n++) {
+        z[i+n*len] = zvec[n];
       }
     }
   }
 };
 
+
 struct normalizeKernel {
   ALPAKA_FN_ACC void operator()(Acc1D const& acc, data_t* x) const {
-    for (auto i : uniform_elements(acc)) {
-      Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
+    for (auto i : uniform_elements(acc)){
+      Vec3d xvec(x[i], x[i+len], x[i+len*2]);
 
       xvec.normalize(acc);
 
       CMS_UNROLL_LOOP
-      for (int n = 0; n < nSrc; n++) {
-        x[i + n * len] = xvec[n];
+      for(int n = 0; n < nSrc; n++) {
+        x[i+n*len] = xvec[n];
       }
     }
   }
 };
 
+
 struct normKernel {
+
   ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, data_t* r) const {
-    for (auto i : uniform_elements(acc)) {
-      const Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
+    for (auto i : uniform_elements(acc)){
+      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
 
       r[i] = xvec.norm(acc);
     }
   }
 };
 
+
 struct partialNormKernel {
+
   ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, data_t* r) const {
-    for (auto i : uniform_elements(acc)) {
-      const Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
+    for (auto i : uniform_elements(acc)){
+      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
 
       r[i] = xvec.template partial_norm<Acc1D, 2>(acc);
     }
@@ -130,15 +137,17 @@ struct partialNormKernel {
 };
 
 struct dotKernel {
+
   ALPAKA_FN_ACC void operator()(Acc1D const& acc, const data_t* x, const data_t* y, data_t* r) const {
-    for (auto i : uniform_elements(acc)) {
-      const Vec3d xvec(x[i], x[i + len], x[i + len * 2]);
-      const Vec3d yvec(y[i], y[i + len], y[i + len * 2]);
+    for (auto i : uniform_elements(acc)){
+      const Vec3d xvec(x[i], x[i+len], x[i+len*2]);
+      const Vec3d yvec(y[i], y[i+len], y[i+len*2]);
 
       r[i] = cms::alpakatools::math::dot(xvec, yvec);
     }
   }
 };
+
 
 int main() {
   // get the list of devices on the current platform
@@ -149,14 +158,14 @@ int main() {
     exit(EXIT_FAILURE);
   }
 
-  using data_t = double;
-
-  constexpr int N = 1 << 12;
-  constexpr int nSrc = 3;
+  constexpr int N = len;
 
   // run the test on each device
   for (auto const& device : devices) {
+    
     auto queue = Queue(device);
+    auto const host_platform = alpaka::PlatformCpu{};
+    auto const host_device   = alpaka::getDevByIdx(host_platform, 0);
 
     auto x_h = make_host_buffer<data_t[]>(queue, N * nSrc);
     auto x_d = make_device_buffer<data_t[]>(queue, N * nSrc);
@@ -167,98 +176,121 @@ int main() {
     auto z_h = make_host_buffer<data_t[]>(queue, N * nSrc);
     auto z_d = make_device_buffer<data_t[]>(queue, N * nSrc);
 
+    auto result_h = make_host_buffer<data_t[]>(queue, N);
     auto result_d = make_device_buffer<data_t[]>(queue, N);
 
-    auto _x = x_h.data();
-    auto _y = y_h.data();
-    auto _z = z_h.data();
+    Vec1D const extent1D(N * nSrc);
+
+    auto x_view = alpaka::createView(host_device, x_h.data(), extent1D);
+    auto y_view = alpaka::createView(host_device, y_h.data(), extent1D);
+    auto z_view = alpaka::createView(host_device, z_h.data(), extent1D);
+
+    auto result_view = alpaka::createView(host_device, result_h.data(), extent1D);
 
     // Initialize random number generator
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::normal_distribution<data_t> distr(0.0, 1.0);
+    std::random_device rd; 
+    std::mt19937 gen(rd()); 
+    std::normal_distribution<data_t> distr(0.0, 1.0); 
 
-    for (int i = 0; i < N * nSrc; i++) {
-      _x[i] = distr(gen);
-      _y[i] = distr(gen);
+    for(int i = 0; i < N * nSrc; i++) {
+      x_view[i] = distr(gen);
+      y_view[i] = distr(gen);
     }
 
     // copy the object to the device.
     alpaka::memcpy(queue, x_d, x_h);
     alpaka::memcpy(queue, y_d, y_h);
+
     alpaka::wait(queue);
 
     const int numBlocks = 4;
-    const int numThreadsPerBlock = len / numBlocks;
+    const int numThreadsPerBlock = len / numBlocks ;
 
     const auto workDiv = make_workdiv<Acc1D>(numBlocks, numThreadsPerBlock);
 
-    alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, axKernel{}, x_d.data(), z_d.data()));
-    alpaka::wait(queue);
+    alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, scaleKernel{}, x_d.data(), z_d.data()));
 
     alpaka::memcpy(queue, z_h, z_d);
+
+    alpaka::wait(queue);
 
     int fails = 0;
-    constexpr data_t epsilon = 1e-16;
+    constexpr data_t epsilon = 1e-12; 
 
-    for (int i = 0; i < len * nSrc; i++) {
-      _x[i] = c * _x[i];
+    for( int i = 0; i < len*nSrc; i++) {
+      const data_t res = s * x_view[i];
       //
-      const data_t r = _x[i] - _z[i];
+      const data_t r = res - z_view[i];
       //
-      if (std::abs(r) > epsilon)
-        fails++;
-    }
-
+      if (std::abs(r) > epsilon) fails++;
+    }   
+  
     assert(fails == 0);
 
-    alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, xpyKernel(), x_d.data(), y_d.data(), z_d.data()));
-    alpaka::wait(queue);
+    alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, addKernel(), x_d.data(), y_d.data(), z_d.data()));
 
     alpaka::memcpy(queue, z_h, z_d);
 
-    for (int i = 0; i < len * nSrc; i++) {
-      const data_t res = _x[i] + _y[i];
+    alpaka::wait(queue);
+
+    for( int i = 0; i < len*nSrc; i++) {
+      const data_t res = x_view[i] + y_view[i];
       //
-      const data_t r = res - _z[i];
+      const data_t r = res - z_view[i];
       //
-      if (std::abs(r) > epsilon)
-        fails++;
-    }
+      if (std::abs(r) > epsilon) fails++;
+    }  
 
     assert(fails == 0);
 
-    alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, xmyKernel(), x_d.data(), y_d.data(), z_d.data()));
-    alpaka::wait(queue);
+    alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, subKernel(), x_d.data(), y_d.data(), z_d.data()));
 
     alpaka::memcpy(queue, z_h, z_d);
 
-    for (int i = 0; i < len * nSrc; i++) {
-      const data_t res = _x[i] - _y[i];
+    alpaka::wait(queue);
+
+    for( int i = 0; i < len*nSrc; i++) {
+      const data_t res = x_view[i] - y_view[i];
       //
-      const data_t r = res - _z[i];
+      const data_t r = res - z_view[i];
       //
-      if (std::abs(r) > epsilon)
-        fails++;
+      if (std::abs(r) > epsilon) fails++;
     }
 
     assert(fails == 0);
 
     alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, axpyKernel(), x_d.data(), y_d.data(), z_d.data()));
-    alpaka::wait(queue);
 
     alpaka::memcpy(queue, z_h, z_d);
 
-    for (int i = 0; i < len * nSrc; i++) {
-      const data_t res = c * _x[i] + _y[i];
+    alpaka::wait(queue);
+
+    for( int i = 0; i < len*nSrc; i++) {
+      const data_t res = s * x_view[i] + y_view[i];
       //
-      const data_t r = res - _z[i];
+      const data_t r = res - z_view[i];
       //
-      if (std::abs(r) > epsilon)
-        fails++;
+      if (std::abs(r) > epsilon) fails++;
     }
 
     assert(fails == 0);
+
+    alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, dotKernel(), x_d.data(), y_d.data(), result_d.data()));
+
+    alpaka::memcpy(queue, result_h, result_d);
+
+    alpaka::wait(queue);
+
+    for( int i = 0; i < len; i++) {
+      data_t res = x_view[i] * y_view[i];
+      for (int j = 1; j < nSrc; j++) res += x_view[i+j*len] * y_view[i+j*len];
+      //
+      const data_t r = res - result_view[i];
+      //
+      if (std::abs(r) > epsilon) fails++;
+    }
+
+    assert(fails == 0);    
   }
   std::cout << "TEST PASSED" << std::endl;
   return 0;


### PR DESCRIPTION
#### PR description:
This PR introduces lightweight math-vector utilities for basic algebraic operations in Alpaka algorithms. It extends VecArray accordingly, in particular, adds a small set of operators/helpers (e.g., element-wise ops, dot, axpy, norms) with constexpr  device-compatible implementations and keeps existing VecArray APIs intact.  This functionality is required for Alpaka electron seeding algorithm implementation (currently WIP). 
resolves https://github.com/cms-sw/framework-team/issues/1516#issue-3304464621

#### PR validation:

