### PR TITLE
Implement GPU vs CPU comparison for HLT pixel tracking heterogeneous products in patatrack workflows 

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1378,7 +1378,7 @@ upgradeWFs['PatatrackECALOnlyAlpaka'] = PatatrackWorkflow(
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     harvest = {
-        '-s': 'HARVESTING:@ecalOnlyValidation+@ecal'
+        '-s': 'HARVESTING:@ecalOnlyValidation+@ecal+@hltGPUvsCPU'
     },
     suffix = 'Patatrack_ECALOnlyAlpaka',
     offset = 0.412,
@@ -1400,7 +1400,7 @@ upgradeWFs['PatatrackECALOnlyAlpakaValidation'] = PatatrackWorkflow(
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     harvest = {
-        '-s': 'HARVESTING:@ecalOnlyValidation+@ecal'
+        '-s': 'HARVESTING:@ecalOnlyValidation+@ecal+@hltGPUvsCPU'
     },
     suffix = 'Patatrack_ECALOnlyAlpakaValidation',
     offset = 0.413,
@@ -1419,7 +1419,7 @@ upgradeWFs['PatatrackHCALOnlyAlpakaValidation'] = PatatrackWorkflow(
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     harvest = {
-        '-s': 'HARVESTING:@hcalOnlyValidation'
+        '-s': 'HARVESTING:@hcalOnlyValidation+@hltGPUvsCPU'
     },
     suffix = 'Patatrack_HCALOnlyAlpaka_Validation',
     offset = 0.422,
@@ -1438,7 +1438,7 @@ upgradeWFs['PatatrackHCALOnlyGPUandAlpakaValidation'] = PatatrackWorkflow(
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     harvest = {
-        '-s': 'HARVESTING:@hcalOnlyValidation'
+        '-s': 'HARVESTING:@hcalOnlyValidation+@hltGPUvsCPU'
     },
     suffix = 'Patatrack_HCALOnlyGPUandAlpaka_Validation',
     offset = 0.423,
@@ -1517,7 +1517,7 @@ upgradeWFs['PatatrackPixelOnlyAlpaka'] = PatatrackWorkflow(
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     harvest = {
-        '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM'
+        '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM+@hltGPUvsCPU'
     },
     suffix = 'Patatrack_PixelOnlyAlpaka',
     offset = 0.402,
@@ -1560,7 +1560,7 @@ upgradeWFs['PatatrackPixelOnlyAlpakaValidation'] = PatatrackWorkflow(
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     harvest = {
-        '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM',
+        '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM+@hltGPUvsCPU',
         '--procModifiers': 'alpakaValidation',
     },
     suffix = 'Patatrack_PixelOnlyAlpaka_Validation',
@@ -1599,7 +1599,7 @@ upgradeWFs['PatatrackPixelOnlyTripletsAlpaka'] = PatatrackWorkflow(
         '--customise' : 'RecoTracker/Configuration/customizePixelTracksForTriplets.customizePixelTracksForTriplets,HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling'
     },
     harvest = {
-        '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM'
+        '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM+@hltGPUvsCPU'
     },
     suffix = 'Patatrack_PixelOnlyTripletsAlpaka',
     offset = 0.406,
@@ -1620,7 +1620,7 @@ upgradeWFs['PatatrackPixelOnlyTripletsAlpakaValidation'] = PatatrackWorkflow(
         '--customise' : 'RecoTracker/Configuration/customizePixelTracksForTriplets.customizePixelTracksForTriplets,HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling'
     },
     harvest = {
-        '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM'
+        '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM+@hltGPUvsCPU'
     },
     suffix = 'Patatrack_PixelOnlyTripletsAlpaka_Validation',
     offset = 0.407,

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareRecHits.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareRecHits.cc
@@ -223,30 +223,30 @@ void SiPixelCompareRecHits::bookHistograms(DQMStore::IBooker& iBook,
 
   // clang-format off
   //Global
-  hnHits_ = iBook.book2I("nHits", "ReferencevsTarget RecHits per event;#Reference RecHits;#Target RecHits", 200, 0, 5000,200, 0, 5000);
+  hnHits_ = iBook.book2I("nHits", "RecHits per event;#Reference RecHits;#Target RecHits", 200, 0, 5000,200, 0, 5000);
   //Barrel Layer
   for(unsigned int il=0;il<tkGeom_->numberOfLayers(PixelSubdetector::PixelBarrel);il++){
-    hBchargeL_[il] = iBook.book2I(Form("recHitsBLay%dCharge",il+1), Form("ReferencevsTarget RecHits Charge Barrel Layer%d;Reference Charge;Target Charge",il+1), 250, 0, 100000, 250, 0, 100000);
-    hBsizexL_[il] = iBook.book2I(Form("recHitsBLay%dSizex",il+1), Form("ReferencevsTarget RecHits SizeX Barrel Layer%d;Reference SizeX;Target SizeX",il+1), 30, 0, 30, 30, 0, 30);
-    hBsizeyL_[il] = iBook.book2I(Form("recHitsBLay%dSizey",il+1), Form("ReferencevsTarget RecHits SizeY Barrel Layer%d;Reference SizeY;Target SizeY",il+1), 30, 0, 30, 30, 0, 30);
-    hBposxL_[il] = iBook.book2D(Form("recHitsBLay%dPosx",il+1), Form("ReferencevsTarget RecHits x-pos in Barrel Layer%d;Reference pos x;Target pos x",il+1), 200, -5, 5, 200,-5,5);
-    hBposyL_[il] = iBook.book2D(Form("recHitsBLay%dPosy",il+1), Form("ReferencevsTarget RecHits y-pos in Barrel Layer%d;Reference pos y;Target pos y",il+1), 200, -5, 5, 200,-5,5);
+    hBchargeL_[il] = iBook.book2I(Form("recHitsBLay%dCharge",il+1), Form("RecHits Charge Barrel Layer%d;Reference Charge;Target Charge",il+1), 250, 0, 100000, 250, 0, 100000);
+    hBsizexL_[il] = iBook.book2I(Form("recHitsBLay%dSizex",il+1), Form("RecHits SizeX Barrel Layer%d;Reference SizeX;Target SizeX",il+1), 30, 0, 30, 30, 0, 30);
+    hBsizeyL_[il] = iBook.book2I(Form("recHitsBLay%dSizey",il+1), Form("RecHits SizeY Barrel Layer%d;Reference SizeY;Target SizeY",il+1), 30, 0, 30, 30, 0, 30);
+    hBposxL_[il] = iBook.book2D(Form("recHitsBLay%dPosx",il+1), Form("RecHits x-pos in Barrel Layer%d;Reference pos x;Target pos x",il+1), 200, -5, 5, 200,-5,5);
+    hBposyL_[il] = iBook.book2D(Form("recHitsBLay%dPosy",il+1), Form("RecHits y-pos in Barrel Layer%d;Reference pos y;Target pos y",il+1), 200, -5, 5, 200,-5,5);
   }
   //Endcaps
   //Endcaps Disk
   for(int is=0;is<2;is++){
     int sign=is==0? -1:1;
     for(unsigned int id=0;id<tkGeom_->numberOfLayers(PixelSubdetector::PixelEndcap);id++){
-      hFchargeD_[is][id] = iBook.book2I(Form("recHitsFDisk%+dCharge",id*sign+sign), Form("ReferencevsTarget RecHits Charge Endcaps Disk%+d;Reference Charge;Target Charge",id*sign+sign), 250, 0, 100000, 250, 0, 100000);
-      hFsizexD_[is][id] = iBook.book2I(Form("recHitsFDisk%+dSizex",id*sign+sign), Form("ReferencevsTarget RecHits SizeX Endcaps Disk%+d;Reference SizeX;Target SizeX",id*sign+sign), 30, 0, 30, 30, 0, 30);
-      hFsizeyD_[is][id] = iBook.book2I(Form("recHitsFDisk%+dSizey",id*sign+sign), Form("ReferencevsTarget RecHits SizeY Endcaps Disk%+d;Reference SizeY;Target SizeY",id*sign+sign), 30, 0, 30, 30, 0, 30);
-      hFposxD_[is][id] = iBook.book2D(Form("recHitsFDisk%+dPosx",id*sign+sign), Form("ReferencevsTarget RecHits x-pos Endcaps Disk%+d;Reference pos x;Target pos x",id*sign+sign), 200, -5, 5, 200, -5, 5);
-      hFposyD_[is][id] = iBook.book2D(Form("recHitsFDisk%+dPosy",id*sign+sign), Form("ReferencevsTarget RecHits y-pos Endcaps Disk%+d;Reference pos y;Target pos y",id*sign+sign), 200, -5, 5, 200, -5, 5);
+      hFchargeD_[is][id] = iBook.book2I(Form("recHitsFDisk%+dCharge",id*sign+sign), Form("RecHits Charge Endcaps Disk%+d;Reference Charge;Target Charge",id*sign+sign), 250, 0, 100000, 250, 0, 100000);
+      hFsizexD_[is][id] = iBook.book2I(Form("recHitsFDisk%+dSizex",id*sign+sign), Form("RecHits SizeX Endcaps Disk%+d;Reference SizeX;Target SizeX",id*sign+sign), 30, 0, 30, 30, 0, 30);
+      hFsizeyD_[is][id] = iBook.book2I(Form("recHitsFDisk%+dSizey",id*sign+sign), Form("RecHits SizeY Endcaps Disk%+d;Reference SizeY;Target SizeY",id*sign+sign), 30, 0, 30, 30, 0, 30);
+      hFposxD_[is][id] = iBook.book2D(Form("recHitsFDisk%+dPosx",id*sign+sign), Form("RecHits x-pos Endcaps Disk%+d;Reference pos x;Target pos x",id*sign+sign), 200, -5, 5, 200, -5, 5);
+      hFposyD_[is][id] = iBook.book2D(Form("recHitsFDisk%+dPosy",id*sign+sign), Form("RecHits y-pos Endcaps Disk%+d;Reference pos y;Target pos y",id*sign+sign), 200, -5, 5, 200, -5, 5);
     }
   }
   //1D differences
-  hBchargeDiff_ = iBook.book1D("rechitChargeDiffBpix","Charge differnce of rechits in BPix; rechit charge difference (Reference - Target)", 101, -50.5, 50.5);
-  hFchargeDiff_ = iBook.book1D("rechitChargeDiffFpix","Charge differnce of rechits in FPix; rechit charge difference (Reference - Target)", 101, -50.5, 50.5);
+  hBchargeDiff_ = iBook.book1D("rechitChargeDiffBpix","Charge difference of rechits in BPix; rechit charge difference (Reference - Target)", 101, -50.5, 50.5);
+  hFchargeDiff_ = iBook.book1D("rechitChargeDiffFpix","Charge difference of rechits in FPix; rechit charge difference (Reference - Target)", 101, -50.5, 50.5);
   hBsizeXDiff_ = iBook.book1D("rechitsizeXDiffBpix","SizeX difference of rechits in BPix; rechit sizex difference (Reference - Target)", 21, -10.5, 10.5);
   hFsizeXDiff_ = iBook.book1D("rechitsizeXDiffFpix","SizeX difference of rechits in FPix; rechit sizex difference (Reference - Target)", 21, -10.5, 10.5);
   hBsizeYDiff_ = iBook.book1D("rechitsizeYDiffBpix","SizeY difference of rechits in BPix; rechit sizey difference (Reference - Target)", 21, -10.5, 10.5);

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareRecHitsSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareRecHitsSoA.cc
@@ -222,8 +222,8 @@ void SiPixelCompareRecHitsSoA<T>::bookHistograms(DQMStore::IBooker& iBook,
     }
   }
   //1D differences
-  hBchargeDiff_ = iBook.book1D("rechitChargeDiffBpix","Charge differnce of rechits in BPix; rechit charge difference (CPU - GPU)", 101, -50.5, 50.5);
-  hFchargeDiff_ = iBook.book1D("rechitChargeDiffFpix","Charge differnce of rechits in FPix; rechit charge difference (CPU - GPU)", 101, -50.5, 50.5);
+  hBchargeDiff_ = iBook.book1D("rechitChargeDiffBpix","Charge difference of rechits in BPix; rechit charge difference (CPU - GPU)", 101, -50.5, 50.5);
+  hFchargeDiff_ = iBook.book1D("rechitChargeDiffFpix","Charge difference of rechits in FPix; rechit charge difference (CPU - GPU)", 101, -50.5, 50.5);
   hBsizeXDiff_ = iBook.book1D("rechitsizeXDiffBpix","SizeX difference of rechits in BPix; rechit sizex difference (CPU - GPU)", 21, -10.5, 10.5);
   hFsizeXDiff_ = iBook.book1D("rechitsizeXDiffFpix","SizeX difference of rechits in FPix; rechit sizex difference (CPU - GPU)", 21, -10.5, 10.5);
   hBsizeYDiff_ = iBook.book1D("rechitsizeYDiffBpix","SizeY difference of rechits in BPix; rechit sizey difference (CPU - GPU)", 21, -10.5, 10.5);

--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -87,6 +87,7 @@ from DQMOffline.Muon.muonQualityTests_cff import *
 from DQMOffline.EGamma.egammaPostProcessing_cff import *
 from DQMOffline.HLTScouting.HLTScoutingPostProcessing_cff import *
 from DQMOffline.Trigger.DQMOffline_Trigger_Client_cff import *
+from DQMOffline.Trigger.HeterogeneousMonitoringClient_cff import *
 from DQMOffline.Trigger.DQMOffline_HLT_Client_cff import *
 from DQMOffline.RecoB.dqmCollector_cff import *
 from DQM.BeamMonitor.AlcaBeamMonitorClient_cff import *
@@ -100,6 +101,9 @@ DQMOffline_SecondStepEGamma = cms.Sequence( egammaPostProcessing )
 
 DQMOffline_SecondStepTrigger = cms.Sequence( triggerOfflineDQMClient *
 						hltOfflineDQMClient )
+
+# HLT Heterogeneous monitoring sequence
+DQMHarvestHLTGPUvsCPU = cms.Sequence( HLTHeterogeneousMonitoringHarvesting )
 
 DQMOffline_SecondStepBTag = cms.Sequence( bTagCollectorSequenceDATA )
 

--- a/DQMOffline/Configuration/python/autoDQM.py
+++ b/DQMOffline/Configuration/python/autoDQM.py
@@ -233,7 +233,7 @@ autoDQM = { 'DQMMessageLogger': ['DQMMessageLoggerSeq',
 
             'hltGPUvsCPU' : ['DQMOfflineHLTGPUvsCPU',
                              'PostDQMOffline',
-                             'dqmHarvesting'],
+                             'DQMHarvestHLTGPUvsCPU'],
 
             'standardDQMExpress': ['DQMOfflineExpress',
                                    'PostDQMOffline',

--- a/DQMOffline/Trigger/python/HeterogeneousMonitoringClient_cff.py
+++ b/DQMOffline/Trigger/python/HeterogeneousMonitoringClient_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+# Tracker
+from DQM.SiPixelHeterogeneous.siPixelTrackComparisonHarvester_cfi import *
+hltSiPixelTrackComparisonHarvester = siPixelTrackComparisonHarvester.clone(topFolderName = 'HLT/HeterogeneousComparisons/PixelTracks')
+
+HLTHeterogeneousMonitoringHarvesting =  cms.Sequence(hltSiPixelTrackComparisonHarvester)

--- a/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
@@ -28,9 +28,28 @@ hltPfHcalGPUComparisonTask = pfHcalGPUComparisonTask.clone(
 from DQM.SiPixelHeterogeneous.SiPixelHeterogenousDQM_FirstStep_cff import *
 
 hltSiPixelPhase1CompareDigiErrors = siPixelPhase1RawDataErrorComparator.clone(
-    topFolderName = cms.string('HLT/HeterogeneousComparisons/PixelErrors'),
-    pixelErrorSrcGPU = cms.InputTag("hltSiPixelDigiErrors"),
-    pixelErrorSrcCPU = cms.InputTag("hltSiPixelDigiErrorsSerialSync")
+    pixelErrorSrcGPU = 'hltSiPixelDigiErrors',
+    pixelErrorSrcCPU = 'hltSiPixelDigiErrorsSerialSync',
+    topFolderName = 'HLT/HeterogeneousComparisons/PixelErrors'
+)
+
+hltSiPixelPhase1CompareRecHits = siPixelPhase1CompareRecHits.clone(
+    pixelHitsReferenceSoA = 'hltSiPixelRecHitsSoASerialSync',
+    pixelHitsTargetSoA  = 'hltSiPixelRecHitsSoA',
+    topFolderName = 'HLT/HeterogeneousComparisons/PixelRecHits'
+)
+
+hltSiPixelPhase1CompareTracks = siPixelPhase1CompareTracks.clone(
+    pixelTrackReferenceSoA = 'hltPixelTracksSoASerialSync',
+    pixelTrackTargetSoA = 'hltPixelTracksSoA',
+    topFolderName = 'HLT/HeterogeneousComparisons/PixelTracks'
+)
+
+hltSiPixelCompareVertices = siPixelCompareVertices.clone(
+    pixelVertexReferenceSoA = 'hltPixelVerticesSoASerialSync',
+    pixelVertexTargetSoA = 'hltPixelVerticesSoA',
+    beamSpotSrc = 'hltOnlineBeamSpot',
+    topFolderName = 'HLT/HeterogeneousComparisons/PixelVertices'
 )
 
 # Ecal
@@ -76,9 +95,12 @@ hltHcalGPUComparisonTask = hcalGPUComparisonTask.clone(
 )
 
 HLTHeterogeneousMonitoringSequence = cms.Sequence(
-    hltPfHcalGPUComparisonTask+
-    hltSiPixelPhase1CompareDigiErrors+
-    hltEcalMonitorTask+
+    hltPfHcalGPUComparisonTask +
+    hltSiPixelPhase1CompareDigiErrors +
+    hltSiPixelPhase1CompareRecHits +
+    hltSiPixelPhase1CompareTracks +
+    hltSiPixelCompareVertices +
+    hltEcalMonitorTask +
     hltHcalGPUComparisonTask    
 )
 


### PR DESCRIPTION
#### PR description:

This PR is a quick follow-up upon https://github.com/cms-sw/cmssw/pull/49105.
Thanks to the recently merged PR https://github.com/cms-sw/cmssw/pull/49303 we are now saving into the `HLTDebugRAW` and `HLTDebugFEVT` event content definitions also `hltSiPixelRecHitsSoA*`, `hltPixelTracksSoA*` and `hltPixelVerticesSoA*`.
This puts us in a position to include in the `HLTHeterogeneousMonitoringSequence` defined in  https://github.com/cms-sw/cmssw/pull/49105 all the various monitoring modules for the pixel rechits, tracks and vertex `SoA`s. This is carried out in commit e8814acc691cbdd0ee902a0bfef56759cb0d1cda.
I profit of this PR to fix some typos / oddities in commit eaef3cd5ba73b1fa6df2a76433897d328319c75a as well as adding a harvesting step for the `@hltGPUvsCPU` sequence in commit 0e98d607aab30a82cc498629ed3a0aa04b955c1d.

#### PR validation:

Run successfully: 

`runTheMatrix.py --what gpu -l 17034.402 -t 4 -j 8 --ibeos`

and checked that the desired output plots are available (see for example [here](https://marcomusich.web.cern.ch/display/DQM_forGPUvsCPU_v2.root)).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, it won't be backported.