### PR TITLE
Assorted fixes post HGCAL test beam

### DIFF
--- a/CondFormats/HGCalObjects/interface/HGCalMappingModuleIndexer.h
+++ b/CondFormats/HGCalObjects/interface/HGCalMappingModuleIndexer.h
@@ -178,6 +178,7 @@ public:
   uint32_t maxErxIndex() const { return maxErxIdx_; }
   uint32_t maxModulesIndex() const { return maxModulesIdx_; }
   std::map<std::string, std::pair<uint32_t, uint32_t>> const &typecodeMap() const { return typecodeMap_; }
+  uint32_t maxModulesCount() const { return maxModulesCount_; }
 
   /// max number of main buffers/capture blocks per FED
   constexpr static uint32_t maxCBperFED_ = 10;
@@ -194,7 +195,7 @@ private:
   /// base offsets to apply per module type with different granularity : module, e-Rx, channel data
   std::vector<uint32_t> moduleOffsets_, erxOffsets_, dataOffsets_;
   /// global counters (sizes of vectors)
-  uint32_t nfeds_, maxDataIdx_, maxErxIdx_, maxModulesIdx_;
+  uint32_t nfeds_, maxDataIdx_, maxErxIdx_, maxModulesIdx_, maxModulesCount_;
   /// map from module type code string to (fedIdx,modIdx) pair (implemented to retrieve dense index offset)
   std::map<std::string, std::pair<uint32_t, uint32_t>> typecodeMap_;
 

--- a/CondFormats/HGCalObjects/src/HGCalMappingModuleIndexer.cc
+++ b/CondFormats/HGCalObjects/src/HGCalMappingModuleIndexer.cc
@@ -60,7 +60,8 @@ void HGCalMappingModuleIndexer::processNewModule(uint32_t fedid,
 void HGCalMappingModuleIndexer::finalize() {
   //max indices at different levels
   nfeds_ = fedReadoutSequences_.size();
-  maxModulesIdx_ = std::accumulate(globalTypesCounter_.begin(), globalTypesCounter_.end(), 0);
+  maxModulesCount_ = std::accumulate(globalTypesCounter_.begin(), globalTypesCounter_.end(), 0);
+  maxModulesIdx_ = globalTypesCounter_.size();
   maxErxIdx_ = std::inner_product(globalTypesCounter_.begin(), globalTypesCounter_.end(), globalTypesNErx_.begin(), 0);
   maxDataIdx_ =
       std::inner_product(globalTypesCounter_.begin(), globalTypesCounter_.end(), globalTypesNWords_.begin(), 0);
@@ -69,7 +70,7 @@ void HGCalMappingModuleIndexer::finalize() {
   moduleOffsets_.resize(maxModulesIdx_, 0);
   erxOffsets_.resize(maxModulesIdx_, 0);
   dataOffsets_.resize(maxModulesIdx_, 0);
-  for (size_t i = 1; i < globalTypesCounter_.size(); i++) {
+  for (size_t i = 1; i < maxModulesIdx_; i++) {
     moduleOffsets_[i] = globalTypesCounter_[i - 1] + moduleOffsets_[i - 1];
     erxOffsets_[i] = globalTypesCounter_[i - 1] * globalTypesNErx_[i - 1] + erxOffsets_[i - 1];
     dataOffsets_[i] = globalTypesCounter_[i - 1] * globalTypesNWords_[i - 1] + dataOffsets_[i - 1];

--- a/DataFormats/HGCalDigi/src/alpaka/classes_cuda.h
+++ b/DataFormats/HGCalDigi/src/alpaka/classes_cuda.h
@@ -6,3 +6,5 @@
 #include "DataFormats/HGCalDigi/interface/alpaka/HGCalECONDPacketInfoDevice.h"
 #include "DataFormats/HGCalDigi/interface/HGCalFEDPacketInfoSoA.h"
 #include "DataFormats/HGCalDigi/interface/alpaka/HGCalFEDPacketInfoDevice.h"
+#include "DataFormats/HGCalDigi/interface/HGCalDigiTriggerSoA.h"
+#include "DataFormats/HGCalDigi/interface/alpaka/HGCalDigiTriggerDevice.h"

--- a/DataFormats/HGCalDigi/src/alpaka/classes_cuda_def.xml
+++ b/DataFormats/HGCalDigi/src/alpaka/classes_cuda_def.xml
@@ -8,4 +8,7 @@
   <class name="alpaka_cuda_async::hgcaldigi::HGCalFEDPacketInfoDevice" persistent="false"/>
   <class name="edm::DeviceProduct<alpaka_cuda_async::hgcaldigi::HGCalFEDPacketInfoDevice>" persistent="false"/>
   <class name="edm::Wrapper<edm::DeviceProduct<alpaka_cuda_async::hgcaldigi::HGCalFEDPacketInfoDevice>>" persistent="false"/>
+  <class name="alpaka_cuda_async::hgcaldigi::HGCalDigiTriggerDevice" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_cuda_async::hgcaldigi::HGCalDigiTriggerDevice>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_cuda_async::hgcaldigi::HGCalDigiTriggerDevice>>" persistent="false"/>
 </lcgdict>

--- a/DataFormats/HGCalDigi/src/alpaka/classes_rocm.h
+++ b/DataFormats/HGCalDigi/src/alpaka/classes_rocm.h
@@ -6,3 +6,5 @@
 #include "DataFormats/HGCalDigi/interface/alpaka/HGCalECONDPacketInfoDevice.h"
 #include "DataFormats/HGCalDigi/interface/HGCalFEDPacketInfoSoA.h"
 #include "DataFormats/HGCalDigi/interface/alpaka/HGCalFEDPacketInfoDevice.h"
+#include "DataFormats/HGCalDigi/interface/HGCalDigiTriggerSoA.h"
+#include "DataFormats/HGCalDigi/interface/alpaka/HGCalDigiTriggerDevice.h"

--- a/DataFormats/HGCalDigi/src/alpaka/classes_rocm_def.xml
+++ b/DataFormats/HGCalDigi/src/alpaka/classes_rocm_def.xml
@@ -8,4 +8,7 @@
   <class name="alpaka_rocm_async::hgcaldigi::HGCalFEDPacketInfoDevice" persistent="false"/>
   <class name="edm::DeviceProduct<alpaka_rocm_async::hgcaldigi::HGCalFEDPacketInfoDevice>" persistent="false"/>
   <class name="edm::Wrapper<edm::DeviceProduct<alpaka_rocm_async::hgcaldigi::HGCalFEDPacketInfoDevice>>" persistent="false"/>
+  <class name="alpaka_rocm_async::hgcaldigi::HGCalDigiTriggerDevice" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_rocm_async::hgcaldigi::HGCalDigiTriggerDevice>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_rocm_async::hgcaldigi::HGCalDigiTriggerDevice>>" persistent="false"/>
 </lcgdict>

--- a/DataFormats/HGCalDigi/src/classes.h
+++ b/DataFormats/HGCalDigi/src/classes.h
@@ -11,3 +11,5 @@
 #include "DataFormats/HGCalDigi/interface/HGCalECONDPacketInfoSoA.h"
 #include "DataFormats/HGCalDigi/interface/HGCalFEDPacketInfoHost.h"
 #include "DataFormats/HGCalDigi/interface/HGCalFEDPacketInfoSoA.h"
+#include "DataFormats/HGCalDigi/interface/HGCalDigiTriggerHost.h"
+#include "DataFormats/HGCalDigi/interface/HGCalDigiTriggerSoA.h"

--- a/DataFormats/HGCalDigi/src/classes_def.xml
+++ b/DataFormats/HGCalDigi/src/classes_def.xml
@@ -61,4 +61,11 @@
   <class name="hgcaldigi::HGCalFEDPacketInfoHost"/>
   <class name="edm::Wrapper<hgcaldigi::HGCalFEDPacketInfoHost>" splitLevel="0"/>
 
+  <class name="hgcaldigi::HGCalDigiTriggerSoA"/>
+  <class name="hgcaldigi::HGCalDigiTriggerSoA::View"/>
+  <class name="hgcaldigi::HGCalDigiTriggerHost"/>
+  <class name="hgcaldigi::HGCalDigiTriggerSoALayout<128,false>"/>
+  <class name="edm::Wrapper<PortableHostCollection<hgcaldigi::HGCalDigiTriggerSoALayout<128,false> > >" splitLevel="0"/>
+  <class name="portablecollection::CollectionLeaf<0, hgcaldigi::HGCalDigiTriggerSoALayout<128, false>>"/>
+  
 </lcgdict>

--- a/EventFilter/HGCalRawToDigi/interface/HGCalUnpacker.h
+++ b/EventFilter/HGCalRawToDigi/interface/HGCalUnpacker.h
@@ -52,6 +52,19 @@ public:
                         hgcaldigi::HGCalECONDPacketInfoHost& econdPacketInfo,
                         bool headerOnlyMode);
 
+  /**
+     @short the 10-bit TOT word is decompressed back to 12 bit word
+     In case truncation occurred the word is shifted by 2 bit
+  */
+  uint16_t decompressToT(uint16_t totraw) const {
+    uint16_t totout(totraw & 0x1ff);
+    if (totraw & 0x200) {
+      totout = ((totraw & 0x1ff) << 3);
+      totout += (1 << 2);
+    }
+    return totout;
+  }
+
 private:
   constexpr static uint8_t tctp_[16] = {
       0b00, 0b00, 0b01, 0b00, 0b00, 0b00, 0b00, 0b00, 0b10, 0b10, 0b10, 0b10, 0b11, 0b11, 0b11, 0b11};

--- a/EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc
+++ b/EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc
@@ -92,7 +92,7 @@ void HGCalRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
   const auto& config = iSetup.getData(configToken_);
 
   hgcaldigi::HGCalDigiHost digis(moduleIndexer.maxDataSize(), cms::alpakatools::host());
-  hgcaldigi::HGCalECONDPacketInfoHost econdPacketInfo(moduleIndexer.maxModuleSize(), cms::alpakatools::host());
+  hgcaldigi::HGCalECONDPacketInfoHost econdPacketInfo(moduleIndexer.maxModulesCount(), cms::alpakatools::host());
   hgcaldigi::HGCalFEDPacketInfoHost fedPacketInfo(moduleIndexer.fedCount(), cms::alpakatools::host());
 
   // retrieve the FED raw data

--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
@@ -341,7 +341,7 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
             digis.view()[denseIdx].tctp() = tctp_[code];
             digis.view()[denseIdx].adcm1() = (temp >> adcm1Shift_[code]) & adcm1Mask_[code];
             digis.view()[denseIdx].adc() = (temp >> adcShift_[code]) & adcMask_[code];
-            digis.view()[denseIdx].tot() = (temp >> totShift_[code]) & totMask_[code];
+            digis.view()[denseIdx].tot() = decompressToT((temp >> totShift_[code]) & totMask_[code]);
             digis.view()[denseIdx].toa() = (temp >> toaShift_[code] & toaMask_[code]);
             digis.view()[denseIdx].cm() = cmSum;
             digis.view()[denseIdx].flags() = 0;
@@ -407,7 +407,7 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
               digis.view()[denseIdx].tctp() = (econd_payload[iword] >> 30) & 0b11;
               digis.view()[denseIdx].adcm1() = 0;
               digis.view()[denseIdx].adc() = (econd_payload[iword] >> 20) & 0b1111111111;
-              digis.view()[denseIdx].tot() = (econd_payload[iword] >> 10) & 0b1111111111;
+              digis.view()[denseIdx].tot() = decompressToT((econd_payload[iword] >> 10) & 0b1111111111);
               digis.view()[denseIdx].toa() = econd_payload[iword] & 0b1111111111;
               digis.view()[denseIdx].cm() = cmSum;
               digis.view()[denseIdx].flags() = hgcal::DIGI_FLAG::Characterization;
@@ -418,7 +418,7 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
               digis.view()[denseIdx].adcm1() = (econd_payload[iword] >> 20) & 0b1111111111;
               if (econd_payload[iword] >> 31 & 0b1) {
                 digis.view()[denseIdx].adc() = 0;
-                digis.view()[denseIdx].tot() = (econd_payload[iword] >> 10) & 0b1111111111;
+                digis.view()[denseIdx].tot() = decompressToT((econd_payload[iword] >> 10) & 0b1111111111);
               } else {
                 digis.view()[denseIdx].adc() = (econd_payload[iword] >> 10) & 0b1111111111;
                 digis.view()[denseIdx].tot() = 0;

--- a/Geometry/HGCalMapping/plugins/alpaka/HGCalMappingModuleESProducer.cc
+++ b/Geometry/HGCalMapping/plugins/alpaka/HGCalMappingModuleESProducer.cc
@@ -48,7 +48,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         auto modIndexer = iRecord.get(moduleIndexTkn_);
 
         // load dense indexing
-        const uint32_t size = modIndexer.maxModulesIndex();
+        const uint32_t size = modIndexer.maxModulesCount();
         HGCalMappingModuleParamHost moduleParams(size, cms::alpakatools::host());
         for (size_t i = 0; i < size; i++)
           moduleParams.view()[i].valid() = false;
@@ -77,8 +77,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           uint32_t detid(0);
           if (!isSiPM) {
             int zp(zside > 0 ? 1 : -1);
-            DetId::Detector det = plane <= 26 ? DetId::Detector::HGCalEE : DetId::Detector::HGCalHSi;
-            detid = HGCSiliconDetId(det, zp, celltype, plane, i1, i2, 0, 0).rawId();
+            DetId::Detector det = plane <= nCEELayers_ ? DetId::Detector::HGCalEE : DetId::Detector::HGCalHSi;
+            auto detid_plane = plane - nCEELayers_ * (plane > nCEELayers_);
+            detid = HGCSiliconDetId(det, zp, celltype, detid_plane, i1, i2, 0, 0).rawId();
           }
 
           auto module = moduleParams.view()[idx];
@@ -108,6 +109,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     private:
       edm::ESGetToken<HGCalMappingModuleIndexer, HGCalElectronicsMappingRcd> moduleIndexTkn_;
       const edm::FileInPath filename_;
+      static constexpr int nCEELayers_ = 26;
     };
 
   }  // namespace hgcal

--- a/Geometry/HGCalMapping/test/BuildFile.xml
+++ b/Geometry/HGCalMapping/test/BuildFile.xml
@@ -8,9 +8,16 @@
   <use name="CondFormats/DataRecord"/>
   <use name="CondFormats/HGCalObjects"/>
   <use name="Geometry/HGCalMapping"/>
+  <use name="Geometry/CaloGeometry"/>
+  <use name="Geometry/Records"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/Utilities"/>
   <flags EDM_PLUGIN="1"/>
 </library>
+
+<test name="testMappingModIndexer_def" command="cmsRun ${LOCALTOP}/src/Geometry/HGCalMapping/test/testMappingModuleIndexer_cfg.py  "/>
+
+<test name="testMappingModIndexer_trigger" command="cmsRun ${LOCALTOP}/src/Geometry/HGCalMapping/test/testMappingModuleIndexerTrigger_cfg.py"/>
+

--- a/Geometry/HGCalMapping/test/testMappingModuleIndexer_cfg.py
+++ b/Geometry/HGCalMapping/test/testMappingModuleIndexer_cfg.py
@@ -4,6 +4,8 @@ process = cms.Process("TEST")
 
 from FWCore.ParameterSet.VarParsing import VarParsing
 options = VarParsing('python')
+options.register('verbosity',0,mytype=VarParsing.varType.int,
+                 info='Tester verbosity: 0 = Base+FED prints / 1 = +Module prints / 2 = +Cell prints')
 options.register('modules','Geometry/HGCalMapping/data/ModuleMaps/modulelocator_test.txt',mytype=VarParsing.varType.string,
                  info="Path to module mapper. Absolute, or relative to CMSSW src directory")
 options.register('sicells','Geometry/HGCalMapping/data/CellMaps/WaferCellMapTraces.txt',mytype=VarParsing.varType.string,
@@ -30,5 +32,6 @@ process.load('Configuration.Geometry.GeometryExtendedRun4D104Reco_cff')
 
 # tester
 process.tester = cms.EDAnalyzer('HGCalMappingESSourceTester')
+process.tester.verbosity = cms.untracked.int32(options.verbosity)
 
 process.p = cms.Path(process.tester)

--- a/RecoLocalCalo/HGCalRecAlgos/interface/alpaka/HGCalRecHitCalibrationAlgorithms.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/alpaka/HGCalRecHitCalibrationAlgorithms.h
@@ -36,7 +36,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                               HGCalCalibParamDevice const& device_calib,
                                               HGCalMappingModuleParamDevice const& device_mapmod,
                                               HGCalMappingCellParamDevice const& device_mapping,
-                                              HGCalDenseIndexInfoDevice const& device_index) const;
+                                              HGCalDenseIndexInfoDevice const& device_index,
+                                              double k_noise) const;
 
     HGCalSoARecHitsDeviceCollection select(Queue& queue,
                                            int const ndigis,

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/HGCalConfigurationESProducer.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/HGCalConfigurationESProducer.cc
@@ -26,8 +26,8 @@ class HGCalConfigurationESProducer : public edm::ESProducer, public edm::EventSe
 public:
   explicit HGCalConfigurationESProducer(const edm::ParameterSet& iConfig)
       :  //edm::ESProducer(iConfig),
-        fedjson_(iConfig.getParameter<std::string>("fedjson")),
-        modjson_(iConfig.getParameter<std::string>("modjson")) {
+        fedjson_(iConfig.getParameter<edm::FileInPath>("fedjson")),
+        modjson_(iConfig.getParameter<edm::FileInPath>("modjson")) {
     if (iConfig.exists("bePassthroughMode"))
       bePassthroughMode_ = iConfig.getParameter<int32_t>("bePassthroughMode");
     if (iConfig.exists("cbHeaderMarker"))
@@ -46,8 +46,8 @@ public:
     edm::ParameterSetDescription desc;
     desc.add<edm::ESInputTag>("indexSource", edm::ESInputTag(""))
         ->setComment("Label for module indexer to set SoA size");
-    desc.add<std::string>("fedjson", "")->setComment("JSON file with FED configuration parameters");
-    desc.add<std::string>("modjson", "")->setComment("JSON file with ECOND configuration parameters");
+    desc.add<edm::FileInPath>("fedjson")->setComment("JSON file with FED configuration parameters");
+    desc.add<edm::FileInPath>("modjson")->setComment("JSON file with ECOND configuration parameters");
     desc.addOptional<int32_t>("bePassthroughMode", -1)
         ->setComment("Manual override for mismatch passthrough mode in the BE");
     desc.addOptional<int32_t>("cbHeaderMarker", -1)
@@ -76,10 +76,10 @@ public:
         << "produce: fedjson_=" << fedjson_ << ",\n         modjson_=" << modjson_;
 
     // retrieve values from custom JSON format (see HGCalCalibrationESProducer)
-    edm::FileInPath fedfip(fedjson_);  // e.g. HGCalCommissioning/LocalCalibration/data/config_feds.json
-    edm::FileInPath modfip(modjson_);  // e.g. HGCalCommissioning/LocalCalibration/data/config_econds.json
-    std::ifstream fedfile(fedjson_);
-    std::ifstream modfile(modjson_);
+    std::string fedjsonurl(fedjson_.fullPath());
+    std::string modjsonurl(modjson_.fullPath());
+    std::ifstream fedfile(fedjsonurl);
+    std::ifstream modfile(modjsonurl);
     const json fed_config_data = json::parse(fedfile, nullptr, true, /*ignore_comments*/ true);
     const json mod_config_data = json::parse(modfile, nullptr, true, /*ignore_comments*/ true);
 
@@ -90,7 +90,7 @@ public:
     const std::vector<std::string> modkeys = {"headerMarker", "CalibrationSC"};
     if (nfeds != fed_config_data.size())
       edm::LogWarning("HGCalConfigurationESProducer")
-          << "Total number of FEDs found in JSON file " << fedjson_ << " (" << fed_config_data.size()
+          << "Total number of FEDs found in JSON file " << fedjsonurl << " (" << fed_config_data.size()
           << ") does not match indexer (" << nfeds << ")";
 
     // loop over FEDs in indexer & fill configuration structs: FED > ECON-D > eRx
@@ -100,11 +100,11 @@ public:
     config_->feds.resize(moduleMap.maxFEDSize());
     for (std::size_t fedid = 0; fedid < moduleMap.maxFEDSize(); ++fedid) {
       // sanity checks
-      if (moduleMap.fedReadoutSequences()[fedid].readoutTypes_.empty())            // check if FED exists (non-empty)
-        continue;                                                                  // skip non-existent FED
-      const auto fedkey = hgcal::search_fedkey(fedid, fed_config_data, fedjson_);  // search matching key
+      if (moduleMap.fedReadoutSequences()[fedid].readoutTypes_.empty())              // check if FED exists (non-empty)
+        continue;                                                                    // skip non-existent FED
+      const auto fedkey = hgcal::search_fedkey(fedid, fed_config_data, fedjsonurl);  // search matching key
       hgcal::check_keys(
-          fed_config_data, fedkey, fedkeys, fedjson_);  // check required keys are in the JSON, warn otherwise
+          fed_config_data, fedkey, fedkeys, fedjsonurl);  // check required keys are in the JSON, warn otherwise
 
       // fill FED configurations
       HGCalFedConfig fed;
@@ -123,9 +123,9 @@ public:
 
         // sanity checks for ECON-Ds
         ntot_mods++;
-        const auto modkey = hgcal::search_modkey(typecode, mod_config_data, modjson_);  // search matching key
+        const auto modkey = hgcal::search_modkey(typecode, mod_config_data, modjsonurl);  // search matching key
         hgcal::check_keys(
-            mod_config_data, modkey, modkeys, modjson_);  // check required keys are in the JSON, warn otherwise
+            mod_config_data, modkey, modkeys, modjsonurl);  // check required keys are in the JSON, warn otherwise
         if (imod >= fed.econds.size())
           fed.econds.resize(imod + 1);
 
@@ -139,7 +139,7 @@ public:
         uint32_t nrocs2 = mod_config_data[modkey]["CalibrationSC"].size();
         if (nrocs != nrocs2)
           edm::LogWarning("HGCalConfigurationESProducer")
-              << " Number of eRx ROCs for ECON-D " << typecode << " in " << fedjson_ << " (" << nrocs2
+              << " Number of eRx ROCs for ECON-D " << typecode << " in " << fedjsonurl << " (" << nrocs2
               << ") does not match that of the indexer for fedid" << fedid << " & imod=" << imod << " (" << nrocs
               << ")!";
         mod.rocs.resize(nrocs);
@@ -158,10 +158,10 @@ public:
     }
 
     // consistency check
-    if (ntot_mods != moduleMap.maxModuleSize())
+    if (ntot_mods != moduleMap.maxModulesCount())
       edm::LogWarning("HGCalConfigurationESProducer")
           << "Total number of ECON-D modules found in JSON file " << modjson_ << " (" << ntot_mods
-          << ") does not match indexer (" << moduleMap.maxModuleSize() << ")";
+          << ") does not match indexer (" << moduleMap.maxModulesCount() << ")";
     if (ntot_rocs != moduleMap.maxERxSize())
       edm::LogWarning("HGCalConfigurationESProducer")
           << "Total number of eRx half-ROCs found in JSON file " << modjson_ << " (" << ntot_rocs
@@ -178,8 +178,8 @@ private:
   }
 
   edm::ESGetToken<HGCalMappingModuleIndexer, HGCalElectronicsMappingRcd> indexToken_;
-  const std::string fedjson_;       // JSON file
-  const std::string modjson_;       // JSON file
+  const edm::FileInPath fedjson_;   // JSON file
+  const edm::FileInPath modjson_;   // JSON file
   int32_t bePassthroughMode_ = -1;  // for manual override
   int32_t cbHeaderMarker_ = -1;     // for manual override
   int32_t slinkHeaderMarker_ = -1;  // for manual override

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationESProducer.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationESProducer.cc
@@ -190,7 +190,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           edm::LogInfo("HGCalCalibrationESProducer")
               << "layer=" << layer << ", celltype=" << celltype << ", isSiPM=" << isSiPM << ", dEdx=" << dEdx
               << ", sf=" << sf << std::endl;
-          dEdx *= sf * 1e3;  // apply correction and convert from MeV to GeV
+          dEdx *= sf * 1e-3;  // apply correction and convert from MeV to GeV
           fill_SoA_column_single<float>(product.view().EM_scale().data(), dEdx, offset, nrows);
 
         }  // end of loop over modules

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitProducers.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitProducers.cc
@@ -60,7 +60,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const device::ESGetToken<hgcal::HGCalMappingModuleParamDevice, HGCalElectronicsMappingRcd> moduleToken_;
     const device::EDPutToken<HGCalSoARecHitsDeviceCollection> recHitsToken_;
     const HGCalRecHitCalibrationAlgorithms calibrator_;
-    const int n_hits_scale;
+    const double k_noise_;
+    const int n_hits_scale_;
     int ndigis_;
     cms::alpakatools::host_buffer<int32_t> nsel_;
     std::optional<cms::alpakatools::device_buffer<Device, int32_t[]>> sidx_;
@@ -76,10 +77,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         moduleToken_{esConsumes()},
         recHitsToken_{produces()},
         calibrator_{iConfig.getParameter<int>("n_blocks"), iConfig.getParameter<int>("n_threads")},
-        n_hits_scale{iConfig.getParameter<int>("n_hits_scale")},
+        k_noise_{iConfig.getParameter<double>("k_noise")},
+        n_hits_scale_{iConfig.getParameter<int>("n_hits_scale")},
         nsel_{cms::alpakatools::make_host_buffer<int32_t, Platform>()} {
 #ifndef HGCAL_PERF_TEST
-    if (n_hits_scale > 1) {
+    if (n_hits_scale_ > 1) {
       throw cms::Exception("RuntimeError") << "Build with `HGCAL_PERF_TEST` flag to activate `n_hits_scale`.";
     }
 #endif
@@ -91,6 +93,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     desc.add("calibSource", edm::ESInputTag{})->setComment("Label for calibration parameters");
     desc.add("mappingSource", edm::ESInputTag{})->setComment("Label for cell mapping parameters");
     desc.add("indexingSource", edm::ESInputTag{})->setComment("Label for cell dense indexer");
+    desc.add<double>("k_noise", -100.)->setComment("ZS threshold for rechits (multiples of noise)");
     desc.add<int>("n_blocks", -1);
     desc.add<int>("n_threads", -1);
     desc.add<int>("n_hits_scale", -1);
@@ -122,7 +125,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
 #ifdef HGCAL_PERF_TEST
     uint32_t oldSize = hostDigisIn.view().metadata().size();
-    uint32_t newSize = oldSize * (n_hits_scale > 0 ? (unsigned)n_hits_scale : 1);
+    uint32_t newSize = oldSize * (n_hits_scale_ > 0 ? (unsigned)n_hits_scale_ : 1);
     auto hostDigis = HGCalDigiHost(newSize, queue);
     auto hostCalibParam = HGCalCalibParamHost(newSize, queue);
     // TODO: replace with memcp ?
@@ -183,7 +186,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                      deviceCalibParam,
                                      deviceModuleInfoProvider,
                                      deviceMappingCellParamProvider,
-                                     deviceIndexingParamProvider);
+                                     deviceIndexingParamProvider,
+                                     k_noise_);
 #endif
 
 #ifdef EDM_ML_DEBUG


### PR DESCRIPTION
#### PR description:

Post HGCAL test beam we have tested more extensively some parts of the code using the orbit accumulated data. This PR patches different pieces of the existing code on the following aspects

- Module locator
   - there was a confusion between the module type index (typically 0-54) and module count (typically 1-500 within a FED). We have introduced an explicit method to decouple the two and start using explicitly module count
   - enabled unit tests for module locator which were otherwise ran by hand locally
- Data formats
    - missing the generation of dictionaries for new TPG SoAs, added in this PR
    - add estimated rec hit noise level (from pedestal runs)
- Unpacker
    - missing decompression of 10b to 12b measurement of time-over-threshold energy measurement
- ESProducer
    - use FileInPath starting at cfg level
- RecHit calibration kernels
    - introduce cut as multiple of noise instead of absolute energy
    - corrected application of local e.m. and dE/dx corrections
- "Workflow 77" configuration update
    - propagate usage of FileInPath and use selection of hits &gt;5&sigma; 
   

#### PR validation:

Tested with test beam data and workflow 77 in `16_0_0_pre1` with:

```runTheMatrix.py -w standard --ibeos -l 77```


FYI @lourda @cramonal @yulunmiao @IzaakWN @stahlleiton 