### PR TITLE
Deprecate PU trend plot in offline DQM for ECAL

### DIFF
--- a/DQM/EcalMonitorTasks/src/OccupancyTask.cc
+++ b/DQM/EcalMonitorTasks/src/OccupancyTask.cc
@@ -15,6 +15,10 @@ namespace ecaldqm {
     metadataTag = _params.getParameter<edm::InputTag>("metadata");
     lumiCheck_ = _params.getUntrackedParameter<bool>("lumiCheck", false);
     if (!onlineMode_) {
+      MEs_.erase(std::string("PU"));
+      MEs_.erase(std::string("NEvents"));
+      MEs_.erase(std::string("TrendEventsperLumi"));
+      MEs_.erase(std::string("TrendPUperLumi"));
       MEs_.erase(std::string("AELoss"));
       MEs_.erase(std::string("AEReco"));
     }
@@ -47,9 +51,11 @@ namespace ecaldqm {
       MEs_.at("TPDigiThrAllByLumi").reset(GetElectronicsMap());
       MEs_.at("RecHitThrAllByLumi").reset(GetElectronicsMap());
       nEv = 0;
-      MEs_.at("PU").reset(GetElectronicsMap(), -1);
-      MEs_.at("NEvents").reset(GetElectronicsMap(), -1);
-      FindPUinLS = true;
+      if (onlineMode_) {
+        MEs_.at("PU").reset(GetElectronicsMap(), -1);
+        MEs_.at("NEvents").reset(GetElectronicsMap(), -1);
+        FindPUinLS = true;
+      }
     }
     nEv++;
     MESet& meLaserCorrProjEta(MEs_.at("LaserCorrProjEta"));
@@ -97,13 +103,15 @@ namespace ecaldqm {
   }
 
   void OccupancyTask::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
-    MESet& meNEvents(static_cast<MESet&>(MEs_.at("NEvents")));
-    MESet& meTrendEventsperLumi(MEs_.at("TrendEventsperLumi"));
-    MESet& meTrendPUperLumi(MEs_.at("TrendPUperLumi"));
+    if (onlineMode_) {
+      MESet& meNEvents(static_cast<MESet&>(MEs_.at("NEvents")));
+      MESet& meTrendEventsperLumi(MEs_.at("TrendEventsperLumi"));
+      MESet& meTrendPUperLumi(MEs_.at("TrendPUperLumi"));
 
-    meNEvents.fill(getEcalDQMSetupObjects(), double(nEv));
-    meTrendEventsperLumi.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), double(nEv));
-    meTrendPUperLumi.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), double(scal_pu));
+      meNEvents.fill(getEcalDQMSetupObjects(), double(nEv));
+      meTrendEventsperLumi.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), double(nEv));
+      meTrendPUperLumi.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), double(scal_pu));
+    }
   }
 
   template <typename DigiCollection>


### PR DESCRIPTION
#### PR description:

This PR removes a plot (`PU vs LS` in `Trend` workspace in GUI) from ECAL workspace of offline DQM. The plot is deprecated in offline DQM with this PR, as the metadata that the plot is fetching seems not available offline. 

#### PR validation:

This PR is validated by running the code with ECAL DQM configuration. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a master PR. Backport to `15_0_X` is made in #48748.