### PR TITLE
Update TestRNTupleTempGetBy to new Tracer output

### DIFF
--- a/FWIO/RNTupleTempTests/test/unit_test_outputs/testGetBy1.log
+++ b/FWIO/RNTupleTempTests/test/unit_test_outputs/testGetBy1.log
@@ -1,3 +1,6 @@
+++ finished: construction of Services
+++ starting: construction of EventSetup modules
+++ finished: construction of EventSetup modules
 ++ starting: constructing source: IntSource
 Module type=IntSource, Module label=source, Parameter Set ID=6f0b3d3a362a6270c801489bb066414a
 ++ finished: constructing source: IntSource
@@ -32,7 +35,17 @@ Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb0
 ++++ finished: constructing module with label 'intProducerU' id = 12
 ++++ starting: constructing module with label 'intVectorProducer' id = 13
 ++++ finished: constructing module with label 'intVectorProducer' id = 13
+++ starting: finalize Schedule
+++ finished: finalize Schedule
+++ starting: creation of Run, LuminosityBlock, and Event Principals
+++ finished: creation of Run, LuminosityBlock, and Event Principals
 ++ preallocate: 1 concurrent runs, 1 concurrent luminosity sections, 1 streams
+++ starting: schedule consistency check
+++ finished: schedule consistency check
+++ starting: finalize EventSetup configuration
+++ finished: finalize EventSetup configuration
+++ starting: finalize EDModules' initialization
+++ finished: finalize EDModules' initialization
 ++ starting: begin job
 ++++ starting: begin job for module with label 'TriggerResults' id = 1
 ++++ finished: begin job for module with label 'TriggerResults' id = 1

--- a/FWIO/RNTupleTempTests/test/unit_test_outputs/testGetBy2.log
+++ b/FWIO/RNTupleTempTests/test/unit_test_outputs/testGetBy2.log
@@ -1,3 +1,6 @@
+++ finished: construction of Services
+++ starting: construction of EventSetup modules
+++ finished: construction of EventSetup modules
 ++ starting: constructing source: RNTupleTempSource
 Module type=RNTupleTempSource, Module label=source, Parameter Set ID=f45c0cea718e3436a3db8abdc232e8c6
 ++++ starting: open input file: lfn = file:testGetBy1.root
@@ -18,7 +21,17 @@ Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a301
 ++++ finished: constructing module with label 'intProducerU' id = 5
 ++++ starting: constructing module with label 'intVectorProducer' id = 6
 ++++ finished: constructing module with label 'intVectorProducer' id = 6
+++ starting: finalize Schedule
+++ finished: finalize Schedule
+++ starting: creation of Run, LuminosityBlock, and Event Principals
+++ finished: creation of Run, LuminosityBlock, and Event Principals
 ++ preallocate: 1 concurrent runs, 1 concurrent luminosity sections, 1 streams
+++ starting: schedule consistency check
+++ finished: schedule consistency check
+++ starting: finalize EventSetup configuration
+++ finished: finalize EventSetup configuration
+++ starting: finalize EDModules' initialization
+++ finished: finalize EDModules' initialization
 ++ starting: begin job
 ++++ starting: begin job for module with label 'TriggerResults' id = 1
 ++++ finished: begin job for module with label 'TriggerResults' id = 1


### PR DESCRIPTION
#### PR description:

The Tracer service added new state transition output so the results of the test need to be updated.

#### PR validation:

Test now passes.

Resolves https://github.com/cms-sw/framework-team/issues/1636