### PR TITLE
cleanup VertexSoA/test/BuildFile to avoid duplicate dependencies

### DIFF
--- a/DataFormats/VertexSoA/test/BuildFile.xml
+++ b/DataFormats/VertexSoA/test/BuildFile.xml
@@ -1,14 +1,8 @@
-<use name="alpaka"/>
-<use name="rootcore"/>
-<use name="eigen"/>
-<use name="DataFormats/Common"/>
-<use name="DataFormats/Portable"/>
-<use name="DataFormats/SoATemplate" source_only="1"/>
-
-
 <bin file="alpaka/ZVertexSoA_test.cc alpaka/ZVertexSoA_test.dev.cc" name="ZVertexSoA_test">
   <use name="alpaka"/>
   <use name="eigen"/>
+  <use name="DataFormats/VertexSoA"/>
+  <use name="FWCore/Utilities"/>
   <use name="HeterogeneousCore/AlpakaInterface"/>
 <flags ALPAKA_BACKENDS="1"/>
 </bin>
@@ -16,6 +10,8 @@
 <library name="testVertexSoA" file="TestWriteHostVertexSoA.cc,TestReadHostVertexSoA.cc,">
   <flags EDM_PLUGIN="1"/>
   <use name="alpaka"/>
+  <use name="eigen"/>
+  <use name="DataFormats/VertexSoA"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/Utilities"/>


### PR DESCRIPTION
This fixes the SCRAM warnings
```
***WARNING: Multiple usage of "alpaka". Please cleanup "use" in "export" section of "src/DataFormats/VertexSoA/test/BuildFile.xml"
***WARNING: Multiple usage of "eigen". Please cleanup "use" in "export" section of "src/DataFormats/VertexSoA/test/BuildFile.xml"
***WARNING: Multiple usage of "alpaka". Please cleanup "use" in "export" section of "src/DataFormats/VertexSoA/test/BuildFile.xml"
***WARNING: Multiple usage of "eigen". Please cleanup "use" in "export" section of "src/DataFormats/VertexSoA/test/BuildFile.xml"
***WARNING: Multiple usage of "alpaka". Please cleanup "use" in "export" section of "src/DataFormats/VertexSoA/test/BuildFile.xml"
***WARNING: Multiple usage of "eigen". Please cleanup "use" in "export" section of "src/DataFormats/VertexSoA/test/BuildFile.xml"
***WARNING: Multiple usage of "alpaka". Please cleanup "use" in "export" section of "src/DataFormats/VertexSoA/test/BuildFile.xml"
```