### PR TITLE
Undo change in PF electron_ecalDrivenHademPreselCut in PbPb era

### DIFF
--- a/RecoParticleFlow/PFProducer/python/particleFlow_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlow_cff.py
@@ -49,5 +49,4 @@ run3_common.toModify(particleFlowTmp.PFEGammaFiltersParameters,
 )
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-pp_on_AA.toModify(particleFlowTmp.PFEGammaFiltersParameters, electron_ecalDrivenHademPreselCut = 0.5)
 pp_on_AA.toModify(particleFlowTmp.PFEGammaFiltersParameters.electron_protectionsForJetMET, maxHcalE = 2000)


### PR DESCRIPTION
#### PR description:

This PR undoes the change in the PF electron_ecalDrivenHademPreselCut threshold that was introduced in the PbPb era. After some checks, it was found that this change in threshold does not have a significant impact in the efficiency of PF electrons while it does degrade the jet resolution by roughly 6%.

@mandrenguyen @pfs @RSalvatico

#### PR validation:

Tested with workflows 162,162.02,162.03,162.1,162.2,162.3,162.4

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 15_1_X for 2025 PbPb data taking
