### PR TITLE
Clamp `fakePixels` to `maxFakesInModule` [15.1.x]

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
@@ -493,6 +493,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
               }
               alpaka::syncBlockThreads(acc);
 
+              // Clamp fakePixels to maxFakesInModule
+              if (fakePixels > maxFakesInModule) {
+                fakePixels = maxFakesInModule;
+                alpaka::syncBlockThreads(acc);
+              }
+
             }  // if (applyDigiMorphing)
           }  // if (lastPixel > 1)
         }  // if constexpr (not isPhase2)


### PR DESCRIPTION
#### PR description:

After running the Pixel digi morphing algorithm, clamp `fakePixels` to `maxFakesInModule` to avoid overflowing the histogram container.

#### PR validation:

Run on top of the reproducer at #49125 without any crashes.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #49142 to 15.1.x.