### PR TITLE
add HLT vertexing resolution monitoring (by split vertex method)

### DIFF
--- a/DQM/TrackingMonitor/src/PrimaryVertexResolution.cc
+++ b/DQM/TrackingMonitor/src/PrimaryVertexResolution.cc
@@ -391,6 +391,10 @@ void PrimaryVertexResolution::bookHistograms(DQMStore::IBooker& iBooker, edm::Ru
 
 void PrimaryVertexResolution::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<reco::VertexCollection> hvertices = iEvent.getHandle(vertexSrc_);
+  if (!hvertices.isValid()) {
+    return;
+  }
+
   const reco::VertexCollection& vertices = *hvertices;
   if (vertices.empty())
     return;

--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -17,6 +17,7 @@ from DQMServices.Components.DQMFEDIntegrityClient_cff import *
 from DQMOffline.L1Trigger.L1TriggerDqmOffline_cff import *
 from DQM.SiTrackerPhase2.Phase2TrackerDQMHarvesting_cff import *
 from DQM.SiPixelHeterogeneous.SiPixelHeterogenousDQMHarvesting_cff import *
+from DQMOffline.Trigger.PrimaryVertexMonitoring_Client_cff import *
 
 DQMNone = cms.Sequence()
 
@@ -129,10 +130,7 @@ DQMOffline_SecondStepPOG = cms.Sequence(
                                          DQMOffline_SecondStep_PrePOG *
                                          DQMMessageLoggerClientSeq )
 
-
-
-
-HLTMonitoringClient = cms.Sequence(trackingMonitorClientHLT * trackEfficiencyMonitoringClientHLT * trackingForDisplacedJetMonitorClientHLT)
+HLTMonitoringClient = cms.Sequence(trackingMonitorClientHLT * trackEfficiencyMonitoringClientHLT * trackingForDisplacedJetMonitorClientHLT * hltVerticesMonitoringClient)
 HLTMonitoringClientPA= cms.Sequence(trackingMonitorClientHLT * PAtrackingMonitorClientHLT)
 
 DQMOffline_SecondStep = cms.Sequence(

--- a/DQMOffline/Trigger/python/PrimaryVertexMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/PrimaryVertexMonitoring_Client_cff.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQM.TrackingMonitorClient.primaryVertexResolutionClient_cfi import primaryVertexResolutionClient as _primaryVertexResolutionClient
+
+hltPixelVertexResolutionClient = _primaryVertexResolutionClient.clone(
+    subDirs = ["HLT/Vertexing/hltPixelVertices/Resolution/*"]
+)
+
+hltTrimmedPixelVertexResolutionClient = _primaryVertexResolutionClient.clone(
+    subDirs = ["HLT/Vertexing/hltTrimmedPixelVertices/Resolution/*"]
+)
+
+hltFullVertexResolutionClient = _primaryVertexResolutionClient.clone(
+    subDirs = ["HLT/Vertexing/hltVerticesPFFilter/Resolution/*"]
+)
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(hltFullVertexResolutionClient,
+                        subDirs = ["HLT/Vertexing/hltFullVertices/Resolution/*"])
+
+hltVerticesMonitoringClient = cms.Sequence(hltPixelVertexResolutionClient+
+                                           hltTrimmedPixelVertexResolutionClient+
+                                           hltFullVertexResolutionClient)
+
+phase2_tracker.toReplaceWith(hltVerticesMonitoringClient,
+                             cms.Sequence(hltPixelVertexResolutionClient+
+                                          hltFullVertexResolutionClient))

--- a/DQMOffline/Trigger/python/PrimaryVertexMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/PrimaryVertexMonitoring_cff.py
@@ -49,10 +49,56 @@ hltVerticesL3PFBjetsMonitoring = hltVerticesMonitoring.clone(
     vertexLabel   = "hltVerticesL3PFBjets",
     useHPforAlignmentPlots = False
 )
+
+#### vertexing resolution plots
+
+from DQM.TrackingMonitor.primaryVertexResolution_cfi import primaryVertexResolution as _primaryVertexResolution
+
+hltPixelVertexResolution = _primaryVertexResolution.clone(
+    vertexSrc = "hltPixelVertices",
+    rootFolder = "HLT/Vertexing/hltPixelVertices/Resolution"
+)
+
+pp_on_PbPb_run3.toModify(hltPixelVertexResolution,
+                         vertexSrc = "hltPixelVerticesPPOnAA")
+
+
+phase2_tracker.toModify(hltPixelVertexResolution,
+                        vertexSrc = "hltPhase2PixelVertices")
+
+hltTrimmedPixelVertexResolution = _primaryVertexResolution.clone(
+    vertexSrc = "hltTrimmedPixelVertices",
+    rootFolder = "HLT/Vertexing/hltTrimmedPixelVertices/Resolution"
+)
+
+pp_on_PbPb_run3.toModify(hltTrimmedPixelVertexResolution,
+                         vertexSrc = "hltTrimmedPixelVerticesPPOnAA")
+
+hltVerticesPFFilterResolution =  _primaryVertexResolution.clone(
+    vertexSrc = "hltVerticesPFFilter",
+    rootFolder = "HLT/Vertexing/hltVerticesPFFilter/Resolution"
+)
+
+pp_on_PbPb_run3.toModify(hltVerticesPFFilterResolution,
+                         vertexSrc = "hltVerticesPFFilterPPOnAA")
+
+phase2_tracker.toModify(hltVerticesPFFilterResolution,
+                        rootFolder = "HLT/Vertexing/hltFullVertices/Resolution",
+                        vertexSrc = "hltOfflinePrimaryVertices")
+
+### the sequence
+
 vertexingMonitorHLT = cms.Sequence(
     hltPixelVerticesMonitoring +
     hltTrimmedPixelVerticesMonitoring +
-    hltVerticesPFFilterMonitoring
+    hltVerticesPFFilterMonitoring +
+    hltPixelVertexResolution +
+    hltTrimmedPixelVertexResolution +
+    hltVerticesPFFilterResolution
 )
 
-phase2_tracker.toReplaceWith(vertexingMonitorHLT, cms.Sequence(hltPixelVerticesMonitoring + hltVerticesMonitoring))
+phase2_tracker.toReplaceWith(vertexingMonitorHLT, cms.Sequence(hltPixelVerticesMonitoring +
+                                                               hltVerticesMonitoring +
+                                                               hltPixelVertexResolution +
+                                                               hltVerticesPFFilterResolution
+                                                               ))


### PR DESCRIPTION
#### PR description:

Add HLT vertexing resolution monitoring (using the "split vertex" method) for all the vertex types available at HLT (in both Run 3 and Phase-2).
This leverages the existing module `PrimaryVertexResolution` (which is lightly adapted to tolerate events in which the input colections are missing) and changes the configuration of both the `DQM` and `Harvesting`  steps to be run in the `@HLTMon` sequence.

#### PR validation:

Run successfully both a run3 and phase-2 workflow (running non-trivial HLT menus) 

```
runTheMatrix.py -l 17034.0,29634.0 -t 4 -j 8 --ibeos -i all --ibeos
```

and checked that the output files have the expected output in terms of monitor elements.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, will be backported to CMSSW_15_0_X for testing in the 2025 data-taking release.
