### PR TITLE
[mkFit] propagation to plane in backward fit phase2 and bug fix

### DIFF
--- a/RecoTracker/MkFitCMS/interface/LayerNumberConverter.h
+++ b/RecoTracker/MkFitCMS/interface/LayerNumberConverter.h
@@ -25,14 +25,16 @@ namespace mkfit {
     bool isPhase2() const { return lo_ == TkLayout::phase2; }
     int convertLayerNumber(int det, int lay, bool useMatched, int isStereo, bool posZ) const {
       if (lo_ == TkLayout::phase2) {
+        // For TOB / TEC stereo is used for P in PS modules so we move stereo before the other
+        // one. The same is done for 2S layers (well, TEC is mixed PS / 2S anyway).
         if (det == 1)
           return lay - 1;
         if (det == 2)
           return 16 + lay - 1 + (posZ ? 0 : 22);
         if (det == 5)
-          return 4 + (2 * (lay - 1)) + isStereo;
+          return 4 + (2 * (lay - 1)) + 1 - isStereo;
         if (det == 4)
-          return 16 + 12 + (2 * (lay - 1)) + isStereo + (posZ ? 0 : 22);
+          return 16 + 12 + (2 * (lay - 1)) + 1 - isStereo + (posZ ? 0 : 22);
         throw std::runtime_error("bad subDet");
       }
 

--- a/RecoTracker/MkFitCore/interface/Config.h
+++ b/RecoTracker/MkFitCore/interface/Config.h
@@ -49,6 +49,8 @@ namespace mkfit {
     // Config for propagation - could/should enter into PropagationFlags?!
     constexpr int Niter = 5;
     constexpr bool useTrigApprox = true;
+    // for prop to plane getS step
+    constexpr int nSStepsInProp2Plane = 2;
     // Move to Config.cc, make a command-line option in mkFit.cc to ease profiling comparisons.
     // If making this constexpr again, also fix ifs using it in MkBuilder.cc and MkFinder.cc.
     // constexpr bool usePropToPlane = true;

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.h
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.h
@@ -10,6 +10,15 @@ namespace mkfit {
 
   enum KalmanFilterOperation { KFO_Calculate_Chi2 = 1, KFO_Update_Params = 2, KFO_Local_Cov = 4 };
 
+  inline void kalmanCheckChargeFlip(MPlexLV& outPar, MPlexQI& Chg, int N_proc) {
+    for (int n = 0; n < NN; ++n) {
+      if (n < N_proc && outPar.At(n, 3, 0) < 0) {
+        Chg.At(n, 0, 0) = -Chg.At(n, 0, 0);
+        outPar.At(n, 3, 0) = -outPar.At(n, 3, 0);
+      }
+    }
+  }
+
   //------------------------------------------------------------------------------
 
   void kalmanUpdate(const MPlexLS& psErr,

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -1381,18 +1381,31 @@ namespace mkfit {
       }
 #endif
 
-      // input tracks
-      mkfndr->bkFitInputTracks(eoccs, icand, end);
+      if (Config::usePropToPlane) {
+        // input tracks
+        mkfndr->bkFitInputTracks(eoccs, icand, end);
+        // fit tracks back to first layer
+        mkfndr->bkFitFitTracksProp2Plane(m_job->m_event_of_hits, st_par, end - icand, chi_debug);
+        // tracks are put back into correcponding TrackCand when finsihed in the above function
+        // now move one last time to PCA
+        if (prop_config.backward_fit_to_pca) {
+          mkfndr->bkFitInputTracks(eoccs, icand, end);
+          mkfndr->bkFitPropTracksToPCA(end - icand);
+          mkfndr->bkFitOutputTracks(eoccs, icand, end, prop_config.backward_fit_to_pca);
+        }
+      } else {
+        // input tracks
+        mkfndr->bkFitInputTracks(eoccs, icand, end);
+        // fit tracks back to first layer
+        mkfndr->bkFitFitTracks(m_job->m_event_of_hits, st_par, end - icand, chi_debug);
 
-      // fit tracks back to first layer
-      mkfndr->bkFitFitTracks(m_job->m_event_of_hits, st_par, end - icand, chi_debug);
+        // now move one last time to PCA
+        if (prop_config.backward_fit_to_pca) {
+          mkfndr->bkFitPropTracksToPCA(end - icand);
+        }
 
-      // now move one last time to PCA
-      if (prop_config.backward_fit_to_pca) {
-        mkfndr->bkFitPropTracksToPCA(end - icand);
+        mkfndr->bkFitOutputTracks(eoccs, icand, end, prop_config.backward_fit_to_pca);
       }
-
-      mkfndr->bkFitOutputTracks(eoccs, icand, end, prop_config.backward_fit_to_pca);
 
 #ifdef DEBUG_FINAL_FIT
       dprintf("Post Final fit for %d - %d\n", icand, end);

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -984,8 +984,8 @@ namespace mkfit {
         for (bidx_t pi = pb1; pi != pb2; pi = L.phiMaskApply(pi + 1)) {
           // Limit to central Q-bin
           if (qi == qb && L.isBinDead(pi, qi) == true) {
-            dprint("dead module for track in layer=" << L.layer_id() << " qb=" << qi << " pi=" << pi
-                                                     << " q=" << B.m_q_center[itrack] << " phi=" << B.m_phi_center[itrack]);
+            dprint("dead module for track in layer=" << L.layer_id() << " qb=" << qi << " pi=" << pi << " q="
+                                                     << B.m_q_center[itrack] << " phi=" << B.m_phi_center[itrack]);
             m_XWsrResult[itrack].m_in_gap = true;
           }
 
@@ -2456,9 +2456,9 @@ namespace mkfit {
     MPlexQF tmp_chi2;
     MPlexQI done_flag(0);
 
-    MPlexHV plNrm; // input detector plane [pl - plane]
-    MPlexHV plDir; // ""
-    MPlexHV plPnt; // ""
+    MPlexHV plNrm;  // input detector plane [pl - plane]
+    MPlexHV plDir;  // ""
+    MPlexHV plPnt;  // ""
 
 #if defined(DEBUG_PROP_UPDATE)
     const int DSLOT = 0;
@@ -2469,7 +2469,6 @@ namespace mkfit {
 
     int done_count = 0;
     while (done_count != N_proc) {
-
 #if defined(DEBUG_BACKWARD_FIT)
       const Hit *last_hit_ptr[NN];
 #endif
@@ -2568,13 +2567,13 @@ namespace mkfit {
 
       // Fixup for failed propagation.
       // for (int i = 0; i < NN; ++i) {
-        // PROP-FAIL-ENABLE The following to be enabled when propagation failure
-        // detection is properly implemented in propagate-to-R/Z.
-        // 1. The following code was only expecting barrel state to be restored.
-        //      auto barrel_pf(m_prop_config->backward_fit_pflags);
-        //      barrel_pf.copy_input_state_on_fail = true;
-        // 2. There is also check on chi2, commented out to keep physics changes minimal.
-        /*
+      // PROP-FAIL-ENABLE The following to be enabled when propagation failure
+      // detection is properly implemented in propagate-to-R/Z.
+      // 1. The following code was only expecting barrel state to be restored.
+      //      auto barrel_pf(m_prop_config->backward_fit_pflags);
+      //      barrel_pf.copy_input_state_on_fail = true;
+      // 2. There is also check on chi2, commented out to keep physics changes minimal.
+      /*
         if (m_FailFlag[i] && LI.is_barrel()) {
           // Barrel pflags are set to include PF_copy_input_state_on_fail.
           // Endcap errors are immaterial here (relevant for fwd search), with prop error codes

--- a/RecoTracker/MkFitCore/src/MkFinder.h
+++ b/RecoTracker/MkFitCore/src/MkFinder.h
@@ -171,6 +171,11 @@ namespace mkfit {
                         const int N_proc,
                         bool chiDebug = false);
 
+    void bkFitFitTracksProp2Plane(const EventOfHits &eventofhits,
+                                  const SteeringParams &st_par,
+                                  const int N_proc,
+                                  bool chiDebug = false);
+
     void bkFitPropTracksToPCA(const int N_proc);
 
     //----------------------------------------------------------------------------

--- a/RecoTracker/MkFitCore/src/PropagationMPlexPlane.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlexPlane.cc
@@ -372,7 +372,7 @@ namespace {
     float p0[3] = {cosP / ipt, sinP / ipt, cosT / ip};
     float B = (p0[0] * eta0 + p0[1] * eta1 + p0[2] * eta2) * ip;
     float rho = kinv * ip;
-    float C = - (eta0 * p0[1] - eta1 * p0[0]) * rho * 0.5f * ip;
+    float C = -(eta0 * p0[1] - eta1 * p0[0]) * rho * 0.5f * ip;
     float sqb2m4ac = std::sqrt(B * B - 4.f * A * C);
     float s1 = (-B + sqb2m4ac) * 0.5f / C;
     float s2 = (-B - sqb2m4ac) * 0.5f / C;

--- a/RecoTracker/MkFitCore/src/PropagationMPlexPlane.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlexPlane.cc
@@ -364,15 +364,15 @@ namespace {
              float cosP,
              float sinT,
              float cosT,
-             float pt,
+             float ipt,
              int q,
              float kinv) {
     float A = delta0 * eta0 + delta1 * eta1 + delta2 * eta2;
-    float ip = sinT / pt;
-    float p0[3] = {pt * cosP, pt * sinP, cosT / ip};
+    float ip = sinT * ipt;
+    float p0[3] = {cosP / ipt, sinP / ipt, cosT / ip};
     float B = (p0[0] * eta0 + p0[1] * eta1 + p0[2] * eta2) * ip;
     float rho = kinv * ip;
-    float C = (eta0 * p0[1] - eta1 * p0[0]) * rho * 0.5f * ip;
+    float C = - (eta0 * p0[1] - eta1 * p0[0]) * rho * 0.5f * ip;
     float sqb2m4ac = std::sqrt(B * B - 4.f * A * C);
     float s1 = (-B + sqb2m4ac) * 0.5f / C;
     float s2 = (-B - sqb2m4ac) * 0.5f / C;

--- a/RecoTracker/MkFitCore/src/PropagationMPlexPlane.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlexPlane.cc
@@ -451,8 +451,8 @@ namespace {
 
     MPlexLV outParTmp;
 
-    CMS_UNROLL_LOOP_COUNT(Config::Niter - 1)
-    for (int i = 0; i < Config::Niter - 1; ++i) {
+    CMS_UNROLL_LOOP_COUNT(Config::nSStepsInProp2Plane - 1)
+    for (int i = 0; i < Config::nSStepsInProp2Plane - 1; ++i) {
       parsFromPathL_impl(inPar, outParTmp, kinv, s);
 
       delta0 = outParTmp(0, 0) - plPnt(0, 0);


### PR DESCRIPTION
#### PR description:

The PR improves the initialStep of mkFit currently used by default in phase2.

Propagation to plane  is introduced in the backward fit and set as the default in phase2.

Additionally a bug is corrected in the getS function in RecoTracker/MkFitCore/src/PropagationMPlexPlane.cc and the number of step used in the propagation to plane before adding the hit is reduced from 5 to 2, without compromising the physics performance.

The PR should be tested with the new json file from this PR to cms-data: [PR18](https://github.com/cms-data/RecoTracker-MkFit/pull/18)


#### PR validation:

MTV validation plots can be found here: [MTV-bkwdfitPR](https://legianni.web.cern.ch//MTV-bkwdfitPR/).

In particular the efficiency, fake and duplicate rates all improve in the initialStep (at build level, but also after selections), see example plots as a function of eta (blue before PR, red after):

<img width="912" height="518" alt="image" src="https://github.com/user-attachments/assets/85dac4e2-efb4-459e-a3fe-f25ddccda133" />
<img width="1225" height="701" alt="image" src="https://github.com/user-attachments/assets/e5962851-3989-4f36-b4aa-8a825e76fc30" />

At the same time the average number of hits increases by ~0.4.

<img width="777" height="512" alt="image" src="https://github.com/user-attachments/assets/913d2940-17e5-428d-b2da-e715b0be2cd2" />


The choice of number of iterations doens't change the results, so we opted for 2 steps to reduce the timing, see [MTV-bkwdfitPR-Niter (initialStep)](https://legianni.web.cern.ch//MTV-bkwdfitPR-Niter/plots_initialStep.html).

The build and fit time for the initialStep are both reduced ([MTV-bkwdfitPR-timing](https://legianni.web.cern.ch//MTV-bkwdfitPR-timing/)), as shown in the plot below:

<img width="461" height="555" alt="image" src="https://github.com/user-attachments/assets/5d4bd024-64cc-4835-bfdb-03efc2f089e7" />



