### PR TITLE
Fixes for Digi Morphing: Limiting Histogram Size and Decoupling for `TrackerTraits`

### DIFF
--- a/Geometry/CommonTopologies/interface/SimplePixelTopology.h
+++ b/Geometry/CommonTopologies/interface/SimplePixelTopology.h
@@ -377,7 +377,7 @@ namespace pixelTopology {
     static constexpr uint16_t last_barrel_detIndex = 864;
 
     static constexpr uint32_t maxPixInModule = 6000;
-    static constexpr uint32_t maxPixInModuleForMorphing = maxPixInModule;
+    static constexpr uint32_t maxPixInModuleForMorphing = 0;
     static constexpr uint32_t maxIterClustering = 16;
 
     static constexpr uint32_t maxNumClustersPerModules = phase2PixelTopology::maxNumClustersPerModules;
@@ -474,7 +474,7 @@ namespace pixelTopology {
     static constexpr uint16_t last_barrel_detIndex = 1184;
 
     static constexpr uint32_t maxPixInModule = 6000;
-    static constexpr uint32_t maxPixInModuleForMorphing = maxPixInModule * 7/5;
+    static constexpr uint32_t maxPixInModuleForMorphing = maxPixInModule * 2 / 5;
     static constexpr uint32_t maxIterClustering = 24;
 
     static constexpr uint32_t maxNumClustersPerModules = phase1PixelTopology::maxNumClustersPerModules;
@@ -588,7 +588,7 @@ namespace pixelTopology {
     static constexpr uint32_t maxNumberOfQuadruplets = maxNumberOfTuples;
 
     static constexpr uint32_t maxPixInModule = 10000;
-    static constexpr uint32_t maxPixInModuleForMorphing = maxPixInModule * 11/10;
+    static constexpr uint32_t maxPixInModuleForMorphing = maxPixInModule * 1 / 10;
     static constexpr uint32_t maxIterClustering = 32;
 
     static constexpr uint32_t maxNumOfActiveDoublets =

--- a/Geometry/CommonTopologies/interface/SimplePixelTopology.h
+++ b/Geometry/CommonTopologies/interface/SimplePixelTopology.h
@@ -377,6 +377,9 @@ namespace pixelTopology {
     static constexpr uint16_t last_barrel_detIndex = 864;
 
     static constexpr uint32_t maxPixInModule = 6000;
+    static constexpr uint32_t maxPixInModuleForMorphing = maxPixInModule;
+    static constexpr uint32_t maxIterClustering = 16;
+
     static constexpr uint32_t maxNumClustersPerModules = phase2PixelTopology::maxNumClustersPerModules;
     static constexpr uint32_t maxHitsInModule = phase2PixelTopology::maxNumClustersPerModules;
 
@@ -471,6 +474,9 @@ namespace pixelTopology {
     static constexpr uint16_t last_barrel_detIndex = 1184;
 
     static constexpr uint32_t maxPixInModule = 6000;
+    static constexpr uint32_t maxPixInModuleForMorphing = maxPixInModule * 7/5;
+    static constexpr uint32_t maxIterClustering = 24;
+
     static constexpr uint32_t maxNumClustersPerModules = phase1PixelTopology::maxNumClustersPerModules;
     static constexpr uint32_t maxHitsInModule = phase1PixelTopology::maxNumClustersPerModules;
 
@@ -582,6 +588,8 @@ namespace pixelTopology {
     static constexpr uint32_t maxNumberOfQuadruplets = maxNumberOfTuples;
 
     static constexpr uint32_t maxPixInModule = 10000;
+    static constexpr uint32_t maxPixInModuleForMorphing = maxPixInModule * 11/10;
+    static constexpr uint32_t maxIterClustering = 32;
 
     static constexpr uint32_t maxNumOfActiveDoublets =
         maxNumberOfDoublets / 4;  // TODO need to think a better way to avoid this duplication

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
@@ -210,6 +210,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     digiMorphingConfig_.applyDigiMorphing = iConfig.getParameter<bool>("DoDigiMorphing");
     digiMorphingConfig_.maxFakesInModule = iConfig.getParameter<uint32_t>("MaxFakesInModule");
 
+    if (digiMorphingConfig_.maxFakesInModule > TrackerTraits::maxPixInModuleForMorphing - TrackerTraits::maxPixInModule) {
+      throw cms::Exception("Configuration") << "[SiPixelDigiMorphing]:"
+                                            << " maxFakesInModule should be <= " << TrackerTraits::maxPixInModuleForMorphing - TrackerTraits::maxPixInModule 
+                                            << " (TrackerTraits::maxPixInModuleForMorphing - TrackerTraits::maxPixInModule)"
+                                            << " while " << digiMorphingConfig_.maxFakesInModule << " was provided at config level.\n";
+    }
+    
     // regions
     if (!iConfig.getParameter<edm::ParameterSet>("Regions").getParameterNames().empty()) {
       regions_ = std::make_unique<PixelUnpackingRegions>(iConfig, consumesCollector());
@@ -233,7 +240,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     desc.add<double>("VCaltoElectronOffset", -60.f);
     desc.add<double>("VCaltoElectronOffset_L1", -670.f);
     desc.add<bool>("DoDigiMorphing", false);
-    desc.add<uint32_t>("MaxFakesInModule", TrackerTraits::maxPixInModule * 2 / 5);
+    desc.add<uint32_t>("MaxFakesInModule", TrackerTraits::maxPixInModuleForMorphing - TrackerTraits::maxPixInModule);
 
     desc.add<edm::InputTag>("InputLabel", edm::InputTag("rawDataCollector"));
     {

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
@@ -210,13 +210,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     digiMorphingConfig_.applyDigiMorphing = iConfig.getParameter<bool>("DoDigiMorphing");
     digiMorphingConfig_.maxFakesInModule = iConfig.getParameter<uint32_t>("MaxFakesInModule");
 
-    if (digiMorphingConfig_.maxFakesInModule > TrackerTraits::maxPixInModuleForMorphing - TrackerTraits::maxPixInModule) {
-      throw cms::Exception("Configuration") << "[SiPixelDigiMorphing]:"
-                                            << " maxFakesInModule should be <= " << TrackerTraits::maxPixInModuleForMorphing - TrackerTraits::maxPixInModule 
-                                            << " (TrackerTraits::maxPixInModuleForMorphing - TrackerTraits::maxPixInModule)"
-                                            << " while " << digiMorphingConfig_.maxFakesInModule << " was provided at config level.\n";
+    if (digiMorphingConfig_.maxFakesInModule > TrackerTraits::maxPixInModuleForMorphing) {
+      throw cms::Exception("Configuration")
+          << "[SiPixelDigiMorphing]:"
+          << " maxFakesInModule should be <= " << TrackerTraits::maxPixInModuleForMorphing
+          << " (TrackerTraits::maxPixInModuleForMorphing)"
+          << " while " << digiMorphingConfig_.maxFakesInModule << " was provided at config level.\n";
     }
-    
+
     // regions
     if (!iConfig.getParameter<edm::ParameterSet>("Regions").getParameterNames().empty()) {
       regions_ = std::make_unique<PixelUnpackingRegions>(iConfig, consumesCollector());
@@ -240,7 +241,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     desc.add<double>("VCaltoElectronOffset", -60.f);
     desc.add<double>("VCaltoElectronOffset_L1", -670.f);
     desc.add<bool>("DoDigiMorphing", false);
-    desc.add<uint32_t>("MaxFakesInModule", TrackerTraits::maxPixInModuleForMorphing - TrackerTraits::maxPixInModule);
+    desc.add<uint32_t>("MaxFakesInModule", TrackerTraits::maxPixInModuleForMorphing);
 
     desc.add<edm::InputTag>("InputLabel", edm::InputTag("rawDataCollector"));
     {

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
@@ -291,7 +291,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     // Kernel to perform Raw to Digi conversion
     template <bool debug = false>
     struct RawToDigi_kernel {
-    ALPAKA_FN_ACC void operator()(Acc1D const &acc,
+      ALPAKA_FN_ACC void operator()(Acc1D const &acc,
                                     const SiPixelMappingSoAConstView &cablingMap,
                                     const unsigned char *modToUnp,
                                     const uint32_t wordCounter,
@@ -571,7 +571,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         {
           const int blocks = 64;
 
-          const auto elementsPerBlockFindClus = digiMorphingConfig.applyDigiMorphing ? FindClus<TrackerTraits>::maxElementsPerBlockMorph : FindClus<TrackerTraits>::maxElementsPerBlock;
+          const auto elementsPerBlockFindClus = digiMorphingConfig.applyDigiMorphing
+                                                    ? FindClus<TrackerTraits>::maxElementsPerBlockMorph
+                                                    : FindClus<TrackerTraits>::maxElementsPerBlock;
           const auto workDivFindClus = cms::alpakatools::make_workdiv<Acc1D>(blocks, elementsPerBlockFindClus);
 
           // allocate a transient collection for the fake pixels recovered by the digi morphing algorithm
@@ -591,7 +593,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                               digiMorphingConfig.applyDigiMorphing,
                               morphingModulesDevice,
                               digiMorphingConfig.numMorphingModules,
-                              digiMorphingConfig.maxFakesInModule, 
+                              digiMorphingConfig.maxFakesInModule,
                               clusters_d->view(),
                               wordCounter);
 #ifdef GPU_DEBUG
@@ -767,5 +769,5 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     template class SiPixelRawToClusterKernel<pixelTopology::HIonPhase1>;
 
   }  // namespace pixelDetails
-  
+
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
@@ -291,7 +291,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     // Kernel to perform Raw to Digi conversion
     template <bool debug = false>
     struct RawToDigi_kernel {
-      ALPAKA_FN_ACC void operator()(Acc1D const &acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const &acc,
                                     const SiPixelMappingSoAConstView &cablingMap,
                                     const unsigned char *modToUnp,
                                     const uint32_t wordCounter,
@@ -570,27 +570,28 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
         {
           const int blocks = 64;
-          const auto elementsPerBlockFindClus = FindClus<TrackerTraits>::maxElementsPerBlock;
-          const auto workDivMaxNumModules = cms::alpakatools::make_workdiv<Acc1D>(blocks, elementsPerBlockFindClus);
+
+          const auto elementsPerBlockFindClus = digiMorphingConfig.applyDigiMorphing ? FindClus<TrackerTraits>::maxElementsPerBlockMorph : FindClus<TrackerTraits>::maxElementsPerBlock;
+          const auto workDivFindClus = cms::alpakatools::make_workdiv<Acc1D>(blocks, elementsPerBlockFindClus);
 
           // allocate a transient collection for the fake pixels recovered by the digi morphing algorithm
           auto fakes_d = SiPixelDigisSoACollection(blocks * digiMorphingConfig.maxFakesInModule, queue);
-
 #ifdef GPU_DEBUG
-          std::cout << " FindClus kernel launch with " << numberOfModules << " blocks of " << elementsPerBlockFindClus
+          alpaka::wait(queue);
+          std::cout << "FindClus kernel launch with " << blocks << " blocks of " << elementsPerBlockFindClus
                     << " threadsPerBlockOrElementsPerThread\n";
 #endif
 
           // Use device buffer created by producer and the module count stored in digiMorphingConfig
           alpaka::exec<Acc1D>(queue,
-                              workDivMaxNumModules,
+                              workDivFindClus,
                               FindClus<TrackerTraits>{},
                               digis_d->view(),
                               fakes_d.view(),
                               digiMorphingConfig.applyDigiMorphing,
                               morphingModulesDevice,
                               digiMorphingConfig.numMorphingModules,
-                              digiMorphingConfig.maxFakesInModule,
+                              digiMorphingConfig.maxFakesInModule, 
                               clusters_d->view(),
                               wordCounter);
 #ifdef GPU_DEBUG
@@ -766,5 +767,5 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     template class SiPixelRawToClusterKernel<pixelTopology::HIonPhase1>;
 
   }  // namespace pixelDetails
-
+  
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE


### PR DESCRIPTION
#### PR description:

This PR proposes a couple of fixes for the digi morphing to work properly for differen conditions (when acitve or not):
- defining a `maxPixInModuleForMorphing` constant depending on the `TrackerTraits` to be used to define the number of threads for the `FindClus` kernel. This also sizes the histogram holding the pixels in a module:

```c++
using Hist = cms::alpakatools::HistoContainer<uint16_t,
                                                      TrackerTraits::clusterBinning,
                                                      TrackerTraits::maxPixInModuleForMorphing,
                                                      TrackerTraits::clusterBits,
                                                      uint16_t>;                                                      
```

- having a different `maxIterGPU` per topology (given the different number of pixels affects the number of iterations we can use to cover the full module);
- limiting the `maxFakesInModule` configuration parameter to take into account the `maxPixInModuleForMorphing` max to avoid the histogram overflowing.

#### PR validation:

`160.03502` run.

Running successfully the test from @henriettepetersen :

```
hltConfigFromDB --configName /online/collisions/2025/2e34/v1.2/HLT/V2 > hlt.py
cp /gpu_data/store/data/Run2025C/EphemeralHLTPhysics/FED/run393240_cff.py .
cat >> hlt.py << @EOF

process.load('run393240_cff')

from Configuration.AlCa.GlobalTag import GlobalTag as customiseGlobalTag
process.GlobalTag = customiseGlobalTag(process.GlobalTag, globaltag = '150X_dataRun3_HLT_v1')

from HLTrigger.Configuration.customizeHLTforCMSSW import customizeHLTforCMSSW
process = customizeHLTforCMSSW(process)

process.PrescaleService.lvl1DefaultLabel = '2p0E34'
process.PrescaleService.forceDefault = True

process.options.wantSummary = False
process.MessageLogger.cerr.enableStatistics = cms.untracked.bool(False)

process.FastTimerService.writeJSONSummary = True

process.ThroughputService = cms.Service('ThroughputService',
    enableDQM = cms.untracked.bool(False),
    printEventSummary = cms.untracked.bool(True),
    eventResolution = cms.untracked.uint32(100),
    eventRange = cms.untracked.uint32(10300),
)
process.MessageLogger.cerr.ThroughputService = cms.untracked.PSet(
    limit = cms.untracked.int32(10000000),
    reportEvery = cms.untracked.int32(1)
)

import os
os.makedirs('%s/run%d' % (process.EvFDaqDirector.baseDir.value(), process.EvFDaqDirector.runNumber.value()), exist_ok=True)

process.options.numberOfThreads = 32
process.options.numberOfStreams = 24
process.options.numberOfConcurrentLuminosityBlocks = 2
process.maxEvents.input = 10300

process.hltSiPixelClustersSoA.DoDigiMorphing = cms.bool( True )
process.hltSiPixelClustersSoASerialSync.DoDigiMorphing = cms.bool( True )

@EOF

# run the configuration
cmsRun hlt.py
```

Backport is needed to `15_1_X` for HI data taking.