### PR TITLE
[RECONSTRUCTION] Fix for virtual method inside a final class

### DIFF
--- a/DataFormats/TrackerRecHit2D/interface/VectorHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/VectorHit.h
@@ -72,7 +72,7 @@ public:
 
   // returning methods
   LocalPoint localPosition() const override { return thePosition; }
-  virtual LocalVector localDirection() const { return theDirection; }
+  LocalVector localDirection() const { return theDirection; }
   const AlgebraicSymMatrix44& covMatrix() const;
   LocalError localPositionError() const override;
   LocalError localDirectionError() const;

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
@@ -84,7 +84,7 @@ namespace sistrip {
     //check FE unit APV addresses in FULL DEBUG header are equal to the APVe address if the majority was good
     bool checkFEUnitAPVAddresses() const;
     //do all corrupt buffer checks
-    virtual bool doCorruptBufferChecks() const;
+    bool doCorruptBufferChecks() const;
 
     //check that there are no errors in channel, APV or FEUnit status bits
     //these are done by channelGood(). Channels with bad status bits may be disabled so bad status bits do not usually indicate an error

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.h
@@ -34,8 +34,8 @@ namespace sistrip {
     DigiToRawModule(const edm::ParameterSet&);
     ~DigiToRawModule() override;
 
-    virtual void beginJob() {}
-    virtual void endJob() {}
+    void beginJob() {}
+    void endJob() {}
 
     void produce(edm::Event&, const edm::EventSetup&) override;
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);

--- a/RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h
+++ b/RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h
@@ -29,24 +29,24 @@ public:
   ~MuonTransientTrackingRecHit() override {}
 
   /// Direction in 3D for segments, otherwise (0,0,0)
-  virtual LocalVector localDirection() const;
+  LocalVector localDirection() const;
 
   /// Direction in 3D for segments, otherwise (0,0,0)
-  virtual GlobalVector globalDirection() const;
+  GlobalVector globalDirection() const;
 
   /// Error on the local direction
-  virtual LocalError localDirectionError() const;
+  LocalError localDirectionError() const;
 
   /// Error on the global direction
-  virtual GlobalError globalDirectionError() const;
+  GlobalError globalDirectionError() const;
 
   AlgebraicSymMatrix parametersError() const override;
 
   /// Chi square of the fit for segments, else 0
-  virtual double chi2() const;
+  double chi2() const;
 
   /// Degrees of freedom for segments, else 0
-  virtual int degreesOfFreedom() const;
+  int degreesOfFreedom() const;
 
   /// if this rec hit is a DT rec hit
   bool isDT() const;
@@ -66,7 +66,7 @@ public:
   /// return the sub components of this transient rechit
   ConstRecHitContainer transientHits() const override;
 
-  /// FIXME virtual ConstMuonRecHitContainer specificTransientHits() const;
+  /// FIXME ConstMuonRecHitContainer specificTransientHits() const;
 
   static RecHitPointer build(const GeomDet* geom, const TrackingRecHit* rh) {
     return RecHitPointer(new MuonTransientTrackingRecHit(geom, rh));

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.h
@@ -30,7 +30,7 @@ public:
   static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
 
   /// set Event for the internal MeasurementTracker data member
-  //  virtual void setEvent(const edm::Event& event) const;
+  //  void setEvent(const edm::Event& event) const;
 
   /// trajectories building starting from a seed
   TrajectoryContainer trajectories(const TrajectorySeed&) const override;
@@ -87,10 +87,10 @@ public:
 protected:
   void setEvent_(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-  virtual void analyseSeed(const TrajectorySeed& seed) const {}
+  void analyseSeed(const TrajectorySeed& seed) const {}
 
-  virtual void analyseMeasurements(const std::vector<TM>& meas, const Trajectory& traj) const {}
-  virtual void analyseResult(const TrajectoryContainer& result) const {}
+  void analyseMeasurements(const std::vector<TM>& meas, const Trajectory& traj) const {}
+  void analyseResult(const TrajectoryContainer& result) const {}
 
 private:
   //  /// no copy constructor

--- a/RecoTracker/TkDetLayers/src/CompositeTECPetal.h
+++ b/RecoTracker/TkDetLayers/src/CompositeTECPetal.h
@@ -27,9 +27,9 @@ public:
   ~CompositeTECPetal() override __attribute__((cold));
 
   // GeometricSearchDet interface
-  const BoundSurface& surface() const final { return *theDiskSector; }
+  const BoundSurface& surface() const override { return *theDiskSector; }
   //Extension of the interface
-  virtual const BoundDiskSector& specificSurface() const final { return *theDiskSector; }
+  const BoundDiskSector& specificSurface() const { return *theDiskSector; }
 
   // GeometricSearchDet interface
   const std::vector<const GeomDet*>& basicComponents() const override { return theBasicComps; }

--- a/RecoTracker/TkDetLayers/src/Phase1PixelBlade.h
+++ b/RecoTracker/TkDetLayers/src/Phase1PixelBlade.h
@@ -37,7 +37,7 @@ public:
                               std::vector<DetGroup>& result) const override __attribute__((hot));
 
   //Extension of the interface
-  virtual const BoundDiskSector& specificSurface() const { return *theDiskSector; }
+  const BoundDiskSector& specificSurface() const { return *theDiskSector; }
 
 private:
   // private methods for the implementation of groupedCompatibleDets()

--- a/RecoTracker/TkDetLayers/src/Phase2EndcapRing.h
+++ b/RecoTracker/TkDetLayers/src/Phase2EndcapRing.h
@@ -35,7 +35,7 @@ public:
                               std::vector<DetGroup>& result) const override __attribute__((hot));
 
   //Extension of interface
-  virtual const BoundDisk& specificSurface() const { return *theDisk; }
+  const BoundDisk& specificSurface() const { return *theDisk; }
 
 private:
   // private methods for the implementation of groupedCompatibleDets()

--- a/RecoTracker/TkDetLayers/src/Phase2EndcapSingleRing.h
+++ b/RecoTracker/TkDetLayers/src/Phase2EndcapSingleRing.h
@@ -32,7 +32,7 @@ public:
                               std::vector<DetGroup>& result) const override;
 
   //Extension of interface
-  virtual const BoundDisk& specificSurface() const { return *theDisk; }
+  const BoundDisk& specificSurface() const { return *theDisk; }
 
 private:
   // private methods for the implementation of groupedCompatibleDets()

--- a/RecoTracker/TkDetLayers/src/PixelBlade.h
+++ b/RecoTracker/TkDetLayers/src/PixelBlade.h
@@ -35,7 +35,7 @@ public:
                               std::vector<DetGroup>& result) const override __attribute__((hot));
 
   //Extension of the interface
-  virtual const BoundDiskSector& specificSurface() const { return *theDiskSector; }
+  const BoundDiskSector& specificSurface() const { return *theDiskSector; }
 
 private:
   // private methods for the implementation of groupedCompatibleDets()

--- a/RecoTracker/TkDetLayers/src/TIBRing.h
+++ b/RecoTracker/TkDetLayers/src/TIBRing.h
@@ -36,7 +36,7 @@ public:
   //--- Extension of the interface
 
   /// Return the ring surface as a
-  virtual const BoundCylinder& specificSurface() const { return *theCylinder; }
+  const BoundCylinder& specificSurface() const { return *theCylinder; }
 
 private:
   //general private methods

--- a/RecoTracker/TkDetLayers/src/TIDRing.h
+++ b/RecoTracker/TkDetLayers/src/TIDRing.h
@@ -32,7 +32,7 @@ public:
                               std::vector<DetGroup>& result) const override __attribute__((hot));
 
   //Extension of interface
-  virtual const BoundDisk& specificSurface() const { return *theDisk; }
+  const BoundDisk& specificSurface() const { return *theDisk; }
 
 private:
   // private methods for the implementation of groupedCompatibleDets()

--- a/RecoTracker/TkNavigation/plugins/NavigationSchoolESProducer.cc
+++ b/RecoTracker/TkNavigation/plugins/NavigationSchoolESProducer.cc
@@ -19,7 +19,7 @@ public:
 
   typedef std::unique_ptr<NavigationSchool> ReturnType;
 
-  virtual ReturnType produce(const NavigationSchoolRecord&);
+  ReturnType produce(const NavigationSchoolRecord&);
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 

--- a/RecoTracker/TrackProducer/plugins/QualityFilter.cc
+++ b/RecoTracker/TrackProducer/plugins/QualityFilter.cc
@@ -15,7 +15,7 @@ public:
 
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob();
+  void endJob();
 
   // ----------member data ---------------------------
 private:

--- a/RecoTracker/TransientTrackingRecHit/interface/TRecHit1DMomConstraint.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TRecHit1DMomConstraint.h
@@ -45,7 +45,7 @@ public:
 
   bool canImproveWithTrack() const override { return false; }
 
-  virtual RecHitPointer clone(const TrajectoryStateOnSurface& ts) const { return RecHitPointer(clone()); }
+  RecHitPointer clone(const TrajectoryStateOnSurface& ts) const { return RecHitPointer(clone()); }
 
   const GeomDetUnit* detUnit() const override { return nullptr; }
 

--- a/RecoTracker/TransientTrackingRecHit/interface/TRecHit2DPosConstraint.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TRecHit2DPosConstraint.h
@@ -54,7 +54,7 @@ public:
 
   bool canImproveWithTrack() const override { return false; }
 
-  virtual RecHitPointer clone(const TrajectoryStateOnSurface& ts) const { return RecHitPointer(clone()); }
+  RecHitPointer clone(const TrajectoryStateOnSurface& ts) const { return RecHitPointer(clone()); }
 
   static RecHitPointer build(const LocalPoint& pos, const LocalError& err, const Surface* surface) {
     return RecHitPointer(new TRecHit2DPosConstraint(pos, err, surface));

--- a/RecoTracker/TransientTrackingRecHit/interface/TRecHit5DParamConstraint.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TRecHit5DParamConstraint.h
@@ -58,7 +58,7 @@ public:
   }
 
   /// ????
-  virtual RecHitPointer clone(const TrajectoryStateOnSurface& tsos) const {
+  RecHitPointer clone(const TrajectoryStateOnSurface& tsos) const {
     return RecHitPointer(new TRecHit5DParamConstraint(tsos));
   }
 

--- a/RecoVertex/KinematicFitPrimitives/interface/TrackKinematicStatePropagator.h
+++ b/RecoVertex/KinematicFitPrimitives/interface/TrackKinematicStatePropagator.h
@@ -40,11 +40,11 @@ private:
    * Internal private methods, distinguishing between the propagation of neutrals
    * and propagation of cahrged tracks.
    */
-  virtual KinematicState propagateToTheTransversePCACharged(const KinematicState& state,
-                                                            const GlobalPoint& referencePoint) const;
+  KinematicState propagateToTheTransversePCACharged(const KinematicState& state,
+                                                    const GlobalPoint& referencePoint) const;
 
-  virtual KinematicState propagateToTheTransversePCANeutral(const KinematicState& state,
-                                                            const GlobalPoint& referencePoint) const;
+  KinematicState propagateToTheTransversePCANeutral(const KinematicState& state,
+                                                    const GlobalPoint& referencePoint) const;
 
   typedef Point3DBase<double, GlobalTag> GlobalPointDouble;
   typedef Vector3DBase<double, GlobalTag> GlobalVectorDouble;

--- a/TrackingTools/GeomPropagators/interface/HelixExtrapolatorToLine2Order.h
+++ b/TrackingTools/GeomPropagators/interface/HelixExtrapolatorToLine2Order.h
@@ -61,7 +61,7 @@ public:
 
 private:
   /// common part for propagation to point and line
-  virtual std::pair<bool, double> pathLengthFromCoefficients(const double ceq[4]) const dso_internal;
+  std::pair<bool, double> pathLengthFromCoefficients(const double ceq[4]) const dso_internal;
   /// Solutions of 3rd order equation
   int solve3rdOrder(const double ceq[], double sol[]) const dso_internal;
   /// Solutions of 2nd order equation

--- a/TrackingTools/GsfTracking/interface/GsfMultipleScatteringUpdator.h
+++ b/TrackingTools/GsfTracking/interface/GsfMultipleScatteringUpdator.h
@@ -21,7 +21,7 @@ public:
   /// Computation: generates vectors of weights, means and standard deviations
   void compute(const TrajectoryStateOnSurface&, const PropagationDirection, Effect[]) const override;
 
-  virtual size_t size() const { return 2; }
+  size_t size() const { return 2; }
 };
 
 #endif

--- a/TrackingTools/PatternTools/interface/TwoTrackMinimumDistance.h
+++ b/TrackingTools/PatternTools/interface/TwoTrackMinimumDistance.h
@@ -31,7 +31,7 @@ public:
 
   bool calculate(const FreeTrajectoryState& sta, const FreeTrajectoryState& stb) override;
 
-  virtual bool calculate(const GlobalTrajectoryParameters& sta, const GlobalTrajectoryParameters& stb);
+  bool calculate(const GlobalTrajectoryParameters& sta, const GlobalTrajectoryParameters& stb);
 
   bool status() const override { return status_; }
 


### PR DESCRIPTION
LLVM21 has a new warning `virtual method inside a final class and can never be overridden`. This PR is to fix these warning. If these methods should remain `virtual` then may be we can then remove the `final` keyword for the class.

See https://github.com/cms-sw/cmssw/issues/49208