### PR TITLE
LHCInfoPerLS endFill conflicting IOVs fix

### DIFF
--- a/CondTools/RunInfo/src/LHCInfoPerLSPopConSourceHandler.cc
+++ b/CondTools/RunInfo/src/LHCInfoPerLSPopConSourceHandler.cc
@@ -35,7 +35,8 @@ namespace theLHCInfoPerLSImpl {
                           std::shared_ptr<LHCInfoPerLS>& prevPayload,
                           const std::map<pair<cond::Time_t, unsigned int>, pair<cond::Time_t, unsigned int>>& lsIdMap,
                           cond::Time_t startStableBeamTime,
-                          cond::Time_t endStableBeamTime) {
+                          cond::Time_t endStableBeamTime,
+                          cond::Time_t lastSince) {
     int lsMissingInPPS = 0;
     int xAngleBothZero = 0, xAngleBothNonZero = 0, xAngleNegative = 0;
     int betaNegative = 0;
@@ -46,6 +47,7 @@ namespace theLHCInfoPerLSImpl {
       bool add = false;
       auto payload = iov.second;
       cond::Time_t since = iov.first;
+      // check if payload is different from the last one added to avoid duplicates
       if (iovsToTransfer.empty()) {
         add = true;
       } else {
@@ -53,6 +55,14 @@ namespace theLHCInfoPerLSImpl {
         if (!comparePayloads(lastAdded, *payload)) {
           add = true;
         }
+      }
+      // skip payloads with IOV <= lastSince to avoid violating synchornization rules
+      if (since <= lastSince) {
+        add = false;
+        edm::LogWarning("transferPayloads")
+            << "Skipping upload of payload with IOV <= last IOV of the destination tag: "
+            << " (since=" << since << ", lastSince=" << lastSince << ")\n"
+            << *payload;
       }
       auto id = make_pair(payload->runNumber(), payload->lumiSection());
       bool stableBeam = since >= startStableBeamTime && since <= endStableBeamTime;
@@ -164,22 +174,18 @@ void LHCInfoPerLSPopConSourceHandler::handleInvalidPayloads() {
   // but iterating through the whole map is implemented just in case the way it's used changes
   auto it = m_iovs.begin();
   while (it != m_iovs.end()) {
-    std::stringstream payloadData;
-    payloadData << "LS = " << it->second->lumiSection() << ", run = " << it->second->runNumber() << ", "
-                << "xAngleX = " << it->second->crossingAngleX() << " urad, "
-                << "xAngleY = " << it->second->crossingAngleY() << " urad, "
-                << "beta*X = " << it->second->betaStarX() << " m, "
-                << "beta*Y = " << it->second->betaStarY() << " m";
-    if (!isPayloadValid(*(it->second))) {
-      std::string msg = "Skipping upload of payload with invalid values: " + payloadData.str();
+    auto payload = it->second;
+    if (!isPayloadValid(*payload)) {
+      std::ostringstream msg;
+      msg << "Skipping upload of payload with invalid values: " << *payload;
       if (m_throwOnInvalid) {
-        throw cms::Exception("LHCInfoPerLSPopConSourceHandler") << msg;
+        throw cms::Exception("LHCInfoPerLSPopConSourceHandler") << msg.str();
       } else {
-        edm::LogWarning(m_name) << msg;
+        edm::LogWarning(m_name) << msg.str();
       }
       m_iovs.erase(it++);  // note: post-increment necessary to avoid using invalidated iterators
     } else {
-      edm::LogInfo(m_name) << "Payload to be uploaded: " << payloadData.str();
+      edm::LogInfo(m_name) << "Payload to be uploaded: " << *payload;
       ++it;
     }
   }
@@ -241,6 +247,7 @@ void LHCInfoPerLSPopConSourceHandler::populateIovs() {
   //create the sessions
   cond::persistency::Session session = connection.createSession(m_connectionString, false);
   // fetch last payload when available
+
   if (!tagInfo().lastInterval.payloadId.empty()) {
     cond::persistency::Session session3 = dbSession();
     session3.transaction().start(true);
@@ -394,7 +401,7 @@ void LHCInfoPerLSPopConSourceHandler::populateIovs() {
     }
 
     size_t niovs = theLHCInfoPerLSImpl::transferPayloads(
-        m_tmpBuffer, m_iovs, m_prevPayload, m_lsIdMap, m_startStableBeamTime, m_endStableBeamTime);
+        m_tmpBuffer, m_iovs, m_prevPayload, m_lsIdMap, m_startStableBeamTime, m_endStableBeamTime, lastSince);
     edm::LogInfo(m_name) << "Added " << niovs << " iovs within the Fill time";
     m_tmpBuffer.clear();
     m_lsIdMap.clear();
@@ -523,6 +530,9 @@ size_t LHCInfoPerLSPopConSourceHandler::getLumiData(const cond::OMSService& oms,
   auto query = oms.query("lumisections");
   query->addOutputVars({"start_time", "run_number", "beams_stable", "lumisection_number"});
   query->filterEQ("fill_number", fillId);
+  // note: the filtering on OMS side works in precision of milliseconds but the values return by OMS have precision of seconds
+  // this makes the GT and GE behave unexpectedly
+  // (GT for 10:00:00 can return also 10:00:00 and GE can skip it depending on the milliseconds part of the value stored in OMS)
   query->filterGT("start_time", beginFillTime).filterLT("start_time", endFillTime);
   query->limit(cond::lhcInfoHelper::kLumisectionsQueryLimit);
   size_t nlumi = 0;
@@ -546,6 +556,7 @@ size_t LHCInfoPerLSPopConSourceHandler::getLumiData(const cond::OMSService& oms,
   }
   return nlumi;
 }
+
 bool LHCInfoPerLSPopConSourceHandler::getCTPPSData(cond::persistency::Session& session,
                                                    const boost::posix_time::ptime& beginFillTime,
                                                    const boost::posix_time::ptime& endFillTime) {


### PR DESCRIPTION
#### PR description:

This PR prevents LHCInfoPerLS O2O from trying to overwrite IOVs  (upload a payload with an IOV that's already in a tag) as this resulted in errors when writing to tags with synchronization different than `any` or `validation`.

In some (not all) cases, when the start_time of the first LS of a fill was the same as the end time of the previous fill (both fills with stable beams) the LHCInfoPerLS O2O was trying to overwrite an IOV, which results with an error for tags with synchronisation. Why does it happen only in some cases?: The list of lumisections of a fill is taken from OMS and filtered by start_time. OMS returns start_time in precision of seconds, and the filtering works in precision of milliseconds. Also the IOV is being saved in precision of seconds. This makes the filtering of lumisections with start_time greater than the start of the fill seem to behave inconsistently when dealing with values in precision of seconds. 

Report from the error happening in production https://cmsonline.cern.ch/cms-elog/1310230

#### PR validation:

The production O2O was modified to run on this code on 28.10.2025 (running on a local CMSSW environment with these changes). It fixed the error and repopulated the data. No problems were detected.

Additionally tested locally: 
prepared local .dbs with the last IOVs of the problematic fills:
```
conddb copy LHCInfoPerLS_endFill_Run3_v3 LHCInfoPerLS_endFill_Run3_v3_test     --destdb sqlite:test_case_1_org.db     --from 7564053886386831360     --to 7564053886386831360     --type tag

conddb copy LHCInfoPerLS_endFill_Run3_v3 LHCInfoPerLS_endFill_Run3_v3_test     --destdb sqlite:logs/test_case_3_org.db     --from 7563816469184643072     --to 7563816469184643072     --type tag
```

and run the o2o for these dbs:
```
cmsRun ../python/LHCInfoPerLSPopConAnalyzer_cfg.py mode=endFill destinationConnection=sqlite:logs/test_case_${TEST_CASE}_${TEST_NR}.db tag=LHCInfoPerLS_endFill_Run3_v3_test startTime='2025-06-26 15:43:20.000' | tee logs/log_test_${TEST_CASE}_${TEST_NR}.log
```


#### Backports

15_0
15_1