### PR TITLE
Fix assertion failure in ProductRegistry merging

### DIFF
--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -250,8 +250,7 @@ namespace edm {
   std::string ProductRegistry::merge(ProductRegistry const& other,
                                      std::string const& fileName,
                                      ProductDescription::MatchMode branchesMustMatch) {
-    if (branchesMustMatch == ProductDescription::FromInputToCurrent) {
-      assert(transient_.processOrder_.size() == 1);
+    if (branchesMustMatch == ProductDescription::FromInputToCurrent and transient_.processOrder_.size() == 1) {
       transient_.processOrder_.insert(
           transient_.processOrder_.end(), other.transient_.processOrder_.begin(), other.transient_.processOrder_.end());
     } else {


### PR DESCRIPTION
#### PR description:

Problem seen in later IB testing where a ProductRegistry was changed.

#### PR validation:

This fixed the problem https://github.com/cms-sw/cmssw/issues/48855 as demonstrated locally by being able to read the first 5 files in the failing job in a simple program that just read those files.

resolves https://github.com/cms-sw/framework-team/issues/1571