### PR TITLE
CaloCluster forward declaration

### DIFF
--- a/DataFormats/CaloRecHit/interface/CaloClusterCollection.h
+++ b/DataFormats/CaloRecHit/interface/CaloClusterCollection.h
@@ -1,0 +1,19 @@
+#ifndef CaloRecHit_CaloClusterCollection_h
+#define CaloRecHit_CaloClusterCollection_h
+
+#include <vector>
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+#include "DataFormats/Common/interface/Ptr.h"
+#include "DataFormats/Common/interface/PtrVector.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+
+namespace reco {
+  typedef std::vector<CaloCluster> CaloClusterCollection;
+  typedef edm::Ptr<CaloCluster> CaloClusterPtr;
+  typedef edm::PtrVector<CaloCluster> CaloClusterPtrVector;
+  typedef edm::View<CaloCluster> CaloClusterView;
+  typedef CaloClusterPtrVector::iterator CaloCluster_iterator;
+}  // namespace reco
+
+#endif

--- a/DataFormats/CaloRecHit/interface/CaloClusterFwd.h
+++ b/DataFormats/CaloRecHit/interface/CaloClusterFwd.h
@@ -1,11 +1,5 @@
-#ifndef CaloRecHit_CaloClusterCollection_h
-#define CaloRecHit_CaloClusterCollection_h
-
-#include <vector>
-#include "DataFormats/Common/interface/Ref.h"
-#include "DataFormats/Common/interface/RefVector.h"
-#include "DataFormats/Common/interface/Ptr.h"
-#include "DataFormats/Common/interface/PtrVector.h"
+#ifndef CaloRecHit_CaloClusterFwd_h
+#define CaloRecHit_CaloClusterFwd_h
 
 namespace edm {
   template <typename T>
@@ -14,15 +8,6 @@ namespace edm {
 
 namespace reco {
   class CaloCluster;
-  
-  /// collection of CaloCluster objects
-  typedef std::vector<CaloCluster> CaloClusterCollection;
+}
 
-  typedef edm::Ptr<CaloCluster> CaloClusterPtr;
-  typedef edm::PtrVector<CaloCluster> CaloClusterPtrVector;
-  typedef edm::View<CaloCluster> CaloClusterView;
-
-  typedef CaloClusterPtrVector::iterator CaloCluster_iterator;
-
-}  // namespace reco
 #endif

--- a/DataFormats/CaloRecHit/interface/CaloClusterFwd.h
+++ b/DataFormats/CaloRecHit/interface/CaloClusterFwd.h
@@ -7,14 +7,14 @@
 #include "DataFormats/Common/interface/Ptr.h"
 #include "DataFormats/Common/interface/PtrVector.h"
 
-#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
-
 namespace edm {
   template <typename T>
   class View;
 }
 
 namespace reco {
+  class CaloCluster;
+  
   /// collection of CaloCluster objects
   typedef std::vector<CaloCluster> CaloClusterCollection;
 

--- a/DataFormats/CaloRecHit/src/classes.h
+++ b/DataFormats/CaloRecHit/src/classes.h
@@ -5,3 +5,4 @@
 #include "DataFormats/CaloRecHit/interface/CaloRecHit.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"

--- a/DataFormats/EgammaCandidates/interface/Conversion.h
+++ b/DataFormats/EgammaCandidates/interface/Conversion.h
@@ -17,7 +17,7 @@
 #include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1DFloat.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"
 
 namespace reco {
   class Conversion {

--- a/DataFormats/EgammaReco/interface/PreshowerCluster.h
+++ b/DataFormats/EgammaReco/interface/PreshowerCluster.h
@@ -7,9 +7,9 @@
  */
 //
 #include "DataFormats/Math/interface/Point3D.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"
 #include "DataFormats/EgammaReco/interface/PreshowerClusterFwd.h"
-
 #include <cmath>
 
 namespace reco {

--- a/DataFormats/EgammaReco/interface/SuperCluster.h
+++ b/DataFormats/EgammaReco/interface/SuperCluster.h
@@ -11,7 +11,7 @@
  */
 #include "DataFormats/Math/interface/Point3D.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"

--- a/DataFormats/EgammaTrackReco/interface/TrackCaloClusterAssociation.h
+++ b/DataFormats/EgammaTrackReco/interface/TrackCaloClusterAssociation.h
@@ -7,7 +7,7 @@
 #include "DataFormats/Common/interface/Ptr.h"
 #include "DataFormats/Common/interface/PtrVector.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 
 namespace reco {

--- a/DataFormats/EgammaTrackReco/interface/TrackCandidateCaloClusterAssociation.h
+++ b/DataFormats/EgammaTrackReco/interface/TrackCandidateCaloClusterAssociation.h
@@ -8,7 +8,7 @@
 #include "DataFormats/Common/interface/Ptr.h"
 #include "DataFormats/Common/interface/PtrVector.h"
 #include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 
 namespace reco {

--- a/DataFormats/ParticleFlowReco/interface/PFCluster.h
+++ b/DataFormats/ParticleFlowReco/interface/PFCluster.h
@@ -8,7 +8,7 @@
 #include <Rtypes.h>
 
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"
 #include "DataFormats/Math/interface/Point3D.h"
 #include "DataFormats/ParticleFlowReco/interface/PFLayer.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"

--- a/Fireworks/Calo/interface/FWECALCaloDataDetailViewBuilder.h
+++ b/Fireworks/Calo/interface/FWECALCaloDataDetailViewBuilder.h
@@ -2,7 +2,7 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 
 #include <map>
 #include <vector>

--- a/Fireworks/Calo/interface/FWECALDetailViewBuilder.h
+++ b/Fireworks/Calo/interface/FWECALDetailViewBuilder.h
@@ -7,7 +7,7 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "Fireworks/Calo/interface/FWBoxRecHit.h"
 
 namespace edm {

--- a/Fireworks/Calo/plugins/FWCaloClusterProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWCaloClusterProxyBuilder.cc
@@ -2,7 +2,7 @@
 #include "Fireworks/Core/interface/FWEventItem.h"
 #include "Fireworks/Core/interface/FWGeometry.h"
 #include "Fireworks/Core/interface/BuilderUtils.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 
 #include "TEveBoxSet.h"

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisRecoCluster.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisRecoCluster.h
@@ -8,8 +8,7 @@
 // Addition of reco information
 //-------------------------------------------------------------------------------
 
-#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 #include "L1AnalysisRecoClusterDataFormat.h"
 

--- a/RecoEcal/EgammaClusterProducers/src/CosmicClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/CosmicClusterProducer.cc
@@ -1,4 +1,4 @@
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHit.h"

--- a/RecoEcal/EgammaClusterProducers/src/IslandClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/IslandClusterProducer.cc
@@ -1,5 +1,5 @@
 #include "CommonTools/Utils/interface/StringToEnumValue.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHit.h"

--- a/RecoEgamma/EgammaHLTProducers/plugins/HLTHGCalLayerClusterIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/HLTHGCalLayerClusterIsolationProducer.cc
@@ -30,7 +30,7 @@
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateIsolation.h"
 
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"
 
 #include "RecoEgamma/EgammaTools/interface/HGCalClusterTools.h"
 

--- a/RecoEgamma/EgammaPhotonAlgos/interface/ConversionTrackEcalImpactPoint.h
+++ b/RecoEgamma/EgammaPhotonAlgos/interface/ConversionTrackEcalImpactPoint.h
@@ -21,7 +21,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/EgammaTrackReco/interface/TrackSuperClusterAssociation.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"
 //
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"

--- a/RecoEgamma/EgammaPhotonAlgos/interface/OutInConversionSeedFinder.h
+++ b/RecoEgamma/EgammaPhotonAlgos/interface/OutInConversionSeedFinder.h
@@ -9,6 +9,7 @@
  ***/
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 #include "RecoEgamma/EgammaPhotonAlgos/interface/ConversionSeedFinder.h"

--- a/RecoEgamma/EgammaTools/interface/HGCalClusterTools.h
+++ b/RecoEgamma/EgammaTools/interface/HGCalClusterTools.h
@@ -2,7 +2,9 @@
 #define RecoEgamma_EgammaTools_HGCalClusterTools_h
 
 #include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/DetId/interface/DetId.h"
 #include <vector>
+#include <algorithm>
 
 class HGCalClusterTools {
 public:

--- a/RecoEgamma/EgammaTools/interface/HGCalIsoCalculator.h
+++ b/RecoEgamma/EgammaTools/interface/HGCalIsoCalculator.h
@@ -10,7 +10,8 @@
 
 #include "DataFormats/HGCRecHit/interface/HGCRecHitCollections.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"
 
 /*
  *

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.cc
@@ -6,6 +6,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
 #include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 
 #include "SimCalorimetry/HGCalAssociatorProducers/interface/AssociatorTools.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.cc
@@ -2,6 +2,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 
 template <typename HIT>
 LCToSCAssociatorByEnergyScoreImpl<HIT>::LCToSCAssociatorByEnergyScoreImpl(

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreImpl.h
@@ -10,6 +10,7 @@
 #include "SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h"
 #include "SimDataFormats/Associations/interface/LayerClusterToCaloParticleAssociator.h"
 #include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSCAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSCAssociatorByEnergyScoreImpl.h
@@ -9,6 +9,7 @@
 #include "DataFormats/HGCRecHit/interface/HGCRecHit.h"
 #include "SimDataFormats/Associations/interface/TracksterToSimClusterAssociator.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 
 namespace edm {
   class EDProductGetter;

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.h
@@ -9,6 +9,7 @@
 #include "DataFormats/HGCRecHit/interface/HGCRecHit.h"
 #include "SimDataFormats/Associations/interface/TracksterToSimTracksterAssociator.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 
 namespace edm {
   class EDProductGetter;

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSHitLCAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSHitLCAssociatorByEnergyScoreImpl.h
@@ -9,6 +9,7 @@
 #include "DataFormats/HGCRecHit/interface/HGCRecHit.h"
 #include "SimDataFormats/Associations/interface/TracksterToSimTracksterHitLCAssociator.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 
 namespace edm {
   class EDProductGetter;

--- a/SimDataFormats/Associations/interface/LayerClusterToCaloParticleAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/LayerClusterToCaloParticleAssociatorBaseImpl.h
@@ -13,7 +13,6 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/AssociationMap.h"
 #include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
-
 #include "SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h"
 
 namespace ticl {

--- a/SimDataFormats/Associations/interface/LayerClusterToCaloParticleAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/LayerClusterToCaloParticleAssociatorBaseImpl.h
@@ -12,7 +12,7 @@
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/AssociationMap.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"
 #include "SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h"
 
 namespace ticl {

--- a/SimDataFormats/Associations/interface/LayerClusterToSimClusterAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/LayerClusterToSimClusterAssociatorBaseImpl.h
@@ -12,7 +12,7 @@
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/AssociationMap.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"
 
 #include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
 

--- a/SimDataFormats/Associations/interface/TracksterToSimClusterAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/TracksterToSimClusterAssociatorBaseImpl.h
@@ -13,7 +13,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/AssociationMap.h"
 #include "DataFormats/HGCalReco/interface/Trackster.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"
 
 #include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
 

--- a/SimDataFormats/Associations/interface/TracksterToSimTracksterAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/TracksterToSimTracksterAssociatorBaseImpl.h
@@ -13,7 +13,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/AssociationMap.h"
 #include "DataFormats/HGCalReco/interface/Trackster.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"
 
 #include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
 

--- a/SimDataFormats/Associations/interface/TracksterToSimTracksterHitLCAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/TracksterToSimTracksterHitLCAssociatorBaseImpl.h
@@ -4,7 +4,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/AssociationMap.h"
 #include "DataFormats/HGCalReco/interface/Trackster.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"
 
 #include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
 typedef std::vector<SimCluster> SimClusterCollection;


### PR DESCRIPTION
The implementation of ```DataFormats/CaloRecHit/interface/CaloClusterFwd.h``` currently includes ```DataFormats/CaloRecHit/interface/CaloCluster.h```, which defeats the the purpose of a forward declaration. 
Compiled under ```CMSSW_15_1_0_pre6```.