### PR TITLE
[BackPort CMSSW_15_0_X] Include scouting EGM in Online DQM stream 

### DIFF
--- a/DQM/HLTEvF/python/ScoutingElectronMonitoring_cff.py
+++ b/DQM/HLTEvF/python/ScoutingElectronMonitoring_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+from HLTriggerOffline.Scouting.ScoutingEGammaCollectionMonitoring_cfi import *
+from HLTriggerOffline.Scouting.ScoutingElectronTagProbeAnalyzer_cfi import *
+
+ScoutingElectronMonitoring = cms.Sequence(scoutingMonitoringEGMOnline + scoutingMonitoringTagProbeOnline)

--- a/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
@@ -52,7 +52,7 @@ process.dqmcommon = cms.Sequence(process.dqmEnv
 
 process.load("DQM.HLTEvF.ScoutingMuonMonitoring_cff")
 process.load("DQM.HLTEvF.ScoutingJetMonitoring_cff")
-
+process.load("DQM.HLTEvF.ScoutingElectronMonitoring_cff")
 ## Run-1 L1TGT required by ScoutingJetMonitoring https://github.com/cms-sw/cmssw/blob/master/DQMOffline/JetMET/src/JetAnalyzer.cc#L2603-L2611
 process.GlobalTag.toGet.append(
  cms.PSet(
@@ -61,7 +61,7 @@ process.GlobalTag.toGet.append(
  )
 )
 
-process.p = cms.Path(process.dqmcommon * process.scoutingCollectionMonitor * process.ScoutingMuonMonitoring * process.ScoutingJetMonitoring)
+process.p = cms.Path(process.dqmcommon * process.scoutingCollectionMonitor * process.ScoutingMuonMonitoring * process.ScoutingJetMonitoring * process.ScoutingElectronMonitoring)
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *

--- a/HLTriggerOffline/Scouting/python/HLTScoutingEGammaDqmOffline_cff.py
+++ b/HLTriggerOffline/Scouting/python/HLTScoutingEGammaDqmOffline_cff.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-from HLTriggerOffline.Scouting. ScoutingEGammaCollectionMonitoring_cfi import *
+from HLTriggerOffline.Scouting.ScoutingEGammaCollectionMonitoring_cfi import *
 from HLTriggerOffline.Scouting.ScoutingElectronTagProbeAnalyzer_cfi import *
 from HLTriggerOffline.Scouting.PatElectronTagProbeAnalyzer_cfi import *
 
@@ -19,4 +19,4 @@ for id_module_name in my_id_modules:
         if hasattr(item,'idName') and hasattr(item,'cutFlow'):
             setupVIDSelection(egmGsfElectronIDsForScoutingDQM,item)
 
-hltScoutingEGammaDqmOffline = cms.Sequence(egmGsfElectronIDsForScoutingDQM + scoutingMonitoringEGM + scoutingMonitoringTagProbe + scoutingMonitoringPatElectronTagProbe)
+hltScoutingEGammaDqmOffline = cms.Sequence(egmGsfElectronIDsForScoutingDQM + scoutingMonitoringEGMOffline + scoutingMonitoringTagProbeOffline + scoutingMonitoringPatElectronTagProbe)

--- a/HLTriggerOffline/Scouting/python/ScoutingEGammaCollectionMonitoring_cfi.py
+++ b/HLTriggerOffline/Scouting/python/ScoutingEGammaCollectionMonitoring_cfi.py
@@ -55,8 +55,8 @@ ScoutingEGammaCollectionMonitoringOffline = DQMEDAnalyzer('ScoutingEGammaCollect
                                                    )
 
 ScoutingEGammaCollectionMonitoringOnline = ScoutingEGammaCollectionMonitoringOffline.clone(
-                                                   OutputInternalPath = cms.string('/HLT/ScoutingOnline/EGamma/Collection'),
-                                                   useOfflineObject = cms.bool(False)
+                                                   OutputInternalPath = '/HLT/ScoutingOnline/EGamma/Collection',
+                                                   useOfflineObject = False
                                                    )
 
 scoutingMonitoringEGMOffline= cms.Sequence(ScoutingEGammaCollectionMonitoringOffline)

--- a/HLTriggerOffline/Scouting/python/ScoutingEGammaCollectionMonitoring_cfi.py
+++ b/HLTriggerOffline/Scouting/python/ScoutingEGammaCollectionMonitoring_cfi.py
@@ -39,7 +39,7 @@ SinglePhotonL1 = [
   'L1_SingleIsoEG34er2p5'
 ]
 
-ScoutingEGammaCollectionMonitoring = DQMEDAnalyzer('ScoutingEGammaCollectionMonitoring',
+ScoutingEGammaCollectionMonitoringOffline = DQMEDAnalyzer('ScoutingEGammaCollectionMonitoring',
                                                    OutputInternalPath = cms.string('/HLT/ScoutingOffline/EGamma/Collection'),
                                                    TriggerResultTag   = cms.InputTag("TriggerResults", "", "HLT"),
                                                    AlgInputTag  = cms.InputTag("gtStage2Digis"),
@@ -50,7 +50,14 @@ ScoutingEGammaCollectionMonitoring = DQMEDAnalyzer('ScoutingEGammaCollectionMoni
                                                    L1Seeds            = cms.vstring(DoubleEGL1 + SinglePhotonL1),
                                                    ElectronCollection = cms.InputTag('slimmedElectrons'),
                                                    ScoutingElectronCollection = cms.InputTag("hltScoutingEgammaPacker"),
-                                                   eleIdMapTight = cms.InputTag('egmGsfElectronIDsForScoutingDQM:cutBasedElectronID-RunIIIWinter22-V1-loose')
+                                                   eleIdMapTight = cms.InputTag('egmGsfElectronIDsForScoutingDQM:cutBasedElectronID-RunIIIWinter22-V1-loose'),
+                                                   useOfflineObject  = cms.bool(True)
                                                    )
 
-scoutingMonitoringEGM = cms.Sequence(ScoutingEGammaCollectionMonitoring)
+ScoutingEGammaCollectionMonitoringOnline = ScoutingEGammaCollectionMonitoringOffline.clone(
+                                                   OutputInternalPath = cms.string('/HLT/ScoutingOnline/EGamma/Collection'),
+                                                   useOfflineObject = cms.bool(False)
+                                                   )
+
+scoutingMonitoringEGMOffline= cms.Sequence(ScoutingEGammaCollectionMonitoringOffline)
+scoutingMonitoringEGMOnline= cms.Sequence(ScoutingEGammaCollectionMonitoringOnline)

--- a/HLTriggerOffline/Scouting/python/ScoutingElectronTagProbeAnalyzer_cfi.py
+++ b/HLTriggerOffline/Scouting/python/ScoutingElectronTagProbeAnalyzer_cfi.py
@@ -14,8 +14,8 @@ ScoutingElectronTagProbeAnalysisOffline = DQMEDAnalyzer('ScoutingElectronTagProb
                                                  )
 
 ScoutingElectronTagProbeAnalysisOnline = ScoutingElectronTagProbeAnalysisOffline.clone(
-                                                 OutputInternalPath = cms.string('/HLT/ScoutingOnline/EGamma/TnP/Tag_ScoutingElectron'),
-                                                 useOfflineObject = cms.bool(False)
+                                                 OutputInternalPath = '/HLT/ScoutingOnline/EGamma/TnP/Tag_ScoutingElectron',
+                                                 useOfflineObject = False
                                                  )
 
 scoutingMonitoringTagProbeOffline = cms.Sequence(ScoutingElectronTagProbeAnalysisOffline)

--- a/HLTriggerOffline/Scouting/python/ScoutingElectronTagProbeAnalyzer_cfi.py
+++ b/HLTriggerOffline/Scouting/python/ScoutingElectronTagProbeAnalyzer_cfi.py
@@ -2,15 +2,21 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
-ScoutingElectronTagProbeAnalysis = DQMEDAnalyzer('ScoutingElectronTagProbeAnalyzer',
+ScoutingElectronTagProbeAnalysisOffline = DQMEDAnalyzer('ScoutingElectronTagProbeAnalyzer',
                                                  OutputInternalPath = cms.string('/HLT/ScoutingOffline/EGamma/TnP/Tag_ScoutingElectron'),
                                                  BaseTriggerSelection = cms.vstring(["DST_PFScouting_ZeroBias_v", "DST_PFScouting_SingleMuon_v", "DST_PFScouting_DoubleMuon_v", "DST_PFScouting_JetHT_v"]),
                                                  triggerSelection = cms.vstring(["DST_PFScouting_DoubleEG_v", "DST_PFScouting_SinglePhotonEB_v"]),
                                                  finalfilterSelection = cms.vstring(["hltDoubleEG11CaloIdLHEFilter", "hltEG30EBTightIDTightIsoTrackIsoFilter"]), # Must align with triggerSelection
                                                  TriggerResultTag   = cms.InputTag("TriggerResults", "", "HLT"),
                                                  TriggerObjects     = cms.InputTag("slimmedPatTrigger"),
-                                                 ElectronCollection = cms.InputTag('slimmedElectrons'),
-                                                 ScoutingElectronCollection = cms.InputTag('hltScoutingEgammaPacker')
+                                                 ScoutingElectronCollection = cms.InputTag('hltScoutingEgammaPacker'),
+                                                 useOfflineObject = cms.bool(True)
                                                  )
 
-scoutingMonitoringTagProbe = cms.Sequence(ScoutingElectronTagProbeAnalysis) # * ScoutingElectronEfficiencySummary)
+ScoutingElectronTagProbeAnalysisOnline = ScoutingElectronTagProbeAnalysisOffline.clone(
+                                                 OutputInternalPath = cms.string('/HLT/ScoutingOnline/EGamma/TnP/Tag_ScoutingElectron'),
+                                                 useOfflineObject = cms.bool(False)
+                                                 )
+
+scoutingMonitoringTagProbeOffline = cms.Sequence(ScoutingElectronTagProbeAnalysisOffline)
+scoutingMonitoringTagProbeOnline = cms.Sequence(ScoutingElectronTagProbeAnalysisOnline)


### PR DESCRIPTION
#### PR description:
A patch is added to include scouting egamma DQM monitoring in the online stream. The update is highly related to previous PR https://github.com/cms-sw/cmssw/pull/48398 i.e. here we introduce scouting egamma part into HLT Scouting DQM online client for the DQMOnlineScoutingstream. This progress has been mentioned in the [scouting meeting at 28 Aug 2025.](https://indico.cern.ch/event/1579341/contributions/6655674/subcontributions/568712/attachments/3124961/5542266/ScoutingEGamma_Report_DPNote_2025Aug28.pdf)

This is the backport of the approved PR for CMSSW_15_1_X: [cmssw#48850 Include scouting EGM in Online DQM stream](https://github.com/cms-sw/cmssw/pull/48850)

#### Description of the current change

- Add options useOfflineObject in the config files under the original `HLTriggerOffline/Scouting`. In online stream, we could choose not to use any offline object by such options.

- Add EGM part to online stream config file accordingly.
- **Note**: The current file `HLTriggerOffline/Scouting/python/HLTScoutingEGammaPostProcessing_cff.py`, which corresponds to the DQM Harvester, uses offline objects to achieve more accurate Tag-and-Probe measurements. Therefore, this postprocessor is not included in the online DQM sequence. (Similarly, in previous PR, for scouting muons, the harvester defined in `HLTriggerOffline/Scouting/python/ScoutingMuonMonitoring_Client_cff.py` is not used in Online DQM.) This is mentioned here for completeness.

#### PR validation:
This PR is prepared under `CMSSW_15_0_13_patch2`
```
scram project CMSSW_15_0_13_patch2
cd CMSSW_15_0_13_patch2/src/
cmsenv
git cms-rebase-topic --old-base  CMSSW_15_1_X_2025-08-27-2300 tihsu99:ScoutingOnlineDQM
scram b && scram b code-checks && scram b code-format && scram b
```
and run with 
```
 runTheMatrix.py -l 145.314
```

[c.c. @mmusich @rseidita @silviodonato @patinkaew ]