### PR TITLE
[DAQ] skip directory creation in read-only discovery mode

### DIFF
--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -2014,7 +2014,7 @@ namespace evf {
         std::string fileprefix = "/fu/";
         std::string rawpath = bu_run_dir_ + "/" + name;  //filestem should be raw
         //make destination dir
-        if (!std::filesystem::exists(bu_run_dir_ + fileprefix)) {
+        if (!discoveryReadOnly_ && !std::filesystem::exists(bu_run_dir_ + fileprefix)) {
           std::filesystem::create_directory(bu_run_dir_ + fileprefix);
         }
         std::filesystem::path p = name;

--- a/EventFilter/Utilities/test/startFU_daqsource.py
+++ b/EventFilter/Utilities/test/startFU_daqsource.py
@@ -52,6 +52,11 @@ options.register ('numFwkStreams',
                   VarParsing.VarParsing.varType.int,          # string, int, or float
                   "Number of CMSSW streams")
 
+options.register ('keepRawFiles',
+                  False, # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.bool,          # string, int, or float
+                  "Read-only")
 
 options.parseArguments()
 
@@ -110,6 +115,7 @@ process.source = cms.Source("DAQSource",
     maxChunkSize = cms.untracked.uint32(10),
     numBuffers = cms.untracked.uint32(3),
     maxBufferedFiles = cms.untracked.uint32(2),
+    keepRawFiles = cms.untracked.bool(options.keepRawFiles)
 )
 
 process.PrescaleService = cms.Service( "PrescaleService",


### PR DESCRIPTION
#### PR description:

Skipping creation of "fu" subdirectory in read-only discovery mode used for Phase-2 tests
An option is also added for the test script.

This might be useful for : https://github.com/cms-sw/cmssw/pull/48941

#### PR validation:

Tested with `startBU.py` and `startFU_daqsource.py` scripts in `EventFilter/Utilities/test`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No plans for backport.