### PR TITLE
LHCInfoAnalyzer Tests

### DIFF
--- a/CondTools/RunInfo/test/BuildFile.xml
+++ b/CondTools/RunInfo/test/BuildFile.xml
@@ -5,6 +5,8 @@
 </ifarch>
 <test name="CondToolsRunInfoTest" command="test_runinfo.sh"/>
 <test name="CondToolsLHCInfoTest" command="test_lhcInfo.sh"/>
+<test name="CondToolsLHCInfoAnalyzerTest" command="test_lhcInfo_analyzer.sh"/>
+<test name="CondToolsPrintLHCInfoPerPayloads" command="test_printLHCInfoPerPayloads.sh"/>
 <ifarch value="x86_64">
 <test name="CondToolsLHCInfoNewPopConTest" command="test_lhcInfoNewPopCon.sh"/>
 </ifarch>

--- a/CondTools/RunInfo/test/test_lhcInfo.sh
+++ b/CondTools/RunInfo/test/test_lhcInfo.sh
@@ -2,7 +2,8 @@
 
 LOCAL_TEST_DIR=$CMSSW_BASE/src/CondTools/RunInfo/test
 
-function die { echo Failure $1: status $2 ; exit $2 ; }
+# Source shared utility functions
+source "${LOCAL_TEST_DIR}/testing_utils.sh"
 
 cmsRun ${LOCAL_TEST_DIR}/LHCInfoPerFillWriter_cfg.py || die "cmsRun LHCInfoPerFillWriter_cfg.py" $?
 cmsRun ${LOCAL_TEST_DIR}/LHCInfoPerFillTester_cfg.py || die "cmsRun LHCInfoPerFillTester_cfg.py" $?

--- a/CondTools/RunInfo/test/test_lhcInfoNewPopCon.sh
+++ b/CondTools/RunInfo/test/test_lhcInfoNewPopCon.sh
@@ -1,27 +1,10 @@
 #!/bin/sh
 
 SCRIPTS_DIR=${CMSSW_BASE}/src/CondTools/RunInfo/python
+LOCAL_TEST_DIR=$CMSSW_BASE/src/CondTools/RunInfo/test
 
-function die {
-  log_file="$3"
-  if [ -f "$log_file" ]; then
-    echo "Log output:"
-    cat "$log_file"
-  fi
-  echo "Failure $1: status $2"
-  exit $2
-}
-
-assert_equal() {
-  expected="$1"
-  actual="$2"
-  message="$3"
-  log_file="$4"
-  
-  if [ "$expected" != "$actual" ]; then
-    die "$message: Expected $expected, but got $actual" 1 "$log_file"
-  fi
-}
+# Source shared utility functions
+source "${LOCAL_TEST_DIR}/testing_utils.sh"
 
 function assert_found_fills {
   log_file="$1"

--- a/CondTools/RunInfo/test/test_lhcInfo_analyzer.sh
+++ b/CondTools/RunInfo/test/test_lhcInfo_analyzer.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+LOCAL_TEST_DIR=$CMSSW_BASE/src/CondTools/RunInfo/test
+LOG_DIR="test_lhcInfo_analyzer_logs"
+
+# Create log directory and clean existing logs
+mkdir -p "${LOG_DIR}"
+rm -f "${LOG_DIR}"/*.log
+rm -f LHCInfoPerFill.sqlite LHCInfoPerLS.sqlite
+
+# Source shared utility functions
+source "${LOCAL_TEST_DIR}/testing_utils.sh"
+
+# Run LHCInfoPerFill writer
+echo "Running LHCInfoPerFill writer..."
+cmsRun "${LOCAL_TEST_DIR}/LHCInfoPerFillWriter_cfg.py" || die "cmsRun LHCInfoPerFillWriter_cfg.py" $?
+
+# LHCInfoPerFill format test case
+echo "Running LHCInfoPerFill analyzer..."
+cmsRun "${LOCAL_TEST_DIR}/LHCInfoPerFillAnalyzer_cfg.py" \
+    tag=LHCInfoPerFillFake \
+    db=sqlite_file:LHCInfoPerFill.sqlite > "${LOG_DIR}/fill_analyzer.log" 2>&1 \
+    || die "cmsRun LHCInfoPerFillAnalyzer_cfg.py" $?
+
+lines=$(grep -cve '^\s*$' "${LOG_DIR}/fill_analyzer.log")
+# Expected: 31 lines (IOV print, 'LHCInfoPerFill retrieved' + 29 payload field lines)
+assert_equal 31 "$lines" "LHCInfoPerFillAnalyzer_cfg.py log has wrong number of lines" "${LOG_DIR}/fill_analyzer.log"
+
+# Run LHCInfoPerLS writer
+echo "Running LHCInfoPerLS writer..."
+cmsRun "${LOCAL_TEST_DIR}/LHCInfoPerLSWriter_cfg.py" || die "cmsRun LHCInfoPerLSWriter_cfg.py" $?
+
+# LHCInfoPerLS format csv=True test case
+echo "Running LHCInfoPerLS analyzer (CSV format)..."
+cmsRun "${LOCAL_TEST_DIR}/LHCInfoPerLSAnalyzer_cfg.py" \
+    tag=LHCInfoPerLSFake \
+    db=sqlite_file:LHCInfoPerLS.sqlite \
+    csv=True \
+    header=True > "${LOG_DIR}/ls_analyzer_csv.log" 2>&1 \
+    || die "cmsRun LHCInfoPerLSAnalyzer_cfg.py" $?
+
+lines=$(grep -cve '^\s*$' "${LOG_DIR}/ls_analyzer_csv.log")
+# Expected: 2 lines due to CSV format
+assert_equal 2 "$lines" "LHCInfoPerLSAnalyzer_cfg.py log has wrong number of lines" "${LOG_DIR}/ls_analyzer_csv.log"
+
+# LHCInfoPerLS format csv=False test case
+echo "Running LHCInfoPerLS analyzer (non-CSV format)..."
+cmsRun "${LOCAL_TEST_DIR}/LHCInfoPerLSAnalyzer_cfg.py" \
+    tag=LHCInfoPerLSFake \
+    db=sqlite_file:LHCInfoPerLS.sqlite \
+    csv=False > "${LOG_DIR}/ls_analyzer_no_csv.log" 2>&1 \
+    || die "cmsRun LHCInfoPerLSAnalyzer_cfg.py" $?
+
+lines=$(grep -cve '^\s*$' "${LOG_DIR}/ls_analyzer_no_csv.log")
+# Expected: 7 lines (variables returned in LHCInfoPerLSAnalyzer)
+assert_equal 7 "$lines" "LHCInfoPerLSAnalyzer_cfg.py log has wrong number of lines" "${LOG_DIR}/ls_analyzer_no_csv.log"
+
+echo "All tests completed successfully!"
+echo "Logs including test output are stored in: ${LOG_DIR}/"

--- a/CondTools/RunInfo/test/test_printLHCInfoPerPayloads.sh
+++ b/CondTools/RunInfo/test/test_printLHCInfoPerPayloads.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+LOCAL_TEST_DIR="${CMSSW_BASE}/src/CondTools/RunInfo/test"
+LOG_DIR="test_printLHCInfoPerPayloads_logs"
+
+# Logs and temporary files cleanup
+mkdir -p "${LOG_DIR}"
+rm -f "${LOG_DIR}"/*.log
+trap "rm -f endFill_iovs.txt" EXIT
+
+# Source shared utility functions
+source "${LOCAL_TEST_DIR}/testing_utils.sh"
+
+# Create test IOVs file for endFill test
+cat > "endFill_iovs.txt" << EOF
+7113674196864991232
+7113765039718268928
+7113769433469812736
+7115287966401953792
+7115357364483522560
+7115389628277850112
+EOF
+
+# Test 1: Print PerLS duringFill (lumiid IOVs)
+echo "Test 1: Print PerLS duringFill (lumiid IOVs)..."
+echo "1686633657139272 1686676606812225 1686771096092709 1686852700471354" | \
+./printLHCInfoPerPayloads.py record=LHCInfoPerLS tag=LHCInfoPerLS_duringFill_hlt_v1 timetype=lumiid csv=True header=True > "${LOG_DIR}/perls_duringfill_lumiid.log" 2>&1
+
+lines=$(grep -cve '^\s*$' "${LOG_DIR}/perls_duringfill_lumiid.log")
+# Expected: CSV header + 4 data lines = 5 lines
+assert_equal 5 "$lines" "PerLS duringFill lumiid test has wrong number of lines" "${LOG_DIR}/perls_duringfill_lumiid.log"
+
+# Test 2: Print PerLS duringFill (lumiid IOVs) with csv=False and header=False
+echo "Test 2: Print PerLS duringFill (lumiid IOVs) - no CSV, no header..."
+echo "1686633657139272 1686676606812225 1686771096092709 1686852700471354" | \
+./printLHCInfoPerPayloads.py record=LHCInfoPerLS tag=LHCInfoPerLS_duringFill_hlt_v1 timetype=lumiid csv=False header=False > "${LOG_DIR}/perls_duringfill_no_csv.log" 2>&1
+
+lines=$(grep -cve '^\s*$' "${LOG_DIR}/perls_duringfill_no_csv.log")
+# Expected: 4 IOVs × multiple lines (7) per payload (depends on payload content)
+assert_equal 28 "$lines" "PerLS duringFill no CSV test has wrong number of lines" "${LOG_DIR}/perls_duringfill_no_csv.log"
+
+# Test 3: Print PerFill duringFill (lumiid IOVs)
+echo "Test 3: Print PerFill duringFill (lumiid IOVs)..."
+echo "1686496218185804" | \
+./printLHCInfoPerPayloads.py record=LHCInfoPerFill tag=LHCInfoPerFill_duringFill_hlt_v1 timetype=lumiid > "${LOG_DIR}/perfill_duringfill_lumiid.log" 2>&1
+
+lines=$(grep -cve '^\s*$' "${LOG_DIR}/perfill_duringfill_lumiid.log")
+# Expected: Multiple lines of payload information (exact count depends on payload content)
+assert_equal 31 "$lines" "PerFill duringFill lumiid test has wrong number of lines" "${LOG_DIR}/perfill_duringfill_lumiid.log"
+
+# Test 4: Print PerFill duringFill (lumiid IOVs), filter fill number and energy only
+echo "Test 4: Print PerFill duringFill - filtered (lumiid IOVs)..."
+echo "1686513398054988 1686633657139272 1686676606812225 1686771096092709 1686852700471354" | \
+./printLHCInfoPerPayloads.py record=LHCInfoPerFill tag=LHCInfoPerFill_duringFill_hlt_v1 timetype=lumiid 2>/dev/null | \
+grep -E "LHC fill|Energy" > "${LOG_DIR}/perfill_duringfill_filtered.log" 2>&1
+
+lines=$(grep -cve '^\s*$' "${LOG_DIR}/perfill_duringfill_filtered.log")
+# Expected: 2 lines per IOV (LHC fill + Energy) × 5 IOVs = 10 lines
+assert_equal 10 "$lines" "PerFill duringFill filtered test has wrong number of lines" "${LOG_DIR}/perfill_duringfill_filtered.log"
+
+# Test 5: Print PerFill endFill (timestamp IOVs), filter fill number, energy and fill creation time only
+echo "Test 5: Print PerFill endFill - filtered (timestamp IOVs from file)..."
+./printLHCInfoPerPayloads.py record=LHCInfoPerFill tag=LHCInfoPerFill_endFill_Run3_v2 timetype=timestamp < "endFill_iovs.txt" 2>/dev/null | \
+grep -E "Energy|LHC fill|Creation time" > "${LOG_DIR}/perfill_endfill_filtered.log" 2>&1
+
+lines=$(grep -cve '^\s*$' "${LOG_DIR}/perfill_endfill_filtered.log")
+# Expected: 3 lines per IOV × 6 IOVs = 18 lines
+assert_equal 18 "$lines" "PerFill endFill filtered test has wrong number of lines" "${LOG_DIR}/perfill_endfill_filtered.log"
+
+echo "All payload printing tests completed successfully!"
+echo "Logs with tests output are stored in: ${LOG_DIR}/"

--- a/CondTools/RunInfo/test/test_printLHCInfoPerPayloads.sh
+++ b/CondTools/RunInfo/test/test_printLHCInfoPerPayloads.sh
@@ -24,7 +24,9 @@ EOF
 # Test 1: Print PerLS duringFill (lumiid IOVs)
 echo "Test 1: Print PerLS duringFill (lumiid IOVs)..."
 echo "1686633657139272 1686676606812225 1686771096092709 1686852700471354" | \
-./printLHCInfoPerPayloads.py record=LHCInfoPerLS tag=LHCInfoPerLS_duringFill_hlt_v1 timetype=lumiid csv=True header=True > "${LOG_DIR}/perls_duringfill_lumiid.log" 2>&1
+${LOCAL_TEST_DIR}/printLHCInfoPerPayloads.py \
+    record=LHCInfoPerLS tag=LHCInfoPerLS_duringFill_hlt_v1 timetype=lumiid \
+    csv=True header=True > "${LOG_DIR}/perls_duringfill_lumiid.log" 2>&1
 
 lines=$(grep -cve '^\s*$' "${LOG_DIR}/perls_duringfill_lumiid.log")
 # Expected: CSV header + 4 data lines = 5 lines
@@ -33,7 +35,9 @@ assert_equal 5 "$lines" "PerLS duringFill lumiid test has wrong number of lines"
 # Test 2: Print PerLS duringFill (lumiid IOVs) with csv=False and header=False
 echo "Test 2: Print PerLS duringFill (lumiid IOVs) - no CSV, no header..."
 echo "1686633657139272 1686676606812225 1686771096092709 1686852700471354" | \
-./printLHCInfoPerPayloads.py record=LHCInfoPerLS tag=LHCInfoPerLS_duringFill_hlt_v1 timetype=lumiid csv=False header=False > "${LOG_DIR}/perls_duringfill_no_csv.log" 2>&1
+${LOCAL_TEST_DIR}/printLHCInfoPerPayloads.py \
+    record=LHCInfoPerLS tag=LHCInfoPerLS_duringFill_hlt_v1 timetype=lumiid \
+    csv=False header=False > "${LOG_DIR}/perls_duringfill_no_csv.log" 2>&1
 
 lines=$(grep -cve '^\s*$' "${LOG_DIR}/perls_duringfill_no_csv.log")
 # Expected: 4 IOVs × multiple lines (7) per payload (depends on payload content)
@@ -42,7 +46,9 @@ assert_equal 28 "$lines" "PerLS duringFill no CSV test has wrong number of lines
 # Test 3: Print PerFill duringFill (lumiid IOVs)
 echo "Test 3: Print PerFill duringFill (lumiid IOVs)..."
 echo "1686496218185804" | \
-./printLHCInfoPerPayloads.py record=LHCInfoPerFill tag=LHCInfoPerFill_duringFill_hlt_v1 timetype=lumiid > "${LOG_DIR}/perfill_duringfill_lumiid.log" 2>&1
+${LOCAL_TEST_DIR}/printLHCInfoPerPayloads.py \
+    record=LHCInfoPerFill tag=LHCInfoPerFill_duringFill_hlt_v1 \
+    timetype=lumiid > "${LOG_DIR}/perfill_duringfill_lumiid.log" 2>&1
 
 lines=$(grep -cve '^\s*$' "${LOG_DIR}/perfill_duringfill_lumiid.log")
 # Expected: Multiple lines of payload information (exact count depends on payload content)
@@ -51,7 +57,9 @@ assert_equal 31 "$lines" "PerFill duringFill lumiid test has wrong number of lin
 # Test 4: Print PerFill duringFill (lumiid IOVs), filter fill number and energy only
 echo "Test 4: Print PerFill duringFill - filtered (lumiid IOVs)..."
 echo "1686513398054988 1686633657139272 1686676606812225 1686771096092709 1686852700471354" | \
-./printLHCInfoPerPayloads.py record=LHCInfoPerFill tag=LHCInfoPerFill_duringFill_hlt_v1 timetype=lumiid 2>/dev/null | \
+${LOCAL_TEST_DIR}/printLHCInfoPerPayloads.py \
+    record=LHCInfoPerFill tag=LHCInfoPerFill_duringFill_hlt_v1 timetype=lumiid 2>/dev/null | \
+
 grep -E "LHC fill|Energy" > "${LOG_DIR}/perfill_duringfill_filtered.log" 2>&1
 
 lines=$(grep -cve '^\s*$' "${LOG_DIR}/perfill_duringfill_filtered.log")
@@ -60,7 +68,9 @@ assert_equal 10 "$lines" "PerFill duringFill filtered test has wrong number of l
 
 # Test 5: Print PerFill endFill (timestamp IOVs), filter fill number, energy and fill creation time only
 echo "Test 5: Print PerFill endFill - filtered (timestamp IOVs from file)..."
-./printLHCInfoPerPayloads.py record=LHCInfoPerFill tag=LHCInfoPerFill_endFill_Run3_v2 timetype=timestamp < "endFill_iovs.txt" 2>/dev/null | \
+${LOCAL_TEST_DIR}/printLHCInfoPerPayloads.py \
+    record=LHCInfoPerFill tag=LHCInfoPerFill_endFill_Run3_v2 timetype=timestamp < "endFill_iovs.txt" 2>/dev/null | \
+    
 grep -E "Energy|LHC fill|Creation time" > "${LOG_DIR}/perfill_endfill_filtered.log" 2>&1
 
 lines=$(grep -cve '^\s*$' "${LOG_DIR}/perfill_endfill_filtered.log")

--- a/CondTools/RunInfo/test/test_runinfo.sh
+++ b/CondTools/RunInfo/test/test_runinfo.sh
@@ -2,7 +2,8 @@
 
 LOCAL_TEST_DIR=$CMSSW_BASE/src/CondTools/RunInfo/test
 
-function die { echo Failure $1: status $2 ; exit $2 ; }
+# Source shared utility functions
+source "${LOCAL_TEST_DIR}/testing_utils.sh"
 
 cmsRun ${LOCAL_TEST_DIR}/test_runinfo_cfg.py | grep '\(run number\)\|\(average current\)' > test_runinfo.run_log || die "cmsRun RefTest_cfg.py" $?
 diff test_runinfo.run_log ${LOCAL_TEST_DIR}/test_runinfo_result.log || die 'incorrect output using test_runinfo_cfg.py' $?

--- a/CondTools/RunInfo/test/testing_utils.sh
+++ b/CondTools/RunInfo/test/testing_utils.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Prints a failure message, optionally dumps a log file, and exits with the given status code.
+function die {
+    message="$1"
+    status="$2"
+    log_file="$3"
+
+    if [ -n "$log_file" ] && [ -f "$log_file" ]; then
+        echo "Log output:"
+        cat "$log_file"
+    fi
+
+    echo "Failure $message: status $status"
+    exit "$status"
+}
+
+# Compares two values and fails the test if they differ.
+function assert_equal {
+    expected="$1"
+    actual="$2"
+    message="$3"
+    log_file="$4"
+
+    if [ "$expected" != "$actual" ]; then
+        die "$message (expected $expected, got $actual)" 1 "$log_file"
+    fi
+}
+


### PR DESCRIPTION
#### PR description:

This PR has tests for lhcinfo_analyzer for both PerFill and PerLS. This have been created after in pull request #48678 the tests that were manually analyzing that the values introduced by the writer are the same ones as returned to tester. The tests defined for this one are instead more generalized, where we want to print the result and check that the number of fields for CondFormats/RunInfo/interface/LHCInfoPerFill.h is correspondent to the number of lines from the print. 

The number for assertion for the testcase in writer (one analyzed) for PerFill is 31 lines, due to the print of both the IOV and the line *LHCInfoPerFill retrieved:\n* " with the content for  **"CondFormats/RunInfo/interface/LHCInfoPerFill.h"** for the specific case.

Meanwhile for PerLS the number of lines is 2 as we test the csv format

Additionally, this PR includes tests for the `printLHCInfoPerPayloads.py` utility with 5 test cases covering different usage scenarios:
1. PerLS duringFill with CSV format and header
2. PerFill duringFill with default output format
3. PerFill duringFill with field filtering (LHC fill and Energy)
4. PerFill endFill with timestamp IOVs from file input and filtered fields
5. PerLS duringFill without CSV format or header

These tests validate various input methods (string input, file input), output formats (CSV, verbose), and field filtering capabilities.

The PR is also related to issue [ts-coordination#56](https://gitlab.cern.ch/cms-ppd/technical-support/ts-coordination/-/issues/56)

Also both tests are named in BuildFile.xml

#### PR validation:

For validation, the tests were run, where the values that are inserted are through writer and obtained later from the SQLite file that is created. The results were working.

The number of lines requested was modified (as to test if it produced a mistake) to confirm that the exceptions were handled correctly for both files, which produces an output like this):


## Failure Test Case For PerFill:

```
[asalgado@lxplus976 test]$ /bin/sh ./test_lhcInfo_analyzer.sh
Begin processing the 1st record. Run 1, Event 1, LumiSection 1 on stream 0 at 26-Aug-2025 17:29:16.133 CEST
Log output (last 5 lines):
Beam 2 VC  (total 0):
Beam 1 RF  (total 0):
Beam 2 RF  (total 0):
Bunches filled for Beam 1 (total 0):
Bunches filled for Beam 2 (total 0):
Failure LHCInfoPerFillAnalyzer_cfg.py log has wrong number of lines (expected 32, got 31): status
```

## Failure Test Case For PerLS

```
[asalgado@lxplus976 test]$ /bin/sh ./test_lhcInfo_analyzer.sh
Begin processing the 1st record. Run 1, Event 1, LumiSection 1 on stream 0 at 26-Aug-2025 17:22:32.196 CEST
Begin processing the 1st record. Run 1, Event 1, LumiSection 1 on stream 0 at 26-Aug-2025 17:22:36.364 CEST
Log output (last 5 lines):
IOV,class,timestamp,runNumber,LS,xangleX,xangleY,beta*X,beta*Y,
1,LHCInfoPerLS,0,301765,1,170,170,11,11,
Failure LHCInfoPerLSAnalyzer_cfg.py log has wrong number of lines (expected 32, got 2): status
```

The printLHCInfoPerPayloads tests also validate proper error handling by verifying expected line counts for each test case and ensuring the utility works with different input formats and filtering options.

### Note: The *Begin Processing...* in test_lhcInfo_analyzer.sh is a print from the writer, therefore not modified

@JanChyczynski please review