### PR TITLE
Use the right TTreeCache in `RootTree::getEntryForAllBranches()` for prompt reading

### DIFF
--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -430,7 +430,7 @@ namespace edm {
 
   void RootTree::getEntryForAllBranches() const {
     oneapi::tbb::this_task_arena::isolate([&]() {
-      auto guard = filePtr_->setCacheReadTemporarily(treeCache_.get(), tree_);
+      auto guard = filePtr_->setCacheReadTemporarily(rawTreeCache_.get(), tree_);
       tree_->GetEntry(entryNumber_);
     });
   }


### PR DESCRIPTION
#### PR description:

While testing RNTuple, I encountered suspiciously large number of singular reads for TTree (i.e. `PoolSource`) with `application-only` storage cache hint (mimics remote files by triggering the use of `TTreeCache`s) and prompt reading (`source.delayReadingEventProducts = False`). Inspection of code revealed the `getEntryForAllBranches()` and `selectCaches()` are using a different `TTreeCache`, causing the data to be read twice. This PR changes the `getEntryForAllBranches()` to use the same `TTreeCache` as the `selectCache()`.

(for curiosity I tested also the other way around, i.e. changing `selectCache()`, but that didn't improve)

The new read numbers below are consistent with the numbers we saw in spring at the time of https://github.com/cms-sw/cmssw/pull/48088. I still had my CMSSW developer area around, and there the code used the `rawTreeCache_` in both functions. So something happened between the tests and the PR, and I didn't catch it in the code review.

Resolves https://github.com/cms-sw/framework-team/issues/1602

#### PR validation:

In a test MiniAOD-only job using 2024 data as input with 1000 events on 1 and 8 threads the number of singular reads and their data volume decreases by orders of magnitude, and the data volume read more than once also decreases. The 1 and 8 thread jobs give same numbers, so I show them only once below

| | CMSSW_15_1_0_pre6 | This PR |
|---|---|---|
| Singular reads | 92620 | 21 |
| Singular read data volume (MB) | 329.84 | 4.71 |
| Vector reads | 22 | 17 |
| Vector read elements | 322 | 176 |
| Vector read data volume (MB) | 374.21 | 352.97 |
| Duplicate read data volume | 346.42 | 0.05 |


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 15_1_X