### PR TITLE
Add algorithm include to fix gcc14 build

### DIFF
--- a/DataFormats/Provenance/src/processingOrderMerge.cc
+++ b/DataFormats/Provenance/src/processingOrderMerge.cc
@@ -1,6 +1,7 @@
 #include "DataFormats/Provenance/interface/processingOrderMerge.h"
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include <algorithm>
 
 namespace edm {
   namespace {


### PR DESCRIPTION
#### PR description:

This should fix the build problem seen when compiling with gcc 14.

#### PR validation:

Using gcc14 now compiles.

resolves https://github.com/cms-sw/framework-team/issues/1533