### PR TITLE
Fixed bug on longitudinal momentum computation for SUEP constituents

### DIFF
--- a/GeneratorInterface/Pythia8Interface/src/SuepShower.cc
+++ b/GeneratorInterface/Pythia8Interface/src/SuepShower.cc
@@ -155,7 +155,7 @@ const Pythia8::Vec4 SuepShower::generateFourVector() {
   // compose the 4 std::vector
   en = sqrt(momentum * momentum + darkmeson_mass_ * darkmeson_mass_);
   Pythia8::Vec4 daughterFourMomentum =
-      Pythia8::Vec4(momentum * cos(phi) * sin(theta), momentum * sin(phi) * sin(theta), momentum * sin(theta), en);
+      Pythia8::Vec4(momentum * cos(phi) * sin(theta), momentum * sin(phi) * sin(theta), momentum * cos(theta), en);
   return daughterFourMomentum;
 }
 


### PR DESCRIPTION
#### PR description:

The SuepShower module involves the generation of 4-vector in polar coordinates and then transforming them to euclidean. In the transformation there is a bug in the longitudinal momentum of the constituents (sin => cos) which makes the resulting shower less spherical than expected.

#### PR validation:

Code checks passed, reproduced gen step samples for several SUEP configurations in use

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Ideally we would like to backport this down to 10_6_X in case new UL-conditions MC is produced, and at least for releases active in Run 3 MC production. If I understood properly this means backporting it to all active intermediate ones (15_0_X, 14_2_X,14_1_X,14_0_X, 13_3_X, 13_2_X, 13_1_X, 13_0_X, 12_4_X, and 10_6_X as per [the IB page](https://cmssdt.cern.ch/SDT/html/cmssdt-ib/#/ib/CMSSW_15_1_X)), is it correct?
