### PR TITLE
Added fillDescriptions method for EcalSeverityLevel

### DIFF
--- a/RecoLocalCalo/EcalRecAlgos/plugins/EcalSeverityLevelESProducer.cc
+++ b/RecoLocalCalo/EcalRecAlgos/plugins/EcalSeverityLevelESProducer.cc
@@ -26,6 +26,8 @@ public:
 
   ReturnType produce(const EcalSeverityLevelAlgoRcd& iRecord);
 
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
 private:
   void setupChannelStatus(const EcalChannelStatusRcd&, EcalSeverityLevelAlgo*);
 
@@ -50,6 +52,70 @@ EcalSeverityLevelESProducer::ReturnType EcalSeverityLevelESProducer::produce(con
 
 void EcalSeverityLevelESProducer::setupChannelStatus(const EcalChannelStatusRcd& chs, EcalSeverityLevelAlgo* algo) {
   algo->setChannelStatus(chs.get(channelToken_));
+}
+
+void EcalSeverityLevelESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::vector<std::string>>("kGood", {
+      "kGood",
+    });
+    psd0.add<std::vector<std::string>>("kProblematic", {
+      "kPoorReco",
+      "kPoorCalib",
+      "kNoisy",
+      "kSaturated",
+    });
+    psd0.add<std::vector<std::string>>("kRecovered", {
+      "kLeadingEdgeRecovered",
+      "kTowerRecovered",
+    });
+    psd0.add<std::vector<std::string>>("kTime", {
+      "kOutOfTime",
+    });
+    psd0.add<std::vector<std::string>>("kWeird", {
+      "kWeird",
+      "kDiWeird",
+    });
+    psd0.add<std::vector<std::string>>("kBad", {
+      "kFaultyHardware",
+      "kDead",
+      "kKilled",
+    });
+    desc.add<edm::ParameterSetDescription>("flagMask", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::vector<std::string>>("kGood", {
+      "kOk",
+    });
+    psd0.add<std::vector<std::string>>("kProblematic", {
+      "kDAC",
+      "kNoLaser",
+      "kNoisy",
+      "kNNoisy",
+      "kNNNoisy",
+      "kNNNNoisy",
+      "kNNNNNoisy",
+      "kFixedG6",
+      "kFixedG1",
+      "kFixedG0",
+    });
+    psd0.add<std::vector<std::string>>("kRecovered", {});
+    psd0.add<std::vector<std::string>>("kTime", {});
+    psd0.add<std::vector<std::string>>("kWeird", {});
+    psd0.add<std::vector<std::string>>("kBad", {
+      "kNonRespondingIsolated",
+      "kDeadVFE",
+      "kDeadFE",
+      "kNoDataNoTP",
+    });
+    desc.add<edm::ParameterSetDescription>("dbstatusMask", psd0);
+  }
+  desc.add<double>("timeThresh", 2.0);
+  descriptions.add("ecalSeverityLevel",desc);
+
 }
 
 //define this as a plug-in

--- a/RecoLocalCalo/EcalRecAlgos/plugins/EcalSeverityLevelESProducer.cc
+++ b/RecoLocalCalo/EcalRecAlgos/plugins/EcalSeverityLevelESProducer.cc
@@ -58,64 +58,72 @@ void EcalSeverityLevelESProducer::fillDescriptions(edm::ConfigurationDescription
   edm::ParameterSetDescription desc;
   {
     edm::ParameterSetDescription psd0;
-    psd0.add<std::vector<std::string>>("kGood", {
-      "kGood",
-    });
-    psd0.add<std::vector<std::string>>("kProblematic", {
-      "kPoorReco",
-      "kPoorCalib",
-      "kNoisy",
-      "kSaturated",
-    });
-    psd0.add<std::vector<std::string>>("kRecovered", {
-      "kLeadingEdgeRecovered",
-      "kTowerRecovered",
-    });
-    psd0.add<std::vector<std::string>>("kTime", {
-      "kOutOfTime",
-    });
-    psd0.add<std::vector<std::string>>("kWeird", {
-      "kWeird",
-      "kDiWeird",
-    });
-    psd0.add<std::vector<std::string>>("kBad", {
-      "kFaultyHardware",
-      "kDead",
-      "kKilled",
-    });
+    psd0.add<std::vector<std::string>>("kGood",
+                                       {
+                                           "kGood",
+                                       });
+    psd0.add<std::vector<std::string>>("kProblematic",
+                                       {
+                                           "kPoorReco",
+                                           "kPoorCalib",
+                                           "kNoisy",
+                                           "kSaturated",
+                                       });
+    psd0.add<std::vector<std::string>>("kRecovered",
+                                       {
+                                           "kLeadingEdgeRecovered",
+                                           "kTowerRecovered",
+                                       });
+    psd0.add<std::vector<std::string>>("kTime",
+                                       {
+                                           "kOutOfTime",
+                                       });
+    psd0.add<std::vector<std::string>>("kWeird",
+                                       {
+                                           "kWeird",
+                                           "kDiWeird",
+                                       });
+    psd0.add<std::vector<std::string>>("kBad",
+                                       {
+                                           "kFaultyHardware",
+                                           "kDead",
+                                           "kKilled",
+                                       });
     desc.add<edm::ParameterSetDescription>("flagMask", psd0);
   }
   {
     edm::ParameterSetDescription psd0;
-    psd0.add<std::vector<std::string>>("kGood", {
-      "kOk",
-    });
-    psd0.add<std::vector<std::string>>("kProblematic", {
-      "kDAC",
-      "kNoLaser",
-      "kNoisy",
-      "kNNoisy",
-      "kNNNoisy",
-      "kNNNNoisy",
-      "kNNNNNoisy",
-      "kFixedG6",
-      "kFixedG1",
-      "kFixedG0",
-    });
+    psd0.add<std::vector<std::string>>("kGood",
+                                       {
+                                           "kOk",
+                                       });
+    psd0.add<std::vector<std::string>>("kProblematic",
+                                       {
+                                           "kDAC",
+                                           "kNoLaser",
+                                           "kNoisy",
+                                           "kNNoisy",
+                                           "kNNNoisy",
+                                           "kNNNNoisy",
+                                           "kNNNNNoisy",
+                                           "kFixedG6",
+                                           "kFixedG1",
+                                           "kFixedG0",
+                                       });
     psd0.add<std::vector<std::string>>("kRecovered", {});
     psd0.add<std::vector<std::string>>("kTime", {});
     psd0.add<std::vector<std::string>>("kWeird", {});
-    psd0.add<std::vector<std::string>>("kBad", {
-      "kNonRespondingIsolated",
-      "kDeadVFE",
-      "kDeadFE",
-      "kNoDataNoTP",
-    });
+    psd0.add<std::vector<std::string>>("kBad",
+                                       {
+                                           "kNonRespondingIsolated",
+                                           "kDeadVFE",
+                                           "kDeadFE",
+                                           "kNoDataNoTP",
+                                       });
     desc.add<edm::ParameterSetDescription>("dbstatusMask", psd0);
   }
   desc.add<double>("timeThresh", 2.0);
-  descriptions.add("ecalSeverityLevel",desc);
-
+  descriptions.add("ecalSeverityLevel", desc);
 }
 
 //define this as a plug-in


### PR DESCRIPTION
#### PR description:

This PR addresses issue [#47275](https://github.com/cms-sw/cmssw/issues/47275) by adding a fillDescriptions method to the plugin  EcalSeverityLevelESProducer, mirroring what's currently set through the cfi file.