### PR TITLE
[FWCore] Fix segmentation fault in testRefInROOT::testGoodChain when using TChain

### DIFF
--- a/FWCore/FWLite/test/ref_t.cppunit.cpp
+++ b/FWCore/FWLite/test/ref_t.cppunit.cpp
@@ -216,6 +216,7 @@ void testRefInROOT::testGoodChain() {
   TChain eventChain(edm::poolNames::eventTreeName().c_str());
   eventChain.Add("good.root");
   eventChain.Add("good_delta5.root");
+  eventChain.LoadTree(0);
 
   edm::Wrapper<edmtest::OtherThingCollection>* pOthers = nullptr;
   TBranch* othersBranch = nullptr;
@@ -226,6 +227,9 @@ void testRefInROOT::testGoodChain() {
   eventChain.SetBranchAddress("edmtestThings_Thing__TEST.", &pThings, &thingsBranch);
 
   int nev = eventChain.GetEntries();
+  if (nev == TTree::kMaxEntries) {
+    return;
+  }
   for (int ev = 0; ev < nev; ++ev) {
     std::cout << "event #" << ev << std::endl;
     othersBranch->SetAddress(&pOthers);

--- a/FWCore/FWLite/test/ref_t.cppunit.cpp
+++ b/FWCore/FWLite/test/ref_t.cppunit.cpp
@@ -227,9 +227,6 @@ void testRefInROOT::testGoodChain() {
   eventChain.SetBranchAddress("edmtestThings_Thing__TEST.", &pThings, &thingsBranch);
 
   int nev = eventChain.GetEntries();
-  if (nev == TTree::kMaxEntries) {
-    return;
-  }
   for (int ev = 0; ev < nev; ++ev) {
     std::cout << "event #" << ev << std::endl;
     othersBranch->SetAddress(&pOthers);


### PR DESCRIPTION
#### PR description:

This PR fixes a segmentation fault in testRefInROOT::testGoodChain caused by calling SetBranchAddress() before the TChain had loaded its first tree.
TChain::SetBranchAddress() requires fTree to be initialized (fTreeNumber >= 0), which wasn’t the case — resulting in null TBranch* pointers and a crash at runtime.