### PR TITLE
Add missing cmath include in FWCore files

### DIFF
--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -33,6 +33,7 @@ Toy EDProducers of Ints for testing purposes only.
 #include <string>
 #include <vector>
 #include <chrono>
+#include <cmath>
 
 namespace edmtest {
 

--- a/FWCore/Integration/plugins/ProducerWithPSetDesc.cc
+++ b/FWCore/Integration/plugins/ProducerWithPSetDesc.cc
@@ -24,6 +24,8 @@
 #include <memory>
 #include <string>
 #include <iostream>
+#include <cmath>
+#include <array>
 
 namespace edmtest {
 


### PR DESCRIPTION
#### PR description:

- We should include what we use.
- Apparently we were getting this header indirectly from ROOT and with the new version that has changed.

This should fix a compilation problem in the ROOT_X build.
#### PR validation:

Code compiles.