### PR TITLE
[NGT] Bug fix for fakerate_vertcount_fwdneg

### DIFF
--- a/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
@@ -127,7 +127,7 @@ postProcessorTrack = DQMEDHarvester("DQMGenericClient",
     "fakerate_vs_seedingLayerSet 'Fake rate vs. seedingLayerSet' num_assoc(recoToSim)_seedingLayerSet num_reco_seedingLayerSet fake",
     "fakerate_vertcount_barrel 'fake rate in barrel vs N of pileup vertices' num_assoc(recoToSim)_vertcount_barrel num_reco_vertcount_barrel fake",
     "fakerate_vertcount_fwdpos 'fake rate in endcap(+) vs N of pileup vertices' num_assoc(recoToSim)_vertcount_fwdpos num_reco_vertcount_fwdpos fake",
-    "fakerate_vertcount_fwdneg 'fake rate in endcap(-) vs N of pileup vertices' num_assoc(recoToSim)_vertcount_fwdneg num_reco_vertcount_fwdneg fake"
+    "fakerate_vertcount_fwdneg 'fake rate in endcap(-) vs N of pileup vertices' num_assoc(recoToSim)_vertcount_fwdneg num_reco_vertcount_fwdneg fake",
     "fakerate_ootpu_entire 'fake rate from out of time pileup vs N of pileup vertices' num_assoc(recoToSim)_ootpu_entire num_reco_ootpu_entire",
     "fakerate_ootpu_barrel 'fake rate from out of time pileup in barrel vs N of pileup vertices' num_assoc(recoToSim)_ootpu_barrel num_reco_ootpu_barrel",
     "fakerate_ootpu_fwdpos 'fake rate from out of time pileup in endcap(+) vs N of pileup vertices' num_assoc(recoToSim)_ootpu_fwdpos num_reco_ootpu_fwdpos",


### PR DESCRIPTION
#### PR description:

This PR fixes a bug in the `Validation/RecoTrack/python/PostProcessorTracker_cfi.py` configuration.

However, this change doesn't modify the DQM output file, since the histograms `num_assoc(recoToSim)_vertcount_fwdneg` and `num_reco_vertcount_fwdneg` are not produced in the tracking validation sequence and the fake rate cannot be computed. In fact, many of the histograms expected by this module are no longer present in the DQM. 
The module should be updated in a future cleanup to reflect the actual DQM content.

#### PR validation:

This PR has been tested by running the HLT validation and harvesting steps with and without the bug fix, with the following commands:

```
cmsDriver.py step2 --step L1P2GT,HLT:@relvalRun4,VALIDATION:@hltValidation \
    --conditions auto:phase2_realistic_T33 --geometry ExtendedRun4D110 --era Phase2C17I13M9 \
    --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
    --datatier GEN-SIM-DIGI-RAW,DQMIO --eventcontent FEVTDEBUGHLT,DQMIO \
    --process HLTX --inputCommands='keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT' \
    --filein file:/eos/cms/store/relval/CMSSW_15_1_0_pre4/RelValQCD_FlatPt_15_3000HS_14/GEN-SIM-DIGI-RAW/PU_150X_mcRun4_realistic_v1_STD_Run4D110_PU-v1/2580000/00e75d40-dde4-430b-8778-5e9ab7c48f97.root \
    --fileout file:step2.root \
    -n 10 --nThreads 0

cmsDriver.py step3 -s HARVESTING:@hltValidation \
    --conditions auto:phase2_realistic_T33 --geometry ExtendedRun4D110 --era Phase2C17I13M9 --mc \
    --scenario pp --filetype DQM --process HLTX -n -1  \
    --filein file:step2_inDQM.root \
    --fileout file:step3.root
```

The output DQM file is correctly produced and does not differ from the default one, as motivated above in the PR description.