### PR TITLE
Add test for reading files with different ProductRegistries

### DIFF
--- a/IOPool/Tests/test/BuildFile.xml
+++ b/IOPool/Tests/test/BuildFile.xml
@@ -118,3 +118,5 @@
 <test name="TestParentageWithStreamerIO" command="run_ParentageWithStreamerIO.sh"/>
 
 <test name="TestIOPoolUnscheduledFailOnOutput" command="run_unscheduledFailOnOutput.sh"/>
+
+<test name="TestIOPoolDifferentProductRegistries" command="runDifferentProductRegistries.sh"/>

--- a/IOPool/Tests/test/runDifferentProductRegistries.sh
+++ b/IOPool/Tests/test/runDifferentProductRegistries.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+
+# Set the directory holding the configuration files
+LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
+
+# Run first write job (events starting at 1)
+cmsRun ${LOCAL_TEST_DIR}/testDifferentProductRegistriesWrite_cfg.py --startEvent 1 --outputFile write1.root || die "cmsRun write1" $?
+
+# Run second write job (events starting at 4)
+cmsRun ${LOCAL_TEST_DIR}/testDifferentProductRegistriesWrite_cfg.py --startEvent 4 --outputFile write2.root || die "cmsRun write2" $?
+
+# Run read job with both output files as input
+cmsRun ${LOCAL_TEST_DIR}/testDifferentProductRegistriesRead_cfg.py --inputFiles file:write1.root file:write2.root || die "cmsRun read 1 then 2" $?
+
+cmsRun ${LOCAL_TEST_DIR}/testDifferentProductRegistriesRead_cfg.py --inputFiles file:write2.root file:write1.root || die "cmsRun read 2 then 1" $?

--- a/IOPool/Tests/test/testDifferentProductRegistriesRead_cfg.py
+++ b/IOPool/Tests/test/testDifferentProductRegistriesRead_cfg.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+import argparse
+
+parser = argparse.ArgumentParser(description="cmsRun config for reading two files with different product registries")
+parser.add_argument("--inputFiles", nargs=2, required=True, help="Input files for PoolSource (two required)")
+args, unknown = parser.parse_known_args()
+
+process = cms.Process("READ")
+
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(
+    fileNames = cms.untracked.vstring(*args.inputFiles)
+)
+
+from FWCore.Modules.modules import AsciiOutputModule
+process.asciiOut = AsciiOutputModule()
+process.outpath = cms.EndPath(process.asciiOut)

--- a/IOPool/Tests/test/testDifferentProductRegistriesWrite_cfg.py
+++ b/IOPool/Tests/test/testDifferentProductRegistriesWrite_cfg.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+import argparse
+
+
+parser = argparse.ArgumentParser(description="cmsRun config for testing writing product registries with different content")
+parser.add_argument("--startEvent", type=int, default=1, help="First event number for EmptySource")
+parser.add_argument("--outputFile", type=str, default=None, help="Output file name for PoolOutputModule")
+args, unknown = parser.parse_known_args()
+
+process = cms.Process("TEST")
+
+process.maxEvents.input = 3
+from FWCore.Modules.modules import EmptySource
+process.source = EmptySource(
+    firstRun = 1,
+    firstLuminosityBlock = 1,
+    firstEvent = args.startEvent
+)
+
+
+from FWCore.Modules.modules import EventIDFilter
+process.eventIDFilter = EventIDFilter(
+    eventsToPass = [
+        cms.EventID(1,1,1),
+        cms.EventID(1,1,2),
+        cms.EventID(1,1,3)
+    ]
+)
+
+
+from FWCore.Integration.modules import ThingProducer, OtherThingProducer
+process.thing = ThingProducer()
+process.otherThing = OtherThingProducer(thingTag="thing")
+
+# Path: EventIDFilter -> ThingProducer -> OtherThingProducer
+process.p = cms.Path(
+    process.eventIDFilter +
+    process.thing +
+    process.otherThing
+)
+
+from IOPool.Output.modules import PoolOutputModule
+output_file = args.outputFile if args.outputFile is not None else f'testDifferentProductRegistriesWrite{args.startEvent}.root'
+process.out = PoolOutputModule(
+    outputCommands = [
+        "keep *",
+        'drop *_thing_*_*'
+    ],
+    fileName = output_file
+)
+
+process.e = cms.EndPath(process.out)


### PR DESCRIPTION
#### PR description:

This checks a fix made in an early pull request.

#### PR validation:

I put a temporary printout in EventProcessor::readFile to show the condition was met.

resolves https://github.com/cms-sw/framework-team/issues/1572