### PR TITLE
Fixing EcalPedestal plots for CondDB [15_1_X]

### DIFF
--- a/CondCore/EcalPlugins/plugins/EcalPedestals_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPedestals_PayloadInspector.cc
@@ -486,7 +486,7 @@ namespace {
         l_tagname[1] = l_tagname[0];
       }
       run[1] = std::get<0>(lastiov);
-      for (int irun = 0; irun < nIOVs; irun++) {
+      for (int irun = 0; irun < 2; irun++) {
         std::shared_ptr<EcalPedestals> payload;
         if (irun == 0) {
           payload = this->fetchPayload(std::get<1>(firstiov));
@@ -606,7 +606,7 @@ namespace {
               }
             }  // loop over cellid
           }  //  barrel data present
-          if (payload->endcapItems().empty()) {
+          if (!payload->endcapItems().empty()) {
             // looping over the EE channels
             for (int iz = -1; iz < 2; iz = iz + 2) {  // -1 or +1
               for (int iy = IY_MIN; iy < IY_MAX + IY_MIN; iy++) {
@@ -824,9 +824,9 @@ namespace {
       return true;
     }  // fill method
   };  // class EcalPedestalsBase
-  using EcalPedestalsDiffOneTag = EcalPedestalsBase<cond::payloadInspector::SINGLE_IOV, 1, 0>;
+  using EcalPedestalsDiffOneTag = EcalPedestalsBase<cond::payloadInspector::MULTI_IOV, 1, 0>;
   using EcalPedestalsDiffTwoTags = EcalPedestalsBase<cond::payloadInspector::SINGLE_IOV, 2, 0>;
-  using EcalPedestalsRatioOneTag = EcalPedestalsBase<cond::payloadInspector::SINGLE_IOV, 1, 1>;
+  using EcalPedestalsRatioOneTag = EcalPedestalsBase<cond::payloadInspector::MULTI_IOV, 1, 1>;
   using EcalPedestalsRatioTwoTags = EcalPedestalsBase<cond::payloadInspector::SINGLE_IOV, 2, 1>;
 
   /*************************************************  


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/49076

#### PR description:

The plots regarding the EcalPedestals on CondDB do not work as intended. Only the EB plots get populated, while EE remains empty (see plot_EcalPedestalsDiffTwoTags example [here](https://cern.ch/uaxgh)). Then, for plots comparing  two IOVs of the same tag, it is not possible to choose a second IOV in the first place, so one can only compare against the exact same IOV within a tag.. (see example [here](https://cern.ch/izowx)

In this PR, I fixed the if-statement logic that accidentally skipped over filling the EE plots, fixed the for loop that mistook nIOVs as number for IOVs (while nIOVs does not actually refer to the number of IOVs but to the IOVMultiplicity defined [here](https://github.com/cms-sw/cmssw/blob/c81b8a1e7d73b37220b4f0d406151d69dc9aaa4d/CondCore/Utilities/interface/PayloadInspector.h#L299)) and finally changed the logic from `SINGLE_IOV` to `MULTI_IOV`  for `EcalPedestalsDiffOneTag` and `EcalPedestalsRatioOneTag`, as they will require multiple IOVs from the same tag and not just a single tag. 


#### PR validation:

I set up the environment as follows:
```
cmsrel CMSSW_15_1_X_2025-10-05-0000
cd CMSSW_15_1_X_2025-10-05-0000/src
cmsenv
git cms-addpkg CondCore/EcalPlugins
scram b
scram b code-checks
scram b code-format
scram b
```
furthermore, running: `git cms-checkdeps -a -A ` shows: no dependencies.

The validation was performed on the workflows `plot_EcalPedestalsDiffTwoTags` and `plot_EcalPedestalsDiffOneTag`, namely by running:
```
getPayloadData.py --plugin pluginEcalPedestals_PayloadInspector --plot plot_EcalPedestalsDiffTwoTags --tag EcalPedestals_2016  --input_params "{}" --tagtwo EcalPedestals_2009runs_hlt --time_type Run --iovs '{"start_iov": "273931", "end_iov": "273931"}'  --iovstwo '{"start_iov": "72686", "end_iov": "72686"}' --db Prod --test

```
which produces the plots that also populate the EE parts:
<img width="1596" height="2572" alt="0ad16109-80b7-4ac1-b4db-ad865fca7dc1" src="https://github.com/user-attachments/assets/2ea0f7cf-d2eb-4cb4-8feb-5c1429259a6d" />

and

```
 getPayloadData.py --plugin pluginEcalPedestals_PayloadInspector --plot plot_EcalPedestalsDiffOneTag --tag EcalPedestals_2016  --input_params "{}" --time_type Run --iovs '{"start_iov": "271837", "end_iov": "271948"}' --db Prod --test

```
which also now enables to choose a second IOV for the same tag comparisons (as well as populating the EE part):
<img width="1596" height="2572" alt="EcalPedestals 2016, IOV 271948 - 271837" src="https://github.com/user-attachments/assets/4d2ea6ab-d949-4bad-a4cf-4f958a4ec130" />

As a consequence, `plot_EcalPedestalsRatioOneTag` and `plot_EcalPedestalsRatioTwoTags` should be fixed with this PR as well.

cc: @mmusich 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/49076 to 15_1_X
