### PR TITLE
BPHNano: backport #49060 to CMSSW_15_0_X

### DIFF
--- a/PhysicsTools/BPHNano/plugins/DiTrackBuilder.cc
+++ b/PhysicsTools/BPHNano/plugins/DiTrackBuilder.cc
@@ -158,9 +158,6 @@ void DiTrackBuilder::produce(edm::StreamID, edm::Event &evt, edm::EventSetup con
       ditrack_cand.addUserFloat("fitted_mass_piK", fitter_piK.fitted_candidate().mass());
       ditrack_cand.addUserFloat("fitted_mass_piK_Err",
                                 sqrt(fitter_piK.fitted_candidate().kinematicParametersError().matrix()(6, 6)));
-      ditrack_cand.addUserFloat("fitted_mass_piK", fitter_piK.fitted_candidate().mass());
-      ditrack_cand.addUserFloat("fitted_mass_piK_Err",
-                                sqrt(fitter_piK.fitted_candidate().kinematicParametersError().matrix()(6, 6)));
 
       ditrack_cand.setVertex(
           reco::Candidate::Point(fitter.fitted_vtx().x(), fitter.fitted_vtx().y(), fitter.fitted_vtx().z()));

--- a/PhysicsTools/BPHNano/python/muons_cff.py
+++ b/PhysicsTools/BPHNano/python/muons_cff.py
@@ -52,7 +52,7 @@ TrgMatchMuonTable = simplePATMuonFlatTableProducer.clone(
         isPFcand    = Var("isPFMuon", bool, doc="muon is PF candidate"),
         isGlobal    = Var("isGlobalMuon", bool, doc="muon is global muon"),
         isTracker   = Var("isTrackerMuon", bool, doc="muon is tracker muon"),
-        looseId     = Var("passed('CutBasedIdLoose')", bool, doc="cut-based ID, medium WP"),
+        looseId     = Var("passed('CutBasedIdLoose')", bool, doc="cut-based ID, loose WP"),
         mediumId    = Var("passed('CutBasedIdMedium')", bool, doc="cut-based ID, medium WP"),
         # tightId     = Var("passed('CutBasedIdTight')", bool, doc="cut-based ID, tight WP"),
         triggerIdLoose  = Var("passed('TriggerIdLoose')", bool, doc="TriggerIdLoose ID"),

--- a/PhysicsTools/NanoAOD/python/custom_bph_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_bph_cff.py
@@ -15,6 +15,7 @@ from PhysicsTools.BPHNano.V0_cff import *
 from PhysicsTools.BPHNano.BToKLL_cff import *
 from PhysicsTools.BPHNano.BToTrkTrkLL_cff import *
 from PhysicsTools.BPHNano.BToV0LL_cff import *
+from PhysicsTools.BPHNano.BToV0TrkLL_cff import *
 
 def nanoAOD_customizeMC(process):
     process.load('PhysicsTools.BPHNano.particlelevelBPH_cff')
@@ -73,22 +74,36 @@ def nanoAOD_customizeLambdabToLambdaLL(process):
     process.nanoSequence = cms.Sequence( process.nanoSequence+ LambdaToProtonPiSequence + LambdaToProtonPiTables + LambdabToLambdaMuMuSequence + LambdabToLambdaMuMuTables  )
     return process
 
+def nanoAOD_customizeBToChargedKstarLL(process):
+    process.load('PhysicsTools.BPHNano.V0_cff')
+    process.load('PhysicsTools.BPHNano.BToV0TrkLL_cff')
+    process.nanoSequenceMC = cms.Sequence( process.nanoSequence+ KshortToPiPiSequenceMC + BToChargedKstarMuMuSequence + KshortToPiPiTable + BToChargedKstarsMuMuTable)
+    process.nanoSequence = cms.Sequence( process.nanoSequence+ KshortToPiPiSequence + BToChargedKstarMuMuSequence + KshortToPiPiTable + BToChargedKstarsMuMuTable)
+    return process
 
-
+def nanoAOD_customizeXibToXiLL(process):
+    process.load('PhysicsTools.BPHNano.V0_cff')
+    process.load('PhysicsTools.BPHNano.BToV0TrkLL_cff')
+    process.nanoSequenceMC = cms.Sequence( process.nanoSequence+ LambdaToProtonPiSequenceMC + XibToXiMuMuSequence + LambdabToLambdaMuMuTables + XibToXiMuMuTable)
+    process.nanoSequence = cms.Sequence( process.nanoSequence+ LambdaToProtonPiSequence + XibToXiMuMuSequence + LambdabToLambdaMuMuTables + XibToXiMuMuTable)
+    return process
 
 def nanoAOD_customizeBPH(process):
     process.load('PhysicsTools.BPHNano.genparticlesBPH_cff')
     process.load('PhysicsTools.BPHNano.muons_cff')
-    process.load('PhysicsTools.BPHNano.MuMu_cff')    
+    process.load('PhysicsTools.BPHNano.MuMu_cff')
     process.load('PhysicsTools.BPHNano.tracks_cff')
-    process.load('PhysicsTools.BPHNano.BToKLL_cff')    
+    process.load('PhysicsTools.BPHNano.BToKLL_cff')
     process.load('PhysicsTools.BPHNano.DiTrack_cff')
     process.load('PhysicsTools.BPHNano.BToTrkTrkLL_cff')
     process.load('PhysicsTools.BPHNano.V0_cff')
-    process.load('PhysicsTools.BPHNano.BToV0LL_cff') 
-    process.load('PhysicsTools.BPHNano.pverticesBPH_cff')    
-    process.nanoSequenceMC = cms.Sequence(process.nanoSequenceMC + particleLevelBPHSequence + genParticleBPHSequence+ genParticleBPHTables + muonBPHSequenceMC + muonBPHTablesMC + MuMuSequence + MuMuTables + tracksBPHSequenceMC + tracksBPHTablesMC + BToKMuMuSequence + BToKMuMuTables + DiTrackSequence + BToTrkTrkMuMuSequence + BToTrkTrkMuMuTables + KshortToPiPiSequenceMC + KshortToPiPiTablesMC + BToKshortMuMuSequence + BToKshortMuMuTables +  LambdaToProtonPiSequenceMC + LambdaToProtonPiTablesMC + LambdabToLambdaMuMuSequence + LambdabToLambdaMuMuTables + BPHPrimaryVerticesSequence)
-    process.nanoSequence = cms.Sequence(process.nanoSequence + muonBPHSequence + muonBPHTables + MuMuSequence + MuMuTables + tracksBPHSequence + tracksBPHTables + BToKMuMuSequence + BToKMuMuTables + DiTrackSequence + BToTrkTrkMuMuSequence + BToTrkTrkMuMuTables + KshortToPiPiSequence + KshortToPiPiTables + BToKshortMuMuSequence + BToKshortMuMuTables +  LambdaToProtonPiSequence + LambdaToProtonPiTables + LambdabToLambdaMuMuSequence + LambdabToLambdaMuMuTables + BPHPrimaryVerticesSequence)
+    process.load('PhysicsTools.BPHNano.BToV0LL_cff')
+    process.load('PhysicsTools.BPHNano.pverticesBPH_cff')
+    process.load('PhysicsTools.BPHNano.BToV0LL_cff')
+    process.load('PhysicsTools.BPHNano.V0_cff')
+    process.load('PhysicsTools.BPHNano.BToV0TrkLL_cff')
+    process.nanoSequenceMC = cms.Sequence(process.nanoSequenceMC +particleLevelBPHSequence + genParticleBPHSequence+ genParticleBPHTables + muonBPHSequenceMC + muonBPHTablesMC + MuMuSequence + MuMuTables + tracksBPHSequenceMC + tracksBPHTablesMC + BToKMuMuSequence + BToKMuMuTables + DiTrackSequence + BToTrkTrkMuMuSequence + BToTrkTrkMuMuTables + KshortToPiPiSequenceMC + KshortToPiPiTablesMC + BToKshortMuMuSequence + BToKshortMuMuTables +  LambdaToProtonPiSequenceMC + LambdaToProtonPiTablesMC + LambdabToLambdaMuMuSequence + LambdabToLambdaMuMuTables + BToChargedKstarMuMuSequence + BToChargedKstarsMuMuTable + XibToXiMuMuSequence + XibToXiMuMuTable)
+    process.nanoSequence = cms.Sequence(process.nanoSequence + muonBPHSequence + muonBPHTables + MuMuSequence + MuMuTables + tracksBPHSequence + tracksBPHTables + BToKMuMuSequence + BToKMuMuTables + DiTrackSequence + BToTrkTrkMuMuSequence + BToTrkTrkMuMuTables + KshortToPiPiSequence + KshortToPiPiTables + BToKshortMuMuSequence + BToKshortMuMuTables +  LambdaToProtonPiSequence + LambdaToProtonPiTables + LambdabToLambdaMuMuSequence + LambdabToLambdaMuMuTables+BToChargedKstarMuMuSequence+BToChargedKstarsMuMuTable + XibToXiMuMuSequence + XibToXiMuMuTable)
     return process
 
-
+    


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/49060 to CMSSW_15_0_X

We would like this PR to be merged as soon as possible in order to have the new CMSSW release ready and installed at P5 before the start of the new Era which is expected to take place on Friday 10/10/2025. 

fyi: @gkaratha @vmariani 