### PR TITLE
Fix ibeos calls

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixUtil.py
+++ b/Configuration/PyReleaseValidation/python/MatrixUtil.py
@@ -141,7 +141,7 @@ class InputInfo(object):
         if not self.skimEvents: ## keep run-lumi sorting
             from os import getenv
             if getenv("CMSSW_USE_IBEOS","false")=="true":
-                return "export CMSSW_USE_IBEOS=true; " + command + " | ibeos-lfn-sort"
+                return "export CMSSW_USE_IBEOS=true; " + command
             return command + " | sort -u"
         else:
             return command

--- a/Utilities/General/scripts/ibeos-lfn-sort
+++ b/Utilities/General/scripts/ibeos-lfn-sort
@@ -53,6 +53,6 @@ else
   done
 fi
 if [ -z "$CMSSW_LIMIT_RESULTS" ]; then
-  CMSSW_LIMIT_RESULTS=20
+  CMSSW_LIMIT_RESULTS=-0
 fi
 echo $(echo $IBEOS_FILES | tr ' ' '\n' | sort -u) $(echo $NON_IBEOS_FILES | tr ' ' '\n' | sort -u) | tr ' ' '\n' | grep '/store' | head -n $CMSSW_LIMIT_RESULTS

--- a/Utilities/General/scripts/ibeos-lfn-sort
+++ b/Utilities/General/scripts/ibeos-lfn-sort
@@ -12,6 +12,7 @@ if [ "$CMSSW_USE_IBEOS" != "true" ]; then
   exit 1
 fi
 
+IBEOS_PFN="root://eoscms.cern.ch//store/user/cmsbuild"
 IBEOS_FILES=""
 NON_IBEOS_FILES=""
 # try to download cache
@@ -32,10 +33,14 @@ if [ -f ${IBEOS_CACHE} ] ; then
     case $LFN in
       /store/* )
         if [ $(grep "^${LFN}$" ${IBEOS_CACHE} | wc -l) -gt 0 ] ; then
-          IBEOS_FILES="$IBEOS_FILES root://eoscms.cern.ch//store/user/cmsbuild${LFN}"
+          IBEOS_FILES="$IBEOS_FILES ${IBEOS_PFN}${LFN}"
         else
           NON_IBEOS_FILES="$NON_IBEOS_FILES $LFN"
         fi
+        ;;
+      ${IBEOS_PFN}* )
+        # line from a repeated call: just keep the previous result
+        IBEOS_FILES="$IBEOS_FILES ${LFN}"
         ;;
     esac
   done


### PR DESCRIPTION
#### PR description:

Addresses #49331:
1. Remove now-extraneous (after #48432) `ibeos-lfn-sort` call from MatrixUtils
2. Modify `ibeos-lfn-sort` to handle repeated calls
3. Change default behavior to print all results (only print limited results when called by `cmsDriver.py`)

#### PR validation:

Both commands in https://github.com/cms-sw/cmssw/issues/49331#issuecomment-3501718034 now return identical output.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport. #48432 entered 15_1, so it is probably worth backporting this to that release.