### PR TITLE
Add ZEE_14 workflows to TICLv5 procModifier

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -856,7 +856,8 @@ class UpgradeWorkflow_ticl_v5(UpgradeWorkflow):
         if 'HARVESTGlobal' in step:
             stepDict[stepName][k] = merge([self.step4, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
-        return (fragment=="TTbar_14TeV" or 'CloseByP' in fragment or 'Eta1p7_2p7' in fragment) and 'Run4' in key
+        selected_fragments = ["TTbar_14TeV", "CloseByP", "Eta1p7_2p7", "ZEE_14"]
+        return (fragment in selected_fragments) and 'Run4' in key
 
 upgradeWFs['ticl_v5'] = UpgradeWorkflow_ticl_v5(
     steps = [


### PR DESCRIPTION
Adding ZEE_14 workflow to TICLv5 procModifier targeting testing for TICL-DNNSuperClustering

In the case tests are needed on these particular workflows, here are the wf numbers:

- 29646.203
- 29846.203