### PR TITLE
Extend `cmsTraceFunction` test to `putenv()` and `--abort`

### DIFF
--- a/Utilities/ReleaseScripts/test/gdb/test-cmsTraceFunction-putenv.cpp
+++ b/Utilities/ReleaseScripts/test/gdb/test-cmsTraceFunction-putenv.cpp
@@ -1,0 +1,35 @@
+#include <iostream>
+#include <cstdlib>
+#include <cstring>
+#include <stdlib.h>
+
+class ScheduleItems {
+public:
+  ScheduleItems() {}
+  void initMisc();
+};
+
+void ScheduleItems::initMisc() { std::cout << "ScheduleItems::initMisc() called" << std::endl; }
+
+void my_putenv(const char* env, char* put) {
+  putenv(put);
+  std::cout << "putenv() called" << std::endl;
+  std::cout << env << "=" << std::getenv(env) << std::endl;
+}
+
+int main() {
+  // putenv() expects modifiable char array that lives throughout the program
+  char* foo1 = new char[10];
+  char* foo2 = new char[10];
+  char* foo3 = new char[10];
+  std::strncpy(foo1, "FOO=1", 10);
+  std::strncpy(foo2, "FOO=2", 10);
+  std::strncpy(foo3, "FOO=3", 10);
+
+  my_putenv("FOO", foo1);
+  ScheduleItems obj;
+  obj.initMisc();
+  my_putenv("FOO", foo2);
+  my_putenv("FOO", foo3);
+  return 0;
+}

--- a/Utilities/ReleaseScripts/test/gdb/test-cmsTraceFunction-setenv.sh
+++ b/Utilities/ReleaseScripts/test/gdb/test-cmsTraceFunction-setenv.sh
@@ -1,9 +1,45 @@
 #!/bin/bash -ex
+
+TRACE="cmsTraceFunction --startAfterFunction ScheduleItems::initMisc setenv -f putenv --abort"
+
+# Check setenv
 g++ -o test-cmsTraceFunction-setenv $(dirname $0)/test-cmsTraceFunction-setenv.cpp
-cmsTraceFunction --startAfterFunction ScheduleItems::initMisc setenv ./test-cmsTraceFunction-setenv 2>&1 | grep setenv > setenv.log
-rm -f test-cmsTraceFunction-setenv
-setenv_count=$(grep '^setenv() called' setenv.log | wc -l)
-break_setenv=$(grep 'Breakpoint .* in setenv ()' setenv.log | wc -l)
-if [ ${setenv_count} != 3 ] || [ ${break_setenv} != 2 ] ; then
+set +e
+$TRACE ./test-cmsTraceFunction-setenv 2>&1 > setenv_raw.log
+ret_setenv=$?
+set -e
+grep setenv setenv_raw.log > setenv.log
+#rm -f test-cmsTraceFunction-setenv
+
+if [ ${ret_setenv} = 0 ]; then
+  echo "cmsTraceFunction exited with exit code 0, expected non-zero exit code"
+  exit 1
+fi
+
+setenv_count=$(grep -c '^setenv() called' setenv.log)
+break_setenv=$(grep -c 'Breakpoint .* in setenv ()' setenv.log)
+if [ ${setenv_count} != 1 ] || [ ${break_setenv} != 1 ] ; then
+  echo "Unexpected number of setenv calls ${setenv_count} or breakpoints ${break_setenv}; expecting both to be 1"
+  exit 1
+fi
+
+# Check putenv
+g++ -o test-cmsTraceFunction-putenv $(dirname $0)/test-cmsTraceFunction-putenv.cpp
+set +e
+$TRACE ./test-cmsTraceFunction-putenv 2>&1 > putenv_raw.log
+ret_putenv=$?
+set -e
+grep putenv putenv_raw.log > putenv.log
+rm -f test-cmsTraceFunction-putenv
+
+if [ ${ret_puttenv} = 0 ]; then
+  echo "cmsTraceFunction exited with exit code 0, expected non-zero exit code"
+  exit 1
+fi
+
+putenv_count=$(grep -c '^putenv() called' putenv.log)
+break_putenv=$(grep -c 'Breakpoint .* in putenv ()' putenv.log)
+if [ ${putenv_count} != 1 ] || [ ${break_tenv} != 1 ] ; then
+  echo "Unexpected number of putenv calls ${putenv_count} or breakpoints ${break_putenv}; expecting both to be 1"
   exit 1
 fi

--- a/Utilities/ReleaseScripts/test/gdb/test-cmsTraceFunction-setenv.sh
+++ b/Utilities/ReleaseScripts/test/gdb/test-cmsTraceFunction-setenv.sh
@@ -2,44 +2,35 @@
 
 TRACE="cmsTraceFunction --startAfterFunction ScheduleItems::initMisc setenv -f putenv --abort"
 
+check_func() {
+  local func_name="$1"
+  local src_name="$2"
+  local exe_name="test-cmsTraceFunction-${func_name}"
+  local raw_log="${func_name}_raw.log"
+  local log="${func_name}.log"
+
+  g++ -o "$exe_name" "$(dirname $0)/$src_name"
+  set +e
+  $TRACE ./$exe_name 2>&1 > "$raw_log"
+  local ret=$?
+  set -e
+  grep "$func_name" "$raw_log" > "$log"
+
+  if [ ${ret} = 0 ]; then
+    echo "cmsTraceFunction exited with exit code 0, expected non-zero exit code"
+    exit 1
+  fi
+
+  local call_count=$(grep -c "^${func_name}() called" "$log")
+  local break_count=$(grep -c "Breakpoint .* in ${func_name} ()" "$log")
+  if [ ${call_count} != 1 ] || [ ${break_count} != 1 ] ; then
+    echo "Unexpected number of ${func_name} calls ${call_count} or breakpoints ${break_count}; expecting both to be 1"
+    exit 1
+  fi
+}
+
 # Check setenv
-g++ -o test-cmsTraceFunction-setenv $(dirname $0)/test-cmsTraceFunction-setenv.cpp
-set +e
-$TRACE ./test-cmsTraceFunction-setenv 2>&1 > setenv_raw.log
-ret_setenv=$?
-set -e
-grep setenv setenv_raw.log > setenv.log
-#rm -f test-cmsTraceFunction-setenv
-
-if [ ${ret_setenv} = 0 ]; then
-  echo "cmsTraceFunction exited with exit code 0, expected non-zero exit code"
-  exit 1
-fi
-
-setenv_count=$(grep -c '^setenv() called' setenv.log)
-break_setenv=$(grep -c 'Breakpoint .* in setenv ()' setenv.log)
-if [ ${setenv_count} != 1 ] || [ ${break_setenv} != 1 ] ; then
-  echo "Unexpected number of setenv calls ${setenv_count} or breakpoints ${break_setenv}; expecting both to be 1"
-  exit 1
-fi
+check_func "setenv" "test-cmsTraceFunction-setenv.cpp"
 
 # Check putenv
-g++ -o test-cmsTraceFunction-putenv $(dirname $0)/test-cmsTraceFunction-putenv.cpp
-set +e
-$TRACE ./test-cmsTraceFunction-putenv 2>&1 > putenv_raw.log
-ret_putenv=$?
-set -e
-grep putenv putenv_raw.log > putenv.log
-rm -f test-cmsTraceFunction-putenv
-
-if [ ${ret_puttenv} = 0 ]; then
-  echo "cmsTraceFunction exited with exit code 0, expected non-zero exit code"
-  exit 1
-fi
-
-putenv_count=$(grep -c '^putenv() called' putenv.log)
-break_putenv=$(grep -c 'Breakpoint .* in putenv ()' putenv.log)
-if [ ${putenv_count} != 1 ] || [ ${break_tenv} != 1 ] ; then
-  echo "Unexpected number of putenv calls ${putenv_count} or breakpoints ${break_putenv}; expecting both to be 1"
-  exit 1
-fi
+check_func "putenv" "test-cmsTraceFunction-putenv.cpp"

--- a/Utilities/ReleaseScripts/test/gdb/test-cmsTraceFunction-setenv.sh
+++ b/Utilities/ReleaseScripts/test/gdb/test-cmsTraceFunction-setenv.sh
@@ -1,36 +1,53 @@
 #!/bin/bash -ex
 
-TRACE="cmsTraceFunction --startAfterFunction ScheduleItems::initMisc setenv -f putenv --abort"
+TRACE="cmsTraceFunction --startAfterFunction ScheduleItems::initMisc setenv -f putenv"
 
 check_func() {
   local func_name="$1"
   local src_name="$2"
+  local trace_opts="$3"
   local exe_name="test-cmsTraceFunction-${func_name}"
   local raw_log="${func_name}_raw.log"
   local log="${func_name}.log"
 
   g++ -o "$exe_name" "$(dirname $0)/$src_name"
   set +e
-  $TRACE ./$exe_name 2>&1 > "$raw_log"
+  $TRACE $trace_opts ./$exe_name 2>&1 > "$raw_log"
   local ret=$?
   set -e
   grep "$func_name" "$raw_log" > "$log"
 
-  if [ ${ret} = 0 ]; then
-    echo "cmsTraceFunction exited with exit code 0, expected non-zero exit code"
-    exit 1
+  if [ ${trace_opts} = "--abort" ]; then
+    call_count_expected=1
+    break_count_expected=1
+
+    if [ ${ret} = 0 ]; then
+      echo "cmsTraceFunction exited with exit code 0, expected non-zero exit code"
+      exit 1
+    fi
+  else
+    call_count_expected=3
+    break_count_expected=2
+
+    if [ ${ret} != 0 ]; then
+      echo "cmsTraceFunction exited with exit code $ret, expected zero exit code"
+      exit 1
+    fi
   fi
 
   local call_count=$(grep -c "^${func_name}() called" "$log")
   local break_count=$(grep -c "Breakpoint .* in ${func_name} ()" "$log")
-  if [ ${call_count} != 1 ] || [ ${break_count} != 1 ] ; then
-    echo "Unexpected number of ${func_name} calls ${call_count} or breakpoints ${break_count}; expecting both to be 1"
+  if [ ${call_count} != ${call_count_expected} ] || [ ${break_count} != ${break_count_expected} ] ; then
+    echo "Unexpected number of ${func_name} calls ${call_count} or breakpoints ${break_count}; expecting calls ${call_count_expected} and breakpoints ${break_count_expected}"
     exit 1
   fi
 }
 
 # Check setenv
-check_func "setenv" "test-cmsTraceFunction-setenv.cpp"
+check_func "setenv" "test-cmsTraceFunction-setenv.cpp" ""
+check_func "setenv" "test-cmsTraceFunction-setenv.cpp" "--abort"
+
 
 # Check putenv
-check_func "putenv" "test-cmsTraceFunction-putenv.cpp"
+check_func "putenv" "test-cmsTraceFunction-putenv.cpp" ""
+check_func "putenv" "test-cmsTraceFunction-putenv.cpp" "--abort"


### PR DESCRIPTION
#### PR description:

This PR complements https://github.com/cms-sw/cms-common/pull/20 by requiring the `cmsTraceFunction` to exit with non-zero exit code. It also extends the testing to cover `putenv()` (https://github.com/cms-sw/cmssw/issues/46002#issuecomment-3057638171, https://github.com/cms-sw/cmssw/issues/46002#issuecomment-3110220011)

Resolves https://github.com/cms-sw/framework-team/issues/1526

Must be merged after https://github.com/cms-sw/cms-common/pull/20

#### PR validation:

Unit test runs with the change in https://github.com/cms-sw/cms-common/pull/20