### PR TITLE
Document constexpr limitation for SoA custom methods

### DIFF
--- a/DataFormats/SoATemplate/README.md
+++ b/DataFormats/SoATemplate/README.md
@@ -72,7 +72,7 @@ and to build a generic `View` as described in [View](#view).
 ## Customized methods
 
 It is possible to generate methods inside the `element` and `const_element` nested structs using the `SOA_ELEMENT_METHODS`
-and `SOA_CONST_ELEMENT_METHODS` macros. Each of these macros can be called only once, and can define multiple methods. 
+and `SOA_CONST_ELEMENT_METHODS` macros. Each of these macros can be called only once, and can define multiple methods. All the methods need to be declared as `constexpr` to work in a heterogenous environment and to avoid the dependency on alpaka for the data formats.
 [An example is showed below.](#examples)
 
 ## ROOT serialization and de-serialization
@@ -152,7 +152,7 @@ using SoA1Layout = SoA1LayoutTemplate<>;
 using SoA1LayoutAligned = SoA1LayoutTemplate<cms::soa::CacheLineSize::defaultSize, cms::soa::AlignmentEnforcement::enforced>;
 ```
 
-It is possible to declare methods that operate on the SoA elements:
+It is possible to declare `constexpr` methods that operate on the SoA elements:
 
 ```C++
 #include "DataFormats/SoALayout.h"
@@ -164,14 +164,14 @@ GENERATE_SOA_LAYOUT(SoATemplate,
   
   // methods operating on const_element
   SOA_CONST_ELEMENT_METHODS(
-    auto norm() const {
+    constexpr auto norm() const {
       return sqrt(x()*x() + y()+y() + z()*z());
     }
   ),
 
   // methods operating on element
   SOA_ELEMENT_METHODS(
-    void scale(float arg) {
+    constexpr void scale(float arg) {
       x() *= arg;
       y() *= arg;
       z() *= arg;

--- a/DataFormats/SoATemplate/test/SoACustomizedMethods_t.cc
+++ b/DataFormats/SoATemplate/test/SoACustomizedMethods_t.cc
@@ -3,6 +3,9 @@
 
 #include "DataFormats/SoATemplate/interface/SoALayout.h"
 
+// This test checks the functionality of customized methods in SoA elements
+// The declared methods need to be constexpr
+
 GENERATE_SOA_LAYOUT(SoATemplate,
                     SOA_COLUMN(float, x),
                     SOA_COLUMN(float, y),
@@ -13,29 +16,30 @@ GENERATE_SOA_LAYOUT(SoATemplate,
 
                     SOA_ELEMENT_METHODS(
 
-                        void normalise() {
+                        constexpr void normalise() {
                           float norm_position = square_norm_position();
                           if (norm_position > 0.0f) {
                             x() /= norm_position;
                             y() /= norm_position;
                             z() /= norm_position;
-                          };
+                          }
                           double norm_velocity = square_norm_velocity();
                           if (norm_velocity > 0.0f) {
                             v_x() /= norm_velocity;
                             v_y() /= norm_velocity;
                             v_z() /= norm_velocity;
-                          };
+                          }
                         }),
 
                     SOA_CONST_ELEMENT_METHODS(
-                        float square_norm_position() const { return sqrt(x() * x() + y() * y() + z() * z()); };
+                        constexpr float square_norm_position()
+                            const { return sqrt(x() * x() + y() * y() + z() * z()); };
 
-                        double square_norm_velocity()
+                        constexpr double square_norm_velocity()
                             const { return sqrt(v_x() * v_x() + v_y() * v_y() + v_z() * v_z()); };
 
                         template <typename T1, typename T2>
-                        static auto time(T1 pos, T2 vel) {
+                        constexpr static auto time(T1 pos, T2 vel) {
                           if (not(vel == 0))
                             return pos / vel;
                           return 0.;


### PR DESCRIPTION
#### PR description:

This PR modifies the test, declaring all the custom methods as `constexpr` and documenting the policy. This limitation comes from the fact that we want the methods to be called within kernels, but without adding any dependency on `alpaka`. This [PR](https://github.com/cms-sw/cmssw/pull/48829#issuecomment-3352688851) had the same issue.

#### PR validation:

The test for custom methods passes.
