### PR TITLE
Fix to HGCAL unpacker: Move from FEDRawDataCollection to RawDataBuffer 

### DIFF
--- a/EventFilter/HGCalRawToDigi/interface/HGCalUnpacker.h
+++ b/EventFilter/HGCalRawToDigi/interface/HGCalUnpacker.h
@@ -12,7 +12,7 @@
 #define EventFilter_HGCalRawToDigi_HGCalUnpacker_h
 
 #include "DataFormats/HGCalDigi/interface/HGCalRawDataDefinitions.h"
-#include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "DataFormats/FEDRawData/interface/RawDataBuffer.h"
 #include "DataFormats/HGCalDigi/interface/HGCalDigiHost.h"
 #include "DataFormats/HGCalDigi/interface/HGCalFEDPacketInfoHost.h"
 #include "DataFormats/HGCalDigi/interface/HGCalECONDPacketInfoHost.h"
@@ -34,13 +34,23 @@ public:
   // HGCalUnpacker(HGCalUnpackerConfig config);
 
   uint16_t parseFEDData(unsigned fedId,
-                        const FEDRawData& fed_data,
+                        const RawFragmentWrapper& fed_data,
                         const HGCalMappingModuleIndexer& moduleIndexer,
                         const HGCalConfiguration& config,
                         hgcaldigi::HGCalDigiHost& digis,
                         hgcaldigi::HGCalFEDPacketInfoHost& fedPacketInfo,
                         hgcaldigi::HGCalECONDPacketInfoHost& econdPacketInfo,
                         bool headerOnlyMode = false);
+
+  uint16_t parseFEDData(unsigned fedId,
+                        const unsigned char* start_fed_data,
+                        size_t fed_data_size,
+                        const HGCalMappingModuleIndexer& moduleIndexer,
+                        const HGCalConfiguration& config,
+                        hgcaldigi::HGCalDigiHost& digis,
+                        hgcaldigi::HGCalFEDPacketInfoHost& fedPacketInfo,
+                        hgcaldigi::HGCalECONDPacketInfoHost& econdPacketInfo,
+                        bool headerOnlyMode);
 
 private:
   constexpr static uint8_t tctp_[16] = {


### PR DESCRIPTION
#### PR description:

Following the update for phase II we're switching the usage of FEDRawDataCollection to RawDataBuffer in the HGCAL unpacker.

#### PR validation:

There is not yet a workflow to test the unpacking (workflow 77 starts from unpacked data). This was tested using pre-series cassette data (run 20'000'000) checking the unpacked results before and after 15_1_0_pre6 are the same in the HGCAL commissioning DQM and NANO.

@yulunmiao @hqucms @cramonal @lourdesurda