### PR TITLE
[DQM/SiPixelMonitorRawData] Fix 'Called C++ object pointer is null'

### DIFF
--- a/DQM/SiPixelMonitorRawData/src/SiPixelRawDataErrorSource.cc
+++ b/DQM/SiPixelMonitorRawData/src/SiPixelRawDataErrorSource.cc
@@ -216,8 +216,10 @@ void SiPixelRawDataErrorSource::buildStructure(const edm::EventSetup &iSetup) {
   for (TrackerGeometry::DetContainer::const_iterator it = pDD->detsPXF().begin(); it != pDD->detsPXF().end(); it++) {
     const GeomDetUnit *geoUnit = dynamic_cast<const GeomDetUnit *>(*it);
     // check if it is a detUnit
-    if (geoUnit == nullptr)
+    if (geoUnit == nullptr) {
       LogError("PixelDQM") << "Pixel GeomDet is not a GeomDetUnit!" << std::endl;
+      continue;
+    }
     const PixelGeomDetUnit *pixDet = dynamic_cast<const PixelGeomDetUnit *>(geoUnit);
     int nrows = (pixDet->specificTopology()).nrows();
     int ncols = (pixDet->specificTopology()).ncolumns();


### PR DESCRIPTION
#### PR description:

LLVM analyzer [reports](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_15_1_X_2025-08-17-2300/el8_amd64_gcc12/llvm-analysis/report-60e427.html#EndPath)  'Called C++ object pointer is null'. The `continue` statement is likely missing here, see code on L199-202 above: https://github.com/cms-sw/cmssw/blob/d6972d018f12413519dac3d273a4caea61ee9afd/DQM/SiPixelMonitorRawData/src/SiPixelRawDataErrorSource.cc#L199-L202

#### PR validation:

Bot tests