### PR TITLE
Clean-up specializations of `PixelTrackProducerFromSoAAlpaka` and `SiPixelRecHitFromSoAAlpaka`

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelTracksCAExtension_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelTracksCAExtension_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hltPhase2PixelTracksCAExtension = cms.EDProducer("PixelTrackProducerFromSoAAlpakaPhase2",
+hltPhase2PixelTracksCAExtension = cms.EDProducer("PixelTrackProducerFromSoAAlpaka",
     beamSpot = cms.InputTag("hltOnlineBeamSpot"),
     minNumberOfHits = cms.int32(0),
     minQuality = cms.string('tight'),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelTracks_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelTracks_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hltPhase2PixelTracks = cms.EDProducer("PixelTrackProducerFromSoAAlpakaPhase2",
+hltPhase2PixelTracks = cms.EDProducer("PixelTrackProducerFromSoAAlpaka",
     beamSpot = cms.InputTag("hltOnlineBeamSpot"),
     minNumberOfHits = cms.int32(0),
     minQuality = cms.string('tight'),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltSiPixelRecHits_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltSiPixelRecHits_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hltSiPixelRecHits = cms.EDProducer('SiPixelRecHitFromSoAAlpakaPhase2',
+hltSiPixelRecHits = cms.EDProducer('SiPixelRecHitFromSoAAlpaka',
     pixelRecHitSrc = cms.InputTag('hltPhase2SiPixelRecHitsSoA'),
     src = cms.InputTag('hltSiPixelClusters'),
 )

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromSoAAlpaka.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromSoAAlpaka.cc
@@ -177,13 +177,5 @@ void SiPixelRecHitFromSoAAlpaka::produce(edm::StreamID streamID,
   iEvent.emplace(rechitsPutToken_, std::move(output));
 }
 
-using SiPixelRecHitFromSoAAlpakaPhase1 = SiPixelRecHitFromSoAAlpaka;
-using SiPixelRecHitFromSoAAlpakaPhase2 = SiPixelRecHitFromSoAAlpaka;
-using SiPixelRecHitFromSoAAlpakaHIonPhase1 = SiPixelRecHitFromSoAAlpaka;
-
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SiPixelRecHitFromSoAAlpaka);
-// Keeping these to ease the migration of the HLT menu
-DEFINE_FWK_MODULE(SiPixelRecHitFromSoAAlpakaPhase1);
-DEFINE_FWK_MODULE(SiPixelRecHitFromSoAAlpakaPhase2);
-DEFINE_FWK_MODULE(SiPixelRecHitFromSoAAlpakaHIonPhase1);

--- a/RecoTracker/PixelTrackFitting/plugins/PixelTrackProducerFromSoAAlpaka.cc
+++ b/RecoTracker/PixelTrackFitting/plugins/PixelTrackProducerFromSoAAlpaka.cc
@@ -508,12 +508,3 @@ void PixelTrackProducerFromSoAAlpaka::produce(edm::StreamID streamID,
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(PixelTrackProducerFromSoAAlpaka);
-
-// (also) for HLT migration, could be removed once done
-using PixelTrackProducerFromSoAAlpakaPhase1 = PixelTrackProducerFromSoAAlpaka;
-using PixelTrackProducerFromSoAAlpakaPhase2 = PixelTrackProducerFromSoAAlpaka;
-using PixelTrackProducerFromSoAAlpakaHIonPhase1 = PixelTrackProducerFromSoAAlpaka;
-
-DEFINE_FWK_MODULE(PixelTrackProducerFromSoAAlpakaPhase1);
-DEFINE_FWK_MODULE(PixelTrackProducerFromSoAAlpakaPhase2);
-DEFINE_FWK_MODULE(PixelTrackProducerFromSoAAlpakaHIonPhase1);


### PR DESCRIPTION
#### PR description:

In PR https://github.com/cms-sw/cmssw/pull/49303 we integrated the following ticket:

- [CMSHLT-3666](https://its.cern.ch/jira/browse/CMSHLT-3666) [TRK,HIN] Clean-up instances of `PixelTrackProducerFromSoAAlpaka* and SiPixelRecHitFromSoAAlpaka*` in the HLT combined tables

Thanks to that we do the final clean-up (post-alpaka migration) and remove the redundant "specialized" copies of these modules.

#### PR validation:

`cmssw` compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

Cc: @AdrianoDee 
