### PR TITLE
improve handling of correlation-conditions cut values in `l1t::TriggerMenuParser`

### DIFF
--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.h
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.h
@@ -1,5 +1,5 @@
-#ifndef L1TGlobal_TriggerMenuParser_h
-#define L1TGlobal_TriggerMenuParser_h
+#ifndef L1Trigger_L1TGlobal_TriggerMenuParser_h
+#define L1Trigger_L1TGlobal_TriggerMenuParser_h
 
 /**
  * \class TriggerMenuParser
@@ -26,12 +26,11 @@
  *
  */
 
-// system include files
+#include <map>
 #include <string>
 #include <vector>
 
 #include "L1Trigger/L1TGlobal/interface/TriggerMenuFwd.h"
-
 #include "L1Trigger/L1TGlobal/interface/MuonTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/MuonShowerTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/CaloTemplate.h"
@@ -43,12 +42,8 @@
 #include "L1Trigger/L1TGlobal/interface/CorrelationThreeBodyTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/CorrelationWithOverlapRemovalTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/ExternalTemplate.h"
-
 #include "L1Trigger/L1TGlobal/interface/GlobalScales.h"
 
-#include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
-
-#include <cmath>
 #include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
 #include "CondFormats/L1TObjects/interface/L1TUtmAlgorithm.h"
 #include "CondFormats/L1TObjects/interface/L1TUtmCondition.h"
@@ -371,6 +366,11 @@ namespace l1t {
                             TrigFunc_t func,
                             unsigned int prec);
 
+    // Multiply two doubles, and return the result as a "long long" integer
+    //  Note: the output value is clamped within values close to the
+    //        min/max values of the "long long" type in order to avoid overflow
+    long long multiply_and_clamp_longlong(double const d1, double const d2, bool const returnMinIfInvalid) const;
+
   private:
     /// hardware limits
 
@@ -444,4 +444,4 @@ namespace l1t {
   };
 
 }  // namespace l1t
-#endif /*L1TGlobal_TriggerMenuParser_h*/
+#endif


### PR DESCRIPTION
#### PR description:

This PR improves how the L1-uGT emulator handles some of the lower/upper cut values used in `CorrCondition` and related classes (cuts on quantities such as $\Delta\eta$, $\Delta\phi$, invariant mass, etc).
 - The main change is the removal of an arbitrary cutoff at 1E8 on the upper cuts specified in the L1T menu for these quantities.
 - For the record, this cutoff was introduced in [#14282](https://github.com/cms-sw/cmssw/pull/14282) (2016), and its value was increased in [#17509](https://github.com/cms-sw/cmssw/pull/17509) (2017).
 - This cutoff is suspected to be the cause of the issue discussed in [#49056](https://github.com/cms-sw/cmssw/issues/49056).

This PR should be considered a bugfix.
 - Changes to the results of the L1-uGT emulator are expected (but they are unlikely to show up in PR tests due to limited statistics).

#### PR validation:

Manual checks documented in #49056 (e.g. https://github.com/cms-sw/cmssw/issues/49056#issuecomment-3369229377 and https://github.com/cms-sw/cmssw/issues/49056#issuecomment-3414537143).

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

~~If merged, this PR will be backported down to (at least) the `15_0_X` cycle.~~

TBD, see https://github.com/cms-sw/cmssw/issues/49056#issuecomment-3426744737.