### PR TITLE
[15_0_X] Always initialize `PortableHostObject::product_`

### DIFF
--- a/DataFormats/Portable/interface/PortableHostObject.h
+++ b/DataFormats/Portable/interface/PortableHostObject.h
@@ -112,7 +112,7 @@ public:
 
 private:
   std::optional<Buffer> buffer_;  //!
-  Product* product_;
+  Product* product_ = nullptr;
 };
 
 #endif  // DataFormats_Portable_interface_PortableHostObject_h

--- a/DataFormats/Portable/interface/PortableHostObjectReadRules.h
+++ b/DataFormats/Portable/interface/PortableHostObjectReadRules.h
@@ -33,8 +33,13 @@ static void readPortableHostObject_v1(char *target, TVirtualObject *from_buffer)
   // pointer to the Object object being constructed in memory
   Object *newObj = (Object *)target;
 
-  // move the data from the on-file layout to the newly constructed object
-  Object::ROOTReadStreamer(newObj, *onfile.product_);
+  // product_ can be null if the Wrapper<PortableHostObject<T>> was
+  // default-constructed because a producer did not produce the
+  // product
+  if (onfile.product_) {
+    // move the data from the on-file layout to the newly constructed object
+    Object::ROOTReadStreamer(newObj, *onfile.product_);
+  }
 }
 
 // put set_PortableHostObject_read_rules in the ROOT namespace to let it forward declare GenerateInitInstance


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/48668. Original PR description
> OutputModules can construct the PortableHostObject via the "uninitialized" constructor if no producer produced the data product. Explicit null value for the pointer communicates the absence of data to ROOT.


#### PR validation:

None beyond #48668

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #48668