### PR TITLE
Add tracker-driven electrons in PbPb eras

### DIFF
--- a/RecoParticleFlow/PFTracking/python/mergedElectronSeeds_cfi.py
+++ b/RecoParticleFlow/PFTracking/python/mergedElectronSeeds_cfi.py
@@ -3,6 +3,4 @@ import FWCore.ParameterSet.Config as cms
 from RecoParticleFlow.PFTracking.modules import ElectronSeedMerger
 electronMergedSeeds = ElectronSeedMerger()
 
-from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-pp_on_AA.toModify(electronMergedSeeds, TkBasedSeeds = '')
 

--- a/TrackingTools/GsfTracking/python/GsfElectronTracking_cff.py
+++ b/TrackingTools/GsfTracking/python/GsfElectronTracking_cff.py
@@ -7,8 +7,6 @@ from RecoParticleFlow.PFTracking.mergedElectronSeeds_cfi import *
 electronSeedsTask = cms.Task(trackerDrivenElectronSeeds,ecalDrivenElectronSeeds,electronMergedSeeds) 
 electronSeeds = cms.Sequence(electronSeedsTask)
 
-from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-pp_on_AA.toReplaceWith(electronSeedsTask, electronSeedsTask.copyAndExclude([trackerDrivenElectronSeeds]))
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 _fastSim_electronSeedsTask = electronSeedsTask.copy()


### PR DESCRIPTION
#### PR description:

Currently there is a significant electron reconstruction inefficiency in central PbPb collisions (mostly dominated by ECAL-driven electrons), specially for electrons of pT < 50 GeV, which can be partially recovered with tracker-driven electrons (disabled at the moment in PbPb eras).

This PR adds back the tracker-driven electrons in the PbPb eras in order to improve the electron efficiency while we investigate the cause of the ECAL-driven inefficiency vs centrality.

These changes were checked offline with an embedded DY->ee 2023 PbPb MC simulation showing the improvement in electron efficiency.
And the timing and event size were checked with 10k minbias events from 2023 PbPb data, showing an increase of at most 1.5% in reco timing and no significant increase in total MiniAOD event size.

@mandrenguyen @pfs @RSalvatico 

#### PR validation:

Tested with workflows 161,161.02,161.03,161.1,161.2,161.3,161.4

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
