### PR TITLE
SoftMuonMvaRun3Estimator: use std::abs

### DIFF
--- a/PhysicsTools/PatAlgos/src/SoftMuonMvaRun3Estimator.cc
+++ b/PhysicsTools/PatAlgos/src/SoftMuonMvaRun3Estimator.cc
@@ -2,6 +2,7 @@
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "PhysicsTools/XGBoost/interface/XGBooster.h"
 #include "FWCore/Utilities/interface/isFinite.h"
+#include <cmath>
 
 typedef std::pair<const reco::MuonChamberMatch*, const reco::MuonSegmentMatch*> MatchPair;
 
@@ -15,7 +16,7 @@ const MatchPair& getBetterMatch(const MatchPair& match1, const MatchPair& match2
   // For the rest compare local x match. We expect that
   // segments belong to the muon, so the difference in
   // local x is a reflection on how well we can measure it
-  if (abs(match1.first->x - match1.second->x) > abs(match2.first->x - match2.second->x))
+  if (std::abs(match1.first->x - match1.second->x) > std::abs(match2.first->x - match2.second->x))
     return match2;
 
   return match1;


### PR DESCRIPTION
#### PR description:

Clang [complains](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_16_0_CLANG_X_2025-09-17-2300/PhysicsTools/PatAlgos) about using wrong abs function:

```
>> Compiling  src/PhysicsTools/PatAlgos/src/VertexingHelper.cc
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/llvm/19.1.6-af5542428395131caa7fdc426cc6023f/bin/clang++ -c -DCMS_MICRO_ARCH='x86-64-v3' -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=120301 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DBOOST_MPL_IGNORE_PARENTHESES_WARNING -DCMSSW_GIT_HASH='CMSSW_16_0_CLANG_X_2025-09-17-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_16_0_CLANG_X_2025-09-17-2300' -Isrc -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/onnxruntime/1.20.1-5e8017d0819e5cf6a4e38f0df8ee582e/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/alpaka/1.3.0-1bebf2b0d3930143ff8d2eb61285273b/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/cudnn/9.9.0.52-6f3f7a44da011543bc9b526abf21b272/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/libpng/1.6.37-04d5aac74fb0e0b044d856194f5a4a98/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/pcre/8.43-2d141998cfe5424b8f7aff48035cc2da/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/boost/1.80.0-9fb12b48c6a745f4b2f453dacee53cef/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/bz2lib/1.0.6-d065ccd79984efc6d4660f410e4c81de/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/clhep/2.4.7.1-9c4bc1e45cbfea5e42130d30ecec04f4/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/giflib/5.2.1-c9b71bd305c04482627fc5451da9661d/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gsl/2.6-f7574c606b0ce57ff601d3ca9534cd01/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/hepmc/2.06.10-262d73524c32528e87adc31a98f68d52/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/heppdt/3.04.01-964d55b5c0bd54a93743604b8bb11a55/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/hls/2025.05-e5a8b222591579ea9b35283eca4c298e/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/libjpeg-turbo/2.0.2-a09ac163eb10711ddf15e845fb1234c1/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/libuuid/2.34-27ce4c3579b5b1de2808ea9c4cd8ed29/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/protobuf/3.21.9-1126508a53768c90e66f6bf1821ac03a/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.32.13-64aa44734d7868ed18fd37d9c1ff18d5/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/sqlite/3.36.0-6a61dda6b4338fb9b6c26060efd5fd9a/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/tbb/v2022.0.0-0fa9c7b61a60a427cb7121233c828101/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/cms/vdt/0.4.3-f008bd09702a81e8a062bbef698ed3af/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/xz/5.2.5-6f3f49b07db84e10c9be594a1176c114/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/zlib/1.2.13-d217cdbdd8d586e845e05946de2796be/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/cuda/12.9.1-ed601c3aacdd4f0b0abc31ff95aeff6e/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-5d91c922e771c0dc4f6bc00f61f3e2c5/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-5d91c922e771c0dc4f6bc00f61f3e2c5/include/eigen3 -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/fmt/10.2.1-e35fd1db5eb3abc8ac0452e8ee427196/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/hepmc3/3.2.7-f10dce5b16f0246f8cac8378933b9681/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/md5/1.0.0-5b594b264e04ae51e893b1d69a797ec6/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/OpenBLAS/0.3.27-70a9dd2c9f309171934f13e3003b0540/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/re2/2021-06-01-9effece1d52fe4315cd5231654cb2160/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/tensorflow/2.12.0-c0ca1ec49e3c9fc0b8aa96e4729f34e1/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/tinyxml2/6.2.0-a0ad3950415fa3138d99b7da42eb4c9f/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/xgboost/1.7.5-a05d32b24fba11208da3df9807f8bb22/include -O3 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++20 -ftree-vectorize -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -march=x86-64-v3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -Wno-unknown-warning-option -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -Wno-tautological-type-limit-compare -Wno-vla-cxx-extension -fsized-deallocation -DEIGEN_DONT_PARALLELIZE -DEIGEN_MAX_ALIGN_BYTES=64 -Wno-error=unused-variable -DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 -DALPAKA_DISABLE_VENDOR_RNG -DBOOST_DISABLE_ASSERTS -fPIC -MMD -MF tmp/el8_amd64_gcc12/src/PhysicsTools/PatAlgos/src/PhysicsToolsPatAlgos/VertexingHelper.cc.d src/PhysicsTools/PatAlgos/src/VertexingHelper.cc -o tmp/el8_amd64_gcc12/src/PhysicsTools/PatAlgos/src/PhysicsToolsPatAlgos/VertexingHelper.cc.o
  src/PhysicsTools/PatAlgos/src/SoftMuonMvaRun3Estimator.cc:18:7: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
    18 |   if (abs(match1.first->x - match1.second->x) > abs(match2.first->x - match2.second->x))
      |       ^
src/PhysicsTools/PatAlgos/src/SoftMuonMvaRun3Estimator.cc:18:7: note: use function 'std::abs' instead
   18 |   if (abs(match1.first->x - match1.second->x) > abs(match2.first->x - match2.second->x))
      |       ^~~
      |       std::abs
  src/PhysicsTools/PatAlgos/src/SoftMuonMvaRun3Estimator.cc:18:49: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
    18 |   if (abs(match1.first->x - match1.second->x) > abs(match2.first->x - match2.second->x))
      |                                                 ^
src/PhysicsTools/PatAlgos/src/SoftMuonMvaRun3Estimator.cc:18:49: note: use function 'std::abs' instead
   18 |   if (abs(match1.first->x - match1.second->x) > abs(match2.first->x - match2.second->x))
      |                                                 ^~~
      |                                                 std::abs
```

#### PR validation:

Bot tests