### PR TITLE
[CMSSW_15_1_X] Update for Labels of GE2/1 Layers on GEM online DQM to backport 15_1_X

### DIFF
--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -604,6 +604,7 @@ protected:
   };
 
   int SortingLayers(std::vector<ME4IdsKey> &listLayers);
+  int getDisplayModuleNumber(int station, int layer, int module_number);
   dqm::impl::MonitorElement *CreateSummaryHist(DQMStore::IBooker &ibooker, TString strName);
 
   template <typename T>
@@ -755,7 +756,7 @@ inline std::string GEMDQMBase::getNameDirLayer(ME4IdsKey key4) {
   char cRegion = (keyToRegion(key4) > 0 ? 'P' : 'M');
   auto nLayer = keyToLayer(key4);
   if (nStation == 2) {
-    auto nModule = keyToModule(key4);
+    auto nModule = getDisplayModuleNumber(nStation, nLayer, keyToModule(key4));
     return std::string(Form("GE%i1-%c-L%i-M%i", nStation, cRegion, nLayer, nModule));
   }
   return std::string(Form("GE%i1-%c-L%i", nStation, cRegion, nLayer));

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -166,7 +166,8 @@ int GEMRecHitSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
       mapCLSOver5_.FindHist(key)->setYTitle("Module");
     }
     for (Int_t i = 1; i <= stationInfo.nNumModules_; i++) {
-      std::string strLabel = std::string(Form("M%i", i));
+      Int_t module_number = getDisplayModuleNumber(keyToStation(key), keyToLayer(key), i);
+      std::string strLabel = std::string(Form("M%i", module_number));
       if (mapCLSAverage_.isOperating()) {
         mapCLSAverage_.FindHist(key)->setBinLabel(i, strLabel, 2);
       }
@@ -199,7 +200,8 @@ int GEMRecHitSource::ProcessWithMEMap4WithChamber(BookingHelper& bh, ME4IdsKey k
       mapCLSPerCh_.FindHist(key)->setYTitle("Module");
     }
     for (Int_t i = 1; i <= stationInfo.nNumModules_; i++) {
-      std::string strLabel = std::string(Form("M%i", i));
+      Int_t module_number = getDisplayModuleNumber(keyToStation(key), keyToLayer(key), i);
+      std::string strLabel = std::string(Form("M%i", module_number));
       if (mapCLSPerCh_.isOperating()) {
         mapCLSPerCh_.FindHist(key)->setBinLabel(i, strLabel, 2);
       }

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -147,6 +147,13 @@ int GEMDQMBase::SortingLayers(std::vector<ME4IdsKey>& listLayers) {
   return 0;
 }
 
+int GEMDQMBase::getDisplayModuleNumber(int station, int layer, int module_number) {
+  // For GE2/1 Layer 1, labeling module numbers as 5–8 instead of 1–4
+  if (station == 2 && layer == 1)
+    return module_number + 4;
+  return module_number;
+}
+
 dqm::impl::MonitorElement* GEMDQMBase::CreateSummaryHist(DQMStore::IBooker& ibooker, TString strName) {
   std::vector<ME4IdsKey> listLayers;
   for (auto const& [key3, stationInfo] : mapStationInfo_) {
@@ -175,14 +182,15 @@ dqm::impl::MonitorElement* GEMDQMBase::CreateSummaryHist(DQMStore::IBooker& iboo
 
     auto region = keyToRegion(key);
     auto strInfo = GEMUtils::getSuffixName(key3);  // NOTE: It starts with '_'
+    auto module_number = getDisplayModuleNumber(keyToStation(key), keyToLayer(key), keyToModule(key));
     if (mapStationInfo_[key3].nNumModules_ > 1) {
-      strInfo += Form("-M%i", keyToModule(key));
+      strInfo += Form("-M%i", module_number);
     }
     auto label = Form("GE%+i1-%cL%i-M%i;%s",
                       region * keyToStation(key),
                       (region > 0 ? 'P' : 'M'),
                       keyToLayer(key),
-                      keyToModule(key),
+                      module_number,
                       strInfo.Data());
     h2Res->setBinLabel(i, label, 2);
     Int_t nNumCh = mapStationInfo_[key3].nNumChambers_;
@@ -246,8 +254,10 @@ int GEMDQMBase::GenerateMEPerChamber(DQMStore::IBooker& ibooker) {
       if (!MEMap4Check_[key4]) {
         Int_t nLa = gid.layer();
         TString strSuffixCh = Form("-L%i", nLa);
-        if (mapStationInfo_[key3].nNumModules_ > 1)
-          strSuffixCh = Form("-L%i-M%i", nLa, module_number);
+        if (mapStationInfo_[key3].nNumModules_ > 1) {
+          Int_t nMo = getDisplayModuleNumber(gid.station(), nLa, module_number);
+          strSuffixCh = Form("-L%i-M%i", nLa, nMo);
+        }
         auto strSuffixName = GEMUtils::getSuffixName(key2) + strSuffixCh;
         auto strSuffixTitle = GEMUtils::getSuffixTitle(key2) + strSuffixCh;
         BookingHelper bh4(ibooker, strSuffixName, strSuffixTitle);
@@ -270,8 +280,10 @@ int GEMDQMBase::GenerateMEPerChamber(DQMStore::IBooker& ibooker) {
         Int_t nLa = gid.layer();
         char cLS = (nCh % 2 == 0 ? 'L' : 'S');  // FIXME: Is it general enough?
         TString strSuffixCh = Form("-%02iL%i-%c", nCh, nLa, cLS);
-        if (mapStationInfo_[key3].nNumModules_ > 1)
-          strSuffixCh = Form("-%02iL%i-M%i-%c", nCh, nLa, module_number, cLS);
+        if (mapStationInfo_[key3].nNumModules_ > 1) {
+          Int_t nMo = getDisplayModuleNumber(gid.station(), nLa, module_number);
+          strSuffixCh = Form("-%02iL%i-M%i-%c", nCh, nLa, nMo, cLS);
+        }
         auto strSuffixName = GEMUtils::getSuffixName(key2) + strSuffixCh;
         auto strSuffixTitle = GEMUtils::getSuffixTitle(key2) + strSuffixCh;
         BookingHelper bh5Ch(ibooker, strSuffixName, strSuffixTitle);


### PR DESCRIPTION
#### PR description:

In this PR, GEM online DQM plots for GE2/1 Layer 1 labels have been implemented. (backport)

#### PR validation:

Tests are done with cmsRun $CMSSW_BASE/src/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py unitTest=True runNumber=396180 dataset=/ExpressPhysics/Run2025E-Express-v1/FEVT and runTheMatrix.py -l limited -i all --ibeos since it makes effects on P5 and reconstruction

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/49191 to 15_1_X

@jshlee @watson-ij @Dongwoon77 @hyokyu-choi