### PR TITLE
Removed FWCore/Utilities dependency on PerfTools/AllocMonitor

### DIFF
--- a/PerfTools/AllocMonitor/BuildFile.xml
+++ b/PerfTools/AllocMonitor/BuildFile.xml
@@ -1,3 +1,7 @@
-<export>
-  <lib name="1"/>
-</export>
+<environment>
+  <use name="sockets"/> <!-- this provides the dl library -->
+  <use name="FWCore/Utilities" source_only="1"/>
+  <export>
+    <lib name="1"/>
+  </export>
+</environment>

--- a/PerfTools/AllocMonitor/BuildFile.xml
+++ b/PerfTools/AllocMonitor/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="FWCore/Utilities"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
#### PR description:

- The dependency on FWCore/Utilities was only there to get the cms::Exception. Switching to std::exception removed the dependency.
- This was initiated to solve a failing when using PerfTools/AllocMonitor in the el10 experimental builds.

#### PR validation:

The failing tests now run and cmsRun also works on el10.

resolves #48556
resolves https://github.com/cms-sw/framework-team/issues/1548