### PR TITLE
Fix recursive calls to ibeos-lfn-sort

### DIFF
--- a/Utilities/General/scripts/ibeos-lfn-sort
+++ b/Utilities/General/scripts/ibeos-lfn-sort
@@ -34,7 +34,7 @@ if [ -f ${IBEOS_CACHE} ] ; then
           IBEOS_FILES="$IBEOS_FILES $LFN"
           ;;
       /store/* )
-        if [ $(grep "${LFN}" ${IBEOS_CACHE} | wc -l) -gt 0 ] ; then
+        if [ $(grep "^${LFN}$" ${IBEOS_CACHE} | wc -l) -gt 0 ] ; then
           IBEOS_FILES="$IBEOS_FILES root://eoscms.cern.ch//store/user/cmsbuild${LFN}"
         else
           NON_IBEOS_FILES="$NON_IBEOS_FILES $LFN"

--- a/Utilities/General/scripts/ibeos-lfn-sort
+++ b/Utilities/General/scripts/ibeos-lfn-sort
@@ -30,8 +30,11 @@ fi
 if [ -f ${IBEOS_CACHE} ] ; then
   while read LFN ; do
     case $LFN in
+      root://eoscms.cern.ch//store/user/cmsbuild/store/* )
+          IBEOS_FILES="$IBEOS_FILES $LFN"
+          ;;
       /store/* )
-        if [ $(grep "^${LFN}$" ${IBEOS_CACHE} | wc -l) -gt 0 ] ; then
+        if [ $(grep "${LFN}" ${IBEOS_CACHE} | wc -l) -gt 0 ] ; then
           IBEOS_FILES="$IBEOS_FILES root://eoscms.cern.ch//store/user/cmsbuild${LFN}"
         else
           NON_IBEOS_FILES="$NON_IBEOS_FILES $LFN"


### PR DESCRIPTION
This should fix the issue with ibeos-lfn-sort when called recursively. With this change following commands now return the correct results

```
> export CMSSW_USE_IBEOS=true
>  dasgoclient --limit 0 --query 'file dataset=/Cosmics/Run2011A-v1/RAW run=160960 site=T2_CH_CERN' | head -2
root://eoscms.cern.ch//store/user/cmsbuild/store/data/Run2011A/Cosmics/RAW/v1/000/160/960/049F6443-8E53-E011-A943-003048F117EA.root
/store/data/Run2011A/Cosmics/RAW/v1/000/160/960/062C43C2-8353-E011-BC2B-001617C3B76E.root
>  dasgoclient --limit 0 --query 'file dataset=/Cosmics/Run2011A-v1/RAW run=160960 site=T2_CH_CERN' | ibeos-lfn-sort | head -2
root://eoscms.cern.ch//store/user/cmsbuild/store/data/Run2011A/Cosmics/RAW/v1/000/160/960/049F6443-8E53-E011-A943-003048F117EA.root
/store/data/Run2011A/Cosmics/RAW/v1/000/160/960/062C43C2-8353-E011-BC2B-001617C3B76E.root
[muzaffar@cmsdev40 src]$ git diff
```

FYI @kpedro88 