### PR TITLE
Monitoring of Pixel tracking SoAs: partial revert of #49340 and #49237

### DIFF
--- a/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
@@ -93,8 +93,8 @@ process.siPixelTrackComparisonHarvesterAlpaka.topFolderName = cms.string('SiPixe
 #-------------------------------------
 #  User switches for what to monitor
 #-------------------------------------
-doRecHits = False
-doTracks = False
+doRecHits  = False
+doTracks   = True
 doVertices = True
 
 #-------------------------------------

--- a/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
@@ -91,6 +91,13 @@ process.load('DQM.SiPixelHeterogeneous.SiPixelHeterogenousDQMHarvesting_cff')
 process.siPixelTrackComparisonHarvesterAlpaka.topFolderName = cms.string('SiPixelHeterogeneous/PixelTrackCompareGPUvsCPU')
 
 #-------------------------------------
+#  User switches for what to monitor
+#-------------------------------------
+doRecHits = False
+doTracks = False
+doVertices = True
+
+#-------------------------------------
 #	Some Settings before Finishing up
 #-------------------------------------
 if process.runType.getRunType() == process.runType.hi_run:
@@ -180,11 +187,50 @@ process.dump = cms.EDAnalyzer("EventContentAnalyzer")
 process.dumpPath = cms.Path(process.dump)
 
 #-------------------------------------
+#  Build the monitoring sequence based on flags
+#-------------------------------------
+monitoring_modules = []
+
+# Mandatory pixel digi error modules
+monitoring_modules.append(process.siPixelPhase1MonitorRawDataASerial)
+monitoring_modules.append(process.siPixelPhase1MonitorRawDataADevice)
+monitoring_modules.append(process.siPixelPhase1CompareDigiErrorsSoAAlpaka)
+
+if doRecHits:
+    monitoring_modules.append(process.siPixelRecHitsSoAMonitorDevice)
+    monitoring_modules.append(process.siPixelRecHitsSoAMonitorSerial)
+    monitoring_modules.append(process.siPixelPhase1CompareRecHits)
+
+if doTracks:
+    monitoring_modules.append(process.siPixelTrackSoAMonitorDevice)
+    monitoring_modules.append(process.siPixelTrackSoAMonitorSerial)
+    monitoring_modules.append(process.siPixelPhase1CompareTracks)
+
+if doVertices:
+    monitoring_modules.append(process.siPixelVertexSoAMonitorDevice)
+    monitoring_modules.append(process.siPixelVertexSoAMonitorSerial)
+    monitoring_modules.append(process.siPixelCompareVertices)
+
+# Always add the comparison harvesting sequence as before
+monitoring_modules.append(process.siPixelPhase1RawDataHarvesterSerial)
+monitoring_modules.append(process.siPixelPhase1RawDataHarvesterDevice)
+
+if doTracks:
+    monitoring_modules.append(process.siPixelTrackComparisonHarvesterAlpaka)
+
+# Now create the path with those modules
+process.tasksPath = cms.Path()
+for mod in monitoring_modules:
+    process.tasksPath *= mod
+
+print(process.tasksPath)
+    
+#-------------------------------------
 #	Pixel DQM Tasks/Clients Sequences Definition
 #-------------------------------------
 
-process.tasksPath = cms.Path(process.monitorpixelSoACompareSourceAlpaka *
-                             process.siPixelHeterogeneousDQMComparisonHarvestingAlpaka)
+#process.tasksPath = cms.Path(process.monitorpixelSoACompareSourceAlpaka *
+#                             process.siPixelHeterogeneousDQMComparisonHarvestingAlpaka)
 
 #-------------------------------------
 #	Paths/Sequences Definitions

--- a/DQM/SiPixelHeterogeneous/python/SiPixelHeterogenousDQMHarvesting_cff.py
+++ b/DQM/SiPixelHeterogeneous/python/SiPixelHeterogenousDQMHarvesting_cff.py
@@ -28,7 +28,6 @@ _siPixelHeterogeneousDQMComparisonHarvestingAlpakaPhase2 = cms.Sequence(siPixelT
 
 phase2_tracker.toReplaceWith(siPixelHeterogeneousDQMComparisonHarvestingAlpaka,_siPixelHeterogeneousDQMComparisonHarvestingAlpakaPhase2)
 
-
 # add the harvester in case of the validation modifier is active
 from Configuration.ProcessModifiers.gpuValidationPixel_cff import gpuValidationPixel
 gpuValidationPixel.toReplaceWith(siPixelHeterogeneousDQMHarvesting,siPixelHeterogeneousDQMComparisonHarvesting)

--- a/DQMOffline/Trigger/python/HeterogeneousMonitoringClient_cff.py
+++ b/DQMOffline/Trigger/python/HeterogeneousMonitoringClient_cff.py
@@ -4,4 +4,6 @@ import FWCore.ParameterSet.Config as cms
 from DQM.SiPixelHeterogeneous.siPixelTrackComparisonHarvester_cfi import *
 hltSiPixelTrackComparisonHarvester = siPixelTrackComparisonHarvester.clone(topFolderName = 'HLT/HeterogeneousComparisons/PixelTracks')
 
-HLTHeterogeneousMonitoringHarvesting =  cms.Sequence(hltSiPixelTrackComparisonHarvester)
+HLTHeterogeneousMonitoringHarvesting =  cms.Sequence(
+    hltSiPixelTrackComparisonHarvester
+)

--- a/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
@@ -97,7 +97,7 @@ hltHcalGPUComparisonTask = hcalGPUComparisonTask.clone(
 HLTHeterogeneousMonitoringSequence = cms.Sequence(
     hltPfHcalGPUComparisonTask +
     hltSiPixelPhase1CompareDigiErrors +
-    hltSiPixelPhase1CompareRecHits +
+    #hltSiPixelPhase1CompareRecHits +   # waiting a resolution of #49349
     hltSiPixelPhase1CompareTracks +
     hltSiPixelCompareVertices +
     hltEcalMonitorTask +


### PR DESCRIPTION
#### PR description:

Due to the issues explained in https://github.com/cms-sw/cmssw/issues/49349, in preparation of a partial revert of the HLT menu change at [CMSHLT-3147](https://its.cern.ch/jira/browse/CMSHLT-3147) via the ticket [CMSHLT-3691](https://its.cern.ch/jira/browse/CMSHLT-3691), I open this PR that partially reverts #49340 and #49237 by:
-  making the sequences run in the pixelgpu dqm client configurable (and running only the tracking and vertexing comparisons, **without the rechits comparisons**) at commit 697b291ad8ef97dbd949e2f50636683853ab45c1
- rolling back the monitoring of pixel RecHits SoA-s in the offline relval Heterogeneous monitoring introduced at #49340.

#### PR validation:

Tested successfully:
- `scram b runtests_TestDQMOnlineClient-pixelgpu_dqm_sourceclient`
- `runTheMatrix.py --what gpu -l 17034.402 -t 4 -j 8 --ibeos`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, might get backported to `CMSSW_15_1_X`