### PR TITLE
Remove miniAOD_customizeOutput, and define miniaod file parameter directly in EventContent

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -712,11 +712,6 @@ class ConfigBuilder(object):
             output = self._createOutputModuleInAddOutput(tier=tier, streamType=streamType, eventContent=theEventContent, fileName = theFileName, filterName = theFilterName, ignoreNano = False)
             self._updateOutputSelectEvents(output, streamType)
 
-            if "MINIAOD" in streamType:
-                ## we should definitely get rid of this customization by now
-                from PhysicsTools.PatAlgos.slimming.miniAOD_tools import miniAOD_customizeOutput
-                miniAOD_customizeOutput(output)
-
             outputModuleName=streamType+streamQualifier+'output'
             outputModule = self._addOutputModuleAndPathToProcess(output, outputModuleName)
 

--- a/Configuration/DataProcessing/test/BuildFile.xml
+++ b/Configuration/DataProcessing/test/BuildFile.xml
@@ -1,6 +1,7 @@
 <test name="TestConfigDP_1" command="run_CfgTest_1.sh"/>
 <test name="TestConfigDP_2" command="run_CfgTest_2.sh"/>
 <test name="TestConfigDP_3" command="run_CfgTest_3.sh"/>
+<test name="TestConfigDP_4" command="run_CfgTest_4.sh"/>
 <test name="TestConfigDP_5" command="run_CfgTest_5.sh"/>
 <test name="TestConfigDP_6" command="run_CfgTest_6.sh"/>
 <test name="TestConfigDP_7" command="run_CfgTest_7.sh"/>

--- a/Configuration/DataProcessing/test/convertPromptPKLtoConfig.py
+++ b/Configuration/DataProcessing/test/convertPromptPKLtoConfig.py
@@ -1,0 +1,6 @@
+import pickle
+
+f=open('RunPromptRecoCfg.pkl','rb')
+process = pickle.load(f)
+fout=open("config_dump.py", "w")
+fout.write(process.dumpPython())

--- a/Configuration/DataProcessing/test/run_CfgTest_4.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest_4.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Test suite for miniaod from prompt
+
+# Pass in name and status
+declare -a arr=("ppEra_Run3_2025")
+for scenario in "${arr[@]}"
+do
+    rm -rf RunPromptRecoCfg.pkl
+    python3 ${SCRAM_TEST_PATH}/RunPromptReco.py --scenario $scenario --miniaod --global-tag GLOBALTAG --lfn=/store/whatever
+    if [ ! -f "RunPromptRecoCfg.pkl" ]; then
+	echo "Can't dump RunPromptRecoCfg.pkl"
+	exit 1;
+    fi
+ 	
+python3 <<EOF
+import sys, pickle 
+f=open('RunPromptRecoCfg.pkl','rb')
+process = pickle.load(f);
+if not hasattr(process, "write_MINIAOD"):
+   sys.exit(1)
+
+mod = process.write_MINIAOD
+if not hasattr(mod, "overrideBranchesSplitLevel"):
+   sys.exit(1)
+EOF
+
+    rc=$?
+    if [ $rc -ne 0 ]; then
+	echo "check process.write_MINIAOD"
+	exit 1;
+    fi
+
+    echo '>>>> Done! <<<<'
+done

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-
+import copy
 #
 # Event Content definition
 #
@@ -946,12 +946,18 @@ REDIGIEventContent.inputCommands.append('drop *_randomEngineStateProducer_*_*')
 # ROOT automatically determine when to flush is a surprisingly big overhead.
 #
 from PhysicsTools.PatAlgos.slimming.slimming_cff import MicroEventContent,MicroEventContentMC,MicroEventContentGEN
+from PhysicsTools.PatAlgos.slimming.MicroEventContent_cff import MiniAODOverrideBranchesSplitLevel
 
 MINIAODEventContent= cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     eventAutoFlushCompressedSize=cms.untracked.int32(-900),
     compressionAlgorithm=cms.untracked.string("LZMA"),
-    compressionLevel=cms.untracked.int32(4)
+    compressionLevel=cms.untracked.int32(4),
+    overrideBranchesSplitLevel=copy.deepcopy(MiniAODOverrideBranchesSplitLevel),
+    splitLevel=cms.untracked.int32(0),
+    dropMetaData=cms.untracked.string('ALL'),
+    fastCloning=cms.untracked.bool(False),
+    overrideInputFileSplitLevels=cms.untracked.bool(True)
 )
 MINIAODEventContent.outputCommands.extend(MicroEventContent.outputCommands)
 MINIAODEventContent.outputCommands.extend(HLTriggerMINIAOD.outputCommands)
@@ -960,7 +966,12 @@ MINIAODSIMEventContent= cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     eventAutoFlushCompressedSize=cms.untracked.int32(-900),
     compressionAlgorithm=cms.untracked.string("LZMA"),
-    compressionLevel=cms.untracked.int32(4)
+    compressionLevel=cms.untracked.int32(4),
+    overrideBranchesSplitLevel=copy.deepcopy(MiniAODOverrideBranchesSplitLevel),
+    splitLevel=cms.untracked.int32(0),
+    dropMetaData=cms.untracked.string('ALL'),
+    fastCloning=cms.untracked.bool(False),
+    overrideInputFileSplitLevels=cms.untracked.bool(True)
 )
 MINIAODSIMEventContent.outputCommands.extend(MicroEventContentMC.outputCommands)
 MINIAODSIMEventContent.outputCommands.extend(HLTriggerMINIAODSIM.outputCommands)
@@ -979,7 +990,12 @@ RAWMINIAODEventContent= cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     eventAutoFlushCompressedSize=cms.untracked.int32(20*1024*1024),
     compressionAlgorithm=cms.untracked.string("LZMA"),
-    compressionLevel=cms.untracked.int32(4)
+    compressionLevel=cms.untracked.int32(4),
+    overrideBranchesSplitLevel=copy.deepcopy(MiniAODOverrideBranchesSplitLevel),
+    splitLevel=cms.untracked.int32(0),
+    dropMetaData=cms.untracked.string('ALL'),
+    fastCloning=cms.untracked.bool(False),
+    overrideInputFileSplitLevels=cms.untracked.bool(True)
 )
 RAWMINIAODEventContent.outputCommands.extend(MicroEventContent.outputCommands)
 RAWMINIAODEventContent.outputCommands.extend(L1TriggerRAW.outputCommands)
@@ -992,7 +1008,12 @@ RAWMINIAODSIMEventContent= cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     eventAutoFlushCompressedSize=cms.untracked.int32(20*1024*1024),
     compressionAlgorithm=cms.untracked.string("LZMA"),
-    compressionLevel=cms.untracked.int32(4)
+    compressionLevel=cms.untracked.int32(4),
+    overrideBranchesSplitLevel=copy.deepcopy(MiniAODOverrideBranchesSplitLevel),
+    splitLevel=cms.untracked.int32(0),
+    dropMetaData=cms.untracked.string('ALL'),
+    fastCloning=cms.untracked.bool(False),
+    overrideInputFileSplitLevels=cms.untracked.bool(True)
 )
 RAWMINIAODSIMEventContent.outputCommands.extend(RAWMINIAODEventContent.outputCommands)
 RAWMINIAODSIMEventContent.outputCommands.extend(MicroEventContentMC.outputCommands)
@@ -1047,7 +1068,6 @@ TauEmbeddingSimHLTEventContent.outputCommands.extend(TauEmbSimHLT.outputCommands
 TauEmbeddingSimRecoEventContent = RAWRECOSIMHLTEventContent.clone()
 TauEmbeddingSimRecoEventContent.outputCommands.extend(TauEmbSimReco.outputCommands)
 
-# needs to have MINIAOD in its name to be recognized by cmsDriver as a MINIAOD output so that miniAOD_customizeOutput is applied
 TauEmbeddingMergeMINIAODEventContent = MINIAODSIMEventContent.clone()
 TauEmbeddingMergeMINIAODEventContent.outputCommands.extend(TauEmbMerge.outputCommands)
 


### PR DESCRIPTION
#### PR description:
This PR is to fix the issue discussed in https://github.com/cms-sw/cmssw/issues/49202
The bug in write_MINIAOD of Tier-0 config leads to 4% bigger of MINIAOD size.

#### PR validation:
Run miniaod from new config, output size is as expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
This PR should be backported to 15_0 and 15_1 (for data taking)