### PR TITLE
PFAnalyzer.cc: use std::abs

### DIFF
--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
@@ -389,10 +389,10 @@ std::string PFAnalyzer::stringWithDecimals(int bin, std::vector<double> bins) {
     signStringHigh = "m";
   return Form("%s%.0fp%.0f_%s%.0fp%.0f",
               signStringLow.c_str(),
-              abs(bins[bin]),
+              std::abs(bins[bin]),
               newDigit,
               signStringHigh.c_str(),
-              abs(bins[bin + 1]),
+              std::abs(bins[bin + 1]),
               newDigit2);
 }
 


### PR DESCRIPTION
#### PR description:

Compilation of CMSSW_16_0_ROOT6_X_2025-09-17-2300 failed:

```
src/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc: In member function 'std::string PFAnalyzer::stringWithDecimals(int, std::vector<double>)':
  src/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc:390:21: error: format '%f' expects argument of type 'double', but argument 3 has type 'int' [-Werror=format=]
   390 |   return Form("%s%.0fp%.0f_%s%.0fp%.0f",
      |                  ~~~^
      |                     |
      |                     double
      |                  %.0d
  391 |               signStringLow.c_str(),
  392 |               abs(bins[bin]),
      |               ~~~~~~~~~~~~~~
      |                  |
      |                  int
  src/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc:390:33: error: format '%f' expects argument of type 'double', but argument 6 has type 'int' [-Werror=format=]
   390 |   return Form("%s%.0fp%.0f_%s%.0fp%.0f",
      |                              ~~~^
      |                                 |
      |                                 double
      |                              %.0d
......
  395 |               abs(bins[bin + 1]),
      |               ~~~~~~~~~~~~~~~~~~ 
      |                  |
      |                  int
cc1plus: some warnings being treated as errors
```

#### PR validation:

Bot tests