### PR TITLE
[151X][DQMEcalMonitor]: Avoid bins with same entries

### DIFF
--- a/DQM/EcalCommon/src/MESetEcal.cc
+++ b/DQM/EcalCommon/src/MESetEcal.cc
@@ -177,8 +177,10 @@ namespace ecaldqm {
                 specs[iSpec]->edges = std::vector<float>(specs[iSpec]->nbins + 1);
                 int nbins(specs[iSpec]->nbins);
                 double low(specs[iSpec]->low), high(specs[iSpec]->high);
-                for (int i(0); i < nbins + 1; i++)
-                  specs[iSpec]->edges[i] = low + (high - low) / nbins * i;
+                double binSize = (high - low) / nbins;
+                specs[iSpec]->edges[0] = low;
+                for (int i(1); i < nbins + 1; i++)
+                  specs[iSpec]->edges[i] = specs[iSpec]->edges[i - 1] + binSize;
               }
             }
             me = _ibooker.book2D(name, name, xaxis.nbins, &(xaxis.edges[0]), yaxis.nbins, &(yaxis.edges[0]));

--- a/DQM/EcalMonitorTasks/python/SelectiveReadoutTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/SelectiveReadoutTask_cfi.py
@@ -1,10 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
-dccSizeBinEdges = []
-for i in range(11) :
-    dccSizeBinEdges.append(0.608 / 10. * i)
+binSize = 0.0608
+dccSizeBinEdges = [0]
+for i in range(1, 11) :
+    dccSizeBinEdges.append(dccSizeBinEdges[-1]+binSize)
+binSize = binSize * 10.
 for i in range(11, 79) :
-    dccSizeBinEdges.append(0.608 * (i - 10.))
+    dccSizeBinEdges.append(dccSizeBinEdges[-1]+binSize)
 
 ecalSelectiveReadoutTask = cms.untracked.PSet(
     params = cms.untracked.PSet(


### PR DESCRIPTION
Backport of #49330  

As reported in https://github.com/cms-sw/cmssw/issues/49307 , newer root now requires bins in increasing order. CMSSW code https://github.com/cms-sw/cmssw/blob/master/DQM/EcalMonitorTasks/python/SelectiveReadoutTask_cfi.py#L3-L7 was generating bins with same value (see https://github.com/cms-sw/cmssw/issues/49307#issuecomment-349352188 ). This PR proposes to fix this code so that it generates bins in increasing order. Code is also a little improved and avoid multiplications and divisions in loop.

Though we might not build 15.1.X with newer root but it is better to fix the Ecal bins and avoid duplicate entires. Backport is requested here https://github.com/cms-sw/cmssw/pull/49330#issuecomment-3502375882