### PR TITLE
[NGT] Add a "Heterogeneous only" HLT phase 2 path and menu 

### DIFF
--- a/Configuration/HLT/python/autoHLT.py
+++ b/Configuration/HLT/python/autoHLT.py
@@ -17,6 +17,7 @@ autoHLT = {
   'relvalRun4'          : '75e33',
   'relvalRun4_timing'   : '75e33_timing',
   'relvalRun4_trk'      : '75e33_trackingOnly',
-  'relvalRun4_scouting' : 'NGTScouting',    
+  'relvalRun4_scouting' : 'NGTScouting',
+  'relvalRun4_offload'  : 'HeterogeneousOnly',
   'test'                : 'GRun',
 }

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelVerticesSoA_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelVerticesSoA_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoVertex.PixelVertexFinding.PixelVertexProducerAlpakaPhase2_alpaka import PixelVertexProducerAlpakaPhase2_alpaka as _PixelVertexProducerAlpakaPhase2_alpaka
+
+hltPhase2PixelVerticesSoA = _PixelVertexProducerAlpakaPhase2_alpaka(
+    PtMin = 1.0,
+    pixelTrackSrc = "hltPhase2PixelTracksSoA",
+    maxVertices = 512,
+    useDBSCAN = cms.bool(False),
+    useDensity = cms.bool(True),
+    useIterative = cms.bool(False)
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/DST_HeterogeneousReco_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/DST_HeterogeneousReco_cfi.py
@@ -1,0 +1,90 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..sequences.HLTBeginSequence_cfi import *
+
+from ..modules.hltHGCalRecHit_cfi import hltHGCalRecHit
+from ..modules.hltHGCalUncalibRecHit_cfi import hltHGCalUncalibRecHit
+from ..modules.hltHgcalDigis_cfi import hltHgcalDigis
+from ..modules.hltHgcalSoALayerClustersProducer_cfi import hltHgcalSoALayerClustersProducer
+from ..modules.hltHgcalSoARecHitsLayerClustersProducer_cfi import hltHgcalSoARecHitsLayerClustersProducer
+from ..modules.hltHgcalSoARecHitsProducer_cfi import hltHgcalSoARecHitsProducer
+from ..modules.hltL1GTAcceptFilter_cfi import *
+from ..modules.hltPhase2OtRecHitsSoA_cfi import hltPhase2OtRecHitsSoA
+from ..modules.hltPhase2PixelRecHitsExtendedSoA_cfi import hltPhase2PixelRecHitsExtendedSoA
+from ..modules.hltPhase2PixelVerticesSoA_cfi import hltPhase2PixelVerticesSoA
+from ..modules.hltPhase2SiPixelClustersSoA_cfi import hltPhase2SiPixelClustersSoA
+from ..modules.hltPhase2SiPixelRecHitsSoA_cfi import hltPhase2SiPixelRecHitsSoA
+from ..modules.hltPhase2PixelTracksSoA_cfi import hltPhase2PixelTracksSoA
+from ..modules.hltSiPhase2Clusters_cfi import hltSiPhase2Clusters
+from ..modules.hltSiPhase2RecHits_cfi import hltSiPhase2RecHits
+
+# this has to come from the auto-generated cfi (no actual physical cfi in the menu yet)
+from RecoTracker.PixelSeeding.caHitNtupletAlpakaPhase2OT_cfi import caHitNtupletAlpakaPhase2OT as _hltPhase2PixelTracksSoA
+
+from ..sequences.HLTEndSequence_cfi import *
+
+HLTHeterogeneousTrackSequence = cms.Sequence(hltPhase2SiPixelClustersSoA
+                                             + hltPhase2SiPixelRecHitsSoA
+                                             + hltPhase2PixelTracksSoA
+                                             #+ hltPhase2PixelVerticesSoA # not yet ready
+                                             )
+
+# in situ change to get the right rechits and tracks
+hltExtendedPhase2PixelTracksSoA = _hltPhase2PixelTracksSoA.clone(pixelRecHitSrc = 'hltPhase2PixelRecHitsExtendedSoA')
+hltExtendedPhase2PixelVerticesSoA = hltPhase2PixelVerticesSoA.clone(pixelTrackSrc = 'hltExtendedPhase2PixelTracksSoA')
+
+_HLTHeterogeneousExtendedTrackSequence = cms.Sequence(hltPhase2SiPixelClustersSoA
+                                                      + hltPhase2SiPixelRecHitsSoA
+                                                      + hltSiPhase2Clusters
+                                                      + hltSiPhase2RecHits
+                                                      + hltPhase2OtRecHitsSoA
+                                                      + hltPhase2PixelRecHitsExtendedSoA
+                                                      + hltExtendedPhase2PixelTracksSoA
+                                                      #+ hltExtendedPhase2PixelVerticesSoA # not yet ready
+                                                      )
+
+from Configuration.ProcessModifiers.phase2CAExtension_cff import phase2CAExtension
+phase2CAExtension.toReplaceWith(HLTHeterogeneousTrackSequence, _HLTHeterogeneousExtendedTrackSequence)
+
+HLTHeterogeneousHGCalRecoSequence = cms.Sequence(hltHgcalDigis +
+                                                 hltHGCalUncalibRecHit +
+                                                 hltHGCalRecHit +
+                                                 hltHgcalSoARecHitsProducer +
+                                                 hltHgcalSoARecHitsLayerClustersProducer +
+                                                 hltHgcalSoALayerClustersProducer)
+
+DST_HeterogeneousReco = cms.Path(
+    HLTBeginSequence
+    + hltL1GTAcceptFilter
+    + HLTHeterogeneousTrackSequence
+    + HLTHeterogeneousHGCalRecoSequence
+    + HLTEndSequence
+)
+
+# LST Specifics
+from ..modules.hltSiPixelClusters_cfi import *
+from ..modules.hltSiPixelRecHits_cfi import *
+from ..modules.hltPhase2PixelTracks_cfi import *
+from ..modules.hltInitialStepSeeds_cfi import *
+from ..modules.hltInitialStepSeedTracksLST_cfi import *
+from ..modules.hltInputLST_cfi import *
+from ..modules.hltLST_cfi import *
+from ..modules.hltInitialStepTrajectorySeedsLST_cfi import *
+
+_LSTSequence = cms.Sequence(
+    hltSiPixelClusters +
+    hltSiPixelRecHits +
+    hltSiPhase2Clusters+
+    hltSiPhase2RecHits+
+    hltPhase2PixelTracks+
+    hltInitialStepSeeds+
+    hltInitialStepSeedTracksLST+
+    hltInputLST+
+    hltLST
+)
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+trackingLST.toModify(
+    DST_HeterogeneousReco,
+    lambda path: path.insert(path.index(HLTEndSequence), _LSTSequence)
+)

--- a/HLTrigger/Configuration/python/HLT_HeterogeneousOnly_cff.py
+++ b/HLTrigger/Configuration/python/HLT_HeterogeneousOnly_cff.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+from .HLT_75e33_cff import fragment
+
+for p in dir(fragment):
+    att = getattr(fragment, p)
+    if isinstance(att, cms.Path) and p not in [ "HLTriggerFinalPath", "HLTAnalyzerEndpath"]:
+        delattr(fragment, p)
+    del att
+
+fragment.load("HLTrigger/Configuration/HLT_75e33/paths/DST_HeterogeneousReco_cfi")    
+fragment.schedule = cms.Schedule(*[
+    fragment.DST_HeterogeneousReco,
+    fragment.HLTriggerFinalPath,
+    fragment.HLTAnalyzerEndpath,
+])


### PR DESCRIPTION
#### PR description:

For the purpose of doing Phase 2 HLT farm extrapolation within NGT we'd like to have a simplified menu that runs as much as possible of the event reconstruction using heterogeneous resources.
The goal of this PR is to add that menu `HLT_HeterogeneousOnly_cff` with a single path in it (`DST_HeterogeneousReco`).
This is a filterless path (excepted accepting any event passing the L1A) that runs the two reconstruction chains currently offloadable to GPU (pixel rechits to pixel tracks and vertices and HGCal reconstruction) together with all the necessary inputs (and conversions to GPU-friendly formats).
Through the ad-hoc modifier the LST tracking (also offloadable to GPU) can be added to the path.
 
#### PR validation:

Tested on the NGT farm (on a session with 4 L40s NVIDIA GPUs) via the following command:

```bash
cmsDriver.py Phase2 -s L1P2GT,HLT:HeterogeneousOnly \
             --processName=HLTX \
             --conditions auto:phase2_realistic_T33 \
             --geometry ExtendedRun4D110 \
             --era Phase2C17I13M9 \
             --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
             --eventcontent FEVTDEBUGHLT \
             --filein $ALL_FILES_TTBAR \
             --mc \
             --inputCommands="keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT" \
             -n -1 \
             --no_exec \
             --output={} \
             --python_filename HeterogeneousOnly_config.py
```

and timed (using 16 jobs, 16 threads and streams) as following [circles](https://marcomusich.web.cern.ch/circles/web/piechart.php?colours=default&data_name=data&dataset=HeterogeneousOnly_16j_16t_16s_CMSSW_16_0_X_2025-11-03-2300&groups=hlt&local=false&resource=time_real&show_labels=true&show_animations=true&threshold=0):

<img width="1078" height="1065" alt="image" src="https://github.com/user-attachments/assets/9599ae40-3666-4232-9770-c8a385d964c4" />

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A