### PR TITLE
[SIMULATION] To virtual method inside a final class; make classes non-final

### DIFF
--- a/DataFormats/GeometrySurface/interface/SimpleConeBounds.h
+++ b/DataFormats/GeometrySurface/interface/SimpleConeBounds.h
@@ -20,7 +20,7 @@
 #include <limits>
 #include <algorithm>
 
-class SimpleConeBounds final : public Bounds {
+class SimpleConeBounds : public Bounds {
 public:
   /// Construct from inner/outer radius on the two Z faces
   SimpleConeBounds(float zmin, float rmin_zmin, float rmax_zmin, float zmax, float rmin_zmax, float rmax_zmax)

--- a/DataFormats/GeometrySurface/interface/SimpleCylinderBounds.h
+++ b/DataFormats/GeometrySurface/interface/SimpleCylinderBounds.h
@@ -16,7 +16,7 @@
 #include <cmath>
 #include <algorithm>
 
-class SimpleCylinderBounds final : public Bounds {
+class SimpleCylinderBounds : public Bounds {
 public:
   SimpleCylinderBounds(float rmin, float rmax, float zmin, float zmax);
 

--- a/DataFormats/GeometrySurface/interface/SimpleDiskBounds.h
+++ b/DataFormats/GeometrySurface/interface/SimpleDiskBounds.h
@@ -8,7 +8,7 @@
  * Plane bounds that define a disk with a concentric hole in the middle.
  */
 
-class SimpleDiskBounds final : public Bounds {
+class SimpleDiskBounds : public Bounds {
 public:
   /// Construct the bounds from min and max R and Z in LOCAL coordinates.
   SimpleDiskBounds(float rmin, float rmax, float zmin, float zmax);

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalSiPMHitResponse.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalSiPMHitResponse.h
@@ -19,7 +19,7 @@ public:
   bool operator()(const PCaloHit* a, const PCaloHit* b) const { return a->time() < b->time(); }
 };
 
-class HcalSiPMHitResponse final : public CaloHitResponse {
+class HcalSiPMHitResponse : public CaloHitResponse {
 public:
   HcalSiPMHitResponse(const CaloVSimParameterMap* parameterMap,
                       const CaloShapes* shapes,


### PR DESCRIPTION
LLVM21 has a new warning `virtual method inside a final class and can never be overridden`. This PR is to fix these warning. 
As suggested in https://github.com/cms-sw/cmssw/pull/49211#issuecomment-3444162494, this PR ake these classes non-final

See https://github.com/cms-sw/cmssw/issues/49208