### PR TITLE
Update high purity ID and simplify HLT LST configurations

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -696,10 +696,7 @@ phase2_tracker.toModify(FEVTDEBUGHLTEventContent,
                             'keep *_hltGeneralTracks_*_*',
                             'keep *_hltInitialStepTrackSelectionHighPurity_*_*',
                             'keep *_hltHighPtTripletStepTrackSelectionHighPurity_*_*',
-                            'keep *_hltInitialStepTrackSelectionHighPuritypTTCLST_*_*',
-                            'keep *_hltInitialStepTrackSelectionHighPuritypLSTCLST_*_*',
                             'keep *_hltInitialStepTracksT5TCLST_*_*',
-                            'keep *_hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST_*_*',
                             'keep *_hltOfflinePrimaryVertices_*_*',
                         ])
 

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -155,7 +155,10 @@ process.pixelTracksCutClassifier = cms.EDProducer( "TrackCutClassifier",
       minNdof = cms.vdouble( 1.0E-5, 1.0E-5, 1.0E-5 ),
       maxChi2 = cms.vdouble( 9999., 9999., 30.0 ),
       maxDr = cms.vdouble( 99., 99., 1. ),
-      minLayers = cms.vint32( 0, 2, 3 )
+      minLayers = cms.vint32( 0, 2, 3 ),
+      passThroughForAll = cms.bool(False),
+      passThroughForDisplaced = cms.bool(False),
+      minLayersForDisplaced = cms.int32(4)
     ),
     ignoreVertices = cms.bool( True ),
 )

--- a/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
@@ -132,31 +132,6 @@ iterHighPtTripletsMonitoringHLT = iterHLTTracksMonitoringHLT.clone(
     allTrackProducer = 'hltHighPtTripletStepTrackSelectionHighPurity',
 )
 
-# LST track collections
-initialSteppTTCLSTTracksMonitoringHLT = trackingMonHLT.clone(
-    FolderName       = 'HLT/Tracking/initialStepTrackSelectionHighPuritypTTCLST',
-    TrackProducer    = 'hltInitialStepTrackSelectionHighPuritypTTCLST',
-    allTrackProducer = 'hltInitialStepTrackSelectionHighPuritypTTCLST'
-)
-
-initialSteppLSTCLSTTracksMonitoringHLT = trackingMonHLT.clone(
-    FolderName       = 'HLT/Tracking/initialStepTrackSelectionHighPuritypLSTCLST',
-    TrackProducer    = 'hltInitialStepTrackSelectionHighPuritypLSTCLST',
-    allTrackProducer = 'hltInitialStepTrackSelectionHighPuritypLSTCLST'
-)
-
-initialStepT5TCLSTTracksMonitoringHLT = trackingMonHLT.clone(
-    FolderName       = 'HLT/Tracking/initialStepTracksT5TCLST',
-    TrackProducer    = 'hltInitialStepTracksT5TCLST',
-    allTrackProducer = 'hltInitialStepTracksT5TCLST'
-)
-
-highPtTripletSteppLSTCLSTTracksMonitoringHLT = trackingMonHLT.clone(
-    FolderName       = 'HLT/Tracking/highPtTripletStepTrackSelectionHighPuritypLSTCLST',
-    TrackProducer    = 'hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST',
-    allTrackProducer = 'hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST'
-)
-
 iter3TracksMonitoringHLT = trackingMonHLT.clone(
     FolderName       = 'HLT/Tracking/iter3Merged',
     TrackProducer    = 'hltIter3Merged',
@@ -298,11 +273,6 @@ trkHLTDQMSourceExtra = cms.Sequence(
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT + doubletRecoveryHPTracksMonitoringHLT))
 phase2_tracker.toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT + iterInitialStepMonitoringHLT + iterHighPtTripletsMonitoringHLT))
-
-from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
-from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
-(~seedingLST & trackingLST).toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT + initialSteppTTCLSTTracksMonitoringHLT + initialSteppLSTCLSTTracksMonitoringHLT + initialStepT5TCLSTTracksMonitoringHLT + iterHighPtTripletsMonitoringHLT))
-(seedingLST & trackingLST).toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT + initialSteppTTCLSTTracksMonitoringHLT + initialStepT5TCLSTTracksMonitoringHLT + highPtTripletSteppLSTCLSTTracksMonitoringHLT))
 
 run3_common.toReplaceWith(trackingMonitorHLTall, cms.Sequence(pixelTracksMonitoringHLT + iter0TracksMonitoringHLT + iter0HPTracksMonitoringHLT + doubletRecoveryTracksMonitoringHLT + doubletRecoveryHPTracksMonitoringHLT + iterHLTTracksMonitoringHLT))
 run3_common.toReplaceWith(egmTrackingMonitorHLT, cms.Sequence(gsfTracksMonitoringHLT))

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltGeneralTracks_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltGeneralTracks_cfi.py
@@ -29,50 +29,18 @@ from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPat
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
 
+(~singleIterPatatrack & trackingLST).toModify(hltGeneralTracks, indivShareFrac = [0.1,0.1])
+
 _hltGeneralTracksSingleIterPatatrack = hltGeneralTracks.clone(
     TrackProducers = ["hltInitialStepTrackSelectionHighPurity"],
     hasSelector = [0],
     indivShareFrac = [1.0],
     selectedTrackQuals = ["hltInitialStepTrackSelectionHighPurity"],
-    setsToMerge = {0: dict(pQual=True, tLists=[0,1])}
+    setsToMerge = {0: dict(pQual=True, tLists=[0])}
 )
 
-(singleIterPatatrack & ~trackingLST & ~seedingLST).toReplaceWith(hltGeneralTracks, _hltGeneralTracksSingleIterPatatrack)
-
-_hltGeneralTracksLST = hltGeneralTracks.clone(
-    TrackProducers = ["hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTrackSelectionHighPuritypLSTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPurity"],
-    hasSelector = [0,0,0,0],
-    indivShareFrac = [0.1,0.1,0.1,0.1],
-    selectedTrackQuals = ["hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTrackSelectionHighPuritypLSTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPurity"],
-    setsToMerge = {0: dict(pQual=True, tLists=[0,1,2,3])}
-)
-
-(~singleIterPatatrack & trackingLST & ~seedingLST).toReplaceWith(hltGeneralTracks, _hltGeneralTracksLST)
-
-_hltGeneralTracksSingleIterPatatrackLST = hltGeneralTracks.clone(
-    TrackProducers = ["hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTrackSelectionHighPuritypLSTCLST", "hltInitialStepTracksT5TCLST"],
-    hasSelector = [0,0,0],
-    indivShareFrac = [0.1,0.1,0.1],
-    selectedTrackQuals = ["hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTrackSelectionHighPuritypLSTCLST", "hltInitialStepTracksT5TCLST"],
-   setsToMerge = {0: dict(pQual=True, tLists=[0,1,2])}
-)
-
-(singleIterPatatrack & trackingLST & ~seedingLST).toReplaceWith(hltGeneralTracks, _hltGeneralTracksSingleIterPatatrackLST)
-
-_hltGeneralTracksLSTSeeding = hltGeneralTracks.clone(
-            TrackProducers = ["hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST"],
-            hasSelector = [0,0,0],
-            indivShareFrac = [0.1,0.1,0.1],
-            selectedTrackQuals = ["hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST"],
-            setsToMerge = {0: dict(pQual=True, tLists=[0,1,2])}
-)
-
-(~singleIterPatatrack & trackingLST & seedingLST).toReplaceWith(hltGeneralTracks, _hltGeneralTracksLSTSeeding)
-
-(singleIterPatatrack & trackingLST & seedingLST).toModify(_hltGeneralTracksSingleIterPatatrack,
-                                                          TrackProducers = ["hltInitialStepTracks"],
-                                                          selectedTrackQuals = ["hltInitialStepTracks"])
-(singleIterPatatrack & trackingLST & seedingLST).toReplaceWith(hltGeneralTracks, _hltGeneralTracksSingleIterPatatrack)
+(singleIterPatatrack & trackingLST).toModify(_hltGeneralTracksSingleIterPatatrack, indivShareFrac = [0.1])
+(singleIterPatatrack).toReplaceWith(hltGeneralTracks, _hltGeneralTracksSingleIterPatatrack)
 
 from Configuration.ProcessModifiers.ngtScouting_cff import ngtScouting
 from ..modules.hltPhase2PixelTracks_cfi import *

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackCandidates_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackCandidates_cfi.py
@@ -24,3 +24,9 @@ hltHighPtTripletStepTrackCandidates = cms.EDProducer("CkfTrackCandidateMaker",
     src = cms.InputTag("hltHighPtTripletStepSeeds"),
     useHitsSplitting = cms.bool(False)
 )
+
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+
+(~singleIterPatatrack & trackingLST & seedingLST).toModify(hltHighPtTripletStepTrackCandidates, src = "hltInitialStepTrackCandidates:pLSTSsLST")

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackCandidatespLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackCandidatespLSTCLST_cfi.py
@@ -1,4 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from ..modules.hltHighPtTripletStepTrackCandidates_cfi import hltHighPtTripletStepTrackCandidates as _hltHighPtTripletStepTrackCandidates
-hltHighPtTripletStepTrackCandidatespLSTCLST = _hltHighPtTripletStepTrackCandidates.clone( src = "hltInitialStepTrackCandidates:pLSTSsLST" )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackCutClassifier_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackCutClassifier_cfi.py
@@ -26,7 +26,10 @@ hltHighPtTripletStepTrackCutClassifier = cms.EDProducer("TrackCutClassifier",
         minLayers = cms.vint32(3, 3, 4),
         minNVtxTrk = cms.int32(3),
         minNdof = cms.vdouble(1e-05, 1e-05, 1e-05),
-        minPixelHits = cms.vint32(0, 0, 3)
+        minPixelHits = cms.vint32(0, 0, 3),
+        passThroughForAll = cms.bool(False),
+        passThroughForDisplaced = cms.bool(False),
+        minLayersForDisplaced = cms.int32(4)
     ),
     qualityCuts = cms.vdouble(-0.7, 0.1, 0.7),
     src = cms.InputTag("hltHighPtTripletStepTracks"),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackCutClassifierpLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackCutClassifierpLSTCLST_cfi.py
@@ -1,4 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from ..modules.hltHighPtTripletStepTrackCutClassifier_cfi import hltHighPtTripletStepTrackCutClassifier as _hltHighPtTripletStepTrackCutClassifier
-hltHighPtTripletStepTrackCutClassifierpLSTCLST = _hltHighPtTripletStepTrackCutClassifier.clone( src = "hltHighPtTripletStepTrackspLSTCLST" )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST_cfi.py
@@ -1,8 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from ..modules.hltHighPtTripletStepTrackSelectionHighPurity_cfi import hltHighPtTripletStepTrackSelectionHighPurity as _hltHighPtTripletStepTrackSelectionHighPurity
-hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST = _hltHighPtTripletStepTrackSelectionHighPurity.clone(
-    originalMVAVals = "hltHighPtTripletStepTrackCutClassifierpLSTCLST:MVAValues",
-    originalQualVals = "hltHighPtTripletStepTrackCutClassifierpLSTCLST:QualityMasks",
-    originalSource = "hltHighPtTripletStepTrackspLSTCLST"
-)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackspLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackspLSTCLST_cfi.py
@@ -1,4 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from ..modules.hltHighPtTripletStepTracks_cfi import hltHighPtTripletStepTracks as _hltHighPtTripletStepTracks
-hltHighPtTripletStepTrackspLSTCLST = _hltHighPtTripletStepTracks.clone( src = "hltHighPtTripletStepTrackCandidatespLSTCLST" )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCutClassifier_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCutClassifier_cfi.py
@@ -26,9 +26,20 @@ hltInitialStepTrackCutClassifier = cms.EDProducer("TrackCutClassifier",
         minLayers = cms.vint32(3, 3, 3),
         minNVtxTrk = cms.int32(3),
         minNdof = cms.vdouble(1e-05, 1e-05, 1e-05),
-        minPixelHits = cms.vint32(0, 0, 3)
+        minPixelHits = cms.vint32(0, 0, 3),
+        passThroughForAll = cms.bool(False),
+        passThroughForDisplaced = cms.bool(False),
+        minLayersForDisplaced = cms.int32(4)
     ),
     qualityCuts = cms.vdouble(-0.7, 0.1, 0.7),
     src = cms.InputTag("hltInitialStepTracks"),
     vertices = cms.InputTag("hltPhase2PixelVertices")
 )
+
+from Configuration.ProcessModifiers.hltTrackingMkFitInitialStep_cff import hltTrackingMkFitInitialStep
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+
+trackingLST.toModify(hltInitialStepTrackCutClassifier, mva = dict( passThroughForDisplaced = True ))
+(singleIterPatatrack & trackingLST & seedingLST).toModify(hltInitialStepTrackCutClassifier, mva = dict( passThroughForAll = True ))

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCutClassifierpLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCutClassifierpLSTCLST_cfi.py
@@ -1,4 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from ..modules.hltInitialStepTrackCutClassifier_cfi import hltInitialStepTrackCutClassifier as _hltInitialStepTrackCutClassifier
-hltInitialStepTrackCutClassifierpLSTCLST = _hltInitialStepTrackCutClassifier.clone( src = "hltInitialStepTrackspLSTCLST" )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCutClassifierpTTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCutClassifierpTTCLST_cfi.py
@@ -1,4 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from ..modules.hltInitialStepTrackCutClassifier_cfi import hltInitialStepTrackCutClassifier as _hltInitialStepTrackCutClassifier
-hltInitialStepTrackCutClassifierpTTCLST = _hltInitialStepTrackCutClassifier.clone( src = "hltInitialStepTrackspTTCLST" )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackSelectionHighPuritypLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackSelectionHighPuritypLSTCLST_cfi.py
@@ -1,8 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from ..modules.hltInitialStepTrackSelectionHighPurity_cfi import hltInitialStepTrackSelectionHighPurity as _hltInitialStepTrackSelectionHighPurity
-hltInitialStepTrackSelectionHighPuritypLSTCLST = _hltInitialStepTrackSelectionHighPurity.clone(
-    originalMVAVals = "hltInitialStepTrackCutClassifierpLSTCLST:MVAValues",
-    originalQualVals = "hltInitialStepTrackCutClassifierpLSTCLST:QualityMasks",
-    originalSource = "hltInitialStepTrackspLSTCLST"
-)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackSelectionHighPuritypTTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackSelectionHighPuritypTTCLST_cfi.py
@@ -1,8 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from ..modules.hltInitialStepTrackSelectionHighPurity_cfi import hltInitialStepTrackSelectionHighPurity as _hltInitialStepTrackSelectionHighPurity
-hltInitialStepTrackSelectionHighPuritypTTCLST = _hltInitialStepTrackSelectionHighPurity.clone(
-    originalMVAVals = "hltInitialStepTrackCutClassifierpTTCLST:MVAValues",
-    originalQualVals = "hltInitialStepTrackCutClassifierpTTCLST:QualityMasks",
-    originalSource = "hltInitialStepTrackspTTCLST"
-)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTracks_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTracks_cfi.py
@@ -18,6 +18,11 @@ hltInitialStepTracks = cms.EDProducer("TrackProducer",
     useSimpleMF = cms.bool(False)
 )
 
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+
+(~singleIterPatatrack & trackingLST & seedingLST).toModify(hltInitialStepTracks, src = "hltInitialStepTrackCandidates:nopLSTCsLST")
 
 _hltInitialStepTracksMkFitFit = cms.EDProducer("MkFitOutputTrackConverter",
     measurementTrackerEvent = cms.InputTag("hltMeasurementTrackerEvent"),
@@ -43,9 +48,7 @@ _hltInitialStepTracksMkFitFitLSTSeeds = _hltInitialStepTracksMkFitFit.clone(seed
 
 from Configuration.ProcessModifiers.hltTrackingMkFitInitialStep_cff import hltTrackingMkFitInitialStep
 from Configuration.ProcessModifiers.trackingMkFitFit_cff import trackingMkFitFit
+
 (hltTrackingMkFitInitialStep & trackingMkFitFit).toReplaceWith(hltInitialStepTracks, _hltInitialStepTracksMkFitFit)
 
-from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
-from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
-from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
 (singleIterPatatrack & trackingLST & seedingLST & hltTrackingMkFitInitialStep & trackingMkFitFit).toReplaceWith(hltInitialStepTracks, _hltInitialStepTracksMkFitFitLSTSeeds)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackspLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackspLSTCLST_cfi.py
@@ -1,4 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from ..modules.hltInitialStepTracks_cfi import hltInitialStepTracks as _hltInitialStepTracks
-hltInitialStepTrackspLSTCLST = _hltInitialStepTracks.clone( src = "hltInitialStepTrackCandidates:pLSTCsLST" )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackspTTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackspTTCLST_cfi.py
@@ -1,4 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from ..modules.hltInitialStepTracks_cfi import hltInitialStepTracks as _hltInitialStepTracks
-hltInitialStepTrackspTTCLST = _hltInitialStepTracks.clone( src = "hltInitialStepTrackCandidates:pTTCsLST" )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltIter0Phase2L3FromL1TkMuonTrackCutClassifier_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltIter0Phase2L3FromL1TkMuonTrackCutClassifier_cfi.py
@@ -26,7 +26,10 @@ hltIter0Phase2L3FromL1TkMuonTrackCutClassifier = cms.EDProducer("TrackCutClassif
         minLayers = cms.vint32(3, 3, 4),
         minNVtxTrk = cms.int32(3),
         minNdof = cms.vdouble(1e-05, 1e-05, 1e-05),
-        minPixelHits = cms.vint32(0, 3, 4)
+        minPixelHits = cms.vint32(0, 3, 4),
+        passThroughForAll = cms.bool(False),
+        passThroughForDisplaced = cms.bool(False),
+        minLayersForDisplaced = cms.int32(4)
     ),
     qualityCuts = cms.vdouble(-0.7, 0.1, 0.7),
     src = cms.InputTag("hltIter0Phase2L3FromL1TkMuonCtfWithMaterialTracks"),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltIter2Phase2L3FromL1TkMuonTrackCutClassifier_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltIter2Phase2L3FromL1TkMuonTrackCutClassifier_cfi.py
@@ -26,7 +26,10 @@ hltIter2Phase2L3FromL1TkMuonTrackCutClassifier = cms.EDProducer("TrackCutClassif
         minLayers = cms.vint32(3, 3, 3),
         minNVtxTrk = cms.int32(3),
         minNdof = cms.vdouble(1e-05, 1e-05, 1e-05),
-        minPixelHits = cms.vint32(0, 0, 0)
+        minPixelHits = cms.vint32(0, 0, 0),
+        passThroughForAll = cms.bool(False),
+        passThroughForDisplaced = cms.bool(False),
+        minLayersForDisplaced = cms.int32(4)
     ),
     qualityCuts = cms.vdouble(-0.7, 0.1, 0.7),
     src = cms.InputTag("hltIter2Phase2L3FromL1TkMuonCtfWithMaterialTracks"),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3MuonHighPtTripletStepTrackCutClassifier_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3MuonHighPtTripletStepTrackCutClassifier_cfi.py
@@ -26,7 +26,10 @@ hltPhase2L3MuonHighPtTripletStepTrackCutClassifier = cms.EDProducer("TrackCutCla
         minLayers = cms.vint32(3, 3, 4),
         minNVtxTrk = cms.int32(3),
         minNdof = cms.vdouble(1e-05, 1e-05, 1e-05),
-        minPixelHits = cms.vint32(0, 0, 3)
+        minPixelHits = cms.vint32(0, 0, 3),
+        passThroughForAll = cms.bool(False),
+        passThroughForDisplaced = cms.bool(False),
+        minLayersForDisplaced = cms.int32(4)
     ),
     qualityCuts = cms.vdouble(-0.7, 0.1, 0.7),
     src = cms.InputTag("hltPhase2L3MuonHighPtTripletStepTracks"),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3MuonInitialStepTrackCutClassifier_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3MuonInitialStepTrackCutClassifier_cfi.py
@@ -26,7 +26,10 @@ hltPhase2L3MuonInitialStepTrackCutClassifier = cms.EDProducer("TrackCutClassifie
         minLayers = cms.vint32(3, 3, 3),
         minNVtxTrk = cms.int32(3),
         minNdof = cms.vdouble(1e-05, 1e-05, 1e-05),
-        minPixelHits = cms.vint32(0, 0, 3)
+        minPixelHits = cms.vint32(0, 0, 3),
+        passThroughForAll = cms.bool(False),
+        passThroughForDisplaced = cms.bool(False),
+        minLayersForDisplaced = cms.int32(4)
     ),
     qualityCuts = cms.vdouble(-0.7, 0.1, 0.7),
     src = cms.InputTag("hltPhase2L3MuonInitialStepTracks"),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3OIMuonTrackCutClassifier_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3OIMuonTrackCutClassifier_cfi.py
@@ -26,7 +26,10 @@ hltPhase2L3OIMuonTrackCutClassifier = cms.EDProducer("TrackCutClassifier",
         minLayers = cms.vint32(3, 5, 5),
         minNVtxTrk = cms.int32(3),
         minNdof = cms.vdouble(1e-05, 1e-05, 1e-05),
-        minPixelHits = cms.vint32(0, 0, 1)
+        minPixelHits = cms.vint32(0, 0, 1),
+        passThroughForAll = cms.bool(False),
+        passThroughForDisplaced = cms.bool(False),
+        minLayersForDisplaced = cms.int32(4)
     ),
     qualityCuts = cms.vdouble(-0.7, 0.1, 0.7),
     src = cms.InputTag("hltPhase2L3OIMuCtfWithMaterialTracks"),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelTracksCutClassifier_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelTracksCutClassifier_cfi.py
@@ -26,7 +26,10 @@ hltPhase2PixelTracksCutClassifier = cms.EDProducer("TrackCutClassifier",
         minLayers = cms.vint32(3, 3, 3),
         minNVtxTrk = cms.int32(3),
         minNdof = cms.vdouble(1e-05, 1e-05, 1e-05),
-        minPixelHits = cms.vint32(0, 0, 3)
+        minPixelHits = cms.vint32(0, 0, 3),
+        passThroughForAll = cms.bool(False),
+        passThroughForDisplaced = cms.bool(False),
+        minLayersForDisplaced = cms.int32(4)
     ),
     qualityCuts = cms.vdouble(-0.7, 0.1, 0.7),
     src = cms.InputTag("hltPhase2PixelTracksCAExtension"),

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHighPtTripletStepSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHighPtTripletStepSequence_cfi.py
@@ -16,17 +16,3 @@ HLTHighPtTripletStepSequence = cms.Sequence(
 
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 trackingLST.toReplaceWith(HLTHighPtTripletStepSequence, HLTHighPtTripletStepSequence.copyAndExclude([HLTHighPtTripletStepSeedingSequence]))
-
-from ..modules.hltHighPtTripletStepTrackCandidatespLSTCLST_cfi import *
-from ..modules.hltHighPtTripletStepTrackspLSTCLST_cfi import *
-from ..modules.hltHighPtTripletStepTrackCutClassifierpLSTCLST_cfi import *
-from ..modules.hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST_cfi import *
-_HLTHighPtTripletStepSequenceLSTSeeding = cms.Sequence(
-     hltHighPtTripletStepTrackCandidatespLSTCLST
-    +hltHighPtTripletStepTrackspLSTCLST
-    +hltHighPtTripletStepTrackCutClassifierpLSTCLST
-    +hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST
-)
-
-from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
-(seedingLST & trackingLST).toReplaceWith(HLTHighPtTripletStepSequence, _HLTHighPtTripletStepSequenceLSTSeeding)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
@@ -18,13 +18,6 @@ from ..modules.hltHighPtTripletStepSeedTracksLST_cfi import *
 from ..modules.hltSiPhase2RecHits_cfi import *
 from ..modules.hltInputLST_cfi import *
 from ..modules.hltLST_cfi import *
-from ..modules.hltInitialStepTrackspTTCLST_cfi import *
-from ..modules.hltInitialStepTrackspLSTCLST_cfi import *
-from ..modules.hltInitialStepTracksT5TCLST_cfi import *
-from ..modules.hltInitialStepTrackCutClassifierpTTCLST_cfi import *
-from ..modules.hltInitialStepTrackCutClassifierpLSTCLST_cfi import *
-from ..modules.hltInitialStepTrackSelectionHighPuritypTTCLST_cfi import *
-from ..modules.hltInitialStepTrackSelectionHighPuritypLSTCLST_cfi import *
 _HLTInitialStepSequenceLST = cms.Sequence(
      hltInitialStepSeeds
     +hltInitialStepSeedTracksLST
@@ -34,24 +27,18 @@ _HLTInitialStepSequenceLST = cms.Sequence(
     +hltInputLST
     +hltLST
     +hltInitialStepTrackCandidates
-    +hltInitialStepTrackspTTCLST
-    +hltInitialStepTrackspLSTCLST
-    +hltInitialStepTracksT5TCLST
-    +hltInitialStepTrackCutClassifierpTTCLST
-    +hltInitialStepTrackCutClassifierpLSTCLST
-    +hltInitialStepTrackSelectionHighPuritypTTCLST
-    +hltInitialStepTrackSelectionHighPuritypLSTCLST
+    +hltInitialStepTracks
+    +hltInitialStepTrackCutClassifier
+    +hltInitialStepTrackSelectionHighPurity
 )
 
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
 from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
-from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
 
-(~singleIterPatatrack & trackingLST & ~seedingLST).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLST)
+(~singleIterPatatrack & trackingLST).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLST)
 
 (singleIterPatatrack & trackingLST & ~seedingLST).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLST.copyAndExclude([HLTHighPtTripletStepSeedingSequence,hltHighPtTripletStepSeedTracksLST]))
-
-(~singleIterPatatrack & trackingLST & seedingLST).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLST.copyAndExclude([hltInitialStepTrackspLSTCLST,hltInitialStepTrackCutClassifierpLSTCLST,hltInitialStepTrackSelectionHighPuritypLSTCLST]))
 
 from ..modules.hltInitialStepTrajectorySeedsLST_cfi import *
 _HLTInitialStepSequenceSingleIterPatatrackLSTSeeding = cms.Sequence(
@@ -63,10 +50,13 @@ _HLTInitialStepSequenceSingleIterPatatrackLSTSeeding = cms.Sequence(
     +hltInitialStepTrajectorySeedsLST
     +hltInitialStepTrackCandidates
     +hltInitialStepTracks
+    +hltInitialStepTrackCutClassifier
+    +hltInitialStepTrackSelectionHighPurity
 )
 
 (singleIterPatatrack & trackingLST & seedingLST).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceSingleIterPatatrackLSTSeeding)
 
+from ..modules.hltInitialStepTracksT5TCLST_cfi import *
 _HLTInitialStepSequenceNGTScouting = cms.Sequence(
     hltInitialStepSeeds
     +hltInitialStepSeedTracksLST
@@ -110,6 +100,8 @@ _HLTInitialStepSequenceSingleIterPatatrackLSTSeedingMkFitTracking = cms.Sequence
     +hltInitialStepTrackCandidatesMkFit
     +hltInitialStepTrackCandidates
     +hltInitialStepTracks
+    +hltInitialStepTrackCutClassifier
+    +hltInitialStepTrackSelectionHighPurity
 )
 
 (singleIterPatatrack & trackingLST & seedingLST & hltTrackingMkFitInitialStep).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceSingleIterPatatrackLSTSeedingMkFitTracking)

--- a/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
+++ b/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
@@ -38,29 +38,12 @@ from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(hltTrackValidator, _modifyForPhase2)
 
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
-from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
 from Configuration.ProcessModifiers.ngtScouting_cff import ngtScouting
-
-def _modifyForPhase2LSTTracking(trackvalidator):
-    trackvalidator.label = ["hltGeneralTracks", "hltPhase2PixelTracks", "hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTrackSelectionHighPuritypLSTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPurity"]
-(~seedingLST & trackingLST).toModify(hltTrackValidator, _modifyForPhase2LSTTracking)
-
-def _modifyForPhase2LSTSeeding(trackvalidator):
-    trackvalidator.label = ["hltGeneralTracks", "hltPhase2PixelTracks", "hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST"]
-(seedingLST & trackingLST).toModify(hltTrackValidator, _modifyForPhase2LSTSeeding)
-
 from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+
 def _modifyForSingleIterPatatrack(trackvalidator):
     trackvalidator.label = ["hltGeneralTracks", "hltPhase2PixelTracks", "hltInitialStepTrackSelectionHighPurity"]
-(singleIterPatatrack & ~trackingLST & ~seedingLST).toModify(hltTrackValidator, _modifyForSingleIterPatatrack)
-
-def _modifyForSingleIterPatatrackLST(trackvalidator):
-    trackvalidator.label = ["hltGeneralTracks", "hltPhase2PixelTracks", "hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTrackSelectionHighPuritypLSTCLST", "hltInitialStepTracksT5TCLST"]
-(singleIterPatatrack & ~seedingLST & trackingLST).toModify(hltTrackValidator, _modifyForSingleIterPatatrackLST)
-
-def _modifyForSingleIterPatatrackLSTSeeding(trackvalidator):
-    trackvalidator.label = ["hltGeneralTracks", "hltPhase2PixelTracks", "hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTracksT5TCLST"]
-(singleIterPatatrack & seedingLST & trackingLST).toModify(hltTrackValidator, _modifyForSingleIterPatatrackLSTSeeding)
+singleIterPatatrack.toModify(hltTrackValidator, _modifyForSingleIterPatatrack)
 
 def _modifyForNGTScouting(trackvalidator):
     trackvalidator.label = ["hltGeneralTracks", "hltPhase2PixelTracks"]

--- a/Validation/RecoTrack/python/customiseTrackingNtuple.py
+++ b/Validation/RecoTrack/python/customiseTrackingNtuple.py
@@ -164,13 +164,7 @@ def customiseTrackingNtupleHLT(process):
 
     process.trackingNtuple.trackCandidates = ["hltIter0PFlowCkfTrackCandidates", "hltDoubletRecoveryPFlowCkfTrackCandidates"]
     trackingPhase2PU140.toModify(process.trackingNtuple, trackCandidates = ["hltInitialStepTrackCandidates", "hltHighPtTripletStepTrackCandidates"])
-    (singleIterPatatrack & (~trackingLST | seedingLST)).toModify(process.trackingNtuple, trackCandidates = ["hltInitialStepTrackCandidates"])
-    (singleIterPatatrack & trackingLST & ~seedingLST).toModify(process.trackingNtuple,
-        trackCandidates = ["hltInitialStepTrackCandidates:pTCsLST", "hltInitialStepTrackCandidates:t5TCsLST"])
-    (~singleIterPatatrack & trackingLST & ~seedingLST).toModify(process.trackingNtuple,
-        trackCandidates = ["hltInitialStepTrackCandidates:pTCsLST", "hltInitialStepTrackCandidates:t5TCsLST", "hltHighPtTripletStepTrackCandidates"])
-    (~singleIterPatatrack & trackingLST & seedingLST).toModify(process.trackingNtuple,
-        trackCandidates = ["hltInitialStepTrackCandidates:pTTCsLST", "hltInitialStepTrackCandidates:t5TCsLST", "hltHighPtTripletStepTrackCandidatespLSTCLST"])
+    singleIterPatatrack.toModify(process.trackingNtuple, trackCandidates = ["hltInitialStepTrackCandidates"])
 
     process.trackingNtuple.clusterMasks = [dict(index = getattr(_algo,"pixelPairStep"), src = "hltDoubletRecoveryClustersRefRemoval")]
     trackingPhase2PU140.toModify(process.trackingNtuple, clusterMasks = [dict(index = getattr(_algo,"highPtTripletStep"), src = "hltHighPtTripletStepClusters")])


### PR DESCRIPTION
This PR updates the high purity ID with two passthrough options:
a) Passthrough for tracks without pixel tracker hits. The only requirement for these tracks is that they have at least 4 hits (that covers T5s with a potential loss of a layer during fitting). The latter requirement is configurable.
b) Passthrough for all tracks. No requirement is applied on the tracks. This is exploited in the single iteration configurations running LST seeding, as these configurations have a very low fake+duplicate. Running the high purity module unifies the configuration and enables the correct usage in downstream objects, in case they require tracks with high purity ID.

The above updates enable a large simplification of the HLT tracking configurations, which is done also in this PR. Below, the relevant procModifier combinations have been validated. The current configuration is in blue and the configuration proposed in this PR is in red:

1. `trackingLST`, falling under option a) above
<img width="1317" height="734" alt="image" src="https://github.com/user-attachments/assets/f776034c-8403-442e-aab7-5e9be101f421" />

2. `trackingLST,seedingLST`, falling under option a) above
<img width="1317" height="732" alt="image" src="https://github.com/user-attachments/assets/3bac2841-fabf-4eef-808e-b1e5dbdd6988" />

3. `singleIterPatatrack,phase2CAExtension,trackingLST`, falling under option a) above
<img width="1317" height="732" alt="image" src="https://github.com/user-attachments/assets/314b193f-793b-4f76-bb0f-ac1a1b2c3112" />

4. `singleIterPatatrack,phase2CAExtension,trackingLST,seedingLST`, falling under option b) above
<img width="1317" height="732" alt="image" src="https://github.com/user-attachments/assets/2feb128c-2911-4dfc-a225-4c2c9e1df016" />

5. `phase2CAExtension,singleIterPatatrack,trackingLST,seedingLST,trackingMkFitCommon,hltTrackingMkFitInitialStep`, falling under option b) above
<img width="1317" height="732" alt="image" src="https://github.com/user-attachments/assets/acd63eb9-1e36-4766-a6be-f53d65de4deb" />

### Comments on the physics perfomance:
- Configurations 1, 2, 3 utilize the TrackListMerger module in a different way (cleaning tracks within the same collection instead of separate collections). This leads to a small increase of the efficiency and either some small decrease of fake rate (for the two iteration setup) or some increase of fake+duplicate rate (in the single iteration setup, where it still remains below 2.5% in any η range).
- Configurations 4, 5 remain unchanged: before they were using built tracks in the general track collection, while they now use the high purity ID tracks, with the passthrough option enabled, in the general track collection, and these two configurations are fully equivalent.

The corresponding presentation can be found in:
https://indico.cern.ch/event/1615436/#2-on-cmssw-pr-49382-update-hig
