### PR TITLE
[L1T] EMTF DQM Errors Plot and GEM Plot Minor Fixes

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2EMTF.h
+++ b/DQM/L1TMonitor/interface/L1TStage2EMTF.h
@@ -29,6 +29,7 @@ private:
   edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> muonToken;
   std::string monitorDir;
   bool verbose;
+  bool isRun3;
 
   MonitorElement* emtfErrors;
   MonitorElement* mpcLinkErrors;

--- a/DQM/L1TMonitor/python/L1TStage2EMTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2EMTF_cfi.py
@@ -6,5 +6,9 @@ l1tStage2Emtf = DQMEDAnalyzer(
     emtfSource = cms.InputTag("emtfStage2Digis"),
     monitorDir = cms.untracked.string("L1T/L1TStage2EMTF"), 
     verbose = cms.untracked.bool(False),
+    isRun3 = cms.untracked.bool(False),
 )
 
+## Era: Run3_2021
+from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
+stage2L1Trigger_2021.toModify(l1tStage2Emtf, isRun3 = True)

--- a/DQM/L1TMonitor/src/L1TStage2EMTF.cc
+++ b/DQM/L1TMonitor/src/L1TStage2EMTF.cc
@@ -13,30 +13,27 @@ L1TStage2EMTF::L1TStage2EMTF(const edm::ParameterSet& ps)
       monitorDir(ps.getUntrackedParameter<std::string>("monitorDir", "")),
       verbose(ps.getUntrackedParameter<bool>("verbose", false)),
       isRun3(ps.getUntrackedParameter<bool>("isRun3", false)) {}
-      
+
 void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) {
   // Monitor Dir
   ibooker.setCurrentFolder(monitorDir);
 
-  emtfErrors = ibooker.book1D("emtfErrors", "EMTF Errors", 6, 0, 6);
+  emtfErrors = ibooker.book1D("emtfErrors", "EMTF Errors", 5, 0, 5);
   emtfErrors->setAxisTitle("Error Type (Corruptions Not Implemented)", 1);
   emtfErrors->setAxisTitle("Number of Errors", 2);
-  if (isRun3 == true) {
+  if (isRun3) {
+    const std::array<std::string, 4> binNamesErrors{{"FMM != Ready", "BSY", "OSY", "WOF"}};
+    for (unsigned int bin = 0; bin < binNamesErrors.size(); ++bin) {
+      emtfErrors->setBinLabel(bin + 1, binNamesErrors[bin], 1);
+    }
+  } else {
     const std::array<std::string, 5> binNamesErrors{
-      {"Corruptions", "FMM != Ready", "BSY", "OSY", "WOF"}};
+        {"Synch. Err.", "Synch. Mod.", "BX Mismatch", "Time Misalign", "FMM != Ready"}};
     for (unsigned int bin = 0; bin < binNamesErrors.size(); ++bin) {
       emtfErrors->setBinLabel(bin + 1, binNamesErrors[bin], 1);
     }
   }
-  if (isRun3 == false) {
-    const std::array<std::string, 6> binNamesErrors{
-      {"Corruptions", "Synch. Err.", "Synch. Mod.", "BX Mismatch", "Time Misalign", "FMM != Ready"}};
-    for (unsigned int bin = 0; bin < binNamesErrors.size(); ++bin) {
-      emtfErrors->setBinLabel(bin + 1, binNamesErrors[bin], 1);
-    }
-  }
-  
-  
+
   // CSC LCT Monitor Elements
   int nChambs, nWires, nStrips;  // Number of chambers, wiregroups, and halfstrips in each station/ring pair
   std::string name, label;
@@ -813,33 +810,32 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
   // DAQ Output
   edm::Handle<l1t::EMTFDaqOutCollection> DaqOutCollection;
   e.getByToken(daqToken, DaqOutCollection);
-  
+
   for (auto DaqOut = DaqOutCollection->begin(); DaqOut != DaqOutCollection->end(); ++DaqOut) {
     const l1t::emtf::MECollection* MECollection = DaqOut->PtrMECollection();
     const l1t::emtf::EventHeader* EventHeader = DaqOut->PtrEventHeader();
-    if (isRun3==false){
-    for (auto ME = MECollection->begin(); ME != MECollection->end(); ++ME) {
-      if (ME->SE())
-        emtfErrors->Fill(1);
-      if (ME->SM())
-        emtfErrors->Fill(2);
-      if (ME->BXE())
-        emtfErrors->Fill(3);
-      if (ME->AF())
-        emtfErrors->Fill(4);
+    if (isRun3) {
       if (!EventHeader->Rdy())
-        emtfErrors->Fill(5);
-    }};
-      
-    if (isRun3==true){
-      if (!EventHeader->Rdy())
-        emtfErrors->Fill(1);
+        emtfErrors->Fill(0);
       if (EventHeader->BSY())
-        emtfErrors->Fill(2);
+        emtfErrors->Fill(1);
       if (EventHeader->OSY())
-        emtfErrors->Fill(3);
+        emtfErrors->Fill(2);
       if (EventHeader->WOF())
-        emtfErrors->Fill(4);
+        emtfErrors->Fill(3);
+    } else {
+      for (auto ME = MECollection->begin(); ME != MECollection->end(); ++ME) {
+        if (ME->SE())
+          emtfErrors->Fill(0);
+        if (ME->SM())
+          emtfErrors->Fill(1);
+        if (ME->BXE())
+          emtfErrors->Fill(2);
+        if (ME->AF())
+          emtfErrors->Fill(3);
+        if (!EventHeader->Rdy())
+          emtfErrors->Fill(4);
+      }
     };
 
     // Fill MPC input link errors
@@ -1019,8 +1015,9 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
       hist_index = (endcap > 0) ? 1 : 0;
       //Added def of layer
       int layer = Hit->Layer();
+      int GEM_MAX_NROLL = 8;
       int phi_part = Hit->Pad() / 64;  // 0-2
-      int vfat = phi_part * 8 + Hit->Partition();
+      int vfat = phi_part * 8 - Hit->Partition() + GEM_MAX_NROLL;
       if (Hit->Neighbor() == false) {
         gemChamberPad[hist_index]->Fill(chamber, Hit->Pad());
         gemChamberPartition[hist_index]->Fill(chamber, Hit->Partition());

--- a/DQM/L1TMonitor/src/L1TStage2EMTF.cc
+++ b/DQM/L1TMonitor/src/L1TStage2EMTF.cc
@@ -18,19 +18,19 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   // Monitor Dir
   ibooker.setCurrentFolder(monitorDir);
 
-  emtfErrors = ibooker.book1D("emtfErrors", "EMTF Errors", 5, 0, 5);
+  emtfErrors = ibooker.book1D("emtfErrors", "EMTF Errors", 6, 0, 6);
   emtfErrors->setAxisTitle("Error Type (Corruptions Not Implemented)", 1);
   emtfErrors->setAxisTitle("Number of Errors", 2);
   if (isRun3 == true) {
-    const std::array<std::string, 10> binNamesErrors{
+    const std::array<std::string, 5> binNamesErrors{
       {"Corruptions", "FMM != Ready", "BSY", "OSY", "WOF"}};
     for (unsigned int bin = 0; bin < binNamesErrors.size(); ++bin) {
       emtfErrors->setBinLabel(bin + 1, binNamesErrors[bin], 1);
     }
   }
   if (isRun3 == false) {
-    const std::array<std::string, 10> binNamesErrors{
-      {"Corruptions", "Synch. Err.", "Synch. Mod.", "BX Mismatch", "Time Misalign"}};
+    const std::array<std::string, 6> binNamesErrors{
+      {"Corruptions", "Synch. Err.", "Synch. Mod.", "BX Mismatch", "Time Misalign", "FMM != Ready"}};
     for (unsigned int bin = 0; bin < binNamesErrors.size(); ++bin) {
       emtfErrors->setBinLabel(bin + 1, binNamesErrors[bin], 1);
     }
@@ -813,7 +813,6 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
   // DAQ Output
   edm::Handle<l1t::EMTFDaqOutCollection> DaqOutCollection;
   e.getByToken(daqToken, DaqOutCollection);
-
   
   for (auto DaqOut = DaqOutCollection->begin(); DaqOut != DaqOutCollection->end(); ++DaqOut) {
     const l1t::emtf::MECollection* MECollection = DaqOut->PtrMECollection();
@@ -828,18 +827,21 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
         emtfErrors->Fill(3);
       if (ME->AF())
         emtfErrors->Fill(4);
+      if (!EventHeader->Rdy())
+        emtfErrors->Fill(5);
     }};
-    
+      
     if (isRun3==true){
-    if (!EventHeader->Rdy())
-      emtfErrors->Fill(1);
-    if (EventHeader->BSY())
-      emtfErrors->Fill(2);
-    if (EventHeader->OSY())
-      emtfErrors->Fill(3);
-    if (EventHeader->WOF())
-      emtfErrors->Fill(4);
+      if (!EventHeader->Rdy())
+        emtfErrors->Fill(1);
+      if (EventHeader->BSY())
+        emtfErrors->Fill(2);
+      if (EventHeader->OSY())
+        emtfErrors->Fill(3);
+      if (EventHeader->WOF())
+        emtfErrors->Fill(4);
     };
+
     // Fill MPC input link errors
     int offset = (EventHeader->Sector() - 1) * 9;
     int endcap = EventHeader->Endcap();


### PR DESCRIPTION
#### PR description:

The proposed changes look to fix minor errors in the EMTF Errors Plot and the gemChamberVFATBX* / gemVFATBXPerChamber* Plots. 

Due to changes in the variable names of EMTF Errors in 2022, the EMTF Errors plot has not displaying the proper errors and instead has been following the Run 2 convention. This code update adds a Run 3 flag to the EMTF DQM code which when true produces the proper error plot while maintaining the option for Run 2 error plots to be produced. 

The proposed fix for the GEM plots is the result of an error in the calculation of the VFAT number. This error was due to the mis-designation of GEM Partition number which changes between hardware and software.

#### PR validation:

In order to validate these changes, the new DQM code was run over a Run 3 file with the Run 3 flag to confirm that the proper plot was produced. In addition, the DQM was run with a forced error to ensure that the plot was filling properly.

EDIT: All of the standard checks were completed (scram b distclean, scram b -j 8, scram build code-checks, scram build code-format)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport request, though if deemed necessary, it would be backported for all of Run 3
