### PR TITLE
[GEOMETRY] Fix for virtual method inside a final class

### DIFF
--- a/Geometry/CaloTopology/interface/CaloTowerTopology.h
+++ b/Geometry/CaloTopology/interface/CaloTowerTopology.h
@@ -18,7 +18,7 @@ public:
   ~CaloTowerTopology() override {}
   /// is this detid present in the Topology?
   bool valid(const DetId& id) const override;
-  virtual bool validDetId(const CaloTowerDetId& id) const;
+  bool validDetId(const CaloTowerDetId& id) const;
   /** Get the neighbors of the given cell in east direction*/
   std::vector<DetId> east(const DetId& id) const override;
   /** Get the neighbors of the given cell in west direction*/

--- a/Geometry/CommonTopologies/interface/PixelGeomDetType.h
+++ b/Geometry/CommonTopologies/interface/PixelGeomDetType.h
@@ -20,7 +20,7 @@ public:
   // Access to topologies
   const Topology& topology() const override { return *theTopology; }
 
-  virtual const TopologyType& specificTopology() const { return *theTopology; }
+  const TopologyType& specificTopology() const { return *theTopology; }
 
   PixelGeomDetType& operator=(const PixelGeomDetType& other) = delete;
   PixelGeomDetType(const PixelGeomDetType& other) = delete;

--- a/Geometry/CommonTopologies/interface/PixelGeomDetUnit.h
+++ b/Geometry/CommonTopologies/interface/PixelGeomDetUnit.h
@@ -35,10 +35,10 @@ public:
   /// the proxy topology (through topology() and specificTopology()) which includes
   /// corrections for the surface deformations, and once via the GeomDetType
   /// (through type().topology() and the like).
-  virtual const PixelGeomDetType& specificType() const;
+  const PixelGeomDetType& specificType() const;
 
   /// Returns a reference to the pixel proxy topology
-  virtual const PixelTopology& specificTopology() const;
+  const PixelTopology& specificTopology() const;
 
   /// Return pointer to surface deformation.
   const SurfaceDeformation* surfaceDeformation() const override { return theTopology->surfaceDeformation(); }

--- a/Geometry/CommonTopologies/interface/ProxyPixelTopology.h
+++ b/Geometry/CommonTopologies/interface/ProxyPixelTopology.h
@@ -85,14 +85,14 @@ public:
   bool isItEdgePixelInY(int iybin) const override { return specificTopology().isItEdgePixelInY(iybin); }
   bool isItEdgePixel(int ixbin, int iybin) const override { return specificTopology().isItEdgePixel(ixbin, iybin); }
 
-  virtual const GeomDetType &type() const { return *theType; }
+  const GeomDetType &type() const { return *theType; }
 
-  virtual PixelGeomDetType const &specificType() const { return *theType; }
+  PixelGeomDetType const &specificType() const { return *theType; }
 
   const SurfaceDeformation *surfaceDeformation() const { return theSurfaceDeformation.operator->(); }
-  virtual void setSurfaceDeformation(const SurfaceDeformation *deformation);
+  void setSurfaceDeformation(const SurfaceDeformation *deformation);
 
-  virtual const PixelTopology &specificTopology() const { return specificType().specificTopology(); }
+  const PixelTopology &specificTopology() const { return specificType().specificTopology(); }
 
 private:
   /// Internal method to get correction of the position from SurfaceDeformation,

--- a/Geometry/CommonTopologies/interface/TrapezoidalStripTopology.h
+++ b/Geometry/CommonTopologies/interface/TrapezoidalStripTopology.h
@@ -69,7 +69,7 @@ public:
   float radius() const { return theDistToBeam; }
 
 protected:
-  virtual float shiftOffset(float pitch_fraction);
+  float shiftOffset(float pitch_fraction);
 
 private:
   int theNumberOfStrips;

--- a/Geometry/EcalAlgo/interface/EcalPreshowerGeometry.h
+++ b/Geometry/EcalAlgo/interface/EcalPreshowerGeometry.h
@@ -52,7 +52,7 @@ public:
   DetId getClosestCell(const GlobalPoint& r) const override;
 
   // Get closest cell in arbitrary plane (1 or 2)
-  virtual DetId getClosestCellInPlane(const GlobalPoint& r, int plane) const;
+  DetId getClosestCellInPlane(const GlobalPoint& r, int plane) const;
 
   void initializeParms() override;
   unsigned int numberOfTransformParms() const override { return 3; }

--- a/Geometry/HGCalGeometry/interface/HGCalGeometry.h
+++ b/Geometry/HGCalGeometry/interface/HGCalGeometry.h
@@ -104,7 +104,7 @@ public:
   */
   DetIdSet getCells(const GlobalPoint& r, double dR) const override;
 
-  virtual void fillNamedParams(DDFilteredView fv);
+  void fillNamedParams(DDFilteredView fv);
   void initializeParms() override;
 
   static std::string producerTag() { return "HGCal"; }

--- a/Geometry/HGCalGeometry/interface/HGCalTBGeometry.h
+++ b/Geometry/HGCalGeometry/interface/HGCalTBGeometry.h
@@ -100,7 +100,7 @@ public:
   */
   DetIdSet getCells(const GlobalPoint& r, double dR) const override;
 
-  virtual void fillNamedParams(DDFilteredView fv);
+  void fillNamedParams(DDFilteredView fv);
   void initializeParms() override;
 
   static std::string producerTag() { return "HGCalTB"; }

--- a/Geometry/MTDGeometryBuilder/interface/MTDGeomDetType.h
+++ b/Geometry/MTDGeometryBuilder/interface/MTDGeomDetType.h
@@ -21,7 +21,7 @@ public:
   // Access to topologies
   const Topology& topology() const override { return *theTopology; }
 
-  virtual const TopologyType& specificTopology() const { return *theTopology; }
+  const TopologyType& specificTopology() const { return *theTopology; }
 
   MTDGeomDetType& operator=(const MTDGeomDetType& other) = delete;
   MTDGeomDetType(const MTDGeomDetType& other) = delete;

--- a/Geometry/MTDGeometryBuilder/interface/MTDGeomDetUnit.h
+++ b/Geometry/MTDGeometryBuilder/interface/MTDGeomDetUnit.h
@@ -35,10 +35,10 @@ public:
   /// the proxy topology (through topology() and specificTopology()) which includes
   /// corrections for the surface deformations, and once via the GeomDetType
   /// (through type().topology() and the like).
-  virtual const MTDGeomDetType& specificType() const;
+  const MTDGeomDetType& specificType() const;
 
   /// Returns a reference to the pixel proxy topology
-  virtual const PixelTopology& specificTopology() const;
+  const PixelTopology& specificTopology() const;
 
   /// Return pointer to surface deformation.
   const SurfaceDeformation* surfaceDeformation() const override { return theTopology->surfaceDeformation(); }

--- a/Geometry/MTDGeometryBuilder/interface/ProxyMTDTopology.h
+++ b/Geometry/MTDGeometryBuilder/interface/ProxyMTDTopology.h
@@ -85,14 +85,14 @@ public:
   bool isItEdgePixelInY(int iybin) const override { return specificTopology().isItEdgePixelInY(iybin); }
   bool isItEdgePixel(int ixbin, int iybin) const override { return specificTopology().isItEdgePixel(ixbin, iybin); }
 
-  virtual const GeomDetType &type() const { return *theType; }
+  const GeomDetType &type() const { return *theType; }
 
-  virtual MTDGeomDetType const &specificType() const { return *theType; }
+  MTDGeomDetType const &specificType() const { return *theType; }
 
   const SurfaceDeformation *surfaceDeformation() const { return theSurfaceDeformation.operator->(); }
-  virtual void setSurfaceDeformation(const SurfaceDeformation *deformation);
+  void setSurfaceDeformation(const SurfaceDeformation *deformation);
 
-  virtual const PixelTopology &specificTopology() const { return specificType().specificTopology(); }
+  const PixelTopology &specificTopology() const { return specificType().specificTopology(); }
 
 private:
   /// Internal method to get correction of the position from SurfaceDeformation,

--- a/Geometry/TrackerGeometryBuilder/interface/ProxyStripTopology.h
+++ b/Geometry/TrackerGeometryBuilder/interface/ProxyStripTopology.h
@@ -93,13 +93,13 @@ public:
   float localStripLength(const LocalPoint& lp) const override { return specificTopology().localStripLength(lp); }
   float localStripLength(const LocalPoint& lp, const Topology::LocalTrackAngles& dir) const override;
 
-  virtual const GeomDetType& type() const { return *theType; }
-  virtual StripGeomDetType const& specificType() const { return *theType; }
+  const GeomDetType& type() const { return *theType; }
+  StripGeomDetType const& specificType() const { return *theType; }
 
   const SurfaceDeformation* surfaceDeformation() const { return theSurfaceDeformation.operator->(); }
-  virtual void setSurfaceDeformation(const SurfaceDeformation* deformation);
+  void setSurfaceDeformation(const SurfaceDeformation* deformation);
 
-  virtual const StripTopology& specificTopology() const { return specificType().specificTopology(); }
+  const StripTopology& specificTopology() const { return specificType().specificTopology(); }
 
 private:
   /// Internal method to get correction of the position from SurfaceDeformation,

--- a/Geometry/TrackerGeometryBuilder/interface/StripGeomDetType.h
+++ b/Geometry/TrackerGeometryBuilder/interface/StripGeomDetType.h
@@ -20,7 +20,7 @@ public:
   // Access to topologies
   const Topology& topology() const override { return *theTopology; }
 
-  virtual const TopologyType& specificTopology() const { return *theTopology; }
+  const TopologyType& specificTopology() const { return *theTopology; }
 
   void setTopology(TopologyType* topol);
 

--- a/Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h
+++ b/Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h
@@ -35,10 +35,10 @@ public:
   /// the proxy topology (through topology() and specificTopology()) which includes
   /// corrections for the surface deformations, and once via the GeomDetType
   /// (through type().topology() and the like).
-  virtual StripGeomDetType const& specificType() const;
+  StripGeomDetType const& specificType() const;
 
   /// Returns a reference to the strip proxy topology
-  virtual const StripTopology& specificTopology() const;
+  const StripTopology& specificTopology() const;
 
   /// Return pointer to surface deformation.
   const SurfaceDeformation* surfaceDeformation() const override { return theTopology->surfaceDeformation(); }


### PR DESCRIPTION
LLVM21 has a new warning `virtual method inside a final class and can never be overridden`. This PR is to fix these warning. If these methods should remain `virtual` then may be we can then remove the `final` keyword for the class.

See https://github.com/cms-sw/cmssw/issues/49208