### PR TITLE
[NanoAOD] Backport of #49137 (Fix puppi weight in PFCand table for reNanoV15) to 151X

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/PFCandidatesVarProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/PFCandidatesVarProducer.cc
@@ -1,0 +1,87 @@
+#include <string>
+#include <memory>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+
+class PFCandidatesVarProducer : public edm::stream::EDProducer<> {
+public:
+  explicit PFCandidatesVarProducer(const edm::ParameterSet&);
+  ~PFCandidatesVarProducer() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void PutValueMapInEvent(edm::Event&, const edm::Handle<edm::View<reco::Candidate>>&, const std::vector<float>&, std::string);
+  edm::EDGetTokenT<edm::View<reco::Candidate>> pfcands_token_;
+  edm::EDGetTokenT<edm::ValueMap<float>> puppi_value_map_token_;
+};
+
+PFCandidatesVarProducer::PFCandidatesVarProducer(const edm::ParameterSet& iConfig)
+    : pfcands_token_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("src"))),
+      puppi_value_map_token_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppi_value_map"))){
+  produces<edm::ValueMap<float>>("ptWeighted");
+  produces<edm::ValueMap<float>>("massWeighted");
+}
+
+PFCandidatesVarProducer::~PFCandidatesVarProducer() {}
+
+void PFCandidatesVarProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  // Get PF candidates
+  edm::Handle<edm::View<reco::Candidate>> pfcands_handle;
+  iEvent.getByToken(pfcands_token_, pfcands_handle);
+  const edm::View<reco::Candidate>* pfcands = pfcands_handle.product();
+
+  // Get puppi value map
+  edm::Handle<edm::ValueMap<float>> puppi_value_map_;
+  iEvent.getByToken(puppi_value_map_token_, puppi_value_map_);
+
+  std::vector<float> ptWeighted(pfcands->size(), 0.f);
+  std::vector<float> massWeighted(pfcands->size(), 0.f);
+
+  for (std::size_t pfcand_idx = 0; pfcand_idx < pfcands->size(); pfcand_idx++) {
+    const auto& cand = (*pfcands)[pfcand_idx];
+
+    reco::CandidatePtr candPtr(pfcands_handle, pfcand_idx);
+    float puppiWeightVal = (*puppi_value_map_)[candPtr];
+
+    ptWeighted[pfcand_idx] = puppiWeightVal * cand.pt();
+    massWeighted[pfcand_idx] = puppiWeightVal * cand.mass();
+  }
+
+  PutValueMapInEvent(iEvent, pfcands_handle, ptWeighted,   "ptWeighted");
+  PutValueMapInEvent(iEvent, pfcands_handle, massWeighted, "massWeighted");
+}
+void PFCandidatesVarProducer::PutValueMapInEvent(edm::Event& iEvent,
+                                                        const edm::Handle<edm::View<reco::Candidate>>& coll,
+                                                        const std::vector<float>& vec_var,
+                                                        std::string VMName) {
+  std::unique_ptr<edm::ValueMap<float>> VM(new edm::ValueMap<float>());
+  edm::ValueMap<float>::Filler fillerVM(*VM);
+  fillerVM.insert(coll, vec_var.begin(), vec_var.end());
+  fillerVM.fill();
+  iEvent.put(std::move(VM), VMName);
+}
+
+
+void PFCandidatesVarProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src", edm::InputTag("packedPFCandidates"));
+  desc.add<edm::InputTag>("puppi_value_map", edm::InputTag("packedpuppi"));
+  desc.add<bool>("fallback_puppi_weight", false);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+DEFINE_FWK_MODULE(PFCandidatesVarProducer);

--- a/PhysicsTools/NanoAOD/plugins/PFCandidatesVarProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/PFCandidatesVarProducer.cc
@@ -23,14 +23,17 @@ public:
 
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void PutValueMapInEvent(edm::Event&, const edm::Handle<edm::View<reco::Candidate>>&, const std::vector<float>&, std::string);
+  void PutValueMapInEvent(edm::Event&,
+                          const edm::Handle<edm::View<reco::Candidate>>&,
+                          const std::vector<float>&,
+                          std::string);
   edm::EDGetTokenT<edm::View<reco::Candidate>> pfcands_token_;
   edm::EDGetTokenT<edm::ValueMap<float>> puppi_value_map_token_;
 };
 
 PFCandidatesVarProducer::PFCandidatesVarProducer(const edm::ParameterSet& iConfig)
     : pfcands_token_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("src"))),
-      puppi_value_map_token_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppi_value_map"))){
+      puppi_value_map_token_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppi_value_map"))) {
   produces<edm::ValueMap<float>>("ptWeighted");
   produces<edm::ValueMap<float>>("massWeighted");
 }
@@ -38,7 +41,6 @@ PFCandidatesVarProducer::PFCandidatesVarProducer(const edm::ParameterSet& iConfi
 PFCandidatesVarProducer::~PFCandidatesVarProducer() {}
 
 void PFCandidatesVarProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-
   // Get PF candidates
   edm::Handle<edm::View<reco::Candidate>> pfcands_handle;
   iEvent.getByToken(pfcands_token_, pfcands_handle);
@@ -61,20 +63,19 @@ void PFCandidatesVarProducer::produce(edm::Event& iEvent, const edm::EventSetup&
     massWeighted[pfcand_idx] = puppiWeightVal * cand.mass();
   }
 
-  PutValueMapInEvent(iEvent, pfcands_handle, ptWeighted,   "ptWeighted");
+  PutValueMapInEvent(iEvent, pfcands_handle, ptWeighted, "ptWeighted");
   PutValueMapInEvent(iEvent, pfcands_handle, massWeighted, "massWeighted");
 }
 void PFCandidatesVarProducer::PutValueMapInEvent(edm::Event& iEvent,
-                                                        const edm::Handle<edm::View<reco::Candidate>>& coll,
-                                                        const std::vector<float>& vec_var,
-                                                        std::string VMName) {
+                                                 const edm::Handle<edm::View<reco::Candidate>>& coll,
+                                                 const std::vector<float>& vec_var,
+                                                 std::string VMName) {
   std::unique_ptr<edm::ValueMap<float>> VM(new edm::ValueMap<float>());
   edm::ValueMap<float>::Filler fillerVM(*VM);
   fillerVM.insert(coll, vec_var.begin(), vec_var.end());
   fillerVM.fill();
   iEvent.put(std::move(VM), VMName);
 }
-
 
 void PFCandidatesVarProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;

--- a/PhysicsTools/NanoAOD/python/jetConstituents_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetConstituents_cff.py
@@ -58,6 +58,23 @@ jetConstituentsTask = cms.Task(finalJetsAK8PFConstituents,selectedFinalJetsAK8PF
 jetConstituentsTablesTask = cms.Task(finalPFCandidates,pfCandidatesTable,finalJetsAK8ConstituentsTable)
 
 
+def UsePuppiWeightFromValueMapForPFCandTable(process,puppiLabel="packedpuppi"):
+    process.packedPFCandidatesVarProducer = cms.EDProducer("PFCandidatesVarProducer",
+        src = cms.InputTag("packedPFCandidates"),
+        puppi_value_map = cms.InputTag(puppiLabel)
+    )
+    process.jetConstituentsTask.add(process.packedPFCandidatesVarProducer)
+
+    del process.pfCandidatesTable.variables.pt
+    del process.pfCandidatesTable.variables.mass
+
+    process.pfCandidatesTable.externalVariables = cms.PSet(
+        pt = ExtVar(cms.InputTag("packedPFCandidatesVarProducer:ptWeighted"), float, doc="Puppi-weighted pt", precision=10),
+        mass = ExtVar(cms.InputTag("packedPFCandidatesVarProducer:massWeighted"), float, doc="Puppi-weighted mass", precision=10),
+    )
+
+    return process
+
 def SaveAK4JetConstituents(process, jetCut="", jetConstCut=""):
     """
     This function can be used as a cmsDriver customization

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -247,7 +247,7 @@ def nanoAOD_customizeCommon(process):
                                     reclusterAK8=nanoAOD_rePuppi_switch.reclusterAK8.value(),
                                     )
 
-    if nanoAOD_rePuppi_switch.useExistingWeights == False:
+    if not(nanoAOD_rePuppi_switch.useExistingWeights) and (nanoAOD_rePuppi_switch.reclusterAK4MET or nanoAOD_rePuppi_switch.reclusterAK8):
         process = UsePuppiWeightFromValueMapForPFCandTable(process)
 
     # This function is defined in jetsAK4_Puppi_cff.py

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -247,6 +247,9 @@ def nanoAOD_customizeCommon(process):
                                     reclusterAK8=nanoAOD_rePuppi_switch.reclusterAK8.value(),
                                     )
 
+    if nanoAOD_rePuppi_switch.useExistingWeights == False:
+        process = UsePuppiWeightFromValueMapForPFCandTable(process)
+
     # This function is defined in jetsAK4_Puppi_cff.py
     process = nanoAOD_addDeepInfoAK4(process,
                                      addParticleNet=nanoAOD_addDeepInfoAK4_switch.nanoAOD_addParticleNet_switch,


### PR DESCRIPTION
Backport of #49137 

#### PR description:

During the validation of reNanoV15 for Run2UL+22+23, it was found that the puppi weights used to store the weighted pt and mass of `PFCand`s are the older versions of puppi as stored the input MiniAOD. This PR fixes the issue by retrieving the puppi weights from the `ValueMap<float>` produced by `packedpuppi`.

#### PR validation:

- Checked that the pT of the AK8 jets calculated from the four-vector sum of PFCand is now consistent with the pT from the AK8 jets four-vector. 