### PR TITLE
[RFC][LLVM static analyzer] More strict definition of "public mutable member"

### DIFF
--- a/Utilities/StaticAnalyzers/src/PublicMutableChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/PublicMutableChecker.cpp
@@ -13,7 +13,7 @@ namespace clangcms {
     if (D->hasAttr<clang::CMSThreadGuardAttr>() || D->hasAttr<clang::CMSThreadSafeAttr>() ||
         D->hasAttr<clang::CMSSaAllowAttr>())
       return;
-    if (D->isMutable() && D->getDeclContext()->isRecord() && D->getAccess() != clang::AS_private) {
+    if (D->isMutable() && D->getDeclContext()->isRecord() && D->getAccess() == clang::AS_public) {
       clang::QualType t = D->getType();
       clang::ento::PathDiagnosticLocation DLoc = clang::ento::PathDiagnosticLocation::create(D, BR.getSourceManager());
 


### PR DESCRIPTION
#### PR description:

This PR proposes to make llvm static analyzer emit "public mutable member" warnings only for public members. Currently it emits these warnings for both public and protected members.

#### PR validation:

Bot tests