### PR TITLE
Make TupleOrPointerType use const pointer in SoAConstParametersImpl

### DIFF
--- a/DataFormats/SoATemplate/interface/SoACommon.h
+++ b/DataFormats/SoATemplate/interface/SoACommon.h
@@ -162,7 +162,7 @@ namespace cms::soa {
 
     using ValueType = T;
     using ScalarType = typename T::Scalar;
-    using TupleOrPointerType = std::tuple<ScalarType*, byte_size_type>;
+    using TupleOrPointerType = std::tuple<const ScalarType*, byte_size_type>;
 
     // default constructor
     SoAConstParametersImpl() = default;


### PR DESCRIPTION
#### PR description:

This PR changes `TupleOrPointerType` in `SoAConstParametersImpl` to use a `const` pointer.

This issue was found as part of recent developments connected with #47984, raising a compilation error:
```
Error: could not convert '{addr_, stride_}' to TupleOrPointerType (expects const pointer)
```

#### PR validation:

Tests and code checks passing, behavior should not change in principle

FYI @leobeltra @fwyzard @felicepantaleo