### PR TITLE
ScoutingNano: Update skipEventsWithoutScouting to include new ScoutingPF0,ScoutingPF1 datasets

### DIFF
--- a/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
@@ -221,7 +221,8 @@ def skipEventsWithoutScouting(process):
     import HLTrigger.HLTfilters.hltHighLevel_cfi
 
     process.scoutingTriggerPathFilter = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
-            HLTPaths = cms.vstring("Dataset_ScoutingPFRun3")
+            HLTPaths = cms.vstring("Dataset_ScoutingPFRun3", "Dataset_ScoutingPF0", "Dataset_ScoutingPF1"),
+            throw = cms.bool(False)
             )
 
     process.nanoSkim_step = cms.Path(process.scoutingTriggerPathFilter)


### PR DESCRIPTION
#### PR description:

From 2025E, ```ScoutingPFRun3``` dataset is split and renamed to ```ScoutingPF0``` and ```ScoutingPF1```.
```skipEventsWithoutScouting``` still uses ```Dataset_ScoutingPFRun3```, resulting in a crash observed by ORM, T0.

This PR updates skipEventsWithoutScouting to include new ScoutingPF0,ScoutingPF1 datasets.

#### PR validation:

pass ```scram b runtests use-ibeos```.

tested with ```ScoutingPFMonitor/2025E/RAW```:
```
cmsDriver.py step2\
 -s NANO:@ScoutMonitor --process NANO\
 --data --eventcontent NANOAOD --datatier NANOAOD\
 -n 20\
 --era Run3_2025 --conditions auto:run3_data\
 --filein file:00e3df82-97ea-4ed3-a10e-a58c89c20fdd.root\
 --fileout ScoutingPFMonitor_2025E_ScoutingNano_Data_Standalone.root\
 --python_file ScoutingPFMonitor_2025E_ScoutingNano_Data_Standalone.py\
 --nThreads 4
```

tested with ```ScoutingPFMonitor/2025D/RAW```:
```
cmsDriver.py step2\
 -s NANO:@ScoutMonitor --process NANO\
 --data --eventcontent NANOAOD --datatier NANOAOD\
 -n 20\
 --era Run3_2025 --conditions auto:run3_data\
 --filein <fileIn.root>\
 --fileout ScoutingPFMonitor_2025D_ScoutingNano_Data_Standalone.root\
 --python_file ScoutingPFMonitor_2025D_ScoutingNano_Data_Standalone.py \
 --nThreads 4
```

tested with ```ScoutingPFMonitor/2024I/MINIAOD```:
```
cmsDriver.py step2\
 -s NANO:@ScoutMonitor --process NANO\
 --data --eventcontent NANOAOD --datatier NANOAOD\
 -n 100\
 --era Run3_2024 --conditions auto:run3_data\
 --filein <fileIn.root>\
 --fileout ScoutingPFMonitor_2024I_ScoutingNano_Data_Standalone.root\
 --python_file ScoutingPFMonitor_2024I_ScoutingNano_Data_Standalone.py \
 --nThreads 4
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport. Backport to 15_0_X is https://github.com/cms-sw/cmssw/pull/48776.
