### PR TITLE
[15.0.X] Improve HLT Scouting DataFormat event content handling in derived datasets

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -95,12 +95,13 @@ from L1Trigger.Configuration.L1Trigger_EventContent_cff import *
 #
 #
 from HLTrigger.Configuration.HLTrigger_EventContent_cff import *
-from HLTrigger.Configuration.HLTScouting_EventContent_cff import HLTScoutingAll
+from HLTrigger.Configuration.HLTScouting_EventContent_cff import HLTScoutingExtra
 # Extend HLT dataformats to the previous scouting objects, to keep them when running on old data/MC
-HLTriggerMINIAOD.outputCommands.extend(HLTScoutingAll.outputCommands)
-HLTriggerAOD.outputCommands.extend(HLTScoutingAll.outputCommands)
-HLTriggerRECO.outputCommands.extend(HLTScoutingAll.outputCommands)
-HLTDebugFEVT.outputCommands.extend(HLTScoutingAll.outputCommands)
+HLTriggerMINIAODSIM.outputCommands.extend(HLTScoutingExtra.outputCommands)
+HLTriggerMINIAOD.outputCommands.extend(HLTScoutingExtra.outputCommands)
+HLTriggerAOD.outputCommands.extend(HLTScoutingExtra.outputCommands)
+HLTriggerRECO.outputCommands.extend(HLTScoutingExtra.outputCommands)
+HLTDebugFEVT.outputCommands.extend(HLTScoutingExtra.outputCommands)
 #
 #
 # DQM

--- a/HLTrigger/Configuration/python/HLTScouting_EventContent_cff.py
+++ b/HLTrigger/Configuration/python/HLTScouting_EventContent_cff.py
@@ -3,11 +3,9 @@ import FWCore.ParameterSet.Config as cms
 # EventContent for HLT Scouting products.
 
 # This file keep track of all the scouting objects used since Run-2 
-# HLTScoutingAll is used in Configuration/EventContent to keep all scouting objects available in all AOD/MINIAOD[SIM]
-
 HLTScoutingAll = cms.PSet(
     outputCommands = cms.vstring( *(
-        ## Current scouting objects (from 2024)
+        ## Current scouting objects (from 2025, V1.3, same content as HLTriggerMINIAOD)
         'keep *_hltFEDSelectorL1_*_*',  # PR#20739
         'keep *_hltScoutingEgammaPacker_*_*', # PR#20739
         'keep *_hltScoutingMuonPackerNoVtx_*_*', # PR#44302
@@ -15,7 +13,21 @@ HLTScoutingAll = cms.PSet(
         'keep *_hltScoutingPFPacker_*_*', # PR#20739
         'keep *_hltScoutingPrimaryVertexPacker_*_*',  # PR#20739
         'keep *_hltScoutingTrackPacker_*_*', # PR #23077
+        'keep *_hltScoutingRecHitPacker_*_*', # PR #48613
+        ## Previous scouting objects
+        # Run3 (2022-23)
+        'keep *_hltScoutingMuonPacker_*_*', # added w/ PR#20739, removed w/ PR#44302
 
+        # Run2 only
+        'keep *_hltScoutingCaloPacker_*_*',  # added  w/ PR#20739, removed w/ PR#37114
+        'keep *_hltScoutingMuonPackerCalo_*_*', # added  w/ PR#20739, removed w/  PR#37114
+        'keep *_hltScoutingPrimaryVertexPackerCaloMuon_*_*', # added  w/ PR#20739, removed w/  PR#37114
+    ) )
+)
+
+# HLTScoutingExtra is used in Configuration/EventContent to keep all scouting objects available in all AOD/MINIAOD[SIM]
+HLTScoutingExtra = cms.PSet(
+    outputCommands = cms.vstring( *(
         ## Previous scouting objects
         # Run3 (2022-23)
         'keep *_hltScoutingMuonPacker_*_*', # added w/ PR#20739, removed w/ PR#44302

--- a/HLTrigger/Configuration/python/HLTScouting_EventContent_cff.py
+++ b/HLTrigger/Configuration/python/HLTScouting_EventContent_cff.py
@@ -6,22 +6,24 @@ import FWCore.ParameterSet.Config as cms
 HLTScoutingAll = cms.PSet(
     outputCommands = cms.vstring( *(
         ## Current scouting objects (from 2025, V1.3, same content as HLTriggerMINIAOD)
-        'keep *_hltFEDSelectorL1_*_*',  # PR#20739
-        'keep *_hltScoutingEgammaPacker_*_*', # PR#20739
-        'keep *_hltScoutingMuonPackerNoVtx_*_*', # PR#44302
-        'keep *_hltScoutingMuonPackerVtx_*_*',  # PR#44302
-        'keep *_hltScoutingPFPacker_*_*', # PR#20739
-        'keep *_hltScoutingPrimaryVertexPacker_*_*',  # PR#20739
-        'keep *_hltScoutingTrackPacker_*_*', # PR #23077
-        'keep *_hltScoutingRecHitPacker_*_*', # PR #48613
+        'keep *_hltFEDSelectorL1_*_*',               # PR #20739
+        'keep *_hltScoutingEgammaPacker_*_*',        # PR #20739
+        'keep *_hltScoutingMuonPackerNoVtx_*_*',     # PR #44302
+        'keep *_hltScoutingMuonPackerVtx_*_*',       # PR #44302
+        'keep *_hltScoutingPFPacker_*_*',            # PR #20739
+        'keep *_hltScoutingPrimaryVertexPacker_*_*', # PR #20739
+        'keep *_hltScoutingRecHitPacker_*_*',        # PR #48613
+        'keep *_hltScoutingTrackPacker_*_*',         # PR #23077
+        'keep edmTriggerResults_*_*_*',
+
         ## Previous scouting objects
         # Run3 (2022-23)
-        'keep *_hltScoutingMuonPacker_*_*', # added w/ PR#20739, removed w/ PR#44302
+        'keep *_hltScoutingMuonPacker_*_*',                  # added w/ PR#20739, removed w/ PR#44302
 
         # Run2 only
-        'keep *_hltScoutingCaloPacker_*_*',  # added  w/ PR#20739, removed w/ PR#37114
-        'keep *_hltScoutingMuonPackerCalo_*_*', # added  w/ PR#20739, removed w/  PR#37114
-        'keep *_hltScoutingPrimaryVertexPackerCaloMuon_*_*', # added  w/ PR#20739, removed w/  PR#37114
+        'keep *_hltScoutingCaloPacker_*_*',                  # added w/ PR#20739, removed w/ PR#37114
+        'keep *_hltScoutingMuonPackerCalo_*_*',              # added w/ PR#20739, removed w/  PR#37114
+        'keep *_hltScoutingPrimaryVertexPackerCaloMuon_*_*', # added w/ PR#20739, removed w/  PR#37114
     ) )
 )
 
@@ -30,11 +32,11 @@ HLTScoutingExtra = cms.PSet(
     outputCommands = cms.vstring( *(
         ## Previous scouting objects
         # Run3 (2022-23)
-        'keep *_hltScoutingMuonPacker_*_*', # added w/ PR#20739, removed w/ PR#44302
+        'keep *_hltScoutingMuonPacker_*_*',                  # added w/ PR#20739, removed w/ PR#44302
 
         # Run2 only
-        'keep *_hltScoutingCaloPacker_*_*',  # added  w/ PR#20739, removed w/ PR#37114
-        'keep *_hltScoutingMuonPackerCalo_*_*', # added  w/ PR#20739, removed w/  PR#37114
-        'keep *_hltScoutingPrimaryVertexPackerCaloMuon_*_*', # added  w/ PR#20739, removed w/  PR#37114
+        'keep *_hltScoutingCaloPacker_*_*',                  # added w/ PR#20739, removed w/ PR#37114
+        'keep *_hltScoutingMuonPackerCalo_*_*',              # added w/ PR#20739, removed w/  PR#37114
+        'keep *_hltScoutingPrimaryVertexPackerCaloMuon_*_*', # added w/ PR#20739, removed w/  PR#37114
     ) )
 )

--- a/HLTrigger/Configuration/test/BuildFile.xml
+++ b/HLTrigger/Configuration/test/BuildFile.xml
@@ -17,3 +17,6 @@
 
 <!-- test script testOnlineVsDevTablesConsistency -->
 <test name="test_OnlineVsDevTablesConsistency" command="test_OnlineVsDevTablesConsistency.sh"/>
+
+<!-- test script to check the consistency of event content of HLTScoutingExtra and HLTScoutingAll -->
+<test name="testHLTScoutingEventContent"  command="python3 ${CMSSW_BASE}/src/HLTrigger/Configuration/test/testHLTScoutingEventContent.py"/>

--- a/HLTrigger/Configuration/test/testHLTScoutingEventContent.py
+++ b/HLTrigger/Configuration/test/testHLTScoutingEventContent.py
@@ -21,11 +21,27 @@ class TestHLTScoutingEventContent(unittest.TestCase):
         if combined != allset:
             missing = allset - combined
             extra_stuff = combined - allset
-            msg = ["HLTScouting consistency check failed:"]
+
+            msg = []
+            msg.append("ERROR: HLTScouting consistency check failed!")
+            msg.append("")
+            msg.append("The combined content of HLTScouting + HLTScoutingExtra")
+            msg.append("does not match HLTScoutingAll.")
+            msg.append("")
             if missing:
-                msg.append(f"  Missing in (HLTScouting + HLTScoutingExtra): {sorted(missing)}")
+                msg.append(" Missing expected entries in (HLTScouting + HLTScoutingExtra):")
+                for item in sorted(missing):
+                    msg.append(f"    - '{item}'")
             if extra_stuff:
-                msg.append(f"  Extra in (HLTScouting + HLTScoutingExtra): {sorted(extra_stuff)}")
+                msg.append(" Extra entries in (HLTScouting + HLTScoutingExtra):")
+                for item in sorted(extra_stuff):
+                    msg.append(f"    - '{item}'")
+            msg.append("")
+            msg.append(
+                "To fix this: edit "
+                "HLTrigger/Configuration/python/HLTScouting_EventContent_cff.py"
+            )
+            msg.append("   (do NOT edit HLTrigger_EventContent_cff.py, it is auto-generated).")
             self.fail("\n".join(msg))
 
 

--- a/HLTrigger/Configuration/test/testHLTScoutingEventContent.py
+++ b/HLTrigger/Configuration/test/testHLTScoutingEventContent.py
@@ -1,0 +1,33 @@
+import unittest
+
+import FWCore.ParameterSet.Config as cms
+
+# Import the definitions
+from HLTrigger.Configuration.HLTrigger_EventContent_cff import HLTScouting
+from HLTrigger.Configuration.HLTScouting_EventContent_cff import HLTScoutingExtra, HLTScoutingAll
+
+class TestHLTScoutingEventContent(unittest.TestCase):
+
+    def test_hlt_scouting_consistency(self):
+        # Convert cms.vstring to Python sets
+        scouting = set(HLTScouting.outputCommands)
+        extra = set(HLTScoutingExtra.outputCommands)
+        allset = set(HLTScoutingAll.outputCommands)
+
+        # Union of current + extra
+        combined = scouting | extra
+
+        # Check consistency
+        if combined != allset:
+            missing = allset - combined
+            extra_stuff = combined - allset
+            msg = ["HLTScouting consistency check failed:"]
+            if missing:
+                msg.append(f"  Missing in (HLTScouting + HLTScoutingExtra): {sorted(missing)}")
+            if extra_stuff:
+                msg.append(f"  Extra in (HLTScouting + HLTScoutingExtra): {sorted(extra_stuff)}")
+            self.fail("\n".join(msg))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/48763

#### PR description:

The goal of this PR is to improve the handling of scouting collections in derived data-tiers, after the merge of https://github.com/cms-sw/cmssw/pull/48666.
The implementation in that PR has two draw-backs:
- the derived dataset events content `outputCommands` statements had duplicated `keep`s in them.
- after the integration of [CMSHLT-3607](https://its.cern.ch/jira/browse/CMSHLT-3607) via https://github.com/cms-sw/cmssw/pull/48719 the collection `hltScoutingRecHitPacker` was missing from `HLTScoutingAll` and there was not a mechanism in place to ensure it gets added to real data event contents but NOT to e.g. `MINIAODSIM`.

This PR solves the issues by adding a new set of `outputCommands` called `HLTScoutingExtra` (which contains only the decommissioned scouting collections) and that's what we add to the existing `HLTrigger*` event contents. 
To ensure that the sum of event contents of `HLTScouting` and `HLTScoutingExtra` stays in synch with the intended full list of collections (`HLTScoutingAll`) a new unit test is put into place (`testHLTScoutingEventContent`).

#### PR validation:

The unit test:

```
scram b runtests_testHLTScoutingEventContent
```
runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/48763 for 2025 data-taking operations.

Cc: @silviodonato @elfontan @patinkaew 