### PR TITLE
[15.0.X] Adjust `trackingIters01` process modifier usage to be functional in Run3 scenarios

### DIFF
--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -33,18 +33,20 @@ trackingPhase2PU140.toReplaceWith(convClusters, _phase2trackClusterRemover.clone
     oldClusterRemovalInfo                    = 'detachedQuadStepClusters',
     overrideTrkQuals                         = 'detachedQuadStepSelector:detachedQuadStepTrk'
 ))
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 from Configuration.ProcessModifiers.trackingIters01_cff import trackingIters01
-(trackingIters01 & ~trackingPhase2PU140).toModify(convClusters,
-                                                  trajectories          = 'highPtTripletStepTracks',
-                                                  oldClusterRemovalInfo = 'highPtTripletStepClusters',
-                                                  trackClassifier       = 'highPtTripletStep:QualityMasks',
-                                                  )
+(trackingIters01 & trackingPhase1).toModify(convClusters,
+                                            trajectories          = 'highPtTripletStepTracks',
+                                            oldClusterRemovalInfo = 'highPtTripletStepClusters',
+                                            trackClassifier       = 'highPtTripletStep:QualityMasks',
+                                            )
 
 (trackingIters01 & trackingPhase2PU140).toModify(convClusters,
                                                  trajectories          = "highPtTripletStepTracks",
                                                  oldClusterRemovalInfo = "highPtTripletStepClusters",
                                                  overrideTrkQuals      = "highPtTripletStepSelector:highPtTripletStep"
                                                  )
+
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 (trackingIters01 & trackingPhase2PU140 & trackingLST).toModify(convClusters,
                                                                overrideTrkQuals      = ""

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -34,15 +34,21 @@ trackingPhase2PU140.toReplaceWith(convClusters, _phase2trackClusterRemover.clone
     overrideTrkQuals                         = 'detachedQuadStepSelector:detachedQuadStepTrk'
 ))
 from Configuration.ProcessModifiers.trackingIters01_cff import trackingIters01
-trackingIters01.toModify(convClusters,
-                         trajectories          = "highPtTripletStepTracks",
-                         oldClusterRemovalInfo = "highPtTripletStepClusters",
-                         overrideTrkQuals      = "highPtTripletStepSelector:highPtTripletStep"
-)
+(trackingIters01 & ~trackingPhase2PU140).toModify(convClusters,
+                                                  trajectories          = 'highPtTripletStepTracks',
+                                                  oldClusterRemovalInfo = 'highPtTripletStepClusters',
+                                                  trackClassifier       = 'highPtTripletStep:QualityMasks',
+                                                  )
+
+(trackingIters01 & trackingPhase2PU140).toModify(convClusters,
+                                                 trajectories          = "highPtTripletStepTracks",
+                                                 oldClusterRemovalInfo = "highPtTripletStepClusters",
+                                                 overrideTrkQuals      = "highPtTripletStepSelector:highPtTripletStep"
+                                                 )
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 (trackingIters01 & trackingPhase2PU140 & trackingLST).toModify(convClusters,
-                         overrideTrkQuals      = ""
-)
+                                                               overrideTrkQuals      = ""
+                                                               )
 
 _convLayerPairsStripOnlyLayers = ['TIB1+TID1_pos', 
                                  'TIB1+TID1_neg', 

--- a/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
@@ -110,15 +110,21 @@ trackingPhase2PU140.toReplaceWith(earlyGeneralTracks, _trackListMerger.clone(
     )
 )
 from Configuration.ProcessModifiers.trackingIters01_cff import trackingIters01
-trackingIters01.toModify(earlyGeneralTracks,
-                         TrackProducers = ['initialStepTracks', 'highPtTripletStepTracks'],
-                         hasSelector = [1,1],
-                         indivShareFrac = [1,0.16],
-                         selectedTrackQuals = ['initialStepSelector:initialStep',
-                                               'highPtTripletStepSelector:highPtTripletStep'
-                         ],
-                         setsToMerge = {0: dict(tLists = [0,1])}
-)
+(trackingPhase2PU140 & trackingIters01).toModify(earlyGeneralTracks,
+                                                 TrackProducers = ['initialStepTracks', 'highPtTripletStepTracks'],
+                                                 hasSelector = [1,1],
+                                                 indivShareFrac = [1,0.16],
+                                                 selectedTrackQuals = ['initialStepSelector:initialStep',
+                                                                       'highPtTripletStepSelector:highPtTripletStep'
+                                                                       ],
+                                                 setsToMerge = {0: dict(tLists = [0,1])}
+                                                 )
+
+(~trackingPhase2PU140 & trackingIters01).toModify(earlyGeneralTracks,
+                                                  trackProducers = ['initialStepTracks', 'highPtTripletStepTracks'],
+                                                  inputClassifiers = cms.vstring('initialStep','highPtTripletStep')
+                                                  )
+
 from Configuration.ProcessModifiers.vectorHits_cff import vectorHits
 def _extend_pixelLess(x):
     x.TrackProducers += ['pixelLessStepTracks']

--- a/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
@@ -50,8 +50,13 @@ _iterations_trackingPhase1 = [
 
 from Configuration.ProcessModifiers.displacedTracking_cff import displacedTracking
 displacedTracking.toModify(_iterations_trackingPhase1, func=lambda x: x.append('DisplacedGeneralStep'))
-
 _iterations_trackingPhase1.append('JetCoreRegionalStep')
+
+from Configuration.ProcessModifiers.trackingIters01_cff import trackingIters01
+trackingIters01.toModify(
+    _iterations_trackingPhase1,
+    func=lambda x: x.clear() or x.extend(["InitialStep", "HighPtTripletStep"])
+)
 
 _iterations_trackingPhase2PU140_VS = cms.PSet(names = cms.vstring(
     "InitialStep",
@@ -63,8 +68,8 @@ _iterations_trackingPhase2PU140_VS = cms.PSet(names = cms.vstring(
 ))
 from Configuration.ProcessModifiers.vectorHits_cff import vectorHits
 vectorHits.toModify(_iterations_trackingPhase2PU140_VS.names, func=lambda x: x.append('PixelLessStep'))
-from Configuration.ProcessModifiers.trackingIters01_cff import trackingIters01
 trackingIters01.toModify(_iterations_trackingPhase2PU140_VS, names = ["InitialStep", "HighPtTripletStep"])
+
 # apply all procModifiers before this
 _iterations_trackingPhase2PU140 = _iterations_trackingPhase2PU140_VS.names.value()
 


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/48886

#### PR description:

From the original PR description:

> In the context of the Next Generation Triggers Task 3.4 ("[Optimal HLT Calibrations](https://cms-ngt-hlt.docs.cern.ch/Task34/)") we are interested in speeding up the calibration procedures with the aim of implementing real time calibrations for the phase-2 upgrade HLT. 
> A stepping stone towards that, consists in the [*NGT Demonstrator*](https://indico.cern.ch/event/1504131/contributions/6341017/attachments/3028520/5345755/NGT-HLT_OptimalCalibrations_AlCaDBWorkshop_10.03.2025_Zarucki.pdf#page=7) which we plan to deploy and operate during Run 3 (late 2025 and 2026). 
> The "calibration leg" of such demonstrator is planned to run a trimmed down version of the Prompt Calibration Loop delivering [selected alignment and calibrations](https://indico.cern.ch/event/1504131/contributions/6341017/attachments/3028520/5345755/NGT-HLT_OptimalCalibrations_AlCaDBWorkshop_10.03.2025_Zarucki.pdf#page=15). 
> Unfortunately in the current Express / Prompt Calibration Loop reconstruction model a disproportionate amount of resources is spent into reconstructing objects which are not particularly useful for the calibration procedures themselves. 
> A very prominent amount of time is spent in the higher iterative tracking iterations targeting particularly either displaced or soft tracks. 
> To boost the timing of the procedure we're interested in having a version of reconstruction that focuses only on prompt and relatively high momentum tracks.  
> The existing `trackingIters01` process modifier is suitable for such purpose, but its usage had to be slightly modified to support the case in which it is not run in conjunction with the modifier `trackingPhase2PU140`, which is the goal of this PR
> 

#### PR validation:

Run successfully the following script:

```bash
#!/bin/bash -ex                                                                                                                                                                                             

file_list="file:/eos/user/j/jprendi/repacked_files/repacked_0.root,file:/eos/user/j/jprendi/repacked_files/repacked_1.root,file:/eos/user/j/jprendi/repacked_files/repacked_10.root,file:/eos/user/j/jprendi/repacked_files/repacked_11.root,file:/eos/user/j/jprendi/repacked_files/repacked_12.root,file:/eos/user/j/jprendi/repacked_files/repacked_13.root,file:/eos/user/j/jprendi/repacked_files/repacked_14.root,file:/eos/user/j/jprendi/repacked_files/repacked_15.root,file:/eos/user/j/jprendi/repacked_files/repacked_16.root,file:/eos/user/j/jprendi/repacked_files/repacked_17.root,file:/eos/user/j/jprendi/repacked_files/repacked_18.root,file:/eos/user/j/jprendi/repacked_files/repacked_19.root,file:/eos/user/j/jprendi/repacked_files/repacked_2.root,file:/eos/user/j/jprendi/repacked_files/repacked_20.root,file:/eos/user/j/jprendi/repacked_files/repacked_3.root,file:/eos/user/j/jprendi/repacked_files/repacked_4.root,file:/eos/user/j/jprendi/repacked_files/repacked_5.root,file:/eos/user/j/jprendi/repacked_files/repacked_6.root,file:/eos/user/j/jprendi/repacked_files/repacked_7.root,file:/eos/user/j/jprendi/repacked_files/repacked_8.root,file:/eos/user/j/jprendi/repacked_files/repacked_9.root"

cmsDriver.py expressStep2 \
         --conditions 140X_dataRun3_Express_v3 \
         -s RAW2DIGI,RECO,ALCAPRODUCER:SiStripPCLHistos+SiStripCalZeroBias+SiStripCalMinBias+SiStripCalMinBiasAAG+TkAlMinBias+SiPixelCalZeroBias+SiPixelCalSingleMuon+SiPixelCalSingleMuonTight+TkAlZMuMu \
         --datatier ALCARECO --eventcontent ALCARECO --data --process RECO \
         --scenario pp --era Run3 \
         --nThreads 8 \
         --nStreams 8 \
         --procModifiers trackingIters01 \
         -n 1000 --filein "$file_list" \
         --fileout file:step2.root --no_exec \
         --python_filename expressStep2_RAW2DIGI_RECO_ALCAPRODUCER.py

cat <<@EOF>> expressStep2_RAW2DIGI_RECO_ALCAPRODUCER.py
process.load('HLTrigger.Timer.FastTimerService_cfi')
process.FastTimerService.writeJSONSummary = True
process.FastTimerService.jsonFileName = "timing_tracking_upperbound_s2.json"
@EOF

cmsRun expressStep2_RAW2DIGI_RECO_ALCAPRODUCER.py >& step2.log
```

In addition I also checked that the previous use of the modifier in phase-2 target workflows still runs, e.g. via:

```
runTheMatrix.py --what upgrade -l 29634.703,29634.704 -i all --ibeos
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/48886 to CMSSW_15_1_X for 2025 operation purposes - to be used in the NGT demonstrator workflows.