### PR TITLE
Determine non-process name lookups at begin job

### DIFF
--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -182,6 +182,7 @@ namespace edm {
           iter->second.merge(prod.second);
         }
       }
+      mergeProcessOrderFromAddInput(iReg.processOrder());
     }
 
   private:
@@ -206,6 +207,7 @@ namespace edm {
 
     void checkForDuplicateProcessName(ProductDescription const& desc, std::string const* processName) const;
     void updateProcessOrder(std::vector<std::string> const& processOrder);
+    void mergeProcessOrderFromAddInput(std::vector<std::string> const& processOrder);
 
     void throwIfNotFrozen() const;
     void throwIfFrozen() const;

--- a/DataFormats/Provenance/interface/ProductResolverIndexHelper.h
+++ b/DataFormats/Provenance/interface/ProductResolverIndexHelper.h
@@ -156,9 +156,6 @@ namespace edm {
                            char const* moduleLabel,
                            char const* instance) const;
 
-    // Return indexes for all groups that match the type.
-    Matches relatedIndexes(KindOfType kindOfType, TypeID const& typeID) const;
-
     // This will throw if called after the object is frozen.
     // The typeID must be for a type with a dictionary
     // (the calling function is expected to check that)
@@ -196,14 +193,12 @@ namespace edm {
     // Before the object is frozen the accessors above will
     // fail to find a match. Once frozen, no more new entries
     // can be added with insert.
-    void setFrozen(std::string_view processName);
+    void setFrozen(std::vector<std::string> const& orderedProcessNames);
 
     /**The list of process names for data products associated to the ProductResolvers.
      * If no products are associated with a process for this transition, the process name will not be in this list.
      */
     std::vector<std::string> const& lookupProcessNames() const;
-
-    bool producesInCurrentProcess() const { return producesInCurrentProcess_; }
 
     class Range {
     public:
@@ -335,6 +330,7 @@ namespace edm {
       ProductResolverIndex index() const { return index_; }
 
       void clearProcess() { process_.clear(); }
+      void setSkipCurrentProcess() { process_ = "#"; }
       void setIndex(ProductResolverIndex v) { index_ = v; }
 
       bool operator<(Item const& right) const;
@@ -351,8 +347,6 @@ namespace edm {
     edm::propagate_const<std::unique_ptr<std::set<Item>>> items_;
 
     edm::propagate_const<std::unique_ptr<std::set<std::string>>> processItems_;
-
-    bool producesInCurrentProcess_{false};
   };
 }  // namespace edm
 #endif

--- a/DataFormats/Provenance/interface/ProductResolverIndexHelper.h
+++ b/DataFormats/Provenance/interface/ProductResolverIndexHelper.h
@@ -258,6 +258,10 @@ namespace edm {
     // For debugging only
     void print(std::ostream& os) const;
 
+    //ProcessName label used to denote the current process should be skipped
+    //used by all methods of this class that accept the process name
+    static constexpr char const* const skipCurrentProcessLabel() { return "#"; }
+
   private:
     // Next available value for a ProductResolverIndex. This just
     // increments by one each time a new value is assigned.
@@ -330,7 +334,7 @@ namespace edm {
       ProductResolverIndex index() const { return index_; }
 
       void clearProcess() { process_.clear(); }
-      void setSkipCurrentProcess() { process_ = "#"; }
+      void setSkipCurrentProcess() { process_ = ProductResolverIndexHelper::skipCurrentProcessLabel(); }
       void setIndex(ProductResolverIndex v) { index_ = v; }
 
       bool operator<(Item const& right) const;

--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -473,7 +473,6 @@ namespace edm {
       throwMissingDictionariesException(missingDictionaries, context, producedTypes, branchNamesForMissing);
     }
 
-    std::string_view processNameSV(processName ? std::string_view(*processName) : std::string_view());
     for (auto& iterProductLookup : new_productLookups) {
       iterProductLookup->setFrozen(processOrder());
     }

--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -218,6 +218,17 @@ namespace edm {
     processingOrderMerge(processOrder, transient_.processOrder_);
   }
 
+  void ProductRegistry::mergeProcessOrderFromAddInput(std::vector<std::string> const& processOrder) {
+    if (processOrder.empty())
+      return;
+    //see if the input already has the current process
+    if (not transient_.processOrder_.empty() and (transient_.processOrder_[0] != processOrder[0])) {
+      transient_.processOrder_.insert(transient_.processOrder_.end(), processOrder.begin(), processOrder.end());
+    } else {
+      updateProcessOrder(processOrder);
+    }
+  }
+
   void ProductRegistry::setUnscheduledProducts(std::set<std::string> const& unscheduledLabels) {
     throwIfFrozen();
 
@@ -250,9 +261,20 @@ namespace edm {
   std::string ProductRegistry::merge(ProductRegistry const& other,
                                      std::string const& fileName,
                                      ProductDescription::MatchMode branchesMustMatch) {
-    if (branchesMustMatch == ProductDescription::FromInputToCurrent and transient_.processOrder_.size() == 1) {
-      transient_.processOrder_.insert(
-          transient_.processOrder_.end(), other.transient_.processOrder_.begin(), other.transient_.processOrder_.end());
+    if (branchesMustMatch == ProductDescription::FromInputToCurrent) {
+      if (processOrder().size() == 1 and not other.processOrder().empty() and
+          processOrder()[0] != other.processOrder()[0]) {
+        assert(transient_.processOrder_.size() == 1);
+        transient_.processOrder_.insert(transient_.processOrder_.end(),
+                                        other.transient_.processOrder_.begin(),
+                                        other.transient_.processOrder_.end());
+      } else {
+        //the current process must not change
+        assert(not processOrder().empty());
+        auto current = processOrder()[0];
+        processingOrderMerge(other.processOrder(), transient_.processOrder_);
+        assert(current == processOrder()[0]);
+      }
     } else {
       processingOrderMerge(other.processOrder(), transient_.processOrder_);
     }
@@ -310,6 +332,7 @@ namespace edm {
     std::vector<std::string> producedTypes;
 
     transient_.branchIDToIndex_.clear();
+    assert(productList_.empty() or processOrder().size() > 0);
 
     std::array<std::shared_ptr<ProductResolverIndexHelper>, NumBranchTypes> new_productLookups{
         {std::make_shared<ProductResolverIndexHelper>(),
@@ -452,7 +475,7 @@ namespace edm {
 
     std::string_view processNameSV(processName ? std::string_view(*processName) : std::string_view());
     for (auto& iterProductLookup : new_productLookups) {
-      iterProductLookup->setFrozen(processNameSV);
+      iterProductLookup->setFrozen(processOrder());
     }
     for (size_t i = 0; i < new_productLookups.size(); ++i) {
       transient_.productLookups_[i] = std::move(new_productLookups[i]);

--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -332,7 +332,7 @@ namespace edm {
     std::vector<std::string> producedTypes;
 
     transient_.branchIDToIndex_.clear();
-    assert(productList_.empty() or processOrder().size() > 0);
+    assert(productList_.empty() or !processOrder().empty());
 
     std::array<std::shared_ptr<ProductResolverIndexHelper>, NumBranchTypes> new_productLookups{
         {std::make_shared<ProductResolverIndexHelper>(),

--- a/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
+++ b/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
@@ -413,7 +413,7 @@ namespace edm {
 
     //sanity check
     for (auto const& p : *processItems_) {
-      if (p.empty() or p == "#")
+      if (p.empty() or p == skipCurrentProcessLabel())
         continue;
       if (orderedProcessNames.end() == std::find(orderedProcessNames.begin(), orderedProcessNames.end(), p)) {
         throw Exception(errors::LogicError)

--- a/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
+++ b/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
@@ -10,7 +10,6 @@
 #include <TClass.h>
 
 #include <cassert>
-#include <iostream>
 #include <limits>
 
 namespace edm {
@@ -121,11 +120,12 @@ namespace edm {
         return index;
       }
       //Now check to see if only one process has this type/module/instance name
-      auto nextIndex = index + 1;
+      // we need to skip the skipCurrentProcess entry
+      auto nextIndex = index + 2;
       while (indexAndNames_.size() > nextIndex && indexAndNames_[nextIndex].startInProcessNames() != 0U) {
         ++nextIndex;
       }
-      return (nextIndex == index + 2) ? index + 1 : index;
+      return (nextIndex == index + 3) ? index + 2 : index;
     };
 
     return indexAndNames_[checkForSingleProcess(iToIndexAndNames)].index();
@@ -201,23 +201,6 @@ namespace edm {
     return Matches(this, startInIndexAndNames, numberOfMatches);
   }
 
-  ProductResolverIndexHelper::Matches ProductResolverIndexHelper::relatedIndexes(KindOfType kindOfType,
-                                                                                 TypeID const& typeID) const {
-    unsigned int startInIndexAndNames = std::numeric_limits<unsigned int>::max();
-    unsigned int numberOfMatches = 0;
-
-    // Look for the type and check to see if it found it
-    unsigned iType = indexToType(kindOfType, typeID);
-    if (iType != std::numeric_limits<unsigned int>::max()) {
-      // Get the range of entries with a matching TypeID
-      Range const& range = ranges_[iType];
-
-      startInIndexAndNames = range.begin();
-      numberOfMatches = range.end() - range.begin();
-    }
-    return Matches(this, startInIndexAndNames, numberOfMatches);
-  }
-
   ProductResolverIndex ProductResolverIndexHelper::insert(TypeID const& typeID,
                                                           char const* moduleLabel,
                                                           char const* instance,
@@ -252,8 +235,11 @@ namespace edm {
     item.clearProcess();
     iter = items_->find(item);
     if (iter == items_->end()) {
-      item.setIndex(nextIndexValue_);
-      ++nextIndexValue_;
+      item.setIndex(ProductResolverIndexInitializing);
+      items_->insert(item);
+      //add entry for skipCurrentProcess
+      item.setSkipCurrentProcess();
+      item.setIndex(ProductResolverIndexInitializing);
       items_->insert(item);
     }
 
@@ -273,8 +259,10 @@ namespace edm {
       containedItem.clearProcess();
       iter = items_->find(containedItem);
       if (iter == items_->end()) {
-        containedItem.setIndex(nextIndexValue_);
-        ++nextIndexValue_;
+        containedItem.setIndex(ProductResolverIndexInitializing);
+        items_->insert(containedItem);
+        containedItem.setSkipCurrentProcess();
+        containedItem.setIndex(ProductResolverIndexInitializing);
         items_->insert(containedItem);
       }
 
@@ -292,8 +280,10 @@ namespace edm {
           baseItem.clearProcess();
           iter = items_->find(baseItem);
           if (iter == items_->end()) {
-            baseItem.setIndex(nextIndexValue_);
-            ++nextIndexValue_;
+            baseItem.setIndex(ProductResolverIndexInitializing);
+            items_->insert(baseItem);
+            baseItem.setSkipCurrentProcess();
+            baseItem.setIndex(ProductResolverIndexInitializing);
             items_->insert(baseItem);
           }
         }
@@ -317,7 +307,67 @@ namespace edm {
     return insert(typeID, moduleLabel, instance, process, containedTypeID, baseTypesOfContainedType);
   }
 
-  void ProductResolverIndexHelper::setFrozen(std::string_view processName) {
+  namespace {
+    void setNoProcessIndices(std::vector<edm::ProductResolverIndexHelper::IndexAndNames>::iterator itBegin,
+                             std::vector<edm::ProductResolverIndexHelper::IndexAndNames>::iterator itEnd,
+                             std::vector<std::string> const& orderedProcessNames,
+                             std::vector<char> const& processNames) {
+      using IndexAndNames = edm::ProductResolverIndexHelper::IndexAndNames;
+      assert(itEnd - itBegin > 2);
+      assert(itBegin->startInProcessNames() == 0U);
+      assert((itBegin + 1)->startInProcessNames() == 1U);
+      assert(processNames[(itBegin + 1)->startInProcessNames()] == '#');
+      assert(itBegin->index() == edm::ProductResolverIndexInitializing);
+      assert((itBegin + 1)->index() == edm::ProductResolverIndexInitializing);
+      if (itEnd - itBegin == 3) {
+        //only have one actual process
+        *itBegin =
+            IndexAndNames((itBegin + 2)->index(), itBegin->startInBigNamesContainer(), itBegin->startInProcessNames());
+        //Now handle skipCurrentProcess
+        if (orderedProcessNames[0] == &processNames[(itBegin + 2)->startInProcessNames()]) {
+          //the one process is the current process
+          *(itBegin + 1) = IndexAndNames(ProductResolverIndexInvalid,
+                                         (itBegin + 1)->startInBigNamesContainer(),
+                                         (itBegin + 1)->startInProcessNames());
+        } else {
+          *(itBegin + 1) = IndexAndNames(
+              (itBegin + 2)->index(), (itBegin + 1)->startInBigNamesContainer(), (itBegin + 1)->startInProcessNames());
+        }
+      } else {
+        bool foundFirstMatch = false;
+        for (auto const& proc : orderedProcessNames) {
+          auto it = itBegin + 2;
+          while (it != itEnd && proc != &processNames[it->startInProcessNames()]) {
+            ++it;
+          }
+          if (it != itEnd) {
+            if (not foundFirstMatch) {
+              foundFirstMatch = true;
+              //found a process that matches
+              *itBegin =
+                  IndexAndNames(it->index(), itBegin->startInBigNamesContainer(), itBegin->startInProcessNames());
+              //Now handle skipCurrentProcess
+              if (proc != orderedProcessNames[0]) {
+                *(itBegin + 1) = IndexAndNames(
+                    it->index(), (itBegin + 1)->startInBigNamesContainer(), (itBegin + 1)->startInProcessNames());
+                break;
+              } else {
+                //this process is the current process
+                *(itBegin + 1) = IndexAndNames(ProductResolverIndexInvalid,
+                                               (itBegin + 1)->startInBigNamesContainer(),
+                                               (itBegin + 1)->startInProcessNames());
+              }
+            } else {
+              *(itBegin + 1) = IndexAndNames(
+                  it->index(), (itBegin + 1)->startInBigNamesContainer(), (itBegin + 1)->startInProcessNames());
+              break;
+            }
+          }
+        }
+      }
+    }
+  }  // namespace
+  void ProductResolverIndexHelper::setFrozen(std::vector<std::string> const& orderedProcessNames) {
     if (!items_)
       return;
 
@@ -361,6 +411,15 @@ namespace edm {
       previousInstance = item.instance();
     }
 
+    //sanity check
+    for (auto const& p : *processItems_) {
+      if (p.empty() or p == "#")
+        continue;
+      if (orderedProcessNames.end() == std::find(orderedProcessNames.begin(), orderedProcessNames.end(), p)) {
+        throw Exception(errors::LogicError)
+            << "ProductResolverIndexHelper::setFrozen process not in ordered list " << p << std::endl;
+      }
+    }
     // Size and fill the process name vector
     unsigned int processNamesSize = 0;
     for (auto const& processItem : *processItems_) {
@@ -374,9 +433,6 @@ namespace edm {
       }
       processNames_.push_back('\0');
       lookupProcessNames_.push_back(processItem);
-      if (processItem == processName) {
-        producesInCurrentProcess_ = true;
-      }
     }
 
     // Reserve memory in the vectors
@@ -393,9 +449,10 @@ namespace edm {
     unsigned int iBeginning = 0;
     iCountCharacters = 0;
     unsigned int previousCharacterCount = 0;
+    unsigned int iNoProcessBegin = 0;
     if (!items_->empty()) {
       for (auto const& item : *items_) {
-        if (iFirstThisType || item.typeID() != previousTypeID || item.kindOfType() != previousKindOfType) {
+        if (iFirstType || item.typeID() != previousTypeID || item.kindOfType() != previousKindOfType) {
           iFirstThisType = true;
           sortedTypeIDs_.push_back(item.typeID());
           if (iFirstType) {
@@ -405,9 +462,15 @@ namespace edm {
           }
           iBeginning = iCount;
         }
-        ++iCount;
 
         if (iFirstThisType || item.moduleLabel() != previousModuleLabel || item.instance() != previousInstance) {
+          if (iNoProcessBegin != iCount) {
+            setNoProcessIndices(indexAndNames_.begin() + iNoProcessBegin,
+                                indexAndNames_.begin() + iCount,
+                                orderedProcessNames,
+                                processNames_);
+            iNoProcessBegin = iCount;
+          }
           unsigned int labelSize = item.moduleLabel().size();
           for (unsigned int j = 0; j < labelSize; ++j) {
             bigNamesContainer_.push_back(item.moduleLabel()[j]);
@@ -439,8 +502,11 @@ namespace edm {
         previousKindOfType = item.kindOfType();
         previousModuleLabel = item.moduleLabel();
         previousInstance = item.instance();
+        ++iCount;
       }
       ranges_.push_back(Range(iBeginning, iCount));
+      setNoProcessIndices(
+          indexAndNames_.begin() + iNoProcessBegin, indexAndNames_.end(), orderedProcessNames, processNames_);
     }
 
     // Some sanity checks to protect against out of bounds vector accesses
@@ -616,30 +682,50 @@ namespace edm {
 
   void ProductResolverIndexHelper::sanityCheck() const {
     bool sanityChecksPass = true;
-    if (sortedTypeIDs_.size() != ranges_.size())
+    std::string errorMessage;
+    if (sortedTypeIDs_.size() != ranges_.size()) {
       sanityChecksPass = false;
+      errorMessage += "sortedTypeIDs_.size() != ranges_.size()\n";
+    }
 
     unsigned int previousEnd = 0;
     for (auto const& range : ranges_) {
-      if (range.begin() != previousEnd)
+      if (range.begin() != previousEnd) {
         sanityChecksPass = false;
-      if (range.begin() >= range.end())
+        errorMessage += "ranges_ are not contiguous\n";
+      }
+      if (range.begin() >= range.end()) {
         sanityChecksPass = false;
+        errorMessage += "ranges_ are not valid\n";
+      }
       previousEnd = range.end();
     }
-    if (previousEnd != indexAndNames_.size())
+    if (previousEnd != indexAndNames_.size()) {
       sanityChecksPass = false;
+      errorMessage += "ranges_ do not cover all of indexAndNames_\n";
+    }
 
     unsigned maxStart = 0;
     unsigned maxStartProcess = 0;
     for (auto const& indexAndName : indexAndNames_) {
-      if (indexAndName.index() >= nextIndexValue_ && indexAndName.index() != ProductResolverIndexAmbiguous)
+      if (indexAndName.index() >= nextIndexValue_ && (indexAndName.index() != ProductResolverIndexAmbiguous and
+                                                      indexAndName.index() != ProductResolverIndexInvalid)) {
         sanityChecksPass = false;
+        auto startOfModule = indexAndName.startInBigNamesContainer();
+        auto startOfInstance = strlen(&bigNamesContainer_[startOfModule]) + 1 + startOfModule;
+        errorMessage += "indexAndNames_ has invalid index" + std::to_string(indexAndName.index()) + " " +
+                        &bigNamesContainer_[startOfModule] + " " + &bigNamesContainer_[startOfInstance] + " " +
+                        &processNames_[indexAndName.startInProcessNames()] + "\n";
+      }
 
-      if (indexAndName.startInBigNamesContainer() >= bigNamesContainer_.size())
+      if (indexAndName.startInBigNamesContainer() >= bigNamesContainer_.size()) {
         sanityChecksPass = false;
-      if (indexAndName.startInProcessNames() >= processNames_.size())
+        errorMessage += "indexAndNames_ has invalid startInBigNamesContainer\n";
+      }
+      if (indexAndName.startInProcessNames() >= processNames_.size()) {
         sanityChecksPass = false;
+        errorMessage += "indexAndNames_ has invalid startInProcessNames\n";
+      }
 
       if (indexAndName.startInBigNamesContainer() > maxStart)
         maxStart = indexAndName.startInBigNamesContainer();
@@ -648,34 +734,47 @@ namespace edm {
     }
 
     if (!indexAndNames_.empty()) {
-      if (bigNamesContainer_.back() != '\0')
+      if (bigNamesContainer_.back() != '\0') {
         sanityChecksPass = false;
-      if (processNames_.back() != '\0')
+        errorMessage += "bigNamesContainer_ does not end with null char\n";
+      }
+      if (processNames_.back() != '\0') {
         sanityChecksPass = false;
-      if (maxStart >= bigNamesContainer_.size())
+        errorMessage += "processNames_ does not end with null char\n";
+      }
+      if (maxStart >= bigNamesContainer_.size()) {
         sanityChecksPass = false;
+        errorMessage += "maxStart >= bigNamesContainer_.size()\n";
+      }
       unsigned int countZeroes = 0;
       for (unsigned j = maxStart; j < bigNamesContainer_.size(); ++j) {
         if (bigNamesContainer_[j] == '\0') {
           ++countZeroes;
         }
       }
-      if (countZeroes != 2)
+      if (countZeroes != 2) {
         sanityChecksPass = false;
-      if (maxStartProcess >= processNames_.size())
+        errorMessage += "bigNamesContainer_ does not have two null chars\n";
+      }
+      if (maxStartProcess >= processNames_.size()) {
         sanityChecksPass = false;
+        errorMessage += "maxStartProcess >= processNames_.size()\n";
+      }
       countZeroes = 0;
       for (unsigned j = maxStartProcess; j < processNames_.size(); ++j) {
         if (processNames_[j] == '\0') {
           ++countZeroes;
         }
       }
-      if (countZeroes != 1)
+      if (countZeroes != 1) {
         sanityChecksPass = false;
+        errorMessage += "processNames_ does not have one null char\n";
+      }
     }
 
     if (!sanityChecksPass) {
-      throw Exception(errors::LogicError) << "ProductResolverIndexHelper::setFrozen - Detected illegal state.\n";
+      throw Exception(errors::LogicError) << "ProductResolverIndexHelper::setFrozen - Detected illegal state.\n"
+                                          << errorMessage;
     }
   }
 
@@ -769,8 +868,8 @@ namespace edm {
     if (items_) {
       os << "******* items_ \n";
       for (auto const& item : *items_) {
-        std::cout << item.kindOfType() << " " << item.moduleLabel() << " " << item.instance() << " " << item.process()
-                  << " " << item.index() << " " << item.typeID() << "\n";
+        os << item.kindOfType() << " " << item.moduleLabel() << " " << item.instance() << " " << item.process() << " "
+           << item.index() << " " << item.typeID() << "\n";
       }
     }
     if (processItems_) {

--- a/DataFormats/Provenance/test/productResolverIndexHelper_t.cpp
+++ b/DataFormats/Provenance/test/productResolverIndexHelper_t.cpp
@@ -21,7 +21,10 @@ TEST_CASE("ProductResolverIndexHelper", "[ProductResolverIndexHelper]") {
 
   SECTION("CreateEmpty") {
     edm::ProductResolverIndexHelper helper;
-    helper.setFrozen("processA");
+    {
+      std::vector<std::string> processNames = {"processA"};
+      helper.setFrozen(processNames);
+    }
 
     REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "processA") ==
             ProductResolverIndexInvalid);
@@ -32,8 +35,6 @@ TEST_CASE("ProductResolverIndexHelper", "[ProductResolverIndexHelper]") {
 
     edm::ProductResolverIndexHelper::Matches matches =
         helper.relatedIndexes(PRODUCT_TYPE, typeID_ProductID, "label_A", "instance_A");
-    REQUIRE(matches.numberOfMatches() == 0);
-    matches = helper.relatedIndexes(PRODUCT_TYPE, typeID_ProductID);
     REQUIRE(matches.numberOfMatches() == 0);
 
     TypeID typeID(typeid(ProductID));
@@ -41,197 +42,411 @@ TEST_CASE("ProductResolverIndexHelper", "[ProductResolverIndexHelper]") {
   }
 
   SECTION("OneEntry") {
-    edm::ProductResolverIndexHelper helper;
+    SECTION("Current process") {
+      edm::ProductResolverIndexHelper helper;
 
-    TypeID typeIDProductID(typeid(ProductID));
-    helper.insert(typeIDProductID, "labelA", "instanceA", "processA");
+      TypeID typeIDProductID(typeid(ProductID));
+      helper.insert(typeIDProductID, "labelA", "instanceA", "processA");
 
-    REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "processA") ==
-            ProductResolverIndexInvalid);
-    REQUIRE(helper.index(ELEMENT_TYPE, typeID_ProductID, "labelA", "instanceA", "processA") ==
-            ProductResolverIndexInvalid);
-    REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "") == ProductResolverIndexInvalid);
-    REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA") == ProductResolverIndexInvalid);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "processA") ==
+              ProductResolverIndexInvalid);
+      REQUIRE(helper.index(ELEMENT_TYPE, typeID_ProductID, "labelA", "instanceA", "processA") ==
+              ProductResolverIndexInvalid);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "") == ProductResolverIndexInvalid);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA") == ProductResolverIndexInvalid);
 
-    edm::ProductResolverIndexHelper::Matches matches =
-        helper.relatedIndexes(PRODUCT_TYPE, typeID_ProductID, "label_A", "instance_A");
-    REQUIRE(matches.numberOfMatches() == 0);
-    matches = helper.relatedIndexes(PRODUCT_TYPE, typeID_ProductID);
-    REQUIRE(matches.numberOfMatches() == 0);
+      edm::ProductResolverIndexHelper::Matches matches =
+          helper.relatedIndexes(PRODUCT_TYPE, typeID_ProductID, "label_A", "instance_A");
+      REQUIRE(matches.numberOfMatches() == 0);
 
-    helper.setFrozen("processA");
+      {
+        std::vector<std::string> processNames = {"processA"};
+        helper.setFrozen(processNames);
+      }
 
-    matches = helper.relatedIndexes(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA");
-    REQUIRE(matches.numberOfMatches() == 2);
-    edm::ProductResolverIndex indexEmptyProcess = matches.index(0);
-    edm::ProductResolverIndex indexWithProcess = matches.index(1);
-    REQUIRE_THROWS_AS(matches.index(2), cms::Exception);
-    REQUIRE(indexEmptyProcess < 2);
-    REQUIRE(indexWithProcess < 2);
-    REQUIRE(indexEmptyProcess != indexWithProcess);
+      matches = helper.relatedIndexes(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA");
+      REQUIRE(matches.numberOfMatches() == 3);
+      edm::ProductResolverIndex indexEmptyProcess = matches.index(0);
+      edm::ProductResolverIndex indexSkipCurrentProcess = matches.index(1);
+      edm::ProductResolverIndex indexWithProcess = matches.index(2);
+      REQUIRE_THROWS_AS(matches.index(3), cms::Exception);
+      REQUIRE(indexEmptyProcess < 2);
+      REQUIRE(indexWithProcess < 2);
+      REQUIRE(indexEmptyProcess == indexWithProcess);
+      REQUIRE(indexSkipCurrentProcess == ProductResolverIndexInvalid);
 
-    //with only one entry, all should resolve to the one with process name
-    REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA") == indexWithProcess);
-    REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "") == indexWithProcess);
-    REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", 0) == indexWithProcess);
-    REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "processA") == indexWithProcess);
+      //with only one entry, all should resolve to the one with process name
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA") == indexWithProcess);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "") == indexWithProcess);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", 0) == indexWithProcess);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "#") == indexSkipCurrentProcess);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "processA") == indexWithProcess);
 
-    REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instance", "processA") ==
-            ProductResolverIndexInvalid);
-    REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceAX", "processA") ==
-            ProductResolverIndexInvalid);
-    REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "label", "instanceA", "processA") ==
-            ProductResolverIndexInvalid);
-    REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelAX", "instanceA", "processA") ==
-            ProductResolverIndexInvalid);
-    REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "process") ==
-            ProductResolverIndexInvalid);
-    REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "processAX") ==
-            ProductResolverIndexInvalid);
-    REQUIRE(helper.index(PRODUCT_TYPE, typeID_EventID, "labelA", "instanceA", "processA") ==
-            ProductResolverIndexInvalid);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instance", "processA") ==
+              ProductResolverIndexInvalid);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceAX", "processA") ==
+              ProductResolverIndexInvalid);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "label", "instanceA", "processA") ==
+              ProductResolverIndexInvalid);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelAX", "instanceA", "processA") ==
+              ProductResolverIndexInvalid);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "process") ==
+              ProductResolverIndexInvalid);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "processAX") ==
+              ProductResolverIndexInvalid);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_EventID, "labelA", "instanceA", "processA") ==
+              ProductResolverIndexInvalid);
 
-    REQUIRE(helper.index(ELEMENT_TYPE, typeID_ProductID, "labelA", "instanceA") == ProductResolverIndexInvalid);
-    REQUIRE(helper.index(ELEMENT_TYPE, typeID_ProductID, "labelA", "instanceA", "processA") ==
-            ProductResolverIndexInvalid);
+      REQUIRE(helper.index(ELEMENT_TYPE, typeID_ProductID, "labelA", "instanceA") == ProductResolverIndexInvalid);
+      REQUIRE(helper.index(ELEMENT_TYPE, typeID_ProductID, "labelA", "instanceA", "processA") ==
+              ProductResolverIndexInvalid);
 
-    matches = helper.relatedIndexes(PRODUCT_TYPE, typeID_ProductID);
-    REQUIRE(matches.numberOfMatches() == 2);
-    REQUIRE(matches.index(0) == indexEmptyProcess);
-    REQUIRE(matches.index(1) == indexWithProcess);
+      matches = helper.relatedIndexes(ELEMENT_TYPE, typeID_ProductID, "labelA", "instanceA");
+      REQUIRE(matches.numberOfMatches() == 0);
 
-    matches = helper.relatedIndexes(PRODUCT_TYPE, typeID_EventID);
-    REQUIRE(matches.numberOfMatches() == 0);
+      {
+        auto indexToModules = helper.indiciesForModulesInProcess("processA");
+        REQUIRE(indexToModules.size() == 1);
+        REQUIRE(indexToModules.count("labelA") == 1);
+        auto const& range = indexToModules.equal_range("labelA");
+        REQUIRE(std::get<2>(range.first->second) == indexWithProcess);
+      }
 
-    matches = helper.relatedIndexes(ELEMENT_TYPE, typeID_ProductID);
-    REQUIRE(matches.numberOfMatches() == 0);
-
-    matches = helper.relatedIndexes(ELEMENT_TYPE, typeID_ProductID, "labelA", "instanceA");
-    REQUIRE(matches.numberOfMatches() == 0);
-
-    {
-      auto indexToModules = helper.indiciesForModulesInProcess("processA");
-      REQUIRE(indexToModules.size() == 1);
-      REQUIRE(indexToModules.count("labelA") == 1);
-      auto const& range = indexToModules.equal_range("labelA");
-      REQUIRE(std::get<2>(range.first->second) == indexWithProcess);
+      {
+        auto indexToModules = helper.indiciesForModulesInProcess("processNotHere");
+        REQUIRE(indexToModules.size() == 0);
+      }
     }
+    SECTION("Previous process") {
+      edm::ProductResolverIndexHelper helper;
 
-    {
-      auto indexToModules = helper.indiciesForModulesInProcess("processNotHere");
-      REQUIRE(indexToModules.size() == 0);
+      TypeID typeIDProductID(typeid(ProductID));
+      helper.insert(typeIDProductID, "labelA", "instanceA", "processA");
+
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "processA") ==
+              ProductResolverIndexInvalid);
+      REQUIRE(helper.index(ELEMENT_TYPE, typeID_ProductID, "labelA", "instanceA", "processA") ==
+              ProductResolverIndexInvalid);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "") == ProductResolverIndexInvalid);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA") == ProductResolverIndexInvalid);
+
+      edm::ProductResolverIndexHelper::Matches matches =
+          helper.relatedIndexes(PRODUCT_TYPE, typeID_ProductID, "label_A", "instance_A");
+      REQUIRE(matches.numberOfMatches() == 0);
+
+      {
+        std::vector<std::string> processNames = {"processB", "processA"};
+        helper.setFrozen(processNames);
+      }
+
+      matches = helper.relatedIndexes(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA");
+      REQUIRE(matches.numberOfMatches() == 3);
+      edm::ProductResolverIndex indexEmptyProcess = matches.index(0);
+      edm::ProductResolverIndex indexSkipCurrentProcess = matches.index(1);
+      edm::ProductResolverIndex indexWithProcess = matches.index(2);
+      REQUIRE_THROWS_AS(matches.index(3), cms::Exception);
+      REQUIRE(indexEmptyProcess < 2);
+      REQUIRE(indexWithProcess < 2);
+      REQUIRE(indexEmptyProcess == indexWithProcess);
+      REQUIRE(indexSkipCurrentProcess == indexWithProcess);
+
+      //with only one entry, all should resolve to the one with process name
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA") == indexWithProcess);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "") == indexWithProcess);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", 0) == indexWithProcess);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "#") == indexSkipCurrentProcess);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "processA") == indexWithProcess);
+
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instance", "processA") ==
+              ProductResolverIndexInvalid);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceAX", "processA") ==
+              ProductResolverIndexInvalid);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "label", "instanceA", "processA") ==
+              ProductResolverIndexInvalid);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelAX", "instanceA", "processA") ==
+              ProductResolverIndexInvalid);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "process") ==
+              ProductResolverIndexInvalid);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "processAX") ==
+              ProductResolverIndexInvalid);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_EventID, "labelA", "instanceA", "processA") ==
+              ProductResolverIndexInvalid);
+
+      REQUIRE(helper.index(ELEMENT_TYPE, typeID_ProductID, "labelA", "instanceA") == ProductResolverIndexInvalid);
+      REQUIRE(helper.index(ELEMENT_TYPE, typeID_ProductID, "labelA", "instanceA", "processA") ==
+              ProductResolverIndexInvalid);
+
+      matches = helper.relatedIndexes(ELEMENT_TYPE, typeID_ProductID, "labelA", "instanceA");
+      REQUIRE(matches.numberOfMatches() == 0);
+
+      {
+        auto indexToModules = helper.indiciesForModulesInProcess("processA");
+        REQUIRE(indexToModules.size() == 1);
+        REQUIRE(indexToModules.count("labelA") == 1);
+        auto const& range = indexToModules.equal_range("labelA");
+        REQUIRE(std::get<2>(range.first->second) == indexWithProcess);
+      }
+
+      {
+        auto indexToModules = helper.indiciesForModulesInProcess("processNotHere");
+        REQUIRE(indexToModules.size() == 0);
+      }
+    }
+    SECTION("current and previous section") {
+      edm::ProductResolverIndexHelper helper;
+
+      TypeID typeIDProductID(typeid(ProductID));
+      helper.insert(typeIDProductID, "labelA", "instanceA", "processA");
+      helper.insert(typeIDProductID, "labelA", "instanceA", "processB");
+      {
+        std::vector<std::string> processNames = {"processB", "processA"};
+        helper.setFrozen(processNames);
+      }
+      auto matches = helper.relatedIndexes(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA");
+      REQUIRE(matches.numberOfMatches() == 4);
+      edm::ProductResolverIndex indexEmptyProcess = matches.index(0);
+      edm::ProductResolverIndex indexSkipCurrentProcess = matches.index(1);
+      edm::ProductResolverIndex indexWithProcessA = matches.index(2);
+      edm::ProductResolverIndex indexWithProcessB = matches.index(3);
+      REQUIRE_THROWS_AS(matches.index(4), cms::Exception);
+      REQUIRE(indexEmptyProcess == indexWithProcessB);
+      REQUIRE(indexSkipCurrentProcess == indexWithProcessA);
+
+      //with only one entry, all should resolve to the one with process name
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA") == indexWithProcessB);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "") == indexWithProcessB);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", 0) == indexWithProcessB);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "#") == indexSkipCurrentProcess);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "processA") == indexWithProcessA);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "processB") == indexWithProcessB);
     }
   }
 
   SECTION("ManyEntries") {
-    edm::ProductResolverIndexHelper helper;
+    SECTION("1 simple type not in current process") {
+      edm::ProductResolverIndexHelper helper;
+      TypeID typeIDEventID(typeid(EventID));
+      helper.insert(typeIDEventID, "labelB", "instanceB", "processB");   // 0,
+      helper.insert(typeIDEventID, "label", "instanceB", "processB");    // 1,
+      helper.insert(typeIDEventID, "labelX", "instanceB", "processB");   // 2,
+      helper.insert(typeIDEventID, "labelB", "instance", "processB");    // 3,
+      helper.insert(typeIDEventID, "labelB", "instanceX", "processB");   // 4,
+      helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");  // 5,
+      helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");  // 6,
+      helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");  // 7,
+      helper.insert(typeIDEventID, "label", "instance", "process");      // 8,
+      {
+        std::vector<std::string> processNames = {
+            "processC", "process", "processB", "processB1", "processB2", "processB3", "processA"};
+        helper.setFrozen(processNames);
+      }
+      auto matches = helper.relatedIndexes(PRODUCT_TYPE, typeID_EventID, "labelB", "instanceB");
+      REQUIRE(matches.numberOfMatches() == 4 + 2);  //4 process matches + 1 empty and 1 skip current process
+      ProductResolverIndex indexEmptyProcess = matches.index(0);
+      ProductResolverIndex indexSkipCurrentProcess = matches.index(1);
+      ProductResolverIndex indexB = matches.index(2);
+      ProductResolverIndex indexB1 = matches.index(3);
+      ProductResolverIndex indexB2 = matches.index(4);
+      ProductResolverIndex indexB3 = matches.index(5);
+      REQUIRE_THROWS_AS(matches.index(6), cms::Exception);
+      REQUIRE(indexB == 0);
+      REQUIRE(indexB1 == 5);
+      REQUIRE(indexB2 == 7);
+      REQUIRE(indexB3 == 6);
+      REQUIRE(indexEmptyProcess == indexB);
+      REQUIRE(indexSkipCurrentProcess == indexB);
 
-    TypeID typeIDProductID(typeid(ProductID));
-    TypeID typeIDEventID(typeid(EventID));
-    TypeID typeIDVectorInt(typeid(std::vector<int>));
-    TypeID typeIDSetInt(typeid(std::set<int>));
-    TypeID typeIDVSimpleDerived(typeid(std::vector<edmtest::SimpleDerived>));
-
-    helper.insert(typeIDVectorInt, "labelC", "instanceC", "processC");                                     // 0, 1, 2
-    helper.insert(typeIDVectorInt, "label", "instance", "process");                                        // 3, 4, 5
-    helper.insert(typeIDEventID, "labelB", "instanceB", "processB");                                       // 6, 7
-    helper.insert(typeIDEventID, "label", "instanceB", "processB");                                        // 8, 9
-    helper.insert(typeIDEventID, "labelX", "instanceB", "processB");                                       // 10, 11
-    helper.insert(typeIDEventID, "labelB", "instance", "processB");                                        // 12, 13
-    helper.insert(typeIDEventID, "labelB", "instanceX", "processB");                                       // 14, 15
-    helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");                                      // 16, 5
-    helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");                                      // 17, 5
-    helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");                                      // 18, 5
-    helper.insert(typeIDProductID, "label", "instance", "process");                                        // 19, 20
-    helper.insert(typeIDEventID, "label", "instance", "process");                                          // 21, 22
-    helper.insert(typeIDProductID, "labelA", "instanceA", "processA");                                     // 23, 24
-    REQUIRE_THROWS_AS(helper.insert(typeIDProductID, "labelA", "instanceA", "processA"), cms::Exception);  // duplicate
-
-    helper.insert(typeIDSetInt, "labelC", "instanceC", "processC");  // 25, 26
-
-    helper.insert(typeIDVSimpleDerived, "labelC", "instanceC", "processC");  // 27, 28, 29, 30
-
-    helper.setFrozen("processC");
-
-    TypeID typeID_int(typeid(int));
-    REQUIRE(helper.index(ELEMENT_TYPE, typeID_int, "labelC", "instanceC", "processC") == ProductResolverIndexAmbiguous);
-    REQUIRE(helper.index(ELEMENT_TYPE, typeID_int, "labelC", "instanceC", "processQ") == ProductResolverIndexInvalid);
-    REQUIRE(helper.index(ELEMENT_TYPE, typeID_int, "labelC", "instanceC") == ProductResolverIndexAmbiguous);
-    edm::ProductResolverIndexHelper::Matches matches = helper.relatedIndexes(ELEMENT_TYPE, typeID_int);
-    REQUIRE(matches.numberOfMatches() == 4);
-    REQUIRE(matches.index(0) == 5);
-    REQUIRE(matches.index(1) == 3);
-    REQUIRE(matches.index(2) == 2);
-    REQUIRE(matches.index(3) == ProductResolverIndexAmbiguous);
-
-    TypeID typeID_vint(typeid(std::vector<int>));
-    REQUIRE(helper.index(PRODUCT_TYPE, typeID_vint, "labelC", "instanceC", "processC") == 0);
-    REQUIRE(helper.index(PRODUCT_TYPE, typeID_vint, "labelC", "instanceC") == 0);  //only one with no process
-
-    TypeID typeID_sint(typeid(std::set<int>));
-    REQUIRE(helper.index(PRODUCT_TYPE, typeID_sint, "labelC", "instanceC", "processC") == 25);
-    REQUIRE(helper.index(PRODUCT_TYPE, typeID_sint, "labelC", "instanceC") == 25);  //only one with no process
-
-    TypeID typeID_Simple(typeid(edmtest::Simple));
-    REQUIRE(helper.index(ELEMENT_TYPE, typeID_Simple, "labelC", "instanceC") == 27);  //only one with no process
-    REQUIRE(helper.index(ELEMENT_TYPE, typeID_Simple, "labelC", "instanceC", "processC") == 27);
-
-    TypeID typeID_SimpleDerived(typeid(edmtest::SimpleDerived));
-    REQUIRE(helper.index(ELEMENT_TYPE, typeID_SimpleDerived, "labelC", "instanceC") == 27);  //only one with no process
-    REQUIRE(helper.index(ELEMENT_TYPE, typeID_SimpleDerived, "labelC", "instanceC", "processC") == 27);
-
-    TypeID typeID_VSimpleDerived(typeid(std::vector<edmtest::SimpleDerived>));
-    REQUIRE(helper.index(PRODUCT_TYPE, typeID_VSimpleDerived, "labelC", "instanceC") == 27);  //only one with no process
-    REQUIRE(helper.index(PRODUCT_TYPE, typeID_VSimpleDerived, "labelC", "instanceC", "processC") == 27);
-
-    matches = helper.relatedIndexes(PRODUCT_TYPE, typeID_EventID, "labelB", "instanceB");
-    REQUIRE(matches.numberOfMatches() == 5);
-    ProductResolverIndex indexEmptyProcess = matches.index(0);
-    ProductResolverIndex indexB = matches.index(1);
-    ProductResolverIndex indexB1 = matches.index(2);
-    ProductResolverIndex indexB2 = matches.index(3);
-    ProductResolverIndex indexB3 = matches.index(4);
-    REQUIRE_THROWS_AS(matches.index(5), cms::Exception);
-    REQUIRE(indexEmptyProcess == 7);
-    REQUIRE(indexB == 6);
-    REQUIRE(indexB1 == 16);
-    REQUIRE(indexB2 == 18);
-    REQUIRE(indexB3 == 17);
-
-    REQUIRE(std::string(matches.moduleLabel(4)) == "labelB");
-    REQUIRE(std::string(matches.productInstanceName(4)) == "instanceB");
-    REQUIRE(std::string(matches.processName(4)) == "processB3");
-    REQUIRE(std::string(matches.processName(0)) == "");
-
-    matches = helper.relatedIndexes(ELEMENT_TYPE, typeID_Simple);
-    REQUIRE(matches.numberOfMatches() == 2);
-    ProductResolverIndex indexC = matches.index(1);
-    REQUIRE_THROWS_AS(matches.index(2), cms::Exception);
-    REQUIRE(indexC == 27);
-
-    {
-      auto indexToModules = helper.indiciesForModulesInProcess("processA");
-      REQUIRE(indexToModules.size() == 1);
+      REQUIRE(std::string(matches.moduleLabel(5)) == "labelB");
+      REQUIRE(std::string(matches.productInstanceName(5)) == "instanceB");
+      REQUIRE(std::string(matches.processName(5)) == "processB3");
+      REQUIRE(std::string(matches.processName(0)) == "");
     }
-    {
-      auto indexToModules = helper.indiciesForModulesInProcess("processB");
-      REQUIRE(indexToModules.size() == 5);
+    SECTION("1 simple type in current process") {
+      edm::ProductResolverIndexHelper helper;
+      TypeID typeIDEventID(typeid(EventID));
+      helper.insert(typeIDEventID, "labelB", "instanceB", "processB");   // 0,
+      helper.insert(typeIDEventID, "label", "instanceB", "processB");    // 1,
+      helper.insert(typeIDEventID, "labelX", "instanceB", "processB");   // 2,
+      helper.insert(typeIDEventID, "labelB", "instance", "processB");    // 3,
+      helper.insert(typeIDEventID, "labelB", "instanceX", "processB");   // 4,
+      helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");  // 5,
+      helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");  // 6,
+      helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");  // 7,
+      {
+        std::vector<std::string> processNames = {"processB", "processB1", "processB2", "processB3", "processA"};
+        helper.setFrozen(processNames);
+      }
+      auto matches = helper.relatedIndexes(PRODUCT_TYPE, typeID_EventID, "labelB", "instanceB");
+      REQUIRE(matches.numberOfMatches() == 4 + 2);  //4 process matches + 1 empty and 1 skip current process
+      ProductResolverIndex indexEmptyProcess = matches.index(0);
+      ProductResolverIndex indexSkipCurrentProcess = matches.index(1);
+      ProductResolverIndex indexB = matches.index(2);
+      ProductResolverIndex indexB1 = matches.index(3);
+      ProductResolverIndex indexB2 = matches.index(4);
+      ProductResolverIndex indexB3 = matches.index(5);
+      REQUIRE_THROWS_AS(matches.index(6), cms::Exception);
+      REQUIRE(indexB == 0);
+      REQUIRE(indexB1 == 5);
+      REQUIRE(indexB2 == 7);
+      REQUIRE(indexB3 == 6);
+      REQUIRE(indexEmptyProcess == indexB);
+      REQUIRE(indexSkipCurrentProcess == indexB1);
+
+      REQUIRE(std::string(matches.moduleLabel(5)) == "labelB");
+      REQUIRE(std::string(matches.productInstanceName(5)) == "instanceB");
+      REQUIRE(std::string(matches.processName(5)) == "processB3");
+      REQUIRE(std::string(matches.processName(0)) == "");
     }
-    {
-      auto indexToModules = helper.indiciesForModulesInProcess("processB1");
-      REQUIRE(indexToModules.size() == 1);
+
+    SECTION("2 simple types") {
+      edm::ProductResolverIndexHelper helper;
+      TypeID typeIDProductID(typeid(ProductID));
+      TypeID typeIDEventID(typeid(EventID));
+      helper.insert(typeIDEventID, "labelB", "instanceB", "processB");    // 0,
+      helper.insert(typeIDEventID, "label", "instanceB", "processB");     // 1,
+      helper.insert(typeIDEventID, "labelX", "instanceB", "processB");    // 2,
+      helper.insert(typeIDEventID, "labelB", "instance", "processB");     // 3,
+      helper.insert(typeIDEventID, "labelB", "instanceX", "processB");    // 4,
+      helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");   // 5,
+      helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");   // 6,
+      helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");   // 7,
+      helper.insert(typeIDProductID, "label", "instance", "process");     // 8,
+      helper.insert(typeIDEventID, "label", "instance", "process");       // 9,
+      helper.insert(typeIDProductID, "labelA", "instanceA", "processA");  // 10
+      {
+        std::vector<std::string> processNames = {
+            "processC", "process", "processB", "processB1", "processB2", "processB3", "processA"};
+        helper.setFrozen(processNames);
+      }
+      auto matches = helper.relatedIndexes(PRODUCT_TYPE, typeID_EventID, "labelB", "instanceB");
+      REQUIRE(matches.numberOfMatches() == 4 + 2);
+      ProductResolverIndex indexEmptyProcess = matches.index(0);
+      ProductResolverIndex indexSkipCurrentProcess = matches.index(1);
+      ProductResolverIndex indexB = matches.index(2);
+      ProductResolverIndex indexB1 = matches.index(3);
+      ProductResolverIndex indexB2 = matches.index(4);
+      ProductResolverIndex indexB3 = matches.index(5);
+      REQUIRE_THROWS_AS(matches.index(6), cms::Exception);
+      REQUIRE(indexB == 0);
+      REQUIRE(indexB1 == 5);
+      REQUIRE(indexB2 == 7);
+      REQUIRE(indexB3 == 6);
+      REQUIRE(indexEmptyProcess == indexB);
+      REQUIRE(indexSkipCurrentProcess == indexB);
+
+      REQUIRE(std::string(matches.moduleLabel(5)) == "labelB");
+      REQUIRE(std::string(matches.productInstanceName(5)) == "instanceB");
+      REQUIRE(std::string(matches.processName(5)) == "processB3");
+      REQUIRE(std::string(matches.processName(0)) == "");
     }
-    {
-      auto indexToModules = helper.indiciesForModulesInProcess("processB2");
-      REQUIRE(indexToModules.size() == 1);
-    }
-    {
-      auto indexToModules = helper.indiciesForModulesInProcess("processB3");
-      REQUIRE(indexToModules.size() == 1);
-    }
-    {
-      auto indexToModules = helper.indiciesForModulesInProcess("processC");
-      REQUIRE(indexToModules.size() == 3);
+    SECTION("many types and entries") {
+      edm::ProductResolverIndexHelper helper;
+
+      TypeID typeIDProductID(typeid(ProductID));
+      TypeID typeIDEventID(typeid(EventID));
+      TypeID typeIDVectorInt(typeid(std::vector<int>));
+      TypeID typeIDSetInt(typeid(std::set<int>));
+      TypeID typeIDVSimpleDerived(typeid(std::vector<edmtest::SimpleDerived>));
+      // order of indicies: <full process> [ same but for each element type]
+      helper.insert(typeIDVectorInt, "labelC", "instanceC", "processC");  // 0,
+      helper.insert(typeIDVectorInt, "label", "instance", "process");     // 1,
+      helper.insert(typeIDEventID, "labelB", "instanceB", "processB");    // 2,
+      helper.insert(typeIDEventID, "label", "instanceB", "processB");     // 3,
+      helper.insert(typeIDEventID, "labelX", "instanceB", "processB");    // 4,
+      helper.insert(typeIDEventID, "labelB", "instance", "processB");     // 5,
+      helper.insert(typeIDEventID, "labelB", "instanceX", "processB");    // 6,
+      helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");   // 7,
+      helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");   // 8,
+      helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");   // 9,
+      helper.insert(typeIDProductID, "label", "instance", "process");     // 10,
+      helper.insert(typeIDEventID, "label", "instance", "process");       // 11,
+      helper.insert(typeIDProductID, "labelA", "instanceA", "processA");  // 12
+      REQUIRE_THROWS_AS(helper.insert(typeIDProductID, "labelA", "instanceA", "processA"),
+                        cms::Exception);  // duplicate
+
+      helper.insert(typeIDSetInt, "labelC", "instanceC", "processC");  // 13
+
+      helper.insert(typeIDVSimpleDerived, "labelC", "instanceC", "processC");  // 14
+
+      {
+        std::vector<std::string> processNames = {
+            "processC", "process", "processB", "processB1", "processB2", "processB3", "processA"};
+        helper.setFrozen(processNames);
+      }
+
+      TypeID typeID_int(typeid(int));
+      REQUIRE(helper.index(ELEMENT_TYPE, typeID_int, "labelC", "instanceC", "processC") ==
+              ProductResolverIndexAmbiguous);
+      REQUIRE(helper.index(ELEMENT_TYPE, typeID_int, "labelC", "instanceC", "processQ") == ProductResolverIndexInvalid);
+      REQUIRE(helper.index(ELEMENT_TYPE, typeID_int, "labelC", "instanceC") == ProductResolverIndexAmbiguous);
+
+      TypeID typeID_vint(typeid(std::vector<int>));
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_vint, "labelC", "instanceC", "processC") == 0);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_vint, "labelC", "instanceC") == 0);  //only one with no process
+
+      TypeID typeID_sint(typeid(std::set<int>));
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_sint, "labelC", "instanceC", "processC") == 13);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_sint, "labelC", "instanceC") == 13);  //only one with no process
+
+      TypeID typeID_Simple(typeid(edmtest::Simple));
+      REQUIRE(helper.index(ELEMENT_TYPE, typeID_Simple, "labelC", "instanceC") == 14);  //only one with no process
+      REQUIRE(helper.index(ELEMENT_TYPE, typeID_Simple, "labelC", "instanceC", "processC") == 14);
+
+      TypeID typeID_SimpleDerived(typeid(edmtest::SimpleDerived));
+      REQUIRE(helper.index(ELEMENT_TYPE, typeID_SimpleDerived, "labelC", "instanceC") ==
+              14);  //only one with no process
+      REQUIRE(helper.index(ELEMENT_TYPE, typeID_SimpleDerived, "labelC", "instanceC", "processC") == 14);
+
+      TypeID typeID_VSimpleDerived(typeid(std::vector<edmtest::SimpleDerived>));
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_VSimpleDerived, "labelC", "instanceC") ==
+              14);  //only one with no process
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_VSimpleDerived, "labelC", "instanceC", "processC") == 14);
+
+      auto matches = helper.relatedIndexes(PRODUCT_TYPE, typeID_EventID, "labelB", "instanceB");
+      REQUIRE(matches.numberOfMatches() == 4 + 2);  //4 process matches + 1 empty and 1 skip current process
+      ProductResolverIndex indexEmptyProcess = matches.index(0);
+      ProductResolverIndex indexSkipCurrentProcess = matches.index(1);
+      ProductResolverIndex indexB = matches.index(2);
+      ProductResolverIndex indexB1 = matches.index(3);
+      ProductResolverIndex indexB2 = matches.index(4);
+      ProductResolverIndex indexB3 = matches.index(5);
+      REQUIRE_THROWS_AS(matches.index(6), cms::Exception);
+      REQUIRE(indexEmptyProcess == 2);
+      REQUIRE(indexSkipCurrentProcess == 2);
+      REQUIRE(indexB == 2);
+      REQUIRE(indexB1 == 7);
+      REQUIRE(indexB2 == 9);
+      REQUIRE(indexB3 == 8);
+
+      REQUIRE(std::string(matches.moduleLabel(5)) == "labelB");
+      REQUIRE(std::string(matches.productInstanceName(5)) == "instanceB");
+      REQUIRE(std::string(matches.processName(5)) == "processB3");
+      REQUIRE(std::string(matches.processName(0)) == "");
+
+      {
+        auto indexToModules = helper.indiciesForModulesInProcess("processA");
+        REQUIRE(indexToModules.size() == 1);
+      }
+      {
+        auto indexToModules = helper.indiciesForModulesInProcess("processB");
+        REQUIRE(indexToModules.size() == 5);
+      }
+      {
+        auto indexToModules = helper.indiciesForModulesInProcess("processB1");
+        REQUIRE(indexToModules.size() == 1);
+      }
+      {
+        auto indexToModules = helper.indiciesForModulesInProcess("processB2");
+        REQUIRE(indexToModules.size() == 1);
+      }
+      {
+        auto indexToModules = helper.indiciesForModulesInProcess("processB3");
+        REQUIRE(indexToModules.size() == 1);
+      }
+      {
+        auto indexToModules = helper.indiciesForModulesInProcess("processC");
+        REQUIRE(indexToModules.size() == 3);
+      }
     }
   }
 }

--- a/DataFormats/Provenance/test/productResolverIndexHelper_t.cpp
+++ b/DataFormats/Provenance/test/productResolverIndexHelper_t.cpp
@@ -14,6 +14,9 @@
 #include <iomanip>
 
 using namespace edm;
+namespace {
+  constexpr auto skipCurrentProcessLabel = edm::ProductResolverIndexHelper::skipCurrentProcessLabel();
+}
 
 TEST_CASE("ProductResolverIndexHelper", "[ProductResolverIndexHelper]") {
   TypeID typeID_ProductID(typeid(ProductID));
@@ -79,7 +82,8 @@ TEST_CASE("ProductResolverIndexHelper", "[ProductResolverIndexHelper]") {
       REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA") == indexWithProcess);
       REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "") == indexWithProcess);
       REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", 0) == indexWithProcess);
-      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "#") == indexSkipCurrentProcess);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", skipCurrentProcessLabel) ==
+              indexSkipCurrentProcess);
       REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "processA") == indexWithProcess);
 
       REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instance", "processA") ==
@@ -154,7 +158,8 @@ TEST_CASE("ProductResolverIndexHelper", "[ProductResolverIndexHelper]") {
       REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA") == indexWithProcess);
       REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "") == indexWithProcess);
       REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", 0) == indexWithProcess);
-      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "#") == indexSkipCurrentProcess);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", skipCurrentProcessLabel) ==
+              indexSkipCurrentProcess);
       REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "processA") == indexWithProcess);
 
       REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instance", "processA") ==
@@ -216,7 +221,8 @@ TEST_CASE("ProductResolverIndexHelper", "[ProductResolverIndexHelper]") {
       REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA") == indexWithProcessB);
       REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "") == indexWithProcessB);
       REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", 0) == indexWithProcessB);
-      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "#") == indexSkipCurrentProcess);
+      REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", skipCurrentProcessLabel) ==
+              indexSkipCurrentProcess);
       REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "processA") == indexWithProcessA);
       REQUIRE(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "processB") == indexWithProcessB);
     }

--- a/DataFormats/StdDictionaries/src/classes_def_others.xml
+++ b/DataFormats/StdDictionaries/src/classes_def_others.xml
@@ -25,5 +25,5 @@
  <class name="std::set<std::basic_string<char> >"/>
  <class name="std::atomic<int>"/>
  <class name="std::__atomic_base<int>"/>
-<class name="std::monostate"/>
+ <class name="std::monostate"/>
 </lcgdict>

--- a/DataFormats/StdDictionaries/src/classes_def_others.xml
+++ b/DataFormats/StdDictionaries/src/classes_def_others.xml
@@ -25,5 +25,5 @@
  <class name="std::set<std::basic_string<char> >"/>
  <class name="std::atomic<int>"/>
  <class name="std::__atomic_base<int>"/>
-<!-- <class name="std::monostate"/>-->
+<class name="std::monostate"/>
 </lcgdict>

--- a/DataFormats/StdDictionaries/src/classes_def_others.xml
+++ b/DataFormats/StdDictionaries/src/classes_def_others.xml
@@ -25,5 +25,5 @@
  <class name="std::set<std::basic_string<char> >"/>
  <class name="std::atomic<int>"/>
  <class name="std::__atomic_base<int>"/>
- <class name="std::monostate"/>
+<!-- <class name="std::monostate"/>-->
 </lcgdict>

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -118,14 +118,12 @@ namespace edm {
     BasicHandle getByToken(KindOfType kindOfType,
                            TypeID const& typeID,
                            ProductResolverIndex index,
-                           bool skipCurrentProcess,
                            bool& ambiguous,
                            SharedResourcesAcquirer* sra,
                            ModuleCallingContext const* mcc) const;
 
     void prefetchAsync(WaitingTaskHolder waitTask,
                        ProductResolverIndex index,
-                       bool skipCurrentProcess,
                        ServiceToken const& token,
                        ModuleCallingContext const* mcc) const;
 

--- a/FWCore/Framework/interface/ProductResolverBase.h
+++ b/FWCore/Framework/interface/ProductResolverBase.h
@@ -58,21 +58,19 @@ namespace edm {
     ProductResolverBase& operator=(ProductResolverBase const&) = delete;  // Disallow copying and moving
 
     Resolution resolveProduct(Principal const& principal,
-                              bool skipCurrentProcess,
                               SharedResourcesAcquirer* sra,
                               ModuleCallingContext const* mcc) const {
-      return resolveProduct_(principal, skipCurrentProcess, sra, mcc);
+      return resolveProduct_(principal, sra, mcc);
     }
 
     /** oDataFetchedIsValid is allowed to be nullptr in which case no value will be assigned
      */
     void prefetchAsync(WaitingTaskHolder waitTask,
                        Principal const& principal,
-                       bool skipCurrentProcess,
                        ServiceToken const& token,
                        SharedResourcesAcquirer* sra,
                        ModuleCallingContext const* mcc) const noexcept {
-      return prefetchAsync_(waitTask, principal, skipCurrentProcess, token, sra, mcc);
+      return prefetchAsync_(waitTask, principal, token, sra, mcc);
     }
 
     void retrieveAndMerge(Principal const& principal,
@@ -99,9 +97,7 @@ namespace edm {
     // Product was deleted early in order to save memory
     bool productWasDeleted() const { return productWasDeleted_(); }
 
-    bool productWasFetchedAndIsValid(bool iSkipCurrentProcess) const {
-      return productWasFetchedAndIsValid_(iSkipCurrentProcess);
-    }
+    bool productWasFetchedAndIsValid() const { return productWasFetchedAndIsValid_(); }
 
     // Retrieves pointer to the per event(lumi)(run) provenance.
     ProductProvenance const* productProvenancePtr() const { return productProvenancePtr_(); }
@@ -164,12 +160,10 @@ namespace edm {
 
   private:
     virtual Resolution resolveProduct_(Principal const& principal,
-                                       bool skipCurrentProcess,
                                        SharedResourcesAcquirer* sra,
                                        ModuleCallingContext const* mcc) const = 0;
     virtual void prefetchAsync_(WaitingTaskHolder waitTask,
                                 Principal const& principal,
-                                bool skipCurrentProcess,
                                 ServiceToken const& token,
                                 SharedResourcesAcquirer* sra,
                                 ModuleCallingContext const* mcc) const noexcept = 0;
@@ -181,7 +175,7 @@ namespace edm {
     virtual bool productUnavailable_() const = 0;
     virtual bool productResolved_() const = 0;
     virtual bool productWasDeleted_() const = 0;
-    virtual bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const = 0;
+    virtual bool productWasFetchedAndIsValid_() const = 0;
 
     virtual ProductDescription const& productDescription_() const = 0;
     virtual void resetProductDescription_(std::shared_ptr<ProductDescription const> bd) = 0;

--- a/FWCore/Framework/interface/SignallingProductRegistryFiller.h
+++ b/FWCore/Framework/interface/SignallingProductRegistryFiller.h
@@ -80,6 +80,8 @@ namespace edm {
       registry_.setProcessOrder(std::vector<std::string>(1, processOrder));
     }
 
+    void setProcessOrder(std::vector<std::string> const& processOrder) { registry_.setProcessOrder(processOrder); }
+
     template <class T>
     void watchProductAdditions(const T& iFunc) {
       serviceregistry::connect_but_block_self(productAddedSignal_, iFunc);

--- a/FWCore/Framework/src/DroppedDataProductResolver.cc
+++ b/FWCore/Framework/src/DroppedDataProductResolver.cc
@@ -6,15 +6,11 @@
 namespace edm {
 
   DroppedDataProductResolver::Resolution DroppedDataProductResolver::resolveProduct_(
-      Principal const& principal,
-      bool skipCurrentProcess,
-      SharedResourcesAcquirer* sra,
-      ModuleCallingContext const* mcc) const {
+      Principal const& principal, SharedResourcesAcquirer* sra, ModuleCallingContext const* mcc) const {
     return Resolution(nullptr);
   }
   void DroppedDataProductResolver::prefetchAsync_(WaitingTaskHolder waitTask,
                                                   Principal const& principal,
-                                                  bool skipCurrentProcess,
                                                   ServiceToken const& token,
                                                   SharedResourcesAcquirer* sra,
                                                   ModuleCallingContext const* mcc) const noexcept {}

--- a/FWCore/Framework/src/DroppedDataProductResolver.h
+++ b/FWCore/Framework/src/DroppedDataProductResolver.h
@@ -19,12 +19,10 @@ namespace edm {
 
   private:
     Resolution resolveProduct_(Principal const& principal,
-                               bool skipCurrentProcess,
                                SharedResourcesAcquirer* sra,
                                ModuleCallingContext const* mcc) const final;
     void prefetchAsync_(WaitingTaskHolder waitTask,
                         Principal const& principal,
-                        bool skipCurrentProcess,
                         ServiceToken const& token,
                         SharedResourcesAcquirer* sra,
                         ModuleCallingContext const* mcc) const noexcept final;
@@ -34,7 +32,7 @@ namespace edm {
     bool productUnavailable_() const final { return true; }
     bool productResolved_() const final { return true; }
     bool productWasDeleted_() const final { return false; }
-    bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const final { return false; }
+    bool productWasFetchedAndIsValid_() const final { return false; }
     bool unscheduledWasNotRun_() const final { return false; }
     void resetProductData_(bool deleteEarly) final {}
     ProductDescription const& productDescription_() const final { return m_provenance.productDescription(); }

--- a/FWCore/Framework/src/DroppedDataProductResolver.h
+++ b/FWCore/Framework/src/DroppedDataProductResolver.h
@@ -13,7 +13,7 @@ namespace edm {
   class DroppedDataProductResolver : public ProductResolverBase {
   public:
     DroppedDataProductResolver(std::shared_ptr<ProductDescription const> bd)
-        : ProductResolverBase(), m_provenance(std::move(bd), {}) {}
+        : ProductResolverBase(), m_provenance(bd, {}) {}
 
     void connectTo(ProductResolverBase const&, Principal const*) final {}
 

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -127,12 +127,14 @@ void EDConsumerBase::updateLookup(BranchType iBranchType,
       if (itInfo->m_branchType == iBranchType) {
         const unsigned int labelStart = itLabels->m_startOfModuleLabel;
         const char* moduleLabel = &(m_tokenLabels[labelStart]);
-        itInfo->m_index = ProductResolverIndexAndSkipBit(iHelper.index(*itKind,
-                                                                       itInfo->m_type,
-                                                                       moduleLabel,
-                                                                       moduleLabel + itLabels->m_deltaToProductInstance,
-                                                                       moduleLabel + itLabels->m_deltaToProcessName),
-                                                         itInfo->m_index.skipCurrentProcess());
+        const char* processName = moduleLabel + itLabels->m_deltaToProcessName;
+        if (itInfo->m_index.skipCurrentProcess()) {
+          processName = "#";
+        }
+        itInfo->m_index = ProductResolverIndexAndSkipBit(
+            iHelper.index(
+                *itKind, itInfo->m_type, moduleLabel, moduleLabel + itLabels->m_deltaToProductInstance, processName),
+            itInfo->m_index.skipCurrentProcess());
       }
     }
   }
@@ -268,7 +270,7 @@ ProductResolverIndexAndSkipBit EDConsumerBase::indexFromIfExactMatch(EDGetToken 
       return info.m_index;
     }
   }
-  return ProductResolverIndexAndSkipBit(edm::ProductResolverIndexInvalid, false);
+  return ProductResolverIndexAndSkipBit(edm::ProductResolverIndexInitializing, false);
 }
 
 EDGetToken EDConsumerBase::getRegisteredToken(TypeID const& typeID,

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -129,7 +129,7 @@ void EDConsumerBase::updateLookup(BranchType iBranchType,
         const char* moduleLabel = &(m_tokenLabels[labelStart]);
         const char* processName = moduleLabel + itLabels->m_deltaToProcessName;
         if (itInfo->m_index.skipCurrentProcess()) {
-          processName = "#";
+          processName = iHelper.skipCurrentProcessLabel();
         }
         itInfo->m_index = ProductResolverIndexAndSkipBit(
             iHelper.index(

--- a/FWCore/Framework/src/EDLooperBase.cc
+++ b/FWCore/Framework/src/EDLooperBase.cc
@@ -201,9 +201,8 @@ namespace edm {
 
     for (auto const& item : items) {
       ProductResolverIndex productResolverIndex = item.productResolverIndex();
-      bool skipCurrentProcess = item.skipCurrentProcess();
       if (productResolverIndex != ProductResolverIndexAmbiguous) {
-        iPrincipal.prefetchAsync(iTask, productResolverIndex, skipCurrentProcess, token, &moduleCallingContext_);
+        iPrincipal.prefetchAsync(iTask, productResolverIndex, token, &moduleCallingContext_);
       }
     }
   }

--- a/FWCore/Framework/src/EventForTransformer.cc
+++ b/FWCore/Framework/src/EventForTransformer.cc
@@ -16,7 +16,7 @@ namespace edm {
 
   BasicHandle EventForTransformer::get(edm::TypeID const& iTypeID, ProductResolverIndex iIndex) const {
     bool amb = false;
-    return eventPrincipal_.getByToken(PRODUCT_TYPE, iTypeID, iIndex, false, amb, nullptr, &mcc_);
+    return eventPrincipal_.getByToken(PRODUCT_TYPE, iTypeID, iIndex, amb, nullptr, &mcc_);
   }
 
   void EventForTransformer::put(ProductResolverIndex index,

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -283,7 +283,7 @@ namespace edm {
         return whyFailed;
       }));
     }
-    auto resolution = phb->resolveProduct(*this, false, nullptr, nullptr);
+    auto resolution = phb->resolveProduct(*this, nullptr, nullptr);
 
     auto data = resolution.data();
     if (data) {
@@ -370,7 +370,7 @@ namespace edm {
           << "EventPrincipal::getThinnedAssociation, ThinnedAssociation ProductResolver cannot be found\n"
           << "This should never happen. Contact a Framework developer";
     }
-    ProductData const* productData = (phb->resolveProduct(*this, false, nullptr, nullptr)).data();
+    ProductData const* productData = (phb->resolveProduct(*this, nullptr, nullptr)).data();
     if (productData == nullptr) {
       return nullptr;
     }

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1615,8 +1615,7 @@ namespace edm {
 
           for (auto const& item : items) {
             ProductResolverIndex productResolverIndex = item.productResolverIndex();
-            bool skipCurrentProcess = item.skipCurrentProcess();
-            iPrincipal.prefetchAsync(iTask, productResolverIndex, skipCurrentProcess, iServiceToken, nullptr);
+            iPrincipal.prefetchAsync(iTask, productResolverIndex, iServiceToken, nullptr);
           }
         }
       }

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -457,7 +457,7 @@ namespace edm {
       if (inputTag.process() == InputTag::kCurrentProcess) {
         processName = &processConfiguration_->processName();
       }
-      std::string const kSkipCurrentProcess = "#";
+      std::string const kSkipCurrentProcess = ProductResolverIndexHelper::skipCurrentProcessLabel();
       if (skipCurrentProcess) {
         processName = &kSkipCurrentProcess;
       }
@@ -481,7 +481,7 @@ namespace edm {
     if (index == ProductResolverIndexInitializing) {
       char const* processName = inputTag.process().c_str();
       if (skipCurrentProcess) {
-        processName = "#";
+        processName = ProductResolverIndexHelper::skipCurrentProcessLabel();
       } else if (inputTag.process() == InputTag::kCurrentProcess) {
         processName = processConfiguration_->processName().c_str();
       }

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -495,6 +495,9 @@ namespace edm {
                                 inputTag.instance(),
                                 appendCurrentProcessIfAlias(inputTag.process(), processConfiguration_->processName()));
       } else if (index == ProductResolverIndexInvalid) {
+        if (not consumer) {
+          return nullptr;
+        }
         // can occur because of missing consumes if nothing else in the process consumes the product
         for (auto const& item : preg_->productList()) {
           auto const& bd = item.second;

--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -147,7 +147,6 @@ namespace edm {
                                                ModuleCallingContext const* mcc) const {
     ProductResolverIndexAndSkipBit indexAndBit = consumer_->indexFrom(token, branchType(), id);
     ProductResolverIndex index = indexAndBit.productResolverIndex();
-    bool skipCurrentProcess = indexAndBit.skipCurrentProcess();
     if (UNLIKELY(index == ProductResolverIndexInvalid)) {
       return makeFailToGetException(kindOfType, id, token);
     } else if (UNLIKELY(index == ProductResolverIndexAmbiguous)) {
@@ -155,8 +154,7 @@ namespace edm {
       throwAmbiguousException(id, token);
     }
     bool ambiguous = false;
-    BasicHandle h =
-        principal_.getByToken(kindOfType, id, index, skipCurrentProcess, ambiguous, resourcesAcquirer_, mcc);
+    BasicHandle h = principal_.getByToken(kindOfType, id, index, ambiguous, resourcesAcquirer_, mcc);
     if (ambiguous) {
       // This deals with ambiguities where the process is not specified
       throwAmbiguousException(id, token);

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -26,10 +26,6 @@
 #include <cassert>
 #include <utility>
 
-static constexpr unsigned int kUnsetOffset = 0;
-static constexpr unsigned int kAmbiguousOffset = 1;
-static constexpr unsigned int kMissingOffset = 2;
-
 namespace edm {
 
   void DataManagingProductResolver::throwProductDeletedException() const {

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -84,7 +84,7 @@ namespace edm {
     bool productUnavailable_() const final;
     bool productResolved_() const final;
     bool productWasDeleted_() const final;
-    bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const final;
+    bool productWasFetchedAndIsValid_() const final;
 
     ProductDescription const& productDescription_() const final { return *getProductData().productDescription(); }
     void resetProductDescription_(std::shared_ptr<ProductDescription const> bd) final {
@@ -130,12 +130,10 @@ namespace edm {
     bool isFromCurrentProcess() const final;
 
     Resolution resolveProduct_(Principal const& principal,
-                               bool skipCurrentProcess,
                                SharedResourcesAcquirer* sra,
                                ModuleCallingContext const* mcc) const override;
     void prefetchAsync_(WaitingTaskHolder waitTask,
                         Principal const& principal,
-                        bool skipCurrentProcess,
                         ServiceToken const& token,
                         SharedResourcesAcquirer* sra,
                         ModuleCallingContext const* mcc) const noexcept override;
@@ -169,12 +167,10 @@ namespace edm {
     void putOrMergeProduct(std::unique_ptr<WrapperBase> prod) const override;
 
     Resolution resolveProduct_(Principal const& principal,
-                               bool skipCurrentProcess,
                                SharedResourcesAcquirer* sra,
                                ModuleCallingContext const* mcc) const final;
     void prefetchAsync_(WaitingTaskHolder waitTask,
                         Principal const& principal,
-                        bool skipCurrentProcess,
                         ServiceToken const& token,
                         SharedResourcesAcquirer* sra,
                         ModuleCallingContext const* mcc) const noexcept final;
@@ -207,12 +203,10 @@ namespace edm {
 
   private:
     Resolution resolveProduct_(Principal const& principal,
-                               bool skipCurrentProcess,
                                SharedResourcesAcquirer* sra,
                                ModuleCallingContext const* mcc) const override;
     void prefetchAsync_(WaitingTaskHolder waitTask,
                         Principal const& principal,
-                        bool skipCurrentProcess,
                         ServiceToken const& token,
                         SharedResourcesAcquirer* sra,
                         ModuleCallingContext const* mcc) const noexcept override;
@@ -235,12 +229,10 @@ namespace edm {
 
   private:
     Resolution resolveProduct_(Principal const& principal,
-                               bool skipCurrentProcess,
                                SharedResourcesAcquirer* sra,
                                ModuleCallingContext const* mcc) const override;
     void prefetchAsync_(WaitingTaskHolder waitTask,
                         Principal const& principal,
-                        bool skipCurrentProcess,
                         ServiceToken const& token,
                         SharedResourcesAcquirer* sra,
                         ModuleCallingContext const* mcc) const noexcept override;
@@ -264,12 +256,10 @@ namespace edm {
   private:
     void putProduct(std::unique_ptr<WrapperBase> edp) const override;
     Resolution resolveProduct_(Principal const& principal,
-                               bool skipCurrentProcess,
                                SharedResourcesAcquirer* sra,
                                ModuleCallingContext const* mcc) const override;
     void prefetchAsync_(WaitingTaskHolder waitTask,
                         Principal const& principal,
-                        bool skipCurrentProcess,
                         ServiceToken const& token,
                         SharedResourcesAcquirer* sra,
                         ModuleCallingContext const* mcc) const noexcept override;
@@ -298,26 +288,22 @@ namespace edm {
 
   private:
     Resolution resolveProduct_(Principal const& principal,
-                               bool skipCurrentProcess,
                                SharedResourcesAcquirer* sra,
                                ModuleCallingContext const* mcc) const override {
-      return realProduct_.resolveProduct(principal, skipCurrentProcess, sra, mcc);
+      return realProduct_.resolveProduct(principal, sra, mcc);
     }
     void prefetchAsync_(WaitingTaskHolder waitTask,
                         Principal const& principal,
-                        bool skipCurrentProcess,
                         ServiceToken const& token,
                         SharedResourcesAcquirer* sra,
                         ModuleCallingContext const* mcc) const noexcept override {
-      realProduct_.prefetchAsync(waitTask, principal, skipCurrentProcess, token, sra, mcc);
+      realProduct_.prefetchAsync(waitTask, principal, token, sra, mcc);
     }
     bool unscheduledWasNotRun_() const override { return realProduct_.unscheduledWasNotRun(); }
     bool productUnavailable_() const override { return realProduct_.productUnavailable(); }
     bool productResolved_() const final { return realProduct_.productResolved(); }
     bool productWasDeleted_() const override { return realProduct_.productWasDeleted(); }
-    bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const final {
-      return realProduct_.productWasFetchedAndIsValid(iSkipCurrentProcess);
-    }
+    bool productWasFetchedAndIsValid_() const final { return realProduct_.productWasFetchedAndIsValid(); }
 
     ProductDescription const& productDescription_() const override { return *bd_; }
     void resetProductDescription_(std::shared_ptr<ProductDescription const> bd) override { bd_ = bd; }
@@ -357,9 +343,7 @@ namespace edm {
   private:
     bool productResolved_() const final;
     bool productWasDeleted_() const final { return realProduct_.productWasDeleted(); }
-    bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const final {
-      return realProduct_.productWasFetchedAndIsValid(iSkipCurrentProcess);
-    }
+    bool productWasFetchedAndIsValid_() const final { return realProduct_.productWasFetchedAndIsValid(); }
     ProductDescription const& productDescription_() const final {
       return *productData_.productDescription();
       ;
@@ -394,12 +378,10 @@ namespace edm {
 
   private:
     Resolution resolveProduct_(Principal const& principal,
-                               bool skipCurrentProcess,
                                SharedResourcesAcquirer* sra,
                                ModuleCallingContext const* mcc) const final;
     void prefetchAsync_(WaitingTaskHolder waitTask,
                         Principal const& principal,
-                        bool skipCurrentProcess,
                         ServiceToken const& token,
                         SharedResourcesAcquirer* sra,
                         ModuleCallingContext const* mcc) const noexcept final;
@@ -425,130 +407,15 @@ namespace edm {
 
   private:
     Resolution resolveProduct_(Principal const& principal,
-                               bool skipCurrentProcess,
                                SharedResourcesAcquirer* sra,
                                ModuleCallingContext const* mcc) const final;
     void prefetchAsync_(WaitingTaskHolder waitTask,
                         Principal const& principal,
-                        bool skipCurrentProcess,
                         ServiceToken const& token,
                         SharedResourcesAcquirer* sra,
                         ModuleCallingContext const* mcc) const noexcept final;
     bool unscheduledWasNotRun_() const final { return realProduct().unscheduledWasNotRun(); }
     bool productUnavailable_() const final { return realProduct().productUnavailable(); }
-  };
-
-  class NoProcessProductResolver : public ProductResolverBase {
-  public:
-    typedef ProducedProductResolver::ProductStatus ProductStatus;
-    NoProcessProductResolver(std::vector<ProductResolverIndex> const& matchingHolders,
-                             std::vector<bool> const& ambiguous,
-                             bool madeAtEnd);
-
-    void connectTo(ProductResolverBase const& iOther, Principal const*) final;
-
-    void tryPrefetchResolverAsync(unsigned int iProcessingIndex,
-                                  Principal const& principal,
-                                  bool skipCurrentProcess,
-                                  SharedResourcesAcquirer* sra,
-                                  ModuleCallingContext const* mcc,
-                                  ServiceToken token,
-                                  oneapi::tbb::task_group*) const noexcept;
-
-    bool dataValidFromResolver(unsigned int iProcessingIndex,
-                               Principal const& principal,
-                               bool iSkipCurrentProcess) const;
-
-    void prefetchFailed(unsigned int iProcessingIndex,
-                        Principal const& principal,
-                        bool iSkipCurrentProcess,
-                        std::exception_ptr iExceptPtr) const;
-
-  private:
-    unsigned int unsetIndexValue() const;
-    Resolution resolveProduct_(Principal const& principal,
-                               bool skipCurrentProcess,
-                               SharedResourcesAcquirer* sra,
-                               ModuleCallingContext const* mcc) const override;
-    void prefetchAsync_(WaitingTaskHolder waitTask,
-                        Principal const& principal,
-                        bool skipCurrentProcess,
-                        ServiceToken const& token,
-                        SharedResourcesAcquirer* sra,
-                        ModuleCallingContext const* mcc) const noexcept override;
-    bool unscheduledWasNotRun_() const override;
-    bool productUnavailable_() const override;
-    bool productWasDeleted_() const override;
-    bool productResolved_() const final;
-    bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const override;
-
-    ProductDescription const& productDescription_() const override;
-    void resetProductDescription_(std::shared_ptr<ProductDescription const> bd) override;
-    Provenance const* provenance_() const override;
-
-    std::string const& resolvedModuleLabel_() const override { return moduleLabel(); }
-    void setProductProvenanceRetriever_(ProductProvenanceRetriever const* provRetriever) override;
-    void setProductID_(ProductID const& pid) override;
-    ProductProvenance const* productProvenancePtr_() const override;
-    void resetProductData_(bool deleteEarly) override;
-    bool singleProduct_() const override;
-
-    Resolution tryResolver(unsigned int index,
-                           Principal const& principal,
-                           bool skipCurrentProcess,
-                           SharedResourcesAcquirer* sra,
-                           ModuleCallingContext const* mcc) const;
-
-    void setCache(bool skipCurrentProcess, ProductResolverIndex index, std::exception_ptr exceptionPtr) const;
-
-    std::vector<ProductResolverIndex> matchingHolders_;
-    std::vector<bool> ambiguous_;
-    CMS_THREAD_SAFE mutable WaitingTaskList waitingTasks_;
-    CMS_THREAD_SAFE mutable WaitingTaskList skippingWaitingTasks_;
-    mutable std::atomic<unsigned int> lastCheckIndex_;
-    mutable std::atomic<unsigned int> lastSkipCurrentCheckIndex_;
-    mutable std::atomic<bool> prefetchRequested_;
-    mutable std::atomic<bool> skippingPrefetchRequested_;
-    const bool madeAtEnd_;
-  };
-
-  class SingleChoiceNoProcessProductResolver : public ProductResolverBase {
-  public:
-    typedef ProducedProductResolver::ProductStatus ProductStatus;
-    SingleChoiceNoProcessProductResolver(ProductResolverIndex iChoice)
-        : ProductResolverBase(), realResolverIndex_(iChoice) {}
-
-    void connectTo(ProductResolverBase const& iOther, Principal const*) final;
-
-  private:
-    Resolution resolveProduct_(Principal const& principal,
-                               bool skipCurrentProcess,
-                               SharedResourcesAcquirer* sra,
-                               ModuleCallingContext const* mcc) const override;
-    void prefetchAsync_(WaitingTaskHolder waitTask,
-                        Principal const& principal,
-                        bool skipCurrentProcess,
-                        ServiceToken const& token,
-                        SharedResourcesAcquirer* sra,
-                        ModuleCallingContext const* mcc) const noexcept override;
-    bool unscheduledWasNotRun_() const override;
-    bool productUnavailable_() const override;
-    bool productWasDeleted_() const override;
-    bool productResolved_() const final;
-    bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const override;
-
-    ProductDescription const& productDescription_() const override;
-    void resetProductDescription_(std::shared_ptr<ProductDescription const> bd) override;
-    Provenance const* provenance_() const override;
-
-    std::string const& resolvedModuleLabel_() const override { return moduleLabel(); }
-    void setProductProvenanceRetriever_(ProductProvenanceRetriever const* provRetriever) override;
-    void setProductID_(ProductID const& pid) override;
-    ProductProvenance const* productProvenancePtr_() const override;
-    void resetProductData_(bool deleteEarly) override;
-    bool singleProduct_() const override;
-
-    ProductResolverIndex realResolverIndex_;
   };
 
 }  // namespace edm

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -136,11 +136,9 @@ namespace edm {
 
     for (auto const& item : items) {
       ProductResolverIndex productResolverIndex = item.productResolverIndex();
-      bool skipCurrentProcess = item.skipCurrentProcess();
       if (productResolverIndex != ProductResolverIndexAmbiguous and
           productResolverIndex != ProductResolverIndexInvalid) {
-        iPrincipal->prefetchAsync(
-            choiceHolder, productResolverIndex, skipCurrentProcess, token, &moduleCallingContext_);
+        iPrincipal->prefetchAsync(choiceHolder, productResolverIndex, token, &moduleCallingContext_);
       }
     }
     choiceHolder.doneWaiting(std::exception_ptr{});
@@ -179,9 +177,8 @@ namespace edm {
 
     for (auto const& item : items) {
       ProductResolverIndex productResolverIndex = item.productResolverIndex();
-      bool skipCurrentProcess = item.skipCurrentProcess();
       if (productResolverIndex != ProductResolverIndexAmbiguous) {
-        iPrincipal.prefetchAsync(iTask, productResolverIndex, skipCurrentProcess, token, &moduleCallingContext_);
+        iPrincipal.prefetchAsync(iTask, productResolverIndex, token, &moduleCallingContext_);
       }
     }
   }
@@ -213,7 +210,7 @@ namespace edm {
     //pre prefetch signal
     actReg_->preModuleTransformPrefetchingSignal_.emit(*mcc.getStreamContext(), mcc);
     iPrincipal.prefetchAsync(
-        WaitingTaskHolder(*iTask.group(), task), itemToGetForTransform(iTransformIndex), false, iToken, &mcc);
+        WaitingTaskHolder(*iTask.group(), task), itemToGetForTransform(iTransformIndex), iToken, &mcc);
   }
 
   void Worker::resetModuleDescription(ModuleDescription const* iDesc) {

--- a/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
+++ b/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
@@ -125,27 +125,35 @@ void TestEDConsumerBase::testRegularType() {
   edm::TypeID typeIDSetInt(typeid(std::set<int>));
   edm::TypeID typeIDVSimpleDerived(typeid(std::vector<edmtest::SimpleDerived>));
 
-  helper.insert(typeIDVectorInt, "labelC", "instanceC", "processC");       // 0, 1, 2
-  helper.insert(typeIDVectorInt, "label", "instance", "process");          // 3, 4, 5
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB");         // 6, 7
-  helper.insert(typeIDEventID, "label", "instanceB", "processB");          // 8, 9
-  helper.insert(typeIDEventID, "labelX", "instanceB", "processB");         // 10, 11
-  helper.insert(typeIDEventID, "labelB", "instance", "processB");          // 12, 13
-  helper.insert(typeIDEventID, "labelB", "instanceX", "processB");         // 14, 15
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");        // 16, 5
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");        // 17, 5
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");        // 18, 5
-  helper.insert(typeIDProductID, "label", "instance", "process");          // 19, 20
-  helper.insert(typeIDEventID, "label", "instance", "process");            // 21, 22
-  helper.insert(typeIDProductID, "labelA", "instanceA", "processA");       // 23, 24
-  helper.insert(typeIDSetInt, "labelC", "instanceC", "processC");          // 25, 26
-  helper.insert(typeIDVSimpleDerived, "labelC", "instanceC", "processC");  // 27, 28, 29, 30
+  //ProductResolverIndex
+  helper.insert(typeIDVectorInt, "labelC", "instanceC", "processC");       // 0
+  helper.insert(typeIDVectorInt, "label", "instance", "process");          // 1
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB");         // 2
+  helper.insert(typeIDEventID, "label", "instanceB", "processB");          // 3
+  helper.insert(typeIDEventID, "labelX", "instanceB", "processB");         // 4
+  helper.insert(typeIDEventID, "labelB", "instance", "processB");          // 5
+  helper.insert(typeIDEventID, "labelB", "instanceX", "processB");         // 6
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");        // 7
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");        // 8
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");        // 9
+  helper.insert(typeIDProductID, "label", "instance", "process");          // 10
+  helper.insert(typeIDEventID, "label", "instance", "process");            // 11
+  helper.insert(typeIDProductID, "labelA", "instanceA", "processA");       // 12
+  helper.insert(typeIDSetInt, "labelC", "instanceC", "processC");          // 13
+  helper.insert(typeIDVSimpleDerived, "labelC", "instanceC", "processC");  // 14
 
-  helper.setFrozen("processC");
+  {
+    std::vector<std::string> processNames = {
+        "processC", "process", "processB", "processB1", "processB2", "processB3", "processA"};
+    helper.setFrozen(processNames);
+  }
 
   edm::TypeID typeID_vint(typeid(std::vector<int>));
   const auto vint_c = helper.index(edm::PRODUCT_TYPE, typeID_vint, "labelC", "instanceC", "processC");
+  const auto vint_c_skipCurrent = helper.index(edm::PRODUCT_TYPE, typeID_vint, "labelC", "instanceC", "#");
+  CPPUNIT_ASSERT(edm::ProductResolverIndexInvalid == vint_c_skipCurrent);
   const auto vint_c_no_proc = helper.index(edm::PRODUCT_TYPE, typeID_vint, "labelC", "instanceC", 0);
+  CPPUNIT_ASSERT(vint_c == vint_c_no_proc);
   const auto vint_blank = helper.index(edm::PRODUCT_TYPE, typeID_vint, "label", "instance", "process");
   const auto vint_blank_no_proc = helper.index(edm::PRODUCT_TYPE, typeID_vint, "label", "instance", 0);
   {
@@ -263,7 +271,7 @@ void TestEDConsumerBase::testRegularType() {
     CPPUNIT_ASSERT(intConsumer.m_tokens[0].index() == 0);
     CPPUNIT_ASSERT(intConsumer.m_tokens[1].index() == 1);
 
-    CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_c_no_proc, true) ==
+    CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_c_skipCurrent, true) ==
                    intConsumer.indexFrom(intConsumer.m_tokens[1], edm::InEvent, typeID_vint));
     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_blank_no_proc, false) ==
                    intConsumer.indexFrom(intConsumer.m_tokens[0], edm::InEvent, typeID_vint));
@@ -271,10 +279,10 @@ void TestEDConsumerBase::testRegularType() {
     std::vector<edm::ProductResolverIndexAndSkipBit> indices;
     intConsumer.itemsToGet(edm::InEvent, indices);
 
-    CPPUNIT_ASSERT(2 == indices.size());
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),
+    CPPUNIT_ASSERT(1 == indices.size());
+    CPPUNIT_ASSERT(indices.end() == std::find(indices.begin(),
                                               indices.end(),
-                                              edm::ProductResolverIndexAndSkipBit(vint_c_no_proc, true)));
+                                              edm::ProductResolverIndexAndSkipBit(vint_c_skipCurrent, true)));
     CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),
                                               indices.end(),
                                               edm::ProductResolverIndexAndSkipBit(vint_blank_no_proc, false)));
@@ -325,23 +333,27 @@ void TestEDConsumerBase::testViewType() {
   edm::TypeID typeIDSetInt(typeid(std::set<int>));
   edm::TypeID typeIDVSimpleDerived(typeid(std::vector<edmtest::SimpleDerived>));
 
-  helper.insert(typeIDVectorInt, "labelC", "instanceC", "processC");       // 0, 1, 2
-  helper.insert(typeIDVectorInt, "label", "instance", "process");          // 3, 4, 5
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB");         // 6, 7
-  helper.insert(typeIDEventID, "label", "instanceB", "processB");          // 8, 9
-  helper.insert(typeIDEventID, "labelX", "instanceB", "processB");         // 10, 11
-  helper.insert(typeIDEventID, "labelB", "instance", "processB");          // 12, 13
-  helper.insert(typeIDEventID, "labelB", "instanceX", "processB");         // 14, 15
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");        // 16, 5
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");        // 17, 5
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");        // 18, 5
-  helper.insert(typeIDProductID, "label", "instance", "process");          // 19, 20
-  helper.insert(typeIDEventID, "label", "instance", "process");            // 21, 22
-  helper.insert(typeIDProductID, "labelA", "instanceA", "processA");       // 23, 24
-  helper.insert(typeIDSetInt, "labelC", "instanceC", "processC");          // 25, 26
-  helper.insert(typeIDVSimpleDerived, "labelC", "instanceC", "processC");  // 27, 28, 29, 30
+  helper.insert(typeIDVectorInt, "labelC", "instanceC", "processC");       // 0
+  helper.insert(typeIDVectorInt, "label", "instance", "process");          // 1
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB");         // 2
+  helper.insert(typeIDEventID, "label", "instanceB", "processB");          // 3
+  helper.insert(typeIDEventID, "labelX", "instanceB", "processB");         // 4
+  helper.insert(typeIDEventID, "labelB", "instance", "processB");          // 5
+  helper.insert(typeIDEventID, "labelB", "instanceX", "processB");         // 6
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");        // 7
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");        // 8
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");        // 9
+  helper.insert(typeIDProductID, "label", "instance", "process");          // 10
+  helper.insert(typeIDEventID, "label", "instance", "process");            // 11
+  helper.insert(typeIDProductID, "labelA", "instanceA", "processA");       // 12
+  helper.insert(typeIDSetInt, "labelC", "instanceC", "processC");          // 13
+  helper.insert(typeIDVSimpleDerived, "labelC", "instanceC", "processC");  // 14
 
-  helper.setFrozen("processC");
+  {
+    std::vector<std::string> processNames = {
+        "processC", "process", "processB", "processB1", "processB2", "processB3", "processA"};
+    helper.setFrozen(processNames);
+  }
 
   edm::TypeID typeID_int(typeid(int));
   edm::TypeID typeID_Simple(typeid(edmtest::Simple));
@@ -351,6 +363,8 @@ void TestEDConsumerBase::testViewType() {
 
   const auto v_int_no_proc = helper.index(edm::ELEMENT_TYPE, typeID_int, "label", "instance");
   const auto v_simple_no_proc = helper.index(edm::ELEMENT_TYPE, typeID_Simple, "labelC", "instanceC");
+  CPPUNIT_ASSERT(v_simple_no_proc == v_simple);
+  const auto v_simple_skip = helper.index(edm::ELEMENT_TYPE, typeID_Simple, "labelC", "#");
 
   {
     std::vector<std::pair<edm::TypeToGet, edm::InputTag>> vT = {
@@ -390,19 +404,19 @@ void TestEDConsumerBase::testViewType() {
 
     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(v_int_no_proc, false) ==
                    consumer.indexFrom(consumer.m_tokens[0], edm::InEvent, typeID_int));
-    CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(v_simple_no_proc, true) ==
+    CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(v_simple_skip, true) ==
                    consumer.indexFrom(consumer.m_tokens[1], edm::InEvent, typeID_Simple));
     {
       std::vector<edm::ProductResolverIndexAndSkipBit> indices;
       consumer.itemsToGet(edm::InEvent, indices);
 
-      CPPUNIT_ASSERT(2 == indices.size());
+      CPPUNIT_ASSERT(1 == indices.size());
       CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),
                                                 indices.end(),
                                                 edm::ProductResolverIndexAndSkipBit(v_int_no_proc, false)));
-      CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),
+      CPPUNIT_ASSERT(indices.end() == std::find(indices.begin(),
                                                 indices.end(),
-                                                edm::ProductResolverIndexAndSkipBit(v_simple_no_proc, true)));
+                                                edm::ProductResolverIndexAndSkipBit(v_simple_skip, true)));
 
       std::vector<edm::ProductResolverIndexAndSkipBit> indicesMay;
       consumer.itemsMayGet(edm::InEvent, indicesMay);
@@ -454,10 +468,16 @@ void TestEDConsumerBase::testMay() {
   helper.insert(typeIDSetInt, "labelC", "instanceC", "processC");          // 25, 26
   helper.insert(typeIDVSimpleDerived, "labelC", "instanceC", "processC");  // 27, 28, 29, 30
 
-  helper.setFrozen("processC");
+  {
+    std::vector<std::string> processNames = {
+        "processC", "process", "processB", "processB1", "processB2", "processB3", "processA"};
+    helper.setFrozen(processNames);
+  }
   edm::TypeID typeID_vint(typeid(std::vector<int>));
   const auto vint_c = helper.index(edm::PRODUCT_TYPE, typeID_vint, "labelC", "instanceC", "processC");
   const auto vint_c_no_proc = helper.index(edm::PRODUCT_TYPE, typeID_vint, "labelC", "instanceC", 0);
+  CPPUNIT_ASSERT(vint_c_no_proc == vint_c);
+  const auto vint_c_skip = helper.index(edm::PRODUCT_TYPE, typeID_vint, "labelC", "instanceC", "#");
   const auto vint_blank = helper.index(edm::PRODUCT_TYPE, typeID_vint, "label", "instance", "process");
   const auto vint_blank_no_proc = helper.index(edm::PRODUCT_TYPE, typeID_vint, "label", "instance", 0);
   {
@@ -559,7 +579,7 @@ void TestEDConsumerBase::testMay() {
     CPPUNIT_ASSERT(consumer.m_mayTokens[1].index() == 1);
     CPPUNIT_ASSERT(consumer.m_tokens.size() == 0);
 
-    CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_c_no_proc, true) ==
+    CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_c_skip, true) ==
                    consumer.indexFrom(consumer.m_mayTokens[1], edm::InEvent, typeID_vint));
     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_blank_no_proc, false) ==
                    consumer.indexFrom(consumer.m_mayTokens[0], edm::InEvent, typeID_vint));

--- a/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
+++ b/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
@@ -114,6 +114,7 @@ namespace {
     std::vector<edm::EDGetTokenT<std::vector<int>>> m_tokens;
   };
 
+  constexpr const auto skipCurrentProcessLabel = edm::ProductResolverIndexHelper::skipCurrentProcessLabel();
 }  // namespace
 
 void TestEDConsumerBase::testRegularType() {
@@ -150,7 +151,8 @@ void TestEDConsumerBase::testRegularType() {
 
   edm::TypeID typeID_vint(typeid(std::vector<int>));
   const auto vint_c = helper.index(edm::PRODUCT_TYPE, typeID_vint, "labelC", "instanceC", "processC");
-  const auto vint_c_skipCurrent = helper.index(edm::PRODUCT_TYPE, typeID_vint, "labelC", "instanceC", "#");
+  const auto vint_c_skipCurrent =
+      helper.index(edm::PRODUCT_TYPE, typeID_vint, "labelC", "instanceC", skipCurrentProcessLabel);
   CPPUNIT_ASSERT(edm::ProductResolverIndexInvalid == vint_c_skipCurrent);
   const auto vint_c_no_proc = helper.index(edm::PRODUCT_TYPE, typeID_vint, "labelC", "instanceC", 0);
   CPPUNIT_ASSERT(vint_c == vint_c_no_proc);
@@ -364,7 +366,7 @@ void TestEDConsumerBase::testViewType() {
   const auto v_int_no_proc = helper.index(edm::ELEMENT_TYPE, typeID_int, "label", "instance");
   const auto v_simple_no_proc = helper.index(edm::ELEMENT_TYPE, typeID_Simple, "labelC", "instanceC");
   CPPUNIT_ASSERT(v_simple_no_proc == v_simple);
-  const auto v_simple_skip = helper.index(edm::ELEMENT_TYPE, typeID_Simple, "labelC", "#");
+  const auto v_simple_skip = helper.index(edm::ELEMENT_TYPE, typeID_Simple, "labelC", skipCurrentProcessLabel);
 
   {
     std::vector<std::pair<edm::TypeToGet, edm::InputTag>> vT = {
@@ -477,7 +479,7 @@ void TestEDConsumerBase::testMay() {
   const auto vint_c = helper.index(edm::PRODUCT_TYPE, typeID_vint, "labelC", "instanceC", "processC");
   const auto vint_c_no_proc = helper.index(edm::PRODUCT_TYPE, typeID_vint, "labelC", "instanceC", 0);
   CPPUNIT_ASSERT(vint_c_no_proc == vint_c);
-  const auto vint_c_skip = helper.index(edm::PRODUCT_TYPE, typeID_vint, "labelC", "instanceC", "#");
+  const auto vint_c_skip = helper.index(edm::PRODUCT_TYPE, typeID_vint, "labelC", "instanceC", skipCurrentProcessLabel);
   const auto vint_blank = helper.index(edm::PRODUCT_TYPE, typeID_vint, "label", "instance", "process");
   const auto vint_blank_no_proc = helper.index(edm::PRODUCT_TYPE, typeID_vint, "label", "instance", 0);
   {

--- a/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
+++ b/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
@@ -156,6 +156,7 @@ void testEventGetRefBeforePut::getRefTest() {
 
   auto preg = std::make_unique<edm::SignallingProductRegistryFiller>();
   preg->addProduct(product);
+  preg->setCurrentProcess(processName);
   preg->setFrozen();
   auto branchIDListHelper = std::make_shared<edm::BranchIDListHelper>();
   branchIDListHelper->updateFromRegistry(preg->registry());

--- a/FWCore/Framework/test/eventprincipal_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprincipal_t.cppunit.cc
@@ -131,6 +131,7 @@ void test_ep::setUp() {
   pProductRegistry_->addProduct(*fake_single_process_branch("test", "TEST"));
   pProductRegistry_->addProduct(*fake_single_process_branch("user", "USER"));
   pProductRegistry_->addProduct(*fake_single_process_branch("rick", "USER2", "rick"));
+  pProductRegistry_->setProcessOrder({"USER2", "USER", "TEST", "PROD", "HLT"});
   pProductRegistry_->setFrozen();
   auto branchIDListHelper = std::make_shared<edm::BranchIDListHelper>();
   branchIDListHelper->updateFromRegistry(pProductRegistry_->registry());

--- a/FWCore/Framework/test/generichandle_t.cppunit.cc
+++ b/FWCore/Framework/test/generichandle_t.cppunit.cc
@@ -150,6 +150,7 @@ void testGenericHandle::getbyLabelTest() {
 
   auto preg = std::make_unique<edm::SignallingProductRegistryFiller>();
   preg->addProduct(product);
+  preg->setCurrentProcess(processName);
   preg->setFrozen();
   auto branchIDListHelper = std::make_shared<edm::BranchIDListHelper>();
   branchIDListHelper->updateFromRegistry(preg->registry());

--- a/FWCore/Framework/test/productregistry.cppunit.cc
+++ b/FWCore/Framework/test/productregistry.cppunit.cc
@@ -238,6 +238,7 @@ void testProductRegistry::testAddAlias() {
                                              simpleVecBranch_->unwrappedTypeID(),
                                              simpleDerivedVecBranch_->unwrappedTypeID()};
   std::set<edm::TypeID> elementTypesConsumed{intBranch_->unwrappedTypeID(), edm::TypeID(typeid(edmtest::Simple))};
+  reg.setProcessOrder({"PROD"});
   reg.setFrozen(productTypesConsumed, elementTypesConsumed, "TEST");
   {
     auto notFound =

--- a/FWCore/Integration/plugins/PutOrMergeTestSource.cc
+++ b/FWCore/Integration/plugins/PutOrMergeTestSource.cc
@@ -78,6 +78,7 @@ void PutOrMergeTestSource::registerProducts() {
   productRegistryUpdate().copyProduct(thingDesc_);
   productRegistryUpdate().copyProduct(thingWithMergeDesc_);
   productRegistryUpdate().copyProduct(thingWithEqualDesc_);
+  productRegistryUpdate().setProcessOrder({"PROD"});
 }
 
 InputSource::ItemTypeInfo PutOrMergeTestSource::getNextItemType() {

--- a/FWCore/Integration/test/testNoProcessFallback3_cfg.py
+++ b/FWCore/Integration/test/testNoProcessFallback3_cfg.py
@@ -69,7 +69,7 @@ process.testerSkipCurrentProcess1 = cms.EDAnalyzer("BuiltinIntTestAnalyzer",
 process.keeper2 = EventIDFilter(
         eventsToPass = [cms.EventID(1,1,2)]
 )
-process.p2 = cms.Path(process.keeper2 + process.testerNoProcess1 + process.testerSkipCurrentProcess1 + process.testerCurrentProcessMissing)
+process.p2 = cms.Path(process.keeper2 + process.testerNoProcessMissing + process.testerSkipCurrentProcessMissing + process.testerCurrentProcessMissing)
 
 process.keeper3 = EventIDFilter(
         eventsToPass = [cms.EventID(1,1,3)]
@@ -87,12 +87,12 @@ process.testerSkipCurrentProcess2 = cms.EDAnalyzer("BuiltinIntTestAnalyzer",
     valueMustBeMissing = cms.untracked.bool(False)
 )
 
-process.p3 = cms.Path(process.keeper3 + process.testerNoProcess2 + process.testerSkipCurrentProcess2 + process.testerCurrentProcessMissing)
+process.p3 = cms.Path(process.keeper3 + process.testerNoProcessMissing + process.testerSkipCurrentProcess2 + process.testerCurrentProcessMissing)
 
 process.keeper4 = EventIDFilter(
         eventsToPass = [cms.EventID(1,1,4)]
 )
-process.p4 = cms.Path(process.keeper4 + process.testerNoProcess2 + process.testerSkipCurrentProcess2 + process.testerCurrentProcessMissing)
+process.p4 = cms.Path(process.keeper4 + process.testerNoProcessMissing + process.testerSkipCurrentProcess2 + process.testerCurrentProcessMissing)
 
 process.testerNoProcess3 = cms.EDAnalyzer("BuiltinIntTestAnalyzer",
     moduleLabel = cms.untracked.InputTag("intProducer"),
@@ -114,7 +114,7 @@ process.p5 = cms.Path(process.keeper5 + process.testerNoProcess3 + process.teste
 process.keeper6 = EventIDFilter(
         eventsToPass = [cms.EventID(1,1,6)]
 )
-process.p6 = cms.Path(process.keeper6 + process.testerNoProcess3 + process.testerSkipCurrentProcess1 + process.testerCurrentProcess3)
+process.p6 = cms.Path(process.keeper6 + process.testerNoProcess3 + process.testerSkipCurrentProcessMissing + process.testerCurrentProcess3)
 
 process.keeper7 = EventIDFilter(
         eventsToPass = [cms.EventID(1,1,7)]

--- a/FWCore/Integration/test/testNoProcessFallbackNoCurrent_cfg.py
+++ b/FWCore/Integration/test/testNoProcessFallbackNoCurrent_cfg.py
@@ -59,7 +59,7 @@ process.testerSkipCurrentProcess1 = cms.EDAnalyzer("BuiltinIntTestAnalyzer",
 process.keeper2 = EventIDFilter(
         eventsToPass = [cms.EventID(1,1,2)]
 )
-process.p2 = cms.Path(process.keeper2 + process.testerNoProcess1 + process.testerSkipCurrentProcess1 + process.testerCurrentProcessMissing)
+process.p2 = cms.Path(process.keeper2 + process.testerNoProcessMissing + process.testerSkipCurrentProcessMissing + process.testerCurrentProcessMissing)
 
 process.keeper3 = EventIDFilter(
         eventsToPass = [cms.EventID(1,1,3)]

--- a/FWCore/Integration/test/testProcessBlockNOMergeOfMergedFiles_cfg.py
+++ b/FWCore/Integration/test/testProcessBlockNOMergeOfMergedFiles_cfg.py
@@ -34,12 +34,15 @@ process.source = cms.Source("PoolSource",
 #
 #     TOTAL                                                       8221
 
+#must use skipCurrentProcess as all ProcessBlocks use the same lookups and
+# the current process contains a module with the same label that makes the
+# same product as is found in the 'MERGE' process block
 process.readProcessBlocksOneAnalyzer = cms.EDAnalyzer("edmtest::one::InputProcessBlockIntAnalyzer",
                                             transitions = cms.int32(30),
                                             consumesBeginProcessBlock = cms.InputTag("intProducerBeginProcessBlock", ""),
                                             consumesEndProcessBlock = cms.InputTag("intProducerEndProcessBlock", ""),
-                                            consumesBeginProcessBlockM = cms.InputTag("intProducerBeginProcessBlockM", ""),
-                                            consumesEndProcessBlockM = cms.InputTag("intProducerEndProcessBlockM", ""),
+                                            consumesBeginProcessBlockM = cms.InputTag("intProducerBeginProcessBlockM", "", cms.InputTag.skipCurrentProcess()),
+                                            consumesEndProcessBlockM = cms.InputTag("intProducerEndProcessBlockM", "", cms.InputTag.skipCurrentProcess()),
                                             expectedByRun = cms.vint32(11, 22, 3300, 4400),
                                             expectedSum = cms.int32(8221)
 )

--- a/FWCore/Sources/src/DaqProvenanceHelper.cc
+++ b/FWCore/Sources/src/DaqProvenanceHelper.cc
@@ -85,6 +85,7 @@ namespace edm {
     // Now we need to set all the metadata
     // Add the product to the product registry
     productRegistry.copyProduct(constProductDescription_);
+    productRegistry.setProcessOrder({constProductDescription_.processName()});
 
     // Insert an entry for this process in the process history registry
     // This process is about the data from LHC, and has thus no

--- a/FWCore/Sources/src/PuttableSourceBase.cc
+++ b/FWCore/Sources/src/PuttableSourceBase.cc
@@ -41,6 +41,7 @@ PuttableSourceBase::PuttableSourceBase(ParameterSet const& iPSet, InputSourceDes
 
 void PuttableSourceBase::registerProducts() {
   SignallingProductRegistryFiller reg;
+  reg.setProcessOrder({moduleDescription().processName()});
   //this handled case were Source's construct injects items into the ProductRegistry
   reg.addFromInput(productRegistryUpdate());
   registerProducts(this, &reg, moduleDescription());

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -45,6 +45,7 @@
 #include "FWCore/ParameterSet/interface/ProcessDesc.h"
 #include "FWCore/ParameterSet/interface/validateTopLevelParameterSets.h"
 
+#include "DataFormats/Provenance/interface/processingOrderMerge.h"
 #include "FWCore/Utilities/interface/ExceptionCollector.h"
 
 #include "oneTimeInitialization.h"
@@ -121,6 +122,11 @@ namespace edm {
         processHistory_.emplace_back(p, psetid, xstr(PROJECT_VERSION), HardwareResourcesDescription());
         processHistoryRegistry_.registerProcessHistory(processHistory_);
       }
+      std::vector<std::string> orderedProcesses;
+      processingOrderMerge(processHistoryRegistry_, orderedProcesses);
+      orderedProcesses.insert(orderedProcesses.begin(), processConfiguration_->processName());
+
+      tempReg->setProcessOrder(orderedProcesses);
 
       //setup the products we will be adding to the event
       for (auto const& produce : iConfig.produceEntries()) {

--- a/GeneratorInterface/Core/plugins/GeneratorSmearedProducer.cc
+++ b/GeneratorInterface/Core/plugins/GeneratorSmearedProducer.cc
@@ -27,27 +27,66 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  const edm::EDGetTokenT<edm::HepMCProduct> newToken_;
-  const edm::EDGetTokenT<edm::HepMCProduct> oldToken_;
-  const edm::EDGetTokenT<edm::HepMC3Product> Token3_;
+  edm::EDGetTokenT<edm::HepMCProduct> newToken_;
+  edm::EDGetTokenT<edm::HepMCProduct> oldToken_;
+  edm::EDGetTokenT<edm::HepMC3Product> Token3_;
 };
 
-GeneratorSmearedProducer::GeneratorSmearedProducer(edm::ParameterSet const& ps)
-    : newToken_(consumes<edm::HepMCProduct>(ps.getUntrackedParameter<edm::InputTag>("currentTag"))),
-      oldToken_(consumes<edm::HepMCProduct>(ps.getUntrackedParameter<edm::InputTag>("previousTag"))),
-      Token3_(consumes<edm::HepMC3Product>(ps.getUntrackedParameter<edm::InputTag>("currentTag"))) {
+namespace {
+  template <typename T>
+  bool match(edm::InputTag const& iTag, edm::ProductDescription const& iDesc) {
+    if (iDesc.unwrappedTypeID() == edm::TypeID(typeid(T))) {
+      if (iDesc.moduleLabel() == iTag.label() and iDesc.productInstanceName() == iTag.instance()) {
+        if (iTag.process().empty() or iTag.willSkipCurrentProcess() or
+            iTag.process() == edm::InputTag::kCurrentProcess) {
+          return true;
+        }
+      } else {
+        return iTag.process() == iDesc.processName();
+      }
+    }
+    return false;
+  }
+}  // namespace
+
+GeneratorSmearedProducer::GeneratorSmearedProducer(edm::ParameterSet const& ps) {
   // This producer produces a HepMCProduct, a copy of the original one
   // It is used for backward compatibility
   // If HepMC3Product exists, it produces its copy
   // It adds "generatorSmeared" to description, which is needed for further processing
-  produces<edm::HepMCProduct>();
-  produces<edm::HepMC3Product>();
+  auto currentTag = ps.getUntrackedParameter<edm::InputTag>("currentTag");
+  auto previousTag = ps.getUntrackedParameter<edm::InputTag>("previousTag");
+  callWhenNewProductsRegistered([this, currentTag, previousTag](edm::ProductDescription const& desc) {
+    bool oldHep = false;
+    if (match<edm::HepMCProduct>(currentTag, desc)) {
+      if (newToken_.isUninitialized()) {
+        newToken_ = consumes<edm::HepMCProduct>(currentTag);
+        oldHep = true;
+      }
+    }
+    if (match<edm::HepMCProduct>(previousTag, desc)) {
+      if (oldToken_.isUninitialized()) {
+        oldToken_ = consumes<edm::HepMCProduct>(previousTag);
+        oldHep = true;
+      }
+    }
+    if (oldHep) {
+      produces<edm::HepMCProduct>();
+    }
+    if (match<edm::HepMC3Product>(currentTag, desc)) {
+      Token3_ = consumes<edm::HepMC3Product>(currentTag);
+      produces<edm::HepMC3Product>();
+    }
+  });
 }
 
 void GeneratorSmearedProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& es) const {
   edm::Handle<edm::HepMCProduct> theHepMCProduct;
-  bool found = iEvent.getByToken(newToken_, theHepMCProduct);
-  if (!found) {
+  bool found = false;
+  if (not newToken_.isUninitialized()) {
+    found = iEvent.getByToken(newToken_, theHepMCProduct);
+  }
+  if (!found and not oldToken_.isUninitialized()) {
     found = iEvent.getByToken(oldToken_, theHepMCProduct);
   }
   if (found) {
@@ -55,11 +94,13 @@ void GeneratorSmearedProducer::produce(edm::StreamID, edm::Event& iEvent, const 
     iEvent.put(std::move(theCopy));
   }
 
-  edm::Handle<edm::HepMC3Product> theHepMC3Product;
-  found = iEvent.getByToken(Token3_, theHepMC3Product);
-  if (found) {
-    std::unique_ptr<edm::HepMC3Product> theCopy3(new edm::HepMC3Product(*theHepMC3Product));
-    iEvent.put(std::move(theCopy3));
+  if (not Token3_.isUninitialized()) {
+    edm::Handle<edm::HepMC3Product> theHepMC3Product;
+    found = iEvent.getByToken(Token3_, theHepMC3Product);
+    if (found) {
+      std::unique_ptr<edm::HepMC3Product> theCopy3(new edm::HepMC3Product(*theHepMC3Product));
+      iEvent.put(std::move(theCopy3));
+    }
   }
 }
 

--- a/GeneratorInterface/LHEInterface/plugins/LHEProvenanceHelper.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHEProvenanceHelper.cc
@@ -48,6 +48,7 @@ namespace edm {
     auto rp = runProductProductDescription_;
     rp.setIsProvenanceSetOnRead();
     productRegistry.copyProduct(rp);
+    productRegistry.setProcessOrder({eventProductProductDescription_.processName()});
     BranchIDList bli(1UL, ep.branchID().id());
     branchIDListHelper.updateFromInput({{bli}});
   }

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -563,9 +563,13 @@ namespace edm {
       processingOrderMerge(*processHistoryRegistry_, processingOrder);
       newReg->setProcessOrder(processingOrder);
 
-      // freeze the product registry
-      newReg->setFrozen(inputType != InputType::Primary);
-      productRegistry_.reset(newReg.release());
+      if (not processingOrder.empty()) {
+        // freeze the product registry
+        newReg->setFrozen(inputType != InputType::Primary);
+        productRegistry_.reset(newReg.release());
+      } else {
+        productRegistry_ = std::make_shared<ProductRegistry>();
+      }
     }
 
     // Set up information from the product registry.
@@ -626,6 +630,7 @@ namespace edm {
 
   RootFile::~RootFile() {}
 
+  bool RootFile::empty() const { return runTree_.entries() == 0; }
   void RootFile::readEntryDescriptionTree(EntryDescriptionMap& entryDescriptionMap, InputType inputType) {
     // Called only for old format files.
     // We use a smart pointer so the tree will be deleted after use, and not kept for the life of the file.

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -155,6 +155,8 @@ namespace edm {
     std::array<bool, NumBranchTypes> const& hasNewlyDroppedBranch() const { return hasNewlyDroppedBranch_; }
     bool branchListIndexesUnchanged() const { return branchListIndexesUnchanged_; }
     bool modifiedIDs() const { return daqProvenanceHelper_.get() != nullptr; }
+    //Are there no data stored in the file?
+    bool empty() const;
     std::shared_ptr<FileBlock> createFileBlock();
     void updateFileBlock(FileBlock&);
 

--- a/IOPool/Input/src/RootPrimaryFileSequence.cc
+++ b/IOPool/Input/src/RootPrimaryFileSequence.cc
@@ -66,7 +66,7 @@ namespace edm {
     // Open the first file.
     for (setAtFirstFile(); !noMoreFiles(); setAtNextFile()) {
       initFile(input_.skipBadFiles());
-      if (rootFile())
+      if (rootFile() and not rootFile()->empty())
         break;
     }
     if (rootFile()) {

--- a/Mixing/Base/src/PileUp.cc
+++ b/Mixing/Base/src/PileUp.cc
@@ -124,6 +124,7 @@ namespace edm {
 
       provider_ = std::make_unique<SecondaryEventProvider>(producers, filler, processConfiguration_);
     }
+    filler.setCurrentProcess(processConfiguration_->processName());
     filler.addFromInput(*input_->productRegistry());
     filler.setFrozen();
     productRegistry_ = std::make_shared<ProductRegistry>(filler.moveTo());

--- a/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
@@ -235,8 +235,14 @@ void GenParticleProducer::produce(StreamID, Event& evt, const EventSetup& es) co
     } else {
       Handle<HepMC3Product> mcp3;
       bool found = evt.getByToken(srcToken3_, mcp3);
-      if (!found)
-        throw cms::Exception("ProductAbsent") << "No HepMCProduct, tried to get HepMC3Product, but it is also absent.";
+      if (!found) {
+        try {
+          *mcp3;
+        } catch (cms::Exception& iExcept) {
+          iExcept.addContext("No HepMCProduct, tried to get HepMC3Product, but it is also absent.");
+          throw;
+        }
+      }
       ivhepmc = 3;
       mc3 = new HepMC3::GenEvent();
       mc3->read_data(*mcp3->GetEvent());


### PR DESCRIPTION
#### PR description:

When a specific process name is not given during the `consumes` call, the system now finds the best matching process to use at begin job time. If at transition processing time the data product matched is not found, no further matches are attempted.

Internally the ProductResolverIndexHelper now holds an entry to lookup which ProductResolver to call if one requests to  _skip current process_ . This is now also determined at begin job time rather than at run time.

#### PR validation:

Code compiles and all framework unit tests (after modification) pass.

resolves https://github.com/cms-sw/framework-team/issues/1522