### PR TITLE
Enabling SiPixel digi morphing from 2025 onward

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_cff.py
@@ -8,5 +8,6 @@ from Configuration.Eras.Modifier_run3_SiPixel_2025_cff import run3_SiPixel_2025
 from Configuration.Eras.Modifier_run3_nanoAOD_2025_cff import run3_nanoAOD_2025
 from Configuration.ProcessModifiers.ecal_cctiming_cff import ecal_cctiming
 from Configuration.ProcessModifiers.siPixelGoodEdgeAlgo_cff import siPixelGoodEdgeAlgo
+from Configuration.ProcessModifiers.siPixelDigiMorphing_cff import siPixelDigiMorphing
 
-Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, stage2L1Trigger_2025, run3_SiPixel_2025, run3_CSC_2025, run3_nanoAOD_2025, ecal_cctiming, siPixelGoodEdgeAlgo)
+Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, stage2L1Trigger_2025, run3_SiPixel_2025, run3_CSC_2025, run3_nanoAOD_2025, ecal_cctiming, siPixelGoodEdgeAlgo, siPixelDigiMorphing)

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -349,8 +349,7 @@ process.tracking_FirstStep = cms.Sequence(
     * process.siStripDigis
     * process.striptrackerlocalreco
     * process.offlineBeamSpot
-    * process.siPixelClustersPreSplitting
-    * process.siPixelRecHitsPreSplitting
+    * process.pixeltrackerlocalreco
     * process.siPixelClusterShapeCachePreSplitting
     * process.recopixelvertexing)
 

--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -230,8 +230,7 @@ process.reconstructionStep = cms.Sequence(process.siPixelDigis*
                                           process.siStripDigis*
                                           process.striptrackerlocalreco*
                                           process.offlineBeamSpot*
-                                          process.siPixelClustersPreSplitting*
-                                          process.siPixelRecHitsPreSplitting*
+                                          process.pixeltrackerlocalreco*
                                           process.siPixelClusterShapeCachePreSplitting*
                                           process.recopixelvertexing)
 


### PR DESCRIPTION
#### PR description:

This PR enables the SiPixel digi morphing in the offline reconstruction from 2025 onward. The HLT version of digi morphing running on GPUs has been introduced in https://github.com/cms-sw/cmssw/pull/48734.

#### PR validation:

None

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to CMSSW_15_1_X and CMSSW_15_0_X.
