### PR TITLE
ETL occupancy study

### DIFF
--- a/Geometry/MTDGeometryBuilder/test/MTDDigiGeometryAnalyzer.cc
+++ b/Geometry/MTDGeometryBuilder/test/MTDDigiGeometryAnalyzer.cc
@@ -70,7 +70,7 @@ private:
   // LGAD counter per Disc, DiscSide, and Sector: [disk][discSide][sector]
   static constexpr int n_discSide = 2;
   static constexpr int n_sector = 3;  // Use size 3 to allow 1-based indexing (1 to 2)
-  uint32_t LGADsPerDiscSideSector_[4][n_discSide][n_sector] = {{{{0}}}};
+  uint32_t LGADsPerDiscSideSector_[4][n_discSide][n_sector] = {};
 
   // Counter for total LGADs per disk per eta bin: [disk][eta_bin]
   uint32_t LGADsPerDiskperEtaBin_[4][n_bin_Eta] = {{0}};

--- a/Geometry/MTDGeometryBuilder/test/MTDDigiGeometryAnalyzer.cc
+++ b/Geometry/MTDGeometryBuilder/test/MTDDigiGeometryAnalyzer.cc
@@ -142,6 +142,9 @@ void MTDDigiGeometryAnalyzer::analyze(const edm::Event& iEvent, const edm::Event
   auto const& etldet = *(dynamic_cast<const MTDGeomDetUnit*>(pDD->detsETL().front()));
   checkPixelsAcceptance(etldet);
 
+  // ETL structure prints
+  edm::LogVerbatim("MTDDigiGeometryAnalyzer") << "\n";
+  sunitt_ << "\n";
   CheckETLstructure(*pDD);
 
   edm::LogVerbatim("MTDUnitTest") << sunitt_.str();

--- a/Geometry/MTDGeometryBuilder/test/MTDDigiGeometryAnalyzer.cc
+++ b/Geometry/MTDGeometryBuilder/test/MTDDigiGeometryAnalyzer.cc
@@ -144,7 +144,6 @@ void MTDDigiGeometryAnalyzer::analyze(const edm::Event& iEvent, const edm::Event
 
   // ETL structure prints
   edm::LogVerbatim("MTDDigiGeometryAnalyzer") << "\n";
-  sunitt_ << "\n";
   CheckETLstructure(*pDD);
 
   edm::LogVerbatim("MTDUnitTest") << sunitt_.str();
@@ -199,7 +198,6 @@ void MTDDigiGeometryAnalyzer::checkPixelsAcceptance(const GeomDetUnit& det) {
 
 void MTDDigiGeometryAnalyzer::CheckETLstructure(const MTDGeometry& geom) {
   edm::LogVerbatim("MTDDigiGeometryAnalyzer") << "\n--- ETL Structure Validation ---";
-  sunitt_ << "\n--- ETL Structure Validation ---";
 
   // Reset counters
   for (int d = 0; d < 4; ++d) {
@@ -261,10 +259,10 @@ void MTDDigiGeometryAnalyzer::CheckETLstructure(const MTDGeometry& geom) {
 
   // --- Print Summary ---
 
-  sunitt_ << " Total ETL Detectors (LGADs): " << totalETLdets << "\n";
+  edm::LogVerbatim("MTDDigiGeometryAnalyzer") << " Total ETL Detectors (LGADs): " << totalETLdets << "\n";
   const char* diskNames[4] = {"Disc 1 (-Z)", "Disc 2 (-Z)", "Disc 1 (+Z)", "Disc 2 (+Z)"};
 
-  sunitt_ << "\n--- LGADs per Eta Bin and per Disk, DiscSide, Sector ---\n";
+  edm::LogVerbatim("MTDDigiGeometryAnalyzer") << "\n--- LGADs per Eta Bin and per Disk, DiscSide, Sector ---\n";
   for (int d = 0; d < 4; ++d) {  // Physical Disk loop (0-3)
     std::string disk_name = diskNames[d];
     uint32_t total_disk = 0;
@@ -273,30 +271,30 @@ void MTDDigiGeometryAnalyzer::CheckETLstructure(const MTDGeometry& geom) {
         total_disk += LGADsPerDiscSideSector_[d][k][l];
       }
     }
-    sunitt_ << "Region: " << disk_name << " | Total LGADs: " << total_disk << "\n";
-    sunitt_ << "  - LGADs per Eta Bin:\n";
+    edm::LogVerbatim("MTDDigiGeometryAnalyzer") << "Region: " << disk_name << " | Total LGADs: " << total_disk << "\n";
+    edm::LogVerbatim("MTDDigiGeometryAnalyzer") << "  - LGADs per Eta Bin:\n";
     const double* eta_edges = (d < 2) ? eta_bins_edges_neg : eta_bins_edges_pos;
     for (int j = 0; j < n_bin_Eta; ++j) {
-      sunitt_ << "    Eta [" << std::setprecision(1) << std::fixed << eta_edges[j] << ", " << eta_edges[j + 1]
-              << "): " << LGADsPerDiskperEtaBin_[d][j] << "\n";
+      edm::LogVerbatim("MTDDigiGeometryAnalyzer")
+          << "    Eta [" << std::setprecision(1) << std::fixed << eta_edges[j] << ", " << eta_edges[j + 1]
+          << "): " << LGADsPerDiskperEtaBin_[d][j] << "\n";
     }
     for (int k = 0; k < n_discSide; ++k) {
       uint32_t total_discside = 0;
       for (int l = 1; l < n_sector; ++l) {
         total_discside += LGADsPerDiscSideSector_[d][k][l];
       }
-      sunitt_ << "  - Side: " << k << " | Total LGADs: " << total_discside << "\n";
-      sunitt_ << "    - Sectors: ";
+      edm::LogVerbatim("MTDDigiGeometryAnalyzer") << "  - Side: " << k << " | Total LGADs: " << total_discside << "\n";
+      edm::LogVerbatim("MTDDigiGeometryAnalyzer") << "    - Sectors: ";
       for (int l = 1; l < n_sector; ++l) {
         if (LGADsPerDiscSideSector_[d][k][l] > 0) {
-          sunitt_ << "Sec " << l << ": " << LGADsPerDiscSideSector_[d][k][l] << " | ";
+          edm::LogVerbatim("MTDDigiGeometryAnalyzer")
+              << "Sec " << l << ": " << LGADsPerDiscSideSector_[d][k][l] << " | ";
         }
       }
-      sunitt_ << "\n";
+      edm::LogVerbatim("MTDDigiGeometryAnalyzer") << "\n";
     }
   }
-
-  edm::LogVerbatim("MTDDigiGeometryAnalyzer") << sunitt_.str();
 }
 
 //define this as a plug-in

--- a/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
@@ -212,7 +212,7 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
     double bin_w_Q = (Q_Max - Q_Min) / n_bin_Q;
     // Initialize the Map Entry (if first hit for this LGAD)
     // The array must be initialized to all zeros.
-    std::array<uint32_t, n_bin_Q> zero_counts_Q{}; // Array of N_bin_q zeros
+    std::array<uint32_t, n_bin_Q> zero_counts_Q{};  // Array of N_bin_q zeros
     ndigiPerLGADoverQ_[idet].emplace(detId.rawId(), zero_counts_Q);
     // Increment the Appropriate Counters
     auto& threshold_counters = ndigiPerLGADoverQ_[idet].at(detId.rawId());
@@ -249,10 +249,10 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
 
   // --- Occupancy study for different thresholds on Q
   double bin_w_Q = (Q_Max - Q_Min) / n_bin_Q;
-  for (int i = 0; i < 4; i++) { // Loop over the 4 ETL regions
+  for (int i = 0; i < 4; i++) {  // Loop over the 4 ETL regions
     // For each threshold bin (x-axis of the profile)
     for (int j = 0; j < n_bin_Q; j++) {
-      double Q_value = Q_Min + j * bin_w_Q + (bin_w_Q / 2.); // Center of the threshold bin
+      double Q_value = Q_Min + j * bin_w_Q + (bin_w_Q / 2.);  // Center of the threshold bin
       double total_n_hits_for_this_threshold = 0.;
       // Variable to count LGADs with at least one hit above threshold j
       size_t n_lgads_with_hits_for_this_threshold = 0;
@@ -266,10 +266,6 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
       }
       // Calculate the average number of hits per LGAD
       double average_n_hits = 0.;
-//      const size_t n_lgads_hit = ndigiPerLGADoverQ_[i].size();
-//      if (n_lgads_hit > 0) {
-//        average_n_hits = total_n_hits_for_this_threshold / static_cast<double>(n_lgads_hit);
-//      }
       if (n_lgads_with_hits_for_this_threshold > 0) {
         average_n_hits = total_n_hits_for_this_threshold / static_cast<double>(n_lgads_with_hits_for_this_threshold);
       }
@@ -280,11 +276,11 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
     }
   }
   // --- Occupancy study for different bins on Eta
-  for (int i = 0; i < 4; i++) { // Loop over the 4 ETL regions
+  for (int i = 0; i < 4; i++) {  // Loop over the 4 ETL regions
     for (int j = 0; j < n_bin_Eta; j++) {
       double eta_low = ((i == 0) || (i == 1)) ? eta_bins_edges_neg[j] : eta_bins_edges_pos[j];
       double eta_high = ((i == 0) || (i == 1)) ? eta_bins_edges_neg[j + 1] : eta_bins_edges_pos[j + 1];
-      double eta_value = (eta_low + eta_high) / 2.; // Center of the Eta bin
+      double eta_value = (eta_low + eta_high) / 2.;  // Center of the Eta bin
       double total_n_hits_for_this_eta_bin = 0.;
       size_t n_lgads_with_hits_for_this_eta_bin = 0;
       for (const auto& entry : ndigiPerLGADoverEta_[i]) {
@@ -341,50 +337,150 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
   meNhitsPerLGAD_[3] =
       ibook.book1D("EtlNhitsPerLGADZposD2", "Number of ETL DIGI hits (+Z, Second disk) per LGAD;N_{DIGI}", 50, 0., 50.);
 
-  meNLgadWithHits_[0] =
-      ibook.book1D("EtlNLgadWithHitsZnegD1", "Number of ETL LGADs with at least 1 DIGI hit (-Z, D1);N_{LGAD with hit}", 100, 0., 4000.);
-  meNLgadWithHits_[1] =
-      ibook.book1D("EtlNLgadWithHitsZnegD2", "Number of ETL LGADs with at least 1 DIGI hit (-Z, D2);N_{LGAD with hit}", 100, 0., 4000.);
-  meNLgadWithHits_[2] =
-      ibook.book1D("EtlNLgadWithHitsZposD1", "Number of ETL LGADs with at least 1 DIGI hit (+Z, D1);N_{LGAD with hit}", 100, 0., 4000.);
-  meNLgadWithHits_[3] =
-       ibook.book1D("EtlNLgadWithHitsZposD2", "Number of ETL LGADs with at least 1 DIGI hit (+Z, D2);N_{LGAD with hit}", 100, 0., 4000.);
+  meNLgadWithHits_[0] = ibook.book1D("EtlNLgadWithHitsZnegD1",
+                                     "Number of ETL LGADs with at least 1 DIGI hit (-Z, D1);N_{LGAD with hit}",
+                                     100,
+                                     0.,
+                                     4000.);
+  meNLgadWithHits_[1] = ibook.book1D("EtlNLgadWithHitsZnegD2",
+                                     "Number of ETL LGADs with at least 1 DIGI hit (-Z, D2);N_{LGAD with hit}",
+                                     100,
+                                     0.,
+                                     4000.);
+  meNLgadWithHits_[2] = ibook.book1D("EtlNLgadWithHitsZposD1",
+                                     "Number of ETL LGADs with at least 1 DIGI hit (+Z, D1);N_{LGAD with hit}",
+                                     100,
+                                     0.,
+                                     4000.);
+  meNLgadWithHits_[3] = ibook.book1D("EtlNLgadWithHitsZposD2",
+                                     "Number of ETL LGADs with at least 1 DIGI hit (+Z, D2);N_{LGAD with hit}",
+                                     100,
+                                     0.,
+                                     4000.);
 
   meNhitsPerLGADoverQ_[0] =
-       ibook.bookProfile("EtlNhitsPerLGADvsQThZnegD1", "ETL DIGI Hits per LGAD vs Q Threshold (-Z, D1);Q Threshold [ADC counts];<N_{DIGI} per LGAD>", n_bin_Q, Q_Min, Q_Max, 0., 50.);
+      ibook.bookProfile("EtlNhitsPerLGADvsQThZnegD1",
+                        "ETL DIGI Hits per LGAD vs Q Threshold (-Z, D1);Q Threshold [ADC counts];<N_{DIGI} per LGAD>",
+                        n_bin_Q,
+                        Q_Min,
+                        Q_Max,
+                        0.,
+                        50.);
   meNhitsPerLGADoverQ_[1] =
-       ibook.bookProfile("EtlNhitsPerLGADvsQThZnegD2", "ETL DIGI Hits per LGAD vs Q Threshold (-Z, D2);Q Threshold [ADC counts];<N_{DIGI} per LGAD>", n_bin_Q, Q_Min, Q_Max, 0., 50.);
+      ibook.bookProfile("EtlNhitsPerLGADvsQThZnegD2",
+                        "ETL DIGI Hits per LGAD vs Q Threshold (-Z, D2);Q Threshold [ADC counts];<N_{DIGI} per LGAD>",
+                        n_bin_Q,
+                        Q_Min,
+                        Q_Max,
+                        0.,
+                        50.);
   meNhitsPerLGADoverQ_[2] =
-       ibook.bookProfile("EtlNhitsPerLGADvsQThZposD1", "ETL DIGI Hits per LGAD vs Q Threshold (+Z, D1);Q Threshold [ADC counts];<N_{DIGI} per LGAD>", n_bin_Q, Q_Min, Q_Max, 0., 50.);
+      ibook.bookProfile("EtlNhitsPerLGADvsQThZposD1",
+                        "ETL DIGI Hits per LGAD vs Q Threshold (+Z, D1);Q Threshold [ADC counts];<N_{DIGI} per LGAD>",
+                        n_bin_Q,
+                        Q_Min,
+                        Q_Max,
+                        0.,
+                        50.);
   meNhitsPerLGADoverQ_[3] =
-       ibook.bookProfile("EtlNhitsPerLGADvsQThZposD2", "ETL DIGI Hits per LGAD vs Q Threshold (+Z, D2);Q Threshold [ADC counts];<N_{DIGI} per LGAD>", n_bin_Q, Q_Min, Q_Max, 0., 50.);
+      ibook.bookProfile("EtlNhitsPerLGADvsQThZposD2",
+                        "ETL DIGI Hits per LGAD vs Q Threshold (+Z, D2);Q Threshold [ADC counts];<N_{DIGI} per LGAD>",
+                        n_bin_Q,
+                        Q_Min,
+                        Q_Max,
+                        0.,
+                        50.);
 
-  meNLgadWithHitsoverQ_[0] =
-       ibook.bookProfile("EtlNLgadWithHitsvsQThZnegD1", "Number of ETL LGADs with at least 1 DIGI hit vs Q Threshold (-Z, D1);Q Threshold [ADC counts];N_{LGAD with hit}", n_bin_Q, Q_Min, Q_Max, 0., 4000.);
-  meNLgadWithHitsoverQ_[1] =
-       ibook.bookProfile("EtlNLgadWithHitsvsQThZnegD2", "Number of ETL LGADs with at least 1 DIGI hit vs Q Threshold (-Z, D2);Q Threshold [ADC counts];N_{LGAD with hit}", n_bin_Q, Q_Min, Q_Max, 0., 4000.);
-  meNLgadWithHitsoverQ_[2] =
-       ibook.bookProfile("EtlNLgadWithHitsvsQThZposD1", "Number of ETL LGADs with at least 1 DIGI hit vs Q Threshold (+Z, D1);Q Threshold [ADC counts];N_{LGAD with hit}", n_bin_Q, Q_Min, Q_Max, 0., 4000.);
-  meNLgadWithHitsoverQ_[3] =
-       ibook.bookProfile("EtlNLgadWithHitsvsQThZposD2", "Number of ETL LGADs with at least 1 DIGI hit vs Q Threshold (+Z, D2);Q Threshold [ADC counts];N_{LGAD with hit}", n_bin_Q, Q_Min, Q_Max, 0., 4000.);
+  meNLgadWithHitsoverQ_[0] = ibook.bookProfile(
+      "EtlNLgadWithHitsvsQThZnegD1",
+      "Number of ETL LGADs with at least 1 DIGI hit vs Q Threshold (-Z, D1);Q Threshold [ADC counts];N_{LGAD with hit}",
+      n_bin_Q,
+      Q_Min,
+      Q_Max,
+      0.,
+      4000.);
+  meNLgadWithHitsoverQ_[1] = ibook.bookProfile(
+      "EtlNLgadWithHitsvsQThZnegD2",
+      "Number of ETL LGADs with at least 1 DIGI hit vs Q Threshold (-Z, D2);Q Threshold [ADC counts];N_{LGAD with hit}",
+      n_bin_Q,
+      Q_Min,
+      Q_Max,
+      0.,
+      4000.);
+  meNLgadWithHitsoverQ_[2] = ibook.bookProfile(
+      "EtlNLgadWithHitsvsQThZposD1",
+      "Number of ETL LGADs with at least 1 DIGI hit vs Q Threshold (+Z, D1);Q Threshold [ADC counts];N_{LGAD with hit}",
+      n_bin_Q,
+      Q_Min,
+      Q_Max,
+      0.,
+      4000.);
+  meNLgadWithHitsoverQ_[3] = ibook.bookProfile(
+      "EtlNLgadWithHitsvsQThZposD2",
+      "Number of ETL LGADs with at least 1 DIGI hit vs Q Threshold (+Z, D2);Q Threshold [ADC counts];N_{LGAD with hit}",
+      n_bin_Q,
+      Q_Min,
+      Q_Max,
+      0.,
+      4000.);
 
   meNhitsPerLGADoverEta_[0] =
-       ibook.bookProfile("EtlNhitsPerLGADvsEtaZnegD1", "ETL DIGI Hits per LGAD vs Eta Bin (-Z, D1);#eta_{DIGI};<N_{DIGI} per LGAD>", n_bin_Eta, eta_bins_edges_neg, 0., 50.);
+      ibook.bookProfile("EtlNhitsPerLGADvsEtaZnegD1",
+                        "ETL DIGI Hits per LGAD vs Eta Bin (-Z, D1);#eta_{DIGI};<N_{DIGI} per LGAD>",
+                        n_bin_Eta,
+                        eta_bins_edges_neg,
+                        0.,
+                        50.);
   meNhitsPerLGADoverEta_[1] =
-       ibook.bookProfile("EtlNhitsPerLGADvsEtaZnegD2", "ETL DIGI Hits per LGAD vs Eta Bin (-Z, D2);#eta_{DIGI};<N_{DIGI} per LGAD>", n_bin_Eta, eta_bins_edges_neg, 0., 50.);
+      ibook.bookProfile("EtlNhitsPerLGADvsEtaZnegD2",
+                        "ETL DIGI Hits per LGAD vs Eta Bin (-Z, D2);#eta_{DIGI};<N_{DIGI} per LGAD>",
+                        n_bin_Eta,
+                        eta_bins_edges_neg,
+                        0.,
+                        50.);
   meNhitsPerLGADoverEta_[2] =
-       ibook.bookProfile("EtlNhitsPerLGADvsEtaZposD1", "ETL DIGI Hits per LGAD vs Eta Bin (+Z, D1);#eta_{DIGI};<N_{DIGI} per LGAD>", n_bin_Eta, eta_bins_edges_pos, 0., 50.);
+      ibook.bookProfile("EtlNhitsPerLGADvsEtaZposD1",
+                        "ETL DIGI Hits per LGAD vs Eta Bin (+Z, D1);#eta_{DIGI};<N_{DIGI} per LGAD>",
+                        n_bin_Eta,
+                        eta_bins_edges_pos,
+                        0.,
+                        50.);
   meNhitsPerLGADoverEta_[3] =
-       ibook.bookProfile("EtlNhitsPerLGADvsEtaZposD2", "ETL DIGI Hits per LGAD vs Eta Bin (+Z, D2);#eta_{DIGI};<N_{DIGI} per LGAD>", n_bin_Eta, eta_bins_edges_pos, 0., 50.);
+      ibook.bookProfile("EtlNhitsPerLGADvsEtaZposD2",
+                        "ETL DIGI Hits per LGAD vs Eta Bin (+Z, D2);#eta_{DIGI};<N_{DIGI} per LGAD>",
+                        n_bin_Eta,
+                        eta_bins_edges_pos,
+                        0.,
+                        50.);
 
-  meNLgadWithHitsoverEta_[0] =
-       ibook.bookProfile("EtlNLgadWithHitsvsEtaZnegD1", "Number of ETL LGADs with at least 1 DIGI hit vs Eta Bin (-Z, D1);#eta_{DIGI};N_{LGAD with hit}", n_bin_Eta, eta_bins_edges_neg, 0., 4000.);
-  meNLgadWithHitsoverEta_[1] =
-       ibook.bookProfile("EtlNLgadWithHitsvsEtaZnegD2", "Number of ETL LGADs with at least 1 DIGI hit vs Eta Bin (-Z, D2);#eta_{DIGI};N_{LGAD with hit}", n_bin_Eta, eta_bins_edges_neg, 0., 4000.);
-  meNLgadWithHitsoverEta_[2] =
-       ibook.bookProfile("EtlNLgadWithHitsvsEtaZposD1", "Number of ETL LGADs with at least 1 DIGI hit vs Eta Bin (+Z, D1);#eta_{DIGI};N_{LGAD with hit}", n_bin_Eta, eta_bins_edges_pos, 0., 4000.);
-  meNLgadWithHitsoverEta_[3] =
-       ibook.bookProfile("EtlNLgadWithHitsvsEtaZposD2", "Number of ETL LGADs with at least 1 DIGI hit vs Eta Bin (+Z, D2);#eta_{DIGI};N_{LGAD with hit}", n_bin_Eta, eta_bins_edges_pos, 0., 4000.);
+  meNLgadWithHitsoverEta_[0] = ibook.bookProfile(
+      "EtlNLgadWithHitsvsEtaZnegD1",
+      "Number of ETL LGADs with at least 1 DIGI hit vs Eta Bin (-Z, D1);#eta_{DIGI};N_{LGAD with hit}",
+      n_bin_Eta,
+      eta_bins_edges_neg,
+      0.,
+      4000.);
+  meNLgadWithHitsoverEta_[1] = ibook.bookProfile(
+      "EtlNLgadWithHitsvsEtaZnegD2",
+      "Number of ETL LGADs with at least 1 DIGI hit vs Eta Bin (-Z, D2);#eta_{DIGI};N_{LGAD with hit}",
+      n_bin_Eta,
+      eta_bins_edges_neg,
+      0.,
+      4000.);
+  meNLgadWithHitsoverEta_[2] = ibook.bookProfile(
+      "EtlNLgadWithHitsvsEtaZposD1",
+      "Number of ETL LGADs with at least 1 DIGI hit vs Eta Bin (+Z, D1);#eta_{DIGI};N_{LGAD with hit}",
+      n_bin_Eta,
+      eta_bins_edges_pos,
+      0.,
+      4000.);
+  meNLgadWithHitsoverEta_[3] = ibook.bookProfile(
+      "EtlNLgadWithHitsvsEtaZposD2",
+      "Number of ETL LGADs with at least 1 DIGI hit vs Eta Bin (+Z, D2);#eta_{DIGI};N_{LGAD with hit}",
+      n_bin_Eta,
+      eta_bins_edges_pos,
+      0.,
+      4000.);
 
   meHitCharge_[0] = ibook.book1D("EtlHitChargeZnegD1",
                                  "ETL DIGI hits charge (-Z, Single(topo1D)/First(topo2D) disk);Q_{DIGI} [ADC counts]",

--- a/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
@@ -324,37 +324,37 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
 
   meNhitsPerLGAD_[0] = ibook.book1D("EtlNhitsPerLGADZnegD1",
                                     "Number of ETL DIGI hits (-Z, Single(topo1D)/First(topo2D) disk) per LGAD;N_{DIGI}",
-                                    50,
+                                    20,
                                     0.,
-                                    50.);
+                                    20.);
   meNhitsPerLGAD_[1] =
-      ibook.book1D("EtlNhitsPerLGADZnegD2", "Number of ETL DIGI hits (-Z, Second disk) per LGAD;N_{DIGI}", 50, 0., 50.);
+      ibook.book1D("EtlNhitsPerLGADZnegD2", "Number of ETL DIGI hits (-Z, Second disk) per LGAD;N_{DIGI}", 20, 0., 20.);
   meNhitsPerLGAD_[2] = ibook.book1D("EtlNhitsPerLGADZposD1",
                                     "Number of ETL DIGI hits (+Z, Single(topo1D)/First(topo2D) disk) per LGAD;N_{DIGI}",
-                                    50,
+                                    20,
                                     0.,
-                                    50.);
+                                    20.);
   meNhitsPerLGAD_[3] =
-      ibook.book1D("EtlNhitsPerLGADZposD2", "Number of ETL DIGI hits (+Z, Second disk) per LGAD;N_{DIGI}", 50, 0., 50.);
+      ibook.book1D("EtlNhitsPerLGADZposD2", "Number of ETL DIGI hits (+Z, Second disk) per LGAD;N_{DIGI}", 20, 0., 20.);
 
   meNLgadWithHits_[0] = ibook.book1D("EtlNLgadWithHitsZnegD1",
                                      "Number of ETL LGADs with at least 1 DIGI hit (-Z, D1);N_{LGAD with hit}",
-                                     100,
+                                     50,
                                      0.,
                                      4000.);
   meNLgadWithHits_[1] = ibook.book1D("EtlNLgadWithHitsZnegD2",
                                      "Number of ETL LGADs with at least 1 DIGI hit (-Z, D2);N_{LGAD with hit}",
-                                     100,
+                                     50,
                                      0.,
                                      4000.);
   meNLgadWithHits_[2] = ibook.book1D("EtlNLgadWithHitsZposD1",
                                      "Number of ETL LGADs with at least 1 DIGI hit (+Z, D1);N_{LGAD with hit}",
-                                     100,
+                                     50,
                                      0.,
                                      4000.);
   meNLgadWithHits_[3] = ibook.book1D("EtlNLgadWithHitsZposD2",
                                      "Number of ETL LGADs with at least 1 DIGI hit (+Z, D2);N_{LGAD with hit}",
-                                     100,
+                                     50,
                                      0.,
                                      4000.);
 
@@ -365,7 +365,7 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                         Q_Min,
                         Q_Max,
                         0.,
-                        50.);
+                        20.);
   meNhitsPerLGADoverQ_[1] =
       ibook.bookProfile("EtlNhitsPerLGADvsQThZnegD2",
                         "ETL DIGI Hits per LGAD vs Q Threshold (-Z, D2);Q Threshold [ADC counts];<N_{DIGI} per LGAD>",
@@ -373,7 +373,7 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                         Q_Min,
                         Q_Max,
                         0.,
-                        50.);
+                        20.);
   meNhitsPerLGADoverQ_[2] =
       ibook.bookProfile("EtlNhitsPerLGADvsQThZposD1",
                         "ETL DIGI Hits per LGAD vs Q Threshold (+Z, D1);Q Threshold [ADC counts];<N_{DIGI} per LGAD>",
@@ -381,7 +381,7 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                         Q_Min,
                         Q_Max,
                         0.,
-                        50.);
+                        20.);
   meNhitsPerLGADoverQ_[3] =
       ibook.bookProfile("EtlNhitsPerLGADvsQThZposD2",
                         "ETL DIGI Hits per LGAD vs Q Threshold (+Z, D2);Q Threshold [ADC counts];<N_{DIGI} per LGAD>",
@@ -389,7 +389,7 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                         Q_Min,
                         Q_Max,
                         0.,
-                        50.);
+                        20.);
 
   meNLgadWithHitsoverQ_[0] = ibook.bookProfile(
       "EtlNLgadWithHitsvsQThZnegD1",
@@ -430,28 +430,28 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                         n_bin_Eta,
                         eta_bins_edges_neg,
                         0.,
-                        50.);
+                        20.);
   meNhitsPerLGADoverEta_[1] =
       ibook.bookProfile("EtlNhitsPerLGADvsEtaZnegD2",
                         "ETL DIGI Hits per LGAD vs Eta Bin (-Z, D2);#eta_{DIGI};<N_{DIGI} per LGAD>",
                         n_bin_Eta,
                         eta_bins_edges_neg,
                         0.,
-                        50.);
+                        20.);
   meNhitsPerLGADoverEta_[2] =
       ibook.bookProfile("EtlNhitsPerLGADvsEtaZposD1",
                         "ETL DIGI Hits per LGAD vs Eta Bin (+Z, D1);#eta_{DIGI};<N_{DIGI} per LGAD>",
                         n_bin_Eta,
                         eta_bins_edges_pos,
                         0.,
-                        50.);
+                        20.);
   meNhitsPerLGADoverEta_[3] =
       ibook.bookProfile("EtlNhitsPerLGADvsEtaZposD2",
                         "ETL DIGI Hits per LGAD vs Eta Bin (+Z, D2);#eta_{DIGI};<N_{DIGI} per LGAD>",
                         n_bin_Eta,
                         eta_bins_edges_pos,
                         0.,
-                        50.);
+                        20.);
 
   meNLgadWithHitsoverEta_[0] = ibook.bookProfile(
       "EtlNLgadWithHitsvsEtaZnegD1",


### PR DESCRIPTION
PR description:

This PR extends EtlDigiHitsValidation to study LGAD occupancy, in particular saving histograms for: number of LGADs with at least one Digi hit per disk and average number of Digi hits per LGADs that were activated for each disk (also as a function of the Charge and predefined eta bins [1.5,2.1),[2.1,2.5),[2.5,3.0]).
Furthermore, this PR introduces the CheckETLstructure method to the MTDDigiGeometryAnalyzer. The CheckETLstructure method performs a detailed analysis of the ETL detector geometry by counting the number of LGAD detectors based on their geographical location: by physical disk and Z-side (e.g., Disc 1 ±Z, Disc 2 ±Z), by Disc Side and Sector as defined in the ETLDetId, and by predefined eta bins ([1.5,2.1),[2.1,2.5),[2.5,3.0]).

PR validation:
The validation code was tested with a TTBar_PU_200 sample, using the CMSSW_15_1_0_pre6 release. The validation of the MTDDigiGeometryAnalyzer ensures the geometrical configuration of the ETL meets the expected layout requirements (for D110, D118 and D119 scenarios).