### PR TITLE
[15.0.X] Trim down `ALCAPROMPT` step in the Prompt Calibration Loop

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAliHG_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAliHG_cff.py
@@ -3,32 +3,6 @@ import FWCore.ParameterSet.Config as cms
 # ------------------------------------------------------------------------------
 # configure a filter to run only on the events selected by TkAlMinBias AlcaReco
 from Alignment.CommonAlignmentProducer.ALCARECOPromptCalibProdSiPixelAli_cff import *
-ALCARECOTkAlMinBiasFilterForSiPixelAliHG = ALCARECOTkAlMinBiasFilterForSiPixelAli.clone()
-
-
-from Alignment.CommonAlignmentProducer.LSNumberFilter_cfi import *
-
-# Ingredient: offlineBeamSpot
-from RecoVertex.BeamSpotProducer.BeamSpot_cfi import offlineBeamSpot
-
-# Ingredient: AlignmentTrackSelector
-# track selector for HighPurity tracks
-#-- AlignmentTrackSelector
-SiPixelAliHighPuritySelectorHG = SiPixelAliHighPuritySelector.clone()
-
-# track selection for alignment
-SiPixelAliTrackSelectorHG = SiPixelAliTrackSelector.clone(
-	src = 'SiPixelAliTrackFitterHG'
-)
-
-# Ingredient: SiPixelAliTrackRefitter0
-# refitting
-SiPixelAliTrackRefitterHG0 = SiPixelAliTrackRefitter0.clone(
-	src = 'SiPixelAliHighPuritySelectorHG'
-)
-SiPixelAliTrackRefitterHG1 = SiPixelAliTrackRefitterHG0.clone(
-	src = 'SiPixelAliTrackSelectorHG'
-)
 
 #-- Alignment producer
 SiPixelAliMilleAlignmentProducerHG = SiPixelAliMilleAlignmentProducer.clone(
@@ -40,7 +14,7 @@ SiPixelAliMilleAlignmentProducerHG = SiPixelAliMilleAlignmentProducer.clone(
 	)
       )
     ),
-    tjTkAssociationMapTag = 'SiPixelAliTrackRefitterHG1',
+    tjTkAssociationMapTag = 'SiPixelAliTrackRefitter1',
     algoConfig = MillePedeAlignmentAlgorithm.clone(
 	binaryFile = 'milleBinaryHG_0.dat',
 	treeFile = 'treeFileHG.root',
@@ -48,29 +22,19 @@ SiPixelAliMilleAlignmentProducerHG = SiPixelAliMilleAlignmentProducer.clone(
     )
 )
 
-# Ingredient: SiPixelAliTrackerTrackHitFilter
-SiPixelAliTrackerTrackHitFilterHG = SiPixelAliTrackerTrackHitFilter.clone(
-	src = 'SiPixelAliTrackRefitterHG0'
-)
-
-# Ingredient: SiPixelAliSiPixelAliTrackFitter
-SiPixelAliTrackFitterHG = SiPixelAliTrackFitter.clone(
-	src = 'SiPixelAliTrackerTrackHitFilterHG'
-)
-
 SiPixelAliMillePedeFileConverterHG = cms.EDProducer("MillePedeFileConverter",
                                                     fileDir = cms.string(SiPixelAliMilleAlignmentProducerHG.algoConfig.fileDir.value()),
                                                     inputBinaryFile = cms.string(SiPixelAliMilleAlignmentProducerHG.algoConfig.binaryFile.value()),
                                                     fileBlobLabel = cms.string(''))
 
-seqALCARECOPromptCalibProdSiPixelAliHG = cms.Sequence(ALCARECOTkAlMinBiasFilterForSiPixelAliHG*
+seqALCARECOPromptCalibProdSiPixelAliHG = cms.Sequence(ALCARECOTkAlMinBiasFilterForSiPixelAli*
                                                       LSNumberFilter*
                                                       offlineBeamSpot*
-                                                      SiPixelAliHighPuritySelectorHG*
-                                                      SiPixelAliTrackRefitterHG0*
-                                                      SiPixelAliTrackerTrackHitFilterHG*
-                                                      SiPixelAliTrackFitterHG*
-                                                      SiPixelAliTrackSelectorHG*
-                                                      SiPixelAliTrackRefitterHG1*
+                                                      SiPixelAliHighPuritySelector*
+                                                      SiPixelAliTrackRefitter0*
+                                                      SiPixelAliTrackerTrackHitFilter*
+                                                      SiPixelAliTrackFitter*
+                                                      SiPixelAliTrackSelector*
+                                                      SiPixelAliTrackRefitter1*
                                                       SiPixelAliMilleAlignmentProducerHG*
                                                       SiPixelAliMillePedeFileConverterHG)

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
@@ -63,7 +63,9 @@ ALCARECOCalibrationTracksRefit = TrackRefitter.clone(src = cms.InputTag("ALCAREC
 
 # refit and BS can be dropped if done together with RECO.
 # track filter can be moved in acalreco if no otehr users
+from RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi import *
 ALCARECOTrackFilterRefit = cms.Sequence(ALCARECOCalibrationTracks +
+                                        MeasurementTrackerEvent +
                                         offlineBeamSpot +
                                         ALCARECOCalibrationTracksRefit )
 


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/48924

#### PR description:

From the original PR

> In the context of the Next Generation Triggers Task 3.4 ("[Optimal HLT Calibrations](https://cms-ngt-hlt.docs.cern.ch/Task34/)") we are interested in speeding up the calibration procedures with the aim of implementing real time calibrations for the phase-2 upgrade HLT. 
> A stepping stone towards that, consists in the [*NGT Demonstrator*](https://indico.cern.ch/event/1504131/contributions/6341017/attachments/3028520/5345755/NGT-HLT_OptimalCalibrations_AlCaDBWorkshop_10.03.2025_Zarucki.pdf#page=7) which we plan to deploy and operate during Run 3 (late 2025 and 2026). 
> The "calibration leg" of such demonstrator is planned to run a trimmed down version of the Prompt Calibration Loop delivering [selected alignment and calibrations](https://indico.cern.ch/event/1504131/contributions/6341017/attachments/3028520/5345755/NGT-HLT_OptimalCalibrations_AlCaDBWorkshop_10.03.2025_Zarucki.pdf#page=15). 
> While looking at optimizing the performance of PCL (see also https://github.com/cms-sw/cmssw/pull/48886) we noticed that a non negligible amount of resources is spent in running duplicated modules (those are different instances of the same `EDModule` configured in the exactly same way but with a different label, thus run by the framework).
> An example in identifying such modules if provided below [*]. The resulting output is available [here](https://marcomusich.web.cern.ch/NGT/3.4/duplicates_step3.txt).
> The goal of this PR is neutralize the CPU / timing penalty from the worst offenders (a more optimal configuration would likely need attention from AlCaDB and involvement of different groups).

#### PR validation:


We have run the following command:

```bash
#!/bin/bash

cmsDriver.py step3 --conditions 140X_dataRun3_Express_v3 \
	-s ALCAOUTPUT:SiStripCalZeroBias+SiStripPCLHistos,ALCA:PromptCalibProd+PromptCalibProdSiStrip+PromptCalibProdSiPixelAli+PromptCalibProdSiStripGains+PromptCalibProdSiStripGainsAAG+PromptCalibProdSiPixel+PromptCalibProdSiPixelLA+PromptCalibProdSiStripHitEff+PromptCalibProdSiPixelAliHG+PromptCalibProdSiPixelAliHGComb \
	--datatier ALCARECO --eventcontent ALCARECO --triggerResultsProcess RECO -n -1 \
	--filein file:step2_nomod.root --no_exec --fileout file:step3_nomod.root --python_filename step3_ALCAOUTPUT_ALCA.py

cat <<@EOF>> step3_ALCAOUTPUT_ALCA_nomod.py
process.options.numberOfStreams = 8
process.options.numberOfThreads = 8

process.load('HLTrigger.Timer.FastTimerService_cfi')

process.FastTimerService.writeJSONSummary = True
process.FastTimerService.jsonFileName = "timing_tracking_upperbound_s3_nomod.json"

@EOF

cmsRun step3_ALCAOUTPUT_ALCA.py
```
on around 40k events from run and measured the timing using either or not the changes in this branch:

| [w/o this PR](https://marcomusich.web.cern.ch/circles/web/piechart.php?colours=default&data_name=data&dataset=timing_tracking_upperbound_s3_nomod&groups=packages&local=false&resource=time_real&show_labels=true&show_animations=true&threshold=0)  | [w/ this PR](https://marcomusich.web.cern.ch/circles/web/piechart.php?colours=default&data_name=data&dataset=timing_tracking_upperbound_s3&groups=packages&local=false&resource=time_real&show_labels=true&show_animations=true&threshold=0) |
| ------------- | ------------- |
| <img width="1094" height="1084" alt="Screenshot from 2025-09-14 17-35-33" src="https://github.com/user-attachments/assets/d2683609-4c03-4581-8f0f-5bb284e4f959" /> | <img width="1094" height="1084" alt="Screenshot from 2025-09-14 17-35-43" src="https://github.com/user-attachments/assets/9f9a5c47-509f-40f0-a90d-5e6a62eeca1c" /> |

The timing reduction is of around 30% of the job total. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/48924 to CMSSW_15_0_X, intended for data-taking operations. 

---
[*]

```
cmsrel CMSSW_15_0_14
cd CMSSW_15_0_14/src/
cmsDriver.py step3 --conditions 140X_dataRun3_Express_v3 \
    -s ALCAOUTPUT:SiStripCalZeroBias+SiStripPCLHistos,ALCA:PromptCalibProd+PromptCalibProdSiStrip+PromptCalibProdSiPixelAli+PromptCalibProdSiStripGains+PromptCalibProdSiStripGainsAAG+PromptCalibProdSiPixel+PromptCalibProdSiPixelLA+PromptCalibProdSiStripHitEff+PromptCalibProdSiPixelAliHG+PromptCalibProdSiPixelAliHGComb \
    --datatier ALCARECO --eventcontent ALCARECO --triggerResultsProcess RECO -n -1 \
    --filein file:step2.root --no_exec --fileout file:step3.root
edmConfigDump step3_ALCAOUTPUT_ALCA.py > dump.py
hltFindDuplicates dump.py
```
