### PR TITLE
Add function and enum aliases for P2 tracker topology with more obvious names

### DIFF
--- a/DataFormats/SiStripDetId/interface/SiStripEnums.h
+++ b/DataFormats/SiStripDetId/interface/SiStripEnums.h
@@ -14,6 +14,6 @@ enum class SiStripModuleGeometry { UNKNOWNGEOMETRY, IB1, IB2, OB1, OB2, W1A, W2A
 namespace Phase2Tracker {
   enum Subdetector { UNKNOWN = 0, Endcap = 4, Barrel = 5 };
   enum BarrelModuleTilt { nonBarrel = 0, tiltedZminus = 1, tiltedZplus = 2, flat = 3 };
-}  // namespace P2Tracker
+}  // namespace Phase2Tracker
 
 #endif

--- a/DataFormats/SiStripDetId/interface/SiStripEnums.h
+++ b/DataFormats/SiStripDetId/interface/SiStripEnums.h
@@ -11,9 +11,9 @@ enum class SiStripModuleGeometry { UNKNOWNGEOMETRY, IB1, IB2, OB1, OB2, W1A, W2A
 
 // P2 Tracker
 
-namespace P2Tracker {
-  enum Subdetector { UNKNOWN = 0, TrackerEndcap = 4, TrackerBarrel = 5 };
-  enum BarrelModuleTilt { nonBarrel = 0, tiltedMinusZ = 1, tiltedPlusZ = 2, flat = 3 };
+namespace Phase2Tracker {
+  enum Subdetector { UNKNOWN = 0, Endcap = 4, Barrel = 5 };
+  enum BarrelModuleTilt { nonBarrel = 0, tiltedZminus = 1, tiltedZplus = 2, flat = 3 };
 }  // namespace P2Tracker
 
 #endif

--- a/DataFormats/SiStripDetId/interface/SiStripEnums.h
+++ b/DataFormats/SiStripDetId/interface/SiStripEnums.h
@@ -13,7 +13,7 @@ enum class SiStripModuleGeometry { UNKNOWNGEOMETRY, IB1, IB2, OB1, OB2, W1A, W2A
 
 namespace P2Tracker {
   enum Subdetector { UNKNOWN = 0, TrackerEndcap = 4, TrackerBarrel = 5 };
-enum BarrelModuleTilt { nonBarrel = 0, tiltedMinusZ = 1, tiltedPlusZ = 2, flat = 3 };
-}
+  enum BarrelModuleTilt { nonBarrel = 0, tiltedMinusZ = 1, tiltedPlusZ = 2, flat = 3 };
+}  // namespace P2Tracker
 
 #endif

--- a/DataFormats/SiStripDetId/interface/SiStripEnums.h
+++ b/DataFormats/SiStripDetId/interface/SiStripEnums.h
@@ -1,10 +1,19 @@
 #ifndef SISTRIPENUMS_H
 #define SISTRIPENUMS_H
 
+// P1 Tracker
+
 namespace SiStripSubdetector {
   enum Subdetector { UNKNOWN = 0, TIB = 3, TID = 4, TOB = 5, TEC = 6 };
 }
 
 enum class SiStripModuleGeometry { UNKNOWNGEOMETRY, IB1, IB2, OB1, OB2, W1A, W2A, W3A, W1B, W2B, W3B, W4, W5, W6, W7 };
+
+// P2 Tracker
+
+namespace P2Tracker {
+  enum Subdetector { UNKNOWN = 0, TrackerEndcap = 4, TrackerBarrel = 5 };
+enum BarrelModuleTilt { nonBarrel = 0, tiltedMinusZ = 1, tiltedPlusZ = 2, flat = 3 };
+}
 
 #endif

--- a/DataFormats/TrackerCommon/interface/TrackerTopology.h
+++ b/DataFormats/TrackerCommon/interface/TrackerTopology.h
@@ -184,8 +184,8 @@ public:
   }
 
   // Get enum indicating if tilted barrel module of P2 tracker.
-  P2Tracker::BarrelModuleTilt barrelTiltTypeP2(const DetId &detId) const {
-    return static_cast<P2Tracker::BarrelModuleTilt>(tobSide(detId));
+  Phase2Tracker::BarrelModuleTilt barrelTiltTypeP2(const DetId &detId) const {
+    return static_cast<Phase2Tracker::BarrelModuleTilt>(tobSide(detId));
   }
 
   unsigned int tecSide(const DetId &id) const { return ((id.rawId() >> tecVals_.sideStartBit_) & tecVals_.sideMask_); }

--- a/DataFormats/TrackerCommon/interface/TrackerTopology.h
+++ b/DataFormats/TrackerCommon/interface/TrackerTopology.h
@@ -10,8 +10,8 @@
 
 //knower of all things tracker geometry
 //flexible replacement for PXBDetId and friends
-//to implement
-// endcap pixel
+//to implement endcap pixel
+//Useful doc in Geometry/TrackerNumberingBuilder/README.md
 
 class TrackerTopology {
 public:
@@ -183,6 +183,11 @@ public:
     return ((id.rawId() >> tobVals_.rod_fw_bwStartBit_) & tobVals_.rod_fw_bwMask_);
   }
 
+  // Get enum indicating if tilted barrel module of P2 tracker.
+  P2Tracker::BarrelModuleTilt barrelTiltTypeP2( const DetId& detId ) const {
+    return static_cast<P2Tracker::BarrelModuleTilt>(tobSide(detId));
+  }
+
   unsigned int tecSide(const DetId &id) const { return ((id.rawId() >> tecVals_.sideStartBit_) & tecVals_.sideMask_); }
 
   unsigned int tibSide(const DetId &id) const {
@@ -195,6 +200,8 @@ public:
 
   //rod
   unsigned int tobRod(const DetId &id) const { return ((id.rawId() >> tobVals_.rodStartBit_) & tobVals_.rodMask_); }
+  // P2 tracker (better name) -- related to phi.
+  unsigned int barrelRodP2(const DetId &id) const { return tobRod(id); }
 
   //wheel
   unsigned int tecWheel(const DetId &id) const {
@@ -203,6 +210,8 @@ public:
   unsigned int tidWheel(const DetId &id) const {
     return ((id.rawId() >> tidVals_.wheelStartBit_) & tidVals_.wheelMask_);
   }
+  // P2 tracker (better name)
+  unsigned int endcapWheelP2(const DetId &id) const { return tidWheel(id); }
 
   //order
   unsigned int tecOrder(const DetId &id) const {
@@ -218,6 +227,8 @@ public:
   /// ring id
   unsigned int tecRing(const DetId &id) const { return ((id.rawId() >> tecVals_.ringStartBit_) & tecVals_.ringMask_); }
   unsigned int tidRing(const DetId &id) const { return ((id.rawId() >> tidVals_.ringStartBit_) & tidVals_.ringMask_); }
+  // P2 tracker (better name)
+  unsigned int endcapRingP2(const DetId &id) const { return tidRing(id); }
 
   //petal
   unsigned int tecPetalNumber(const DetId &id) const {

--- a/DataFormats/TrackerCommon/interface/TrackerTopology.h
+++ b/DataFormats/TrackerCommon/interface/TrackerTopology.h
@@ -184,7 +184,7 @@ public:
   }
 
   // Get enum indicating if tilted barrel module of P2 tracker.
-  P2Tracker::BarrelModuleTilt barrelTiltTypeP2( const DetId& detId ) const {
+  P2Tracker::BarrelModuleTilt barrelTiltTypeP2(const DetId &detId) const {
     return static_cast<P2Tracker::BarrelModuleTilt>(tobSide(detId));
   }
 


### PR DESCRIPTION
#### PR description:

The TrackerTopology class was developed for the P1 Tracker, and its continued use with the P2 Tracker is ugly, with one needing to call functions and refer to enum values whose names still relate to the original P1 Tracker.

This ugliness probably deserves a full rerwrite to clean this up. However, this PR provides a superficial clean up by providing P2 aliases for the most commonly used functions and enums. 

This PR targets CMSSW 16.

#### PR validation:

This doesn't remove any of the original enums or functions, so shouldn't break anything. I've checked that the P2 L1 tracking algorithm can successfully run if a few small changes are made to it to switch to the new P2 function names and enums. (We'll make this change at some point in the future, once this PR is merged).

