### PR TITLE
Revert "L1Calo , fix Zero Suppression  producer position to get it consistent with o2o definition"

### DIFF
--- a/L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h
+++ b/L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h
@@ -75,9 +75,9 @@ namespace l1t {
       metHFPhiCalibration = 49,
       layer1HCalFBUpper = 50,
       layer1HCalFBLower = 51,
-      layer1ECalZS = 52,
-      layer1HCalZS = 53,
-      hiZDC = 54,
+      hiZDC = 52,
+      layer1ECalZS = 53,
+      layer1HCalZS = 54,
       NUM_CALOPARAMNODES = 55
     };
 


### PR DESCRIPTION
Reverts cms-sw/cmssw#48658

We need to make it other way around and change o2o producer