### PR TITLE
add hepmc writer

### DIFF
--- a/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
+++ b/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
@@ -22,6 +22,7 @@
 #include "HepMC3/GenParticle.h"
 #include "HepMC3/GenVertex.h"
 #include "HepMC3/Print.h"
+#include "HepMC3/WriterAscii.h" 
 
 #include <iostream>
 #include <map>
@@ -31,7 +32,7 @@ using namespace std;
 class GenParticles2HepMCConverter : public edm::stream::EDProducer<> {
 public:
   explicit GenParticles2HepMCConverter(const edm::ParameterSet& pset);
-  ~GenParticles2HepMCConverter() override {}
+  ~GenParticles2HepMCConverter() override;
 
   void beginRun(edm::Run const& iRun, edm::EventSetup const&) override;
   void produce(edm::Event& event, const edm::EventSetup& eventSetup) override;
@@ -43,7 +44,10 @@ private:
   edm::ESGetToken<HepPDT::ParticleDataTable, PDTRecord> pTable_;
 
   const double cmEnergy_;
+  const bool writeHepMC_;
+  const std::string outputFile_;
   HepMC3::GenCrossSectionPtr xsec_;
+  std::shared_ptr<HepMC3::Writer> writer_; 
 
 private:
   inline HepMC3::FourVector FourVector(const reco::Candidate::Point& point) {
@@ -57,14 +61,28 @@ private:
 };
 
 GenParticles2HepMCConverter::GenParticles2HepMCConverter(const edm::ParameterSet& pset)
-    // dummy value to set incident proton pz for particle gun samples
-    : cmEnergy_(pset.getUntrackedParameter<double>("cmEnergy", 13000)) {
+    : cmEnergy_(pset.getUntrackedParameter<double>("cmEnergy", 13000)),
+      writeHepMC_(pset.getUntrackedParameter<bool>("writeHepMC", false)),
+      outputFile_(pset.getUntrackedParameter<std::string>("outputFile", "events.hepmc")) {
+  
   genParticlesToken_ = consumes<reco::CandidateView>(pset.getParameter<edm::InputTag>("genParticles"));
   genEventInfoToken_ = consumes<GenEventInfoProduct>(pset.getParameter<edm::InputTag>("genEventInfo"));
   genRunInfoToken_ = consumes<GenRunInfoProduct, edm::InRun>(pset.getParameter<edm::InputTag>("genEventInfo"));
   pTable_ = esConsumes<HepPDT::ParticleDataTable, PDTRecord>();
 
   produces<edm::HepMC3Product>("unsmeared");
+
+  // Initialize HepMC3 writer
+  if (writeHepMC_){
+      writer_ = std::make_shared<HepMC3::WriterAscii>(outputFile_);
+  }
+}
+
+GenParticles2HepMCConverter::~GenParticles2HepMCConverter() {
+  if (writeHepMC_) {
+    writer_->close();
+    writer_.reset();
+  }
 }
 
 void GenParticles2HepMCConverter::beginRun(edm::Run const& iRun, edm::EventSetup const&) {
@@ -208,9 +226,15 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
     }
   }
 
+  // Write event to HepMC file
+  if (writeHepMC_) {
+    writer_->write_event(hepmc_event);
+  }
+
   // Finalize HepMC event record
   auto hepmc_product = std::make_unique<edm::HepMC3Product>(&hepmc_event);
   event.put(std::move(hepmc_product), "unsmeared");
 }
 
 DEFINE_FWK_MODULE(GenParticles2HepMCConverter);
+

--- a/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
+++ b/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
@@ -22,7 +22,7 @@
 #include "HepMC3/GenParticle.h"
 #include "HepMC3/GenVertex.h"
 #include "HepMC3/Print.h"
-#include "HepMC3/WriterAscii.h" 
+#include "HepMC3/WriterAscii.h"
 
 #include <iostream>
 #include <map>
@@ -47,7 +47,7 @@ private:
   const bool writeHepMC_;
   const std::string outputFile_;
   HepMC3::GenCrossSectionPtr xsec_;
-  std::shared_ptr<HepMC3::Writer> writer_; 
+  std::shared_ptr<HepMC3::Writer> writer_;
 
 private:
   inline HepMC3::FourVector FourVector(const reco::Candidate::Point& point) {
@@ -64,7 +64,6 @@ GenParticles2HepMCConverter::GenParticles2HepMCConverter(const edm::ParameterSet
     : cmEnergy_(pset.getUntrackedParameter<double>("cmEnergy", 13000)),
       writeHepMC_(pset.getUntrackedParameter<bool>("writeHepMC", false)),
       outputFile_(pset.getUntrackedParameter<std::string>("outputFile", "events.hepmc")) {
-  
   genParticlesToken_ = consumes<reco::CandidateView>(pset.getParameter<edm::InputTag>("genParticles"));
   genEventInfoToken_ = consumes<GenEventInfoProduct>(pset.getParameter<edm::InputTag>("genEventInfo"));
   genRunInfoToken_ = consumes<GenRunInfoProduct, edm::InRun>(pset.getParameter<edm::InputTag>("genEventInfo"));
@@ -73,8 +72,8 @@ GenParticles2HepMCConverter::GenParticles2HepMCConverter(const edm::ParameterSet
   produces<edm::HepMC3Product>("unsmeared");
 
   // Initialize HepMC3 writer
-  if (writeHepMC_){
-      writer_ = std::make_shared<HepMC3::WriterAscii>(outputFile_);
+  if (writeHepMC_) {
+    writer_ = std::make_shared<HepMC3::WriterAscii>(outputFile_);
   }
 }
 
@@ -237,4 +236,3 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
 }
 
 DEFINE_FWK_MODULE(GenParticles2HepMCConverter);
-

--- a/GeneratorInterface/RivetInterface/test/genParticles2HepMC_cfg.py
+++ b/GeneratorInterface/RivetInterface/test/genParticles2HepMC_cfg.py
@@ -26,5 +26,8 @@ process.load("GeneratorInterface.RivetInterface.mergedGenParticles_cfi")
 process.load("GeneratorInterface.RivetInterface.genParticles2HepMC_cfi")
 process.genParticles2HepMC.genParticles = cms.InputTag("mergedGenParticles")
 
+# Turn on to write HepMC file
+#process.genParticles2HepMC.writeHepMC = cms.untracked.bool(True)
+
 process.path = cms.Path(process.mergedGenParticles*process.genParticles2HepMC)
 


### PR DESCRIPTION
#### PR description:

Added a functionality to enabling writing (dumping) hepmc ascii files after converting genparticles into hepmc format

#### PR validation:

Trimmed down the first few lines that I get in `output.hepmc` when the writing mode is turned on

```
HepMC::Version 3.02.07
HepMC::Asciiv3-START_EVENT_LISTING
E 129042011 225 569
U GEV MM
W 7.2698300000000003251444e+01 7.2698300000000003251444e+01 7.5442662939467979299479e+01 6.7539464134343020873530e+01 7.1330607316946597507012e+01 6.1823425881110843249644e+01 4.5230877608189345551182e+01 5.1388303989645507385831e+01 6.1208685920636412447493e+01 7.3489966547826384157815e+01 5.9028755982519058420621e+01 8.0512377202821909349950e+01 7.7629593162582253285109e+01 6.9438626993907760720504e+01 9.7711277404051358530523e+01 5.7814131884557980356476e+01 8.3996442000043685993660e+01 6.2821265424383902598038e+01 7.4525507510859128501579e+01 7.0871092489140892212163e+01 7.2698300000000003251444e+01 7.2698300000000003251444e+01 7.2698300000000003251444e+01 7.2698300000000003251444e+01 7.2979533560089137722571e+01 7.2345002821923657165826e+01 7.3125002462524250290699e+01 7.1952493150425311796425e+01 7.2650074270307982260420e+01 7.1127581167121093130845e+01 6.8461303356879000148183e+01 7.5847233876864379453764e+01 7.2698300000000003251444e+01 7.2698300000000003251444e+01 7.7650630441688363703179e+01 6.8965256416465251732006e+01 7.2698300000000003251444e+01 7.2698300000000003251444e+01 7.2699817911698119132780e+01 7.2696782115873730845124e+01 7.2698300000000003251444e+01 7.2698300000000003251444e+01 7.2698945636851945550916e+01 7.2697654364771381096944e+01 7.2698300000000003251444e+01 7.2698300000000003251444e+01
A 0 GenCrossSection 7.22621102e+01 0.00000000e+00 -1 -1 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00 7.22621102e+01 0.00000000e+00
A 0 GenPdfInfo 2 21 1.96223071e-01 2.30340933e-02 1.14547000e+01 0.00000000e+00 0.00000000e+00 0 0
A 0 alphaQCD 0.185409
A 0 alphaQED 0.00763790072917374
A 0 event_scale 11.4547
A 0 signal_process_id 9999
P 1 0 2212 0.0000000000000000e+00 0.0000000000000000e+00 6.5000000000000000e+03 6.5000000677192720e+03 9.3827000000000005e-01 4
P 2 0 2212 0.0000000000000000e+00 0.0000000000000000e+00 -6.5000000000000000e+03 6.5000000677192720e+03 9.3827000000000005e-01 4
V -3 0 [1] @ 1.1144998483359814e-01 4.2333636432886124e-01 2.8694467544555664e+01 0.0000000000000000e+00
P 3 -3 2 0.0000000000000000e+00 0.0000000000000000e+00 1.2754492187500000e+03 1.2754492187500000e+03 3.3000000000000002e-01 21
V -4 0 [2] @ 1.1144998483359814e-01 4.2333636432886124e-01 2.8694467544555664e+01 0.0000000000000000e+00
P 4 -4 21 0.0000000000000000e+00 0.0000000000000000e+00 -1.4972070312500000e+02 1.4972070312500000e+02 0.0000000000000000e+00 21
V -5 0 [3,4] @ 1.1144998483359814e-01 4.2333636432886124e-01 2.8694467544555664e+01 0.0000000000000000e+00
P 5 -5 6 -8.3791383360557944e+01 5.3330827835119429e+01 6.2418566218044418e+02 6.6289368320454321e+02 1.7500000000000000e+02 22
P 6 -5 -6 8.7813705718289995e+01 -4.2605523420648673e+01 -5.8468137209996087e+01 2.0214990107019085e+02 1.7500000000000000e+02 22
P 7 -5 2 -4.0223192380859167e+00 -1.0725298523853828e+01 5.6001082066531717e+02 5.6012796782763962e+02 3.3000000000000002e-01 23
V -6 0 [5] @ 1.1144998483359814e-01 4.2333636432886124e-01 2.8694467544555664e+01 0.0000000000000000e+00
P 8 -6 6 -8.7455939681159563e+01 5.4927857393211774e+01 6.2973566375903954e+02 6.6872097196899108e+02 1.7500000000000000e+02 44
V -7 0 [6] @ 1.1144998483359814e-01 4.2333636432886124e-01 2.8694467544555664e+01 0.0000000000000000e+00
P 9 -7 -6 8.7404617546591496e+01 -4.2427239985655390e+01 -5.6391708074212673e+01 2.0134359810222099e+02 1.7500000000000000e+02 44
V -8 0 [8] @ 1.1144998483359814e-01 4.2333636432886124e-01 2.8694467544555664e+01 0.0000000000000000e+00
P 10 -8 6 -8.5431827947949074e+01 5.2284033394730884e+01 6.3085857489432362e+02 6.6930552076763615e+02 1.7500000000000000e+02 44
V -9 0 [9] @ 1.1144998483359814e-01 4.2333636432886124e-01 2.8694467544555664e+01 0.0000000000000000e+00
P 11 -9 -6 8.7630572700936384e+01 -4.2722379967934813e+01 -5.6349989102118442e+01 2.0149248668320789e+02 1.7500000000000000e+02 44
V -10 0 [10] @ 1.1144998483359814e-01 4.2333636432886124e-01 2.8694467544555664e+01 0.0000000000000000e+00
```