### PR TITLE
Improve performance of heterogeneous CLUE.

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersAlgoWrapper.dev.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersAlgoWrapper.dev.cc
@@ -25,18 +25,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     CLUEAlgoAlpaka<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D, Queue, HGCalSiliconTilesConstants, kHGCalLayers> algoStandalone(
         queue, dc, kappa, outlierDeltaFactor, false);
 
-    // Initialize output memory to 0
-    auto delta = cms::alpakatools::make_device_view<float>(queue, outputs.delta(), size);
-    alpaka::memset(queue, delta, 0x0);
-    auto rho = cms::alpakatools::make_device_view<float>(queue, outputs.rho(), size);
-    alpaka::memset(queue, rho, 0x0);
-    auto nearestHigher = cms::alpakatools::make_device_view<unsigned int>(queue, outputs.nearestHigher(), size);
-    alpaka::memset(queue, nearestHigher, 0x0);
-    auto clusterIndex = cms::alpakatools::make_device_view<int>(queue, outputs.clusterIndex(), size);
-    alpaka::memset(queue, clusterIndex, kInvalidClusterByte);
-    auto isSeed = cms::alpakatools::make_device_view<uint8_t>(queue, outputs.isSeed(), size);
-    alpaka::memset(queue, isSeed, 0x0);
-
     algoStandalone.makeClustersCMSSW(size,
                                      inputs.dim1(),
                                      inputs.dim2(),

--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersSoAAlgoWrapper.dev.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersSoAAlgoWrapper.dev.cc
@@ -155,10 +155,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     alpaka::memset(queue, x, 0x0);
     auto y = cms::alpakatools::make_device_view<float>(queue, outputs.y(), size);
     alpaka::memset(queue, y, 0x0);
-    auto z = cms::alpakatools::make_device_view<float>(queue, outputs.z(), size);
-    alpaka::memset(queue, z, 0x0);
-    auto seed = cms::alpakatools::make_device_view<int>(queue, outputs.seed(), size);
-    alpaka::memset(queue, seed, 0x0);
     auto energy = cms::alpakatools::make_device_view<float>(queue, outputs.energy(), size);
     alpaka::memset(queue, energy, 0x0);
     auto cells = cms::alpakatools::make_device_view<int>(queue, outputs.cells(), size);
@@ -167,8 +163,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     alpaka::memset(queue, total_weight, 0x0);
     auto total_weight_log = cms::alpakatools::make_device_view<float>(queue, outputs_service.total_weight_log(), size);
     alpaka::memset(queue, total_weight_log, 0x0);
-    auto maxEnergyValue = cms::alpakatools::make_device_view<float>(queue, outputs_service.maxEnergyValue(), size);
-    alpaka::memset(queue, maxEnergyValue, 0x0);
     auto maxEnergyIndex = cms::alpakatools::make_device_view<int>(queue, outputs_service.maxEnergyIndex(), size);
     alpaka::memset(queue, maxEnergyIndex, kInvalidIndexByte);
 


### PR DESCRIPTION
#### PR description:

Remove unnecessary memset operations on all cases in which the memory is in any case written by the kernels w/o assuming any previous value. In all other cases, leave the memset operations to preserve the correctness of the algorithms.

#### PR validation:

Run on a set of events, the output, in terms of `Tracksters` is identical.
The performance has improved both running on GPU and, also, using the alpaka Serial CPU backend (thanks @mmusich for the results of the tests!!)

<img width="1049" height="1067" alt="Screenshot from 2025-10-06 16-06-34" src="https://github.com/user-attachments/assets/aa927766-6288-4597-8c4d-98178b0ecd14" />
<img width="1526" height="1313" alt="Screenshot from 2025-10-06 10-56-56" src="https://github.com/user-attachments/assets/33aea9c7-12a1-44ba-84f1-f85a6725cf1d" />


To properly test this PR, we also need an updated version of the CLUE external library:

cms-sw/cmsdist#10114
