### PR TITLE
[NGT] Jet Validation for Phase-2 HLT: Part 2

### DIFF
--- a/DQMServices/Components/plugins/DQMGenericClient.cc
+++ b/DQMServices/Components/plugins/DQMGenericClient.cc
@@ -389,69 +389,69 @@ DQMGenericClient::DQMGenericClient(const ParameterSet& pset)
   // Parse resolution commands
   std::array<std::string, 2> optionNames = {{"resolution", "resolutionProfile"}};
   for (auto& optName : optionNames) {
-	vstring resCmds;
-	if (optName.find("Profile") != std::string::npos)
-	  resCmds = pset.getUntrackedParameter<vstring>(optName, vstring());
-	else
-	  resCmds = pset.getParameter<vstring>(optName);
+    vstring resCmds;
+    if (optName.find("Profile") != std::string::npos)
+      resCmds = pset.getUntrackedParameter<vstring>(optName, vstring());
+    else
+      resCmds = pset.getParameter<vstring>(optName);
 
-	for (vstring::const_iterator resCmd = resCmds.begin(); resCmd != resCmds.end(); ++resCmd) {
-	  if (resCmd->empty())
-		continue;
-	  boost::tokenizer<elsc> tokens(*resCmd, commonEscapes);
+    for (vstring::const_iterator resCmd = resCmds.begin(); resCmd != resCmds.end(); ++resCmd) {
+      if (resCmd->empty())
+        continue;
+      boost::tokenizer<elsc> tokens(*resCmd, commonEscapes);
 
-	  vector<string> args;
-	  for (boost::tokenizer<elsc>::const_iterator iToken = tokens.begin(); iToken != tokens.end(); ++iToken) {
-		if (iToken->empty())
-		  continue;
-		args.push_back(*iToken);
-	  }
+      vector<string> args;
+      for (boost::tokenizer<elsc>::const_iterator iToken = tokens.begin(); iToken != tokens.end(); ++iToken) {
+        if (iToken->empty())
+          continue;
+        args.push_back(*iToken);
+      }
 
-	  if (args.size() < 3) {
-		LogInfo("DQMGenericClient") << "Wrong input to resCmds\n";
-		continue;
-	  }
+      if (args.size() < 3) {
+        LogInfo("DQMGenericClient") << "Wrong input to resCmds\n";
+        continue;
+      }
 
-	  ResolOption opt;
-	  opt.namePrefix = args[0];
-	  opt.titlePrefix = args[1];
-	  opt.srcName = args[2];
-	  opt.isProfile = (optName.find("Profile") != std::string::npos) ? true : false;
+      ResolOption opt;
+      opt.namePrefix = args[0];
+      opt.titlePrefix = args[1];
+      opt.srcName = args[2];
+      opt.isProfile = (optName.find("Profile") != std::string::npos) ? true : false;
 
-	  std::string typeDefault = (optName.find("Profile") != std::string::npos) ? "rms" : "fit";
-	  const string typeName = args.size() == 3 ? typeDefault : args[3];
-	  if (typeName == "fit")
-		opt.type = ResType::fit;
-	  else if (typeName == "rms")
-		opt.type = ResType::rms;
-	  else
-		opt.type = ResType::none;
+      std::string typeDefault = (optName.find("Profile") != std::string::npos) ? "rms" : "fit";
+      const string typeName = args.size() == 3 ? typeDefault : args[3];
+      if (typeName == "fit")
+        opt.type = ResType::fit;
+      else if (typeName == "rms")
+        opt.type = ResType::rms;
+      else
+        opt.type = ResType::none;
 
-	  resolOptions_.push_back(opt);	  
-	}
+      resolOptions_.push_back(opt);
+    }
   }
 
   std::array<std::string, 2> optionSetNames = {{"resolutionProfileSets", "resolutionSets"}};
   for (auto& optName : optionSetNames) {
-	VPSet resSets = pset.getUntrackedParameter<VPSet>(optName, VPSet());
-	for (VPSet::const_iterator resSet = resSets.begin(); resSet != resSets.end(); ++resSet) {
-	  ResolOption opt;
-	  opt.namePrefix  = resSet->getUntrackedParameter<string>("namePrefix");
-	  opt.titlePrefix = resSet->getUntrackedParameter<string>("titlePrefix");
-	  opt.srcName	  = resSet->getUntrackedParameter<string>("srcName");
+    VPSet resSets = pset.getUntrackedParameter<VPSet>(optName, VPSet());
+    for (VPSet::const_iterator resSet = resSets.begin(); resSet != resSets.end(); ++resSet) {
+      ResolOption opt;
+      opt.namePrefix = resSet->getUntrackedParameter<string>("namePrefix");
+      opt.titlePrefix = resSet->getUntrackedParameter<string>("titlePrefix");
+      opt.srcName = resSet->getUntrackedParameter<string>("srcName");
 
-	  std::string typeDefault = (optName.find("Profile") != std::string::npos) ? "rms" : "fit";
-	  const string typeName = resSet->getUntrackedParameter<string>("typeName", typeDefault);
-	  if (typeName == "fit")
-		opt.type = ResType::fit;
-	  else if (typeName == "rms")
-		opt.type = ResType::rms;
-	  else
-		opt.type = ResType::none;
-	  opt.isProfile = (optName.find("Profile") != std::string::npos) ? true : false;
+      std::string typeDefault = (optName.find("Profile") != std::string::npos) ? "rms" : "fit";
+      const string typeName = resSet->getUntrackedParameter<string>("typeName", typeDefault);
+      if (typeName == "fit")
+        opt.type = ResType::fit;
+      else if (typeName == "rms")
+        opt.type = ResType::rms;
+      else
+        opt.type = ResType::none;
+      opt.isProfile = (optName.find("Profile") != std::string::npos) ? true : false;
 
-	  resolOptions_.push_back(opt);
-	}
+      resolOptions_.push_back(opt);
+    }
   }
 
   // Parse profiles

--- a/Validation/RecoJets/plugins/JetTester.cc
+++ b/Validation/RecoJets/plugins/JetTester.cc
@@ -528,43 +528,45 @@ void JetTester::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun,
         RespRange[0],
         RespRange[1]);
 
+	h2d_chHadMult_vs_pt[j] = ibooker.book2D(
+        fmt::format("h2d_chHadMult_pt_{}", etaRegion),
+        fmt::format("Profiled charged HAD multiplicity - {};p_{{T}}^{{reco}};charged HAD multiplicity", etaLabel),
+        n_PtBins, PtRange[0], PtRange[1], 50, 0, 50);
+	h2d_neHadMult_vs_pt[j] = ibooker.book2D(
+        fmt::format("h2d_neHadMult_pt_{}", etaRegion),
+        fmt::format("Profiled neutral HAD multiplicity - {};p_{{T}}^{{reco}};neutral HAD multiplicity", etaLabel),
+        n_PtBins, PtRange[0], PtRange[1], 50, 0, 50);
+	h2d_chMult_vs_pt[j] = ibooker.book2D(
+        fmt::format("h2d_chMult_pt_{}", etaRegion),
+        fmt::format("Profiled charged multiplicity - {};p_{{T}}^{{reco}};charged multiplicity", etaLabel),
+        n_PtBins, PtRange[0], PtRange[1], 50, 0, 50);
+	h2d_neMult_vs_pt[j] = ibooker.book2D(
+        fmt::format("h2d_neMult_pt_{}", etaRegion),
+        fmt::format("Profiled neutral multiplicity - {};p_{{T}}^{{reco}};neutral EM multiplicity", etaLabel),
+        n_PtBins, PtRange[0], PtRange[1], 50, 0, 50);
+	h2d_phoMult_vs_pt[j] = ibooker.book2D(
+        fmt::format("h2d_phoMult_pt_{}", etaRegion),
+        fmt::format("Profiled photon multiplicity - {};p_{{T}}^{{reco}};photon multiplicity", etaLabel),
+        n_PtBins, PtRange[0], PtRange[1], 15, 0, 15);
+	
     h2d_chHad_vs_pt[j] = ibooker.book2D(
         fmt::format("h2d_chHad_pt_{}", etaRegion),
         fmt::format("Profiled charged HAD energy fraction - {};p_{{T}}^{{reco}};charged HAD energy fraction", etaLabel),
-        n_PtBins,
-        PtRange[0],
-        PtRange[1],
-        40,
-        0,
-        1);
+        n_PtBins, PtRange[0], PtRange[1], 40, 0, 1);
     h2d_neHad_vs_pt[j] = ibooker.book2D(
         fmt::format("h2d_neHad_pt_{}", etaRegion),
         fmt::format("Profiled neutral HAD energy fraction - {};p_{{T}}^{{reco}};neutral HAD energy fraction", etaLabel),
-        n_PtBins,
-        PtRange[0],
-        PtRange[1],
-        40,
-        0,
-        1);
+        n_PtBins, PtRange[0], PtRange[1], 40, 0, 1);
     h2d_chEm_vs_pt[j] = ibooker.book2D(
         fmt::format("h2d_chEm_pt_{}", etaRegion),
         fmt::format("Profiled charged EM energy fraction - {};p_{{T}}^{{reco}};charged EM energy fraction", etaLabel),
-        n_PtBins,
-        PtRange[0],
-        PtRange[1],
-        40,
-        0,
-        1);
+        n_PtBins, PtRange[0], PtRange[1], 40, 0, 1);
     h2d_neEm_vs_pt[j] = ibooker.book2D(
         fmt::format("h2d_neEm_pt_{}", etaRegion),
         fmt::format("Profiled neutral EM energy fraction - {};p_{{T}}^{{reco}};neutral EM energy fraction", etaLabel),
-        n_PtBins,
-        PtRange[0],
-        PtRange[1],
-        40,
-        0,
-        1);
-    h2d_JetPtRecoOverGen_vs_chHad[j] = ibooker.book2D(
+        n_PtBins, PtRange[0], PtRange[1], 40, 0, 1);
+
+	h2d_JetPtRecoOverGen_vs_chHad[j] = ibooker.book2D(
         fmt::format("h2d_PtRecoOverGen_chHad_{}", etaRegion),
         fmt::format("Response Reco Jets - {};charged HAD energy Fraction;p_{{T}}^{{reco}}/p_{{T}}^{{gen}}", etaLabel),
         30,
@@ -1188,6 +1190,12 @@ void JetTester::analyze(const edm::Event& mEvent, const edm::EventSetup& mSetup)
           neutralMultiplicity_EtaBins[j]->Fill((*pfJets)[ijet].neutralMultiplicity());
           chargedHadronMultiplicity_EtaBins[j]->Fill((*pfJets)[ijet].chargedHadronMultiplicity());
           chargedMultiplicity_EtaBins[j]->Fill((*pfJets)[ijet].chargedMultiplicity());
+
+		  h2d_chHadMult_vs_pt[j]->Fill(recoJets[ijet].pt(), (*pfJets)[ijet].chargedHadronMultiplicity());
+          h2d_neHadMult_vs_pt[j]->Fill(recoJets[ijet].pt(), (*pfJets)[ijet].neutralHadronMultiplicity());
+          h2d_chMult_vs_pt[j]->Fill(recoJets[ijet].pt(), (*pfJets)[ijet].chargedMultiplicity());
+          h2d_neMult_vs_pt[j]->Fill(recoJets[ijet].pt(), (*pfJets)[ijet].neutralMultiplicity());
+		  h2d_phoMult_vs_pt[j]->Fill(recoJets[ijet].pt(), (*pfJets)[ijet].photonMultiplicity());
 
           h2d_chHad_vs_pt[j]->Fill(recoJets[ijet].pt(), (*pfJets)[ijet].chargedHadronEnergyFraction());
           h2d_neHad_vs_pt[j]->Fill(recoJets[ijet].pt(), (*pfJets)[ijet].neutralHadronEnergyFraction());

--- a/Validation/RecoJets/plugins/JetTester.cc
+++ b/Validation/RecoJets/plugins/JetTester.cc
@@ -343,11 +343,11 @@ void JetTester::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun,
 
   // DeltaR distance jet
   h2d_DeltaR_vs_Eta = ibooker.book2D(
-      "h2d_DeltaR_Eta", "#Delta R Jets;#eta^{{reco}};#Delta R", n_EtaBins, EtaRange[0], EtaRange[1], 50, 0.0, 0.5);
+      "h2d_DeltaR_Eta", "#Delta R Jets;#eta^{reco};#Delta R", n_EtaBins, EtaRange[0], EtaRange[1], 50, 0.0, 0.5);
   h2d_DeltaR_vs_Phi = ibooker.book2D(
-      "h2d_DeltaR_Phi", "#Delta R Jets;#phi^{{reco}};#Delta R", n_PhiBins, PhiRange[0], PhiRange[1], 50, 0.0, 0.5);
+      "h2d_DeltaR_Phi", "#Delta R Jets;#phi^{reco};#Delta R", n_PhiBins, PhiRange[0], PhiRange[1], 50, 0.0, 0.5);
   h2d_DeltaR_vs_Pt = ibooker.book2D(
-      "h2d_DeltaR_Pt", "#Delta R Jets;p_{T}^{{reco}};#Delta R", n_PtBins, PtRange[0], PtRange[1], 50, 0.0, 0.5);
+      "h2d_DeltaR_Pt", "#Delta R Jets;p_{T}^{reco};#Delta R", n_PtBins, PtRange[0], PtRange[1], 50, 0.0, 0.5);
 
   // Duplicated jet
   mDuplicatesJetEta = ibooker.book1D(
@@ -399,11 +399,11 @@ void JetTester::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun,
 
   // DeltaR distance gen jet
   h2d_DeltaR_vs_GenEta = ibooker.book2D(
-      "h2d_DeltaR_GenEta", "#Delta R Gen Jets;#eta^{{gen}};#Delta R", n_EtaBins, EtaRange[0], EtaRange[1], 50, 0.0, 0.5);
+      "h2d_DeltaR_GenEta", "#Delta R Gen Jets;#eta^{gen};#Delta R", n_EtaBins, EtaRange[0], EtaRange[1], 50, 0.0, 0.5);
   h2d_DeltaR_vs_GenPhi = ibooker.book2D(
-      "h2d_DeltaR_GenPhi", "#Delta R Gen Jets;#phi^{{gen}};#Delta R", n_PhiBins, PhiRange[0], PhiRange[1], 50, 0.0, 0.5);
+      "h2d_DeltaR_GenPhi", "#Delta R Gen Jets;#phi^{gen};#Delta R", n_PhiBins, PhiRange[0], PhiRange[1], 50, 0.0, 0.5);
   h2d_DeltaR_vs_GenPt = ibooker.book2D(
-      "h2d_DeltaR_GenPt", "#Delta R Gen Jets;p_{T}^{{gen}};#Delta R", n_PtBins, PtRange[0], PtRange[1], 50, 0.0, 0.5);
+      "h2d_DeltaR_GenPt", "#Delta R Gen Jets;p_{T}^{gen};#Delta R", n_PtBins, PtRange[0], PtRange[1], 50, 0.0, 0.5);
 
   // Duplicated gen jet
   mDuplicatesGenEta = ibooker.book1D(
@@ -431,7 +431,7 @@ void JetTester::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun,
 
   // Response
   h2d_JetPtRecoOverGen_vs_GenEta = ibooker.book2D("h2d_PtRecoOverGen_GenEta",
-                                                  "Response Reco Jets;#eta^{{gen}};p_{{T}}^{{reco}}/p_{{T}}^{{gen}}",
+                                                  "Response Reco Jets;#eta^{gen};p_{T}^{reco}/p_{T}^{gen}",
                                                   n_EtaBins,
                                                   EtaRange[0],
                                                   EtaRange[1],
@@ -439,7 +439,7 @@ void JetTester::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun,
                                                   RespRange[0],
                                                   RespRange[1]);
   h2d_JetPtRecoOverGen_vs_GenPhi = ibooker.book2D("h2d_PtRecoOverGen_GenPhi",
-                                                  "Response Reco Jets;#phi^{{gen}};p_{{T}}^{{reco}}/p_{{T}}^{{gen}}",
+                                                  "Response Reco Jets;#phi^{gen};p_{T}^{reco}/p_{T}^{gen}",
                                                   n_PhiBins,
                                                   PhiRange[0],
                                                   PhiRange[1],
@@ -447,7 +447,7 @@ void JetTester::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun,
                                                   RespRange[0],
                                                   RespRange[1]);
   h2d_JetPtRecoOverGen_vs_GenPt = ibooker.book2D("h2d_PtRecoOverGen_GenPt",
-                                                 "Response Reco Jets;p_{T}^{{gen}};p_{{T}}^{{reco}}/p_{{T}}^{{gen}}",
+                                                 "Response Reco Jets;p_{T}^{gen};p_{T}^{reco}/p_{T}^{gen}",
                                                  n_PtBins,
                                                  PtRange[0],
                                                  PtRange[1],

--- a/Validation/RecoJets/plugins/JetTester.cc
+++ b/Validation/RecoJets/plugins/JetTester.cc
@@ -239,8 +239,8 @@ void JetTester::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun,
   std::vector<double> PhiRange = {-3.5, 3.5};
   int n_PtBins = 50;
   std::vector<double> PtRange = {0, 1000};
-  int n_RespBins = 60;
-  std::vector<double> RespRange = {0, 3};
+  int n_RespBins = 70;
+  std::vector<double> RespRange = {0, 3.5};
 
   // Event variables
   mNvtx = ibooker.book1D("Nvtx", "number of vertices", 60, 0, 60);

--- a/Validation/RecoJets/plugins/JetTester.cc
+++ b/Validation/RecoJets/plugins/JetTester.cc
@@ -528,45 +528,90 @@ void JetTester::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun,
         RespRange[0],
         RespRange[1]);
 
-	h2d_chHadMult_vs_pt[j] = ibooker.book2D(
+    h2d_chHadMult_vs_pt[j] = ibooker.book2D(
         fmt::format("h2d_chHadMult_pt_{}", etaRegion),
         fmt::format("Profiled charged HAD multiplicity - {};p_{{T}}^{{reco}};charged HAD multiplicity", etaLabel),
-        n_PtBins, PtRange[0], PtRange[1], 50, 0, 50);
-	h2d_neHadMult_vs_pt[j] = ibooker.book2D(
+        n_PtBins,
+        PtRange[0],
+        PtRange[1],
+        50,
+        0,
+        50);
+    h2d_neHadMult_vs_pt[j] = ibooker.book2D(
         fmt::format("h2d_neHadMult_pt_{}", etaRegion),
         fmt::format("Profiled neutral HAD multiplicity - {};p_{{T}}^{{reco}};neutral HAD multiplicity", etaLabel),
-        n_PtBins, PtRange[0], PtRange[1], 50, 0, 50);
-	h2d_chMult_vs_pt[j] = ibooker.book2D(
+        n_PtBins,
+        PtRange[0],
+        PtRange[1],
+        50,
+        0,
+        50);
+    h2d_chMult_vs_pt[j] = ibooker.book2D(
         fmt::format("h2d_chMult_pt_{}", etaRegion),
         fmt::format("Profiled charged multiplicity - {};p_{{T}}^{{reco}};charged multiplicity", etaLabel),
-        n_PtBins, PtRange[0], PtRange[1], 50, 0, 50);
-	h2d_neMult_vs_pt[j] = ibooker.book2D(
+        n_PtBins,
+        PtRange[0],
+        PtRange[1],
+        50,
+        0,
+        50);
+    h2d_neMult_vs_pt[j] = ibooker.book2D(
         fmt::format("h2d_neMult_pt_{}", etaRegion),
         fmt::format("Profiled neutral multiplicity - {};p_{{T}}^{{reco}};neutral EM multiplicity", etaLabel),
-        n_PtBins, PtRange[0], PtRange[1], 50, 0, 50);
-	h2d_phoMult_vs_pt[j] = ibooker.book2D(
-        fmt::format("h2d_phoMult_pt_{}", etaRegion),
-        fmt::format("Profiled photon multiplicity - {};p_{{T}}^{{reco}};photon multiplicity", etaLabel),
-        n_PtBins, PtRange[0], PtRange[1], 15, 0, 15);
-	
+        n_PtBins,
+        PtRange[0],
+        PtRange[1],
+        50,
+        0,
+        50);
+    h2d_phoMult_vs_pt[j] =
+        ibooker.book2D(fmt::format("h2d_phoMult_pt_{}", etaRegion),
+                       fmt::format("Profiled photon multiplicity - {};p_{{T}}^{{reco}};photon multiplicity", etaLabel),
+                       n_PtBins,
+                       PtRange[0],
+                       PtRange[1],
+                       15,
+                       0,
+                       15);
+
     h2d_chHad_vs_pt[j] = ibooker.book2D(
         fmt::format("h2d_chHad_pt_{}", etaRegion),
         fmt::format("Profiled charged HAD energy fraction - {};p_{{T}}^{{reco}};charged HAD energy fraction", etaLabel),
-        n_PtBins, PtRange[0], PtRange[1], 40, 0, 1);
+        n_PtBins,
+        PtRange[0],
+        PtRange[1],
+        40,
+        0,
+        1);
     h2d_neHad_vs_pt[j] = ibooker.book2D(
         fmt::format("h2d_neHad_pt_{}", etaRegion),
         fmt::format("Profiled neutral HAD energy fraction - {};p_{{T}}^{{reco}};neutral HAD energy fraction", etaLabel),
-        n_PtBins, PtRange[0], PtRange[1], 40, 0, 1);
+        n_PtBins,
+        PtRange[0],
+        PtRange[1],
+        40,
+        0,
+        1);
     h2d_chEm_vs_pt[j] = ibooker.book2D(
         fmt::format("h2d_chEm_pt_{}", etaRegion),
         fmt::format("Profiled charged EM energy fraction - {};p_{{T}}^{{reco}};charged EM energy fraction", etaLabel),
-        n_PtBins, PtRange[0], PtRange[1], 40, 0, 1);
+        n_PtBins,
+        PtRange[0],
+        PtRange[1],
+        40,
+        0,
+        1);
     h2d_neEm_vs_pt[j] = ibooker.book2D(
         fmt::format("h2d_neEm_pt_{}", etaRegion),
         fmt::format("Profiled neutral EM energy fraction - {};p_{{T}}^{{reco}};neutral EM energy fraction", etaLabel),
-        n_PtBins, PtRange[0], PtRange[1], 40, 0, 1);
+        n_PtBins,
+        PtRange[0],
+        PtRange[1],
+        40,
+        0,
+        1);
 
-	h2d_JetPtRecoOverGen_vs_chHad[j] = ibooker.book2D(
+    h2d_JetPtRecoOverGen_vs_chHad[j] = ibooker.book2D(
         fmt::format("h2d_PtRecoOverGen_chHad_{}", etaRegion),
         fmt::format("Response Reco Jets - {};charged HAD energy Fraction;p_{{T}}^{{reco}}/p_{{T}}^{{gen}}", etaLabel),
         30,
@@ -1191,11 +1236,11 @@ void JetTester::analyze(const edm::Event& mEvent, const edm::EventSetup& mSetup)
           chargedHadronMultiplicity_EtaBins[j]->Fill((*pfJets)[ijet].chargedHadronMultiplicity());
           chargedMultiplicity_EtaBins[j]->Fill((*pfJets)[ijet].chargedMultiplicity());
 
-		  h2d_chHadMult_vs_pt[j]->Fill(recoJets[ijet].pt(), (*pfJets)[ijet].chargedHadronMultiplicity());
+          h2d_chHadMult_vs_pt[j]->Fill(recoJets[ijet].pt(), (*pfJets)[ijet].chargedHadronMultiplicity());
           h2d_neHadMult_vs_pt[j]->Fill(recoJets[ijet].pt(), (*pfJets)[ijet].neutralHadronMultiplicity());
           h2d_chMult_vs_pt[j]->Fill(recoJets[ijet].pt(), (*pfJets)[ijet].chargedMultiplicity());
           h2d_neMult_vs_pt[j]->Fill(recoJets[ijet].pt(), (*pfJets)[ijet].neutralMultiplicity());
-		  h2d_phoMult_vs_pt[j]->Fill(recoJets[ijet].pt(), (*pfJets)[ijet].photonMultiplicity());
+          h2d_phoMult_vs_pt[j]->Fill(recoJets[ijet].pt(), (*pfJets)[ijet].photonMultiplicity());
 
           h2d_chHad_vs_pt[j]->Fill(recoJets[ijet].pt(), (*pfJets)[ijet].chargedHadronEnergyFraction());
           h2d_neHad_vs_pt[j]->Fill(recoJets[ijet].pt(), (*pfJets)[ijet].neutralHadronEnergyFraction());

--- a/Validation/RecoJets/plugins/JetTester.h
+++ b/Validation/RecoJets/plugins/JetTester.h
@@ -198,6 +198,13 @@ private:
   std::array<MonitorElement *, etaSize> h2d_JetPtCorrOverReco_vs_Phi_EtaBins;
   std::array<MonitorElement *, etaSize> h2d_JetPtCorrOverReco_vs_Pt_EtaBins;
 
+  // Jet charged/neutral multiplicities profiled in pt
+  std::array<MonitorElement *, etaSize> h2d_chHadMult_vs_pt;
+  std::array<MonitorElement *, etaSize> h2d_neHadMult_vs_pt;
+  std::array<MonitorElement *, etaSize> h2d_chMult_vs_pt;
+  std::array<MonitorElement *, etaSize> h2d_neMult_vs_pt;
+  std::array<MonitorElement *, etaSize> h2d_phoMult_vs_pt;
+
   // Jet em/had fractions profiled in pt
   std::array<MonitorElement *, etaSize> h2d_chHad_vs_pt;
   std::array<MonitorElement *, etaSize> h2d_neHad_vs_pt;

--- a/Validation/RecoJets/scripts/makeHLTJetValidationPlots.py
+++ b/Validation/RecoJets/scripts/makeHLTJetValidationPlots.py
@@ -29,7 +29,7 @@ def CheckRootFile(hname, rebin=None):
     hist.SetDirectory(0) # detach from file
 
     if rebin is not None:
-        if isinstance(rebin, int) or isinstance(rebin, float):
+        if isinstance(rebin, (int, float)):
             hist = hist.Rebin(int(rebin), hname + "_rebin")
         elif hasattr(rebin, '__iter__'):
             bin_edges_c = array.array('d', rebin)


### PR DESCRIPTION
#### PR description:

Follow-up of #48722, including missing validation plots as presented [here](https://indico.cern.ch/event/990646/contributions/4205799/attachments/2179273/3680752/Validate_11_2_0.pdf), among which:
+ 1D and 2D multiplicity plots, with and without pT bins
+ Resolution tails (gaussian core fit taken from [here](https://gitlab.cern.ch/dkarasav/pfpatatrackvalidation/-/blob/master/ProducerTest/C_scripts/include/include_functions.h#L411))

The PR also includes:
+ Errors cutoff whenever the errobars go above 1 or below 0 in efficiency and rate plots (connected to #48780)
+ Extend the response range in the histograms 
+ Minor optimizations and fixes
+ Fix some axis labels directly in the DQM ROOT files (which are then picked up by the plotter)


Some validation examples:

<img width="400" height="400" alt="h2d_neMult_pt_E_PtBinAll" src="https://github.com/user-attachments/assets/630488a9-6cd7-4da5-8586-e6b1c43811d9" />
<img width="400" height="400" alt="h2d_PtRecoOverGen_GenPt_tails_fit3" src="https://github.com/user-attachments/assets/089251a3-e081-4fd0-bcb0-09b70da60736" />
<img width="400" height="400" alt="h2d_PtRecoOverGen_GenPt_tails" src="https://github.com/user-attachments/assets/d596e0cd-8935-479f-9819-ffecbc8adcb2" />

#### PR validation:

Validated using the same configuration as in #48722.
