### PR TITLE
Update for Labels of GE2/1 Layers on GEM online DQM

### DIFF
--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -604,6 +604,7 @@ protected:
   };
 
   int SortingLayers(std::vector<ME4IdsKey> &listLayers);
+  int getDisplayModuleNumber(int station, int layer, int module_number);
   dqm::impl::MonitorElement *CreateSummaryHist(DQMStore::IBooker &ibooker, TString strName);
 
   template <typename T>
@@ -755,7 +756,7 @@ inline std::string GEMDQMBase::getNameDirLayer(ME4IdsKey key4) {
   char cRegion = (keyToRegion(key4) > 0 ? 'P' : 'M');
   auto nLayer = keyToLayer(key4);
   if (nStation == 2) {
-    auto nModule = keyToModule(key4);
+    auto nModule = getDisplayModuleNumber(nStation, nLayer, keyToModule(key4));
     return std::string(Form("GE%i1-%c-L%i-M%i", nStation, cRegion, nLayer, nModule));
   }
   return std::string(Form("GE%i1-%c-L%i", nStation, cRegion, nLayer));

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -166,7 +166,8 @@ int GEMRecHitSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
       mapCLSOver5_.FindHist(key)->setYTitle("Module");
     }
     for (Int_t i = 1; i <= stationInfo.nNumModules_; i++) {
-      std::string strLabel = std::string(Form("M%i", i));
+      Int_t module_number = getDisplayModuleNumber(keyToStation(key), keyToLayer(key), i);
+      std::string strLabel = std::string(Form("M%i", module_number));
       if (mapCLSAverage_.isOperating()) {
         mapCLSAverage_.FindHist(key)->setBinLabel(i, strLabel, 2);
       }
@@ -199,7 +200,8 @@ int GEMRecHitSource::ProcessWithMEMap4WithChamber(BookingHelper& bh, ME4IdsKey k
       mapCLSPerCh_.FindHist(key)->setYTitle("Module");
     }
     for (Int_t i = 1; i <= stationInfo.nNumModules_; i++) {
-      std::string strLabel = std::string(Form("M%i", i));
+      Int_t module_number = getDisplayModuleNumber(keyToStation(key), keyToLayer(key), i);
+      std::string strLabel = std::string(Form("M%i", module_number));
       if (mapCLSPerCh_.isOperating()) {
         mapCLSPerCh_.FindHist(key)->setBinLabel(i, strLabel, 2);
       }

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -148,6 +148,7 @@ int GEMDQMBase::SortingLayers(std::vector<ME4IdsKey>& listLayers) {
 }
 
 int GEMDQMBase::getDisplayModuleNumber(int station, int layer, int module_number) {
+  // For GE2/1 Layer 1, labeling module numbers as 5–8 instead of 1–4
   if (station == 2 && layer == 1)
     return module_number + 4;
   return module_number;

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -148,8 +148,9 @@ int GEMDQMBase::SortingLayers(std::vector<ME4IdsKey>& listLayers) {
 }
 
 int GEMDQMBase::getDisplayModuleNumber(int station, int layer, int module_number) {
-    if (station == 2 && layer == 1) return module_number + 4;
-    return module_number;
+  if (station == 2 && layer == 1)
+    return module_number + 4;
+  return module_number;
 }
 
 dqm::impl::MonitorElement* GEMDQMBase::CreateSummaryHist(DQMStore::IBooker& ibooker, TString strName) {


### PR DESCRIPTION
#### PR description:

In this PR, GEM online DQM plots for GE2/1 Layer 1 labels have been implemented.

#### PR validation:

Tests are done with cmsRun $CMSSW_BASE/src/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py unitTest=True runNumber=396180 dataset=/ExpressPhysics/Run2025E-Express-v1/FEVT and runTheMatrix.py -l limited -i all --ibeos since it makes effects on P5 and reconstruction

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Since this year's data taking is on the 15_0_X version so I will backport to 15_0_X and create a separate backport PR as well.

@jshlee @watson-ij @Dongwoon77 @hyokyu-choi