### PR TITLE
New HLTFilter to read out L1P2GT tau candidates at Phase-2 HLT

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltL1P2GTTau_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltL1P2GTTau_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+hltL1P2GTTau = cms.EDFilter("HLTP2GTTauFilter",
+    maxAbsEta = cms.double(1e+99),
+    minN = cms.uint32(1),
+    minPt = cms.double(5.0),
+    l1GTAlgoBlockTag = cms.InputTag("l1tGTAlgoBlockProducer"),
+    l1GTAlgoNames = cms.vstring("pDoublePuppiTau52_52"),
+    saveTags = cms.bool(True)
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_DoubleMediumChargedIsoPFTauHPS40_eta2p1_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_DoubleMediumChargedIsoPFTauHPS40_eta2p1_cfi.py
@@ -15,11 +15,11 @@ from ..sequences.HLTPFTauHPS_cfi import *
 from ..sequences.HLTTrackingSequence_cfi import *
 from ..sequences.HLTLocalrecoSequence_cfi import *
 from ..sequences.HLTRawToDigiSequence_cfi import *
-from ..modules.hltL1SeedForDoublePuppiTau_cfi import *
+from ..modules.hltL1P2GTTau_cfi import *
 
 HLT_DoubleMediumChargedIsoPFTauHPS40_eta2p1 = cms.Path(
     HLTBeginSequence
-    + hltL1SeedForDoublePuppiTau
+    + hltL1P2GTTau
     + hltPreDoublePFTauHPS
     + HLTRawToDigiSequence
     + HLTLocalrecoSequence

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1_cfi.py
@@ -15,11 +15,11 @@ from ..sequences.HLTPFTauHPS_cfi import *
 from ..sequences.HLTTrackingSequence_cfi import *
 from ..sequences.HLTLocalrecoSequence_cfi import *
 from ..sequences.HLTRawToDigiSequence_cfi import *
-from ..modules.hltL1SeedForDoublePuppiTau_cfi import *
+from ..modules.hltL1P2GTTau_cfi import *
 
 HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1 = cms.Path(
     HLTBeginSequence
-    + hltL1SeedForDoublePuppiTau
+    + hltL1P2GTTau
     + hltPreDoublePFTauHPS
     + HLTRawToDigiSequence
     + HLTLocalrecoSequence

--- a/HLTrigger/HLTfilters/plugins/HLTP2GTTauFilter.cc
+++ b/HLTrigger/HLTfilters/plugins/HLTP2GTTauFilter.cc
@@ -1,0 +1,89 @@
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "DataFormats/L1Trigger/interface/P2GTCandidate.h"
+#include "DataFormats/L1Trigger/interface/P2GTAlgoBlock.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+class HLTP2GTTauFilter : public HLTFilter {
+public:
+  explicit HLTP2GTTauFilter(const edm::ParameterSet&);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs&) const override;
+
+private:
+  edm::InputTag m_l1GTAlgoBlockTag;
+  edm::EDGetTokenT<l1t::P2GTAlgoBlockMap> m_algoBlockToken;
+  std::vector<std::string> m_l1GTAlgoNames;
+  double m_minPt;
+  unsigned int m_minN;
+  double m_maxAbsEta;
+};
+
+HLTP2GTTauFilter::HLTP2GTTauFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) {
+  m_l1GTAlgoBlockTag = iConfig.getParameter<edm::InputTag>("l1GTAlgoBlockTag");
+  m_algoBlockToken = consumes<l1t::P2GTAlgoBlockMap>(m_l1GTAlgoBlockTag);
+  m_l1GTAlgoNames = iConfig.getParameter<std::vector<std::string>>("l1GTAlgoNames");
+  m_minPt = iConfig.getParameter<double>("minPt");
+  m_minN = iConfig.getParameter<unsigned int>("minN");
+  m_maxAbsEta = iConfig.getParameter<double>("maxAbsEta");
+}
+
+void HLTP2GTTauFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  makeHLTFilterDescription(desc);
+  desc.add<edm::InputTag>("l1GTAlgoBlockTag", edm::InputTag(""));
+  desc.add<std::vector<std::string>>("l1GTAlgoNames", {});
+  desc.add<double>("minPt", 24);
+  desc.add<unsigned int>("minN", 1);
+  desc.add<double>("maxAbsEta", 1e99);
+  descriptions.add("HLTP2GTTauFilter", desc);
+}
+
+bool HLTP2GTTauFilter::hltFilter(edm::Event& iEvent,
+                                 const edm::EventSetup& iSetup,
+                                 trigger::TriggerFilterObjectWithRefs& filterproduct) const {
+  std::vector<l1t::P2GTCandidateRef> vl1cands;
+  if (saveTags()) {
+    filterproduct.addCollectionTag(m_l1GTAlgoBlockTag);  // algorithm blocks
+  }
+  bool check_l1match = true;
+  if (m_l1GTAlgoBlockTag.isUninitialized() || m_l1GTAlgoNames.empty())
+    check_l1match = false;
+  if (check_l1match) {
+    const l1t::P2GTAlgoBlockMap& algos = iEvent.get(m_algoBlockToken);
+    for (const auto& algoName : m_l1GTAlgoNames) {
+      auto it = algos.find(algoName);
+      if (it != algos.end() && it->second.decisionBeforeBxMaskAndPrescale()) {
+        const l1t::P2GTCandidateVectorRef& objects = it->second.trigObjects();
+        for (const l1t::P2GTCandidateRef& obj : objects) {
+          if (obj->objectType() == l1t::P2GTCandidate::CL2Taus && obj->pt() >= m_minPt &&
+              std::abs(obj->eta()) <= m_maxAbsEta) {
+            vl1cands.push_back(obj);
+          }
+        }
+      }
+    }
+  }
+
+  if (saveTags()) {
+    edm::InputTag tagOld;
+    for (size_t i = 0; i < vl1cands.size(); ++i) {
+      const auto& cand = vl1cands[i];
+      const edm::ProductID pid(cand.id());
+      const auto& prov = iEvent.getStableProvenance(pid);
+      edm::InputTag tagNew(prov.moduleLabel(), prov.productInstanceName(), prov.processName());
+      if (tagNew.encode() != tagOld.encode()) {
+        filterproduct.addCollectionTag(tagNew);
+        tagOld = tagNew;
+      }
+    }
+  }
+  for (const auto& vl1cand : vl1cands) {
+    filterproduct.addObject(trigger::TriggerL1Tau, vl1cand);
+  }
+
+  return vl1cands.size() >= m_minN;
+}
+DEFINE_FWK_MODULE(HLTP2GTTauFilter);


### PR DESCRIPTION
#### PR description:

This PR adds a new HLTFilter module for Phase-2 designed to read out L1 tau objects and make them available for use downstream. Mainly, this allows us to check the L1 object efficiencies on-the-fly with the HLT Upgrade validation app currently under development (https://cmshltvalidation.app.cern.ch/), but it is foreseen to be later used to perform L1-HLT object matching also in the tau HLT paths. 
As this is only a technical swap of the filter module, no impact on the path efficiencies is expected. 

#### PR validation:

Basic tests:
- scram b runtests use-ibeos
- runTheMatrix.py -l limited -i all --ibeos

Also tested on the validation server: https://cmshltvalidation.app.cern.ch/display/sharper/CMSSW_15_1_0_pre4_withL1SeedPR.20250811_084147?view=1&selectedPath=HLT_DoubleMediumChargedIsoPFTauHPS40_eta2p1&selectedFilter=hltL1P2GTTau