### PR TITLE
Don't use GLEW in Fireworks

### DIFF
--- a/Fireworks/Core/src/CmsAnnotation.cc
+++ b/Fireworks/Core/src/CmsAnnotation.cc
@@ -1,7 +1,9 @@
 #include <sstream>
 #include <cmath>
 
-#include "TGLIncludes.h"
+#include <GL/gl.h>
+#include <GL/glu.h>
+
 #include "TGLCamera.h"
 #include "TGLRnrCtx.h"
 #include "TGLSelectRecord.h"

--- a/Fireworks/Core/src/FWEveDigitSetScalableMarker.cc
+++ b/Fireworks/Core/src/FWEveDigitSetScalableMarker.cc
@@ -1,4 +1,6 @@
-#include "TGLIncludes.h"
+#include <GL/gl.h>
+#include <GL/glu.h>
+
 #include "Fireworks/Core/src/FWEveDigitSetScalableMarker.h"
 
 void FWEveDigitSetScalableMarkerGL::DirectDraw(TGLRnrCtx& rnrCtx) const {

--- a/Fireworks/Core/src/FWGUIManager.cc
+++ b/Fireworks/Core/src/FWGUIManager.cc
@@ -17,10 +17,12 @@
 #include <thread>
 #include <future>
 
+#include <GL/gl.h>
+#include <GL/glu.h>
+
 #include "TGButton.h"
 #include "TGLabel.h"
 #include "TSystem.h"
-#include "TGLIncludes.h"
 #include "TGLViewer.h"
 #include "TEveBrowser.h"
 #include "TEveManager.h"
@@ -849,16 +851,14 @@ void FWGUIManager::exportAllViews(const std::string& format, int height) {
       TString file;
       file.Form(format.c_str(), event->id().run(), event->id().event(), event->luminosityBlock(), view_name.Data());
 
-      if (GLEW_EXT_framebuffer_object) {
-        // Multi-threaded save
-        futures.push_back((*j)->CaptureAndSaveImage(file, height));
-      } else {
-        // Single-threaded save
-        if (height == -1)
-          (*j)->GetGLViewer()->SavePicture(file);
-        else
-          (*j)->GetGLViewer()->SavePictureHeight(file, height);
-      }
+      // Multi-threaded save
+      futures.push_back((*j)->CaptureAndSaveImage(file, height));
+
+      // Single-threaded save
+      // if (height == -1)
+      //   (*j)->GetGLViewer()->SavePicture(file);
+      // else
+      //   (*j)->GetGLViewer()->SavePictureHeight(file, height);
     }
   }
 

--- a/Fireworks/Core/src/FWGeoTopNodeGL.cc
+++ b/Fireworks/Core/src/FWGeoTopNodeGL.cc
@@ -1,7 +1,9 @@
 #include "Fireworks/Core/src/FWGeoTopNodeGL.h"
 #include "Fireworks/Core/interface/FWGeoTopNode.h"
 
-#include "TGLIncludes.h"
+#include <GL/gl.h>
+#include <GL/glu.h>
+
 #include "TGLRnrCtx.h"
 #include "TGLViewer.h"
 

--- a/Fireworks/Core/src/FWTEveViewer.cc
+++ b/Fireworks/Core/src/FWTEveViewer.cc
@@ -18,8 +18,10 @@
 // user include files
 
 #include "TMath.h"
-#include "TGLIncludes.h"
 #include "TGLFBO.h"
+
+#include <GL/gl.h>
+#include <GL/glu.h>
 
 #include "Fireworks/Core/interface/FWTEveViewer.h"
 #include "Fireworks/Core/interface/FWTGLViewer.h"

--- a/Fireworks/Core/src/FWTGLViewer.cc
+++ b/Fireworks/Core/src/FWTGLViewer.cc
@@ -18,7 +18,9 @@
 
 #include "TMath.h"
 
-#include "TGLIncludes.h"
+#include <GL/gl.h>
+#include <GL/glu.h>
+
 #include "TGLFBO.h"
 #include "TGLWidget.h"
 
@@ -141,10 +143,6 @@ TGLFBO* FWTGLViewer::GenerateFbo(Int_t w, Int_t h, Float_t pixel_object_scale) {
   // Generate FBO -- function that does the actual work.
 
   static const TString eh("FWTGLViewer::SavePictureUsingFBO");
-
-  if (!GLEW_EXT_framebuffer_object) {
-    ::Warning(eh, "Missing FBO support.");
-  }
 
   if (!TakeLock(kDrawLock)) {
     ::Error(eh, "viewer locked - try later.");

--- a/Fireworks/Core/src/FWTextProjected.cc
+++ b/Fireworks/Core/src/FWTextProjected.cc
@@ -20,7 +20,8 @@
 #include "TEveTrans.h"
 #include "TGLBoundingBox.h"
 
-#include "TGLIncludes.h"
+#include <GL/gl.h>
+#include <GL/glu.h>
 
 #include "TGLRnrCtx.h"
 #include "TGLUtil.h"

--- a/Fireworks/Vertices/src/TEveEllipsoidGL.cc
+++ b/Fireworks/Vertices/src/TEveEllipsoidGL.cc
@@ -14,7 +14,9 @@
 #include "TMatrixDSym.h"
 
 #include "TDecompSVD.h"
-#include "TGLIncludes.h"
+
+#include <GL/gl.h>
+#include <GL/glu.h>
 
 //==============================================================================
 // TEveEllipsoidGL


### PR DESCRIPTION
The Frame Buffer Object (FBO) feature is part of OpenGL since version 3.0 from 2008. Nowadays, we can therefore assume that this feature is always available. That means we don't have to use GLEW to check whether this feature is present.

Like that, we can avoid using GLEW entirely, which is an implementation detail of OpenGL loading in ROOT that will soon go away.

To make sure GLEW is not included anymore, this commit replaces includes of `TGLIncludes.h` with the OpenGL headers only, because `TGLIncludes.h` was including OpenGL plus GLEW.

See also:

  * https://github.com/root-project/root/issues/18471
  * https://github.com/root-project/root/pull/20294#issuecomment-3501449951
  * 1235f792c29b126e2e2d5c9522d53788d0da8961

FYI @smuzaffar @bellenot @osschar 