### PR TITLE
Use RNTupleTemp* modules

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -458,7 +458,7 @@ class ConfigBuilder(object):
                                                secondaryFileNames= cms.untracked.vstring())
                 filesFromOption(self)
             if self._options.filetype == "EDM_RNTUPLE":
-                self.process.source=cms.Source("RNTupleSource",
+                self.process.source=cms.Source("RNTupleTempSource",
                                                fileNames = cms.untracked.vstring())#, 2ndary not supported yet
                                                #secondaryFileNames= cms.untracked.vstring())
                 filesFromOption(self)
@@ -733,7 +733,7 @@ class ConfigBuilder(object):
         elif not ignoreNano and "NANOAOD" in streamType:
             CppType='NanoAODRNTupleOutputModule' if self._options.rntuple_out else 'NanoAODOutputModule'
         elif self._options.rntuple_out:
-            CppType='RNTupleOutputModule'
+            CppType='RNTupleTempOutputModule'
         if 'RNTuple' in CppType:
             fileName = fileName.replace('.root', '.rntpl')
         else:
@@ -1241,7 +1241,7 @@ class ConfigBuilder(object):
             # define output module and go from there
         if self._options.rntuple_out:
             extension = '.rntpl'
-            output = cms.OutputModule('RNTupleOutputModule')
+            output = cms.OutputModule('RNTupleTempOutputModule')
         else:
             extension = '.root'
             output = cms.OutputModule("PoolOutputModule")

--- a/Configuration/Applications/test/ConfigBuilderTest.py
+++ b/Configuration/Applications/test/ConfigBuilderTest.py
@@ -139,7 +139,7 @@ if __name__=="__main__":
             options.datatier= "MINIAOD"
             options.eventcontent="MINIAOD"
             options.rntuple_out = True
-            _test_addOutput(self, options, process, [OutStats('MINIAODoutput','RNTupleOutputModule','MINIAOD','output.rntpl',outputCommands_)])
+            _test_addOutput(self, options, process, [OutStats('MINIAODoutput','RNTupleTempOutputModule','MINIAOD','output.rntpl',outputCommands_)])
             #MINIAOD1 [NOTE notiation not restricted to MINIAOD]
             #NOT SUPPORTED BY outputDefinition
             process = cms.Process("TEST")
@@ -234,7 +234,7 @@ if __name__=="__main__":
             options.datatier= "NANOAOD"
             options.eventcontent="NANOEDMAOD"
             options.rntuple_out = True
-            _test_addOutput(self, options, process, [OutStats('NANOEDMAODoutput', 'RNTupleOutputModule', 'NANOAOD', 'output.rntpl', outputCommands_)])
+            _test_addOutput(self, options, process, [OutStats('NANOEDMAODoutput', 'RNTupleTempOutputModule', 'NANOAOD', 'output.rntpl', outputCommands_)])
             #ALCARECO empty
             process = cms.Process("TEST")
             options.scenario = "TEST"

--- a/DataFormats/Histograms/src/classes_def.xml
+++ b/DataFormats/Histograms/src/classes_def.xml
@@ -33,6 +33,7 @@
  <class name="MEtoEDM<TProfile2D>"/>
  <class name="MEtoEDM<double>"/>
  <class name="MEtoEDM<int>"/>
+ <class name="MEtoEDM<long>"/>
  <class name="MEtoEDM<long long>"/>
  <class name="MEtoEDM<TString>"/>
  <class name="MEtoEDM<TH1F>::MEtoEDMObject" rntupleStreamerMode="true"/>
@@ -49,6 +50,8 @@
  <class name="MEtoEDM<TProfile2D>::MEtoEDMObject" rntupleStreamerMode="true"/>
  <class name="MEtoEDM<double>::MEtoEDMObject" rntupleStreamerMode="true"/>
  <class name="MEtoEDM<int>::MEtoEDMObject" rntupleStreamerMode="true"/>
+ <!--The following is a workaround for an RNTuple issue. Will be removed once ROOT fix exists. -->
+ <class name="MEtoEDM<long>::MEtoEDMObject" rntupleStreamerMode="true"/>
  <class name="MEtoEDM<long long>::MEtoEDMObject" rntupleStreamerMode="true"/>
  <class name="MEtoEDM<TString>::MEtoEDMObject" rntupleStreamerMode="true"/>
  <class name="std::vector<MEtoEDM<TH1F>::MEtoEDMObject>"/>
@@ -81,6 +84,8 @@
  <class name="edm::Wrapper<MEtoEDM<TProfile2D> >"/>
  <class name="edm::Wrapper<MEtoEDM<double> >"/>
  <class name="edm::Wrapper<MEtoEDM<int> >"/>
+ <!--The following is a workaround for an RNTuple issue. Will be removed once ROOT fix exists. -->
+ <class name="edm::Wrapper<MEtoEDM<long> >"/>
  <class name="edm::Wrapper<MEtoEDM<long long> >"/>
  <class name="edm::Wrapper<MEtoEDM<TString> >"/>
 


### PR DESCRIPTION
#### PR description:

- Switched ConfigBuilder to use RNTupleTemp* modules instead of RNTuple*
- Testing showed that RNTuple required generating a MEtoEDM<long> dictionary

#### PR validation:

This was tested with a PR using RNTUPLE_X build.

resolves https://github.com/cms-sw/framework-team/issues/1559