### PR TITLE
BTagPerformance.h: added cmath header to fix the header consistency error

### DIFF
--- a/PhysicsTools/PatExamples/interface/BTagPerformance.h
+++ b/PhysicsTools/PatExamples/interface/BTagPerformance.h
@@ -12,6 +12,7 @@
 #include "TArrayD.h"
 #include "TGraph.h"
 #include <cassert>
+#include <cmath>
 #include <map>
 
 class BTagPerformance {


### PR DESCRIPTION
This adds the missing header `cmath` for https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/PatExamples/interface/BTagPerformance.h which uses `sqrt` without including `cmath` header.   This causes header consistency error [a]


[a] https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-d1f908/48627/headers_chks.log
```
>> Compiling src/RecoBTag/SecondaryVertex/interface/CandidateBoostedDoubleSecondaryVertexComputer.h 
src/PhysicsTools/PatExamples/interface/BTagPerformance.h: In member function 'void BTagPerformance::Eval()':
src/PhysicsTools/PatExamples/interface/BTagPerformance.h:73:20: error: 'sqrt' was not declared in this scope
   73 |       double err = sqrt(eff * (1 - eff) / b_all);
      |                    ^~~~
src/PhysicsTools/PatExamples/interface/BTagPerformance.h:87:20: error: 'sqrt' was not declared in this scope
   87 |       double err = sqrt(eff * (1 - eff) / c_all);
      |                    ^~~~
src/PhysicsTools/PatExamples/interface/BTagPerformance.h:101:20: error: 'sqrt' was not declared in this scope
  101 |       double err = sqrt(eff * (1 - eff) / udsg_all);

```