### PR TITLE
Reading Certification JSON from `cvmfs` in `das-up-to-nevents.py`

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/das-up-to-nevents.py
+++ b/Configuration/PyReleaseValidation/scripts/das-up-to-nevents.py
@@ -16,7 +16,8 @@ import json
 
 ## Helpers
 base_cert_url = "https://cms-service-dqmdc.web.cern.ch/CAF/certification/"
-base_cert_path = "/eos/user/c/cmsdqm/www/CAF/certification/"
+base_cert_eos = "/eos/user/c/cmsdqm/www/CAF/certification/"
+base_cert_cvmfs = "/cvmfs/cms-griddata.cern.ch/cat/metadata/DC/"
 
 def get_url_clean(url):
     
@@ -142,18 +143,29 @@ if __name__ == '__main__':
         elif "HI" in PD:
             cert_type = "Collisions" + str(year) + "HI"
         
-        cert_path = base_cert_path + cert_type + "/"
-        web_fallback = False
+        cert_path = base_cert_cvmfs + cert_type + "/"
+        web_fallback = True
 
-        ## if we have access to eos we get from there ...
+        ## if we have access to cvmfs we get from there ...
         if os.path.isdir(cert_path):
+            cert_path = cert_path + "/latest/"
+            web_fallback = False
             json_list = os.listdir(cert_path)
             if len(json_list) == 0:
                 web_fallback == True 
             json_list = [c for c in json_list if "golden" in c.lower() and "era" not in c.lower() and "ppref" not in c.lower()]
             json_list = [c for c in json_list if c.lower().startswith("cert_c") and c.endswith("json")]
-        else:
-            web_fallback = True
+        
+        ## ... if not we try eos ...
+        if web_fallback and os.path.isdir(base_cert_eos + cert_type +"/"):
+            web_fallback = False
+            cert_path = base_cert_eos + cert_type +"/"
+            json_list = os.listdir(cert_path)
+            if len(json_list) == 0:
+                web_fallback == True 
+            json_list = [c for c in json_list if "golden" in c.lower() and "era" not in c.lower() and "ppref" not in c.lower()]
+            json_list = [c for c in json_list if c.lower().startswith("cert_c") and c.endswith("json")]
+
         ## ... if not we go to the website
         if web_fallback:
             cert_url = base_cert_url + cert_type + "/"


### PR DESCRIPTION
#### PR description:

Taking the comment https://github.com/cms-sw/cmssw/pull/49020#issuecomment-3359932758 by @gabrielmscampos, this PR proposes to allow `das-up-to-nevents.py` to look for the json certification on `cvmfs`. This would supersede https://github.com/cms-sw/cmssw/pull/49020 solving the same issue:

> Lately (with https://github.com/cms-sw/cmssw/pull/48490), spurious DAS errors appear frequently in the tests (see e.g. https://github.com/cms-sw/cmssw/pull/49014#issuecomment-3344368295). This is due to random glitches in accessing https://cms-service-dqmdc.web.cern.ch/CAF/certification/ when running the tests (no access to EOS is available). This results in not finding any certification JSON files to use for skimming the datasets.

#### PR validation:

Running the standard tests.
