### PR TITLE
GEM Eta-partition id check in Muon-Rechit matching

### DIFF
--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -275,7 +275,8 @@ void MuonIdProducer::init(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     iEvent.getByToken(glbQualToken_, glbQualHandle_);
   if (selectHighPurity_)
     iEvent.getByToken(pvToken_, pvHandle_);
-  gemgeom = &iSetup.getData(gemgeomToken_);
+  if (gemHitHandle_.isValid())
+    gemgeom = &iSetup.getData(gemgeomToken_);
 }
 
 reco::Muon MuonIdProducer::makeMuon(edm::Event& iEvent,
@@ -1123,14 +1124,15 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent,
         gemHitMatch.x = gemRecHit.localPosition().x();
         gemHitMatch.mask = 0;
         gemHitMatch.bx = gemRecHit.BunchX();
-        
+
         const GeomDet* geomDet = gemgeom->idToDetUnit(chamber.id);
         const GlobalPoint& global_position = geomDet->toGlobal(lPos);
         if (const GEMChamber* gemChamber = dynamic_cast<const GEMChamber*>(geomDet)) {
           const GeomDet* eta_geomdet = gemChamber->component(gemRecHit.gemId());
           const GEMEtaPartition* eta_partition = dynamic_cast<const GEMEtaPartition*>(eta_geomdet);
           float bordercut = 2;
-          const TrapezoidalPlaneBounds* bounds = dynamic_cast<const TrapezoidalPlaneBounds*>(&eta_partition->surface().bounds());
+          const TrapezoidalPlaneBounds* bounds =
+              dynamic_cast<const TrapezoidalPlaneBounds*>(&eta_partition->surface().bounds());
           LocalPoint localPoint = eta_partition->surface().toLocal(global_position);
           float wideWidth = bounds->width();
           float narrowWidth = 2.f * bounds->widthAtHalfLength() - wideWidth;
@@ -1242,8 +1244,8 @@ void MuonIdProducer::fillArbitrationInfo(reco::MuonCollection* pOutputMuons, uns
                     arbitrationPairs.push_back(std::make_pair(&chamber2, &segment2));
                   }
                 }  // segmentIter2
-              }    // chamberIter2
-            }      // muonIndex2
+              }  // chamberIter2
+            }  // muonIndex2
           }
 
           // arbitration segment sort

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -61,6 +61,7 @@
 #include "RecoMuon/MuonIdentification/interface/MuonIdTruthInfo.h"
 #include "RecoMuon/MuonIdentification/interface/MuonArbitrationMethods.h"
 #include "DataFormats/Common/interface/ValueMap.h"
+#include "Geometry/GEMGeometry/interface/GEMGeometry.h"
 
 class MuonMesh;
 class MuonKinkFinder;
@@ -79,6 +80,8 @@ public:
   static double sectorPhi(const DetId& id);
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  
+  bool checkBounds(const GeomDet* geomDet, const GlobalPoint& global_position, const float bordercut);
 
 private:
   void fillMuonId(edm::Event&,
@@ -281,5 +284,8 @@ private:
 
   bool arbClean_;
   std::unique_ptr<MuonMesh> meshAlgo_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemgeomToken_;
+  const GEMGeometry* gemgeom;
+  double GEM_edgecut_;
 };
 #endif

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -80,8 +80,6 @@ public:
   static double sectorPhi(const DetId& id);
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  
-  bool checkBounds(const GeomDet* geomDet, const GlobalPoint& global_position, const float bordercut);
 
 private:
   void fillMuonId(edm::Event&,


### PR DESCRIPTION
#### PR description:

This PR adds an eta-partition identity check to the `GEMChamberMatch–GEMRechit` matching so that a `GEMHitMatch–GEMChamberMatch` pair is kept only when both objects belong to the same physical η partition (`ieta`). By doing this check, we can reduce spurious matches.
It will affect the number of GEMMuons, which are muons with at least one matched GEM rechit. With this change, the number of GEMMuons will decrease by removing irrelevant matches.  
Slides detailing this change were presented to the GEM DPG group.
https://indico.cern.ch/event/1577119/contributions/6645023/subcontributions/566782/attachments/3117123/5526888/GEMmergeexp_.pdf
The number of TrackerMuons aren't affected, and we don't expect any changes to physics muon properties.

#### PR validation:

runTheMatrix.py -l limited -i all --ibeos
`50 49 46 41 19 1 1 1 1 1 1 tests passed, 0 0 1 0 0 0 0 0 0 0 0 failed`
1 fail also fails on the plain master branch.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 150X.

@watson-ij @jshlee 