### PR TITLE
[ROOT6_X] Fix deprecated-literal-operator warning

### DIFF
--- a/DataFormats/Math/interface/angle_units.h
+++ b/DataFormats/Math/interface/angle_units.h
@@ -11,11 +11,11 @@ namespace angle_units {
   namespace operators {
 
     // Angle
-    constexpr double operator"" _pi(long double x) { return double(x) * M_PI; }
-    constexpr double operator"" _pi(unsigned long long int x) { return double(x) * M_PI; }
-    constexpr double operator"" _deg(long double deg) { return deg / degPerRad; }
-    constexpr double operator"" _deg(unsigned long long int deg) { return deg / degPerRad; }
-    constexpr double operator"" _rad(long double rad) { return rad * 1.; }
+    constexpr double operator""_pi(long double x) { return double(x) * M_PI; }
+    constexpr double operator""_pi(unsigned long long int x) { return double(x) * M_PI; }
+    constexpr double operator""_deg(long double deg) { return deg / degPerRad; }
+    constexpr double operator""_deg(unsigned long long int deg) { return deg / degPerRad; }
+    constexpr double operator""_rad(long double rad) { return rad * 1.; }
 
     template <class NumType>
     inline constexpr NumType convertRadToDeg(NumType radians)  // Radians -> degrees


### PR DESCRIPTION
#### PR description:

In CMSSW_16_0_ROOT6_X_2025-10-13-1600, gcc emits a warning of type `deprecated-literal-operator`: `warning: identifier '<identifier>' preceded by whitespace in a literal operator declaration is deprecated`. 

In older C++ standards, both of these were valid:

```cpp
operator""_pi     // no space
operator"" _pi    // space before suffix
```

But starting with C++23, the spaced form (`operator"" _pi`) is deprecated — the standard now prefers the no-space form.

#### PR validation:

Bot tests