### PR TITLE
[15.1.X] add HLT vertexing resolution monitoring (by split vertex method)

### DIFF
--- a/DQM/TrackingMonitor/src/PrimaryVertexResolution.cc
+++ b/DQM/TrackingMonitor/src/PrimaryVertexResolution.cc
@@ -391,6 +391,10 @@ void PrimaryVertexResolution::bookHistograms(DQMStore::IBooker& iBooker, edm::Ru
 
 void PrimaryVertexResolution::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<reco::VertexCollection> hvertices = iEvent.getHandle(vertexSrc_);
+  if (!hvertices.isValid()) {
+    return;
+  }
+
   const reco::VertexCollection& vertices = *hvertices;
   if (vertices.empty())
     return;

--- a/DQM/TrackingMonitor/src/PrimaryVertexResolution.cc
+++ b/DQM/TrackingMonitor/src/PrimaryVertexResolution.cc
@@ -47,7 +47,7 @@ namespace {
 class PrimaryVertexResolution : public DQMEDAnalyzer {
 public:
   PrimaryVertexResolution(const edm::ParameterSet& iConfig);
-  ~PrimaryVertexResolution() override;
+  ~PrimaryVertexResolution() override = default;
 
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
@@ -60,12 +60,15 @@ private:
                                                    const reco::BeamSpot& beamspot);
 
   const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> ttbToken_;
-  edm::EDGetTokenT<reco::VertexCollection> vertexSrc_;
-  edm::EDGetTokenT<reco::BeamSpot> beamspotSrc_;
-  edm::EDGetTokenT<LumiScalersCollection> lumiScalersSrc_;
-  edm::EDGetTokenT<OnlineLuminosityRecord> metaDataSrc_;
+
+  const edm::InputTag vertexInputTag_;
+  const edm::EDGetTokenT<reco::VertexCollection> vertexSrc_;
+  const edm::EDGetTokenT<reco::BeamSpot> beamspotSrc_;
+  const edm::EDGetTokenT<LumiScalersCollection> lumiScalersSrc_;
+  const edm::EDGetTokenT<OnlineLuminosityRecord> metaDataSrc_;
   const bool forceSCAL_;
-  std::string rootFolder_;
+  const std::string rootFolder_;
+  bool errorPrinted_;
 
   AdaptiveVertexFitter fitter_;
 
@@ -327,18 +330,18 @@ private:
 
 PrimaryVertexResolution::PrimaryVertexResolution(const edm::ParameterSet& iConfig)
     : ttbToken_(esConsumes(edm::ESInputTag("", iConfig.getUntrackedParameter<std::string>("transientTrackBuilder")))),
-      vertexSrc_(consumes<reco::VertexCollection>(iConfig.getUntrackedParameter<edm::InputTag>("vertexSrc"))),
+      vertexInputTag_(iConfig.getUntrackedParameter<edm::InputTag>("vertexSrc")),
+      vertexSrc_(consumes<reco::VertexCollection>(vertexInputTag_)),
       beamspotSrc_(consumes<reco::BeamSpot>(iConfig.getUntrackedParameter<edm::InputTag>("beamspotSrc"))),
       lumiScalersSrc_(consumes<LumiScalersCollection>(iConfig.getUntrackedParameter<edm::InputTag>("lumiScalersSrc"))),
       metaDataSrc_(consumes<OnlineLuminosityRecord>(iConfig.getUntrackedParameter<edm::InputTag>("metaDataSrc"))),
       forceSCAL_(iConfig.getUntrackedParameter<bool>("forceSCAL")),
       rootFolder_(iConfig.getUntrackedParameter<std::string>("rootFolder")),
+      errorPrinted_(false),
       binningX_(iConfig),
       binningY_(iConfig),
       hPV_(binningX_, binningY_),
       hOtherV_(binningX_, binningY_) {}
-
-PrimaryVertexResolution::~PrimaryVertexResolution() {}
 
 void PrimaryVertexResolution::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -398,6 +401,28 @@ void PrimaryVertexResolution::analyze(const edm::Event& iEvent, const edm::Event
   const reco::VertexCollection& vertices = *hvertices;
   if (vertices.empty())
     return;
+
+  // check upfront that refs to track are (likely) to be valid
+  {
+    bool ok = true;
+    for (const auto& v : vertices) {
+      if (v.tracksSize() > 0) {
+        const auto& ref = v.trackRefAt(0);
+        if (ref.isNull() || !ref.isAvailable()) {
+          if (!errorPrinted_)
+            edm::LogWarning("PrimaryVertexResolution")
+                << "Skipping vertex collection: " << vertexInputTag_
+                << " since likely the track collection the vertex has refs pointing to is missing (at least the first "
+                   "TrackBaseRef is null or not available)";
+          else
+            errorPrinted_ = true;
+          ok = false;
+        }
+      }
+    }
+    if (!ok)
+      return;
+  }
 
   edm::Handle<reco::BeamSpot> hbeamspot = iEvent.getHandle(beamspotSrc_);
   const reco::BeamSpot& beamspot = *hbeamspot;

--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -17,6 +17,7 @@ from DQMServices.Components.DQMFEDIntegrityClient_cff import *
 from DQMOffline.L1Trigger.L1TriggerDqmOffline_cff import *
 from DQM.SiTrackerPhase2.Phase2TrackerDQMHarvesting_cff import *
 from DQM.SiPixelHeterogeneous.SiPixelHeterogenousDQMHarvesting_cff import *
+from DQMOffline.Trigger.PrimaryVertexMonitoring_Client_cff import *
 
 DQMNone = cms.Sequence()
 
@@ -129,10 +130,7 @@ DQMOffline_SecondStepPOG = cms.Sequence(
                                          DQMOffline_SecondStep_PrePOG *
                                          DQMMessageLoggerClientSeq )
 
-
-
-
-HLTMonitoringClient = cms.Sequence(trackingMonitorClientHLT * trackEfficiencyMonitoringClientHLT * trackingForDisplacedJetMonitorClientHLT)
+HLTMonitoringClient = cms.Sequence(trackingMonitorClientHLT * trackEfficiencyMonitoringClientHLT * trackingForDisplacedJetMonitorClientHLT * hltVerticesMonitoringClient)
 HLTMonitoringClientPA= cms.Sequence(trackingMonitorClientHLT * PAtrackingMonitorClientHLT)
 
 DQMOffline_SecondStep = cms.Sequence(

--- a/DQMOffline/Trigger/python/PrimaryVertexMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/PrimaryVertexMonitoring_Client_cff.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQM.TrackingMonitorClient.primaryVertexResolutionClient_cfi import primaryVertexResolutionClient as _primaryVertexResolutionClient
+
+hltPixelVertexResolutionClient = _primaryVertexResolutionClient.clone(
+    subDirs = ["HLT/Vertexing/hltPixelVertices/Resolution/*"]
+)
+
+hltTrimmedPixelVertexResolutionClient = _primaryVertexResolutionClient.clone(
+    subDirs = ["HLT/Vertexing/hltTrimmedPixelVertices/Resolution/*"]
+)
+
+hltFullVertexResolutionClient = _primaryVertexResolutionClient.clone(
+    subDirs = ["HLT/Vertexing/hltVerticesPFFilter/Resolution/*"]
+)
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(hltFullVertexResolutionClient,
+                        subDirs = ["HLT/Vertexing/hltFullVertices/Resolution/*"])
+
+hltVerticesMonitoringClient = cms.Sequence(hltPixelVertexResolutionClient+
+                                           hltTrimmedPixelVertexResolutionClient+
+                                           hltFullVertexResolutionClient)
+
+phase2_tracker.toReplaceWith(hltVerticesMonitoringClient,
+                             cms.Sequence(hltPixelVertexResolutionClient+
+                                          hltFullVertexResolutionClient))

--- a/DQMOffline/Trigger/python/PrimaryVertexMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/PrimaryVertexMonitoring_cff.py
@@ -49,10 +49,56 @@ hltVerticesL3PFBjetsMonitoring = hltVerticesMonitoring.clone(
     vertexLabel   = "hltVerticesL3PFBjets",
     useHPforAlignmentPlots = False
 )
+
+#### vertexing resolution plots
+
+from DQM.TrackingMonitor.primaryVertexResolution_cfi import primaryVertexResolution as _primaryVertexResolution
+
+hltPixelVertexResolution = _primaryVertexResolution.clone(
+    vertexSrc = "hltPixelVertices",
+    rootFolder = "HLT/Vertexing/hltPixelVertices/Resolution"
+)
+
+pp_on_PbPb_run3.toModify(hltPixelVertexResolution,
+                         vertexSrc = "hltPixelVerticesPPOnAA")
+
+
+phase2_tracker.toModify(hltPixelVertexResolution,
+                        vertexSrc = "hltPhase2PixelVertices")
+
+hltTrimmedPixelVertexResolution = _primaryVertexResolution.clone(
+    vertexSrc = "hltTrimmedPixelVertices",
+    rootFolder = "HLT/Vertexing/hltTrimmedPixelVertices/Resolution"
+)
+
+pp_on_PbPb_run3.toModify(hltTrimmedPixelVertexResolution,
+                         vertexSrc = "hltTrimmedPixelVerticesPPOnAA")
+
+hltVerticesPFFilterResolution =  _primaryVertexResolution.clone(
+    vertexSrc = "hltVerticesPFFilter",
+    rootFolder = "HLT/Vertexing/hltVerticesPFFilter/Resolution"
+)
+
+pp_on_PbPb_run3.toModify(hltVerticesPFFilterResolution,
+                         vertexSrc = "hltVerticesPFFilterPPOnAA")
+
+phase2_tracker.toModify(hltVerticesPFFilterResolution,
+                        rootFolder = "HLT/Vertexing/hltFullVertices/Resolution",
+                        vertexSrc = "hltOfflinePrimaryVertices")
+
+### the sequence
+
 vertexingMonitorHLT = cms.Sequence(
     hltPixelVerticesMonitoring +
     hltTrimmedPixelVerticesMonitoring +
-    hltVerticesPFFilterMonitoring
+    hltVerticesPFFilterMonitoring +
+    hltPixelVertexResolution +
+    hltTrimmedPixelVertexResolution +
+    hltVerticesPFFilterResolution
 )
 
-phase2_tracker.toReplaceWith(vertexingMonitorHLT, cms.Sequence(hltPixelVerticesMonitoring + hltVerticesMonitoring))
+phase2_tracker.toReplaceWith(vertexingMonitorHLT, cms.Sequence(hltPixelVerticesMonitoring +
+                                                               hltVerticesMonitoring +
+                                                               hltPixelVertexResolution +
+                                                               hltVerticesPFFilterResolution
+                                                               ))


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/48980
backport of https://github.com/cms-sw/cmssw/pull/49014

#### PR description:

From the original PR https://github.com/cms-sw/cmssw/pull/48980

> Add HLT vertexing resolution monitoring (using the "split vertex" method) for all the vertex types available at HLT (in both Run 3 and Phase-2).
This leverages the existing module `PrimaryVertexResolution` (which is lightly adapted to tolerate events in which the input colections are missing) and changes the configuration of both the `DQM` and `Harvesting`  steps to be run in the `@HLTMon` sequence.

#### PR validation:

```
runTheMatrix.py -l 17034.0,29634.0,161.4 -t 4 -j 8 --ibeos -i all --ibeos
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/48980 + https://github.com/cms-sw/cmssw/pull/49014 to the 2025 PbPb data-taking release.