### PR TITLE
[15.0.X] Technical follow ups to #48702

### DIFF
--- a/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
+++ b/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
@@ -2,14 +2,15 @@
 #include <vector>
 #include <utility>
 
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/Utilities/interface/EDGetToken.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
@@ -183,10 +184,10 @@ void ClusterTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, co
          ++iter) {
       uint32_t detid = iter->id();
       DetId detId(detid);
-      edmNew::DetSet<SiPixelCluster> link_pixel = (*iter);
-      for (edmNew::DetSet<SiPixelCluster>::const_iterator di = link_pixel.begin(); di != link_pixel.end(); ++di) {
-        const SiPixelCluster& cluster = (*di);
-        edm::Ref<edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster> c_ref = edmNew::makeRefTo(pixelClusters, di);
+      const auto& link_pixel = (*iter);
+      for (const auto& cluster : link_pixel) {
+        auto di = &cluster - &*link_pixel.begin();
+        auto c_ref = edmNew::makeRefTo(pixelClusters, link_pixel.begin() + di);
 
         simTkIds.clear();
         for (int irow = cluster.minPixelRow(); irow <= cluster.maxPixelRow(); ++irow) {
@@ -197,10 +198,13 @@ void ClusterTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, co
             simTkIds.insert(trkid.begin(), trkid.end());
           }
         }
-        for (auto iset = simTkIds.begin(); iset != simTkIds.end(); iset++) {
-          auto ipos = mapping.find(*iset);
+
+        for (const auto& simTkId : simTkIds) {
+          auto ipos = mapping.find(simTkId);
           if (ipos != mapping.end()) {
-            //std::cout << "cluster in detid: " << detid << " from tp: " << ipos->second.key() << " " << iset->first << std::endl;
+            LogDebug("ClusterTPAssociationProducer")
+                << "cluster in detid: " << detid << " from tp: " << ipos->second.key() << " " << simTkId.first
+                << std::endl;
             clusterTPList->emplace_back(OmniClusterRef(c_ref), ipos->second);
           }
         }
@@ -219,10 +223,10 @@ void ClusterTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, co
         continue;
       uint32_t detid = iter->id();
       DetId detId(detid);
-      edmNew::DetSet<SiStripCluster> link_strip = (*iter);
-      for (edmNew::DetSet<SiStripCluster>::const_iterator di = link_strip.begin(); di != link_strip.end(); di++) {
-        const SiStripCluster& cluster = (*di);
-        edm::Ref<edmNew::DetSetVector<SiStripCluster>, SiStripCluster> c_ref = edmNew::makeRefTo(stripClusters, di);
+      const auto& link_strip = (*iter);
+      for (const auto& cluster : link_strip) {
+        auto di = &cluster - &*link_strip.begin();
+        auto c_ref = edmNew::makeRefTo(stripClusters, link_strip.begin() + di);
 
         simTkIds.clear();
         int first = cluster.firstStrip();
@@ -233,10 +237,13 @@ void ClusterTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, co
           getSimTrackId<StripDigiSimLink>(trkid, sistripSimLinks, detId, istr);
           simTkIds.insert(trkid.begin(), trkid.end());
         }
-        for (auto iset = simTkIds.begin(); iset != simTkIds.end(); iset++) {
-          auto ipos = mapping.find(*iset);
+
+        for (const auto& simTkId : simTkIds) {
+          const auto& ipos = mapping.find(simTkId);
           if (ipos != mapping.end()) {
-            //std::cout << "cluster in detid: " << detid << " from tp: " << ipos->second.key() << " " << iset->first << std::endl;
+            LogDebug("ClusterTPAssociationProducer")
+                << "cluster in detid: " << detid << " from tp: " << ipos->second.key() << " " << simTkId.first
+                << std::endl;
             clusterTPList->emplace_back(OmniClusterRef(c_ref), ipos->second);
           }
         }

--- a/SimTracker/TrackerHitAssociation/src/classes_def.xml
+++ b/SimTracker/TrackerHitAssociation/src/classes_def.xml
@@ -14,7 +14,7 @@
 
   <class name="std::pair<OmniClusterRef, TrackingParticleRef>" persistent="true" />
   <class name="std::vector<std::pair<OmniClusterRef, TrackingParticleRef> >" />
-  <class name="ClusterTPAssociation" persistent="true" />
+  <class name="ClusterTPAssociation" persistent="false" />
   <class name="edm::Wrapper<ClusterTPAssociation>" />
   <class name="std::map<TrackingParticleRef, std::vector<OmniClusterRef> >" persistent="false" /> 
   <class name="edm::Wrapper<std::map<TrackingParticleRef, std::vector<OmniClusterRef> > >" persistent="false" /> 


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/48731

#### PR description:

Title says it all, as a follow-up of the (post-merge) review of https://github.com/cms-sw/cmssw/pull/48701

#### PR validation:

 `runTheMatrix.py -l 17034.0,16834.0 --ibeos`
 
 runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/48731 to the 2025 data-taking release.