### PR TITLE
L1 emulator of topological trigger for cms-sw

### DIFF
--- a/L1Trigger/L1TGlobal/interface/GlobalDefinitions.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalDefinitions.h
@@ -83,6 +83,7 @@ namespace l1t {
     TypeZDCP,
     TypeZDCM,
     TypeAXOL1TL,
+    TypeTOPO,
     TypeCICADA,
     GtConditionTypeInvalid = -1
   };
@@ -108,6 +109,7 @@ namespace l1t {
     CondMuonShower,
     CondEnergySumZdc,
     CondAXOL1TL,
+    CondTOPO,
     CondCICADA,
     GtConditionCategoryInvalid = -1
   };

--- a/L1Trigger/L1TGlobal/interface/TOPOCondition.h
+++ b/L1Trigger/L1TGlobal/interface/TOPOCondition.h
@@ -1,0 +1,91 @@
+#ifndef L1Trigger_L1TGlobal_TOPOCondition_h
+#define L1Trigger_L1TGlobal_TOPOCondition_h
+
+/**
+ * \class TOPOCondition
+ *
+ * Description: evaluation of a CondTOPO condition.
+ */
+
+#include <iosfwd>
+#include <string>
+#include <utility>
+
+#include "L1Trigger/L1TGlobal/interface/ConditionEvaluation.h"
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+
+#include "hls4ml/emulator.h"
+
+// forward declarations
+class GlobalCondition;
+class TOPOTemplate;
+
+namespace l1t {
+
+  class L1Candidate;
+  class GlobalBoard;
+
+  // class declaration
+  class TOPOCondition : public ConditionEvaluation {
+  public:
+    /// constructors
+    ///     default
+    TOPOCondition();
+
+    ///     from base template condition (from event setup usually)
+    TOPOCondition(const GlobalCondition*, const GlobalBoard*);
+
+    // copy constructor
+    TOPOCondition(const TOPOCondition&);
+    // destructor
+    ~TOPOCondition() override;
+
+    // assign operator
+    TOPOCondition& operator=(const TOPOCondition&);
+
+    /// the core function to check if the condition matches
+    const bool evaluateCondition(const int bxEval) const override;
+
+    /// print condition
+    void print(std::ostream& myCout) const override;
+
+    ///   get / set the pointer to a Condition
+    inline const TOPOTemplate* gtTOPOTemplate() const { return m_gtTOPOTemplate; }
+
+    void setGtTOPOTemplate(const TOPOTemplate*);
+
+    ///   get / set the pointer to GTL
+    inline const GlobalBoard* gtGTB() const { return m_gtGTB; }
+
+    void setuGtB(const GlobalBoard*);
+
+    /// get/set score value
+    void setScore(const float scoreval) const;
+
+    inline float getScore() const { return m_savedscore; }
+
+    void loadModel();
+
+    inline hls4mlEmulator::ModelLoader const& model_loader() const { return m_model_loader; }
+
+  private:
+    /// copy function for copy constructor and operator=
+    void copy(const TOPOCondition& cp);
+
+    /// pointer to a TOPOTemplate
+    const TOPOTemplate* m_gtTOPOTemplate;
+
+    /// pointer to uGt GlobalBoard, to be able to get the trigger objects
+    const GlobalBoard* m_gtGTB;
+
+    static constexpr char const* kModelNamePrefix = "topo_";
+
+    hls4mlEmulator::ModelLoader m_model_loader;
+    std::shared_ptr<hls4mlEmulator::Model> m_model;
+
+    ///axo score for possible score saving
+    mutable float m_savedscore;
+  };
+
+}  // namespace l1t
+#endif

--- a/L1Trigger/L1TGlobal/interface/TOPOTemplate.h
+++ b/L1Trigger/L1TGlobal/interface/TOPOTemplate.h
@@ -1,0 +1,79 @@
+#ifndef L1Trigger_L1TGlobal_TOPOTemplate_h
+#define L1Trigger_L1TGlobal_TOPOTemplate_h
+
+/**
+ * \class TOPOTemplate
+ *
+ *
+ * Description: L1 Global Trigger TOPO template.
+ *
+ * \author: Melissa Quinnan (UC San Diego)
+ *
+ */
+
+// system include files
+#include <string>
+#include <iosfwd>
+
+// user include files
+
+//   base class
+#include "L1Trigger/L1TGlobal/interface/GlobalCondition.h"
+
+// forward declarations
+
+// class declaration
+class TOPOTemplate : public GlobalCondition {
+public:
+  // constructor
+  TOPOTemplate();
+
+  // constructor
+  TOPOTemplate(const std::string&);
+
+  // constructor
+  TOPOTemplate(const std::string&, const l1t::GtConditionType&);
+
+  // copy constructor
+  TOPOTemplate(const TOPOTemplate&);
+
+  // destructor
+  ~TOPOTemplate() override;
+
+  // assign operator
+  TOPOTemplate& operator=(const TOPOTemplate&);
+
+  // typedef for a single object template
+  struct ObjectParameter {
+    int minTOPOThreshold;
+    int maxTOPOThreshold;
+  };
+
+public:
+  inline const std::vector<ObjectParameter>* objectParameter() const { return &m_objectParameter; }
+
+  inline const std::string& modelVersion() const { return m_modelVersion; }
+
+  /// set functions
+  void setConditionParameter(const std::vector<ObjectParameter>& objParameter);
+
+  void setModelVersion(const std::string& modelversion);
+
+  /// print the condition
+  void print(std::ostream& myCout) const override;
+
+  /// output stream operator
+  friend std::ostream& operator<<(std::ostream&, const TOPOTemplate&);
+
+private:
+  /// copy function for copy constructor and operator=
+  void copy(const TOPOTemplate& cp);
+
+  /// variables containing the parameters
+  std::vector<ObjectParameter> m_objectParameter;
+
+  /// model version
+  std::string m_modelVersion;
+};
+
+#endif

--- a/L1Trigger/L1TGlobal/interface/TriggerMenu.h
+++ b/L1Trigger/L1TGlobal/interface/TriggerMenu.h
@@ -37,6 +37,7 @@
 #include "L1Trigger/L1TGlobal/interface/EnergySumTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/EnergySumZdcTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/AXOL1TLTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/TOPOTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/CICADATemplate.h"
 #include "L1Trigger/L1TGlobal/interface/ExternalTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/CorrelationTemplate.h"
@@ -62,6 +63,7 @@ public:
               const std::vector<std::vector<EnergySumTemplate> >&,
               const std::vector<std::vector<EnergySumZdcTemplate> >&,
               const std::vector<std::vector<AXOL1TLTemplate> >&,
+              const std::vector<std::vector<TOPOTemplate> >&,
               const std::vector<std::vector<CICADATemplate> >&,
               const std::vector<std::vector<ExternalTemplate> >&,
               const std::vector<std::vector<CorrelationTemplate> >&,
@@ -147,6 +149,11 @@ public:
   inline const std::vector<std::vector<AXOL1TLTemplate> >& vecAXOL1TLTemplate() const { return m_vecAXOL1TLTemplate; }
 
   void setVecAXOL1TLTemplate(const std::vector<std::vector<AXOL1TLTemplate> >&);
+
+  //
+  inline const std::vector<std::vector<TOPOTemplate> >& vecTOPOTemplate() const { return m_vecTOPOTemplate; }
+
+  void setVecTOPOTemplate(const std::vector<std::vector<TOPOTemplate> >&);
 
   //
   inline const std::vector<std::vector<CICADATemplate> >& vecCICADATemplate() const { return m_vecCICADATemplate; }
@@ -256,6 +263,7 @@ private:
   std::vector<std::vector<EnergySumTemplate> > m_vecEnergySumTemplate;
   std::vector<std::vector<EnergySumZdcTemplate> > m_vecEnergySumZdcTemplate;
   std::vector<std::vector<AXOL1TLTemplate> > m_vecAXOL1TLTemplate;
+  std::vector<std::vector<TOPOTemplate> > m_vecTOPOTemplate;
   std::vector<std::vector<CICADATemplate> > m_vecCICADATemplate;
 
   std::vector<std::vector<ExternalTemplate> > m_vecExternalTemplate;

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -338,6 +338,7 @@ void L1TGlobalProducer::beginRun(edm::Run const& iRun, const edm::EventSetup& ev
                                              gtParser.vecEnergySumTemplate(),
                                              gtParser.vecEnergySumZdcTemplate(),
                                              gtParser.vecAXOL1TLTemplate(),
+                                             gtParser.vecTOPOTemplate(),
                                              gtParser.vecCICADATemplate(),
                                              gtParser.vecExternalTemplate(),
                                              gtParser.vecCorrelationTemplate(),

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -149,6 +149,10 @@ void l1t::TriggerMenuParser::setVecAXOL1TLTemplate(const std::vector<std::vector
   m_vecAXOL1TLTemplate = vecAXOL1TLTempl;
 }
 
+void l1t::TriggerMenuParser::setVecTOPOTemplate(const std::vector<std::vector<TOPOTemplate> >& vecTOPOTempl) {
+  m_vecTOPOTemplate = vecTOPOTempl;
+}
+
 void l1t::TriggerMenuParser::setVecCICADATemplate(const std::vector<std::vector<CICADATemplate> >& vecCICADATempl) {
   m_vecCICADATemplate = vecCICADATempl;
 }
@@ -233,6 +237,7 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
   m_vecEnergySumTemplate.resize(m_numberConditionChips);
   m_vecEnergySumZdcTemplate.resize(m_numberConditionChips);
   m_vecAXOL1TLTemplate.resize(m_numberConditionChips);
+  m_vecTOPOTemplate.resize(m_numberConditionChips);
   m_vecCICADATemplate.resize(m_numberConditionChips);
   m_vecExternalTemplate.resize(m_numberConditionChips);
 
@@ -333,6 +338,10 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
         } else if (condition.getType() == esConditionType::Axol1tlTrigger ||
                    condition.getType() == esConditionType::AnomalyDetectionTrigger) {
           parseAXOL1TL(condition, chipNr);
+        
+          //parse TOPO
+        } else if (condition.getType() == esConditionType::TopologicalTrigger) {
+          parseTOPO(condition, chipNr);
 
           //parse CICADA
         } else if (condition.getType() == esConditionType::CicadaTrigger) {
@@ -2880,6 +2889,105 @@ bool l1t::TriggerMenuParser::parseAXOL1TL(L1TUtmCondition condAXOL1TL, unsigned 
   }
 
   (m_vecAXOL1TLTemplate[chipNr]).push_back(axol1tlCond);
+
+  return true;
+}
+
+/**
+ * Parse conditions of Topological Trigger - dummy function so far
+ */
+
+bool l1t::TriggerMenuParser::parseTOPO(L1TUtmCondition condTOPO, unsigned int chipNr) {
+  using namespace tmeventsetup;
+
+  std::cout << "#### parse TOPO information ####" << std::endl;
+  // std::cout << l1t2string(condTOPO.getType()) << std::endl;
+  // std::cout << l1t2string(condTOPO.getName()) << std::endl;
+  // std::cout << l1t2string(condTOPO.getObjects().at(0).getType()) << std::endl;
+
+  // get condition, particle name and particle type
+  std::string condition = "axol1tl";
+  std::string type = l1t2string(condTOPO.getType());
+  std::string name = l1t2string(condTOPO.getName());
+
+  LogDebug("TriggerMenuParser") << " ****************************************** " << std::endl
+                                << "     (in parseTOPO) " << std::endl
+                                << " condition = " << condition << std::endl
+                                << " type      = " << type << std::endl
+                                << " name      = " << name << std::endl;
+
+  const int nrObj = 1;
+  GtConditionType cType = TypeTOPO;
+
+  std::vector<TOPOTemplate::ObjectParameter> objParameter(nrObj);
+
+  if (int(condTOPO.getObjects().size()) != nrObj) {
+    edm::LogError("TriggerMenuParser") << " condTOPO objects: nrObj = " << nrObj
+                                       << "condTOPO.getObjects().size() = " << condTOPO.getObjects().size()
+                                       << std::endl;
+    return false;
+  }
+
+  // Get the axol1tl object
+  L1TUtmObject object = condTOPO.getObjects().at(0);
+  int relativeBx = object.getBxOffset();
+  bool gEq = (object.getComparisonOperator() == esComparisonOperator::GE);
+
+  //Loop over cuts for this  object
+  int lowerThresholdInd = 0;
+  int upperThresholdInd = -1;
+
+  //save model and threshold
+  std::string model = "";
+
+  // for UTM v12+
+  const std::vector<L1TUtmCut>& cuts = object.getCuts();
+  for (size_t kk = 0; kk < cuts.size(); kk++) {
+    const L1TUtmCut& cut = cuts.at(kk);
+
+    //save model
+    if (cut.getCutType() == tmeventsetup::Model) {
+      model = cut.getData();
+    }
+    //save score
+    else if (cut.getCutType() == esCutType::Score) {
+      lowerThresholdInd = cut.getMinimum().value;
+      upperThresholdInd = cut.getMaximum().value;
+    }  //end else if
+  }  //end cut loop
+
+  // check model version is not empty
+  if (model.empty()) {
+    edm::LogError("TriggerMenuParser") << "    Error: TOPO movel version is empty" << std::endl;
+    return false;
+  }
+
+  //fill object params
+  objParameter[0].minTOPOThreshold = lowerThresholdInd;
+  objParameter[0].maxTOPOThreshold = upperThresholdInd;
+
+  // create a new TOPO  condition
+  TOPOTemplate topoCond(name);
+  topoCond.setCondType(cType);
+  topoCond.setCondGEq(gEq);
+  topoCond.setCondChipNr(chipNr);
+  topoCond.setCondRelativeBx(relativeBx);
+  topoCond.setConditionParameter(objParameter);
+  topoCond.setModelVersion(model);
+
+  if (edm::isDebugEnabled()) {
+    std::ostringstream myCoutStream;
+    topoCond.print(myCoutStream);
+    LogTrace("TriggerMenuParser") << myCoutStream.str() << "\n" << std::endl;
+  }
+
+  // check that the condition does not exist already in the map
+  if (!insertConditionIntoMap(topoCond, chipNr)) {
+    edm::LogError("TriggerMenuParser") << "    Error: duplicate TOPO condition (" << name << ")" << std::endl;
+    return false;
+  }
+
+  (m_vecTOPOTemplate[chipNr]).push_back(topoCond);
 
   return true;
 }

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -338,7 +338,7 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
         } else if (condition.getType() == esConditionType::Axol1tlTrigger ||
                    condition.getType() == esConditionType::AnomalyDetectionTrigger) {
           parseAXOL1TL(condition, chipNr);
-        
+
           //parse TOPO
         } else if (condition.getType() == esConditionType::TopologicalTrigger) {
           parseTOPO(condition, chipNr);

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.h
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.h
@@ -38,6 +38,7 @@
 #include "L1Trigger/L1TGlobal/interface/EnergySumTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/EnergySumZdcTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/AXOL1TLTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/TOPOTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/CICADATemplate.h"
 #include "L1Trigger/L1TGlobal/interface/CorrelationTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/CorrelationThreeBodyTemplate.h"
@@ -157,6 +158,10 @@ namespace l1t {
     //
     inline const std::vector<std::vector<AXOL1TLTemplate> >& vecAXOL1TLTemplate() const { return m_vecAXOL1TLTemplate; }
     void setVecAXOL1TLTemplate(const std::vector<std::vector<AXOL1TLTemplate> >&);
+
+    //
+    inline const std::vector<std::vector<TOPOTemplate> >& vecTOPOTemplate() const { return m_vecTOPOTemplate; }
+    void setVecTOPOTemplate(const std::vector<std::vector<TOPOTemplate> >&);
 
     //
     inline const std::vector<std::vector<CICADATemplate> >& vecCICADATemplate() const { return m_vecCICADATemplate; }
@@ -314,6 +319,8 @@ namespace l1t {
 
     bool parseAXOL1TL(L1TUtmCondition condAXOL1TL, unsigned int chipNr = 0);
 
+    bool parseTOPO(L1TUtmCondition condTOPO, unsigned int chipNr = 0);
+
     bool parseCICADA(L1TUtmCondition condCICADA, unsigned int chipNr = 0);
 
     bool parseEnergySumCorr(const L1TUtmObject* corrESum, unsigned int chipNr = 0);
@@ -423,6 +430,7 @@ namespace l1t {
     std::vector<std::vector<EnergySumTemplate> > m_vecEnergySumTemplate;
     std::vector<std::vector<EnergySumZdcTemplate> > m_vecEnergySumZdcTemplate;
     std::vector<std::vector<AXOL1TLTemplate> > m_vecAXOL1TLTemplate;
+    std::vector<std::vector<TOPOTemplate> > m_vecTOPOTemplate;
     std::vector<std::vector<CICADATemplate> > m_vecCICADATemplate;
     std::vector<std::vector<ExternalTemplate> > m_vecExternalTemplate;
 

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -661,10 +661,6 @@ void l1t::GlobalBoard::initTriggerConditions(const edm::EventSetup& evSetup,
           theCondition = std::make_unique<TOPOCondition>(itCond.second, this);
           theCondition->setVerbosity(m_verbosity);
 
-          if (m_saveAXOScore and not m_axoScoreConditionName.empty()) {
-            m_axoScoreConditionName = itCond.first;
-          }
-
           if (m_verbosity && m_isDebugEnabled) {
             std::ostringstream myCout;
             theCondition->print(myCout);

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -38,6 +38,7 @@
 #include "L1Trigger/L1TGlobal/interface/EnergySumTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/EnergySumZdcTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/AXOL1TLTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/TOPOTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/CICADATemplate.h"
 #include "L1Trigger/L1TGlobal/interface/ExternalTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/CorrelationTemplate.h"
@@ -56,6 +57,7 @@
 #include "L1Trigger/L1TGlobal/interface/EnergySumCondition.h"
 #include "L1Trigger/L1TGlobal/interface/EnergySumZdcCondition.h"
 #include "L1Trigger/L1TGlobal/interface/AXOL1TLCondition.h"
+#include "L1Trigger/L1TGlobal/interface/TOPOCondition.h"
 #include "L1Trigger/L1TGlobal/interface/CICADACondition.h"
 #include "L1Trigger/L1TGlobal/interface/ExternalCondition.h"
 #include "L1Trigger/L1TGlobal/interface/CorrCondition.h"
@@ -641,6 +643,22 @@ void l1t::GlobalBoard::initTriggerConditions(const edm::EventSetup& evSetup,
 
         case CondAXOL1TL: {
           theCondition = std::make_unique<AXOL1TLCondition>(itCond.second, this);
+          theCondition->setVerbosity(m_verbosity);
+
+          if (m_saveAXOScore and not m_axoScoreConditionName.empty()) {
+            m_axoScoreConditionName = itCond.first;
+          }
+
+          if (m_verbosity && m_isDebugEnabled) {
+            std::ostringstream myCout;
+            theCondition->print(myCout);
+
+            LogTrace("L1TGlobal") << myCout.str();
+          }
+        } break;
+
+        case CondTOPO: {
+          theCondition = std::make_unique<TOPOCondition>(itCond.second, this);
           theCondition->setVerbosity(m_verbosity);
 
           if (m_saveAXOScore and not m_axoScoreConditionName.empty()) {

--- a/L1Trigger/L1TGlobal/src/GlobalCondition.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalCondition.cc
@@ -122,6 +122,7 @@ const int GlobalCondition::nrObjects() const {
     case l1t::TypeZDCP:
     case l1t::TypeZDCM:
     case l1t::TypeAXOL1TL:
+    case l1t::TypeTOPO:
     case l1t::TypeAsymEt:
     case l1t::TypeAsymHt:
     case l1t::TypeAsymEtHF:
@@ -211,6 +212,12 @@ void GlobalCondition::print(std::ostream& myCout) const {
     case l1t::CondAXOL1TL: {
       myCout << "  Condition category: "
              << "CondAXOL1TL" << std::endl;
+    }
+
+    break;
+    case l1t::CondTOPO: {
+      myCout << "  Condition category: "
+             << "CondTOPO" << std::endl;
     }
 
     break;

--- a/L1Trigger/L1TGlobal/src/GlobalDefinitions.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalDefinitions.cc
@@ -96,6 +96,7 @@ namespace {
       {"l1t::CondEnergySum", l1t::CondEnergySum},
       {"l1t::CondEnergySumZdc", l1t::CondEnergySumZdc},
       {"l1t::CondAXOL1TL", l1t::CondAXOL1TL},
+      {"l1t::CondTOPO", l1t::CondTOPO},
       {"l1t::CondCICADA", l1t::CondCICADA},
       {"l1t::CondCorrelation", l1t::CondCorrelation},
       {"l1t::CondCorrelationThreeBody", l1t::CondCorrelationThreeBody},

--- a/L1Trigger/L1TGlobal/src/TOPOCondition.cc
+++ b/L1Trigger/L1TGlobal/src/TOPOCondition.cc
@@ -97,8 +97,7 @@ void l1t::TOPOCondition::loadModel() {
     // hls4mlEmulator::ModelLoader loader(TOPOmodelversion);
     // m_model = loader.load_model();
   } catch (std::runtime_error& e) {
-    throw cms::Exception("ModelError") << " ERROR: failed to load TOPO model version \""
-                                       << m_model_loader.model_name()
+    throw cms::Exception("ModelError") << " ERROR: failed to load TOPO model version \"" << m_model_loader.model_name()
                                        << "\". Model version not found in cms-hls4ml externals.";
   }
 }
@@ -108,7 +107,7 @@ const bool l1t::TOPOCondition::evaluateCondition(const int bxEval) const {
     throw cms::Exception("ModelError") << " ERROR: no model was loaded for TOPO model version \""
                                        << m_model_loader.model_name() << "\".";
   }
-  
+
   bool condResult = false;
   int useBx = bxEval + m_gtTOPOTemplate->condRelativeBx();
 
@@ -117,7 +116,7 @@ const bool l1t::TOPOCondition::evaluateCondition(const int bxEval) const {
   const BXVector<const l1t::L1Candidate*>* candJetVec = m_gtGTB->getCandL1Jet();
   const BXVector<const l1t::L1Candidate*>* candEGVec = m_gtGTB->getCandL1EG();
   const BXVector<const l1t::EtSum*>* candEtSumVec = m_gtGTB->getCandL1EtSum();
-  
+
   const int NMuons = 2;
   const int NJets = 4;
   const int NEgammas = 0;
@@ -148,7 +147,7 @@ const bool l1t::TOPOCondition::evaluateCondition(const int bxEval) const {
 
   //declare result vectors +score
   losstype loss;
-  float score = -1.0; 
+  float score = -1.0;
 
   //check number of input objects we actually have (muons, jets etc)
   int NCandMu = candMuVec->size(useBx);
@@ -168,7 +167,7 @@ const bool l1t::TOPOCondition::evaluateCondition(const int bxEval) const {
     for (int iEtSum = 0; iEtSum < NCandEtSum; iEtSum++) {
       if ((candEtSumVec->at(useBx, iEtSum))->getType() == 1) {
         EtSumInput[0] = (candEtSumVec->at(useBx, iEtSum))->hwPt();
-        EtSumInput[1] = 0.0; //no phi for ht
+        EtSumInput[1] = 0.0;  //no phi for ht
       }
     }
   }
@@ -176,7 +175,7 @@ const bool l1t::TOPOCondition::evaluateCondition(const int bxEval) const {
   //next egammas
   if (NCandEG > 0) {  //check if not empty
     for (int iEG = 0; iEG < NCandEG; iEG++) {
-      if (iEG < NEgammas) {  //stop if fill the Nobjects we need
+      if (iEG < NEgammas) {                                                 //stop if fill the Nobjects we need
         EgammaInput[0 + (3 * iEG)] = (candEGVec->at(useBx, iEG))->hwPt();   //index 0,3,6,9
         EgammaInput[1 + (3 * iEG)] = (candEGVec->at(useBx, iEG))->hwEta();  //index 1,4,7,10
         EgammaInput[2 + (3 * iEG)] = (candEGVec->at(useBx, iEG))->hwPhi();  //index 2,5,8,11
@@ -187,7 +186,7 @@ const bool l1t::TOPOCondition::evaluateCondition(const int bxEval) const {
   //next muons
   if (NCandMu > 0) {  //check if not empty
     for (int iMu = 0; iMu < NCandMu; iMu++) {
-      if (iMu < NMuons) {  //stop if fill the Nobjects we need
+      if (iMu < NMuons) {                                               //stop if fill the Nobjects we need
         MuInput[0 + (3 * iMu)] = (candMuVec->at(useBx, iMu))->hwPt();   //index 0,3,6,9
         MuInput[1 + (3 * iMu)] = (candMuVec->at(useBx, iMu))->hwEta();  //index 1,4,7,10
         MuInput[2 + (3 * iMu)] = (candMuVec->at(useBx, iMu))->hwPhi();  //index 2,5,8,11
@@ -198,7 +197,7 @@ const bool l1t::TOPOCondition::evaluateCondition(const int bxEval) const {
   //next jets
   if (NCandJet > 0) {  //check if not empty
     for (int iJet = 0; iJet < NCandJet; iJet++) {
-      if (iJet < NJets) {  //stop if fill the Nobjects we need
+      if (iJet < NJets) {                                                   //stop if fill the Nobjects we need
         JetInput[0 + (3 * iJet)] = (candJetVec->at(useBx, iJet))->hwPt();   //index 0,3,6,9
         JetInput[1 + (3 * iJet)] = (candJetVec->at(useBx, iJet))->hwEta();  //index 1,4,7,10
         JetInput[2 + (3 * iJet)] = (candJetVec->at(useBx, iJet))->hwPhi();  //index 2,5,8,11
@@ -224,8 +223,8 @@ const bool l1t::TOPOCondition::evaluateCondition(const int bxEval) const {
   //now run the inference
   m_model->prepare_input(ModelInput);  //scaling internal here
   m_model->predict();
-  m_model->read_result(&loss); //store result as loss variable
-  score = ((loss).to_float() * 1023); 
+  m_model->read_result(&loss);  //store result as loss variable
+  score = ((loss).to_float() * 1023);
   setScore(score);
 
   //number of objects/thrsholds to check
@@ -245,7 +244,7 @@ const bool l1t::TOPOCondition::evaluateCondition(const int bxEval) const {
   passCondition = checkCut(objPar.minTOPOThreshold, score, condGEqVal);
 
   condResult |= passCondition;  //condresult true if passCondition true else it is false
-    
+
   //return result
   return condResult;
 }

--- a/L1Trigger/L1TGlobal/src/TOPOCondition.cc
+++ b/L1Trigger/L1TGlobal/src/TOPOCondition.cc
@@ -1,0 +1,258 @@
+/**
+ * \class TOPOCondition
+ *
+ *
+ * Description: evaluation of a condition for TOPO anomaly detection algorithm
+ *
+ * Author: Melissa Quinnan, Lukas Ebeling, Artur Lobanov
+ *
+ **/
+
+// this class header
+#include "L1Trigger/L1TGlobal/interface/CorrCondition.h"
+
+// system include files
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+
+#include <string>
+#include <vector>
+#include <algorithm>
+#include "ap_fixed.h"
+
+// user include files
+//   base classes
+#include "L1Trigger/L1TGlobal/interface/TOPOTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/ConditionEvaluation.h"
+
+#include "L1Trigger/L1TGlobal/interface/MuCondition.h"
+#include "L1Trigger/L1TGlobal/interface/TOPOCondition.h"
+#include "L1Trigger/L1TGlobal/interface/CaloCondition.h"
+#include "L1Trigger/L1TGlobal/interface/EnergySumCondition.h"
+#include "L1Trigger/L1TGlobal/interface/MuonTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/CaloTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/EnergySumTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/GlobalScales.h"
+
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+
+#include "L1Trigger/L1TGlobal/interface/GlobalBoard.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/MessageLogger/interface/MessageDrop.h"
+
+l1t::TOPOCondition::TOPOCondition()
+    : ConditionEvaluation(), m_gtTOPOTemplate{nullptr}, m_gtGTB{nullptr}, m_model{nullptr} {}
+
+l1t::TOPOCondition::TOPOCondition(const GlobalCondition* topoTemplate, const GlobalBoard* ptrGTB)
+    : ConditionEvaluation(),
+      m_gtTOPOTemplate(static_cast<const TOPOTemplate*>(topoTemplate)),
+      m_gtGTB(ptrGTB),
+      m_model_loader{kModelNamePrefix + m_gtTOPOTemplate->modelVersion()} {
+  loadModel();
+}
+
+// copy constructor
+void l1t::TOPOCondition::copy(const l1t::TOPOCondition& cp) {
+  m_gtTOPOTemplate = cp.gtTOPOTemplate();
+  m_gtGTB = cp.gtGTB();
+
+  m_condMaxNumberObjects = cp.condMaxNumberObjects();
+  m_condLastResult = cp.condLastResult();
+  m_combinationsInCond = cp.getCombinationsInCond();
+
+  m_verbosity = cp.m_verbosity;
+
+  m_model_loader.reset(cp.model_loader().model_name());
+  loadModel();
+}
+
+l1t::TOPOCondition::TOPOCondition(const l1t::TOPOCondition& cp) : ConditionEvaluation() { copy(cp); }
+
+// destructor
+l1t::TOPOCondition::~TOPOCondition() {
+  // empty
+}
+
+// equal operator
+l1t::TOPOCondition& l1t::TOPOCondition::operator=(const l1t::TOPOCondition& cp) {
+  copy(cp);
+  return *this;
+}
+
+// methods
+void l1t::TOPOCondition::setGtTOPOTemplate(const TOPOTemplate* caloTempl) { m_gtTOPOTemplate = caloTempl; }
+
+///   set the pointer to uGT GlobalBoard
+void l1t::TOPOCondition::setuGtB(const GlobalBoard* ptrGTB) { m_gtGTB = ptrGTB; }
+
+/// set score for score saving
+void l1t::TOPOCondition::setScore(const float scoreval) const { m_savedscore = scoreval; }
+
+void l1t::TOPOCondition::loadModel() {
+  try {
+    m_model = m_model_loader.load_model();
+    // std::string TOPOmodelversion = "/afs/desy.de/user/e/ebelingl/topo/compile/topo_v1";
+    // hls4mlEmulator::ModelLoader loader(TOPOmodelversion);
+    // m_model = loader.load_model();
+  } catch (std::runtime_error& e) {
+    throw cms::Exception("ModelError") << " ERROR: failed to load TOPO model version \""
+                                       << m_model_loader.model_name()
+                                       << "\". Model version not found in cms-hls4ml externals.";
+  }
+}
+
+const bool l1t::TOPOCondition::evaluateCondition(const int bxEval) const {
+  if (m_model == nullptr) {
+    throw cms::Exception("ModelError") << " ERROR: no model was loaded for TOPO model version \""
+                                       << m_model_loader.model_name() << "\".";
+  }
+  
+  bool condResult = false;
+  int useBx = bxEval + m_gtTOPOTemplate->condRelativeBx();
+
+  // //pointers to objects
+  const BXVector<const l1t::Muon*>* candMuVec = m_gtGTB->getCandL1Mu();
+  const BXVector<const l1t::L1Candidate*>* candJetVec = m_gtGTB->getCandL1Jet();
+  const BXVector<const l1t::L1Candidate*>* candEGVec = m_gtGTB->getCandL1EG();
+  const BXVector<const l1t::EtSum*>* candEtSumVec = m_gtGTB->getCandL1EtSum();
+  
+  const int NMuons = 2;
+  const int NJets = 4;
+  const int NEgammas = 0;
+  const int NEtSums = 1;
+
+  //number of indices in vector is #objects * 3 for et, eta, phi
+  const int MuVecSize = NMuons * 3;      //so 6
+  const int JVecSize = NJets * 3;        //so 12
+  const int EGVecSize = NEgammas * 3;    //so 0
+  const int EtSumVecSize = NEtSums * 2;  //no eta
+
+  //total # inputs in vector
+  const int NInputs = MuVecSize + JVecSize + EGVecSize + EtSumVecSize;  //so 20
+
+  //types of inputs and outputs modified for topo
+  typedef ap_fixed<23, 23> inputtype;
+  typedef ap_fixed<16, 6> losstype;
+
+  //input vector declaration, will fill later
+  inputtype ModelInput[NInputs];
+  inputtype fillzero = 0.0;
+
+  //initializing vector by type for my sanity
+  double MuInput[MuVecSize];
+  double JetInput[JVecSize];
+  double EgammaInput[EGVecSize];
+  double EtSumInput[EtSumVecSize];
+
+  //declare result vectors +score
+  losstype loss;
+  float score = -1.0; 
+
+  //check number of input objects we actually have (muons, jets etc)
+  int NCandMu = candMuVec->size(useBx);
+  int NCandJet = candJetVec->size(useBx);
+  int NCandEG = candEGVec->size(useBx);
+  int NCandEtSum = candEtSumVec->size(useBx);
+
+  //initialize arrays to zero (std::fill(first, last, value);)
+  std::fill(EtSumInput, EtSumInput + EtSumVecSize, 0.0);
+  std::fill(MuInput, MuInput + MuVecSize, 0.0);
+  std::fill(JetInput, JetInput + JVecSize, 0.0);
+  std::fill(EgammaInput, EgammaInput + EGVecSize, 0.0);
+  std::fill(ModelInput, ModelInput + NInputs, fillzero);
+
+  //then fill the object vectors
+  if (NCandEtSum > 0) {  //check if not empty
+    for (int iEtSum = 0; iEtSum < NCandEtSum; iEtSum++) {
+      if ((candEtSumVec->at(useBx, iEtSum))->getType() == 1) {
+        EtSumInput[0] = (candEtSumVec->at(useBx, iEtSum))->hwPt();
+        EtSumInput[1] = 0.0; //no phi for ht
+      }
+    }
+  }
+
+  //next egammas
+  if (NCandEG > 0) {  //check if not empty
+    for (int iEG = 0; iEG < NCandEG; iEG++) {
+      if (iEG < NEgammas) {  //stop if fill the Nobjects we need
+        EgammaInput[0 + (3 * iEG)] = (candEGVec->at(useBx, iEG))->hwPt();   //index 0,3,6,9
+        EgammaInput[1 + (3 * iEG)] = (candEGVec->at(useBx, iEG))->hwEta();  //index 1,4,7,10
+        EgammaInput[2 + (3 * iEG)] = (candEGVec->at(useBx, iEG))->hwPhi();  //index 2,5,8,11
+      }
+    }
+  }
+
+  //next muons
+  if (NCandMu > 0) {  //check if not empty
+    for (int iMu = 0; iMu < NCandMu; iMu++) {
+      if (iMu < NMuons) {  //stop if fill the Nobjects we need
+        MuInput[0 + (3 * iMu)] = (candMuVec->at(useBx, iMu))->hwPt();   //index 0,3,6,9
+        MuInput[1 + (3 * iMu)] = (candMuVec->at(useBx, iMu))->hwEta();  //index 1,4,7,10
+        MuInput[2 + (3 * iMu)] = (candMuVec->at(useBx, iMu))->hwPhi();  //index 2,5,8,11
+      }
+    }
+  }
+
+  //next jets
+  if (NCandJet > 0) {  //check if not empty
+    for (int iJet = 0; iJet < NCandJet; iJet++) {
+      if (iJet < NJets) {  //stop if fill the Nobjects we need
+        JetInput[0 + (3 * iJet)] = (candJetVec->at(useBx, iJet))->hwPt();   //index 0,3,6,9
+        JetInput[1 + (3 * iJet)] = (candJetVec->at(useBx, iJet))->hwEta();  //index 1,4,7,10
+        JetInput[2 + (3 * iJet)] = (candJetVec->at(useBx, iJet))->hwPhi();  //index 2,5,8,11
+      }
+    }
+  }
+
+  //now put it all together-> EtSum+EGamma+Muon+Jet into ModelInput
+  int index = 0;
+  for (int idET = 0; idET < EtSumVecSize; idET++) {
+    ModelInput[index++] = EtSumInput[idET];
+  }
+  for (int idEG = 0; idEG < EGVecSize; idEG++) {
+    ModelInput[index++] = EgammaInput[idEG];
+  }
+  for (int idMu = 0; idMu < MuVecSize; idMu++) {
+    ModelInput[index++] = MuInput[idMu];
+  }
+  for (int idJ = 0; idJ < JVecSize; idJ++) {
+    ModelInput[index++] = JetInput[idJ];
+  }
+
+  //now run the inference
+  m_model->prepare_input(ModelInput);  //scaling internal here
+  m_model->predict();
+  m_model->read_result(&loss); //store result as loss variable
+  score = ((loss).to_float() * 1023); 
+  setScore(score);
+
+  //number of objects/thrsholds to check
+  int iCondition = 0;  // number of conditions: there is only one
+  int nObjInCond = m_gtTOPOTemplate->nrObjects();
+
+  if (iCondition >= nObjInCond || iCondition < 0) {
+    return false;
+  }
+
+  const TOPOTemplate::ObjectParameter objPar = (*(m_gtTOPOTemplate->objectParameter()))[iCondition];
+
+  // condGEqVal indicates the operator used for the condition (>=, =): true for >=
+  bool condGEqVal = m_gtTOPOTemplate->condGEq();
+  bool passCondition = false;
+
+  passCondition = checkCut(objPar.minTOPOThreshold, score, condGEqVal);
+
+  condResult |= passCondition;  //condresult true if passCondition true else it is false
+    
+  //return result
+  return condResult;
+}
+
+void l1t::TOPOCondition::print(std::ostream& myCout) const {
+  myCout << "Dummy Print for TOPOCondition" << std::endl;
+  m_gtTOPOTemplate->print(myCout);
+
+  ConditionEvaluation::print(myCout);
+}

--- a/L1Trigger/L1TGlobal/src/TOPOTemplate.cc
+++ b/L1Trigger/L1TGlobal/src/TOPOTemplate.cc
@@ -7,9 +7,7 @@
 
 TOPOTemplate::TOPOTemplate() : GlobalCondition() { m_condCategory = l1t::CondTOPO; }
 
-TOPOTemplate::TOPOTemplate(const std::string& cName) : GlobalCondition(cName) {
-  m_condCategory = l1t::CondTOPO;
-}
+TOPOTemplate::TOPOTemplate(const std::string& cName) : GlobalCondition(cName) { m_condCategory = l1t::CondTOPO; }
 
 TOPOTemplate::TOPOTemplate(const std::string& cName, const l1t::GtConditionType& cType)  //not sure we need cType
     : GlobalCondition(cName, l1t::CondTOPO, cType) {

--- a/L1Trigger/L1TGlobal/src/TOPOTemplate.cc
+++ b/L1Trigger/L1TGlobal/src/TOPOTemplate.cc
@@ -1,0 +1,79 @@
+// this class header
+#include "L1Trigger/L1TGlobal/interface/TOPOTemplate.h"
+
+// system include files
+#include <iostream>
+#include <iomanip>
+
+TOPOTemplate::TOPOTemplate() : GlobalCondition() { m_condCategory = l1t::CondTOPO; }
+
+TOPOTemplate::TOPOTemplate(const std::string& cName) : GlobalCondition(cName) {
+  m_condCategory = l1t::CondTOPO;
+}
+
+TOPOTemplate::TOPOTemplate(const std::string& cName, const l1t::GtConditionType& cType)  //not sure we need cType
+    : GlobalCondition(cName, l1t::CondTOPO, cType) {
+  int nObjects = nrObjects();
+
+  if (nObjects > 0) {
+    m_objectType.reserve(nObjects);
+  }
+}
+
+// copy constructor
+TOPOTemplate::TOPOTemplate(const TOPOTemplate& cp) : GlobalCondition(cp.m_condName) { copy(cp); }
+
+// destructor
+TOPOTemplate::~TOPOTemplate() {
+  // empty now
+}
+
+// assign operator
+TOPOTemplate& TOPOTemplate::operator=(const TOPOTemplate& cp) {
+  copy(cp);
+  return *this;
+}
+
+// setConditionParameter - set the parameters of the condition
+void TOPOTemplate::setConditionParameter(const std::vector<ObjectParameter>& objParameter) {
+  m_objectParameter = objParameter;
+}
+
+//setModelVersion - set the model version of the condition
+void TOPOTemplate::setModelVersion(const std::string& modelversion) { m_modelVersion = modelversion; }
+
+void TOPOTemplate::print(std::ostream& myCout) const {
+  myCout << "\n  TOPOTemplate print..." << std::endl;
+
+  GlobalCondition::print(myCout);
+
+  int nObjects = nrObjects();
+
+  for (int i = 0; i < nObjects; i++) {
+    myCout << std::endl;
+    myCout << "  Template for object " << i << " [ hex ]" << std::endl;
+    myCout << "    TOPOThreshold   = " << std::hex << m_objectParameter[i].minTOPOThreshold << std::endl;
+  }
+
+  // reset to decimal output
+  myCout << std::dec << std::endl;
+}
+
+void TOPOTemplate::copy(const TOPOTemplate& cp) {
+  m_condName = cp.condName();
+  m_condCategory = cp.condCategory();
+  m_condType = cp.condType();
+  m_objectType = cp.objectType();  //not needed for TOPO
+  m_condGEq = cp.condGEq();
+  m_condChipNr = cp.condChipNr();
+  m_condRelativeBx = cp.condRelativeBx();
+
+  m_modelVersion = cp.modelVersion();  // new for utm 0.12.0
+  m_objectParameter = *(cp.objectParameter());
+}
+
+// output stream operator
+std::ostream& operator<<(std::ostream& os, const TOPOTemplate& result) {
+  result.print(os);
+  return os;
+}

--- a/L1Trigger/L1TGlobal/src/TriggerMenu.cc
+++ b/L1Trigger/L1TGlobal/src/TriggerMenu.cc
@@ -319,8 +319,7 @@ void TriggerMenu::buildGtConditionMap() {
        itCondOnChip++) {
     chipNr++;
 
-    for (std::vector<TOPOTemplate>::iterator itCond = itCondOnChip->begin(); itCond != itCondOnChip->end();
-         itCond++) {
+    for (std::vector<TOPOTemplate>::iterator itCond = itCondOnChip->begin(); itCond != itCondOnChip->end(); itCond++) {
       (m_conditionMap.at(chipNr))[itCond->condName()] = &(*itCond);
     }
   }

--- a/L1Trigger/L1TGlobal/src/TriggerMenu.cc
+++ b/L1Trigger/L1TGlobal/src/TriggerMenu.cc
@@ -46,6 +46,7 @@ TriggerMenu::TriggerMenu(
     const std::vector<std::vector<EnergySumTemplate> >& vecEnergySumTemplateVal,
     const std::vector<std::vector<EnergySumZdcTemplate> >& vecEnergySumZdcTemplateVal,
     const std::vector<std::vector<AXOL1TLTemplate> >& vecAXOL1TLTemplateVal,
+    const std::vector<std::vector<TOPOTemplate> >& vecTOPOTemplateVal,
     const std::vector<std::vector<CICADATemplate> >& vecCICADATemplateVal,
     const std::vector<std::vector<ExternalTemplate> >& vecExternalTemplateVal,
     const std::vector<std::vector<CorrelationTemplate> >& vecCorrelationTemplateVal,
@@ -66,6 +67,7 @@ TriggerMenu::TriggerMenu(
       m_vecEnergySumTemplate(vecEnergySumTemplateVal),
       m_vecEnergySumZdcTemplate(vecEnergySumZdcTemplateVal),
       m_vecAXOL1TLTemplate(vecAXOL1TLTemplateVal),
+      m_vecTOPOTemplate(vecTOPOTemplateVal),
       m_vecCICADATemplate(vecCICADATemplateVal),
       m_vecExternalTemplate(vecExternalTemplateVal),
       m_vecCorrelationTemplate(vecCorrelationTemplateVal),
@@ -94,6 +96,7 @@ TriggerMenu::TriggerMenu(const TriggerMenu& rhs) {
   m_vecEnergySumTemplate = rhs.m_vecEnergySumTemplate;
   m_vecEnergySumZdcTemplate = rhs.m_vecEnergySumZdcTemplate;
   m_vecAXOL1TLTemplate = rhs.m_vecAXOL1TLTemplate;
+  m_vecTOPOTemplate = rhs.m_vecTOPOTemplate;
   m_vecCICADATemplate = rhs.m_vecCICADATemplate;
   m_vecExternalTemplate = rhs.m_vecExternalTemplate;
 
@@ -145,6 +148,7 @@ TriggerMenu& TriggerMenu::operator=(const TriggerMenu& rhs) {
     m_vecEnergySumTemplate = rhs.m_vecEnergySumTemplate;
     m_vecEnergySumZdcTemplate = rhs.m_vecEnergySumZdcTemplate;
     m_vecAXOL1TLTemplate = rhs.m_vecAXOL1TLTemplate;
+    m_vecTOPOTemplate = rhs.m_vecTOPOTemplate;
     m_vecCICADATemplate = rhs.m_vecCICADATemplate;
     m_vecExternalTemplate = rhs.m_vecExternalTemplate;
 
@@ -302,6 +306,26 @@ void TriggerMenu::buildGtConditionMap() {
   }
 
   //
+  size_t vecTOPOSize = m_vecTOPOTemplate.size();
+  if (condMapSize < vecTOPOSize) {
+    m_conditionMap.resize(vecTOPOSize);
+    condMapSize = m_conditionMap.size();
+  }
+
+  chipNr = -1;
+
+  for (std::vector<std::vector<TOPOTemplate> >::iterator itCondOnChip = m_vecTOPOTemplate.begin();
+       itCondOnChip != m_vecTOPOTemplate.end();
+       itCondOnChip++) {
+    chipNr++;
+
+    for (std::vector<TOPOTemplate>::iterator itCond = itCondOnChip->begin(); itCond != itCondOnChip->end();
+         itCond++) {
+      (m_conditionMap.at(chipNr))[itCond->condName()] = &(*itCond);
+    }
+  }
+
+  //
   size_t vecCICADASize = m_vecCICADATemplate.size();
   if (condMapSize < vecCICADASize) {
     m_conditionMap.resize(vecCICADASize);
@@ -442,6 +466,10 @@ void TriggerMenu::setVecEnergySumZdcTemplate(
 
 void TriggerMenu::setVecAXOL1TLTemplate(const std::vector<std::vector<AXOL1TLTemplate> >& vecAXOL1TLTempl) {
   m_vecAXOL1TLTemplate = vecAXOL1TLTempl;
+}
+
+void TriggerMenu::setVecTOPOTemplate(const std::vector<std::vector<TOPOTemplate> >& vecTOPOTempl) {
+  m_vecTOPOTemplate = vecTOPOTempl;
 }
 
 void TriggerMenu::setVecCICADATemplate(const std::vector<std::vector<CICADATemplate> >& vecCICADATempl) {

--- a/L1Trigger/L1TGlobal/src/classes.h
+++ b/L1Trigger/L1TGlobal/src/classes.h
@@ -11,5 +11,6 @@ namespace L1Trigger_L1TGlobal {
     std::vector<MuonShowerTemplate> dummy6;
     std::vector<AXOL1TLTemplate> dummy7;
     std::vector<CICADATemplate> dummy8;
+    std::vector<TOPOTemplate> dummy9;
   };
 }  // namespace L1Trigger_L1TGlobal

--- a/L1Trigger/L1TGlobal/src/classes_def.xml
+++ b/L1Trigger/L1TGlobal/src/classes_def.xml
@@ -28,6 +28,7 @@
     <field name="m_vecEnergySumTemplate" mapping="blob" />
     <field name="m_vecEnergySumZdcTemplate" mapping="blob" />
     <field name="m_vecAXOL1TLTemplate" mapping="blob" />
+    <field name="m_vecTOPOTemplate" mapping="blob" />
     <field name="m_vecCICADATemplate" mapping="blob" />
     <field name="m_vecExternalTemplate" mapping="blob" />
     <field name="m_vecHfBitCountsTemplate" mapping="blob" />


### PR DESCRIPTION
**PR description**
This PR adds the L1 emulator code for the topological trigger targeting the single-muon finale state of the hhbbww process. 
- Based on the AXOL1TL emulator code added in this [PR](https://github.com/cms-sw/cmssw/pull/42964) 
- The model was trained (quantised training) on di-Higgs signal samples and minimal bias background samples of the summer 2022 data taking period. 
- The training repository (containing the qkeras model) is liked [here](https://gitlab.cern.ch/uhh-l1t/hhtobbww/-/tree/hhbbww_mu_v1?ref_type=heads)
- The model binaries are generated at runtime from the external cms-hls4ml [TOPO repository](https://github.com/cms-hls4ml/TOPO). This [draft PR](https://github.com/cms-hls4ml/TOPO/pull/1) contains the current hls model. 
- Run-3 Deployment of the topological trigger is targeted for early 2026
- The lastest [talk](https://indico.cern.ch/event/1506588/timetable/?view=standard_inline_minutes#47-machine-learning-based-topo) summarises the technical details of the latest model


**PR validation**
the final dnn score outputted by the cms-sw L1 emulator agrees well with the keras model training in a python environment. At relevant scores above 0.8, only deviations of the order two percent are expected: 
<img width="1431" height="1101" alt="image" src="https://github.com/user-attachments/assets/91257300-11d3-4897-bb0a-559cf8c0e54d" />