### PR TITLE
Fix energy regression issue in TICLv5

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltTiclCandidate_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltTiclCandidate_cfi.py
@@ -6,14 +6,14 @@ hltTiclCandidate = cms.EDProducer("TICLCandidateProducer",
     pluginInferenceAlgoTracksterInferenceByPFN = cms.PSet(
       algo_verbosity = cms.int32(0),
       onnxPIDModelPath = cms.FileInPath('RecoHGCal/TICL/data/ticlv5/onnx_models/PFN/linking/id_v0.onnx'),
-      onnxEnergyModelPath = cms.FileInPath('RecoHGCal/TICL/data/ticlv5/onnx_models/PFN/linking/energy_v0.onnx'),
+      onnxEnergyModelPath = cms.FileInPath('RecoHGCal/TICL/data/ticlv5/onnx_models/PFN/linking/energy_v1.onnx'),
       inputNames = cms.vstring(
         'input',
         'input_tr_features'
       ),
       output_en = cms.vstring('enreg_output'),
       output_id = cms.vstring('pid_output'),
-      eid_min_cluster_energy = cms.double(1),
+      eid_min_cluster_energy = cms.double(2.5),
       eid_n_layers = cms.int32(50),
       eid_n_clusters = cms.int32(10),
       doPID = cms.int32(1),

--- a/RecoHGCal/TICL/interface/TracksterInferenceAlgoBase.h
+++ b/RecoHGCal/TICL/interface/TracksterInferenceAlgoBase.h
@@ -18,6 +18,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "PhysicsTools/ONNXRuntime/interface/ONNXRuntime.h"
 #include "FWCore/PluginManager/interface/PluginFactory.h"
+#include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
 namespace ticl {
   class TracksterInferenceAlgoBase {
@@ -26,7 +27,9 @@ namespace ticl {
         : algo_verbosity_(conf.getParameter<int>("algo_verbosity")) {}
     virtual ~TracksterInferenceAlgoBase() {}
 
-    virtual void inputData(const std::vector<reco::CaloCluster>& layerClusters, std::vector<Trackster>& tracksters) = 0;
+    virtual void inputData(const std::vector<reco::CaloCluster>& layerClusters,
+                           std::vector<Trackster>& tracksters,
+                           const hgcal::RecHitTools& rhtools) = 0;
     virtual void runInference(std::vector<Trackster>& tracksters) = 0;
     static void fillPSetDescription(edm::ParameterSetDescription& desc) { desc.add<int>("algo_verbosity", 0); };
 

--- a/RecoHGCal/TICL/interface/TracksterInferenceByANN.h
+++ b/RecoHGCal/TICL/interface/TracksterInferenceByANN.h
@@ -7,7 +7,9 @@ namespace ticl {
   class TracksterInferenceByANN : public TracksterInferenceAlgoBase {
   public:
     explicit TracksterInferenceByANN(const edm::ParameterSet& conf);
-    void inputData(const std::vector<reco::CaloCluster>& layerClusters, std::vector<Trackster>& tracksters) override;
+    void inputData(const std::vector<reco::CaloCluster>& layerClusters,
+                   std::vector<Trackster>& tracksters,
+                   const hgcal::RecHitTools& rhtools) override;
     void runInference(std::vector<Trackster>& tracksters) override;
 
   private:

--- a/RecoHGCal/TICL/interface/TracksterInferenceByCNNv4.h
+++ b/RecoHGCal/TICL/interface/TracksterInferenceByCNNv4.h
@@ -9,7 +9,9 @@ namespace ticl {
   class TracksterInferenceByCNNv4 : public TracksterInferenceAlgoBase {
   public:
     explicit TracksterInferenceByCNNv4(const edm::ParameterSet& conf);
-    void inputData(const std::vector<reco::CaloCluster>& layerClusters, std::vector<Trackster>& tracksters) override;
+    void inputData(const std::vector<reco::CaloCluster>& layerClusters,
+                   std::vector<Trackster>& tracksters,
+                   const hgcal::RecHitTools& rhtools) override;
     void runInference(std::vector<Trackster>& tracksters) override;
 
     static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
@@ -27,7 +29,6 @@ namespace ticl {
     int doPID_;
     int doRegression_;
 
-    hgcal::RecHitTools rhtools_;
     std::vector<std::vector<int64_t>> input_shapes_;
     std::vector<int> tracksterIndices_;
     std::vector<std::vector<float>> input_Data_;

--- a/RecoHGCal/TICL/interface/TracksterInferenceByDNN.h
+++ b/RecoHGCal/TICL/interface/TracksterInferenceByDNN.h
@@ -9,7 +9,9 @@ namespace ticl {
   class TracksterInferenceByDNN : public TracksterInferenceAlgoBase {
   public:
     explicit TracksterInferenceByDNN(const edm::ParameterSet& conf);
-    void inputData(const std::vector<reco::CaloCluster>& layerClusters, std::vector<Trackster>& tracksters) override;
+    void inputData(const std::vector<reco::CaloCluster>& layerClusters,
+                   std::vector<Trackster>& tracksters,
+                   const hgcal::RecHitTools& rhtools) override;
     void runInference(std::vector<Trackster>& tracksters) override;
 
     static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
@@ -30,7 +32,6 @@ namespace ticl {
     int doPID_;
     int doRegression_;
 
-    hgcal::RecHitTools rhtools_;
     std::vector<std::vector<int64_t>> input_shapes_;
     std::vector<int> tracksterIndices_;
     std::vector<std::vector<float>> input_Data_;

--- a/RecoHGCal/TICL/interface/TracksterInferenceByPFN.h
+++ b/RecoHGCal/TICL/interface/TracksterInferenceByPFN.h
@@ -9,7 +9,9 @@ namespace ticl {
   class TracksterInferenceByPFN : public TracksterInferenceAlgoBase {
   public:
     explicit TracksterInferenceByPFN(const edm::ParameterSet& conf);
-    void inputData(const std::vector<reco::CaloCluster>& layerClusters, std::vector<Trackster>& tracksters) override;
+    void inputData(const std::vector<reco::CaloCluster>& layerClusters,
+                   std::vector<Trackster>& tracksters,
+                   const hgcal::RecHitTools& rhtools) override;
     void runInference(std::vector<Trackster>& tracksters) override;
 
     static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
@@ -30,7 +32,6 @@ namespace ticl {
     int doPID_;
     int doRegression_;
 
-    hgcal::RecHitTools rhtools_;
     std::vector<std::vector<int64_t>> input_shapes_;
     std::vector<int> tracksterIndices_;
     std::vector<std::vector<float>> input_Data_;

--- a/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
+++ b/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
@@ -332,7 +332,7 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
                         true);
   if (regressionAndPid_) {
     // Run inference algorithm
-    inferenceAlgo_->inputData(layerClusters, *resultTracksters);
+    inferenceAlgo_->inputData(layerClusters, *resultTracksters, rhtools_);
     inferenceAlgo_->runInference(
         *resultTracksters);  //option to use "Linking" instead of "CLU3D"/"energyAndPid" instead of "PID"
   }

--- a/RecoHGCal/TICL/plugins/TracksterInferenceByANN.cc
+++ b/RecoHGCal/TICL/plugins/TracksterInferenceByANN.cc
@@ -10,7 +10,8 @@ namespace ticl {
   }
 
   void TracksterInferenceByANN::inputData(const std::vector<reco::CaloCluster>& layerClusters,
-                                          std::vector<Trackster>& tracksters) {
+                                          std::vector<Trackster>& tracksters,
+                                          const hgcal::RecHitTools& rhtools) {
     // Prepare data for inference
   }
 

--- a/RecoHGCal/TICL/plugins/TracksterInferenceByCNNv4.cc
+++ b/RecoHGCal/TICL/plugins/TracksterInferenceByCNNv4.cc
@@ -30,7 +30,8 @@ namespace ticl {
 
   // Method to process input data and prepare it for inference
   void TracksterInferenceByCNNv4::inputData(const std::vector<reco::CaloCluster>& layerClusters,
-                                            std::vector<Trackster>& tracksters) {
+                                            std::vector<Trackster>& tracksters,
+                                            const hgcal::RecHitTools& rhtools) {
     tracksterIndices_.clear();  // Clear previous indices
     for (int i = 0; i < static_cast<int>(tracksters.size()); i++) {
       float sumClusterEnergy = 0.;
@@ -74,7 +75,7 @@ namespace ticl {
       // Fill input data with cluster information
       for (const int& k : clusterIndices) {
         const reco::CaloCluster& cluster = layerClusters[trackster.vertices(k)];
-        int j = rhtools_.getLayerWithOffset(cluster.hitsAndFractions()[0].first) - 1;
+        int j = rhtools.getLayerWithOffset(cluster.hitsAndFractions()[0].first) - 1;
         if (j < eidNLayers_ && seenClusters[j] < eidNClusters_) {
           auto index = (i * eidNLayers_ + j) * eidNFeatures_ * eidNClusters_ + seenClusters[j] * eidNFeatures_;
           input_Data_[0][index] =

--- a/RecoHGCal/TICL/plugins/TracksterInferenceByDNN.cc
+++ b/RecoHGCal/TICL/plugins/TracksterInferenceByDNN.cc
@@ -33,12 +33,13 @@ namespace ticl {
 
   // Method to process input data and prepare it for inference
   void TracksterInferenceByDNN::inputData(const std::vector<reco::CaloCluster>& layerClusters,
-                                          std::vector<Trackster>& tracksters) {
+                                          std::vector<Trackster>& tracksters,
+                                          const hgcal::RecHitTools& rhtools) {
     tracksterIndices_.clear();  // Clear previous indices
     for (int i = 0; i < static_cast<int>(tracksters.size()); i++) {
       float sumClusterEnergy = 0.;
       for (const unsigned int& vertex : tracksters[i].vertices()) {
-        if (rhtools_.isBarrel(layerClusters[vertex].seed()))
+        if (rhtools.isBarrel(layerClusters[vertex].seed()))
           continue;
         sumClusterEnergy += static_cast<float>(layerClusters[vertex].energy());
         if (sumClusterEnergy >= eidMinClusterEnergy_) {
@@ -79,7 +80,7 @@ namespace ticl {
       // Fill input data with cluster information
       for (const int& k : clusterIndices) {
         const reco::CaloCluster& cluster = layerClusters[trackster.vertices(k)];
-        int j = rhtools_.getLayerWithOffset(cluster.hitsAndFractions()[0].first) - 1;
+        int j = rhtools.getLayerWithOffset(cluster.hitsAndFractions()[0].first) - 1;
         if (j < eidNLayers_ && seenClusters[j] < eidNClusters_) {
           auto index = (i * eidNLayers_ + j) * eidNFeatures_ * eidNClusters_ + seenClusters[j] * eidNFeatures_;
           input_Data_[0][index] =

--- a/RecoHGCal/TICL/plugins/TracksterLinksProducer.cc
+++ b/RecoHGCal/TICL/plugins/TracksterLinksProducer.cc
@@ -239,7 +239,7 @@ void TracksterLinksProducer::produce(edm::Event &evt, const edm::EventSetup &es)
 
   if (regressionAndPid_) {
     // Run inference algorithm
-    inferenceAlgo_->inputData(layerClusters, *resultTracksters);
+    inferenceAlgo_->inputData(layerClusters, *resultTracksters, rhtools_);
     inferenceAlgo_->runInference(
         *resultTracksters);  //option to use "Linking" instead of "CLU3D"/"energyAndPid" instead of "PID"
   }

--- a/RecoHGCal/TICL/python/iterativeTICL_cff.py
+++ b/RecoHGCal/TICL/python/iterativeTICL_cff.py
@@ -107,10 +107,10 @@ ticlTracksterLinks = _tracksterLinksProducer.clone(
         inputNames  = cms.vstring('input','input_tr_features'),
         output_en   = cms.vstring('enreg_output'),
         output_id   = cms.vstring('pid_output'),
-	eid_min_cluster_energy = cms.double(1),
+	eid_min_cluster_energy = cms.double(2.5),
         eid_n_clusters = cms.int32(10),
 	eid_n_layers = cms.int32(50),
-        onnxEnergyModelPath = cms.FileInPath('RecoHGCal/TICL/data/ticlv5/onnx_models/PFN/linking/energy_v0.onnx'),
+        onnxEnergyModelPath = cms.FileInPath('RecoHGCal/TICL/data/ticlv5/onnx_models/PFN/linking/energy_v1.onnx'),
         onnxPIDModelPath = cms.FileInPath('RecoHGCal/TICL/data/ticlv5/onnx_models/PFN/linking/id_v0.onnx'),
         type = cms.string('TracksterInferenceByPFN')
     )
@@ -124,14 +124,14 @@ ticlCandidate = _ticlCandidateProducer.clone(
         onnxPIDModelPath=cms.FileInPath(
             'RecoHGCal/TICL/data/ticlv5/onnx_models/PFN/linking/id_v0.onnx'),
         onnxEnergyModelPath=cms.FileInPath(
-            'RecoHGCal/TICL/data/ticlv5/onnx_models/PFN/linking/energy_v0.onnx'),
+            'RecoHGCal/TICL/data/ticlv5/onnx_models/PFN/linking/energy_v1.onnx'),
         inputNames=cms.vstring(
             'input',
             'input_tr_features'
         ),
         output_en=cms.vstring('enreg_output'),
         output_id=cms.vstring('pid_output'),
-        eid_min_cluster_energy=cms.double(1),
+        eid_min_cluster_energy=cms.double(2.5),
         eid_n_layers=cms.int32(50),
         eid_n_clusters=cms.int32(10),
         doPID=cms.int32(1),

--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -112,6 +112,7 @@ namespace hgcal {
 
   private:
     const CaloGeometry* geom_;
+    void checkGeometry() const;
     unsigned int eeOffset_, fhOffset_, bhFirstLayer_, bhLastLayer_, bhOffset_, fhLastLayer_, noseLastLayer_;
     unsigned int hcalBarrelFirstLayer_, hcalBarrelLastLayer_, ecalBarrelFirstLayer_, ecalBarrelLastLayer_;
     unsigned int maxNumberOfWafersPerLayer_, maxNumberOfWafersNose_;

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -32,7 +32,6 @@ namespace {
       throw cms::Exception("hgcal::RecHitTools") << "Geometry not provided yet to hgcal::RecHitTools!";
     }
   }
-
   inline const HGCalDDDConstants* get_ddd(const CaloSubdetectorGeometry* geom, const HGCalDetId& detid) {
     const HGCalGeometry* hg = static_cast<const HGCalGeometry*>(geom);
     const HGCalDDDConstants* ddd = &(hg->topology().dddConstants());
@@ -145,6 +144,7 @@ void RecHitTools::setGeometry(const CaloGeometry& geom) {
 }
 
 const CaloSubdetectorGeometry* RecHitTools::getSubdetectorGeometry(const DetId& id) const {
+  checkGeometry();
   DetId::Detector det = id.det();
   int subdet = (det == DetId::HGCalEE || det == DetId::HGCalHSi || det == DetId::HGCalHSc)
                    ? ForwardSubdetector::ForwardEmpty
@@ -155,6 +155,7 @@ const CaloSubdetectorGeometry* RecHitTools::getSubdetectorGeometry(const DetId& 
 }
 
 GlobalPoint RecHitTools::getPosition(const DetId& id) const {
+  checkGeometry();
   auto geom = getSubdetectorGeometry(id);
   GlobalPoint position;
   if (id.det() == DetId::Hcal || id.det() == DetId::Ecal) {
@@ -167,6 +168,7 @@ GlobalPoint RecHitTools::getPosition(const DetId& id) const {
 }
 
 GlobalPoint RecHitTools::getPositionLayer(int layer, bool nose, bool barrel) const {
+  checkGeometry();
   unsigned int lay = std::abs(layer);
   double x(0), y(0), z(0);
   if (nose) {
@@ -273,6 +275,7 @@ std::pair<float, float> RecHitTools::getScintDEtaDPhi(const DetId& id) const {
 }
 
 std::float_t RecHitTools::getRadiusToSide(const DetId& id) const {
+  checkGeometry();
   auto geom = getSubdetectorGeometry(id);
   std::float_t size(std::numeric_limits<std::float_t>::max());
   if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) {
@@ -295,6 +298,7 @@ std::float_t RecHitTools::getRadiusToSide(const DetId& id) const {
 }
 
 unsigned int RecHitTools::getLayer(const ForwardSubdetector type) const {
+  checkGeometry();
   int layer(0);
   switch (type) {
     case (ForwardSubdetector::HGCEE): {
@@ -408,6 +412,7 @@ unsigned int RecHitTools::getLayer(const DetId& id) const {
 }
 
 unsigned int RecHitTools::getLayerWithOffset(const DetId& id) const {
+  checkGeometry();
   unsigned int layer = getLayer(id);
   if (id.det() == DetId::Forward && id.subdetId() == HGCHEF) {
     layer += fhOffset_;
@@ -458,6 +463,7 @@ std::pair<int, int> RecHitTools::getCell(const DetId& id) const {
 }
 
 bool RecHitTools::isHalfCell(const DetId& id) const {
+  checkGeometry();
   bool ishalf = false;
   if (id.det() == DetId::Forward) {
     HGCalDetId hid(id);
@@ -471,6 +477,7 @@ bool RecHitTools::isHalfCell(const DetId& id) const {
 }
 
 int RecHitTools::getCellType(const DetId& id) const {
+  checkGeometry();
   auto layer_number = getLayerWithOffset(id);
   auto thickness = getSiThickIndex(id);
   auto geomNose =
@@ -524,7 +531,6 @@ bool RecHitTools::isBarrel(const DetId& id) const {
          (id.det() == DetId::Hcal && id.subdetId() == HcalBarrel) ||
          (id.det() == DetId::Hcal && id.subdetId() == HcalOuter);
 }
-
 bool RecHitTools::isOnlySilicon(const unsigned int layer) const {
   // HFnose TODO
   bool isonlysilicon = (layer % bhLastLayer_) < bhOffset_;
@@ -635,3 +641,12 @@ std::vector<double> RecHitTools::getSiThickness(DetId::Detector det, int subdet)
   auto ddd = get_ddd(geom_, det, subdet);
   return ddd->cellThickness();
 }
+
+namespace hgcal {
+  void RecHitTools::checkGeometry() const {
+    if (!geom_) {
+      throw cms::Exception("hgcal::RecHitTools")
+          << "Geometry not provided yet to RecHitTools! Call setGeometry() before using this function.";
+    }
+  }
+}  // namespace hgcal


### PR DESCRIPTION
Fix for the regression issue observed in TICLv5 by the NGT group during JetValidation at HLT, where the jet response vs. pT showed abnormally high values.

After investigation, the main issue was traced to missing geometry in the rechit tools responsible for assigning the layer ID to LC during the image formation step used as input to the regression model.

This PR implements the following changes:
- Fixes the missing geometry assignment in the rechit tools.
- Retrains the regression model to account for the recent updates introduced in TICL.
- Adds protection in the rechit tools to ensure they crash if used without proper geometry initialization.

This PR to be tested with TICL workflows such as: 29888.203, 29688.203
Additionally, it requires the following cms-data PR: https://github.com/cms-data/RecoHGCal-TICL/pull/10

workflow_opts = -w upgrade
workflow = 29888.203,29688.203

Adding the jet response as a function of pT before (left) and after (right) the issue was fixed, looking at the jet validation plots at the HLT. It can be clearly seen the issue has been resolved.

<img width="500" alt="Before fix" src="https://github.com/user-attachments/assets/8a2116f9-2366-4b61-94c9-3d72a2fd756b" /> <img width="500" alt="After fix" src="https://github.com/user-attachments/assets/2fba103c-e13e-4b19-82c5-3024a7930c2a" />
Also adding the links of the full sets of plots before [1] and after [2] fixing the issue.

[1] Plots before the fix: https://evernazz.web.cern.ch/evernazz/NGT/JetMETValidationPlots/JetPerformance_TICLv5_NewPlots/hltAK4PFPuppiJets/

[2] Plots after the fix: https://mohamed.web.cern.ch/linking/hltAK4PFPuppiJets_RelVal_newPFN_v3/

FYI: @felicepantaleo @waredjeb @hatakeyamak