### PR TITLE
disable ubsan checks for some global summary functions

### DIFF
--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -43,8 +43,15 @@
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
-#include "FWCore/Utilities/interface/disable_ubsan.h"
 #include "DataFormats/Common/interface/Wrapper.h"
+
+// With gcc 13.4.0, some summary routines are failing with unreachable program point
+// UBSAN errors.  No UB has been identified, so for now this workaround suppresses
+// UBSAN checking for the routines that are failing.
+//
+// details at https://github.com/cms-sw/cmssw/issues/49151
+#include "FWCore/Utilities/interface/disable_ubsan.h"
+
 
 // forward declarations
 namespace edm {

--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -52,7 +52,6 @@
 // details at https://github.com/cms-sw/cmssw/issues/49151
 #include "FWCore/Utilities/interface/disable_ubsan.h"
 
-
 // forward declarations
 namespace edm {
 

--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -45,6 +45,12 @@
 #include "FWCore/Utilities/interface/propagate_const.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
+#ifdef CMS_UNDEFINED_SANITIZER
+#define NOUBSAN __attribute__((no_sanitize("undefined")))
+#else
+#define NOUBSAN
+#endif
+
 // forward declarations
 namespace edm {
 
@@ -164,7 +170,9 @@ namespace edm {
         C const* runCache(edm::RunIndex iID) const { return caches_[iID].get(); }
 
       private:
-        void doBeginRun_(Run const& rp, EventSetup const& c) final { caches_[rp.index()] = globalBeginRun(rp, c); }
+        void doBeginRun_(Run const& rp, EventSetup const& c) final NOUBSAN {
+          caches_[rp.index()] = globalBeginRun(rp, c);
+        }
         void doEndRun_(Run const& rp, EventSetup const& c) final {
           globalEndRun(rp, c);
           caches_[rp.index()].reset();
@@ -189,7 +197,7 @@ namespace edm {
         C const* luminosityBlockCache(edm::LuminosityBlockIndex iID) const { return caches_[iID].get(); }
 
       private:
-        void doBeginLuminosityBlock_(LuminosityBlock const& lp, EventSetup const& c) final {
+        void doBeginLuminosityBlock_(LuminosityBlock const& lp, EventSetup const& c) final NOUBSAN {
           caches_[lp.index()] = globalBeginLuminosityBlock(lp, c);
         }
         void doEndLuminosityBlock_(LuminosityBlock const& lp, EventSetup const& c) final {
@@ -219,7 +227,7 @@ namespace edm {
 
         friend class EndRunSummaryProducer<T, C>;
 
-        void doBeginRunSummary_(edm::Run const& rp, EventSetup const& c) final {
+        void doBeginRunSummary_(edm::Run const& rp, EventSetup const& c) final NOUBSAN {
           caches_[rp.index()] = globalBeginRunSummary(rp, c);
         }
         void doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c) final {
@@ -259,7 +267,7 @@ namespace edm {
 
         friend class EndLuminosityBlockSummaryProducer<T, C>;
 
-        void doBeginLuminosityBlockSummary_(edm::LuminosityBlock const& lb, EventSetup const& c) final {
+        void doBeginLuminosityBlockSummary_(edm::LuminosityBlock const& lb, EventSetup const& c) final NOUBSAN {
           caches_[lb.index()] = globalBeginLuminosityBlockSummary(lb, c);
         }
 

--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -43,18 +43,8 @@
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/disable_ubsan.h"
 #include "DataFormats/Common/interface/Wrapper.h"
-
-// With gcc 13.4.0, some summary routines are failing with unreachable program point
-// UBSAN errors.  No UB has been identified, so for now this workaround suppresses
-// UBSAN checking for the routines that are failing.
-//
-// details at https://github.com/cms-sw/cmssw/issues/49151
-#ifdef CMS_UNDEFINED_SANITIZER
-#define NOUBSAN __attribute__((no_sanitize("undefined")))
-#else
-#define NOUBSAN
-#endif
 
 // forward declarations
 namespace edm {
@@ -175,7 +165,7 @@ namespace edm {
         C const* runCache(edm::RunIndex iID) const { return caches_[iID].get(); }
 
       private:
-        void doBeginRun_(Run const& rp, EventSetup const& c) final NOUBSAN {
+        void doBeginRun_(Run const& rp, EventSetup const& c) final DISABLE_UBSAN {
           caches_[rp.index()] = globalBeginRun(rp, c);
         }
         void doEndRun_(Run const& rp, EventSetup const& c) final {
@@ -202,7 +192,7 @@ namespace edm {
         C const* luminosityBlockCache(edm::LuminosityBlockIndex iID) const { return caches_[iID].get(); }
 
       private:
-        void doBeginLuminosityBlock_(LuminosityBlock const& lp, EventSetup const& c) final NOUBSAN {
+        void doBeginLuminosityBlock_(LuminosityBlock const& lp, EventSetup const& c) final DISABLE_UBSAN {
           caches_[lp.index()] = globalBeginLuminosityBlock(lp, c);
         }
         void doEndLuminosityBlock_(LuminosityBlock const& lp, EventSetup const& c) final {
@@ -232,7 +222,7 @@ namespace edm {
 
         friend class EndRunSummaryProducer<T, C>;
 
-        void doBeginRunSummary_(edm::Run const& rp, EventSetup const& c) final NOUBSAN {
+        void doBeginRunSummary_(edm::Run const& rp, EventSetup const& c) final DISABLE_UBSAN {
           caches_[rp.index()] = globalBeginRunSummary(rp, c);
         }
         void doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c) final {
@@ -272,7 +262,7 @@ namespace edm {
 
         friend class EndLuminosityBlockSummaryProducer<T, C>;
 
-        void doBeginLuminosityBlockSummary_(edm::LuminosityBlock const& lb, EventSetup const& c) final NOUBSAN {
+        void doBeginLuminosityBlockSummary_(edm::LuminosityBlock const& lb, EventSetup const& c) final DISABLE_UBSAN {
           caches_[lb.index()] = globalBeginLuminosityBlockSummary(lb, c);
         }
 

--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -45,6 +45,11 @@
 #include "FWCore/Utilities/interface/propagate_const.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
+// With gcc 13.4.0, some summary routines are failing with unreachable program point
+// UBSAN errors.  No UB has been identified, so for now this workaround suppresses
+// UBSAN checking for the routines that are failing.
+//
+// details at https://github.com/cms-sw/cmssw/issues/49151
 #ifdef CMS_UNDEFINED_SANITIZER
 #define NOUBSAN __attribute__((no_sanitize("undefined")))
 #else

--- a/FWCore/Framework/interface/limited/implementors.h
+++ b/FWCore/Framework/interface/limited/implementors.h
@@ -42,8 +42,14 @@
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
-#include "FWCore/Utilities/interface/disable_ubsan.h"
 #include "DataFormats/Common/interface/Wrapper.h"
+
+// With gcc 13.4.0, some summary routines are failing with unreachable program point
+// UBSAN errors.  No UB has been identified, so for now this workaround suppresses
+// UBSAN checking for the routines that are failing.
+//
+// details at https://github.com/cms-sw/cmssw/issues/49151
+#include "FWCore/Utilities/interface/disable_ubsan.h"
 
 // forward declarations
 namespace edm {

--- a/FWCore/Framework/interface/limited/implementors.h
+++ b/FWCore/Framework/interface/limited/implementors.h
@@ -42,6 +42,7 @@
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/disable_ubsan.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
 // forward declarations
@@ -164,7 +165,9 @@ namespace edm {
         C const* runCache(edm::RunIndex iID) const { return caches_[iID].get(); }
 
       private:
-        void doBeginRun_(Run const& rp, EventSetup const& c) final { caches_[rp.index()] = globalBeginRun(rp, c); }
+        void doBeginRun_(Run const& rp, EventSetup const& c) final DISABLE_UBSAN {
+          caches_[rp.index()] = globalBeginRun(rp, c);
+        }
         void doEndRun_(Run const& rp, EventSetup const& c) final {
           globalEndRun(rp, c);
           caches_[rp.index()].reset();
@@ -190,7 +193,7 @@ namespace edm {
       private:
         void preallocLumis(unsigned int iNLumis) final { caches_.reset(new std::shared_ptr<C>[iNLumis]); }
 
-        void doBeginLuminosityBlock_(LuminosityBlock const& lp, EventSetup const& c) final {
+        void doBeginLuminosityBlock_(LuminosityBlock const& lp, EventSetup const& c) final DISABLE_UBSAN {
           caches_[lp.index()] = globalBeginLuminosityBlock(lp, c);
         }
         void doEndLuminosityBlock_(LuminosityBlock const& lp, EventSetup const& c) final {
@@ -220,7 +223,7 @@ namespace edm {
         void preallocRunsSummary(unsigned int iNRuns) final { caches_.reset(new std::shared_ptr<C>[iNRuns]); }
 
         friend class EndRunSummaryProducer<T, C>;
-        void doBeginRunSummary_(edm::Run const& rp, EventSetup const& c) final {
+        void doBeginRunSummary_(edm::Run const& rp, EventSetup const& c) final DISABLE_UBSAN {
           caches_[rp.index()] = globalBeginRunSummary(rp, c);
         }
         void doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c) final {
@@ -260,7 +263,7 @@ namespace edm {
 
         friend class EndLuminosityBlockSummaryProducer<T, C>;
 
-        void doBeginLuminosityBlockSummary_(edm::LuminosityBlock const& lb, EventSetup const& c) final {
+        void doBeginLuminosityBlockSummary_(edm::LuminosityBlock const& lb, EventSetup const& c) final DISABLE_UBSAN {
           caches_[lb.index()] = globalBeginLuminosityBlockSummary(lb, c);
         }
 

--- a/FWCore/Framework/interface/one/implementors.h
+++ b/FWCore/Framework/interface/one/implementors.h
@@ -42,8 +42,14 @@
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
-#include "FWCore/Utilities/interface/disable_ubsan.h"
 #include "DataFormats/Common/interface/Wrapper.h"
+
+// With gcc 13.4.0, some summary routines are failing with unreachable program point
+// UBSAN errors.  No UB has been identified, so for now this workaround suppresses
+// UBSAN checking for the routines that are failing.
+//
+// details at https://github.com/cms-sw/cmssw/issues/49151
+#include "FWCore/Utilities/interface/disable_ubsan.h"
 
 // forward declarations
 

--- a/FWCore/Framework/interface/one/implementors.h
+++ b/FWCore/Framework/interface/one/implementors.h
@@ -42,6 +42,7 @@
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/disable_ubsan.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
 // forward declarations
@@ -280,7 +281,9 @@ namespace edm {
         C const* runCache(edm::RunIndex iID) const { return caches_[iID].get(); }
 
       private:
-        void doBeginRun_(Run const& rp, EventSetup const& c) final { caches_[rp.index()] = globalBeginRun(rp, c); }
+        void doBeginRun_(Run const& rp, EventSetup const& c) final DISABLE_UBSAN {
+          caches_[rp.index()] = globalBeginRun(rp, c);
+        }
         void doEndRun_(Run const& rp, EventSetup const& c) final {
           globalEndRun(rp, c);
           caches_[rp.index()].reset();
@@ -307,7 +310,7 @@ namespace edm {
         C* luminosityBlockCache(edm::LuminosityBlockIndex iID) { return caches_[iID].get(); }
 
       private:
-        void doBeginLuminosityBlock_(LuminosityBlock const& lp, EventSetup const& c) final {
+        void doBeginLuminosityBlock_(LuminosityBlock const& lp, EventSetup const& c) final DISABLE_UBSAN {
           caches_[lp.index()] = globalBeginLuminosityBlock(lp, c);
         }
         void doEndLuminosityBlock_(LuminosityBlock const& lp, EventSetup const& c) final {

--- a/FWCore/Utilities/interface/disable_ubsan.h
+++ b/FWCore/Utilities/interface/disable_ubsan.h
@@ -1,10 +1,13 @@
 #ifndef FWCore_Utilites_disable_ubsan_h
 #define FWCore_Utilites_disable_ubsan_h
-// With gcc 13.4.0, some summary routines are failing with unreachable program point
-// UBSAN errors.  No UB has been identified, so for now this workaround suppresses
-// UBSAN checking for the routines that are failing.
 //
-// details at https://github.com/cms-sw/cmssw/issues/49151
+// function attribute to suppress UBSAN checking for routines that
+// give false positives for undefined behavior
+//
+// background at https://github.com/cms-sw/cmssw/issues/49151
+//
+// usage: void f() DISABLE_UBSAN {}
+//
 #ifdef CMS_UNDEFINED_SANITIZER
 #define DISABLE_UBSAN __attribute__((no_sanitize("undefined")))
 #else

--- a/FWCore/Utilities/interface/disable_ubsan.h
+++ b/FWCore/Utilities/interface/disable_ubsan.h
@@ -1,0 +1,13 @@
+#ifndef FWCore_Utilites_disable_ubsan_h
+#define FWCore_Utilites_disable_ubsan_h
+// With gcc 13.4.0, some summary routines are failing with unreachable program point
+// UBSAN errors.  No UB has been identified, so for now this workaround suppresses
+// UBSAN checking for the routines that are failing.
+//
+// details at https://github.com/cms-sw/cmssw/issues/49151
+#ifdef CMS_UNDEFINED_SANITIZER
+#define DISABLE_UBSAN __attribute__((no_sanitize("undefined")))
+#else
+#define DISABLE_UBSAN
+#endif
+#endif


### PR DESCRIPTION
#### PR description:

UBSAN jobs are failing in recent IBs with the runtime error `unreachable program point`. This is mostly seen in NANOAOD production jobs that read run products at BeginRun, but also appears in the framework `TestFWCoreFrameworkGlobalStreamOne` unit test.  See #49151 for details.

This PR disables UBSAN checks for the problematic routines.  While `unreachable program point` usually means some undefined behavior that the optimizer is trying to take advantage of, no UB has been found.  Selective disabling of the UBSAN checks also failed to work around the problem, so this PR completely disables UBSAN for the routines in question.

Resolves #49151
Resolves https://github.com/cms-sw/framework-team/issues/1610

#### PR validation:

Compiles, verified to fix the `TestFWCoreFrameworkGlobalStreamOne` unit test.  Purely technical fix.