### PR TITLE
Fix for the matches_dPt histogram title 

### DIFF
--- a/DQM/TrackingMonitorSource/src/TrackToTrackComparisonHists.cc
+++ b/DQM/TrackingMonitorSource/src/TrackToTrackComparisonHists.cc
@@ -471,7 +471,7 @@ void TrackToTrackComparisonHists::book_matching_tracks_histos(DQMStore::IBooker&
                                       Phi_rangeMin,
                                       Phi_rangeMax);
 
-  (mes.h_dPt) = ibooker.book1D(label + "_dPt", "#Delta track #P_T", ptRes_nbin, ptRes_rangeMin, ptRes_rangeMax);
+  (mes.h_dPt) = ibooker.book1D(label + "_dPt", "#Delta track p_{T}", ptRes_nbin, ptRes_rangeMin, ptRes_rangeMax);
   (mes.h_dEta) = ibooker.book1D(label + "_dEta", "#Delta track #eta", etaRes_nbin, etaRes_rangeMin, etaRes_rangeMax);
   (mes.h_dPhi) = ibooker.book1D(label + "_dPhi", "#Delta track #phi", phiRes_nbin, phiRes_rangeMin, phiRes_rangeMax);
   (mes.h_dDxy) = ibooker.book1D(


### PR DESCRIPTION
#### PR description:
Title of the `matches_dPt` histogram contains a typo, as shown in the following image (from HLT/Tracking/ValidationWRTOffline/hltMergedWrtHighPurityPV/matches_dPt)

<img width="1827" height="1044" alt="Screenshot 2025-10-20 092657" src="https://github.com/user-attachments/assets/035ada13-8ac9-4427-8c80-f9714542e402" />

The typo is fixed by replacement of `#P_T` to `p_{T}` so that the latex for $p_T$ is rendered correctly.


#### PR validation:
This PR addresses a fix for an histogram title in DQM, no physics/timing validation is required.

The fix can be tested promptly creating a ROOT histogram with the modified title - i.e.:
```python
import ROOT
hist = ROOT.TH1D("h1", "#Delta track p_{T}; xaxis; counts", 10, 0, 10)
hist.Draw("hist")
input("press Enter to quit")
```