### PR TITLE
[Draft] Allow users to set a valid data range for the SoA View

### DIFF
--- a/DataFormats/SoATemplate/README.md
+++ b/DataFormats/SoATemplate/README.md
@@ -28,6 +28,8 @@ are supported. Scalar members are members of layout with one element, irrespecti
 Static utility functions automatically compute the byte size of a layout, taking into account all its columns and
 alignment.
 
+The number of elements per column (size) that the layout can hold is defined at construction time and is equal to its capacity.
+
 ## View
 
 Layout classes also define a `View` and `ConstView` subclass that provide access to each column and
@@ -43,6 +45,10 @@ can be used as a shortcut: `auto si = soa[index]; si.z() = si.x() + si.y();`
 
 A view can be instanciated by being passed the corresponding layout or passing from the [Metarecords subclass](#metarecords-subclass). 
 This view can point to data belonging to different SoAs and thus not contiguous in memory.
+
+The View defines a method `setSize` which can be called to define a valid data range. This is useful when the 
+number of elements per coloumn is not known beforehand but only a maximum number of elements. Once the 
+number of elements is known the valid data range can be adjusted.
 
 ## Descriptor
 

--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -1375,6 +1375,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
       struct Metadata {                                                                                                \
         friend ConstViewTemplateFreeParams;                                                                            \
         SOA_HOST_DEVICE SOA_INLINE size_type size() const { return parent_.elements_; }                                \
+        SOA_HOST_DEVICE SOA_INLINE size_type capacity() const { return parent_.capacity_; }                            \
         /* Alias layout to name-derived identifyer to allow simpler definitions */                                     \
         using TypeOf_Layout = BOOST_PP_CAT(CLASS, _parametrized);                                                      \
                                                                                                                        \
@@ -1414,7 +1415,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
                                                                                                                        \
       /* Constructor relying the layout */                                                                             \
       SOA_HOST_ONLY ConstViewTemplateFreeParams(const Metadata::TypeOf_Layout& layout)                                 \
-      : elements_(layout.metadata().size()),                                                                           \
+      : elements_(layout.metadata().size()), capacity_(layout.metadata().size()),                                  \
         _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_MEMBER_INITIALIZERS, ~, __VA_ARGS__) {}                                    \
                                                                                                                        \
       /* Constructor relying on individually provided column structs */                                                \
@@ -1435,7 +1436,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
                 bool OTHER_RANGE_CHECKING>                                                                             \
       ConstViewTemplateFreeParams(ConstViewTemplateFreeParams<OTHER_VIEW_ALIGNMENT,                                    \
         OTHER_VIEW_ALIGNMENT_ENFORCEMENT, OTHER_RESTRICT_QUALIFY, OTHER_RANGE_CHECKING> const& other)                  \
-        : ConstViewTemplateFreeParams{other.elements_,                                                                 \
+        : ConstViewTemplateFreeParams{other.elements_, other.capacity_,                                                                \
             _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_OTHER_MEMBER_LIST, BOOST_PP_EMPTY(), __VA_ARGS__)                      \
           } {}                                                                                                         \
       /* Copy operator for other parameters */                                                                         \
@@ -1489,6 +1490,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
                                                                                                                        \
         private:                                                                                                       \
           size_type elements_ = 0;                                                                                     \
+          size_type capacity_ = 0;                                                                                     \
           _ITERATE_ON_ALL(_DECLARE_CONST_VIEW_SOA_MEMBER, ~, __VA_ARGS__)                                              \
       };                                                                                                               \
                                                                                                                        \
@@ -1535,6 +1537,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
       struct Metadata {                                                                                                \
         friend ViewTemplateFreeParams;                                                                                 \
         SOA_HOST_DEVICE SOA_INLINE size_type size() const { return parent_.elements_; }                                \
+        SOA_HOST_DEVICE SOA_INLINE size_type capacity() const { return parent_.capacity_; }                            \
         /* Alias layout to name-derived identifyer to allow simpler definitions */                                     \
         using TypeOf_Layout = BOOST_PP_CAT(CLASS, _parametrized);                                                      \
                                                                                                                        \
@@ -1598,7 +1601,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
                 bool OTHER_RANGE_CHECKING>                                                                             \
       ViewTemplateFreeParams(ViewTemplateFreeParams<OTHER_VIEW_ALIGNMENT, OTHER_VIEW_ALIGNMENT_ENFORCEMENT,            \
                                                     OTHER_RESTRICT_QUALIFY, OTHER_RANGE_CHECKING> const& other)        \
-      : base_type{other.elements_,                                                                                     \
+      : base_type{other.elements_, other.capacity_,                                                                    \
                   _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_OTHER_MEMBER_LIST, BOOST_PP_EMPTY(), __VA_ARGS__)                \
                 } {}                                                                                                   \
       /* Copy operator for other parameters */                                                                         \
@@ -1661,6 +1664,11 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         return element{_soa_impl_index, _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_ELEMENT_CONSTR_CALL, ~, __VA_ARGS__)};     \
       }                                                                                                                \
                                                                                                                        \
+      /* change size to valid data range */                                                                            \
+      SOA_HOST_DEVICE SOA_INLINE void setSize(const size_type size) {                                                  \
+         base_type::elements_ = size < 0 ? 0 : size > base_type::capacity_ ? base_type::capacity_ : size;              \
+      }                                                                                                                \
+                                                                                                                       \
       /* inherit const accessors from ConstView */                                                                     \
                                                                                                                        \
       /* non-const accessors */                                                                                        \
@@ -1708,8 +1716,11 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
           _ITERATE_ON_ALL_COMMA(_DECLARE_MEMBER_TRIVIAL_CONSTRUCTION, ~, __VA_ARGS__) {}                               \
                                                                                                                        \
     /* Constructor relying on user provided storage (implementation shared with ROOT streamer) */                      \
-    SOA_HOST_ONLY CLASS(std::byte* mem, size_type elements) : mem_(mem), elements_(elements), byteSize_(0) {           \
-      organizeColumnsFromBuffer();                                                                                     \
+    SOA_HOST_ONLY CLASS(std::byte* mem, size_type elements)                                                            \
+        : mem_(mem),                                                                                                   \
+          elements_(elements),                                                                                         \
+          byteSize_(0) {                                                                                               \
+            organizeColumnsFromBuffer();                                                                               \
     }                                                                                                                  \
                                                                                                                        \
     /* Explicit copy constructor and assignment operator */                                                            \

--- a/DataFormats/SoATemplate/test/SoAUnitTests.cc
+++ b/DataFormats/SoATemplate/test/SoAUnitTests.cc
@@ -6,6 +6,8 @@
 
 #include "DataFormats/SoATemplate/interface/SoALayout.h"
 
+#include <iostream>
+
 // clang-format off
 GENERATE_SOA_LAYOUT(SimpleLayoutTemplate,
   SOA_COLUMN(float, x),
@@ -134,5 +136,26 @@ TEST_CASE("SoATemplate") {
     // Check for under-and overflow in the element accessors
     REQUIRE_THROWS_AS(slcv.x(underflow), std::out_of_range);
     REQUIRE_THROWS_AS(slcv.x(overflow), std::out_of_range);
+  }
+
+  SECTION("Adapt valid data range") {
+    SimpleLayout::View slv{sl};
+    REQUIRE(slv.metadata().size() == slSize);
+    REQUIRE(slv.metadata().capacity() == slSize);
+
+    slv.setSize(slv.metadata().size() * 2); // should not change anything
+    REQUIRE(slv.metadata().size() == slSize);
+    REQUIRE(slv.metadata().capacity() == slSize);
+
+    slv.setSize(-10); // should set size to 0
+    REQUIRE(slv.metadata().size() == 0);
+    REQUIRE(slv.metadata().capacity() == slSize);
+
+    const SimpleLayout::size_type validDataRange = 6;
+  
+    slv.setSize(validDataRange); // should set size to validDataRange
+    REQUIRE(slv.metadata().size() == validDataRange);
+    REQUIRE(slv.metadata().capacity() == slSize);
+    REQUIRE_THROWS_AS(slv[validDataRange], std::out_of_range);
   }
 }

--- a/DataFormats/SoATemplate/test/SoAUnitTests.cc
+++ b/DataFormats/SoATemplate/test/SoAUnitTests.cc
@@ -143,17 +143,17 @@ TEST_CASE("SoATemplate") {
     REQUIRE(slv.metadata().size() == slSize);
     REQUIRE(slv.metadata().capacity() == slSize);
 
-    slv.setSize(slv.metadata().size() * 2); // should not change anything
+    slv.setSize(slv.metadata().size() * 2);  // should not change anything
     REQUIRE(slv.metadata().size() == slSize);
     REQUIRE(slv.metadata().capacity() == slSize);
 
-    slv.setSize(-10); // should set size to 0
+    slv.setSize(-10);  // should set size to 0
     REQUIRE(slv.metadata().size() == 0);
     REQUIRE(slv.metadata().capacity() == slSize);
 
     const SimpleLayout::size_type validDataRange = 6;
-  
-    slv.setSize(validDataRange); // should set size to validDataRange
+
+    slv.setSize(validDataRange);  // should set size to validDataRange
     REQUIRE(slv.metadata().size() == validDataRange);
     REQUIRE(slv.metadata().capacity() == slSize);
     REQUIRE_THROWS_AS(slv[validDataRange], std::out_of_range);


### PR DESCRIPTION
At the moment an SoA is constructed by defining a number of elements which is the element size of each coloumn.
Sometimes the number of needed elements is not known beforehand but only a maximum number of elements. In these cases users have to keep track of the valid data range manually for example by introducing a SCALAR which stores the number of valid elements in the data. 

This PR adds a method to the View called `setSize` which lets users define a valid datarange. Then `view.metadata().size()` returns the valid data range which can be used to lunch kernels that iterate only the valid data range. Furthermore, the underlying `std::span` s for each coloumn will be the size which was defined by `setSize`

FYI: @felicepantaleo @leobeltra
