### PR TITLE
fix ticl barrel in ph-2 HLT configuration

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltMergeLayerClusters_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltMergeLayerClusters_cfi.py
@@ -15,7 +15,7 @@ barrel_time_layerClusters = [x + ":timeLayerCluster" for x in barrel_layerCluste
 # Define the producer with ceh lists
 hltMergeLayerClusters = cms.EDProducer("MergeClusterProducer",
     layerClusters = cms.VInputTag("hltHgcalLayerClustersEE", *ceh_layerClusters),
-    time_layerclusters = cms.VInputTag(*ceh_time_layerClusters),
+    time_layerclusters = cms.VInputTag("hltHgcalLayerClustersEE:timeLayerCluster", *ceh_time_layerClusters),
 )
 
 # Process modifiers: ticl_barrel and alpaka

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltMergeLayerClusters_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltMergeLayerClusters_cfi.py
@@ -22,39 +22,17 @@ hltMergeLayerClusters = cms.EDProducer("MergeClusterProducer",
 from Configuration.ProcessModifiers.alpaka_cff import alpaka
 from Configuration.ProcessModifiers.ticl_barrel_cff import ticl_barrel
 
-(alpaka & (~ticl_barrel)).toModify(hltMergeLayerClusters,
-    layerClusters = cms.VInputTag(
-        "hltHgCalLayerClustersFromSoAProducer",
-        *ceh_layerClusters
-    ),
-    time_layerclusters = cms.VInputTag(
-        "hltHgCalLayerClustersFromSoAProducer:timeLayerCluster",
-        *ceh_time_layerClusters
-    )
+(alpaka & ~ticl_barrel).toModify(hltMergeLayerClusters,
+    layerClusters = ["hltHgCalLayerClustersFromSoAProducer", *ceh_layerClusters],
+    time_layerclusters = ["hltHgCalLayerClustersFromSoAProducer:timeLayerCluster", *ceh_time_layerClusters]
 )
 
-(ticl_barrel & (~alpaka)).toModify(hltMergeLayerClusters,
-    layerClusters = cms.VInputTag(
-        "hltHgcalLayerClustersEE",
-        *ceh_layerClusters,
-        *barrel_layerClusters
-    ),
-    time_layerclusters = cms.VInputTag(
-        "hltHgcalLayerClustersEE:timeLayerCluster",
-        *ceh_time_layerClusters,
-        *barrel_time_layerClusters
-    )
+(ticl_barrel & ~alpaka).toModify(hltMergeLayerClusters,
+    layerClusters = ["hltHgcalLayerClustersEE", *ceh_layerClusters, *barrel_layerClusters],
+    time_layerclusters = ["hltHgcalLayerClustersEE:timeLayerCluster", *ceh_time_layerClusters, *barrel_time_layerClusters]
 )
 
 (ticl_barrel & alpaka).toModify(hltMergeLayerClusters,
-    layerClusters = cms.VInputTag(
-        "hltHgCalLayerClustersFromSoAProducer",
-        *ceh_layerClusters,
-        *barrel_layerClusters
-    ),
-    time_layerclusters = cms.VInputTag(
-        "hltHgCalLayerClustersFromSoAProducer:timeLayerCluster",
-        *ceh_time_layerClusters,
-        *barrel_time_layerClusters
-    )
+    layerClusters = ["hltHgCalLayerClustersFromSoAProducer", *ceh_layerClusters, *barrel_layerClusters],
+    time_layerclusters = ["hltHgCalLayerClustersFromSoAProducer:timeLayerCluster", *ceh_time_layerClusters, *barrel_time_layerClusters]
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/DST_PFScouting_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/DST_PFScouting_cfi.py
@@ -46,8 +46,8 @@ DST_PFScouting = cms.Path(
     HLTBeginSequence
     + hltL1GTAcceptFilter
     + HLTRawToDigiSequence
-    + HLTTICLLocalRecoSequence
     + HLTLocalrecoSequence
+    + HLTTICLLocalRecoSequence
     + HLTTrackingSequence
     + HLTMuonsSequence
     + HLTParticleFlowSequence

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTICLLocalRecoSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTICLLocalRecoSequence_cfi.py
@@ -18,6 +18,9 @@ from ..modules.hltBarrelLayerClustersEB_cfi import *
 from ..modules.hltBarrelLayerClustersHB_cfi import *
 from ..sequences.HLTPfRecHitUnseededSequence_cfi import *
 
+from Configuration.ProcessModifiers.alpaka_cff import alpaka
+from Configuration.ProcessModifiers.ticl_barrel_cff import ticl_barrel
+
 HLTTICLLocalRecoSequence = cms.Sequence(
         hltHGCalUncalibRecHit+
         hltHGCalRecHit+
@@ -36,9 +39,7 @@ _HLTTICLLocalRecoSequence_heterogeneous = cms.Sequence(
         hltHgcalLayerClustersHSci+
         hltHgcalLayerClustersHSi+
         hltMergeLayerClusters)
-
-from Configuration.ProcessModifiers.alpaka_cff import alpaka
-alpaka.toReplaceWith(HLTTICLLocalRecoSequence, _HLTTICLLocalRecoSequence_heterogeneous)
+(alpaka & (~ticl_barrel)).toReplaceWith(HLTTICLLocalRecoSequence, _HLTTICLLocalRecoSequence_heterogeneous)
 
 _HLTTICLLocalRecoSequence_withBarrel = cms.Sequence(
         hltHGCalUncalibRecHit+
@@ -51,9 +52,7 @@ _HLTTICLLocalRecoSequence_withBarrel = cms.Sequence(
         hltBarrelLayerClustersHB+
         hltMergeLayerClusters
 )
-
-from Configuration.ProcessModifiers.ticl_barrel_cff import ticl_barrel
-ticl_barrel.toReplaceWith(HLTTICLLocalRecoSequence, _HLTTICLLocalRecoSequence_withBarrel)
+(ticl_barrel & (~alpaka)).toReplaceWith(HLTTICLLocalRecoSequence, _HLTTICLLocalRecoSequence_withBarrel)
 
 _HLTTICLLocalRecoSequence_heterogeneous_withBarrel = cms.Sequence(
         hltHGCalUncalibRecHit+
@@ -69,5 +68,4 @@ _HLTTICLLocalRecoSequence_heterogeneous_withBarrel = cms.Sequence(
         hltBarrelLayerClustersHB+
         hltMergeLayerClusters
 )
-
 (ticl_barrel & alpaka).toReplaceWith(HLTTICLLocalRecoSequence, _HLTTICLLocalRecoSequence_heterogeneous_withBarrel)


### PR DESCRIPTION
#### PR description:

Multiple fixes are required to run the TICL-barrel validation at HLT.

## First issue

Running:

```
cmsDriver.py step2 --step L1P2GT,HLT:NGTScouting,VALIDATION:@hltValidation \
				 --conditions auto:phase2_realistic_T33 \
				 --datatier GEN-SIM-DIGI-RAW,DQMIO \
				 -n 4 \
				 --eventcontent FEVTDEBUGHLT,DQMIO \
				 --geometry ExtendedRun4D110 \
				 --era Phase2C17I13M9 \
				 --procModifier ticl_barrel \
				 --filein file:/eos/cms/store/relval/CMSSW_15_1_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_150X_mcRun4_realistic_v1_STD_Run4D110_PU-v1/2580000/e01960c2-2b0f-4911-b35f-f71629844dee.root \
				 --fileout file:step2.root \
				 --nThreads 1 \
				 --process HLTX \
				 --inputCommands='keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT'
```

leads to:

```
----- Begin Fatal Exception 17-Jul-2025 11:24:05 CEST-----------------------
An exception of category 'ScheduleExecutionFailure' occurred while
   [0] Calling beginJob
Exception Message:
Unrunnable schedule
The Path/EndPath configuration could cause the job to deadlock
  module 'hltParticleFlowRecHitECALUnseeded' is on path 'DST_PFScouting' and depends on module 'hltEcalRecHit'
  module 'hltEcalRecHit' is on path 'DST_PFScouting' and follows module 'hltParticleFlowRecHitECALUnseeded' on the path
----- End Fatal Exception -------------------------------------------------
```

The command used to test https://github.com/cms-sw/cmssw/pull/47859 was

```bash
HLTrigger/Configuration/scripts/hltPhase2UpgradeIntegrationTests --globaltag auto:phase2_realistic_T33 --geometry ExtendedRun4D110 --events 10 --threads 4 --procModifiers ticl_barrel
```

which does not test the `DST_PFScouting` path, used [here](https://github.com/cms-sw/cmssw/blob/e152e7e2b26dd10cb2a20a5f1bc26ac6f8e4f0e6/HLTrigger/Configuration/python/HLT_NGTScouting_cff.py#L292). 

~~Would it make sense to add `HLT:NGTScouting` [here](https://github.com/cms-sw/cmssw/blob/e152e7e2b26dd10cb2a20a5f1bc26ac6f8e4f0e6/HLTrigger/Configuration/scripts/hltPhase2UpgradeIntegrationTests#L146) to avoid these issues in the future?~~ (This has been addressed at https://github.com/cms-sw/cmssw/pull/48664 + https://github.com/cms-sw/cms-bot/pull/2545 )



## Second issue

Having fixed the ordering of the sequences in `DST_PFScouting`, the following error is observed when running the above step2 command with  `--procModifier alpaka,ticl_barrel`:

```
----- Begin Fatal Exception 17-Jul-2025 18:16:59 CEST-----------------------
An exception of category 'ProductNotFound' occurred while
   [0] Processing  Event run: 1 lumi: 61 event: 6001 stream: 0
   [1] Running path 'DST_PFScouting'
   [2] Calling method for module MergeClusterProducer/'hltMergeLayerClusters'
Exception Message:
Principal::getByToken: Found zero products matching all criteria
Looking for type: std::vector<reco::CaloCluster>
Looking for module label: hltHgcalLayerClustersEE
Looking for productInstanceName: 

   Additional Info:
      [a] If you wish to continue processing events after a ProductNotFound exception,
add "TryToContinue = cms.untracked.vstring('ProductNotFound')" to the "options" PSet in the configuration.

----- End Fatal Exception -------------------------------------------------
```

This is due to a bug in the CE-E layer cluster input collection used when the `alpaka` and `ticl_barrel` modifiers are both active. The fix consists on defining what happens when both modifiers are active, via the `(ticl_barrel & alpaka).toModify(...)` call.
In parallel, I added the negation ~ operator in some `.toModify()` calls. This improves clarity and makes the code more efficient, since [this call](https://github.com/cms-sw/cmssw/blob/e152e7e2b26dd10cb2a20a5f1bc26ac6f8e4f0e6/FWCore/ParameterSet/python/Config.py#L1712) is not run.

#### PR validation:

Tested with `runTheMatrix.py -w upgrade -l 29634.771` (wf from [48687](https://github.com/cms-sw/cmssw/pull/48687)).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A