### PR TITLE
[DQM]: Improvements to ZDC DQM

### DIFF
--- a/DQM/HcalTasks/interface/ZDCQIE10Task.h
+++ b/DQM/HcalTasks/interface/ZDCQIE10Task.h
@@ -38,9 +38,11 @@ protected:
   //	tags
   edm::InputTag _tagQIE10;
   edm::InputTag sumTag;
+  edm::InputTag sumTagUnpacked;
   edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
   edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDbServiceToken_;
   edm::EDGetToken sumToken_;
+  edm::EDGetToken sumTokenUnpacked_;
   edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> htopoToken_;
   edm::ESGetToken<HcalLongRecoParams, HcalLongRecoParamsRcd> paramsToken_;
 
@@ -61,6 +63,7 @@ protected:
   std::map<uint32_t, MonitorElement *> _cZDC_SUMS;
   std::map<uint32_t, MonitorElement *> _cZDC_BXSUMS;
   std::map<uint32_t, MonitorElement *> _cZDC_BX_EmuSUMS;
+  std::map<uint32_t, MonitorElement *> _cZDC_EmuSumTP_DataSum;
   std::map<uint32_t, MonitorElement *> _cZDC_CapIDS;
   std::map<uint32_t, MonitorElement *> _cfC_EChannel;
   std::map<uint32_t, MonitorElement *> _cTDC_EChannel;

--- a/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
+++ b/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
@@ -126,25 +126,38 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
 
   // create variable binning for TP sum histograms
   std::vector<double> varbins;
-  // -1 - 100 : 101 1-unit bins
-  // 100 - 700 :100 6-unit bins
-  // 700 - 1024 : 18 18-unit bins
-  for (int i = -1; i < 100; i += 1)
+  // -1 - 64 : 65 1-unit bins
+  // 64 - 128 : 32 2-unit bins
+  // 128 - 256 : 32 4-unit bins
+  // 256 - 512 : 32 8-unit bins
+  // 512 - 1008 : 31 16-unit bins
+  // 1008 - 1023: 1 bin
+  // 1023 - 1024: 1 bin
+  for (int i = -1; i < 64; i += 1)
     varbins.push_back(i);
-  for (int i = 100; i < 700; i += 6)
+  for (int i = 64; i < 128; i += 2)
     varbins.push_back(i);
-  for (int i = 700; i < 1024; i += 18)
+  for (int i = 128; i < 256; i += 4)
     varbins.push_back(i);
+  for (int i = 256; i < 512; i += 8)
+    varbins.push_back(i);
+  for (int i = 512; i <= 1008; i += 16)
+    varbins.push_back(i);
+
+  // add additional bins
+  varbins.push_back(1023);
+  varbins.push_back(1024);
+
+  histoname = "ZDCM_EmuSumTP_DataSum";
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task/TPs");
+
   TH2D* varBinningTH2D = new TH2D(
       histoname.c_str(), histoname.c_str(), varbins.size() - 1, varbins.data(), varbins.size() - 1, varbins.data());
   _cZDC_EmuSumTP_DataSum[0] = ib.book2DD(histoname.c_str(), varBinningTH2D);
-
-  histoname = "ZDCM_EmuSumTP_DataSum";
-  ib.setCurrentFolder("Hcal/ZDCQIE10Task/Sums");
   _cZDC_EmuSumTP_DataSum[0]->setAxisTitle("Emulated TP Sum (Online Counts)", 2);
 
   histoname = "ZDCP_EmuSumTP_DataSum";
-  ib.setCurrentFolder("Hcal/ZDCQIE10Task/Sums");
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task/TPs");
   _cZDC_EmuSumTP_DataSum[1] = ib.book2DD(histoname.c_str(), varBinningTH2D);
   _cZDC_EmuSumTP_DataSum[1]->setAxisTitle("Data TP Sum (Online Counts)", 1);
   _cZDC_EmuSumTP_DataSum[1]->setAxisTitle("Emulated TP Sum (Online Counts)", 2);

--- a/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
+++ b/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
@@ -252,14 +252,14 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
     // EM Minus
     HcalZDCDetId didm(HcalZDCDetId::EM, false, channel);
 
-    std::vector<std::string> stationString = {"Station2_Top",
-                                              "Station2_Bottom",
-                                              "Station3_BottomLeft",
-                                              "Station3_BottomRight",
-                                              "Station3_TopLeft",
-                                              "Station3_TopRight"};
+    std::vector<std::string> stationString = {"2_M_Top",
+                                              "2_M_Bottom",
+                                              "3_M_BottomLeft",
+                                              "3_M_BottomRight",
+                                              "3_M_TopLeft",
+                                              "3_M_TopRight"};
 
-    histoname = "FSC_M_" + stationString.at(channel - 7);
+    histoname = "FSC" + stationString.at(channel - 7);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
     _cADC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 256, 0, 256);
     _cADC_EChannel[didm()]->setAxisTitle("ADC", 1);
@@ -269,7 +269,7 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
     _cADC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
     _cADC_vs_TS_EChannel[didm()]->setAxisTitle("sum ADC", 2);
 
-    histoname = "FSC_M_" + stationString.at(channel - 7);
+    histoname = "FSC" + stationString.at(channel - 7);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/fC_perChannel");
     _cfC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 100, 0, 8000);
     _cfC_EChannel[didm()]->setAxisTitle("fC", 1);
@@ -279,7 +279,7 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
     _cfC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
     _cfC_vs_TS_EChannel[didm()]->setAxisTitle("sum fC", 2);
 
-    histoname = "FSC_M_" + stationString.at(channel - 7);
+    histoname = "FSC" + stationString.at(channel - 7);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/TDC_perChannel");
     _cTDC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 150, 0, 150);
     _cTDC_EChannel[didm()]->setAxisTitle("TDC", 1);

--- a/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
+++ b/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
@@ -212,7 +212,8 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
     _cfC_vs_TS_EChannel[didp()]->setAxisTitle("sum fC", 2);
 
     histoname = "EM_P_" + std::to_string(channel);
-    _cTDC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 50, 1, 50);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/TDC_perChannel");
+    _cTDC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 150,0,150);
     _cTDC_EChannel[didp()]->setAxisTitle("TDC", 1);
     _cTDC_EChannel[didp()]->setAxisTitle("N", 2);
 
@@ -240,7 +241,8 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
     _cfC_vs_TS_EChannel[didm()]->setAxisTitle("sum fC", 2);
 
     histoname = "EM_M_" + std::to_string(channel);
-    _cTDC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 50, 1, 50);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/TDC_perChannel");
+    _cTDC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 150,0,150);
     _cTDC_EChannel[didm()]->setAxisTitle("TDC", 1);
     _cTDC_EChannel[didm()]->setAxisTitle("N", 2);
   }
@@ -250,7 +252,9 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
     // EM Minus
     HcalZDCDetId didm(HcalZDCDetId::EM, false, channel);
 
-    histoname = "EM_M_" + std::to_string(channel);
+    std::vector<std::string> stationString = {"Station2_Top", "Station2_Bottom", "Station3_BottomLeft","Station3_BottomRight", "Station3_TopLeft", "Station3_TopRight"};
+    
+    histoname = "FSC_M_" + stationString.at(channel-7);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
     _cADC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 256, 0, 256);
     _cADC_EChannel[didm()]->setAxisTitle("ADC", 1);
@@ -260,7 +264,7 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
     _cADC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
     _cADC_vs_TS_EChannel[didm()]->setAxisTitle("sum ADC", 2);
 
-    histoname = "EM_M_" + std::to_string(channel);
+    histoname = "FSC_M_" + stationString.at(channel-7);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/fC_perChannel");
     _cfC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 100, 0, 8000);
     _cfC_EChannel[didm()]->setAxisTitle("fC", 1);
@@ -270,8 +274,9 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
     _cfC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
     _cfC_vs_TS_EChannel[didm()]->setAxisTitle("sum fC", 2);
 
-    histoname = "EM_M_" + std::to_string(channel);
-    _cTDC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 50, 1, 50);
+    histoname = "FSC_M_" + stationString.at(channel-7);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/TDC_perChannel");
+    _cTDC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 150,0,150);
     _cTDC_EChannel[didm()]->setAxisTitle("TDC", 1);
     _cTDC_EChannel[didm()]->setAxisTitle("N", 2);
   }
@@ -301,7 +306,8 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
     _cfC_vs_TS_EChannel[didp()]->setAxisTitle("sum fC", 2);
 
     histoname = "HAD_P_" + std::to_string(channel);
-    _cTDC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 50, 1, 50);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/TDC_perChannel");
+    _cTDC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 150,0,150);
     _cTDC_EChannel[didp()]->setAxisTitle("TDC", 1);
     _cTDC_EChannel[didp()]->setAxisTitle("N", 2);
 
@@ -329,7 +335,7 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
     _cfC_vs_TS_EChannel[didm()]->setAxisTitle("sum fC", 2);
 
     histoname = "HAD_M_" + std::to_string(channel);
-    _cTDC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 50, 1, 50);
+    _cTDC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 150,0,150);
     _cTDC_EChannel[didm()]->setAxisTitle("TDC", 1);
     _cTDC_EChannel[didm()]->setAxisTitle("N", 2);
   }
@@ -359,7 +365,8 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
     _cfC_vs_TS_EChannel[didp()]->setAxisTitle("sum fC", 2);
 
     histoname = "RPD_P_" + std::to_string(channel);
-    _cTDC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 50, 1, 50);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/TDC_perChannel");
+    _cTDC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 150, 1, 150);
     _cTDC_EChannel[didp()]->setAxisTitle("TDC", 1);
     _cTDC_EChannel[didp()]->setAxisTitle("N", 2);
 
@@ -386,7 +393,8 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
     _cfC_vs_TS_EChannel[didm()]->setAxisTitle("sum fC", 2);
 
     histoname = "RPD_M_" + std::to_string(channel);
-    _cTDC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 50, 1, 50);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/TDC_perChannel");
+    _cTDC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 150, 1, 150);
     _cTDC_EChannel[didm()]->setAxisTitle("TDC", 1);
     _cTDC_EChannel[didm()]->setAxisTitle("N", 2);
   }
@@ -488,7 +496,13 @@ void ZDCQIE10Task::_process(edm::Event const& e, edm::EventSetup const& es) {
       if (_cADC_EChannel.find(did()) != _cADC_EChannel.end()) {
         _cADC_EChannel[did()]->Fill(digi[i].adc());
         _cfC_EChannel[did()]->Fill(constants::adc2fC[digi[i].adc()]);
-        _cTDC_EChannel[did()]->Fill(digi[i].le_tdc());
+        // fill the tdc time the same way as in the reco
+        float tmp_tdctime = 0;
+        // TDC error codes will be 60=-1, 61 = -2, 62 = -3, 63 = -4
+        // assume max amplitude should occur in TS2
+        if (digi[i].le_tdc() >= 60) tmp_tdctime = -1 * (digi[i].le_tdc() - 59);
+        else tmp_tdctime = 50. + (digi[i].le_tdc() / 2);
+        _cTDC_EChannel[did()]->Fill(tmp_tdctime);
       }
       if (_cADC_vs_TS_EChannel.find(did()) != _cADC_vs_TS_EChannel.end()) {
         _cADC_vs_TS_EChannel[did()]->Fill(i, digi[i].adc());

--- a/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
+++ b/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
@@ -213,7 +213,7 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
 
     histoname = "EM_P_" + std::to_string(channel);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/TDC_perChannel");
-    _cTDC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 150,0,150);
+    _cTDC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 150, 0, 150);
     _cTDC_EChannel[didp()]->setAxisTitle("TDC", 1);
     _cTDC_EChannel[didp()]->setAxisTitle("N", 2);
 
@@ -242,7 +242,7 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
 
     histoname = "EM_M_" + std::to_string(channel);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/TDC_perChannel");
-    _cTDC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 150,0,150);
+    _cTDC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 150, 0, 150);
     _cTDC_EChannel[didm()]->setAxisTitle("TDC", 1);
     _cTDC_EChannel[didm()]->setAxisTitle("N", 2);
   }
@@ -252,9 +252,14 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
     // EM Minus
     HcalZDCDetId didm(HcalZDCDetId::EM, false, channel);
 
-    std::vector<std::string> stationString = {"Station2_Top", "Station2_Bottom", "Station3_BottomLeft","Station3_BottomRight", "Station3_TopLeft", "Station3_TopRight"};
-    
-    histoname = "FSC_M_" + stationString.at(channel-7);
+    std::vector<std::string> stationString = {"Station2_Top",
+                                              "Station2_Bottom",
+                                              "Station3_BottomLeft",
+                                              "Station3_BottomRight",
+                                              "Station3_TopLeft",
+                                              "Station3_TopRight"};
+
+    histoname = "FSC_M_" + stationString.at(channel - 7);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
     _cADC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 256, 0, 256);
     _cADC_EChannel[didm()]->setAxisTitle("ADC", 1);
@@ -264,7 +269,7 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
     _cADC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
     _cADC_vs_TS_EChannel[didm()]->setAxisTitle("sum ADC", 2);
 
-    histoname = "FSC_M_" + stationString.at(channel-7);
+    histoname = "FSC_M_" + stationString.at(channel - 7);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/fC_perChannel");
     _cfC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 100, 0, 8000);
     _cfC_EChannel[didm()]->setAxisTitle("fC", 1);
@@ -274,9 +279,9 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
     _cfC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
     _cfC_vs_TS_EChannel[didm()]->setAxisTitle("sum fC", 2);
 
-    histoname = "FSC_M_" + stationString.at(channel-7);
+    histoname = "FSC_M_" + stationString.at(channel - 7);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/TDC_perChannel");
-    _cTDC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 150,0,150);
+    _cTDC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 150, 0, 150);
     _cTDC_EChannel[didm()]->setAxisTitle("TDC", 1);
     _cTDC_EChannel[didm()]->setAxisTitle("N", 2);
   }
@@ -307,7 +312,7 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
 
     histoname = "HAD_P_" + std::to_string(channel);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/TDC_perChannel");
-    _cTDC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 150,0,150);
+    _cTDC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 150, 0, 150);
     _cTDC_EChannel[didp()]->setAxisTitle("TDC", 1);
     _cTDC_EChannel[didp()]->setAxisTitle("N", 2);
 
@@ -335,7 +340,7 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
     _cfC_vs_TS_EChannel[didm()]->setAxisTitle("sum fC", 2);
 
     histoname = "HAD_M_" + std::to_string(channel);
-    _cTDC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 150,0,150);
+    _cTDC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 150, 0, 150);
     _cTDC_EChannel[didm()]->setAxisTitle("TDC", 1);
     _cTDC_EChannel[didm()]->setAxisTitle("N", 2);
   }
@@ -500,8 +505,10 @@ void ZDCQIE10Task::_process(edm::Event const& e, edm::EventSetup const& es) {
         float tmp_tdctime = 0;
         // TDC error codes will be 60=-1, 61 = -2, 62 = -3, 63 = -4
         // assume max amplitude should occur in TS2
-        if (digi[i].le_tdc() >= 60) tmp_tdctime = -1 * (digi[i].le_tdc() - 59);
-        else tmp_tdctime = 50. + (digi[i].le_tdc() / 2);
+        if (digi[i].le_tdc() >= 60)
+          tmp_tdctime = -1 * (digi[i].le_tdc() - 59);
+        else
+          tmp_tdctime = 50. + (digi[i].le_tdc() / 2);
         _cTDC_EChannel[did()]->Fill(tmp_tdctime);
       }
       if (_cADC_vs_TS_EChannel.find(did()) != _cADC_vs_TS_EChannel.end()) {


### PR DESCRIPTION
#### PR description:

This PR implements two of the 3 foreseen DQM improvements for 2025.

Changing FSC information to be more informative
Adding fine timing information
The remaining change still to come is to implement a plot to check emulated information vs. unpacked data information.

#### PR validation:

This PR was tested by running the DQM locally using 2025 OO raw data. This process is documented [here](https://paper.dropbox.com/doc/2025-PbPb-ZDC-DQM-Updates--CuK8CtKKuGvkq4FWzfIesJKuAQ-5Pf9AQ68Neaa5ZvQ8PNfg).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is intended for HI data-taking in 2025 and will need to be backported to 15_1_X.

Tagging HIN colleagues: @mandrenguyen
Tagging HCAL colleagues:@abdoulline @akhukhun @salimcerci, @denizsun
Tagging FSC colleagues: @michael-pitt