### PR TITLE
add and use isUninitialized() accessor for InputTag

### DIFF
--- a/Calibration/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.cc
+++ b/Calibration/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.cc
@@ -115,7 +115,7 @@ SelectedElectronFEDListProducer<TEle, TCand>::SelectedElectronFEDListProducer(co
   else
     beamSpotTag_ = edm::InputTag("hltOnlineBeamSpot");
 
-  if (!(beamSpotTag_ == edm::InputTag("")))
+  if (!beamSpotTag_.isUninitialized())
     beamSpotToken_ = consumes<reco::BeamSpot>(beamSpotTag_);
 
   LogDebug("SelectedElectronFEDListProducer") << " Beam Spot Tag " << beamSpotTag_ << std::endl;
@@ -126,7 +126,7 @@ SelectedElectronFEDListProducer<TEle, TCand>::SelectedElectronFEDListProducer(co
   else
     HBHERecHitTag_ = edm::InputTag("hltHbhereco");
 
-  if (!(HBHERecHitTag_ == edm::InputTag("")))
+  if (!HBHERecHitTag_.isUninitialized())
     hbheRecHitToken_ = consumes<HBHERecHitCollection>(HBHERecHitTag_);
 
   // raw data collector label
@@ -135,7 +135,7 @@ SelectedElectronFEDListProducer<TEle, TCand>::SelectedElectronFEDListProducer(co
   else
     rawDataTag_ = edm::InputTag("rawDataCollector");
 
-  if (!(rawDataTag_ == edm::InputTag("")))
+  if (!rawDataTag_.isUninitialized())
     rawDataToken_ = consumes<FEDRawDataCollection>(rawDataTag_);
 
   LogDebug("SelectedElectronFEDListProducer") << " RawDataInput " << rawDataTag_ << std::endl;
@@ -347,12 +347,12 @@ void SelectedElectronFEDListProducer<TEle, TCand>::produce(edm::Event& iEvent, c
   // event by event analysis
   // Get event raw data
   edm::Handle<FEDRawDataCollection> rawdata;
-  if (!(rawDataTag_ == edm::InputTag("")))
+  if (!rawDataTag_.isUninitialized())
     iEvent.getByToken(rawDataToken_, rawdata);
 
   // take the beam spot position
   edm::Handle<reco::BeamSpot> beamSpot;
-  if (!(beamSpotTag_ == edm::InputTag("")))
+  if (!beamSpotTag_.isUninitialized())
     iEvent.getByToken(beamSpotToken_, beamSpot);
   if (!beamSpot.failedToGet())
     beamSpotPosition_ = beamSpot->position();
@@ -361,7 +361,7 @@ void SelectedElectronFEDListProducer<TEle, TCand>::produce(edm::Event& iEvent, c
 
   // take the calo tower collection
   edm::Handle<HBHERecHitCollection> hbheRecHitHandle;
-  if (!(HBHERecHitTag_ == edm::InputTag("")))
+  if (!HBHERecHitTag_.isUninitialized())
     iEvent.getByToken(hbheRecHitToken_, hbheRecHitHandle);
   const HBHERecHitCollection* hcalRecHitCollection = nullptr;
   if (!hbheRecHitHandle.failedToGet())

--- a/FWCore/Utilities/interface/InputTag.h
+++ b/FWCore/Utilities/interface/InputTag.h
@@ -44,6 +44,8 @@ namespace edm {
 
     void cacheToken(EDGetToken) const;
 
+    bool isUninitialized() const;
+
     static const std::string kSkipCurrentProcess;
     static const std::string kCurrentProcess;
 

--- a/FWCore/Utilities/src/InputTag.cc
+++ b/FWCore/Utilities/src/InputTag.cc
@@ -108,6 +108,10 @@ namespace edm {
 
   void InputTag::cacheToken(EDGetToken token) const { token_.store(token); }
 
+  bool InputTag::isUninitialized() const {
+    return label_.empty() and instance_.empty() and process_.empty();
+  }
+
   std::ostream& operator<<(std::ostream& ost, InputTag const& tag) {
     static std::string const process(", process = ");
     ost << "InputTag:  label = " << tag.label() << ", instance = " << tag.instance()

--- a/FWCore/Utilities/src/InputTag.cc
+++ b/FWCore/Utilities/src/InputTag.cc
@@ -108,9 +108,7 @@ namespace edm {
 
   void InputTag::cacheToken(EDGetToken token) const { token_.store(token); }
 
-  bool InputTag::isUninitialized() const {
-    return label_.empty() and instance_.empty() and process_.empty();
-  }
+  bool InputTag::isUninitialized() const { return label_.empty() and instance_.empty() and process_.empty(); }
 
   std::ostream& operator<<(std::ostream& ost, InputTag const& tag) {
     static std::string const process(", process = ");

--- a/FWCore/Utilities/src/InputTag.cc
+++ b/FWCore/Utilities/src/InputTag.cc
@@ -108,7 +108,7 @@ namespace edm {
 
   void InputTag::cacheToken(EDGetToken token) const { token_.store(token); }
 
-  bool InputTag::isUninitialized() const { return label_.empty() and instance_.empty() and process_.empty(); }
+  bool InputTag::isUninitialized() const { return label_.empty(); }
 
   std::ostream& operator<<(std::ostream& ost, InputTag const& tag) {
     static std::string const process(", process = ");

--- a/HLTrigger/Muon/plugins/HLTMuonTrkFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonTrkFilter.cc
@@ -96,7 +96,7 @@ bool HLTMuonTrkFilter::hltFilter(edm::Event& iEvent,
   std::vector<l1extra::L1MuonParticleRef>::iterator vl1cands_end;
 
   bool check_l1match = true;
-  if (m_previousCandTag == edm::InputTag(""))
+  if (m_previousCandTag.isUninitialized())
     check_l1match = false;
   if (check_l1match) {
     iEvent.getByToken(m_previousCandToken, previousLevelCands);

--- a/HLTrigger/Muon/plugins/HLTMuonTrkL1TFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonTrkL1TFilter.cc
@@ -94,7 +94,7 @@ bool HLTMuonTrkL1TFilter::hltFilter(edm::Event& iEvent,
   std::vector<l1t::MuonRef>::iterator vl1cands_end;
 
   bool check_l1match = true;
-  if (m_previousCandTag == edm::InputTag(""))
+  if (m_previousCandTag.isUninitialized())
     check_l1match = false;
   if (check_l1match) {
     iEvent.getByToken(m_previousCandToken, previousLevelCands);

--- a/HLTrigger/Muon/plugins/HLTMuonTrkL1TkMuFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonTrkL1TkMuFilter.cc
@@ -73,7 +73,7 @@ bool HLTMuonTrkL1TkMuFilter::hltFilter(edm::Event& iEvent,
 
   std::vector<l1t::P2GTCandidateRef> vl1cands;
   bool check_l1match = true;
-  if (m_l1GTAlgoBlockTag == edm::InputTag("") || m_l1GTAlgoNames.empty())
+  if (m_l1GTAlgoBlockTag.isUninitialized() || m_l1GTAlgoNames.empty())
     check_l1match = false;
   if (check_l1match) {
     const l1t::P2GTAlgoBlockMap& algos = iEvent.get(m_algoBlockToken);

--- a/L1Trigger/L1TGlobal/plugins/L1TExtCondProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TExtCondProducer.cc
@@ -96,7 +96,7 @@ L1TExtCondProducer::L1TExtCondProducer(const ParameterSet& iConfig)
 
   tcdsRecordToken_ = consumes<TCDSRecord>(tcdsInputTag_);
   // Note that the tcdsRecord input tag should be used as InputTag("unpackTcds","tcdsRecord") only for data
-  if (!(tcdsInputTag_ == edm::InputTag(""))) {
+  if (!tcdsInputTag_.isUninitialized()) {
     makeTriggerRulePrefireVetoBit_ = true;
   }
 

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
@@ -821,7 +821,7 @@ void TrackListMerger::produce(edm::Event& e, const edm::EventSetup& es) {
           }  //valid hit
         }  //nhit!=0
 
-        if (doRekeyOnThisSeed && !(clusterRemovalInfos == edm::InputTag(""))) {
+        if (doRekeyOnThisSeed && !clusterRemovalInfos.isUninitialized()) {
           ClusterRemovalRefSetter refSetter(e, clusterRemovalInfos);
           TrajectorySeed::RecHitContainer newRecHitContainer;
           newRecHitContainer.reserve(origSeedRef->nHits());

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.cc
@@ -60,7 +60,7 @@ MeasurementTrackerEventProducer::MeasurementTrackerEventProducer(const edm::Para
     isPhase2_ = true;
   }
   if (!iConfig.getParameter<edm::InputTag>("vectorHits").isUninitialized() ||
-       iConfig.getParameter<edm::InputTag>("vectorHitsRej").isUninitialized()) {
+      iConfig.getParameter<edm::InputTag>("vectorHitsRej").isUninitialized()) {
     thePh2OTVectorHitsLabel = consumes<VectorHitCollection>(iConfig.getParameter<edm::InputTag>("vectorHits"));
     thePh2OTVectorHitsRejLabel = consumes<VectorHitCollection>(iConfig.getParameter<edm::InputTag>("vectorHitsRej"));
     isPhase2_ = true;

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.cc
@@ -35,7 +35,7 @@ MeasurementTrackerEventProducer::MeasurementTrackerEventProducer(const edm::Para
 
   //the measurement tracking is set to skip clusters, the other option is set from outside
   edm::InputTag skip = iConfig.getParameter<edm::InputTag>("skipClusters");
-  selfUpdateSkipClusters_ = !(skip == edm::InputTag(""));
+  selfUpdateSkipClusters_ = !skip.isUninitialized();
   LogDebug("MeasurementTracker") << "skipping clusters: " << selfUpdateSkipClusters_;
   isPhase2_ = false;
   useVectorHits_ = false;
@@ -59,8 +59,8 @@ MeasurementTrackerEventProducer::MeasurementTrackerEventProducer(const edm::Para
         edm::InputTag(iConfig.getParameter<std::string>("Phase2TrackerCluster1DProducer")));
     isPhase2_ = true;
   }
-  if (!(iConfig.getParameter<edm::InputTag>("vectorHits") == edm::InputTag("") ||
-        iConfig.getParameter<edm::InputTag>("vectorHitsRej") == edm::InputTag(""))) {
+  if (!iConfig.getParameter<edm::InputTag>("vectorHits").isUninitialized() ||
+       iConfig.getParameter<edm::InputTag>("vectorHitsRej").isUninitialized()) {
     thePh2OTVectorHitsLabel = consumes<VectorHitCollection>(iConfig.getParameter<edm::InputTag>("vectorHits"));
     thePh2OTVectorHitsRejLabel = consumes<VectorHitCollection>(iConfig.getParameter<edm::InputTag>("vectorHitsRej"));
     isPhase2_ = true;

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.cc
@@ -59,8 +59,8 @@ MeasurementTrackerEventProducer::MeasurementTrackerEventProducer(const edm::Para
         edm::InputTag(iConfig.getParameter<std::string>("Phase2TrackerCluster1DProducer")));
     isPhase2_ = true;
   }
-  if (!iConfig.getParameter<edm::InputTag>("vectorHits").isUninitialized() ||
-      iConfig.getParameter<edm::InputTag>("vectorHitsRej").isUninitialized()) {
+  if (!(iConfig.getParameter<edm::InputTag>("vectorHits").isUninitialized() ||
+        iConfig.getParameter<edm::InputTag>("vectorHitsRej").isUninitialized())) {
     thePh2OTVectorHitsLabel = consumes<VectorHitCollection>(iConfig.getParameter<edm::InputTag>("vectorHits"));
     thePh2OTVectorHitsRejLabel = consumes<VectorHitCollection>(iConfig.getParameter<edm::InputTag>("vectorHitsRej"));
     isPhase2_ = true;

--- a/RecoTracker/TkSeedGenerator/plugins/SeedCombiner.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedCombiner.cc
@@ -36,7 +36,7 @@ SeedCombiner::SeedCombiner(const edm::ParameterSet& cfg) {
     clusterRemovalInfos_ = cfg.getParameter<std::vector<edm::InputTag> >("clusterRemovalInfos");
     clusterRemovalTokens_.resize(clusterRemovalInfos_.size());
     for (unsigned int i = 0; i < clusterRemovalInfos_.size(); ++i)
-      if (!(clusterRemovalInfos_[i] == edm::InputTag("")))
+      if (!clusterRemovalInfos_[i].isUninitialized())
         clusterRemovalTokens_[i] = consumes<reco::ClusterRemovalInfo>(clusterRemovalInfos_[i]);
     if (!clusterRemovalInfos_.empty() && clusterRemovalInfos_.size() == inputCollections_.size())
       reKeing_ = true;
@@ -61,7 +61,7 @@ void SeedCombiner::produce(edm::Event& ev, const edm::EventSetup& es) {
   unsigned int iSC = 0, iSC_max = seedCollections.size();
   for (; iSC != iSC_max; ++iSC) {
     Handle<TrajectorySeedCollection>& collection = seedCollections[iSC];
-    if (reKeing_ && !(clusterRemovalInfos_[iSC] == edm::InputTag(""))) {
+    if (reKeing_ && !clusterRemovalInfos_[iSC].isUninitialized()) {
       ClusterRemovalRefSetter refSetter(ev, clusterRemovalTokens_[iSC]);
 
       for (TrajectorySeedCollection::const_iterator iS = collection->begin(); iS != collection->end(); ++iS) {

--- a/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
+++ b/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
@@ -124,7 +124,7 @@ void ClusterTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, co
   // Strip Cluster (other product, if there)
   bool foundOtherStripClusters = false;
   edm::Handle<edmNew::DetSetVector<SiStripCluster> > stripClustersOther;
-  if (otherStripClusterTag_ != edm::InputTag(""))
+  if (!otherStripClusterTag_.isUninitialized())
     foundOtherStripClusters = iEvent.getByToken(stripClustersOtherToken_, stripClustersOther);
 
   // Phase2 Cluster

--- a/Validation/HcalDigis/src/HcalDigisValidation.cc
+++ b/Validation/HcalDigis/src/HcalDigisValidation.cc
@@ -46,7 +46,7 @@ HcalDigisValidation::HcalDigisValidation(const edm::ParameterSet& iConfig) {
   tok_ho_ = consumes<HODigiCollection>(inputTag_);
   tok_hf_ = consumes<HFDigiCollection>(inputTag_);
   tok_emulTPs_ = consumes<HcalTrigPrimDigiCollection>(emulTPsTag_);
-  if (dataTPsTag_ == edm::InputTag(""))
+  if (dataTPsTag_.isUninitialized())
     skipDataTPs = true;
   else {
     skipDataTPs = false;

--- a/Validation/HcalDigis/test/HcalDigiStudy.cc
+++ b/Validation/HcalDigis/test/HcalDigiStudy.cc
@@ -183,7 +183,7 @@ HcalDigiStudy::HcalDigiStudy(const edm::ParameterSet& iConfig) {
   tok_ho_ = consumes<HODigiCollection>(inputTag_);
   tok_hf_ = consumes<HFDigiCollection>(inputTag_);
   tok_emulTPs_ = consumes<HcalTrigPrimDigiCollection>(emulTPsTag_);
-  if (dataTPsTag_ == edm::InputTag("")) {
+  if (dataTPsTag_.isUninitialized()) {
     skipDataTPs = true;
     skipTPs = true;
   } else {


### PR DESCRIPTION
#### PR description:

`InputTag("")` is frequently used to represent a default/empty value. Comparing to this value involves constructing an `InputTag` object and then using its equality operator, which is unnecessarily expensive. The `InputTag` fields (strings) have STL `empty()` accessors that immediately return the desired status. This PR wraps those into a single accessor for convenience.

All such comparisons that I could find with `git grep` are updated.

#### PR validation:

Code compiles. (Did not try a full checkdeps recompilation because it requires 922 packages; will leave that for the bot.)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, not intended to be backported.