### PR TITLE
[NGT] Rename HLT DQM jet validation folder

### DIFF
--- a/HLTriggerOffline/JetMET/python/Validation/JetMETPostProcessor_cff.py
+++ b/HLTriggerOffline/JetMET/python/Validation/JetMETPostProcessor_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 hltJetMETPostProcessor = DQMEDHarvester("JetMETDQMPostProcessor",
-     subDir = cms.untracked.string("HLT/HLTJETMET"),
+     subDir = cms.untracked.string("JetMET/TurnOnValidation/"),
      PatternJetTrg = cms.untracked.string("Jet([0-9])+"),
      PatternMetTrg = cms.untracked.string("M([E,H])+T([0-9])+")
 )

--- a/HLTriggerOffline/JetMET/python/Validation/SingleJetValidation_cfi.py
+++ b/HLTriggerOffline/JetMET/python/Validation/SingleJetValidation_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 SingleJetMetPaths = DQMEDAnalyzer('HLTJetMETValidation',
     triggerEventObject    = cms.untracked.InputTag("hltTriggerSummaryRAW","","HLT"),
-    DQMFolder             = cms.untracked.string("HLT/HLTJETMET/"),
+    DQMFolder             = cms.untracked.string("HLT/JetMET/TurnOnValidation/"),
     PatternJetTrg         = cms.untracked.string("HLT_PF(NoPU)?Jet([0-9])+(_v[0-9]+)?$"),                                   
     PatternMetTrg         = cms.untracked.string("HLT_+[Calo|PF]+MET([0-9])+[_NotCleaned|_BeamHaloCleaned]+(_v[0-9]+)?$"),
     PatternMuTrg          = cms.untracked.string("HLT_Mu([0-9])+(_v[0-9]+)?$"),

--- a/Validation/RecoHI/python/SingleJetValidationHI_cfi.py
+++ b/Validation/RecoHI/python/SingleJetValidationHI_cfi.py
@@ -8,7 +8,7 @@ genjetcoll="iterativeCone5HiGenJets"
 
 hltlow35  =""
 hltname35="HLT_HIJet35U"
-folderjet35="HLT/HLTJETMET/SingleJet35U"
+folderjet35="HLT/JetMET/TurnOnValidation/SingleJet35U"
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 SingleJetPathVal35 = DQMEDAnalyzer('HLTJetMETValidation',


### PR DESCRIPTION
#### PR description:

This PR reorganizes the HLT jet validation folder structure inside the DQM files.
Following #48722, all jet validation plots are now stored under JetMET instead of being split across two separate folders.
For consistency, the same renaming is applied to the `SingleJetPathVal35` sequence, even though it is not currently used in any workflow.

Below a before (left) - after (right) comparison:
<img width="404" height="400" alt="DQMStructureJets_before" src="https://github.com/user-attachments/assets/39d4672c-7033-4145-a0d5-84da12d56339" /> <img width="358" height="400" alt="DQMStructureJets_after" src="https://github.com/user-attachments/assets/f216ba13-4181-4de7-a169-6b54f5f200f2" />

#### PR validation:

This PR has been tested by running the HLT validation and harvesting steps with and without the bug fix, with the following commands:
```
cmsDriver.py step2 --step L1P2GT,HLT:@relvalRun4,VALIDATION:@hltValidation \
    --conditions auto:phase2_realistic_T33 --geometry ExtendedRun4D110 --era Phase2C17I13M9 \
    --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
    --datatier GEN-SIM-DIGI-RAW,DQMIO --eventcontent FEVTDEBUGHLT,DQMIO \
    --process HLTX --inputCommands='keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT' \
    --filein file:/eos/cms/store/relval/CMSSW_15_1_0_pre4/RelValQCD_FlatPt_15_3000HS_14/GEN-SIM-DIGI-RAW/PU_150X_mcRun4_realistic_v1_STD_Run4D110_PU-v1/2580000/00e75d40-dde4-430b-8778-5e9ab7c48f97.root \
    --fileout file:step2.root \
    -n 10 --nThreads 0

cmsDriver.py step3 -s HARVESTING:@hltValidation \
    --conditions auto:phase2_realistic_T33 --geometry ExtendedRun4D110 --era Phase2C17I13M9 --mc \
    --scenario pp --filetype DQM --process HLTX -n -1  \
    --filein file:step2_inDQM.root \
    --fileout file:step3.root
```
The output DQM file is produced with the correct new folder structure.