### PR TITLE
Update low pT egamma regression in 2025 UPC era

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2916,9 +2916,9 @@ steps['RECODR3_2023_UPC']=merge([{'--conditions':'auto:run3_data', '--era':'Run3
 steps['RECODR3_2024_HIN']=merge([{'--conditions':'auto:run3_data_prompt', '-s':'RAW2DIGI,L1Reco,RECO,PAT,DQM:@commonFakeHLT+@standardDQMFakeHLT', '--repacked':'', '-n':1000},steps['RECODR3_2024']])
 steps['RECODR3_2024_UPC']=merge([{'--era':'Run3_2024_UPC'},steps['RECODR3_2024_HIN']])
 steps['RECODR3_2025_HIN']=merge([{'--conditions':'auto:run3_data_prompt', '-s':'RAW2DIGI,L1Reco,RECO,PAT,DQM:@commonFakeHLT+@standardDQMFakeHLT', '--repacked':'', '-n':1000},steps['RECODR3_2025']])
-steps['RECODR3_2025_UPC']=merge([{'--era':'Run3_2025_UPC'},steps['RECODR3_2025_HIN']])
+steps['RECODR3_2025_UPC']=merge([{'--era':'Run3_2025_UPC', '--conditions':'150X_dataRun3_Prompt_v3'},steps['RECODR3_2025_HIN']])
 steps['RECODR3_2025_OXY']=merge([{'--era':'Run3_2025_OXY'},steps['RECODR3_2025_HIN']])
-steps['RECODR3_2025_UPC_OXY']=merge([{'--era':'Run3_2025_UPC_OXY'},steps['RECODR3_2025_HIN']])
+steps['RECODR3_2025_UPC_OXY']=merge([{'--era':'Run3_2025_UPC_OXY'},steps['RECODR3_2025_UPC']])
 steps['RECODR3_2025_OXY_SKIMIONPHYSICS0']=merge([{'--era':'Run3_2025_OXY', '-s':'RAW2DIGI,L1Reco,RECO,SKIM:%s,PAT,DQM:@commonFakeHLT+@standardDQMFakeHLT'%(autoSkim['IonPhysics0'])},steps['RECODR3_2025_HIN']])
 
 steps['RECODR3Splash']=merge([{'-n': 2,

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -28,8 +28,8 @@ egamma_lowPt_exclusive.toModify(particleFlowSuperClusterECAL,
                                 thresh_PFClusterSeedBarrel = 0.5,
                                 thresh_PFClusterSeedEndcap = 0.5)
 
-from Configuration.Eras.Modifier_run3_upc_2023_cff import run3_upc_2023
-(egamma_lowPt_exclusive & run3_upc_2023).toModify(particleFlowSuperClusterECAL, regressionConfig = dict(
+from Configuration.Eras.Modifier_run3_egamma_cff import run3_egamma
+(egamma_lowPt_exclusive & run3_egamma).toModify(particleFlowSuperClusterECAL, regressionConfig = dict(
     regressionKeyEB  = 'pfscecal_ebCorrection_offline_v2',
     uncertaintyKeyEB = 'pfscecal_ebUncertainty_offline_v2',
     regressionKeyEE  = 'pfscecal_eeCorrection_offline_v2',

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectrons_cfi.py
@@ -71,8 +71,9 @@ _lowPtRegressionModifierUPC = regressionModifier103XLowPtPho.clone(
     ),
 )
 from Configuration.Eras.Modifier_run3_upc_2023_cff import run3_upc_2023
+from Configuration.Eras.Modifier_run3_upc_2025_cff import run3_upc_2025
 from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
-(egamma_lowPt_exclusive & run3_upc_2023).toReplaceWith(lowPtRegressionModifier,_lowPtRegressionModifierUPC)
+(egamma_lowPt_exclusive & (run3_upc_2023 | run3_upc_2025)).toReplaceWith(lowPtRegressionModifier,_lowPtRegressionModifierUPC)
 
 from RecoEgamma.EgammaElectronProducers.lowPtGsfElectronFinalizer_cfi import lowPtGsfElectronFinalizer
 lowPtGsfElectrons = lowPtGsfElectronFinalizer.clone(

--- a/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
+++ b/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
@@ -266,9 +266,8 @@ regressionModifierRun3 = regressionModifierRun2.clone(
 from Configuration.Eras.Modifier_run3_egamma_cff import run3_egamma
 run3_egamma.toReplaceWith(regressionModifier,regressionModifierRun3)
 
-from Configuration.Eras.Modifier_run3_upc_2023_cff import run3_upc_2023
-from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
-(run3_egamma_2023 & run3_upc_2023).toModify(regressionModifier103XLowPtPho,
+from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
+(run3_egamma & egamma_lowPt_exclusive).toModify(regressionModifier103XLowPtPho,
     eleRegs = dict(
         ecalOnlyMean = dict(
             rangeMinHighEt = 0.2,
@@ -283,5 +282,4 @@ from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
     )
 )
 
-from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
 egamma_lowPt_exclusive.toReplaceWith(regressionModifier,regressionModifier103XLowPtPho)


### PR DESCRIPTION
#### PR description:

This PR updates the low pT egamma regression settings in the 2025 UPC era to those used in the 2023 PbPb UPC rereco, updating the egamma regression of low pT electrons and photons.

@mandrenguyen 

#### PR validation:

Tested using workflows 182,182.1,143.901,143.902

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: