### PR TITLE
Cleanup in InputFileCatalog

### DIFF
--- a/FWCore/Catalog/interface/FileLocator.h
+++ b/FWCore/Catalog/interface/FileLocator.h
@@ -1,6 +1,7 @@
 #ifndef FWCore_Catalog_FileLocator_h
 #define FWCore_Catalog_FileLocator_h
 
+#include <filesystem>
 #include <map>
 #include <regex>
 #include <string>
@@ -14,11 +15,7 @@ namespace edm {
 
   class FileLocator {
   public:
-    explicit FileLocator(
-        CatalogAttributes const& catalogAttributes,
-        unsigned iCatalog = 0,
-        //storageDescriptionPath is used to override path provided by SiteLocalConfig. This is used in FileLocator_t.cpp tests
-        std::string const& storageDescriptionPath = std::string());
+    explicit FileLocator(CatalogAttributes const& catalogAttributes, std::filesystem::path const& filename_storage);
 
     std::string pfn(std::string const& ilfn) const;
 
@@ -32,15 +29,13 @@ namespace edm {
     using Rules = std::vector<Rule>;
     using ProtocolRules = std::map<std::string, Rules>;
 
-    void init(CatalogAttributes const& catalogAttributes, unsigned iCatalog, std::string const& storageDescriptionPath);
-
     void parseRule(boost::property_tree::ptree::value_type const& storageRule,
                    std::string const& protocol,
                    ProtocolRules& rules);
 
     std::string applyRules(ProtocolRules const& protocolRules, std::string const& protocol, std::string name) const;
 
-    /** Direct rules are used to do the mapping from LFN to PFN taken from storage.json*/
+    /** Direct rules are used to do the mapping from LFN to PFN and taken from storage.json*/
     ProtocolRules m_directRules;
     std::string m_protocol;
   };

--- a/FWCore/Catalog/interface/InputFileCatalog.h
+++ b/FWCore/Catalog/interface/InputFileCatalog.h
@@ -56,7 +56,6 @@ namespace edm {
     static bool isPhysical(std::string const& name) { return (name.empty() || name.find(':') != std::string::npos); }
 
   private:
-    void init(std::vector<std::string> logicalFileNames, std::string const& override, bool useLFNasPFNifLFNnotFound);
     void findFile(std::string const& lfn, std::vector<std::string>& pfns, bool useLFNasPFNifLFNnotFound);
 
     std::vector<FileCatalogItem> fileCatalogItems_;

--- a/FWCore/Catalog/src/InputFileCatalog.cc
+++ b/FWCore/Catalog/src/InputFileCatalog.cc
@@ -1,3 +1,5 @@
+#include <filesystem>
+
 #include <boost/algorithm/string.hpp>
 
 #include "FWCore/Catalog/interface/FileLocator.h"
@@ -12,28 +14,11 @@ namespace edm {
   InputFileCatalog::InputFileCatalog(std::vector<std::string> logicalFileNames,
                                      std::string const& override,
                                      bool useLFNasPFNifLFNnotFound) {
-    init(std::move(logicalFileNames), override, useLFNasPFNifLFNnotFound);
-  }
-
-  InputFileCatalog::~InputFileCatalog() {}
-
-  std::vector<std::string> InputFileCatalog::fileNames(unsigned iCatalog) const {
-    std::vector<std::string> tmp;
-    tmp.reserve(fileCatalogItems_.size());
-    for (auto const& item : fileCatalogItems_) {
-      tmp.push_back(item.fileName(iCatalog));
-    }
-    return tmp;
-  }
-
-  void InputFileCatalog::init(std::vector<std::string> logicalFileNames,
-                              std::string const& override,
-                              bool useLFNasPFNifLFNnotFound) {
     Service<SiteLocalConfig> localconfservice;
     if (!localconfservice.isAvailable()) {
       cms::Exception ex("FileCatalog");
       ex << "edm::SiteLocalConfigService is not available";
-      ex.addContext("Calling edm::InputFileCatalog::init()");
+      ex.addContext("Calling edm::InputFileCatalog constructor");
       throw ex;
     }
 
@@ -45,7 +30,7 @@ namespace edm {
         cms::Exception ex("FileCatalog");
         ex << "Trying to override input file catalog but invalid input override string " << override
            << " (Should be site,subSite,storageSite,volume,protocol)";
-        ex.addContext("Calling edm::InputFileCatalog::init()");
+        ex.addContext("Calling edm::InputFileCatalog constructor");
         throw ex;
       }
 
@@ -54,30 +39,42 @@ namespace edm {
                                         tmps[2],   //desired-data-access-site
                                         tmps[3],   //desired-data-access-volume
                                         tmps[4]);  //desired-data-access-protocol
-
-      overrideFileLocator_ =
-          std::make_unique<FileLocator>(override_struct);  // propagate_const<T> has no reset() function
-    }
-
-    std::vector<CatalogAttributes> const& tmp_dataCatalogs = localconfservice->dataCatalogs();
-    fileLocators_.clear();
-    // Construct all file locators from data catalogs. If a data catalog is
-    // invalid (wrong protocol for example), it is skipped and no file locator
-    // is constructed (an exception is thrown out from FileLocator::init).
-    for (const auto& catalog : tmp_dataCatalogs) {
-      try {
-        fileLocators_.push_back(std::make_unique<FileLocator>(catalog));
-      } catch (cms::Exception const& e) {
-        edm::LogWarning("InputFileCatalog")
-            << "Caught an exception while constructing a file locator in InputFileCatalog::init: " << e.what()
-            << "Skip this catalog";
+      if (override_struct.empty()) {
+        cms::Exception ex("FileCatalog");
+        ex << "Trying to override input file catalog but invalid input override string " << override
+           << "\nResulting CatalogAttributes is empty (should be site,subSite,storageSite,volume,protocol)";
+        ex.addContext("Calling edm::InputFileCatalog constructor");
+        throw ex;
       }
-    }
-    if (fileLocators_.empty()) {
-      cms::Exception ex("FileCatalog");
-      ex << "Unable to construct any file locator in InputFileCatalog::init";
-      ex.addContext("Calling edm::InputFileCatalog::init()");
-      throw ex;
+      std::filesystem::path filename_storage = localconfservice->storageDescriptionPath(override_struct);
+      overrideFileLocator_ = std::make_unique<FileLocator>(override_struct, filename_storage);
+    } else {
+      std::vector<CatalogAttributes> const& tmp_dataCatalogs = localconfservice->dataCatalogs();
+      fileLocators_.clear();
+      // Construct all file locators from data catalogs. If a data catalog is
+      // invalid (wrong protocol for example), it is skipped and no file locator
+      // is constructed (an exception is thrown out from the FileLocator constructor).
+      for (const auto& catalogAttributes : tmp_dataCatalogs) {
+        if (catalogAttributes.empty()) {
+          edm::LogWarning("InputFileCatalog")
+              << "Empty CatalogAttributes object in InputFileCatalog constructor. This catalog will be skipped.";
+          continue;
+        }
+        try {
+          std::filesystem::path filename_storage = localconfservice->storageDescriptionPath(catalogAttributes);
+          fileLocators_.push_back(std::make_unique<FileLocator>(catalogAttributes, filename_storage));
+        } catch (cms::Exception const& e) {
+          edm::LogWarning("InputFileCatalog")
+              << "Caught an exception while constructing a file locator in InputFileCatalog constructor: " << e.what()
+              << "Skip this catalog";
+        }
+      }
+      if (fileLocators_.empty()) {
+        cms::Exception ex("FileCatalog");
+        ex << "Unable to construct any file locator in InputFileCatalog constructor";
+        ex.addContext("Calling edm::InputFileCatalog constructor");
+        throw ex;
+      }
     }
 
     fileCatalogItems_.reserve(logicalFileNames.size());
@@ -87,14 +84,14 @@ namespace edm {
       if (lfn.empty()) {
         cms::Exception ex("FileCatalog");
         ex << "An empty string specified in the fileNames parameter for input source";
-        ex.addContext("Calling edm::InputFileCatalog::init()");
+        ex.addContext("Calling edm::InputFileCatalog constructor");
         throw ex;
       }
       if (isPhysical(lfn)) {
         if (lfn.back() == ':') {
           cms::Exception ex("FileCatalog");
           ex << "An empty physical file name specified in the fileNames parameter for input source";
-          ex.addContext("Calling edm::InputFileCatalog::init()");
+          ex.addContext("Calling edm::InputFileCatalog constructor");
           throw ex;
         }
         pfns.push_back(lfn);
@@ -107,6 +104,17 @@ namespace edm {
 
       fileCatalogItems_.emplace_back(std::move(pfns), std::move(lfn));
     }
+  }
+
+  InputFileCatalog::~InputFileCatalog() = default;
+
+  std::vector<std::string> InputFileCatalog::fileNames(unsigned iCatalog) const {
+    std::vector<std::string> tmp;
+    tmp.reserve(fileCatalogItems_.size());
+    for (auto const& item : fileCatalogItems_) {
+      tmp.push_back(item.fileName(iCatalog));
+    }
+    return tmp;
   }
 
   void InputFileCatalog::findFile(std::string const& lfn,

--- a/FWCore/Catalog/test/FileLocator_t.cpp
+++ b/FWCore/Catalog/test/FileLocator_t.cpp
@@ -2,32 +2,31 @@
 #include "catch2/catch_all.hpp"
 
 #include <array>
+#include <memory>
 #include <string>
+#include <vector>
 
 #include "FWCore/Catalog/interface/FileLocator.h"
 #include "FWCore/Catalog/interface/SiteLocalConfig.h"
-#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
-#include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 
 #include "TestSiteLocalConfig.h"
 
-TEST_CASE("FileLocator with Rucio data catalog", "[FWCore/Catalog]") {
-  edm::ServiceToken tempToken = edmtest::catalog::makeTestSiteLocalConfigToken();
+namespace {
+  std::unique_ptr<edm::FileLocator> makeFileLocator(unsigned int iCatalog) {
+    auto vec = edmtest::catalog::makeVectorOfCatalogAttributes();
+    edm::CatalogAttributes const& catalogAttributes = vec.at(iCatalog);
+    std::filesystem::path filename_storage = edmtest::catalog::storageDescriptionPathImpl(catalogAttributes);
+    return std::make_unique<edm::FileLocator>(catalogAttributes, filename_storage);
+  }
+}  // namespace
 
+TEST_CASE("FileLocator with Rucio data catalog", "[FWCore/Catalog]") {
   SECTION("prefix") {
-    edm::ServiceRegistry::Operate operate(tempToken);
-    //empty catalog
-    edm::CatalogAttributes tmp_cat;
-    //use the first catalog provided by site local config
-    edm::FileLocator fl(tmp_cat, 0);
-    CHECK("root://cmsxrootd.fnal.gov/store/group/bha/bho" == fl.pfn("/store/group/bha/bho"));
+    auto fl = makeFileLocator(0);
+    CHECK("root://cmsxrootd.fnal.gov/store/group/bha/bho" == fl->pfn("/store/group/bha/bho"));
   }
   SECTION("rule") {
-    edm::ServiceRegistry::Operate operate(tempToken);
-    //empty catalog
-    edm::CatalogAttributes tmp_cat;
-    //use the second catalog provided by site local config
-    edm::FileLocator fl(tmp_cat, 1);
+    auto fl = makeFileLocator(1);
     const std::array<const char*, 7> lfn = {{"/bha/bho",
                                              "bha",
                                              "file:bha",
@@ -35,17 +34,13 @@ TEST_CASE("FileLocator with Rucio data catalog", "[FWCore/Catalog]") {
                                              "/castor/cern.ch/cms/bha/bho",
                                              "someprotocol:/castor/cern.ch/cms/bha/bho",
                                              "someprotocol:/bha/bho"}};
-    CHECK("root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/group/bha/bho" == fl.pfn("/store/group/bha/bho"));
+    CHECK("root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/group/bha/bho" == fl->pfn("/store/group/bha/bho"));
     for (auto file : lfn) {
-      CHECK("" == fl.pfn(file));
+      CHECK("" == fl->pfn(file));
     }
   }
   SECTION("chainedrule") {
-    edm::ServiceRegistry::Operate operate(tempToken);
-    //empty catalog
-    edm::CatalogAttributes tmp_cat;
-    //use the third catalog provided by site local config above
-    edm::FileLocator fl(tmp_cat, 2);
+    auto fl = makeFileLocator(2);
     const std::array<const char*, 7> lfn = {{"/bha/bho",
                                              "bha",
                                              "file:bha",
@@ -54,11 +49,11 @@ TEST_CASE("FileLocator with Rucio data catalog", "[FWCore/Catalog]") {
                                              "someprotocol:/castor/cern.ch/cms/bha/bho",
                                              "someprotocol:/bha/bho"}};
     //one level chain between "root" and "second" protocols (see storage.json)
-    CHECK("root://host.domain//pnfs/cms/store/group/bha/bho" == fl.pfn("/store/group/bha/bho"));
+    CHECK("root://host.domain//pnfs/cms/store/group/bha/bho" == fl->pfn("/store/group/bha/bho"));
     //two levels chain between "root", "second" and "first" (see storage.json)
-    CHECK("root://host.domain//pnfs/cms/store/user/AAA/bho" == fl.pfn("/store/user/aaa/bho"));
+    CHECK("root://host.domain//pnfs/cms/store/user/AAA/bho" == fl->pfn("/store/user/aaa/bho"));
     for (auto file : lfn) {
-      CHECK("" == fl.pfn(file));
+      CHECK("" == fl->pfn(file));
     }
   }
 }

--- a/FWCore/Catalog/test/TestSiteLocalConfig.h
+++ b/FWCore/Catalog/test/TestSiteLocalConfig.h
@@ -1,26 +1,34 @@
 #ifndef FWCore_Catalog_test_TestSiteLocalConfig_h
 #define FWCore_Catalog_test_TestSiteLocalConfig_h
 
-#include "FWCore/Catalog/interface/SiteLocalConfig.h"
-
 #include <cstdlib>
 #include <filesystem>
 #include <string>
+#include <vector>
+
+#include "FWCore/Catalog/interface/SiteLocalConfig.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 
 namespace edmtest::catalog {
+
+  inline std::filesystem::path const storageDescriptionPathImpl(const edm::CatalogAttributes& aDataCatalog) {
+    std::string CMSSW_BASE(std::getenv("CMSSW_BASE"));
+    std::string CMSSW_RELEASE_BASE(std::getenv("CMSSW_RELEASE_BASE"));
+    std::string file_name("/src/FWCore/Catalog/test/storage.json");
+    std::string full_file_name = std::filesystem::exists((CMSSW_BASE + file_name).c_str())
+                                     ? CMSSW_BASE + file_name
+                                     : CMSSW_RELEASE_BASE + file_name;
+    return full_file_name;
+  }
+
   class TestSiteLocalConfig : public edm::SiteLocalConfig {
   public:
     //constructor using Rucio data catalogs
     TestSiteLocalConfig(std::vector<edm::CatalogAttributes> catalogs) : m_catalogs(std::move(catalogs)) {}
     std::vector<edm::CatalogAttributes> const& dataCatalogs() const final { return m_catalogs; }
     std::filesystem::path const storageDescriptionPath(const edm::CatalogAttributes& aDataCatalog) const final {
-      std::string CMSSW_BASE(std::getenv("CMSSW_BASE"));
-      std::string CMSSW_RELEASE_BASE(std::getenv("CMSSW_RELEASE_BASE"));
-      std::string file_name("/src/FWCore/Catalog/test/storage.json");
-      std::string full_file_name = std::filesystem::exists((CMSSW_BASE + file_name).c_str())
-                                       ? CMSSW_BASE + file_name
-                                       : CMSSW_RELEASE_BASE + file_name;
-      return full_file_name;
+      return edmtest::catalog::storageDescriptionPathImpl(aDataCatalog);
     }
 
     std::string const lookupCalibConnect(std::string const& input) const final { return std::string(); }
@@ -49,7 +57,9 @@ namespace edmtest::catalog {
     std::string m_emptyString;
   };
 
-  inline edm::ServiceToken makeTestSiteLocalConfigToken() {
+  inline std::vector<edm::CatalogAttributes> makeVectorOfCatalogAttributes() {
+    std::vector<edm::CatalogAttributes> tmp;
+
     //catalog for testing "prefix"
     edm::CatalogAttributes aCatalog;
     aCatalog.site = "T1_US_FNAL";
@@ -57,7 +67,8 @@ namespace edmtest::catalog {
     aCatalog.storageSite = "T1_US_FNAL";
     aCatalog.volume = "American_Federation";
     aCatalog.protocol = "XRootD";
-    std::vector<edm::CatalogAttributes> tmp{aCatalog};
+    tmp.push_back(aCatalog);
+
     //catalog for testing "rules"
     aCatalog.site = "T1_US_FNAL";
     aCatalog.subSite = "T1_US_FNAL";
@@ -65,6 +76,7 @@ namespace edmtest::catalog {
     aCatalog.volume = "FNAL_dCache_EOS";
     aCatalog.protocol = "XRootD";
     tmp.push_back(aCatalog);
+
     //catalog for testing chained "rules"
     aCatalog.site = "T1_US_FNAL";
     aCatalog.subSite = "T1_US_FNAL";
@@ -73,9 +85,13 @@ namespace edmtest::catalog {
     aCatalog.protocol = "root";
     tmp.push_back(aCatalog);
 
+    return tmp;
+  }
+
+  inline edm::ServiceToken makeTestSiteLocalConfigToken() {
     //create the services
     return edm::ServiceToken(edm::ServiceRegistry::createContaining(
-        std::unique_ptr<edm::SiteLocalConfig>(std::make_unique<TestSiteLocalConfig>(std::move(tmp)))));
+        std::unique_ptr<edm::SiteLocalConfig>(std::make_unique<TestSiteLocalConfig>(makeVectorOfCatalogAttributes()))));
   }
 }  // namespace edmtest::catalog
 


### PR DESCRIPTION
#### PR description:

Clean up InputFileCatalog. It seems easier to understand this code if the part of it dealing with the SiteLocalConfigService is all in the InputFileCatalog class and not split between the InputFileCatalog and FileLocator classes.

Also get rid of the init functions and just move their content directly into the constructors (A few functions were moved because of this but otherwise unmodified).

This should give the same behavior as before. No changes expected.

#### PR validation:

We had good unit tests for this and I updated the FileLocator one to still work with the changes. They still pass. Compiles after ```checkdeps -a``` also.
