### PR TITLE
Fix `idLastStoredAncestor` to point to a track parent when the full graph is not saved

### DIFF
--- a/SimDataFormats/Track/interface/SimTrack.h
+++ b/SimDataFormats/Track/interface/SimTrack.h
@@ -68,7 +68,7 @@ public:
 
   void setIsPrimary() { trackInfo_ |= (1 << 1); }
   void setGenParticleID(const int idx) { igenpart = idx; }
-  int getPrimaryID() const { return igenpart; }
+  int getPrimaryOrLastStoredID() const { return igenpart; }
   uint8_t getTrackInfo() const { return trackInfo_; }
 
 private:

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -574,7 +574,8 @@ unsigned int CaloSD::findBoundaryCrossingParent(const G4Track* track, bool markA
 #endif
     boundaryCrossingParentMap_[id] = id;
     trkInfo->setStoreTrack();
-    trkInfo->setIdLastStoredAncestor(id);
+    if (trkInfo->idLastStoredAncestor() == track->GetParentID())
+      trkInfo->setIdLastStoredAncestor(id);
     return id;
   }
   // Else, traverse the history of the track
@@ -683,7 +684,8 @@ CaloG4Hit* CaloSD::createNewHit(const G4Step* aStep, const G4Track* theTrack, in
 #endif
       if (etrack >= energyCut || forceSave) {
         trkInfo->setStoreTrack();
-        trkInfo->setIdLastStoredAncestor(theTrack->GetTrackID());
+        if (trkInfo->idLastStoredAncestor() == theTrack->GetParentID())
+          trkInfo->setIdLastStoredAncestor(theTrack->GetTrackID());
       }
     } else {
       TrackWithHistory* trkh = tkMap[currentID[k].trackID()];

--- a/SimG4CMS/Forward/src/TimingSD.cc
+++ b/SimG4CMS/Forward/src/TimingSD.cc
@@ -163,7 +163,8 @@ void TimingSD::getStepInfo(const G4Step* aStep) {
     if (incidentEnergy > energyCut) {
       info = cmsTrackInformation(theTrack);
       info->setStoreTrack();
-      info->setIdLastStoredAncestor(theTrack->GetTrackID());
+      if (info->idLastStoredAncestor() == theTrack->GetParentID())
+        info->setIdLastStoredAncestor(theTrack->GetTrackID());
     }
     if (incidentEnergy > energyHistoryCut) {
       if (nullptr == info) {

--- a/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
+++ b/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
@@ -249,7 +249,8 @@ void MuonSensitiveDetector::createHit(const G4Step* aStep) {
   if (thePabs > ePersistentCutGeV_ || (thePID == 13 && allMuonsPersistent_)) {
     TrackInformation* info = cmsTrackInformation(theTrack);
     info->setStoreTrack();
-    info->setIdLastStoredAncestor(theTrack->GetTrackID());
+    if (info->idLastStoredAncestor() == theTrack->GetParentID())
+      info->setIdLastStoredAncestor(theTrack->GetTrackID());
   }
 
 #ifdef EDM_ML_DEBUG

--- a/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
+++ b/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
@@ -153,7 +153,8 @@ void TkAccumulatingSensitiveDetector::update(const BeginOfTrack* bot) {
     if (gTrack->GetKineticEnergy() > energyCut) {
       info = cmsTrackInformation(gTrack);
       info->setStoreTrack();
-      info->setIdLastStoredAncestor(gTrack->GetTrackID());
+      if (info->idLastStoredAncestor() == gTrack->GetParentID())
+        info->setIdLastStoredAncestor(gTrack->GetTrackID());
     }
     //
     // Save History?

--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -268,7 +268,7 @@ void OscarMTProducer::produce(edm::Event& e, const edm::EventSetup& es) {
         edm::LogVerbatim("Track") << " " << i << ". " << (*p1)[i].trackId() << ", " << (*p1)[i] << ", "
                                   << (*p1)[i].crossedBoundary() << "-> " << (*p1)[i].getIDAtBoundary() << ", "
                                   << (*p1)[i].isFromBackScattering() << ", " << (*p1)[i].isPrimary() << "-> "
-                                  << (*p1)[i].getPrimaryID();
+                                  << (*p1)[i].getPrimaryOrLastStoredID();
       }
     }
   }

--- a/SimG4Core/CustomPhysics/plugins/DBremWatcher.cc
+++ b/SimG4Core/CustomPhysics/plugins/DBremWatcher.cc
@@ -105,7 +105,8 @@ void DBremWatcher::update(const BeginOfTrack* trk) {
     if (std::find(pdgs_.begin(), pdgs_.end(), pdg) != pdgs_.end()) {
       //Found an A'
       trkInfo->setStoreTrack();
-      trkInfo->setIdLastStoredAncestor(theTrack->GetTrackID());
+      if (trkInfo->idLastStoredAncestor() == theTrack->GetParentID())
+        trkInfo->setIdLastStoredAncestor(theTrack->GetTrackID());
       VertexPos = Vpos;
       aPrimeTraj = theTrack->GetMomentum();
       LogDebug("DBremWatcher") << "Save SimTrack the Track " << theTrack->GetTrackID() << " Type "
@@ -137,7 +138,8 @@ void DBremWatcher::update(const EndOfTrack* trk) {
     if (std::find(pdgs_.begin(), pdgs_.end(), pdg) == pdgs_.end() &&
         (theTrack->GetCreatorProcess()->GetProcessName()) == "muDBrem") {
       trkInfo->setStoreTrack();
-      trkInfo->setIdLastStoredAncestor(theTrack->GetTrackID());
+      if (trkInfo->idLastStoredAncestor() == theTrack->GetParentID())
+        trkInfo->setIdLastStoredAncestor(theTrack->GetTrackID());
     }
   }
 }

--- a/SimG4Core/Notification/src/SimTrackManager.cc
+++ b/SimG4Core/Notification/src/SimTrackManager.cc
@@ -76,12 +76,12 @@ void SimTrackManager::addTrack(TrackWithHistory* iTrack, const G4Track* track, b
     auto info = static_cast<const TrackInformation*>(track->GetUserInformation());
     if (info->isInTrkFromBackscattering())
       iTrack->setFromBackScattering();
-    // set there for the *non-primary* tracks the genParticle ID associated with the G4Track
-    // for the primaries this is done in the TrackWithHistory constructor.
+    // set there for the *non-primary* tracks the G4Track ID of the last stored ancestor
+    // for the primaries the genparticle id is saved in the TrackWithHistory constructor.
     // In the constructor of TrackWithHistory the info isPrimary is saved and used
     // to give -1 if the track is not a primary.
     if (not iTrack->isPrimary())
-      iTrack->setGenParticleID(info->mcTruthID());
+      iTrack->setGenParticleID(info->idLastStoredAncestor());
     m_trackContainer.push_back(iTrack);
     const auto& v = track->GetStep()->GetPostStepPoint()->GetPosition();
     std::pair<int, math::XYZVectorD> p(iTrack->trackID(),

--- a/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc
+++ b/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc
@@ -164,7 +164,7 @@ void CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSet
     LogVerbatim("CaloParticleDebuggerSimTracks")
         << i << "\t" << t.trackId() << "\t" << t << "  Crossed  Boundary: " << t.crossedBoundary()
         << "  Vtx: " << t.vertIndex() << " isFromBackScattering: " << t.isFromBackScattering()
-        << " isPrimary: " << t.isPrimary() << " ParentID: " << t.getPrimaryID()
+        << " isPrimary: " << t.isPrimary() << " ParentID: " << t.getPrimaryOrLastStoredID()
         << "  Position Boundary: " << t.getPositionAtBoundary() << "  Momentum Boundary: " << t.getMomentumAtBoundary()
         << "  Momemtum Origin:   " << t.momentum();
     trackid_to_track_index[t.trackId()] = i;
@@ -232,10 +232,11 @@ void CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSet
         << "\n\n"
         << i << "\tType: " << simcl.pdgId() << "\tEnergy: " << simcl.energy() << "\tKey: " << i;  // << simcl ;
     auto const& simtrack = simcl.g4Tracks()[0];
-    LogVerbatim("CaloParticleDebuggerSimClusters") << "\n  Primary GenParticleID: " << simtrack.getPrimaryID()
-                                                   << "\n  Crossed  Boundary:     " << simtrack.crossedBoundary()
-                                                   << "\n  Position Boundary:     " << simtrack.getPositionAtBoundary()
-                                                   << "\n  Momentum Boundary:     " << simtrack.getMomentumAtBoundary();
+    LogVerbatim("CaloParticleDebuggerSimClusters")
+        << "\n  GenParticleID/ancestor: " << simtrack.getPrimaryOrLastStoredID()
+        << "\n  Crossed  Boundary:      " << simtrack.crossedBoundary()
+        << "\n  Position Boundary:      " << simtrack.getPositionAtBoundary()
+        << "\n  Momentum Boundary:      " << simtrack.getMomentumAtBoundary();
     if (simClusters_in_CaloParticles.find(simcl.g4Tracks()[0].trackId()) == simClusters_in_CaloParticles.end()) {
       LogVerbatim("CaloParticleDebuggerSimClusters") << "  Orphan SimCluster: " << simtrack.trackId();
     }


### PR DESCRIPTION
#### PR description:

Currently the `idLastStoredAncestor()` in the track info stores:
- the id of the G4 track itself if it is marked as to be saved in the `simTrack` collection
- the id of the last parent saved in the `simTrack` collection if the track itself will not be saved

This led to a problem in the case of a particle which is saved in the collection but its parent is not, because `idLastStoredAncestor()` pointed to that track, but there was no way in the final simtrack collection to understand from which particle this track originated.
With this change the `idLastStoredAncestor()` will contain:
- the id of the G4 track itself if it is marked as to be saved in the `simTrack` collection, and all its parents up to the first G4 track are saved
- the id of the last parent saved in the `simTrack` collection otherwise

As an example, suppose we have track 1 `->` track 2 `->` track 3 `->` track 4 ( `a -> b` means that track `a` is the mother of track `b`) and track 3 is the only one not saved in the event. Before this PR track 4 was saved but there was no way to link it to track 1, now it stores the Geant4 Id of track 2.

This is a follow-up of #47883 that eventually will allow us to recover the `simCluster`s that are currently discarded.

#### PR validation:

Looked at the output files of the `SimGeneral/Debugging/python/caloParticleDebugger_cfg.py`, the only expected change is in the value returned by the method `getPrimaryOrLastStoredID()` of the simTrack. 

FYI @rovere @fabiocos 
