### PR TITLE
Refined pT-based sorting of FastSim jets in NANO, Type-1 MET correction

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/JetSorter.cc
+++ b/PhysicsTools/NanoAOD/plugins/JetSorter.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -6,7 +6,11 @@
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
-class JetSorter : public edm::stream::EDProducer<> {
+#include <algorithm>
+#include <string>
+#include <memory>
+
+class JetSorter : public edm::global::EDProducer<> {
 public:
   explicit JetSorter(const edm::ParameterSet &iConfig)
       : srcToken_(consumes<edm::View<pat::Jet>>(iConfig.getParameter<edm::InputTag>("src"))),
@@ -17,7 +21,7 @@ public:
 
   ~JetSorter() override = default;
 
-  void produce(edm::Event &iEvent, const edm::EventSetup &) override {
+  void produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &) const override {
     edm::Handle<edm::View<pat::Jet>> hSrc;
     iEvent.getByToken(srcToken_, hSrc);
 
@@ -28,14 +32,14 @@ public:
       out->push_back(jIn);
     }
 
-    auto key = [&](pat::Jet const &j) -> float {
+    auto key = [this](pat::Jet const &j) -> float {
       if (j.hasUserFloat(userFloatSorter_)) {
         return j.userFloat(userFloatSorter_);
       }
       return static_cast<float>(j.pt());
     };
 
-    std::stable_sort(out->begin(), out->end(), [&](pat::Jet const &a, pat::Jet const &b) {
+    std::stable_sort(out->begin(), out->end(), [this, &key](pat::Jet const &a, pat::Jet const &b) {
       float pa = key(a);
       float pb = key(b);
       return descending_ ? (pa > pb) : (pa < pb);

--- a/PhysicsTools/NanoAOD/plugins/JetSorter.cc
+++ b/PhysicsTools/NanoAOD/plugins/JetSorter.cc
@@ -1,0 +1,53 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+
+class JetSorter : public edm::stream::EDProducer<> {
+public:
+  explicit JetSorter(const edm::ParameterSet &iConfig)
+      : srcToken_(consumes<edm::View<pat::Jet>>(iConfig.getParameter<edm::InputTag>("src"))),
+        userFloatSorter_(iConfig.getParameter<std::string>("userFloatSorter")),
+        descending_(iConfig.getParameter<bool>("descending")) {
+    produces<std::vector<pat::Jet>>();
+  }
+
+  ~JetSorter() override = default;
+
+  void produce(edm::Event &iEvent, const edm::EventSetup &) override {
+    edm::Handle<edm::View<pat::Jet>> hSrc;
+    iEvent.getByToken(srcToken_, hSrc);
+
+    auto out = std::make_unique<std::vector<pat::Jet>>();
+    out->reserve(hSrc->size());
+
+    for (auto const &jIn : *hSrc) {
+      out->push_back(jIn);
+    }
+
+    auto key = [&](pat::Jet const &j) -> float {
+      if (j.hasUserFloat(userFloatSorter_)) {
+        return j.userFloat(userFloatSorter_);
+      }
+      return static_cast<float>(j.pt());
+    };
+
+    std::stable_sort(out->begin(), out->end(), [&](pat::Jet const &a, pat::Jet const &b) {
+      float pa = key(a);
+      float pb = key(b);
+      return descending_ ? (pa > pb) : (pa < pb);
+    });
+
+    iEvent.put(std::move(out));
+  }
+
+private:
+  edm::EDGetTokenT<edm::View<pat::Jet>> srcToken_;
+  std::string userFloatSorter_;
+  bool descending_;
+};
+
+DEFINE_FWK_MODULE(JetSorter);

--- a/PhysicsTools/NanoAOD/plugins/ProcessRefinedJets.cc
+++ b/PhysicsTools/NanoAOD/plugins/ProcessRefinedJets.cc
@@ -55,15 +55,13 @@ public:
       pat::Jet j(jIn);
 
       const double pt_orig = j.pt();
-      const double phi     = j.phi();
+      const double phi = j.phi();
 
       // mask: BvsAll > 0
       const float bvsAll = j.bDiscriminator(maskBtagName_);
-      const bool refine  = (bvsAll > 0.f);
+      const bool refine = (bvsAll > 0.f);
 
-      const double pt_ref = j.hasUserFloat(refinedPtName_)
-                                ? static_cast<double>(j.userFloat(refinedPtName_))
-                                : pt_orig;
+      const double pt_ref = j.hasUserFloat(refinedPtName_) ? static_cast<double>(j.userFloat(refinedPtName_)) : pt_orig;
 
       const double pt_final = refine ? pt_ref : pt_orig;
 
@@ -107,11 +105,11 @@ public:
         const double ptFinal = std::sqrt(pxFinal * pxFinal + pyFinal * pyFinal);
         const double phiFinal = std::atan2(pyFinal, pxFinal);
 
-        m.addUserFloat("pt_unrefined",  static_cast<float>(ptOrig));
+        m.addUserFloat("pt_unrefined", static_cast<float>(ptOrig));
         m.addUserFloat("phi_unrefined", static_cast<float>(phiOrig));
 
         // stash final values, needed for sorting.
-        m.addUserFloat("pt_final",  static_cast<float>(ptFinal));
+        m.addUserFloat("pt_final", static_cast<float>(ptFinal));
         m.addUserFloat("phi_final", static_cast<float>(phiFinal));
 
         // push back into pat::MET with reco::Candidate::LorentzVector ---

--- a/PhysicsTools/NanoAOD/plugins/ProcessRefinedJets.cc
+++ b/PhysicsTools/NanoAOD/plugins/ProcessRefinedJets.cc
@@ -1,0 +1,145 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/PatCandidates/interface/MET.h"
+#include "TLorentzVector.h"
+
+#include <cmath>
+
+//This producer was written to embed the final refined FastSim jet pT values
+//so that they can be used as input to the pT-based sorting routine, as well
+//as to implement the Type-1 MET correction based on the refined jets.
+class ProcessRefinedJets : public edm::stream::EDProducer<> {
+public:
+  explicit ProcessRefinedJets(const edm::ParameterSet &iConfig)
+      : jetsToken_(consumes<edm::View<pat::Jet>>(iConfig.getParameter<edm::InputTag>("jets"))),
+        refinedPtName_(iConfig.getParameter<std::string>("refinedPtName")),
+        maskBtagName_(iConfig.getParameter<std::string>("maskBtagName")),
+        ptFinalName_(iConfig.getParameter<std::string>("ptFinalName")),
+        ptUnrefinedName_(iConfig.getParameter<std::string>("ptUnrefinedName")) {
+    // Type-1 MET correction is optional
+    if (iConfig.existsAs<edm::InputTag>("met")) {
+      metToken_ = consumes<edm::View<pat::MET>>(iConfig.getParameter<edm::InputTag>("met"));
+      doMET_ = true;
+    } else {
+      doMET_ = false;
+    }
+
+    produces<std::vector<pat::Jet>>();
+
+    if (doMET_) {
+      // refined MET made available in python
+      produces<std::vector<pat::MET>>("Refined");
+    }
+  }
+
+  ~ProcessRefinedJets() override = default;
+
+  void produce(edm::Event &iEvent, const edm::EventSetup &) override {
+    edm::Handle<edm::View<pat::Jet>> hJets;
+    iEvent.getByToken(jetsToken_, hJets);
+
+    auto outJets = std::make_unique<std::vector<pat::Jet>>();
+    outJets->reserve(hJets->size());
+
+    // Sum over (pt_orig - pt_final) for MET correction
+    double sumDeltaPx = 0.;
+    double sumDeltaPy = 0.;
+
+    for (auto const &jIn : *hJets) {
+      pat::Jet j(jIn);
+
+      const double pt_orig = j.pt();
+      const double phi = j.phi();
+
+      // mask: BvsAll > 0
+      const float bvsAll = j.bDiscriminator(maskBtagName_);
+      const bool refine = (bvsAll > 0.f);
+
+      const double pt_ref = j.hasUserFloat(refinedPtName_) ? static_cast<double>(j.userFloat(refinedPtName_)) : pt_orig;
+
+      const double pt_final = refine ? pt_ref : pt_orig;
+
+      // store unrefined pt if requested
+      if (!ptUnrefinedName_.empty()) {
+        j.addUserFloat(ptUnrefinedName_, static_cast<float>(pt_orig));
+      }
+
+      // store final pt used for Nano, needed for the sorting
+      j.addUserFloat(ptFinalName_, static_cast<float>(pt_final));
+
+      // MET delta: add unrefined jets, subtract final jets
+      // This is equivalent to adding (pt_orig - pt_final) in the jet direction.
+      const double dpt = pt_orig - pt_final;
+      sumDeltaPx += dpt * std::cos(phi);
+      sumDeltaPy += dpt * std::sin(phi);
+
+      outJets->push_back(std::move(j));
+    }
+
+    iEvent.put(std::move(outJets));
+
+    // Optionally correct MET
+    if (doMET_) {
+      edm::Handle<edm::View<pat::MET>> hMET;
+      iEvent.getByToken(metToken_, hMET);
+
+      auto outMET = std::make_unique<std::vector<pat::MET>>();
+      outMET->reserve(hMET->size());
+
+      for (auto const &mIn : *hMET) {
+        pat::MET m(mIn);
+
+        // --- original MET as TLorentzVector ---
+        const double pxOrig = m.px();
+        const double pyOrig = m.py();
+        const double ptOrig = std::sqrt(pxOrig * pxOrig + pyOrig * pyOrig);
+        const double phiOrig = std::atan2(pyOrig, pxOrig);
+
+        TLorentzVector metOrig;
+        metOrig.SetPxPyPzE(pxOrig, pyOrig, 0.0, ptOrig);  // pz=0, E ~ pt (E not really used for MET)
+
+        // Type-1 MET correction for PUPPI MET with refined jets:
+        TLorentzVector delta;
+        const double ptDelta = std::sqrt(sumDeltaPx * sumDeltaPx + sumDeltaPy * sumDeltaPy);
+        delta.SetPxPyPzE(sumDeltaPx, sumDeltaPy, 0.0, ptDelta);
+
+        TLorentzVector metFinal = metOrig + delta;
+
+        const double ptFinal = metFinal.Pt();
+        const double phiFinal = metFinal.Phi();
+
+        // stash unrefined values
+        m.addUserFloat("pt_unrefined", static_cast<float>(ptOrig));
+        m.addUserFloat("phi_unrefined", static_cast<float>(phiOrig));
+
+        // stash final values, needed for sorting.
+        m.addUserFloat("pt_final", static_cast<float>(ptFinal));
+        m.addUserFloat("phi_final", static_cast<float>(phiFinal));
+
+        // push back into pat::MET with reco::Candidate::LorentzVector ---
+        reco::Candidate::LorentzVector p4(metFinal.Px(), metFinal.Py(), 0.0, ptFinal);
+        m.setP4(p4);
+
+        outMET->push_back(std::move(m));
+      }
+      iEvent.put(std::move(outMET), "Refined");
+    }
+  }
+
+private:
+  edm::EDGetTokenT<edm::View<pat::Jet>> jetsToken_;
+  edm::EDGetTokenT<edm::View<pat::MET>> metToken_;
+  bool doMET_;
+
+  std::string refinedPtName_;
+  std::string maskBtagName_;
+  std::string ptFinalName_;
+  std::string ptUnrefinedName_;
+};
+
+DEFINE_FWK_MODULE(ProcessRefinedJets);

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -289,7 +289,8 @@ def nanoAOD_refineFastSim_puppiJet(process):
             btagUParTAK4Brefined   = cms.InputTag("puppiJetRefineNN","btagUParTAK4Brefined"),
             btagUParTAK4CvBrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4CvBrefined"),
             btagUParTAK4CvLrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4CvLrefined"),
-            btagUParTAK4QvGrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4QvGrefined"),)
+            btagUParTAK4QvGrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4QvGrefined"),
+        )
     )
     fastSim.toModify(process.jetPuppiTablesTask, process.jetPuppiTablesTask.add(process.finalJetsPuppiWithRefined))
 

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -220,22 +220,11 @@ jetPuppiTask = cms.Task(jetPuppiCorrFactorsNano,updatedJetsPuppi,jetPuppiUserDat
 jetPuppiTablesTask = cms.Task(jetPuppiTable)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-from PhysicsTools.NanoAOD.common_cff import ExtVar
-
-import FWCore.ParameterSet.Config as cms
-from Configuration.Eras.Modifier_fastSim_cff import fastSim
-from PhysicsTools.NanoAOD.common_cff import Var
-
 from PhysicsTools.NanoAOD.common_cff import Var, ExtVar
-from Configuration.Eras.Modifier_fastSim_cff import fastSim
-
-from Configuration.Eras.Modifier_fastSim_cff import fastSim
-from PhysicsTools.NanoAOD.common_cff       import ExtVar, Var
-import FWCore.ParameterSet.Config           as cms
 
 def nanoAOD_refineFastSim_puppiJet(process):
 
-    #save originals and clear so we can republish
+    # 0. Save originals and clear so we can republish refined versions
     fastSim.toModify(process.jetPuppiTable.variables,
         pt_unrefined               = process.jetPuppiTable.variables.pt.clone(),
         btagDeepFlavB_unrefined    = process.jetPuppiTable.variables.btagDeepFlavB.clone(),
@@ -252,13 +241,13 @@ def nanoAOD_refineFastSim_puppiJet(process):
         btagUParTAK4B=None, btagUParTAK4CvB=None, btagUParTAK4CvL=None, btagUParTAK4QvG=None,
     )
 
-    # run refinement model and return features
+    # 1. Run refinement model and return features
     process.puppiJetRefineNN = cms.EDProducer(
         "JetBaseMVAValueMapProducer",
         backend             = cms.string("ONNX"),
         batch_eval          = cms.bool(True),
         disableONNXGraphOpt = cms.bool(True),
-        src                 = cms.InputTag("linkedObjects","jets"),  # <— matches table
+        src                 = cms.InputTag("linkedObjects","jets"),  # matches table
         weightFile          = cms.FileInPath("PhysicsTools/NanoAOD/data/fastSimPuppiJetRefineNN_31July2025.onnx"),
         name                = cms.string("puppiJetRefineNN"),
         variables = cms.VPSet(
@@ -273,25 +262,24 @@ def nanoAOD_refineFastSim_puppiJet(process):
             cms.PSet(name=cms.string("Jet_btagUParTAK4B"),   expr=cms.string("bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')")),
             cms.PSet(name=cms.string("Jet_btagUParTAK4CvB"), expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'):-1")),
             cms.PSet(name=cms.string("Jet_btagUParTAK4CvL"), expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'):-1")),
-            cms.PSet(name=cms.string("Jet_btagUParTAK4QvG"), expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'):-1")),
-        ),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4QvG"), expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'):-1")),),
         inputTensorName  = cms.string("input"),
         outputTensorName = cms.string("output"),
         outputNames      = cms.vstring(
             "ptrefined",
             "btagDeepFlavBrefined","btagDeepFlavCvBrefined","btagDeepFlavCvLrefined","btagDeepFlavQGrefined",
-            "btagUParTAK4Brefined","btagUParTAK4CvBrefined","btagUParTAK4CvLrefined","btagUParTAK4QvGrefined",
-        ),
+            "btagUParTAK4Brefined","btagUParTAK4CvBrefined","btagUParTAK4CvLrefined","btagUParTAK4QvGrefined",),
         outputFormulas   = cms.vstring("at(0)","at(1)","at(2)","at(3)","at(4)","at(5)","at(6)","at(7)","at(8)"),
     )
     fastSim.toModify(process.jetPuppiTablesTask, process.jetPuppiTablesTask.add(process.puppiJetRefineNN))
 
-    #copy the ONNX ValueMaps onto jets as userFloats
+    # Ensure src is what we expect (redundant but explicit)
     process.puppiJetRefineNN.src = cms.InputTag("linkedObjects","jets")
-    
+
+    # 2. Copy the ONNX ValueMaps onto jets as userFloats
     process.finalJetsPuppiWithRefined = cms.EDProducer(
         "PATJetUserDataEmbedder",
-        src = cms.InputTag("linkedObjects","jets"),  # <— same!
+        src = cms.InputTag("linkedObjects","jets"),
         userFloats = cms.PSet(
             ptrefined              = cms.InputTag("puppiJetRefineNN","ptrefined"),
             btagDeepFlavBrefined   = cms.InputTag("puppiJetRefineNN","btagDeepFlavBrefined"),
@@ -301,29 +289,73 @@ def nanoAOD_refineFastSim_puppiJet(process):
             btagUParTAK4Brefined   = cms.InputTag("puppiJetRefineNN","btagUParTAK4Brefined"),
             btagUParTAK4CvBrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4CvBrefined"),
             btagUParTAK4CvLrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4CvLrefined"),
-            btagUParTAK4QvGrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4QvGrefined"),
-        )
+            btagUParTAK4QvGrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4QvGrefined"),)
     )
-    process.jetPuppiTable.src = cms.InputTag("finalJetsPuppiWithRefined")
-    
     fastSim.toModify(process.jetPuppiTablesTask, process.jetPuppiTablesTask.add(process.finalJetsPuppiWithRefined))
 
+    # Intermediate src: jets with refined userFloats
     process.jetPuppiTable.src = cms.InputTag("finalJetsPuppiWithRefined")
 
-    #mask jets we shouldn't be refining - Note: the -1 safety in the definitions of the original flavor taggers cannot be implemented in the following, because nested ternaries either crash the parser or confuse the logic and mess up the default values. The max(x,-1) is used as an alternative. 
+    # 3. Apply mask for all refined quantities in Nano (pt + taggers)
+    # Note: we keep all the masking logic here in python.
     _mask = "bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')>0"
+
     fastSim.toModify(process.jetPuppiTable.variables,
-        pt = Var(f"?{_mask}?userFloat('ptrefined'):pt()", float, precision=10),
-        btagDeepFlavB = Var(f"?{_mask}?userFloat('btagDeepFlavBrefined'):(bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))", float, precision=10),
-        btagDeepFlavCvB = Var(f"?{_mask}?userFloat('btagDeepFlavCvBrefined'):max(bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')),-1)", float, precision=10),#max(x,-1) safety because double-ternary not allowed 
-        btagDeepFlavCvL = Var(f"?{_mask}?userFloat('btagDeepFlavCvLrefined'):max(bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')),-1)", float, precision=10),#max(x,-1) safety because double-ternary not allowed 
-        btagDeepFlavQG = Var(f"?{_mask}?userFloat('btagDeepFlavQGrefined'):max(bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')),-1)", float, precision=10),#max(x,-1) safety because double-ternary not allowed 
-        btagUParTAK4B = Var(f"?{_mask}?userFloat('btagUParTAK4Brefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll'),-1)", float, precision=12),
-        btagUParTAK4CvB = Var(f"?{_mask}?userFloat('btagUParTAK4CvBrefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'),-1)", float, precision=12),
-        btagUParTAK4CvL = Var(f"?{_mask}?userFloat('btagUParTAK4CvLrefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'),-1)", float, precision=12),
-        btagUParTAK4QvG = Var(f"?{_mask}?userFloat('btagUParTAK4QvGrefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'),-1)", float, precision=12),        
+        pt = Var("?" + _mask + "?userFloat('ptrefined'):pt()", float, precision=10),
+        btagDeepFlavB = Var("?" + _mask + "?userFloat('btagDeepFlavBrefined'):(bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))", float, precision=10),
+        btagDeepFlavCvB = Var("?" + _mask + "?userFloat('btagDeepFlavCvBrefined'):max(bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')),-1)", float, precision=10),
+        btagDeepFlavCvL = Var("?" + _mask + "?userFloat('btagDeepFlavCvLrefined'):max(bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')),-1)", float, precision=10),
+        btagDeepFlavQG = Var("?" + _mask + "?userFloat('btagDeepFlavQGrefined'):max(bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')),-1)", float, precision=10),
+        btagUParTAK4B = Var("?" + _mask + "?userFloat('btagUParTAK4Brefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll'),-1)", float, precision=12),
+        btagUParTAK4CvB = Var("?" + _mask + "?userFloat('btagUParTAK4CvBrefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'),-1)", float, precision=12),
+        btagUParTAK4CvL = Var("?" + _mask + "?userFloat('btagUParTAK4CvLrefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'),-1)", float, precision=12),
+        btagUParTAK4QvG = Var("?" + _mask + "?userFloat('btagUParTAK4QvGrefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'),-1)", float, precision=12),
     )
+
+    # 4. Build pt_final as a userFloat on jets (mask applied), also do type 1 met correction
+    #    Note for future refinement: The mask definition above is also coded into the producer
+    process.processRefinedJets = cms.EDProducer(
+        "ProcessRefinedJets",  # or "FastSimPuppiRefinedJetProducer" if that is your C++ class name
+        jets            = cms.InputTag("finalJetsPuppiWithRefined"),
+        refinedPtName   = cms.string("ptrefined"),
+        maskBtagName    = cms.string("pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll"),
+        ptFinalName     = cms.string("pt_final"),
+        ptUnrefinedName = cms.string("pt_unrefined"),
+        met             = cms.InputTag("slimmedMETsPuppi"), # MET collection where type-1 refinement corrections 
+    )
+    fastSim.toModify(
+        process.jetPuppiTablesTask,
+        process.jetPuppiTablesTask.add(process.processRefinedJets)
+    )
+
+    #point PuppiMET Nano table to the *refined* MET collection
+    fastSim.toModify(
+        process.puppiMetTable,
+        src = cms.InputTag("processRefinedJets", "Refined"),
+    )
+
+    # And add _unrefined branches from the MET userFloats filled in C++
+    fastSim.toModify(
+        process.puppiMetTable.variables,
+        pt_unrefined  = Var("userFloat('pt_unrefined')",  float, precision=10),
+        phi_unrefined = Var("userFloat('phi_unrefined')", float, precision=10),
+    )
+
+    # 5. Sort jets by pt_final only
+    process.finalJetsPuppiSorted = cms.EDProducer(
+        "JetSorter",
+        src           = cms.InputTag("processRefinedJets"),
+        userFloatSorter = cms.string("pt_final"),
+        descending    = cms.bool(True),
+    )
+    fastSim.toModify(
+        process.jetPuppiTablesTask,
+        process.jetPuppiTablesTask.add(process.finalJetsPuppiSorted)
+    )
+    process.jetPuppiTable.src = cms.InputTag("finalJetsPuppiSorted")
+
     return process
+
 
 # bind for the customise step
 nanoAOD_refineFastSim_puppiJet = nanoAOD_refineFastSim_puppiJet

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -352,7 +352,10 @@ def nanoAOD_refineFastSim_puppiJet(process):
         process.jetPuppiTablesTask,
         process.jetPuppiTablesTask.add(process.finalJetsPuppiSorted)
     )
-    process.jetPuppiTable.src = cms.InputTag("finalJetsPuppiSorted")
+    fastSim.toModify(
+        process.jetPuppiTable,
+        src = cms.InputTag("finalJetsPuppiSorted")
+    )
 
     return process
 


### PR DESCRIPTION
This PR re-sorts the Jet_* branches in FastSim NANO in descending order of refined jet pT and propagates the refined jet pT as a Type-1 correction to the PUPPI MET. It is a direct follow-up of the refinement implemented in https://github.com/cms-sw/cmssw/pull/48587#issuecomment-3151196024. 

The only expected changes to DQM are to PuppiMET_pt and PuppiMET_phi. 

The PR creates additional backup branches: PuppiMET_pt_unrefined and PuppiMET_phi_unrefined in case anything goes wrong with the refined jets in some unanticipated corner of phase space. 

The Type-1 correction was implemented independently in stand-alone code and compared to the results in the NANO product:

Event 0
  PuppiMET (stored refined):   pt=  11.600, phi=  -2.089
  PuppiMET (recomputed T1):    pt=  11.627, phi=  -2.086
  Differences: dpt=   0.027, dphi=   0.003

Event 1
  PuppiMET (stored refined):   pt=  37.961, phi=   0.613
  PuppiMET (recomputed T1):    pt=  37.973, phi=   0.612
  Differences: dpt=   0.013, dphi=  -0.000

Event 2
  PuppiMET (stored refined):   pt=  10.061, phi=  -1.397
  PuppiMET (recomputed T1):    pt=  10.073, phi=  -1.401
  Differences: dpt=   0.012, dphi=  -0.004

Event 3
  PuppiMET (stored refined):   pt=  38.431, phi=   1.609
  PuppiMET (recomputed T1):    pt=  38.430, phi=   1.608
  Differences: dpt=  -0.001, dphi=  -0.001

The differences are very small and consistent with the floating point precisoin=10. Setting precision=20 caused the difference to vanish. 
