### PR TITLE
[DAQ] large input source buffer fix

### DIFF
--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -88,6 +88,8 @@ private:
 
   std::string defPath_;
 
+  unsigned int paramChunkSize_;   // chunk size in MB
+  unsigned int paramBlockSize_;   // read/write block size in MB
   unsigned int eventChunkSize_;   // for buffered read-ahead
   unsigned int eventChunkBlock_;  // how much read(2) asks at the time
   unsigned int readBlocks_;

--- a/EventFilter/Utilities/interface/SourceRawFile.h
+++ b/EventFilter/Utilities/interface/SourceRawFile.h
@@ -107,8 +107,8 @@ public:
 
   tbb::concurrent_vector<InputChunk*> chunks_;
 
-  uint32_t bufferPosition_ = 0;
-  uint32_t chunkPosition_ = 0;
+  uint64_t bufferPosition_ = 0;
+  uint64_t chunkPosition_ = 0;
   unsigned int currentChunk_ = 0;
 
   InputFile(evf::EvFDaqDirector::FileStatus status,

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -53,8 +53,8 @@ using namespace edm::streamer;
 FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset, edm::InputSourceDescription const& desc)
     : edm::RawInputSource(pset, desc),
       defPath_(pset.getUntrackedParameter<std::string>("buDefPath", "")),
-      eventChunkSize_(pset.getUntrackedParameter<unsigned int>("eventChunkSize", 32) * 1048576),
-      eventChunkBlock_(pset.getUntrackedParameter<unsigned int>("eventChunkBlock", 32) * 1048576),
+      paramChunkSize_(pset.getUntrackedParameter<unsigned int>("eventChunkSize", 32)),
+      paramBlockSize_(pset.getUntrackedParameter<unsigned int>("eventChunkBlock", 32)),
       numConcurrentReads_(pset.getUntrackedParameter<int>("numConcurrentReads", -1)),
       numBuffers_(pset.getUntrackedParameter<unsigned int>("numBuffers", 2)),
       maxBufferedFiles_(pset.getUntrackedParameter<unsigned int>("maxBufferedFiles", 2)),
@@ -77,6 +77,17 @@ FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset, edm:
       eventsThisLumi_(0) {
   char thishost[256];
   gethostname(thishost, 255);
+
+  //ensure 32-bit buffer limits
+  if (paramChunkSize_ > 4095)
+    throw cms::Exception("FedRawDataInputSource::fillFEDRawDataCollection")
+        << "Invalid chunk size of " << paramChunkSize_ << " MB. Only less than 4GB is supported.";
+  if (paramBlockSize_ > 4095)
+    throw cms::Exception("FedRawDataInputSource::fillFEDRawDataCollection")
+        << "Invalid block size of " << paramBlockSize_ << " MB. Only less than 4GB is supported.";
+  eventChunkSize_ = paramChunkSize_ << 20;
+  eventChunkBlock_ = paramBlockSize_ << 20;
+
   edm::LogInfo("FedRawDataInputSource") << "Construction. read-ahead chunk size -: " << std::endl
                                         << (eventChunkSize_ / 1048576) << " MB on host " << thishost;
 
@@ -476,6 +487,13 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
     //advance buffer position to skip file header (chunk will be acquired later)
     currentFile_->chunkPosition_ += currentFile_->rawHeaderSize_;
     currentFile_->bufferPosition_ += currentFile_->rawHeaderSize_;
+
+    if (currentFile_->chunkPosition_ > UINT32_MAX)
+      throw cms::Exception("FedRawDataInputSource::getNextEvent")
+          << "chunkPosition_ overflow " << currentFile_->chunkPosition_;
+    if (currentFile_->bufferPosition_ > UINT32_MAX)
+      throw cms::Exception("FedRawDataInputSource::getNextEvent")
+          << "bufferPosition_ overflow " << currentFile_->bufferPosition_;
   }
 
   //file is too short
@@ -532,6 +550,11 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
       chunkIsFree_ = true;
     } else {
       //header was contiguous, but check if payload fits the chunk
+
+      if (currentFile_->chunkPosition_ > UINT32_MAX)
+        throw cms::Exception("FedRawDataInputSource::getNextEvent")
+            << "chunkPosition_ overflow " << currentFile_->chunkPosition_;
+
       if (eventChunkSize_ - (uint32_t)currentFile_->chunkPosition_ < msgSize) {
         //rewind to header start position
         currentFile_->rewindChunk(FRDHeaderVersionSize[detectedFRDversion_]);
@@ -1528,6 +1551,11 @@ void FedRawDataInputSource::readNextChunkIntoBuffer(InputFile* file) {
       }
     } else {
       //event didn't fit in last chunk, so leftover must be moved to the beginning and completed
+
+      if (file->chunkPosition_ > UINT32_MAX)
+        throw cms::Exception("FedRawDataInputSource::readNextChunkIntoBuffer")
+            << "chunkPosition_ overflow " << file->chunkPosition_;
+
       uint32_t existingSizeLeft = eventChunkSize_ - (uint32_t)file->chunkPosition_;
       memmove((void*)file->chunks_[0]->buf_, file->chunks_[0]->buf_ + file->chunkPosition_, existingSizeLeft);
 

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -532,7 +532,7 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
       chunkIsFree_ = true;
     } else {
       //header was contiguous, but check if payload fits the chunk
-      if (eventChunkSize_ - currentFile_->chunkPosition_ < msgSize) {
+      if (eventChunkSize_ - (uint32_t)currentFile_->chunkPosition_ < msgSize) {
         //rewind to header start position
         currentFile_->rewindChunk(FRDHeaderVersionSize[detectedFRDversion_]);
         //copy event to a chunk start and move pointers
@@ -1528,12 +1528,12 @@ void FedRawDataInputSource::readNextChunkIntoBuffer(InputFile* file) {
       }
     } else {
       //event didn't fit in last chunk, so leftover must be moved to the beginning and completed
-      uint32_t existingSizeLeft = eventChunkSize_ - file->chunkPosition_;
+      uint32_t existingSizeLeft = eventChunkSize_ - (uint32_t)file->chunkPosition_;
       memmove((void*)file->chunks_[0]->buf_, file->chunks_[0]->buf_ + file->chunkPosition_, existingSizeLeft);
 
       //calculate amount of data that can be added
-      const uint32_t blockcount = file->chunkPosition_ / eventChunkBlock_;
-      const uint32_t leftsize = file->chunkPosition_ % eventChunkBlock_;
+      const uint32_t blockcount = (uint32_t)file->chunkPosition_ / eventChunkBlock_;
+      const uint32_t leftsize = (uint32_t)file->chunkPosition_ % eventChunkBlock_;
 
       for (uint32_t i = 0; i < blockcount; i++) {
         const ssize_t last =


### PR DESCRIPTION
#### PR description:

Fixes an issue supporting buffer size over 4G for DAQSource.

Only DAQSource is adapted to this and this mainly concerns SFB mode (for example with large virgin raw events and 650 events / file typically used for SFB), since it does not read input file in chunks in this mode.
FEDRawDataInputSource remains with the 32-bit limitation, but typically only around 200 MB buffers are used with it.


<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Tested with a modified RunBUFU.sh script on FU class machines. This test is unfeasible for an unit test due to RAM requirement.