### PR TITLE
Increase electron PF maxHcalE in PbPb eras

### DIFF
--- a/RecoParticleFlow/PFProducer/python/particleFlow_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlow_cff.py
@@ -50,3 +50,4 @@ run3_common.toModify(particleFlowTmp.PFEGammaFiltersParameters,
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 pp_on_AA.toModify(particleFlowTmp.PFEGammaFiltersParameters, electron_ecalDrivenHademPreselCut = 0.5)
+pp_on_AA.toModify(particleFlowTmp.PFEGammaFiltersParameters.electron_protectionsForJetMET, maxHcalE = 2000)


### PR DESCRIPTION
#### PR description:

This PR increases the maximum HCAL energy used for PF electrons to 2000 in the PbPb eras via the pp_on_AA era modifier.

After the recovery of the tracker-driven [[1]](https://github.com/cms-sw/cmssw/pull/48728) and ECAL-driven [[2]](https://github.com/cms-sw/cmssw/pull/48769) electrons in central PbPb collisions, there was still an inefficiency remaining in PF electrons due to the HCAL energy selections used in the protectionsForJetMET filter, which was restrictive for central PbPb collisions.

Increasing the PF HCAL energy threshold managed to increase the efficiency by 5% in the barrel and by 25% in the endcap on top of the previous two PRs, while keeping the jet energy resolution under control in central PbPb.

These changes were checked offline with a HYDJET embedded dijet and DY->ee 2023 PbPb MC simulations showing the jet performance and improvement in electron efficiency.

@mandrenguyen @pfs @RSalvatico

#### PR validation:

Tested with workflows 161,161.02,161.03,161.1,161.2,161.3,161.4

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
