### PR TITLE
[15.1.X] deal with `Fake` HLT menus in `ScoutingMuonTriggerAnalyzer`

### DIFF
--- a/HLTriggerOffline/Scouting/plugins/ScoutingMuonTriggerAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingMuonTriggerAnalyzer.cc
@@ -127,11 +127,21 @@ ScoutingMuonTriggerAnalyzer::ScoutingMuonTriggerAnalyzer(const edm::ParameterSet
 void ScoutingMuonTriggerAnalyzer::dqmBeginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {
   bool changed{false};
   hltConfig_.init(iRun, iSetup, hltProcessName_, changed);
+
+  // deal with Fake HLT menus
+  if (hltConfig_.tableName().find("Fake") != std::string::npos) {
+    edm::LogPrint("ScoutingMuonTriggerAnalyzer")
+        << "Detected Fake in HLT Config tableName(): " << hltConfig_.tableName()
+        << "; the list of trigger expressions is going to be overriden!" << std::endl;
+    vtriggerSelector_.clear();
+    return;
+  }
+
   for (const auto& menu : special_HLT_Menus_) {
     std::size_t found = hltConfig_.tableName().find(menu);
     if (found != std::string::npos) {
       isSpecial_ = true;
-      edm::LogWarning("ScoutingMuonTriggerAnalyzer")
+      edm::LogPrint("ScoutingMuonTriggerAnalyzer")
           << "Detected " << menu << " in HLT Config tableName(): " << hltConfig_.tableName()
           << "; the list of trigger expressions is going to be overriden!" << std::endl;
       break;
@@ -279,7 +289,7 @@ void ScoutingMuonTriggerAnalyzer::fillDescriptions(edm::ConfigurationDescription
 
   desc.add<std::string>("OutputInternalPath", "MY_FOLDER");
   desc.add<std::vector<string>>("triggerSelection", {});
-  desc.add<std::string>("hltProcessName", "HLT");
+  desc.add<std::string>("hltProcessName", {});
   desc.add<std::vector<std::string>>("special_HLT_Menus", {})
       ->setComment("list of HLT menus to use to clear the trigger selection");
   desc.add<edm::InputTag>("ScoutingMuonCollection", edm::InputTag("hltScoutingMuonPackerVtx"));

--- a/HLTriggerOffline/Scouting/plugins/ScoutingMuonTriggerAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingMuonTriggerAnalyzer.cc
@@ -132,7 +132,7 @@ void ScoutingMuonTriggerAnalyzer::dqmBeginRun(edm::Run const& iRun, edm::EventSe
   if (hltConfig_.tableName().find("Fake") != std::string::npos) {
     edm::LogPrint("ScoutingMuonTriggerAnalyzer")
         << "Detected Fake in HLT Config tableName(): " << hltConfig_.tableName()
-        << "; the list of trigger expressions is going to be overriden!" << std::endl;
+        << "; the list of trigger expressions is going to be overridden!" << std::endl;
     vtriggerSelector_.clear();
     return;
   }
@@ -143,7 +143,7 @@ void ScoutingMuonTriggerAnalyzer::dqmBeginRun(edm::Run const& iRun, edm::EventSe
       isSpecial_ = true;
       edm::LogPrint("ScoutingMuonTriggerAnalyzer")
           << "Detected " << menu << " in HLT Config tableName(): " << hltConfig_.tableName()
-          << "; the list of trigger expressions is going to be overriden!" << std::endl;
+          << "; the list of trigger expressions is going to be overridden!" << std::endl;
       break;
     }
   }

--- a/HLTriggerOffline/Scouting/python/ScoutingMuonTriggerAnalyzer_cfi.py
+++ b/HLTriggerOffline/Scouting/python/ScoutingMuonTriggerAnalyzer_cfi.py
@@ -31,7 +31,7 @@ ScoutingMuonTriggerAnalysis_DoubleMu = DQMEDAnalyzer('ScoutingMuonTriggerAnalyze
     OutputInternalPath = cms.string('/HLT/ScoutingOffline/Muons/L1Efficiency/DoubleMu'), #Output of the root file
     ScoutingMuonCollection = cms.InputTag('hltScoutingMuonPackerVtx'),
     triggerSelection = cms.vstring(["DST_PFScouting_ZeroBias_v*", "DST_PFScouting_DoubleEG_v*", "DST_PFScouting_JetHT_v*"]), #Denominator
-    special_HLT_Menus = cms.vstring(["LumiScan"]), # list of menus to use to reset the trigge selections
+    special_HLT_Menus = cms.vstring(["LumiScan"]), # list of menus to use to reset the trigger selections
     triggerConfiguration = cms.PSet(
         hltResults            = cms.InputTag('TriggerResults','','HLT'),
         l1tResults            = cms.InputTag('','',''),
@@ -39,6 +39,7 @@ ScoutingMuonTriggerAnalysis_DoubleMu = DQMEDAnalyzer('ScoutingMuonTriggerAnalyze
         throw                 = cms.bool(True),
         usePathStatus = cms.bool(False),
     ),
+    hltProcessName = cms.string("HLT"),
     AlgInputTag = cms.InputTag("gtStage2Digis"),
     l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
     l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/48968

#### PR description:

Fix for issue https://github.com/cms-sw/cmssw/issues/48964. 
In PR https://github.com/cms-sw/cmssw/pull/48652 we introduced a mechanism to reset the list of trigger paths used for `ScoutingMuonTriggerAnalyzer` in presence of `Special` menus (see a rationale in that PR description).
Unfortunately, that doesn't work correctly when the relval uses a `Fake` HLT menu (as it happens for past data, e.g. in wf. 145.415 which runs the 2024 default menu which in CMSSW_16_0_X points to the `Fake` menu

https://github.com/cms-sw/cmssw/blob/51437cded9d8764898fc426c9bc65d64d5bd769b/Configuration/HLT/python/autoHLT.py#L15

)
To make this run, I have to expose the `hltProcessName` parameter in configuration such that it gets overridden using the `--hltProcess reHLT` flag from the relval.

#### PR validation:


Run succesfully:

```
runTheMatrix.py -l 145.415
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/48968 to CMSSW_15_1_X.