### PR TITLE
Add a `const` overload of `bareProduct()` and a `markAsPresent()` method to `Wrapper.h`

### DIFF
--- a/DataFormats/Common/interface/Wrapper.h
+++ b/DataFormats/Common/interface/Wrapper.h
@@ -17,7 +17,6 @@ Wrapper: A template wrapper around EDProducts to hold the product ID.
 #include <algorithm>
 #include <cassert>
 #include <memory>
-#include <string>
 #include <typeinfo>
 
 namespace edm {
@@ -38,6 +37,9 @@ namespace edm {
     T const* operator->() const { return product(); }
 
     T& bareProduct() { return obj; }
+    T const& bareProduct() const { return obj; }
+
+    void markAsPresent() { present = true; }
 
     //these are used by FWLite
     static std::type_info const& productTypeInfo() { return typeid(T); }
@@ -176,6 +178,7 @@ namespace edm {
       }
     };
   }  // namespace soa
+
   template <typename T>
   inline std::shared_ptr<edm::soa::TableExaminerBase> Wrapper<T>::tableExaminer_() const {
     return soa::MakeTableExaminer<T>::make(&obj);
@@ -185,4 +188,4 @@ namespace edm {
 
 #include "DataFormats/Common/interface/WrapperView.icc"
 
-#endif
+#endif  // DataFormats_Common_Wrapper_h


### PR DESCRIPTION
#### PR description:

Add two methods to `Wrapper.h`, which are required by our implementation of a `GenericCloner` based on an `edmplugin::PluginFactory` (#49152):

```cpp
void markAsPresent() { present = true; }
```
This is required to mark as present a newly created `Wrapper<T>` initialized in our case from an `edm::WrapperBase&`.

```cpp
T const& bareProduct() const { return obj; }
```

We don't strictly need this overload, but we would appreciate having it, so we can call `bareProduct()` on a non const `Wrapper<T>`. Otherwise we would need to do `*w.product();`, but that includes a check for `present` that we don't need when we can ensure in advance that `present` is true.
