### PR TITLE
Require that process order be consistent when merging files [first try]

### DIFF
--- a/DataFormats/Provenance/interface/BranchDescription.h
+++ b/DataFormats/Provenance/interface/BranchDescription.h
@@ -35,7 +35,7 @@ namespace edm {
   public:
     static int const invalidSplitLevel = -1;
     static int const invalidBasketSize = 0;
-    enum MatchMode { Strict = 0, Permissive };
+    enum MatchMode { Strict = 0, Permissive, FromInputToCurrent };
 
     BranchDescription();
 

--- a/DataFormats/Provenance/interface/ProcessHistoryRegistry.h
+++ b/DataFormats/Provenance/interface/ProcessHistoryRegistry.h
@@ -35,5 +35,12 @@ namespace edm {
     ProcessHistoryMap data_;
     std::map<ProcessHistoryID, ProcessHistoryID> extra_;
   };
+
+  /**
+   * Merge the processing order from the given ProcessHistoryRegistry into the
+   * given vector of process names. Will throw if ordering in processNames is not compatible.
+   * The vector will be filled with process names in reverse time order (most recent to oldest).
+   */
+  void processingOrderMerge(ProcessHistoryRegistry const&, std::vector<std::string>& processNames);
 }  // namespace edm
 #endif

--- a/DataFormats/Provenance/interface/processingOrderMerge.h
+++ b/DataFormats/Provenance/interface/processingOrderMerge.h
@@ -1,0 +1,22 @@
+#ifndef DataFormats_Provenance_processingOrderMerge_h
+#define DataFormats_Provenance_processingOrderMerge_h
+
+#include <string>
+#include <vector>
+
+namespace edm {
+  class ProcessHistory;
+  /**
+   * Merge the processing order from the given ProcessHistory into the
+   * given vector of process names. Will throw if ordering in processNames is not compatible.
+   * The vector will be filled with process names in reverse time order (most recent to oldest).
+   */
+  void processingOrderMerge(ProcessHistory const& iHistory, std::vector<std::string>& processNames);
+  /**
+     * Merge the processing order from the given vector of process names into the
+     * given vector of process names. Will throw if ordering in processNames is not compatible.
+     * The vectors must both be in reverse time order (most recent to oldest).
+     */
+  void processingOrderMerge(std::vector<std::string> const& iFrom, std::vector<std::string>& iTo);
+}  // namespace edm
+#endif

--- a/DataFormats/Provenance/src/ProcessHistoryRegistry.cc
+++ b/DataFormats/Provenance/src/ProcessHistoryRegistry.cc
@@ -1,4 +1,5 @@
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
+#include "DataFormats/Provenance/interface/processingOrderMerge.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
 #include <cassert>
@@ -42,4 +43,25 @@ namespace edm {
     }
     return &iter->second;
   }
+
+  void processingOrderMerge(ProcessHistoryRegistry const& registry, std::vector<std::string>& processNames) {
+    /*handle a case for reading an old file merge in a possibly incompatible way*/
+    if (registry.begin() == registry.end()) {
+      return;
+    }
+    auto itLongest = registry.begin();
+    for (auto it = registry.begin(), itEnd = registry.end(); it != itEnd; ++it) {
+      if (it->second.size() > itLongest->second.size()) {
+        itLongest = it;
+      }
+    }
+    processingOrderMerge(itLongest->second, processNames);
+    for (auto it = registry.begin(), itEnd = registry.end(); it != itEnd; ++it) {
+      if (it == itLongest) {
+        continue;
+      }
+      processingOrderMerge(it->second, processNames);
+    }
+  }
+
 }  // namespace edm

--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -10,6 +10,7 @@
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 
 #include "DataFormats/Provenance/interface/ProductResolverIndexHelper.h"
+#include "DataFormats/Provenance/interface/processingOrderMerge.h"
 
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/EDMException.h"
@@ -197,16 +198,24 @@ namespace edm {
     return result;
   }
 
-  void ProductRegistry::updateFromInput(ProductList const& other) {
+  void ProductRegistry::updateFromInput(ProductList const& other, std::vector<std::string> const& processOrder) {
     for (auto const& product : other) {
       copyProduct(product.second);
     }
+    updateProcessOrder(processOrder);
   }
 
-  void ProductRegistry::updateFromInput(std::vector<ProductDescription> const& other) {
+  void ProductRegistry::updateFromInput(std::vector<ProductDescription> const& other,
+                                        std::vector<std::string> const& processOrder) {
     for (ProductDescription const& productDescription : other) {
       copyProduct(productDescription);
     }
+    updateProcessOrder(processOrder);
+  }
+
+  void ProductRegistry::updateProcessOrder(std::vector<std::string> const& processOrder) {
+    throwIfFrozen();
+    processingOrderMerge(processOrder, transient_.processOrder_);
   }
 
   void ProductRegistry::setUnscheduledProducts(std::set<std::string> const& unscheduledLabels) {
@@ -241,6 +250,13 @@ namespace edm {
   std::string ProductRegistry::merge(ProductRegistry const& other,
                                      std::string const& fileName,
                                      ProductDescription::MatchMode branchesMustMatch) {
+    if (branchesMustMatch == ProductDescription::FromInputToCurrent) {
+      assert(transient_.processOrder_.size() == 1);
+      transient_.processOrder_.insert(
+          transient_.processOrder_.end(), other.transient_.processOrder_.begin(), other.transient_.processOrder_.end());
+    } else {
+      processingOrderMerge(other.processOrder(), transient_.processOrder_);
+    }
     std::ostringstream differences;
 
     ProductRegistry::ProductList::iterator j = productList_.begin();

--- a/DataFormats/Provenance/src/processingOrderMerge.cc
+++ b/DataFormats/Provenance/src/processingOrderMerge.cc
@@ -41,7 +41,6 @@ namespace edm {
       std::vector<std::string> tempNames;
       tempNames.reserve(processNames.size() > iHistory.size() ? processNames.size() : iHistory.size());
       auto itNew = iHistory.begin();
-      ;
       auto itNewEnd = iHistory.end();
       auto itOld = processNames.begin();
       auto itOldEnd = processNames.end();

--- a/DataFormats/Provenance/src/processingOrderMerge.cc
+++ b/DataFormats/Provenance/src/processingOrderMerge.cc
@@ -1,0 +1,96 @@
+#include "DataFormats/Provenance/interface/processingOrderMerge.h"
+#include "DataFormats/Provenance/interface/ProcessHistory.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+namespace edm {
+  namespace {
+    [[noreturn]] void throwIncompatibleOrdering(std::string const& msg) {
+      throw cms::Exception("IncompatibleProcessHistoryOrdering")
+          << "Incompatible process history ordering during merge: " << msg << "\n";
+    }
+
+    template <typename Iter>
+    Iter foundLaterIn(Iter itBegin, Iter it, Iter itEnd, std::string const& name) {
+      auto itFind = std::find(itBegin, itEnd, name);
+      if (itFind < it) {
+        throwIncompatibleOrdering("process " + name + " found earlier in other list");
+      }
+      return itFind;
+    }
+  }  // namespace
+
+  void processingOrderMerge(ProcessHistory const& iHistory, std::vector<std::string>& processNames) {
+    if (processNames.empty()) {
+      for (auto it = iHistory.rbegin(); it != iHistory.rend(); ++it) {
+        processNames.push_back(it->processName());
+      }
+    } else {
+      std::vector<std::string> fromHistory;
+      fromHistory.reserve(iHistory.size());
+      for (auto it = iHistory.rbegin(); it != iHistory.rend(); ++it) {
+        fromHistory.push_back(it->processName());
+      }
+      processingOrderMerge(fromHistory, processNames);
+    }
+  }
+
+  void processingOrderMerge(std::vector<std::string> const& iHistory, std::vector<std::string>& processNames) {
+    if (processNames.empty()) {
+      processNames = iHistory;
+    } else {
+      std::vector<std::string> tempNames;
+      tempNames.reserve(processNames.size() > iHistory.size() ? processNames.size() : iHistory.size());
+      auto itNew = iHistory.begin();
+      ;
+      auto itNewEnd = iHistory.end();
+      auto itOld = processNames.begin();
+      auto itOldEnd = processNames.end();
+      while (itNew != itNewEnd && itOld != itOldEnd) {
+        if (*itNew == *itOld) {
+          tempNames.push_back(*itOld);
+          ++itNew;
+          ++itOld;
+        } else {
+          //see if we can find it in the old list
+          auto itFindOld = foundLaterIn(processNames.begin(), itOld, itOldEnd, *itNew);
+          auto itFindNew = foundLaterIn(iHistory.begin(), itNew, itNewEnd, *itOld);
+          if (itFindOld != itOldEnd) {
+            if (itFindNew != itNewEnd) {
+              throwIncompatibleOrdering("process " + *itNew + " and " + *itOld + " are out of order");
+            }
+            //found it, copy over everything up to and including it
+            while (itOld != itFindOld) {
+              tempNames.push_back(*itOld);
+              ++itOld;
+            }
+            tempNames.push_back(*itOld);
+            ++itOld;
+            ++itNew;
+          } else {
+            if (itFindNew == itNewEnd) {
+              throwIncompatibleOrdering("process " + *itOld + " and " + *itNew + " are independent");
+            }
+            while (itNew != itFindNew) {
+              tempNames.push_back(*itNew);
+              ++itNew;
+            }
+            //not found, add the new one
+            tempNames.push_back(*itNew);
+            ++itNew;
+            ++itOld;
+          }
+        }
+      }
+      //copy over any remaining old names
+      while (itOld != itOldEnd) {
+        tempNames.push_back(*itOld);
+        ++itOld;
+      }
+      while (itNew != itNewEnd) {
+        tempNames.push_back(*itNew);
+        ++itNew;
+      }
+      processNames.swap(tempNames);
+    }
+  }
+}  // namespace edm

--- a/DataFormats/Provenance/test/BuildFile.xml
+++ b/DataFormats/Provenance/test/BuildFile.xml
@@ -3,7 +3,7 @@
 <use name="DataFormats/Provenance"/>
 </bin>
 
-<bin name="testDataFormatsProvenanceCatch2" file="ElementID_t.cpp,Parentage_t.cpp,StoredProcessBlockHelper_t.cpp,CompactHash_t.cpp,Hash_t.cpp,HardwareResourcesDescription_t.cpp,ProductNamePattern_t.cpp">
+<bin name="testDataFormatsProvenanceCatch2" file="ElementID_t.cpp,Parentage_t.cpp,StoredProcessBlockHelper_t.cpp,CompactHash_t.cpp,Hash_t.cpp,HardwareResourcesDescription_t.cpp,ProductNamePattern_t.cpp,processingOrderMerge_t.cpp">
   <use name="DataFormats/Provenance"/>
   <use name="catch2"/>
 </bin>

--- a/DataFormats/Provenance/test/processingOrderMerge_t.cpp
+++ b/DataFormats/Provenance/test/processingOrderMerge_t.cpp
@@ -12,7 +12,7 @@ TEST_CASE("processingOrderMerge", "[processingOrderMerge]") {
         edm::processingOrderMerge(ph, names);
         REQUIRE(names.empty());
       }
-      SECTION("one history") {
+      SECTION("one process") {
         edm::ProcessHistory ph;
         edm::ProcessConfiguration pc("A", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
         ph.push_back(pc);
@@ -21,7 +21,7 @@ TEST_CASE("processingOrderMerge", "[processingOrderMerge]") {
         REQUIRE(names.size() == 1);
         REQUIRE(names[0] == "A");
       }
-      SECTION("two histories") {
+      SECTION("two processes") {
         edm::ProcessHistory ph;
         ph.emplace_back("A", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
         ph.emplace_back("B", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
@@ -142,7 +142,7 @@ TEST_CASE("processingOrderMerge", "[processingOrderMerge]") {
         std::vector<std::string> names = {"C", "B", "A"};
         REQUIRE_THROWS_AS(edm::processingOrderMerge(ph, names), cms::Exception);
       }
-      SECTION("beginning out order") {
+      SECTION("ending inconsistent") {
         edm::ProcessHistory ph;
         ph.emplace_back("A", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
         ph.emplace_back("B", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
@@ -150,7 +150,7 @@ TEST_CASE("processingOrderMerge", "[processingOrderMerge]") {
         std::vector<std::string> names = {"B", "C", "A"};
         REQUIRE_THROWS_AS(edm::processingOrderMerge(ph, names), cms::Exception);
       }
-      SECTION("end out order") {
+      SECTION("beginning inconsistent") {
         edm::ProcessHistory ph;
         ph.emplace_back("A", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
         ph.emplace_back("B", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
@@ -158,7 +158,7 @@ TEST_CASE("processingOrderMerge", "[processingOrderMerge]") {
         std::vector<std::string> names = {"C", "A", "B"};
         REQUIRE_THROWS_AS(edm::processingOrderMerge(ph, names), cms::Exception);
       }
-      SECTION("middle out order") {
+      SECTION("middle inconsistent") {
         edm::ProcessHistory ph;
         ph.emplace_back("A", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
         ph.emplace_back("B", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());

--- a/DataFormats/Provenance/test/processingOrderMerge_t.cpp
+++ b/DataFormats/Provenance/test/processingOrderMerge_t.cpp
@@ -1,0 +1,172 @@
+#include "catch.hpp"
+#include "DataFormats/Provenance/interface/ProcessHistory.h"
+#include "DataFormats/Provenance/interface/processingOrderMerge.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+TEST_CASE("processingOrderMerge", "[processingOrderMerge]") {
+  SECTION("merge") {
+    SECTION("empty vector") {
+      SECTION("empty history") {
+        edm::ProcessHistory ph;
+        std::vector<std::string> names;
+        edm::processingOrderMerge(ph, names);
+        REQUIRE(names.empty());
+      }
+      SECTION("one history") {
+        edm::ProcessHistory ph;
+        edm::ProcessConfiguration pc("A", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.push_back(pc);
+        std::vector<std::string> names;
+        edm::processingOrderMerge(ph, names);
+        REQUIRE(names.size() == 1);
+        REQUIRE(names[0] == "A");
+      }
+      SECTION("two histories") {
+        edm::ProcessHistory ph;
+        ph.emplace_back("A", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.emplace_back("B", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        std::vector<std::string> names;
+        edm::processingOrderMerge(ph, names);
+        REQUIRE(names.size() == 2);
+        REQUIRE(names[0] == "B");
+        REQUIRE(names[1] == "A");
+      }
+    }
+    SECTION("identical") {
+      edm::ProcessHistory ph;
+      ph.emplace_back("A", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+      ph.emplace_back("B", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+      std::vector<std::string> names = {"B", "A"};
+      edm::processingOrderMerge(ph, names);
+      REQUIRE(names.size() == 2);
+      REQUIRE(names[0] == "B");
+      REQUIRE(names[1] == "A");
+    }
+    SECTION("missing items from one") {
+      SECTION("vector missing most recent from history") {
+        edm::ProcessHistory ph;
+        ph.emplace_back("A", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.emplace_back("B", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.emplace_back("C", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        std::vector<std::string> names = {"B", "A"};
+        edm::processingOrderMerge(ph, names);
+        REQUIRE(names.size() == 3);
+        REQUIRE(names[0] == "C");
+        REQUIRE(names[1] == "B");
+        REQUIRE(names[2] == "A");
+      }
+      SECTION("history missing most recent from vector") {
+        edm::ProcessHistory ph;
+        ph.emplace_back("A", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.emplace_back("B", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        std::vector<std::string> names = {"C", "B", "A"};
+        edm::processingOrderMerge(ph, names);
+        REQUIRE(names.size() == 3);
+        REQUIRE(names[0] == "C");
+        REQUIRE(names[1] == "B");
+        REQUIRE(names[2] == "A");
+      }
+      SECTION("vector missing last from history") {
+        edm::ProcessHistory ph;
+        ph.emplace_back("A", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.emplace_back("B", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.emplace_back("C", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        std::vector<std::string> names = {"C", "B"};
+        edm::processingOrderMerge(ph, names);
+        REQUIRE(names.size() == 3);
+        REQUIRE(names[0] == "C");
+        REQUIRE(names[1] == "B");
+        REQUIRE(names[2] == "A");
+      }
+      SECTION("history missing last from vector") {
+        edm::ProcessHistory ph;
+        ph.emplace_back("B", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.emplace_back("C", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        std::vector<std::string> names = {"C", "B", "A"};
+        edm::processingOrderMerge(ph, names);
+        REQUIRE(names.size() == 3);
+        REQUIRE(names[0] == "C");
+        REQUIRE(names[1] == "B");
+        REQUIRE(names[2] == "A");
+      }
+      SECTION("vector missing middle from history") {
+        edm::ProcessHistory ph;
+        ph.emplace_back("A", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.emplace_back("B", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.emplace_back("C", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        std::vector<std::string> names = {"C", "A"};
+        edm::processingOrderMerge(ph, names);
+        REQUIRE(names.size() == 3);
+        REQUIRE(names[0] == "C");
+        REQUIRE(names[1] == "B");
+        REQUIRE(names[2] == "A");
+      }
+      SECTION("history missing middle from vector") {
+        edm::ProcessHistory ph;
+        ph.emplace_back("A", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.emplace_back("C", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        std::vector<std::string> names = {"C", "B", "A"};
+        edm::processingOrderMerge(ph, names);
+        REQUIRE(names.size() == 3);
+        REQUIRE(names[0] == "C");
+        REQUIRE(names[1] == "B");
+        REQUIRE(names[2] == "A");
+      }
+    }
+    SECTION("incompatible") {
+      SECTION("independent 1") {
+        edm::ProcessHistory ph;
+        ph.emplace_back("C", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        std::vector<std::string> names = {"B"};
+        REQUIRE_THROWS_AS(edm::processingOrderMerge(ph, names), cms::Exception);
+      }
+      SECTION("independent 2") {
+        edm::ProcessHistory ph;
+        ph.emplace_back("C", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.emplace_back("D", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        std::vector<std::string> names = {"B", "A"};
+        REQUIRE_THROWS_AS(edm::processingOrderMerge(ph, names), cms::Exception);
+      }
+      SECTION("reversed order") {
+        edm::ProcessHistory ph;
+        ph.emplace_back("B", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.emplace_back("A", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        std::vector<std::string> names = {"B", "A"};
+        REQUIRE_THROWS_AS(edm::processingOrderMerge(ph, names), cms::Exception);
+      }
+      SECTION("longer reversed order") {
+        edm::ProcessHistory ph;
+        ph.emplace_back("C", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.emplace_back("B", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.emplace_back("A", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        std::vector<std::string> names = {"C", "B", "A"};
+        REQUIRE_THROWS_AS(edm::processingOrderMerge(ph, names), cms::Exception);
+      }
+      SECTION("beginning out order") {
+        edm::ProcessHistory ph;
+        ph.emplace_back("A", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.emplace_back("B", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.emplace_back("C", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        std::vector<std::string> names = {"B", "C", "A"};
+        REQUIRE_THROWS_AS(edm::processingOrderMerge(ph, names), cms::Exception);
+      }
+      SECTION("end out order") {
+        edm::ProcessHistory ph;
+        ph.emplace_back("A", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.emplace_back("B", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.emplace_back("C", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        std::vector<std::string> names = {"C", "A", "B"};
+        REQUIRE_THROWS_AS(edm::processingOrderMerge(ph, names), cms::Exception);
+      }
+      SECTION("middle out order") {
+        edm::ProcessHistory ph;
+        ph.emplace_back("A", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.emplace_back("B", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.emplace_back("C", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        ph.emplace_back("D", edm::ReleaseVersion(""), edm::HardwareResourcesDescription());
+        std::vector<std::string> names = {"D", "B", "C", "A"};
+        REQUIRE_THROWS_AS(edm::processingOrderMerge(ph, names), cms::Exception);
+      }
+    }
+  }
+}

--- a/DataFormats/Streamer/interface/StreamedProducts.h
+++ b/DataFormats/Streamer/interface/StreamedProducts.h
@@ -123,13 +123,16 @@ namespace edm {
     SendJobHeader() {}
     SendDescs const& descs() const { return descs_; }
     ParameterSetMap const& processParameterSet() const { return processParameterSet_; }
+    std::vector<std::string> const& orderedProcessNames() const { return processNames_; }
     void push_back(ProductDescription const& bd) { descs_.push_back(bd); }
     void setParameterSetMap(ParameterSetMap const& psetMap) { processParameterSet_ = psetMap; }
+    void setOrderedProcessNames(std::vector<std::string> const& processNames) { processNames_ = processNames; }
     void initializeTransients();
 
   private:
     SendDescs descs_;
     ParameterSetMap processParameterSet_;
+    std::vector<std::string> processNames_;
   };
 
 }  // namespace edm

--- a/DataFormats/Streamer/src/classes_def.xml
+++ b/DataFormats/Streamer/src/classes_def.xml
@@ -11,7 +11,8 @@
   <version ClassVersion="11" checksum="3216100975"/>
   <version ClassVersion="10" checksum="747121728"/>
  </class>
- <class name="edm::SendJobHeader" ClassVersion="12">
+ <class name="edm::SendJobHeader" ClassVersion="13">
+  <version ClassVersion="13" checksum="2608260554"/>
   <version ClassVersion="12" checksum="3199648792"/>
   <version ClassVersion="11" checksum="79372782"/>
   <version ClassVersion="10" checksum="1238072397"/>

--- a/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
+++ b/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
@@ -476,7 +476,7 @@ namespace evf {
 
   void GlobalEvFOutputModule::beginJob() {
     msgBuilders_ = std::make_unique<StreamerOutputMsgBuilders>(
-        commonParameters_, &keptProducts()[edm::InEvent], description().moduleLabel());
+        commonParameters_, &keptProducts()[edm::InEvent], &orderedProcessNames(), description().moduleLabel());
 
     cacheEventMetaData();
   }

--- a/FWCore/Framework/interface/OutputModuleCore.h
+++ b/FWCore/Framework/interface/OutputModuleCore.h
@@ -97,6 +97,7 @@ namespace edm {
       std::string const& processName() const { return process_name_; }
       SelectedProductsForBranchType const& keptProducts() const { return keptProducts_; }
       std::array<bool, NumBranchTypes> const& hasNewlyDroppedBranch() const { return hasNewlyDroppedBranch_; }
+      std::vector<std::string> const& orderedProcessNames() const { return orderedProcessNames_; }
 
       static void fillDescription(
           ParameterSetDescription& desc,
@@ -171,6 +172,7 @@ namespace edm {
       // We do not own the ProductDescriptions to which we point.
       SelectedProductsForBranchType keptProducts_;
       std::array<bool, NumBranchTypes> hasNewlyDroppedBranch_;
+      std::vector<std::string> orderedProcessNames_;
 
       std::string process_name_;
       ProductSelectorRules productSelectorRules_;

--- a/FWCore/Framework/interface/SignallingProductRegistryFiller.h
+++ b/FWCore/Framework/interface/SignallingProductRegistryFiller.h
@@ -76,6 +76,10 @@ namespace edm {
     }
     ProductRegistry::ProductList& productListUpdator() { return registry_.productListUpdator(); }
 
+    void setCurrentProcess(std::string processOrder) {
+      registry_.setProcessOrder(std::vector<std::string>(1, std::move(processOrder)));
+    }
+
     template <class T>
     void watchProductAdditions(const T& iFunc) {
       serviceregistry::connect_but_block_self(productAddedSignal_, iFunc);

--- a/FWCore/Framework/interface/SignallingProductRegistryFiller.h
+++ b/FWCore/Framework/interface/SignallingProductRegistryFiller.h
@@ -76,8 +76,8 @@ namespace edm {
     }
     ProductRegistry::ProductList& productListUpdator() { return registry_.productListUpdator(); }
 
-    void setCurrentProcess(std::string processOrder) {
-      registry_.setProcessOrder(std::vector<std::string>(1, std::move(processOrder)));
+    void setCurrentProcess(std::string const& processOrder) {
+      registry_.setProcessOrder(std::vector<std::string>(1, processOrder));
     }
 
     template <class T>

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -974,7 +974,8 @@ namespace edm {
     //incase the input's registry changed
     if (input_->productRegistry().cacheIdentifier() != oldCacheID) {
       auto temp = std::make_shared<edm::ProductRegistry>(*preg_);
-      temp->merge(input_->productRegistry(), fb_ ? fb_->fileName() : std::string());
+      temp->merge(
+          input_->productRegistry(), fb_ ? fb_->fileName() : std::string(), ProductDescription::FromInputToCurrent);
       preg_ = std::move(temp);
     }
     if (preallocations_.numberOfStreams() > 1 and preallocations_.numberOfThreads() > 1) {

--- a/FWCore/Framework/src/OutputModuleCore.cc
+++ b/FWCore/Framework/src/OutputModuleCore.cc
@@ -141,6 +141,7 @@ namespace edm {
           thinnedAssociationsHelper, keepAssociation_, droppedBranchIDToKeptBranchID_);
       outputProcessBlockHelper_.updateAfterProductSelection(processesWithKeptProcessBlockProducts, processBlockHelper);
 
+      orderedProcessNames_ = preg.processOrder();
       initialRegistry(preg);
     }
 

--- a/FWCore/Framework/src/ScheduleItems.cc
+++ b/FWCore/Framework/src/ScheduleItems.cc
@@ -87,6 +87,7 @@ namespace edm {
     }
     // propagate_const<T> has no reset() function
     processConfiguration_ = std::make_shared<ProcessConfiguration>(processName, releaseVersion, hwResources);
+    preg_->setCurrentProcess(processName);
     auto common = std::make_shared<CommonParams>(
         parameterSet.getUntrackedParameterSet("maxEvents").getUntrackedParameter<int>("input"),
         parameterSet.getUntrackedParameterSet("maxLuminosityBlocks").getUntrackedParameter<int>("input"),

--- a/FWCore/Integration/plugins/DelayedReaderThrowingSource.cc
+++ b/FWCore/Integration/plugins/DelayedReaderThrowingSource.cc
@@ -100,7 +100,8 @@ namespace edm {
                                             ));
       branches.back().setOnDemand(true);  //says we use delayed reader
     }
-    productRegistryUpdate().updateFromInput(branches);
+    std::vector<std::string> processOrder = {"INPUTTEST"};
+    productRegistryUpdate().updateFromInput(branches, processOrder);
 
     ProcessHistory ph;
     ph.emplace_back("INPUTTEST", dummy.id(), PROJECT_VERSION, HardwareResourcesDescription());

--- a/FWCore/Integration/test/run_TestProcessBlock.sh
+++ b/FWCore/Integration/test/run_TestProcessBlock.sh
@@ -134,6 +134,9 @@ then
   echo "testProcessBlock5"
   cmsRun ${LOCAL_TEST_DIR}/testProcessBlock5_cfg.py &> testProcessBlock5.log || die "cmsRun testProcessBlock5_cfg.py" $?
 
+  echo "testProcessBlockDummy"
+  cmsRun ${LOCAL_TEST_DIR}/testProcessBlockDummy_cfg.py &> testProcessBlockDummy.log || die "cmsRun testProcessBlockDummy_cfg.py" $?
+
   echo "testProcessBlockMerge3"
   cmsRun ${LOCAL_TEST_DIR}/testProcessBlockMerge3_cfg.py &> testProcessBlockMerge3.log || die "cmsRun testProcessBlockMerge3_cfg.py" $?
 
@@ -234,6 +237,7 @@ then
   rm testProcessBlockRead2.log
   rm testProcessBlockLooper.log
   rm testProcessBlock5.log
+  rm testProcessBlockDummy.log
   rm testProcessBlockMerge3.log
   rm testProcessBlockMergeOfMergedFiles2.log
   rm testProcessBlockDropOnInput.log
@@ -261,6 +265,7 @@ then
   rm testProcessBlockRead2.root
   rm testProcessBlockLooperTest.root
   rm testProcessBlock5.root
+  rm testProcessBlockDummy.root
   rm testProcessBlockMerge3.root
   rm testProcessBlockMergeOfMergedFiles2.root
   rm testProcessBlockDropOnInput.root

--- a/FWCore/Integration/test/testProcessBlock5_cfg.py
+++ b/FWCore/Integration/test/testProcessBlock5_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 # Intentionally reversing the order of process names in this series
-process = cms.Process("MERGEOFMERGED")
+process = cms.Process("PROD1")
 
 process.options = cms.untracked.PSet(
     numberOfStreams = cms.untracked.uint32(1),
@@ -20,17 +20,16 @@ process.out = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('testProcessBlock5.root')
 )
 
+process.intProducerBeginProcessBlock = cms.EDProducer("IntProducerBeginProcessBlock", ivalue = cms.int32(707))
 
-process.intProducerBeginProcessBlockMM = cms.EDProducer("IntProducerBeginProcessBlock", ivalue = cms.int32(404))
+process.intProducerEndProcessBlock = cms.EDProducer("IntProducerEndProcessBlock", ivalue = cms.int32(7000))
 
-process.intProducerEndProcessBlockMM = cms.EDProducer("IntProducerEndProcessBlock", ivalue = cms.int32(440))
+process.intProducerBeginProcessBlockB = cms.EDProducer("IntProducerBeginProcessBlock", ivalue = cms.int32(40000))
 
-process.intProducerBeginProcessBlockB = cms.EDProducer("IntProducerBeginProcessBlock", ivalue = cms.int32(308))
+process.intProducerEndProcessBlockB = cms.EDProducer("IntProducerEndProcessBlock", ivalue = cms.int32(400000))
 
-process.intProducerEndProcessBlockB = cms.EDProducer("IntProducerEndProcessBlock", ivalue = cms.int32(380))
-
-process.p = cms.Path(process.intProducerBeginProcessBlockMM *
-                     process.intProducerEndProcessBlockMM *
+process.p = cms.Path(process.intProducerBeginProcessBlock *
+                     process.intProducerEndProcessBlock *
                      process.intProducerBeginProcessBlockB *
                      process.intProducerEndProcessBlockB
 )

--- a/FWCore/Integration/test/testProcessBlockDummy_cfg.py
+++ b/FWCore/Integration/test/testProcessBlockDummy_cfg.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DUMMY")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1)
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testProcessBlock5.root'
+    )
+)
+
+process.dummy = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
+
+process.p = cms.Path(process.dummy)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testProcessBlockDummy.root'),
+    outputCommands = cms.untracked.vstring(
+        "keep *",
+        "drop *_*_*_DUMMY")
+)
+process.e = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testProcessBlockMerge3_cfg.py
+++ b/FWCore/Integration/test/testProcessBlockMerge3_cfg.py
@@ -10,7 +10,7 @@ process.options = cms.untracked.PSet(
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-        'file:testProcessBlock5.root'
+        'file:testProcessBlockDummy.root'
     )
 )
 
@@ -20,7 +20,7 @@ process.out = cms.OutputModule("PoolOutputModule",
 
 process.testOneOutput = cms.OutputModule("TestOneOutput",
     verbose = cms.untracked.bool(False),
-    expectedProcessesWithProcessBlockProducts = cms.untracked.vstring('MERGEOFMERGED', 'MERGE'),
+    expectedProcessesWithProcessBlockProducts = cms.untracked.vstring('PROD1', 'MERGE'),
     expectedWriteProcessBlockTransitions = cms.untracked.int32(2)
 )
 

--- a/FWCore/Integration/test/testProcessBlockMergeOfMergedFiles2_cfg.py
+++ b/FWCore/Integration/test/testProcessBlockMergeOfMergedFiles2_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 # Intentionally reversing the order of process names in this series
-process = cms.Process("PROD1")
+process = cms.Process("MERGEOFMERGED")
 
 process.options = cms.untracked.PSet(
     numberOfStreams = cms.untracked.uint32(1),
@@ -19,16 +19,17 @@ process.out = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('testProcessBlockMergeOfMergedFiles2.root')
 )
 
-process.intProducerBeginProcessBlock = cms.EDProducer("IntProducerBeginProcessBlock", ivalue = cms.int32(707))
+#NEW
+process.intProducerBeginProcessBlockMM = cms.EDProducer("IntProducerBeginProcessBlock", ivalue = cms.int32(404))
 
-process.intProducerEndProcessBlock = cms.EDProducer("IntProducerEndProcessBlock", ivalue = cms.int32(7000))
+process.intProducerEndProcessBlockMM = cms.EDProducer("IntProducerEndProcessBlock", ivalue = cms.int32(440))
 
-process.intProducerBeginProcessBlockB = cms.EDProducer("IntProducerBeginProcessBlock", ivalue = cms.int32(40000))
+process.intProducerBeginProcessBlockB = cms.EDProducer("IntProducerBeginProcessBlock", ivalue = cms.int32(308))
 
-process.intProducerEndProcessBlockB = cms.EDProducer("IntProducerEndProcessBlock", ivalue = cms.int32(400000))
+process.intProducerEndProcessBlockB = cms.EDProducer("IntProducerEndProcessBlock", ivalue = cms.int32(380))
 
-process.p = cms.Path(process.intProducerBeginProcessBlock *
-                     process.intProducerEndProcessBlock *
+process.p = cms.Path(process.intProducerBeginProcessBlockMM *
+                     process.intProducerEndProcessBlockMM *
                      process.intProducerBeginProcessBlockB *
                      process.intProducerEndProcessBlockB
 )

--- a/IOPool/Input/src/RepeatingCachedRootSource.cc
+++ b/IOPool/Input/src/RepeatingCachedRootSource.cc
@@ -210,8 +210,10 @@ RepeatingCachedRootSource::RepeatingCachedRootSource(ParameterSet const& pset, I
       logicalFileName, physicalFileName, 0 != nEventsToSkip, input, skipper, duplicateChecker, indexesIntoFiles);
   rootFile_->reportOpened("repeating");
 
+  std::vector<std::string> processOrder;
+  processingOrderMerge(processHistoryRegistry(), processOrder);
   auto const& prodList = rootFile_->productRegistry()->productList();
-  productRegistryUpdate().updateFromInput(prodList);
+  productRegistryUpdate().updateFromInput(prodList, processOrder);
 
   //setup caching
   auto nProdsInEvent =

--- a/IOPool/Input/src/RootEmbeddedFileSequence.cc
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.cc
@@ -112,7 +112,9 @@ namespace edm {
       }
     }
     if (rootFile()) {
-      input_.productRegistryUpdate().updateFromInput(rootFile()->productRegistry()->productList());
+      std::vector<std::string> processOrder;
+      processingOrderMerge(input_.processHistoryRegistry(), processOrder);
+      input_.productRegistryUpdate().updateFromInput(rootFile()->productRegistry()->productList(), processOrder);
     } else {
       throw Exception(errors::FileOpenError) << "RootEmbeddedFileSequence::RootEmbeddedFileSequence(): "
                                              << " input file retries exhausted.\n";

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -19,6 +19,7 @@
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "DataFormats/Provenance/interface/processingOrderMerge.h"
 #include "DataFormats/Provenance/interface/StoredMergeableRunProductMetadata.h"
 #include "DataFormats/Provenance/interface/StoredProcessBlockHelper.h"
 #include "DataFormats/Provenance/interface/StoredProductProvenance.h"
@@ -558,6 +559,9 @@ namespace edm {
       for (auto& processBlockTree : processBlockTrees_) {
         treePointers_.push_back(processBlockTree.get());
       }
+      auto processingOrder = inputProdDescReg.processOrder();
+      processingOrderMerge(*processHistoryRegistry_, processingOrder);
+      newReg->setProcessOrder(processingOrder);
 
       // freeze the product registry
       newReg->setFrozen(inputType != InputType::Primary);

--- a/IOPool/Input/src/RootPrimaryFileSequence.cc
+++ b/IOPool/Input/src/RootPrimaryFileSequence.cc
@@ -9,6 +9,7 @@
 
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "FWCore/Catalog/interface/InputFileCatalog.h"
 #include "FWCore/Catalog/interface/SiteLocalConfig.h"
 #include "FWCore/Framework/interface/FileBlock.h"
@@ -69,7 +70,10 @@ namespace edm {
         break;
     }
     if (rootFile()) {
-      input_.productRegistryUpdate().updateFromInput(rootFile()->productRegistry()->productList());
+      std::vector<std::string> processOrder;
+      processingOrderMerge(input_.processHistoryRegistry(), processOrder);
+
+      input_.productRegistryUpdate().updateFromInput(rootFile()->productRegistry()->productList(), processOrder);
       if (initialNumberOfEventsToSkip_ != 0) {
         skipEventsAtBeginning(initialNumberOfEventsToSkip_);
       }

--- a/IOPool/Input/src/RootSecondaryFileSequence.cc
+++ b/IOPool/Input/src/RootSecondaryFileSequence.cc
@@ -9,6 +9,7 @@
 
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "FWCore/Catalog/interface/InputFileCatalog.h"
 #include "FWCore/Catalog/interface/SiteLocalConfig.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -46,7 +47,9 @@ namespace edm {
         break;
     }
     if (rootFile()) {
-      input_.productRegistryUpdate().updateFromInput(rootFile()->productRegistry()->productList());
+      std::vector<std::string> processOrder;
+      processingOrderMerge(input_.processHistoryRegistry(), processOrder);
+      input_.productRegistryUpdate().updateFromInput(rootFile()->productRegistry()->productList(), processOrder);
     }
   }
 

--- a/IOPool/Streamer/interface/StreamSerializer.h
+++ b/IOPool/Streamer/interface/StreamSerializer.h
@@ -73,7 +73,7 @@ namespace edm::streamer {
 
   class StreamSerializer {
   public:
-    StreamSerializer(SelectedProducts const *selections);
+    explicit StreamSerializer(SelectedProducts const *selections, std::vector<std::string> const *orderedProcessNames);
 
     int serializeRegistry(SerializeDataBuffer &data_buffer) const;
 
@@ -128,6 +128,7 @@ namespace edm::streamer {
                              unsigned int reserveSize) const;
 
     SelectedProducts const *selections_;
+    std::vector<std::string> const *orderedProcessNames_;
     edm::propagate_const<TClass *> tc_;
   };
 

--- a/IOPool/Streamer/interface/StreamerOutputModuleCommon.h
+++ b/IOPool/Streamer/interface/StreamerOutputModuleCommon.h
@@ -28,12 +28,14 @@ namespace edm {
 
       explicit StreamerOutputModuleCommon(Parameters const& p,
                                           SelectedProducts const* selections,
+                                          std::vector<std::string> const* orderedProcessNames,
                                           std::string const& moduleLabel);
 
       explicit StreamerOutputModuleCommon(ParameterSet const& ps,
                                           SelectedProducts const* selections,
+                                          std::vector<std::string> const* orderedProcessNames,
                                           std::string const& moduleLabel)
-          : StreamerOutputModuleCommon(parameters(ps), selections, moduleLabel) {}
+          : StreamerOutputModuleCommon(parameters(ps), selections, orderedProcessNames, moduleLabel) {}
 
       ~StreamerOutputModuleCommon();
       static void fillDescription(ParameterSetDescription& desc);

--- a/IOPool/Streamer/interface/StreamerOutputMsgBuilders.h
+++ b/IOPool/Streamer/interface/StreamerOutputMsgBuilders.h
@@ -34,6 +34,7 @@ namespace edm {
 
       explicit StreamerOutputMsgBuilders(Parameters const& p,
                                          SelectedProducts const* selections,
+                                         std::vector<std::string> const* orderedProcessNames,
                                          std::string const& moduleLabel);
 
       ~StreamerOutputMsgBuilders();

--- a/IOPool/Streamer/src/StreamSerializer.cc
+++ b/IOPool/Streamer/src/StreamSerializer.cc
@@ -34,8 +34,9 @@ namespace edm::streamer {
   /**
    * Creates a translator instance for the specified product registry.
    */
-  StreamSerializer::StreamSerializer(SelectedProducts const *selections)
-      : selections_(selections), tc_(getTClass(typeid(SendEvent))) {}
+  StreamSerializer::StreamSerializer(SelectedProducts const *selections,
+                                     std::vector<std::string> const *orderedProcessNames)
+      : selections_(selections), orderedProcessNames_(orderedProcessNames), tc_(getTClass(typeid(SendEvent))) {}
 
   /**
    * Serializes the product registry (that was specified to the constructor)
@@ -59,6 +60,7 @@ namespace edm::streamer {
       FDEBUG(9) << "StreamOutput got product = " << selection.first->className() << std::endl;
     }
     sd.setParameterSetMap(psetMap);
+    sd.setOrderedProcessNames(*orderedProcessNames_);
 
     data_buffer.rootbuf_.Reset();
 

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -62,7 +62,7 @@ namespace edm::streamer {
 
     if (subsequent) {
       ProductRegistry pReg;
-      pReg.updateFromInput(descs);
+      pReg.updateFromInput(descs, header.orderedProcessNames());
       std::string mergeInfo = reg.merge(pReg, std::string(), ProductDescription::Permissive);
       if (!mergeInfo.empty()) {
         throw cms::Exception("MismatchedInput", "StreamerInputSource::mergeIntoRegistry") << mergeInfo;
@@ -72,7 +72,7 @@ namespace edm::streamer {
       buildClassCache(descs);
       loadExtraClasses();
       if (!reg.frozen()) {
-        reg.updateFromInput(descs);
+        reg.updateFromInput(descs, header.orderedProcessNames());
       }
     }
   }

--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -16,7 +16,7 @@ namespace edm::streamer {
   StreamerOutputModuleBase::StreamerOutputModuleBase(ParameterSet const& ps)
       : one::OutputModuleBase::OutputModuleBase(ps),
         one::OutputModule<one::WatchRuns, one::WatchLuminosityBlocks>(ps),
-        StreamerOutputModuleCommon(ps, &keptProducts()[InEvent], description().moduleLabel()),
+        StreamerOutputModuleCommon(ps, &keptProducts()[InEvent], &orderedProcessNames(), description().moduleLabel()),
         trToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"))),
         psetToken_(
             consumes<SendJobHeader::ParameterSetMap, edm::InRun>(ps.getUntrackedParameter<edm::InputTag>("psetMap"))) {}

--- a/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
@@ -29,8 +29,9 @@ namespace edm::streamer {
 
   StreamerOutputModuleCommon::StreamerOutputModuleCommon(Parameters const& p,
                                                          SelectedProducts const* selections,
+                                                         std::vector<std::string> const* orderedProcessNames,
                                                          std::string const& moduleLabel)
-      : builders_(p, selections, moduleLabel) {}
+      : builders_(p, selections, orderedProcessNames, moduleLabel) {}
 
   StreamerOutputModuleCommon::~StreamerOutputModuleCommon() {}
 

--- a/IOPool/Streamer/src/StreamerOutputMsgBuilders.cc
+++ b/IOPool/Streamer/src/StreamerOutputMsgBuilders.cc
@@ -35,10 +35,11 @@ namespace edm::streamer {
 
   StreamerOutputMsgBuilders::StreamerOutputMsgBuilders(Parameters const& p,
                                                        SelectedProducts const* selections,
+                                                       std::vector<std::string> const* orderedProcessNames,
                                                        std::string const& moduleLabel)
       :
 
-        serializer_(selections),
+        serializer_(selections, orderedProcessNames),
         useCompression_(p.useCompression),
         compressionAlgoStr_(p.compressionAlgoStr),
         compressionLevel_(p.compressionLevel),


### PR DESCRIPTION
#### PR description:

- Previously, you could (theoretically) merge jobs with wildly different process histories, e.g.
   - A,B,C with B,C,A
   - A,B,C with D,E
- This change requires the process histories of the different files be consistent, i.e. when put together they form an unambiguous proper ordering based on a transitive relationship, e.g.
   - A,B,C merged with A,C,D gives A,B,C,D 
- The ordering of the processes is now available at begin job time via the ProductRegistry.
- Changed the streamer file format to support setting the process order at begin job time
   - The streamer format writes the ProductRegistry contents into the SendJobHeader object. This was extended to include the list of process names in process order. This is needed to fully interpret the ProductRegistry content.

#### PR validation:

Framework unit tests pass

resolves https://github.com/cms-sw/framework-team/issues/1518
resolves https://github.com/cms-sw/framework-team/issues/1519