### PR TITLE
Use RNTuple streamer mode for more SoA classes

### DIFF
--- a/DataFormats/TrackSoA/src/classes_def.xml
+++ b/DataFormats/TrackSoA/src/classes_def.xml
@@ -3,7 +3,7 @@
   <class name="reco::TrackLayout<128, false>"/>
   <class name="reco::TrackHitsLayout<128, false>"/>
 
-  <class name="reco::TracksHost"/>
+  <class name="reco::TracksHost" rntupleStreamerMode="true"/>
   <class name="edm::Wrapper<reco::TracksHost>" splitLevel="0"/>
 
   <!-- Recursive templates (with no data) ensuring we have one CollectionLeaf<index, type> for each layout in the collection -->

--- a/DataFormats/TrackingRecHitSoA/src/classes_def.xml
+++ b/DataFormats/TrackingRecHitSoA/src/classes_def.xml
@@ -4,7 +4,7 @@
   <class name="reco::HitModulesLayout<128, false>"/>
 
   <class name="reco::HitPortableCollectionHost"/>
-  <class name="reco::TrackingRecHitHost"/>
+  <class name="reco::TrackingRecHitHost"  rntupleStreamerMode="true"/>
   <class name="edm::Wrapper<reco::TrackingRecHitHost>" splitLevel="0"/>
 
   <class name="SiPixelHitStatus"/>

--- a/DataFormats/VertexSoA/src/classes_def.xml
+++ b/DataFormats/VertexSoA/src/classes_def.xml
@@ -13,6 +13,6 @@
   <class name="portablecollection::CollectionLeaf<1, reco::ZVertexTracksLayout<128, false>>"/>
 
   <!-- Collection declaration for dictionary -->
-  <class name="ZVertexHost"/>
+  <class name="ZVertexHost" rntupleStreamerMode="true"/>
   <class name="edm::Wrapper<ZVertexHost>" splitLevel="0"/>
 </lcgdict>


### PR DESCRIPTION
#### PR description:

- This should fix the problems seen in the RNTUPLE_X IBs.

#### PR validation:

Ran the RelVal 17034.0 in a CMSSW_16_0_RNTUPLE_X_2025-11-05-2300 work area with this PR and now the job runs.

resolves https://github.com/cms-sw/framework-team/issues/1637