### PR TITLE
Enabling SiPixel good edge algorithm from 2025 onward

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_cff.py
@@ -7,5 +7,6 @@ from Configuration.Eras.Modifier_stage2L1Trigger_2025_cff import stage2L1Trigger
 from Configuration.Eras.Modifier_run3_SiPixel_2025_cff import run3_SiPixel_2025
 from Configuration.Eras.Modifier_run3_nanoAOD_2025_cff import run3_nanoAOD_2025
 from Configuration.ProcessModifiers.ecal_cctiming_cff import ecal_cctiming
+from Configuration.ProcessModifiers.siPixelGoodEdgeAlgo_cff import siPixelGoodEdgeAlgo
 
-Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, stage2L1Trigger_2025, run3_SiPixel_2025, run3_CSC_2025, run3_nanoAOD_2025, ecal_cctiming)
+Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, stage2L1Trigger_2025, run3_SiPixel_2025, run3_CSC_2025, run3_nanoAOD_2025, ecal_cctiming, siPixelGoodEdgeAlgo)


### PR DESCRIPTION
#### PR description:

This PR enables from 2025 onward the SiPixel good edge algorithm introduced in https://github.com/cms-sw/cmssw/pull/48356.

#### PR validation:

None

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to CMSSW_15_0_X
