### PR TITLE
No need to explicitly delete the pre-existsing histogram for ROOT >= 6.38

### DIFF
--- a/Alignment/OfflineValidation/bin/jetHtPlotter.cc
+++ b/Alignment/OfflineValidation/bin/jetHtPlotter.cc
@@ -362,7 +362,9 @@ std::vector<double> scaleGraphByLuminosity(TGraphErrors *runGraph,
   }  // Loop over all runs in original histogram
 
   // Delete remaining old content and replace it with new one calculated from luminosities
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 38, 0)
   runGraph->GetHistogram()->Delete();
+#endif
   runGraph->SetHistogram(nullptr);
   for (int iRun = 0; iRun < nRuns; iRun++) {
     runGraph->SetPoint(iRun, xAxisValues.at(iRun), yAxisValues.at(iRun));


### PR DESCRIPTION
Fixes https://github.com/cms-sw/cmssw/issues/49309
This change needs a newer ROOT 6.38
With latest root change https://github.com/root-project/root/commit/17a49d188f74103abc5a47be471ba5fa37668c78  , to avoid memory leak, `SetHistogram` now deletes pre-existing histogram. This change propose to call `runGraph->GetHistogram()->Delete();` only for old versions of root.