### PR TITLE
Add support for `{pre,post}ModuleEventDelayedGet` signals to the `FastTimerService`

### DIFF
--- a/HLTrigger/Timer/plugins/FastTimerService.h
+++ b/HLTrigger/Timer/plugins/FastTimerService.h
@@ -268,7 +268,6 @@ private:
   public:
     Resources total;
     unsigned events;
-    bool has_acquire;  // whether this module has an acquire() method
   };
 
   struct ResourcesPerPath {
@@ -311,6 +310,7 @@ private:
     AtomicResources overhead;
     AtomicResources eventsetup;
     AtomicResources idle;
+    AtomicResources source;
     Resources event;  // total time etc. spent between preSourceEvent and postEvent
     Measurement event_measurement;
     std::vector<Resources> highlight;
@@ -439,6 +439,7 @@ private:
     PlotsPerElement event_ex_;
     PlotsPerElement overhead_;
     PlotsPerElement idle_;
+    PlotsPerElement source_;
     // resources spent in the modules' lumi and run transitions
     PlotsPerElement lumi_;
     PlotsPerElement run_;


### PR DESCRIPTION
#### PR description:

This PR extends the functionality of the `FastTimerService` adding support for the  {pre,post}ModuleEventDelayedGet signals. The time before and after each of these signals is assigned to the calling module, while the interval between the two is assigned to `Source` since the framework is effectively reading from the input file. 
This change fixes the observed fluctuation of Phase 2 Muon modules' timing as reported in the [HLT Upgrade meeting on 13/05/2025](https://indico.cern.ch/event/1547579/#5-update-on-timing-variation-o).
The issue was further investigated and relates back to modules that consume `L1TkMuon`s and in particular a `TrackerMuonRefVector` defined [here](https://github.com/cms-sw/cmssw/blob/763da79e4e09c5053b9d64c6516816c4942bdd51/DataFormats/L1TMuonPhase2/interface/TrackerMuon.h#L21),  which has then access to an `edm::Ptr<L1TTTrackType>`. Introducing a generic consumer to consume `"*TTTrack*_*_*_*", "*_l1tStubsGmt_*_*"` directly in `HLTBeginSequence` completely masks the issue and removes the warnings related to the unsupported signals for both Phase 1 and Phase 2 workflows.

Related to #40433 and #48062

#### PR validation:

The proposed fix has been tested both with and without the `genericConsumer` as you can see in the following picture

<img width="1771" height="947" alt="plot(1)" src="https://github.com/user-attachments/assets/9a6d7bfc-8a72-4d73-a63d-885d041059a0" />


Note that, moving from before to after the fix, there is a shift in where the time is assigned with the source module growing and the Muon slice shrinking as expected, but the overall time is not impacted.

These measurements have been obtained by running a benchmark with both the current `FastTimerService` and the updated one in the same job as to have the most precise comparison between the two. The interactive pie and bar charts are available at the following links:
- [baseline](https://lferragi.web.cern.ch/timing/piechart.php?local=false&dataset=muonTiming48062%2Flegacy_16j_16t_16s&resource=time_real&colours=default&groups=hlt&data_name=data&show_labels=true&threshold=0)
- [updated](https://lferragi.web.cern.ch/timing/piechart.php?local=false&dataset=muonTiming48062%2Flegacy_16j_16t_16s_updated&resource=time_real&colours=default&groups=hlt&data_name=data&show_labels=true&threshold=0)
- [genericConsumerBaseline](https://lferragi.web.cern.ch/timing/piechart.php?local=false&dataset=muonTiming48062%2FgenericConsumer%2Flegacy_16j_16t_16s&resource=time_real&colours=default&groups=hlt&data_name=data&show_labels=true&threshold=0)
- [genericConsumerUpdated](https://lferragi.web.cern.ch/timing/piechart.php?local=false&dataset=muonTiming48062%2FgenericConsumer%2Flegacy_16j_16t_16s_updated&resource=time_real&colours=default&groups=hlt&data_name=data&show_labels=true&threshold=0)

