### PR TITLE
[15.1.X] Further fixes for HGCal validation at HLT

### DIFF
--- a/RecoHGCal/TICL/plugins/SimTrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/SimTrackstersProducer.cc
@@ -78,6 +78,7 @@ public:
                     const bool add = false);
 
 private:
+  void returnEmptyCollections(edm::Event& e, const int lcSize);
   std::string detector_;
   const bool doNose_ = false;
   const bool computeLocalTime_;
@@ -231,6 +232,34 @@ void SimTrackstersProducer::addTrackster(
   }
 }
 
+void SimTrackstersProducer::returnEmptyCollections(edm::Event& evt, const int lcSize) {
+  // put into the event empty collections
+  auto e_result = std::make_unique<TracksterCollection>();
+  evt.put(std::move(e_result));
+
+  auto e_result_ticlCandidates = std::make_unique<std::vector<TICLCandidate>>();
+  evt.put(std::move(e_result_ticlCandidates));
+
+  auto e_output_mask = std::make_unique<std::vector<float>>();
+  e_output_mask->resize(lcSize, 1.f);
+  evt.put(std::move(e_output_mask));
+
+  auto e_result_fromCP = std::make_unique<TracksterCollection>();
+  evt.put(std::move(e_result_fromCP), "fromCPs");
+
+  auto e_resultPU = std::make_unique<TracksterCollection>();
+  evt.put(std::move(e_resultPU), "PU");
+
+  auto e_output_mask_fromCP = std::make_unique<std::vector<float>>();
+  e_output_mask_fromCP->resize(lcSize, 1.f);
+  evt.put(std::move(e_output_mask_fromCP), "fromCPs");
+
+  auto e_cpToSc_SimTrackstersMap = std::make_unique<std::map<uint, std::vector<uint>>>();
+  evt.put(std::move(e_cpToSc_SimTrackstersMap));
+
+  return;
+}
+
 void SimTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   auto result = std::make_unique<TracksterCollection>();
   auto output_mask = std::make_unique<std::vector<float>>();
@@ -247,14 +276,7 @@ void SimTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
   // Validate input collections
   if (!layerClustersHandle.isValid() || !layerClustersTimesHandle.isValid() || !inputClusterMaskHandle.isValid()) {
     edm::LogWarning("SimTrackstersProducer") << "Missing input collections. Producing empty outputs.";
-
-    evt.put(std::move(result));
-    evt.put(std::move(result_ticlCandidates));
-    evt.put(std::move(output_mask));
-    evt.put(std::move(result_fromCP), "fromCPs");
-    evt.put(std::move(resultPU), "PU");
-    evt.put(std::move(output_mask_fromCP), "fromCPs");
-    evt.put(std::move(cpToSc_SimTrackstersMap));
+    this->returnEmptyCollections(evt, 0);
     return;
   }
 
@@ -269,6 +291,11 @@ void SimTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
   const auto& simclusters = evt.get(simclusters_token_);
   edm::Handle<std::vector<CaloParticle>> caloParticles_h;
   evt.getByToken(caloparticles_token_, caloParticles_h);
+  if (!caloParticles_h.isValid()) {
+    edm::LogWarning("SimTrackstersProducer") << "Missing CaloParticles.";
+    this->returnEmptyCollections(evt, layerClusters.size());
+    return;
+  }
   const auto& caloparticles = *caloParticles_h;
 
   edm::Handle<MtdSimTracksterCollection> MTDSimTracksters_h;
@@ -286,13 +313,7 @@ void SimTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
   const auto TPtoRecoTrackMapHandle = evt.getHandle(associatormapStRsToken_);
   if (!TPtoRecoTrackMapHandle.isValid()) {
     edm::LogWarning("SimTrackstersProducer") << "Missing TP->RecoTrack association.";
-    evt.put(std::move(result));
-    evt.put(std::move(result_ticlCandidates));
-    evt.put(std::move(output_mask));
-    evt.put(std::move(result_fromCP), "fromCPs");
-    evt.put(std::move(resultPU), "PU");
-    evt.put(std::move(output_mask_fromCP), "fromCPs");
-    evt.put(std::move(cpToSc_SimTrackstersMap));
+    this->returnEmptyCollections(evt, layerClusters.size());
     return;
   }
   const auto& TPtoRecoTrackMap = *TPtoRecoTrackMapHandle;

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -420,6 +420,8 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
   for (const auto& token : hits_tokens_) {
     Handle<HGCRecHitCollection> hitsHandle;
     event.getByToken(token, hitsHandle);
+    if (!hitsHandle.isValid())
+      continue;
     rechitManager.addVector(*hitsHandle);
   }
 
@@ -451,6 +453,10 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
   //Layer clusters
   edm::Handle<reco::CaloClusterCollection> clusterHandle;
   event.getByToken(layerclusters_, clusterHandle);
+
+  if (!clusterHandle.isValid())
+    return;
+
   const reco::CaloClusterCollection& clusters = *clusterHandle;
 
   std::vector<edm::Handle<TracksterToTracksterMap>> tracksterToTracksterMapsHandles;


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/48221

#### PR description:

From the original PR:

> This PR is a further follow-up to https://github.com/cms-sw/cmssw/pull/47892 and https://github.com/cms-sw/cmssw/pull/48114.
It solves the problem spotted at https://github.com/cms-sw/cmssw/pull/47708#issuecomment-2884694870 in which wf 29634.75 is failing in the current IB on ARM platforms. 
I also reproduced the same issue by running `runTheMatrix.py --what upgrade -l 29634.751 -t 4 -j 8` in a regular IB with arch `el9_amd64_gcc12`.

#### PR validation:

See original PR.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/48221 to CMSSW_15_1_X