### PR TITLE
Implement GPU vs CPU comparison for HLT heterogeneous products in patatrack workflows

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1369,7 +1369,7 @@ upgradeWFs['PatatrackECALOnlyAlpaka'] = PatatrackWorkflow(
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     reco = {
-        '-s': 'RAW2DIGI:RawToDigi_ecalOnly,RECO:reconstruction_ecalOnly,VALIDATION:@ecalOnlyValidation,DQM:@ecalOnly',
+        '-s': 'RAW2DIGI:RawToDigi_ecalOnly,RECO:reconstruction_ecalOnly,VALIDATION:@ecalOnlyValidation,DQM:@ecalOnly+@hltGPUvsCPU',
         '--procModifiers': 'alpaka',
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
@@ -1391,7 +1391,7 @@ upgradeWFs['PatatrackECALOnlyAlpakaValidation'] = PatatrackWorkflow(
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     reco = {
-        '-s': 'RAW2DIGI:RawToDigi_ecalOnly,RECO:reconstruction_ecalOnly,VALIDATION:@ecalOnlyValidation,DQM:@ecalOnly',
+        '-s': 'RAW2DIGI:RawToDigi_ecalOnly,RECO:reconstruction_ecalOnly,VALIDATION:@ecalOnlyValidation,DQM:@ecalOnly+@hltGPUvsCPU',
         '--procModifiers': 'alpakaValidation',
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
@@ -1410,7 +1410,7 @@ upgradeWFs['PatatrackHCALOnlyAlpakaValidation'] = PatatrackWorkflow(
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     reco = {
-        '-s': 'RAW2DIGI:RawToDigi_hcalOnly,RECO:reconstruction_hcalOnly,VALIDATION:@hcalOnlyValidation,DQM:@hcalOnly+@hcal2Only',
+        '-s': 'RAW2DIGI:RawToDigi_hcalOnly,RECO:reconstruction_hcalOnly,VALIDATION:@hcalOnlyValidation,DQM:@hcalOnly+@hcal2Only+@hltGPUvsCPU',
         '--procModifiers': 'alpaka',
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
@@ -1429,7 +1429,7 @@ upgradeWFs['PatatrackHCALOnlyGPUandAlpakaValidation'] = PatatrackWorkflow(
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     reco = {
-        '-s': 'RAW2DIGI:RawToDigi_hcalOnly,RECO:reconstruction_hcalOnlyLegacy+reconstruction_hcalOnly,VALIDATION:@hcalOnlyValidation+pfClusterHBHEOnlyAlpakaComparisonSequence,DQM:@hcalOnly+@hcal2Only+hcalOnlyOfflineSourceSequenceAlpaka',
+        '-s': 'RAW2DIGI:RawToDigi_hcalOnly,RECO:reconstruction_hcalOnlyLegacy+reconstruction_hcalOnly,VALIDATION:@hcalOnlyValidation+pfClusterHBHEOnlyAlpakaComparisonSequence,DQM:@hcalOnly+@hcal2Only+hcalOnlyOfflineSourceSequenceAlpaka+@hltGPUvsCPU',
         '--procModifiers': 'alpaka',
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
@@ -1465,7 +1465,7 @@ upgradeWFs['PatatrackFullRecoAlpaka'] = PatatrackWorkflow(
     },
     reco = {
         # skip the @pixelTrackingOnlyValidation which cannot run together with the full reconstruction
-        '-s': 'RAW2DIGI:RawToDigi+RawToDigi_pixelOnly,L1Reco,RECO:reconstruction+reconstruction_pixelTrackingOnly,RECOSIM,PAT,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@ExtraHLT+@miniAODDQM+@pixelTrackingOnlyDQM',
+        '-s': 'RAW2DIGI:RawToDigi+RawToDigi_pixelOnly,L1Reco,RECO:reconstruction+reconstruction_pixelTrackingOnly,RECOSIM,PAT,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@ExtraHLT+@miniAODDQM+@pixelTrackingOnlyDQM+@hltGPUvsCPU',
         '--procModifiers': 'alpaka',
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
@@ -1487,7 +1487,7 @@ upgradeWFs['PatatrackFullRecoAlpaka'] = PatatrackWorkflow(
     },
     reco = {
         # skip the @pixelTrackingOnlyValidation which cannot run together with the full reconstruction
-        '-s': 'RAW2DIGI:RawToDigi+RawToDigi_pixelOnly,L1Reco,RECO:reconstruction+reconstruction_pixelTrackingOnly,RECOSIM,PAT,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@ExtraHLT+@miniAODDQM+@pixelTrackingOnlyDQM',
+        '-s': 'RAW2DIGI:RawToDigi+RawToDigi_pixelOnly,L1Reco,RECO:reconstruction+reconstruction_pixelTrackingOnly,RECOSIM,PAT,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@ExtraHLT+@miniAODDQM+@pixelTrackingOnlyDQM+@hltGPUvsCPU',
         '--procModifiers': 'alpaka',
         '--customise' : 'RecoTracker/Configuration/customizePixelTracksForTriplets.customizePixelTracksForTriplets,HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
@@ -1508,7 +1508,7 @@ upgradeWFs['PatatrackPixelOnlyAlpaka'] = PatatrackWorkflow(
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     reco = {
-        '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM',
+        '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM+@hltGPUvsCPU',
         '--procModifiers': 'alpaka',
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
@@ -1529,7 +1529,7 @@ upgradeWFs['PatatrackPixelOnlyAlpakaValidation'] = PatatrackWorkflow(
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     reco = {
-        '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM',
+        '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM+@hltGPUvsCPU',
         '--procModifiers': 'alpakaValidation',
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
@@ -1568,7 +1568,7 @@ upgradeWFs['PatatrackPixelOnlyTripletsAlpaka'] = PatatrackWorkflow(
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     reco = {
-        '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM',
+        '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM+@hltGPUvsCPU',
         '--procModifiers': 'alpaka',
         '--customise' : 'RecoTracker/Configuration/customizePixelTracksForTriplets.customizePixelTracksForTriplets,HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling'
     },
@@ -1589,7 +1589,7 @@ upgradeWFs['PatatrackPixelOnlyTripletsAlpakaValidation'] = PatatrackWorkflow(
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     reco = {
-        '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM',
+        '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM+@hltGPUvsCPU',
         '--procModifiers': 'alpakaValidation',
         '--customise' : 'RecoTracker/Configuration/customizePixelTracksForTriplets.customizePixelTracksForTriplets,HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling'
     },

--- a/DQM/PFTasks/plugins/PFHcalGPUComparisonTask.cc
+++ b/DQM/PFTasks/plugins/PFHcalGPUComparisonTask.cc
@@ -89,6 +89,7 @@ private:
   MonitorElement* pfCluster_Eta_Diff_HostvsDevice_;
   MonitorElement* pfCluster_Phi_Diff_HostvsDevice_;
 
+  std::string subsystemDir_;
   std::string pfCaloGPUCompDir_;
 };
 
@@ -98,9 +99,11 @@ PFHcalGPUComparisonTask::PFHcalGPUComparisonTask(edm::ParameterSet const& conf)
           consumes<reco::PFClusterCollection>(conf.getUntrackedParameter<edm::InputTag>("pfClusterToken_ref"))},
       pfClusterTok_target_{
           consumes<reco::PFClusterCollection>(conf.getUntrackedParameter<edm::InputTag>("pfClusterToken_target"))},
+      subsystemDir_{conf.getUntrackedParameter<std::string>("subsystem")},
       pfCaloGPUCompDir_{conf.getUntrackedParameter<std::string>("name")} {}
 
 void PFHcalGPUComparisonTask::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& r, edm::EventSetup const& es) {
+  _subsystem = subsystemDir_;
   ibooker.setCurrentFolder(pfCaloGPUCompDir_);
   DQTask::bookHistograms(ibooker, r, es);
   //	Book monitoring elements
@@ -254,6 +257,7 @@ void PFHcalGPUComparisonTask::globalEndLuminosityBlock(edm::LuminosityBlock cons
 
 void PFHcalGPUComparisonTask::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
+  desc.addUntracked<std::string>("subsystem", "ParticleFlow");
   desc.addUntracked<std::string>("name", "ParticleFlow/pfCaloGPUCompDir");
   desc.addUntracked<edm::InputTag>("pfClusterToken_ref", edm::InputTag("hltParticleFlowClusterHCALSerialSync"));
   desc.addUntracked<edm::InputTag>("pfClusterToken_target", edm::InputTag("hltParticleFlowClusterHCAL"));

--- a/DQM/PFTasks/plugins/PFHcalGPUComparisonTask.cc
+++ b/DQM/PFTasks/plugins/PFHcalGPUComparisonTask.cc
@@ -101,8 +101,7 @@ PFHcalGPUComparisonTask::PFHcalGPUComparisonTask(edm::ParameterSet const& conf)
       pfCaloGPUCompDir_{conf.getUntrackedParameter<std::string>("name")} {}
 
 void PFHcalGPUComparisonTask::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& r, edm::EventSetup const& es) {
-  _subsystem = "ParticleFlow";
-  ibooker.setCurrentFolder("ParticleFlow/" + pfCaloGPUCompDir_);
+  ibooker.setCurrentFolder(pfCaloGPUCompDir_);
   DQTask::bookHistograms(ibooker, r, es);
   //	Book monitoring elements
   const char* histo;
@@ -158,11 +157,19 @@ void PFHcalGPUComparisonTask::bookHistograms(DQMStore::IBooker& ibooker, edm::Ru
 void PFHcalGPUComparisonTask::_resetMonitors(hcaldqm::UpdateFreq uf) { DQTask::_resetMonitors(uf); }
 
 void PFHcalGPUComparisonTask::_process(edm::Event const& event, edm::EventSetup const&) {
-  edm::Handle<reco::PFClusterCollection> pfClusters_ref;
-  event.getByToken(pfClusterTok_ref_, pfClusters_ref);
+  const auto& pfClusters_ref = event.getHandle(pfClusterTok_ref_);
+  const auto& pfClusters_target = event.getHandle(pfClusterTok_target_);
 
-  edm::Handle<reco::PFClusterCollection> pfClusters_target;
-  event.getByToken(pfClusterTok_target_, pfClusters_target);
+  // Exit early if any handle is invalid
+  if (!pfClusters_ref || !pfClusters_target) {
+    edm::LogWarning out("PFHcalGPUComparisonTask");
+    if (!pfClusters_ref)
+      out << "reference PF cluster collection not found; ";
+    if (!pfClusters_target)
+      out << "target PF cluster collection not found; ";
+    out << "the comparison will not run.";
+    return;
+  }
 
   auto lumiCache = luminosityBlockCache(event.getLuminosityBlock().index());
   _currentLS = lumiCache->currentLS;
@@ -247,7 +254,7 @@ void PFHcalGPUComparisonTask::globalEndLuminosityBlock(edm::LuminosityBlock cons
 
 void PFHcalGPUComparisonTask::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.addUntracked<std::string>("name", "pfCaloGPUCompDir");
+  desc.addUntracked<std::string>("name", "ParticleFlow/pfCaloGPUCompDir");
   desc.addUntracked<edm::InputTag>("pfClusterToken_ref", edm::InputTag("hltParticleFlowClusterHCALSerialSync"));
   desc.addUntracked<edm::InputTag>("pfClusterToken_target", edm::InputTag("hltParticleFlowClusterHCAL"));
   descriptions.addWithDefaultLabel(desc);

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -34,7 +34,7 @@ DQMOfflineDCS = cms.Sequence( dqmProvInfo )
 DQMOfflineScouting = cms.Sequence( hltScoutingDqmOffline ) 
 
 # HLT Heterogeneous monitoring sequence
-DQMOfflineHLTGPUvsCPU =  cms.Sequence( HLT_HeterogeneousMonitoringSequence )
+DQMOfflineHLTGPUvsCPU =  cms.Sequence( HLTHeterogeneousMonitoringSequence )
 
 # L1 trigger sequences
 DQMOfflineL1T = cms.Sequence( l1TriggerDqmOffline ) # L1 emulator is run within this sequence for real data

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -4,22 +4,23 @@ from DQMServices.Components.DQMMessageLogger_cfi import *
 from DQMServices.Components.DQMProvInfo_cfi import *
 from DQMServices.Components.DQMFastTimerService_cff import *
 
-from DQMOffline.HLTScouting.HLTScoutingDqmOffline_cff import *
-from DQMOffline.L1Trigger.L1TriggerDqmOffline_cff import *
-from DQMOffline.Ecal.ecal_dqm_source_offline_cff import *
-from DQM.EcalPreshowerMonitorModule.es_dqm_source_offline_cff import *
-from DQM.HcalTasks.OfflineSourceSequence_pp import *
-from DQMOffline.Hcal.HcalDQMOfflineSequence_cff import *
-from DQM.SiStripMonitorClient.SiStripSourceConfigTier0_cff import *
-from DQM.SiPixelCommon.SiPixelOfflineDQM_source_cff import *
-from DQM.DTMonitorModule.dtDQMOfflineSources_cff import *
-from DQM.RPCMonitorClient.RPCTier0Source_cff import *
 from DQM.CSCMonitorModule.csc_dqm_sourceclient_offline_cff import *
-from DQM.GEM.gem_dqm_offline_source_cff import *
-from DQM.CastorMonitor.castor_dqm_sourceclient_offline_cff import *
 from DQM.CTPPS.ctppsDQM_cff import *
-from DQM.SiTrackerPhase2.Phase2TrackerDQMFirstStep_cff import *
+from DQM.CastorMonitor.castor_dqm_sourceclient_offline_cff import *
+from DQM.DTMonitorModule.dtDQMOfflineSources_cff import *
+from DQM.EcalPreshowerMonitorModule.es_dqm_source_offline_cff import *
+from DQM.GEM.gem_dqm_offline_source_cff import *
+from DQM.HcalTasks.OfflineSourceSequence_pp import *
+from DQM.RPCMonitorClient.RPCTier0Source_cff import *
+from DQM.SiPixelCommon.SiPixelOfflineDQM_source_cff import *
 from DQM.SiPixelHeterogeneous.SiPixelHeterogenousDQM_FirstStep_cff import *
+from DQM.SiStripMonitorClient.SiStripSourceConfigTier0_cff import *
+from DQM.SiTrackerPhase2.Phase2TrackerDQMFirstStep_cff import *
+from DQMOffline.Ecal.ecal_dqm_source_offline_cff import *
+from DQMOffline.HLTScouting.HLTScoutingDqmOffline_cff import *
+from DQMOffline.Hcal.HcalDQMOfflineSequence_cff import *
+from DQMOffline.L1Trigger.L1TriggerDqmOffline_cff import *
+from DQMOffline.Trigger.HeterogeneousMonitoring_cff import *
 
 DQMNone = cms.Sequence()
 
@@ -31,6 +32,9 @@ DQMOfflineDCS = cms.Sequence( dqmProvInfo )
 
 # HLT Scouting trigger sequence
 DQMOfflineScouting = cms.Sequence( hltScoutingDqmOffline ) 
+
+# HLT Heterogeneous monitoring sequence
+DQMOfflineHLTGPUvsCPU =  cms.Sequence( HLT_HeterogeneousMonitoringSequence )
 
 # L1 trigger sequences
 DQMOfflineL1T = cms.Sequence( l1TriggerDqmOffline ) # L1 emulator is run within this sequence for real data

--- a/DQMOffline/Configuration/python/autoDQM.py
+++ b/DQMOffline/Configuration/python/autoDQM.py
@@ -231,6 +231,10 @@ autoDQM = { 'DQMMessageLogger': ['DQMMessageLoggerSeq',
 			    'PostDQMOffline',
 			    'DQMHarvestHLTScouting'],
 
+            'hltGPUvsCPU' : ['DQMOfflineHLTGPUvsCPU',
+                             'PostDQMOffline',
+                             'dqmHarvesting'],
+
             'standardDQMExpress': ['DQMOfflineExpress',
                                    'PostDQMOffline',
                                    'dqmHarvestingExpress'],

--- a/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
@@ -18,7 +18,8 @@ import FWCore.ParameterSet.Config as cms
 from DQM.PFTasks.pfHcalGPUComparisonTask_cfi import *  
 
 hltPfHcalGPUComparisonTask = pfHcalGPUComparisonTask.clone(
-    name = cms.untracked.string('HLT/HeterogeneousComparisons/ParticleFlow'),
+    subsystem = cms.untracked.string("HLT"),
+    name = cms.untracked.string('HeterogeneousComparisons/ParticleFlow'),
     pfClusterToken_ref = cms.untracked.InputTag('hltParticleFlowClusterHCALSerialSync'),
     pfClusterToken_target = cms.untracked.InputTag('hltParticleFlowClusterHCAL'),   
 )
@@ -40,6 +41,7 @@ hltSiPixelPhase1CompareDigiErrors = siPixelPhase1RawDataErrorComparator.clone(
 from DQM.HcalTasks.hcalGPUComparisonTask_cfi import *
 
 hltHcalGPUComparisonTask = hcalGPUComparisonTask.clone(
+    subsystem = "HLT",
     tagHBHE_ref = "hltHbherecoSerialSync",
     tagHBHE_target = "hltHbhereco"
 )

--- a/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
@@ -75,9 +75,12 @@ hltHcalGPUComparisonTask = hcalGPUComparisonTask.clone(
     tagHBHE_target = "hltHbhereco"
 )
 
-HLT_HeterogeneousMonitoringSequence = cms.Sequence(
+HLTHeterogeneousMonitoringSequence = cms.Sequence(
     hltPfHcalGPUComparisonTask+
     hltSiPixelPhase1CompareDigiErrors+
     hltEcalMonitorTask+
     hltHcalGPUComparisonTask    
 )
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toReplaceWith(HLTHeterogeneousMonitoringSequence,cms.Sequence())

--- a/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
@@ -1,0 +1,51 @@
+import FWCore.ParameterSet.Config as cms
+
+# list of products available 
+# outputCommands = cms.untracked.vstring( 'drop *',
+#       'keep *_hltEcalDigisSerialSync_*_*',
+#       'keep *_hltEcalDigis_*_*',
+#       'keep *_hltEcalUncalibRecHitSerialSync_*_*',
+#       'keep *_hltEcalUncalibRecHit_*_*',
+#       'keep *_hltHbherecoSerialSync_*_*',
+#       'keep *_hltHbhereco_*_*',
+#       'keep *_hltParticleFlowClusterHCALSerialSync_*_*',
+#       'keep *_hltParticleFlowClusterHCAL_*_*',
+#       'keep *_hltSiPixelDigiErrorsSerialSync_*_*',
+#       'keep *_hltSiPixelDigiErrors_*_*' )
+# )
+
+# Particle Flow 
+from DQM.PFTasks.pfHcalGPUComparisonTask_cfi import *  
+
+hltPfHcalGPUComparisonTask = pfHcalGPUComparisonTask.clone(
+    name = cms.untracked.string('HLT/HeterogeneousComparisons/ParticleFlow'),
+    pfClusterToken_ref = cms.untracked.InputTag('hltParticleFlowClusterHCALSerialSync'),
+    pfClusterToken_target = cms.untracked.InputTag('hltParticleFlowClusterHCAL'),   
+)
+
+# Tracker
+from DQM.SiPixelHeterogeneous.SiPixelHeterogenousDQM_FirstStep_cff import *
+
+hltSiPixelPhase1CompareDigiErrors = siPixelPhase1RawDataErrorComparator.clone(
+    topFolderName = cms.string('HLT/HeterogeneousComparisons/PixelErrors'),
+    pixelErrorSrcGPU = cms.InputTag("hltSiPixelDigiErrors"),
+    pixelErrorSrcCPU = cms.InputTag("hltSiPixelDigiErrorsSerialSync")
+)
+
+# Ecal
+
+# TBD
+
+# Hcal
+from DQM.HcalTasks.hcalGPUComparisonTask_cfi import *
+
+hltHcalGPUComparisonTask = hcalGPUComparisonTask.clone(
+    tagHBHE_ref = "hltHbherecoSerialSync",
+    tagHBHE_target = "hltHbhereco"
+)
+
+HLT_HeterogeneousMonitoringSequence = cms.Sequence(
+    hltPfHcalGPUComparisonTask+
+    hltSiPixelPhase1CompareDigiErrors+
+    hltHcalGPUComparisonTask    
+)

--- a/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
@@ -35,7 +35,36 @@ hltSiPixelPhase1CompareDigiErrors = siPixelPhase1RawDataErrorComparator.clone(
 
 # Ecal
 
-# TBD
+from DQM.EcalMonitorTasks.EcalMonitorTask_cfi import *
+from DQM.EcalMonitorTasks.ecalGpuTask_cfi import ecalGpuTask as _ecalGpuTask
+
+hltEcalGpuTask =  _ecalGpuTask.clone(
+    params = _ecalGpuTask.params.clone(
+        runGpuTask = True,
+        enableRecHit = False
+    )
+)
+
+hltEcalMonitorTask = ecalMonitorTask.clone(
+    workers = ['GpuTask'],
+    workerParameters = cms.untracked.PSet(GpuTask = hltEcalGpuTask),
+    verbosity = 0,
+    commonParameters = ecalMonitorTask.commonParameters.clone(
+        willConvertToEDM = False,
+        onlineMode = True
+    ),
+    collectionTags = ecalMonitorTask.collectionTags.clone(
+        EcalRawData          = cms.untracked.InputTag("hltEcalDigisSerialSync"),
+        EBCpuDigi            = cms.untracked.InputTag("hltEcalDigisSerialSync", "ebDigis"),
+        EECpuDigi            = cms.untracked.InputTag("hltEcalDigisSerialSync", "eeDigis"),
+        EBGpuDigi            = cms.untracked.InputTag("hltEcalDigis", "ebDigis"),
+        EEGpuDigi            = cms.untracked.InputTag("hltEcalDigis", "eeDigis"),
+        EBCpuUncalibRecHit   = cms.untracked.InputTag("hltEcalUncalibRecHitSerialSync", "EcalUncalibRecHitsEB"),
+        EECpuUncalibRecHit   = cms.untracked.InputTag("hltEcalUncalibRecHitSerialSync", "EcalUncalibRecHitsEE"),
+        EBGpuUncalibRecHit   = cms.untracked.InputTag("hltEcalUncalibRecHit", "EcalUncalibRecHitsEB"),
+        EEGpuUncalibRecHit   = cms.untracked.InputTag("hltEcalUncalibRecHit", "EcalUncalibRecHitsEE")
+    )
+)
 
 # Hcal
 from DQM.HcalTasks.hcalGPUComparisonTask_cfi import *
@@ -49,5 +78,6 @@ hltHcalGPUComparisonTask = hcalGPUComparisonTask.clone(
 HLT_HeterogeneousMonitoringSequence = cms.Sequence(
     hltPfHcalGPUComparisonTask+
     hltSiPixelPhase1CompareDigiErrors+
+    hltEcalMonitorTask+
     hltHcalGPUComparisonTask    
 )


### PR DESCRIPTION
#### PR description:

It has been discussed that it would be desirable to have means to assess the discrepancies in the heterogeneous reconstruction chains when run on CPU vs GPU backends at release validation level by submitting some of the existing patatrack workflows on dedicated resources. 
In all those workflows the HLT menu is run as part of the step 2 and in PR https://github.com/cms-sw/cmssw/pull/49079 we have percolated the `DQMGPUvsCPU` stream event content (as it is run online) to the `HLTDebugRAW` and `HLTDebugFEVT` for release validation purposes. 
This means we can thus finally profit of the existing DQM infrastructure (developed for online DQM) to generate such comparisons in relvals.
The goal of this PR is to provide the infrastructural changes to do so, while making sure to not crash the process in case some of the input collections are not available.

#### PR validation:

I have run the following workflow 

```
runTheMatrix.py --what gpu -l 17034.402 -t 4 -j 8 --ibeos
```

both in a machine equipped with a NVIDIA T4 GPU and in one without GPU attached, and I was able to inspect the output comparison plots in the earlier case.
I have also run the subset of relval test in the `gpu` matrix run in PR tests via:

```
runTheMatrix.py --job-reports -w gpu -l 17034.402,17034.403,17034.406,17034.412,17034.422,17034.423,29834.402,29834.403,29834.404,29834.704,29834.751 --ibeos
```

and did not observe issues.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, I think it would be useful to backport at least to CMSSW_15_1_X.

Cc: @AdrianoDee @fwyzard @bainbrid @mtosi 
