### PR TITLE
[CMSSW_15_0_X] Replace the GT for Run2 data re-reco in autoCond with a 150X clone of previous 141X_dataRun2_v3

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,7 +24,7 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'                   :    '131X_mcRun2_pA_v3',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    :    '141X_dataRun2_v3',
+    'run2_data'                    :    '150X_dataRun2_v1',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_HEfail'             :    '140X_dataRun2_HEfail_v1',
     # GlobalTag for Run2 HI data


### PR DESCRIPTION
#### PR description:
As requested in https://cms-talk.web.cern.ch/t/gt-offline-conditions-for-ul-nanov15-reprocessing/134970

#### PR validation:
Being a clone of the previous 141X GT, I don't expect any issue or difference in the results of the tests in Run1 or Run2 workflows.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. 
Backport of #49222 back till to the release intended to be used in the Run2-re-reco (re-nano, in fact), supposedly CMSSW_15_0_X, see https://github.com/cms-sw/cmssw/pull/48176
