### PR TITLE
Disable PID and Energy Regression for Recovery Tracksters

### DIFF
--- a/RecoHGCal/TICL/python/PRbyRecovery_cff.py
+++ b/RecoHGCal/TICL/python/PRbyRecovery_cff.py
@@ -24,7 +24,24 @@ ticlTrackstersRecovery = _trackstersProducer.clone(
     patternRecognitionBy = "Recovery",
     pluginPatternRecognitionByRecovery = dict (
         algo_verbosity = 0
-    )
+    ),
+    pluginInferenceAlgoTracksterInferenceByPFN = cms.PSet(
+      algo_verbosity = cms.int32(0),
+      onnxPIDModelPath = cms.FileInPath('RecoHGCal/TICL/data/ticlv5/onnx_models/PFN/patternrecognition/id_v0.onnx'),
+      onnxEnergyModelPath = cms.FileInPath('RecoHGCal/TICL/data/ticlv5/onnx_models/PFN/patternrecognition/energy_v0.onnx'),
+      inputNames = cms.vstring(
+        'input',
+        'input_tr_features'
+      ),
+      output_en = cms.vstring('enreg_output'),
+      output_id = cms.vstring('pid_output'),
+      eid_min_cluster_energy = cms.double(1),
+      eid_n_layers = cms.int32(50),
+      eid_n_clusters = cms.int32(10),
+      doPID = cms.int32(0),
+      doRegression = cms.int32(0),
+      type = cms.string('TracksterInferenceByPFN')
+    ),
 )
 
 from Configuration.ProcessModifiers.ticl_v5_cff import ticl_v5


### PR DESCRIPTION
This PR disables the energy regression and PID for the recovery tracksters, not needed for this iteration. 
This should not have any effects on physics but should heavily reduce the offline computing time (for HLT they are already disabled (https://github.com/cms-sw/cmssw/blob/master/HLTrigger/Configuration/python/HLT_75e33/modules/hltTiclTrackstersRecovery_cfi.py#L86-L99)) 