### PR TITLE
Fixed outgoing R-hadron check for stop R-hadrons

### DIFF
--- a/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
+++ b/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
@@ -141,7 +141,8 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
       TargetSurvives = true;
     }
 
-    if (finalStateParticle->GetParticleType() == "rhadron") {
+    if (finalStateParticle->GetParticleType() == "rhadron" || finalStateParticle->GetParticleType() == "mesonino" ||
+        finalStateParticle->GetParticleType() == "sbaryon") {
       outgoingRhadronDefinition = finalStateParticle;
       outgoingCloudDefinition = finalStateCustomParticle->GetCloud();
     }


### PR DESCRIPTION
#### PR description:

[This PR](https://github.com/cms-sw/cmssw/commit/22f2e008851b21371836a73c342af19953e782f5) mistakenly introduced a bug for stop R-hadron simulation. When finding the outgoing R-hadron, the previous if statement checks if the particle type is `rhadron`. This works for gluino R-hadrons, but stop R-hadrons have either particle type `mesonino` or `sbaryon`.

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

<!-- Please delete the text above after you verified all points of the checklist  -->
