### PR TITLE
Removed workaround for illegal memory access

### DIFF
--- a/RecoTracker/PixelSeeding/plugins/alpaka/BrokenLineFit.dev.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/BrokenLineFit.dev.cc
@@ -7,7 +7,6 @@
 
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsSoA.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/debug.h"
 #include "RecoTracker/PixelSeeding/interface/CAGeometrySoA.h"
 #include "RecoTracker/PixelTrackFitting/interface/alpaka/BrokenLine.h"
 
@@ -177,9 +176,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   double *__restrict__ phits,
                                   float *__restrict__ phits_ge,
                                   double *__restrict__ pfast_fit) const {
-      // workaround for #47808
-      debug::do_not_optimise(results_view);
-
       ALPAKA_ASSERT_ACC(results_view.pt().data());
       ALPAKA_ASSERT_ACC(results_view.eta().data());
       ALPAKA_ASSERT_ACC(results_view.chi2().data());

--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksByDensity.h
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksByDensity.h
@@ -32,9 +32,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
                                                              float errmax,  // max error to be "seed"
                                                              float chi2max  // max normalized distance to cluster
   ) {
-    // workaround for #47808
-    debug::do_not_optimise(ws);
-
     constexpr bool verbose = false;
 
     if constexpr (verbose) {

--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksDBSCAN.h
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksDBSCAN.h
@@ -31,9 +31,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
                                   float errmax,  // max error to be "seed"
                                   float chi2max  // max normalized distance to cluster
     ) const {
-      // workaround for #47808
-      debug::do_not_optimise(ws);
-
       constexpr bool verbose = false;
 
       if constexpr (verbose) {


### PR DESCRIPTION
#### PR description:

This PR removes the workaround introduced in [#47931](https://github.com/cms-sw/cmssw/pull/47931) for the issue in GPU relvals found in [#47808](https://github.com/cms-sw/cmssw/issues/47808).

The problem has been addressed by reverting some changes introduced in [#47306](https://github.com/cms-sw/cmssw/pull/47306). In particular, `size_` has been deleted from `SoAParametersImpl`.

When CUDA 13.1 is released, it will be possible to add `size_` for other purposes, and the bug should be fixed (since a bug report has been opened and closed).

#### PR validation:

Workflows 12834.402 and 29661.402 work.


