### PR TITLE
[DAQ] SFB mode detection of run end flag

### DIFF
--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -139,8 +139,12 @@ namespace evf {
                                   bool requireHeader,
                                   bool retry,
                                   bool closeFile);
+
+    uint16_t frdFileDataType(const void* buf) const;
+
     int grabNextJsonFromRaw(std::string const& rawSourcePath,
                             int& rawFd,
+                            uint16_t& rawDataType,
                             uint16_t& rawHeaderSize,
                             int64_t& fileSizeFromHeader,
                             bool& fileFound,
@@ -157,6 +161,7 @@ namespace evf {
                                      unsigned int& ls,
                                      std::string& nextFile,
                                      int& rawFd,
+                                     uint16_t& rawDataType,
                                      uint16_t& rawHeaderSize,
                                      int32_t& serverEventsInNewFile_,
                                      int64_t& fileSize,

--- a/EventFilter/Utilities/interface/SourceRawFile.h
+++ b/EventFilter/Utilities/interface/SourceRawFile.h
@@ -95,6 +95,7 @@ public:
   std::vector<uint64_t> bufferEnds_;
   std::vector<uint64_t> fileSizes_;
   std::vector<unsigned int> fileOrder_;
+  std::vector<uint16_t> fileDataType_;
   bool deleteFile_;
   int rawFd_;
   uint64_t fileSize_;
@@ -115,6 +116,7 @@ public:
             std::string const& name = std::string(),
             bool deleteFile = true,
             int rawFd = -1,
+            uint16_t rawDataType = 0,
             uint64_t fileSize = 0,
             uint16_t rawHeaderSize = 0,
             uint16_t nChunks = 0,
@@ -134,6 +136,7 @@ public:
         nProcessed_(0) {
     fileNames_.push_back(name);
     fileOrder_.push_back(fileOrder_.size());
+    fileDataType_.push_back(rawDataType);
     diskFileSizes_.push_back(fileSize);
     fileSizes_.push_back(0);
     bufferOffsets_.push_back(0);
@@ -159,6 +162,7 @@ public:
     numFiles_++;
     fileNames_.push_back(name);
     fileOrder_.push_back(fileOrder_.size());
+    fileDataType_.push_back(0);
     diskFileSizes_.push_back(size);
     fileSizes_.push_back(0);
     bufferOffsets_.push_back(prevOffset + prevSize);
@@ -205,6 +209,13 @@ public:
       throw cms::Exception("InputFile") << "buffers are inconsistent for input files with primary " << fileName_;
     return complete > 0;
   }
+  void setFileDataType(unsigned int j, uint16_t dataType) { fileDataType_[j] = dataType; }
+  int daqRunEndFlagIndex() const {
+    for (unsigned j = 0; j < fileDataType_.size(); j++)
+      if (fileDataType_[j] == 0xffff)
+        return (int)j;
+    return -1;
+  }
 };
 
 class DAQSource;
@@ -216,12 +227,14 @@ public:
                std::string const& name = std::string(),
                bool deleteFile = true,
                int rawFd = -1,
+               uint16_t rawDataType = 0,
                uint64_t fileSize = 0,
                uint16_t rawHeaderSize = 0,
                uint32_t nChunks = 0,
                int nEvents = 0,
                DAQSource* parent = nullptr)
-      : InputFile(status, lumi, name, deleteFile, rawFd, fileSize, rawHeaderSize, nChunks, nEvents, nullptr),
+      : InputFile(
+            status, lumi, name, deleteFile, rawFd, rawDataType, fileSize, rawHeaderSize, nChunks, nEvents, nullptr),
         sourceParent_(parent) {}
   bool advance(std::mutex& m, std::condition_variable& cv, unsigned char*& dataPosition, const size_t size);
   void advance(const size_t size) {

--- a/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
+++ b/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
@@ -25,6 +25,7 @@ using namespace edm::streamer;
 RawEventFileWriterForBU::RawEventFileWriterForBU(edm::ParameterSet const& ps)
     : microSleep_(ps.getParameter<int>("microSleep")),
       frdFileVersion_(ps.getParameter<unsigned int>("frdFileVersion")),
+      dataType_(ps.getUntrackedParameter<unsigned int>("dataType")),
       writeEoR_(ps.getUntrackedParameter<bool>("writeEoR")),
       writeToOpen_(ps.getUntrackedParameter<bool>("writeToOpen")) {
   if (edm::Service<evf::FastMonitoringService>().isAvailable())
@@ -247,7 +248,8 @@ void RawEventFileWriterForBU::finishFileWrite(unsigned int ls) {
         << " and size " << perFileSize_.value();
   } else if (frdFileVersion_ == 2) {
     lseek(outfd_, 0, SEEK_SET);
-    FRDFileHeader_v2 frdFileHeader(0, perFileEventCount_.value(), (uint32_t)run_, (uint32_t)ls, perFileSize_.value());
+    FRDFileHeader_v2 frdFileHeader(
+        (uint16_t)(dataType_ & 0xffff), perFileEventCount_.value(), (uint32_t)run_, (uint32_t)ls, perFileSize_.value());
     write(outfd_, (char*)&frdFileHeader, sizeof(FRDFileHeader_v2));
     closefd();
     //move raw file from open to run directory
@@ -342,5 +344,6 @@ void RawEventFileWriterForBU::stop() {
 void RawEventFileWriterForBU::extendDescription(edm::ParameterSetDescription& desc) {
   desc.add<int>("microSleep", 0);
   desc.add<unsigned int>("frdFileVersion", 0);
+  desc.addUntracked<unsigned int>("dataType", 0)->setComment("data typw field in FRD file header v2");
   desc.addUntracked<bool>("writeEoR", true);
 }

--- a/EventFilter/Utilities/plugins/RawEventFileWriterForBU.h
+++ b/EventFilter/Utilities/plugins/RawEventFileWriterForBU.h
@@ -88,6 +88,7 @@ private:
 
   int microSleep_;
   unsigned int frdFileVersion_;
+  unsigned int dataType_;
   bool writeEoR_;
   bool writeToOpen_;
 

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -850,6 +850,7 @@ void FedRawDataInputSource::readSupervisor() {
     uint32_t lsFromRaw = 0;
     int32_t serverEventsInNewFile = -1;
     int rawFd = -1;
+    uint16_t rawDataType = 0;
 
     int backoff_exp = 0;
 
@@ -895,7 +896,6 @@ void FedRawDataInputSource::readSupervisor() {
         //return LS if LS not set, otherwise return file
         status = getFile(ls, nextFile, fileSizeIndex, thisLockWaitTimeUs);
         if (status == evf::EvFDaqDirector::newFile) {
-          uint16_t rawDataType;
           if (evf::EvFDaqDirector::parseFRDFileHeader(nextFile,
                                                       rawFd,
                                                       rawHeaderSize,
@@ -922,6 +922,7 @@ void FedRawDataInputSource::readSupervisor() {
                                                      ls,
                                                      nextFile,
                                                      rawFd,
+                                                     rawDataType,
                                                      rawHeaderSize,
                                                      serverEventsInNewFile,
                                                      fileSizeFromMetadata,
@@ -1102,7 +1103,7 @@ void FedRawDataInputSource::readSupervisor() {
             uint16_t rawHeaderCheck;
             bool fileFound;
             eventsInNewFile = daqDirector_->grabNextJsonFromRaw(
-                nextFile, rawFdEmpty, rawHeaderCheck, fileSizeFromMetadata, fileFound, 0, true);
+                nextFile, rawFdEmpty, rawDataType, rawHeaderCheck, fileSizeFromMetadata, fileFound, 0, true);
             assert(fileFound && rawHeaderCheck == rawHeaderSize);
             daqDirector_->unlockFULocal();
           } else
@@ -1125,6 +1126,7 @@ void FedRawDataInputSource::readSupervisor() {
                                                               rawFile,
                                                               !fileListMode_,
                                                               rawFd,
+                                                              rawDataType,
                                                               fileSize,
                                                               rawHeaderSize,
                                                               neededChunks,

--- a/EventFilter/Utilities/test/startBU.py
+++ b/EventFilter/Utilities/test/startBU.py
@@ -82,7 +82,11 @@ options.register ('writeToOpen',
                   VarParsing.VarParsing.varType.int,          # string, int, or float
                   "Write only to open directory")
 
-
+options.register ('eventDataType',
+                  0,
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,
+                  "Event data type value in FRD file header v2")
 
 options.parseArguments()
 
@@ -161,6 +165,7 @@ if  options.dataType == "FRD":
         numEventsPerFile = cms.uint32(options.eventsPerFile),
         frdVersion = cms.uint32(6),
         frdFileVersion = cms.uint32(options.frdFileVersion),
+        dataType = cms.untracked.uint32(options.eventDataType),
         writeToOpen = cms.untracked.bool(True if options.writeToOpen else False)
         )
 
@@ -178,6 +183,7 @@ elif  options.dataType == "DTH":
         numEventsPerFile = cms.uint32(options.eventsPerFile),
         frdVersion = cms.uint32(0),
         frdFileVersion = cms.uint32(0),
+        dataType = cms.untracked.uint32(options.eventDataType),
         sourceIdList = cms.untracked.vuint32(66,1511),
         rawProductName = cms.untracked.string("RawDataBuffer")
     )

--- a/EventFilter/Utilities/test/testIncompleteSFB.sh
+++ b/EventFilter/Utilities/test/testIncompleteSFB.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function diebu {  echo Failure $1: status $2 ; echo "" ; echo "----- Error -----"; echo ""; cat out_2_bu.log;  rm -rf $3/{ramdisk,data,dqmdisk,ecalInDir,*.py}; exit $2 ; }
+function diefu {  echo Failure $1: status $2 ; echo "" ; echo "----- Error -----"; echo ""; cat out_2_fu.log;  rm -rf $3/{ramdisk,data,dqmdisk,ecalInDir,*.py}; exit $2 ; }
+function diedqm { echo Failure $1: status $2 ; echo "" ; echo "----- Error -----"; echo ""; cat out_2_dqm.log; rm -rf $3/{ramdisk,data,dqmdisk,ecalInDir,*.py}; exit $2 ; }
+function dieecal { echo Failure $1: status $2 ; echo "" ; echo "----- Error -----"; echo ""; cat out_2_ecal.log; rm -rf $3/{ramdisk,data,dqmdisk,ecalInDir,*.py}; exit $2 ; }
+
+copy_index_files() {
+  directory=$1
+  sourceid=$2
+  del_orig=$3
+  shopt -s nullglob
+  for file in "$directory"/*_index*.raw; do
+    filename=$(basename "$file")
+    if [[ "$filename" =~ ^(.*)_index([0-9]+)\.raw$ ]]; then
+        base="${BASH_REMATCH[1]}"
+        x="${BASH_REMATCH[2]}"
+        new_name="${base}_index${x}_source${sourceid}.raw"
+        cp -- "$file" "$directory/$new_name"
+        #echo "Copied: $filename -> $new_name"
+        if [[ $del_orig -eq 1 ]]; then
+          rm -rf $file
+        fi
+    fi
+  done
+  shopt -u nullglob
+}
+
+copy_json_files() {
+  directory=$1
+  sourceid=$2
+  shopt -s nullglob
+  for file in "$directory"/*.jsn; do
+    filename=$(basename "$file")
+    if [[ "$filename" =~ ^(.*)_EoR.jsn$ ]]; then
+        base="${BASH_REMATCH[1]}"
+        x="${BASH_REMATCH[2]}"
+        new_name="${base}_EoR_source${sourceid}.jsn"
+        mv "$file" "$directory/$new_name"
+    fi
+    if [[ "$filename" =~ ^(.*)_EoLS.jsn$ ]]; then
+        base="${BASH_REMATCH[1]}"
+        x="${BASH_REMATCH[2]}"
+        new_name="${base}_EoLS_source${sourceid}.jsn"
+        mv "$file" "$directory/$new_name"
+    fi
+  done
+  shopt -u nullglob
+}
+
+FUSCRIPT="startFU.py"
+
+if [ -z  ${SCRAM_TEST_PATH} ]; then
+SCRAM_TEST_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+fi
+echo "SCRAM_TEST_PATH = ${SCRAM_TEST_PATH}"
+
+RC=0
+P=$$
+PREFIX=results_${USER}${P}
+OUTDIR=${PWD}/${PREFIX}
+
+echo "OUT_TMP_DIR = $OUTDIR"
+
+mkdir ${OUTDIR}
+cp ${SCRIPTDIR}/startBU.py ${OUTDIR}
+cp ${SCRIPTDIR}/startFU.py ${OUTDIR}
+cp ${SCRIPTDIR}/ufu2.py ${OUTDIR}
+cp ${SCRIPTDIR}/startFU_daqsource.py ${OUTDIR}
+cp ${SCRIPTDIR}/unittest_FU_daqsource.py ${OUTDIR}
+cp ${SCRIPTDIR}/startFU_ds_multi.py ${OUTDIR}
+cp ${SCRIPTDIR}/test_dqmstream.py ${OUTDIR}
+cp ${SCRIPTDIR}/testECALCalib_cfg.py ${OUTDIR}
+cd ${OUTDIR}
+
+rm -rf $OUTDIR/{ramdisk,data,dqmdisk,ecalInDir,*.log}
+
+runnumber="100101"
+
+################
+echo "Running fileListMode test"
+
+echo "running DAQSource test with striped event FRD (SFB)"
+CMDLINE_STARTBU="cmsRun startBU.py runNumber=${runnumber} fffBaseDir=${OUTDIR} maxLS=2 fedMeanSize=128 eventsPerFile=20 eventsPerLS=35 frdFileVersion=2 buBaseDir=ramdisk1 subsystems=TCDS,SiPixel,ECAL,RPC"
+#CMDLINE_STARTBU="cmsRun startBU.py runNumber=${runnumber} fffBaseDir=${OUTDIR} maxLS=2 fedMeanSize=128 eventsPerFile=20 eventsPerLS=35 frdFileVersion=2 buBaseDir=ramdisk1 subsystems=TCDS,SiPixel,ECAL,RPC eventDataType=65535"
+${CMDLINE_STARTBU}
+CMDLINE_STARTBU="cmsRun startBU.py runNumber=${runnumber} fffBaseDir=${OUTDIR} maxLS=2 fedMeanSize=128 eventsPerFile=20 eventsPerLS=35 frdFileVersion=2 buBaseDir=ramdisk2 subsystems=SiStrip,HCAL,DT,CSC eventDataType=65535"
+#CMDLINE_STARTBU="cmsRun startBU.py runNumber=${runnumber} fffBaseDir=${OUTDIR} maxLS=2 fedMeanSize=128 eventsPerFile=20 eventsPerLS=35 frdFileVersion=2 buBaseDir=ramdisk2 subsystems=SiStrip,HCAL,DT,CSC"
+${CMDLINE_STARTBU}
+#run reader
+CMDLINE_STARTFU="cmsRun startFU_daqsource.py daqSourceMode=FRDStriped runNumber=${runnumber} fffBaseDir=${OUTDIR} numRamdisks=2"
+${CMDLINE_STARTFU}
+
+rm -rf $OUTDIR
+exit ${RC}


### PR DESCRIPTION
#### PR description:

Adding detection of run-end flag set by SFB RU in case of run blocked, out of sync and subsequent end of run which closes files without complete fragment content.
Instead of throwing exception in CMSSW, the process ends run and hltd will take care of closing the lumisection with processed events.
It reused FRD file header V2 used already in L1 Scouting. Data type filed is reused, as L1 Scouting used only values 0-32. Here, value of 0xffff is used for the flag.

#### PR validation:

Tested with SFB in DAQ3VAL system.
A tect script is also added to the source.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport is planned for 15_1_X and 15_0_X and PRs will follow up