### PR TITLE
Increase electron H/E threshold in PbPb eras

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeeds_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeeds_cff.py
@@ -12,6 +12,7 @@ ecalDrivenElectronSeeds.initialSeedsVector = newCombinedSeeds.seedCollections
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 pp_on_AA.toModify(ecalDrivenElectronSeeds, SCEtCut = 15.0)
+pp_on_AA.toModify(ecalDrivenElectronSeeds, maxHOverEBarrel = 0.5, maxHOverEEndcaps = 0.5)
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toModify(

--- a/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
@@ -27,6 +27,7 @@ ecalDrivenGsfElectrons = gsfElectronProducer.clone(
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 pp_on_AA.toModify(ecalDrivenGsfElectrons.preselection, minSCEtBarrel = 15.0)
 pp_on_AA.toModify(ecalDrivenGsfElectrons.preselection, minSCEtEndcaps = 15.0)
+pp_on_AA.toModify(ecalDrivenGsfElectrons.preselection, maxHOverEBarrelCone = 0.5, maxHOverEEndcapsCone = 0.5)
 
 ecalDrivenGsfElectronsHGC = ecalDrivenGsfElectrons.clone(
     gsfElectronCoresTag = "ecalDrivenGsfElectronCoresHGC",

--- a/RecoParticleFlow/PFProducer/python/particleFlow_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlow_cff.py
@@ -47,3 +47,6 @@ run3_common.toModify(particleFlowTmp.PFEGammaFiltersParameters,
     useElePFidDnn = True,  
     usePhotonPFidDnn = True
 )
+
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+pp_on_AA.toModify(particleFlowTmp.PFEGammaFiltersParameters, electron_ecalDrivenHademPreselCut = 0.5)


### PR DESCRIPTION
#### PR description:

This PR increases the H/E threshold used for electrons from 0.15 to 0.5 in the PbPb eras via the pp_on_AA era modifier.

The inefficiency of ECAL-driven electrons in central PbPb collisions was identified to arise from the maximum H/E selection of 0.15 applied on super clusters used for producing ECAL-driven seeds. This selection was too tight for central PbPb collisions where the large event activity increases the H/E.

Increasing the H/E threshold to the same value used for photons (0.5) managed to recover the electrons and reach similar electron efficiencies in central PbPb as in peripheral PbPb and pp collisions, leading to an increase of efficiency from 64% to 95% in the barrel and from 30% to 94% in the endcap, while the fake rate in the reconstructed electrons (gedGsfElectron) remained under control only increasing by less than 1% in the barrel and 10% in the endcap in 0-20% centrality.

These changes were checked offline with a HYDJET embedded DY->ee 2023 PbPb MC simulation showing the improvement in electron efficiency. And the timing and event size were checked with 10k minbias events from 2023 PbPb data, showing an increase of less than 1% in reco timing and no significant increase in total MiniAOD event size.

@mandrenguyen @pfs @RSalvatico

#### PR validation:

Tested with workflows 162,162.02,162.03,162.1,162.2,162.3,162.4

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
