### PR TITLE
Fixing minor error in Scouting DQM module

### DIFF
--- a/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
+++ b/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
@@ -750,6 +750,7 @@ void ScoutingCollectionMonitor::analyze(const edm::Event& iEvent, const edm::Eve
     mvaDiscriminator_pfj_hist->Fill(jet.mvaDiscriminator());
   }
 
+  primaryVertex_counter = 0;
   // fill all the primary vertices histograms
   for (const auto& vtx : *primaryVerticesH) {
     primaryVertex_counter++;

--- a/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
+++ b/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
@@ -949,8 +949,8 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
 
   if (!onlyScouting_) {
     PVvsPU_hist =
-        ibook.bookProfile("PVvsPU", "Number of primary vertices vs pile up; pile up; <N_{PV}>", 20, 20, 60, 0, 65);
-    rhovsPU_hist = ibook.bookProfile("rhovsPU", "#rho vs pile up; pile up; <#rho>", 20, 20, 60, 0, 45);
+        ibook.bookProfile("PVvsPU", "Number of primary vertices vs pile up; pile up; <N_{PV}>", 20, 20, 70, 0, 65);
+    rhovsPU_hist = ibook.bookProfile("rhovsPU", "#rho vs pile up; pile up; <#rho>", 20, 20, 70, 0, 45);
   }
 
   ibook.setCurrentFolder(topfoldername_ + "/PFcand");


### PR DESCRIPTION
#### PR description:

@mmusich noticed an error in the way the `primaryVertex_counter` is initialised within the code. The way it was until now, the counter does to not get updated for each event separately. The fix starts and sets the counter to 0 each over each event.

#### PR validation:

Using input files set at https://github.com/cms-data/DQM-Integration/pull/12 by coping inside the `DQM/Integration/data/run392642` folder and running:

```
cmsRun DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py runInputDir=DQM/Integration/data/ runNumber=392642 scanOnce=True
```
followed by subsequent inspection of the output histograms. 


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but it will be backported to CMSSW_15_0_X for data-taking operations.