### PR TITLE
Add Run3_2025_NEON in Eras.py

### DIFF
--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -58,6 +58,7 @@ class Eras (object):
                  'Run3_2025_UPC',
                  'Run3_2025_OXY',
                  'Run3_2025_UPC_OXY',
+                 'Run3_2025_NEON',
                  'Run3_2025_FastSim',
                  'Phase2',
                  'Phase2_noMkFit',


### PR DESCRIPTION
#### PR description:

This PR adds the era Run3_2025_NEON (introduced in https://github.com/cms-sw/cmssw/pull/48597) in the list of eras in Eras.py to be used for MC production of NeNe collision data.

@mandrenguyen

#### PR validation:

Tested locally

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 15_1_X and 15_0_X
