### PR TITLE
[L1T] Update P2GT Emulator with latest IDs and Scalings from Annual Review 2025 (Phase 2)

### DIFF
--- a/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTMenuObjects_cff.py
+++ b/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTMenuObjects_cff.py
@@ -84,6 +84,7 @@ l1tGTtkElectronLowPt = l1tGTtkElectronBase.clone(
 
 l1tGTtkIsoElectron = l1tGTtkElectronBase.clone(
     regionsMaxRelIsolationPt = get_object_isos("CL2Electrons","Iso"),
+    regionsQualityFlags = get_object_ids("CL2Electrons","Iso"),
 )
 
 ############################################################

--- a/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTMenu_BTagSeeds_cff.py
+++ b/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTMenu_BTagSeeds_cff.py
@@ -54,12 +54,12 @@ DoubleTkMuon4p5OSEr2Mass7to18 = l1tGTDoubleObjectCond.clone(
     collection1 = l1tGTtkMuonLoose.clone(
         minEta = cms.double(-2.0),
         maxEta = cms.double(2.0),
-        minPt = cms.double(4),
+        minPt = cms.double(4.4),
     ),
     collection2 = l1tGTtkMuonLoose.clone(
         minEta = cms.double(-2.0),
         maxEta = cms.double(2.0),
-        minPt = cms.double(4),
+        minPt = cms.double(4.4),
     ),
     minDR = cms.double(0),
     minInvMass = cms.double(7),

--- a/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTMenu_crossLepSeeds_cff.py
+++ b/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTMenu_crossLepSeeds_cff.py
@@ -44,7 +44,7 @@ algorithms.append(cms.PSet(expression = cms.string("pTkMuonTkEle7_23")))
 
 TkEleTkMuon1020 = l1tGTDoubleObjectCond.clone(
     collection1 = l1tGTtkElectron.clone(
-        regionsMinPt = get_object_thrs(36, "CL2Electrons","NoIso"),
+        regionsMinPt = get_object_thrs(10, "CL2Electrons","NoIso"),
     ),
     collection2 = l1tGTtkMuonVLoose.clone(
         regionsMinPt = get_object_thrs(20, "GMTTkMuons","VLoose"),

--- a/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTMenu_lepSeeds_cff.py
+++ b/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTMenu_lepSeeds_cff.py
@@ -69,17 +69,17 @@ algorithms.append(cms.PSet(expression = cms.string("pTripleTkMuon5_3_3")))
 
 SingleEGEle51 = l1tGTSingleObjectCond.clone(
     l1tGTtkPhoton.clone(),
-    regionsMinPt = get_object_thrs(51, "CL2Photons","Iso"),
+    regionsMinPt = get_object_thrs(51, "L1EG","default"),
 )
 pSingleEGEle51 = cms.Path(SingleEGEle51) 
 algorithms.append(cms.PSet(expression = cms.string("pSingleEGEle51")))
 
 DoubleEGEle3724 = l1tGTDoubleObjectCond.clone(
-    collection1 = l1tGTtkIsoPhoton.clone(
-        regionsMinPt = get_object_thrs(37, "CL2Photons","Iso"),
+    collection1 = l1tGTtkPhoton.clone(
+        regionsMinPt = get_object_thrs(37, "L1EG","default"),
     ),
-    collection2 = l1tGTtkIsoPhoton.clone(
-        regionsMinPt = get_object_thrs(24, "CL2Photons","Iso"), 
+    collection2 = l1tGTtkPhoton.clone(
+        regionsMinPt = get_object_thrs(24, "L1EG","default"), 
     ),
     minDR = cms.double(0.1),
 )
@@ -90,8 +90,8 @@ IsoTkEleEGEle2212 = l1tGTDoubleObjectCond.clone(
     collection1 = l1tGTtkIsoElectron.clone(
         regionsMinPt = get_object_thrs(22, "CL2Electrons","Iso"),
     ),
-    collection2 = l1tGTtkIsoPhoton.clone(
-        regionsMinPt = get_object_thrs(12, "CL2Photons","Iso"),
+    collection2 = l1tGTtkPhoton.clone(
+        regionsMinPt = get_object_thrs(12, "L1EG","default"),
     ),
     minDR = cms.double(0.1),
 )

--- a/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTObject_constants.py
+++ b/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTObject_constants.py
@@ -9,6 +9,7 @@ from L1Trigger.Configuration.Phase2GTMenus.SeedDefinitions.step1_2024.l1tGTObjec
 obj_regions_abseta_lowbounds = {
     "CL2Photons": { "barrel": 0, "endcap": 1.479 },
     "CL2Electrons": { "barrel": 0, "endcap": 1.479 },
+    "L1EG": { "barrel": 0, "endcap": 1.479 },
 
     "CL2Taus": { "barrel": 0, "endcap": 1.5 },
     "CL2JetsSC4": { "barrel": 0, "endcap": 1.5, "forwardHGC": 2.4, "forwardHF": 3.0 },

--- a/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTObject_constants.py
+++ b/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTObject_constants.py
@@ -11,7 +11,7 @@ obj_regions_abseta_lowbounds = {
     "CL2Electrons": { "barrel": 0, "endcap": 1.479 },
 
     "CL2Taus": { "barrel": 0, "endcap": 1.5 },
-    "CL2JetsSC4": { "barrel": 0, "endcap": 1.5, "forward": 2.4 },
+    "CL2JetsSC4": { "barrel": 0, "endcap": 1.5, "forwardHGC": 2.4, "forwardHF": 3.0 },
 
     "GMTTkMuons": { "barrel": 0, "overlap": 0.83, "endcap": 1.24 },
     "GMTMuons": { "barrel": 0, "overlap": 0.83, "endcap": 1.24 },

--- a/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTObject_ids.py
+++ b/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTObject_ids.py
@@ -22,10 +22,10 @@ objectIDs = {
     },
     "CL2Electrons":{
         "Iso": {
-            # "qual": {
-            #     "barrel": 0b0010,
-            #     "endcap": 0b0010,
-            # },
+            "qual": {
+                "barrel": 0b0010,
+                "endcap": 0b0010,
+            },
             "iso": {
                 "barrel": 0.13,
                 "endcap": 0.28,

--- a/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTObject_ids.py
+++ b/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTObject_ids.py
@@ -40,7 +40,7 @@ objectIDs = {
         "NoIsoLowPt": {
             "qual": {
                 "barrel": 0b0010,
-                "endcap": 0b0000,
+                "endcap": 0b0010, # Now apply electron ID in endcap for all pT, remove separate LowPt category?
             },
         }
     },

--- a/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTObject_ids.py
+++ b/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTObject_ids.py
@@ -11,7 +11,7 @@ objectIDs = {
     "CL2Photons":{
         "Iso": {
             "qual": {
-                "barrel": 0b0010,
+                "barrel": 0b0100,
                 "endcap": 0b0100,
             },
             "iso": {

--- a/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTObject_scalings.py
+++ b/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTObject_scalings.py
@@ -21,7 +21,7 @@ scalings = {
         },
         "NoIso": {
             "barrel": {
-                "offset": 3.69,
+                "offset": 3.7,
                 "slope": 1.18
             },
             "endcap": {
@@ -33,7 +33,7 @@ scalings = {
     "CL2EtSum": {
         "default": {
             "inclusive": {
-                "offset": 36.8,
+                "offset": 37.03,
                 "slope": 1.68
             }
         }
@@ -41,13 +41,13 @@ scalings = {
     "CL2HtSum": {
         "HT": {
             "inclusive": {
-                "offset": 37.73,
+                "offset": 37.82,
                 "slope": 1.17
             }
         },
         "MHT": {
             "inclusive": {
-                "offset": -13.67,
+                "offset": -13.7,
                 "slope": 1.2
             }
         }
@@ -55,19 +55,19 @@ scalings = {
     "CL2JetsSC4": {
         "default": {
             "barrel": {
-                "offset": 16.52,
+                "offset": 16.51,
                 "slope": 1.36
             },
             "endcap": {
-                "offset": 10.14,
+                "offset": 10.1,
                 "slope": 1.59
             },
             "forwardHF": {
-                "offset": -6.35,
-                "slope": 1.34
+                "offset": -5.9,
+                "slope": 1.33
             },
             "forwardHGC": {
-                "offset": 47.81,
+                "offset": 47.64,
                 "slope": 1.22
             }
         }
@@ -75,20 +75,38 @@ scalings = {
     "CL2JetsSC8": {
         "default": {
             "barrel": {
-                "offset": 25.88,
+                "offset": 25.77,
                 "slope": 1.4
             },
             "endcap": {
-                "offset": 24.88,
+                "offset": 24.97,
                 "slope": 1.46
             },
             "forwardHF": {
-                "offset": -5.31,
+                "offset": -5.49,
                 "slope": 1.5
             },
             "forwardHGC": {
-                "offset": 63.24,
+                "offset": 63.12,
                 "slope": 1.28
+            }
+        },
+        "mass30": {
+            "barrel": {
+                "offset": 2.84,
+                "slope": 1.45
+            },
+            "endcap": {
+                "offset": 6.82,
+                "slope": 1.31
+            },
+            "forwardHF": {
+                "offset": 95.12,
+                "slope": 0.58
+            },
+            "forwardHGC": {
+                "offset": 51.74,
+                "slope": 1.15
             }
         }
     },
@@ -117,7 +135,7 @@ scalings = {
     "CL2Taus": {
         "default": {
             "barrel": {
-                "offset": -0.31,
+                "offset": -0.29,
                 "slope": 1.38
             },
             "endcap": {
@@ -129,16 +147,16 @@ scalings = {
     "GMTSaPromptMuons": {
         "default": {
             "barrel": {
-                "offset": 1.1,
+                "offset": 1.09,
                 "slope": 1.69
             },
             "endcap": {
-                "offset": -3.1,
+                "offset": -3.08,
                 "slope": 1.21
             },
             "overlap": {
-                "offset": -1.19,
-                "slope": 1.32
+                "offset": -1.15,
+                "slope": 1.31
             }
         }
     },
@@ -149,7 +167,7 @@ scalings = {
                 "slope": 1.04
             },
             "endcap": {
-                "offset": 0.81,
+                "offset": 0.82,
                 "slope": 1.04
             },
             "overlap": {
@@ -163,11 +181,11 @@ scalings = {
                 "slope": 1.04
             },
             "endcap": {
-                "offset": 0.81,
+                "offset": 0.82,
                 "slope": 1.04
             },
             "overlap": {
-                "offset": 1.08,
+                "offset": 1.09,
                 "slope": 1.03
             }
         },
@@ -195,7 +213,7 @@ scalings = {
                 "slope": 1.04
             },
             "overlap": {
-                "offset": 1.08,
+                "offset": 1.09,
                 "slope": 1.03
             }
         },
@@ -205,7 +223,7 @@ scalings = {
                 "slope": 1.04
             },
             "endcap": {
-                "offset": 0.79,
+                "offset": 0.8,
                 "slope": 1.04
             },
             "overlap": {
@@ -221,7 +239,7 @@ scalings = {
                 "slope": 1.15
             },
             "endcap": {
-                "offset": 2.38,
+                "offset": 2.37,
                 "slope": 1.24
             }
         }
@@ -229,25 +247,25 @@ scalings = {
     "L1TrackHT": {
         "HT": {
             "inclusive": {
-                "offset": -36.76,
+                "offset": -36.64,
                 "slope": 2.51
             }
         },
         "MHT": {
             "inclusive": {
-                "offset": -9.98,
-                "slope": 2.16
+                "offset": -10.92,
+                "slope": 2.17
             }
         }
     },
     "L1TrackJet": {
         "default": {
             "barrel": {
-                "offset": 13.45,
+                "offset": 13.36,
                 "slope": 5.26
             },
             "endcap": {
-                "offset": 17.38,
+                "offset": 17.39,
                 "slope": 7.67
             }
         }
@@ -255,7 +273,7 @@ scalings = {
     "L1TrackMET": {
         "default": {
             "inclusive": {
-                "offset": -77.78,
+                "offset": -77.79,
                 "slope": 8.69
             }
         }
@@ -263,12 +281,12 @@ scalings = {
     "L1caloJet": {
         "default": {
             "barrel": {
-                "offset": 2.83,
-                "slope": 1.46
+                "offset": 2.77,
+                "slope": 1.47
             },
             "endcap": {
-                "offset": 25.75,
-                "slope": 1.99
+                "offset": 23.47,
+                "slope": 2.0
             },
             "forwardHF": {
                 "offset": -30.41,
@@ -319,27 +337,33 @@ scalings = {
     "L1puppiExtJetSC4": {
         "default": {
             "barrel": {
-                "offset": 3.29,
+                "offset": 3.24,
                 "slope": 1.61
             },
             "endcap": {
-                "offset": 12.25,
+                "offset": 12.05,
                 "slope": 1.53
             },
             "forwardHF": {
-                "offset": -6.35,
-                "slope": 1.34
+                "offset": -5.9,
+                "slope": 1.33
             },
             "forwardHGC": {
-                "offset": 47.57,
+                "offset": 47.31,
                 "slope": 1.23
             }
         }
     },
     "L1puppiHistoJetSums": {
+        "HT": {
+            "inclusive": {
+                "offset": 45.97,
+                "slope": 1.18
+            }
+        },
         "MHT": {
             "inclusive": {
-                "offset": -17.4,
+                "offset": -17.45,
                 "slope": 1.23
             }
         }
@@ -347,8 +371,8 @@ scalings = {
     "L1puppiJetSC4NG": {
         "default": {
             "barrel": {
-                "offset": 10.8,
-                "slope": 1.66
+                "offset": 12.02,
+                "slope": 1.64
             },
             "endcap": {
                 "offset": 4.32,
@@ -359,7 +383,7 @@ scalings = {
     "L1puppiMLMET": {
         "default": {
             "inclusive": {
-                "offset": 28.82,
+                "offset": 28.84,
                 "slope": 1.6
             }
         }

--- a/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTObject_scalings.py
+++ b/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTObject_scalings.py
@@ -2,7 +2,7 @@
 ### as derived by the Phase-2 L1 DPG Menu team
 ### using the Phase-2 MenuTools: https://github.com/cms-l1-dpg/Phase2-L1MenuTools
 
-### Corresponds to version v44 derived with the Annual Review 2024 config in the 14_2_x release
+### Corresponds to version v49 derived with the Annual Review 2025 config in the 15_1_x release
 ### See the L1T Phase-2 Menu Twiki for more details: https://twiki.cern.ch/twiki/bin/viewauth/CMS/PhaseIIL1TriggerMenuTools#Phase_2_L1_Trigger_objects_based
 
 ### NB Objects starting with L1 are not yet part of the Step1 Menu and thus no seeds implemented in the P2GT emulator
@@ -11,21 +11,21 @@ scalings = {
     "CL2Electrons": {
         "Iso": {
             "barrel": {
-                "offset": 1.16,
-                "slope": 1.18
+                "offset": 3.58,
+                "slope": 1.17
             },
             "endcap": {
-                "offset": 0.18,
-                "slope": 1.25
+                "offset": 2.05,
+                "slope": 1.24
             }
         },
         "NoIso": {
             "barrel": {
-                "offset": 1.24,
+                "offset": 3.69,
                 "slope": 1.18
             },
             "endcap": {
-                "offset": 0.63,
+                "offset": 2.6,
                 "slope": 1.25
             }
         }
@@ -33,175 +33,183 @@ scalings = {
     "CL2EtSum": {
         "default": {
             "inclusive": {
-                "offset": 37.05,
-                "slope": 1.64
+                "offset": 36.8,
+                "slope": 1.68
             }
         }
     },
     "CL2HtSum": {
         "HT": {
             "inclusive": {
-                "offset": 45.7,
-                "slope": 1.12
+                "offset": 37.73,
+                "slope": 1.17
             }
         },
         "MHT": {
             "inclusive": {
-                "offset": -12.93,
-                "slope": 1.16
+                "offset": -13.67,
+                "slope": 1.2
             }
         }
     },
     "CL2JetsSC4": {
         "default": {
             "barrel": {
-                "offset": 17.33,
-                "slope": 1.28
+                "offset": 16.52,
+                "slope": 1.36
             },
             "endcap": {
-                "offset": 15.33,
-                "slope": 1.67
+                "offset": 10.14,
+                "slope": 1.59
             },
-            "forward": {
-                "offset": 71.45,
-                "slope": 1.14
+            "forwardHF": {
+                "offset": -6.35,
+                "slope": 1.34
+            },
+            "forwardHGC": {
+                "offset": 47.81,
+                "slope": 1.22
             }
         }
     },
     "CL2JetsSC8": {
         "default": {
             "barrel": {
-                "offset": 23.98,
-                "slope": 1.37
+                "offset": 25.88,
+                "slope": 1.4
             },
             "endcap": {
-                "offset": 28.95,
-                "slope": 1.56
+                "offset": 24.88,
+                "slope": 1.46
             },
-            "forward": {
-                "offset": 69.06,
-                "slope": 1.42
+            "forwardHF": {
+                "offset": -5.31,
+                "slope": 1.5
+            },
+            "forwardHGC": {
+                "offset": 63.24,
+                "slope": 1.28
             }
         }
     },
     "CL2Photons": {
         "Iso": {
             "barrel": {
-                "offset": 3.04,
-                "slope": 1.09
+                "offset": 3.43,
+                "slope": 1.13
             },
             "endcap": {
-                "offset": 7.73,
-                "slope": 0.96
+                "offset": 7.71,
+                "slope": 0.97
             }
         },
         "NoIso": {
             "barrel": {
-                "offset": 4.43,
-                "slope": 1.07
+                "offset": 4.44,
+                "slope": 1.12
             },
             "endcap": {
-                "offset": 5.22,
-                "slope": 1.07
+                "offset": 6.01,
+                "slope": 1.06
             }
         }
     },
     "CL2Taus": {
         "default": {
             "barrel": {
-                "offset": 3.53,
-                "slope": 1.26
+                "offset": -0.31,
+                "slope": 1.38
             },
             "endcap": {
-                "offset": -3.15,
-                "slope": 1.66
+                "offset": -4.96,
+                "slope": 1.89
             }
         }
     },
     "GMTSaPromptMuons": {
         "default": {
             "barrel": {
-                "offset": 1.08,
+                "offset": 1.1,
                 "slope": 1.69
             },
             "endcap": {
-                "offset": -2.97,
+                "offset": -3.1,
                 "slope": 1.21
             },
             "overlap": {
-                "offset": -1.17,
-                "slope": 1.35
+                "offset": -1.19,
+                "slope": 1.32
             }
         }
     },
     "GMTTkMuons": {
         "Loose": {
             "barrel": {
-                "offset": 0.96,
+                "offset": 1.0,
                 "slope": 1.04
             },
             "endcap": {
-                "offset": 0.87,
+                "offset": 0.81,
                 "slope": 1.04
             },
             "overlap": {
-                "offset": 1.16,
+                "offset": 1.09,
                 "slope": 1.03
             }
         },
         "Medium": {
             "barrel": {
-                "offset": 0.95,
+                "offset": 1.0,
                 "slope": 1.04
             },
             "endcap": {
-                "offset": 0.87,
+                "offset": 0.81,
                 "slope": 1.04
             },
             "overlap": {
-                "offset": 1.16,
+                "offset": 1.08,
                 "slope": 1.03
             }
         },
         "Tight": {
             "barrel": {
-                "offset": 0.94,
+                "offset": 1.01,
                 "slope": 1.04
             },
             "endcap": {
-                "offset": 0.87,
+                "offset": 0.81,
                 "slope": 1.04
             },
             "overlap": {
-                "offset": 1.17,
-                "slope": 1.03
+                "offset": 1.07,
+                "slope": 1.04
             }
         },
         "VLoose": {
             "barrel": {
-                "offset": 0.96,
+                "offset": 1.01,
                 "slope": 1.04
             },
             "endcap": {
-                "offset": 0.94,
+                "offset": 0.85,
                 "slope": 1.04
             },
             "overlap": {
-                "offset": 1.17,
+                "offset": 1.08,
                 "slope": 1.03
             }
         },
         "default": {
             "barrel": {
-                "offset": 0.96,
+                "offset": 1.0,
                 "slope": 1.04
             },
             "endcap": {
-                "offset": 0.87,
+                "offset": 0.79,
                 "slope": 1.04
             },
             "overlap": {
-                "offset": 1.16,
+                "offset": 1.09,
                 "slope": 1.03
             }
         }
@@ -209,45 +217,45 @@ scalings = {
     "L1EG": {
         "default": {
             "barrel": {
-                "offset": 4.36,
-                "slope": 1.12
+                "offset": 4.91,
+                "slope": 1.15
             },
             "endcap": {
-                "offset": 5.22,
-                "slope": 1.07
+                "offset": 2.38,
+                "slope": 1.24
             }
         }
     },
     "L1TrackHT": {
         "HT": {
             "inclusive": {
-                "offset": -51.83,
-                "slope": 2.58
+                "offset": -36.76,
+                "slope": 2.51
             }
         },
         "MHT": {
             "inclusive": {
-                "offset": -19.41,
-                "slope": 2.27
+                "offset": -9.98,
+                "slope": 2.16
             }
         }
     },
     "L1TrackJet": {
         "default": {
             "barrel": {
-                "offset": 14.84,
-                "slope": 5.15
+                "offset": 13.45,
+                "slope": 5.26
             },
             "endcap": {
-                "offset": 30.24,
-                "slope": 7.12
+                "offset": 17.38,
+                "slope": 7.67
             }
         }
     },
     "L1TrackMET": {
         "default": {
             "inclusive": {
-                "offset": -75.85,
+                "offset": -77.78,
                 "slope": 8.69
             }
         }
@@ -255,68 +263,104 @@ scalings = {
     "L1caloJet": {
         "default": {
             "barrel": {
-                "offset": 2.27,
-                "slope": 1.48
+                "offset": 2.83,
+                "slope": 1.46
             },
             "endcap": {
-                "offset": 77.98,
-                "slope": 1.74
+                "offset": 25.75,
+                "slope": 1.99
             },
-            "forward": {
-                "offset": 223.84,
-                "slope": 0.89
+            "forwardHF": {
+                "offset": -30.41,
+                "slope": 1.57
+            },
+            "forwardHGC": {
+                "offset": -46.91,
+                "slope": 2.4
             }
         }
     },
     "L1caloTau": {
         "default": {
             "barrel": {
-                "offset": -10.87,
-                "slope": 1.69
+                "offset": -8.82,
+                "slope": 1.63
             },
             "endcap": {
-                "offset": -45.77,
-                "slope": 2.54
+                "offset": -49.41,
+                "slope": 2.67
             }
         }
     },
     "L1hpsTau": {
         "default": {
             "barrel": {
-                "offset": 1.88,
-                "slope": 1.74
+                "offset": -6.51,
+                "slope": 1.85
             },
             "endcap": {
-                "offset": 37.49,
-                "slope": 1.5
+                "offset": 15.2,
+                "slope": 1.75
             }
         }
     },
     "L1nnCaloTau": {
         "default": {
             "barrel": {
-                "offset": -0.72,
-                "slope": 1.31
+                "offset": -1.73,
+                "slope": 1.33
             },
             "endcap": {
-                "offset": -6.02,
-                "slope": 1.38
+                "offset": -6.3,
+                "slope": 1.4
+            }
+        }
+    },
+    "L1puppiExtJetSC4": {
+        "default": {
+            "barrel": {
+                "offset": 3.29,
+                "slope": 1.61
+            },
+            "endcap": {
+                "offset": 12.25,
+                "slope": 1.53
+            },
+            "forwardHF": {
+                "offset": -6.35,
+                "slope": 1.34
+            },
+            "forwardHGC": {
+                "offset": 47.57,
+                "slope": 1.23
             }
         }
     },
     "L1puppiHistoJetSums": {
         "MHT": {
             "inclusive": {
-                "offset": -15.69,
-                "slope": 1.18
+                "offset": -17.4,
+                "slope": 1.23
+            }
+        }
+    },
+    "L1puppiJetSC4NG": {
+        "default": {
+            "barrel": {
+                "offset": 10.8,
+                "slope": 1.66
+            },
+            "endcap": {
+                "offset": 4.32,
+                "slope": 2.15
             }
         }
     },
     "L1puppiMLMET": {
         "default": {
             "inclusive": {
-                "offset": 29.35,
-                "slope": 1.56
+                "offset": 28.82,
+                "slope": 1.6
             }
         }
     }


### PR DESCRIPTION
#### PR description:

This PR updates the Phase-2 Global Trigger Emulator step-1 menu to use the latest online-to-offline scalings from [L1T annual review 2025](https://indico.cern.ch/event/1516922/#4-algorithms-physics-performan), derived with the [standalone menu tools](https://github.com/cms-l1-dpg/Phase2-L1MenuTools) using CMSSW_15_1_0_pre4, as well as the latest object IDs from the review. In particular the ID changes are to apply tight electron ID in the endcap for all pTs both for TkElectron and TkIsoElectron, and to correct the bit used for photon ID for TkIsoPhoton. The scalings for the forward region, relevant for seeded cone jets, have also been separated into two bins to separate the HGC and HF segments of the detector. 

In addition to the AR25-specific changes, some additional updates have been implemented:
- Handling of standalone EG triggers have been updated to use TkPhoton instead of TkIsoPhoton, and to use the L1EG scalings
- PT thresholds in TkEleTkMuon10_20 and DoubleTkMuon_4p5_4p5_OS_Er2_Mass7to18 were incorrect and have been fixed

#### PR validation:

The trigger rates from the menu and the P2GT emulator results are directly compared in the attached plot below, where the same online-to-offline scalings are used in each case. Some discrepancies remain in specific seeds but these require further discussion and are out of scope of this PR. These are discrepancies are independent of the AR25 scalings and IDs, and this PR is already significant improvement on the current P2GT vs standalone tools.

<img width="1710" height="1157" alt="image" src="https://github.com/user-attachments/assets/614ee6ff-a544-486c-8b60-8b01a5b73566" />
