### PR TITLE
[CondTools/RunInfo] Use edm::isNotFinite instead of std::isnan

### DIFF
--- a/CondTools/RunInfo/src/LHCInfoPerFillPopConSourceHandler.cc
+++ b/CondTools/RunInfo/src/LHCInfoPerFillPopConSourceHandler.cc
@@ -15,6 +15,7 @@
 #include "RelationalAccess/IQuery.h"
 #include "RelationalAccess/ISchema.h"
 #include "RelationalAccess/ISessionProxy.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 
 using std::make_pair;
 using std::pair;
@@ -722,7 +723,7 @@ bool LHCInfoPerFillPopConSourceHandler::getEcalData(cond::persistency::Session& 
         dipVal = dipValAttribute.data<std::string>();
         elementNr = elementNrAttribute.data<unsigned int>();
         value = valueNumberAttribute.data<float>();
-        if (std::isnan(value))
+        if (edm::isNotFinite(value))
           value = 0.;
         if (filter.process(iovTime)) {
           iovMap.insert(make_pair(changeTime, filter.current()->first));


### PR DESCRIPTION
#### PR description:

Static analyzer [reports](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_15_1_X_2025-08-17-2300/el8_amd64_gcc12/llvm-analysis/report-73c4e1.html#EndPath) use of std::isnan, which doesn't work when fastmath is enabled.

#### PR validation:

Bot tests