### PR TITLE
Provide fillDescriptions to CSC ESproducers for HLT

### DIFF
--- a/CalibMuon/CSCCalibration/interface/CSCChannelMapperESProducer.h
+++ b/CalibMuon/CSCCalibration/interface/CSCChannelMapperESProducer.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"  // for fillDescriptions
 
 #include "CalibMuon/CSCCalibration/interface/CSCChannelMapperBase.h"
 #include "CalibMuon/CSCCalibration/interface/CSCChannelMapperRecord.h"
@@ -16,6 +17,8 @@ public:
   ~CSCChannelMapperESProducer() override;
 
   BSP_TYPE produce(const CSCChannelMapperRecord &);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
   std::string algoName;

--- a/CalibMuon/CSCCalibration/interface/CSCIndexerESProducer.h
+++ b/CalibMuon/CSCCalibration/interface/CSCIndexerESProducer.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"  // needed for fillDescriptions
 
 #include "CalibMuon/CSCCalibration/interface/CSCIndexerBase.h"
 #include "CalibMuon/CSCCalibration/interface/CSCIndexerRecord.h"
@@ -16,6 +17,8 @@ public:
   ~CSCIndexerESProducer() override;
 
   BSP_TYPE produce(const CSCIndexerRecord &);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
   std::string algoName;

--- a/CalibMuon/CSCCalibration/plugins/CSCChannelMapperESProducer.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCChannelMapperESProducer.cc
@@ -1,9 +1,8 @@
 #include "FWCore/Framework/interface/ModuleFactory.h"
-
 #include "CalibMuon/CSCCalibration/interface/CSCChannelMapperESProducer.h"
 #include "CalibMuon/CSCCalibration/interface/CSCChannelMapperFactory.h"
-
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 CSCChannelMapperESProducer::CSCChannelMapperESProducer(const edm::ParameterSet &pset) {
   algoName = pset.getParameter<std::string>("AlgoName");
@@ -19,6 +18,13 @@ CSCChannelMapperESProducer::BSP_TYPE CSCChannelMapperESProducer::produce(const C
   LogTrace("CSCChannelMapperESProducer") << " producing: " << algoName;
 
   return CSCChannelMapperESProducer::BSP_TYPE(CSCChannelMapperFactory::get()->create(algoName));
+}
+
+// ---- add this ----
+void CSCChannelMapperESProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("AlgoName", "CSCChannelMapperStartup");  // default
+  descriptions.addWithDefaultLabel(desc);
 }
 
 // define this as a plug-in

--- a/CalibMuon/CSCCalibration/plugins/CSCIndexerESProducer.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCIndexerESProducer.cc
@@ -1,9 +1,8 @@
 #include "FWCore/Framework/interface/ModuleFactory.h"
-
 #include "CalibMuon/CSCCalibration/interface/CSCIndexerESProducer.h"
 #include "CalibMuon/CSCCalibration/interface/CSCIndexerFactory.h"
-
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 CSCIndexerESProducer::CSCIndexerESProducer(const edm::ParameterSet &pset) {
   algoName = pset.getParameter<std::string>("AlgoName");
@@ -19,6 +18,13 @@ CSCIndexerESProducer::BSP_TYPE CSCIndexerESProducer::produce(const CSCIndexerRec
   LogTrace("CSCIndexerESProducer") << " producing: " << algoName;
 
   return CSCIndexerESProducer::BSP_TYPE(CSCIndexerFactory::get()->create(algoName));
+}
+
+// ---- add this ----
+void CSCIndexerESProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("AlgoName", "CSCIndexerStartup");  // default
+  descriptions.addWithDefaultLabel(desc);
 }
 
 // define this as a plug-in


### PR DESCRIPTION
#### PR description:

This PR is against a fix for the modules CSCChannelMapperESProducer and CSCIndexerESProducer to produce the cfi files. Please review the issue at https://github.com/cms-sw/cmssw/issues/47275.

#### PR validation:

I have tried compiling the changes by compiling the code in CMSSW with the following command
scram b -j 8

Everything looked good with the cfi files being produced in the CalibMuon/CSCCalibration/python directory. 
