### PR TITLE
[15_0_X] Bug fixing in the RecoEgamma/plugins/PhotonValidator.cc

### DIFF
--- a/Validation/RecoEgamma/plugins/PhotonValidator.cc
+++ b/Validation/RecoEgamma/plugins/PhotonValidator.cc
@@ -4175,7 +4175,7 @@ void PhotonValidator::analyze(const edm::Event& e, const edm::EventSetup& esup) 
                   h_dRPhoPFcand_NeuHad_unCleaned_[4]->Fill(dR);
                 }
               } else {
-                h_dRPhoPFcand_NeuHad_Cleaned_[2]->Fill(dR);
+                h_dRPhoPFcand_NeuHad_unCleaned_[2]->Fill(dR);
               }
             }
 


### PR DESCRIPTION
Simple bug fixing. A histogram was being filled with the wrong name

#### PR description:
Simple bug fixing. A histogram was being filled with the wrong name


#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

This is a backport of PR 48852. This PR is meant for the CMSSW_15_0_X

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<!-- Please delete the text above after you verified all points of the checklist  -->
