### PR TITLE
Implement a `GenericCloner` test module based on an `edmplugin::PluginFactory`

### DIFF
--- a/DataFormats/Common/interface/AnyBuffer.h
+++ b/DataFormats/Common/interface/AnyBuffer.h
@@ -1,0 +1,74 @@
+#ifndef DataFormats_Common_interface_AnyBuffer_h
+#define DataFormats_Common_interface_AnyBuffer_h
+
+#include <type_traits>
+#include <typeinfo>
+#include <cstddef>
+
+#include <boost/container/small_vector.hpp>
+
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/TypeDemangler.h"
+
+namespace edm {
+
+  class AnyBuffer {
+  public:
+    AnyBuffer() = default;
+
+    template <typename T>
+    AnyBuffer(T const& t)
+      requires(std::is_trivially_copyable_v<T>)
+        : storage_(reinterpret_cast<std::byte const*>(&t), reinterpret_cast<std::byte const*>(&t) + sizeof(T)),
+          typeid_(&typeid(std::remove_cv_t<T>)) {}
+
+    template <typename T>
+    T& cast_to()
+      requires(std::is_trivially_copyable_v<T>)
+    {
+      if (empty()) {
+        throw edm::Exception(edm::errors::LogicError)
+            << "Attempt to read an object of type " << edm::typeDemangle(typeid(T).name())
+            << " from an empty AnyBuffer";
+      }
+      if (typeid(std::remove_cv_t<T>) != *typeid_) {
+        throw edm::Exception(edm::errors::LogicError)
+            << "Attempt to read an object of type " << edm::typeDemangle(typeid(T).name())
+            << " from an AnyBuffer holding an object of type " << edm::typeDemangle(typeid_->name());
+      }
+      return *reinterpret_cast<T*>(storage_.data());
+    }
+
+    template <typename T>
+    T const& cast_to() const
+      requires(std::is_trivially_copyable_v<T>)
+    {
+      if (empty()) {
+        throw edm::Exception(edm::errors::LogicError)
+            << "Attempt to read an object of type " << edm::typeDemangle(typeid(T).name())
+            << " from an empty AnyBuffer";
+      }
+      if (typeid(std::remove_cv_t<T>) != *typeid_) {
+        throw edm::Exception(edm::errors::LogicError)
+            << "Attempt to read an object of type " << edm::typeDemangle(typeid(T).name())
+            << " from an AnyBuffer holding an object of type " << edm::typeDemangle(typeid_->name());
+      }
+      return *reinterpret_cast<T const*>(storage_.data());
+    }
+
+    bool empty() const { return typeid_ == nullptr; }
+
+    std::byte* data() { return storage_.data(); }
+
+    std::byte const* data() const { return storage_.data(); }
+
+    size_t size_bytes() const { return storage_.size(); }
+
+  private:
+    boost::container::small_vector<std::byte, 32> storage_;  // arbitrary small vector size to fit AnyBuffer in 64 bytes
+    std::type_info const* typeid_ = nullptr;
+  };
+
+}  // namespace edm
+
+#endif  // DataFormats_Common_interface_AnyBuffer_h

--- a/DataFormats/Common/interface/TrivialCopyTraits.h
+++ b/DataFormats/Common/interface/TrivialCopyTraits.h
@@ -1,0 +1,142 @@
+#ifndef Dataformats_Common_interface_TrivialCopyTraits_h
+#define Dataformats_Common_interface_TrivialCopyTraits_h
+
+#include <cassert>
+#include <span>
+#include <type_traits>
+#include <vector>
+#include <string>
+
+namespace edm {
+
+  // This struct should be specialised for each type that can be safely memcpy'ed.
+  //
+  // The specialisation shall have two static methods
+  //
+  //   static std::vector<std::span<std::byte>> regions(T& object);
+  //   static std::vector<std::span<const std::byte>> regions(T const& object);
+  //
+  // that return a vector of address, size pairs. A type that supports this
+  // interface can be copied by doing a memcpy of all the address, size pairs from a
+  // source object to a destination object.
+  //
+  //
+  // A specialisation may implement the method properties(), which returns the
+  // properties of an existing object, which can be used to initialize a newly
+  // allocated copy of the object via the initialize() method.
+  //
+  //   using Properties = ...;
+  //   static Properties properties(T const& object);
+  //
+  // If properties() is not implemented, the initialize() method takes a single
+  // argument:
+  //
+  //   static void initialize(T& object);
+  //
+  // If properties() is implemented, the initialize() method should take as a
+  // second parameter a const reference to a Properties object:
+  //
+  //   static void initialize(T& object, Properties const& args);
+  //
+  //
+  // A specialisation can optionally provide a static method
+  //
+  //   static void finalize(T& object);
+  //
+  // If present, it should be called to restore the object invariants after a
+  // memcpy operation.
+  //
+
+  template <typename T>
+  struct TrivialCopyTraits;
+
+  // Checks if the properties method is defined
+  template <typename T>
+  concept HasTrivialCopyProperties = requires(T const& object) { TrivialCopyTraits<T>::properties(object); };
+
+  // Get the return type of properties(...), if it exists.
+  template <typename T>
+    requires HasTrivialCopyProperties<T>
+  using TrivialCopyProperties = decltype(TrivialCopyTraits<T>::properties(std::declval<T const&>()));
+
+  // Checks if the declaration of initialize(...) is consistent with the presence or absence of properties.
+  template <typename T>
+  concept HasValidInitialize =
+      // does not have properties(...) and initialize(object) takes a single argument
+      (not HasTrivialCopyProperties<T> && requires(T& object) { TrivialCopyTraits<T>::initialize(object); }) ||
+      // or does have properties(...) and initialize(object, props) takes two arguments
+      (HasTrivialCopyProperties<T> &&
+       requires(T& object, TrivialCopyProperties<T> props) { TrivialCopyTraits<T>::initialize(object, props); });
+
+  // Checks for const and non const memory regions
+  template <typename T>
+  concept HasRegions = requires(T& object, T const& const_object) {
+    TrivialCopyTraits<T>::regions(object);
+    TrivialCopyTraits<T>::regions(const_object);
+  };
+
+  // Checks if there is a valid specialisation of TrivialCopyTraits for a type T
+  template <typename T>
+  concept HasTrivialCopyTraits =
+      // Has memory regions declared
+      (HasRegions<T>) &&
+      // and has either no initialize(...) or a valid one
+      (not requires { &TrivialCopyTraits<T>::initialize; } || HasValidInitialize<T>);
+
+  // Checks if finalize(...) is defined
+  template <typename T>
+  concept HasTrivialCopyFinalize = requires(T& object) { edm::TrivialCopyTraits<T>::finalize(object); };
+
+  // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  // Specialisations for various types
+
+  // Specialisation for arithmetic types
+  template <typename T>
+    requires std::is_arithmetic_v<T>
+  struct TrivialCopyTraits<T> {
+    static std::vector<std::span<std::byte>> regions(T& object) {
+      return {{reinterpret_cast<std::byte*>(&object), sizeof(T)}};
+    }
+
+    static std::vector<std::span<const std::byte>> regions(T const& object) {
+      return {{reinterpret_cast<std::byte const*>(&object), sizeof(T)}};
+    }
+  };
+
+  // Specialisation for std::string
+  template <>
+  struct TrivialCopyTraits<std::string> {
+    using Properties = std::string::size_type;
+
+    static Properties properties(std::string const& object) { return object.size(); }
+    static void initialize(std::string& object, Properties const& size) { object.resize(size); }
+
+    static std::vector<std::span<std::byte>> regions(std::string& object) {
+      return {{reinterpret_cast<std::byte*>(object.data()), object.size() * sizeof(char)}};
+    }
+
+    static std::vector<std::span<const std::byte>> regions(std::string const& object) {
+      return {{reinterpret_cast<std::byte const*>(object.data()), object.size() * sizeof(char)}};
+    }
+  };
+
+  // Specialisation for vectors of arithmetic types
+  template <typename T>
+    requires(std::is_arithmetic_v<T> and not std::is_same_v<T, bool>)
+  struct TrivialCopyTraits<std::vector<T>> {
+    using Properties = std::vector<T>::size_type;
+
+    static Properties properties(std::vector<T> const& object) { return object.size(); }
+    static void initialize(std::vector<T>& object, Properties const& size) { object.resize(size); }
+
+    static std::vector<std::span<std::byte>> regions(std::vector<T>& object) {
+      return {{reinterpret_cast<std::byte*>(object.data()), object.size() * sizeof(T)}};
+    }
+
+    static std::vector<std::span<const std::byte>> regions(std::vector<T> const& object) {
+      return {{reinterpret_cast<std::byte const*>(object.data()), object.size() * sizeof(T)}};
+    }
+  };
+}  // namespace edm
+
+#endif  // Dataformats_Common_interface_TrivialCopyTraits_h

--- a/DataFormats/Common/interface/Wrapper.h
+++ b/DataFormats/Common/interface/Wrapper.h
@@ -17,7 +17,6 @@ Wrapper: A template wrapper around EDProducts to hold the product ID.
 #include <algorithm>
 #include <cassert>
 #include <memory>
-#include <string>
 #include <typeinfo>
 
 namespace edm {
@@ -38,6 +37,9 @@ namespace edm {
     T const* operator->() const { return product(); }
 
     T& bareProduct() { return obj; }
+    T const& bareProduct() const { return obj; }
+
+    void markAsPresent() { present = true; }
 
     //these are used by FWLite
     static std::type_info const& productTypeInfo() { return typeid(T); }
@@ -176,6 +178,7 @@ namespace edm {
       }
     };
   }  // namespace soa
+
   template <typename T>
   inline std::shared_ptr<edm::soa::TableExaminerBase> Wrapper<T>::tableExaminer_() const {
     return soa::MakeTableExaminer<T>::make(&obj);
@@ -185,4 +188,4 @@ namespace edm {
 
 #include "DataFormats/Common/interface/WrapperView.icc"
 
-#endif
+#endif  // DataFormats_Common_Wrapper_h

--- a/DataFormats/Common/test/test_catch2_TrivialCopyTraits.cpp
+++ b/DataFormats/Common/test/test_catch2_TrivialCopyTraits.cpp
@@ -1,0 +1,329 @@
+#include <catch.hpp>
+
+#include "DataFormats/Common/interface/TrivialCopyTraits.h"
+
+#include <cmath>
+#include <map>
+#include <type_traits>
+#include <vector>
+#include <numeric>
+#include <cstring>
+
+// Catch2 tests for TrivialCopyTraits
+//
+// This test file defines various types, and specializes TrivialCopyTraits for them.
+//
+// The following tests are performed:
+//
+// - TrivialCopyTraits specializations for int and double are correct. In
+// particular, their memory regions are correct.
+// - TrivialCopyTraits specialization for std::vector<float> is correct. In
+// particular, one can successfully initialize a vector from the properties of
+// another.
+// - A memcpy-able struct "S" can be copied correctly using its TrivialCopyTraits
+// specialization, and the method edm::TrivialCopyTraits<S>::finalize() works
+// correctly.
+// - It can be checked that there is no TrivialCopyTraits specialization for
+// std::map.
+// - A type "S2" whose specialization requires initialization but has no
+// properties can be copied correctly through the TrivialCopyTraits interface.
+// - Several bad TrivialCopyTraits specializations can be detected correctly at
+// compile time.
+//
+
+// --------------------------------------------------------------------------
+// Definitions of various types, and their TrivialCopyTraits specializations
+
+// A trivially copyable type and its nice TrivialCopyTraits specialization
+struct S {
+  S() = default;
+  S(std::string m, std::vector<float> v) : msg{std::move(m)}, vec{std::move(v)} { setVecSum(); }
+
+  std::string msg;
+  std::vector<float> vec;
+  float vec_sum = 0.0f;  // something that needs to be calculated after the copy is finished
+  void setVecSum() { vec_sum = std::accumulate(vec.begin(), vec.end(), 0.0f); }
+};
+
+template <>
+struct edm::TrivialCopyTraits<S> {
+  using Properties = std::array<size_t, 2>;  // {vec.size(), s.size()}
+
+  static Properties properties(S const& object) {
+    return std::array<size_t, 2>{{object.vec.size(), object.msg.size()}};
+  }
+
+  static void initialize(S& object, Properties const& sizes) {
+    object.vec.resize(sizes.at(0));
+    object.msg.resize(sizes.at(1));
+  }
+
+  static void finalize(S& object) { object.setVecSum(); }
+
+  static std::vector<std::span<std::byte>> regions(S& object) {
+    return {{reinterpret_cast<std::byte*>(object.msg.data()), object.msg.size()},
+            {reinterpret_cast<std::byte*>(object.vec.data()), object.vec.size() * sizeof(float)}};
+  }
+
+  static std::vector<std::span<const std::byte>> regions(S const& object) {
+    return {{reinterpret_cast<std::byte const*>(object.msg.data()), object.msg.size()},
+            {reinterpret_cast<std::byte const*>(object.vec.data()), object.vec.size() * sizeof(float)}};
+  }
+};
+
+// A type that does not have properties but requires initialization, and its valid
+// TrivialCopyTraits specialization
+struct S2 {
+  S2() { vec.resize(size); }
+
+  // vec requires initialization, but doesn't need properties because its size is
+  // fixed
+  const size_t size = 10;
+  std::vector<int> vec;
+};
+
+template <>
+struct edm::TrivialCopyTraits<S2> {
+  static void initialize(S2& object) { object.vec.resize(object.size); }
+
+  static std::vector<std::span<std::byte>> regions(S2& object) {
+    return {{reinterpret_cast<std::byte*>(object.vec.data()), object.vec.size() * sizeof(int)}};
+  }
+
+  static std::vector<std::span<const std::byte>> regions(S2 const& object) {
+    return {{reinterpret_cast<std::byte const*>(object.vec.data()), object.vec.size() * sizeof(int)}};
+  }
+};
+
+// A bad TrivialCopyTraits specialization, that is missing regions()
+struct S3 {
+  std::vector<int> vec;
+};
+
+template <>
+struct edm::TrivialCopyTraits<S3> {
+  static void initialize(S3& object) { object.vec.resize(10); }
+};
+
+// A bad TrivialCopyTraits specialization, with a non-valid initialize()
+struct S4 {
+  std::vector<int> data;
+};
+
+template <>
+struct edm::TrivialCopyTraits<S4> {
+  using Properties = size_t;
+
+  static Properties properties(S4 const& object) { return object.data.size(); }
+
+  // initialize should take two arguments; the object and its properties (size)
+  static void initialize(S4& object) { object.data.resize(5); }
+
+  static std::vector<std::span<std::byte>> regions(S4& object) {
+    return {{reinterpret_cast<std::byte*>(object.data.data()), object.data.size() * sizeof(int)}};
+  }
+
+  static std::vector<std::span<const std::byte>> regions(S4 const& object) {
+    return {{reinterpret_cast<std::byte const*>(object.data.data()), object.data.size() * sizeof(int)}};
+  }
+};
+
+// A bad TrivialCopyTraits specialization, missing only the const regions
+struct S5 {
+  int value;
+};
+
+template <>
+struct edm::TrivialCopyTraits<S5> {
+  static std::vector<std::span<std::byte>> regions(S5& object) {
+    return {{reinterpret_cast<std::byte*>(&object.value), sizeof(int)}};
+  }
+};
+
+// --------------------------------------------------------------------------
+// The tests
+
+TEST_CASE("test TrivialCopyTraits", "[TrivialCopyTraits]") {
+  SECTION("int") {
+    REQUIRE(edm::HasTrivialCopyTraits<int>);
+
+    auto checkInt = [](int v) {
+      // test non-const regions
+      auto regions = edm::TrivialCopyTraits<int>::regions(v);
+      REQUIRE(regions.size() == 1);
+      REQUIRE(regions[0].size() == sizeof(int));
+      REQUIRE(regions[0].data() == reinterpret_cast<std::byte*>(&v));
+
+      // test const regions
+      const int const_v = v;
+      auto const_regions = edm::TrivialCopyTraits<int>::regions(const_v);
+      REQUIRE(const_regions.size() == 1);
+      REQUIRE(const_regions[0].size() == sizeof(int));
+      REQUIRE(const_regions[0].data() == reinterpret_cast<const std::byte*>(&const_v));
+    };
+
+    checkInt(-1);
+    checkInt(42);
+    checkInt(std::numeric_limits<int>::max());
+    checkInt(std::numeric_limits<int>::min());
+  }
+
+  SECTION("double") {
+    REQUIRE(edm::HasTrivialCopyTraits<double>);
+
+    auto checkDouble = [](double v) {
+      // test non-const regions
+      auto regions = edm::TrivialCopyTraits<double>::regions(v);
+      REQUIRE(regions.size() == 1);
+      REQUIRE(regions[0].size() == sizeof(double));
+      REQUIRE(regions[0].data() == reinterpret_cast<std::byte*>(&v));
+
+      // test const regions
+      const double const_v = v;
+      auto const_regions = edm::TrivialCopyTraits<double>::regions(const_v);
+      REQUIRE(const_regions.size() == 1);
+      REQUIRE(const_regions[0].size() == sizeof(double));
+      REQUIRE(const_regions[0].data() == reinterpret_cast<const std::byte*>(&const_v));
+    };
+
+    checkDouble(-1.0);
+    checkDouble(std::sqrt(2.));
+    checkDouble(std::numeric_limits<double>::max());
+    checkDouble(std::numeric_limits<double>::min());
+    checkDouble(std::numeric_limits<double>::epsilon());
+  }
+
+  SECTION("std::vector<float>") {
+    using VectorType = std::vector<float>;
+
+    REQUIRE(edm::HasTrivialCopyTraits<VectorType>);
+    REQUIRE(edm::HasTrivialCopyProperties<VectorType>);
+    REQUIRE(edm::HasValidInitialize<VectorType>);
+
+    VectorType vec = {-5.5f, -3.3f, -1.1f, 4.4f, 8.8f};
+
+    // Test properties
+    auto vec_size = edm::TrivialCopyTraits<VectorType>::properties(vec);
+    REQUIRE(vec_size == 5);
+
+    // Test initialize
+    VectorType new_vec;
+    edm::TrivialCopyTraits<VectorType>::initialize(new_vec, vec_size);
+    REQUIRE(new_vec.size() == 5);
+
+    // Test non-const regions
+    auto regions = edm::TrivialCopyTraits<VectorType>::regions(vec);
+    REQUIRE(regions.size() == 1);
+    REQUIRE(regions[0].size() == vec.size() * sizeof(float));
+    REQUIRE(regions[0].data() == reinterpret_cast<std::byte*>(vec.data()));
+
+    // Test const regions
+    const VectorType const_vec = {1.1f, 2.2f, 3.3f, 4.4f, 5.5f};
+    auto const_regions = edm::TrivialCopyTraits<VectorType>::regions(const_vec);
+    REQUIRE(const_regions.size() == 1);
+    REQUIRE(const_regions[0].size() == const_vec.size() * sizeof(float));
+    REQUIRE(const_regions[0].data() == reinterpret_cast<const std::byte*>(const_vec.data()));
+  }
+
+  SECTION("memcpy-able struct") {
+    std::string test_msg = "hello!";
+    std::vector<float> test_vec = {-1.0f, 4.0f, 42.0f};
+    float test_vec_sum = std::accumulate(test_vec.begin(), test_vec.end(), 0.0f);
+
+    // initialize a memcpy-able struct s
+    REQUIRE(edm::HasTrivialCopyTraits<S>);
+    REQUIRE(edm::HasTrivialCopyProperties<S>);
+    REQUIRE(edm::HasValidInitialize<S>);
+    S s{test_msg, test_vec};
+
+    // initialize a clone of s
+    S s_clone;
+    edm::TrivialCopyTraits<S>::initialize(s_clone, edm::TrivialCopyTraits<S>::properties(s));
+
+    // Get memory regions
+    auto const s_regions = edm::TrivialCopyTraits<S>::regions(s);
+    auto s_clone_regions = edm::TrivialCopyTraits<S>::regions(s_clone);
+
+    REQUIRE(s_regions.size() == s_clone_regions.size());
+    REQUIRE(s_clone.msg.size() == s.msg.size());
+    REQUIRE(s_clone.vec.size() == s.vec.size());
+
+    for (size_t i = 0; i < s_regions.size(); ++i) {
+      // check that initialize worked, i.e. enough memory in s_clone has been made available to copy s into it
+      REQUIRE(s_regions.at(i).size_bytes() == s_clone_regions.at(i).size_bytes());
+
+      // do the copy
+      std::memcpy(s_clone_regions.at(i).data(), s_regions.at(i).data(), s_regions.at(i).size_bytes());
+    }
+
+    //s_clone.vec_sum has not been touched yet
+    REQUIRE(s_clone.vec_sum == 0.0f);
+
+    // finalize the clone, which should calculate vec_sum
+    edm::TrivialCopyTraits<S>::finalize(s_clone);
+
+    // check that the copy worked
+    REQUIRE(s_clone.vec == test_vec);
+    REQUIRE(s_clone.msg == test_msg);
+
+    // check that finalize worked
+    REQUIRE(s_clone.vec_sum == test_vec_sum);
+  }
+
+  SECTION("std::map<int,int>") {
+    using MapType = std::map<int, int>;
+
+    // there is no TrivialCopyTraits specialization for std::map (and there shouldn't be, since std::map is not trivially copyable)
+    static_assert(!edm::HasTrivialCopyTraits<MapType>);
+  }
+
+  SECTION("A valid specialization with initialize() but without properties()") {
+    REQUIRE(edm::HasTrivialCopyTraits<S2>);
+    REQUIRE(!edm::HasTrivialCopyProperties<S2>);
+    REQUIRE(edm::HasValidInitialize<S2>);
+
+    S2 s2;
+    // fill its member vector with some data
+    for (size_t i = 0; i < s2.vec.size(); ++i) {
+      s2.vec[i] = static_cast<int>(i * 10);
+    }
+
+    S2 s2_clone;
+    // initialize the clone (no properties required)
+    edm::TrivialCopyTraits<S2>::initialize(s2_clone);
+
+    // get memory regions
+    auto const s2_regions = edm::TrivialCopyTraits<S2>::regions(s2);
+    auto s2_clone_regions = edm::TrivialCopyTraits<S2>::regions(s2_clone);
+
+    // Only one memory region (the vector)
+    REQUIRE(s2_regions.size() == 1);
+    REQUIRE(s2_clone_regions.size() == 1);
+    REQUIRE(s2_regions[0].size_bytes() == s2_clone_regions[0].size_bytes());
+
+    // before the copy:
+    REQUIRE(s2_clone.vec != s2.vec);
+
+    // do the copy
+    std::memcpy(s2_clone_regions[0].data(), s2_regions[0].data(), s2_regions[0].size_bytes());
+
+    // and now,
+    REQUIRE(s2_clone.vec == s2.vec);
+  }
+
+  SECTION("Invalid specializations") {
+    // S3: Missing regions() method
+    static_assert(!edm::HasTrivialCopyTraits<S3>);
+    static_assert(!edm::HasRegions<S3>);
+
+    // S5: Missing just the const regions() overload
+    static_assert(!edm::HasTrivialCopyTraits<S5>);
+    static_assert(!edm::HasRegions<S5>);
+
+    // S4: Has properties, but the initialize() declaration takes only one
+    // argument.
+    static_assert(!edm::HasTrivialCopyTraits<S4>);
+    static_assert(edm::HasTrivialCopyProperties<S4>);
+    static_assert(!edm::HasValidInitialize<S4>);
+  }
+}

--- a/DataFormats/Portable/interface/PortableHostObject.h
+++ b/DataFormats/Portable/interface/PortableHostObject.h
@@ -7,6 +7,7 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "DataFormats/Common/interface/TrivialCopyTraits.h"
 #include "DataFormats/Common/interface/Uninitialized.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/host.h"
@@ -114,5 +115,29 @@ private:
   std::optional<Buffer> buffer_;  //!
   Product* product_;
 };
+
+// Specialize the TrivialCopyTraits for PortableHostObject
+namespace edm {
+
+  template <typename T>
+  struct TrivialCopyTraits<PortableHostObject<T>> {
+    // this specialisation requires a initialize() method, but does not need to pass any parameters to it
+    using Properties = void;
+
+    static void initialize(PortableHostObject<T>& object) {
+      // replace the default-constructed empty object with one where the buffer has been allocated in pageable system memory
+      object = PortableHostObject<T>(cms::alpakatools::host());
+    }
+
+    static std::vector<std::span<std::byte>> regions(PortableHostObject<T>& object) {
+      return {{reinterpret_cast<std::byte*>(object.data()), sizeof(T)}};
+    }
+
+    static std::vector<std::span<const std::byte>> regions(PortableHostObject<T> const& object) {
+      return {{reinterpret_cast<std::byte const*>(object.data()), sizeof(T)}};
+    }
+  };
+
+}  // namespace edm
 
 #endif  // DataFormats_Portable_interface_PortableHostObject_h

--- a/DataFormats/PortableTestObjects/plugins/BuildFile.xml
+++ b/DataFormats/PortableTestObjects/plugins/BuildFile.xml
@@ -1,0 +1,5 @@
+<library file="TrivialSerialisationPlugins.cc" name="DataFormatsPortableTestObjectsPlugins">
+  <use name="DataFormats/PortableTestObjects"/>
+  <use name="TrivialSerialisation/Common"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/DataFormats/PortableTestObjects/plugins/TrivialSerialisationPlugins.cc
+++ b/DataFormats/PortableTestObjects/plugins/TrivialSerialisationPlugins.cc
@@ -1,0 +1,19 @@
+#include "DataFormats/Portable/interface/PortableHostObject.h"
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "TrivialSerialisation/Common/interface/SerialiserFactory.h"
+#include "DataFormats/PortableTestObjects/interface/TestSoA.h"
+#include "DataFormats/PortableTestObjects/interface/TestStruct.h"
+
+DEFINE_TRIVIAL_SERIALISER_PLUGIN(PortableHostObject<portabletest::TestStruct>);
+
+using PortableHostCollectionTestSoALayout = PortableHostCollection<portabletest::TestSoALayout<128, false>>;
+DEFINE_TRIVIAL_SERIALISER_PLUGIN(PortableHostCollectionTestSoALayout);
+
+using PortableHostMultiCollectionTestSoALayout2 =
+    PortableHostMultiCollection<portabletest::TestSoALayout<128, false>, portabletest::TestSoALayout2<128, false>>;
+DEFINE_TRIVIAL_SERIALISER_PLUGIN(PortableHostMultiCollectionTestSoALayout2);
+
+using PortableHostMultiCollectionTestSoALayout3 = PortableHostMultiCollection<portabletest::TestSoALayout<128, false>,
+                                                                              portabletest::TestSoALayout2<128, false>,
+                                                                              portabletest::TestSoALayout3<128, false>>;
+DEFINE_TRIVIAL_SERIALISER_PLUGIN(PortableHostMultiCollectionTestSoALayout3);

--- a/DataFormats/PortableTestObjects/test/BuildFile.xml
+++ b/DataFormats/PortableTestObjects/test/BuildFile.xml
@@ -2,3 +2,5 @@
   <use name="DataFormats/PortableTestObjects"/>
   <use name="HeterogeneousCore/AlpakaInterface"/>
 </bin>
+
+<test name="TestDataFormatsPortableTestObjectsGenericCloner" command="cmsRun ${LOCALTOP}/src/DataFormats/PortableTestObjects/test/testGenericCloner_cfg.py"/>

--- a/DataFormats/PortableTestObjects/test/testGenericCloner_cfg.py
+++ b/DataFormats/PortableTestObjects/test/testGenericCloner_cfg.py
@@ -1,0 +1,45 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.INFO.limit = 10000000
+
+process.options.numberOfThreads = 1
+process.options.numberOfStreams = 1
+
+process.source = cms.Source("EmptySource")
+process.maxEvents.input = 10
+
+
+
+#produce, clone and validate a portable object, a portable collection, and some portable multicollections
+process.load('Configuration.StandardSequences.Accelerators_cff')
+process.load('HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi')
+
+process.producePortableObjects = cms.EDProducer('alpaka_serial_sync::TestAlpakaProducer',
+    size = cms.int32(42),
+    size2 = cms.int32(33),
+    size3 = cms.int32(61),
+    alpaka = cms.untracked.PSet(
+        backend = cms.untracked.string("") #"serial_sync", "cuda_async", "rocm_async"
+    )
+)
+
+process.clonePortableObjects = cms.EDProducer("edmtest::GenericCloner",
+    eventProducts = cms.vstring("producePortableObjects"),
+    verbose = cms.untracked.bool(True)
+)
+
+process.validatePortableCollections = cms.EDAnalyzer('TestAlpakaAnalyzer',
+    source = cms.InputTag('clonePortableObjects')
+)
+
+process.validatePortableObject = cms.EDAnalyzer('TestAlpakaObjectAnalyzer',
+    source = cms.InputTag('clonePortableObjects')
+)
+
+process.taskSoA = cms.Task(process.producePortableObjects, process.clonePortableObjects)
+
+process.pathSoA = cms.Path(process.validatePortableCollections + process.validatePortableObject, process.taskSoA)
+

--- a/DataFormats/StdDictionaries/plugins/BuildFile.xml
+++ b/DataFormats/StdDictionaries/plugins/BuildFile.xml
@@ -1,0 +1,6 @@
+<library file="TrivialSerialisationPlugins.cc" name="DataFormatsStdDictionariesTrivialSerialisationPlugins">
+  <use name="DataFormats/Common"/>
+  <use name="FWCore/PluginManager"/>
+  <use name="TrivialSerialisation/Common"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/DataFormats/StdDictionaries/plugins/TrivialSerialisationPlugins.cc
+++ b/DataFormats/StdDictionaries/plugins/TrivialSerialisationPlugins.cc
@@ -1,0 +1,8 @@
+#include "TrivialSerialisation/Common/interface/SerialiserFactory.h"
+
+DEFINE_TRIVIAL_SERIALISER_PLUGIN(int);
+
+DEFINE_TRIVIAL_SERIALISER_PLUGIN(unsigned short);
+
+using basic_string = std::basic_string<char, std::char_traits<char>>;
+DEFINE_TRIVIAL_SERIALISER_PLUGIN(basic_string);

--- a/FWCore/Framework/interface/WrapperBaseHandle.h
+++ b/FWCore/Framework/interface/WrapperBaseHandle.h
@@ -1,0 +1,119 @@
+#ifndef FWCore_Framework_interface_WrapperBaseHandle_h
+#define FWCore_Framework_interface_WrapperBaseHandle_h
+/*
+ Description: Allows interaction with data in the Event without actually using the C++ class
+
+ Usage:
+    The Handle<WrapperBase> allows one to get data back from the edm::Event as an edm::Wrappter<T>
+  via a polymorphic pointer of type edm::WrapperBase, instead of as the actual C++ class type.
+
+  // make a handle to hold an instance of MyClass
+  edm::Handle<edm::WrapperBase> handle(typeid(MyClass));
+  event.getByToken(token, handle);
+
+  // handle.product() returns a polymorphic pointer of type edm::WrapperBase to the underlying
+  // edm::Wrapper<MyClass>
+  assert(handle.product()->dynamicTypeInfo() == typeid(MyClass));
+  edm::Wrapper<MyClass> const* wrapper = dynamic_cast<edm::Wrapper<MyClass> const*>(handle.product());
+*/
+
+// c++ include files
+#include <memory>
+#include <string>
+
+// CMSSW include files
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/WrapperBase.h"
+#include "DataFormats/Provenance/interface/ProductID.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/TypeID.h"
+
+// forward declarations
+namespace edm {
+
+  class Provenance;
+
+  template <>
+  class Handle<WrapperBase> {
+  public:
+    explicit Handle(std::type_info const& type) : type_(type), product_(nullptr), prov_(nullptr) {}
+
+    explicit Handle(TypeID type) : type_(type), product_(nullptr), prov_(nullptr) {
+      if (not type_) {
+        throw Exception(errors::NotFound, "Handle<WrapperBase> given an invalid type.");
+      }
+    }
+
+    Handle(WrapperBase const* product, Provenance const* prov)
+        : type_(product->dynamicTypeInfo()), product_(product), prov_(prov) {
+      assert(product_);
+      assert(prov_);
+    }
+
+    // Reimplement the interface of HandleBase
+
+    void clear() {
+      product_ = nullptr;
+      prov_ = nullptr;
+      whyFailedFactory_ = nullptr;
+    }
+
+    bool isValid() const { return nullptr != product_ and nullptr != prov_; }
+
+    bool failedToGet() const { return bool(whyFailedFactory_); }
+
+    Provenance const* provenance() const { return prov_; }
+
+    ProductID id() const { return prov_->productID(); }
+
+    std::shared_ptr<cms::Exception> whyFailed() const {
+      if (whyFailedFactory_.get()) {
+        return whyFailedFactory_->make();
+      }
+      return std::shared_ptr<cms::Exception>();
+    }
+
+    std::shared_ptr<HandleExceptionFactory const> const& whyFailedFactory() const { return whyFailedFactory_; }
+
+    explicit operator bool() const { return isValid(); }
+
+    bool operator!() const { return not isValid(); }
+
+    // Reimplement the interface of Handle<T>
+
+    WrapperBase const* product() const {
+      if (this->failedToGet()) {
+        whyFailedFactory_->make()->raise();
+      }
+      return product_;
+    }
+
+    WrapperBase const* operator->() const { return this->product(); }
+    WrapperBase const& operator*() const { return *(this->product()); }
+
+    // Additional methods
+
+    TypeID const& type() const { return type_; }
+
+    void setWhyFailedFactory(std::shared_ptr<HandleExceptionFactory const> const& iWhyFailed) {
+      whyFailedFactory_ = iWhyFailed;
+    }
+
+  private:
+    TypeID type_;
+    WrapperBase const* product_;
+    Provenance const* prov_;
+    std::shared_ptr<HandleExceptionFactory const> whyFailedFactory_;
+  };
+
+  // Specialize convert_handle for Handle<WrapperBase>
+  void convert_handle(BasicHandle&& orig, Handle<WrapperBase>& result);
+
+  // Specialize the Event's getByToken method to work with a Handle<WrapperBase>
+  template <>
+  bool Event::getByToken<WrapperBase>(EDGetToken token, Handle<WrapperBase>& result) const;
+
+}  // namespace edm
+
+#endif  // FWCore_Framework_interface_WrapperBaseHandle_h

--- a/FWCore/Framework/interface/WrapperBaseOrphanHandle.h
+++ b/FWCore/Framework/interface/WrapperBaseOrphanHandle.h
@@ -1,0 +1,80 @@
+#ifndef FWCore_Framework_interface_WrapperBaseOrphanHandle_h
+#define FWCore_Framework_interface_WrapperBaseOrphanHandle_h
+
+// c++ include files
+#include <memory>
+#include <typeinfo>
+
+// CMSSW include files
+#include "DataFormats/Common/interface/OrphanHandle.h"
+#include "DataFormats/Common/interface/WrapperBase.h"
+#include "DataFormats/Provenance/interface/ProductID.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/TypeID.h"
+
+// forward declarations
+namespace edm {
+
+  template <>
+  class OrphanHandle<WrapperBase> {
+  public:
+    OrphanHandle() : product_(nullptr), id_() {}
+
+    OrphanHandle(WrapperBase const* prod, ProductID const& id) : product_(prod), id_(id) { assert(product_); }
+
+    // Reimplement the interface of OrphanHandleBase
+
+    void clear() { product_ = nullptr; }
+
+    bool isValid() const { return nullptr != product_; }
+
+    ProductID id() const { return id_; }
+
+    // Reimplement the interface of OrphanHandle
+
+    WrapperBase const* product() const { return product_; }
+
+    WrapperBase const* operator->() const { return this->product(); }
+    WrapperBase const& operator*() const { return *(this->product()); }
+
+  private:
+    WrapperBase const* product_;
+    ProductID id_;
+  };
+
+  // specialise Event::putImpl for WrapperBase
+  template <>
+  inline OrphanHandle<WrapperBase> Event::putImpl(EDPutToken::value_type index, std::unique_ptr<WrapperBase> product) {
+    assert(index < putProducts().size());
+
+    // move the wrapped product into the event
+    putProducts()[index] = std::move(product);
+
+    // construct and return a handle to the product
+    WrapperBase const* prod = putProducts()[index].get();
+    ProductID const& prodID = provRecorder_.getProductID(index);
+    return OrphanHandle<WrapperBase>(prod, prodID);
+  }
+
+  // specialise Event::put for WrapperBase
+  template <>
+  inline OrphanHandle<WrapperBase> Event::put(EDPutToken token, std::unique_ptr<WrapperBase> product) {
+    if (UNLIKELY(product.get() == nullptr)) {  // null pointer is illegal
+      TypeID typeID(typeid(WrapperBase));
+      principal_get_adapter_detail::throwOnPutOfNullProduct("Event", typeID, provRecorder_.productInstanceLabel(token));
+    }
+    std::type_info const& type = product->dynamicTypeInfo();
+    if (UNLIKELY(token.isUninitialized())) {
+      principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", type);
+    }
+    TypeID const& expected = provRecorder_.getTypeIDForPutTokenIndex(token.index());
+    if (UNLIKELY(expected != TypeID{type})) {
+      principal_get_adapter_detail::throwOnPutOfWrongType(type, expected);
+    }
+
+    return putImpl(token.index(), std::move(product));
+  }
+
+}  // namespace edm
+
+#endif  // FWCore_Framework_interface_WrapperBaseOrphanHandle_h

--- a/FWCore/Framework/src/WrapperBaseHandle.cc
+++ b/FWCore/Framework/src/WrapperBaseHandle.cc
@@ -1,0 +1,47 @@
+// CMSSW include files
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/WrapperBase.h"
+#include "DataFormats/Provenance/interface/Provenance.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/WrapperBaseHandle.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/TypeDemangler.h"
+#include "FWCore/Utilities/interface/TypeID.h"
+
+namespace edm {
+
+  // Specialize the convert_handle free function for Handle<WrapperBase>
+  void convert_handle(BasicHandle&& handle, Handle<WrapperBase>& result) {
+    if (handle.failedToGet()) {
+      result.setWhyFailedFactory(handle.whyFailedFactory());
+      return;
+    }
+
+    WrapperBase const* wrapper = handle.wrapper();
+    if (wrapper == nullptr) {
+      throw Exception(errors::InvalidReference, "NullPointer") << "edm::BasicHandle has null pointer to Wrapper";
+    }
+
+    if (TypeID(wrapper->dynamicTypeInfo()) != result.type()) {
+      throw Exception(errors::LogicError) << "WrapperBase asked for " << typeDemangle(result.type().name())
+                                          << " but was given a " << typeDemangle(wrapper->dynamicTypeInfo().name());
+    }
+
+    // Move the handle into result
+    result = Handle<WrapperBase>(wrapper, handle.provenance());
+  }
+
+  // Specialize the Event::getByToken method for Handle<WrapperBase>
+  template <>
+  bool Event::getByToken<WrapperBase>(EDGetToken token, Handle<WrapperBase>& result) const {
+    result.clear();
+    BasicHandle bh = provRecorder_.getByToken_(result.type(), PRODUCT_TYPE, token, moduleCallingContext_);
+    convert_handle(std::move(bh), result);  // throws on conversion error
+    if (UNLIKELY(result.failedToGet())) {
+      return false;
+    }
+    addToGotBranchIDs(*result.provenance());
+    return true;
+  }
+
+}  // namespace edm

--- a/FWCore/TestModules/plugins/BuildFile.xml
+++ b/FWCore/TestModules/plugins/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="DataFormats/Provenance"/>
+<use name="TrivialSerialisation/Common"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>

--- a/FWCore/TestModules/plugins/GenericCloner.cc
+++ b/FWCore/TestModules/plugins/GenericCloner.cc
@@ -1,0 +1,227 @@
+/*
+ * This EDProducer will clone all the event products declared by its configuration, using their ROOT dictionaries.
+ *
+ * The products can be specified either as module labels (e.g. "<module label>") or as branch names (e.g.
+ * "<product type>_<module label>_<instance name>_<process name>").
+ *
+ * If a module label is used, no underscore ("_") must be present; this module will clone all the products produced by
+ * that module, including those produced by the Transformer functionality (such as the implicitly copied-to-host
+ * products in case of Alpaka-based modules).
+ * If a branch name is used, all four fields must be present, separated by underscores; this module will clone only on
+ * the matching product(s).
+ *
+ * Glob expressions ("?" and "*") are supported in module labels and within the individual fields of branch names,
+ * similar to an OutputModule's "keep" statements.
+ * Use "*" to clone all products.
+ *
+ * For example, in the case of Alpaka-based modules running on a device, using
+ *
+ *   eventProducts = cms.untracked.vstring( "module" )
+ *
+ * will cause "module" to run, along with automatic copy of its device products to the host, and will attempt to clone
+ * all device and host products.
+ * To clone only the host product, the branch can be specified explicitly with
+ *
+ *   eventProducts = cms.untracked.vstring( "HostProductType_module_*_*" )
+ *
+ * .
+ */
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <TBufferFile.h>
+
+#include "DataFormats/Provenance/interface/ProductDescription.h"
+#include "DataFormats/Provenance/interface/ProductNamePattern.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/WrapperBaseHandle.h"
+#include "FWCore/Framework/interface/WrapperBaseOrphanHandle.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterDescriptionNode.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Reflection/interface/ObjectWithDict.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "TrivialSerialisation/Common/interface/SerialiserFactory.h"
+#include "TrivialSerialisation/Common/interface/TrivialSerialiserBase.h"
+
+namespace edmtest {
+
+  class GenericCloner : public edm::global::EDProducer<> {
+  public:
+    explicit GenericCloner(edm::ParameterSet const&);
+    ~GenericCloner() override = default;
+
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    struct Entry {
+      edm::TypeWithDict objectType_;
+      edm::TypeWithDict wrappedType_;
+      edm::EDGetToken getToken_;
+      edm::EDPutToken putToken_;
+    };
+
+    std::vector<edm::ProductNamePattern> eventPatterns_;
+    std::vector<Entry> eventProducts_;
+    std::string label_;
+    bool verbose_;
+  };
+
+  GenericCloner::GenericCloner(edm::ParameterSet const& config)
+      : eventPatterns_(edm::productPatterns(config.getParameter<std::vector<std::string>>("eventProducts"))),
+        label_(config.getParameter<std::string>("@module_label")),
+        verbose_(config.getUntrackedParameter<bool>("verbose")) {
+    eventProducts_.reserve(eventPatterns_.size());
+
+    callWhenNewProductsRegistered([this](edm::ProductDescription const& product) {
+      static const std::string_view kPathStatus("edm::PathStatus");
+      static const std::string_view kEndPathStatus("edm::EndPathStatus");
+
+      switch (product.branchType()) {
+        case edm::InEvent:
+          if (product.className() == kPathStatus or product.className() == kEndPathStatus) {
+            return;
+          }
+          for (auto& pattern : eventPatterns_) {
+            if (pattern.match(product)) {
+              // check that the product is not transient
+              if (product.transient()) {
+                edm::LogWarning("GenericCloner") << "Event product " << product.branchName() << " of type "
+                                                 << product.unwrappedType() << " is transient, will not be cloned.";
+                break;
+              }
+              if (verbose_) {
+                edm::LogInfo("GenericCloner")
+                    << "will clone Event product " << product.branchName() << " of type " << product.unwrappedType();
+              }
+              Entry entry;
+              entry.objectType_ = product.unwrappedType();
+              entry.wrappedType_ = product.wrappedType();
+              // TODO move this to EDConsumerBase::consumes() ?
+              entry.getToken_ = this->consumes(
+                  edm::TypeToGet{product.unwrappedTypeID(), edm::PRODUCT_TYPE},
+                  edm::InputTag{product.moduleLabel(), product.productInstanceName(), product.processName()});
+              entry.putToken_ = this->produces(product.unwrappedTypeID(), product.productInstanceName());
+              eventProducts_.emplace_back(std::move(entry));
+              break;
+            }
+          }
+          break;
+
+        case edm::InLumi:
+        case edm::InRun:
+        case edm::InProcess:
+          // lumi, run and process products are not supported
+          break;
+
+        default:
+          throw edm::Exception(edm::errors::LogicError)
+              << "Unexpected product type " << product.branchType() << "\nPlease contact a Framework developer.";
+      }
+    });
+  }
+
+  void GenericCloner::produce(edm::StreamID /*unused*/, edm::Event& event, edm::EventSetup const& /*unused*/) const {
+    for (auto& product : eventProducts_) {
+      edm::Handle<edm::WrapperBase> handle(product.objectType_.typeInfo());
+
+      event.getByToken(product.getToken_, handle);
+
+      // create a "wrapper", whose wrapped product will be cloned into "clone"
+      edm::WrapperBase const* wrapper = handle.product();
+      std::unique_ptr<edm::WrapperBase> clone(static_cast<edm::WrapperBase*>(product.wrappedType_.getClass()->New()));
+
+      // get a "serialiser" object from the plugin factory. This object can
+      // produce, for a given type, both const and mutable TrivialSerialisers.
+      std::unique_ptr<ngt::SerialiserBase> serialiser{
+          ngt::SerialiserFactory::get()->tryToCreate(product.objectType_.typeInfo().name())};
+
+      if (serialiser) {
+        // if a serialiser is found for this type, initialise a const and a mutable TrivialSerialisers.
+        auto reader = serialiser->initialize(*wrapper);
+        auto writer = serialiser->initialize(*clone);
+
+        edm::LogInfo("GenericCloner") << "A specialization of TrivialCopyTraits exists for type "
+                                      << product.objectType_.typeInfo().name() << ".";
+        // initialise the clone, if the type requires it
+        writer->initialize(reader->parameters());
+
+        // copy the source regions to the target
+        auto targets = writer->regions();
+        auto sources = reader->regions();
+
+        assert(sources.size() == targets.size());
+        for (size_t i = 0; i < sources.size(); ++i) {
+          assert(sources[i].data() != nullptr);
+          assert(targets[i].data() != nullptr);
+          assert(targets[i].size_bytes() == sources[i].size_bytes());
+          std::memcpy(targets[i].data(), sources[i].data(), sources[i].size_bytes());
+        }
+
+        // finalize the clone after the trivialCopy, if the type requires it
+        writer->trivialCopyFinalize();
+      } else {
+        edm::LogInfo("GenericCloner") << "No specialization of TrivialCopyTraits found for type "
+                                      << product.objectType_.typeInfo().name()
+                                      << ", falling back to the ROOT serialization.";
+        // Use ROOT-based serialisation and deserialisation to clone the wrapped object.
+
+        // write the wrapper into a TBuffer
+        TBufferFile buffer(TBuffer::kWrite);
+        product.wrappedType_.getClass()->Streamer(const_cast<edm::WrapperBase*>(wrapper), buffer);
+
+        // read back a copy of the product form the TBuffer
+        buffer.SetReadMode();
+        buffer.SetBufferOffset(0);
+        product.wrappedType_.getClass()->Streamer(clone.get(), buffer);
+      }
+
+      // move the wrapper into the Event
+      event.put(product.putToken_, std::move(clone));
+    }
+  }
+
+  void GenericCloner::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    descriptions.setComment(
+        R"(This EDProducer will clone all the event products declared by its configuration, using their ROOT dictionaries.
+
+The products can be specified either as module labels (e.g. "<module label>") or as branch names (e.g. "<product type>_<module label>_<instance name>_<process name>").
+If a module label is used, no underscore ("_") must be present; this module will clone all the products produced by that module, including those produced by the Transformer functionality (such as the implicitly copied-to-host products in case of Alpaka-based modules).
+If a branch name is used, all four fields must be present, separated by underscores; this module will clone only on the matching product(s).
+
+Glob expressions ("?" and "*") are supported in module labels and within the individual fields of branch names, similar to an OutputModule's "keep" statements.
+Use "*" to clone all products.
+
+For example, in the case of Alpaka-based modules running on a device, using
+
+    eventProducts = cms.untracked.vstring( "module" )
+
+will cause "module" to run, along with automatic copy of its device products to the host, and will attempt to clone all device and host products.
+To clone only the host product, the branch can be specified explicitly with
+
+    eventProducts = cms.untracked.vstring( "HostProductType_module_*_*" )
+
+.)");
+
+    edm::ParameterSetDescription desc;
+    desc.add<std::vector<std::string>>("eventProducts", {})
+        ->setComment("List of modules or branches whose event products will be cloned.");
+    desc.addUntracked<bool>("verbose", false)
+        ->setComment("Print the branch names of the products that will be cloned.");
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+}  // namespace edmtest
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(edmtest::GenericCloner);

--- a/FWCore/TestModules/test/BuildFile.xml
+++ b/FWCore/TestModules/test/BuildFile.xml
@@ -1,1 +1,2 @@
 <test name="TestFWCoreModulesEventIDValidator" command="cmsRun ${LOCALTOP}/src/FWCore/TestModules/test/testEventIDValidator_cfg.py"/>
+<test name="TestFWCoreModulesGenericCloner" command="cmsRun ${LOCALTOP}/src/FWCore/TestModules/test/testGenericCloner_cfg.py"/>

--- a/FWCore/TestModules/test/testGenericCloner_cfg.py
+++ b/FWCore/TestModules/test/testGenericCloner_cfg.py
@@ -1,0 +1,87 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.INFO.limit = 10000000
+
+process.options.numberOfThreads = 1
+process.options.numberOfStreams = 1
+
+process.source = cms.Source("EmptySource")
+process.maxEvents.input = 10
+
+# produce, clone and validate products of type int
+process.produceInt = cms.EDProducer("edmtest::GlobalIntProducer",
+    value = cms.int32(42)
+)
+
+process.cloneInt = cms.EDProducer("edmtest::GenericCloner",
+    eventProducts = cms.vstring("produceInt"),
+    verbose = cms.untracked.bool(True)
+)
+
+process.validateInt = cms.EDAnalyzer("edmtest::GlobalIntAnalyzer",
+    source = cms.InputTag("cloneInt"),
+    expected = cms.int32(42)
+)
+
+process.taskInt = cms.Task(process.produceInt, process.cloneInt)
+
+process.pathInt = cms.Path(process.validateInt, process.taskInt)
+
+# produce, clone and validate products of type std::string
+process.produceString = cms.EDProducer("edmtest::GlobalStringProducer",
+    value = cms.string("Hello world")
+)
+
+process.cloneString = cms.EDProducer("edmtest::GenericCloner",
+    eventProducts = cms.vstring("produceString"),
+    verbose = cms.untracked.bool(True)
+)
+
+process.validateString = cms.EDAnalyzer("edmtest::GlobalStringAnalyzer",
+    source = cms.InputTag("cloneString"),
+    expected = cms.string("Hello world")
+)
+
+process.taskString = cms.Task(process.produceString, process.cloneString)
+
+process.pathString = cms.Path(process.validateString, process.taskString)
+
+# produce, clone and validate products of type edm::EventID
+process.eventIds = cms.EDProducer("edmtest::EventIDProducer")
+
+process.cloneIdsByLabel = cms.EDProducer("edmtest::GenericCloner",
+    eventProducts = cms.vstring("eventIds"),
+    verbose = cms.untracked.bool(True)
+)
+
+process.cloneIdsByBranch = cms.EDProducer("edmtest::GenericCloner",
+    eventProducts = cms.vstring("*_eventIds__TEST"),
+    verbose = cms.untracked.bool(True)
+)
+
+process.validateIdsByLabel = cms.EDAnalyzer("edmtest::EventIDValidator",
+    source = cms.untracked.InputTag('cloneIdsByLabel')
+)
+
+process.validateIdsByBranch = cms.EDAnalyzer("edmtest::EventIDValidator",
+    source = cms.untracked.InputTag('cloneIdsByBranch')
+)
+
+process.taskIds = cms.Task(process.eventIds, process.cloneIdsByLabel, process.cloneIdsByBranch)
+
+process.pathIds = cms.Path(process.validateIdsByLabel + process.validateIdsByBranch, process.taskIds)
+
+# will not clone a transient product
+process.produceTransient = cms.EDProducer("TransientIntProducer",
+    ivalue = cms.int32(22)
+)
+
+process.cloneTransient = cms.EDProducer("edmtest::GenericCloner",
+    eventProducts = cms.vstring("produceTransient"),
+    verbose = cms.untracked.bool(True)
+)
+
+process.pathTransient = cms.Path(process.produceTransient + process.cloneTransient)

--- a/TrivialSerialisation/Common/BuildFile.xml
+++ b/TrivialSerialisation/Common/BuildFile.xml
@@ -1,0 +1,7 @@
+<use name="DataFormats/Common"/>
+<use name="FWCore/Framework"/>
+<use name="FWCore/PluginManager"/>
+<use name="FWCore/Utilities"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/TrivialSerialisation/Common/interface/Serialiser.h
+++ b/TrivialSerialisation/Common/interface/Serialiser.h
@@ -1,0 +1,24 @@
+#ifndef TrivialSerialisation_Common_Serialiser_h
+#define TrivialSerialisation_Common_Serialiser_h
+
+#include "TrivialSerialisation/Common/interface/SerialiserBase.h"
+#include "TrivialSerialisation/Common/interface/TrivialSerialiser.h"
+
+namespace ngt {
+  template <typename T>
+  class Serialiser : public SerialiserBase {
+  public:
+    std::unique_ptr<TrivialSerialiserBase> initialize(edm::WrapperBase& wrapper) override {
+      edm::Wrapper<T>& w = dynamic_cast<edm::Wrapper<T>&>(wrapper);
+      w.markAsPresent();
+      return std::make_unique<TrivialSerialiser<T>>(w);
+    }
+    std::unique_ptr<const TrivialSerialiserBase> initialize(edm::WrapperBase const& wrapper) override {
+      edm::Wrapper<T> const& w = dynamic_cast<edm::Wrapper<T> const&>(wrapper);
+      return std::make_unique<const TrivialSerialiser<T>>(w);
+    }
+  };
+
+}  // namespace ngt
+
+#endif  // TrivialSerialisation_Common_Serialiser_h

--- a/TrivialSerialisation/Common/interface/SerialiserBase.h
+++ b/TrivialSerialisation/Common/interface/SerialiserBase.h
@@ -1,0 +1,19 @@
+#ifndef TrivialSerialisation_Common_SerialiserBase_h
+#define TrivialSerialisation_Common_SerialiserBase_h
+
+#include "DataFormats/Common/interface/WrapperBase.h"
+#include "TrivialSerialisation/Common/interface/TrivialSerialiserBase.h"
+
+namespace ngt {
+  class SerialiserBase {
+  public:
+    SerialiserBase() = default;
+
+    virtual std::unique_ptr<TrivialSerialiserBase> initialize(edm::WrapperBase& wrapper) = 0;
+    virtual std::unique_ptr<const TrivialSerialiserBase> initialize(const edm::WrapperBase& wrapper) = 0;
+
+    virtual ~SerialiserBase() = default;
+  };
+}  // namespace ngt
+
+#endif  // TrivialSerialisation_Common_SerialiserBase_h

--- a/TrivialSerialisation/Common/interface/SerialiserFactory.h
+++ b/TrivialSerialisation/Common/interface/SerialiserFactory.h
@@ -1,0 +1,16 @@
+#ifndef TrivialSerialisation_src_SerialiserFactory_h
+#define TrivialSerialisation_src_SerialiserFactory_h
+
+#include "FWCore/PluginManager/interface/PluginFactory.h"
+#include "TrivialSerialisation/Common/interface/Serialiser.h"
+#include "TrivialSerialisation/Common/interface/SerialiserBase.h"
+
+namespace ngt {
+  using SerialiserFactory = edmplugin::PluginFactory<ngt::SerialiserBase*()>;
+}
+
+// Helper macro to define Serialiser plugins
+#define DEFINE_TRIVIAL_SERIALISER_PLUGIN(TYPE) \
+  DEFINE_EDM_PLUGIN(ngt::SerialiserFactory, ngt::Serialiser<TYPE>, typeid(TYPE).name())
+
+#endif  // TrivialSerialisation_src_SerialiserFactory_h

--- a/TrivialSerialisation/Common/interface/TrivialSerialiser.h
+++ b/TrivialSerialisation/Common/interface/TrivialSerialiser.h
@@ -1,0 +1,113 @@
+#ifndef TrivialSerialisation_Common_TrivialSerialiser_h
+#define TrivialSerialisation_Common_TrivialSerialiser_h
+
+#include <cstdio>
+#include <vector>
+#include <span>
+#include <cstddef>
+#include <type_traits>
+
+#include "DataFormats/Common/interface/AnyBuffer.h"
+#include "DataFormats/Common/interface/TrivialCopyTraits.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "TrivialSerialisation/Common/interface/TrivialSerialiserBase.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/TypeDemangler.h"
+
+// defines all methods of TrivialSerialiserBase
+
+namespace ngt {
+
+  template <typename T>
+  class TrivialSerialiser : public TrivialSerialiserBase {
+    static_assert(edm::HasTrivialCopyTraits<T>, "No specialization of TrivialCopyTraits found for type T");
+
+  public:
+    using WrapperType = edm::Wrapper<T>;
+    TrivialSerialiser(WrapperType const& obj) : TrivialSerialiserBase(&obj) {}
+
+    void initialize(edm::AnyBuffer const& args) override;
+    edm::AnyBuffer parameters() const override;
+    std::vector<std::span<const std::byte>> regions() const override;
+    std::vector<std::span<std::byte>> regions() override;
+    void trivialCopyFinalize() override;
+
+  private:
+    const T& getWrappedObj_() const {
+      WrapperType const& w = static_cast<WrapperType const&>(*getWrapperBasePtr());
+      if (not w.isPresent()) {
+        throw edm::Exception(edm::errors::LogicError) << "Attempt to access an empty Wrapper";
+      }
+      // return *w.product();
+      return w.bareProduct();
+    }
+
+    T& getWrappedObj_() {
+      WrapperType& w = const_cast<WrapperType&>(static_cast<WrapperType const&>(*getWrapperBasePtr()));
+      if (not w.isPresent()) {
+        throw edm::Exception(edm::errors::LogicError) << "Attempt to access an empty Wrapper";
+      }
+      return w.bareProduct();
+    }
+  };
+
+  template <typename T>
+  void TrivialSerialiser<T>::initialize(edm::AnyBuffer const& args) {
+    if constexpr (not edm::HasValidInitialize<T>) {
+      // If there is no valid initialize(), there shouldn't be present
+      static_assert(not edm::HasTrivialCopyProperties<T>);
+      return;
+    } else {
+      auto& w = static_cast<WrapperType const&>(*getWrapperBasePtr());
+      // Each serialiser stores a pointer to the wrapper used to initialize it as "const edm::WrapperBase*"
+      // For serialisers used for writing, that were initialized with a non-const wrapper, the const_cast below is safe because the wrapper was originally non-const.
+      // For serialisers used for reading, that were initialized with a const wrapper, this function cannot be called because it is not marked as const.
+      if constexpr (not edm::HasTrivialCopyProperties<T>) {
+        // if T has no TrivialCopyProperties, call initialize() without any additional arguments
+        edm::TrivialCopyTraits<T>::initialize(const_cast<WrapperType&>(w).bareProduct());
+      } else {
+        // if T has TrivialCopyProperties, cast args to Properties and pass it as an additional argument to initialize()
+        edm::TrivialCopyTraits<T>::initialize(const_cast<WrapperType&>(w).bareProduct(),
+                                              args.cast_to<edm::TrivialCopyProperties<T>>());
+      }
+    }
+  }
+
+  template <typename T>
+  inline edm::AnyBuffer TrivialSerialiser<T>::parameters() const {
+    const T& obj = getWrappedObj_();
+    if constexpr (not edm::HasTrivialCopyProperties<T>) {
+      // if edm::TrivialCopyTraits<T>::properties(...) is not declared, do not call it.
+      return {};
+    } else {
+      // if edm::TrivialCopyTraits<T>::properties(...) is declared, call it and wrap the result in an edm::AnyBuffer
+      edm::TrivialCopyProperties<T> p = edm::TrivialCopyTraits<T>::properties(obj);
+      return edm::AnyBuffer(p);
+    }
+  }
+
+  template <typename T>
+  inline std::vector<std::span<const std::byte>> TrivialSerialiser<T>::regions() const {
+    static_assert(edm::HasRegions<T>);
+    const T& obj = getWrappedObj_();
+    return edm::TrivialCopyTraits<T>::regions(obj);
+  }
+
+  template <typename T>
+  inline std::vector<std::span<std::byte>> TrivialSerialiser<T>::regions() {
+    static_assert(edm::HasRegions<T>);
+    T& obj = getWrappedObj_();
+    return edm::TrivialCopyTraits<T>::regions(obj);
+  }
+
+  template <typename T>
+  inline void TrivialSerialiser<T>::trivialCopyFinalize() {
+    if constexpr (edm::HasTrivialCopyFinalize<T>) {
+      const T& obj = getWrappedObj_();
+      edm::TrivialCopyTraits<T>::finalize(obj);
+    }
+  }
+
+}  // namespace ngt
+
+#endif  // TrivialSerialisation_Common_TrivialSerialiser_h

--- a/TrivialSerialisation/Common/interface/TrivialSerialiserBase.h
+++ b/TrivialSerialisation/Common/interface/TrivialSerialiserBase.h
@@ -1,0 +1,31 @@
+#ifndef TrivialSerialisation_Common_interface_TrivialSerialiserBase_h
+#define TrivialSerialisation_Common_interface_TrivialSerialiserBase_h
+
+#include "DataFormats/Common/interface/AnyBuffer.h"
+#include "DataFormats/Common/interface/WrapperBase.h"
+
+#include <span>
+#include <vector>
+
+namespace ngt {
+  class TrivialSerialiserBase {
+  public:
+    TrivialSerialiserBase(const edm::WrapperBase* ptr) : ptr_(ptr) {}
+
+    virtual void initialize(edm::AnyBuffer const& args) = 0;
+    virtual edm::AnyBuffer parameters() const = 0;
+    virtual std::vector<std::span<const std::byte>> regions() const = 0;
+    virtual std::vector<std::span<std::byte>> regions() = 0;
+    virtual void trivialCopyFinalize() = 0;
+
+    const edm::WrapperBase* getWrapperBasePtr() const { return ptr_; }
+
+    virtual ~TrivialSerialiserBase() = default;
+
+  private:
+    const edm::WrapperBase* ptr_;
+  };
+
+}  // namespace ngt
+
+#endif  // TrivialSerialisation_Common_interface_TrivialSerialiserBase_h

--- a/TrivialSerialisation/Common/src/SerialiserFactory.cc
+++ b/TrivialSerialisation/Common/src/SerialiserFactory.cc
@@ -1,0 +1,3 @@
+#include "TrivialSerialisation/Common/interface/SerialiserFactory.h"
+
+EDM_REGISTER_PLUGINFACTORY(ngt::SerialiserFactory, "SerialiserFactory");


### PR DESCRIPTION
#### PR description:

Implements an alternative to #47504 based on a plugin factory. This PR and #47504 provide the same functionality:

> Specialise `Handle` and `OrphanHandle` for `WrapperBase`: this lets users produce and consume collections via their wrapper, using their run time type information (_e.g._ type name, type id, ...) instead of the compile time types. Implement integration test for these specialisations.
> 
> Introduce a `TrivialCopyTraits` structure, that should be specialised for types that can be safely `memcpy`ed, without requiring a full ROOT streamer de/serialisation. Specialise the `TrivialCopyTraits` for arithmetic types and `vector`s of arithmetic types, and all `PortableObject` and `PortableCollection` types.
> 
> Implement `edmtest::GenericCloner`: this `EDProducer` will consume and clone all the event products declared by its configuration; a direct `memcpy` will be used for types that support the `TrivialCopyTraits` interface; the ROOT dictionaries will be used to serialise and deserialise the other types.


The plugin factory returns `TrivialSerialiserSource` objects for a given type. `TrivialSerialiser`s can then be initialized by calling `TrivialSerialiserSource::initialize` with a `WrapperBase` object. The initialized TrivialSerialiser is `const` or non `const` depending on the constness of the `WrapperBase` object used to initialize it. A pointer to this `WrapperBase` object is stored in `TrivialSerialiserBase` as `const edm::WrapperBase*`.

#### PR validation:

Various unit tests have been included:
- `FWCore/TestModules/test/testGenericCloner_cfg.py`: produce, clone and validate products of type `int`, `std::string`, and `edm::EventID`. does *not* clone a transient `cms.int32()`.
- `DataFormats/Portable/test/testGenericCloner_cfg.py`: Produce, clone and validate a portable object, a portable collection, and some portable multicollections.
- `DataFormats/Common/test/test_catch2_TrivialCopyTraits.cpp`: Implements a `TrivialCopyTraits`  specialization for a simple struct. Tests the methods of `TrivialCopyTraits` with the types `int`, `double`, `std::vector<float>`, and the struct.


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->
