### PR TITLE
[NGT] Bug fix for JetTester::etaInfo

### DIFF
--- a/Validation/RecoJets/plugins/JetTester.h
+++ b/Validation/RecoJets/plugins/JetTester.h
@@ -10,6 +10,7 @@
 
 #include <cmath>
 #include <string>
+#include <string_view>
 
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -82,7 +83,7 @@ private:
       {20., 30., 40., 100., 200., 300., 600., 2000., 5000., 6500., 1e6}};
   double minJetPt;
 
-  static constexpr std::array<std::tuple<std::string, std::string, double, double>, 3> etaInfo = {{
+  static constexpr std::array<std::tuple<std::string_view, std::string_view, double, double>, 3> etaInfo = {{
       std::make_tuple("B", "0<|#eta|<1.5", 0.0, 1.5),     // barrel
       std::make_tuple("E", "1.5#leq|#eta|<3", 1.5, 3.0),  // endcap
       std::make_tuple("F", "3#leq|#eta|<6", 3.0, 6.0),    // forward


### PR DESCRIPTION
#### PR description:

This PR is a follow-up of #48722: it is related to a compilation bug observed in #48802. 
After this change, JetTester.cc producer correctly compiles under UBSAN environment too.

#### PR validation:

After correct compilation with `CMSSW_15_1_UBSAN_X_2025-08-25-2300` and `CMSSW_15_1_0_pre5` environments, this PR has been tested by running the HLT validation and harvesting steps:
```
cmsDriver.py step2 --step L1P2GT,HLT:@relvalRun4,VALIDATION:@hltValidation \
    --conditions auto:phase2_realistic_T33 --geometry ExtendedRun4D110 --era Phase2C17I13M9 \
    --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
    --datatier GEN-SIM-DIGI-RAW,DQMIO --eventcontent FEVTDEBUGHLT,DQMIO \
    --process HLTX --inputCommands='keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT' \
    --filein file:/eos/cms/store/relval/CMSSW_15_1_0_pre4/RelValQCD_FlatPt_15_3000HS_14/GEN-SIM-DIGI-RAW/PU_150X_mcRun4_realistic_v1_STD_Run4D110_PU-v1/2580000/00e75d40-dde4-430b-8778-5e9ab7c48f97.root \
    --fileout file:step2.root \
    -n 10 --nThreads 0

cmsDriver.py step3 -s HARVESTING:@hltValidation \
    --conditions auto:phase2_realistic_T33 --geometry ExtendedRun4D110 --era Phase2C17I13M9 --mc \
    --scenario pp --filetype DQM --process HLTX -n -1  \
    --filein file:step2_inDQM.root \
    --fileout file:step3.root
```
The output DQM file is correctly produced in both environments.