### PR TITLE
Cosmics pMin and Strip Clusters threshold DQM

### DIFF
--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -267,8 +267,8 @@ if (process.runType.getRunType() == process.runType.cosmic_run or process.runTyp
 
     # Reco for cosmic data
     process.load('RecoTracker.SpecialSeedGenerators.SimpleCosmicBONSeeder_cfi')
-    process.simpleCosmicBONSeeds.ClusterCheckPSet.MaxNumberOfStripClusters = 450
-    process.combinatorialcosmicseedfinderP5.MaxNumberOfStripClusters = 450
+    process.simpleCosmicBONSeeds.ClusterCheckPSet.MaxNumberOfStripClusters = 1000
+    process.combinatorialcosmicseedfinderP5.MaxNumberOfStripClusters = 1000
 
     process.RecoForDQM_TrkReco_cosmic = cms.Sequence(process.offlineBeamSpot*process.MeasurementTrackerEvent*process.ctftracksP5)
 

--- a/DQM/TrackingMonitorClient/data/tracking_qualitytest_config_tier0_cosmic.xml
+++ b/DQM/TrackingMonitorClient/data/tracking_qualitytest_config_tier0_cosmic.xml
@@ -41,7 +41,7 @@
       <PARAM name="useRange">1</PARAM>
       <PARAM name="minEntries">0</PARAM>
       <PARAM name="xmin">0.0</PARAM>
-      <PARAM name="xmax">200.0</PARAM>
+      <PARAM name="xmax">800.0</PARAM>
 </QTEST>
 <QTEST name="MeanWithinExpectedRange:SeedNPixel" activate="true">
      <TYPE>MeanWithinExpected</TYPE>

--- a/RecoTracker/SpecialSeedGenerators/python/SimpleCosmicBONSeeder_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/SimpleCosmicBONSeeder_cfi.py
@@ -51,7 +51,7 @@ simpleCosmicBONSeeds = simpleCosmicBONSeeder.clone(
         originRadius     = cms.double(150.0),  #  |-> probably don't change
         originHalfLength = cms.double(90.0),   # /    anything at all.
         ptMin = cms.double(0.5),               # pt cut, applied both at the triplet finding and at the seeding level
-        pMin  = cms.double(1.0),               # p  cut, applied only at the seeding level
+        pMin  = cms.double(4.0),               # p  cut, applied only at the seeding level
     ),
     TripletsSrc = "simpleCosmicBONSeedingLayers",
     TripletsDebugLevel = 0,  # debug triplet finding (0 to 3)

--- a/RecoTracker/SpecialSeedGenerators/src/SimpleCosmicBONSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/SimpleCosmicBONSeeder.cc
@@ -644,7 +644,7 @@ void SimpleCosmicBONSeeder::fillDescriptions(edm::ConfigurationDescriptions &des
   regionPSet.add<double>("originRadius", 150.0);
   regionPSet.add<double>("originHalfLength", 90.0);
   regionPSet.add<double>("ptMin", 0.5);
-  regionPSet.add<double>("pMin", 1.0);
+  regionPSet.add<double>("pMin", 4.0);
   desc.add<edm::ParameterSetDescription>("RegionPSet", regionPSet);
 
   desc.add<edm::InputTag>("TripletsSrc", edm::InputTag("simpleCosmicBONSeedingLayers"));


### PR DESCRIPTION
#### PR description:

These threshold changes are related to Cosmics tracks reconstruction in DQM GUI.

Since 2025D, after HV raise in Strip TEC (23 July), there is an excess of noise clusters in TEC, generating a large number of fake tracks reconstructed (low pT) with respect to reference (blue): https://tinyurl.com/4twf29xb

Actions:
- Update Error Threshold value on Number of Strip Clusters in DQM GUI Tracking Summary (from 200 to 800) as real threshold limit used for track reconstruction was updated to 1000 in PR: https://github.com/cms-sw/cmssw/pull/47577
- Change pMin filter for Cosmics tracks seeding (with B field ON) from 1 GeV to 4 GeV (same [value used by Tracker Alignment](https://github.com/cms-sw/cmssw/blob/master/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlCosmics0T_Skimmed_cff.py#L89)), to clean the pT distribution as done on AlcaReco tracks used by Tracker Alignment: https://tinyurl.com/2b2nqne4
- Change Threshold on Number of Strip Clusters that prevents Track reconstruction in Cosmics inside Strip DQM client, from 450 to 1000, as in 2025 we often reach 450 clusters, i.e. run 395610 with 600 Strip clusters: https://tinyurl.com/22jbxzrq 
 
#### PR validation:

Simply changed 4 threshold values.

#### Backport
This PR is intended for 2025 data taking.
Corresponding Backport to 15_1_X : https://github.com/cms-sw/cmssw/pull/48849