### PR TITLE
[Hotfix] MET Validation: Division by zero

### DIFF
--- a/Validation/RecoMET/plugins/METTester.h
+++ b/Validation/RecoMET/plugins/METTester.h
@@ -41,10 +41,10 @@ public:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   static void fillDescriptions(edm::ConfigurationDescriptions &);
 
-  static const int mNMETBins = 11;
+  static constexpr int mNMETBins = 11;
   static constexpr std::array<float, mNMETBins + 1> mMETBins = {
       {0., 20., 40., 60., 80., 100., 150., 200., 300., 400., 500., 1000.}};
-  static const int mNPhiBins = 6;
+  static constexpr int mNPhiBins = 6;
   static constexpr std::array<float, mNPhiBins + 1> mPhiBins = {{-3.15, -2., -1., 0., 1., 2., 3.15}};
 
   static std::string binStr(float left, float right, bool roundInt = true);

--- a/Validation/RecoMET/plugins/METTesterPostProcessor.cc
+++ b/Validation/RecoMET/plugins/METTesterPostProcessor.cc
@@ -47,10 +47,10 @@ void METTesterPostProcessor::mFillAggrHistograms(std::string metdir, DQMStore::I
       mArrayIdx<MElem *>(mMETRatio_GenMETTrue[bt], idx) = iget.get(metdir + "/METRatio_GenMETTrue_" + bt + edges);
       mArrayIdx<MElem *>(mMETDeltaPhi_GenMETTrue[bt], idx) = iget.get(metdir + "/METDeltaPhi_GenMETTrue_" + bt + edges);
 
-      if (mArrayIdx<MElem *>(mMET[bt], idx)->getEntries() < std::numeric_limits<float>::epsilon() ||
-          mArrayIdx<MElem *>(mMETDiff_GenMETTrue[bt], idx)->getEntries() < std::numeric_limits<float>::epsilon() ||
-          mArrayIdx<MElem *>(mMETRatio_GenMETTrue[bt], idx)->getEntries() < std::numeric_limits<float>::epsilon() ||
-          mArrayIdx<MElem *>(mMETDeltaPhi_GenMETTrue[bt], idx)->getEntries() < std::numeric_limits<float>::epsilon()) {
+      if (mArrayIdx<MElem *>(mMET[bt], idx)->getEntries() < mEpsilonDouble ||
+          mArrayIdx<MElem *>(mMETDiff_GenMETTrue[bt], idx)->getEntries() < mEpsilonDouble ||
+          mArrayIdx<MElem *>(mMETRatio_GenMETTrue[bt], idx)->getEntries() < mEpsilonDouble ||
+          mArrayIdx<MElem *>(mMETDeltaPhi_GenMETTrue[bt], idx)->getEntries() < mEpsilonDouble) {
         edm::LogWarning("METTesterPostProcessor")
             << "At least one of the " << bt + edges << " histograms has zero entries:\n"
             << "  MET: " << mArrayIdx<MElem *>(mMET[bt], idx)->getEntries() << "\n"
@@ -79,12 +79,11 @@ void METTesterPostProcessor::mFillAggrHistograms(std::string metdir, DQMStore::I
         mMETResolAggr[bt]->setBinContent(idx + 1, metRMS);
         mMETResolAggr[bt]->setBinError(idx + 1, resolError);
 
-        float significance = metRMS < std::numeric_limits<float>::epsilon() ? 0.f : metMean / metRMS;
-        float significance_error =
-            metRMS < std::numeric_limits<float>::epsilon() || metMean < std::numeric_limits<float>::epsilon()
-                ? 0.f
-                : significance * std::sqrt((metRMS * metRMS / (metMean * metMean)) +
-                                           (resolError * resolError / (metRMS * metRMS)));
+        float significance = metRMS < mEpsilonFloat ? 0.f : metMean / metRMS;
+        float significance_error = metRMS < mEpsilonFloat || metMean < mEpsilonFloat
+                                       ? 0.f
+                                       : significance * std::sqrt((metRMS * metRMS / (metMean * metMean)) +
+                                                                  (resolError * resolError / (metRMS * metRMS)));
         mMETSignAggr[bt]->setBinContent(idx + 1, significance);
         mMETSignAggr[bt]->setBinError(idx + 1, significance_error);
       }

--- a/Validation/RecoMET/plugins/METTesterPostProcessor.cc
+++ b/Validation/RecoMET/plugins/METTesterPostProcessor.cc
@@ -67,11 +67,13 @@ void METTesterPostProcessor::mFillAggrHistograms(std::string metdir, DQMStore::I
         mMETResolAggr[bt]->setBinContent(idx + 1, metRMS);
         mMETResolAggr[bt]->setBinError(idx + 1, resolError);
 
-        float significance = metMean / metRMS;
+        float significance = metRMS == 0 ? 0.f : metMean / metRMS;
+        float significance_error = metRMS == 0 || metMean == 0
+                                       ? 0.f
+                                       : significance * std::sqrt((metRMS * metRMS / (metMean * metMean)) +
+                                                                  (resolError * resolError / (metRMS * metRMS)));
         mMETSignAggr[bt]->setBinContent(idx + 1, significance);
-        mMETSignAggr[bt]->setBinError(idx + 1,
-                                      significance * std::sqrt((metRMS * metRMS / (metMean * metMean)) +
-                                                               (resolError * resolError / (metRMS * metRMS))));
+        mMETSignAggr[bt]->setBinError(idx + 1, significance_error);
       }
     }
   }

--- a/Validation/RecoMET/plugins/METTesterPostProcessor.cc
+++ b/Validation/RecoMET/plugins/METTesterPostProcessor.cc
@@ -67,8 +67,8 @@ void METTesterPostProcessor::mFillAggrHistograms(std::string metdir, DQMStore::I
         mMETResolAggr[bt]->setBinContent(idx + 1, metRMS);
         mMETResolAggr[bt]->setBinError(idx + 1, resolError);
 
-        float significance = metRMS == 0 ? 0.f : metMean / metRMS;
-        float significance_error = metRMS == 0 || metMean == 0
+        float significance = metRMS < FLT_EPSILON ? 0.f : metMean / metRMS;
+        float significance_error = metRMS < FLT_EPSILON || metMean < FLT_EPSILON
                                        ? 0.f
                                        : significance * std::sqrt((metRMS * metRMS / (metMean * metMean)) +
                                                                   (resolError * resolError / (metRMS * metRMS)));

--- a/Validation/RecoMET/plugins/METTesterPostProcessor.cc
+++ b/Validation/RecoMET/plugins/METTesterPostProcessor.cc
@@ -46,6 +46,18 @@ void METTesterPostProcessor::mFillAggrHistograms(std::string metdir, DQMStore::I
       mArrayIdx<MElem *>(mMETDiff_GenMETTrue[bt], idx) = iget.get(metdir + "/METDiff_GenMETTrue_" + bt + edges);
       mArrayIdx<MElem *>(mMETRatio_GenMETTrue[bt], idx) = iget.get(metdir + "/METRatio_GenMETTrue_" + bt + edges);
       mArrayIdx<MElem *>(mMETDeltaPhi_GenMETTrue[bt], idx) = iget.get(metdir + "/METDeltaPhi_GenMETTrue_" + bt + edges);
+
+      if (mArrayIdx<MElem *>(mMET[bt], idx)->getEntries() < std::numeric_limits<float>::epsilon() ||
+          mArrayIdx<MElem *>(mMETDiff_GenMETTrue[bt], idx)->getEntries() < std::numeric_limits<float>::epsilon() ||
+          mArrayIdx<MElem *>(mMETRatio_GenMETTrue[bt], idx)->getEntries() < std::numeric_limits<float>::epsilon() ||
+          mArrayIdx<MElem *>(mMETDeltaPhi_GenMETTrue[bt], idx)->getEntries() < std::numeric_limits<float>::epsilon()) {
+        edm::LogWarning("METTesterPostProcessor")
+            << "At least one of the " << bt + edges << " histograms has zero entries:\n"
+            << "  MET: " << mArrayIdx<MElem *>(mMET[bt], idx)->getEntries() << "\n"
+            << "  METDiff: " << mArrayIdx<MElem *>(mMET[bt], idx)->getEntries() << "\n"
+            << "  METRatio: " << mArrayIdx<MElem *>(mMET[bt], idx)->getEntries() << "\n"
+            << "  METDeltaPhi: " << mArrayIdx<MElem *>(mMET[bt], idx)->getEntries();
+      }
     }
 
     // check one object, if it exists, then the remaining ME's exists too
@@ -68,10 +80,11 @@ void METTesterPostProcessor::mFillAggrHistograms(std::string metdir, DQMStore::I
         mMETResolAggr[bt]->setBinError(idx + 1, resolError);
 
         float significance = metRMS < std::numeric_limits<float>::epsilon() ? 0.f : metMean / metRMS;
-        float significance_error = metRMS < std::numeric_limits<float>::epsilon() || metMean < std::numeric_limits<float>::epsilon()
-                                       ? 0.f
-                                       : significance * std::sqrt((metRMS * metRMS / (metMean * metMean)) +
-                                                                  (resolError * resolError / (metRMS * metRMS)));
+        float significance_error =
+            metRMS < std::numeric_limits<float>::epsilon() || metMean < std::numeric_limits<float>::epsilon()
+                ? 0.f
+                : significance * std::sqrt((metRMS * metRMS / (metMean * metMean)) +
+                                           (resolError * resolError / (metRMS * metRMS)));
         mMETSignAggr[bt]->setBinContent(idx + 1, significance);
         mMETSignAggr[bt]->setBinError(idx + 1, significance_error);
       }

--- a/Validation/RecoMET/plugins/METTesterPostProcessor.cc
+++ b/Validation/RecoMET/plugins/METTesterPostProcessor.cc
@@ -57,7 +57,7 @@ void METTesterPostProcessor::mFillAggrHistograms(std::string metdir, DQMStore::I
             mArrayIdx<MElem *>(mMETDiff_GenMETTrue[bt], idx)->getEntries() < mEpsilonDouble ||
             mArrayIdx<MElem *>(mMETRatio_GenMETTrue[bt], idx)->getEntries() < mEpsilonDouble ||
             mArrayIdx<MElem *>(mMETDeltaPhi_GenMETTrue[bt], idx)->getEntries() < mEpsilonDouble) {
-          edm::LogWarning("METTesterPostProcessor")
+          LogDebug("METTesterPostProcessor")
               << "At least one of the " << bt + edges << " histograms has zero entries:\n"
               << "  MET: " << mArrayIdx<MElem *>(mMET[bt], idx)->getEntries() << "\n"
               << "  METDiff: " << mArrayIdx<MElem *>(mMETDiff_GenMETTrue[bt], idx)->getEntries() << "\n"

--- a/Validation/RecoMET/plugins/METTesterPostProcessor.cc
+++ b/Validation/RecoMET/plugins/METTesterPostProcessor.cc
@@ -67,8 +67,8 @@ void METTesterPostProcessor::mFillAggrHistograms(std::string metdir, DQMStore::I
         mMETResolAggr[bt]->setBinContent(idx + 1, metRMS);
         mMETResolAggr[bt]->setBinError(idx + 1, resolError);
 
-        float significance = metRMS < FLT_EPSILON ? 0.f : metMean / metRMS;
-        float significance_error = metRMS < FLT_EPSILON || metMean < FLT_EPSILON
+        float significance = metRMS < std::numeric_limits<float>::epsilon() ? 0.f : metMean / metRMS;
+        float significance_error = metRMS < std::numeric_limits<float>::epsilon() || metMean < std::numeric_limits<float>::epsilon()
                                        ? 0.f
                                        : significance * std::sqrt((metRMS * metRMS / (metMean * metMean)) +
                                                                   (resolError * resolError / (metRMS * metRMS)));

--- a/Validation/RecoMET/plugins/METTesterPostProcessor.h
+++ b/Validation/RecoMET/plugins/METTesterPostProcessor.h
@@ -22,9 +22,11 @@ private:
   void dqmEndJob(DQMStore::IBooker&, DQMStore::IGetter&) override;
   std::vector<std::string> met_dirs;
 
-  void mFillAggrHistograms(std::string, DQMStore::IGetter&);
-
   using MElem = MonitorElement;
+
+  void mFillAggrHistograms(std::string, DQMStore::IGetter&);
+  bool mCheckHisto(MElem* h);
+
   template <typename T>
   using ArrayVariant = std::variant<std::array<T, METTester::mNMETBins + 1>, std::array<T, METTester::mNPhiBins + 1>>;
 

--- a/Validation/RecoMET/plugins/METTesterPostProcessor.h
+++ b/Validation/RecoMET/plugins/METTesterPostProcessor.h
@@ -59,6 +59,9 @@ private:
   ElemMap mMETSignAggr;
 
   std::string runDir;
+
+  float mEpsilonFloat = std::numeric_limits<float>::epsilon();
+  double mEpsilonDouble = std::numeric_limits<double>::epsilon();
 };
 
 #endif


### PR DESCRIPTION
Hotfix to #49073, avoiding division by zero.


I've also included the fix for the UBSAN build errors observed in https://github.com/cms-sw/cmssw/pull/48745#issuecomment-3372834032.

