### PR TITLE
[RECONSTRUCTION] Fix identifier preceded by whitespace in a literal operator declaration

### DIFF
--- a/DataFormats/Math/interface/CMSUnits.h
+++ b/DataFormats/Math/interface/CMSUnits.h
@@ -23,19 +23,19 @@ namespace cms_units {
     using angle_units::operators::convertRadToDeg;
 
     // Length
-    constexpr double operator"" _mm(long double length) { return length * 0.1; }
-    constexpr double operator"" _cm(long double length) { return length * 1.; }
-    constexpr double operator"" _m(long double length) { return length * 100.; }
-    constexpr double operator"" _cm3(long double length) { return length * 1._cm * 1._cm * 1._cm; }
-    constexpr double operator"" _m3(long double length) { return length * 1._m * 1._m * 1._m; }
-    constexpr double operator"" _mm(unsigned long long int length) { return length * 0.1; }
-    constexpr double operator"" _cm(unsigned long long int length) { return length * 1; }
+    constexpr double operator""_mm(long double length) { return length * 0.1; }
+    constexpr double operator""_cm(long double length) { return length * 1.; }
+    constexpr double operator""_m(long double length) { return length * 100.; }
+    constexpr double operator""_cm3(long double length) { return length * 1._cm * 1._cm * 1._cm; }
+    constexpr double operator""_m3(long double length) { return length * 1._m * 1._m * 1._m; }
+    constexpr double operator""_mm(unsigned long long int length) { return length * 0.1; }
+    constexpr double operator""_cm(unsigned long long int length) { return length * 1; }
 
     // Energy
-    constexpr double operator"" _GeV(long double energy) { return energy * 1.; }
-    constexpr double operator"" _eV(long double energy) { return energy * 1.e-9_GeV; }
-    constexpr double operator"" _MeV(long double energy) { return energy * 1.e-3_GeV; }
-    constexpr double operator"" _TeV(long double energy) { return energy * 1.e3_GeV; }
+    constexpr double operator""_GeV(long double energy) { return energy * 1.; }
+    constexpr double operator""_eV(long double energy) { return energy * 1.e-9_GeV; }
+    constexpr double operator""_MeV(long double energy) { return energy * 1.e-3_GeV; }
+    constexpr double operator""_TeV(long double energy) { return energy * 1.e3_GeV; }
 
     // Add these conversion functions to this namespace for convenience
     using angle_units::operators::convertCm2ToMm2;

--- a/DataFormats/Math/interface/GeantUnits.h
+++ b/DataFormats/Math/interface/GeantUnits.h
@@ -28,36 +28,36 @@ namespace geant_units {
     using angle_units::operators::convertRadToDeg;
 
     // Length
-    constexpr double operator"" _mm(long double length) { return length * 1.; }
-    constexpr double operator"" _cm(long double length) { return length * 10.; }
-    constexpr double operator"" _m(long double length) { return length * 1000.; }
-    constexpr double operator"" _cm3(long double length) { return length * 1._cm * 1._cm * 1._cm; }
-    constexpr double operator"" _m3(long double length) { return length * 1._m * 1._m * 1._m; }
-    constexpr double operator"" _mm(unsigned long long int length) { return length * 1; }
-    constexpr double operator"" _cm(unsigned long long int length) { return length * 10; }
+    constexpr double operator""_mm(long double length) { return length * 1.; }
+    constexpr double operator""_cm(long double length) { return length * 10.; }
+    constexpr double operator""_m(long double length) { return length * 1000.; }
+    constexpr double operator""_cm3(long double length) { return length * 1._cm * 1._cm * 1._cm; }
+    constexpr double operator""_m3(long double length) { return length * 1._m * 1._m * 1._m; }
+    constexpr double operator""_mm(unsigned long long int length) { return length * 1; }
+    constexpr double operator""_cm(unsigned long long int length) { return length * 10; }
 
     // Time
-    constexpr double operator"" _s(long double x) { return x * seconds; }
-    constexpr double operator"" _ns(long double x) { return x * nanoseconds; }
+    constexpr double operator""_s(long double x) { return x * seconds; }
+    constexpr double operator""_ns(long double x) { return x * nanoseconds; }
 
     // Energy
-    constexpr double operator"" _MeV(long double energy) { return energy * 1.; }
-    constexpr double operator"" _eV(long double energy) { return energy * 1.e-6_MeV; }
-    constexpr double operator"" _TeV(long double energy) { return energy * 1.e6_MeV; }
-    constexpr double operator"" _GeV(long double energy) { return energy * 1000._MeV; }
+    constexpr double operator""_MeV(long double energy) { return energy * 1.; }
+    constexpr double operator""_eV(long double energy) { return energy * 1.e-6_MeV; }
+    constexpr double operator""_TeV(long double energy) { return energy * 1.e6_MeV; }
+    constexpr double operator""_GeV(long double energy) { return energy * 1000._MeV; }
 
     // Mass
     constexpr double operator"" _kg(long double mass) {
       return mass * (1._eV / 1.602176487e-19) * 1._s * 1._s / (1._m * 1._m);
     }
-    constexpr double operator"" _g(long double mass) { return mass * 1.e-3_kg; }
-    constexpr double operator"" _mg(long double mass) { return mass * 1.e-3_g; }
-    constexpr double operator"" _mole(long double mass) { return mass * 1.; }
+    constexpr double operator""_g(long double mass) { return mass * 1.e-3_kg; }
+    constexpr double operator""_mg(long double mass) { return mass * 1.e-3_g; }
+    constexpr double operator""_mole(long double mass) { return mass * 1.; }
 
     // Material properties
-    constexpr double operator"" _mg_per_cm3(long double density) { return density * 1._mg / 1._cm3; }
-    constexpr double operator"" _g_per_cm3(long double density) { return density * 1._g / 1._cm3; }
-    constexpr double operator"" _g_per_mole(long double mass) { return mass * 1._g / 1._mole; }
+    constexpr double operator""_mg_per_cm3(long double density) { return density * 1._mg / 1._cm3; }
+    constexpr double operator""_g_per_cm3(long double density) { return density * 1._g / 1._cm3; }
+    constexpr double operator""_g_per_mole(long double mass) { return mass * 1._g / 1._mole; }
 
     // Add these conversion functions to this namespace for convenience
     using angle_units::operators::convertCm2ToMm2;

--- a/DataFormats/Math/interface/GeantUnits.h
+++ b/DataFormats/Math/interface/GeantUnits.h
@@ -47,7 +47,7 @@ namespace geant_units {
     constexpr double operator""_GeV(long double energy) { return energy * 1000._MeV; }
 
     // Mass
-    constexpr double operator"" _kg(long double mass) {
+    constexpr double operator""_kg(long double mass) {
       return mass * (1._eV / 1.602176487e-19) * 1._s * 1._s / (1._m * 1._m);
     }
     constexpr double operator""_g(long double mass) { return mass * 1.e-3_kg; }


### PR DESCRIPTION
LLVM21 (in CLANG_X IBs) reports over 2K warnings like [a] from two of cmssw header files. This PR proposes to fix these by removing the  whitespace.

There are few such warnings coming from thepeg external too [b]. A cmsdist PR will follow to fix these for externals.


[a]
```
DataFormats/Math/interface/GeantUnits.h:53:33: warning: identifier '_g' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
DataFormats/Math/interface/GeantUnits.h:54:33: warning: identifier '_mg' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
DataFormats/Math/interface/GeantUnits.h:55:33: warning: identifier '_mole' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
DataFormats/Math/interface/GeantUnits.h:58:33: warning: identifier '_mg_per_cm3' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
DataFormats/Math/interface/GeantUnits.h:59:33: warning: identifier '_g_per_cm3' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
DataFormats/Math/interface/GeantUnits.h:60:33: warning: identifier '_g_per_mole' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
```

[b]
```
ThePEG/Config/Unitsystem.h:163:30: warning: identifier '_mm' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
```