### PR TITLE
update mds trigger thresholds with era change tracked

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2025_FtoG_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_FtoG_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
+from Configuration.Eras.Modifier_run3_CSC_2025_cff import run3_CSC_2025_FtoG
+
+Run3_2025_FtoG = cms.ModifierChain(Run3_2025, run3_CSC_2025_FtoG)

--- a/Configuration/Eras/python/Era_Run3_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
 from Configuration.Eras.Modifier_run3_GEM_2025_cff import run3_GEM_2025
-from Configuration.Eras.Modifier_run3_CSC_2025_cff import run3_CSC_2025
+from Configuration.Eras.Modifier_run3_CSC_2025_cff import run3_CSC_2025_AtoE
 from Configuration.Eras.Modifier_stage2L1Trigger_2025_cff import stage2L1Trigger_2025
 from Configuration.Eras.Modifier_run3_SiPixel_2025_cff import run3_SiPixel_2025
 from Configuration.Eras.Modifier_run3_nanoAOD_2025_cff import run3_nanoAOD_2025
@@ -11,4 +11,4 @@ from Configuration.ProcessModifiers.ecal_cctiming_cff import ecal_cctiming
 from Configuration.ProcessModifiers.siPixelGoodEdgeAlgo_cff import siPixelGoodEdgeAlgo
 from Configuration.ProcessModifiers.siPixelDigiMorphing_cff import siPixelDigiMorphing
 
-Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, stage2L1Trigger_2025, run3_SiPixel_2025, run3_CSC_2025, run3_nanoAOD_2025, run3_scouting_2025, ecal_cctiming, siPixelGoodEdgeAlgo, siPixelDigiMorphing)
+Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, stage2L1Trigger_2025, run3_SiPixel_2025, run3_CSC_2025_AtoE, run3_nanoAOD_2025, run3_scouting_2025, ecal_cctiming, siPixelGoodEdgeAlgo, siPixelDigiMorphing)

--- a/Configuration/Eras/python/Era_Run3_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_cff.py
@@ -11,4 +11,4 @@ from Configuration.ProcessModifiers.ecal_cctiming_cff import ecal_cctiming
 from Configuration.ProcessModifiers.siPixelGoodEdgeAlgo_cff import siPixelGoodEdgeAlgo
 from Configuration.ProcessModifiers.siPixelDigiMorphing_cff import siPixelDigiMorphing
 
-Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, stage2L1Trigger_2025, run3_SiPixel_2025, run3_CSC_2025_AtoE, run3_nanoAOD_2025, run3_scouting_2025, ecal_cctiming, siPixelGoodEdgeAlgo, siPixelDigiMorphing)
+Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, stage2L1Trigger_2025, run3_SiPixel_2025, run3_CSC_2025_FtoG, run3_nanoAOD_2025, run3_scouting_2025, ecal_cctiming, siPixelGoodEdgeAlgo, siPixelDigiMorphing)

--- a/Configuration/Eras/python/Era_Run3_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
 from Configuration.Eras.Modifier_run3_GEM_2025_cff import run3_GEM_2025
-from Configuration.Eras.Modifier_run3_CSC_2025_cff import run3_CSC_2025_AtoE
+from Configuration.Eras.Modifier_run3_CSC_2025_cff import run3_CSC_2025_FtoG
 from Configuration.Eras.Modifier_stage2L1Trigger_2025_cff import stage2L1Trigger_2025
 from Configuration.Eras.Modifier_run3_SiPixel_2025_cff import run3_SiPixel_2025
 from Configuration.Eras.Modifier_run3_nanoAOD_2025_cff import run3_nanoAOD_2025

--- a/Configuration/Eras/python/Modifier_run3_CSC_2025_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_CSC_2025_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-run3_CSC_2025 =  cms.Modifier()
+run3_CSC_2025_AtoE =  cms.Modifier()
+run3_CSC_2025_FtoG =  cms.Modifier()
 

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -11,7 +11,7 @@ from L1Trigger.CSCTriggerPrimitives.params.clctParams import clctPSets
 from L1Trigger.CSCTriggerPrimitives.params.tmbParams import tmbPSets
 from L1Trigger.CSCTriggerPrimitives.params.auxiliaryParams import auxPSets
 from L1Trigger.CSCTriggerPrimitives.params.gemcscParams import gemcscPSets
-from L1Trigger.CSCTriggerPrimitives.params.showerParams import showerPSet,showerPSet_2025
+from L1Trigger.CSCTriggerPrimitives.params.showerParams import showerPSet,showerPSet_2025_AtoE, showerPSet_2025_FtoG
 
 cscTriggerPrimitiveDigis = cms.EDProducer(
     "CSCTriggerPrimitivesProducer",
@@ -73,12 +73,17 @@ run3_common.toModify( cscTriggerPrimitiveDigis,
                                          runME31Up = True,
                                          runME41Up = True)
 )
-## update shower thresholds for 2025 runs
-from Configuration.Eras.Modifier_run3_CSC_2025_cff import run3_CSC_2025
-run3_CSC_2025.toModify( cscTriggerPrimitiveDigis,
-                      showerParams = showerPSet_2025.clone()
+## update shower thresholds for 2025 runs Eras A-E
+from Configuration.Eras.Modifier_run3_CSC_2025_cff import run3_CSC_2025_AtoE
+run3_CSC_2025_AtoE.toModify( cscTriggerPrimitiveDigis,
+                      showerParams = showerPSet_2025_AtoE.clone()
 )
 
+## update shower thresholds for 2025 runs Eras F-G
+from Configuration.Eras.Modifier_run3_CSC_2025_cff import run3_CSC_2025_FtoG
+run3_CSC_2025_FtoG.toModify( cscTriggerPrimitiveDigis,
+                      showerParams = showerPSet_2025_FtoG.clone()
+)
 
 ## GEM-CSC integrated local trigger in ME1/1
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM

--- a/L1Trigger/CSCTriggerPrimitives/python/params/showerParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/showerParams.py
@@ -95,7 +95,88 @@ showerPSet = cms.PSet(
     )
 )
 
-showerPSet_2025 = cms.PSet(
+showerPSet_2025_AtoE = cms.PSet(
+    ## what kind of shower triggers the logic?
+    ## 0: cathode-only (TMB/OTMB)
+    ## 1: anode-only (from ALCT board)
+    source  = cms.vuint32(
+	# ME1/1
+	1,
+	# ME1/2
+	1,
+	# ME1/3
+	1,
+	# ME2/1
+	1,
+	# ME2/2
+	1,
+	# ME3/1
+	1,
+	# ME3/2
+	1,
+	# ME4/1
+	1,
+	# ME4/2
+	1
+	),
+
+    ## settings for cathode showers (counting CSCComparatorDigi)
+    cathodeShower = cms.PSet(
+	## 10000 means to disable cathode HMT for this chamber type
+        showerThresholds = cms.vuint32(
+            # ME1/1
+            10000, 10000, 10000,
+            # ME1/2
+            10000, 10000, 10000,
+            # ME1/3
+            10000, 10000, 10000,
+            # ME2/1
+            10000, 10000, 10000,
+            # ME2/2
+            10000, 10000, 10000,
+            # ME3/1
+            10000, 10000, 10000,
+            # ME3/2
+            10000, 10000, 10000,
+            # ME4/1
+            10000, 10000, 10000,
+            # ME4/2
+            10000, 10000, 10000
+        ),
+        showerNumTBins = cms.uint32(3),# 3BX for cathode HMT
+        minLayersCentralTBin = cms.uint32(5),
+	## peack check feature is not implemented in firmware
+	## plan to upgrade in future
+	peakCheck = cms.bool(False),
+    ),
+    ## settings for anode showers (counting CSCWireDigi)
+    anodeShower = cms.PSet(
+        ## {loose, nominal, tight} thresholds for hit counters
+        showerThresholds = cms.vuint32(
+            # ME1/1
+            1000, 1000, 1000,
+            # ME1/2
+            1000, 1000, 1000,
+            # ME1/3
+            7, 14, 18,
+            # ME2/1
+            24, 76, 84,
+            # ME2/2
+            12, 34, 37,
+            # ME3/1
+            22, 67, 77,
+            # ME3/2
+            12, 21, 21,
+            # ME4/1
+            26, 80, 92,
+            # ME4/2
+            12, 23, 23
+        ),
+        showerNumTBins = cms.uint32(1),# 1BX for anode HMT
+        minLayersCentralTBin = cms.uint32(5),
+    )
+)
+showerPSet_2025_FtoG = cms.PSet(
     ## what kind of shower triggers the logic?
     ## 0: cathode-only (TMB/OTMB)
     ## 1: anode-only (from ALCT board)


### PR DESCRIPTION
PR description:

This pull request corresponds with the backport PR #49217. It is an improvement of the changes in PR #49216 , which changed the trigger thresholds without accounting for the change in Era. We only want the new thresholds to be applied for 2025 Era F and after, and this is accounted for in this PR.

This PR updates 2025 HMT shower thresholds for pp collisions to be implemented for Era 2025F.

Details were presented by @kakwok at the TSG Meeting on August 20. [1].

[1] https://indico.cern.ch/event/1571789/#35-exo-report-on-l1t-muon-show

PR validation:

Tuning of trigger thresholds for redistribution of rates within CSC station-rings for optimized physics performance.