### PR TITLE
[15.1.X] add support for multiple input FEDs in `HLTL1NumberFilter`

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -182,6 +182,15 @@ def customizeHLTfor47611(process):
 
     return process
 
+def customizeHLTfor48957(process):
+    for filt in filters_by_type(process, "HLTL1NumberFilter"):
+        if hasattr(filt, "fedId"):
+            value = filt.fedId.value()
+            del filt.fedId
+            filt.fedIds = cms.vint32([value])
+
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -191,6 +200,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     # process = customiseFor12718(process)
     
     process = customizeHLTfor47611(process)
+    process = customizeHLTfor48957(process)
 
     return process
 

--- a/HLTrigger/special/plugins/HLTL1NumberFilter.h
+++ b/HLTrigger/special/plugins/HLTL1NumberFilter.h
@@ -1,8 +1,8 @@
-#ifndef HLTL1NumberFilter_h
-#define HLTL1NumberFilter_h
+#ifndef HLTrigger_special_HLTL1NumberFilter_h
+#define HLTrigger_special_HLTL1NumberFilter_h
 // -*- C++ -*-
 //
-// Package:    HLTL1NumberFilter
+// Package:    HLTrigger/special
 // Class:      HLTL1NumberFilter
 //
 /**\class HLTL1NumberFilter HLTL1NumberFilter.cc filter/HLTL1NumberFilter/src/HLTL1NumberFilter.cc
@@ -19,15 +19,13 @@ Implementation:
 //
 
 // include files
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/global/EDFilter.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include <string>
 
@@ -38,7 +36,7 @@ Implementation:
 class HLTL1NumberFilter : public edm::global::EDFilter<> {
 public:
   explicit HLTL1NumberFilter(const edm::ParameterSet &);
-  ~HLTL1NumberFilter() override;
+  ~HLTL1NumberFilter() override = default;
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
@@ -50,8 +48,8 @@ private:
   const edm::EDGetTokenT<FEDRawDataCollection> inputToken_;
   /// accept the event if its event number is a multiple of period_
   const unsigned int period_;
-  /// FED from which to get lv1ID number
-  const int fedId_;
+  /// FEDs from which to get lv1ID number
+  const std::vector<int> fedIds_;
   /// if invert_=true, invert that event accept decision
   const bool invert_;
   /// if useTCDS=true, use 64-bit Event Number from TCDS record (FED 1024) word 11


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/48957

#### PR description:

From the original PR description:

> Title says it all: the DAQ group is preparing the global system for running with the secondary TCDS system, where FED 1050 would be present as TCDS FED instead of 1024, see more details at [CMSHLT-3643](https://its.cern.ch/jira/browse/CMSHLT-3643).
> Considering HLT, they went through the modules consuming FED 1024 and they found that the module `HLTL1NumberFilter` does not support multiple FED input values, thus it can work with both FED IDs in global HLT. 
> The goal of this PR is to support multiple TCDS FEDs in input.

#### PR validation:

TSG integration tests: `addOnTests.py` works.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/48957 to the 2025 PbPb data-taking release, for online tests.
 
Cc: @smorovic 