### PR TITLE
`PrimaryVertexResolution`: add protection against missing track references in input vertex

### DIFF
--- a/DQM/TrackingMonitor/src/PrimaryVertexResolution.cc
+++ b/DQM/TrackingMonitor/src/PrimaryVertexResolution.cc
@@ -47,7 +47,7 @@ namespace {
 class PrimaryVertexResolution : public DQMEDAnalyzer {
 public:
   PrimaryVertexResolution(const edm::ParameterSet& iConfig);
-  ~PrimaryVertexResolution() override;
+  ~PrimaryVertexResolution() override = default;
 
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
@@ -60,12 +60,15 @@ private:
                                                    const reco::BeamSpot& beamspot);
 
   const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> ttbToken_;
-  edm::EDGetTokenT<reco::VertexCollection> vertexSrc_;
-  edm::EDGetTokenT<reco::BeamSpot> beamspotSrc_;
-  edm::EDGetTokenT<LumiScalersCollection> lumiScalersSrc_;
-  edm::EDGetTokenT<OnlineLuminosityRecord> metaDataSrc_;
+
+  const edm::InputTag vertexInputTag_;
+  const edm::EDGetTokenT<reco::VertexCollection> vertexSrc_;
+  const edm::EDGetTokenT<reco::BeamSpot> beamspotSrc_;
+  const edm::EDGetTokenT<LumiScalersCollection> lumiScalersSrc_;
+  const edm::EDGetTokenT<OnlineLuminosityRecord> metaDataSrc_;
   const bool forceSCAL_;
-  std::string rootFolder_;
+  const std::string rootFolder_;
+  bool errorPrinted_;
 
   AdaptiveVertexFitter fitter_;
 
@@ -327,18 +330,18 @@ private:
 
 PrimaryVertexResolution::PrimaryVertexResolution(const edm::ParameterSet& iConfig)
     : ttbToken_(esConsumes(edm::ESInputTag("", iConfig.getUntrackedParameter<std::string>("transientTrackBuilder")))),
-      vertexSrc_(consumes<reco::VertexCollection>(iConfig.getUntrackedParameter<edm::InputTag>("vertexSrc"))),
+      vertexInputTag_(iConfig.getUntrackedParameter<edm::InputTag>("vertexSrc")),
+      vertexSrc_(consumes<reco::VertexCollection>(vertexInputTag_)),
       beamspotSrc_(consumes<reco::BeamSpot>(iConfig.getUntrackedParameter<edm::InputTag>("beamspotSrc"))),
       lumiScalersSrc_(consumes<LumiScalersCollection>(iConfig.getUntrackedParameter<edm::InputTag>("lumiScalersSrc"))),
       metaDataSrc_(consumes<OnlineLuminosityRecord>(iConfig.getUntrackedParameter<edm::InputTag>("metaDataSrc"))),
       forceSCAL_(iConfig.getUntrackedParameter<bool>("forceSCAL")),
       rootFolder_(iConfig.getUntrackedParameter<std::string>("rootFolder")),
+      errorPrinted_(false),
       binningX_(iConfig),
       binningY_(iConfig),
       hPV_(binningX_, binningY_),
       hOtherV_(binningX_, binningY_) {}
-
-PrimaryVertexResolution::~PrimaryVertexResolution() {}
 
 void PrimaryVertexResolution::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -398,6 +401,28 @@ void PrimaryVertexResolution::analyze(const edm::Event& iEvent, const edm::Event
   const reco::VertexCollection& vertices = *hvertices;
   if (vertices.empty())
     return;
+
+  // check upfront that refs to track are (likely) to be valid
+  {
+    bool ok = true;
+    for (const auto& v : vertices) {
+      if (v.tracksSize() > 0) {
+        const auto& ref = v.trackRefAt(0);
+        if (ref.isNull() || !ref.isAvailable()) {
+          if (!errorPrinted_)
+            edm::LogWarning("PrimaryVertexResolution")
+                << "Skipping vertex collection: " << vertexInputTag_
+                << " since likely the track collection the vertex has refs pointing to is missing (at least the first "
+                   "TrackBaseRef is null or not available)";
+          else
+            errorPrinted_ = true;
+          ok = false;
+        }
+      }
+    }
+    if (!ok)
+      return;
+  }
 
   edm::Handle<reco::BeamSpot> hbeamspot = iEvent.getHandle(beamspotSrc_);
   const reco::BeamSpot& beamspot = *hbeamspot;


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/49018

#### PR description:

Title says it all, workaround for https://github.com/cms-sw/cmssw/pull/48980#issuecomment-3342742674.
The proper fix would consist in making sure the constituent tracks of an HLT vertex are saved as output of the `HIon` HLT menu. This will be follow-up with a ticket CMSHLT (analogous to [CMSHLT-3618](https://its.cern.ch/jira/browse/CMSHLT-3618) that was done to supply the same for the pp menu `GRun`) 
Whenever the input vertex misses the references to constituent tracks, skip the processing and emit a warning (once per job). 
The logic is the same as in 

https://github.com/cms-sw/cmssw/blob/4ddd889fcd7688d0d51f25afd1ea6475b9a824ec/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc#L415-L435

#### PR validation:

`runTheMatrix.py -l 161.4 -t 4 -j 8 -i all --ibeos` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A