### PR TITLE
[CommonTools/TrackerMap] Use edm::isNotFinite instead of std::isnan

### DIFF
--- a/CommonTools/TrackerMap/src/TrackerMap.cc
+++ b/CommonTools/TrackerMap/src/TrackerMap.cc
@@ -9,6 +9,7 @@
 #include "CommonTools/TrackerMap/interface/TmApvPair.h"
 #include "CommonTools/TrackerMap/interface/TmCcu.h"
 #include "CommonTools/TrackerMap/interface/TmPsu.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 #include <fstream>
 #include <vector>
 #include <iostream>
@@ -693,7 +694,7 @@ void TrackerMap::drawModule(TmModule *mod, int key, int mlay, bool print_total, 
 
   //Get value and name for TH2Poly bin
   float vals = mod->value;
-  if (std::isnan(vals))
+  if (edm::isNotFinite(vals))
     vals = 0;  //Avoid nan values
   std::string nams = mod->name;
 


### PR DESCRIPTION
#### PR description:

Static analyzer [reports](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_15_1_X_2025-08-17-2300/el8_amd64_gcc12/llvm-analysis/report-8df3db.html#EndPath) use of `std::isnan`, which doesn't work when fastmath is enabled.

#### PR validation:

Bot tests