### PR TITLE
Avoid running testWriteReadAlCaRecoTriggerBits in parallel during unit tests

### DIFF
--- a/CondTools/HLT/scripts/run_AlCaRecoTriggerBitsUpdateWorkflow.py
+++ b/CondTools/HLT/scripts/run_AlCaRecoTriggerBitsUpdateWorkflow.py
@@ -116,6 +116,7 @@ def main():
                       help = 'tag to be written')
     parser.add_option('-p', '--processes',
                       dest = 'nproc',
+                      type = "int",
                       default = defaultProc,
                       help = 'multiprocesses to run')
     parser.add_option("-C", '--clean',

--- a/CondTools/HLT/test/BuildFile.xml
+++ b/CondTools/HLT/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="testWriteReadAlCaRecoTriggerBits" command="testWriteReadAlCaRecoTriggerBits.sh -p 1"/>
+<test name="testWriteReadAlCaRecoTriggerBits" command="testWriteReadAlCaRecoTriggerBits.sh -p 2"/>

--- a/CondTools/HLT/test/BuildFile.xml
+++ b/CondTools/HLT/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="testWriteReadAlCaRecoTriggerBits" command="testWriteReadAlCaRecoTriggerBits.sh"/>
+<test name="testWriteReadAlCaRecoTriggerBits" command="testWriteReadAlCaRecoTriggerBits.sh -p 1"/>

--- a/CondTools/HLT/test/testWriteReadAlCaRecoTriggerBits.sh
+++ b/CondTools/HLT/test/testWriteReadAlCaRecoTriggerBits.sh
@@ -14,7 +14,7 @@ check_for_success run_AlCaRecoTriggerBitsUpdateWorkflow.py --help
 ########################################
 # Test update AlCaRecoTriggerBits
 ########################################
-run_AlCaRecoTriggerBitsUpdateWorkflow.py -f frontier://PromptProd/CMS_CONDITIONS -i AlCaRecoHLTpaths8e29_1e31_v24_offline -d AlCaRecoHLTpaths_TEST || die 'failed running run_AlCaRecoTriggerBitsUpdateWorkflow.py' $?
+run_AlCaRecoTriggerBitsUpdateWorkflow.py -f frontier://PromptProd/CMS_CONDITIONS -i AlCaRecoHLTpaths8e29_1e31_v24_offline -d AlCaRecoHLTpaths_TEST "$@" || die 'failed running run_AlCaRecoTriggerBitsUpdateWorkflow.py' $?
 
 ########################################
 # Test read AlCaRecoTriggerBits


### PR DESCRIPTION
This PR suggests to run `run_AlCaRecoTriggerBitsUpdateWorkflow.py` with `-p 1` (one job at a time) to avoid overloading build nodes during IB's unit testing.