### PR TITLE
StaticAnalyzer fixes for clang 21

### DIFF
--- a/TauAnalysis/MCEmbeddingTools/plugins/MuonDetCleaner.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MuonDetCleaner.cc
@@ -256,7 +256,8 @@ uint32_t MuonDetCleaner<RPCDetId, RPCRecHit>::getRawDetId(const RPCRecHit &recHi
 
 template <typename T1, typename T2>
 bool MuonDetCleaner<T1, T2>::checkrecHit(const TrackingRecHit &recHit) {
-  edm::LogError("TauEmbedding") << "!!!! Please add the checkrecHit for the individual class templates " assert(0);
+  edm::LogError("TauEmbedding") << "!!!! Please add the checkrecHit for the individual class templates ";
+  assert(0);
 }
 
 template <>

--- a/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
@@ -107,7 +107,11 @@ namespace clangcms {
       llvm::raw_string_ostream os(buf);
       os << "function '" << dname << "' accesses or modifies non-const static local variable '" << svname << "'.\n";
       BR.EmitBasicReport(D,
+#if LLVM_VERSION_MAJOR >= 21
+                         Checker->getName(),
+#else
                          Checker->getCheckerName(),
+#endif
                          "non-const static local variable accessed or modified",
                          "ThreadSafety",
                          os.str(),
@@ -123,7 +127,11 @@ namespace clangcms {
       os << "function '" << dname << "' accesses or modifies non-const static member data variable '" << svname
          << "'.\n";
       BR.EmitBasicReport(D,
+#if LLVM_VERSION_MAJOR >= 21
+                         Checker->getName(),
+#else
                          Checker->getCheckerName(),
+#endif
                          "non-const static local variable accessed or modified",
                          "ThreadSafety",
                          os.str(),
@@ -138,7 +146,11 @@ namespace clangcms {
       llvm::raw_string_ostream os(buf);
       os << "function '" << dname << "' accesses or modifies non-const global static variable '" << svname << "'.\n";
       BR.EmitBasicReport(D,
+#if LLVM_VERSION_MAJOR >= 21
+                         Checker->getName(),
+#else
                          Checker->getCheckerName(),
+#endif
                          "non-const static local variable accessed or modified",
                          "ThreadSafety",
                          os.str(),
@@ -178,8 +190,16 @@ namespace clangcms {
               "'COMMONBLOCK'.\n";
         clang::ento::PathDiagnosticLocation FDLoc =
             clang::ento::PathDiagnosticLocation::createBegin(FD, BR.getSourceManager());
-        BR.EmitBasicReport(
-            FD, this->getCheckerName(), "COMMONBLOCK variable accessed or modified", "ThreadSafety", os.str(), FDLoc);
+        BR.EmitBasicReport(FD,
+#if LLVM_VERSION_MAJOR >= 21
+                           this->getName(),
+#else
+                           this->getCheckerName(),
+#endif
+                           "COMMONBLOCK variable accessed or modified",
+                           "ThreadSafety",
+                           os.str(),
+                           FDLoc);
         std::string ostring = "function '" + dname + "' static variable 'COMMONBLOCK'.\n";
         std::string tname = "function-checker.txt.unsorted";
         support::writeLog(ostring, tname);


### PR DESCRIPTION
This fixes the build error we have seen while testing [llvm 21](https://github.com/cms-sw/cmsdist/pull/10142#issuecomment-3427475910) . See full build logs at https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-d3be3a/48764/build-logs/ though there are many warnings like
```
src/Geometry/TrackerGeometryBuilder/interface/StripGeomDetType.h:23:31: warning: virtual method 'specificTopology' is inside a 'final' class and can never be overridden [-Wunnecessary-virtual-specifier]
    23 |   virtual const TopologyType& specificTopology() const { return *theTopology; }
```

these can be fixed later once we have llvm 21 in CLANG_X IBs.

- getCheckerName : https://github.com/llvm/llvm-project/pull/130953/
- PrintCanonicalTypes:  https://github.com/llvm/llvm-project/pull/135133