### PR TITLE
Mitigate impact of FPIX hole in UPC reco

### DIFF
--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -177,6 +177,7 @@ highBetaStar.toModify(pixelPairStepTrackingRegionsSeedLayersB,RegionPSet = dict(
      ptMin        = 0.05,
      originRadius = 0.2,
 ))
+(highBetaStar & run3_upc).toModify(pixelPairStepTrackingRegionsSeedLayersB,RegionPSet = dict(ptMin = 0.08, originRadius  = 0.015))
 #include commented lines from above in pp_on_XY eras; global seeds (A) are not used in this era b/c timing
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA


### PR DESCRIPTION
#### PR description:

This PR improves the tracking efficiency of the UPC reconstruction around the forward pixel hole (eta=-1.8/phi=2.6), by slightly increasing the min pT and changing the origin radius threshold of pixelPairStepTrackingRegionsSeedLayersB, similarly as was done for pixelPairStepTrackingRegions in https://github.com/cms-sw/cmssw/pull/43378 to mitigate the impact of the barrel pixel hole.

@mandrenguyen 

#### PR validation:

Tested with workflows 182,182.1,143.901,143.902

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 15_1_X for PbPb data taking