### PR TITLE
Changing https to http for CMS network in the uploadConditions script [15_1_X]

### DIFF
--- a/CondCore/Utilities/scripts/uploadConditions.py
+++ b/CondCore/Utilities/scripts/uploadConditions.py
@@ -455,7 +455,7 @@ class ConditionsUploader(object):
             '''
             self.http = HTTP()
             if socket.getfqdn().strip().endswith('.cms'):
-                self.http.setProxy('https://cmsproxy.cms:3128/')
+                self.http.setProxy('http://cmsproxy.cms:3128/')
             self.http.setBaseUrl(self.urlTemplate % self.hostname)
             '''Signs in the server.
             '''


### PR DESCRIPTION
this is a backport of https://github.com/cms-sw/cmssw/pull/49116

#### PR description:

This PR changes https to http in CMS network within the `uploadConditions.py` script, to enable uploads of conditions from `ngtcalfu-c2b04-43-01`, as it failed before, within the package:
```
git cms-addpkg CondCore/Utilities
```

#### PR validation:

When trying to upload conditions before, one would get the following message:
```
[jprendi@ngtcalfu-c2b03-43-01 db]$ uploadConditions.py promptCalibConditions_2023485
[2025-10-08 18:05:10,373] INFO: Checking promptCalibConditions_2023485...
[2025-10-08 18:05:10,397] INFO: netrc entry "ConditionUploader" not found: if you wish not to have to retype your password, you can add an entry in your .netrc file. However, beware of the risks of having your password stored as plaintext. Instead.

Username [jprendi]: jprendi
Password:
[2025-10-08 18:05:24,538] INFO: cms-conddb-dev.cern.ch: Signing in user jprendi ...
[2025-10-08 18:05:24,776] ERROR: Caught exception when trying to connect to cms-conddb-dev.cern.ch: (35, 'error:1408F10B:SSL routines:ssl3_get_record:wrong version number')
[2025-10-08 18:05:24,777] ERROR: Error trying to connect to the server. Aborting.
{'status': -1, 'error': 'Error trying to connect to the server. Aborting.'}
upload ended with code: -1

```

The proposed fix came from @fwyzard , which in the end enabled conditions uploading:
```
[jprendi@ngtcalfu-c2b04-43-01 src]$ uploadConditions.py promptCalibConditions_2023485
[2025-10-09 15:49:09,174] INFO: Checking promptCalibConditions_2023485...
[2025-10-09 15:49:09,187] INFO: netrc entry "ConditionUploader" not found: if you wish not to have to retype your password, you can add an entry in your .netrc file. However, beware of the risks of having your password stored as plaintext. Instead.

Username [jprendi]: jprendi
Password: 
[2025-10-09 15:49:17,666] INFO: cms-conddb-dev.cern.ch: Signing in user jprendi ...
[2025-10-09 15:49:18,077] INFO: cms-conddb-dev.cern.ch: promptCalibConditions_2023485: Uploading file (684653cdc5949bf7af6f1ccc1b581b617e65f29a, size 1063341) to the online backend...
[2025-10-09 15:49:19,749] INFO: tag EcalPedestals_NGT_2023485_test successfully uploaded
[2025-10-09 15:49:19,749] INFO: tags sucessfully uploaded: ['EcalPedestals_NGT_2023485_test'] 
[2025-10-09 15:49:19,749] INFO: file log at: https://cms-conddb.cern.ch/cmsDbBrowser/logs/show_cond_uploader_log/Prep/684653cdc5949bf7af6f1ccc1b581b617e65f29a
[2025-10-09 15:49:19,749] INFO: cms-conddb-dev.cern.ch: Signing out...
{'status': 0, 'files': {'promptCalibConditions_2023485': True}}
upload ended with code: 0

```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/49116

cc: @mmusich 


