### PR TITLE
Updated custom suffix syntax required by clang

### DIFF
--- a/IOPool/Input/src/RootEmbeddedFileSequence.cc
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.cc
@@ -25,7 +25,7 @@
 
 namespace {
   std::atomic<unsigned int> badFilesSkipped_{0};
-  auto operator"" _uz(unsigned long long i) -> std::size_t { return std::size_t{i}; }  // uz will be in C++23
+  auto operator""_uz(unsigned long long i) -> std::size_t { return std::size_t{i}; }  // uz will be in C++23
 }  // namespace
 
 namespace edm {


### PR DESCRIPTION
#### PR description:

- meant to fix a compilation warning from the newest version of clang.

#### PR validation:

Should compile.

resolves https://github.com/cms-sw/framework-team/issues/1622