### PR TITLE
[15_1_X] Use the right TTreeCache in `RootTree::getEntryForAllBranches()` for prompt reading

### DIFF
--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -430,7 +430,7 @@ namespace edm {
 
   void RootTree::getEntryForAllBranches() const {
     oneapi::tbb::this_task_arena::isolate([&]() {
-      auto guard = filePtr_->setCacheReadTemporarily(treeCache_.get(), tree_);
+      auto guard = filePtr_->setCacheReadTemporarily(rawTreeCache_.get(), tree_);
       tree_->GetEntry(entryNumber_);
     });
   }


### PR DESCRIPTION
#### PR description:

From original PR description

> While testing RNTuple, I encountered suspiciously large number of singular reads for TTree (i.e. `PoolSource`) with `application-only` storage cache hint (mimics remote files by triggering the use of `TTreeCache`s) and prompt reading (`source.delayReadingEventProducts = False`). Inspection of code revealed the `getEntryForAllBranches()` and `selectCaches()` are using a different `TTreeCache`, causing the data to be read twice. This PR changes the `getEntryForAllBranches()` to use the same `TTreeCache` as the `selectCache()`.

#### PR validation:

See https://github.com/cms-sw/cmssw/pull/49070

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/49070