### PR TITLE
[15_0_X]: HCAL DQM fix missing FED 1136 (ZDC)

### DIFF
--- a/DQM/HcalCommon/interface/Utilities.h
+++ b/DQM/HcalCommon/interface/Utilities.h
@@ -182,7 +182,7 @@ namespace hcaldqm {
     bool isFEDHBHE(HcalElectronicsId const &);
     bool isFEDHF(HcalElectronicsId const &);
     bool isFEDHO(HcalElectronicsId const &);
-
+    bool isFEDZDC(HcalElectronicsId const &);
     /**
  *	This is wrap around in case hashing scheme changes in the future
  */

--- a/DQM/HcalCommon/src/Utilities.cc
+++ b/DQM/HcalCommon/src/Utilities.cc
@@ -190,9 +190,20 @@ namespace hcaldqm {
 
       return false;
     }
+    bool isFEDZDC(HcalElectronicsId const &eid) {
+      if (eid.isVMEid())
+        return false;
+      int fed = crate2fed(eid.crateId(), eid.slot());
+      if (fed == 1136)
+        return true;
+      else
+        return false;
+
+      return false;
+    }
 
     /*
- *	Orbit Gap Related
+       *	Orbit Gap Related
  */
     std::string ogtype2string(OrbitGapType type) {
       switch (type) {

--- a/DQM/HcalTasks/interface/RawTask.h
+++ b/DQM/HcalTasks/interface/RawTask.h
@@ -43,7 +43,7 @@ protected:
 
   //	flag vector
   std::vector<hcaldqm::flag::Flag> _vflags;
-  enum RawFlag { fEvnMsm = 0, fBcnMsm = 1, fOrnMsm = 2, fBadQ = 3, nRawFlag = 4 };
+  enum RawFlag { fEvnMsm = 0, fBcnMsm = 1, fOrnMsm = 2, fBadQ = 3, fUnknownIds = 4, nRawFlag = 5 };
 
   //	emap
   hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
@@ -52,6 +52,7 @@ protected:
   bool _calibProcessing;
   int _thresh_calib_nbadq;
   int _NBadQEvent;
+  bool _unknownIdsPresent;
   //	vector of HcalElectronicsId for FEDs
   std::vector<uint32_t> _vhashFEDs;
 

--- a/DQM/HcalTasks/plugins/RawTask.cc
+++ b/DQM/HcalTasks/plugins/RawTask.cc
@@ -18,6 +18,7 @@ RawTask::RawTask(edm::ParameterSet const& ps)
   _vflags[fBcnMsm] = flag::Flag("BcnMsm");
   _vflags[fBadQ] = flag::Flag("BadQ");
   _vflags[fOrnMsm] = flag::Flag("OrnMsm");
+  _vflags[fUnknownIds] = flag::Flag("UnknownIds");
   _NBadQEvent = 0;
 }
 
@@ -435,7 +436,8 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
     }
 
     //	FED is @cDAQ
-    if (hcaldqm::utilities::isFEDHBHE(eid) || hcaldqm::utilities::isFEDHF(eid) || hcaldqm::utilities::isFEDHO(eid)) {
+    if (hcaldqm::utilities::isFEDHBHE(eid) || hcaldqm::utilities::isFEDHF(eid) || hcaldqm::utilities::isFEDHO(eid) ||
+        hcaldqm::utilities::isFEDZDC(eid)) {
       if (_xEvnMsmLS.get(eid) > 0)
         _vflags[fEvnMsm]._state = flag::fBAD;
       else
@@ -455,6 +457,11 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
       } else
         _vflags[fBadQ]._state = flag::fGOOD;
     }
+    _unknownIdsPresent = false;
+    if (_unknownIdsPresent)
+      _vflags[fUnknownIds]._state = hcaldqm::flag::fBAD;
+    else
+      _vflags[fUnknownIds]._state = hcaldqm::flag::fGOOD;
 
     int iflag = 0;
     //	iterate over all flags:
@@ -477,6 +484,8 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
       //	each one of them after using
       ft->reset();
     }
+    if (fed == 1136)
+      edm::LogWarning(" fSum._state =") << fSum._state << std::endl;
     _cSummaryvsLS.setBinContent(eid, _currentLS, fSum._state);
   }
 


### PR DESCRIPTION
#### PR description:

Fixes issue [#289](https://gitlab.cern.ch/cmshcal/docs/-/issues/289).

This PR fixes the problem where FED 1136 (ZDC) was shown as empty in the Hcal/RawTask/SummaryvsLS DQM plot.
With this update, the FED data is now correctly displayed in the plot.

#### PR validation:

- The changes were tested locally by running the relevant HCAL DQM workflows.
- Verified that Hcal/RawTask/SummaryvsLS now correctly displays FED 1136 (ZDC) data.
- Checked that no other FED plots were affected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/48742

Tagging @salimcerci @denizsun @akhukhun 
