### PR TITLE
[FSC DQMn - master]: Initial commit of FSC plus implementation in DQM.

### DIFF
--- a/DQM/HcalTasks/interface/ZDCQIE10Task.h
+++ b/DQM/HcalTasks/interface/ZDCQIE10Task.h
@@ -37,12 +37,14 @@ protected:
 
   //	tags
   edm::InputTag _tagQIE10;
+  edm::InputTag _tagData;
   edm::InputTag sumTag;
   edm::InputTag sumTagUnpacked;
   edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
   edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDbServiceToken_;
   edm::EDGetToken sumToken_;
   edm::EDGetToken sumTokenUnpacked_;
+  edm::EDGetToken sumTokenData_;
   edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> htopoToken_;
   edm::ESGetToken<HcalLongRecoParams, HcalLongRecoParamsRcd> paramsToken_;
 
@@ -64,6 +66,8 @@ protected:
   std::map<uint32_t, MonitorElement *> _cZDC_BXSUMS;
   std::map<uint32_t, MonitorElement *> _cZDC_BX_EmuSUMS;
   std::map<uint32_t, MonitorElement *> _cZDC_EmuSumTP_DataSum;
+  std::map<uint32_t, MonitorElement *> _cZDC_EmuSumTP_L1rcvdSum;
+  std::map<uint32_t, MonitorElement *> _cZDC_L1rcvdSumTP_DataSum;
   std::map<uint32_t, MonitorElement *> _cZDC_CapIDS;
   std::map<uint32_t, MonitorElement *> _cfC_EChannel;
   std::map<uint32_t, MonitorElement *> _cTDC_EChannel;

--- a/DQM/HcalTasks/interface/ZDCQIE10Task.h
+++ b/DQM/HcalTasks/interface/ZDCQIE10Task.h
@@ -77,7 +77,7 @@ protected:
 
   std::unique_ptr<HcalLongRecoParams> longRecoParams_;
 
-  // ZDC params 
+  // ZDC params
   static constexpr int kZDCAbsIEta = 42;
   static constexpr int kZDCiEtSumsIPhi = 99;
   static constexpr int kZDCiEtSumMaxValue = 1023;

--- a/DQM/HcalTasks/interface/ZDCQIE10Task.h
+++ b/DQM/HcalTasks/interface/ZDCQIE10Task.h
@@ -76,6 +76,11 @@ protected:
   std::map<uint32_t, MonitorElement *> _cZDC_EM_TM;
 
   std::unique_ptr<HcalLongRecoParams> longRecoParams_;
+
+  // ZDC params 
+  static constexpr int kZDCAbsIEta = 42;
+  static constexpr int kZDCiEtSumsIPhi = 99;
+  static constexpr int kZDCiEtSumMaxValue = 1023;
 };
 
 #endif

--- a/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
+++ b/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
@@ -292,7 +292,7 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
 
   // adding 6 FSC channels on z- side (labeled as EM7_minus - EM12_minus)
   for (int channel = 7; channel < 13; channel++) {
-    // EM Minus
+    // FSC Minus
     HcalZDCDetId didm(HcalZDCDetId::EM, false, channel);
 
     std::vector<std::string> stationString = {
@@ -323,6 +323,38 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
     _cTDC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 150, 0, 150);
     _cTDC_EChannel[didm()]->setAxisTitle("TDC", 1);
     _cTDC_EChannel[didm()]->setAxisTitle("N", 2);
+
+    // FSC plus 
+    HcalZDCDetId didp(HcalZDCDetId::EM, true, channel);
+
+    std::vector<std::string> stationStringP = {
+        "2_P_Top", "2_P_Bottom", "3_P_BottomLeft", "3_P_BottomRight", "3_P_TopLeft", "3_P_TopRight"};
+
+    histoname = "FSC" + stationStringP.at(channel - 7);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
+    _cADC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 256, 0, 256);
+    _cADC_EChannel[didp()]->setAxisTitle("ADC", 1);
+    _cADC_EChannel[didp()]->setAxisTitle("N", 2);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
+    _cADC_vs_TS_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 6, 0, 6);
+    _cADC_vs_TS_EChannel[didp()]->setAxisTitle("TS", 1);
+    _cADC_vs_TS_EChannel[didp()]->setAxisTitle("sum ADC", 2);
+
+    histoname = "FSC" + stationString.at(channel - 7);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/fC_perChannel");
+    _cfC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 100, 0, 8000);
+    _cfC_EChannel[didp()]->setAxisTitle("fC", 1);
+    _cfC_EChannel[didp()]->setAxisTitle("N", 2);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/fC_vs_TS_perChannel");
+    _cfC_vs_TS_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 6, 0, 6);
+    _cfC_vs_TS_EChannel[didp()]->setAxisTitle("TS", 1);
+    _cfC_vs_TS_EChannel[didp()]->setAxisTitle("sum fC", 2);
+
+    histoname = "FSC" + stationString.at(channel - 7);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/TDC_perChannel");
+    _cTDC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 150, 0, 150);
+    _cTDC_EChannel[didp()]->setAxisTitle("TDC", 1);
+    _cTDC_EChannel[didp()]->setAxisTitle("N", 2);
   }
 
   for (int channel = 1; channel < 5; channel++) {

--- a/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
+++ b/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
@@ -580,14 +580,14 @@ void ZDCQIE10Task::_process(edm::Event const& e, edm::EventSetup const& es) {
     HcalTrigTowerDetId tid = it->id();
 
     // ZDCp TP
-    if (tid.ieta() >= 42 && tid.iphi() == 99) {
+    if (tid.ieta() >= kZDCAbsIEta && tid.iphi() == kZDCiEtSumsIPhi) {
       // need to convert to the actual dynamic range of the ZDC sums
-      dataSumP = it->t0().raw() & 1023;
+      dataSumP = it->t0().raw() & kZDCiEtSumMaxValue;
     }
     // ZDCm TP
-    if (tid.ieta() <= -42 && tid.iphi() == 99) {
+    if (tid.ieta() <= -kZDCAbsIEta && tid.iphi() == kZDCiEtSumsIPhi) {
       // need to convert to the actual dynamic range of the ZDC sums
-      dataSumM = it->t0().raw() & 1023;
+      dataSumM = it->t0().raw() & kZDCiEtSumMaxValue;
     }
   }
 


### PR DESCRIPTION
#### PR description:

This PR includes the addition of the FSC on the plus side to the DQM, that will be newly installed for the heavy-ion run. Note that this PR can only be merged once the global tag is updated with the emap included in the ongoing full track validation. See [JIRA ticket](https://its.cern.ch/jira/browse/CMSALCA-348) for more details. 

#### PR validation:

As the FSC on the plus side is not yet installed, this PR was validated using data from the light ion run. A description of this and proof this histograms are created is included here. [See dropbox paper]( https://paper.dropbox.com/doc/DQM-Updates-20252-Part-2--Cwh0J6G1ek~ju7ubC3YDdfOtAQ-2xdhrRZT9spze6zXsn39S)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is intended for HIN data taking and will need to be backported to 15_1_X. 

Tagging HIN colleagues: @mandrenguyen
Tagging HCAL colleagues:@abdoulline @akhukhun @salimcerci, @denizsun
Tagging FSC colleagues: @michael-pitt
