### PR TITLE
LST: Introducing a condition before checking cuts in the T5 counting kernel

### DIFF
--- a/RecoTracker/LSTCore/interface/alpaka/Common.h
+++ b/RecoTracker/LSTCore/interface/alpaka/Common.h
@@ -42,6 +42,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
   HOST_DEVICE_CONSTANT float kWidth2S = 0.009;
   HOST_DEVICE_CONSTANT float kWidthPS = 0.01;
   HOST_DEVICE_CONSTANT float kPt_betaMax = 7.0;
+  HOST_DEVICE_CONSTANT int kNTripletThreshold = 1000;
   // To be updated with std::numeric_limits<float>::infinity() in the code and data files
   HOST_DEVICE_CONSTANT float kVerticalModuleSlope = 123456789.0;
 

--- a/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
@@ -746,10 +746,12 @@ void LSTEvent::createQuintuplets() {
                       countConn_workDiv,
                       CountTripletConnections{},
                       modules_.const_view<ModulesSoA>(),
+                      miniDoubletsDC_->const_view<MiniDoubletsSoA>(),
                       segmentsDC_->const_view<SegmentsSoA>(),
                       tripletsDC_->view<TripletsSoA>(),
                       tripletsDC_->const_view<TripletsOccupancySoA>(),
-                      rangesDC_->const_view());
+                      rangesDC_->const_view(),
+                      ptCut_);
 
   auto const createEligibleModulesListForQuintuplets_workDiv = cms::alpakatools::make_workdiv<Acc1D>(1, 1024);
 

--- a/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
@@ -1801,7 +1801,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                 } else {
                   int quintupletModuleIndex = alpaka::atomicAdd(
                       acc, &quintupletsOccupancy.nQuintuplets()[lowerModule1], 1u, alpaka::hierarchy::Threads{});
-                  //this if statement should never get executed!
                   if (ranges.quintupletModuleIndices()[lowerModule1] == -1) {
 #ifdef WARNINGS
                     printf("Quintuplets : no memory for module at module index = %d\n", lowerModule1);

--- a/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
@@ -1747,6 +1747,111 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
             if (miniDoublet3Index != outerInnerInnerMiniDoubletIndex)
               continue;
 
+            // If densely connected, do not attempt parallel processing to avoid truncation
+            if (nInnerTriplets >= kNTripletThreshold || nOuterTriplets >= kNTripletThreshold) {
+              uint16_t lowerModule2 = triplets.lowerModuleIndices()[innerTripletIndex][1];
+              uint16_t lowerModule4 = triplets.lowerModuleIndices()[outerTripletIndex][1];
+              uint16_t lowerModule5 = triplets.lowerModuleIndices()[outerTripletIndex][2];
+
+              float innerRadius, outerRadius, bridgeRadius, regressionCenterX, regressionCenterY, regressionRadius,
+                  rzChiSquared, chiSquared, nonAnchorChiSquared, dBeta1, dBeta2;  //required for making distributions
+
+              float t5Embed[Params_T5::kEmbed] = {0.f};
+
+              bool tightCutFlag = false;
+
+              bool success = runQuintupletDefaultAlgo(acc,
+                                                      modules,
+                                                      mds,
+                                                      segments,
+                                                      triplets,
+                                                      lowerModule1,
+                                                      lowerModule2,
+                                                      lowerModule3,
+                                                      lowerModule4,
+                                                      lowerModule5,
+                                                      innerTripletIndex,
+                                                      outerTripletIndex,
+                                                      innerRadius,
+                                                      outerRadius,
+                                                      bridgeRadius,
+                                                      regressionCenterX,
+                                                      regressionCenterY,
+                                                      regressionRadius,
+                                                      rzChiSquared,
+                                                      chiSquared,
+                                                      nonAnchorChiSquared,
+                                                      dBeta1,
+                                                      dBeta2,
+                                                      tightCutFlag,
+                                                      t5Embed,
+                                                      ptCut);
+              if (success) {
+                int totOccupancyQuintuplets =
+                    alpaka::atomicAdd(acc,
+                                      &quintupletsOccupancy.totOccupancyQuintuplets()[lowerModule1],
+                                      1u,
+                                      alpaka::hierarchy::Threads{});
+                if (totOccupancyQuintuplets >= ranges.quintupletModuleOccupancy()[lowerModule1]) {
+#ifdef WARNINGS
+                  printf("Quintuplet excess alert! Module index = %d, Occupancy = %d\n",
+                         lowerModule1,
+                         totOccupancyQuintuplets);
+#endif
+                } else {
+                  int quintupletModuleIndex = alpaka::atomicAdd(
+                      acc, &quintupletsOccupancy.nQuintuplets()[lowerModule1], 1u, alpaka::hierarchy::Threads{});
+                  //this if statement should never get executed!
+                  if (ranges.quintupletModuleIndices()[lowerModule1] == -1) {
+#ifdef WARNINGS
+                    printf("Quintuplets : no memory for module at module index = %d\n", lowerModule1);
+#endif
+                  } else {
+                    unsigned int quintupletIndex =
+                        ranges.quintupletModuleIndices()[lowerModule1] + quintupletModuleIndex;
+                    float phi = mds.anchorPhi()[segments.mdIndices()[triplets.segmentIndices()[innerTripletIndex][0]]
+                                                                    [layer2_adjustment]];
+                    float eta = mds.anchorEta()[segments.mdIndices()[triplets.segmentIndices()[innerTripletIndex][0]]
+                                                                    [layer2_adjustment]];
+                    float pt = (innerRadius + outerRadius) * k2Rinv1GeVf;
+                    float scores = chiSquared + nonAnchorChiSquared;
+                    addQuintupletToMemory(triplets,
+                                          quintuplets,
+                                          innerTripletIndex,
+                                          outerTripletIndex,
+                                          lowerModule1,
+                                          lowerModule2,
+                                          lowerModule3,
+                                          lowerModule4,
+                                          lowerModule5,
+                                          innerRadius,
+                                          bridgeRadius,
+                                          outerRadius,
+                                          regressionCenterX,
+                                          regressionCenterY,
+                                          regressionRadius,
+                                          rzChiSquared,
+                                          chiSquared,
+                                          nonAnchorChiSquared,
+                                          dBeta1,
+                                          dBeta2,
+                                          pt,
+                                          eta,
+                                          phi,
+                                          scores,
+                                          layer,
+                                          quintupletIndex,
+                                          t5Embed,
+                                          tightCutFlag);
+
+                    triplets.partOfT5()[quintuplets.tripletIndices()[quintupletIndex][0]] = true;
+                    triplets.partOfT5()[quintuplets.tripletIndices()[quintupletIndex][1]] = true;
+                  }
+                }
+              }
+              continue;
+            }
+
             // Match inner Sg and Outer Sg
             int mIdx = alpaka::atomicAdd(acc, &matchCount, 1, alpaka::hierarchy::Threads{});
             unsigned int quintupletIndex = ranges.quintupletModuleIndices()[lowerModule1] + mIdx;
@@ -1892,10 +1997,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
   struct CountTripletConnections {
     ALPAKA_FN_ACC void operator()(Acc3D const& acc,
                                   ModulesConst modules,
+                                  MiniDoubletsConst mds,
                                   SegmentsConst segments,
                                   Triplets triplets,
                                   TripletsOccupancyConst tripletsOcc,
-                                  ObjectRangesConst ranges) const {
+                                  ObjectRangesConst ranges,
+                                  const float ptCut) const {
       // The atomicAdd below with hierarchy::Threads{} requires one block in x, y dimensions.
       ALPAKA_ASSERT_ACC((alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[1] == 1) &&
                         (alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[2] == 1));
@@ -1929,7 +2036,50 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
             const unsigned int thirdMDInner = mdIndices[thirdSegIdx][0];
 
             if (secondMDOuter == thirdMDInner) {
-              alpaka::atomicAdd(acc, &triplets.connectedMax()[innerTripletIndex], 1u, alpaka::hierarchy::Threads{});
+              // Will only perform runQuintupletDefaultAlgorithm() checks if densely connected
+              if (nInnerTriplets < kNTripletThreshold && nOuterTriplets < kNTripletThreshold) {
+                alpaka::atomicAdd(acc, &triplets.connectedMax()[innerTripletIndex], 1u, alpaka::hierarchy::Threads{});
+              } else {
+                const uint16_t lowerModule2 = lmIdx[innerTripletIndex][1];
+                const uint16_t lowerModule4 = lmIdx[outerTripletIndex][1];
+                const uint16_t lowerModule5 = lmIdx[outerTripletIndex][2];
+
+                float innerRadius, outerRadius, bridgeRadius;
+                float regCx, regCy, regR;
+                float rzChi2, chi2, nonAnchorChi2, dBeta1, dBeta2;
+                float t5Embed[Params_T5::kEmbed] = {0.f};
+                bool tightFlag = false;
+
+                const bool ok = runQuintupletDefaultAlgo(acc,
+                                                         modules,
+                                                         mds,
+                                                         segments,
+                                                         triplets,
+                                                         lowerModule1,
+                                                         lowerModule2,
+                                                         lowerModule3,
+                                                         lowerModule4,
+                                                         lowerModule5,
+                                                         innerTripletIndex,
+                                                         outerTripletIndex,
+                                                         innerRadius,
+                                                         outerRadius,
+                                                         bridgeRadius,
+                                                         regCx,
+                                                         regCy,
+                                                         regR,
+                                                         rzChi2,
+                                                         chi2,
+                                                         nonAnchorChi2,
+                                                         dBeta1,
+                                                         dBeta2,
+                                                         tightFlag,
+                                                         t5Embed,
+                                                         ptCut);
+                if (ok) {
+                  alpaka::atomicAdd(acc, &triplets.connectedMax()[innerTripletIndex], 1u, alpaka::hierarchy::Threads{});
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
With dynamic memory allocation implemented, the high pT QCD sample I am looking at causes LST to crash. There is an overwhelming large amount of fake tracks that need to be accounted for. As is, it attempts to allocate memory for millions of (mostly fake) T5's. We expect the true amount to be around 300,000, compared to the 60,000 in the ttbar sample.

We could implement a cut that would remove many of the fake tracks, but there is a chance that this impacts the efficiency. Instead, here I included a condition that performs the standard set of cuts in the counting kernel if the corresponding triplet is densely connected. Most triplets will only be connected to a handful of potential quintuplets, whereas the ones leading to a large amount of fake tracks will have O(1000) connections. So, I included a condition that checks if the number of inner and outer connections is less than 1000.

Normally the full set of cuts would only be performed in the creation kernel. The cuts that are now included in the counting kernel do not affect the timing for a ttbar sample as none of its events meet the densely connected condition.

Here is a comparison in performance and timing on standalone:
```
   Evt    Hits       MD       LS      T3       T5       pLS       pT5      pT3      TC       Reset    Event     Short             Rate
[target branch]
   avg     15.2      0.4      0.4      0.5      0.6      0.3      0.6      0.3      0.9      0.0      19.3       3.9+/-  0.8      19.3   explicit[s=1]
   avg      1.2      0.6      0.6      0.7      0.8      0.3      0.9      0.4      1.3      0.0       6.8       5.3+/-  1.1       6.9   explicit[s=2]
   avg      2.1      0.8      1.0      1.2      1.3      0.4      1.5      0.7      1.9      0.0      10.9       8.4+/-  1.5       2.8   explicit[s=4]
   avg      2.4      1.3      1.5      1.8      1.8      0.6      2.0      0.9      2.6      0.0      14.8      11.8+/-  2.3       2.5   explicit[s=6]
   avg      3.5      1.7      2.0      2.2      2.5      0.7      2.9      1.2      3.3      0.0      20.1      15.8+/-  3.6       5.1   explicit[s=8]
[this PR]
   avg     24.3      0.4      0.4      0.5      0.9      0.3      0.6      0.3      0.9      0.0      28.7       4.1+/-  1.7      28.8   explicit[s=1]
   avg      1.2      0.6      0.6      0.7      1.1      0.3      1.0      0.5      1.2      0.0       7.2       5.7+/-  1.9       3.6   explicit[s=2]
   avg      2.5      0.8      1.0      1.2      1.6      0.4      1.5      0.7      1.9      0.0      11.8       8.8+/-  2.4       3.0   explicit[s=4]
   avg      3.0      1.3      1.4      1.8      2.3      0.6      2.1      1.0      2.7      0.0      16.3      12.7+/-  3.4       2.8   explicit[s=6]
   avg      3.8      1.7      2.0      2.4      3.0      0.7      2.9      1.3      3.3      0.0      21.2      16.7+/-  3.9       2.7   explicit[s=8]
```