### PR TITLE
Adding missing cmath header which was cleaned up in root master

### DIFF
--- a/Alignment/OfflineValidation/interface/PVValidationHelpers.h
+++ b/Alignment/OfflineValidation/interface/PVValidationHelpers.h
@@ -1,6 +1,7 @@
 #ifndef ALIGNMENT_OFFLINEVALIDATION_PVVALIDATIONHELPER_H
 #define ALIGNMENT_OFFLINEVALIDATION_PVVALIDATIONHELPER_H
 
+#include <cmath>
 #include <string>
 #include <vector>
 #include <map>

--- a/CalibTracker/SiStripCommon/plugins/ShallowClustersProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowClustersProducer.cc
@@ -1,3 +1,4 @@
+#include <cmath>
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/Calibration/HcalCalibAlgos/plugins/RecAnalyzerHF.cc
+++ b/Calibration/HcalCalibAlgos/plugins/RecAnalyzerHF.cc
@@ -1,4 +1,5 @@
 // system include files
+#include <cmath>
 #include <memory>
 #include <string>
 #include <iostream>

--- a/DQM/CTPPS/src/TotemT2Segmentation.cc
+++ b/DQM/CTPPS/src/TotemT2Segmentation.cc
@@ -11,6 +11,7 @@
 #include "DQM/CTPPS/interface/TotemT2Segmentation.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
+#include <cmath>
 #include "TH2D.h"
 
 TotemT2Segmentation::TotemT2Segmentation(size_t nbinsx, size_t nbinsy) : nbinsx_(nbinsx), nbinsy_(nbinsy) {

--- a/EventFilter/Utilities/plugins/ExceptionGenerator.cc
+++ b/EventFilter/Utilities/plugins/ExceptionGenerator.cc
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <typeinfo>
 #include <map>
+#include <cmath>
 #include <sstream>
 #include <sys/time.h>
 

--- a/GeneratorInterface/LHEInterface/plugins/LHECOMWeightProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHECOMWeightProducer.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <memory>
+#include <cmath>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDProducer.h"

--- a/L1Trigger/GlobalTrigger/plugins/L1GTPrescaler.cc
+++ b/L1Trigger/GlobalTrigger/plugins/L1GTPrescaler.cc
@@ -1,5 +1,6 @@
 #include <array>
 #include <cassert>
+#include <cmath>
 #include <memory>
 #include <vector>
 

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -15,6 +15,7 @@
 #include "boost/algorithm/string.hpp"
 
 #include <array>
+#include <cmath>
 #include <memory>
 
 #include <vector>

--- a/RecoEgamma/EgammaPhotonAlgos/src/EnergyUncertaintyPhotonSpecific.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/EnergyUncertaintyPhotonSpecific.cc
@@ -1,6 +1,7 @@
 #include "RecoEgamma/EgammaPhotonAlgos/interface/EnergyUncertaintyPhotonSpecific.h"
 
 #include <iostream>
+#include <cmath>
 
 EnergyUncertaintyPhotonSpecific::EnergyUncertaintyPhotonSpecific(const edm::ParameterSet& config) {}
 

--- a/RecoLocalCalo/HcalRecAlgos/test/HcalRecHitReflagger.cc
+++ b/RecoLocalCalo/HcalRecAlgos/test/HcalRecHitReflagger.cc
@@ -16,6 +16,7 @@
 
 // system include files
 #include <iostream>
+#include <cmath>
 #include <memory>
 
 // user include files

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripApprox2ApproxClusters.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripApprox2ApproxClusters.cc
@@ -12,6 +12,7 @@
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 
+#include <cmath>
 #include <vector>
 #include <memory>
 

--- a/SimPPS/PPSPixelDigiProducer/src/RPixDummyROCSimulator.cc
+++ b/SimPPS/PPSPixelDigiProducer/src/RPixDummyROCSimulator.cc
@@ -1,4 +1,5 @@
 #include "SimPPS/PPSPixelDigiProducer/interface/RPixDummyROCSimulator.h"
+#include <cmath>
 #include <vector>
 #include "TRandom.h"
 #include <iostream>

--- a/Validation/CTPPS/plugins/CTPPSTrackDistributionPlotter.cc
+++ b/Validation/CTPPS/plugins/CTPPSTrackDistributionPlotter.cc
@@ -26,6 +26,7 @@
 #include "TProfile2D.h"
 #include "TGraph.h"
 
+#include <cmath>
 #include <map>
 #include <memory>
 


### PR DESCRIPTION
Fixed build errors for ROOT6_X IBs. `cmath` header is picked up from ROOT's Math package for default IBs but for ROOT master based IBs (ROOT6_X), root has cleaned up Math package and we need to explicitly add the mssing `cmath` include.