### PR TITLE
Improve `PortableHost{Collection,Object}` dictionary declarations

### DIFF
--- a/DataFormats/BeamSpot/src/classes_def.xml
+++ b/DataFormats/BeamSpot/src/classes_def.xml
@@ -5,11 +5,17 @@
   </class>
   <class name="edm::Wrapper<reco::BeamSpot>"/>
 
+  <class name="BeamSpotHost"/>
+  <!-- BeamSpotHost::Product must be listed before the aliased-to type -->
+  <!-- TODO: we should find a better way than replicating the class versions and checksums -->
+  <class name="BeamSpotHost::Product" ClassVersion="3">
+   <version ClassVersion="3" checksum="280341519"/>
+  </class>
+
   <class name="BeamSpotPOD" ClassVersion="3">
    <version ClassVersion="3" checksum="280341519"/>
   </class>
   <class name="edm::Wrapper<BeamSpotPOD>"/>
 
-  <class name="BeamSpotHost"/>
   <class name="edm::Wrapper<BeamSpotHost>"/>
 </lcgdict>

--- a/DataFormats/EcalRecHit/src/classes_def.xml
+++ b/DataFormats/EcalRecHit/src/classes_def.xml
@@ -39,15 +39,19 @@
   <class name="edm::Wrapper<edm::DetSetVector<EcalRecHit> >"/>
   <class name="edm::Wrapper<std::vector<std::vector<edm::DetSet<EcalRecHit> > > >"/>
 
+  <class name="EcalUncalibratedRecHitHostCollection"/>
+  <!-- EcalUncalibratedRecHitHostCollection::Layout must be listed before the aliased-to type -->
+  <class name="EcalUncalibratedRecHitHostCollection::Layout"/>
   <class name="EcalOotAmpArray"/>
   <class name="EcalUncalibratedRecHitSoA"/>
   <class name="EcalUncalibratedRecHitSoA::View"/>
-  <class name="EcalUncalibratedRecHitHostCollection"/>
   <class name="edm::Wrapper<EcalUncalibratedRecHitHostCollection>" splitLevel="0"/>
 
+  <class name="EcalRecHitHostCollection"/>
+  <!-- EcalRecHitHostCollection::Layout must be listed before the aliased-to type -->
+  <class name="EcalRecHitHostCollection::Layout"/>
   <class name="EcalRecHitSoA"/>
   <class name="EcalRecHitSoA::View"/>
-  <class name="EcalRecHitHostCollection"/>
   <class name="edm::Wrapper<EcalRecHitHostCollection>" splitLevel="0"/>
 
 </lcgdict>

--- a/DataFormats/HGCalReco/src/classes_def.xml
+++ b/DataFormats/HGCalReco/src/classes_def.xml
@@ -76,24 +76,29 @@
   <class name="edm::Wrapper<TICLCandidate>" />
   <class name="edm::Wrapper<std::vector<TICLCandidate> >" />
 
+  <class name="MtdHostCollection"/>
+  <!-- MtdHostCollection::Layout must be listed before the aliased-to type -->
+  <class name="MtdHostCollection::Layout"/>
   <class name="MtdSoA"/>
   <class name="MtdSoA::View"/>
-
-  <class name="MtdHostCollection"/>
   <class name="edm::Wrapper<MtdHostCollection>" splitLevel="0"/>
 
+  <class name="HGCalSoARecHitsHostCollection"/>
+  <!-- HGCalSoARecHitsHostCollection::Layout must be listed before the aliased-to type -->
+  <class name="HGCalSoARecHitsHostCollection::Layout"/>
   <class name="HGCalSoARecHits"/>
-  <class name="HGCalSoARecHitsHostCollection" ClassVersion="3" rntupleStreamerMode="true">
-    <version ClassVersion="3" checksum="1452864040"/>
-  </class>
   <class name="edm::Wrapper<HGCalSoARecHitsHostCollection>" splitLevel="0"/>
 
-  <class name="HGCalSoARecHitsExtra"/>
   <class name="HGCalSoARecHitsExtraHostCollection" rntupleStreamerMode="true"/>
+  <!-- HGCalSoARecHitsExtraHostCollection::Layout must be listed before the aliased-to type -->
+  <class name="HGCalSoARecHitsExtraHostCollection::Layout"/>
+  <class name="HGCalSoARecHitsExtra"/>
   <class name="edm::Wrapper<HGCalSoARecHitsExtraHostCollection>" splitLevel="0"/>
 
-  <class name="HGCalSoAClusters"/>
   <class name="HGCalSoAClustersHostCollection" rntupleStreamerMode="true"/>
+  <!-- HGCalSoAClustersHostCollection::Layout must be listed before the aliased-to type -->
+  <class name="HGCalSoAClustersHostCollection::Layout"/>
+  <class name="HGCalSoAClusters"/>
   <class name="edm::Wrapper<HGCalSoAClustersHostCollection>" splitLevel="0"/>
 
 </lcgdict>

--- a/DataFormats/HcalDigi/src/classes_def.xml
+++ b/DataFormats/HcalDigi/src/classes_def.xml
@@ -114,15 +114,19 @@
    </class>
    <class name="edm::Wrapper<HcalUMNioDigi>" splitLevel="0"/>
 
-   <class name="hcal::HcalPhase1DigiSoA"/>
-   <class name="hcal::HcalPhase0DigiSoA"/>
-   <class name="hcal::HcalPhase1DigiSoA::View"/>
-   <class name="hcal::HcalPhase0DigiSoA::View"/>
 
   <class name="hcal::Phase1DigiHostCollection"/>
+  <!-- hcal::Phase1DigiHostCollection::Layout must be listed before the aliased-to type -->
+  <class name="hcal::Phase1DigiHostCollection::Layout"/>
+  <class name="hcal::HcalPhase1DigiSoA"/>
+  <class name="hcal::HcalPhase1DigiSoA::View"/>
   <class name="edm::Wrapper<hcal::Phase1DigiHostCollection>" splitLevel="0"/>
 
   <class name="hcal::Phase0DigiHostCollection"/> 
+  <!-- hcal::Phase0DigiHostCollection::Layout must be listed before the aliased-to type -->
+  <class name="hcal::Phase0DigiHostCollection::Layout"/>
+  <class name="hcal::HcalPhase0DigiSoA"/>
+  <class name="hcal::HcalPhase0DigiSoA::View"/>
   <class name="edm::Wrapper<hcal::Phase0DigiHostCollection>" splitLevel="0"/>
 
 </lcgdict>

--- a/DataFormats/HcalRecHit/src/classes_def.xml
+++ b/DataFormats/HcalRecHit/src/classes_def.xml
@@ -120,8 +120,10 @@
   <class name="edm::reftobase::Holder<CaloRecHit,edm::Ref<edm::SortedCollection<HORecHit,edm::StrictWeakOrdering<HORecHit> >,HORecHit,edm::refhelper::FindUsingAdvance<edm::SortedCollection<HORecHit,edm::StrictWeakOrdering<HORecHit> >,HORecHit> > >" />
   <class name="edm::reftobase::Holder<CaloRecHit,edm::Ref<edm::SortedCollection<HBHERecHit,edm::StrictWeakOrdering<HBHERecHit> >,HBHERecHit,edm::refhelper::FindUsingAdvance<edm::SortedCollection<HBHERecHit,edm::StrictWeakOrdering<HBHERecHit> >,HBHERecHit> > >" />
 
+  <class name="hcal::RecHitHostCollection" />
+  <!-- hcal::RecHitHostCollection::Layout must be listed before the aliased-to type -->
+  <class name="hcal::RecHitHostCollection::Layout" />
   <class name="hcal::HcalRecHitSoA"/>
   <class name="hcal::HcalRecHitSoA::View"/>
-  <class name="hcal::RecHitHostCollection" />
   <class name="edm::Wrapper<hcal::RecHitHostCollection>" splitLevel="0"/>
   </lcgdict>

--- a/DataFormats/ParticleFlowReco/src/classes_serial_def.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_serial_def.xml
@@ -1,29 +1,29 @@
 <lcgdict>
+  <class name="reco::CaloRecHitHostCollection"/>
+  <!-- reco::CaloRecHitHostCollection::Layout must be listed before the aliased-to type -->
+  <class name="reco::CaloRecHitHostCollection::Layout"/>
   <class name="reco::CaloRecHitSoA"/>
   <class name="reco::CaloRecHitSoA::View"/>
-  <class name="reco::CaloRecHitHostCollection" ClassVersion="3">
-    <version ClassVersion="3" checksum="1876594952"/>
-  </class>
   <class name="edm::Wrapper<reco::CaloRecHitHostCollection>" splitLevel="0"/>
 
+  <class name="reco::PFRecHitHostCollection"/>
+  <!-- reco::PFRecHitHostCollection::Layout must be listed before the aliased-to type -->
+  <class name="reco::PFRecHitHostCollection::Layout"/>
   <class name="reco::PFRecHitSoA"/>
   <class name="reco::PFRecHitSoA::View"/>
-  <class name="reco::PFRecHitHostCollection" ClassVersion="3">
-    <version ClassVersion="3" checksum="1936051484"/>
-  </class>
   <class name="edm::Wrapper<reco::PFRecHitHostCollection>" splitLevel="0"/>
 
+  <class name="reco::PFClusterHostCollection"/>
+  <!-- reco::PFClusterHostCollection::Layout must be listed before the aliased-to type -->
+  <class name="reco::PFClusterHostCollection::Layout"/>
   <class name="reco::PFClusterSoA"/>
   <class name="reco::PFClusterSoA::View"/>
-  <class name="reco::PFClusterHostCollection" ClassVersion="3">
-    <version ClassVersion="3" checksum="1232566394"/>
-  </class>
   <class name="edm::Wrapper<reco::PFClusterHostCollection>" splitLevel="0"/>
 
+  <class name="reco::PFRecHitFractionHostCollection"/>
+  <!-- reco::PFRecHitFractionHostCollection::Layout must be listed before the aliased-to type -->
+  <class name="reco::PFRecHitFractionHostCollection::Layout"/>
   <class name="reco::PFRecHitFractionSoA"/>
   <class name="reco::PFRecHitFractionSoA::View"/>
-  <class name="reco::PFRecHitFractionHostCollection" ClassVersion="3">
-    <version ClassVersion="3" checksum="2181211668"/>
-  </class>
   <class name="edm::Wrapper<reco::PFRecHitFractionHostCollection>" splitLevel="0"/>
 </lcgdict>

--- a/DataFormats/Portable/README.md
+++ b/DataFormats/Portable/README.md
@@ -34,6 +34,8 @@ would create the file `classes.cc` with the content:
 
 SET_PORTABLEHOSTOBJECT_READ_RULES(portabletest::TestHostObject);
 ```
+**Note:** The dictionary for `portabletest::TestHostObject::Product` (using the same type alias as in the registration macro above) must be placed in the `classes_def.xml` file before the type that `Product` aliases.
+
 
 `PortableHostObject<T>` objects can also be read back in "bare ROOT" mode, without any dictionaries.
 They have no implicit or explicit references to alpaka (neither as part of the class signature nor as part of its name).
@@ -93,6 +95,8 @@ one would create the file `classes.cc` with the content:
 
 SET_PORTABLEHOSTCOLLECTION_READ_RULES(portabletest::TestHostCollection);
 ```
+**Note:** The dictionary for `portabletest::TestHostCollection::Layout` (using the same type alias as in the registration macro above) must be placed in the `classes_def.xml` file before the type that `Layout` aliases.
+
 
 `PortableHostCollection<T>` collections can also be read back in "bare ROOT" mode, without any dictionaries.
 They have no implicit or explicit references to alpaka (neither as part of the class signature nor as part of its name).
@@ -159,6 +163,7 @@ Both scripts expect the collections to be aliased as in:
 ```
 using TestDeviceMultiCollection3 = PortableCollection3<TestSoA, TestSoA2, TestSoA3>;
 ```
+and assume the `TestDeviceMultiCollection3` is used in the `SET_PORTABLEHOSTMULTICOLLECTION_READ_RULES()` macro.
 
 For the host xml, SoA layouts have to be listed and duplicates should be removed manually is multiple
 collections share a same layout. The scripts are called as follows:

--- a/DataFormats/Portable/scripts/portableHostCollectionHints
+++ b/DataFormats/Portable/scripts/portableHostCollectionHints
@@ -16,6 +16,11 @@ print("<lcgdict>")
 for l in layouts:
   print("  <class name=\"%s\"/>"% l)
 print()
+print("  <!-- Collection declaration for dictionary -->")
+print("  <class name=\"%s\"/>"% collectionName)
+print("  <!-- %s::Implementation alias must be listed before the aliased-to type -->"% collectionName)
+print("  <class name=\"%s::Implementation\"/>"% collectionName)
+print()
 if len(layouts) > 1:
   print("  <!-- Recursive templates (with no data) ensuring we have one CollectionLeaf<index, type> for each layout in the collection -->")
   for i in range(0, len(layouts)):
@@ -27,7 +32,5 @@ if len(layouts) > 1:
   for i in range(0, len(layouts)):
     print("  <class name=\"portablecollection::CollectionLeaf<%d, %s>\"/>" % (i, layouts[i]))
   print("")
-print("  <!-- Collection declaration for dictionary -->")
-print("  <class name=\"%s\"/>"% collectionName)
 print("  <class name=\"edm::Wrapper<%s>\" splitLevel=\"0\"/>"% collectionName)
 print("</lcgdict>")

--- a/DataFormats/PortableTestObjects/src/classes_def.xml
+++ b/DataFormats/PortableTestObjects/src/classes_def.xml
@@ -1,14 +1,28 @@
 <lcgdict>
   <class name="portabletest::TestHostCollection"/>
+  <!-- portabletest::TestHostCollection::Layout alias must be listed before the aliased-to type -->
+  <class name="portabletest::TestHostCollection::Layout"/>
   <class name="edm::Wrapper<portabletest::TestHostCollection>" splitLevel="0"/>
 
-  <class name="portabletest::TestStruct"/>
   <class name="portabletest::TestHostObject"/>
+  <!-- portabletest::TestHostObject::Product alias must be listed before the aliased-to type -->
+  <class name="portabletest::TestHostObject::Product"/>
   <class name="edm::Wrapper<portabletest::TestHostObject>"/>
+  <class name="portabletest::TestStruct"/>
 
   <class name="portabletest::TestSoALayout<128,false>"/>
   <class name="portabletest::TestSoALayout2<128,false>"/>
   <class name="portabletest::TestSoALayout3<128,false>"/>
+
+  <!-- Collection declaration for dictionary -->
+  <class name="portabletest::TestHostMultiCollection2"/>
+  <!-- portabletest::TestHostObject::Implementation alias must be listed before the aliased-to type -->
+  <class name="portabletest::TestHostMultiCollection2::Implementation"/>
+
+  <!-- Collection declaration for dictionary -->
+  <class name="portabletest::TestHostMultiCollection3"/>
+  <!-- portabletest::TestHostObject::Implementation alias must be listed before the aliased-to type -->
+  <class name="portabletest::TestHostMultiCollection3::Implementation"/>
 
   <!-- Recursive templates (with no data) ensuring we have one CollectionLeaf<index, type> for each layout in the collection -->
   <class name="portablecollection::CollectionImpl<0, portabletest::TestSoALayout<128, false>, portabletest::TestSoALayout2<128, false>>"/>
@@ -17,9 +31,6 @@
   <!-- Recursive templates implementing the association of indices and layouts, and containing the data -->
   <class name="portablecollection::CollectionLeaf<0, portabletest::TestSoALayout<128, false>>"/>
   <class name="portablecollection::CollectionLeaf<1, portabletest::TestSoALayout2<128, false>>"/>
-
-  <!-- Collection declaration for dictionary -->
-  <class name="portabletest::TestHostMultiCollection2"/>
 
   <class name="edm::Wrapper<portabletest::TestHostMultiCollection2>" splitLevel="0"/>
 
@@ -34,9 +45,6 @@
   <class name="portablecollection::CollectionLeaf<1, portabletest::TestSoALayout2<128, false>>"/>
   -->
   <class name="portablecollection::CollectionLeaf<2, portabletest::TestSoALayout3<128, false>>"/>
-
-  <!-- Collection declaration for dictionary -->
-  <class name="portabletest::TestHostMultiCollection3"/>
 
   <class name="edm::Wrapper<portabletest::TestHostMultiCollection3>" splitLevel="0"/>
 

--- a/DataFormats/PortableTestObjects/src/classes_def.xml
+++ b/DataFormats/PortableTestObjects/src/classes_def.xml
@@ -57,39 +57,51 @@
   <class name="edm::Wrapper<portabletest::TestProductWithPtr<alpaka_common::DevHost>>" persistent="false"/>
 
   <!-- Torch SoAs and Collections -->
+  <class name="portabletest::ParticleHostCollection"/>
+  <!-- portabletest::ParticleHostCollection::Layout must be listed before the aliased-to type -->
+  <class name="portabletest::ParticleHostCollection::Layout"/>
   <class name="portabletest::ParticleSoA"/>
   <class name="portabletest::ParticleSoA::View"/>
   <class name="portabletest::ParticleSoA::ConstView"/>
-  <class name="portabletest::ParticleHostCollection"/>
   <class name="edm::Wrapper<portabletest::ParticleHostCollection>" splitLevel="0"/>
 
+  <class name="portabletest::SimpleNetHostCollection"/>
+  <!-- portabletest::SimpleNetHostCollection::Layout must be listed before the aliased-to type -->
+  <class name="portabletest::SimpleNetHostCollection::Layout"/>
   <class name="portabletest::SimpleNetSoA"/>
   <class name="portabletest::SimpleNetSoA::View"/>
   <class name="portabletest::SimpleNetSoA::ConstView"/>
-  <class name="portabletest::SimpleNetHostCollection"/>
   <class name="edm::Wrapper<portabletest::SimpleNetHostCollection>" splitLevel="0"/>
 
+  <class name="portabletest::MultiHeadNetHostCollection"/>
+  <!-- portabletest::MultiHeadNetHostCollection::Layout must be listed before the aliased-to type -->
+  <class name="portabletest::MultiHeadNetHostCollection::Layout"/>
   <class name="portabletest::MultiHeadNetSoA"/>
   <class name="portabletest::MultiHeadNetSoA::View"/>
   <class name="portabletest::MultiHeadNetSoA::ConstView"/>
-  <class name="portabletest::MultiHeadNetHostCollection"/>
   <class name="edm::Wrapper<portabletest::MultiHeadNetHostCollection>" splitLevel="0"/>
 
+  <class name="portabletest::ImageHostCollection"/>
+  <!-- portabletest::ImageHostCollection::Layout must be listed before the aliased-to type -->
+  <class name="portabletest::ImageHostCollection::Layout"/>
   <class name="portabletest::ImageSoA"/>
   <class name="portabletest::ImageSoA::View"/>
   <class name="portabletest::ImageSoA::ConstView"/>
-  <class name="portabletest::ImageHostCollection"/>
   <class name="edm::Wrapper<portabletest::ImageHostCollection>" splitLevel="0"/>
 
+  <class name="portabletest::LogitsHostCollection"/>
+  <!-- portabletest::LogitsHostCollection::Layout must be listed before the aliased-to type -->
+  <class name="portabletest::LogitsHostCollection::Layout"/>
   <class name="portabletest::LogitsSoA"/>
   <class name="portabletest::LogitsSoA::View"/>
   <class name="portabletest::LogitsSoA::ConstView"/>
-  <class name="portabletest::LogitsHostCollection"/>
   <class name="edm::Wrapper<portabletest::LogitsHostCollection>" splitLevel="0"/>
 
+  <class name="portabletest::MaskHostCollection"/>
+  <!-- portabletest::MaskHostCollection::Layout must be listed before the aliased-to type -->
+  <class name="portabletest::MaskHostCollection::Layout"/>
   <class name="portabletest::MaskSoA"/>
   <class name="portabletest::MaskSoA::View"/>
   <class name="portabletest::MaskSoA::ConstView"/>
-  <class name="portabletest::MaskHostCollection"/>
   <class name="edm::Wrapper<portabletest::MaskHostCollection>" splitLevel="0"/>
 </lcgdict>

--- a/DataFormats/PortableTestObjects/src/classes_def.xml
+++ b/DataFormats/PortableTestObjects/src/classes_def.xml
@@ -6,9 +6,14 @@
 
   <class name="portabletest::TestHostObject"/>
   <!-- portabletest::TestHostObject::Product alias must be listed before the aliased-to type -->
-  <class name="portabletest::TestHostObject::Product"/>
+  <!-- TODO: we should find a better way than replicating the class versions and checksums -->
+  <class name="portabletest::TestHostObject::Product" ClassVersion="3">
+   <version ClassVersion="3" checksum="1507282054"/>
+  </class>
+  <class name="portabletest::TestStruct" ClassVersion="3">
+   <version ClassVersion="3" checksum="1507282054"/>
+  </class>
   <class name="edm::Wrapper<portabletest::TestHostObject>"/>
-  <class name="portabletest::TestStruct"/>
 
   <class name="portabletest::TestSoALayout<128,false>"/>
   <class name="portabletest::TestSoALayout2<128,false>"/>

--- a/DataFormats/SiPixelClusterSoA/src/classes_def.xml
+++ b/DataFormats/SiPixelClusterSoA/src/classes_def.xml
@@ -1,10 +1,10 @@
 <lcgdict>
+  <class name="PortableHostCollection<SiPixelClustersSoA>"/>
+  <!-- PortableHostCollection<SiPixelClustersSoA>::Layout must be listed before the aliased-to type -->
+  <class name="PortableHostCollection<SiPixelClustersSoA>::Layout"/>
   <class name="SiPixelClustersSoA"/>
   <class name="SiPixelClustersSoA::View"/>
-  <class name="PortableHostCollection<SiPixelClustersSoA>"/>
 
-  <class name="SiPixelClustersHost" ClassVersion="3">
-    <version ClassVersion="3" checksum="3089948089"/>
-  </class>
+  <class name="SiPixelClustersHost"/>
   <class name="edm::Wrapper<SiPixelClustersHost>" splitLevel="0"/>
 </lcgdict>

--- a/DataFormats/SiPixelDigiSoA/src/classes_def.xml
+++ b/DataFormats/SiPixelDigiSoA/src/classes_def.xml
@@ -1,18 +1,17 @@
 <lcgdict>
+  <class name="PortableHostCollection<SiPixelDigisSoA>"/>
+  <!-- PortableHostCollection<SiPixelDigisSoA>::Layout must be listed before the aliased-to type -->
+  <class name="PortableHostCollection<SiPixelDigisSoA>::Layout"/>
   <class name="SiPixelDigisSoA"/>
   <class name="SiPixelDigisSoA::View"/>
-  <class name="PortableHostCollection<SiPixelDigisSoA>"/>
-  <class name="SiPixelDigisHost" ClassVersion="4">
-    <version ClassVersion="4" checksum="2247404879"/>
-    <version ClassVersion="3" checksum="3022474662"/>
-  </class>
+  <class name="SiPixelDigisHost"/>
   <class name="edm::Wrapper<SiPixelDigisHost>" splitLevel="0"/>
 
+  <class name="PortableHostCollection<SiPixelDigiErrorsSoA>"/>
+  <!-- PortableHostCollection<SiPixelDigiErrorsSoA>::Layout must be listed before the aliased-to type -->
+  <class name="PortableHostCollection<SiPixelDigiErrorsSoA>::Layout"/>
   <class name="SiPixelDigiErrorsSoA"/>
   <class name="SiPixelDigiErrorsSoA::View"/>
-  <class name="PortableHostCollection<SiPixelDigiErrorsSoA>"/>
-  <class name="SiPixelDigiErrorsHost"  ClassVersion="3">
-    <version ClassVersion="3" checksum="958593711"/>
-  </class>
+  <class name="SiPixelDigiErrorsHost"/>
   <class name="edm::Wrapper<SiPixelDigiErrorsHost>" splitLevel="0"/>
 </lcgdict>

--- a/RecoTracker/LSTCore/src/classes_def.xml
+++ b/RecoTracker/LSTCore/src/classes_def.xml
@@ -2,16 +2,21 @@
   <class name="lst::HitsBaseSoALayout<128,false>"/>
   <class name="lst::PixelSeedsSoALayout<128,false>"/>
 
+  <class name="lst::LSTInputHostCollection"/>
+  <!-- lst::LSTInputHostCollection::Implementation must be listed before the aliased-to type -->
+  <class name="lst::LSTInputHostCollection::Implementation"/>
+
   <class name="portablecollection::CollectionImpl<0,lst::HitsBaseSoALayout<128,false>,lst::PixelSeedsSoALayout<128,false> >"/>
   <class name="portablecollection::CollectionImpl<1,lst::PixelSeedsSoALayout<128,false> >"/>
 
   <class name="portablecollection::CollectionLeaf<0,lst::HitsBaseSoALayout<128,false> >"/>
   <class name="portablecollection::CollectionLeaf<1,lst::PixelSeedsSoALayout<128,false> >"/>
 
-  <class name="lst::LSTInputHostCollection"/>
   <class name="edm::Wrapper<lst::LSTInputHostCollection>" splitLevel="0"/>
 
-  <class name="lst::TrackCandidatesBaseSoALayout<128,false>"/>
   <class name="lst::TrackCandidatesBaseHostCollection"/>
+  <!-- lst::TrackCandidatesBaseHostCollection::Layout must be listed before the aliased-to type -->
+  <class name="lst::TrackCandidatesBaseHostCollection::Layout"/>
+  <class name="lst::TrackCandidatesBaseSoALayout<128,false>"/>
   <class name="edm::Wrapper<lst::TrackCandidatesBaseHostCollection>" splitLevel="0"/>
 </lcgdict>

--- a/RecoTracker/LSTCore/src/classes_def.xml
+++ b/RecoTracker/LSTCore/src/classes_def.xml
@@ -12,11 +12,11 @@
   <class name="portablecollection::CollectionLeaf<0,lst::HitsBaseSoALayout<128,false> >"/>
   <class name="portablecollection::CollectionLeaf<1,lst::PixelSeedsSoALayout<128,false> >"/>
 
-  <class name="edm::Wrapper<lst::LSTInputHostCollection>" splitLevel="0"/>
+  <class name="edm::Wrapper<lst::LSTInputHostCollection>" splitLevel="0" persistent="false"/>
 
   <class name="lst::TrackCandidatesBaseHostCollection"/>
   <!-- lst::TrackCandidatesBaseHostCollection::Layout must be listed before the aliased-to type -->
   <class name="lst::TrackCandidatesBaseHostCollection::Layout"/>
   <class name="lst::TrackCandidatesBaseSoALayout<128,false>"/>
-  <class name="edm::Wrapper<lst::TrackCandidatesBaseHostCollection>" splitLevel="0"/>
+  <class name="edm::Wrapper<lst::TrackCandidatesBaseHostCollection>" splitLevel="0" persistent="false"/>
 </lcgdict>


### PR DESCRIPTION
#### PR description:

Testing ROOT PR on an option to disable header parsing during `TClass::GetClass()` call (https://github.com/root-project/root/pull/18402) it was noticed the type alias gets listed in the `rootmap` file only if the alias is requested before the real type (see https://github.com/root-project/root/issues/19705 for more details).

In the mean time, having the type alias in the `rootmap` file is necessary to avoid header parsing for the execution of the read rules that use the type alias names, e.g.
https://github.com/cms-sw/cmssw/blob/2de49449715cd97f6de642a9b73a06318bd3f8b9/DataFormats/Portable/interface/PortableHostCollectionReadRules.h#L84
, and therefore it seemed worthwhile to change the dictionaries with ` PortableHost{Collection,Object}`.

In the present state this PR demonstrates what the impact would be for the `PortableTestObjects`. If deemed viable, the next steps would be to update `DataFormats/Portable` README and `scripts`, and then update all the other `classes_def.xml` files that declare these portable data products.

Resolves https://github.com/cms-sw/framework-team/issues/1542

#### PR validation:

The `testHeterogeneousCoreAlpakaTestWriteReadSerialSync` unit test succeeds with the build of https://github.com/cms-sw/root/pull/222#issuecomment-3235701670. The resulting `rootmap` contains the `::Product`, `::Layout`, and `::Implementation` type aliases that the read rules use.