### PR TITLE
Add pixel charge and deltaphi to LST ntuple

### DIFF
--- a/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
@@ -456,6 +456,8 @@ void createPixelLineSegmentBranches() {
   ana.tx->createBranch<std::vector<float>>("pLS_py");
   ana.tx->createBranch<std::vector<float>>("pLS_pz");
   ana.tx->createBranch<std::vector<bool>>("pLS_isQuad");
+  ana.tx->createBranch<std::vector<int>>("pLS_charge");
+  ana.tx->createBranch<std::vector<float>>("pLS_deltaPhi");
 }
 
 //________________________________________________________________________________________________________________________________
@@ -1466,16 +1468,18 @@ std::map<unsigned int, unsigned int> setPixelLineSegmentBranches(LSTEvent* event
     ana.tx->pushbackToBranch<float>("pLS_py", pixelSeeds.py()[ipLS]);
     ana.tx->pushbackToBranch<float>("pLS_pz", pixelSeeds.pz()[ipLS]);
     ana.tx->pushbackToBranch<bool>("pLS_isQuad", static_cast<bool>(pixelSeeds.isQuad()[ipLS]));
+    ana.tx->pushbackToBranch<int>("pLS_charge", pixelSeeds.charge()[ipLS]);
+    ana.tx->pushbackToBranch<float>("pLS_deltaPhi", pixelSeeds.deltaPhi()[ipLS]);
     ana.tx->pushbackToBranch<int>("pLS_nhit", hit_idx.size());
     for (size_t ihit = 0; ihit < trk_see_hitIdx[ipLS].size(); ++ihit) {
       int hitidx = trk_see_hitIdx[ipLS][ihit];
       int hittype = trk_see_hitType[ipLS][ihit];
-      int x = trk_pix_x[hitidx];
-      int y = trk_pix_y[hitidx];
-      int z = trk_pix_z[hitidx];
-      ana.tx->pushbackToBranch<float>(TString::Format("pLS_hit%d_x", ihit), x);
-      ana.tx->pushbackToBranch<float>(TString::Format("pLS_hit%d_y", ihit), y);
-      ana.tx->pushbackToBranch<float>(TString::Format("pLS_hit%d_z", ihit), z);
+      auto const& x = trk_pix_x[hitidx];
+      auto const& y = trk_pix_y[hitidx];
+      auto const& z = trk_pix_z[hitidx];
+      ana.tx->pushbackToBranch<float>(TString::Format("pLS_hit%zu_x", ihit), x);
+      ana.tx->pushbackToBranch<float>(TString::Format("pLS_hit%zu_y", ihit), y);
+      ana.tx->pushbackToBranch<float>(TString::Format("pLS_hit%zu_z", ihit), z);
     }
     if (trk_see_hitIdx[ipLS].size() == 3) {
       ana.tx->pushbackToBranch<float>("pLS_hit3_x", -999);


### PR DESCRIPTION
#### PR description:

Here's a PR which adds two pixel (pLS) variables to the LST ntuple which were helpful while studying pLS/T5 track embedding. It also changes pLS xyz to floats instead of ints (they should be floats), and addresses a compiler warning for signed int instead of size_t.

#### PR validation:

I ran this code locally and it works fine.


