### PR TITLE
MTD digitization: update ETL digitization to emulate ETROC TDC window 

### DIFF
--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/ETLUncalibRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/ETLUncalibRecHitAlgo.cc
@@ -12,7 +12,6 @@ public:
         adcSaturation_(conf.getParameter<double>("adcSaturation")),
         adcLSB_(adcSaturation_ / (1 << adcNBits_)),
         toaLSBToNS_(conf.getParameter<double>("toaLSB_ns")),
-        tofDelay_(conf.getParameter<double>("tofDelay")),
         timeError_(conf.getParameter<std::string>("timeResolutionInNs")),
         timeCorr_p0_(conf.getParameter<double>("timeCorr_p0")),
         timeCorr_p1_(conf.getParameter<double>("timeCorr_p1")),
@@ -33,7 +32,6 @@ private:
   const double adcSaturation_;
   const double adcLSB_;
   const double toaLSBToNS_;
-  const double tofDelay_;
   const reco::FormulaEvaluator timeError_;
   const double timeCorr_p0_;
   const double timeCorr_p1_;
@@ -45,7 +43,7 @@ FTLUncalibratedRecHit ETLUncalibRecHitAlgo::makeRecHit(const ETLDataFrame& dataF
   constexpr int iSample = 2;  //only in-time sample
   const auto& sample = dataFrame.sample(iSample);
 
-  double time = double(sample.toa()) * toaLSBToNS_ - tofDelay_;
+  double time = double(sample.toa()) * toaLSBToNS_;
   double time_over_threshold = double(sample.tot()) * toaLSBToNS_;
   const std::array<double, 1> time_over_threshold_V = {{time_over_threshold}};
 

--- a/RecoLocalFastTime/FTLRecProducers/python/mtdUncalibratedRecHits_cfi.py
+++ b/RecoLocalFastTime/FTLRecProducers/python/mtdUncalibratedRecHits_cfi.py
@@ -17,7 +17,6 @@ _endcapAlgo = cms.PSet(
     adcNbits      = mtdDigitizer.endcapDigitizer.ElectronicsSimulation.adcNbits,
     adcSaturation = mtdDigitizer.endcapDigitizer.ElectronicsSimulation.adcSaturation_MIP,
     toaLSB_ns     = mtdDigitizer.endcapDigitizer.ElectronicsSimulation.toaLSB_ns,
-    tofDelay      = mtdDigitizer.endcapDigitizer.DeviceSimulation.tofDelay,
     timeResolutionInNs = cms.string("0.0370"), # [ns]
     timeCorr_p0 = cms.double(0.967683), # 0.974683 - 0.007, ad hoc correction for bias from global delay removal
     timeCorr_p1 = cms.double(-0.237274),

--- a/SimFastTiming/FastTimingCommon/interface/ETLDeviceSim.h
+++ b/SimFastTiming/FastTimingCommon/interface/ETLDeviceSim.h
@@ -43,12 +43,13 @@ private:
   const reco::FormulaEvaluator lgadGainDegradation_;
   const bool applyDegradation_;
   float bxTime_;
-  float tofDelay_;
   const reco::FormulaEvaluator MPVMuon_;
   const reco::FormulaEvaluator MPVPion_;
   const reco::FormulaEvaluator MPVKaon_;
   const reco::FormulaEvaluator MPVElectron_;
   const reco::FormulaEvaluator MPVProton_;
+  float tdcWindowStart_;
+  float tdcWindowEnd_;
 };
 
 #endif

--- a/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
+++ b/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
@@ -71,13 +71,14 @@ _endcap_MTDDigitizer = cms.PSet(
         LGADGainVsFluence    = cms.string("TMath::Min(15.,30.-x)"),
         LGADGainDegradation  = cms.string("TMath::Max(1.0, TMath::Min(x, x + 0.05/0.01 * (x - 1) + y * (1 - x)/0.01))"),
         applyDegradation     = cms.bool(False),
-        tofDelay             = cms.double(1),
         meVPerMIP            = cms.double(0.085), #from HGCAL
         MPVMuon             = cms.string("1.21561e-05 + 8.89462e-07 / (x * x)"),
         MPVPion             = cms.string("1.24531e-05 + 7.16578e-07 / (x * x)"),
         MPVKaon             = cms.string("1.20998e-05 + 2.47192e-06 / (x * x * x)"),
         MPVElectron         = cms.string("1.30030e-05 + 1.55166e-07 / (x * x)"),
-        MPVProton           = cms.string("1.13666e-05 + 1.20093e-05 / (x * x)")
+        MPVProton           = cms.string("1.13666e-05 + 1.20093e-05 / (x * x)"),
+        tdcWindowStart      = cms.double(9.375), # 3 x ETROC_clock
+        tdcWindowEnd        = cms.double(21.875) # 3 x ETROC_clock + 12.5 ns
         ),
     ElectronicsSimulation = cms.PSet(
         bxTime               = cms.double(25),

--- a/SimFastTiming/FastTimingCommon/src/ETLDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/ETLDeviceSim.cc
@@ -23,12 +23,13 @@ ETLDeviceSim::ETLDeviceSim(const edm::ParameterSet& pset, edm::ConsumesCollector
       lgadGainDegradation_(pset.getParameter<std::string>("LGADGainDegradation")),
       applyDegradation_(pset.getParameter<bool>("applyDegradation")),
       bxTime_(pset.getParameter<double>("bxTime")),
-      tofDelay_(pset.getParameter<double>("tofDelay")),
       MPVMuon_(pset.getParameter<std::string>("MPVMuon")),
       MPVPion_(pset.getParameter<std::string>("MPVPion")),
       MPVKaon_(pset.getParameter<std::string>("MPVKaon")),
       MPVElectron_(pset.getParameter<std::string>("MPVElectron")),
-      MPVProton_(pset.getParameter<std::string>("MPVProton")) {}
+      MPVProton_(pset.getParameter<std::string>("MPVProton")),
+      tdcWindowStart_(pset.getParameter<double>("tdcWindowStart")),
+      tdcWindowEnd_(pset.getParameter<double>("tdcWindowEnd")) {}
 
 void ETLDeviceSim::getEventSetup(const edm::EventSetup& evs) { geom_ = &evs.getData(geomToken_); }
 
@@ -73,7 +74,7 @@ void ETLDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t, f
     const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
     const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
 
-    const float toa = std::get<2>(hitRefs[i]) + tofDelay_;
+    const float toa = std::get<2>(hitRefs[i]);
     const PSimHit& hit = hits->at(hitidx);
     float charge = convertGeVToMeV(hit.energyLoss()) * MIPPerMeV_;
 
@@ -131,6 +132,10 @@ void ETLDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t, f
 
     auto simHitIt =
         simHitAccumulator->emplace(mtd_digitizer::MTDCellId(id, row, col), mtd_digitizer::MTDCellInfo()).first;
+
+    // Check if toa is within the ETROC TDC window [12.5 ns nominal]
+    if (toa < tdcWindowStart_ || toa > tdcWindowEnd_)
+      continue;
 
     // Accumulate in 15 buckets of 25ns (9 pre-samples, 1 in-time, 5 post-samples)
     const int itime = std::floor(toa / bxTime_) + mtd_digitizer::kInTimeBX;

--- a/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
@@ -629,7 +629,7 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
       0.,
       256.,
       0.,
-      1024.);
+      2048.);
   meHitTvsQ_[1] =
       ibook.bookProfile("EtlHitTvsQZnegD2",
                         "ETL DIGI ToA vs charge (-Z, Second Disk);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
@@ -637,7 +637,7 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                         0.,
                         256.,
                         0.,
-                        1024.);
+                        2048.);
   meHitTvsQ_[2] = ibook.bookProfile(
       "EtlHitTvsQZposD1",
       "ETL DIGI ToA vs charge (+Z, Single(topo1D)/First(topo2D) disk);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
@@ -645,7 +645,7 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
       0.,
       256.,
       0.,
-      1024.);
+      2048.);
   meHitTvsQ_[3] =
       ibook.bookProfile("EtlHitTvsQZposD2",
                         "ETL DIGI ToA vs charge (+Z, Second disk);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
@@ -653,7 +653,7 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                         0.,
                         256.,
                         0.,
-                        1024.);
+                        2048.);
   meHitToTvsQ_[0] = ibook.bookProfile(
       "EtlHitToTvsQZnegD1",
       "ETL DIGI ToT vs charge (-Z, Single(topo1D)/First(topo2D) disk);Q_{DIGI} [ADC counts];ToT_{DIGI} [TDC counts]",
@@ -661,7 +661,7 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
       0.,
       256.,
       0.,
-      1024.);
+      2048.);
   meHitToTvsQ_[1] =
       ibook.bookProfile("EtlHitToTvsQZnegD2",
                         "ETL DIGI ToT vs charge (-Z, Second Disk);Q_{DIGI} [ADC counts];ToT_{DIGI} [TDC counts]",
@@ -669,7 +669,7 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                         0.,
                         256.,
                         0.,
-                        1024.);
+                        2048.);
   meHitToTvsQ_[2] = ibook.bookProfile(
       "EtlHitToTvsQZposD1",
       "ETL DIGI ToT vs charge (+Z, Single(topo1D)/First(topo2D) disk);Q_{DIGI} [ADC counts];ToT_{DIGI} [TDC counts]",
@@ -677,7 +677,7 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
       0.,
       256.,
       0.,
-      1024.);
+      2048.);
   meHitToTvsQ_[3] =
       ibook.bookProfile("EtlHitToTvsQZposD2",
                         "ETL DIGI ToT vs charge (+Z, Second disk);Q_{DIGI} [ADC counts];ToT_{DIGI} [TDC counts]",
@@ -685,7 +685,7 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                         0.,
                         256.,
                         0.,
-                        1024.);
+                        2048.);
   meHitQvsPhi_[0] = ibook.bookProfile(
       "EtlHitQvsPhiZnegD1",
       "ETL DIGI charge vs #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
@@ -755,7 +755,7 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
       -3.15,
       3.15,
       0.,
-      1024.);
+      2048.);
   meHitTvsPhi_[1] =
       ibook.bookProfile("EtlHitTvsPhiZnegD2",
                         "ETL DIGI ToA vs #phi (-Z, Second disk);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
@@ -763,7 +763,7 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                         -3.15,
                         3.15,
                         0.,
-                        1024.);
+                        2048.);
   meHitTvsPhi_[2] = ibook.bookProfile(
       "EtlHitTvsPhiZposD1",
       "ETL DIGI ToA vs #phi (+Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
@@ -771,7 +771,7 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
       -3.15,
       3.15,
       0.,
-      1024.);
+      2048.);
   meHitTvsPhi_[3] =
       ibook.bookProfile("EtlHitTvsPhiZposD2",
                         "ETL DIGI ToA vs #phi (+Z, Second disk);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
@@ -779,7 +779,7 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                         -3.15,
                         3.15,
                         0.,
-                        1024.);
+                        2048.);
   meHitTvsEta_[0] = ibook.bookProfile(
       "EtlHitTvsEtaZnegD1",
       "ETL DIGI ToA vs #eta (-Z, Single(topo1D)/First(topo2D) disk);#eta_{DIGI};ToA_{DIGI} [TDC counts]",
@@ -787,14 +787,14 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
       -3.2,
       -1.56,
       0.,
-      1024.);
+      2048.);
   meHitTvsEta_[1] = ibook.bookProfile("EtlHitTvsEtaZnegD2",
                                       "ETL DIGI ToA vs #eta (-Z, Second disk);#eta_{DIGI};ToA_{DIGI} [TDC counts]",
                                       50,
                                       -3.2,
                                       -1.56,
                                       0.,
-                                      1024.);
+                                      2048.);
   meHitTvsEta_[2] = ibook.bookProfile(
       "EtlHitTvsEtaZposD1",
       "ETL DIGI ToA vs #eta (+Z, Single(topo1D)/First(topo2D) disk);#eta_{DIGI};ToA_{DIGI} [TDC counts]",
@@ -802,14 +802,14 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
       1.56,
       3.2,
       0.,
-      1024.);
+      2048.);
   meHitTvsEta_[3] = ibook.bookProfile("EtlHitTvsEtaZposD2",
                                       "ETL DIGI ToA vs #eta (+Z, Second disk);#eta_{DIGI};ToA_{DIGI} [TDC counts]",
                                       50,
                                       1.56,
                                       3.2,
                                       0.,
-                                      1024.);
+                                      2048.);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------


### PR DESCRIPTION
#### PR description:

This PR contains two updates to the ETL digitization model:
- a selection on the ToA is applied in the ETLDeviceSim class to emulate the ETROC TDC measurement window (nominal value 12.5 ns)
- the unnecessary parameter tofDelay is removed, both in the ETL digitization and in the local reconstruction

#### PR validation:
The code was tested producing 10 events + PU200 from workflow 29906.0. 
The results look as expected.  A small reduction in the ETL occupancy is observed due to the TDC window emulation.


