### PR TITLE
New Validation/RecoEgamma PF differential Isolation Electrons plots V1

### DIFF
--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -181,9 +181,10 @@ ElectronMcSignalValidator::ElectronMcSignalValidator(const edm::ParameterSet &co
   seed_min = histosSet.getParameter<double>("SEED_min");
   seed_max = histosSet.getParameter<double>("SEED_max");
 
-  et_nbin = histosSet.getParameter<int>("NetBin");
-  et_min = histosSet.getParameter<double>("etMin");
-  et_max = histosSet.getParameter<double>("etMax");
+  et_IsolationConeSize = histosSet.getParameter<double>("IsolationConeSize");
+  et_NbinsDeltaRPlot = histosSet.getParameter<int>("NbinsDeltaRPlot");
+  et_RMaxDeltaRPlot = histosSet.getParameter<double>("RMaxDeltaRPlot");
+  et_RMinDeltaRPlot = histosSet.getParameter<double>("RMinDeltaRPlot");
 
   // so to please coverity...
   h1_mcNum = nullptr;
@@ -3260,62 +3261,62 @@ void ElectronMcSignalValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::
   h1_ele_dRElectronsPFcand_ChHad_unCleaned = bookH1(iBooker,
                                                     "dRElectronsPFcand_ChHad_unCleaned",
                                                     "dR(pho,cand) Charged Hadrons :  All Ecal",
-                                                    et_nbin,
-                                                    et_min,
-                                                    0.7,
+                                                    et_NbinsDeltaRPlot,
+                                                    et_RMinDeltaRPlot,
+                                                    et_RMaxDeltaRPlot,
                                                     "N_{ele}");
   h1_ele_dRElectronsPFcand_ChHad_unCleaned_barrel = bookH1(iBooker,
                                                            "dRElectronsPFcand_ChHad_unCleaned_barrel",
                                                            "dR(pho,cand) Charged Hadrons :  Barrel",
-                                                           et_nbin,
-                                                           et_min,
-                                                           0.7,
+                                                           et_NbinsDeltaRPlot,
+                                                           et_RMinDeltaRPlot,
+                                                           et_RMaxDeltaRPlot,
                                                            "N_{ele}");
   h1_ele_dRElectronsPFcand_ChHad_unCleaned_endcaps = bookH1(iBooker,
                                                             "dRElectronsPFcand_ChHad_unCleaned_endcaps",
                                                             "dR(pho,cand) Charged Hadrons :  Endcaps",
-                                                            et_nbin,
-                                                            et_min,
-                                                            0.7,
+                                                            et_NbinsDeltaRPlot,
+                                                            et_RMinDeltaRPlot,
+                                                            et_RMaxDeltaRPlot,
                                                             "N_{ele}");
 
   h1_ele_dRElectronsPFcand_NeuHad_unCleaned = bookH1(iBooker,
                                                      "dRElectronsPFcand_NeuHad_unCleaned",
                                                      "dR(pho,cand) Neutral Hadrons :  All Ecal",
-                                                     et_nbin,
-                                                     et_min,
-                                                     0.7,
+                                                     et_NbinsDeltaRPlot,
+                                                     et_RMinDeltaRPlot,
+                                                     et_RMaxDeltaRPlot,
                                                      "N_{ele}");
   h1_ele_dRElectronsPFcand_NeuHad_unCleaned_barrel = bookH1(iBooker,
                                                             "dRElectronsPFcand_NeuHad_unCleaned_barrel",
                                                             "dR(pho,cand) Neutral Hadrons :  Barrel",
-                                                            et_nbin,
-                                                            et_min,
-                                                            0.7,
+                                                            et_NbinsDeltaRPlot,
+                                                            et_RMinDeltaRPlot,
+                                                            et_RMaxDeltaRPlot,
                                                             "N_{ele}");
   h1_ele_dRElectronsPFcand_NeuHad_unCleaned_endcaps = bookH1(iBooker,
                                                              "dRElectronsPFcand_NeuHad_unCleaned_endcaps",
                                                              "dR(pho,cand) Neutral Hadrons :  Endcaps",
-                                                             et_nbin,
-                                                             et_min,
-                                                             0.7,
+                                                             et_NbinsDeltaRPlot,
+                                                             et_RMinDeltaRPlot,
+                                                             et_RMaxDeltaRPlot,
                                                              "N_{ele}");
 
   h1_ele_dRElectronsPFcand_Pho_unCleaned = bookH1(
-      iBooker, "dRElectronsPFcand_Pho_unCleaned", "dR(pho,cand) Photons :  All Ecal", et_nbin, et_min, 0.7, "N_{ele}");
+      iBooker, "dRElectronsPFcand_Pho_unCleaned", "dR(pho,cand) Photons :  All Ecal", et_NbinsDeltaRPlot, et_RMinDeltaRPlot, et_RMaxDeltaRPlot, "N_{ele}");
   h1_ele_dRElectronsPFcand_Pho_unCleaned_barrel = bookH1(iBooker,
                                                          "dRElectronsPFcand_Pho_unCleaned_barrel",
                                                          "dR(pho,cand) Photons :  Barrel",
-                                                         et_nbin,
-                                                         et_min,
-                                                         0.7,
+                                                         et_NbinsDeltaRPlot,
+                                                         et_RMinDeltaRPlot,
+                                                         et_RMaxDeltaRPlot,
                                                          "N_{ele}");
   h1_ele_dRElectronsPFcand_Pho_unCleaned_endcaps = bookH1(iBooker,
                                                           "dRElectronsPFcand_Pho_unCleaned_endcaps",
                                                           "dR(pho,cand) Photons :  Endcaps",
-                                                          et_nbin,
-                                                          et_min,
-                                                          0.7,
+                                                          et_NbinsDeltaRPlot,
+                                                          et_RMinDeltaRPlot,
+                                                          et_RMaxDeltaRPlot,
                                                           "N_{ele}");
 
   // conversion rejection information
@@ -3357,12 +3358,12 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
   } else {
     edm::LogInfo("ElectronMcSignalValidator::analyze") << "vertexCollectionHandle OK";
   }
-  auto pfCandidateHandle = iEvent.getHandle(pfCandidates_);  // #### NEW PR ####
+  auto pfCandidateHandle = iEvent.getHandle(pfCandidates_);
   if (!pfCandidateHandle.isValid()) {
     edm::LogInfo("ElectronMcSignalValidator::analyze") << "pfCandidateHandle KO";
   } else {
     edm::LogInfo("ElectronMcSignalValidator::analyze") << "pfCandidateHandle OK";
-  }  // #### NEW PR ####
+  }
 
   reco::GsfElectronCollection::const_iterator gsfIter;          //
   reco::GsfElectronCoreCollection::const_iterator gsfCoreIter;  //
@@ -4368,7 +4369,7 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
       //float dR = deltaR(mcIter->eta(), mcIter->phi(), pfCandRef->eta(), pfCandRef->phi());
       float dR = deltaR(bestGsfElectron.eta(), bestGsfElectron.phi(), pfCandRef->eta(), pfCandRef->phi());
 
-      if (dR < 0.4) {
+      if (dR < et_IsolationConeSize) {
         /// uncleaned
         reco::PFCandidate::ParticleType type = pfCandRef->particleId();
         if (type == reco::PFCandidate::e)
@@ -4404,7 +4405,7 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
           }
         }
 
-      }  // dr=0.4
+      }  // dr=et_IsolationConeSize=0.4
 
     }  // loop over all PF Candidates
 

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -15,7 +15,7 @@
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
-#include "DataFormats/Math/interface/deltaR.h" 
+#include "DataFormats/Math/interface/deltaR.h"
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/ValueMap.h"
@@ -69,7 +69,7 @@ ElectronMcSignalValidator::ElectronMcSignalValidator(const edm::ParameterSet &co
   offlineVerticesCollection_ =
       consumes<reco::VertexCollection>(conf.getParameter<edm::InputTag>("offlinePrimaryVertices"));
   beamSpotTag_ = consumes<reco::BeamSpot>(conf.getParameter<edm::InputTag>("beamSpot"));
-  pfCandidates_ = consumes<reco::PFCandidateCollection>(conf.getParameter<edm::InputTag>("pfCandidates")); 
+  pfCandidates_ = consumes<reco::PFCandidateCollection>(conf.getParameter<edm::InputTag>("pfCandidates"));
 
   readAOD_ = conf.getParameter<bool>("readAOD");
 
@@ -604,15 +604,14 @@ ElectronMcSignalValidator::ElectronMcSignalValidator(const edm::ParameterSet &co
   h1_ele_photonRelativeIso_mAOD_barrel = nullptr;
   h1_ele_photonRelativeIso_mAOD_endcaps = nullptr;
   h1_ele_dRElectronsPFcand_ChHad_unCleaned = nullptr;
-  h1_ele_dRElectronsPFcand_ChHad_unCleaned_barrel = nullptr; 
-  h1_ele_dRElectronsPFcand_ChHad_unCleaned_endcaps = nullptr; 
+  h1_ele_dRElectronsPFcand_ChHad_unCleaned_barrel = nullptr;
+  h1_ele_dRElectronsPFcand_ChHad_unCleaned_endcaps = nullptr;
   h1_ele_dRElectronsPFcand_NeuHad_unCleaned = nullptr;
-  h1_ele_dRElectronsPFcand_NeuHad_unCleaned_barrel = nullptr; 
-  h1_ele_dRElectronsPFcand_NeuHad_unCleaned_endcaps = nullptr; 
-  h1_ele_dRElectronsPFcand_Pho_unCleaned = nullptr;  
-  h1_ele_dRElectronsPFcand_Pho_unCleaned_barrel = nullptr; 
-  h1_ele_dRElectronsPFcand_Pho_unCleaned_endcaps = nullptr; 
-
+  h1_ele_dRElectronsPFcand_NeuHad_unCleaned_barrel = nullptr;
+  h1_ele_dRElectronsPFcand_NeuHad_unCleaned_endcaps = nullptr;
+  h1_ele_dRElectronsPFcand_Pho_unCleaned = nullptr;
+  h1_ele_dRElectronsPFcand_Pho_unCleaned_barrel = nullptr;
+  h1_ele_dRElectronsPFcand_Pho_unCleaned_endcaps = nullptr;
 }
 
 void ElectronMcSignalValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::Run const &, edm::EventSetup const &) {
@@ -3258,17 +3257,66 @@ void ElectronMcSignalValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::
                                                           "Events",
                                                           "ELE_LOGY E1 P");
 
-  h1_ele_dRElectronsPFcand_ChHad_unCleaned = bookH1(iBooker, "dRElectronsPFcand_ChHad_unCleaned", "dR(pho,cand) Charged Hadrons :  All Ecal", et_nbin, et_min, 0.7, "N_{ele}");
-  h1_ele_dRElectronsPFcand_ChHad_unCleaned_barrel = bookH1(iBooker, "dRElectronsPFcand_ChHad_unCleaned_barrel", "dR(pho,cand) Charged Hadrons :  Barrel", et_nbin, et_min, 0.7, "N_{ele}");
-  h1_ele_dRElectronsPFcand_ChHad_unCleaned_endcaps = bookH1(iBooker, "dRElectronsPFcand_ChHad_unCleaned_endcaps", "dR(pho,cand) Charged Hadrons :  Endcaps", et_nbin, et_min, 0.7, "N_{ele}");
+  h1_ele_dRElectronsPFcand_ChHad_unCleaned = bookH1(iBooker,
+                                                    "dRElectronsPFcand_ChHad_unCleaned",
+                                                    "dR(pho,cand) Charged Hadrons :  All Ecal",
+                                                    et_nbin,
+                                                    et_min,
+                                                    0.7,
+                                                    "N_{ele}");
+  h1_ele_dRElectronsPFcand_ChHad_unCleaned_barrel = bookH1(iBooker,
+                                                           "dRElectronsPFcand_ChHad_unCleaned_barrel",
+                                                           "dR(pho,cand) Charged Hadrons :  Barrel",
+                                                           et_nbin,
+                                                           et_min,
+                                                           0.7,
+                                                           "N_{ele}");
+  h1_ele_dRElectronsPFcand_ChHad_unCleaned_endcaps = bookH1(iBooker,
+                                                            "dRElectronsPFcand_ChHad_unCleaned_endcaps",
+                                                            "dR(pho,cand) Charged Hadrons :  Endcaps",
+                                                            et_nbin,
+                                                            et_min,
+                                                            0.7,
+                                                            "N_{ele}");
 
-  h1_ele_dRElectronsPFcand_NeuHad_unCleaned = bookH1(iBooker, "dRElectronsPFcand_NeuHad_unCleaned", "dR(pho,cand) Neutral Hadrons :  All Ecal", et_nbin, et_min, 0.7, "N_{ele}");
-  h1_ele_dRElectronsPFcand_NeuHad_unCleaned_barrel = bookH1(iBooker, "dRElectronsPFcand_NeuHad_unCleaned_barrel", "dR(pho,cand) Neutral Hadrons :  Barrel", et_nbin, et_min, 0.7, "N_{ele}");
-  h1_ele_dRElectronsPFcand_NeuHad_unCleaned_endcaps = bookH1(iBooker, "dRElectronsPFcand_NeuHad_unCleaned_endcaps", "dR(pho,cand) Neutral Hadrons :  Endcaps", et_nbin, et_min, 0.7, "N_{ele}");
+  h1_ele_dRElectronsPFcand_NeuHad_unCleaned = bookH1(iBooker,
+                                                     "dRElectronsPFcand_NeuHad_unCleaned",
+                                                     "dR(pho,cand) Neutral Hadrons :  All Ecal",
+                                                     et_nbin,
+                                                     et_min,
+                                                     0.7,
+                                                     "N_{ele}");
+  h1_ele_dRElectronsPFcand_NeuHad_unCleaned_barrel = bookH1(iBooker,
+                                                            "dRElectronsPFcand_NeuHad_unCleaned_barrel",
+                                                            "dR(pho,cand) Neutral Hadrons :  Barrel",
+                                                            et_nbin,
+                                                            et_min,
+                                                            0.7,
+                                                            "N_{ele}");
+  h1_ele_dRElectronsPFcand_NeuHad_unCleaned_endcaps = bookH1(iBooker,
+                                                             "dRElectronsPFcand_NeuHad_unCleaned_endcaps",
+                                                             "dR(pho,cand) Neutral Hadrons :  Endcaps",
+                                                             et_nbin,
+                                                             et_min,
+                                                             0.7,
+                                                             "N_{ele}");
 
-  h1_ele_dRElectronsPFcand_Pho_unCleaned = bookH1(iBooker, "dRElectronsPFcand_Pho_unCleaned", "dR(pho,cand) Photons :  All Ecal", et_nbin, et_min, 0.7, "N_{ele}");
-  h1_ele_dRElectronsPFcand_Pho_unCleaned_barrel = bookH1(iBooker, "dRElectronsPFcand_Pho_unCleaned_barrel", "dR(pho,cand) Photons :  Barrel", et_nbin, et_min, 0.7, "N_{ele}");
-  h1_ele_dRElectronsPFcand_Pho_unCleaned_endcaps = bookH1(iBooker, "dRElectronsPFcand_Pho_unCleaned_endcaps", "dR(pho,cand) Photons :  Endcaps", et_nbin, et_min, 0.7, "N_{ele}");
+  h1_ele_dRElectronsPFcand_Pho_unCleaned = bookH1(
+      iBooker, "dRElectronsPFcand_Pho_unCleaned", "dR(pho,cand) Photons :  All Ecal", et_nbin, et_min, 0.7, "N_{ele}");
+  h1_ele_dRElectronsPFcand_Pho_unCleaned_barrel = bookH1(iBooker,
+                                                         "dRElectronsPFcand_Pho_unCleaned_barrel",
+                                                         "dR(pho,cand) Photons :  Barrel",
+                                                         et_nbin,
+                                                         et_min,
+                                                         0.7,
+                                                         "N_{ele}");
+  h1_ele_dRElectronsPFcand_Pho_unCleaned_endcaps = bookH1(iBooker,
+                                                          "dRElectronsPFcand_Pho_unCleaned_endcaps",
+                                                          "dR(pho,cand) Photons :  Endcaps",
+                                                          et_nbin,
+                                                          et_min,
+                                                          0.7,
+                                                          "N_{ele}");
 
   // conversion rejection information
   h1_ele_convFlags = bookH1withSumw2(iBooker, "convFlags", "conversion rejection flag", 5, -1.5, 3.5);
@@ -3288,7 +3336,6 @@ void ElectronMcSignalValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::
   h1_ele_convRadius = bookH1withSumw2(iBooker, "convRadius", "signed conversion radius", 100, 0., 130.);
   h1_ele_convRadius_all =
       bookH1withSumw2(iBooker, "convRadius_all", "signed conversion radius, all electrons", 100, 0., 130.);
-  
 }
 
 ElectronMcSignalValidator::~ElectronMcSignalValidator() {}
@@ -3310,12 +3357,12 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
   } else {
     edm::LogInfo("ElectronMcSignalValidator::analyze") << "vertexCollectionHandle OK";
   }
-  auto pfCandidateHandle = iEvent.getHandle(pfCandidates_); // #### NEW PR ####
+  auto pfCandidateHandle = iEvent.getHandle(pfCandidates_);  // #### NEW PR ####
   if (!pfCandidateHandle.isValid()) {
     edm::LogInfo("ElectronMcSignalValidator::analyze") << "pfCandidateHandle KO";
   } else {
     edm::LogInfo("ElectronMcSignalValidator::analyze") << "pfCandidateHandle OK";
-  } // #### NEW PR ####
+  }  // #### NEW PR ####
 
   reco::GsfElectronCollection::const_iterator gsfIter;          //
   reco::GsfElectronCoreCollection::const_iterator gsfCoreIter;  //
@@ -4324,7 +4371,7 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
       reco::PFCandidateRef pfCandRef(reco::PFCandidateRef(pfCandidateHandle, lCand));
       //float dR = deltaR(mcIter->eta(), mcIter->phi(), pfCandRef->eta(), pfCandRef->phi());
       float dR = deltaR(bestGsfElectron.eta(), bestGsfElectron.phi(), pfCandRef->eta(), pfCandRef->phi());
-      
+
       if (dR < 0.4) {
         /// uncleaned
         reco::PFCandidate::ParticleType type = pfCandRef->particleId();
@@ -4365,11 +4412,10 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
         }
 
       }  // dr=0.4
-      
+
     }  // loop over all PF Candidates
 
   }  // loop over mc particle
   h1_mcNum->Fill(mcNum);
   h1_eleNum->Fill(eleNum);
-
 }

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -4363,10 +4363,6 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
       h1_ele_convRadius->Fill(bestGsfElectron.convRadius());
     }
 
-    float SumPtIsoValCh = 0.;
-    float SumPtIsoValNh = 0.;
-    float SumPtIsoValPh = 0.;
-
     for (unsigned int lCand = 0; lCand < pfCandidateHandle->size(); lCand++) {
       reco::PFCandidateRef pfCandRef(reco::PFCandidateRef(pfCandidateHandle, lCand));
       //float dR = deltaR(mcIter->eta(), mcIter->phi(), pfCandRef->eta(), pfCandRef->phi());
@@ -4381,7 +4377,6 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
           continue;
 
         if (type == reco::PFCandidate::h) {
-          SumPtIsoValCh += pfCandRef->pt();
           h1_ele_dRElectronsPFcand_ChHad_unCleaned->Fill(dR);
           if (isEBflag) {
             h1_ele_dRElectronsPFcand_ChHad_unCleaned_barrel->Fill(dR);
@@ -4391,7 +4386,6 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
           }
         }
         if (type == reco::PFCandidate::h0) {
-          SumPtIsoValNh += pfCandRef->pt();
           h1_ele_dRElectronsPFcand_NeuHad_unCleaned->Fill(dR);
           if (isEBflag) {
             h1_ele_dRElectronsPFcand_NeuHad_unCleaned_barrel->Fill(dR);
@@ -4401,7 +4395,6 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
           }
         }
         if (type == reco::PFCandidate::gamma) {
-          SumPtIsoValPh += pfCandRef->pt();
           h1_ele_dRElectronsPFcand_Pho_unCleaned->Fill(dR);
           if (isEBflag) {
             h1_ele_dRElectronsPFcand_Pho_unCleaned_barrel->Fill(dR);

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -3302,8 +3302,13 @@ void ElectronMcSignalValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::
                                                              et_RMaxDeltaRPlot,
                                                              "N_{ele}");
 
-  h1_ele_dRElectronsPFcand_Pho_unCleaned = bookH1(
-      iBooker, "dRElectronsPFcand_Pho_unCleaned", "dR(pho,cand) Photons :  All Ecal", et_NbinsDeltaRPlot, et_RMinDeltaRPlot, et_RMaxDeltaRPlot, "N_{ele}");
+  h1_ele_dRElectronsPFcand_Pho_unCleaned = bookH1(iBooker,
+                                                  "dRElectronsPFcand_Pho_unCleaned",
+                                                  "dR(pho,cand) Photons :  All Ecal",
+                                                  et_NbinsDeltaRPlot,
+                                                  et_RMinDeltaRPlot,
+                                                  et_RMaxDeltaRPlot,
+                                                  "N_{ele}");
   h1_ele_dRElectronsPFcand_Pho_unCleaned_barrel = bookH1(iBooker,
                                                          "dRElectronsPFcand_Pho_unCleaned_barrel",
                                                          "dR(pho,cand) Photons :  Barrel",

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -15,12 +15,14 @@
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/Math/interface/deltaR.h" 
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 
 #include "RecoEcal/EgammaCoreTools/interface/EcalTools.h"
 
@@ -67,21 +69,9 @@ ElectronMcSignalValidator::ElectronMcSignalValidator(const edm::ParameterSet &co
   offlineVerticesCollection_ =
       consumes<reco::VertexCollection>(conf.getParameter<edm::InputTag>("offlinePrimaryVertices"));
   beamSpotTag_ = consumes<reco::BeamSpot>(conf.getParameter<edm::InputTag>("beamSpot"));
+  pfCandidates_ = consumes<reco::PFCandidateCollection>(conf.getParameter<edm::InputTag>("pfCandidates")); 
 
   readAOD_ = conf.getParameter<bool>("readAOD");
-
-  isoFromDepsTk03Tag_ = consumes<edm::ValueMap<double> >(conf.getParameter<edm::InputTag>("isoFromDepsTk03"));
-  isoFromDepsTk04Tag_ = consumes<edm::ValueMap<double> >(conf.getParameter<edm::InputTag>("isoFromDepsTk04"));
-  isoFromDepsEcalFull03Tag_ =
-      consumes<edm::ValueMap<double> >(conf.getParameter<edm::InputTag>("isoFromDepsEcalFull03"));
-  isoFromDepsEcalFull04Tag_ =
-      consumes<edm::ValueMap<double> >(conf.getParameter<edm::InputTag>("isoFromDepsEcalFull04"));
-  isoFromDepsEcalReduced03Tag_ =
-      consumes<edm::ValueMap<double> >(conf.getParameter<edm::InputTag>("isoFromDepsEcalReduced03"));
-  isoFromDepsEcalReduced04Tag_ =
-      consumes<edm::ValueMap<double> >(conf.getParameter<edm::InputTag>("isoFromDepsEcalReduced04"));
-  isoFromDepsHcal03Tag_ = consumes<edm::ValueMap<double> >(conf.getParameter<edm::InputTag>("isoFromDepsHcal03"));
-  isoFromDepsHcal04Tag_ = consumes<edm::ValueMap<double> >(conf.getParameter<edm::InputTag>("isoFromDepsHcal04"));
 
   maxPt_ = conf.getParameter<double>("MaxPt");
   maxAbsEta_ = conf.getParameter<double>("MaxAbsEta");
@@ -190,6 +180,10 @@ ElectronMcSignalValidator::ElectronMcSignalValidator(const edm::ParameterSet &co
   seed_nbin = histosSet.getParameter<int>("NbinSEED");
   seed_min = histosSet.getParameter<double>("SEED_min");
   seed_max = histosSet.getParameter<double>("SEED_max");
+
+  et_nbin = histosSet.getParameter<int>("NetBin");
+  et_min = histosSet.getParameter<double>("etMin");
+  et_max = histosSet.getParameter<double>("etMax");
 
   // so to please coverity...
   h1_mcNum = nullptr;
@@ -609,6 +603,16 @@ ElectronMcSignalValidator::ElectronMcSignalValidator(const edm::ParameterSet &co
   h1_ele_photonRelativeIso_mAOD = nullptr;
   h1_ele_photonRelativeIso_mAOD_barrel = nullptr;
   h1_ele_photonRelativeIso_mAOD_endcaps = nullptr;
+  h1_ele_dRElectronsPFcand_ChHad_unCleaned = nullptr;
+  h1_ele_dRElectronsPFcand_ChHad_unCleaned_barrel = nullptr; 
+  h1_ele_dRElectronsPFcand_ChHad_unCleaned_endcaps = nullptr; 
+  h1_ele_dRElectronsPFcand_NeuHad_unCleaned = nullptr;
+  h1_ele_dRElectronsPFcand_NeuHad_unCleaned_barrel = nullptr; 
+  h1_ele_dRElectronsPFcand_NeuHad_unCleaned_endcaps = nullptr; 
+  h1_ele_dRElectronsPFcand_Pho_unCleaned = nullptr;  
+  h1_ele_dRElectronsPFcand_Pho_unCleaned_barrel = nullptr; 
+  h1_ele_dRElectronsPFcand_Pho_unCleaned_endcaps = nullptr; 
+
 }
 
 void ElectronMcSignalValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::Run const &, edm::EventSetup const &) {
@@ -3254,6 +3258,18 @@ void ElectronMcSignalValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::
                                                           "Events",
                                                           "ELE_LOGY E1 P");
 
+  h1_ele_dRElectronsPFcand_ChHad_unCleaned = bookH1(iBooker, "dRElectronsPFcand_ChHad_unCleaned", "dR(pho,cand) Charged Hadrons :  All Ecal", et_nbin, et_min, 0.7, "N_{ele}");
+  h1_ele_dRElectronsPFcand_ChHad_unCleaned_barrel = bookH1(iBooker, "dRElectronsPFcand_ChHad_unCleaned_barrel", "dR(pho,cand) Charged Hadrons :  Barrel", et_nbin, et_min, 0.7, "N_{ele}");
+  h1_ele_dRElectronsPFcand_ChHad_unCleaned_endcaps = bookH1(iBooker, "dRElectronsPFcand_ChHad_unCleaned_endcaps", "dR(pho,cand) Charged Hadrons :  Endcaps", et_nbin, et_min, 0.7, "N_{ele}");
+
+  h1_ele_dRElectronsPFcand_NeuHad_unCleaned = bookH1(iBooker, "dRElectronsPFcand_NeuHad_unCleaned", "dR(pho,cand) Neutral Hadrons :  All Ecal", et_nbin, et_min, 0.7, "N_{ele}");
+  h1_ele_dRElectronsPFcand_NeuHad_unCleaned_barrel = bookH1(iBooker, "dRElectronsPFcand_NeuHad_unCleaned_barrel", "dR(pho,cand) Neutral Hadrons :  Barrel", et_nbin, et_min, 0.7, "N_{ele}");
+  h1_ele_dRElectronsPFcand_NeuHad_unCleaned_endcaps = bookH1(iBooker, "dRElectronsPFcand_NeuHad_unCleaned_endcaps", "dR(pho,cand) Neutral Hadrons :  Endcaps", et_nbin, et_min, 0.7, "N_{ele}");
+
+  h1_ele_dRElectronsPFcand_Pho_unCleaned = bookH1(iBooker, "dRElectronsPFcand_Pho_unCleaned", "dR(pho,cand) Photons :  All Ecal", et_nbin, et_min, 0.7, "N_{ele}");
+  h1_ele_dRElectronsPFcand_Pho_unCleaned_barrel = bookH1(iBooker, "dRElectronsPFcand_Pho_unCleaned_barrel", "dR(pho,cand) Photons :  Barrel", et_nbin, et_min, 0.7, "N_{ele}");
+  h1_ele_dRElectronsPFcand_Pho_unCleaned_endcaps = bookH1(iBooker, "dRElectronsPFcand_Pho_unCleaned_endcaps", "dR(pho,cand) Photons :  Endcaps", et_nbin, et_min, 0.7, "N_{ele}");
+
   // conversion rejection information
   h1_ele_convFlags = bookH1withSumw2(iBooker, "convFlags", "conversion rejection flag", 5, -1.5, 3.5);
   h1_ele_convFlags_all =
@@ -3272,6 +3288,7 @@ void ElectronMcSignalValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::
   h1_ele_convRadius = bookH1withSumw2(iBooker, "convRadius", "signed conversion radius", 100, 0., 130.);
   h1_ele_convRadius_all =
       bookH1withSumw2(iBooker, "convRadius_all", "signed conversion radius, all electrons", 100, 0., 130.);
+  
 }
 
 ElectronMcSignalValidator::~ElectronMcSignalValidator() {}
@@ -3287,20 +3304,18 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
   auto genParticles = iEvent.getHandle(mcTruthCollection_);
   auto theBeamSpot = iEvent.getHandle(beamSpotTag_);
 
-  auto isoFromDepsTk03Handle = iEvent.getHandle(isoFromDepsTk03Tag_);
-  auto isoFromDepsTk04Handle = iEvent.getHandle(isoFromDepsTk04Tag_);
-  auto isoFromDepsEcalFull03Handle = iEvent.getHandle(isoFromDepsEcalFull03Tag_);
-  auto isoFromDepsEcalFull04Handle = iEvent.getHandle(isoFromDepsEcalFull04Tag_);
-  auto isoFromDepsEcalReduced03Handle = iEvent.getHandle(isoFromDepsEcalReduced03Tag_);
-  auto isoFromDepsEcalReduced04Handle = iEvent.getHandle(isoFromDepsEcalReduced04Tag_);
-  auto isoFromDepsHcal03Handle = iEvent.getHandle(isoFromDepsHcal03Tag_);
-  auto isoFromDepsHcal04Handle = iEvent.getHandle(isoFromDepsHcal04Tag_);
   auto vertexCollectionHandle = iEvent.getHandle(offlineVerticesCollection_);
   if (!vertexCollectionHandle.isValid()) {
     edm::LogInfo("ElectronMcSignalValidator::analyze") << "vertexCollectionHandle KO";
   } else {
     edm::LogInfo("ElectronMcSignalValidator::analyze") << "vertexCollectionHandle OK";
   }
+  auto pfCandidateHandle = iEvent.getHandle(pfCandidates_); // #### NEW PR ####
+  if (!pfCandidateHandle.isValid()) {
+    edm::LogInfo("ElectronMcSignalValidator::analyze") << "pfCandidateHandle KO";
+  } else {
+    edm::LogInfo("ElectronMcSignalValidator::analyze") << "pfCandidateHandle OK";
+  } // #### NEW PR ####
 
   reco::GsfElectronCollection::const_iterator gsfIter;          //
   reco::GsfElectronCoreCollection::const_iterator gsfCoreIter;  //
@@ -4301,7 +4316,60 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
       h1_ele_convRadius->Fill(bestGsfElectron.convRadius());
     }
 
+    float SumPtIsoValCh = 0.;
+    float SumPtIsoValNh = 0.;
+    float SumPtIsoValPh = 0.;
+
+    for (unsigned int lCand = 0; lCand < pfCandidateHandle->size(); lCand++) {
+      reco::PFCandidateRef pfCandRef(reco::PFCandidateRef(pfCandidateHandle, lCand));
+      //float dR = deltaR(mcIter->eta(), mcIter->phi(), pfCandRef->eta(), pfCandRef->phi());
+      float dR = deltaR(bestGsfElectron.eta(), bestGsfElectron.phi(), pfCandRef->eta(), pfCandRef->phi());
+      
+      if (dR < 0.4) {
+        /// uncleaned
+        reco::PFCandidate::ParticleType type = pfCandRef->particleId();
+        if (type == reco::PFCandidate::e)
+          continue;
+        if (type == reco::PFCandidate::gamma && pfCandRef->mva_nothing_gamma() > 0.)
+          continue;
+
+        if (type == reco::PFCandidate::h) {
+          SumPtIsoValCh += pfCandRef->pt();
+          h1_ele_dRElectronsPFcand_ChHad_unCleaned->Fill(dR);
+          if (isEBflag) {
+            h1_ele_dRElectronsPFcand_ChHad_unCleaned_barrel->Fill(dR);
+          }
+          if (isEEflag) {
+            h1_ele_dRElectronsPFcand_ChHad_unCleaned_endcaps->Fill(dR);
+          }
+        }
+        if (type == reco::PFCandidate::h0) {
+          SumPtIsoValNh += pfCandRef->pt();
+          h1_ele_dRElectronsPFcand_NeuHad_unCleaned->Fill(dR);
+          if (isEBflag) {
+            h1_ele_dRElectronsPFcand_NeuHad_unCleaned_barrel->Fill(dR);
+          }
+          if (isEEflag) {
+            h1_ele_dRElectronsPFcand_NeuHad_unCleaned_endcaps->Fill(dR);
+          }
+        }
+        if (type == reco::PFCandidate::gamma) {
+          SumPtIsoValPh += pfCandRef->pt();
+          h1_ele_dRElectronsPFcand_Pho_unCleaned->Fill(dR);
+          if (isEBflag) {
+            h1_ele_dRElectronsPFcand_Pho_unCleaned_barrel->Fill(dR);
+          }
+          if (isEEflag) {
+            h1_ele_dRElectronsPFcand_Pho_unCleaned_endcaps->Fill(dR);
+          }
+        }
+
+      }  // dr=0.4
+      
+    }  // loop over all PF Candidates
+
   }  // loop over mc particle
   h1_mcNum->Fill(mcNum);
   h1_eleNum->Fill(eleNum);
+
 }

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
@@ -14,7 +14,7 @@ class MagneticField;
 #include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h" 
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
@@ -40,8 +40,8 @@ private:
   edm::EDGetTokenT<reco::ElectronSeedCollection> electronSeedCollection_;
   edm::EDGetTokenT<reco::VertexCollection> offlineVerticesCollection_;
   edm::EDGetTokenT<reco::BeamSpot> beamSpotTag_;
-  edm::EDGetTokenT<reco::PFCandidateCollection> pfCandidates_; 
-  edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef> > > particleBasedIso_token; 
+  edm::EDGetTokenT<reco::PFCandidateCollection> pfCandidates_;
+  edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef> > > particleBasedIso_token;
 
   bool readAOD_;
 
@@ -62,7 +62,7 @@ private:
   std::string outputFile_;
   std::string inputInternalPath_;
   std::string outputInternalPath_;
-  //std::string valueMapElectronsPFCandIso_; 
+  //std::string valueMapElectronsPFCandIso_;
 
   // histos limits and binning
 
@@ -552,15 +552,15 @@ private:
   MonitorElement *h1_ele_photonRelativeIso_mAOD;
   MonitorElement *h1_ele_photonRelativeIso_mAOD_barrel;
   MonitorElement *h1_ele_photonRelativeIso_mAOD_endcaps;
-  MonitorElement* h1_ele_dRElectronsPFcand_ChHad_unCleaned; 
-  MonitorElement* h1_ele_dRElectronsPFcand_ChHad_unCleaned_barrel;
-  MonitorElement* h1_ele_dRElectronsPFcand_ChHad_unCleaned_endcaps; 
-  MonitorElement* h1_ele_dRElectronsPFcand_NeuHad_unCleaned; 
-  MonitorElement* h1_ele_dRElectronsPFcand_NeuHad_unCleaned_barrel; 
-  MonitorElement* h1_ele_dRElectronsPFcand_NeuHad_unCleaned_endcaps;
-  MonitorElement* h1_ele_dRElectronsPFcand_Pho_unCleaned; 
-  MonitorElement* h1_ele_dRElectronsPFcand_Pho_unCleaned_barrel; 
-  MonitorElement* h1_ele_dRElectronsPFcand_Pho_unCleaned_endcaps; 
+  MonitorElement *h1_ele_dRElectronsPFcand_ChHad_unCleaned;
+  MonitorElement *h1_ele_dRElectronsPFcand_ChHad_unCleaned_barrel;
+  MonitorElement *h1_ele_dRElectronsPFcand_ChHad_unCleaned_endcaps;
+  MonitorElement *h1_ele_dRElectronsPFcand_NeuHad_unCleaned;
+  MonitorElement *h1_ele_dRElectronsPFcand_NeuHad_unCleaned_barrel;
+  MonitorElement *h1_ele_dRElectronsPFcand_NeuHad_unCleaned_endcaps;
+  MonitorElement *h1_ele_dRElectronsPFcand_Pho_unCleaned;
+  MonitorElement *h1_ele_dRElectronsPFcand_Pho_unCleaned_barrel;
+  MonitorElement *h1_ele_dRElectronsPFcand_Pho_unCleaned_endcaps;
   // isolation
   MonitorElement *h1_ele_tkSumPt_dr03;
   MonitorElement *h1_ele_tkSumPt_dr03_barrel;

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
@@ -14,7 +14,8 @@ class MagneticField;
 #include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
-
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h" 
+#include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
@@ -39,16 +40,10 @@ private:
   edm::EDGetTokenT<reco::ElectronSeedCollection> electronSeedCollection_;
   edm::EDGetTokenT<reco::VertexCollection> offlineVerticesCollection_;
   edm::EDGetTokenT<reco::BeamSpot> beamSpotTag_;
-  bool readAOD_;
+  edm::EDGetTokenT<reco::PFCandidateCollection> pfCandidates_; 
+  edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef> > > particleBasedIso_token; 
 
-  edm::EDGetTokenT<edm::ValueMap<double> > isoFromDepsTk03Tag_;
-  edm::EDGetTokenT<edm::ValueMap<double> > isoFromDepsTk04Tag_;
-  edm::EDGetTokenT<edm::ValueMap<double> > isoFromDepsEcalFull03Tag_;
-  edm::EDGetTokenT<edm::ValueMap<double> > isoFromDepsEcalFull04Tag_;
-  edm::EDGetTokenT<edm::ValueMap<double> > isoFromDepsEcalReduced03Tag_;
-  edm::EDGetTokenT<edm::ValueMap<double> > isoFromDepsEcalReduced04Tag_;
-  edm::EDGetTokenT<edm::ValueMap<double> > isoFromDepsHcal03Tag_;
-  edm::EDGetTokenT<edm::ValueMap<double> > isoFromDepsHcal04Tag_;
+  bool readAOD_;
 
   edm::ESHandle<TrackerGeometry> pDD;
   edm::ESHandle<MagneticField> theMagField;
@@ -67,6 +62,7 @@ private:
   std::string outputFile_;
   std::string inputInternalPath_;
   std::string outputInternalPath_;
+  //std::string valueMapElectronsPFCandIso_; 
 
   // histos limits and binning
 
@@ -140,6 +136,9 @@ private:
   int seed_nbin;
   double seed_min;
   double seed_max;
+  int et_nbin;
+  double et_min;
+  double et_max;
 
   // histos
 
@@ -553,6 +552,15 @@ private:
   MonitorElement *h1_ele_photonRelativeIso_mAOD;
   MonitorElement *h1_ele_photonRelativeIso_mAOD_barrel;
   MonitorElement *h1_ele_photonRelativeIso_mAOD_endcaps;
+  MonitorElement* h1_ele_dRElectronsPFcand_ChHad_unCleaned; 
+  MonitorElement* h1_ele_dRElectronsPFcand_ChHad_unCleaned_barrel;
+  MonitorElement* h1_ele_dRElectronsPFcand_ChHad_unCleaned_endcaps; 
+  MonitorElement* h1_ele_dRElectronsPFcand_NeuHad_unCleaned; 
+  MonitorElement* h1_ele_dRElectronsPFcand_NeuHad_unCleaned_barrel; 
+  MonitorElement* h1_ele_dRElectronsPFcand_NeuHad_unCleaned_endcaps;
+  MonitorElement* h1_ele_dRElectronsPFcand_Pho_unCleaned; 
+  MonitorElement* h1_ele_dRElectronsPFcand_Pho_unCleaned_barrel; 
+  MonitorElement* h1_ele_dRElectronsPFcand_Pho_unCleaned_endcaps; 
   // isolation
   MonitorElement *h1_ele_tkSumPt_dr03;
   MonitorElement *h1_ele_tkSumPt_dr03_barrel;

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
@@ -1,4 +1,3 @@
-
 #ifndef Validation_RecoEgamma_ElectronMcSignalValidator_h
 #define Validation_RecoEgamma_ElectronMcSignalValidator_h
 
@@ -136,9 +135,10 @@ private:
   int seed_nbin;
   double seed_min;
   double seed_max;
-  int et_nbin;
-  double et_min;
-  double et_max;
+  double et_IsolationConeSize;
+  int et_NbinsDeltaRPlot;
+  double et_RMaxDeltaRPlot;
+  double et_RMinDeltaRPlot;
 
   // histos
 

--- a/Validation/RecoEgamma/python/ElectronMcSignalValidatorPt1000_gedGsfElectrons_cfi.py
+++ b/Validation/RecoEgamma/python/ElectronMcSignalValidatorPt1000_gedGsfElectrons_cfi.py
@@ -27,7 +27,7 @@ electronMcSignalHistosCfg = cms.PSet(
   NbinCORE = cms.int32(21), CORE_min = cms.double(-0.5), CORE_max = cms.double(20.5), # CORE : recCoreNum
   NbinTRACK = cms.int32(41), TRACK_min = cms.double(-0.5), TRACK_max = cms.double(40.5), # TRACK : recTrackNum
   NbinSEED = cms.int32(101), SEED_min = cms.double(-0.5), SEED_max = cms.double(100.5), # SEED : recSeedNum
-  NetBin = cms.int32(100), etMax = cms.double(250.), etMin = cms.double(0.0), #### NEW PR ####
+  IsolationConeSize = cms.double(0.4), NbinsDeltaRPlot = cms.int32(101), RMaxDeltaRPlot = cms.double(0.5), RMinDeltaRPlot = cms.double(0.), # Differential isolation
 )
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer

--- a/Validation/RecoEgamma/python/ElectronMcSignalValidatorPt1000_gedGsfElectrons_cfi.py
+++ b/Validation/RecoEgamma/python/ElectronMcSignalValidatorPt1000_gedGsfElectrons_cfi.py
@@ -27,6 +27,7 @@ electronMcSignalHistosCfg = cms.PSet(
   NbinCORE = cms.int32(21), CORE_min = cms.double(-0.5), CORE_max = cms.double(20.5), # CORE : recCoreNum
   NbinTRACK = cms.int32(41), TRACK_min = cms.double(-0.5), TRACK_max = cms.double(40.5), # TRACK : recTrackNum
   NbinSEED = cms.int32(101), SEED_min = cms.double(-0.5), SEED_max = cms.double(100.5), # SEED : recSeedNum
+  NetBin = cms.int32(100), etMax = cms.double(250.), etMin = cms.double(0.0), #### NEW PR ####
 )
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer

--- a/Validation/RecoEgamma/python/ElectronMcSignalValidatorPt1000_gedGsfElectrons_cfi.py
+++ b/Validation/RecoEgamma/python/ElectronMcSignalValidatorPt1000_gedGsfElectrons_cfi.py
@@ -48,8 +48,8 @@ electronMcSignalValidatorPt1000 = DQMEDAnalyzer('ElectronMcSignalValidator',
   electronTrackCollection = cms.InputTag("electronGsfTracks"),
   electronSeedCollection = cms.InputTag("electronMergedSeeds"),
   offlinePrimaryVertices = cms.InputTag("offlinePrimaryVertices"),
-  pfCandidates = cms.InputTag("particleFlow"), #### NEW PR ####
-  valueMapElectronsToParticleBasedIso = cms.string("gedGsfElectrons"), #### NEW PR ####
+  pfCandidates = cms.InputTag("particleFlow"), 
+  valueMapElectronsToParticleBasedIso = cms.string("gedGsfElectrons"), 
   
   beamSpot = cms.InputTag("offlineBeamSpot"),
   readAOD = cms.bool(False),

--- a/Validation/RecoEgamma/python/ElectronMcSignalValidatorPt1000_gedGsfElectrons_cfi.py
+++ b/Validation/RecoEgamma/python/ElectronMcSignalValidatorPt1000_gedGsfElectrons_cfi.py
@@ -47,6 +47,8 @@ electronMcSignalValidatorPt1000 = DQMEDAnalyzer('ElectronMcSignalValidator',
   electronTrackCollection = cms.InputTag("electronGsfTracks"),
   electronSeedCollection = cms.InputTag("electronMergedSeeds"),
   offlinePrimaryVertices = cms.InputTag("offlinePrimaryVertices"),
+  pfCandidates = cms.InputTag("particleFlow"), #### NEW PR ####
+  valueMapElectronsToParticleBasedIso = cms.string("gedGsfElectrons"), #### NEW PR ####
   
   beamSpot = cms.InputTag("offlineBeamSpot"),
   readAOD = cms.bool(False),

--- a/Validation/RecoEgamma/python/ElectronMcSignalValidator_gedGsfElectrons_cfi.py
+++ b/Validation/RecoEgamma/python/ElectronMcSignalValidator_gedGsfElectrons_cfi.py
@@ -45,8 +45,8 @@ electronMcSignalValidator = DQMEDAnalyzer('ElectronMcSignalValidator',
   electronTrackCollection = cms.InputTag("electronGsfTracks"),
   electronSeedCollection = cms.InputTag("electronMergedSeeds"),
   offlinePrimaryVertices = cms.InputTag("offlinePrimaryVertices"),
-  pfCandidates = cms.InputTag("particleFlow"), #### NEW PR ####
-  valueMapElectronsToParticleBasedIso = cms.string("gedGsfElectrons"), #### NEW PR ####
+  pfCandidates = cms.InputTag("particleFlow"), 
+  valueMapElectronsToParticleBasedIso = cms.string("gedGsfElectrons"), 
   beamSpot = cms.InputTag("offlineBeamSpot"),
   readAOD = cms.bool(False),
 

--- a/Validation/RecoEgamma/python/ElectronMcSignalValidator_gedGsfElectrons_cfi.py
+++ b/Validation/RecoEgamma/python/ElectronMcSignalValidator_gedGsfElectrons_cfi.py
@@ -24,7 +24,7 @@ electronMcSignalHistosCfg = cms.PSet(
   NbinCORE = cms.int32(21), CORE_min = cms.double(-0.5), CORE_max = cms.double(20.5), # CORE : recCoreNum
   NbinTRACK = cms.int32(41), TRACK_min = cms.double(-0.5), TRACK_max = cms.double(40.5), # TRACK : recTrackNum
   NbinSEED = cms.int32(101), SEED_min = cms.double(-0.5), SEED_max = cms.double(100.5), # SEED : recSeedNum
-  NetBin = cms.int32(100), etMax = cms.double(250.), etMin = cms.double(0.0), #### NEW PR ####
+  IsolationConeSize = cms.double(0.4), NbinsDeltaRPlot = cms.int32(101), RMaxDeltaRPlot = cms.double(0.5), RMinDeltaRPlot = cms.double(0.), # Differential isolation
 )
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
@@ -81,7 +81,7 @@ phase2_hgcal.toModify(
         Etamin = -3.0 ,
         Etamax = 3.0 ,
  
-        NbinOPV = 125, OPV_min = -0.5, OPV_max = 249.5 ,
+        NbinOPV = 125, OPV_min = -0.5, OPV_max = 249.5,
         NbinELE = 100, ELE_min = -0.5, ELE_max = 99.5, 
         NbinCORE = 100, CORE_min = -0.5, CORE_max = 499.5, 
         NbinTRACK = 100, TRACK_min = -0.5, TRACK_max = 999.5,

--- a/Validation/RecoEgamma/python/ElectronMcSignalValidator_gedGsfElectrons_cfi.py
+++ b/Validation/RecoEgamma/python/ElectronMcSignalValidator_gedGsfElectrons_cfi.py
@@ -24,6 +24,7 @@ electronMcSignalHistosCfg = cms.PSet(
   NbinCORE = cms.int32(21), CORE_min = cms.double(-0.5), CORE_max = cms.double(20.5), # CORE : recCoreNum
   NbinTRACK = cms.int32(41), TRACK_min = cms.double(-0.5), TRACK_max = cms.double(40.5), # TRACK : recTrackNum
   NbinSEED = cms.int32(101), SEED_min = cms.double(-0.5), SEED_max = cms.double(100.5), # SEED : recSeedNum
+  NetBin = cms.int32(100), etMax = cms.double(250.), etMin = cms.double(0.0), #### NEW PR ####
 )
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
@@ -44,25 +45,28 @@ electronMcSignalValidator = DQMEDAnalyzer('ElectronMcSignalValidator',
   electronTrackCollection = cms.InputTag("electronGsfTracks"),
   electronSeedCollection = cms.InputTag("electronMergedSeeds"),
   offlinePrimaryVertices = cms.InputTag("offlinePrimaryVertices"),
+  pfCandidates = cms.InputTag("particleFlow"), #### NEW PR ####
+  valueMapElectronsToParticleBasedIso = cms.string("gedGsfElectrons"), #### NEW PR ####
   beamSpot = cms.InputTag("offlineBeamSpot"),
   readAOD = cms.bool(False),
 
-  isoFromDepsTk03            = cms.InputTag(""),
-  isoFromDepsTk04            = cms.InputTag(""),
-  isoFromDepsEcalFull03      = cms.InputTag(""),
-  isoFromDepsEcalFull04      = cms.InputTag(""),
-  isoFromDepsEcalReduced03   = cms.InputTag(""),
-  isoFromDepsEcalReduced04   = cms.InputTag(""),
-  isoFromDepsHcal03          = cms.InputTag(""),
-  isoFromDepsHcal04          = cms.InputTag(""),
-  
+  #isoFromDepsTk03            = cms.InputTag(""),
+  #isoFromDepsTk04            = cms.InputTag(""),
+  #isoFromDepsEcalFull03      = cms.InputTag(""),
+  #isoFromDepsEcalFull04      = cms.InputTag(""),
+  #isoFromDepsEcalReduced03   = cms.InputTag(""),
+  #isoFromDepsEcalReduced04   = cms.InputTag(""),
+  #isoFromDepsHcal03          = cms.InputTag(""),
+  #isoFromDepsHcal04          = cms.InputTag(""),
+
   MaxPt = cms.double(100.0),
   DeltaR = cms.double(0.05),
   MaxAbsEta = cms.double(2.5),
   MaxAbsEtaExtended = cms.double(3.0),
   MatchingID = cms.vint32(11,-11),
   MatchingMotherID = cms.vint32(23,24,-24,32,990),
-  histosCfg = cms.PSet(electronMcSignalHistosCfg)
+  histosCfg = cms.PSet(electronMcSignalHistosCfg),
+  analyzerName = cms.string('ElectronMcSignalValidator'),
 )
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal

--- a/Validation/RecoEgamma/test/ElectronMcSignalHistos.txt
+++ b/Validation/RecoEgamma/test/ElectronMcSignalHistos.txt
@@ -10,7 +10,9 @@ ElectronMcSignalValidator/h_recSeedNum                      1 1 1 1
 Basic electron quantities
 
 ElectronMcSignalValidator/h_ele_charge                      1 1 1 0
-ElectronMcSignalValidator/h_ele_vertexPt                    1 1 1 0
+ElectronMcSignalValidator/h_ele_vertexPt                    1 1 0 0
+ElectronMcSignalValidator/h_ele_vertexPt_EB                 1 1 0 0
+ElectronMcSignalValidator/h_ele_vertexPt_EE                 1 1 1 0
 ElectronMcSignalValidator/h_ele_vertexEta                   1 1 1 0
 ElectronMcSignalValidator/h_ele_vertexPhi                   1 1 1 0
 ElectronMcSignalValidator/h_ele_vertexP                     1 1 1 0
@@ -19,7 +21,6 @@ ElectronMcSignalValidator/h_ele_vertexY                     1 1 1 0
 ElectronMcSignalValidator/h_ele_vertexZ                     1 1 1 0
 ElectronMcSignalValidator/h_ele_vertexTIP                   1 1 1 0
 ElectronMcSignalValidator/h_ele_Et                          1 1 1 0
-ElectronMcSignalValidator/h_mc_Eta_matched                  1 1 0 0
 ElectronMcSignalValidator/h_mc_Eta_Extended_matched         1 1 1 0
 ElectronMcSignalValidator/h_ele_outerP_mode                 1 1 1 0
 ElectronMcSignalValidator/h_ele_outerPt_mode                1 1 1 0
@@ -65,7 +66,6 @@ ElectronMcSignalValidator/h_ele_EtaMnEtaTrue_endcaps        1 1 1 0
 ElectronMcSignalValidator/h_ele_PhiMnPhiTrue                1 1 0 0
 ElectronMcSignalValidator/h_ele_PhiMnPhiTrue_barrel         1 1 0 0
 ElectronMcSignalValidator/h_ele_PhiMnPhiTrue_endcaps        1 1 1 0
-ElectronMcSignalValidator/h_ele_PoPtrueVsEta_pfx            0 1 0 0
 ElectronMcSignalValidator/h_ele_PoPtrueVsEta_Extended_pfx   0 1 1 0
 ElectronMcSignalValidator/h_ele_PoPtrueVsPhi_pfx            0 1 1 0
 ElectronMcSignalValidator/h_scl_EoEtruePfVsEg_pfy           0 1 1 0
@@ -106,7 +106,6 @@ ElectronMcSignalValidator/h_ele_dPhiSc_propVtx              1 1 0 0
 ElectronMcSignalValidator/h_ele_dPhiSc_propVtx_barrel       1 1 0 0
 ElectronMcSignalValidator/h_ele_dPhiSc_propVtx_endcaps      1 1 1 0
 ElectronMcSignalValidator/h_ele_dPhiSc_propVtx_Extended     1 1 1 0
-ElectronMcSignalValidator/h_ele_EoPVsEta_pfx                0 1 0 0
 ElectronMcSignalValidator/h_ele_EoPVsEta_Extended_pfx       0 1 1 0
 ElectronMcSignalValidator/h_ele_EoPoutVsEta_pfx             0 1 1 0
 ElectronMcSignalValidator/h_ele_EeleOPoutVsEta_pfx          0 1 1 1
@@ -161,8 +160,7 @@ ElectronMcSignalValidator/h_ele_lostHits_barrel             1 1 0 0
 ElectronMcSignalValidator/h_ele_lostHits_endcaps            1 1 1 0
 ElectronMcSignalValidator/h_ele_ambiguousTracks             1 1 1 0
 ElectronMcSignalValidator/h_ele_chi2VsEta_pfx               0 1 1 0
-ElectronMcSignalValidator/h_ele_foundHitsVsEta_pfx          0 1 0 0
-ElectronMcSignalValidator/h_ele_foundHitsVsEta_Extended_pfx   0 1 1 0
+ElectronMcSignalValidator/h_ele_foundHitsVsEta_Extended_pfx 0 1 1 0
 ElectronMcSignalValidator/h_ele_ambiguousTracksVsEta_pfx    0 1 1 1
 
 Electron seeds
@@ -221,7 +219,15 @@ ElectronMcSignalValidator/h_ele_hcalTowerSumEtBc_dr03_depth1_barrel  1 1 0 0
 ElectronMcSignalValidator/h_ele_hcalTowerSumEtBc_dr03_depth1_endcaps 1 1 1 0
 ElectronMcSignalValidator/h_ele_hcalTowerSumEtBc_dr03_depth2         1 1 0 0
 ElectronMcSignalValidator/h_ele_hcalTowerSumEtBc_dr03_depth2_barrel  1 1 0 0
-ElectronMcSignalValidator/h_ele_hcalTowerSumEtBc_dr03_depth2_endcaps 1 1 1 1
+ElectronMcSignalValidator/h_ele_hcalTowerSumEtBc_dr03_depth2_endcaps 1 1 1 0
+ElectronMcSignalValidator/h_ele_ecalPFClusterIso                     1 1 0 0
+ElectronMcSignalValidator/h_ele_ecalPFClusterIso_barrel              1 1 0 0
+ElectronMcSignalValidator/h_ele_ecalPFClusterIso_endcaps             1 1 1 0
+ElectronMcSignalValidator/h_ele_ecalPFClusterIso_Extended            1 1 1 0
+ElectronMcSignalValidator/h_ele_hcalPFClusterIso                     1 1 0 0
+ElectronMcSignalValidator/h_ele_hcalPFClusterIso_barrel              1 1 0 0
+ElectronMcSignalValidator/h_ele_hcalPFClusterIso_endcaps             1 1 1 0
+ElectronMcSignalValidator/h_ele_hcalPFClusterIso_Extended            1 1 1 1
 
 Distributions for all reconstructed electrons (i.e. not requiring a match with mc truth)
 
@@ -230,13 +236,13 @@ ElectronMcSignalValidator/h_ele_EseedOP_all         1 1 1 0
 ElectronMcSignalValidator/h_ele_EoPout_all          1 1 1 0
 ElectronMcSignalValidator/h_ele_EeleOPout_all       1 1 1 0
 ElectronMcSignalValidator/h_ele_TIP_all             1 1 1 0
-ElectronMcSignalValidator/h_ele_dEtaSc_propVtx_all  1 1 0 0
+ElectronMcSignalValidator/h_ele_dEtaSc_propVtx_all  1 1 1 0
+ElectronMcSignalValidator/h_ele_dPhiSc_propVtx_all  1 1 1 0
 ElectronMcSignalValidator/h_ele_dEtaCl_propOut_all  1 1 1 0
-ElectronMcSignalValidator/h_ele_dPhiSc_propVtx_all  1 1 0 0
 ElectronMcSignalValidator/h_ele_dPhiCl_propOut_all  1 1 1 0
-ElectronMcSignalValidator/h_ele_HoE_all             1 1 0 0
+ElectronMcSignalValidator/h_ele_HoE_all             1 1 1 0
 ElectronMcSignalValidator/h_ele_HoE_bc_all          1 1 1 0
-ElectronMcSignalValidator/h_ele_mee_all             1 1 0 0
+ElectronMcSignalValidator/h_ele_mee_all             1 1 1 0
 ElectronMcSignalValidator/h_ele_mee_os              1 1 1 1
 
 Charge mis-ID
@@ -282,7 +288,16 @@ ElectronMcSignalValidator/h_ele_neutralHadronRelativeIso_Extended  1 1 1 0
 ElectronMcSignalValidator/h_ele_photonRelativeIso           1 1 0 0
 ElectronMcSignalValidator/h_ele_photonRelativeIso_barrel    1 1 0 0
 ElectronMcSignalValidator/h_ele_photonRelativeIso_endcaps   1 1 1 0
-ElectronMcSignalValidator/h_ele_photonRelativeIso_Extended  1 1 1 1
+ElectronMcSignalValidator/h_ele_photonRelativeIso_Extended  1 1 1 0
+ElectronMcSignalValidator/h_ele_dRElectronsPFcand_ChHad_unCleaned    1 1 0 0
+ElectronMcSignalValidator/h_ele_dRElectronsPFcand_ChHad_unCleaned_barrel   1 1 0 0
+ElectronMcSignalValidator/h_ele_dRElectronsPFcand_ChHad_unCleaned_endcaps  1 1 1 0
+ElectronMcSignalValidator/h_ele_dRElectronsPFcand_NeuHad_unCleaned    1 1 0 0
+ElectronMcSignalValidator/h_ele_dRElectronsPFcand_NeuHad_unCleaned_barrel   1 1 0 0
+ElectronMcSignalValidator/h_ele_dRElectronsPFcand_NeuHad_unCleaned_endcaps  1 1 1 0
+ElectronMcSignalValidator/h_ele_dRElectronsPFcand_Pho_unCleaned    1 1 0 0
+ElectronMcSignalValidator/h_ele_dRElectronsPFcand_Pho_unCleaned_barrel   1 1 0 0
+ElectronMcSignalValidator/h_ele_dRElectronsPFcand_Pho_unCleaned_endcaps  1 1 1 1
 
 Conversion rejection information
 
@@ -297,9 +312,7 @@ ElectronMcSignalValidator/h_ele_convRadius_all  1 1 1 1
 
 Reconstruction efficiency
 
-ElectronMcSignalValidator/h_ele_absetaEff   0 1 0 0 0 ElectronMcSignalValidator/h_mc_AbsEta_matched ElectronMcSignalValidator/h_mc_AbsEta
 ElectronMcSignalValidator/h_ele_absetaEff_Extended   0 1 1 0 0 ElectronMcSignalValidator/h_mc_AbsEta_Extended_matched ElectronMcSignalValidator/h_mc_AbsEta_Extended
-ElectronMcSignalValidator/h_ele_etaEff      0 1 0 0 0 ElectronMcSignalValidator/h_mc_Eta_matched    ElectronMcSignalValidator/h_mc_Eta    
 ElectronMcSignalValidator/h_ele_etaEff_Extended      0 1 1 0 0 ElectronMcSignalValidator/h_mc_Eta_Extended_matched    ElectronMcSignalValidator/h_mc_Eta_Extended
 ElectronMcSignalValidator/h_ele_ptEff       0 1 1 0 0 ElectronMcSignalValidator/h_mc_Pt_matched     ElectronMcSignalValidator/h_mc_Pt     
 ElectronMcSignalValidator/h_ele_phiEff      0 1 1 0 0 ElectronMcSignalValidator/h_mc_Phi_matched    ElectronMcSignalValidator/h_mc_Phi    

--- a/Validation/RecoEgamma/test/ElectronMcSignalHistosPt1000.txt
+++ b/Validation/RecoEgamma/test/ElectronMcSignalHistosPt1000.txt
@@ -10,7 +10,9 @@ ElectronMcSignalValidatorPt1000/h_recSeedNum                      1 1 1 1
 Basic electron quantities
 
 ElectronMcSignalValidatorPt1000/h_ele_charge                      1 1 1 0
-ElectronMcSignalValidatorPt1000/h_ele_vertexPt                    1 1 1 0
+ElectronMcSignalValidatorPt1000/h_ele_vertexPt                    1 1 0 0
+ElectronMcSignalValidatorPt1000/h_ele_vertexPt_EB                 1 1 0 0
+ElectronMcSignalValidatorPt1000/h_ele_vertexPt_EE                 1 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_vertexEta                   1 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_vertexPhi                   1 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_vertexP                     1 1 1 0
@@ -48,16 +50,18 @@ ElectronMcSignalValidatorPt1000/h_scl_EoEtrue_barrel_new_phigap   1 1 1 0
 ElectronMcSignalValidatorPt1000/h_scl_EoEtrue_ebeegap_new         1 1 1 0
 ElectronMcSignalValidatorPt1000/h_scl_EoEtrue_endcaps_new         1 1 0 0
 ElectronMcSignalValidatorPt1000/h_scl_EoEtrue_endcaps_new_deegap  1 1 1 0
+ElectronMcSignalValidatorPt1000/h_scl_EoEtrue_endcaps_new_Extended 1 1 1 0
 ElectronMcSignalValidatorPt1000/h_scl_bcl_EtotoEtrue              1 1 0 0
 ElectronMcSignalValidatorPt1000/h_scl_bcl_EtotoEtrue_barrel       1 1 0 0
 ElectronMcSignalValidatorPt1000/h_scl_bcl_EtotoEtrue_endcaps      1 1 1 0
+ElectronMcSignalValidatorPt1000/h_scl_bcl_EtotoEtrue_Extended     1 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_EtaMnEtaTrue                1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_EtaMnEtaTrue_barrel         1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_EtaMnEtaTrue_endcaps        1 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_PhiMnPhiTrue                1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_PhiMnPhiTrue_barrel         1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_PhiMnPhiTrue_endcaps        1 1 1 0
-ElectronMcSignalValidatorPt1000/h_ele_PoPtrueVsEta_pfx            0 1 1 0
+ElectronMcSignalValidatorPt1000/h_ele_PoPtrueVsEta_Extended_pfx   0 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_PoPtrueVsPhi_pfx            0 1 1 0
 ElectronMcSignalValidatorPt1000/h_scl_EoEtruePfVsEg_pfy           0 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_EtaMnEtaTrueVsEta_pfx       0 1 1 0
@@ -86,6 +90,7 @@ ElectronMcSignalValidatorPt1000/h_ele_dEtaEleCl_propOut_endcaps   1 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_dEtaSc_propVtx              1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_dEtaSc_propVtx_barrel       1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_dEtaSc_propVtx_endcaps      1 1 1 0
+ElectronMcSignalValidatorPt1000/h_ele_dEtaSc_propVtx_Extended     1 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_dPhiCl_propOut              1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_dPhiCl_propOut_barrel       1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_dPhiCl_propOut_endcaps      1 1 1 0
@@ -95,7 +100,8 @@ ElectronMcSignalValidatorPt1000/h_ele_dPhiEleCl_propOut_endcaps   1 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_dPhiSc_propVtx              1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_dPhiSc_propVtx_barrel       1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_dPhiSc_propVtx_endcaps      1 1 1 0
-ElectronMcSignalValidatorPt1000/h_ele_EoPVsEta_pfx                0 1 1 0
+ElectronMcSignalValidatorPt1000/h_ele_dPhiSc_propVtx_Extended     1 1 1 0
+ElectronMcSignalValidatorPt1000/h_ele_EoPVsEta_Extended_pfx       0 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_EoPoutVsEta_pfx             0 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_EeleOPoutVsEta_pfx          0 1 1 1
 
@@ -104,6 +110,7 @@ Electron Cluster shapes
 ElectronMcSignalValidatorPt1000/h_ele_HoE                         1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_HoE_barrel                  1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_HoE_endcaps                 1 1 1 0
+ElectronMcSignalValidatorPt1000/h_ele_HoE_Extended                1 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_HoE_bc                      1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_HoE_bc_barrel               1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_HoE_bc_endcaps              1 1 1 0
@@ -120,6 +127,7 @@ ElectronMcSignalValidatorPt1000/h_scl_sigietaieta_endcaps         1 1 1 0
 ElectronMcSignalValidatorPt1000/h_scl_full5x5_sigietaieta                 1 1 0 0
 ElectronMcSignalValidatorPt1000/h_scl_full5x5_sigietaieta_barrel          1 1 0 0
 ElectronMcSignalValidatorPt1000/h_scl_full5x5_sigietaieta_endcaps         1 1 1 0
+ElectronMcSignalValidatorPt1000/h_scl_full5x5_sigietaieta_Extended        1 1 1 0
 ElectronMcSignalValidatorPt1000/h_scl_E1x5                        1 1 0 0
 ElectronMcSignalValidatorPt1000/h_scl_E1x5_barrel                 1 1 0 0
 ElectronMcSignalValidatorPt1000/h_scl_E1x5_endcaps                1 1 1 0
@@ -144,7 +152,7 @@ ElectronMcSignalValidatorPt1000/h_ele_lostHits_barrel             1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_lostHits_endcaps            1 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_ambiguousTracks             1 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_chi2VsEta_pfx               0 1 1 0
-ElectronMcSignalValidatorPt1000/h_ele_foundHitsVsEta_pfx          0 1 1 0
+ElectronMcSignalValidatorPt1000/h_ele_foundHitsVsEta_Extended_pfx 0 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_ambiguousTracksVsEta_pfx    0 1 1 1
 
 Electron seeds
@@ -173,6 +181,7 @@ ElectronMcSignalValidatorPt1000/h_ele_PinMnPout_mode              1 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_fbrem                       1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_fbrem_barrel                1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_fbrem_endcaps               1 1 1 0
+ElectronMcSignalValidatorPt1000/h_ele_fbrem_Extended              1 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_superclusterfbrem                               1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_superclusterfbrem_barrel                        1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_superclusterfbrem_endcaps                       1 1 1 0
@@ -197,30 +206,20 @@ ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEt_dr03_depth1_endcaps  1 1 1 
 ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEt_dr03_depth2          1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEt_dr03_depth2_barrel   1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEt_dr03_depth2_endcaps  1 1 1 0
-ElectronMcSignalValidatorPt1000/h_ele_tkSumPt_dr04                        1 1 0 0
-ElectronMcSignalValidatorPt1000/h_ele_tkSumPt_dr04_barrel                 1 1 0 0
-ElectronMcSignalValidatorPt1000/h_ele_tkSumPt_dr04_endcaps                1 1 1 0
-ElectronMcSignalValidatorPt1000/h_ele_ecalRecHitSumEt_dr04                1 1 0 0
-ElectronMcSignalValidatorPt1000/h_ele_ecalRecHitSumEt_dr04_barrel         1 1 0 0
-ElectronMcSignalValidatorPt1000/h_ele_ecalRecHitSumEt_dr04_endcaps        1 1 1 0
-ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEt_dr04_depth1          1 1 0 0
-ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEt_dr04_depth1_barrel   1 1 0 0
-ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEt_dr04_depth1_endcaps  1 1 1 0
-ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEt_dr04_depth2          1 1 0 0
-ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEt_dr04_depth2_barrel   1 1 0 0
-ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEt_dr04_depth2_endcaps  1 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEtBc_dr03_depth1         1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEtBc_dr03_depth1_barrel  1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEtBc_dr03_depth1_endcaps 1 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEtBc_dr03_depth2         1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEtBc_dr03_depth2_barrel  1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEtBc_dr03_depth2_endcaps 1 1 1 0
-ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEtBc_dr04_depth1         1 1 0 0
-ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEtBc_dr04_depth1_barrel  1 1 0 0
-ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEtBc_dr04_depth1_endcaps 1 1 1 0
-ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEtBc_dr04_depth2         1 1 0 0
-ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEtBc_dr04_depth2_barrel  1 1 0 0
-ElectronMcSignalValidatorPt1000/h_ele_hcalTowerSumEtBc_dr04_depth2_endcaps 1 1 1 1
+ElectronMcSignalValidatorPt1000/h_ele_ecalPFClusterIso                     1 1 0 0
+ElectronMcSignalValidatorPt1000/h_ele_ecalPFClusterIso_barrel              1 1 0 0
+ElectronMcSignalValidatorPt1000/h_ele_ecalPFClusterIso_endcaps             1 1 1 0
+ElectronMcSignalValidatorPt1000/h_ele_ecalPFClusterIso_Extended            1 1 1 0
+ElectronMcSignalValidatorPt1000/h_ele_hcalPFClusterIso                     1 1 0 0
+ElectronMcSignalValidatorPt1000/h_ele_hcalPFClusterIso_barrel              1 1 0 0
+ElectronMcSignalValidatorPt1000/h_ele_hcalPFClusterIso_endcaps             1 1 1 0
+ElectronMcSignalValidatorPt1000/h_ele_hcalPFClusterIso_Extended            1 1 1 1
 
 Distributions for all reconstructed electrons (i.e. not requiring a match with mc truth)
 
@@ -251,6 +250,7 @@ Provenance
 ElectronMcSignalValidatorPt1000/h_ele_provenance                  0 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_provenance_barrel           0 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_provenance_endcaps          0 1 1 0
+ElectronMcSignalValidatorPt1000/h_ele_provenance_Extended         0 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_mva                         1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_mva_barrel                  1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_mva_endcaps                 1 1 1 0
@@ -272,12 +272,24 @@ ElectronMcSignalValidatorPt1000/h_ele_photonIso_endcaps          1 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_chargedHadronRelativeIso           1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_chargedHadronRelativeIso_barrel    1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_chargedHadronRelativeIso_endcaps   1 1 1 0
+ElectronMcSignalValidatorPt1000/h_ele_chargedHadronRelativeIso_Extended  1 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_neutralHadronRelativeIso           1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_neutralHadronRelativeIso_barrel    1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_neutralHadronRelativeIso_endcaps   1 1 1 0
+ElectronMcSignalValidatorPt1000/h_ele_neutralHadronRelativeIso_Extended  1 1 1 0
 ElectronMcSignalValidatorPt1000/h_ele_photonRelativeIso           1 1 0 0
 ElectronMcSignalValidatorPt1000/h_ele_photonRelativeIso_barrel    1 1 0 0
-ElectronMcSignalValidatorPt1000/h_ele_photonRelativeIso_endcaps   1 1 1 1
+ElectronMcSignalValidatorPt1000/h_ele_photonRelativeIso_endcaps   1 1 1 0
+ElectronMcSignalValidatorPt1000/h_ele_photonRelativeIso_Extended  1 1 1 0
+ElectronMcSignalValidatorPt1000/h_ele_dRElectronsPFcand_ChHad_unCleaned    1 1 0 0
+ElectronMcSignalValidatorPt1000/h_ele_dRElectronsPFcand_ChHad_unCleaned_barrel   1 1 0 0
+ElectronMcSignalValidatorPt1000/h_ele_dRElectronsPFcand_ChHad_unCleaned_endcaps  1 1 1 0
+ElectronMcSignalValidatorPt1000/h_ele_dRElectronsPFcand_NeuHad_unCleaned    1 1 0 0
+ElectronMcSignalValidatorPt1000/h_ele_dRElectronsPFcand_NeuHad_unCleaned_barrel   1 1 0 0
+ElectronMcSignalValidatorPt1000/h_ele_dRElectronsPFcand_NeuHad_unCleaned_endcaps  1 1 1 0
+ElectronMcSignalValidatorPt1000/h_ele_dRElectronsPFcand_Pho_unCleaned    1 1 0 0
+ElectronMcSignalValidatorPt1000/h_ele_dRElectronsPFcand_Pho_unCleaned_barrel   1 1 0 0
+ElectronMcSignalValidatorPt1000/h_ele_dRElectronsPFcand_Pho_unCleaned_endcaps  1 1 1 1
 
 Conversion rejection information
 
@@ -292,8 +304,8 @@ ElectronMcSignalValidatorPt1000/h_ele_convRadius_all  1 1 1 1
 
 Reconstruction efficiency
 
-ElectronMcSignalValidatorPt1000/h_ele_absetaEff   0 1 1 0 0 ElectronMcSignalValidatorPt1000/h_mc_AbsEta_matched ElectronMcSignalValidatorPt1000/h_mc_AbsEta 
-ElectronMcSignalValidatorPt1000/h_ele_etaEff      0 1 1 0 0 ElectronMcSignalValidatorPt1000/h_mc_Eta_matched    ElectronMcSignalValidatorPt1000/h_mc_Eta    
+ElectronMcSignalValidatorPt1000/h_ele_absetaEff_Extended   0 1 1 0 0 ElectronMcSignalValidatorPt1000/h_mc_AbsEta_Extended_matched ElectronMcSignalValidatorPt1000/h_mc_AbsEta_Extended 
+ElectronMcSignalValidatorPt1000/h_ele_etaEff_Extended      0 1 1 0 0 ElectronMcSignalValidatorPt1000/h_mc_Eta_Extended_matched    ElectronMcSignalValidatorPt1000/h_mc_Eta_Extended    
 ElectronMcSignalValidatorPt1000/h_ele_ptEff       0 1 1 0 0 ElectronMcSignalValidatorPt1000/h_mc_Pt_matched     ElectronMcSignalValidatorPt1000/h_mc_Pt     
 ElectronMcSignalValidatorPt1000/h_ele_phiEff      0 1 1 0 0 ElectronMcSignalValidatorPt1000/h_mc_Phi_matched    ElectronMcSignalValidatorPt1000/h_mc_Phi    
 ElectronMcSignalValidatorPt1000/h_ele_zEff        0 1 1 0 0 ElectronMcSignalValidatorPt1000/h_mc_Z_matched      ElectronMcSignalValidatorPt1000/h_mc_Z      

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidation_gedGsfElectrons_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidation_gedGsfElectrons_cfg.py
@@ -36,13 +36,13 @@ dqmStoreStats.runOnEndJob = cms.untracked.bool(True)
 
 print("reading files ...")
 # max_skipped = 165
-max_number = -1  # 10 # number of events
+max_number = -1  # 10 # number of events (-1 : default)
 process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(max_number))
 # process.source = cms.Source ("PoolSource",skipEvents = cms.untracked.uint32(max_skipped), fileNames = cms.untracked.vstring(),secondaryFileNames = cms.untracked.vstring())
 
 data = os.environ['data']
 flist = dd.getCMSdata(data)
-print(flist)
+print('flist : ', flist)
 process.source = cms.Source("PoolSource",
     #eventsToProcess = cms.untracked.VEventRange('1:38-1:40'),
     fileNames=cms.untracked.vstring(*flist)
@@ -86,6 +86,7 @@ from Configuration.AlCa.autoCond import autoCond
 # CONFIGURATION
 process.load("Validation.RecoEgamma.electronIsoFromDeps_cff")
 process.load("Validation.RecoEgamma.ElectronMcSignalValidator_gedGsfElectrons_cfi")
+#process.load("Validation.RecoEgamma.pfElectronMcSignalValidator_gedGsfElectrons_cfi")
 
 # load DQM
 process.load("DQMServices.Core.DQM_cfg")
@@ -102,6 +103,8 @@ process.electronMcSignalValidator.OutputFolderName = cms.string("EgammaV/Electro
 
 # process.p = cms.Path(process.electronIsoFromDeps * process.electronMcSignalValidator * process.MEtoEDMConverter * process.dqmStoreStats)
 #process.p = cms.Path(process.electronMcSignalValidator * process.MEtoEDMConverter * process.dqmStoreStats)
+
+#process.p = cms.Path(process.electronMcSignalValidator * process.pfElectronsValidation * process.MEtoEDMConverter)
 process.p = cms.Path(process.electronMcSignalValidator * process.MEtoEDMConverter)
 
 process.outpath = cms.EndPath(

--- a/Validation/RecoEgamma/test/electronValidationCheck_Env.py
+++ b/Validation/RecoEgamma/test/electronValidationCheck_Env.py
@@ -24,18 +24,21 @@ class env:
             print('Existing Sample name:', sampleName, ' - ', os.environ['DD_SAMPLE'])
 
     def beginTag(self):
-        beginTag = 'Phase2'
-        #beginTag = 'Run3'
+        #beginTag = 'Phase2'
+        beginTag = 'Run3'
         return beginTag
 
     def dd_tier(self):
         dd_tier = 'GEN-SIM-RECO'
-        dd_tier = 'MINIAODSIM'
+        #dd_tier = 'MINIAODSIM'
         return dd_tier
 
     def tag_startup(self):
         #tag_startup = '125X_mcRun3_2022_realistic_v3'
-        tag_startup = '140X_mcRun4_realistic_v4_STD_2026D110_noPU'
+        #tag_startup = '140X_mcRun4_realistic_v4_STD_2026D110_noPU'
+        tag_startup = '150X_mcRun3_2025_realistic_v2_STD_RecycledGS_2025_noPU'
+        tag_startup = 'PU_151X_mcRun3_2025_realistic_v3_STD_2025_PU'
+        #tag_startup = 'PU_142X_mcRun3_2025_realistic_v5_STD_2025_PU'
         # tag_startup = '113X_mcRun3_2021_realistic_v7'
         return tag_startup
 


### PR DESCRIPTION
#### PR description:

Adding plots which are present in the PhotonValidation as to enable comparisons. Those plots are particularly sensitive to details of the supercluster reconstruction. 
|PhotonValidation|ElectronValidation|
|---|---|
| <img width="300" height="300" alt="Nancy" src="https://github.com/user-attachments/assets/330bad7e-cd97-482e-bb67-b991c49fc0b1" /> | <img width="320" height="300" alt="Nancy" src="https://github.com/user-attachments/assets/ac8123c3-4c36-427d-9fe4-04a9cceac0c9" /> |

A bit of cleanup of obsolete code has also been done

#### PR validation:

compilation is OK, basics tests (scram b runtests or local tests) are OK too.
runTheMatrix.py -l limited -i all --ibeos tests are fine
42 27 19 15 1 0 0 0 0 0 0 tests passed, 8 14 8 1 0 0 0 0 0 0 0 failed
the errors are DAS error (see runall-report-step123-.log).
runall-report-step123-.logation is OK, basics tests (scram b runtests or local tests) are OK too.
[runall-report-step123-.log](https://github.com/user-attachments/files/22298628/runall-report-step123-.log)

@beaudett