### PR TITLE
TrackerGeometry: add assert() to offsetDU and endsetDU

### DIFF
--- a/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
+++ b/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
@@ -1,6 +1,8 @@
 #ifndef Geometry_TrackerGeometryBuilder_TrackerGeometry_H
 #define Geometry_TrackerGeometryBuilder_TrackerGeometry_H
 
+#include <cassert>
+
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetEnumerators.h"
 #include "Geometry/CommonDetUnit/interface/TrackerGeomDet.h"
@@ -77,8 +79,14 @@ public:
   unsigned int numberOfLayers(int subdet) const;
   bool isThere(GeomDetEnumerators::SubDetector subdet) const;
 
-  unsigned int offsetDU(SubDetector sid) const { return theOffsetDU[sid]; }
-  unsigned int endsetDU(SubDetector sid) const { return theEndsetDU[sid]; }
+  unsigned int offsetDU(SubDetector sid) const {
+    assert(0 <= sid && sid < 7);
+    return theOffsetDU[sid];
+  }
+  unsigned int endsetDU(SubDetector sid) const {
+    assert(0 <= sid && sid < 7);
+    return theEndsetDU[sid];
+  }
   // Magic : better be called at the right moment...
   void setOffsetDU(SubDetector sid) { theOffsetDU[sid] = detUnits().size(); }
   void setEndsetDU(SubDetector sid) { theEndsetDU[sid] = detUnits().size(); }


### PR DESCRIPTION
Fixes cms-sw/cmssw#49157

#### PR description:

Adds `assert`s to check if requested index is in range for offsetDU() and endsetDU() methods, as discussed in mentioned issue.

#### PR validation:

Bot tests

