### PR TITLE
Update Mixing.py to include 100_BX_25ns_m3p3

### DIFF
--- a/Configuration/StandardSequences/python/Mixing.py
+++ b/Configuration/StandardSequences/python/Mixing.py
@@ -172,6 +172,7 @@ addMixingScenario("AVE_90_BX_50ns",{'file': 'SimGeneral.MixingModule.mix_POISSON
 addMixingScenario("AVE_90_BX_25ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':25, 'B': (-12,3), 'N': 90})
 addMixingScenario("AVE_100_BX_50ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':50, 'B': (-12,3), 'N': 100})
 addMixingScenario("AVE_100_BX_25ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':25, 'B': (-12,3), 'N': 100})
+addMixingScenario("AVE_100_BX_25ns_m3p3",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':25, 'B': (-3,3), 'N': 100})
 addMixingScenario("AVE_120_BX_50ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':50, 'B': (-12,3), 'N': 120})
 addMixingScenario("AVE_120_BX_25ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':25, 'B': (-12,3), 'N': 120})
 addMixingScenario("AVE_125_BX_50ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':50, 'B': (-12,3), 'N': 125})


### PR DESCRIPTION
#### PR description:

This PR adds a BX 100 mixing scenario, for fair comparison with BX50 and BX200 scenarios. BX50 and BX200 already have (-3, 3) scenarios.

#### PR validation:

I produced ttbar samples with this mixing scenario and it seems to work as expected.

cc @slava77 