### PR TITLE
[14_0] Add dedicated 2024 FastSim workflow

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2024_FastSim_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2024_FastSim_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+
+Run3_2024_FastSim = Run3_2024.copyAndExclude([run3_GEM])

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -36,6 +36,8 @@ upgradeKeys[2017] = [
     '2022HIRP', #RawPrime
     '2023HI',
     '2023HIRP', #RawPrime
+    '2024FS',
+    '2024FSPU',
 ]
 
 upgradeKeys[2026] = [
@@ -93,6 +95,7 @@ numWFStart={
 numWFSkip=200
 # temporary measure to keep other WF numbers the same
 numWFConflict = [[14400,14800], #2022ReReco, 2022ReRecoPU (in 12_4)
+                 [15600,16400], #20242024HLTOnDigi, 2024HLTOnDigiPU, 2024GenOnly, 2024SimOnGen (no backport)
                  [20400,20800], #D87
                  [21200,22000], #D89-D90
                  [50000,51000]]
@@ -3008,7 +3011,15 @@ upgradeProperties[2017] = {
         'Era':'Run3_pp_on_PbPb_approxSiStripClusters',
         'BeamSpot': 'DBrealistic',
         'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],
-    }
+    },
+    '2024FS' : {
+        'Geom' : 'DB:Extended',
+        'GT' : 'auto:phase1_2024_realistic',
+        'HLTmenu': '@relval2024',
+        'Era' : 'Run3_2024_FastSim',
+        'BeamSpot': 'DBrealistic',
+        'ScenToRun' : ['Gen','FastSimRun3','HARVESTFastRun3'],
+    },
 }
 
 # standard PU sequences

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -48,6 +48,7 @@ class Eras (object):
                  'Run3_2023_FastSim',
                  'Run3_2023_ZDC',
                  'Run3_2023_UPC',
+                 'Run3_2024_FastSim',
                  'Phase2',
                  'Phase2C9',
                  'Phase2C10',


### PR DESCRIPTION
#### PR description:
This is a partial backport of https://github.com/cms-sw/cmssw/pull/48153
Note that, since I don't do backport for all workflows that added in between, including 20242024HLTOnDigi, 2024HLTOnDigiPU, 2024GenOnly, 2024SimOnGen, so I add an exception on workflow numbers in this PR. So the 2024FS workflow has the same id with CMSSW_14_2_X, and later.

Without dedicated 2024FS workflow, we will face an issue when try to run FastSim
```
Principal::getByLabel: Found zero products matching all criteria
Looking for type: std::vector<PSimHit>
Looking for module label: g4SimHits
Looking for productInstanceName: MuonGEMHits
```

#### PR validation:
Run 16434.0 and it works fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
This is a backport PR.
