### PR TITLE
Fix to unpacker / module locator for HGCAL

### DIFF
--- a/CondFormats/HGCalObjects/interface/HGCalMappingModuleIndexer.h
+++ b/CondFormats/HGCalObjects/interface/HGCalMappingModuleIndexer.h
@@ -21,6 +21,8 @@
  */
 struct HGCalFEDReadoutSequence {
   uint32_t id;
+  //overall counters for total number of ECONs and Capture Blocks (useful to steer the unpacker behavior)
+  size_t totalECONs_, totalCBs_;
   /// look-up table (capture block, econd idx) -> internal dense index
   std::vector<int> moduleLUT_;
   /// dense sequence of modules in the readout: the type is the one in use in the cell mapping

--- a/CondFormats/HGCalObjects/src/HGCalMappingModuleIndexer.cc
+++ b/CondFormats/HGCalObjects/src/HGCalMappingModuleIndexer.cc
@@ -94,7 +94,7 @@ void HGCalMappingModuleIndexer::finalize() {
       fedit.moduleLUT_[i] = nconn;
       nconn++;
 
-      uniqueCB.insert( modFedIndexer_.unpackDenseIndex(i)[0] );
+      uniqueCB.insert(modFedIndexer_.unpackDenseIndex(i)[0]);
     }
     fedit.totalECONs_ = nconn;
     fedit.totalCBs_ = uniqueCB.size();

--- a/CondFormats/HGCalObjects/src/HGCalMappingModuleIndexer.cc
+++ b/CondFormats/HGCalObjects/src/HGCalMappingModuleIndexer.cc
@@ -82,8 +82,10 @@ void HGCalMappingModuleIndexer::finalize() {
   std::vector<uint32_t> typeCounters(globalTypesCounter_.size(), 0);
   for (auto& fedit : fedReadoutSequences_) {
     //assign the final indexing in the look-up table depending on which ECON-D's are really present
+    //count also the the number of capture blocks present
     size_t nconn(0);
     fedit.moduleLUT_.resize(fedit.readoutTypes_.size(), -1);
+    std::set<uint32_t> uniqueCB;
     for (size_t i = 0; i < fedit.readoutTypes_.size(); i++) {
       if (fedit.readoutTypes_[i] == -1)
         continue;  //unexisting
@@ -91,7 +93,11 @@ void HGCalMappingModuleIndexer::finalize() {
       reassignTypecodeLocation(fedit.id, i, nconn);
       fedit.moduleLUT_[i] = nconn;
       nconn++;
+
+      uniqueCB.insert( modFedIndexer_.unpackDenseIndex(i)[0] );
     }
+    fedit.totalECONs_ = nconn;
+    fedit.totalCBs_ = uniqueCB.size();
 
     //remove unexisting ECONs building a final compact readout sequence
     fedit.readoutTypes_.erase(

--- a/DataFormats/HGCalDigi/interface/HGCalFEDPacketInfoSoA.h
+++ b/DataFormats/HGCalDigi/interface/HGCalFEDPacketInfoSoA.h
@@ -14,7 +14,7 @@ namespace hgcaldigi {
     constexpr uint8_t NormalUnpacking = 0, GenericUnpackError = 1, ErrorSLinkHeader = 2, ErrorPayload = 3,
                       ErrorCaptureBlockHeader = 4, ActiveCaptureBlockFlags = 5, ErrorECONDHeader = 6,
                       ECONDPayloadLengthOverflow = 7, ECONDPayloadLengthMismatch = 8, ErrorSLinkTrailer = 9,
-                      EarlySLinkEnd = 10;
+                      EarlySLinkEnd = 10, GenericUnpackWarning = 11;
   }  // namespace FEDUnpackingFlags
 
   inline constexpr bool isNotNormalFED(uint16_t fedUnpackingFlag) {

--- a/EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc
+++ b/EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc
@@ -159,7 +159,6 @@ uint16_t HGCalRawToDigi::callUnpacker(unsigned fedId,
 void HGCalRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag("rawDataCollector"));
-  desc.add<std::vector<unsigned int> >("fedIds", {});
   desc.add<bool>("doSerial", true)->setComment("do not attempt to paralleize unpacking of different FEDs");
   desc.add<bool>("headersOnly", false)->setComment("unpack only headers");
   descriptions.add("hgcalDigis", desc);

--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
@@ -102,7 +102,7 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
 
   // parse SLink body (capture blocks)
   bool hasActiveCBFlags(false);
-  for (uint32_t captureblockIdx = 0; captureblockIdx < HGCalMappingModuleIndexer::maxCBperFED_ && ptr < trailer - 2;
+  for (uint32_t captureblockIdx = 0; captureblockIdx < fedReadoutSequence.totalCBs_ && ptr < trailer - 2;
        captureblockIdx++) {
     // check capture block header (64b)
 
@@ -159,10 +159,9 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
         // always increment the global ECON-D index (unless inactive/unconnected)
         globalECONDIdx++;
 
-	//if for some reason we get more than expected there is something funny with the data
-	//for now raise a payload error
-	if(globalECONDIdx >= fedReadoutSequence.readoutTypes_.size()) {
-	  return (0x1 << hgcaldigi::FEDUnpackingFlags::ErrorPayload);
+	//stop if we have all the ECON-Ds expected
+	if(globalECONDIdx >= fedReadoutSequence.totalECONs_) {
+	  return (0x1 << hgcaldigi::FEDUnpackingFlags::GenericUnpackWarning);
 	}
 	  
       }

--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
@@ -84,7 +84,7 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
   auto slink_header = *(ptr + 1);
   if (((slink_header >> (BACKEND_FRAME::SLINK_BOE_POS + 32)) & BACKEND_FRAME::SLINK_BOE_MASK) !=
       fedConfig.slinkHeaderMarker) {
-    uint32_t ECONDdenseIdx = moduleIndexer.getIndexForModule(fedId, 0);    
+    uint32_t ECONDdenseIdx = moduleIndexer.getIndexForModule(fedId, 0);
     econdPacketInfo.view()[ECONDdenseIdx].exception() = 1;
     econdPacketInfo.view()[ECONDdenseIdx].location() = 0;
     edm::LogWarning("[HGCalUnpacker]") << "Expected a S-Link header (BOE: 0x" << std::hex << fedConfig.slinkHeaderMarker
@@ -117,7 +117,7 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
         fedConfig.cbHeaderMarker) {
       //if word is a 0x0 it probably means that it's a 64b padding word: check that we are ending
       //the s-link may have less capture blocks than the maxCBperFED_ so for now this is considered normal
-      uint32_t ECONDdenseIdx = moduleIndexer.getIndexForModule(fedId, 0);      
+      uint32_t ECONDdenseIdx = moduleIndexer.getIndexForModule(fedId, 0);
       econdPacketInfo.view()[ECONDdenseIdx].location() = (uint32_t)(ptr - header);
       if (cb_header == 0x0) {
         auto nToEnd = (fed_data.size() / 8 - 2) - std::distance(header, ptr);
@@ -159,11 +159,10 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
         // always increment the global ECON-D index (unless inactive/unconnected)
         globalECONDIdx++;
 
-	//stop if we have all the ECON-Ds expected
-	if(globalECONDIdx >= fedReadoutSequence.totalECONs_) {
-	  return (0x1 << hgcaldigi::FEDUnpackingFlags::GenericUnpackWarning);
-	}
-	  
+        //stop if we have all the ECON-Ds expected
+        if (globalECONDIdx >= fedReadoutSequence.totalECONs_) {
+          return (0x1 << hgcaldigi::FEDUnpackingFlags::GenericUnpackWarning);
+        }
       }
       LogDebug("[HGCalUnpacker]") << "fedId = " << fedId << ", captureblockIdx = " << captureblockIdx
                                   << ", econdIdx = " << econdIdx << ", globalECONDIdx = " << (int)globalECONDIdx

--- a/EventFilter/Utilities/src/DAQSourceModelsDTH.cc
+++ b/EventFilter/Utilities/src/DAQSourceModelsDTH.cc
@@ -512,7 +512,7 @@ int DataModeDTH::eventCounterCallback(
       edm::LogError("EvFDaqDirector") << "Invalid DTH header encountered";
       return fileClose();
     }
-    if (!oh->verifyMarker() || oh->version() != 1) {
+    if (!oh->verifyMarker() || (oh->version() != 1 && oh->version() != 2)) {
       edm::LogError("EvFDaqDirector") << "Unexpected DTH header version " << oh->version();
       return fileClose();
     }

--- a/Geometry/HGCalMapping/test/HGCalMappingESSourceTester.cc
+++ b/Geometry/HGCalMapping/test/HGCalMappingESSourceTester.cc
@@ -272,7 +272,7 @@ void HGCalMappingESSourceTester::analyze(const edm::Event& iEvent, const edm::Ev
   assert(gid.cellU() == celliu);
   assert(gid.cellV() == celliv);
 
-  int modidx(2), cellidx(1);
+  int modidx(0), cellidx(1);
   printf(
       "[HGCalMappingIndexESSourceTester][produce]  Creating %d number of raw ElectronicsIds from SoAs module idx: "
       "%d, cell idx: %d\n",

--- a/Geometry/HGCalMapping/test/HGCalMappingESSourceTester.cc
+++ b/Geometry/HGCalMapping/test/HGCalMappingESSourceTester.cc
@@ -272,7 +272,7 @@ void HGCalMappingESSourceTester::analyze(const edm::Event& iEvent, const edm::Ev
   assert(gid.cellU() == celliu);
   assert(gid.cellV() == celliv);
 
-  int modidx(0), cellidx(1);
+  int modidx(2), cellidx(1);
   printf(
       "[HGCalMappingIndexESSourceTester][produce]  Creating %d number of raw ElectronicsIds from SoAs module idx: "
       "%d, cell idx: %d\n",

--- a/Geometry/HGCalMapping/test/HGCalMappingESSourceTester.cc
+++ b/Geometry/HGCalMapping/test/HGCalMappingESSourceTester.cc
@@ -148,9 +148,12 @@ void HGCalMappingESSourceTester::analyze(const edm::Event& iEvent, const edm::Ev
               frs.chDataOffsets_.end(),
               std::inserter(unique_chDataOffsets, unique_chDataOffsets.end()));
 
-    size_t nmods = frs.readoutTypes_.size();
+    assert(frs.readoutTypes_.size() == frs.totalECONs_);
+    size_t nmods = frs.totalECONs_;
+    if(nmods==0) continue;
     totalmods += nmods;
-    printf("\t[FED %d] packs data from %ld ECON-Ds - readout types -> (offsets) :", frs.id, nmods);
+    printf("\t[FED %d] packs data from %ld ECON-Ds - readout types -> (offsets)\n", frs.id, nmods);
+    printf("\tTotal capture blocks: %ld Total ECON-Ds %ld\n", frs.totalCBs_, frs.totalECONs_);
     for (size_t i = 0; i < nmods; i++) {
       printf("\t%d -> (%d;%d;%d)", frs.readoutTypes_[i], frs.modOffsets_[i], frs.erxOffsets_[i], frs.chDataOffsets_[i]);
     }
@@ -247,7 +250,7 @@ void HGCalMappingESSourceTester::analyze(const edm::Event& iEvent, const edm::Ev
   printf("\tTime: %f seconds\n", elapsed.count());
 
   HGCalElectronicsId eid(elecid);
-  assert(eid.localFEDId() == fedid);
+  assert(eid.localFEDId() == (fedid & HGCalElectronicsId::HGCalElectronicsIdMask::kLocalFEDIDMask));
   assert((uint32_t)eid.captureBlock() == captureblockidx);
   assert((uint32_t)eid.econdIdx() == econdidx);
   assert((uint32_t)eid.econdeRx() == (uint32_t)(2 * chip + half));
@@ -288,7 +291,7 @@ void HGCalMappingESSourceTester::analyze(const edm::Event& iEvent, const edm::Ev
   elapsed = stop - start;
   printf("\tTime: %f seconds\n", elapsed.count());
   eid = HGCalElectronicsId(elecid);
-  assert(eid.localFEDId() == modules.view()[modidx].fedid());
+  assert(eid.localFEDId() == (modules.view()[modidx].fedid() & HGCalElectronicsId::HGCalElectronicsIdMask::kLocalFEDIDMask));
   assert((uint32_t)eid.captureBlock() == modules.view()[modidx].captureblockidx());
   assert((uint32_t)eid.econdIdx() == modules.view()[modidx].econdidx());
   assert((uint32_t)eid.halfrocChannel() == cells.view()[cellidx].seq());

--- a/Geometry/HGCalMapping/test/HGCalMappingESSourceTester.cc
+++ b/Geometry/HGCalMapping/test/HGCalMappingESSourceTester.cc
@@ -150,7 +150,8 @@ void HGCalMappingESSourceTester::analyze(const edm::Event& iEvent, const edm::Ev
 
     assert(frs.readoutTypes_.size() == frs.totalECONs_);
     size_t nmods = frs.totalECONs_;
-    if(nmods==0) continue;
+    if (nmods == 0)
+      continue;
     totalmods += nmods;
     printf("\t[FED %d] packs data from %ld ECON-Ds - readout types -> (offsets)\n", frs.id, nmods);
     printf("\tTotal capture blocks: %ld Total ECON-Ds %ld\n", frs.totalCBs_, frs.totalECONs_);
@@ -291,7 +292,8 @@ void HGCalMappingESSourceTester::analyze(const edm::Event& iEvent, const edm::Ev
   elapsed = stop - start;
   printf("\tTime: %f seconds\n", elapsed.count());
   eid = HGCalElectronicsId(elecid);
-  assert(eid.localFEDId() == (modules.view()[modidx].fedid() & HGCalElectronicsId::HGCalElectronicsIdMask::kLocalFEDIDMask));
+  assert(eid.localFEDId() ==
+         (modules.view()[modidx].fedid() & HGCalElectronicsId::HGCalElectronicsIdMask::kLocalFEDIDMask));
   assert((uint32_t)eid.captureBlock() == modules.view()[modidx].captureblockidx());
   assert((uint32_t)eid.econdIdx() == modules.view()[modidx].econdidx());
   assert((uint32_t)eid.halfrocChannel() == cells.view()[cellidx].seq());


### PR DESCRIPTION
#### PR description:

In the course of commissioning HGCAL pre-series cassettes using the readout with the DTH-P2 we have found a few fragilities in the unpacker related to monitoring of the sub-packets in the raw data of each FED. Namely the unpacker was allowing the process the proceed up to the max. number of sub-packets that may exist and relying on sub-packet identifiers to continue or stop. In cases where padding to 64b is needed the backend may spuriously generate a word which resembles the sub-packet identified making the unpacker crash.
This was solved in two ways
* limit the unpacking to the max. number of sub-packets (capture blocks) expected for given FED : this PR
* change the padding in the backend firmware to be a 0 instead of word copy : independent of this PR

In the PR we propose also a simple patch to the `EventFilter/Utilities/src/DAQSourceModelsDTH.cc` to cope with DTH-P2 from @ hqucms. @smorovic - up to you if you prefer this taken out of this PR

#### PR validation:

PR was validated using data collected at CERN and FNAL for the first pre-series cassettes. Report given here 
https://indico.cern.ch/event/1574536/contributions/6633231/attachments/3112326/5519755/DPG-RDHFeedback-2025Jul31.pdf (only useful to illustrate that data are unpacked and pushed all the way through DQM...)


FYI @yulunmiao @IzaakWN @cramonal @lourdesurda @hqucms 