### PR TITLE
[15_1_X][HCAL-DQM] Additional plots: mask channels in HEP07 (RM 3, RMfib 4) affected by sporadic bad data 

### DIFF
--- a/DQM/HcalTasks/plugins/RawTask.cc
+++ b/DQM/HcalTasks/plugins/RawTask.cc
@@ -240,7 +240,7 @@ RawTask::RawTask(edm::ParameterSet const& ps)
       _cBadQ_FEDvsLSmod10.setBinContent(eid, _currentLS % 10, 0);
     }
   }
-  int nn = 0;
+  
   //	loop thru and fill the detIds with bad quality
   //	NOTE: Calibration Channels are skipped!
   //	TODO: Include for Online Calibration Channels marked as bad
@@ -266,10 +266,11 @@ RawTask::RawTask(edm::ParameterSet const& ps)
     Nbadqevt = true;
   }
   if (lumiCache->EvtCntLS == 1)
-    _NBadQEvent = 0;  // Reset at the beginning of each new LS
+      _NBadQEvent = 0;  // Reset at the beginning of each new LS
   if (Nbadqevt)
-    _NBadQEvent++;
-
+      _NBadQEvent++;
+  
+  int nn = 0;
   for (std::vector<DetId>::const_iterator it = creport->bad_quality_begin(); it != creport->bad_quality_end(); ++it) {
     //	skip non HCAL det ids
     if (!HcalGenericDetId(*it).isHcalDetId())
@@ -282,15 +283,18 @@ RawTask::RawTask(edm::ParameterSet const& ps)
       if (cs.isBitSet(HcalChannelStatus::HcalCellMask) || cs.isBitSet(HcalChannelStatus::HcalCellDead))
         continue;
     }
-
-    nn++;
+    // Masked HEP07 sporadic bad data https://gitlab.cern.ch/cmshcal/docs/-/issues/242
     HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(*it));
+    if (eid.crateId() == 21 && eid.slot() == 11 && eid.fiberIndex() == 19)
+    	continue;
+    nn++;
+    //HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(*it));
     _cBadQuality_depth.fill(HcalDetId(*it));
     //	ONLINE ONLY!
     if (_ptype == fOnline)
       //Number of BadQualityDigis
       _xBadQLS.get(eid)++;
-    //std::cout << " event _xBadQLS "<<  double(_xBadQLS.get(eid)) << std::endl;
+    
     if (_ptype != fOffline) {  // hidefed2crate
       if (!eid.isVMEid()) {
         if (_filter_FEDsuTCA.filter(eid))


### PR DESCRIPTION
#### PR description:

-This PR extends the masking of channels in HEP07 (RM 3, RMfib 4) that are affected by sporadic bad data.
-Previously, only the BadQ_FEDvsLSmod10 plot was updated. With this PR, the masking is consistently applied across the following plots: BadQ_FEDvsLS, BadQ_FEDvsLSmod10, BadQuality, BadQualityvsBX, and BadQualityvsLS.
-The modification is implemented in RawTask.cc.
-This PR is related with the PR [49220](https://github.com/cms-sw/cmssw/pull/49220).

Additional information: See related issue: [HCAL DQM Issue #242](https://gitlab.cern.ch/cmshcal/docs/-/issues/242)

#### PR validation:
-This PR is a backport.
