### PR TITLE
Properly Clamping the Clusters in Module with `maxNumClustersPerModules`

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/ClusterChargeCut.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/ClusterChargeCut.h
@@ -95,7 +95,10 @@ namespace pixelClustering {
             }
           }
           nclus = maxNumClustersPerModules;
+          clus_view[thisModuleId].clusInModule() = nclus;
         }
+
+        ALPAKA_ASSERT_ACC(clus_view[thisModuleId].clusInModule() <= maxNumClustersPerModules);
 
 #ifdef GPU_DEBUG
         if (thisModuleId % 100 == 1)


### PR DESCRIPTION
#### PR description:

This PR proposes a small fix for the `ClusterChargeCut` kernel. As is, if no pixel is cut, the number of clusters is left untouched since the kernel hits

```cpp
// if all clusters are above threshold, do nothing
if (alpaka::syncBlockThreadsPredicate<alpaka::BlockAnd>(acc, good))
     continue;
```

 while it should be clamped to `maxNumClustersPerModules` in any case.

#### PR validation:

Running successfully the test in https://github.com/cms-sw/cmssw/issues/49017.
