### PR TITLE
Phase2-hgx364 Add 2 more workflows for HGCal v19 (with no creation of geometry tree beyond the wafers; one with no gaps among the silicon modules)

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_Run4.py
+++ b/Configuration/PyReleaseValidation/python/relval_Run4.py
@@ -41,6 +41,8 @@ numWFIB.extend([33234.0]) #Run4D118
 numWFIB.extend([33634.0]) #Run4D119
 numWFIB.extend([34034.0]) #Run4D120
 numWFIB.extend([34434.0]) #Run4D121
+numWFIB.extend([34834.0]) #Run4D122
+numWFIB.extend([35234.0]) #Run4D123
 
 #Additional sample for short matrix and IB
 #Default Phase-2 Det NoPU


### PR DESCRIPTION
#### PR description:

Add 2 more workflows for HGCal v19 (with no creation of geometry tree beyond the wafers; one with no gaps among the silicon modules)

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special