### PR TITLE
Update mkFit-related processModifier for LST-seeded phase-2 HLT single tracking iteration

### DIFF
--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -65,8 +65,8 @@ The offsets currently in use are:
 * 0.7561 HLT phase-2 timing menu Alpaka, trimmed tracking
 * 0.7562 HLT phase-2 timing menu Alpaka, trimmed tracking, single tracking iteration variant
 * 0.757: HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + CKF building variant
-* 0.7571: HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + mkFit building variant
-* 0.7572: HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + mkFit building and fitting variant
+* 0.7571: HLT phase-2 timing menu Alpaka, single tracking iteration, Phase2CAExtension+LST seeding + mkFit building variant
+* 0.7572: HLT phase-2 timing menu Alpaka, single tracking iteration, Phase2CAExtension+LST seeding + mkFit building and fitting variant
 * 0.758 HLT phase-2 timing menu ticl_barrel variant
 * 0.759: HLT phase-2 timing menu, with NANO:@Phase2HLT
 * 0.76: HLT phase-2 reduced menu, with DIGI step

--- a/Configuration/PyReleaseValidation/python/relval_Run4.py
+++ b/Configuration/PyReleaseValidation/python/relval_Run4.py
@@ -81,8 +81,8 @@ numWFIB.extend([prefixDet+34.756]) # HLTTiming75e33, phase2_hlt_vertexTrimming
 numWFIB.extend([prefixDet+34.7561])# HLTTiming75e33, alpaka,phase2_hlt_vertexTrimming
 numWFIB.extend([prefixDet+34.7562])# HLTTiming75e33, alpaka,phase2_hlt_vertexTrimming,singleIterPatatrack
 numWFIB.extend([prefixDet+34.757]) # HLTTiming75e33, alpaka,singleIterPatatrack,trackingLST,seedingLST
-numWFIB.extend([prefixDet+34.7571]) # HLTTiming75e33, alpaka,singleIterPatatrack,trackingLST,seedingLST,buildingMkFit
-numWFIB.extend([prefixDet+34.7572]) # HLTTiming75e33, alpaka,singleIterPatatrack,trackingLST,seedingLST,buildingMkFit,fittingMkFit
+numWFIB.extend([prefixDet+34.7571]) # HLTTiming75e33, alpaka,singleIterPatatrack,Phase2CAExtension,trackingLST,seedingLST,buildingMkFit
+numWFIB.extend([prefixDet+34.7572]) # HLTTiming75e33, alpaka,singleIterPatatrack,Phase2CAExtension,trackingLST,seedingLST,buildingMkFit,fittingMkFit
 numWFIB.extend([prefixDet+34.758]) # HLTTiming75e33, ticl_barrel
 numWFIB.extend([prefixDet+34.759]) # HLTTiming75e33 + NANO
 numWFIB.extend([prefixDet+34.77])  # NGTScouting

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2032,7 +2032,7 @@ upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuilding'].suffix = '_H
 upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuilding'].offset = 0.7571
 upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuilding'].step2 = {
     '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing,VALIDATION:@hltValidation',
-    '--procModifiers': 'alpaka,singleIterPatatrack,trackingLST,seedingLST,trackingMkFitCommon,hltTrackingMkFitInitialStep',
+    '--procModifiers': 'alpaka,phase2CAExtension,singleIterPatatrack,trackingLST,seedingLST,trackingMkFitCommon,hltTrackingMkFitInitialStep',
     '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
     '--eventcontent':'FEVTDEBUGHLT,DQMIO'
 }
@@ -2045,7 +2045,7 @@ upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuildingFitting'].suffi
 upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuildingFitting'].offset = 0.7572
 upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuildingFitting'].step2 = {
     '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing,VALIDATION:@hltValidation',
-    '--procModifiers': 'alpaka,singleIterPatatrack,trackingLST,seedingLST,trackingMkFitCommon,hltTrackingMkFitInitialStep,trackingMkFitFit',
+    '--procModifiers': 'alpaka,phase2CAExtension,singleIterPatatrack,trackingLST,seedingLST,trackingMkFitCommon,hltTrackingMkFitInitialStep,trackingMkFitFit',
     '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
     '--eventcontent':'FEVTDEBUGHLT,DQMIO'
 }

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -167,8 +167,8 @@ if __name__ == '__main__':
                      29634.7561,  # HLT phase-2 timing menu Alpaka, trimmed tracking
                      29634.7562,  # HLT phase-2 timing menu Alpaka, trimmed tracking, single tracking iteration variant
                      29634.757,   # HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + CKF building variant
-                     29634.7571,  # HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + mkFit building variant 
-                     29634.7572,  # HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + mkFit building and fitting variant
+                     29634.7571,  # HLT phase-2 timing menu Alpaka, single tracking iteration, Phase2CAExtension+LST seeding + mkFit building variant
+                     29634.7572,  # HLT phase-2 timing menu Alpaka, single tracking iteration, Phase2CAExtension+LST seeding + mkFit building and fitting variant
                      29634.758,   # HLT phase-2 timing menu ticl_barrel variant
                      29634.759,   # HLT phase-2 timing menu, with NANO:@Phase2HLT
                      29634.77,    # HLT phase-2 NGT Scouting menu

--- a/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPMkFit_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPMkFit_cfi.py
@@ -17,5 +17,16 @@ def _addProcesshltInitialStepMkFitConfig(process):
         minPt = cms.double(0.8)
     )
 
+def _addProcesshltLSTStepMkFitConfig(process):
+    process.hltInitialStepTrackCandidatesMkFitConfig = cms.ESProducer("MkFitIterationConfigESProducer",
+        ComponentName = cms.string('hltInitialStepTrackCandidatesMkFitConfig'),
+        appendToDataLabel = cms.string(''),
+        config = cms.FileInPath('RecoTracker/MkFit/data/mkfit-phase2-lstStep.json'),
+        maxClusterSize = cms.uint32(8),
+        minPt = cms.double(0.9)
+    )
+
 from Configuration.ProcessModifiers.hltTrackingMkFitInitialStep_cff import hltTrackingMkFitInitialStep
-modifyConfigurationForTrackingMkFithltInitialStepMkFitConfig_ = hltTrackingMkFitInitialStep.makeProcessModifier(_addProcesshltInitialStepMkFitConfig)
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+modifyConfigurationForTrackingMkFithltInitialStepMkFitConfig_ = (~seedingLST & hltTrackingMkFitInitialStep).makeProcessModifier(_addProcesshltInitialStepMkFitConfig)
+modifyConfigurationForTrackingMkFithltLSTStepMkFitConfig_ = (seedingLST & hltTrackingMkFitInitialStep).makeProcessModifier(_addProcesshltLSTStepMkFitConfig)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidates_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidates_cfi.py
@@ -72,8 +72,12 @@ _hltInitialStepTrackCandidatesMkFit = cms.EDProducer('MkFitOutputConverter',
     ttrhBuilder = cms.ESInputTag("","WithTrackAngle")
 )
 
-_hltInitialStepTrackCandidatesMkFitLSTSeeds = _hltInitialStepTrackCandidatesMkFit.clone(seeds = "hltInitialStepTrajectorySeedsLST")
-                                                     
+_hltInitialStepTrackCandidatesMkFitLSTSeeds = _hltInitialStepTrackCandidatesMkFit.clone(
+    seeds = "hltInitialStepTrajectorySeedsLST",
+    candMinNHitsCut = 4,
+    candMinPtCut = 0.9
+)
+
 from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 from Configuration.ProcessModifiers.seedingLST_cff import seedingLST


### PR DESCRIPTION
### PR description:

As per title, for upcoming update of the HLT phase-2 tracking baseline, building on:
- CA extension to OT + LST for track seeding;
- mkFit for track building.

For more details, this follows previous work and discussions; see [presentation](https://indico.cern.ch/event/1587306/#7-update-on-lst-and-mkfit-for) by @bdanzi.

### PR validation:
See [presentation](https://indico.cern.ch/event/1587306/#7-update-on-lst-and-mkfit-for).
Re-validated in 160X, obtaining analogous results (see recap below).

Can be tested with workflow 29634.7571, introduced in #49231.

NOTE: it requires https://github.com/cms-data/RecoTracker-MkFit/pull/19

Recap of physics performance:
<img width="769" height="432" alt="Screenshot 2025-11-13 at 13 51 28" src="https://github.com/user-attachments/assets/dd87ed96-207f-476c-9cfe-c866b5fd69fa" />
Blue: current baseline, with two iterations using patatrack IT-only ntuples (>=4 hits) + legacy triplets as seeds, respectively;
Red: previous baseline, with two iterations using legacy quadruplets + legacy triplets as seeds, respectively - procModifiers=[phase2LegacyPixelTracks];
Black: future baseline, with a single iteration using seeds resulting from CA OT-extension + LST, and mkFit for track building - procModifiers=[phase2CAExtension,singleIterPatatrack,trackingLST,seedingLST,trackingMkFitCommon,hltTrackingMkFitInitialStep];
Orange: for comparison, single iteration using seeds resulting from CA OT-extension + LST, and CKF for track building - procModifiers=[phase2CAExtension,singleIterPatatrack,trackingLST,seedingLST].

Focusing on physics performance for the best single-iteration approach (in black, using mkFit):
- Efficiency is comparable to current baseline, with mild inefficiency at 2 < |η| < 3 (see [presentation](https://indico.cern.ch/event/1587306/#7-update-on-lst-and-mkfit-for) for more details);
- Fake+duplicate rate is significantly reduced.
- Using mkFit for track building instead of CKF allows to improve both efficiency and fake+duplicate rate, as well as timing.

For timing of (pixel) tracking, i.e., summing all (pixel) tracking modules from usual circles, from single-thread measurements - using GPUs:
- Current baseline = X (X~2 s)
- Previous baseline = ~1.3X
- Single iteration (CA extension+LST seeds) with mkFit (future baseline) = ~0.25X
- Single iteration (CA extension+LST seeds) with CKF = ~0.35X 
  (--> speed-up of full tracking by ~1.4X when mkFit is used for track building wrt. CKF).

For timing of (pixel) tracking, i.e., summing all (pixel) tracking modules from usual circles, from single-thread measurements - using CPU-only, for completeness:
- Current baseline = X (X~2.7 s)
- Previous baseline = ~1.075X
- Single iteration (CA extension+LST seeds) with mkFit (future baseline) = ~0.99X (fastest option also for CPU-only)
- Single iteration (CA extension+LST seeds) with CKF = ~1.09X

