### PR TITLE
add new dependencies spotted by UBSAN build

### DIFF
--- a/Geometry/HGCalMapping/test/BuildFile.xml
+++ b/Geometry/HGCalMapping/test/BuildFile.xml
@@ -7,8 +7,10 @@
 <library file="HGCalMapping*.cc" name="GeometryHGCalMappingTesters">
   <use name="CondFormats/DataRecord"/>
   <use name="CondFormats/HGCalObjects"/>
+  <use name="Geometry/HGCalGeometry"/>
   <use name="Geometry/HGCalMapping"/>
   <use name="Geometry/CaloGeometry"/>
+  <use name="Geometry/CaloTopology"/>
   <use name="Geometry/Records"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>

--- a/RecoTracker/MkFit/plugins/BuildFile.xml
+++ b/RecoTracker/MkFit/plugins/BuildFile.xml
@@ -22,6 +22,7 @@
   <use name="Geometry/Records"/>
   <use name="Geometry/TrackerGeometryBuilder"/>
   <use name="PhysicsTools/TensorFlow"/>
+  <use name="RecoTracker/MeasurementDet"/>
   <use name="RecoTracker/MkFit"/>
   <use name="RecoTracker/TkDetLayers"/>
   <use name="RecoTracker/TransientTrackingRecHit"/>


### PR DESCRIPTION
#### PR description:

#49339 and #49148 added some new package dependencies.  These were effectively hidden in normal builds, but caused failures in the UBSAN builds (where more debugging information is required).  These took the form of
```
undefined reference to `typeinfo for HGCalTopology'
undefined reference to `typeinfo for HGCalGeometry'
undefined reference to `typeinfo for MeasurementTracker'
```
This PR adds the missing dependencies.

#### PR validation:

Tested to fix the linking errors in CMSSW_16_0_UBSAN_X_2025-11-19-2300, purely technical build fix.