### PR TITLE
Consider Run3 for the MET validation.

### DIFF
--- a/HLTriggerOffline/JetMET/python/Validation/HLTJetMETValidation_cff.py
+++ b/HLTriggerOffline/JetMET/python/Validation/HLTJetMETValidation_cff.py
@@ -1,8 +1,15 @@
 import FWCore.ParameterSet.Config as cms
+from functools import reduce
 
 from HLTriggerOffline.JetMET.Validation.SingleJetValidation_cfi import *
 from Validation.RecoJets.hltJetValidation_cff import *
 from Validation.RecoMET.hltMETValidation_cff import *
+
+def sumModules(alist):
+    return reduce(lambda x, y: x + y, alist)
+
+met_run3_analyzers = [hltMetAnalyzerPF, hltMetAnalyzerPFCalo]
+met_ph2_analyzers = [hltMetAnalyzerPF, hltMetAnalyzerPFPuppi, hltMetTypeOneAnalyzerPFPuppi]
 
 ##please do NOT include paths here!
 HLTJetMETValSeq = cms.Sequence(
@@ -10,7 +17,11 @@ HLTJetMETValSeq = cms.Sequence(
     + hltJetAnalyzerAK4PFPuppi
     + hltJetAnalyzerAK4PF
     + hltJetAnalyzerAK4PFCHS
-    + hltMetAnalyzerPF
-    + hltMetAnalyzerPFPuppi
-    + hltMetTypeOneAnalyzerPFPuppi
+    + sumModules(met_run3_analyzers)
 )
+
+_phase2_HLTJetMETValSeq = HLTJetMETValSeq.copyAndExclude(met_run3_analyzers)
+_phase2_HLTJetMETValSeq += cms.Sequence(sumModules(met_ph2_analyzers))
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toReplaceWith(HLTJetMETValSeq, _phase2_HLTJetMETValSeq)

--- a/Validation/RecoMET/plugins/METTester.cc
+++ b/Validation/RecoMET/plugins/METTester.cc
@@ -224,7 +224,8 @@ void METTester::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup)
   edm::Handle<reco::VertexCollection> pvHandle;
   iEvent.getByToken(pvToken_, pvHandle);
   if (!pvHandle.isValid()) {
-    edm::LogWarning("MissingInput") << __FUNCTION__ << ":" << __LINE__ << ": pvHandle handle with tag " << pvTokenTag_ << " not found!";
+    edm::LogWarning("MissingInput") << __FUNCTION__ << ":" << __LINE__ << ": pvHandle handle with tag " << pvTokenTag_
+                                    << " not found!";
     return;
   }
   const int nvtx = pvHandle->size();

--- a/Validation/RecoMET/plugins/METTester.cc
+++ b/Validation/RecoMET/plugins/METTester.cc
@@ -29,7 +29,8 @@ METTester::METTester(const edm::ParameterSet &iConfig) {
     genMETsCaloToken_ = consumes<reco::GenMETCollection>(edm::InputTag("genMetCalo"));
   }
 
-  pvToken_ = consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("primaryVertices"));
+  pvTokenTag_ = iConfig.getParameter<edm::InputTag>("primaryVertices");
+  pvToken_ = consumes<std::vector<reco::Vertex>>(pvTokenTag_);
 
   // Events variables
   mNvertex = nullptr;
@@ -223,7 +224,7 @@ void METTester::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup)
   edm::Handle<reco::VertexCollection> pvHandle;
   iEvent.getByToken(pvToken_, pvHandle);
   if (!pvHandle.isValid()) {
-    edm::LogWarning("MissingInput") << __FUNCTION__ << ":" << __LINE__ << ":pvHandle handle not found!";
+    edm::LogWarning("MissingInput") << __FUNCTION__ << ":" << __LINE__ << ": pvHandle handle with tag " << pvTokenTag_ << " not found!";
     return;
   }
   const int nvtx = pvHandle->size();

--- a/Validation/RecoMET/plugins/METTester.h
+++ b/Validation/RecoMET/plugins/METTester.h
@@ -59,6 +59,7 @@ private:
   edm::InputTag inputCaloMETLabel_;
 
   // Tokens
+  edm::InputTag pvTokenTag_;
   edm::EDGetTokenT<std::vector<reco::Vertex>> pvToken_;
   edm::EDGetTokenT<reco::CaloMETCollection> caloMETsToken_;
   edm::EDGetTokenT<reco::PFMETCollection> pfMETsToken_;

--- a/Validation/RecoMET/python/hltMETValidation_cff.py
+++ b/Validation/RecoMET/python/hltMETValidation_cff.py
@@ -13,10 +13,13 @@ hltMetPostProcessor = _metTesterPostProcessor.clone(
 from Validation.RecoMET.metTester_cfi import metTester as _metTester
 _hltMetTester = _metTester.clone(
     runDir = "HLT/JetMET/METValidation/",
-    primaryVertices = 'hltPhase2PixelVertices',
+    primaryVertices = 'hltPixelVertices',
     genMetTrue = 'genMetTrue',
     genMetCalo = 'genMetCalo',
 )
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(_hltMetTester, primaryVertices = 'hltPhase2PixelVertices')
 
 hltMetAnalyzerPF = _hltMetTester.clone(
     inputMETLabel = 'hltPFMET', 

--- a/Validation/RecoMET/python/hltMETValidation_cff.py
+++ b/Validation/RecoMET/python/hltMETValidation_cff.py
@@ -22,22 +22,25 @@ from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify(_hltMetTester, primaryVertices = 'hltPhase2PixelVertices')
 
 hltMetAnalyzerPF = _hltMetTester.clone(
-    inputMETLabel = 'hltPFMET', 
-    METType = 'pf', 
+    inputMETLabel = 'hltPFMETProducer', 
+    METType = 'pf',
 )
+phase2_common.toModify(hltMetAnalyzerPF, inputMETLabel = 'hltPFMET')
 
 hltMetAnalyzerPFPuppi = _hltMetTester.clone(
-    inputMETLabel = 'hltPFPuppiMET',
+    inputMETLabel = 'dummy (phase2-only)',
     METType = 'pf',
 )
+phase2_common.toModify(hltMetAnalyzerPFPuppi, inputMETLabel = 'hltPFPuppiMET')
 
 hltMetTypeOneAnalyzerPFPuppi = _hltMetTester.clone(
-    inputMETLabel = 'hltPFPuppiMETTypeOne',
+    inputMETLabel = 'dummy (phase2-only)',
     METType = 'pf',
 )
+phase2_common.toModify(hltMetTypeOneAnalyzerPFPuppi, inputMETLabel = 'hltPFPuppiMETTypeOne')
 
 hltMetAnalyzerPFCalo = _hltMetTester.clone(
-    inputMETLabel = 'hltCaloMET',
+    inputMETLabel = 'hltMet',
     METType = 'calo',
 )
-
+phase2_common.toModify(hltMetAnalyzerPFCalo, inputMETLabel = 'hltCaloMET')

--- a/Validation/RecoMET/scripts/makeHLTMETValidationPlots.py
+++ b/Validation/RecoMET/scripts/makeHLTMETValidationPlots.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import shutil
 import argparse
 import numpy as np
 import hist
@@ -29,7 +30,7 @@ def createDir(adir):
 def createIndexPHP(src, dest):
     php_file = os.path.join(src, 'index.php')
     if os.path.exists(php_file):
-        os.system(f'cp {php_file} {dest}')
+        shutil.copy(php_file, dest)
 
 def checkRootDir(afile, adir):
     if not afile.Get(adir):

--- a/Validation/RecoMET/scripts/makeHLTMETValidationPlots.py
+++ b/Validation/RecoMET/scripts/makeHLTMETValidationPlots.py
@@ -26,6 +26,11 @@ def createDir(adir):
         os.makedirs(adir)
     return adir
 
+def createIndexPHP(src, dest):
+    php_file = os.path.join(src, 'index.php')
+    if os.path.exists(php_file):
+        os.system(f'cp {php_file} {dest}')
+
 def checkRootDir(afile, adir):
     if not afile.Get(adir):
         raise RuntimeError(f"Directory '{adir}' not found in {afile}")
@@ -357,4 +362,5 @@ if __name__ == '__main__':
         checkRootDir(afile, turnon_dir)
         vars1Dtrigger = ('TurnOngMET', 'TurnOngMETLow', 'TurnOnhMET', 'TurnOnhMETLow')
         outdir = createDir(os.path.join(args.odir, trigger))
+        createIndexPHP(src=args.odir, dest=trigger)
         plot1Dtrigger(afile, turnon_dir, vars1Dtrigger, outdir=outdir, metType=METType[metType])


### PR DESCRIPTION
#### PR description:

This PR addresses [this comment](https://github.com/cms-sw/cmssw/pull/48745#discussion_r2508228924). 

The goal is to run the MET validation implemented in #48745 for Phase-2 also in Run 3.

@mmusich 

#### PR validation:

Validated with `runTheMatrix.py -l 17034.0 --what upgrade` (`TTbar_14TeV_TuneCP5_2025PU_GenSim+DigiPU_2025PU+RecoNanoPU_2025PU+HARVESTNanoPU_2025PU`), which produces logs without warnings for the `METTester.cc` producer and creates the `MetValidation` folder in the DQM file, as expected.

<img width="608" height="580" alt="image" src="https://github.com/user-attachments/assets/a8368777-1d8a-48fd-92e8-0d66c05c2d18" />