### PR TITLE
[15.0.X] fix `GeneralPurposeTrackAnalyzer` for `StreamHLTMonitor` events

### DIFF
--- a/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
+++ b/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
@@ -710,9 +710,12 @@ private:
         hd0PV->Fill(100);
         hdzPV->Fill(100);
 
-        hd0vsphi->Fill(track->phi(), -track->dxy());
-        hd0vseta->Fill(track->eta(), -track->dxy());
-        hd0vspt->Fill(track->pt(), -track->dxy());
+        // gotta protect the case in which it's not comsics, but the handle is invalid! (HLT)
+        if (isCosmics_) {
+          hd0vsphi->Fill(track->phi(), -track->dxy());
+          hd0vseta->Fill(track->eta(), -track->dxy());
+          hd0vspt->Fill(track->pt(), -track->dxy());
+        }
       }
 
       if (DEBUG) {


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/48820

#### PR description:

The goal of this tiny PR is to allow to run the alignment `GenericV` validation introduced at https://github.com/cms-sw/cmssw/pull/47055 on the `ALCARECOTkAlHLTTracks` samples. 
Previously this lead to a segmentation fault at runtime as some of the histograms were being filled despite not being booked due to the logic implemented here:

https://github.com/cms-sw/cmssw/blob/1db657f0363bc8baf9657f69d9a4f245b97c6790/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc#L691 

in which the `else` clause is entered due to `vertexHandle.isValid()` being false (which might happen in HLT events). 

#### PR validation:

Run the following:

```
cmsRun validation_cfg.py config=validation.json
```

using the files at this [gist](https://gist.github.com/mmusich/ab94a65cbdc0a8f431e63754702e899f).
It previously failed, while it does run normally now.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but it will be backported to CMSSW_15_0_X for 2025 operation purposes.