### PR TITLE
Drop not used Vector3D in header and Update BTagPerformance.h

### DIFF
--- a/PhysicsTools/CandUtils/interface/EventShapeVariables.h
+++ b/PhysicsTools/CandUtils/interface/EventShapeVariables.h
@@ -20,7 +20,6 @@
 	   Christian Veelken, UC Davis
 */
 
-#include "DataFormats/Math/interface/Vector3D.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 

--- a/PhysicsTools/CandUtils/interface/Thrust.h
+++ b/PhysicsTools/CandUtils/interface/Thrust.h
@@ -31,7 +31,6 @@
  *
  *
  */
-#include "DataFormats/Math/interface/Vector3D.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include <vector>
 

--- a/PhysicsTools/PatExamples/interface/BTagPerformance.h
+++ b/PhysicsTools/PatExamples/interface/BTagPerformance.h
@@ -12,6 +12,7 @@
 #include "TArrayD.h"
 #include "TGraph.h"
 #include <cassert>
+#include <cmath>
 #include <map>
 
 class BTagPerformance {


### PR DESCRIPTION
#### PR description:

This PR performs minor cleanup and header corrections across a few packages.

- Dropped #include "DataFormats/Math/interface/Vector3D.h" from files in PhysicsTools/CandUtils/interface/{EventShapeVariables.h,Thrust.h}, as it’s no longer required.
- Updated PhysicsTools/PatExamples/interface/BTagPerformance.h to explicitly include <cmath> 