### PR TITLE
Move default Run 4 workflows to D121

### DIFF
--- a/CondTools/Geometry/test/calogeometryRun4writer.py
+++ b/CondTools/Geometry/test/calogeometryRun4writer.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 process = cms.Process("CaloGeometryWriter",Phase2C17I13M9)
 process.load('CondCore.CondDB.CondDB_cfi')
-process.load('Configuration.Geometry.GeometryExtendedRun4D110_cff')
+process.load('Configuration.Geometry.GeometryExtendedRun4D121_cff')
 process.load('Geometry.CaloEventSetup.CaloGeometryRun4DBWriter_cfi')
 process.load('CondTools.Geometry.HcalParametersWriter_cff')
 

--- a/CondTools/Geometry/test/calogeometryRun4writer.py
+++ b/CondTools/Geometry/test/calogeometryRun4writer.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
-process = cms.Process("CaloGeometryWriter",Phase2C17I13M9)
+from Configuration.Eras.Era_Phase2C22I13M9_cff import Phase2C22I13M9
+process = cms.Process("CaloGeometryWriter",Phase2C22I13M9)
 process.load('CondCore.CondDB.CondDB_cfi')
 process.load('Configuration.Geometry.GeometryExtendedRun4D121_cff')
 process.load('Geometry.CaloEventSetup.CaloGeometryRun4DBWriter_cfi')

--- a/CondTools/Geometry/test/hgcalgeometrywriter.py
+++ b/CondTools/Geometry/test/hgcalgeometrywriter.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
-process = cms.Process("HGCalGeometryWriter",Phase2C17I13M9)
+from Configuration.Eras.Era_Phase2C22I13M9_cff import Phase2C22I13M9
+process = cms.Process("HGCalGeometryWriter",Phase2C22I13M9)
 process.load('CondCore.CondDB.CondDB_cfi')
 process.load('Configuration.Geometry.GeometryExtendedRun4D121_cff')
 

--- a/CondTools/Geometry/test/hgcalgeometrywriter.py
+++ b/CondTools/Geometry/test/hgcalgeometrywriter.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 process = cms.Process("HGCalGeometryWriter",Phase2C17I13M9)
 process.load('CondCore.CondDB.CondDB_cfi')
-process.load('Configuration.Geometry.GeometryExtendedRun4D110_cff')
+process.load('Configuration.Geometry.GeometryExtendedRun4D121_cff')
 
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),

--- a/CondTools/Geometry/test/me0geometrywriter.py
+++ b/CondTools/Geometry/test/me0geometrywriter.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 process = cms.Process("ME0GeometryWriter",Phase2C17I13M9)
 process.load('CondCore.CondDB.CondDB_cfi')
-process.load('Configuration.Geometry.GeometryExtendedRun4D110_cff')
+process.load('Configuration.Geometry.GeometryExtendedRun4D121_cff')
 process.load('Geometry.MuonNumbering.muonNumberingInitialization_cfi')
 process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
 process.load('Configuration.StandardSequences.DD4hep_GeometrySimPhase2_cff')

--- a/CondTools/Geometry/test/me0geometrywriter.py
+++ b/CondTools/Geometry/test/me0geometrywriter.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
-process = cms.Process("ME0GeometryWriter",Phase2C17I13M9)
+from Configuration.Eras.Era_Phase2C22I13M9_cff import Phase2C22I13M9
+process = cms.Process("ME0GeometryWriter",Phase2C22I13M9)
 process.load('CondCore.CondDB.CondDB_cfi')
 process.load('Configuration.Geometry.GeometryExtendedRun4D121_cff')
 process.load('Geometry.MuonNumbering.muonNumberingInitialization_cfi')

--- a/CondTools/Geometry/test/writehelpers/geometryExtendedRun4_writer.py
+++ b/CondTools/Geometry/test/writehelpers/geometryExtendedRun4_writer.py
@@ -9,7 +9,7 @@ process.load('CondCore.CondDB.CondDB_cfi')
 # 2) GEM, if Configuration.Geometry.GeometryExtendedRun4D77_cff is used (ScenarioRun4D77 has to be set in DD4hep_GeometrySimPhase2_cff)  
 # Please add the right Scenario (D110 or ..) also in geometryExtendedRun4_xmlwriter.py and in splitExtendedRun4Database.sh 
 #
-process.load('Configuration.Geometry.GeometryExtendedRun4D110_cff')
+process.load('Configuration.Geometry.GeometryExtendedRun4D121_cff')
 process.load('Geometry.MuonNumbering.muonNumberingInitialization_cfi')
 process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
 process.load('Configuration.StandardSequences.DD4hep_GeometrySimPhase2_cff')
@@ -51,7 +51,7 @@ process.CondDB.timetype = cms.untracked.string('runnumber')
 process.CondDB.connect = cms.string('sqlite_file:myfile.db')
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           process.CondDB,
-                                          toPut = cms.VPSet(cms.PSet(record = cms.string('GeometryFileRcd'), tag = cms.string('XMLFILE_Geometry_TagXX_ExtendedRun4D110_mc')),
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string('GeometryFileRcd'), tag = cms.string('XMLFILE_Geometry_TagXX_ExtendedRun4D121_mc')),
                                                             cms.PSet(record = cms.string('IdealGeometryRecord'), tag = cms.string('TKRECO_Geometry_TagXX')),
                                                             cms.PSet(record = cms.string('PTrackerParametersRcd'), tag = cms.string('TKParameters_Geometry_TagXX')),
                                                             cms.PSet(record = cms.string('PTrackerAdditionalParametersPerDetRcd'), tag = cms.string('TKAdditionalParametersPerDet_Geometry_TagXX')),

--- a/CondTools/Geometry/test/writehelpers/geometryExtendedRun4_xmlwriter.py
+++ b/CondTools/Geometry/test/writehelpers/geometryExtendedRun4_xmlwriter.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("GeometryXMLWriter")
 
-process.load('Configuration.Geometry.GeometryExtendedRun4D110_cff')
+process.load('Configuration.Geometry.GeometryExtendedRun4D121_cff')
 
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),
@@ -13,7 +13,7 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.BigXMLWriter = cms.EDAnalyzer("OutputDDToDDL",
                               rotNumSeed = cms.int32(0),
-                              fileName = cms.untracked.string("./geD110SingleBigFile.xml")
+                              fileName = cms.untracked.string("./geD121SingleBigFile.xml")
                               )
 
 

--- a/CondTools/Geometry/test/writehelpers/splitExtendedRun4Database.sh
+++ b/CondTools/Geometry/test/writehelpers/splitExtendedRun4Database.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-conddb -f sqlite_file:myfile.db -c sqlite_file:GeometryFileExtendedRun4D110.db -t XMLFILE_Geometry_TagXX_ExtendedRun4D110_mc -i XMLFILE_Geometry_TagXX_ExtendedRun4D110_mc
+conddb -f sqlite_file:myfile.db -c sqlite_file:GeometryFileExtendedRun4D121.db -t XMLFILE_Geometry_TagXX_ExtendedRun4D121_mc -i XMLFILE_Geometry_TagXX_ExtendedRun4D121_mc
 conddb -f sqlite_file:myfile.db -c sqlite_file:TKRECO_Geometry.db -t TKRECO_Geometry_TagXX -i TKRECO_Geometry_TagXX
 conddb -f sqlite_file:myfile.db -c sqlite_file:TKParameters_Geometry.db -t TKParameters_Geometry_TagXX -i TKParameters_Geometry_TagXX
 conddb -f sqlite_file:myfile.db -c sqlite_file:EBRECO_Geometry.db -t EBRECO_Geometry_TagXX -i EBRECO_Geometry_TagXX

--- a/Configuration/PyReleaseValidation/python/relval_Run4.py
+++ b/Configuration/PyReleaseValidation/python/relval_Run4.py
@@ -11,7 +11,7 @@ workflows = Matrix()
 from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgrade_workflows
 
 #just define all of them
-prefixDet = 29600 #update this line when change the default version
+prefixDet = 34400 #update this line when change the default version
 
 #Run4 WFs to run in IB (TTbar)
 numWFIB = []

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4768,7 +4768,7 @@ defaultDataSets['Run4D95']='CMSSW_13_1_0_pre1-130X_mcRun4_realistic_v2_2026D95no
 defaultDataSets['Run4D96']='CMSSW_13_1_0_pre1-130X_mcRun4_realistic_v2_2026D96noPU-v'
 defaultDataSets['Run4D98']='CMSSW_13_2_0_pre1-131X_mcRun4_realistic_v5_2026D98noPU-v'
 defaultDataSets['Run4D110']='CMSSW_15_1_0_pre5-150X_mcRun4_realistic_v1_STD_RegeneratedGS_Run4D110_noPU-v'
-defaultDataSets['Run4D121']=''
+defaultDataSets['Run4D121']='CMSSW_16_0_0_pre2-150X_mcRun4_realistic_v1_STD_RegeneratedGS_Run4D121_noPU-v'
 
 ## HIN
 defaultDataSets['2023HIN']='CCMSSW_14_1_0-PU_140X_mcRun3_2023_realistic_HI_v4_STD_2023HIN_PU-v'

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4768,6 +4768,7 @@ defaultDataSets['Run4D95']='CMSSW_13_1_0_pre1-130X_mcRun4_realistic_v2_2026D95no
 defaultDataSets['Run4D96']='CMSSW_13_1_0_pre1-130X_mcRun4_realistic_v2_2026D96noPU-v'
 defaultDataSets['Run4D98']='CMSSW_13_2_0_pre1-131X_mcRun4_realistic_v5_2026D98noPU-v'
 defaultDataSets['Run4D110']='CMSSW_15_1_0_pre5-150X_mcRun4_realistic_v1_STD_RegeneratedGS_Run4D110_noPU-v'
+defaultDataSets['Run4D121']=''
 
 ## HIN
 defaultDataSets['2023HIN']='CCMSSW_14_1_0-PU_140X_mcRun3_2023_realistic_HI_v4_STD_2023HIN_PU-v'

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -7,6 +7,7 @@ from Configuration.PyReleaseValidation.MatrixReader import MatrixReader
 from Configuration.PyReleaseValidation.MatrixRunner import MatrixRunner
 from Configuration.PyReleaseValidation.MatrixInjector import MatrixInjector,performInjectionOptionTest
 from Configuration.PyReleaseValidation.MatrixUtil import cleanComputeCapabilities
+from Configuration.PyReleaseValidation.relval_Run4 import prefixDet
 # ================================================================================
 
 def showRaw(opt):
@@ -133,13 +134,13 @@ if __name__ == '__main__':
         'phase2' : [
             ###### MC (generated from scratch or from RelVals)
             # Phase2
-            29634.0,    # RelValTTbar_14TeV                     phase2_realistic_T33        ExtendedRun4D110         (Phase-2 baseline)
-            29634.911,  # TTbar_14TeV_TuneCP5                   phase2_realistic_T33        DD4hepExtendedRun4D110   DD4Hep (HLLHC14TeV BeamSpot)
-            29834.999,  # RelValTTbar_14TeV (PREMIX)            phase2_realistic_T33        ExtendedRun4D110         AVE_50_BX_25ns_m3p3
-            29696.0,    # RelValCloseByPGun_CE_E_Front_120um    phase2_realistic_T33        ExtendedRun4D110
-            29700.0,    # RelValCloseByPGun_CE_H_Coarse_Scint   phase2_realistic_T33        ExtendedRun4D110
+            prefixDet+34.0,    # RelValTTbar_14TeV                     phase2_realistic_T33        ExtendedRun4D121         (Phase-2 baseline)
+            prefixDet+34.911,  # TTbar_14TeV_TuneCP5                   phase2_realistic_T33        DD4hepExtendedRun4D121   DD4Hep (HLLHC14TeV BeamSpot)
+            prefixDet+234.999, # RelValTTbar_14TeV (PREMIX)            phase2_realistic_T33        ExtendedRun4D121         AVE_50_BX_25ns_m3p3
+            prefixDet+96.0,    # RelValCloseByPGun_CE_E_Front_120um    phase2_realistic_T33        ExtendedRun4D121
+            prefixDet+100.0,   # RelValCloseByPGun_CE_H_Coarse_Scint   phase2_realistic_T33        ExtendedRun4D121
             #23234.0,   # Need new workflow with HFNose
-            29634.75,   # RelValTTbar_14TeV                     phase2_realistic_T33        ExtendedRun4D110         (Phase-2 baseline -  but using timing menu, and only up to step 2)
+            prefixDet+34.75,   # RelValTTbar_14TeV                     phase2_realistic_T33        ExtendedRun4D121         (Phase-2 baseline -  but using timing menu, and only up to step 2)
         ],
 
         'heavyIons' : [
@@ -155,28 +156,28 @@ if __name__ == '__main__':
         'metmc' : [5.1, 15, 25, 37, 38, 39], #MC
         'muonmc' : [5.1, 124.4, 124.5, 20, 21, 22, 23, 25, 30], #MC
 
-        'ph2_hlt' : [29634.75,    # HLT phase-2 timing menu
-                     29634.7501,  # HLT phase-2 tracking-only menu
-                     29634.751,   # HLT phase-2 timing menu Alpaka variant
-                     29634.7511,  # HLT phase-2 timing menu Phase2CAExtension variant
-                     29634.752,   # HLT phase-2 timing menu ticl_v5 variant
-                     29634.753,   # HLT phase-2 timing menu Alpaka, single tracking iteration variant
-                     29634.754,   # HLT phase-2 timing menu Alpaka, single tracking iteration, LST building variant
-                     29634.755,   # HLT phase-2 timing menu Alpaka, LST building variant
-                     29634.756,   # HLT phase-2 timing menu trimmed tracking
-                     29634.7561,  # HLT phase-2 timing menu Alpaka, trimmed tracking
-                     29634.7562,  # HLT phase-2 timing menu Alpaka, trimmed tracking, single tracking iteration variant
-                     29634.757,   # HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + CKF building variant
-                     29634.7571,  # HLT phase-2 timing menu Alpaka, single tracking iteration, Phase2CAExtension+LST seeding + mkFit building variant
-                     29634.7572,  # HLT phase-2 timing menu Alpaka, single tracking iteration, Phase2CAExtension+LST seeding + mkFit building and fitting variant
-                     29634.758,   # HLT phase-2 timing menu ticl_barrel variant
-                     29634.759,   # HLT phase-2 timing menu, with NANO:@Phase2HLT
-                     29634.77,    # HLT phase-2 NGT Scouting menu
-                     29634.771,   # HLT phase-2 NGT Scouting menu, Alpaka, TICL-v5, TICL-Barrel, CA Extension
-                     29634.772,   # HLT phase-2 NGT Scouting menu, with NANO:@NGTScouting
-                     29634.773,   # HLT phase-2 NGT Scouting menu, with NANO:@NGTScoutingVal
-                     29634.774,   # HLT phase-2 NGT Scouting menu, Phase2CAExtension as GeneralTracks
-                     29634.775],  # HLT phase-2 NGT Scouting menu, Phase2CAExtension&LSTT5 as GeneralTracks
+        'ph2_hlt' : [prefixDet+34.75,    # HLT phase-2 timing menu
+                     prefixDet+34.7501,  # HLT phase-2 tracking-only menu
+                     prefixDet+34.751,   # HLT phase-2 timing menu Alpaka variant
+                     prefixDet+34.7511,  # HLT phase-2 timing menu Phase2CAExtension variant
+                     prefixDet+34.752,   # HLT phase-2 timing menu ticl_v5 variant
+                     prefixDet+34.753,   # HLT phase-2 timing menu Alpaka, single tracking iteration variant
+                     prefixDet+34.754,   # HLT phase-2 timing menu Alpaka, single tracking iteration, LST building variant
+                     prefixDet+34.755,   # HLT phase-2 timing menu Alpaka, LST building variant
+                     prefixDet+34.756,   # HLT phase-2 timing menu trimmed tracking
+                     prefixDet+34.7561,  # HLT phase-2 timing menu Alpaka, trimmed tracking
+                     prefixDet+34.7562,  # HLT phase-2 timing menu Alpaka, trimmed tracking, single tracking iteration variant
+                     prefixDet+34.757,   # HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + CKF building variant
+                     prefixDet+34.7571,  # HLT phase-2 timing menu Alpaka, single tracking iteration, Phase2CAExtension+LST seeding + mkFit building variant
+                     prefixDet+34.7572,  # HLT phase-2 timing menu Alpaka, single tracking iteration, Phase2CAExtension+LST seeding + mkFit building and fitting variant
+                     prefixDet+34.758,   # HLT phase-2 timing menu ticl_barrel variant
+                     prefixDet+34.759,   # HLT phase-2 timing menu, with NANO:@Phase2HLT
+                     prefixDet+34.77,    # HLT phase-2 NGT Scouting menu
+                     prefixDet+34.771,   # HLT phase-2 NGT Scouting menu, Alpaka, TICL-v5, TICL-Barrel, CA Extension
+                     prefixDet+34.772,   # HLT phase-2 NGT Scouting menu, with NANO:@NGTScouting
+                     prefixDet+34.773,   # HLT phase-2 NGT Scouting menu, with NANO:@NGTScoutingVal
+                     prefixDet+34.774,   # HLT phase-2 NGT Scouting menu, Phase2CAExtension as GeneralTracks
+                     prefixDet+34.775],  # HLT phase-2 NGT Scouting menu, Phase2CAExtension&LSTT5 as GeneralTracks
     }
 
     predefinedSet['limited'] = (

--- a/Configuration/StandardSequences/python/DD4hep_GeometrySimPhase2_cff.py
+++ b/Configuration/StandardSequences/python/DD4hep_GeometrySimPhase2_cff.py
@@ -1,3 +1,3 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Geometry.GeometryDD4hepExtendedRun4D110_cff import *
+from Configuration.Geometry.GeometryDD4hepExtendedRun4D121_cff import *


### PR DESCRIPTION
#### PR description:

This PR is intended to complete the update of the default Run 4 geometry to D121, started in #48297.

#### PR validation:

runTheMatrix.py lists the correct workflows.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport. Can be backported upon request, but no immediate needs are foreseen.