### PR TITLE
[ReMiniFromMini] Add modules for updating puppi weights in pat::PackedCandidate and rekeying PAT object candidates

### DIFF
--- a/DataFormats/PatCandidates/interface/Electron.h
+++ b/DataFormats/PatCandidates/interface/Electron.h
@@ -47,6 +47,7 @@ namespace reco {
 // Class definition
 namespace pat {
   class PATElectronSlimmer;
+  class PATElectronCandidatesRekeyer;
 
   class Electron : public Lepton<reco::GsfElectron> {
   public:
@@ -269,6 +270,7 @@ namespace pat {
     }
 
     friend class PATElectronSlimmer;
+    friend class PATElectronCandidatesRekeyer;
 
   protected:
     /// init impact parameter defaults (for use in a constructor)

--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -47,6 +47,7 @@ namespace reco {
 namespace pat {
 
   class PATMuonSlimmer;
+  class PATMuonCandidatesRekeyer;
 
   class Muon : public Lepton<reco::Muon> {
   public:
@@ -272,6 +273,7 @@ namespace pat {
     friend std::ostream& reco::operator<<(std::ostream& out, const pat::Muon& obj);
 
     friend class PATMuonSlimmer;
+    friend class PATMuonCandidatesRekeyer;
 
     float pfEcalEnergy() const { return pfEcalEnergy_; }
     void setPfEcalEnergy(float pfEcalEnergy) { pfEcalEnergy_ = pfEcalEnergy; }

--- a/DataFormats/PatCandidates/interface/Photon.h
+++ b/DataFormats/PatCandidates/interface/Photon.h
@@ -42,6 +42,7 @@ namespace reco {
 // Class definition
 namespace pat {
   class PATPhotonSlimmer;
+  class PATPhotonCandidatesRekeyer;
 
   class Photon : public PATObject<reco::Photon> {
   public:
@@ -328,6 +329,7 @@ namespace pat {
     reco::CandidatePtr sourceCandidatePtr(size_type i) const override;
 
     friend class PATPhotonSlimmer;
+    friend class PATPhotonCandidatesRekeyer;
 
   protected:
     // ---- for content embedding ----

--- a/PhysicsTools/PatAlgos/plugins/PATElectronCandidatesRekeyer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronCandidatesRekeyer.cc
@@ -1,0 +1,80 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/View.h"
+
+#include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+
+namespace pat {
+  class PATElectronCandidatesRekeyer : public edm::stream::EDProducer<> {
+  public:
+    explicit PATElectronCandidatesRekeyer(const edm::ParameterSet &iConfig);
+    ~PATElectronCandidatesRekeyer() override;
+
+    void produce(edm::Event &, const edm::EventSetup &) override;
+
+  private:
+    // configurables
+    edm::EDGetTokenT<std::vector<pat::Electron>> src_;
+    edm::EDGetTokenT<reco::CandidateView> pcNewCandViewToken_;
+    edm::EDGetTokenT<pat::PackedCandidateCollection> pcNewToken_;
+  };
+
+}  // namespace pat
+
+using namespace pat;
+
+PATElectronCandidatesRekeyer::PATElectronCandidatesRekeyer(const edm::ParameterSet &iConfig):
+
+  src_(consumes<std::vector<pat::Electron>>(iConfig.getParameter<edm::InputTag>("src"))),
+  pcNewCandViewToken_(consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))),
+  pcNewToken_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))){
+  produces<std::vector<pat::Electron>>();
+
+}
+
+PATElectronCandidatesRekeyer::~PATElectronCandidatesRekeyer() {}
+
+void PATElectronCandidatesRekeyer::produce(edm::Event &iEvent, edm::EventSetup const &) {
+  edm::Handle<std::vector<pat::Electron>> src;
+  iEvent.getByToken(src_, src);
+
+  edm::Handle<reco::CandidateView> pcNewCandViewHandle;
+  iEvent.getByToken(pcNewCandViewToken_, pcNewCandViewHandle);
+
+  edm::Handle<pat::PackedCandidateCollection> pcNewHandle;
+  iEvent.getByToken(pcNewToken_, pcNewHandle);
+
+  auto outPtrP = std::make_unique<std::vector<pat::Electron>>();
+  outPtrP->reserve(src->size());
+
+  for (size_t i = 0; i < src->size(); ++i) {
+    // copy original pat object and append to vector
+    outPtrP->emplace_back((*src)[i]);
+
+    std::vector<unsigned int> keys;
+    for (const edm::Ref<pat::PackedCandidateCollection> &ref : outPtrP->back().associatedPackedPFCandidates()){
+      keys.push_back(ref.key());
+    };
+    outPtrP->back().setAssociatedPackedPFCandidates(
+      edm::RefProd<pat::PackedCandidateCollection>(pcNewHandle),
+      keys.begin(), keys.end()
+    );
+    if (keys.size() == 1) {
+      outPtrP->back().refToOrig_ = outPtrP->back().sourceCandidatePtr(0);
+    } else {
+      outPtrP->back().refToOrig_ = reco::CandidatePtr(pcNewHandle.id());
+    }
+  }
+  iEvent.put(std::move(outPtrP));
+}
+
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(PATElectronCandidatesRekeyer);

--- a/PhysicsTools/PatAlgos/plugins/PATElectronCandidatesRekeyer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronCandidatesRekeyer.cc
@@ -30,13 +30,14 @@ namespace pat {
 
 using namespace pat;
 
-PATElectronCandidatesRekeyer::PATElectronCandidatesRekeyer(const edm::ParameterSet &iConfig):
+PATElectronCandidatesRekeyer::PATElectronCandidatesRekeyer(const edm::ParameterSet &iConfig)
+    :
 
-  src_(consumes<std::vector<pat::Electron>>(iConfig.getParameter<edm::InputTag>("src"))),
-  pcNewCandViewToken_(consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))),
-  pcNewToken_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))){
+      src_(consumes<std::vector<pat::Electron>>(iConfig.getParameter<edm::InputTag>("src"))),
+      pcNewCandViewToken_(consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))),
+      pcNewToken_(
+          consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))) {
   produces<std::vector<pat::Electron>>();
-
 }
 
 PATElectronCandidatesRekeyer::~PATElectronCandidatesRekeyer() {}
@@ -59,13 +60,11 @@ void PATElectronCandidatesRekeyer::produce(edm::Event &iEvent, edm::EventSetup c
     outPtrP->emplace_back((*src)[i]);
 
     std::vector<unsigned int> keys;
-    for (const edm::Ref<pat::PackedCandidateCollection> &ref : outPtrP->back().associatedPackedPFCandidates()){
+    for (const edm::Ref<pat::PackedCandidateCollection> &ref : outPtrP->back().associatedPackedPFCandidates()) {
       keys.push_back(ref.key());
     };
     outPtrP->back().setAssociatedPackedPFCandidates(
-      edm::RefProd<pat::PackedCandidateCollection>(pcNewHandle),
-      keys.begin(), keys.end()
-    );
+        edm::RefProd<pat::PackedCandidateCollection>(pcNewHandle), keys.begin(), keys.end());
     if (keys.size() == 1) {
       outPtrP->back().refToOrig_ = outPtrP->back().sourceCandidatePtr(0);
     } else {
@@ -74,7 +73,6 @@ void PATElectronCandidatesRekeyer::produce(edm::Event &iEvent, edm::EventSetup c
   }
   iEvent.put(std::move(outPtrP));
 }
-
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(PATElectronCandidatesRekeyer);

--- a/PhysicsTools/PatAlgos/plugins/PATJetCandidatesRekeyer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATJetCandidatesRekeyer.cc
@@ -1,0 +1,100 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/View.h"
+
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+
+namespace pat {
+  class PATJetCandidatesRekeyer : public edm::stream::EDProducer<> {
+  public:
+    explicit PATJetCandidatesRekeyer(const edm::ParameterSet &iConfig);
+    ~PATJetCandidatesRekeyer() override;
+
+    void produce(edm::Event &, const edm::EventSetup &) override;
+
+  private:
+    // configurables
+    edm::EDGetTokenT<std::vector<pat::Jet>> src_;
+    edm::EDGetTokenT<reco::CandidateView> pcNewCandViewToken_;
+    edm::EDGetTokenT<pat::PackedCandidateCollection> pcNewToken_;
+    // std::string subjetLabel_;
+  };
+}  // namespace pat
+
+using namespace pat;
+
+PATJetCandidatesRekeyer::PATJetCandidatesRekeyer(const edm::ParameterSet &iConfig):
+  src_(consumes<std::vector<pat::Jet>>(iConfig.getParameter<edm::InputTag>("src"))),
+  pcNewCandViewToken_(consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))),
+  pcNewToken_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))){
+  produces<std::vector<pat::Jet>>();
+  produces<edm::OwnVector<reco::BaseTagInfo>>("tagInfos");
+}
+
+PATJetCandidatesRekeyer::~PATJetCandidatesRekeyer() {}
+
+void PATJetCandidatesRekeyer::produce(edm::Event &iEvent, edm::EventSetup const &) {
+  edm::Handle<std::vector<pat::Jet>> src;
+  iEvent.getByToken(src_, src);
+
+  edm::Handle<reco::CandidateView> pcNewCandViewHandle;
+  iEvent.getByToken(pcNewCandViewToken_, pcNewCandViewHandle);
+
+  edm::Handle<pat::PackedCandidateCollection> pcNewHandle;
+  iEvent.getByToken(pcNewToken_, pcNewHandle);
+
+ edm::RefProd<edm::OwnVector<reco::BaseTagInfo>> h_tagInfosOut = iEvent.getRefBeforePut<edm::OwnVector<reco::BaseTagInfo>>("tagInfos");
+ auto tagInfosOut = std::make_unique<edm::OwnVector<reco::BaseTagInfo>>();
+
+  auto outPtrP = std::make_unique<std::vector<pat::Jet>>();
+  outPtrP->reserve(src->size());
+
+  //
+  //
+  //
+  for (std::vector<pat::Jet>::const_iterator ibegin = (*src).begin(), iend = (*src).end(), ijet = ibegin; ijet != iend; ++ijet) {
+    for (TagInfoFwdPtrCollection::const_iterator iinfoBegin = ijet->tagInfosFwdPtr().begin(), iinfoEnd = ijet->tagInfosFwdPtr().end(), iinfo = iinfoBegin;iinfo != iinfoEnd;++iinfo) {
+      tagInfosOut->push_back(**iinfo);
+    }
+  }
+
+  edm::OrphanHandle<edm::OwnVector<reco::BaseTagInfo>> oh_tagInfosOut = iEvent.put(std::move(tagInfosOut), "tagInfos");
+
+  //
+  //
+  //
+  unsigned int tagInfoIndex = 0;
+
+  for (size_t i = 0; i < src->size(); ++i) {
+    // copy original pat object and append to vector
+    outPtrP->emplace_back((*src)[i]);
+
+    reco::CompositePtrCandidate::daughters old = outPtrP->back().daughterPtrVector();
+    outPtrP->back().clearDaughters();
+    for (const auto & dauItr : old) {
+      outPtrP->back().addDaughter(edm::Ptr<reco::Candidate>(pcNewHandle,dauItr.key()));
+    }
+
+    // Copy the tag infos
+    for (TagInfoFwdPtrCollection::const_iterator iinfoBegin = outPtrP->back().tagInfosFwdPtr().begin(), iinfoEnd = outPtrP->back().tagInfosFwdPtr().end(), iinfo = iinfoBegin; iinfo != iinfoEnd; ++iinfo) {
+      // Update the "forward" bit of the FwdPtr to point at the new collection.
+      // ptr to "this" info in the global list
+      edm::Ptr<reco::BaseTagInfo> outPtr(oh_tagInfosOut, tagInfoIndex);
+      outPtrP->back().updateFwdTagInfoFwdPtr(iinfo - iinfoBegin,  outPtr);
+      ++tagInfoIndex;
+    }
+  }
+
+  iEvent.put(std::move(outPtrP));
+}
+
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(PATJetCandidatesRekeyer);

--- a/PhysicsTools/PatAlgos/plugins/PATMuonCandidatesRekeyer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonCandidatesRekeyer.cc
@@ -30,10 +30,11 @@ namespace pat {
 
 using namespace pat;
 
-PATMuonCandidatesRekeyer::PATMuonCandidatesRekeyer(const edm::ParameterSet &iConfig):
-  src_(consumes<std::vector<pat::Muon>>(iConfig.getParameter<edm::InputTag>("src"))),
-  pcNewCandViewToken_(consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))),
-  pcNewToken_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))){
+PATMuonCandidatesRekeyer::PATMuonCandidatesRekeyer(const edm::ParameterSet &iConfig)
+    : src_(consumes<std::vector<pat::Muon>>(iConfig.getParameter<edm::InputTag>("src"))),
+      pcNewCandViewToken_(consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))),
+      pcNewToken_(
+          consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))) {
   produces<std::vector<pat::Muon>>();
 }
 
@@ -59,19 +60,18 @@ void PATMuonCandidatesRekeyer::produce(edm::Event &iEvent, edm::EventSetup const
     //
     std::vector<unsigned int> keys;
     for (size_t ic = 0; ic < outPtrP->back().numberOfSourceCandidatePtrs(); ++ic) {
-      const reco::CandidatePtr& candPtr = outPtrP->back().sourceCandidatePtr(ic);
-      if (candPtr.isNonnull()){
+      const reco::CandidatePtr &candPtr = outPtrP->back().sourceCandidatePtr(ic);
+      if (candPtr.isNonnull()) {
         keys.push_back(candPtr.key());
       }
     }
-    if(keys.size() == 1){
-      outPtrP->back().refToOrig_ = reco::CandidatePtr(pcNewCandViewHandle,keys[0]);
+    if (keys.size() == 1) {
+      outPtrP->back().refToOrig_ = reco::CandidatePtr(pcNewCandViewHandle, keys[0]);
     }
   }
 
   iEvent.put(std::move(outPtrP));
 }
-
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(PATMuonCandidatesRekeyer);

--- a/PhysicsTools/PatAlgos/plugins/PATMuonCandidatesRekeyer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonCandidatesRekeyer.cc
@@ -1,0 +1,77 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/View.h"
+
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+
+namespace pat {
+  class PATMuonCandidatesRekeyer : public edm::stream::EDProducer<> {
+  public:
+    explicit PATMuonCandidatesRekeyer(const edm::ParameterSet &iConfig);
+    ~PATMuonCandidatesRekeyer() override;
+
+    void produce(edm::Event &, const edm::EventSetup &) override;
+
+  private:
+    // configurables
+    edm::EDGetTokenT<std::vector<pat::Muon>> src_;
+    edm::EDGetTokenT<reco::CandidateView> pcNewCandViewToken_;
+    edm::EDGetTokenT<pat::PackedCandidateCollection> pcNewToken_;
+  };
+
+}  // namespace pat
+
+using namespace pat;
+
+PATMuonCandidatesRekeyer::PATMuonCandidatesRekeyer(const edm::ParameterSet &iConfig):
+  src_(consumes<std::vector<pat::Muon>>(iConfig.getParameter<edm::InputTag>("src"))),
+  pcNewCandViewToken_(consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))),
+  pcNewToken_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))){
+  produces<std::vector<pat::Muon>>();
+}
+
+PATMuonCandidatesRekeyer::~PATMuonCandidatesRekeyer() {}
+
+void PATMuonCandidatesRekeyer::produce(edm::Event &iEvent, edm::EventSetup const &) {
+  edm::Handle<std::vector<pat::Muon>> src;
+  iEvent.getByToken(src_, src);
+
+  edm::Handle<reco::CandidateView> pcNewCandViewHandle;
+  iEvent.getByToken(pcNewCandViewToken_, pcNewCandViewHandle);
+
+  edm::Handle<pat::PackedCandidateCollection> pcNewHandle;
+  iEvent.getByToken(pcNewToken_, pcNewHandle);
+
+  auto outPtrP = std::make_unique<std::vector<pat::Muon>>();
+  outPtrP->reserve(src->size());
+
+  for (size_t i = 0; i < src->size(); ++i) {
+    // copy original pat object and append to vector
+    outPtrP->emplace_back((*src)[i]);
+
+    //
+    std::vector<unsigned int> keys;
+    for (size_t ic = 0; ic < outPtrP->back().numberOfSourceCandidatePtrs(); ++ic) {
+      const reco::CandidatePtr& candPtr = outPtrP->back().sourceCandidatePtr(ic);
+      if (candPtr.isNonnull()){
+        keys.push_back(candPtr.key());
+      }
+    }
+    if(keys.size() == 1){
+      outPtrP->back().refToOrig_ = reco::CandidatePtr(pcNewCandViewHandle,keys[0]);
+    }
+  }
+
+  iEvent.put(std::move(outPtrP));
+}
+
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(PATMuonCandidatesRekeyer);

--- a/PhysicsTools/PatAlgos/plugins/PATObjectPuppiIsolationUpdater.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATObjectPuppiIsolationUpdater.cc
@@ -38,15 +38,21 @@ namespace pat {
 using namespace pat;
 
 template <typename T>
-PATObjectPuppiIsolationUpdater<T>::PATObjectPuppiIsolationUpdater(const edm::ParameterSet &iConfig):
-  src_(consumes<std::vector<T>>(iConfig.getParameter<edm::InputTag>("src"))){
-  PUPPIIsolation_charged_hadrons_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiIsolationChargedHadrons"));
-  PUPPIIsolation_neutral_hadrons_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiIsolationNeutralHadrons"));
-  PUPPIIsolation_photons_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiIsolationPhotons"));
-  if constexpr (std::is_same<T,pat::Electron>::value || std::is_same<T,pat::Muon>::value){
-    PUPPINoLeptonsIsolation_charged_hadrons_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationChargedHadrons"));
-    PUPPINoLeptonsIsolation_neutral_hadrons_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationNeutralHadrons"));
-    PUPPINoLeptonsIsolation_photons_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationPhotons"));
+PATObjectPuppiIsolationUpdater<T>::PATObjectPuppiIsolationUpdater(const edm::ParameterSet &iConfig)
+    : src_(consumes<std::vector<T>>(iConfig.getParameter<edm::InputTag>("src"))) {
+  PUPPIIsolation_charged_hadrons_ =
+      consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiIsolationChargedHadrons"));
+  PUPPIIsolation_neutral_hadrons_ =
+      consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiIsolationNeutralHadrons"));
+  PUPPIIsolation_photons_ =
+      consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiIsolationPhotons"));
+  if constexpr (std::is_same<T, pat::Electron>::value || std::is_same<T, pat::Muon>::value) {
+    PUPPINoLeptonsIsolation_charged_hadrons_ =
+        consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationChargedHadrons"));
+    PUPPINoLeptonsIsolation_neutral_hadrons_ =
+        consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationNeutralHadrons"));
+    PUPPINoLeptonsIsolation_photons_ =
+        consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationPhotons"));
   }
   produces<std::vector<T>>();
 }
@@ -74,7 +80,7 @@ void PATObjectPuppiIsolationUpdater<T>::produce(edm::Event &iEvent, edm::EventSe
   iEvent.getByToken(PUPPIIsolation_photons_, PUPPIIsolation_photons);
   //puppiNoLeptons
 
-  if constexpr (std::is_same<T,pat::Electron>::value || std::is_same<T,pat::Muon>::value){
+  if constexpr (std::is_same<T, pat::Electron>::value || std::is_same<T, pat::Muon>::value) {
     iEvent.getByToken(PUPPINoLeptonsIsolation_charged_hadrons_, PUPPINoLeptonsIsolation_charged_hadrons);
     iEvent.getByToken(PUPPINoLeptonsIsolation_neutral_hadrons_, PUPPINoLeptonsIsolation_neutral_hadrons);
     iEvent.getByToken(PUPPINoLeptonsIsolation_photons_, PUPPINoLeptonsIsolation_photons);
@@ -87,27 +93,26 @@ void PATObjectPuppiIsolationUpdater<T>::produce(edm::Event &iEvent, edm::EventSe
     // copy original pat object and append to vector
     outPtrP->emplace_back((*src)[i]);
 
-    edm::Ptr<T> objPtr(src,i);
+    edm::Ptr<T> objPtr(src, i);
 
     outPtrP->back().setIsolationPUPPI((*PUPPIIsolation_charged_hadrons)[objPtr],
-                            (*PUPPIIsolation_neutral_hadrons)[objPtr],
-                            (*PUPPIIsolation_photons)[objPtr]);
+                                      (*PUPPIIsolation_neutral_hadrons)[objPtr],
+                                      (*PUPPIIsolation_photons)[objPtr]);
 
-    if constexpr (std::is_same<T,pat::Electron>::value || std::is_same<T,pat::Muon>::value){
+    if constexpr (std::is_same<T, pat::Electron>::value || std::is_same<T, pat::Muon>::value) {
       outPtrP->back().setIsolationPUPPINoLeptons((*PUPPINoLeptonsIsolation_charged_hadrons)[objPtr],
-                                     (*PUPPINoLeptonsIsolation_neutral_hadrons)[objPtr],
-                                     (*PUPPINoLeptonsIsolation_photons)[objPtr]);
+                                                 (*PUPPINoLeptonsIsolation_neutral_hadrons)[objPtr],
+                                                 (*PUPPINoLeptonsIsolation_photons)[objPtr]);
     }
   }
   iEvent.put(std::move(outPtrP));
 }
 
 typedef PATObjectPuppiIsolationUpdater<pat::Electron> PATElectronPuppiIsolationUpdater;
-typedef PATObjectPuppiIsolationUpdater<pat::Photon>   PATPhotonPuppiIsolationUpdater;
-typedef PATObjectPuppiIsolationUpdater<pat::Muon>     PATMuonPuppiIsolationUpdater;
+typedef PATObjectPuppiIsolationUpdater<pat::Photon> PATPhotonPuppiIsolationUpdater;
+typedef PATObjectPuppiIsolationUpdater<pat::Muon> PATMuonPuppiIsolationUpdater;
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-
 
 DEFINE_FWK_MODULE(PATElectronPuppiIsolationUpdater);
 DEFINE_FWK_MODULE(PATPhotonPuppiIsolationUpdater);

--- a/PhysicsTools/PatAlgos/plugins/PATObjectPuppiIsolationUpdater.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATObjectPuppiIsolationUpdater.cc
@@ -1,0 +1,114 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/View.h"
+
+#include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/PatCandidates/interface/Photon.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+
+namespace pat {
+  template <typename T>
+  class PATObjectPuppiIsolationUpdater : public edm::stream::EDProducer<> {
+  public:
+    explicit PATObjectPuppiIsolationUpdater(const edm::ParameterSet &iConfig);
+    ~PATObjectPuppiIsolationUpdater() override;
+
+    void produce(edm::Event &, const edm::EventSetup &) override;
+
+  private:
+    // configurables
+    edm::EDGetTokenT<std::vector<T>> src_;
+    //PUPPI isolation tokens
+    edm::EDGetTokenT<edm::ValueMap<float>> PUPPIIsolation_charged_hadrons_;
+    edm::EDGetTokenT<edm::ValueMap<float>> PUPPIIsolation_neutral_hadrons_;
+    edm::EDGetTokenT<edm::ValueMap<float>> PUPPIIsolation_photons_;
+    //PUPPINoLeptons isolation tokens
+    edm::EDGetTokenT<edm::ValueMap<float>> PUPPINoLeptonsIsolation_charged_hadrons_;
+    edm::EDGetTokenT<edm::ValueMap<float>> PUPPINoLeptonsIsolation_neutral_hadrons_;
+    edm::EDGetTokenT<edm::ValueMap<float>> PUPPINoLeptonsIsolation_photons_;
+  };
+}  // namespace pat
+
+using namespace pat;
+
+template <typename T>
+PATObjectPuppiIsolationUpdater<T>::PATObjectPuppiIsolationUpdater(const edm::ParameterSet &iConfig):
+  src_(consumes<std::vector<T>>(iConfig.getParameter<edm::InputTag>("src"))){
+  PUPPIIsolation_charged_hadrons_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiIsolationChargedHadrons"));
+  PUPPIIsolation_neutral_hadrons_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiIsolationNeutralHadrons"));
+  PUPPIIsolation_photons_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiIsolationPhotons"));
+  if constexpr (std::is_same<T,pat::Electron>::value || std::is_same<T,pat::Muon>::value){
+    PUPPINoLeptonsIsolation_charged_hadrons_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationChargedHadrons"));
+    PUPPINoLeptonsIsolation_neutral_hadrons_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationNeutralHadrons"));
+    PUPPINoLeptonsIsolation_photons_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationPhotons"));
+  }
+  produces<std::vector<T>>();
+}
+
+template <typename T>
+PATObjectPuppiIsolationUpdater<T>::~PATObjectPuppiIsolationUpdater() {}
+
+template <typename T>
+void PATObjectPuppiIsolationUpdater<T>::produce(edm::Event &iEvent, edm::EventSetup const &) {
+  edm::Handle<std::vector<T>> src;
+  iEvent.getByToken(src_, src);
+
+  //value maps for puppi isolation
+  edm::Handle<edm::ValueMap<float>> PUPPIIsolation_charged_hadrons;
+  edm::Handle<edm::ValueMap<float>> PUPPIIsolation_neutral_hadrons;
+  edm::Handle<edm::ValueMap<float>> PUPPIIsolation_photons;
+  //value maps for puppiNoLeptons isolation
+  edm::Handle<edm::ValueMap<float>> PUPPINoLeptonsIsolation_charged_hadrons;
+  edm::Handle<edm::ValueMap<float>> PUPPINoLeptonsIsolation_neutral_hadrons;
+  edm::Handle<edm::ValueMap<float>> PUPPINoLeptonsIsolation_photons;
+
+  //puppi
+  iEvent.getByToken(PUPPIIsolation_charged_hadrons_, PUPPIIsolation_charged_hadrons);
+  iEvent.getByToken(PUPPIIsolation_neutral_hadrons_, PUPPIIsolation_neutral_hadrons);
+  iEvent.getByToken(PUPPIIsolation_photons_, PUPPIIsolation_photons);
+  //puppiNoLeptons
+
+  if constexpr (std::is_same<T,pat::Electron>::value || std::is_same<T,pat::Muon>::value){
+    iEvent.getByToken(PUPPINoLeptonsIsolation_charged_hadrons_, PUPPINoLeptonsIsolation_charged_hadrons);
+    iEvent.getByToken(PUPPINoLeptonsIsolation_neutral_hadrons_, PUPPINoLeptonsIsolation_neutral_hadrons);
+    iEvent.getByToken(PUPPINoLeptonsIsolation_photons_, PUPPINoLeptonsIsolation_photons);
+  }
+
+  auto outPtrP = std::make_unique<std::vector<T>>();
+  outPtrP->reserve(src->size());
+
+  for (size_t i = 0; i < src->size(); ++i) {
+    // copy original pat object and append to vector
+    outPtrP->emplace_back((*src)[i]);
+
+    edm::Ptr<T> objPtr(src,i);
+
+    outPtrP->back().setIsolationPUPPI((*PUPPIIsolation_charged_hadrons)[objPtr],
+                            (*PUPPIIsolation_neutral_hadrons)[objPtr],
+                            (*PUPPIIsolation_photons)[objPtr]);
+
+    if constexpr (std::is_same<T,pat::Electron>::value || std::is_same<T,pat::Muon>::value){
+      outPtrP->back().setIsolationPUPPINoLeptons((*PUPPINoLeptonsIsolation_charged_hadrons)[objPtr],
+                                     (*PUPPINoLeptonsIsolation_neutral_hadrons)[objPtr],
+                                     (*PUPPINoLeptonsIsolation_photons)[objPtr]);
+    }
+  }
+  iEvent.put(std::move(outPtrP));
+}
+
+typedef PATObjectPuppiIsolationUpdater<pat::Electron> PATElectronPuppiIsolationUpdater;
+typedef PATObjectPuppiIsolationUpdater<pat::Photon>   PATPhotonPuppiIsolationUpdater;
+typedef PATObjectPuppiIsolationUpdater<pat::Muon>     PATMuonPuppiIsolationUpdater;
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+
+DEFINE_FWK_MODULE(PATElectronPuppiIsolationUpdater);
+DEFINE_FWK_MODULE(PATPhotonPuppiIsolationUpdater);
+DEFINE_FWK_MODULE(PATMuonPuppiIsolationUpdater);

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateUpdater.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateUpdater.cc
@@ -7,7 +7,7 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 
 namespace pat {
-  class PATPackedCandidateUpdater : public edm::stream::EDProducer<>  {
+  class PATPackedCandidateUpdater : public edm::stream::EDProducer<> {
   public:
     explicit PATPackedCandidateUpdater(const edm::ParameterSet&);
     ~PATPackedCandidateUpdater() override {}
@@ -21,15 +21,15 @@ namespace pat {
     edm::EDGetTokenT<edm::ValueMap<float>> puppiWeightToken_;
     edm::EDGetTokenT<edm::ValueMap<float>> puppiWeightNoLepToken_;
   };
-} // namespace pat
+}  // namespace pat
 
 using namespace pat;
 
-PATPackedCandidateUpdater::PATPackedCandidateUpdater(const edm::ParameterSet& iConfig):
-  candsToken_(consumes<std::vector<pat::PackedCandidate>>(iConfig.getParameter<edm::InputTag>("src"))),
-  updatePuppiWeights_(iConfig.getParameter<bool>("updatePuppiWeights")),
-  puppiWeightToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiWeight"))),
-  puppiWeightNoLepToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiWeightNoLep"))){
+PATPackedCandidateUpdater::PATPackedCandidateUpdater(const edm::ParameterSet& iConfig)
+    : candsToken_(consumes<std::vector<pat::PackedCandidate>>(iConfig.getParameter<edm::InputTag>("src"))),
+      updatePuppiWeights_(iConfig.getParameter<bool>("updatePuppiWeights")),
+      puppiWeightToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiWeight"))),
+      puppiWeightNoLepToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiWeightNoLep"))) {
   produces<std::vector<pat::PackedCandidate>>();
 }
 
@@ -39,7 +39,7 @@ void PATPackedCandidateUpdater::produce(edm::Event& iEvent, const edm::EventSetu
 
   edm::Handle<edm::ValueMap<float>> puppiWeight;
   edm::Handle<edm::ValueMap<float>> puppiWeightNoLep;
-  if (updatePuppiWeights_){
+  if (updatePuppiWeights_) {
     iEvent.getByToken(puppiWeightToken_, puppiWeight);
     iEvent.getByToken(puppiWeightNoLepToken_, puppiWeightNoLep);
   }
@@ -48,14 +48,13 @@ void PATPackedCandidateUpdater::produce(edm::Event& iEvent, const edm::EventSetu
   outPtrP->reserve(cands->size());
 
   for (size_t ic = 0; ic < cands->size(); ++ic) {
-
     // copy original pat::PackedCandidate and append to vector
     outPtrP->emplace_back((*cands)[ic]);
 
     // Retrieve puppi weights from edm::ValueMap
     pat::PackedCandidateRef pkref(cands, ic);
 
-    if (updatePuppiWeights_){
+    if (updatePuppiWeights_) {
       float puppiWeightVal = (*puppiWeight)[pkref];
       float puppiWeightNoLepVal = (*puppiWeightNoLep)[pkref];
       outPtrP->back().setPuppiWeight(puppiWeightVal, puppiWeightNoLepVal);

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateUpdater.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateUpdater.cc
@@ -1,0 +1,69 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+
+namespace pat {
+  class PATPackedCandidateUpdater : public edm::stream::EDProducer<>  {
+  public:
+    explicit PATPackedCandidateUpdater(const edm::ParameterSet&);
+    ~PATPackedCandidateUpdater() override {}
+
+    void produce(edm::Event&, const edm::EventSetup&) override;
+
+  private:
+    edm::EDGetTokenT<std::vector<pat::PackedCandidate>> candsToken_;
+
+    bool updatePuppiWeights_;
+    edm::EDGetTokenT<edm::ValueMap<float>> puppiWeightToken_;
+    edm::EDGetTokenT<edm::ValueMap<float>> puppiWeightNoLepToken_;
+  };
+} // namespace pat
+
+using namespace pat;
+
+PATPackedCandidateUpdater::PATPackedCandidateUpdater(const edm::ParameterSet& iConfig):
+  candsToken_(consumes<std::vector<pat::PackedCandidate>>(iConfig.getParameter<edm::InputTag>("src"))),
+  updatePuppiWeights_(iConfig.getParameter<bool>("updatePuppiWeights")),
+  puppiWeightToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiWeight"))),
+  puppiWeightNoLepToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiWeightNoLep"))){
+  produces<std::vector<pat::PackedCandidate>>();
+}
+
+void PATPackedCandidateUpdater::produce(edm::Event& iEvent, const edm::EventSetup&) {
+  edm::Handle<std::vector<pat::PackedCandidate>> cands;
+  iEvent.getByToken(candsToken_, cands);
+
+  edm::Handle<edm::ValueMap<float>> puppiWeight;
+  edm::Handle<edm::ValueMap<float>> puppiWeightNoLep;
+  if (updatePuppiWeights_){
+    iEvent.getByToken(puppiWeightToken_, puppiWeight);
+    iEvent.getByToken(puppiWeightNoLepToken_, puppiWeightNoLep);
+  }
+
+  auto outPtrP = std::make_unique<std::vector<pat::PackedCandidate>>();
+  outPtrP->reserve(cands->size());
+
+  for (size_t ic = 0; ic < cands->size(); ++ic) {
+
+    // copy original pat::PackedCandidate and append to vector
+    outPtrP->emplace_back((*cands)[ic]);
+
+    // Retrieve puppi weights from edm::ValueMap
+    pat::PackedCandidateRef pkref(cands, ic);
+
+    if (updatePuppiWeights_){
+      float puppiWeightVal = (*puppiWeight)[pkref];
+      float puppiWeightNoLepVal = (*puppiWeightNoLep)[pkref];
+      outPtrP->back().setPuppiWeight(puppiWeightVal, puppiWeightNoLepVal);
+    }
+  }
+
+  iEvent.put(std::move(outPtrP));
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(PATPackedCandidateUpdater);

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonCandidatesRekeyer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonCandidatesRekeyer.cc
@@ -1,0 +1,78 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/View.h"
+
+#include "DataFormats/PatCandidates/interface/Photon.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+
+namespace pat {
+  class PATPhotonCandidatesRekeyer : public edm::stream::EDProducer<> {
+  public:
+    explicit PATPhotonCandidatesRekeyer(const edm::ParameterSet &iConfig);
+    ~PATPhotonCandidatesRekeyer() override;
+
+    void produce(edm::Event &, const edm::EventSetup &) override;
+
+  private:
+    // configurables
+    edm::EDGetTokenT<std::vector<pat::Photon>> src_;
+    edm::EDGetTokenT<reco::CandidateView> pcNewCandViewToken_;
+    edm::EDGetTokenT<pat::PackedCandidateCollection> pcNewToken_;
+  };
+
+}  // namespace pat
+
+using namespace pat;
+
+PATPhotonCandidatesRekeyer::PATPhotonCandidatesRekeyer(const edm::ParameterSet &iConfig):
+  src_(consumes<std::vector<pat::Photon>>(iConfig.getParameter<edm::InputTag>("src"))),
+  pcNewCandViewToken_(consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))),
+  pcNewToken_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))){
+  produces<std::vector<pat::Photon>>();
+}
+
+PATPhotonCandidatesRekeyer::~PATPhotonCandidatesRekeyer() {}
+
+void PATPhotonCandidatesRekeyer::produce(edm::Event &iEvent, edm::EventSetup const &) {
+  edm::Handle<std::vector<pat::Photon>> src;
+  iEvent.getByToken(src_, src);
+
+  edm::Handle<reco::CandidateView> pcNewCandViewHandle;
+  iEvent.getByToken(pcNewCandViewToken_, pcNewCandViewHandle);
+
+  edm::Handle<pat::PackedCandidateCollection> pcNewHandle;
+  iEvent.getByToken(pcNewToken_, pcNewHandle);
+
+  auto outPtrP = std::make_unique<std::vector<pat::Photon>>();
+  outPtrP->reserve(src->size());
+
+  for (size_t i = 0; i < src->size(); ++i) {
+    // copy original pat object and append to vector
+    outPtrP->emplace_back((*src)[i]);
+
+    std::vector<unsigned int> keys;
+    for (const edm::Ref<pat::PackedCandidateCollection> &ref : outPtrP->back().associatedPackedPFCandidates()){
+      keys.push_back(ref.key());
+    };
+    outPtrP->back().setAssociatedPackedPFCandidates(
+      edm::RefProd<pat::PackedCandidateCollection>(pcNewHandle),
+      keys.begin(), keys.end()
+    );
+    if (keys.size() == 1) {
+      outPtrP->back().refToOrig_ = outPtrP->back().sourceCandidatePtr(0);
+    } else {
+      outPtrP->back().refToOrig_ = reco::CandidatePtr(pcNewHandle.id());
+    }
+  }
+  iEvent.put(std::move(outPtrP));
+}
+
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(PATPhotonCandidatesRekeyer);

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonCandidatesRekeyer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonCandidatesRekeyer.cc
@@ -30,10 +30,11 @@ namespace pat {
 
 using namespace pat;
 
-PATPhotonCandidatesRekeyer::PATPhotonCandidatesRekeyer(const edm::ParameterSet &iConfig):
-  src_(consumes<std::vector<pat::Photon>>(iConfig.getParameter<edm::InputTag>("src"))),
-  pcNewCandViewToken_(consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))),
-  pcNewToken_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))){
+PATPhotonCandidatesRekeyer::PATPhotonCandidatesRekeyer(const edm::ParameterSet &iConfig)
+    : src_(consumes<std::vector<pat::Photon>>(iConfig.getParameter<edm::InputTag>("src"))),
+      pcNewCandViewToken_(consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))),
+      pcNewToken_(
+          consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))) {
   produces<std::vector<pat::Photon>>();
 }
 
@@ -57,13 +58,11 @@ void PATPhotonCandidatesRekeyer::produce(edm::Event &iEvent, edm::EventSetup con
     outPtrP->emplace_back((*src)[i]);
 
     std::vector<unsigned int> keys;
-    for (const edm::Ref<pat::PackedCandidateCollection> &ref : outPtrP->back().associatedPackedPFCandidates()){
+    for (const edm::Ref<pat::PackedCandidateCollection> &ref : outPtrP->back().associatedPackedPFCandidates()) {
       keys.push_back(ref.key());
     };
     outPtrP->back().setAssociatedPackedPFCandidates(
-      edm::RefProd<pat::PackedCandidateCollection>(pcNewHandle),
-      keys.begin(), keys.end()
-    );
+        edm::RefProd<pat::PackedCandidateCollection>(pcNewHandle), keys.begin(), keys.end());
     if (keys.size() == 1) {
       outPtrP->back().refToOrig_ = outPtrP->back().sourceCandidatePtr(0);
     } else {
@@ -72,7 +71,6 @@ void PATPhotonCandidatesRekeyer::produce(edm::Event &iEvent, edm::EventSetup con
   }
   iEvent.put(std::move(outPtrP));
 }
-
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(PATPhotonCandidatesRekeyer);

--- a/PhysicsTools/PatAlgos/plugins/PATTauCandidatesRekeyer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauCandidatesRekeyer.cc
@@ -1,0 +1,102 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/View.h"
+
+#include "DataFormats/PatCandidates/interface/Tau.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+
+namespace pat {
+  class PATTauCandidatesRekeyer : public edm::stream::EDProducer<> {
+  public:
+    explicit PATTauCandidatesRekeyer(const edm::ParameterSet &iConfig);
+    ~PATTauCandidatesRekeyer() override;
+
+    void produce(edm::Event &, const edm::EventSetup &) override;
+
+  private:
+    // configurables
+    edm::EDGetTokenT<std::vector<pat::Tau>> src_;
+    edm::EDGetTokenT<reco::CandidateView> pcNewCandViewToken_;
+    edm::EDGetTokenT<pat::PackedCandidateCollection> pcNewToken_;
+  };
+
+}  // namespace pat
+
+using namespace pat;
+
+PATTauCandidatesRekeyer::PATTauCandidatesRekeyer(const edm::ParameterSet &iConfig):
+  src_(consumes<std::vector<pat::Tau>>(iConfig.getParameter<edm::InputTag>("src"))),
+  pcNewCandViewToken_(consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))),
+  pcNewToken_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))){
+  produces<std::vector<pat::Tau>>();
+
+}
+
+PATTauCandidatesRekeyer::~PATTauCandidatesRekeyer() {}
+
+void PATTauCandidatesRekeyer::produce(edm::Event &iEvent, edm::EventSetup const &) {
+  edm::Handle<std::vector<pat::Tau>> src;
+  iEvent.getByToken(src_, src);
+
+  edm::Handle<reco::CandidateView> pcNewCandViewHandle;
+  iEvent.getByToken(pcNewCandViewToken_, pcNewCandViewHandle);
+
+  edm::Handle<pat::PackedCandidateCollection> pcNewHandle;
+  iEvent.getByToken(pcNewToken_, pcNewHandle);
+
+  auto outPtrP = std::make_unique<std::vector<pat::Tau>>();
+  outPtrP->reserve(src->size());
+
+  for (size_t i = 0; i < src->size(); ++i) {
+    // copy original pat object and append to vector
+    outPtrP->emplace_back((*src)[i]);
+
+    reco::CandidatePtrVector signalChHPtrs;
+    for (const reco::CandidatePtr &p : outPtrP->back().signalChargedHadrCands()) {
+      signalChHPtrs.push_back(edm::Ptr<reco::Candidate>(pcNewHandle,p.key()));
+    }
+    outPtrP->back().setSignalChargedHadrCands(signalChHPtrs);
+
+    reco::CandidatePtrVector signalNHPtrs;
+    for (const reco::CandidatePtr &p : outPtrP->back().signalNeutrHadrCands()) {
+      signalNHPtrs.push_back(edm::Ptr<reco::Candidate>(pcNewHandle,p.key()));
+    }
+    outPtrP->back().setSignalNeutralHadrCands(signalNHPtrs);
+
+    reco::CandidatePtrVector signalGammaPtrs;
+    for (const reco::CandidatePtr &p : outPtrP->back().signalGammaCands()) {
+      signalGammaPtrs.push_back(edm::Ptr<reco::Candidate>(pcNewHandle,p.key()));
+    }
+    outPtrP->back().setSignalGammaCands(signalGammaPtrs);
+
+    reco::CandidatePtrVector isolationChHPtrs;
+    for (const reco::CandidatePtr &p : outPtrP->back().isolationChargedHadrCands()) {
+      isolationChHPtrs.push_back(edm::Ptr<reco::Candidate>(pcNewHandle,p.key()));
+    }
+    outPtrP->back().setIsolationChargedHadrCands(isolationChHPtrs);
+
+    reco::CandidatePtrVector isolationNHPtrs;
+
+    for (const reco::CandidatePtr &p : outPtrP->back().isolationNeutrHadrCands()) {
+      isolationNHPtrs.push_back(edm::Ptr<reco::Candidate>(pcNewHandle,p.key()));
+    }
+    outPtrP->back().setIsolationNeutralHadrCands(isolationNHPtrs);
+
+    reco::CandidatePtrVector isolationGammaPtrs;
+    for (const reco::CandidatePtr &p : outPtrP->back().isolationGammaCands()) {
+      isolationGammaPtrs.push_back(edm::Ptr<reco::Candidate>(pcNewHandle,p.key()));
+    }
+    outPtrP->back().setIsolationGammaCands(isolationGammaPtrs);
+  }
+  iEvent.put(std::move(outPtrP));
+}
+
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(PATTauCandidatesRekeyer);

--- a/PhysicsTools/PatAlgos/plugins/PATTauCandidatesRekeyer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauCandidatesRekeyer.cc
@@ -30,12 +30,12 @@ namespace pat {
 
 using namespace pat;
 
-PATTauCandidatesRekeyer::PATTauCandidatesRekeyer(const edm::ParameterSet &iConfig):
-  src_(consumes<std::vector<pat::Tau>>(iConfig.getParameter<edm::InputTag>("src"))),
-  pcNewCandViewToken_(consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))),
-  pcNewToken_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))){
+PATTauCandidatesRekeyer::PATTauCandidatesRekeyer(const edm::ParameterSet &iConfig)
+    : src_(consumes<std::vector<pat::Tau>>(iConfig.getParameter<edm::InputTag>("src"))),
+      pcNewCandViewToken_(consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))),
+      pcNewToken_(
+          consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))) {
   produces<std::vector<pat::Tau>>();
-
 }
 
 PATTauCandidatesRekeyer::~PATTauCandidatesRekeyer() {}
@@ -59,44 +59,43 @@ void PATTauCandidatesRekeyer::produce(edm::Event &iEvent, edm::EventSetup const 
 
     reco::CandidatePtrVector signalChHPtrs;
     for (const reco::CandidatePtr &p : outPtrP->back().signalChargedHadrCands()) {
-      signalChHPtrs.push_back(edm::Ptr<reco::Candidate>(pcNewHandle,p.key()));
+      signalChHPtrs.push_back(edm::Ptr<reco::Candidate>(pcNewHandle, p.key()));
     }
     outPtrP->back().setSignalChargedHadrCands(signalChHPtrs);
 
     reco::CandidatePtrVector signalNHPtrs;
     for (const reco::CandidatePtr &p : outPtrP->back().signalNeutrHadrCands()) {
-      signalNHPtrs.push_back(edm::Ptr<reco::Candidate>(pcNewHandle,p.key()));
+      signalNHPtrs.push_back(edm::Ptr<reco::Candidate>(pcNewHandle, p.key()));
     }
     outPtrP->back().setSignalNeutralHadrCands(signalNHPtrs);
 
     reco::CandidatePtrVector signalGammaPtrs;
     for (const reco::CandidatePtr &p : outPtrP->back().signalGammaCands()) {
-      signalGammaPtrs.push_back(edm::Ptr<reco::Candidate>(pcNewHandle,p.key()));
+      signalGammaPtrs.push_back(edm::Ptr<reco::Candidate>(pcNewHandle, p.key()));
     }
     outPtrP->back().setSignalGammaCands(signalGammaPtrs);
 
     reco::CandidatePtrVector isolationChHPtrs;
     for (const reco::CandidatePtr &p : outPtrP->back().isolationChargedHadrCands()) {
-      isolationChHPtrs.push_back(edm::Ptr<reco::Candidate>(pcNewHandle,p.key()));
+      isolationChHPtrs.push_back(edm::Ptr<reco::Candidate>(pcNewHandle, p.key()));
     }
     outPtrP->back().setIsolationChargedHadrCands(isolationChHPtrs);
 
     reco::CandidatePtrVector isolationNHPtrs;
 
     for (const reco::CandidatePtr &p : outPtrP->back().isolationNeutrHadrCands()) {
-      isolationNHPtrs.push_back(edm::Ptr<reco::Candidate>(pcNewHandle,p.key()));
+      isolationNHPtrs.push_back(edm::Ptr<reco::Candidate>(pcNewHandle, p.key()));
     }
     outPtrP->back().setIsolationNeutralHadrCands(isolationNHPtrs);
 
     reco::CandidatePtrVector isolationGammaPtrs;
     for (const reco::CandidatePtr &p : outPtrP->back().isolationGammaCands()) {
-      isolationGammaPtrs.push_back(edm::Ptr<reco::Candidate>(pcNewHandle,p.key()));
+      isolationGammaPtrs.push_back(edm::Ptr<reco::Candidate>(pcNewHandle, p.key()));
     }
     outPtrP->back().setIsolationGammaCands(isolationGammaPtrs);
   }
   iEvent.put(std::move(outPtrP));
 }
-
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(PATTauCandidatesRekeyer);

--- a/PhysicsTools/PatAlgos/plugins/VertexCompositeCandidateDaughtersRekeyer.cc
+++ b/PhysicsTools/PatAlgos/plugins/VertexCompositeCandidateDaughtersRekeyer.cc
@@ -32,10 +32,12 @@ namespace pat {
 
 using namespace pat;
 
-VertexCompositeCandidateDaughtersRekeyer::VertexCompositeCandidateDaughtersRekeyer(const edm::ParameterSet &iConfig):
-  src_(consumes<reco::VertexCompositePtrCandidateCollection>(iConfig.getParameter<edm::InputTag>("src"))),
-  pcOriToken_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesOri"))),
-  pcNewToken_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))){
+VertexCompositeCandidateDaughtersRekeyer::VertexCompositeCandidateDaughtersRekeyer(const edm::ParameterSet &iConfig)
+    : src_(consumes<reco::VertexCompositePtrCandidateCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      pcOriToken_(
+          consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesOri"))),
+      pcNewToken_(
+          consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))) {
   produces<reco::VertexCompositePtrCandidateCollection>();
 }
 
@@ -66,9 +68,9 @@ void VertexCompositeCandidateDaughtersRekeyer::produce(edm::Event &iEvent, edm::
       // We check if this CandidatePtr points to a candidate in the original packedPFCandidates collection
       // This is needed because the CandidatePtr can point to a candidate in lostTracks collection
       //
-      if (dau.id() == pcOriHandle.id()){
-        outPtrP->back().addDaughter(edm::Ptr<reco::Candidate>(pcNewHandle,dau.key()));
-      }else{
+      if (dau.id() == pcOriHandle.id()) {
+        outPtrP->back().addDaughter(edm::Ptr<reco::Candidate>(pcNewHandle, dau.key()));
+      } else {
         outPtrP->back().addDaughter(dau);
       }
     }

--- a/PhysicsTools/PatAlgos/plugins/VertexCompositeCandidateDaughtersRekeyer.cc
+++ b/PhysicsTools/PatAlgos/plugins/VertexCompositeCandidateDaughtersRekeyer.cc
@@ -1,0 +1,80 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/View.h"
+
+#include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
+#include "DataFormats/Candidate/interface/VertexCompositeCandidate.h"
+#include "DataFormats/Candidate/interface/VertexCompositeCandidateFwd.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+
+namespace pat {
+  class VertexCompositeCandidateDaughtersRekeyer : public edm::stream::EDProducer<> {
+  public:
+    explicit VertexCompositeCandidateDaughtersRekeyer(const edm::ParameterSet &iConfig);
+    ~VertexCompositeCandidateDaughtersRekeyer() override;
+
+    void produce(edm::Event &, const edm::EventSetup &) override;
+
+  private:
+    // configurables
+    edm::EDGetTokenT<reco::VertexCompositePtrCandidateCollection> src_;
+    edm::EDGetTokenT<pat::PackedCandidateCollection> pcOriToken_;
+    edm::EDGetTokenT<pat::PackedCandidateCollection> pcNewToken_;
+  };
+
+}  // namespace pat
+
+using namespace pat;
+
+VertexCompositeCandidateDaughtersRekeyer::VertexCompositeCandidateDaughtersRekeyer(const edm::ParameterSet &iConfig):
+  src_(consumes<reco::VertexCompositePtrCandidateCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+  pcOriToken_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesOri"))),
+  pcNewToken_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidatesNew"))){
+  produces<reco::VertexCompositePtrCandidateCollection>();
+}
+
+VertexCompositeCandidateDaughtersRekeyer::~VertexCompositeCandidateDaughtersRekeyer() {}
+
+void VertexCompositeCandidateDaughtersRekeyer::produce(edm::Event &iEvent, edm::EventSetup const &) {
+  edm::Handle<reco::VertexCompositePtrCandidateCollection> src;
+  iEvent.getByToken(src_, src);
+
+  edm::Handle<pat::PackedCandidateCollection> pcOriHandle;
+  iEvent.getByToken(pcOriToken_, pcOriHandle);
+
+  edm::Handle<pat::PackedCandidateCollection> pcNewHandle;
+  iEvent.getByToken(pcNewToken_, pcNewHandle);
+
+  auto outPtrP = std::make_unique<reco::VertexCompositePtrCandidateCollection>();
+  outPtrP->reserve(src->size());
+
+  for (size_t i = 0; i < src->size(); ++i) {
+    // copy original object and append to vector
+    outPtrP->emplace_back((*src)[i]);
+
+    std::vector<reco::CandidatePtr> daughters = outPtrP->back().daughterPtrVector();
+    outPtrP->back().clearDaughters();
+
+    for (const reco::CandidatePtr &dau : daughters) {
+      //
+      // We check if this CandidatePtr points to a candidate in the original packedPFCandidates collection
+      // This is needed because the CandidatePtr can point to a candidate in lostTracks collection
+      //
+      if (dau.id() == pcOriHandle.id()){
+        outPtrP->back().addDaughter(edm::Ptr<reco::Candidate>(pcNewHandle,dau.key()));
+      }else{
+        outPtrP->back().addDaughter(dau);
+      }
+    }
+  }
+  iEvent.put(std::move(outPtrP));
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(VertexCompositeCandidateDaughtersRekeyer);

--- a/PhysicsTools/PatAlgos/python/slimming/miniAODFromMiniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAODFromMiniAOD_tools.py
@@ -1,0 +1,250 @@
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.PatAlgos.tools.helpers  import getPatAlgosToolsTask, addToProcessAndTask
+
+def miniAODFromMiniAOD_customizeCommon(process):
+
+    task = getPatAlgosToolsTask(process)
+
+    ###########################################################################
+    # Update packedPFCandidates with the recomputed puppi weights
+    ###########################################################################
+    addToProcessAndTask("packedPFCandidates", cms.EDProducer("PATPackedCandidateUpdater",
+        src = cms.InputTag("packedPFCandidates", processName=cms.InputTag.skipCurrentProcess()),
+        updatePuppiWeights = cms.bool(True),
+        puppiWeight = cms.InputTag("packedpuppi"),
+        puppiWeightNoLep = cms.InputTag("packedpuppiNoLep"),
+      ),
+      process, task
+    )
+
+    ###########################################################################
+    # Recompute Puppi Isolation for muons, electrons and photons
+    ###########################################################################
+    from RecoMuon.MuonIsolation.muonIsolationPUPPI_cff import muonIsolationMiniAODPUPPI as _muonIsolationMiniAODPUPPI
+    from RecoMuon.MuonIsolation.muonIsolationPUPPI_cff import muonIsolationMiniAODPUPPINoLeptons as _muonIsolationMiniAODPUPPINoLeptons
+
+    addToProcessAndTask('muonPUPPIIsolation', _muonIsolationMiniAODPUPPI.clone(
+        srcToIsolate = cms.InputTag('slimmedMuons', processName=cms.InputTag.skipCurrentProcess()),
+        srcForIsolationCone = cms.InputTag('packedPFCandidates', processName=cms.InputTag.skipCurrentProcess()),
+        puppiValueMap = cms.InputTag('packedpuppi'),
+      ),
+      process, task
+    )
+
+    addToProcessAndTask('muonPUPPINoLeptonsIsolation', _muonIsolationMiniAODPUPPINoLeptons.clone(
+        srcToIsolate = cms.InputTag('slimmedMuons', processName=cms.InputTag.skipCurrentProcess()),
+        srcForIsolationCone = cms.InputTag('packedPFCandidates', processName=cms.InputTag.skipCurrentProcess()),
+        puppiValueMap = cms.InputTag('packedpuppiNoLep'),
+      ),
+      process, task
+    )
+
+    addToProcessAndTask('slimmedMuonsUpdatedPuppiIsolation', cms.EDProducer('PATMuonPuppiIsolationUpdater',
+        src = cms.InputTag('slimmedMuons', processName=cms.InputTag.skipCurrentProcess()),
+        puppiIsolationChargedHadrons          = cms.InputTag("muonPUPPIIsolation","h+-DR040-ThresholdVeto000-ConeVeto000"),
+        puppiIsolationNeutralHadrons          = cms.InputTag("muonPUPPIIsolation","h0-DR040-ThresholdVeto000-ConeVeto001"),
+        puppiIsolationPhotons                 = cms.InputTag("muonPUPPIIsolation","gamma-DR040-ThresholdVeto000-ConeVeto001"),
+        puppiNoLeptonsIsolationChargedHadrons = cms.InputTag("muonPUPPINoLeptonsIsolation","h+-DR040-ThresholdVeto000-ConeVeto000"),
+        puppiNoLeptonsIsolationNeutralHadrons = cms.InputTag("muonPUPPINoLeptonsIsolation","h0-DR040-ThresholdVeto000-ConeVeto001"),
+        puppiNoLeptonsIsolationPhotons        = cms.InputTag("muonPUPPINoLeptonsIsolation","gamma-DR040-ThresholdVeto000-ConeVeto001"),
+      ),
+      process, task
+    )
+
+    from RecoEgamma.EgammaIsolationAlgos.egmPhotonIsolationPUPPI_cff import egmPhotonIsolationMiniAODPUPPI as _egmPhotonPUPPIIsolationForPhotons
+    from RecoEgamma.EgammaIsolationAlgos.egmElectronIsolationPUPPI_cff import egmElectronIsolationMiniAODPUPPI as _egmElectronIsolationMiniAODPUPPI
+    from RecoEgamma.EgammaIsolationAlgos.egmElectronIsolationPUPPI_cff import egmElectronIsolationMiniAODPUPPINoLeptons as _egmElectronIsolationMiniAODPUPPINoLeptons
+
+    addToProcessAndTask('egmPhotonPUPPIIsolation', _egmPhotonPUPPIIsolationForPhotons.clone(
+        srcToIsolate = cms.InputTag('slimmedPhotons', processName=cms.InputTag.skipCurrentProcess()),
+        srcForIsolationCone = cms.InputTag("packedPFCandidates", processName=cms.InputTag.skipCurrentProcess()),
+        puppiValueMap = cms.InputTag('packedpuppi'),
+      ),
+      process, task
+    )
+
+    addToProcessAndTask('egmElectronPUPPIIsolation', _egmElectronIsolationMiniAODPUPPI.clone(
+        srcToIsolate = cms.InputTag('slimmedElectrons', processName=cms.InputTag.skipCurrentProcess()),
+        srcForIsolationCone = cms.InputTag("packedPFCandidates", processName=cms.InputTag.skipCurrentProcess()),
+        puppiValueMap = cms.InputTag('packedpuppi'),
+      ),
+      process, task
+    )
+
+    addToProcessAndTask('egmElectronPUPPINoLeptonsIsolation', _egmElectronIsolationMiniAODPUPPI.clone(
+        srcToIsolate = cms.InputTag('slimmedElectrons', processName=cms.InputTag.skipCurrentProcess()),
+        srcForIsolationCone = cms.InputTag("packedPFCandidates", processName=cms.InputTag.skipCurrentProcess()),
+        puppiValueMap = cms.InputTag('packedpuppiNoLep'),
+      ),
+      process, task
+    )
+
+    addToProcessAndTask('slimmedPhotonsUpdatedPuppiIsolation', cms.EDProducer('PATPhotonPuppiIsolationUpdater',
+        src = cms.InputTag('slimmedPhotons', processName=cms.InputTag.skipCurrentProcess()),
+        puppiIsolationChargedHadrons = cms.InputTag("egmPhotonPUPPIIsolation","h+-DR030-"),
+        puppiIsolationNeutralHadrons = cms.InputTag("egmPhotonPUPPIIsolation","h0-DR030-"),
+        puppiIsolationPhotons        = cms.InputTag("egmPhotonPUPPIIsolation","gamma-DR030-"),
+      ),
+      process, task
+    )
+
+    addToProcessAndTask('slimmedElectronsUpdatedPuppiIsolation', cms.EDProducer('PATElectronPuppiIsolationUpdater',
+        src = cms.InputTag('slimmedElectrons', processName=cms.InputTag.skipCurrentProcess()),
+        puppiIsolationChargedHadrons          = cms.InputTag("egmElectronPUPPIIsolation","h+-DR030-BarVeto000-EndVeto001"),
+        puppiIsolationNeutralHadrons          = cms.InputTag("egmElectronPUPPIIsolation","h0-DR030-BarVeto000-EndVeto000"),
+        puppiIsolationPhotons                 = cms.InputTag("egmElectronPUPPIIsolation","gamma-DR030-BarVeto000-EndVeto008"),
+        puppiNoLeptonsIsolationChargedHadrons = cms.InputTag("egmElectronPUPPINoLeptonsIsolation","h+-DR030-BarVeto000-EndVeto001"),
+        puppiNoLeptonsIsolationNeutralHadrons = cms.InputTag("egmElectronPUPPINoLeptonsIsolation","h0-DR030-BarVeto000-EndVeto000"),
+        puppiNoLeptonsIsolationPhotons        = cms.InputTag("egmElectronPUPPINoLeptonsIsolation","gamma-DR030-BarVeto000-EndVeto008"),
+      ),
+      process, task
+    )
+
+    ###########################################################################
+    # Rekey jet constituents
+    ###########################################################################
+    addToProcessAndTask("slimmedJets", cms.EDProducer("PATJetCandidatesRekeyer",
+        src = cms.InputTag("slimmedJets", processName=cms.InputTag.skipCurrentProcess()),
+        packedPFCandidatesNew = cms.InputTag("packedPFCandidates",processName=cms.InputTag.currentProcess()),
+      ),
+      process, task
+    )
+
+    addToProcessAndTask("slimmedJetsPuppiPreRekey", process.slimmedJetsPuppi.clone(), process, task)
+    del process.slimmedJetsPuppi
+
+    addToProcessAndTask("slimmedJetsPuppi", cms.EDProducer("PATJetCandidatesRekeyer",
+        src = cms.InputTag("slimmedJetsPuppiPreRekey"),
+        packedPFCandidatesNew = cms.InputTag("packedPFCandidates",processName=cms.InputTag.currentProcess()),
+      ),
+      process, task
+    )
+
+    addToProcessAndTask("slimmedJetsAK8PreRekey", process.slimmedJetsAK8.clone(), process, task)
+    del process.slimmedJetsAK8
+
+    addToProcessAndTask("slimmedJetsAK8", cms.EDProducer("PATJetCandidatesRekeyer",
+        src = cms.InputTag("slimmedJetsAK8PreRekey"),
+        packedPFCandidatesNew = cms.InputTag("packedPFCandidates",processName=cms.InputTag.currentProcess()),
+      ),
+      process, task
+    )
+
+    addToProcessAndTask("selectedUpdatedPatJetsAK8PFPuppiSoftDropSubjetsSlimmedDeepFlavourPreRekey",
+        process.selectedUpdatedPatJetsAK8PFPuppiSoftDropSubjetsSlimmedDeepFlavour.clone(),
+        process,
+        task
+    )
+    del process.selectedUpdatedPatJetsAK8PFPuppiSoftDropSubjetsSlimmedDeepFlavour
+
+    addToProcessAndTask("selectedUpdatedPatJetsAK8PFPuppiSoftDropSubjetsSlimmedDeepFlavour", cms.EDProducer("PATJetCandidatesRekeyer",
+        src = cms.InputTag("selectedUpdatedPatJetsAK8PFPuppiSoftDropSubjetsSlimmedDeepFlavourPreRekey"),
+        packedPFCandidatesNew = cms.InputTag("packedPFCandidates",processName=cms.InputTag.currentProcess()),
+      ),
+      process, task
+    )
+
+    ###########################################################################
+    # Rekey tau constituents
+    ###########################################################################
+    addToProcessAndTask("slimmedTaus", cms.EDProducer("PATTauCandidatesRekeyer",
+        src = cms.InputTag("slimmedTaus", processName=cms.InputTag.skipCurrentProcess()),
+        packedPFCandidatesNew = cms.InputTag("packedPFCandidates",processName=cms.InputTag.currentProcess()),
+      ),
+      process, task
+    )
+
+    addToProcessAndTask("slimmedTausBoosted", cms.EDProducer("PATTauCandidatesRekeyer",
+        src = cms.InputTag("slimmedTausBoosted", processName=cms.InputTag.skipCurrentProcess()),
+        packedPFCandidatesNew = cms.InputTag("packedPFCandidates",processName=cms.InputTag.currentProcess()),
+      ),
+      process, task
+    )
+
+    ###########################################################################
+    # Rekey candidates in electrons, photons and muons
+    ###########################################################################
+    addToProcessAndTask("slimmedElectrons", cms.EDProducer("PATElectronCandidatesRekeyer",
+        src = cms.InputTag("slimmedElectronsUpdatedPuppiIsolation"),
+        packedPFCandidatesNew = cms.InputTag("packedPFCandidates", processName=cms.InputTag.currentProcess()),
+      ),
+      process, task
+    )
+
+    addToProcessAndTask("slimmedLowPtElectrons", cms.EDProducer("PATElectronCandidatesRekeyer",
+        src = cms.InputTag("slimmedLowPtElectrons", processName=cms.InputTag.skipCurrentProcess()),
+        packedPFCandidatesNew = cms.InputTag("packedPFCandidates", processName=cms.InputTag.currentProcess()),
+      ),
+      process, task
+    )
+
+    addToProcessAndTask("slimmedPhotons", cms.EDProducer("PATPhotonCandidatesRekeyer",
+        src = cms.InputTag("slimmedPhotonsUpdatedPuppiIsolation"),
+        packedPFCandidatesNew = cms.InputTag("packedPFCandidates", processName=cms.InputTag.currentProcess()),
+      ),
+      process, task
+    )
+
+
+    addToProcessAndTask("slimmedMuons", cms.EDProducer("PATMuonCandidatesRekeyer",
+        src = cms.InputTag("slimmedMuonsUpdatedPuppiIsolation"),
+        packedPFCandidatesNew = cms.InputTag("packedPFCandidates", processName=cms.InputTag.currentProcess()),
+      ),
+      process, task
+    )
+
+    addToProcessAndTask("slimmedDisplacedMuons", cms.EDProducer("PATMuonCandidatesRekeyer",
+        src = cms.InputTag("slimmedDisplacedMuons", processName=cms.InputTag.skipCurrentProcess()),
+        packedPFCandidatesNew = cms.InputTag("packedPFCandidates", processName=cms.InputTag.currentProcess()),
+      ),
+      process, task
+    )
+
+    ###########################################################################
+    # Rekey daughters of secondary vertices
+    ###########################################################################
+    addToProcessAndTask("slimmedKshortVertices", cms.EDProducer("VertexCompositeCandidateDaughtersRekeyer",
+        src = cms.InputTag("slimmedKshortVertices", processName=cms.InputTag.skipCurrentProcess()),
+        packedPFCandidatesOri = cms.InputTag("packedPFCandidates", processName=cms.InputTag.skipCurrentProcess()),
+        packedPFCandidatesNew = cms.InputTag("packedPFCandidates", processName=cms.InputTag.currentProcess()),
+      ),
+      process, task
+    )
+
+    addToProcessAndTask("slimmedLambdaVertices", cms.EDProducer("VertexCompositeCandidateDaughtersRekeyer",
+        src = cms.InputTag("slimmedLambdaVertices", processName=cms.InputTag.skipCurrentProcess()),
+        packedPFCandidatesOri = cms.InputTag("packedPFCandidates", processName=cms.InputTag.skipCurrentProcess()),
+        packedPFCandidatesNew = cms.InputTag("packedPFCandidates", processName=cms.InputTag.currentProcess()),
+      ),
+      process, task
+    )
+
+    addToProcessAndTask("slimmedSecondaryVertices", cms.EDProducer("VertexCompositeCandidateDaughtersRekeyer",
+        src = cms.InputTag("slimmedSecondaryVertices", processName=cms.InputTag.skipCurrentProcess()),
+        packedPFCandidatesOri = cms.InputTag("packedPFCandidates", processName=cms.InputTag.skipCurrentProcess()),
+        packedPFCandidatesNew = cms.InputTag("packedPFCandidates", processName=cms.InputTag.currentProcess()),
+      ),
+      process, task
+    )
+
+    return process
+
+def miniAODFromMiniAOD_customizeData(process):
+    from PhysicsTools.PatAlgos.tools.puppiJetMETReclusteringFromMiniAOD_cff import puppiJetMETReclusterFromMiniAOD_Data
+    process = puppiJetMETReclusterFromMiniAOD_Data(process)
+    return process
+
+def miniAODFromMiniAOD_customizeMC(process):
+    from PhysicsTools.PatAlgos.tools.puppiJetMETReclusteringFromMiniAOD_cff import puppiJetMETReclusterFromMiniAOD_MC
+    process = puppiJetMETReclusterFromMiniAOD_MC(process)
+    return process
+
+def miniAODFromMiniAOD_customizeAllData(process):
+    process = miniAODFromMiniAOD_customizeData(process)
+    process = miniAODFromMiniAOD_customizeCommon(process)
+    return process
+
+def miniAODFromMiniAOD_customizeAllMC(process):
+    process = miniAODFromMiniAOD_customizeMC(process)
+    process = miniAODFromMiniAOD_customizeCommon(process)
+    return process

--- a/PhysicsTools/PatAlgos/python/slimming/miniAODFromMiniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAODFromMiniAOD_tools.py
@@ -6,6 +6,12 @@ def miniAODFromMiniAOD_customizeCommon(process):
     task = getPatAlgosToolsTask(process)
 
     ###########################################################################
+    # Set puppi producers to use the original packedPFCandidate collection
+    ###########################################################################
+    process.packedpuppi.candName = 'packedPFCandidates::@skipCurrentProcess'
+    process.packedpuppiNoLep.candName = 'packedPFCandidates::@skipCurrentProcess'
+
+    ###########################################################################
     # Update packedPFCandidates with the recomputed puppi weights
     ###########################################################################
     addToProcessAndTask("packedPFCandidates", cms.EDProducer("PATPackedCandidateUpdater",

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -255,7 +255,7 @@ def setupPuppiForPackedPF(process, useExistingWeights=True, postfix=''):
     if not hasattr(process, puppiLabel):
         addToProcessAndTask(puppiLabel, puppi.clone(
             useExistingWeights = useExistingWeights,
-            candName = 'packedPFCandidates',
+            candName = 'packedPFCandidates::@skipCurrentProcess',
             vertexName = 'offlineSlimmedPrimaryVertices'), process, task)
 
     puppiNoLepLabel = puppiLabel+'NoLep'
@@ -408,7 +408,7 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
 
     # Setup the PUPPI ValueMap that will consumed by the TagInfo producers.
     puppi_value_map = "puppi"
-    if pfCandidates.value() == 'packedPFCandidates':
+    if 'packedPFCandidates' in pfCandidates.value():
         puppi_value_map = setupPuppiForPackedPF(process)[0]
 
     acceptedTagInfos = list()
@@ -651,7 +651,7 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
 
                 # use right input tags when running with RECO PF candidates, which actually
                 # depends of whether jets use "particleFlow"
-                if pfCandidates.value() == 'packedPFCandidates':
+                if 'packedPFCandidates' in pfCandidates.value():
                     vertex_associator = cms.InputTag("")
                 else:
                     vertex_associator = cms.InputTag("primaryVertexAssociation","original")
@@ -680,7 +680,7 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                     svUsed, flip, max_sip3dsig_for_flip = svSource, False, -1.
                 # use right input tags when running with RECO PF candidates, which actually
                 # depends of whether jets use "particleFlow"
-                if pfCandidates.value() == 'packedPFCandidates':
+                if 'packedPFCandidates' in pfCandidates.value():
                     vertex_associator = cms.InputTag("")
                 else:
                     vertex_associator = cms.InputTag("primaryVertexAssociation","original")
@@ -710,7 +710,7 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                     flip = False
                 # use right input tags when running with RECO PF candidates, which actually
                 # depends of whether jets use "particleFlow"
-                if pfCandidates.value() == 'packedPFCandidates':
+                if 'packedPFCandidates' in pfCandidates.value():
                     vertex_associator = cms.InputTag("")
                 else:
                     vertex_associator = cms.InputTag("primaryVertexAssociation","original")
@@ -739,7 +739,7 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                     flip = False
                 # use right input tags when running with RECO PF candidates, which actually
                 # depends of whether jets use "particleFlow"
-                if pfCandidates.value() == 'packedPFCandidates':
+                if 'packedPFCandidates' in pfCandidates.value():
                     puppi_value_map = setupPuppiForPackedPF(process)[0]
                     vertex_associator = cms.InputTag("")
                 else:
@@ -786,7 +786,7 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                                     process, task)
 
             if btagInfo == 'pfDeepBoostedJetTagInfos':
-                if pfCandidates.value() == 'packedPFCandidates':
+                if 'packedPFCandidates' in pfCandidates.value():
                     # case 1: running over jets whose daughters are PackedCandidates (only via updateJetCollection for now)
                     if 'updated' not in jetSource.value().lower():
                         raise ValueError("Invalid jet collection: %s. pfDeepBoostedJetTagInfos only supports running via updateJetCollection." % jetSource.value())
@@ -811,7 +811,7 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                                     process, task)
 
             if btagInfo == 'pfParticleNetTagInfos' or btagInfo == 'pfGlobalParticleTransformerAK8TagInfos':
-                if pfCandidates.value() == 'packedPFCandidates':
+                if 'packedPFCandidates' in pfCandidates.value():
                     # case 1: running over jets whose daughters are PackedCandidates (only via updateJetCollection for now)
                     vertex_associator = ""
                 elif pfCandidates.value() == 'particleFlow':
@@ -841,7 +841,7 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                     secondary_vertices = svSource
                     flip_ip_sign = False
                     sip3dSigMax = -1
-                if pfCandidates.value() == 'packedPFCandidates':
+                if 'packedPFCandidates' in pfCandidates.value():
                     # case 1: running over jets whose daughters are PackedCandidates (only via updateJetCollection for now)
                     vertex_associator = ""
                 elif pfCandidates.value() == 'particleFlow':
@@ -877,7 +877,7 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                 svUsed, flip_ip_sign, max_sip3dsig_for_flip = cms.InputTag(btagPrefix+'inclusiveCandidateNegativeSecondaryVertices'+labelName+postfix), True, 10.
             else:
                 svUsed, flip_ip_sign, max_sip3dsig_for_flip = svSource, False, -1.
-            if pfCandidates.value() != 'packedPFCandidates':
+            if 'packedPFCandidates' not in pfCandidates.value():
                 raise ValueError("Invalid pfCandidates collection: %s." % pfCandidates.value())
             addToProcessAndTask(btagPrefix+btagInfo+labelName+postfix,
                                 pfParticleNetFromMiniAODAK4PuppiCentralTagInfos.clone(
@@ -893,7 +893,7 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
             acceptedTagInfos.append(btagInfo)
         elif btagInfo == 'pfParticleNetFromMiniAODAK4PuppiForwardTagInfos':
             # ParticleNetFromMiniAOD cannot be run on RECO inputs, so need a workaround
-            if pfCandidates.value() != 'packedPFCandidates':
+            if 'packedPFCandidates' not in pfCandidates.value():
                 raise ValueError("Invalid pfCandidates collection: %s." % pfCandidates.value())
             addToProcessAndTask(btagPrefix+btagInfo+labelName+postfix,
                                 pfParticleNetFromMiniAODAK4PuppiForwardTagInfos.clone(
@@ -911,7 +911,7 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                 svUsed, flip_ip_sign, max_sip3dsig_for_flip = cms.InputTag(btagPrefix+'inclusiveCandidateNegativeSecondaryVertices'+labelName+postfix), True, 10.
             else:
                 svUsed, flip_ip_sign, max_sip3dsig_for_flip = svSource, False, -1.
-            if pfCandidates.value() != 'packedPFCandidates':
+            if 'packedPFCandidates' not in pfCandidates.value():
                 raise ValueError("Invalid pfCandidates collection: %s." % pfCandidates.value())
             addToProcessAndTask(btagPrefix+btagInfo+labelName+postfix,
                                 pfParticleNetFromMiniAODAK4CHSCentralTagInfos.clone(
@@ -927,7 +927,7 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
             acceptedTagInfos.append(btagInfo)
         elif btagInfo == 'pfParticleNetFromMiniAODAK4CHSForwardTagInfos':
             # ParticleNetFromMiniAOD cannot be run on RECO inputs, so need a workaround
-            if pfCandidates.value() != 'packedPFCandidates':
+            if 'packedPFCandidates' not in pfCandidates.value():
                 raise ValueError("Invalid pfCandidates collection: %s." % pfCandidates.value())
             addToProcessAndTask(btagPrefix+btagInfo+labelName+postfix,
                                 pfParticleNetFromMiniAODAK4CHSForwardTagInfos.clone(
@@ -941,7 +941,7 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
             acceptedTagInfos.append(btagInfo)
         elif btagInfo == 'pfParticleNetFromMiniAODAK8TagInfos':
             # ParticleNetFromMiniAOD cannot be run on RECO inputs, so need a workaround
-            if pfCandidates.value() != 'packedPFCandidates':
+            if 'packedPFCandidates' not in pfCandidates.value():
                 raise ValueError("Invalid pfCandidates collection: %s." % pfCandidates.value())
             addToProcessAndTask(btagPrefix+btagInfo+labelName+postfix,
                                 pfParticleNetFromMiniAODAK8TagInfos.clone(

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -255,7 +255,7 @@ def setupPuppiForPackedPF(process, useExistingWeights=True, postfix=''):
     if not hasattr(process, puppiLabel):
         addToProcessAndTask(puppiLabel, puppi.clone(
             useExistingWeights = useExistingWeights,
-            candName = 'packedPFCandidates::@skipCurrentProcess',
+            candName = 'packedPFCandidates',
             vertexName = 'offlineSlimmedPrimaryVertices'), process, task)
 
     puppiNoLepLabel = puppiLabel+'NoLep'

--- a/PhysicsTools/PatAlgos/python/tools/puppiJetMETReclusteringTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/puppiJetMETReclusteringTools.py
@@ -131,6 +131,7 @@ def puppiAK4METReclusterFromMiniAOD(process, runOnMC, useExistingWeights, btagDi
   runMetCorAndUncFromMiniAOD(process,
     isData=not(runOnMC),
     jetCollUnskimmed="slimmedJetsPuppi",
+    pfCandColl=pfInputTag,
     metType="Puppi",
     postfix="Puppi",
     jetFlavor="AK4PFPuppi",

--- a/PhysicsTools/PatAlgos/python/tools/puppiJetMETReclusteringTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/puppiJetMETReclusteringTools.py
@@ -8,7 +8,7 @@ def puppiAK4METReclusterFromMiniAOD(process, runOnMC, useExistingWeights, btagDi
 
   task = getPatAlgosToolsTask(process)
 
-  pfLabel = "packedPFCandidates"
+  pfInputTag = cms.InputTag("packedPFCandidates", processName=cms.InputTag.skipCurrentProcess())
   pvLabel = "offlineSlimmedPrimaryVertices"
   svLabel = "slimmedSecondaryVertices"
   muLabel = "slimmedMuons"
@@ -37,7 +37,7 @@ def puppiAK4METReclusterFromMiniAOD(process, runOnMC, useExistingWeights, btagDi
   #
   process.load("RecoJets.JetProducers.ak4PFJets_cfi")
   task.add(process.ak4PFJetsPuppi)
-  process.ak4PFJetsPuppi.src = pfLabel
+  process.ak4PFJetsPuppi.src = pfInputTag
   process.ak4PFJetsPuppi.srcWeights = puppiLabel
 
   from RecoJets.JetAssociationProducers.j2tParametersVX_cfi import j2tParametersVX
@@ -62,7 +62,7 @@ def puppiAK4METReclusterFromMiniAOD(process, runOnMC, useExistingWeights, btagDi
     jetSource          = cms.InputTag("ak4PFJetsPuppi"),
     algo               = "ak",
     rParam             = 0.4,
-    pfCandidates       = cms.InputTag(pfLabel),
+    pfCandidates       = pfInputTag,
     pvSource           = cms.InputTag(pvLabel),
     svSource           = cms.InputTag(svLabel),
     muSource           = cms.InputTag(muLabel),
@@ -96,7 +96,7 @@ def puppiAK4METReclusterFromMiniAOD(process, runOnMC, useExistingWeights, btagDi
   from PhysicsTools.PatAlgos.slimming.slimmedJets_cfi import slimmedJets
   addToProcessAndTask('slimmedJetsPuppiNoDeepTags', slimmedJets.clone(
       src = "selectedPatJetsPuppi",
-      packedPFCandidates = pfLabel,
+      packedPFCandidates = pfInputTag,
       dropDaughters = "0",
       rekeyDaughters = "0",
     ),
@@ -108,7 +108,7 @@ def puppiAK4METReclusterFromMiniAOD(process, runOnMC, useExistingWeights, btagDi
     jetSource = cms.InputTag("slimmedJetsPuppiNoDeepTags"),
     # updateJetCollection defaults to MiniAOD inputs but
     # here it is made explicit (as in training or MINIAOD redoing)
-    pfCandidates = cms.InputTag(pfLabel),
+    pfCandidates = pfInputTag,
     pvSource = cms.InputTag(pvLabel),
     svSource = cms.InputTag(svLabel),
     muSource = cms.InputTag(muLabel),
@@ -155,7 +155,7 @@ def puppiAK8ReclusterFromMiniAOD(process, runOnMC, useExistingWeights, btagDiscr
 
   task = getPatAlgosToolsTask(process)
 
-  pfLabel = "packedPFCandidates"
+  pfInputTag = cms.InputTag("packedPFCandidates", processName=cms.InputTag.skipCurrentProcess())
   pvLabel = "offlineSlimmedPrimaryVertices"
   svLabel = "slimmedSecondaryVertices"
   muLabel = "slimmedMuons"
@@ -188,7 +188,7 @@ def puppiAK8ReclusterFromMiniAOD(process, runOnMC, useExistingWeights, btagDiscr
   task.add(process.ak8PFJetsPuppiSoftDrop)
 
   # AK8 jet constituents for softdrop
-  process.ak8PFJetsPuppi.src = pfLabel
+  process.ak8PFJetsPuppi.src = pfInputTag
   process.ak8PFJetsPuppi.srcWeights = puppiLabel
 
   # AK8 jet constituents for softdrop
@@ -223,7 +223,7 @@ def puppiAK8ReclusterFromMiniAOD(process, runOnMC, useExistingWeights, btagDiscr
     jetSource          = cms.InputTag("ak8PFJetsPuppi"),
     algo               = "ak",
     rParam             = 0.8,
-    pfCandidates       = cms.InputTag(pfLabel),
+    pfCandidates       = pfInputTag,
     pvSource           = cms.InputTag(pvLabel),
     svSource           = cms.InputTag(svLabel),
     muSource           = cms.InputTag(muLabel),
@@ -269,7 +269,7 @@ def puppiAK8ReclusterFromMiniAOD(process, runOnMC, useExistingWeights, btagDiscr
     labelName = "AK8PFPuppiSoftDrop",
     jetSource = cms.InputTag("ak8PFJetsPuppiSoftDrop"),
     btagDiscriminators = ["None"],
-    pfCandidates = cms.InputTag(pfLabel),
+    pfCandidates = pfInputTag,
     pvSource = cms.InputTag(pvLabel),
     svSource = cms.InputTag(svLabel),
     muSource = cms.InputTag(muLabel),
@@ -291,7 +291,7 @@ def puppiAK8ReclusterFromMiniAOD(process, runOnMC, useExistingWeights, btagDiscr
     rParam = 0.8, # needed for subjet flavor clustering
     explicitJTA = True,  # needed for subjet b tagging
     svClustering = True, # needed for subjet b tagging
-    pfCandidates = cms.InputTag(pfLabel),
+    pfCandidates = pfInputTag,
     pvSource = cms.InputTag(pvLabel),
     svSource = cms.InputTag(svLabel),
     muSource = cms.InputTag(muLabel),
@@ -381,7 +381,7 @@ def puppiAK8ReclusterFromMiniAOD(process, runOnMC, useExistingWeights, btagDiscr
 
   addToProcessAndTask("slimmedJetsAK8PFPuppiSoftDropSubjetsNoDeepTags", cms.EDProducer("PATJetSlimmer",
       src = cms.InputTag("selectedPatJetsAK8PFPuppiSoftDropSubjets"),
-      packedPFCandidates = cms.InputTag(pfLabel),
+      packedPFCandidates = pfInputTag,
       dropJetVars = cms.string("1"),
       dropDaughters = cms.string("0"),
       rekeyDaughters = cms.string("0"),
@@ -402,7 +402,7 @@ def puppiAK8ReclusterFromMiniAOD(process, runOnMC, useExistingWeights, btagDiscr
     jetSource = cms.InputTag("slimmedJetsAK8PFPuppiSoftDropSubjetsNoDeepTags"),
     # updateJetCollection defaults to MiniAOD inputs but
     # here it is made explicit (as in training or MINIAOD redoing)
-    pfCandidates = cms.InputTag(pfLabel),
+    pfCandidates = pfInputTag,
     pvSource = cms.InputTag(pvLabel),
     svSource = cms.InputTag(svLabel),
     muSource = cms.InputTag(muLabel),
@@ -430,7 +430,7 @@ def puppiAK8ReclusterFromMiniAOD(process, runOnMC, useExistingWeights, btagDiscr
         'SoftDropPuppi'
       ),
       fixDaughters = cms.bool(False),
-      packedPFCandidates = cms.InputTag(pfLabel),
+      packedPFCandidates = pfInputTag,
     ),
     process, task
   )
@@ -455,7 +455,7 @@ def puppiAK8ReclusterFromMiniAOD(process, runOnMC, useExistingWeights, btagDiscr
     jetSource = cms.InputTag("slimmedJetsAK8NoDeepTags"),
     # updateJetCollection defaults to MiniAOD inputs but
     # here it is made explicit (as in training or MINIAOD redoing)
-    pfCandidates = cms.InputTag(pfLabel),
+    pfCandidates = pfInputTag,
     pvSource = cms.InputTag(pvLabel),
     svSource = cms.InputTag(svLabel),
     muSource = cms.InputTag(muLabel),


### PR DESCRIPTION
#### PR description:

This PR is the first step towards establishing a reMiniFromMini workflow. With this PR, the following features will be integrated:

- A module to update the puppi weights for `pat::PackedCandidate`.
- Modules to rekey PF candidates of PAT objects and `VertexCompositeCandidate` objects, from the old `packedPFCandidates` collection in the original MiniAOD to the new collection with the updated puppi weights.
- Modules to update `pat::Muon`, `pat::Electron` and `pat::Photon` objects with recomputed PUPPI Isolation variables.
- A customization function to setup the reMiniFromMini workflow by scheduling the necessary modules.

At the moment, the reMiniFromMini workflow is not setup to run. The purpose of this PR is to setup the machinery for the reMiniFromMini workflow and to check that the modifications in `jetTools.py` and `puppiJetMETReclusteringTools.py` do not interfere with existing MINI+NANO workflows. Once merged, a subsequent PR will soon follow to fully setup the reMiniFromMini production workflows.

#### PR validation:

- passes the usual runTheMatrix test:  `runTheMatrix.py -l limited -i all --ibeos` for a majority of the workflows. Those that failed were due to inability read files. The failed workflows are `4.22_RunCosmics2011A,4.53_RunPhoton2012B,8.0_BeamHalo,9.0_Higgs200ChargedTaus,25.0_TTbar,1330.0_ZMM_13,25202.0_TTbar_13,10224.0_TTbar_13+2017P,10224.0_TTbar_13+2017P,10224.0_TTbar_13+2017PU,12434.0_TTbar_14TeV+2023,12834.0_TTbar_14TeV+2024,12846.0_ZEE_14+2024,13034.0_TTbar_14TeV+2024PU,250202.181_TTbar13TeVPUppmx2018`.  
- successfully ran a reMiniFromMini test production with a single TTtoLNu2Q Run3Summer23MiniAODv4 file, using the  `miniAODFromMiniAOD_customizeAllMC()` customization function defined in `miniAODFromMiniAOD_tools.py`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to `15_0_X`, for reMiniFromMini campaign, and `15_1_X`.