### PR TITLE
Migrate skeletons to catch2 v3 (follow-up on #49121)

### DIFF
--- a/FWCore/Skeletons/mkTemplates/EDAnalyzer/test_catch2_EDAnalyzer.cc
+++ b/FWCore/Skeletons/mkTemplates/EDAnalyzer/test_catch2_EDAnalyzer.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 #include "FWCore/Utilities/interface/Exception.h"
 

--- a/FWCore/Skeletons/mkTemplates/EDAnalyzer/test_catch2_main.cc
+++ b/FWCore/Skeletons/mkTemplates/EDAnalyzer/test_catch2_main.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/FWCore/Skeletons/mkTemplates/EDFilter/test_catch2_EDFilter.cc
+++ b/FWCore/Skeletons/mkTemplates/EDFilter/test_catch2_EDFilter.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 #include "FWCore/Utilities/interface/Exception.h"
 

--- a/FWCore/Skeletons/mkTemplates/EDFilter/test_catch2_main.cc
+++ b/FWCore/Skeletons/mkTemplates/EDFilter/test_catch2_main.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/FWCore/Skeletons/mkTemplates/EDProducer/test_catch2_EDProducer.cc
+++ b/FWCore/Skeletons/mkTemplates/EDProducer/test_catch2_EDProducer.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 #include "FWCore/Utilities/interface/Exception.h"
 

--- a/FWCore/Skeletons/mkTemplates/EDProducer/test_catch2_main.cc
+++ b/FWCore/Skeletons/mkTemplates/EDProducer/test_catch2_main.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"

--- a/FWCore/TestProcessor/Readme.md
+++ b/FWCore/TestProcessor/Readme.md
@@ -167,7 +167,7 @@ int main() {
 ```cpp
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 ...
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 TEST_CASE("FooProd tests", "[FooProd]") {
   //The python configuration

--- a/PhysicsTools/TensorFlow/test/testBaseCUDA.h
+++ b/PhysicsTools/TensorFlow/test/testBaseCUDA.h
@@ -11,7 +11,7 @@
 #include <filesystem>
 #include <cppunit/extensions/HelperMacros.h>
 #include <stdexcept>
-#include "catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include "FWCore/AbstractServices/interface/ResourceInformation.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"


### PR DESCRIPTION
#### PR description:

Follow-up on #49121 to fix failing TestFWCoreSkeletons unit test:

```
>> Compiling  src/TestSubsystem/TestEDAnalyzer/test/test_catch2_TestEDAnalyzer.cc
src/TestSubsystem/TestEDAnalyzer/test/test_catch2_TestEDAnalyzer.cc:1:10: fatal error: catch.hpp: No such file or directory
    1 | #include "catch.hpp"
      |          ^~~~~~~~~~~
compilation terminated.
```

#### PR validation:

Bot tests