### PR TITLE
Allow defining valid range of Energy values for LHCInfoPerFill O2O

### DIFF
--- a/CondTools/RunInfo/interface/LHCInfoPerFillPopConSourceHandler.h
+++ b/CondTools/RunInfo/interface/LHCInfoPerFillPopConSourceHandler.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "CondCore/PopCon/interface/PopConSourceHandler.h"
 #include "CondFormats/RunInfo/interface/LHCInfoPerFill.h"
 #include "CondTools/RunInfo/interface/OMSAccess.h"
@@ -11,31 +13,64 @@ public:
   void getNewObjects() override;
   std::string id() const override;
 
-private:
+  bool isPayloadValid(const LHCInfoPerFill& payload) const;
+
+protected:
+  virtual std::unique_ptr<LHCInfoPerFill> findFillToProcess(cond::OMSService& oms,
+                                                            const boost::posix_time::ptime& nextFillSearchTime,
+                                                            bool inclusiveSearchTime);
   void addEmptyPayload(cond::Time_t iov);
 
   // Add payload to buffer and store corresponding lumiid IOV in m_timestampToLumiid map
   void addPayloadToBuffer(cond::OMSServiceResultRef& row);
   void convertBufferedIovsToLumiid(std::map<cond::Time_t, cond::Time_t> timestampToLumiid);
 
-  size_t getLumiData(const cond::OMSService& oms,
-                     unsigned short fillId,
-                     const boost::posix_time::ptime& beginFillTime,
-                     const boost::posix_time::ptime& endFillTime);
+  /**
+   * @return A tuple containing:
+   *         - cond::OMSServiceResult: The result of the luminosity query.
+   *         - bool: Indicates whether the query was successful.
+   *         - std::unique_ptr<cond::OMSServiceQuery>: Owner object for the query.
+   *           Query result resources are tied to its lifetime so it needs to be kept in the same scope.
+   */
+  virtual std::tuple<cond::OMSServiceResult, bool, std::unique_ptr<cond::OMSServiceQuery>> executeLumiQuery(
+      const cond::OMSService& oms,
+      unsigned short fillId,
+      const boost::posix_time::ptime& beginFillTime,
+      const boost::posix_time::ptime& endFillTime) const;
 
-  void getDipData(const cond::OMSService& oms,
-                  const boost::posix_time::ptime& beginFillTime,
-                  const boost::posix_time::ptime& endFillTime);
+  virtual void getLumiData(const cond::OMSService& oms,
+                           unsigned short fillId,
+                           const boost::posix_time::ptime& beginFillTime,
+                           const boost::posix_time::ptime& endFillTime);
 
-  bool getCTPPSData(cond::persistency::Session& session,
-                    const boost::posix_time::ptime& beginFillTime,
-                    const boost::posix_time::ptime& endFillTime);
+  virtual void getDipData(const cond::OMSService& oms,
+                          const boost::posix_time::ptime& beginFillTime,
+                          const boost::posix_time::ptime& endFillTime);
 
-  bool getEcalData(cond::persistency::Session& session,
-                   const boost::posix_time::ptime& lowerTime,
-                   const boost::posix_time::ptime& upperTime);
+  virtual bool getCTPPSData(cond::persistency::Session& session,
+                            const boost::posix_time::ptime& beginFillTime,
+                            const boost::posix_time::ptime& endFillTime);
 
-private:
+  virtual bool getEcalData(cond::persistency::Session& session,
+                           const boost::posix_time::ptime& lowerTime,
+                           const boost::posix_time::ptime& upperTime);
+
+  bool getCTPPSDataImpl(cond::persistency::Session& session,
+                        const boost::posix_time::ptime& beginFillTime,
+                        const boost::posix_time::ptime& endFillTime);
+
+  bool getEcalDataImpl(cond::persistency::Session& session,
+                       const boost::posix_time::ptime& lowerTime,
+                       const boost::posix_time::ptime& upperTime);
+
+protected:
+  virtual std::tuple<cond::persistency::Session, cond::persistency::Session> createSubsystemDbSessions() const;
+  virtual cond::Time_t getNextFillSearchTimestamp(cond::Time_t lastSince) const;
+  virtual cond::Time_t handleIfNewTagAndGetLastSince();
+  virtual void fetchLastPayload();
+  virtual boost::posix_time::ptime getExecutionTime() const;
+  void populateIovs();
+  void handleInvalidPayloads();
   bool m_debug;
   // starting date for sampling
   boost::posix_time::ptime m_startTime;
@@ -46,6 +81,11 @@ private:
   std::string m_connectionString, m_ecalConnectionString;
   std::string m_authpath;
   std::string m_omsBaseUrl;
+
+  float m_minEnergy;  // [GeV], applicable in duringFill mode only
+  float m_maxEnergy;  // [GeV], applicable in duringFill mode only
+  bool m_throwOnInvalid = true;
+
   std::unique_ptr<LHCInfoPerFill> m_fillPayload;
   std::shared_ptr<LHCInfoPerFill> m_prevPayload;
   std::vector<std::pair<cond::Time_t, std::shared_ptr<LHCInfoPerFill>>> m_tmpBuffer;

--- a/CondTools/RunInfo/interface/LHCInfoPerLSPopConSourceHandler.h
+++ b/CondTools/RunInfo/interface/LHCInfoPerLSPopConSourceHandler.h
@@ -20,7 +20,7 @@ public:
 
 private:
   void populateIovs();
-  void filterInvalidPayloads();
+  void handleInvalidPayloads();
   bool isPayloadValid(const LHCInfoPerLS& payload) const;
   void addEmptyPayload(cond::Time_t iov);
   void addDefaultPayload(cond::Time_t iov, unsigned short fill, const cond::OMSService& oms);
@@ -62,15 +62,16 @@ private:
   float m_maxBetaStar;       // meters
   float m_minCrossingAngle;  // urad
   float m_maxCrossingAngle;  // urad
+  bool m_throwOnInvalid;     // duringFill: whether to throw exception or filter out invalid payloads
 
   std::unique_ptr<LHCInfoPerLS> m_fillPayload;
   std::shared_ptr<LHCInfoPerLS> m_prevPayload;
-  cond::Time_t m_startFillTime;
-  cond::Time_t m_endFillTime;
-  cond::Time_t m_prevEndFillTime = 0;
-  cond::Time_t m_prevStartFillTime;
-  cond::Time_t m_startStableBeamTime;
-  cond::Time_t m_endStableBeamTime;
+  cond::Time_t m_startFillTime{};
+  cond::Time_t m_endFillTime{};
+  cond::Time_t m_prevEndFillTime{};
+  cond::Time_t m_prevStartFillTime{};
+  cond::Time_t m_startStableBeamTime{};
+  cond::Time_t m_endStableBeamTime{};
   std::vector<std::pair<cond::Time_t, std::shared_ptr<LHCInfoPerLS>>> m_tmpBuffer;
   bool m_lastPayloadEmpty = false;
   // mapping of lumisections IDs (pairs of runnumber an LS number) found in OMS to

--- a/CondTools/RunInfo/interface/TestLHCInfoPerFillPopConSourceHandler.h
+++ b/CondTools/RunInfo/interface/TestLHCInfoPerFillPopConSourceHandler.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "CondFormats/RunInfo/interface/LHCInfoPerFill.h"
+#include "CondTools/RunInfo/interface/LHCInfoPerFillPopConSourceHandler.h"
+#include "CondTools/RunInfo/interface/OMSAccess.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include <map>
+#include <memory>
+#include <string>
+#include <tuple>
+
+class TestLHCInfoPerFillPopConSourceHandler : public LHCInfoPerFillPopConSourceHandler {
+public:
+  TestLHCInfoPerFillPopConSourceHandler(edm::ParameterSet const& pset);
+  ~TestLHCInfoPerFillPopConSourceHandler() override = default;
+
+  std::vector<std::pair<cond::Time_t /*timestamp*/, std::shared_ptr<LHCInfoPerFill>>> mockOmsFills;
+  std::map<unsigned short /*fillNr*/, cond::OMSServiceResult> mockLumiData;
+  boost::posix_time::ptime mockExecutionTime;
+
+  Container& iovs() { return m_iovs; }
+
+protected:
+  std::unique_ptr<LHCInfoPerFill> findFillToProcess(cond::OMSService& oms,
+                                                    const boost::posix_time::ptime& nextFillSearchTime,
+                                                    bool inclusiveSearchTime) override;
+
+  cond::Time_t handleIfNewTagAndGetLastSince() override;
+
+  void fetchLastPayload() override {};
+
+  boost::posix_time::ptime getExecutionTime() const override;
+
+  std::tuple<cond::persistency::Session, cond::persistency::Session> createSubsystemDbSessions() const override;
+
+  void getDipData(const cond::OMSService& oms,
+                  const boost::posix_time::ptime& beginFillTime,
+                  const boost::posix_time::ptime& endFillTime) override {};
+
+  bool getCTPPSData(cond::persistency::Session& session,
+                    const boost::posix_time::ptime& beginFillTime,
+                    const boost::posix_time::ptime& endFillTime) override {
+    return true;
+  };
+
+  bool getEcalData(cond::persistency::Session& session,
+                   const boost::posix_time::ptime& lowerTime,
+                   const boost::posix_time::ptime& upperTime) override {
+    return true;
+  };
+
+  std::tuple<cond::OMSServiceResult, bool, std::unique_ptr<cond::OMSServiceQuery>> executeLumiQuery(
+      const cond::OMSService& oms,
+      unsigned short fillId,
+      const boost::posix_time::ptime& beginFillTime,
+      const boost::posix_time::ptime& endFillTime) const override;
+};

--- a/CondTools/RunInfo/python/LHCInfoPerFillPopConAnalyzer_cfg.py
+++ b/CondTools/RunInfo/python/LHCInfoPerFillPopConAnalyzer_cfg.py
@@ -93,6 +93,19 @@ options.register( 'frontierKey'
                   )
 
 
+options.register('minEnergy',  450  
+                , VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.float
+                , """duringFill only: [GeV] min value of the range of valid values (inclusive).
+                     If the value is outside of this range the payload is not uploaded""")
+options.register('maxEnergy',  8000.
+                , VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.float
+                , """duringFill only: [GeV] max value of the range of valid values (inclusive).
+                     If the value is outside of this range the payload is not uploaded""")
+options.register('throwOnInvalid', False,
+                VarParsing.VarParsing.multiplicity.singleton,
+                VarParsing.VarParsing.varType.bool,
+                "duringFill only: If true, throw on invalid payloads; if false, filter them out.")
+
 # so far there was no need to use option, added just in case
 options.register( 'authenticationPath'
                 , ""
@@ -173,7 +186,10 @@ process.Test1 = cms.EDAnalyzer("LHCInfoPerFillPopConAnalyzer" if options.mode ==
                                    ecalConnectionString = cms.untracked.string(options.ecalConnection),
                                    omsBaseUrl = cms.untracked.string(options.oms),
                                    authenticationPath = cms.untracked.string(options.authenticationPath),
-                                   debug=cms.untracked.bool(False)
+                                   debug=cms.untracked.bool(False),
+                                   minEnergy = cms.untracked.double(options.minEnergy),
+                                   maxEnergy = cms.untracked.double(options.maxEnergy),
+                                   throwOnInvalid = cms.untracked.bool(options.throwOnInvalid)
                                ),
                                loggingOn = cms.untracked.bool(True),
                                IsDestDbCheckedInQueryLog = cms.untracked.bool(False)

--- a/CondTools/RunInfo/python/LHCInfoPerLSPopConAnalyzer_cfg.py
+++ b/CondTools/RunInfo/python/LHCInfoPerLSPopConAnalyzer_cfg.py
@@ -136,20 +136,24 @@ options.register( 'defaultBetaY'
 # it's unlikely to ever use values different from the defaults, added as a parameter just in case
 options.register('minBetaStar',  0.1 
                 , VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.float
-                , """duringFill only: [meters] min value of the range of valid values.
+                , """duringFill only: [meters] min value of the range of valid values (inclusive).
                      If the value is outside of this range the payload is not uploaded""")
 options.register('maxBetaStar',  100.
                 , VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.float
-                , """duringFill only: [meters] min value of the range of valid values.
+                , """duringFill only: [meters] max value of the range of valid values (inclusive).
                      If the value is outside of this range the payload is not uploaded""")
 options.register('minCrossingAngle',  10.
                 , VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.float
-                , """duringFill only: [urad] min value of the range of valid values.
+                , """duringFill only: [urad] min value of the range of valid values (inclusive).
                      If the value is outside of this range the payload is not uploaded""")
 options.register('maxCrossingAngle',  500.
                 , VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.float
-                , """duringFill only: [urad] min value of the range of valid values.
+                , """duringFill only: [urad] max value of the range of valid values (inclusive).
                      If the value is outside of this range the payload is not uploaded""")
+options.register('throwOnInvalid', False,
+                VarParsing.VarParsing.multiplicity.singleton,
+                VarParsing.VarParsing.varType.bool,
+                "duringFill only: If true, throw on invalid payloads; if false, filter them out.")
 
 # as the previous options, so far there was no need to use option, added just in case
 options.register( 'authenticationPath'
@@ -164,6 +168,8 @@ if options.mode is None:
   raise ValueError("mode argument not provided. Supported modes are: duringFill endFill")
 if options.mode not in ("duringFill", "endFill"):
   raise ValueError("Wrong mode argument. Supported modes are: duringFill endFill")
+if options.throwOnInvalid and options.mode != "duringFill":
+  raise ValueError("throwOnInvalid option can be True only in duringFill mode")
 
 CondDBConnection = CondDB.clone( connect = cms.string( options.destinationConnection ) )
 CondDBConnection.DBParameters.messageLevel = cms.untracked.int32( options.messageLevel )
@@ -241,6 +247,7 @@ process.Test1 = cms.EDAnalyzer(("LHCInfoPerLSPopConAnalyzer" if options.mode == 
                                    maxBetaStar = cms.untracked.double(options.maxBetaStar),
                                    minCrossingAngle = cms.untracked.double(options.minCrossingAngle),
                                    maxCrossingAngle = cms.untracked.double(options.maxCrossingAngle),
+                                   throwOnInvalid = cms.untracked.bool(options.throwOnInvalid)
                                ),
                                loggingOn = cms.untracked.bool(True),
                                IsDestDbCheckedInQueryLog = cms.untracked.bool(False)

--- a/CondTools/RunInfo/src/LHCInfoPerFillPopConSourceHandler.cc
+++ b/CondTools/RunInfo/src/LHCInfoPerFillPopConSourceHandler.cc
@@ -107,6 +107,13 @@ namespace theLHCInfoPerFillImpl {
       targetPayload->setEndTime(beamDumpTime);
       targetPayload->setInjectionScheme(injectionScheme);
       ret = true;
+
+      if (energy <= 0) {
+        // only log an error, do not fail the payload creation, the logic of skipping payloads with invalid energy is handled elsewhere
+        edm::LogError("LHCInfoPerFillPopConSourceHandler")
+            << "Received non-positive energy from OMS for fill " << currentFill << ": " << energy
+            << " GeV, string value: '" << row.get<std::string>("energy") << "'.";
+      }
     }
     return ret;
   }
@@ -204,6 +211,9 @@ LHCInfoPerFillPopConSourceHandler::LHCInfoPerFillPopConSourceHandler(edm::Parame
       m_ecalConnectionString(pset.getUntrackedParameter<std::string>("ecalConnectionString", "")),
       m_authpath(pset.getUntrackedParameter<std::string>("authenticationPath", "")),
       m_omsBaseUrl(pset.getUntrackedParameter<std::string>("omsBaseUrl", "")),
+      m_minEnergy(pset.getUntrackedParameter<double>("minEnergy", 450.)),
+      m_maxEnergy(pset.getUntrackedParameter<double>("maxEnergy", 8000.)),
+      m_throwOnInvalid(pset.getUntrackedParameter<bool>("throwOnInvalid", false)),
       m_fillPayload(),
       m_prevPayload(),
       m_tmpBuffer() {
@@ -220,7 +230,66 @@ LHCInfoPerFillPopConSourceHandler::LHCInfoPerFillPopConSourceHandler(edm::Parame
 }
 
 void LHCInfoPerFillPopConSourceHandler::getNewObjects() {
-  //if a new tag is created, transfer fake fill from 1 to the first fill for the first time
+  populateIovs();
+  if (!m_endFillMode) {  // duringFill mode
+    handleInvalidPayloads();
+  }
+}
+
+void LHCInfoPerFillPopConSourceHandler::handleInvalidPayloads() {
+  // note: at the moment used only in duringFill mode so the m_iovs is quaranteed to have size() <= 1
+  // but iterating through the whole map is implemented just in case the way it's used changes
+  auto it = m_iovs.begin();
+  while (it != m_iovs.end()) {
+    std::stringstream payloadData;
+    payloadData << "Fill = " << it->second->fillNumber() << ", Energy = " << it->second->energy();
+    if (!isPayloadValid(*(it->second))) {
+      // define the message and then either throw or print log and filter out
+      std::string msg = "Skipping upload of payload with invalid values: " + payloadData.str();
+      if (m_throwOnInvalid) {
+        throw cms::Exception("LHCInfoPerFillPopConSourceHandler") << msg;
+      } else {
+        edm::LogWarning(m_name) << msg;
+      }
+      // filter out (erase) invalid payloads
+      m_iovs.erase(it++);  // note: post-increment necessary to avoid using invalidated iterators
+    } else {
+      edm::LogInfo(m_name) << "Payload to be uploaded: " << payloadData.str();
+      ++it;
+    }
+  }
+}
+
+bool LHCInfoPerFillPopConSourceHandler::isPayloadValid(const LHCInfoPerFill& payload) const {
+  return (m_minEnergy <= payload.energy() && payload.energy() <= m_maxEnergy);
+}
+
+std::tuple<cond::persistency::Session, cond::persistency::Session>
+LHCInfoPerFillPopConSourceHandler::createSubsystemDbSessions() const {
+  cond::persistency::ConnectionPool connection;
+  //configure the connection
+  if (m_debug) {
+    connection.setMessageVerbosity(coral::Debug);
+  } else {
+    connection.setMessageVerbosity(coral::Error);
+  }
+  connection.setAuthenticationPath(m_authpath);
+  connection.configure();
+  //create the sessions
+  cond::persistency::Session cttpsSession = connection.createSession(m_connectionString, false);
+  cond::persistency::Session ecalSession = connection.createSession(m_ecalConnectionString, false);
+  return std::make_tuple(std::move(cttpsSession), std::move(ecalSession));
+}
+
+cond::Time_t LHCInfoPerFillPopConSourceHandler::getNextFillSearchTimestamp(cond::Time_t lastSince) const {
+  cond::Time_t startTimestamp = m_startTime.is_not_a_date_time() ? 0 : cond::time::from_boost(m_startTime);
+  cond::Time_t nextFillSearchTimestamp =
+      std::max(startTimestamp, m_endFillMode ? lastSince : (m_prevPayload ? m_prevPayload->createTime() : 0));
+  return nextFillSearchTimestamp;
+}
+
+cond::Time_t LHCInfoPerFillPopConSourceHandler::handleIfNewTagAndGetLastSince() {
+  //print tag info
   if (tagInfo().size == 0) {
     edm::LogInfo(m_name) << "New tag " << tagInfo().name << "; from " << m_name << "::getNewObjects";
   } else {
@@ -234,48 +303,45 @@ void LHCInfoPerFillPopConSourceHandler::getNewObjects() {
 
   cond::Time_t lastSince = tagInfo().lastInterval.since;
   if (tagInfo().isEmpty()) {
-    // for a new or empty tag in endFill mode, an empty payload should be added on top with since=1
-    addEmptyPayload(1);
-    lastSince = 1;
-    if (!m_endFillMode) {
-      edm::LogInfo(m_name) << "Empty or new tag: uploading a default payload and ending the job";
-      return;
+    if (m_endFillMode) {
+      // for a new or empty tag in endFill mode, an empty payload should be added on top with since=1
+      addEmptyPayload(1);
+      lastSince = 1;
+    } else {
+      // in duringFill mode, we don't upload empty payloads to the empty tag
+      lastSince = 0;  // in duringFill mode, this value is not used when the tag is empty
     }
   } else {
     edm::LogInfo(m_name) << "The last Iov in tag " << tagInfo().name << " valid since " << lastSince << "from "
                          << m_name << "::getNewObjects";
   }
 
-  //retrieve the data from the relational database source
-  cond::persistency::ConnectionPool connection;
-  //configure the connection
-  if (m_debug) {
-    connection.setMessageVerbosity(coral::Debug);
-  } else {
-    connection.setMessageVerbosity(coral::Error);
-  }
-  connection.setAuthenticationPath(m_authpath);
-  connection.configure();
-  //create the sessions
-  cond::persistency::Session session = connection.createSession(m_connectionString, false);
-  cond::persistency::Session session2 = connection.createSession(m_ecalConnectionString, false);
-  // fetch last payload when available
+  return lastSince;
+}
+
+void LHCInfoPerFillPopConSourceHandler::fetchLastPayload() {
   if (!tagInfo().lastInterval.payloadId.empty()) {
     cond::persistency::Session session3 = dbSession();
     session3.transaction().start(true);
     m_prevPayload = session3.fetchPayload<LHCInfoPerFill>(tagInfo().lastInterval.payloadId);
     session3.transaction().commit();
   }
+}
 
-  boost::posix_time::ptime executionTime = boost::posix_time::second_clock::local_time();
-  cond::Time_t executionTimeIov = cond::time::from_boost(executionTime);
+boost::posix_time::ptime LHCInfoPerFillPopConSourceHandler::getExecutionTime() const {
+  return boost::posix_time::second_clock::local_time();
+}
 
-  cond::Time_t startTimestamp = m_startTime.is_not_a_date_time() ? 0 : cond::time::from_boost(m_startTime);
-  cond::Time_t nextFillSearchTimestamp =
-      std::max(startTimestamp, m_endFillMode ? lastSince : m_prevPayload->createTime());
-
+void LHCInfoPerFillPopConSourceHandler::populateIovs() {
+  cond::Time_t lastSince = handleIfNewTagAndGetLastSince();
+  fetchLastPayload();
+  cond::Time_t nextFillSearchTimestamp = getNextFillSearchTimestamp(lastSince);
   edm::LogInfo(m_name) << "Starting sampling at "
                        << boost::posix_time::to_simple_string(cond::time::to_boost(nextFillSearchTimestamp));
+
+  auto [cttpsSession, ecalSession] = createSubsystemDbSessions();
+  boost::posix_time::ptime executionTime = getExecutionTime();
+  cond::Time_t executionTimeIov = cond::time::from_boost(executionTime);
 
   while (true) {
     if (nextFillSearchTimestamp >= executionTimeIov) {
@@ -289,26 +355,12 @@ void LHCInfoPerFillPopConSourceHandler::getNewObjects() {
 
     cond::OMSService oms;
     oms.connect(m_omsBaseUrl);
-    auto query = oms.query("fills");
 
-    edm::LogInfo(m_name) << "Searching new fill after " << boost::posix_time::to_simple_string(nextFillSearchTime);
-    query->filterNotNull("start_stable_beam").filterNotNull("fill_number");
-    if (nextFillSearchTime > cond::time::to_boost(m_prevPayload->createTime())) {
-      query->filterGE("start_time", nextFillSearchTime);
-    } else {
-      query->filterGT("start_time", nextFillSearchTime);
-    }
+    bool inclusiveSearchTime =
+        nextFillSearchTime > cond::time::to_boost(m_prevPayload ? m_prevPayload->createTime() : 0);
+    m_fillPayload = findFillToProcess(oms, nextFillSearchTime, inclusiveSearchTime);
 
-    query->filterLT("start_time", m_endTime);
-    if (m_endFillMode)
-      query->filterNotNull("end_time");
-    else
-      query->filterEQ("end_time", cond::OMSServiceQuery::SNULL);
-
-    bool foundFill = query->execute();
-    if (foundFill)
-      foundFill = theLHCInfoPerFillImpl::makeFillPayload(m_fillPayload, query->result());
-    if (!foundFill) {
+    if (!m_fillPayload) {
       edm::LogInfo(m_name) << "No fill found - END of job.";
       break;
     }
@@ -335,12 +387,8 @@ void LHCInfoPerFillPopConSourceHandler::getNewObjects() {
         boost::posix_time::ptime flumiStart = cond::time::to_boost(m_tmpBuffer.front().first);
         boost::posix_time::ptime flumiStop = cond::time::to_boost(m_tmpBuffer.back().first);
         edm::LogInfo(m_name) << "First lumi starts at " << flumiStart << " last lumi starts at " << flumiStop;
-        session.transaction().start(true);
-        getCTPPSData(session, startSampleTime, endSampleTime);
-        session.transaction().commit();
-        session2.transaction().start(true);
-        getEcalData(session2, startSampleTime, endSampleTime);
-        session2.transaction().commit();
+        getCTPPSData(cttpsSession, startSampleTime, endSampleTime);
+        getEcalData(ecalSession, startSampleTime, endSampleTime);
       }
     }
 
@@ -350,14 +398,11 @@ void LHCInfoPerFillPopConSourceHandler::getNewObjects() {
             << "More than 1 payload buffered for writing in duringFill mode.\
           In this mode only up to 1 payload can be written";
       } else if (m_tmpBuffer.size() == 1) {
-        if (theLHCInfoPerFillImpl::comparePayloads(*(m_tmpBuffer.begin()->second), *m_prevPayload)) {
+        if (m_prevPayload && theLHCInfoPerFillImpl::comparePayloads(*(m_tmpBuffer.begin()->second), *m_prevPayload)) {
           m_tmpBuffer.clear();
           edm::LogInfo(m_name)
               << "The buffered payload has the same data as the previous payload in the tag. It will not be written.";
         }
-      } else if (m_tmpBuffer.empty()) {
-        addEmptyPayload(
-            cond::lhcInfoHelper::getFillLastLumiIOV(oms, lhcFill));  //the IOV doesn't matter when using OnlinePopCon
       }
       // In duringFill mode, convert the timestamp-type IOVs to lumiid-type IOVs
       // before transferring the payloads from the buffer to the final collection
@@ -377,14 +422,38 @@ void LHCInfoPerFillPopConSourceHandler::getNewObjects() {
     if (m_prevPayload->fillNumber() and !ongoingFill) {
       if (m_endFillMode) {
         addEmptyPayload(endFillTime);
-      } else {
-        addEmptyPayload(cond::lhcInfoHelper::getFillLastLumiIOV(oms, lhcFill));
       }
     }
   }
 }
 
 std::string LHCInfoPerFillPopConSourceHandler::id() const { return m_name; }
+
+std::unique_ptr<LHCInfoPerFill> LHCInfoPerFillPopConSourceHandler::findFillToProcess(
+    cond::OMSService& oms, const boost::posix_time::ptime& nextFillSearchTime, bool inclusiveSearchTime) {
+  oms.connect(m_omsBaseUrl);
+  auto query = oms.query("fills");
+
+  edm::LogInfo(m_name) << "Searching new fill after " << boost::posix_time::to_simple_string(nextFillSearchTime);
+  query->filterNotNull("start_stable_beam").filterNotNull("fill_number");
+  if (inclusiveSearchTime) {
+    query->filterGE("start_time", nextFillSearchTime);
+  } else {
+    query->filterGT("start_time", nextFillSearchTime);
+  }
+
+  query->filterLT("start_time", m_endTime);
+  if (m_endFillMode)
+    query->filterNotNull("end_time");
+  else
+    query->filterEQ("end_time", cond::OMSServiceQuery::SNULL);
+
+  bool foundFill = query->execute();
+  std::unique_ptr<LHCInfoPerFill> fillToBeProcessedPayload;
+  if (foundFill)
+    foundFill = theLHCInfoPerFillImpl::makeFillPayload(fillToBeProcessedPayload, query->result());
+  return fillToBeProcessedPayload;
+}
 
 void LHCInfoPerFillPopConSourceHandler::addEmptyPayload(cond::Time_t iov) {
   bool add = false;
@@ -438,10 +507,11 @@ void LHCInfoPerFillPopConSourceHandler::convertBufferedIovsToLumiid(
   }
 }
 
-size_t LHCInfoPerFillPopConSourceHandler::getLumiData(const cond::OMSService& oms,
-                                                      unsigned short fillId,
-                                                      const boost::posix_time::ptime& beginFillTime,
-                                                      const boost::posix_time::ptime& endFillTime) {
+std::tuple<cond::OMSServiceResult, bool, std::unique_ptr<cond::OMSServiceQuery>>
+LHCInfoPerFillPopConSourceHandler::executeLumiQuery(const cond::OMSService& oms,
+                                                    unsigned short fillId,
+                                                    const boost::posix_time::ptime& beginFillTime,
+                                                    const boost::posix_time::ptime& endFillTime) const {
   auto query = oms.query("lumisections");
   query->addOutputVars(
       {"start_time", "delivered_lumi", "recorded_lumi", "beams_stable", "run_number", "lumisection_number"});
@@ -449,22 +519,42 @@ size_t LHCInfoPerFillPopConSourceHandler::getLumiData(const cond::OMSService& om
   query->filterGT("start_time", beginFillTime).filterLT("start_time", endFillTime);
   query->filterEQ("beams_stable", "true");
   query->limit(cond::lhcInfoHelper::kLumisectionsQueryLimit);
-  if (query->execute()) {
-    auto queryResult = query->result();
-    edm::LogInfo(m_name) << "Found " << queryResult.size() << " lumisections with STABLE BEAM during the fill "
-                         << fillId;
 
-    if (!queryResult.empty()) {
-      if (m_endFillMode) {
-        auto firstRow = queryResult.front();
-        addPayloadToBuffer(firstRow);
-      }
-
-      auto lastRow = queryResult.back();
-      addPayloadToBuffer(lastRow);
-    }
+  bool executed = query->execute();
+  if (executed) {
+    return std::make_tuple(query->result(), true, std::move(query));
+  } else {
+    return std::make_tuple(cond::OMSServiceResult(), false, std::move(query));
   }
-  return 0;
+}
+
+void LHCInfoPerFillPopConSourceHandler::getLumiData(const cond::OMSService& oms,
+                                                    unsigned short fillId,
+                                                    const boost::posix_time::ptime& beginFillTime,
+                                                    const boost::posix_time::ptime& endFillTime) {
+  // keeping the query ownerObject in scope is necessary as the lifetime of the queryResult resources is tied to it
+  auto [queryResult, success, ownerObject] = executeLumiQuery(oms, fillId, beginFillTime, endFillTime);
+  if (!success) {
+    edm::LogError(m_name) << "Failed to execute luminosity query.";
+    return;
+  }
+  edm::LogInfo(m_name) << "Found " << queryResult.size() << " lumisections with STABLE BEAM during the fill " << fillId;
+
+  if (queryResult.empty()) {
+    edm::LogWarning(m_name) << "No lumisections with STABLE BEAM found during the fill " << fillId
+                            << ". No payload will be added to buffer for writing.";
+    return;
+  }
+
+  if (m_endFillMode) {
+    auto firstRow = queryResult.front();
+    addPayloadToBuffer(firstRow);
+  }
+
+  auto lastRow = queryResult.back();
+  addPayloadToBuffer(lastRow);
+
+  return;
 }
 
 void LHCInfoPerFillPopConSourceHandler::getDipData(const cond::OMSService& oms,
@@ -529,12 +619,21 @@ void LHCInfoPerFillPopConSourceHandler::getDipData(const cond::OMSService& oms,
   }
 }
 
-bool LHCInfoPerFillPopConSourceHandler::getCTPPSData(cond::persistency::Session& session,
+bool LHCInfoPerFillPopConSourceHandler::getCTPPSData(cond::persistency::Session& cttpsSession,
                                                      const boost::posix_time::ptime& beginFillTime,
                                                      const boost::posix_time::ptime& endFillTime) {
+  cttpsSession.transaction().start(true);
+  auto ret = getCTPPSDataImpl(cttpsSession, beginFillTime, endFillTime);
+  cttpsSession.transaction().commit();
+  return ret;
+}
+
+bool LHCInfoPerFillPopConSourceHandler::getCTPPSDataImpl(cond::persistency::Session& cttpsSession,
+                                                         const boost::posix_time::ptime& beginFillTime,
+                                                         const boost::posix_time::ptime& endFillTime) {
   //run the fifth query against the CTPPS schema
   //Initializing the CMS_CTP_CTPPS_COND schema.
-  coral::ISchema& CTPPS = session.coralSession().schema("CMS_PPS_SPECT_COND");
+  coral::ISchema& CTPPS = cttpsSession.coralSession().schema("CMS_PPS_SPECT_COND");
   //execute query for CTPPS Data
   std::unique_ptr<coral::IQuery> CTPPSDataQuery(CTPPS.newQuery());
   //FROM clause
@@ -636,12 +735,21 @@ bool LHCInfoPerFillPopConSourceHandler::getCTPPSData(cond::persistency::Session&
   return ret;
 }
 
-bool LHCInfoPerFillPopConSourceHandler::getEcalData(cond::persistency::Session& session,
+bool LHCInfoPerFillPopConSourceHandler::getEcalData(cond::persistency::Session& ecalSession,
                                                     const boost::posix_time::ptime& lowerTime,
                                                     const boost::posix_time::ptime& upperTime) {
+  ecalSession.transaction().start(true);
+  auto ret = getEcalDataImpl(ecalSession, lowerTime, upperTime);
+  ecalSession.transaction().commit();
+  return ret;
+}
+
+bool LHCInfoPerFillPopConSourceHandler::getEcalDataImpl(cond::persistency::Session& ecalSession,
+                                                        const boost::posix_time::ptime& lowerTime,
+                                                        const boost::posix_time::ptime& upperTime) {
   //run the sixth query against the CMS_DCS_ENV_PVSS_COND schema
   //Initializing the CMS_DCS_ENV_PVSS_COND schema.
-  coral::ISchema& ECAL = session.nominalSchema();
+  coral::ISchema& ECAL = ecalSession.nominalSchema();
   //start the transaction against the fill logging schema
   //execute query for ECAL Data
   std::unique_ptr<coral::IQuery> ECALDataQuery(ECAL.newQuery());

--- a/CondTools/RunInfo/src/TestLHCInfoPerFillPopConSourceHandler.cc
+++ b/CondTools/RunInfo/src/TestLHCInfoPerFillPopConSourceHandler.cc
@@ -1,0 +1,47 @@
+#include "CondTools/RunInfo/interface/TestLHCInfoPerFillPopConSourceHandler.h"
+#include <tuple>
+
+TestLHCInfoPerFillPopConSourceHandler::TestLHCInfoPerFillPopConSourceHandler(edm::ParameterSet const& pset)
+    : LHCInfoPerFillPopConSourceHandler(pset) {}
+
+std::unique_ptr<LHCInfoPerFill> TestLHCInfoPerFillPopConSourceHandler::findFillToProcess(
+    cond::OMSService& oms, const boost::posix_time::ptime& nextFillSearchTime, bool inclusiveSearchTime) {
+  for (auto& fill : mockOmsFills) {
+    auto fillStartTime = cond::time::to_boost(fill.first);
+    if (inclusiveSearchTime ? (fillStartTime >= nextFillSearchTime) : (fillStartTime > nextFillSearchTime)) {
+      auto fillPayload = std::make_unique<LHCInfoPerFill>(*fill.second);
+      return fillPayload;
+    }
+  }
+  return nullptr;
+}
+
+cond::Time_t TestLHCInfoPerFillPopConSourceHandler::handleIfNewTagAndGetLastSince() {
+  cond::Time_t lastSince = 0;
+  if (m_endFillMode) {
+    addEmptyPayload(1);
+    lastSince = 1;
+  } else {
+    lastSince = 0;
+  }
+  return lastSince;
+}
+
+boost::posix_time::ptime TestLHCInfoPerFillPopConSourceHandler::getExecutionTime() const { return mockExecutionTime; }
+
+std::tuple<cond::persistency::Session, cond::persistency::Session>
+TestLHCInfoPerFillPopConSourceHandler::createSubsystemDbSessions() const {
+  return std::make_tuple(cond::persistency::Session(), cond::persistency::Session());
+}
+
+std::tuple<cond::OMSServiceResult, bool, std::unique_ptr<cond::OMSServiceQuery>>
+TestLHCInfoPerFillPopConSourceHandler::executeLumiQuery(const cond::OMSService& oms,
+                                                        unsigned short fillId,
+                                                        const boost::posix_time::ptime& beginFillTime,
+                                                        const boost::posix_time::ptime& endFillTime) const {
+  auto it = mockLumiData.find(fillId);
+  if (it != mockLumiData.end()) {
+    return std::make_tuple(it->second, true, nullptr);
+  }
+  return std::make_tuple(cond::OMSServiceResult(), false, nullptr);
+}

--- a/CondTools/RunInfo/test/BuildFile.xml
+++ b/CondTools/RunInfo/test/BuildFile.xml
@@ -8,3 +8,8 @@
 <ifarch value="x86_64">
 <test name="CondToolsLHCInfoNewPopConTest" command="test_lhcInfoNewPopCon.sh"/>
 </ifarch>
+
+<bin file="test_catch2_LHCInfoPerFillPopCon.cpp" name="TestLHCInfoPerFillPopCon">
+  <use name="catch2"/>
+  <use name="FWCore/ParameterSet"/>
+</bin>

--- a/CondTools/RunInfo/test/test_catch2_LHCInfoPerFillPopCon.cpp
+++ b/CondTools/RunInfo/test/test_catch2_LHCInfoPerFillPopCon.cpp
@@ -1,0 +1,629 @@
+#define CATCH_CONFIG_MAIN
+
+#include "catch.hpp"
+
+#include "CondTools/RunInfo/interface/LHCInfoPerFillPopConSourceHandler.h"
+#include "CondTools/RunInfo/interface/TestLHCInfoPerFillPopConSourceHandler.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+struct LHCInfoPerFillPopConSourceHandlerProtectedAccessor : public LHCInfoPerFillPopConSourceHandler {
+  using LHCInfoPerFillPopConSourceHandler::addPayloadToBuffer;
+  using LHCInfoPerFillPopConSourceHandler::m_fillPayload;
+  using LHCInfoPerFillPopConSourceHandler::m_timestampToLumiid;
+  using LHCInfoPerFillPopConSourceHandler::m_tmpBuffer;
+
+  LHCInfoPerFillPopConSourceHandlerProtectedAccessor(edm::ParameterSet const& pset)
+      : LHCInfoPerFillPopConSourceHandler(pset) {}
+};
+
+// Helper function to create a default ParameterSet
+edm::ParameterSet createDefaultPSet() {
+  edm::ParameterSet pset;
+  pset.addUntrackedParameter<bool>("debug", true);
+  pset.addUntrackedParameter<std::string>("startTime", "2023-01-01 00:00:00");
+  pset.addUntrackedParameter<std::string>("endTime", "2023-12-31 23:59:59");
+  pset.addUntrackedParameter<std::string>("name", "LHCInfoPerFillPopConSourceHandler");
+  pset.addUntrackedParameter<std::string>("connectionString", "");
+  pset.addUntrackedParameter<std::string>("ecalConnectionString", "");
+  pset.addUntrackedParameter<std::string>("authenticationPath", "");
+  pset.addUntrackedParameter<std::string>("omsBaseUrl", "");
+  pset.addUntrackedParameter<double>("minEnergy", 450.0);
+  pset.addUntrackedParameter<double>("maxEnergy", 8000.0);
+  pset.addUntrackedParameter<bool>("throwOnInvalid", true);
+  return pset;
+}
+
+TEST_CASE("LHCInfoPerFillPopConSourceHandler.isPayloadValid works", "[isPayloadValid]") {
+  //generate test for both endFill and duringFill modes
+  bool endFillMode = GENERATE(true, false);
+  edm::ParameterSet pset = createDefaultPSet();
+  pset.addUntrackedParameter<bool>("endFill", endFillMode);
+  LHCInfoPerFillPopConSourceHandlerProtectedAccessor handler(pset);
+
+  LHCInfoPerFill payload;
+
+  SECTION("Energy within range is valid") {
+    payload.setEnergy(6500.0);
+    CHECK(handler.isPayloadValid(payload) == true);
+  }
+
+  SECTION("Energy at lower bound is valid") {
+    payload.setEnergy(450.0);
+    CHECK(handler.isPayloadValid(payload) == true);
+  }
+
+  SECTION("Energy at upper bound is valid") {
+    payload.setEnergy(8000.0);
+    CHECK(handler.isPayloadValid(payload) == true);
+  }
+
+  SECTION("Energy below range is invalid") {
+    payload.setEnergy(400.0);
+    CHECK(handler.isPayloadValid(payload) == false);
+  }
+
+  SECTION("Energy above range is invalid") {
+    payload.setEnergy(8500.0);
+    CHECK(handler.isPayloadValid(payload) == false);
+  }
+}
+
+TEST_CASE("LHCInfoPerFillPopConSourceHandler.addPayloadToBuffer works", "[addPayloadToBuffer]") {
+  //generate test for both endFill and duringFill modes
+  bool endFillMode = GENERATE(true, false);
+  edm::ParameterSet pset = createDefaultPSet();
+  pset.addUntrackedParameter<bool>("endFill", endFillMode);
+  LHCInfoPerFillPopConSourceHandlerProtectedAccessor handler(pset);
+
+  // Create a mock OMSServiceResultRef
+  boost::property_tree::ptree mockRow;
+
+  mockRow.put("start_time", "2023-06-01 12:00:00");
+  mockRow.put("delivered_lumi", 100.0f);
+  mockRow.put("recorded_lumi", 80.0f);
+  mockRow.put("run_number", "3500");
+  mockRow.put("lumisection_number", "150");
+  cond::OMSServiceResultRef mockResultRef(&mockRow);
+
+  // Set the m_fillPayload before calling addPayloadToBuffer
+  handler.m_fillPayload = std::make_unique<LHCInfoPerFill>();
+  handler.m_fillPayload->setFillNumber(1234);
+  handler.m_fillPayload->setEnergy(6500.0);
+
+  // Call the addPayloadToBuffer method
+  handler.addPayloadToBuffer(mockResultRef);
+
+  //verify that the payload was added to the tmpBuffer
+  REQUIRE(handler.m_tmpBuffer.empty() == false);
+  CHECK(handler.m_tmpBuffer.size() == 1);
+
+  SECTION("addPayloadToBuffer adds correct payload to buffer") {
+    auto& addedPayload = handler.m_tmpBuffer.front().second;
+    CHECK(addedPayload->delivLumi() == 100.0f);
+    CHECK(addedPayload->recLumi() == 80.0f);
+    CHECK(addedPayload->fillNumber() == 1234);
+    CHECK(addedPayload->energy() == 6500.0);
+  }
+
+  SECTION("addPayloadToBuffer adds correct IOV to buffer") {
+    auto addedIov = handler.m_tmpBuffer.front().first;
+    CHECK(addedIov == cond::time::from_boost(boost::posix_time::time_from_string("2023-06-01 12:00:00")));
+  }
+
+  if (!endFillMode) {
+    SECTION("addPayloadToBuffer updates timestampToLumiid map in duringFill mode") {
+      CAPTURE(endFillMode);
+      REQUIRE(handler.m_timestampToLumiid.empty() == false);
+      CHECK(handler.m_timestampToLumiid.size() == 1);
+      auto it = handler.m_timestampToLumiid.begin();
+      CHECK(it->first == cond::time::from_boost(boost::posix_time::time_from_string("2023-06-01 12:00:00")));
+      CHECK(it->second == cond::time::lumiTime(3500, 150));
+    }
+  }
+}
+
+TEST_CASE("LHCInfoPerFillPopConSourceHandler.getNewObjects fills IOVs correctly: endFill mode", "[populate]") {
+  std::cout << "\nTEST: getNewObjects fills IOVs correctly: endfill mode" << std::endl;
+  edm::setStandAloneMessageThreshold(edm::messagelogger::ELinfo);
+
+  bool endFillMode = true;
+  edm::ParameterSet pset = createDefaultPSet();
+  pset.addUntrackedParameter<bool>("endFill", endFillMode);
+  TestLHCInfoPerFillPopConSourceHandler handler(pset);
+
+  // Set up mock data
+  std::vector<cond::OMSServiceResultRef> mockOmsFills;
+  std::map<unsigned short /*fillNr*/, cond::OMSServiceResult> mockLumiData;
+
+  // Populate mock data
+  std::vector<unsigned short> fillNumbers = {1000, 1001, 1002};
+  std::vector<float> energies = {6500.0, 6600.0, 6700.0};
+  std::vector<boost::posix_time::ptime> fillStartTimes /* force formatting */ = {
+      boost::posix_time::time_from_string("2023-06-01 11:30:00"),
+      boost::posix_time::time_from_string("2023-06-01 12:30:00"),
+      boost::posix_time::time_from_string("2023-06-01 13:30:00")};
+  std::vector<boost::posix_time::ptime> fillStableBeamBeginTimes = {
+      boost::posix_time::time_from_string("2023-06-01 12:00:00"),
+      boost::posix_time::time_from_string("2023-06-01 13:00:00"),
+      boost::posix_time::time_from_string("2023-06-01 14:00:00")};
+  std::vector<boost::posix_time::ptime> fillEndTimes /* force formatting */ = {
+      boost::posix_time::time_from_string("2023-06-01 12:30:00"),
+      boost::posix_time::time_from_string("2023-06-01 13:29:00"),
+      boost::posix_time::time_from_string("2023-06-01 14:30:00")};
+
+  for (size_t i = 0; i < fillNumbers.size(); ++i) {
+    auto fillPayload = std::make_shared<LHCInfoPerFill>();
+    fillPayload->setFillNumber(fillNumbers[i]);
+    fillPayload->setEnergy(energies[i]);
+    fillPayload->setCreationTime(cond::time::from_boost(fillStartTimes[i]));
+    fillPayload->setBeginTime(cond::time::from_boost(fillStableBeamBeginTimes[i]));
+    fillPayload->setEndTime(cond::time::from_boost(fillEndTimes[i]));
+    handler.mockOmsFills.emplace_back(std::make_pair(cond::time::from_boost(fillStartTimes[i]), fillPayload));
+  }
+
+  // populate json mockLumiData for each fill
+  // OMSServiceResult cannot be initialized directly from vector of OMSServiceResultRef
+  // Instead we need to prepare the data in json format and parse it using OMSServiceResult::parseData
+  std::vector<std::string> lumiJsons = {
+      R"delimiter(
+{
+  "data": [
+    {
+      "id": "354496_113",
+      "type": "lumisections",
+      "attributes": {
+        "beams_stable": true,
+        "start_time": "2023-06-01T12:00:00Z",
+        "run_number": 354496,
+        "recorded_lumi": 0,
+        "delivered_lumi": 0,
+        "lumisection_number": 113
+      }
+    },
+    {
+      "id": "354496_114",
+      "type": "lumisections",
+      "attributes": {
+        "beams_stable": true,
+        "start_time": "2023-06-01T12:00:00Z",
+        "run_number": 354496,
+        "recorded_lumi": 1,
+        "delivered_lumi": 1,
+        "lumisection_number": 114
+      }
+    },
+    {
+      "id": "354496_115",
+      "type": "lumisections",
+      "attributes": {
+        "beams_stable": true,
+        "start_time": "2023-06-01T12:00:46Z",
+        "run_number": 354496,
+        "recorded_lumi": 123,
+        "delivered_lumi": 123,
+        "lumisection_number": 115
+      }
+    }
+  ]
+}
+)delimiter",
+      R"delimiter(
+{
+  "data": [
+    {
+      "id": "354496_113",
+      "type": "lumisections",
+      "attributes": {
+        "beams_stable": true,
+        "start_time": "2023-06-01T13:00:00Z",
+        "run_number": 354496,
+        "recorded_lumi": 0,
+        "delivered_lumi": 0,
+        "lumisection_number": 200
+      }
+    },
+    {
+      "id": "354496_114",
+      "type": "lumisections",
+      "attributes": {
+        "beams_stable": true,
+        "start_time": "2023-06-01T13:00:23Z",
+        "run_number": 354496,
+        "recorded_lumi": 0,
+        "delivered_lumi": 0,
+        "lumisection_number": 201
+      }
+    }
+  ]
+}
+)delimiter",
+      R"delimiter(
+{
+  "data": [
+    {
+      "id": "354496_113",
+      "type": "lumisections",
+      "attributes": {
+        "beams_stable": true,
+        "start_time": "2023-06-01T14:00:00Z",
+        "run_number": 354497,
+        "recorded_lumi": 0,
+        "delivered_lumi": 0,
+        "lumisection_number": 100
+      }
+    },
+    {
+      "id": "354496_114",
+      "type": "lumisections",
+      "attributes": {
+        "beams_stable": true,
+        "start_time": "2023-06-01T14:00:23Z",
+        "run_number": 354497,
+        "recorded_lumi": 0,
+        "delivered_lumi": 0,
+        "lumisection_number": 101
+      }
+    }
+  ]
+}
+)delimiter"};
+
+  std::cout << "lumiJsons size: " << lumiJsons.size() << std::endl;
+
+  for (size_t i = 0; i < fillNumbers.size(); ++i) {
+    handler.mockLumiData[fillNumbers[i]] = cond::OMSServiceResult();
+    handler.mockLumiData[fillNumbers[i]].parseData(lumiJsons[i]);
+  }
+
+  // Run the populate function
+  REQUIRE_NOTHROW(handler.getNewObjects());
+  REQUIRE(handler.iovs().empty() == false);
+
+  REQUIRE(handler.iovs().size() == 8);
+
+  // Check that IOVs were populated correctly
+  auto it = handler.iovs().begin();
+  auto end = handler.iovs().end();
+
+  auto to_since = [](const char* ts) { return cond::time::from_boost(boost::posix_time::time_from_string(ts)); };
+
+  // Helper lambda to check and advance iterator safely
+  auto check_iov = [&](decltype(it)& iter,
+                       auto expected_since,
+                       auto expected_fill,
+                       auto expected_energy,
+                       auto expected_delivLumi,
+                       auto expected_recLumi) {
+    REQUIRE(iter != end);
+    std::cout << "IOV since: " << iter->first << ", Fill: " << iter->second->fillNumber()
+              << ", Energy: " << iter->second->energy() << ", delivLumi: " << iter->second->delivLumi()
+              << ", recLumi: " << iter->second->recLumi() << std::endl;
+    CHECK(iter->first == (unsigned long long)expected_since);
+    CHECK(iter->second->fillNumber() == expected_fill);
+    CHECK(iter->second->energy() == expected_energy);
+    CHECK(iter->second->delivLumi() == expected_delivLumi);
+    CHECK(iter->second->recLumi() == expected_recLumi);
+    ++iter;
+  };
+
+  check_iov(it, 1, 0, 0.0, 0.0f, 0.0f);                                          // empty payload added to empty tag
+  check_iov(it, to_since("2023-06-01 12:00:00"), 1000, 6500.0, 0.0f, 0.0f);      // first payload of SB of fill 1000
+  check_iov(it, to_since("2023-06-01 12:00:46"), 1000, 6500.0, 123.0f, 123.0f);  // last payload of SB of fill 1000
+  check_iov(it, to_since("2023-06-01 12:30:00"), 0, 0.0, 0.0f, 0.0f);            // empty payload between fills
+  check_iov(it, to_since("2023-06-01 13:00:00"), 1001, 6600.0, 0.0f, 0.0f);
+  // only one payload of fill 1001 because of same data
+  check_iov(it, to_since("2023-06-01 13:29:00"), 0, 0.0, 0.0f, 0.0f);
+  check_iov(it, to_since("2023-06-01 14:00:00"), 1002, 6700.0, 0.0f, 0.0f);
+  // only one payload of fill 1002 because of same data
+  check_iov(it, to_since("2023-06-01 14:30:00"), 0, 0.0, 0.0f, 0.0f);
+}
+
+TEST_CASE("LHCInfoPerFillPopConSourceHandler.getNewObjects fills IOVs correctly in duringFill mode", "[populate]") {
+  std::cout << "\nTEST: getNewObjects fills IOVs correctly in duringFill mode" << std::endl;
+  edm::setStandAloneMessageThreshold(edm::messagelogger::ELinfo);
+
+  bool endFillMode = false;
+  edm::ParameterSet pset = createDefaultPSet();
+  pset.addUntrackedParameter<bool>("endFill", endFillMode);
+  TestLHCInfoPerFillPopConSourceHandler handler(pset);
+
+  // Set up mock data
+  std::vector<cond::OMSServiceResultRef> mockOmsFills;
+  std::map<unsigned short /*fillNr*/, cond::OMSServiceResult> mockLumiData;
+  //set mock execution time
+  handler.mockExecutionTime = boost::posix_time::time_from_string("2023-06-01 12:10:00");
+
+  // Populate mock data
+  std::vector<unsigned short> fillNumbers = {1000};
+  std::vector<float> energies = {GENERATE(450.0, 6600.0, 8000.0)};
+  std::vector<boost::posix_time::ptime> fillStartTimes = {boost::posix_time::time_from_string("2023-06-01 11:30:00")};
+  std::vector<boost::posix_time::ptime> fillStableBeamBeginTimes = {
+      boost::posix_time::time_from_string("2023-06-01 12:00:00")};
+  std::vector<boost::posix_time::ptime> fillEndTimes = {boost::posix_time::time_from_string("2023-06-01 12:30:00")};
+
+  for (size_t i = 0; i < 3; ++i) {
+    auto fillPayload = std::make_shared<LHCInfoPerFill>();
+    fillPayload->setFillNumber(fillNumbers[i]);
+    fillPayload->setEnergy(energies[i]);
+    fillPayload->setCreationTime(cond::time::from_boost(fillStartTimes[i]));
+    fillPayload->setBeginTime(cond::time::from_boost(fillStableBeamBeginTimes[i]));
+    fillPayload->setEndTime(0LL);
+    handler.mockOmsFills.emplace_back(std::make_pair(cond::time::from_boost(fillStartTimes[i]), fillPayload));
+  }
+
+  std::vector<std::string> lumiJsons = {
+      R"delimiter(
+{
+  "data": [
+    {
+      "id": "354496_113",
+      "type": "lumisections",
+      "attributes": {
+        "beams_stable": true,
+        "start_time": "2023-06-01T12:00:00Z",
+        "run_number": 354496,
+        "recorded_lumi": 0,
+        "delivered_lumi": 0,
+        "lumisection_number": 113
+      }
+    },
+    {
+      "id": "354496_114",
+      "type": "lumisections",
+      "attributes": {
+        "beams_stable": true,
+        "start_time": "2023-06-01T12:00:23Z",
+        "run_number": 354496,
+        "recorded_lumi": 123,
+        "delivered_lumi": 123,
+        "lumisection_number": 114
+      }
+    }
+  ]
+}
+)delimiter"};
+
+  for (size_t i = 0; i < fillNumbers.size(); ++i) {
+    handler.mockLumiData[fillNumbers[i]] = cond::OMSServiceResult();
+    handler.mockLumiData[fillNumbers[i]].parseData(lumiJsons[i]);
+  }
+
+  // Run the populate function
+  REQUIRE_NOTHROW(handler.getNewObjects());
+  REQUIRE(handler.iovs().empty() == false);
+
+  REQUIRE(handler.iovs().size() == 1);
+  // Check that IOVs were populated correctly
+
+  auto it = handler.iovs().begin();
+  auto end = handler.iovs().end();
+
+  // Helper lambda to check and advance iterator safely
+  auto check_iov =
+      [&](decltype(it)& iter, auto expected_fill, auto expected_energy, auto expected_delivLumi, auto expected_recLumi) {
+        REQUIRE(iter != end);
+        std::cout << "IOV since: " << iter->first << ", Fill: " << iter->second->fillNumber()
+                  << ", Energy: " << iter->second->energy() << ", delivLumi: " << iter->second->delivLumi()
+                  << ", recLumi: " << iter->second->recLumi() << std::endl;
+        // we don't check IOV since in duringFill mode
+        CHECK(iter->second->fillNumber() == expected_fill);
+        CHECK(iter->second->energy() == expected_energy);
+        CHECK(iter->second->delivLumi() == expected_delivLumi);
+        CHECK(iter->second->recLumi() == expected_recLumi);
+        ++iter;
+      };
+
+  check_iov(it, 1000, energies.front(), 123.0f, 123.0f);
+}
+
+TEST_CASE(
+    "LHCInfoPerFillPopConSourceHandler.getNewObjects doesn't upload payloads with invalid energy in duringFill mode",
+    "[populate]") {
+  std::cout << "\nTEST: getNewObjects doesn't upload payloads with invalid energy in duringFill mode" << std::endl;
+  edm::setStandAloneMessageThreshold(edm::messagelogger::ELinfo);
+
+  bool endFillMode = false;
+  edm::ParameterSet pset = createDefaultPSet();
+  pset.addUntrackedParameter<bool>("endFill", endFillMode);
+  TestLHCInfoPerFillPopConSourceHandler handler(pset);
+
+  // Set up mock data
+  std::vector<cond::OMSServiceResultRef> mockOmsFills;
+  std::map<unsigned short /*fillNr*/, cond::OMSServiceResult> mockLumiData;
+  //set mock execution time
+  handler.mockExecutionTime = boost::posix_time::time_from_string("2023-06-01 12:10:00");
+
+  // Populate mock data
+  std::vector<unsigned short> fillNumbers = {1000};
+  std::vector<float> energies = {GENERATE(-6800., -1., 0., 449.9, 8000.1)};  // invalid energy
+  std::vector<boost::posix_time::ptime> fillStartTimes = {boost::posix_time::time_from_string("2023-06-01 11:30:00")};
+  std::vector<boost::posix_time::ptime> fillStableBeamBeginTimes = {
+      boost::posix_time::time_from_string("2023-06-01 12:00:00")};
+
+  for (size_t i = 0; i < fillNumbers.size(); ++i) {
+    auto fillPayload = std::make_shared<LHCInfoPerFill>();
+    fillPayload->setFillNumber(fillNumbers[i]);
+    fillPayload->setEnergy(energies[i]);
+    fillPayload->setCreationTime(cond::time::from_boost(fillStartTimes[i]));
+    fillPayload->setBeginTime(cond::time::from_boost(fillStableBeamBeginTimes[i]));
+    fillPayload->setEndTime(0LL);
+    handler.mockOmsFills.emplace_back(std::make_pair(cond::time::from_boost(fillStartTimes[i]), fillPayload));
+  }
+
+  std::vector<std::string> lumiJsons = {
+      R"delimiter(
+{
+  "data": [
+    {
+      "id": "354496_113",
+      "type": "lumisections",
+      "attributes": {
+        "beams_stable": true,
+        "start_time": "2023-06-01T12:00:00Z",
+        "run_number": 354496,
+        "recorded_lumi": 0,
+        "delivered_lumi": 0,
+        "lumisection_number": 113
+      }
+    },
+    {
+      "id": "354496_114",
+      "type": "lumisections",
+      "attributes": {
+        "beams_stable": true,
+        "start_time": "2023-06-01T12:00:23Z",
+        "run_number": 354496,
+        "recorded_lumi": 123,
+        "delivered_lumi": 123,
+        "lumisection_number": 114
+      }
+    }
+  ]
+}
+)delimiter"};
+
+  for (size_t i = 0; i < fillNumbers.size(); ++i) {
+    handler.mockLumiData[fillNumbers[i]] = cond::OMSServiceResult();
+    handler.mockLumiData[fillNumbers[i]].parseData(lumiJsons[i]);
+  }
+
+  // Run the populate function
+  REQUIRE_THROWS(handler.getNewObjects());
+  // test that the exception message contains "Invalid energy"
+  try {
+    handler.getNewObjects();
+  } catch (const cms::Exception& e) {
+    std::string what = e.what();
+    CHECK(what.find("Skipping upload of payload with invalid values: Fill = 1000, Energy = ") != std::string::npos);
+  }
+}
+
+TEST_CASE("LHCInfoPerFillPopConSourceHandler.getNewObjects during fill mode: doesn't upload payloads for ended fills",
+          "[populate]") {
+  std::cout << "\nTEST: getNewObjects during fill mode: doesn't upload payloads for ended fills" << std::endl;
+  edm::setStandAloneMessageThreshold(edm::messagelogger::ELinfo);
+
+  bool endFillMode = false;
+  edm::ParameterSet pset = createDefaultPSet();
+  pset.addUntrackedParameter<bool>("endFill", endFillMode);
+  TestLHCInfoPerFillPopConSourceHandler handler(pset);
+
+  // Set up mock data
+  std::vector<cond::OMSServiceResultRef> mockOmsFills;
+  std::map<unsigned short /*fillNr*/, cond::OMSServiceResult> mockLumiData;
+  //set mock execution time
+  handler.mockExecutionTime = boost::posix_time::time_from_string("2023-06-01 12:30:01");
+
+  // Populate mock data
+  std::vector<unsigned short> fillNumbers = {1000};
+  std::vector<float> energies = {6800};
+  std::vector<boost::posix_time::ptime> fillStartTimes = {boost::posix_time::time_from_string("2023-06-01 11:30:00")};
+  std::vector<boost::posix_time::ptime> fillStableBeamBeginTimes = {
+      boost::posix_time::time_from_string("2023-06-01 12:00:00")};
+  std::vector<boost::posix_time::ptime> fillEndTimes = {boost::posix_time::time_from_string("2023-06-01 12:30:00")};
+
+  for (size_t i = 0; i < fillNumbers.size(); ++i) {
+    auto fillPayload = std::make_shared<LHCInfoPerFill>();
+    fillPayload->setFillNumber(fillNumbers[i]);
+    fillPayload->setEnergy(energies[i]);
+    fillPayload->setCreationTime(cond::time::from_boost(fillStartTimes[i]));
+    fillPayload->setBeginTime(cond::time::from_boost(fillStableBeamBeginTimes[i]));
+    fillPayload->setEndTime(cond::time::from_boost(fillEndTimes[i]));
+    handler.mockOmsFills.emplace_back(std::make_pair(cond::time::from_boost(fillStartTimes[i]), fillPayload));
+  }
+
+  std::vector<std::string> lumiJsons = {
+      R"delimiter(
+{
+  "data": [
+    {
+      "id": "354496_113",
+      "type": "lumisections",
+      "attributes": {
+        "beams_stable": true,
+        "start_time": "2023-06-01T12:00:00Z",
+        "run_number": 354496,
+        "recorded_lumi": 0,
+        "delivered_lumi": 0,
+        "lumisection_number": 113
+      }
+    },
+    {
+      "id": "354496_114",
+      "type": "lumisections",
+      "attributes": {
+        "beams_stable": true,
+        "start_time": "2023-06-01T12:00:23Z",
+        "run_number": 354496,
+        "recorded_lumi": 123,
+        "delivered_lumi": 123,
+        "lumisection_number": 114
+      }
+    }
+  ]
+}
+)delimiter"};
+
+  for (size_t i = 0; i < fillNumbers.size(); ++i) {
+    handler.mockLumiData[fillNumbers[i]] = cond::OMSServiceResult();
+    handler.mockLumiData[fillNumbers[i]].parseData(lumiJsons[i]);
+  }
+
+  handler.getNewObjects();
+  CHECK(handler.iovs().size() == 0);
+}
+
+TEST_CASE(
+    "LHCInfoPerFillPopConSourceHandler.getNewObjects during fill mode: doesn't upload payloads for fills with no "
+    "lumisections",
+    "[populate]") {
+  std::cout << "\nTEST: getNewObjects during fill mode: doesn't upload payloads for fills with no lumisections"
+            << std::endl;
+  edm::setStandAloneMessageThreshold(edm::messagelogger::ELinfo);
+
+  bool endFillMode = false;
+  edm::ParameterSet pset = createDefaultPSet();
+  pset.addUntrackedParameter<bool>("endFill", endFillMode);
+  TestLHCInfoPerFillPopConSourceHandler handler(pset);
+
+  // Set up mock data
+  std::vector<cond::OMSServiceResultRef> mockOmsFills;
+  std::map<unsigned short /*fillNr*/, cond::OMSServiceResult> mockLumiData;
+  //set mock execution time
+  handler.mockExecutionTime = boost::posix_time::time_from_string("2023-06-01 12:00:01");
+
+  // Populate mock data
+  std::vector<unsigned short> fillNumbers = {1000};
+  std::vector<float> energies = {6800};
+  std::vector<boost::posix_time::ptime> fillStartTimes = {boost::posix_time::time_from_string("2023-06-01 11:30:00")};
+  std::vector<boost::posix_time::ptime> fillStableBeamBeginTimes = {
+      boost::posix_time::time_from_string("2023-06-01 12:00:00")};
+  // no need for fillEndTimes, end time of the fill is set to 0
+
+  for (size_t i = 0; i < fillNumbers.size(); ++i) {
+    auto fillPayload = std::make_shared<LHCInfoPerFill>();
+    fillPayload->setFillNumber(fillNumbers[i]);
+    fillPayload->setEnergy(energies[i]);
+    fillPayload->setCreationTime(cond::time::from_boost(fillStartTimes[i]));
+    fillPayload->setBeginTime(cond::time::from_boost(fillStableBeamBeginTimes[i]));
+    fillPayload->setEndTime(0LL);
+    handler.mockOmsFills.emplace_back(std::make_pair(cond::time::from_boost(fillStartTimes[i]), fillPayload));
+  }
+
+  std::vector<std::string> lumiJsons = {
+      R"delimiter(
+{
+  "data": [
+  ]
+}
+)delimiter"};
+
+  for (size_t i = 0; i < fillNumbers.size(); ++i) {
+    handler.mockLumiData[fillNumbers[i]] = cond::OMSServiceResult();
+    handler.mockLumiData[fillNumbers[i]].parseData(lumiJsons[i]);
+  }
+
+  REQUIRE_NOTHROW(handler.getNewObjects());
+  CHECK(handler.iovs().size() == 0);
+}

--- a/CondTools/RunInfo/test/test_lhcInfoNewPopCon.sh
+++ b/CondTools/RunInfo/test/test_lhcInfoNewPopCon.sh
@@ -71,7 +71,7 @@ cmsRun ${SCRIPTS_DIR}/LHCInfoPerFillPopConAnalyzer_cfg.py mode=duringFill \
     startTime="2022-10-24 01:00:00.000" endTime="2022-10-24 20:00:00.000" \
     lastLumiFile=last_lumi.txt \
     tag=fill_during_test > fill_during_test.log || die "cmsRun LHCInfoPerFillPopConAnalyzer_cfg.py" $? "fill_during_test.log"
-assert_equal 1 `cat fill_during_test.log | grep -E 'uploaded with since' | \
+assert_equal 0 `cat fill_during_test.log | grep -E 'uploaded with since' | \
     wc -l` "LHCInfoPerFillPopConAnalyzer in DuringFill written wrong number of payloads" "fill_during_test.log"
 
 echo "testing LHCInfoPerLSPopConAnalyzer in duringFill mode for startTime=\"2022-10-24 01:00:00.000\" endTime=\"2022-10-24 20:00:00.000\"" 


### PR DESCRIPTION
#### PR description:

This PR enables to define a range of valid values of Energy for the LHCInfoPerFill O20 in during fill mode. Depending on the `throwOnInvalid` argument when payload with invalid values is buffered for upload an exception is thrown or the payload is filtered out. The `throwOnInvalid` arguement was also added to LHCInfoPerLS O2O which already had a funtionality of filtering out invalid payload, wheras now it can also throw an exception enabling to notice issues via the O2O monitoring system.
The PR also refactors the main logic of the O2O implemented in the getNewObject method and implements unit tests in the Cath2 framework. The refactoring enabled implementing TestLHCInfoPerFillSourceHandler which replaces communication with external systems (OMS, subsystem DBs etc.) with mocks which is then levareged in the unit tests.

#### PR validation:

Tested with unit tests implemented in test_catch2_LHCInfoPerFillPopCon.cpp. Additionally, existing tests in test_lhcInfoNewPopCon.sh were updated. Tested also by deploying it as a test O2O (LHCInfoPerFill_test) in on the cms-conddb-2 machine in P5 and running it with a cron job alongside the production jobs.


#### Backport:

Backport to 15_0 will follow


P.S will squash commits into meaningfull parts of the update soon