### PR TITLE
Insert a newline at end of file if missing

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -15,3 +15,4 @@ AlwaysBreakTemplateDeclarations: Yes
 ReflowComments: false
 BinPackArguments: false
 BinPackParameters: false
+InsertNewlineAtEOF: true


### PR DESCRIPTION
#### PR description:

Add a `clang-format` rule to insert a newline at end of file if missing.

See https://releases.llvm.org/16.0.0/tools/clang/docs/ClangFormatStyleOptions.html#insertnewlineateof .

#### PR validation:

None.