### PR TITLE
[15_0_X] ScoutingNano: Update skipEventsWithoutScouting to include new ScoutingPF0,ScoutingPF1 datasets

### DIFF
--- a/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
@@ -221,7 +221,8 @@ def skipEventsWithoutScouting(process):
     import HLTrigger.HLTfilters.hltHighLevel_cfi
 
     process.scoutingTriggerPathFilter = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
-            HLTPaths = cms.vstring("Dataset_ScoutingPFRun3")
+            HLTPaths = cms.vstring("Dataset_ScoutingPFRun3", "Dataset_ScoutingPF0", "Dataset_ScoutingPF1"),
+            throw = cms.bool(False)
             )
 
     process.nanoSkim_step = cms.Path(process.scoutingTriggerPathFilter)


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/48775.

#### PR validation:

Same as https://github.com/cms-sw/cmssw/pull/48775.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport to 15_0_X.
