### PR TITLE
PoolSource TTreeCache refactoring

### DIFF
--- a/IOPool/Input/src/InputFile.h
+++ b/IOPool/Input/src/InputFile.h
@@ -48,13 +48,12 @@ namespace edm {
     static void reportReadBranch(InputType inputType, std::string const& branchname);
 
     TObject* Get(char const* name) { return file_->Get(name); }
-    std::unique_ptr<TTreeCache> createCacheWithSize(TTree& iTree, unsigned int cacheSize) {
-      iTree.SetCacheSize(static_cast<Long64_t>(cacheSize));
-      std::unique_ptr<TTreeCache> newCache(dynamic_cast<TTreeCache*>(file_->GetCacheRead(&iTree)));
-      file_->SetCacheRead(nullptr, &iTree, TFile::kDoNotDisconnect);
+    std::unique_ptr<TTreeCache> createCacheWithSize(TTree* iTree, unsigned int cacheSize) {
+      iTree->SetCacheSize(static_cast<Long64_t>(cacheSize));
+      std::unique_ptr<TTreeCache> newCache(dynamic_cast<TTreeCache*>(file_->GetCacheRead(iTree)));
+      file_->SetCacheRead(nullptr, iTree, TFile::kDoNotDisconnect);
       return newCache;
     }
-    TTreeCache* getCacheRead(TTree* tree) { return dynamic_cast<TTreeCache*>(file_->GetCacheRead(tree)); }
 
     class CacheGuard {
     public:

--- a/IOPool/Input/src/InputFile.h
+++ b/IOPool/Input/src/InputFile.h
@@ -54,6 +54,7 @@ namespace edm {
       file_->SetCacheRead(nullptr, &iTree, TFile::kDoNotDisconnect);
       return newCache;
     }
+    TTreeCache* getCacheRead(TTree* tree) { return dynamic_cast<TTreeCache*>(file_->GetCacheRead(tree)); }
 
     class CacheGuard {
     public:

--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -270,17 +270,13 @@ namespace edm {
     return retval;
   }
 
-  void RootTree::resetTraining() { treeCacheManager_->resetTraining(); }
+  void RootTree::resetTraining() { treeCacheManager_->resetTraining(promptRead_); }
 
   void RootTree::close() {
     // The TFile is about to be closed, and destructed.
     // Just to play it safe, zero all pointers to quantities that are owned by the TFile.
     auxBranch_ = branchEntryInfoBranch_ = nullptr;
     tree_ = metaTree_ = infoTree_ = nullptr;
-    // We own the treeCache_.
-    // We make sure the treeCache_ is detached from the file,
-    // so that ROOT does not also delete it.
-    filePtr_->clearCacheRead(tree_);
     // We *must* delete the TTreeCache here because the TFilePrefetch object
     // references the TFile.  If TFile is closed, before the TTreeCache is
     // deleted, the TFilePrefetch may continue to do TFile operations, causing
@@ -324,7 +320,7 @@ namespace edm {
                                            unsigned int cacheSize,
                                            char const* branchNames) {
       tree->LoadTree(0);
-      std::unique_ptr<TTreeCache> treeCache = file.createCacheWithSize(*tree, cacheSize);
+      std::unique_ptr<TTreeCache> treeCache = file.createCacheWithSize(tree, cacheSize);
       if (nullptr != treeCache.get()) {
         treeCache->StartLearningPhase();
         treeCache->SetEntryRange(0, tree->GetEntries());

--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -6,6 +6,7 @@
 
 #include "InputFile.h"
 #include "RootTree.h"
+#include "RootTreeCacheManager.h"
 #include "RootDelayedReader.h"
 #include "RootPromptReadDelayedReader.h"
 
@@ -54,11 +55,10 @@ namespace edm {
       : filePtr_(filePtr),
         branchType_(branchType),
         entryNumberForIndex_(std::make_unique<std::vector<EntryNumber>>(nIndexes, IndexIntoFile::invalidEntry)),
-        learningEntries_(learningEntries),
-        enablePrefetching_(enablePrefetching),
-        enableTriggerCache_(branchType_ == InEvent),
-        promptRead_(promptRead),
-        rootDelayedReader_(makeRootDelayedReader(*this, filePtr, inputType, nIndexes, promptRead)) {}
+        promptRead_(promptRead or not branchType_ == InEvent),
+        rootDelayedReader_(makeRootDelayedReader(*this, filePtr, inputType, nIndexes, promptRead_)),
+        treeCacheManager_(roottree::CacheManagerBase::create(
+            promptRead_ ? "Simple" : "Sparse", filePtr_, learningEntries, enablePrefetching, branchType_)) {}
 
   // Used for Event/Lumi/Run RootTrees
   RootTree::RootTree(std::shared_ptr<InputFile> filePtr,
@@ -113,15 +113,12 @@ namespace edm {
     } else {
       treeAutoFlush_ = treeAutoFlush;
     }
-    if (treeAutoFlush_ < learningEntries_) {
-      learningEntries_ = treeAutoFlush_;
-    }
+    treeCacheManager_->init(tree_, treeAutoFlush_);
     setTreeMaxVirtualSize(maxVirtualSize);
-    setCacheSize(cacheSize);
+    treeCacheManager_->createPrimaryCache(cacheSize);
     if (branchType_ == InEvent) {
       Int_t branchCount = tree_->GetListOfBranches()->GetEntriesFast();
-      trainedSet_.reserve(branchCount);
-      triggerSet_.reserve(branchCount);
+      treeCacheManager_->reserve(branchCount);
     }
   }
 
@@ -224,22 +221,12 @@ namespace edm {
 
   roottree::BranchMap const& RootTree::branches() const { return branches_; }
 
-  std::shared_ptr<TTreeCache> RootTree::createCacheWithSize(unsigned int cacheSize) const {
-    return filePtr_->createCacheWithSize(*tree_, cacheSize);
-  }
-
-  void RootTree::setCacheSize(unsigned int cacheSize) {
-    cacheSize_ = cacheSize;
-    treeCache_ = createCacheWithSize(cacheSize);
-    if (treeCache_)
-      treeCache_->SetEnablePrefetching(enablePrefetching_);
-    rawTreeCache_.reset();
-  }
-
   void RootTree::setTreeMaxVirtualSize(int treeMaxVirtualSize) {
     if (treeMaxVirtualSize >= 0)
       tree_->SetMaxVirtualSize(static_cast<Long64_t>(treeMaxVirtualSize));
   }
+
+  void RootTree::fillAuxHelper() { treeCacheManager_->getAuxEntry(auxBranch_, entryNumber_); }
 
   bool RootTree::nextWithCache() {
     bool returnValue = ++entryNumber_ < entries_;
@@ -250,220 +237,14 @@ namespace edm {
   }
 
   void RootTree::setEntryNumber(EntryNumber theEntryNumber) {
-    {
-      auto guard = filePtr_->setCacheReadTemporarily(treeCache_.get(), tree_);
-
-      // Detect a backward skip.  If the skip is sufficiently large, we roll the dice and reset the treeCache.
-      // This will cause some amount of over-reading: we pre-fetch all the events in some prior cluster.
-      // However, because reading one event in the cluster is supposed to be equivalent to reading all events in the cluster,
-      // we're not incurring additional over-reading - we're just doing it more efficiently.
-      // NOTE: Constructor guarantees treeAutoFlush_ is positive, even if TTree->GetAutoFlush() is negative.
-      if (theEntryNumber < entryNumber_ and theEntryNumber >= 0) {
-        //We started reading the file near the end, now we need to correct for the learning length
-        if (switchOverEntry_ > tree_->GetEntries()) {
-          switchOverEntry_ = switchOverEntry_ - tree_->GetEntries();
-          if (rawTreeCache_) {
-            rawTreeCache_->SetEntryRange(theEntryNumber, switchOverEntry_);
-            rawTreeCache_->FillBuffer();
-          }
-        }
-        if (performedSwitchOver_ and triggerTreeCache_) {
-          //We are using the triggerTreeCache_ not the rawTriggerTreeCache_.
-          //The triggerTreeCache was originally told to start from an entry further in the file.
-          triggerTreeCache_->SetEntryRange(theEntryNumber, tree_->GetEntries());
-        } else if (rawTriggerTreeCache_) {
-          //move the switch point to the end of the cluster holding theEntryNumber
-          rawTriggerSwitchOverEntry_ = -1;
-          TTree::TClusterIterator clusterIter = tree_->GetClusterIterator(theEntryNumber);
-          while ((rawTriggerSwitchOverEntry_ < theEntryNumber) || (rawTriggerSwitchOverEntry_ <= 0)) {
-            rawTriggerSwitchOverEntry_ = clusterIter();
-          }
-          rawTriggerTreeCache_->SetEntryRange(theEntryNumber, rawTriggerSwitchOverEntry_);
-        }
-      }
-      if ((theEntryNumber < static_cast<EntryNumber>(entryNumber_ - treeAutoFlush_)) && (treeCache_) &&
-          (!treeCache_->IsLearning()) && (entries_ > 0) && (switchOverEntry_ >= 0)) {
-        treeCache_->SetEntryRange(theEntryNumber, entries_);
-        treeCache_->FillBuffer();
-      }
-
-      entryNumber_ = theEntryNumber;
-      tree_->LoadTree(entryNumber_);
-      //want guard to end here
-    }
-    if (treeCache_ && trainNow_ && entryNumber_ >= 0) {
-      startTraining();
-      trainNow_ = false;
-      trainedSet_.clear();
-      triggerSet_.clear();
-      rawTriggerSwitchOverEntry_ = -1;
-    }
-    if (not promptRead_ && treeCache_ && treeCache_->IsLearning() && switchOverEntry_ >= 0 &&
-        entryNumber_ >= switchOverEntry_) {
-      stopTraining();
-    }
+    treeCacheManager_->setEntryNumber(theEntryNumber, entryNumber_, entries_);
+    entryNumber_ = theEntryNumber;
   }
 
-  // The actual implementation is done below; it's split in this strange
-  // manner in order to keep a by-definition-rare code path out of the instruction cache.
-  inline TTreeCache* RootTree::checkTriggerCache(TBranch* branch, EntryNumber entryNumber) const {
-    if (!treeCache_->IsAsyncReading() && enableTriggerCache_ && (trainedSet_.find(branch) == trainedSet_.end())) {
-      return checkTriggerCacheImpl(branch, entryNumber);
-    } else {
-      return nullptr;
-    }
-  }
-
-  // See comments in the header.  If this function is called, we already know
-  // the trigger cache is active and it was a cache miss for the regular cache.
-  TTreeCache* RootTree::checkTriggerCacheImpl(TBranch* branch, EntryNumber entryNumber) const {
-    // This branch is not going to be in the cache.
-    // Assume this is a "trigger pattern".
-    // Always make sure the branch is added to the trigger set.
-    if (triggerSet_.find(branch) == triggerSet_.end()) {
-      triggerSet_.insert(branch);
-      if (triggerTreeCache_.get()) {
-        triggerTreeCache_->AddBranch(branch, kTRUE);
-      }
-    }
-
-    if (rawTriggerSwitchOverEntry_ < 0) {
-      // The trigger has never fired before.  Take everything not in the
-      // trainedSet and load it from disk
-
-      // Calculate the end of the next cluster; triggers in the next cluster
-      // will use the triggerCache, not the rawTriggerCache.
-      //
-      // Guarantee that rawTriggerSwitchOverEntry_ is positive (non-zero) after completion
-      // of this if-block.
-      TTree::TClusterIterator clusterIter = tree_->GetClusterIterator(entryNumber);
-      while ((rawTriggerSwitchOverEntry_ < entryNumber) || (rawTriggerSwitchOverEntry_ <= 0)) {
-        rawTriggerSwitchOverEntry_ = clusterIter();
-      }
-
-      // ROOT will automatically expand the cache to fit one cluster; hence, we use
-      // 5 MB as the cache size below
-      rawTriggerTreeCache_ = createCacheWithSize(5 * 1024 * 1024);
-      if (rawTriggerTreeCache_)
-        rawTriggerTreeCache_->SetEnablePrefetching(false);
-      TObjArray* branches = tree_->GetListOfBranches();
-      int branchCount = branches->GetEntriesFast();
-
-      // Train the rawTriggerCache to have everything not in the regular cache.
-      rawTriggerTreeCache_->SetLearnEntries(0);
-      rawTriggerTreeCache_->SetEntryRange(entryNumber, rawTriggerSwitchOverEntry_);
-      for (int i = 0; i < branchCount; i++) {
-        TBranch* tmp_branch = (TBranch*)branches->UncheckedAt(i);
-        if (trainedSet_.find(tmp_branch) != trainedSet_.end()) {
-          continue;
-        }
-        rawTriggerTreeCache_->AddBranch(tmp_branch, kTRUE);
-      }
-      performedSwitchOver_ = false;
-      rawTriggerTreeCache_->StopLearningPhase();
-
-      return rawTriggerTreeCache_.get();
-    } else if (!performedSwitchOver_ and entryNumber_ < rawTriggerSwitchOverEntry_) {
-      // The raw trigger has fired and it contents are valid.
-      return rawTriggerTreeCache_.get();
-    } else if (rawTriggerSwitchOverEntry_ > 0) {
-      // The raw trigger has fired, but we are out of the cache.  Use the
-      // triggerCache instead.
-      if (!performedSwitchOver_) {
-        rawTriggerTreeCache_.reset();
-        performedSwitchOver_ = true;
-
-        // Train the triggerCache
-        triggerTreeCache_ = createCacheWithSize(5 * 1024 * 1024);
-        triggerTreeCache_->SetEnablePrefetching(false);
-        triggerTreeCache_->SetLearnEntries(0);
-        triggerTreeCache_->SetEntryRange(entryNumber, tree_->GetEntries());
-        for (std::unordered_set<TBranch*>::const_iterator it = triggerSet_.begin(), itEnd = triggerSet_.end();
-             it != itEnd;
-             it++) {
-          triggerTreeCache_->AddBranch(*it, kTRUE);
-        }
-        triggerTreeCache_->StopLearningPhase();
-      }
-      return triggerTreeCache_.get();
-    }
-
-    // By construction, this case should be impossible.
-    assert(false);
-    return nullptr;
-  }
-
-  inline TTreeCache* RootTree::selectCache(TBranch* branch, EntryNumber entryNumber) const {
-    TTreeCache* triggerCache = nullptr;
-    if (promptRead_) {
-      return rawTreeCache_.get();
-    }
-    if (!treeCache_) {
-      return nullptr;
-    } else if (treeCache_->IsLearning() && rawTreeCache_) {
-      treeCache_->AddBranch(branch, kTRUE);
-      trainedSet_.insert(branch);
-      return rawTreeCache_.get();
-    } else if ((triggerCache = checkTriggerCache(branch, entryNumber))) {
-      // A NULL return value from checkTriggerCache indicates the trigger cache case
-      // does not apply, and we should continue below.
-      return triggerCache;
-    } else {
-      // The "normal" TTreeCache case.
-      return treeCache_.get();
-    }
-  }
-  TTreeCache* RootTree::getAuxCache(TBranch* auxBranch) const {
-    if (not auxCache_ and cacheSize_ > 0) {
-      auxCache_ = createCacheWithSize(1 * 1024 * 1024);
-      if (auxCache_) {
-        auxCache_->SetEnablePrefetching(enablePrefetching_);
-        auxCache_->SetLearnEntries(0);
-        auxCache_->StartLearningPhase();
-        auxCache_->SetEntryRange(0, tree_->GetEntries());
-        auxCache_->AddBranch(auxBranch->GetName(), kTRUE);
-        auxCache_->StopLearningPhase();
-      }
-    }
-    return auxCache_.get();
-  }
-
-  void RootTree::getEntryForAllBranches() const {
-    oneapi::tbb::this_task_arena::isolate([&]() {
-      auto guard = filePtr_->setCacheReadTemporarily(rawTreeCache_.get(), tree_);
-      tree_->GetEntry(entryNumber_);
-    });
-  }
+  void RootTree::getEntryForAllBranches() const { treeCacheManager_->getEntryForAllBranches(entryNumber_); }
 
   void RootTree::getEntry(TBranch* branch, EntryNumber entryNumber) const {
-    getEntryUsingCache(branch, entryNumber, selectCache(branch, entryNumber));
-  }
-
-  inline void RootTree::getEntryUsingCache(TBranch* branch, EntryNumber entryNumber, TTreeCache* cache) const {
-    LogTrace("IOTrace").format(
-        "RootTree::getEntryUsingCache() begin for branch {} entry {}", branch->GetName(), entryNumber);
-    try {
-      auto guard = filePtr_->setCacheReadTemporarily(cache, tree_);
-      branch->GetEntry(entryNumber);
-    } catch (cms::Exception const& e) {
-      // We make sure the treeCache_ is detached from the file,
-      // so that ROOT does not also delete it.
-      Exception t(errors::FileReadError, "", e);
-      t.addContext(std::string("Reading branch ") + branch->GetName());
-      throw t;
-    } catch (std::exception const& e) {
-      Exception t(errors::FileReadError);
-      t << e.what();
-      t.addContext(std::string("Reading branch ") + branch->GetName());
-      throw t;
-    } catch (...) {
-      Exception t(errors::FileReadError);
-      t << "An exception of unknown type was thrown.";
-      t.addContext(std::string("Reading branch ") + branch->GetName());
-      throw t;
-    }
-    LogTrace("IOTrace").format(
-        "RootTree::getEntryUsingCache() end for branch {} entry {}", branch->GetName(), entryNumber);
+    treeCacheManager_->getEntry(branch, entryNumber);
   }
 
   bool RootTree::skipEntries(unsigned int& offset) {
@@ -481,51 +262,7 @@ namespace edm {
     return retval;
   }
 
-  void RootTree::startTraining() {
-    if (cacheSize_ == 0) {
-      return;
-    }
-    assert(treeCache_);
-    assert(branchType_ == InEvent);
-    assert(!rawTreeCache_);
-    treeCache_->SetLearnEntries(learningEntries_);
-    rawTreeCache_ = createCacheWithSize(cacheSize_);
-    rawTreeCache_->SetEnablePrefetching(false);
-    rawTreeCache_->SetLearnEntries(0);
-    if (promptRead_) {
-      switchOverEntry_ = entries_;
-    } else {
-      switchOverEntry_ = entryNumber_ + learningEntries_;
-    }
-    auto rawStart = entryNumber_;
-    auto rawEnd = switchOverEntry_;
-    auto treeStart = switchOverEntry_;
-    if (switchOverEntry_ >= tree_->GetEntries()) {
-      treeStart = switchOverEntry_ - tree_->GetEntries();
-      rawEnd = tree_->GetEntries();
-    }
-    rawTreeCache_->StartLearningPhase();
-    rawTreeCache_->SetEntryRange(rawStart, rawEnd);
-    rawTreeCache_->AddBranch("*", kTRUE);
-    rawTreeCache_->StopLearningPhase();
-
-    treeCache_->StartLearningPhase();
-    treeCache_->SetEntryRange(treeStart, tree_->GetEntries());
-    // Make sure that 'branchListIndexes' branch exist in input file
-    if (filePtr_->Get(poolNames::branchListIndexesBranchName().c_str()) != nullptr) {
-      treeCache_->AddBranch(poolNames::branchListIndexesBranchName().c_str(), kTRUE);
-    }
-    treeCache_->AddBranch(BranchTypeToAuxiliaryBranchName(branchType_).c_str(), kTRUE);
-    trainedSet_.clear();
-    triggerSet_.clear();
-    assert(treeCache_->GetTree() == tree_);
-  }
-
-  void RootTree::stopTraining() {
-    auto guard = filePtr_->setCacheReadTemporarily(treeCache_.get(), tree_);
-    treeCache_->StopLearningPhase();
-    rawTreeCache_.reset();
-  }
+  void RootTree::resetTraining() { treeCacheManager_->resetTraining(); }
 
   void RootTree::close() {
     // The TFile is about to be closed, and destructed.
@@ -540,47 +277,12 @@ namespace edm {
     // references the TFile.  If TFile is closed, before the TTreeCache is
     // deleted, the TFilePrefetch may continue to do TFile operations, causing
     // deadlocks or exceptions.
-    treeCache_.reset();
-    rawTreeCache_.reset();
-    triggerTreeCache_.reset();
-    rawTriggerTreeCache_.reset();
-    auxCache_.reset();
+    treeCacheManager_->reset();
     // We give up our shared ownership of the TFile itself.
     filePtr_.reset();
   }
 
-  void RootTree::trainCache(char const* branchNames) {
-    if (cacheSize_ == 0) {
-      return;
-    }
-    tree_->LoadTree(0);
-    assert(treeCache_);
-    {
-      auto guard = filePtr_->setCacheReadTemporarily(treeCache_.get(), tree_);
-      treeCache_->StartLearningPhase();
-      treeCache_->SetEntryRange(0, tree_->GetEntries());
-      treeCache_->AddBranch(branchNames, kTRUE);
-      treeCache_->StopLearningPhase();
-      assert(treeCache_->GetTree() == tree_);
-      // We own the treeCache_.
-      // We make sure the treeCache_ is detached from the file,
-      // so that ROOT does not also delete it.
-
-      //want guard to end here
-    }
-
-    if (branchType_ == InEvent) {
-      // Must also manually add things to the trained set.
-      TObjArray* branches = tree_->GetListOfBranches();
-      int branchCount = branches->GetEntriesFast();
-      for (int i = 0; i < branchCount; i++) {
-        TBranch* branch = (TBranch*)branches->UncheckedAt(i);
-        if ((branchNames[0] == '*') || (strcmp(branchNames, branch->GetName()) == 0)) {
-          trainedSet_.insert(branch);
-        }
-      }
-    }
-  }
+  void RootTree::trainCache(char const* branchNames) { treeCacheManager_->trainCache(branchNames); }
 
   void RootTree::setSignals(
       signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadSource,

--- a/IOPool/Input/src/RootTree.h
+++ b/IOPool/Input/src/RootTree.h
@@ -99,7 +99,7 @@ namespace edm {
       bool promptReading = false;
 
       Options usingDefaultNonEventOptions() const {
-        return {roottree::defaultNonEventCacheSize, treeMaxVirtualSize, enablePrefetching, true};
+        return {roottree::defaultNonEventCacheSize, treeMaxVirtualSize, enablePrefetching, false};
       }
     };
 

--- a/IOPool/Input/src/RootTree.h
+++ b/IOPool/Input/src/RootTree.h
@@ -35,6 +35,8 @@ namespace edm {
   class InputFile;
 
   namespace roottree {
+    class CacheManagerBase;
+
     unsigned int const defaultCacheSize = 20U * 1024 * 1024;
     unsigned int const defaultNonEventCacheSize = 1U * 1024 * 1024;
     unsigned int const defaultLearningEntries = 20U;
@@ -150,8 +152,7 @@ namespace edm {
     template <typename T>
     void fillAux(T*& pAux) {
       auxBranch_->SetAddress(&pAux);
-      auto cache = getAuxCache(auxBranch_);
-      getEntryUsingCache(auxBranch_, entryNumber_, cache);
+      fillAuxHelper();
       auxBranch_->SetAddress(nullptr);
     }
 
@@ -188,11 +189,8 @@ namespace edm {
     //For backwards compatibility
     TBranch* branchEntryInfoBranch() const { return branchEntryInfoBranch_; }
 
-    inline TTreeCache* checkTriggerCache(TBranch* branch, EntryNumber entryNumber) const;
-    TTreeCache* checkTriggerCacheImpl(TBranch* branch, EntryNumber entryNumber) const;
-    inline TTreeCache* selectCache(TBranch* branch, EntryNumber entryNumber) const;
     void trainCache(char const* branchNames);
-    void resetTraining() { trainNow_ = true; }
+    void resetTraining();
 
     BranchType branchType() const { return branchType_; }
     std::string const& processName() const { return processName_; }
@@ -210,13 +208,10 @@ namespace edm {
              bool promptRead,
              InputType inputType);
 
-    std::shared_ptr<TTreeCache> createCacheWithSize(unsigned int cacheSize) const;
-    void setCacheSize(unsigned int cacheSize);
     void setTreeMaxVirtualSize(int treeMaxVirtualSize);
     void startTraining();
     void stopTraining();
-    void getEntryUsingCache(TBranch* branch, EntryNumber entry, TTreeCache*) const;
-    TTreeCache* getAuxCache(TBranch* auxBranch) const;
+    void fillAuxHelper();
 
     std::shared_ptr<InputFile> filePtr_;
     // We use bare pointers for pointers to some ROOT entities.
@@ -227,35 +222,15 @@ namespace edm {
     BranchType branchType_;
     std::string processName_;
     TBranch* auxBranch_ = nullptr;
-    // We use a smart pointer to own the TTreeCache.
-    // Unfortunately, ROOT owns it when attached to a TFile, but not after it is detached.
-    // So, we make sure to it is detached before closing the TFile so there is no double delete.
-    std::shared_ptr<TTreeCache> treeCache_;
-    std::shared_ptr<TTreeCache> rawTreeCache_;
-    CMS_SA_ALLOW mutable std::shared_ptr<TTreeCache> auxCache_;
-    //All access to a ROOT file is serialized
-    CMS_SA_ALLOW mutable std::shared_ptr<TTreeCache> triggerTreeCache_;
-    CMS_SA_ALLOW mutable std::shared_ptr<TTreeCache> rawTriggerTreeCache_;
-    CMS_SA_ALLOW mutable std::unordered_set<TBranch*> trainedSet_;
-    CMS_SA_ALLOW mutable std::unordered_set<TBranch*> triggerSet_;
     EntryNumber entries_ = 0;
     EntryNumber entryNumber_ = IndexIntoFile::invalidEntry;
     std::unique_ptr<std::vector<EntryNumber> > entryNumberForIndex_;
     std::vector<std::string> branchNames_;
     BranchMap branches_;
-    bool trainNow_ = false;
-    EntryNumber switchOverEntry_ = -1;
-    CMS_SA_ALLOW mutable EntryNumber rawTriggerSwitchOverEntry_ = -1;
-    CMS_SA_ALLOW mutable bool performedSwitchOver_ = false;
-    unsigned int learningEntries_;
-    unsigned int cacheSize_ = 0;
     unsigned long treeAutoFlush_ = 0;
-    // Enable asynchronous I/O in ROOT (done in a separate thread).  Only takes
-    // effect on the primary treeCache_; all other caches have this explicitly disabled.
-    bool enablePrefetching_;
-    bool enableTriggerCache_;
     bool promptRead_;
     std::unique_ptr<RootDelayedReaderBase> rootDelayedReader_;
+    CMS_SA_ALLOW mutable std::unique_ptr<roottree::CacheManagerBase> treeCacheManager_;
 
     TBranch* branchEntryInfoBranch_ = nullptr;  //backwards compatibility
     // below for backward compatibility

--- a/IOPool/Input/src/RootTree.h
+++ b/IOPool/Input/src/RootTree.h
@@ -144,7 +144,7 @@ namespace edm {
     EntryNumber const& entryNumber() const { return entryNumber_; }
     EntryNumber const& entryNumberForIndex(unsigned int index) const;
     EntryNumber const& entries() const { return entries_; }
-    void setEntryNumber(EntryNumber theEntryNumber);
+    void setEntryNumber(EntryNumber newEntryNumber);
     void insertEntryForIndex(unsigned int index);
     std::vector<std::string> const& branchNames() const { return branchNames_; }
     RootDelayedReaderBase* rootDelayedReader() const;
@@ -230,6 +230,7 @@ namespace edm {
     unsigned long treeAutoFlush_ = 0;
     bool promptRead_;
     std::unique_ptr<RootDelayedReaderBase> rootDelayedReader_;
+    //All access to a ROOT file is serialized
     CMS_SA_ALLOW mutable std::unique_ptr<roottree::CacheManagerBase> treeCacheManager_;
 
     TBranch* branchEntryInfoBranch_ = nullptr;  //backwards compatibility

--- a/IOPool/Input/src/RootTree.h
+++ b/IOPool/Input/src/RootTree.h
@@ -99,7 +99,7 @@ namespace edm {
       bool promptReading = false;
 
       Options usingDefaultNonEventOptions() const {
-        return {roottree::defaultNonEventCacheSize, treeMaxVirtualSize, enablePrefetching, false};
+        return {roottree::defaultNonEventCacheSize, treeMaxVirtualSize, enablePrefetching, true};
       }
     };
 

--- a/IOPool/Input/src/RootTreeCacheManager.cc
+++ b/IOPool/Input/src/RootTreeCacheManager.cc
@@ -198,7 +198,6 @@ namespace edm {
             learningEntries_(learningEntries),
             enablePrefetching_(enablePrefetching),
             enableTriggerCache_(branchType_ == InEvent) {}
-      ~SparseReadCache() override { reset(); }
       void createPrimaryCache(unsigned int cacheSize) override;
       void resetTraining(bool promptRead) override;
       void reset() override;

--- a/IOPool/Input/src/RootTreeCacheManager.cc
+++ b/IOPool/Input/src/RootTreeCacheManager.cc
@@ -1,0 +1,546 @@
+#include "InputFile.h"
+#include "RootTreeCacheManager.h"
+
+#include "DataFormats/Provenance/interface/BranchType.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "TBranch.h"
+#include "TTree.h"
+#include "TTreeCache.h"
+#include "TTreeCacheUnzip.h"
+
+#include <unordered_set>
+#include <cassert>
+
+#include "oneapi/tbb/task_arena.h"
+
+//#define CACHESTATS
+#define PARALLELUNZIP
+
+namespace edm {
+  namespace roottree {
+    void CacheManagerBase::getEntry(TBranch* branch, EntryNumber entryNumber) { branch->GetEntry(entryNumber); }
+    void CacheManagerBase::getAuxEntry(TBranch* branch, EntryNumber entryNumber) { branch->GetEntry(entryNumber); }
+
+    //
+    // SimpleCache implements a policy that uses the TTreeCache
+    // in a straightforward way, with no swapping of Caches.
+    // It is intended for use primarily in production-like jobs
+    // that read nearly all the branches in a file sequentially,
+    // with little or no event selection or other event skipping.
+    //
+    class SimpleCache : public CacheManagerBase {
+    public:
+      SimpleCache(std::shared_ptr<InputFile> filePtr,
+                  unsigned int learningEntries,
+                  bool enablePrefetching,
+                  BranchType const& branchType);
+      void reset() override;
+      void createPrimaryCache(unsigned int cacheSize) override;
+      void setEntryNumber(EntryNumber theEntryNumber, EntryNumber entryNumber, EntryNumber entries) override;
+      void trainCache(char const* branchNames) override;
+      void resetTraining() override;
+      void getEntry(TBranch* branch, EntryNumber entryNumber) override;
+      void getEntryForAllBranches(EntryNumber entryNumber) const override;
+
+    private:
+      // SimpleCache does not own the treeCache_
+      TTreeCache* treeCache_;
+      BranchType branchType_;
+      unsigned int learningEntries_;
+      bool enablePrefetching_;
+    };
+
+    SimpleCache::SimpleCache(std::shared_ptr<InputFile> filePtr,
+                             unsigned int learningEntries,
+                             bool enablePrefetching,
+                             BranchType const& branchType)
+        : CacheManagerBase(filePtr),
+          branchType_(branchType),
+          learningEntries_(learningEntries),
+          enablePrefetching_(enablePrefetching) {
+#ifdef PARALLELUNZIP
+      if (branchType_ == InEvent) {
+        TTreeCacheUnzip::SetParallelUnzip();
+      }
+#endif
+    }
+
+    void SimpleCache::reset() {
+      if (treeCache_) {
+#ifdef CACHESTATS
+        treeCache_->Print("a cachedbranches");
+#endif
+        treeCache_->DropBranch("*");
+      }
+    }
+
+    void SimpleCache::setEntryNumber(EntryNumber theEntryNumber, EntryNumber entryNumber, EntryNumber entries) {
+      if (theEntryNumber != entryNumber) {
+        tree_->LoadTree(theEntryNumber);
+        oneapi::tbb::this_task_arena::isolate([&]() { treeCache_->FillBuffer(); });
+      }
+    }
+
+    void SimpleCache::getEntry(TBranch* branch, EntryNumber entryNumber) {
+      oneapi::tbb::this_task_arena::isolate([&]() { branch->GetEntry(entryNumber); });
+    }
+
+    void SimpleCache::getEntryForAllBranches(EntryNumber entryNumber) const {
+      oneapi::tbb::this_task_arena::isolate([&]() { tree_->GetEntry(entryNumber); });
+    }
+
+    void SimpleCache::createPrimaryCache(unsigned int cacheSize) {
+#ifdef PARALLELUNZIP
+      tree_->SetParallelUnzip(branchType_ == InEvent);
+#endif
+
+      tree_->SetCacheSize(static_cast<Long64_t>(cacheSize));
+      treeCache_ = dynamic_cast<TTreeCache*>(filePtr_->getCacheRead(tree_));
+
+      assert(treeCache_);
+
+      treeCache_->SetEnablePrefetching(enablePrefetching_);
+      treeCache_->SetLearnEntries(learningEntries_);
+      treeCache_->SetOptimizeMisses(true);
+    }
+
+    void SimpleCache::resetTraining() {
+      reset();
+      trainCache(nullptr);
+      treeCache_->SetLearnEntries(learningEntries_);
+    }
+
+    void SimpleCache::trainCache(char const* branchNames) {
+      if (branchType_ != InEvent) {
+        tree_->SetParallelUnzip(false);
+      }
+      treeCache_->StartLearningPhase();
+      tree_->LoadTree(0);
+      tree_->SetCacheEntryRange(0, tree_->GetEntries());
+      if (branchNames) {
+        tree_->AddBranchToCache(branchNames, kTRUE);
+      }
+    }
+
+    //
+    // SparseReadCache implements a policy for jobs with access
+    // patterns typical of late-stage analysis jobs, which may
+    // read only a sparse selection of branches from selected
+    // events.  Handles many special cases by swapping between
+    // different specialized caches.  Is not thread safe.
+    //
+    class SparseReadCache : public CacheManagerBase {
+    public:
+      SparseReadCache(std::shared_ptr<InputFile> filePtr,
+                      unsigned int learningEntries,
+                      bool enablePrefetching,
+                      BranchType const& branchType)
+          : CacheManagerBase(filePtr),
+            branchType_(branchType),
+            learningEntries_(learningEntries),
+            enablePrefetching_(enablePrefetching),
+            enableTriggerCache_(branchType_ == InEvent) {}
+      ~SparseReadCache() override { reset(); }
+      void createPrimaryCache(unsigned int cacheSize) override;
+      void resetTraining() override;
+      void reset() override;
+      void setEntryNumber(EntryNumber theEntryNumber, EntryNumber entryNumber, EntryNumber entries) override;
+      void trainCache(char const* branchNames) override;
+      void getEntry(TBranch* branch, EntryNumber entryNumber) override;
+      void getAuxEntry(TBranch* auxBranch, EntryNumber entryNumber) override;
+      void init(TTree* tree, unsigned int treeAutoFlush) override;
+      void reserve(Int_t branchCount) override;
+      void getEntryForAllBranches(EntryNumber entryNumber) const override;
+      ;
+
+    private:
+      void getEntryUsingCache(TBranch* branch, EntryNumber entryNumber, TTreeCache* cache);
+      TTreeCache* getAuxCache(TBranch* auxBranch);
+      std::shared_ptr<TTreeCache> createCacheWithSize(unsigned int cacheSize);
+      TTreeCache* selectCache(TBranch* branch, EntryNumber entryNumber);
+      TTreeCache* checkTriggerCache(TBranch* branch, EntryNumber entryNumber);
+      TTreeCache* checkTriggerCacheImpl(TBranch* branch, EntryNumber entryNumber);
+      void startTraining(EntryNumber entryNumber);
+      void stopTraining();
+
+      BranchType branchType_;
+      bool trainNow_ = false;
+      EntryNumber switchOverEntry_ = -1;
+      EntryNumber rawTriggerSwitchOverEntry_ = -1;
+      bool performedSwitchOver_ = false;
+      unsigned int learningEntries_;
+      unsigned int cacheSize_ = 0;
+      unsigned long treeAutoFlush_ = 0;
+
+      // Enable asynchronous I/O in ROOT (done in a separate thread).  Only takes
+      // effect on the primary treeCache_; all other caches have this explicitly disabled.
+      bool enablePrefetching_;
+      bool enableTriggerCache_;
+
+      // We use a smart pointer to own the TTreeCache.
+      // Unfortunately, ROOT owns it when attached to a TFile, but not after it is detached.
+      // So, we make sure to it is detached before closing the TFile so there is no double delete.
+      std::shared_ptr<TTreeCache> treeCache_;
+      std::shared_ptr<TTreeCache> rawTreeCache_;
+      std::shared_ptr<TTreeCache> auxCache_;
+      std::shared_ptr<TTreeCache> triggerTreeCache_;
+      std::shared_ptr<TTreeCache> rawTriggerTreeCache_;
+
+      std::unordered_set<TBranch*> trainedSet_;
+      std::unordered_set<TBranch*> triggerSet_;
+    };
+
+    std::shared_ptr<TTreeCache> SparseReadCache::createCacheWithSize(unsigned int cacheSize) {
+      return filePtr_->createCacheWithSize(*tree_, cacheSize);
+    }
+
+    void SparseReadCache::createPrimaryCache(unsigned int cacheSize) {
+      cacheSize_ = cacheSize;
+      treeCache_ = createCacheWithSize(cacheSize);
+      if (treeCache_)
+        treeCache_->SetEnablePrefetching(enablePrefetching_);
+      rawTreeCache_.reset();
+    }
+
+    TTreeCache* SparseReadCache::checkTriggerCache(TBranch* branch, EntryNumber entryNumber) {
+      if (!treeCache_->IsAsyncReading() && enableTriggerCache_ && (trainedSet_.find(branch) == trainedSet_.end())) {
+        return checkTriggerCacheImpl(branch, entryNumber);
+      } else {
+        return nullptr;
+      }
+    }
+
+    // If this function is called, we already know
+    // the trigger cache is active and it was a cache miss for the regular cache.
+    TTreeCache* SparseReadCache::checkTriggerCacheImpl(TBranch* branch, EntryNumber entryNumber) {
+      // This branch is not going to be in the cache.
+      // Assume this is a "trigger pattern".
+      // Always make sure the branch is added to the trigger set.
+      if (triggerSet_.find(branch) == triggerSet_.end()) {
+        triggerSet_.insert(branch);
+        if (triggerTreeCache_.get()) {
+          triggerTreeCache_->AddBranch(branch, kTRUE);
+        }
+      }
+
+      if (rawTriggerSwitchOverEntry_ < 0) {
+        // The trigger has never fired before.  Take everything not in the
+        // trainedSet and load it from disk
+
+        // Calculate the end of the next cluster; triggers in the next cluster
+        // will use the triggerCache, not the rawTriggerCache.
+        //
+        // Guarantee that rawTriggerSwitchOverEntry_ is positive (non-zero) after completion
+        // of this if-block.
+        TTree::TClusterIterator clusterIter = tree_->GetClusterIterator(entryNumber);
+        while ((rawTriggerSwitchOverEntry_ < entryNumber) || (rawTriggerSwitchOverEntry_ <= 0)) {
+          rawTriggerSwitchOverEntry_ = clusterIter();
+        }
+
+        // ROOT will automatically expand the cache to fit one cluster; hence, we use
+        // 5 MB as the cache size below
+        rawTriggerTreeCache_ = createCacheWithSize(5 * 1024 * 1024);
+        if (rawTriggerTreeCache_) {
+          rawTriggerTreeCache_->SetEnablePrefetching(false);
+          TObjArray* branches = tree_->GetListOfBranches();
+          int branchCount = branches->GetEntriesFast();
+
+          // Train the rawTriggerCache to have everything not in the regular cache.
+          rawTriggerTreeCache_->SetLearnEntries(0);
+          rawTriggerTreeCache_->SetEntryRange(entryNumber, rawTriggerSwitchOverEntry_);
+          for (int i = 0; i < branchCount; i++) {
+            auto tmp_branch = dynamic_cast<TBranch*>(branches->UncheckedAt(i));
+            if (trainedSet_.find(tmp_branch) != trainedSet_.end()) {
+              continue;
+            }
+            rawTriggerTreeCache_->AddBranch(tmp_branch, kTRUE);
+          }
+          rawTriggerTreeCache_->StopLearningPhase();
+        }
+        performedSwitchOver_ = false;
+
+        return rawTriggerTreeCache_.get();
+      } else if (!performedSwitchOver_ and entryNumber < rawTriggerSwitchOverEntry_) {
+        // The raw trigger has fired and it contents are valid.
+        return rawTriggerTreeCache_.get();
+      } else if (rawTriggerSwitchOverEntry_ > 0) {
+        // The raw trigger has fired, but we are out of the cache.  Use the
+        // triggerCache instead.
+        if (!performedSwitchOver_) {
+          rawTriggerTreeCache_.reset();
+          performedSwitchOver_ = true;
+
+          // Train the triggerCache
+          triggerTreeCache_ = createCacheWithSize(5 * 1024 * 1024);
+          triggerTreeCache_->SetEnablePrefetching(false);
+          triggerTreeCache_->SetLearnEntries(0);
+          triggerTreeCache_->SetEntryRange(entryNumber, tree_->GetEntries());
+          for (std::unordered_set<TBranch*>::const_iterator it = triggerSet_.begin(), itEnd = triggerSet_.end();
+               it != itEnd;
+               it++) {
+            triggerTreeCache_->AddBranch(*it, kTRUE);
+          }
+          triggerTreeCache_->StopLearningPhase();
+        }
+        return triggerTreeCache_.get();
+      }
+
+      // By construction, this case should be impossible.
+      assert(false);
+      return nullptr;
+    }
+
+    TTreeCache* SparseReadCache::getAuxCache(TBranch* auxBranch) {
+      if (not auxCache_ and cacheSize_ > 0) {
+        auxCache_ = createCacheWithSize(1 * 1024 * 1024);
+        if (auxCache_) {
+          auxCache_->SetEnablePrefetching(enablePrefetching_);
+          auxCache_->SetLearnEntries(0);
+          auxCache_->StartLearningPhase();
+          auxCache_->SetEntryRange(0, tree_->GetEntries());
+          auxCache_->AddBranch(auxBranch->GetName(), kTRUE);
+          auxCache_->StopLearningPhase();
+        }
+      }
+      return auxCache_.get();
+    }
+
+    TTreeCache* SparseReadCache::selectCache(TBranch* branch, EntryNumber entryNumber) {
+      TTreeCache* triggerCache = nullptr;
+      if (!treeCache_) {
+        return nullptr;
+      } else if (treeCache_->IsLearning() && rawTreeCache_) {
+        treeCache_->AddBranch(branch, kTRUE);
+        trainedSet_.insert(branch);
+        return rawTreeCache_.get();
+      } else if ((triggerCache = checkTriggerCache(branch, entryNumber))) {
+        // A NULL return value from checkTriggerCache indicates the trigger cache case
+        // does not apply, and we should continue below.
+        return triggerCache;
+      } else {
+        // The "normal" TTreeCache case.
+        return treeCache_.get();
+      }
+    }
+
+    void SparseReadCache::getEntryUsingCache(TBranch* branch, EntryNumber entryNumber, TTreeCache* cache) {
+      // We make sure the treeCache_ is detached from the file,
+      // so that ROOT does not also delete it.
+      try {
+        auto guard = filePtr_->setCacheReadTemporarily(cache, tree_);
+        branch->GetEntry(entryNumber);
+      } catch (cms::Exception const& e) {
+        Exception t(errors::FileReadError, "", e);
+        t.addContext(std::string("Reading branch ") + branch->GetName());
+        throw t;
+      } catch (std::exception const& e) {
+        Exception t(errors::FileReadError);
+        t << e.what();
+        t.addContext(std::string("Reading branch ") + branch->GetName());
+        throw t;
+      } catch (...) {
+        Exception t(errors::FileReadError);
+        t << "An exception of unknown type was thrown.";
+        t.addContext(std::string("Reading branch ") + branch->GetName());
+        throw t;
+      }
+    }
+
+    void SparseReadCache::getEntry(TBranch* branch, EntryNumber entryNumber) {
+      auto cache = selectCache(branch, entryNumber);
+      getEntryUsingCache(branch, entryNumber, cache);
+    }
+
+    void SparseReadCache::getAuxEntry(TBranch* branch, EntryNumber entryNumber) {
+      auto cache = getAuxCache(branch);
+      getEntryUsingCache(branch, entryNumber, cache);
+    }
+
+    void SparseReadCache::getEntryForAllBranches(EntryNumber entryNumber) const {
+      oneapi::tbb::this_task_arena::isolate([&]() {
+        auto guard = filePtr_->setCacheReadTemporarily(treeCache_.get(), tree_);
+        tree_->GetEntry(entryNumber);
+      });
+    }
+
+    void SparseReadCache::startTraining(EntryNumber entryNumber) {
+      if (cacheSize_ == 0) {
+        return;
+      }
+      assert(treeCache_);
+      assert(branchType_ == InEvent);
+      assert(!rawTreeCache_);
+
+      switchOverEntry_ = entryNumber + learningEntries_;
+      auto treeStart = switchOverEntry_;
+
+      treeCache_->SetLearnEntries(learningEntries_);
+      rawTreeCache_ = createCacheWithSize(cacheSize_);
+      if (rawTreeCache_) {
+        rawTreeCache_->SetEnablePrefetching(false);
+        rawTreeCache_->SetLearnEntries(0);
+        auto rawStart = entryNumber;
+        auto rawEnd = switchOverEntry_;
+        if (switchOverEntry_ >= tree_->GetEntries()) {
+          treeStart = switchOverEntry_ - tree_->GetEntries();
+          rawEnd = tree_->GetEntries();
+        }
+        rawTreeCache_->StartLearningPhase();
+        rawTreeCache_->SetEntryRange(rawStart, rawEnd);
+        rawTreeCache_->AddBranch("*", kTRUE);
+        rawTreeCache_->StopLearningPhase();
+      }
+      treeCache_->StartLearningPhase();
+      treeCache_->SetEntryRange(treeStart, tree_->GetEntries());
+      // Make sure that 'branchListIndexes' branch exist in input file
+      if (filePtr_->Get(poolNames::branchListIndexesBranchName().c_str()) != nullptr) {
+        treeCache_->AddBranch(poolNames::branchListIndexesBranchName().c_str(), kTRUE);
+      }
+      treeCache_->AddBranch(BranchTypeToAuxiliaryBranchName(branchType_).c_str(), kTRUE);
+      trainedSet_.clear();
+      triggerSet_.clear();
+      assert(treeCache_->GetTree() == tree_);
+    }
+
+    void SparseReadCache::stopTraining() {
+      auto guard = filePtr_->setCacheReadTemporarily(treeCache_.get(), tree_);
+      treeCache_->StopLearningPhase();
+      rawTreeCache_.reset();
+    }
+
+    void SparseReadCache::resetTraining() { trainNow_ = true; }
+
+    void SparseReadCache::reset() {
+#ifdef CACHESTATS
+      if (treeCache_)
+        treeCache_->Print("a cachedbranches");
+      if (rawTreeCache_)
+        rawTreeCache_->Print("a cachedbranches");
+      if (triggerTreeCache_)
+        triggerTreeCache_->Print("a cachedbranches");
+      if (rawTriggerTreeCache_)
+        rawTriggerTreeCache_->Print("a cachedbranches");
+      if (auxCache_)
+        auxCache_->Print("a cachedbranches");
+#endif
+      treeCache_.reset();
+      rawTreeCache_.reset();
+      triggerTreeCache_.reset();
+      rawTriggerTreeCache_.reset();
+      auxCache_.reset();
+    }
+
+    void SparseReadCache::setEntryNumber(EntryNumber theEntryNumber, EntryNumber entryNumber, EntryNumber entries) {
+      {
+        auto guard = filePtr_->setCacheReadTemporarily(treeCache_.get(), tree_);
+
+        // Detect a backward skip.  If the skip is sufficiently large, we roll the dice and reset the treeCache.
+        // This will cause some amount of over-reading: we pre-fetch all the events in some prior cluster.
+        // However, because reading one event in the cluster is supposed to be equivalent to reading all events in the cluster,
+        // we're not incurring additional over-reading - we're just doing it more efficiently.
+        // NOTE: Constructor guarantees treeAutoFlush_ is positive, even if TTree->GetAutoFlush() is negative.
+        if (theEntryNumber < entryNumber and theEntryNumber >= 0) {
+          //We started reading the file near the end, now we need to correct for the learning length
+          if (switchOverEntry_ > tree_->GetEntries()) {
+            switchOverEntry_ = switchOverEntry_ - tree_->GetEntries();
+            if (rawTreeCache_) {
+              rawTreeCache_->SetEntryRange(theEntryNumber, switchOverEntry_);
+              rawTreeCache_->FillBuffer();
+            }
+          }
+          if (performedSwitchOver_ and triggerTreeCache_) {
+            //We are using the triggerTreeCache_ not the rawTriggerTreeCache_.
+            //The triggerTreeCache was originally told to start from an entry further in the file.
+            triggerTreeCache_->SetEntryRange(theEntryNumber, tree_->GetEntries());
+          } else if (rawTriggerTreeCache_) {
+            //move the switch point to the end of the cluster holding theEntryNumber
+            rawTriggerSwitchOverEntry_ = -1;
+            TTree::TClusterIterator clusterIter = tree_->GetClusterIterator(theEntryNumber);
+            while ((rawTriggerSwitchOverEntry_ < theEntryNumber) || (rawTriggerSwitchOverEntry_ <= 0)) {
+              rawTriggerSwitchOverEntry_ = clusterIter();
+            }
+            rawTriggerTreeCache_->SetEntryRange(theEntryNumber, rawTriggerSwitchOverEntry_);
+          }
+        }
+        if ((theEntryNumber < static_cast<EntryNumber>(entryNumber - treeAutoFlush_)) && (treeCache_) &&
+            (!treeCache_->IsLearning()) && (entries > 0) && (switchOverEntry_ >= 0)) {
+          treeCache_->SetEntryRange(theEntryNumber, entries);
+          treeCache_->FillBuffer();
+        }
+
+        tree_->LoadTree(theEntryNumber);
+      }
+      if (treeCache_ && trainNow_ && theEntryNumber >= 0) {
+        startTraining(theEntryNumber);
+        trainNow_ = false;
+        trainedSet_.clear();
+        triggerSet_.clear();
+        rawTriggerSwitchOverEntry_ = -1;
+      }
+      if (treeCache_ && treeCache_->IsLearning() && switchOverEntry_ >= 0 && theEntryNumber >= switchOverEntry_) {
+        stopTraining();
+      }
+    }
+
+    void SparseReadCache::trainCache(char const* branchNames) {
+      // We own the treeCache_.
+      // We make sure the treeCache_ is detached from the file,
+      // so that ROOT does not also delete it.
+
+      if (cacheSize_ == 0) {
+        return;
+      }
+
+      tree_->LoadTree(0);
+      assert(treeCache_);
+      {
+        auto guard = filePtr_->setCacheReadTemporarily(treeCache_.get(), tree_);
+        treeCache_->StartLearningPhase();
+        treeCache_->SetEntryRange(0, tree_->GetEntries());
+        treeCache_->AddBranch(branchNames, kTRUE);
+        treeCache_->StopLearningPhase();
+        assert(treeCache_->GetTree() == tree_);
+        //want guard to end here
+      }
+      if (branchType_ == InEvent) {
+        // Must also manually add things to the trained set.
+        TObjArray* branches = tree_->GetListOfBranches();
+        int branchCount = branches->GetEntriesFast();
+        for (int i = 0; i < branchCount; i++) {
+          TBranch* branch = (TBranch*)branches->UncheckedAt(i);
+          if ((branchNames[0] == '*') || (strcmp(branchNames, branch->GetName()) == 0)) {
+            trainedSet_.insert(branch);
+          }
+        }
+      }
+    }
+
+    void SparseReadCache::init(TTree* tree, unsigned int treeAutoFlush) {
+      tree_ = tree;
+      treeAutoFlush_ = treeAutoFlush;
+      if (treeAutoFlush < learningEntries_) {
+        learningEntries_ = treeAutoFlush;
+      }
+    }
+
+    void SparseReadCache::reserve(Int_t branchCount) {
+      trainedSet_.reserve(branchCount);
+      triggerSet_.reserve(branchCount);
+    }
+
+    std::unique_ptr<CacheManagerBase> CacheManagerBase::create(const std::string& strategy,
+                                                               std::shared_ptr<InputFile> filePtr,
+                                                               unsigned int learningEntries,
+                                                               bool enablePrefetching,
+                                                               BranchType const& branchType) {
+      if (strategy == "Simple") {
+        return std::make_unique<SimpleCache>(filePtr, learningEntries, enablePrefetching, branchType);
+      } else if (strategy == "Sparse") {
+        return std::make_unique<SparseReadCache>(filePtr, learningEntries, enablePrefetching, branchType);
+      }
+      throw cms::Exception("BadConfig") << "CacheManagerBase:  unknown cache strategy requested: " << strategy;
+    }
+  }  // namespace roottree
+}  // namespace edm

--- a/IOPool/Input/src/RootTreeCacheManager.h
+++ b/IOPool/Input/src/RootTreeCacheManager.h
@@ -19,7 +19,7 @@
 
 #include <memory>
 
-class TFileCacheRead;
+class TTreeCache;
 class TBranch;
 class TTree;
 
@@ -34,6 +34,7 @@ namespace edm {
       enum class CacheStrategy {
         kNone,
         kSimple,
+        kSimpleWithAuxCache,
         kSparse,
       };
 
@@ -45,7 +46,7 @@ namespace edm {
       // non-serial reads, especially skipping backwards in the tree
       virtual void setEntryNumber(EntryNumber nextEntryNumber, EntryNumber entryNumber, EntryNumber entries) = 0;
 
-      virtual void resetTraining() {}
+      virtual void resetTraining(bool promptRead = false) {}
       virtual void reset() {}
       virtual void trainCache(char const* branchNames) {}
       virtual void init(TTree* tree, unsigned int treeAutoFlush) { tree_ = tree; }
@@ -61,6 +62,8 @@ namespace edm {
                                                       BranchType const& branchType);
 
     protected:
+      std::shared_ptr<TTreeCache> createCacheWithSize(unsigned int cacheSize);
+
       std::shared_ptr<InputFile> filePtr_;
       TTree* tree_ = nullptr;
 

--- a/IOPool/Input/src/RootTreeCacheManager.h
+++ b/IOPool/Input/src/RootTreeCacheManager.h
@@ -1,0 +1,62 @@
+#ifndef IOPool_Input_RootTreeCacheManager_h
+#define IOPool_Input_RootTreeCacheManager_h
+// -*- C++ -*-
+//
+// Package:     IOPool/Input
+// Class  :     roottree::CacheManagerBase
+//
+/**\class roottree::CacheManagerBase RootTreeCacheManager.h IOPool/Input/src/RootTreeCacheManager.h
+
+ Description: Base class for TTreeCache policy implementations
+
+ Usage:
+    <usage>
+
+*/
+
+#include "DataFormats/Provenance/interface/IndexIntoFile.h"
+#include "FWCore/Utilities/interface/BranchType.h"
+
+#include <memory>
+
+class TFileCacheRead;
+class TBranch;
+class TTree;
+
+namespace edm {
+  class InputFile;
+
+  namespace roottree {
+    using EntryNumber = IndexIntoFile::EntryNumber_t;
+
+    class CacheManagerBase {
+    public:
+      CacheManagerBase(std::shared_ptr<InputFile> filePtr) : filePtr_(filePtr) {}
+      virtual ~CacheManagerBase() = default;
+
+      virtual void createPrimaryCache(unsigned int cacheSize) = 0;
+      virtual void setEntryNumber(EntryNumber theEntryNumber, EntryNumber entryNumber, EntryNumber entries) = 0;
+
+      virtual void resetTraining() {}
+      virtual void reset() {}
+      virtual void trainCache(char const* branchNames) {}
+      virtual void init(TTree* tree, unsigned int treeAutoFlush) { tree_ = tree; }
+      virtual void reserve(Int_t branchCount) {}
+      virtual void getEntry(TBranch* branch, EntryNumber entryNumber);
+      virtual void getAuxEntry(TBranch* auxBranch, EntryNumber entryNumber);
+      virtual void getEntryForAllBranches(EntryNumber entryNumber) const = 0;
+
+      static std::unique_ptr<CacheManagerBase> create(const std::string& strategy,
+                                                      std::shared_ptr<InputFile> filePtr,
+                                                      unsigned int learningEntries,
+                                                      bool enablePrefetching,
+                                                      BranchType const& branchType);
+
+    protected:
+      std::shared_ptr<InputFile> filePtr_;
+      TTree* tree_ = nullptr;
+    };
+
+  }  // namespace roottree
+}  // namespace edm
+#endif

--- a/IOPool/Input/src/RootTreeCacheManager.h
+++ b/IOPool/Input/src/RootTreeCacheManager.h
@@ -31,11 +31,19 @@ namespace edm {
 
     class CacheManagerBase {
     public:
+      enum class CacheStrategy {
+        kNone,
+        kSimple,
+        kSparse,
+      };
+
       CacheManagerBase(std::shared_ptr<InputFile> filePtr) : filePtr_(filePtr) {}
       virtual ~CacheManagerBase() = default;
 
       virtual void createPrimaryCache(unsigned int cacheSize) = 0;
-      virtual void setEntryNumber(EntryNumber theEntryNumber, EntryNumber entryNumber, EntryNumber entries) = 0;
+      // set the tree to read at nextEntryNumber; the current entryNumber is used when detecting
+      // non-serial reads, especially skipping backwards in the tree
+      virtual void setEntryNumber(EntryNumber nextEntryNumber, EntryNumber entryNumber, EntryNumber entries) = 0;
 
       virtual void resetTraining() {}
       virtual void reset() {}
@@ -44,9 +52,9 @@ namespace edm {
       virtual void reserve(Int_t branchCount) {}
       virtual void getEntry(TBranch* branch, EntryNumber entryNumber);
       virtual void getAuxEntry(TBranch* auxBranch, EntryNumber entryNumber);
-      virtual void getEntryForAllBranches(EntryNumber entryNumber) const = 0;
+      virtual void getEntryForAllBranches(EntryNumber entryNumber) const;
 
-      static std::unique_ptr<CacheManagerBase> create(const std::string& strategy,
+      static std::unique_ptr<CacheManagerBase> create(CacheStrategy strategy,
                                                       std::shared_ptr<InputFile> filePtr,
                                                       unsigned int learningEntries,
                                                       bool enablePrefetching,
@@ -55,6 +63,8 @@ namespace edm {
     protected:
       std::shared_ptr<InputFile> filePtr_;
       TTree* tree_ = nullptr;
+
+      static constexpr bool cachestats = false;
     };
 
   }  // namespace roottree


### PR DESCRIPTION
#### PR description:

This PR moves all the TTreeCache management logic from the RootTree class into a new CacheManagerBase abstract base class and two specializations.  SparseReadCache implements the complicated cache-switching logic used by default.  SimpleCache implements a simplified version of the caching logic from #48088 that allows use of TTree::GetEntry.

Simplification of the simple caching case results in an improved IO profile.  By factoring out the two use cases, this also provides a better base for future modifications (especially to the simple caching case).

#### PR validation:

Tested on an AOD to MINIAOD production job similar to the one used for validation of #48088.  A limited matrix test job was also run.  This is a purely technical change to the ROOT file input system, no changes are expected in physics results.

resolves https://github.com/cms-sw/framework-team/issues/126