### PR TITLE
[HCAL-DQM] Mask channels in HEP07 (RM 3, RMfib 4) affected by sporadic bad data

### DIFF
--- a/DQM/HcalTasks/plugins/RawTask.cc
+++ b/DQM/HcalTasks/plugins/RawTask.cc
@@ -264,8 +264,7 @@ RawTask::RawTask(edm::ParameterSet const& ps)
     if (eid.crateId() == 21 && eid.slot() == 11 && eid.fiberIndex() == 19)
       continue;
     Nbadqevt = true;
-
-   // std::cout << "   crate  :" << eid.crateId() << "   slot  :" << eid.slot() << "   fiberIndex  :" << eid.fiberIndex()  << "   fiberChanId  :" << eid.fiberChanId() << std::endl;
+   
   }
   if (lumiCache->EvtCntLS == 1)
     _NBadQEvent = 0;  // Reset at the beginning of each new LS

--- a/DQM/HcalTasks/plugins/RawTask.cc
+++ b/DQM/HcalTasks/plugins/RawTask.cc
@@ -265,8 +265,7 @@ RawTask::RawTask(edm::ParameterSet const& ps)
       continue;
     Nbadqevt = true;
 
-    std::cout << "   crate  :" << eid.crateId() << "   slot  :" << eid.slot() << "   fiberIndex  :" << eid.fiberIndex()
-              << "   fiberChanId  :" << eid.fiberChanId() << std::endl;
+   // std::cout << "   crate  :" << eid.crateId() << "   slot  :" << eid.slot() << "   fiberIndex  :" << eid.fiberIndex()  << "   fiberChanId  :" << eid.fiberChanId() << std::endl;
   }
   if (lumiCache->EvtCntLS == 1)
     _NBadQEvent = 0;  // Reset at the beginning of each new LS

--- a/DQM/HcalTasks/plugins/RawTask.cc
+++ b/DQM/HcalTasks/plugins/RawTask.cc
@@ -249,11 +249,11 @@ RawTask::RawTask(edm::ParameterSet const& ps)
 
   bool Nbadqevt = false;
   for (std::vector<DetId>::const_iterator it = creport->bad_quality_begin(); it != creport->bad_quality_end(); ++it) {
-    //  skip non HCAL det ids                                                                                                                                                                                                                               
+    //  skip non HCAL det ids
     if (!HcalGenericDetId(*it).isHcalDetId())
       continue;
-    //  skip those that are of bad quality from conditions                                                                                                                                                                                                  
-    //  Masked or Dead                                                                                                                                                                                                                                      
+    //  skip those that are of bad quality from conditions
+    //  Masked or Dead
     if (_xQuality.exists(HcalDetId(*it))) {
       HcalChannelStatus cs(it->rawId(), _xQuality.get(HcalDetId(*it)));
       if (cs.isBitSet(HcalChannelStatus::HcalCellMask) || cs.isBitSet(HcalChannelStatus::HcalCellDead))
@@ -261,18 +261,18 @@ RawTask::RawTask(edm::ParameterSet const& ps)
     }
     HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(*it));
     // Masked HEP07 sporadic bad data https://gitlab.cern.ch/cmshcal/docs/-/issues/242
-    if (eid.crateId() == 21 && eid.slot() == 11 && eid.fiberIndex() ==19)
-    	continue;
-    Nbadqevt = true;  
-  
-    std::cout << "   crate  :"<<   eid.crateId()<< "   slot  :" <<eid.slot()<< "   fiberIndex  :" <<eid.fiberIndex()<< "   fiberChanId  :"<< eid.fiberChanId() <<std::endl;
-       
+    if (eid.crateId() == 21 && eid.slot() == 11 && eid.fiberIndex() == 19)
+      continue;
+    Nbadqevt = true;
+
+    std::cout << "   crate  :" << eid.crateId() << "   slot  :" << eid.slot() << "   fiberIndex  :" << eid.fiberIndex()
+              << "   fiberChanId  :" << eid.fiberChanId() << std::endl;
   }
   if (lumiCache->EvtCntLS == 1)
     _NBadQEvent = 0;  // Reset at the beginning of each new LS
   if (Nbadqevt)
     _NBadQEvent++;
-  
+
   for (std::vector<DetId>::const_iterator it = creport->bad_quality_begin(); it != creport->bad_quality_end(); ++it) {
     //	skip non HCAL det ids
     if (!HcalGenericDetId(*it).isHcalDetId())
@@ -478,10 +478,10 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
     }
     _unknownIdsPresent = false;
     if (_unknownIdsPresent)
-	_vflags[fUnknownIds]._state = hcaldqm::flag::fBAD;
+      _vflags[fUnknownIds]._state = hcaldqm::flag::fBAD;
     else
-	_vflags[fUnknownIds]._state = hcaldqm::flag::fGOOD;
-    
+      _vflags[fUnknownIds]._state = hcaldqm::flag::fGOOD;
+
     int iflag = 0;
     //	iterate over all flags:
     //	- sum them all up in summary flag for this FED

--- a/DQM/HcalTasks/plugins/RawTask.cc
+++ b/DQM/HcalTasks/plugins/RawTask.cc
@@ -264,7 +264,6 @@ RawTask::RawTask(edm::ParameterSet const& ps)
     if (eid.crateId() == 21 && eid.slot() == 11 && eid.fiberIndex() == 19)
       continue;
     Nbadqevt = true;
-   
   }
   if (lumiCache->EvtCntLS == 1)
     _NBadQEvent = 0;  // Reset at the beginning of each new LS

--- a/DQM/HcalTasks/plugins/RawTask.cc
+++ b/DQM/HcalTasks/plugins/RawTask.cc
@@ -233,7 +233,6 @@ RawTask::RawTask(edm::ParameterSet const& ps)
     if (nbadq >= _thresh_calib_nbadq)
       return;
   }
-
   if (_ptype == fOnline &&
       lumiCache->EvtCntLS == 1) {  // Reset the bin for  _cBadQ_FEDvsLSmod10 at the beginning of each new LS
     for (std::vector<uint32_t>::const_iterator it = _vhashFEDs.begin(); it != _vhashFEDs.end(); ++it) {
@@ -248,12 +247,32 @@ RawTask::RawTask(edm::ParameterSet const& ps)
   //	a comment below is left on purpose!
   //_cBadQualityvsBX.fill(bx, creport->badQualityDigis());
 
-  int Nbadq = creport->badQualityDigis();
+  bool Nbadqevt = false;
+  for (std::vector<DetId>::const_iterator it = creport->bad_quality_begin(); it != creport->bad_quality_end(); ++it) {
+    //  skip non HCAL det ids                                                                                                                                                                                                                               
+    if (!HcalGenericDetId(*it).isHcalDetId())
+      continue;
+    //  skip those that are of bad quality from conditions                                                                                                                                                                                                  
+    //  Masked or Dead                                                                                                                                                                                                                                      
+    if (_xQuality.exists(HcalDetId(*it))) {
+      HcalChannelStatus cs(it->rawId(), _xQuality.get(HcalDetId(*it)));
+      if (cs.isBitSet(HcalChannelStatus::HcalCellMask) || cs.isBitSet(HcalChannelStatus::HcalCellDead))
+        continue;
+    }
+    HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(*it));
+    // Masked HEP07 sporadic bad data https://gitlab.cern.ch/cmshcal/docs/-/issues/242
+    if (eid.crateId() == 21 && eid.slot() == 11 && eid.fiberIndex() ==19)
+    	continue;
+    Nbadqevt = true;  
+  
+    std::cout << "   crate  :"<<   eid.crateId()<< "   slot  :" <<eid.slot()<< "   fiberIndex  :" <<eid.fiberIndex()<< "   fiberChanId  :"<< eid.fiberChanId() <<std::endl;
+       
+  }
   if (lumiCache->EvtCntLS == 1)
     _NBadQEvent = 0;  // Reset at the beginning of each new LS
-  if (Nbadq > 0)
+  if (Nbadqevt)
     _NBadQEvent++;
-  //std::cout << " Nbadq  "<<  Nbadq   << " NBadQEvent  " <<_NBadQEvent<< std::endl;
+  
   for (std::vector<DetId>::const_iterator it = creport->bad_quality_begin(); it != creport->bad_quality_end(); ++it) {
     //	skip non HCAL det ids
     if (!HcalGenericDetId(*it).isHcalDetId())
@@ -459,10 +478,10 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
     }
     _unknownIdsPresent = false;
     if (_unknownIdsPresent)
-      _vflags[fUnknownIds]._state = hcaldqm::flag::fBAD;
+	_vflags[fUnknownIds]._state = hcaldqm::flag::fBAD;
     else
-      _vflags[fUnknownIds]._state = hcaldqm::flag::fGOOD;
-
+	_vflags[fUnknownIds]._state = hcaldqm::flag::fGOOD;
+    
     int iflag = 0;
     //	iterate over all flags:
     //	- sum them all up in summary flag for this FED


### PR DESCRIPTION
#### PR description:

-This PR implements masking of channels in HEP07 (RM 3, RMfib 4) that were affected by sporadic bad data.
-The modification was made in the RawTask.cc code to mask the relevant channels only in the alarm plot (BadQ_FEDvsLSmod10).
-Additionally, the same masking was applied to other related plots such as BadQ_FEDvsLS.
-This PR does not depend on any other PRs or externals

- Additional information: See related issue: [HCAL DQM Issue #242](https://gitlab.cern.ch/cmshcal/docs/-/issues/242)

#### PR validation:
This PR is not a backport; however, it is planned to be backported.

@salimcerci

