### PR TITLE
Not Running the CA When Starting Layers are Empty

### DIFF
--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernels.dev.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernels.dev.cc
@@ -57,6 +57,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 #ifdef GPU_DEBUG
     std::cout << "Allocation for tuple building with: " << std::endl;
     std::cout << "- nHits          = " << nHits << std::endl;
+    std::cout << "- outerHits      = " << outerHits << std::endl;
     std::cout << "- maxDoublets    = " << maxDoublets << std::endl;
     std::cout << "- maxTracks      = " << maxTuples << std::endl;
 


### PR DESCRIPTION
#### PR description:

This PR proposes a small improvement for the CA seeding (inspired by the debugging of https://github.com/cms-sw/cmssw/issues/49186, in which many events have no hits on BPix1). As is, when BPix1 is empty, we run the CA anyway, even if all the starting pairs have BPix1 as the inner layer. This is useless and not easy to spot. Instead of running the CA, now a `LogWarning` is printed. In principle, it would make sense to generalize this to all the possible starting layers (I wouldn't push this in this PR since it would need non-trivial changes).

For the sake of curiosity I've run a vanilla TTBar wf running pixel quadruplets on GPU with `runTheMatrix.py -w upgrade -l 16834.402 ` with `--conditions 150X_mcRun3_2025_realistic_Candidate_2025_10_24_20_44_54`(BPix Layer 1 off) [*] and as expected at `step3` I get:

```
Begin processing the 1st record. Run 1, Event 1, LumiSection 1 on stream 0 at 21-Nov-2025 15:24:59.285 CET
%MSG-w SiPixelCompareRecHits:   SiPixelPhase1CompareRecHits:hltSiPixelPhase1CompareRecHits  21-Nov-2025 15:24:59 CET Run: 1 Event: 1
reference rechits not found; target rechits not found; the comparison will not run.
%MSG
%MSG-w CAHitNtupletAlpaka:  CAHitNtupletAlpakaPhase1@alpaka:pixelTracksAlpaka  21-Nov-2025 15:25:00 CET Run: 1 Event: 1
No hit on BPix1 (0) and all the starting pairs has BPix1 as inner layer.
It's useless to run the CA. Returning with 0 tracks!
%MSG
21-Nov-2025 15:25:00 CET  Closed file file:step2.root
```

----------

[*] the full setup

```
# in: /data/user/adiflori/cmssw_prs/PR_NoCANoGraph/dev dryRun for 'cd 16834.402_TTbar_14TeV+2025_Patatrack_PixelOnlyAlpaka
 cmsDriver.py TTbar_14TeV_TuneCP5_cfi  -s GEN,SIM -n 1 --conditions 150X_mcRun3_2025_realistic_Candidate_2025_10_24_20_44_54 --beamspot DBrealistic --datatier GEN-SIM --eventcontent FEVTDEBUG --geometry DB:Extended --era Run3_2025 --relval 9000,100 --fileout file:step1.root  > step1_TTbar_14TeV+2025_Patatrack_PixelOnlyAlpaka.log  2>&1


# in: /data/user/adiflori/cmssw_prs/PR_NoCANoGraph/dev dryRun for 'cd 16834.402_TTbar_14TeV+2025_Patatrack_PixelOnlyAlpaka
 cmsDriver.py step2  -s DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@relval2025 --conditions 150X_mcRun3_2025_realistic_Candidate_2025_10_24_20_44_54 --datatier GEN-SIM-DIGI-RAW -n 1 --eventcontent FEVTDEBUGHLT --geometry DB:Extended --era Run3_2025 --procModifiers alpaka --customise HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling --filein  file:step1.root  --fileout file:step2.root  > step2_TTbar_14TeV+2025_Patatrack_PixelOnlyAlpaka.log  2>&1


# in: /data/user/adiflori/cmssw_prs/PR_NoCANoGraph/dev dryRun for 'cd 16834.402_TTbar_14TeV+2025_Patatrack_PixelOnlyAlpaka
 cmsDriver.py step3  -s RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM+@hltGPUvsCPU --conditions 150X_mcRun3_2025_realistic_Candidate_2025_10_24_20_44_54 --datatier GEN-SIM-RECO,MINIAODSIM,NANOAODSIM,DQMIO -n 1 --eventcontent RECOSIM,MINIAODSIM,NANOEDMAODSIM,DQM --geometry DB:Extended --era Run3_2025 --procModifiers alpaka --customise HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling --filein  file:step2.root  --fileout file:step3.root  > step3_TTbar_14TeV+2025_Patatrack_PixelOnlyAlpaka.log  2>&1


# in: /data/user/adiflori/cmssw_prs/PR_NoCANoGraph/dev dryRun for 'cd 16834.402_TTbar_14TeV+2025_Patatrack_PixelOnlyAlpaka
 cmsDriver.py step4  -s HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM+@hltGPUvsCPU --conditions 150X_mcRun3_2025_realistic_Candidate_2025_10_24_20_44_54 --mc  --geometry DB:Extended --scenario pp --filetype DQM --era Run3_2025 -n 1  --filein file:step3_inDQM.root --fileout file:step4.root  > step4_TTbar_14TeV+2025_Patatrack_PixelOnlyAlpaka.log  2>&1
 ```
