### PR TITLE
Run3-alca262 Update the calibration macro which is used for IsoTrack calibration of HCAL

### DIFF
--- a/Calibration/HcalCalibAlgos/macros/CalibFitPlots.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibFitPlots.C
@@ -48,6 +48,8 @@
 //           text0 is the text for general title added within ()
 //           type=0 plots response distributions and MPV of response vs ieta
 //               =1 plots MPV of response vs RBX #
+//           *drawStatBox* is of type *int* here specifying the index for
+//           calling SetOptStat and SetOptFit
 //
 //             For plotting stored histograms from CalibTree
 //  PlotFiveHists(infile, text0, prefix0, type, iname, drawStatBox, normalize,
@@ -59,6 +61,8 @@
 //           text0 is the text for general title added within ()
 //           prefix0 is the tag attached to the canvas name
 //           type has the same meaning as in PlotTwoHists
+//           *drawStatBox* is of type *int* here specifying the index for
+//           calling SetOptStat and SetOptFit
 //
 //  PlotHistCorrResults(infile, text, prefixF, save);
 //      Defaults: save=0
@@ -66,7 +70,7 @@
 //             For plotting correction factors
 //  PlotHistCorrFactor(infile, text, prefixF, scale, nmin, isRealData,
 //                     drawStatBox, iformat, save);
-//      Defaults: scale=1.0, nmin=100, isRealData=true, drwaStatBox=false,
+//      Defaults: scale=1.0, nmin=100, isRealData=true, drawStatBox=false,
 //                iformat=0, save=0
 //
 //             For plotting correction factors for a sigle depth

--- a/Calibration/HcalCalibAlgos/macros/CalibFitPlots.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibFitPlots.C
@@ -163,7 +163,7 @@
 //             uncertainty for each depth
 //
 //            For plotting histogram defined in "hist0" of phisymmetry
-//  DrawHistPhiSymmetry(hist0, isRealData, drawStatBox, save) 
+//  DrawHistPhiSymmetry(hist0, isRealData, drawStatBox, save)
 //      Defaults save=false
 //
 //            For plotting phisymmetry results
@@ -1304,11 +1304,7 @@ void FitHistExtended2(const char* infile,
   }
 }
 
-void FitHistRBX(const char* infile, 
-		const char* outfile, 
-		std::string prefix, 
-		bool append = true, 
-		int iname = 3) {
+void FitHistRBX(const char* infile, const char* outfile, std::string prefix, bool append = true, int iname = 3) {
   std::string sname("RBX"), lname("R");
   int numb(18);
   bool debug(false);
@@ -1704,11 +1700,7 @@ void PlotHistEta(const char* infile,
   }
 }
 
-void PlotHists(std::string infile, 
-	       std::string prefix, 
-	       std::string text, 
-	       bool drawStatBox = true, 
-	       int save = 0) {
+void PlotHists(std::string infile, std::string prefix, std::string text, bool drawStatBox = true, int save = 0) {
   int colors[6] = {1, 6, 4, 7, 2, 9};
   std::string types[6] = {"B", "C", "D", "E", "F", "G"};
   std::string names[3] = {"ratio20", "Z2", "W2"};
@@ -2237,10 +2229,7 @@ void PlotFiveHists(std::string infile,
   }
 }
 
-void PlotHistCorrResults(std::string infile, 
-			 std::string text,
-			 std::string prefixF, 
-			 int save = 0) {
+void PlotHistCorrResults(std::string infile, std::string text, std::string prefixF, int save = 0) {
   std::string name[5] = {"Eta1Bf", "Eta2Bf", "Eta1Af", "Eta2Af", "Cvg0"};
   std::string title[5] = {"Mean at the start of itertions",
                           "Median at the start of itertions",
@@ -2606,12 +2595,8 @@ void PlotHistCorrFactor(char* infile,
   }
 }
 
-void PlotHistCorrAsymmetry(char* infile,
-			   std::string text,
-			   std::string prefixF = "", 
-			   int depth = -1,
-			   int iformat = 0, 
-			   int save = 0) {
+void PlotHistCorrAsymmetry(
+    char* infile, std::string text, std::string prefixF = "", int depth = -1, int iformat = 0, int save = 0) {
   std::map<int, cfactors> cfacs;
   int etamin(100), etamax(-100), maxdepth(0);
   double scale(1.0);
@@ -3481,10 +3466,7 @@ void PlotHistCorrDFactors(char* infile1,
   }
 }
 
-void PlotHistCorrSys(std::string infilec, 
-		     int conds, 
-		     std::string text, 
-		     int save = 0) {
+void PlotHistCorrSys(std::string infilec, int conds, std::string text, int save = 0) {
   char fname[100];
   int iformat(0);
   sprintf(fname, "%s_cond0.txt", infilec.c_str());
@@ -3604,10 +3586,7 @@ void PlotHistCorrSys(std::string infilec,
   }
 }
 
-void PlotHistCorrLumis(std::string infilec, 
-		       int conds, 
-		       double lumi, 
-		       int save = 0) {
+void PlotHistCorrLumis(std::string infilec, int conds, double lumi, int save = 0) {
   char fname[100];
   int iformat(0);
   sprintf(fname, "%s_0.txt", infilec.c_str());
@@ -4504,11 +4483,7 @@ void PlotPropertyHist(const char* infile,
   }
 }
 
-void PlotMeanError(const std::string infilest, 
-		   int reg = 3, 
-		   bool resol = false, 
-		   int save = 0, 
-		   bool debug = false) {
+void PlotMeanError(const std::string infilest, int reg = 3, bool resol = false, int save = 0, bool debug = false) {
   bool ok(false);
   const int ntypmx = 3;
   const int nregmx = 4;
@@ -4813,10 +4788,7 @@ void PlotDepthCorrFactor(char* infile,
   }
 }
 
-void DrawHistPhiSymmetry(TH1D* hist0, 
-			 bool isRealData, 
-			 bool drawStatBox, 
-			 bool save=false) {
+void DrawHistPhiSymmetry(TH1D* hist0, bool isRealData, bool drawStatBox, bool save = false) {
   char name[30], namep[30], txt1[30];
   TH1D* hist = (TH1D*)(hist0->Clone());
   sprintf(namep, "c_%s", hist->GetName());
@@ -4859,11 +4831,8 @@ void DrawHistPhiSymmetry(TH1D* hist0,
   }
 }
 
-void PlotPhiSymmetryResults(char* infile, 
-                            bool isRealData = true, 
-                            bool drawStatBox = true, 
-                            bool debug = false, 
-                            bool save = false) {
+void PlotPhiSymmetryResults(
+    char* infile, bool isRealData = true, bool drawStatBox = true, bool debug = false, bool save = false) {
   const int maxDepthHB(4), maxDepthHE(7);
   const double cfacMin(0.70), cfacMax(1.5);
   const int nbin = (100.0 * (cfacMax - cfacMin));
@@ -4987,7 +4956,7 @@ void PlotHistCorrRatio(char* infile1,
                        bool isRealData = true,
                        const char* year = "2024",
                        int iformat = 0,
-		       int range = 2,
+                       int range = 2,
                        int save = 0) {
   std::map<int, cfactors> cfacs[2];
   std::vector<std::string> texts;

--- a/Calibration/HcalCalibAlgos/macros/CalibFitPlots.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibFitPlots.C
@@ -13,22 +13,22 @@
 //                debug=false
 //
 //             Same as FitHistExtend with summary of each ieta/depth
-//  FitHistExtended2(infile, outfile, prefix, numb, append, iname, debug);
-//      Defaults: numb=50, append=true, iname=3, debug=false
+//  FitHistExtended2(infile, outfile, prefix, numb, type, append, iname, debug);
+//      Defaults: numb=50, type=0, append=true, iname=3, debug=false
 //
 //             For RBX dependence in sets of histograms from CalibMonitor
 //  FitHistRBX(infile, outfile, prefix, append, iname);
-//      Defaults: append=true, iname=2
+//      Defaults: append=true, iname=3
 //
 //             For plotting stored histograms from FitHist's
 //  PlotHist(infile, prefix, text, modePlot, kopt, lumi, ener, isRealData,
 //           drawStatBox, save);
-//      Defaults: modePlot=4, kopt=100, lumi=0, ener=13, isRealData=false,
+//      Defaults: modePlot=4, kopt=100, lumi=0, ener=13.0, isRealData=false,
 //                drawStatBox=true, save=0
 //
 //             For plotting histograms corresponding to individual ieta's
 //  PlotHistEta(infile, prefix, text, iene, numb, ieta, lumi, ener, isRealData,
-//           drawStatBox, save);
+//              drawStatBox, save);
 //      Defaults iene=3, numb=50, ieta=0, lumi=0, ener=13.0, isRealData=false,
 //                drawStatBox=true, save=0
 //
@@ -42,7 +42,7 @@
 //             prefixes residing in the same file with approrprate text
 //  PlotTwoHists(infile, prefix1, text1, prefix2, text2, text0, type, iname,
 //               lumi, ener, drawStatBox, save);
-//      Defaults: type=0; iname=2; lumi=0; ener=13; drawStatBox=true;
+//      Defaults: type=0; iname=3; lumi=0; ener=13.0; drawStatBox=0;
 //                save=0;
 //      Note prefixN, textN have the same meaning as prefix and text for set N
 //           text0 is the text for general title added within ()
@@ -53,7 +53,7 @@
 //  PlotFiveHists(infile, text0, prefix0, type, iname, drawStatBox, normalize,
 //                save, prefix1, text1, prefix2, text2, prefix3, text3,
 //                 prefix4, text4, prefix5, text5);
-//      Defaults: type=0; iname=0; drawStatBox=true; normalize=false;
+//      Defaults: type=0; iname=3; drawStatBox=0; normalize=false;
 //                save=0; prefixN=""; textN=""; (for N > 0)
 //      Note prefixN, textN have the same meaning as prefix and text for set N
 //           text0 is the text for general title added within ()
@@ -66,14 +66,14 @@
 //             For plotting correction factors
 //  PlotHistCorrFactor(infile, text, prefixF, scale, nmin, isRealData,
 //                     drawStatBox, iformat, save);
-//      Defaults: isRealData=true, drwaStatBox=false, nmin=100, iformat=0,
-//                save=0
+//      Defaults: scale=1.0, nmin=100, isRealData=true, drwaStatBox=false,
+//                iformat=0, save=0
 //
 //             For plotting correction factors for a sigle depth
 //  PlotHistCorrFactor(infile, text, depth, prefixF, scale, nmin, isRealData,
 //                     drawStatBox, iformat, save);
-//      Defaults: isRealData=true, drwaStatBox=false, nmin=100, iformat=0,
-//                save=0
+//      Defaults: scale=1.0, nmin=100, isRealData=true, drwaStatBox=false,
+//                iformat=0, save=0
 //
 //             For plotting (fractional) asymmetry in the correction factors
 //
@@ -85,20 +85,23 @@
 //
 //  PlotHistCorrFactors(infile1, text1, infile2, text2, infile3, text3,
 //                      infile4, text4, infile5, text5, prefixF, ratio,
-//                      drawStatBox, nmin, isRealData, year, iformat, save)
+//                      drawStatBox, nmin, isRealData, year, iformat, range,
+//                      save)
 //      Defaults: ratio=false, drawStatBox=true, nmin=100, isRealData=false,
-//                year="2024", iformat=0, save=0
+//                year="2025", iformat=0, range=1, save=0
 //
 //  PlotHistCorr2Factors(infile1, text1, infile2, text2, depth, prefixF, ratio,
-//                      drawStatBox, nmin, isRealData, year, iformat, save)
+//                      drawStatBox, nmin, isRealData, year, iformat, range,
+//                      save)
 //      Defaults: ratio=true, drawStatBox=false, nmin=100, isRealData=true,
-//                year="2024", iformat=0, save=0
+//                year="2025", iformat=0, range=1, save=0
 //
 //  PlotHistCorrDFactors(infile1, text1, infile2, text2, infile3, text3,
 //                      infile4, text4, infile5, text5, depth, prefixF, ratio,
-//                      drawStatBox, nmin, isRealData, year, iformat, save)
+//                      drawStatBox, nmin, isRealData, year, iformat, range,
+//                      save)
 //      Defaults: ratio=true, drawStatBox=false, nmin=100, isRealData=true,
-//                year="2024", iformat=0, save=0
+//                year="2025", iformat=0, range=0, save=0
 //
 //             For plotting correction factors including systematics
 //  PlotHistCorrSys(infilec, conds, text, save)
@@ -115,8 +118,8 @@
 //
 //             For plotting difference of correction factors for a given depth
 //  PlotHistCorrDepth(infile1, infile2, text1, text2, depth, iformat1, iformat2,
-//                    save)
-//      Defaults: iformat1=0, iformat2=0, save=0
+//                    save, debug)
+//      Defaults: iformat1=0, iformat2=0, save=0, debug=1
 //
 //             For plotting four histograms
 //  PlotFourHists(infile, prefix0, type, drawStatBox, normalize, save, prefix1,
@@ -126,26 +129,26 @@
 //
 //            For plotting PU corrected histograms (o/p of CalibPlotCombine)
 //  PlotPUCorrHists(infile, prefix drawStatBox, approve, save)
-//      Defaults: infile = "corrfac.root", prefix = "", drawStatBox = 0,
-//                approve = true, save = 0
+//      Defaults: infile="corrfac.root", prefix="", drawStatBox=0,
+//                approve=true, save=0
 //
 //             For plotting histograms obtained from fits to PU correction
 //             (o/p of CalibFitPU) for a given ieta using 2D/profile/Graphs
 //  PlotHistCorr(infile, prefix, text, eta, mode, drawStatBox, save)
-//      Defaults eta = 0 (all ieta values), mode = 1 (profile histograms),
-//               drawStatBox = true, save = 0
+//      Defaults eta=0 (all ieta values), mode=1 (profile histograms),
+//               drawStatBox=true, save=0
 //
 //             For plotting histograms created by CalibPlotProperties
 //  PlotPropertyHist(infile, prefix, text, etaMax, lumi, ener, isRealData,
 //		     drawStatBox, save)
-//      Defaults etaMax = 25 (draws for eta = 1 .. etaMax), lumi = 0,
-//               ener = 13.0, isRealData = false,  drawStatBox = true, save = 0
+//      Defaults etaMax=25 (draws for eta = 1 .. etaMax), lumi=0,
+//               ener=13.0, isRealData=false,  drawStatBox=true, save=0
 //
 //            For plotting mean response and resolution as a function of
 //            particle momentum
 //  PlotMeanError(infilest, region, resol, save, debug)
-//      Defaults region = 3 (overall), resol = false (response), save = 0,
-//               debug = false
+//      Defaults region=3 (overall), resol=false (response), save=0,
+//               debug=false
 //      Format of the input file:
 //       # of energy points, # of types, # of regions
 //       Then for each type, energy point
@@ -155,18 +158,26 @@
 //
 //            For plotting depth dependent correction factors from muon study
 //  PlotDepthCorrFactor(infile, text, prefix, isRealData, drawStatBox, save)
-//      Defaults prefix = "", isRealData = true, drawStatBox = true, save = 0
+//      Defaults prefix="", isRealData=true, drawStatBox=true, save=0
 //      Format for the input file: ieta and correcrion factor with its
 //             uncertainty for each depth
+//
+//            For plotting histogram defined in "hist0" of phisymmetry
+//  DrawHistPhiSymmetry(hist0, isRealData, drawStatBox, save) 
+//      Defaults save=false
+//
+//            For plotting phisymmetry results
+//  PlotPhiSymmetryResults(char* infile, isRealData, drawStatBox, debug, save)
+//      Defaults isRealData=true, drawStatBox=true, debug=false, save=false
 //
 //            For plotting ratio of correction factors as defined in a file
 //            give by infileX for 2 depths (depth1, depth2) as a function of
 //            ieta obaned from 2 sources of data (defined by text1 and text2)
 //  PlotHistCorrRatio(infile1, text1, infile2, text2, depth1, depth2, prefix,
 //                    text0, etaMin, etaMax, doFit, isRealData, year, iformat,
-//                    save)
-//      Defaults etaMin = -1, etaMax = -1, doFit = true, isRealData = true,
-//               year = "2024", iformat = 0, save = 0
+//                    range, save)
+//      Defaults etaMin=-1, etaMax=-1, doFit=true, isRealData=true,
+//               year="2025", iformat=0, range=2, save=0
 //      text0 is a general description common to both sets of corr factors
 //      etaMin < 0 and etaMax > 0 will take ieta range from -etaMax to +etaMax;
 //      etaMin > 0 will select ieta's where |ieta| is greater than etaMin
@@ -235,6 +246,11 @@
 //                           false = response (false)
 //  iformat  (int)         = flag if it is created by standard (0) or by
 //                           Marina's (1) code
+//  range    (int)         = sets the range for y-axis
+//                           if (range == 0) ylow = 0.8; yhigh = 1.2;
+//                           else if (range == 1) ylow = 0.5; yhigh = 1.5;
+//                           else if (range == 2) ylow = 0.0; yhigh = 3.0;
+//                           else ylow = 0.0; yhigh = 2.0;
 //////////////////////////////////////////////////////////////////////////////
 
 #include <TCanvas.h>
@@ -1288,7 +1304,11 @@ void FitHistExtended2(const char* infile,
   }
 }
 
-void FitHistRBX(const char* infile, const char* outfile, std::string prefix, bool append = true, int iname = 3) {
+void FitHistRBX(const char* infile, 
+		const char* outfile, 
+		std::string prefix, 
+		bool append = true, 
+		int iname = 3) {
   std::string sname("RBX"), lname("R");
   int numb(18);
   bool debug(false);
@@ -1684,7 +1704,11 @@ void PlotHistEta(const char* infile,
   }
 }
 
-void PlotHists(std::string infile, std::string prefix, std::string text, bool drawStatBox = true, int save = 0) {
+void PlotHists(std::string infile, 
+	       std::string prefix, 
+	       std::string text, 
+	       bool drawStatBox = true, 
+	       int save = 0) {
   int colors[6] = {1, 6, 4, 7, 2, 9};
   std::string types[6] = {"B", "C", "D", "E", "F", "G"};
   std::string names[3] = {"ratio20", "Z2", "W2"};
@@ -2213,7 +2237,10 @@ void PlotFiveHists(std::string infile,
   }
 }
 
-void PlotHistCorrResults(std::string infile, std::string text, std::string prefixF, int save = 0) {
+void PlotHistCorrResults(std::string infile, 
+			 std::string text,
+			 std::string prefixF, 
+			 int save = 0) {
   std::string name[5] = {"Eta1Bf", "Eta2Bf", "Eta1Af", "Eta2Af", "Cvg0"};
   std::string title[5] = {"Mean at the start of itertions",
                           "Median at the start of itertions",
@@ -2579,8 +2606,12 @@ void PlotHistCorrFactor(char* infile,
   }
 }
 
-void PlotHistCorrAsymmetry(
-    char* infile, std::string text, std::string prefixF = "", int depth = -1, int iformat = 0, int save = 0) {
+void PlotHistCorrAsymmetry(char* infile,
+			   std::string text,
+			   std::string prefixF = "", 
+			   int depth = -1,
+			   int iformat = 0, 
+			   int save = 0) {
   std::map<int, cfactors> cfacs;
   int etamin(100), etamax(-100), maxdepth(0);
   double scale(1.0);
@@ -2697,7 +2728,7 @@ void PlotHistCorrFactors(char* infile1,
                          bool drawStatBox = true,
                          int nmin = 100,
                          bool isRealData = false,
-                         const char* year = "2024",
+                         const char* year = "2025",
                          int iformat = 0,
                          int range = 1,
                          int save = 0) {
@@ -2754,6 +2785,9 @@ void PlotHistCorrFactors(char* infile1,
     } else if (range == 1) {
       ylow = 0.5;
       yhigh = 1.5;
+    } else if (range == 2) {
+      ylow = 0.0;
+      yhigh = 3.0;
     } else {
       ylow = 0.0;
       yhigh = 2.0;
@@ -2964,7 +2998,7 @@ void PlotHistCorr2Factors(char* infile1,
                           bool drawStatBox = false,
                           int nmin = 100,
                           bool isRealData = true,
-                          const char* year = "2024",
+                          const char* year = "2025",
                           int iformat = 0,
                           int range = 1,
                           int save = 0) {
@@ -3000,6 +3034,9 @@ void PlotHistCorr2Factors(char* infile1,
     } else if (range == 1) {
       ylow = 0.5;
       yhigh = 1.5;
+    } else if (range == 2) {
+      ylow = 0.0;
+      yhigh = 3.0;
     } else {
       ylow = 0.0;
       yhigh = 2.0;
@@ -3198,7 +3235,7 @@ void PlotHistCorrDFactors(char* infile1,
                           bool drawStatBox = false,
                           int nmin = 100,
                           bool isRealData = true,
-                          const char* year = "2024",
+                          const char* year = "2025",
                           int iformat = 0,
                           int range = 0,
                           int save = 0) {
@@ -3255,6 +3292,9 @@ void PlotHistCorrDFactors(char* infile1,
     } else if (range == 1) {
       ylow = 0.5;
       yhigh = 1.5;
+    } else if (range == 2) {
+      ylow = 0.0;
+      yhigh = 3.0;
     } else {
       ylow = 0.0;
       yhigh = 2.0;
@@ -3441,7 +3481,10 @@ void PlotHistCorrDFactors(char* infile1,
   }
 }
 
-void PlotHistCorrSys(std::string infilec, int conds, std::string text, int save = 0) {
+void PlotHistCorrSys(std::string infilec, 
+		     int conds, 
+		     std::string text, 
+		     int save = 0) {
   char fname[100];
   int iformat(0);
   sprintf(fname, "%s_cond0.txt", infilec.c_str());
@@ -3561,7 +3604,10 @@ void PlotHistCorrSys(std::string infilec, int conds, std::string text, int save 
   }
 }
 
-void PlotHistCorrLumis(std::string infilec, int conds, double lumi, int save = 0) {
+void PlotHistCorrLumis(std::string infilec, 
+		       int conds, 
+		       double lumi, 
+		       int save = 0) {
   char fname[100];
   int iformat(0);
   sprintf(fname, "%s_0.txt", infilec.c_str());
@@ -4458,7 +4504,11 @@ void PlotPropertyHist(const char* infile,
   }
 }
 
-void PlotMeanError(const std::string infilest, int reg = 3, bool resol = false, int save = 0, bool debug = false) {
+void PlotMeanError(const std::string infilest, 
+		   int reg = 3, 
+		   bool resol = false, 
+		   int save = 0, 
+		   bool debug = false) {
   bool ok(false);
   const int ntypmx = 3;
   const int nregmx = 4;
@@ -4763,7 +4813,10 @@ void PlotDepthCorrFactor(char* infile,
   }
 }
 
-void DrawHistPhiSymmetry(TH1D* hist0, bool isRealData, bool drawStatBox, bool save) {
+void DrawHistPhiSymmetry(TH1D* hist0, 
+			 bool isRealData, 
+			 bool drawStatBox, 
+			 bool save=false) {
   char name[30], namep[30], txt1[30];
   TH1D* hist = (TH1D*)(hist0->Clone());
   sprintf(namep, "c_%s", hist->GetName());
@@ -4806,8 +4859,11 @@ void DrawHistPhiSymmetry(TH1D* hist0, bool isRealData, bool drawStatBox, bool sa
   }
 }
 
-void PlotPhiSymmetryResults(
-    char* infile, bool isRealData = true, bool drawStatBox = true, bool debug = false, bool save = false) {
+void PlotPhiSymmetryResults(char* infile, 
+                            bool isRealData = true, 
+                            bool drawStatBox = true, 
+                            bool debug = false, 
+                            bool save = false) {
   const int maxDepthHB(4), maxDepthHE(7);
   const double cfacMin(0.70), cfacMax(1.5);
   const int nbin = (100.0 * (cfacMax - cfacMin));
@@ -4931,6 +4987,7 @@ void PlotHistCorrRatio(char* infile1,
                        bool isRealData = true,
                        const char* year = "2024",
                        int iformat = 0,
+		       int range = 2,
                        int save = 0) {
   std::map<int, cfactors> cfacs[2];
   std::vector<std::string> texts;
@@ -4967,6 +5024,20 @@ void PlotHistCorrRatio(char* infile1,
     } else {
       gStyle->SetOptStat(0);
       gStyle->SetOptFit(0);
+    }
+    double ylow, yhigh;
+    if (range == 0) {
+      ylow = 0.8;
+      yhigh = 1.2;
+    } else if (range == 1) {
+      ylow = 0.5;
+      yhigh = 1.5;
+    } else if (range == 2) {
+      ylow = 0.0;
+      yhigh = 3.0;
+    } else {
+      ylow = 0.0;
+      yhigh = 2.0;
     }
     int colors[7] = {1, 6, 4, 7, 2, 9, 3};
     int mtype[7] = {20, 21, 22, 23, 24, 25, 26};
@@ -5018,7 +5089,7 @@ void PlotHistCorrRatio(char* infile1,
       h->GetYaxis()->SetLabelOffset(0.005);
       h->GetYaxis()->SetTitleSize(0.036);
       h->GetYaxis()->SetTitleOffset(1.20);
-      h->GetYaxis()->SetRangeUser(0.0, 3.0);
+      h->GetYaxis()->SetRangeUser(ylow, yhigh);
       if (doFit) {
         TObject* ob = gROOT->FindObject(name);
         if (ob)


### PR DESCRIPTION
#### PR description:

Update the calibration macro, which is used for IsoTrack calibration of HCAL

#### PR validation:

The macro is used in the calibration studies

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special