### PR TITLE
Fixed outgoing R-hadron check for stop R-hadrons

### DIFF
--- a/SimG4Core/CustomPhysics/interface/FullModelHadronicProcess.h
+++ b/SimG4Core/CustomPhysics/interface/FullModelHadronicProcess.h
@@ -7,25 +7,35 @@
 #include "G4Nucleus.hh"
 #include "G4ReactionProduct.hh"
 #include <vector>
+#include "G4HadronicException.hh"
 
 #include "SimG4Core/CustomPhysics/interface/FullModelReactionDynamics.h"
 
-class CustomProcessHelper;
+class G4ProcessHelper;
 
 class FullModelHadronicProcess : public G4VDiscreteProcess {
 public:
-  FullModelHadronicProcess(CustomProcessHelper *aHelper, const G4String &processName = "FullModelHadronicProcess");
+  FullModelHadronicProcess(G4ProcessHelper *aHelper, const G4String &processName = "FullModelHadronicProcess");
 
-  ~FullModelHadronicProcess() override = default;
+  ~FullModelHadronicProcess() override;
 
   G4bool IsApplicable(const G4ParticleDefinition &aP) override;
 
   G4VParticleChange *PostStepDoIt(const G4Track &aTrack, const G4Step &aStep) override;
 
 protected:
-  G4double GetMeanFreePath(const G4Track &aTrack, G4double, G4ForceCondition *) override;
+  const G4ParticleDefinition *theParticle;
+  G4ParticleDefinition *newParticle;
+
+  G4ParticleChange theParticleChange;
 
 private:
+  virtual G4double GetMicroscopicCrossSection(const G4DynamicParticle *aParticle,
+                                              const G4Element *anElement,
+                                              G4double aTemp);
+
+  G4double GetMeanFreePath(const G4Track &aTrack, G4double, G4ForceCondition *) override;
+
   void CalculateMomenta(G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
                         G4int &vecLen,
                         const G4HadProjectile *originalIncident,
@@ -44,15 +54,10 @@ private:
 
   void Rotate(G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec, G4int &vecLen);
 
-  CustomProcessHelper *theHelper;
-  const G4ParticleDefinition *theParticle{nullptr};
-  G4ParticleDefinition *newParticle{nullptr};
-
-  G4Nucleus targetNucleus;
-  FullModelReactionDynamics theReactionDynamics;
-
+  G4ProcessHelper *theHelper;
+  G4bool toyModel;
   G4ThreeVector incomingCloud3Momentum;
-  std::vector<G4double> xsec_;
+
 };
 
 #endif

--- a/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
+++ b/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
@@ -141,7 +141,8 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
       TargetSurvives = true;
     }
 
-    if (finalStateParticle->GetParticleType() == "rhadron" || finalStateParticle->GetParticleType() == "mesonino" || finalStateParticle->GetParticleType() == "sbaryon") {
+    if (finalStateParticle->GetParticleType() == "rhadron" || finalStateParticle->GetParticleType() == "mesonino" ||
+        finalStateParticle->GetParticleType() == "sbaryon") {
       outgoingRhadronDefinition = finalStateParticle;
       outgoingCloudDefinition = finalStateCustomParticle->GetCloud();
     }

--- a/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
+++ b/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
@@ -141,7 +141,7 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
       TargetSurvives = true;
     }
 
-    if (finalStateParticle->GetParticleType() == "rhadron") {
+    if (finalStateParticle->GetParticleType() == "rhadron" || finalStateParticle->GetParticleType() == "mesonino" || finalStateParticle->GetParticleType() == "sbaryon") {
       outgoingRhadronDefinition = finalStateParticle;
       outgoingCloudDefinition = finalStateCustomParticle->GetCloud();
     }


### PR DESCRIPTION
#### PR description:

[This PR](https://github.com/cms-sw/cmssw/commit/22f2e008851b21371836a73c342af19953e782f5) mistakenly introduced a bug for stop R-hadron simulation. When finding the outgoing R-hadron, the previous if statement checks if the particle type is `rhadron`. This works for gluino R-hadrons, but stop R-hadrons have either particle type `mesonino` or `sbaryon`.

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

<!-- Please delete the text above after you verified all points of the checklist  -->
