### PR TITLE
Remove obsolete TrivialFileCatalog

### DIFF
--- a/FWCore/Catalog/interface/FileLocator.h
+++ b/FWCore/Catalog/interface/FileLocator.h
@@ -1,77 +1,48 @@
 #ifndef FWCore_Catalog_FileLocator_h
 #define FWCore_Catalog_FileLocator_h
 
-#include "FWCore/Catalog/interface/SiteLocalConfig.h"
-#include <string>
-#include <list>
 #include <map>
-#include <utility>
 #include <regex>
-#include "tinyxml2.h"
+#include <string>
+#include <vector>
+
 #include <boost/property_tree/ptree.hpp>
 
 namespace edm {
 
+  struct CatalogAttributes;
+
   class FileLocator {
   public:
     explicit FileLocator(
-        edm::CatalogAttributes const& catAttr,
+        CatalogAttributes const& catalogAttributes,
         unsigned iCatalog = 0,
         //storageDescriptionPath is used to override path provided by SiteLocalConfig. This is used in FileLocator_t.cpp tests
         std::string const& storageDescriptionPath = std::string());
-    explicit FileLocator(std::string const& catUrl, unsigned iCatalog = 0);
 
-    ~FileLocator();
-
-    std::string pfn(std::string const& ilfn, edm::CatalogType catType) const;
+    std::string pfn(std::string const& ilfn) const;
 
   private:
-    /** For the time being the only allowed configuration item is a
-     *  prefix to be added to the GUID/LFN.
-     */
     struct Rule {
       std::regex pathMatch;
-      std::regex destinationMatch;
       std::string result;
       std::string chain;
     };
 
-    typedef std::vector<Rule> Rules;
-    typedef std::map<std::string, Rules> ProtocolRules;
+    using Rules = std::vector<Rule>;
+    using ProtocolRules = std::map<std::string, Rules>;
 
-    void init_trivialCatalog(std::string const& catUrl, unsigned iCatalog);
+    void init(CatalogAttributes const& catalogAttributes, unsigned iCatalog, std::string const& storageDescriptionPath);
 
-    void parseRuleTrivialCatalog(tinyxml2::XMLElement* ruleNode, ProtocolRules& rules);
-    //using data-access
-    void init(edm::CatalogAttributes const& input_dataCatalog,
-              unsigned iCatalog,
-              std::string const& storageDescriptionPath);
     void parseRule(boost::property_tree::ptree::value_type const& storageRule,
                    std::string const& protocol,
                    ProtocolRules& rules);
 
-    std::string applyRules(ProtocolRules const& protocolRules,
-                           std::string const& protocol,
-                           std::string const& destination,
-                           bool direct,
-                           std::string name) const;
+    std::string applyRules(ProtocolRules const& protocolRules, std::string const& protocol, std::string name) const;
 
-    std::string convert(std::string const& input, ProtocolRules const& rules, bool direct) const;
-
-    /** Direct rules are used to do the mapping from LFN to PFN.*/
-    ProtocolRules m_directRules_trivialCatalog;
-    /** Inverse rules are used to do the mapping from PFN to LFN*/
-    ProtocolRules m_inverseRules;
     /** Direct rules are used to do the mapping from LFN to PFN taken from storage.json*/
     ProtocolRules m_directRules;
-
-    std::string m_fileType;
-    std::string m_filename;
-    //TFC allows more than one protocols provided in a catalog, separated by a comma
-    //In new Rucio storage description, only one protocol is provided in a catalog
-    //This variable can be simplified in the future
-    std::vector<std::string> m_protocols;
-    std::string m_destination;
+    std::string m_protocol;
   };
 }  // namespace edm
 

--- a/FWCore/Catalog/interface/InputFileCatalog.h
+++ b/FWCore/Catalog/interface/InputFileCatalog.h
@@ -2,28 +2,40 @@
 #define FWCore_Catalog_InputFileCatalog_h
 //////////////////////////////////////////////////////////////////////
 //
-// Class InputFileCatalog. Services to manage InputFile catalog.
-// Physical file names, pfns_ of FileCatalogItem, are constructed from multiple data catalogs in site-local-config.xml. Each member of pfns_ corresponds to a data catalog.
-// Note that fileNames(unsigned iCatalog) of InputFileCatalog return physical file names of all input files corresponding to a data catalog (for example, a job has 10 input files provided as a PoolSource, the fileNames(unsigned iCatalog) will return PFNs of these 10 files constructed from a data catalog)
-// Set catType=TrivialCatalog: use trivial data catalogs from <event-data>
-// Set catType=RucioCatalog: use data catalogs from <data-access> and storage.json
+// Class InputFileCatalog.
+//
+// The physical file names, pfns_ of each FileCatalogItem, are constructed from
+// multiple data catalogs in site-local-config.xml. Each member of pfns_ corresponds
+// to a data catalog.
+//
+// Note that InputFileCatalog::fileNames(unsigned iCatalog) returns the physical file
+// names of all input files corresponding to a data catalog (for example, a job has
+// 10 input files provided via a PoolSource, InputFileCatalog::fileNames(unsigned iCatalog)
+// will return the PFNs of those 10 files constructed from one data catalog)
+//
+// Catalogs are based on Rucio (from <data-access> and storage.json)
+//
+// Note that support for TrivialFileCatalog was removed in 2025.
 //
 //////////////////////////////////////////////////////////////////////
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
-#include "FWCore/Catalog/interface/FileLocator.h"
+
 #include "FWCore/Utilities/interface/propagate_const.h"
 
 namespace edm {
+
+  class FileLocator;
+
   class FileCatalogItem {
   public:
     FileCatalogItem(std::vector<std::string> pfns, std::string lfn) : pfns_(std::move(pfns)), lfn_(std::move(lfn)) {}
 
     std::string const& fileName(unsigned iCatalog) const { return pfns_[iCatalog]; }
     std::string const& logicalFileName() const { return lfn_; }
-
     std::vector<std::string> const& fileNames() const { return pfns_; }
 
   private:
@@ -33,34 +45,23 @@ namespace edm {
 
   class InputFileCatalog {
   public:
-    InputFileCatalog(std::vector<std::string> fileNames,
+    InputFileCatalog(std::vector<std::string> logicalFileNames,
                      std::string const& override,
-                     bool useLFNasPFNifLFNnotFound = false,
-                     //switching between two catalog types
-                     //edm::CatalogType catType = edm::CatalogType::TrivialCatalog);
-                     edm::CatalogType catType = edm::CatalogType::RucioCatalog);
-
+                     bool useLFNasPFNifLFNnotFound = false);
     ~InputFileCatalog();
+
     std::vector<FileCatalogItem> const& fileCatalogItems() const { return fileCatalogItems_; }
     std::vector<std::string> fileNames(unsigned iCatalog) const;
     bool empty() const { return fileCatalogItems_.empty(); }
     static bool isPhysical(std::string const& name) { return (name.empty() || name.find(':') != std::string::npos); }
 
   private:
-    void init(std::vector<std::string> logicalFileNames,
-              std::string const& override,
-              bool useLFNasPFNifLFNnotFound,
-              edm::CatalogType catType);
-    void findFile(std::string const& lfn,
-                  std::vector<std::string>& pfns,
-                  bool useLFNasPFNifLFNnotFound,
-                  edm::CatalogType catType);
-    std::vector<FileCatalogItem> fileCatalogItems_;
-    edm::propagate_const<std::unique_ptr<FileLocator>> overrideFileLocator_;
+    void init(std::vector<std::string> logicalFileNames, std::string const& override, bool useLFNasPFNifLFNnotFound);
+    void findFile(std::string const& lfn, std::vector<std::string>& pfns, bool useLFNasPFNifLFNnotFound);
 
-    std::vector<edm::propagate_const<std::unique_ptr<FileLocator>>> fileLocators_trivalCatalog_;
-    std::vector<edm::propagate_const<std::unique_ptr<FileLocator>>> fileLocators_;
+    std::vector<FileCatalogItem> fileCatalogItems_;
+    propagate_const<std::unique_ptr<FileLocator>> overrideFileLocator_;
+    std::vector<propagate_const<std::unique_ptr<FileLocator>>> fileLocators_;
   };
 }  // namespace edm
-
 #endif

--- a/FWCore/Catalog/interface/SiteLocalConfig.h
+++ b/FWCore/Catalog/interface/SiteLocalConfig.h
@@ -43,8 +43,6 @@ namespace edm {
     std::string volume;
     std::string protocol;
   };
-
-  enum class CatalogType { TrivialCatalog, RucioCatalog };
 }  // namespace edm
 
 // PUBLIC VARIABLES
@@ -57,7 +55,6 @@ namespace edm {
     SiteLocalConfig() {}
     virtual ~SiteLocalConfig() {}
 
-    virtual std::vector<std::string> const& trivialDataCatalogs() const = 0;
     virtual std::vector<edm::CatalogAttributes> const& dataCatalogs() const = 0;
     virtual std::filesystem::path const storageDescriptionPath(const edm::CatalogAttributes& aDataCatalog) const = 0;
     virtual std::string const lookupCalibConnect(std::string const& input) const = 0;

--- a/FWCore/Catalog/src/FileLocator.cc
+++ b/FWCore/Catalog/src/FileLocator.cc
@@ -1,18 +1,15 @@
-#include "FWCore/Catalog/interface/FileLocator.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/Utilities/interface/Exception.h"
+#include <algorithm>
+#include <filesystem>
+#include <sstream>
+#include <utility>
 
-#include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
-#include <filesystem>
-#include <cstdlib>
-#include <stdexcept>
-#include <fstream>
-#include <sstream>
-
-namespace pt = boost::property_tree;
+#include "FWCore/Catalog/interface/FileLocator.h"
+#include "FWCore/Catalog/interface/SiteLocalConfig.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 namespace {
 
@@ -33,212 +30,48 @@ namespace {
   constexpr char const* const kEmptyString = "";
   constexpr char const* const kLFNPrefix = "/store/";
 
-  const char* safe(const char* iCheck) {
-    if (iCheck == nullptr) {
-      return kEmptyString;
-    }
-    return iCheck;
-  }
-
 }  // namespace
 
 namespace pt = boost::property_tree;
 
 namespace edm {
 
-  FileLocator::FileLocator(std::string const& catUrl, unsigned iCatalog) : m_destination("any") {
-    init_trivialCatalog(catUrl, iCatalog);
-  }
-
-  FileLocator::FileLocator(edm::CatalogAttributes const& catAttr,
+  FileLocator::FileLocator(CatalogAttributes const& catalogAttributes,
                            unsigned iCatalog,
-                           std::string const& storageDescriptionPath)
-      : m_destination("any") {
-    init(catAttr, iCatalog, storageDescriptionPath);
+                           std::string const& storageDescriptionPath) {
+    init(catalogAttributes, iCatalog, storageDescriptionPath);
   }
 
-  FileLocator::~FileLocator() {}
-
-  std::string FileLocator::pfn(std::string const& ilfn, edm::CatalogType catType) const {
-    if (catType == edm::CatalogType::TrivialCatalog)
-      return convert(ilfn, m_directRules_trivialCatalog, true);
-    return convert(ilfn, m_directRules, true);
+  std::string FileLocator::pfn(std::string const& ilfn) const {
+    //check if ilfn is an authentic LFN
+    if (ilfn.compare(0, 7, kLFNPrefix) != 0) {
+      return "";
+    }
+    return applyRules(m_directRules, m_protocol, ilfn);
   }
 
-  std::string FileLocator::convert(std::string const& input, ProtocolRules const& rules, bool direct) const {
-    std::string out = "";
-    //check if input is an authentic LFN
-    if (input.compare(0, 7, kLFNPrefix) != 0)
-      return out;
-    for (size_t pi = 0, pe = m_protocols.size(); pi != pe; ++pi) {
-      out = applyRules(rules, m_protocols[pi], m_destination, direct, input);
-      if (!out.empty()) {
-        return out;
-      }
-    }
-    return out;
-  }
-
-  void FileLocator::parseRuleTrivialCatalog(tinyxml2::XMLElement* ruleElement, ProtocolRules& rules) {
-    if (!ruleElement) {
-      throw cms::Exception("TrivialFileCatalog", std::string("TrivialFileCatalog::connect: Malformed trivial catalog"));
-    }
-
-    auto const protocol = safe(ruleElement->Attribute("protocol"));
-    auto destinationMatchRegexp = ruleElement->Attribute("destination-match");
-    if (destinationMatchRegexp == nullptr or destinationMatchRegexp[0] == 0) {
-      destinationMatchRegexp = ".*";
-    }
-
-    auto const pathMatchRegexp = safe(ruleElement->Attribute("path-match"));
-    auto const result = safe(ruleElement->Attribute("result"));
-    auto const chain = safe(ruleElement->Attribute("chain"));
-
-    Rule rule;
-    rule.pathMatch.assign(pathMatchRegexp);
-    rule.destinationMatch.assign(destinationMatchRegexp);
-    rule.result = result;
-    rule.chain = chain;
-    rules[protocol].emplace_back(std::move(rule));
-  }
-
-  void FileLocator::parseRule(pt::ptree::value_type const& storageRule,
-                              std::string const& protocol,
-                              ProtocolRules& rules) {
-    if (storageRule.second.empty()) {
-      throw cms::Exception("RucioFileCatalog", "edm::FileLocator::parseRule Malformed storage rule");
-    }
-    auto const pathMatchRegexp = storageRule.second.get<std::string>("lfn");
-    auto const result = storageRule.second.get<std::string>("pfn");
-    auto const chain = storageRule.second.get("chain", kEmptyString);
-    Rule rule;
-    rule.pathMatch.assign(pathMatchRegexp);
-    rule.destinationMatch.assign(".*");
-    rule.result = result;
-    rule.chain = chain;
-    rules[protocol].emplace_back(std::move(rule));
-  }
-
-  void FileLocator::init_trivialCatalog(std::string const& catUrl, unsigned iCatalog) {
-    std::string url = catUrl;
-    if (url.empty()) {
-      Service<SiteLocalConfig> localconfservice;
-      if (!localconfservice.isAvailable())
-        throw cms::Exception("TrivialFileCatalog", "edm::SiteLocalConfigService is not available");
-      if (iCatalog >= localconfservice->trivialDataCatalogs().size())
-        throw cms::Exception("TrivialFileCatalog", "edm::FileLocator: Request nonexistence data catalog");
-      url = localconfservice->trivialDataCatalogs()[iCatalog];
-    }
-
-    if (url.find("file:") == std::string::npos) {
-      throw cms::Exception("TrivialFileCatalog",
-                           "TrivialFileCatalog::connect: Malformed url for file catalog configuration");
-    }
-
-    url = url.erase(0, url.find(':') + 1);
-
-    std::vector<std::string> tokens;
-    boost::algorithm::split(tokens, url, boost::is_any_of(std::string("?")));
-    m_filename = tokens[0];
-
-    if (tokens.size() == 2) {
-      std::string const options = tokens[1];
-      std::vector<std::string> optionTokens;
-      boost::algorithm::split(optionTokens, options, boost::is_any_of(std::string("&")));
-
-      std::string const equalSign("=");
-      std::string const comma(",");
-
-      for (size_t oi = 0, oe = optionTokens.size(); oi != oe; ++oi) {
-        std::string const option = optionTokens[oi];
-        std::vector<std::string> argTokens;
-        boost::algorithm::split(argTokens, option, boost::is_any_of(equalSign));
-
-        if (argTokens.size() != 2) {
-          throw cms::Exception("TrivialFileCatalog",
-                               "TrivialFileCatalog::connect: Malformed url for file catalog configuration");
-        }
-
-        if (argTokens[0] == "protocol") {
-          boost::algorithm::split(m_protocols, argTokens[1], boost::is_any_of(comma));
-        } else if (argTokens[0] == "destination") {
-          m_destination = argTokens[1];
-        }
-      }
-    }
-
-    if (m_protocols.empty()) {
-      throw cms::Exception("TrivialFileCatalog",
-                           "TrivialFileCatalog::connect: protocol was not supplied in the contact string");
-    }
-
-    std::ifstream configFile;
-    configFile.open(m_filename.c_str());
-
-    if (!configFile.good() || !configFile.is_open()) {
-      throw cms::Exception("TrivialFileCatalog",
-                           "TrivialFileCatalog::connect: Unable to open trivial file catalog " + m_filename);
-    }
-
-    configFile.close();
-
-    tinyxml2::XMLDocument doc;
-    auto loadErr = doc.LoadFile(m_filename.c_str());
-    if (loadErr != tinyxml2::XML_SUCCESS) {
-      throw cms::Exception("TrivialFileCatalog")
-          << "tinyxml file load failed with error : " << doc.ErrorStr() << std::endl;
-    }
-    /* trivialFileCatalog matches the following xml schema
-	 FIXME: write a proper DTD
-	 <storage-mapping>
-	 <lfn-to-pfn protocol="direct" destination-match=".*"
-	 path-match="lfn/guid match regular expression"
-	 result="/castor/cern.ch/cms/$1"/>
-	 <pfn-to-lfn protocol="srm"
-	 path-match="lfn/guid match regular expression"
-	 result="$1"/>
-	 </storage-mapping>
-    */
-    auto rootElement = doc.RootElement();
-    /*first of all do the lfn-to-pfn bit*/
-    for (auto el = rootElement->FirstChildElement("lfn-to-pfn"); el != nullptr;
-         el = el->NextSiblingElement("lfn-to-pfn")) {
-      parseRuleTrivialCatalog(el, m_directRules_trivialCatalog);
-    }
-
-    /*Then we handle the pfn-to-lfn bit*/
-    for (auto el = rootElement->FirstChildElement("pfn-to-lfn"); el != nullptr;
-         el = el->NextSiblingElement("pfn-to-lfn")) {
-      parseRuleTrivialCatalog(el, m_inverseRules);
-    }
-  }
-
-  void FileLocator::init(edm::CatalogAttributes const& input_dataCatalog,
+  void FileLocator::init(CatalogAttributes const& catalogAttributes,
                          unsigned iCatalog,
                          std::string const& storageDescriptionPath) {
     Service<SiteLocalConfig> localconfservice;
-    edm::CatalogAttributes aCatalog = input_dataCatalog;
-    if (input_dataCatalog.empty()) {
-      if (!localconfservice.isAvailable()) {
-        cms::Exception ex("FileCatalog");
-        ex << "edm::SiteLocalConfigService is not available";
-        ex.addContext("Calling edm::FileLocator::init()");
-        throw ex;
-      }
+
+    CatalogAttributes aCatalog = catalogAttributes;
+    if (catalogAttributes.empty()) {
       if (iCatalog >= localconfservice->dataCatalogs().size()) {
         cms::Exception ex("FileCatalog");
-        ex << "Request nonexistence data catalog";
+        ex << "Request nonexistent data catalog";
         ex.addContext("Calling edm::FileLocator::init()");
         throw ex;
       }
       aCatalog = localconfservice->dataCatalogs()[iCatalog];
     }
 
-    std::filesystem::path filename_storage = localconfservice->storageDescriptionPath(aCatalog);
-
-    //use path to storage description from input parameter
-    if (!storageDescriptionPath.empty())
+    std::filesystem::path filename_storage;
+    if (!storageDescriptionPath.empty()) {
       filename_storage = storageDescriptionPath;
+    } else {
+      filename_storage = localconfservice->storageDescriptionPath(aCatalog);
+    }
 
     //now read json
     pt::ptree json;
@@ -284,8 +117,7 @@ namespace edm {
       throw ex;
     }
 
-    std::string protName = found_protocol->second.get("protocol", kEmptyString);
-    m_protocols.push_back(protName);
+    m_protocol = found_protocol->second.get("protocol", kEmptyString);
 
     //store all prefixes and rules to m_directRules. We need to do this so that "applyRules" can find the rule in case chaining is used
     //loop over protocols
@@ -303,7 +135,6 @@ namespace edm {
       else {
         Rule rule;
         rule.pathMatch.assign("/?(.*)");
-        rule.destinationMatch.assign(".*");
         rule.result = prefixTmp + "/$1";
         rule.chain = kEmptyString;
         m_directRules[protName].emplace_back(std::move(rule));
@@ -311,48 +142,50 @@ namespace edm {
     }
   }
 
+  void FileLocator::parseRule(pt::ptree::value_type const& storageRule,
+                              std::string const& protocol,
+                              ProtocolRules& rules) {
+    if (storageRule.second.empty()) {
+      throw cms::Exception("RucioFileCatalog", "edm::FileLocator::parseRule Malformed storage rule");
+    }
+    auto const pathMatchRegexp = storageRule.second.get<std::string>("lfn");
+    auto const result = storageRule.second.get<std::string>("pfn");
+    auto const chain = storageRule.second.get("chain", kEmptyString);
+    Rule rule;
+    rule.pathMatch.assign(pathMatchRegexp);
+    rule.result = result;
+    rule.chain = chain;
+    rules[protocol].emplace_back(std::move(rule));
+  }
+
   std::string FileLocator::applyRules(ProtocolRules const& protocolRules,
                                       std::string const& protocol,
-                                      std::string const& destination,
-                                      bool direct,
                                       std::string name) const {
     ProtocolRules::const_iterator const rulesIterator = protocolRules.find(protocol);
     if (rulesIterator == protocolRules.end()) {
       return "";
     }
 
-    Rules const& rules = (*(rulesIterator)).second;
+    Rules const& rules = rulesIterator->second;
 
-    std::smatch destinationMatches;
     std::smatch nameMatches;
 
     /* Look up for a matching rule*/
-    for (Rules::const_iterator i = rules.begin(); i != rules.end(); ++i) {
-      if (!std::regex_match(destination, destinationMatches, i->destinationMatch)) {
+    for (auto const& rule : rules) {
+      if (!std::regex_match(name, rule.pathMatch)) {
         continue;
       }
 
-      if (!std::regex_match(name, i->pathMatch)) {
-        continue;
-      }
-
-      // std::cerr << "Rule " << i->pathMatch << "matched! " << std::endl;
-
-      std::string const chain = i->chain;
-      if ((direct == true) && (!chain.empty())) {
-        name = applyRules(protocolRules, chain, destination, direct, name);
+      std::string const& chain = rule.chain;
+      if (!chain.empty()) {
+        name = applyRules(protocolRules, chain, name);
         if (name.empty()) {
           return "";
         }
       }
 
-      std::regex_match(name, nameMatches, i->pathMatch);
-      name = replaceWithRegexp(nameMatches, i->result);
-
-      if ((direct == false) && (!chain.empty())) {
-        name = applyRules(protocolRules, chain, destination, direct, name);
-      }
-      return name;
+      std::regex_match(name, nameMatches, rule.pathMatch);
+      return replaceWithRegexp(nameMatches, rule.result);
     }
     return "";
   }

--- a/FWCore/Catalog/src/InputFileCatalog.cc
+++ b/FWCore/Catalog/src/InputFileCatalog.cc
@@ -1,28 +1,18 @@
-//////////////////////////////////////////////////////////////////////
-//
-//////////////////////////////////////////////////////////////////////
-
-#include "FWCore/Catalog/interface/InputFileCatalog.h"
-
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/Catalog/interface/SiteLocalConfig.h"
-
-#include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/Utilities/interface/EDMException.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
 #include <boost/algorithm/string.hpp>
 
-#include <iostream>
+#include "FWCore/Catalog/interface/FileLocator.h"
+#include "FWCore/Catalog/interface/InputFileCatalog.h"
+#include "FWCore/Catalog/interface/SiteLocalConfig.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 namespace edm {
 
-  InputFileCatalog::InputFileCatalog(std::vector<std::string> fileNames,
+  InputFileCatalog::InputFileCatalog(std::vector<std::string> logicalFileNames,
                                      std::string const& override,
-                                     bool useLFNasPFNifLFNnotFound,
-                                     edm::CatalogType catType)
-      : fileCatalogItems_(), overrideFileLocator_() {
-    init(std::move(fileNames), override, useLFNasPFNifLFNnotFound, catType);
+                                     bool useLFNasPFNifLFNnotFound) {
+    init(std::move(logicalFileNames), override, useLFNasPFNifLFNnotFound);
   }
 
   InputFileCatalog::~InputFileCatalog() {}
@@ -37,38 +27,8 @@ namespace edm {
   }
 
   void InputFileCatalog::init(std::vector<std::string> logicalFileNames,
-                              std::string const& inputOverride,
-                              bool useLFNasPFNifLFNnotFound,
-                              edm::CatalogType catType) {
-    typedef std::vector<std::string>::iterator iter;
-
-    if (!overrideFileLocator_ && !inputOverride.empty()) {
-      if (catType == edm::CatalogType::TrivialCatalog) {
-        overrideFileLocator_ =
-            std::make_unique<FileLocator>(inputOverride);  // propagate_const<T> has no reset() function
-      } else if (catType == edm::CatalogType::RucioCatalog) {
-        //now make a struct from input string
-        std::vector<std::string> tmps;
-        boost::algorithm::split(tmps, inputOverride, boost::is_any_of(std::string(",")));
-        if (tmps.size() != 5) {
-          cms::Exception ex("FileCatalog");
-          ex << "Trying to override input file catalog but invalid input override string " << inputOverride
-             << " (Should be site,subSite,storageSite,volume,protocol)";
-          ex.addContext("Calling edm::InputFileCatalog::init()");
-          throw ex;
-        }
-
-        edm::CatalogAttributes inputOverride_struct(tmps[0],   //current-site
-                                                    tmps[1],   //current-subSite
-                                                    tmps[2],   //desired-data-access-site
-                                                    tmps[3],   //desired-data-access-volume
-                                                    tmps[4]);  //desired-data-access-protocol
-
-        overrideFileLocator_ =
-            std::make_unique<FileLocator>(inputOverride_struct);  // propagate_const<T> has no reset() function
-      }
-    }
-
+                              std::string const& override,
+                              bool useLFNasPFNifLFNnotFound) {
     Service<SiteLocalConfig> localconfservice;
     if (!localconfservice.isAvailable()) {
       cms::Exception ex("FileCatalog");
@@ -77,53 +37,50 @@ namespace edm {
       throw ex;
     }
 
-    if (catType == edm::CatalogType::TrivialCatalog) {
-      std::vector<std::string> const& tmp_dataCatalogs = localconfservice->trivialDataCatalogs();
-      if (!fileLocators_trivalCatalog_.empty())
-        fileLocators_trivalCatalog_.clear();
-      //Construct all file locators from data catalogs. If a data catalog is invalid (wrong protocol for example), it is skipped and no file locator is constructed (an exception is thrown out from FileLocator::init).
-      for (const auto& catalog : tmp_dataCatalogs) {
-        try {
-          fileLocators_trivalCatalog_.push_back(std::make_unique<FileLocator>(catalog));
-        } catch (cms::Exception const& e) {
-          edm::LogWarning("InputFileCatalog")
-              << "Caught an exception while constructing a file locator in InputFileCatalog::init: " << e.what()
-              << "Skip this catalog";
-        }
-      }
-      if (fileLocators_trivalCatalog_.empty()) {
+    if (!overrideFileLocator_ && !override.empty()) {
+      //now make a struct from input string
+      std::vector<std::string> tmps;
+      boost::algorithm::split(tmps, override, boost::is_any_of(std::string(",")));
+      if (tmps.size() != 5) {
         cms::Exception ex("FileCatalog");
-        ex << "Unable to construct any file locator in InputFileCatalog::init";
+        ex << "Trying to override input file catalog but invalid input override string " << override
+           << " (Should be site,subSite,storageSite,volume,protocol)";
         ex.addContext("Calling edm::InputFileCatalog::init()");
         throw ex;
       }
-    } else if (catType == edm::CatalogType::RucioCatalog) {
-      std::vector<edm::CatalogAttributes> const& tmp_dataCatalogs = localconfservice->dataCatalogs();
-      if (!fileLocators_.empty())
-        fileLocators_.clear();
-      //Construct all file locators from data catalogs. If a data catalog is invalid (wrong protocol for example), it is skipped and no file locator is constructed (an exception is thrown out from FileLocator::init).
-      for (const auto& catalog : tmp_dataCatalogs) {
-        try {
-          fileLocators_.push_back(std::make_unique<FileLocator>(catalog));
-        } catch (cms::Exception const& e) {
-          edm::LogWarning("InputFileCatalog")
-              << "Caught an exception while constructing a file locator in InputFileCatalog::init: " << e.what()
-              << "Skip this catalog";
-        }
+
+      CatalogAttributes override_struct(tmps[0],   //current-site
+                                        tmps[1],   //current-subSite
+                                        tmps[2],   //desired-data-access-site
+                                        tmps[3],   //desired-data-access-volume
+                                        tmps[4]);  //desired-data-access-protocol
+
+      overrideFileLocator_ =
+          std::make_unique<FileLocator>(override_struct);  // propagate_const<T> has no reset() function
+    }
+
+    std::vector<CatalogAttributes> const& tmp_dataCatalogs = localconfservice->dataCatalogs();
+    fileLocators_.clear();
+    // Construct all file locators from data catalogs. If a data catalog is
+    // invalid (wrong protocol for example), it is skipped and no file locator
+    // is constructed (an exception is thrown out from FileLocator::init).
+    for (const auto& catalog : tmp_dataCatalogs) {
+      try {
+        fileLocators_.push_back(std::make_unique<FileLocator>(catalog));
+      } catch (cms::Exception const& e) {
+        edm::LogWarning("InputFileCatalog")
+            << "Caught an exception while constructing a file locator in InputFileCatalog::init: " << e.what()
+            << "Skip this catalog";
       }
-      if (fileLocators_.empty()) {
-        cms::Exception ex("FileCatalog");
-        ex << "Unable to construct any file locator in InputFileCatalog::init";
-        ex.addContext("Calling edm::InputFileCatalog::init()");
-        throw ex;
-      }
-    } else {
+    }
+    if (fileLocators_.empty()) {
       cms::Exception ex("FileCatalog");
-      ex << "Undefined catalog type";
+      ex << "Unable to construct any file locator in InputFileCatalog::init";
       ex.addContext("Calling edm::InputFileCatalog::init()");
       throw ex;
     }
 
+    fileCatalogItems_.reserve(logicalFileNames.size());
     for (auto& lfn : logicalFileNames) {
       boost::trim(lfn);
       std::vector<std::string> pfns;
@@ -144,7 +101,7 @@ namespace edm {
         // Clear the LFN.
         lfn.clear();
       } else {
-        findFile(lfn, pfns, useLFNasPFNifLFNnotFound, catType);
+        findFile(lfn, pfns, useLFNasPFNifLFNnotFound);
       }
       lfn.shrink_to_fit();  // try to release memory
 
@@ -154,32 +111,17 @@ namespace edm {
 
   void InputFileCatalog::findFile(std::string const& lfn,
                                   std::vector<std::string>& pfns,
-                                  bool useLFNasPFNifLFNnotFound,
-                                  edm::CatalogType catType) {
+                                  bool useLFNasPFNifLFNnotFound) {
     if (overrideFileLocator_) {
-      pfns.push_back(overrideFileLocator_->pfn(lfn, catType));
+      pfns.push_back(overrideFileLocator_->pfn(lfn));
     } else {
-      if (catType == edm::CatalogType::TrivialCatalog) {
-        for (auto const& locator : fileLocators_trivalCatalog_) {
-          std::string pfn = locator->pfn(lfn, edm::CatalogType::TrivialCatalog);
-          if (pfn.empty() && useLFNasPFNifLFNnotFound)
-            pfns.push_back(lfn);
-          else
-            pfns.push_back(pfn);
+      for (auto const& locator : fileLocators_) {
+        std::string pfn = locator->pfn(lfn);
+        if (pfn.empty() && useLFNasPFNifLFNnotFound) {
+          pfns.push_back(lfn);
+        } else {
+          pfns.push_back(pfn);
         }
-      } else if (catType == edm::CatalogType::RucioCatalog) {
-        for (auto const& locator : fileLocators_) {
-          std::string pfn = locator->pfn(lfn, edm::CatalogType::RucioCatalog);
-          if (pfn.empty() && useLFNasPFNifLFNnotFound)
-            pfns.push_back(lfn);
-          else
-            pfns.push_back(pfn);
-        }
-      } else {
-        cms::Exception ex("FileCatalog");
-        ex << "Undefined catalog type";
-        ex.addContext("Calling edm::InputFileCatalog::findFile()");
-        throw ex;
       }
     }
 

--- a/FWCore/Catalog/test/FileLocator_t.cpp
+++ b/FWCore/Catalog/test/FileLocator_t.cpp
@@ -1,15 +1,15 @@
-#include "FWCore/Catalog/interface/FileLocator.h"
-#include "FWCore/Catalog/interface/SiteLocalConfig.h"
-#include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
-
-#include "TestSiteLocalConfig.h"
-
-#include <filesystem>
-#include <string>
-
 #define CATCH_CONFIG_MAIN
 #include "catch2/catch_all.hpp"
+
+#include <array>
+#include <string>
+
+#include "FWCore/Catalog/interface/FileLocator.h"
+#include "FWCore/Catalog/interface/SiteLocalConfig.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ServiceToken.h"
+
+#include "TestSiteLocalConfig.h"
 
 TEST_CASE("FileLocator with Rucio data catalog", "[FWCore/Catalog]") {
   edm::ServiceToken tempToken = edmtest::catalog::makeTestSiteLocalConfigToken();
@@ -20,8 +20,7 @@ TEST_CASE("FileLocator with Rucio data catalog", "[FWCore/Catalog]") {
     edm::CatalogAttributes tmp_cat;
     //use the first catalog provided by site local config
     edm::FileLocator fl(tmp_cat, 0);
-    CHECK("root://cmsxrootd.fnal.gov/store/group/bha/bho" ==
-          fl.pfn("/store/group/bha/bho", edm::CatalogType::RucioCatalog));
+    CHECK("root://cmsxrootd.fnal.gov/store/group/bha/bho" == fl.pfn("/store/group/bha/bho"));
   }
   SECTION("rule") {
     edm::ServiceRegistry::Operate operate(tempToken);
@@ -36,10 +35,9 @@ TEST_CASE("FileLocator with Rucio data catalog", "[FWCore/Catalog]") {
                                              "/castor/cern.ch/cms/bha/bho",
                                              "someprotocol:/castor/cern.ch/cms/bha/bho",
                                              "someprotocol:/bha/bho"}};
-    CHECK("root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/group/bha/bho" ==
-          fl.pfn("/store/group/bha/bho", edm::CatalogType::RucioCatalog));
+    CHECK("root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/group/bha/bho" == fl.pfn("/store/group/bha/bho"));
     for (auto file : lfn) {
-      CHECK("" == fl.pfn(file, edm::CatalogType::RucioCatalog));
+      CHECK("" == fl.pfn(file));
     }
   }
   SECTION("chainedrule") {
@@ -56,77 +54,11 @@ TEST_CASE("FileLocator with Rucio data catalog", "[FWCore/Catalog]") {
                                              "someprotocol:/castor/cern.ch/cms/bha/bho",
                                              "someprotocol:/bha/bho"}};
     //one level chain between "root" and "second" protocols (see storage.json)
-    CHECK("root://host.domain//pnfs/cms/store/group/bha/bho" ==
-          fl.pfn("/store/group/bha/bho", edm::CatalogType::RucioCatalog));
+    CHECK("root://host.domain//pnfs/cms/store/group/bha/bho" == fl.pfn("/store/group/bha/bho"));
     //two levels chain between "root", "second" and "first" (see storage.json)
-    CHECK("root://host.domain//pnfs/cms/store/user/AAA/bho" ==
-          fl.pfn("/store/user/aaa/bho", edm::CatalogType::RucioCatalog));
+    CHECK("root://host.domain//pnfs/cms/store/user/AAA/bho" == fl.pfn("/store/user/aaa/bho"));
     for (auto file : lfn) {
-      CHECK("" == fl.pfn(file, edm::CatalogType::RucioCatalog));
-    }
-  }
-}
-
-TEST_CASE("FileLocator with TrivialFileCatalog", "[FWCore/Catalog]") {
-  std::string CMSSW_BASE(std::getenv("CMSSW_BASE"));
-  std::string CMSSW_RELEASE_BASE(std::getenv("CMSSW_RELEASE_BASE"));
-  std::string file_name("/src/FWCore/Catalog/test/simple_catalog.xml");
-  std::string full_file_name = std::filesystem::exists((CMSSW_BASE + file_name).c_str())
-                                   ? CMSSW_BASE + file_name
-                                   : CMSSW_RELEASE_BASE + file_name;
-
-  //create the services
-  std::vector<std::string> tmp{std::string("trivialcatalog_file:") + full_file_name + "?protocol=xrd"};
-  edm::ServiceToken tempToken(edm::ServiceRegistry::createContaining(
-      std::unique_ptr<edm::SiteLocalConfig>(std::make_unique<edmtest::catalog::TestSiteLocalConfig>(tmp))));
-
-  //make the services available
-  SECTION("standard") {
-    edm::ServiceRegistry::Operate operate(tempToken);
-    edm::FileLocator fl("");
-
-    const std::array<const char*, 7> lfn = {{"/bha/bho",
-                                             "bha",
-                                             "file:bha",
-                                             "file:/bha/bho",
-                                             "/castor/cern.ch/cms/bha/bho",
-                                             "someprotocol:/castor/cern.ch/cms/bha/bho",
-                                             "someprotocol:/bha/bho"}};
-
-    CHECK("/storage/path/store/group/bha/bho" == fl.pfn("/store/group/bha/bho", edm::CatalogType::TrivialCatalog));
-    for (auto file : lfn) {
-      CHECK("" == fl.pfn(file, edm::CatalogType::TrivialCatalog));
-    }
-  }
-
-  SECTION("override") {
-    edm::ServiceRegistry::Operate operate(tempToken);
-
-    std::string override_file_name("/src/FWCore/Catalog/test/override_catalog.xml");
-    std::string override_full_file_name = std::filesystem::exists((CMSSW_BASE + override_file_name).c_str())
-                                              ? CMSSW_BASE + override_file_name
-                                              : CMSSW_RELEASE_BASE + override_file_name;
-
-    edm::FileLocator fl(("trivialcatalog_file:" + override_full_file_name + "?protocol=override").c_str());
-
-    std::array<const char*, 8> lfn = {{"/store/group/bha/bho",
-                                       "/bha/bho",
-                                       "bha",
-                                       "file:bha",
-                                       "file:/bha/bho",
-                                       "/castor/cern.ch/cms/bha/bho",
-                                       "someprotocol:/castor/cern.ch/cms/bha/bho",
-                                       "someprotocol:/bha/bho"}};
-
-    auto const overriden_file =
-        "/store/unmerged/relval/CMSSW_3_8_0_pre3/RelValZTT/GEN-SIM-DIGI-RAW-HLTDEBUG/START38_V2-v1/0666/"
-        "80EC0BCD-D279-DF11-B1DB-0030487C90EE.root";
-
-    CHECK("/FULL_PATH_TO_THE_FIRST_STEP_ROOT_FILE/80EC0BCD-D279-DF11-B1DB-0030487C90EE.root" ==
-          fl.pfn(overriden_file, edm::CatalogType::TrivialCatalog));
-
-    for (auto f : lfn) {
-      CHECK("" == fl.pfn(f, edm::CatalogType::TrivialCatalog));
+      CHECK("" == fl.pfn(file));
     }
   }
 }

--- a/FWCore/Catalog/test/InputFileCatalog_t.cpp
+++ b/FWCore/Catalog/test/InputFileCatalog_t.cpp
@@ -1,5 +1,6 @@
 #include "FWCore/Catalog/interface/InputFileCatalog.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 
 #include "TestSiteLocalConfig.h"
 
@@ -24,6 +25,7 @@ TEST_CASE("InputFileCatalog with Rucio data catalog", "[FWCore/Catalog]") {
     edm::ServiceRegistry::Operate operate(tempToken);
 
     edm::InputFileCatalog catalog(std::vector<std::string>{"/store/foo/bar", "   file:/foo/bar", "root://foobar "}, "");
+    REQUIRE(!catalog.empty());
 
     SECTION("fileNames") {
       SECTION("Catalog 0") {
@@ -57,6 +59,7 @@ TEST_CASE("InputFileCatalog with Rucio data catalog", "[FWCore/Catalog]") {
       }
       SECTION("Catalog 1") {
         CHECK(items[0].fileName(1) == "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar");
+        CHECK(items[0].fileNames()[1] == "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar");
       }
       SECTION("Catalog 2") { CHECK(items[0].fileName(2) == "root://host.domain//pnfs/cms/store/foo/bar"); }
     }

--- a/FWCore/Catalog/test/TestSiteLocalConfig.h
+++ b/FWCore/Catalog/test/TestSiteLocalConfig.h
@@ -10,11 +10,8 @@
 namespace edmtest::catalog {
   class TestSiteLocalConfig : public edm::SiteLocalConfig {
   public:
-    //constructor using trivial data catalogs
-    TestSiteLocalConfig(std::vector<std::string> catalogs) : m_trivialCatalogs(std::move(catalogs)) {}
     //constructor using Rucio data catalogs
     TestSiteLocalConfig(std::vector<edm::CatalogAttributes> catalogs) : m_catalogs(std::move(catalogs)) {}
-    std::vector<std::string> const& trivialDataCatalogs() const final { return m_trivialCatalogs; }
     std::vector<edm::CatalogAttributes> const& dataCatalogs() const final { return m_catalogs; }
     std::filesystem::path const storageDescriptionPath(const edm::CatalogAttributes& aDataCatalog) const final {
       std::string CMSSW_BASE(std::getenv("CMSSW_BASE"));
@@ -47,7 +44,6 @@ namespace edmtest::catalog {
     std::string const& localConnectSuffix() const final { return m_emptyString; }
 
   private:
-    std::vector<std::string> m_trivialCatalogs;
     std::vector<edm::CatalogAttributes> m_catalogs;
     std::filesystem::path m_storageDescription_path;
     std::string m_emptyString;

--- a/FWCore/Services/src/SiteLocalConfigService.h
+++ b/FWCore/Services/src/SiteLocalConfigService.h
@@ -3,10 +3,8 @@
 
 ///////////////////////////////////////////////////////////////////////
 //
-// dataCatalogs(unsigned catType) returns multiple data catalogs in site-local-config.xml.
-//    catType=TrivialCatalog: returns trivial catalogs defined in <event-data> blocks
-//    catType=RucioCatalog: returns catalogs defined in <data-access> blocks
-//    (the "enum" is defined in FWCore/Catalog/interface/SiteLocalConfig.h)
+// dataCatalogs() returns multiple data catalogs in site-local-config.xml
+//    and defined in <data-access> blocks.
 ///////////////////////////////////////////////////////////////////////
 //<<<<<< INCLUDES                                                       >>>>>>
 #include <string>
@@ -35,7 +33,6 @@ namespace edm {
     public:
       explicit SiteLocalConfigService(ParameterSet const& pset);
 
-      std::vector<std::string> const& trivialDataCatalogs() const override;
       std::vector<edm::CatalogAttributes> const& dataCatalogs() const override;
       std::filesystem::path const storageDescriptionPath(edm::CatalogAttributes const& aDataCatalog) const override;
       std::string const lookupCalibConnect(std::string const& input) const override;
@@ -70,7 +67,6 @@ namespace edm {
       void computeStatisticsDestination();
       std::string const frontierConnect(std::string const& servlet) const;
       std::string m_url;
-      std::vector<std::string> m_trivialDataCatalogs;
       std::vector<edm::CatalogAttributes> m_dataCatalogs;
       std::string m_frontierConnect;
       bool m_connected;

--- a/FWCore/Services/test/sitelocalconfig/full/site-local-config.xml
+++ b/FWCore/Services/test/sitelocalconfig/full/site-local-config.xml
@@ -1,16 +1,12 @@
 <site-local-config>
 <site name="DUMMY">
   <subsite name="DUMMY_SUB_SITE"/>
-  <event-data>
-    <catalog url="trivialcatalog_file:/dummy/storage.xml?protocol=dcap"/>
-  </event-data>
   <data-access>
     <catalog site="DUMMY_CROSS_SITE" volume="CMSXrootdFederation" protocol="XRootD"/>
   </data-access>
   <local-stage-out>
     <se-name value="cmssrm.dummy.foo"/>
     <command value="srm"/>
-    <catalog url="trivialcatalog_file:/dummy/storage.xml?protocol=srm"/>
   </local-stage-out>
   <calib-data>
     <local-connect>

--- a/FWCore/Services/test/sitelocalconfig/no_source/site-local-config.xml
+++ b/FWCore/Services/test/sitelocalconfig/no_source/site-local-config.xml
@@ -1,16 +1,12 @@
 <site-local-config>
 <site name="DUMMY">
   <subsite name="DUMMY_SUB_SITE"/>
-  <event-data>
-    <catalog url="trivialcatalog_file:/dummy/storage.xml?protocol=dcap"/>
-  </event-data>
   <data-access>
     <catalog site="DUMMY_CROSS_SITE" volume="CMSXrootdFederation" protocol="XRootD"/>
   </data-access>
   <local-stage-out>
     <se-name value="cmssrm.dummy.foo"/>
     <command value="srm"/>
-    <catalog url="trivialcatalog_file:/dummy/storage.xml?protocol=srm"/>
   </local-stage-out>
   <calib-data>
     <frontier-connect>

--- a/FWCore/Services/test/sitelocalconfig/source/site-local-config.xml
+++ b/FWCore/Services/test/sitelocalconfig/source/site-local-config.xml
@@ -1,16 +1,12 @@
 <site-local-config>
 <site name="DUMMY">
   <subsite name="DUMMY_SUB_SITE"/>
-  <event-data>
-    <catalog url="trivialcatalog_file:/dummy/storage.xml?protocol=dcap"/>
-  </event-data>
   <data-access>
     <catalog site="DUMMY_CROSS_SITE" volume="CMSXrootdFederation" protocol="XRootD"/>
   </data-access>
   <local-stage-out>
     <se-name value="cmssrm.dummy.foo"/>
     <command value="srm"/>
-    <catalog url="trivialcatalog_file:/dummy/storage.xml?protocol=srm"/>
   </local-stage-out>
   <calib-data>
     <local-connect>

--- a/FWCore/Services/test/test_catch2_SiteLocalConfigService.cc
+++ b/FWCore/Services/test/test_catch2_SiteLocalConfigService.cc
@@ -26,7 +26,6 @@ TEST_CASE("Test SiteLocalConfigService", "[sitelocalconfig]") {
 
     edm::service::SiteLocalConfigService slc(pset);
 
-    CHECK(slc.trivialDataCatalogs()[0] == "trivialcatalog_file:/dummy/storage.xml?protocol=dcap");
     edm::CatalogAttributes tmp("DUMMY", "DUMMY_SUB_SITE", "DUMMY_CROSS_SITE", "CMSXrootdFederation", "XRootD");
     CHECK(slc.dataCatalogs()[0].site == tmp.site);
     CHECK(slc.dataCatalogs()[0].subSite == tmp.subSite);
@@ -83,7 +82,6 @@ TEST_CASE("Test SiteLocalConfigService", "[sitelocalconfig]") {
 
     edm::service::SiteLocalConfigService slc(pset);
 
-    CHECK(slc.trivialDataCatalogs()[0] == "trivialcatalog_file:/dummy/storage.xml?protocol=dcap");
     edm::CatalogAttributes tmp("DUMMY", "DUMMY_SUB_SITE", "DUMMY_CROSS_SITE", "CMSXrootdFederation", "XRootD");
     CHECK(slc.dataCatalogs()[0].site == tmp.site);
     CHECK(slc.dataCatalogs()[0].subSite == tmp.subSite);


### PR DESCRIPTION
#### PR description:

Remove TrivialFileCatalog. It is now obsolete. The Rucio based catalogs now provide the functionality it used to provide. In addition, there is some cleanup in the same files affected by the TrivialFileCatalog deletion. 

This should not affect the behavior or output of cmsRun processes.

See Issue #47058.

Resolves https://github.com/cms-sw/framework-team/issues/1486
Resolves https://github.com/cms-sw/framework-team/issues/1488

FYI @stlammel

#### PR validation:

I reviewed the coverage of the unit tests for the files affected by this change and with the deletion of TrivialFileCatalog the unit tests provide good coverage for the InputFileCatalog and FileLocator classes. I added a tiny bit to those tests, but they were good already. The unit tests pass.
