### PR TITLE
Py312: use sys._getframe instead of slow inspect.getframeinfo

### DIFF
--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -1,5 +1,6 @@
 from builtins import range, object
 import inspect
+import sys
 from typing import Union
 
 class _ConfigureComponent(object):
@@ -731,10 +732,9 @@ class _ValidatingParameterListBase(_ValidatingListBase,_ParameterTypeBase):
         return (converter(x).value() for x in strings)
 
 def saveOrigin(obj, level):
-    import sys
-    fInfo = inspect.getframeinfo(sys._getframe(level+1))
-    obj._filename = fInfo.filename
-    obj._lineNumber =fInfo.lineno
+    frame = sys._getframe(level+1)
+    obj._filename = frame.f_code.co_filename
+    obj._lineNumber = frame.f_lineno
 
 def _modifyParametersFromDict(params, newParams, errorRaiser, keyDepth=""):
     if len(newParams):


### PR DESCRIPTION
In PY312 IBs, few unit tests fail due to timeout (not finishing with in an hour). Debugging shows that call to https://github.com/cms-sw/cmssw/blob/master/FWCore/ParameterSet/python/Mixins.py#L733-L737 (which uses `inspect.getframeinfo`) is very slow.  As we are only interested in filename and line number, so this PR proposes to use `sys._getframe` directly.

Note that `sys._getframe`  is still much slower in `python 3.12` as compare to `python 3.9`. On `cmsdevXX` nodes,  unit test e.g. `TestConfigDP_12` from `Configuration/DataProcessing` packages takes on avg `145sec` in DEFAULT IBs but takes over `380s` for PY312 IBs
 
[a]https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc13/CMSSW_16_0_PY312_X_2025-11-09-2300/unitTestLogs/Configuration/DataProcessing#/
```
Retrieved Scenario: cosmicsHybridEra_Run2_2018
Using Global Tag: GLOBALTAG
Configuring to Write out FEVT
Configuring to Write out DQMIO
Configuring to Write out ALCARECO
removing ENDJOB from steps since not compatible with DQMIO dataTier
entry tobeoverwritten.xyz
Warning: The default GeometryRecoDB_cff is being used; however, the DB geometry is not applied. You may need to verify your cmsDriver.
Step: RAW2DIGI Spec: 
Step: L1Reco Spec: 
Step: RECO Spec: 
Step: ALCAPRODUCER Spec: ['TkAlMinBias', 'SiStripCalMinBias']

---> test TestConfigDP_2 had ERRORS
TestTime:3600
```