### PR TITLE
Proper Clamping for CA Doublets Histogram

### DIFF
--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernels.dev.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernels.dev.cc
@@ -57,8 +57,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 #ifdef GPU_DEBUG
     std::cout << "Allocation for tuple building with: " << std::endl;
     std::cout << "- nHits          = " << nHits << std::endl;
-    std::cout << "- maxDoublets    = " << maxTuples << std::endl;
-    std::cout << "- maxTracks      = " << maxDoublets << std::endl;
+    std::cout << "- maxDoublets    = " << maxDoublets << std::endl;
+    std::cout << "- maxTracks      = " << maxTuples << std::endl;
 
     std::cout << "- nCellsToCells  = " << nCellsToCells << std::endl;
     std::cout << "- nHitsToCells   = " << nHitsToCells << std::endl;

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAPixelDoubletsAlgos.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAPixelDoubletsAlgos.h
@@ -420,9 +420,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caPixelDoublets {
           }
 
           auto ind = alpaka::atomicAdd(acc, nCells, 1u, alpaka::hierarchy::Blocks{});
-          if (ind >= maxNumOfDoublets) {
+          if (ind >= maxNumOfDoublets or ind >= uint32_t(outerHitHisto->capacity())) {
 #ifdef CA_WARNINGS
-            printf("Warning!!!! Too many cells (limit = %d)!\n", maxNumOfDoublets);
+            printf("Warning!!!! Too many cells (maxNumOfDoublets = %d - nHitsToCell = %d)!\n",
+                   maxNumOfDoublets,
+                   outerHitHisto->capacity());
 #endif
             alpaka::atomicSub(acc, nCells, 1u, alpaka::hierarchy::Blocks{});
             break;


### PR DESCRIPTION
#### PR description:

This PR proposes a small fix for the crash reported in https://github.com/cms-sw/cmssw/issues/49186. The crash there happens because we fill the `outerHitHisto` histo beyond its capacity (that is defined as `nHitsToCells = nHits * avgCellsPerHit`). The check there is only done for `maxDoublets`. Now, technically, `maxDoublets` and `nHitsToCells` should be the same (given the one-to-one correspondence between a doublet and its outer hit). Having two distinct variables is inherited from how the structures were defined before #47611 (one `OuterHitOfCell` array per hit). In the longer term, these two numbers should be merged. For the moment, I'm just adding a small fix to have it quickly integrated in `15_1_X` for HI operations.

#### PR validation:

Reproducer in https://github.com/cms-sw/cmssw/issues/49186 runs without error (and we get the warnings if `CA_WARNINGS` is defined).

