### PR TITLE
[EventFilter/Utilities] Fix clang static analyzer warning

### DIFF
--- a/EventFilter/Utilities/src/GlobalEventNumber.cc
+++ b/EventFilter/Utilities/src/GlobalEventNumber.cc
@@ -4,12 +4,12 @@ namespace evf {
   namespace evtn {
 
     bool daq_board_sense(const unsigned char *p) {
-      return (*(unsigned int *)(p + FEDHeader::length + DAQ_BOARDID_OFFSET * SLINK_WORD_SIZE / 2) >>
+      return (*(const unsigned int *)(p + FEDHeader::length + DAQ_BOARDID_OFFSET * SLINK_WORD_SIZE / 2) >>
               DAQ_BOARDID_SHIFT) == DAQ_BOARDID_VALUE;
     }
 
     bool gtpe_board_sense(const unsigned char *p) {
-      return (*(unsigned int *)(p + GTPE_BOARDID_OFFSET * SLINK_WORD_SIZE / 2) >> GTPE_BOARDID_SHIFT) != 0;
+      return (*(const unsigned int *)(p + GTPE_BOARDID_OFFSET * SLINK_WORD_SIZE / 2) >> GTPE_BOARDID_SHIFT) != 0;
     }
 
     bool evm_board_sense(const unsigned char *p, size_t size) {


### PR DESCRIPTION
#### PR description:

Fixes these clang analyzer warnings of type "const cast away": [1](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_15_1_X_2025-08-17-2300/el8_amd64_gcc12/llvm-analysis/report-6bbcd4.html#EndPath), [2](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_15_1_X_2025-08-17-2300/el8_amd64_gcc12/llvm-analysis/report-94c9b1.html#EndPath)

#### PR validation:

Bot tests
