### PR TITLE
add barrel simHitCollections to `caloParticles` only in presence of `ticl_barrel` modifier

### DIFF
--- a/SimGeneral/MixingModule/python/caloTruthProducer_cfi.py
+++ b/SimGeneral/MixingModule/python/caloTruthProducer_cfi.py
@@ -59,8 +59,8 @@ run3_ecalclustering.toModify(
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toReplaceWith(caloParticles, cms.PSet()) # don't allow this to run in fastsim
 
-from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-phase2_common.toModify(
+from Configuration.ProcessModifiers.ticl_barrel_cff import ticl_barrel
+ticl_barrel.toModify(
     caloParticles, 
     simHitCollections = cms.PSet(
         hgc = cms.VInputTag(


### PR DESCRIPTION
#### PR description:

Title says it all, limits https://github.com/cms-sw/cmssw/commit/949095969e88e65c634a163b80fe328f9e6181fb from [cms-sw/cmssw#44560](https://github.com/cms-sw/cmssw/pull/44560) to `ticl_barrel` modifier, instead of extending to all phase-2 scenarios (not clear what's the advantage in that, also it might have introduced regressions in the HGCal ticl validation).
This PR in draft mode for now, just to understand the impact of the change.

#### PR validation:

None.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, not to be backported. 

Cc: @waredjeb @brusale @elenavernazza @bfonta @rovere 