### PR TITLE
[15_0_X] added new miniAODDQMBtagOnly sequence to OfflineDQM 

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -276,5 +276,6 @@ from Validation.RecoParticleFlow.DQMForPF_MiniAOD_cff import *
 from DQMOffline.RecoB.bTagMiniDQM_cff import *
 
 DQMHarvestMiniAOD = cms.Sequence( dataCertificationJetMETSequence * muonQualityTests_miniAOD * DQMHarvestPF * bTagMiniDQMHarvesting)
+DQMHarvestMiniAODBTagOnly = cms.Sequence(bTagMiniDQMHarvesting)
 DQMHarvestNanoAOD = cms.Sequence( nanoHarvest )
 

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -302,6 +302,7 @@ from DQMOffline.Muon.miniAOD_cff import *
 from DQM.Physics.DQMTopMiniAOD_cff import *
 
 DQMOfflineMiniAOD = cms.Sequence(jetMETDQMOfflineRedoProductsMiniAOD*bTagMiniDQMSource*muonMonitors_miniAOD*MuonMiniAOD*DQMOfflinePF)
+DQMOfflineMiniAODBTagOnly = cms.Sequence(bTagMiniDQMSource)
 
 #Post sequences are automatically placed in the EndPath by ConfigBuilder if PAT is run.
 #miniAOD DQM sequences need to access the filter results.

--- a/DQMOffline/Configuration/python/autoDQM.py
+++ b/DQMOffline/Configuration/python/autoDQM.py
@@ -202,6 +202,10 @@ autoDQM = { 'DQMMessageLogger': ['DQMMessageLoggerSeq',
                            'PostDQMOfflineMiniAOD',
                            'DQMHarvestMiniAOD'],
 
+            'miniAODDQMBTagOnly': ['DQMOfflineMiniAODBTagOnly',
+                            'PostDQMOfflineMiniAOD',
+                           'DQMHarvestMiniAODBTagOnly'],  
+
             'nanoAODDQM': ['DQMOfflineNanoAOD',
                            'PostDQMOffline',
                            'DQMHarvestNanoAOD'],


### PR DESCRIPTION
This is a 15_0_X backport of [PR #48638](https://github.com/cms-sw/cmssw/pull/48638). 
We hope to include this change so that BTag histograms may be monitored at T0 for the 2025F datataking period. 

PR was validated as described in original PR. 