### PR TITLE
Store SiPixelHitStatusAndCharge as 4 bytes in ROOT trees

### DIFF
--- a/DataFormats/TrackingRecHitSoA/interface/SiPixelHitStatus.h
+++ b/DataFormats/TrackingRecHitSoA/interface/SiPixelHitStatus.h
@@ -1,5 +1,5 @@
-#ifndef DataFormats_TrackingRecHitSoA_SiPixelHitStatus_H
-#define DataFormats_TrackingRecHitSoA_SiPixelHitStatus_H
+#ifndef DataFormats_TrackingRecHitSoA_interface_SiPixelHitStatus_h
+#define DataFormats_TrackingRecHitSoA_interface_SiPixelHitStatus_h
 
 #include <cstdint>
 
@@ -12,9 +12,22 @@ struct SiPixelHitStatus {
   uint8_t qBin : 3;  //  ∈[0,1,...,7]
 };
 
-struct SiPixelHitStatusAndCharge {
+static_assert(sizeof(SiPixelHitStatus) == sizeof(uint8_t));
+static_assert(alignof(SiPixelHitStatus) == alignof(uint8_t));
+
+struct alignas(alignof(uint32_t)) SiPixelHitStatusAndCharge {
+#ifdef __CLING__
+  // ROOT does not support the serialisation and deserialisation of bit fields.
+  // See https://github.com/root-project/root/issues/17501 .
+  uint8_t status;
+  uint8_t charge[3];
+#else
   SiPixelHitStatus status;
   uint32_t charge : 24;
+#endif
 };
 
-#endif
+static_assert(sizeof(SiPixelHitStatusAndCharge) == sizeof(uint32_t));
+static_assert(alignof(SiPixelHitStatusAndCharge) == alignof(uint32_t));
+
+#endif  // DataFormats_TrackingRecHitSoA_interface_SiPixelHitStatus_h


### PR DESCRIPTION
#### PR description:

Make SiPixelHitStatusAndCharge appear as 4 bytes during ROOT serialisation, because currently ROOT does not support the serialisation and deserialisation of bit fields. 

#### PR validation:

None.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Might be backported to 15.1.x.