### PR TITLE
[15_0_X] Add Run3_2025_NEON in Eras.py

### DIFF
--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -58,6 +58,7 @@ class Eras (object):
                  'Run3_2025_UPC',
                  'Run3_2025_OXY',
                  'Run3_2025_UPC_OXY',
+                 'Run3_2025_NEON',
                  'Phase2',
                  'Phase2C9',
                  'Phase2C10',


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/49240

@mandrenguyen 
