### PR TITLE
[Do not merge] LLVM21 clang-tidy changes

### DIFF
--- a/Alignment/CocoaFit/src/Fit.cc
+++ b/Alignment/CocoaFit/src/Fit.cc
@@ -1311,7 +1311,7 @@ void Fit::printCentreInOptOFrame(const OpticalObject* opto,
               << " parent GLOB " << optoAncestor->centreGlob() << std::endl;
     ALIUtils::dumprm(optoAncestor->rmGlob(), " parent rm ");
   }
-  std::vector<Entry*> entries = opto->CoordinateEntryList();
+  const std::vector<Entry*>& entries = opto->CoordinateEntryList();
   for (ALIuint ii = 0; ii < 3; ii++) {
     /* double entryvalue = getEntryValue( entries[ii] );
        ALIdouble entryvalue;
@@ -1333,7 +1333,7 @@ void Fit::printRotationAnglesInOptOFrame(const OpticalObject* opto,
                                          ALIFileOut& fileout,
                                          ALIbool printErrors,
                                          ALIbool printOrig) {
-  std::vector<Entry*> entries = opto->CoordinateEntryList();
+  const std::vector<Entry*>& entries = opto->CoordinateEntryList();
   std::vector<double> entryvalues = opto->getRotationAnglesInOptOFrame(optoAncestor, entries);
   //-    std::cout << " after return entryvalues[0] " << entryvalues[0] << " entryvalues[1] " << entryvalues[1] << " entryvalues[2] " << entryvalues[2] << std::endl;
   for (ALIuint ii = 3; ii < entries.size(); ii++) {

--- a/Alignment/CocoaFit/src/NtupleManager.cc
+++ b/Alignment/CocoaFit/src/NtupleManager.cc
@@ -291,7 +291,7 @@ void NtupleManager::FillMeasurements() {
   for (vmcite = Model::MeasurementList().begin(); vmcite != Model::MeasurementList().end(); ++vmcite) {
     std::vector<ALIstring> optonamelist = (*vmcite)->OptONameList();
     int last = optonamelist.size() - 1;
-    ALIstring LastOptOName = optonamelist[last];
+    const ALIstring& LastOptOName = optonamelist[last];
     int optoind = -999;
     for (int no = 0; no < NOptObjects; no++) {
       OptObject* optobj = (OptObject*)CloneOptObject->At(no);

--- a/Alignment/CocoaModel/src/CocoaDaqReaderRoot.cc
+++ b/Alignment/CocoaModel/src/CocoaDaqReaderRoot.cc
@@ -125,7 +125,7 @@ OpticalAlignMeasurementInfo CocoaDaqReaderRoot::GetMeasFromPosition2D(AliDaqPosi
   meas.name_ = std::string(pos2D->GetID().Data());
   //-   std::vector<std::string> measObjectNames_;
   std::vector<bool> isSimu;
-  for (size_t jj = 0; jj < 2; jj++) {
+  isSimu.reserve(2); for (size_t jj = 0; jj < 2; jj++) {
     isSimu.push_back(false);
   }
   meas.isSimulatedValue_ = isSimu;
@@ -155,7 +155,7 @@ OpticalAlignMeasurementInfo CocoaDaqReaderRoot::GetMeasFromPositionCOPS(AliDaqPo
   meas.name_ = std::string(posCOPS->GetID().Data());
   //-   std::vector<std::string> measObjectNames_;
   std::vector<bool> isSimu;
-  for (size_t jj = 0; jj < 4; jj++) {
+  isSimu.reserve(4); for (size_t jj = 0; jj < 4; jj++) {
     isSimu.push_back(false);
   }
   meas.isSimulatedValue_ = isSimu;
@@ -198,7 +198,7 @@ OpticalAlignMeasurementInfo CocoaDaqReaderRoot::GetMeasFromTilt(AliDaqTilt* tilt
   meas.name_ = std::string(tilt->GetID().Data());
   //-   std::vector<std::string> measObjectNames_;
   std::vector<bool> isSimu;
-  for (size_t jj = 0; jj < 2; jj++) {
+  isSimu.reserve(2); for (size_t jj = 0; jj < 2; jj++) {
     isSimu.push_back(false);
   }
   meas.isSimulatedValue_ = isSimu;
@@ -222,7 +222,7 @@ OpticalAlignMeasurementInfo CocoaDaqReaderRoot::GetMeasFromDist(AliDaqDistance* 
   meas.name_ = std::string(dist->GetID().Data());
   //-   std::vector<std::string> measObjectNames_;
   std::vector<bool> isSimu;
-  for (size_t jj = 0; jj < 2; jj++) {
+  isSimu.reserve(2); for (size_t jj = 0; jj < 2; jj++) {
     isSimu.push_back(false);
   }
   meas.isSimulatedValue_ = isSimu;
@@ -265,7 +265,7 @@ void CocoaDaqReaderRoot::BuildMeasurementsFromOptAlign(std::vector<OpticalAlignM
     //---------- loop measurements read from ROOT
     ALIint ii;
     for (ii = 0; ii < nMeasRoot; ii++) {
-      OpticalAlignMeasurementInfo measInfo = measList[ii];
+      const OpticalAlignMeasurementInfo& measInfo = measList[ii];
       std::cout << " measurement name ROOT " << measInfo.name_ << " Model= " << (*vmcite)->name() << " short " << oname
                 << std::endl;
 

--- a/Alignment/CocoaModel/src/CocoaDaqReaderRoot.cc
+++ b/Alignment/CocoaModel/src/CocoaDaqReaderRoot.cc
@@ -125,7 +125,8 @@ OpticalAlignMeasurementInfo CocoaDaqReaderRoot::GetMeasFromPosition2D(AliDaqPosi
   meas.name_ = std::string(pos2D->GetID().Data());
   //-   std::vector<std::string> measObjectNames_;
   std::vector<bool> isSimu;
-  isSimu.reserve(2); for (size_t jj = 0; jj < 2; jj++) {
+  isSimu.reserve(2);
+  for (size_t jj = 0; jj < 2; jj++) {
     isSimu.push_back(false);
   }
   meas.isSimulatedValue_ = isSimu;
@@ -155,7 +156,8 @@ OpticalAlignMeasurementInfo CocoaDaqReaderRoot::GetMeasFromPositionCOPS(AliDaqPo
   meas.name_ = std::string(posCOPS->GetID().Data());
   //-   std::vector<std::string> measObjectNames_;
   std::vector<bool> isSimu;
-  isSimu.reserve(4); for (size_t jj = 0; jj < 4; jj++) {
+  isSimu.reserve(4);
+  for (size_t jj = 0; jj < 4; jj++) {
     isSimu.push_back(false);
   }
   meas.isSimulatedValue_ = isSimu;
@@ -198,7 +200,8 @@ OpticalAlignMeasurementInfo CocoaDaqReaderRoot::GetMeasFromTilt(AliDaqTilt* tilt
   meas.name_ = std::string(tilt->GetID().Data());
   //-   std::vector<std::string> measObjectNames_;
   std::vector<bool> isSimu;
-  isSimu.reserve(2); for (size_t jj = 0; jj < 2; jj++) {
+  isSimu.reserve(2);
+  for (size_t jj = 0; jj < 2; jj++) {
     isSimu.push_back(false);
   }
   meas.isSimulatedValue_ = isSimu;
@@ -222,7 +225,8 @@ OpticalAlignMeasurementInfo CocoaDaqReaderRoot::GetMeasFromDist(AliDaqDistance* 
   meas.name_ = std::string(dist->GetID().Data());
   //-   std::vector<std::string> measObjectNames_;
   std::vector<bool> isSimu;
-  isSimu.reserve(2); for (size_t jj = 0; jj < 2; jj++) {
+  isSimu.reserve(2);
+  for (size_t jj = 0; jj < 2; jj++) {
     isSimu.push_back(false);
   }
   meas.isSimulatedValue_ = isSimu;

--- a/Alignment/CocoaModel/src/Model.cc
+++ b/Alignment/CocoaModel/src/Model.cc
@@ -372,7 +372,7 @@ void Model::readSystemDescription() {
         if (ALIUtils::debug >= 3) {
           std::vector<std::vector<ALIstring> >::iterator itevs;
           for (itevs = OptODictionary().begin(); itevs != OptODictionary().end(); ++itevs) {
-            std::vector<ALIstring> ptemp = *itevs;
+            const std::vector<ALIstring>& ptemp = *itevs;
             ALIUtils::dumpVS(ptemp, " SYSTEM TREE DESCRIPTION: after ordering: OBJECT ", std::cout);
           }
         }

--- a/Alignment/CommonAlignmentParametrization/src/TwoBowedSurfacesAlignmentParameters.cc
+++ b/Alignment/CommonAlignmentParametrization/src/TwoBowedSurfacesAlignmentParameters.cc
@@ -222,7 +222,7 @@ double TwoBowedSurfacesAlignmentParameters::ySplitFromAlignable(const Alignable 
   if (!ali)
     return 0.;
 
-  const align::PositionType pos(ali->globalPosition());
+  const align::PositionType& pos(ali->globalPosition());
   const double r = pos.perp();
 
   // The returned numbers for TEC are calculated as stated below from

--- a/Alignment/CommonAlignmentParametrization/src/TwoBowedSurfacesAlignmentParameters.cc
+++ b/Alignment/CommonAlignmentParametrization/src/TwoBowedSurfacesAlignmentParameters.cc
@@ -222,7 +222,7 @@ double TwoBowedSurfacesAlignmentParameters::ySplitFromAlignable(const Alignable 
   if (!ali)
     return 0.;
 
-  const align::PositionType& pos(ali->globalPosition());
+  const align::PositionType &pos(ali->globalPosition());
   const double r = pos.perp();
 
   // The returned numbers for TEC are calculated as stated below from

--- a/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
+++ b/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
@@ -801,7 +801,7 @@ void HIPAlignmentAlgorithm::run(const edm::EventSetup& setup, const EventInfo& e
     // loop over measurements
     std::vector<TrajectoryMeasurement> measurements = traj->measurements();
     for (std::vector<TrajectoryMeasurement>::iterator im = measurements.begin(); im != measurements.end(); ++im) {
-      TrajectoryMeasurement meas = *im;
+      const TrajectoryMeasurement& meas = *im;
 
       // const TransientTrackingRecHit* ttrhit = &(*meas.recHit());
       // const TrackingRecHit *hit = ttrhit->hit();

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeMonitor.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeMonitor.cc
@@ -591,7 +591,7 @@ void MillePedeMonitor::fillTrack(const reco::Track *track,
   if (!track)
     return;
 
-  const reco::TrackBase::Vector& p(track->momentum());
+  const reco::TrackBase::Vector &p(track->momentum());
 
   static const int iPtLog = this->GetIndex(trackHists1D, "ptTrackLogBins");
   trackHists1D[iPtLog]->Fill(track->pt());

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeMonitor.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeMonitor.cc
@@ -591,7 +591,7 @@ void MillePedeMonitor::fillTrack(const reco::Track *track,
   if (!track)
     return;
 
-  const reco::TrackBase::Vector p(track->momentum());
+  const reco::TrackBase::Vector& p(track->momentum());
 
   static const int iPtLog = this->GetIndex(trackHists1D, "ptTrackLogBins");
   trackHists1D[iPtLog]->Fill(track->pt());

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.cc
@@ -463,7 +463,7 @@ double PedeSteererWeakModeConstraints::getX0(const std::pair<Alignable*, std::li
   double x0 = 0.0;
 
   for (const auto& ali : iHLS.second) {
-    align::PositionType pos = ali->globalPosition();
+    const align::PositionType& pos = ali->globalPosition();
     bool alignableIsFloating = false;  //means: true=alignable is able to move in at least one direction
 
     //test whether at least one variable has been selected in the configuration

--- a/Alignment/OfflineValidation/plugins/JetHTAnalyzer.cc
+++ b/Alignment/OfflineValidation/plugins/JetHTAnalyzer.cc
@@ -186,7 +186,7 @@ void JetHTAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
     h_ntrks->Fill(ntrks);
 
     for (uint tracksIt = 0; tracksIt < ntrks; tracksIt++) {
-      auto tk = allTracks.at(tracksIt);
+      const auto& tk = allTracks.at(tracksIt);
 
       double dxyRes = tk.dxy(pos_) * cmToum;
       double dzRes = tk.dz(pos_) * cmToum;

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -331,7 +331,7 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
     double chi2prob = 0.;
 
     if (!vsorted.at(0).isFake()) {
-      Vertex pv = vsorted.at(0);
+      const Vertex& pv = vsorted.at(0);
 
       ntracks = pv.tracksSize();
       chi2ndf = pv.normalizedChi2();

--- a/Alignment/OfflineValidation/plugins/SplitVertexResolution.cc
+++ b/Alignment/OfflineValidation/plugins/SplitVertexResolution.cc
@@ -458,8 +458,8 @@ void SplitVertexResolution::analyze(const edm::Event& iEvent, const edm::EventSe
 
     // split into two sets equally populated
     for (uint tracksIt = 0; tracksIt < even_ntrks; tracksIt = tracksIt + 2) {
-      reco::Track firstTrk = allTracks.at(tracksIt);
-      reco::Track secondTrk = allTracks.at(tracksIt + 1);
+      const reco::Track& firstTrk = allTracks.at(tracksIt);
+      const reco::Track& secondTrk = allTracks.at(tracksIt + 1);
       auto dis = std::uniform_int_distribution<>(0, 1);  // [0, 1]
 
       if (dis(engine_) > 0.5) {

--- a/Alignment/OfflineValidation/src/PrepareDMRTrends.cc
+++ b/Alignment/OfflineValidation/src/PrepareDMRTrends.cc
@@ -124,7 +124,7 @@ void PrepareDMRTrends::compileDMRTrends(vector<int> IOVlist,
         vector<float> runs = geom.Run();
         size_t n = runs.size();
         vector<float> emptyvec;
-        for (size_t i = 0; i < runs.size(); i++)
+        emptyvec.reserve(runs.size()); for (size_t i = 0; i < runs.size(); i++)
           emptyvec.push_back(0.);
         for (size_t iVar = 0; iVar < variables.size(); iVar++) {
           Trend trend = trends.at(iVar);

--- a/Alignment/OfflineValidation/src/PrepareDMRTrends.cc
+++ b/Alignment/OfflineValidation/src/PrepareDMRTrends.cc
@@ -124,7 +124,8 @@ void PrepareDMRTrends::compileDMRTrends(vector<int> IOVlist,
         vector<float> runs = geom.Run();
         size_t n = runs.size();
         vector<float> emptyvec;
-        emptyvec.reserve(runs.size()); for (size_t i = 0; i < runs.size(); i++)
+        emptyvec.reserve(runs.size());
+        for (size_t i = 0; i < runs.size(); i++)
           emptyvec.push_back(0.);
         for (size_t iVar = 0; iVar < variables.size(); iVar++) {
           Trend trend = trends.at(iVar);

--- a/Alignment/SurveyAnalysis/plugins/SurveyAlignmentAlgorithm.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyAlignmentAlgorithm.cc
@@ -19,7 +19,8 @@ void SurveyAlignmentAlgorithm::initialize(
   //        - check this, when resurrecting this code in the future
   AlignableObjectId alignableObjectId{AlignableObjectId::Geometry::General};
 
-  levels.reserve(theLevels.size()); for (unsigned int l = 0; l < theLevels.size(); ++l) {
+  levels.reserve(theLevels.size());
+  for (unsigned int l = 0; l < theLevels.size(); ++l) {
     levels.push_back(alignableObjectId.stringToId(theLevels[l].c_str()));
   }
 

--- a/Alignment/SurveyAnalysis/plugins/SurveyAlignmentAlgorithm.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyAlignmentAlgorithm.cc
@@ -19,7 +19,7 @@ void SurveyAlignmentAlgorithm::initialize(
   //        - check this, when resurrecting this code in the future
   AlignableObjectId alignableObjectId{AlignableObjectId::Geometry::General};
 
-  for (unsigned int l = 0; l < theLevels.size(); ++l) {
+  levels.reserve(theLevels.size()); for (unsigned int l = 0; l < theLevels.size(); ++l) {
     levels.push_back(alignableObjectId.stringToId(theLevels[l].c_str()));
   }
 

--- a/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGParamBuilder.cc
+++ b/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGParamBuilder.cc
@@ -2882,7 +2882,8 @@ std::vector<unsigned int> EcalTPGParamBuilder::computeWeights(EcalShapeBase& sha
   edm::LogInfo("TopInfo") << ss.str();
 
   std::vector<unsigned int> theWeights;
-  theWeights.reserve(nSample_); for (unsigned int sample = 0; sample < nSample_; sample++)
+  theWeights.reserve(nSample_);
+  for (unsigned int sample = 0; sample < nSample_; sample++)
     theWeights.push_back(iweight[sample]);
 
   delete[] weight;

--- a/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGParamBuilder.cc
+++ b/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGParamBuilder.cc
@@ -996,7 +996,7 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
     int SLBch = (towerInTCC - 1) % 8 + 1;
     int cmsswId = id.rawId();
     int ixtal = (id.ism() - 1) * 1700 + (id.ic() - 1);
-    EcalLogicID logicId = my_EcalLogicId[ixtal];
+    const EcalLogicID& logicId = my_EcalLogicId[ixtal];
     int dbId = logicId.getLogicID();
     int val[] = {dccNb + 600,
                  tccNb,
@@ -1272,7 +1272,7 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
     if (writeToDB_) {
       // 1700 crystals/SM in the ECAL barrel
       int ixtal = (id.ism() - 1) * 1700 + (id.ic() - 1);
-      EcalLogicID logicId = my_EcalLogicId[ixtal];
+      const EcalLogicID& logicId = my_EcalLogicId[ixtal];
       pedset[logicId] = pedDB;
       linset[logicId] = linDB;
     }
@@ -2141,7 +2141,7 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
     for (int ich = 0; ich < (int)my_StripEcalLogicId.size(); ich++) {
       // EB
       FEConfigFgrEEStripDat zut;
-      EcalLogicID thestrip = my_StripEcalLogicId[ich];
+      const EcalLogicID& thestrip = my_StripEcalLogicId[ich];
       uint32_t elStripId = stripMapEB[ich];
       map<uint32_t, uint32_t>::const_iterator it = stripMapEBsintheta.find(elStripId);
       if (it != stripMapEBsintheta.end())
@@ -2191,7 +2191,7 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
     for (int ich = 0; ich < (int)my_TTEcalLogicId_EB_by_TCC.size(); ich++) {
       FEConfigTimingDat delay;
 
-      EcalLogicID logiciddelay = my_TTEcalLogicId_EB_by_TCC[ich];
+      const EcalLogicID& logiciddelay = my_TTEcalLogicId_EB_by_TCC[ich];
       int id1_tcc = logiciddelay.getID1();  // the TCC
       int id2_tt = logiciddelay.getID2();   // the tower
       std::map<int, vector<int>>::const_iterator ittEB = delays_EB_.find(id1_tcc);
@@ -2244,7 +2244,7 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
     for (int ich = 0; ich < (int)my_StripEcalLogicId_EE_strips_by_TCC.size(); ich++) {
       FEConfigTimingDat delay;
 
-      EcalLogicID logiciddelay = my_StripEcalLogicId_EE_strips_by_TCC[ich];
+      const EcalLogicID& logiciddelay = my_StripEcalLogicId_EE_strips_by_TCC[ich];
       int id1_tcc = logiciddelay.getID1();  // the TCC
       int id2_tt = logiciddelay.getID2();   // the tower
       int id3_st = logiciddelay.getID3();   // the strip
@@ -2882,7 +2882,7 @@ std::vector<unsigned int> EcalTPGParamBuilder::computeWeights(EcalShapeBase& sha
   edm::LogInfo("TopInfo") << ss.str();
 
   std::vector<unsigned int> theWeights;
-  for (unsigned int sample = 0; sample < nSample_; sample++)
+  theWeights.reserve(nSample_); for (unsigned int sample = 0; sample < nSample_; sample++)
     theWeights.push_back(iweight[sample]);
 
   delete[] weight;

--- a/CalibFormats/SiPixelObjects/src/PixelCalibConfiguration.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelCalibConfiguration.cc
@@ -543,7 +543,7 @@ void PixelCalibConfiguration::buildROCAndModuleLists(const PixelNameTranslation*
   for (std::vector<std::string>::iterator rocListInstructions_itr = rocListInstructions_.begin();
        rocListInstructions_itr != rocListInstructions_.end();
        ++rocListInstructions_itr) {
-    std::string instruction = *rocListInstructions_itr;
+    const std::string& instruction = *rocListInstructions_itr;
 
     if (instruction == "+") {
       addNext = true;

--- a/CalibFormats/SiPixelObjects/src/PixelDACSettings.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelDACSettings.cc
@@ -178,7 +178,7 @@ PixelDACSettings::PixelDACSettings(std::vector<std::vector<std::string> >& table
 */
   //   std::multimap<std::string,std::pair<std::string,int > > pDSM;
   //  std::stringstream currentRocName;
-  std::vector<std::string> ins = tableMat[0];
+  const std::vector<std::string>& ins = tableMat[0];
   std::string mthn("[PixelDACSettings::PixelDACSettings()] ");
   std::string dacName;
   std::istringstream dbin;

--- a/CalibFormats/SiPixelObjects/src/PixelDetectorConfig.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelDetectorConfig.cc
@@ -21,7 +21,7 @@ using namespace pos;
 PixelDetectorConfig::PixelDetectorConfig(std::vector<std::vector<std::string> > &tableMat)
     : PixelConfigBase("", "", "") {
   std::string mthn = "]\t[PixelDetectorConfig::PixelDetectorConfig()]\t\t    ";
-  std::vector<std::string> ins = tableMat[0];
+  const std::vector<std::string>& ins = tableMat[0];
   std::map<std::string, int> colM;
   std::vector<std::string> colNames;
   /*

--- a/CalibFormats/SiPixelObjects/src/PixelDetectorConfig.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelDetectorConfig.cc
@@ -21,7 +21,7 @@ using namespace pos;
 PixelDetectorConfig::PixelDetectorConfig(std::vector<std::vector<std::string> > &tableMat)
     : PixelConfigBase("", "", "") {
   std::string mthn = "]\t[PixelDetectorConfig::PixelDetectorConfig()]\t\t    ";
-  const std::vector<std::string>& ins = tableMat[0];
+  const std::vector<std::string> &ins = tableMat[0];
   std::map<std::string, int> colM;
   std::vector<std::string> colNames;
   /*

--- a/CalibFormats/SiPixelObjects/src/PixelFEDCard.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelFEDCard.cc
@@ -392,7 +392,7 @@ PixelFEDCard::PixelFEDCard(vector<vector<string> > &tableMat) : PixelConfigBase(
 
 void PixelFEDCard::readDBTBMLevels(std::vector<std::vector<std::string> > &tableMat, int firstRow, int lastRow) {
   string mthn = "[PixelFEDCard::readDBTBMLevels()] ";
-  const vector<string>& ins = tableMat[firstRow];
+  const vector<string> &ins = tableMat[firstRow];
   map<string, int> colM;
   vector<string> colNames;
 

--- a/CalibFormats/SiPixelObjects/src/PixelFEDCard.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelFEDCard.cc
@@ -392,7 +392,7 @@ PixelFEDCard::PixelFEDCard(vector<vector<string> > &tableMat) : PixelConfigBase(
 
 void PixelFEDCard::readDBTBMLevels(std::vector<std::vector<std::string> > &tableMat, int firstRow, int lastRow) {
   string mthn = "[PixelFEDCard::readDBTBMLevels()] ";
-  vector<string> ins = tableMat[firstRow];
+  const vector<string>& ins = tableMat[firstRow];
   map<string, int> colM;
   vector<string> colNames;
 

--- a/CalibFormats/SiPixelObjects/src/PixelFEDConfig.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelFEDConfig.cc
@@ -18,7 +18,7 @@ using namespace std;
 PixelFEDConfig::PixelFEDConfig(std::vector<std::vector<std::string> > &tableMat) : PixelConfigBase(" ", " ", " ") {
   std::string mthn = "[PixelFEDConfig::PixelFEDConfig()]\t\t\t    ";
 
-   std::map<std::string, int> colM;
+  std::map<std::string, int> colM;
   std::vector<std::string> colNames;
   /*
    EXTENSION_TABLE_NAME: FED_CRATE_CONFIG (VIEW: CONF_KEY_FED_CRATE_CONFIGV)

--- a/CalibFormats/SiPixelObjects/src/PixelFEDConfig.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelFEDConfig.cc
@@ -18,8 +18,7 @@ using namespace std;
 PixelFEDConfig::PixelFEDConfig(std::vector<std::vector<std::string> > &tableMat) : PixelConfigBase(" ", " ", " ") {
   std::string mthn = "[PixelFEDConfig::PixelFEDConfig()]\t\t\t    ";
 
-  std::vector<std::string> ins = tableMat[0];
-  std::map<std::string, int> colM;
+   std::map<std::string, int> colM;
   std::vector<std::string> colNames;
   /*
    EXTENSION_TABLE_NAME: FED_CRATE_CONFIG (VIEW: CONF_KEY_FED_CRATE_CONFIGV)

--- a/CalibFormats/SiPixelObjects/src/PixelGlobalDelay25.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelGlobalDelay25.cc
@@ -19,7 +19,7 @@ using namespace std;
 
 PixelGlobalDelay25::PixelGlobalDelay25(vector<vector<string> > &tableMat) : PixelConfigBase(" ", " ", " ") {
   std::string mthn = "[PixelGlobalDelay25::PixelGlobalDelay25()]\t\t    ";
-  const vector<string>& ins = tableMat[0];
+  const vector<string> &ins = tableMat[0];
   map<string, int> colM;
   vector<string> colNames;
 

--- a/CalibFormats/SiPixelObjects/src/PixelGlobalDelay25.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelGlobalDelay25.cc
@@ -19,7 +19,7 @@ using namespace std;
 
 PixelGlobalDelay25::PixelGlobalDelay25(vector<vector<string> > &tableMat) : PixelConfigBase(" ", " ", " ") {
   std::string mthn = "[PixelGlobalDelay25::PixelGlobalDelay25()]\t\t    ";
-  vector<string> ins = tableMat[0];
+  const vector<string>& ins = tableMat[0];
   map<string, int> colM;
   vector<string> colNames;
 

--- a/CalibFormats/SiPixelObjects/src/PixelMaskAllPixels.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelMaskAllPixels.cc
@@ -28,7 +28,7 @@ PixelMaskAllPixels::PixelMaskAllPixels(std::vector<std::vector<std::string> > &t
   std::string mthn = "[PixelMaskAllPixels::PixelMaskAllPixels()]\t\t    ";
   //std::cout << __LINE__ << "]\t" << mthn << "Table Size in const: " << tableMat.size() << std::endl;
 
-  std::vector<std::string> ins = tableMat[0];
+  const std::vector<std::string>& ins = tableMat[0];
   std::map<std::string, int> colM;
   std::vector<std::string> colNames;
 

--- a/CalibFormats/SiPixelObjects/src/PixelMaskAllPixels.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelMaskAllPixels.cc
@@ -28,7 +28,7 @@ PixelMaskAllPixels::PixelMaskAllPixels(std::vector<std::vector<std::string> > &t
   std::string mthn = "[PixelMaskAllPixels::PixelMaskAllPixels()]\t\t    ";
   //std::cout << __LINE__ << "]\t" << mthn << "Table Size in const: " << tableMat.size() << std::endl;
 
-  const std::vector<std::string>& ins = tableMat[0];
+  const std::vector<std::string> &ins = tableMat[0];
   std::map<std::string, int> colM;
   std::vector<std::string> colNames;
 

--- a/CalibFormats/SiPixelObjects/src/PixelPortcardMap.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelPortcardMap.cc
@@ -18,7 +18,7 @@ using namespace std;
 
 PixelPortcardMap::PixelPortcardMap(std::vector<std::vector<std::string> > &tableMat) : PixelConfigBase(" ", " ", " ") {
   std::string mthn = "[PixelPortcardMap::PixelPortcardMap()]\t\t\t    ";
-  std::vector<std::string> ins = tableMat[0];
+  const std::vector<std::string>& ins = tableMat[0];
   std::map<std::string, int> colM;
   std::vector<std::string> colNames;
   /*

--- a/CalibFormats/SiPixelObjects/src/PixelPortcardMap.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelPortcardMap.cc
@@ -18,7 +18,7 @@ using namespace std;
 
 PixelPortcardMap::PixelPortcardMap(std::vector<std::vector<std::string> > &tableMat) : PixelConfigBase(" ", " ", " ") {
   std::string mthn = "[PixelPortcardMap::PixelPortcardMap()]\t\t\t    ";
-  const std::vector<std::string>& ins = tableMat[0];
+  const std::vector<std::string> &ins = tableMat[0];
   std::map<std::string, int> colM;
   std::vector<std::string> colNames;
   /*

--- a/CalibFormats/SiPixelObjects/src/PixelTBMSettings.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelTBMSettings.cc
@@ -19,7 +19,7 @@ using namespace pos;
 
 PixelTBMSettings::PixelTBMSettings(std::vector<std::vector<std::string> > &tableMat) : PixelConfigBase("", "", "") {
   std::string mthn = "]\t[PixelTBMSettings::PixelTBMSettings()]\t\t\t    ";
-  std::vector<std::string> ins = tableMat[0];
+  const std::vector<std::string>& ins = tableMat[0];
   std::map<std::string, int> colM;
   std::vector<std::string> colNames;
 

--- a/CalibFormats/SiPixelObjects/src/PixelTBMSettings.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelTBMSettings.cc
@@ -19,7 +19,7 @@ using namespace pos;
 
 PixelTBMSettings::PixelTBMSettings(std::vector<std::vector<std::string> > &tableMat) : PixelConfigBase("", "", "") {
   std::string mthn = "]\t[PixelTBMSettings::PixelTBMSettings()]\t\t\t    ";
-  const std::vector<std::string>& ins = tableMat[0];
+  const std::vector<std::string> &ins = tableMat[0];
   std::map<std::string, int> colM;
   std::vector<std::string> colNames;
 

--- a/CalibPPS/AlignmentRelative/src/JanAlignmentAlgorithm.cc
+++ b/CalibPPS/AlignmentRelative/src/JanAlignmentAlgorithm.cc
@@ -434,7 +434,7 @@ unsigned int JanAlignmentAlgorithm::solve(const std::vector<AlignmentConstraint>
 
   // eigen analysis of CS matrix
   TMatrixDSymEigen CS_eig(CS);
-  const TVectorD& CS_eigVal = CS_eig.GetEigenValues();
+  const TVectorD &CS_eigVal = CS_eig.GetEigenValues();
   TMatrixD CS_eigVec = CS_eig.GetEigenVectors();
 
   // check regularity of CS matrix

--- a/CalibPPS/AlignmentRelative/src/JanAlignmentAlgorithm.cc
+++ b/CalibPPS/AlignmentRelative/src/JanAlignmentAlgorithm.cc
@@ -434,7 +434,7 @@ unsigned int JanAlignmentAlgorithm::solve(const std::vector<AlignmentConstraint>
 
   // eigen analysis of CS matrix
   TMatrixDSymEigen CS_eig(CS);
-  TVectorD CS_eigVal = CS_eig.GetEigenValues();
+  const TVectorD& CS_eigVal = CS_eig.GetEigenValues();
   TMatrixD CS_eigVec = CS_eig.GetEigenVectors();
 
   // check regularity of CS matrix

--- a/CalibTracker/SiStripHitEfficiency/plugins/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/HitEff.cc
@@ -662,7 +662,7 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es) {
             }
           }
           if (!tmpTmeas.empty() && !foundConsMissingHits) {
-            TrajectoryMeasurement TM_tmp(tmpTmeas.back());
+            const TrajectoryMeasurement& TM_tmp(tmpTmeas.back());
             unsigned int iidd_tmp = TM_tmp.recHit()->geographicalId().rawId();
             if (iidd_tmp != 0) {
               LogDebug("SiStripHitEfficiency:HitEff") << " hit actually being added to TM vector";
@@ -779,7 +779,7 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es) {
             // take the last of the TMs, which is always an invalid hit
             // if no detId is available, ie detId==0, then no compatible layer was crossed
             // otherwise, use that TM for the efficiency measurement
-            TrajectoryMeasurement tob6TM(tmp.back());
+            const TrajectoryMeasurement& tob6TM(tmp.back());
             const auto& tob6Hit = tob6TM.recHit();
 
             if (tob6Hit->geographicalId().rawId() != 0) {
@@ -827,7 +827,7 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es) {
             // take the last of the TMs, which is always an invalid hit
             // if no detId is available, ie detId==0, then no compatible layer was crossed
             // otherwise, use that TM for the efficiency measurement
-            TrajectoryMeasurement tec9TM(tmp.back());
+            const TrajectoryMeasurement& tec9TM(tmp.back());
             const auto& tec9Hit = tec9TM.recHit();
 
             unsigned int tec9id = tec9Hit->geographicalId().rawId();

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyWorker.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyWorker.cc
@@ -791,7 +791,7 @@ void SiStripHitEfficiencyWorker::analyze(const edm::Event& e, const edm::EventSe
             }
           }
           if (!tmpTmeas.empty() && !foundConsMissingHits) {
-            TrajectoryMeasurement TM_tmp(tmpTmeas.back());
+            const TrajectoryMeasurement& TM_tmp(tmpTmeas.back());
             unsigned int iidd_tmp = TM_tmp.recHit()->geographicalId().rawId();
             if (iidd_tmp != 0) {
               LogDebug("SiStripHitEfficiency:HitEff") << " hit actually being added to TM vector";

--- a/Calibration/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.cc
+++ b/Calibration/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.cc
@@ -576,7 +576,7 @@ void SelectedElectronFEDListProducer<TEle, TCand>::produce(edm::Event& iEvent, c
                 if (R - sqrt(pow(regionDimension_.first / 2, 2) + pow(regionDimension_.second / 2, 2)) > dRStripRegion_)
                   continue;
                 //get vector of subdets within region
-                const SiStripRegionCabling::RegionCabling regSubdets = SiStripCabling[iCabling];
+                const SiStripRegionCabling::RegionCabling& regSubdets = SiStripCabling[iCabling];
                 //cycle on subdets
                 for (uint32_t idet = 0; idet < SiStripRegionCabling::ALLSUBDETS; idet++) {  //cicle between 1 and 4
                   //get vector of layers whin subdet of region

--- a/Calibration/IsolatedParticles/plugins/IsoTrig.cc
+++ b/Calibration/IsolatedParticles/plugins/IsoTrig.cc
@@ -1837,7 +1837,8 @@ void IsoTrig::chgIsolation(double &etaTriggered,
   spr::propagateCALO(trkCollection, geo_, bField_, theTrackQuality_, trkCaloDirections1, ((verbosity_ / 100) % 10 > 2));
   if (verbosity_ % 10 > 0)
     edm::LogVerbatim("IsoTrack") << "Propagated TrkCollection";
-  maxP.reserve(pixelIsolationConeSizeAtEC_.size()); for (unsigned int k = 0; k < pixelIsolationConeSizeAtEC_.size(); ++k)
+  maxP.reserve(pixelIsolationConeSizeAtEC_.size());
+  for (unsigned int k = 0; k < pixelIsolationConeSizeAtEC_.size(); ++k)
     maxP.push_back(0);
   unsigned i = pixelTrackRefsHE_.size();
   std::vector<std::pair<unsigned int, std::pair<double, double>>> VecSeedsatEC;

--- a/Calibration/IsolatedParticles/plugins/IsoTrig.cc
+++ b/Calibration/IsolatedParticles/plugins/IsoTrig.cc
@@ -1837,7 +1837,7 @@ void IsoTrig::chgIsolation(double &etaTriggered,
   spr::propagateCALO(trkCollection, geo_, bField_, theTrackQuality_, trkCaloDirections1, ((verbosity_ / 100) % 10 > 2));
   if (verbosity_ % 10 > 0)
     edm::LogVerbatim("IsoTrack") << "Propagated TrkCollection";
-  for (unsigned int k = 0; k < pixelIsolationConeSizeAtEC_.size(); ++k)
+  maxP.reserve(pixelIsolationConeSizeAtEC_.size()); for (unsigned int k = 0; k < pixelIsolationConeSizeAtEC_.size(); ++k)
     maxP.push_back(0);
   unsigned i = pixelTrackRefsHE_.size();
   std::vector<std::pair<unsigned int, std::pair<double, double>>> VecSeedsatEC;

--- a/Calibration/LumiAlCaRecoProducers/plugins/CorrPCCProducer.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/CorrPCCProducer.cc
@@ -208,7 +208,8 @@ float CorrPCCProducer::getMaximum(std::vector<float> lumi_vector) {
 // the follow non-active bunch crossing to estimate the spill over fraction (type 1 afterglow).
 void CorrPCCProducer::estimateType1Frac(std::vector<float> uncorrPCCPerBX, float& type1Frac) {
   std::vector<float> corrected_tmp_;
-  corrected_tmp_.reserve(uncorrPCCPerBX.size()); for (size_t i = 0; i < uncorrPCCPerBX.size(); i++) {
+  corrected_tmp_.reserve(uncorrPCCPerBX.size());
+  for (size_t i = 0; i < uncorrPCCPerBX.size(); i++) {
     corrected_tmp_.push_back(uncorrPCCPerBX.at(i));
   }
 
@@ -309,7 +310,8 @@ void CorrPCCProducer::calculateCorrections(std::vector<float> uncorrected,
   type1Frac = std::max(0.0, (double)type1Frac);
 
   std::vector<float> corrected_tmp_;
-  corrected_tmp_.reserve(uncorrected.size()); for (size_t i = 0; i < uncorrected.size(); i++) {
+  corrected_tmp_.reserve(uncorrected.size());
+  for (size_t i = 0; i < uncorrected.size(); i++) {
     corrected_tmp_.push_back(uncorrected.at(i));
   }
 

--- a/Calibration/LumiAlCaRecoProducers/plugins/CorrPCCProducer.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/CorrPCCProducer.cc
@@ -208,7 +208,7 @@ float CorrPCCProducer::getMaximum(std::vector<float> lumi_vector) {
 // the follow non-active bunch crossing to estimate the spill over fraction (type 1 afterglow).
 void CorrPCCProducer::estimateType1Frac(std::vector<float> uncorrPCCPerBX, float& type1Frac) {
   std::vector<float> corrected_tmp_;
-  for (size_t i = 0; i < uncorrPCCPerBX.size(); i++) {
+  corrected_tmp_.reserve(uncorrPCCPerBX.size()); for (size_t i = 0; i < uncorrPCCPerBX.size(); i++) {
     corrected_tmp_.push_back(uncorrPCCPerBX.at(i));
   }
 
@@ -309,7 +309,7 @@ void CorrPCCProducer::calculateCorrections(std::vector<float> uncorrected,
   type1Frac = std::max(0.0, (double)type1Frac);
 
   std::vector<float> corrected_tmp_;
-  for (size_t i = 0; i < uncorrected.size(); i++) {
+  corrected_tmp_.reserve(uncorrected.size()); for (size_t i = 0; i < uncorrected.size(); i++) {
     corrected_tmp_.push_back(uncorrected.at(i));
   }
 

--- a/CaloOnlineTools/EcalTools/bin/TPGTreeReader.cpp
+++ b/CaloOnlineTools/EcalTools/bin/TPGTreeReader.cpp
@@ -146,7 +146,7 @@ int main(int argc, char** argv) {
 
   std::vector<int> algobits;
   std::vector<std::string> algos = split(l1algo, ",");
-  for (unsigned int i = 0; i < algos.size(); i++)
+  algobits.reserve(algos.size()); for (unsigned int i = 0; i < algos.size(); i++)
     algobits.push_back(atoi(algos[i].c_str()));
 
   unsigned int ref = 2;

--- a/CaloOnlineTools/EcalTools/bin/TPGTreeReader.cpp
+++ b/CaloOnlineTools/EcalTools/bin/TPGTreeReader.cpp
@@ -146,7 +146,8 @@ int main(int argc, char** argv) {
 
   std::vector<int> algobits;
   std::vector<std::string> algos = split(l1algo, ",");
-  algobits.reserve(algos.size()); for (unsigned int i = 0; i < algos.size(); i++)
+  algobits.reserve(algos.size());
+  for (unsigned int i = 0; i < algos.size(); i++)
     algobits.push_back(atoi(algos[i].c_str()));
 
   unsigned int ref = 2;

--- a/CaloOnlineTools/EcalTools/plugins/EcalTPGAnalyzer.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalTPGAnalyzer.cc
@@ -112,7 +112,7 @@ void EcalTPGAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const& i
   DecisionWord dWord = gtRecord->decisionWord();  // this will get the decision word *before* masking disabled bits
 
   const auto& l1GtTmAlgo = iSetup.getData(l1GtMaskToken_);
-  std::vector<unsigned int> triggerMaskAlgoTrig = l1GtTmAlgo.gtTriggerMask();
+  const std::vector<unsigned int>& triggerMaskAlgoTrig = l1GtTmAlgo.gtTriggerMask();
 
   // apply masks on algo
   int iDaq = 0;

--- a/CaloOnlineTools/HcalOnlineDb/plugins/HcalLutComparer.cc
+++ b/CaloOnlineTools/HcalOnlineDb/plugins/HcalLutComparer.cc
@@ -186,7 +186,7 @@ void HcalLutComparer::dumpLutDiff(LutXml &xmls1, LutXml &xmls2, bool testFormat 
     std::cout << Form("%9s  %6s  %6s  %6s", "Det", "total", "zeroes", "extra") << std::endl;
     for (unsigned int i = 0; i < detCodes.size(); i++) {
       int detCode = detCodes.at(i);
-      std::string detName = detNames.at(i);
+      const std::string& detName = detNames.at(i);
       std::cout << Form("%9s  %6d  %6d  %6d", detName.c_str(), n[detCode][total], n[detCode][zeros], n[detCode][extra])
                 << std::endl;
       if (detCode < 0) {
@@ -211,7 +211,7 @@ void HcalLutComparer::dumpLutDiff(LutXml &xmls1, LutXml &xmls2, bool testFormat 
               << std::endl;
     for (unsigned int i = 0; i < detCodes.size(); i++) {
       int detCode = detCodes.at(i);
-      std::string detName = detNames.at(i);
+      const std::string& detName = detNames.at(i);
       std::cout << Form("%9s  %6d  %6d  %8d  %8d  %11d",
                         detName.c_str(),
                         n[detCode][total],

--- a/CaloOnlineTools/HcalOnlineDb/plugins/HcalLutComparer.cc
+++ b/CaloOnlineTools/HcalOnlineDb/plugins/HcalLutComparer.cc
@@ -186,7 +186,7 @@ void HcalLutComparer::dumpLutDiff(LutXml &xmls1, LutXml &xmls2, bool testFormat 
     std::cout << Form("%9s  %6s  %6s  %6s", "Det", "total", "zeroes", "extra") << std::endl;
     for (unsigned int i = 0; i < detCodes.size(); i++) {
       int detCode = detCodes.at(i);
-      const std::string& detName = detNames.at(i);
+      const std::string &detName = detNames.at(i);
       std::cout << Form("%9s  %6d  %6d  %6d", detName.c_str(), n[detCode][total], n[detCode][zeros], n[detCode][extra])
                 << std::endl;
       if (detCode < 0) {
@@ -211,7 +211,7 @@ void HcalLutComparer::dumpLutDiff(LutXml &xmls1, LutXml &xmls2, bool testFormat 
               << std::endl;
     for (unsigned int i = 0; i < detCodes.size(); i++) {
       int detCode = detCodes.at(i);
-      const std::string& detName = detNames.at(i);
+      const std::string &detName = detNames.at(i);
       std::cout << Form("%9s  %6d  %6d  %8d  %8d  %11d",
                         detName.c_str(),
                         n[detCode][total],

--- a/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseStandardXMLParser.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseStandardXMLParser.cc
@@ -252,7 +252,8 @@ std::vector<unsigned int> ConfigurationDatabaseStandardXMLParser::Item::convert(
     strtol_base = 10;
 
   // convert the data
-  values.reserve(items.size()); for (unsigned int j = 0; j < items.size(); j++)
+  values.reserve(items.size());
+  for (unsigned int j = 0; j < items.size(); j++)
     values.push_back(strtol(items[j].c_str(), nullptr, strtol_base));
   return values;
 }

--- a/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseStandardXMLParser.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseStandardXMLParser.cc
@@ -252,7 +252,7 @@ std::vector<unsigned int> ConfigurationDatabaseStandardXMLParser::Item::convert(
     strtol_base = 10;
 
   // convert the data
-  for (unsigned int j = 0; j < items.size(); j++)
+  values.reserve(items.size()); for (unsigned int j = 0; j < items.size(); j++)
     values.push_back(strtol(items[j].c_str(), nullptr, strtol_base));
   return values;
 }

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
@@ -354,7 +354,7 @@ std::map<int, std::shared_ptr<LutXml>> HcalLutManager::getLinearizationLutXmlFro
 
   // setup "zero" LUT for channel masking
   std::vector<unsigned int> zeroLut;
-  for (size_t adc = 0; adc < 128; adc++)
+  zeroLut.reserve(128); for (size_t adc = 0; adc < 128; adc++)
     zeroLut.push_back(0);
 
   RooGKCounter _counter;

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
@@ -354,7 +354,8 @@ std::map<int, std::shared_ptr<LutXml>> HcalLutManager::getLinearizationLutXmlFro
 
   // setup "zero" LUT for channel masking
   std::vector<unsigned int> zeroLut;
-  zeroLut.reserve(128); for (size_t adc = 0; adc < 128; adc++)
+  zeroLut.reserve(128);
+  for (size_t adc = 0; adc < 128; adc++)
     zeroLut.push_back(0);
 
   RooGKCounter _counter;

--- a/CommonTools/RecoAlgos/plugins/PrimaryVertexSorter.h
+++ b/CommonTools/RecoAlgos/plugins/PrimaryVertexSorter.h
@@ -243,7 +243,7 @@ void PrimaryVertexSorter<ParticlesCollection>::produce(edm::Event& iEvent, const
   if (produceSortedVertices_) {
     std::vector<int> pfToSortedPVVector;
     //      std::vector<int> pfToSortedPVQualityVector;
-    for (size_t i = 0; i < pfToPVVector.size(); i++) {
+    pfToSortedPVVector.reserve(pfToPVVector.size()); for (size_t i = 0; i < pfToPVVector.size(); i++) {
       pfToSortedPVVector.push_back(oldToNew[pfToPVVector[i]]);
       //        pfToSortedPVQualityVector.push_back(pfToPVQualityVector[i]); //same as old!
     }

--- a/CommonTools/RecoAlgos/plugins/PrimaryVertexSorter.h
+++ b/CommonTools/RecoAlgos/plugins/PrimaryVertexSorter.h
@@ -243,7 +243,8 @@ void PrimaryVertexSorter<ParticlesCollection>::produce(edm::Event& iEvent, const
   if (produceSortedVertices_) {
     std::vector<int> pfToSortedPVVector;
     //      std::vector<int> pfToSortedPVQualityVector;
-    pfToSortedPVVector.reserve(pfToPVVector.size()); for (size_t i = 0; i < pfToPVVector.size(); i++) {
+    pfToSortedPVVector.reserve(pfToPVVector.size());
+    for (size_t i = 0; i < pfToPVVector.size(); i++) {
       pfToSortedPVVector.push_back(oldToNew[pfToPVVector[i]]);
       //        pfToSortedPVQualityVector.push_back(pfToPVQualityVector[i]); //same as old!
     }

--- a/CommonTools/UtilAlgos/interface/SortCollectionSelector.h
+++ b/CommonTools/UtilAlgos/interface/SortCollectionSelector.h
@@ -49,7 +49,7 @@ public:
   const_iterator end() const { return selected_.end(); }
   void select(const edm::Handle<InputCollection> &c, const edm::Event &, const edm::EventSetup &) {
     std::vector<pair> v;
-    for (size_t idx = 0; idx < c->size(); ++idx)
+    v.reserve(c->size()); for (size_t idx = 0; idx < c->size(); ++idx)
       v.push_back(std::make_pair(&(*c)[idx], idx));
     std::sort(v.begin(), v.end(), compare_);
     selected_.clear();

--- a/CommonTools/UtilAlgos/interface/SortCollectionSelector.h
+++ b/CommonTools/UtilAlgos/interface/SortCollectionSelector.h
@@ -49,7 +49,8 @@ public:
   const_iterator end() const { return selected_.end(); }
   void select(const edm::Handle<InputCollection> &c, const edm::Event &, const edm::EventSetup &) {
     std::vector<pair> v;
-    v.reserve(c->size()); for (size_t idx = 0; idx < c->size(); ++idx)
+    v.reserve(c->size());
+    for (size_t idx = 0; idx < c->size(); ++idx)
       v.push_back(std::make_pair(&(*c)[idx], idx));
     std::sort(v.begin(), v.end(), compare_);
     selected_.clear();

--- a/CommonTools/Utils/interface/parser/MethodChain.h
+++ b/CommonTools/Utils/interface/parser/MethodChain.h
@@ -53,7 +53,7 @@ namespace reco {
     public:  // Public Methods
       MethodChain(const std::vector<MethodInvoker>& methods);
       MethodChain(const MethodChain&);
-      ~MethodChain();
+      ~MethodChain() override;
       edm::ObjectWithDict value(const edm::ObjectWithDict&) const override;
     };
 

--- a/CondCore/CondDB/src/DbCore.h
+++ b/CondCore/CondDB/src/DbCore.h
@@ -622,7 +622,7 @@ namespace cond {
         if (m_tables.find(Col::tableName()) == m_tables.end()) {
           std::string const tb{Col::tableName()};
           m_coralQuery->addToTableList(std::string(tb));
-          m_tables.insert(std::move(tb));
+          m_tables.insert(tb);
         }
         return *this;
       }

--- a/CondCore/EcalPlugins/plugins/EcalADCToGeVConstant_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalADCToGeVConstant_PayloadInspector.cc
@@ -40,7 +40,7 @@ namespace {
       if (payload.get()) {
         NbRows = 1;
         align = new TH2F("ADC To GeV [GeV/ADC count]", "EB          EE", 2, 0, 2, NbRows, 0, NbRows);
-        EcalADCToGeVConstant it = (*payload);
+        const EcalADCToGeVConstant& it = (*payload);
 
         double row = NbRows - 0.5;
 

--- a/CondCore/EcalPlugins/plugins/EcalSampleMask_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalSampleMask_PayloadInspector.cc
@@ -39,7 +39,7 @@ namespace {
       if (payload.get()) {
         NbRows = 1;
         align = new TH2F("Ecal Sample Mask", "EB          EE", 2, 0, 2, NbRows, 0, NbRows);
-        EcalSampleMask it = (*payload);
+        const EcalSampleMask& it = (*payload);
 
         double row = NbRows - 0.5;
 

--- a/CondCore/EcalPlugins/plugins/EcalSamplesCorrelation_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalSamplesCorrelation_PayloadInspector.cc
@@ -40,7 +40,7 @@ namespace {
       int NbRows;
 
       if (payload.get()) {
-        EcalSamplesCorrelation it = (*payload);
+        const EcalSamplesCorrelation& it = (*payload);
         NbRows = it.EBG12SamplesCorrelation.size();
         if (NbRows == 0)
           return false;
@@ -143,7 +143,7 @@ namespace {
         }
 
         if (payload.get()) {
-          EcalSamplesCorrelation it = (*payload);
+          const EcalSamplesCorrelation& it = (*payload);
           NbRows = it.EBG12SamplesCorrelation.size();
 
           if (irun == 1) {

--- a/CondCore/EcalPlugins/plugins/EcalTimeBiasCorrections_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalTimeBiasCorrections_PayloadInspector.cc
@@ -151,7 +151,7 @@ std::cout<<str.str()<<std::endl;
           payload = this->fetchPayload(std::get<1>(lastiov));
         }
         if (payload.get()) {
-          EcalTimeBiasCorrections it = (*payload);
+          const EcalTimeBiasCorrections& it = (*payload);
 
           NbRows = it.EBTimeCorrAmplitudeBins.size();
           if (irun == 1) {

--- a/CondCore/EcalPlugins/plugins/EcalTimeOffsetConstant_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalTimeOffsetConstant_PayloadInspector.cc
@@ -40,7 +40,7 @@ namespace {
       if (payload.get()) {
         NbRows = 1;
         align = new TH2F("Time Offset Constant [ns]", "EB          EE", 2, 0, 2, NbRows, 0, NbRows);
-        EcalTimeOffsetConstant it = (*payload);
+        const EcalTimeOffsetConstant& it = (*payload);
 
         double row = NbRows - 0.5;
 
@@ -121,7 +121,7 @@ namespace {
           if (irun == 1)
             align = new TH2F("Ecal Time Offset Constant [ns]", "EB          EE", 2, 0, 2, NbRows, 0, NbRows);
 
-          EcalTimeOffsetConstant it = (*payload);
+          const EcalTimeOffsetConstant& it = (*payload);
 
           if (irun == 0) {
             val[0] = it.getEBValue();

--- a/CondCore/L1TPlugins/interface/L1TUtmTriggerMenuPayloadInspectorHelper.h
+++ b/CondCore/L1TPlugins/interface/L1TUtmTriggerMenuPayloadInspectorHelper.h
@@ -251,12 +251,12 @@ namespace L1TUtmTriggerMenuInspectorHelper {
 
   // Explicit specialization outside the class
   template <>
-  std::string L1TUtmTriggerMenuDisplay<L1TUtmCondition>::getLabel() const {
+  inline std::string L1TUtmTriggerMenuDisplay<L1TUtmCondition>::getLabel() const {
     return "#scale[1.1]{Condition Name}";
   }
 
   template <>
-  std::string L1TUtmTriggerMenuDisplay<L1TUtmAlgorithm>::getLabel() const {
+  inline std::string L1TUtmTriggerMenuDisplay<L1TUtmAlgorithm>::getLabel() const {
     return "#scale[1.1]{Algo Name}";
   }
 }  // namespace L1TUtmTriggerMenuInspectorHelper

--- a/CondCore/PhysicsToolsPlugins/plugins/PfCalibration_PayloadInspector.cc
+++ b/CondCore/PhysicsToolsPlugins/plugins/PfCalibration_PayloadInspector.cc
@@ -80,8 +80,8 @@ public:
 
     int pos = ((PerformancePayloadFromTFormulaExposed*)payload.get())->resultPos(T);
     auto formula = payload->formulaPayload();
-    auto formula_vec = formula.formulas();
-    auto limits_vec = formula.limits();
+    const auto& formula_vec = formula.formulas();
+    const auto& limits_vec = formula.limits();
     if (pos < 0 || pos > (int)formula_vec.size()) {
       edm::LogError("PfCalibration") << "Will not display image for " << functType[T]
                                      << " as it's not contained in the payload!";
@@ -89,7 +89,7 @@ public:
     }
     TCanvas canvas("PfCalibration", "PfCalibration", 1500, 800);
     canvas.cd();
-    auto formula_string = formula_vec[pos];
+    const auto& formula_string = formula_vec[pos];
     auto limits = limits_vec[pos];
 
     auto function_plot = new TF1("f1", formula_string.c_str(), limits.first, limits.second);

--- a/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
+++ b/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
@@ -659,7 +659,7 @@ namespace SiStripPI {
                            const TrackerTopology m_trackerTopo)
   /*--------------------------------------------------------------------*/
   {
-    std::vector<SiStripQuality::BadComponent> BC = siStripQuality_->getBadComponentList();
+    const std::vector<SiStripQuality::BadComponent>& BC = siStripQuality_->getBadComponentList();
 
     for (size_t i = 0; i < BC.size(); ++i) {
       //&&&&&&&&&&&&&

--- a/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
@@ -385,7 +385,7 @@ namespace {
           canvas.cd(index)->Update();
 
           std::vector<int> boundaries;
-          for (size_t b = 0; b < v_nAPVs.at(index); b++) {
+          boundaries.reserve(v_nAPVs.at(index)); for (size_t b = 0; b < v_nAPVs.at(index); b++) {
             boundaries.push_back(b * sistrip::STRIPS_PER_APV);
           }
 

--- a/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
@@ -385,7 +385,8 @@ namespace {
           canvas.cd(index)->Update();
 
           std::vector<int> boundaries;
-          boundaries.reserve(v_nAPVs.at(index)); for (size_t b = 0; b < v_nAPVs.at(index); b++) {
+          boundaries.reserve(v_nAPVs.at(index));
+          for (size_t b = 0; b < v_nAPVs.at(index); b++) {
             boundaries.push_back(b * sistrip::STRIPS_PER_APV);
           }
 

--- a/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
@@ -345,7 +345,8 @@ namespace {
           canvas.cd(index)->Update();
 
           std::vector<int> boundaries;
-          boundaries.reserve(v_nAPVs.at(index)); for (size_t b = 0; b < v_nAPVs.at(index); b++) {
+          boundaries.reserve(v_nAPVs.at(index));
+          for (size_t b = 0; b < v_nAPVs.at(index); b++) {
             boundaries.push_back(b * sistrip::STRIPS_PER_APV);
           }
 

--- a/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
@@ -345,7 +345,7 @@ namespace {
           canvas.cd(index)->Update();
 
           std::vector<int> boundaries;
-          for (size_t b = 0; b < v_nAPVs.at(index); b++) {
+          boundaries.reserve(v_nAPVs.at(index)); for (size_t b = 0; b < v_nAPVs.at(index); b++) {
             boundaries.push_back(b * sistrip::STRIPS_PER_APV);
           }
 

--- a/CondFormats/DQMObjects/src/HDQMSummary.cc
+++ b/CondFormats/DQMObjects/src/HDQMSummary.cc
@@ -103,7 +103,7 @@ void HDQMSummary::setObj(const uint32_t& detID, std::string elementName, float v
 }
 
 std::vector<float> HDQMSummary::getSummaryObj(uint32_t& detID, const std::vector<std::string>& _list) const {
-  std::vector<std::string> list = _list;
+  const std::vector<std::string>& list = _list;
   std::vector<float> SummaryObj;
   const HDQMSummary::Range range = getRange(detID);
   if (range.first != range.second) {

--- a/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
+++ b/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
@@ -50,7 +50,7 @@ JetCorrectorParameters::Definitions::Definitions(const std::string& fLine) {
     for (unsigned i = 0; i < npar; i++)
       mParVar.push_back(tokens[nvar + 2 + i]);
     mFormula = tokens[npar + nvar + 2];
-    std::string ss = tokens[npar + nvar + 3];
+    const std::string& ss = tokens[npar + nvar + 3];
     if (ss == "Response")
       mIsResponse = true;
     else if (ss == "Correction")
@@ -268,7 +268,7 @@ unsigned JetCorrectorParameters::size(unsigned fVar) const {
 //------------------------------------------------------------------------
 std::vector<float> JetCorrectorParameters::binCenters(unsigned fVar) const {
   std::vector<float> result;
-  for (unsigned i = 0; i < size(); ++i)
+  result.reserve(size()); for (unsigned i = 0; i < size(); ++i)
     result.push_back(record(i).xMiddle(fVar));
   return result;
 }

--- a/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
+++ b/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
@@ -268,7 +268,8 @@ unsigned JetCorrectorParameters::size(unsigned fVar) const {
 //------------------------------------------------------------------------
 std::vector<float> JetCorrectorParameters::binCenters(unsigned fVar) const {
   std::vector<float> result;
-  result.reserve(size()); for (unsigned i = 0; i < size(); ++i)
+  result.reserve(size());
+  for (unsigned i = 0; i < size(); ++i)
     result.push_back(record(i).xMiddle(fVar));
   return result;
 }

--- a/CondFormats/L1TObjects/interface/L1MuPacking.h
+++ b/CondFormats/L1TObjects/interface/L1MuPacking.h
@@ -84,9 +84,9 @@ public:
   };
 
 private:
-  int signFromPacked(unsigned packed) const = 0;
-  int idxFromPacked(unsigned packed) const = 0;
-  unsigned packedFromIdx(int idx) const = 0;
+  int signFromPacked(unsigned packed) const override = 0;
+  int idxFromPacked(unsigned packed) const override = 0;
+  unsigned packedFromIdx(int idx) const override = 0;
 };
 
 /**
@@ -134,9 +134,9 @@ public:
   };
 
 private:
-  int signFromPacked(unsigned packed) const = 0;
-  int idxFromPacked(unsigned packed) const = 0;
-  unsigned packedFromIdx(int idx) const = 0;
+  int signFromPacked(unsigned packed) const override = 0;
+  int idxFromPacked(unsigned packed) const override = 0;
+  unsigned packedFromIdx(int idx) const override = 0;
 };
 
 /**

--- a/CondFormats/L1TObjects/src/L1GctJetFinderParams.cc
+++ b/CondFormats/L1TObjects/src/L1GctJetFinderParams.cc
@@ -353,8 +353,8 @@ std::ostream& operator<<(std::ostream& os, const L1GctJetFinderParams& fn) {
         os << "Unrecognised" << std::endl;
         break;
     }
-    std::vector<std::vector<double> > jetCoeffs = fn.getJetCorrCoeffs();
-    std::vector<std::vector<double> > tauCoeffs = fn.getTauCorrCoeffs();
+    const std::vector<std::vector<double> >& jetCoeffs = fn.getJetCorrCoeffs();
+    const std::vector<std::vector<double> >& tauCoeffs = fn.getTauCorrCoeffs();
 
     os << "Non-tau jet correction coefficients" << std::endl;
     for (unsigned i = 0; i < jetCoeffs.size(); i++) {

--- a/CondFormats/SiPixelObjects/src/SiPixelCalibConfiguration.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelCalibConfiguration.cc
@@ -75,8 +75,8 @@ SiPixelCalibConfiguration::SiPixelCalibConfiguration(const pos::PixelCalibConfig
   }
   // copy row and column patterns
 
-  std::vector<std::vector<uint32_t> > cols = fancyConfig.columnList();
-  std::vector<std::vector<uint32_t> > rows = fancyConfig.rowList();
+  const std::vector<std::vector<uint32_t> >& cols = fancyConfig.columnList();
+  const std::vector<std::vector<uint32_t> >& rows = fancyConfig.rowList();
   for (uint32_t i = 0; i < cols.size(); ++i) {
     for (uint32_t j = 0; j < cols[i].size(); ++j) {
       short colval = cols[i][j];

--- a/CondFormats/SiPixelObjects/src/SiPixelCalibConfiguration.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelCalibConfiguration.cc
@@ -75,8 +75,8 @@ SiPixelCalibConfiguration::SiPixelCalibConfiguration(const pos::PixelCalibConfig
   }
   // copy row and column patterns
 
-  const std::vector<std::vector<uint32_t> >& cols = fancyConfig.columnList();
-  const std::vector<std::vector<uint32_t> >& rows = fancyConfig.rowList();
+  const std::vector<std::vector<uint32_t> > &cols = fancyConfig.columnList();
+  const std::vector<std::vector<uint32_t> > &rows = fancyConfig.rowList();
   for (uint32_t i = 0; i < cols.size(); ++i) {
     for (uint32_t j = 0; j < cols[i].size(); ++j) {
       short colval = cols[i][j];

--- a/CondTools/Ecal/src/EcalChannelStatusHandler.cc
+++ b/CondTools/Ecal/src/EcalChannelStatusHandler.cc
@@ -454,7 +454,7 @@ void popcon::EcalChannelStatusHandler::daqOut(const RunIOV& _myRun) {
                                              "EE_crystal_number");
 
       for (size_t mycrys = 0; mycrys < badCrystals.size(); mycrys++) {
-        EcalLogicID ecid_xt = badCrystals[mycrys];
+        const EcalLogicID& ecid_xt = badCrystals[mycrys];
         int zSide = 999;
         int log_id = ecid_xt.getLogicID();
         int yt2 = log_id % 1000;              //  EE_crystal_number:   2010100060 -> z=-1, x=100, y=60
@@ -488,7 +488,7 @@ void popcon::EcalChannelStatusHandler::daqOut(const RunIOV& _myRun) {
                                              "EB_crystal_number");
 
       for (size_t mycrys = 0; mycrys < badCrystals.size(); mycrys++) {
-        EcalLogicID ecid_xt = badCrystals[mycrys];
+        const EcalLogicID& ecid_xt = badCrystals[mycrys];
         int sm_num = ecid_xt.getID1();
         int log_id = ecid_xt.getLogicID();
         int xt2_num = log_id % 10000;

--- a/CondTools/Hcal/bin/corrGains.cc
+++ b/CondTools/Hcal/bin/corrGains.cc
@@ -38,7 +38,7 @@ corrGains::corrGains(const edm::ParameterSet& iConfig) {
 corrGains::~corrGains() {}
 
 void corrGains::analyze(edm::Event const&, edm::EventSetup const& iSetup) {
-  HcalTopology topo = iSetup.getData(tok_htopo_);
+  const HcalTopology& topo = iSetup.getData(tok_htopo_);
 
   HcalGains gainsIn(&topo);
   ;

--- a/CondTools/Hcal/bin/corrResps.cc
+++ b/CondTools/Hcal/bin/corrResps.cc
@@ -36,7 +36,7 @@ corrResps::corrResps(const edm::ParameterSet& iConfig) {
 corrResps::~corrResps() {}
 
 void corrResps::analyze(edm::Event const&, edm::EventSetup const& iSetup) {
-  HcalTopology topo = iSetup.getData(tok_htopo_);
+  const HcalTopology& topo = iSetup.getData(tok_htopo_);
 
   HcalRespCorrs respIn(&topo);
   std::ifstream inStream(fileIn.c_str());

--- a/CondTools/Hcal/bin/modGains.cc
+++ b/CondTools/Hcal/bin/modGains.cc
@@ -58,7 +58,7 @@ modGains::modGains(const edm::ParameterSet& iConfig) : vectorop(false) {
 modGains::~modGains() {}
 
 void modGains::analyze(edm::Event const&, edm::EventSetup const& iSetup) {
-  HcalTopology topo = iSetup.getData(tok_htopo_);
+  const HcalTopology& topo = iSetup.getData(tok_htopo_);
 
   // get base conditions
   std::cerr << fileIn << std::endl;

--- a/CondTools/Hcal/bin/scaleGains.cc
+++ b/CondTools/Hcal/bin/scaleGains.cc
@@ -37,7 +37,7 @@ scaleGains::scaleGains(const edm::ParameterSet& iConfig) {
 scaleGains::~scaleGains() {}
 
 void scaleGains::analyze(edm::Event const&, edm::EventSetup const& iSetup) {
-  HcalTopology topo = iSetup.getData(tok_htopo_);
+  const HcalTopology& topo = iSetup.getData(tok_htopo_);
 
   HcalGains gainsIn(&topo);
   ;

--- a/DPGAnalysis/SiStripTools/plugins/TrackerDpgAnalysis.cc
+++ b/DPGAnalysis/SiStripTools/plugins/TrackerDpgAnalysis.cc
@@ -713,7 +713,8 @@ void TrackerDpgAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup
 
   // build the reverse map tracks -> vertex
   std::vector<std::map<size_t, int> > trackVertices;
-  trackVertices.reserve(trackSize); for (size_t i = 0; i < trackSize; ++i) {
+  trackVertices.reserve(trackSize);
+  for (size_t i = 0; i < trackSize; ++i) {
     trackVertices.push_back(inVertex(trackCollection[0], vertexColl, globalvertexid_ + 1));
   }
 
@@ -775,11 +776,13 @@ void TrackerDpgAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup
 
   // determine if each cluster is on a track or not, and record the trackid
   std::vector<std::vector<int> > stripClusterOntrackIndices;
-  stripClusterOntrackIndices.reserve(trackSize); for (size_t i = 0; i < trackSize; ++i) {
+  stripClusterOntrackIndices.reserve(trackSize);
+  for (size_t i = 0; i < trackSize; ++i) {
     stripClusterOntrackIndices.push_back(onTrack(clusters, trackCollection[i], globaltrackid_[i] + 1));
   }
   std::vector<std::vector<int> > pixelClusterOntrackIndices;
-  pixelClusterOntrackIndices.reserve(trackSize); for (size_t i = 0; i < trackSize; ++i) {
+  pixelClusterOntrackIndices.reserve(trackSize);
+  for (size_t i = 0; i < trackSize; ++i) {
     pixelClusterOntrackIndices.push_back(onTrack(pixelclusters, trackCollection[i], globaltrackid_[i] + 1));
   }
   nclustersOntrack_ = count_if(

--- a/DPGAnalysis/SiStripTools/plugins/TrackerDpgAnalysis.cc
+++ b/DPGAnalysis/SiStripTools/plugins/TrackerDpgAnalysis.cc
@@ -713,7 +713,7 @@ void TrackerDpgAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup
 
   // build the reverse map tracks -> vertex
   std::vector<std::map<size_t, int> > trackVertices;
-  for (size_t i = 0; i < trackSize; ++i) {
+  trackVertices.reserve(trackSize); for (size_t i = 0; i < trackSize; ++i) {
     trackVertices.push_back(inVertex(trackCollection[0], vertexColl, globalvertexid_ + 1));
   }
 
@@ -775,11 +775,11 @@ void TrackerDpgAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup
 
   // determine if each cluster is on a track or not, and record the trackid
   std::vector<std::vector<int> > stripClusterOntrackIndices;
-  for (size_t i = 0; i < trackSize; ++i) {
+  stripClusterOntrackIndices.reserve(trackSize); for (size_t i = 0; i < trackSize; ++i) {
     stripClusterOntrackIndices.push_back(onTrack(clusters, trackCollection[i], globaltrackid_[i] + 1));
   }
   std::vector<std::vector<int> > pixelClusterOntrackIndices;
-  for (size_t i = 0; i < trackSize; ++i) {
+  pixelClusterOntrackIndices.reserve(trackSize); for (size_t i = 0; i < trackSize; ++i) {
     pixelClusterOntrackIndices.push_back(onTrack(pixelclusters, trackCollection[i], globaltrackid_[i] + 1));
   }
   nclustersOntrack_ = count_if(

--- a/DPGAnalysis/SiStripTools/src/EventShape.cc
+++ b/DPGAnalysis/SiStripTools/src/EventShape.cc
@@ -27,7 +27,7 @@ EventShape::EventShape(reco::TrackCollection& tracks) : eigenvalues(3) {
   MomentumTensor *= 1 / (MomentumTensor[0][0] + MomentumTensor[1][1] + MomentumTensor[2][2]);
   // find the eigen values
   TMatrixDSymEigen eigen(MomentumTensor);
-  TVectorD eigenvals = eigen.GetEigenValues();
+  const TVectorD& eigenvals = eigen.GetEigenValues();
   eigenvalues[0] = eigenvals[0];
   eigenvalues[1] = eigenvals[1];
   eigenvalues[2] = eigenvals[2];
@@ -232,7 +232,7 @@ float EventShape::sphericity(const reco::TrackCollection& tracks) {
   MomentumTensor *= 1 / (MomentumTensor[0][0] + MomentumTensor[1][1] + MomentumTensor[2][2]);
   // find the eigen values
   TMatrixDSymEigen eigen(MomentumTensor);
-  TVectorD eigenvals = eigen.GetEigenValues();
+  const TVectorD& eigenvals = eigen.GetEigenValues();
   vector<float> eigenvaluess(3);
   eigenvaluess[0] = eigenvals[0];
   eigenvaluess[1] = eigenvals[1];
@@ -262,7 +262,7 @@ float EventShape::aplanarity(const reco::TrackCollection& tracks) {
   MomentumTensor *= 1 / (MomentumTensor[0][0] + MomentumTensor[1][1] + MomentumTensor[2][2]);
   // find the eigen values
   TMatrixDSymEigen eigen(MomentumTensor);
-  TVectorD eigenvals = eigen.GetEigenValues();
+  const TVectorD& eigenvals = eigen.GetEigenValues();
   vector<float> eigenvaluess(3);
   eigenvaluess[0] = eigenvals[0];
   eigenvaluess[1] = eigenvals[1];
@@ -291,7 +291,7 @@ float EventShape::planarity(const reco::TrackCollection& tracks) {
   MomentumTensor *= 1 / (MomentumTensor[0][0] + MomentumTensor[1][1] + MomentumTensor[2][2]);
   // find the eigen values
   TMatrixDSymEigen eigen(MomentumTensor);
-  TVectorD eigenvals = eigen.GetEigenValues();
+  const TVectorD& eigenvals = eigen.GetEigenValues();
   vector<float> eigenvaluess(3);
   eigenvaluess[0] = eigenvals[0];
   eigenvaluess[1] = eigenvals[1];

--- a/DQM/CSCMonitorModule/plugins/CSCOfflineClient.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCOfflineClient.cc
@@ -97,7 +97,7 @@ void CSCOfflineClient::dqmEndJob(DQMStore::IBooker& ib, DQMStore::IGetter& igett
   ibooker->setCurrentFolder(config.getFOLDER_EMU());
   std::vector<std::string> me_names = igetter.getMEs();
   for (std::vector<std::string>::iterator iter = me_names.begin(); iter != me_names.end(); iter++) {
-    std::string me_name = *iter;
+    const std::string& me_name = *iter;
     MonitorElement* me = igetter.get(config.getFOLDER_EMU() + me_name);
     cscdqm::HistoId id;
     if (me && cscdqm::HistoDef::getHistoIdByName(me_name, id)) {

--- a/DQM/CastorMonitor/src/CastorDigiMonitor.cc
+++ b/DQM/CastorMonitor/src/CastorDigiMonitor.cc
@@ -73,7 +73,7 @@ void CastorDigiMonitor::bookHistograms(DQMStore::IBooker &ibooker,
       "average E(digi) in BX", "Castor average E (digi);Event.BX;fC", 3601, -0.5, 3600.5, 0., 1.e10, "");
   hBX->getTProfile()->SetOption("hist");
 
-  const string& trname = HltPaths_[0];
+  const string &trname = HltPaths_[0];
   hpBXtrig = ibooker.bookProfile("average E(digi) in BXtrig",
                                  "Castor average E (digi) trigger:'" + trname + "';Event.BX;fC",
                                  3601,

--- a/DQM/CastorMonitor/src/CastorDigiMonitor.cc
+++ b/DQM/CastorMonitor/src/CastorDigiMonitor.cc
@@ -73,7 +73,7 @@ void CastorDigiMonitor::bookHistograms(DQMStore::IBooker &ibooker,
       "average E(digi) in BX", "Castor average E (digi);Event.BX;fC", 3601, -0.5, 3600.5, 0., 1.e10, "");
   hBX->getTProfile()->SetOption("hist");
 
-  string trname = HltPaths_[0];
+  const string& trname = HltPaths_[0];
   hpBXtrig = ibooker.bookProfile("average E(digi) in BXtrig",
                                  "Castor average E (digi) trigger:'" + trname + "';Event.BX;fC",
                                  3601,

--- a/DQM/DTMonitorClient/src/DTLocalTriggerBaseTest.cc
+++ b/DQM/DTMonitorClient/src/DTLocalTriggerBaseTest.cc
@@ -279,7 +279,7 @@ pair<float, float> DTLocalTriggerBaseTest::phiRange(const DTChamberId& id) {
     } else
       return make_pair(min, max);
 
-    DTTopology topo2 = layer2->specificTopology();
+    const DTTopology& topo2 = layer2->specificTopology();
 
     if (lposx > 0) {
       max = lposx * .5 + topo2.wirePosition(topo2.lastChannel());

--- a/DQM/DTMonitorModule/src/DTChamberEfficiency.cc
+++ b/DQM/DTMonitorModule/src/DTChamberEfficiency.cc
@@ -187,7 +187,7 @@ void DTChamberEfficiency::analyze(const Event& event, const EventSetup& eventSet
           continue;
 
         // get the first det (it's the most compatible)
-        const DetWithState detWithState = dss.front();
+        const DetWithState& detWithState = dss.front();
         const DetId idDetLay = detWithState.first->geographicalId();
 
         // check if this is a DT and the track has the needed quality

--- a/DQM/DTMonitorModule/src/DTLocalTriggerBaseTask.cc
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerBaseTask.cc
@@ -219,7 +219,7 @@ void DTLocalTriggerBaseTask::bookHistos(DQMStore::IBooker& ibooker, const DTCham
     for (size_t iLabel = 0; iLabel < plotLabels.size(); ++iLabel) {
       // Book Phi View Related Plots
 
-      auto plotLabel = plotLabels.at(iLabel);
+      const auto& plotLabel = plotLabels.at(iLabel);
       ibooker.setCurrentFolder(topFolder(type) + "Wheel" + wheel.str() + "/Sector" + sector.str() + "/Station" +
                                station.str() + folderLabels.at(iLabel));
 

--- a/DQM/L1TMonitor/src/L1TCaloLayer1Summary.cc
+++ b/DQM/L1TMonitor/src/L1TCaloLayer1Summary.cc
@@ -33,8 +33,8 @@ void L1TCaloLayer1Summary::analyze(const edm::Event& iEvent, const edm::EventSet
     }
   }
 
-  L1CaloRegionCollection caloLayer1Regions = iEvent.get(caloLayer1RegionsToken_);
-  L1CaloRegionCollection simRegions = iEvent.get(simRegionsToken_);
+  const L1CaloRegionCollection& caloLayer1Regions = iEvent.get(caloLayer1RegionsToken_);
+  const L1CaloRegionCollection& simRegions = iEvent.get(simRegionsToken_);
   int nRegions = caloLayer1Regions.size();
 
   unsigned int maxEtaIdx = 0;
@@ -57,8 +57,8 @@ void L1TCaloLayer1Summary::analyze(const edm::Event& iEvent, const edm::EventSet
   }
 
   for (int iRegion = 0; iRegion < nRegions; iRegion++) {
-    L1CaloRegion cRegion = caloLayer1Regions[iRegion];
-    L1CaloRegion sRegion = simRegions[iRegion];
+    const L1CaloRegion& cRegion = caloLayer1Regions[iRegion];
+    const L1CaloRegion& sRegion = simRegions[iRegion];
 
     foundMatrix[0][cRegion.gctEta()][cRegion.gctPhi()] = true;
     etMatrix[0][cRegion.gctEta()][cRegion.gctPhi()] = cRegion.et();
@@ -77,9 +77,9 @@ void L1TCaloLayer1Summary::analyze(const edm::Event& iEvent, const edm::EventSet
     }
   }
 
-  auto caloCICADAScores = iEvent.get(caloLayer1CICADAScoreToken_);
+  const auto& caloCICADAScores = iEvent.get(caloLayer1CICADAScoreToken_);
   const auto& gtCICADAScores = iEvent.get(gtCICADAScoreToken_);
-  auto simCICADAScores = iEvent.get(simCICADAScoreToken_);
+  const auto& simCICADAScores = iEvent.get(simCICADAScoreToken_);
 
   if (caloCICADAScores.size() > 0) {
     histoCaloLayer1CICADAScore->Fill(caloCICADAScores[0]);

--- a/DQM/L1TMonitor/src/L1TObjectsTiming.cc
+++ b/DQM/L1TMonitor/src/L1TObjectsTiming.cc
@@ -303,7 +303,8 @@ void L1TObjectsTiming::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run
 
       ibooker.setCurrentFolder(monitorDir_ + "/L1TEGamma/timing/Isolated_bunch/ptmin_" + egammaPtCutStrAlpha + "_gev");
       std::vector<MonitorElement*> vHelper;
-      vHelper.reserve(bxrange_); for (unsigned int i = 0; i < bxrange_; ++i) {
+      vHelper.reserve(bxrange_);
+      for (unsigned int i = 0; i < bxrange_; ++i) {
         vHelper.push_back(ibooker.book2D("egamma_eta_phi_bx_isolated_" + bx_obj[i],
                                          "L1T EGamma p_{T}#geq" + egammaPtCutStr +
                                              " GeV #eta vs #phi for first bunch BX=" + bx_obj[i] + ";#eta;#phi",
@@ -482,7 +483,8 @@ void L1TObjectsTiming::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run
 
       ibooker.setCurrentFolder(monitorDir_ + "/L1TEGamma/timing/First_bunch/ptmin_" + egammaPtCutStrAlpha + "_gev");
       std::vector<MonitorElement*> vHelper;
-      vHelper.reserve(bxrange_ - 2); for (unsigned int i = 0; i < bxrange_ - 2; ++i) {
+      vHelper.reserve(bxrange_ - 2);
+      for (unsigned int i = 0; i < bxrange_ - 2; ++i) {
         vHelper.push_back(ibooker.book2D("egamma_eta_phi_bx_firstbunch_" + bx_obj[i],
                                          "L1T EGamma p_{T}#geq" + egammaPtCutStr +
                                              " GeV #eta vs #phi for first bunch BX=" + bx_obj[i] + ";#eta;#phi",
@@ -661,7 +663,8 @@ void L1TObjectsTiming::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run
 
       ibooker.setCurrentFolder(monitorDir_ + "/L1TEGamma/timing/Last_bunch/ptmin_" + egammaPtCutStrAlpha + "_gev");
       std::vector<MonitorElement*> vHelper;
-      vHelper.reserve(bxrange_ - 2); for (unsigned int i = 0; i < bxrange_ - 2; ++i) {
+      vHelper.reserve(bxrange_ - 2);
+      for (unsigned int i = 0; i < bxrange_ - 2; ++i) {
         vHelper.push_back(ibooker.book2D("egamma_eta_phi_bx_lastbunch_" + bx_obj[i + 2],
                                          "L1T EGamma p_{T}#geq" + egammaPtCutStr +
                                              " GeV #eta vs #phi for first bunch BX=" + bx_obj[i] + ";#eta;#phi",

--- a/DQM/L1TMonitor/src/L1TObjectsTiming.cc
+++ b/DQM/L1TMonitor/src/L1TObjectsTiming.cc
@@ -303,7 +303,7 @@ void L1TObjectsTiming::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run
 
       ibooker.setCurrentFolder(monitorDir_ + "/L1TEGamma/timing/Isolated_bunch/ptmin_" + egammaPtCutStrAlpha + "_gev");
       std::vector<MonitorElement*> vHelper;
-      for (unsigned int i = 0; i < bxrange_; ++i) {
+      vHelper.reserve(bxrange_); for (unsigned int i = 0; i < bxrange_; ++i) {
         vHelper.push_back(ibooker.book2D("egamma_eta_phi_bx_isolated_" + bx_obj[i],
                                          "L1T EGamma p_{T}#geq" + egammaPtCutStr +
                                              " GeV #eta vs #phi for first bunch BX=" + bx_obj[i] + ";#eta;#phi",
@@ -482,7 +482,7 @@ void L1TObjectsTiming::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run
 
       ibooker.setCurrentFolder(monitorDir_ + "/L1TEGamma/timing/First_bunch/ptmin_" + egammaPtCutStrAlpha + "_gev");
       std::vector<MonitorElement*> vHelper;
-      for (unsigned int i = 0; i < bxrange_ - 2; ++i) {
+      vHelper.reserve(bxrange_ - 2); for (unsigned int i = 0; i < bxrange_ - 2; ++i) {
         vHelper.push_back(ibooker.book2D("egamma_eta_phi_bx_firstbunch_" + bx_obj[i],
                                          "L1T EGamma p_{T}#geq" + egammaPtCutStr +
                                              " GeV #eta vs #phi for first bunch BX=" + bx_obj[i] + ";#eta;#phi",
@@ -661,7 +661,7 @@ void L1TObjectsTiming::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run
 
       ibooker.setCurrentFolder(monitorDir_ + "/L1TEGamma/timing/Last_bunch/ptmin_" + egammaPtCutStrAlpha + "_gev");
       std::vector<MonitorElement*> vHelper;
-      for (unsigned int i = 0; i < bxrange_ - 2; ++i) {
+      vHelper.reserve(bxrange_ - 2); for (unsigned int i = 0; i < bxrange_ - 2; ++i) {
         vHelper.push_back(ibooker.book2D("egamma_eta_phi_bx_lastbunch_" + bx_obj[i + 2],
                                          "L1T EGamma p_{T}#geq" + egammaPtCutStr +
                                              " GeV #eta vs #phi for first bunch BX=" + bx_obj[i] + ";#eta;#phi",

--- a/DQM/Physics/src/EwkMuLumiMonitorDQM.cc
+++ b/DQM/Physics/src/EwkMuLumiMonitorDQM.cc
@@ -491,7 +491,7 @@ void EwkMuLumiMonitorDQM::analyze(const Event& ev, const EventSetup&) {
       const MET& met = metCollection->at(0);
       nW = 0;
       for (unsigned int i = 0; i < nHighPtGlbMu; i++) {
-        reco::Muon muon1 = highPtGlbMuons[i];
+        const reco::Muon& muon1 = highPtGlbMuons[i];
         /*
                quality cut not implemented
             Quality Cuts           double dxy =
@@ -520,7 +520,7 @@ if (!quality) continue;
 
         if (!metIncludesMuons_) {
           for (unsigned int i = 0; i < nHighPtGlbMu; i++) {
-            reco::Muon muon1 = highPtGlbMuons[i];
+            const reco::Muon& muon1 = highPtGlbMuons[i];
             met_px -= muon1.px();
             met_py -= muon1.py();
           }
@@ -554,7 +554,7 @@ if (!quality) continue;
     // efficiency  and muon system efficiency
     if (!(isZGolden2HLT_ || isZGolden1HLT_ || isZGoldenNoIso_)) {
       for (unsigned int i = 0; i < nHighPtGlbMu; ++i) {
-        reco::Muon glbMuon = highPtGlbMuons[i];
+        const reco::Muon& glbMuon = highPtGlbMuons[i];
         const math::XYZTLorentzVector& mu1(glbMuon.p4());
         // double pt1= glbMuon.pt();
         // checking that the global muon is hlt matched otherwise skip the event
@@ -571,7 +571,7 @@ if (!quality) continue;
         // stop the loop after 10 cicles....
         (nHighPtStaMu > 10) ? nHighPtStaMu = 10 : 1;
         for (unsigned int j = 0; j < nHighPtStaMu; ++j) {
-          reco::Muon staMuon = highPtStaMuons[j];
+          const reco::Muon& staMuon = highPtStaMuons[j];
           const math::XYZTLorentzVector& mu2(staMuon.p4());
           // double pt2= staMuon.pt();
           if (glbMuon.charge() == staMuon.charge())

--- a/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySource.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySource.cc
@@ -531,7 +531,7 @@ void SiPixelHitEfficiencySource::analyze(const edm::Event &iEvent, const edm::Ev
     // left
     if (!expTrajMeasurements.empty()) {
       for (size_t f = 0; f < expTrajMeasurements.size(); f++) {
-        const TrajectoryMeasurement& AddHit = expTrajMeasurements[f];
+        const TrajectoryMeasurement &AddHit = expTrajMeasurements[f];
         if (AddHit.recHit()->getType() == TrackingRecHit::missing) {
           tmeasColl.push_back(AddHit);
           isBpixtrack = true;

--- a/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySource.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySource.cc
@@ -531,7 +531,7 @@ void SiPixelHitEfficiencySource::analyze(const edm::Event &iEvent, const edm::Ev
     // left
     if (!expTrajMeasurements.empty()) {
       for (size_t f = 0; f < expTrajMeasurements.size(); f++) {
-        TrajectoryMeasurement AddHit = expTrajMeasurements[f];
+        const TrajectoryMeasurement& AddHit = expTrajMeasurements[f];
         if (AddHit.recHit()->getType() == TrackingRecHit::missing) {
           tmeasColl.push_back(AddHit);
           isBpixtrack = true;

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackEfficiency.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackEfficiency.cc
@@ -417,7 +417,7 @@ namespace {
         bool valid = false;
         bool missing = false;
         bool passcuts_hit = true;
-        TrajectoryMeasurement pxb1TM(expTrajMeasurements[p]);
+        const TrajectoryMeasurement& pxb1TM(expTrajMeasurements[p]);
         const auto& pxb1Hit = pxb1TM.recHit();
         bool inactive = (pxb1Hit->getType() == TrackingRecHit::inactive);
         int detidHit = pxb1Hit->geographicalId();

--- a/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
+++ b/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
@@ -793,7 +793,7 @@ void SiStripMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventSe
       // All connections for a detid have same FED Id therefore one FEDID is
       // associated with a given detID. Vector of constant FedChannelConnection
       // objects to variable pointers.
-      std::vector<const FedChannelConnection*> fedConnections = siStripDetCabling.getConnections(detid);
+      const std::vector<const FedChannelConnection*>& fedConnections = siStripDetCabling.getConnections(detid);
 
       // Filling FED Id associated clusters map.
 

--- a/DQM/SiStripMonitorPedestals/src/SiStripMonitorRawData.cc
+++ b/DQM/SiStripMonitorPedestals/src/SiStripMonitorRawData.cc
@@ -96,7 +96,7 @@ void SiStripMonitorRawData::analyze(edm::Event const &iEvent, edm::EventSetup co
        ++idetid) {
     std::vector<edm::DetSet<SiStripRawDigi>>::const_iterator digis = digi_collection->find((*idetid));
     if (digis == digi_collection->end() || digis->data.empty() || digis->data.size() > 768) {
-      const std::vector<const FedChannelConnection *>& fed_conns = detcabling.getConnections((*idetid));
+      const std::vector<const FedChannelConnection *> &fed_conns = detcabling.getConnections((*idetid));
       for (unsigned int k = 0; k < fed_conns.size(); k++) {
         if (fed_conns[k] && fed_conns[k]->isConnected()) {
           float fed_id = fed_conns[k]->fedId() + 0.01 * fed_conns[k]->fedCh();

--- a/DQM/SiStripMonitorPedestals/src/SiStripMonitorRawData.cc
+++ b/DQM/SiStripMonitorPedestals/src/SiStripMonitorRawData.cc
@@ -96,7 +96,7 @@ void SiStripMonitorRawData::analyze(edm::Event const &iEvent, edm::EventSetup co
        ++idetid) {
     std::vector<edm::DetSet<SiStripRawDigi>>::const_iterator digis = digi_collection->find((*idetid));
     if (digis == digi_collection->end() || digis->data.empty() || digis->data.size() > 768) {
-      std::vector<const FedChannelConnection *> fed_conns = detcabling.getConnections((*idetid));
+      const std::vector<const FedChannelConnection *>& fed_conns = detcabling.getConnections((*idetid));
       for (unsigned int k = 0; k < fed_conns.size(); k++) {
         if (fed_conns[k] && fed_conns[k]->isConnected()) {
           float fed_id = fed_conns[k]->fedId() + 0.01 * fed_conns[k]->fedCh();

--- a/DQM/TrackerRemapper/src/Phase1PixelSummaryMap.cc
+++ b/DQM/TrackerRemapper/src/Phase1PixelSummaryMap.cc
@@ -196,7 +196,7 @@ void Phase1PixelSummaryMap::addNamedBins(
 
       auto detInfo = Ph1PMapSummaryHelper::tokenize(tokens[0], ' ');
       unsigned int detId = stoi(detInfo[0]);
-           auto xy = Ph1PMapSummaryHelper::tokenize(tokens[1], ' ');
+      auto xy = Ph1PMapSummaryHelper::tokenize(tokens[1], ' ');
       unsigned int verNum = 1;
       std::vector<float> xP, yP;
       for (const auto& coord : xy) {

--- a/DQM/TrackerRemapper/src/Phase1PixelSummaryMap.cc
+++ b/DQM/TrackerRemapper/src/Phase1PixelSummaryMap.cc
@@ -196,8 +196,7 @@ void Phase1PixelSummaryMap::addNamedBins(
 
       auto detInfo = Ph1PMapSummaryHelper::tokenize(tokens[0], ' ');
       unsigned int detId = stoi(detInfo[0]);
-      std::string detIdName = detInfo[1];
-      auto xy = Ph1PMapSummaryHelper::tokenize(tokens[1], ' ');
+           auto xy = Ph1PMapSummaryHelper::tokenize(tokens[1], ' ');
       unsigned int verNum = 1;
       std::vector<float> xP, yP;
       for (const auto& coord : xy) {

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -1419,7 +1419,7 @@ void TrackAnalyzer::fillHistosForEfficiencyFromHitPatter(const reco::Track& trac
 
   //    if (track.pt() > 1.0 && track.dxy() < 0.1 and monitoring > 0) {
   if (track.pt() > 1.0 && track.dxy() < 0.1 and monitoring > -9.) {
-    auto hp = track.hitPattern();
+    const auto& hp = track.hitPattern();
     // Here hit_category is meant to iterate over
     // reco::HitPattern::HitCategory, defined here:
     // http://cmslxr.fnal.gov/dxr/CMSSW/source/DataFormats/TrackReco/interface/HitPattern.h

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -214,9 +214,9 @@ TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig)
     if (primaryVertexInputTags.size() == pvLabels.size() and
         primaryVertexInputTags.size() == selPrimaryVertexInputTags.size()) {
       for (size_t i = 0; i < primaryVertexInputTags.size(); i++) {
-        edm::InputTag iPVinputTag = primaryVertexInputTags[i];
-        edm::InputTag iSelPVinputTag = selPrimaryVertexInputTags[i];
-        std::string iPVlabel = pvLabels[i];
+        const edm::InputTag& iPVinputTag = primaryVertexInputTags[i];
+        const edm::InputTag& iSelPVinputTag = selPrimaryVertexInputTags[i];
+        const std::string& iPVlabel = pvLabels[i];
 
         theVertexMonitor.push_back(new VertexMonitor(iConfig, iPVinputTag, iSelPVinputTag, iPVlabel, c));
       }

--- a/DQM/TrackingMonitorClient/src/TrackingActionExecutor.cc
+++ b/DQM/TrackingMonitorClient/src/TrackingActionExecutor.cc
@@ -152,7 +152,7 @@ void TrackingActionExecutor::printShiftHistoParameters(DQMStore::IBooker& ibooke
     str_val << std::setprecision(2);
     str_val << setiosflags(std::ios::fixed);
     for (std::vector<std::string>::iterator im = it->second.begin(); im != it->second.end(); im++) {
-      std::string path_name = (*im);
+      const std::string& path_name = (*im);
       if (path_name.empty())
         continue;
       MonitorElement* me = igetter.get(path_name);

--- a/DQMOffline/CalibTracker/plugins/SiStripPopConFEDErrorsDQM.cc
+++ b/DQMOffline/CalibTracker/plugins/SiStripPopConFEDErrorsDQM.cc
@@ -209,7 +209,7 @@ void SiStripPopConFEDErrorsHandlerFromDQM::readHistogram(MonitorElement* aMe,
                                                          const float aNorm,
                                                          const unsigned int aFedId) {
   unsigned short lFlag = 0;
-  std::string lMeName = aMe->getName();
+  const std::string& lMeName = aMe->getName();
   if (lMeName.find("DataMissing") != lMeName.npos) {
     lFlag = 0;
   } else if (lMeName.find("AnyFEDErrors") != lMeName.npos) {

--- a/DQMOffline/L1Trigger/src/L1TCommon.cc
+++ b/DQMOffline/L1Trigger/src/L1TCommon.cc
@@ -74,7 +74,7 @@ namespace dqmoffline {
 
     trigger::TriggerObjectCollection getTriggerObjects(const std::vector<edm::InputTag> &hltFilters,
                                                        const trigger::TriggerEvent &triggerEvent) {
-      const trigger::TriggerObjectCollection& triggerObjects = triggerEvent.getObjects();
+      const trigger::TriggerObjectCollection &triggerObjects = triggerEvent.getObjects();
       trigger::TriggerObjectCollection results;
 
       for (const auto &filter : hltFilters) {

--- a/DQMOffline/L1Trigger/src/L1TCommon.cc
+++ b/DQMOffline/L1Trigger/src/L1TCommon.cc
@@ -74,7 +74,7 @@ namespace dqmoffline {
 
     trigger::TriggerObjectCollection getTriggerObjects(const std::vector<edm::InputTag> &hltFilters,
                                                        const trigger::TriggerEvent &triggerEvent) {
-      trigger::TriggerObjectCollection triggerObjects = triggerEvent.getObjects();
+      const trigger::TriggerObjectCollection& triggerObjects = triggerEvent.getObjects();
       trigger::TriggerObjectCollection results;
 
       for (const auto &filter : hltFilters) {

--- a/DQMOffline/L1Trigger/src/L1TTauOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TTauOffline.cc
@@ -143,7 +143,7 @@ void L1TTauOffline::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
   bookTauHistos(ibooker);
 
   for (auto trigNamesIt = triggerPath_.begin(); trigNamesIt != triggerPath_.end(); trigNamesIt++) {
-    std::string tNameTmp = (*trigNamesIt);
+    const std::string& tNameTmp = (*trigNamesIt);
     std::string tNamePattern = "";
     std::size_t found0 = tNameTmp.find('*');
     if (found0 != std::string::npos)

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
@@ -510,7 +510,7 @@ int PFAnalyzer::getBinNumbers(std::vector<double> binVal, std::vector<std::vecto
 
 int PFAnalyzer::getPFBin(const reco::PFCandidate pfCand, int i) {
   std::vector<double> binVals;
-  for (unsigned int j = 0; j < m_fullCutList[i].size(); j++) {
+  binVals.reserve(m_fullCutList[i].size()); for (unsigned int j = 0; j < m_fullCutList[i].size(); j++) {
     binVals.push_back(m_funcMap[m_fullCutList[i][j]](pfCand));
   }
 
@@ -519,7 +519,7 @@ int PFAnalyzer::getPFBin(const reco::PFCandidate pfCand, int i) {
 
 int PFAnalyzer::getJetBin(const reco::PFJet jetCand, int i) {
   std::vector<double> binVals;
-  for (unsigned int j = 0; j < m_fullJetCutList[i].size(); j++) {
+  binVals.reserve(m_fullJetCutList[i].size()); for (unsigned int j = 0; j < m_fullJetCutList[i].size(); j++) {
     binVals.push_back(m_jetFuncMap[m_fullJetCutList[i][j]](jetCand));
   }
 

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
@@ -510,7 +510,8 @@ int PFAnalyzer::getBinNumbers(std::vector<double> binVal, std::vector<std::vecto
 
 int PFAnalyzer::getPFBin(const reco::PFCandidate pfCand, int i) {
   std::vector<double> binVals;
-  binVals.reserve(m_fullCutList[i].size()); for (unsigned int j = 0; j < m_fullCutList[i].size(); j++) {
+  binVals.reserve(m_fullCutList[i].size());
+  for (unsigned int j = 0; j < m_fullCutList[i].size(); j++) {
     binVals.push_back(m_funcMap[m_fullCutList[i][j]](pfCand));
   }
 
@@ -519,7 +520,8 @@ int PFAnalyzer::getPFBin(const reco::PFCandidate pfCand, int i) {
 
 int PFAnalyzer::getJetBin(const reco::PFJet jetCand, int i) {
   std::vector<double> binVals;
-  binVals.reserve(m_fullJetCutList[i].size()); for (unsigned int j = 0; j < m_fullJetCutList[i].size(); j++) {
+  binVals.reserve(m_fullJetCutList[i].size());
+  for (unsigned int j = 0; j < m_fullJetCutList[i].size(); j++) {
     binVals.push_back(m_jetFuncMap[m_fullJetCutList[i][j]](jetCand));
   }
 

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
@@ -109,7 +109,7 @@ private:
 
   static double getNPFC(const reco::PFCandidateCollection pfCands, reco::PFCandidate::ParticleType pfType) {
     int nPF = 0;
-    for (auto pfCand : pfCands) {
+    for (const auto& pfCand : pfCands) {
       // We use X to indicate all
       if (pfCand.particleId() == pfType || pfType == reco::PFCandidate::ParticleType::X) {
         nPF++;
@@ -120,7 +120,7 @@ private:
 
   static double getNPFCinJet(const std::vector<reco::PFCandidatePtr> pfCands, reco::PFCandidate::ParticleType pfType) {
     int nPF = 0;
-    for (auto pfCand : pfCands) {
+    for (const auto& pfCand : pfCands) {
       if (!pfCand)
         continue;
       // We use X to indicate all
@@ -194,7 +194,7 @@ private:
           if (elements[iEle].type() == reco::PFBlockElement::HCAL ||
               elements[iEle].type() == reco::PFBlockElement::ECAL) {  // Element is HB or HE
             reco::PFClusterRef clusterref = elements[iEle].clusterRef();
-            reco::PFCluster cluster = *clusterref;
+            const reco::PFCluster& cluster = *clusterref;
             energy += cluster.energy();
           }
         }
@@ -215,7 +215,7 @@ private:
           if (elements[iEle].type() == reco::PFBlockElement::HCAL) {  // Element is HB or HE
             // Get cluster and hits
             reco::PFClusterRef clusterref = elements[iEle].clusterRef();
-            reco::PFCluster cluster = *clusterref;
+            const reco::PFCluster& cluster = *clusterref;
             //std::vector<std::pair<DetId, float>> hitsAndFracs = cluster.hitsAndFractions();
             energy += cluster.energy();
           }
@@ -238,7 +238,7 @@ private:
             // Get cluster and hits
             reco::PFClusterRef clusterref = elements[iEle].clusterRef();
             // When we don't have isolated tracks, this will be a bit useless, since the energy is shared across multiple tracks
-            reco::PFCluster cluster = *clusterref;
+            const reco::PFCluster& cluster = *clusterref;
             energy += cluster.energy();
           }
         }

--- a/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.h
+++ b/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.h
@@ -25,7 +25,7 @@ namespace pvMonitor {
   // cf https://github.com/cms-sw/cmssw/blob/master/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
   typedef dqm::reco::DQMStore DQMStore;
 
-  void setBinLog(TAxis *axis) {
+  inline void setBinLog(TAxis *axis) {
     int bins = axis->GetNbins();
     float from = axis->GetXmin();
     float to = axis->GetXmax();
@@ -37,11 +37,11 @@ namespace pvMonitor {
     axis->Set(bins, new_bins.data());
   }
 
-  void setBinLogX(TH1 *h) {
+  inline void setBinLogX(TH1 *h) {
     TAxis *axis = h->GetXaxis();
     setBinLog(axis);
   }
-  void setBinLogY(TH1 *h) {
+  inline void setBinLogY(TH1 *h) {
     TAxis *axis = h->GetYaxis();
     setBinLog(axis);
   }

--- a/DQMOffline/Trigger/plugins/HLTMuonRefMethod.cc
+++ b/DQMOffline/Trigger/plugins/HLTMuonRefMethod.cc
@@ -110,7 +110,7 @@ void HLTMuonRefMethod::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& 
 
       // looping over all reference triggers
       for (auto iTrigger = hltTriggers_.begin(); iTrigger != hltTriggers_.end(); ++iTrigger) {
-        string trig = *iTrigger;
+        const string& trig = *iTrigger;
         MonitorElement* trigEff = igetter.get(subDir + "/" + trig + "/" + eff);
         if (!trigEff)
           continue;

--- a/DQMOffline/Trigger/src/HLTTauDQMTagAndProbePlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMTagAndProbePlotter.cc
@@ -79,7 +79,7 @@ void HLTTauDQMTagAndProbePlotter::bookHistograms(HistoWrapper& iWrapper,
 HLTTauDQMTagAndProbePlotter::~HLTTauDQMTagAndProbePlotter() = default;
 
 LV HLTTauDQMTagAndProbePlotter::findTrgObject(std::string pathName, const trigger::TriggerEvent& triggerEvent) {
-  trigger::TriggerObjectCollection trigObjs = triggerEvent.getObjects();
+  const trigger::TriggerObjectCollection& trigObjs = triggerEvent.getObjects();
   const unsigned moduleIndex = moduleLabels.size() - 2;
 
   const unsigned hltFilterIndex = triggerEvent.filterIndex(edm::InputTag(moduleLabels[moduleIndex], "", "HLT"));

--- a/DataFormats/BTauReco/interface/IPTagInfo.h
+++ b/DataFormats/BTauReco/interface/IPTagInfo.h
@@ -201,7 +201,8 @@ namespace reco {
   template <class Container, class Base>
   Container IPTagInfo<Container, Base>::sorted(const std::vector<size_t>& indexes) const {
     Container tr;
-    tr.reserve(indexes.size()); for (size_t i = 0; i < indexes.size(); i++)
+    tr.reserve(indexes.size());
+    for (size_t i = 0; i < indexes.size(); i++)
       tr.push_back(m_selected[indexes[i]]);
     return tr;
   }

--- a/DataFormats/BTauReco/interface/IPTagInfo.h
+++ b/DataFormats/BTauReco/interface/IPTagInfo.h
@@ -201,7 +201,7 @@ namespace reco {
   template <class Container, class Base>
   Container IPTagInfo<Container, Base>::sorted(const std::vector<size_t>& indexes) const {
     Container tr;
-    for (size_t i = 0; i < indexes.size(); i++)
+    tr.reserve(indexes.size()); for (size_t i = 0; i < indexes.size(); i++)
       tr.push_back(m_selected[indexes[i]]);
     return tr;
   }

--- a/DataFormats/ForwardDetId/src/HFNoseTriggerDetId.cc
+++ b/DataFormats/ForwardDetId/src/HFNoseTriggerDetId.cc
@@ -132,7 +132,7 @@ std::vector<std::pair<int, int> > HFNoseTriggerDetId::cellUV() const {
   std::vector<int> uc = cellU();
   std::vector<int> vc = cellV();
   std::vector<std::pair<int, int> > uv;
-  for (unsigned int k = 0; k < uc.size(); ++k) {
+  uv.reserve(uc.size()); for (unsigned int k = 0; k < uc.size(); ++k) {
     uv.emplace_back(uc[k], vc[k]);
   }
   return uv;

--- a/DataFormats/ForwardDetId/src/HFNoseTriggerDetId.cc
+++ b/DataFormats/ForwardDetId/src/HFNoseTriggerDetId.cc
@@ -132,7 +132,8 @@ std::vector<std::pair<int, int> > HFNoseTriggerDetId::cellUV() const {
   std::vector<int> uc = cellU();
   std::vector<int> vc = cellV();
   std::vector<std::pair<int, int> > uv;
-  uv.reserve(uc.size()); for (unsigned int k = 0; k < uc.size(); ++k) {
+  uv.reserve(uc.size());
+  for (unsigned int k = 0; k < uc.size(); ++k) {
     uv.emplace_back(uc[k], vc[k]);
   }
   return uv;

--- a/DataFormats/ForwardDetId/src/HGCalTriggerDetId.cc
+++ b/DataFormats/ForwardDetId/src/HGCalTriggerDetId.cc
@@ -139,7 +139,7 @@ std::vector<std::pair<int, int> > HGCalTriggerDetId::cellUV() const {
   std::vector<int> uc = cellU();
   std::vector<int> vc = cellV();
   std::vector<std::pair<int, int> > uv;
-  for (unsigned int k = 0; k < uc.size(); ++k) {
+  uv.reserve(uc.size()); for (unsigned int k = 0; k < uc.size(); ++k) {
     uv.emplace_back(std::pair<int, int>(uc[k], vc[k]));
   }
   return uv;

--- a/DataFormats/ForwardDetId/src/HGCalTriggerDetId.cc
+++ b/DataFormats/ForwardDetId/src/HGCalTriggerDetId.cc
@@ -139,7 +139,8 @@ std::vector<std::pair<int, int> > HGCalTriggerDetId::cellUV() const {
   std::vector<int> uc = cellU();
   std::vector<int> vc = cellV();
   std::vector<std::pair<int, int> > uv;
-  uv.reserve(uc.size()); for (unsigned int k = 0; k < uc.size(); ++k) {
+  uv.reserve(uc.size());
+  for (unsigned int k = 0; k < uc.size(); ++k) {
     uv.emplace_back(std::pair<int, int>(uc[k], vc[k]));
   }
   return uv;

--- a/DataFormats/JetReco/src/CaloJet.cc
+++ b/DataFormats/JetReco/src/CaloJet.cc
@@ -77,7 +77,8 @@ CaloTowerPtr CaloJet::getCaloConstituent(unsigned fIndex) const {
 
 std::vector<CaloTowerPtr> CaloJet::getCaloConstituents() const {
   std::vector<CaloTowerPtr> result;
-  result.reserve(numberOfDaughters()); for (unsigned i = 0; i < numberOfDaughters(); i++)
+  result.reserve(numberOfDaughters());
+  for (unsigned i = 0; i < numberOfDaughters(); i++)
     result.push_back(getCaloConstituent(i));
   return result;
 }
@@ -115,7 +116,8 @@ std::string CaloJet::print() const {
 std::vector<CaloTowerDetId> CaloJet::getTowerIndices() const {
   std::vector<CaloTowerDetId> result;
   std::vector<CaloTowerPtr> towers = getCaloConstituents();
-  result.reserve(towers.size()); for (unsigned i = 0; i < towers.size(); ++i) {
+  result.reserve(towers.size());
+  for (unsigned i = 0; i < towers.size(); ++i) {
     result.push_back(towers[i]->id());
   }
   return result;

--- a/DataFormats/JetReco/src/CaloJet.cc
+++ b/DataFormats/JetReco/src/CaloJet.cc
@@ -77,7 +77,7 @@ CaloTowerPtr CaloJet::getCaloConstituent(unsigned fIndex) const {
 
 std::vector<CaloTowerPtr> CaloJet::getCaloConstituents() const {
   std::vector<CaloTowerPtr> result;
-  for (unsigned i = 0; i < numberOfDaughters(); i++)
+  result.reserve(numberOfDaughters()); for (unsigned i = 0; i < numberOfDaughters(); i++)
     result.push_back(getCaloConstituent(i));
   return result;
 }
@@ -115,7 +115,7 @@ std::string CaloJet::print() const {
 std::vector<CaloTowerDetId> CaloJet::getTowerIndices() const {
   std::vector<CaloTowerDetId> result;
   std::vector<CaloTowerPtr> towers = getCaloConstituents();
-  for (unsigned i = 0; i < towers.size(); ++i) {
+  result.reserve(towers.size()); for (unsigned i = 0; i < towers.size(); ++i) {
     result.push_back(towers[i]->id());
   }
   return result;

--- a/DataFormats/JetReco/src/GenJet.cc
+++ b/DataFormats/JetReco/src/GenJet.cc
@@ -50,7 +50,8 @@ const GenParticle* GenJet::getGenConstituent(unsigned fIndex) const {
 
 std::vector<const GenParticle*> GenJet::getGenConstituents() const {
   std::vector<const GenParticle*> result;
-  result.reserve(numberOfDaughters()); for (unsigned i = 0; i < numberOfDaughters(); i++)
+  result.reserve(numberOfDaughters());
+  for (unsigned i = 0; i < numberOfDaughters(); i++)
     result.push_back(getGenConstituent(i));
   return result;
 }

--- a/DataFormats/JetReco/src/GenJet.cc
+++ b/DataFormats/JetReco/src/GenJet.cc
@@ -50,7 +50,7 @@ const GenParticle* GenJet::getGenConstituent(unsigned fIndex) const {
 
 std::vector<const GenParticle*> GenJet::getGenConstituents() const {
   std::vector<const GenParticle*> result;
-  for (unsigned i = 0; i < numberOfDaughters(); i++)
+  result.reserve(numberOfDaughters()); for (unsigned i = 0; i < numberOfDaughters(); i++)
     result.push_back(getGenConstituent(i));
   return result;
 }

--- a/DataFormats/JetReco/src/JetAssociationTemplate.icc
+++ b/DataFormats/JetReco/src/JetAssociationTemplate.icc
@@ -45,7 +45,8 @@ namespace JetAssociationTemplate {
   template <typename Container>
   inline std::vector<reco::JetBaseRef> allJets(const Container& fContainer) {
     std::vector<reco::JetBaseRef> result;
-    result.reserve(fContainer.size()); for (unsigned i = 0; i < fContainer.size(); ++i) {
+    result.reserve(fContainer.size());
+    for (unsigned i = 0; i < fContainer.size(); ++i) {
       result.push_back(fContainer[i].first);
     }
     return result;

--- a/DataFormats/JetReco/src/JetAssociationTemplate.icc
+++ b/DataFormats/JetReco/src/JetAssociationTemplate.icc
@@ -45,7 +45,7 @@ namespace JetAssociationTemplate {
   template <typename Container>
   inline std::vector<reco::JetBaseRef> allJets(const Container& fContainer) {
     std::vector<reco::JetBaseRef> result;
-    for (unsigned i = 0; i < fContainer.size(); ++i) {
+    result.reserve(fContainer.size()); for (unsigned i = 0; i < fContainer.size(); ++i) {
       result.push_back(fContainer[i].first);
     }
     return result;

--- a/DataFormats/JetReco/src/PFJet.cc
+++ b/DataFormats/JetReco/src/PFJet.cc
@@ -40,7 +40,8 @@ reco::PFCandidatePtr PFJet::getPFConstituent(unsigned fIndex) const {
 
 std::vector<reco::PFCandidatePtr> PFJet::getPFConstituents() const {
   std::vector<PFCandidatePtr> result;
-  result.reserve(numberOfDaughters()); for (unsigned i = 0; i < numberOfDaughters(); i++)
+  result.reserve(numberOfDaughters());
+  for (unsigned i = 0; i < numberOfDaughters(); i++)
     result.push_back(getPFConstituent(i));
   return result;
 }

--- a/DataFormats/JetReco/src/PFJet.cc
+++ b/DataFormats/JetReco/src/PFJet.cc
@@ -40,7 +40,7 @@ reco::PFCandidatePtr PFJet::getPFConstituent(unsigned fIndex) const {
 
 std::vector<reco::PFCandidatePtr> PFJet::getPFConstituents() const {
   std::vector<PFCandidatePtr> result;
-  for (unsigned i = 0; i < numberOfDaughters(); i++)
+  result.reserve(numberOfDaughters()); for (unsigned i = 0; i < numberOfDaughters(); i++)
     result.push_back(getPFConstituent(i));
   return result;
 }

--- a/DataFormats/JetReco/src/TrackJet.cc
+++ b/DataFormats/JetReco/src/TrackJet.cc
@@ -41,7 +41,8 @@ edm::Ptr<reco::Track> reco::TrackJet::track(size_t i) const {
 
 std::vector<edm::Ptr<reco::Track> > reco::TrackJet::tracks() const {
   std::vector<edm::Ptr<reco::Track> > result;
-  result.reserve(numberOfDaughters()); for (unsigned i = 0; i < numberOfDaughters(); i++)
+  result.reserve(numberOfDaughters());
+  for (unsigned i = 0; i < numberOfDaughters(); i++)
     result.push_back(track(i));
   return result;
 }

--- a/DataFormats/JetReco/src/TrackJet.cc
+++ b/DataFormats/JetReco/src/TrackJet.cc
@@ -41,7 +41,7 @@ edm::Ptr<reco::Track> reco::TrackJet::track(size_t i) const {
 
 std::vector<edm::Ptr<reco::Track> > reco::TrackJet::tracks() const {
   std::vector<edm::Ptr<reco::Track> > result;
-  for (unsigned i = 0; i < numberOfDaughters(); i++)
+  result.reserve(numberOfDaughters()); for (unsigned i = 0; i < numberOfDaughters(); i++)
     result.push_back(track(i));
   return result;
 }

--- a/DataFormats/L1GlobalTrigger/src/L1GtfeExtWord.cc
+++ b/DataFormats/L1GlobalTrigger/src/L1GtfeExtWord.cc
@@ -73,7 +73,7 @@ L1GtfeExtWord::~L1GtfeExtWord() {
 bool L1GtfeExtWord::operator==(const L1GtfeExtWord& result) const {
   // base class
 
-  const L1GtfeWord gtfeResult = result;
+  const L1GtfeWord& gtfeResult = result;
   const L1GtfeWord gtfeThis = *this;
 
   if (gtfeThis != gtfeResult) {

--- a/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
+++ b/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
@@ -332,7 +332,7 @@ ostream& reco::operator<<(ostream& out, const PFCandidate& c) {
 
   out << ", blocks/iele: ";
 
-  PFCandidate::ElementsInBlocks eleInBlocks = c.elementsInBlocks();
+  const PFCandidate::ElementsInBlocks& eleInBlocks = c.elementsInBlocks();
   for (unsigned i = 0; i < eleInBlocks.size(); i++) {
     PFBlockRef blockRef = eleInBlocks[i].first;
     unsigned indexInBlock = eleInBlocks[i].second;

--- a/DataFormats/PatCandidates/src/TriggerCondition.cc
+++ b/DataFormats/PatCandidates/src/TriggerCondition.cc
@@ -31,7 +31,8 @@ TriggerCondition::TriggerCondition(const std::string& name, bool accept)
 // Get the trigger object types
 std::vector<int> TriggerCondition::triggerObjectTypes() const {
   std::vector<int> triggerObjectTypes;
-  triggerObjectTypes.reserve(triggerObjectTypes_.size()); for (size_t iT = 0; iT < triggerObjectTypes_.size(); ++iT) {
+  triggerObjectTypes.reserve(triggerObjectTypes_.size());
+  for (size_t iT = 0; iT < triggerObjectTypes_.size(); ++iT) {
     triggerObjectTypes.push_back(int(triggerObjectTypes_.at(iT)));
   }
   return triggerObjectTypes;

--- a/DataFormats/PatCandidates/src/TriggerCondition.cc
+++ b/DataFormats/PatCandidates/src/TriggerCondition.cc
@@ -31,7 +31,7 @@ TriggerCondition::TriggerCondition(const std::string& name, bool accept)
 // Get the trigger object types
 std::vector<int> TriggerCondition::triggerObjectTypes() const {
   std::vector<int> triggerObjectTypes;
-  for (size_t iT = 0; iT < triggerObjectTypes_.size(); ++iT) {
+  triggerObjectTypes.reserve(triggerObjectTypes_.size()); for (size_t iT = 0; iT < triggerObjectTypes_.size(); ++iT) {
     triggerObjectTypes.push_back(int(triggerObjectTypes_.at(iT)));
   }
   return triggerObjectTypes;

--- a/DataFormats/PatCandidates/src/TriggerFilter.cc
+++ b/DataFormats/PatCandidates/src/TriggerFilter.cc
@@ -40,7 +40,8 @@ bool TriggerFilter::setStatus(int status) {
 // Get all trigger object type identifiers
 std::vector<int> TriggerFilter::triggerObjectTypes() const {
   std::vector<int> triggerObjectTypes;
-  triggerObjectTypes.reserve(triggerObjectTypes_.size()); for (size_t iTo = 0; iTo < triggerObjectTypes_.size(); ++iTo) {
+  triggerObjectTypes.reserve(triggerObjectTypes_.size());
+  for (size_t iTo = 0; iTo < triggerObjectTypes_.size(); ++iTo) {
     triggerObjectTypes.push_back(triggerObjectTypes_.at(iTo));
   }
   return triggerObjectTypes;

--- a/DataFormats/PatCandidates/src/TriggerFilter.cc
+++ b/DataFormats/PatCandidates/src/TriggerFilter.cc
@@ -40,7 +40,7 @@ bool TriggerFilter::setStatus(int status) {
 // Get all trigger object type identifiers
 std::vector<int> TriggerFilter::triggerObjectTypes() const {
   std::vector<int> triggerObjectTypes;
-  for (size_t iTo = 0; iTo < triggerObjectTypes_.size(); ++iTo) {
+  triggerObjectTypes.reserve(triggerObjectTypes_.size()); for (size_t iTo = 0; iTo < triggerObjectTypes_.size(); ++iTo) {
     triggerObjectTypes.push_back(triggerObjectTypes_.at(iTo));
   }
   return triggerObjectTypes;

--- a/DataFormats/PatCandidates/src/TriggerObject.cc
+++ b/DataFormats/PatCandidates/src/TriggerObject.cc
@@ -44,7 +44,7 @@ TriggerObject::TriggerObject(const reco::Particle::PolarLorentzVector& vec, int 
 // Get all trigger object type identifiers
 std::vector<int> TriggerObject::triggerObjectTypes() const {
   std::vector<int> triggerObjectTypes;
-  for (size_t iTo = 0; iTo < triggerObjectTypes_.size(); ++iTo) {
+  triggerObjectTypes.reserve(triggerObjectTypes_.size()); for (size_t iTo = 0; iTo < triggerObjectTypes_.size(); ++iTo) {
     triggerObjectTypes.push_back(triggerObjectTypes_.at(iTo));
   }
   return triggerObjectTypes;

--- a/DataFormats/PatCandidates/src/TriggerObject.cc
+++ b/DataFormats/PatCandidates/src/TriggerObject.cc
@@ -44,7 +44,8 @@ TriggerObject::TriggerObject(const reco::Particle::PolarLorentzVector& vec, int 
 // Get all trigger object type identifiers
 std::vector<int> TriggerObject::triggerObjectTypes() const {
   std::vector<int> triggerObjectTypes;
-  triggerObjectTypes.reserve(triggerObjectTypes_.size()); for (size_t iTo = 0; iTo < triggerObjectTypes_.size(); ++iTo) {
+  triggerObjectTypes.reserve(triggerObjectTypes_.size());
+  for (size_t iTo = 0; iTo < triggerObjectTypes_.size(); ++iTo) {
     triggerObjectTypes.push_back(triggerObjectTypes_.at(iTo));
   }
   return triggerObjectTypes;

--- a/DataFormats/TauReco/src/PFTauDecayMode.cc
+++ b/DataFormats/TauReco/src/PFTauDecayMode.cc
@@ -45,7 +45,8 @@ namespace reco {
   std::vector<const Candidate*> PFTauDecayMode::chargedPionCandidates() const {
     size_type numberOfChargedPions = chargedPions_.numberOfDaughters();
     std::vector<const Candidate*> output;
-    output.reserve(numberOfChargedPions); for (size_type iterCand = 0; iterCand < numberOfChargedPions; ++iterCand)
+    output.reserve(numberOfChargedPions);
+    for (size_type iterCand = 0; iterCand < numberOfChargedPions; ++iterCand)
       output.push_back(chargedPions_.daughter(iterCand));
     return output;
   }
@@ -53,7 +54,8 @@ namespace reco {
   std::vector<const Candidate*> PFTauDecayMode::neutralPionCandidates() const {
     size_type numberOfChargedPions = piZeroes_.numberOfDaughters();
     std::vector<const Candidate*> output;
-    output.reserve(numberOfChargedPions); for (size_type iterCand = 0; iterCand < numberOfChargedPions; ++iterCand)
+    output.reserve(numberOfChargedPions);
+    for (size_type iterCand = 0; iterCand < numberOfChargedPions; ++iterCand)
       output.push_back(piZeroes_.daughter(iterCand));
     return output;
   }

--- a/DataFormats/TauReco/src/PFTauDecayMode.cc
+++ b/DataFormats/TauReco/src/PFTauDecayMode.cc
@@ -45,7 +45,7 @@ namespace reco {
   std::vector<const Candidate*> PFTauDecayMode::chargedPionCandidates() const {
     size_type numberOfChargedPions = chargedPions_.numberOfDaughters();
     std::vector<const Candidate*> output;
-    for (size_type iterCand = 0; iterCand < numberOfChargedPions; ++iterCand)
+    output.reserve(numberOfChargedPions); for (size_type iterCand = 0; iterCand < numberOfChargedPions; ++iterCand)
       output.push_back(chargedPions_.daughter(iterCand));
     return output;
   }
@@ -53,7 +53,7 @@ namespace reco {
   std::vector<const Candidate*> PFTauDecayMode::neutralPionCandidates() const {
     size_type numberOfChargedPions = piZeroes_.numberOfDaughters();
     std::vector<const Candidate*> output;
-    for (size_type iterCand = 0; iterCand < numberOfChargedPions; ++iterCand)
+    output.reserve(numberOfChargedPions); for (size_type iterCand = 0; iterCand < numberOfChargedPions; ++iterCand)
       output.push_back(piZeroes_.daughter(iterCand));
     return output;
   }

--- a/DetectorDescription/Parser/src/DDLParser.cc
+++ b/DetectorDescription/Parser/src/DDLParser.cc
@@ -133,7 +133,7 @@ int DDLParser::parse(const DDLDocumentProvider& dp) {
   const std::vector<std::string>& urlList = dp.getURLList();
 
   for (; fileIndex < fileList.size(); ++fileIndex) {
-    std::string ts = urlList[fileIndex];
+    const std::string& ts = urlList[fileIndex];
     std::string tf = fileList[fileIndex];
     if (!ts.empty()) {
       if (ts[ts.size() - 1] == '/') {

--- a/EventFilter/CSCRawToDigi/src/CSCCFEBData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCCFEBData.cc
@@ -80,7 +80,7 @@ CSCCFEBData::CSCCFEBData(unsigned number, bool sixteenSamples, uint16_t format_v
 }
 
 void CSCCFEBData::add(const CSCStripDigi &digi, int layer) {
-  std::vector<int> scaCounts = digi.getADCCounts();
+  const std::vector<int>& scaCounts = digi.getADCCounts();
   for (unsigned itime = 0; itime < theNumberOfSamples; ++itime) {
     unsigned channel = (digi.getStrip() - 1) % 16 + 1;
     unsigned value = scaCounts[itime] & 0xFFF;  // 12-bit

--- a/EventFilter/CSCRawToDigi/src/CSCCFEBData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCCFEBData.cc
@@ -80,7 +80,7 @@ CSCCFEBData::CSCCFEBData(unsigned number, bool sixteenSamples, uint16_t format_v
 }
 
 void CSCCFEBData::add(const CSCStripDigi &digi, int layer) {
-  const std::vector<int>& scaCounts = digi.getADCCounts();
+  const std::vector<int> &scaCounts = digi.getADCCounts();
   for (unsigned itime = 0; itime < theNumberOfSamples; ++itime) {
     unsigned channel = (digi.getStrip() - 1) % 16 + 1;
     unsigned value = scaCounts[itime] & 0xFFF;  // 12-bit

--- a/EventFilter/L1TRawToDigi/plugins/OmtfUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/OmtfUnpacker.cc
@@ -281,7 +281,7 @@ namespace omtf {
       // loop over AMC's
       //
       unsigned int blockNum = 0;
-      for (auto amc : packetAmc13.payload()) {
+      for (const auto& amc : packetAmc13.payload()) {
         amc::BlockHeader bh = amc.blockHeader();
         if (debug) {
           std::ostringstream str;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockCounters.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockCounters.cc
@@ -32,7 +32,7 @@ namespace l1t {
     namespace emtf {
 
       int CountersBlockUnpacker::checkFormat(const Block& block) {
-        auto payload = block.payload();
+        const auto& payload = block.payload();
         int errors = 0;
 
         //Check the number of 16-bit words
@@ -91,7 +91,7 @@ namespace l1t {
         // Get the payload for this block, made up of 16-bit words (0xffff)
         // Format defined in MTF7Payload::getBlock() in src/Block.cc
         // payload[0] = bits 0-15, payload[1] = 16-31, payload[3] = 32-47, etc.
-        auto payload = block.payload();
+        const auto& payload = block.payload();
 
         // Check Format of Payload
         l1t::emtf::Counters Counters_;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockGEM.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockGEM.cc
@@ -31,7 +31,7 @@ namespace l1t {
     namespace emtf {
 
       int GEMBlockUnpacker::checkFormat(const Block& block) {
-        auto payload = block.payload();
+        const auto& payload = block.payload();
         int errors = 0;
 
         // Check the number of 16-bit words
@@ -125,7 +125,7 @@ namespace l1t {
         // Get the payload for this block, made up of 16-bit words (0xffff)
         // Format defined in MTF7Payload::getBlock() in src/Block.cc
         // payload[0] = bits 0-15, payload[1] = 16-31, payload[3] = 32-47, etc.
-        auto payload = block.payload();
+        const auto& payload = block.payload();
 
         // Run 3 has a different EMTF DAQ output format since August 26th
         // Computed as (Year - 2000)*2^9 + Month*2^5 + Day (see Block.cc and EMTFBlockTrailers.cc)

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockHeaders.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockHeaders.cc
@@ -32,7 +32,7 @@ namespace l1t {
     namespace emtf {
 
       int HeadersBlockUnpacker::checkFormat(const Block& block) {
-        auto payload = block.payload();
+        const auto& payload = block.payload();
         int errors = 0;
 
         //Check the number of 16-bit words
@@ -163,7 +163,7 @@ namespace l1t {
         // Get the payload for this block, made up of 16-bit words (0xffff)
         // Format defined in MTF7Payload::getBlock() in src/Block.cc
         // payload[0] = bits 0-15, payload[1] = 16-31, payload[3] = 32-47, etc.
-        auto payload = block.payload();
+        const auto& payload = block.payload();
 
         // Check Format of Payload
         l1t::emtf::AMC13Header AMC13Header_;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
@@ -32,7 +32,7 @@ namespace l1t {
     namespace emtf {
 
       int MEBlockUnpacker::checkFormat(const Block& block) {
-        auto payload = block.payload();
+        const auto& payload = block.payload();
         int errors = 0;
 
         // Check the number of 16-bit words
@@ -151,7 +151,7 @@ namespace l1t {
         // Get the payload for this block, made up of 16-bit words (0xffff)
         // Format defined in MTF7Payload::getBlock() in src/Block.cc
         // payload[0] = bits 0-15, payload[1] = 16-31, payload[3] = 32-47, etc.
-        auto payload = block.payload();
+        const auto& payload = block.payload();
 
         // Assign payload to 16-bit words
         uint16_t MEa = payload[0];

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
@@ -33,7 +33,7 @@ namespace l1t {
     namespace emtf {
 
       int RPCBlockUnpacker::checkFormat(const Block& block) {
-        auto payload = block.payload();
+        const auto& payload = block.payload();
         int errors = 0;
 
         // Check the number of 16-bit words
@@ -119,7 +119,7 @@ namespace l1t {
         // Get the payload for this block, made up of 16-bit words (0xffff)
         // Format defined in MTF7Payload::getBlock() in src/Block.cc
         // payload[0] = bits 0-15, payload[1] = 16-31, payload[3] = 32-47, etc.
-        auto payload = block.payload();
+        const auto& payload = block.payload();
 
         // Run 3 has a different EMTF DAQ output format since August 26th
         // Computed as (Year - 2000)*2^9 + Month*2^5 + Day (see Block.cc and EMTFBlockTrailers.cc)

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
@@ -32,7 +32,7 @@ namespace l1t {
     namespace emtf {
 
       int SPBlockUnpacker::checkFormat(const Block& block) {
-        auto payload = block.payload();
+        const auto& payload = block.payload();
         int errors = 0;
 
         // Check the number of 16-bit words
@@ -174,7 +174,7 @@ namespace l1t {
         // Get the payload for this block, made up of 16-bit words (0xffff)
         // Format defined in MTF7Payload::getBlock() in src/Block.cc
         // payload[0] = bits 0-15, payload[1] = 16-31, payload[3] = 32-47, etc.
-        auto payload = block.payload();
+        const auto& payload = block.payload();
 
         // FW version is computed as (Year - 2000)*2^9 + Month*2^5 + Day (see Block.cc and EMTFBlockTrailers.cc)
         bool useNNBits_ = getAlgoVersion() >= 11098;   // FW versions >= 26.10.2021

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockTrailers.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockTrailers.cc
@@ -32,7 +32,7 @@ namespace l1t {
     namespace emtf {
 
       int TrailersBlockUnpacker::checkFormat(const Block& block) {
-        auto payload = block.payload();
+        const auto& payload = block.payload();
         int errors = 0;
 
         //Check the number of 16-bit words
@@ -128,7 +128,7 @@ namespace l1t {
         // Get the payload for this block, made up of 16-bit words (0xffff)
         // Format defined in MTF7Payload::getBlock() in src/Block.cc
         // payload[0] = bits 0-15, payload[1] = 16-31, payload[3] = 32-47, etc.
-        auto payload = block.payload();
+        const auto& payload = block.payload();
 
         // Check Format of Payload
         l1t::emtf::AMC13Trailer AMC13Trailer_;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/IntermediateMuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/IntermediateMuonUnpacker.cc
@@ -19,7 +19,7 @@ namespace l1t {
         return true;
       }
 
-      auto payload = block.payload();
+      const auto& payload = block.payload();
 
       int nBX, firstBX, lastBX;
       // Check if per BX zero suppression was enabled

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
@@ -18,7 +18,7 @@ namespace l1t {
         return true;
       }
 
-      auto payload = block.payload();
+      const auto& payload = block.payload();
 
       int nBX, firstBX, lastBX;
       // Check if per BX zero suppression was enabled

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
@@ -16,7 +16,7 @@ namespace l1t {
         return true;
       }
 
-      auto payload = block.payload();
+      const auto& payload = block.payload();
 
       int nBX, firstBX, lastBX;
       // Check if per BX zero suppression was enabled

--- a/EventFilter/L1TRawToDigi/src/AMC13Spec.cc
+++ b/EventFilter/L1TRawToDigi/src/AMC13Spec.cc
@@ -141,7 +141,7 @@ namespace amc13 {
       Header block_h(data++);
       std::vector<amc::BlockHeader> headers;
 
-      for (unsigned int i = 0; i < block_h.getNumberOfAMCs(); ++i)
+      headers.reserve(block_h.getNumberOfAMCs()); for (unsigned int i = 0; i < block_h.getNumberOfAMCs(); ++i)
         headers.push_back(amc::BlockHeader(data++));
 
       check_crc = false;

--- a/EventFilter/L1TRawToDigi/src/AMC13Spec.cc
+++ b/EventFilter/L1TRawToDigi/src/AMC13Spec.cc
@@ -141,7 +141,8 @@ namespace amc13 {
       Header block_h(data++);
       std::vector<amc::BlockHeader> headers;
 
-      headers.reserve(block_h.getNumberOfAMCs()); for (unsigned int i = 0; i < block_h.getNumberOfAMCs(); ++i)
+      headers.reserve(block_h.getNumberOfAMCs());
+      for (unsigned int i = 0; i < block_h.getNumberOfAMCs(); ++i)
         headers.push_back(amc::BlockHeader(data++));
 
       check_crc = false;

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -820,7 +820,7 @@ namespace evf {
 
         if (fastMonIntervals_ && (snapCounter_ % fastMonIntervals_) == 0) {
           std::vector<std::string> CSVv;
-          for (unsigned int i = 0; i < nMonThreads_; i++) {
+          CSVv.reserve(nMonThreads_); for (unsigned int i = 0; i < nMonThreads_; i++) {
             CSVv.push_back(fmt_->jsonMonitor_->getCSVString((int)i));
           }
           // release mutex before writing out fast path file

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -820,7 +820,8 @@ namespace evf {
 
         if (fastMonIntervals_ && (snapCounter_ % fastMonIntervals_) == 0) {
           std::vector<std::string> CSVv;
-          CSVv.reserve(nMonThreads_); for (unsigned int i = 0; i < nMonThreads_; i++) {
+          CSVv.reserve(nMonThreads_);
+          for (unsigned int i = 0; i < nMonThreads_; i++) {
             CSVv.push_back(fmt_->jsonMonitor_->getCSVString((int)i));
           }
           // release mutex before writing out fast path file

--- a/FastSimulation/Muons/plugins/FastTSGFromL2Muon.cc
+++ b/FastSimulation/Muons/plugins/FastTSGFromL2Muon.cc
@@ -72,7 +72,7 @@ void FastTSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es) {
     std::set<unsigned> tkIds;
     tkSeeds.reserve(seed_size);
     for (unsigned iseed = 0; iseed < seedCollections; ++iseed) {
-      edm::Handle<edm::View<TrajectorySeed> > aSeedCollection = theSeeds[iseed];
+      const edm::Handle<edm::View<TrajectorySeed> >& aSeedCollection = theSeeds[iseed];
       unsigned nSeeds = aSeedCollection->size();
       for (unsigned seednr = 0; seednr < nSeeds; ++seednr) {
         // The seed

--- a/FastSimulation/ParticleDecay/plugins/TestPythiaDecays.cc
+++ b/FastSimulation/ParticleDecay/plugins/TestPythiaDecays.cc
@@ -325,7 +325,7 @@ void TestPythiaDecays::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 
     // fill br hist
     std::vector<int> prod;
-    for (size_t d = 0; d < childIndices.size(); ++d) {
+    prod.reserve(childIndices.size()); for (size_t d = 0; d < childIndices.size(); ++d) {
       prod.push_back(abs(simtracks->at(childIndices[d]).type()));
     }
     std::sort(prod.begin(), prod.end());

--- a/FastSimulation/ParticleDecay/plugins/TestPythiaDecays.cc
+++ b/FastSimulation/ParticleDecay/plugins/TestPythiaDecays.cc
@@ -325,7 +325,8 @@ void TestPythiaDecays::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 
     // fill br hist
     std::vector<int> prod;
-    prod.reserve(childIndices.size()); for (size_t d = 0; d < childIndices.size(); ++d) {
+    prod.reserve(childIndices.size());
+    for (size_t d = 0; d < childIndices.size(); ++d) {
       prod.push_back(abs(simtracks->at(childIndices[d]).type()));
     }
     std::sort(prod.begin(), prod.end());

--- a/FastSimulation/Utilities/src/Looses.cc
+++ b/FastSimulation/Utilities/src/Looses.cc
@@ -19,7 +19,7 @@ Looses::~Looses() { summary(); }
 void Looses::count(const std::string& name, unsigned cut) {
   if (theLosses.find(name) == theLosses.end()) {
     std::vector<unsigned> myCounts;
-    for (unsigned i = 0; i < 20; ++i)
+    myCounts.reserve(20); for (unsigned i = 0; i < 20; ++i)
       myCounts.push_back(0);
     theLosses[name] = myCounts;
   }

--- a/FastSimulation/Utilities/src/Looses.cc
+++ b/FastSimulation/Utilities/src/Looses.cc
@@ -19,7 +19,8 @@ Looses::~Looses() { summary(); }
 void Looses::count(const std::string& name, unsigned cut) {
   if (theLosses.find(name) == theLosses.end()) {
     std::vector<unsigned> myCounts;
-    myCounts.reserve(20); for (unsigned i = 0; i < 20; ++i)
+    myCounts.reserve(20);
+    for (unsigned i = 0; i < 20; ++i)
       myCounts.push_back(0);
     theLosses[name] = myCounts;
   }

--- a/Fireworks/Calo/src/FWECALCaloDataDetailViewBuilder.cc
+++ b/Fireworks/Calo/src/FWECALCaloDataDetailViewBuilder.cc
@@ -209,7 +209,7 @@ void FWECALCaloDataDetailViewBuilder::setColor(Color_t color, const std::vector<
 void FWECALCaloDataDetailViewBuilder::showSuperCluster(const reco::SuperCluster& cluster, Color_t color) {
   std::vector<DetId> clusterDetIds;
   const std::vector<std::pair<DetId, float> >& hitsAndFractions = cluster.hitsAndFractions();
-  for (size_t j = 0; j < hitsAndFractions.size(); ++j) {
+  clusterDetIds.reserve(hitsAndFractions.size()); for (size_t j = 0; j < hitsAndFractions.size(); ++j) {
     clusterDetIds.push_back(hitsAndFractions[j].first);
   }
 

--- a/Fireworks/Calo/src/FWECALCaloDataDetailViewBuilder.cc
+++ b/Fireworks/Calo/src/FWECALCaloDataDetailViewBuilder.cc
@@ -209,7 +209,8 @@ void FWECALCaloDataDetailViewBuilder::setColor(Color_t color, const std::vector<
 void FWECALCaloDataDetailViewBuilder::showSuperCluster(const reco::SuperCluster& cluster, Color_t color) {
   std::vector<DetId> clusterDetIds;
   const std::vector<std::pair<DetId, float> >& hitsAndFractions = cluster.hitsAndFractions();
-  clusterDetIds.reserve(hitsAndFractions.size()); for (size_t j = 0; j < hitsAndFractions.size(); ++j) {
+  clusterDetIds.reserve(hitsAndFractions.size());
+  for (size_t j = 0; j < hitsAndFractions.size(); ++j) {
     clusterDetIds.push_back(hitsAndFractions[j].first);
   }
 

--- a/Fireworks/Calo/src/FWECALDetailViewBuilder.cc
+++ b/Fireworks/Calo/src/FWECALDetailViewBuilder.cc
@@ -146,7 +146,7 @@ void FWECALDetailViewBuilder::setColor(Color_t color, const std::vector<DetId> &
 void FWECALDetailViewBuilder::showSuperCluster(const reco::SuperCluster &cluster, Color_t color) {
   std::vector<DetId> clusterDetIds;
   const std::vector<std::pair<DetId, float> > &hitsAndFractions = cluster.hitsAndFractions();
-  for (size_t j = 0; j < hitsAndFractions.size(); ++j) {
+  clusterDetIds.reserve(hitsAndFractions.size()); for (size_t j = 0; j < hitsAndFractions.size(); ++j) {
     clusterDetIds.push_back(hitsAndFractions[j].first);
   }
 

--- a/Fireworks/Calo/src/FWECALDetailViewBuilder.cc
+++ b/Fireworks/Calo/src/FWECALDetailViewBuilder.cc
@@ -146,7 +146,8 @@ void FWECALDetailViewBuilder::setColor(Color_t color, const std::vector<DetId> &
 void FWECALDetailViewBuilder::showSuperCluster(const reco::SuperCluster &cluster, Color_t color) {
   std::vector<DetId> clusterDetIds;
   const std::vector<std::pair<DetId, float> > &hitsAndFractions = cluster.hitsAndFractions();
-  clusterDetIds.reserve(hitsAndFractions.size()); for (size_t j = 0; j < hitsAndFractions.size(); ++j) {
+  clusterDetIds.reserve(hitsAndFractions.size());
+  for (size_t j = 0; j < hitsAndFractions.size(); ++j) {
     clusterDetIds.push_back(hitsAndFractions[j].first);
   }
 

--- a/Fireworks/ParticleFlow/plugins/FWPFCandidateWithHitsProxyBuilder.cc
+++ b/Fireworks/ParticleFlow/plugins/FWPFCandidateWithHitsProxyBuilder.cc
@@ -217,7 +217,7 @@ namespace {
 void FWPFCandidateWithHitsProxyBuilder::addHitsForCandidate(const reco::PFCandidate& cand,
                                                             TEveElement* holder,
                                                             const FWViewContext* vc) {
-  reco::PFCandidate::ElementsInBlocks eleInBlocks = cand.elementsInBlocks();
+  const reco::PFCandidate::ElementsInBlocks& eleInBlocks = cand.elementsInBlocks();
 
   TEveBoxSet* boxset = nullptr;
   TEveStraightLineSet* lineset = nullptr;

--- a/Fireworks/Vertices/plugins/FWSecVertexCandidateProxyBuilder.cc
+++ b/Fireworks/Vertices/plugins/FWSecVertexCandidateProxyBuilder.cc
@@ -73,7 +73,7 @@ void FWSecVertexCandidateProxyBuilder::build(const reco::CandSecondaryVertexTagI
       for (int j = 0; j < 3; j++) {
         t(i + 1, j + 1) = mm(i, j);
       }
-    TVectorD vv(eig.GetEigenValuesRe());
+    const TVectorD& vv(eig.GetEigenValuesRe());
     t.Scale(sqrt(vv(0)) * 1000., sqrt(vv(1)) * 1000., sqrt(vv(2)) * 1000.);
     t.SetPos(v.vx(), v.vy(), v.vz());
 

--- a/Fireworks/Vertices/plugins/FWSecVertexProxyBuilder.cc
+++ b/Fireworks/Vertices/plugins/FWSecVertexProxyBuilder.cc
@@ -71,7 +71,7 @@ void FWSecVertexProxyBuilder::build(const reco::SecondaryVertexTagInfo& iData,
       for (int j = 0; j < 3; j++) {
         t(i + 1, j + 1) = mm(i, j);
       }
-    TVectorD vv(eig.GetEigenValuesRe());
+    const TVectorD& vv(eig.GetEigenValuesRe());
     t.Scale(sqrt(vv(0)) * 1000., sqrt(vv(1)) * 1000., sqrt(vv(2)) * 1000.);
     t.SetPos(v.x(), v.y(), v.z());
 

--- a/Fireworks/Vertices/plugins/FWVertexCandidateProxyBuilder.cc
+++ b/Fireworks/Vertices/plugins/FWVertexCandidateProxyBuilder.cc
@@ -108,7 +108,7 @@ void FWVertexCandidateProxyBuilder::build(const reco::VertexCompositePtrCandidat
 
     // cache 3D extend used in eval bbox and render 3D
     TMatrixDEigen eig(m);
-    TVectorD vv(eig.GetEigenValuesRe());
+    const TVectorD& vv(eig.GetEigenValuesRe());
     eveEllipsoid->RefExtent3D().Set(sqrt(vv(0)) * ellipseScale, sqrt(vv(1)) * ellipseScale, sqrt(vv(2)) * ellipseScale);
 
     eveEllipsoid->SetLineWidth(2);

--- a/Fireworks/Vertices/plugins/FWVertexProxyBuilder.cc
+++ b/Fireworks/Vertices/plugins/FWVertexProxyBuilder.cc
@@ -106,7 +106,7 @@ void FWVertexProxyBuilder::build(const reco::Vertex& iData,
 
     // cache 3D extend used in eval bbox and render 3D
     TMatrixDEigen eig(m);
-    TVectorD vv(eig.GetEigenValuesRe());
+    const TVectorD& vv(eig.GetEigenValuesRe());
     eveEllipsoid->RefExtent3D().Set(sqrt(vv(0)) * ellipseScale, sqrt(vv(1)) * ellipseScale, sqrt(vv(2)) * ellipseScale);
 
     eveEllipsoid->SetLineWidth(2);

--- a/Fireworks/Vertices/src/TEveEllipsoidGL.cc
+++ b/Fireworks/Vertices/src/TEveEllipsoidGL.cc
@@ -172,7 +172,7 @@ void TEveEllipsoidProjectedGL::DrawRhoPhi() const {
     }
 
   TMatrixDEigen eig(xxx);
-  TVectorD xxxEig(eig.GetEigenValuesRe());
+  const TVectorD& xxxEig(eig.GetEigenValuesRe());
 
   // Projection supports only floats  :(
   TEveVector v0(fE->RefPos()[0], fE->RefPos()[1], 0);
@@ -231,7 +231,7 @@ void TEveEllipsoidProjectedGL::DrawRhoZ() const {
       xxx(i, j) = fE->RefEMtx()(i + 1, j + 1);
     }
   TMatrixDEigen eig(xxx);
-  TVectorD xxxEig(eig.GetEigenValuesRe());
+  const TVectorD& xxxEig(eig.GetEigenValuesRe());
 
   TEveVector v1(0, eig.GetEigenVectors()(1, 2), eig.GetEigenVectors()(2, 2));
   v1 *= fE->fEScale * sqrt(TMath::Abs(xxxEig[2]));

--- a/GeneratorInterface/CepGenInterface/interface/CepGenEventGenerator.h
+++ b/GeneratorInterface/CepGenInterface/interface/CepGenEventGenerator.h
@@ -15,7 +15,7 @@ namespace gen {
   class CepGenEventGenerator : public BaseHadronizer {
   public:
     explicit CepGenEventGenerator(const edm::ParameterSet&, edm::ConsumesCollector&&);
-    virtual ~CepGenEventGenerator();
+    ~CepGenEventGenerator() override;
 
     bool readSettings(int) { return true; }
     bool declareStableParticles(const std::vector<int>&) { return true; }

--- a/GeneratorInterface/CepGenInterface/interface/CepGenParametersConverter.h
+++ b/GeneratorInterface/CepGenInterface/interface/CepGenParametersConverter.h
@@ -9,7 +9,7 @@
 #include <CepGen/Core/ParametersList.h>
 
 namespace cepgen {
-  ParametersList fromParameterSet(const edm::ParameterSet& iConfig) {
+  inline ParametersList fromParameterSet(const edm::ParameterSet& iConfig) {
     ParametersList params;
     for (const auto& param : iConfig.getParameterNames()) {
       const auto cepgen_param = param == "name" ? MODULE_NAME : param;

--- a/GeneratorInterface/EvtGenInterface/plugins/EvtGen/EvtGenInterface.cc
+++ b/GeneratorInterface/EvtGenInterface/plugins/EvtGen/EvtGenInterface.cc
@@ -464,7 +464,7 @@ HepMC::GenEvent* EvtGenInterface::decay(HepMC::GenEvent* evt) {
   // decay all request unforced particles and store the forced decays to later decay one per event
   unsigned int nisforced = 0;
   std::vector<std::vector<HepMC::GenParticle*> > forcedparticles;
-  for (unsigned int i = 0; i < forced_pdgids.size(); i++)
+  forcedparticles.reserve(forced_pdgids.size()); for (unsigned int i = 0; i < forced_pdgids.size(); i++)
     forcedparticles.push_back(std::vector<HepMC::GenParticle*>());
 
   // notice this is a dynamic loop

--- a/GeneratorInterface/EvtGenInterface/plugins/EvtGen/EvtGenInterface.cc
+++ b/GeneratorInterface/EvtGenInterface/plugins/EvtGen/EvtGenInterface.cc
@@ -464,7 +464,8 @@ HepMC::GenEvent* EvtGenInterface::decay(HepMC::GenEvent* evt) {
   // decay all request unforced particles and store the forced decays to later decay one per event
   unsigned int nisforced = 0;
   std::vector<std::vector<HepMC::GenParticle*> > forcedparticles;
-  forcedparticles.reserve(forced_pdgids.size()); for (unsigned int i = 0; i < forced_pdgids.size(); i++)
+  forcedparticles.reserve(forced_pdgids.size());
+  for (unsigned int i = 0; i < forced_pdgids.size(); i++)
     forcedparticles.push_back(std::vector<HepMC::GenParticle*>());
 
   // notice this is a dynamic loop

--- a/GeneratorInterface/ExternalDecays/src/ConcurrentExternalDecayDriver.cc
+++ b/GeneratorInterface/ExternalDecays/src/ConcurrentExternalDecayDriver.cc
@@ -24,7 +24,7 @@ ConcurrentExternalDecayDriver::ConcurrentExternalDecayDriver(const ParameterSet&
   std::vector<std::string> extGenNames = pset.getParameter<std::vector<std::string> >("parameterSets");
 
   for (unsigned int ip = 0; ip < extGenNames.size(); ++ip) {
-    std::string curSet = extGenNames[ip];
+    const std::string& curSet = extGenNames[ip];
     throw cms::Exception("ThreadUnsafeDecayer") << "The decayer " << curSet << " is not thread-friendly.";
     /*
     if (curSet == "EvtGen") {

--- a/GeneratorInterface/ExternalDecays/src/ExternalDecayDriver.cc
+++ b/GeneratorInterface/ExternalDecays/src/ExternalDecayDriver.cc
@@ -26,7 +26,7 @@ ExternalDecayDriver::ExternalDecayDriver(const ParameterSet& pset, edm::Consumes
   std::vector<std::string> extGenNames = pset.getParameter<std::vector<std::string> >("parameterSets");
 
   for (unsigned int ip = 0; ip < extGenNames.size(); ++ip) {
-    std::string curSet = extGenNames[ip];
+    const std::string& curSet = extGenNames[ip];
     if (curSet == "EvtGen") {
       fEvtGenInterface = std::unique_ptr<EvtGenInterfaceBase>(
           EvtGenFactory::get()->create("EvtGen", pset.getUntrackedParameter<ParameterSet>(curSet)));

--- a/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.cc
+++ b/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.cc
@@ -26,7 +26,7 @@ bool BCToEFilterAlgo::filter(const edm::Event& iEvent) const {
   reco::GenParticleCollection genPars = *genParsHandle;
 
   for (uint32_t ig = 0; ig < genPars.size(); ig++) {
-    reco::GenParticle gp = genPars.at(ig);
+    const reco::GenParticle& gp = genPars.at(ig);
     if (gp.status() == 1 && std::abs(gp.pdgId()) == 11 && gp.et() > eTThreshold_ && std::fabs(gp.eta()) < maxAbsEta_) {
       if (hasBCAncestors(gp)) {
         result = true;

--- a/GeneratorInterface/GenFilters/plugins/MCParticlePairFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/MCParticlePairFilter.cc
@@ -53,7 +53,8 @@ MCParticlePairFilter::MCParticlePairFilter(const edm::ParameterSet& iConfig)
   // if ptMin size smaller than 2, fill up further with defaults
   if (2 > ptMin.size()) {
     vector<double> defptmin2;
-    defptmin2.reserve(2); for (unsigned int i = 0; i < 2; i++) {
+    defptmin2.reserve(2);
+    for (unsigned int i = 0; i < 2; i++) {
       defptmin2.push_back(0.);
     }
     ptMin = defptmin2;
@@ -61,7 +62,8 @@ MCParticlePairFilter::MCParticlePairFilter(const edm::ParameterSet& iConfig)
   // if pMin size smaller than 2, fill up further with defaults
   if (2 > pMin.size()) {
     vector<double> defpmin2;
-    defpmin2.reserve(2); for (unsigned int i = 0; i < 2; i++) {
+    defpmin2.reserve(2);
+    for (unsigned int i = 0; i < 2; i++) {
       defpmin2.push_back(0.);
     }
     pMin = defpmin2;
@@ -69,7 +71,8 @@ MCParticlePairFilter::MCParticlePairFilter(const edm::ParameterSet& iConfig)
   // if etaMin size smaller than 2, fill up further with defaults
   if (2 > etaMin.size()) {
     vector<double> defetamin2;
-    defetamin2.reserve(2); for (unsigned int i = 0; i < 2; i++) {
+    defetamin2.reserve(2);
+    for (unsigned int i = 0; i < 2; i++) {
       defetamin2.push_back(-10.);
     }
     etaMin = defetamin2;
@@ -77,7 +80,8 @@ MCParticlePairFilter::MCParticlePairFilter(const edm::ParameterSet& iConfig)
   // if etaMax size smaller than 2, fill up further with defaults
   if (2 > etaMax.size()) {
     vector<double> defetamax2;
-    defetamax2.reserve(2); for (unsigned int i = 0; i < 2; i++) {
+    defetamax2.reserve(2);
+    for (unsigned int i = 0; i < 2; i++) {
       defetamax2.push_back(10.);
     }
     etaMax = defetamax2;
@@ -85,7 +89,8 @@ MCParticlePairFilter::MCParticlePairFilter(const edm::ParameterSet& iConfig)
   // if status size smaller than 2, fill up further with defaults
   if (2 > status.size()) {
     vector<int> defstat2;
-    defstat2.reserve(2); for (unsigned int i = 0; i < 2; i++) {
+    defstat2.reserve(2);
+    for (unsigned int i = 0; i < 2; i++) {
       defstat2.push_back(0);
     }
     status = defstat2;

--- a/GeneratorInterface/GenFilters/plugins/MCParticlePairFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/MCParticlePairFilter.cc
@@ -53,7 +53,7 @@ MCParticlePairFilter::MCParticlePairFilter(const edm::ParameterSet& iConfig)
   // if ptMin size smaller than 2, fill up further with defaults
   if (2 > ptMin.size()) {
     vector<double> defptmin2;
-    for (unsigned int i = 0; i < 2; i++) {
+    defptmin2.reserve(2); for (unsigned int i = 0; i < 2; i++) {
       defptmin2.push_back(0.);
     }
     ptMin = defptmin2;
@@ -61,7 +61,7 @@ MCParticlePairFilter::MCParticlePairFilter(const edm::ParameterSet& iConfig)
   // if pMin size smaller than 2, fill up further with defaults
   if (2 > pMin.size()) {
     vector<double> defpmin2;
-    for (unsigned int i = 0; i < 2; i++) {
+    defpmin2.reserve(2); for (unsigned int i = 0; i < 2; i++) {
       defpmin2.push_back(0.);
     }
     pMin = defpmin2;
@@ -69,7 +69,7 @@ MCParticlePairFilter::MCParticlePairFilter(const edm::ParameterSet& iConfig)
   // if etaMin size smaller than 2, fill up further with defaults
   if (2 > etaMin.size()) {
     vector<double> defetamin2;
-    for (unsigned int i = 0; i < 2; i++) {
+    defetamin2.reserve(2); for (unsigned int i = 0; i < 2; i++) {
       defetamin2.push_back(-10.);
     }
     etaMin = defetamin2;
@@ -77,7 +77,7 @@ MCParticlePairFilter::MCParticlePairFilter(const edm::ParameterSet& iConfig)
   // if etaMax size smaller than 2, fill up further with defaults
   if (2 > etaMax.size()) {
     vector<double> defetamax2;
-    for (unsigned int i = 0; i < 2; i++) {
+    defetamax2.reserve(2); for (unsigned int i = 0; i < 2; i++) {
       defetamax2.push_back(10.);
     }
     etaMax = defetamax2;
@@ -85,7 +85,7 @@ MCParticlePairFilter::MCParticlePairFilter(const edm::ParameterSet& iConfig)
   // if status size smaller than 2, fill up further with defaults
   if (2 > status.size()) {
     vector<int> defstat2;
-    for (unsigned int i = 0; i < 2; i++) {
+    defstat2.reserve(2); for (unsigned int i = 0; i < 2; i++) {
       defstat2.push_back(0);
     }
     status = defstat2;

--- a/GeneratorInterface/GenFilters/plugins/MCProcessFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/MCProcessFilter.cc
@@ -66,7 +66,7 @@ MCProcessFilter::MCProcessFilter(const edm::ParameterSet& iConfig)
   // if pthatMin size smaller than processID , fill up further with defaults
   if (processID.size() > pthatMin.size()) {
     vector<double> defpthatmin2;
-    for (unsigned int i = 0; i < processID.size(); i++) {
+    defpthatmin2.reserve(processID.size()); for (unsigned int i = 0; i < processID.size(); i++) {
       defpthatmin2.push_back(0.);
     }
     pthatMin = defpthatmin2;
@@ -74,7 +74,7 @@ MCProcessFilter::MCProcessFilter(const edm::ParameterSet& iConfig)
   // if pthatMax size smaller than processID , fill up further with defaults
   if (processID.size() > pthatMax.size()) {
     vector<double> defpthatmax2;
-    for (unsigned int i = 0; i < processID.size(); i++) {
+    defpthatmax2.reserve(processID.size()); for (unsigned int i = 0; i < processID.size(); i++) {
       defpthatmax2.push_back(10000.);
     }
     pthatMax = defpthatmax2;

--- a/GeneratorInterface/GenFilters/plugins/MCProcessFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/MCProcessFilter.cc
@@ -66,7 +66,8 @@ MCProcessFilter::MCProcessFilter(const edm::ParameterSet& iConfig)
   // if pthatMin size smaller than processID , fill up further with defaults
   if (processID.size() > pthatMin.size()) {
     vector<double> defpthatmin2;
-    defpthatmin2.reserve(processID.size()); for (unsigned int i = 0; i < processID.size(); i++) {
+    defpthatmin2.reserve(processID.size());
+    for (unsigned int i = 0; i < processID.size(); i++) {
       defpthatmin2.push_back(0.);
     }
     pthatMin = defpthatmin2;
@@ -74,7 +75,8 @@ MCProcessFilter::MCProcessFilter(const edm::ParameterSet& iConfig)
   // if pthatMax size smaller than processID , fill up further with defaults
   if (processID.size() > pthatMax.size()) {
     vector<double> defpthatmax2;
-    defpthatmax2.reserve(processID.size()); for (unsigned int i = 0; i < processID.size(); i++) {
+    defpthatmax2.reserve(processID.size());
+    for (unsigned int i = 0; i < processID.size(); i++) {
       defpthatmax2.push_back(10000.);
     }
     pthatMax = defpthatmax2;

--- a/GeneratorInterface/GenFilters/plugins/MCSingleParticleFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/MCSingleParticleFilter.cc
@@ -42,7 +42,8 @@ MCSingleParticleFilter::MCSingleParticleFilter(const edm::ParameterSet& iConfig)
   // if ptMin size smaller than particleID , fill up further with defaults
   if (particleID.size() > ptMin.size()) {
     vector<double> defptmin2;
-    defptmin2.reserve(particleID.size()); for (unsigned int i = 0; i < particleID.size(); i++) {
+    defptmin2.reserve(particleID.size());
+    for (unsigned int i = 0; i < particleID.size(); i++) {
       defptmin2.push_back(0.);
     }
     ptMin = defptmin2;
@@ -50,7 +51,8 @@ MCSingleParticleFilter::MCSingleParticleFilter(const edm::ParameterSet& iConfig)
   // if etaMin size smaller than particleID , fill up further with defaults
   if (particleID.size() > etaMin.size()) {
     vector<double> defetamin2;
-    defetamin2.reserve(particleID.size()); for (unsigned int i = 0; i < particleID.size(); i++) {
+    defetamin2.reserve(particleID.size());
+    for (unsigned int i = 0; i < particleID.size(); i++) {
       defetamin2.push_back(-10.);
     }
     etaMin = defetamin2;
@@ -58,7 +60,8 @@ MCSingleParticleFilter::MCSingleParticleFilter(const edm::ParameterSet& iConfig)
   // if etaMax size smaller than particleID , fill up further with defaults
   if (particleID.size() > etaMax.size()) {
     vector<double> defetamax2;
-    defetamax2.reserve(particleID.size()); for (unsigned int i = 0; i < particleID.size(); i++) {
+    defetamax2.reserve(particleID.size());
+    for (unsigned int i = 0; i < particleID.size(); i++) {
       defetamax2.push_back(10.);
     }
     etaMax = defetamax2;
@@ -66,7 +69,8 @@ MCSingleParticleFilter::MCSingleParticleFilter(const edm::ParameterSet& iConfig)
   // if status size smaller than particleID , fill up further with defaults
   if (particleID.size() > status.size()) {
     vector<int> defstat2;
-    defstat2.reserve(particleID.size()); for (unsigned int i = 0; i < particleID.size(); i++) {
+    defstat2.reserve(particleID.size());
+    for (unsigned int i = 0; i < particleID.size(); i++) {
       defstat2.push_back(0);
     }
     status = defstat2;

--- a/GeneratorInterface/GenFilters/plugins/MCSingleParticleFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/MCSingleParticleFilter.cc
@@ -42,7 +42,7 @@ MCSingleParticleFilter::MCSingleParticleFilter(const edm::ParameterSet& iConfig)
   // if ptMin size smaller than particleID , fill up further with defaults
   if (particleID.size() > ptMin.size()) {
     vector<double> defptmin2;
-    for (unsigned int i = 0; i < particleID.size(); i++) {
+    defptmin2.reserve(particleID.size()); for (unsigned int i = 0; i < particleID.size(); i++) {
       defptmin2.push_back(0.);
     }
     ptMin = defptmin2;
@@ -50,7 +50,7 @@ MCSingleParticleFilter::MCSingleParticleFilter(const edm::ParameterSet& iConfig)
   // if etaMin size smaller than particleID , fill up further with defaults
   if (particleID.size() > etaMin.size()) {
     vector<double> defetamin2;
-    for (unsigned int i = 0; i < particleID.size(); i++) {
+    defetamin2.reserve(particleID.size()); for (unsigned int i = 0; i < particleID.size(); i++) {
       defetamin2.push_back(-10.);
     }
     etaMin = defetamin2;
@@ -58,7 +58,7 @@ MCSingleParticleFilter::MCSingleParticleFilter(const edm::ParameterSet& iConfig)
   // if etaMax size smaller than particleID , fill up further with defaults
   if (particleID.size() > etaMax.size()) {
     vector<double> defetamax2;
-    for (unsigned int i = 0; i < particleID.size(); i++) {
+    defetamax2.reserve(particleID.size()); for (unsigned int i = 0; i < particleID.size(); i++) {
       defetamax2.push_back(10.);
     }
     etaMax = defetamax2;
@@ -66,7 +66,7 @@ MCSingleParticleFilter::MCSingleParticleFilter(const edm::ParameterSet& iConfig)
   // if status size smaller than particleID , fill up further with defaults
   if (particleID.size() > status.size()) {
     vector<int> defstat2;
-    for (unsigned int i = 0; i < particleID.size(); i++) {
+    defstat2.reserve(particleID.size()); for (unsigned int i = 0; i < particleID.size(); i++) {
       defstat2.push_back(0);
     }
     status = defstat2;

--- a/GeneratorInterface/GenFilters/plugins/MCSingleParticleYPt.cc
+++ b/GeneratorInterface/GenFilters/plugins/MCSingleParticleYPt.cc
@@ -86,7 +86,8 @@ MCSingleParticleYPt::MCSingleParticleYPt(const edm::ParameterSet& iConfig)
   // if ptMin size smaller than particleID , fill up further with defaults
   if (particleID.size() > ptMin.size()) {
     vector<double> defptmin2;
-    defptmin2.reserve(particleID.size()); for (unsigned int i = 0; i < particleID.size(); i++) {
+    defptmin2.reserve(particleID.size());
+    for (unsigned int i = 0; i < particleID.size(); i++) {
       defptmin2.push_back(0.);
     }
     ptMin = defptmin2;
@@ -94,7 +95,8 @@ MCSingleParticleYPt::MCSingleParticleYPt(const edm::ParameterSet& iConfig)
   // if etaMin size smaller than particleID , fill up further with defaults
   if (particleID.size() > rapMin.size()) {
     vector<double> defrapmin2;
-    defrapmin2.reserve(particleID.size()); for (unsigned int i = 0; i < particleID.size(); i++) {
+    defrapmin2.reserve(particleID.size());
+    for (unsigned int i = 0; i < particleID.size(); i++) {
       defrapmin2.push_back(-10.);
     }
     rapMin = defrapmin2;
@@ -102,7 +104,8 @@ MCSingleParticleYPt::MCSingleParticleYPt(const edm::ParameterSet& iConfig)
   // if etaMax size smaller than particleID , fill up further with defaults
   if (particleID.size() > rapMax.size()) {
     vector<double> defrapmax2;
-    defrapmax2.reserve(particleID.size()); for (unsigned int i = 0; i < particleID.size(); i++) {
+    defrapmax2.reserve(particleID.size());
+    for (unsigned int i = 0; i < particleID.size(); i++) {
       defrapmax2.push_back(10.);
     }
     rapMax = defrapmax2;
@@ -110,7 +113,8 @@ MCSingleParticleYPt::MCSingleParticleYPt(const edm::ParameterSet& iConfig)
   // if status size smaller than particleID , fill up further with defaults
   if (particleID.size() > status.size()) {
     vector<int> defstat2;
-    defstat2.reserve(particleID.size()); for (unsigned int i = 0; i < particleID.size(); i++) {
+    defstat2.reserve(particleID.size());
+    for (unsigned int i = 0; i < particleID.size(); i++) {
       defstat2.push_back(0);
     }
     status = defstat2;

--- a/GeneratorInterface/GenFilters/plugins/MCSingleParticleYPt.cc
+++ b/GeneratorInterface/GenFilters/plugins/MCSingleParticleYPt.cc
@@ -86,7 +86,7 @@ MCSingleParticleYPt::MCSingleParticleYPt(const edm::ParameterSet& iConfig)
   // if ptMin size smaller than particleID , fill up further with defaults
   if (particleID.size() > ptMin.size()) {
     vector<double> defptmin2;
-    for (unsigned int i = 0; i < particleID.size(); i++) {
+    defptmin2.reserve(particleID.size()); for (unsigned int i = 0; i < particleID.size(); i++) {
       defptmin2.push_back(0.);
     }
     ptMin = defptmin2;
@@ -94,7 +94,7 @@ MCSingleParticleYPt::MCSingleParticleYPt(const edm::ParameterSet& iConfig)
   // if etaMin size smaller than particleID , fill up further with defaults
   if (particleID.size() > rapMin.size()) {
     vector<double> defrapmin2;
-    for (unsigned int i = 0; i < particleID.size(); i++) {
+    defrapmin2.reserve(particleID.size()); for (unsigned int i = 0; i < particleID.size(); i++) {
       defrapmin2.push_back(-10.);
     }
     rapMin = defrapmin2;
@@ -102,7 +102,7 @@ MCSingleParticleYPt::MCSingleParticleYPt(const edm::ParameterSet& iConfig)
   // if etaMax size smaller than particleID , fill up further with defaults
   if (particleID.size() > rapMax.size()) {
     vector<double> defrapmax2;
-    for (unsigned int i = 0; i < particleID.size(); i++) {
+    defrapmax2.reserve(particleID.size()); for (unsigned int i = 0; i < particleID.size(); i++) {
       defrapmax2.push_back(10.);
     }
     rapMax = defrapmax2;
@@ -110,7 +110,7 @@ MCSingleParticleYPt::MCSingleParticleYPt(const edm::ParameterSet& iConfig)
   // if status size smaller than particleID , fill up further with defaults
   if (particleID.size() > status.size()) {
     vector<int> defstat2;
-    for (unsigned int i = 0; i < particleID.size(); i++) {
+    defstat2.reserve(particleID.size()); for (unsigned int i = 0; i < particleID.size(); i++) {
       defstat2.push_back(0);
     }
     status = defstat2;

--- a/GeneratorInterface/LHEInterface/src/LHEEvent.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEEvent.cc
@@ -249,7 +249,8 @@ namespace lhef {
     std::vector<HepMC::GenVertex *> genVertices;
 
     // I. convert particles
-    genParticles.reserve(nup); for (unsigned int i = 0; i < nup; i++)
+    genParticles.reserve(nup);
+    for (unsigned int i = 0; i < nup; i++)
       genParticles.push_back(makeHepMCParticle(i));
 
     // II. loop again to build vertices

--- a/GeneratorInterface/LHEInterface/src/LHEEvent.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEEvent.cc
@@ -249,7 +249,7 @@ namespace lhef {
     std::vector<HepMC::GenVertex *> genVertices;
 
     // I. convert particles
-    for (unsigned int i = 0; i < nup; i++)
+    genParticles.reserve(nup); for (unsigned int i = 0; i < nup; i++)
       genParticles.push_back(makeHepMCParticle(i));
 
     // II. loop again to build vertices

--- a/GeneratorInterface/PartonShowerVeto/src/JetMatchingMadgraph.cc
+++ b/GeneratorInterface/PartonShowerVeto/src/JetMatchingMadgraph.cc
@@ -263,7 +263,7 @@ namespace gen {
       throw cms::Exception("Generator|PartonShowerVeto") << "Run not initialized in JetMatchingMadgraph" << std::endl;
 
     if (uppriv_.ickkw) {
-      const std::vector<std::string>& comments = event->getComments();
+      const std::vector<std::string> &comments = event->getComments();
       if (comments.size() == 1) {
         std::istringstream ss(comments[0].substr(1));
         for (int i = 0; i < 1000; i++) {

--- a/GeneratorInterface/PartonShowerVeto/src/JetMatchingMadgraph.cc
+++ b/GeneratorInterface/PartonShowerVeto/src/JetMatchingMadgraph.cc
@@ -263,7 +263,7 @@ namespace gen {
       throw cms::Exception("Generator|PartonShowerVeto") << "Run not initialized in JetMatchingMadgraph" << std::endl;
 
     if (uppriv_.ickkw) {
-      std::vector<std::string> comments = event->getComments();
+      const std::vector<std::string>& comments = event->getComments();
       if (comments.size() == 1) {
         std::istringstream ss(comments[0].substr(1));
         for (int i = 0; i < 1000; i++) {

--- a/GeneratorInterface/PhotosInterface/plugins/PhotosppInterface.cc
+++ b/GeneratorInterface/PhotosInterface/plugins/PhotosppInterface.cc
@@ -27,7 +27,7 @@ PhotosppInterface::PhotosppInterface(const edm::ParameterSet& pset)
   fPSet = new ParameterSet(pset);
   std::vector<std::string> par = fPSet->getParameter<std::vector<std::string> >("parameterSets");
   for (unsigned int ip = 0; ip < par.size(); ++ip) {
-    std::string curSet = par[ip];
+    const std::string& curSet = par[ip];
     // Physics settings
     if (curSet == "UseHadronizerQEDBrem")
       UseHadronizerQEDBrem = true;
@@ -53,7 +53,7 @@ void PhotosppInterface::init() {
   Photospp::Photos::createHistoryEntries(true, 746);  // P-H-O
   std::vector<std::string> par = fPSet->getParameter<std::vector<std::string> >("parameterSets");
   for (unsigned int ip = 0; ip < par.size(); ++ip) {
-    std::string curSet = par[ip];
+    const std::string& curSet = par[ip];
 
     // Physics settings
     if (curSet == "maxWtInterference")
@@ -107,7 +107,7 @@ void PhotosppInterface::init() {
       edm::ParameterSet cfg = fPSet->getParameter<edm::ParameterSet>(curSet);
       std::vector<std::string> v = cfg.getParameter<std::vector<std::string> >("parameterSets");
       for (unsigned int i = 0; i < v.size(); i++) {
-        std::string vs = v[i];
+        const std::string& vs = v[i];
         std::vector<int> vpar = cfg.getParameter<std::vector<int> >(vs);
         if (vpar.size() == 1)
           Photospp::Photos::suppressBremForBranch(0, vpar[0]);
@@ -138,7 +138,7 @@ void PhotosppInterface::init() {
       edm::ParameterSet cfg = fPSet->getParameter<edm::ParameterSet>(curSet);
       std::vector<std::string> v = cfg.getParameter<std::vector<std::string> >("parameterSets");
       for (unsigned int i = 0; i < v.size(); i++) {
-        std::string vs = v[i];
+        const std::string& vs = v[i];
         std::vector<int> vpar = cfg.getParameter<std::vector<int> >(vs);
         if (vpar.size() == 1)
           Photospp::Photos::suppressBremForDecay(0, vpar[0]);
@@ -170,7 +170,7 @@ void PhotosppInterface::init() {
       edm::ParameterSet cfg = fPSet->getParameter<edm::ParameterSet>(curSet);
       std::vector<std::string> v = cfg.getParameter<std::vector<std::string> >("parameterSets");
       for (unsigned int i = 0; i < v.size(); i++) {
-        std::string vs = v[i];
+        const std::string& vs = v[i];
         std::vector<int> vpar = cfg.getParameter<std::vector<int> >(vs);
         if (vpar.size() == 1)
           Photospp::Photos::forceBremForBranch(0, vpar[0]);
@@ -200,7 +200,7 @@ void PhotosppInterface::init() {
       edm::ParameterSet cfg = fPSet->getParameter<edm::ParameterSet>(curSet);
       std::vector<std::string> v = cfg.getParameter<std::vector<std::string> >("parameterSets");
       for (unsigned int i = 0; i < v.size(); i++) {
-        std::string vs = v[i];
+        const std::string& vs = v[i];
         std::vector<int> vpar = cfg.getParameter<std::vector<int> >(vs);
         if (vpar.size() == 1)
           Photospp::Photos::forceBremForDecay(0, vpar[0]);
@@ -231,7 +231,7 @@ void PhotosppInterface::init() {
       edm::ParameterSet cfg = fPSet->getParameter<edm::ParameterSet>(curSet);
       std::vector<std::string> v = cfg.getParameter<std::vector<std::string> >("parameterSets");
       for (unsigned int i = 0; i < v.size(); i++) {
-        std::string vs = v[i];
+        const std::string& vs = v[i];
         std::vector<double> vpar = cfg.getParameter<std::vector<double> >(vs);
         if (vpar.size() == 2)
           Photospp::Photos::forceMass((int)vpar[0], vpar[1]);

--- a/GeneratorInterface/Pythia8Interface/plugins/PowhegHooksBB4L.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/PowhegHooksBB4L.h
@@ -108,10 +108,10 @@ namespace Pythia8 {
   class PowhegHooksBB4L : public UserHooks {
   public:
     PowhegHooksBB4L() {}
-    ~PowhegHooksBB4L() { std::cout << "Number of FSR vetoed in BB4l = " << nInResonanceFSRveto << std::endl; }
+    ~PowhegHooksBB4L() override { std::cout << "Number of FSR vetoed in BB4l = " << nInResonanceFSRveto << std::endl; }
 
     //--- Initialization -------------------------------------------------------
-    bool initAfterBeams() {
+    bool initAfterBeams() override {
       // initialize settings of this class
       vetoFSREmission = settingsPtr->flag("POWHEG:bb4l:FSREmission:veto");
       vetoDipoleFrame = settingsPtr->flag("POWHEG:bb4l:FSREmission:vetoDipoleFrame");
@@ -128,8 +128,8 @@ namespace Pythia8 {
     //--- PROCESS LEVEL HOOK ---------------------------------------------------
     // This hook gets triggered for each event before the shower starts, i.e. at
     // the LHE level. We use it to calculate the scales of resonances.
-    inline bool canVetoProcessLevel() { return true; }
-    inline bool doVetoProcessLevel(Event &e) {
+    inline bool canVetoProcessLevel() override { return true; }
+    inline bool doVetoProcessLevel(Event &e) override {
       // extract the radtype from the event comment
       stringstream ss;
       // use eventattribute as comments not filled when using edm input
@@ -168,8 +168,8 @@ namespace Pythia8 {
     //--- FSR EMISSION LEVEL HOOK ----------------------------------------------
     // This hook gets triggered everytime the parton shower attempts to attach
     // a FSR emission.
-    inline bool canVetoFSREmission() { return vetoFSREmission; }
-    inline bool doVetoFSREmission(int sizeOld, const Event &e, int iSys, bool inResonance) {
+    inline bool canVetoFSREmission() override { return vetoFSREmission; }
+    inline bool doVetoFSREmission(int sizeOld, const Event &e, int iSys, bool inResonance) override {
       // FSR VETO INSIDE THE RESONANCE (if it is switched on)
       if (inResonance && vetoFSREmission) {
         // get the participants of the splitting: the recoiler, the radiator and the emitted
@@ -264,14 +264,14 @@ namespace Pythia8 {
 
     //--- SCALE RESONANCE HOOK -------------------------------------------------
     // called before each resonance decay shower
-    inline bool canSetResonanceScale() { return scaleResonanceVeto; }
+    inline bool canSetResonanceScale() override { return scaleResonanceVeto; }
     // if the resonance is the (anti)top or W+/W- set the scale to:
     // - if radtype=2 (remnant): resonance virtuality
     // - if radtype=1 (btilde):
     //  - (a)topresscale/wp(m)resscale for tops and Ws
     //  - a large number otherwise
     // if is not the top, set it to a big number
-    inline double scaleResonance(int iRes, const Event &e) {
+    inline double scaleResonance(int iRes, const Event &e) override {
       if (!vetoAllRadtypes && radtype == 2)
         return sqrt(e[iRes].m2Calc());
       else {

--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -184,7 +184,7 @@ void HTXSRivetProducer::beginRun(edm::Run const& iRun, edm::EventSetup const& es
            iter++) {
         std::vector<std::string> lines = iter->lines();
         for (unsigned int iLine = 0; iLine < lines.size(); iLine++) {
-          std::string line = lines.at(iLine);
+          const std::string& line = lines.at(iLine);
           // POWHEG
           if (line.find("gg_H_quark-mass-effects") != std::string::npos) {
             edm::LogInfo("HTXSRivetProducer") << iLine << " " << line << std::endl;

--- a/GeneratorInterface/RivetInterface/plugins/RivetAnalyzer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/RivetAnalyzer.cc
@@ -139,7 +139,7 @@ void RivetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
   genEvent->read_data(*genEventData);
 
   std::vector<double> mergedWeights;
-  for (unsigned int i = 0; i < genEvent->weights().size(); i++) {
+  mergedWeights.reserve(genEvent->weights().size()); for (unsigned int i = 0; i < genEvent->weights().size(); i++) {
     mergedWeights.push_back(genEvent->weights()[i]);
   }
 

--- a/GeneratorInterface/RivetInterface/plugins/RivetAnalyzer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/RivetAnalyzer.cc
@@ -139,7 +139,8 @@ void RivetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
   genEvent->read_data(*genEventData);
 
   std::vector<double> mergedWeights;
-  mergedWeights.reserve(genEvent->weights().size()); for (unsigned int i = 0; i < genEvent->weights().size(); i++) {
+  mergedWeights.reserve(genEvent->weights().size());
+  for (unsigned int i = 0; i < genEvent->weights().size(); i++) {
     mergedWeights.push_back(genEvent->weights()[i]);
   }
 

--- a/GeneratorInterface/TauolaInterface/plugins/Tauolapp/TauolappInterface.cc
+++ b/GeneratorInterface/TauolaInterface/plugins/Tauolapp/TauolappInterface.cc
@@ -119,7 +119,7 @@ void TauolappInterface::init(const edm::EventSetup& es) {
   if (fPSet->exists("parameterSets")) {
     std::vector<std::string> par = fPSet->getParameter<std::vector<std::string> >("parameterSets");
     for (unsigned int ip = 0; ip < par.size(); ++ip) {
-      std::string curSet = par[ip];
+      const std::string& curSet = par[ip];
       if (curSet == "setNewCurrents")
         Tauolapp::Tauola::setNewCurrents(fPSet->getParameter<int>(curSet));
     }
@@ -133,7 +133,7 @@ void TauolappInterface::init(const edm::EventSetup& es) {
   if (fPSet->exists("parameterSets")) {
     std::vector<std::string> par = fPSet->getParameter<std::vector<std::string> >("parameterSets");
     for (unsigned int ip = 0; ip < par.size(); ++ip) {
-      std::string curSet = par[ip];
+      const std::string& curSet = par[ip];
       if (curSet == "spinCorrelationSetAll")
         Tauolapp::Tauola::spin_correlation.setAll(fPSet->getParameter<bool>(curSet));
       if (curSet == "spinCorrelationGAMMA")

--- a/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryLoaderFromDDD.cc
+++ b/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryLoaderFromDDD.cc
@@ -98,7 +98,7 @@ void EcalTBHodoscopeGeometryLoaderFromDDD::makeGeometry(const DDCompactView* cpv
 unsigned int EcalTBHodoscopeGeometryLoaderFromDDD::getDetIdForDDDNode(const DDFilteredView& fv) {
   // perform some consistency checks
   // get the parents and grandparents of this node
-  DDGeoHistory parents = fv.geoHistory();
+  const DDGeoHistory& parents = fv.geoHistory();
 
   assert(parents.size() >= 3);
 

--- a/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilder.cc
@@ -230,7 +230,7 @@ ME0Chamber* ME0GeometryBuilder::buildChamber(DDFilteredView& fv, ME0DetId detId)
   LogTrace("ME0Geometry") << "buildChamber " << fv.logicalPart().name().name() << " " << detId << std::endl;
   DDBooleanSolid solid = (DDBooleanSolid)(fv.logicalPart().solid());
 
-  std::vector<double> dpar = solid.parameters();
+  const std::vector<double>& dpar = solid.parameters();
 
   double L = convertMmToCm(dpar[0]);  // length is along local Y
   double T = convertMmToCm(dpar[3]);  // thickness is long local Z
@@ -258,7 +258,7 @@ ME0Layer* ME0GeometryBuilder::buildLayer(DDFilteredView& fv, ME0DetId detId) con
 
   DDBooleanSolid solid = (DDBooleanSolid)(fv.logicalPart().solid());
 
-  std::vector<double> dpar = solid.parameters();
+  const std::vector<double>& dpar = solid.parameters();
   double L = convertMmToCm(dpar[0]);  // length is along local Y
   double t = convertMmToCm(dpar[3]);  // thickness is long local Z
   double b = convertMmToCm(dpar[4]);  // bottom width is along local X

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -565,7 +565,8 @@ HGCalParameters::hgtrap HGCalDDDConstants::getModule(unsigned int indx, bool hex
 
 std::vector<HGCalParameters::hgtrap> HGCalDDDConstants::getModules() const {
   std::vector<HGCalParameters::hgtrap> mytrs;
-  mytrs.reserve(hgpar_->moduleLayR_.size()); for (unsigned int k = 0; k < hgpar_->moduleLayR_.size(); ++k)
+  mytrs.reserve(hgpar_->moduleLayR_.size());
+  for (unsigned int k = 0; k < hgpar_->moduleLayR_.size(); ++k)
     mytrs.emplace_back(hgpar_->getModule(k, true));
   return mytrs;
 }
@@ -603,7 +604,8 @@ std::pair<int, int> HGCalDDDConstants::getREtaRange(int lay) const {
 
 std::vector<HGCalParameters::hgtrform> HGCalDDDConstants::getTrForms() const {
   std::vector<HGCalParameters::hgtrform> mytrs;
-  mytrs.reserve(hgpar_->trformIndex_.size()); for (unsigned int k = 0; k < hgpar_->trformIndex_.size(); ++k)
+  mytrs.reserve(hgpar_->trformIndex_.size());
+  for (unsigned int k = 0; k < hgpar_->trformIndex_.size(); ++k)
     mytrs.emplace_back(hgpar_->getTrForm(k));
   return mytrs;
 }

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -565,7 +565,7 @@ HGCalParameters::hgtrap HGCalDDDConstants::getModule(unsigned int indx, bool hex
 
 std::vector<HGCalParameters::hgtrap> HGCalDDDConstants::getModules() const {
   std::vector<HGCalParameters::hgtrap> mytrs;
-  for (unsigned int k = 0; k < hgpar_->moduleLayR_.size(); ++k)
+  mytrs.reserve(hgpar_->moduleLayR_.size()); for (unsigned int k = 0; k < hgpar_->moduleLayR_.size(); ++k)
     mytrs.emplace_back(hgpar_->getModule(k, true));
   return mytrs;
 }
@@ -603,7 +603,7 @@ std::pair<int, int> HGCalDDDConstants::getREtaRange(int lay) const {
 
 std::vector<HGCalParameters::hgtrform> HGCalDDDConstants::getTrForms() const {
   std::vector<HGCalParameters::hgtrform> mytrs;
-  for (unsigned int k = 0; k < hgpar_->trformIndex_.size(); ++k)
+  mytrs.reserve(hgpar_->trformIndex_.size()); for (unsigned int k = 0; k < hgpar_->trformIndex_.size(); ++k)
     mytrs.emplace_back(hgpar_->getTrForm(k));
   return mytrs;
 }

--- a/Geometry/HGCalMapping/interface/HGCalMappingTools.h
+++ b/Geometry/HGCalMapping/interface/HGCalMappingTools.h
@@ -55,7 +55,7 @@ namespace hgcal {
       std::vector<HGCalEntityRow> entities_;
       void setHeader(HGCalEntityRow &header) {
         for (size_t i = 0; i < header.size(); i++) {
-          std::string cname = header[i];
+          const std::string& cname = header[i];
           colNames_.push_back(cname);
           columnIndex_[cname] = i;
         }

--- a/Geometry/HGCalMapping/interface/HGCalMappingTools.h
+++ b/Geometry/HGCalMapping/interface/HGCalMappingTools.h
@@ -55,7 +55,7 @@ namespace hgcal {
       std::vector<HGCalEntityRow> entities_;
       void setHeader(HGCalEntityRow &header) {
         for (size_t i = 0; i < header.size(); i++) {
-          const std::string& cname = header[i];
+          const std::string &cname = header[i];
           colNames_.push_back(cname);
           columnIndex_[cname] = i;
         }

--- a/Geometry/HGCalMapping/plugins/alpaka/HGCalMappingModuleESProducer.cc
+++ b/Geometry/HGCalMapping/plugins/alpaka/HGCalMappingModuleESProducer.cc
@@ -45,7 +45,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       //
       std::optional<HGCalMappingModuleParamHost> produce(const HGCalElectronicsMappingRcd& iRecord) {
         //get cell and module indexer
-        auto modIndexer = iRecord.get(moduleIndexTkn_);
+        const auto& modIndexer = iRecord.get(moduleIndexTkn_);
 
         // load dense indexing
         const uint32_t size = modIndexer.maxModulesIndex();

--- a/Geometry/HGCalTBCommonData/src/HGCalTBDDDConstants.cc
+++ b/Geometry/HGCalTBCommonData/src/HGCalTBDDDConstants.cc
@@ -237,14 +237,14 @@ HGCalTBParameters::hgtrap HGCalTBDDDConstants::getModule(unsigned int indx, bool
 
 std::vector<HGCalTBParameters::hgtrap> HGCalTBDDDConstants::getModules() const {
   std::vector<HGCalTBParameters::hgtrap> mytrs;
-  for (unsigned int k = 0; k < hgpar_->moduleLayR_.size(); ++k)
+  mytrs.reserve(hgpar_->moduleLayR_.size()); for (unsigned int k = 0; k < hgpar_->moduleLayR_.size(); ++k)
     mytrs.emplace_back(hgpar_->getModule(k, true));
   return mytrs;
 }
 
 std::vector<HGCalTBParameters::hgtrform> HGCalTBDDDConstants::getTrForms() const {
   std::vector<HGCalTBParameters::hgtrform> mytrs;
-  for (unsigned int k = 0; k < hgpar_->trformIndex_.size(); ++k)
+  mytrs.reserve(hgpar_->trformIndex_.size()); for (unsigned int k = 0; k < hgpar_->trformIndex_.size(); ++k)
     mytrs.emplace_back(hgpar_->getTrForm(k));
   return mytrs;
 }

--- a/Geometry/HGCalTBCommonData/src/HGCalTBDDDConstants.cc
+++ b/Geometry/HGCalTBCommonData/src/HGCalTBDDDConstants.cc
@@ -237,14 +237,16 @@ HGCalTBParameters::hgtrap HGCalTBDDDConstants::getModule(unsigned int indx, bool
 
 std::vector<HGCalTBParameters::hgtrap> HGCalTBDDDConstants::getModules() const {
   std::vector<HGCalTBParameters::hgtrap> mytrs;
-  mytrs.reserve(hgpar_->moduleLayR_.size()); for (unsigned int k = 0; k < hgpar_->moduleLayR_.size(); ++k)
+  mytrs.reserve(hgpar_->moduleLayR_.size());
+  for (unsigned int k = 0; k < hgpar_->moduleLayR_.size(); ++k)
     mytrs.emplace_back(hgpar_->getModule(k, true));
   return mytrs;
 }
 
 std::vector<HGCalTBParameters::hgtrform> HGCalTBDDDConstants::getTrForms() const {
   std::vector<HGCalTBParameters::hgtrform> mytrs;
-  mytrs.reserve(hgpar_->trformIndex_.size()); for (unsigned int k = 0; k < hgpar_->trformIndex_.size(); ++k)
+  mytrs.reserve(hgpar_->trformIndex_.size());
+  for (unsigned int k = 0; k < hgpar_->trformIndex_.size(); ++k)
     mytrs.emplace_back(hgpar_->getTrForm(k));
   return mytrs;
 }

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalLinearXY.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalLinearXY.cc
@@ -38,7 +38,7 @@ static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext
       unsigned int k = (childName.size() == 1) ? 0 : copy;
       ++copy;
       if (k < childName.size() && (childName[k] != " " && childName[k] != "Null")) {
-        std::string child = childName[k];
+        const std::string& child = childName[k];
         dd4hep::Position tran(xoff + i * deltaX, yoff + j * deltaY, centre[2]);
         parent.placeVolume(ns.volume(child), copy, tran);
 #ifdef EDM_ML_DEBUG

--- a/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
+++ b/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
@@ -63,7 +63,8 @@ std::vector<int> HcalDDDRecConstants::getDepth(const unsigned int& eta, const bo
     std::map<int, int> layers;
     hcons.ldMap()->getLayerDepth(eta + 1, layers);
     std::vector<int> depths;
-    depths.reserve(layers.size()); for (unsigned int lay = 0; lay < layers.size(); ++lay)
+    depths.reserve(layers.size());
+    for (unsigned int lay = 0; lay < layers.size(); ++lay)
       depths.emplace_back(layers[lay + 1]);
     return depths;
   }
@@ -79,7 +80,8 @@ std::vector<int> HcalDDDRecConstants::getDepth(const int& det,
     return getDepth(eta, false);
   } else {
     std::vector<int> depths;
-    depths.reserve(layers.size()); for (unsigned int lay = 0; lay < layers.size(); ++lay)
+    depths.reserve(layers.size());
+    for (unsigned int lay = 0; lay < layers.size(); ++lay)
       depths.emplace_back(layers[lay + 1]);
     return depths;
   }

--- a/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
+++ b/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
@@ -63,7 +63,7 @@ std::vector<int> HcalDDDRecConstants::getDepth(const unsigned int& eta, const bo
     std::map<int, int> layers;
     hcons.ldMap()->getLayerDepth(eta + 1, layers);
     std::vector<int> depths;
-    for (unsigned int lay = 0; lay < layers.size(); ++lay)
+    depths.reserve(layers.size()); for (unsigned int lay = 0; lay < layers.size(); ++lay)
       depths.emplace_back(layers[lay + 1]);
     return depths;
   }
@@ -79,7 +79,7 @@ std::vector<int> HcalDDDRecConstants::getDepth(const int& det,
     return getDepth(eta, false);
   } else {
     std::vector<int> depths;
-    for (unsigned int lay = 0; lay < layers.size(); ++lay)
+    depths.reserve(layers.size()); for (unsigned int lay = 0; lay < layers.size(); ++lay)
       depths.emplace_back(layers[lay + 1]);
     return depths;
   }

--- a/Geometry/MTDGeometryBuilder/src/MTDGeomBuilderFromGeometricTimingDet.cc
+++ b/Geometry/MTDGeometryBuilder/src/MTDGeomBuilderFromGeometricTimingDet.cc
@@ -44,7 +44,7 @@ MTDGeometry* MTDGeomBuilderFromGeometricTimingDet::build(const GeometricTimingDe
 
   std::vector<GeometricTimingDet::GTDEnumType> gdsubdetmap(
       2, GeometricTimingDet::unknown);  // hardcoded "2" should not be a surprise...
-  GeometricTimingDet::ConstGeometricTimingDetContainer subdetgd = gd->components();
+  const GeometricTimingDet::ConstGeometricTimingDetContainer& subdetgd = gd->components();
 
   LogDebug("SubDetectorGeometricTimingDetType") << "MTD GeometricTimingDet enumerator values of the subdetectors";
   for (unsigned int i = 0; i < subdetgd.size(); ++i) {

--- a/Geometry/MTDGeometryBuilder/src/MTDGeometry.cc
+++ b/Geometry/MTDGeometryBuilder/src/MTDGeometry.cc
@@ -44,7 +44,7 @@ MTDGeometry::MTDGeometry(GeometricTimingDet const* gd) : theTrackerDet(gd) {
     theSubDetTypeMap[i] = GeomDetEnumerators::invalidDet;
     theNumberOfLayers[i] = 0;
   }
-  GeometricTimingDet::ConstGeometricTimingDetContainer subdetgd = gd->components();
+  const GeometricTimingDet::ConstGeometricTimingDetContainer& subdetgd = gd->components();
 
 #ifdef EDM_ML_DEBUG
   edm::LogInfo("BuildingSubDetTypeMap")

--- a/Geometry/MuonNumbering/src/MuonGeometryNumbering.cc
+++ b/Geometry/MuonNumbering/src/MuonGeometryNumbering.cc
@@ -95,7 +95,7 @@ int MuonGeometryNumbering::getInt(const std::string &s, const DDLogicalPart &par
       break;
   }
   if (foundIt) {
-    const std::vector<double>& temp = val.doubles();
+    const std::vector<double> &temp = val.doubles();
     if (temp.size() != 1) {
       edm::LogError("MuonGeom") << "MuonGeometryNumbering:: ERROR: I need only 1 " << s << " in DDLogicalPart "
                                 << part.name();

--- a/Geometry/MuonNumbering/src/MuonGeometryNumbering.cc
+++ b/Geometry/MuonNumbering/src/MuonGeometryNumbering.cc
@@ -95,7 +95,7 @@ int MuonGeometryNumbering::getInt(const std::string &s, const DDLogicalPart &par
       break;
   }
   if (foundIt) {
-    std::vector<double> temp = val.doubles();
+    const std::vector<double>& temp = val.doubles();
     if (temp.size() != 1) {
       edm::LogError("MuonGeom") << "MuonGeometryNumbering:: ERROR: I need only 1 " << s << " in DDLogicalPart "
                                 << part.name();

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDPixBarLayerAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDPixBarLayerAlgo.cc
@@ -83,8 +83,8 @@ static long algorithm(Detector& description, cms::DDParsingContext& ctxt, xml_h 
   edm::LogVerbatim("PixelGeom") << "Cool " << cool.name() << " number 1 positioned in " << coolTube.name()
                                 << " at (0,0,0) with no rotation";
 
-  string ladderFull = ladder[0];
-  string ladderHalf = ladder[1];
+  const string& ladderFull = ladder[0];
+  const string& ladderHalf = ladder[1];
   int nphi = number / 2, copy = 1, iup = -1;
   double phi0 = 90_deg;
   Volume ladderHalfVol = ns.volume(ladderHalf);

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
@@ -71,7 +71,7 @@ TrackerGeometry* TrackerGeomBuilderFromGeometricDet::build(const GeometricDet* g
 
   std::vector<GeometricDet::GDEnumType> gdsubdetmap(
       6, GeometricDet::unknown);  // hardcoded "6" should not be a surprise...
-  GeometricDet::ConstGeometricDetContainer subdetgd = gd->components();
+  const GeometricDet::ConstGeometricDetContainer& subdetgd = gd->components();
 
   LogDebug("SubDetectorGeometricDetType") << "GeometriDet enumerator values of the subdetectors";
   for (unsigned int i = 0; i < subdetgd.size(); ++i) {

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
@@ -60,7 +60,7 @@ TrackerGeometry::TrackerGeometry(GeometricDet const* gd) : theTrackerDet(gd) {
     theSubDetTypeMap[i] = GeomDetEnumerators::invalidDet;
     theNumberOfLayers[i] = 0;
   }
-  GeometricDet::ConstGeometricDetContainer subdetgd = gd->components();
+  const GeometricDet::ConstGeometricDetContainer& subdetgd = gd->components();
 
   LogDebug("BuildingSubDetTypeMap") << "GeometriDet and GeomDetEnumerators enumerator values of the subdetectors";
   for (unsigned int i = 0; i < subdetgd.size(); ++i) {

--- a/HLTrigger/Egamma/plugins/HLTEgammaCaloIsolFilterPairs.cc
+++ b/HLTrigger/Egamma/plugins/HLTEgammaCaloIsolFilterPairs.cc
@@ -101,8 +101,8 @@ bool HLTEgammaCaloIsolFilterPairs::hltFilter(edm::Event& iEvent,
 
   // Should I check that the size of recoecalcands is even ?
   for (unsigned int i = 0; i < recoecalcands.size(); i = i + 2) {
-    edm::Ref<reco::RecoEcalCandidateCollection> r1 = recoecalcands[i];
-    edm::Ref<reco::RecoEcalCandidateCollection> r2 = recoecalcands[i + 1];
+    const edm::Ref<reco::RecoEcalCandidateCollection>& r1 = recoecalcands[i];
+    const edm::Ref<reco::RecoEcalCandidateCollection>& r2 = recoecalcands[i + 1];
     // std::cout<<"CaloIsol 1) Et Eta phi: "<<r1->et()<<" "<<r1->eta()<<" "<<r1->phi()<<" 2) Et eta phi: "<<r2->et()<<" "<<r2->eta()<<" "<<r2->phi()<<std::endl;
 
     if (PassCaloIsolation(r1, *depMap, *depNonIsoMap, 1, AlsoNonIso_1) &&

--- a/HLTrigger/Egamma/plugins/HLTEgammaEtFilterPairs.cc
+++ b/HLTrigger/Egamma/plugins/HLTEgammaEtFilterPairs.cc
@@ -69,8 +69,8 @@ bool HLTEgammaEtFilterPairs::hltFilter(edm::Event& iEvent,
   int n(0);
 
   for (unsigned int i = 0; i < recoecalcands.size(); i = i + 2) {
-    edm::Ref<reco::RecoEcalCandidateCollection> r1 = recoecalcands[i];
-    edm::Ref<reco::RecoEcalCandidateCollection> r2 = recoecalcands[i + 1];
+    const edm::Ref<reco::RecoEcalCandidateCollection>& r1 = recoecalcands[i];
+    const edm::Ref<reco::RecoEcalCandidateCollection>& r2 = recoecalcands[i + 1];
     //  std::cout<<"EtFilter: 1) Et Eta phi: "<<r1->et()<<" "<<r1->eta()<<" "<<r1->phi()<<" 2) Et eta phi: "<<r2->et()<<" "<<r2->eta()<<" "<<r2->phi()<<std::endl;
     bool first =
         (fabs(r1->eta()) < 1.479 && r1->et() >= etcutEB1_) || (fabs(r1->eta()) >= 1.479 && r1->et() >= etcutEE1_);

--- a/HLTrigger/Egamma/plugins/HLTGenericFilter.cc
+++ b/HLTrigger/Egamma/plugins/HLTGenericFilter.cc
@@ -176,7 +176,7 @@ bool HLTGenericFilter<T1>::hltFilter(edm::Event& iEvent,
   int n = 0;
   for (unsigned int i = 0; i < recoCands.size(); i++) {
     // Ref to Candidate object to be recorded in filter object
-    T1Ref ref = recoCands[i];
+    const T1Ref& ref = recoCands[i];
     typename T1IsolationMap::const_iterator mapi = (*depMap).find(ref);
 
     //should we do the abs before or after the rho corr?

--- a/HLTrigger/JetMET/interface/HLTCATopTagFilter.h
+++ b/HLTrigger/JetMET/interface/HLTCATopTagFilter.h
@@ -80,13 +80,13 @@ inline reco::CATopJetProperties CATopJetHelperUser::operator()(reco::Jet const& 
     // Now look at the subjets that were formed
     for (int isub = 0; isub < 2; ++isub) {
       // Get this subjet
-      reco::Jet::Constituent icandJet = subjets[isub];
+      const reco::Jet::Constituent& icandJet = subjets[isub];
 
       // Now look at the "other" subjets than this one, form the minimum invariant mass
       // pairing, as well as the "closest" combination to the W mass
       for (int jsub = isub + 1; jsub < 3; ++jsub) {
         // Get the second subjet
-        reco::Jet::Constituent jcandJet = subjets[jsub];
+        const reco::Jet::Constituent& jcandJet = subjets[jsub];
 
         reco::Candidate::LorentzVector wCand = icandJet->p4() + jcandJet->p4();
 

--- a/HLTrigger/Muon/plugins/HLTMuonL1TFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonL1TFilter.cc
@@ -167,7 +167,7 @@ bool HLTMuonL1TFilter::hltFilter(edm::Event& iEvent,
     vector<MuonRef> firedMuons;
     filterproduct.getObjects(TriggerL1Mu, firedMuons);
     for (size_t i = 0; i < firedMuons.size(); i++) {
-      l1t::MuonRef mu = firedMuons[i];
+      const l1t::MuonRef& mu = firedMuons[i];
       bool isPrev = find(prevMuons.begin(), prevMuons.end(), mu) != prevMuons.end();
       LogTrace("HLTMuonL1TFilter") << i << '\t' << setprecision(2) << scientific << mu->charge() << '\t' << mu->pt()
                                    << '\t' << fixed << mu->eta() << '\t' << mu->phi() << '\t' << mu->hwQual() << '\t'

--- a/HLTrigger/Muon/plugins/HLTMuonL1TRegionalFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonL1TRegionalFilter.cc
@@ -231,7 +231,7 @@ bool HLTMuonL1TRegionalFilter::hltFilter(edm::Event& iEvent,
     vector<MuonRef> firedMuons;
     filterproduct.getObjects(TriggerL1Mu, firedMuons);
     for (size_t i = 0; i < firedMuons.size(); i++) {
-      l1t::MuonRef mu = firedMuons[i];
+      const l1t::MuonRef& mu = firedMuons[i];
       bool isPrev = find(prevMuons.begin(), prevMuons.end(), mu) != prevMuons.end();
       LogTrace("HLTMuonL1TRegionalFilter")
           << i << '\t' << setprecision(2) << scientific << mu->charge() * mu->pt() << '\t' << fixed << mu->eta() << '\t'

--- a/HLTrigger/btau/plugins/HLTmumutkFilter.cc
+++ b/HLTrigger/btau/plugins/HLTmumutkFilter.cc
@@ -96,7 +96,7 @@ bool HLTmumutkFilter::hltFilter(edm::Event& iEvent,
   // loop over vertex collection
   reco::VertexCollection::iterator it;
   for (it = displacedVertexColl.begin(); it != displacedVertexColl.end(); it++) {
-    reco::Vertex displacedVertex = *it;
+    const reco::Vertex& displacedVertex = *it;
 
     // check if the vertex actually consists of exactly two muon + 1 track, throw exception if not
     if (displacedVertex.tracksSize() != 3)

--- a/HLTrigger/btau/plugins/HLTmumutktkFilter.cc
+++ b/HLTrigger/btau/plugins/HLTmumutktkFilter.cc
@@ -103,7 +103,7 @@ bool HLTmumutktkFilter::hltFilter(edm::Event& iEvent,
   // loop over vertex collection
   reco::VertexCollection::iterator it;
   for (it = displacedVertexColl.begin(); it != displacedVertexColl.end(); it++) {
-    reco::Vertex displacedVertex = *it;
+    const reco::Vertex& displacedVertex = *it;
 
     // check if the vertex actually consists of exactly two muon + 1 track, throw exception if not
     if (displacedVertex.tracksSize() != 4)

--- a/HLTriggerOffline/Egamma/src/EmDQMPostProcessor.cc
+++ b/HLTriggerOffline/Egamma/src/EmDQMPostProcessor.cc
@@ -312,7 +312,7 @@ void EmDQMPostProcessor::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter
 
           // Is this the last filter? Book efficiency vs gen (or reco, for data)
           // level
-          std::string temp = *postfix;
+          const std::string& temp = *postfix;
           if (filter == total->GetNbinsX() - 3 && temp.find("matched") != std::string::npos) {
             if (normalizeToReco)
               genName = ibooker.pwd() + "/reco_" + *var;

--- a/HLTriggerOffline/Egamma/src/EmDQMPostProcessor.cc
+++ b/HLTriggerOffline/Egamma/src/EmDQMPostProcessor.cc
@@ -312,7 +312,7 @@ void EmDQMPostProcessor::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter
 
           // Is this the last filter? Book efficiency vs gen (or reco, for data)
           // level
-          const std::string& temp = *postfix;
+          const std::string &temp = *postfix;
           if (filter == total->GetNbinsX() - 3 && temp.find("matched") != std::string::npos) {
             if (normalizeToReco)
               genName = ibooker.pwd() + "/reco_" + *var;

--- a/HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc
@@ -53,7 +53,7 @@ void HLTExoticaPlotter::plotterBookHistos(DQMStore::IBooker &iBooker,
     const std::string objTypeStr = EVTColContainer::getTypeString(*it);
 
     for (size_t i = 0; i < sources.size(); i++) {
-      const std::string& source = sources[i];
+      const std::string &source = sources[i];
 
       if (source == "gen") {
         if (TString(objTypeStr).Contains("MET") || TString(objTypeStr).Contains("MHT") ||

--- a/HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc
@@ -53,7 +53,7 @@ void HLTExoticaPlotter::plotterBookHistos(DQMStore::IBooker &iBooker,
     const std::string objTypeStr = EVTColContainer::getTypeString(*it);
 
     for (size_t i = 0; i < sources.size(); i++) {
-      std::string source = sources[i];
+      const std::string& source = sources[i];
 
       if (source == "gen") {
         if (TString(objTypeStr).Contains("MET") || TString(objTypeStr).Contains("MHT") ||

--- a/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
@@ -205,7 +205,7 @@ void HLTExoticaSubAnalysis::subAnalysisBookHistos(DQMStore::IBooker &iBooker,
     sources[1] = "rec";
 
     for (size_t i = 0; i < sources.size(); i++) {
-      const std::string& source = sources[i];
+      const std::string &source = sources[i];
 
       if (source == "gen") {
         if (TString(objStr).Contains("MET") || TString(objStr).Contains("MHT") || TString(objStr).Contains("Jet")) {

--- a/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
@@ -205,7 +205,7 @@ void HLTExoticaSubAnalysis::subAnalysisBookHistos(DQMStore::IBooker &iBooker,
     sources[1] = "rec";
 
     for (size_t i = 0; i < sources.size(); i++) {
-      std::string source = sources[i];
+      const std::string& source = sources[i];
 
       if (source == "gen") {
         if (TString(objStr).Contains("MET") || TString(objStr).Contains("MHT") || TString(objStr).Contains("Jet")) {

--- a/HLTriggerOffline/Higgs/plugins/HLTHiggsPlotter.cc
+++ b/HLTriggerOffline/Higgs/plugins/HLTHiggsPlotter.cc
@@ -56,7 +56,7 @@ void HLTHiggsPlotter::bookHistograms(DQMStore::IBooker &ibooker, const bool &use
     const std::string objTypeStr = EVTColContainer::getTypeString(*it);
 
     for (size_t i = 0; i < sources.size(); i++) {
-      std::string source = sources[i];
+      const std::string& source = sources[i];
 
       if (useNminOneCuts && *it == EVTColContainer::PFJET) {
         if (source == "gen")

--- a/HLTriggerOffline/Higgs/plugins/HLTHiggsPlotter.cc
+++ b/HLTriggerOffline/Higgs/plugins/HLTHiggsPlotter.cc
@@ -56,7 +56,7 @@ void HLTHiggsPlotter::bookHistograms(DQMStore::IBooker &ibooker, const bool &use
     const std::string objTypeStr = EVTColContainer::getTypeString(*it);
 
     for (size_t i = 0; i < sources.size(); i++) {
-      const std::string& source = sources[i];
+      const std::string &source = sources[i];
 
       if (useNminOneCuts && *it == EVTColContainer::PFJET) {
         if (source == "gen")

--- a/HLTriggerOffline/Higgs/plugins/HLTHiggsSubAnalysis.cc
+++ b/HLTriggerOffline/Higgs/plugins/HLTHiggsSubAnalysis.cc
@@ -268,7 +268,7 @@ void HLTHiggsSubAnalysis::bookHistograms(DQMStore::IBooker& ibooker) {
     TString maxPt;
 
     for (size_t i = 0; i < sources.size(); i++) {
-      std::string source = sources[i];
+      const std::string& source = sources[i];
       if (_useNminOneCuts && it->first == EVTColContainer::PFJET) {
         if (source == "gen")
           continue;

--- a/HLTriggerOffline/JetMET/src/HLTJetMETValidation.cc
+++ b/HLTriggerOffline/JetMET/src/HLTJetMETValidation.cc
@@ -206,16 +206,20 @@ void HLTJetMETValidation::analyze(const edm::Event &iEvent, const edm::EventSetu
   // get TriggerResults object
   bool gotHLT = true;
   std::vector<bool> myTrigJ;
-  myTrigJ.reserve(hltTrgJet.size()); for (size_t it = 0; it < hltTrgJet.size(); it++)
+  myTrigJ.reserve(hltTrgJet.size());
+  for (size_t it = 0; it < hltTrgJet.size(); it++)
     myTrigJ.push_back(false);
   std::vector<bool> myTrigJLow;
-  myTrigJLow.reserve(hltTrgJetLow.size()); for (size_t it = 0; it < hltTrgJetLow.size(); it++)
+  myTrigJLow.reserve(hltTrgJetLow.size());
+  for (size_t it = 0; it < hltTrgJetLow.size(); it++)
     myTrigJLow.push_back(false);
   std::vector<bool> myTrigM;
-  myTrigM.reserve(hltTrgMet.size()); for (size_t it = 0; it < hltTrgMet.size(); it++)
+  myTrigM.reserve(hltTrgMet.size());
+  for (size_t it = 0; it < hltTrgMet.size(); it++)
     myTrigM.push_back(false);
   std::vector<bool> myTrigMLow;
-  myTrigMLow.reserve(hltTrgMetLow.size()); for (size_t it = 0; it < hltTrgMetLow.size(); it++)
+  myTrigMLow.reserve(hltTrgMetLow.size());
+  for (size_t it = 0; it < hltTrgMetLow.size(); it++)
     myTrigMLow.push_back(false);
 
   Handle<TriggerResults> hltresults;

--- a/HLTriggerOffline/JetMET/src/HLTJetMETValidation.cc
+++ b/HLTriggerOffline/JetMET/src/HLTJetMETValidation.cc
@@ -206,16 +206,16 @@ void HLTJetMETValidation::analyze(const edm::Event &iEvent, const edm::EventSetu
   // get TriggerResults object
   bool gotHLT = true;
   std::vector<bool> myTrigJ;
-  for (size_t it = 0; it < hltTrgJet.size(); it++)
+  myTrigJ.reserve(hltTrgJet.size()); for (size_t it = 0; it < hltTrgJet.size(); it++)
     myTrigJ.push_back(false);
   std::vector<bool> myTrigJLow;
-  for (size_t it = 0; it < hltTrgJetLow.size(); it++)
+  myTrigJLow.reserve(hltTrgJetLow.size()); for (size_t it = 0; it < hltTrgJetLow.size(); it++)
     myTrigJLow.push_back(false);
   std::vector<bool> myTrigM;
-  for (size_t it = 0; it < hltTrgMet.size(); it++)
+  myTrigM.reserve(hltTrgMet.size()); for (size_t it = 0; it < hltTrgMet.size(); it++)
     myTrigM.push_back(false);
   std::vector<bool> myTrigMLow;
-  for (size_t it = 0; it < hltTrgMetLow.size(); it++)
+  myTrigMLow.reserve(hltTrgMetLow.size()); for (size_t it = 0; it < hltTrgMetLow.size(); it++)
     myTrigMLow.push_back(false);
 
   Handle<TriggerResults> hltresults;

--- a/HLTriggerOffline/Muon/src/HLTMuonPlotter.cc
+++ b/HLTriggerOffline/Muon/src/HLTMuonPlotter.cc
@@ -104,7 +104,7 @@ void HLTMuonPlotter::beginRun(DQMStore::IBooker &iBooker, const edm::Run &iRun, 
   elements_["CutMaxEta"]->Fill(cutMaxEta_);
 
   for (size_t i = 0; i < sources.size(); i++) {
-    const std::string& source = sources[i];
+    const std::string &source = sources[i];
     for (size_t j = 0; j < stepLabels_.size(); j++) {
       bookHist(iBooker, hltPath_, stepLabels_[j], source, "Eta");
       bookHist(iBooker, hltPath_, stepLabels_[j], source, "Phi");

--- a/HLTriggerOffline/Muon/src/HLTMuonPlotter.cc
+++ b/HLTriggerOffline/Muon/src/HLTMuonPlotter.cc
@@ -104,7 +104,7 @@ void HLTMuonPlotter::beginRun(DQMStore::IBooker &iBooker, const edm::Run &iRun, 
   elements_["CutMaxEta"]->Fill(cutMaxEta_);
 
   for (size_t i = 0; i < sources.size(); i++) {
-    std::string source = sources[i];
+    const std::string& source = sources[i];
     for (size_t j = 0; j < stepLabels_.size(); j++) {
       bookHist(iBooker, hltPath_, stepLabels_[j], source, "Eta");
       bookHist(iBooker, hltPath_, stepLabels_[j], source, "Phi");

--- a/HLTriggerOffline/Scouting/plugins/PatElectronTagProbeAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/PatElectronTagProbeAnalyzer.cc
@@ -306,7 +306,8 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
   // Pt ordered pat electron and sct electron collection
 
   std::vector<std::pair<size_t, pat::Electron>> indexed_patElectrons;
-  indexed_patElectrons.reserve(patEls->size()); for (size_t i = 0; i < patEls->size(); i++) {
+  indexed_patElectrons.reserve(patEls->size());
+  for (size_t i = 0; i < patEls->size(); i++) {
     indexed_patElectrons.emplace_back(i, (*patEls)[i]);
   }
 
@@ -315,7 +316,8 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
   });
 
   std::vector<std::pair<size_t, Run3ScoutingElectron>> indexed_sctElectrons;
-  indexed_sctElectrons.reserve(sctEls->size()); for (size_t i = 0; i < sctEls->size(); i++) {
+  indexed_sctElectrons.reserve(sctEls->size());
+  for (size_t i = 0; i < sctEls->size(); i++) {
     indexed_sctElectrons.emplace_back(i, (*sctEls)[i]);
   }
   std::sort(indexed_sctElectrons.begin(), indexed_sctElectrons.end(), [](const auto& a, const auto& b) {

--- a/HLTriggerOffline/Scouting/plugins/PatElectronTagProbeAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/PatElectronTagProbeAnalyzer.cc
@@ -306,7 +306,7 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
   // Pt ordered pat electron and sct electron collection
 
   std::vector<std::pair<size_t, pat::Electron>> indexed_patElectrons;
-  for (size_t i = 0; i < patEls->size(); i++) {
+  indexed_patElectrons.reserve(patEls->size()); for (size_t i = 0; i < patEls->size(); i++) {
     indexed_patElectrons.emplace_back(i, (*patEls)[i]);
   }
 
@@ -315,7 +315,7 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
   });
 
   std::vector<std::pair<size_t, Run3ScoutingElectron>> indexed_sctElectrons;
-  for (size_t i = 0; i < sctEls->size(); i++) {
+  indexed_sctElectrons.reserve(sctEls->size()); for (size_t i = 0; i < sctEls->size(); i++) {
     indexed_sctElectrons.emplace_back(i, (*sctEls)[i]);
   }
   std::sort(indexed_sctElectrons.begin(), indexed_sctElectrons.end(), [](const auto& a, const auto& b) {

--- a/HLTriggerOffline/Scouting/plugins/ScoutingElectronTagProbeAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingElectronTagProbeAnalyzer.cc
@@ -213,7 +213,8 @@ void ScoutingElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
   // Pt ordered sct electron collection
 
   std::vector<std::pair<size_t, Run3ScoutingElectron>> indexed_sctElectrons;
-  indexed_sctElectrons.reserve(sctEls->size()); for (size_t i = 0; i < sctEls->size(); i++) {
+  indexed_sctElectrons.reserve(sctEls->size());
+  for (size_t i = 0; i < sctEls->size(); i++) {
     indexed_sctElectrons.emplace_back(i, (*sctEls)[i]);
   }
   std::sort(indexed_sctElectrons.begin(), indexed_sctElectrons.end(), [](const auto& a, const auto& b) {

--- a/HLTriggerOffline/Scouting/plugins/ScoutingElectronTagProbeAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingElectronTagProbeAnalyzer.cc
@@ -213,7 +213,7 @@ void ScoutingElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
   // Pt ordered sct electron collection
 
   std::vector<std::pair<size_t, Run3ScoutingElectron>> indexed_sctElectrons;
-  for (size_t i = 0; i < sctEls->size(); i++) {
+  indexed_sctElectrons.reserve(sctEls->size()); for (size_t i = 0; i < sctEls->size(); i++) {
     indexed_sctElectrons.emplace_back(i, (*sctEls)[i]);
   }
   std::sort(indexed_sctElectrons.begin(), indexed_sctElectrons.end(), [](const auto& a, const auto& b) {

--- a/HLTriggerOffline/Scouting/plugins/ScoutingMuonTagProbeAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingMuonTagProbeAnalyzer.cc
@@ -169,7 +169,7 @@ void ScoutingMuonTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
     if (foundTag)
       continue;
     math::PtEtaPhiMLorentzVector tag_sct_mu(sct_mu.pt(), sct_mu.eta(), sct_mu.phi(), sct_mu.m());
-    const std::vector<int> vtxIndx_tag = sct_mu.vtxIndx();
+    const std::vector<int>& vtxIndx_tag = sct_mu.vtxIndx();
 
     // Then pair the tag with the probe
     for (const auto& sct_mu_second : *sctMuons) {
@@ -179,7 +179,7 @@ void ScoutingMuonTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
           sct_mu_second.pt(), sct_mu_second.eta(), sct_mu_second.phi(), sct_mu_second.m());
       if (sct_mu_second.pt() < 1)
         continue;
-      const std::vector<int> vtxIndx_probe = sct_mu_second.vtxIndx();
+      const std::vector<int>& vtxIndx_probe = sct_mu_second.vtxIndx();
 
       float invMass = (tag_sct_mu + probe_sct_mu).mass();
       edm::LogInfo("ScoutingMonitoring") << "Inv Mass: " << invMass;

--- a/HeavyFlavorAnalysis/Onia2MuMu/src/OniaVtxReProducer.cc
+++ b/HeavyFlavorAnalysis/Onia2MuMu/src/OniaVtxReProducer.cc
@@ -18,7 +18,7 @@ OniaVtxReProducer::OniaVtxReProducer(const edm::Handle<reco::VertexCollection> &
   if (edm::moduleName(prov->stable(), iEvent.processHistory()) != "PrimaryVertexProducer") {
     std::vector<edm::BranchID> parents = prov->productProvenance()->parentage().parents();
     for (std::vector<edm::BranchID>::const_iterator it = parents.begin(), ed = parents.end(); it != ed; ++it) {
-      const edm::Provenance& parprov = iEvent.getProvenance(*it);
+      const edm::Provenance &parprov = iEvent.getProvenance(*it);
       if (parprov.friendlyClassName() == "recoVertexs") {  // for AOD actually this the parent we should look for
         parent_prov = &parprov;
         psetFromProvenance = edm::parameterSet(parprov.stable(), iEvent.processHistory());

--- a/HeavyFlavorAnalysis/Onia2MuMu/src/OniaVtxReProducer.cc
+++ b/HeavyFlavorAnalysis/Onia2MuMu/src/OniaVtxReProducer.cc
@@ -18,7 +18,7 @@ OniaVtxReProducer::OniaVtxReProducer(const edm::Handle<reco::VertexCollection> &
   if (edm::moduleName(prov->stable(), iEvent.processHistory()) != "PrimaryVertexProducer") {
     std::vector<edm::BranchID> parents = prov->productProvenance()->parentage().parents();
     for (std::vector<edm::BranchID>::const_iterator it = parents.begin(), ed = parents.end(); it != ed; ++it) {
-      edm::Provenance parprov = iEvent.getProvenance(*it);
+      const edm::Provenance& parprov = iEvent.getProvenance(*it);
       if (parprov.friendlyClassName() == "recoVertexs") {  // for AOD actually this the parent we should look for
         parent_prov = &parprov;
         psetFromProvenance = edm::parameterSet(parprov.stable(), iEvent.processHistory());

--- a/HeavyFlavorAnalysis/SpecificDecay/src/BPHDecayToChargedXXbarBuilder.cc
+++ b/HeavyFlavorAnalysis/SpecificDecay/src/BPHDecayToChargedXXbarBuilder.cc
@@ -158,7 +158,7 @@ void BPHDecayToChargedXXbarBuilder::addParticle(const BPHRecoBuilder::BPHGeneric
       continue;
     if ((charge < 0) && (q >= 0))
       continue;
-    const reco::Candidate::LorentzVector p4 = cand.p4();
+    const reco::Candidate::LorentzVector& p4 = cand.p4();
     if (p4.pt() < ptMin)
       continue;
     if (p4.eta() > etaMax)

--- a/HeavyFlavorAnalysis/SpecificDecay/src/BPHDecayToTkpTknSymChargeBuilder.cc
+++ b/HeavyFlavorAnalysis/SpecificDecay/src/BPHDecayToTkpTknSymChargeBuilder.cc
@@ -201,7 +201,7 @@ void BPHDecayToTkpTknSymChargeBuilder::addParticle(const BPHRecoBuilder::BPHGene
       continue;
     if ((charge < 0) && (q >= 0))
       continue;
-    const reco::Candidate::LorentzVector p4 = cand.p4();
+    const reco::Candidate::LorentzVector& p4 = cand.p4();
     const reco::Track* tk = BPHTrackReference::getTrack(cand, "cfhp");
     if (tk == nullptr)
       continue;

--- a/JetMETCorrections/Modules/plugins/JetResolutionDemo.cc
+++ b/JetMETCorrections/Modules/plugins/JetResolutionDemo.cc
@@ -120,7 +120,8 @@ void JetResolutionDemo::analyze(const edm::Event& iEvent, const edm::EventSetup&
       }
 
       std::vector<float> res;
-      res.reserve(40); for (std::size_t i = 0; i < 40; i++) {
+      res.reserve(40);
+      for (std::size_t i = 0; i < 40; i++) {
         res.push_back(i * 0.005);
       }
 

--- a/JetMETCorrections/Modules/plugins/JetResolutionDemo.cc
+++ b/JetMETCorrections/Modules/plugins/JetResolutionDemo.cc
@@ -120,7 +120,7 @@ void JetResolutionDemo::analyze(const edm::Event& iEvent, const edm::EventSetup&
       }
 
       std::vector<float> res;
-      for (std::size_t i = 0; i < 40; i++) {
+      res.reserve(40); for (std::size_t i = 0; i < 40; i++) {
         res.push_back(i * 0.005);
       }
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMatcher.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMatcher.cc
@@ -277,7 +277,7 @@ uint16_t CSCGEMMatcher::mitigatedSlopeByConsistency(const CSCCLCTDigi& clct,
   const bool isME1a(station_ == 1 and clct.getKeyStrip() > CSCConstants::MAX_HALF_STRIP_ME1B);
 
   // extract hit values from CLCT hit matrix
-  std::vector<std::vector<uint16_t>> CLCTHitMatrix = clct.getHits();
+  const std::vector<std::vector<uint16_t>>& CLCTHitMatrix = clct.getHits();
   int CLCTHits[6] = {-1, -1, -1, -1, -1, -1};
 
   for (unsigned layer = 0; layer < CLCTHitMatrix.size(); ++layer) {

--- a/L1Trigger/DTTriggerPhase2/src/LateralityCoarsedProvider.cc
+++ b/L1Trigger/DTTriggerPhase2/src/LateralityCoarsedProvider.cc
@@ -249,7 +249,7 @@ std::vector<std::vector<short>> LateralityCoarsedProvider::convertString(std::st
 
   for (size_t i = 0; i < chain.size(); i += 4) {
     std::vector<short> group;
-    for (size_t j = 0; j < 4; j++) {
+    group.reserve(4); for (size_t j = 0; j < 4; j++) {
       group.push_back(chain[i + j] - '0');  // Convert the character to integer
     }
     result.push_back(group);

--- a/L1Trigger/DTTriggerPhase2/src/LateralityCoarsedProvider.cc
+++ b/L1Trigger/DTTriggerPhase2/src/LateralityCoarsedProvider.cc
@@ -249,7 +249,8 @@ std::vector<std::vector<short>> LateralityCoarsedProvider::convertString(std::st
 
   for (size_t i = 0; i < chain.size(); i += 4) {
     std::vector<short> group;
-    group.reserve(4); for (size_t j = 0; j < 4; j++) {
+    group.reserve(4);
+    for (size_t j = 0; j < 4; j++) {
       group.push_back(chain[i + j] - '0');  // Convert the character to integer
     }
     result.push_back(group);

--- a/L1Trigger/DTTriggerPhase2/src/MuonPathCorFitter.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MuonPathCorFitter.cc
@@ -407,7 +407,8 @@ void MuonPathCorFitter::fillLuts() {
     ifin2sl >> line;
 
     std::vector<int> myNumbers;
-    myNumbers.reserve(line.size()); for (size_t i = 0; i < line.size(); i++) {
+    myNumbers.reserve(line.size());
+    for (size_t i = 0; i < line.size(); i++) {
       // This converts the char into an int and pushes it into vec
       myNumbers.push_back(line[i] - '0');  // The digits will be in the same order as before
     }

--- a/L1Trigger/DTTriggerPhase2/src/MuonPathCorFitter.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MuonPathCorFitter.cc
@@ -407,7 +407,7 @@ void MuonPathCorFitter::fillLuts() {
     ifin2sl >> line;
 
     std::vector<int> myNumbers;
-    for (size_t i = 0; i < line.size(); i++) {
+    myNumbers.reserve(line.size()); for (size_t i = 0; i < line.size(); i++) {
       // This converts the char into an int and pushes it into vec
       myNumbers.push_back(line[i] - '0');  // The digits will be in the same order as before
     }

--- a/L1Trigger/DTTriggerPhase2/src/MuonPathSLFitter.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MuonPathSLFitter.cc
@@ -68,7 +68,7 @@ void MuonPathSLFitter::run(edm::Event &iEvent,
   // fit per SL (need to allow for multiple outputs for a single mpath)
   // for (auto &muonpath : muonpaths) {
   if (!muonpaths.empty()) {
-    auto muonpath = muonpaths[0];
+    const auto& muonpath = muonpaths[0];
     int rawId = muonpath->primitive(0)->cameraId();
     if (muonpath->primitive(0)->cameraId() == -1) {
       rawId = muonpath->primitive(1)->cameraId();
@@ -79,7 +79,7 @@ void MuonPathSLFitter::run(edm::Event &iEvent,
 
   for (size_t i = 0; i < muonpaths.size(); i++) {
     auto muonpath = muonpaths[i];
-    auto lats = lateralities[i];
+    const auto& lats = lateralities[i];
     analyze(muonpath, lats, metaPrimitives);
   }
 }
@@ -448,7 +448,7 @@ void MuonPathSLFitter::fillLuts() {
     ifinsl1 >> line;
 
     std::vector<int> myNumbers;
-    for (size_t i = 0; i < line.size(); i++) {
+    myNumbers.reserve(line.size()); for (size_t i = 0; i < line.size(); i++) {
       // This converts the char into an int and pushes it into vec
       myNumbers.push_back(line[i] - '0');  // The digits will be in the same order as before
     }
@@ -461,7 +461,7 @@ void MuonPathSLFitter::fillLuts() {
     ifinsl2 >> line;
 
     std::vector<int> myNumbers;
-    for (size_t i = 0; i < line.size(); i++) {
+    myNumbers.reserve(line.size()); for (size_t i = 0; i < line.size(); i++) {
       // This converts the char into an int and pushes it into vec
       myNumbers.push_back(line[i] - '0');  // The digits will be in the same order as before
     }
@@ -474,7 +474,7 @@ void MuonPathSLFitter::fillLuts() {
     ifinsl3 >> line;
 
     std::vector<int> myNumbers;
-    for (size_t i = 0; i < line.size(); i++) {
+    myNumbers.reserve(line.size()); for (size_t i = 0; i < line.size(); i++) {
       // This converts the char into an int and pushes it into vec
       myNumbers.push_back(line[i] - '0');  // The digits will be in the same order as before
     }

--- a/L1Trigger/DTTriggerPhase2/src/MuonPathSLFitter.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MuonPathSLFitter.cc
@@ -68,7 +68,7 @@ void MuonPathSLFitter::run(edm::Event &iEvent,
   // fit per SL (need to allow for multiple outputs for a single mpath)
   // for (auto &muonpath : muonpaths) {
   if (!muonpaths.empty()) {
-    const auto& muonpath = muonpaths[0];
+    const auto &muonpath = muonpaths[0];
     int rawId = muonpath->primitive(0)->cameraId();
     if (muonpath->primitive(0)->cameraId() == -1) {
       rawId = muonpath->primitive(1)->cameraId();
@@ -79,7 +79,7 @@ void MuonPathSLFitter::run(edm::Event &iEvent,
 
   for (size_t i = 0; i < muonpaths.size(); i++) {
     auto muonpath = muonpaths[i];
-    const auto& lats = lateralities[i];
+    const auto &lats = lateralities[i];
     analyze(muonpath, lats, metaPrimitives);
   }
 }
@@ -448,7 +448,8 @@ void MuonPathSLFitter::fillLuts() {
     ifinsl1 >> line;
 
     std::vector<int> myNumbers;
-    myNumbers.reserve(line.size()); for (size_t i = 0; i < line.size(); i++) {
+    myNumbers.reserve(line.size());
+    for (size_t i = 0; i < line.size(); i++) {
       // This converts the char into an int and pushes it into vec
       myNumbers.push_back(line[i] - '0');  // The digits will be in the same order as before
     }
@@ -461,7 +462,8 @@ void MuonPathSLFitter::fillLuts() {
     ifinsl2 >> line;
 
     std::vector<int> myNumbers;
-    myNumbers.reserve(line.size()); for (size_t i = 0; i < line.size(); i++) {
+    myNumbers.reserve(line.size());
+    for (size_t i = 0; i < line.size(); i++) {
       // This converts the char into an int and pushes it into vec
       myNumbers.push_back(line[i] - '0');  // The digits will be in the same order as before
     }
@@ -474,7 +476,8 @@ void MuonPathSLFitter::fillLuts() {
     ifinsl3 >> line;
 
     std::vector<int> myNumbers;
-    myNumbers.reserve(line.size()); for (size_t i = 0; i < line.size(); i++) {
+    myNumbers.reserve(line.size());
+    for (size_t i = 0; i < line.size(); i++) {
       // This converts the char into an int and pushes it into vec
       myNumbers.push_back(line[i] - '0');  // The digits will be in the same order as before
     }

--- a/L1Trigger/L1CaloTrigger/plugins/L1NNCaloTauEmulator.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/L1NNCaloTauEmulator.cc
@@ -789,7 +789,7 @@ void L1NNCaloTauEmulator::produce(edm::Event& iEvent, const edm::EventSetup& eSe
 
   for (int clNxMIdx = 0; clNxMIdx < Nclusters_CE; clNxMIdx++) {
     // Indexing of cl3ds is the same as the one of clNxMs
-    InputHGCluster HGClu = HGClusters[clNxMIdx];
+    const InputHGCluster& HGClu = HGClusters[clNxMIdx];
 
     // Fill inputs for Tensorflow inference
     for (int eta = 0; eta < IEta_dim; ++eta) {

--- a/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.cc
+++ b/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.cc
@@ -27,15 +27,15 @@
 using namespace l1tcalo;
 
 bool L1TCaloLayer1FetchLUTs(
-    const L1TCaloLayer1FetchLUTsTokens &iTokens,
-    const edm::EventSetup &iSetup,
-    std::vector<std::array<std::array<std::array<uint32_t, nEtBins>, nCalSideBins>, nCalEtaBins> > &eLUT,
-    std::vector<std::array<std::array<std::array<uint32_t, nEtBins>, nCalSideBins>, nCalEtaBins> > &hLUT,
-    std::vector<std::array<std::array<uint32_t, nEtBins>, nHfEtaBins> > &hfLUT,
-    std::vector<unsigned long long int> &hcalFBLUT,
-    std::vector<unsigned int> &ePhiMap,
-    std::vector<unsigned int> &hPhiMap,
-    std::vector<unsigned int> &hfPhiMap,
+    const L1TCaloLayer1FetchLUTsTokens& iTokens,
+    const edm::EventSetup& iSetup,
+    std::vector<std::array<std::array<std::array<uint32_t, nEtBins>, nCalSideBins>, nCalEtaBins> >& eLUT,
+    std::vector<std::array<std::array<std::array<uint32_t, nEtBins>, nCalSideBins>, nCalEtaBins> >& hLUT,
+    std::vector<std::array<std::array<uint32_t, nEtBins>, nHfEtaBins> >& hfLUT,
+    std::vector<unsigned long long int>& hcalFBLUT,
+    std::vector<unsigned int>& ePhiMap,
+    std::vector<unsigned int>& hPhiMap,
+    std::vector<unsigned int>& hfPhiMap,
     bool useLSB,
     bool useCalib,
     bool useECALLUT,
@@ -44,7 +44,7 @@ bool L1TCaloLayer1FetchLUTs(
     bool useHCALFBLUT,
     int fwVersion) {
   int hfValid = 1;
-  const HcalTrigTowerGeometry &pG = iSetup.getData(iTokens.geom_);
+  const HcalTrigTowerGeometry& pG = iSetup.getData(iTokens.geom_);
   if (!pG.use1x1()) {
     edm::LogError("L1TCaloLayer1FetchLUTs")
         << "Using Stage2-Layer1 but HCAL Geometry has use1x1 = 0! HF will be suppressed.  Check Global Tag, etc.";

--- a/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.cc
+++ b/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.cc
@@ -71,7 +71,7 @@ bool L1TCaloLayer1FetchLUTs(
   //   etBin = size of Real ET Bins vector
   //   phiBin = max(Real Phi Bins vector)
   //   So, index = phiBin*etBin*28+etBin*28+ieta
-  auto ecalScaleETBins = caloParams.layer1ECalScaleETBins();
+  const auto& ecalScaleETBins = caloParams.layer1ECalScaleETBins();
   auto ecalScalePhiBins = caloParams.layer1ECalScalePhiBins();
   if (ecalScalePhiBins.empty()) {
     // Backwards-compatibility (no phi binning)
@@ -81,14 +81,14 @@ bool L1TCaloLayer1FetchLUTs(
     return false;
   }
   size_t numEcalPhiBins = (*std::max_element(ecalScalePhiBins.begin(), ecalScalePhiBins.end())) + 1;
-  auto ecalSF = caloParams.layer1ECalScaleFactors();
-  auto ecalZSF = caloParams.layer1ECalZSFactors();
+  const auto& ecalSF = caloParams.layer1ECalScaleFactors();
+  const auto& ecalZSF = caloParams.layer1ECalZSFactors();
   if (ecalSF.size() != ecalScaleETBins.size() * numEcalPhiBins * 28) {
     edm::LogError("L1TCaloLayer1FetchLUTs") << "caloParams.layer1ECalScaleFactors().size() != "
                                                "caloParams.layer1ECalScaleETBins().size()*numEcalPhiBins*28 !!";
     return false;
   }
-  auto hcalScaleETBins = caloParams.layer1HCalScaleETBins();
+  const auto& hcalScaleETBins = caloParams.layer1HCalScaleETBins();
   auto hcalScalePhiBins = caloParams.layer1HCalScalePhiBins();
   if (hcalScalePhiBins.empty()) {
     hcalScalePhiBins.resize(36, 0);
@@ -97,8 +97,8 @@ bool L1TCaloLayer1FetchLUTs(
     return false;
   }
   size_t numHcalPhiBins = (*std::max_element(hcalScalePhiBins.begin(), hcalScalePhiBins.end())) + 1;
-  auto hcalSF = caloParams.layer1HCalScaleFactors();
-  auto hcalZSF = caloParams.layer1HCalZSFactors();
+  const auto& hcalSF = caloParams.layer1HCalScaleFactors();
+  const auto& hcalZSF = caloParams.layer1HCalZSFactors();
   if (hcalSF.size() != hcalScaleETBins.size() * numHcalPhiBins * 28) {
     edm::LogError("L1TCaloLayer1FetchLUTs") << "caloParams.layer1HCalScaleFactors().size() != "
                                                "caloParams.layer1HCalScaleETBins().size()*numHcalPhiBins*28 !!";
@@ -110,7 +110,7 @@ bool L1TCaloLayer1FetchLUTs(
   //   etBin = size of Real ET Bins vector
   //   phiBin = max(Real Phi Bins vector)
   //   So, index = phiBin*etBin*12+etBin*12+ieta
-  auto hfScaleETBins = caloParams.layer1HFScaleETBins();
+  const auto& hfScaleETBins = caloParams.layer1HFScaleETBins();
   auto hfScalePhiBins = caloParams.layer1HFScalePhiBins();
   if (hfScalePhiBins.empty()) {
     hfScalePhiBins.resize(36, 0);
@@ -119,7 +119,7 @@ bool L1TCaloLayer1FetchLUTs(
     return false;
   }
   size_t numHFPhiBins = (*std::max_element(hfScalePhiBins.begin(), hfScalePhiBins.end())) + 1;
-  auto hfSF = caloParams.layer1HFScaleFactors();
+  const auto& hfSF = caloParams.layer1HFScaleFactors();
   if (hfSF.size() != hfScaleETBins.size() * numHFPhiBins * 12) {
     edm::LogError("L1TCaloLayer1FetchLUTs")
         << "caloParams.layer1HFScaleFactors().size() != caloParams.layer1HFScaleETBins().size()*numHFPhiBins*12 !!";
@@ -136,8 +136,8 @@ bool L1TCaloLayer1FetchLUTs(
   // HCAL FB LUT will be a 1*28 array:
   //   ieta = 28 eta scale factors (1 .. 28)
   //   So, index = ieta
-  auto fbLUTUpper = caloParams.layer1HCalFBLUTUpper();
-  auto fbLUTLower = caloParams.layer1HCalFBLUTLower();
+  const auto& fbLUTUpper = caloParams.layer1HCalFBLUTUpper();
+  const auto& fbLUTLower = caloParams.layer1HCalFBLUTLower();
   // Only check for HCAL FB LUT if useHCALFBLUT = true
   if (useHCALFBLUT) {
     if (fbLUTUpper.size() != nCalEtaBins) {

--- a/L1Trigger/L1TCalorimeter/src/HardwareSortingMethods.cc
+++ b/L1Trigger/L1TCalorimeter/src/HardwareSortingMethods.cc
@@ -544,8 +544,8 @@ namespace l1t {
         super_sort_matrix_rows(non_iso_stage2_row_sorted_matrix_sig, N_EGAMMA_SECOND_GROUP_SIZE, N_KEEP_EGAMMA);
 
     //Prepare output
-    std::vector<l1t::L1Candidate> sorted_iso_egammas = iso_stage2_super_sorted_matrix_sig[0];
-    std::vector<l1t::L1Candidate> sorted_noniso_egammas = non_iso_stage2_super_sorted_matrix_sig[0];
+    const std::vector<l1t::L1Candidate>& sorted_iso_egammas = iso_stage2_super_sorted_matrix_sig[0];
+    const std::vector<l1t::L1Candidate>& sorted_noniso_egammas = non_iso_stage2_super_sorted_matrix_sig[0];
 
     //verbose = false;
 

--- a/L1Trigger/L1TCalorimeter/src/PUSubtractionMethods.cc
+++ b/L1Trigger/L1TCalorimeter/src/PUSubtractionMethods.cc
@@ -69,7 +69,7 @@ namespace l1t {
   void RegionCorrection(const std::vector<l1t::CaloRegion> &regions,
                         std::vector<l1t::CaloRegion> *subRegions,
                         CaloParamsHelper const *params) {
-    std::string regionPUSType = params->regionPUSType();
+    const std::string& regionPUSType = params->regionPUSType();
 
     if (regionPUSType == "None") {
       for (std::vector<CaloRegion>::const_iterator notCorrectedRegion = regions.begin();

--- a/L1Trigger/L1TCalorimeter/src/PUSubtractionMethods.cc
+++ b/L1Trigger/L1TCalorimeter/src/PUSubtractionMethods.cc
@@ -69,7 +69,7 @@ namespace l1t {
   void RegionCorrection(const std::vector<l1t::CaloRegion> &regions,
                         std::vector<l1t::CaloRegion> *subRegions,
                         CaloParamsHelper const *params) {
-    const std::string& regionPUSType = params->regionPUSType();
+    const std::string &regionPUSType = params->regionPUSType();
 
     if (regionPUSType == "None") {
       for (std::vector<CaloRegion>::const_iterator notCorrectedRegion = regions.begin();

--- a/L1Trigger/L1TGEM/src/ME0StubAlgoPatUnit.cc
+++ b/L1Trigger/L1TGEM/src/ME0StubAlgoPatUnit.cc
@@ -17,7 +17,7 @@ std::pair<std::vector<double>, double> l1t::me0::calculateCentroids(
   std::vector<int> bxs;
   for (int ly = 0; ly < static_cast<int>(maskedData.size()); ++ly) {
     auto data = maskedData[ly];
-    auto bxData = partitionBxData[ly];
+    const auto& bxData = partitionBxData[ly];
     const auto temp = findCentroid(data);
     double curCentroid = temp.first;
     std::vector<int> hitsIndices = temp.second;

--- a/L1Trigger/L1TGlobal/interface/CICADATemplate.h
+++ b/L1Trigger/L1TGlobal/interface/CICADATemplate.h
@@ -12,7 +12,7 @@ public:
   CICADATemplate(const std::string&);
   CICADATemplate(const std::string&, const l1t::GtConditionType&);
   CICADATemplate(const CICADATemplate&);
-  ~CICADATemplate() = default;
+  ~CICADATemplate() override = default;
 
   CICADATemplate& operator=(const CICADATemplate&);
 

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosESProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosESProducer.cc
@@ -237,7 +237,7 @@ L1TGlobalPrescalesVetosESProducer::L1TGlobalPrescalesVetosESProducer(const edm::
 
   // veto mask
   // Setting veto mask to default 0 (no veto)
-  for (unsigned int iAlg = 0; iAlg < m_numberPhysTriggers; iAlg++)
+  triggerVetoMasks.reserve(m_numberPhysTriggers); for (unsigned int iAlg = 0; iAlg < m_numberPhysTriggers; iAlg++)
     triggerVetoMasks.push_back(0);
 
   std::ifstream input_mask_veto;

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosESProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosESProducer.cc
@@ -237,7 +237,8 @@ L1TGlobalPrescalesVetosESProducer::L1TGlobalPrescalesVetosESProducer(const edm::
 
   // veto mask
   // Setting veto mask to default 0 (no veto)
-  triggerVetoMasks.reserve(m_numberPhysTriggers); for (unsigned int iAlg = 0; iAlg < m_numberPhysTriggers; iAlg++)
+  triggerVetoMasks.reserve(m_numberPhysTriggers);
+  for (unsigned int iAlg = 0; iAlg < m_numberPhysTriggers; iAlg++)
     triggerVetoMasks.push_back(0);
 
   std::ifstream input_mask_veto;

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosFractESProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosFractESProducer.cc
@@ -237,7 +237,8 @@ L1TGlobalPrescalesVetosFractESProducer::L1TGlobalPrescalesVetosFractESProducer(c
 
   // veto mask
   // Setting veto mask to default 0 (no veto)
-  triggerVetoMasks.reserve(m_numberPhysTriggers); for (unsigned int iAlg = 0; iAlg < m_numberPhysTriggers; iAlg++)
+  triggerVetoMasks.reserve(m_numberPhysTriggers);
+  for (unsigned int iAlg = 0; iAlg < m_numberPhysTriggers; iAlg++)
     triggerVetoMasks.push_back(0);
 
   std::ifstream input_mask_veto;

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosFractESProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosFractESProducer.cc
@@ -237,7 +237,7 @@ L1TGlobalPrescalesVetosFractESProducer::L1TGlobalPrescalesVetosFractESProducer(c
 
   // veto mask
   // Setting veto mask to default 0 (no veto)
-  for (unsigned int iAlg = 0; iAlg < m_numberPhysTriggers; iAlg++)
+  triggerVetoMasks.reserve(m_numberPhysTriggers); for (unsigned int iAlg = 0; iAlg < m_numberPhysTriggers; iAlg++)
     triggerVetoMasks.push_back(0);
 
   std::ifstream input_mask_veto;

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
@@ -30,7 +30,8 @@ public:
 
     /* create a persistent vector of pointers to the towerMaps */
     std::vector<edm::Ptr<l1t::HGCalTowerMap>> towerMapsPtrs;
-    towerMapsPtrs.reserve(towerMapCollHandle->size()); for (unsigned i = 0; i < towerMapCollHandle->size(); ++i) {
+    towerMapsPtrs.reserve(towerMapCollHandle->size());
+    for (unsigned i = 0; i < towerMapCollHandle->size(); ++i) {
       towerMapsPtrs.emplace_back(towerMapCollHandle, i);
     }
 

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
@@ -30,7 +30,7 @@ public:
 
     /* create a persistent vector of pointers to the towerMaps */
     std::vector<edm::Ptr<l1t::HGCalTowerMap>> towerMapsPtrs;
-    for (unsigned i = 0; i < towerMapCollHandle->size(); ++i) {
+    towerMapsPtrs.reserve(towerMapCollHandle->size()); for (unsigned i = 0; i < towerMapCollHandle->size(); ++i) {
       towerMapsPtrs.emplace_back(towerMapCollHandle, i);
     }
 

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor_SA.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor_SA.cc
@@ -26,7 +26,7 @@ public:
 
     /* create a persistent vector of pointers to the towerMaps */
     std::vector<edm::Ptr<l1t::HGCalTowerMap>> towerMapsPtrs;
-    for (unsigned i = 0; i < towerMapCollHandle->size(); ++i) {
+    towerMapsPtrs.reserve(towerMapCollHandle->size()); for (unsigned i = 0; i < towerMapCollHandle->size(); ++i) {
       towerMapsPtrs.emplace_back(towerMapCollHandle, i);
     }
 

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor_SA.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor_SA.cc
@@ -26,7 +26,8 @@ public:
 
     /* create a persistent vector of pointers to the towerMaps */
     std::vector<edm::Ptr<l1t::HGCalTowerMap>> towerMapsPtrs;
-    towerMapsPtrs.reserve(towerMapCollHandle->size()); for (unsigned i = 0; i < towerMapCollHandle->size(); ++i) {
+    towerMapsPtrs.reserve(towerMapCollHandle->size());
+    for (unsigned i = 0; i < towerMapCollHandle->size(); ++i) {
       towerMapsPtrs.emplace_back(towerMapCollHandle, i);
     }
 

--- a/L1Trigger/L1TMuonOverlap/src/OMTFSorter.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFSorter.cc
@@ -12,12 +12,12 @@
 ///////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////
 AlgoMuon OMTFSorter::sortSingleResult(const OMTFResult& aResult) {
-  OMTFResult::vector1D pdfValsVec = aResult.getSummaryVals();
+  const OMTFResult::vector1D& pdfValsVec = aResult.getSummaryVals();
   OMTFResult::vector1D nHitsVec = aResult.getSummaryHits();
-  OMTFResult::vector1D refPhiVec = aResult.getRefPhis();
-  OMTFResult::vector1D refEtaVec = aResult.getRefEtas();
-  OMTFResult::vector1D hitsVec = aResult.getHitsWord();
-  OMTFResult::vector1D refPhiRHitVec = aResult.getRefPhiRHits();
+  const OMTFResult::vector1D& refPhiVec = aResult.getRefPhis();
+  const OMTFResult::vector1D& refEtaVec = aResult.getRefEtas();
+  const OMTFResult::vector1D& hitsVec = aResult.getHitsWord();
+  const OMTFResult::vector1D& refPhiRHitVec = aResult.getRefPhiRHits();
 
   assert(pdfValsVec.size() == nHitsVec.size());
 

--- a/L1Trigger/L1TMuonOverlap/src/XMLConfigWriter.cc
+++ b/L1Trigger/L1TMuonOverlap/src/XMLConfigWriter.cc
@@ -311,7 +311,7 @@ void XMLConfigWriter::writeResultsData(xercesc::DOMElement* aTopElement,
                                        unsigned int iRegion,
                                        const Key& aKey,
                                        const OMTFResult& aResult) {
-  OMTFResult::vector2D results = aResult.getResults();
+  const OMTFResult::vector2D& results = aResult.getResults();
 
   std::ostringstream stringStr;
   ///Write GP key parameters

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
@@ -190,8 +190,8 @@ void L1TrackJetEmulatorProducer::produce(Event &iEvent, const EventSetup &iSetup
   // logic: loop over z bins find tracks in this bin and arrange them in a 2D eta-phi matrix
   for (unsigned int zbin = 0; zbin < zmins.size(); ++zbin) {
     // initialize matrices for every z bin
-    const z0_intern& zmin = zmins[zbin];
-    const z0_intern& zmax = zmaxs[zbin];
+    const z0_intern &zmin = zmins[zbin];
+    const z0_intern &zmax = zmaxs[zbin];
 
     TrackJetEmulationEtaPhiBin epbins[phiBins_][etaBins_];
 

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
@@ -190,8 +190,8 @@ void L1TrackJetEmulatorProducer::produce(Event &iEvent, const EventSetup &iSetup
   // logic: loop over z bins find tracks in this bin and arrange them in a 2D eta-phi matrix
   for (unsigned int zbin = 0; zbin < zmins.size(); ++zbin) {
     // initialize matrices for every z bin
-    z0_intern zmin = zmins[zbin];
-    z0_intern zmax = zmaxs[zbin];
+    const z0_intern& zmin = zmins[zbin];
+    const z0_intern& zmax = zmaxs[zbin];
 
     TrackJetEmulationEtaPhiBin epbins[phiBins_][etaBins_];
 

--- a/L1Trigger/L1TTrackMatch/src/pTFrom2Stubs.cc
+++ b/L1Trigger/L1TTrackMatch/src/pTFrom2Stubs.cc
@@ -23,7 +23,7 @@ namespace pTFrom2Stubs {
     //loop over L1Track's stubs
     int rsize = vecStubRefs.size();
     for (int j = 0; j < rsize; ++j) {
-      edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > stubRef =
+      const edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> >& stubRef =
           vecStubRefs.at(j);
       const TTStub<Ref_Phase2TrackerDigi_>* stub = &(*stubRef);
       MeasurementPoint localPos = stub->clusterRef(0)->findAverageLocalCoordinates();

--- a/L1Trigger/Phase2L1GMT/interface/Isolation.h
+++ b/L1Trigger/Phase2L1GMT/interface/Isolation.h
@@ -85,7 +85,7 @@ namespace Phase2L1GMT {
     static std::atomic<int> nevto = 0;
     auto evto = nevto++;
     for (unsigned int i = 0; i < trkMus.size(); ++i) {
-      const auto& mu = trkMus.at(i);
+      const auto &mu = trkMus.at(i);
       if (mu.hwPt() != 0) {
         double convertphi = mu.hwPhi() * LSBphi;
         if (convertphi > M_PI) {

--- a/L1Trigger/Phase2L1GMT/interface/Isolation.h
+++ b/L1Trigger/Phase2L1GMT/interface/Isolation.h
@@ -85,7 +85,7 @@ namespace Phase2L1GMT {
     static std::atomic<int> nevto = 0;
     auto evto = nevto++;
     for (unsigned int i = 0; i < trkMus.size(); ++i) {
-      auto mu = trkMus.at(i);
+      const auto& mu = trkMus.at(i);
       if (mu.hwPt() != 0) {
         double convertphi = mu.hwPhi() * LSBphi;
         if (convertphi > M_PI) {

--- a/L1Trigger/Phase2L1ParticleFlow/interface/taus/L1HPSPFTauEmulator.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/taus/L1HPSPFTauEmulator.h
@@ -232,7 +232,7 @@ namespace l1HPSPFTauEmu {
     }
 
     for (std::vector<int>::size_type i = 0; i != signalParts.size(); i++) {
-      Particle sigP = signalParts.at(i);
+      const Particle& sigP = signalParts.at(i);
       if (is_charged(sigP) || (sigP.pID == 3)) {
         sum_pt += sigP.hwPt;
         sum_eta += sigP.hwPt * sigP.hwEta;
@@ -302,7 +302,7 @@ namespace l1HPSPFTauEmu {
     int parts_max = parts_copy.size();
     //first find the seeds
     while (preseed.size() < 128 && parts_index != parts_max) {
-      Particle pSeed = parts_copy.at(parts_index);
+      const Particle& pSeed = parts_copy.at(parts_index);
 
       if (pSeed.hwPt > l1ct::Scales::makePtFromFloat(5.) && is_charged(pSeed) && int_abs(pSeed.hwEta) < etaCutoff) {
         preseed.push_back(pSeed);
@@ -322,7 +322,7 @@ namespace l1HPSPFTauEmu {
     //With jets
     if (jEnable) {
       while (jseeds.size() < 4 && jets_index != jets_max) {
-        Particle jSeed = jets_copy.at(jets_index);
+        const Particle& jSeed = jets_copy.at(jets_index);
 
         if (jSeed.hwPt > l1ct::Scales::makePtFromFloat(20.) && int_abs(jSeed.hwEta) < etaCutoff) {
           jseeds.push_back(jSeed);
@@ -331,7 +331,7 @@ namespace l1HPSPFTauEmu {
       }
     }
     for (std::vector<int>::size_type i = 0; i != seeds.size(); i++) {
-      Particle seed = seeds[i];
+      const Particle& seed = seeds[i];
 
       std::vector<Particle> iso_parts;
 
@@ -339,7 +339,7 @@ namespace l1HPSPFTauEmu {
       pt_t total_pt = 0;
       std::vector<int>::size_type iso_index = 0;
       while (iso_index < parts_copy.size() && iso_parts.size() < 30) {
-        Particle isoCand = parts_copy.at(iso_index);
+        const Particle& isoCand = parts_copy.at(iso_index);
         if (inIsolationCone(isoCand, seed)) {
           iso_parts.push_back(isoCand);
           total_pt += isoCand.hwPt;
@@ -361,7 +361,7 @@ namespace l1HPSPFTauEmu {
 
         pt_t max_pt_j = 0;
         while (iso_index < parts_copy.size()) {
-          Particle isoCand = parts_copy.at(iso_index);
+          const Particle& isoCand = parts_copy.at(iso_index);
 
           if (inIsolationCone(isoCand, jseed)) {
             if (is_charged(isoCand) && isoCand.hwPt > max_pt_j) {

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1HPSPFTauProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1HPSPFTauProducer.cc
@@ -76,13 +76,13 @@ void L1HPSPFTauProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::E
 
   //adding collection
   std::vector<edm::Ptr<l1t::PFCandidate>> particles;
-  for (unsigned i = 0; i < (*l1PFCandidates).size(); i++) {
+  particles.reserve((*l1PFCandidates).size()); for (unsigned i = 0; i < (*l1PFCandidates).size(); i++) {
     particles.push_back(edm::Ptr<l1t::PFCandidate>(l1PFCandidates, i));
   }
 
   //get the jets
   std::vector<edm::Ptr<reco::CaloJet>> jets;
-  for (unsigned int i = 0; i < (*l1PFJets).size(); i++) {
+  jets.reserve((*l1PFJets).size()); for (unsigned int i = 0; i < (*l1PFJets).size(); i++) {
     jets.push_back(edm::Ptr<reco::CaloJet>(l1PFJets, i));
     //
   }

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1HPSPFTauProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1HPSPFTauProducer.cc
@@ -76,13 +76,15 @@ void L1HPSPFTauProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::E
 
   //adding collection
   std::vector<edm::Ptr<l1t::PFCandidate>> particles;
-  particles.reserve((*l1PFCandidates).size()); for (unsigned i = 0; i < (*l1PFCandidates).size(); i++) {
+  particles.reserve((*l1PFCandidates).size());
+  for (unsigned i = 0; i < (*l1PFCandidates).size(); i++) {
     particles.push_back(edm::Ptr<l1t::PFCandidate>(l1PFCandidates, i));
   }
 
   //get the jets
   std::vector<edm::Ptr<reco::CaloJet>> jets;
-  jets.reserve((*l1PFJets).size()); for (unsigned int i = 0; i < (*l1PFJets).size(); i++) {
+  jets.reserve((*l1PFJets).size());
+  for (unsigned int i = 0; i < (*l1PFJets).size(); i++) {
     jets.push_back(edm::Ptr<reco::CaloJet>(l1PFJets, i));
     //
   }

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1SeedConePFJetProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1SeedConePFJetProducer.cc
@@ -80,7 +80,7 @@ void L1SeedConePFJetProducer::produce(edm::StreamID /*unused*/,
   edm::Handle<l1t::PFCandidateCollection> l1PFCandidates;
   iEvent.getByToken(l1PFToken, l1PFCandidates);
   std::vector<edm::Ptr<l1t::PFCandidate>> particles;
-  for (unsigned i = 0; i < (*l1PFCandidates).size(); i++) {
+  particles.reserve((*l1PFCandidates).size()); for (unsigned i = 0; i < (*l1PFCandidates).size(); i++) {
     particles.push_back(edm::Ptr<l1t::PFCandidate>(l1PFCandidates, i));
   }
 

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1SeedConePFJetProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1SeedConePFJetProducer.cc
@@ -80,7 +80,8 @@ void L1SeedConePFJetProducer::produce(edm::StreamID /*unused*/,
   edm::Handle<l1t::PFCandidateCollection> l1PFCandidates;
   iEvent.getByToken(l1PFToken, l1PFCandidates);
   std::vector<edm::Ptr<l1t::PFCandidate>> particles;
-  particles.reserve((*l1PFCandidates).size()); for (unsigned i = 0; i < (*l1PFCandidates).size(); i++) {
+  particles.reserve((*l1PFCandidates).size());
+  for (unsigned i = 0; i < (*l1PFCandidates).size(); i++) {
     particles.push_back(edm::Ptr<l1t::PFCandidate>(l1PFCandidates, i));
   }
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/pf/pfalgo2hgc_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/pf/pfalgo2hgc_ref.cpp
@@ -205,7 +205,7 @@ void l1ct::PFAlgo2HGCEmulator::run(const PFInputRegion& in, OutputRegion& out) c
   for (unsigned int ic = 0; ic < nCALO; ++ic) {
     if (calo_sumtk[ic] > 0) {
       pt_t ptdiff = in.hadcalo[ic].hwPt - calo_sumtk[ic];
-      pt2_t sigmamult =
+      const pt2_t& sigmamult =
           calo_sumtkErr2[ic];  //  + (calo_sumtkErr2[ic] >> 1)); // this multiplies by 1.5 = sqrt(1.5)^2 ~ (1.2)^2
       if (debug_ && (in.hadcalo[ic].hwPt > 0)) {
         dbgPrintf(

--- a/L1Trigger/Phase2L1ParticleFlow/src/pf/pfalgo3_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/pf/pfalgo3_ref.cpp
@@ -461,7 +461,7 @@ void l1ct::PFAlgo3Emulator::run(const PFInputRegion& in, OutputRegion& out) cons
   for (unsigned int ic = 0; ic < nCALO; ++ic) {
     if (calo_sumtk[ic] > 0) {
       dpt_t ptdiff = dpt_t(hadcalo_subem[ic].hwPt) - dpt_t(calo_sumtk[ic]);
-      pt2_t sigmamult = calo_sumtkErr2
+      const pt2_t& sigmamult = calo_sumtkErr2
           [ic];  // before we did (calo_sumtkErr2[ic] + (calo_sumtkErr2[ic] >> 1)); to multiply by 1.5 = sqrt(1.5)^2 ~ (1.2)^2
       if (debug_ && (hadcalo_subem[ic].hwPt > 0)) {
         dbgPrintf(

--- a/L1Trigger/TrackFindingTMTT/src/HTrphi.cc
+++ b/L1Trigger/TrackFindingTMTT/src/HTrphi.cc
@@ -166,7 +166,7 @@ namespace tmtt {
     cellCenters_.clear();
     for (unsigned int m = 0; m < nBinsQoverPtAxis_; m++) {
       std::vector<std::pair<float, float> > binCenters;
-      for (unsigned int c = 0; c < nBinsPhiTrkAxis_; c++)
+      binCenters.reserve(nBinsPhiTrkAxis_); for (unsigned int c = 0; c < nBinsPhiTrkAxis_; c++)
         binCenters.push_back(this->helix2Dhough(m, c));
       cellCenters_.push_back(binCenters);
     }

--- a/L1Trigger/TrackFindingTMTT/src/HTrphi.cc
+++ b/L1Trigger/TrackFindingTMTT/src/HTrphi.cc
@@ -166,7 +166,8 @@ namespace tmtt {
     cellCenters_.clear();
     for (unsigned int m = 0; m < nBinsQoverPtAxis_; m++) {
       std::vector<std::pair<float, float> > binCenters;
-      binCenters.reserve(nBinsPhiTrkAxis_); for (unsigned int c = 0; c < nBinsPhiTrkAxis_; c++)
+      binCenters.reserve(nBinsPhiTrkAxis_);
+      for (unsigned int c = 0; c < nBinsPhiTrkAxis_; c++)
         binCenters.push_back(this->helix2Dhough(m, c));
       cellCenters_.push_back(binCenters);
     }

--- a/L1Trigger/TrackFindingTMTT/src/KFParamsComb.cc
+++ b/L1Trigger/TrackFindingTMTT/src/KFParamsComb.cc
@@ -185,7 +185,7 @@ namespace tmtt {
   /* Get physical helix params */
 
   TVectorD KFParamsComb::trackParams(const KalmanState* state) const {
-    TVectorD vecX = state->vectorX();
+    const TVectorD& vecX = state->vectorX();
     TVectorD vecY(nHelixPar_);
     vecY[QOVERPT] = 2. * vecX[INV2R] / settings_->invPtToInvR();
     vecY[PHI0] = reco::deltaPhi(vecX[PHI0] + sectorPhi(), 0.);

--- a/L1Trigger/TrackFindingTMTT/src/KFbase.cc
+++ b/L1Trigger/TrackFindingTMTT/src/KFbase.cc
@@ -407,8 +407,8 @@ namespace tmtt {
     numUpdateCalls_++;  // For monitoring, count calls to updator per track.
 
     // Helix params & their covariance.
-    const TVectorD& vecX = state->vectorX();
-    const TMatrixD& matC = state->matrixC();
+    const TVectorD &vecX = state->vectorX();
+    const TMatrixD &matC = state->matrixC();
     if (state->barrel() && !stub->barrel()) {
       if (settings_->kalmanDebugLevel() >= 4) {
         PrintL1trk() << "STATE BARREL TO ENDCAP BEFORE ";

--- a/L1Trigger/TrackFindingTMTT/src/KFbase.cc
+++ b/L1Trigger/TrackFindingTMTT/src/KFbase.cc
@@ -407,8 +407,8 @@ namespace tmtt {
     numUpdateCalls_++;  // For monitoring, count calls to updator per track.
 
     // Helix params & their covariance.
-    TVectorD vecX = state->vectorX();
-    TMatrixD matC = state->matrixC();
+    const TVectorD& vecX = state->vectorX();
+    const TMatrixD& matC = state->matrixC();
     if (state->barrel() && !stub->barrel()) {
       if (settings_->kalmanDebugLevel() >= 4) {
         PrintL1trk() << "STATE BARREL TO ENDCAP BEFORE ";

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -340,10 +340,12 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
                 std::vector<const Stub*> stubsTrk2 = inputstublists_[rejetrk];
                 std::vector<unsigned int> stubsTrk1indices;
                 std::vector<unsigned int> stubsTrk2indices;
-                stubsTrk1indices.reserve(stubsTrk1.size()); for (unsigned int stub1it = 0; stub1it < stubsTrk1.size(); stub1it++) {
+                stubsTrk1indices.reserve(stubsTrk1.size());
+                for (unsigned int stub1it = 0; stub1it < stubsTrk1.size(); stub1it++) {
                   stubsTrk1indices.push_back(stubsTrk1[stub1it]->l1tstub()->uniqueIndex());
                 }
-                stubsTrk2indices.reserve(stubsTrk2.size()); for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
+                stubsTrk2indices.reserve(stubsTrk2.size());
+                for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
                   stubsTrk2indices.push_back(stubsTrk2[stub2it]->l1tstub()->uniqueIndex());
                 }
                 newStubList = stubsTrk1;

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -340,10 +340,10 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
                 std::vector<const Stub*> stubsTrk2 = inputstublists_[rejetrk];
                 std::vector<unsigned int> stubsTrk1indices;
                 std::vector<unsigned int> stubsTrk2indices;
-                for (unsigned int stub1it = 0; stub1it < stubsTrk1.size(); stub1it++) {
+                stubsTrk1indices.reserve(stubsTrk1.size()); for (unsigned int stub1it = 0; stub1it < stubsTrk1.size(); stub1it++) {
                   stubsTrk1indices.push_back(stubsTrk1[stub1it]->l1tstub()->uniqueIndex());
                 }
-                for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
+                stubsTrk2indices.reserve(stubsTrk2.size()); for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
                   stubsTrk2indices.push_back(stubsTrk2[stub2it]->l1tstub()->uniqueIndex());
                 }
                 newStubList = stubsTrk1;

--- a/L1Trigger/TrackTrigger/src/TTStubAlgorithm_official.cc
+++ b/L1Trigger/TrackTrigger/src/TTStubAlgorithm_official.cc
@@ -169,7 +169,7 @@ float TTStubAlgorithm_official<Ref_Phase2TrackerDigi_>::degradeBend(bool psModul
     // Then you alternate large-small-large-small....large. In the middle, you
     // put either large or small, depending if group size is odd or not
 
-    for (unsigned int i = 0; i < numLargeGroups / 2; i++)
+    groups.reserve(numLargeGroups / 2); for (unsigned int i = 0; i < numLargeGroups / 2; i++)
       groups.push_back(inLargeGroup);
     for (unsigned int i = 0; i < numSmallGroups / 2; i++)
       groups.push_back(inSmallGroup);

--- a/L1Trigger/TrackTrigger/src/TTStubAlgorithm_official.cc
+++ b/L1Trigger/TrackTrigger/src/TTStubAlgorithm_official.cc
@@ -169,7 +169,8 @@ float TTStubAlgorithm_official<Ref_Phase2TrackerDigi_>::degradeBend(bool psModul
     // Then you alternate large-small-large-small....large. In the middle, you
     // put either large or small, depending if group size is odd or not
 
-    groups.reserve(numLargeGroups / 2); for (unsigned int i = 0; i < numLargeGroups / 2; i++)
+    groups.reserve(numLargeGroups / 2);
+    for (unsigned int i = 0; i < numLargeGroups / 2; i++)
       groups.push_back(inLargeGroup);
     for (unsigned int i = 0; i < numSmallGroups / 2; i++)
       groups.push_back(inSmallGroup);

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -285,7 +285,7 @@ namespace l1tVertexFinder {
         }
 
         if (removing) {
-          const L1Track badTrack = *badTrackIt;
+          const L1Track& badTrack = *badTrackIt;
           if (settings_->debug() > 2)
             edm::LogInfo("VertexFinder") << "PVR::Removing track " << badTrack.z0() << " at distance " << oldDistance;
           discardedTracks.push_back(badTrack);
@@ -321,13 +321,13 @@ namespace l1tVertexFinder {
       start = false;
       discardedTracks2.clear();
       FitTrackCollection::iterator it = discardedTracks.begin();
-      const L1Track track = *it;
+      const L1Track& track = *it;
       acceptedTracks.push_back(track);
       float z0sum = track.z0();
 
       for (FitTrackCollection::iterator it2 = discardedTracks.begin(); it2 < discardedTracks.end(); ++it2) {
         if (it2 != it) {
-          const L1Track secondTrack = *it2;
+          const L1Track& secondTrack = *it2;
           // Calculate new vertex z0 adding this track
           z0sum += secondTrack.z0();
           float z0vertex = z0sum / (acceptedTracks.size() + 1);
@@ -533,9 +533,9 @@ namespace l1tVertexFinder {
     out.push_back(std::string(intervalswidth + valueswidth + 2, ' ') + scale);
     out.push_back(capstone);
     for (int i = 0; i < tableSize; i++) {
-      std::string interval = intervals[i];
-      std::string value = values[i];
-      data_type x = data[i];
+      const std::string& interval = intervals[i];
+      const std::string& value = values[i];
+      const data_type& x = data[i];
       std::fill_n(line.begin(), plotwidth, ' ');
 
       int pos = std::round((float(x) - minimum) * norm);

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosOnlineProd.cc
@@ -224,7 +224,7 @@ std::unique_ptr<const L1TGlobalPrescalesVetosFract> L1TGlobalPrescalesVetosOnlin
             settings_prescale.at("prescales").getTableColumn<double>(col.first.c_str());
         for (unsigned int row = 0; row < prescalesForSet.size(); row++) {
           double prescale = prescalesForSet[row];
-          const std::string& algoName = algoNames[row];
+          const std::string &algoName = algoNames[row];
           unsigned int algoBit = algoName2bit[algoName];
           prescales[iSet][algoBit] = prescale;
         }
@@ -276,7 +276,7 @@ std::unique_ptr<const L1TGlobalPrescalesVetosFract> L1TGlobalPrescalesVetosOnlin
       triggerMasks.push_back(default_finor_mask);
 
     for (unsigned int row = 0; row < algo_mask_finor.size(); row++) {
-      const std::string& algoName = algo_mask_finor[row];
+      const std::string &algoName = algo_mask_finor[row];
       if (strcasecmp("all", algoName.c_str()) == 0)
         continue;
       unsigned int algoBit = algoName2bit[algoName];
@@ -328,7 +328,7 @@ std::unique_ptr<const L1TGlobalPrescalesVetosFract> L1TGlobalPrescalesVetosOnlin
       triggerVetoMasks.push_back(default_veto_mask);
 
     for (unsigned int row = 0; row < algo_mask_veto.size(); row++) {
-      const std::string& algoName = algo_mask_veto[row];
+      const std::string &algoName = algo_mask_veto[row];
       if (strcasecmp("all", algoName.c_str()) == 0)
         continue;
       unsigned int algoBit = algoName2bit[algoName];

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosOnlineProd.cc
@@ -224,7 +224,7 @@ std::unique_ptr<const L1TGlobalPrescalesVetosFract> L1TGlobalPrescalesVetosOnlin
             settings_prescale.at("prescales").getTableColumn<double>(col.first.c_str());
         for (unsigned int row = 0; row < prescalesForSet.size(); row++) {
           double prescale = prescalesForSet[row];
-          std::string algoName = algoNames[row];
+          const std::string& algoName = algoNames[row];
           unsigned int algoBit = algoName2bit[algoName];
           prescales[iSet][algoBit] = prescale;
         }
@@ -276,7 +276,7 @@ std::unique_ptr<const L1TGlobalPrescalesVetosFract> L1TGlobalPrescalesVetosOnlin
       triggerMasks.push_back(default_finor_mask);
 
     for (unsigned int row = 0; row < algo_mask_finor.size(); row++) {
-      std::string algoName = algo_mask_finor[row];
+      const std::string& algoName = algo_mask_finor[row];
       if (strcasecmp("all", algoName.c_str()) == 0)
         continue;
       unsigned int algoBit = algoName2bit[algoName];
@@ -328,7 +328,7 @@ std::unique_ptr<const L1TGlobalPrescalesVetosFract> L1TGlobalPrescalesVetosOnlin
       triggerVetoMasks.push_back(default_veto_mask);
 
     for (unsigned int row = 0; row < algo_mask_veto.size(); row++) {
-      std::string algoName = algo_mask_veto[row];
+      const std::string& algoName = algo_mask_veto[row];
       if (strcasecmp("all", algoName.c_str()) == 0)
         continue;
       unsigned int algoBit = algoName2bit[algoName];

--- a/L1TriggerScouting/Utilities/plugins/SimpleOrbitFlatTableProducer.cc
+++ b/L1TriggerScouting/Utilities/plugins/SimpleOrbitFlatTableProducer.cc
@@ -112,7 +112,7 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
     edm::ParameterSetDescription desc;
-    std::string classname = ClassName<T>::name();
+    const std::string& classname = ClassName<T>::name();
     desc.add<std::string>("name")->setComment("name of the branch in the flat table output for " + classname);
     desc.add<std::string>("doc", "")->setComment("few words of self documentation");
     desc.ifValue(

--- a/L1TriggerScouting/Utilities/plugins/SimpleOrbitFlatTableProducer.cc
+++ b/L1TriggerScouting/Utilities/plugins/SimpleOrbitFlatTableProducer.cc
@@ -112,7 +112,7 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
     edm::ParameterSetDescription desc;
-    const std::string& classname = ClassName<T>::name();
+    const std::string &classname = ClassName<T>::name();
     desc.add<std::string>("name")->setComment("name of the branch in the flat table output for " + classname);
     desc.add<std::string>("doc", "")->setComment("few words of self documentation");
     desc.ifValue(

--- a/MagneticField/GeomBuilder/src/bLayer.cc
+++ b/MagneticField/GeomBuilder/src/bLayer.cc
@@ -141,7 +141,8 @@ MagBLayer* bLayer::buildMagBLayer() const {
 
     // If we have several sectors, create the MagBSector
     std::vector<MagBSector*> mSectors;
-    mSectors.reserve(sectors.size()); for (unsigned int i = 0; i < sectors.size(); ++i) {
+    mSectors.reserve(sectors.size());
+    for (unsigned int i = 0; i < sectors.size(); ++i) {
       mSectors.push_back(sectors[i].buildMagBSector());
     }
     mlayer = new MagBLayer(mSectors, minR());

--- a/MagneticField/GeomBuilder/src/bLayer.cc
+++ b/MagneticField/GeomBuilder/src/bLayer.cc
@@ -141,7 +141,7 @@ MagBLayer* bLayer::buildMagBLayer() const {
 
     // If we have several sectors, create the MagBSector
     std::vector<MagBSector*> mSectors;
-    for (unsigned int i = 0; i < sectors.size(); ++i) {
+    mSectors.reserve(sectors.size()); for (unsigned int i = 0; i < sectors.size(); ++i) {
       mSectors.push_back(sectors[i].buildMagBSector());
     }
     mlayer = new MagBLayer(mSectors, minR());

--- a/OnlineDB/EcalCondDB/interface/DataReducer.h
+++ b/OnlineDB/EcalCondDB/interface/DataReducer.h
@@ -77,7 +77,7 @@ public:
         for (it = my_new_list->begin(); it != my_new_list->end(); ++it) {
           // check on the state
 
-          std::pair<Tm, DataMap> pair_new_list = *it;
+          const std::pair<Tm, DataMap>& pair_new_list = *it;
 
           Tm t_l = pair_new_list.first;
           DataMap dd = pair_new_list.second;
@@ -104,7 +104,7 @@ public:
 
         if (last_state != d.second.getStatus()) {
           if (!new_time_change) {
-            std::pair<Tm, DataMap> pair_new_list = *it_good;
+            const std::pair<Tm, DataMap>& pair_new_list = *it_good;
             Tm t_good = pair_new_list.first;
             the_data = pair_new_list.second;
             the_data.insert(d);
@@ -130,7 +130,7 @@ public:
           if (m_printout) {
             std::cout << "************" << std::endl;
             for (it3 = my_new_list->begin(); it3 != my_new_list->end(); ++it3) {
-              std::pair<Tm, DataMap> pair_new_list3 = *it3;
+              const std::pair<Tm, DataMap>& pair_new_list3 = *it3;
               Tm t3 = pair_new_list3.first;
               std::cout << " T =" << t3.str() << std::endl;
             }
@@ -153,7 +153,7 @@ public:
     if (m_printout) {
       list_iterator it3;
       for (it3 = my_new_list->begin(); it3 != my_new_list->end(); ++it3) {
-        std::pair<Tm, DataMap> pair_new_list3 = *it3;
+        const std::pair<Tm, DataMap>& pair_new_list3 = *it3;
         Tm t3 = pair_new_list3.first;
         std::cout << " T =" << t3.str() << std::endl;
       }

--- a/PhysicsTools/BPHNano/plugins/KinVtxFitter.cc
+++ b/PhysicsTools/BPHNano/plugins/KinVtxFitter.cc
@@ -12,7 +12,7 @@ KinVtxFitter::KinVtxFitter(const std::vector<reco::TransientTrack> tracks,
     : n_particles_{masses.size()} {
   KinematicParticleFactoryFromTransientTrack factory;
   std::vector<RefCountedKinematicParticle> particles;
-  for (size_t i = 0; i < tracks.size(); ++i) {
+  particles.reserve(tracks.size()); for (size_t i = 0; i < tracks.size(); ++i) {
     particles.emplace_back(factory.particle(tracks.at(i), masses.at(i), kin_chi2_, kin_ndof_, sigmas[i]));
   }
 
@@ -48,7 +48,7 @@ KinVtxFitter::KinVtxFitter(const std::vector<reco::TransientTrack> tracks,
     : n_particles_{masses.size()} {
   KinematicParticleFactoryFromTransientTrack factory;
   std::vector<RefCountedKinematicParticle> particles;
-  for (size_t i = 0; i < tracks.size(); ++i) {
+  particles.reserve(tracks.size()); for (size_t i = 0; i < tracks.size(); ++i) {
     particles.emplace_back(factory.particle(tracks.at(i), masses.at(i), kin_chi2_, kin_ndof_, sigmas[i]));
   }
 

--- a/PhysicsTools/BPHNano/plugins/KinVtxFitter.cc
+++ b/PhysicsTools/BPHNano/plugins/KinVtxFitter.cc
@@ -12,7 +12,8 @@ KinVtxFitter::KinVtxFitter(const std::vector<reco::TransientTrack> tracks,
     : n_particles_{masses.size()} {
   KinematicParticleFactoryFromTransientTrack factory;
   std::vector<RefCountedKinematicParticle> particles;
-  particles.reserve(tracks.size()); for (size_t i = 0; i < tracks.size(); ++i) {
+  particles.reserve(tracks.size());
+  for (size_t i = 0; i < tracks.size(); ++i) {
     particles.emplace_back(factory.particle(tracks.at(i), masses.at(i), kin_chi2_, kin_ndof_, sigmas[i]));
   }
 
@@ -48,7 +49,8 @@ KinVtxFitter::KinVtxFitter(const std::vector<reco::TransientTrack> tracks,
     : n_particles_{masses.size()} {
   KinematicParticleFactoryFromTransientTrack factory;
   std::vector<RefCountedKinematicParticle> particles;
-  particles.reserve(tracks.size()); for (size_t i = 0; i < tracks.size(); ++i) {
+  particles.reserve(tracks.size());
+  for (size_t i = 0; i < tracks.size(); ++i) {
     particles.emplace_back(factory.particle(tracks.at(i), masses.at(i), kin_chi2_, kin_ndof_, sigmas[i]));
   }
 

--- a/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
@@ -899,7 +899,7 @@ int GenHFHadronMatcher::findInMothers(int idx,
   if (std::abs(hadMothers.at(idx).pdgId()) > 10 && std::abs(hadMothers.at(idx).pdgId()) < 19)
     printf("Lepton: %d\n", hadMothers.at(idx).pdgId());
 
-  std::vector<int> mothers = hadMothersIndices.at(idx);
+  const std::vector<int>& mothers = hadMothersIndices.at(idx);
   unsigned int nMothers = mothers.size();
   bool isCorrect = false;  // Whether current particle is what is being searched
   if (verbose) {

--- a/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
@@ -899,7 +899,7 @@ int GenHFHadronMatcher::findInMothers(int idx,
   if (std::abs(hadMothers.at(idx).pdgId()) > 10 && std::abs(hadMothers.at(idx).pdgId()) < 19)
     printf("Lepton: %d\n", hadMothers.at(idx).pdgId());
 
-  const std::vector<int>& mothers = hadMothersIndices.at(idx);
+  const std::vector<int> &mothers = hadMothersIndices.at(idx);
   unsigned int nMothers = mothers.size();
   bool isCorrect = false;  // Whether current particle is what is being searched
   if (verbose) {

--- a/PhysicsTools/JetMCAlgos/plugins/JetFlavourClustering.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/JetFlavourClustering.cc
@@ -737,7 +737,8 @@ void JetFlavourClustering::assignToSubjets(const reco::GenParticleRefVector& clu
        ++it) {
     std::vector<double> dR2toSubjets;
 
-    dR2toSubjets.reserve(subjetIndices.size()); for (size_t sj = 0; sj < subjetIndices.size(); ++sj)
+    dR2toSubjets.reserve(subjetIndices.size());
+    for (size_t sj = 0; sj < subjetIndices.size(); ++sj)
       dR2toSubjets.push_back(reco::deltaR2((*it)->rapidity(),
                                            (*it)->phi(),
                                            subjets->at(subjetIndices.at(sj)).rapidity(),

--- a/PhysicsTools/JetMCAlgos/plugins/JetFlavourClustering.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/JetFlavourClustering.cc
@@ -737,7 +737,7 @@ void JetFlavourClustering::assignToSubjets(const reco::GenParticleRefVector& clu
        ++it) {
     std::vector<double> dR2toSubjets;
 
-    for (size_t sj = 0; sj < subjetIndices.size(); ++sj)
+    dR2toSubjets.reserve(subjetIndices.size()); for (size_t sj = 0; sj < subjetIndices.size(); ++sj)
       dR2toSubjets.push_back(reco::deltaR2((*it)->rapidity(),
                                            (*it)->phi(),
                                            subjets->at(subjetIndices.at(sj)).rapidity(),

--- a/PhysicsTools/MVAComputer/src/ProcSort.cc
+++ b/PhysicsTools/MVAComputer/src/ProcSort.cc
@@ -116,7 +116,7 @@ namespace {  // anonymous
     LeaderLookup lookup(leaderIter.begin());
 
     std::vector<int> sort;
-    for (unsigned int i = 0; i < size; i++)
+    sort.reserve(size); for (unsigned int i = 0; i < size; i++)
       sort.push_back((int)i);
 
     boost::transform_iterator<LeaderLookup, std::vector<int>::const_iterator> begin(sort.begin(), lookup);

--- a/PhysicsTools/MVAComputer/src/ProcSort.cc
+++ b/PhysicsTools/MVAComputer/src/ProcSort.cc
@@ -116,7 +116,8 @@ namespace {  // anonymous
     LeaderLookup lookup(leaderIter.begin());
 
     std::vector<int> sort;
-    sort.reserve(size); for (unsigned int i = 0; i < size; i++)
+    sort.reserve(size);
+    for (unsigned int i = 0; i < size; i++)
       sort.push_back((int)i);
 
     boost::transform_iterator<LeaderLookup, std::vector<int>::const_iterator> begin(sort.begin(), lookup);

--- a/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
+++ b/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
@@ -255,7 +255,7 @@ public:
 
   static edm::ParameterSetDescription baseDescriptions() {
     edm::ParameterSetDescription desc;
-    std::string classname = ClassName<T>::name();
+    const std::string& classname = ClassName<T>::name();
     desc.add<std::string>("name")->setComment("name of the branch in the flat table output for " + classname);
     desc.add<std::string>("doc", "")->setComment("few words of self documentation");
     desc.add<bool>("extension", false)->setComment("whether or not to extend an existing same table");

--- a/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
+++ b/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
@@ -255,7 +255,7 @@ public:
 
   static edm::ParameterSetDescription baseDescriptions() {
     edm::ParameterSetDescription desc;
-    const std::string& classname = ClassName<T>::name();
+    const std::string &classname = ClassName<T>::name();
     desc.add<std::string>("name")->setComment("name of the branch in the flat table output for " + classname);
     desc.add<std::string>("doc", "")->setComment("few words of self documentation");
     desc.add<bool>("extension", false)->setComment("whether or not to extend an existing same table");

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -449,7 +449,7 @@ public:
     const std::vector<unsigned int>& scaleWeightIDs = weightChoice->scaleWeightIDs;
     const std::vector<unsigned int>& pdfWeightIDs = weightChoice->pdfWeightIDs;
 
-    auto weights = genProd.weights();
+    const auto& weights = genProd.weights();
     double w0 = (weights.size() > 1) ? weights.at(1) : 1.;
     double originalXWGTUP = (weights.size() > 1) ? weights.at(1) : 1.;
 

--- a/PhysicsTools/PatAlgos/src/SoftMuonMvaRun3Estimator.cc
+++ b/PhysicsTools/PatAlgos/src/SoftMuonMvaRun3Estimator.cc
@@ -90,7 +90,8 @@ void fillMatchInfo(pat::XGBooster& booster, const pat::Muon& muon) {
   // Initiate containter for results
   const int n_stations = 2;
   std::vector<MatchPair> matches;
-  matches.reserve(n_stations); for (unsigned int i = 0; i < n_stations; ++i)
+  matches.reserve(n_stations);
+  for (unsigned int i = 0; i < n_stations; ++i)
     matches.push_back(std::pair(nullptr, nullptr));
 
   // Find best matches

--- a/PhysicsTools/PatAlgos/src/SoftMuonMvaRun3Estimator.cc
+++ b/PhysicsTools/PatAlgos/src/SoftMuonMvaRun3Estimator.cc
@@ -90,7 +90,7 @@ void fillMatchInfo(pat::XGBooster& booster, const pat::Muon& muon) {
   // Initiate containter for results
   const int n_stations = 2;
   std::vector<MatchPair> matches;
-  for (unsigned int i = 0; i < n_stations; ++i)
+  matches.reserve(n_stations); for (unsigned int i = 0; i < n_stations; ++i)
     matches.push_back(std::pair(nullptr, nullptr));
 
   // Find best matches

--- a/PhysicsTools/PatUtils/interface/ShiftedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/ShiftedJetProducerT.h
@@ -141,7 +141,7 @@ private:
     JetCollection shiftedJets;
     shiftedJets.reserve(originalJets.size());
     for (auto const& originalJet : originalJets) {
-      reco::Candidate::LorentzVector originalJetP4 = originalJet.p4();
+      const reco::Candidate::LorentzVector& originalJetP4 = originalJet.p4();
       if (verbosity_) {
         std::cout << "originalJet: Pt = " << originalJetP4.pt() << ", eta = " << originalJetP4.eta()
                   << ", phi = " << originalJetP4.phi() << std::endl;

--- a/PhysicsTools/SelectorUtils/interface/VersionedIdProducer.h
+++ b/PhysicsTools/SelectorUtils/interface/VersionedIdProducer.h
@@ -178,7 +178,7 @@ void VersionedIdProducer<PhysicsObjectPtr, SelectorType>::produce(edm::Event& iE
     //now add the value map of ptrs to user datas
     auto out_usrdptrs = std::make_unique<edm::ValueMap<edm::Ptr<pat::UserData>>>();
     std::vector<edm::Ptr<pat::UserData>> usrdptrs;
-    for (unsigned i = 0; i < usrd_handle->size(); ++i) {
+    usrdptrs.reserve(usrd_handle->size()); for (unsigned i = 0; i < usrd_handle->size(); ++i) {
       usrdptrs.push_back(edm::Ptr<pat::UserData>(usrd_handle, i));
     }
 

--- a/PhysicsTools/SelectorUtils/interface/VersionedIdProducer.h
+++ b/PhysicsTools/SelectorUtils/interface/VersionedIdProducer.h
@@ -178,7 +178,8 @@ void VersionedIdProducer<PhysicsObjectPtr, SelectorType>::produce(edm::Event& iE
     //now add the value map of ptrs to user datas
     auto out_usrdptrs = std::make_unique<edm::ValueMap<edm::Ptr<pat::UserData>>>();
     std::vector<edm::Ptr<pat::UserData>> usrdptrs;
-    usrdptrs.reserve(usrd_handle->size()); for (unsigned i = 0; i < usrd_handle->size(); ++i) {
+    usrdptrs.reserve(usrd_handle->size());
+    for (unsigned i = 0; i < usrd_handle->size(); ++i) {
       usrdptrs.push_back(edm::Ptr<pat::UserData>(usrd_handle, i));
     }
 

--- a/PhysicsTools/UtilAlgos/bin/mergeTFileServiceHistograms.cpp
+++ b/PhysicsTools/UtilAlgos/bin/mergeTFileServiceHistograms.cpp
@@ -115,7 +115,7 @@ int main(int argc, char *argv[]) {
 
   bool empty = true;
   for (size_t i = 0; i < fileNames.size(); ++i) {
-    const string& fileName = fileNames[i];
+    const string &fileName = fileNames[i];
     TFile file(fileName.c_str(), "read");
     if (!file.IsOpen()) {
       cerr << "can't open input file: " << fileName << endl;

--- a/PhysicsTools/UtilAlgos/bin/mergeTFileServiceHistograms.cpp
+++ b/PhysicsTools/UtilAlgos/bin/mergeTFileServiceHistograms.cpp
@@ -115,7 +115,7 @@ int main(int argc, char *argv[]) {
 
   bool empty = true;
   for (size_t i = 0; i < fileNames.size(); ++i) {
-    string fileName = fileNames[i];
+    const string& fileName = fileNames[i];
     TFile file(fileName.c_str(), "read");
     if (!file.IsOpen()) {
       cerr << "can't open input file: " << fileName << endl;

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -546,7 +546,7 @@ void TemplatedSecondaryVertexProducer<IPTI, VTX>::produce(edm::Event &event, con
 
           std::vector<double> dR2toSubjets;
 
-          for (size_t sj = 0; sj < subjetIndices.at(i).size(); ++sj)
+          dR2toSubjets.reserve(subjetIndices.at(i).size()); for (size_t sj = 0; sj < subjetIndices.at(i).size(); ++sj)
             dR2toSubjets.push_back(Geom::deltaR2(p.rapidity(),
                                                  p.phi_std(),
                                                  trackIPTagInfos->at(subjetIndices.at(i).at(sj)).jet()->rapidity(),
@@ -671,7 +671,7 @@ void TemplatedSecondaryVertexProducer<IPTI, VTX>::produce(edm::Event &event, con
 
         std::vector<double> dR2toSubjets;
 
-        for (size_t sj = 0; sj < subjetIndices.at(i).size(); ++sj)
+        dR2toSubjets.reserve(subjetIndices.at(i).size()); for (size_t sj = 0; sj < subjetIndices.at(i).size(); ++sj)
           dR2toSubjets.push_back(Geom::deltaR2(p.rapidity(),
                                                p.phi_std(),
                                                trackIPTagInfos->at(subjetIndices.at(i).at(sj)).jet()->rapidity(),

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -546,7 +546,8 @@ void TemplatedSecondaryVertexProducer<IPTI, VTX>::produce(edm::Event &event, con
 
           std::vector<double> dR2toSubjets;
 
-          dR2toSubjets.reserve(subjetIndices.at(i).size()); for (size_t sj = 0; sj < subjetIndices.at(i).size(); ++sj)
+          dR2toSubjets.reserve(subjetIndices.at(i).size());
+          for (size_t sj = 0; sj < subjetIndices.at(i).size(); ++sj)
             dR2toSubjets.push_back(Geom::deltaR2(p.rapidity(),
                                                  p.phi_std(),
                                                  trackIPTagInfos->at(subjetIndices.at(i).at(sj)).jet()->rapidity(),
@@ -671,7 +672,8 @@ void TemplatedSecondaryVertexProducer<IPTI, VTX>::produce(edm::Event &event, con
 
         std::vector<double> dR2toSubjets;
 
-        dR2toSubjets.reserve(subjetIndices.at(i).size()); for (size_t sj = 0; sj < subjetIndices.at(i).size(); ++sj)
+        dR2toSubjets.reserve(subjetIndices.at(i).size());
+        for (size_t sj = 0; sj < subjetIndices.at(i).size(); ++sj)
           dR2toSubjets.push_back(Geom::deltaR2(p.rapidity(),
                                                p.phi_std(),
                                                trackIPTagInfos->at(subjetIndices.at(i).at(sj)).jet()->rapidity(),

--- a/RecoEcal/EgammaClusterAlgos/src/HybridClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/HybridClusterAlgo.cc
@@ -390,7 +390,7 @@ void HybridClusterAlgo::mainSearch(const EcalRecHitCollection* hits, const CaloS
       int nhits = 0;
       for (int j = 0; j < int(dominoEnergy.size()); ++j) {
         if (OwnerShip[j] == i) {
-          std::vector<EcalRecHit> temp = dominoCells[j];
+          const std::vector<EcalRecHit>& temp = dominoCells[j];
           for (int k = 0; k < int(temp.size()); ++k) {
             dets.push_back(std::pair<DetId, float>(temp[k].id(), 1.));  // by default energy fractions are 1
             if (temp[k].id() == itID)
@@ -471,7 +471,7 @@ reco::SuperClusterCollection HybridClusterAlgo::makeSuperClusters(const reco::Ca
     //supercluster.  This could be somehow more efficient.
 
     for (int i = 0; i < int(thiscoll.size()); ++i) {
-      reco::BasicCluster thisclus = thiscoll[i];  //The Cluster in question.
+      const reco::BasicCluster& thisclus = thiscoll[i];  //The Cluster in question.
       for (int j = 0; j < int(clustersCollection.size()); ++j) {
         //Find the appropriate cluster from the list of references
         reco::BasicCluster cluster_p = *clustersCollection[j];

--- a/RecoEcal/EgammaClusterProducers/src/EcalBasicClusterLocalContCorrection.cc
+++ b/RecoEcal/EgammaClusterProducers/src/EcalBasicClusterLocalContCorrection.cc
@@ -54,7 +54,7 @@ float EcalBasicClusterLocalContCorrection::operator()(const reco::BasicCluster &
 
   //search which crystal is closest to the cluster position and call it crystalseed:
   //std::vector<DetId> crystals_vector = *scRef.getHitsByDetId();   //deprecated
-  const std::vector<std::pair<DetId, float> >& crystals_vector = basicCluster.hitsAndFractions();
+  const std::vector<std::pair<DetId, float> > &crystals_vector = basicCluster.hitsAndFractions();
   float dphimin = 999.;
   float detamin = 999.;
   int ietaclosest = 0;

--- a/RecoEcal/EgammaClusterProducers/src/EcalBasicClusterLocalContCorrection.cc
+++ b/RecoEcal/EgammaClusterProducers/src/EcalBasicClusterLocalContCorrection.cc
@@ -54,7 +54,7 @@ float EcalBasicClusterLocalContCorrection::operator()(const reco::BasicCluster &
 
   //search which crystal is closest to the cluster position and call it crystalseed:
   //std::vector<DetId> crystals_vector = *scRef.getHitsByDetId();   //deprecated
-  std::vector<std::pair<DetId, float> > crystals_vector = basicCluster.hitsAndFractions();
+  const std::vector<std::pair<DetId, float> >& crystals_vector = basicCluster.hitsAndFractions();
   float dphimin = 999.;
   float detamin = 999.;
   int ietaclosest = 0;

--- a/RecoEcal/EgammaClusterProducers/src/EcalDigiSelector.cc
+++ b/RecoEcal/EgammaClusterProducers/src/EcalDigiSelector.cc
@@ -155,7 +155,7 @@ void EcalDigiSelector::produce(edm::Event& evt, const edm::EventSetup& es) {
         std::vector<DetId> saveTheseDetIds;
         //pick out the detids for the 3x3 in each of the selected superclusters
         for (int loop = 0; loop < int(saveBarrelSuperClusters.size()); loop++) {
-          SuperCluster clus1 = saveBarrelSuperClusters[loop];
+          const SuperCluster& clus1 = saveBarrelSuperClusters[loop];
           const CaloClusterPtr& bcref = clus1.seed();
           const BasicCluster* bc = bcref.get();
           //Get the maximum detid
@@ -206,7 +206,7 @@ void EcalDigiSelector::produce(edm::Event& evt, const edm::EventSetup& es) {
         std::set<DetId> saveTheseDetIds;
         //pick out the digis for the 3x3 in each of the selected superclusters
         for (int loop = 0; loop < int(saveEndcapSuperClusters.size()); loop++) {
-          SuperCluster clus1 = saveEndcapSuperClusters[loop];
+          const SuperCluster& clus1 = saveEndcapSuperClusters[loop];
           const CaloClusterPtr& bcref = clus1.seed();
           const BasicCluster* bc = bcref.get();
           //Get the maximum detid

--- a/RecoEcal/EgammaClusterProducers/src/UncleanSCRecoveryProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/UncleanSCRecoveryProducer.cc
@@ -220,7 +220,7 @@ void UncleanSCRecoveryProducer::produce(edm::StreamID, edm::Event& evt, const ed
   // the new collection
   LogTrace("EcalCleaning") << "The new SC clean collection with size " << superClusters.size();
   for (unsigned int i = 0; i < superClusters.size(); ++i) {
-    const reco::SuperCluster nsc = superClusters[i];
+    const reco::SuperCluster& nsc = superClusters[i];
     LogTrace("EcalCleaning") << " >>> newSC    #" << i << "; Energy: " << nsc.energy() << " eta: " << nsc.eta()
                              << " isClean=" << nsc.isInClean() << " isUnclean=" << nsc.isInUnclean()
                              << " sc seed detid: " << nsc.seed()->seed().rawId();

--- a/RecoEcal/EgammaClusterProducers/src/UnifiedSCCollectionProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/UnifiedSCCollectionProducer.cc
@@ -432,7 +432,7 @@ void UnifiedSCCollectionProducer::produce(edm::Event& evt, const edm::EventSetup
   }
   LogTrace("UnifiedSC") << "The new SC unclean only collection with size " << superClustersUncleanOnly.size();
   for (int i = 0; i < (int)superClustersUncleanOnly.size(); ++i) {
-    const reco::SuperCluster nsc = superClustersUncleanOnly[i];
+    const reco::SuperCluster& nsc = superClustersUncleanOnly[i];
     LogTrace("UnifiedSC") << " >>> newSC    #" << i << "; Energy: " << nsc.energy() << " eta: " << nsc.eta()
                           << " isClean=" << nsc.isInClean() << " isUnclean=" << nsc.isInUnclean()
                           << " sc seed detid: " << nsc.seed()->seed().rawId();

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterCrackCorrection.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterCrackCorrection.cc
@@ -95,7 +95,7 @@ float EcalClusterCrackCorrection::getValue(const reco::CaloCluster &seedbclus) c
 
   //search which crystal is closest to the cluster position and call it crystalseed:
   //std::vector<DetId> crystals_vector = seedbclus.getHitsByDetId();   //deprecated
-  const std::vector<std::pair<DetId, float> >& crystals_vector = seedbclus.hitsAndFractions();
+  const std::vector<std::pair<DetId, float> > &crystals_vector = seedbclus.hitsAndFractions();
   float dphimin = 999.;
   float detamin = 999.;
   int ietaclosest = 0;

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterCrackCorrection.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterCrackCorrection.cc
@@ -95,7 +95,7 @@ float EcalClusterCrackCorrection::getValue(const reco::CaloCluster &seedbclus) c
 
   //search which crystal is closest to the cluster position and call it crystalseed:
   //std::vector<DetId> crystals_vector = seedbclus.getHitsByDetId();   //deprecated
-  std::vector<std::pair<DetId, float> > crystals_vector = seedbclus.hitsAndFractions();
+  const std::vector<std::pair<DetId, float> >& crystals_vector = seedbclus.hitsAndFractions();
   float dphimin = 999.;
   float detamin = 999.;
   int ietaclosest = 0;

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedValueMapsProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedValueMapsProducer.cc
@@ -80,7 +80,7 @@ void LowPtGsfElectronSeedValueMapsProducer::produce(edm::Event& event, const edm
 
     // Iterate through GsfTracks, extract BDT output, and store result in ValueMap for each model
     std::vector<std::vector<float> > output;
-    for (unsigned int iname = 0; iname < names_.size(); ++iname) {
+    output.reserve(names_.size()); for (unsigned int iname = 0; iname < names_.size(); ++iname) {
       output.push_back(std::vector<float>(gsfTracks->size(), -999.));
     }
     auto const& gsfTracksV = *gsfTracks;

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedValueMapsProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedValueMapsProducer.cc
@@ -80,7 +80,8 @@ void LowPtGsfElectronSeedValueMapsProducer::produce(edm::Event& event, const edm
 
     // Iterate through GsfTracks, extract BDT output, and store result in ValueMap for each model
     std::vector<std::vector<float> > output;
-    output.reserve(names_.size()); for (unsigned int iname = 0; iname < names_.size(); ++iname) {
+    output.reserve(names_.size());
+    for (unsigned int iname = 0; iname < names_.size(); ++iname) {
       output.push_back(std::vector<float>(gsfTracks->size(), -999.));
     }
     auto const& gsfTracksV = *gsfTracks;

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTPhase2ExtraProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTPhase2ExtraProducer.cc
@@ -276,7 +276,7 @@ void EgammaHLTPhase2ExtraProducer::produce(edm::StreamID streamID,
   auto l1TrkExtraColl = std::make_unique<L1TrackTruthPairCollection>();
 
   for (size_t l1TrkNr = 0; l1TrkNr < orgL1TrkRefs.size(); l1TrkNr++) {
-    auto orgTrkRef = orgL1TrkRefs[l1TrkNr];
+    const auto& orgTrkRef = orgL1TrkRefs[l1TrkNr];
     auto orgTrkPtr = edm::refToPtr(orgTrkRef);
     int flags = 0;
     if (l1TrkToTrkPartMap->isGenuine(orgTrkPtr))

--- a/RecoEgamma/EgammaIsolationAlgos/src/ElectronTkIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/ElectronTkIsolation.cc
@@ -47,7 +47,7 @@ std::pair<int, double> ElectronTkIsolation::getIso(const reco::Track* tmpTrack) 
   int counter = 0;
   double ptSum = 0.;
   //Take the electron track
-  math::XYZVector tmpElectronMomentumAtVtx = (*tmpTrack).momentum();
+  const math::XYZVector& tmpElectronMomentumAtVtx = (*tmpTrack).momentum();
   double tmpElectronEtaAtVertex = (*tmpTrack).eta();
 
   for (reco::TrackCollection::const_iterator itrTr = (*trackCollection_).begin(); itrTr != (*trackCollection_).end();

--- a/RecoEgamma/EgammaPhotonAlgos/src/ConversionVertexFinder.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/ConversionVertexFinder.cc
@@ -34,7 +34,7 @@ ConversionVertexFinder::~ConversionVertexFinder() {
 }
 
 bool ConversionVertexFinder::run(const std::vector<reco::TransientTrack>& _pair, reco::Vertex& the_vertex) {
-  std::vector<reco::TransientTrack> pair = _pair;
+  const std::vector<reco::TransientTrack>& pair = _pair;
   bool found = false;
 
   if (pair.size() < 2)

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackMerger.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackMerger.cc
@@ -111,11 +111,13 @@ void ConversionTrackMerger::produce(edm::Event& e, const edm::EventSetup& es) {
   int i;
 
   std::vector<int> selected1;
-  selected1.reserve(tC1.size()); for (unsigned int i = 0; i < tC1.size(); ++i) {
+  selected1.reserve(tC1.size());
+  for (unsigned int i = 0; i < tC1.size(); ++i) {
     selected1.push_back(1);
   }
   std::vector<int> selected2;
-  selected2.reserve(tC2.size()); for (unsigned int i = 0; i < tC2.size(); ++i) {
+  selected2.reserve(tC2.size());
+  for (unsigned int i = 0; i < tC2.size(); ++i) {
     selected2.push_back(1);
   }
 

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackMerger.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackMerger.cc
@@ -111,11 +111,11 @@ void ConversionTrackMerger::produce(edm::Event& e, const edm::EventSetup& es) {
   int i;
 
   std::vector<int> selected1;
-  for (unsigned int i = 0; i < tC1.size(); ++i) {
+  selected1.reserve(tC1.size()); for (unsigned int i = 0; i < tC1.size(); ++i) {
     selected1.push_back(1);
   }
   std::vector<int> selected2;
-  for (unsigned int i = 0; i < tC2.size(); ++i) {
+  selected2.reserve(tC2.size()); for (unsigned int i = 0; i < tC2.size(); ++i) {
     selected2.push_back(1);
   }
 

--- a/RecoEgamma/EgammaTools/src/EcalClusterLocal.cc
+++ b/RecoEgamma/EgammaTools/src/EcalClusterLocal.cc
@@ -35,7 +35,7 @@ namespace egammaTools {
     double depth = X0 * (T0 + log(bclus.energy()));
 
     //find max energy crystal
-    const std::vector<std::pair<DetId, float> >& crystals_vector = bclus.hitsAndFractions();
+    const std::vector<std::pair<DetId, float> > &crystals_vector = bclus.hitsAndFractions();
     float drmin = 999.;
     EBDetId crystalseed;
     //printf("starting loop over crystals, etot = %5f:\n",bclus.energy());
@@ -115,7 +115,7 @@ namespace egammaTools {
     double depth = X0 * (T0 + log(bclus.energy()));
 
     //find max energy crystal
-    const std::vector<std::pair<DetId, float> >& crystals_vector = bclus.hitsAndFractions();
+    const std::vector<std::pair<DetId, float> > &crystals_vector = bclus.hitsAndFractions();
     float drmin = 999.;
     EEDetId crystalseed;
     //printf("starting loop over crystals, etot = %5f:\n",bclus.energy());

--- a/RecoEgamma/EgammaTools/src/EcalClusterLocal.cc
+++ b/RecoEgamma/EgammaTools/src/EcalClusterLocal.cc
@@ -35,7 +35,7 @@ namespace egammaTools {
     double depth = X0 * (T0 + log(bclus.energy()));
 
     //find max energy crystal
-    std::vector<std::pair<DetId, float> > crystals_vector = bclus.hitsAndFractions();
+    const std::vector<std::pair<DetId, float> >& crystals_vector = bclus.hitsAndFractions();
     float drmin = 999.;
     EBDetId crystalseed;
     //printf("starting loop over crystals, etot = %5f:\n",bclus.energy());
@@ -115,7 +115,7 @@ namespace egammaTools {
     double depth = X0 * (T0 + log(bclus.energy()));
 
     //find max energy crystal
-    std::vector<std::pair<DetId, float> > crystals_vector = bclus.hitsAndFractions();
+    const std::vector<std::pair<DetId, float> >& crystals_vector = bclus.hitsAndFractions();
     float drmin = 999.;
     EEDetId crystalseed;
     //printf("starting loop over crystals, etot = %5f:\n",bclus.energy());

--- a/RecoHGCal/TICL/plugins/TICLDumper.cc
+++ b/RecoHGCal/TICL/plugins/TICLDumper.cc
@@ -388,7 +388,8 @@ public:
       }
 
       std::vector<float> id_probs;
-      id_probs.reserve(8); for (size_t i = 0; i < 8; i++)
+      id_probs.reserve(8);
+      for (size_t i = 0; i < 8; i++)
         id_probs.push_back(trackster_iterator->id_probabilities(i));
       trackster_id_probabilities.push_back(id_probs);
 

--- a/RecoHGCal/TICL/plugins/TICLDumper.cc
+++ b/RecoHGCal/TICL/plugins/TICLDumper.cc
@@ -388,7 +388,7 @@ public:
       }
 
       std::vector<float> id_probs;
-      for (size_t i = 0; i < 8; i++)
+      id_probs.reserve(8); for (size_t i = 0; i < 8; i++)
         id_probs.push_back(trackster_iterator->id_probabilities(i));
       trackster_id_probabilities.push_back(id_probs);
 

--- a/RecoHGCal/TICL/plugins/TracksterLinkingbySkeletons.cc
+++ b/RecoHGCal/TICL/plugins/TracksterLinkingbySkeletons.cc
@@ -448,7 +448,7 @@ void TracksterLinkingbySkeletons::linkTracksters(
   std::vector<int> isRootTracksters(tracksters.size(), 1);
 
   std::vector<ticl::Node> allNodes;
-  for (size_t it = 0; it < tracksters.size(); ++it) {
+  allNodes.reserve(tracksters.size()); for (size_t it = 0; it < tracksters.size(); ++it) {
     allNodes.emplace_back(it);
   }
 

--- a/RecoHGCal/TICL/plugins/TracksterLinkingbySkeletons.cc
+++ b/RecoHGCal/TICL/plugins/TracksterLinkingbySkeletons.cc
@@ -448,7 +448,8 @@ void TracksterLinkingbySkeletons::linkTracksters(
   std::vector<int> isRootTracksters(tracksters.size(), 1);
 
   std::vector<ticl::Node> allNodes;
-  allNodes.reserve(tracksters.size()); for (size_t it = 0; it < tracksters.size(); ++it) {
+  allNodes.reserve(tracksters.size());
+  for (size_t it = 0; it < tracksters.size(); ++it) {
     allNodes.emplace_back(it);
   }
 

--- a/RecoHGCal/TICL/plugins/TracksterLinkingbySuperClusteringMustache.h
+++ b/RecoHGCal/TICL/plugins/TracksterLinkingbySuperClusteringMustache.h
@@ -43,7 +43,7 @@ namespace ticl {
                     const edm::ESHandle<MagneticField> bfieldH,
                     const edm::ESHandle<Propagator> propH) override;
 
-    virtual void setEvent(edm::Event& iEvent, edm::EventSetup const& iEventSetup) override;
+    void setEvent(edm::Event& iEvent, edm::EventSetup const& iEventSetup) override;
 
   private:
     bool trackstersPassesPIDCut(const Trackster& ts) const;

--- a/RecoHGCal/TICL/plugins/TrackstersPCA.h
+++ b/RecoHGCal/TICL/plugins/TrackstersPCA.h
@@ -38,7 +38,7 @@ namespace ticl {
                                                size_t N);
 
   inline unsigned getLayerFromLC(const reco::CaloCluster &LC, const hgcal::RecHitTools &rhtools) {
-    std::vector<std::pair<DetId, float>> thisclusterHits = LC.hitsAndFractions();
+    const std::vector<std::pair<DetId, float>>& thisclusterHits = LC.hitsAndFractions();
     auto layer = rhtools.getLayerWithOffset(thisclusterHits[0].first);
     return layer;
   }

--- a/RecoHGCal/TICL/plugins/TrackstersPCA.h
+++ b/RecoHGCal/TICL/plugins/TrackstersPCA.h
@@ -38,7 +38,7 @@ namespace ticl {
                                                size_t N);
 
   inline unsigned getLayerFromLC(const reco::CaloCluster &LC, const hgcal::RecHitTools &rhtools) {
-    const std::vector<std::pair<DetId, float>>& thisclusterHits = LC.hitsAndFractions();
+    const std::vector<std::pair<DetId, float>> &thisclusterHits = LC.hitsAndFractions();
     auto layer = rhtools.getLayerWithOffset(thisclusterHits[0].first);
     return layer;
   }

--- a/RecoHI/HiJetAlgos/plugins/HiPuRhoProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiPuRhoProducer.cc
@@ -501,7 +501,8 @@ void HiPuRhoProducer::putRho(edm::Event& iEvent, const edm::EventSetup& iSetup) 
   std::size_t size = etaEdgeLow_.size();
 
   std::vector<std::pair<std::size_t, double>> order;
-  order.reserve(size); for (std::size_t i = 0; i < size; ++i) {
+  order.reserve(size);
+  for (std::size_t i = 0; i < size; ++i) {
     order.emplace_back(i, etaEdgeLow_[i]);
   }
 

--- a/RecoHI/HiJetAlgos/plugins/HiPuRhoProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiPuRhoProducer.cc
@@ -501,7 +501,7 @@ void HiPuRhoProducer::putRho(edm::Event& iEvent, const edm::EventSetup& iSetup) 
   std::size_t size = etaEdgeLow_.size();
 
   std::vector<std::pair<std::size_t, double>> order;
-  for (std::size_t i = 0; i < size; ++i) {
+  order.reserve(size); for (std::size_t i = 0; i < size; ++i) {
     order.emplace_back(i, etaEdgeLow_[i]);
   }
 

--- a/RecoJets/JetAlgorithms/src/CATopJetAlgorithm.cc
+++ b/RecoJets/JetAlgorithms/src/CATopJetAlgorithm.cc
@@ -116,7 +116,7 @@ void CATopJetAlgorithm::run(const vector<fastjet::PseudoJet>& cell_particles,
     if (verbose_)
       cout << "\nJet " << i << endl;
     i++;
-    fastjet::PseudoJet localJet = *jetIt;
+    const fastjet::PseudoJet& localJet = *jetIt;
 
     // Get the 4-vector for this jet
     p4_hardJets.push_back(math::XYZTLorentzVector(localJet.px(), localJet.py(), localJet.pz(), localJet.e()));

--- a/RecoJets/JetAlgorithms/src/CATopJetHelper.cc
+++ b/RecoJets/JetAlgorithms/src/CATopJetHelper.cc
@@ -23,13 +23,13 @@ reco::CATopJetProperties CATopJetHelper::operator()(reco::Jet const& ihardJet) c
     // Now look at the subjets that were formed
     for (int isub = 0; isub < 2; ++isub) {
       // Get this subjet
-      reco::Jet::Constituent icandJet = subjets[isub];
+      const reco::Jet::Constituent& icandJet = subjets[isub];
 
       // Now look at the "other" subjets than this one, form the minimum invariant mass
       // pairing, as well as the "closest" combination to the W mass
       for (int jsub = isub + 1; jsub < 3; ++jsub) {
         // Get the second subjet
-        reco::Jet::Constituent jcandJet = subjets[jsub];
+        const reco::Jet::Constituent& jcandJet = subjets[jsub];
 
         reco::Candidate::LorentzVector wCand = icandJet->p4() + jcandJet->p4();
 

--- a/RecoJets/JetProducers/src/JetMatchingTools.cc
+++ b/RecoJets/JetProducers/src/JetMatchingTools.cc
@@ -155,7 +155,8 @@ const reco::CandidateCollection* JetMatchingTools::getGenParticlesCollection() {
 std::vector<const CaloTower*> JetMatchingTools::getConstituents(const reco::CaloJet& fJet) {
   std::vector<const CaloTower*> result;
   std::vector<CaloTowerPtr> constituents = fJet.getCaloConstituents();
-  result.reserve(constituents.size()); for (unsigned i = 0; i < constituents.size(); ++i)
+  result.reserve(constituents.size());
+  for (unsigned i = 0; i < constituents.size(); ++i)
     result.push_back(&*(constituents[i]));
   return result;
 }

--- a/RecoJets/JetProducers/src/JetMatchingTools.cc
+++ b/RecoJets/JetProducers/src/JetMatchingTools.cc
@@ -155,7 +155,7 @@ const reco::CandidateCollection* JetMatchingTools::getGenParticlesCollection() {
 std::vector<const CaloTower*> JetMatchingTools::getConstituents(const reco::CaloJet& fJet) {
   std::vector<const CaloTower*> result;
   std::vector<CaloTowerPtr> constituents = fJet.getCaloConstituents();
-  for (unsigned i = 0; i < constituents.size(); ++i)
+  result.reserve(constituents.size()); for (unsigned i = 0; i < constituents.size(); ++i)
     result.push_back(&*(constituents[i]));
   return result;
 }

--- a/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
@@ -108,7 +108,7 @@ namespace cms {
       std::cout << "================    jetEta   =  " << (*jet).eta() << std::endl;
     }
 
-    const edm::RefToBase<reco::Jet> jptjetRef = jet->getCaloJetRef();
+    const edm::RefToBase<reco::Jet>& jptjetRef = jet->getCaloJetRef();
     reco::CaloJet const* rawcalojet = dynamic_cast<reco::CaloJet const*>(&*jptjetRef);
 
     int ncalotowers = 0.;
@@ -196,7 +196,7 @@ namespace cms {
     double detatr1 = 0.;
     double dphidetatr = 0.;
 
-    const reco::TrackRefVector pioninin = (*jet).getPionsInVertexInCalo();
+    const reco::TrackRefVector& pioninin = (*jet).getPionsInVertexInCalo();
 
     for (reco::TrackRefVector::const_iterator it = pioninin.begin(); it != pioninin.end(); it++) {
       if ((*it)->pt() > 0.5 && ((*it)->ptError() / (*it)->pt()) < 0.05) {
@@ -221,7 +221,7 @@ namespace cms {
       }
     }  // pioninin
 
-    const reco::TrackRefVector pioninout = (*jet).getPionsInVertexOutCalo();
+    const reco::TrackRefVector& pioninout = (*jet).getPionsInVertexOutCalo();
 
     for (reco::TrackRefVector::const_iterator it = pioninout.begin(); it != pioninout.end(); it++) {
       if ((*it)->pt() > 0.5 && ((*it)->ptError() / (*it)->pt()) < 0.05) {

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
@@ -526,7 +526,7 @@ void CaloTowersCreationAlgo::rescaleTowers(const CaloTowerCollection& ctc, CaloT
                                 theTowerTopology->lastHORing());
 
     std::vector<DetId> contains;
-    for (unsigned int iConst = 0; iConst < ctcItr->constituentsSize(); ++iConst) {
+    contains.reserve(ctcItr->constituentsSize()); for (unsigned int iConst = 0; iConst < ctcItr->constituentsSize(); ++iConst) {
       contains.push_back(ctcItr->constituent(iConst));
     }
     rescaledTower.addConstituents(contains);

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
@@ -526,7 +526,8 @@ void CaloTowersCreationAlgo::rescaleTowers(const CaloTowerCollection& ctc, CaloT
                                 theTowerTopology->lastHORing());
 
     std::vector<DetId> contains;
-    contains.reserve(ctcItr->constituentsSize()); for (unsigned int iConst = 0; iConst < ctcItr->constituentsSize(); ++iConst) {
+    contains.reserve(ctcItr->constituentsSize());
+    for (unsigned int iConst = 0; iConst < ctcItr->constituentsSize(); ++iConst) {
       contains.push_back(ctcItr->constituent(iConst));
     }
     rescaledTower.addConstituents(contains);

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -608,7 +608,7 @@ void EcalUncalibRecHitWorkerMultiFit::run(const edm::Event& evt,
       } else if (timealgo_ == weightsMethod) {
         //  weights method on the PU subtracted pulse shape
         std::vector<double> amplitudes;
-        for (unsigned int ibx = 0; ibx < activeBX.size(); ++ibx)
+        amplitudes.reserve(activeBX.size()); for (unsigned int ibx = 0; ibx < activeBX.size(); ++ibx)
           amplitudes.push_back(uncalibRecHit.outOfTimeAmplitude(ibx));
 
         EcalTBWeights::EcalTDCId tdcid(1);

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -608,7 +608,8 @@ void EcalUncalibRecHitWorkerMultiFit::run(const edm::Event& evt,
       } else if (timealgo_ == weightsMethod) {
         //  weights method on the PU subtracted pulse shape
         std::vector<double> amplitudes;
-        amplitudes.reserve(activeBX.size()); for (unsigned int ibx = 0; ibx < activeBX.size(); ++ibx)
+        amplitudes.reserve(activeBX.size());
+        for (unsigned int ibx = 0; ibx < activeBX.size(); ++ibx)
           amplitudes.push_back(uncalibRecHit.outOfTimeAmplitude(ibx));
 
         EcalTBWeights::EcalTDCId tdcid(1);

--- a/RecoLocalCalo/HcalLaserReco/src/HcalLaserUnpacker.cc
+++ b/RecoLocalCalo/HcalLaserReco/src/HcalLaserUnpacker.cc
@@ -22,7 +22,7 @@ void HcalLaserUnpacker::unpack(const FEDRawData& raw, HcalLaserDigi& digi) const
 
   // first, we do the QADC
   std::vector<uint16_t> qadcvals;
-  for (unsigned int i = 0; i < qdctdc->n_qdc_hits; i++) {
+  qadcvals.reserve(qdctdc->n_qdc_hits); for (unsigned int i = 0; i < qdctdc->n_qdc_hits; i++) {
     qadcvals.push_back(qdctdc->qdc_values[i] & 0xFFF);
   }
   digi.setQADC(qadcvals);

--- a/RecoLocalCalo/HcalLaserReco/src/HcalLaserUnpacker.cc
+++ b/RecoLocalCalo/HcalLaserReco/src/HcalLaserUnpacker.cc
@@ -22,7 +22,8 @@ void HcalLaserUnpacker::unpack(const FEDRawData& raw, HcalLaserDigi& digi) const
 
   // first, we do the QADC
   std::vector<uint16_t> qadcvals;
-  qadcvals.reserve(qdctdc->n_qdc_hits); for (unsigned int i = 0; i < qdctdc->n_qdc_hits; i++) {
+  qadcvals.reserve(qdctdc->n_qdc_hits);
+  for (unsigned int i = 0; i < qdctdc->n_qdc_hits; i++) {
     qadcvals.push_back(qdctdc->qdc_values[i] & 0xFFF);
   }
   digi.setQADC(qadcvals);

--- a/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.cc
+++ b/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.cc
@@ -1559,7 +1559,7 @@ TrajectoryStateOnSurface CSCEfficiency::propagate(FreeTrajectoryState &ftsStart,
 //
 bool CSCEfficiency::applyTrigger(edm::Handle<edm::TriggerResults> &hltR, const edm::TriggerNames &triggerNames) {
   bool triggerPassed = true;
-  const std::vector<std::string>& hlNames = triggerNames.triggerNames();
+  const std::vector<std::string> &hlNames = triggerNames.triggerNames();
   pointToTriggers.clear();
   for (size_t imyT = 0; imyT < myTriggers.size(); ++imyT) {
     for (size_t iT = 0; iT < hlNames.size(); ++iT) {

--- a/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.cc
+++ b/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.cc
@@ -1559,7 +1559,7 @@ TrajectoryStateOnSurface CSCEfficiency::propagate(FreeTrajectoryState &ftsStart,
 //
 bool CSCEfficiency::applyTrigger(edm::Handle<edm::TriggerResults> &hltR, const edm::TriggerNames &triggerNames) {
   bool triggerPassed = true;
-  std::vector<std::string> hlNames = triggerNames.triggerNames();
+  const std::vector<std::string>& hlNames = triggerNames.triggerNames();
   pointToTriggers.clear();
   for (size_t imyT = 0; imyT < myTriggers.size(); ++imyT) {
     for (size_t iT = 0; iT < hlNames.size(); ++iT) {

--- a/RecoLocalMuon/DTSegment/src/DTCombinatorialPatternReco4D.cc
+++ b/RecoLocalMuon/DTSegment/src/DTCombinatorialPatternReco4D.cc
@@ -297,7 +297,7 @@ DTRecSegment4D* DTCombinatorialPatternReco4D::segmentSpecialZed(const DTRecSegme
 
   // pick up a hit "in the middle", where the single hit will be put.
   int nHits = hits.size();
-  DTRecHit1D middle = hits[static_cast<int>(nHits / 2.)];
+  const DTRecHit1D& middle = hits[static_cast<int>(nHits / 2.)];
 
   // Need to extrapolate pos to the middle layer z
   LocalPoint posInSL = zedSeg->localPosition();

--- a/RecoLuminosity/LumiProducer/plugins/CMSRunSummary2DB.cc
+++ b/RecoLuminosity/LumiProducer/plugins/CMSRunSummary2DB.cc
@@ -85,7 +85,7 @@ namespace lumi {
       std::string fillnum = record[0];
       if (fillnum == result.fillnumber) {
         result.fillscheme = record[1];
-        std::string ncollidingbunchesStr = record[2];
+        const std::string& ncollidingbunchesStr = record[2];
         result.ncollidingbunches = str2int(ncollidingbunchesStr);
         break;
       }

--- a/RecoMET/METPUSubtraction/src/PFMETAlgorithmMVA.cc
+++ b/RecoMET/METPUSubtraction/src/PFMETAlgorithmMVA.cc
@@ -84,7 +84,8 @@ const GBRForest* PFMETAlgorithmMVA::loadMVAfromFile(const edm::FileInPath& input
   }
 
   std::vector<std::string> variableNames;
-  variableNames.reserve(lVec->size()); for (unsigned int i = 0; i < lVec->size(); ++i) {
+  variableNames.reserve(lVec->size());
+  for (unsigned int i = 0; i < lVec->size(); ++i) {
     variableNames.push_back(updateVariableNames(lVec->at(i)));
   }
 

--- a/RecoMET/METPUSubtraction/src/PFMETAlgorithmMVA.cc
+++ b/RecoMET/METPUSubtraction/src/PFMETAlgorithmMVA.cc
@@ -84,7 +84,7 @@ const GBRForest* PFMETAlgorithmMVA::loadMVAfromFile(const edm::FileInPath& input
   }
 
   std::vector<std::string> variableNames;
-  for (unsigned int i = 0; i < lVec->size(); ++i) {
+  variableNames.reserve(lVec->size()); for (unsigned int i = 0; i < lVec->size(); ++i) {
     variableNames.push_back(updateVariableNames(lVec->at(i)));
   }
 

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -1410,9 +1410,9 @@ void MuonIdProducer::fillMuonIsolation(edm::Event& iEvent,
     return;
   }
 
-  reco::IsoDeposit depEcal = caloDeps.at(0);
-  reco::IsoDeposit depHcal = caloDeps.at(1);
-  reco::IsoDeposit depHo = caloDeps.at(2);
+  const reco::IsoDeposit& depEcal = caloDeps.at(0);
+  const reco::IsoDeposit& depHcal = caloDeps.at(1);
+  const reco::IsoDeposit& depHo = caloDeps.at(2);
 
   //no need to copy outside if we don't write them
   if (writeIsoDeposits_) {

--- a/RecoMuon/MuonSeedGenerator/src/RPCSeedGenerator.cc
+++ b/RecoMuon/MuonSeedGenerator/src/RPCSeedGenerator.cc
@@ -190,14 +190,14 @@ void RPCSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
   MuonDetLayerGeometry const& muonLayers = iSetup.getData(muonLayersToken);
 
   // Get the RPC layers
-  vector<const DetLayer*> RPCBarrelLayers = muonLayers.barrelRPCLayers();
+  const vector<const DetLayer*>& RPCBarrelLayers = muonLayers.barrelRPCLayers();
   const DetLayer* RB4L = RPCBarrelLayers[5];
   const DetLayer* RB3L = RPCBarrelLayers[4];
   const DetLayer* RB22L = RPCBarrelLayers[3];
   const DetLayer* RB21L = RPCBarrelLayers[2];
   const DetLayer* RB12L = RPCBarrelLayers[1];
   const DetLayer* RB11L = RPCBarrelLayers[0];
-  vector<const DetLayer*> RPCEndcapLayers = muonLayers.endcapRPCLayers();
+  const vector<const DetLayer*>& RPCEndcapLayers = muonLayers.endcapRPCLayers();
   const DetLayer* REM3L = RPCEndcapLayers[0];
   const DetLayer* REM2L = RPCEndcapLayers[1];
   const DetLayer* REM1L = RPCEndcapLayers[2];

--- a/RecoMuon/TrackingTools/src/MuonTrajectoryUpdator.cc
+++ b/RecoMuon/TrackingTools/src/MuonTrajectoryUpdator.cc
@@ -101,7 +101,7 @@ pair<bool, TrajectoryStateOnSurface> MuonTrajectoryUpdator::update(const Traject
   const DetLayer* detLayer = measurement->layer();
 
   // these are the 4D segment for the CSC/DT and a point for the RPC
-  TransientTrackingRecHit::ConstRecHitPointer muonRecHit = measurement->recHit();
+  const TransientTrackingRecHit::ConstRecHitPointer& muonRecHit = measurement->recHit();
 
   // The KFUpdator takes TransientTrackingRecHits as arg.
   TransientTrackingRecHit::ConstRecHitContainer recHitsForFit =

--- a/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
+++ b/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
@@ -100,7 +100,7 @@ CTPPSPixelLocalTrackProducer::CTPPSPixelLocalTrackProducer(const edm::ParameterS
   }
 
   std::vector<uint32_t> listOfAllPlanes;
-  for (uint32_t i = 0; i < numberOfPlanesPerPot_; ++i) {
+  listOfAllPlanes.reserve(numberOfPlanesPerPot_); for (uint32_t i = 0; i < numberOfPlanesPerPot_; ++i) {
     listOfAllPlanes.push_back(i);
   }
 

--- a/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
+++ b/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
@@ -100,7 +100,8 @@ CTPPSPixelLocalTrackProducer::CTPPSPixelLocalTrackProducer(const edm::ParameterS
   }
 
   std::vector<uint32_t> listOfAllPlanes;
-  listOfAllPlanes.reserve(numberOfPlanesPerPot_); for (uint32_t i = 0; i < numberOfPlanesPerPot_; ++i) {
+  listOfAllPlanes.reserve(numberOfPlanesPerPot_);
+  for (uint32_t i = 0; i < numberOfPlanesPerPot_; ++i) {
     listOfAllPlanes.push_back(i);
   }
 

--- a/RecoPPS/Local/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoPPS/Local/src/RPixPlaneCombinatoryTracking.cc
@@ -648,7 +648,7 @@ bool RPixPlaneCombinatoryTracking::calculatePointOnDetector(CTPPSPixelLocalTrack
                                                             CTPPSPixelDetId planeId,
                                                             GlobalPoint &planeLineIntercept) {
   double z0 = track->z0();
-  const CTPPSPixelLocalTrack::ParameterVector& parameters = track->parameterVector();
+  const CTPPSPixelLocalTrack::ParameterVector &parameters = track->parameterVector();
 
   math::Vector<3>::type pointOnLine(parameters[0], parameters[1], z0);
   GlobalVector tmpLineUnitVector = track->directionVector();

--- a/RecoPPS/Local/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoPPS/Local/src/RPixPlaneCombinatoryTracking.cc
@@ -648,7 +648,7 @@ bool RPixPlaneCombinatoryTracking::calculatePointOnDetector(CTPPSPixelLocalTrack
                                                             CTPPSPixelDetId planeId,
                                                             GlobalPoint &planeLineIntercept) {
   double z0 = track->z0();
-  CTPPSPixelLocalTrack::ParameterVector parameters = track->parameterVector();
+  const CTPPSPixelLocalTrack::ParameterVector& parameters = track->parameterVector();
 
   math::Vector<3>::type pointOnLine(parameters[0], parameters[1], z0);
   GlobalVector tmpLineUnitVector = track->directionVector();

--- a/RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h
@@ -66,7 +66,7 @@ public:
         thresh_pT.push_back(pset.getParameter<double>("gatheringThresholdPt"));
       }
 
-      for (unsigned int i = 0; i < thresh_pT.size(); ++i) {
+      thresh_pT2.reserve(thresh_pT.size()); for (unsigned int i = 0; i < thresh_pT.size(); ++i) {
         thresh_pT2.push_back(thresh_pT[i] * thresh_pT[i]);
       }
 

--- a/RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h
@@ -66,7 +66,8 @@ public:
         thresh_pT.push_back(pset.getParameter<double>("gatheringThresholdPt"));
       }
 
-      thresh_pT2.reserve(thresh_pT.size()); for (unsigned int i = 0; i < thresh_pT.size(); ++i) {
+      thresh_pT2.reserve(thresh_pT.size());
+      for (unsigned int i = 0; i < thresh_pT.size(); ++i) {
         thresh_pT2.push_back(thresh_pT[i] * thresh_pT[i]);
       }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
@@ -59,7 +59,8 @@ public:
       logWeightDenom.push_back(conf.getParameter<double>("logWeightDenominator"));
     }
 
-    logWeightDenomInv.reserve(depths.size()); for (unsigned int i = 0; i < depths.size(); ++i) {
+    logWeightDenomInv.reserve(depths.size());
+    for (unsigned int i = 0; i < depths.size(); ++i) {
       logWeightDenomInv.push_back(1. / logWeightDenom[i]);
     }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
@@ -59,7 +59,7 @@ public:
       logWeightDenom.push_back(conf.getParameter<double>("logWeightDenominator"));
     }
 
-    for (unsigned int i = 0; i < depths.size(); ++i) {
+    logWeightDenomInv.reserve(depths.size()); for (unsigned int i = 0; i < depths.size(); ++i) {
       logWeightDenomInv.push_back(1. / logWeightDenom[i]);
     }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.cc
@@ -78,7 +78,7 @@ LocalMaximumSeedFinder::LocalMaximumSeedFinder(const edm::ParameterSet& conf)
       thresh_pT.push_back(pset.getParameter<double>("seedingThresholdPt"));
     }
 
-    for (unsigned int i = 0; i < thresh_pT.size(); ++i) {
+    thresh_pT2.reserve(thresh_pT.size()); for (unsigned int i = 0; i < thresh_pT.size(); ++i) {
       thresh_pT2.push_back(thresh_pT[i] * thresh_pT[i]);
     }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.cc
@@ -78,7 +78,8 @@ LocalMaximumSeedFinder::LocalMaximumSeedFinder(const edm::ParameterSet& conf)
       thresh_pT.push_back(pset.getParameter<double>("seedingThresholdPt"));
     }
 
-    thresh_pT2.reserve(thresh_pT.size()); for (unsigned int i = 0; i < thresh_pT.size(); ++i) {
+    thresh_pT2.reserve(thresh_pT.size());
+    for (unsigned int i = 0; i < thresh_pT.size(); ++i) {
       thresh_pT2.push_back(thresh_pT[i] * thresh_pT[i]);
     }
 

--- a/RecoParticleFlow/PFProducer/src/MLPFModel.cc
+++ b/RecoParticleFlow/PFProducer/src/MLPFModel.cc
@@ -66,7 +66,7 @@ namespace reco::mlpf {
       charge = ref->charge();
       num_hits = ref->recHitsSize();
 
-      reco::MuonRef muonRef = orig.muonRef();
+      const reco::MuonRef& muonRef = orig.muonRef();
       if (muonRef.isNonnull()) {
         reco::TrackRef standAloneMu = muonRef->standAloneMuon();
         if (standAloneMu.isNonnull()) {

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -790,7 +790,7 @@ bool PFEGammaAlgo::unwrapSuperCluster(const PFSCElement* thesc,
                                                  << " This is a bug we should fix this!" << std::endl;
     return false;
   }
-  reco::SuperClusterRef scref = thesc->superClusterRef();
+  const reco::SuperClusterRef& scref = thesc->superClusterRef();
   const bool is_pf_sc = thesc->fromPFSuperCluster();
   if (!(scref.isAvailable() && scref.isNonnull())) {
     throw cms::Exception("PFEGammaAlgo::unwrapSuperCluster()")

--- a/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
@@ -829,7 +829,7 @@ std::pair<double, double> PFMuonAlgo::getMinMaxMET2(const reco::PFCandidate& pfc
   double METXNO = METX_ - pfc.px();
   double METYNO = METY_ - pfc.py();
   std::vector<double> met2;
-  for (unsigned int i = 0; i < tracks.size(); ++i) {
+  met2.reserve(tracks.size()); for (unsigned int i = 0; i < tracks.size(); ++i) {
     met2.push_back(pow(METXNO + tracks.at(i).first->px(), 2) + pow(METYNO + tracks.at(i).first->py(), 2));
   }
 

--- a/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
@@ -829,7 +829,8 @@ std::pair<double, double> PFMuonAlgo::getMinMaxMET2(const reco::PFCandidate& pfc
   double METXNO = METX_ - pfc.px();
   double METYNO = METY_ - pfc.py();
   std::vector<double> met2;
-  met2.reserve(tracks.size()); for (unsigned int i = 0; i < tracks.size(); ++i) {
+  met2.reserve(tracks.size());
+  for (unsigned int i = 0; i < tracks.size(); ++i) {
     met2.push_back(pow(METXNO + tracks.at(i).first->px(), 2) + pow(METYNO + tracks.at(i).first->py(), 2));
   }
 

--- a/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
@@ -869,8 +869,8 @@ bool PFElecTkProducer::resolveGsfTracks(const vector<reco::GsfPFRecTrack>& GsfPF
 float PFElecTkProducer::minTangDist(const reco::GsfPFRecTrack& primGsf, const reco::GsfPFRecTrack& secGsf) {
   float minDphi = 1000.;
 
-  std::vector<reco::PFBrem> primPFBrem = primGsf.PFRecBrem();
-  std::vector<reco::PFBrem> secPFBrem = secGsf.PFRecBrem();
+  const std::vector<reco::PFBrem>& primPFBrem = primGsf.PFRecBrem();
+  const std::vector<reco::PFBrem>& secPFBrem = secGsf.PFRecBrem();
 
   unsigned int cbrem = 0;
   for (unsigned isbrem = 0; isbrem < secPFBrem.size(); isbrem++) {
@@ -994,7 +994,7 @@ bool PFElecTkProducer::isSharingEcalEnergyWithEgSC(const reco::GsfPFRecTrack& nG
         }
         // check if it touch the Brem-tangents
         else {
-          vector<PFBrem> primPFBrem = gsfPfTrack.PFRecBrem();
+          const vector<PFBrem>& primPFBrem = gsfPfTrack.PFRecBrem();
           for (unsigned ipbrem = 0; ipbrem < primPFBrem.size(); ipbrem++) {
             if (primPFBrem[ipbrem].indTrajPoint() == 99)
               continue;
@@ -1081,7 +1081,7 @@ bool PFElecTkProducer::isSharingEcalEnergyWithEgSC(const reco::GsfPFRecTrack& nG
           iPFCluster.push_back(clust);
           iEnergy += clust.energy();
         } else {
-          vector<PFBrem> primPFBrem = iGsfPFRecTrack.PFRecBrem();
+          const vector<PFBrem>& primPFBrem = iGsfPFRecTrack.PFRecBrem();
           for (unsigned ipbrem = 0; ipbrem < primPFBrem.size(); ipbrem++) {
             if (primPFBrem[ipbrem].indTrajPoint() == 99)
               continue;

--- a/RecoParticleFlow/PFTracking/src/ConvBremPFTrackFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/ConvBremPFTrackFinder.cc
@@ -57,7 +57,7 @@ void ConvBremPFTrackFinder::runConvBremFinder(const Handle<PFRecTrackCollection>
   float refGsfPtMode = refGsf->ptMode();
 
   const reco::PFRecTrackRef& pfTrackRef = gsfpfrectk.kfPFRecTrackRef();
-  vector<PFBrem> primPFBrem = gsfpfrectk.PFRecBrem();
+  const vector<PFBrem>& primPFBrem = gsfpfrectk.PFRecBrem();
 
   const PFRecTrackCollection& PfRTkColl = *(thePfRecTrackCol.product());
   reco::PFRecTrackCollection::const_iterator pft = PfRTkColl.begin();

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
@@ -659,8 +659,8 @@ reco::PFDisplacedVertex::VertexTrackType PFDisplacedVertexFinder::getVertexTrack
 }
 
 unsigned PFDisplacedVertexFinder::commonTracks(const PFDisplacedVertex& v1, const PFDisplacedVertex& v2) const {
-  vector<Track> vt1 = v1.refittedTracks();
-  vector<Track> vt2 = v2.refittedTracks();
+  const vector<Track>& vt1 = v1.refittedTracks();
+  const vector<Track>& vt2 = v2.refittedTracks();
 
   unsigned commonTracks = 0;
 

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexHelper.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexHelper.cc
@@ -214,13 +214,13 @@ reco::PFDisplacedVertex::VertexType PFDisplacedVertexHelper::identifyVertex(cons
 int PFDisplacedVertexHelper::lambdaCP(const PFDisplacedVertex& v) const {
   int lambdaCP = 0;
 
-  vector<Track> refittedTracks = v.refittedTracks();
+  const vector<Track>& refittedTracks = v.refittedTracks();
 
   math::XYZTLorentzVector totalMomentumDcaRefit_lambda;
   math::XYZTLorentzVector totalMomentumDcaRefit_lambdabar;
 
-  reco::Track tMomentumDcaRefit_0 = refittedTracks[0];
-  reco::Track tMomentumDcaRefit_1 = refittedTracks[1];
+  const reco::Track& tMomentumDcaRefit_0 = refittedTracks[0];
+  const reco::Track& tMomentumDcaRefit_1 = refittedTracks[1];
 
   double mass2_0 = 0, mass2_1 = 0;
 

--- a/RecoParticleFlow/PFTracking/src/PFTrackTransformer.cc
+++ b/RecoParticleFlow/PFTracking/src/PFTrackTransformer.cc
@@ -95,7 +95,7 @@ bool PFTrackTransformer::addPoints(reco::PFRecTrack& pftrack,
 
   if (!onlyprop_) {
     bool direction = (traj.direction() == alongMomentum);
-    vector<TrajectoryMeasurement> measurements = traj.measurements();
+    const vector<TrajectoryMeasurement>& measurements = traj.measurements();
     int iTrajFirst = (direction) ? 0 : measurements.size() - 1;
     int increment = (direction) ? +1 : -1;
     int iTrajLast = (direction) ? int(measurements.size()) : -1;
@@ -239,7 +239,7 @@ bool PFTrackTransformer::addPointsAndBrems(reco::GsfPFRecTrack& pftrack,
   // Trajectory for each trajectory point
 
   bool direction = (traj.direction() == alongMomentum);
-  vector<TrajectoryMeasurement> measurements = traj.measurements();
+  const vector<TrajectoryMeasurement>& measurements = traj.measurements();
   int iTrajFirst = (direction) ? 0 : measurements.size() - 1;
   int increment = (direction) ? +1 : -1;
   int iTrajLast = (direction) ? int(measurements.size()) : -1;

--- a/RecoTauTag/HLTProducers/src/L2TauPixelTrackMatch.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauPixelTrackMatch.cc
@@ -75,7 +75,7 @@ void L2TauPixelTrackMatch::produce(edm::StreamID, edm::Event& ev, const edm::Eve
   std::unique_ptr<CaloJetCollection> new_tau_jets(new CaloJetCollection);
   if (!good_tracks.empty())
     for (size_t i = 0; i < n_jets; ++i) {
-      reco::CaloJetRef jet = tau_jets[i];
+      const reco::CaloJetRef& jet = tau_jets[i];
       if (jet->pt() < m_jetMinPt || std::abs(jet->eta()) > m_jetMaxEta)
         continue;
 

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
@@ -148,7 +148,7 @@ namespace reco {
       for (size_t candId = 0; candId < numCands; ++candId) {
         if ((!candFlags[candId]) &&
             candIdsCurrentStrip.find(candId) == candIdsCurrentStrip.end()) {  // do not include same cand twice
-          reco::CandidatePtr cand = cands[candId];
+          const reco::CandidatePtr& cand = cands[candId];
           if (fabs(strip.eta() - cand->eta()) <
                   etaAssociationDistance_ &&  // check if cand is within eta-phi window centered on strip
               fabs(strip.phi() - cand->phi()) < phiAssociationDistance_) {

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin3.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin3.cc
@@ -169,7 +169,7 @@ namespace reco {
       for (size_t candId = 0; candId < numCands; ++candId) {
         if ((!candFlags[candId]) &&
             candIdsCurrentStrip.find(candId) == candIdsCurrentStrip.end()) {  // do not include same cand twice
-          reco::CandidatePtr cand = cands[candId];
+          const reco::CandidatePtr& cand = cands[candId];
           double etaAssociationDistance_value =
               etaAssociationDistance_->Eval(strip.pt()) + etaAssociationDistance_->Eval(cand->pt());
           double phiAssociationDistance_value =

--- a/RecoTracker/DeDx/interface/LikelihoodFitDeDxEstimator.h
+++ b/RecoTracker/DeDx/interface/LikelihoodFitDeDxEstimator.h
@@ -37,7 +37,7 @@ private:
 };
 
 /*****************************************************************************/
-void LikelihoodFitDeDxEstimator::calculate_wrt_epsilon(const reco::DeDxHit& h,
+inline void LikelihoodFitDeDxEstimator::calculate_wrt_epsilon(const reco::DeDxHit& h,
                                                        const double& epsilon,
                                                        std::array<double, 3>& value) {
   const auto& ls = h.pathLength();
@@ -84,7 +84,7 @@ void LikelihoodFitDeDxEstimator::calculate_wrt_epsilon(const reco::DeDxHit& h,
 }
 
 /*****************************************************************************/
-void LikelihoodFitDeDxEstimator::functionEpsilon(const reco::DeDxHitCollection& Hits,
+inline void LikelihoodFitDeDxEstimator::functionEpsilon(const reco::DeDxHitCollection& Hits,
                                                  const double& epsilon,
                                                  std::array<double, 3>& val) {
   val = {{0, 0, 0}};
@@ -93,7 +93,7 @@ void LikelihoodFitDeDxEstimator::functionEpsilon(const reco::DeDxHitCollection& 
 }
 
 /*****************************************************************************/
-double LikelihoodFitDeDxEstimator::minimizeAllSaturated(const reco::DeDxHitCollection& Hits,
+inline double LikelihoodFitDeDxEstimator::minimizeAllSaturated(const reco::DeDxHitCollection& Hits,
                                                         std::array<double, 2>& value) {
   int nStep(0);
   double par(3.0);  // input MeV/cm
@@ -113,7 +113,7 @@ double LikelihoodFitDeDxEstimator::minimizeAllSaturated(const reco::DeDxHitColle
 }
 
 /*****************************************************************************/
-double LikelihoodFitDeDxEstimator::newtonMethodEpsilon(const reco::DeDxHitCollection& Hits,
+inline double LikelihoodFitDeDxEstimator::newtonMethodEpsilon(const reco::DeDxHitCollection& Hits,
                                                        std::array<double, 2>& value) {
   int nStep(0);
   double par(3.0);  // input MeV/cm
@@ -140,7 +140,7 @@ double LikelihoodFitDeDxEstimator::newtonMethodEpsilon(const reco::DeDxHitCollec
 }
 
 /*****************************************************************************/
-double LikelihoodFitDeDxEstimator::estimate(const reco::DeDxHitCollection& Hits, std::array<double, 2>& value) {
+inline double LikelihoodFitDeDxEstimator::estimate(const reco::DeDxHitCollection& Hits, std::array<double, 2>& value) {
   // use newton method if at least one hit is not saturated
   for (const auto& h : Hits)
     if (h.rawDetId() == 0)

--- a/RecoTracker/DeDx/interface/LikelihoodFitDeDxEstimator.h
+++ b/RecoTracker/DeDx/interface/LikelihoodFitDeDxEstimator.h
@@ -38,8 +38,8 @@ private:
 
 /*****************************************************************************/
 inline void LikelihoodFitDeDxEstimator::calculate_wrt_epsilon(const reco::DeDxHit& h,
-                                                       const double& epsilon,
-                                                       std::array<double, 3>& value) {
+                                                              const double& epsilon,
+                                                              std::array<double, 3>& value) {
   const auto& ls = h.pathLength();
   const auto& sn = h.error();      // energy sigma
   const auto y = h.charge() * ls;  // = g * y
@@ -85,8 +85,8 @@ inline void LikelihoodFitDeDxEstimator::calculate_wrt_epsilon(const reco::DeDxHi
 
 /*****************************************************************************/
 inline void LikelihoodFitDeDxEstimator::functionEpsilon(const reco::DeDxHitCollection& Hits,
-                                                 const double& epsilon,
-                                                 std::array<double, 3>& val) {
+                                                        const double& epsilon,
+                                                        std::array<double, 3>& val) {
   val = {{0, 0, 0}};
   for (const auto& h : Hits)
     calculate_wrt_epsilon(h, epsilon, val);
@@ -94,7 +94,7 @@ inline void LikelihoodFitDeDxEstimator::functionEpsilon(const reco::DeDxHitColle
 
 /*****************************************************************************/
 inline double LikelihoodFitDeDxEstimator::minimizeAllSaturated(const reco::DeDxHitCollection& Hits,
-                                                        std::array<double, 2>& value) {
+                                                               std::array<double, 2>& value) {
   int nStep(0);
   double par(3.0);  // input MeV/cm
 
@@ -114,7 +114,7 @@ inline double LikelihoodFitDeDxEstimator::minimizeAllSaturated(const reco::DeDxH
 
 /*****************************************************************************/
 inline double LikelihoodFitDeDxEstimator::newtonMethodEpsilon(const reco::DeDxHitCollection& Hits,
-                                                       std::array<double, 2>& value) {
+                                                              std::array<double, 2>& value) {
   int nStep(0);
   double par(3.0);  // input MeV/cm
   double dpar(0);

--- a/RecoTracker/DeDx/src/DeDxTools.cc
+++ b/RecoTracker/DeDx/src/DeDxTools.cc
@@ -432,7 +432,7 @@ namespace deDxTools {
     LocalPoint HitLocalPos = trajState.localPosition();
     LocalError HitLocalError = trajState.localError().positionError();
 
-    const BoundPlane plane = it->surface();
+    const BoundPlane& plane = it->surface();
     const TrapezoidalPlaneBounds* trapezoidalBounds(dynamic_cast<const TrapezoidalPlaneBounds*>(&(plane.bounds())));
     const RectangularPlaneBounds* rectangularBounds(dynamic_cast<const RectangularPlaneBounds*>(&(plane.bounds())));
 

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
@@ -572,7 +572,7 @@ namespace reco {
     }
 
     bool TrackerTrackHitFilter::isFirstValidHitInLayer(const reco::Track &tk, std::vector<bool> isNotValidVec) {
-      reco::HitPattern hp = tk.hitPattern();
+      const reco::HitPattern& hp = tk.hitPattern();
 
       int vecSize = static_cast<int>(isNotValidVec.size());
       // If hit is not valid, it will not count as a tracker layer with measurement -> don't increase sequLayers

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
@@ -572,7 +572,7 @@ namespace reco {
     }
 
     bool TrackerTrackHitFilter::isFirstValidHitInLayer(const reco::Track &tk, std::vector<bool> isNotValidVec) {
-      const reco::HitPattern& hp = tk.hitPattern();
+      const reco::HitPattern &hp = tk.hitPattern();
 
       int vecSize = static_cast<int>(isNotValidVec.size());
       // If hit is not valid, it will not count as a tracker layer with measurement -> don't increase sequLayers

--- a/RecoTracker/PixelTrackFitting/src/PixelTrackBuilder.cc
+++ b/RecoTracker/PixelTrackFitting/src/PixelTrackBuilder.cc
@@ -70,7 +70,7 @@ namespace {
     float phi_v = state.globalMomentum().phi();
     float theta_v = state.globalMomentum().theta();
 
-    CurvilinearTrajectoryError curv = state.curvilinearError();
+    const CurvilinearTrajectoryError& curv = state.curvilinearError();
     float errPhi2 = curv.matrix()(3, 3);
     float errLambda2 = curv.matrix()(2, 2);
     float errInvP2 = curv.matrix()(1, 1);

--- a/RecoTracker/SingleTrackPattern/src/CRackTrajectoryBuilder.cc
+++ b/RecoTracker/SingleTrackPattern/src/CRackTrajectoryBuilder.cc
@@ -794,7 +794,7 @@ std::pair<TrajectoryStateOnSurface, const GeomDet*> CRackTrajectoryBuilder::inne
   if (nhits < lastFitted + 1)
     lastFitted = nhits - 1;
 
-  std::vector<TrajectoryMeasurement> measvec = traj.measurements();
+  const std::vector<TrajectoryMeasurement>& measvec = traj.measurements();
   TransientTrackingRecHit::ConstRecHitContainer firstHits;
 
   bool foundLast = false;

--- a/RecoTracker/SpecialSeedGenerators/src/SeedFromGenericPairOrTriplet.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/SeedFromGenericPairOrTriplet.cc
@@ -295,7 +295,8 @@ bool SeedFromGenericPairOrTriplet::qualityFilter(const SeedingHitSet& hits) cons
     if (hits.size() == 3) {
       std::vector<GlobalPoint> gPoints;
       unsigned int nHits = hits.size();
-      gPoints.reserve(nHits); for (unsigned int iHit = 0; iHit < nHits; ++iHit)
+      gPoints.reserve(nHits);
+      for (unsigned int iHit = 0; iHit < nHits; ++iHit)
         gPoints.push_back(hits[iHit]->globalPosition());
       unsigned int subid = (*hits[0]).geographicalId().subdetId();
       if (subid == StripSubdetector::TEC || subid == StripSubdetector::TID) {

--- a/RecoTracker/SpecialSeedGenerators/src/SeedFromGenericPairOrTriplet.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/SeedFromGenericPairOrTriplet.cc
@@ -295,7 +295,7 @@ bool SeedFromGenericPairOrTriplet::qualityFilter(const SeedingHitSet& hits) cons
     if (hits.size() == 3) {
       std::vector<GlobalPoint> gPoints;
       unsigned int nHits = hits.size();
-      for (unsigned int iHit = 0; iHit < nHits; ++iHit)
+      gPoints.reserve(nHits); for (unsigned int iHit = 0; iHit < nHits; ++iHit)
         gPoints.push_back(hits[iHit]->globalPosition());
       unsigned int subid = (*hits[0]).geographicalId().subdetId();
       if (subid == StripSubdetector::TEC || subid == StripSubdetector::TID) {

--- a/RecoTracker/TkDetLayers/src/PixelBarrelLayerBuilder.cc
+++ b/RecoTracker/TkDetLayers/src/PixelBarrelLayerBuilder.cc
@@ -9,7 +9,7 @@ PixelBarrelLayer* PixelBarrelLayerBuilder::build(const GeometricDet* aPixelBarre
   // This builder is very similar to TOBLayer one. Most of the code should be put in a
   // common place.
 
-  vector<const GeometricDet*> theGeometricDetRods = aPixelBarrelLayer->components();
+  const vector<const GeometricDet*>& theGeometricDetRods = aPixelBarrelLayer->components();
   //edm::LogInfo(TkDetLayers) << "theGeometricDetRods has size: " << theGeometricDetRods.size() ;
 
   PixelRodBuilder myPixelRodBuilder;

--- a/RecoTracker/TkDetLayers/src/PixelForwardLayerBuilder.h
+++ b/RecoTracker/TkDetLayers/src/PixelForwardLayerBuilder.h
@@ -27,7 +27,7 @@ public:
 template <class T1, class T2>
 ForwardDetLayer* PixelForwardLayerBuilder<T1, T2>::build(const GeometricDet* aPixelForwardLayer,
                                                          const TrackerGeometry* theGeomDetGeometry) {
-  std::vector<const GeometricDet*> theGeometricPanels = aPixelForwardLayer->components();
+  const std::vector<const GeometricDet*>& theGeometricPanels = aPixelForwardLayer->components();
   int panelsSize = theGeometricPanels.size();
 
   /*

--- a/RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc
@@ -250,7 +250,7 @@ void DeepCoreSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& i
           }
         }  //end of TensorFlow tensors init
 
-        GlobalVector bigClustDir = splitClustDirSet[cc];
+        const GlobalVector& bigClustDir = splitClustDirSet[cc];
 
         jetEta_ = jet.eta();
         jetPt_ = jet.pt();

--- a/RecoTracker/TrackProducer/src/DAFTrackProducerAlgorithm.cc
+++ b/RecoTracker/TrackProducer/src/DAFTrackProducerAlgorithm.cc
@@ -396,7 +396,7 @@ float DAFTrackProducerAlgorithm::calculateNdof(const Trajectory vtraj) const {
 //------------------------------------------------------------------------------------------------
 int DAFTrackProducerAlgorithm::checkHits(Trajectory iInitTraj, const Trajectory iFinalTraj) const {
   std::vector<TrajectoryMeasurement> initmeasurements = iInitTraj.measurements();
-  std::vector<TrajectoryMeasurement> finalmeasurements = iFinalTraj.measurements();
+  const std::vector<TrajectoryMeasurement>& finalmeasurements = iFinalTraj.measurements();
   std::vector<TrajectoryMeasurement>::iterator jmeas;
   int nSame = 0;
   int ihit = 0;
@@ -419,7 +419,7 @@ int DAFTrackProducerAlgorithm::checkHits(Trajectory iInitTraj, const Trajectory 
       continue;
 
     if (initHit->isValid()) {
-      TrajectoryMeasurement imeas = finalmeasurements.at(ihit);
+      const TrajectoryMeasurement& imeas = finalmeasurements.at(ihit);
       const TrackingRecHit* finalHit = imeas.recHit()->hit();
       const TrackingRecHit* MaxWeightHit = nullptr;
       float maxweight = 0;
@@ -458,7 +458,7 @@ int DAFTrackProducerAlgorithm::checkHits(Trajectory iInitTraj, const Trajectory 
         }
       }
     } else {
-      TrajectoryMeasurement imeas = finalmeasurements.at(ihit);
+      const TrajectoryMeasurement& imeas = finalmeasurements.at(ihit);
       const TrackingRecHit* finalHit = imeas.recHit()->hit();
       if (!finalHit->isValid()) {
         nSame++;

--- a/RecoVertex/KinematicFit/plugins/KineExample.cc
+++ b/RecoVertex/KinematicFit/plugins/KineExample.cc
@@ -157,10 +157,10 @@ void KineExample::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
         else
           edm::LogPrint("KineExample") << "KVF fit Position: " << Vertex::Point(tv.position()) << "\n";
 
-        TransientTrack ttMuPlus = t_tks[0];
-        TransientTrack ttMuMinus = t_tks[1];
-        TransientTrack ttKPlus = t_tks[2];
-        TransientTrack ttKMinus = t_tks[3];
+        const TransientTrack& ttMuPlus = t_tks[0];
+        const TransientTrack& ttMuMinus = t_tks[1];
+        const TransientTrack& ttKPlus = t_tks[2];
+        const TransientTrack& ttKMinus = t_tks[3];
 
         //the final state muons and kaons from the Bs->J/PsiPhi->mumuKK decay
         //Creating a KinematicParticleFactory

--- a/RecoVertex/LinearizationPointFinders/src/CrossingPtBasedLinearizationPointFinder.cc
+++ b/RecoVertex/LinearizationPointFinders/src/CrossingPtBasedLinearizationPointFinder.cc
@@ -233,8 +233,8 @@ GlobalPoint CrossingPtBasedLinearizationPointFinder::getLinearizationPoint(
   bool dir = false;
 
   while (vgp.size() < ((unsigned int)(theNPairs))) {
-    reco::TransientTrack rt1 = goodtracks[t_first];
-    reco::TransientTrack rt2 = goodtracks[t_first + t_interval];
+    const reco::TransientTrack& rt1 = goodtracks[t_first];
+    const reco::TransientTrack& rt2 = goodtracks[t_first + t_interval];
     // std::cout << "Considering now: " << t_first << ", " << t_first+t_interval << std::endl;
     if (useMatrix) {
       PointAndDistance v(theMatrix->crossingPoint(rt1, rt2), theMatrix->distance(rt1, rt2));

--- a/RecoVertex/PrimaryVertexProducer/src/AdaptiveChisquarePrimaryVertexFitter.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/AdaptiveChisquarePrimaryVertexFitter.cc
@@ -515,7 +515,7 @@ TransientVertex AdaptiveChisquarePrimaryVertexFitter::refit(const TransientVerte
 
   // put the result into a transient vertex
   std::vector<std::pair<unsigned int, float>> vertex_track_weights;
-  for (unsigned int i = 0; i < nt; i++) {
+  vertex_track_weights.reserve(nt); for (unsigned int i = 0; i < nt; i++) {
     vertex_track_weights.emplace_back(i, tkweight_[i]);
   }
 

--- a/RecoVertex/PrimaryVertexProducer/src/AdaptiveChisquarePrimaryVertexFitter.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/AdaptiveChisquarePrimaryVertexFitter.cc
@@ -515,7 +515,8 @@ TransientVertex AdaptiveChisquarePrimaryVertexFitter::refit(const TransientVerte
 
   // put the result into a transient vertex
   std::vector<std::pair<unsigned int, float>> vertex_track_weights;
-  vertex_track_weights.reserve(nt); for (unsigned int i = 0; i < nt; i++) {
+  vertex_track_weights.reserve(nt);
+  for (unsigned int i = 0; i < nt; i++) {
     vertex_track_weights.emplace_back(i, tkweight_[i]);
   }
 

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -937,7 +937,7 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices_no_blocks(const vector<r
 vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<reco::TransientTrack>& tracks) const {
   vector<reco::TransientTrack> sorted_tracks;
   vector<pair<float, float>> vertices_tot;  // z, rho for each vertex
-  for (unsigned int i = 0; i < tracks.size(); i++) {
+  sorted_tracks.reserve(tracks.size()); for (unsigned int i = 0; i < tracks.size(); i++) {
     sorted_tracks.push_back(tracks[i]);
   }
   double rho0, beta;

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -937,7 +937,8 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices_no_blocks(const vector<r
 vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<reco::TransientTrack>& tracks) const {
   vector<reco::TransientTrack> sorted_tracks;
   vector<pair<float, float>> vertices_tot;  // z, rho for each vertex
-  sorted_tracks.reserve(tracks.size()); for (unsigned int i = 0; i < tracks.size(); i++) {
+  sorted_tracks.reserve(tracks.size());
+  for (unsigned int i = 0; i < tracks.size(); i++) {
     sorted_tracks.push_back(tracks[i]);
   }
   double rho0, beta;

--- a/RecoVertex/VertexTools/interface/Lms3d.h
+++ b/RecoVertex/VertexTools/interface/Lms3d.h
@@ -14,7 +14,7 @@ public:
   virtual GlobalPoint operator()(std::vector<GlobalPoint>& values) const;
 
 private:
-  virtual GlobalPoint operator()(const std::vector<PointAndDistance>&) const = 0;
+  GlobalPoint operator()(const std::vector<PointAndDistance>&) const override = 0;
 };
 
 #endif

--- a/SimCalorimetry/HGCalSimAlgos/src/HGCalECONDEmulatorParameters.cc
+++ b/SimCalorimetry/HGCalSimAlgos/src/HGCalECONDEmulatorParameters.cc
@@ -41,7 +41,7 @@ edm::ParameterSetDescription EmulatorParameters::description() {
   {  // list the enabled eRxs in all ECON-Ds
     const unsigned int max_erxs_per_econd = 12;
     std::vector<unsigned int> default_enabled_erxs;
-    for (size_t i = 0; i < max_erxs_per_econd; ++i)
+    default_enabled_erxs.reserve(max_erxs_per_econd); for (size_t i = 0; i < max_erxs_per_econd; ++i)
       default_enabled_erxs.emplace_back(i);
     desc.add<std::vector<unsigned int> >("enabledERxs", default_enabled_erxs)
         ->setComment("list of channels to be enabled in readout");

--- a/SimCalorimetry/HGCalSimAlgos/src/HGCalECONDEmulatorParameters.cc
+++ b/SimCalorimetry/HGCalSimAlgos/src/HGCalECONDEmulatorParameters.cc
@@ -41,7 +41,8 @@ edm::ParameterSetDescription EmulatorParameters::description() {
   {  // list the enabled eRxs in all ECON-Ds
     const unsigned int max_erxs_per_econd = 12;
     std::vector<unsigned int> default_enabled_erxs;
-    default_enabled_erxs.reserve(max_erxs_per_econd); for (size_t i = 0; i < max_erxs_per_econd; ++i)
+    default_enabled_erxs.reserve(max_erxs_per_econd);
+    for (size_t i = 0; i < max_erxs_per_econd; ++i)
       default_enabled_erxs.emplace_back(i);
     desc.add<std::vector<unsigned int> >("enabledERxs", default_enabled_erxs)
         ->setComment("list of channels to be enabled in readout");

--- a/SimDataFormats/CaloAnalysis/interface/CaloParticle.h
+++ b/SimDataFormats/CaloAnalysis/interface/CaloParticle.h
@@ -177,7 +177,8 @@ public:
   /** @brief Returns list of rechit IDs and fractions for this CaloParticle */
   std::vector<std::pair<uint32_t, float>> hits_and_fractions() const {
     std::vector<std::pair<uint32_t, float>> result;
-    result.reserve(hits_.size()); for (size_t i = 0; i < hits_.size(); ++i) {
+    result.reserve(hits_.size());
+    for (size_t i = 0; i < hits_.size(); ++i) {
       result.emplace_back(hits_[i], fractions_[i]);
     }
     return result;

--- a/SimDataFormats/CaloAnalysis/interface/CaloParticle.h
+++ b/SimDataFormats/CaloAnalysis/interface/CaloParticle.h
@@ -177,7 +177,7 @@ public:
   /** @brief Returns list of rechit IDs and fractions for this CaloParticle */
   std::vector<std::pair<uint32_t, float>> hits_and_fractions() const {
     std::vector<std::pair<uint32_t, float>> result;
-    for (size_t i = 0; i < hits_.size(); ++i) {
+    result.reserve(hits_.size()); for (size_t i = 0; i < hits_.size(); ++i) {
       result.emplace_back(hits_[i], fractions_[i]);
     }
     return result;

--- a/SimDataFormats/CaloAnalysis/interface/SimCluster.h
+++ b/SimDataFormats/CaloAnalysis/interface/SimCluster.h
@@ -188,7 +188,7 @@ public:
   /** @brief Returns list of rechit IDs and fractions for this SimCluster */
   std::vector<std::pair<uint32_t, float>> hits_and_fractions() const {
     std::vector<std::pair<uint32_t, float>> result;
-    for (size_t i = 0; i < hits_.size(); ++i) {
+    result.reserve(hits_.size()); for (size_t i = 0; i < hits_.size(); ++i) {
       result.emplace_back(hits_[i], fractions_[i]);
     }
     return result;

--- a/SimDataFormats/CaloAnalysis/interface/SimCluster.h
+++ b/SimDataFormats/CaloAnalysis/interface/SimCluster.h
@@ -188,7 +188,8 @@ public:
   /** @brief Returns list of rechit IDs and fractions for this SimCluster */
   std::vector<std::pair<uint32_t, float>> hits_and_fractions() const {
     std::vector<std::pair<uint32_t, float>> result;
-    result.reserve(hits_.size()); for (size_t i = 0; i < hits_.size(); ++i) {
+    result.reserve(hits_.size());
+    for (size_t i = 0; i < hits_.size(); ++i) {
       result.emplace_back(hits_[i], fractions_[i]);
     }
     return result;

--- a/SimG4Core/CustomPhysics/src/CustomProcessHelper.cc
+++ b/SimG4Core/CustomPhysics/src/CustomProcessHelper.cc
@@ -70,7 +70,7 @@ CustomProcessHelper::CustomProcessHelper(const edm::ParameterSet& p, CustomParti
     // Making a ReactionProduct
     ReactionProduct prod;
     for (std::size_t i = 2; i != tokens.size(); i++) {
-      G4String part = tokens[i];
+      const G4String& part = tokens[i];
       if (particleTable->contains(part)) {
         prod.push_back(particleTable->FindParticle(part)->GetPDGEncoding());
       } else {

--- a/SimG4Core/CustomPhysics/src/HadronicProcessHelper.cc
+++ b/SimG4Core/CustomPhysics/src/HadronicProcessHelper.cc
@@ -40,7 +40,7 @@ HadronicProcessHelper::HadronicProcessHelper(const std::string& fileName) {
     // Making a ReactionProduct
     ReactionProduct prod;
     for (size_t i = 2; i != tokens.size(); i++) {
-      G4String part = tokens[i];
+      const G4String& part = tokens[i];
       if (m_particleTable->contains(part)) {
         prod.push_back(m_particleTable->FindParticle(part)->GetPDGEncoding());
       } else {

--- a/SimG4Core/Geometry/src/DDG4Builder.cc
+++ b/SimG4Core/Geometry/src/DDG4Builder.cc
@@ -198,7 +198,7 @@ int DDG4Builder::getInt(const std::string &ss, const DDLogicalPart &part) {
       break;
   }
   if (foundIt) {
-    std::vector<double> temp = val.doubles();
+    const std::vector<double>& temp = val.doubles();
     if (temp.size() != 1) {
       throw cms::Exception("SimG4CoreGeometry",
                            " DDG4Builder::getInt() Problem with Region tags - "
@@ -220,7 +220,7 @@ double DDG4Builder::getDouble(const std::string &ss, const DDLogicalPart &part) 
       break;
   }
   if (foundIt) {
-    std::vector<std::string> temp = val.strings();
+    const std::vector<std::string>& temp = val.strings();
     if (temp.size() != 1) {
       throw cms::Exception("SimG4CoreGeometry",
                            " DDG4Builder::getDouble() Problem with Region tags "

--- a/SimG4Core/Geometry/src/DDG4Builder.cc
+++ b/SimG4Core/Geometry/src/DDG4Builder.cc
@@ -198,7 +198,7 @@ int DDG4Builder::getInt(const std::string &ss, const DDLogicalPart &part) {
       break;
   }
   if (foundIt) {
-    const std::vector<double>& temp = val.doubles();
+    const std::vector<double> &temp = val.doubles();
     if (temp.size() != 1) {
       throw cms::Exception("SimG4CoreGeometry",
                            " DDG4Builder::getInt() Problem with Region tags - "
@@ -220,7 +220,7 @@ double DDG4Builder::getDouble(const std::string &ss, const DDLogicalPart &part) 
       break;
   }
   if (foundIt) {
-    const std::vector<std::string>& temp = val.strings();
+    const std::vector<std::string> &temp = val.strings();
     if (temp.size() != 1) {
       throw cms::Exception("SimG4CoreGeometry",
                            " DDG4Builder::getDouble() Problem with Region tags "

--- a/SimG4Core/Geometry/src/DDG4SolidConverter.cc
+++ b/SimG4Core/Geometry/src/DDG4SolidConverter.cc
@@ -249,9 +249,11 @@ G4VSolid *DDG4SolidConverter::extrudedpolygon(const DDSolid &solid) {
 
   std::vector<G4TwoVector> polygon;
   std::vector<G4ExtrudedSolid::ZSection> zsections;
-  polygon.reserve(x.size()); for (unsigned int it = 0; it < x.size(); ++it)
+  polygon.reserve(x.size());
+  for (unsigned int it = 0; it < x.size(); ++it)
     polygon.emplace_back(x[it], y[it]);
-  zsections.reserve(z.size()); for (unsigned int it = 0; it < z.size(); ++it)
+  zsections.reserve(z.size());
+  for (unsigned int it = 0; it < z.size(); ++it)
     zsections.emplace_back(z[it], G4TwoVector(zx[it], zy[it]), zs[it]);
   return new G4ExtrudedSolid(solid.name().name(), polygon, zsections);
 }

--- a/SimG4Core/Geometry/src/DDG4SolidConverter.cc
+++ b/SimG4Core/Geometry/src/DDG4SolidConverter.cc
@@ -249,9 +249,9 @@ G4VSolid *DDG4SolidConverter::extrudedpolygon(const DDSolid &solid) {
 
   std::vector<G4TwoVector> polygon;
   std::vector<G4ExtrudedSolid::ZSection> zsections;
-  for (unsigned int it = 0; it < x.size(); ++it)
+  polygon.reserve(x.size()); for (unsigned int it = 0; it < x.size(); ++it)
     polygon.emplace_back(x[it], y[it]);
-  for (unsigned int it = 0; it < z.size(); ++it)
+  zsections.reserve(z.size()); for (unsigned int it = 0; it < z.size(); ++it)
     zsections.emplace_back(z[it], G4TwoVector(zx[it], zy[it]), zs[it]);
   return new G4ExtrudedSolid(solid.name().name(), polygon, zsections);
 }

--- a/SimG4Core/Notification/src/TrackWithHistory.cc
+++ b/SimG4Core/Notification/src/TrackWithHistory.cc
@@ -21,7 +21,7 @@ TrackWithHistory::TrackWithHistory(const G4Track* g4trk, int pID) {
   auto mom = g4trk->GetMomentum();
   momentum_ = math::XYZVectorD(mom.x(), mom.y(), mom.z());
   totalEnergy_ = g4trk->GetTotalEnergy();
-  auto pos = g4trk->GetPosition();
+  const auto& pos = g4trk->GetPosition();
   vertexPosition_ = math::XYZVectorD(pos.x(), pos.y(), pos.z());
   time_ = g4trk->GetGlobalTime();
   auto p = g4trk->GetCreatorProcess();

--- a/SimG4Core/PhysicsLists/src/MonopoleTransportation.cc
+++ b/SimG4Core/PhysicsLists/src/MonopoleTransportation.cc
@@ -124,7 +124,7 @@ G4double MonopoleTransportation::AlongStepGetPhysicalInteractionLength(const G4T
   //
   const G4DynamicParticle* pParticle = track.GetDynamicParticle();
   const G4ThreeVector& startMomentumDir = pParticle->GetMomentumDirection();
-  G4ThreeVector startPosition = track.GetPosition();
+  const G4ThreeVector& startPosition = track.GetPosition();
 
   // The Step Point safety can be limited by other geometries and/or the
   // assumptions of any process - it's not always the geometrical safety.
@@ -233,7 +233,7 @@ G4double MonopoleTransportation::AlongStepGetPhysicalInteractionLength(const G4T
                                             restMass);
     // SetChargeMomentumMass now passes both the electric and magnetic charge - in chargeState
 
-    G4ThreeVector spin = track.GetPolarization();
+    const G4ThreeVector& spin = track.GetPolarization();
     G4FieldTrack aFieldTrack = G4FieldTrack(startPosition,
                                             track.GetMomentumDirection(),
                                             0.0,

--- a/SimGeneral/MixingModule/plugins/HiMixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/HiMixingModule.cc
@@ -187,7 +187,7 @@ namespace edm {
 
       std::string signal;
       for (size_t itag = 0; itag < tags.size(); ++itag) {
-        InputTag tag = tags[itag];
+        const InputTag& tag = tags[itag];
         std::vector<InputTag> inputs;
 
         for (size_t input = 0; input < simtags.size(); ++input) {

--- a/SimTracker/TrackerMaterialAnalysis/plugins/XHistogram.h
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/XHistogram.h
@@ -57,11 +57,13 @@ public:
         m_colormap() {
     // setup unnamed ROOT histograms
     for (size_t i = 0; i < m_size; ++i) {
-      m_histograms[i] = std::make_shared<Histogram>(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second);
+      m_histograms[i] =
+          std::make_shared<Histogram>(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second);
       m_histograms[i]->SetMinimum(0.);
       m_histograms[i]->SetMaximum(max[i]);
     }
-    m_normalization = std::make_shared<Histogram>(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second);
+    m_normalization =
+        std::make_shared<Histogram>(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second);
     m_colormap = std::make_shared<ColorMap>(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second);
     m_colormap->SetMinimum(0);
     m_colormap->SetMaximum(zones);

--- a/SimTracker/TrackerMaterialAnalysis/plugins/XHistogram.h
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/XHistogram.h
@@ -2,6 +2,7 @@
 #define XHistogram_h
 
 #include <algorithm>
+#include <memory>
 #include <vector>
 #include <iostream>
 #include <stdexcept>
@@ -56,12 +57,12 @@ public:
         m_colormap() {
     // setup unnamed ROOT histograms
     for (size_t i = 0; i < m_size; ++i) {
-      m_histograms[i].reset(new Histogram(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second));
+      m_histograms[i] = std::make_shared<Histogram>(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second);
       m_histograms[i]->SetMinimum(0.);
       m_histograms[i]->SetMaximum(max[i]);
     }
-    m_normalization.reset(new Histogram(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second));
-    m_colormap.reset(new ColorMap(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second));
+    m_normalization = std::make_shared<Histogram>(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second);
+    m_colormap = std::make_shared<ColorMap>(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second);
     m_colormap->SetMinimum(0);
     m_colormap->SetMaximum(zones);
     Histogram(nullptr, nullptr, 0, 0., 0., 0, 0., 0.);  // make ROOT "forget" about unnamed histograms

--- a/SimTracker/TrackerMaterialAnalysis/plugins/dd4hep/DD4hep_XHistogram.h
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/dd4hep/DD4hep_XHistogram.h
@@ -58,11 +58,13 @@ public:
         m_colormap() {
     // setup unnamed ROOT histograms
     for (size_t i = 0; i < m_size; ++i) {
-      m_histograms[i] = std::make_shared<Histogram>(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second);
+      m_histograms[i] =
+          std::make_shared<Histogram>(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second);
       m_histograms[i]->SetMinimum(0.);
       m_histograms[i]->SetMaximum(max[i]);
     }
-    m_normalization = std::make_shared<Histogram>(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second);
+    m_normalization =
+        std::make_shared<Histogram>(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second);
     m_colormap = std::make_shared<ColorMap>(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second);
     m_colormap->SetMinimum(0);
     m_colormap->SetMaximum(zones);

--- a/SimTracker/TrackerMaterialAnalysis/plugins/dd4hep/DD4hep_XHistogram.h
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/dd4hep/DD4hep_XHistogram.h
@@ -2,6 +2,7 @@
 #define DD4hep_XHistogram_h
 
 #include <algorithm>
+#include <memory>
 #include <vector>
 #include <iostream>
 #include <stdexcept>
@@ -57,12 +58,12 @@ public:
         m_colormap() {
     // setup unnamed ROOT histograms
     for (size_t i = 0; i < m_size; ++i) {
-      m_histograms[i].reset(new Histogram(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second));
+      m_histograms[i] = std::make_shared<Histogram>(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second);
       m_histograms[i]->SetMinimum(0.);
       m_histograms[i]->SetMaximum(max[i]);
     }
-    m_normalization.reset(new Histogram(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second));
-    m_colormap.reset(new ColorMap(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second));
+    m_normalization = std::make_shared<Histogram>(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second);
+    m_colormap = std::make_shared<ColorMap>(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second);
     m_colormap->SetMinimum(0);
     m_colormap->SetMaximum(zones);
     Histogram(nullptr, nullptr, 0, 0., 0., 0, 0., 0.);  // make ROOT "forget" about unnamed histograms

--- a/TopQuarkAnalysis/TopEventProducers/src/TtSemiEvtSolutionMaker.cc
+++ b/TopQuarkAnalysis/TopEventProducers/src/TtSemiEvtSolutionMaker.cc
@@ -376,7 +376,7 @@ TtSemiLepKinFitter::Constraint TtSemiEvtSolutionMaker::constraint(unsigned val) 
 
 std::vector<TtSemiLepKinFitter::Constraint> TtSemiEvtSolutionMaker::constraints(std::vector<unsigned>& val) {
   std::vector<TtSemiLepKinFitter::Constraint> result;
-  for (unsigned i = 0; i < val.size(); ++i) {
+  result.reserve(val.size()); for (unsigned i = 0; i < val.size(); ++i) {
     result.push_back(constraint(val[i]));
   }
   return result;

--- a/TopQuarkAnalysis/TopEventProducers/src/TtSemiEvtSolutionMaker.cc
+++ b/TopQuarkAnalysis/TopEventProducers/src/TtSemiEvtSolutionMaker.cc
@@ -376,7 +376,8 @@ TtSemiLepKinFitter::Constraint TtSemiEvtSolutionMaker::constraint(unsigned val) 
 
 std::vector<TtSemiLepKinFitter::Constraint> TtSemiEvtSolutionMaker::constraints(std::vector<unsigned>& val) {
   std::vector<TtSemiLepKinFitter::Constraint> result;
-  result.reserve(val.size()); for (unsigned i = 0; i < val.size(); ++i) {
+  result.reserve(val.size());
+  for (unsigned i = 0; i < val.size(); ++i) {
     result.push_back(constraint(val[i]));
   }
   return result;

--- a/TopQuarkAnalysis/TopHitFit/plugins/TtSemiLepHitFitProducer.cc
+++ b/TopQuarkAnalysis/TopHitFit/plugins/TtSemiLepHitFitProducer.cc
@@ -253,7 +253,7 @@ void TtSemiLepHitFitProducer<LeptonCollection>::produce(edm::Event& evt, const e
     pNeutrinos->push_back(pat::Particle());
     // indices referring to the jet combination
     std::vector<int> invalidCombi;
-    for (unsigned int i = 0; i < nPartons; ++i)
+    invalidCombi.reserve(nPartons); for (unsigned int i = 0; i < nPartons; ++i)
       invalidCombi.push_back(-1);
     pCombi->push_back(invalidCombi);
     // chi2
@@ -420,7 +420,7 @@ void TtSemiLepHitFitProducer<LeptonCollection>::produce(edm::Event& evt, const e
     pNeutrinos->push_back(pat::Particle());
     // indices referring to the jet combination
     std::vector<int> invalidCombi;
-    for (unsigned int i = 0; i < nPartons; ++i)
+    invalidCombi.reserve(nPartons); for (unsigned int i = 0; i < nPartons; ++i)
       invalidCombi.push_back(-1);
     pCombi->push_back(invalidCombi);
     // chi2

--- a/TopQuarkAnalysis/TopHitFit/plugins/TtSemiLepHitFitProducer.cc
+++ b/TopQuarkAnalysis/TopHitFit/plugins/TtSemiLepHitFitProducer.cc
@@ -253,7 +253,8 @@ void TtSemiLepHitFitProducer<LeptonCollection>::produce(edm::Event& evt, const e
     pNeutrinos->push_back(pat::Particle());
     // indices referring to the jet combination
     std::vector<int> invalidCombi;
-    invalidCombi.reserve(nPartons); for (unsigned int i = 0; i < nPartons; ++i)
+    invalidCombi.reserve(nPartons);
+    for (unsigned int i = 0; i < nPartons; ++i)
       invalidCombi.push_back(-1);
     pCombi->push_back(invalidCombi);
     // chi2
@@ -420,7 +421,8 @@ void TtSemiLepHitFitProducer<LeptonCollection>::produce(edm::Event& evt, const e
     pNeutrinos->push_back(pat::Particle());
     // indices referring to the jet combination
     std::vector<int> invalidCombi;
-    invalidCombi.reserve(nPartons); for (unsigned int i = 0; i < nPartons; ++i)
+    invalidCombi.reserve(nPartons);
+    for (unsigned int i = 0; i < nPartons; ++i)
       invalidCombi.push_back(-1);
     pCombi->push_back(invalidCombi);
     // chi2

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombGeom.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombGeom.cc
@@ -51,7 +51,8 @@ void TtSemiLepJetCombGeom::produce(edm::StreamID, edm::Event& evt, const edm::Ev
   auto pJetsConsidered = std::make_unique<int>(0);
 
   std::vector<int> match;
-  match.reserve(4); for (unsigned int i = 0; i < 4; ++i)
+  match.reserve(4);
+  for (unsigned int i = 0; i < 4; ++i)
     match.push_back(-1);
 
   // get jets

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombGeom.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombGeom.cc
@@ -51,7 +51,7 @@ void TtSemiLepJetCombGeom::produce(edm::StreamID, edm::Event& evt, const edm::Ev
   auto pJetsConsidered = std::make_unique<int>(0);
 
   std::vector<int> match;
-  for (unsigned int i = 0; i < 4; ++i)
+  match.reserve(4); for (unsigned int i = 0; i < 4; ++i)
     match.push_back(-1);
 
   // get jets

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.cc
@@ -47,7 +47,8 @@ void TtSemiLepJetCombMVAComputer::produce(edm::Event& evt, const edm::EventSetup
   // empty METs vector or less jets than partons
   if (leptons->empty() || mets->empty() || jets->size() < nPartons) {
     std::vector<int> invalidCombi;
-    invalidCombi.reserve(nPartons); for (unsigned int i = 0; i < nPartons; ++i)
+    invalidCombi.reserve(nPartons);
+    for (unsigned int i = 0; i < nPartons; ++i)
       invalidCombi.push_back(-1);
     pOut->push_back(invalidCombi);
     evt.put(std::move(pOut));
@@ -73,7 +74,8 @@ void TtSemiLepJetCombMVAComputer::produce(edm::Event& evt, const edm::EventSetup
   }
 
   std::vector<int> combi;
-  combi.reserve(nPartons); for (unsigned int i = 0; i < nPartons; ++i)
+  combi.reserve(nPartons);
+  for (unsigned int i = 0; i < nPartons; ++i)
     combi.push_back(i);
 
   typedef std::pair<double, std::vector<int>> discCombPair;

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.cc
@@ -47,7 +47,7 @@ void TtSemiLepJetCombMVAComputer::produce(edm::Event& evt, const edm::EventSetup
   // empty METs vector or less jets than partons
   if (leptons->empty() || mets->empty() || jets->size() < nPartons) {
     std::vector<int> invalidCombi;
-    for (unsigned int i = 0; i < nPartons; ++i)
+    invalidCombi.reserve(nPartons); for (unsigned int i = 0; i < nPartons; ++i)
       invalidCombi.push_back(-1);
     pOut->push_back(invalidCombi);
     evt.put(std::move(pOut));
@@ -73,7 +73,7 @@ void TtSemiLepJetCombMVAComputer::produce(edm::Event& evt, const edm::EventSetup
   }
 
   std::vector<int> combi;
-  for (unsigned int i = 0; i < nPartons; ++i)
+  combi.reserve(nPartons); for (unsigned int i = 0; i < nPartons; ++i)
     combi.push_back(i);
 
   typedef std::pair<double, std::vector<int>> discCombPair;

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMaxSumPtWMass.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMaxSumPtWMass.cc
@@ -48,7 +48,8 @@ void TtSemiLepJetCombMaxSumPtWMass::produce(edm::StreamID, edm::Event& evt, cons
   auto pJetsConsidered = std::make_unique<int>(0);
 
   std::vector<int> match;
-  match.reserve(4); for (unsigned int i = 0; i < 4; ++i)
+  match.reserve(4);
+  for (unsigned int i = 0; i < 4; ++i)
     match.push_back(-1);
 
   // get jets

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMaxSumPtWMass.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMaxSumPtWMass.cc
@@ -48,7 +48,7 @@ void TtSemiLepJetCombMaxSumPtWMass::produce(edm::StreamID, edm::Event& evt, cons
   auto pJetsConsidered = std::make_unique<int>(0);
 
   std::vector<int> match;
-  for (unsigned int i = 0; i < 4; ++i)
+  match.reserve(4); for (unsigned int i = 0; i < 4; ++i)
     match.push_back(-1);
 
   // get jets

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombWMassDeltaTopMass.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombWMassDeltaTopMass.cc
@@ -57,7 +57,7 @@ void TtSemiLepJetCombWMassDeltaTopMass::produce(edm::StreamID, edm::Event& evt, 
   auto pJetsConsidered = std::make_unique<int>(0);
 
   std::vector<int> match;
-  for (unsigned int i = 0; i < 4; ++i)
+  match.reserve(4); for (unsigned int i = 0; i < 4; ++i)
     match.push_back(-1);
 
   // get jets

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombWMassDeltaTopMass.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombWMassDeltaTopMass.cc
@@ -57,7 +57,8 @@ void TtSemiLepJetCombWMassDeltaTopMass::produce(edm::StreamID, edm::Event& evt, 
   auto pJetsConsidered = std::make_unique<int>(0);
 
   std::vector<int> match;
-  match.reserve(4); for (unsigned int i = 0; i < 4; ++i)
+  match.reserve(4);
+  for (unsigned int i = 0; i < 4; ++i)
     match.push_back(-1);
 
   // get jets

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombWMassMaxSumPt.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombWMassMaxSumPt.cc
@@ -48,7 +48,8 @@ void TtSemiLepJetCombWMassMaxSumPt::produce(edm::StreamID, edm::Event& evt, cons
   auto pJetsConsidered = std::make_unique<int>(0);
 
   std::vector<int> match;
-  match.reserve(4); for (unsigned int i = 0; i < 4; ++i)
+  match.reserve(4);
+  for (unsigned int i = 0; i < 4; ++i)
     match.push_back(-1);
 
   // get jets

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombWMassMaxSumPt.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombWMassMaxSumPt.cc
@@ -48,7 +48,7 @@ void TtSemiLepJetCombWMassMaxSumPt::produce(edm::StreamID, edm::Event& evt, cons
   auto pJetsConsidered = std::make_unique<int>(0);
 
   std::vector<int> match;
-  for (unsigned int i = 0; i < 4; ++i)
+  match.reserve(4); for (unsigned int i = 0; i < 4; ++i)
     match.push_back(-1);
 
   // get jets

--- a/TopQuarkAnalysis/TopJetCombination/src/TtFullHadHypothesis.cc
+++ b/TopQuarkAnalysis/TopJetCombination/src/TtFullHadHypothesis.cc
@@ -28,7 +28,8 @@ void TtFullHadHypothesis::produce(edm::Event& evt, const edm::EventSetup& setup)
     matchVec = *matchHandle;
   } else {
     std::vector<int> dummyMatch;
-    dummyMatch.reserve(4); for (unsigned int i = 0; i < 4; ++i)
+    dummyMatch.reserve(4);
+    for (unsigned int i = 0; i < 4; ++i)
       dummyMatch.push_back(-1);
     matchVec.push_back(dummyMatch);
   }

--- a/TopQuarkAnalysis/TopJetCombination/src/TtFullHadHypothesis.cc
+++ b/TopQuarkAnalysis/TopJetCombination/src/TtFullHadHypothesis.cc
@@ -28,7 +28,7 @@ void TtFullHadHypothesis::produce(edm::Event& evt, const edm::EventSetup& setup)
     matchVec = *matchHandle;
   } else {
     std::vector<int> dummyMatch;
-    for (unsigned int i = 0; i < 4; ++i)
+    dummyMatch.reserve(4); for (unsigned int i = 0; i < 4; ++i)
       dummyMatch.push_back(-1);
     matchVec.push_back(dummyMatch);
   }

--- a/TopQuarkAnalysis/TopJetCombination/src/TtFullLepHypothesis.cc
+++ b/TopQuarkAnalysis/TopJetCombination/src/TtFullLepHypothesis.cc
@@ -45,7 +45,7 @@ void TtFullLepHypothesis::produce(edm::Event& evt, const edm::EventSetup& setup)
     matchVec = *matchHandle;
   } else {
     std::vector<int> dummyMatch;
-    for (unsigned int i = 0; i < 4; ++i)
+    dummyMatch.reserve(4); for (unsigned int i = 0; i < 4; ++i)
       dummyMatch.push_back(-1);
     matchVec.push_back(dummyMatch);
   }

--- a/TopQuarkAnalysis/TopJetCombination/src/TtFullLepHypothesis.cc
+++ b/TopQuarkAnalysis/TopJetCombination/src/TtFullLepHypothesis.cc
@@ -45,7 +45,8 @@ void TtFullLepHypothesis::produce(edm::Event& evt, const edm::EventSetup& setup)
     matchVec = *matchHandle;
   } else {
     std::vector<int> dummyMatch;
-    dummyMatch.reserve(4); for (unsigned int i = 0; i < 4; ++i)
+    dummyMatch.reserve(4);
+    for (unsigned int i = 0; i < 4; ++i)
       dummyMatch.push_back(-1);
     matchVec.push_back(dummyMatch);
   }

--- a/TopQuarkAnalysis/TopJetCombination/src/TtSemiLepHypothesis.cc
+++ b/TopQuarkAnalysis/TopJetCombination/src/TtSemiLepHypothesis.cc
@@ -52,7 +52,8 @@ void TtSemiLepHypothesis::produce(edm::Event& evt, const edm::EventSetup& setup)
     matchVec = *matchHandle;
   } else {
     std::vector<int> dummyMatch;
-    dummyMatch.reserve(4); for (unsigned int i = 0; i < 4; ++i)
+    dummyMatch.reserve(4);
+    for (unsigned int i = 0; i < 4; ++i)
       dummyMatch.push_back(-1);
     matchVec.push_back(dummyMatch);
   }

--- a/TopQuarkAnalysis/TopJetCombination/src/TtSemiLepHypothesis.cc
+++ b/TopQuarkAnalysis/TopJetCombination/src/TtSemiLepHypothesis.cc
@@ -52,7 +52,7 @@ void TtSemiLepHypothesis::produce(edm::Event& evt, const edm::EventSetup& setup)
     matchVec = *matchHandle;
   } else {
     std::vector<int> dummyMatch;
-    for (unsigned int i = 0; i < 4; ++i)
+    dummyMatch.reserve(4); for (unsigned int i = 0; i < 4; ++i)
       dummyMatch.push_back(-1);
     matchVec.push_back(dummyMatch);
   }

--- a/TopQuarkAnalysis/TopKinFitter/plugins/TtSemiLepKinFitProducer.cc
+++ b/TopQuarkAnalysis/TopKinFitter/plugins/TtSemiLepKinFitProducer.cc
@@ -237,7 +237,7 @@ void TtSemiLepKinFitProducer<LeptonCollection>::produce(edm::Event& evt, const e
     pNeutrinos->push_back(fitter->fittedNeutrino());
     // indices referring to the jet combination
     std::vector<int> invalidCombi;
-    for (unsigned int i = 0; i < nPartons; ++i)
+    invalidCombi.reserve(nPartons); for (unsigned int i = 0; i < nPartons; ++i)
       invalidCombi.push_back(-1);
     pCombi->push_back(invalidCombi);
     // chi2
@@ -346,7 +346,7 @@ void TtSemiLepKinFitProducer<LeptonCollection>::produce(edm::Event& evt, const e
     pNeutrinos->push_back(fitter->fittedNeutrino());
     // indices referring to the jet combination
     std::vector<int> invalidCombi;
-    for (unsigned int i = 0; i < nPartons; ++i)
+    invalidCombi.reserve(nPartons); for (unsigned int i = 0; i < nPartons; ++i)
       invalidCombi.push_back(-1);
     pCombi->push_back(invalidCombi);
     // chi2
@@ -450,7 +450,7 @@ template <typename LeptonCollection>
 std::vector<TtSemiLepKinFitter::Constraint> TtSemiLepKinFitProducer<LeptonCollection>::constraints(
     std::vector<unsigned>& val) {
   std::vector<TtSemiLepKinFitter::Constraint> result;
-  for (unsigned i = 0; i < val.size(); ++i) {
+  result.reserve(val.size()); for (unsigned i = 0; i < val.size(); ++i) {
     result.push_back(constraint(val[i]));
   }
   return result;

--- a/TopQuarkAnalysis/TopKinFitter/plugins/TtSemiLepKinFitProducer.cc
+++ b/TopQuarkAnalysis/TopKinFitter/plugins/TtSemiLepKinFitProducer.cc
@@ -237,7 +237,8 @@ void TtSemiLepKinFitProducer<LeptonCollection>::produce(edm::Event& evt, const e
     pNeutrinos->push_back(fitter->fittedNeutrino());
     // indices referring to the jet combination
     std::vector<int> invalidCombi;
-    invalidCombi.reserve(nPartons); for (unsigned int i = 0; i < nPartons; ++i)
+    invalidCombi.reserve(nPartons);
+    for (unsigned int i = 0; i < nPartons; ++i)
       invalidCombi.push_back(-1);
     pCombi->push_back(invalidCombi);
     // chi2
@@ -346,7 +347,8 @@ void TtSemiLepKinFitProducer<LeptonCollection>::produce(edm::Event& evt, const e
     pNeutrinos->push_back(fitter->fittedNeutrino());
     // indices referring to the jet combination
     std::vector<int> invalidCombi;
-    invalidCombi.reserve(nPartons); for (unsigned int i = 0; i < nPartons; ++i)
+    invalidCombi.reserve(nPartons);
+    for (unsigned int i = 0; i < nPartons; ++i)
       invalidCombi.push_back(-1);
     pCombi->push_back(invalidCombi);
     // chi2
@@ -450,7 +452,8 @@ template <typename LeptonCollection>
 std::vector<TtSemiLepKinFitter::Constraint> TtSemiLepKinFitProducer<LeptonCollection>::constraints(
     std::vector<unsigned>& val) {
   std::vector<TtSemiLepKinFitter::Constraint> result;
-  result.reserve(val.size()); for (unsigned i = 0; i < val.size(); ++i) {
+  result.reserve(val.size());
+  for (unsigned i = 0; i < val.size(); ++i) {
     result.push_back(constraint(val[i]));
   }
   return result;

--- a/TopQuarkAnalysis/TopKinFitter/src/TtFullHadKinFitter.cc
+++ b/TopQuarkAnalysis/TopKinFitter/src/TtFullHadKinFitter.cc
@@ -480,7 +480,7 @@ std::list<TtFullHadKinFitter::KinFitResult> TtFullHadKinFitter::KinFit::fit(cons
   if (jets.size() < nPartons || invalidMatch_) {
     // indices referring to the jet combination
     std::vector<int> invalidCombi;
-    for (unsigned int i = 0; i < nPartons; ++i)
+    invalidCombi.reserve(nPartons); for (unsigned int i = 0; i < nPartons; ++i)
       invalidCombi.push_back(-1);
 
     KinFitResult result;
@@ -661,7 +661,7 @@ TtFullHadKinFitter::Constraint TtFullHadKinFitter::KinFit::constraint(unsigned c
 std::vector<TtFullHadKinFitter::Constraint> TtFullHadKinFitter::KinFit::constraints(
     const std::vector<unsigned>& configParameters) {
   std::vector<TtFullHadKinFitter::Constraint> result;
-  for (unsigned i = 0; i < configParameters.size(); ++i) {
+  result.reserve(configParameters.size()); for (unsigned i = 0; i < configParameters.size(); ++i) {
     result.push_back(constraint(configParameters[i]));
   }
   return result;

--- a/TopQuarkAnalysis/TopKinFitter/src/TtFullHadKinFitter.cc
+++ b/TopQuarkAnalysis/TopKinFitter/src/TtFullHadKinFitter.cc
@@ -480,7 +480,8 @@ std::list<TtFullHadKinFitter::KinFitResult> TtFullHadKinFitter::KinFit::fit(cons
   if (jets.size() < nPartons || invalidMatch_) {
     // indices referring to the jet combination
     std::vector<int> invalidCombi;
-    invalidCombi.reserve(nPartons); for (unsigned int i = 0; i < nPartons; ++i)
+    invalidCombi.reserve(nPartons);
+    for (unsigned int i = 0; i < nPartons; ++i)
       invalidCombi.push_back(-1);
 
     KinFitResult result;
@@ -661,7 +662,8 @@ TtFullHadKinFitter::Constraint TtFullHadKinFitter::KinFit::constraint(unsigned c
 std::vector<TtFullHadKinFitter::Constraint> TtFullHadKinFitter::KinFit::constraints(
     const std::vector<unsigned>& configParameters) {
   std::vector<TtFullHadKinFitter::Constraint> result;
-  result.reserve(configParameters.size()); for (unsigned i = 0; i < configParameters.size(); ++i) {
+  result.reserve(configParameters.size());
+  for (unsigned i = 0; i < configParameters.size(); ++i) {
     result.push_back(constraint(configParameters[i]));
   }
   return result;

--- a/TopQuarkAnalysis/TopTools/src/JetPartonMatching.cc
+++ b/TopQuarkAnalysis/TopTools/src/JetPartonMatching.cc
@@ -10,7 +10,7 @@ JetPartonMatching::JetPartonMatching(const std::vector<const reco::Candidate*>& 
                                      const double maxDist = 0.3)
     : partons(p), algorithm_(algorithm), useMaxDist_(useMaxDist), useDeltaR_(useDeltaR), maxDist_(maxDist) {
   std::vector<const reco::Candidate*> js;
-  for (unsigned int i = 0; i < j.size(); ++i)
+  js.reserve(j.size()); for (unsigned int i = 0; i < j.size(); ++i)
     js.push_back(&(j[i]));
   jets = js;
   calculate();
@@ -24,7 +24,7 @@ JetPartonMatching::JetPartonMatching(const std::vector<const reco::Candidate*>& 
                                      const double maxDist = 0.3)
     : partons(p), algorithm_(algorithm), useMaxDist_(useMaxDist), useDeltaR_(useDeltaR), maxDist_(maxDist) {
   std::vector<const reco::Candidate*> js;
-  for (unsigned int i = 0; i < j.size(); ++i)
+  js.reserve(j.size()); for (unsigned int i = 0; i < j.size(); ++i)
     js.push_back(&(j[i]));
   jets = js;
   calculate();
@@ -38,7 +38,7 @@ JetPartonMatching::JetPartonMatching(const std::vector<const reco::Candidate*>& 
                                      const double maxDist = 0.3)
     : partons(p), algorithm_(algorithm), useMaxDist_(useMaxDist), useDeltaR_(useDeltaR), maxDist_(maxDist) {
   std::vector<const reco::Candidate*> js;
-  for (unsigned int i = 0; i < j.size(); ++i)
+  js.reserve(j.size()); for (unsigned int i = 0; i < j.size(); ++i)
     js.push_back(&(j[i]));
   jets = js;
   calculate();
@@ -234,7 +234,7 @@ void JetPartonMatching::matchingMinSumDist() {
   std::vector<std::pair<double, MatchingCollection> > distMatchVec;
 
   std::vector<bool> usedJets;
-  for (unsigned int i = 0; i < jets.size(); ++i) {
+  usedJets.reserve(jets.size()); for (unsigned int i = 0; i < jets.size(); ++i) {
     usedJets.push_back(false);
   }
 
@@ -265,14 +265,14 @@ void JetPartonMatching::matchingPtOrderedMinDist() {
   // order partons in pt first
   std::vector<std::pair<double, unsigned int> > ptOrderedPartons;
 
-  for (unsigned int ip = 0; ip < partons.size(); ++ip)
+  ptOrderedPartons.reserve(partons.size()); for (unsigned int ip = 0; ip < partons.size(); ++ip)
     ptOrderedPartons.push_back(std::make_pair(partons[ip]->pt(), ip));
 
   std::sort(ptOrderedPartons.begin(), ptOrderedPartons.end());
   std::reverse(ptOrderedPartons.begin(), ptOrderedPartons.end());
 
   std::vector<unsigned int> jetIndices;
-  for (unsigned int ij = 0; ij < jets.size(); ++ij)
+  jetIndices.reserve(jets.size()); for (unsigned int ij = 0; ij < jets.size(); ++ij)
     jetIndices.push_back(ij);
 
   MatchingCollection match;
@@ -307,7 +307,7 @@ void JetPartonMatching::matchingUnambiguousOnly() {
   // match partons to jets, only accept event
   // if there are no ambiguities
   std::vector<bool> jetMatched;
-  for (unsigned int ij = 0; ij < jets.size(); ++ij)
+  jetMatched.reserve(jets.size()); for (unsigned int ij = 0; ij < jets.size(); ++ij)
     jetMatched.push_back(false);
 
   MatchingCollection match;
@@ -350,7 +350,7 @@ std::vector<int> JetPartonMatching::getMatchesForPartons(const unsigned int comb
   // return a vector with the indices of the matched jets
   // (ordered according to the vector of partons)
   std::vector<int> jetIndices;
-  for (unsigned int part = 0; part < partons.size(); ++part)
+  jetIndices.reserve(partons.size()); for (unsigned int part = 0; part < partons.size(); ++part)
     jetIndices.push_back(getMatchForParton(part, comb));
   return jetIndices;
 }

--- a/TopQuarkAnalysis/TopTools/src/JetPartonMatching.cc
+++ b/TopQuarkAnalysis/TopTools/src/JetPartonMatching.cc
@@ -10,7 +10,8 @@ JetPartonMatching::JetPartonMatching(const std::vector<const reco::Candidate*>& 
                                      const double maxDist = 0.3)
     : partons(p), algorithm_(algorithm), useMaxDist_(useMaxDist), useDeltaR_(useDeltaR), maxDist_(maxDist) {
   std::vector<const reco::Candidate*> js;
-  js.reserve(j.size()); for (unsigned int i = 0; i < j.size(); ++i)
+  js.reserve(j.size());
+  for (unsigned int i = 0; i < j.size(); ++i)
     js.push_back(&(j[i]));
   jets = js;
   calculate();
@@ -24,7 +25,8 @@ JetPartonMatching::JetPartonMatching(const std::vector<const reco::Candidate*>& 
                                      const double maxDist = 0.3)
     : partons(p), algorithm_(algorithm), useMaxDist_(useMaxDist), useDeltaR_(useDeltaR), maxDist_(maxDist) {
   std::vector<const reco::Candidate*> js;
-  js.reserve(j.size()); for (unsigned int i = 0; i < j.size(); ++i)
+  js.reserve(j.size());
+  for (unsigned int i = 0; i < j.size(); ++i)
     js.push_back(&(j[i]));
   jets = js;
   calculate();
@@ -38,7 +40,8 @@ JetPartonMatching::JetPartonMatching(const std::vector<const reco::Candidate*>& 
                                      const double maxDist = 0.3)
     : partons(p), algorithm_(algorithm), useMaxDist_(useMaxDist), useDeltaR_(useDeltaR), maxDist_(maxDist) {
   std::vector<const reco::Candidate*> js;
-  js.reserve(j.size()); for (unsigned int i = 0; i < j.size(); ++i)
+  js.reserve(j.size());
+  for (unsigned int i = 0; i < j.size(); ++i)
     js.push_back(&(j[i]));
   jets = js;
   calculate();
@@ -234,7 +237,8 @@ void JetPartonMatching::matchingMinSumDist() {
   std::vector<std::pair<double, MatchingCollection> > distMatchVec;
 
   std::vector<bool> usedJets;
-  usedJets.reserve(jets.size()); for (unsigned int i = 0; i < jets.size(); ++i) {
+  usedJets.reserve(jets.size());
+  for (unsigned int i = 0; i < jets.size(); ++i) {
     usedJets.push_back(false);
   }
 
@@ -265,14 +269,16 @@ void JetPartonMatching::matchingPtOrderedMinDist() {
   // order partons in pt first
   std::vector<std::pair<double, unsigned int> > ptOrderedPartons;
 
-  ptOrderedPartons.reserve(partons.size()); for (unsigned int ip = 0; ip < partons.size(); ++ip)
+  ptOrderedPartons.reserve(partons.size());
+  for (unsigned int ip = 0; ip < partons.size(); ++ip)
     ptOrderedPartons.push_back(std::make_pair(partons[ip]->pt(), ip));
 
   std::sort(ptOrderedPartons.begin(), ptOrderedPartons.end());
   std::reverse(ptOrderedPartons.begin(), ptOrderedPartons.end());
 
   std::vector<unsigned int> jetIndices;
-  jetIndices.reserve(jets.size()); for (unsigned int ij = 0; ij < jets.size(); ++ij)
+  jetIndices.reserve(jets.size());
+  for (unsigned int ij = 0; ij < jets.size(); ++ij)
     jetIndices.push_back(ij);
 
   MatchingCollection match;
@@ -307,7 +313,8 @@ void JetPartonMatching::matchingUnambiguousOnly() {
   // match partons to jets, only accept event
   // if there are no ambiguities
   std::vector<bool> jetMatched;
-  jetMatched.reserve(jets.size()); for (unsigned int ij = 0; ij < jets.size(); ++ij)
+  jetMatched.reserve(jets.size());
+  for (unsigned int ij = 0; ij < jets.size(); ++ij)
     jetMatched.push_back(false);
 
   MatchingCollection match;
@@ -350,7 +357,8 @@ std::vector<int> JetPartonMatching::getMatchesForPartons(const unsigned int comb
   // return a vector with the indices of the matched jets
   // (ordered according to the vector of partons)
   std::vector<int> jetIndices;
-  jetIndices.reserve(partons.size()); for (unsigned int part = 0; part < partons.size(); ++part)
+  jetIndices.reserve(partons.size());
+  for (unsigned int part = 0; part < partons.size(); ++part)
     jetIndices.push_back(getMatchForParton(part, comb));
   return jetIndices;
 }

--- a/TrackingTools/TrackRefitter/src/TrackTransformerForGlobalCosmicMuons.cc
+++ b/TrackingTools/TrackRefitter/src/TrackTransformerForGlobalCosmicMuons.cc
@@ -227,7 +227,7 @@ vector<Trajectory> TrackTransformerForGlobalCosmicMuons::transform(const reco::T
     return vector<Trajectory>();
   }
 
-  Trajectory trajectoryBW = trajectories.front();
+  const Trajectory& trajectoryBW = trajectories.front();
 
   vector<Trajectory> trajectoriesSM = smoother(up)->trajectories(trajectoryBW);
 

--- a/TrackingTools/TrajectoryState/src/PerigeeConversions.cc
+++ b/TrackingTools/TrajectoryState/src/PerigeeConversions.cc
@@ -62,7 +62,7 @@ CurvilinearTrajectoryError PerigeeConversions::curvilinearError(const PerigeeTra
 
 GlobalPoint PerigeeConversions::positionFromPerigee(const PerigeeTrajectoryParameters& parameters,
                                                     const GlobalPoint& referencePoint) {
-  AlgebraicVector5 theVector = parameters.vector();
+  const AlgebraicVector5& theVector = parameters.vector();
   return GlobalPoint(theVector[3] * vdt::fast_sin(theVector[2]) + referencePoint.x(),
                      -theVector[3] * vdt::fast_cos(theVector[2]) + referencePoint.y(),
                      theVector[4] + referencePoint.z());

--- a/Validation/EcalClusters/src/ContainmentCorrectionAnalyzer.cc
+++ b/Validation/EcalClusters/src/ContainmentCorrectionAnalyzer.cc
@@ -413,7 +413,7 @@ std::vector<EcalSimPhotonMCTruth> ContainmentCorrectionAnalyzer::findMcTruth(std
         if (abs((*iSimTk).type()) != 11)
           continue;
         int vertexId = (*iSimTk).vertIndex();
-        SimVertex vertex = theSimVertices[vertexId];
+        const SimVertex& vertex = theSimVertices[vertexId];
         int motherId = -1;
         if (vertex.parentIndex()) {
           unsigned motherGeantId = vertex.parentIndex();
@@ -435,7 +435,7 @@ std::vector<EcalSimPhotonMCTruth> ContainmentCorrectionAnalyzer::findMcTruth(std
         nConv++;
         convInd[iPho] = nConv;
         int convVtxId = trkFromConversion[0]->vertIndex();
-        SimVertex convVtx = theSimVertices[convVtxId];
+        const SimVertex& convVtx = theSimVertices[convVtxId];
         const math::XYZTLorentzVectorD &vtxPosition = convVtx.position();
         // math::XYZTLorentzVectorD momentum = (*iPhoTk)->momentum(); // UNUSED
 

--- a/Validation/EcalClusters/src/ContainmentCorrectionAnalyzer.cc
+++ b/Validation/EcalClusters/src/ContainmentCorrectionAnalyzer.cc
@@ -413,7 +413,7 @@ std::vector<EcalSimPhotonMCTruth> ContainmentCorrectionAnalyzer::findMcTruth(std
         if (abs((*iSimTk).type()) != 11)
           continue;
         int vertexId = (*iSimTk).vertIndex();
-        const SimVertex& vertex = theSimVertices[vertexId];
+        const SimVertex &vertex = theSimVertices[vertexId];
         int motherId = -1;
         if (vertex.parentIndex()) {
           unsigned motherGeantId = vertex.parentIndex();
@@ -435,7 +435,7 @@ std::vector<EcalSimPhotonMCTruth> ContainmentCorrectionAnalyzer::findMcTruth(std
         nConv++;
         convInd[iPho] = nConv;
         int convVtxId = trkFromConversion[0]->vertIndex();
-        const SimVertex& convVtx = theSimVertices[convVtxId];
+        const SimVertex &convVtx = theSimVertices[convVtxId];
         const math::XYZTLorentzVectorD &vtxPosition = convVtx.position();
         // math::XYZTLorentzVectorD momentum = (*iPhoTk)->momentum(); // UNUSED
 

--- a/Validation/EventGenerator/plugins/BPhysicsValidation.cc
+++ b/Validation/EventGenerator/plugins/BPhysicsValidation.cc
@@ -18,7 +18,7 @@ BPhysicsValidation::BPhysicsValidation(const edm::ParameterSet& iPSet)
   genparticleCollectionToken_ = consumes<reco::GenParticleCollection>(genparticleCollection_);
   std::vector<std::string> daughterNames = iPSet.getParameter<std::vector<std::string> >("daughters");
   for (unsigned int i = 0; i < daughterNames.size(); i++) {
-    std::string curSet = daughterNames[i];
+    const std::string& curSet = daughterNames[i];
     daughters.push_back(ParticleMonitor(name + curSet, iPSet.getUntrackedParameter<ParameterSet>(curSet)));
   }
 }

--- a/Validation/EventGenerator/plugins/GenWeightValidation.cc
+++ b/Validation/EventGenerator/plugins/GenWeightValidation.cc
@@ -154,7 +154,7 @@ void GenWeightValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   std::sort(leptons.begin(), leptons.end(), HepMCValidationHelper::sortByPtRef<reco::GenParticleRef>);
 
   if (!leptons.empty()) {
-    reco::GenParticleRef leadLep = leptons.at(0);
+    const reco::GenParticleRef& leadLep = leptons.at(0);
     fillTemplates(leadLepPtTemp_, leadLep->pt());
     fillTemplates(leadLepEtaTemp_, leadLep->eta());
   }

--- a/Validation/EventGenerator/plugins/LheWeightValidation.cc
+++ b/Validation/EventGenerator/plugins/LheWeightValidation.cc
@@ -198,7 +198,7 @@ void LheWeightValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   std::sort(leptons.begin(), leptons.end(), HepMCValidationHelper::sortByPtRef<reco::GenParticleRef>);
 
   if (!leptons.empty()) {
-    reco::GenParticleRef leadLep = leptons.at(0);
+    const reco::GenParticleRef& leadLep = leptons.at(0);
     fillTemplates(leadLepPtScaleVar_, leadLepPtPdfVar_, leadLepPtTemp_, leadLep->pt());
     fillTemplates(leadLepEtaScaleVar_, leadLepEtaPdfVar_, leadLepEtaTemp_, leadLep->eta());
   }

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -678,7 +678,7 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
         std::vector<MtdSimLayerClusterRef> simClustersRefs =
             (*itp.first).second;  // the range of itp.first, itp.second should be always 1
         for (unsigned int i = 0; i < simClustersRefs.size(); i++) {
-          auto simClusterRef = simClustersRefs[i];
+          const auto& simClusterRef = simClustersRefs[i];
 
           float simClusEnergy = convertUnitsTo(0.001_MeV, (*simClusterRef).simLCEnergy());  // GeV --> MeV
           float simClusTime = (*simClusterRef).simLCTime();

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -521,7 +521,7 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
         std::vector<MtdSimLayerClusterRef> simClustersRefs =
             (*itp.first).second;  // the range of itp.first, itp.second should be always 1
         for (unsigned int i = 0; i < simClustersRefs.size(); i++) {
-          auto simClusterRef = simClustersRefs[i];
+          const auto& simClusterRef = simClustersRefs[i];
 
           float simClusEnergy = convertUnitsTo(0.001_MeV, (*simClusterRef).simLCEnergy());  // GeV --> MeV
           float simClusTime = (*simClusterRef).simLCTime();

--- a/Validation/MtdValidation/plugins/MtdEleIsoValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdEleIsoValidation.cc
@@ -892,7 +892,7 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   auto GenRecTrackHandle = iEvent.getHandle(GenRecTrackToken_);
 
   auto VertexHandle = iEvent.getHandle(RecVertexToken_);
-  std::vector<reco::Vertex> vertices = *VertexHandle;
+  const std::vector<reco::Vertex>& vertices = *VertexHandle;
 
   const auto& t0Pid = iEvent.get(t0PidToken_);
   const auto& Sigmat0Pid = iEvent.get(Sigmat0PidToken_);

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -921,7 +921,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                   if (optionalPlots_ && isTPmtdDirectBTL) {
                     // simCluster matched to TP
                     // NB we are taking the position and id of the first hit in the cluster.
-                    auto directSimClus = *directSimClusIt;
+                    const auto& directSimClus = *directSimClusIt;
                     MTDDetId mtddetid = directSimClus->detIds_and_rows().front().first;
                     BTLDetId detid(mtddetid.rawId());
                     LocalPoint simClusLocalPos = directSimClus->hits_and_positions().front().second;

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -2108,7 +2108,7 @@ void Primary4DVertexValidation::matchReco2Sim(std::vector<recoPrimaryVertex>& re
       unsigned int iv = NOT_MATCHED;  // select a rec vertex index
       for (unsigned int k = 0; k < simpv.at(iev).wos_dominated_recv.size(); k++) {
         unsigned int rec = simpv.at(iev).wos_dominated_recv.at(k);  //candidate rec vertex index
-        auto vrec = recopv.at(rec);
+        const auto& vrec = recopv.at(rec);
         if (vrec.sim != NOT_MATCHED) {
           continue;  // already matched
         }

--- a/Validation/MuonCSCDigis/src/CSCStripDigiValidation.cc
+++ b/Validation/MuonCSCDigis/src/CSCStripDigiValidation.cc
@@ -86,13 +86,13 @@ void CSCStripDigiValidation::analyze(const edm::Event &e, const edm::EventSetup 
 }
 
 void CSCStripDigiValidation::fillPedestalPlots(const CSCStripDigi &digi) {
-  std::vector<int> adcCounts = digi.getADCCounts();
+  const std::vector<int>& adcCounts = digi.getADCCounts();
   thePedestalPlot->Fill(adcCounts[0]);
   thePedestalPlot->Fill(adcCounts[1]);
 }
 
 void CSCStripDigiValidation::fillSignalPlots(const CSCStripDigi &digi) {
-  std::vector<int> adcCounts = digi.getADCCounts();
+  const std::vector<int>& adcCounts = digi.getADCCounts();
   float pedestal = thePedestalSum / thePedestalCount;
   theAmplitudePlot->Fill(adcCounts[4] - pedestal);
   theRatio4to5Plot->Fill((adcCounts[3] - pedestal) / (adcCounts[4] - pedestal));

--- a/Validation/MuonCSCDigis/src/CSCStripDigiValidation.cc
+++ b/Validation/MuonCSCDigis/src/CSCStripDigiValidation.cc
@@ -86,13 +86,13 @@ void CSCStripDigiValidation::analyze(const edm::Event &e, const edm::EventSetup 
 }
 
 void CSCStripDigiValidation::fillPedestalPlots(const CSCStripDigi &digi) {
-  const std::vector<int>& adcCounts = digi.getADCCounts();
+  const std::vector<int> &adcCounts = digi.getADCCounts();
   thePedestalPlot->Fill(adcCounts[0]);
   thePedestalPlot->Fill(adcCounts[1]);
 }
 
 void CSCStripDigiValidation::fillSignalPlots(const CSCStripDigi &digi) {
-  const std::vector<int>& adcCounts = digi.getADCCounts();
+  const std::vector<int> &adcCounts = digi.getADCCounts();
   float pedestal = thePedestalSum / thePedestalCount;
   theAmplitudePlot->Fill(adcCounts[4] - pedestal);
   theRatio4to5Plot->Fill((adcCounts[3] - pedestal) / (adcCounts[4] - pedestal));

--- a/Validation/RecoEgamma/plugins/EgammaObjects.cc
+++ b/Validation/RecoEgamma/plugins/EgammaObjects.cc
@@ -575,8 +575,8 @@ void EgammaObjects::analyzePhotons(const edm::Event& evt, const edm::EventSetup&
   }
 
   if (photonsMCMatched.size() == 2) {
-    reco::Photon pOne = photonsMCMatched[0];
-    reco::Photon pTwo = photonsMCMatched[1];
+    const reco::Photon& pOne = photonsMCMatched[0];
+    const reco::Photon& pTwo = photonsMCMatched[1];
 
     double recoMass = findRecoMass(pOne, pTwo);
 
@@ -732,8 +732,8 @@ void EgammaObjects::analyzeElectrons(const edm::Event& evt, const edm::EventSetu
   }
 
   if (electronsMCMatched.size() == 2) {
-    reco::GsfElectron eOne = electronsMCMatched[0];
-    reco::GsfElectron eTwo = electronsMCMatched[1];
+    const reco::GsfElectron& eOne = electronsMCMatched[0];
+    const reco::GsfElectron& eTwo = electronsMCMatched[1];
 
     double recoMass = findRecoMass(eOne, eTwo);
 

--- a/Validation/RecoTrack/plugins/JetCoreMCtruthSeedGenerator.cc
+++ b/Validation/RecoTrack/plugins/JetCoreMCtruthSeedGenerator.cc
@@ -214,7 +214,7 @@ void JetCoreMCtruthSeedGenerator::produce(edm::Event& iEvent, const edm::EventSe
       splitClustDirSet.emplace_back(GlobalVector(jet.px(), jet.py(), jet.pz()));
 
       for (int cc = 0; cc < (int)splitClustDirSet.size(); cc++) {
-        GlobalVector bigClustDir = splitClustDirSet[cc];
+        const GlobalVector& bigClustDir = splitClustDirSet[cc];
 
         jetEta_ = jet.eta();
         jetPt_ = jet.pt();
@@ -466,8 +466,8 @@ std::vector<std::array<double, 5>> JetCoreMCtruthSeedGenerator::seedParFilling(
 
   edm::LogInfo("PerfectSeeder") << "goodSimTrk size" << goodSimTrk.size();
   for (uint j = 0; j < goodSimTrk.size(); j++) {
-    SimTrack st = goodSimTrk[j];
-    SimVertex sv = goodSimVtx[j];
+    const SimTrack& st = goodSimTrk[j];
+    const SimVertex& sv = goodSimVtx[j];
     GlobalVector trkMom(st.momentum().x(), st.momentum().y(), st.momentum().z());
     GlobalPoint trkPos(sv.position().x(), sv.position().y(), sv.position().z());
     edm::LogInfo("PerfectSeeder") << "seed " << j << ", very int pt" << st.momentum().Pt()

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateStub.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateStub.cc
@@ -584,7 +584,7 @@ void Phase2OTValidateStub::analyze(const edm::Event& iEvent, const edm::EventSet
 
     // Loop through associated clusters
     for (std::size_t k = 0; k < associatedClusters.size(); ++k) {
-      auto clusA = associatedClusters[k];
+      const auto& clusA = associatedClusters[k];
 
       // Get cluster details
       DetId clusdetid = clusA->getDetId();


### PR DESCRIPTION
These are the changes which clang-tidy from LLVM 21.1.4  suggested. Mostly it suggest
- make variable `const &`
- reserving `std::vector` size before the `for` loop
- added missing `override`