### PR TITLE
Gather more timing information about Framework startup

### DIFF
--- a/FWCore/AbstractServices/interface/TimingServiceBase.h
+++ b/FWCore/AbstractServices/interface/TimingServiceBase.h
@@ -41,8 +41,14 @@ namespace edm {
     virtual double getTotalCPU() const = 0;
 
     static void jobStarted();
+    static void pythonStarting();
+    static void pythonFinished();
+    static void servicesStarting();
 
     static std::chrono::steady_clock::time_point jobStartTime();
+    static std::chrono::steady_clock::time_point pythonStartTime();
+    static std::chrono::steady_clock::time_point pythonEndTime();
+    static std::chrono::steady_clock::time_point servicesStartTime();
   };
 }  // namespace edm
 

--- a/FWCore/AbstractServices/src/TimingServiceBase.cc
+++ b/FWCore/AbstractServices/src/TimingServiceBase.cc
@@ -24,6 +24,26 @@ std::chrono::steady_clock::time_point TimingServiceBase::jobStartTime() {
   return s_jobStartTime;
 }
 
+void TimingServiceBase::pythonStarting() { (void)pythonStartTime(); }
+void TimingServiceBase::pythonFinished() { (void)pythonEndTime(); }
+
+void TimingServiceBase::servicesStarting() { (void)servicesStartTime(); }
+
+std::chrono::steady_clock::time_point TimingServiceBase::pythonStartTime() {
+  static const std::chrono::steady_clock::time_point s_pythonStartTime = std::chrono::steady_clock::now();
+  return s_pythonStartTime;
+}
+
+std::chrono::steady_clock::time_point TimingServiceBase::pythonEndTime() {
+  static const std::chrono::steady_clock::time_point s_pythonEndTime = std::chrono::steady_clock::now();
+  return s_pythonEndTime;
+}
+
+std::chrono::steady_clock::time_point TimingServiceBase::servicesStartTime() {
+  static const std::chrono::steady_clock::time_point s_servicesStartTime = std::chrono::steady_clock::now();
+  return s_servicesStartTime;
+}
+
 //
 // constructors and destructor
 //

--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -189,11 +189,13 @@ int main(int argc, const char* argv[]) {
       }
       std::shared_ptr<edm::ProcessDesc> processDesc;
       try {
+        edm::TimingServiceBase::pythonStarting();
         std::unique_ptr<edm::ParameterSet> parameterSet;
         if (!fileName.empty())
           parameterSet = edm::readConfig(fileName, pythonOptValues);
         else
           edm::makeParameterSets(cmdString, parameterSet);
+        edm::TimingServiceBase::pythonFinished();
         processDesc = std::make_shared<edm::ProcessDesc>(std::move(parameterSet));
       } catch (edm::Exception const&) {
         throw;

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -82,6 +82,7 @@
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/Utilities/interface/Transition.h"
+#include "FWCore/Utilities/interface/Signal.h"
 
 #include <array>
 #include <map>
@@ -323,6 +324,8 @@ namespace edm {
 
     std::vector<std::string> const* pathNames_;
     std::vector<std::string> const* endPathNames_;
+    edm::signalslot::Signal<void()> preModulesInitializationFinalizedSignal_;
+    edm::signalslot::Signal<void()> postModulesInitializationFinalizedSignal_;
     bool wantSummary_;
   };
 

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -237,6 +237,8 @@ namespace edm {
         pathNames_(&tns.getTrigPaths()),
         endPathNames_(&tns.getEndPaths()),
         wantSummary_(tns.wantSummary()) {
+    preModulesInitializationFinalizedSignal_.connect(std::cref(areg->preModulesInitializationFinalizedSignal_));
+    postModulesInitializationFinalizedSignal_.connect(std::cref(areg->postModulesInitializationFinalizedSignal_));
     ScheduleBuilder builder(
         *moduleRegistry_, proc_pset, *pathNames_, *endPathNames_, prealloc, preg, *areg, processConfiguration);
     resultsInserter_ = std::move(builder.resultsInserter_);
@@ -900,6 +902,9 @@ namespace edm {
                           eventsetup::ESRecordsToProductResolverIndices const& iESIndices,
                           ProcessBlockHelperBase const& processBlockHelperBase,
                           std::string const& iProcessName) {
+    preModulesInitializationFinalizedSignal_();
+    auto post = [this](void*) { postModulesInitializationFinalizedSignal_(); };
+    std::unique_ptr<void, decltype(post)> const postGuard(this, post);
     finishModulesInitialization(*moduleRegistry_, iRegistry, iESIndices, processBlockHelperBase, iProcessName);
     globalSchedule_->beginJob(*moduleRegistry_);
   }

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -146,11 +146,97 @@ namespace edm {
     ActivityRegistry& operator=(ActivityRegistry const&) = delete;  // Disallow copying and moving
 
     // ---------- signals ------------------------------------
+    using PostServicesConstruction = signalslot::Signal<void()>;
+    /// signal is emitted after all services have been constructed
+    PostServicesConstruction postServicesConstructionSignal_;
+    void watchPostServicesConstruction(PostServicesConstruction::slot_type const& iSlot) {
+      postServicesConstructionSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_0(watchPostServicesConstruction)
+
+    using PreEventSetupModulesConstruction = signalslot::Signal<void()>;
+    /// signal is emitted before any EventSetup modules have been constructed
+    PreEventSetupModulesConstruction preEventSetupModulesConstructionSignal_;
+    void watchPreEventSetupModulesConstruction(PreEventSetupModulesConstruction::slot_type const& iSlot) {
+      preEventSetupModulesConstructionSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_0(watchPreEventSetupModulesConstruction)
+
+    using PostEventSetupModulesConstruction = signalslot::Signal<void()>;
+    /// signal is emitted after all EventSetup modules have been constructed
+    PostEventSetupModulesConstruction postEventSetupModulesConstructionSignal_;
+    void watchPostEventSetupModulesConstruction(PostEventSetupModulesConstruction::slot_type const& iSlot) {
+      postEventSetupModulesConstructionSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_0(watchPostEventSetupModulesConstruction)
+
+    using PreFinishSchedule = signalslot::Signal<void()>;
+    /// signal is emitted before the call to EventSetup::finishSchedule
+    PreFinishSchedule preFinishScheduleSignal_;
+    void watchPreFinishSchedule(PreFinishSchedule::slot_type const& iSlot) { preFinishScheduleSignal_.connect(iSlot); }
+    AR_WATCH_USING_METHOD_0(watchPreFinishSchedule)
+
+    using PostFinishSchedule = signalslot::Signal<void()>;
+    /// signal is emitted after the call to EventSetup::finishSchedule
+    PostFinishSchedule postFinishScheduleSignal_;
+    void watchPostFinishSchedule(PostFinishSchedule::slot_type const& iSlot) {
+      postFinishScheduleSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_0(watchPostFinishSchedule)
+
+    using PrePrincipalsCreation = signalslot::Signal<void()>;
+    /// signal is emitted before the creation of the Run, LuminosityBlock, and Event Principals
+    PrePrincipalsCreation prePrincipalsCreationSignal_;
+    void watchPrePrincipalsCreation(PrePrincipalsCreation::slot_type const& iSlot) {
+      prePrincipalsCreationSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_0(watchPrePrincipalsCreation)
+
+    using PostPrincipalsCreation = signalslot::Signal<void()>;
+    /// signal is emitted after the creation of the Run, LuminosityBlock, and Event Principals
+    PostPrincipalsCreation postPrincipalsCreationSignal_;
+    void watchPostPrincipalsCreation(PostPrincipalsCreation::slot_type const& iSlot) {
+      postPrincipalsCreationSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_0(watchPostPrincipalsCreation)
+
+    using PreScheduleConsistencyCheck = signalslot::Signal<void()>;
+    /// signal is emitted before the call to Schedule::consistencyCheck
+    PreScheduleConsistencyCheck preScheduleConsistencyCheckSignal_;
+    void watchPreScheduleConsistencyCheck(PreScheduleConsistencyCheck::slot_type const& iSlot) {
+      preScheduleConsistencyCheckSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_0(watchPreScheduleConsistencyCheck)
+
+    using PostScheduleConsistencyCheck = signalslot::Signal<void()>;
+    /// signal is emitted after the call to Schedule::consistencyCheck
+    PostScheduleConsistencyCheck postScheduleConsistencyCheckSignal_;
+    void watchPostScheduleConsistencyCheck(PostScheduleConsistencyCheck::slot_type const& iSlot) {
+      postScheduleConsistencyCheckSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_0(watchPostScheduleConsistencyCheck)
+
     typedef signalslot::Signal<void(service::SystemBounds const&)> Preallocate;
     ///signal is emitted before beginJob
     Preallocate preallocateSignal_;
     void watchPreallocate(Preallocate::slot_type const& iSlot) { preallocateSignal_.connect(iSlot); }
     AR_WATCH_USING_METHOD_1(watchPreallocate)
+
+    using PreEventSetupConfigurationFinalized = signalslot::Signal<void()>;
+    /// signal is emitted just before the EventSetup configuration has been finalized
+    PreEventSetupConfigurationFinalized preEventSetupConfigurationFinalizedSignal_;
+    void watchPreEventSetupConfigurationFinalized(PreEventSetupConfigurationFinalized::slot_type const& iSlot) {
+      preEventSetupConfigurationFinalizedSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_0(watchPreEventSetupConfigurationFinalized)
+
+    using PostEventSetupConfigurationFinalized = signalslot::Signal<void()>;
+    /// signal is emitted just after the EventSetup configuration has been finalized
+    PostEventSetupConfigurationFinalized postEventSetupConfigurationFinalizedSignal_;
+    void watchPostEventSetupConfigurationFinalized(PostEventSetupConfigurationFinalized::slot_type const& iSlot) {
+      postEventSetupConfigurationFinalizedSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_0(watchPostEventSetupConfigurationFinalized)
 
     typedef signalslot::Signal<void(eventsetup::ESRecordsToProductResolverIndices const&, ProcessContext const&)>
         EventSetupConfiguration;
@@ -160,6 +246,22 @@ namespace edm {
       eventSetupConfigurationSignal_.connect(iSlot);
     }
     AR_WATCH_USING_METHOD_2(watchEventSetupConfiguration)
+
+    using PreModulesInitializationFinalized = signalslot::Signal<void()>;
+    /// signal is emitted just before all module initialization has been finalized
+    PreModulesInitializationFinalized preModulesInitializationFinalizedSignal_;
+    void watchPreModulesInitializationFinalized(PreModulesInitializationFinalized::slot_type const& iSlot) {
+      preModulesInitializationFinalizedSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_0(watchPreModulesInitializationFinalized)
+
+    using PostModulesInitializationFinalized = signalslot::Signal<void()>;
+    /// signal is emitted just after all module initialization has been finalized
+    PostModulesInitializationFinalized postModulesInitializationFinalizedSignal_;
+    void watchPostModulesInitializationFinalized(PostModulesInitializationFinalized::slot_type const& iSlot) {
+      postModulesInitializationFinalizedSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_0(watchPostModulesInitializationFinalized)
 
     typedef signalslot::Signal<void(ProcessContext const&)> PreBeginJob;
     ///signal is emitted before all modules have gotten their beginJob called

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -54,8 +54,21 @@ namespace edm {
   }  // namespace signalslot
 
   void ActivityRegistry::connect(ActivityRegistry& iOther) {
+    postServicesConstructionSignal_.connect(std::cref(iOther.postServicesConstructionSignal_));
+    preEventSetupModulesConstructionSignal_.connect(std::cref(iOther.preEventSetupModulesConstructionSignal_));
+    postEventSetupModulesConstructionSignal_.connect(std::cref(iOther.postEventSetupModulesConstructionSignal_));
+    preFinishScheduleSignal_.connect(std::cref(iOther.preFinishScheduleSignal_));
+    postFinishScheduleSignal_.connect(std::cref(iOther.postFinishScheduleSignal_));
+    prePrincipalsCreationSignal_.connect(std::cref(iOther.prePrincipalsCreationSignal_));
+    postPrincipalsCreationSignal_.connect(std::cref(iOther.postPrincipalsCreationSignal_));
+    preScheduleConsistencyCheckSignal_.connect(std::cref(iOther.preScheduleConsistencyCheckSignal_));
+    postScheduleConsistencyCheckSignal_.connect(std::cref(iOther.postScheduleConsistencyCheckSignal_));
     preallocateSignal_.connect(std::cref(iOther.preallocateSignal_));
+    preEventSetupConfigurationFinalizedSignal_.connect(std::cref(iOther.preEventSetupConfigurationFinalizedSignal_));
+    postEventSetupConfigurationFinalizedSignal_.connect(std::cref(iOther.postEventSetupConfigurationFinalizedSignal_));
     eventSetupConfigurationSignal_.connect(std::cref(iOther.eventSetupConfigurationSignal_));
+    preModulesInitializationFinalizedSignal_.connect(std::cref(iOther.preModulesInitializationFinalizedSignal_));
+    postModulesInitializationFinalizedSignal_.connect(std::cref(iOther.postModulesInitializationFinalizedSignal_));
     beginProcessingSignal_.connect(std::cref(iOther.beginProcessingSignal_));
     endProcessingSignal_.connect(std::cref(iOther.endProcessingSignal_));
     postBeginJobSignal_.connect(std::cref(iOther.postBeginJobSignal_));
@@ -259,8 +272,22 @@ namespace edm {
   }
 
   void ActivityRegistry::copySlotsFrom(ActivityRegistry& iOther) {
+    copySlotsToFrom(postServicesConstructionSignal_, iOther.postServicesConstructionSignal_);
+    copySlotsToFrom(preEventSetupModulesConstructionSignal_, iOther.preEventSetupModulesConstructionSignal_);
+    copySlotsToFromReverse(postEventSetupModulesConstructionSignal_, iOther.postEventSetupModulesConstructionSignal_);
+    copySlotsToFrom(preFinishScheduleSignal_, iOther.preFinishScheduleSignal_);
+    copySlotsToFromReverse(postFinishScheduleSignal_, iOther.postFinishScheduleSignal_);
+    copySlotsToFrom(prePrincipalsCreationSignal_, iOther.prePrincipalsCreationSignal_);
+    copySlotsToFromReverse(postPrincipalsCreationSignal_, iOther.postPrincipalsCreationSignal_);
+    copySlotsToFrom(preScheduleConsistencyCheckSignal_, iOther.preScheduleConsistencyCheckSignal_);
+    copySlotsToFromReverse(postScheduleConsistencyCheckSignal_, iOther.postScheduleConsistencyCheckSignal_);
     copySlotsToFrom(preallocateSignal_, iOther.preallocateSignal_);
+    copySlotsToFrom(preEventSetupConfigurationFinalizedSignal_, iOther.preEventSetupConfigurationFinalizedSignal_);
+    copySlotsToFromReverse(postEventSetupConfigurationFinalizedSignal_,
+                           iOther.postEventSetupConfigurationFinalizedSignal_);
     copySlotsToFrom(eventSetupConfigurationSignal_, iOther.eventSetupConfigurationSignal_);
+    copySlotsToFrom(preModulesInitializationFinalizedSignal_, iOther.preModulesInitializationFinalizedSignal_);
+    copySlotsToFromReverse(postModulesInitializationFinalizedSignal_, iOther.postModulesInitializationFinalizedSignal_);
     copySlotsToFrom(beginProcessingSignal_, iOther.beginProcessingSignal_);
     copySlotsToFrom(endProcessingSignal_, iOther.endProcessingSignal_);
     copySlotsToFrom(preBeginJobSignal_, iOther.preBeginJobSignal_);


### PR DESCRIPTION
#### PR description:

- Capture additional timing information before Services have started
- Added additional signals around major framework startup activities

#### PR validation:

Code compiles and framework unit tests pass.

resolves https://github.com/cms-sw/cmssw/issues/48974