### PR TITLE
Feature: Simplified and improved Pixel Seed Creation

### DIFF
--- a/RecoTracker/TkSeedGenerator/plugins/ElectronSeedFitter.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/ElectronSeedFitter.cc
@@ -1,0 +1,277 @@
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
+#include "FWCore/Utilities/interface/Likely.h"
+#include "FWCore/Utilities/interface/Visibility.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/EgammaReco/interface/ElectronSeed.h"
+#include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
+#include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
+#include "DataFormats/TrackingRecHit/interface/mayown_ptr.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
+#include "RecoTracker/TkSeedGenerator/interface/FastHelix.h"
+#include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
+#include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
+
+#include "TrackingTools/KalmanUpdators/interface/KFUpdator.h"
+#include "TrackingTools/GeomPropagators/interface/Propagator.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
+
+namespace {
+
+  template <class T>
+  inline T sqr(T t) {
+    return t * t;
+  }
+
+}  // namespace
+
+class dso_hidden ElectronSeedFitter : public edm::stream::EDProducer<> {
+public:
+  ElectronSeedFitter(const edm::ParameterSet&);
+
+  ~ElectronSeedFitter() override = default;
+
+  static void fillDescription(edm::ConfigurationDescriptions& description);
+
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+
+  // initialize the "event dependent state"
+  void init(const edm::EventSetup& es);
+
+  // make job
+  // fill seedCollection with the "ElectronSeedCollection"
+  void makeSeed(reco::ElectronSeedCollection& seedCollection, const reco::ElectronSeed& seed);
+
+private:
+  void initialKinematic(GlobalTrajectoryParameters& kine, const reco::ElectronSeed& seed) const;
+
+  CurvilinearTrajectoryError initialError(float sin2Theta) const dso_hidden;
+
+  void buildSeed(reco::ElectronSeedCollection& seedCollection,
+                 const reco::ElectronSeed& seed,
+                 const FreeTrajectoryState& fts) const dso_hidden;
+
+  SeedingHitSet::RecHitPointer refitHit(SeedingHitSet::ConstRecHitPointer hit,
+                                        const TrajectoryStateOnSurface& state) const dso_hidden;
+
+protected:
+  const edm::EDGetTokenT<reco::ElectronSeedCollection> eleSeedCollectionToken_;
+
+  const std::string propagatorLabel_;
+  const float bOFFMomentum_;
+  const float originTransverseErrorMultiplier_;
+  const float minOneOverPtError_;
+
+  TrackerGeometry const* trackerGeometry_;
+  Propagator const* propagator_;
+  MagneticField const* magneticField_;
+  float nomField_ = 0.;
+  bool isBOFF_ = false;
+  const std::string ttrhBuilder_;
+  const std::string mfName_;
+
+  TkClonerImpl cloner_;
+
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeometryESToken_;
+  const edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorESToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldESToken_;
+  const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> transientTrackingRecHitBuilderESToken_;
+  const edm::EDPutTokenT<reco::ElectronSeedCollection> putToken_;
+};
+
+ElectronSeedFitter::ElectronSeedFitter(const edm::ParameterSet& cfg)
+    : eleSeedCollectionToken_(
+          consumes<reco::ElectronSeedCollection>(cfg.getParameter<edm::InputTag>("eleSeedCollection"))),
+      propagatorLabel_(cfg.getParameter<std::string>("propagator")),
+      bOFFMomentum_(cfg.getParameter<double>("SeedMomentumForBOFF")),
+      originTransverseErrorMultiplier_(cfg.getParameter<double>("OriginTransverseErrorMultiplier")),
+      minOneOverPtError_(cfg.getParameter<double>("MinOneOverPtError")),
+      ttrhBuilder_(cfg.getParameter<std::string>("TTRHBuilder")),
+      mfName_(cfg.getParameter<std::string>("magneticField")),
+      trackerGeometryESToken_(esConsumes()),
+      propagatorESToken_(esConsumes(edm::ESInputTag("", propagatorLabel_))),
+      magneticFieldESToken_(esConsumes(edm::ESInputTag("", mfName_))),
+      transientTrackingRecHitBuilderESToken_(esConsumes(edm::ESInputTag("", ttrhBuilder_))),
+      putToken_{produces()} {}
+
+void ElectronSeedFitter::fillDescription(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<edm::InputTag>("eleSeedCollection", edm::InputTag("hltEgammaFittedElectronPixelSeeds"));
+  desc.add<std::string>("propagator", "PropagatorWithMaterialParabolicMf");
+  desc.add<double>("SeedMomentumForBOFF", 5.0);
+  desc.add<double>("OriginTransverseErrorMultiplier", 1.0);
+  desc.add<double>("MinOneOverPtError", 1.0);
+  desc.add<std::string>("TTRHBuilder", "WithTrackAngle");
+  desc.add<std::string>("magneticField", "ParabolicMf");
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+void ElectronSeedFitter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  init(iSetup);
+
+  const auto& electronSeedsIn = *iEvent.getHandle(eleSeedCollectionToken_);
+
+  auto electronSeedsOut = std::make_unique<reco::ElectronSeedCollection>();
+  electronSeedsOut->reserve(electronSeedsIn.size());
+
+  for (const reco::ElectronSeed& seed : electronSeedsIn) {
+    makeSeed(*electronSeedsOut, seed);
+  }
+
+  electronSeedsOut->shrink_to_fit();
+  iEvent.put(putToken_, std::move(electronSeedsOut));
+}
+
+void ElectronSeedFitter::init(const edm::EventSetup& es) {
+  trackerGeometry_ = &es.getData(trackerGeometryESToken_);
+  propagator_ = &es.getData(propagatorESToken_);
+  magneticField_ = &es.getData(magneticFieldESToken_);
+  nomField_ = magneticField_->nominalValue();
+  isBOFF_ = (0 == nomField_);
+
+  TransientTrackingRecHitBuilder const* transientTrackingRecHitBuilder =
+      &es.getData(transientTrackingRecHitBuilderESToken_);
+  auto builder = (TkTransientTrackingRecHitBuilder const*)(transientTrackingRecHitBuilder);
+  cloner_ = (*builder).cloner();
+}
+
+void ElectronSeedFitter::makeSeed(reco::ElectronSeedCollection& seedCollection, const reco::ElectronSeed& seed) {
+  if (seed.nHits() < 2) {
+    return;
+  }
+
+  GlobalTrajectoryParameters kine;
+  initialKinematic(kine, seed);
+
+  auto sin2Theta = kine.momentum().perp2() / kine.momentum().mag2();
+
+  CurvilinearTrajectoryError error = initialError(sin2Theta);
+  FreeTrajectoryState fts(kine, error);
+
+  buildSeed(seedCollection, seed, fts);
+}
+
+void ElectronSeedFitter::initialKinematic(GlobalTrajectoryParameters& kine, const reco::ElectronSeed& seed) const {
+  const TrackingRecHit& tth1 = *(seed.recHits().begin());
+  const TrackingRecHit& tth2 = *(seed.recHits().begin() + 1);
+
+  const GlobalPoint vertexPos;
+
+  FastHelix helix(tth2.globalPosition(), tth1.globalPosition(), vertexPos, nomField_, magneticField_);
+  if (helix.isValid()) {
+    kine = helix.stateAtVertex();
+  } else {
+    GlobalVector initMomentum(tth2.globalPosition() - vertexPos);
+    initMomentum *= (100.f / initMomentum.perp());
+    kine = GlobalTrajectoryParameters(vertexPos, initMomentum, 1, magneticField_);
+  }
+
+  if UNLIKELY (isBOFF_ && (bOFFMomentum_ > 0)) {
+    kine = GlobalTrajectoryParameters(
+        kine.position(), kine.momentum().unit() * bOFFMomentum_, kine.charge(), magneticField_);
+  }
+}
+
+CurvilinearTrajectoryError ElectronSeedFitter::initialError(float sin2Theta) const {
+  // Set initial uncertainty on track parameters, using only P.V. constraint and no hit information.
+  CurvilinearTrajectoryError newError;  // zeroed
+  auto& C = newError.matrix();
+
+  auto sin2th = sin2Theta;
+  auto minC00 = sqr(minOneOverPtError_);
+  C[0][0] = std::max(sin2th / sqr(1.5f), minC00);
+  auto zErr = sqr(12.5);
+  auto transverseErr = sqr(originTransverseErrorMultiplier_ * 0.2);
+  C[1][1] = C[2][2] = 1.;
+  C[3][3] = transverseErr;
+  C[4][4] = zErr * sin2th + transverseErr * (1.f - sin2th);
+
+  return newError;
+}
+
+void ElectronSeedFitter::buildSeed(reco::ElectronSeedCollection& seedCollection,
+                                   const reco::ElectronSeed& seed,
+                                   const FreeTrajectoryState& fts) const {
+  // get updator
+  KFUpdator updator;
+
+  // Now update initial state track using information from seed hits.
+
+  TrajectoryStateOnSurface updatedState;
+  edm::OwnVector<TrackingRecHit> seedHits;
+
+  TrackingRecHit::id_type lastHitId = 0;
+
+  for (unsigned int iHit = 0; iHit < seed.nHits(); iHit++) {
+    const TrackingRecHit& hit = *(seed.recHits().begin() + iHit);
+    TrajectoryStateOnSurface state =
+        (iHit == 0) ? propagator_->propagate(fts, trackerGeometry_->idToDet(hit.geographicalId())->surface())
+                    : propagator_->propagate(updatedState, trackerGeometry_->idToDet(hit.geographicalId())->surface());
+    if (!state.isValid()) {
+      return;
+    }
+
+    BaseTrackerRecHit const* tth = static_cast<BaseTrackerRecHit const*>(&hit);
+
+    if (not tth) {
+      return;
+    }
+
+    std::unique_ptr<BaseTrackerRecHit> newtth(refitHit(tth, state));
+
+    if (not newtth) {
+      return;
+    }
+
+    updatedState = updator.update(state, *newtth);
+    if (!updatedState.isValid()) {
+      return;
+    }
+
+    lastHitId = hit.geographicalId().rawId();
+    seedHits.push_back(newtth.release());
+  }
+
+  PTrajectoryStateOnDet const& PTraj = trajectoryStateTransform::persistentState(updatedState, lastHitId);
+
+  reco::ElectronSeed eleSeed(TrajectorySeed(PTraj, std::move(seedHits), alongMomentum));
+  const reco::ElectronSeed::CaloClusterRef& caloClusRef(seed.caloCluster());
+  eleSeed.setCaloCluster(caloClusRef);
+  eleSeed.setNrLayersAlongTraj(seed.nrLayersAlongTraj());
+  for (auto const& hitInfo : seed.hitInfo()) {
+    eleSeed.addHitInfo(hitInfo);
+  }
+
+  seedCollection.emplace_back(eleSeed);
+}
+
+SeedingHitSet::RecHitPointer ElectronSeedFitter::refitHit(SeedingHitSet::ConstRecHitPointer hit,
+                                                          const TrajectoryStateOnSurface& state) const {
+  return (SeedingHitSet::RecHitPointer)(cloner_(*hit, state));
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(ElectronSeedFitter);

--- a/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreatorFakeState.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreatorFakeState.cc
@@ -1,0 +1,80 @@
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
+#include "FWCore/Utilities/interface/Likely.h"
+#include "FWCore/Utilities/interface/Visibility.h"
+
+#include "DataFormats/TrackingRecHit/interface/mayown_ptr.h"
+
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
+#include "RecoTracker/TkSeedGenerator/interface/SeedCreator.h"
+#include "RecoTracker/TkSeedingLayers/interface/SeedComparitor.h"
+#include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
+
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
+
+class dso_hidden SeedFromConsecutiveHitsCreatorFakeState : public SeedCreator {
+public:
+  SeedFromConsecutiveHitsCreatorFakeState(const edm::ParameterSet &, edm::ConsumesCollector &&);
+
+  ~SeedFromConsecutiveHitsCreatorFakeState() override = default;
+
+  static void fillDescriptions(edm::ParameterSetDescription &desc);
+  static const char *fillDescriptionsLabel() { return "ConsecutiveHitsSimple"; }
+
+  // initialize the "event dependent state"
+  void init(const TrackingRegion &region, const edm::EventSetup &es, const SeedComparitor *filter) final;
+
+  // make job
+  // fill seedCollection with the "TrajectorySeed"
+  void makeSeed(TrajectorySeedCollection &seedCollection, const SeedingHitSet &hits) final;
+
+protected:
+  const TrackingRegion *region = nullptr;
+  const SeedComparitor *filter = nullptr;
+};
+
+SeedFromConsecutiveHitsCreatorFakeState::SeedFromConsecutiveHitsCreatorFakeState(const edm::ParameterSet &cfg,
+                                                                                 edm::ConsumesCollector &&iC) {}
+
+void SeedFromConsecutiveHitsCreatorFakeState::fillDescriptions(edm::ParameterSetDescription &desc) {}
+
+void SeedFromConsecutiveHitsCreatorFakeState::init(const TrackingRegion &iregion,
+                                                   const edm::EventSetup &es,
+                                                   const SeedComparitor *ifilter) {
+  region = &iregion;
+  filter = ifilter;
+}
+
+void SeedFromConsecutiveHitsCreatorFakeState::makeSeed(TrajectorySeedCollection &seedCollection,
+                                                       const SeedingHitSet &hits) {
+  if (hits.size() < 2)
+    return;
+
+  edm::OwnVector<TrackingRecHit> seedHits;
+
+  const TrackingRecHit *hit = nullptr;
+  for (unsigned int iHit = 0; iHit < hits.size(); iHit++) {
+    hit = hits[iHit]->hit();
+    if (!hit) {
+      continue;
+    }
+    seedHits.push_back(*hit);
+  }
+
+  // Since there is no valid state with valid trajectory parameters, the trajectory state creation is faked
+  PTrajectoryStateOnDet const fakePTraj = PTrajectoryStateOnDet();
+
+  seedCollection.emplace_back(fakePTraj, std::move(seedHits), alongMomentum);
+}
+
+#include "RecoTracker/TkSeedGenerator/interface/SeedCreatorFromRegionHitsEDProducerT.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+using FakeStateSeedCreatorFromRegionConsecutiveHitsEDProducer =
+    SeedCreatorFromRegionHitsEDProducerT<SeedFromConsecutiveHitsCreatorFakeState>;
+DEFINE_FWK_MODULE(FakeStateSeedCreatorFromRegionConsecutiveHitsEDProducer);


### PR DESCRIPTION
#### PR description:

This PR adds two new producers with the goal of speeding up the PixelSeed generation for the EGamma reconstruction.

Extensive analysis of the `ElectronNHitSeedProducer`, which is the first producer consuming the `TrajectorySeeds` which are the product of the `SeedCreatorFromRegionConsecutiveHitsEDProducer` during the EGamma reconstruction showed that the `ElectronNHitSeedProducer` only really needs the hit collection in the seeds, but not fitted information or a proper `TrajectoryStateOnSurface`. However, the `SeedCreatorFromRegionConsecutiveHitsEDProducer` fits **all** seed candidates, thus potentially wasting a lot of compute resources on seeds that will discarded in the next step without ever checking the fitted information (the state).

The two producers introduced in this PR:
1. Produce simplified `TrajectorySeed` objects by just taking the collection of hits in the `SeedingHitSet`s and creating a dummy `PTrajectoryStateOnDet` to have valid information in the state. This is done by the `SeedFromConsecutiveHitsCreatorSimple`.
2. Fit the seeds selected by the `ElectronNHitSeedProducer` and produce a new `ElectronSeedCollection` with proper state information in the `PTrajectoryStateOnDet`. This is done by the `SeedFitter`

The subsequent producers in the path then can use the fitted information as usual. The features have been presented [in the GPU meeting on 17.11.2025](https://indico.cern.ch/event/1613298/#4-update-on-electron-seeding). As a lot of unnecessary work is omitted, the seed creation is expected to be significantly faster, but reliable timing studies are still pending. First tests show that the physics performance is essentially unchanged. Few differences arise from the fact that the `TrajectorySeed` objects produced by the default `SeedFromConsecutiveHitsCreator` contain the hit information updated in the fit, while the new implementation directly uses the existing hit, and the difference in position can sometimes be large enough for a seed to be rejected or not in the `ElectronNHitSeedProducer`. More detailed physics performance studies will follow.

This PR will also lay the ground for a later Alpaka based version of the`ElectronNHitSeedProducer`, which will operate on the simple seed objects without fit information, too. The new feature could potentially be used in the 2026 data taking to speed up the seed creation.

#### PR validation:

Basic test of the physics performance of the newly introduced producers with an adapted HLT chain. 