### PR TITLE
[UBSAN_X] Added missing <use> dependencies in BuildFile.xml for HGCalMapping tests and MkFit plugin

### DIFF
--- a/Geometry/HGCalMapping/test/BuildFile.xml
+++ b/Geometry/HGCalMapping/test/BuildFile.xml
@@ -8,6 +8,8 @@
   <use name="CondFormats/DataRecord"/>
   <use name="CondFormats/HGCalObjects"/>
   <use name="Geometry/HGCalMapping"/>
+  <use name="Geometry/CaloTopology"/>
+  <use name="Geometry/HGCalGeometry"/>
   <use name="Geometry/CaloGeometry"/>
   <use name="Geometry/Records"/>
   <use name="FWCore/Framework"/>

--- a/RecoTracker/MkFit/plugins/BuildFile.xml
+++ b/RecoTracker/MkFit/plugins/BuildFile.xml
@@ -25,6 +25,7 @@
   <use name="RecoTracker/MkFit"/>
   <use name="RecoTracker/TkDetLayers"/>
   <use name="RecoTracker/TransientTrackingRecHit"/>
+  <use name="RecoTracker/MeasurementDet"/>
   <use name="TrackingTools/GeomPropagators"/>
   <use name="TrackingTools/KalmanUpdators"/>
   <use name="TrackingTools/MaterialEffects"/>


### PR DESCRIPTION
### Fixed build errors and warnings in HGCalMapping tests and MkFit plugin.
Added the  <use> dependencies in BuildFile.xml:
- Geometry/HGCalGeometry, Geometry/HGCalCommonData, Geometry/CaloTopology for HGCalMapping tests.
- RecoTracker/MeasurementDet for MkFit plugin.