### PR TITLE
Remove weight from SeedCandidate

### DIFF
--- a/RecoMuon/MuonSeedGenerator/interface/SETFilter.h
+++ b/RecoMuon/MuonSeedGenerator/interface/SETFilter.h
@@ -34,7 +34,6 @@ struct SeedCandidate {
   MuonTransientTrackingRecHit::MuonRecHitContainer theSet;
   CLHEP::Hep3Vector momentum;
   int charge;
-  double weight;
   Trajectory::DataContainer trajectoryMeasurementsInTheSet;
 };
 


### PR DESCRIPTION
#### PR description:

This PR addresses issue https://github.com/cms-sw/cmssw/issues/49156 and removes the declaration of ```weight``` in ```SeedCandidate``` as it doesn't seem to be used anywhere in the MuonSeedGenerator modules:

```
> RecoMuon/MuonSeedGenerator/interface/MuonSeedBuilder.h
> RecoMuon/MuonSeedGenerator/interface/MuonSeedCleaner.h
> RecoMuon/MuonSeedGenerator/interface/SETSeedFinder.h
> RecoMuon/MuonSeedGenerator/plugins/SETMuonSeedProducer.cc
> RecoMuon/MuonSeedGenerator/src/MuonSeedCleaner.cc
> ​RecoMuon/MuonSeedGenerator/src/SETFilter.cc
> RecoMuon/MuonSeedGenerator/src/SETSeedFinder.cc
```

It is built in ```CMSSW_16_0_UBSAN_X_2025-10-13-2300``` which is the release where the warning was spotted.

This PR should not create any changes.

#### PR validation:

I validated that the warning was gone by compiling ```CMSSW_16_0_UBSAN_X_2025-10-13-2300```. I tested with workflow ```4003.0``` without any errors.

I also did an additional validation of the change in ```CMSSW_15_1_0``` with workflows ```4003.0``` and ```11650.0```.

Passes unit tests.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport.

