### PR TITLE
Pixel GPU Online DQM Client changes for CMSHLT-3147

### DIFF
--- a/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
@@ -99,6 +99,40 @@ if process.runType.getRunType() == process.runType.hi_run:
 
     process.siPixelPhase1CompareDigiErrorsSoAAlpaka.pixelErrorSrcGPU = 'hltSiPixelDigiErrorsPPOnAA'
     process.siPixelPhase1CompareDigiErrorsSoAAlpaka.pixelErrorSrcCPU = 'hltSiPixelDigiErrorsPPOnAASerialSync'
+
+    process.siPixelRecHitsSoAMonitorSerial.pixelHitsSrc = 'hltSiPixelRecHitsPPOnAASoASerialSync'
+    process.siPixelRecHitsSoAMonitorSerial.TopFolderName = 'SiPixelHeterogeneous/PixelRecHitsCPU'
+
+    process.siPixelRecHitsSoAMonitorDevice.pixelHitsSrc = 'hltSiPixelRecHitsPPOnAASoA'
+    process.siPixelRecHitsSoAMonitorDevice.TopFolderName = 'SiPixelHeterogeneous/PixelRecHitsGPU'
+
+    process.siPixelPhase1CompareRecHits.pixelHitsReferenceSoA = 'hltSiPixelRecHitsPPOnAASoASerialSync'
+    process.siPixelPhase1CompareRecHits.pixelHitsTargetSoA  = 'hltSiPixelRecHitsPPOnAASoA'
+    process.siPixelPhase1CompareRecHits.topFolderName = 'SiPixelHeterogeneous/PixelRecHitsCompareGPUvsCPU'
+
+    process.siPixelTrackSoAMonitorSerial.pixelTrackSrc = 'hltPixelTracksPPOnAASoASerialSync'
+    process.siPixelTrackSoAMonitorSerial.topFolderName = 'SiPixelHeterogeneous/PixelTrackCPU'
+
+    process.siPixelTrackSoAMonitorDevice.pixelTrackSrc = 'hltPixelTracksPPOnAASoA'
+    process.siPixelTrackSoAMonitorDevice.topFolderName = 'SiPixelHeterogeneous/PixelTrackGPU'
+
+    process.siPixelPhase1CompareTracks.pixelTrackReferenceSoA = 'hltPixelTracksPPOnAASoASerialSync'
+    process.siPixelPhase1CompareTracks.pixelTrackTargetSoA = 'hltPixelTracksPPOnAASoA'
+    process.siPixelPhase1CompareTracks.topFolderName = 'SiPixelHeterogeneous/PixelTrackCompareGPUvsCPU'
+
+    process.siPixelVertexSoAMonitorSerial.pixelVertexSrc = 'hltPixelVerticesPPOnAASoASerialSync'
+    process.siPixelVertexSoAMonitorSerial.beamSpotSrc = 'hltOnlineBeamSpot'
+    process.siPixelVertexSoAMonitorSerial.topFolderName = 'SiPixelHeterogeneous/PixelVertexCPU'
+
+    process.siPixelVertexSoAMonitorDevice.pixelVertexSrc = 'hltPixelVerticesPPOnAASoA'
+    process.siPixelVertexSoAMonitorDevice.beamSpotSrc = 'hltOnlineBeamSpot'
+    process.siPixelVertexSoAMonitorDevice.topFolderName = 'SiPixelHeterogeneous/PixelVertexGPU'
+
+    process.siPixelCompareVertices.pixelVertexReferenceSoA = 'hltPixelVerticesPPOnAASoASerialSync'
+    process.siPixelCompareVertices.pixelVertexTargetSoA = 'hltPixelVerticesPPOnAASoA'
+    process.siPixelCompareVertices.beamSpotSrc = 'hltOnlineBeamSpot'
+    process.siPixelCompareVertices.topFolderName = 'SiPixelHeterogeneous/PixelVertexCompareGPUvsCPU'
+
 else:
     process.siPixelPhase1MonitorRawDataASerial.src = 'hltSiPixelDigiErrorsSerialSync'
     process.siPixelPhase1MonitorRawDataADevice.src = 'hltSiPixelDigiErrors'
@@ -146,16 +180,11 @@ process.dump = cms.EDAnalyzer("EventContentAnalyzer")
 process.dumpPath = cms.Path(process.dump)
 
 #-------------------------------------
-#	Hcal DQM Tasks/Clients Sequences Definition
+#	Pixel DQM Tasks/Clients Sequences Definition
 #-------------------------------------
 
-if process.runType.getRunType() == process.runType.hi_run:
-    process.tasksPath = cms.Path(process.siPixelPhase1MonitorRawDataASerial*
-                                 process.siPixelPhase1MonitorRawDataADevice*
-                                 process.siPixelPhase1CompareDigiErrorsSoAAlpaka)
-else:
-    process.tasksPath = cms.Path(process.monitorpixelSoACompareSourceAlpaka *
-                                 process.siPixelHeterogeneousDQMComparisonHarvestingAlpaka)
+process.tasksPath = cms.Path(process.monitorpixelSoACompareSourceAlpaka *
+                             process.siPixelHeterogeneousDQMComparisonHarvestingAlpaka)
 
 #-------------------------------------
 #	Paths/Sequences Definitions

--- a/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
@@ -50,7 +50,7 @@ process.load('DQM.Integration.config.environment_cfi')
 #	Central DQM Customization
 #-------------------------------------
 
-if not useFileInput:
+if not useFileInput and not options.inputFiles:
     # stream label
     if process.runType.getRunType() == process.runType.hi_run:
         process.source.streamLabel = "streamHIDQMGPUvsCPU"
@@ -64,7 +64,7 @@ process.dqmSaver.runNumber = options.runNumber
 # process.dqmSaverPB.runNumber = options.runNumber
 process = customise(process)
 process.DQMStore.verbose = 0
-if not unitTest and not useFileInput :
+if not unitTest and not useFileInput and not options.inputFiles:
   if not options.BeamSplashRun :
     process.source.minEventsPerLumi = 100
 
@@ -96,13 +96,49 @@ process.siPixelTrackComparisonHarvesterAlpaka.topFolderName = cms.string('SiPixe
 if process.runType.getRunType() == process.runType.hi_run:
     process.siPixelPhase1MonitorRawDataASerial.src = 'hltSiPixelDigiErrorsPPOnAASerialSync'
     process.siPixelPhase1MonitorRawDataADevice.src = 'hltSiPixelDigiErrorsPPOnAA'
-    process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcGPU = 'hltSiPixelDigiErrorsPPOnAA'
-    process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcCPU = 'hltSiPixelDigiErrorsPPOnAASerialSync'
+
+    process.siPixelPhase1CompareDigiErrorsSoAAlpaka.pixelErrorSrcGPU = 'hltSiPixelDigiErrorsPPOnAA'
+    process.siPixelPhase1CompareDigiErrorsSoAAlpaka.pixelErrorSrcCPU = 'hltSiPixelDigiErrorsPPOnAASerialSync'
 else:
     process.siPixelPhase1MonitorRawDataASerial.src = 'hltSiPixelDigiErrorsSerialSync'
     process.siPixelPhase1MonitorRawDataADevice.src = 'hltSiPixelDigiErrors'
-    process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcGPU = 'hltSiPixelDigiErrors'
-    process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcCPU = 'hltSiPixelDigiErrorsSerialSync'
+    
+    process.siPixelPhase1CompareDigiErrorsSoAAlpaka.pixelErrorSrcGPU = 'hltSiPixelDigiErrors'
+    process.siPixelPhase1CompareDigiErrorsSoAAlpaka.pixelErrorSrcCPU = 'hltSiPixelDigiErrorsSerialSync'
+    
+    process.siPixelRecHitsSoAMonitorSerial.pixelHitsSrc = 'hltSiPixelRecHitsSoASerialSync'
+    process.siPixelRecHitsSoAMonitorSerial.TopFolderName = 'SiPixelHeterogeneous/PixelRecHitsCPU'
+    
+    process.siPixelRecHitsSoAMonitorDevice.pixelHitsSrc = 'hltSiPixelRecHitsSoA'
+    process.siPixelRecHitsSoAMonitorDevice.TopFolderName = 'SiPixelHeterogeneous/PixelRecHitsGPU'
+    
+    process.siPixelPhase1CompareRecHits.pixelHitsReferenceSoA = 'hltSiPixelRecHitsSoASerialSync'
+    process.siPixelPhase1CompareRecHits.pixelHitsTargetSoA  = 'hltSiPixelRecHitsSoA'
+    process.siPixelPhase1CompareRecHits.topFolderName = 'SiPixelHeterogeneous/PixelRecHitsCompareGPUvsCPU'
+    
+    process.siPixelTrackSoAMonitorSerial.pixelTrackSrc = 'hltPixelTracksSoASerialSync'
+    process.siPixelTrackSoAMonitorSerial.topFolderName = 'SiPixelHeterogeneous/PixelTrackCPU'
+
+    process.siPixelTrackSoAMonitorDevice.pixelTrackSrc = 'hltPixelTracksSoA'
+    process.siPixelTrackSoAMonitorDevice.topFolderName = 'SiPixelHeterogeneous/PixelTrackGPU'
+
+    process.siPixelPhase1CompareTracks.pixelTrackReferenceSoA = 'hltPixelTracksSoASerialSync'
+    process.siPixelPhase1CompareTracks.pixelTrackTargetSoA = 'hltPixelTracksSoA'
+    process.siPixelPhase1CompareTracks.topFolderName = 'SiPixelHeterogeneous/PixelTrackCompareGPUvsCPU'
+    
+    process.siPixelVertexSoAMonitorSerial.pixelVertexSrc = 'hltPixelVerticesSoASerialSync'
+    process.siPixelVertexSoAMonitorSerial.beamSpotSrc = 'hltOnlineBeamSpot'
+    process.siPixelVertexSoAMonitorSerial.topFolderName = 'SiPixelHeterogeneous/PixelVertexCPU'
+    
+    process.siPixelVertexSoAMonitorDevice.pixelVertexSrc = 'hltPixelVerticesSoA'    
+    process.siPixelVertexSoAMonitorDevice.beamSpotSrc = 'hltOnlineBeamSpot'
+    process.siPixelVertexSoAMonitorDevice.topFolderName = 'SiPixelHeterogeneous/PixelVertexGPU'
+    
+    process.siPixelCompareVertices.pixelVertexReferenceSoA = 'hltPixelVerticesSoASerialSync'
+    process.siPixelCompareVertices.pixelVertexTargetSoA = 'hltPixelVerticesSoA'
+    process.siPixelCompareVertices.beamSpotSrc = 'hltOnlineBeamSpot'
+    process.siPixelCompareVertices.topFolderName = 'SiPixelHeterogeneous/PixelVertexCompareGPUvsCPU'
+    
 #-------------------------------------
 #       Some Debug
 #-------------------------------------
@@ -112,11 +148,14 @@ process.dumpPath = cms.Path(process.dump)
 #-------------------------------------
 #	Hcal DQM Tasks/Clients Sequences Definition
 #-------------------------------------
-process.tasksPath = cms.Path(process.siPixelPhase1MonitorRawDataASerial *
-                             process.siPixelPhase1MonitorRawDataADevice *
-                             process.siPixelPhase1RawDataErrorComparator *
-                             process.siPixelHeterogeneousDQMComparisonHarvestingAlpaka
-                             )
+
+if process.runType.getRunType() == process.runType.hi_run:
+    process.tasksPath = cms.Path(process.siPixelPhase1MonitorRawDataASerial*
+                                 process.siPixelPhase1MonitorRawDataADevice*
+                                 process.siPixelPhase1CompareDigiErrorsSoAAlpaka)
+else:
+    process.tasksPath = cms.Path(process.monitorpixelSoACompareSourceAlpaka *
+                                 process.siPixelHeterogeneousDQMComparisonHarvestingAlpaka)
 
 #-------------------------------------
 #	Paths/Sequences Definitions

--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -27,10 +27,10 @@
 <test name="TestDQMOnlineClient-sistrip_dqm_sourceclient" command="runtest.sh sistrip_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-sistrip_approx_dqm_sourceclient" command="runtest.sh sistrip_approx_dqm_sourceclient-live_cfg.py 362321 hi_run"/>
 <test name="TestDQMOnlineClient-onlinebeammonitor_dqm_sourceclient" command="runtest.sh onlinebeammonitor_dqm_sourceclient-live_cfg.py 381594 pp_run"/>
-<test name="TestDQMOnlineClient-ecalgpu_dqm_sourceclient" command="runtest.sh ecalgpu_dqm_sourceclient-live_cfg.py 381594"/>
-<test name="TestDQMOnlineClient-hcalgpu_dqm_sourceclient" command="runtest.sh hcalgpu_dqm_sourceclient-live_cfg.py 381594"/>
-<test name="TestDQMOnlineClient-pixelgpu_dqm_sourceclient" command="runtest.sh pixelgpu_dqm_sourceclient-live_cfg.py 381594"/>
-<test name="TestDQMOnlineClient-pfgpu_dqm_sourceclient" command="runtest.sh pfgpu_dqm_sourceclient-live_cfg.py 381594"/>
+<test name="TestDQMOnlineClient-ecalgpu_dqm_sourceclient" command="runtest.sh ecalgpu_dqm_sourceclient-live_cfg.py 397813"/>
+<test name="TestDQMOnlineClient-hcalgpu_dqm_sourceclient" command="runtest.sh hcalgpu_dqm_sourceclient-live_cfg.py 397813"/>
+<test name="TestDQMOnlineClient-pixelgpu_dqm_sourceclient" command="runtest.sh pixelgpu_dqm_sourceclient-live_cfg.py 397813"/>
+<test name="TestDQMOnlineClient-pfgpu_dqm_sourceclient" command="runtest.sh pfgpu_dqm_sourceclient-live_cfg.py 397813"/>
 <!-- streamDQMCalibration is required -->
 <!-- <test name="TestDQMOnlineClient-ecalcalib_dqm_sourceclient" command="runtest.sh ecalcalib_dqm_sourceclient-live_cfg.py" /> -->
 <!-- streamDQMCalibration is required -->


### PR DESCRIPTION
#### PR description:

This PR is opened in preparation of the integration of the ticket [CMSHLT-3147](https://its.cern.ch/jira/browse/CMSHLT-3147).
In a nutshell that ticket suggests that the DQM plugins which are currently in the Path `DQM_PixelReconstruction_v` (Sequence: `HLTDQMPixelReconstruction`) and in the Path `DQM_PixelReconstruction_v` (Sequece `HLTDQMPixelReconstruction`) can be removed from the HLT combined table, as long as the Tracker-DPG and/or Tracking-POG experts move the corresponding monitoring sequence into the appropriate online-DQM client (which reads the `DQMGPUvsCPU` streamer files).
This latter point is proposed in this PR, in which we change the client `DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py` to include directly the modules responsible of monitoring of the GPU vs CPU comparisons, as the input data to feed them will be sent by the input `DQMGPUvsCPU`  stream.

#### PR validation:

I created a suitable set of streamer files using the following script:

```bash
#!/bin/bash -ex
RUNNUMBER=397813
LUMISECTION=131

# cmsrel CMSSW_15_1_X_2025-10-22-2300
# cd CMSSW_15_1_X_2025-10-22-2300/src/
# cmsenv
# git cms-addpkg DataFormats/TrackSoA DataFormats/TrackingRecHitSoA DQM/Integration
# git remote add AdrianoDee git@github.com:AdrianoDee/cmssw.git; git fetch AdrianoDee
# git cherry-pick 1eb24e6536182945d6f7ac55fedc023a9f0d4410
# git cherry-pick 9a3ef9ae14f452aa15d3f868b97c63f6b996b1dc
# cmsenv
# scram b

INPUTFILE=root://eoscms.cern.ch//eos/cms/store/express/Run2025F/ExpressPhysics/FEVT/Express-v2/000/397/813/00000/f95a79f9-18ef-48f1-951a-2ae78c1a107f.root
rm -rf run${RUNNUMBER}*

# run on 100 events of LS 131, with 100 events per input file
convertToRaw -f 100 -l 100 -r ${RUNNUMBER}:${LUMISECTION} -o . -- "${INPUTFILE}"

tmpfile=$(mktemp)
hltConfigFromDB --configName /users/musich/tests/dev/CMSSW_15_1_0/CMSHLT-3147/GRun > "${tmpfile}"
cat <<@EOF >> "${tmpfile}"
process.load("run${RUNNUMBER}_cff")

# to run without any HLT prescales
del process.PrescaleService
del process.MessageLogger
process.load('FWCore.MessageLogger.MessageLogger_cfi')

process.options.numberOfThreads = 32
process.options.numberOfStreams = 32

process.options.wantSummary = True
process.GlobalTag.globaltag = cms.string( "150X_dataRun3_HLT_v1" )
# # to run using the same HLT prescales as used online in LS 1000
# process.PrescaleService.forceDefault = True

from HLTrigger.Configuration.common import *
def customizeHLTFor49149(process):
    ca_producers_pp = ['CAHitNtupletAlpakaPhase1@alpaka','alpaka_serial_sync::CAHitNtupletAlpakaPhase1']
    for ca_producer in ca_producers_pp:
        for prod in producers_by_type(process, ca_producer):
            if hasattr(prod, 'geometry'):
                g = getattr(prod, 'geometry')
                g.startingPairs = cms.vuint32( [i for i in range(8)] + [i for i in range(13,19)])
                setattr(prod, 'geometry', g)
    return process

process = customizeHLTFor49149(process)
@EOF
edmConfigDump "${tmpfile}" > hlt.py

cmsRun hlt.py &> hlt.log

bash -c 'echo $$ > cmsrun.pid; exec cmsRun hlt.py &> hlt.log'
job_pid=$(cat cmsrun.pid)
echo "cmsRun is running with PID: $job_pid"

# remove input files to save space
rm -f run397813/run397813_ls0*_index*.*

# prepare the files by concatenating the .ini and .dat files
mkdir -p prepared
cat run397813/run397813_ls0000_streamDQMGPUvsCPU_pid${job_pid}.ini run397813/run397813_ls0131_streamDQMGPUvsCPU_pid${job_pid}.dat > prepared/run397813_ls0131_streamDQMGPUvsCPU_pid${job_pid}.dat
cp run397813/run397813_ls0131_streamDQMGPUvsCPU_pid${job_pid}.jsn prepared/run397813_ls0131_streamDQMGPUvsCPU_pid${job_pid}.jsn
# manually edit to remove the extra 0 in the json file.
```

and then placed the resulting files under the path `$CMSSW_BASE/src/DQM/Integration/data/run397813`.
The resulting streamers files have been committed to the `cms-data` `DQM-Integration` repository via PR https://github.com/cms-data/DQM-Integration/pull/14 (that needs to be tested together with this one).
I then run the unit test of the package via:

```bash
 scram b runtests_TestDQMOnlineClient-pixelgpu_dqm_sourceclient
 scram b runtests_TestDQMOnlineClient-hcalgpu_dqm_sourceclient
 scram b runtests_TestDQMOnlineClient-ecalgpu_dqm_sourceclient
 scram b runtests_TestDQMOnlineClient-pfgpu_dqm_sourceclient
```

and I did not observe any issues.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but it will be backported to CMSSW_15_1_X for 2025 datat-taking operations.