### PR TITLE
Modification of existing rawprime version of SiStripApproxCluster

### DIFF
--- a/DataFormats/SiStripCluster/interface/SiStripApproximateClusterCollection_v1.h
+++ b/DataFormats/SiStripCluster/interface/SiStripApproximateClusterCollection_v1.h
@@ -1,0 +1,111 @@
+#ifndef DataFormats_SiStripCluster_SiStripApproximateClusterCollection_v1_h
+#define DataFormats_SiStripCluster_SiStripApproximateClusterCollection_v1_h
+
+#include <vector>
+
+#include "DataFormats/SiStripCluster/interface/SiStripApproximateCluster_v1.h"
+#include <iostream>
+#include <numeric>
+/**
+ * This class provides a minimal interface that resembles
+ * edmNew::DetSetVector, but is crafted such that we are comfortable
+ * to provide an infinite backwards compatibility guarantee for it
+ * (like all RAW data). Any modifications need to be made with care.
+ * Please consult core software group if in doubt.
+**/
+namespace v1 {
+class SiStripApproximateClusterCollection {
+public:
+  // Helper classes to make creation and iteration easier
+  class Filler {
+  public:
+    void push_back(SiStripApproximateCluster_v1 const& cluster) { clusters_.push_back(cluster); }
+
+  private:
+    friend SiStripApproximateClusterCollection;
+    Filler(std::vector<SiStripApproximateCluster_v1>& clusters) : clusters_(clusters) {}
+
+    std::vector<SiStripApproximateCluster_v1>& clusters_;
+  };
+
+  class const_iterator;
+  class DetSet {
+  public:
+    using const_iterator = std::vector<SiStripApproximateCluster_v1>::const_iterator;
+
+    unsigned int id() const { return std::accumulate(coll_->detIds_.cbegin(), coll_->detIds_.cbegin()+detIndex_+1, 0); }
+
+    void move(unsigned int clusBegin) const { clusBegin_ = clusBegin; }
+    const_iterator begin() const { return coll_->clusters_.begin() + clusBegin_; }
+    const_iterator cbegin() const { return begin(); }
+    const_iterator end() const { return coll_->clusters_.begin() + clusEnd_; }
+    const_iterator cend() const { return end(); }
+
+  private:
+    friend SiStripApproximateClusterCollection::const_iterator;
+    DetSet(SiStripApproximateClusterCollection const* coll, unsigned int detIndex)
+        : coll_(coll),
+          detIndex_(detIndex),
+          clusEnd_(coll->clusters_.size())
+          //clusBegin_(coll_->beginIndices_[detIndex]),
+          //clusEnd_(detIndex == coll_->beginIndices_.size() - 1 ? coll->clusters_.size()
+                                                               //: coll_->beginIndices_[detIndex + 1]) {}
+          {}
+
+    SiStripApproximateClusterCollection const* const coll_;
+    unsigned int const detIndex_;
+    mutable unsigned int clusBegin_ = 0;
+    unsigned int const clusEnd_;
+  };
+
+  class const_iterator {
+  public:
+    DetSet operator*() const { return DetSet(coll_, index_); }
+
+    const_iterator& operator++() {
+      ++index_;
+      if (index_ == coll_->detIds_.size()) {
+        *this = const_iterator();
+      }
+      return *this;
+    }
+
+    const_iterator operator++(int) {
+      const_iterator clone = *this;
+      ++(*this);
+      return clone;
+    }
+
+    bool operator==(const_iterator const& other) const { return coll_ == other.coll_ and index_ == other.index_; }
+    bool operator!=(const_iterator const& other) const { return not operator==(other); }
+
+  private:
+    friend SiStripApproximateClusterCollection;
+    // default-constructed object acts as the sentinel
+    const_iterator() = default;
+    const_iterator(SiStripApproximateClusterCollection const* coll) : coll_(coll) {}
+
+    SiStripApproximateClusterCollection const* coll_ = nullptr;
+    unsigned int index_ = 0;
+  };
+
+  // Actual public interface
+  SiStripApproximateClusterCollection() = default;
+
+  void reserve(std::size_t dets, std::size_t clusters);
+  Filler beginDet(unsigned int detId);
+
+  const_iterator begin() const { return clusters_.empty() ? end() : const_iterator(this); }
+  const_iterator cbegin() const { return begin(); }
+  const_iterator end() const { return const_iterator(); }
+  const_iterator cend() const { return end(); }
+
+private:
+  // The detIds_ and beginIndices_ have one element for each Det. An
+  // element of beginIndices_ points to the first cluster of the Det
+  // in clusters_.
+  std::vector<unsigned int> detIds_;  // DetId for the Det
+  std::vector<SiStripApproximateCluster_v1> clusters_;
+};
+}
+#endif

--- a/DataFormats/SiStripCluster/interface/SiStripApproximateClusterCollection_v1.h
+++ b/DataFormats/SiStripCluster/interface/SiStripApproximateClusterCollection_v1.h
@@ -47,9 +47,6 @@ public:
         : coll_(coll),
           detIndex_(detIndex),
           clusEnd_(coll->clusters_.size())
-          //clusBegin_(coll_->beginIndices_[detIndex]),
-          //clusEnd_(detIndex == coll_->beginIndices_.size() - 1 ? coll->clusters_.size()
-                                                               //: coll_->beginIndices_[detIndex + 1]) {}
           {}
 
     SiStripApproximateClusterCollection const* const coll_;

--- a/DataFormats/SiStripCluster/interface/SiStripApproximateClusterCollection_v1.h
+++ b/DataFormats/SiStripCluster/interface/SiStripApproximateClusterCollection_v1.h
@@ -14,95 +14,94 @@
  * Please consult core software group if in doubt.
 **/
 namespace v1 {
-class SiStripApproximateClusterCollection {
-public:
-  // Helper classes to make creation and iteration easier
-  class Filler {
+  class SiStripApproximateClusterCollection {
   public:
-    void push_back(SiStripApproximateCluster_v1 const& cluster) { clusters_.push_back(cluster); }
+    // Helper classes to make creation and iteration easier
+    class Filler {
+    public:
+      void push_back(SiStripApproximateCluster_v1 const& cluster) { clusters_.push_back(cluster); }
 
-  private:
-    friend SiStripApproximateClusterCollection;
-    Filler(std::vector<SiStripApproximateCluster_v1>& clusters) : clusters_(clusters) {}
+    private:
+      friend SiStripApproximateClusterCollection;
+      Filler(std::vector<SiStripApproximateCluster_v1>& clusters) : clusters_(clusters) {}
 
-    std::vector<SiStripApproximateCluster_v1>& clusters_;
-  };
+      std::vector<SiStripApproximateCluster_v1>& clusters_;
+    };
 
-  class const_iterator;
-  class DetSet {
-  public:
-    using const_iterator = std::vector<SiStripApproximateCluster_v1>::const_iterator;
+    class const_iterator;
+    class DetSet {
+    public:
+      using const_iterator = std::vector<SiStripApproximateCluster_v1>::const_iterator;
 
-    unsigned int id() const { return std::accumulate(coll_->detIds_.cbegin(), coll_->detIds_.cbegin()+detIndex_+1, 0); }
+      unsigned int id() const {
+        return std::accumulate(coll_->detIds_.cbegin(), coll_->detIds_.cbegin() + detIndex_ + 1, 0);
+      }
 
-    void move(unsigned int clusBegin) const { clusBegin_ = clusBegin; }
-    const_iterator begin() const { return coll_->clusters_.begin() + clusBegin_; }
+      void move(unsigned int clusBegin) const { clusBegin_ = clusBegin; }
+      const_iterator begin() const { return coll_->clusters_.begin() + clusBegin_; }
+      const_iterator cbegin() const { return begin(); }
+      const_iterator end() const { return coll_->clusters_.begin() + clusEnd_; }
+      const_iterator cend() const { return end(); }
+
+    private:
+      friend SiStripApproximateClusterCollection::const_iterator;
+      DetSet(SiStripApproximateClusterCollection const* coll, unsigned int detIndex)
+          : coll_(coll), detIndex_(detIndex), clusEnd_(coll->clusters_.size()) {}
+
+      SiStripApproximateClusterCollection const* const coll_;
+      unsigned int const detIndex_;
+      mutable unsigned int clusBegin_ = 0;
+      unsigned int const clusEnd_;
+    };
+
+    class const_iterator {
+    public:
+      DetSet operator*() const { return DetSet(coll_, index_); }
+
+      const_iterator& operator++() {
+        ++index_;
+        if (index_ == coll_->detIds_.size()) {
+          *this = const_iterator();
+        }
+        return *this;
+      }
+
+      const_iterator operator++(int) {
+        const_iterator clone = *this;
+        ++(*this);
+        return clone;
+      }
+
+      bool operator==(const_iterator const& other) const { return coll_ == other.coll_ and index_ == other.index_; }
+      bool operator!=(const_iterator const& other) const { return not operator==(other); }
+
+    private:
+      friend SiStripApproximateClusterCollection;
+      // default-constructed object acts as the sentinel
+      const_iterator() = default;
+      const_iterator(SiStripApproximateClusterCollection const* coll) : coll_(coll) {}
+
+      SiStripApproximateClusterCollection const* coll_ = nullptr;
+      unsigned int index_ = 0;
+    };
+
+    // Actual public interface
+    SiStripApproximateClusterCollection() = default;
+
+    void reserve(std::size_t dets, std::size_t clusters);
+    Filler beginDet(unsigned int detId);
+
+    const_iterator begin() const { return clusters_.empty() ? end() : const_iterator(this); }
     const_iterator cbegin() const { return begin(); }
-    const_iterator end() const { return coll_->clusters_.begin() + clusEnd_; }
+    const_iterator end() const { return const_iterator(); }
     const_iterator cend() const { return end(); }
 
   private:
-    friend SiStripApproximateClusterCollection::const_iterator;
-    DetSet(SiStripApproximateClusterCollection const* coll, unsigned int detIndex)
-        : coll_(coll),
-          detIndex_(detIndex),
-          clusEnd_(coll->clusters_.size())
-          {}
-
-    SiStripApproximateClusterCollection const* const coll_;
-    unsigned int const detIndex_;
-    mutable unsigned int clusBegin_ = 0;
-    unsigned int const clusEnd_;
+    // The detIds_ and beginIndices_ have one element for each Det. An
+    // element of beginIndices_ points to the first cluster of the Det
+    // in clusters_.
+    std::vector<unsigned int> detIds_;  // DetId for the Det
+    std::vector<SiStripApproximateCluster_v1> clusters_;
   };
-
-  class const_iterator {
-  public:
-    DetSet operator*() const { return DetSet(coll_, index_); }
-
-    const_iterator& operator++() {
-      ++index_;
-      if (index_ == coll_->detIds_.size()) {
-        *this = const_iterator();
-      }
-      return *this;
-    }
-
-    const_iterator operator++(int) {
-      const_iterator clone = *this;
-      ++(*this);
-      return clone;
-    }
-
-    bool operator==(const_iterator const& other) const { return coll_ == other.coll_ and index_ == other.index_; }
-    bool operator!=(const_iterator const& other) const { return not operator==(other); }
-
-  private:
-    friend SiStripApproximateClusterCollection;
-    // default-constructed object acts as the sentinel
-    const_iterator() = default;
-    const_iterator(SiStripApproximateClusterCollection const* coll) : coll_(coll) {}
-
-    SiStripApproximateClusterCollection const* coll_ = nullptr;
-    unsigned int index_ = 0;
-  };
-
-  // Actual public interface
-  SiStripApproximateClusterCollection() = default;
-
-  void reserve(std::size_t dets, std::size_t clusters);
-  Filler beginDet(unsigned int detId);
-
-  const_iterator begin() const { return clusters_.empty() ? end() : const_iterator(this); }
-  const_iterator cbegin() const { return begin(); }
-  const_iterator end() const { return const_iterator(); }
-  const_iterator cend() const { return end(); }
-
-private:
-  // The detIds_ and beginIndices_ have one element for each Det. An
-  // element of beginIndices_ points to the first cluster of the Det
-  // in clusters_.
-  std::vector<unsigned int> detIds_;  // DetId for the Det
-  std::vector<SiStripApproximateCluster_v1> clusters_;
-};
-}
+}  // namespace v1
 #endif

--- a/DataFormats/SiStripCluster/interface/SiStripApproximateCluster_v1.h
+++ b/DataFormats/SiStripCluster/interface/SiStripApproximateCluster_v1.h
@@ -11,10 +11,7 @@ public:
 
   explicit SiStripApproximateCluster_v1(cms_uint16_t compBarycenter,
                                      cms_uint8_t width,
-                                     cms_uint8_t compavgCharge,
-				     bool filter,
-                                     bool isSaturated,
-                                     bool peakFilter = false
+                                     cms_uint8_t compavgCharge
                                     )
       : compBarycenter_(compBarycenter),
         width_(width),

--- a/DataFormats/SiStripCluster/interface/SiStripApproximateCluster_v1.h
+++ b/DataFormats/SiStripCluster/interface/SiStripApproximateCluster_v1.h
@@ -9,55 +9,51 @@ class SiStripApproximateCluster_v1 {
 public:
   SiStripApproximateCluster_v1() {}
 
-  explicit SiStripApproximateCluster_v1(cms_uint16_t compBarycenter,
-                                     cms_uint8_t width,
-                                     cms_uint8_t compavgCharge
-                                    )
-      : compBarycenter_(compBarycenter),
-        width_(width),
-        compavgCharge_(compavgCharge)
-        {}
+  explicit SiStripApproximateCluster_v1(cms_uint16_t compBarycenter, cms_uint8_t width, cms_uint8_t compavgCharge)
+      : compBarycenter_(compBarycenter), width_(width), compavgCharge_(compavgCharge) {}
 
   explicit SiStripApproximateCluster_v1(const SiStripCluster& cluster,
-                                     unsigned int maxNSat,
-                                     float hitPredPos,
-                                     float& previous_cluster,
-                                     unsigned int& module_length,
-                                     unsigned int& previous_module_length,
-                                     bool peakFilter);
+                                        unsigned int maxNSat,
+                                        float hitPredPos,
+                                        float& previous_cluster,
+                                        unsigned int& module_length,
+                                        unsigned int& previous_module_length,
+                                        bool peakFilter);
 
-  const cms_uint16_t compBarycenter() const {
-    return compBarycenter_;
-  }
+  const cms_uint16_t compBarycenter() const { return compBarycenter_; }
 
-  float barycenter(float previous_barycenter=0,
-                   unsigned int module_length=0, unsigned int previous_module_length=0) const {
+  float barycenter(float previous_barycenter = 0,
+                   unsigned int module_length = 0,
+                   unsigned int previous_module_length = 0) const {
     float _barycenter;
-    cms_uint16_t compBarycenter = (compBarycenter_&0x7FFF);
-    if (  previous_barycenter == -999 )
-      _barycenter = compBarycenter * maxBarycenter_/maxRange_;
+    cms_uint16_t compBarycenter = (compBarycenter_ & 0x7FFF);
+    if (previous_barycenter == -999)
+      _barycenter = compBarycenter * maxBarycenter_ / maxRange_;
     else {
-      _barycenter = ((compBarycenter * maxBarycenter_/maxRange_) - (module_length-previous_module_length)) + previous_barycenter;
+      _barycenter = ((compBarycenter * maxBarycenter_ / maxRange_) - (module_length - previous_module_length)) +
+                    previous_barycenter;
     }
     assert(_barycenter <= maxBarycenter_ && "Returning barycenter > maxBarycenter");
-    return _barycenter; }
-  cms_uint8_t width() const {return width_; }
+    return _barycenter;
+  }
+  cms_uint8_t width() const { return width_; }
   float avgCharge() const {
-     cms_uint8_t compavgCharge = (compavgCharge_ & 0x3F); 
-     float avgCharge_ = compavgCharge * maxavgCharge_/maxavgChargeRange_ ;
+    cms_uint8_t compavgCharge = (compavgCharge_ & 0x3F);
+    float avgCharge_ = compavgCharge * maxavgCharge_ / maxavgChargeRange_;
     assert(avgCharge_ <= maxavgCharge_ && "Returning avgCharge > maxavgCharge");
-     return avgCharge_; }
-  bool filter() const { return (compavgCharge_& (1<<kfilterMask)); }
-  bool isSaturated() const { return (compavgCharge_& (1<<kSaturatedMask)); }
-  bool peakFilter() const { return (compBarycenter_ & (1<<kpeakFilterMask)); }
+    return avgCharge_;
+  }
+  bool filter() const { return (compavgCharge_ & (1 << kfilterMask)); }
+  bool isSaturated() const { return (compavgCharge_ & (1 << kSaturatedMask)); }
+  bool peakFilter() const { return (compBarycenter_ & (1 << kpeakFilterMask)); }
 
 private:
   cms_uint16_t compBarycenter_ = 0;
   cms_uint8_t width_ = 0;
   cms_uint8_t compavgCharge_ = 0;
-  static constexpr double maxRange_ = 32767; //32767;
+  static constexpr double maxRange_ = 32767;
   static constexpr double maxBarycenter_ = 1536.;
-  static constexpr double maxavgChargeRange_ = 63; //63;
+  static constexpr double maxavgChargeRange_ = 63;
   static constexpr double maxavgCharge_ = 255.;
   static constexpr double trimMaxADC_ = 30.;
   static constexpr double trimMaxFracTotal_ = .15;

--- a/DataFormats/SiStripCluster/interface/SiStripCluster.h
+++ b/DataFormats/SiStripCluster/interface/SiStripCluster.h
@@ -46,7 +46,11 @@ public:
   }
 
   SiStripCluster(const SiStripApproximateCluster cluster, const uint16_t maxStrips);
-  SiStripCluster(const SiStripApproximateCluster_v1 cluster, const uint16_t maxStrips, float pc=-999, unsigned int module_length=0, unsigned int previous_module_length=0);
+  SiStripCluster(const SiStripApproximateCluster_v1 cluster,
+                 const uint16_t maxStrips,
+                 float pc = -999,
+                 unsigned int module_length = 0,
+                 unsigned int previous_module_length = 0);
 
   // extend the cluster
   template <typename Iter>

--- a/DataFormats/SiStripCluster/interface/SiStripCluster.h
+++ b/DataFormats/SiStripCluster/interface/SiStripCluster.h
@@ -3,6 +3,7 @@
 
 #include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
 #include "DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h"
+#include "DataFormats/SiStripCluster/interface/SiStripApproximateCluster_v1.h"
 #include <vector>
 #include <numeric>
 #include <iostream>
@@ -45,6 +46,7 @@ public:
   }
 
   SiStripCluster(const SiStripApproximateCluster cluster, const uint16_t maxStrips);
+  SiStripCluster(const SiStripApproximateCluster_v1 cluster, const uint16_t maxStrips, float pc=-999, unsigned int module_length=0, unsigned int previous_module_length=0);
 
   // extend the cluster
   template <typename Iter>

--- a/DataFormats/SiStripCluster/src/SiStripApproximateClusterCollection_v1.cc
+++ b/DataFormats/SiStripCluster/src/SiStripApproximateClusterCollection_v1.cc
@@ -1,0 +1,11 @@
+#include "DataFormats/SiStripCluster/interface/SiStripApproximateClusterCollection_v1.h"
+using namespace v1;
+void SiStripApproximateClusterCollection::reserve(std::size_t dets, std::size_t clusters) {
+  detIds_.reserve(dets);
+  clusters_.reserve(clusters);
+}
+
+SiStripApproximateClusterCollection::Filler SiStripApproximateClusterCollection::beginDet(unsigned int detId) {
+  detIds_.push_back((detIds_.size() == 0) ? detId : detId - (std::accumulate(detIds_.cbegin(), detIds_.cend(),0)));
+  return Filler(clusters_);
+}

--- a/DataFormats/SiStripCluster/src/SiStripApproximateClusterCollection_v1.cc
+++ b/DataFormats/SiStripCluster/src/SiStripApproximateClusterCollection_v1.cc
@@ -6,6 +6,6 @@ void SiStripApproximateClusterCollection::reserve(std::size_t dets, std::size_t 
 }
 
 SiStripApproximateClusterCollection::Filler SiStripApproximateClusterCollection::beginDet(unsigned int detId) {
-  detIds_.push_back((detIds_.size() == 0) ? detId : detId - (std::accumulate(detIds_.cbegin(), detIds_.cend(),0)));
+  detIds_.push_back((detIds_.empty()) ? detId : detId - (std::accumulate(detIds_.cbegin(), detIds_.cend(), 0)));
   return Filler(clusters_);
 }

--- a/DataFormats/SiStripCluster/src/SiStripApproximateCluster_v1.cc
+++ b/DataFormats/SiStripCluster/src/SiStripApproximateCluster_v1.cc
@@ -1,28 +1,30 @@
 #include "DataFormats/SiStripCluster/interface/SiStripApproximateCluster_v1.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include <algorithm>
+#include <cassert>
 #include <cmath>
-#include <assert.h>
 
 SiStripApproximateCluster_v1::SiStripApproximateCluster_v1(const SiStripCluster& cluster,
-                                                     unsigned int maxNSat,
-                                                     float hitPredPos,
-                                                     float& previous_cluster,
-                                                     unsigned int& module_length,
-                                                     unsigned int& previous_module_length,
-                                                     bool peakFilter) {
+                                                           unsigned int maxNSat,
+                                                           float hitPredPos,
+                                                           float& previous_cluster,
+                                                           unsigned int& module_length,
+                                                           unsigned int& previous_module_length,
+                                                           bool peakFilter) {
   bool filter_, isSaturated_, peakFilter_;
   if (previous_cluster == -999.)
-   compBarycenter_ = std::round(cluster.barycenter() * maxRange_/maxBarycenter_);
+    compBarycenter_ = std::round(cluster.barycenter() * maxRange_ / maxBarycenter_);
   else
-   compBarycenter_ = std::round(((cluster.barycenter()-previous_cluster)+(module_length-previous_module_length))* maxRange_/maxBarycenter_);
+    compBarycenter_ =
+        std::round(((cluster.barycenter() - previous_cluster) + (module_length - previous_module_length)) * maxRange_ /
+                   maxBarycenter_);
   previous_cluster = barycenter(previous_cluster, module_length, previous_module_length);
   assert(cluster.barycenter() <= maxBarycenter_ && "Got a barycenter > maxBarycenter");
   assert(compBarycenter_ <= maxRange_ && "Filling compBarycenter > maxRange");
-  width_ = std::min(255,(int)cluster.size());//cluster.size();
+  width_ = std::min(255, (int)cluster.size());  //cluster.size();
   float avgCharge_ = cluster.charge() * 1. / width_;
   assert(avgCharge_ <= maxavgCharge_ && "Got a avgCharge > maxavgCharge");
-  compavgCharge_ = std::round(avgCharge_ * maxavgChargeRange_/maxavgCharge_);
+  compavgCharge_ = std::round(avgCharge_ * maxavgChargeRange_ / maxavgCharge_);
   assert(compavgCharge_ <= maxavgChargeRange_ && "Filling compavgCharge > maxavgChargeRange");
   filter_ = false;
   isSaturated_ = false;

--- a/DataFormats/SiStripCluster/src/SiStripApproximateCluster_v1.cc
+++ b/DataFormats/SiStripCluster/src/SiStripApproximateCluster_v1.cc
@@ -1,0 +1,74 @@
+#include "DataFormats/SiStripCluster/interface/SiStripApproximateCluster_v1.h"
+#include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
+#include <algorithm>
+#include <cmath>
+#include <assert.h>
+
+SiStripApproximateCluster_v1::SiStripApproximateCluster_v1(const SiStripCluster& cluster,
+                                                     unsigned int maxNSat,
+                                                     float hitPredPos,
+                                                     float& previous_cluster,
+                                                     unsigned int& module_length,
+                                                     unsigned int& previous_module_length,
+                                                     bool peakFilter) {
+  bool filter_, isSaturated_, peakFilter_;
+  if (previous_cluster == -999.)
+   compBarycenter_ = std::round(cluster.barycenter() * maxRange_/maxBarycenter_);
+  else
+   compBarycenter_ = std::round(((cluster.barycenter()-previous_cluster)+(module_length-previous_module_length))* maxRange_/maxBarycenter_);
+  previous_cluster = barycenter(previous_cluster, module_length, previous_module_length);
+  assert(cluster.barycenter() <= maxBarycenter_ && "Got a barycenter > maxBarycenter");
+  assert(compBarycenter_ <= maxRange_ && "Filling compBarycenter > maxRange");
+  width_ = std::min(255,(int)cluster.size());//cluster.size();
+  float avgCharge_ = cluster.charge() * 1. / width_;
+  assert(avgCharge_ <= maxavgCharge_ && "Got a avgCharge > maxavgCharge");
+  compavgCharge_ = std::round(avgCharge_ * maxavgChargeRange_/maxavgCharge_);
+  assert(compavgCharge_ <= maxavgChargeRange_ && "Filling compavgCharge > maxavgChargeRange");
+  filter_ = false;
+  isSaturated_ = false;
+  peakFilter_ = peakFilter;
+
+  //mimicing the algorithm used in StripSubClusterShapeTrajectoryFilter...
+  //Looks for 3 adjacent saturated strips (ADC>=254)
+  const auto& ampls = cluster.amplitudes();
+  unsigned int thisSat = (ampls[0] >= 254), maxSat = thisSat;
+  for (unsigned int i = 1, n = ampls.size(); i < n; ++i) {
+    if (ampls[i] >= 254) {
+      thisSat++;
+    } else if (thisSat > 0) {
+      maxSat = std::max<int>(maxSat, thisSat);
+      thisSat = 0;
+    }
+  }
+  if (thisSat > 0) {
+    maxSat = std::max<int>(maxSat, thisSat);
+  }
+  if (maxSat >= maxNSat) {
+    filter_ = true;
+    isSaturated_ = true;
+  }
+
+  unsigned int hitStripsTrim = ampls.size();
+  int sum = std::accumulate(ampls.begin(), ampls.end(), 0);
+  uint8_t trimCut = std::min<uint8_t>(trimMaxADC_, std::floor(trimMaxFracTotal_ * sum));
+  auto begin = ampls.begin();
+  auto last = ampls.end() - 1;
+  while (hitStripsTrim > 1 && (*begin < std::max<uint8_t>(trimCut, trimMaxFracNeigh_ * (*(begin + 1))))) {
+    hitStripsTrim--;
+    ++begin;
+  }
+  while (hitStripsTrim > 1 && (*last < std::max<uint8_t>(trimCut, trimMaxFracNeigh_ * (*(last - 1))))) {
+    hitStripsTrim--;
+    --last;
+  }
+  if (hitStripsTrim < std::floor(std::abs(hitPredPos) - maxTrimmedSizeDiffNeg_)) {
+    filter_ = false;
+  } else if (hitStripsTrim <= std::ceil(std::abs(hitPredPos) + maxTrimmedSizeDiffPos_)) {
+    filter_ = true;
+  } else {
+    filter_ = peakFilter_;
+  }
+  compavgCharge_ = (compavgCharge_ | (filter_ << kfilterMask));
+  compavgCharge_ = (compavgCharge_ | (peakFilter_ << kpeakFilterMask));
+  compBarycenter_ = (compBarycenter_ | (isSaturated_ << kSaturatedMask));
+}

--- a/DataFormats/SiStripCluster/src/SiStripCluster.cc
+++ b/DataFormats/SiStripCluster/src/SiStripCluster.cc
@@ -40,7 +40,12 @@ SiStripCluster::SiStripCluster(const SiStripApproximateCluster cluster, const ui
   firstStrip_ |= approximateMask;
 }
 
-SiStripCluster::SiStripCluster(const SiStripApproximateCluster_v1 cluster, const uint16_t maxStrips, float p_bc,unsigned int module_length, unsigned int previous_module_length) : error_x(-99999.9) {
+SiStripCluster::SiStripCluster(const SiStripApproximateCluster_v1 cluster,
+                               const uint16_t maxStrips,
+                               float p_bc,
+                               unsigned int module_length,
+                               unsigned int previous_module_length)
+    : error_x(-99999.9) {
   barycenter_ = cluster.barycenter(p_bc, module_length, previous_module_length);
   charge_ = cluster.width() * cluster.avgCharge();
   amplitudes_.resize(cluster.width(), cluster.avgCharge());

--- a/DataFormats/SiStripCluster/src/SiStripCluster.cc
+++ b/DataFormats/SiStripCluster/src/SiStripCluster.cc
@@ -39,3 +39,20 @@ SiStripCluster::SiStripCluster(const SiStripApproximateCluster cluster, const ui
   }
   firstStrip_ |= approximateMask;
 }
+
+SiStripCluster::SiStripCluster(const SiStripApproximateCluster_v1 cluster, const uint16_t maxStrips, float p_bc,unsigned int module_length, unsigned int previous_module_length) : error_x(-99999.9) {
+  barycenter_ = cluster.barycenter(p_bc, module_length, previous_module_length);
+  charge_ = cluster.width() * cluster.avgCharge();
+  amplitudes_.resize(cluster.width(), cluster.avgCharge());
+  filter_ = cluster.filter();
+
+  float halfwidth_ = 0.5f * float(cluster.width());
+
+  //initialize firstStrip_
+  firstStrip_ = std::max(barycenter_ - halfwidth_, 0.f);
+
+  if UNLIKELY (firstStrip_ + cluster.width() > maxStrips) {
+    firstStrip_ = maxStrips - cluster.width();
+  }
+  firstStrip_ |= approximateMask;
+}

--- a/DataFormats/SiStripCluster/src/classes.h
+++ b/DataFormats/SiStripCluster/src/classes.h
@@ -7,7 +7,9 @@
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "DataFormats/SiStripCluster/interface/SiStripClustersSOA.h"
 #include "DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h"
+#include "DataFormats/SiStripCluster/interface/SiStripApproximateCluster_v1.h"
 #include "DataFormats/SiStripCluster/interface/SiStripApproximateClusterCollection.h"
+#include "DataFormats/SiStripCluster/interface/SiStripApproximateClusterCollection_v1.h"
 #include "DataFormats/Common/interface/ContainerMask.h"
 
 #endif  // SISTRIPCLUSTER_CLASSES_H

--- a/DataFormats/SiStripCluster/src/classes_def.xml
+++ b/DataFormats/SiStripCluster/src/classes_def.xml
@@ -59,6 +59,36 @@
  <class name="edmNew::DetSetVector<edm::Ref<edmNew::DetSetVector<SiStripApproximateCluster>,SiStripApproximateCluster,edmNew::DetSetVector<SiStripApproximateCluster>::FindForDetSetVector> >" />
  <class name="edm::Wrapper<edmNew::DetSetVector<edm::Ref<edmNew::DetSetVector<SiStripApproximateCluster>,SiStripApproximateCluster,edmNew::DetSetVector<SiStripApproximateCluster>::FindForDetSetVector> > >" />
 
+
+
+					 <class name="SiStripApproximateCluster_v1" ClassVersion="7">
+						 <version ClassVersion="7" checksum="1154754493"/>
+  <version ClassVersion="6" checksum="132211472"/>
+  <version ClassVersion="5" checksum="3495825183"/>
+  <version ClassVersion="4" checksum="2854791577"/>
+  <version ClassVersion="3" checksum="2041370183"/>
+ </class>
+ <class name="v1::SiStripApproximateClusterCollection" ClassVersion="4">
+	<version ClassVersion="4" checksum="2896589077"/>
+  <version ClassVersion="3" checksum="3101417750"/>
+ </class>
+ <class name="edm::Wrapper<v1::SiStripApproximateClusterCollection>"/>
+
+ <class name="edmNew::DetSetVector<SiStripApproximateCluster_v1>"/>
+ <class name="edm::Wrapper<edmNew::DetSetVector<SiStripApproximateCluster_v1>>"/>
+
+ <class name="std::vector<SiStripApproximateCluster_v1>"/>
+
+ <class name="edm::Ref<edmNew::DetSetVector<SiStripApproximateCluster_v1>, SiStripApproximateCluster_v1, edmNew::DetSetVector<SiStripApproximateCluster_v1>::FindForDetSetVector>"/>
+
+
+ <class name="edm::ContainerMask<edmNew::DetSetVector<SiStripApproximateCluster_v1> >"/>
+ <class name="edm::Wrapper<edm::ContainerMask<edmNew::DetSetVector<SiStripApproximateCluster_v1> > >"/>
+
+
+ <class name="std::vector<edm::Ref<edmNew::DetSetVector<SiStripApproximateCluster_v1>,SiStripApproximateCluster_v1,edmNew::DetSetVector<SiStripApproximateCluster_v1>::FindForDetSetVector> >" />
+ <class name="edmNew::DetSetVector<edm::Ref<edmNew::DetSetVector<SiStripApproximateCluster_v1>,SiStripApproximateCluster_v1,edmNew::DetSetVector<SiStripApproximateCluster_v1>::FindForDetSetVector> >" />
+ <class name="edm::Wrapper<edmNew::DetSetVector<edm::Ref<edmNew::DetSetVector<SiStripApproximateCluster_v1>,SiStripApproximateCluster_v1,edmNew::DetSetVector<SiStripApproximateCluster_v1>::FindForDetSetVector> > >" />
  <class name="SiStripClustersSOA" ClassVersion="3">
   <version ClassVersion="3" checksum="2739562998"/>
  </class>

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripApprox2Clusters.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripApprox2Clusters.cc
@@ -1,6 +1,8 @@
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h"
 #include "DataFormats/SiStripCluster/interface/SiStripApproximateClusterCollection.h"
+#include "DataFormats/SiStripCluster/interface/SiStripApproximateCluster_v1.h"
+#include "DataFormats/SiStripCluster/interface/SiStripApproximateClusterCollection_v1.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -26,36 +28,79 @@ public:
 
 private:
   edm::EDGetTokenT<SiStripApproximateClusterCollection> clusterToken_;
+  edm::EDGetTokenT<v1::SiStripApproximateClusterCollection> clusterToken_v1_;
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeomToken_;
+  bool v1;
 };
 
 SiStripApprox2Clusters::SiStripApprox2Clusters(const edm::ParameterSet& conf) {
   clusterToken_ = consumes(conf.getParameter<edm::InputTag>("inputApproxClusters"));
+  clusterToken_v1_ = consumes(conf.getParameter<edm::InputTag>("inputApproxClusters"));
   tkGeomToken_ = esConsumes();
+  v1 = conf.getParameter<bool>("v1"); 
   produces<edmNew::DetSetVector<SiStripCluster>>();
 }
 
 void SiStripApprox2Clusters::produce(edm::StreamID id, edm::Event& event, const edm::EventSetup& iSetup) const {
   auto result = std::make_unique<edmNew::DetSetVector<SiStripCluster>>();
-  const auto& clusterCollection = event.get(clusterToken_);
 
   const auto& tkGeom = &iSetup.getData(tkGeomToken_);
   const auto& tkDets = tkGeom->dets();
 
-  for (const auto& detClusters : clusterCollection) {
-    edmNew::DetSetVector<SiStripCluster>::FastFiller ff{*result, detClusters.id()};
-    unsigned int detId = detClusters.id();
+  if ( !v1 ) {
+      const auto& clusterCollection = event.get(clusterToken_);
+      for (const auto& detClusters : clusterCollection) {
+          edmNew::DetSetVector<SiStripCluster>::FastFiller ff{*result, detClusters.id()};
+          unsigned int detId = detClusters.id();
 
-    uint16_t nStrips{0};
-    auto det = std::find_if(tkDets.begin(), tkDets.end(), [detId](auto& elem) -> bool {
-      return (elem->geographicalId().rawId() == detId);
-    });
-    const StripTopology& p = dynamic_cast<const StripGeomDetUnit*>(*det)->specificTopology();
-    nStrips = p.nstrips() - 1;
+          uint16_t nStrips{0};
+          auto det = std::find_if(tkDets.begin(), tkDets.end(), [detId](auto& elem) -> bool {
+             return (elem->geographicalId().rawId() == detId);
+          });
+          const StripTopology& p = dynamic_cast<const StripGeomDetUnit*>(*det)->specificTopology();
+          nStrips = p.nstrips() - 1;
 
-    for (const auto& cluster : detClusters) {
-      ff.push_back(SiStripCluster(cluster, nStrips));
-    }
+          for (const auto& cluster : detClusters) {
+            ff.push_back(SiStripCluster(cluster, nStrips));
+          }
+       }
+  }
+  else {
+     const auto& clusterCollection = event.get(clusterToken_v1_);
+     std::vector<uint16_t> v_strip;
+     float previous_barycenter = -999.;
+     unsigned int module_length = 0;
+     unsigned int previous_module_length = 0;
+
+     unsigned int clusBegin = 0;
+     for (const auto& detClusters : clusterCollection) {
+         edmNew::DetSetVector<SiStripCluster>::FastFiller ff{*result, detClusters.id()};
+         unsigned int detId = detClusters.id();
+
+         uint16_t nStrips{0};
+         auto det = std::find_if(tkDets.begin(), tkDets.end(), [detId](auto& elem) -> bool {
+		      return (elem->geographicalId().rawId() == detId); 
+		      });
+         const StripTopology& p = dynamic_cast<const StripGeomDetUnit*>(*det)->specificTopology();
+         nStrips = p.nstrips();
+
+         v_strip.push_back(nStrips);
+         previous_module_length += (v_strip.size() <3) ? 0 : v_strip[v_strip.size()-3];
+         module_length += (v_strip.size() <2) ? 0 : v_strip[v_strip.size()-2];
+         bool first_cluster = true;
+         detClusters.move(clusBegin);
+ 
+         for (const auto& cluster : detClusters) {
+	      const auto convertedCluster = SiStripCluster(cluster, nStrips-1, previous_barycenter, module_length, first_cluster ? previous_module_length : module_length);
+	        if ( (convertedCluster.barycenter()) >= nStrips) {
+		             break;
+		}
+              previous_barycenter = convertedCluster.barycenter();
+              ++clusBegin;
+              ff.push_back(convertedCluster);
+              first_cluster = false;
+	 }
+     }
   }
 
   event.put(std::move(result));
@@ -64,6 +109,7 @@ void SiStripApprox2Clusters::produce(edm::StreamID id, edm::Event& event, const 
 void SiStripApprox2Clusters::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("inputApproxClusters", edm::InputTag("siStripClusters"));
+  desc.add<bool>("v1", false);
   descriptions.add("SiStripApprox2Clusters", desc);
 }
 

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripApprox2Clusters.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripApprox2Clusters.cc
@@ -37,7 +37,7 @@ SiStripApprox2Clusters::SiStripApprox2Clusters(const edm::ParameterSet& conf) {
   clusterToken_ = consumes(conf.getParameter<edm::InputTag>("inputApproxClusters"));
   clusterToken_v1_ = consumes(conf.getParameter<edm::InputTag>("inputApproxClusters"));
   tkGeomToken_ = esConsumes();
-  v1 = conf.getParameter<bool>("v1"); 
+  v1 = conf.getParameter<bool>("v1");
   produces<edmNew::DetSetVector<SiStripCluster>>();
 }
 
@@ -47,60 +47,63 @@ void SiStripApprox2Clusters::produce(edm::StreamID id, edm::Event& event, const 
   const auto& tkGeom = &iSetup.getData(tkGeomToken_);
   const auto& tkDets = tkGeom->dets();
 
-  if ( !v1 ) {
-      const auto& clusterCollection = event.get(clusterToken_);
-      for (const auto& detClusters : clusterCollection) {
-          edmNew::DetSetVector<SiStripCluster>::FastFiller ff{*result, detClusters.id()};
-          unsigned int detId = detClusters.id();
+  if (!v1) {
+    const auto& clusterCollection = event.get(clusterToken_);
+    for (const auto& detClusters : clusterCollection) {
+      edmNew::DetSetVector<SiStripCluster>::FastFiller ff{*result, detClusters.id()};
+      unsigned int detId = detClusters.id();
 
-          uint16_t nStrips{0};
-          auto det = std::find_if(tkDets.begin(), tkDets.end(), [detId](auto& elem) -> bool {
-             return (elem->geographicalId().rawId() == detId);
-          });
-          const StripTopology& p = dynamic_cast<const StripGeomDetUnit*>(*det)->specificTopology();
-          nStrips = p.nstrips() - 1;
+      uint16_t nStrips{0};
+      auto det = std::find_if(tkDets.begin(), tkDets.end(), [detId](auto& elem) -> bool {
+        return (elem->geographicalId().rawId() == detId);
+      });
+      const StripTopology& p = dynamic_cast<const StripGeomDetUnit*>(*det)->specificTopology();
+      nStrips = p.nstrips() - 1;
 
-          for (const auto& cluster : detClusters) {
-            ff.push_back(SiStripCluster(cluster, nStrips));
-          }
-       }
-  }
-  else {
-     const auto& clusterCollection = event.get(clusterToken_v1_);
-     std::vector<uint16_t> v_strip;
-     float previous_barycenter = -999.;
-     unsigned int module_length = 0;
-     unsigned int previous_module_length = 0;
+      for (const auto& cluster : detClusters) {
+        ff.push_back(SiStripCluster(cluster, nStrips));
+      }
+    }
+  } else {
+    const auto& clusterCollection = event.get(clusterToken_v1_);
+    std::vector<uint16_t> v_strip;
+    float previous_barycenter = -999.;
+    unsigned int module_length = 0;
+    unsigned int previous_module_length = 0;
 
-     unsigned int clusBegin = 0;
-     for (const auto& detClusters : clusterCollection) {
-         edmNew::DetSetVector<SiStripCluster>::FastFiller ff{*result, detClusters.id()};
-         unsigned int detId = detClusters.id();
+    unsigned int clusBegin = 0;
+    for (const auto& detClusters : clusterCollection) {
+      edmNew::DetSetVector<SiStripCluster>::FastFiller ff{*result, detClusters.id()};
+      unsigned int detId = detClusters.id();
 
-         uint16_t nStrips{0};
-         auto det = std::find_if(tkDets.begin(), tkDets.end(), [detId](auto& elem) -> bool {
-		      return (elem->geographicalId().rawId() == detId); 
-		      });
-         const StripTopology& p = dynamic_cast<const StripGeomDetUnit*>(*det)->specificTopology();
-         nStrips = p.nstrips();
+      uint16_t nStrips{0};
+      auto det = std::find_if(tkDets.begin(), tkDets.end(), [detId](auto& elem) -> bool {
+        return (elem->geographicalId().rawId() == detId);
+      });
+      const StripTopology& p = dynamic_cast<const StripGeomDetUnit*>(*det)->specificTopology();
+      nStrips = p.nstrips();
 
-         v_strip.push_back(nStrips);
-         previous_module_length += (v_strip.size() <3) ? 0 : v_strip[v_strip.size()-3];
-         module_length += (v_strip.size() <2) ? 0 : v_strip[v_strip.size()-2];
-         bool first_cluster = true;
-         detClusters.move(clusBegin);
- 
-         for (const auto& cluster : detClusters) {
-	      const auto convertedCluster = SiStripCluster(cluster, nStrips-1, previous_barycenter, module_length, first_cluster ? previous_module_length : module_length);
-	        if ( (convertedCluster.barycenter()) >= nStrips) {
-		             break;
-		}
-              previous_barycenter = convertedCluster.barycenter();
-              ++clusBegin;
-              ff.push_back(convertedCluster);
-              first_cluster = false;
-	 }
-     }
+      v_strip.push_back(nStrips);
+      previous_module_length += (v_strip.size() < 3) ? 0 : v_strip[v_strip.size() - 3];
+      module_length += (v_strip.size() < 2) ? 0 : v_strip[v_strip.size() - 2];
+      bool first_cluster = true;
+      detClusters.move(clusBegin);
+
+      for (const auto& cluster : detClusters) {
+        const auto convertedCluster = SiStripCluster(cluster,
+                                                     nStrips - 1,
+                                                     previous_barycenter,
+                                                     module_length,
+                                                     first_cluster ? previous_module_length : module_length);
+        if ((convertedCluster.barycenter()) >= nStrips) {
+          break;
+        }
+        previous_barycenter = convertedCluster.barycenter();
+        ++clusBegin;
+        ff.push_back(convertedCluster);
+        first_cluster = false;
+      }
+    }
   }
 
   event.put(std::move(result));

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusters2ApproxClusters_v1.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusters2ApproxClusters_v1.cc
@@ -1,0 +1,189 @@
+#include "CalibFormats/SiStripObjects/interface/SiStripDetInfo.h"
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
+#include "CondFormats/DataRecord/interface/SiStripNoisesRcd.h"
+#include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementPoint.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+#include "DataFormats/SiStripCluster/interface/SiStripApproximateCluster_v1.h"
+#include "DataFormats/SiStripCluster/interface/SiStripApproximateClusterCollection_v1.h"
+#include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
+#include "DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackBase.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "RecoTracker/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h"
+#include "RecoTracker/PixelLowPtUtilities/interface/SlidingPeakFinder.h"
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
+
+#include <vector>
+#include <memory>
+
+class SiStripClusters2ApproxClusters_v1 : public edm::stream::EDProducer<> {
+public:
+  explicit SiStripClusters2ApproxClusters_v1(const edm::ParameterSet& conf);
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  edm::InputTag inputClusters;
+  edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > clusterToken;
+
+  unsigned int maxNSat;
+  static constexpr double subclusterWindow_ = .7;
+  static constexpr double seedCutMIPs_ = .35;
+  static constexpr double seedCutSN_ = 7.;
+  static constexpr double subclusterCutMIPs_ = .45;
+  static constexpr double subclusterCutSN_ = 12.;
+
+  edm::InputTag beamSpot_;
+  edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeomToken_;
+
+  edm::FileInPath fileInPath_;
+  SiStripDetInfo detInfo_;
+
+  std::string csfLabel_;
+  edm::ESGetToken<ClusterShapeHitFilter, CkfComponentsRecord> csfToken_;
+
+  edm::ESGetToken<SiStripNoises, SiStripNoisesRcd> stripNoiseToken_;
+  edm::ESHandle<SiStripNoises> theNoise_;
+};
+
+SiStripClusters2ApproxClusters_v1::SiStripClusters2ApproxClusters_v1(const edm::ParameterSet& conf) {
+  inputClusters = conf.getParameter<edm::InputTag>("inputClusters");
+  maxNSat = conf.getParameter<unsigned int>("maxSaturatedStrips");
+
+  clusterToken = consumes<edmNew::DetSetVector<SiStripCluster> >(inputClusters);
+
+  beamSpot_ = conf.getParameter<edm::InputTag>("beamSpot");
+  beamSpotToken_ = consumes<reco::BeamSpot>(beamSpot_);
+
+  tkGeomToken_ = esConsumes();
+
+  fileInPath_ = edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile);
+  detInfo_ = SiStripDetInfoFileReader::read(fileInPath_.fullPath());
+
+  csfLabel_ = conf.getParameter<std::string>("clusterShapeHitFilterLabel");
+  csfToken_ = esConsumes(edm::ESInputTag("", csfLabel_));
+
+  stripNoiseToken_ = esConsumes();
+  produces<v1::SiStripApproximateClusterCollection>();
+}
+
+void SiStripClusters2ApproxClusters_v1::produce(edm::Event& event, edm::EventSetup const& iSetup) {
+  const auto& clusterCollection = event.get(clusterToken);
+  auto result = std::make_unique<v1::SiStripApproximateClusterCollection>();
+  result->reserve(clusterCollection.size(), clusterCollection.dataSize());
+
+  auto const beamSpotHandle = event.getHandle(beamSpotToken_);
+  auto const& bs = beamSpotHandle.isValid() ? *beamSpotHandle : reco::BeamSpot();
+  if (not beamSpotHandle.isValid()) {
+    edm::LogError("SiStripClusters2ApproxClusters_v1")
+        << "didn't find a valid beamspot with label \"" << beamSpot_.encode() << "\" -> using (0,0,0)";
+  }
+
+  const auto& tkGeom = &iSetup.getData(tkGeomToken_);
+  const auto& theFilter = &iSetup.getData(csfToken_);
+  const auto& theNoise_ = &iSetup.getData(stripNoiseToken_);
+
+  float previous_cluster = -999.;
+  unsigned int module_length = 0;
+  unsigned int previous_module_length = 0;
+  const auto tkDets = tkGeom->dets();
+
+  std::vector<uint16_t> v_strip;
+
+  for (const auto& detClusters : clusterCollection) {
+    auto ff = result->beginDet(detClusters.id());
+
+    unsigned int detId = detClusters.id();
+    const GeomDet* det = tkGeom->idToDet(detId);
+    double nApvs = detInfo_.getNumberOfApvsAndStripLength(detId).first;
+    double stripLength = detInfo_.getNumberOfApvsAndStripLength(detId).second;
+    double barycenter_ypos = 0.5 * stripLength;
+
+    const StripGeomDetUnit* stripDet = dynamic_cast<const StripGeomDetUnit*>(det);
+    float mip = 3.9 / (sistrip::MeVperADCStrip / stripDet->surface().bounds().thickness());
+
+    uint16_t nStrips{0};
+    const auto& _detId = detId; // for the capture clause in the lambda function
+    auto _det = std::find_if(tkDets.begin(), tkDets.end(), [_detId](auto& elem) -> bool {
+        return (elem->geographicalId().rawId() == _detId);
+      });
+    const StripTopology& p = dynamic_cast<const StripGeomDetUnit*>(*_det)->specificTopology();
+    nStrips = p.nstrips();
+    v_strip.push_back(nStrips);
+
+    previous_module_length += (v_strip.size() <3) ? 0 : v_strip[v_strip.size()-3];
+    module_length += (v_strip.size() <2) ? 0 : v_strip[v_strip.size()-2];
+    assert(detClusters.size());
+    bool first_cluster = true;
+
+    for (const auto& cluster : detClusters) {
+      const LocalPoint& lp = LocalPoint(((cluster.barycenter() * 10 / (sistrip::STRIPS_PER_APV * nApvs)) -
+                                         ((stripDet->surface().bounds().width()) * 0.5f)),
+                                        barycenter_ypos - (0.5f * stripLength),
+                                        0.);
+      const GlobalPoint& gpos = det->surface().toGlobal(lp);
+      GlobalPoint beamspot(bs.position().x(), bs.position().y(), bs.position().z());
+      const GlobalVector& gdir = gpos - beamspot;
+      const LocalVector& ldir = det->toLocal(gdir);
+
+      int hitStrips;
+      float hitPredPos;
+      bool usable = theFilter->getSizes(detId, cluster, lp, ldir, hitStrips, hitPredPos);
+      // (almost) same logic as in StripSubClusterShapeTrajectoryFilter
+      bool isTrivial = (std::abs(hitPredPos) < 2.f && hitStrips <= 2);
+
+      if (!usable || isTrivial) {
+        ff.push_back(SiStripApproximateCluster_v1(cluster, maxNSat, hitPredPos, previous_cluster, module_length, first_cluster ? previous_module_length : module_length, true));
+      } else {
+        bool peakFilter = false;
+        SlidingPeakFinder pf(std::max<int>(2, std::ceil(std::abs(hitPredPos) + subclusterWindow_)));
+        float mipnorm = mip / std::abs(ldir.z());
+        PeakFinderTest test(mipnorm,
+                            detId,
+                            cluster.firstStrip(),
+                            theNoise_,
+                            seedCutMIPs_,
+                            seedCutSN_,
+                            subclusterCutMIPs_,
+                            subclusterCutSN_);
+        peakFilter = pf.apply(cluster.amplitudes(), test);
+
+        ff.push_back(SiStripApproximateCluster_v1(cluster, maxNSat, hitPredPos, previous_cluster, module_length, first_cluster? previous_module_length : module_length, peakFilter));
+      }
+      first_cluster = false;
+    }
+  }
+
+  event.put(std::move(result));
+}
+
+void SiStripClusters2ApproxClusters_v1::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("inputClusters", edm::InputTag("siStripClusters"));
+  desc.add<unsigned int>("maxSaturatedStrips", 3);
+  desc.add<std::string>("clusterShapeHitFilterLabel", "ClusterShapeHitFilter");  // add CSF label
+  desc.add<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"));         // add BeamSpot tag
+  descriptions.add("SiStripClusters2ApproxClusters_v1", desc);
+}
+
+DEFINE_FWK_MODULE(SiStripClusters2ApproxClusters_v1);

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusters2ApproxClusters_v1.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusters2ApproxClusters_v1.cc
@@ -123,17 +123,17 @@ void SiStripClusters2ApproxClusters_v1::produce(edm::Event& event, edm::EventSet
     float mip = 3.9 / (sistrip::MeVperADCStrip / stripDet->surface().bounds().thickness());
 
     uint16_t nStrips{0};
-    const auto& _detId = detId; // for the capture clause in the lambda function
+    const auto& _detId = detId;  // for the capture clause in the lambda function
     auto _det = std::find_if(tkDets.begin(), tkDets.end(), [_detId](auto& elem) -> bool {
-        return (elem->geographicalId().rawId() == _detId);
-      });
+      return (elem->geographicalId().rawId() == _detId);
+    });
     const StripTopology& p = dynamic_cast<const StripGeomDetUnit*>(*_det)->specificTopology();
     nStrips = p.nstrips();
     v_strip.push_back(nStrips);
 
-    previous_module_length += (v_strip.size() <3) ? 0 : v_strip[v_strip.size()-3];
-    module_length += (v_strip.size() <2) ? 0 : v_strip[v_strip.size()-2];
-    assert(detClusters.size());
+    previous_module_length += (v_strip.size() < 3) ? 0 : v_strip[v_strip.size() - 3];
+    module_length += (v_strip.size() < 2) ? 0 : v_strip[v_strip.size() - 2];
+    assert(!detClusters.empty());
     bool first_cluster = true;
 
     for (const auto& cluster : detClusters) {
@@ -153,7 +153,13 @@ void SiStripClusters2ApproxClusters_v1::produce(edm::Event& event, edm::EventSet
       bool isTrivial = (std::abs(hitPredPos) < 2.f && hitStrips <= 2);
 
       if (!usable || isTrivial) {
-        ff.push_back(SiStripApproximateCluster_v1(cluster, maxNSat, hitPredPos, previous_cluster, module_length, first_cluster ? previous_module_length : module_length, true));
+        ff.push_back(SiStripApproximateCluster_v1(cluster,
+                                                  maxNSat,
+                                                  hitPredPos,
+                                                  previous_cluster,
+                                                  module_length,
+                                                  first_cluster ? previous_module_length : module_length,
+                                                  true));
       } else {
         bool peakFilter = false;
         SlidingPeakFinder pf(std::max<int>(2, std::ceil(std::abs(hitPredPos) + subclusterWindow_)));
@@ -168,7 +174,13 @@ void SiStripClusters2ApproxClusters_v1::produce(edm::Event& event, edm::EventSet
                             subclusterCutSN_);
         peakFilter = pf.apply(cluster.amplitudes(), test);
 
-        ff.push_back(SiStripApproximateCluster_v1(cluster, maxNSat, hitPredPos, previous_cluster, module_length, first_cluster? previous_module_length : module_length, peakFilter));
+        ff.push_back(SiStripApproximateCluster_v1(cluster,
+                                                  maxNSat,
+                                                  hitPredPos,
+                                                  previous_cluster,
+                                                  module_length,
+                                                  first_cluster ? previous_module_length : module_length,
+                                                  peakFilter));
       }
       first_cluster = false;
     }


### PR DESCRIPTION
This PR is created to implement the changes described in the DP note [CMS-DP-2025-031](http://cds-lb.cern.ch/record/2936314?ln=el). The changes are as described in the DP note exactly, except following things

- the boolean variables ```filter_```, ```isSaturated_```, and ```peakFilter_``` have been dropped for the collection [SiStripApproxCluster_v1](https://github.com/saswatinandan/cmssw/blob/HI_test_with_v1/DataFormats/SiStripCluster/interface/SiStripApproximateCluster_v1.h) and encoded to the ```compBarycenter_ ``` and ```compavgCharge_```. **It reduces the size of strip collection by 5%**.
-  A flag ```v1``` is [added](https://github.com/saswatinandan/cmssw/blob/HI_test_with_v1/RecoLocalTracker/SiStripClusterizer/plugins/SiStripApprox2Clusters.cc#L50) to the code so that default and the new version can be run. To run v1 online, this line should be added to the hlt configuration file ```process.hltSiStripClusters2ApproxClusters = cms.EDProducer("SiStripClusters2ApproxClusters_v1"....``` instead of ```process.hltSiStripClusters2ApproxClusters = cms.EDProducer("SiStripClusters2ApproxClusters"....```.
- To apply tight charge cut on strip cluster these lines shoyld be added to the online configuration ```process.HLTSiStripClusterChargeCutTight = cms.PSet(  value = cms.double( 1945.0 ) )
process.HLTSiStripClusterChargeCutNone = cms.PSet(  value = cms.double( -1.0 ) )
process.hltSiStripClusterizerForRawPrime.Clusterizer.clusterChargeCut.refToPSet_='HLTSiStripClusterChargeCutTight'
process.ClusterShapeHitFilterESProducer.clusterChargeCut.refToPSet_='HLTSiStripClusterChargeCutTight'```. **This reduces the cluster size by 3.3%**.

With all these changes, the **strip cluster collection size is reduced by ~21%**.