### PR TITLE
Switch `addOnTests.py` script from `getopt` to `argparse`

### DIFF
--- a/Utilities/ReleaseScripts/scripts/addOnTests.py
+++ b/Utilities/ReleaseScripts/scripts/addOnTests.py
@@ -204,43 +204,45 @@ class StandardTester(object):
 
         return
 
+import argparse
 
-def main(argv) :
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Run CMSSW addOnTests in parallel threads and collect reports."
+    )
 
-    import getopt
+    parser.add_argument(
+        "-j", "--nproc", type=int, default=4,
+        help="Number of parallel threads to run (default: 4)"
+    )
+    parser.add_argument(
+        "-t", "--tests", type=lambda s: s.split(","),
+        help="Comma-separated list of tests to run (default: all)"
+    )
+    parser.add_argument(
+        "-d", "--dump", action="store_true",
+        help="Print the list of available tests and exit"
+    )
+    parser.add_argument(
+        "--noRun", action="store_true",
+        help="Do not run tests (useful with --dump)"
+    )
+    parser.add_argument(
+        "--uploadDir", metavar="DIR",
+        help="Copy logs and reports to the given directory"
+    )
 
-    try:
-        opts, args = getopt.getopt(argv, "dj:t:", ["nproc=", 'uploadDir=', 'tests=','noRun','dump'])
-    except getopt.GetoptError as e:
-        print("unknown option", str(e))
-        sys.exit(2)
+    args = parser.parse_args(argv)
 
-    np        = 4
-    uploadDir = None
-    runTests  = True
-    testList  = None
-    dump      = False
-    for opt, arg in opts :
-        if opt in ('-j', "--nproc" ):
-            np=int(arg)
-        if opt in ("--uploadDir", ):
-            uploadDir = arg
-        if opt in ('--noRun', ):
-            runTests = False
-        if opt in ('-d','--dump', ):
-            dump = True
-        if opt in ('-t','--tests', ):
-            testList = arg.split(",")
+    tester = StandardTester(args.nproc)
 
-    tester = StandardTester(np)
-    if dump:
+    if args.dump:
         tester.dumpTest()
     else:
-        if runTests:
-            tester.runTests(testList)
-        if uploadDir:
-            tester.upload(uploadDir)
-    return
+        if not args.noRun:
+            tester.runTests(args.tests)
+        if args.uploadDir:
+            tester.upload(args.uploadDir)
 
-if __name__ == '__main__' :
-    main(sys.argv[1:])
+if __name__ == '__main__':
+    main()

--- a/Utilities/ReleaseScripts/scripts/addOnTests.py
+++ b/Utilities/ReleaseScripts/scripts/addOnTests.py
@@ -119,7 +119,7 @@ class StandardTester(object):
         if os.path.exists(self.devPath + rFile): fullPath = self.devPath + rFile
         return fullPath
 
-    def runTests(self, testList = None):
+    def runTests(self, testList = None, dontRun = False):
 
         actDir = os.getcwd()
 
@@ -145,8 +145,14 @@ class StandardTester(object):
             print('Preparing to run %s' % str(command))
             current = testit(dirName, command)
             self.threadList.append(current)
+
+            if dontRun:
+                continue
             current.start()
             time.sleep(random.randint(1,5)) # try to avoid race cond by sleeping random amount of time [1,5] sec 
+
+        if dontRun:
+            return
 
         # wait until all threads are finished
         while self.activeThreads() > 0:
@@ -239,8 +245,7 @@ def main(argv=None):
     if args.dump:
         tester.dumpTest()
     else:
-        if not args.noRun:
-            tester.runTests(args.tests)
+        tester.runTests(args.tests,args.noRun)
         if args.uploadDir:
             tester.upload(args.uploadDir)
 


### PR DESCRIPTION

#### PR description:

Replaced manual `getopt` parsing with `argparse`
  * Provides built-in `--help` support and clearer usage messages
  * Simplifies handling of options and default values

Additionally changed the meaning of `--noRun` such that it actually dumps the configuration that it's going to be run to `stdout` instead of just actually doing nothing (what for ??)

#### PR validation:

* `addOnTests.py`
*  `addOnTests.py -t hlt_mc_GRun,hlt_data_GRun`
* `addOnTests.py -j 16`
* `addOnTests.py --help`
* `addOnTests.py --noRun`

all work OK for me.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Might backport to 15.0.X for convenience