### PR TITLE
Switch to use RNTupleTemp* plugins

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -458,7 +458,7 @@ class ConfigBuilder(object):
                                                secondaryFileNames= cms.untracked.vstring())
                 filesFromOption(self)
             if self._options.filetype == "EDM_RNTUPLE":
-                self.process.source=cms.Source("RNTupleSource",
+                self.process.source=cms.Source("RNTupleTempSource",
                                                fileNames = cms.untracked.vstring())#, 2ndary not supported yet
                                                #secondaryFileNames= cms.untracked.vstring())
                 filesFromOption(self)
@@ -733,7 +733,7 @@ class ConfigBuilder(object):
         elif not ignoreNano and "NANOAOD" in streamType:
             CppType='NanoAODRNTupleOutputModule' if self._options.rntuple_out else 'NanoAODOutputModule'
         elif self._options.rntuple_out:
-            CppType='RNTupleOutputModule'
+            CppType='RNTupleTempOutputModule'
         if 'RNTuple' in CppType:
             fileName = fileName.replace('.root', '.rntpl')
         else:
@@ -1241,7 +1241,7 @@ class ConfigBuilder(object):
             # define output module and go from there
         if self._options.rntuple_out:
             extension = '.rntpl'
-            output = cms.OutputModule('RNTupleOutputModule')
+            output = cms.OutputModule('RNTupleTempOutputModule')
         else:
             extension = '.root'
             output = cms.OutputModule("PoolOutputModule")

--- a/Configuration/Applications/test/ConfigBuilderTest.py
+++ b/Configuration/Applications/test/ConfigBuilderTest.py
@@ -139,7 +139,7 @@ if __name__=="__main__":
             options.datatier= "MINIAOD"
             options.eventcontent="MINIAOD"
             options.rntuple_out = True
-            _test_addOutput(self, options, process, [OutStats('MINIAODoutput','RNTupleOutputModule','MINIAOD','output.rntpl',outputCommands_)])
+            _test_addOutput(self, options, process, [OutStats('MINIAODoutput','RNTupleTempOutputModule','MINIAOD','output.rntpl',outputCommands_)])
             #MINIAOD1 [NOTE notiation not restricted to MINIAOD]
             #NOT SUPPORTED BY outputDefinition
             process = cms.Process("TEST")
@@ -234,7 +234,7 @@ if __name__=="__main__":
             options.datatier= "NANOAOD"
             options.eventcontent="NANOEDMAOD"
             options.rntuple_out = True
-            _test_addOutput(self, options, process, [OutStats('NANOEDMAODoutput', 'RNTupleOutputModule', 'NANOAOD', 'output.rntpl', outputCommands_)])
+            _test_addOutput(self, options, process, [OutStats('NANOEDMAODoutput', 'RNTupleTempOutputModule', 'NANOAOD', 'output.rntpl', outputCommands_)])
             #ALCARECO empty
             process = cms.Process("TEST")
             options.scenario = "TEST"

--- a/DataFormats/Histograms/interface/MEtoEDMFormat.h
+++ b/DataFormats/Histograms/interface/MEtoEDMFormat.h
@@ -264,6 +264,54 @@ inline bool MEtoEDM<int>::mergeProduct(const MEtoEDM<int> &newMEtoEDM) {
 }
 
 template <>
+inline bool MEtoEDM<long>::mergeProduct(const MEtoEDM<long> &newMEtoEDM) {
+  const MEtoEdmObjectVector &newMEtoEDMObject = newMEtoEDM.getMEtoEdmObject();
+  const size_t nObjects = newMEtoEDMObject.size();
+  //  NOTE: we remember the present size since we will only add content
+  //        from newMEtoEDMObject after this point
+  const size_t nOldObjects = MEtoEdmObject.size();
+
+  // if the old and new are not the same size, we want to report a problem
+  if (nObjects != nOldObjects) {
+    std::cout << "WARNING MEtoEDM::mergeProducts(): the lists of histograms to be merged have different sizes: new="
+              << nObjects << ", old=" << nOldObjects << std::endl;
+  }
+
+  for (unsigned int i = 0; i < nObjects; ++i) {
+    unsigned int j = 0;
+    // see if the name is already in the old container up to the point where
+    // we may have added new entries in the container
+    const std::string &name = newMEtoEDMObject[i].name;
+    if (i < nOldObjects && (MEtoEdmObject[i].name == name)) {
+      j = i;
+    } else {
+      j = 0;
+      while (j < nOldObjects && (MEtoEdmObject[j].name != name))
+        ++j;
+    }
+    if (j >= nOldObjects) {
+      // this value is only in the new container, not the old one
+#if METOEDMFORMAT_DEBUG
+      std::cout << "WARNING MEtoEDM::mergeProducts(): adding new histogram '" << name << "'" << std::endl;
+#endif
+      MEtoEdmObject.push_back(newMEtoEDMObject[i]);
+    } else {
+      // this value is also in the new container: add the two
+      if (MEtoEdmObject[j].name.find("EventInfo/processedEvents") != std::string::npos) {
+        MEtoEdmObject[j].object += (newMEtoEDMObject[i].object);
+      }
+      if (MEtoEdmObject[j].name.find("EventInfo/iEvent") != std::string::npos ||
+          MEtoEdmObject[j].name.find("EventInfo/iLumiSection") != std::string::npos) {
+        if (MEtoEdmObject[j].object < newMEtoEDMObject[i].object) {
+          MEtoEdmObject[j].object = (newMEtoEDMObject[i].object);
+        }
+      }
+    }
+  }
+  return true;
+}
+
+template <>
 inline bool MEtoEDM<long long>::mergeProduct(const MEtoEDM<long long> &newMEtoEDM) {
   const MEtoEdmObjectVector &newMEtoEDMObject = newMEtoEDM.getMEtoEdmObject();
   const size_t nObjects = newMEtoEDMObject.size();

--- a/DataFormats/Histograms/src/classes_def.xml
+++ b/DataFormats/Histograms/src/classes_def.xml
@@ -33,6 +33,7 @@
  <class name="MEtoEDM<TProfile2D>"/>
  <class name="MEtoEDM<double>"/>
  <class name="MEtoEDM<int>"/>
+ <class name="MEtoEDM<long>"/>
  <class name="MEtoEDM<long long>"/>
  <class name="MEtoEDM<TString>"/>
  <class name="MEtoEDM<TH1F>::MEtoEDMObject" rntupleStreamerMode="true"/>
@@ -49,6 +50,7 @@
  <class name="MEtoEDM<TProfile2D>::MEtoEDMObject" rntupleStreamerMode="true"/>
  <class name="MEtoEDM<double>::MEtoEDMObject" rntupleStreamerMode="true"/>
  <class name="MEtoEDM<int>::MEtoEDMObject" rntupleStreamerMode="true"/>
+ <class name="MEtoEDM<long>::MEtoEDMObject" rntupleStreamerMode="true"/>
  <class name="MEtoEDM<long long>::MEtoEDMObject" rntupleStreamerMode="true"/>
  <class name="MEtoEDM<TString>::MEtoEDMObject" rntupleStreamerMode="true"/>
  <class name="std::vector<MEtoEDM<TH1F>::MEtoEDMObject>"/>
@@ -81,6 +83,7 @@
  <class name="edm::Wrapper<MEtoEDM<TProfile2D> >"/>
  <class name="edm::Wrapper<MEtoEDM<double> >"/>
  <class name="edm::Wrapper<MEtoEDM<int> >"/>
+ <class name="edm::Wrapper<MEtoEDM<long> >"/>
  <class name="edm::Wrapper<MEtoEDM<long long> >"/>
  <class name="edm::Wrapper<MEtoEDM<TString> >"/>
 


### PR DESCRIPTION
#### PR description:

- Switch from RNTuple* to RNTupleTemp* as the latter more closely behave like their Pool* counterparts.

#### PR validation:

A simple test of `runTheMatrix.py` showed the change worked.

resolves https://github.com/cms-sw/framework-team/issues/1559