### PR TITLE
Introduce new dEdX weights V19 HGCAL Geometry

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
@@ -59,6 +59,55 @@ weightsPerLayer_V16 = cms.vdouble(dummy_weight,
                                   83.61,
                                   83.61)
 
+weightsPerLayer_V19 = cms.vdouble(dummy_weight,
+                                  4.25, # MeV
+                                  12.86,
+                                  6.98,
+                                  12.86,
+                                  6.98,
+                                  12.86,
+                                  6.98,
+                                  12.86,
+                                  6.98,
+                                  12.86,
+                                  6.98,
+                                  12.86,
+                                  6.98,
+                                  12.86,
+                                  6.98,
+                                  12.86,
+                                  6.98,
+                                  12.86,
+                                  11.18,
+                                  12.86,
+                                  11.18,
+                                  12.86,
+                                  11.18,
+                                  12.86,
+                                  11.18,
+                                  12.86,
+                                  55.47,
+                                  60.07,
+                                  60.07,
+                                  60.07,
+                                  60.07,
+                                  60.07,
+                                  60.07,
+                                  60.07,
+                                  60.07,
+                                  60.07,
+                                  60.07,
+                                  82.45,
+                                  82.45,
+                                  82.45,
+                                  82.45,
+                                  82.45,
+                                  82.45,
+                                  82.45,
+                                  82.45,
+                                  82.45,
+                                  82.45)
+
 
 dEdX = cms.PSet(
 	# for v10 geometry
@@ -141,6 +190,22 @@ dEdX_v16 = cms.PSet(
                               92.283895)
 )
 
+# for v19 geometry
+dEdX_v19 = cms.PSet(
+    weights = cms.vdouble(calcWeights(weightsPerLayer_V19)),
+
+    weightsNose = cms.vdouble(0.0,   # there is no layer zero
+                              39.500245, # MeV
+                              39.756638,
+                              39.756638,
+                              39.756638,
+                              39.756638,
+                              66.020266,
+                              92.283895,
+                              92.283895)
+)
+
+
 # HGCAL rechit producer
 HGCalRecHit = cms.EDProducer(
     "HGCalRecHitProducer",
@@ -216,4 +281,4 @@ phase2_hgcalV16.toModify(HGCalRecHit,
 phase2_hgcalV19.toModify(HGCalRecHit, 
                          thicknessCorrection = [0.75, 0.76, 0.75, 0.76, 0.85, 0.85, 0.84, 0.85] , 
                          sciThicknessCorrection =  0.69,
-                         layerWeights = dEdX_v16.weights) 
+                         layerWeights = dEdX_v19.weights) 


### PR DESCRIPTION
This PR adds the new dEdX weights for the V19 HGCAL Geometry. 


Should be tested on a D120 workflow:
Maybe:
 `34234.0 TTbar_14TeV_TuneCP5_Run4D120PU_GenSimHLBeamSpot14+DigiTriggerPU_Run4D120PU+RecoGlobalPU_Run4D120PU+HARVESTGlobalPU_Run4D120PU` ?

@pfs @felicepantaleo 