### PR TITLE
Cosmics Strip Clusters thresholds DQM

### DIFF
--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -185,8 +185,8 @@ if (process.runType.getRunType() == process.runType.cosmic_run or process.runTyp
         
     # Reco for cosmic data
     process.load('RecoTracker.SpecialSeedGenerators.SimpleCosmicBONSeeder_cfi')
-    process.simpleCosmicBONSeeds.ClusterCheckPSet.MaxNumberOfStripClusters = 450
-    process.combinatorialcosmicseedfinderP5.MaxNumberOfStripClusters = 450
+    process.simpleCosmicBONSeeds.ClusterCheckPSet.MaxNumberOfStripClusters = 1000
+    process.combinatorialcosmicseedfinderP5.MaxNumberOfStripClusters = 1000
 
     
 

--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -267,8 +267,13 @@ if (process.runType.getRunType() == process.runType.cosmic_run or process.runTyp
 
     # Reco for cosmic data
     process.load('RecoTracker.SpecialSeedGenerators.SimpleCosmicBONSeeder_cfi')
-    process.simpleCosmicBONSeeds.ClusterCheckPSet.MaxNumberOfStripClusters = 450
-    process.combinatorialcosmicseedfinderP5.MaxNumberOfStripClusters = 450
+    process.simpleCosmicBONSeeds.ClusterCheckPSet.MaxNumberOfStripClusters = 1000
+    process.combinatorialcosmicseedfinderP5.MaxNumberOfStripClusters = 1000
+
+    process.load('RecoTracker.FinalTrackSelectors.CTFFinalTrackSelectorP5_cff')
+    process.ctfWithMaterialTracksP5.min_nHit = 8
+    process.load('RecoTracker.FinalTrackSelectors.CosmicTFFinalTrackSelectorP5_cff')
+    process.cosmictrackfinderP5.min_nHit = 8
 
     process.RecoForDQM_TrkReco_cosmic = cms.Sequence(process.offlineBeamSpot*process.MeasurementTrackerEvent*process.ctftracksP5)
 

--- a/DQM/TrackingMonitorClient/data/tracking_qualitytest_config_tier0_cosmic.xml
+++ b/DQM/TrackingMonitorClient/data/tracking_qualitytest_config_tier0_cosmic.xml
@@ -41,7 +41,7 @@
       <PARAM name="useRange">1</PARAM>
       <PARAM name="minEntries">0</PARAM>
       <PARAM name="xmin">0.0</PARAM>
-      <PARAM name="xmax">200.0</PARAM>
+      <PARAM name="xmax">800.0</PARAM>
 </QTEST>
 <QTEST name="MeanWithinExpectedRange:SeedNPixel" activate="true">
      <TYPE>MeanWithinExpected</TYPE>


### PR DESCRIPTION
#### PR description:

These threshold changes are related to Cosmics tracks reconstruction in DQM GUI.

Since July era 2025D, after HV raise in Strip TEC, there is an excess of noise clusters in TEC, generating a large number of fake cosmics tracks reconstructed (low pT) with respect to reference (blue): https://cern.ch/fmgdm

Actions:
- Update Error Threshold value on Number of Strip Clusters in DQM GUI Tracking Summary (from 200 to 800) as real threshold limit used for track reconstruction was updated to 1000 in PR: https://github.com/cms-sw/cmssw/pull/47577
- Change Threshold on Number of Strip Clusters that prevents Track reconstruction in Cosmics inside Pixel and Strip DQM client, from 450 to 1000, as in 2025 the value often reach 450 clusters, i.e. run 395610 with 600 Strip clusters: https://cern.ch/jdn4h
- Increase threshold on number of Hits on Cosmics track from [default 5](https://github.com/cms-sw/cmssw/blob/master/RecoTracker/FinalTrackSelectors/plugins/CosmicTrackSelector.cc#L334) to 8 (same [value used by Tracker Alignment](https://github.com/cms-sw/cmssw/blob/master/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlCosmics0T_Skimmed_cff.py#L93)), to exclude tracks with 5 Hits (fake tracks, low pT): https://cern.ch/yxspq

#### PR validation:

Tested producing DQM .root file on 2000 events, observed reduction of low pT tracks (from 50 to 15) with < 8 hits.

cmsRun DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py dataset=/Cosmics/Run2025G-v1/RAW runNumber=398506 runkey=cosmic_run 

#### Backport
This PR is intended for 2025 (cosmics) data taking. 
Corresponding Backport to 15_1_X: https://github.com/cms-sw/cmssw/pull/49246