### PR TITLE
provide default value for SimTrack member variable

### DIFF
--- a/SimDataFormats/Track/interface/SimTrack.h
+++ b/SimDataFormats/Track/interface/SimTrack.h
@@ -78,7 +78,7 @@ private:
   math::XYZVectorD tkposition;
   math::XYZTLorentzVectorD tkmomentum;
 
-  int idAtBoundary_;
+  int idAtBoundary_{-1};
   math::XYZTLorentzVectorF positionAtBoundary_;
   math::XYZTLorentzVectorF momentumAtBoundary_;
   uint8_t trackInfo_;


### PR DESCRIPTION
#### PR description:

While running valgrind for an unrelated issue, I noticed that this member variable was uninitialized. The initial value is set to -1, following the similar and related class https://github.com/cms-sw/cmssw/blob/c923b8ff02b7c8bb0501821bfee1e04ee3f5e62a/SimG4Core/Notification/interface/TmpSimTrack.h#L86

#### PR validation:

Code compiles. No changes expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, not expected to be backported.