### PR TITLE
TICLv5 Adjust Linking step

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -857,7 +857,7 @@ class UpgradeWorkflow_ticl_v5(UpgradeWorkflow):
             stepDict[stepName][k] = merge([self.step4, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
         selected_fragments = ["TTbar_14TeV", "CloseByP", "Eta1p7_2p7", "ZEE_14"]
-        return (fragment in selected_fragments) and 'Run4' in key
+        return any(sf in fragment for sf in selected_fragments) and 'Run4' in key
 
 upgradeWFs['ticl_v5'] = UpgradeWorkflow_ticl_v5(
     steps = [

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltTiclCandidate_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltTiclCandidate_cfi.py
@@ -1,6 +1,25 @@
 import FWCore.ParameterSet.Config as cms
 
 hltTiclCandidate = cms.EDProducer("TICLCandidateProducer",
+    inferenceAlgo = cms.string('TracksterInferenceByPFN'),
+    regressionAndPid = cms.bool(True),
+    pluginInferenceAlgoTracksterInferenceByPFN = cms.PSet(
+      algo_verbosity = cms.int32(0),
+      onnxPIDModelPath = cms.FileInPath('RecoHGCal/TICL/data/ticlv5/onnx_models/PFN/linking/id_v0.onnx'),
+      onnxEnergyModelPath = cms.FileInPath('RecoHGCal/TICL/data/ticlv5/onnx_models/PFN/linking/energy_v0.onnx'),
+      inputNames = cms.vstring(
+        'input',
+        'input_tr_features'
+      ),
+      output_en = cms.vstring('enreg_output'),
+      output_id = cms.vstring('pid_output'),
+      eid_min_cluster_energy = cms.double(1),
+      eid_n_layers = cms.int32(50),
+      eid_n_clusters = cms.int32(10),
+      doPID = cms.int32(1),
+      doRegression = cms.int32(1),
+      type = cms.string('TracksterInferenceByPFN')
+    ),
     cutTk = cms.string('1.48 < abs(eta) < 3.0 && pt > 1. && quality("highPurity") && hitPattern().numberOfLostHits("MISSING_OUTER_HITS") < 5'),
     detector = cms.string('HGCAL'),
     egamma_tracksterlinks_collections = cms.VInputTag("hltTiclTracksterLinks"),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltTiclTracksterLinksL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltTiclTracksterLinksL1Seeded_cfi.py
@@ -38,7 +38,7 @@ hltTiclTracksterLinksL1Seeded = cms.EDProducer("TracksterLinksProducer",
     mightGet = cms.optional.untracked.vstring,
     original_masks = cms.VInputTag("hltMergeLayerClustersL1Seeded:InitialLayerClustersMask"),
     propagator = cms.string('PropagatorWithMaterial'),
-    regressionAndPid = cms.bool(True),
+    regressionAndPid = cms.bool(False),
     tracksters_collections = cms.VInputTag("hltTiclTrackstersCLUE3DHighL1Seeded", "hltTiclTrackstersRecoveryL1Seeded")
 )
 

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltTiclTracksterLinks_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltTiclTracksterLinks_cfi.py
@@ -38,7 +38,7 @@ hltTiclTracksterLinks = cms.EDProducer("TracksterLinksProducer",
     mightGet = cms.optional.untracked.vstring,
     original_masks = cms.VInputTag("hltMergeLayerClusters:InitialLayerClustersMask"),
     propagator = cms.string('PropagatorWithMaterial'),
-    regressionAndPid = cms.bool(True),
+    regressionAndPid = cms.bool(False),
     tracksters_collections = cms.VInputTag("hltTiclTrackstersCLUE3DHigh", "hltTiclTrackstersRecovery")
 )
 

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/hltTiclTracksterLinksPSet_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/hltTiclTracksterLinksPSet_cfi.py
@@ -18,11 +18,11 @@ hltTiclTracksterLinksPSet = cms.PSet(
         100
       ),
       upper_distance_projective_sqr = cms.vdouble(
-        30,
+        4,
         60
       ),
       lower_distance_projective_sqr = cms.vdouble(
-        30,
+        4,
         60
       ),
       min_distance_z = cms.vdouble(

--- a/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
@@ -376,7 +376,6 @@ void GeneralInterpretationAlgo::makeCandidates(const Inputs &input,
         // TODO: fix probabilities when CNN will be splitted
         Trackster outTrackster;
         bool isHadron = false;
-        outTrackster.mergeTracksters(input.tracksters, trackstersInTrackIndices[iTrack]);
         for (auto const tracksterId : trackstersInTrackIndices[iTrack]) {
           //maskTracksters[tracksterId] = 0;
           outTrackster.mergeTracksters(input.tracksters[tracksterId]);

--- a/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
@@ -375,18 +375,16 @@ void GeneralInterpretationAlgo::makeCandidates(const Inputs &input,
         // in this case mergeTracksters() clears the pid probabilities and the regressed energy is not set
         // TODO: fix probabilities when CNN will be splitted
         Trackster outTrackster;
-        float regr_en = 0.f;
         bool isHadron = false;
         outTrackster.mergeTracksters(input.tracksters, trackstersInTrackIndices[iTrack]);
         for (auto const tracksterId : trackstersInTrackIndices[iTrack]) {
           //maskTracksters[tracksterId] = 0;
-          regr_en += input.tracksters[tracksterId].regressed_energy();
+          outTrackster.mergeTracksters(input.tracksters[tracksterId]);
           if (input.tracksters[tracksterId].isHadronic())
             isHadron = true;
         }
         resultCandidate[iTrack] = resultTracksters.size();
         resultTracksters.push_back(outTrackster);
-        resultTracksters.back().setRegressedEnergy(regr_en);
         // since a track has been linked it can only be electron or charged hadron
         if (isHadron)
           resultTracksters.back().setIdProbability(ticl::Trackster::ParticleType::charged_hadron, 1.f);

--- a/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
+++ b/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
@@ -1,5 +1,4 @@
-// Author: Felice Pantaleo, Wahid Redjeb, Aurora Perego (CERN) - felice.pantaleo@cern.ch, wahid.redjeb@cern.ch, aurora.perego@cern.ch
-// Date: 12/2023
+// Author: Felice Pantaleo, Wahid Redjeb, Aurora Perego (CERN) - felice.pantaleo@cern.ch, wahid.redjeb@cern.ch, aurora.perego@cern.ch Date: 12/2023
 #include <memory>  // unique_ptr
 #include "DataFormats/HGCalReco/interface/MultiVectorManager.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
@@ -47,22 +46,28 @@
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
+#include "PhysicsTools/ONNXRuntime/interface/ONNXRuntime.h"
+
 #include "Geometry/HGCalCommonData/interface/HGCalDDDConstants.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "RecoHGCal/TICL/interface/TracksterInferenceAlgoFactory.h"
 
 #include "TrackstersPCA.h"
 
 using namespace ticl;
+using cms::Ort::ONNXRuntime;
 
-class TICLCandidateProducer : public edm::stream::EDProducer<> {
+class TICLCandidateProducer : public edm::stream::EDProducer<edm::GlobalCache<ONNXRuntime>> {
 public:
-  explicit TICLCandidateProducer(const edm::ParameterSet &ps);
+  explicit TICLCandidateProducer(const edm::ParameterSet &ps, const ONNXRuntime *);
   ~TICLCandidateProducer() override {}
   void produce(edm::Event &, const edm::EventSetup &) override;
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
   void beginRun(edm::Run const &iEvent, edm::EventSetup const &es) override;
+  static std::unique_ptr<ONNXRuntime> initializeGlobalCache(const edm::ParameterSet &iConfig);
+  static void globalEndJob(const ONNXRuntime *);
 
 private:
   void dumpCandidate(const TICLCandidate &) const;
@@ -82,6 +87,8 @@ private:
 
   const edm::EDGetTokenT<std::vector<reco::CaloCluster>> clusters_token_;
   const edm::EDGetTokenT<edm::ValueMap<std::pair<float, float>>> clustersTime_token_;
+  const bool regressionAndPid_;
+  std::unique_ptr<TracksterInferenceAlgoBase> inferenceAlgo_;
 
   std::vector<edm::EDGetTokenT<std::vector<float>>> original_masks_tokens_;
 
@@ -113,10 +120,11 @@ private:
   static constexpr float timeRes = 0.02f;
 };
 
-TICLCandidateProducer::TICLCandidateProducer(const edm::ParameterSet &ps)
+TICLCandidateProducer::TICLCandidateProducer(const edm::ParameterSet &ps, const ONNXRuntime *)
     : clusters_token_(consumes<std::vector<reco::CaloCluster>>(ps.getParameter<edm::InputTag>("layer_clusters"))),
       clustersTime_token_(
           consumes<edm::ValueMap<std::pair<float, float>>>(ps.getParameter<edm::InputTag>("layer_clustersTime"))),
+      regressionAndPid_(ps.getParameter<bool>("regressionAndPid")),
       tracks_token_(consumes<std::vector<reco::Track>>(ps.getParameter<edm::InputTag>("tracks"))),
       muons_token_(consumes<std::vector<reco::Muon>>(ps.getParameter<edm::InputTag>("muons"))),
       useMTDTiming_(ps.getParameter<bool>("useMTDTiming")),
@@ -168,6 +176,11 @@ TICLCandidateProducer::TICLCandidateProducer(const edm::ParameterSet &ps)
   if (useMTDTiming_) {
     inputTimingToken_ = consumes<MtdHostCollection>(ps.getParameter<edm::InputTag>("timingSoA"));
   }
+  // Initialize inference algorithm using the factory
+  std::string inferencePlugin = ps.getParameter<std::string>("inferenceAlgo");
+  edm::ParameterSet inferencePSet = ps.getParameter<edm::ParameterSet>("pluginInferenceAlgo" + inferencePlugin);
+  inferenceAlgo_ = std::unique_ptr<TracksterInferenceAlgoBase>(
+      TracksterInferenceAlgoFactory::get()->create(inferencePlugin, inferencePSet));
 
   produces<std::vector<TICLCandidate>>();
 
@@ -179,6 +192,12 @@ TICLCandidateProducer::TICLCandidateProducer(const edm::ParameterSet &ps)
   generalInterpretationAlgo_ =
       TICLGeneralInterpretationPluginFactory::get()->create(algoType, interpretationPSet, consumesCollector());
 }
+
+std::unique_ptr<ONNXRuntime> TICLCandidateProducer::initializeGlobalCache(const edm::ParameterSet &iConfig) {
+  return std::unique_ptr<ONNXRuntime>(nullptr);
+}
+
+void TICLCandidateProducer::globalEndJob(const ONNXRuntime *) {}
 
 void TICLCandidateProducer::beginRun(edm::Run const &iEvent, edm::EventSetup const &es) {
   edm::ESHandle<HGCalDDDConstants> hdc = es.getHandle(hdc_token_);
@@ -311,6 +330,12 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
                         rhtools_.getPositionLayer(rhtools_.lastLayerEE()).z(),
                         rhtools_,
                         true);
+  if (regressionAndPid_) {
+    // Run inference algorithm
+    inferenceAlgo_->inputData(layerClusters, *resultTracksters);
+    inferenceAlgo_->runInference(
+        *resultTracksters);  //option to use "Linking" instead of "CLU3D"/"energyAndPid" instead of "PID"
+  }
 
   std::vector<bool> maskTracksters(resultTracksters->size(), true);
   edm::OrphanHandle<std::vector<Trackster>> resultTracksters_h = evt.put(std::move(resultTracksters));
@@ -326,16 +351,16 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
         maskTracksters[tracksterId] = false;
       } else {
         //charged candidates track only
-        edm::Ptr<Trackster> tracksterPtr;
-        TICLCandidate chargedCandidate(trackPtr, tracksterPtr);
         auto trackRef = edm::Ref<reco::TrackCollection>(tracks_h, iTrack);
         const int muId = PFMuonAlgo::muAssocToTrack(trackRef, *muons_h);
         const reco::MuonRef muonRef = reco::MuonRef(muons_h, muId);
         if (muonRef.isNonnull() and muonRef->isGlobalMuon()) {
           // create muon candidate
+          edm::Ptr<Trackster> tracksterPtr;
+          TICLCandidate chargedCandidate(trackPtr, tracksterPtr);
           chargedCandidate.setPdgId(13 * trackPtr.get()->charge());
+          resultCandidates->push_back(chargedCandidate);
         }
-        resultCandidates->push_back(chargedCandidate);
       }
     }
   }
@@ -478,6 +503,9 @@ void TICLCandidateProducer::fillDescriptions(edm::ConfigurationDescriptions &des
   edm::ParameterSetDescription desc;
   edm::ParameterSetDescription interpretationDesc;
   interpretationDesc.addNode(edm::PluginDescription<TICLGeneralInterpretationPluginFactory>("type", "General", true));
+  edm::ParameterSetDescription inferenceDesc;
+  inferenceDesc.addNode(edm::PluginDescription<TracksterInferenceAlgoFactory>("type", "TracksterInferenceByPFN", true));
+  desc.add<edm::ParameterSetDescription>("pluginInferenceAlgoTracksterInferenceByPFN", inferenceDesc);
   desc.add<edm::ParameterSetDescription>("interpretationDescPSet", interpretationDesc);
   desc.add<std::vector<edm::InputTag>>("egamma_tracksters_collections", {edm::InputTag("ticlTracksterLinks")});
   desc.add<std::vector<edm::InputTag>>("egamma_tracksterlinks_collections", {edm::InputTag("ticlTracksterLinks")});
@@ -498,6 +526,8 @@ void TICLCandidateProducer::fillDescriptions(edm::ConfigurationDescriptions &des
   desc.add<std::string>("cutTk",
                         "1.48 < abs(eta) < 3.0 && pt > 1. && quality(\"highPurity\") && "
                         "hitPattern().numberOfLostHits(\"MISSING_OUTER_HITS\") < 5");
+  desc.add<bool>("regressionAndPid", true);
+  desc.add<std::string>("inferenceAlgo", "TracksterInferenceByPFN");
   descriptions.add("ticlCandidateProducer", desc);
 }
 

--- a/RecoHGCal/TICL/plugins/TracksterLinkingbySkeletons.cc
+++ b/RecoHGCal/TICL/plugins/TracksterLinkingbySkeletons.cc
@@ -286,16 +286,19 @@ bool TracksterLinkingbySkeletons::areCompatible(const ticl::Trackster &myTrackst
                                           << myTrackster.vertices().size() << " IS GOOD " << std::endl;
 
   float proj_distance = projective_distance(mySkeleton[1], otherSkeleton[1]);
-
   bool isInEE = std::abs(mySkeleton[1].z()) <= zVal_interface;
   bool isOutEE = std::abs(otherSkeleton[1].z()) <= zVal_interface;
-  bool bothEE = (isInEE && isOutEE); // only check if they are aligned
+  bool bothEE = (isInEE && isOutEE);  // only check if they are aligned
 
   // inEE --> !outEE --> True
   // inEE --> outEE --> False
   // !inEE --> outEE --> False
   // !inEE --> !outEE --> True
   bool isLoose = (!isOutEE);
+
+  if (bothEE) {  //just don't try to link if two objects are in the CEE part (too much occupancy)
+    return false;
+  }
 
   auto const max_distance_proj_sqr = computeParameter(myTrackster.raw_energy(),
                                                       lower_boundary_[isLoose],
@@ -314,9 +317,6 @@ bool TracksterLinkingbySkeletons::areCompatible(const ticl::Trackster &myTrackst
       LogDebug("TracksterLinkingbySkeletons") << "\t\t Linked! " << std::endl;
       return true;
     } else {
-      if (bothEE) {
-        return false;
-      }
       //if the tracksters are not aligned in Projective distance, check if otherTrackster is within the cylinder of 3cm radius
       //this is used to recover LC splittings
       if (isSplitComponent(myTrackster, otherTrackster, mySkeleton, otherSkeleton, proj_distance)) {
@@ -329,9 +329,6 @@ bool TracksterLinkingbySkeletons::areCompatible(const ticl::Trackster &myTrackst
       return checkClosestPoints(myTrackster, otherTrackster, mySkeleton, otherSkeleton, isLoose);
     }
   } else {
-    if (bothEE) {
-      return false;
-    }
     if (otherTrackster.vertices().size() >= 3) {
       if (areAlignedInProjectiveSpace) {
         LogDebug("TracksterLinkingbySkeletons") << "\t\t Linked! " << std::endl;

--- a/RecoHGCal/TICL/plugins/TracksterLinkingbySkeletons.cc
+++ b/RecoHGCal/TICL/plugins/TracksterLinkingbySkeletons.cc
@@ -274,7 +274,7 @@ bool TracksterLinkingbySkeletons::areCompatible(const ticl::Trackster &myTrackst
                                                 const ticl::Trackster &otherTrackster,
                                                 const std::array<ticl::Vector, 3> &mySkeleton,
                                                 const std::array<ticl::Vector, 3> &otherSkeleton) {
-  float zVal_interface = rhtools_.getPositionLayer(rhtools_.lastLayerEE()).z();
+  float zVal_interface = std::abs(rhtools_.getPositionLayer(rhtools_.lastLayerEE()).z());
 
   if (!isGoodTrackster(myTrackster, mySkeleton, min_num_lcs_, min_trackster_energy_, pca_quality_th_)) {
     LogDebug("TracksterLinkingbySkeletons") << "Inner Trackster with energy " << myTrackster.raw_energy() << " Num LCs "
@@ -286,12 +286,22 @@ bool TracksterLinkingbySkeletons::areCompatible(const ticl::Trackster &myTrackst
                                           << myTrackster.vertices().size() << " IS GOOD " << std::endl;
 
   float proj_distance = projective_distance(mySkeleton[1], otherSkeleton[1]);
-  auto isEE = mySkeleton[1].z() <= zVal_interface ? 0 : 1;
+
+  bool isInEE = std::abs(mySkeleton[1].z()) <= zVal_interface;
+  bool isOutEE = std::abs(otherSkeleton[1].z()) <= zVal_interface;
+  bool bothEE = (isInEE && isOutEE); // only check if they are aligned
+
+  // inEE --> !outEE --> True
+  // inEE --> outEE --> False
+  // !inEE --> outEE --> False
+  // !inEE --> !outEE --> True
+  bool isLoose = (!isOutEE);
+
   auto const max_distance_proj_sqr = computeParameter(myTrackster.raw_energy(),
-                                                      lower_boundary_[isEE],
-                                                      lower_distance_projective_sqr_[isEE],
-                                                      upper_boundary_[isEE],
-                                                      upper_distance_projective_sqr_[isEE]);
+                                                      lower_boundary_[isLoose],
+                                                      lower_distance_projective_sqr_[isLoose],
+                                                      upper_boundary_[isLoose],
+                                                      upper_distance_projective_sqr_[isLoose]);
   bool areAlignedInProjectiveSpace = proj_distance < max_distance_proj_sqr;
 
   LogDebug("TracksterLinkingbySkeletons")
@@ -304,21 +314,24 @@ bool TracksterLinkingbySkeletons::areCompatible(const ticl::Trackster &myTrackst
       LogDebug("TracksterLinkingbySkeletons") << "\t\t Linked! " << std::endl;
       return true;
     } else {
+      if (bothEE) {
+        return false;
+      }
       //if the tracksters are not aligned in Projective distance, check if otherTrackster is within the cylinder of 3cm radius
       //this is used to recover LC splittings
       if (isSplitComponent(myTrackster, otherTrackster, mySkeleton, otherSkeleton, proj_distance)) {
         LogDebug("TracksterLinkingbySkeletons") << "\t\t Linked! Splitted components!" << std::endl;
         return true;
       }
-      //if is EE do not try to link more, PU occupancy is too high in this region
-      if (isEE) {
-        return false;
-      }
+
       //if instead we are in the CE-H part of the detector, we can try to link more
       // we measure the distance between the two closest nodes in the two skeletons
-      return checkClosestPoints(myTrackster, otherTrackster, mySkeleton, otherSkeleton, isEE);
+      return checkClosestPoints(myTrackster, otherTrackster, mySkeleton, otherSkeleton, isLoose);
     }
   } else {
+    if (bothEE) {
+      return false;
+    }
     if (otherTrackster.vertices().size() >= 3) {
       if (areAlignedInProjectiveSpace) {
         LogDebug("TracksterLinkingbySkeletons") << "\t\t Linked! " << std::endl;
@@ -327,22 +340,22 @@ bool TracksterLinkingbySkeletons::areCompatible(const ticl::Trackster &myTrackst
         LogDebug("TracksterLinkingbySkeletons")
             << "\t Not aligned in projective space, check distance between closest points in the two skeletons "
             << std::endl;
-        if (checkClosestPoints(myTrackster, otherTrackster, mySkeleton, otherSkeleton, isEE)) {
+        if (checkClosestPoints(myTrackster, otherTrackster, mySkeleton, otherSkeleton, isLoose)) {
           return true;
         } else {
-          return checkCylinderAlignment(mySkeleton, otherSkeleton, isEE);
+          return checkCylinderAlignment(mySkeleton, otherSkeleton, isLoose);
         }
       }
     } else {
-      return checkCylinderAlignment(mySkeleton, otherSkeleton, isEE);
+      return checkCylinderAlignment(mySkeleton, otherSkeleton, isLoose);
     }
   }
 }
 
 bool TracksterLinkingbySkeletons::checkCylinderAlignment(const std::array<ticl::Vector, 3> &mySkeleton,
                                                          const std::array<ticl::Vector, 3> &otherSkeleton,
-                                                         int isEE) {
-  bool isInCyl = isInCylinder(mySkeleton, otherSkeleton, cylinder_radius_sqr_[isEE]);
+                                                         int isLoose) {
+  bool isInCyl = isInCylinder(mySkeleton, otherSkeleton, cylinder_radius_sqr_[isLoose]);
   if (isInCyl) {
     LogDebug("TracksterLinkingbySkeletons") << "Two Points are in Cylinder  " << isInCyl << " Linked! " << std::endl;
   }
@@ -369,7 +382,7 @@ bool TracksterLinkingbySkeletons::checkClosestPoints(const ticl::Trackster &myTr
                                                      const ticl::Trackster &otherTrackster,
                                                      const std::array<ticl::Vector, 3> &mySkeleton,
                                                      const std::array<ticl::Vector, 3> &otherSkeleton,
-                                                     int isEE) {
+                                                     int isLoose) {
   int myClosestPoint = -1;
   int otherClosestPoint = -1;
   float minDistance_z = std::numeric_limits<float>::max();
@@ -387,24 +400,24 @@ bool TracksterLinkingbySkeletons::checkClosestPoints(const ticl::Trackster &myTr
 
   float d = projective_distance(mySkeleton[myClosestPoint], otherSkeleton[otherClosestPoint]);
   auto const max_distance_proj_sqr_closest = computeParameter(myTrackster.raw_energy(),
-                                                              lower_boundary_[isEE],
-                                                              lower_distance_projective_sqr_closest_points_[isEE],
-                                                              upper_boundary_[isEE],
-                                                              upper_distance_projective_sqr_closest_points_[isEE]);
+                                                              lower_boundary_[isLoose],
+                                                              lower_distance_projective_sqr_closest_points_[isLoose],
+                                                              upper_boundary_[isLoose],
+                                                              upper_distance_projective_sqr_closest_points_[isLoose]);
 
   LogDebug("TracksterLinkingbySkeletons")
       << "\t\t Distance between closest points " << d << " TH " << 10.f << " Z Distance " << minDistance_z << " TH "
       << max_distance_proj_sqr_closest << std::endl;
 
-  if (d < max_distance_proj_sqr_closest && minDistance_z < max_z_distance_closest_points_[isEE]) {
+  if (d < max_distance_proj_sqr_closest && minDistance_z < max_z_distance_closest_points_[isLoose]) {
     LogDebug("TracksterLinkingbySkeletons") << "\t\t\t Linked! " << d << std::endl;
     return true;
   }
 
   LogDebug("TracksterLinkingbySkeletons") << "Distance between closest point " << d << " Distance in z "
-                                          << max_z_distance_closest_points_[isEE] << std::endl;
+                                          << max_z_distance_closest_points_[isLoose] << std::endl;
 
-  return checkCylinderAlignment(mySkeleton, otherSkeleton, isEE);
+  return checkCylinderAlignment(mySkeleton, otherSkeleton, isLoose);
 }
 
 void TracksterLinkingbySkeletons::linkTracksters(

--- a/RecoHGCal/TICL/python/iterativeTICL_cff.py
+++ b/RecoHGCal/TICL/python/iterativeTICL_cff.py
@@ -52,11 +52,11 @@ ticlTracksterLinks = _tracksterLinksProducer.clone(
         100
       ),  
       upper_distance_projective_sqr = cms.vdouble(
-        30, 
+        4, 
         60  
       ),  
       lower_distance_projective_sqr = cms.vdouble(
-        30, 
+        4, 
         60  
       ),  
       min_distance_z = cms.vdouble(

--- a/RecoHGCal/TICL/python/iterativeTICL_cff.py
+++ b/RecoHGCal/TICL/python/iterativeTICL_cff.py
@@ -84,7 +84,7 @@ ticlTracksterLinks = _tracksterLinksProducer.clone(
       type = cms.string('Skeletons')
     
     ),  
-    regressionAndPid = cms.bool(True),
+    regressionAndPid = cms.bool(False),
     inferenceAlgo = cms.string('TracksterInferenceByPFN'),
     pluginInferenceAlgoTracksterInferenceByDNN = cms.PSet(
         algo_verbosity = cms.int32(0),
@@ -115,7 +115,31 @@ ticlTracksterLinks = _tracksterLinksProducer.clone(
         type = cms.string('TracksterInferenceByPFN')
     )
 )
-ticlCandidate = _ticlCandidateProducer.clone()
+
+ticlCandidate = _ticlCandidateProducer.clone(
+    inferenceAlgo=cms.string('TracksterInferenceByPFN'),
+    regressionAndPid = cms.bool(True),
+    pluginInferenceAlgoTracksterInferenceByPFN=cms.PSet(
+        algo_verbosity=cms.int32(0),
+        onnxPIDModelPath=cms.FileInPath(
+            'RecoHGCal/TICL/data/ticlv5/onnx_models/PFN/linking/id_v0.onnx'),
+        onnxEnergyModelPath=cms.FileInPath(
+            'RecoHGCal/TICL/data/ticlv5/onnx_models/PFN/linking/energy_v0.onnx'),
+        inputNames=cms.vstring(
+            'input',
+            'input_tr_features'
+        ),
+        output_en=cms.vstring('enreg_output'),
+        output_id=cms.vstring('pid_output'),
+        eid_min_cluster_energy=cms.double(1),
+        eid_n_layers=cms.int32(50),
+        eid_n_clusters=cms.int32(10),
+        doPID=cms.int32(1),
+        doRegression=cms.int32(1),
+        type=cms.string('TracksterInferenceByPFN')
+    )
+)
+
 mtdSoA = _mtdSoAProducer.clone()
 
 pfTICL = _pfTICLProducer.clone()


### PR DESCRIPTION
#### PR description

This PR addresse the issue reported by the NGT group on Jet performance with TICLv5, showing a disruptive increase in the jet energy response. See presentation at HLT upgrade [1] from slide 15 with the comparison between TICLv4 and TICLv5.
This PR introduces a first stage of changes:
- Addressing the Trackster-Trackster linking, limiting links between objects in the HGCAL-CEE region, where the occupancy of the detector can lead the linking to merge too many tracksters, eventually building candidates with lot of contamination from PU that are affecting the final jet reconstruction.
- Moving the energy regression at the TICLCandidateProducer level, where the final calorimeter objects are produced after the additional Trackster-Trackster linking through the Track-Trackster linking.
- Remove Track-only candidates building for tracks that have not been linked to any trackster. This change remove possible candidate duplication in case of failure in the Track-Trackster linking step

### Testing
The PR has been tested on CMSSW_15_1_0_pre5. Physics validation has been performed exploiting the HLT Jet Validation. 
To evaluate the effectiveness of the changes, a comparison between Baseline and PR has been performed on a QCD sample in 200 PU, where the energy regression was turned off (as the regression is the other issue that will be fixed in a future PR). 
Below some plots where on the **left you have the Baseline** while on the **right the PR changes** have been applied
### pT Response with energy correction

Distributions after the changes look more healthy

<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/e548a801-7fa7-4e5d-90ad-f3f4b52686ab" />
<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/5e0b63ce-8781-4c7d-97a3-b722ef134f4a" />

### Fake Rate

Major reduction in the jet fake rate in the [1.5,3.0] pseudorapidity region

<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/b7ca53bb-004d-4faa-85a2-1880880cbc9a" />
<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/83839dce-336e-4a23-b664-ce2ab9b6eadc" />

### HGCAL/TICL side

These changes leads to a mild drop in the overall efficiency. Tested on a pion sample in 200PU

<img width="400" height="325" alt="image" src="https://github.com/user-attachments/assets/840e3ff3-a2dd-4f23-bdcd-14a52865460a" />


These changes should be tested on workflow enabling the TICLv5 procModifier:

- 29634.203,29834.203, 29696.203,29896.203


@AuroraPerego @felicepantaleo 

[1] https://indico.cern.ch/event/1578363/contributions/6650118/attachments/3119987/5532471/2025_08_19%20-%20Jet%20Validation%20HLT.pdf