### PR TITLE
Moved catch2 tests to the v3 API

### DIFF
--- a/Alignment/HIPAlignmentAlgorithm/test/testHIPAnalyzers.cc
+++ b/Alignment/HIPAlignmentAlgorithm/test/testHIPAnalyzers.cc
@@ -5,7 +5,7 @@
 #include <format>
 
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 // Function to run the catch2 tests
 //___________________________________________________________________________________________

--- a/Alignment/OfflineValidation/test/testTrackAnalyzers.cc
+++ b/Alignment/OfflineValidation/test/testTrackAnalyzers.cc
@@ -6,7 +6,7 @@
 
 #include <format>
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 // Function to run the catch2 tests
 //___________________________________________________________________________________________

--- a/CUDADataFormats/Common/test/test_Product.cc
+++ b/CUDADataFormats/Common/test/test_Product.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "CUDADataFormats/Common/interface/Product.h"
 #include "HeterogeneousCore/CUDACore/interface/ScopedContext.h"

--- a/CUDADataFormats/Common/test/test_main.cc
+++ b/CUDADataFormats/Common/test/test_main.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/CalibFormats/SiStripObjects/test/test_catch2_SiStripHashedDetId.cc
+++ b/CalibFormats/SiStripObjects/test/test_catch2_SiStripHashedDetId.cc
@@ -2,7 +2,7 @@
 #include "CalibFormats/SiStripObjects/interface/SiStripDetInfo.h"
 #include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include <set>
 #include <vector>

--- a/CalibFormats/SiStripObjects/test/test_catch2_main.cc
+++ b/CalibFormats/SiStripObjects/test/test_catch2_main.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/CalibTracker/SiPixelESProducers/test/test_catch2_ESSources.cc
+++ b/CalibTracker/SiPixelESProducers/test/test_catch2_ESSources.cc
@@ -4,7 +4,7 @@
 #include <format>
 
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 // Function to run the catch2 tests
 //___________________________________________________________________________________________

--- a/CommonTools/BaseParticlePropagator/test/makeMuon_catch2.cc
+++ b/CommonTools/BaseParticlePropagator/test/makeMuon_catch2.cc
@@ -2,7 +2,7 @@
 #include "CommonTools/BaseParticlePropagator/interface/RawParticle.h"
 
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 static constexpr const double kMuonMass = 0.10566;
 

--- a/CondCore/CondHDF5ESSource/test/test_catch2_convertSyncValue.cc
+++ b/CondCore/CondHDF5ESSource/test/test_catch2_convertSyncValue.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "CondCore/CondHDF5ESSource/plugins/convertSyncValue.h"
 
 using namespace cond::hdf5;

--- a/CondCore/CondHDF5ESSource/test/test_catch2_findMatchFirst.cc
+++ b/CondCore/CondHDF5ESSource/test/test_catch2_findMatchFirst.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "CondCore/CondHDF5ESSource/plugins/IOVSyncValue.h"
 //can't link to plugin so must include source
 #include "CondCore/CondHDF5ESSource/plugins/IOVSyncValue.cc"

--- a/CondCore/CondHDF5ESSource/test/test_catch2_h5cpp.cc
+++ b/CondCore/CondHDF5ESSource/test/test_catch2_h5cpp.cc
@@ -12,7 +12,7 @@
 
 // system include files
 #include <cassert>
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 // user include files
 #include "FWCore/Utilities/interface/FileInPath.h"

--- a/CondCore/CondHDF5ESSource/test/test_catch2_main.cc
+++ b/CondCore/CondHDF5ESSource/test/test_catch2_main.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/CondFormats/EcalObjects/test/EcalPulseSymmCovariance_catch2.cc
+++ b/CondFormats/EcalObjects/test/EcalPulseSymmCovariance_catch2.cc
@@ -1,7 +1,7 @@
 #include "CondFormats/EcalObjects/interface/EcalPulseSymmCovariances.h"
 
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include <iostream>
 
 TEST_CASE("EcalPulseSymmCovariance testing", "[EcalPulseSymmCovariance]") {

--- a/CondFormats/SerializationHelper/test/test_catch2_SerializationHelper.cc
+++ b/CondFormats/SerializationHelper/test/test_catch2_SerializationHelper.cc
@@ -11,7 +11,7 @@
 //
 
 // system include files
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 // user include files
 #include "CondFormats/SerializationHelper/interface/SerializationHelper.h"

--- a/CondFormats/SerializationHelper/test/test_catch2_main.cc
+++ b/CondFormats/SerializationHelper/test/test_catch2_main.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/CondFormats/SerializationHelper/test/test_catch2_unique_void_ptr.cc
+++ b/CondFormats/SerializationHelper/test/test_catch2_unique_void_ptr.cc
@@ -10,7 +10,7 @@
 //         Created:  Wed, 31 May 2023 15:24:23 GMT
 //
 
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "CondFormats/SerializationHelper/interface/unique_void_ptr.h"
 
 using namespace cond::serialization;

--- a/CondFormats/SiStripObjects/test/test_catch2_SiStripBadStripForPhase2.cpp
+++ b/CondFormats/SiStripObjects/test/test_catch2_SiStripBadStripForPhase2.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include <iostream>
 #include <iomanip>  // std::setw
 #include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"

--- a/CondFormats/SiStripObjects/test/test_catch2_SiStripLatency.cpp
+++ b/CondFormats/SiStripObjects/test/test_catch2_SiStripLatency.cpp
@@ -1,5 +1,5 @@
 #include <sstream>
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include <iostream>
 #include <iomanip>  // std::setw
 

--- a/CondFormats/SiStripObjects/test/test_catch2_main.cpp
+++ b/CondFormats/SiStripObjects/test/test_catch2_main.cpp
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/CondTools/RunInfo/test/test_catch2_LHCInfoPerFillPopCon.cpp
+++ b/CondTools/RunInfo/test/test_catch2_LHCInfoPerFillPopCon.cpp
@@ -1,6 +1,6 @@
 #define CATCH_CONFIG_MAIN
 
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "CondTools/RunInfo/interface/LHCInfoPerFillPopConSourceHandler.h"
 #include "CondTools/RunInfo/interface/TestLHCInfoPerFillPopConSourceHandler.h"
@@ -336,7 +336,7 @@ TEST_CASE("LHCInfoPerFillPopConSourceHandler.getNewObjects fills IOVs correctly 
 
   // Populate mock data
   std::vector<unsigned short> fillNumbers = {1000};
-  std::vector<float> energies = {GENERATE(450.0, 6600.0, 8000.0)};
+  std::vector<float> energies = {GENERATE(450.0f, 6600.0f, 8000.0f)};
   std::vector<boost::posix_time::ptime> fillStartTimes = {boost::posix_time::time_from_string("2023-06-01 11:30:00")};
   std::vector<boost::posix_time::ptime> fillStableBeamBeginTimes = {
       boost::posix_time::time_from_string("2023-06-01 12:00:00")};
@@ -436,7 +436,7 @@ TEST_CASE(
 
   // Populate mock data
   std::vector<unsigned short> fillNumbers = {1000};
-  std::vector<float> energies = {GENERATE(-6800., -1., 0., 449.9, 8000.1)};  // invalid energy
+  std::vector<float> energies = {GENERATE(-6800.f, -1.f, 0.f, 449.9f, 8000.1f)};  // invalid energy
   std::vector<boost::posix_time::ptime> fillStartTimes = {boost::posix_time::time_from_string("2023-06-01 11:30:00")};
   std::vector<boost::posix_time::ptime> fillStableBeamBeginTimes = {
       boost::posix_time::time_from_string("2023-06-01 12:00:00")};

--- a/DQM/BeamMonitor/test/testAlcaBeamMonitor.cc
+++ b/DQM/BeamMonitor/test/testAlcaBeamMonitor.cc
@@ -1,7 +1,7 @@
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 TEST_CASE("AlcaBeamMonitor tests", "[AlcaBeamMonitor]") {
   //The python configuration

--- a/DQM/EcalCommon/test/testEcalCommon.cc
+++ b/DQM/EcalCommon/test/testEcalCommon.cc
@@ -4,7 +4,7 @@
 #include <format>
 
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 // Function to run the catch2 tests
 //___________________________________________________________________________________________

--- a/DQM/TrackerRemapper/test/test_catch2_Phase1PixelMaps.cc
+++ b/DQM/TrackerRemapper/test/test_catch2_Phase1PixelMaps.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include <iostream>
 #include <numeric>  // std::accumulate
 #include "TCanvas.h"

--- a/DQM/TrackerRemapper/test/test_catch2_Phase1PixelROCMaps.cc
+++ b/DQM/TrackerRemapper/test/test_catch2_Phase1PixelROCMaps.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include <iostream>
 #include <numeric>  // std::accumulate
 #include "TCanvas.h"

--- a/DQM/TrackerRemapper/test/test_catch2_Phase1PixelSummaryMap.cc
+++ b/DQM/TrackerRemapper/test/test_catch2_Phase1PixelSummaryMap.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include <iostream>
 #include <numeric>  // std::accumulate
 #include "TCanvas.h"

--- a/DQM/TrackerRemapper/test/test_catch2_SiStripTkMaps.cc
+++ b/DQM/TrackerRemapper/test/test_catch2_SiStripTkMaps.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include <iostream>
 #include <numeric>  // std::accumulate
 #include "TCanvas.h"

--- a/DQM/TrackerRemapper/test/test_catch2_main.cc
+++ b/DQM/TrackerRemapper/test/test_catch2_main.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/DQM/TrackingMonitorSource/test/testTrackingDQMAnalyzers.cc
+++ b/DQM/TrackingMonitorSource/test/testTrackingDQMAnalyzers.cc
@@ -5,7 +5,7 @@
 #include <format>
 
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 // Function to run the catch2 tests
 //___________________________________________________________________________________________

--- a/DQMOffline/Trigger/test/EgHLTComCodes_catch2_test.cpp
+++ b/DQMOffline/Trigger/test/EgHLTComCodes_catch2_test.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "DQMOffline/Trigger/interface/EgHLTComCodes.h"
 #include "DQMOffline/Trigger/interface/EgHLTEgCutCodes.h"

--- a/DQMOffline/Trigger/test/EgHLTTrigCodes_catch2_test.cpp
+++ b/DQMOffline/Trigger/test/EgHLTTrigCodes_catch2_test.cpp
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "DQMOffline/Trigger/interface/EgHLTTrigCodes.h"
 

--- a/DataFormats/Common/test/test_catch2_BoostRange.cpp
+++ b/DataFormats/Common/test/test_catch2_BoostRange.cpp
@@ -9,7 +9,7 @@
 #include <cassert>
 #include <iostream>
 #include <vector>
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 struct Dummy {
   Dummy() : id() {}

--- a/DataFormats/Common/test/test_catch2_DataFrame.cpp
+++ b/DataFormats/Common/test/test_catch2_DataFrame.cpp
@@ -4,7 +4,7 @@
 #include <numeric>
 #include <cstring>
 #include <random>
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "DataFormats/Common/interface/DataFrame.h"
 #include "DataFormats/Common/interface/DataFrameContainer.h"
 

--- a/DataFormats/Common/test/test_catch2_DetSetNew.cpp
+++ b/DataFormats/Common/test/test_catch2_DetSetNew.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "DataFormats/Common/interface/DetSetNew.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
@@ -207,7 +207,7 @@ TEST_CASE("DetSetNew", "[DetSetNew]") {
 
     // test error conditions
     REQUIRE_THROWS_MATCHES(
-        detsets.insert(22, 6), edm::Exception, Catch::Predicate<edm::Exception>([](edm::Exception const &e) {
+        detsets.insert(22, 6), edm::Exception, Catch::Matchers::Predicate<edm::Exception>([](edm::Exception const &e) {
           return e.categoryCode() == edm::errors::InvalidReference;
         }));
   }
@@ -307,7 +307,7 @@ TEST_CASE("DetSetNew", "[DetSetNew]") {
 
     // test error conditions
     REQUIRE_THROWS_MATCHES(
-        FF(detsets, 22), edm::Exception, Catch::Predicate<edm::Exception>([](edm::Exception const &e) {
+        FF(detsets, 22), edm::Exception, Catch::Matchers::Predicate<edm::Exception>([](edm::Exception const &e) {
           return e.categoryCode() == edm::errors::InvalidReference;
         }));
     REQUIRE_THROWS_MATCHES(
@@ -316,7 +316,7 @@ TEST_CASE("DetSetNew", "[DetSetNew]") {
           FF ff2(d, 45);
         }(detsets),
         edm::Exception,
-        Catch::Predicate<edm::Exception>(
+        Catch::Matchers::Predicate<edm::Exception>(
             [](edm::Exception const &e) { return e.categoryCode() == edm::errors::LogicError; }));
   }
 
@@ -378,7 +378,7 @@ TEST_CASE("DetSetNew", "[DetSetNew]") {
     }
     SECTION("error conditions") {
       REQUIRE_THROWS_MATCHES(
-          TSFF(detsets, 22), edm::Exception, Catch::Predicate<edm::Exception>([](edm::Exception const &e) {
+          TSFF(detsets, 22), edm::Exception, Catch::Matchers::Predicate<edm::Exception>([](edm::Exception const &e) {
             return e.categoryCode() == edm::errors::InvalidReference;
           }));
       REQUIRE_THROWS_MATCHES(
@@ -387,7 +387,7 @@ TEST_CASE("DetSetNew", "[DetSetNew]") {
             TSFF ff2(d, 45);
           }(detsets),
           edm::Exception,
-          Catch::Predicate<edm::Exception>(
+          Catch::Matchers::Predicate<edm::Exception>(
               [](edm::Exception const &e) { return e.categoryCode() == edm::errors::LogicError; }));
     }
   }
@@ -439,9 +439,10 @@ TEST_CASE("DetSetNew", "[DetSetNew]") {
       REQUIRE(p == detsets.end());
     }
     SECTION("invalid index") {
-      REQUIRE_THROWS_MATCHES(detsets[44], edm::Exception, Catch::Predicate<edm::Exception>([](edm::Exception const &e) {
-                               return e.categoryCode() == edm::errors::InvalidReference;
-                             }));
+      REQUIRE_THROWS_MATCHES(
+          detsets[44], edm::Exception, Catch::Matchers::Predicate<edm::Exception>([](edm::Exception const &e) {
+            return e.categoryCode() == edm::errors::InvalidReference;
+          }));
     }
   }
 
@@ -535,9 +536,10 @@ TEST_CASE("DetSetNew", "[DetSetNew]") {
     }
 
     SECTION("invalid index") {
-      REQUIRE_THROWS_MATCHES(detsets[22], edm::Exception, Catch::Predicate<edm::Exception>([](edm::Exception const &e) {
-                               return e.categoryCode() == edm::errors::InvalidReference;
-                             }));
+      REQUIRE_THROWS_MATCHES(
+          detsets[22], edm::Exception, Catch::Matchers::Predicate<edm::Exception>([](edm::Exception const &e) {
+            return e.categoryCode() == edm::errors::InvalidReference;
+          }));
     }
     DSTV detsets2;
     detsets2.swap(detsets);

--- a/DataFormats/Common/test/test_catch2_DetSetNewTS.cpp
+++ b/DataFormats/Common/test/test_catch2_DetSetNewTS.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "DataFormats/Common/interface/DetSetNew.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"

--- a/DataFormats/Common/test/test_catch2_DetSetVector.cpp
+++ b/DataFormats/Common/test/test_catch2_DetSetVector.cpp
@@ -2,7 +2,7 @@
  *  CMSSW
  */
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/Ref.h"

--- a/DataFormats/Common/test/test_catch2_DetSetVectorWithKey_t.cpp
+++ b/DataFormats/Common/test/test_catch2_DetSetVectorWithKey_t.cpp
@@ -5,7 +5,7 @@
 #include <stdexcept>
 #include <vector>
 
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/Ref.h"

--- a/DataFormats/Common/test/test_catch2_DictionaryTools.cpp
+++ b/DataFormats/Common/test/test_catch2_DictionaryTools.cpp
@@ -4,7 +4,7 @@
 #include "FWCore/Utilities/interface/TypeDemangler.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 #include "FWCore/Reflection/interface/TypeWithDict.h"
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include <typeinfo>
 #include <map>
 #include <vector>

--- a/DataFormats/Common/test/test_catch2_MapOfVectors.cpp
+++ b/DataFormats/Common/test/test_catch2_MapOfVectors.cpp
@@ -1,6 +1,6 @@
 #include <vector>
 #include <algorithm>
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "DataFormats/Common/interface/MapOfVectors.h"
 
 typedef edm::MapOfVectors<int, int> MII;

--- a/DataFormats/Common/test/test_catch2_MultiSpan.cpp
+++ b/DataFormats/Common/test/test_catch2_MultiSpan.cpp
@@ -3,7 +3,7 @@
 #include <cmath>
 #include <numeric>
 #include <vector>
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "DataFormats/Common/interface/MultiSpan.h"
 

--- a/DataFormats/Common/test/test_catch2_OwnVector.cpp
+++ b/DataFormats/Common/test/test_catch2_OwnVector.cpp
@@ -1,7 +1,7 @@
 #include <algorithm>
 #include <cassert>
 #include <memory>
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "DataFormats/Common/interface/OwnVector.h"
 #include "FWCore/Utilities/interface/propagate_const.h"

--- a/DataFormats/Common/test/test_catch2_Ref.cpp
+++ b/DataFormats/Common/test/test_catch2_Ref.cpp
@@ -3,7 +3,7 @@
 #include "DataFormats/Common/interface/EDProductGetter.h"
 #include "DataFormats/Common/interface/Ref.h"
 #include "FWCore/Utilities/interface/EDMException.h"
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include <iostream>
 #include <string>

--- a/DataFormats/Common/test/test_catch2_RefCore.cpp
+++ b/DataFormats/Common/test/test_catch2_RefCore.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "DataFormats/Common/interface/RefCore.h"
 #include "DataFormats/Common/interface/RefCoreWithIndex.h"

--- a/DataFormats/Common/test/test_catch2_RefToBase.cpp
+++ b/DataFormats/Common/test/test_catch2_RefToBase.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "DataFormats/Common/interface/RefToBase.h"
 #include "DataFormats/Common/interface/Ref.h"

--- a/DataFormats/Common/test/test_catch2_RefVector.cpp
+++ b/DataFormats/Common/test/test_catch2_RefVector.cpp
@@ -1,5 +1,5 @@
 #include <vector>
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefVector.h"

--- a/DataFormats/Common/test/test_catch2_StdArray.cpp
+++ b/DataFormats/Common/test/test_catch2_StdArray.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "DataFormats/Common/interface/StdArray.h"
 

--- a/DataFormats/Common/test/test_catch2_ThinnedRefSet.cpp
+++ b/DataFormats/Common/test/test_catch2_ThinnedRefSet.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/Common/interface/ThinnedRefSet.h"

--- a/DataFormats/Common/test/test_catch2_Trie.cpp
+++ b/DataFormats/Common/test/test_catch2_Trie.cpp
@@ -19,7 +19,7 @@
 **   modified by Vincenzo Innocente on 15/08/2007
 */
 
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include <iostream>
 #include <sstream>
 #include <list>

--- a/DataFormats/Common/test/test_catch2_Wrapper.cpp
+++ b/DataFormats/Common/test/test_catch2_Wrapper.cpp
@@ -3,7 +3,7 @@
 #include <memory>
 #include <vector>
 
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "DataFormats/Common/interface/Wrapper.h"
 

--- a/DataFormats/Common/test/test_catch2_exDSTV.cpp
+++ b/DataFormats/Common/test/test_catch2_exDSTV.cpp
@@ -2,7 +2,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include <iostream>
 #include <functional>
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 namespace {
   struct T {

--- a/DataFormats/Common/test/test_catch2_exTrie.cpp
+++ b/DataFormats/Common/test/test_catch2_exTrie.cpp
@@ -1,6 +1,6 @@
 /*
  */
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "DataFormats/Common/interface/Trie.h"
 #include "FWCore/Utilities/interface/Exception.h"
@@ -131,7 +131,7 @@ TEST_CASE("test Trie", "[Trie]") {
         label[i] value[8]
         label[j] value[9]
 )";
-    REQUIRE_THAT(s.str(), Catch::Equals(output));
+    REQUIRE_THAT(s.str(), Catch::Matchers::Equals(output));
 
     SECTION("ab display") {
       pointer pn = trie.node("ab", 2);

--- a/DataFormats/Common/test/test_catch2_traits.cpp
+++ b/DataFormats/Common/test/test_catch2_traits.cpp
@@ -2,7 +2,7 @@
 #include <string>
 #include <vector>
 
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "DataFormats/Common/interface/traits.h"
 
 TEST_CASE("edm::key_traits", "[traits]") {

--- a/DataFormats/HGCalReco/test/EtaPhiSearchInTile_t.cpp
+++ b/DataFormats/HGCalReco/test/EtaPhiSearchInTile_t.cpp
@@ -5,7 +5,7 @@
 #include "DataFormats/HGCalReco/interface/TICLLayerTile.h"
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 using namespace ticl;
 

--- a/DataFormats/Histograms/test/MonitorElementData_Path_catch.cc
+++ b/DataFormats/Histograms/test/MonitorElementData_Path_catch.cc
@@ -13,7 +13,7 @@
 // system include files
 
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 // user include files
 #include "DataFormats/Histograms/interface/MonitorElementCollection.h"

--- a/DataFormats/L1TGlobal/test/test_catch2_l1tGlobalObject.cc
+++ b/DataFormats/L1TGlobal/test/test_catch2_l1tGlobalObject.cc
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include <algorithm>
 #include <string>

--- a/DataFormats/ParticleFlowReco/test/test_catch2_PFDisplacedVertexSeed.cc
+++ b/DataFormats/ParticleFlowReco/test/test_catch2_PFDisplacedVertexSeed.cc
@@ -1,7 +1,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertexSeed.h"
 
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 static constexpr auto s_tag = "[PFDisplacedVertexSeed]";
 TEST_CASE("Check adding elements", s_tag) {

--- a/DataFormats/ParticleFlowReco/test/test_catch2_main.cc
+++ b/DataFormats/ParticleFlowReco/test/test_catch2_main.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/DataFormats/Portable/test/alpaka/test_catch2_heterogeneousDeepCopy.dev.cc
+++ b/DataFormats/Portable/test/alpaka/test_catch2_heterogeneousDeepCopy.dev.cc
@@ -4,7 +4,7 @@
 #include <alpaka/alpaka.hpp>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "DataFormats/SoATemplate/interface/SoALayout.h"
 #include "DataFormats/Portable/interface/PortableCollection.h"

--- a/DataFormats/Portable/test/test_catch2_deepCopyOnHost.cc
+++ b/DataFormats/Portable/test/test_catch2_deepCopyOnHost.cc
@@ -1,7 +1,7 @@
 #include <Eigen/Core>
 #include <Eigen/Dense>
 
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "DataFormats/Portable/interface/PortableHostCollection.h"
 #include "DataFormats/SoATemplate/interface/SoACommon.h"

--- a/DataFormats/Portable/test/test_catch2_main.cc
+++ b/DataFormats/Portable/test/test_catch2_main.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>

--- a/DataFormats/Portable/test/test_catch2_portableCollectionOnHost.cc
+++ b/DataFormats/Portable/test/test_catch2_portableCollectionOnHost.cc
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "DataFormats/Portable/interface/PortableCollection.h"
 #include "DataFormats/Portable/interface/PortableHostCollection.h"

--- a/DataFormats/Portable/test/test_catch2_portableMultiCollectionOnHost.cc
+++ b/DataFormats/Portable/test/test_catch2_portableMultiCollectionOnHost.cc
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "DataFormats/Portable/interface/PortableCollection.h"
 #include "DataFormats/Portable/interface/PortableHostCollection.h"

--- a/DataFormats/Portable/test/test_catch2_portableObjectOnHost.cc
+++ b/DataFormats/Portable/test/test_catch2_portableObjectOnHost.cc
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "DataFormats/Portable/interface/PortableObject.h"
 #include "DataFormats/Portable/interface/PortableHostObject.h"

--- a/DataFormats/Provenance/test/CompactHash_t.cpp
+++ b/DataFormats/Provenance/test/CompactHash_t.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "DataFormats/Provenance/interface/CompactHash.h"
 #include "FWCore/Utilities/interface/Digest.h"

--- a/DataFormats/Provenance/test/ElementID_t.cpp
+++ b/DataFormats/Provenance/test/ElementID_t.cpp
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "DataFormats/Provenance/interface/ElementID.h"
 

--- a/DataFormats/Provenance/test/HardwareResourcesDescription_t.cpp
+++ b/DataFormats/Provenance/test/HardwareResourcesDescription_t.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "DataFormats/Provenance/interface/HardwareResourcesDescription.h"
 #include "FWCore/Utilities/interface/EDMException.h"

--- a/DataFormats/Provenance/test/Hash_t.cpp
+++ b/DataFormats/Provenance/test/Hash_t.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include <algorithm>
 #include <ranges>

--- a/DataFormats/Provenance/test/Parentage_t.cpp
+++ b/DataFormats/Provenance/test/Parentage_t.cpp
@@ -4,7 +4,7 @@
 #include <cassert>
 #include <iostream>
 
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 TEST_CASE("test Parentage", "[Parentage]") {
   edm::Parentage ed1;

--- a/DataFormats/Provenance/test/ProductNamePattern_t.cpp
+++ b/DataFormats/Provenance/test/ProductNamePattern_t.cpp
@@ -1,7 +1,7 @@
 #include <cassert>
 #include <iostream>
 
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "DataFormats/Provenance/interface/ProductNamePattern.h"
 #include "DataFormats/Provenance/interface/ProductDescription.h"

--- a/DataFormats/Provenance/test/StoredProcessBlockHelper_t.cpp
+++ b/DataFormats/Provenance/test/StoredProcessBlockHelper_t.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "DataFormats/Provenance/interface/EventToProcessBlockIndexes.h"
 #include "DataFormats/Provenance/interface/StoredProcessBlockHelper.h"

--- a/DataFormats/Provenance/test/processingOrderMerge_t.cpp
+++ b/DataFormats/Provenance/test/processingOrderMerge_t.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/processingOrderMerge.h"
 #include "FWCore/Utilities/interface/Exception.h"

--- a/DataFormats/Provenance/test/productResolverIndexHelper_t.cpp
+++ b/DataFormats/Provenance/test/productResolverIndexHelper_t.cpp
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/ProductID.h"

--- a/DataFormats/SoATemplate/test/SoACustomizedMethods_t.cc
+++ b/DataFormats/SoATemplate/test/SoACustomizedMethods_t.cc
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "DataFormats/SoATemplate/interface/SoALayout.h"
 

--- a/DataFormats/SoATemplate/test/SoAGenericView_t.cc
+++ b/DataFormats/SoATemplate/test/SoAGenericView_t.cc
@@ -2,7 +2,7 @@
 #include <Eigen/Dense>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "DataFormats/SoATemplate/interface/SoALayout.h"
 

--- a/DataFormats/SoATemplate/test/SoAUnitTests.cc
+++ b/DataFormats/SoATemplate/test/SoAUnitTests.cc
@@ -2,7 +2,7 @@
 #include <tuple>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "DataFormats/SoATemplate/interface/SoALayout.h"
 

--- a/FWCore/Catalog/test/FileLocator_t.cpp
+++ b/FWCore/Catalog/test/FileLocator_t.cpp
@@ -9,7 +9,7 @@
 #include <string>
 
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 TEST_CASE("FileLocator with Rucio data catalog", "[FWCore/Catalog]") {
   edm::ServiceToken tempToken = edmtest::catalog::makeTestSiteLocalConfigToken();

--- a/FWCore/Catalog/test/InputFileCatalog_t.cpp
+++ b/FWCore/Catalog/test/InputFileCatalog_t.cpp
@@ -3,7 +3,7 @@
 
 #include "TestSiteLocalConfig.h"
 
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 TEST_CASE("InputFileCatalog with Rucio data catalog", "[FWCore/Catalog]") {
   edm::ServiceToken tempToken = edmtest::catalog::makeTestSiteLocalConfigToken();

--- a/FWCore/Common/test/test_catch2_ProcessBlockHelpers.cc
+++ b/FWCore/Common/test/test_catch2_ProcessBlockHelpers.cc
@@ -1,5 +1,5 @@
 //#define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "FWCore/Common/interface/OutputProcessBlockHelper.h"
 #include "FWCore/Common/interface/ProcessBlockHelper.h"
 

--- a/FWCore/Common/test/test_catch2_TriggerNames.cc
+++ b/FWCore/Common/test/test_catch2_TriggerNames.cc
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "FWCore/Common/interface/TriggerNames.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <memory>

--- a/FWCore/Concurrency/test/test2_catch2_limitedtaskqueue.cc
+++ b/FWCore/Concurrency/test/test2_catch2_limitedtaskqueue.cc
@@ -6,7 +6,7 @@
 //
 
 #include <iostream>
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <chrono>
 #include <memory>
 #include <atomic>
@@ -65,17 +65,17 @@ TEST_CASE("LimitedTaskQueue", "[LimitedTaskQueue]") {
         oneapi::tbb::task_group group;
         edm::FinalWaitingTask lastTask(group);
         edm::WaitingTaskHolder waitingTask(group, &lastTask);
-        queue.push(group, [&count, waitingTask, kMax] {
+        queue.push(group, [&count, waitingTask] {
           SAFE_REQUIRE(count++ < kMax);
           std::this_thread::sleep_for(10us);
           --count;
         });
-        queue.push(group, [&count, waitingTask, kMax] {
+        queue.push(group, [&count, waitingTask] {
           SAFE_REQUIRE(count++ < kMax);
           std::this_thread::sleep_for(10us);
           --count;
         });
-        queue.push(group, [&count, lastTask = std::move(waitingTask), kMax] {
+        queue.push(group, [&count, lastTask = std::move(waitingTask)] {
           SAFE_REQUIRE(count++ < kMax);
           std::this_thread::sleep_for(10us);
           --count;
@@ -159,11 +159,11 @@ TEST_CASE("LimitedTaskQueue", "[LimitedTaskQueue]") {
       {
         edm::WaitingTaskHolder waitingTask(group, &lastTask);
 
-        group.run([&queue, &waitToStart, &group, waitingTask, &count, &nRunningTasks, kMax] {
+        group.run([&queue, &waitToStart, &group, waitingTask, &count, &nRunningTasks] {
           while (waitToStart) {
           }
           for (unsigned int i = 0; i < nTasks; ++i) {
-            queue.push(group, [&count, waitingTask, &nRunningTasks, kMax] {
+            queue.push(group, [&count, waitingTask, &nRunningTasks] {
               auto nrt = nRunningTasks++;
               if (nrt >= kMax) {
                 std::cout << "ERROR " << nRunningTasks << " >= " << kMax << std::endl;
@@ -174,10 +174,10 @@ TEST_CASE("LimitedTaskQueue", "[LimitedTaskQueue]") {
             });
           }
         });
-        group.run([&queue, &waitToStart, &group, waitingTask, &count, &nRunningTasks, kMax] {
+        group.run([&queue, &waitToStart, &group, waitingTask, &count, &nRunningTasks] {
           waitToStart = false;
           for (unsigned int i = 0; i < nTasks; ++i) {
-            queue.push(group, [&count, waitingTask, &nRunningTasks, kMax] {
+            queue.push(group, [&count, waitingTask, &nRunningTasks] {
               auto nrt = nRunningTasks++;
               if (nrt >= kMax) {
                 std::cout << "ERROR " << nRunningTasks << " >= " << kMax << std::endl;

--- a/FWCore/Concurrency/test/test2_catch2_serialtaskqueue.cc
+++ b/FWCore/Concurrency/test/test2_catch2_serialtaskqueue.cc
@@ -8,7 +8,7 @@
 #include <iostream>
 #define CATCH_CONFIG_MAIN
 
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <chrono>
 #include <memory>
 #include <atomic>

--- a/FWCore/Concurrency/test/test2_catch2_serialtaskqueuechain.cc
+++ b/FWCore/Concurrency/test/test2_catch2_serialtaskqueuechain.cc
@@ -5,7 +5,7 @@
 //  Created by Chris Jones on 9/27/11.
 //
 
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <chrono>
 #include <memory>
 #include <atomic>

--- a/FWCore/Concurrency/test/test2_catch2_waitingtasklist.cc
+++ b/FWCore/Concurrency/test/test2_catch2_waitingtasklist.cc
@@ -6,7 +6,7 @@
 //
 
 #include <iostream>
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <chrono>
 #include <memory>
 #include <atomic>

--- a/FWCore/Concurrency/test/test_catch2_Async.cc
+++ b/FWCore/Concurrency/test/test_catch2_Async.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include <atomic>
 
@@ -30,7 +30,7 @@ namespace {
   };
 }  // namespace
 
-TEST_CASE("Test Async", "[edm::Async") {
+TEST_CASE("Test Async", "[edm::Async]") {
   // Using parallelism 2 here because otherwise the
   // tbb::task_arena::enqueue() in WaitingTaskWithArenaHolder will
   // start a new TBB thread that "inherits" the name from the
@@ -92,6 +92,6 @@ TEST_CASE("Test Async", "[edm::Async") {
     REQUIRE(waitTask.done());
     REQUIRE(waitTask.exceptionPtr());
     REQUIRE_THROWS_WITH(std::rethrow_exception(waitTask.exceptionPtr()),
-                        Catch::Contains("Calling run in this context is not allowed"));
+                        Catch::Matchers::ContainsSubstring("Calling run in this context is not allowed"));
   }
 }

--- a/FWCore/Concurrency/test/test_catch2_WaitingTaskChain.cc
+++ b/FWCore/Concurrency/test/test_catch2_WaitingTaskChain.cc
@@ -6,7 +6,7 @@
 //
 
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "oneapi/tbb/global_control.h"
 

--- a/FWCore/Concurrency/test/test_catch2_WaitingThreadPool.cc
+++ b/FWCore/Concurrency/test/test_catch2_WaitingThreadPool.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "oneapi/tbb/global_control.h"
 
@@ -11,7 +11,7 @@ namespace {
   constexpr char const* errorContext() { return "WaitingThreadPool test"; }
 }  // namespace
 
-TEST_CASE("Test WaitingThreadPool", "[edm::WaitingThreadPool") {
+TEST_CASE("Test WaitingThreadPool", "[edm::WaitingThreadPool]") {
   // Using parallelism 2 here because otherwise the
   // tbb::task_arena::enqueue() in WaitingTaskWithArenaHolder will
   // start a new TBB thread that "inherits" the name from the
@@ -126,9 +126,10 @@ TEST_CASE("Test WaitingThreadPool", "[edm::WaitingThreadPool") {
                  lastTask(edm::WaitingTaskHolder(group, &waitTask));
         h.doneWaiting(std::exception_ptr());
       }
-      REQUIRE_THROWS_WITH(
-          waitTask.wait(),
-          Catch::Contains("error") and Catch::Contains("StdException") and Catch::Contains("WaitingThreadPool test"));
+      REQUIRE_THROWS_WITH(waitTask.wait(),
+                          Catch::Matchers::ContainsSubstring("error") and
+                              Catch::Matchers::ContainsSubstring("StdException") and
+                              Catch::Matchers::ContainsSubstring("WaitingThreadPool test"));
       REQUIRE(count.load() == 0);
     }
 

--- a/FWCore/Framework/test/EventSelExc_t.cpp
+++ b/FWCore/Framework/test/EventSelExc_t.cpp
@@ -13,7 +13,7 @@
 //    11 - Exception demanded
 //    12 - Specific and wildcarded exceptions
 //    13 - Everything - also tests that it accepts all Ready
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "FWCore/Framework/interface/EventSelector.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
@@ -208,8 +208,9 @@ void evSelTest(PathSpecifiers const& ps, TrigResults const& tr, bool ans) {
       << "pathspecs = " << ps.path << "\n"
       << "trigger results = " << tr << "\n";
   }
-  REQUIRE_THAT(ans,
-               Catch::Predicate<bool>([a, b, aa](auto ans) { return a == ans and b == ans and aa == ans; }, s.str()));
+  REQUIRE_THAT(
+      ans,
+      Catch::Matchers::Predicate<bool>([a, b, aa](auto ans) { return a == ans and b == ans and aa == ans; }, s.str()));
 
   // Repeat putting the list of trigger names in the pset
   // registry
@@ -230,7 +231,7 @@ void evSelTest(PathSpecifiers const& ps, TrigResults const& tr, bool ans) {
       << "pathspecs =" << ps.path << "\n"
       << "trigger results = " << tr << "\n";
   }
-  REQUIRE_THAT(ans, Catch::Predicate<bool>([x, y](auto ans) { return x == ans and y == ans; }, s.str()));
+  REQUIRE_THAT(ans, Catch::Matchers::Predicate<bool>([x, y](auto ans) { return x == ans and y == ans; }, s.str()));
 }
 
 TEST_CASE("test EventSelector test", "[EventSelector]") {

--- a/FWCore/Framework/test/EventSelOverlap_t.cpp
+++ b/FWCore/Framework/test/EventSelOverlap_t.cpp
@@ -3,7 +3,7 @@
 //   maskTriggerResults
 
 // Note - work in progress - only very cursory testing is done right now!
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "FWCore/Framework/interface/EventSelector.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
@@ -194,7 +194,7 @@ namespace {
         << "pathspecs = " << ps.path << "\n"
         << "trigger results = " << tr << "\n";
     }
-    REQUIRE_THAT(ok, Catch::Predicate<bool>([](bool iValue) { return iValue; }, s.str()));
+    REQUIRE_THAT(ok, Catch::Matchers::Predicate<bool>([](bool iValue) { return iValue; }, s.str()));
   }
 }  // namespace
 TEST_CASE("test EventSelector overlap", "[EventSelector overlap]") {

--- a/FWCore/Framework/test/EventSelWildcard_t.cpp
+++ b/FWCore/Framework/test/EventSelWildcard_t.cpp
@@ -1,5 +1,5 @@
 
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "FWCore/Framework/interface/EventSelector.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
@@ -105,7 +105,7 @@ namespace {
         << "jmask = " << jmask << "\n";
     }
     REQUIRE_THAT(answer,
-                 Catch::Predicate<bool>(
+                 Catch::Matchers::Predicate<bool>(
                      [a, b, aa](bool answer) { return a == answer and b == answer and aa == answer; }, s.str()));
 
     // Repeat putting the list of trigger names in the pset
@@ -128,7 +128,8 @@ namespace {
         << "mask=" << mask << "\n"
         << "jmask = " << jmask << "\n";
     }
-    REQUIRE_THAT(answer, Catch::Predicate<bool>([x, y](bool answer) { return x == answer and y == answer; }, s.str()));
+    REQUIRE_THAT(
+        answer, Catch::Matchers::Predicate<bool>([x, y](bool answer) { return x == answer and y == answer; }, s.str()));
   }
 
   void testall(const Strings& paths, const VStrings& patterns, const VBools& masks, const Answers& answers) {

--- a/FWCore/Framework/test/EventSelector_t.cpp
+++ b/FWCore/Framework/test/EventSelector_t.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "FWCore/Framework/interface/EventSelector.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
@@ -103,7 +103,7 @@ void testone(const Strings& paths, const Strings& pattern, const Bools& mask, bo
   }
   REQUIRE_THAT(
       answer,
-      Catch::Predicate<bool>(
+      Catch::Matchers::Predicate<bool>(
           [a1, a2, b2, c1](auto answer) { return a1 == answer and a2 == answer and b2 == answer and c1 == answer; },
           s.str()));
 
@@ -133,8 +133,8 @@ void testone(const Strings& paths, const Strings& pattern, const Bools& mask, bo
   }
   REQUIRE_THAT(
       answer,
-      Catch::Predicate<bool>([a11, a12, a13](auto answer) { return a11 == answer and a12 == answer and a13 == answer; },
-                             s.str()));
+      Catch::Matchers::Predicate<bool>(
+          [a11, a12, a13](auto answer) { return a11 == answer and a12 == answer and a13 == answer; }, s.str()));
 }
 
 void testall(const Strings& paths, const VStrings& patterns, const VBools& masks, const Answers& answers) {

--- a/FWCore/Framework/test/ProductSelector_t.cpp
+++ b/FWCore/Framework/test/ProductSelector_t.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include <iostream>
 #include <string>
 #include <vector>
@@ -243,9 +243,9 @@ TEST_CASE("test ProductSelector", "[ProductSelector]") {
     cmds.push_back(bad_rule);
     bad.addUntrackedParameter<std::vector<std::string> >("outputCommands", cmds);
     bad.registerIt();
-    REQUIRE_THROWS_MATCHES(
-        edm::ProductSelectorRules(bad, "outputCommands", "ProductSelectorTest"),
-        edm::Exception,
-        Catch::Predicate<edm::Exception>([](auto const& x) { return x.categoryCode() == edm::errors::Configuration; }));
+    REQUIRE_THROWS_MATCHES(edm::ProductSelectorRules(bad, "outputCommands", "ProductSelectorTest"),
+                           edm::Exception,
+                           Catch::Matchers::Predicate<edm::Exception>(
+                               [](auto const& x) { return x.categoryCode() == edm::errors::Configuration; }));
   }
 }

--- a/FWCore/Framework/test/TriggerResultsBasedEventSelectorUtilities_t.cpp
+++ b/FWCore/Framework/test/TriggerResultsBasedEventSelectorUtilities_t.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 namespace trigger_results_based_event_selector_utils {
   // Implemented in TriggerResultsBasedEventSelector.cc
   void remove_whitespace(std::string& s);

--- a/FWCore/Framework/test/test_catch2_CmsRunParser.cc
+++ b/FWCore/Framework/test/test_catch2_CmsRunParser.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "FWCore/Framework/interface/CmsRunParser.h"
 #include "FWCore/Utilities/interface/EDMException.h"

--- a/FWCore/Framework/test/test_catch2_ESHandle.cc
+++ b/FWCore/Framework/test/test_catch2_ESHandle.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/EDMException.h"

--- a/FWCore/Framework/test/test_catch2_ModuleHolderFactory.cc
+++ b/FWCore/Framework/test/test_catch2_ModuleHolderFactory.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "FWCore/Framework/src/ModuleHolderFactory.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
@@ -86,10 +86,10 @@ TEST_CASE("test edm::Factory", "[Factory]") {
     pset.addParameter<std::string>("@module_type", "DoesNotExistModule");
     pset.addParameter<std::string>("@module_edm_type", "EDProducer");
     edm::test::SimpleTestTypeResolverMaker resolver;
-    using Catch::Matchers::Contains;
+    using Catch::Matchers::ContainsSubstring;
     CHECK_THROWS_WITH(
         factory->makeModule(MakeModuleParams(&pset, prodReg, &preallocConfig, procConfig), &resolver, pre, post),
-        Contains("DoesNotExistModule"));
+        ContainsSubstring("DoesNotExistModule"));
   }
   SECTION("test missing plugin with complex resolver") {
     auto factory = ModuleHolderFactory::get();
@@ -97,11 +97,11 @@ TEST_CASE("test edm::Factory", "[Factory]") {
     pset.addParameter<std::string>("@module_type", "generic::DoesNotExistModule");
     pset.addParameter<std::string>("@module_edm_type", "EDProducer");
     edm::test::ComplexTestTypeResolverMaker resolver;
-    using Catch::Matchers::Contains;
+    using Catch::Matchers::ContainsSubstring;
     CHECK_THROWS_WITH(
         factory->makeModule(MakeModuleParams(&pset, prodReg, &preallocConfig, procConfig), &resolver, pre, post),
-        Contains("generic::DoesNotExistModule") && Contains("edm::test::other::DoesNotExistModule") &&
-            Contains("edm::test::cpu::DoesNotExistModule"));
+        ContainsSubstring("generic::DoesNotExistModule") && ContainsSubstring("edm::test::other::DoesNotExistModule") &&
+            ContainsSubstring("edm::test::cpu::DoesNotExistModule"));
   }
   SECTION("test missing plugin with configurable resolver") {
     auto factory = ModuleHolderFactory::get();
@@ -110,29 +110,32 @@ TEST_CASE("test edm::Factory", "[Factory]") {
     pset.addParameter<std::string>("@module_edm_type", "EDProducer");
     SECTION("default behavior") {
       edm::test::ConfigurableTestTypeResolverMaker resolver;
-      using Catch::Matchers::Contains;
+      using Catch::Matchers::ContainsSubstring;
       CHECK_THROWS_WITH(
           factory->makeModule(MakeModuleParams(&pset, prodReg, &preallocConfig, procConfig), &resolver, pre, post),
-          Contains("generic::DoesNotExistModule") && Contains("edm::test::other::DoesNotExistModule") &&
-              Contains("edm::test::cpu::DoesNotExistModule"));
+          ContainsSubstring("generic::DoesNotExistModule") &&
+              ContainsSubstring("edm::test::other::DoesNotExistModule") &&
+              ContainsSubstring("edm::test::cpu::DoesNotExistModule"));
     }
     SECTION("set variant to other") {
       pset.addUntrackedParameter<std::string>("variant", "other");
       edm::test::ConfigurableTestTypeResolverMaker resolver;
-      using Catch::Matchers::Contains;
+      using Catch::Matchers::ContainsSubstring;
       CHECK_THROWS_WITH(
           factory->makeModule(MakeModuleParams(&pset, prodReg, &preallocConfig, procConfig), &resolver, pre, post),
-          Contains("generic::DoesNotExistModule") && Contains("edm::test::other::DoesNotExistModule") &&
-              not Contains("edm::test::cpu::DoesNotExistModule"));
+          ContainsSubstring("generic::DoesNotExistModule") &&
+              ContainsSubstring("edm::test::other::DoesNotExistModule") &&
+              not ContainsSubstring("edm::test::cpu::DoesNotExistModule"));
     }
     SECTION("set variant to cpu") {
       pset.addUntrackedParameter<std::string>("variant", "cpu");
       edm::test::ConfigurableTestTypeResolverMaker resolver;
-      using Catch::Matchers::Contains;
+      using Catch::Matchers::ContainsSubstring;
       CHECK_THROWS_WITH(
           factory->makeModule(MakeModuleParams(&pset, prodReg, &preallocConfig, procConfig), &resolver, pre, post),
-          Contains("generic::DoesNotExistModule") && not Contains("edm::test::other::DoesNotExistModule") &&
-              Contains("edm::test::cpu::DoesNotExistModule"));
+          ContainsSubstring("generic::DoesNotExistModule") &&
+              not ContainsSubstring("edm::test::other::DoesNotExistModule") &&
+              ContainsSubstring("edm::test::cpu::DoesNotExistModule"));
     }
   }
 

--- a/FWCore/Framework/test/test_catch2_ScheduleBuilder.cc
+++ b/FWCore/Framework/test/test_catch2_ScheduleBuilder.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "FWCore/Framework/src/ScheduleBuilder.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"

--- a/FWCore/Framework/test/test_catch2_main.cc
+++ b/FWCore/Framework/test/test_catch2_main.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/FWCore/Framework/test/test_catch2notTP_ESRecordsToProductResolverIndices.cc
+++ b/FWCore/Framework/test/test_catch2notTP_ESRecordsToProductResolverIndices.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "FWCore/Framework/interface/ESRecordsToProductResolverIndices.h"
 #include "FWCore/Framework/interface/ComponentDescription.h"

--- a/FWCore/Framework/test/test_catch2notTP_InputProcessBlock.cc
+++ b/FWCore/Framework/test/test_catch2notTP_InputProcessBlock.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "FWCore/Framework/interface/InputProcessBlockCacheImpl.h"
 #include "FWCore/Framework/interface/moduleAbilities.h"

--- a/FWCore/Framework/test/test_catch2notTP_InputProcessBlockCacheHolder.cc
+++ b/FWCore/Framework/test/test_catch2notTP_InputProcessBlockCacheHolder.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "FWCore/Framework/interface/InputProcessBlockCacheImpl.h"
 #include "FWCore/Framework/interface/global/EDProducerBase.h"

--- a/FWCore/Framework/test/test_catch2notTP_MergeableRunProductMetadata.cc
+++ b/FWCore/Framework/test/test_catch2notTP_MergeableRunProductMetadata.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/IndexIntoFile.h"

--- a/FWCore/Integration/test/EDAlias_t.cpp
+++ b/FWCore/Integration/test/EDAlias_t.cpp
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -81,11 +81,13 @@ process.moduleToTest(process.test, cms.Task(process.intprod))
   edm::test::TestProcessor::Config config{baseConfig};
 
   SECTION("Alias with two instances pointing to the same product is not allowed") {
-    REQUIRE_THROWS_WITH(
-        edm::test::TestProcessor(config),
-        Catch::Contains("EDAlias conflict") && Catch::Contains("is used for multiple products of type") &&
-            Catch::Contains("with module label") && Catch::Contains("and instance name") &&
-            Catch::Contains("alias has the instance name") && Catch::Contains("and the other has the instance name"));
+    REQUIRE_THROWS_WITH(edm::test::TestProcessor(config),
+                        Catch::Matchers::ContainsSubstring("EDAlias conflict") &&
+                            Catch::Matchers::ContainsSubstring("is used for multiple products of type") &&
+                            Catch::Matchers::ContainsSubstring("with module label") &&
+                            Catch::Matchers::ContainsSubstring("and instance name") &&
+                            Catch::Matchers::ContainsSubstring("alias has the instance name") &&
+                            Catch::Matchers::ContainsSubstring("and the other has the instance name"));
   }
 }
 
@@ -112,9 +114,11 @@ process.moduleToTest(process.test, cms.Task(process.intprod))
 
   SECTION("Alias with two instances pointing to the same product is not allowed") {
     REQUIRE_THROWS_WITH(edm::test::TestProcessor(config),
-                        Catch::Contains("EDAlias conflict") && Catch::Contains("and product instance alias") &&
-                            Catch::Contains("are used for multiple products of type") &&
-                            Catch::Contains("One has module label") && Catch::Contains("the other has module label"));
+                        Catch::Matchers::ContainsSubstring("EDAlias conflict") &&
+                            Catch::Matchers::ContainsSubstring("and product instance alias") &&
+                            Catch::Matchers::ContainsSubstring("are used for multiple products of type") &&
+                            Catch::Matchers::ContainsSubstring("One has module label") &&
+                            Catch::Matchers::ContainsSubstring("the other has module label"));
   }
 }
 
@@ -232,12 +236,12 @@ process.moduleToTest(process.test, cms.Task(process.intprod))
     {
       edm::test::TestProcessor::Config config{std::format(baseConfig, "'intalias:foo'")};
       edm::test::TestProcessor tester(config);
-      REQUIRE_THROWS_WITH(tester.test(), Catch::Contains("ProductNotFound"));
+      REQUIRE_THROWS_WITH(tester.test(), Catch::Matchers::ContainsSubstring("ProductNotFound"));
     }
     {
       edm::test::TestProcessor::Config config{std::format(baseConfig, "'intalias'")};
       edm::test::TestProcessor tester(config);
-      REQUIRE_THROWS_WITH(tester.test(), Catch::Contains("ProductNotFound"));
+      REQUIRE_THROWS_WITH(tester.test(), Catch::Matchers::ContainsSubstring("ProductNotFound"));
     }
   }
 }
@@ -343,7 +347,8 @@ process.moduleToTest(process.test, cms.Task(process.intprod))
 
     REQUIRE_THROWS_WITH(
         edm::test::TestProcessor(config),
-        Catch::Contains("There are no products with module label 'intprod' and product instance name 'nonexistent'"));
+        Catch::Matchers::ContainsSubstring(
+            "There are no products with module label 'intprod' and product instance name 'nonexistent'"));
   }
 
   SECTION("Instance wildcard") {
@@ -351,7 +356,7 @@ process.moduleToTest(process.test, cms.Task(process.intprod))
         std::format(baseConfig, "intprod = cms.VPSet(cms.PSet(type = cms.string('nonexistentType')))")};
 
     REQUIRE_THROWS_WITH(edm::test::TestProcessor(config),
-                        Catch::Contains("There are no products of type 'nonexistentType'") &&
-                            Catch::Contains("with module label 'intprod'"));
+                        Catch::Matchers::ContainsSubstring("There are no products of type 'nonexistentType'") &&
+                            Catch::Matchers::ContainsSubstring("with module label 'intprod'"));
   }
 }

--- a/FWCore/Integration/test/ProcessAccelerator_t.cpp
+++ b/FWCore/Integration/test/ProcessAccelerator_t.cpp
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -93,7 +93,7 @@ TEST_CASE("Configuration with ModuleTypeResolver", s_tag) {
     edm::makeParameterSets(baseConfigOtherDisabled_auto, psetOtherDisabled_auto);
     edm::makeParameterSets(baseConfigOtherDisabled_cpu, psetOtherDisabled_cpu);
     REQUIRE_THROWS_WITH(edm::makeParameterSets(baseConfigOtherDisabled_other, psetOtherDisabled_other),
-                        Catch::Contains("UnavailableAccelerator"));
+                        Catch::Matchers::ContainsSubstring("UnavailableAccelerator"));
     pset_auto->registerIt();
     pset_cpu->registerIt();
     pset_other->registerIt();

--- a/FWCore/Integration/test/ProcessConfiguration_t.cpp
+++ b/FWCore/Integration/test/ProcessConfiguration_t.cpp
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/FWCore/Integration/test/ProcessHistory_t.cpp
+++ b/FWCore/Integration/test/ProcessHistory_t.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Provenance/interface/IndexIntoFile.h"

--- a/FWCore/Integration/test/RandomIntProducer_t.cpp
+++ b/FWCore/Integration/test/RandomIntProducer_t.cpp
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/FWCore/Modules/test/test_catch2_LogErrorFilter.cc
+++ b/FWCore/Modules/test/test_catch2_LogErrorFilter.cc
@@ -3,7 +3,7 @@
 #include "DataFormats/Common/interface/ErrorSummaryEntry.h"
 
 #include <vector>
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 static constexpr auto s_tag = "[LogErrorFilter]";
 TEST_CASE("Tests of LogErrorFilter", s_tag) {

--- a/FWCore/Modules/test/test_catch2_ModuloEventIDFilter.cc
+++ b/FWCore/Modules/test/test_catch2_ModuloEventIDFilter.cc
@@ -1,7 +1,7 @@
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 static constexpr auto s_tag = "[ModuloEventIDFilter]";
 

--- a/FWCore/Modules/test/test_catch2_PathStatusFilter.cc
+++ b/FWCore/Modules/test/test_catch2_PathStatusFilter.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 #include "FWCore/Utilities/interface/Exception.h"
 

--- a/FWCore/Modules/test/test_catch2_Prescaler.cc
+++ b/FWCore/Modules/test/test_catch2_Prescaler.cc
@@ -1,7 +1,7 @@
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 static constexpr auto s_tag = "[Prescaler]";
 TEST_CASE("Check parameters of Prescaler", s_tag) {

--- a/FWCore/Modules/test/test_catch2_main.cc
+++ b/FWCore/Modules/test/test_catch2_main.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/FWCore/ParameterSet/test/test_catch2_ps.cc
+++ b/FWCore/ParameterSet/test/test_catch2_ps.cc
@@ -1,7 +1,7 @@
 /*
  */
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include <algorithm>
 #include <iostream>
@@ -17,6 +17,9 @@
 namespace edm {
   bool operator!=(const edm::EventRange& iLHS, const edm::EventRange& iRHS) {
     return ((iLHS.startEventID() != iRHS.startEventID()) or (iLHS.endEventID() != iRHS.endEventID()));
+  }
+  bool operator==(const edm::EventRange& iLHS, const edm::EventRange& iRHS) {
+    return ((iLHS.startEventID() == iRHS.startEventID()) or (iLHS.endEventID() == iRHS.endEventID()));
   }
 }  // namespace edm
 namespace {

--- a/FWCore/ParameterSet/test/test_catch_ParameterSetDescription.cc
+++ b/FWCore/ParameterSet/test/test_catch_ParameterSetDescription.cc
@@ -2,7 +2,7 @@
 // Test code for the ParameterSetDescription and ParameterDescription
 // classes.
 
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/LuminosityBlockID.h"

--- a/FWCore/Services/test/test_catch2_ExternalRandomNumberGeneratorService.cc
+++ b/FWCore/Services/test/test_catch2_ExternalRandomNumberGeneratorService.cc
@@ -6,7 +6,7 @@
 #include "CLHEP/Random/MixMaxRng.h"
 
 //#define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 namespace {
   void test(CLHEP::HepRandomEngine& iRand, CLHEP::HepRandomEngine& iEngine) {

--- a/FWCore/Services/test/test_catch2_SiteLocalConfigService.cc
+++ b/FWCore/Services/test/test_catch2_SiteLocalConfigService.cc
@@ -4,7 +4,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 TEST_CASE("Test SiteLocalConfigService", "[sitelocalconfig]") {
   std::string dirString;

--- a/FWCore/Services/test/test_catch2_cpu_features.cc
+++ b/FWCore/Services/test/test_catch2_cpu_features.cc
@@ -1,6 +1,6 @@
 #include <iostream>
 
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "cpu_features/cpu_features_macros.h"
 

--- a/FWCore/SharedMemory/test/test_catch2_buffer.cc
+++ b/FWCore/SharedMemory/test/test_catch2_buffer.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include <stdio.h>
 #include <string>
 #include <algorithm>

--- a/FWCore/SharedMemory/test/test_catch2_main.cc
+++ b/FWCore/SharedMemory/test/test_catch2_main.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/FWCore/SharedMemory/test/test_catch2_serialize.cc
+++ b/FWCore/SharedMemory/test/test_catch2_serialize.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include <utility>
 #include <algorithm>
 #include <iterator>

--- a/FWCore/Utilities/test/test_catch2HRTime.cc
+++ b/FWCore/Utilities/test/test_catch2HRTime.cc
@@ -5,7 +5,7 @@
 #include <typeinfo>
 #include <iostream>
 
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 namespace {
 

--- a/FWCore/Utilities/test/test_catch2Slow_cputimer.cc
+++ b/FWCore/Utilities/test/test_catch2Slow_cputimer.cc
@@ -7,7 +7,7 @@ Test program for edm::TypeIDBase class.
 #include <string>
 #include <unistd.h>
 #include <sys/resource.h>
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 #include "FWCore/Utilities/interface/CPUTimer.h"
 
 using std::cerr;

--- a/FWCore/Utilities/test/test_catch2_Digest.cc
+++ b/FWCore/Utilities/test/test_catch2_Digest.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "FWCore/Utilities/interface/Digest.h"
 #include "FWCore/Utilities/interface/Exception.h"

--- a/FWCore/Utilities/test/test_catch2_EDGetToken.cc
+++ b/FWCore/Utilities/test/test_catch2_EDGetToken.cc
@@ -1,6 +1,6 @@
 #include <functional>
 #include "FWCore/Utilities/interface/EDGetToken.h"
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 namespace edm {
   class TestEDGetToken {

--- a/FWCore/Utilities/test/test_catch2_EDMException.cc
+++ b/FWCore/Utilities/test/test_catch2_EDMException.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "FWCore/Utilities/interface/EDMException.h"
 
 #include <iostream>

--- a/FWCore/Utilities/test/test_catch2_Exception.cc
+++ b/FWCore/Utilities/test/test_catch2_Exception.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "FWCore/Utilities/interface/Exception.h"
 #include <cstdlib>
 #include <iomanip>

--- a/FWCore/Utilities/test/test_catch2_Guid.cc
+++ b/FWCore/Utilities/test/test_catch2_Guid.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "FWCore/Utilities/interface/Guid.h"
 
 TEST_CASE(

--- a/FWCore/Utilities/test/test_catch2_InputTag.cc
+++ b/FWCore/Utilities/test/test_catch2_InputTag.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 

--- a/FWCore/Utilities/test/test_catch2_OftenEmptyCString.cc
+++ b/FWCore/Utilities/test/test_catch2_OftenEmptyCString.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "FWCore/Utilities/interface/OftenEmptyCString.h"
 #include <cstring>
 

--- a/FWCore/Utilities/test/test_catch2_atomic_value_ptr.cc
+++ b/FWCore/Utilities/test/test_catch2_atomic_value_ptr.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "FWCore/Utilities/interface/atomic_value_ptr.h"
 
 #include <memory>

--- a/FWCore/Utilities/test/test_catch2_calculateCRC32.cc
+++ b/FWCore/Utilities/test/test_catch2_calculateCRC32.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "FWCore/Utilities/interface/calculateCRC32.h"
 
 TEST_CASE("test cms::calculateCRC32", "[calculateCRC32]") {

--- a/FWCore/Utilities/test/test_catch2_callxnowait.cc
+++ b/FWCore/Utilities/test/test_catch2_callxnowait.cc
@@ -3,7 +3,7 @@ Test program for edm::TypeID class.
  ----------------------------------------------------------------------*/
 
 #include <cassert>
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 #include "FWCore/Utilities/interface/CallOnceNoWait.h"
 #include "FWCore/Utilities/interface/CallNTimesNoWait.h"
 #include <thread>

--- a/FWCore/Utilities/test/test_catch2_clone_ptr.cc
+++ b/FWCore/Utilities/test/test_catch2_clone_ptr.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "FWCore/Utilities/interface/clone_ptr.h"
 #include <vector>
 

--- a/FWCore/Utilities/test/test_catch2_compactStringSerializer.cc
+++ b/FWCore/Utilities/test/test_catch2_compactStringSerializer.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include <iostream>
 #include <list>

--- a/FWCore/Utilities/test/test_catch2_esinputtag.cc
+++ b/FWCore/Utilities/test/test_catch2_esinputtag.cc
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <string>
 
 #include "FWCore/Utilities/interface/EDMException.h"

--- a/FWCore/Utilities/test/test_catch2_friendlyname.cc
+++ b/FWCore/Utilities/test/test_catch2_friendlyname.cc
@@ -6,7 +6,7 @@
  *
  */
 
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <iostream>
 #include "FWCore/Utilities/interface/FriendlyName.h"
 #include <map>

--- a/FWCore/Utilities/test/test_catch2_indexset.cc
+++ b/FWCore/Utilities/test/test_catch2_indexset.cc
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "FWCore/Utilities/interface/IndexSet.h"
 

--- a/FWCore/Utilities/test/test_catch2_isFinite.cc
+++ b/FWCore/Utilities/test/test_catch2_isFinite.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "FWCore/Utilities/interface/isFinite.h"
 

--- a/FWCore/Utilities/test/test_catch2_main.cc
+++ b/FWCore/Utilities/test/test_catch2_main.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/FWCore/Utilities/test/test_catch2_path_configuration.cc
+++ b/FWCore/Utilities/test/test_catch2_path_configuration.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Utilities/interface/path_configuration.h"
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 using namespace edm::path_configuration;
 TEST_CASE("Test path_configuration", "[path_configuration]") {

--- a/FWCore/Utilities/test/test_catch2_propagate_const.cc
+++ b/FWCore/Utilities/test/test_catch2_propagate_const.cc
@@ -4,7 +4,7 @@ Test program for edm::propagate_const class.
 
  ----------------------------------------------------------------------*/
 
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <memory>
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 #include "FWCore/Utilities/interface/propagate_const.h"

--- a/FWCore/Utilities/test/test_catch2_propagate_const_array.cc
+++ b/FWCore/Utilities/test/test_catch2_propagate_const_array.cc
@@ -4,7 +4,7 @@ Test program for edm::propagate_const_array class.
 
  ----------------------------------------------------------------------*/
 
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 #include "FWCore/Utilities/interface/propagate_const_array.h"
 

--- a/FWCore/Utilities/test/test_catch2_reusableobjectholder.cc
+++ b/FWCore/Utilities/test/test_catch2_reusableobjectholder.cc
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <set>
 #include <thread>
 #include <iostream>

--- a/FWCore/Utilities/test/test_catch2_signal.cc
+++ b/FWCore/Utilities/test/test_catch2_signal.cc
@@ -4,7 +4,7 @@ Test program for edm::signalslot::Signal class.
 
  ----------------------------------------------------------------------*/
 
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <cassert>
 #include <iostream>
 #include <string>

--- a/FWCore/Utilities/test/test_catch2_soatuple.cc
+++ b/FWCore/Utilities/test/test_catch2_soatuple.cc
@@ -5,7 +5,7 @@ Changed by Viji on 29-06-2005
 
  ----------------------------------------------------------------------*/
 
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <cassert>
 #include <cstdint>
 #include <iostream>

--- a/FWCore/Utilities/test/test_catch2_stemFromPath.cc
+++ b/FWCore/Utilities/test/test_catch2_stemFromPath.cc
@@ -1,6 +1,6 @@
 #include "FWCore/Utilities/interface/stemFromPath.h"
 
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 TEST_CASE("Test stemFromPath", "[sources]") {
   CHECK(edm::stemFromPath("foo.root") == "foo");

--- a/FWCore/Utilities/test/test_catch2_transform.cc
+++ b/FWCore/Utilities/test/test_catch2_transform.cc
@@ -8,7 +8,7 @@ Test program for edm::vector_transform class.
 #include <iostream>
 #include <string>
 #include <boost/algorithm/string.hpp>
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "FWCore/Utilities/interface/transform.h"
 

--- a/FWCore/Utilities/test/test_catch2_typeid.cc
+++ b/FWCore/Utilities/test/test_catch2_typeid.cc
@@ -8,7 +8,7 @@ Changed by Viji on 29-06-2005
 #include <cassert>
 #include <iostream>
 #include <string>
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 #include "FWCore/Utilities/interface/TypeID.h"
 
 namespace edmtest {

--- a/FWCore/Utilities/test/test_catch2_typeidbase.cc
+++ b/FWCore/Utilities/test/test_catch2_typeidbase.cc
@@ -8,7 +8,7 @@ Changed by Viji on 29-06-2005
 #include <cassert>
 #include <iostream>
 #include <string>
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 #include "FWCore/Utilities/interface/TypeIDBase.h"
 
 namespace edmtest {

--- a/FWCore/Utilities/test/test_catch2_value_ptr.cc
+++ b/FWCore/Utilities/test/test_catch2_value_ptr.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "FWCore/Utilities/interface/value_ptr.h"
 
 #include <memory>

--- a/FWCore/Utilities/test/test_catch2_vecarray.cc
+++ b/FWCore/Utilities/test/test_catch2_vecarray.cc
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "FWCore/Utilities/interface/VecArray.h"
 

--- a/GeneratorInterface/LHEInterface/test/test_catch2_ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/test/test_catch2_ExternalLHEProducer.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"

--- a/GeneratorInterface/LHEInterface/test/test_catch2_main.cc
+++ b/GeneratorInterface/LHEInterface/test/test_catch2_main.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/GeneratorInterface/Pythia8Interface/test/test_catch2_External_Pythia8GeneratorFilter.cc
+++ b/GeneratorInterface/Pythia8Interface/test/test_catch2_External_Pythia8GeneratorFilter.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 #include "FWCore/Utilities/interface/Exception.h"
 

--- a/GeneratorInterface/Pythia8Interface/test/test_catch2_Pythia8GeneratorFilter.cc
+++ b/GeneratorInterface/Pythia8Interface/test/test_catch2_Pythia8GeneratorFilter.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 #include "FWCore/Utilities/interface/Exception.h"
 

--- a/GeneratorInterface/Pythia8Interface/test/test_catch2_main.cc
+++ b/GeneratorInterface/Pythia8Interface/test/test_catch2_main.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/Geometry/CaloGeometry/test/calocellgeometryptr_catch2.cc
+++ b/Geometry/CaloGeometry/test/calocellgeometryptr_catch2.cc
@@ -16,7 +16,7 @@
 #include "Geometry/CaloGeometry/interface/CaloCellGeometryPtr.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometryMayOwnPtr.h"
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 namespace {
   class DummyCell : public CaloCellGeometry {

--- a/HLTrigger/HLTcore/test/test_catch2_HLTConfigData.cc
+++ b/HLTrigger/HLTcore/test/test_catch2_HLTConfigData.cc
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "HLTrigger/HLTcore/interface/HLTConfigData.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/HLTrigger/HLTcore/test/test_catch2_TriggerExpressionParser.cc
+++ b/HLTrigger/HLTcore/test/test_catch2_TriggerExpressionParser.cc
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include <string>
 

--- a/HeterogeneousCore/AlpakaCore/test/alpaka/testFriendlyClassNames.cc
+++ b/HeterogeneousCore/AlpakaCore/test/alpaka/testFriendlyClassNames.cc
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <alpaka/alpaka.hpp>
 

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testAtomicPairCounter.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testAtomicPairCounter.dev.cc
@@ -2,7 +2,7 @@
 #include <iostream>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <alpaka/alpaka.hpp>
 

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testBuffer.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testBuffer.dev.cc
@@ -1,7 +1,7 @@
 #include <alpaka/alpaka.hpp>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "FWCore/Utilities/interface/stringize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testCopyBufferToDevice.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testCopyBufferToDevice.dev.cc
@@ -1,7 +1,7 @@
 #include <alpaka/alpaka.hpp>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testHistoContainer.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testHistoContainer.dev.cc
@@ -5,7 +5,7 @@
 #include <random>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <alpaka/alpaka.hpp>
 

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testIndependentKernel.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testIndependentKernel.dev.cc
@@ -4,7 +4,7 @@
 #include <alpaka/alpaka.hpp>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "FWCore/Utilities/interface/stringize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testKernel.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testKernel.dev.cc
@@ -4,7 +4,7 @@
 #include <alpaka/alpaka.hpp>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "FWCore/Utilities/interface/stringize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testMoveToDeviceAsync.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testMoveToDeviceAsync.dev.cc
@@ -4,7 +4,7 @@
 #include <alpaka/alpaka.hpp>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/CopyToDevice.h"

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testVec.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testVec.cc
@@ -1,7 +1,7 @@
 #include <alpaka/alpaka.hpp>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 

--- a/HeterogeneousCore/AlpakaInterface/test/testBackend.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/testBackend.cc
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "HeterogeneousCore/AlpakaInterface/interface/Backend.h"
 
@@ -12,7 +12,8 @@ TEST_CASE("Test cms::alpakatools::toBackend", "cms::alpakatools::Backend") {
   }
   SECTION("Invalid string") {
     REQUIRE_THROWS_WITH(cms::alpakatools::toBackend("Nonexistent"),
-                        Catch::Contains("EnumNotFound") and Catch::Contains("Invalid backend name"));
+                        Catch::Matchers::ContainsSubstring("EnumNotFound") and
+                            Catch::Matchers::ContainsSubstring("Invalid backend name"));
   }
 }
 
@@ -25,6 +26,7 @@ TEST_CASE("Test cms::alpakatools::toString", "cms::alpakatools::Backend") {
   }
   SECTION("Invalid enum") {
     REQUIRE_THROWS_WITH(cms::alpakatools::toString(cms::alpakatools::Backend::size),
-                        Catch::Contains("InvalidEnumValue") and Catch::Contains("Invalid backend enum value"));
+                        Catch::Matchers::ContainsSubstring("InvalidEnumValue") and
+                            Catch::Matchers::ContainsSubstring("Invalid backend enum value"));
   }
 }

--- a/HeterogeneousCore/AlpakaMath/test/alpaka/testDeltaPhi.dev.cc
+++ b/HeterogeneousCore/AlpakaMath/test/alpaka/testDeltaPhi.dev.cc
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <numbers>
 #include <vector>
 

--- a/HeterogeneousCore/CUDACore/test/test_ScopedContext.cc
+++ b/HeterogeneousCore/CUDACore/test/test_ScopedContext.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "CUDADataFormats/Common/interface/Product.h"
 #include "FWCore/Concurrency/interface/FinalWaitingTask.h"

--- a/HeterogeneousCore/CUDACore/test/test_main.cc
+++ b/HeterogeneousCore/CUDACore/test/test_main.cc
@@ -1,14 +1,14 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 
-class ServiceRegistryListener : public Catch::TestEventListenerBase {
+class ServiceRegistryListener : public Catch::EventListenerBase {
 public:
-  using Catch::TestEventListenerBase::TestEventListenerBase;  // inherit constructor
+  using Catch::EventListenerBase::EventListenerBase;  // inherit constructor
 
   void testRunStarting(Catch::TestRunInfo const& testRunInfo) override {
     edmplugin::PluginManager::configure(edmplugin::standard::config());

--- a/HeterogeneousCore/CUDAServices/test/testCUDAService.cpp
+++ b/HeterogeneousCore/CUDAServices/test/testCUDAService.cpp
@@ -8,7 +8,7 @@
 
 #include <fmt/core.h>
 
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "FWCore/AbstractServices/interface/ResourceInformation.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"

--- a/HeterogeneousCore/CUDAServices/test/test_main.cpp
+++ b/HeterogeneousCore/CUDAServices/test/test_main.cpp
@@ -1,12 +1,12 @@
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
 
-class ServiceRegistryListener : public Catch::TestEventListenerBase {
+class ServiceRegistryListener : public Catch::EventListenerBase {
 public:
-  using Catch::TestEventListenerBase::TestEventListenerBase;  // inherit constructor
+  using Catch::EventListenerBase::EventListenerBase;  // inherit constructor
 
   void testRunStarting(Catch::TestRunInfo const& testRunInfo) override {
     edmplugin::PluginManager::configure(edmplugin::standard::config());

--- a/HeterogeneousCore/CUDATest/test/test_TestCUDAProducerGPUFirst.cc
+++ b/HeterogeneousCore/CUDATest/test/test_TestCUDAProducerGPUFirst.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 #include "FWCore/Utilities/interface/Exception.h"
 

--- a/HeterogeneousCore/CUDATest/test/test_main.cc
+++ b/HeterogeneousCore/CUDATest/test/test_main.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/HeterogeneousCore/CUDAUtilities/test/copyAsync_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/copyAsync_t.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"

--- a/HeterogeneousCore/CUDAUtilities/test/device_unique_ptr_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/device_unique_ptr_t.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"

--- a/HeterogeneousCore/CUDAUtilities/test/host_noncached_unique_ptr_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/host_noncached_unique_ptr_t.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "HeterogeneousCore/CUDAUtilities/interface/host_noncached_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"

--- a/HeterogeneousCore/CUDAUtilities/test/host_unique_ptr_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/host_unique_ptr_t.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"

--- a/HeterogeneousCore/CUDAUtilities/test/memsetAsync_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/memsetAsync_t.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"

--- a/HeterogeneousCore/CUDAUtilities/test/testCatch2Main.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/testCatch2Main.cpp
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/HeterogeneousCore/CUDAUtilities/test/testCudaCheck.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/testCudaCheck.cpp
@@ -1,6 +1,6 @@
 // Catch2 headers
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 // CUDA headers
 #include <cuda_runtime.h>

--- a/HeterogeneousCore/CUDAUtilities/test/testRequireCUDADevices.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/testRequireCUDADevices.cpp
@@ -1,6 +1,6 @@
 // Catch2 headers
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 // CUDA headers
 #include <cuda_runtime.h>

--- a/HeterogeneousCore/ROCmServices/test/testROCmService.cpp
+++ b/HeterogeneousCore/ROCmServices/test/testROCmService.cpp
@@ -8,7 +8,7 @@
 
 #include <fmt/core.h>
 
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "FWCore/AbstractServices/interface/ResourceInformation.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"

--- a/HeterogeneousCore/ROCmServices/test/test_main.cpp
+++ b/HeterogeneousCore/ROCmServices/test/test_main.cpp
@@ -1,12 +1,12 @@
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
 
-class ServiceRegistryListener : public Catch::TestEventListenerBase {
+class ServiceRegistryListener : public Catch::EventListenerBase {
 public:
-  using Catch::TestEventListenerBase::TestEventListenerBase;  // inherit constructor
+  using Catch::EventListenerBase::EventListenerBase;  // inherit constructor
 
   void testRunStarting(Catch::TestRunInfo const& testRunInfo) override {
     edmplugin::PluginManager::configure(edmplugin::standard::config());

--- a/HeterogeneousCore/ROCmUtilities/test/testHipCheck.cpp
+++ b/HeterogeneousCore/ROCmUtilities/test/testHipCheck.cpp
@@ -1,6 +1,6 @@
 // Catch2 headers
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 // ROCm headers
 #include <hip/hip_runtime.h>

--- a/HeterogeneousCore/ROCmUtilities/test/testRequireROCmDevices.cpp
+++ b/HeterogeneousCore/ROCmUtilities/test/testRequireROCmDevices.cpp
@@ -1,6 +1,6 @@
 // Catch2 headers
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 // ROCm headers
 #include <hip/hip_runtime.h>

--- a/HeterogeneousTest/AlpakaDevice/test/alpaka/testDeviceAddition.dev.cc
+++ b/HeterogeneousTest/AlpakaDevice/test/alpaka/testDeviceAddition.dev.cc
@@ -3,7 +3,7 @@
 #include <vector>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <alpaka/alpaka.hpp>
 

--- a/HeterogeneousTest/AlpakaKernel/test/alpaka/testDeviceAdditionKernel.dev.cc
+++ b/HeterogeneousTest/AlpakaKernel/test/alpaka/testDeviceAdditionKernel.dev.cc
@@ -3,7 +3,7 @@
 #include <vector>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <alpaka/alpaka.hpp>
 

--- a/HeterogeneousTest/AlpakaOpaque/test/alpaka/testDeviceAdditionOpaque.cc
+++ b/HeterogeneousTest/AlpakaOpaque/test/alpaka/testDeviceAdditionOpaque.cc
@@ -3,7 +3,7 @@
 #include <vector>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/devices.h"

--- a/HeterogeneousTest/AlpakaWrapper/test/alpaka/testDeviceAdditionWrapper.cc
+++ b/HeterogeneousTest/AlpakaWrapper/test/alpaka/testDeviceAdditionWrapper.cc
@@ -3,7 +3,7 @@
 #include <vector>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <alpaka/alpaka.hpp>
 

--- a/HeterogeneousTest/CUDADevice/test/testDeviceAddition.cu
+++ b/HeterogeneousTest/CUDADevice/test/testDeviceAddition.cu
@@ -4,7 +4,7 @@
 #include <vector>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <cuda_runtime.h>
 

--- a/HeterogeneousTest/CUDAKernel/test/testDeviceAdditionKernel.cu
+++ b/HeterogeneousTest/CUDAKernel/test/testDeviceAdditionKernel.cu
@@ -4,7 +4,7 @@
 #include <vector>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <cuda_runtime.h>
 

--- a/HeterogeneousTest/CUDAOpaque/test/testDeviceAdditionOpaque.cc
+++ b/HeterogeneousTest/CUDAOpaque/test/testDeviceAdditionOpaque.cc
@@ -4,7 +4,7 @@
 #include <vector>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"
 #include "HeterogeneousTest/CUDAOpaque/interface/DeviceAdditionOpaque.h"

--- a/HeterogeneousTest/CUDAWrapper/test/testDeviceAdditionWrapper.cc
+++ b/HeterogeneousTest/CUDAWrapper/test/testDeviceAdditionWrapper.cc
@@ -4,7 +4,7 @@
 #include <vector>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <cuda_runtime.h>
 

--- a/HeterogeneousTest/ROCmDevice/test/testDeviceAddition.hip.cc
+++ b/HeterogeneousTest/ROCmDevice/test/testDeviceAddition.hip.cc
@@ -4,7 +4,7 @@
 #include <vector>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <hip/hip_runtime.h>
 

--- a/HeterogeneousTest/ROCmKernel/test/testDeviceAdditionKernel.hip.cc
+++ b/HeterogeneousTest/ROCmKernel/test/testDeviceAdditionKernel.hip.cc
@@ -4,7 +4,7 @@
 #include <vector>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <hip/hip_runtime.h>
 

--- a/HeterogeneousTest/ROCmOpaque/test/testDeviceAdditionOpaque.cc
+++ b/HeterogeneousTest/ROCmOpaque/test/testDeviceAdditionOpaque.cc
@@ -4,7 +4,7 @@
 #include <vector>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "HeterogeneousTest/ROCmOpaque/interface/DeviceAdditionOpaque.h"
 #include "HeterogeneousCore/ROCmUtilities/interface/requireDevices.h"

--- a/HeterogeneousTest/ROCmWrapper/test/testDeviceAdditionWrapper.cc
+++ b/HeterogeneousTest/ROCmWrapper/test/testDeviceAdditionWrapper.cc
@@ -4,7 +4,7 @@
 #include <vector>
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <hip/hip_runtime.h>
 

--- a/IOPool/Common/test/test_catch2_main.cc
+++ b/IOPool/Common/test/test_catch2_main.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/IOPool/Common/test/test_catch2_output2input.cc
+++ b/IOPool/Common/test/test_catch2_output2input.cc
@@ -5,7 +5,7 @@
 #include "DataFormats/TestObjects/interface/Thing.h"
 #include <vector>
 #include <filesystem>
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 static constexpr auto s_tag = "[PoolOutputSource]";
 

--- a/L1Trigger/GlobalMuonTrigger/test/test_L1MuGMTMatrix.cc
+++ b/L1Trigger/GlobalMuonTrigger/test/test_L1MuGMTMatrix.cc
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "L1Trigger/GlobalMuonTrigger/src/L1MuGMTMatrix.h"
 

--- a/PerfTools/AllocMonitor/test/test_catch2_AllocMonitorRegistry.cc
+++ b/PerfTools/AllocMonitor/test/test_catch2_AllocMonitorRegistry.cc
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "PerfTools/AllocMonitor/interface/AllocMonitorRegistry.h"
 

--- a/PerfTools/AllocMonitor/test/test_catch2_allocmap.cc
+++ b/PerfTools/AllocMonitor/test/test_catch2_allocmap.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "PerfTools/AllocMonitor/plugins/mea_AllocMap.h"
 

--- a/PhysicsTools/NanoAOD/test/test_catch2_NanoAODDQM.cc
+++ b/PhysicsTools/NanoAOD/test/test_catch2_NanoAODDQM.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "DataFormats/NanoAOD/interface/FlatTable.h"

--- a/PhysicsTools/NanoAOD/test/test_catch2_main.cc
+++ b/PhysicsTools/NanoAOD/test/test_catch2_main.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/RecoEgamma/PhotonIdentification/test/test_PhotonMvaXgb.cc
+++ b/RecoEgamma/PhotonIdentification/test/test_PhotonMvaXgb.cc
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 

--- a/RecoLocalCalo/HGCalRecProducers/test/EtaPhiSearchInTile_t.cpp
+++ b/RecoLocalCalo/HGCalRecProducers/test/EtaPhiSearchInTile_t.cpp
@@ -5,7 +5,7 @@
 #include "RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h"
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 
 int countEntries(const HGCalScintillatorLayerTiles &t, const std::array<int, 4> &limits) {
   int entries = 0;

--- a/RecoParticleFlow/PFTracking/test/test_catch2_PFDisplacedVertexProducer.cc
+++ b/RecoParticleFlow/PFTracking/test/test_catch2_PFDisplacedVertexProducer.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertexFwd.h"

--- a/RecoParticleFlow/PFTracking/test/test_catch2_main.cc
+++ b/RecoParticleFlow/PFTracking/test/test_catch2_main.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/RecoTracker/PixelTrackFitting/test/RZLine_catch2.cc
+++ b/RecoTracker/PixelTrackFitting/test/RZLine_catch2.cc
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <algorithm>
 #include "RecoTracker/PixelTrackFitting/interface/RZLine.h"
 
@@ -19,11 +19,11 @@ TEST_CASE("test RZLine", "[RZLine]") {
     SECTION("array") {
       RZLine l(r, z, errz);
 
-      REQUIRE(l.cotTheta() == Approx(cotTheta));
-      REQUIRE(l.intercept() == Approx(intercept));
-      REQUIRE(l.covss() == Approx(covss));
-      REQUIRE(l.covii() == Approx(covii));
-      REQUIRE(l.covsi() == Approx(covsi));
+      REQUIRE_THAT(l.cotTheta(), Catch::Matchers::WithinRel(cotTheta));
+      REQUIRE_THAT(l.intercept(), Catch::Matchers::WithinRel(intercept));
+      REQUIRE_THAT(l.covss(), Catch::Matchers::WithinRel(covss));
+      REQUIRE_THAT(l.covii(), Catch::Matchers::WithinRel(covii));
+      REQUIRE_THAT(l.covsi(), Catch::Matchers::WithinRel(covsi));
       REQUIRE_THAT(l.chi2(), Catch::Matchers::WithinAbs(chi2, chi2_diff));
     }
 
@@ -33,11 +33,11 @@ TEST_CASE("test RZLine", "[RZLine]") {
       const std::vector<float> errzv{errz.begin(), errz.end()};
       RZLine l(rv, zv, errzv);
 
-      REQUIRE(l.cotTheta() == Approx(cotTheta));
-      REQUIRE(l.intercept() == Approx(intercept));
-      REQUIRE(l.covss() == Approx(covss));
-      REQUIRE(l.covii() == Approx(covii));
-      REQUIRE(l.covsi() == Approx(covsi));
+      REQUIRE_THAT(l.cotTheta(), Catch::Matchers::WithinRel(cotTheta));
+      REQUIRE_THAT(l.intercept(), Catch::Matchers::WithinRel(intercept));
+      REQUIRE_THAT(l.covss(), Catch::Matchers::WithinRel(covss));
+      REQUIRE_THAT(l.covii(), Catch::Matchers::WithinRel(covii));
+      REQUIRE_THAT(l.covsi(), Catch::Matchers::WithinRel(covsi));
       REQUIRE_THAT(l.chi2(), Catch::Matchers::WithinAbs(chi2, chi2_diff));
     }
 
@@ -48,11 +48,11 @@ TEST_CASE("test RZLine", "[RZLine]") {
       std::transform(errz.begin(), errz.end(), std::back_inserter(errzv), [](float v) { return v * v; });
       RZLine l(rv, zv, errzv, RZLine::ErrZ2_tag());
 
-      REQUIRE(l.cotTheta() == Approx(cotTheta));
-      REQUIRE(l.intercept() == Approx(intercept));
-      REQUIRE(l.covss() == Approx(covss));
-      REQUIRE(l.covii() == Approx(covii));
-      REQUIRE(l.covsi() == Approx(covsi));
+      REQUIRE_THAT(l.cotTheta(), Catch::Matchers::WithinRel(cotTheta));
+      REQUIRE_THAT(l.intercept(), Catch::Matchers::WithinRel(intercept));
+      REQUIRE_THAT(l.covss(), Catch::Matchers::WithinRel(covss));
+      REQUIRE_THAT(l.covii(), Catch::Matchers::WithinRel(covii));
+      REQUIRE_THAT(l.covsi(), Catch::Matchers::WithinRel(covsi));
       REQUIRE_THAT(l.chi2(), Catch::Matchers::WithinAbs(chi2, chi2_diff));
     }
 
@@ -73,11 +73,11 @@ TEST_CASE("test RZLine", "[RZLine]") {
       const std::vector<bool> barrel{{true, true}};
       RZLine l(p, err, barrel);
 
-      REQUIRE(l.cotTheta() == Approx(cotTheta));
-      REQUIRE(l.intercept() == Approx(intercept));
-      REQUIRE(l.covss() == Approx(covss));
-      REQUIRE(l.covii() == Approx(covii));
-      REQUIRE(l.covsi() == Approx(covsi));
+      REQUIRE_THAT(l.cotTheta(), Catch::Matchers::WithinRel(cotTheta));
+      REQUIRE_THAT(l.intercept(), Catch::Matchers::WithinRel(intercept));
+      REQUIRE_THAT(l.covss(), Catch::Matchers::WithinRel(covss));
+      REQUIRE_THAT(l.covii(), Catch::Matchers::WithinRel(covii));
+      REQUIRE_THAT(l.covsi(), Catch::Matchers::WithinRel(covsi));
       REQUIRE_THAT(l.chi2(), Catch::Matchers::WithinAbs(chi2, chi2_diff));
     }
   }

--- a/RecoTracker/TkSeedingLayers/test/test_catch2_SeedingHitSet.cpp
+++ b/RecoTracker/TkSeedingLayers/test/test_catch2_SeedingHitSet.cpp
@@ -6,7 +6,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/MTDTrackingRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
 
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include <iostream>
 

--- a/RecoTracker/TkSeedingLayers/test/test_catch2_main.cpp
+++ b/RecoTracker/TkSeedingLayers/test/test_catch2_main.cpp
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/RecoVertex/BeamSpotProducer/test/testBeamSpotAnalyzer.cc
+++ b/RecoVertex/BeamSpotProducer/test/testBeamSpotAnalyzer.cc
@@ -1,7 +1,7 @@
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 TEST_CASE("BeamSpotAnalyzer tests", "[BeamSpotAnalyzer]") {
   //The python configuration

--- a/RecoVertex/BeamSpotProducer/test/testBeamSpotCompatibility.cc
+++ b/RecoVertex/BeamSpotProducer/test/testBeamSpotCompatibility.cc
@@ -3,7 +3,7 @@
 #include "RecoVertex/BeamSpotProducer/plugins/BeamSpotCompatibilityChecker.cc"
 
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 //_________________________________________________________
 TEST_CASE("Significance Calculation", "[Significance]") {
@@ -16,7 +16,7 @@ TEST_CASE("Significance Calculation", "[Significance]") {
   float significance = sig.getSig(false);
 
   // Correct the expected value based on actual calculation
-  REQUIRE(significance == Approx(1.1094).epsilon(10e-6));
+  REQUIRE_THAT(significance, Catch::Matchers::WithinRel(1.1094, 10e-6));
 }
 
 //_________________________________________________________
@@ -54,10 +54,10 @@ TEST_CASE("BeamSpot Compatibility Checker", "[compareBS]") {
     std::cout << "Significance[" << i << "]: " << significances[i] << std::endl;
   }
 
-  REQUIRE(significances[0] == Approx(0.57735).epsilon(10e-6));    // x0 significance
-  REQUIRE(significances[1] == Approx(0.288675).epsilon(10e-6));   // y0 significance
-  REQUIRE(significances[2] == Approx(0.19245).epsilon(10e-6));    // z0 significance
-  REQUIRE(significances[3] == Approx(0.0164957).epsilon(10e-6));  // sigmaX significance
-  REQUIRE(significances[4] == Approx(0.0164957).epsilon(10e-6));  // sigmaY significance
-  REQUIRE(significances[5] == Approx(0.288675).epsilon(10e-6));   // sigmaZ significance
+  REQUIRE_THAT(significances[0], Catch::Matchers::WithinRel(0.57735, 10e-6));    // x0 significance
+  REQUIRE_THAT(significances[1], Catch::Matchers::WithinRel(0.288675, 10e-6));   // y0 significance
+  REQUIRE_THAT(significances[2], Catch::Matchers::WithinRel(0.19245, 10e-6));    // z0 significance
+  REQUIRE_THAT(significances[3], Catch::Matchers::WithinRel(0.0164957, 10e-6));  // sigmaX significance
+  REQUIRE_THAT(significances[4], Catch::Matchers::WithinRel(0.0164957, 10e-6));  // sigmaY significance
+  REQUIRE_THAT(significances[5], Catch::Matchers::WithinRel(0.288675, 10e-6));   // sigmaZ significance
 }

--- a/SimG4CMS/Calo/test/test_catch2_hffibre.cc
+++ b/SimG4CMS/Calo/test/test_catch2_hffibre.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "SimG4CMS/Calo/interface/HFFibre.h"
 #include <CLHEP/Units/GlobalPhysicalConstants.h>
 #include <CLHEP/Units/SystemOfUnits.h>

--- a/SimG4CMS/Calo/test/test_catch2_hfshowerlibrary.cc
+++ b/SimG4CMS/Calo/test/test_catch2_hfshowerlibrary.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "SimG4CMS/Calo/interface/HFShowerLibrary.h"
 #include <CLHEP/Units/GlobalPhysicalConstants.h>
 #include <CLHEP/Units/SystemOfUnits.h>

--- a/SimG4CMS/Calo/test/test_catch2_main.cc
+++ b/SimG4CMS/Calo/test/test_catch2_main.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/SimG4Core/Application/test/test_catch2_ThreadHandoff.cc
+++ b/SimG4Core/Application/test/test_catch2_ThreadHandoff.cc
@@ -1,7 +1,7 @@
 #include "SimG4Core/Application/interface/ThreadHandoff.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 using namespace omt;
 TEST_CASE("Test omt::ThreadHandoff", "[ThreadHandoff]") {


### PR DESCRIPTION
#### PR description:

- moved to new header '"catch2/catch_all.hpp"'
- moved to new listener API
- moved away from `Approx` as it was removed in v3
- moved `Matchers` to their new namespace
#### PR validation:

- this builds with the version of catch2 v3 that I built and then redirected scram to use.

resolves #49109 
resolves https://github.com/cms-sw/framework-team/issues/1607