### PR TITLE
[L1T] rearrange ordering of EMTF setup member functions

### DIFF
--- a/L1Trigger/L1TMuonEndCap/interface/EMTFSetup.h
+++ b/L1Trigger/L1TMuonEndCap/interface/EMTFSetup.h
@@ -64,6 +64,10 @@ private:
 
   SectorProcessorLUT sector_processor_lut_;
 
+  // Declare before pt_assign_engine_dxy_ to avoid library deletion
+  hls4mlEmulator::ModelLoader loader;
+  std::shared_ptr<hls4mlEmulator::Model> model;
+
   // Polymorphic class
   std::unique_ptr<PtAssignmentEngine> pt_assign_engine_;
   // Displaced muon pT assignment
@@ -73,9 +77,6 @@ private:
   unsigned fw_ver_;
   unsigned pt_lut_ver_;
   unsigned pc_lut_ver_;
-
-  hls4mlEmulator::ModelLoader loader;
-  std::shared_ptr<hls4mlEmulator::Model> model;
 };
 
 #endif

--- a/L1Trigger/L1TMuonEndCap/src/EMTFSetup.cc
+++ b/L1Trigger/L1TMuonEndCap/src/EMTFSetup.cc
@@ -13,12 +13,12 @@ EMTFSetup::EMTFSetup(const edm::ParameterSet& iConfig, edm::ConsumesCollector iC
       condition_helper_(iCollector),
       version_control_(iConfig),
       sector_processor_lut_(),
+      loader(version_control_.nnModelDxy()),
       pt_assign_engine_(nullptr),
       pt_assign_engine_dxy_(nullptr),
       fw_ver_(0),
       pt_lut_ver_(0),
-      pc_lut_ver_(0),
-      loader(version_control_.nnModelDxy()) {
+      pc_lut_ver_(0) {
   // Set pt assignment engine according to Era
   if (era() == "Run2_2016") {
     pt_assign_engine_ = std::make_unique<PtAssignmentEngine2016>();


### PR DESCRIPTION
#### PR description:

Implementing suggestion from https://github.com/cms-sw/cmssw/issues/49351

#### PR validation:

Compiled using code-checks and code-format, ran local cmsDriver tests.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.
