### PR TITLE
Update of the BTL digitization model

### DIFF
--- a/RecoLocalFastTime/FTLCommonAlgos/interface/MTDTimeCalib.h
+++ b/RecoLocalFastTime/FTLCommonAlgos/interface/MTDTimeCalib.h
@@ -20,11 +20,8 @@ public:
 private:
   const MTDGeometry* geom_;
   const MTDTopology* topo_;
-  float btlTimeOffset_;
-  float etlTimeOffset_;
 
   //specific paramters from BTL simulation
-  float btlLightCollTime_;
   float btlLightCollSlope_;
 };
 

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/MTDRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/MTDRecHitAlgo.cc
@@ -74,7 +74,7 @@ FTLRecHit MTDRecHitAlgo::makeRecHit(const FTLUncalibratedRecHit& uRecHit, uint32
     }
   }
 
-  // --- Energy calibration: for the time being this is just a conversion pC --> MeV
+  // --- Energy calibration
   energy *= calibration_;
 
   // --- Time calibration: for the time being just removes a time offset in BTL

--- a/RecoLocalFastTime/FTLCommonAlgos/src/MTDTimeCalib.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/src/MTDTimeCalib.cc
@@ -9,12 +9,7 @@
 #include "Geometry/MTDCommonData/interface/MTDTopologyMode.h"
 
 MTDTimeCalib::MTDTimeCalib(edm::ParameterSet const& conf, const MTDGeometry* geom, const MTDTopology* topo)
-    : geom_(geom),
-      topo_(topo),
-      btlTimeOffset_(conf.getParameter<double>("BTLTimeOffset")),
-      etlTimeOffset_(conf.getParameter<double>("ETLTimeOffset")),
-      btlLightCollTime_(conf.getParameter<double>("BTLLightCollTime")),
-      btlLightCollSlope_(conf.getParameter<double>("BTLLightCollSlope")) {}
+    : geom_(geom), topo_(topo), btlLightCollSlope_(conf.getParameter<double>("BTLLightCollSlope")) {}
 
 float MTDTimeCalib::getTimeCalib(const MTDDetId& id) const {
   if (id.subDetector() != MTDDetId::FastTime) {
@@ -25,7 +20,6 @@ float MTDTimeCalib::getTimeCalib(const MTDDetId& id) const {
   float time_calib = 0.;
 
   if (id.mtdSubDetector() == MTDDetId::BTL) {
-    time_calib += btlTimeOffset_;
     BTLDetId hitId(id);
     //for BTL topology gives different layout id
     DetId geoId = hitId.geographicalId(MTDTopologyMode::crysLayoutFromTopoMode(topo_->getMTDTopologyMode()));
@@ -47,7 +41,7 @@ float MTDTimeCalib::getTimeCalib(const MTDDetId& id) const {
           << "BTL topology mode " << static_cast<int>(btlL) << " unsupported! Aborting";
     }
   } else if (id.mtdSubDetector() == MTDDetId::ETL) {
-    time_calib += etlTimeOffset_;
+    // no correction applied for ETL
   } else {
     throw cms::Exception("MTDTimeCalib") << "MTDDetId: " << std::hex << id.rawId() << " is invalid!" << std::dec
                                          << std::endl;

--- a/RecoLocalFastTime/FTLRecProducers/plugins/MTDTimeCalibESProducer.cc
+++ b/RecoLocalFastTime/FTLRecProducers/plugins/MTDTimeCalibESProducer.cc
@@ -44,10 +44,7 @@ MTDTimeCalibESProducer::MTDTimeCalibESProducer(const edm::ParameterSet& p) {
 // Configuration descriptions
 void MTDTimeCalibESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<double>("BTLTimeOffset", 0.)->setComment("Time offset (additive) to all the BTL RecHits [ns]");
-  desc.add<double>("ETLTimeOffset", 0.)->setComment("Time offset (additive) to all the ETL RecHits [ns]");
-  desc.add<double>("BTLLightCollTime", 0.2)->setComment("Light collection time for BTL tile geometry [ns]");
-  desc.add<double>("BTLLightCollSlope", 0.075)
+  desc.add<double>("BTLLightCollSlope", 0.095)
       ->setComment("Light collection slope for bar for BTL bar tile geometry [ns/cm]");
   descriptions.add("MTDTimeCalibESProducer", desc);
 }

--- a/RecoLocalFastTime/FTLRecProducers/python/MTDTimeCalibESProducers_cff.py
+++ b/RecoLocalFastTime/FTLRecProducers/python/MTDTimeCalibESProducers_cff.py
@@ -2,7 +2,5 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoLocalFastTime.FTLRecProducers.MTDTimeCalibESProducer_cfi import *
 
-# the following numbers are obtained on single pions 0.7-10 GeV noPU
-# to have backpropagated time average at 0
-MTDTimeCalibESProducer.BTLTimeOffset = cms.double(0.0115)
-MTDTimeCalibESProducer.ETLTimeOffset = cms.double(0.0066)
+from SimFastTiming.FastTimingCommon.mtdDigitizer_cfi import mtdDigitizer
+MTDTimeCalibESProducer.BTLLightCollSlope = mtdDigitizer.barrelDigitizer.DeviceSimulation.LightCollectionSlope

--- a/RecoLocalFastTime/FTLRecProducers/python/mtdRecHits_cfi.py
+++ b/RecoLocalFastTime/FTLRecProducers/python/mtdRecHits_cfi.py
@@ -2,8 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 _barrelAlgo = cms.PSet(
     algoName = cms.string("MTDRecHitAlgo"),
-    thresholdToKeep = cms.double(1.),          # MeV
-    calibrationConstant = cms.double(0.03125), # MeV/pC
+    thresholdToKeep = cms.double(1.), # [MeV]
+    calibrationConstant = cms.double(1.)
 )
 
 

--- a/RecoLocalFastTime/FTLRecProducers/python/mtdUncalibratedRecHits_cfi.py
+++ b/RecoLocalFastTime/FTLRecProducers/python/mtdUncalibratedRecHits_cfi.py
@@ -2,19 +2,15 @@ import FWCore.ParameterSet.Config as cms
 
 from SimFastTiming.FastTimingCommon.mtdDigitizer_cfi import mtdDigitizer
 
-
 _barrelAlgo = cms.PSet(
     algoName = cms.string("BTLUncalibRecHitAlgo"),
-    adcNbits = mtdDigitizer.barrelDigitizer.ElectronicsSimulation.adcNbits,
-    adcSaturation = mtdDigitizer.barrelDigitizer.ElectronicsSimulation.adcSaturation_MIP,
-    toaLSB_ns = mtdDigitizer.barrelDigitizer.ElectronicsSimulation.toaLSB_ns,
-    timeResolutionInNs = cms.string("0.308*pow(x,-0.4175)"), # [ns]
-    timeCorr_p0 = cms.double( 2.21103),
-    timeCorr_p1 = cms.double(-0.933552),
-    timeCorr_p2 = cms.double( 0.),
-    c_LYSO = cms.double(13.846235)     # in unit cm/ns
+    invLightSpeedLYSO = mtdDigitizer.barrelDigitizer.DeviceSimulation.LightCollectionSlope, # [ns/cm]
+    npeToADC = mtdDigitizer.barrelDigitizer.ElectronicsSimulation.PulseQParam, # Npe to ADC counts conversion
+    npePerMeV = mtdDigitizer.barrelDigitizer.DeviceSimulation.LightOutput, # [Npe/MeV]
+    tdcLSB_ns = cms.double(0.020), # [ns]
+    timeResolutionInNs = cms.string("0.0593858*pow(x,-1.02826)+0.0156719"), # [ns]
+    timeWalkCorrection = cms.string("1.9e6/0.020*pow(9.389e5/0.0348*(x+22.5),-0.663)-7.5e-4*x-3.5e-3") # linear ad hoc correction for bias from global delay removal
 )
-
 
 _endcapAlgo = cms.PSet(
     algoName      = cms.string("ETLUncalibRecHitAlgo"),
@@ -23,12 +19,11 @@ _endcapAlgo = cms.PSet(
     toaLSB_ns     = mtdDigitizer.endcapDigitizer.ElectronicsSimulation.toaLSB_ns,
     tofDelay      = mtdDigitizer.endcapDigitizer.DeviceSimulation.tofDelay,
     timeResolutionInNs = cms.string("0.0370"), # [ns]
-    timeCorr_p0 = cms.double(0.974683),
+    timeCorr_p0 = cms.double(0.967683), # 0.974683 - 0.007, ad hoc correction for bias from global delay removal
     timeCorr_p1 = cms.double(-0.237274),
     timeCorr_p2 = cms.double(0.021455),
     timeCorr_p3 = cms.double(-0.000727429)
 )
-
 
 mtdUncalibratedRecHits = cms.EDProducer(
     "MTDUncalibratedRecHitProducer",

--- a/SLHCUpgradeSimulations/Configuration/python/aging.py
+++ b/SLHCUpgradeSimulations/Configuration/python/aging.py
@@ -245,6 +245,89 @@ def ecal_complete_aging(process):
         process.ecal_digi_parameters.UseLCcorrection = cms.untracked.bool(False)
     return process
 
+def ageMTD(process,lumi):
+
+    mtd_lumis = [1000, 3000]
+    mtd_parameters = {
+        1000: {
+            "light_output": 1444.,
+            "dark_count_rate": 12.,
+            "pulse_t2_threshold": 7.199,
+            "pulse_e_threshold": 10.48,
+            "sipm_gain": 417840.,
+            "pulse_tbranch_a": [-2.2, 1.89e-8],
+            "pulse_ebranch_a": [-1.1, 1.9e-8],
+            "time_at_thr1rise": [3.1e5, -0.580],
+            "time_at_thr2rise": [1.11e6, -0.631],
+            "time_over_thr1": [1.3e9, 9.58676, -2.51351e-10, 5.98501e-18, -3.326821e-27, -7.61576e-10, 13.21],
+            "slew_rate": [1.3e9, -0.8, 8.7e-9, 11.1],
+            "pulse_q": [-43.5, 0.0793],
+            "hit_time_res": "0.143789*pow(x,-1.09324)+0.0166063"
+        },
+        3000: {
+            "light_output": 1004.,
+            "dark_count_rate": 20.,
+            "pulse_t2_threshold": 7.199,
+            "pulse_e_threshold": 4.95,
+            "sipm_gain": 330990.,
+            "pulse_tbranch_a": [-2.2, 1.89e-8],
+            "pulse_ebranch_a": [-1.1, 1.9e-8],
+            "time_at_thr1rise": [3.1e5, -0.580],
+            "time_at_thr2rise": [1.11e6, -0.631],
+            "time_over_thr1": [1.3e9, 9.58676, -2.51351e-10, 5.98501e-18, -3.326821e-27, -7.61576e-10, 13.21],
+            "slew_rate": [1.3e9, -0.8, 8.7e-9, 11.1],
+            "pulse_q": [-34.3, 0.085],
+            "hit_time_res": "0.2567*pow(x,-1.10973)+0.0165099"
+        },
+    }
+
+    if int(lumi) in mtd_lumis:
+        if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'fastTimingLayer'):
+            process.mix.digitizers.fastTimingLayer.barrelDigitizer.DeviceSimulation.LightOutput = cms.double(mtd_parameters[lumi]["light_output"])
+            process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.LightOutput = cms.double(mtd_parameters[lumi]["light_output"])
+            process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.PulseT2Threshold = cms.double(mtd_parameters[lumi]["pulse_t2_threshold"])
+            process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.PulseEThrershold = cms.double(mtd_parameters[lumi]["pulse_e_threshold"])
+            process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.DarkCountRate  = cms.double(mtd_parameters[lumi]["dark_count_rate"])
+            process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.SiPMGain = cms.double(mtd_parameters[lumi]["sipm_gain"])
+            process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.PulseTbranchAParam = cms.vdouble(mtd_parameters[lumi]["pulse_tbranch_a"])
+            process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.PulseEbranchAParam = cms.vdouble(mtd_parameters[lumi]["pulse_ebranch_a"])
+            process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.TimeAtThr1RiseParam = cms.vdouble(mtd_parameters[lumi]["time_at_thr1rise"])
+            process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.TimeAtThr2RiseParam = cms.vdouble(mtd_parameters[lumi]["time_at_thr2rise"])
+            process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.TimeOverThr1Param = cms.vdouble(mtd_parameters[lumi]["time_over_thr1"])
+            process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.SlewRateParam = cms.vdouble(mtd_parameters[lumi]["slew_rate"])
+            process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.PulseQParam = cms.vdouble(mtd_parameters[lumi]["pulse_q"])
+        # --- This is for the workflows with premixing:
+        if hasattr(process,'mixData') and hasattr(process.mixData,'workers') and hasattr(process.mixData.workers,'mtdBarrel'):
+            process.mixData.workers.mtdBarrel.DeviceSimulation.LightOutput = cms.double(mtd_parameters[lumi]["light_output"])
+            process.mixData.workers.mtdBarrel.ElectronicsSimulation.LightOutput = cms.double(mtd_parameters[lumi]["light_output"])
+            process.mixData.workers.mtdBarrel.ElectronicsSimulation.PulseT2Threshold = cms.double(mtd_parameters[lumi]["pulse_t2_threshold"])
+            process.mixData.workers.mtdBarrel.ElectronicsSimulation.PulseEThrershold = cms.double(mtd_parameters[lumi]["pulse_e_threshold"])
+            process.mixData.workers.mtdBarrel.ElectronicsSimulation.DarkCountRate  = cms.double(mtd_parameters[lumi]["dark_count_rate"])
+            process.mixData.workers.mtdBarrel.ElectronicsSimulation.SiPMGain = cms.double(mtd_parameters[lumi]["sipm_gain"])
+            process.mixData.workers.mtdBarrel.ElectronicsSimulation.PulseTbranchAParam = cms.vdouble(mtd_parameters[lumi]["pulse_tbranch_a"])
+            process.mixData.workers.mtdBarrel.ElectronicsSimulation.PulseEbranchAParam = cms.vdouble(mtd_parameters[lumi]["pulse_ebranch_a"])
+            process.mixData.workers.mtdBarrel.ElectronicsSimulation.TimeAtThr1RiseParam = cms.vdouble(mtd_parameters[lumi]["time_at_thr1rise"])
+            process.mixData.workers.mtdBarrel.ElectronicsSimulation.TimeAtThr2RiseParam = cms.vdouble(mtd_parameters[lumi]["time_at_thr2rise"])
+            process.mixData.workers.mtdBarrel.ElectronicsSimulation.TimeOverThr1Param = cms.vdouble(mtd_parameters[lumi]["time_over_thr1"])
+            process.mixData.workers.mtdBarrel.ElectronicsSimulation.SlewRateParam = cms.vdouble(mtd_parameters[lumi]["slew_rate"])
+            process.mixData.workers.mtdBarrel.ElectronicsSimulation.PulseQParam = cms.vdouble(mtd_parameters[lumi]["pulse_q"])
+        # --- This is for the uncalibrated RecHit reconstruction:
+        if hasattr(process,'mtdUncalibratedRecHits') and hasattr(process.mtdUncalibratedRecHits,'barrel'):
+            process.mtdUncalibratedRecHits.barrel.npePerMeV = cms.double(mtd_parameters[lumi]["light_output"])
+            process.mtdUncalibratedRecHits.barrel.npeToADC = cms.vdouble(mtd_parameters[lumi]["pulse_q"])
+            process.mtdUncalibratedRecHits.barrel.timeResolutionInNs = cms.string(mtd_parameters[lumi]["hit_time_res"])
+            process.mtdUncalibratedRecHits.barrel.timeWalkCorrection = cms.string(
+                "{}/{}*pow({}/{}*(x-{}),{})".format( mtd_parameters[lumi]["time_at_thr1rise"][0],
+                                                     0.020, # [ns], TDC LSB
+                                                     mtd_parameters[lumi]["sipm_gain"],
+                                                     mtd_parameters[lumi]["pulse_q"][1],
+                                                     mtd_parameters[lumi]["pulse_q"][0],
+                                                     mtd_parameters[lumi]["time_at_thr1rise"][1]
+                )
+            )
+
+    return process
+
 def customise_aging_300(process):
     process=ageHcal(process,300,5.0e34,"nominal")
     process=ageEcal(process,300,5.0e34)
@@ -254,12 +337,14 @@ def customise_aging_1000(process):
     process=ageHcal(process,1000,5.0e34,"nominal")
     process=turn_off_HE_aging(process) #avoid conflict between HGCal and Hcal in phase2 geom configuration
     process=ageEcal(process,1000,5.0e34)
+    process=ageMTD(process,1000)
     return process
 
 def customise_aging_3000(process):
     process=ageHcal(process,3000,5.0e34,"nominal")
     process=turn_off_HE_aging(process) #avoid conflict between HGCal and Hcal in phase2 geom configuration
     process=ageEcal(process,3000,5.0e34)
+    process=ageMTD(process,3000)
     process=agedHGCal(process)
     process=agedHFNose(process)
     return process
@@ -268,6 +353,7 @@ def customise_aging_3000_ultimate(process):
     process=ageHcal(process,3000,7.5e34,"ultimate")
     process=turn_off_HE_aging(process) #avoid conflict between HGCal and Hcal in phase2 geom configuration
     process=ageEcal(process,3000,7.5e34)
+    process=ageMTD(process,3000)
     process=agedHGCal(process)
     process=agedHFNose(process)
     return process

--- a/SimFastTiming/FastTimingCommon/interface/BTLDeviceSim.h
+++ b/SimFastTiming/FastTimingCommon/interface/BTLDeviceSim.h
@@ -40,12 +40,10 @@ private:
   const MTDTopology* topo_;
 
   const float bxTime_;
-  const float LightYield_;
-  const float LightCollEff_;
-
-  const float LightCollSlope_;
-  const float PDE_;
-  const float LCEpositionSlope_;
+  const float lightOutput_;
+  const float lightCollSlope_;
+  const float sigmaLightCollSlope_;
+  const float lcepositionSlope_;
 };
 
 #endif

--- a/SimFastTiming/FastTimingCommon/interface/MTDDigitizerTypes.h
+++ b/SimFastTiming/FastTimingCommon/interface/MTDDigitizerTypes.h
@@ -15,12 +15,13 @@ namespace mtd_digitizer {
   typedef std::array<MTDSimData_t, nSamples> MTDSimHitData;
 
   struct MTDCellInfo {
-    // for the BTL bar geometry:
-    //     3rd array=energy (right side), 4th array=time-of-flight (right side)
+    // for BTL:
+    //     0 --> number of photo-electrons (left side),  1 --> time of flight (left side)
+    //     2 --> number of photo-electrons (right side), 3 --> time of flight (right side)
     std::array<MTDSimHitData, 4> hit_info;
   };
 
-  // Maximum value of time-of-flight for premixing packing
+  // Maximum value of time of flight for premixing packing
   constexpr float PREMIX_MAX_TOF = 25.0f;
 
   struct MTDCellId {

--- a/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
+++ b/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
@@ -1,10 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 _common_BTLparameters = cms.PSet(
-    bxTime                   = cms.double(25),      # [ns]
-    LightYield               = cms.double(40000.),  # [photons/MeV]
-    LightCollectionEff       = cms.double(0.25),
-    PhotonDetectionEff       = cms.double(0.20),
+    BunchCrossingTime = cms.double(25),    # [ns]
+    LightOutput       = cms.double(2285.), # [npe/MeV], including Light Yield, Light Collection Efficincy and Photon Detection Efficiency
+    LCEpositionSlope  = cms.double(0.035)  # [1/cm] LCE variation vs longitudinal position shift
 )
 
 _barrel_MTDDigitizer = cms.PSet(
@@ -17,41 +16,40 @@ _barrel_MTDDigitizer = cms.PSet(
     premixStage1MaxCharge = cms.double(1e6),
     DeviceSimulation = cms.PSet(
         _common_BTLparameters,
-        LightCollectionSlope     = cms.double(0.075),   # [ns/cm]
-        LCEpositionSlope         = cms.double(0.071),   # [1/cm] LCE variation vs longitudinal position shift
+        LightCollectionSlope      = cms.double(0.0915), # [ns/cm]
+        SigmaLightCollectionSlope = cms.double(0.001)  # [ns/cm] sigma of the light collection slope
         ),
     ElectronicsSimulation = cms.PSet(
         _common_BTLparameters,
-        TestBeamMIPTimeRes         = cms.double(4.293), # This is given by 0.048[ns]*sqrt(8000.), in order to
-                                                        # rescale the time resolution of 1 MIP = 8000 p.e.
-        ScintillatorRiseTime       = cms.double(1.1),   # [ns]
-        ScintillatorDecayTime      = cms.double(40.),   # [ns]
-        ChannelTimeOffset          = cms.double(0.),    # [ns]
-        smearChannelTimeOffset     = cms.double(0.),    # [ns]
-        EnergyThreshold            = cms.double(4.),    # [photo-electrons]
-        TimeThreshold1             = cms.double(20.),   # [photo-electrons]
-        TimeThreshold2             = cms.double(50.),   # [photo-electrons]
-        ReferencePulseNpe          = cms.double(100.),  # [photo-electrons]
-        DarkCountRate              = cms.double(10.),   # [GHz]
-        SinglePhotonTimeResolution = cms.double(0.060), # [ns]
-        SigmaElectronicNoise       = cms.double(1.),    # [p.e.]
-        SigmaClock                 = cms.double(0.015), # [ns]
-        CorrelationCoefficient     = cms.double(1.),
-        SmearTimeForOOTtails       = cms.bool(True),
-        Npe_to_pC                  = cms.double(0.016), # [pC]
-        Npe_to_V                   = cms.double(0.0064),# [V]
-        SigmaRelTOFHIRenergy       = cms.vdouble(0.139,-4.35e-05,3.315e-09,-1.20e-13,1.67e-18), # [%] coefficients of 4th degree Chebyshev polynomial parameterization
+        SigmaLCEpositionSlope     = cms.double(0.002),  # [1/cm] sigma of the LCE variation vs longitudinal position shift
+        PulseT2Threshold          = cms.double(8.764),  # [uA] T2 threshold
+        PulseEThrershold          = cms.double(20.32),  # [uA] energy threshold (it corresponds to 1 MeV)
+        ChannelRearmMode          = cms.uint32(2),      # 0: the channel rearming is switched off
+                                                        # 1: the channel is rearmed after the end-of-event signal
+                                                        # 2: the channel is rearmed after ChannelRearmNClocks cycles of the TOFHiR clock
+        ChannelRearmNClocks       = cms.double(3.),     # number of TOFHiR clock cycles after which the channel is rearmed
+        T1Delay                   = cms.double(0.),     # [ns]
+        SiPMGain                  = cms.double(9.389e5),# SiPM gain at Vov = 3 V
+        PulseTbranchAParam        = cms.vdouble(-2.2, 1.89e-8), # average pulse amplitude in uA vs Gain * Npe in the TOFHiR's time branch
+        PulseEbranchAParam        = cms.vdouble(-1.3, 1.01e-8), # average pulse amplitude in uA vs Gain * Npe in the TOFHiR's energy branch
+        TimeAtThr1RiseParam       = cms.vdouble(1.9e6,-0.663), # time at threshold T1 (20 DAC) vs Gain * Npe on the rising edge
+        TimeAtThr2RiseParam       = cms.vdouble(5.2e6,-0.704), # time at threshold T2 (28 DAC) vs Gain * Npe on the rising edge
+        TimeOverThr1Param         = cms.vdouble(1.4776e9,7.93403,-3.78578e-10,5.42505e-18,-2.27325e-27,-7.32799e-10,12.933), # time over the T1 threshold vs Gain * Npe
+        SmearTimeForOOTtails      = cms.bool(True),     # switch to turn ON/OFF the uncertainty due to photons from OOT hits
+        ScintillatorRiseTime      = cms.double(1.1),    # [ns]
+        ScintillatorDecayTime     = cms.double(42.8),   # [ns]
+        StocasticParam            = cms.vdouble(14.746531, 0.7), # (0.030[ns]*7000^0.7, 0.7)
+        DarkCountRate             = cms.double(0.),     # [GHz]
+        DCRParam                  = cms.vdouble(50.583684, 0.41), # (0.034[ns]*6000/30^0.41, 0.41)
+        SigmaElectronicNoise      = cms.double(0.420),  # [uA]
+        SlewRateParam             = cms.vdouble(1.3e9,-3.5,10.9e-9,14.7), # parameterization of slew rate vs Gain * npe
+        SigmaTDC                  = cms.double(0.0133), # [ns]
+        SigmaClockGlobal          = cms.double(0.007),  # [ns], uncertainty due to the global LHC clock distribution
+        SigmaClockRU              = cms.double(0.005),  # [ns], uncertainty due to clock distribution within the readout units
+        CorrelationCoefficient    = cms.double(1.),     # correlation coefficient between T1 and T2 uncertainties
 
-        # n bits for the ADC 
-        adcNbits          = cms.uint32(10),
-        # n bits for the TDC
-        tdcNbits          = cms.uint32(10),
-        # ADC saturation
-        adcSaturation_MIP = cms.double(600.),           # [pC]
-        # for different thickness
-        adcThreshold_MIP   = cms.double(0.064),         # [pC]
-        # LSB for time of arrival estimate from TDC
-        toaLSB_ns         = cms.double(0.020),          # [ns]
+        PulseQParam               = cms.vdouble(-22.5, 0.0348), # pulse amplitude in ADC counts vs Npe
+        PulseQResParam            = cms.vdouble(51., -0.88),    # relative amplitude resolution vs Npe
         )
 
 
@@ -67,6 +65,7 @@ _endcap_MTDDigitizer = cms.PSet(
     premixStage1MaxCharge = cms.double(1e6),
     DeviceSimulation  = cms.PSet(
         bxTime               = cms.double(25),
+
         IntegratedLuminosity = cms.double(1000.0),
         FluenceVsRadius      = cms.string("1.937*TMath::Power(x,-1.706)"),
         LGADGainVsFluence    = cms.string("TMath::Min(15.,30.-x)"),

--- a/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
@@ -1,5 +1,3 @@
-#define EDM_ML_DEBUG
-
 #include "SimFastTiming/FastTimingCommon/interface/BTLElectronicsSim.h"
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"

--- a/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
@@ -1,226 +1,286 @@
+#define EDM_ML_DEBUG
+
 #include "SimFastTiming/FastTimingCommon/interface/BTLElectronicsSim.h"
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "DataFormats/ForwardDetId/interface/BTLDetId.h"
+
 #include "CLHEP/Random/RandPoissonQ.h"
 #include "CLHEP/Random/RandGaussQ.h"
-
-#include "Math/ChebyshevPol.h"
 
 using namespace mtd;
 
 BTLElectronicsSim::BTLElectronicsSim(const edm::ParameterSet& pset, edm::ConsumesCollector iC)
-    : debug_(pset.getUntrackedParameter<bool>("debug", false)),
-      bxTime_(pset.getParameter<double>("bxTime")),
-      testBeamMIPTimeRes_(pset.getParameter<double>("TestBeamMIPTimeRes")),
-      ScintillatorRiseTime_(pset.getParameter<double>("ScintillatorRiseTime")),
-      ScintillatorDecayTime_(pset.getParameter<double>("ScintillatorDecayTime")),
-      ChannelTimeOffset_(pset.getParameter<double>("ChannelTimeOffset")),
-      smearChannelTimeOffset_(pset.getParameter<double>("smearChannelTimeOffset")),
-      EnergyThreshold_(pset.getParameter<double>("EnergyThreshold")),
-      TimeThreshold1_(pset.getParameter<double>("TimeThreshold1")),
-      TimeThreshold2_(pset.getParameter<double>("TimeThreshold2")),
-      ReferencePulseNpe_(pset.getParameter<double>("ReferencePulseNpe")),
-      SinglePhotonTimeResolution_(pset.getParameter<double>("SinglePhotonTimeResolution")),
-      DarkCountRate_(pset.getParameter<double>("DarkCountRate")),
-      SigmaElectronicNoise_(pset.getParameter<double>("SigmaElectronicNoise")),
-      SigmaClock_(pset.getParameter<double>("SigmaClock")),
+    : bxTime_(pset.getParameter<double>("BunchCrossingTime")),
+      lcepositionSlope_(pset.getParameter<double>("LCEpositionSlope")),
+      sigmaLCEpositionSlope_(pset.getParameter<double>("SigmaLCEpositionSlope")),
+      pulseT2Threshold_(pset.getParameter<double>("PulseT2Threshold")),
+      pulseEThreshold_(pset.getParameter<double>("PulseEThrershold")),
+      channelRearmMode_(pset.getParameter<uint32_t>("ChannelRearmMode")),
+      channelRearmNClocks_(pset.getParameter<double>("ChannelRearmNClocks")),
+      t1Delay_(pset.getParameter<double>("T1Delay")),
+      sipmGain_(pset.getParameter<double>("SiPMGain")),
+      paramPulseTbranchA_(pset.getParameter<std::vector<double>>("PulseTbranchAParam")),
+      paramPulseEbranchA_(pset.getParameter<std::vector<double>>("PulseEbranchAParam")),
+      paramThr1Rise_(pset.getParameter<std::vector<double>>("TimeAtThr1RiseParam")),
+      paramThr2Rise_(pset.getParameter<std::vector<double>>("TimeAtThr2RiseParam")),
+      paramTimeOverThr1_(pset.getParameter<std::vector<double>>("TimeOverThr1Param")),
       smearTimeForOOTtails_(pset.getParameter<bool>("SmearTimeForOOTtails")),
-      Npe_to_pC_(pset.getParameter<double>("Npe_to_pC")),
-      Npe_to_V_(pset.getParameter<double>("Npe_to_V")),
-      sigmaRelTOFHIRenergy_(pset.getParameter<std::vector<double>>("SigmaRelTOFHIRenergy")),
-      adcNbits_(pset.getParameter<uint32_t>("adcNbits")),
-      tdcNbits_(pset.getParameter<uint32_t>("tdcNbits")),
-      adcSaturation_MIP_(pset.getParameter<double>("adcSaturation_MIP")),
-      adcBitSaturation_(std::pow(2, adcNbits_) - 1),
-      adcLSB_MIP_(adcSaturation_MIP_ / adcBitSaturation_),
-      adcThreshold_MIP_(pset.getParameter<double>("adcThreshold_MIP")),
-      toaLSB_ns_(pset.getParameter<double>("toaLSB_ns")),
-      tdcBitSaturation_(std::pow(2, tdcNbits_) - 1),
-      CorrCoeff_(pset.getParameter<double>("CorrelationCoefficient")),
-      cosPhi_(0.5 * (sqrt(1. + CorrCoeff_) + sqrt(1. - CorrCoeff_))),
-      sinPhi_(0.5 * CorrCoeff_ / cosPhi_),
-      ScintillatorDecayTime2_(ScintillatorDecayTime_ * ScintillatorDecayTime_),
-      ScintillatorDecayTimeInv_(1. / ScintillatorDecayTime_),
-      SPTR2_(SinglePhotonTimeResolution_ * SinglePhotonTimeResolution_),
-      DCRxRiseTime_(DarkCountRate_ * ScintillatorRiseTime_),
-      SigmaElectronicNoise2_(SigmaElectronicNoise_ * SigmaElectronicNoise_),
-      SigmaClock2_(SigmaClock_ * SigmaClock_) {
+      scintillatorRiseTime_(pset.getParameter<double>("ScintillatorRiseTime")),
+      scintillatorDecayTime_(pset.getParameter<double>("ScintillatorDecayTime")),
+      stocasticParam_(pset.getParameter<std::vector<double>>("StocasticParam")),
+      darkCountRate_(pset.getParameter<double>("DarkCountRate")),
+      paramDCR_(pset.getParameter<std::vector<double>>("DCRParam")),
+      sigmaElectronicNoise_(pset.getParameter<double>("SigmaElectronicNoise")),
+      paramSR_(pset.getParameter<std::vector<double>>("SlewRateParam")),
+      sigmaTDC_(pset.getParameter<double>("SigmaTDC")),
+      sigmaClockGlobal_(pset.getParameter<double>("SigmaClockGlobal")),
+      sigmaClockRU_(pset.getParameter<double>("SigmaClockRU")),
+      paramPulseQ_(pset.getParameter<std::vector<double>>("PulseQParam")),
+      paramPulseQRes_(pset.getParameter<std::vector<double>>("PulseQResParam")),
+      corrCoeff_(pset.getParameter<double>("CorrelationCoefficient")),
+      cosPhi_(0.5 * (sqrt(1. + corrCoeff_) + sqrt(1. - corrCoeff_))),
+      sinPhi_(0.5 * corrCoeff_ / cosPhi_),
+      scintillatorDecayTimeInv_(1. / scintillatorDecayTime_),
+      sigmaConst2_(sigmaTDC_ * sigmaTDC_ + sigmaClockGlobal_ * sigmaClockGlobal_),
 #ifdef EDM_ML_DEBUG
-  float lightOutput = 4.2f * pset.getParameter<double>("LightYield") * pset.getParameter<double>("LightCollectionEff") *
-                      pset.getParameter<double>("PhotonDetectionEff");  // average npe for 4.2 MeV
+      debug_(true) {
+#else
+      debug_(false) {
+#endif
+#ifdef EDM_ML_DEBUG
+  float lightOutput = 4.4f * pset.getParameter<double>("LightOutput");  // average Npe for 4.4 MeV
   float s1 = sigma_stochastic(lightOutput);
-  float s2 = std::sqrt(sigma2_DCR(lightOutput));
-  float s3 = std::sqrt(sigma2_electronics(lightOutput));
-  float s4 = SinglePhotonTimeResolution_ / std::sqrt(TimeThreshold1_);
-  float s5 = SigmaClock_;
-  LogDebug("BTLElectronicsSim") << " BTL time resolution model (ns, 1 SiPM), for an average light output of "
-                                << std::fixed << std::setw(14) << lightOutput << " N_pe:"
+  float s2 = sigma_DCR(lightOutput);
+  float s3 = sigma_electronics(lightOutput);
+  float s4 = sigmaTDC_;
+  float s5 = sqrt(sigmaClockGlobal_ * sigmaClockGlobal_ + sigmaClockRU_ * sigmaClockRU_);
+  LogDebug("BTLElectronicsSim") << " BTL resolution model, for an average light output of " << std::fixed
+                                << std::setw(14) << lightOutput << " :"
                                 << "\n sigma stochastic   = " << std::setw(14) << s1
                                 << "\n sigma DCR          = " << std::setw(14) << s2
                                 << "\n sigma electronics  = " << std::setw(14) << s3
-                                << "\n sigma sptr         = " << std::setw(14) << s4
+                                << "\n sigma digitization = " << std::setw(14) << s4
                                 << "\n sigma clock        = " << std::setw(14) << s5 << "\n ---------------------"
                                 << "\n sigma total        = " << std::setw(14)
                                 << std::sqrt(s1 * s1 + s2 * s2 + s3 * s3 + s4 * s4 + s5 * s5);
 #endif
+
+  // --- Array to store a different local clock jitter for each readout unit
+  smearingClockRU_ = new std::array<float, numberOfRUs_>();
+  smearingClockRU_->fill(0.f);
 }
+
+BTLElectronicsSim::~BTLElectronicsSim() { delete smearingClockRU_; }
 
 void BTLElectronicsSim::run(const mtd::MTDSimHitDataAccumulator& input,
                             BTLDigiCollection& output,
                             CLHEP::HepRandomEngine* hre) const {
-  MTDSimHitData chargeColl, toa1, toa2;
+  // --- Fill the readout-unit clock jitter array
+  for (unsigned int iRU = 0; iRU < numberOfRUs_; ++iRU) {
+    (*smearingClockRU_)[iRU] = CLHEP::RandGaussQ::shoot(hre, 0., sigmaClockRU_);
+  }
 
+  // --- Loop over the simhits (which have been propagated to the right and left sides of the crystal bar)
   for (MTDSimHitDataAccumulator::const_iterator it = input.begin(); it != input.end(); it++) {
-    // --- Digitize only the in-time bucket:
+    // --- Digitize only the in-time bucket
     const unsigned int iBX = mtd_digitizer::kInTimeBX;
 
-    chargeColl.fill(0.f);
-    toa1.fill(0.f);
-    toa2.fill(0.f);
+    // --- Apply a common Npe Poisson fluctuation and independet Gaussian smearings
+    //     for the LCE position slope to the right and left hits of the bar
+    float npe[2] = {0.f, 0.f};
+
+    // If both sides of the bar have an hit, the original simhit Npe and x can be determined:
+    if ((it->second).hit_info[0][iBX] != 0. && (it->second).hit_info[2][iBX] != 0.) {
+      float npe_origin = 0.5 * ((it->second).hit_info[0][iBX] + (it->second).hit_info[2][iBX]);
+      float x_origin =
+          0.5 * ((it->second).hit_info[0][iBX] - (it->second).hit_info[2][iBX]) / (npe_origin * lcepositionSlope_);
+
+      float npe_fluctuated = CLHEP::RandPoissonQ::shoot(hre, npe_origin);
+
+      float lceSlope_smearing = CLHEP::RandGaussQ::shoot(hre, 0., sigmaLCEpositionSlope_);
+      npe[0] = npe_fluctuated * (1. + (sigmaLCEpositionSlope_ + lceSlope_smearing) * x_origin);
+
+      lceSlope_smearing = CLHEP::RandGaussQ::shoot(hre, 0., sigmaLCEpositionSlope_);
+      npe[1] = npe_fluctuated * (1. - (sigmaLCEpositionSlope_ + lceSlope_smearing) * x_origin);
+
+    }
+    // If there is a hit only on one side of the bar, the original simhit Npe and x can't be
+    // determined and only a Poisson fluctuation to Npe_R or Npe_L is applied:
+    else if ((it->second).hit_info[0][iBX] != 0. && (it->second).hit_info[2][iBX] == 0.) {
+      npe[0] = CLHEP::RandPoissonQ::shoot(hre, (it->second).hit_info[0][iBX]);
+    } else if ((it->second).hit_info[0][iBX] == 0. && (it->second).hit_info[2][iBX] != 0.) {
+      npe[1] = CLHEP::RandPoissonQ::shoot(hre, (it->second).hit_info[2][iBX]);
+    }
+    // If there is no hit on either side of the bar, the hit is skipped:
+    else {
+      continue;
+    }
+
+    float charge_adc[2] = {0.f, 0.f};
+    float toa1[2] = {0.f, 0.f};
+    float toa2[2] = {0.f, 0.f};
     for (size_t iside = 0; iside < 2; iside++) {
-      // --- Fluctuate the total number of photo-electrons
-      float npe = CLHEP::RandPoissonQ::shoot(hre, (it->second).hit_info[2 * iside][iBX]);
-      if (npe < EnergyThreshold_)
+      // --- Skip the empty buckets
+      if (npe[iside] == 0.) {
         continue;
-
-      // --- Get the time of arrival and add a channel time offset
-      float finalToA1 = (it->second).hit_info[1 + 2 * iside][iBX] + ChannelTimeOffset_;
-
-      if (smearChannelTimeOffset_ > 0.) {
-        float timeSmearing = CLHEP::RandGaussQ::shoot(hre, 0., smearChannelTimeOffset_);
-        finalToA1 += timeSmearing;
       }
 
-      // --- Calculate and add the time walk: the time of arrival is read in correspondence
-      //                                      with two thresholds on the signal pulse
-      std::array<float, 3> times =
-          btlPulseShape_.timeAtThr(npe / ReferencePulseNpe_, TimeThreshold1_ * Npe_to_V_, TimeThreshold2_ * Npe_to_V_);
+      // ================================================================================
+      //  TOFHiR's time branch
+      // ================================================================================
 
-      // --- If the pulse amplitude is smaller than TimeThreshold2, the trigger does not fire
-      if (times[1] == 0.)
+      // --- Skip the hit if its amplitude is below the T2 threshold
+      if (pulse_tbranch_uA(npe[iside]) < pulseT2Threshold_) {
         continue;
+      }
 
-      float finalToA2 = finalToA1 + times[1];
-      finalToA1 += times[0];
+      // --- Skip the hit if its amplitude is below the energy threshold
+      if (pulse_ebranch_uA(npe[iside]) < pulseEThreshold_) {
+        continue;
+      }
 
-      // --- Estimate the time uncertainty due to photons from earlier OOT hits in the current BTL cell
-      if (smearTimeForOOTtails_) {
-        float rate_oot = 0.;
-        // Loop on earlier OOT hits
-        for (int ibx = 0; ibx < mtd_digitizer::kInTimeBX; ++ibx) {
-          if ((it->second).hit_info[2 * iside][ibx] > 0.) {
-            float hit_time = (it->second).hit_info[1 + 2 * iside][ibx] + bxTime_ * (ibx - mtd_digitizer::kInTimeBX);
-            float npe_oot = CLHEP::RandPoissonQ::shoot(hre, (it->second).hit_info[2 * iside][ibx]);
-            rate_oot += npe_oot * exp(hit_time * ScintillatorDecayTimeInv_) * ScintillatorDecayTimeInv_;
-          }
-        }  // ibx loop
+      // --- Add the T1 and T2 threshold crossing times on the pulse rising edge to the SimHit time
+      float finalToA1 = (it->second).hit_info[1 + 2 * iside][iBX] + time_at_Thr1Rise(npe[iside]);
+      float finalToA2 = (it->second).hit_info[1 + 2 * iside][iBX] + time_at_Thr2Rise(npe[iside]);
 
-        if (rate_oot > 0.) {
-          float sigma_oot = sqrt(rate_oot * ScintillatorRiseTime_) * ScintillatorDecayTime_ / npe;
-          float smearing_oot = CLHEP::RandGaussQ::shoot(hre, 0., sigma_oot);
-          finalToA1 += smearing_oot;
-          finalToA2 += smearing_oot;
+      // --- Loop over the earlier OOT hits in the current bar to determine the channel
+      //     rearming time and estimate the photon flux arriving at the in-time BX
+      float channelRearmingTime = -bxTime_ * (mtd_digitizer::kInTimeBX - 1);
+      float rate_oot = 0.;
+      for (int ibx = 0; ibx < mtd_digitizer::kInTimeBX; ++ibx) {
+        // Skip the OOT empty buckets
+        if ((it->second).hit_info[2 * iside][ibx] == 0.) {
+          continue;
         }
-      }  // if smearTimeForOOTtails_
 
-      // --- Uncertainty due to the fluctuations of the n-th photon arrival time:
-      if (testBeamMIPTimeRes_ > 0.) {
-        // In this case the time resolution is parametrized from the testbeam.
-        // The same parameterization is used for both thresholds.
-        float sigma = sigma_stochastic(npe);
-        float smearing_stat_thr1 = CLHEP::RandGaussQ::shoot(hre, 0., sigma);
-        float smearing_stat_thr2 = CLHEP::RandGaussQ::shoot(hre, 0., sigma);
+        float hit_time_oot = (it->second).hit_info[1 + 2 * iside][ibx];
+        float hit_npe_oot = CLHEP::RandPoissonQ::shoot(hre, (it->second).hit_info[2 * iside][ibx]);
 
-        finalToA1 += smearing_stat_thr1;
-        finalToA2 += smearing_stat_thr2;
+        // Calculate the channel rearming time for this hit (the hit is skipped if it
+        // doesn't pass the T2 threshold or an earlier hit is holding the channel)
+        float time_at_T1_oot = time_at_Thr1Rise(hit_npe_oot);
 
-      } else {
-        // In this case the time resolution is taken from the literature.
-        // The fluctuations due to the first TimeThreshold1_ p.e. are common to both times
-        float smearing_stat_thr1 =
-            CLHEP::RandGaussQ::shoot(hre, 0., ScintillatorDecayTime_ * sqrt(sigma2_pe(TimeThreshold1_, npe)));
-        float smearing_stat_thr2 = CLHEP::RandGaussQ::shoot(
-            hre, 0., ScintillatorDecayTime_ * sqrt(sigma2_pe(TimeThreshold2_ - TimeThreshold1_, npe)));
-        finalToA1 += smearing_stat_thr1;
-        finalToA2 += smearing_stat_thr1 + smearing_stat_thr2;
+        if (channelRearmMode_ && pulse_tbranch_uA(hit_npe_oot) > pulseT2Threshold_ &&
+            hit_time_oot + time_at_T1_oot > channelRearmingTime) {
+          channelRearmingTime = rearming_time(hit_time_oot + time_at_T1_oot, hit_npe_oot);
+        }
+
+        // Rate of photons from earlier OOT hits in the current BTL cell
+        if (smearTimeForOOTtails_) {
+          rate_oot += hit_npe_oot * exp(hit_time_oot * scintillatorDecayTimeInv_) * scintillatorDecayTimeInv_;
+        }
+
+      }  // ibx loop
+
+      // --- Skip the hit if the readout channel is not rearmed
+      if (channelRearmMode_ && finalToA1 < channelRearmingTime) {
+        continue;
       }
 
-      // --- Add in quadrature the uncertainties due to the SiPM timing resolution, the SiPM DCR,
-      //     the electronic noise and the clock distribution:
-      float sigma2_tot_thr1 = SPTR2_ / TimeThreshold1_ + sigma2_DCR(npe) + sigma2_electronics(npe) + SigmaClock2_;
-      float sigma2_tot_thr2 = SPTR2_ / TimeThreshold2_ + sigma2_DCR(npe) + sigma2_electronics(npe) + SigmaClock2_;
+      // --- Uncertainty due to photons from earlier OOT hits in the current BTL cell
+      if (smearTimeForOOTtails_ && rate_oot > 0.) {
+        float sigma_oot = sqrt(rate_oot * scintillatorRiseTime_) * scintillatorDecayTime_ / npe[iside];
+        float smearing_oot = CLHEP::RandGaussQ::shoot(hre, 0., sigma_oot);
+        finalToA1 += smearing_oot;
+        finalToA2 += smearing_oot;
+      }
 
-      // --- Smear the arrival times using the correlated uncertainties:
-      float smearing_thr1_uncorr = CLHEP::RandGaussQ::shoot(hre, 0., sqrt(sigma2_tot_thr1));
-      float smearing_thr2_uncorr = CLHEP::RandGaussQ::shoot(hre, 0., sqrt(sigma2_tot_thr2));
+      // --- Stochastich term
+      float sigmaStoc = sigma_stochastic(npe[iside]);
+      finalToA1 += CLHEP::RandGaussQ::shoot(hre, 0., sigmaStoc);
+      finalToA2 += CLHEP::RandGaussQ::shoot(hre, 0., sigmaStoc);
+
+      // --- Add in quadrature the uncertainties due to the SiPM DCR and the electronic noise
+      float sigmaDCR = sigma_DCR(npe[iside]);
+      float sigmaElec = sigma_electronics(npe[iside]);
+      float sigma2_tot_thr1 = sigmaDCR * sigmaDCR + sigmaElec * sigmaElec;
+
+      // --- Add in quadrature the uncertainties independent of Npe: digitization and global clock distribution
+      sigma2_tot_thr1 += sigmaConst2_;
+
+      float sigma2_tot_thr2 = sigma2_tot_thr1;
+
+      // --- Add the contribution due to the clock distribution within the readout units
+      //     and smear the T1 and T2 arrival times assuming correlated uncertainties
+
+      // Define a global readout-unit ID
+      BTLDetId cellId((it->first).detid_);
+      const int iRU = ((it->first).detid_ & BTLDetId::kBTLNewFormat
+                           ? 12 * cellId.mtdRR() + 6 * cellId.mtdSide() + cellId.runit()
+                           : 12 * (cellId.mtdRR() - 1) + 6 * cellId.mtdSide() + cellId.runit() - 1);
+
+      float smearing_thr1_uncorr = CLHEP::RandGaussQ::shoot(hre, 0., sqrt(sigma2_tot_thr1)) + (*smearingClockRU_)[iRU];
+      float smearing_thr2_uncorr = CLHEP::RandGaussQ::shoot(hre, 0., sqrt(sigma2_tot_thr2)) + (*smearingClockRU_)[iRU];
 
       finalToA1 += cosPhi_ * smearing_thr1_uncorr + sinPhi_ * smearing_thr2_uncorr;
       finalToA2 += sinPhi_ * smearing_thr1_uncorr + cosPhi_ * smearing_thr2_uncorr;
 
-      //Smear the energy according to TOFHIR energy branch measured resolution
-      float tofhir_ampnoise_relsigma = ROOT::Math::Chebyshev4(npe,
-                                                              sigmaRelTOFHIRenergy_[0],
-                                                              sigmaRelTOFHIRenergy_[1],
-                                                              sigmaRelTOFHIRenergy_[2],
-                                                              sigmaRelTOFHIRenergy_[3],
-                                                              sigmaRelTOFHIRenergy_[4]);
-      float smearing_tofhir = CLHEP::RandGaussQ::shoot(hre, 0., tofhir_ampnoise_relsigma);
-      // the amplitude resolution already includes the photostatistics fluctuation, use the original average deposit
-      chargeColl[iside] = (it->second).hit_info[2 * iside][iBX] * Npe_to_pC_ *
-                          (1. + smearing_tofhir);  // the p.e. number is here converted to pC
-
       toa1[iside] = finalToA1;
       toa2[iside] = finalToA2;
 
+      // ================================================================================
+      //  TOFHiR's energy branch
+      // ================================================================================
+
+      // --- Get the pulse amplitude in ADC counts
+      float amp = pulse_q(npe[iside]);
+
+      // --- Get the average uncertainty on the pulse amplitude (here the unsmeared
+      //     value of Npe is used, because the parameterization of the relative
+      //     amplitude resolution already includes the photostatistics fluctuation)
+      float sigma_amp = amp * pulse_qRes((it->second).hit_info[2 * iside][iBX]);
+
+      charge_adc[iside] = CLHEP::RandGaussQ::shoot(hre, amp, sigma_amp);
+
     }  // iside loop
 
-    //run the shaper to create a new data frame
+    // --- Run the shaper to create a new data frame
     BTLDataFrame rawDataFrame(it->first.detid_);
-    runTrivialShaper(rawDataFrame, chargeColl, toa1, toa2, it->first.row_, it->first.column_);
+    runTrivialShaper(rawDataFrame, charge_adc, toa1, toa2, it->first.row_, it->first.column_);
     updateOutput(output, rawDataFrame);
 
   }  // MTDSimHitDataAccumulator loop
 }
 
 void BTLElectronicsSim::runTrivialShaper(BTLDataFrame& dataFrame,
-                                         const mtd::MTDSimHitData& chargeColl,
-                                         const mtd::MTDSimHitData& toa1,
-                                         const mtd::MTDSimHitData& toa2,
+                                         const float (&charge_adc)[2],
+                                         const float (&toa1)[2],
+                                         const float (&toa2)[2],
                                          const uint8_t row,
                                          const uint8_t col) const {
   bool debug = debug_;
-#ifdef EDM_ML_DEBUG
-  for (int it = 0; it < (int)(chargeColl.size()); it++)
-    debug |= (chargeColl[it] > adcThreshold_MIP_);
-#endif
 
-  if (debug)
-    edm::LogVerbatim("BTLElectronicsSim") << "[runTrivialShaper]" << std::endl;
+  if (debug) {
+    LogTrace("BTLElectronicsSim") << "[runTrivialShaper] DetId " << dataFrame.id().rawId() << std::endl;
+  }
 
-  //set new ADCs
-  for (int it = 0; it < (int)(chargeColl.size()); it++) {
+  // --- Digitize the hit charge and times
+  for (int iside = 0; iside < dfSIZE; iside++) {
     BTLSample newSample;
     newSample.set(false, false, 0, 0, 0, row, col);
 
     //brute force saturation, maybe could to better with an exponential like saturation
-    const uint32_t adc = std::min((uint32_t)std::floor(chargeColl[it] / adcLSB_MIP_), adcBitSaturation_);
-    const uint32_t tdc_time1 = std::min((uint32_t)std::floor(toa1[it] / toaLSB_ns_), tdcBitSaturation_);
-    const uint32_t tdc_time2 = std::min((uint32_t)std::floor(toa2[it] / toaLSB_ns_), tdcBitSaturation_);
+    const uint32_t adc = std::min((uint32_t)std::round(charge_adc[iside]), adcBitSaturation_);
+    const uint32_t tdc_time1 = std::min((uint32_t)std::round(toa1[iside] / tdcLSB_ns_), tdcBitSaturation_);
+    const uint32_t tdc_time2 = std::min((uint32_t)std::round(toa2[iside] / tdcLSB_ns_), tdcBitSaturation_);
 
-    newSample.set(
-        chargeColl[it] > adcThreshold_MIP_, tdc_time1 == tdcBitSaturation_, tdc_time2, tdc_time1, adc, row, col);
-    dataFrame.setSample(it, newSample);
+    newSample.set(true, tdc_time1 == tdcBitSaturation_, tdc_time2, tdc_time1, adc, row, col);
+    dataFrame.setSample(iside, newSample);
 
-    if (debug)
-      edm::LogVerbatim("BTLElectronicsSim") << adc << " (" << chargeColl[it] << "/" << adcLSB_MIP_ << ") ";
-  }
+    if (debug) {
+      LogTrace("BTLElectronicsSim") << "Side " << iside << ": ADC = " << adc << " (" << charge_adc[iside] << "), "
+                                    << "TDC1 = " << tdc_time1 << " (" << toa1[iside] << "), "
+                                    << "TDC2 = " << tdc_time2 << " (" << toa2[iside] << ")" << std::endl;
+    }
+  }  // iside loop
 
   if (debug) {
     std::ostringstream msg;
     dataFrame.print(msg);
-    edm::LogVerbatim("BTLElectronicsSim") << msg.str() << std::endl;
+    LogTrace("BTLElectronicsSim") << msg.str() << std::endl;
   }
 }
 
@@ -239,34 +299,86 @@ void BTLElectronicsSim::updateOutput(BTLDigiCollection& coll, const BTLDataFrame
   }
 }
 
-float BTLElectronicsSim::sigma2_pe(const float& Q, const float& R) const {
-  float OneOverR = 1. / R;
-  float OneOverR2 = OneOverR * OneOverR;
+float BTLElectronicsSim::rearming_time(const float& hit_time, const float& hit_npe) const {
+  // mode 1: the channel is rearmed after the falling edge of the trigger_B signal
+  // mode 2: the channel is rearmed after n cycles of the TOFHiR clock
+  float deadTime = t1Delay_ + (channelRearmMode_ == 1 ? time_over_Thr1(hit_npe) : channelRearmNClocks_ * tofhirClock_);
 
-  // --- This is Eq. (17) from Nucl. Instr. Meth. A 564 (2006) 185
-  float sigma2 = Q * OneOverR2 *
-                 (1. + 2. * (Q + 1.) * OneOverR + (Q + 1.) * (6. * Q + 11) * OneOverR2 +
-                  (Q + 1.) * (Q + 2.) * (2. * Q + 5.) * OneOverR2 * OneOverR);
-
-  return sigma2;
+  // Sync the rearming time with the next rising edge of the TOFHiR clock
+  return (std::round((hit_time + deadTime) / tofhirClock_) + 1.) * tofhirClock_;
 }
 
-float BTLElectronicsSim::sigma_stochastic(const float& npe) const { return testBeamMIPTimeRes_ / std::sqrt(npe); }
-
-float BTLElectronicsSim::sigma2_DCR(const float& npe) const {
-  // trick to safely switch off the electronics contribution for resolution studies
-
-  if (DCRxRiseTime_ == 0.) {
-    return 0.;
-  }
-  return DCRxRiseTime_ * ScintillatorDecayTime2_ / npe / npe;
+float BTLElectronicsSim::pulse_tbranch_uA(const float& npe) const {
+  float gainXnpe = sipmGain_ * npe;
+  return paramPulseTbranchA_[0] + paramPulseTbranchA_[1] * gainXnpe;
 }
 
-float BTLElectronicsSim::sigma2_electronics(const float npe) const {
-  // trick to safely switch off the electronics contribution for resolution studies
+float BTLElectronicsSim::pulse_ebranch_uA(const float& npe) const {
+  float gainXnpe = sipmGain_ * npe;
+  return paramPulseEbranchA_[0] + paramPulseEbranchA_[1] * gainXnpe;
+}
 
-  if (SigmaElectronicNoise2_ == 0.) {
+float BTLElectronicsSim::time_at_Thr1Rise(const float& npe) const {
+  return paramThr1Rise_[0] * std::pow(sipmGain_ * npe, paramThr1Rise_[1]);
+}
+
+float BTLElectronicsSim::time_at_Thr2Rise(const float& npe) const {
+  return paramThr2Rise_[0] * std::pow(sipmGain_ * npe, paramThr2Rise_[1]);
+}
+
+float BTLElectronicsSim::time_over_Thr1(const float& npe) const {
+  float gainXnpe = sipmGain_ * npe;
+
+  float time_over_thr1 =
+      (gainXnpe <= paramTimeOverThr1_[0]
+           ? paramTimeOverThr1_[4] * gainXnpe * gainXnpe * gainXnpe + paramTimeOverThr1_[3] * gainXnpe * gainXnpe +
+                 paramTimeOverThr1_[2] * gainXnpe + paramTimeOverThr1_[1]
+           : paramTimeOverThr1_[5] * gainXnpe + paramTimeOverThr1_[6]);
+
+  return time_over_thr1;
+}
+
+float BTLElectronicsSim::sigma_stochastic(const float& npe) const {
+  // Trick to safely switch off the stochastic contribution for resolution studies:
+  if (stocasticParam_[0] == 0.) {
     return 0.;
   }
-  return SigmaElectronicNoise2_ * ScintillatorDecayTime2_ / npe / npe;
+
+  return sqrt2_ * stocasticParam_[0] *
+         std::pow(npe, -stocasticParam_[1]);  // The uncertainty is provided for the combination of two SiPMs
+}
+
+float BTLElectronicsSim::sigma_DCR(const float& npe) const {
+  // Trick to safely switch off the electronics contribution for resolution studies:
+  if (darkCountRate_ == 0.) {
+    return 0.;
+  }
+
+  return sqrt2_ * paramDCR_[0] * std::pow(darkCountRate_, paramDCR_[1]) /
+         npe;  // The uncertainty is provided for the combination of two SiPMs
+}
+
+float BTLElectronicsSim::sigma_electronics(const float& npe) const {
+  // Trick to safely switch off the electronics contribution for resolution studies:
+  if (sigmaElectronicNoise_ == 0.) {
+    return 0.;
+  }
+
+  float gainXnpe = sipmGain_ * npe;
+  float res = sigmaElectronicNoise_;
+
+  if (gainXnpe <= paramSR_[0]) {
+    res /= (paramSR_[2] * gainXnpe + paramSR_[1]);
+  } else {
+    res /= (paramSR_[3] * std::log(gainXnpe) + paramSR_[2] * paramSR_[0] - paramSR_[3] * std::log(paramSR_[0]) +
+            paramSR_[1]);
+  }
+
+  return std::sqrt(res * res);
+}
+
+float BTLElectronicsSim::pulse_q(const float& npe) const { return paramPulseQ_[0] + paramPulseQ_[1] * npe; }
+
+float BTLElectronicsSim::pulse_qRes(const float& npe) const {
+  return paramPulseQRes_[0] * std::pow(npe, paramPulseQRes_[1]);
 }

--- a/SimFastTiming/FastTimingCommon/src/ETLDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/ETLDeviceSim.cc
@@ -133,8 +133,8 @@ void ETLDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t, f
         simHitAccumulator->emplace(mtd_digitizer::MTDCellId(id, row, col), mtd_digitizer::MTDCellInfo()).first;
 
     // Accumulate in 15 buckets of 25ns (9 pre-samples, 1 in-time, 5 post-samples)
-    const int itime = std::floor(toa / bxTime_) + 9;
-    if (itime < 0 || itime > 14)
+    const int itime = std::floor(toa / bxTime_) + mtd_digitizer::kInTimeBX;
+    if (itime < 0 || itime >= mtd_digitizer::kNumberOfBX)
       continue;
 
     // Check if time index is ok and store energy

--- a/SimFastTiming/FastTimingCommon/src/ETLElectronicsSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/ETLElectronicsSim.cc
@@ -1,5 +1,3 @@
-#define EDM_ML_DEBUG
-
 #include "SimFastTiming/FastTimingCommon/interface/ETLElectronicsSim.h"
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"

--- a/SimFastTiming/FastTimingCommon/src/ETLElectronicsSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/ETLElectronicsSim.cc
@@ -1,3 +1,5 @@
+#define EDM_ML_DEBUG
+
 #include "SimFastTiming/FastTimingCommon/interface/ETLElectronicsSim.h"
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -140,7 +142,7 @@ void ETLElectronicsSim::runTrivialShaper(ETLDataFrame& dataFrame,
     }
   }
   if (dumpInfo) {
-    LogTrace("ETLElectronicsSim") << "[runTrivialShaper]";
+    LogTrace("ETLElectronicsSim") << "[runTrivialShaper] DetId " << dataFrame.id().rawId() << std::endl;
   }
 #endif
 
@@ -178,7 +180,7 @@ void ETLElectronicsSim::runTrivialShaper(ETLDataFrame& dataFrame,
 }
 
 void ETLElectronicsSim::updateOutput(ETLDigiCollection& coll, const ETLDataFrame& rawDataFrame) const {
-  int itIdx(9);
+  int itIdx(mtd_digitizer::kInTimeBX);
   if (rawDataFrame.size() <= itIdx + 2)
     return;
 

--- a/Validation/MtdValidation/macros/makeTimeResPlots.C
+++ b/Validation/MtdValidation/macros/makeTimeResPlots.C
@@ -8,7 +8,7 @@
 //     root -l makeTimeResPlot.C\(\"DQM_filename.root\"\)
 //
 //  NB: In order to have the UncalibratedRecHits histograms filled,
-//      the MTD validation has to be run the flags:
+//      the MTD validation has to be run with the flags:
 //
 //      process.btlLocalRecoValid.optionalPlots = cms.bool(True)
 //      process.btlLocalRecoValid.UncalibRecHitsPlots = cms.bool(True)
@@ -73,10 +73,11 @@ TH1F* h_TimeResEta_ETL[2][nBinsEta_ETL];
 TH1F* g_TimeResQ_ETL[2];
 TH1F* g_TimeResEta_ETL[2];
 
-// subDet = 0: make both BTL and ETL plots
-// subDet = 1: make only BTL plots
-// subDet = 2: make only ETL plots
-void makeTimeResPlots(const TString DQMfilename = "DQM_V0001_UNKNOWN_R000000001.root", const int subDet = 0) {
+constexpr int SUBDET_BOTH = 0;
+constexpr int SUBDET_BTL = 1;
+constexpr int SUBDET_ETL = 2;
+
+void makeTimeResPlots(const TString DQMfilename = "DQM_V0001_UNKNOWN_R000000001.root", const int subDet = SUBDET_BOTH) {
   gStyle->SetOptStat(kFALSE);
 
   // --- Histograms booking
@@ -120,7 +121,7 @@ void makeTimeResPlots(const TString DQMfilename = "DQM_V0001_UNKNOWN_R000000001.
   // BTL
   /////////////////////////////////////////////////////////////////////////////////
 
-  if (subDet == 0 || subDet == 1) {
+  if (subDet == SUBDET_BOTH || subDet == SUBDET_BTL) {
     // ---------------------------------------------------------------------------
     // BTL time resolution vs E
 
@@ -308,7 +309,7 @@ void makeTimeResPlots(const TString DQMfilename = "DQM_V0001_UNKNOWN_R000000001.
   // ETL
   /////////////////////////////////////////////////////////////////////////////////
 
-  if (subDet == 0 || subDet == 2) {
+  if (subDet == SUBDET_BOTH || subDet == SUBDET_ETL) {
     // ---------------------------------------------------------------------------
     // ETL time resolution vs amplitude and |eta|
 

--- a/Validation/MtdValidation/macros/makeTimeResPlots.C
+++ b/Validation/MtdValidation/macros/makeTimeResPlots.C
@@ -5,13 +5,15 @@
 //  plots vs the hit amplitude and the hit |eta|.
 //
 //  Usage:
-//     root -l make_resPlot.C\(\"DQM_filename.root\"\)
+//     root -l makeTimeResPlot.C\(\"DQM_filename.root\"\)
 //
 //  NB: In order to have the UncalibratedRecHits histograms filled,
 //      the MTD validation has to be run the flags:
 //
-//      process.btlLocalReco.UncalibRecHitsPlots = cms.bool(True);
-//      process.etlLocalReco.UncalibRecHitsPlots = cms.bool(True);
+//      process.btlLocalRecoValid.optionalPlots = cms.bool(True)
+//      process.btlLocalRecoValid.UncalibRecHitsPlots = cms.bool(True)
+//      process.etlLocalRecoValid.optionalPlots = cms.bool(True)
+//      process.etlLocalRecoValid.UncalibRecHitsPlots = cms.bool(True)
 //
 // =============================================================================
 
@@ -31,15 +33,15 @@ const Float_t minBinContent = 20.;
 
 // --- BTL
 
-const Int_t nBinsQ_BTL = 20;
-const Float_t binWidthQ_BTL = 30.;  // [pC]
+const Int_t nBinsQ_BTL = 30;
+const Float_t binWidthQ_BTL = 0.5;  // [MeV]
 const Int_t nBinsQEta_BTL = 3;
-const Float_t binsQEta_BTL[4] = {0., 0.65, 1.15, 1.55};
+const Float_t binsQEta_BTL[nBinsQEta_BTL + 1] = {0., 0.65, 1.15, 1.55};
 
 const Int_t nBinsEta_BTL = 31;
 const Float_t binWidthEta_BTL = 0.05;
-const Int_t nBinsEtaQ_BTL = 7;
-const Float_t binsEtaQ_BTL[8] = {0., 30., 60., 90., 120., 150., 360., 600.};
+const Int_t nBinsEtaQ_BTL = 6;
+const Float_t binsEtaQ_BTL[nBinsEtaQ_BTL + 1] = {0., 2., 4., 6., 8., 12., 15.};
 
 // --- ETL
 
@@ -53,6 +55,7 @@ const Float_t etaMin_ETL = 1.65;
 // =============================================================================
 
 TCanvas* c[10];
+TLegend* legend[10];
 
 TH1F* h_TimeResQ_BTL[nBinsQ_BTL];
 TH1F* h_TimeResQEta_BTL[nBinsQ_BTL][nBinsQEta_BTL];
@@ -70,17 +73,20 @@ TH1F* h_TimeResEta_ETL[2][nBinsEta_ETL];
 TH1F* g_TimeResQ_ETL[2];
 TH1F* g_TimeResEta_ETL[2];
 
-void makeTimeResPlots(const TString DQMfilename = "DQM_V0001_UNKNOWN_R000000001.root") {
+// subDet = 0: make both BTL and ETL plots
+// subDet = 1: make only BTL plots
+// subDet = 2: make only ETL plots
+void makeTimeResPlots(const TString DQMfilename = "DQM_V0001_UNKNOWN_R000000001.root", const int subDet = 0) {
   gStyle->SetOptStat(kFALSE);
 
   // --- Histograms booking
 
-  g_TimeResQ_BTL = new TH1F("g_TimeResQ_BTL", "BTL time resolution vs Q", nBinsQ_BTL, 0., nBinsQ_BTL * binWidthQ_BTL);
+  g_TimeResQ_BTL = new TH1F("g_TimeResQ_BTL", "BTL time resolution vs E", nBinsQ_BTL, 0., nBinsQ_BTL * binWidthQ_BTL);
 
   for (Int_t ih = 0; ih < nBinsQEta_BTL; ++ih) {
     TString hname = Form("g_TimeResQEta_BTL_%d", ih);
     TString htitle =
-        Form("BTL time resolution vs Q (%4.2f < |#eta_{hit}| < %4.2f)", binsQEta_BTL[ih], binsQEta_BTL[ih + 1]);
+        Form("BTL time resolution vs E (%4.2f < |#eta_{hit}| < %4.2f)", binsQEta_BTL[ih], binsQEta_BTL[ih + 1]);
     g_TimeResQEta_BTL[ih] = new TH1F(hname, htitle, nBinsQ_BTL, 0., nBinsQ_BTL * binWidthQ_BTL);
   }
 
@@ -90,7 +96,7 @@ void makeTimeResPlots(const TString DQMfilename = "DQM_V0001_UNKNOWN_R000000001.
   for (Int_t ih = 0; ih < nBinsEtaQ_BTL; ++ih) {
     TString hname = Form("g_TimeResEtaQ_BTL_%d", ih);
     TString htitle =
-        Form("BTL time resolution vs |#eta_{hit}| (%4.2f < Q < %4.2f)", binsEtaQ_BTL[ih], binsEtaQ_BTL[ih + 1]);
+        Form("BTL time resolution vs |#eta_{hit}| (%4.2f < E < %4.2f)", binsEtaQ_BTL[ih], binsEtaQ_BTL[ih + 1]);
     g_TimeResEtaQ_BTL[ih] = new TH1F(hname, htitle, nBinsEta_BTL, 0., nBinsEta_BTL * binWidthEta_BTL);
   }
 
@@ -110,272 +116,287 @@ void makeTimeResPlots(const TString DQMfilename = "DQM_V0001_UNKNOWN_R000000001.
   std::cout << " Processing file " << DQMfilename.Data() << " ... " << std::endl;
   TFile* input_file = new TFile(DQMfilename.Data());
 
-  // ---------------------------------------------------------------------------
-  // BTL time resolution vs Q
+  /////////////////////////////////////////////////////////////////////////////////
+  // BTL
+  /////////////////////////////////////////////////////////////////////////////////
 
-  for (Int_t iq = 0; iq < nBinsQ_BTL; ++iq) {
-    TString hname = Form("DQMData/Run 1/MTD/Run summary/BTL/LocalReco/TimeResQ_%d", iq);
-    h_TimeResQ_BTL[iq] = (TH1F*)input_file->Get(hname);
+  if (subDet == 0 || subDet == 1) {
+    // ---------------------------------------------------------------------------
+    // BTL time resolution vs E
 
-    if (h_TimeResQ_BTL[iq]->GetEntries() < minBinContent)
-      continue;
+    for (Int_t iq = 0; iq < nBinsQ_BTL; ++iq) {
+      TString hname = Form("DQMData/Run 1/MTD/Run summary/BTL/LocalReco/TimeResQ_%d", iq);
+      h_TimeResQ_BTL[iq] = (TH1F*)input_file->Get(hname);
 
-    Float_t low_limit = h_TimeResQ_BTL[iq]->GetMean() - 2. * h_TimeResQ_BTL[iq]->GetRMS();
-    Float_t up_limit = h_TimeResQ_BTL[iq]->GetMean() + 3 * h_TimeResQ_BTL[iq]->GetRMS();
-
-    TFitResultPtr fit_res = h_TimeResQ_BTL[iq]->Fit("gaus", "SERQ0", "", low_limit, up_limit);
-
-    if (fit_res->Status() != 0) {
-      std::cout << " *** ERROR: fit failed for the histogram" << h_TimeResQ_BTL[iq]->GetName() << std::endl;
-      continue;
-    }
-
-    g_TimeResQ_BTL->SetBinContent(iq + 1, fit_res->GetParams()[2]);
-    g_TimeResQ_BTL->SetBinError(iq + 1, fit_res->GetErrors()[2]);
-
-  }  // iq loop
-
-  // ---------------------------------------------------------------------------
-  // BTL time resolution vs Q in bind of |eta|
-
-  for (Int_t iq = 0; iq < nBinsQ_BTL; ++iq) {
-    for (Int_t ieta = 0; ieta < nBinsQEta_BTL; ++ieta) {
-      TString hname = Form("DQMData/Run 1/MTD/Run summary/BTL/LocalReco/TimeResQvsEta_%d_%d", iq, ieta);
-      h_TimeResQEta_BTL[iq][ieta] = (TH1F*)input_file->Get(hname);
-
-      if (h_TimeResQEta_BTL[iq][ieta]->GetEntries() < minBinContent)
+      if (h_TimeResQ_BTL[iq]->GetEntries() < minBinContent)
         continue;
 
-      Float_t low_limit = h_TimeResQEta_BTL[iq][ieta]->GetMean() - 2. * h_TimeResQEta_BTL[iq][ieta]->GetRMS();
-      Float_t up_limit = h_TimeResQEta_BTL[iq][ieta]->GetMean() + 3 * h_TimeResQEta_BTL[iq][ieta]->GetRMS();
+      Float_t low_limit = h_TimeResQ_BTL[iq]->GetMean() - 2. * h_TimeResQ_BTL[iq]->GetRMS();
+      Float_t up_limit = h_TimeResQ_BTL[iq]->GetMean() + 3 * h_TimeResQ_BTL[iq]->GetRMS();
 
-      TFitResultPtr fit_res = h_TimeResQEta_BTL[iq][ieta]->Fit("gaus", "SERQ0", "", low_limit, up_limit);
+      TFitResultPtr fit_res = h_TimeResQ_BTL[iq]->Fit("gaus", "SERQ0", "", low_limit, up_limit);
 
       if (fit_res->Status() != 0) {
-        std::cout << " *** ERROR: fit failed for the histogram" << h_TimeResQEta_BTL[iq][ieta]->GetName() << std::endl;
+        std::cout << " *** ERROR: fit failed for the histogram" << h_TimeResQ_BTL[iq]->GetName() << std::endl;
         continue;
       }
 
-      g_TimeResQEta_BTL[ieta]->SetBinContent(iq + 1, fit_res->GetParams()[2]);
-      g_TimeResQEta_BTL[ieta]->SetBinError(iq + 1, fit_res->GetErrors()[2]);
-
-    }  // ieta loop
-
-  }  // iq loop
-
-  // ---------------------------------------------------------------------------
-  // BTL time resolution vs |eta|
-
-  for (Int_t ieta = 0; ieta < nBinsEta_BTL; ++ieta) {
-    TString hname = Form("DQMData/Run 1/MTD/Run summary/BTL/LocalReco/TimeResEta_%d", ieta);
-    h_TimeResEta_BTL[ieta] = (TH1F*)input_file->Get(hname);
-
-    if (h_TimeResEta_BTL[ieta]->GetEntries() < minBinContent)
-      continue;
-
-    Float_t low_limit = h_TimeResEta_BTL[ieta]->GetMean() - 2. * h_TimeResEta_BTL[ieta]->GetRMS();
-    Float_t up_limit = h_TimeResEta_BTL[ieta]->GetMean() + 3 * h_TimeResEta_BTL[ieta]->GetRMS();
-
-    TFitResultPtr fit_res = h_TimeResEta_BTL[ieta]->Fit("gaus", "SERQ0", "", low_limit, up_limit);
-
-    if (fit_res->Status() != 0) {
-      std::cout << " *** ERROR: fit failed for the histogram" << h_TimeResEta_BTL[ieta]->GetName() << std::endl;
-      continue;
-    }
-
-    g_TimeResEta_BTL->SetBinContent(ieta + 1, fit_res->GetParams()[2]);
-    g_TimeResEta_BTL->SetBinError(ieta + 1, fit_res->GetErrors()[2]);
-
-  }  // ieta loop
-
-  // ---------------------------------------------------------------------------
-  // BTL time resolution vs |eta| in bind of Q
-
-  for (Int_t ieta = 0; ieta < nBinsEta_BTL; ++ieta) {
-    for (Int_t iq = 0; iq < nBinsEtaQ_BTL; ++iq) {
-      TString hname = Form("DQMData/Run 1/MTD/Run summary/BTL/LocalReco/TimeResEtavsQ_%d_%d", ieta, iq);
-      h_TimeResEtaQ_BTL[ieta][iq] = (TH1F*)input_file->Get(hname);
-
-      if (h_TimeResEtaQ_BTL[ieta][iq]->GetEntries() < minBinContent)
-        continue;
-
-      Float_t low_limit = h_TimeResEtaQ_BTL[ieta][iq]->GetMean() - 2. * h_TimeResEtaQ_BTL[ieta][iq]->GetRMS();
-      Float_t up_limit = h_TimeResEtaQ_BTL[ieta][iq]->GetMean() + 3 * h_TimeResEtaQ_BTL[ieta][iq]->GetRMS();
-
-      TFitResultPtr fit_res = h_TimeResEtaQ_BTL[ieta][iq]->Fit("gaus", "SERQ0", "", low_limit, up_limit);
-
-      if (fit_res->Status() != 0) {
-        std::cout << " *** ERROR: fit failed for the histogram" << h_TimeResEtaQ_BTL[ieta][iq]->GetName() << std::endl;
-        continue;
-      }
-
-      g_TimeResEtaQ_BTL[iq]->SetBinContent(ieta + 1, fit_res->GetParams()[2]);
-      g_TimeResEtaQ_BTL[iq]->SetBinError(ieta + 1, fit_res->GetErrors()[2]);
+      g_TimeResQ_BTL->SetBinContent(iq + 1, fit_res->GetParams()[2]);
+      g_TimeResQ_BTL->SetBinError(iq + 1, fit_res->GetErrors()[2]);
 
     }  // iq loop
 
-  }  // ieta loop
+    // ---------------------------------------------------------------------------
+    // BTL time resolution vs E in bind of |eta|
 
-  // ---------------------------------------------------------------------------
-  // ETL time resolution vs amplitude and |eta|
+    for (Int_t iq = 0; iq < nBinsQ_BTL; ++iq) {
+      for (Int_t ieta = 0; ieta < nBinsQEta_BTL; ++ieta) {
+        TString hname = Form("DQMData/Run 1/MTD/Run summary/BTL/LocalReco/TimeResQvsEta_%d_%d", iq, ieta);
+        h_TimeResQEta_BTL[iq][ieta] = (TH1F*)input_file->Get(hname);
 
-  for (Int_t iside = 0; iside < 2; ++iside) {
-    for (Int_t iq = 0; iq < nBinsQ_ETL; ++iq) {
-      TString hname = Form("DQMData/Run 1/MTD/Run summary/ETL/LocalReco/TimeResTot_%d_%d", iside, iq);
-      h_TimeResQ_ETL[iside][iq] = (TH1F*)input_file->Get(hname);
+        if (h_TimeResQEta_BTL[iq][ieta]->GetEntries() < minBinContent)
+          continue;
 
-      if (h_TimeResQ_ETL[iside][iq]->GetEntries() < minBinContent)
-        continue;
+        Float_t low_limit = h_TimeResQEta_BTL[iq][ieta]->GetMean() - 2. * h_TimeResQEta_BTL[iq][ieta]->GetRMS();
+        Float_t up_limit = h_TimeResQEta_BTL[iq][ieta]->GetMean() + 3 * h_TimeResQEta_BTL[iq][ieta]->GetRMS();
 
-      Float_t low_limit = h_TimeResQ_ETL[iside][iq]->GetMean() - 2. * h_TimeResQ_ETL[iside][iq]->GetRMS();
-      Float_t up_limit = h_TimeResQ_ETL[iside][iq]->GetMean() + 3 * h_TimeResQ_ETL[iside][iq]->GetRMS();
+        TFitResultPtr fit_res = h_TimeResQEta_BTL[iq][ieta]->Fit("gaus", "SERQ0", "", low_limit, up_limit);
 
-      TFitResultPtr fit_res = h_TimeResQ_ETL[iside][iq]->Fit("gaus", "SERQ0", "", low_limit, up_limit);
+        if (fit_res->Status() != 0) {
+          std::cout << " *** ERROR: fit failed for the histogram" << h_TimeResQEta_BTL[iq][ieta]->GetName()
+                    << std::endl;
+          continue;
+        }
 
-      if (fit_res->Status() != 0) {
-        std::cout << " *** ERROR: fit failed for the histogram" << h_TimeResQ_ETL[iside][iq]->GetName() << std::endl;
-        continue;
-      }
+        g_TimeResQEta_BTL[ieta]->SetBinContent(iq + 1, fit_res->GetParams()[2]);
+        g_TimeResQEta_BTL[ieta]->SetBinError(iq + 1, fit_res->GetErrors()[2]);
 
-      g_TimeResQ_ETL[iside]->SetBinContent(iq + 1, fit_res->GetParams()[2]);
-      g_TimeResQ_ETL[iside]->SetBinError(iq + 1, fit_res->GetErrors()[2]);
+      }  // ieta loop
 
     }  // iq loop
 
-    for (Int_t ieta = 0; ieta < nBinsEta_ETL; ++ieta) {
-      TString hname = Form("DQMData/Run 1/MTD/Run summary/ETL/LocalReco/TimeResEta_%d_%d", iside, ieta);
-      h_TimeResEta_ETL[iside][ieta] = (TH1F*)input_file->Get(hname);
+    // ---------------------------------------------------------------------------
+    // BTL time resolution vs |eta|
 
-      if (h_TimeResEta_ETL[iside][ieta]->GetEntries() < minBinContent)
+    for (Int_t ieta = 0; ieta < nBinsEta_BTL; ++ieta) {
+      TString hname = Form("DQMData/Run 1/MTD/Run summary/BTL/LocalReco/TimeResEta_%d", ieta);
+      h_TimeResEta_BTL[ieta] = (TH1F*)input_file->Get(hname);
+
+      if (h_TimeResEta_BTL[ieta]->GetEntries() < minBinContent)
         continue;
 
-      Float_t low_limit = h_TimeResEta_ETL[iside][ieta]->GetMean() - 2. * h_TimeResEta_ETL[iside][ieta]->GetRMS();
-      Float_t up_limit = h_TimeResEta_ETL[iside][ieta]->GetMean() + 3 * h_TimeResEta_ETL[iside][ieta]->GetRMS();
+      Float_t low_limit = h_TimeResEta_BTL[ieta]->GetMean() - 2. * h_TimeResEta_BTL[ieta]->GetRMS();
+      Float_t up_limit = h_TimeResEta_BTL[ieta]->GetMean() + 3 * h_TimeResEta_BTL[ieta]->GetRMS();
 
-      TFitResultPtr fit_res = h_TimeResEta_ETL[iside][ieta]->Fit("gaus", "SERQ0", "", low_limit, up_limit);
+      TFitResultPtr fit_res = h_TimeResEta_BTL[ieta]->Fit("gaus", "SERQ0", "", low_limit, up_limit);
 
       if (fit_res->Status() != 0) {
-        std::cout << " *** ERROR: fit failed for the histogram" << h_TimeResEta_ETL[iside][ieta]->GetName()
-                  << std::endl;
+        std::cout << " *** ERROR: fit failed for the histogram" << h_TimeResEta_BTL[ieta]->GetName() << std::endl;
         continue;
       }
 
-      g_TimeResEta_ETL[iside]->SetBinContent(ieta + 1, fit_res->GetParams()[2]);
-      g_TimeResEta_ETL[iside]->SetBinError(ieta + 1, fit_res->GetErrors()[2]);
+      g_TimeResEta_BTL->SetBinContent(ieta + 1, fit_res->GetParams()[2]);
+      g_TimeResEta_BTL->SetBinError(ieta + 1, fit_res->GetErrors()[2]);
 
     }  // ieta loop
 
-  }  // iside loop
+    // ---------------------------------------------------------------------------
+    // BTL time resolution vs |eta| in bind of E
 
-  // =============================================================================
-  // Draw the histograms
+    for (Int_t ieta = 0; ieta < nBinsEta_BTL; ++ieta) {
+      for (Int_t iq = 0; iq < nBinsEtaQ_BTL; ++iq) {
+        TString hname = Form("DQMData/Run 1/MTD/Run summary/BTL/LocalReco/TimeResEtavsQ_%d_%d", ieta, iq);
+        h_TimeResEtaQ_BTL[ieta][iq] = (TH1F*)input_file->Get(hname);
 
-  // --- BTL
+        if (h_TimeResEtaQ_BTL[ieta][iq]->GetEntries() < minBinContent)
+          continue;
 
-  c[0] = new TCanvas("c_0", "BTL time resolution vs Q");
-  c[0]->SetGridy(kTRUE);
-  g_TimeResQ_BTL->SetTitle("BTL UncalibratedRecHits");
-  g_TimeResQ_BTL->SetMarkerStyle(20);
-  g_TimeResQ_BTL->SetMarkerColor(4);
-  g_TimeResQ_BTL->SetXTitle("hit amplitude [pC]");
-  g_TimeResQ_BTL->SetYTitle("#sigma_{T} [ns]");
-  g_TimeResQ_BTL->GetYaxis()->SetRangeUser(0., 0.075);
-  g_TimeResQ_BTL->Draw("EP");
+        Float_t low_limit = h_TimeResEtaQ_BTL[ieta][iq]->GetMean() - 2. * h_TimeResEtaQ_BTL[ieta][iq]->GetRMS();
+        Float_t up_limit = h_TimeResEtaQ_BTL[ieta][iq]->GetMean() + 3 * h_TimeResEtaQ_BTL[ieta][iq]->GetRMS();
 
-  c[1] = new TCanvas("c_1", "BTL time resolution vs Q");
-  c[1]->SetGridy(kTRUE);
-  g_TimeResQEta_BTL[0]->SetTitle("BTL UncalibratedRecHits");
-  g_TimeResQEta_BTL[0]->SetXTitle("hit amplitude [pC]");
-  g_TimeResQEta_BTL[0]->SetYTitle("#sigma_{T} [ns]");
-  g_TimeResQEta_BTL[0]->GetYaxis()->SetRangeUser(0., 0.075);
-  g_TimeResQEta_BTL[0]->SetMarkerStyle(20);
-  g_TimeResQEta_BTL[0]->SetMarkerColor(1);
-  g_TimeResQEta_BTL[0]->Draw("EP");
-  g_TimeResQEta_BTL[1]->SetMarkerStyle(20);
-  g_TimeResQEta_BTL[1]->SetMarkerColor(4);
-  g_TimeResQEta_BTL[1]->Draw("EPSAME");
-  g_TimeResQEta_BTL[2]->SetMarkerStyle(20);
-  g_TimeResQEta_BTL[2]->SetMarkerColor(2);
-  g_TimeResQEta_BTL[2]->Draw("EPSAME");
+        TFitResultPtr fit_res = h_TimeResEtaQ_BTL[ieta][iq]->Fit("gaus", "SERQ0", "", low_limit, up_limit);
 
-  TLegend* legend_1 = new TLegend(0.510, 0.634, 0.862, 0.847);
-  legend_1->SetBorderSize(0.);
-  legend_1->SetFillStyle(0);
-  for (Int_t ih = 0; ih < nBinsQEta_BTL; ++ih)
-    legend_1->AddEntry(
-        g_TimeResQEta_BTL[ih], Form("%4.2f #leq |#eta_{hit}| < %4.2f", binsQEta_BTL[ih], binsQEta_BTL[ih + 1]), "LP");
-  legend_1->Draw();
+        if (fit_res->Status() != 0) {
+          std::cout << " *** ERROR: fit failed for the histogram" << h_TimeResEtaQ_BTL[ieta][iq]->GetName()
+                    << std::endl;
+          continue;
+        }
 
-  c[2] = new TCanvas("c_2", "BTL time resolution vs eta");
-  c[2]->SetGridy(kTRUE);
-  g_TimeResEta_BTL->SetTitle("BTL UncalibratedRecHits");
-  g_TimeResEta_BTL->SetMarkerStyle(20);
-  g_TimeResEta_BTL->SetMarkerColor(4);
-  g_TimeResEta_BTL->SetXTitle("|#eta_{hit}|");
-  g_TimeResEta_BTL->SetYTitle("#sigma_{T} [ns]");
-  g_TimeResEta_BTL->GetYaxis()->SetRangeUser(0., 0.075);
-  g_TimeResEta_BTL->Draw("EP");
+        g_TimeResEtaQ_BTL[iq]->SetBinContent(ieta + 1, fit_res->GetParams()[2]);
+        g_TimeResEtaQ_BTL[iq]->SetBinError(ieta + 1, fit_res->GetErrors()[2]);
 
-  c[3] = new TCanvas("c_3", "BTL time resolution vs eta");
-  c[3]->SetGridy(kTRUE);
-  g_TimeResEtaQ_BTL[1]->SetTitle("BTL UncalibratedRecHits");
-  g_TimeResEtaQ_BTL[1]->SetXTitle("|#eta_{hit}|");
-  g_TimeResEtaQ_BTL[1]->SetYTitle("#sigma_{T} [ns]");
-  g_TimeResEtaQ_BTL[1]->GetYaxis()->SetRangeUser(0., 0.075);
-  g_TimeResEtaQ_BTL[1]->SetMarkerStyle(20);
-  g_TimeResEtaQ_BTL[1]->SetMarkerColor(1);
-  g_TimeResEtaQ_BTL[1]->Draw("EP");
+      }  // iq loop
 
-  TLegend* legend_3 = new TLegend(0.649, 0.124, 0.862, 0.328);
-  legend_3->SetBorderSize(0.);
-  legend_3->SetFillStyle(0);
-  for (Int_t ih = 1; ih < nBinsEtaQ_BTL; ++ih) {
-    if (ih > 1) {
-      g_TimeResEtaQ_BTL[ih]->SetMarkerStyle(20);
-      g_TimeResEtaQ_BTL[ih]->SetMarkerColor(ih);
-      g_TimeResEtaQ_BTL[ih]->Draw("EPSAME");
+    }  // ieta loop
+
+    // ---------------------------------------------------------------------------
+    // Draw the BTL histograms
+
+    c[0] = new TCanvas("c_0", "BTL time resolution vs E");
+    c[0]->SetGridy(kTRUE);
+    g_TimeResQ_BTL->SetTitle("BTL UncalibratedRecHits");
+    g_TimeResQ_BTL->SetMarkerStyle(20);
+    g_TimeResQ_BTL->SetMarkerColor(4);
+    g_TimeResQ_BTL->SetXTitle("hit amplitude [MeV]");
+    g_TimeResQ_BTL->SetYTitle("#sigma_{T} [ns]");
+    g_TimeResQ_BTL->GetYaxis()->SetRangeUser(0., 0.075);
+    g_TimeResQ_BTL->Draw("EP");
+
+    c[1] = new TCanvas("c_1", "BTL time resolution vs E");
+    c[1]->SetGridy(kTRUE);
+    g_TimeResQEta_BTL[0]->SetTitle("BTL UncalibratedRecHits");
+    g_TimeResQEta_BTL[0]->SetXTitle("hit amplitude [MeV]");
+    g_TimeResQEta_BTL[0]->SetYTitle("#sigma_{T} [ns]");
+    g_TimeResQEta_BTL[0]->GetYaxis()->SetRangeUser(0., 0.075);
+    g_TimeResQEta_BTL[0]->SetMarkerStyle(20);
+    g_TimeResQEta_BTL[0]->SetMarkerColor(1);
+    g_TimeResQEta_BTL[0]->Draw("EP");
+    g_TimeResQEta_BTL[1]->SetMarkerStyle(20);
+    g_TimeResQEta_BTL[1]->SetMarkerColor(4);
+    g_TimeResQEta_BTL[1]->Draw("EPSAME");
+    g_TimeResQEta_BTL[2]->SetMarkerStyle(20);
+    g_TimeResQEta_BTL[2]->SetMarkerColor(2);
+    g_TimeResQEta_BTL[2]->Draw("EPSAME");
+
+    legend[1] = new TLegend(0.510, 0.634, 0.862, 0.847);
+    legend[1]->SetBorderSize(0.);
+    legend[1]->SetFillStyle(0);
+    for (Int_t ih = 0; ih < nBinsQEta_BTL; ++ih)
+      legend[1]->AddEntry(
+          g_TimeResQEta_BTL[ih], Form("%4.2f #leq |#eta_{hit}| < %4.2f", binsQEta_BTL[ih], binsQEta_BTL[ih + 1]), "LP");
+    legend[1]->Draw();
+
+    c[2] = new TCanvas("c_2", "BTL time resolution vs eta");
+    c[2]->SetGridy(kTRUE);
+    g_TimeResEta_BTL->SetTitle("BTL UncalibratedRecHits");
+    g_TimeResEta_BTL->SetMarkerStyle(20);
+    g_TimeResEta_BTL->SetMarkerColor(4);
+    g_TimeResEta_BTL->SetXTitle("|#eta_{hit}|");
+    g_TimeResEta_BTL->SetYTitle("#sigma_{T} [ns]");
+    g_TimeResEta_BTL->GetYaxis()->SetRangeUser(0., 0.075);
+    g_TimeResEta_BTL->Draw("EP");
+
+    c[3] = new TCanvas("c_3", "BTL time resolution vs eta");
+    c[3]->SetGridy(kTRUE);
+    g_TimeResEtaQ_BTL[1]->SetTitle("BTL UncalibratedRecHits");
+    g_TimeResEtaQ_BTL[1]->SetXTitle("|#eta_{hit}|");
+    g_TimeResEtaQ_BTL[1]->SetYTitle("#sigma_{T} [ns]");
+    g_TimeResEtaQ_BTL[1]->GetYaxis()->SetRangeUser(0., 0.075);
+    g_TimeResEtaQ_BTL[1]->SetMarkerStyle(20);
+    g_TimeResEtaQ_BTL[1]->SetMarkerColor(1);
+    g_TimeResEtaQ_BTL[1]->Draw("EP");
+
+    legend[3] = new TLegend(0.649, 0.124, 0.862, 0.328);
+    legend[3]->SetBorderSize(0.);
+    legend[3]->SetFillStyle(0);
+    for (Int_t ih = 1; ih < nBinsEtaQ_BTL; ++ih) {
+      if (ih > 1) {
+        g_TimeResEtaQ_BTL[ih]->SetMarkerStyle(20);
+        g_TimeResEtaQ_BTL[ih]->SetMarkerColor(ih);
+        g_TimeResEtaQ_BTL[ih]->Draw("EPSAME");
+      }
+
+      legend[3]->AddEntry(
+          g_TimeResEtaQ_BTL[ih], Form("%4.0f #leq E_{hit} < %4.0f MeV", binsEtaQ_BTL[ih], binsEtaQ_BTL[ih + 1]), "LP");
     }
 
-    legend_3->AddEntry(
-        g_TimeResEtaQ_BTL[ih], Form("%4.0f #leq Q_{hit} < %4.0f pC", binsEtaQ_BTL[ih], binsEtaQ_BTL[ih + 1]), "LP");
-  }
+    legend[3]->Draw();
 
-  legend_3->Draw();
+  }  // if subDet
 
-  // --- ETL
+  /////////////////////////////////////////////////////////////////////////////////
+  // ETL
+  /////////////////////////////////////////////////////////////////////////////////
 
-  c[4] = new TCanvas("c_4", "ETL time resolution vs amplitude");
-  c[4]->SetGridy(kTRUE);
-  g_TimeResQ_ETL[0]->SetTitle("ETL UncalibratedRecHits");
-  g_TimeResQ_ETL[0]->SetXTitle("hit amplitude [MIP]");
-  g_TimeResQ_ETL[0]->SetYTitle("#sigma_{T} [ns]");
-  g_TimeResQ_ETL[0]->GetYaxis()->SetRangeUser(0., 0.075);
-  g_TimeResQ_ETL[0]->SetMarkerStyle(20);
-  g_TimeResQ_ETL[0]->SetMarkerColor(4);
-  g_TimeResQ_ETL[0]->Draw("EP");
-  g_TimeResQ_ETL[1]->SetMarkerStyle(20);
-  g_TimeResQ_ETL[1]->SetMarkerColor(2);
-  g_TimeResQ_ETL[1]->Draw("EPSAME");
+  if (subDet == 0 || subDet == 2) {
+    // ---------------------------------------------------------------------------
+    // ETL time resolution vs amplitude and |eta|
 
-  TLegend* legend_4 = new TLegend(0.673, 0.655, 0.872, 0.819);
-  legend_4->SetBorderSize(0.);
-  legend_4->SetFillStyle(0);
-  legend_4->AddEntry(g_TimeResQ_ETL[0], "ETL-", "LP");
-  legend_4->AddEntry(g_TimeResQ_ETL[1], "ETL+", "LP");
-  legend_4->DrawClone();
+    for (Int_t iside = 0; iside < 2; ++iside) {
+      for (Int_t iq = 0; iq < nBinsQ_ETL; ++iq) {
+        TString hname = Form("DQMData/Run 1/MTD/Run summary/ETL/LocalReco/TimeResTot_%d_%d", iside, iq);
+        h_TimeResQ_ETL[iside][iq] = (TH1F*)input_file->Get(hname);
 
-  c[5] = new TCanvas("c_5", "ETL time resolution vs |eta|");
-  c[5]->SetGridy(kTRUE);
-  g_TimeResEta_ETL[0]->SetTitle("ETL UncalibratedRecHits");
-  g_TimeResEta_ETL[0]->SetXTitle("|#eta_{hit}|");
-  g_TimeResEta_ETL[0]->SetYTitle("#sigma_{T} [ns]");
-  g_TimeResEta_ETL[0]->GetYaxis()->SetRangeUser(0., 0.075);
-  g_TimeResEta_ETL[0]->SetMarkerStyle(20);
-  g_TimeResEta_ETL[0]->SetMarkerColor(4);
-  g_TimeResEta_ETL[0]->Draw("EP");
-  g_TimeResEta_ETL[1]->SetMarkerStyle(20);
-  g_TimeResEta_ETL[1]->SetMarkerColor(2);
-  g_TimeResEta_ETL[1]->Draw("EPSAME");
+        if (h_TimeResQ_ETL[iside][iq]->GetEntries() < minBinContent)
+          continue;
 
-  legend_4->DrawClone();
+        Float_t low_limit = h_TimeResQ_ETL[iside][iq]->GetMean() - 2. * h_TimeResQ_ETL[iside][iq]->GetRMS();
+        Float_t up_limit = h_TimeResQ_ETL[iside][iq]->GetMean() + 3 * h_TimeResQ_ETL[iside][iq]->GetRMS();
+
+        TFitResultPtr fit_res = h_TimeResQ_ETL[iside][iq]->Fit("gaus", "SERQ0", "", low_limit, up_limit);
+
+        if (fit_res->Status() != 0) {
+          std::cout << " *** ERROR: fit failed for the histogram" << h_TimeResQ_ETL[iside][iq]->GetName() << std::endl;
+          continue;
+        }
+
+        g_TimeResQ_ETL[iside]->SetBinContent(iq + 1, fit_res->GetParams()[2]);
+        g_TimeResQ_ETL[iside]->SetBinError(iq + 1, fit_res->GetErrors()[2]);
+
+      }  // iq loop
+
+      for (Int_t ieta = 0; ieta < nBinsEta_ETL; ++ieta) {
+        TString hname = Form("DQMData/Run 1/MTD/Run summary/ETL/LocalReco/TimeResEta_%d_%d", iside, ieta);
+        h_TimeResEta_ETL[iside][ieta] = (TH1F*)input_file->Get(hname);
+
+        if (h_TimeResEta_ETL[iside][ieta]->GetEntries() < minBinContent)
+          continue;
+
+        Float_t low_limit = h_TimeResEta_ETL[iside][ieta]->GetMean() - 2. * h_TimeResEta_ETL[iside][ieta]->GetRMS();
+        Float_t up_limit = h_TimeResEta_ETL[iside][ieta]->GetMean() + 3 * h_TimeResEta_ETL[iside][ieta]->GetRMS();
+
+        TFitResultPtr fit_res = h_TimeResEta_ETL[iside][ieta]->Fit("gaus", "SERQ0", "", low_limit, up_limit);
+
+        if (fit_res->Status() != 0) {
+          std::cout << " *** ERROR: fit failed for the histogram" << h_TimeResEta_ETL[iside][ieta]->GetName()
+                    << std::endl;
+          continue;
+        }
+
+        g_TimeResEta_ETL[iside]->SetBinContent(ieta + 1, fit_res->GetParams()[2]);
+        g_TimeResEta_ETL[iside]->SetBinError(ieta + 1, fit_res->GetErrors()[2]);
+
+      }  // ieta loop
+
+    }  // iside loop
+
+    // ---------------------------------------------------------------------------
+    // Draw the ETL histograms
+
+    c[4] = new TCanvas("c_4", "ETL time resolution vs amplitude");
+    c[4]->SetGridy(kTRUE);
+    g_TimeResQ_ETL[0]->SetTitle("ETL UncalibratedRecHits");
+    g_TimeResQ_ETL[0]->SetXTitle("hit amplitude [MIP]");
+    g_TimeResQ_ETL[0]->SetYTitle("#sigma_{T} [ns]");
+    g_TimeResQ_ETL[0]->GetYaxis()->SetRangeUser(0., 0.075);
+    g_TimeResQ_ETL[0]->SetMarkerStyle(20);
+    g_TimeResQ_ETL[0]->SetMarkerColor(4);
+    g_TimeResQ_ETL[0]->Draw("EP");
+    g_TimeResQ_ETL[1]->SetMarkerStyle(20);
+    g_TimeResQ_ETL[1]->SetMarkerColor(2);
+    g_TimeResQ_ETL[1]->Draw("EPSAME");
+
+    legend[4] = new TLegend(0.673, 0.655, 0.872, 0.819);
+    legend[4]->SetBorderSize(0.);
+    legend[4]->SetFillStyle(0);
+    legend[4]->AddEntry(g_TimeResQ_ETL[0], "ETL-", "LP");
+    legend[4]->AddEntry(g_TimeResQ_ETL[1], "ETL+", "LP");
+    legend[4]->DrawClone();
+
+    c[5] = new TCanvas("c_5", "ETL time resolution vs |eta|");
+    c[5]->SetGridy(kTRUE);
+    g_TimeResEta_ETL[0]->SetTitle("ETL UncalibratedRecHits");
+    g_TimeResEta_ETL[0]->SetXTitle("|#eta_{hit}|");
+    g_TimeResEta_ETL[0]->SetYTitle("#sigma_{T} [ns]");
+    g_TimeResEta_ETL[0]->GetYaxis()->SetRangeUser(0., 0.075);
+    g_TimeResEta_ETL[0]->SetMarkerStyle(20);
+    g_TimeResEta_ETL[0]->SetMarkerColor(4);
+    g_TimeResEta_ETL[0]->Draw("EP");
+    g_TimeResEta_ETL[1]->SetMarkerStyle(20);
+    g_TimeResEta_ETL[1]->SetMarkerColor(2);
+    g_TimeResEta_ETL[1]->Draw("EPSAME");
+
+    legend[4]->DrawClone();
+
+  }  // if subDet
 }


### PR DESCRIPTION
#### PR description:

This PR introduces an updated digitization model for the BTL detector, derived from parameterizations of the TOFHiR response based on testbeam and laboratory measurements. To ensure compatibility with this new model, some modifications had to be made also to the reconstruction code. Specifically, the time-walk correction was updated, and the parameterization of the RecHit error was revised.

The new BTL digitization model is documented in the CMS note [CMS DN-2025/013](cms.cern.ch/iCMS/user/noteinfo?cmsnoteid=CMS%20DN-2025/013) and was presented in the MTD DPG Meetings on [24/01/2025](https://indico.cern.ch/event/1498383/contributions/6311175/attachments/3002509/5312752/casarsa_BTLdigitization.pdf) and [10/10/2025](https://indico.cern.ch/event/1597247/contributions/6731800/attachments/3152519/5598505/casarsa_BTLdigitization_1.pdf).

#### PR validation:

The updated code was validated using the runTheMatrix workflows 34434.0 and 34634.0, compiled against both CMSSW_15_1_0_pre5 and CMSSW_16_0_0_pre1. WF 34634.99 was tested successfully in CMSSW_15_1_0_pre5.

The performance of both the new and existing code was also evaluated:

### new code

**WF 34434.0**

step2:

> TimeReport> Time report complete in 359.063 seconds
>  Time Summary: 
>  - Min event:   5.49725
>  - Max event:   21.327
>  - Avg event:   7.72135
>  - Total loop:  144.639
>  - Total init:  214.423
>  - Total job:   359.063
>  - Total EventSetup: 39.103
>  - Total non-module: 26.6364
>  Event Throughput: 0.0691378 ev/s
>  CPU Summary: 
>  - Total loop:     124.473
>  - Total init:     62.1638
>  - Total extra:    0
>  - Total children: 0.309533
>  - Total job:      186.638
>  Processing Summary: 
>  - Number of Events:  10
>  - Number of Global Begin Lumi Calls:  1
>  - Number of Global Begin Run Calls: 1
> 
> MemoryReport> EndJob: virtual size 5764.84 Mbytes, RSS 3401.21 Mbytes, PSS 3401.59 MBytes, Private 3401.57
>  AnonHugePages 0 Mbytes
>  mmapped memory pages 4337.12 Mbytes (VSize), 2925.13 MBytes (RSS)
>  mmapped file pages 1427.07 Mbytes (VSize), 475.816 MBytes (RSS)
>   of which .so's 1107.23 Mbytes (VSize), 318.465 MBytes (RSS)
>   of which PCM's 319.359 Mbytes (VSize), 156.902 MBytes (RSS)
>   of which other 0.472656 Mbytes (VSize), 0.449219 MBytes (RSS)
>  Jemalloc allocated 2761.92 MBytes, active 2801.77 MBytes
>   resident 3198.94 Mbytes, mapped 3221.84 Mbytes
>   metadata 43.1884 Mbytes
> MemoryReport> Peak virtual size 5764.84 Mbytes (RSS 3534.42)
>  Jemalloc allocated 3282.43 active 3333.12 resident 3397.15 mapped 3420.05 metadata 43.1884
>  Key events increasing vsize: 
> [0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
> [1] run: 1 lumi: 1 event: 1  vsize = 5302.83 deltaVsize = 0 rss = 3467.82 delta = 0 allocated = 3263.97 active = 3313.7
> [2] run: 1 lumi: 1 event: 2  vsize = 5764.83 deltaVsize = 462 rss = 3521.99 delta = 54.1719 allocated = 3280.23 active = 3330.71
> [7] run: 1 lumi: 1 event: 7  vsize = 5764.84 deltaVsize = 0.0117188 rss = 3534.42 delta = 12.4336 allocated = 3282.43 active = 3333.12
> [0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
> [9] run: 1 lumi: 1 event: 9  vsize = 5764.84 deltaVsize = 0 rss = 3518.76 delta = -15.6641 allocated = 3252.22 active = 3304.46
> [8] run: 1 lumi: 1 event: 8  vsize = 5764.84 deltaVsize = 0 rss = 3539.84 delta = 5.42188 allocated = 3275.19 active = 3326.84
> [7] run: 1 lumi: 1 event: 7  vsize = 5764.84 deltaVsize = 0.0117188 rss = 3534.42 delta = 12.4336 allocated = 3282.43 active = 3333.12
> MemoryReport> Peak rss size 3539.84 Mbytes (VSIZE 5764.84)
>  Jemalloc allocated 3275.19 active 3326.84 resident 3401.95 mapped 3424.85 metadata 43.1884
>  Key events increasing rss:
> [5] run: 1 lumi: 1 event: 5  vsize = 5764.83 deltaVsize = 0 rss = 3524.86 delta = 2.87109 allocated = 3271.8 active = 3322.55
> [7] run: 1 lumi: 1 event: 7  vsize = 5764.84 deltaVsize = 0.0117188 rss = 3534.42 delta = 9.5625 allocated = 3282.43 active = 3333.12
> [8] run: 1 lumi: 1 event: 8  vsize = 5764.84 deltaVsize = 0 rss = 3539.84 delta = 5.42188 allocated = 3275.19 active = 3326.84
> [8] run: 1 lumi: 1 event: 8  vsize = 5764.84 deltaVsize = 0 rss = 3539.84 delta = 5.42188 allocated = 3275.19 active = 3326.84
> [7] run: 1 lumi: 1 event: 7  vsize = 5764.84 deltaVsize = 0.0117188 rss = 3534.42 delta = 9.5625 allocated = 3282.43 active = 3333.12
> [2] run: 1 lumi: 1 event: 2  vsize = 5764.83 deltaVsize = 462 rss = 3521.99 delta = 54.1719 allocated = 3280.23 active = 3330.71

step3:
 
> TimeReport> Time report complete in 380.431 seconds
>  Time Summary: 
>  - Min event:   2.44118
>  - Max event:   15.0109
>  - Avg event:   5.38594
>  - Total loop:  105.008
>  - Total init:  275.421
>  - Total job:   380.431
>  - Total EventSetup: 34.9639
>  - Total non-module: 2.11923e+08
>  Event Throughput: 0.0952306 ev/s
>  CPU Summary: 
>  - Total loop:     88.2355
>  - Total init:     195.271
>  - Total extra:    0
>  - Total children: 0.289704
>  - Total job:      283.508
>  Processing Summary: 
>  - Number of Events:  10
>  - Number of Global Begin Lumi Calls:  1
>  - Number of Global Begin Run Calls: 1
> 
> MemoryReport> EndJob: virtual size 7812.23 Mbytes, RSS 5042.26 Mbytes, PSS 5042.65 MBytes, Private 5042.63
>  AnonHugePages 0 Mbytes
>  mmapped memory pages 6300.87 Mbytes (VSize), 4516.33 MBytes (RSS)
>  mmapped file pages 1510.68 Mbytes (VSize), 525.664 MBytes (RSS)
>   of which .so's 1190.84 Mbytes (VSize), 358.84 MBytes (RSS)
>   of which PCM's 319.359 Mbytes (VSize), 166.375 MBytes (RSS)
>   of which other 0.472656 Mbytes (VSize), 0.449219 MBytes (RSS)
>  Jemalloc allocated 4377.01 MBytes, active 4477.87 MBytes
>   resident 4937.07 Mbytes, mapped 4947.36 Mbytes
>   metadata 55.8063 Mbytes
> MemoryReport> Peak virtual size 7812.2 Mbytes (RSS 5180.32)
>  Jemalloc allocated 4918.63 active 5033.42 resident 5116.26 mapped 5127.05 metadata 55.3062
>  Key events increasing vsize: 
> [1] run: 1 lumi: 1 event: 1  vsize = 7811.93 deltaVsize = 0 rss = 5143.53 delta = 0 allocated = 4909.3 active = 5022.68
> [2] run: 1 lumi: 1 event: 2  vsize = 7811.94 deltaVsize = 0.0117188 rss = 5217.19 delta = 73.6562 allocated = 4975.5 active = 5089.69
> [4] run: 1 lumi: 1 event: 4  vsize = 7812.2 deltaVsize = 0.257812 rss = 5180.32 delta = -36.8672 allocated = 4918.63 active = 5033.42
> [0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
> [0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
> [6] run: 1 lumi: 1 event: 6  vsize = 7812.2 deltaVsize = 0 rss = 5192.02 delta = 11.7031 allocated = 4921.58 active = 5037.11
> [5] run: 1 lumi: 1 event: 5  vsize = 7812.2 deltaVsize = 0 rss = 5198.68 delta = 18.3555 allocated = 4960.92 active = 5075.41
> [4] run: 1 lumi: 1 event: 4  vsize = 7812.2 deltaVsize = 0.257812 rss = 5180.32 delta = -36.8672 allocated = 4918.63 active = 5033.42
> MemoryReport> Peak rss size 5228.22 Mbytes (VSIZE 7812.2)
>  Jemalloc allocated 4987.75 active 5101.77 resident 5167.43 mapped 5178.22 metadata 55.3062
>  Key events increasing rss:
> [2] run: 1 lumi: 1 event: 2  vsize = 7811.94 deltaVsize = 0.0117188 rss = 5217.19 delta = 73.6562 allocated = 4975.5 active = 5089.69
> [8] run: 1 lumi: 1 event: 8  vsize = 7812.2 deltaVsize = 0 rss = 5220.33 delta = -7.89062 allocated = 4967.19 active = 5082
> [7] run: 1 lumi: 1 event: 7  vsize = 7812.2 deltaVsize = 0 rss = 5228.22 delta = 11.0312 allocated = 4987.75 active = 5101.77
> [1] run: 1 lumi: 1 event: 1  vsize = 7811.93 deltaVsize = 0 rss = 5143.53 delta = 0 allocated = 4909.3 active = 5022.68
> [7] run: 1 lumi: 1 event: 7  vsize = 7812.2 deltaVsize = 0 rss = 5228.22 delta = 11.0312 allocated = 4987.75 active = 5101.77
> [2] run: 1 lumi: 1 event: 2  vsize = 7811.94 deltaVsize = 0.0117188 rss = 5217.19 delta = 73.6562 allocated = 4975.5 active = 5089.69
> 

**WF 34634.0**

step2:

> TimeReport> Time report complete in 952.013 seconds
>  Time Summary: 
>  - Min event:   74.4032
>  - Max event:   91.267
>  - Avg event:   81.5496
>  - Total loop:  891.496
>  - Total init:  60.5148
>  - Total job:   952.013
>  - Total EventSetup: 37.7103
>  - Total non-module: 35.6813
>  Event Throughput: 0.0112171 ev/s
>  CPU Summary: 
>  - Total loop:     857.874
>  - Total init:     51.0842
>  - Total extra:    0
>  - Total children: 0.251329
>  - Total job:      908.96
>  Processing Summary: 
>  - Number of Events:  10
>  - Number of Global Begin Lumi Calls:  1
>  - Number of Global Begin Run Calls: 1
> 
> MemoryReport> EndJob: virtual size 10024.1 Mbytes, RSS 4484.42 Mbytes, PSS 4466.07 MBytes, Private 4447.29
>  AnonHugePages 0 Mbytes
>  mmapped memory pages 8596.36 Mbytes (VSize), 4391.38 MBytes (RSS)
>  mmapped file pages 1427.07 Mbytes (VSize), 92.8398 MBytes (RSS)
>   of which .so's 1107.23 Mbytes (VSize), 91.1523 MBytes (RSS)
>   of which PCM's 319.359 Mbytes (VSize), 1.64844 MBytes (RSS)
>   of which other 0.472656 Mbytes (VSize), 0.0390625 MBytes (RSS)
>  Jemalloc allocated 3239.22 MBytes, active 3346.47 MBytes
>   resident 4682.01 Mbytes, mapped 4705.85 Mbytes
>   metadata 78.2559 Mbytes
> MemoryReport> Peak virtual size 10024.1 Mbytes (RSS 6375.16)
>  Jemalloc allocated 6622.54 active 6780.8 resident 6902.95 mapped 6929.3 metadata 75.7393
>  Key events increasing vsize: 
> [0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
> [1] run: 1 lumi: 1 event: 1  vsize = 9236.09 deltaVsize = 0 rss = 6181.71 delta = 0 allocated = 6631.48 active = 6706.14
> [2] run: 1 lumi: 1 event: 2  vsize = 10024.1 deltaVsize = 788 rss = 6375.16 delta = 193.441 allocated = 6622.54 active = 6780.8
> [0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
> [0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
> [4] run: 1 lumi: 1 event: 4  vsize = 10024.1 deltaVsize = 0 rss = 6130.57 delta = -244.582 allocated = 6510.48 active = 6672.88
> [3] run: 1 lumi: 1 event: 3  vsize = 10024.1 deltaVsize = 0 rss = 6167.18 delta = -207.98 allocated = 6400.37 active = 6559.91
> [2] run: 1 lumi: 1 event: 2  vsize = 10024.1 deltaVsize = 788 rss = 6375.16 delta = 193.441 allocated = 6622.54 active = 6780.8
> MemoryReport> Peak rss size 6375.16 Mbytes (VSIZE 10024.1)
>  Jemalloc allocated 6622.54 active 6780.8 resident 6902.95 mapped 6929.3 metadata 75.7393
>  Key events increasing rss:
> [9] run: 1 lumi: 1 event: 9  vsize = 10024.1 deltaVsize = 0 rss = 6354.02 delta = -21.1406 allocated = 6706.86 active = 6874.25
> [8] run: 1 lumi: 1 event: 8  vsize = 10024.1 deltaVsize = 0 rss = 6369.13 delta = -6.02344 allocated = 6710.92 active = 6877.94
> [2] run: 1 lumi: 1 event: 2  vsize = 10024.1 deltaVsize = 788 rss = 6375.16 delta = 193.441 allocated = 6622.54 active = 6780.8
> [0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
> [1] run: 1 lumi: 1 event: 1  vsize = 9236.09 deltaVsize = 0 rss = 6181.71 delta = 0 allocated = 6631.48 active = 6706.14
> [2] run: 1 lumi: 1 event: 2  vsize = 10024.1 deltaVsize = 788 rss = 6375.16 delta = 193.441 allocated = 6622.54 active = 6780.8

step3:

> TimeReport> Time report complete in 1646.23 seconds
>  Time Summary: 
>  - Min event:   103.907
>  - Max event:   190.794
>  - Avg event:   140.346
>  - Total loop:  1473.77
>  - Total init:  172.455
>  - Total job:   1646.23
>  - Total EventSetup: 32.0388
>  - Total non-module: 4.21399e+09
>  Event Throughput: 0.00678531 ev/s
>  CPU Summary: 
>  - Total loop:     1409.27
>  - Total init:     163.929
>  - Total extra:    0
>  - Total children: 0.14007
>  - Total job:      1573.2
>  Processing Summary: 
>  - Number of Events:  10
>  - Number of Global Begin Lumi Calls:  1
>  - Number of Global Begin Run Calls: 1
> 
> MemoryReport> EndJob: virtual size 13358.8 Mbytes, RSS 5578.61 Mbytes, PSS 5578.51 MBytes, Private 5578.26
>  AnonHugePages 2 Mbytes
>  mmapped memory pages 11843.4 Mbytes (VSize), 5006.38 MBytes (RSS)
>  mmapped file pages 1510.68 Mbytes (VSize), 569 MBytes (RSS)
>   of which .so's 1190.84 Mbytes (VSize), 402.16 MBytes (RSS)
>   of which PCM's 319.359 Mbytes (VSize), 166.375 MBytes (RSS)
>   of which other 0.472656 Mbytes (VSize), 0.464844 MBytes (RSS)
>  Jemalloc allocated 4727.41 MBytes, active 4858.62 MBytes
>   resident 5522.86 Mbytes, mapped 5555.25 Mbytes
>   metadata 93.6972 Mbytes
> MemoryReport> Peak virtual size 13358.8 Mbytes (RSS 9867.04)
>  Jemalloc allocated 9889.22 active 10051.9 resident 10156.9 mapped 10189.3 metadata 93.6972
>  Key events increasing vsize: 
> [0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
> [1] run: 1 lumi: 1 event: 1  vsize = 12430.4 deltaVsize = 0 rss = 9470.92 delta = 0 allocated = 9589.64 active = 9748.64
> [2] run: 1 lumi: 1 event: 2  vsize = 13334.4 deltaVsize = 904 rss = 9646.25 delta = 175.328 allocated = 9737.63 active = 9893.46
> [8] run: 1 lumi: 1 event: 8  vsize = 13358.8 deltaVsize = 24.0508 rss = 9914.41 delta = 268.156 allocated = 9921.35 active = 10083.9
> [4] run: 1 lumi: 1 event: 4  vsize = 13334.7 deltaVsize = 0.253906 rss = 9604.01 delta = -42.2383 allocated = 9660.05 active = 9821.44
> [8] run: 1 lumi: 1 event: 8  vsize = 13358.8 deltaVsize = 24.0508 rss = 9914.41 delta = 546.02 allocated = 9921.35 active = 10083.9
> [10] run: 1 lumi: 1 event: 10  vsize = 13358.8 deltaVsize = 0 rss = 9642.3 delta = -224.734 allocated = 9649.61 active = 9808.99
> [9] run: 1 lumi: 1 event: 9  vsize = 13358.8 deltaVsize = 0.0078125 rss = 9867.04 delta = -47.3672 allocated = 9889.22 active = 10051.9
> MemoryReport> Peak rss size 9914.41 Mbytes (VSIZE 13358.8)
>  Jemalloc allocated 9921.35 active 10083.9 resident 10189.2 mapped 10222.1 metadata 93.1971
>  Key events increasing rss:
> [5] run: 1 lumi: 1 event: 5  vsize = 13334.7 deltaVsize = 0 rss = 9705.54 delta = 59.2852 allocated = 9731.42 active = 9892.84
> [9] run: 1 lumi: 1 event: 9  vsize = 13358.8 deltaVsize = 0.0078125 rss = 9867.04 delta = -47.3672 allocated = 9889.22 active = 10051.9
> [8] run: 1 lumi: 1 event: 8  vsize = 13358.8 deltaVsize = 24.0508 rss = 9914.41 delta = 208.871 allocated = 9921.35 active = 10083.9
> [5] run: 1 lumi: 1 event: 5  vsize = 13334.7 deltaVsize = 0 rss = 9705.54 delta = 59.2852 allocated = 9731.42 active = 9892.84
> [2] run: 1 lumi: 1 event: 2  vsize = 13334.4 deltaVsize = 904 rss = 9646.25 delta = 175.328 allocated = 9737.63 active = 9893.46
> [8] run: 1 lumi: 1 event: 8  vsize = 13358.8 deltaVsize = 24.0508 rss = 9914.41 delta = 208.871 allocated = 9921.35 active = 10083.9
> 

### current code

**WF 34434.0**

step2:

> TimeReport> Time report complete in 209.282 seconds
>  Time Summary: 
>  - Min event:   6.71515
>  - Max event:   16.1988
>  - Avg event:   8.19631
>  - Total loop:  146.214
>  - Total init:  63.0658
>  - Total job:   209.282
>  - Total EventSetup: 36.4081
>  - Total non-module: 28.731
>  Event Throughput: 0.0683927 ev/s
>  CPU Summary: 
>  - Total loop:     135.223
>  - Total init:     52.9835
>  - Total extra:    0
>  - Total children: 0.23298
>  - Total job:      188.208
>  Processing Summary: 
>  - Number of Events:  10
>  - Number of Global Begin Lumi Calls:  1
>  - Number of Global Begin Run Calls: 1
> 
> MemoryReport> EndJob: virtual size 5765.34 Mbytes, RSS 3387.84 Mbytes, PSS 3359.44 MBytes, Private 3330.68
>  AnonHugePages 0 Mbytes
>  mmapped memory pages 4337.62 Mbytes (VSize), 2911.83 MBytes (RSS)
>  mmapped file pages 1427.06 Mbytes (VSize), 475.742 MBytes (RSS)
>   of which .so's 1107.23 Mbytes (VSize), 318.391 MBytes (RSS)
>   of which PCM's 319.359 Mbytes (VSize), 156.902 MBytes (RSS)
>   of which other 0.472656 Mbytes (VSize), 0.449219 MBytes (RSS)
>  Jemalloc allocated 2762.42 MBytes, active 2802.26 MBytes
>   resident 3174.88 Mbytes, mapped 3196.85 Mbytes
>   metadata 44.1184 Mbytes
> MemoryReport> Peak virtual size 5765.34 Mbytes (RSS 3522.34)
>  Jemalloc allocated 3281.91 active 3332.64 resident 3386.37 mapped 3408.35 metadata 44.1184
>  Key events increasing vsize: 
> [0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
> [1] run: 1 lumi: 1 event: 1  vsize = 5303.33 deltaVsize = 0 rss = 3471.89 delta = 0 allocated = 3263.27 active = 3313.05
> [2] run: 1 lumi: 1 event: 2  vsize = 5765.33 deltaVsize = 462 rss = 3533.48 delta = 61.582 allocated = 3281.08 active = 3331.75
> [7] run: 1 lumi: 1 event: 7  vsize = 5765.34 deltaVsize = 0.0117188 rss = 3522.34 delta = -11.1367 allocated = 3281.91 active = 3332.64
> [0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
> [9] run: 1 lumi: 1 event: 9  vsize = 5765.34 deltaVsize = 0 rss = 3505.97 delta = -16.3672 allocated = 3251.77 active = 3304.11
> [8] run: 1 lumi: 1 event: 8  vsize = 5765.34 deltaVsize = 0 rss = 3546.32 delta = 23.9766 allocated = 3275.05 active = 3326.71
> [7] run: 1 lumi: 1 event: 7  vsize = 5765.34 deltaVsize = 0.0117188 rss = 3522.34 delta = -11.1367 allocated = 3281.91 active = 3332.64
> MemoryReport> Peak rss size 3546.32 Mbytes (VSIZE 5765.34)
>  Jemalloc allocated 3275.05 active 3326.71 resident 3407.64 mapped 3429.61 metadata 44.1184
>  Key events increasing rss:
> [10] run: 1 lumi: 1 event: 10  vsize = 5765.34 deltaVsize = 0 rss = 3529.32 delta = -16.9922 allocated = 3267.13 active = 3318.74
> [2] run: 1 lumi: 1 event: 2  vsize = 5765.33 deltaVsize = 462 rss = 3533.48 delta = 61.582 allocated = 3281.08 active = 3331.75
> [8] run: 1 lumi: 1 event: 8  vsize = 5765.34 deltaVsize = 0 rss = 3546.32 delta = 12.8398 allocated = 3275.05 active = 3326.71
> [1] run: 1 lumi: 1 event: 1  vsize = 5303.33 deltaVsize = 0 rss = 3471.89 delta = 0 allocated = 3263.27 active = 3313.05
> [8] run: 1 lumi: 1 event: 8  vsize = 5765.34 deltaVsize = 0 rss = 3546.32 delta = 12.8398 allocated = 3275.05 active = 3326.71
> [2] run: 1 lumi: 1 event: 2  vsize = 5765.33 deltaVsize = 462 rss = 3533.48 delta = 61.582 allocated = 3281.08 active = 3331.75

step3:

> TimeReport> Time report complete in 264.591 seconds
>  Time Summary: 
>  - Min event:   2.62059
>  - Max event:   11.6885
>  - Avg event:   5.46101
>  - Total loop:  105.659
>  - Total init:  158.931
>  - Total job:   264.591
>  - Total EventSetup: 35.4576
>  - Total non-module: 2.22483e+08
>  Event Throughput: 0.0946443 ev/s
>  CPU Summary: 
>  - Total loop:     92.57
>  - Total init:     140.514
>  - Total extra:    0
>  - Total children: 0.268215
>  - Total job:      233.084
>  Processing Summary: 
>  - Number of Events:  10
>  - Number of Global Begin Lumi Calls:  1
>  - Number of Global Begin Run Calls: 1
> 
> MemoryReport> EndJob: virtual size 7812.73 Mbytes, RSS 5038.78 Mbytes, PSS 5039.14 MBytes, Private 5039.08
>  AnonHugePages 0 Mbytes
>  mmapped memory pages 6301.37 Mbytes (VSize), 4513.23 MBytes (RSS)
>  mmapped file pages 1510.68 Mbytes (VSize), 525.301 MBytes (RSS)
>   of which .so's 1190.84 Mbytes (VSize), 358.477 MBytes (RSS)
>   of which PCM's 319.359 Mbytes (VSize), 166.375 MBytes (RSS)
>   of which other 0.472656 Mbytes (VSize), 0.449219 MBytes (RSS)
>  Jemalloc allocated 4373.04 MBytes, active 4474.26 MBytes
>   resident 4910.62 Mbytes, mapped 4921.46 Mbytes
>   metadata 55.2542 Mbytes
> MemoryReport> Peak virtual size 7812.7 Mbytes (RSS 5170.06)
>  Jemalloc allocated 4914.52 active 5029.17 resident 5099.59 mapped 5110.47 metadata 55.2129
>  Key events increasing vsize: 
> [1] run: 1 lumi: 1 event: 1  vsize = 7812.43 deltaVsize = 0 rss = 5145.29 delta = 0 allocated = 4905.87 active = 5019.11
> [2] run: 1 lumi: 1 event: 2  vsize = 7812.44 deltaVsize = 0.0117188 rss = 5216.16 delta = 70.8711 allocated = 4971.57 active = 5085.81
> [4] run: 1 lumi: 1 event: 4  vsize = 7812.7 deltaVsize = 0.257812 rss = 5170.06 delta = -46.0977 allocated = 4914.52 active = 5029.17
> [0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
> [0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
> [6] run: 1 lumi: 1 event: 6  vsize = 7812.7 deltaVsize = 0 rss = 5198.07 delta = 28.0156 allocated = 4917.08 active = 5032.37
> [5] run: 1 lumi: 1 event: 5  vsize = 7812.7 deltaVsize = 0 rss = 5200.33 delta = 30.2734 allocated = 4955.51 active = 5069.99
> [4] run: 1 lumi: 1 event: 4  vsize = 7812.7 deltaVsize = 0.257812 rss = 5170.06 delta = -46.0977 allocated = 4914.52 active = 5029.17
> MemoryReport> Peak rss size 5229.39 Mbytes (VSIZE 7812.7)
>  Jemalloc allocated 4984.43 active 5098.37 resident 5162.59 mapped 5173.43 metadata 55.254
>  Key events increasing rss:
> [2] run: 1 lumi: 1 event: 2  vsize = 7812.44 deltaVsize = 0.0117188 rss = 5216.16 delta = 70.8711 allocated = 4971.57 active = 5085.81
> [8] run: 1 lumi: 1 event: 8  vsize = 7812.7 deltaVsize = 0 rss = 5228.87 delta = -0.519531 allocated = 4965.22 active = 5079.92
> [7] run: 1 lumi: 1 event: 7  vsize = 7812.7 deltaVsize = 0 rss = 5229.39 delta = 13.2344 allocated = 4984.43 active = 5098.37
> [1] run: 1 lumi: 1 event: 1  vsize = 7812.43 deltaVsize = 0 rss = 5145.29 delta = 0 allocated = 4905.87 active = 5019.11
> [7] run: 1 lumi: 1 event: 7  vsize = 7812.7 deltaVsize = 0 rss = 5229.39 delta = 13.2344 allocated = 4984.43 active = 5098.37
> [2] run: 1 lumi: 1 event: 2  vsize = 7812.44 deltaVsize = 0.0117188 rss = 5216.16 delta = 70.8711 allocated = 4971.57 active = 5085.81

**WF 34634.0**

step2:

> TimeReport> Time report complete in 1131.58 seconds
>  Time Summary: 
>  - Min event:   87.9561
>  - Max event:   113.274
>  - Avg event:   97.929
>  - Total loop:  1068.92
>  - Total init:  62.654
>  - Total job:   1131.58
>  - Total EventSetup: 45.9732
>  - Total non-module: 42.7303
>  Event Throughput: 0.00935523 ev/s
>  CPU Summary: 
>  - Total loop:     1030.79
>  - Total init:     51.8137
>  - Total extra:    0
>  - Total children: 0.243355
>  - Total job:      1082.61
>  Processing Summary: 
>  - Number of Events:  10
>  - Number of Global Begin Lumi Calls:  1
>  - Number of Global Begin Run Calls: 1
> 
> MemoryReport> EndJob: virtual size 10025.8 Mbytes, RSS 4878.72 Mbytes, PSS 4879.06 MBytes, Private 4879
>  AnonHugePages 0 Mbytes
>  mmapped memory pages 8598.11 Mbytes (VSize), 4403.17 MBytes (RSS)
>  mmapped file pages 1427.06 Mbytes (VSize), 475.32 MBytes (RSS)
>   of which .so's 1107.23 Mbytes (VSize), 317.969 MBytes (RSS)
>   of which PCM's 319.359 Mbytes (VSize), 156.902 MBytes (RSS)
>   of which other 0.472656 Mbytes (VSize), 0.449219 MBytes (RSS)
>  Jemalloc allocated 3235.97 MBytes, active 3346.5 MBytes
>   resident 4667.55 Mbytes, mapped 4689.3 Mbytes
>   metadata 80.347 Mbytes
> MemoryReport> Peak virtual size 10025.8 Mbytes (RSS 6520.79)
>  Jemalloc allocated 6472.68 active 6637.82 resident 6757.52 mapped 6783.6 metadata 76.0108
>  Key events increasing vsize: 
> [0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
> [1] run: 1 lumi: 1 event: 1  vsize = 9257.83 deltaVsize = 0 rss = 6675.96 delta = 0 allocated = 6906.73 active = 6982.79
> [2] run: 1 lumi: 1 event: 2  vsize = 10025.8 deltaVsize = 768 rss = 6520.79 delta = -155.168 allocated = 6472.68 active = 6637.82
> [0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
> [0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
> [4] run: 1 lumi: 1 event: 4  vsize = 10025.8 deltaVsize = 0 rss = 6536.94 delta = 16.1523 allocated = 6528.42 active = 6692.44
> [3] run: 1 lumi: 1 event: 3  vsize = 10025.8 deltaVsize = 0 rss = 6462.14 delta = -58.6445 allocated = 6461.96 active = 6621.07
> [2] run: 1 lumi: 1 event: 2  vsize = 10025.8 deltaVsize = 768 rss = 6520.79 delta = -155.168 allocated = 6472.68 active = 6637.82
> MemoryReport> Peak rss size 6938.06 Mbytes (VSIZE 10025.8)
>  Jemalloc allocated 6914.64 active 7080.66 resident 7181.88 mapped 7204.12 metadata 79.8468
>  Key events increasing rss:
> [7] run: 1 lumi: 1 event: 7  vsize = 10025.8 deltaVsize = 0 rss = 6852.44 delta = 176.484 allocated = 6822.63 active = 6992.02
> [9] run: 1 lumi: 1 event: 9  vsize = 10025.8 deltaVsize = 0 rss = 6878.41 delta = -59.6445 allocated = 6840.5 active = 7009.02
> [8] run: 1 lumi: 1 event: 8  vsize = 10025.8 deltaVsize = 0 rss = 6938.06 delta = 85.6172 allocated = 6914.64 active = 7080.66
> [1] run: 1 lumi: 1 event: 1  vsize = 9257.83 deltaVsize = 0 rss = 6675.96 delta = 0 allocated = 6906.73 active = 6982.79
> [8] run: 1 lumi: 1 event: 8  vsize = 10025.8 deltaVsize = 0 rss = 6938.06 delta = 85.6172 allocated = 6914.64 active = 7080.66
> [7] run: 1 lumi: 1 event: 7  vsize = 10025.8 deltaVsize = 0 rss = 6852.44 delta = 176.484 allocated = 6822.63 active = 6992.02
> 

step3:

> TimeReport> Time report complete in 3050.05 seconds
>  Time Summary: 
>  - Min event:   125.086
>  - Max event:   201.681
>  - Avg event:   160.713
>  - Total loop:  1958.77
>  - Total init:  1091.29
>  - Total job:   3050.05
>  - Total EventSetup: 308.065
>  - Total non-module: 4.61459e+09
>  Event Throughput: 0.00510526 ev/s
>  CPU Summary: 
>  - Total loop:     1595.1
>  - Total init:     170.583
>  - Total extra:    0
>  - Total children: 0.156349
>  - Total job:      1765.69
>  Processing Summary: 
>  - Number of Events:  10
>  - Number of Global Begin Lumi Calls:  1
>  - Number of Global Begin Run Calls: 1
> 
> MemoryReport> EndJob: virtual size 13359.2 Mbytes, RSS 5200.06 Mbytes, PSS 5200.08 MBytes, Private 5199.83
>  AnonHugePages 0 Mbytes
>  mmapped memory pages 11843.4 Mbytes (VSize), 4979.23 MBytes (RSS)
>  mmapped file pages 1510.68 Mbytes (VSize), 217.16 MBytes (RSS)
>   of which .so's 1190.84 Mbytes (VSize), 182.902 MBytes (RSS)
>   of which PCM's 319.359 Mbytes (VSize), 33.9258 MBytes (RSS)
>   of which other 0.472656 Mbytes (VSize), 0.332031 MBytes (RSS)
>  Jemalloc allocated 4612.68 MBytes, active 4746.95 MBytes
>   resident 5434.71 Mbytes, mapped 5463.49 Mbytes
>   metadata 97.3148 Mbytes
> MemoryReport> Peak virtual size 13359.1 Mbytes (RSS 9756.34)
>  Jemalloc allocated 10111.8 active 10277.5 resident 10393.9 mapped 10423.4 metadata 96.5356
>  Key events increasing vsize: 
> [0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
> [1] run: 1 lumi: 1 event: 1  vsize = 13326.3 deltaVsize = 0 rss = 9388.9 delta = 0 allocated = 9794.21 active = 9955.02
> [2] run: 1 lumi: 1 event: 2  vsize = 13358.4 deltaVsize = 32.1562 rss = 9252.11 delta = -136.797 allocated = 9577.96 active = 9740.27
> [4] run: 1 lumi: 1 event: 4  vsize = 13359 deltaVsize = 0.570312 rss = 9299.01 delta = 46.9023 allocated = 9673.72 active = 9836.34
> [7] run: 1 lumi: 1 event: 7  vsize = 13359.1 deltaVsize = 0.140625 rss = 9756.34 delta = 457.336 allocated = 10111.8 active = 10277.5
> [9] run: 1 lumi: 1 event: 9  vsize = 13359.1 deltaVsize = 0 rss = 9732.85 delta = -23.4922 allocated = 10095 active = 10260.3
> [8] run: 1 lumi: 1 event: 8  vsize = 13359.1 deltaVsize = 0 rss = 9802.33 delta = 45.9844 allocated = 10144.4 active = 10312.3
> [7] run: 1 lumi: 1 event: 7  vsize = 13359.1 deltaVsize = 0.140625 rss = 9756.34 delta = 457.336 allocated = 10111.8 active = 10277.5
> MemoryReport> Peak rss size 9802.33 Mbytes (VSIZE 13359.1)
>  Jemalloc allocated 10144.4 active 10312.3 resident 10416.1 mapped 10444.9 metadata 97.3148
>  Key events increasing rss:
> [9] run: 1 lumi: 1 event: 9  vsize = 13359.1 deltaVsize = 0 rss = 9732.85 delta = -69.4766 allocated = 10095 active = 10260.3
> [7] run: 1 lumi: 1 event: 7  vsize = 13359.1 deltaVsize = 0.140625 rss = 9756.34 delta = 367.441 allocated = 10111.8 active = 10277.5
> [8] run: 1 lumi: 1 event: 8  vsize = 13359.1 deltaVsize = 0 rss = 9802.33 delta = 45.9844 allocated = 10144.4 active = 10312.3
> [1] run: 1 lumi: 1 event: 1  vsize = 13326.3 deltaVsize = 0 rss = 9388.9 delta = 0 allocated = 9794.21 active = 9955.02
> [8] run: 1 lumi: 1 event: 8  vsize = 13359.1 deltaVsize = 0 rss = 9802.33 delta = 45.9844 allocated = 10144.4 active = 10312.3
> [7] run: 1 lumi: 1 event: 7  vsize = 13359.1 deltaVsize = 0.140625 rss = 9756.34 delta = 367.441 allocated = 10111.8 active = 10277.5
> 