### PR TITLE
remove wf 24834.911

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_Run4.py
+++ b/Configuration/PyReleaseValidation/python/relval_Run4.py
@@ -66,8 +66,6 @@ numWFIB.extend([prefixDet+234.21])   #prodlike PU
 numWFIB.extend([prefixDet+234.9921]) #prodlike premix stage1+stage2
 numWFIB.extend([prefixDet+234.114])  #PU, with 10% OT inefficiency
 numWFIB.extend([prefixDet+234.703])  #LST tracking on CPU (initialStep+HighPtTripletStep only)
-#
-numWFIB.extend([24834.911]) #D98 XML, to monitor instability of DD4hep
 
 # Phase-2 HLT tests
 numWFIB.extend([prefixDet+34.7501])# HLTTrackingOnly75e33

--- a/Configuration/PyReleaseValidation/scripts/README.md
+++ b/Configuration/PyReleaseValidation/scripts/README.md
@@ -334,7 +334,7 @@ MC workflows for pp collisions:
 | **Phase2** 	|  	|  	|  	|  	**Geometry** |  	
 | |  	|  	|  	|  	|  	
 | 24834.0 	| RelValTTbar_14TeV 	| phase2_realistic_T25 	| Phase2C17I13M9 	| ExtendedRun4D98 	| (Phase-2 baseline) 	
-| 24834.911 	| TTbar_14TeV_TuneCP5 	| phase2_realistic_T25 	| Phase2C17I13M9 	| DD4hepExtendedRun4D98 	| DD4Hep (HLLHC14TeV BeamSpot) 	
+| 29634.911 	| TTbar_14TeV_TuneCP5 	| phase2_realistic_T33 	| Phase2C17I13M9 	| DD4hepExtendedRun4D110 	| DD4Hep (HLLHC14TeV BeamSpot)
 | 25034.999 	| RelValTTbar_14TeV (PREMIX) 	| phase2_realistic_T25 	| Phase2C17I13M9 	| ExtendedRun4D98 	| AVE_50_BX_25ns_m3p3 	
 | 24896.0 	| RelValCloseByPGun_CE_E_Front_120um 	| phase2_realistic_T25 	| Phase2C17I13M9 	| ExtendedRun4D98 	|  	
 | 24900.0 	| RelValCloseByPGun_CE_H_Coarse_Scint 	| phase2_realistic_T25 	| Phase2C17I13M9 	| ExtendedRun4D98 	|  	

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -130,7 +130,6 @@ if __name__ == '__main__':
             ###### MC (generated from scratch or from RelVals)
             # Phase2
             29634.0,    # RelValTTbar_14TeV                     phase2_realistic_T33        ExtendedRun4D110         (Phase-2 baseline)
-            24834.911,  # Previous DD4hep baseline for monitoring the stability of DD4hep workflow
             29634.911,  # TTbar_14TeV_TuneCP5                   phase2_realistic_T33        DD4hepExtendedRun4D110   DD4Hep (HLLHC14TeV BeamSpot)
             29834.999,  # RelValTTbar_14TeV (PREMIX)            phase2_realistic_T33        ExtendedRun4D110         AVE_50_BX_25ns_m3p3
             29696.0,    # RelValCloseByPGun_CE_E_Front_120um    phase2_realistic_T33        ExtendedRun4D110


### PR DESCRIPTION
#### PR description:

Title says it all. Remove old DD4HEP baseline for unsupported geometry D98.

#### PR validation:

None. Will be tested by the bot.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A