### PR TITLE
Reduce size of dEdx estimators in PbPb MiniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -173,7 +173,7 @@ _upc_extraCommands = [
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 run3_upc.toModify(MicroEventContent, outputCommands = MicroEventContent.outputCommands + _upc_extraCommands)
 
-_dedx_extraCommands = ["keep recoDeDxDataedmValueMap_dedxEstimator_*_*"]
+_dedx_extraCommands = ["keep recoDeDxDataedmValueMap_dedxEstimator_dedxAllLikelihood_*"]
 from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
 dedx_lfit.toModify(MicroEventContent, outputCommands = MicroEventContent.outputCommands + _dedx_extraCommands)
 


### PR DESCRIPTION
#### PR description:

This PR reduces the size of the dEdx estimators stored in PbPb MiniAOD by reducing the precision of the mantissa and only keeping the combined dedxAllLikelihood estimator. This helps to reduce the size of minbias PbPb MiniAOD by 25%.

@flodamas @mandrenguyen 

#### PR validation:

Tested locally by using 2024 PbPb minimum bias events.
Also tested using the relvals 162,162.02,162.03,162.1,162.2,162.3,162.4

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Plan to backport to 15_1_X for PbPb data taking