### PR TITLE
Update Disabled ROCs for Online DQM Pixel Summary [15_1_X]

### DIFF
--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -272,7 +272,7 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
   //Fill the dead ROC summary
   std::vector<trendPlots> trendOrder = {layer1, layer2, layer3, layer4, ring1, ring2};
   std::vector<int> nRocsPerTrend = {1536, 3584, 5632, 8192, 4224, 6528};
-  std::vector<int> nDisabledRocs = {12, 128, 240, 320, 96, 120};
+  std::vector<int> nDisabledRocs = {16, 152, 272, 320, 368, 256};
   for (unsigned int i = 0; i < trendOrder.size(); i++) {
     int xBin = i < 4 ? 1 : 2;
     int yBin = i % 4 + 1;


### PR DESCRIPTION
#### PR description:

Update number of disabled ROCs (used in calculation of the fraction of "good" ROCs for the Online DQM Pixel Summary map, see May 2024 PR https://github.com/cms-sw/cmssw/pull/45027 ).
Since May 2024, new dead modules, i.e. Disk -1 region, DCDC modules in Ring 1, ...

#### PR validation:
Just update number on request of Pixel Ops team.

#### Backport
This PR is intended for 2025 data taking.
Backport to 15_1_X of original PR: https://github.com/cms-sw/cmssw/pull/49305