### PR TITLE
[NGT] Add support for older geometries in PixelTracking CA

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelPhase2DigiToCluster.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelPhase2DigiToCluster.cc
@@ -13,13 +13,17 @@
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
 #include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsSoACollection.h"
 #include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisSoACollection.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "Geometry/CommonTopologies/interface/GeomDetEnumerators.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/EDPutToken.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/SynchronizingEDProducer.h"
@@ -41,8 +45,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   private:
     void acquire(device::Event const& iEvent, device::EventSetup const& iSetup) override;
     void produce(device::Event& iEvent, device::EventSetup const& iSetup) override;
+    void beginRun(edm::Run const&, edm::EventSetup const& iSetup) override;
 
     const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+    const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomTokenBeginRun_;  // For BeginRun
+    const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+
     const edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> pixelDigiToken_;
     const device::EDPutToken<SiPixelDigisSoACollection> digiPutToken_;
     const device::EDPutToken<SiPixelClustersSoACollection> clusterPutToken_;
@@ -51,11 +59,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     Algo algo_;
     uint32_t nDigis_ = 0;
     std::optional<SiPixelDigisSoACollection> digis_d_;
+    mutable uint32_t offsetBPIX2_ = pixelTopology::Phase2::layerStart[1];
   };
 
   SiPixelPhase2DigiToCluster::SiPixelPhase2DigiToCluster(const edm::ParameterSet& iConfig)
       : SynchronizingEDProducer(iConfig),
         geomToken_(esConsumes()),
+        geomTokenBeginRun_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
+        topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()),
         pixelDigiToken_(consumes<edm::DetSetVector<PixelDigi>>(iConfig.getParameter<edm::InputTag>("InputDigis"))),
         digiPutToken_(produces()),
         clusterPutToken_(produces()),
@@ -79,6 +90,44 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     desc.add<uint32_t>("Phase2KinkADC", 8);
     desc.add<edm::InputTag>("InputDigis", edm::InputTag("simSiPixelDigis:Pixel"));
     descriptions.addWithDefaultLabel(desc);
+  }
+  void SiPixelPhase2DigiToCluster::beginRun(edm::Run const&, edm::EventSetup const& iSetup) {
+    using namespace pixelTopology;
+
+    auto const& trackerGeometry = iSetup.getData(geomTokenBeginRun_);
+    auto const& trackerTopology = iSetup.getData(topoToken_);
+
+    auto const& dets = trackerGeometry.detUnits();
+
+    uint32_t n_modules = 0;
+    uint32_t oldLayer = std::numeric_limits<uint32_t>::max();
+    uint32_t layerCount = 0;
+    uint32_t bpix2Start = 0;
+
+    // Loop over detector modules to find where BPIX2 starts
+    for (auto& det : dets) {
+      if (!GeomDetEnumerators::isInnerTracker(det->subDetector()))
+        continue;
+
+      DetId detId = det->geographicalId();
+      auto layer = trackerTopology.layer(detId);
+
+      if (layer != oldLayer) {
+        if (layerCount == 1) {
+          // layer 1 is BPIX2
+          bpix2Start = n_modules;
+        }
+        layerCount++;
+        oldLayer = layer;
+      }
+      n_modules++;
+    }
+
+    offsetBPIX2_ = bpix2Start;
+
+    LogDebug("SiPixelPhase2DigiToCluster")
+        << "beginRun: BPIX2 module start = " << offsetBPIX2_ << " (total pixel modules: " << n_modules
+        << "). Offset from simplePixelTopology = " << pixelTopology::Phase2::layerStart[1] << '\n';
   }
 
   void SiPixelPhase2DigiToCluster::acquire(device::Event const& iEvent, device::EventSetup const& iSetup) {
@@ -117,7 +166,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     assert(nDigis == nDigis_);
 
     alpaka::memcpy(iEvent.queue(), digis_d_->buffer(), digis_h.buffer());
-    algo_.makePhase2ClustersAsync(iEvent.queue(), clusterThresholds_, digis_d_->view(), nDigis_);
+    algo_.makePhase2ClustersAsync(iEvent.queue(), clusterThresholds_, digis_d_->view(), nDigis_, offsetBPIX2_);
   }
 
   void SiPixelPhase2DigiToCluster::produce(device::Event& iEvent, device::EventSetup const& iSetup) {

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
@@ -661,7 +661,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         Queue &queue,
         const SiPixelClusterThresholds clusterThresholds,
         SiPixelDigisSoAView &digis_view,
-        const uint32_t numDigis) {
+        const uint32_t numDigis,
+        const uint32_t offsetBPIX2) {
       using namespace pixelClustering;
       using pixelTopology::Phase2;
       nDigis = numDigis;
@@ -744,7 +745,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       // last element holds the number of all clusters
       const auto clusModuleStartLastElement = cms::alpakatools::make_device_view(
           queue, clusters_d->const_view().clusModuleStart().data() + numberOfModules, 1u);
-      constexpr int startBPIX2 = pixelTopology::Phase2::layerStart[1];
+      const int startBPIX2 = offsetBPIX2;
       // element startBPIX2 hold the number of clusters until BPIX2
       const auto bpix2ClusterStart =
           cms::alpakatools::make_device_view(queue, clusters_d->const_view().clusModuleStart().data() + startBPIX2, 1u);

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.h
@@ -168,7 +168,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       void makePhase2ClustersAsync(Queue& queue,
                                    const SiPixelClusterThresholds clusterThresholds,
                                    SiPixelDigisSoAView& digis_view,
-                                   const uint32_t numDigis);
+                                   const uint32_t numDigis,
+                                   const uint32_t offsetBPIX2);
 
       SiPixelDigisSoACollection getDigis() {
         digis_d->setNModules(nModules_Clusters_h[0]);


### PR DESCRIPTION
#### PR description:
Since #48921 made the alpaka-based PixelTracking CA default for Phase 2 we have observed some failures in IB tests, mostly related to older geometries failing an assertion in the CA code (see #49266). The root cause has been investigated and found to be in the way used to compute `offsetBPIX2` https://github.com/cms-sw/cmssw/issues/49266#issuecomment-3470624939.
This PR implements a more flexible computation based on the geometry instead of using an hard-coded constant stored in `simplePixelTopology.h` 

#### PR validation:

Tested locally on workflows that were failing in the latest IB: `23634.0, 24834.0,25234.0,25634.0,26034.0,26834.0` plus a D110 reference `29634.0`.
Run 3 performance is unaffected, verified using the following recipe
```bash
#!/bin/bash -ex

cmsDriver.py step2 -s HLT:@relval2025,VALIDATION:hltMultiTrackValidation \
    --conditions auto:phase1_2025_realistic \
    --datatier DQMIO \
    -n 1000 \
    --eventcontent DQMIO \
    --geometry DB:Extended \
    --era Run3_2025 \
    --filein file:/eos/cms/store/relval/CMSSW_16_0_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_151X_mcRun3_2025_realistic_v4_STD_2025_PU-v1/2590000/0003c424-1e5a-4177-adbe-5afbbb578af1.root \
    --fileout file:step2.root \
    --nThreads 32 \
    --process HLTX \
    --inputCommands='keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT' \
    >step2.log 2>&1

cmsDriver.py step3 -s HARVESTING:postProcessorHLTtrackingSequence \
    --conditions auto:phase1_2025_realistic \
    --mc \
    --geometry DB:Extended \
    --scenario pp \
    --filetype DQM \
    --era Run3_2025 \
    -n 1000 \
    --filein file:step2.root \
    --fileout file:step3.root >step3.log 2>&1
```
before and after the fix (full plots [here](https://lferragi.web.cern.ch/plots/tracking_phase2/CAExtPR/postMergeIssue49266/run3/comparison/)).

Phase-2 CA (and CA Extension) physics performance is also unaffected and reflects the results in #48921.
