### PR TITLE
MTD digitization: fix for empty BTL digis

### DIFF
--- a/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
@@ -236,9 +236,11 @@ void BTLElectronicsSim::run(const mtd::MTDSimHitDataAccumulator& input,
     }  // iside loop
 
     // --- skip if both sides are empty
-    if (charge_adc[0] == 0 && charge_adc[1] == 0) continue;
-    if (toa1[0] == 0 && toa1[1] == 0) continue;
-    
+    if (charge_adc[0] == 0 && charge_adc[1] == 0)
+      continue;
+    if (toa1[0] == 0 && toa1[1] == 0)
+      continue;
+
     // --- Run the shaper to create a new data frame
     BTLDataFrame rawDataFrame(it->first.detid_);
     runTrivialShaper(rawDataFrame, charge_adc, toa1, toa2, it->first.row_, it->first.column_);

--- a/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
@@ -235,6 +235,10 @@ void BTLElectronicsSim::run(const mtd::MTDSimHitDataAccumulator& input,
 
     }  // iside loop
 
+    // --- skip if both sides are empty
+    if (charge_adc[0] == 0 && charge_adc[1] == 0) continue;
+    if (toa1[0] == 0 && toa1[1] == 0) continue;
+    
     // --- Run the shaper to create a new data frame
     BTLDataFrame rawDataFrame(it->first.detid_);
     runTrivialShaper(rawDataFrame, charge_adc, toa1, toa2, it->first.row_, it->first.column_);


### PR DESCRIPTION
#### PR description:
This PR implements a fix to the BTL DigiCollection to skip empty BTL samples (i.e. with charge and time  = 0) from the event.

#### PR validation:
The code compiles and runs. It was tested on wf 29706.0 and produces the expected results.
The effectiveness of the fix was also verified by running:
https://github.com/cms-sw/cmssw/blob/master/SimFastTiming/FastTimingCommon/test/runMTDDigiDump.py
