### PR TITLE
 Run Scouting DQM in RelVals (+ change in JME scouting DQM sequence)

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -147,6 +147,11 @@ DQMOfflineJetMET = cms.Sequence( jetMETDQMOfflineSource )
 DQMOfflineEGamma = cms.Sequence( egammaDQMOffline )
 
 DQMOfflineTrigger = cms.Sequence( triggerOfflineDQMSource )
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+## Remove Scouting DQM in run1/2 eras and phase2
+(~run3_common | phase2_common).toReplaceWith(DQMOfflineScouting, cms.Sequence( ))
+
 
 DQMOfflineBTag = cms.Sequence( bTagPlotsDATA )
 
@@ -161,6 +166,7 @@ DQMOfflinePrePOG = cms.Sequence( DQMOfflineTracking *
                                  DQMOfflineJetMET *
                                  DQMOfflineEGamma *
                                  DQMOfflineTrigger *
+                                 DQMOfflineScouting *
                                  DQMOfflineBTag *
                                  DQMOfflineBeam *
                                  DQMOfflinePhysics )
@@ -198,14 +204,13 @@ DQMOfflineExpress = cms.Sequence( DQMOfflinePreDPGExpress *
                                   HLTMonitoring *
                                   DQMMessageLogger )
 
-
 DQMOfflineExtraHLT = cms.Sequence( offlineValidationHLTSource )
 
 
 DQMOfflineFakeHLT = cms.Sequence( DQMOffline )
 DQMOfflineFakeHLT.remove( HLTMonitoring )
 DQMOfflineFakeHLT.remove( DQMOfflineTrigger )
-
+DQMOfflineFakeHLT.remove( DQMOfflineScouting )
 #MC
 DQMOfflinePrePOGMC = cms.Sequence( DQMOfflineVertex *
                                    DQMOfflineBTag *
@@ -244,6 +249,7 @@ DQMOfflineCommon = cms.Sequence( DQMOfflineDCS *
 				 DQMOfflineTrackerPixel *
                                  DQMOfflineTracking *
                                  DQMOfflineTrigger *
+                                 DQMOfflineScouting *
                                  DQMOfflineBeam *
                                  DQMOfflineCASTOR *
                                  DQMOfflinePhysics *
@@ -252,6 +258,7 @@ DQMOfflineCommon = cms.Sequence( DQMOfflineDCS *
 
 DQMOfflineCommonFakeHLT = cms.Sequence( DQMOfflineCommon )
 DQMOfflineCommonFakeHLT.remove( DQMOfflineTrigger )
+DQMOfflineCommonFakeHLT.remove( DQMOfflineScouting )
 
 #MinBias/ZeroBias
 DQMOfflineTrackerStripMinBias = cms.Sequence( SiStripDQMTier0MinBias )

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -36,6 +36,7 @@ from Configuration.Eras.Modifier_run3_common_cff import run3_common
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 ## Remove Scouting DQM in run1/2 eras and phase2
 (~run3_common | phase2_common).toReplaceWith(DQMOfflineScouting, cms.Sequence( ))
+DQMOfflineScoutingForRelVals = DQMOfflineScouting.copy()
 DQMOfflineScoutingForRelVals.replace(hltScoutingDqmOffline, hltScoutingJetDqmOfflineForRelVals)
 
 # HLT Heterogeneous monitoring sequence

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -32,6 +32,11 @@ DQMOfflineDCS = cms.Sequence( dqmProvInfo )
 
 # HLT Scouting trigger sequence
 DQMOfflineScouting = cms.Sequence( hltScoutingDqmOffline ) 
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+## Remove Scouting DQM in run1/2 eras and phase2
+(~run3_common | phase2_common).toReplaceWith(DQMOfflineScouting, cms.Sequence( ))
+DQMOfflineScoutingForRelVals.replace(hltScoutingDqmOffline, hltScoutingJetDqmOfflineForRelVals)
 
 # HLT Heterogeneous monitoring sequence
 DQMOfflineHLTGPUvsCPU =  cms.Sequence( HLTHeterogeneousMonitoringSequence )
@@ -147,11 +152,6 @@ DQMOfflineJetMET = cms.Sequence( jetMETDQMOfflineSource )
 DQMOfflineEGamma = cms.Sequence( egammaDQMOffline )
 
 DQMOfflineTrigger = cms.Sequence( triggerOfflineDQMSource )
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
-from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-## Remove Scouting DQM in run1/2 eras and phase2
-(~run3_common | phase2_common).toReplaceWith(DQMOfflineScouting, cms.Sequence( ))
-
 
 DQMOfflineBTag = cms.Sequence( bTagPlotsDATA )
 
@@ -166,7 +166,7 @@ DQMOfflinePrePOG = cms.Sequence( DQMOfflineTracking *
                                  DQMOfflineJetMET *
                                  DQMOfflineEGamma *
                                  DQMOfflineTrigger *
-                                 DQMOfflineScouting *
+                                 DQMOfflineScoutingForRelVals *
                                  DQMOfflineBTag *
                                  DQMOfflineBeam *
                                  DQMOfflinePhysics )
@@ -210,7 +210,7 @@ DQMOfflineExtraHLT = cms.Sequence( offlineValidationHLTSource )
 DQMOfflineFakeHLT = cms.Sequence( DQMOffline )
 DQMOfflineFakeHLT.remove( HLTMonitoring )
 DQMOfflineFakeHLT.remove( DQMOfflineTrigger )
-DQMOfflineFakeHLT.remove( DQMOfflineScouting )
+DQMOfflineFakeHLT.remove( DQMOfflineScoutingForRelVals )
 #MC
 DQMOfflinePrePOGMC = cms.Sequence( DQMOfflineVertex *
                                    DQMOfflineBTag *
@@ -249,7 +249,7 @@ DQMOfflineCommon = cms.Sequence( DQMOfflineDCS *
 				 DQMOfflineTrackerPixel *
                                  DQMOfflineTracking *
                                  DQMOfflineTrigger *
-                                 DQMOfflineScouting *
+                                 DQMOfflineScoutingForRelVals *
                                  DQMOfflineBeam *
                                  DQMOfflineCASTOR *
                                  DQMOfflinePhysics *
@@ -258,7 +258,7 @@ DQMOfflineCommon = cms.Sequence( DQMOfflineDCS *
 
 DQMOfflineCommonFakeHLT = cms.Sequence( DQMOfflineCommon )
 DQMOfflineCommonFakeHLT.remove( DQMOfflineTrigger )
-DQMOfflineCommonFakeHLT.remove( DQMOfflineScouting )
+DQMOfflineCommonFakeHLT.remove( DQMOfflineScoutingForRelVals )
 
 #MinBias/ZeroBias
 DQMOfflineTrackerStripMinBias = cms.Sequence( SiStripDQMTier0MinBias )

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -37,7 +37,7 @@ from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 ## Remove Scouting DQM in run1/2 eras and phase2
 (~run3_common | phase2_common).toReplaceWith(DQMOfflineScouting, cms.Sequence( ))
 DQMOfflineScoutingForRelVals = DQMOfflineScouting.copy()
-DQMOfflineScoutingForRelVals.replace(hltScoutingDqmOffline, hltScoutingJetDqmOfflineForRelVals)
+DQMOfflineScoutingForRelVals.replace(hltScoutingDqmOffline, hltScoutingDqmOfflineForRelVals)
 
 # HLT Heterogeneous monitoring sequence
 DQMOfflineHLTGPUvsCPU =  cms.Sequence( HLTHeterogeneousMonitoringSequence )

--- a/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
+++ b/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
@@ -28,6 +28,8 @@ hltScoutingMuonDqmOffline = cms.Sequence(scoutingMonitoringTagProbeMuonNoVtx *
                                          ScoutingMuonPropertiesMonitor )
 
 hltScoutingJetDqmOffline = cms.Sequence(jetMETDQMOfflineSourceScouting)
+## remove corrector to not schedule the run of the corrector modules which crash if scouting objects are missing
+hltScoutingJetDqmOfflineForRelVals = cms.Sequence(jetMETDQMOfflineSourceScoutingNoCorrection)
 
 hltScoutingCollectionMonitor = cms.Sequence(scoutingCollectionMonitor)
 

--- a/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
+++ b/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
@@ -34,3 +34,5 @@ hltScoutingJetDqmOfflineForRelVals = cms.Sequence(jetMETDQMOfflineSourceScouting
 hltScoutingCollectionMonitor = cms.Sequence(scoutingCollectionMonitor)
 
 hltScoutingDqmOffline = cms.Sequence(hltScoutingMuonDqmOffline + hltScoutingEGammaDqmOffline + hltScoutingJetDqmOffline + hltScoutingCollectionMonitor)
+hltScoutingDqmOfflineForRelVals = hltScoutingDqmOffline.copy()
+hltScoutingDqmOfflineForRelVals.replace(hltScoutingJetDqmOffline, hltScoutingJetDqmOfflineForRelVals)

--- a/DQMOffline/JetMET/python/jetAnalyzer_cff.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cff.py
@@ -15,6 +15,9 @@ _jetDQMAnalyzerSequenceWithPUPPI = cms.Sequence(jetDQMAnalyzerAk4CaloCleaned
                                    )
 
 jetDQMAnalyzerSequenceScouting = cms.Sequence(jetDQMAnalyzerAk4ScoutingUncleaned*jetDQMAnalyzerAk4ScoutingCleaned)
+jetDQMAnalyzerAk4ScoutingUncleanedNoCorrection = jetDQMAnalyzerAk4ScoutingUncleaned.clone(JetCorrections = cms.InputTag(''))
+jetDQMAnalyzerAk4ScoutingCleanedNoCorrection = jetDQMAnalyzerAk4ScoutingCleaned.clone(JetCorrections = cms.InputTag(''))
+jetDQMAnalyzerSequenceScoutingNoCorrection = cms.Sequence(jetDQMAnalyzerAk4ScoutingUncleanedNoCorrection*jetDQMAnalyzerAk4ScoutingCleanedNoCorrection)
 
 jetDQMAnalyzerSequenceCosmics = cms.Sequence(jetDQMAnalyzerAk4CaloUncleaned)
 

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
@@ -139,7 +139,7 @@ ak4PFScoutingL1FastL2L3ResidualCorrectorTask = cms.Task(
 ak4PFScoutingL1FastL2L3ResidualCorrectorChain = cms.Sequence(ak4PFScoutingL1FastL2L3ResidualCorrectorTask)
     
 dqmAk4PFScoutingL1FastL2L3ResidualCorrector = ak4PFScoutingL1FastL2L3ResidualCorrector.clone()
-dqmAk4PFScoutingL1FastL2L3ResidualCorrectorChain = cms.Sequence(
+dqmAk4PFScoutingL1FastL2L3ResidualCorrectorTask = cms.Task(
     dqmAk4PFScoutingL1FastL2L3ResidualCorrector
 )
 
@@ -220,9 +220,10 @@ _jetMETDQMOfflineSourceWithPUPPI = cms.Sequence(AnalyzeSUSYDQM*QGTagger*
                                       *METDQMAnalyzerSequence
                                       *pfCandidateDQMAnalyzer)
 
-jetMETDQMOfflineSourceScouting = cms.Sequence(jetPreDQMSeqScouting*
-                                      dqmAk4PFScoutingL1FastL2L3ResidualCorrectorChain*
-                                      jetDQMAnalyzerSequenceScouting)
+# We must keep correctors in Task to skip their execution when in events without scouting objects
+jetMETDQMOfflineSourceScouting = cms.Sequence(jetDQMAnalyzerSequenceScouting,
+                                              jetPreDQMTaskScouting,
+                                              dqmAk4PFScoutingL1FastL2L3ResidualCorrectorTask)
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 (~pp_on_AA).toReplaceWith(jetMETDQMOfflineSource, _jetMETDQMOfflineSourceWithPUPPI)

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
@@ -224,6 +224,7 @@ _jetMETDQMOfflineSourceWithPUPPI = cms.Sequence(AnalyzeSUSYDQM*QGTagger*
 jetMETDQMOfflineSourceScouting = cms.Sequence(jetDQMAnalyzerSequenceScouting,
                                               jetPreDQMTaskScouting,
                                               dqmAk4PFScoutingL1FastL2L3ResidualCorrectorTask)
+jetMETDQMOfflineSourceScoutingNoCorrection = cms.Sequence(jetDQMAnalyzerSequenceScoutingNoCorrection)
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 (~pp_on_AA).toReplaceWith(jetMETDQMOfflineSource, _jetMETDQMOfflineSourceWithPUPPI)


### PR DESCRIPTION
#### PR description:

DQM Offline for Scouting was added by https://github.com/cms-sw/cmssw/pull/47235. 
It was activated in PromptReco at T0 only for `ScoutingPFMonitor` dataset by https://github.com/dmwm/T0/pull/5053, specifically by adding `@hltScouting` to `dqm_sequences` in [ProdOfflineConfiguration.py](https://github.com/dmwm/T0/blob/master/etc/ProdOfflineConfiguration.py).
As discussed at the [trigger review](https://indico.cern.ch/event/1597088/contributions/6738695/), it would be useful to have these DQM plots also in RelVals -- and also in AlCaVal -- to monitor the performance of HLT/Scouting objects.

Note: Currently Scouting DQM requires scouting object to run (otherwise it will crash). This PR changes the JME scouting DQM (`jetMETDQMOfflineSourceScouting`) to use Task. In this way the crashing module (`ak4PFScoutingL1FastjetCorrector`) will run only when requested by the JME scouting module (`jetDQMAnalyzerSequenceScouting`), ie. when scouting objects exists. In this way we avoid the crash (cc @etzovara).
Note-2: `egmGsfElectronIDsForScoutingDQM` will use `gedGsfElectrons` instead of `slimmedElectrons` to be compatible with RECO without AOD (cc @tihsu99)

This PR simply adds scouting DQM to the trigger DQM sequence. 

#### PR validation:

I'm having some problems with the validation (https://github.com/cms-sw/cmssw/issues/49331). I would like to check that all corner cases are covered (in particular I suspect that a re-reco of a non-scouting dataset might have problems)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be defined

(previous attempts #49350  #49336)

FYI @patinkaew @cms-sw/hlt-l2 