### PR TITLE
initialized variables before use in framework code

### DIFF
--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -928,10 +928,10 @@ namespace edm {
 
   bool RootFile::wasFirstEventJustRead() const {
     IndexIntoFile::IndexIntoFileItr itr(indexIntoFileIter_);
-    int phIndex;
-    RunNumber_t run;
-    LuminosityBlockNumber_t lumi;
-    IndexIntoFile::EntryNumber_t eventEntry;
+    int phIndex = 0;
+    RunNumber_t run = 0;
+    LuminosityBlockNumber_t lumi = 0;
+    IndexIntoFile::EntryNumber_t eventEntry = 0;
     itr.skipEventBackward(phIndex, run, lumi, eventEntry);
     itr.skipEventBackward(phIndex, run, lumi, eventEntry);
     return eventEntry == IndexIntoFile::invalidEntry;

--- a/IOPool/TFileAdaptor/src/ReadRepacker.cc
+++ b/IOPool/TFileAdaptor/src/ReadRepacker.cc
@@ -70,8 +70,8 @@ int ReadRepacker::packInternal(long long int *pos, int *len, int nbuf, char *buf
   m_idx_to_iopb_offset.push_back(0);
 
   IOSize buffer_used = len[0];
-  int idx;
-  for (idx = 1; idx < nbuf; idx++) {
+  int idx = 1;
+  for (; idx < nbuf; idx++) {
     if (buffer_used + len[idx] > buffer_size) {
       // No way we can include this chunk in the read buffer
       break;

--- a/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
+++ b/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
@@ -475,11 +475,10 @@ Bool_t TStorageFactoryFile::ReadBuffers(char *buf, Long64_t *pos, Int_t *len, In
   }
 
   // Null buffer means asynchronous reads into I/O system's cache.
-  bool success;
   StorageAccount::Stamp astats(storageCounter(s_statsARead, StorageAccount::Operation::readAsync));
   // Synchronise low-level cache with the supposed cache in TFile.
   // storage_->caching(true, -1, 0);
-  success = storage_->prefetch(iov.data(), nbuf);
+  bool success = storage_->prefetch(iov.data(), nbuf);
   astats.tick(total);
 
   // If it didn't suceeed, pass down to the base class.

--- a/Utilities/General/src/ClassName.cc
+++ b/Utilities/General/src/ClassName.cc
@@ -5,7 +5,7 @@
 Demangle::Demangle(const char* sc) : demangle(nullptr) {
   if (sc == nullptr)
     return;
-  int status;
+  int status = 0;
   demangle = abi::__cxa_demangle(sc, nullptr, nullptr, &status);
   if (status == 0)
     return;


### PR DESCRIPTION
#### PR description:

All of these were fine before but initializing them should not cause any performance issues and makes the code safer to maintain.

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/1594