### PR TITLE
[NGT] Rearrange Nano Phase2 HLT flavours

### DIFF
--- a/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
+++ b/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
@@ -27,7 +27,12 @@ from HLTrigger.NGTScouting.hltLayerClusters_cfi import *
 from HLTrigger.NGTScouting.hltSums_cfi import *
 from HLTrigger.NGTScouting.hltTriggerAcceptFilter_cfi import hltTriggerAcceptFilter,dstTriggerAcceptFilter
 
-NanoGenTable = cms.Sequence(
+######################################
+# Tables 
+######################################
+
+# Produce and store gen particles and gen jets
+NanoGenTables = cms.Sequence(
     prunedGenParticlesWithStatusOne
     + prunedGenParticles
     + finalGenParticles
@@ -43,13 +48,12 @@ NanoGenTable = cms.Sequence(
     + genJetFlavourTable
 )
 
-hltNanoProducer = cms.Sequence(
-    NanoGenTable
-    #+ hltTriggerAcceptFilter
-    + hltVertexTable
-    + hltPixelTrackTable
+# Store hlt objects for NGT scouting
+NanoHltTables = cms.Sequence(
+    hltVertexTable
     + hltPixelVertexTable
     + hltGeneralTrackTable
+    + hltGeneralTrackExtTable
     + hltEgammaPacker
     + hltPhotonTable
     + hltElectronTable
@@ -57,44 +61,72 @@ hltNanoProducer = cms.Sequence(
     + hltMuonTable
     + hltPFCandidateTable
     + hltJetTable
-    + hltTrackstersTableSequence
-    + hltTiclCandidateTable
-    + hltTiclCandidateExtraTable
-    + hltTiclSuperClustersTable
     + hltTauTable
     + hltTauExtTable
     + METTable
     + HTTable
 )
 
-dstNanoProducer = cms.Sequence(
-    NanoGenTable
+# Store HGCal lower-level objects
+NanoHGCalTables = cms.Sequence(
+    hltTrackstersTableSequence
+    + hltTiclCandidateTable
+    + hltTiclCandidateExtraTable
+    + hltTiclSuperClustersTable
+)
+
+# Store PixelTracks objects
+NanoPixelTables = cms.Sequence(
+    hltPixelTrackTable
+    + hltPixelTrackExtTable
+)
+
+# Store variables and associators for validation purposes
+NanoValTables = cms.Sequence(
+    hltTiclAssociationsTableSequence
+    + hltSimTracksterSequence
+    + hltSimTiclCandidateTable
+    + hltSimTiclCandidateExtraTable
+    + hltLayerClustersTableSequence
+)
+
+######################################
+# Sequences for Nano flavours
+######################################
+
+# NGT Scouting Nano flavour (NANO:@NGTScouting)
+dstNanoFlavour = cms.Sequence(
+    dstTriggerAcceptFilter
+    + NanoHltTables
+)
+
+# NGT Scouting Nano flavour with MC/HGCal info (NANO:@NGTScoutingVal)
+dstValidationNanoFlavour = cms.Sequence(
+    NanoGenTables
     + dstTriggerAcceptFilter
-    + hltVertexTable
-    + hltPixelTrackTable
-    + hltPixelVertexTable
-    + hltGeneralTrackTable
-    + hltEgammaPacker
-    + hltPhotonTable
-    + hltElectronTable
-    + hltPhase2L3MuonIdTracks
-    + hltMuonTable
-    + hltPFCandidateTable
-    + hltJetTable
-    + hltTauTable
-    + hltTrackstersTableSequence
-    + hltTiclCandidateTable
-    + hltTiclCandidateExtraTable
-    + hltTiclSuperClustersTable
-    + hltTauExtTable
-    + METTable
-    + HTTable
+    + NanoHltTables
+    + NanoPixelTables
+    + NanoHGCalTables
+    + NanoValTables
 )
 
-trackingExtraNanoProducer = cms.Sequence(
-    hltPixelTrackExtTable+
-    hltGeneralTrackExtTable
+# Phase-2 HLT Nano flavour (NANO:@Phase2HLT)
+hltNanoFlavour = cms.Sequence(
+    NanoHltTables
 )
+
+# Phase-2 HLT Nano flavour with MC/HGCal info (NANO:@Phase2HLTVal)
+hltValidationNanoFlavour = cms.Sequence(
+    NanoGenTables
+    + NanoHltTables
+    + NanoPixelTables
+    + NanoHGCalTables
+    + NanoValTables
+)
+
+######################################
+# Customization
+######################################
 
 def hltNanoCustomize(process):
 
@@ -110,17 +142,5 @@ def hltNanoCustomize(process):
                 [p for p in process.paths if p.startswith('HLT_') or p.startswith('MC_') or p.startswith('DST_')]
             )
         )
-
-    return process
-
-def hltNanoValCustomize(process):
-    if hasattr(process, "dstNanoProducer"):
-
-        process.dstNanoProducer += (process.hltTiclAssociationsTableSequence +
-                                    process.hltSimTracksterSequence +
-                                    process.hltSimTiclCandidateTable +
-                                    process.hltSimTiclCandidateExtraTable +
-                                    process.hltLayerClustersTableSequence  +
-                                    process.trackingExtraNanoProducer)
 
     return process

--- a/PhysicsTools/NanoAOD/python/autoNANO.py
+++ b/PhysicsTools/NanoAOD/python/autoNANO.py
@@ -74,15 +74,16 @@ autoNANO = {
               'customize': 'DPGAnalysis/MuonTools/muNtupleProducer_cff.muDPGNanoCustomize'},
     'MUDPGBKG': {'sequence': 'DPGAnalysis/MuonTools/muNtupleProducerBkg_cff.muDPGNanoProducerBkg',
                  'customize': 'DPGAnalysis/MuonTools/muNtupleProducerBkg_cff.muDPGNanoBkgCustomize'},
-    # HLT Nano
-    'Phase2HLT' : {'sequence': 'HLTrigger/NGTScouting/HLTNanoProducer_cff.hltNanoProducer',
-             'customize': 'HLTrigger/NGTScouting/HLTNanoProducer_cff.hltNanoCustomize'},
-
+    # HLT Phase-2 Nano
+    'Phase2HLT' : {'sequence': 'HLTrigger/NGTScouting/HLTNanoProducer_cff.hltNanoFlavour',
+                   'customize': 'HLTrigger/NGTScouting/HLTNanoProducer_cff.hltNanoCustomize'},
+    'Phase2HLTVal' : {'sequence': 'HLTrigger/NGTScouting/HLTNanoProducer_cff.hltValidationNanoFlavour',
+                      'customize': 'HLTrigger/NGTScouting/HLTNanoProducer_cff.hltNanoCustomize'},
     # NGT scouting Nano
-    'NGTScouting' : {'sequence': 'HLTrigger/NGTScouting/HLTNanoProducer_cff.dstNanoProducer',
+    'NGTScouting' : {'sequence': 'HLTrigger/NGTScouting/HLTNanoProducer_cff.dstNanoFlavour',
                      'customize': 'HLTrigger/NGTScouting/HLTNanoProducer_cff.hltNanoCustomize'},
-    'NGTScoutingVal' : {'sequence': '@NGTScouting',
-                        'customize': ','.join(['HLTrigger/NGTScouting/HLTNanoProducer_cff.hltNanoCustomize', 'HLTrigger/NGTScouting/HLTNanoProducer_cff.hltNanoValCustomize'])},
+    'NGTScoutingVal' : {'sequence': 'HLTrigger/NGTScouting/HLTNanoProducer_cff.dstValidationNanoFlavour',
+                        'customize': 'HLTrigger/NGTScouting/HLTNanoProducer_cff.hltNanoCustomize'},
     # Muon High Level Trigger
     'MUHLT' : {'sequence': 'DPGAnalysis/MuonTools/muNtupleProducerHlt_cff.hltMuNanoProducer',
                'customize': 'DPGAnalysis/MuonTools/muNtupleProducerHlt_cff.hltMuNanoCustomize'},


### PR DESCRIPTION
#### PR description:

This PR proposes a rearrangement of the NanoAOD flavours for NGT Scouting and Phase-2 HLT.

The NGT Scouting NanoAOD flavour introduced in #48091 has been subsequently modified in:
- #48500 to introduce the TICL-based objects and associators
- #48935 to include the track impact parameters w.r.t. the beam spot

This resulted in the definition of multiple NanoAOD flavours for Phase-2 HLT, potentially causing confusion in users and enhancing the complexity in the maintenance.

With this PR, the NanoAOD flavours are reduced to only two:
- the "default" NanoAOD flavour contains only the main objects reconstructed by the HLT, which defines a proxy for the future output format of the NGT Scouting stream;
- the "validation" NanoAOD flavour also stores all the generator-level information and additional lower-level objects from intermediate steps of the HLT reconstruction chain, such as different track collections or TICL objects and associators. This is the flavour that should be used for validating HLT objects against truth information.

##### Default flavour 
The "default" flavour can be plugged: 
- into the standard Phase-2 menu by `NANO:@Phase2HLT`
- into the NGT scouting menu by `NANO:@NGTScouting` 

Both flavours will contain the same collections. The only difference is the `dstTriggerAcceptFilter` for the NGT Scouting flavour, which selects only the event passing the logical `OR` of all the L1 seeds. 
The previous duplication between the `hltPixelTrackTable` and the `hltGeneralTrackTable` has been resolved by only storing general tracks.
The event size summary for 1k events of tt-bar 200 PU processed with `NANO:@NGTScouting` is available [here](https://evernazz.web.cern.ch/evernazz/NGT/NanoAOD/SizeAndContentReport/NGTScouting/SizeReport.html).

<img width="446" height="266" alt="Nano_NGTScouting" src="https://github.com/user-attachments/assets/b1f0c704-7230-494b-bff0-57f5d1f3f4cb" />

##### Validation flavour 
The "validation" flavour is specified by the `Val` suffix and can be plugged: 
- into the standard Phase-2 menu by `NANO:@Phase2HLTVal`
- into the NGT scouting menu by `NANO:@NGTScoutingVal` 

Both flavours will contain the same collections. Again, the only difference is the `dstTriggerAcceptFilter` for the NGT Scouting flavour, which selects only the event passing the logical `OR` of all the L1 seeds.
The event size summary for 1k events of tt-bar 200 PU processed with `NANO:@Phase2HLTVal`is available [here](https://evernazz.web.cern.ch/evernazz/NGT/NanoAOD/SizeAndContentReport/Phase2HLTVal/SizeReport.html).

<img width="554" height="266" alt="Phase2HLTVal" src="https://github.com/user-attachments/assets/47344267-3f21-4480-ad34-daa29ca14e0f" />

#### PR validation:

The "default" flavour has been tested by running:
-  for the standard Phase-2 menu by `NANO:@Phase2HLT`
```
cmsDriver.py step2 --processName=HLTX \
-s L1P2GT,HLT:@relvalRun4,NANO:@Phase2HLT \
--procModifier phase2CAExtension --conditions auto:phase2_realistic_T33 \
--datatier NANOAODSIM --eventcontent NANOAODSIM \
--geometry ExtendedRun4D110 --era Phase2C17I13M9 \
--filein file:step1.root -n -1 --fileout file:step2.root
```
-  for the standard Phase-2 menu by `NANO:@NGTScouting`
```
cmsDriver.py step2 --processName=HLTX \
-s L1P2GT,HLT:NGTScouting,NANO:@NGTScouting \
--procModifier phase2CAExtension --conditions auto:phase2_realistic_T33 \
--datatier NANOAODSIM --eventcontent NANOAODSIM \
--geometry ExtendedRun4D110 --era Phase2C17I13M9 \
--filein file:step1.root -n -1 --fileout file:step2.root
```

The "validation" flavour has been tested by running:
-  for the standard Phase-2 menu by `NANO:@Phase2HLTVal`
```
cmsDriver.py step2 --processName=HLTX \
-s L1P2GT,HLT:@relvalRun4,NANO:@Phase2HLTVal \
--procModifier phase2CAExtension --conditions auto:phase2_realistic_T33 \
--datatier NANOAODSIM --eventcontent NANOAODSIM \
--geometry ExtendedRun4D110 --era Phase2C17I13M9 \
--filein file:step1.root -n -1 --fileout file:step2.root
```
-  for the standard Phase-2 menu by `NANO:@NGTScoutingVal`
```
cmsDriver.py step2 --processName=HLTX \
-s L1P2GT,HLT:NGTScouting,NANO:@NGTScoutingVal \
--procModifier phase2CAExtension --conditions auto:phase2_realistic_T33 \
--datatier NANOAODSIM --eventcontent NANOAODSIM \
--geometry ExtendedRun4D110 --era Phase2C17I13M9 \
--filein file:step1.root -n -1 --fileout file:step2.root
```