### PR TITLE
[mkFit] procModifier for Phase-2 HLT tracking and track candidates selections

### DIFF
--- a/Configuration/ProcessModifiers/python/hltTrackingMkFitInitialStep_cff.py
+++ b/Configuration/ProcessModifiers/python/hltTrackingMkFitInitialStep_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier sets replaces the default pattern recognition with mkFit for initialStep
+hltTrackingMkFitInitialStep = cms.Modifier()

--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -65,6 +65,7 @@ The offsets currently in use are:
 * 0.7561 HLT phase-2 timing menu Alpaka, trimmed tracking
 * 0.7562 HLT phase-2 timing menu Alpaka, trimmed tracking, single tracking iteration variant
 * 0.757: HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + CKF building variant
+* 0.7571: HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + mkFit building variant
 * 0.758 HLT phase-2 timing menu ticl_barrel variant
 * 0.759: HLT phase-2 timing menu, with NANO:@Phase2HLT
 * 0.76: HLT phase-2 reduced menu, with DIGI step

--- a/Configuration/PyReleaseValidation/python/relval_Run4.py
+++ b/Configuration/PyReleaseValidation/python/relval_Run4.py
@@ -79,6 +79,7 @@ numWFIB.extend([prefixDet+34.756]) # HLTTiming75e33, phase2_hlt_vertexTrimming
 numWFIB.extend([prefixDet+34.7561])# HLTTiming75e33, alpaka,phase2_hlt_vertexTrimming
 numWFIB.extend([prefixDet+34.7562])# HLTTiming75e33, alpaka,phase2_hlt_vertexTrimming,singleIterPatatrack
 numWFIB.extend([prefixDet+34.757]) # HLTTiming75e33, alpaka,singleIterPatatrack,trackingLST,seedingLST
+numWFIB.extend([prefixDet+34.7571]) # HLTTiming75e33, alpaka,singleIterPatatrack,trackingLST,seedingLST,buildingMkFit
 numWFIB.extend([prefixDet+34.758]) # HLTTiming75e33, ticl_barrel
 numWFIB.extend([prefixDet+34.759]) # HLTTiming75e33 + NANO
 numWFIB.extend([prefixDet+34.77])  # NGTScouting

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2023,6 +2023,19 @@ upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeeding'].step3 = {
     '-s':'HARVESTING:@hltValidation'
 }
 
+upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuilding'] = deepcopy(upgradeWFs['HLTTiming75e33'])
+upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuilding'].suffix = '_HLT75e33TimingAlpakaSingleIterLSTSeedingMkFitBuilding'
+upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuilding'].offset = 0.7571
+upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuilding'].step2 = {
+    '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing,VALIDATION:@hltValidation',
+    '--procModifiers': 'alpaka,singleIterPatatrack,trackingLST,seedingLST,trackingMkFitCommon,hltTrackingMkFitInitialStep',
+    '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
+    '--eventcontent':'FEVTDEBUGHLT,DQMIO'
+}
+upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuilding'].step3 = {
+    '-s':'HARVESTING:@hltValidation'
+}
+
 upgradeWFs['HLTTiming75e33TiclBarrel'] = deepcopy(upgradeWFs['HLTTiming75e33'])
 upgradeWFs['HLTTiming75e33TiclBarrel'].suffix = '_HLT75e33TimingTiclBarrel'
 upgradeWFs['HLTTiming75e33TiclBarrel'].offset = 0.758

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -166,9 +166,10 @@ if __name__ == '__main__':
                      29634.756,   # HLT phase-2 timing menu trimmed tracking
                      29634.7561,  # HLT phase-2 timing menu Alpaka, trimmed tracking
                      29634.7562,  # HLT phase-2 timing menu Alpaka, trimmed tracking, single tracking iteration variant
-                     29634.757,   # HLT phase-2 timing menu, with NANO:@Phase2HLT
+                     29634.757,   # HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + CKF building variant
+                     29634.7571,  # HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + mkFit building variant 
                      29634.758,   # HLT phase-2 timing menu ticl_barrel variant
-                     29634.759,   # HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + CKF building variant
+                     29634.759,   # HLT phase-2 timing menu, with NANO:@Phase2HLT
                      29634.77,    # HLT phase-2 NGT Scouting menu
                      29634.771,   # HLT phase-2 NGT Scouting menu, Alpaka, TICL-v5, TICL-Barrel, CA Extension
                      29634.772,   # HLT phase-2 NGT Scouting menu, with NANO:@NGTScouting

--- a/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPMkFit_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPMkFit_cfi.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+def _addProcessMkFitGeometry(process):
+    process.mkFitGeometryESProducer = cms.ESProducer("MkFitGeometryESProducer",
+        appendToDataLabel = cms.string('')
+    )
+
+from Configuration.ProcessModifiers.trackingMkFitCommon_cff import trackingMkFitCommon
+modifyConfigurationForTrackingMkFitGeometryMkfit_ = trackingMkFitCommon.makeProcessModifier(_addProcessMkFitGeometry)
+
+def _addProcesshltInitialStepMkFitConfig(process):
+    process.hltInitialStepTrackCandidatesMkFitConfig = cms.ESProducer("MkFitIterationConfigESProducer",
+        ComponentName = cms.string('hltInitialStepTrackCandidatesMkFitConfig'),
+        appendToDataLabel = cms.string(''),
+        config = cms.FileInPath('RecoTracker/MkFit/data/mkfit-phase2-initialStep.json'),
+        maxClusterSize = cms.uint32(8),
+        minPt = cms.double(0.8)
+    )
+
+from Configuration.ProcessModifiers.hltTrackingMkFitInitialStep_cff import hltTrackingMkFitInitialStep
+modifyConfigurationForTrackingMkFithltInitialStepMkFitConfig_ = hltTrackingMkFitInitialStep.makeProcessModifier(_addProcesshltInitialStepMkFitConfig)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepMkFitSeeds_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepMkFitSeeds_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+# MkFitSeedConverter options
+hltInitialStepMkFitSeeds = cms.EDProducer("MkFitSeedConverter",
+        maxNSeeds = cms.uint32(500000),
+        mightGet = cms.optional.untracked.vstring,
+        seeds = cms.InputTag("hltInitialStepSeeds"),
+        ttrhBuilder = cms.ESInputTag("","WithTrackAngle")
+)
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+from Configuration.ProcessModifiers.hltTrackingMkFitInitialStep_cff import hltTrackingMkFitInitialStep
+(trackingLST & seedingLST & hltTrackingMkFitInitialStep).toModify(hltInitialStepMkFitSeeds, seeds = "hltInitialStepTrajectorySeedsLST")

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidatesMkFit_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidatesMkFit_cfi.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+# InitialStepTrackCandidatesMkFit options
+hltInitialStepTrackCandidatesMkFit = cms.EDProducer("MkFitProducer",
+        backwardFitInCMSSW = cms.bool(False),
+        buildingRoutine = cms.string('cloneEngine'),
+        clustersToSkip = cms.InputTag(""),
+        config = cms.ESInputTag("","hltInitialStepTrackCandidatesMkFitConfig"),
+        eventOfHits = cms.InputTag("hltMkFitEventOfHits"),
+        limitConcurrency = cms.untracked.bool(False),
+        mightGet = cms.optional.untracked.vstring,
+        minGoodStripCharge = cms.PSet(),
+        mkFitSilent = cms.untracked.bool(True),
+        pixelHits = cms.InputTag("hltMkFitSiPixelHits"),
+        removeDuplicates = cms.bool(True),
+        seedCleaning = cms.bool(True),
+        seeds = cms.InputTag("hltInitialStepMkFitSeeds"),
+        stripHits = cms.InputTag("hltMkFitSiPhase2Hits")
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidates_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidates_cfi.py
@@ -44,11 +44,42 @@ _hltInitialStepTrackCandidatesLST = cms.EDProducer('LSTOutputConverter',
     )
 )
 
+
+_hltInitialStepTrackCandidatesMkFit = cms.EDProducer('MkFitOutputConverter',
+    batchSize = cms.int32(16),
+    candMVASel = cms.bool(False),
+    candCutSel = cms.bool(True),
+    candMinNHitsCut = cms.int32(3),
+    candMinPtCut = cms.double(0.8),
+    candWP = cms.double(0),
+    doErrorRescale = cms.bool(True),
+    mightGet = cms.optional.untracked.vstring,
+    mkFitEventOfHits = cms.InputTag("hltMkFitEventOfHits"),
+    mkFitPixelHits = cms.InputTag("hltMkFitSiPixelHits"),
+    mkFitSeeds = cms.InputTag("hltInitialStepMkFitSeeds"),
+    mkFitStripHits = cms.InputTag("hltMkFitSiPhase2Hits"),
+    propagatorAlong = cms.ESInputTag("","PropagatorWithMaterial"),
+    propagatorOpposite = cms.ESInputTag("","PropagatorWithMaterialOpposite"),
+    qualityMaxInvPt = cms.double(100),
+    qualityMaxPosErr = cms.double(100),
+    qualityMaxR = cms.double(120),
+    qualityMaxZ = cms.double(280),
+    qualityMinTheta = cms.double(0.01),
+    qualitySignPt = cms.bool(True),
+    seeds = cms.InputTag("hltInitialStepSeeds"),
+    tfDnnLabel = cms.string('trackSelectionTf'),
+    tracks = cms.InputTag("hltInitialStepTrackCandidatesMkFit"),
+    ttrhBuilder = cms.ESInputTag("","WithTrackAngle")
+)
+
+_hltInitialStepTrackCandidatesMkFitLSTSeeds = _hltInitialStepTrackCandidatesMkFit.clone(seeds = "hltInitialStepTrajectorySeedsLST")
+                                                     
 from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+from Configuration.ProcessModifiers.hltTrackingMkFitInitialStep_cff import hltTrackingMkFitInitialStep
 # All useful combinations added to make the code work as expected and for clarity
-(~singleIterPatatrack & trackingLST & ~seedingLST).toReplaceWith(hltInitialStepTrackCandidates, _hltInitialStepTrackCandidatesLST)
-(~singleIterPatatrack & trackingLST & seedingLST).toReplaceWith(hltInitialStepTrackCandidates, _hltInitialStepTrackCandidatesLST)
-(singleIterPatatrack & trackingLST & ~seedingLST).toReplaceWith(hltInitialStepTrackCandidates, _hltInitialStepTrackCandidatesLST)
+(~(singleIterPatatrack & seedingLST) & trackingLST).toReplaceWith(hltInitialStepTrackCandidates, _hltInitialStepTrackCandidatesLST)
 (singleIterPatatrack & trackingLST & seedingLST).toModify(hltInitialStepTrackCandidates, src = "hltInitialStepTrajectorySeedsLST") # All LST seeds
+(~seedingLST & ~trackingLST & hltTrackingMkFitInitialStep).toReplaceWith(hltInitialStepTrackCandidates, _hltInitialStepTrackCandidatesMkFit)
+(singleIterPatatrack & seedingLST & trackingLST & hltTrackingMkFitInitialStep).toReplaceWith(hltInitialStepTrackCandidates, _hltInitialStepTrackCandidatesMkFitLSTSeeds)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltMkFitEventOfHits_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltMkFitEventOfHits_cfi.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+# MkFitEventOfHits options
+hltMkFitEventOfHits = cms.EDProducer("MkFitEventOfHitsProducer",
+    beamSpot = cms.InputTag("offlineBeamSpot"),
+    mightGet = cms.optional.untracked.vstring,
+    pixelHits = cms.InputTag("hltMkFitSiPixelHits"),
+    stripHits = cms.InputTag("hltMkFitSiPhase2Hits"),
+    usePixelQualityDB = cms.bool(True),
+    useStripStripQualityDB = cms.bool(False)
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltMkFitSiPhase2Hits_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltMkFitSiPhase2Hits_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+# MkFitSiPhase2Hits options
+hltMkFitSiPhase2Hits = cms.EDProducer("MkFitPhase2HitConverter",
+        mightGet = cms.optional.untracked.vstring,
+        hits = cms.InputTag("hltSiPhase2RecHits"),
+        clusters = cms.InputTag("hltSiPhase2Clusters"),
+        ttrhBuilder = cms.ESInputTag("","WithTrackAngle")
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltMkFitSiPixelHits_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltMkFitSiPixelHits_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+# MkFitSiPixelHits options
+hltMkFitSiPixelHits = cms.EDProducer("MkFitSiPixelHitConverter",
+        hits = cms.InputTag("hltSiPixelRecHits"),
+        clusters = cms.InputTag("hltSiPixelClusters"),
+        mightGet = cms.optional.untracked.vstring,
+        ttrhBuilder = cms.ESInputTag("","WithTrackAngle")
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltMkFitSiStripHits_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltMkFitSiStripHits_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+# MkFitSiStripHits options
+hltMkFitSiStripHits = cms.EDProducer("MkFitSiStripHitConverter",
+        mightGet = cms.optional.untracked.vstring,
+        minGoodStripCharge = cms.PSet(
+            refToPSet_ = cms.string('SiStripClusterChargeCutLoose')
+        ),
+        rphiHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
+        stereoHits = cms.InputTag("siStripMatchedRecHits","stereoRecHit"),
+        ttrhBuilder = cms.ESInputTag("","WithTrackAngle")
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
@@ -79,3 +79,37 @@ _HLTInitialStepSequenceNGTScouting = cms.Sequence(
 
 from Configuration.ProcessModifiers.ngtScouting_cff import ngtScouting
 ngtScouting.toReplaceWith(HLTInitialStepSequence,_HLTInitialStepSequenceNGTScouting)
+
+from ..sequences.HLTMkFitInputSequence_cfi import *
+from ..modules.hltInitialStepMkFitSeeds_cfi import *
+from ..modules.hltInitialStepTrackCandidatesMkFit_cfi import *
+_HLTInitialStepSequenceMkFitTracking = cms.Sequence(
+    hltInitialStepSeeds
+    +hltSiPhase2RecHits
+    +HLTMkFitInputSequence
+    +hltInitialStepMkFitSeeds
+    +hltInitialStepTrackCandidatesMkFit
+    +hltInitialStepTrackCandidates
+    +hltInitialStepTracks
+    +hltInitialStepTrackCutClassifier
+    +hltInitialStepTrackSelectionHighPurity
+)
+
+from Configuration.ProcessModifiers.hltTrackingMkFitInitialStep_cff import hltTrackingMkFitInitialStep
+(~seedingLST & ~trackingLST & hltTrackingMkFitInitialStep).toReplaceWith(HLTInitialStepSequence,_HLTInitialStepSequenceMkFitTracking)
+
+_HLTInitialStepSequenceSingleIterPatatrackLSTSeedingMkFitTracking = cms.Sequence(
+     hltInitialStepSeeds
+    +hltInitialStepSeedTracksLST
+    +hltSiPhase2RecHits # Probably need to move elsewhere in the final setup                                                 
+    +hltInputLST
+    +hltLST
+    +hltInitialStepTrajectorySeedsLST
+    +HLTMkFitInputSequence
+    +hltInitialStepMkFitSeeds
+    +hltInitialStepTrackCandidatesMkFit
+    +hltInitialStepTrackCandidates
+    +hltInitialStepTracks
+)
+
+(singleIterPatatrack & trackingLST & seedingLST & hltTrackingMkFitInitialStep).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceSingleIterPatatrackLSTSeedingMkFitTracking)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTMkFitInputSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTMkFitInputSequence_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltMkFitSiPixelHits_cfi import *
+from ..modules.hltMkFitSiStripHits_cfi import *
+from ..modules.hltMkFitSiPhase2Hits_cfi import *
+from ..modules.hltMkFitEventOfHits_cfi import *
+
+HLTMkFitInputSequence = cms.Sequence(
+    hltMkFitSiPixelHits
+    +hltMkFitSiPhase2Hits
+    +hltMkFitEventOfHits
+)

--- a/HLTrigger/Configuration/python/HLT_75e33_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_cff.py
@@ -85,6 +85,7 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltPhase2L3MuonTrack
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPPixelCPEFastParams_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltPixelTracksCleanerBySharedHits_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPTTRHBuilderWithTrackAngle_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPMkFit_cfi")
 
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPKFFittingSmootherForL2Muon_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPKFTrajectoryFitterForL2Muon_cfi")

--- a/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
@@ -90,6 +90,7 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltPhase2L3MuonTrack
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPPixelCPEFastParams_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltPixelTracksCleanerBySharedHits_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPTTRHBuilderWithTrackAngle_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPMkFit_cfi")
 
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPKFFittingSmootherForL2Muon_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPKFTrajectoryFitterForL2Muon_cfi")

--- a/RecoTracker/MkFit/plugins/MkFitProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitProducer.cc
@@ -157,19 +157,16 @@ void MkFitProducer::produce(edm::StreamID iID, edm::Event& iEvent, const edm::Ev
   const auto& mkFitGeom = iSetup.getData(mkFitGeomToken_);
   const auto& mkFitIterConfig = iSetup.getData(mkFitIterConfigToken_);
 
-  //const std::vector<bool>* pixelMaskPtr = nullptr;
   std::vector<bool> pixelMask(pixelHits.hits().size(), false);
   std::vector<bool> stripMask(stripHits.hits().size(), false);
   if (not pixelMaskToken_.isUninitialized()) {
     if (not pixelHits.hits().empty()) {
       const auto& pixelContainerMask = iEvent.get(pixelMaskToken_);
-      //pixelMask.resize(pixelContainerMask.size(), false);
       if UNLIKELY (pixelContainerMask.refProd().id() != pixelHits.clustersID()) {
         throw cms::Exception("LogicError") << "MkFitHitWrapper has pixel cluster ID " << pixelHits.clustersID()
                                            << " but pixel cluster mask has " << pixelContainerMask.refProd().id();
       }
       pixelContainerMask.copyMaskTo(pixelMask);
-      //pixelMaskPtr = &pixelMask;
     }
 
     if (not stripHits.hits().empty()) {
@@ -204,7 +201,6 @@ void MkFitProducer::produce(edm::StreamID iID, edm::Event& iEvent, const edm::Ev
                             mkFitIterConfig,
                             eventOfHits.get(),
                             {&pixelMask, &stripMask},
-                            //{pixelMaskPtr, &stripMask},
                             streamCache(iID)->get(),
                             seeds_mutable,
                             tracks,


### PR DESCRIPTION
#### PR description:

This is a procModifier-based implementation of the _mkFit_ tracking building algorithm at HLT Phase-2. It reuses the `trackingMkFitCommon` procModifier to configure the internal _mkFit_ geometry setup,  and  introduces the new procModifier `hltTrackingMkFitInitialStep` to test the _mkFit_ building primarly in a single-iteration HLT Phase-2 tracking configuration.  The _mkFit_ tracking building algorithm can also be tested at `hltInitialStep`. 

The PR adds support for applying selection thresholds on the transverse momentum (`MinPtCut`) and the minimum number of hits (`MinNHitsCut`) for track candidates after the forward and backward search steps of the _mkFit_ tracking building algorithm.

The PR also fixes an inconsistency in the workflow numbering between `runTheMatrix.py` and `upgradeWorkflowComponents.py`, where the `offset` value did not match the corresponding workflow ID in the `runTheMatrix.py` comments.

A new variation of the HLT timing workflow has been added, including Patatrack seeding and a single tracking iteration with _mkFit_ building. The implementation makes use of existing procModifiers, and can be executed through the corresponding procModifier sequence `alpaka,singleIterPatatrack,trackingLST,seedingLST,trackingMkFitCommon,hltTrackingMkFitInitialStep`. The workflow `.7571` is being introduced to monitor this configuration.

A follow-up PR will extend this work to implement the proposed HLT Phase-2 baseline single-iteration tracking configuration (configuration 3) as presented at the [HLT Upgrade meeting](https://indico.cern.ch/event/1587306/contributions/6719158/attachments/3145286/5583730/HLTUpgrade30Sep2025.pdf). The developments in this PR are independent and provide the necessary framework for ongoing _mkFit_-related HLT studies. The main results related to the `hltInitialStep` configuration have been presented in [JIRA ticket CMSHLT-3613](https://its.cern.ch/jira/browse/CMSHLT-3613), and in this [DP note](https://cds.cern.ch/record/2941438), where the configuration was executed via customisers.

FYI @mmasciov @slava77 @VourMa 