### PR TITLE
Fix for `startingPairs` for Pixel Tracks CA

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -36,12 +36,21 @@ def customiseForOffline(process):
             ]
 
     return process
+def customizeHLTFor49147(process):
+    ca_producers_pp = ['CAHitNtupletAlpakaPhase1@alpaka','alpaka_serial_sync::CAHitNtupletAlpakaPhase1']
+    for ca_producer in ca_producers_pp:
+        for prod in producers_by_type(process, ca_producer):
+            if hasattr(prod, 'geometry'):
+                g = getattr(prod, 'geometry')
+                g.startingPairs = cms.vuint32( [i for i in range(8)] + [i for i in range(13,19)])
+                setattr(prod, 'geometry', g) 
+    return process 
 
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
     process = customiseForOffline(process)
-
+    process = customizeHLTFor49147(process)
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
     

--- a/RecoTracker/Configuration/python/customizePixelTracksForTriplets.py
+++ b/RecoTracker/Configuration/python/customizePixelTracksForTriplets.py
@@ -27,7 +27,7 @@ def customizePixelTracksForTriplets(process):
                9, 0, 2, 1, 3,
                0, 5, 0, 8, 
                4, 6, 7, 9 ]
-            producer.geometry.startingPairs = [i for i in range(8)] + [13, 14, 15, 16, 17, 18, 19]
+            producer.geometry.startingPairs = [i for i in range(8)] + [13, 14, 15, 16, 17, 18]
             producer.geometry.phiCuts = [522, 730, 730, 522, 626,
                626, 522, 522, 626, 626,
                626, 522, 522, 522, 522,

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtuplet.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtuplet.cc
@@ -120,7 +120,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 #endif
 
       assert(int(n_pairs) == int(iCache->minZ_.size()));
-      assert(int(*std::max_element(iCache->startingPairs_.begin(), iCache->startingPairs_.end())) <= n_pairs);
+      assert(int(*std::max_element(iCache->startingPairs_.begin(), iCache->startingPairs_.end())) < n_pairs);
       assert(int(*std::max_element(iCache->pairGraph_.begin(), iCache->pairGraph_.end())) < n_layers);
 
       const auto& trackerGeometry = iSetup.getData(iCache->tokenGeometry_);


### PR DESCRIPTION
#### PR description:

This PR propose a small fix to the pixel tracks CA as used at HLT for Run3. As is the starting pairs for triplets includes also pair `19` that does not exist (we have 19 pairs in total). This also fixes the check in the `CAGeometry` filling to properly works (that is also why this was not spotted before).

#### PR validation:

The limited matrix runs. No change expected to physics.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

It would be good to backport this to `15_1_X`. It's not affecting the HIon HLT since there we run only quadruplets.
