### PR TITLE
ECAL - Get fill number and delivered lumi from LHCInfoPerFill

### DIFF
--- a/Calibration/EcalCalibAlgos/plugins/BuildFile.xml
+++ b/Calibration/EcalCalibAlgos/plugins/BuildFile.xml
@@ -3,8 +3,8 @@
 <use name="DataFormats/EcalRecHit"/>
 <use name="DataFormats/EcalDetId"/>
 <use name="CondFormats/EcalObjects"/>
-<use name="CondFormats/RunInfo"/>
 <use name="CondFormats/DataRecord"/>
+<use name="CondTools/RunInfo"/>
 <use name="Geometry/CaloGeometry"/>
 <use name="Calibration/Tools"/>
 <use name="PhysicsTools/NanoAOD"/>

--- a/Calibration/EcalCalibAlgos/python/EcalPhiSymRecHitProducers_cfi.py
+++ b/Calibration/EcalCalibAlgos/python/EcalPhiSymRecHitProducers_cfi.py
@@ -33,6 +33,7 @@ phisym_params = {
     "nMisCalib" : cms.int32(10), # <= 10; even; central value does not count
     "misCalibRangeEB" : cms.vdouble(0.95, 1.05),
     "misCalibRangeEE" : cms.vdouble(0.90, 1.10),
+    "useNewLHCInfo" : cms.bool(False),
 }
 
 EcalPhiSymRecHitProducerLumi = cms.EDProducer("EcalPhiSymRecHitProducerLumi")
@@ -42,3 +43,7 @@ for par, value in phisym_params.items():
 EcalPhiSymRecHitProducerRun = cms.EDProducer("EcalPhiSymRecHitProducerRun")
 for par, value in phisym_params.items():
     setattr(EcalPhiSymRecHitProducerRun, par, value)
+
+from Configuration.Eras.Modifier_run3_ecal_cff import run3_ecal
+run3_ecal.toModify(EcalPhiSymRecHitProducerLumi, useNewLHCInfo = True)
+run3_ecal.toModify(EcalPhiSymRecHitProducerRun, useNewLHCInfo = True)

--- a/CondTools/RunInfo/interface/LHCInfoCombined.h
+++ b/CondTools/RunInfo/interface/LHCInfoCombined.h
@@ -52,6 +52,8 @@ public:
   float betaStarX;
   float betaStarY;
   float energy;
+  float delivLumi;
+  float recLumi;
   unsigned short fillNumber;
 
   void print(std::ostream& os) const;

--- a/CondTools/RunInfo/src/LHCInfoCombined.cc
+++ b/CondTools/RunInfo/src/LHCInfoCombined.cc
@@ -30,6 +30,8 @@ void LHCInfoCombined::setFromLHCInfo(const LHCInfo& lhcInfo) {
   betaStarX = lhcInfo.betaStar();
   betaStarY = lhcInfo.betaStar();
   energy = lhcInfo.energy();
+  delivLumi = lhcInfo.delivLumi();
+  recLumi = lhcInfo.recLumi();
   fillNumber = lhcInfo.fillNumber();
 }
 void LHCInfoCombined::setFromPerLS(const LHCInfoPerLS& infoPerLS) {
@@ -40,6 +42,8 @@ void LHCInfoCombined::setFromPerLS(const LHCInfoPerLS& infoPerLS) {
 }
 void LHCInfoCombined::setFromPerFill(const LHCInfoPerFill& infoPerFill) {
   energy = infoPerFill.energy();
+  delivLumi = infoPerFill.delivLumi();
+  recLumi = infoPerFill.recLumi();
   fillNumber = infoPerFill.fillNumber();
 }
 
@@ -61,11 +65,14 @@ bool LHCInfoCombined::isCrossingAngleInvalid() {
 }
 
 void LHCInfoCombined::print(std::ostream& os) const {
-  os << "Crossing angle x (urad): " << crossingAngleX << std::endl
+  os << "Fill: " << fillNumber << std::endl
+     << "Crossing angle x (urad): " << crossingAngleX << std::endl
      << "Crossing angle y (urad): " << crossingAngleY << std::endl
      << "Beta star x (m): " << betaStarX << std::endl
      << "Beta star y (m): " << betaStarY << std::endl
-     << "Energy (GeV): " << energy << std::endl;
+     << "Energy (GeV): " << energy << std::endl
+     << "Delivered lumi (pb^-1): " << delivLumi << std::endl
+     << "Recorded lumi (pb^-1): " << recLumi << std::endl;
 }
 
 std::ostream& operator<<(std::ostream& os, LHCInfoCombined beamInfo) {


### PR DESCRIPTION
#### PR description:

Since the `LHCInfo` tag in the prompt GT is not updated after May 2024 get the fill number and delivered and recorded lumi information from `LHCInfoPerFill` instead for Run 3. This should fix the `fill`, `delivLumi`, and `recLumi` branches being set to 0  in the output ntuple for runs after May 2024.

Adds the `delivLumi` and `recLumi` fields to `LHCInfoCombined`.

#### PR validation:

With the PR the `fill`, `delivLumi`, and `recLumi` branches in the output ntuple are filled for 2025 runs.