### PR TITLE
Move dqmoffline_step from EndPath to Path

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1524,7 +1524,11 @@ class ConfigBuilder(object):
         self.schedule.append(self.process.generation_step)
 
         #register to the genstepfilter the name of the path (static right now, but might evolve)
-        self.executeAndRemember('process.genstepfilter.triggerConditions=cms.vstring("generation_step")')
+        self.executeAndRemember(
+'''process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+process.genstepfilter.usePathStatus = True
+process.genstepfilter.hltResults = ""
+''')
 
         if 'reGEN' in self.stepMap or stepSpec == 'pgen_smear':
             #stop here

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -2174,7 +2174,7 @@ class ConfigBuilder(object):
             if 'HLT' in self.stepMap.keys() or self._options.hltProcess:
                 self.renameHLTprocessInSequence(_sequence)
 
-            setattr(self.process,pathName, cms.EndPath( getattr(self.process,_sequence ) ) )
+            setattr(self.process,pathName, cms.Path( getattr(self.process,_sequence ) ) )
             self.schedule.append(getattr(self.process,pathName))
 
             if hasattr(self.process,"genstepfilter") and len(self.process.genstepfilter.triggerConditions):


### PR DESCRIPTION
#### PR description:

As discussed in https://github.com/cms-sw/cmssw/issues/49377 , in scouting DQM we need to apply a filter to skip scouting DQM in events without scouting objects.
This is currently not possible because EDFilter are ignored in `EndPath` and `dqmoffline_step` is an `EndPath`.
From https://github.com/cms-sw/cmssw/issues/49377 it looks like there is no reason to use  `EndPath` for DQM, so this PR move the `dqmoffline_step` from EndPath to Path

#### PR validation:

```
cmsDriver.py step3 --conditions auto:run3_data_prompt_relval -s RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@standardDQM+@miniAODDQM+@nanoAODDQM --datatier RECO,MINIAOD,NANOAOD,DQMIO --eventcontent RECO,MINIAOD,NANOEDMAOD,DQM --data --process reRECO --scenario pp --era Run3_2025 --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run3 --hltProcess reHLT --maxmem_profile --customise Validation/Performance/TimeMemoryJobReport.customiseWithTimeMemoryJobReport --maxmem_profile -n 10 --filein file:step2.root --fileout file:step3.root --suffix '-j JobReport3.xml ' 
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

I'd say no backport