### PR TITLE
Tau fixes to mini-to-mini

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAODFromMiniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAODFromMiniAOD_tools.py
@@ -252,8 +252,12 @@ def miniAODFromMiniAOD_customizeCommon(process):
         if not (storePNetCHSjets or storeUParTPUPPIjets): return process
         noUpdatedTauName = f'{tausToUpdate}NoUTag'
         updatedTauName = ''
-        addToProcessAndTask(noUpdatedTauName, getattr(process, tausToUpdate).clone(), process, task)
-        delattr(process, tausToUpdate)
+        if '@skipCurrentProcess' in tausToUpdate or not hasattr(process, tausToUpdate):
+            noUpdatedTauName = tausToUpdate
+            tausToUpdate = noUpdatedTauName.partition(':')[0]+'Updated'
+        else:
+            addToProcessAndTask(noUpdatedTauName, getattr(process, tausToUpdate).clone(), process, task)
+            delattr(process, tausToUpdate)
         if addGenJet:
             from PhysicsTools.JetMCAlgos.TauGenJets_cfi import tauGenJets
             addToProcessAndTask('tauGenJets',
@@ -345,6 +349,8 @@ def miniAODFromMiniAOD_customizeCommon(process):
                        storeUParTPUPPIjets = m2m_uTagToTaus_switches.storeUParTPUPPIjets.value(),
                        addGenJet = m2m_uTagToTaus_switches.addGenJet.value()
     )
+    if m2m_uTagToTaus_switches.storePNetCHSjets.value() or m2m_uTagToTaus_switches.storeUParTPUPPIjets.value():
+        taus_to_use = 'slimmedTausUpdated'
 
     addToProcessAndTask("slimmedTaus", cms.EDProducer("PATTauCandidatesRekeyer",
                                                       src = cms.InputTag(taus_to_use),


### PR DESCRIPTION
#### PR description:

This is a followup development to the mini-v2/v4 to mini-v6 (cms-sw/cmssw#49098), which fixes issues related to (boosted)taus.
These issue were spot when comparing the outputs of the nano-v15 produced using two different workflows: one based on the mini-v6 from the mini-v2/v4 (re-mini wf) and the other produced directly from the mini-v2/v4 (direct wf), as documented [here](https://ftorresd.web.cern.ch/ftorresd/xpog/mini2mini_2025_10_28).

There were two types of issue:
* the difference in the DeepTau output affecting then the (boosted)tau selection applied at the nano step,
* missing tauIDs by unified taggers (PNet & UParT).

The first issue was caused by the use of different collections of pf-candidates with different puppi tunes in the DeepTauID input: in the direct wf pf-candidates with "original" puppi weights were used while in the re-mini wf pf-candidates with with updated puppi were used. These two approaches lead to comparable, but not identical DeepTauID responses, the differences are especially important for jet-like tau candidates (low vsjet scores). The fix was to use pf-candidates with "original" puppi weights.

Fixing the former issue required the addition of "hybrid" taus, i.e. a mixture of taus reconstructed by HPS reconstruction and taus tagged by unified jet taggers. Modern deep-flavour taggers were added to the CHS AK4 jet collection (slimmedJets) to make this work. These taggers are anyway present in the "genuine" mini v6 with CMSSW_15_0 (Summer24 production) therefore adding them makes re-mini v6 more similar to the "genuine" version, although they are not necessary for nano v15 where CHS jets are not stored. 

**Question for BTV experts:** In the proposed setup all deep-flavour taggers are added to the CHS AK4 jets (DeepBTag, DeepFlavour, ParticleNet, RobustParTAK4, and UnifiedParTAK4). Is it fine, or should only a subset be kept? Should it be era dependent? Note that for taus only ParticleNet (central) is necessary.

#### PR validation:

Checked with private wfs as set [this tool](https://gist.github.com/ftorrresd/3689ec54f4a5367a757ce0b2bc83e976) and with the standard wfs 2500.0401-4 and 2500.0501-3 as follows:
`runTheMatrix.py -l 2500.0401,2500.0402,2500.0403,2500.0404,2500.0501,2500.0502,2500.0503 -i all --ibeos`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to whichever release it is needed - probably all down to 15_0. Experts please comment!
