### PR TITLE
PerfTools/AllocMonitor: Update edmModuleAllocJsonToCircles.py to add "event setup" transition for ESProducers

### DIFF
--- a/PerfTools/AllocMonitor/scripts/edmModuleAllocJsonToCircles.py
+++ b/PerfTools/AllocMonitor/scripts/edmModuleAllocJsonToCircles.py
@@ -153,7 +153,7 @@ def formatToCircles(moduleTransitions):
                 recordName = ""
 
             modules_dict[displayKey] = {
-                "label": f"{recordName}" if recordName else moduleLabel,
+                "label": moduleLabel,
                 "type": moduleType,
                 "record": recordName
             }

--- a/PerfTools/AllocMonitor/scripts/edmModuleAllocJsonToCircles.py
+++ b/PerfTools/AllocMonitor/scripts/edmModuleAllocJsonToCircles.py
@@ -14,7 +14,7 @@ transitionTypes = [
     "global begin luminosity block",
     "stream begin luminosity block",
     "event",
-    "ESProducer",
+    "event setup",
 ]
 allocTypes = ["added", "nAlloc", "nDealloc", "maxTemp", "max1Alloc"]
 
@@ -125,7 +125,7 @@ def formatToCircles(moduleTransitions):
     all_module_keys = set()
     for transitionType, moduleTransition in moduleTransitions.items():
         for uniqueKey in moduleTransition.keys():
-            if transitionType == "ESProducer":
+            if transitionType == "event setup":
                 displayKey = uniqueKey
             else:
                 displayKey = uniqueKey  # For regular transitions, this is just the module label
@@ -153,7 +153,7 @@ def formatToCircles(moduleTransitions):
                 recordName = ""
 
             modules_dict[displayKey] = {
-                "label": moduleLabel,
+                "label": recordName if recordName else moduleLabel,
                 "type": moduleType,
                 "record": recordName
             }
@@ -169,7 +169,7 @@ def formatToCircles(moduleTransitions):
             allocs = info.get("allocs", [])
 
             # For ESProducer transitions, use the unique key; for others, use original label
-            if transitionType == "ESProducer":
+            if transitionType == "event setup":
                 displayKey = uniqueKey
             else:
                 displayKey = uniqueKey  # For regular transitions, this is just the module label
@@ -255,7 +255,7 @@ def main(args):
     moduleTransitions = dict()
     for transition in transitionTypes:
         moduleTransition = dict()
-        if transition == "ESProducer":
+        if transition == "event setup":
             # ESProducer transitions are handled differently - look for records with names
             processESProducerTransition("source", "PoolSource", doc["source"], moduleTransition)
             for moduleLabel, moduleInfo in doc["modules"].items():

--- a/PerfTools/AllocMonitor/scripts/edmModuleAllocJsonToCircles.py
+++ b/PerfTools/AllocMonitor/scripts/edmModuleAllocJsonToCircles.py
@@ -19,7 +19,7 @@ transitionTypes = [
     "global begin luminosity block",
     "stream begin luminosity block",
     "event",
-    "event setup",
+    EVENTSETUP_TRANSITION,
 ]
 allocTypes = ["added", "nAlloc", "nDealloc", "maxTemp", "max1Alloc"]
 

--- a/PerfTools/AllocMonitor/scripts/edmModuleAllocJsonToCircles.py
+++ b/PerfTools/AllocMonitor/scripts/edmModuleAllocJsonToCircles.py
@@ -37,27 +37,27 @@ def processModuleTransition(moduleLabel, moduleType, moduleInfo, transitionType,
         }
     Any missing field defaults to 0.
 
-    Note: Entries with record names are excluded as they belong to event setup transition only.
+    Note: Entries with record names are excluded as they belong to EventSetup transition only.
     """
     moduleKey = UniqueKey(moduleLabel, moduleType, "")
     moduleTransition[moduleKey] = {"cpptype": moduleType, "allocs": []}
     for entry in moduleInfo:
         # Only process entries that match the transition type AND don't have record names
-        # (entries with record names are event setup-only)
+        # (entries with record names are EventSetup only)
         if (entry.get("transition", None) == transitionType and
             not ("record" in entry and "name" in entry["record"])):
             moduleTransition[moduleKey]["allocs"].append(entry.get("alloc", {}))
     moduleTransition[moduleKey]["nTransitions"] = len(moduleTransition[moduleKey]["allocs"])
 
 def processESModuleTransition(moduleLabel, moduleType, moduleInfo, moduleTransition):
-    """Process event setup transitions - entries with record names
+    """Process EventSetup transitions - entries with record names
 
     Creates unique entries for each module+type+record combination.
     """
     # Group allocations by record name
     recordAllocations = {}
     for entry in moduleInfo:
-        # event setup entries are those with a "record" field containing "name"
+        # EventSetup entries are those with a "record" field containing "name"
         if "record" in entry and "name" in entry["record"]:
             recordName = entry["record"]["name"]
             if recordName not in recordAllocations:
@@ -233,7 +233,7 @@ def main(args):
     for transition in transitionTypes:
         moduleTransition = dict()
         if transition == EVENTSETUP_TRANSITION:
-            # event setup transitions are handled differently - look for records with names
+            # EventSetup transitions are handled differently - look for records with names
             for moduleLabel, moduleInfo in doc["modules"].items():
                 processESModuleTransition(moduleLabel, moduleTypes[moduleLabel], moduleInfo, moduleTransition)
         else:


### PR DESCRIPTION
Updated edmModuleAllocJsonToCircles.py to treat ESmodules that appear in edmModuleAllocMonitorAnalyze.py output json files in `event`, `stream begin lumi` and `stream begin run` transitions as their own transition `event setup`.  These `event setup` transitions are identified by the presence of  `["record"]["name"] ` field in the list element. They are excluded from the averages for other transitions.

Addresses https://github.com/cms-sw/framework-team/issues/1582
