### PR TITLE
MaterialBudgetData: Return a const& to string instead of making a copy

### DIFF
--- a/Validation/Geometry/interface/MaterialBudgetData.h
+++ b/Validation/Geometry/interface/MaterialBudgetData.h
@@ -131,7 +131,7 @@ public:
   int getNumberOfSteps() const { return theStepN; }
 
   float getTrkLen() const { return theTrkLen; }
-  std::string getPVname() const { return thePVname; }
+  const std::string& getPVname() const { return thePVname; }
   int getPVcopyNo() const { return thePVcopyNo; }
   float getRadLen() const { return theRadLen; }
   float getIntLen() const { return theIntLen; }
@@ -211,7 +211,7 @@ public:
   int getStepPostProcess(int is) { return theStepPostProcess[is]; }
 
   int getStepVolumeID(int is) { return theVolumeID[is]; }
-  std::string getStepVolumeName(int is) { return theVolumeName[is]; }
+  const std::string& getStepVolumeName(int is) { return theVolumeName[is]; }
   int getStepVolumeCopy(int is) { return theVolumeCopy[is]; }
   float getStepVolumeX(int is) { return theVolumeX[is]; }
   float getStepVolumeY(int is) { return theVolumeY[is]; }
@@ -226,7 +226,7 @@ public:
     return CLHEP::HepLorentzVector(theVolumeZaxis1[is], theVolumeZaxis2[is], theVolumeZaxis3[is]);
   }
   int getStepMaterialID(int is) { return theMaterialID[is]; }
-  std::string getStepMaterialName(int is) { return theMaterialName[is]; }
+  const std::string& getStepMaterialName(int is) { return theMaterialName[is]; }
   float getStepMaterialX0(int is) { return theMaterialX0[is]; }
   float getStepMaterialLambda0(int is) { return theMaterialLambda0[is]; }
   float getStepMaterialDensity(int is) { return theMaterialDensity[is]; }


### PR DESCRIPTION
In CLANG_X IBs (with llvm21), we have couple of warnings like [a]. This is because `MaterialBudgetData` returns a copy of `std::string` which gets destroyed after the `getStepVolumeName` or `getStepMaterialName` call. This PR proposes to change `MaterialBudgetData` class and return a `const std::string&` nstead of a copy. This should fix the compilation warning and should also avoid `string` copy


[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc13/CMSSW_16_0_CLANG_X_2025-10-28-2300/Validation/Geometry
```
[src/Validation/Geometry/src/MaterialBudgetTree.cc:161](https://github.com/cms-sw/cmssw/blob/CMSSW_16_0_CLANG_X_2025-10-28-2300/Validation/Geometry/src/MaterialBudgetTree.cc#L161):26: warning: object backing the pointer 'this->t_VolumeName[ii]' will be destroyed at the end of the full-expression [-Wdangling-assignment-gsl]
   161 |       t_VolumeName[ii] = theData->getStepVolumeName(ii).c_str();
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  [src/Validation/Geometry/src/MaterialBudgetTree.cc:177](https://github.com/cms-sw/cmssw/blob/CMSSW_16_0_CLANG_X_2025-10-28-2300/Validation/Geometry/src/MaterialBudgetTree.cc#L177):28: warning: object backing the pointer 'this->t_MaterialName[ii]' will be destroyed at the end of the full-expression [-Wdangling-assignment-gsl]
   177 |       t_MaterialName[ii] = theData->getStepMaterialName(ii).c_str();
```