### PR TITLE
[15_0_X] ScoutingNano: Rename era modifier to be more generic (partial backport of #49084)

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2023_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2023_cff.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_cff import Run3
 from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
-from Configuration.Eras.Modifier_run3_scouting_nanoAOD_2023_cff import run3_scouting_nanoAOD_2023
+from Configuration.Eras.Modifier_run3_scouting_2023_cff import run3_scouting_2023
 
-Run3_2023 = cms.ModifierChain(Run3, run3_egamma_2023, run3_scouting_nanoAOD_2023)
+Run3_2023 = cms.ModifierChain(Run3, run3_egamma_2023, run3_scouting_2023)

--- a/Configuration/Eras/python/Era_Run3_2024_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2024_cff.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_cff import Run3
 from Configuration.Eras.Modifier_stage2L1Trigger_2024_cff import stage2L1Trigger_2024
-from Configuration.Eras.Modifier_run3_scouting_nanoAOD_2024_cff import run3_scouting_nanoAOD_2024
+from Configuration.Eras.Modifier_run3_scouting_2024_cff import run3_scouting_2024
 
-Run3_2024 = cms.ModifierChain(Run3, stage2L1Trigger_2024, run3_scouting_nanoAOD_2024)
+Run3_2024 = cms.ModifierChain(Run3, stage2L1Trigger_2024, run3_scouting_2024)

--- a/Configuration/Eras/python/Era_Run3_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_cff.py
@@ -6,8 +6,9 @@ from Configuration.Eras.Modifier_run3_CSC_2025_cff import run3_CSC_2025
 from Configuration.Eras.Modifier_stage2L1Trigger_2025_cff import stage2L1Trigger_2025
 from Configuration.Eras.Modifier_run3_SiPixel_2025_cff import run3_SiPixel_2025
 from Configuration.Eras.Modifier_run3_nanoAOD_2025_cff import run3_nanoAOD_2025
+from Configuration.Eras.Modifier_run3_scouting_2025_cff import run3_scouting_2025
 from Configuration.ProcessModifiers.ecal_cctiming_cff import ecal_cctiming
 from Configuration.ProcessModifiers.siPixelGoodEdgeAlgo_cff import siPixelGoodEdgeAlgo
 from Configuration.ProcessModifiers.siPixelDigiMorphing_cff import siPixelDigiMorphing
 
-Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, stage2L1Trigger_2025, run3_SiPixel_2025, run3_CSC_2025, run3_nanoAOD_2025, ecal_cctiming, siPixelGoodEdgeAlgo, siPixelDigiMorphing)
+Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, stage2L1Trigger_2025, run3_SiPixel_2025, run3_CSC_2025, run3_nanoAOD_2025, run3_scouting_2025, ecal_cctiming, siPixelGoodEdgeAlgo, siPixelDigiMorphing)

--- a/Configuration/Eras/python/Modifier_run3_scouting_2023_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_scouting_2023_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_scouting_2023 = cms.Modifier()

--- a/Configuration/Eras/python/Modifier_run3_scouting_2024_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_scouting_2024_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_scouting_2024 = cms.Modifier()

--- a/Configuration/Eras/python/Modifier_run3_scouting_2025_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_scouting_2025_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_scouting_2025 = cms.Modifier()

--- a/Configuration/Eras/python/Modifier_run3_scouting_nanoAOD_2023_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_scouting_nanoAOD_2023_cff.py
@@ -1,3 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-run3_scouting_nanoAOD_2023 = cms.Modifier()

--- a/Configuration/Eras/python/Modifier_run3_scouting_nanoAOD_2024_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_scouting_nanoAOD_2024_cff.py
@@ -1,3 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-run3_scouting_nanoAOD_2024 = cms.Modifier()

--- a/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
@@ -20,7 +20,7 @@ scoutingMuonTableTask = cms.Task(scoutingMuonTable)
 scoutingMuonDisplacedVertexTableTask = cms.Task(scoutingMuonDisplacedVertexTable)
 
 # from 2024, there are two muon collections (https://its.cern.ch/jira/browse/CMSHLT-3089)
-run3_scouting_nanoAOD_2024.toReplaceWith(scoutingMuonTableTask, cms.Task(scoutingMuonVtxTable, scoutingMuonNoVtxTable))\
+run3_scouting_2024.toReplaceWith(scoutingMuonTableTask, cms.Task(scoutingMuonVtxTable, scoutingMuonNoVtxTable))\
     .toReplaceWith(scoutingMuonDisplacedVertexTableTask, cms.Task(scoutingMuonVtxDisplacedVertexTable, scoutingMuonNoVtxDisplacedVertexTable))
 
 # Scouting Electron
@@ -28,7 +28,7 @@ scoutingElectronTableTask = cms.Task(scoutingElectronTable)
 
 # from 2023, scouting electron's tracks are added as std::vector since multiple tracks can be associated to a scouting electron
 # plugin to select the best track to reduce to a single track per scouting electron is added
-(run3_scouting_nanoAOD_2023 | run3_scouting_nanoAOD_2024).toReplaceWith(
+(run3_scouting_2023 | run3_scouting_2024).toReplaceWith(
      scoutingElectronTableTask, cms.Task(scoutingElectronBestTrack, scoutingElectronTable)
 )
 
@@ -278,7 +278,7 @@ def addScoutingElectronTrack(process):
     )
     
     # additional electron track variables added in 2024 in https://github.com/cms-sw/cmssw/pull/43744
-    run3_scouting_nanoAOD_2024.toModify(
+    run3_scouting_2024.toModify(
         process.scoutingElectronTable.collectionVariables.variables,
         pMode = Var("trkpMode", "float", doc="track pMode"),
         etaMode = Var("trketaMode", "float", doc="track etaMode"),

--- a/PhysicsTools/NanoAOD/python/run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/run3scouting_cff.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 from  PhysicsTools.NanoAOD.common_cff import *
 from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
-from Configuration.Eras.Modifier_run3_scouting_nanoAOD_2023_cff import run3_scouting_nanoAOD_2023
-from Configuration.Eras.Modifier_run3_scouting_nanoAOD_2024_cff import run3_scouting_nanoAOD_2024
+from Configuration.Eras.Modifier_run3_scouting_2023_cff import run3_scouting_2023
+from Configuration.Eras.Modifier_run3_scouting_2024_cff import run3_scouting_2024
 
 #####################################
 ##### Scouting Original Objects #####
@@ -125,7 +125,7 @@ scoutingVertexVariables = cms.PSet(
 # used for both primary vertex and dimuon displaced vertex
 # https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingVertex.h
 
-run3_scouting_nanoAOD_2024.toModify(
+run3_scouting_2024.toModify(
     scoutingVertexVariables,
     xyCov = Var('xyCov', 'float', precision=10, doc='xy covariance'),
     xzCov = Var('xzCov', 'float', precision=10, doc='xz covariance'),
@@ -234,7 +234,7 @@ scoutingElectronBestTrack = cms.EDProducer("Run3ScoutingElectronBestTrackProduce
     DeltaPhiMax = cms.vdouble(0.06, 0.06)
 )
 
-(run3_scouting_nanoAOD_2023 | run3_scouting_nanoAOD_2024).toModify(
+(run3_scouting_2023 | run3_scouting_2024).toModify(
     scoutingElectronTable.variables,
     d0 = None,      # replaced with trkd0 (std::vector)
     dz = None,      # replaced with trkdz (std::vector)
@@ -253,7 +253,7 @@ scoutingElectronBestTrack = cms.EDProducer("Run3ScoutingElectronBestTrackProduce
 # scouting electron format changed for 2024 data-taking in https://github.com/cms-sw/cmssw/pull/43744
 # https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingElectron.h
 
-run3_scouting_nanoAOD_2024.toModify(
+run3_scouting_2024.toModify(
     scoutingElectronTable.variables,
     rawEnergy = Var("rawEnergy", "float", precision=10, doc="raw energy"),
     preshowerEnergy = Var("preshowerEnergy", "float", precision=10, doc='preshower energy'),
@@ -301,7 +301,7 @@ scoutingPhotonTable = cms.EDProducer("SimpleRun3ScoutingPhotonFlatTableProducer"
 # scouting photon format changed for 2024 data-taking in https://github.com/cms-sw/cmssw/pull/43744
 # https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingPhoton.h
 
-run3_scouting_nanoAOD_2024.toModify(
+run3_scouting_2024.toModify(
     scoutingPhotonTable.variables,
     rawEnergy = Var("rawEnergy", "float", precision=10, doc="raw energy"),
     preshowerEnergy = Var("preshowerEnergy", "float", precision=10, doc='preshower energy'),
@@ -702,7 +702,7 @@ scoutingFatPFJetReclusterGlobalParticleTransformerJetTags = cms.EDProducer("Boos
     debugMode = cms.untracked.bool(False),
 )
 
-run3_scouting_nanoAOD_2024.toModify(
+run3_scouting_2024.toModify(
     scoutingFatPFJetReclusterGlobalParticleTransformerJetTags,
     model_path = cms.FileInPath("RecoBTag/Combined/data/Run3Scouting/GlobalParticleTransformerAK8/General/V00/global-part_2024.onnx")
 )


### PR DESCRIPTION
#### PR description:

This PR is a partial backport (first 2 commits) from https://github.com/cms-sw/cmssw/pull/49084 to rename era modifiers used in ScoutingNano to be more generic (run3_scouting_nanoAOD_YYYY -> run3_scouting_YYYY) so they can be reused for other tasks, e.g. DQM.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Partial backport of https://github.com/cms-sw/cmssw/pull/49084 to 15_0_X.

FYI: @silviodonato @mmusich 

