### PR TITLE
Avoid ROOT auto parsing for PortableHostMultiCollection

### DIFF
--- a/DataFormats/TrackingRecHitSoA/src/classes_def.xml
+++ b/DataFormats/TrackingRecHitSoA/src/classes_def.xml
@@ -4,6 +4,9 @@
   <class name="reco::HitModulesLayout<128, false>"/>
 
   <class name="reco::HitPortableCollectionHost"/>
+  <!-- needed to avoid auto parsing by ROOT. Order in the file matters -->
+  <class name="reco::HitPortableCollectionHost::Implementation"/>
+
   <class name="reco::TrackingRecHitHost"  rntupleStreamerMode="true"/>
   <class name="edm::Wrapper<reco::TrackingRecHitHost>" splitLevel="0"/>
 

--- a/DataFormats/VertexSoA/src/classes_def.xml
+++ b/DataFormats/VertexSoA/src/classes_def.xml
@@ -3,7 +3,9 @@
   <!-- FIXME using the ZVertexSoA and ZVertexTracksSoA type aliases here and below does not work -->
   <class name="reco::ZVertexLayout<128, false>"/>
   <class name="reco::ZVertexTracksLayout<128, false>"/>
-
+  <!-- needed to avoid auto parsing by ROOT. Order in the file matters -->
+  <class name="ZVertexHost::Implementation"/>
+  
   <!-- Recursive templates (with no data) ensuring we have one CollectionLeaf<index, type> for each layout in the collection -->
   <class name="portablecollection::CollectionImpl<0, reco::ZVertexLayout<128, false>, reco::ZVertexTracksLayout<128, false>>"/>
   <class name="portablecollection::CollectionImpl<1, reco::ZVertexTracksLayout<128, false>>"/>


### PR DESCRIPTION
#### PR description:

Memory increases when moving to ROOT 6.36 pointed to these two classes not having dictionaries explicitly defined.

#### PR validation:

Using the MaxMemoryAllocMonitor shows that running workflow 16834.0 step 2 with this change brought down overall memory by more than 500MB, to approximately the ROOT 6.32 level.

resolves https://github.com/cms-sw/framework-team/issues/1692