### PR TITLE
[14_1_X]: Backport of fix for Noisy ElectronSeedProducer

### DIFF
--- a/DataFormats/EgammaReco/src/ElectronSeed.cc
+++ b/DataFormats/EgammaReco/src/ElectronSeed.cc
@@ -77,8 +77,8 @@ void ElectronSeed::initTwoHitSeed(const unsigned char hitMask) {
   }
   for (size_t hitNr = 0; hitNr < hitInfo_.size(); hitNr++) {
     auto& info = hitInfo_[hitNr];
-    info.setDPhi(std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity());
-    info.setDRZ(std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity());
+    info.setDPhi(std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
+    info.setDRZ(std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
     info.setDet((recHits().begin() + hitNrs[hitNr])->geographicalId(), -1);
   }
 }
@@ -164,10 +164,10 @@ std::vector<ElectronSeed::PMVars> ElectronSeed::createHitInfo(const float dPhi1P
 }
 
 ElectronSeed::PMVars::PMVars()
-    : dRZPos(std::numeric_limits<float>::infinity()),
-      dRZNeg(std::numeric_limits<float>::infinity()),
-      dPhiPos(std::numeric_limits<float>::infinity()),
-      dPhiNeg(std::numeric_limits<float>::infinity()),
+    : dRZPos(std::numeric_limits<float>::max()),
+      dRZNeg(std::numeric_limits<float>::max()),
+      dPhiPos(std::numeric_limits<float>::max()),
+      dPhiNeg(std::numeric_limits<float>::max()),
       detId(0),
       layerOrDiskNr(-1) {}
 


### PR DESCRIPTION
#### PR description:

This PR  is intended to fix the noisy output from the Electron Seed Producer, resolving issue https://github.com/cms-sw/cmssw/issues/45658. 

#### PR validation:
I have tested the PR in 14_1_X and shown that it indeed suppresses the warnings. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/46710 and propagates the fix to the release used for HI data-taking in 2024. 

Tagging folks from the original fix: @beaudett @archiron
Tagging HIN colleagues: @mandrenguyen @stahlleiton
