### PR TITLE
[15_1_X] Update skipEventsWithoutScoutingByEra for ScoutingNano (backport of #49084)

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2023_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2023_cff.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_cff import Run3
 from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
-from Configuration.Eras.Modifier_run3_scouting_nanoAOD_2023_cff import run3_scouting_nanoAOD_2023
+from Configuration.Eras.Modifier_run3_scouting_2023_cff import run3_scouting_2023
 
-Run3_2023 = cms.ModifierChain(Run3, run3_egamma_2023, run3_scouting_nanoAOD_2023)
+Run3_2023 = cms.ModifierChain(Run3, run3_egamma_2023, run3_scouting_2023)

--- a/Configuration/Eras/python/Era_Run3_2024_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2024_cff.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_cff import Run3
 from Configuration.Eras.Modifier_stage2L1Trigger_2024_cff import stage2L1Trigger_2024
-from Configuration.Eras.Modifier_run3_scouting_nanoAOD_2024_cff import run3_scouting_nanoAOD_2024
+from Configuration.Eras.Modifier_run3_scouting_2024_cff import run3_scouting_2024
 
-Run3_2024 = cms.ModifierChain(Run3, stage2L1Trigger_2024, run3_scouting_nanoAOD_2024)
+Run3_2024 = cms.ModifierChain(Run3, stage2L1Trigger_2024, run3_scouting_2024)

--- a/Configuration/Eras/python/Era_Run3_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_cff.py
@@ -6,8 +6,9 @@ from Configuration.Eras.Modifier_run3_CSC_2025_cff import run3_CSC_2025
 from Configuration.Eras.Modifier_stage2L1Trigger_2025_cff import stage2L1Trigger_2025
 from Configuration.Eras.Modifier_run3_SiPixel_2025_cff import run3_SiPixel_2025
 from Configuration.Eras.Modifier_run3_nanoAOD_2025_cff import run3_nanoAOD_2025
+from Configuration.Eras.Modifier_run3_scouting_2025_cff import run3_scouting_2025
 from Configuration.ProcessModifiers.ecal_cctiming_cff import ecal_cctiming
 from Configuration.ProcessModifiers.siPixelGoodEdgeAlgo_cff import siPixelGoodEdgeAlgo
 from Configuration.ProcessModifiers.siPixelDigiMorphing_cff import siPixelDigiMorphing
 
-Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, stage2L1Trigger_2025, run3_SiPixel_2025, run3_CSC_2025, run3_nanoAOD_2025, ecal_cctiming, siPixelGoodEdgeAlgo, siPixelDigiMorphing)
+Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, stage2L1Trigger_2025, run3_SiPixel_2025, run3_CSC_2025, run3_nanoAOD_2025, run3_scouting_2025, ecal_cctiming, siPixelGoodEdgeAlgo, siPixelDigiMorphing)

--- a/Configuration/Eras/python/Modifier_run3_scouting_2023_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_scouting_2023_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_scouting_2023 = cms.Modifier()

--- a/Configuration/Eras/python/Modifier_run3_scouting_2024_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_scouting_2024_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_scouting_2024 = cms.Modifier()

--- a/Configuration/Eras/python/Modifier_run3_scouting_2025_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_scouting_2025_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_scouting_2025 = cms.Modifier()

--- a/Configuration/Eras/python/Modifier_run3_scouting_nanoAOD_2023_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_scouting_nanoAOD_2023_cff.py
@@ -1,3 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-run3_scouting_nanoAOD_2023 = cms.Modifier()

--- a/Configuration/Eras/python/Modifier_run3_scouting_nanoAOD_2024_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_scouting_nanoAOD_2024_cff.py
@@ -1,3 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-run3_scouting_nanoAOD_2024 = cms.Modifier()

--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -151,6 +151,23 @@ steps['NANO_data_UL18reMINI'] = merge([{'--era': 'Run2_2018',
                                        _NANO_data])
 
 ################################################################
+# 12.4 workflows -- data
+steps['ScoutingPFRun3_Run2022D_RAW_124X'] = {'INPUT': InputInfo(
+    dataSet='/ScoutingPFRun3/Run2022D-v1/RAW', label='2022D', events=100000, location='STD', ls=Run2022D)}
+
+steps['ScoutingPFMonitor_Run2022D_RAW_124X'] = {'INPUT': InputInfo(
+    dataSet='/ScoutingPFMonitor/Run2022D-v1/RAW', label='2022D', events=100000, location='STD', ls=Run2022D)}
+
+steps['NANO_data12.4'] = merge([{'--era': 'Run3,run3_nanoAOD_pre142X', '--conditions': 'auto:run3_data'},
+                                _NANO_data])
+
+steps['scoutingNANO_data12.4'] = merge([{'-s': 'NANO:@Scout'},
+                                        steps['NANO_data12.4']])
+
+steps['scoutingNANO_monitor_data12.4'] = merge([{'-s': 'NANO:@ScoutMonitor'},
+                                                steps['NANO_data12.4']])
+
+################################################################
 # 13.0 workflows
 steps['TTbarMINIAOD13.0'] = {'INPUT': InputInfo(
     location='STD', dataSet='/TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM')}
@@ -163,11 +180,13 @@ steps['NANO_mc13.0'] = merge([{'--era': 'Run3,run3_nanoAOD_pre142X', '--conditio
 steps['MuonEG2023MINIAOD13.0'] = {'INPUT': InputInfo(location='STD', ls={368489: [[46, 546]]},
                                                      dataSet='/MuonEG/Run2023C-22Sep2023_v4-v1/MINIAOD')}
 
-steps['ScoutingPFRun32022RAW13.0'] = {'INPUT': InputInfo(
-    dataSet='/ScoutingPFRun3/Run2022D-v1/RAW', label='2022D', events=100000, location='STD', ls=Run2022D)}
+steps['ScoutingPFRun3_Run2023D_RAW_130X'] = {'INPUT': InputInfo(
+    dataSet='/ScoutingPFRun3/Run2023D-v1/RAW', label='2023D', events=100000, location='STD', ls=Run2023D)}
 
+steps['ScoutingPFMonitor_Run2023D_RAW_130X'] = {'INPUT': InputInfo(
+    dataSet='/ScoutingPFMonitor/Run2023D-v1/RAW', label='2023D', events=100000, location='STD', ls=Run2023D)}
 
-steps['NANO_data13.0'] = merge([{'--era': 'Run3,run3_nanoAOD_pre142X', '--conditions': 'auto:run3_data'},
+steps['NANO_data13.0'] = merge([{'--era': 'Run3_2023,run3_nanoAOD_pre142X', '--conditions': 'auto:run3_data'},
                                 _NANO_data])
 
 steps['NANO_data13.0_prompt'] = merge([{'-s': 'NANO:@Prompt,DQM:@nanoAODDQM', '-n': '1000'},
@@ -176,6 +195,9 @@ steps['NANO_data13.0_prompt'] = merge([{'-s': 'NANO:@Prompt,DQM:@nanoAODDQM', '-
 
 steps['scoutingNANO_data13.0'] = merge([{'-s': 'NANO:@Scout'},
                                         steps['NANO_data13.0']])
+
+steps['scoutingNANO_monitor_data13.0'] = merge([{'-s': 'NANO:@ScoutMonitor'},
+                                                steps['NANO_data13.0']])
 
 
 ################################################################
@@ -264,8 +286,11 @@ steps['jmeNANO_data14.0'] = merge([{'-s': 'NANO:@JME,DQM:@nanojmeDQM', '-n': '10
 steps['scoutingNANO_data14.0'] = merge([{'-s': 'NANO:@Scout'},
                                         steps['NANO_data14.0']])
 
-steps['scoutingNANO_withPrompt_data14.0'] = merge([{'-s': 'NANO:@Prompt+@ScoutMonitor'},
-                                                   steps['NANO_data14.0']])
+steps['scoutingNANO_monitor_data14.0'] = merge([{'-s': 'NANO:@Prompt+@ScoutMonitor'},
+                                                steps['NANO_data14.0']])
+
+steps['scoutingNANO_monitorWithPrompt_data14.0'] = merge([{'-s': 'NANO:@Prompt+@ScoutMonitor'},
+                                                           steps['NANO_data14.0']])
 
 steps['l1ScoutingNANO_data14.0'] = merge([{'-s': 'NANO:@L1Scout', '-n': '1000'},
                                           steps['NANO_data14.0']])
@@ -381,8 +406,11 @@ steps['jmeNANO_rePuppi_data15.0'] = merge([{'-s': 'NANO:@JMErePuppi,DQM:@nanojme
 steps['scoutingNANO_data15.0'] = merge([{'-s': 'NANO:@Scout'},
                                         steps['NANO_data15.0']])
 
-steps['scoutingNANO_withPrompt_data15.0'] = merge([{'-s': 'NANO:@Prompt+@ScoutMonitor'},
-                                                   steps['NANO_data15.0']])
+steps['scoutingNANO_monitor_data15.0'] = merge([{'-s': 'NANO:@ScoutMonitor'},
+                                                steps['NANO_data15.0']])
+
+steps['scoutingNANO_monitorWithPrompt_data15.0'] = merge([{'-s': 'NANO:@Prompt+@ScoutMonitor'},
+                                                          steps['NANO_data15.0']])
 
 ################################################################
 # NANOGEN
@@ -434,7 +462,10 @@ _wfn.subnext()
 
 # POG/PAG custom NANOs, data
 _wfn.subnext()
-workflows[_wfn()] = ['ScoutingNANOdata130Xrun3', ['ScoutingPFRun32022RAW13.0', 'scoutingNANO_data13.0']]
+workflows[_wfn()] = ['ScoutingNANOdata124Xrun3', ['ScoutingPFRun3_Run2022D_RAW_124X', 'scoutingNANO_data12.4']]
+workflows[_wfn()] = ['ScoutingNANOmonitordata124Xrun3', ['ScoutingPFMonitor_Run2022D_RAW_124X', 'scoutingNANO_monitor_data12.4']]
+workflows[_wfn()] = ['ScoutingNANOdata130Xrun3', ['ScoutingPFRun3_Run2023D_RAW_130X', 'scoutingNANO_data13.0']]
+workflows[_wfn()] = ['ScoutingNANOmonitordata130Xrun3', ['ScoutingPFMonitor_Run2023D_RAW_130X', 'scoutingNANO_monitor_data13.0']]
 
 # DPG custom NANOs, data
 _wfn.subnext()
@@ -467,7 +498,8 @@ workflows[_wfn()] = ['jmeNANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'jmeNANO_d
 _wfn()  # workflows[_wfn()] = ['jmeNANOrePuppidata140Xrun3', ['MuonEG2024MINIAOD14.0', 'jmeNANO_rePuppi_data14.0']]
 workflows[_wfn()] = ['lepTrackInfoNANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'lepTrackInfoNANO_data14.0']]
 workflows[_wfn()] = ['ScoutingNANOdata140Xrun3', ['ScoutingPFRun32024RAW14.0', 'scoutingNANO_data14.0']]
-workflows[_wfn()] = ['ScoutingNANOwithPromptdata140Xrun3', ['ScoutingPFMonitor2024MINIAOD14.0', 'scoutingNANO_withPrompt_data14.0']]
+workflows[_wfn()] = ['ScoutingNANOmonitordata140Xrun3', ['ScoutingPFMonitor2024MINIAOD14.0', 'scoutingNANO_monitor_data14.0']]
+workflows[_wfn()] = ['ScoutingNANOmonitorWithPromptdata140Xrun3', ['ScoutingPFMonitor2024MINIAOD14.0', 'scoutingNANO_monitorWithPrompt_data14.0']]
 workflows[_wfn()] = ['L1ScoutingNANOdata140Xrun3', ['L1Scouting2024RAW14.0', 'l1ScoutingNANO_data14.0']]
 workflows[_wfn()] = ['L1ScoutingSelectionNANOdata140Xrun3', ['L1ScoutingSelection2024RAW14.0', 'l1ScoutingSelectionNANO_data14.0']]
 
@@ -526,7 +558,8 @@ workflows[_wfn()] = ['jmeNANOdata150Xrun3', ['JetMET1_Run2025C_MINIAOD_150X', 'j
 workflows[_wfn()] = ['jmeNANOrePuppidata150Xrun3', ['JetMET1_Run2025C_MINIAOD_150X', 'jmeNANO_rePuppi_data15.0']]
 workflows[_wfn()] = ['lepTrackInfoNANOdata150Xrun3', ['JetMET1_Run2025C_MINIAOD_150X', 'lepTrackInfoNANO_data15.0']]
 workflows[_wfn()] = ['ScoutingNANOdata150Xrun3', ['ScoutingPFRun3_Run2025C_HLTSCOUT_150X', 'scoutingNANO_data15.0']]
-workflows[_wfn()] = ['ScoutingNANOwithPromptdata150Xrun3', ['ScoutingPFMonitor_Run2025C_MINIAOD_150X', 'scoutingNANO_withPrompt_data15.0']]  # noqa
+workflows[_wfn()] = ['ScoutingNANOmonitordata150Xrun3', ['ScoutingPFMonitor_Run2025C_MINIAOD_150X', 'scoutingNANO_monitor_data15.0']]  # noqa
+workflows[_wfn()] = ['ScoutingNANOmonitorWithPromptdata150Xrun3', ['ScoutingPFMonitor_Run2025C_MINIAOD_150X', 'scoutingNANO_monitorWithPrompt_data15.0']]  # noqa
 workflows[_wfn()] = ['BPHNANOdata150Xrun3', ['JetMET1_Run2025C_MINIAOD_150X', 'BPHNANO_data15.0']]
 
 # DPG custom NANOs, data

--- a/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
@@ -20,7 +20,7 @@ scoutingMuonTableTask = cms.Task(scoutingMuonTable)
 scoutingMuonDisplacedVertexTableTask = cms.Task(scoutingMuonDisplacedVertexTable)
 
 # from 2024, there are two muon collections (https://its.cern.ch/jira/browse/CMSHLT-3089)
-run3_scouting_nanoAOD_2024.toReplaceWith(scoutingMuonTableTask, cms.Task(scoutingMuonVtxTable, scoutingMuonNoVtxTable))\
+run3_scouting_2024.toReplaceWith(scoutingMuonTableTask, cms.Task(scoutingMuonVtxTable, scoutingMuonNoVtxTable))\
     .toReplaceWith(scoutingMuonDisplacedVertexTableTask, cms.Task(scoutingMuonVtxDisplacedVertexTable, scoutingMuonNoVtxDisplacedVertexTable))
 
 # Scouting Electron
@@ -28,7 +28,7 @@ scoutingElectronTableTask = cms.Task(scoutingElectronTable)
 
 # from 2023, scouting electron's tracks are added as std::vector since multiple tracks can be associated to a scouting electron
 # plugin to select the best track to reduce to a single track per scouting electron is added
-(run3_scouting_nanoAOD_2023 | run3_scouting_nanoAOD_2024).toReplaceWith(
+(run3_scouting_2023 | run3_scouting_2024).toReplaceWith(
      scoutingElectronTableTask, cms.Task(scoutingElectronBestTrack, scoutingElectronTable)
 )
 
@@ -278,7 +278,7 @@ def addScoutingElectronTrack(process):
     )
     
     # additional electron track variables added in 2024 in https://github.com/cms-sw/cmssw/pull/43744
-    run3_scouting_nanoAOD_2024.toModify(
+    run3_scouting_2024.toModify(
         process.scoutingElectronTable.collectionVariables.variables,
         pMode = Var("trkpMode", "float", doc="track pMode"),
         etaMode = Var("trketaMode", "float", doc="track etaMode"),

--- a/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
@@ -20,7 +20,7 @@ scoutingMuonTableTask = cms.Task(scoutingMuonTable)
 scoutingMuonDisplacedVertexTableTask = cms.Task(scoutingMuonDisplacedVertexTable)
 
 # from 2024, there are two muon collections (https://its.cern.ch/jira/browse/CMSHLT-3089)
-run3_scouting_2024.toReplaceWith(scoutingMuonTableTask, cms.Task(scoutingMuonVtxTable, scoutingMuonNoVtxTable))\
+(run3_scouting_2024 | run3_scouting_2025).toReplaceWith(scoutingMuonTableTask, cms.Task(scoutingMuonVtxTable, scoutingMuonNoVtxTable))\
     .toReplaceWith(scoutingMuonDisplacedVertexTableTask, cms.Task(scoutingMuonVtxDisplacedVertexTable, scoutingMuonNoVtxDisplacedVertexTable))
 
 # Scouting Electron
@@ -28,7 +28,7 @@ scoutingElectronTableTask = cms.Task(scoutingElectronTable)
 
 # from 2023, scouting electron's tracks are added as std::vector since multiple tracks can be associated to a scouting electron
 # plugin to select the best track to reduce to a single track per scouting electron is added
-(run3_scouting_2023 | run3_scouting_2024).toReplaceWith(
+(run3_scouting_2023 | run3_scouting_2024 | run3_scouting_2025).toReplaceWith(
      scoutingElectronTableTask, cms.Task(scoutingElectronBestTrack, scoutingElectronTable)
 )
 
@@ -149,6 +149,18 @@ def customiseScoutingNano(process):
     
     return process
 
+##############
+### Filter ###
+##############
+
+# this filter selects only events triggered by scouting paths by checking scouting primary dataset bit(s)
+# if scouting paths are triggered, scouting objects will be reconstructed, so this gurantees that scouting objects  exist
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+scoutingTriggerPathFilter = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
+    HLTPaths = cms.vstring("Dataset_ScoutingPFRun3", "Dataset_ScoutingPF0", "Dataset_ScoutingPF1"),
+    throw = cms.bool(False)
+)
+
 #####################
 ### Customisation ###
 #####################
@@ -160,7 +172,7 @@ def customiseScoutingNano(process):
 # this is suitable when ScoutingPFMonitor/RAW is involved, e.g. RAW, RAW-MiniAOD two-file solution, full chain RAW-MiniAOD-NanoAOD
 # when running full chain RAW-MiniAOD-NanoAOD, this ensures that gtStage2Digis, gmtStage2Digis, and caloStage2Digis are run
 def customiseScoutingNanoForScoutingPFMonitor(process):
-    process = skipEventsWithoutScouting(process)
+    process = skipEventsWithoutScoutingByEra(process)
 
     # replace gtStage2DigisScouting with standard gtStage2Digis
     process.scoutingTriggerTask.remove(process.gtStage2DigisScouting)
@@ -194,7 +206,7 @@ def customiseScoutingNanoFromMini(process):
     # when running on data, assume ScoutingPFMonitor/MiniAOD dataset as inputs
     runOnData = hasattr(process,"NANOAODSIMoutput") or hasattr(process,"NANOAODoutput")
     if runOnData:
-        process = skipEventsWithoutScouting(process)
+        process = skipEventsWithoutScoutingByEra(process)
 
     # remove gtStage2Digis since they are already run for Mini
     process.scoutingTriggerTask.remove(process.gtStage2DigisScouting)
@@ -213,29 +225,50 @@ def customiseScoutingNanoFromMini(process):
     return process
 
 # skip events without scouting object products
-# this may be needed since for there are some events which do not contain scouting object products in 2022-24
+# this may be useful since ScoutingPFMonitor dataset contains some events which do not contain scouting object products in 2022-24
 # this is fixed for 2025: https://its.cern.ch/jira/browse/CMSHLT-3331
 def skipEventsWithoutScouting(process):
-    # if scouting paths are triggered, scouting objects will be reconstructed
-    # so we select events passing scouting paths
-    import HLTrigger.HLTfilters.hltHighLevel_cfi
+    # add filter/skim path to the process
+    process.scoutingNanoSkim_step = cms.Path(process.scoutingTriggerPathFilter)
 
-    process.scoutingTriggerPathFilter = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
-            HLTPaths = cms.vstring("Dataset_ScoutingPFRun3", "Dataset_ScoutingPF0", "Dataset_ScoutingPF1"),
-            throw = cms.bool(False)
-            )
-
-    process.nanoSkim_step = cms.Path(process.scoutingTriggerPathFilter)
-    process.schedule.extend([process.nanoSkim_step])
+    # schedule filter/skim path to run
+    process.schedule.extend([process.scoutingNanoSkim_step])
 
     if hasattr(process, "NANOAODoutput"):
-        process.NANOAODoutput.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("nanoSkim_step"))
+        process.NANOAODoutput.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("scoutingNanoSkim_step"))
 
-    if hasattr(process, "NANOAODEDMoutput"):
-        process.NANOEDMAODoutput.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("nanoSkim_step"))
+    if hasattr(process, "NANOEDMAODoutput"):
+        process.NANOEDMAODoutput.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("scoutingNanoSkim_step"))
 
     if hasattr(process, "write_NANOAOD"): # PromptReco
-        process.write_NANOAOD.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("nanoSkim_step")) 
+        process.write_NANOAOD.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("scoutingNanoSkim_step")) 
+
+    return process
+
+# skip events without scouting object products by era
+# this may be useful since ScoutingPFMonitor dataset contains some events which do not contain scouting object products in 2022-24
+# this is fixed for 2025: https://its.cern.ch/jira/browse/CMSHLT-3331
+def skipEventsWithoutScoutingByEra(process):
+    # add filter/skim path to the process
+    process.scoutingNanoSkim_step = cms.Path(process.scoutingTriggerPathFilter)
+
+    if hasattr(process, "NANOAODoutput"):
+        (~run3_scouting_2025).toModify(process.NANOAODoutput, SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("scoutingNanoSkim_step")))
+        if hasattr(process.NANOAODoutput, "SelectEvents") and "scoutingNanoSkim_step" in process.NANOAODoutput.SelectEvents.SelectEvents:
+            # schedule filter/skim path to run
+            process.schedule.extend([process.scoutingNanoSkim_step])
+
+    if hasattr(process, "NANOEDMAODoutput"):
+        (~run3_scouting_2025).toModify(process.NANOEDMAODoutput, SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("scoutingNanoSkim_step")))
+        if hasattr(process.NANOEDMAODoutput, "SelectEvents") and "scoutingNanoSkim_step" in process.NANOEDMAODoutput.SelectEvents.SelectEvents:
+            # schedule filter/skim path to run
+            process.schedule.extend([process.scoutingNanoSkim_step])
+
+    if hasattr(process, "write_NANOAOD"): # PromptReco
+        (~run3_scouting_2025).toModify(process.write_NANOAOD, SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("scoutingNanoSkim_step")))
+        if hasattr(process.write_NANOAOD, "SelectEvents") and "scoutingNanoSkim_step" in process.write_NANOAOD.SelectEvents.SelectEvents:
+            # schedule filter/skim path to run
+            process.schedule.extend([process.scoutingNanoSkim_step])
 
     return process
 
@@ -278,7 +311,7 @@ def addScoutingElectronTrack(process):
     )
     
     # additional electron track variables added in 2024 in https://github.com/cms-sw/cmssw/pull/43744
-    run3_scouting_2024.toModify(
+    (run3_scouting_2024 | run3_scouting_2025).toModify(
         process.scoutingElectronTable.collectionVariables.variables,
         pMode = Var("trkpMode", "float", doc="track pMode"),
         etaMode = Var("trketaMode", "float", doc="track etaMode"),

--- a/PhysicsTools/NanoAOD/python/run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/run3scouting_cff.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 from  PhysicsTools.NanoAOD.common_cff import *
 from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
-from Configuration.Eras.Modifier_run3_scouting_nanoAOD_2023_cff import run3_scouting_nanoAOD_2023
-from Configuration.Eras.Modifier_run3_scouting_nanoAOD_2024_cff import run3_scouting_nanoAOD_2024
+from Configuration.Eras.Modifier_run3_scouting_2023_cff import run3_scouting_2023
+from Configuration.Eras.Modifier_run3_scouting_2024_cff import run3_scouting_2024
 
 #####################################
 ##### Scouting Original Objects #####
@@ -125,7 +125,7 @@ scoutingVertexVariables = cms.PSet(
 # used for both primary vertex and dimuon displaced vertex
 # https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingVertex.h
 
-run3_scouting_nanoAOD_2024.toModify(
+run3_scouting_2024.toModify(
     scoutingVertexVariables,
     xyCov = Var('xyCov', 'float', precision=10, doc='xy covariance'),
     xzCov = Var('xzCov', 'float', precision=10, doc='xz covariance'),
@@ -234,7 +234,7 @@ scoutingElectronBestTrack = cms.EDProducer("Run3ScoutingElectronBestTrackProduce
     DeltaPhiMax = cms.vdouble(0.06, 0.06)
 )
 
-(run3_scouting_nanoAOD_2023 | run3_scouting_nanoAOD_2024).toModify(
+(run3_scouting_2023 | run3_scouting_2024).toModify(
     scoutingElectronTable.variables,
     d0 = None,      # replaced with trkd0 (std::vector)
     dz = None,      # replaced with trkdz (std::vector)
@@ -253,7 +253,7 @@ scoutingElectronBestTrack = cms.EDProducer("Run3ScoutingElectronBestTrackProduce
 # scouting electron format changed for 2024 data-taking in https://github.com/cms-sw/cmssw/pull/43744
 # https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingElectron.h
 
-run3_scouting_nanoAOD_2024.toModify(
+run3_scouting_2024.toModify(
     scoutingElectronTable.variables,
     rawEnergy = Var("rawEnergy", "float", precision=10, doc="raw energy"),
     preshowerEnergy = Var("preshowerEnergy", "float", precision=10, doc='preshower energy'),
@@ -301,7 +301,7 @@ scoutingPhotonTable = cms.EDProducer("SimpleRun3ScoutingPhotonFlatTableProducer"
 # scouting photon format changed for 2024 data-taking in https://github.com/cms-sw/cmssw/pull/43744
 # https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingPhoton.h
 
-run3_scouting_nanoAOD_2024.toModify(
+run3_scouting_2024.toModify(
     scoutingPhotonTable.variables,
     rawEnergy = Var("rawEnergy", "float", precision=10, doc="raw energy"),
     preshowerEnergy = Var("preshowerEnergy", "float", precision=10, doc='preshower energy'),
@@ -702,7 +702,7 @@ scoutingFatPFJetReclusterGlobalParticleTransformerJetTags = cms.EDProducer("Boos
     debugMode = cms.untracked.bool(False),
 )
 
-run3_scouting_nanoAOD_2024.toModify(
+run3_scouting_2024.toModify(
     scoutingFatPFJetReclusterGlobalParticleTransformerJetTags,
     model_path = cms.FileInPath("RecoBTag/Combined/data/Run3Scouting/GlobalParticleTransformerAK8/General/V00/global-part_2024.onnx")
 )

--- a/PhysicsTools/NanoAOD/python/run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/run3scouting_cff.py
@@ -3,6 +3,7 @@ from  PhysicsTools.NanoAOD.common_cff import *
 from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
 from Configuration.Eras.Modifier_run3_scouting_2023_cff import run3_scouting_2023
 from Configuration.Eras.Modifier_run3_scouting_2024_cff import run3_scouting_2024
+from Configuration.Eras.Modifier_run3_scouting_2025_cff import run3_scouting_2025
 
 #####################################
 ##### Scouting Original Objects #####
@@ -125,7 +126,7 @@ scoutingVertexVariables = cms.PSet(
 # used for both primary vertex and dimuon displaced vertex
 # https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingVertex.h
 
-run3_scouting_2024.toModify(
+(run3_scouting_2024 | run3_scouting_2025).toModify(
     scoutingVertexVariables,
     xyCov = Var('xyCov', 'float', precision=10, doc='xy covariance'),
     xzCov = Var('xzCov', 'float', precision=10, doc='xz covariance'),
@@ -234,7 +235,7 @@ scoutingElectronBestTrack = cms.EDProducer("Run3ScoutingElectronBestTrackProduce
     DeltaPhiMax = cms.vdouble(0.06, 0.06)
 )
 
-(run3_scouting_2023 | run3_scouting_2024).toModify(
+(run3_scouting_2023 | run3_scouting_2024 | run3_scouting_2025).toModify(
     scoutingElectronTable.variables,
     d0 = None,      # replaced with trkd0 (std::vector)
     dz = None,      # replaced with trkdz (std::vector)
@@ -253,7 +254,7 @@ scoutingElectronBestTrack = cms.EDProducer("Run3ScoutingElectronBestTrackProduce
 # scouting electron format changed for 2024 data-taking in https://github.com/cms-sw/cmssw/pull/43744
 # https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingElectron.h
 
-run3_scouting_2024.toModify(
+(run3_scouting_2024 | run3_scouting_2025).toModify(
     scoutingElectronTable.variables,
     rawEnergy = Var("rawEnergy", "float", precision=10, doc="raw energy"),
     preshowerEnergy = Var("preshowerEnergy", "float", precision=10, doc='preshower energy'),
@@ -301,7 +302,7 @@ scoutingPhotonTable = cms.EDProducer("SimpleRun3ScoutingPhotonFlatTableProducer"
 # scouting photon format changed for 2024 data-taking in https://github.com/cms-sw/cmssw/pull/43744
 # https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingPhoton.h
 
-run3_scouting_2024.toModify(
+(run3_scouting_2024 | run3_scouting_2025).toModify(
     scoutingPhotonTable.variables,
     rawEnergy = Var("rawEnergy", "float", precision=10, doc="raw energy"),
     preshowerEnergy = Var("preshowerEnergy", "float", precision=10, doc='preshower energy'),
@@ -702,7 +703,7 @@ scoutingFatPFJetReclusterGlobalParticleTransformerJetTags = cms.EDProducer("Boos
     debugMode = cms.untracked.bool(False),
 )
 
-run3_scouting_2024.toModify(
+(run3_scouting_2024 | run3_scouting_2025).toModify(
     scoutingFatPFJetReclusterGlobalParticleTransformerJetTags,
     model_path = cms.FileInPath("RecoBTag/Combined/data/Run3Scouting/GlobalParticleTransformerAK8/General/V00/global-part_2024.onnx")
 )


### PR DESCRIPTION
#### PR description:

Backport of Update skipEventsWithoutScoutingByEra for ScoutingNano https://github.com/cms-sw/cmssw/pull/49084 to 15_1_X.

FYI: @silviodonato @mmusich 
