### PR TITLE
Fix memory in case of hepmc3

### DIFF
--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -727,6 +727,7 @@ G4Event* RunManagerMTWorker::generateEvent(const edm::Event& inpevt) {
     } else {
       //m_generator3.nonCentralEvent2G4(HepMCEvt->GetEvent(), evt);
     }
+    delete genevt3;
   }
   return evt;
 }

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -713,12 +713,12 @@ G4Event* RunManagerMTWorker::generateEvent(const edm::Event& inpevt) {
     edm::Handle<edm::HepMC3Product> HepMCEvt3;
     inpevt.getByToken(m_InToken3, HepMCEvt3);
 
-    HepMC3::GenEvent* genevt3 = new HepMC3::GenEvent();
-    genevt3->read_data(*HepMCEvt3->GetEvent());
-    m_generator3.setGenEvent(genevt3);
+    HepMC3::GenEvent genevt3;
+    genevt3.read_data(*HepMCEvt3->GetEvent());
+    m_generator3.setGenEvent(&genevt3);
 
     if (!m_nonBeam) {
-      m_generator3.HepMC2G4(genevt3, evt);
+      m_generator3.HepMC2G4(&genevt3, evt);
       if (m_LHCTransport) {
         edm::Handle<edm::HepMC3Product> LHCMCEvt;
         inpevt.getByToken(m_LHCToken, LHCMCEvt);
@@ -727,7 +727,6 @@ G4Event* RunManagerMTWorker::generateEvent(const edm::Event& inpevt) {
     } else {
       //m_generator3.nonCentralEvent2G4(HepMCEvt->GetEvent(), evt);
     }
-    delete genevt3;
   }
   return evt;
 }


### PR DESCRIPTION
#### PR description:

Getting HepMC3 record from edm is different from HepMC2 in the sense of additional step, reading from data. The class created for this step is to be deleted after usage.

#### PR validation:

 Validated using the test configurations from Pythia8Interface

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

