### PR TITLE
cmsDriver.py "command line options" readiness for copy-paste

### DIFF
--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -10,6 +10,7 @@ import Configuration.Applications
 from Configuration.Applications.ConfigBuilder import ConfigBuilder, defaultOptions
 import traceback
 from functools import reduce
+import shlex
 
 def checkModifier(era):
     from FWCore.ParameterSet.Config import Modifier, ModifierChain
@@ -35,7 +36,7 @@ def OptionsFromCommandLine():
     import sys
     options=OptionsFromItems(sys.argv[1:])
     # memorize the command line arguments
-    options.arguments = reduce(lambda x, y: x+' '+y, sys.argv[1:])
+    options.arguments = " ".join(shlex.quote(arg) for arg in sys.argv[1:])
     return options
 
 def OptionsFromItems(items):


### PR DESCRIPTION
#### PR description:
The "command line options" reported in the first lines of a `cmsDriver.py`-generated configuration file cannot be copy-pasted into a sh. 

The root cause for this stems in the fact that arguments passed between quotes (either single or double) are stripped away from the quotes, when stored in the `options.arguments` variable.

For example, the following command
```bash
cmsDriver.py anExample --no_exec \
    --filein "das:/StreamHLTMonitor/Run2025E-Express-v1/DQMIO run=396127" \
    -s HARVESTING:@HLTMon --data --conditions 150X_dataRun3_HLT_v1 --scenario pp \
    --filetype DQM --geometry DB:Extended --era Run3_2025 -n -1
```

Generates the file `anExample_HARVESTING.py` which starts as
```python
# Auto generated configuration file
# using:
# Revision: 1.19
# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v
# with command line options: anExample --no_exec --filein das:/StreamHLTMonitor/Run2025E-Express-v1/DQMIO run=396127 -s HARVESTING:@HLTMon --data --conditions 150X_dataRun3_HLT_v1 --scenario pp --filetype DQM --geometry DB:Extended --era Run3_2025 -n -1 --lumiToProcess masking_leq10.json
import FWCore.ParameterSet.Config as cms

from Configuration.Eras.Era_Run3_2025_cff import Run3_2025

process = cms.Process('HARVESTING',Run3_2025)
```

In this PR, I propose to change the variable `options.arguments` is stored, so that the formatting of quote and space (i.e., in `--filein` or in das queries) will be preserved in the line.


#### PR validation:
This PR addresses a fix for a line comment in the generated hlt.py file, no physics/timing validation is required.