### PR TITLE
MkFitCore/Track: Fix for llvm21 warning calling bzero on pointer to non-trivially copyable type

### DIFF
--- a/RecoTracker/MkFitCore/interface/Track.h
+++ b/RecoTracker/MkFitCore/interface/Track.h
@@ -432,8 +432,6 @@ namespace mkfit {
     // Used by TrackCand::ExportTrack
     void setHitIdxAtPos(int pos, const HitOnTrack& hot) { hitsOnTrk_[pos] = hot; }
 
-    void resizeHitsForInput();
-
     void addHitIdx(int hitIdx, int hitLyr, float chi2) {
       hitsOnTrk_.push_back({hitIdx, hitLyr});
       ++lastHitIdx_;
@@ -489,6 +487,8 @@ namespace mkfit {
       }
       return mcHitID;
     }
+
+    const std::vector<HitOnTrack>& refHitsOnTrackVector() const { return hitsOnTrk_; }
 
     const HitOnTrack* getHitsOnTrackArray() const { return hitsOnTrk_.data(); }
     const HitOnTrack* beginHitsOnTrack() const { return hitsOnTrk_.data(); }

--- a/RecoTracker/MkFitCore/src/Track.cc
+++ b/RecoTracker/MkFitCore/src/Track.cc
@@ -386,11 +386,6 @@ namespace mkfit {
   // Track
   //==============================================================================
 
-  void Track::resizeHitsForInput() {
-    bzero(&hitsOnTrk_, sizeof(hitsOnTrk_));
-    hitsOnTrk_.resize(lastHitIdx_ + 1);
-  }
-
   void Track::sortHitsByLayer() {
     std::stable_sort(&hitsOnTrk_[0], &hitsOnTrk_[lastHitIdx_ + 1], [](const auto& h1, const auto& h2) {
       return h1.layer < h2.layer;

--- a/RecoTracker/MkFitCore/standalone/Event.cc
+++ b/RecoTracker/MkFitCore/standalone/Event.cc
@@ -6,6 +6,7 @@
 #include "RecoTracker/MkFitCore/src/Debug.h"
 
 #include <memory>
+#include <cstring>
 
 namespace {
   std::unique_ptr<mkfit::Validation> dummyValidation(mkfit::Validation::make_validation("dummy", nullptr));
@@ -451,8 +452,10 @@ namespace mkfit {
       fread(tracks.data(), sizeof(Track), n_tracks, fp);
 
       for (int i = 0; i < n_tracks; ++i) {
-        tracks[i].resizeHitsForInput();
-        fread(tracks[i].beginHitsOnTrack_nc(), sizeof(HitOnTrack), tracks[i].nTotalHits(), fp);
+        auto &hot_vec = const_cast<std::vector<HitOnTrack> &>(tracks[i].refHitsOnTrackVector());
+        memset((void *)&hot_vec, 0, sizeof(hot_vec));
+        hot_vec.resize(tracks[i].nTotalHits());
+        fread(hot_vec.data(), sizeof(HitOnTrack), tracks[i].nTotalHits(), fp);
       }
     }
 


### PR DESCRIPTION
In CLANG_X Ibs (with llvm21), we get compilation warnings like [a]. As `hitsOnTrk_` which is `std::vector<HitOnTrack>` a non-trivially copyable type that is why compiler complains. `bzero` is going to zero out only memory of `std::vector` itself and not the items it contains. This PR proposes to use `vector::clear()` to clean up the existing items.

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc13/CMSSW_16_0_CLANG_X_2025-10-28-2300/RecoTracker/MkFitCore
```
[src/RecoTracker/MkFitCore/src/Track.cc:390](https://github.com/cms-sw/cmssw/blob/CMSSW_16_0_CLANG_X_2025-10-28-2300/RecoTracker/MkFitCore/src/Track.cc#L390):11: warning: first argument in call to 'bzero' is a pointer to non-trivially copyable type 'std::vector<HitOnTrack>' [-Wnontrivial-memcall]
   390 |     bzero(&hitsOnTrk_, sizeof(hitsOnTrk_));
      |           ^
src/RecoTracker/MkFitCore/src/Track.cc:390:11: note: explicitly cast the pointer to silence this warning
  390 |     bzero(&hitsOnTrk_, sizeof(hitsOnTrk_));
      |           ^
      |           (void*)
```


**After the discussion in https://github.com/cms-sw/cmssw/pull/49251#pullrequestreview-3393318855 , now `Track::resizeHitsForInput()` is removed from class and code is moved to standalone test which actually needed it. Warnings was avoided by `(void*)` casting the pointer to non-trivially copyable type and squashed changes**