### PR TITLE
HGCAL LayerClusters in HLT NanoAOD

### DIFF
--- a/HLTrigger/NGTScouting/plugins/LayerClustersExtraTableProducer.cc
+++ b/HLTrigger/NGTScouting/plugins/LayerClustersExtraTableProducer.cc
@@ -1,0 +1,62 @@
+#include "PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h"
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+
+class LayerClustersExtraTableProducer : public edm::stream::EDProducer<> {
+public:
+  LayerClustersExtraTableProducer(edm::ParameterSet const& params)
+      : skipNonExistingSrc_(params.getParameter<bool>("skipNonExistingSrc")),
+        tableName_(params.getParameter<std::string>("tableName")),
+        precision_(params.getParameter<int>("precision")),
+        clustersTime_token_(consumes<edm::ValueMap<std::pair<float, float>>>(
+            params.getParameter<edm::InputTag>("time_layerclusters"))) {
+    produces<nanoaod::FlatTable>(tableName_);
+  }
+
+  void produce(edm::Event& iEvent, const edm::EventSetup&) override {
+    //Layer Clusters time value map
+    auto clustersTime_h = iEvent.getHandle(clustersTime_token_);
+    const auto nClusters = clustersTime_h.isValid() ? clustersTime_h->size() : 0;
+
+    static constexpr float default_value = std::numeric_limits<float>::quiet_NaN();
+
+    std::vector<float> time(nClusters, default_value);
+    std::vector<float> timeError(nClusters, default_value);
+
+    // initialize to quiet Nans
+    if (clustersTime_h.isValid() or !(skipNonExistingSrc_)) {
+      const auto& clustersTime = *clustersTime_h;
+      for (size_t i = 0; i < clustersTime.size(); ++i) {
+        float t = clustersTime.get(i).first;
+        float tE = clustersTime.get(i).first;
+        time[i] = t;
+        timeError[i] = tE;
+      }
+    }
+
+    auto layerClustersTable =
+        std::make_unique<nanoaod::FlatTable>(nClusters, tableName_, /*singleton*/ false, /*extension*/ true);
+    layerClustersTable->addColumn<float>("time", time, "LayerCluster time [ns]", precision_);
+    layerClustersTable->addColumn<float>("timeError", timeError, "LayerCluster timeError [ns]", precision_);
+    iEvent.put(std::move(layerClustersTable), tableName_);
+  }
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<bool>("skipNonExistingSrc", false)
+        ->setComment("whether or not to skip producing the table on absent input product");
+    desc.add<std::string>("tableName", "hltMergeLayerClusters")->setComment("name of the flat table ouput");
+    desc.add<edm::InputTag>("time_layerclusters", edm::InputTag("hltMergeLayerClusters", "timeLayerCluster"));
+    desc.add<int>("precision", 7);
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+private:
+  const bool skipNonExistingSrc_;
+  const std::string tableName_;
+  const unsigned int precision_;
+  const edm::EDGetTokenT<std::vector<reco::CaloCluster>> layerClusters_token_;
+  const edm::EDGetTokenT<edm::ValueMap<std::pair<float, float>>> clustersTime_token_;
+};
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(LayerClustersExtraTableProducer);

--- a/HLTrigger/NGTScouting/plugins/LayerClustersTableProducer.cc
+++ b/HLTrigger/NGTScouting/plugins/LayerClustersTableProducer.cc
@@ -1,0 +1,7 @@
+#include "PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h"
+
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+typedef SimpleCollectionFlatTableProducer<reco::CaloCluster> LayerClustersCollectionTableProducer;
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(LayerClustersCollectionTableProducer);

--- a/HLTrigger/NGTScouting/plugins/TICLCandidateExtraTableProducer.cc
+++ b/HLTrigger/NGTScouting/plugins/TICLCandidateExtraTableProducer.cc
@@ -1,6 +1,3 @@
-#ifndef HLTrigger_HLTUpgradeNano_TICLCandidateExtraTableProducer_h
-#define HLTrigger_HLTUpgradeNano_TICLCandidateExtraTableProducer_h
-
 #include "PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h"
 #include "DataFormats/HGCalReco/interface/TICLCandidate.h"
 #include "DataFormats/HGCalReco/interface/Trackster.h"
@@ -123,5 +120,3 @@ protected:
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(TICLCandidateExtraTableProducer);
-
-#endif

--- a/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
+++ b/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
@@ -23,6 +23,7 @@ from HLTrigger.NGTScouting.hltTaus_cfi import *
 from HLTrigger.NGTScouting.hltTracksters_cfi import *
 from HLTrigger.NGTScouting.hltTICLCandidates_cfi import *
 from HLTrigger.NGTScouting.hltTICLSuperClusters_cfi import *
+from HLTrigger.NGTScouting.hltLayerClusters_cfi import * 
 from HLTrigger.NGTScouting.hltSums_cfi import *
 from HLTrigger.NGTScouting.hltTriggerAcceptFilter_cfi import hltTriggerAcceptFilter,dstTriggerAcceptFilter
 
@@ -119,6 +120,7 @@ def hltNanoValCustomize(process):
                                     process.hltSimTracksterSequence +
                                     process.hltSimTiclCandidateTable +
                                     process.hltSimTiclCandidateExtraTable +
+                                    process.hltLayerClustersTableSequence  +
                                     process.trackingExtraNanoProducer)
 
     return process

--- a/HLTrigger/NGTScouting/python/hltLayerClusters_cfi.py
+++ b/HLTrigger/NGTScouting/python/hltLayerClusters_cfi.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.NanoAOD.common_cff import *
+from PhysicsTools.NanoAOD.nano_cff import nanoMetadata
+from Validation.HGCalValidation.HLT_TICLIterLabels_cff import hltTiclIterLabels
+
+# Tracksters
+hltLayerClustersTable = cms.EDProducer(
+    "LayerClustersCollectionTableProducer",
+    skipNonExistingSrc=cms.bool(True),
+    src=cms.InputTag("hltMergeLayerClusters"),
+    cut=cms.string(""),
+    name=cms.string("hltMergeLayerClusters"),
+    doc=cms.string("HLT HGCAL Layer Clusters"),
+    singleton=cms.bool(False),  # the number of entries is variable
+    variables=cms.PSet(
+        energy=Var("energy", "float",
+                   doc="Energy of the LayerCluster [GeV]"),
+        correctedEnergy=Var("correctedEnergy", "float",
+                            doc="Corrected energy of the LayerCluster [GeV]"),
+        position_x=Var(
+            "x", "float", doc="X coordinate of the LayerCluster [cm]"),
+        position_y=Var(
+            "y", "float", doc="Y coordinate of the LayerCluster [cm]"),
+        position_z=Var(
+            "z", "float", doc="Z coordinate of the LayerCluster [cm]"),
+        position_eta=Var(
+            "eta", "float", doc="eta coordinate of the LayerCluster"),
+        position_phi=Var(
+            "phi", "float", doc="phi coordinate of the LayerCluster"),
+        nHits=Var(
+            "size", "int", doc="Number of RecHits in LayerCluster"),
+        algoID=Var(
+            "algoID", "int", doc="ID of the algo used for producing LayerCluster"),
+
+    ),
+)
+
+hltLayerClustersExtraTable = cms.EDProducer("LayerClustersExtraTableProducer",
+    tableName=cms.string("hltMergeLayerClusters"),
+    skipNonExistingSrc=cms.bool(True),
+    time_layerclusters=cms.InputTag("hltMergeLayerClusters", "timeLayerCluster"),
+    precision=cms.int32(7))
+
+
+hltLayerClustersTableSequence = cms.Sequence(hltLayerClustersTable + hltLayerClustersExtraTable)
+

--- a/HLTrigger/NGTScouting/test/readNano.py
+++ b/HLTrigger/NGTScouting/test/readNano.py
@@ -32,6 +32,17 @@ def main():
     # Event loop
     for i, event in enumerate(events):
         print(f"Processing event {i}")
+        #LayerClusters
+
+        print("Found {} LayerClusters ".format(event.nhltMergeLayerClusters))
+        for lc_idx in range(event.nhltMergeLayerClusters):
+            lcX = event.hltMergeLayerClusters_position_x[lc_idx]
+            lcY = event.hltMergeLayerClusters_position_y[lc_idx]
+            lcZ = event.hltMergeLayerClusters_position_z[lc_idx]
+            lcEta = event.hltMergeLayerClusters_position_eta[lc_idx]
+            lcPhi = event.hltMergeLayerClusters_position_phi[lc_idx]
+            lcE = event.hltMergeLayerClusters_energy[lc_idx]
+            print(f"LC Idx {lc_idx} at ({lcX},{lcY},{lcZ}) (eta-phi) : ({lcEta}, {lcPhi}) with energy {lcE}")
         ## CLUE3D Tracksters ##
         print("Found {} CLUE3D Tracksters".format(event.nhltTiclTrackstersCLUE3DHigh))
         for t_idx in range(event.nhltTiclTrackstersCLUE3DHigh):


### PR DESCRIPTION
This PR adds the HGCAL LayerClusters to the NGT NanoAOD data format. 


Tested on workflow 29634.772

### Event content size impact:

Branch Name  Avg Uncompressed Size (Bytes/Event)  Avg Compressed Size (Bytes/Event)                                                                           
0       hltMergeLayerClusters_position_phi                              11431.8                             9767.2                                                                           
1       hltMergeLayerClusters_position_eta                              11431.8                             8551.6                                                                           
2         hltMergeLayerClusters_position_x                              11430.7                             7688.0                                                                           
3         hltMergeLayerClusters_position_y                              11430.7                             7098.8                                                                           
4             hltMergeLayerClusters_energy                              11427.4                             6998.0                                                                           
6              hltMergeLayerClusters_nHits                              11426.1                              994.4                                                                           
12        hltMergeLayerClusters_position_z                              11430.7                              397.2                                                                           
13         hltMergeLayerClusters_timeError                              11429.0                              344.4                                                                           
14              hltMergeLayerClusters_time                              11425.0                              342.4                                                                           
74            hltMergeLayerClusters_algoID                              11428.1                              106.4                                                                           
76   hltMergeLayerClusters_correctedEnergy                              11434.7                              102.8                                                                           
242                 nhltMergeLayerClusters                                 68.4                               13.1               
                                                     

Total (all branches):
  Uncompressed: 180573.0 bytes/event
  Compressed:   62484.7 bytes/event

Only hltMergeLayerClusters:
  Uncompressed: 125794.4 bytes/event
  Compressed:   42404.3 bytes/event
