### PR TITLE
MTD Validation: add optional histograms for ETL

### DIFF
--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -3118,7 +3118,7 @@ void MtdTracksValidation::fillDescriptions(edm::ConfigurationDescriptions& descr
   edm::ParameterSetDescription desc;
 
   desc.add<std::string>("folder", "MTD/Tracks");
-  desc.add<bool>("optionalPlots", true);
+  desc.add<bool>("optionalPlots", false);
   desc.add<edm::InputTag>("inputTagG", edm::InputTag("generalTracks"));
   desc.add<edm::InputTag>("inputTagT", edm::InputTag("trackExtenderWithMTD"));
   desc.add<edm::InputTag>("inputTagV", edm::InputTag("offlinePrimaryVertices4D"));

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -263,6 +263,11 @@ private:
   MonitorElement* meTrackResTotvsMVAQual_;
   MonitorElement* meTrackPullTotvsMVAQual_;
 
+  MonitorElement* meTrackResEtl_;
+  MonitorElement* meTrackResEtlLowEta_;
+  MonitorElement* meTrackResEtlHighEta_;
+  MonitorElement* meTrackResEtlvsEta_;
+  
   MonitorElement* meTrackMatchedTPPtTotLV_;
   MonitorElement* meTrackMatchedTPEtaTotLV_;
   MonitorElement* meExtraPtMtd_;
@@ -1413,6 +1418,12 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             meTrackPullTot_->Fill(pullT);
             meTrackResTotvsMVAQual_->Fill(mtdQualMVA[trackref], dT);
             meTrackPullTotvsMVAQual_->Fill(mtdQualMVA[trackref], pullT);
+	    if ( isETL ){
+	      meTrackResEtl_->Fill(dT);
+	      meTrackResEtlvsEta_->Fill(std::abs(trackGen.eta()), dT);
+	      if (std::abs(trackGen.eta()) < 2.1 )  meTrackResEtlLowEta_->Fill(dT); // reduced coverage 1.7 disks option
+	      if (std::abs(trackGen.eta()) >= 2.1 )  meTrackResEtlHighEta_->Fill(dT); // full coverage 1.7 disks option
+	    }
           }
         }  // time res and time pull
       }  // TP matching
@@ -2609,6 +2620,25 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       5.,
       "s");
 
+  meTrackResEtl_ = ibook.book1D(
+      "TrackResEtl", "t_{rec} - t_{sim} for LV associated tracks matched to TP (ETL); t_{rec} - t_{sim} [ns] ", 120, -0.15, 0.15);
+  meTrackResEtlLowEta_ = ibook.book1D(
+      "TrackResEtlLowEta", "t_{rec} - t_{sim} for LV associated tracks matched to TP (ETL, low eta); t_{rec} - t_{sim} [ns] ", 120, -0.15, 0.15);
+
+  meTrackResEtlHighEta_ = ibook.book1D(
+      "TrackResEtlHighEta", "t_{rec} - t_{sim} for LV associated tracks matched to TP (ETL, high eta); t_{rec} - t_{sim} [ns] ", 120, -0.15, 0.15);
+
+  meTrackResEtlvsEta_ = ibook.bookProfile(
+      "TrackResEtlvsEta",
+      "t_{rec} - t_{sim} for LV associated tracks matched to TP vs eta; eta; t_{rec} - t_{sim} [ns] ",
+      100,
+      1.5,
+      3.0,
+      -0.15,
+      0.15,
+      "s");
+
+  
   meExtraPhiAtBTL_ = ibook.book1D(
       "ExtraPhiAtBTL", "Phi at BTL surface of extrapolated tracks associated to LV; phi [deg]", 720, -180., 180.);
   meExtraPhiAtBTLmatched_ =

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -3118,7 +3118,7 @@ void MtdTracksValidation::fillDescriptions(edm::ConfigurationDescriptions& descr
   edm::ParameterSetDescription desc;
 
   desc.add<std::string>("folder", "MTD/Tracks");
-  desc.add<bool>("optionalPlots", false);
+  desc.add<bool>("optionalPlots", true);
   desc.add<edm::InputTag>("inputTagG", edm::InputTag("generalTracks"));
   desc.add<edm::InputTag>("inputTagT", edm::InputTag("trackExtenderWithMTD"));
   desc.add<edm::InputTag>("inputTagV", edm::InputTag("offlinePrimaryVertices4D"));

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -2631,7 +2631,7 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meTrackResEtlvsEta_ = ibook.bookProfile(
       "TrackResEtlvsEta",
       "t_{rec} - t_{sim} for LV associated tracks matched to TP vs eta; eta; t_{rec} - t_{sim} [ns] ",
-      100,
+      30,
       1.5,
       3.0,
       -0.15,

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -267,7 +267,7 @@ private:
   MonitorElement* meTrackResEtlLowEta_;
   MonitorElement* meTrackResEtlHighEta_;
   MonitorElement* meTrackResEtlvsEta_;
-  
+
   MonitorElement* meTrackMatchedTPPtTotLV_;
   MonitorElement* meTrackMatchedTPEtaTotLV_;
   MonitorElement* meExtraPtMtd_;
@@ -1418,12 +1418,16 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             meTrackPullTot_->Fill(pullT);
             meTrackResTotvsMVAQual_->Fill(mtdQualMVA[trackref], dT);
             meTrackPullTotvsMVAQual_->Fill(mtdQualMVA[trackref], pullT);
-	    if ( isETL ){
-	      meTrackResEtl_->Fill(dT);
-	      meTrackResEtlvsEta_->Fill(std::abs(trackGen.eta()), dT);
-	      if (std::abs(trackGen.eta()) < 2.1 )  meTrackResEtlLowEta_->Fill(dT); // reduced coverage 1.7 disks option
-	      if (std::abs(trackGen.eta()) >= 2.1 )  meTrackResEtlHighEta_->Fill(dT); // full coverage 1.7 disks option
-	    }
+            if (optionalPlots_) {
+              if (isETL) {
+                meTrackResEtl_->Fill(dT);
+                meTrackResEtlvsEta_->Fill(std::abs(trackGen.eta()), dT);
+                if (std::abs(trackGen.eta()) < 2.1)
+                  meTrackResEtlLowEta_->Fill(dT);  // reduced coverage 1.7 disks option
+                if (std::abs(trackGen.eta()) >= 2.1)
+                  meTrackResEtlHighEta_->Fill(dT);  // full coverage 1.7 disks option
+              }
+            }
           }
         }  // time res and time pull
       }  // TP matching
@@ -2620,25 +2624,36 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       5.,
       "s");
 
-  meTrackResEtl_ = ibook.book1D(
-      "TrackResEtl", "t_{rec} - t_{sim} for LV associated tracks matched to TP (ETL); t_{rec} - t_{sim} [ns] ", 120, -0.15, 0.15);
-  meTrackResEtlLowEta_ = ibook.book1D(
-      "TrackResEtlLowEta", "t_{rec} - t_{sim} for LV associated tracks matched to TP (ETL, low eta); t_{rec} - t_{sim} [ns] ", 120, -0.15, 0.15);
+  if (optionalPlots_) {
+    meTrackResEtl_ =
+        ibook.book1D("TrackResEtl",
+                     "t_{rec} - t_{sim} for LV associated tracks matched to TP (ETL); t_{rec} - t_{sim} [ns] ",
+                     120,
+                     -0.15,
+                     0.15);
+    meTrackResEtlLowEta_ =
+        ibook.book1D("TrackResEtlLowEta",
+                     "t_{rec} - t_{sim} for LV associated tracks matched to TP (ETL, low eta); t_{rec} - t_{sim} [ns] ",
+                     120,
+                     -0.15,
+                     0.15);
+    meTrackResEtlHighEta_ = ibook.book1D(
+        "TrackResEtlHighEta",
+        "t_{rec} - t_{sim} for LV associated tracks matched to TP (ETL, high eta); t_{rec} - t_{sim} [ns] ",
+        120,
+        -0.15,
+        0.15);
+    meTrackResEtlvsEta_ = ibook.bookProfile(
+        "TrackResEtlvsEta",
+        "t_{rec} - t_{sim} for LV associated tracks matched to TP vs eta; eta; t_{rec} - t_{sim} [ns] ",
+        30,
+        1.5,
+        3.0,
+        -0.15,
+        0.15,
+        "s");
+  }
 
-  meTrackResEtlHighEta_ = ibook.book1D(
-      "TrackResEtlHighEta", "t_{rec} - t_{sim} for LV associated tracks matched to TP (ETL, high eta); t_{rec} - t_{sim} [ns] ", 120, -0.15, 0.15);
-
-  meTrackResEtlvsEta_ = ibook.bookProfile(
-      "TrackResEtlvsEta",
-      "t_{rec} - t_{sim} for LV associated tracks matched to TP vs eta; eta; t_{rec} - t_{sim} [ns] ",
-      30,
-      1.5,
-      3.0,
-      -0.15,
-      0.15,
-      "s");
-
-  
   meExtraPhiAtBTL_ = ibook.book1D(
       "ExtraPhiAtBTL", "Phi at BTL surface of extrapolated tracks associated to LV; phi [deg]", 720, -180., 180.);
   meExtraPhiAtBTLmatched_ =

--- a/Validation/MtdValidation/plugins/Primary4DVertexHarvester.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexHarvester.cc
@@ -90,7 +90,7 @@ private:
   MonitorElement* meEndcapKPurity_;
   MonitorElement* meEndcapPPurity_;
 
-  // Histograms to study PID efficiency and purity 
+  // Histograms to study PID efficiency and purity
   MonitorElement* meEndcapTruePi_Eta_[2];
   MonitorElement* meEndcapTrueK_Eta_[2];
   MonitorElement* meEndcapTrueP_Eta_[2];
@@ -118,7 +118,6 @@ private:
   MonitorElement* meEndcapPiPurity_Eta_[2];
   MonitorElement* meEndcapKPurity_Eta_[2];
   MonitorElement* meEndcapPPurity_Eta_[2];
-  
 };
 
 // ------------ constructor and destructor --------------
@@ -265,7 +264,6 @@ void Primary4DVertexHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGe
   MonitorElement* meEndcapTrueKAsP = igetter.get(folder_ + "EndcapTrueKAsP");
   MonitorElement* meEndcapTruePAsP = igetter.get(folder_ + "EndcapTruePAsP");
 
-
   // additional plots for PID study in different eta regions of ETL
   MonitorElement* meEndcapTruePiNoPID_Eta[2];
   MonitorElement* meEndcapTrueKNoPID_Eta[2];
@@ -286,7 +284,7 @@ void Primary4DVertexHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGe
   meEndcapTruePiAsPi_Eta[1] = igetter.get(folder_ + "EndcapTruePiAsPi_highEta");
   meEndcapTrueKAsPi_Eta[1] = igetter.get(folder_ + "EndcapTrueKAsPi_highEta");
   meEndcapTruePAsPi_Eta[1] = igetter.get(folder_ + "EndcapTruePAsPi_highEta");
-  
+
   MonitorElement* meEndcapTruePiAsK_Eta[2];
   MonitorElement* meEndcapTrueKAsK_Eta[2];
   MonitorElement* meEndcapTruePAsK_Eta[2];
@@ -307,22 +305,18 @@ void Primary4DVertexHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGe
   meEndcapTrueKAsP_Eta[1] = igetter.get(folder_ + "EndcapTrueKAsP_highEta");
   meEndcapTruePAsP_Eta[1] = igetter.get(folder_ + "EndcapTruePAsP_highEta");
 
-
   if (!meBarrelPIDp || !meEndcapPIDp || !meBarrelTruePiNoPID || !meBarrelTrueKNoPID || !meBarrelTruePNoPID ||
       !meEndcapTruePiNoPID || !meEndcapTrueKNoPID || !meEndcapTruePNoPID || !meBarrelTruePiAsPi || !meBarrelTrueKAsPi ||
       !meBarrelTruePAsPi || !meEndcapTruePiAsPi || !meEndcapTrueKAsPi || !meEndcapTruePAsPi || !meBarrelTruePiAsK ||
       !meBarrelTrueKAsK || !meBarrelTruePAsK || !meEndcapTruePiAsK || !meEndcapTrueKAsK || !meEndcapTruePAsK ||
       !meBarrelTruePiAsP || !meBarrelTrueKAsP || !meBarrelTruePAsP || !meEndcapTruePiAsP || !meEndcapTrueKAsP ||
-      !meEndcapTruePAsP ||
-      !meEndcapTruePiNoPID_Eta[0] || !meEndcapTrueKNoPID_Eta[0] || !meEndcapTruePNoPID_Eta[0] ||
+      !meEndcapTruePAsP || !meEndcapTruePiNoPID_Eta[0] || !meEndcapTrueKNoPID_Eta[0] || !meEndcapTruePNoPID_Eta[0] ||
       !meEndcapTruePiNoPID_Eta[1] || !meEndcapTrueKNoPID_Eta[1] || !meEndcapTruePNoPID_Eta[1] ||
       !meEndcapTruePiAsPi_Eta[0] || !meEndcapTrueKAsPi_Eta[0] || !meEndcapTruePAsPi_Eta[0] ||
       !meEndcapTruePiAsPi_Eta[1] || !meEndcapTrueKAsPi_Eta[1] || !meEndcapTruePAsPi_Eta[1] ||
-      !meEndcapTruePiAsK_Eta[0] || !meEndcapTrueKAsK_Eta[0] || !meEndcapTruePAsK_Eta[0] ||
-      !meEndcapTruePiAsK_Eta[1] || !meEndcapTrueKAsK_Eta[1] || !meEndcapTruePAsK_Eta[1] ||
-      !meEndcapTruePiAsP_Eta[0] || !meEndcapTrueKAsP_Eta[0] || !meEndcapTruePAsP_Eta[0] ||
-      !meEndcapTruePiAsP_Eta[1] || !meEndcapTrueKAsP_Eta[1] || !meEndcapTruePAsP_Eta[1] 
-      ) {
+      !meEndcapTruePiAsK_Eta[0] || !meEndcapTrueKAsK_Eta[0] || !meEndcapTruePAsK_Eta[0] || !meEndcapTruePiAsK_Eta[1] ||
+      !meEndcapTrueKAsK_Eta[1] || !meEndcapTruePAsK_Eta[1] || !meEndcapTruePiAsP_Eta[0] || !meEndcapTrueKAsP_Eta[0] ||
+      !meEndcapTruePAsP_Eta[0] || !meEndcapTruePiAsP_Eta[1] || !meEndcapTrueKAsP_Eta[1] || !meEndcapTruePAsP_Eta[1]) {
     edm::LogWarning("Primary4DVertexHarvester") << "PID Monitoring histograms not found!" << std::endl;
     return;
   }
@@ -699,52 +693,51 @@ void Primary4DVertexHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGe
   meEndcapPPurity_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meEndcapTruePAsP, meEndcapAsP_, meEndcapPPurity_);
 
-
   // additional plots to study PID in regions of ETL
-  for (int i = 0; i < 2; i++){ 
+  for (int i = 0; i < 2; i++) {
     std::string suffix = "lowEta";
-    if (i == 1) suffix = "highEta";
+    if (i == 1)
+      suffix = "highEta";
 
-    meEndcapTruePi_Eta_[i] = ibook.book1D(Form("EndcapTruePi_%s",suffix.c_str()),
-					  "Endcap True Pi P;P [GeV]",
-					  meEndcapPIDp->getNbinsX(),
-					  meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
-					  meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapTruePi_Eta_[i] = ibook.book1D(Form("EndcapTruePi_%s", suffix.c_str()),
+                                          "Endcap True Pi P;P [GeV]",
+                                          meEndcapPIDp->getNbinsX(),
+                                          meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                          meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
     incrementME(meEndcapTruePi_Eta_[i], meEndcapTruePiAsPi_Eta[i]);
     incrementME(meEndcapTruePi_Eta_[i], meEndcapTruePiAsK_Eta[i]);
     incrementME(meEndcapTruePi_Eta_[i], meEndcapTruePiAsP_Eta[i]);
     incrementME(meEndcapTruePi_Eta_[i], meEndcapTruePiNoPID_Eta[i]);
 
-    meEndcapTrueK_Eta_[i] = ibook.book1D(Form("EndcapTrueK_%s",suffix.c_str()),
-					 "Endcap True K P;P [GeV]",
-					 meEndcapPIDp->getNbinsX(),
-					 meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
-					 meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapTrueK_Eta_[i] = ibook.book1D(Form("EndcapTrueK_%s", suffix.c_str()),
+                                         "Endcap True K P;P [GeV]",
+                                         meEndcapPIDp->getNbinsX(),
+                                         meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                         meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
     incrementME(meEndcapTrueK_Eta_[i], meEndcapTrueKAsPi_Eta[i]);
     incrementME(meEndcapTrueK_Eta_[i], meEndcapTrueKAsK_Eta[i]);
     incrementME(meEndcapTrueK_Eta_[i], meEndcapTrueKAsP_Eta[i]);
     incrementME(meEndcapTrueK_Eta_[i], meEndcapTrueKNoPID_Eta[i]);
-    
-    meEndcapTrueP_Eta_[i] = ibook.book1D(Form("EndcapTrueP_%s",suffix.c_str()),
-					 "Endcap True P P;P [GeV]",
-					 meEndcapPIDp->getNbinsX(),
-					 meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
-					 meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+
+    meEndcapTrueP_Eta_[i] = ibook.book1D(Form("EndcapTrueP_%s", suffix.c_str()),
+                                         "Endcap True P P;P [GeV]",
+                                         meEndcapPIDp->getNbinsX(),
+                                         meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                         meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
     incrementME(meEndcapTrueP_Eta_[i], meEndcapTruePAsPi_Eta[i]);
     incrementME(meEndcapTrueP_Eta_[i], meEndcapTruePAsK_Eta[i]);
     incrementME(meEndcapTrueP_Eta_[i], meEndcapTruePAsP_Eta[i]);
     incrementME(meEndcapTrueP_Eta_[i], meEndcapTruePNoPID_Eta[i]);
 
-
-    meEndcapPIDPiAsPiEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPiAsPiEff_%s",suffix.c_str()),
-					       "Endcap True pi as pi id. fraction VS P;P [GeV]",
-					       meEndcapPIDp->getNbinsX(),
-					       meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
-					       meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPIDPiAsPiEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPiAsPiEff_%s", suffix.c_str()),
+                                                "Endcap True pi as pi id. fraction VS P;P [GeV]",
+                                                meEndcapPIDp->getNbinsX(),
+                                                meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                                meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
     meEndcapPIDPiAsPiEff_Eta_[i]->getTH1()->SetMinimum(0.);
     computeEfficiency1D(meEndcapTruePiAsPi_Eta[i], meEndcapTruePi_Eta_[i], meEndcapPIDPiAsPiEff_Eta_[i]);
 
-    meEndcapPIDPiAsKEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPiAsKEff_%s",suffix.c_str()),
+    meEndcapPIDPiAsKEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPiAsKEff_%s", suffix.c_str()),
                                                "Endcap True pi as k id. fraction VS P;P [GeV]",
                                                meEndcapPIDp->getNbinsX(),
                                                meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
@@ -752,145 +745,140 @@ void Primary4DVertexHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGe
     meEndcapPIDPiAsKEff_Eta_[i]->getTH1()->SetMinimum(0.);
     computeEfficiency1D(meEndcapTruePiAsK_Eta[i], meEndcapTruePi_Eta_[i], meEndcapPIDPiAsKEff_Eta_[i]);
 
-    meEndcapPIDPiAsPEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPiAsPEff_%s",suffix.c_str()),
+    meEndcapPIDPiAsPEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPiAsPEff_%s", suffix.c_str()),
                                                "Endcap True pi as p id. fraction VS P;P [GeV]",
                                                meEndcapPIDp->getNbinsX(),
                                                meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
                                                meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
     meEndcapPIDPiAsPEff_Eta_[i]->getTH1()->SetMinimum(0.);
     computeEfficiency1D(meEndcapTruePiAsP_Eta[i], meEndcapTruePi_Eta_[i], meEndcapPIDPiAsPEff_Eta_[i]);
-    
-    meEndcapPIDPiNoPIDEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPiNoPIDEff_%s",suffix.c_str()),
-						 "Endcap True pi no PID id. fraction VS P;P [GeV]",
-						 meEndcapPIDp->getNbinsX(),
-						 meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
-						 meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+
+    meEndcapPIDPiNoPIDEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPiNoPIDEff_%s", suffix.c_str()),
+                                                 "Endcap True pi no PID id. fraction VS P;P [GeV]",
+                                                 meEndcapPIDp->getNbinsX(),
+                                                 meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                                 meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
     meEndcapPIDPiNoPIDEff_Eta_[i]->getTH1()->SetMinimum(0.);
     computeEfficiency1D(meEndcapTruePiNoPID_Eta[i], meEndcapTruePi_Eta_[i], meEndcapPIDPiNoPIDEff_Eta_[i]);
 
-
     //
-    meEndcapPIDKAsPiEff_Eta_[i] = ibook.book1D(Form("EndcapPIDKAsPiEff_%s",suffix.c_str()),
-					       "Endcap True k as pi id. fraction VS P;P [GeV]",
-					       meEndcapPIDp->getNbinsX(),
-					       meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
-					       meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPIDKAsPiEff_Eta_[i] = ibook.book1D(Form("EndcapPIDKAsPiEff_%s", suffix.c_str()),
+                                               "Endcap True k as pi id. fraction VS P;P [GeV]",
+                                               meEndcapPIDp->getNbinsX(),
+                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
     meEndcapPIDKAsPiEff_Eta_[i]->getTH1()->SetMinimum(0.);
     computeEfficiency1D(meEndcapTrueKAsPi_Eta[i], meEndcapTrueK_Eta_[i], meEndcapPIDKAsPiEff_Eta_[i]);
 
-    meEndcapPIDKAsKEff_Eta_[i] = ibook.book1D(Form("EndcapPIDKAsKEff_%s",suffix.c_str()),
-                                               "Endcap True k as k id. fraction VS P;P [GeV]",
-                                               meEndcapPIDp->getNbinsX(),
-                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
-                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPIDKAsKEff_Eta_[i] = ibook.book1D(Form("EndcapPIDKAsKEff_%s", suffix.c_str()),
+                                              "Endcap True k as k id. fraction VS P;P [GeV]",
+                                              meEndcapPIDp->getNbinsX(),
+                                              meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                              meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
     meEndcapPIDKAsKEff_Eta_[i]->getTH1()->SetMinimum(0.);
     computeEfficiency1D(meEndcapTrueKAsK_Eta[i], meEndcapTrueK_Eta_[i], meEndcapPIDKAsKEff_Eta_[i]);
 
-    meEndcapPIDKAsPEff_Eta_[i] = ibook.book1D(Form("EndcapPIDKAsPEff_%s",suffix.c_str()),
-                                               "Endcap True k as p id. fraction VS P;P [GeV]",
-                                               meEndcapPIDp->getNbinsX(),
-                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
-                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPIDKAsPEff_Eta_[i] = ibook.book1D(Form("EndcapPIDKAsPEff_%s", suffix.c_str()),
+                                              "Endcap True k as p id. fraction VS P;P [GeV]",
+                                              meEndcapPIDp->getNbinsX(),
+                                              meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                              meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
     meEndcapPIDKAsPEff_Eta_[i]->getTH1()->SetMinimum(0.);
     computeEfficiency1D(meEndcapTrueKAsP_Eta[i], meEndcapTrueK_Eta_[i], meEndcapPIDKAsPEff_Eta_[i]);
-    
-    meEndcapPIDKNoPIDEff_Eta_[i] = ibook.book1D(Form("EndcapPIDKNoPIDEff_%s",suffix.c_str()),
-						"Endcap True k no PID id. fraction VS P;P [GeV]",
-						meEndcapPIDp->getNbinsX(),
-						meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
-						meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+
+    meEndcapPIDKNoPIDEff_Eta_[i] = ibook.book1D(Form("EndcapPIDKNoPIDEff_%s", suffix.c_str()),
+                                                "Endcap True k no PID id. fraction VS P;P [GeV]",
+                                                meEndcapPIDp->getNbinsX(),
+                                                meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                                meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
     meEndcapPIDKNoPIDEff_Eta_[i]->getTH1()->SetMinimum(0.);
     computeEfficiency1D(meEndcapTrueKNoPID_Eta[i], meEndcapTrueK_Eta_[i], meEndcapPIDKNoPIDEff_Eta_[i]);
 
     //
-    meEndcapPIDPAsPiEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPAsPiEff_%s",suffix.c_str()),
-					       "Endcap True p as pi id. fraction VS P;P [GeV]",
-					       meEndcapPIDp->getNbinsX(),
-					       meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
-					       meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPIDPAsPiEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPAsPiEff_%s", suffix.c_str()),
+                                               "Endcap True p as pi id. fraction VS P;P [GeV]",
+                                               meEndcapPIDp->getNbinsX(),
+                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
     meEndcapPIDPAsPiEff_Eta_[i]->getTH1()->SetMinimum(0.);
     computeEfficiency1D(meEndcapTruePAsPi_Eta[i], meEndcapTrueP_Eta_[i], meEndcapPIDPAsPiEff_Eta_[i]);
 
-    meEndcapPIDPAsKEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPAsKEff_%s",suffix.c_str()),
-                                               "Endcap True p as k id. fraction VS P;P [GeV]",
-                                               meEndcapPIDp->getNbinsX(),
-                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
-                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPIDPAsKEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPAsKEff_%s", suffix.c_str()),
+                                              "Endcap True p as k id. fraction VS P;P [GeV]",
+                                              meEndcapPIDp->getNbinsX(),
+                                              meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                              meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
     meEndcapPIDPAsKEff_Eta_[i]->getTH1()->SetMinimum(0.);
     computeEfficiency1D(meEndcapTruePAsK_Eta[i], meEndcapTrueP_Eta_[i], meEndcapPIDPAsKEff_Eta_[i]);
 
-    meEndcapPIDPAsPEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPAsPEff_%s",suffix.c_str()),
-                                               "Endcap True p as p id. fraction VS P;P [GeV]",
-                                               meEndcapPIDp->getNbinsX(),
-                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
-                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPIDPAsPEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPAsPEff_%s", suffix.c_str()),
+                                              "Endcap True p as p id. fraction VS P;P [GeV]",
+                                              meEndcapPIDp->getNbinsX(),
+                                              meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                              meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
     meEndcapPIDPAsPEff_Eta_[i]->getTH1()->SetMinimum(0.);
     computeEfficiency1D(meEndcapTruePAsP_Eta[i], meEndcapTrueP_Eta_[i], meEndcapPIDPAsPEff_Eta_[i]);
-    
-    meEndcapPIDPNoPIDEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPNoPIDEff_%s",suffix.c_str()),
-						"Endcap True p no PID id. fraction VS P;P [GeV]",
-						meEndcapPIDp->getNbinsX(),
-						meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
-						meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+
+    meEndcapPIDPNoPIDEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPNoPIDEff_%s", suffix.c_str()),
+                                                "Endcap True p no PID id. fraction VS P;P [GeV]",
+                                                meEndcapPIDp->getNbinsX(),
+                                                meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                                meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
     meEndcapPIDPNoPIDEff_Eta_[i]->getTH1()->SetMinimum(0.);
     computeEfficiency1D(meEndcapTruePNoPID_Eta[i], meEndcapTrueP_Eta_[i], meEndcapPIDPNoPIDEff_Eta_[i]);
 
     // purity
     meEndcapAsPi_Eta_[i] = ibook.book1D(Form("EndcapAsPi_%s", suffix.c_str()),
-					"Endcap Identified Pi P;P [GeV]",
-					meEndcapPIDp->getNbinsX(),
-					meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
-					meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+                                        "Endcap Identified Pi P;P [GeV]",
+                                        meEndcapPIDp->getNbinsX(),
+                                        meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                        meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
     incrementME(meEndcapAsPi_Eta_[i], meEndcapTruePiAsPi_Eta[i]);
     incrementME(meEndcapAsPi_Eta_[i], meEndcapTrueKAsPi_Eta[i]);
     incrementME(meEndcapAsPi_Eta_[i], meEndcapTruePAsPi_Eta[i]);
 
-    meEndcapAsK_Eta_[i] = ibook.book1D(Form("EndcapAsK_%s",suffix.c_str()),
-					"Endcap Identified k P;P [GeV]",
-					meEndcapPIDp->getNbinsX(),
-					meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
-					meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapAsK_Eta_[i] = ibook.book1D(Form("EndcapAsK_%s", suffix.c_str()),
+                                       "Endcap Identified k P;P [GeV]",
+                                       meEndcapPIDp->getNbinsX(),
+                                       meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                       meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
     incrementME(meEndcapAsK_Eta_[i], meEndcapTruePiAsK_Eta[i]);
     incrementME(meEndcapAsK_Eta_[i], meEndcapTrueKAsK_Eta[i]);
     incrementME(meEndcapAsK_Eta_[i], meEndcapTruePAsK_Eta[i]);
 
-    meEndcapAsP_Eta_[i] = ibook.book1D(Form("EndcapAsP_%s",suffix.c_str()),
-					"Endcap Identified p P;P [GeV]",
-					meEndcapPIDp->getNbinsX(),
-					meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
-					meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapAsP_Eta_[i] = ibook.book1D(Form("EndcapAsP_%s", suffix.c_str()),
+                                       "Endcap Identified p P;P [GeV]",
+                                       meEndcapPIDp->getNbinsX(),
+                                       meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                       meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
     incrementME(meEndcapAsP_Eta_[i], meEndcapTruePiAsP_Eta[i]);
     incrementME(meEndcapAsP_Eta_[i], meEndcapTrueKAsP_Eta[i]);
     incrementME(meEndcapAsP_Eta_[i], meEndcapTruePAsP_Eta[i]);
-    
 
-    meEndcapPiPurity_Eta_[i] = ibook.book1D(Form("EndcapPiPurity_%s",suffix.c_str()),
-					    "Endcap pi id. fraction true pi VS P;P [GeV]",
-					    meEndcapPIDp->getNbinsX(),
-					    meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
-					    meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
-    meEndcapPiPurity_Eta_[i]->getTH1()->SetMinimum(0.);
-    computeEfficiency1D(meEndcapTruePiAsPi_Eta[i], meEndcapAsPi_Eta_[i], meEndcapPiPurity_Eta_[i]);
-    
-
-    meEndcapKPurity_Eta_[i] = ibook.book1D(Form("EndcapKPurity_%s",suffix.c_str()),
-                                            "Endcap k id. fraction true k VS P;P [GeV]",
+    meEndcapPiPurity_Eta_[i] = ibook.book1D(Form("EndcapPiPurity_%s", suffix.c_str()),
+                                            "Endcap pi id. fraction true pi VS P;P [GeV]",
                                             meEndcapPIDp->getNbinsX(),
                                             meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
                                             meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPiPurity_Eta_[i]->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEndcapTruePiAsPi_Eta[i], meEndcapAsPi_Eta_[i], meEndcapPiPurity_Eta_[i]);
+
+    meEndcapKPurity_Eta_[i] = ibook.book1D(Form("EndcapKPurity_%s", suffix.c_str()),
+                                           "Endcap k id. fraction true k VS P;P [GeV]",
+                                           meEndcapPIDp->getNbinsX(),
+                                           meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                           meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
     meEndcapKPurity_Eta_[i]->getTH1()->SetMinimum(0.);
     computeEfficiency1D(meEndcapTrueKAsK_Eta[i], meEndcapAsK_Eta_[i], meEndcapKPurity_Eta_[i]);
 
-    meEndcapPPurity_Eta_[i] = ibook.book1D(Form("EndcapPPurity_%s",suffix.c_str()),
-                                            "Endcap p id. fraction true p VS P;P [GeV]",
-                                            meEndcapPIDp->getNbinsX(),
-                                            meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
-                                            meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPPurity_Eta_[i] = ibook.book1D(Form("EndcapPPurity_%s", suffix.c_str()),
+                                           "Endcap p id. fraction true p VS P;P [GeV]",
+                                           meEndcapPIDp->getNbinsX(),
+                                           meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                           meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
     meEndcapPPurity_Eta_[i]->getTH1()->SetMinimum(0.);
     computeEfficiency1D(meEndcapTruePAsP_Eta[i], meEndcapAsP_Eta_[i], meEndcapPPurity_Eta_[i]);
   }
-
-  
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ----------

--- a/Validation/MtdValidation/plugins/Primary4DVertexHarvester.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexHarvester.cc
@@ -89,6 +89,36 @@ private:
   MonitorElement* meEndcapPiPurity_;
   MonitorElement* meEndcapKPurity_;
   MonitorElement* meEndcapPPurity_;
+
+  // Histograms to study PID efficiency and purity 
+  MonitorElement* meEndcapTruePi_Eta_[2];
+  MonitorElement* meEndcapTrueK_Eta_[2];
+  MonitorElement* meEndcapTrueP_Eta_[2];
+
+  MonitorElement* meEndcapAsPi_Eta_[2];
+  MonitorElement* meEndcapAsK_Eta_[2];
+  MonitorElement* meEndcapAsP_Eta_[2];
+  MonitorElement* meEndcapNoPID_Eta_[2];
+
+  MonitorElement* meEndcapPIDPiAsPiEff_Eta_[2];
+  MonitorElement* meEndcapPIDPiAsKEff_Eta_[2];
+  MonitorElement* meEndcapPIDPiAsPEff_Eta_[2];
+  MonitorElement* meEndcapPIDPiNoPIDEff_Eta_[2];
+
+  MonitorElement* meEndcapPIDKAsPiEff_Eta_[2];
+  MonitorElement* meEndcapPIDKAsKEff_Eta_[2];
+  MonitorElement* meEndcapPIDKAsPEff_Eta_[2];
+  MonitorElement* meEndcapPIDKNoPIDEff_Eta_[2];
+
+  MonitorElement* meEndcapPIDPAsPiEff_Eta_[2];
+  MonitorElement* meEndcapPIDPAsKEff_Eta_[2];
+  MonitorElement* meEndcapPIDPAsPEff_Eta_[2];
+  MonitorElement* meEndcapPIDPNoPIDEff_Eta_[2];
+
+  MonitorElement* meEndcapPiPurity_Eta_[2];
+  MonitorElement* meEndcapKPurity_Eta_[2];
+  MonitorElement* meEndcapPPurity_Eta_[2];
+  
 };
 
 // ------------ constructor and destructor --------------
@@ -235,12 +265,64 @@ void Primary4DVertexHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGe
   MonitorElement* meEndcapTrueKAsP = igetter.get(folder_ + "EndcapTrueKAsP");
   MonitorElement* meEndcapTruePAsP = igetter.get(folder_ + "EndcapTruePAsP");
 
+
+  // additional plots for PID study in different eta regions of ETL
+  MonitorElement* meEndcapTruePiNoPID_Eta[2];
+  MonitorElement* meEndcapTrueKNoPID_Eta[2];
+  MonitorElement* meEndcapTruePNoPID_Eta[2];
+  meEndcapTruePiNoPID_Eta[0] = igetter.get(folder_ + "EndcapTruePiNoPID_lowEta");
+  meEndcapTrueKNoPID_Eta[0] = igetter.get(folder_ + "EndcapTrueKNoPID_lowEta");
+  meEndcapTruePNoPID_Eta[0] = igetter.get(folder_ + "EndcapTruePNoPID_lowEta");
+  meEndcapTruePiNoPID_Eta[1] = igetter.get(folder_ + "EndcapTruePiNoPID_highEta");
+  meEndcapTrueKNoPID_Eta[1] = igetter.get(folder_ + "EndcapTrueKNoPID_highEta");
+  meEndcapTruePNoPID_Eta[1] = igetter.get(folder_ + "EndcapTruePNoPID_highEta");
+
+  MonitorElement* meEndcapTruePiAsPi_Eta[2];
+  MonitorElement* meEndcapTrueKAsPi_Eta[2];
+  MonitorElement* meEndcapTruePAsPi_Eta[2];
+  meEndcapTruePiAsPi_Eta[0] = igetter.get(folder_ + "EndcapTruePiAsPi_lowEta");
+  meEndcapTrueKAsPi_Eta[0] = igetter.get(folder_ + "EndcapTrueKAsPi_lowEta");
+  meEndcapTruePAsPi_Eta[0] = igetter.get(folder_ + "EndcapTruePAsPi_lowEta");
+  meEndcapTruePiAsPi_Eta[1] = igetter.get(folder_ + "EndcapTruePiAsPi_highEta");
+  meEndcapTrueKAsPi_Eta[1] = igetter.get(folder_ + "EndcapTrueKAsPi_highEta");
+  meEndcapTruePAsPi_Eta[1] = igetter.get(folder_ + "EndcapTruePAsPi_highEta");
+  
+  MonitorElement* meEndcapTruePiAsK_Eta[2];
+  MonitorElement* meEndcapTrueKAsK_Eta[2];
+  MonitorElement* meEndcapTruePAsK_Eta[2];
+  meEndcapTruePiAsK_Eta[0] = igetter.get(folder_ + "EndcapTruePiAsK_lowEta");
+  meEndcapTrueKAsK_Eta[0] = igetter.get(folder_ + "EndcapTrueKAsK_lowEta");
+  meEndcapTruePAsK_Eta[0] = igetter.get(folder_ + "EndcapTruePAsK_lowEta");
+  meEndcapTruePiAsK_Eta[1] = igetter.get(folder_ + "EndcapTruePiAsK_highEta");
+  meEndcapTrueKAsK_Eta[1] = igetter.get(folder_ + "EndcapTrueKAsK_highEta");
+  meEndcapTruePAsK_Eta[1] = igetter.get(folder_ + "EndcapTruePAsK_highEta");
+
+  MonitorElement* meEndcapTruePiAsP_Eta[2];
+  MonitorElement* meEndcapTrueKAsP_Eta[2];
+  MonitorElement* meEndcapTruePAsP_Eta[2];
+  meEndcapTruePiAsP_Eta[0] = igetter.get(folder_ + "EndcapTruePiAsP_lowEta");
+  meEndcapTrueKAsP_Eta[0] = igetter.get(folder_ + "EndcapTrueKAsP_lowEta");
+  meEndcapTruePAsP_Eta[0] = igetter.get(folder_ + "EndcapTruePAsP_lowEta");
+  meEndcapTruePiAsP_Eta[1] = igetter.get(folder_ + "EndcapTruePiAsP_highEta");
+  meEndcapTrueKAsP_Eta[1] = igetter.get(folder_ + "EndcapTrueKAsP_highEta");
+  meEndcapTruePAsP_Eta[1] = igetter.get(folder_ + "EndcapTruePAsP_highEta");
+
+
   if (!meBarrelPIDp || !meEndcapPIDp || !meBarrelTruePiNoPID || !meBarrelTrueKNoPID || !meBarrelTruePNoPID ||
       !meEndcapTruePiNoPID || !meEndcapTrueKNoPID || !meEndcapTruePNoPID || !meBarrelTruePiAsPi || !meBarrelTrueKAsPi ||
       !meBarrelTruePAsPi || !meEndcapTruePiAsPi || !meEndcapTrueKAsPi || !meEndcapTruePAsPi || !meBarrelTruePiAsK ||
       !meBarrelTrueKAsK || !meBarrelTruePAsK || !meEndcapTruePiAsK || !meEndcapTrueKAsK || !meEndcapTruePAsK ||
       !meBarrelTruePiAsP || !meBarrelTrueKAsP || !meBarrelTruePAsP || !meEndcapTruePiAsP || !meEndcapTrueKAsP ||
-      !meEndcapTruePAsP) {
+      !meEndcapTruePAsP ||
+      !meEndcapTruePiNoPID_Eta[0] || !meEndcapTrueKNoPID_Eta[0] || !meEndcapTruePNoPID_Eta[0] ||
+      !meEndcapTruePiNoPID_Eta[1] || !meEndcapTrueKNoPID_Eta[1] || !meEndcapTruePNoPID_Eta[1] ||
+      !meEndcapTruePiAsPi_Eta[0] || !meEndcapTrueKAsPi_Eta[0] || !meEndcapTruePAsPi_Eta[0] ||
+      !meEndcapTruePiAsPi_Eta[1] || !meEndcapTrueKAsPi_Eta[1] || !meEndcapTruePAsPi_Eta[1] ||
+      !meEndcapTruePiAsK_Eta[0] || !meEndcapTrueKAsK_Eta[0] || !meEndcapTruePAsK_Eta[0] ||
+      !meEndcapTruePiAsK_Eta[1] || !meEndcapTrueKAsK_Eta[1] || !meEndcapTruePAsK_Eta[1] ||
+      !meEndcapTruePiAsP_Eta[0] || !meEndcapTrueKAsP_Eta[0] || !meEndcapTruePAsP_Eta[0] ||
+      !meEndcapTruePiAsP_Eta[1] || !meEndcapTrueKAsP_Eta[1] || !meEndcapTruePAsP_Eta[1] 
+      ) {
     edm::LogWarning("Primary4DVertexHarvester") << "PID Monitoring histograms not found!" << std::endl;
     return;
   }
@@ -616,6 +698,199 @@ void Primary4DVertexHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGe
                                   meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
   meEndcapPPurity_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meEndcapTruePAsP, meEndcapAsP_, meEndcapPPurity_);
+
+
+  // additional plots to study PID in regions of ETL
+  for (int i = 0; i < 2; i++){ 
+    std::string suffix = "lowEta";
+    if (i == 1) suffix = "highEta";
+
+    meEndcapTruePi_Eta_[i] = ibook.book1D(Form("EndcapTruePi_%s",suffix.c_str()),
+					  "Endcap True Pi P;P [GeV]",
+					  meEndcapPIDp->getNbinsX(),
+					  meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+					  meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    incrementME(meEndcapTruePi_Eta_[i], meEndcapTruePiAsPi_Eta[i]);
+    incrementME(meEndcapTruePi_Eta_[i], meEndcapTruePiAsK_Eta[i]);
+    incrementME(meEndcapTruePi_Eta_[i], meEndcapTruePiAsP_Eta[i]);
+    incrementME(meEndcapTruePi_Eta_[i], meEndcapTruePiNoPID_Eta[i]);
+
+    meEndcapTrueK_Eta_[i] = ibook.book1D(Form("EndcapTrueK_%s",suffix.c_str()),
+					 "Endcap True K P;P [GeV]",
+					 meEndcapPIDp->getNbinsX(),
+					 meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+					 meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    incrementME(meEndcapTrueK_Eta_[i], meEndcapTrueKAsPi_Eta[i]);
+    incrementME(meEndcapTrueK_Eta_[i], meEndcapTrueKAsK_Eta[i]);
+    incrementME(meEndcapTrueK_Eta_[i], meEndcapTrueKAsP_Eta[i]);
+    incrementME(meEndcapTrueK_Eta_[i], meEndcapTrueKNoPID_Eta[i]);
+    
+    meEndcapTrueP_Eta_[i] = ibook.book1D(Form("EndcapTrueP_%s",suffix.c_str()),
+					 "Endcap True P P;P [GeV]",
+					 meEndcapPIDp->getNbinsX(),
+					 meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+					 meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    incrementME(meEndcapTrueP_Eta_[i], meEndcapTruePAsPi_Eta[i]);
+    incrementME(meEndcapTrueP_Eta_[i], meEndcapTruePAsK_Eta[i]);
+    incrementME(meEndcapTrueP_Eta_[i], meEndcapTruePAsP_Eta[i]);
+    incrementME(meEndcapTrueP_Eta_[i], meEndcapTruePNoPID_Eta[i]);
+
+
+    meEndcapPIDPiAsPiEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPiAsPiEff_%s",suffix.c_str()),
+					       "Endcap True pi as pi id. fraction VS P;P [GeV]",
+					       meEndcapPIDp->getNbinsX(),
+					       meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+					       meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPIDPiAsPiEff_Eta_[i]->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEndcapTruePiAsPi_Eta[i], meEndcapTruePi_Eta_[i], meEndcapPIDPiAsPiEff_Eta_[i]);
+
+    meEndcapPIDPiAsKEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPiAsKEff_%s",suffix.c_str()),
+                                               "Endcap True pi as k id. fraction VS P;P [GeV]",
+                                               meEndcapPIDp->getNbinsX(),
+                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPIDPiAsKEff_Eta_[i]->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEndcapTruePiAsK_Eta[i], meEndcapTruePi_Eta_[i], meEndcapPIDPiAsKEff_Eta_[i]);
+
+    meEndcapPIDPiAsPEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPiAsPEff_%s",suffix.c_str()),
+                                               "Endcap True pi as p id. fraction VS P;P [GeV]",
+                                               meEndcapPIDp->getNbinsX(),
+                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPIDPiAsPEff_Eta_[i]->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEndcapTruePiAsP_Eta[i], meEndcapTruePi_Eta_[i], meEndcapPIDPiAsPEff_Eta_[i]);
+    
+    meEndcapPIDPiNoPIDEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPiNoPIDEff_%s",suffix.c_str()),
+						 "Endcap True pi no PID id. fraction VS P;P [GeV]",
+						 meEndcapPIDp->getNbinsX(),
+						 meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+						 meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPIDPiNoPIDEff_Eta_[i]->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEndcapTruePiNoPID_Eta[i], meEndcapTruePi_Eta_[i], meEndcapPIDPiNoPIDEff_Eta_[i]);
+
+
+    //
+    meEndcapPIDKAsPiEff_Eta_[i] = ibook.book1D(Form("EndcapPIDKAsPiEff_%s",suffix.c_str()),
+					       "Endcap True k as pi id. fraction VS P;P [GeV]",
+					       meEndcapPIDp->getNbinsX(),
+					       meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+					       meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPIDKAsPiEff_Eta_[i]->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEndcapTrueKAsPi_Eta[i], meEndcapTrueK_Eta_[i], meEndcapPIDKAsPiEff_Eta_[i]);
+
+    meEndcapPIDKAsKEff_Eta_[i] = ibook.book1D(Form("EndcapPIDKAsKEff_%s",suffix.c_str()),
+                                               "Endcap True k as k id. fraction VS P;P [GeV]",
+                                               meEndcapPIDp->getNbinsX(),
+                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPIDKAsKEff_Eta_[i]->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEndcapTrueKAsK_Eta[i], meEndcapTrueK_Eta_[i], meEndcapPIDKAsKEff_Eta_[i]);
+
+    meEndcapPIDKAsPEff_Eta_[i] = ibook.book1D(Form("EndcapPIDKAsPEff_%s",suffix.c_str()),
+                                               "Endcap True k as p id. fraction VS P;P [GeV]",
+                                               meEndcapPIDp->getNbinsX(),
+                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPIDKAsPEff_Eta_[i]->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEndcapTrueKAsP_Eta[i], meEndcapTrueK_Eta_[i], meEndcapPIDKAsPEff_Eta_[i]);
+    
+    meEndcapPIDKNoPIDEff_Eta_[i] = ibook.book1D(Form("EndcapPIDKNoPIDEff_%s",suffix.c_str()),
+						"Endcap True k no PID id. fraction VS P;P [GeV]",
+						meEndcapPIDp->getNbinsX(),
+						meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+						meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPIDKNoPIDEff_Eta_[i]->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEndcapTrueKNoPID_Eta[i], meEndcapTrueK_Eta_[i], meEndcapPIDKNoPIDEff_Eta_[i]);
+
+    //
+    meEndcapPIDPAsPiEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPAsPiEff_%s",suffix.c_str()),
+					       "Endcap True p as pi id. fraction VS P;P [GeV]",
+					       meEndcapPIDp->getNbinsX(),
+					       meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+					       meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPIDPAsPiEff_Eta_[i]->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEndcapTruePAsPi_Eta[i], meEndcapTrueP_Eta_[i], meEndcapPIDPAsPiEff_Eta_[i]);
+
+    meEndcapPIDPAsKEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPAsKEff_%s",suffix.c_str()),
+                                               "Endcap True p as k id. fraction VS P;P [GeV]",
+                                               meEndcapPIDp->getNbinsX(),
+                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPIDPAsKEff_Eta_[i]->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEndcapTruePAsK_Eta[i], meEndcapTrueP_Eta_[i], meEndcapPIDPAsKEff_Eta_[i]);
+
+    meEndcapPIDPAsPEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPAsPEff_%s",suffix.c_str()),
+                                               "Endcap True p as p id. fraction VS P;P [GeV]",
+                                               meEndcapPIDp->getNbinsX(),
+                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                               meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPIDPAsPEff_Eta_[i]->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEndcapTruePAsP_Eta[i], meEndcapTrueP_Eta_[i], meEndcapPIDPAsPEff_Eta_[i]);
+    
+    meEndcapPIDPNoPIDEff_Eta_[i] = ibook.book1D(Form("EndcapPIDPNoPIDEff_%s",suffix.c_str()),
+						"Endcap True p no PID id. fraction VS P;P [GeV]",
+						meEndcapPIDp->getNbinsX(),
+						meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+						meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPIDPNoPIDEff_Eta_[i]->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEndcapTruePNoPID_Eta[i], meEndcapTrueP_Eta_[i], meEndcapPIDPNoPIDEff_Eta_[i]);
+
+    // purity
+    meEndcapAsPi_Eta_[i] = ibook.book1D(Form("EndcapAsPi_%s", suffix.c_str()),
+					"Endcap Identified Pi P;P [GeV]",
+					meEndcapPIDp->getNbinsX(),
+					meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+					meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    incrementME(meEndcapAsPi_Eta_[i], meEndcapTruePiAsPi_Eta[i]);
+    incrementME(meEndcapAsPi_Eta_[i], meEndcapTrueKAsPi_Eta[i]);
+    incrementME(meEndcapAsPi_Eta_[i], meEndcapTruePAsPi_Eta[i]);
+
+    meEndcapAsK_Eta_[i] = ibook.book1D(Form("EndcapAsK_%s",suffix.c_str()),
+					"Endcap Identified k P;P [GeV]",
+					meEndcapPIDp->getNbinsX(),
+					meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+					meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    incrementME(meEndcapAsK_Eta_[i], meEndcapTruePiAsK_Eta[i]);
+    incrementME(meEndcapAsK_Eta_[i], meEndcapTrueKAsK_Eta[i]);
+    incrementME(meEndcapAsK_Eta_[i], meEndcapTruePAsK_Eta[i]);
+
+    meEndcapAsP_Eta_[i] = ibook.book1D(Form("EndcapAsP_%s",suffix.c_str()),
+					"Endcap Identified p P;P [GeV]",
+					meEndcapPIDp->getNbinsX(),
+					meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+					meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    incrementME(meEndcapAsP_Eta_[i], meEndcapTruePiAsP_Eta[i]);
+    incrementME(meEndcapAsP_Eta_[i], meEndcapTrueKAsP_Eta[i]);
+    incrementME(meEndcapAsP_Eta_[i], meEndcapTruePAsP_Eta[i]);
+    
+
+    meEndcapPiPurity_Eta_[i] = ibook.book1D(Form("EndcapPiPurity_%s",suffix.c_str()),
+					    "Endcap pi id. fraction true pi VS P;P [GeV]",
+					    meEndcapPIDp->getNbinsX(),
+					    meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+					    meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPiPurity_Eta_[i]->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEndcapTruePiAsPi_Eta[i], meEndcapAsPi_Eta_[i], meEndcapPiPurity_Eta_[i]);
+    
+
+    meEndcapKPurity_Eta_[i] = ibook.book1D(Form("EndcapKPurity_%s",suffix.c_str()),
+                                            "Endcap k id. fraction true k VS P;P [GeV]",
+                                            meEndcapPIDp->getNbinsX(),
+                                            meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                            meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapKPurity_Eta_[i]->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEndcapTrueKAsK_Eta[i], meEndcapAsK_Eta_[i], meEndcapKPurity_Eta_[i]);
+
+    meEndcapPPurity_Eta_[i] = ibook.book1D(Form("EndcapPPurity_%s",suffix.c_str()),
+                                            "Endcap p id. fraction true p VS P;P [GeV]",
+                                            meEndcapPIDp->getNbinsX(),
+                                            meEndcapPIDp->getTH1()->GetXaxis()->GetXmin(),
+                                            meEndcapPIDp->getTH1()->GetXaxis()->GetXmax());
+    meEndcapPPurity_Eta_[i]->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEndcapTruePAsP_Eta[i], meEndcapAsP_Eta_[i], meEndcapPPurity_Eta_[i]);
+  }
+
+  
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ----------

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -532,6 +532,23 @@ private:
   MonitorElement* meEndcapTruePAsK_;
   MonitorElement* meEndcapTruePAsP_;
 
+  // Histograms to study PID purity/efficiency in different eta regions of ETL
+  MonitorElement* meEndcapTruePiNoPID_Eta_[2];
+  MonitorElement* meEndcapTrueKNoPID_Eta_[2];
+  MonitorElement* meEndcapTruePNoPID_Eta_[2];
+ 
+  MonitorElement* meEndcapTruePiAsPi_Eta_[2];
+  MonitorElement* meEndcapTruePiAsK_Eta_[2];
+  MonitorElement* meEndcapTruePiAsP_Eta_[2];
+
+  MonitorElement* meEndcapTrueKAsPi_Eta_[2];
+  MonitorElement* meEndcapTrueKAsK_Eta_[2];
+  MonitorElement* meEndcapTrueKAsP_Eta_[2];
+
+  MonitorElement* meEndcapTruePAsPi_Eta_[2];
+  MonitorElement* meEndcapTruePAsK_Eta_[2];
+  MonitorElement* meEndcapTruePAsP_Eta_[2];
+
   // Histograms for study of no PID tracks
 
   //Time residual
@@ -1554,6 +1571,42 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
       ibook.book1D("EndcapTruePAsPi", "True p as pi momentum spectrum, |eta| > 1.6;p [GeV]", 25, 0., 10.);
   meEndcapTruePAsK_ = ibook.book1D("EndcapTruePAsK", "True p as k momentum spectrum, |eta| > 1.6;p [GeV]", 25, 0., 10.);
   meEndcapTruePAsP_ = ibook.book1D("EndcapTruePAsP", "True p as p momentum spectrum, |eta| > 1.6;p [GeV]", 25, 0., 10.);
+
+  if (optionalPlots_){
+    meEndcapTruePiNoPID_Eta_[0] = ibook.book1D("EndcapTruePiNoPID_lowEta", "True pi NoPID momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTrueKNoPID_Eta_[0] = ibook.book1D("EndcapTrueKNoPID_lowEta", "True k NoPID momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePNoPID_Eta_[0] = ibook.book1D("EndcapTruePNoPID_lowEta", "True p NoPID momentum spectrum, 1.6 < |eta| > 2.1;p [GeV]", 25, 0., 10.);
+
+    meEndcapTruePiAsPi_Eta_[0] = ibook.book1D("EndcapTruePiAsPi_lowEta", "True pi as pi momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePiAsK_Eta_[0] = ibook.book1D("EndcapTruePiAsK_lowEta", "True pi as k momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePiAsP_Eta_[0] = ibook.book1D("EndcapTruePiAsP_lowEta", "True pi as p momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
+
+    meEndcapTrueKAsPi_Eta_[0] = ibook.book1D("EndcapTrueKAsPi_lowEta", "True k as pi momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTrueKAsK_Eta_[0] = ibook.book1D("EndcapTrueKAsK_lowEta", "True k as k momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTrueKAsP_Eta_[0] = ibook.book1D("EndcapTrueKAsP_lowEta", "True k as p momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
+    
+    meEndcapTruePAsPi_Eta_[0] = ibook.book1D("EndcapTruePAsPi_lowEta", "True p as pi momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePAsK_Eta_[0] = ibook.book1D("EndcapTruePAsK_lowEta", "True p as k momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePAsP_Eta_[0] = ibook.book1D("EndcapTruePAsP_lowEta", "True p as p momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
+    
+    meEndcapTruePiNoPID_Eta_[1] = ibook.book1D("EndcapTruePiNoPID_highEta", "True pi NoPID momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTrueKNoPID_Eta_[1] = ibook.book1D("EndcapTrueKNoPID_highEta", "True k NoPID momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePNoPID_Eta_[1] = ibook.book1D("EndcapTruePNoPID_highEta", "True p NoPID momentum spectrum, 1.6 < |eta| > 2.1;p [GeV]", 25, 0., 10.);
+
+    meEndcapTruePiAsPi_Eta_[1] = ibook.book1D("EndcapTruePiAsPi_highEta", "True pi as pi momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePiAsK_Eta_[1] = ibook.book1D("EndcapTruePiAsK_highEta", "True pi as k momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePiAsP_Eta_[1] = ibook.book1D("EndcapTruePiAsP_highEta", "True pi as p momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+
+    meEndcapTrueKAsPi_Eta_[1] = ibook.book1D("EndcapTrueKAsPi_highEta", "True k as pi momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTrueKAsK_Eta_[1] = ibook.book1D("EndcapTrueKAsK_highEta", "True k as k momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTrueKAsP_Eta_[1] = ibook.book1D("EndcapTrueKAsP_highEta", "True k as p momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+    
+    meEndcapTruePAsPi_Eta_[1] = ibook.book1D("EndcapTruePAsPi_highEta", "True p as pi momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePAsK_Eta_[1] = ibook.book1D("EndcapTruePAsK_highEta", "True p as k momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePAsP_Eta_[1] = ibook.book1D("EndcapTruePAsP_highEta", "True p as p momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+      
+  }
+
 }
 
 bool Primary4DVertexValidation::matchRecoTrack2SimSignal(const reco::TrackBaseRef& recoTrack) {
@@ -2527,12 +2580,28 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
                 if (std::abs((*tp_info)->pdgId()) == 211) {
                   if (noPID) {
                     meEndcapTruePiNoPID_->Fill((*iTrack)->p());
+		    if (optionalPlots_){
+		      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTruePiNoPID_Eta_[0]->Fill((*iTrack)->p());
+		      else meEndcapTruePiNoPID_Eta_[1]->Fill((*iTrack)->p());
+		    }
                   } else if (isPi) {
                     meEndcapTruePiAsPi_->Fill((*iTrack)->p());
-                  } else if (isK) {
+		    if (optionalPlots_){
+		      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTruePiAsPi_Eta_[0]->Fill((*iTrack)->p());
+		      else meEndcapTruePiAsPi_Eta_[1]->Fill((*iTrack)->p());
+		    }
+		  } else if (isK) {
                     meEndcapTruePiAsK_->Fill((*iTrack)->p());
+		    if (optionalPlots_){
+		      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTruePiAsK_Eta_[0]->Fill((*iTrack)->p());
+		      else meEndcapTruePiAsK_Eta_[1]->Fill((*iTrack)->p()); 
+		    }
                   } else if (isP) {
                     meEndcapTruePiAsP_->Fill((*iTrack)->p());
+		    if (optionalPlots_){
+		      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTruePiAsP_Eta_[0]->Fill((*iTrack)->p());
+		      else meEndcapTruePiAsP_Eta_[1]->Fill((*iTrack)->p());
+		    }
                   } else {
                     edm::LogWarning("Primary4DVertexValidation")
                         << "No PID class: " << std::abs((*tp_info)->pdgId()) << " t0/t0safe " << t0Pid[*iTrack] << " "
@@ -2542,12 +2611,28 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
                 } else if (std::abs((*tp_info)->pdgId()) == 321) {
                   if (noPID) {
                     meEndcapTrueKNoPID_->Fill((*iTrack)->p());
-                  } else if (isPi) {
+		    if (optionalPlots_){
+		      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTrueKNoPID_Eta_[0]->Fill((*iTrack)->p());
+		      else meEndcapTrueKNoPID_Eta_[1]->Fill((*iTrack)->p());
+		    }
+		  } else if (isPi) {
                     meEndcapTrueKAsPi_->Fill((*iTrack)->p());
+		    if (optionalPlots_){
+		      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTrueKAsPi_Eta_[0]->Fill((*iTrack)->p());
+		      else meEndcapTrueKAsPi_Eta_[1]->Fill((*iTrack)->p());
+		    }
                   } else if (isK) {
                     meEndcapTrueKAsK_->Fill((*iTrack)->p());
+		    if (optionalPlots_){
+		      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTrueKAsK_Eta_[0]->Fill((*iTrack)->p());
+		      else meEndcapTrueKAsK_Eta_[1]->Fill((*iTrack)->p());
+		    }
                   } else if (isP) {
                     meEndcapTrueKAsP_->Fill((*iTrack)->p());
+		    if (optionalPlots_){
+		      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTrueKAsP_Eta_[0]->Fill((*iTrack)->p());
+		      else meEndcapTrueKAsP_Eta_[1]->Fill((*iTrack)->p());
+		    }
                   } else {
                     edm::LogWarning("Primary4DVertexValidation")
                         << "No PID class: " << std::abs((*tp_info)->pdgId()) << " t0/t0safe " << t0Pid[*iTrack] << " "
@@ -2557,12 +2642,28 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
                 } else if (std::abs((*tp_info)->pdgId()) == 2212) {
                   if (noPID) {
                     meEndcapTruePNoPID_->Fill((*iTrack)->p());
+		    if (optionalPlots_){
+                      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTruePNoPID_Eta_[0]->Fill((*iTrack)->p());
+                      else meEndcapTruePNoPID_Eta_[1]->Fill((*iTrack)->p());
+                    }
                   } else if (isPi) {
                     meEndcapTruePAsPi_->Fill((*iTrack)->p());
+		    if (optionalPlots_){
+                      if (std::abs((*iTrack)->eta()) < 2.1)  meEndcapTruePAsPi_Eta_[0]->Fill((*iTrack)->p());
+                      else meEndcapTruePAsPi_Eta_[1]->Fill((*iTrack)->p());
+			}
                   } else if (isK) {
                     meEndcapTruePAsK_->Fill((*iTrack)->p());
+		    if (optionalPlots_){
+                      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTruePAsK_Eta_[0]->Fill((*iTrack)->p());
+                      else meEndcapTruePAsK_Eta_[1]->Fill((*iTrack)->p());
+                    }
                   } else if (isP) {
                     meEndcapTruePAsP_->Fill((*iTrack)->p());
+		    if (optionalPlots_){
+		      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTruePAsP_Eta_[0]->Fill((*iTrack)->p());
+		      else meEndcapTruePAsP_Eta_[1]->Fill((*iTrack)->p());
+                    }
                   } else {
                     edm::LogWarning("Primary4DVertexValidation")
                         << "No PID class: " << std::abs((*tp_info)->pdgId()) << " t0/t0safe " << t0Pid[*iTrack] << " "

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -536,7 +536,7 @@ private:
   MonitorElement* meEndcapTruePiNoPID_Eta_[2];
   MonitorElement* meEndcapTrueKNoPID_Eta_[2];
   MonitorElement* meEndcapTruePNoPID_Eta_[2];
- 
+
   MonitorElement* meEndcapTruePiAsPi_Eta_[2];
   MonitorElement* meEndcapTruePiAsK_Eta_[2];
   MonitorElement* meEndcapTruePiAsP_Eta_[2];
@@ -1572,41 +1572,63 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
   meEndcapTruePAsK_ = ibook.book1D("EndcapTruePAsK", "True p as k momentum spectrum, |eta| > 1.6;p [GeV]", 25, 0., 10.);
   meEndcapTruePAsP_ = ibook.book1D("EndcapTruePAsP", "True p as p momentum spectrum, |eta| > 1.6;p [GeV]", 25, 0., 10.);
 
-  if (optionalPlots_){
-    meEndcapTruePiNoPID_Eta_[0] = ibook.book1D("EndcapTruePiNoPID_lowEta", "True pi NoPID momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
-    meEndcapTrueKNoPID_Eta_[0] = ibook.book1D("EndcapTrueKNoPID_lowEta", "True k NoPID momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
-    meEndcapTruePNoPID_Eta_[0] = ibook.book1D("EndcapTruePNoPID_lowEta", "True p NoPID momentum spectrum, 1.6 < |eta| > 2.1;p [GeV]", 25, 0., 10.);
+  if (optionalPlots_) {
+    meEndcapTruePiNoPID_Eta_[0] = ibook.book1D(
+        "EndcapTruePiNoPID_lowEta", "True pi NoPID momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTrueKNoPID_Eta_[0] = ibook.book1D(
+        "EndcapTrueKNoPID_lowEta", "True k NoPID momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePNoPID_Eta_[0] = ibook.book1D(
+        "EndcapTruePNoPID_lowEta", "True p NoPID momentum spectrum, 1.6 < |eta| > 2.1;p [GeV]", 25, 0., 10.);
 
-    meEndcapTruePiAsPi_Eta_[0] = ibook.book1D("EndcapTruePiAsPi_lowEta", "True pi as pi momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
-    meEndcapTruePiAsK_Eta_[0] = ibook.book1D("EndcapTruePiAsK_lowEta", "True pi as k momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
-    meEndcapTruePiAsP_Eta_[0] = ibook.book1D("EndcapTruePiAsP_lowEta", "True pi as p momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePiAsPi_Eta_[0] = ibook.book1D(
+        "EndcapTruePiAsPi_lowEta", "True pi as pi momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePiAsK_Eta_[0] = ibook.book1D(
+        "EndcapTruePiAsK_lowEta", "True pi as k momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePiAsP_Eta_[0] = ibook.book1D(
+        "EndcapTruePiAsP_lowEta", "True pi as p momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
 
-    meEndcapTrueKAsPi_Eta_[0] = ibook.book1D("EndcapTrueKAsPi_lowEta", "True k as pi momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
-    meEndcapTrueKAsK_Eta_[0] = ibook.book1D("EndcapTrueKAsK_lowEta", "True k as k momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
-    meEndcapTrueKAsP_Eta_[0] = ibook.book1D("EndcapTrueKAsP_lowEta", "True k as p momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
-    
-    meEndcapTruePAsPi_Eta_[0] = ibook.book1D("EndcapTruePAsPi_lowEta", "True p as pi momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
-    meEndcapTruePAsK_Eta_[0] = ibook.book1D("EndcapTruePAsK_lowEta", "True p as k momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
-    meEndcapTruePAsP_Eta_[0] = ibook.book1D("EndcapTruePAsP_lowEta", "True p as p momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
-    
-    meEndcapTruePiNoPID_Eta_[1] = ibook.book1D("EndcapTruePiNoPID_highEta", "True pi NoPID momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
-    meEndcapTrueKNoPID_Eta_[1] = ibook.book1D("EndcapTrueKNoPID_highEta", "True k NoPID momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
-    meEndcapTruePNoPID_Eta_[1] = ibook.book1D("EndcapTruePNoPID_highEta", "True p NoPID momentum spectrum, 1.6 < |eta| > 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTrueKAsPi_Eta_[0] = ibook.book1D(
+        "EndcapTrueKAsPi_lowEta", "True k as pi momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTrueKAsK_Eta_[0] =
+        ibook.book1D("EndcapTrueKAsK_lowEta", "True k as k momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTrueKAsP_Eta_[0] =
+        ibook.book1D("EndcapTrueKAsP_lowEta", "True k as p momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
 
-    meEndcapTruePiAsPi_Eta_[1] = ibook.book1D("EndcapTruePiAsPi_highEta", "True pi as pi momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
-    meEndcapTruePiAsK_Eta_[1] = ibook.book1D("EndcapTruePiAsK_highEta", "True pi as k momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
-    meEndcapTruePiAsP_Eta_[1] = ibook.book1D("EndcapTruePiAsP_highEta", "True pi as p momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePAsPi_Eta_[0] = ibook.book1D(
+        "EndcapTruePAsPi_lowEta", "True p as pi momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePAsK_Eta_[0] =
+        ibook.book1D("EndcapTruePAsK_lowEta", "True p as k momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePAsP_Eta_[0] =
+        ibook.book1D("EndcapTruePAsP_lowEta", "True p as p momentum spectrum, 1.6 < |eta| < 2.1;p [GeV]", 25, 0., 10.);
 
-    meEndcapTrueKAsPi_Eta_[1] = ibook.book1D("EndcapTrueKAsPi_highEta", "True k as pi momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
-    meEndcapTrueKAsK_Eta_[1] = ibook.book1D("EndcapTrueKAsK_highEta", "True k as k momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
-    meEndcapTrueKAsP_Eta_[1] = ibook.book1D("EndcapTrueKAsP_highEta", "True k as p momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
-    
-    meEndcapTruePAsPi_Eta_[1] = ibook.book1D("EndcapTruePAsPi_highEta", "True p as pi momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
-    meEndcapTruePAsK_Eta_[1] = ibook.book1D("EndcapTruePAsK_highEta", "True p as k momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
-    meEndcapTruePAsP_Eta_[1] = ibook.book1D("EndcapTruePAsP_highEta", "True p as p momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
-      
+    meEndcapTruePiNoPID_Eta_[1] =
+        ibook.book1D("EndcapTruePiNoPID_highEta", "True pi NoPID momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTrueKNoPID_Eta_[1] =
+        ibook.book1D("EndcapTrueKNoPID_highEta", "True k NoPID momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePNoPID_Eta_[1] = ibook.book1D(
+        "EndcapTruePNoPID_highEta", "True p NoPID momentum spectrum, 1.6 < |eta| > 2.1;p [GeV]", 25, 0., 10.);
+
+    meEndcapTruePiAsPi_Eta_[1] =
+        ibook.book1D("EndcapTruePiAsPi_highEta", "True pi as pi momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePiAsK_Eta_[1] =
+        ibook.book1D("EndcapTruePiAsK_highEta", "True pi as k momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePiAsP_Eta_[1] =
+        ibook.book1D("EndcapTruePiAsP_highEta", "True pi as p momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+
+    meEndcapTrueKAsPi_Eta_[1] =
+        ibook.book1D("EndcapTrueKAsPi_highEta", "True k as pi momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTrueKAsK_Eta_[1] =
+        ibook.book1D("EndcapTrueKAsK_highEta", "True k as k momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTrueKAsP_Eta_[1] =
+        ibook.book1D("EndcapTrueKAsP_highEta", "True k as p momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+
+    meEndcapTruePAsPi_Eta_[1] =
+        ibook.book1D("EndcapTruePAsPi_highEta", "True p as pi momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePAsK_Eta_[1] =
+        ibook.book1D("EndcapTruePAsK_highEta", "True p as k momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
+    meEndcapTruePAsP_Eta_[1] =
+        ibook.book1D("EndcapTruePAsP_highEta", "True p as p momentum spectrum, |eta| >= 2.1;p [GeV]", 25, 0., 10.);
   }
-
 }
 
 bool Primary4DVertexValidation::matchRecoTrack2SimSignal(const reco::TrackBaseRef& recoTrack) {
@@ -2580,28 +2602,36 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
                 if (std::abs((*tp_info)->pdgId()) == 211) {
                   if (noPID) {
                     meEndcapTruePiNoPID_->Fill((*iTrack)->p());
-		    if (optionalPlots_){
-		      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTruePiNoPID_Eta_[0]->Fill((*iTrack)->p());
-		      else meEndcapTruePiNoPID_Eta_[1]->Fill((*iTrack)->p());
-		    }
+                    if (optionalPlots_) {
+                      if (std::abs((*iTrack)->eta()) < 2.1)
+                        meEndcapTruePiNoPID_Eta_[0]->Fill((*iTrack)->p());
+                      else
+                        meEndcapTruePiNoPID_Eta_[1]->Fill((*iTrack)->p());
+                    }
                   } else if (isPi) {
                     meEndcapTruePiAsPi_->Fill((*iTrack)->p());
-		    if (optionalPlots_){
-		      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTruePiAsPi_Eta_[0]->Fill((*iTrack)->p());
-		      else meEndcapTruePiAsPi_Eta_[1]->Fill((*iTrack)->p());
-		    }
-		  } else if (isK) {
+                    if (optionalPlots_) {
+                      if (std::abs((*iTrack)->eta()) < 2.1)
+                        meEndcapTruePiAsPi_Eta_[0]->Fill((*iTrack)->p());
+                      else
+                        meEndcapTruePiAsPi_Eta_[1]->Fill((*iTrack)->p());
+                    }
+                  } else if (isK) {
                     meEndcapTruePiAsK_->Fill((*iTrack)->p());
-		    if (optionalPlots_){
-		      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTruePiAsK_Eta_[0]->Fill((*iTrack)->p());
-		      else meEndcapTruePiAsK_Eta_[1]->Fill((*iTrack)->p()); 
-		    }
+                    if (optionalPlots_) {
+                      if (std::abs((*iTrack)->eta()) < 2.1)
+                        meEndcapTruePiAsK_Eta_[0]->Fill((*iTrack)->p());
+                      else
+                        meEndcapTruePiAsK_Eta_[1]->Fill((*iTrack)->p());
+                    }
                   } else if (isP) {
                     meEndcapTruePiAsP_->Fill((*iTrack)->p());
-		    if (optionalPlots_){
-		      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTruePiAsP_Eta_[0]->Fill((*iTrack)->p());
-		      else meEndcapTruePiAsP_Eta_[1]->Fill((*iTrack)->p());
-		    }
+                    if (optionalPlots_) {
+                      if (std::abs((*iTrack)->eta()) < 2.1)
+                        meEndcapTruePiAsP_Eta_[0]->Fill((*iTrack)->p());
+                      else
+                        meEndcapTruePiAsP_Eta_[1]->Fill((*iTrack)->p());
+                    }
                   } else {
                     edm::LogWarning("Primary4DVertexValidation")
                         << "No PID class: " << std::abs((*tp_info)->pdgId()) << " t0/t0safe " << t0Pid[*iTrack] << " "
@@ -2611,28 +2641,36 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
                 } else if (std::abs((*tp_info)->pdgId()) == 321) {
                   if (noPID) {
                     meEndcapTrueKNoPID_->Fill((*iTrack)->p());
-		    if (optionalPlots_){
-		      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTrueKNoPID_Eta_[0]->Fill((*iTrack)->p());
-		      else meEndcapTrueKNoPID_Eta_[1]->Fill((*iTrack)->p());
-		    }
-		  } else if (isPi) {
+                    if (optionalPlots_) {
+                      if (std::abs((*iTrack)->eta()) < 2.1)
+                        meEndcapTrueKNoPID_Eta_[0]->Fill((*iTrack)->p());
+                      else
+                        meEndcapTrueKNoPID_Eta_[1]->Fill((*iTrack)->p());
+                    }
+                  } else if (isPi) {
                     meEndcapTrueKAsPi_->Fill((*iTrack)->p());
-		    if (optionalPlots_){
-		      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTrueKAsPi_Eta_[0]->Fill((*iTrack)->p());
-		      else meEndcapTrueKAsPi_Eta_[1]->Fill((*iTrack)->p());
-		    }
+                    if (optionalPlots_) {
+                      if (std::abs((*iTrack)->eta()) < 2.1)
+                        meEndcapTrueKAsPi_Eta_[0]->Fill((*iTrack)->p());
+                      else
+                        meEndcapTrueKAsPi_Eta_[1]->Fill((*iTrack)->p());
+                    }
                   } else if (isK) {
                     meEndcapTrueKAsK_->Fill((*iTrack)->p());
-		    if (optionalPlots_){
-		      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTrueKAsK_Eta_[0]->Fill((*iTrack)->p());
-		      else meEndcapTrueKAsK_Eta_[1]->Fill((*iTrack)->p());
-		    }
+                    if (optionalPlots_) {
+                      if (std::abs((*iTrack)->eta()) < 2.1)
+                        meEndcapTrueKAsK_Eta_[0]->Fill((*iTrack)->p());
+                      else
+                        meEndcapTrueKAsK_Eta_[1]->Fill((*iTrack)->p());
+                    }
                   } else if (isP) {
                     meEndcapTrueKAsP_->Fill((*iTrack)->p());
-		    if (optionalPlots_){
-		      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTrueKAsP_Eta_[0]->Fill((*iTrack)->p());
-		      else meEndcapTrueKAsP_Eta_[1]->Fill((*iTrack)->p());
-		    }
+                    if (optionalPlots_) {
+                      if (std::abs((*iTrack)->eta()) < 2.1)
+                        meEndcapTrueKAsP_Eta_[0]->Fill((*iTrack)->p());
+                      else
+                        meEndcapTrueKAsP_Eta_[1]->Fill((*iTrack)->p());
+                    }
                   } else {
                     edm::LogWarning("Primary4DVertexValidation")
                         << "No PID class: " << std::abs((*tp_info)->pdgId()) << " t0/t0safe " << t0Pid[*iTrack] << " "
@@ -2642,27 +2680,35 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
                 } else if (std::abs((*tp_info)->pdgId()) == 2212) {
                   if (noPID) {
                     meEndcapTruePNoPID_->Fill((*iTrack)->p());
-		    if (optionalPlots_){
-                      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTruePNoPID_Eta_[0]->Fill((*iTrack)->p());
-                      else meEndcapTruePNoPID_Eta_[1]->Fill((*iTrack)->p());
+                    if (optionalPlots_) {
+                      if (std::abs((*iTrack)->eta()) < 2.1)
+                        meEndcapTruePNoPID_Eta_[0]->Fill((*iTrack)->p());
+                      else
+                        meEndcapTruePNoPID_Eta_[1]->Fill((*iTrack)->p());
                     }
                   } else if (isPi) {
                     meEndcapTruePAsPi_->Fill((*iTrack)->p());
-		    if (optionalPlots_){
-                      if (std::abs((*iTrack)->eta()) < 2.1)  meEndcapTruePAsPi_Eta_[0]->Fill((*iTrack)->p());
-                      else meEndcapTruePAsPi_Eta_[1]->Fill((*iTrack)->p());
-			}
+                    if (optionalPlots_) {
+                      if (std::abs((*iTrack)->eta()) < 2.1)
+                        meEndcapTruePAsPi_Eta_[0]->Fill((*iTrack)->p());
+                      else
+                        meEndcapTruePAsPi_Eta_[1]->Fill((*iTrack)->p());
+                    }
                   } else if (isK) {
                     meEndcapTruePAsK_->Fill((*iTrack)->p());
-		    if (optionalPlots_){
-                      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTruePAsK_Eta_[0]->Fill((*iTrack)->p());
-                      else meEndcapTruePAsK_Eta_[1]->Fill((*iTrack)->p());
+                    if (optionalPlots_) {
+                      if (std::abs((*iTrack)->eta()) < 2.1)
+                        meEndcapTruePAsK_Eta_[0]->Fill((*iTrack)->p());
+                      else
+                        meEndcapTruePAsK_Eta_[1]->Fill((*iTrack)->p());
                     }
                   } else if (isP) {
                     meEndcapTruePAsP_->Fill((*iTrack)->p());
-		    if (optionalPlots_){
-		      if (std::abs((*iTrack)->eta()) < 2.1) meEndcapTruePAsP_Eta_[0]->Fill((*iTrack)->p());
-		      else meEndcapTruePAsP_Eta_[1]->Fill((*iTrack)->p());
+                    if (optionalPlots_) {
+                      if (std::abs((*iTrack)->eta()) < 2.1)
+                        meEndcapTruePAsP_Eta_[0]->Fill((*iTrack)->p());
+                      else
+                        meEndcapTruePAsP_Eta_[1]->Fill((*iTrack)->p());
                     }
                   } else {
                     edm::LogWarning("Primary4DVertexValidation")

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -3201,7 +3201,7 @@ void Primary4DVertexValidation::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<edm::InputTag>("probK", edm::InputTag("tofPID:probK"));
   desc.add<edm::InputTag>("probP", edm::InputTag("tofPID:probP"));
   desc.add<bool>("useOnlyChargedTracks", true);
-  desc.addUntracked<bool>("optionalPlots", false);
+  desc.addUntracked<bool>("optionalPlots", true);
   desc.add<bool>("use3dNoTime", false);
   desc.add<double>("trackweightTh", 0.5);
   desc.add<double>("mvaTh", 0.8);

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -3201,7 +3201,7 @@ void Primary4DVertexValidation::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<edm::InputTag>("probK", edm::InputTag("tofPID:probK"));
   desc.add<edm::InputTag>("probP", edm::InputTag("tofPID:probP"));
   desc.add<bool>("useOnlyChargedTracks", true);
-  desc.addUntracked<bool>("optionalPlots", true);
+  desc.addUntracked<bool>("optionalPlots", false);
   desc.add<bool>("use3dNoTime", false);
   desc.add<double>("trackweightTh", 0.5);
   desc.add<double>("mvaTh", 0.8);


### PR DESCRIPTION
#### PR description:

This PR adds some optional histograms to MtdTracksValidation and Primary4DVertexValidation in the MtdValidation module to study ETL time resolution and PID in different pseudorapidity regions (the "optionalPlots" flag is by default set to false).


#### PR validation:
Code compiles, runs, and provides the desired output in the standalone MTD validation test on TTbar+PU events.
