### PR TITLE
Added ThresholdAbortAllocMonitor

### DIFF
--- a/PerfTools/AllocMonitor/README.md
+++ b/PerfTools/AllocMonitor/README.md
@@ -165,3 +165,13 @@ The message will print
 | `nDealloc` | Number of memory deallocations |
 
 This service is multi-thread safe, and concurrent measurements can be done in different threads. Nested measurements are not supported (i.e. one thread can be doing only one measurement at a time), and neither are measurements started in one thread and ended in different thread.
+
+### ThresholdAbortAllocMonitor
+
+This service registers a monitor when the service is created and will abort the job (which will normally trigger a stack trace) if a memory request falling within a certain memory range is seen for a specified number of times. The service accepts the following parameters
+
+- `minThreshold` : the minimum number of bytes an allocation request must reach before an abort might be triggered.
+- `maxThreshold` : the maximum number of bytes an allocation request must stay below (or equal) before an abort might be triggered. A value of `0` means there is no such limit.
+- `skipCount` : the number of times allocations have satisfied the `minThreshold` to `maxThreshold` range before the next time will trigger an abort. A value of `0` will trigger the first time the range is met.
+
+This service is multi-thread safe although it may not yeild consistent results if multiple thread reach the criteria at the same time. Using `skipCount` concurrently will likely make the inconsistency worse.

--- a/PerfTools/AllocMonitor/plugins/ThresholdAbortAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/ThresholdAbortAllocMonitor.cc
@@ -1,0 +1,68 @@
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+
+#include "PerfTools/AllocMonitor/interface/AllocMonitorBase.h"
+#include "PerfTools/AllocMonitor/interface/AllocMonitorRegistry.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include <atomic>
+#include <iostream>
+#include <format>
+
+namespace {
+  class MonitorAdaptor : public cms::perftools::AllocMonitorBase {
+  public:
+    MonitorAdaptor(unsigned int skip, size_t minThreshold, size_t maxThreshold)
+        : m_skip{skip}, m_min{minThreshold}, m_max{maxThreshold}, m_count{0} {}
+
+  private:
+    void allocCalled(size_t iRequested, size_t iActual, void const*) final {
+      if (iRequested >= m_min) {
+        if (m_max == 0 or iRequested <= m_max) {
+          auto v = ++m_count;
+          if (v > m_skip) {
+            std::cout << std::format("abort threshold reached count: {} request: {}", v, iRequested) << std::endl;
+            abort();
+          }
+        }
+      }
+    }
+    void deallocCalled(size_t iActual, void const*) final {}
+
+    unsigned int m_skip;
+    size_t m_min;
+    size_t m_max;
+    std::atomic<unsigned int> m_count;
+  };
+}  // namespace
+
+class ThresholdAbortAllocMonitor {
+public:
+  ThresholdAbortAllocMonitor(edm::ParameterSet const& iPSet) {
+    (void)cms::perftools::AllocMonitorRegistry::instance().createAndRegisterMonitor<MonitorAdaptor>(
+        iPSet.getUntrackedParameter<unsigned int>("skipCount"),
+        iPSet.getUntrackedParameter<unsigned long long>("minThreshold"),
+        iPSet.getUntrackedParameter<unsigned long long>("maxThreshold"));
+  };
+  static void fillDescriptions(edm::ConfigurationDescriptions& iConfig) {
+    edm::ParameterSetDescription desc;
+    desc.addUntracked<unsigned int>("skipCount", 0)
+        ->setComment(
+            "Number of times the threshold range must be met before doing an abort. A value of 0 will happen the first "
+            "time.");
+    desc.addUntracked<unsigned long long>("minThreshold")
+        ->setComment(
+            "A memory request below this value will not trigger the abort. The exact value is allowed to trigger the "
+            "abort. Triggering the abort also requires being within 'maxThreshold' setting. The units are bytes.");
+    desc.addUntracked<unsigned long long>("maxThreshold", 0)
+        ->setComment(
+            "A memory request above this value will not trigger the abort. A value of 0 means any value could trigger "
+            "the abort. The exact value is allowed to trigger the abort. Triggering the abort also depends on being "
+            "within 'minThreshold' setting. The units are bytes.");
+    iConfig.addDefault(desc);
+  }
+};
+
+typedef edm::serviceregistry::ParameterSetMaker<ThresholdAbortAllocMonitor> ThresholdAbortAllocMonitorMaker;
+DEFINE_FWK_SERVICE_MAKER(ThresholdAbortAllocMonitor, ThresholdAbortAllocMonitorMaker);


### PR DESCRIPTION
#### PR description:

This can be used to abort a job (triggering a traceback) if a memory request falling into a certain range is seen.

#### PR validation:

This was used to trace down why a job using ROOT 6.36 was using more memory than its ROOT 6.32 equivalent.

resolves https://github.com/cms-sw/framework-team/issues/1693