### PR TITLE
Have HGCal SoA classes be storable by RNTuple

### DIFF
--- a/DataFormats/HGCalDigi/src/classes_def.xml
+++ b/DataFormats/HGCalDigi/src/classes_def.xml
@@ -46,19 +46,19 @@
   <class name="hgcaldigi::HGCalDigiHost"/>
 
   <class name="hgcaldigi::HGCalDigiSoALayout<128,false>"/>
-  <class name="edm::Wrapper<PortableHostCollection<hgcaldigi::HGCalDigiSoALayout<128,false> > >" splitLevel="0"/>
+  <class name="edm::Wrapper<PortableHostCollection<hgcaldigi::HGCalDigiSoALayout<128,false> > >" splitLevel="0" rntupleStreamerMode="true"/>
 
   <!-- Recursive templates implementing the association of indices and layouts, and containing the data -->
   <class name="portablecollection::CollectionLeaf<0, hgcaldigi::HGCalDigiSoALayout<128, false>>"/>
 
   <class name="hgcaldigi::HGCalECONDPacketInfoSoA"/>
   <class name="hgcaldigi::HGCalECONDPacketInfoSoA::View"/>
-  <class name="hgcaldigi::HGCalECONDPacketInfoHost"/>
+  <class name="hgcaldigi::HGCalECONDPacketInfoHost" rntupleStreamerMode="true"/>
   <class name="edm::Wrapper<hgcaldigi::HGCalECONDPacketInfoHost>" splitLevel="0"/>
 
   <class name="hgcaldigi::HGCalFEDPacketInfoSoA"/>
   <class name="hgcaldigi::HGCalFEDPacketInfoSoA::View"/>
-  <class name="hgcaldigi::HGCalFEDPacketInfoHost"/>
+  <class name="hgcaldigi::HGCalFEDPacketInfoHost" rntupleStreamerMode="true"/>
   <class name="edm::Wrapper<hgcaldigi::HGCalFEDPacketInfoHost>" splitLevel="0"/>
 
 </lcgdict>

--- a/DataFormats/HGCalReco/src/classes_def.xml
+++ b/DataFormats/HGCalReco/src/classes_def.xml
@@ -83,17 +83,17 @@
   <class name="edm::Wrapper<MtdHostCollection>" splitLevel="0"/>
 
   <class name="HGCalSoARecHits"/>
-  <class name="HGCalSoARecHitsHostCollection" ClassVersion="3">
+  <class name="HGCalSoARecHitsHostCollection" ClassVersion="3" rntupleStreamerMode="true">
     <version ClassVersion="3" checksum="1452864040"/>
   </class>
   <class name="edm::Wrapper<HGCalSoARecHitsHostCollection>" splitLevel="0"/>
 
   <class name="HGCalSoARecHitsExtra"/>
-  <class name="HGCalSoARecHitsExtraHostCollection"/>
+  <class name="HGCalSoARecHitsExtraHostCollection" rntupleStreamerMode="true"/>
   <class name="edm::Wrapper<HGCalSoARecHitsExtraHostCollection>" splitLevel="0"/>
 
   <class name="HGCalSoAClusters"/>
-  <class name="HGCalSoAClustersHostCollection"/>
+  <class name="HGCalSoAClustersHostCollection" rntupleStreamerMode="true"/>
   <class name="edm::Wrapper<HGCalSoAClustersHostCollection>" splitLevel="0"/>
 
 </lcgdict>


### PR DESCRIPTION
#### PR description:

This required declaring them using rntupleStreamerMode="true"
This fixes the failure seen in workflow 77.0 in the RNTUPLE_X IB.

#### PR validation:

Now running the workflow succeeds.

resolves https://github.com/cms-sw/cmssw/issues/49090
resolves https://github.com/cms-sw/framework-team/issues/1605