### PR TITLE
Need to add TracksHost::Implementation to classes_def.xml

### DIFF
--- a/DataFormats/TrackSoA/src/classes_def.xml
+++ b/DataFormats/TrackSoA/src/classes_def.xml
@@ -4,6 +4,9 @@
   <class name="reco::TrackHitsLayout<128, false>"/>
 
   <class name="reco::TracksHost" rntupleStreamerMode="true"/>
+  <!-- In principle this should not be necessary, but it looks like it is triggering a bug (?) in ROOT/cling. -->
+  <!-- For more details see the discussion in #49333 and #49360. -->
+  <class name="reco::TracksHost::Implementation"/>
   <class name="edm::Wrapper<reco::TracksHost>" splitLevel="0"/>
 
   <!-- Recursive templates (with no data) ensuring we have one CollectionLeaf<index, type> for each layout in the collection -->


### PR DESCRIPTION
#### PR description:

- This avoids a segmentation fault in new version of ROOT.

#### PR validation:

Ran with addOn test `Raw_PIon_MC_HLT` in CMSSW_16_0_ROOT6_X_2025-11-06-2300 and that now works.

resolves #49333
resolves https://github.com/cms-sw/framework-team/issues/1647
