### PR TITLE
Add EW skim for 2025 PbPb

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -579,6 +579,9 @@ workflows[143.911] = ['',['RunUPC2024','RECODR3_2025_OXY','HARVESTDPROMPTR3']]
 workflows[143.912] = ['',['RunUPC2024','RECODR3_2025_UPC_OXY','HARVESTDPROMPTR3']]
 workflows[143.921] = ['',['RunUPC2024','RECODR3_2025_OXY_SKIMIONPHYSICS0','HARVESTDPROMPTR3']]
 
+### run3-2025 skim (2025 HI MC temp)
+workflows[143.203] = ['',['HydjetQ_MinBias_5362GeV_2025','DIGIHI2024','RAWPRIMESIMHI18','SKIMHIPHYSICSRAWPRIMERUN3_2025','HARVESTHI2025S4']]
+
 ## special HLT scouting workflow (with hardcoded private input file from ScoutingPFMonitor skimmed to remove all events without scouting)
 workflows[145.415] = ['',['HLTDR3_ScoutingPFMonitor_2024','RECONANORUN3_ScoutingPFMonitor_reHLT_2024','HARVESTRUN3_ScoutingPFMonitor_2024']]
 

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3548,6 +3548,7 @@ steps['RECOHI2024MBAPPROXCLUSTERS']=merge([hiDefaults2024_approxClusters,{'-s':'
 
 steps['SKIMHIFORWARDRUN3_2024'] = merge([upcDefaults2024, {'-s':'RAW2DIGI,L1Reco,RECO,SKIM:UPCMonopole,PAT,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@miniAODDQM'},steps['RECOUPC2024']])
 steps['SKIMHIPHYSICSRAWPRIMERUN3_2024'] = merge([hiDefaults2024_approxClusters, {'-s':'RAW2DIGI,L1Reco,RECO,SKIM:PbPbEMu+PbPbZEE+PbPbZMu+PbPbHighPtJets,PAT,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@miniAODDQM'},steps['RECOHI2024']])
+steps['SKIMHIPHYSICSRAWPRIMERUN3_2025'] = merge([hiDefaults2025_approxClusters, {'-s':'RAW2DIGI,L1Reco,RECO,PAT,SKIM:PbPbEW+PbPbHighPtJets,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@miniAODDQM'},steps['RECOHI2025']])
 
 steps['MINIHI2024PROD']=merge([hiDefaults2024,{'-s':'PAT',
                                                '--datatier':'MINIAODSIM',

--- a/Configuration/Skimming/python/PbPb_EWSkim_cff.py
+++ b/Configuration/Skimming/python/PbPb_EWSkim_cff.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+# primary vertex filter
+primaryVertexFilterForPbPbEWSkim = cms.EDFilter("VertexSelector",
+    src = cms.InputTag("offlinePrimaryVertices"),
+    cut = cms.string("!isFake && abs(z) <= 25 && position.Rho <= 2"), 
+    filter = cms.bool(True),
+)
+
+# lepton filter
+goodMuonsForPbPbEWSkim = cms.EDFilter("PATMuonSelector",
+    src = cms.InputTag("slimmedMuons"),
+    cut = cms.string("pt >= 15.0 && passed('CutBasedIdLoose')")
+)
+goodElectronsForPbPbEWSkim = cms.EDFilter("PATElectronSelector",
+    src = cms.InputTag("slimmedElectrons"),
+    cut = cms.string("pt >= 15.0")
+)
+oneLeptonForPbPbEWSkim = cms.EDFilter("PATLeptonCountFilter",
+    electronSource = cms.InputTag("goodElectronsForPbPbEWSkim"),
+    muonSource     = cms.InputTag("goodMuonsForPbPbEWSkim"),
+    tauSource      = cms.InputTag(""),
+    countElectrons = cms.bool(True),
+    countMuons     = cms.bool(True),
+    countTaus      = cms.bool(False),
+    minNumber = cms.uint32(1),
+    maxNumber = cms.uint32(1000000),
+)
+
+# skim sequence
+EWSkimSequence = cms.Sequence(
+    primaryVertexFilterForPbPbEWSkim *
+    goodMuonsForPbPbEWSkim *
+    goodElectronsForPbPbEWSkim *
+    oneLeptonForPbPbEWSkim
+)
+
+# skim content
+from Configuration.EventContent.EventContent_cff import MINIAODEventContent
+EWSkimContent = MINIAODEventContent.clone()
+EWSkimContent.outputCommands.append("drop *_*_*_SKIM")

--- a/Configuration/Skimming/python/Skims_PbPb_cff.py
+++ b/Configuration/Skimming/python/Skims_PbPb_cff.py
@@ -90,3 +90,17 @@ SKIMStreamUPCMonopole = cms.FilteredStream(
     )
 
 #####################
+
+from Configuration.Skimming.PbPb_EWSkim_cff import *
+EWSkimPathPbPb = cms.Path( EWSkimSequence )
+SKIMStreamPbPbEW = cms.FilteredStream(
+    responsible = 'HI PAG',
+    name = 'PbPbEW',
+    paths = (EWSkimPathPbPb),
+    content = EWSkimContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('MINIAOD')
+    )
+
+
+#####################

--- a/Configuration/Skimming/python/autoSkim.py
+++ b/Configuration/Skimming/python/autoSkim.py
@@ -50,7 +50,7 @@ for i_split in range(20):
 
 # For 2023 PbPb skims
 for i_split in range(60):
-    autoSkim[f'HIPhysicsRawPrime{i_split}'] = 'PbPbEMu+PbPbZEE+PbPbZMu+PbPbHighPtJets+LogError+LogErrorMonitor'
+    autoSkim[f'HIPhysicsRawPrime{i_split}'] = 'PbPbEW+PbPbHighPtJets'
 
 autoSkimRunII = {
  'BTagCSV' : 'LogError+LogErrorMonitor',


### PR DESCRIPTION
#### PR description:

This PR replaces the previous muon and electron PbPb skims (PbPbEMu, PbPbZEE and PbPbZMu) with one new skim that requires the presence of a high pT (> 15 GeV) electron or muon, labelled as EW skim. The content of this new skim is stored in MiniAOD. After testing on ~5000 minbias events from 2024 PbPb data, the size of the old skims (PbPbEMu + PbPbZEE + PbPbZMu) is about 3% of 2024 RawPrime PDs while the new EW skim is only 1%, reducing the skim PD size by a factor of 3 in 2025 PbPb while enhancing the physics potential (looser selection). The relval 143.203 is added to test the new skim.

@flodamas @mandrenguyen 

#### PR validation:

Tested with relval 143.203

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 15_1_X for PbPb data taking
