### PR TITLE
HCAL: Move HB LLP bit energy thresholds to CondDB

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
@@ -61,7 +61,9 @@ public:
   void updateXML(const char* filename);
   void setLUTGenerationMode(bool gen) { LUTGenerationMode_ = gen; };
   void setOverrideFGHF(bool overrideFGHF) { overrideFGHF_ = overrideFGHF; };
-  void setFGHFthresholds(const std::vector<uint32_t>& fgthresholds) { FG_HF_thresholds_ = fgthresholds; };
+  void setFGHFthresholds(const std::array<uint32_t, 2>& fgthresholds) { FG_HF_thresholds_ = fgthresholds; };
+  void setOverrideHBLLP(bool overrideHBLLP) { overrideHBLLP_ = overrideHBLLP; };
+  void setHBLLPthresholds(const std::array<uint32_t, 4>& llpthresholds) { HB_LLP_thresholds_ = llpthresholds; };
   void setMaskBit(int bit) { bitToMask_ = bit; };
   void setAllLinear(bool linear, double lsb8, double lsb11, double lsb11overlap) {
     allLinear_ = linear;
@@ -116,7 +118,9 @@ private:
   const HcalTimeSlew* delay_;
   bool LUTGenerationMode_;
   bool overrideFGHF_ = false;
-  std::vector<uint32_t> FG_HF_thresholds_;
+  std::array<uint32_t, 2> FG_HF_thresholds_;
+  bool overrideHBLLP_ = false;
+  std::array<uint32_t, 4> HB_LLP_thresholds_;
   int bitToMask_;
   int firstHBEta_, lastHBEta_, nHBEta_, maxDepthHB_, sizeHB_;
   int firstHEEta_, lastHEEta_, nHEEta_, maxDepthHE_, sizeHE_;

--- a/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc
+++ b/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc
@@ -65,7 +65,9 @@ private:
   double linearLSB_QIE8_, linearLSB_QIE11Overlap_, linearLSB_QIE11_;
   int maskBit_;
   bool overrideFGHF_;
-  std::vector<uint32_t> FG_HF_thresholds_;
+  std::array<uint32_t, 2> FG_HF_thresholds_;
+  bool overrideHBLLP_;
+  std::array<uint32_t, 4> HB_LLP_thresholds_;
   edm::FileInPath fgfile_, ifilename_;
 };
 
@@ -109,7 +111,9 @@ HcalTPGCoderULUT::HcalTPGCoderULUT(const edm::ParameterSet& iConfig) {
     linearLSB_QIE11Overlap_ = scales.getParameter<double>("LSBQIE11Overlap");
     maskBit_ = iConfig.getParameter<int>("MaskBit");
     overrideFGHF_ = iConfig.getParameter<bool>("overrideFGHF");
-    FG_HF_thresholds_ = iConfig.getParameter<std::vector<uint32_t> >("FG_HF_thresholds");
+    FG_HF_thresholds_ = iConfig.getParameter<std::array<uint32_t, 2> >("FG_HF_thresholds");
+    overrideHBLLP_ = iConfig.getParameter<bool>("overrideHBLLP");
+    HB_LLP_thresholds_ = iConfig.getParameter<std::array<uint32_t, 4> >("HB_LLP_thresholds");
   } else {
     ifilename_ = iConfig.getParameter<edm::FileInPath>("inputLUTs");
   }
@@ -150,6 +154,8 @@ void HcalTPGCoderULUT::buildCoder(const HcalTopology* topo,
     theCoder->setMaskBit(maskBit_);
     theCoder->setOverrideFGHF(overrideFGHF_);
     theCoder->setFGHFthresholds(FG_HF_thresholds_);
+    theCoder->setOverrideHBLLP(overrideHBLLP_);
+    theCoder->setHBLLPthresholds(HB_LLP_thresholds_);
   }
 }
 

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cff.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cff.py
@@ -26,6 +26,8 @@ HcalTPGCoderULUT = cms.ESProducer("HcalTPGCoderULUT",
     MaskBit = cms.int32(0x8000),
     overrideFGHF = cms.bool(False),
     FG_HF_thresholds = cms.vuint32(17, 255),
+    overrideHBLLP = cms.bool(False),
+    HB_LLP_thresholds = cms.vuint32(0, 0, 999, 999),
     inputLUTs = cms.FileInPath('CalibCalorimetry/HcalTPGAlgos/data/inputLUTcoder_physics.dat'),
     FGLUTs = cms.FileInPath('CalibCalorimetry/HcalTPGAlgos/data/HBHE_FG_LUT.dat'),
     RCalibFile = cms.FileInPath('CalibCalorimetry/HcalTPGAlgos/data/RecHit-TPG-calib.dat')
@@ -58,3 +60,6 @@ from Configuration.Eras.Modifier_run3_upc_2025_cff import run3_upc_2025
 #add NeNe configuration
 from Configuration.Eras.Modifier_run3_neon_cff import run3_neon
 (run3_neon).toModify(HcalTPGCoderULUT, FG_HF_thresholds = [14, 12])
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(HcalTPGCoderULUT, HB_LLP_thresholds = [16, 80, 64, 64])

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
@@ -84,6 +84,11 @@ simHcalTriggerPrimitiveDigis = cms.EDProducer("HcalTrigPrimDigiProducer",
         ieta28 = cms.int32(0)
     ),
 
+    overrideHBLLP = cms.bool(False), ## switch: False = read thresholds from TPParameters (default), True = override with HB_LLP_thresholds                                                         
+    ## defaults for energy requirement for bits 12-15 are high / low to avoid FG bit 0-4 being set when not intended                                                                                              
+    HB_LLP_thresholds = cms.vuint32(0, 0, 999, 999),  ## default energy thresholds for setting HB LLP bit                                                                                           
+                                                      ## depths 1,2 max energy, depths 3+ min energy, prompt min energy, delayed min energy                                            
+
     overrideDBvetoThresholdsHB = cms.bool(False),
     overrideDBvetoThresholdsHE = cms.bool(False),
     numberOfSamples = cms.int32(4),


### PR DESCRIPTION
#### PR description:

Until now the thresholds used to set the LLP energy bits in the HB LUTs were hard-coded inside `CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc`. Specifically, the energy thresholds are set per channel, with a choice between a _legacy_ and a _default_ set of values depending on the year (2018 or later) or whether the corresponding cell follows the Plan 1 segmentation. With this update we:

1. Move this logic to `SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cff.py`. The choice between the legacy and default values is decided with a Run 3 modifier. This is safe as the LLP bits in the HB LUTs only became a thing in Run 3. The python configuration will serve as the fallback to the new condition-based method.
2. Read the four thresholds from conditions. We repurpose the, until now, unused `auxi2` word of `HcalTPParameters` to store the four thresholds (one per byte). The method falls back to python when the word is empty or when explicitly forced by a dedicated testing switch.

- No changes are expected in the output at this stage, until the conditions are updated with non-zero values in the auxi2 field of HcalTPParameters.
- This PR is self-contained and does not depend on other PRs or externals.
- Additional documentation: [Indico](https://indico.cern.ch/event/1591849/), [cmshcal#294](https://gitlab.cern.ch/cmshcal/docs/-/issues/294)

The changes have been discussed and approved by the HCAL DPG.

#### PR validation:

- Code compiles successfully under CMSSW_16_0_X with `scram build code-checks` and `scram build code-format`.
- Tests have been performed locally with `runTheMatrix.py`.
- The LUT generation was tested using `CaloOnlineTools/HcalOnlineDb/test/genLUT.sh`. We tested the energy thresholds for cases where auxi2 is empty, when it is filled, when the switch is open and finally when auxi2 is empty but for a Run 2 GT. LUTs were compared before and after the code updates and were found to be identical in the case of auxi2 being empty and differing only to HB when auxi2 was filled with example values, as expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport. 

@akhukhun @abdoulline @JHiltbrand