### PR TITLE
Add ActivityRegistry signals for ESModule construction

### DIFF
--- a/FWCore/Framework/interface/ComponentConstructionSentry.h
+++ b/FWCore/Framework/interface/ComponentConstructionSentry.h
@@ -20,7 +20,7 @@
 namespace edm {
   namespace eventsetup {
     class EventSetupProvider;
-    class ComponentDescription;
+    struct ComponentDescription;
 
     struct ComponentConstructionSentry {
       ComponentConstructionSentry(EventSetupProvider const& iProvider, ComponentDescription const& iDescription);

--- a/FWCore/Framework/interface/ComponentConstructionSentry.h
+++ b/FWCore/Framework/interface/ComponentConstructionSentry.h
@@ -1,0 +1,39 @@
+#ifndef FWCore_Framework_ComponentConstructionSentry_h
+#define FWCore_Framework_ComponentConstructionSentry_h
+//
+// Package:     Framework
+// Class  :     ComponentConstructionSentry
+//
+/**\class edm::eventsetup::ComponentConstructionSentry
+
+ Description: Used to send ActivityRegistry signals before and after the construction of an EventSetup component (ESSource or ESProducer)
+
+ Usage:
+    <usage>
+
+*/
+//
+// Author:      Chris Jones
+// Created:     Wed May 25 16:56:05 EDT 2005
+//
+
+namespace edm {
+  namespace eventsetup {
+    class EventSetupProvider;
+    class ComponentDescription;
+
+    struct ComponentConstructionSentry {
+      ComponentConstructionSentry(EventSetupProvider const& iProvider, ComponentDescription const& iDescription);
+      ~ComponentConstructionSentry() noexcept(false);
+
+      //call if the construction call succeeded without throwing an exception.
+      void succeeded() { succeeded_ = true; }
+
+    private:
+      EventSetupProvider const& provider_;
+      ComponentDescription const& description_;
+      bool succeeded_ = false;
+    };
+  }  // namespace eventsetup
+}  // namespace edm
+#endif

--- a/FWCore/Framework/interface/ComponentMaker.h
+++ b/FWCore/Framework/interface/ComponentMaker.h
@@ -106,9 +106,9 @@ namespace edm {
       const ComponentDescription description = this->createComponentDescription(iConfiguration);
       std::shared_ptr<TComponent> component;
       {
-        //here would be where the construction signal would go
         ComponentConstructionSentry sentry(iProvider, description);
         component = std::make_shared<TComponent>(iConfiguration);
+        sentry.succeeded();
       }
 
       this->setDescription(component.get(), description);

--- a/FWCore/Framework/interface/ComponentMaker.h
+++ b/FWCore/Framework/interface/ComponentMaker.h
@@ -28,6 +28,7 @@
 #include "FWCore/Framework/interface/ComponentDescription.h"
 #include "FWCore/Framework/interface/ESProductResolverProvider.h"
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
+#include "FWCore/Framework/interface/ComponentConstructionSentry.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescriptionFiller.h"
@@ -102,8 +103,13 @@ namespace edm {
           throw;
         }
       }
-      std::shared_ptr<TComponent> component = std::make_shared<TComponent>(iConfiguration);
-      ComponentDescription description = this->createComponentDescription(iConfiguration);
+      const ComponentDescription description = this->createComponentDescription(iConfiguration);
+      std::shared_ptr<TComponent> component;
+      {
+        //here would be where the construction signal would go
+        ComponentConstructionSentry sentry(iProvider, description);
+        component = std::make_shared<TComponent>(iConfiguration);
+      }
 
       this->setDescription(component.get(), description);
       this->setDescriptionForFinder(component.get(), description);

--- a/FWCore/Framework/interface/EventSetupProvider.h
+++ b/FWCore/Framework/interface/EventSetupProvider.h
@@ -99,6 +99,8 @@ namespace edm {
 
       void fillAllESProductResolverProviders(std::vector<ESProductResolverProvider const*>&) const;
 
+      ActivityRegistry const* activityRegistry() const { return activityRegistry_; }
+
     private:
       std::shared_ptr<EventSetupRecordProvider>& recordProvider(const EventSetupRecordKey& iKey);
       void insert(EventSetupRecordKey const&, std::unique_ptr<EventSetupRecordProvider>);

--- a/FWCore/Framework/src/ComponentConstructionSentry.cc
+++ b/FWCore/Framework/src/ComponentConstructionSentry.cc
@@ -1,0 +1,27 @@
+#include "FWCore/Framework/interface/ComponentConstructionSentry.h"
+#include "FWCore/Framework/interface/EventSetupProvider.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+
+namespace edm {
+  namespace eventsetup {
+
+    ComponentConstructionSentry::ComponentConstructionSentry(EventSetupProvider const& iProvider,
+                                                             ComponentDescription const& iDescription)
+        : provider_(iProvider), description_(iDescription) {
+      provider_.activityRegistry()->preESModuleConstructionSignal_(description_);
+      // Here would be where the construction signal would go
+    }
+
+    ComponentConstructionSentry::~ComponentConstructionSentry() noexcept(false) {
+      try {
+        provider_.activityRegistry()->postESModuleConstructionSignal_(description_);
+      } catch (...) {
+        if (succeeded_) {
+          // no exception happened during construction so can rethrow the exception from the post construction signal
+          throw;
+        }
+      }
+    }
+
+  }  // namespace eventsetup
+}  // namespace edm

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -707,6 +707,22 @@ namespace edm {
     }
     AR_WATCH_USING_METHOD_1(watchPreSourceEarlyTermination)
 
+    /// signal is emitted before the ESModule is constructed
+    using PreESModuleConstruction = signalslot::Signal<void(eventsetup::ComponentDescription const&)>;
+    PreESModuleConstruction preESModuleConstructionSignal_;
+    void watchPreESModuleConstruction(PreESModuleConstruction::slot_type const& iSlot) {
+      preESModuleConstructionSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_1(watchPreESModuleConstruction)
+
+    /// signal is emitted after the ESModule is constructed
+    using PostESModuleConstruction = signalslot::Signal<void(eventsetup::ComponentDescription const&)>;
+    PostESModuleConstruction postESModuleConstructionSignal_;
+    void watchPostESModuleConstruction(PostESModuleConstruction::slot_type const& iSlot) {
+      postESModuleConstructionSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_1(watchPostESModuleConstruction)
+
     /// signal is emitted after the ESModule is registered with EventSetupProvider
     using PostESModuleRegistration = signalslot::Signal<void(eventsetup::ComponentDescription const&)>;
     PostESModuleRegistration postESModuleRegistrationSignal_;

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -57,6 +57,8 @@ namespace edm {
     postServicesConstructionSignal_.connect(std::cref(iOther.postServicesConstructionSignal_));
     preEventSetupModulesConstructionSignal_.connect(std::cref(iOther.preEventSetupModulesConstructionSignal_));
     postEventSetupModulesConstructionSignal_.connect(std::cref(iOther.postEventSetupModulesConstructionSignal_));
+    preESModuleConstructionSignal_.connect(std::cref(iOther.preESModuleConstructionSignal_));
+    postESModuleConstructionSignal_.connect(std::cref(iOther.postESModuleConstructionSignal_));
     preFinishScheduleSignal_.connect(std::cref(iOther.preFinishScheduleSignal_));
     postFinishScheduleSignal_.connect(std::cref(iOther.postFinishScheduleSignal_));
     prePrincipalsCreationSignal_.connect(std::cref(iOther.prePrincipalsCreationSignal_));
@@ -275,6 +277,8 @@ namespace edm {
     copySlotsToFrom(postServicesConstructionSignal_, iOther.postServicesConstructionSignal_);
     copySlotsToFrom(preEventSetupModulesConstructionSignal_, iOther.preEventSetupModulesConstructionSignal_);
     copySlotsToFromReverse(postEventSetupModulesConstructionSignal_, iOther.postEventSetupModulesConstructionSignal_);
+    copySlotsToFrom(preESModuleConstructionSignal_, iOther.preESModuleConstructionSignal_);
+    copySlotsToFromReverse(postESModuleConstructionSignal_, iOther.postESModuleConstructionSignal_);
     copySlotsToFrom(preFinishScheduleSignal_, iOther.preFinishScheduleSignal_);
     copySlotsToFromReverse(postFinishScheduleSignal_, iOther.postFinishScheduleSignal_);
     copySlotsToFrom(prePrincipalsCreationSignal_, iOther.prePrincipalsCreationSignal_);

--- a/FWCore/Services/plugins/Tracer.cc
+++ b/FWCore/Services/plugins/Tracer.cc
@@ -302,6 +302,19 @@ Tracer::Tracer(ParameterSet const& iPS, ActivityRegistry& iRegistry)
     LogAbsolute out("Tracer");
     out << TimeStamper(printTimestamps_) << indention_ << " starting: construction of EventSetup modules";
   });
+  iRegistry.watchPreESModuleConstruction([this](eventsetup::ComponentDescription const& iDesc) {
+    LogAbsolute out("Tracer");
+    auto label = iDesc.label_.empty() ? iDesc.type_ : iDesc.label_;
+    out << TimeStamper(printTimestamps_) << indention_ << indention_ << " starting: constructing esmodule with label '"
+        << label << "' id = " << iDesc.id_;
+  });
+  iRegistry.watchPostESModuleConstruction([this](eventsetup::ComponentDescription const& iDesc) {
+    LogAbsolute out("Tracer");
+    auto label = iDesc.label_.empty() ? iDesc.type_ : iDesc.label_;
+    out << TimeStamper(printTimestamps_) << indention_ << indention_ << " finished: constructing esmodule with label '"
+        << label << "' id = " << iDesc.id_;
+  });
+
   iRegistry.watchPostEventSetupModulesConstruction([this]() {
     LogAbsolute out("Tracer");
     out << TimeStamper(printTimestamps_) << indention_ << " finished: construction of EventSetup modules";

--- a/FWCore/Services/scripts/edmTracerCompactLogViewer.py
+++ b/FWCore/Services/scripts/edmTracerCompactLogViewer.py
@@ -657,15 +657,20 @@ class ESModuleTransitionParser(object):
         self.moduleID = int(payload[2])
         self.moduleName = esModuleNames[self.moduleID]
         self.recordID = int(payload[3])
-        self.recordName = recordNames[self.recordID]
+        if self.transition != Phase.constructESModules:
+            self.recordName = recordNames[self.recordID]
+        else:
+            self.recordName = '<N/A>'
         self.callID = int(payload[4])
         self.requestingModuleID = int(payload[5])
         self.requestingCallID = int(payload[6])
         self.requestingModuleName = None
         if self.requestingModuleID < 0 :
             self.requestingModuleName = esModuleNames[-1*self.requestingModuleID]
-        else:
+        elif self.requestingModuleID != 0:
             self.requestingModuleName = moduleNames[self.requestingModuleID]
+        else:
+            self.requestingModuleName = '<N/A>'
         self.time = int(payload[7])
     def baseIndentLevel(self):
         return transitionIndentLevel(self.transition)

--- a/FWCore/Services/test/test_tracer_file.sh
+++ b/FWCore/Services/test/test_tracer_file.sh
@@ -2,40 +2,40 @@
 
 function die { echo Failure $1: status $2 ; exit $2 ; }
 
-cmsRun -e ${SCRAM_TEST_PATH}/tracer_cfg.py &> test_Timing.log || die "cmsRun tracer_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/tracer_cfg.py &> test_tracer.log || die "cmsRun tracer_cfg.py" $?
 edmTracerCompactLogViewer.py -j tracer.log &> tracer.json || die "edmTracerCompactLogViewer.py" $?
-grep -q '"type": 24' tracer.json || die "Check for processPython transition in JSON" $?
-grep -q '"type": 23' tracer.json || die "Check for startServices transition in JSON" $?
-grep -q '"type": 22' tracer.json || die "Check for constructESModules transition in JSON" $?
-grep -q '"type": 21' tracer.json || die "Check for finishSchedule transition in JSON" $?
-grep -q '"type": 20' tracer.json || die "Check for createRunLumiEvents transition in JSON" $?
-grep -q '"type": 19' tracer.json || die "Check for scheduleConsistencyCheck transition in JSON" $?
-grep -q '"type": 18' tracer.json || die "Check for finalizeEventSetupConfiguration transition in JSON" $?
-grep -q '"type": 17' tracer.json || die "Check for finalizeEDModules transition in JSON" $?
-grep -q '"type": 16' tracer.json || die "Check for construction transition in JSON" $?
-#grep -q '"type": -16' tracer.json || die "Check for destruction transition in JSON" $? #there are no destruction calls in the file
-grep -q '"type": 12' tracer.json || die "Check for beginJob transition in JSON" $?
-grep -q '"type": -12' tracer.json || die "Check for endJob transition in JSON" $?
-grep -q '"type": 11' tracer.json || die "Check for beginStream transition in JSON" $?
-grep -q '"type": -11' tracer.json || die "Check for endStream transition in JSON" $?
-#grep -q '"type": 10' tracer.json || die "Check for open file transition in JSON" $? #no file in EmptySource
-grep -q '"type": -10' tracer.json || die "Check for write file transition in JSON" $?
-grep -q '"type": 9' tracer.json || die "Check for beginProcessBlock transition in JSON" $?
-grep -q '"type": -9' tracer.json || die "Check for endProcessBlock transition in JSON" $?
-#grep -q '"type": 8' tracer.json || die "Check for inputProcessBlock transition in JSON" $? #no file transition for inputProcessBlock in this test
-grep -q '"type": -8' tracer.json && die "Check for missing -8 transition in JSON" $?
-grep -q '"type": 7' tracer.json && die "Check for missing 7 transition in JSON" $?
-grep -q '"type": -7' tracer.json || die "Check for globalWriteRun transition in JSON" $?
-grep -q '"type": 6' tracer.json || die "Check for globalBeginRun transition in JSON" $?
-grep -q '"type": -6' tracer.json || die "Check for globalEndRun transition in JSON" $?
-grep -q '"type": 5' tracer.json || die "Check for streamBeginRun transition in JSON" $?
-grep -q '"type": -5' tracer.json || die "Check for streamEndRun transition in JSON" $?
-grep -q '"type": 4' tracer.json && die "Check for missing 4 transition in JSON" $?
-grep -q '"type": -4' tracer.json || die "Check for globalWriteLumi transition in JSON" $?
-grep -q '"type": 3' tracer.json || die "Check for globalBeginLumi transition in JSON" $?
-grep -q '"type": -3' tracer.json || die "Check for globalEndLumi transition in JSON" $?
-grep -q '"type": 2' tracer.json || die "Check for streamBeginLumi transition in JSON" $?
-grep -q '"type": -2' tracer.json || die "Check for streamEndLumi transition in JSON" $?
-grep -q '"type": 1' tracer.json && die "Check for missing 1 transition in JSON" $?
-grep -q '"type": -1' tracer.json || die "Check for clearEvent transition in JSON" $?
-grep -q '"type": 0' tracer.json || die "Check for event transition in JSON" $?
+grep -q '"type": 24,' tracer.json || die "Check for processPython transition in JSON" $?
+grep -q '"type": 23,' tracer.json || die "Check for startServices transition in JSON" $?
+grep -q '"type": 22,' tracer.json || die "Check for constructESModules transition in JSON" $?
+grep -q '"type": 21,' tracer.json || die "Check for finishSchedule transition in JSON" $?
+grep -q '"type": 20,' tracer.json || die "Check for createRunLumiEvents transition in JSON" $?
+grep -q '"type": 19,' tracer.json || die "Check for scheduleConsistencyCheck transition in JSON" $?
+grep -q '"type": 18,' tracer.json || die "Check for finalizeEventSetupConfiguration transition in JSON" $?
+grep -q '"type": 17,' tracer.json || die "Check for finalizeEDModules transition in JSON" $?
+grep -q '"type": 16,' tracer.json || die "Check for construction transition in JSON" $?
+#grep -q '"type": -16,' tracer.json || die "Check for destruction transition in JSON" $? #there are no destruction calls in the file
+grep -q '"type": 12,' tracer.json || die "Check for beginJob transition in JSON" $?
+grep -q '"type": -12,' tracer.json || die "Check for endJob transition in JSON" $?
+grep -q '"type": 11,' tracer.json || die "Check for beginStream transition in JSON" $?
+grep -q '"type": -11,' tracer.json || die "Check for endStream transition in JSON" $?
+#grep -q '"type": 10,' tracer.json || die "Check for open file transition in JSON" $? #no file in EmptySource
+grep -q '"type": -10,' tracer.json || die "Check for write file transition in JSON" $?
+grep -q '"type": 9,' tracer.json || die "Check for beginProcessBlock transition in JSON" $?
+grep -q '"type": -9,' tracer.json || die "Check for endProcessBlock transition in JSON" $?
+#grep -q '"type": 8,' tracer.json || die "Check for inputProcessBlock transition in JSON" $? #no file transition for inputProcessBlock in this test
+grep -q '"type": -8,' tracer.json && die "Check for missing -8 transition in JSON" 1
+grep -q '"type": 7,' tracer.json && die "Check for missing 7 transition in JSON" 1
+grep -q '"type": -7,' tracer.json || die "Check for globalWriteRun transition in JSON" $?
+grep -q '"type": 6,' tracer.json || die "Check for globalBeginRun transition in JSON" $?
+grep -q '"type": -6,' tracer.json || die "Check for globalEndRun transition in JSON" $?
+grep -q '"type": 5,' tracer.json || die "Check for streamBeginRun transition in JSON" $?
+grep -q '"type": -5,' tracer.json || die "Check for streamEndRun transition in JSON" $?
+grep -q '"type": 4,' tracer.json && die "Check for missing 4 transition in JSON" 1
+grep -q '"type": -4,' tracer.json || die "Check for globalWriteLumi transition in JSON" $?
+grep -q '"type": 3,' tracer.json || die "Check for globalBeginLumi transition in JSON" $?
+grep -q '"type": -3,' tracer.json || die "Check for globalEndLumi transition in JSON" $?
+grep -q '"type": 2,' tracer.json || die "Check for streamBeginLumi transition in JSON" $?
+grep -q '"type": -2,' tracer.json || die "Check for streamEndLumi transition in JSON" $?
+grep -q '"type": 1,' tracer.json && die "Check for missing 1 transition in JSON" 1
+grep -q '"type": -1,' tracer.json || die "Check for clearEvent transition in JSON" $?
+grep -q '"type": 0,' tracer.json || die "Check for event transition in JSON" $?

--- a/FWCore/Services/test/tracer_cfg.py
+++ b/FWCore/Services/test/tracer_cfg.py
@@ -16,10 +16,26 @@ process.maxEvents = cms.untracked.PSet(
 
 process.source = cms.Source("EmptySource")
 
+process.WhatsItESProducer = cms.ESProducer("WhatsItESProducer",
+    doodadLabel = cms.string('Two')
+)
+
+process.DoodadESSource = cms.ESSource("DoodadESSource",
+    appendToDataLabel = cms.string('Two')
+)
+
+process.get = cms.EDAnalyzer("EventSetupRecordDataGetter",
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string('GadgetRcd'),
+        data = cms.vstring('edmtest::WhatsIt', 
+                           'edmtest::Doodad/Two')
+    ))
+)
+
 process.print1 = cms.OutputModule("AsciiOutputModule")
 
 process.print2 = cms.OutputModule("AsciiOutputModule")
 
-process.p = cms.EndPath(process.print1*process.print2)
+process.p = cms.EndPath(process.print1*process.print2+process.get)
 
 


### PR DESCRIPTION
#### PR description:

- Added signals for pre and post ESModule construction
- extended Tracer output to include those signals
- extended file generated by Tracer to include those signals
- extended the web-based viewer to show the ESModule construction timing

#### PR validation:

Framework test all pass. Running a simple hand written configuration showed the output.

resolves https://github.com/cms-sw/framework-team/issues/1661
resolves https://github.com/cms-sw/framework-team/issues/1662
resolves https://github.com/cms-sw/framework-team/issues/1663
resolves https://github.com/cms-sw/framework-team/issues/1664