### PR TITLE
Fix digi morphing (offline) out-of-bounds access

### DIFF
--- a/RecoLocalTracker/SiPixelDigiReProducers/plugins/SiPixelDigiMorphing.cc
+++ b/RecoLocalTracker/SiPixelDigiReProducers/plugins/SiPixelDigiMorphing.cc
@@ -136,7 +136,7 @@ void SiPixelDigiMorphing::produce(edm::Event& e, const edm::EventSetup& es) {
   const TrackerTopology* tTopo = &es.getData(trackerTopologyToken_);
 
   const int rocSize = nrows_ + 2 * iters_;
-  const int arrSize = nrocs_ * rocSize;
+  const int arrSize = nrocs_ * rocSize + ksize_;
 
   uint64_t imap[arrSize];
   uint64_t map1[arrSize];


### PR DESCRIPTION
#### PR description:
This PR adresses an issue reported here: https://github.com/cms-sw/cmssw/issues/49112
In the [`morph`](https://github.com/cms-sw/cmssw/blob/baf71ca92cc5ec69a5a14c7c8a57a2cadf9eaf79/RecoLocalTracker/SiPixelDigiReProducers/plugins/SiPixelDigiMorphing.cc#L210) method, expressions `valid = (valid << 1) | (*i[ii] != 0);`  could dereference pointers that point past the end of the input map when processing the final rows of a ROC, where no padding is present.

This fix adds kernel-sized zero padding to prevent this.

Potentially introduces small changes in offline digi-morphing wfs, although the out-of-bound accessed memory is not used anywhere.

#### PR validation:

Passes one of the wfs (143.901) that have been reported as failing in CMSSW_16_0_ASAN_X_2025-10-08-2300

`runTheMatrix.py -l limited -i all --ibeos` running.

To be backported to 15.1.X
