### PR TITLE
[L1T] replacing tensorflow with hls4ml model for EMTF NN

### DIFF
--- a/L1Trigger/L1TMuonEndCap/BuildFile.xml
+++ b/L1Trigger/L1TMuonEndCap/BuildFile.xml
@@ -8,3 +8,5 @@
 <use name="DataFormats/L1TMuon"/>
 <use name="L1Trigger/L1TMuon"/>
 <use name="PhysicsTools/TensorFlow"/>
+<use name="hls"/>
+<use name="hls4mlEmulatorExtras"/>

--- a/L1Trigger/L1TMuonEndCap/interface/PtAssignment.h
+++ b/L1Trigger/L1TMuonEndCap/interface/PtAssignment.h
@@ -24,7 +24,7 @@ public:
                  bool promoteMode7,
                  int modeQualVer,
                  std::vector<int> promoteMode7Sectors,
-                 std::string pbFileName);
+                 std::string nnModel);
 
   void process(EMTFTrackCollection& best_tracks);
 

--- a/L1Trigger/L1TMuonEndCap/interface/PtAssignmentEngineDxy.h
+++ b/L1Trigger/L1TMuonEndCap/interface/PtAssignmentEngineDxy.h
@@ -10,15 +10,16 @@
 
 #include "L1Trigger/L1TMuonEndCap/interface/Common.h"
 #include "L1Trigger/L1TMuonEndCap/interface/PtAssignmentEngineAux2017.h"
-#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "ap_fixed.h"
+#include "hls4ml/emulator.h"
 
 class PtAssignmentEngineDxy {
 public:
   explicit PtAssignmentEngineDxy();
   virtual ~PtAssignmentEngineDxy();
 
-  void configure(int verbose, const std::string pbFileNameDxy);
+  void configure(int verbose, const std::string nnModel);
 
   const PtAssignmentEngineAux2017& aux() const;
 
@@ -26,17 +27,13 @@ public:
 
   virtual void preprocessing_dxy(const EMTFTrack& track, emtf::Feature& feature) const;
 
-  virtual void call_tensorflow_dxy(const emtf::Feature& feature, emtf::Prediction& prediction) const;
+  virtual void call_hls_dxy(const emtf::Feature& feature, emtf::Prediction& prediction) const;
 
 protected:
   int verbose_;
-
-  tensorflow::GraphDef* graphDefDxy_;
-  tensorflow::Session* sessionDxy_;
-  std::string pbFileNameDxy_;
-  std::string pbFilePathDxy_;
-  std::string inputNameDxy_;
-  std::vector<std::string> outputNamesDxy_;
+  std::string nnModel_;
+  std::unique_ptr<hls4mlEmulator::ModelLoader> loader;
+  std::shared_ptr<hls4mlEmulator::Model> model;
 };
 
 #endif

--- a/L1Trigger/L1TMuonEndCap/interface/VersionControl.h
+++ b/L1Trigger/L1TMuonEndCap/interface/VersionControl.h
@@ -58,7 +58,7 @@ private:
   bool bug9BitDPhi_, bugMode7CLCT_, bugNegPt_, bugGMTPhi_, promoteMode7_;
   int modeQualVer_;
   std::vector<int> promoteMode7Sectors_;  // Sectors to promote mode 7 tracks in Run 2 and Run 3, -1 for all sectors
-  std::string pbFileName_;
+  std::string nnModel_;
 };
 
 #endif

--- a/L1Trigger/L1TMuonEndCap/plugins/BuildFile.xml
+++ b/L1Trigger/L1TMuonEndCap/plugins/BuildFile.xml
@@ -1,4 +1,6 @@
 <library file="*.cc" name="L1TriggerL1TMuonEndCapPlugins">
   <use name="L1Trigger/L1TMuonEndCap"/>
+  <use name="hls"/>
+  <use name="hls4mlEmulatorExtras"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
@@ -126,7 +126,7 @@ simEmtfDigisMC = cms.EDProducer("L1TMuonEndCapTrackProducer",
         PromoteMode7    = cms.bool(False), # Assign station 2-3-4 tracks with |eta| > 1.6 SingleMu quality
         ModeQualVer     = cms.int32(2),    # Version 2 contains modified mode-quality mapping for 2018
         PromoteMode7Sectors = cms.vint32(-1), # Sectors to promote mode 7 tracks in Run 2 and Run 3, -1 for all sectors
-        ProtobufFileName = cms.string('model_graph.displ.16.pb'), # Protobuf file name to be used by NN based pT assignment NNv16 is online since 26.06.2023
+        NNModel = cms.string('EMTFnn_v1'), # HLS model name to be used by NN based pT assignment NNv16 is online since 26.06.2023
     ),
 
 )

--- a/L1Trigger/L1TMuonEndCap/src/PtAssignment.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignment.cc
@@ -18,7 +18,7 @@ void PtAssignment::configure(PtAssignmentEngine* pt_assign_engine,
                              bool promoteMode7,
                              int modeQualVer,
                              std::vector<int> promoteMode7Sectors,
-                             std::string pbFileName) {
+                             std::string nnModel) {
   emtf_assert(pt_assign_engine != nullptr);
   emtf_assert(pt_assign_engine_dxy != nullptr);
 
@@ -33,7 +33,7 @@ void PtAssignment::configure(PtAssignmentEngine* pt_assign_engine,
 
   pt_assign_engine_->configure(verbose_, readPtLUTFile, fixMode15HighPt, bug9BitDPhi, bugMode7CLCT, bugNegPt);
 
-  pt_assign_engine_dxy_->configure(verbose_, pbFileName);
+  pt_assign_engine_dxy_->configure(verbose_, nnModel);
 
   bugGMTPhi_ = bugGMTPhi;
   promoteMode7_ = promoteMode7;

--- a/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngineDxy.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngineDxy.cc
@@ -13,7 +13,7 @@ PtAssignmentEngineDxy::~PtAssignmentEngineDxy() {}
 void PtAssignmentEngineDxy::configure(int verbose, const std::string nnModel) {
   nnModel_ = nnModel;
   verbose_ = verbose;
-  std::string nnModelDxy_ = "L1Trigger/L1TMuonEndCap/test/" + nnModel_ + "/" + nnModel_;
+  std::string nnModelDxy_ = nnModel_;
   loader = std::make_unique<hls4mlEmulator::ModelLoader>(nnModelDxy_);
   model = loader->load_model();
 }

--- a/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngineDxy.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngineDxy.cc
@@ -6,34 +6,16 @@
 
 #include "helper.h"  // assert_no_abort
 
-PtAssignmentEngineDxy::PtAssignmentEngineDxy() : graphDefDxy_(nullptr), sessionDxy_(nullptr) {}
+PtAssignmentEngineDxy::PtAssignmentEngineDxy() {}
 
-PtAssignmentEngineDxy::~PtAssignmentEngineDxy() {
-  if (sessionDxy_ != nullptr) {
-    tensorflow::closeSession(sessionDxy_);
-  }
-  delete graphDefDxy_;
-}
+PtAssignmentEngineDxy::~PtAssignmentEngineDxy() {}
 
-void PtAssignmentEngineDxy::configure(int verbose, const std::string pbFileNameDxy) {
+void PtAssignmentEngineDxy::configure(int verbose, const std::string nnModel) {
+  nnModel_ = nnModel;
   verbose_ = verbose;
-
-  pbFileNameDxy_ = pbFileNameDxy;
-  std::string pbFilePathDxy_ = "L1Trigger/L1TMuon/data/emtf_luts/" + pbFileNameDxy_;
-
-  inputNameDxy_ = "input1";
-  outputNamesDxy_ = {"Identity"};
-
-  if (graphDefDxy_ == nullptr) {
-    graphDefDxy_ = tensorflow::loadGraphDef(edm::FileInPath(pbFilePathDxy_).fullPath());
-  }
-  emtf_assert(graphDefDxy_ != nullptr);
-
-  if (sessionDxy_ == nullptr) {
-    sessionDxy_ = tensorflow::createSession(graphDefDxy_);
-  }
-
-  emtf_assert(sessionDxy_ != nullptr);
+  std::string nnModelDxy_ = "L1Trigger/L1TMuonEndCap/test/" + nnModel_ + "/" + nnModel_;
+  loader = std::make_unique<hls4mlEmulator::ModelLoader>(nnModelDxy_);
+  model = loader->load_model();
 }
 
 const PtAssignmentEngineAux2017& PtAssignmentEngineDxy::aux() const {
@@ -46,7 +28,7 @@ void PtAssignmentEngineDxy::calculate_pt_dxy(const EMTFTrack& track,
                                              emtf::Prediction& prediction) const {
   // This is called for each track instead of for entire track collection as was done in Phase-2 implementation
   preprocessing_dxy(track, feature);
-  call_tensorflow_dxy(feature, prediction);
+  call_hls_dxy(feature, prediction);
   return;
 }
 
@@ -153,19 +135,24 @@ void PtAssignmentEngineDxy::preprocessing_dxy(const EMTFTrack& track, emtf::Feat
   return;
 }
 
-void PtAssignmentEngineDxy::call_tensorflow_dxy(const emtf::Feature& feature, emtf::Prediction& prediction) const {
-  tensorflow::Tensor input(tensorflow::DT_FLOAT, {1, emtf::NUM_FEATURES});
-  std::vector<tensorflow::Tensor> outputs;
+void PtAssignmentEngineDxy::call_hls_dxy(const emtf::Feature& feature, emtf::Prediction& prediction) const {
   emtf_assert(feature.size() == emtf::NUM_FEATURES);
 
-  float* d = input.flat<float>().data();
-  std::copy(feature.begin(), feature.end(), d);
-  tensorflow::run(sessionDxy_, {{inputNameDxy_, input}}, outputNamesDxy_, &outputs);
-  emtf_assert(outputs.size() == 1);
+  ap_uint<13> nn_input[29];
+  for (size_t i = 0; i < feature.size(); i++) {
+    nn_input[i] = feature[i];
+  }
+  ap_uint<8> nn_output[2];
+  model->prepare_input(nn_input);
+  model->predict();
+  model->read_result(nn_output);
+  ap_uint<8> pT = nn_output[0];
+  ap_uint<7> dxy = (nn_output[1] > 127) ? ap_uint<7>(127) : ap_uint<7>(nn_output[1]);
+
   emtf_assert(prediction.size() == emtf::NUM_PREDICTIONS);
 
-  prediction.at(0) = outputs[0].matrix<float>()(0, 0);
-  prediction.at(1) = outputs[0].matrix<float>()(0, 1);
+  prediction.at(0) = pT.to_float();
+  prediction.at(1) = dxy.to_float();
 
   return;
 }

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessor.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessor.cc
@@ -169,7 +169,7 @@ void SectorProcessor::process_single_bx(int bx,
                       cfg.promoteMode7_,
                       cfg.modeQualVer_,
                       cfg.promoteMode7Sectors_,
-                      cfg.pbFileName_);
+                      cfg.nnModel_);
 
   std::map<int, TriggerPrimitiveCollection> selected_dt_map;
   std::map<int, TriggerPrimitiveCollection> selected_csc_map;

--- a/L1Trigger/L1TMuonEndCap/src/VersionControl.cc
+++ b/L1Trigger/L1TMuonEndCap/src/VersionControl.cc
@@ -64,7 +64,7 @@ VersionControl::VersionControl(const edm::ParameterSet& iConfig) : config_(iConf
   promoteMode7_ = spPAParams16.getParameter<bool>("PromoteMode7");
   modeQualVer_ = spPAParams16.getParameter<int>("ModeQualVer");
   promoteMode7Sectors_ = spPAParams16.getParameter<std::vector<int> >("PromoteMode7Sectors");
-  pbFileName_ = spPAParams16.getParameter<std::string>("ProtobufFileName");
+  nnModel_ = spPAParams16.getParameter<std::string>("NNModel");
 }
 
 VersionControl::~VersionControl() {}


### PR DESCRIPTION
#### PR description:

This PR replaces the tensorflow .pb file for EMTF NN and directly uses the hls4ml model files in CMSSW. Performance was tested and presented to L1T Offline SW meeting: https://indico.cern.ch/event/1591535/#3-emtf , we expect 1-2% improvement in DQM mismatches between data and emulator muons.
This depends on the external: https://github.com/cms-hls4ml

#### PR validation:

Compiled using code-checks and code-format

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.
