### PR TITLE
L1CSCSPStatusDigi: replace bzero with explicit initialization

### DIFF
--- a/DataFormats/L1CSCTrackFinder/interface/L1CSCSPStatusDigi.h
+++ b/DataFormats/L1CSCTrackFinder/interface/L1CSCSPStatusDigi.h
@@ -1,21 +1,19 @@
 #ifndef L1CSCSPStatusDigi_h
 #define L1CSCSPStatusDigi_h
 
-#include <cstring>
-
 class CSCTFUnpacker;
 
 class L1CSCSPStatusDigi {
 private:
-  unsigned short sp_slot;     //
-  unsigned short l1a_bxn;     // Take from the SP header
-  unsigned short fmm_status;  // Take from the SP header
+  unsigned short sp_slot{};     //
+  unsigned short l1a_bxn{};     // Take from the SP header
+  unsigned short fmm_status{};  // Take from the SP header
 
-  unsigned short se;  // Make logical OR of all tbins for each of 15(endcap) SE bits
-  unsigned short sm;  // Make logical OR of all tbins for each of 15(endcap) SM bits
-  unsigned long bx;   // Make logical OR of all tbins for each of 15(endcap)+2(barrel) BX bits
-  unsigned long af;   // Make logical OR of all tbins for each of 15(endcap)+2(barrel) AF bits
-  unsigned long vp;   // Make logical OR of all tbins for each of 15(endcap)+2(barrel) VP/VQ bits
+  unsigned short se{};  // Make logical OR of all tbins for each of 15(endcap) SE bits
+  unsigned short sm{};  // Make logical OR of all tbins for each of 15(endcap) SM bits
+  unsigned long bx{};   // Make logical OR of all tbins for each of 15(endcap)+2(barrel) BX bits
+  unsigned long af{};   // Make logical OR of all tbins for each of 15(endcap)+2(barrel) AF bits
+  unsigned long vp{};   // Make logical OR of all tbins for each of 15(endcap)+2(barrel) VP/VQ bits
   enum {
     IDLE = 1,
     CARRIER = 2,
@@ -23,11 +21,11 @@ private:
     ERROR = 8,
     FIFO = 16
   };  // States of optical receivers + Alignment FIFO full OR empty status
-  unsigned short link_status[15];  // Optical receiver status ORed for all tbins
-  unsigned short mpc_link_id;      // MPC_id and link# from MEx Data Record ORed for all tbins
+  unsigned short link_status[15]{};  // Optical receiver status ORed for all tbins
+  unsigned short mpc_link_id{};      // MPC_id and link# from MEx Data Record ORed for all tbins
 
-  unsigned long track_cnt;
-  unsigned long orbit_cnt;
+  unsigned long track_cnt{};
+  unsigned long orbit_cnt{};
 
   friend class CSCTFUnpacker;
 
@@ -45,8 +43,8 @@ public:
   unsigned long track_counter(void) const throw() { return track_cnt; }
   unsigned long orbit_counter(void) const throw() { return orbit_cnt; }
 
-  L1CSCSPStatusDigi(void) { bzero(this, sizeof(L1CSCSPStatusDigi)); }
-  ~L1CSCSPStatusDigi(void) {}
+  L1CSCSPStatusDigi(void) = default;
+  ~L1CSCSPStatusDigi(void) = default;
 };
 
 #endif


### PR DESCRIPTION
#### PR description:

In [ROOT6](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_aarch64_gcc13/CMSSW_16_0_ROOT6_X_2025-10-15-2300/DataFormats/L1CSCTrackFinder) IBs, the following warning is emitted at dictionary generation stage:

```
[src/DataFormats/L1CSCTrackFinder/interface/L1CSCSPStatusDigi.h:48](https://github.com/cms-sw/cmssw/blob/CMSSW_16_0_ROOT6_X_2025-10-15-2300/DataFormats/L1CSCTrackFinder/interface/L1CSCSPStatusDigi.h#L48):35: warning: first argument in call to 'bzero' is a pointer to non-trivially copyable type 'L1CSCSPStatusDigi' [-Wnontrivial-memcall]
   L1CSCSPStatusDigi(void) { bzero(this, sizeof(L1CSCSPStatusDigi)); }
                                  ^
src/DataFormats/L1CSCTrackFinder/interface/L1CSCSPStatusDigi.h:48:35: note: explicitly cast the pointer to silence this warning
  L1CSCSPStatusDigi(void) { bzero(this, sizeof(L1CSCSPStatusDigi)); }
                                  ^
                                  (void*)
```

This PR replaces (non-standard) `bzero` function with explicit initialization of class members.

#### PR validation:

No warnings emitted during local compilation.
