### PR TITLE
Add InputTag parameters to fillDescriptions method for ctppsProtonReconstructionSimulationValidator_cfi

### DIFF
--- a/Validation/CTPPS/plugins/CTPPSProtonReconstructionSimulationValidator.cc
+++ b/Validation/CTPPS/plugins/CTPPSProtonReconstructionSimulationValidator.cc
@@ -215,16 +215,16 @@ CTPPSProtonReconstructionSimulationValidator::CTPPSProtonReconstructionSimulatio
 
 void CTPPSProtonReconstructionSimulationValidator::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-
   desc.add<std::string>("lhcInfoLabel", "")->setComment("label of the LHCInfo record");
   desc.add<std::string>("lhcInfoPerLSLabel", "")->setComment("label of the LHCInfoPerLS record");
   desc.add<std::string>("lhcInfoPerFillLabel", "")->setComment("label of the LHCInfoPerFill record");
   desc.add<bool>("useNewLHCInfo", false)->setComment("flag whether to use new LHCInfoPer* records or old LHCInfo");
-
+  desc.add<edm::InputTag>("tagHepMCBeforeSmearing", edm::InputTag(""));
+  desc.add<edm::InputTag>("tagHepMCAfterSmearing", edm::InputTag(""));
+  desc.add<InputTag>("tagRecoProtonsSingleRP", edm::InputTag(""));
+  desc.add<InputTag>("tagRecoProtonsMultiRP", edm::InputTag(""));
   desc.add<std::string>("outputFile", "output.root")->setComment("output file name");
-
   desc.addUntracked<unsigned int>("verbosity", 0)->setComment("verbosity level");
-
   descriptions.add("ctppsProtonReconstructionSimulationValidatorDefault", desc);
 }
 

--- a/Validation/CTPPS/plugins/CTPPSProtonReconstructionSimulationValidator.cc
+++ b/Validation/CTPPS/plugins/CTPPSProtonReconstructionSimulationValidator.cc
@@ -219,10 +219,10 @@ void CTPPSProtonReconstructionSimulationValidator::fillDescriptions(edm::Configu
   desc.add<std::string>("lhcInfoPerLSLabel", "")->setComment("label of the LHCInfoPerLS record");
   desc.add<std::string>("lhcInfoPerFillLabel", "")->setComment("label of the LHCInfoPerFill record");
   desc.add<bool>("useNewLHCInfo", false)->setComment("flag whether to use new LHCInfoPer* records or old LHCInfo");
-  desc.add<edm::InputTag>("tagHepMCBeforeSmearing", edm::InputTag(""));
-  desc.add<edm::InputTag>("tagHepMCAfterSmearing", edm::InputTag(""));
-  desc.add<InputTag>("tagRecoProtonsSingleRP", edm::InputTag(""));
-  desc.add<InputTag>("tagRecoProtonsMultiRP", edm::InputTag(""));
+  desc.add<edm::InputTag>("tagHepMCBeforeSmearing", edm::InputTag("generator", "unsmeared"));
+  desc.add<edm::InputTag>("tagHepMCAfterSmearing", edm::InputTag("beamDivergenceVtxGenerator"));
+  desc.add<InputTag>("tagRecoProtonsSingleRP", edm::InputTag("ctppsProtons", "singleRP"));
+  desc.add<InputTag>("tagRecoProtonsMultiRP", edm::InputTag("ctppsProtons", "multiRP"));
   desc.add<std::string>("outputFile", "output.root")->setComment("output file name");
   desc.addUntracked<unsigned int>("verbosity", 0)->setComment("verbosity level");
   descriptions.add("ctppsProtonReconstructionSimulationValidatorDefault", desc);


### PR DESCRIPTION
#### PR description:

resolves https://github.com/cms-sw/cmssw/issues/49180.
Provide `InputTag` parameter defaults to `Validation/CTPPS/plugins/CTPPSProtonReconstructionSimulationValidator.cc`

#### PR validation:

Compilation passed.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.
