### PR TITLE
btvNano: fix link between GenCands and decayed hadrons

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/GenCandMotherTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenCandMotherTableProducer.cc
@@ -42,10 +42,19 @@ public:
       reco::GenParticleRef motherRef = cands->at(i).motherRef();
       reco::GenParticleRef match = (*map)[motherRef];
 
-      if (match.isNull())
-        continue;
+      if (match.isNonnull())
+        key[i] = match.key();
+      else {
+        key[i] = -1;
+        // try to find the closest mother which is in the map
+        while (match.isNull() && motherRef.isNonnull()) {
+          motherRef = motherRef->motherRef();
+          match = (*map)[motherRef];
+          if (match.isNonnull())
+            key[i] = match.key();
+        }
+      }
 
-      key[i] = match.key();
       fromB[i] = isFromB(cands->at(i));
       fromC[i] = isFromC(cands->at(i));
     }


### PR DESCRIPTION
#### PR description:

- Fix erroneous `continue` that prevented GenCands `isFromB/C` information to be calculated
- Traverse mother link until we find a hadron that exists in the finalGenParticles collection

#### PR validation:

Before:
- On average 5.92+/-0.25 charged GenCands from two B hadron decays per event

After
- On average 10.29+/-0.42 charged GenCands, in agreement with [CLEO measurement](https://arxiv.org/abs/hep-ex/9907057) (10.7+/-0.2)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Need backport to 15_0_X for btvNanoV15 production
