### PR TITLE
Remove vebose output in concurrency test

### DIFF
--- a/FWCore/Concurrency/test/BuildFile.xml
+++ b/FWCore/Concurrency/test/BuildFile.xml
@@ -2,8 +2,7 @@
   <use name="catch2"/>
   <use name="FWCore/Concurrency"/>
   <use name="tbb"/>
-  <!-- be verbose to help find failure-->
-  <flags TEST_RUNNER_CMD="testFWCoreConcurrency -s"/>
+  <flags TEST_RUNNER_CMD="testFWCoreConcurrency"/>
 </bin>
 
 <bin file="test_threadSafeOutputFileStream.cpp">

--- a/FWCore/Concurrency/test/test2_catch2_serialtaskqueuechain.cc
+++ b/FWCore/Concurrency/test/test2_catch2_serialtaskqueuechain.cc
@@ -5,13 +5,10 @@
 //  Created by Chris Jones on 9/27/11.
 //
 
-#include <iostream>
-#include <sstream>
 #include <catch.hpp>
 #include <chrono>
 #include <memory>
 #include <atomic>
-#include <iostream>
 #include "oneapi/tbb/task.h"
 #include "oneapi/tbb/global_control.h"
 #include "oneapi/tbb/task_arena.h"
@@ -100,36 +97,23 @@ TEST_CASE("SerialTaskQueueChain", "[SerialTaskQueueChain]") {
         {
           edm::WaitingTaskHolder lastHolder(group, &lastTask);
 
-          group.run([&chain, &waitToStart, &group, &count, lastHolder, index] {
+          group.run([&chain, &waitToStart, &group, &count, lastHolder] {
             --waitToStart;
             while (waitToStart.load() != 0)
               ;
-            std::ostringstream ss;
-            ss << "start task 1, index: " << index << "\n";
-            std::cout << ss.str() << std::flush;
             for (unsigned int i = 0; i < nTasks; ++i) {
               chain.push(group, [&count, lastHolder] { ++count; });
             }
-            ss.str(std::string());
-            ss << "stop task 1, index: " << index << "\n";
-            std::cout << ss.str() << std::flush;
           });
-          group.run([&chain, &waitToStart, &group, &count, lastHolder, index] {
+          group.run([&chain, &waitToStart, &group, &count, lastHolder] {
             --waitToStart;
             while (waitToStart.load() != 0)
               ;
-            std::ostringstream ss;
-            ss << "start task 2, index: " << index << "\n";
-            std::cout << ss.str() << std::flush;
             for (unsigned int i = 0; i < nTasks; ++i) {
               chain.push(group, [&count, lastHolder] { ++count; });
             }
-            ss.str(std::string());
-            ss << "stop task 2, index: " << index << "\n";
-            std::cout << ss.str() << std::flush;
           });
         }
-        std::cout << "Waiting for tasks to finish, index: " << index << "\n" << std::flush;
         lastTask.wait();
         REQUIRE(2 * nTasks == count);
       }


### PR DESCRIPTION
#### PR description:

The problem for which the extra output was added has not been seen since the last change to the test.

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/1529
