### PR TITLE
[PhysicsTools/TensorFlowAOT/testAOTTools] Fix unknown-pc-linux on EL10 by replacing platform.processor() with platform.machine()

### DIFF
--- a/PhysicsTools/TensorFlowAOT/test/testAOTTools.py
+++ b/PhysicsTools/TensorFlowAOT/test/testAOTTools.py
@@ -43,7 +43,8 @@ class TFAOTTests(unittest.TestCase):
         config_file = os.path.join(m.group(1), "share", "test_models", "simple", "aot_config.yaml")
         self.assertTrue(os.path.exists(config_file))
 
-        arch = "{0}-pc-linux".format(platform.processor())
+        arch = f"{platform.machine()}-pc-linux"
+
 
         # run the dev workflow
         # create the test model


### PR DESCRIPTION
#### PR description:

### Problem
On EL10, `platform.processor()` returns an empty string because `uname -p` reports "unknown". This caused the constructed target triple to become `-pc-linux`, which is interpreted as `unknown-pc-linux`, leading to compilation failures such as:

```BASH
XLA compilation failed: TargetRegistry::lookupTarget failed: No available targets are compatible with triple "unknown-pc-linux" | subprocess.CalledProcessError: Command 'cms_tfaot_compile -c /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02905/el10_amd64_gcc14/external/py3-cms-tfaot/1.0.1-ccabcb1b7fd1ee5db83d4f81e8f5ac2c/share/test_models/simple/aot_config.yaml -o 
```
### Fix
Switch from `platform.processor()` to `platform.machine()` which reliably reports the architecture `x86_64` on both EL9 and EL10.
