### PR TITLE
[cmsTraceFunction]Added test for abort option

### DIFF
--- a/Utilities/ReleaseScripts/test/gdb/test-cmsTraceFunction-setenv.sh
+++ b/Utilities/ReleaseScripts/test/gdb/test-cmsTraceFunction-setenv.sh
@@ -1,9 +1,15 @@
 #!/bin/bash -ex
 g++ -o test-cmsTraceFunction-setenv $(dirname $0)/test-cmsTraceFunction-setenv.cpp
-cmsTraceFunction --startAfterFunction ScheduleItems::initMisc setenv ./test-cmsTraceFunction-setenv 2>&1 | grep setenv > setenv.log
+cmsTraceFunction         --startAfterFunction ScheduleItems::initMisc setenv ./test-cmsTraceFunction-setenv 2>&1 | grep setenv > setenv.log
+cmsTraceFunction --abort --startAfterFunction ScheduleItems::initMisc setenv ./test-cmsTraceFunction-setenv 2>&1 | grep setenv > setenv-abort.log
 rm -f test-cmsTraceFunction-setenv
 setenv_count=$(grep '^setenv() called' setenv.log | wc -l)
 break_setenv=$(grep 'Breakpoint .* in setenv ()' setenv.log | wc -l)
 if [ ${setenv_count} != 3 ] || [ ${break_setenv} != 2 ] ; then
+  exit 1
+fi
+setenv_count=$(grep '^setenv() called' setenv-abort.log | wc -l)
+break_setenv=$(grep 'Breakpoint .* in setenv ()' setenv-abort.log | wc -l)
+if [ ${setenv_count} != 1 ] || [ ${break_setenv} != 1 ] ; then
   exit 1
 fi


### PR DESCRIPTION
`test-cmsTraceFunction-setenv` test is updated to test the new `--abort` option too. This needs https://github.com/cms-sw/cmsdist/pull/10051 to be merged first