### PR TITLE
Fix FastSim refinement for CHS

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -664,7 +664,6 @@ workflows[135.9] = ['ZMMFS_13',['ZMMFS_13','HARVESTUP15FS','MINIAODMCUP15FS','NA
 workflows[135.11] = ['SMS-T1tttt_mGl-1500_mLSP-100FS_13', ['SMS-T1tttt_mGl-1500_mLSP-100FS_13','HARVESTUP15FS','MINIAODMCUP15FS','NANOUP15FS']]
 workflows[135.12] = ['QCD_Pt_80_120FS_13', ['QCD_Pt_80_120FS_13','HARVESTUP15FS','MINIAODMCUP15FS','NANOUP15FS']]
 workflows[135.13] = ['TTbarFS_13', ['TTbarFS_13_trackingOnlyValidation','HARVESTUP15FS_trackingOnly']]
-workflows[135.14] = ['TTbarFS_13', ['TTbarFS_13','HARVESTUP15FS','MINIAODMCUP15FS','NANOUP15FSrefine']]
 
 ### MinBias fastsim_13 TeV for mixing ###
 workflows[135.8] = ['MinBiasFS_13',['MinBiasFS_13_ForMixing']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4708,7 +4708,6 @@ steps['NANOUP15FS'] = merge([{'--filein':'file:step3.root','--fast':''}, steps['
 steps['NANOUP17FS'] = merge([{'--filein':'file:step3.root','--fast':'','--era':'Run2_2017_FastSim'}, steps['NANOUP17']])
 steps['NANOUP18FS'] = merge([{'--filein':'file:step3.root','--fast':'','--era':'Run2_2018_FastSim'}, steps['NANOUP18']])
 
-steps['NANOUP15FSrefine'] = merge([{'--customise':'PhysicsTools/NanoAOD/jetsAK4_CHS_cff.nanoAOD_refineFastSim_bTagDeepFlav'}, steps['NANOUP15FS']])
 
 steps['HEfail'] = {'--conditions':'auto:phase1_2018_realistic_HEfail',
                    '-n':'10',

--- a/PhysicsTools/NanoAOD/python/jetsAK4_CHS_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_CHS_cff.py
@@ -396,7 +396,11 @@ nanoAOD_addDeepInfoAK4CHS_switch = cms.PSet(
 # ML-based FastSim refinement
 #
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-def nanoAOD_refineFastSim_bTagDeepFlav(process):
+def nanoAOD_refineFastSim_bTagDeepFlav(process, addDeepFlavour):
+
+    # for CHS, only DeepFlav refinement is implemented
+    if not addDeepFlavour:
+        return process
 
     fastSim.toModify( process.jetTable.variables,
       btagDeepFlavBunrefined = process.jetTable.variables.btagDeepFlavB.clone(),

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -313,7 +313,7 @@ def nanoAOD_customizeCommon(process):
     process = addTimeLifeInfoBase(process)
     
     process = nanoAOD_refineFastSim_puppiJet(process)
-    process = nanoAOD_refineFastSim_bTagDeepFlav(process)
+    process = nanoAOD_refineFastSim_bTagDeepFlav(process, nanoAOD_addDeepInfoAK4CHS_switch.nanoAOD_addDeepFlavourTag_switch)
 
     return process
 


### PR DESCRIPTION
#### PR description:

Addresses #49390 after changes from #48587:
1. protect the application of CHS refinement for DeepFlavour variables using existing nanoAOD switch, to avoid accessing nonexistent properties.
2. remove test workflow 135.14: now that refinement is the default for FastSim, a test workflow using a customize function is no longer necessary or desired.

#### PR validation:

Ran affected workflows successfully.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport. Should be backported along with #48587 to NANOv15 production releases.
