### PR TITLE
Support writing nanoaod::FlatTable to Run RNTuple

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
@@ -163,13 +163,15 @@ void NanoAODRNTupleOutputModule::openFile(edm::FileBlock const&) {
   const auto& keeps = keptProducts();
   for (const auto& keep : keeps[edm::InRun]) {
     if (keep.first->className() == "nanoaod::MergeableCounterTable") {
-      m_run.registerToken(keep.second);
+      m_run.registerCounterTableToken(keep.second);
     } else if (keep.first->className() == "nanoaod::UniqueString" && keep.first->moduleLabel() == "nanoMetadata") {
       m_nanoMetadata.emplace_back(keep.first->productInstanceName(), keep.second);
+    } else if (keep.first->className() == "nanoaod::FlatTable") {
+      m_run.registerFlatTableToken(keep.second);
     } else {
       throw cms::Exception(
           "Configuration",
-          "NanoAODRNTupleOutputModule cannot handle class " + keep.first->className() + " in Run branch");
+          "NanoAODRNTupleOutputModule cannot handle class " + keep.first->className() + " in Run RNTuple");
     }
   }
 }

--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.h
@@ -37,16 +37,19 @@ private:
 class RunNTuple {
 public:
   RunNTuple() = default;
-  void registerToken(const edm::EDGetToken& token);
+  void registerCounterTableToken(const edm::EDGetToken& token);
+  void registerFlatTableToken(const edm::EDGetToken& token);
   void fill(const edm::RunForOutput& iRun, TFile& file);
   void finalizeWrite();
 
 private:
   void createFields(const edm::RunForOutput& iRun, TFile& file);
-  std::vector<edm::EDGetToken> m_tokens;
+  std::vector<edm::EDGetToken> m_counterTableTokens;
+  std::vector<edm::EDGetToken> m_flatTableTokens;
   std::unique_ptr<RNTupleWriter> m_ntuple;
   RNTupleFieldPtr<UInt_t> m_run;
-  std::vector<SummaryTableOutputFields> m_tables;
+  std::vector<SummaryTableOutputFields> m_counterTables;
+  TableCollectionSet m_flatTables;
 };
 
 class PSetNTuple {

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.cc
@@ -49,7 +49,7 @@ void TableOutputFields::print() const {
   }
 }
 
-void TableOutputFields::createFields(const edm::EventForOutput& event, RNTupleModel& model) {
+void TableOutputFields::createFields(const edm::OccurrenceForOutput& event, RNTupleModel& model) {
   edm::Handle<nanoaod::FlatTable> handle;
   event.getByToken(m_token, handle);
   const nanoaod::FlatTable& table = *handle;
@@ -92,7 +92,7 @@ void TableOutputFields::fillEntry(const nanoaod::FlatTable& table, std::size_t i
 
 const edm::EDGetToken& TableOutputFields::getToken() const { return m_token; }
 
-const edm::Handle<nanoaod::FlatTable> TableOutputFields::getTable(const edm::EventForOutput& event) const {
+const edm::Handle<nanoaod::FlatTable> TableOutputFields::getTable(const edm::OccurrenceForOutput& event) const {
   edm::Handle<nanoaod::FlatTable> handle;
   event.getByToken(m_token, handle);
   return handle;
@@ -100,7 +100,7 @@ const edm::Handle<nanoaod::FlatTable> TableOutputFields::getTable(const edm::Eve
 
 ///////////////////////////////////////////////////////////////////////////////
 
-void TableOutputVectorFields::createFields(const edm::EventForOutput& event, RNTupleModel& model) {
+void TableOutputVectorFields::createFields(const edm::OccurrenceForOutput& event, RNTupleModel& model) {
   edm::Handle<nanoaod::FlatTable> handle;
   event.getByToken(m_token, handle);
   const nanoaod::FlatTable& table = *handle;
@@ -125,7 +125,7 @@ void TableOutputVectorFields::createFields(const edm::EventForOutput& event, RNT
     }
   }
 }
-void TableOutputVectorFields::fill(const edm::EventForOutput& event) {
+void TableOutputVectorFields::fill(const edm::OccurrenceForOutput& event) {
   edm::Handle<nanoaod::FlatTable> handle;
   event.getByToken(m_token, handle);
   const auto& table = *handle;
@@ -159,7 +159,7 @@ void TableCollection::add(const edm::EDGetToken& table_token, const nanoaod::Fla
   m_main = TableOutputFields(table_token);
 }
 
-void TableCollection::createFields(const edm::EventForOutput& event, RNTupleModel& eventModel) {
+void TableCollection::createFields(const edm::OccurrenceForOutput& event, RNTupleModel& eventModel) {
   std::vector<edm::Handle<nanoaod::FlatTable>> tables;
 
   auto main_table = m_main.getTable(event);
@@ -176,7 +176,7 @@ void TableCollection::createFields(const edm::EventForOutput& event, RNTupleMode
 
 void TableCollection::bindBuffer(RNTupleModel& eventModel) { m_collection->bindBuffer(eventModel); }
 
-void TableCollection::fill(const edm::EventForOutput& event) {
+void TableCollection::fill(const edm::OccurrenceForOutput& event) {
   std::vector<edm::Handle<nanoaod::FlatTable>> tables;
 
   auto main_table = m_main.getTable(event);
@@ -248,7 +248,7 @@ void TableCollectionSet::print() const {
   }
 }
 
-void TableCollectionSet::createFields(const edm::EventForOutput& event, RNTupleModel& eventModel) {
+void TableCollectionSet::createFields(const edm::OccurrenceForOutput& event, RNTupleModel& eventModel) {
   for (auto& collection : m_collections) {
     if (!collection.hasMainTable()) {
       throw cms::Exception("LogicError",
@@ -271,7 +271,7 @@ void TableCollectionSet::bindBuffers(RNTupleModel& eventModel) {
   }
 }
 
-void TableCollectionSet::fill(const edm::EventForOutput& event) {
+void TableCollectionSet::fill(const edm::OccurrenceForOutput& event) {
   for (auto& collection : m_collections) {
     collection.fill(event);
   }

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.h
@@ -4,7 +4,7 @@
 #include "RNTupleFieldPtr.h"
 #include "RNTupleCollection.h"
 
-#include "FWCore/Framework/interface/EventForOutput.h"
+#include "FWCore/Framework/interface/OccurrenceForOutput.h"
 #include "DataFormats/NanoAOD/interface/FlatTable.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
@@ -65,10 +65,10 @@ public:
   TableOutputFields() = default;
   explicit TableOutputFields(const edm::EDGetToken& token) : m_token(token) {}
   void print() const;
-  void createFields(const edm::EventForOutput& event, RNTupleModel& model);
+  void createFields(const edm::OccurrenceForOutput& event, RNTupleModel& model);
   void fillEntry(const nanoaod::FlatTable& table, std::size_t i);
   const edm::EDGetToken& getToken() const;
-  const edm::Handle<nanoaod::FlatTable> getTable(const edm::EventForOutput& event) const;
+  const edm::Handle<nanoaod::FlatTable> getTable(const edm::OccurrenceForOutput& event) const;
 
 private:
   edm::EDGetToken m_token;
@@ -82,8 +82,8 @@ class TableOutputVectorFields {
 public:
   TableOutputVectorFields() = default;
   explicit TableOutputVectorFields(const edm::EDGetToken& token) : m_token(token) {}
-  void createFields(const edm::EventForOutput& event, RNTupleModel& model);
-  void fill(const edm::EventForOutput& event);
+  void createFields(const edm::OccurrenceForOutput& event, RNTupleModel& model);
+  void fill(const edm::OccurrenceForOutput& event);
 
 private:
   edm::EDGetToken m_token;
@@ -103,9 +103,9 @@ public:
   // Invariants:
   // * m_main not null
   // * m_collectionName not empty
-  void createFields(const edm::EventForOutput& event, RNTupleModel& eventModel);
+  void createFields(const edm::OccurrenceForOutput& event, RNTupleModel& eventModel);
   void bindBuffer(RNTupleModel& eventModel);
-  void fill(const edm::EventForOutput& event);
+  void fill(const edm::OccurrenceForOutput& event);
   void print() const;
   bool hasMainTable();
   const std::string& getCollectionName() const;
@@ -120,9 +120,9 @@ private:
 class TableCollectionSet {
 public:
   void add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table);
-  void createFields(const edm::EventForOutput& event, RNTupleModel& eventModel);
+  void createFields(const edm::OccurrenceForOutput& event, RNTupleModel& eventModel);
   void bindBuffers(RNTupleModel& eventModel);
-  void fill(const edm::EventForOutput& event);
+  void fill(const edm::OccurrenceForOutput& event);
   void print() const;
 
 private:


### PR DESCRIPTION
This PR extends the code a bit so that `nano::FlatTable`s can be written to the Run RNTuple.

Closes #48737