### PR TITLE
[15_1_X] Add Run3_2025_NEON in Eras.py

### DIFF
--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -58,6 +58,7 @@ class Eras (object):
                  'Run3_2025_UPC',
                  'Run3_2025_OXY',
                  'Run3_2025_UPC_OXY',
+                 'Run3_2025_NEON',
                  'Run3_2025_FastSim',
                  'Phase2',
                  'Phase2_noMkFit',


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/49240

@mandrenguyen 
