### PR TITLE
SequentialVertexFitter: use std::abs instead of integer abs

### DIFF
--- a/RecoVertex/VertexTools/interface/SequentialVertexFitter.h
+++ b/RecoVertex/VertexTools/interface/SequentialVertexFitter.h
@@ -172,7 +172,7 @@ public:
   * muon system, set the tracker bounds to larger values.
   */
   const bool insideTrackerBounds(const GlobalPoint& point) const {
-    return ((point.transverse() < trackerBoundsRadius) && (abs(point.z()) < trackerBoundsHalfLength));
+    return ((point.transverse() < trackerBoundsRadius) && (std::abs(point.z()) < trackerBoundsHalfLength));
   }
 
   void setTrackerBounds(float radius, float halfLength) {


### PR DESCRIPTION
#### PR description:

Clang [warns](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_16_0_CLANG_X_2025-09-17-2300/RecoVertex/KalmanVertexFit) about usage of integer `abs()` for floating-point argument:

```
In file included from src/RecoVertex/KalmanVertexFit/src/KalmanVertexFitter.cc:1:
In file included from src/RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h:4:
  src/RecoVertex/VertexTools/interface/SequentialVertexFitter.h:175:60: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
   175 |     return ((point.transverse() < trackerBoundsRadius) && (abs(point.z()) < trackerBoundsHalfLength));
      |                                                            ^
src/RecoVertex/VertexTools/interface/SequentialVertexFitter.h:175:60: note: use function 'std::abs' instead
  175 |     return ((point.transverse() < trackerBoundsRadius) && (abs(point.z()) < trackerBoundsHalfLength));
      |                                                            ^~~
      |                                                            std::abs
1 warning generated.
```

#### PR validation:

Bot tests
