### PR TITLE
[TkAl][PixBary][FIX] Do not clobber output of multiple PixBary extract

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/PixBary.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/PixBary.py
@@ -81,7 +81,7 @@ def PixBary(config, validationDir, verbose=False):
                     "exe": "extractBaryCentre.py",
                     "config": {
                         "input": os.path.join(singleConfig["config"]["output"], "PixelBaryCentre.root"),
-                        "output": os.path.join(out_base, jobType, jobName),
+                        "output": os.path.join(out_base, jobType, jobName, singleName, alignment, IOV),
                         "styles": jobConfig.get("styles", ["csv", "twiki"])
                         },
                     "flavour": "espresso" # So fast that anything else would not make sense


### PR DESCRIPTION
#### PR description:
The PixBary `extract` job, introduced in https://github.com/cms-sw/cmssw/pull/48512, is configured such that the output directory does not depend on the name of the `single` job nor of the alignment; thus validations with multiple alignments/IOVs see their output clobbered by different jobs. This PR fixes this problem.

#### PR validation:
Ran the unit tests for the PixBary job:
```
scram b
cd Alignment/OfflineValidation/test
./testingScripts/validateAlignments.sh
./testingScripts/test_unitPixBary.sh
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Not applicable.
