### PR TITLE
[SIM] added doFineCalo_ variable definition to Phase2SteppingAction

### DIFF
--- a/SimG4Core/Application/interface/Phase2SteppingAction.h
+++ b/SimG4Core/Application/interface/Phase2SteppingAction.h
@@ -57,6 +57,7 @@ private:
   bool killBeamPipe{false};
   bool hasWatcher;
   bool dd4hep_;
+  bool doFineCalo_;
 
   std::vector<double> maxTrackTimes, ekinMins;
   std::vector<std::string> maxTimeNames, ekinNames, ekinParticles;

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -347,6 +347,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         EndPrintTrackID = cms.int32(0)
     ),
     SteppingAction = cms.PSet(
+        common_MCtruth,
         common_maximum_time,
         CMStoZDCtransport       = cms.bool(False),
         MaxNumberOfSteps        = cms.int32(20000),

--- a/SimG4Core/Application/src/Phase2SteppingAction.cc
+++ b/SimG4Core/Application/src/Phase2SteppingAction.cc
@@ -38,6 +38,7 @@ Phase2SteppingAction::Phase2SteppingAction(const CMSSteppingVerbose* sv,
   caloName_ = (G4String)(p.getParameter<std::string>("CaloName"));
   btlName_ = (G4String)(p.getParameter<std::string>("BTLName"));
   cms2ZDCName_ = p.getParameter<std::string>("CMS2ZDCName");
+  doFineCalo_ = (p.getParameter<bool>("DoFineCalo"));
 
   edm::LogVerbatim("SimG4CoreApplication")
       << "Phase2SteppingAction:: KillBeamPipe = " << killBeamPipe

--- a/SimG4Core/Application/src/Phase2SteppingAction.cc
+++ b/SimG4Core/Application/src/Phase2SteppingAction.cc
@@ -199,7 +199,7 @@ void Phase2SteppingAction::UserSteppingAction(const G4Step* aStep) {
     } else if (preStep->GetPhysicalVolume() == tracker && postStep->GetPhysicalVolume() == calo) {
       // store transition tracker -> calo
       TrackInformation* trkinfo = static_cast<TrackInformation*>(theTrack->GetUserInformation());
-      if (!trkinfo->crossedBoundary()) {
+      if (!trkinfo->crossedBoundary() && !doFineCalo_) {
         trkinfo->setCrossedBoundary(theTrack);
       }
     } else if ((preStep->GetPhysicalVolume() == calo && postStep->GetPhysicalVolume() == tracker) ||


### PR DESCRIPTION
#### PR description:

Added check for fineCalo in setBoundaryCrossing to avoid double counting simTrack energy when fineCalo is on. Currently in CaloTrkProcessing we make a difference for calling setBoundaryCrossing by checking wether fineCalo is on or not, but this is not accounted for in Phase2SteppingAction, which causes setBoundaryCrossing to be called twice, once in Phase2SteppingAction and once in CaloTrkProcessing, which causes energy double counting behaviour. By adding a check to see if doFineCalo_ is set to false, we avoid this double calling.

#### PR validation:

After adding this check, I plotted the total simTrack energy per event and verified that the double counting behaviour was no longer happening.


