### PR TITLE
Updated SuperclusterDNN v3 for superclustering in TICLv5 

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalTiclPFClusteringForEgammaL1SeededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalTiclPFClusteringForEgammaL1SeededSequence_cfi.py
@@ -48,8 +48,8 @@ hltTiclTracksterLinksSuperclusteringDNNL1Seeded = hltTiclTracksterLinksL1Seeded.
     linkingPSet = cms.PSet(
         type=cms.string("SuperClusteringDNN"),
         algo_verbosity=cms.int32(0),
-        onnxModelPath = cms.FileInPath("RecoHGCal/TICL/data/superclustering/supercls_v2p1.onnx"),
-        nnWorkingPoint=cms.double(0.3),
+        onnxModelPath = cms.FileInPath("RecoHGCal/TICL/data/superclustering/balanced_deltaTime_noFlags_tunedModel.onnx"),
+        nnWorkingPoint=cms.double(0.57247),
     ),
     tracksters_collections = [cms.InputTag("hltTiclTrackstersCLUE3DHighL1Seeded")], # to be changed to ticlTrackstersCLUE3DEM once separate CLUE3D iterations are introduced
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalTiclPFClusteringForEgammaL1SeededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalTiclPFClusteringForEgammaL1SeededSequence_cfi.py
@@ -48,7 +48,7 @@ hltTiclTracksterLinksSuperclusteringDNNL1Seeded = hltTiclTracksterLinksL1Seeded.
     linkingPSet = cms.PSet(
         type=cms.string("SuperClusteringDNN"),
         algo_verbosity=cms.int32(0),
-        onnxModelPath = cms.FileInPath("RecoHGCal/TICL/data/superclustering/balanced_deltaTime_noFlags_tunedModel.onnx"),
+        onnxModelPath = cms.FileInPath("RecoHGCal/TICL/data/superclustering/supercls_v3.onnx"),
         nnWorkingPoint=cms.double(0.57247),
     ),
     tracksters_collections = [cms.InputTag("hltTiclTrackstersCLUE3DHighL1Seeded")], # to be changed to ticlTrackstersCLUE3DEM once separate CLUE3D iterations are introduced

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalTiclPFClusteringForEgammaUnseededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalTiclPFClusteringForEgammaUnseededSequence_cfi.py
@@ -61,8 +61,8 @@ hltTiclTracksterLinksSuperclusteringDNNUnseeded = hltTiclTracksterLinks.clone(
     linkingPSet = cms.PSet(
         type=cms.string("SuperClusteringDNN"),
         algo_verbosity=cms.int32(0),
-        onnxModelPath = cms.FileInPath("RecoHGCal/TICL/data/superclustering/supercls_v2p1.onnx"),
-        nnWorkingPoint=cms.double(0.3),
+        onnxModelPath = cms.FileInPath("RecoHGCal/TICL/data/superclustering/balanced_deltaTime_noFlags_tunedModel.onnx"),
+        nnWorkingPoint=cms.double(0.57247),
     ),
     tracksters_collections = [cms.InputTag("hltTiclTrackstersCLUE3DHigh")], # to be changed to ticlTrackstersCLUE3DEM once separate CLUE3D iterations are introduced
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalTiclPFClusteringForEgammaUnseededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalTiclPFClusteringForEgammaUnseededSequence_cfi.py
@@ -61,7 +61,7 @@ hltTiclTracksterLinksSuperclusteringDNNUnseeded = hltTiclTracksterLinks.clone(
     linkingPSet = cms.PSet(
         type=cms.string("SuperClusteringDNN"),
         algo_verbosity=cms.int32(0),
-        onnxModelPath = cms.FileInPath("RecoHGCal/TICL/data/superclustering/balanced_deltaTime_noFlags_tunedModel.onnx"),
+        onnxModelPath = cms.FileInPath("RecoHGCal/TICL/data/superclustering/supercls_v3.onnx"),
         nnWorkingPoint=cms.double(0.57247),
     ),
     tracksters_collections = [cms.InputTag("hltTiclTrackstersCLUE3DHigh")], # to be changed to ticlTrackstersCLUE3DEM once separate CLUE3D iterations are introduced

--- a/RecoHGCal/TICL/interface/SuperclusteringDNNInputs.h
+++ b/RecoHGCal/TICL/interface/SuperclusteringDNNInputs.h
@@ -99,34 +99,34 @@ namespace ticl {
   /* Third version of DNN by Gamze Sokmen and Shamik Ghosh, making use of time information as new variables.
   Uses features : ['DeltaEta', 'DeltaPhi', 'multi_en', 'multi_eta', 'multi_pt', 'seedEta','seedPhi','seedEn', 'seedPt',   theta', 'theta_xz_seedFrame', 'theta_yz_seedFrame', 'theta_xy_cmsFrame', 'theta_yz_cmsFrame', 'theta_xz_cmsFrame', 'explVar', 'explVarRatio', 'mod_deltaTime']
   */
- 
+
   class SuperclusteringDNNInputV3 : public AbstractSuperclusteringDNNInput {
-    public:
-      unsigned int featureCount() const override { return 18; }
+  public:
+    unsigned int featureCount() const override { return 18; }
 
-      std::vector<float> computeVector(ticl::Trackster const& ts_base, ticl::Trackster const& ts_toCluster) override;
+    std::vector<float> computeVector(ticl::Trackster const& ts_base, ticl::Trackster const& ts_toCluster) override;
 
-      std::vector<std::string> featureNames() const override {
-        return {"DeltaEtaBaryc",
-                "DeltaPhiBaryc",
-                "multi_en",
-                "multi_eta",
-                "multi_pt",
-                "seedEta",
-                "seedPhi",
-                "seedEn",
-                "seedPt",
-                "theta",
-                "theta_xz_seedFrame",
-                "theta_yz_seedFrame",
-                "theta_xy_cmsFrame",
-                "theta_yz_cmsFrame",
-                "theta_xz_cmsFrame",
-                "explVar",
-                "explVarRatio",
-                "mod_deltaTime"};
-      }
-    };  
+    std::vector<std::string> featureNames() const override {
+      return {"DeltaEtaBaryc",
+              "DeltaPhiBaryc",
+              "multi_en",
+              "multi_eta",
+              "multi_pt",
+              "seedEta",
+              "seedPhi",
+              "seedEn",
+              "seedPt",
+              "theta",
+              "theta_xz_seedFrame",
+              "theta_yz_seedFrame",
+              "theta_xy_cmsFrame",
+              "theta_yz_cmsFrame",
+              "theta_xz_cmsFrame",
+              "explVar",
+              "explVarRatio",
+              "mod_deltaTime"};
+    }
+  };
 
   std::unique_ptr<AbstractSuperclusteringDNNInput> makeSuperclusteringDNNInputFromString(std::string dnnVersion);
 }  // namespace ticl

--- a/RecoHGCal/TICL/interface/SuperclusteringDNNInputs.h
+++ b/RecoHGCal/TICL/interface/SuperclusteringDNNInputs.h
@@ -2,7 +2,7 @@
 // Author: Theo Cuisset - theo.cuisset@cern.ch
 // Date: 11/2023
 
-// Modified by Gamze Sokmen 
+// Modified by Gamze Sokmen - gamze.sokmen@cern.ch
 // Changes: Implementation of the delta time feature under a new DNN input version (v3) for the superclustering DNN and correcting the seed pT calculation.
 // Date: 07/2025
 
@@ -14,6 +14,11 @@
 #include <memory>
 
 namespace ticl {
+
+  // any raw_dt outside +/- kDeltaTimeDefault is considered bad
+  static constexpr float kDeltaTimeDefault = 50.f;
+  static constexpr float kBadDeltaTime = -5.f;
+
   class Trackster;
 
   // Abstract base class for DNN input preparation.
@@ -91,7 +96,7 @@ namespace ticl {
     }
   };
 
-  /* Third version of DNN by Gamze Sokmen, making use of time information as new variables.
+  /* Third version of DNN by Gamze Sokmen and Shamik Ghosh, making use of time information as new variables.
   Uses features : ['DeltaEta', 'DeltaPhi', 'multi_en', 'multi_eta', 'multi_pt', 'seedEta','seedPhi','seedEn', 'seedPt',   theta', 'theta_xz_seedFrame', 'theta_yz_seedFrame', 'theta_xy_cmsFrame', 'theta_yz_cmsFrame', 'theta_xz_cmsFrame', 'explVar', 'explVarRatio', 'mod_deltaTime']
   */
  

--- a/RecoHGCal/TICL/interface/SuperclusteringDNNInputs.h
+++ b/RecoHGCal/TICL/interface/SuperclusteringDNNInputs.h
@@ -2,6 +2,10 @@
 // Author: Theo Cuisset - theo.cuisset@cern.ch
 // Date: 11/2023
 
+// Modified by Gamze Sokmen 
+// Changes: Implementation of the delta time feature under a new DNN input version (v3) for the superclustering DNN and correcting the seed pT calculation.
+// Date: 07/2025
+
 #ifndef __RecoHGCal_TICL_SuperclusteringDNNInputs_H__
 #define __RecoHGCal_TICL_SuperclusteringDNNInputs_H__
 
@@ -86,6 +90,38 @@ namespace ticl {
               "explVarRatio"};
     }
   };
+
+  /* Third version of DNN by Gamze Sokmen, making use of time information as new variables.
+  Uses features : ['DeltaEta', 'DeltaPhi', 'multi_en', 'multi_eta', 'multi_pt', 'seedEta','seedPhi','seedEn', 'seedPt',   theta', 'theta_xz_seedFrame', 'theta_yz_seedFrame', 'theta_xy_cmsFrame', 'theta_yz_cmsFrame', 'theta_xz_cmsFrame', 'explVar', 'explVarRatio', 'mod_deltaTime']
+  */
+ 
+  class SuperclusteringDNNInputV3 : public AbstractSuperclusteringDNNInput {
+    public:
+      unsigned int featureCount() const override { return 18; }
+
+      std::vector<float> computeVector(ticl::Trackster const& ts_base, ticl::Trackster const& ts_toCluster) override;
+
+      std::vector<std::string> featureNames() const override {
+        return {"DeltaEtaBaryc",
+                "DeltaPhiBaryc",
+                "multi_en",
+                "multi_eta",
+                "multi_pt",
+                "seedEta",
+                "seedPhi",
+                "seedEn",
+                "seedPt",
+                "theta",
+                "theta_xz_seedFrame",
+                "theta_yz_seedFrame",
+                "theta_xy_cmsFrame",
+                "theta_yz_cmsFrame",
+                "theta_xz_cmsFrame",
+                "explVar",
+                "explVarRatio",
+                "mod_deltaTime"};
+      }
+    };  
 
   std::unique_ptr<AbstractSuperclusteringDNNInput> makeSuperclusteringDNNInputFromString(std::string dnnVersion);
 }  // namespace ticl

--- a/RecoHGCal/TICL/plugins/SuperclusteringSampleDumper.cc
+++ b/RecoHGCal/TICL/plugins/SuperclusteringSampleDumper.cc
@@ -151,8 +151,7 @@ void SuperclusteringSampleDumper::analyze(const edm::Event& evt, const edm::Even
   std::iota(trackstersIndicesPt.begin(), trackstersIndicesPt.end(), 0);
   std::stable_sort(
       trackstersIndicesPt.begin(), trackstersIndicesPt.end(), [&inputTracksters](unsigned int i1, unsigned int i2) {
-        return (*inputTracksters)[i1].raw_energy() * std::sin((*inputTracksters)[i1].barycenter().Theta()) >
-               (*inputTracksters)[i2].raw_energy() * std::sin((*inputTracksters)[i2].barycenter().Theta());
+        return (*inputTracksters)[i1].raw_pt() > (*inputTracksters)[i2].raw_pt();
       });
 
   // Order of loops are reversed compared to SuperclusteringProducer (here outer is seed, inner is candidate), for performance reasons.
@@ -163,7 +162,7 @@ void SuperclusteringSampleDumper::analyze(const edm::Event& evt, const edm::Even
         trackstersIndicesPt[ts_seed_idx_pt];  // Index of seed trackster in input collection (not in pT sorted collection)
     Trackster const& ts_seed = (*inputTracksters)[ts_seed_idx_input];
 
-    if (ts_seed.raw_energy() * std::sin(ts_seed.barycenter().Theta()) < seedPtThreshold_)
+    if (ts_seed.raw_pt() < seedPtThreshold_)
       break;  // All further seeds will have lower pT than threshold (due to pT sorting)
 
     if (!checkExplainedVarianceRatioCut(ts_seed))

--- a/RecoHGCal/TICL/plugins/SuperclusteringSampleDumper.cc
+++ b/RecoHGCal/TICL/plugins/SuperclusteringSampleDumper.cc
@@ -151,7 +151,8 @@ void SuperclusteringSampleDumper::analyze(const edm::Event& evt, const edm::Even
   std::iota(trackstersIndicesPt.begin(), trackstersIndicesPt.end(), 0);
   std::stable_sort(
       trackstersIndicesPt.begin(), trackstersIndicesPt.end(), [&inputTracksters](unsigned int i1, unsigned int i2) {
-	return (*inputTracksters)[i1].raw_energy()*std::sin((*inputTracksters)[i1].barycenter().Theta()) > (*inputTracksters)[i2].raw_energy()*std::sin((*inputTracksters)[i2].barycenter().Theta());
+        return (*inputTracksters)[i1].raw_energy() * std::sin((*inputTracksters)[i1].barycenter().Theta()) >
+               (*inputTracksters)[i2].raw_energy() * std::sin((*inputTracksters)[i2].barycenter().Theta());
       });
 
   // Order of loops are reversed compared to SuperclusteringProducer (here outer is seed, inner is candidate), for performance reasons.
@@ -162,7 +163,7 @@ void SuperclusteringSampleDumper::analyze(const edm::Event& evt, const edm::Even
         trackstersIndicesPt[ts_seed_idx_pt];  // Index of seed trackster in input collection (not in pT sorted collection)
     Trackster const& ts_seed = (*inputTracksters)[ts_seed_idx_input];
 
-    if (ts_seed.raw_energy()*std::sin(ts_seed.barycenter().Theta()) < seedPtThreshold_)
+    if (ts_seed.raw_energy() * std::sin(ts_seed.barycenter().Theta()) < seedPtThreshold_)
       break;  // All further seeds will have lower pT than threshold (due to pT sorting)
 
     if (!checkExplainedVarianceRatioCut(ts_seed))

--- a/RecoHGCal/TICL/plugins/SuperclusteringSampleDumper.cc
+++ b/RecoHGCal/TICL/plugins/SuperclusteringSampleDumper.cc
@@ -151,7 +151,7 @@ void SuperclusteringSampleDumper::analyze(const edm::Event& evt, const edm::Even
   std::iota(trackstersIndicesPt.begin(), trackstersIndicesPt.end(), 0);
   std::stable_sort(
       trackstersIndicesPt.begin(), trackstersIndicesPt.end(), [&inputTracksters](unsigned int i1, unsigned int i2) {
-        return (*inputTracksters)[i1].raw_pt() > (*inputTracksters)[i2].raw_pt();
+	return (*inputTracksters)[i1].raw_energy()*std::sin((*inputTracksters)[i1].barycenter().Theta()) > (*inputTracksters)[i2].raw_energy()*std::sin((*inputTracksters)[i2].barycenter().Theta());
       });
 
   // Order of loops are reversed compared to SuperclusteringProducer (here outer is seed, inner is candidate), for performance reasons.
@@ -162,7 +162,7 @@ void SuperclusteringSampleDumper::analyze(const edm::Event& evt, const edm::Even
         trackstersIndicesPt[ts_seed_idx_pt];  // Index of seed trackster in input collection (not in pT sorted collection)
     Trackster const& ts_seed = (*inputTracksters)[ts_seed_idx_input];
 
-    if (ts_seed.raw_pt() < seedPtThreshold_)
+    if (ts_seed.raw_energy()*std::sin(ts_seed.barycenter().Theta()) < seedPtThreshold_)
       break;  // All further seeds will have lower pT than threshold (due to pT sorting)
 
     if (!checkExplainedVarianceRatioCut(ts_seed))
@@ -265,8 +265,8 @@ void SuperclusteringSampleDumper::fillDescriptions(edm::ConfigurationDescription
       ->setComment("Input trackster collection, same as what is used for superclustering inference.");
   desc.add<edm::InputTag>("recoToSimAssociatorCP",
                           edm::InputTag("tracksterSimTracksterAssociationLinkingbyCLUE3D", "recoToSim"));
-  desc.ifValue(edm::ParameterDescription<std::string>("dnnInputsVersion", "v2", true),
-               edm::allowedValues<std::string>("v1", "v2"))
+  desc.ifValue(edm::ParameterDescription<std::string>("dnnInputsVersion", "v3", true),
+               edm::allowedValues<std::string>("v1", "v2", "v3"))
       ->setComment(
           "DNN inputs version tag. Defines which set of features is fed to the DNN. Must match with the actual DNN.");
   // Cuts are intentionally looser than those used for inference in TracksterLinkingBySuperClustering.cpp

--- a/RecoHGCal/TICL/plugins/TracksterLinkingbySuperClusteringDNN.cc
+++ b/RecoHGCal/TICL/plugins/TracksterLinkingbySuperClusteringDNN.cc
@@ -1,6 +1,6 @@
 /*
 TICL plugin for electron superclustering in HGCAL using a DNN. 
-DNN designed by Alessandro Tarabini.
+DNN designed by Alessandro Tarabini, Florian Beaudette, Gamze Sokmen, Shamik Ghosh, Theo Cuisset.
 
 Inputs are CLUE3D EM tracksters. Outputs are superclusters (as vectors of IDs of trackster)
 "Seed trackster" : seed of supercluster, always highest pT trackster of supercluster, normally should be an electron
@@ -18,6 +18,9 @@ The loop is first on candidate, then on seeds as it is more efficient for step 4
 
 Authors : Theo Cuisset <theo.cuisset@cern.ch>, Shamik Ghosh <shamik.ghosh@cern.ch>
 Date : 11/2023
+
+Updates : Logic works as it should and switching to v3 (Shamik)
+Date: 07/2025
 */
 
 #include <string>

--- a/RecoHGCal/TICL/plugins/TracksterLinkingbySuperClusteringDNN.cc
+++ b/RecoHGCal/TICL/plugins/TracksterLinkingbySuperClusteringDNN.cc
@@ -116,7 +116,7 @@ void TracksterLinkingbySuperClusteringDNN::linkTracksters(
   std::iota(trackstersIndicesPt.begin(), trackstersIndicesPt.end(), 0);
   std::stable_sort(
       trackstersIndicesPt.begin(), trackstersIndicesPt.end(), [&inputTracksters](unsigned int i1, unsigned int i2) {
-        return inputTracksters[i1].raw_pt() > inputTracksters[i2].raw_pt();
+        return inputTracksters[i1].raw_energy()*std::sin(inputTracksters[i1].barycenter().Theta()) > inputTracksters[i2].raw_energy()*std::sin(inputTracksters[i2].barycenter().Theta());
       });
 
   /* Evaluate in minibatches since running with trackster count = 3000 leads to a short-lived ~15GB memory allocation
@@ -146,7 +146,8 @@ void TracksterLinkingbySuperClusteringDNN::linkTracksters(
     Trackster const& ts_cand = inputTracksters[trackstersIndicesPt[ts_cand_idx_pt]];
 
     if (ts_cand.raw_energy() < candidateEnergyThreshold_ ||
-        !checkExplainedVarianceRatioCut(ts_cand))  // || !trackstersPassesPIDCut(ts_cand)
+	//        !checkExplainedVarianceRatioCut(ts_cand))  // || !trackstersPassesPIDCut(ts_cand)
+	!checkExplainedVarianceRatioCut(ts_cand))//   || !trackstersPassesPIDCut(ts_cand))
       continue;
 
     auto& tracksterTiles = tracksterTilesBothEndcaps_pt[ts_cand.barycenter().eta() > 0];
@@ -164,7 +165,7 @@ void TracksterLinkingbySuperClusteringDNN::linkTracksters(
 
           Trackster const& ts_seed = inputTracksters[trackstersIndicesPt[ts_seed_idx_pt]];
 
-          if (ts_seed.raw_pt() < seedPtThreshold_)
+          if (ts_seed.raw_energy()*std::sin(ts_seed.barycenter().Theta()) < seedPtThreshold_)
             break;  // All further seeds will have lower pT than threshold (due to pT sorting)
 
           if (!checkExplainedVarianceRatioCut(ts_seed) || !trackstersPassesPIDCut(ts_seed))
@@ -245,87 +246,95 @@ void TracksterLinkingbySuperClusteringDNN::linkTracksters(
   Also mask seeds (only needed to add tracksters not in a supercluster to the output). */
   std::vector<bool> tracksterMask(tracksterCount, false);
 
-  /* Index of the seed trackster of the previous iteration 
-  Initialized with an id that cannot be obtained in input */
+
+  /////////////////////////////////////////////////////////////////////////TRKBUILDINGMOD
+  
   unsigned int previousCandTrackster_idx = std::numeric_limits<unsigned int>::max();
   unsigned int bestSeedForCurrentCandidate_idx = std::numeric_limits<unsigned int>::max();
   float bestSeedForCurrentCandidate_dnnScore = nnWorkingPoint_;
-
-  // Lambda to be called when there is a transition from one candidate to the next (as well as after the last iteration)
-  // Does the actual supercluster creation
+  
+  // Track which tracksters were ever used as candidates
+  std::vector<bool> usedAsCandidate(tracksterCount, false);
+  
+  
   auto onCandidateTransition = [&](unsigned ts_cand_idx) {
-    if (bestSeedForCurrentCandidate_idx <
-        std::numeric_limits<unsigned int>::max()) {  // At least one seed can be superclustered with the candidate
-      tracksterMask[ts_cand_idx] = true;  // Mask the candidate so it is not considered as seed in later iterations
-
-      // Look for a supercluster of the seed
-      std::vector<std::vector<unsigned int>>::iterator seed_supercluster_it =
-          std::find_if(outputSuperclusters.begin(),
-                       outputSuperclusters.end(),
-                       [bestSeedForCurrentCandidate_idx](std::vector<unsigned int> const& sc) {
-                         return sc[0] == bestSeedForCurrentCandidate_idx;
-                       });
-
-      if (seed_supercluster_it == outputSuperclusters.end()) {  // No supercluster exists yet for the seed. Create one.
-        outputSuperclusters.emplace_back(std::initializer_list<unsigned int>{bestSeedForCurrentCandidate_idx});
-        resultTracksters.emplace_back(inputTracksters[bestSeedForCurrentCandidate_idx]);
-        linkedTracksterIdToInputTracksterId.emplace_back(
-            std::initializer_list<unsigned int>{bestSeedForCurrentCandidate_idx});
-        seed_supercluster_it = outputSuperclusters.end() - 1;
-        tracksterMask[bestSeedForCurrentCandidate_idx] =
-            true;  // mask the seed as well (needed to find tracksters not in any supercluster)
+    if (bestSeedForCurrentCandidate_idx < std::numeric_limits<unsigned int>::max()) {
+      tracksterMask[ts_cand_idx] = true;           // Mask the candidate so it’s not reused as a seed
+      usedAsCandidate[ts_cand_idx] = true;
+      
+      // Find the supercluster the seed belongs to (even if it's already used in another supercluster)
+      // Find existing supercluster for the seed
+      auto seed_supercluster_it =
+        std::find_if(outputSuperclusters.begin(),
+                     outputSuperclusters.end(),
+                     [bestSeedForCurrentCandidate_idx](const std::vector<unsigned int>& sc) {
+                       return sc[0] == bestSeedForCurrentCandidate_idx;
+                     });
+      if (seed_supercluster_it == outputSuperclusters.end()) {
+	// No supercluster exists for this seed, create one
+	outputSuperclusters.emplace_back(std::initializer_list<unsigned int>{bestSeedForCurrentCandidate_idx});
+	resultTracksters.emplace_back(inputTracksters[bestSeedForCurrentCandidate_idx]);
+	linkedTracksterIdToInputTracksterId.emplace_back(
+							 std::initializer_list<unsigned int>{bestSeedForCurrentCandidate_idx});
+	seed_supercluster_it = outputSuperclusters.end() - 1;
+	tracksterMask[bestSeedForCurrentCandidate_idx] = true;
       }
-      // Index of the supercluster into resultTracksters, outputSuperclusters and linkedTracksterIdToInputTracksterId collections (the indices are the same)
+      
       unsigned int indexIntoOutputTracksters = seed_supercluster_it - outputSuperclusters.begin();
       seed_supercluster_it->push_back(ts_cand_idx);
       resultTracksters[indexIntoOutputTracksters].mergeTracksters(inputTracksters[ts_cand_idx]);
       linkedTracksterIdToInputTracksterId[indexIntoOutputTracksters].push_back(ts_cand_idx);
-
+      
       assert(outputSuperclusters.size() == resultTracksters.size() &&
-             outputSuperclusters.size() == linkedTracksterIdToInputTracksterId.size());
+	     outputSuperclusters.size() == linkedTracksterIdToInputTracksterId.size());
       assert(seed_supercluster_it->size() == linkedTracksterIdToInputTracksterId[indexIntoOutputTracksters].size());
-
+      
       bestSeedForCurrentCandidate_idx = std::numeric_limits<unsigned int>::max();
       bestSeedForCurrentCandidate_dnnScore = nnWorkingPoint_;
     }
   };
-
-  //Iterate over minibatches
+  
+  // Iterate over minibatches
   for (unsigned int batchIndex = 0; batchIndex < batchOutputs.size(); batchIndex++) {
-    std::vector<float> const& currentBatchOutputs = batchOutputs[batchIndex];  // DNN score outputs
-    // Iterate over seed-candidate pairs inside current minibatch
+    std::vector<float> const& currentBatchOutputs = batchOutputs[batchIndex];
+    
     for (unsigned int indexInBatch = 0; indexInBatch < tracksterIndicesUsedInDNN[batchIndex].size(); indexInBatch++) {
       assert(indexInBatch < static_cast<unsigned int>(batchOutputs[batchIndex].size()));
-
+      
       const unsigned int ts_seed_idx = tracksterIndicesUsedInDNN[batchIndex][indexInBatch].first;
       const unsigned int ts_cand_idx = tracksterIndicesUsedInDNN[batchIndex][indexInBatch].second;
       const float currentDnnScore = currentBatchOutputs[indexInBatch];
-
+      
       if (previousCandTrackster_idx != std::numeric_limits<unsigned int>::max() &&
-          ts_cand_idx != previousCandTrackster_idx) {
-        // There is a transition from one seed to the next (don't make a transition for the first iteration)
-        onCandidateTransition(previousCandTrackster_idx);
+	  ts_cand_idx != previousCandTrackster_idx) {
+	onCandidateTransition(previousCandTrackster_idx);
       }
-
-      if (currentDnnScore > bestSeedForCurrentCandidate_dnnScore && !tracksterMask[ts_seed_idx]) {
-        // Check that the DNN suggests superclustering, that this seed-candidate assoc is better than previous ones, and that the seed is not already in a supercluster as candidate
-        bestSeedForCurrentCandidate_idx = ts_seed_idx;
-        bestSeedForCurrentCandidate_dnnScore = currentDnnScore;
+      
+      // Ignore seed if it was previously used as a candidate
+      if (currentDnnScore > bestSeedForCurrentCandidate_dnnScore  && !usedAsCandidate[ts_seed_idx]) {
+	bestSeedForCurrentCandidate_idx = ts_seed_idx;
+	bestSeedForCurrentCandidate_dnnScore = currentDnnScore;
       }
+      
       previousCandTrackster_idx = ts_cand_idx;
     }
   }
   onCandidateTransition(previousCandTrackster_idx);
-
-  // Adding one-trackster superclusters for all tracksters not in a supercluster already that pass the seed threshold
+  
+  // Create singleton superclusters for unused tracksters with enough pt
   for (unsigned int ts_id = 0; ts_id < tracksterCount; ts_id++) {
-    if (!tracksterMask[ts_id] && inputTracksters[ts_id].raw_pt() >= seedPtThreshold_) {
+    if (!tracksterMask[ts_id] && inputTracksters[ts_id].raw_energy()*std::sin(inputTracksters[ts_id].barycenter().Theta()) >= seedPtThreshold_) {
       outputSuperclusters.emplace_back(std::initializer_list<unsigned int>{ts_id});
       resultTracksters.emplace_back(inputTracksters[ts_id]);
       linkedTracksterIdToInputTracksterId.emplace_back(std::initializer_list<unsigned int>{ts_id});
     }
   }
-
+  
+  
+  
+  /////////////////////////////////////////////////////////////////////////TRKBUILDINGMOD
+  
+  
 #ifdef EDM_ML_DEBUG
   for (std::vector<unsigned int> const& sc : outputSuperclusters) {
     std::ostringstream s;
@@ -340,8 +349,8 @@ void TracksterLinkingbySuperClusteringDNN::linkTracksters(
 void TracksterLinkingbySuperClusteringDNN::fillPSetDescription(edm::ParameterSetDescription& desc) {
   TracksterLinkingAlgoBase::fillPSetDescription(desc);  // adds algo_verbosity
   desc.add<edm::FileInPath>("onnxModelPath")->setComment("Path to DNN (as ONNX model)");
-  desc.ifValue(edm::ParameterDescription<std::string>("dnnInputsVersion", "v2", true),
-               edm::allowedValues<std::string>("v1", "v2"))
+  desc.ifValue(edm::ParameterDescription<std::string>("dnnInputsVersion", "v3", true),
+               edm::allowedValues<std::string>("v1", "v2", "v3"))
       ->setComment(
           "DNN inputs version tag. Defines which set of features is fed to the DNN. Must match with the actual DNN.");
   desc.add<unsigned int>("inferenceBatchSize", 1e5)

--- a/RecoHGCal/TICL/plugins/TracksterLinkingbySuperClusteringDNN.cc
+++ b/RecoHGCal/TICL/plugins/TracksterLinkingbySuperClusteringDNN.cc
@@ -119,8 +119,7 @@ void TracksterLinkingbySuperClusteringDNN::linkTracksters(
   std::iota(trackstersIndicesPt.begin(), trackstersIndicesPt.end(), 0);
   std::stable_sort(
       trackstersIndicesPt.begin(), trackstersIndicesPt.end(), [&inputTracksters](unsigned int i1, unsigned int i2) {
-        return inputTracksters[i1].raw_energy() * std::sin(inputTracksters[i1].barycenter().Theta()) >
-               inputTracksters[i2].raw_energy() * std::sin(inputTracksters[i2].barycenter().Theta());
+        return inputTracksters[i1].raw_pt() > inputTracksters[i2].raw_pt();
       });
 
   /* Evaluate in minibatches since running with trackster count = 3000 leads to a short-lived ~15GB memory allocation
@@ -169,7 +168,7 @@ void TracksterLinkingbySuperClusteringDNN::linkTracksters(
 
           Trackster const& ts_seed = inputTracksters[trackstersIndicesPt[ts_seed_idx_pt]];
 
-          if (ts_seed.raw_energy() * std::sin(ts_seed.barycenter().Theta()) < seedPtThreshold_)
+          if (ts_seed.raw_pt() < seedPtThreshold_)
             break;  // All further seeds will have lower pT than threshold (due to pT sorting)
 
           if (!checkExplainedVarianceRatioCut(ts_seed) || !trackstersPassesPIDCut(ts_seed))
@@ -324,9 +323,7 @@ void TracksterLinkingbySuperClusteringDNN::linkTracksters(
 
   // Create singleton superclusters for unused tracksters with enough pt
   for (unsigned int ts_id = 0; ts_id < tracksterCount; ts_id++) {
-    if (!tracksterMask[ts_id] &&
-        inputTracksters[ts_id].raw_energy() * std::sin(inputTracksters[ts_id].barycenter().Theta()) >=
-            seedPtThreshold_) {
+    if (!tracksterMask[ts_id] && inputTracksters[ts_id].raw_pt() >= seedPtThreshold_) {
       outputSuperclusters.emplace_back(std::initializer_list<unsigned int>{ts_id});
       resultTracksters.emplace_back(inputTracksters[ts_id]);
       linkedTracksterIdToInputTracksterId.emplace_back(std::initializer_list<unsigned int>{ts_id});

--- a/RecoHGCal/TICL/python/superclustering_cff.py
+++ b/RecoHGCal/TICL/python/superclustering_cff.py
@@ -13,8 +13,8 @@ ticlTracksterLinksSuperclusteringDNN = _tracksterLinksProducer.clone(
     linkingPSet = cms.PSet(
         type=cms.string("SuperClusteringDNN"),
         algo_verbosity=cms.int32(0),
-        onnxModelPath = cms.FileInPath("RecoHGCal/TICL/data/superclustering/supercls_v2p1.onnx"),
-        nnWorkingPoint=cms.double(0.3),
+        onnxModelPath = cms.FileInPath("RecoHGCal/TICL/data/superclustering/balanced_deltaTime_noFlags_tunedModel.onnx"),
+        nnWorkingPoint=cms.double(0.57247),
     ),
     tracksters_collections = [cms.InputTag("ticlTrackstersCLUE3DHigh")], # to be changed to ticlTrackstersCLUE3DEM once separate CLUE3D iterations are introduced
 )

--- a/RecoHGCal/TICL/python/superclustering_cff.py
+++ b/RecoHGCal/TICL/python/superclustering_cff.py
@@ -13,7 +13,7 @@ ticlTracksterLinksSuperclusteringDNN = _tracksterLinksProducer.clone(
     linkingPSet = cms.PSet(
         type=cms.string("SuperClusteringDNN"),
         algo_verbosity=cms.int32(0),
-        onnxModelPath = cms.FileInPath("RecoHGCal/TICL/data/superclustering/balanced_deltaTime_noFlags_tunedModel.onnx"),
+        onnxModelPath = cms.FileInPath("RecoHGCal/TICL/data/superclustering/supercls_v3.onnx"),
         nnWorkingPoint=cms.double(0.57247),
     ),
     tracksters_collections = [cms.InputTag("ticlTrackstersCLUE3DHigh")], # to be changed to ticlTrackstersCLUE3DEM once separate CLUE3D iterations are introduced

--- a/RecoHGCal/TICL/src/SuperclusteringDNNInputs.cc
+++ b/RecoHGCal/TICL/src/SuperclusteringDNNInputs.cc
@@ -32,11 +32,11 @@ namespace ticl {
         ts_toCluster.barycenter().Phi() - ts_base.barycenter().phi(),                      //DeltaPhiBaryc
         ts_toCluster.raw_energy(),                                                         //multi_en
         ts_toCluster.barycenter().Eta(),                                                   //multi_eta
-        (ts_toCluster.raw_energy() * std::sin(ts_toCluster.barycenter().Theta())),         //multi_pt
+        ts_toCluster.raw_pt(),                                                             //multi_pt
         ts_base.barycenter().Eta(),                                                        //seedEta
         ts_base.barycenter().Phi(),                                                        //seedPhi
         ts_base.raw_energy(),                                                              //seedEn
-        (ts_base.raw_energy() * std::sin(ts_base.barycenter().Theta())),                   //seedPt
+        ts_base.raw_pt(),                                                                  //seedPt
     }};
   }
 
@@ -91,11 +91,11 @@ namespace ticl {
         ts_toCluster.barycenter().Phi() - ts_base.barycenter().phi(),                      //DeltaPhiBaryc
         ts_toCluster.raw_energy(),                                                         //multi_en
         ts_toCluster.barycenter().Eta(),                                                   //multi_eta
-        (ts_toCluster.raw_energy() * std::sin(ts_toCluster.barycenter().Theta())),         //multi_pt
+        ts_toCluster.raw_pt(),                                                             //multi_pt
         ts_base.barycenter().Eta(),                                                        //seedEta
         ts_base.barycenter().Phi(),                                                        //seedPhi
         ts_base.raw_energy(),                                                              //seedEn
-        (ts_base.raw_energy() * std::sin(ts_base.barycenter().Theta())),                   //seedPt
+        ts_base.raw_pt(),                                                                  //seedPt
         static_cast<float>(Angle(pca_cand_cmsFrame, pca_seed_cmsFrame)),  // theta : angle between seed and candidate
         Angle2D(XYVectorF(pca_cand_seedFrame.x(), pca_cand_seedFrame.z()), XYVectorF(0, 1)),  // theta_xz_seedFrame
         Angle2D(XYVectorF(pca_cand_seedFrame.y(), pca_cand_seedFrame.z()), XYVectorF(0, 1)),  // theta_yz_seedFrame
@@ -140,11 +140,11 @@ namespace ticl {
         ts_toCluster.barycenter().Phi() - ts_base.barycenter().phi(),                      // DeltaPhiBaryc
         ts_toCluster.raw_energy(),                                                         // multi_en
         ts_toCluster.barycenter().Eta(),                                                   // multi_eta
-        ts_toCluster.raw_energy() * std::sin(ts_toCluster.barycenter().Theta()),           // multi_pt
+        ts_toCluster.raw_pt(),                                                             // multi_pt
         ts_base.barycenter().Eta(),                                                        // seedEta
         ts_base.barycenter().Phi(),                                                        // seedPhi
         ts_base.raw_energy(),                                                              // seedEn
-        ts_base.raw_energy() * std::sin(ts_base.barycenter().Theta()),                     // seedPt
+        ts_base.raw_pt(),                                                                  // seedPt
         static_cast<float>(Angle(pca_cand_cmsFrame, pca_seed_cmsFrame)),                   // theta
         Angle2D(XYVectorF(pca_cand_seedFrame.x(), pca_cand_seedFrame.z()),                 // theta_xz_seedFrame
                 XYVectorF(0, 1)),

--- a/RecoHGCal/TICL/src/SuperclusteringDNNInputs.cc
+++ b/RecoHGCal/TICL/src/SuperclusteringDNNInputs.cc
@@ -2,7 +2,7 @@
 // Author: Theo Cuisset - theo.cuisset@cern.ch
 // Date: 11/2023
 
-// Modified by Gamze Sokmen 
+// Modified by Gamze Sokmen - gamze.sokmen@cern.ch 
 // Changes: Implementation of the delta time feature under a new DNN input version (v3) for the superclustering DNN and correcting the seed pT calculation.
 // Date: 07/2025
 
@@ -123,8 +123,8 @@ namespace ticl {
 
     float explVar_denominator = std::accumulate(
         std::begin(ts_toCluster.eigenvalues()), std::end(ts_toCluster.eigenvalues()), 0.f, std::plus<float>());
-    float explVarRatio = 0.;
-    if (explVar_denominator != 0.) {
+    float explVarRatio = 0.f;
+    if (explVar_denominator != 0.f) {
       explVarRatio = ts_toCluster.eigenvalues()[0] / explVar_denominator;
     } else {
       edm::LogWarning("HGCalTICLSuperclustering")
@@ -134,8 +134,7 @@ namespace ticl {
 
     // modified deltaTime: set the default values <-50 or >50 to -5
     float raw_dt       = ts_toCluster.time() - ts_base.time();
-    float mod_deltaTime = (raw_dt < -50.f || raw_dt > 50.f) ? -5.f : raw_dt;
-
+    float mod_deltaTime = ( raw_dt < -kDeltaTimeDefault || raw_dt > kDeltaTimeDefault ) ? kBadDeltaTime : raw_dt;
 
     return {{
       std::abs(ts_toCluster.barycenter().Eta()) - std::abs(ts_base.barycenter().Eta()),  // DeltaEtaBaryc

--- a/RecoHGCal/TICL/src/SuperclusteringDNNInputs.cc
+++ b/RecoHGCal/TICL/src/SuperclusteringDNNInputs.cc
@@ -1,6 +1,11 @@
 /** Computation of input features for superclustering DNN. Used by plugins/TracksterLinkingBySuperClustering.cc and plugins/SuperclusteringSampleDumper.cc */
 // Author: Theo Cuisset - theo.cuisset@cern.ch
 // Date: 11/2023
+
+// Modified by Gamze Sokmen 
+// Changes: Implementation of the delta time feature under a new DNN input version (v3) for the superclustering DNN and correcting the seed pT calculation.
+// Date: 07/2025
+
 #include "RecoHGCal/TICL/interface/SuperclusteringDNNInputs.h"
 
 #include <algorithm>
@@ -31,7 +36,7 @@ namespace ticl {
         ts_base.barycenter().Eta(),                                                        //seedEta
         ts_base.barycenter().Phi(),                                                        //seedPhi
         ts_base.raw_energy(),                                                              //seedEn
-        (ts_base.raw_energy() * std::sin(ts_toCluster.barycenter().Theta())),              //seedPt
+        (ts_base.raw_energy() * std::sin(ts_base.barycenter().Theta())),              //seedPt
     }};
   }
 
@@ -90,7 +95,7 @@ namespace ticl {
         ts_base.barycenter().Eta(),                                                        //seedEta
         ts_base.barycenter().Phi(),                                                        //seedPhi
         ts_base.raw_energy(),                                                              //seedEn
-        (ts_base.raw_energy() * std::sin(ts_toCluster.barycenter().Theta())),              //seedPt
+        (ts_base.raw_energy() * std::sin(ts_base.barycenter().Theta())),                   //seedPt 
         static_cast<float>(Angle(pca_cand_cmsFrame, pca_seed_cmsFrame)),  // theta : angle between seed and candidate
         Angle2D(XYVectorF(pca_cand_seedFrame.x(), pca_cand_seedFrame.z()), XYVectorF(0, 1)),  // theta_xz_seedFrame
         Angle2D(XYVectorF(pca_cand_seedFrame.y(), pca_cand_seedFrame.z()), XYVectorF(0, 1)),  // theta_yz_seedFrame
@@ -105,11 +110,67 @@ namespace ticl {
     }};
   }
 
+  std::vector<float> SuperclusteringDNNInputV3::computeVector(Trackster const& ts_base, Trackster const& ts_toCluster) {
+    using ROOT::Math::XYVectorF;
+    using ROOT::Math::XYZVectorF;
+    using ROOT::Math::VectorUtil::Angle;
+    XYZVectorF const& pca_seed_cmsFrame(ts_base.eigenvectors(0));
+    XYZVectorF const& pca_cand_cmsFrame(ts_toCluster.eigenvectors(0));
+    XYZVectorF xs(pca_seed_cmsFrame.Cross(XYZVectorF(0, 0, 1)).Unit());
+    ROOT::Math::Rotation3D rot(xs, xs.Cross(pca_seed_cmsFrame).Unit(), pca_seed_cmsFrame);
+
+    XYZVectorF pca_cand_seedFrame = rot(pca_cand_cmsFrame);  // seed coordinates
+
+    float explVar_denominator = std::accumulate(
+        std::begin(ts_toCluster.eigenvalues()), std::end(ts_toCluster.eigenvalues()), 0.f, std::plus<float>());
+    float explVarRatio = 0.;
+    if (explVar_denominator != 0.) {
+      explVarRatio = ts_toCluster.eigenvalues()[0] / explVar_denominator;
+    } else {
+      edm::LogWarning("HGCalTICLSuperclustering")
+          << "Sum of eigenvalues was zero for trackster. Could not compute explained variance ratio.";
+    }
+
+
+    // modified deltaTime: set the default values <-50 or >50 to -5
+    float raw_dt       = ts_toCluster.time() - ts_base.time();
+    float mod_deltaTime = (raw_dt < -50.f || raw_dt > 50.f) ? -5.f : raw_dt;
+
+
+    return {{
+      std::abs(ts_toCluster.barycenter().Eta()) - std::abs(ts_base.barycenter().Eta()),  // DeltaEtaBaryc
+      ts_toCluster.barycenter().Phi() - ts_base.barycenter().phi(),                      // DeltaPhiBaryc
+      ts_toCluster.raw_energy(),                                                         // multi_en
+      ts_toCluster.barycenter().Eta(),                                                   // multi_eta
+      ts_toCluster.raw_energy() * std::sin(ts_toCluster.barycenter().Theta()),           // multi_pt
+      ts_base.barycenter().Eta(),                                                        // seedEta
+      ts_base.barycenter().Phi(),                                                        // seedPhi
+      ts_base.raw_energy(),                                                              // seedEn
+      ts_base.raw_energy() * std::sin(ts_base.barycenter().Theta()),                     // seedPt
+      static_cast<float>(Angle(pca_cand_cmsFrame, pca_seed_cmsFrame)),                   // theta
+      Angle2D(XYVectorF(pca_cand_seedFrame.x(), pca_cand_seedFrame.z()),                 // theta_xz_seedFrame
+            XYVectorF(0,1)),
+      Angle2D(XYVectorF(pca_cand_seedFrame.y(), pca_cand_seedFrame.z()),                 // theta_yz_seedFrame
+            XYVectorF(0,1)),
+      Angle2D(XYVectorF(pca_cand_cmsFrame.x(), pca_cand_cmsFrame.y()),                   // theta_xy_cmsFrame
+            XYVectorF(pca_seed_cmsFrame.x(), pca_seed_cmsFrame.y())),
+      Angle2D(XYVectorF(pca_cand_cmsFrame.y(), pca_cand_cmsFrame.z()),                   // theta_yz_cmsFrame
+            XYVectorF(pca_seed_cmsFrame.y(), pca_seed_cmsFrame.z())),
+      Angle2D(XYVectorF(pca_cand_cmsFrame.x(), pca_cand_cmsFrame.z()),                   // theta_xz_cmsFrame
+            XYVectorF(pca_seed_cmsFrame.x(), pca_seed_cmsFrame.z())),
+      ts_toCluster.eigenvalues()[0],                                                     // explVar
+      explVarRatio,                                                                      // explVarRatio
+      mod_deltaTime                                                                      // mod_deltaTime
+      }};
+  }
+
   std::unique_ptr<AbstractSuperclusteringDNNInput> makeSuperclusteringDNNInputFromString(std::string dnnInputVersion) {
     if (dnnInputVersion == "v1")
       return std::make_unique<SuperclusteringDNNInputV1>();
     else if (dnnInputVersion == "v2")
       return std::make_unique<SuperclusteringDNNInputV2>();
+    else if (dnnInputVersion == "v3")
+      return std::make_unique<SuperclusteringDNNInputV3>();
     assert(false);
   }
 

--- a/RecoHGCal/TICL/src/SuperclusteringDNNInputs.cc
+++ b/RecoHGCal/TICL/src/SuperclusteringDNNInputs.cc
@@ -2,7 +2,7 @@
 // Author: Theo Cuisset - theo.cuisset@cern.ch
 // Date: 11/2023
 
-// Modified by Gamze Sokmen - gamze.sokmen@cern.ch 
+// Modified by Gamze Sokmen - gamze.sokmen@cern.ch
 // Changes: Implementation of the delta time feature under a new DNN input version (v3) for the superclustering DNN and correcting the seed pT calculation.
 // Date: 07/2025
 
@@ -36,7 +36,7 @@ namespace ticl {
         ts_base.barycenter().Eta(),                                                        //seedEta
         ts_base.barycenter().Phi(),                                                        //seedPhi
         ts_base.raw_energy(),                                                              //seedEn
-        (ts_base.raw_energy() * std::sin(ts_base.barycenter().Theta())),              //seedPt
+        (ts_base.raw_energy() * std::sin(ts_base.barycenter().Theta())),                   //seedPt
     }};
   }
 
@@ -95,7 +95,7 @@ namespace ticl {
         ts_base.barycenter().Eta(),                                                        //seedEta
         ts_base.barycenter().Phi(),                                                        //seedPhi
         ts_base.raw_energy(),                                                              //seedEn
-        (ts_base.raw_energy() * std::sin(ts_base.barycenter().Theta())),                   //seedPt 
+        (ts_base.raw_energy() * std::sin(ts_base.barycenter().Theta())),                   //seedPt
         static_cast<float>(Angle(pca_cand_cmsFrame, pca_seed_cmsFrame)),  // theta : angle between seed and candidate
         Angle2D(XYVectorF(pca_cand_seedFrame.x(), pca_cand_seedFrame.z()), XYVectorF(0, 1)),  // theta_xz_seedFrame
         Angle2D(XYVectorF(pca_cand_seedFrame.y(), pca_cand_seedFrame.z()), XYVectorF(0, 1)),  // theta_yz_seedFrame
@@ -131,36 +131,35 @@ namespace ticl {
           << "Sum of eigenvalues was zero for trackster. Could not compute explained variance ratio.";
     }
 
-
     // modified deltaTime: set the default values <-50 or >50 to -5
-    float raw_dt       = ts_toCluster.time() - ts_base.time();
-    float mod_deltaTime = ( raw_dt < -kDeltaTimeDefault || raw_dt > kDeltaTimeDefault ) ? kBadDeltaTime : raw_dt;
+    float raw_dt = ts_toCluster.time() - ts_base.time();
+    float mod_deltaTime = (raw_dt < -kDeltaTimeDefault || raw_dt > kDeltaTimeDefault) ? kBadDeltaTime : raw_dt;
 
     return {{
-      std::abs(ts_toCluster.barycenter().Eta()) - std::abs(ts_base.barycenter().Eta()),  // DeltaEtaBaryc
-      ts_toCluster.barycenter().Phi() - ts_base.barycenter().phi(),                      // DeltaPhiBaryc
-      ts_toCluster.raw_energy(),                                                         // multi_en
-      ts_toCluster.barycenter().Eta(),                                                   // multi_eta
-      ts_toCluster.raw_energy() * std::sin(ts_toCluster.barycenter().Theta()),           // multi_pt
-      ts_base.barycenter().Eta(),                                                        // seedEta
-      ts_base.barycenter().Phi(),                                                        // seedPhi
-      ts_base.raw_energy(),                                                              // seedEn
-      ts_base.raw_energy() * std::sin(ts_base.barycenter().Theta()),                     // seedPt
-      static_cast<float>(Angle(pca_cand_cmsFrame, pca_seed_cmsFrame)),                   // theta
-      Angle2D(XYVectorF(pca_cand_seedFrame.x(), pca_cand_seedFrame.z()),                 // theta_xz_seedFrame
-            XYVectorF(0,1)),
-      Angle2D(XYVectorF(pca_cand_seedFrame.y(), pca_cand_seedFrame.z()),                 // theta_yz_seedFrame
-            XYVectorF(0,1)),
-      Angle2D(XYVectorF(pca_cand_cmsFrame.x(), pca_cand_cmsFrame.y()),                   // theta_xy_cmsFrame
-            XYVectorF(pca_seed_cmsFrame.x(), pca_seed_cmsFrame.y())),
-      Angle2D(XYVectorF(pca_cand_cmsFrame.y(), pca_cand_cmsFrame.z()),                   // theta_yz_cmsFrame
-            XYVectorF(pca_seed_cmsFrame.y(), pca_seed_cmsFrame.z())),
-      Angle2D(XYVectorF(pca_cand_cmsFrame.x(), pca_cand_cmsFrame.z()),                   // theta_xz_cmsFrame
-            XYVectorF(pca_seed_cmsFrame.x(), pca_seed_cmsFrame.z())),
-      ts_toCluster.eigenvalues()[0],                                                     // explVar
-      explVarRatio,                                                                      // explVarRatio
-      mod_deltaTime                                                                      // mod_deltaTime
-      }};
+        std::abs(ts_toCluster.barycenter().Eta()) - std::abs(ts_base.barycenter().Eta()),  // DeltaEtaBaryc
+        ts_toCluster.barycenter().Phi() - ts_base.barycenter().phi(),                      // DeltaPhiBaryc
+        ts_toCluster.raw_energy(),                                                         // multi_en
+        ts_toCluster.barycenter().Eta(),                                                   // multi_eta
+        ts_toCluster.raw_energy() * std::sin(ts_toCluster.barycenter().Theta()),           // multi_pt
+        ts_base.barycenter().Eta(),                                                        // seedEta
+        ts_base.barycenter().Phi(),                                                        // seedPhi
+        ts_base.raw_energy(),                                                              // seedEn
+        ts_base.raw_energy() * std::sin(ts_base.barycenter().Theta()),                     // seedPt
+        static_cast<float>(Angle(pca_cand_cmsFrame, pca_seed_cmsFrame)),                   // theta
+        Angle2D(XYVectorF(pca_cand_seedFrame.x(), pca_cand_seedFrame.z()),                 // theta_xz_seedFrame
+                XYVectorF(0, 1)),
+        Angle2D(XYVectorF(pca_cand_seedFrame.y(), pca_cand_seedFrame.z()),  // theta_yz_seedFrame
+                XYVectorF(0, 1)),
+        Angle2D(XYVectorF(pca_cand_cmsFrame.x(), pca_cand_cmsFrame.y()),  // theta_xy_cmsFrame
+                XYVectorF(pca_seed_cmsFrame.x(), pca_seed_cmsFrame.y())),
+        Angle2D(XYVectorF(pca_cand_cmsFrame.y(), pca_cand_cmsFrame.z()),  // theta_yz_cmsFrame
+                XYVectorF(pca_seed_cmsFrame.y(), pca_seed_cmsFrame.z())),
+        Angle2D(XYVectorF(pca_cand_cmsFrame.x(), pca_cand_cmsFrame.z()),  // theta_xz_cmsFrame
+                XYVectorF(pca_seed_cmsFrame.x(), pca_seed_cmsFrame.z())),
+        ts_toCluster.eigenvalues()[0],  // explVar
+        explVarRatio,                   // explVarRatio
+        mod_deltaTime                   // mod_deltaTime
+    }};
   }
 
   std::unique_ptr<AbstractSuperclusteringDNNInput> makeSuperclusteringDNNInputFromString(std::string dnnInputVersion) {


### PR DESCRIPTION
This PR introduces a new version (v3) of the SuperclusterDNN to be used for superclustering in TICLv5. This PR includes  updates to the previous DNN model as well as the superclustering algorithm. The model and algorithm are used for reconstructing electromagnetic objects within TICL. 

-This PR needs to be tested with the following cms-data PR: https://github.com/cms-data/RecoHGCal-TICL/pull/9

-It needs to be tested with the following workflows 
  . 29646.203
  . 29846.203

-Validation plots are attached. 
[Validation_SuperclusterDNN_v3_4Sept_GSokmen.pdf](https://github.com/user-attachments/files/22174080/Validation_SuperclusterDNN_v3_4Sept_GSokmen.pdf)


@waredjeb @felicepantaleo @sameasy 