### PR TITLE
add `fillDescriptions` to several plugins used at HLT (6/N)

### DIFF
--- a/CalibCalorimetry/HcalPlugins/src/HcalTimeSlewEP.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTimeSlewEP.cc
@@ -47,27 +47,97 @@ void HcalTimeSlewEP::setIntervalFor(const edm::eventsetup::EventSetupRecordKey& 
 }
 
 void HcalTimeSlewEP::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // HcalTimeSlewEP
   edm::ParameterSetDescription desc;
-
-  edm::ParameterSetDescription desc_M2;
-  desc_M2.add<double>("tzero");
-  desc_M2.add<double>("slope");
-  desc_M2.add<double>("tmax");
-  std::vector<edm::ParameterSet> default_M2(1);
-  desc.addVPSet("timeSlewParametersM2", desc_M2, default_M2);
-
-  edm::ParameterSetDescription desc_M3;
-  desc_M3.add<double>("cap");
-  desc_M3.add<double>("tspar0");
-  desc_M3.add<double>("tspar1");
-  desc_M3.add<double>("tspar2");
-  desc_M3.add<double>("tspar0_siPM");
-  desc_M3.add<double>("tspar1_siPM");
-  desc_M3.add<double>("tspar2_siPM");
-  std::vector<edm::ParameterSet> default_M3(1);
-  desc.addVPSet("timeSlewParametersM3", desc_M3, default_M3);
-
-  descriptions.addDefault(desc);
+  desc.add<std::string>("appendToDataLabel", "HBHE");
+  {
+    edm::ParameterSetDescription vpsd1;
+    vpsd1.add<double>("tzero", 23.960177);
+    vpsd1.add<double>("slope", -3.178648);
+    vpsd1.add<double>("tmax", 16.0);
+    std::vector<edm::ParameterSet> temp1;
+    temp1.reserve(3);
+    {
+      edm::ParameterSet temp2;
+      temp2.addParameter<double>("tzero", 23.960177);
+      temp2.addParameter<double>("slope", -3.178648);
+      temp2.addParameter<double>("tmax", 16.0);
+      temp1.push_back(temp2);
+    }
+    {
+      edm::ParameterSet temp2;
+      temp2.addParameter<double>("tzero", 11.977461);
+      temp2.addParameter<double>("slope", -1.5610227);
+      temp2.addParameter<double>("tmax", 10.0);
+      temp1.push_back(temp2);
+    }
+    {
+      edm::ParameterSet temp2;
+      temp2.addParameter<double>("tzero", 9.109694);
+      temp2.addParameter<double>("slope", -1.075824);
+      temp2.addParameter<double>("tmax", 6.25);
+      temp1.push_back(temp2);
+    }
+    desc.addVPSet("timeSlewParametersM2", vpsd1, temp1);
+  }
+  {
+    edm::ParameterSetDescription vpsd1;
+    vpsd1.add<double>("cap", 6.0);
+    vpsd1.add<double>("tspar0", 12.2999);
+    vpsd1.add<double>("tspar1", -2.19142);
+    vpsd1.add<double>("tspar2", 0.0);
+    vpsd1.add<double>("tspar0_siPM", 0.0);
+    vpsd1.add<double>("tspar1_siPM", 0.0);
+    vpsd1.add<double>("tspar2_siPM", 0.0);
+    std::vector<edm::ParameterSet> temp1;
+    temp1.reserve(4);
+    {
+      edm::ParameterSet temp2;
+      temp2.addParameter<double>("cap", 6.0);
+      temp2.addParameter<double>("tspar0", 12.2999);
+      temp2.addParameter<double>("tspar1", -2.19142);
+      temp2.addParameter<double>("tspar2", 0.0);
+      temp2.addParameter<double>("tspar0_siPM", 0.0);
+      temp2.addParameter<double>("tspar1_siPM", 0.0);
+      temp2.addParameter<double>("tspar2_siPM", 0.0);
+      temp1.push_back(temp2);
+    }
+    {
+      edm::ParameterSet temp2;
+      temp2.addParameter<double>("cap", 6.0);
+      temp2.addParameter<double>("tspar0", 15.5);
+      temp2.addParameter<double>("tspar1", -3.2);
+      temp2.addParameter<double>("tspar2", 32.0);
+      temp2.addParameter<double>("tspar0_siPM", 0.0);
+      temp2.addParameter<double>("tspar1_siPM", 0.0);
+      temp2.addParameter<double>("tspar2_siPM", 0.0);
+      temp1.push_back(temp2);
+    }
+    {
+      edm::ParameterSet temp2;
+      temp2.addParameter<double>("cap", 6.0);
+      temp2.addParameter<double>("tspar0", 12.2999);
+      temp2.addParameter<double>("tspar1", -2.19142);
+      temp2.addParameter<double>("tspar2", 0.0);
+      temp2.addParameter<double>("tspar0_siPM", 0.0);
+      temp2.addParameter<double>("tspar1_siPM", 0.0);
+      temp2.addParameter<double>("tspar2_siPM", 0.0);
+      temp1.push_back(temp2);
+    }
+    {
+      edm::ParameterSet temp2;
+      temp2.addParameter<double>("cap", 6.0);
+      temp2.addParameter<double>("tspar0", 12.2999);
+      temp2.addParameter<double>("tspar1", -2.19142);
+      temp2.addParameter<double>("tspar2", 0.0);
+      temp2.addParameter<double>("tspar0_siPM", 0.0);
+      temp2.addParameter<double>("tspar1_siPM", 0.0);
+      temp2.addParameter<double>("tspar2_siPM", 0.0);
+      temp1.push_back(temp2);
+    }
+    desc.addVPSet("timeSlewParametersM3", vpsd1, temp1);
+  }
+  descriptions.addWithDefaultLabel(desc);
 }
 
 // ------------ method called to produce the data  ------------

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelTemplateDBObjectESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelTemplateDBObjectESProducer.cc
@@ -17,16 +17,16 @@
 
 #include <memory>
 
+#include "CalibTracker/Records/interface/SiPixelTemplateDBObjectESProducerRcd.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelTemplateDBObject.h"
 #include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/ESProductTag.h"
 #include "FWCore/Utilities/interface/do_nothing_deleter.h"
-
-#include "FWCore/Framework/interface/ModuleFactory.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
-
-#include "CondFormats/SiPixelObjects/interface/SiPixelTemplateDBObject.h"
-#include "CalibTracker/Records/interface/SiPixelTemplateDBObjectESProducerRcd.h"
 
 using namespace edm;
 
@@ -34,6 +34,7 @@ class SiPixelTemplateDBObjectESProducer : public edm::ESProducer {
 public:
   SiPixelTemplateDBObjectESProducer(const edm::ParameterSet& iConfig);
   std::shared_ptr<const SiPixelTemplateDBObject> produce(const SiPixelTemplateDBObjectESProducerRcd&);
+  static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
 private:
   edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfieldToken_;
@@ -71,6 +72,11 @@ std::shared_ptr<const SiPixelTemplateDBObject> SiPixelTemplateDBObjectESProducer
         << "Magnetic field is " << theMagField << " Template Magnetic field is " << dbobject.sVector()[22];
 
   return std::shared_ptr<const SiPixelTemplateDBObject>(&dbobject, edm::do_nothing_deleter());
+}
+
+void SiPixelTemplateDBObjectESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  descriptions.addWithDefaultLabel(desc);
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(SiPixelTemplateDBObjectESProducer);

--- a/Geometry/CaloEventSetup/plugins/CaloTopologyBuilder.cc
+++ b/Geometry/CaloEventSetup/plugins/CaloTopologyBuilder.cc
@@ -4,6 +4,8 @@
 #include "Geometry/CaloTopology/interface/EcalEndcapTopology.h"
 #include "Geometry/CaloTopology/interface/EcalPreshowerTopology.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 CaloTopologyBuilder::CaloTopologyBuilder(const edm::ParameterSet& /*iConfig*/)
     : geometryToken_{setWhatProduced(this, &CaloTopologyBuilder::produceCalo)
@@ -25,4 +27,9 @@ CaloTopologyBuilder::ReturnType CaloTopologyBuilder::produceCalo(const CaloTopol
   ct->setSubdetTopology(DetId::Ecal, EcalEndcap, std::make_unique<EcalEndcapTopology>(geometry));
   ct->setSubdetTopology(DetId::Ecal, EcalPreshower, std::make_unique<EcalPreshowerTopology>());
   return ct;
+}
+
+void CaloTopologyBuilder::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  descriptions.addWithDefaultLabel(desc);
 }

--- a/Geometry/CaloEventSetup/plugins/CaloTopologyBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/CaloTopologyBuilder.h
@@ -40,6 +40,8 @@ public:
 
   ReturnType produceCalo(const CaloTopologyRecord&);
 
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
 private:
   // ----------member data ---------------------------
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
@@ -488,5 +488,5 @@ void CaloTowersCreator::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.add<int>("HcalPhase", 0);
   desc.add<bool>("usePFThresholdsFromDB", true);
   desc.add<bool>("EcalRecHitThresh", false);
-  descriptions.addDefault(desc);
+  descriptions.addWithDefaultLabel(desc);
 }

--- a/RecoLocalCalo/EcalRecProducers/plugins/ESRecHitProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/ESRecHitProducer.cc
@@ -8,7 +8,9 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "RecoLocalCalo/EcalRecProducers/interface/ESRecHitWorkerFactory.h"
 
 #include "ESRecHitWorker.h"
@@ -17,6 +19,8 @@ class ESRecHitProducer : public edm::stream::EDProducer<> {
 public:
   explicit ESRecHitProducer(const edm::ParameterSet& ps);
   void produce(edm::Event& e, const edm::EventSetup& es) override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   const edm::EDGetTokenT<ESDigiCollection> digiToken_;
@@ -55,6 +59,15 @@ void ESRecHitProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   }
 
   e.put(std::move(rec), rechitCollection_);
+}
+
+void ESRecHitProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("ESrechitCollection", "EcalRecHitsES");
+  desc.add<edm::InputTag>("ESdigiCollection", edm::InputTag("ecalPreshowerDigis"));
+  desc.add<std::string>("algo", "ESRecHitWorker");
+  desc.add<int>("ESRecoAlgo", 0);
+  descriptions.addWithDefaultLabel(desc);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc
+++ b/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc
@@ -1,29 +1,25 @@
-#include "FWCore/Framework/interface/ESProducer.h"
-#include "FWCore/Utilities/interface/ESGetToken.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
 #include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
-
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
+#include "CondFormats/DataRecord/interface/HcalRecoParamsRcd.h"
+#include "CondFormats/HcalObjects/interface/HcalPFCuts.h"
+#include "CondFormats/HcalObjects/interface/HcalRecoParams.h"
 #include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
-
-#include "CondFormats/HcalObjects/interface/HcalRecoParams.h"
-#include "CondFormats/DataRecord/interface/HcalRecoParamsRcd.h"
-
-#include "CondFormats/HcalObjects/interface/HcalPFCuts.h"
-#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
-
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
-
-#include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputer.h"
-#include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputerRcd.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalChannelProperties.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesAuxRecord.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesRecord.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputer.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputerRcd.h"
 
 class HcalChannelPropertiesEP : public edm::ESProducer {
 public:
@@ -51,6 +47,11 @@ public:
   }
 
   inline ~HcalChannelPropertiesEP() override {}
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    descriptions.addWithDefaultLabel(desc);
+  }
 
   ReturnType1 produce1(const HcalChannelPropertiesAuxRecord& rcd) {
     const HcalTopology& htopo = rcd.get(topoToken_);

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
@@ -210,7 +210,7 @@ namespace {
         psdigi.getParameter<double>("nominalPedestal"),
         psdigi.getParameter<double>("hitEnergyMinimum"),
         psdigi.getParameter<int>("hitMultiplicityThreshold"),
-        psdigi.getParameter<std::vector<edm::ParameterSet> >("pulseShapeParameterSets"));
+        psdigi.getParameter<std::vector<edm::ParameterSet>>("pulseShapeParameterSets"));
   }
 
   std::unique_ptr<HBHEPulseShapeFlagSetter> parse_HBHEPulseShapeFlagSetter(const edm::ParameterSet& psPulseShape,
@@ -225,20 +225,20 @@ namespace {
         psPulseShape.getParameter<double>("R45PlusOneRange"),
         psPulseShape.getParameter<double>("R45MinusOneRange"),
         psPulseShape.getParameter<unsigned int>("TrianglePeakTS"),
-        psPulseShape.getParameter<std::vector<double> >("LinearThreshold"),
-        psPulseShape.getParameter<std::vector<double> >("LinearCut"),
-        psPulseShape.getParameter<std::vector<double> >("RMS8MaxThreshold"),
-        psPulseShape.getParameter<std::vector<double> >("RMS8MaxCut"),
-        psPulseShape.getParameter<std::vector<double> >("LeftSlopeThreshold"),
-        psPulseShape.getParameter<std::vector<double> >("LeftSlopeCut"),
-        psPulseShape.getParameter<std::vector<double> >("RightSlopeThreshold"),
-        psPulseShape.getParameter<std::vector<double> >("RightSlopeCut"),
-        psPulseShape.getParameter<std::vector<double> >("RightSlopeSmallThreshold"),
-        psPulseShape.getParameter<std::vector<double> >("RightSlopeSmallCut"),
-        psPulseShape.getParameter<std::vector<double> >("TS4TS5LowerThreshold"),
-        psPulseShape.getParameter<std::vector<double> >("TS4TS5LowerCut"),
-        psPulseShape.getParameter<std::vector<double> >("TS4TS5UpperThreshold"),
-        psPulseShape.getParameter<std::vector<double> >("TS4TS5UpperCut"),
+        psPulseShape.getParameter<std::vector<double>>("LinearThreshold"),
+        psPulseShape.getParameter<std::vector<double>>("LinearCut"),
+        psPulseShape.getParameter<std::vector<double>>("RMS8MaxThreshold"),
+        psPulseShape.getParameter<std::vector<double>>("RMS8MaxCut"),
+        psPulseShape.getParameter<std::vector<double>>("LeftSlopeThreshold"),
+        psPulseShape.getParameter<std::vector<double>>("LeftSlopeCut"),
+        psPulseShape.getParameter<std::vector<double>>("RightSlopeThreshold"),
+        psPulseShape.getParameter<std::vector<double>>("RightSlopeCut"),
+        psPulseShape.getParameter<std::vector<double>>("RightSlopeSmallThreshold"),
+        psPulseShape.getParameter<std::vector<double>>("RightSlopeSmallCut"),
+        psPulseShape.getParameter<std::vector<double>>("TS4TS5LowerThreshold"),
+        psPulseShape.getParameter<std::vector<double>>("TS4TS5LowerCut"),
+        psPulseShape.getParameter<std::vector<double>>("TS4TS5UpperThreshold"),
+        psPulseShape.getParameter<std::vector<double>>("TS4TS5UpperCut"),
         psPulseShape.getParameter<bool>("UseDualFit"),
         psPulseShape.getParameter<bool>("TriangleIgnoreSlow"),
         setLegacyFlags);
@@ -761,46 +761,287 @@ void HBHEPhase1Reconstructor::beginRun(edm::Run const& r, edm::EventSetup const&
 
 void HBHEPhase1Reconstructor::endRun(edm::Run const&, edm::EventSetup const&) { reco_->endRun(); }
 
-#define add_param_set(name) /**/     \
-  edm::ParameterSetDescription name; \
-  name.setAllowAnything();           \
-  desc.add<edm::ParameterSetDescription>(#name, name)
-
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void HBHEPhase1Reconstructor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // hbheprereco
   edm::ParameterSetDescription desc;
-
-  desc.add<edm::InputTag>("digiLabelQIE8");
-  desc.add<edm::InputTag>("digiLabelQIE11");
-  desc.add<std::string>("algoConfigClass");
-  desc.add<bool>("processQIE8");
-  desc.add<bool>("processQIE11");
-  desc.add<bool>("saveInfos");
-  desc.add<bool>("saveDroppedInfos");
-  desc.add<bool>("makeRecHits");
-  desc.add<bool>("dropZSmarkedPassed");
-  desc.add<bool>("tsFromDB");
-  desc.add<bool>("recoParamsFromDB");
+  desc.add<edm::InputTag>("digiLabelQIE8", edm::InputTag("hcalDigis"));
+  desc.add<bool>("processQIE8", true);
+  desc.add<edm::InputTag>("digiLabelQIE11", edm::InputTag("hcalDigis"));
+  desc.add<bool>("processQIE11", true);
+  desc.add<bool>("tsFromDB", false);
+  desc.add<bool>("recoParamsFromDB", true);
   desc.add<bool>("saveEffectivePedestal", false);
-  desc.add<bool>("use8ts", false);
+  desc.add<bool>("dropZSmarkedPassed", true);
+  desc.add<bool>("makeRecHits", true);
+  desc.add<bool>("saveInfos", false);
+  desc.add<bool>("saveDroppedInfos", false);
+  desc.add<bool>("use8ts", true);
   desc.add<int>("sipmQTSShift", 0);
   desc.add<int>("sipmQNTStoSum", 3);
-  desc.add<bool>("setNegativeFlagsQIE8");
-  desc.add<bool>("setNegativeFlagsQIE11");
-  desc.add<bool>("setNoiseFlagsQIE8");
-  desc.add<bool>("setNoiseFlagsQIE11");
-  desc.add<bool>("setPulseShapeFlagsQIE8");
-  desc.add<bool>("setPulseShapeFlagsQIE11");
-  desc.add<bool>("setLegacyFlagsQIE8");
-  desc.add<bool>("setLegacyFlagsQIE11");
-
-  desc.add<edm::ParameterSetDescription>("algorithm", fillDescriptionForParseHBHEPhase1Algo());
-  add_param_set(flagParametersQIE8);
-  add_param_set(flagParametersQIE11);
-  add_param_set(pulseShapeParametersQIE8);
-  add_param_set(pulseShapeParametersQIE11);
-
-  descriptions.addDefault(desc);
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<bool>("applyTimeSlewM3", true);
+    psd0.add<int>("timeSlewParsType", 3);
+    psd0.add<double>("respCorrM3", 1.0);
+    psd0.add<bool>("applyPedConstraint", true);
+    psd0.add<bool>("applyTimeConstraint", true);
+    psd0.add<bool>("applyPulseJitter", false);
+    psd0.add<bool>("applyTimeSlew", true);
+    psd0.add<double>("ts4Min", 0.0);
+    psd0.add<std::vector<double>>("ts4Max",
+                                  {
+                                      100.0,
+                                      20000.0,
+                                      30000,
+                                  });
+    psd0.add<double>("pulseJitter", 1.0);
+    psd0.add<double>("meanPed", 0.0);
+    psd0.add<double>("meanTime", 0.0);
+    psd0.add<double>("timeSigmaHPD", 5.0);
+    psd0.add<double>("timeSigmaSiPM", 2.5);
+    psd0.add<double>("timeMin", -12.5);
+    psd0.add<double>("timeMax", 12.5);
+    psd0.add<std::vector<double>>("ts4chi2",
+                                  {
+                                      15.0,
+                                      15.0,
+                                  });
+    psd0.add<int>("fitTimes", 1);
+    psd0.add<int>("firstSampleShift", 0);
+    psd0.add<int>("samplesToAdd", 2);
+    psd0.add<bool>("correctForPhaseContainment", true);
+    psd0.add<double>("correctionPhaseNS", 6.0);
+    psd0.add<bool>("applyFixPCC", false);
+    psd0.add<bool>("calculateArrivalTime", true);
+    psd0.add<int>("timeAlgo", 2);
+    psd0.add<double>("thEnergeticPulses", 5.0);
+    psd0.add<bool>("dynamicPed", false);
+    psd0.add<double>("ts4Thresh", 0.0);
+    psd0.add<double>("chiSqSwitch", 15.0);
+    psd0.add<std::vector<int>>("activeBXs",
+                               {
+                                   -3,
+                                   -2,
+                                   -1,
+                                   0,
+                                   1,
+                                   2,
+                                   3,
+                                   4,
+                               });
+    psd0.add<int>("nMaxItersMin", 500);
+    psd0.add<int>("nMaxItersNNLS", 500);
+    psd0.add<double>("deltaChiSqThresh", 0.001);
+    psd0.add<double>("nnlsThresh", 1e-11);
+    psd0.add<std::string>("Class", "SimpleHBHEPhase1Algo");
+    psd0.add<double>("tdcTimeShift", 0.0);
+    psd0.add<bool>("useM2", false);
+    psd0.add<bool>("useM3", true);
+    psd0.add<bool>("useMahi", true);
+    psd0.add<bool>("applyLegacyHBMCorrection", true);
+    desc.add<edm::ParameterSetDescription>("algorithm", psd0);
+  }
+  desc.add<std::string>("algoConfigClass", "");
+  desc.add<bool>("setNegativeFlagsQIE8", true);
+  desc.add<bool>("setNegativeFlagsQIE11", false);
+  desc.add<bool>("setNoiseFlagsQIE8", true);
+  desc.add<bool>("setNoiseFlagsQIE11", false);
+  desc.add<bool>("setPulseShapeFlagsQIE8", true);
+  desc.add<bool>("setPulseShapeFlagsQIE11", false);
+  desc.add<bool>("setLegacyFlagsQIE8", true);
+  desc.add<bool>("setLegacyFlagsQIE11", false);
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<double>("nominalPedestal", 3.0);
+    psd0.add<double>("hitEnergyMinimum", 1.0);
+    psd0.add<int>("hitMultiplicityThreshold", 17);
+    {
+      edm::ParameterSetDescription vpsd2;
+      vpsd2.add<std::vector<double>>("pulseShapeParameters",
+                                     {
+                                         0.0,
+                                         100.0,
+                                         -50.0,
+                                         0.0,
+                                         -15.0,
+                                         0.15,
+                                     });
+      std::vector<edm::ParameterSet> temp2;
+      temp2.reserve(4);
+      {
+        edm::ParameterSet temp3;
+        temp3.addParameter<std::vector<double>>("pulseShapeParameters",
+                                                {
+                                                    0.0,
+                                                    100.0,
+                                                    -50.0,
+                                                    0.0,
+                                                    -15.0,
+                                                    0.15,
+                                                });
+        temp2.push_back(temp3);
+      }
+      {
+        edm::ParameterSet temp3;
+        temp3.addParameter<std::vector<double>>("pulseShapeParameters",
+                                                {
+                                                    100.0,
+                                                    2000.0,
+                                                    -50.0,
+                                                    0.0,
+                                                    -5.0,
+                                                    0.05,
+                                                });
+        temp2.push_back(temp3);
+      }
+      {
+        edm::ParameterSet temp3;
+        temp3.addParameter<std::vector<double>>("pulseShapeParameters",
+                                                {
+                                                    2000.0,
+                                                    1000000.0,
+                                                    -50.0,
+                                                    0.0,
+                                                    95.0,
+                                                    0.0,
+                                                });
+        temp2.push_back(temp3);
+      }
+      {
+        edm::ParameterSet temp3;
+        temp3.addParameter<std::vector<double>>("pulseShapeParameters",
+                                                {
+                                                    -1000000.0,
+                                                    1000000.0,
+                                                    45.0,
+                                                    0.1,
+                                                    1000000.0,
+                                                    0.0,
+                                                });
+        temp2.push_back(temp3);
+      }
+      psd0.addVPSet("pulseShapeParameterSets", vpsd2, temp2);
+    }
+    desc.add<edm::ParameterSetDescription>("flagParametersQIE8", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    desc.add<edm::ParameterSetDescription>("flagParametersQIE11", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<double>("MinimumChargeThreshold", 20);
+    psd0.add<double>("TS4TS5ChargeThreshold", 70);
+    psd0.add<double>("TS3TS4ChargeThreshold", 70);
+    psd0.add<double>("TS3TS4UpperChargeThreshold", 20);
+    psd0.add<double>("TS5TS6ChargeThreshold", 70);
+    psd0.add<double>("TS5TS6UpperChargeThreshold", 20);
+    psd0.add<double>("R45PlusOneRange", 0.2);
+    psd0.add<double>("R45MinusOneRange", 0.2);
+    psd0.add<unsigned int>("TrianglePeakTS", 10000);
+    psd0.add<std::vector<double>>("LinearThreshold",
+                                  {
+                                      20,
+                                      100,
+                                      100000,
+                                  });
+    psd0.add<std::vector<double>>("LinearCut",
+                                  {
+                                      -3,
+                                      -0.054,
+                                      -0.054,
+                                  });
+    psd0.add<std::vector<double>>("RMS8MaxThreshold",
+                                  {
+                                      20,
+                                      100,
+                                      100000,
+                                  });
+    psd0.add<std::vector<double>>("RMS8MaxCut",
+                                  {
+                                      -13.5,
+                                      -11.5,
+                                      -11.5,
+                                  });
+    psd0.add<std::vector<double>>("LeftSlopeThreshold",
+                                  {
+                                      250,
+                                      500,
+                                      100000,
+                                  });
+    psd0.add<std::vector<double>>("LeftSlopeCut",
+                                  {
+                                      5,
+                                      2.55,
+                                      2.55,
+                                  });
+    psd0.add<std::vector<double>>("RightSlopeThreshold",
+                                  {
+                                      250,
+                                      400,
+                                      100000,
+                                  });
+    psd0.add<std::vector<double>>("RightSlopeCut",
+                                  {
+                                      5,
+                                      4.15,
+                                      4.15,
+                                  });
+    psd0.add<std::vector<double>>("RightSlopeSmallThreshold",
+                                  {
+                                      150,
+                                      200,
+                                      100000,
+                                  });
+    psd0.add<std::vector<double>>("RightSlopeSmallCut",
+                                  {
+                                      1.08,
+                                      1.16,
+                                      1.16,
+                                  });
+    psd0.add<double>("MinimumTS4TS5Threshold", 100);
+    psd0.add<std::vector<double>>("TS4TS5UpperThreshold",
+                                  {
+                                      70,
+                                      90,
+                                      100,
+                                      400,
+                                  });
+    psd0.add<std::vector<double>>("TS4TS5UpperCut",
+                                  {
+                                      1,
+                                      0.8,
+                                      0.75,
+                                      0.72,
+                                  });
+    psd0.add<std::vector<double>>("TS4TS5LowerThreshold",
+                                  {
+                                      100,
+                                      120,
+                                      160,
+                                      200,
+                                      300,
+                                      500,
+                                  });
+    psd0.add<std::vector<double>>("TS4TS5LowerCut",
+                                  {
+                                      -1,
+                                      -0.7,
+                                      -0.5,
+                                      -0.4,
+                                      -0.3,
+                                      0.1,
+                                  });
+    psd0.add<bool>("UseDualFit", true);
+    psd0.add<bool>("TriangleIgnoreSlow", false);
+    desc.add<edm::ParameterSetDescription>("pulseShapeParametersQIE8", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    desc.add<edm::ParameterSetDescription>("pulseShapeParametersQIE11", psd0);
+  }
+  descriptions.addWithDefaultLabel(desc);
 }
 
 //define this as a plug-in

--- a/RecoLocalMuon/RPCRecHit/plugins/RPCRecHitProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/plugins/RPCRecHitProducer.cc
@@ -5,14 +5,14 @@
 
 #include "RPCRecHitProducer.h"
 
-#include "Geometry/RPCGeometry/interface/RPCRoll.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
-
-#include "RPCRecHitAlgoFactory.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
-
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "Geometry/RPCGeometry/interface/RPCRoll.h"
+#include "RPCRecHitAlgoFactory.h"
 
 #include <string>
 #include <fstream>
@@ -159,4 +159,19 @@ void RPCRecHitProducer::produce(Event& event, const EventSetup& setup) {
   }
 
   event.put(std::move(recHitCollection));
+}
+
+void RPCRecHitProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  {
+    edm::ParameterSetDescription psd0;
+    desc.add<edm::ParameterSetDescription>("recAlgoConfig", psd0);
+  }
+  desc.add<std::string>("recAlgo", "RPCRecHitStandardAlgo");
+  desc.add<edm::InputTag>("rpcDigiLabel", edm::InputTag("muonRPCDigis"));
+  desc.add<std::string>("maskSource", "File");
+  desc.add<edm::FileInPath>("maskvecfile", edm::FileInPath("RecoLocalMuon/RPCRecHit/data/RPCMaskVec.dat"));
+  desc.add<std::string>("deadSource", "File");
+  desc.add<edm::FileInPath>("deadvecfile", edm::FileInPath("RecoLocalMuon/RPCRecHit/data/RPCDeadVec.dat"));
+  descriptions.addWithDefaultLabel(desc);
 }

--- a/RecoLocalMuon/RPCRecHit/plugins/RPCRecHitProducer.h
+++ b/RecoLocalMuon/RPCRecHit/plugins/RPCRecHitProducer.h
@@ -26,13 +26,16 @@ public:
   RPCRecHitProducer(const edm::ParameterSet& config);
 
   /// Destructor
-  ~RPCRecHitProducer() override {}
+  ~RPCRecHitProducer() override = default;
 
   // Method that access the EventSetup for each run
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
 
   /// The method which produces the rechits
   void produce(edm::Event& event, const edm::EventSetup& setup) override;
+
+  /// fillDescriptions
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   // The label to be used to retrieve RPC digis from the event

--- a/TrackingTools/MaterialEffects/plugins/PropagatorWithMaterialESProducer.cc
+++ b/TrackingTools/MaterialEffects/plugins/PropagatorWithMaterialESProducer.cc
@@ -1,11 +1,11 @@
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/ParameterSet/interface/allowedValues.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
 #include "PropagatorWithMaterialESProducer.h"
 #include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
-
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/ModuleFactory.h"
-#include "FWCore/Framework/interface/ESProducer.h"
-#include "FWCore/Utilities/interface/ESInputTag.h"
 
 #include <string>
 #include <memory>
@@ -48,13 +48,14 @@ std::unique_ptr<Propagator> PropagatorWithMaterialESProducer::produce(const Trac
 
 void PropagatorWithMaterialESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   ParameterSetDescription desc;
-  desc.add<std::string>("PropagationDirection");
+  desc.ifValue(edm::ParameterDescription<std::string>("PropagationDirection", "alongMomentum", true),
+               edm::allowedValues<std::string>("oppositeToMomentum", "alongMomentum", "anyDirection"));
   desc.add<std::string>("SimpleMagneticField", "");
-  desc.add<std::string>("ComponentName");
-  desc.add<double>("Mass");
-  desc.add<double>("MaxDPhi");
-  desc.add<bool>("useRungeKutta");
+  desc.add<std::string>("ComponentName", "");
+  desc.add<double>("Mass", 0.);
+  desc.add<double>("MaxDPhi", 0.);
+  desc.add<bool>("useRungeKutta", false);
   desc.add<bool>("useOldAnalPropLogic", true);
   desc.add<double>("ptMin", -1.0);
-  descriptions.addDefault(desc);
+  descriptions.addWithDefaultLabel(desc);
 }


### PR DESCRIPTION
#### PR description:


This PR is similar in spirit to https://github.com/cms-sw/cmssw/pull/47017, https://github.com/cms-sw/cmssw/pull/47045, https://github.com/cms-sw/cmssw/pull/47079, https://github.com/cms-sw/cmssw/pull/47107, https://github.com/cms-sw/cmssw/pull/47136, https://github.com/cms-sw/cmssw/pull/47191 and https://github.com/cms-sw/cmssw/pull/47224, towards solving issue https://github.com/cms-sw/cmssw/issues/47275.  
It adds `fillDescriptions` (and applies light modification to modernize the source code) to a few `EDProducer`s used at HLT for both Run 3 and Phase 2. 

#### PR validation:

   * `addOnTests.py` runs fine. 
   * `hltPhase2UpgradeIntegrationTests` runs fine. 
   * `runTheMatrix.py -l limited` runs fine.


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A