### PR TITLE
PF Offline DQM MiniAOD compatibility and jet calibration addition

### DIFF
--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
@@ -406,7 +406,7 @@ void PFAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
   }
 
   std::string histName = Form("NPV");
-  MonitorElement* mHist = ibooker.book1D(histName, Form(";%s;", "N_PV"), 100, 0, 100);
+  MonitorElement* mHist = ibooker.book1D(histName, Form(";%s;", "N_PV"), 180, 0, 180);
   map_of_MEs.insert(std::pair<std::string, MonitorElement*>(m_directory + "/" + histName, mHist));
 }
 

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
@@ -7,6 +7,8 @@
  */
 
 #include "DQMOffline/ParticleFlow/plugins/PFAnalyzer.h"
+#include <iostream>
+#include <stdio.h>
 
 // ***********************************************************
 PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
@@ -15,10 +17,15 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
 
   thePfCandidateCollection_ = consumes<reco::PFCandidateCollection>(pSet.getParameter<edm::InputTag>("pfCandidates"));
   pfJetsToken_ = consumes<reco::PFJetCollection>(pSet.getParameter<edm::InputTag>("pfJetCollection"));
+  // Jets calibration
+  jetCorrectorTag_ = pSet.getParameter<edm::InputTag>("JetCorrections");
+
 
   theTriggerResultsLabel_ = pSet.getParameter<edm::InputTag>("TriggerResultsLabel");
+  m_selection = pSet.getParameter<std::string>("eventSelection");
+
   triggerResultsToken_ = consumes<edm::TriggerResults>(edm::InputTag(theTriggerResultsLabel_));
-  highPtJetExpr_ = pSet.getParameter<edm::InputTag>("TriggerName");
+  m_triggerOptions = pSet.getParameter<vstring>("TriggerNames");
 
   srcWeights = pSet.getParameter<edm::InputTag>("srcWeights");
   weightsToken_ = consumes<edm::ValueMap<float>>(srcWeights);
@@ -36,8 +43,14 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
 
   // List of cuts applied to PFCs that we want to plot
   m_cutList = parameters_.getParameter<vstring>("cutList");
+  m_cutList2D = parameters_.getParameter<vstring>("binList2D");
   // List of jet cuts that we apply for the case of plotting PFCs in jets
   m_jetCutList = parameters_.getParameter<vstring>("jetCutList");
+
+  m_eventSelectionMap["none"] = &passesEventSelection;
+  m_eventSelectionMap["dijet"] = &passesDijetSelection;
+  m_eventSelectionMap["nocut"] = &passesNoCutSelection;
+  m_eventSelectionMap["anomalous"] = &passesAnomalousSelection;
 
   // Link observable strings to the static functions defined in the header file
   // Many of these are quite trivial, but this enables a simple way to include a
@@ -45,6 +58,7 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   m_funcMap["pt"] = &getPt;
   m_funcMap["energy"] = getEnergy;
   m_funcMap["eta"] = getEta;
+  m_funcMap["abseta"] = getAbsEta;
   m_funcMap["phi"] = getPhi;
 
   m_funcMap["HCalE_depth1"] = getHcalEnergy_depth1;
@@ -54,6 +68,11 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   m_funcMap["HCalE_depth5"] = getHcalEnergy_depth5;
   m_funcMap["HCalE_depth6"] = getHcalEnergy_depth6;
   m_funcMap["HCalE_depth7"] = getHcalEnergy_depth7;
+
+
+  m_funcMap["PS1_E"] = getPS1Energy;
+  m_funcMap["PS2_E"] = getPS2Energy;
+  m_funcMap["PS_E"] = getPSEnergy;
 
   m_funcMap["ECal_E"] = getEcalEnergy;
   m_funcMap["RawECal_E"] = getRawEcalEnergy;
@@ -81,14 +100,37 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   m_funcMap["eOverP"] = getEoverP;
   m_funcMap["nTrkInBlock"] = getNTracksInBlock;
 
+  m_funcMap["trk_nStripHits"] = getTrackNStripHits;
+  m_funcMap["trk_nPixHits"] = getTrackNPixHits;
+  m_funcMap["trk_chi2"] = getTrackChi2;
+  m_funcMap["trk_ptError"] = getTrackPtError;
+  m_funcMap["trk_relPtError"] = getTrackRelPtError;
+  m_funcMap["trk_d0"] = getTrackD0;
+  m_funcMap["trk_z0"] = getTrackZ0;
+  m_funcMap["trk_thetaError"] = getTrackThetaError;
+  m_funcMap["trk_etaError"] = getTrackEtaError;
+  m_funcMap["trk_phiError"] = getTrackPhiError;
+
   m_eventFuncMap["NPFC"] = getNPFC;
+  m_eventFuncMap["MaxPtFrac"] = getMaxPt;
   m_jetWideFuncMap["NPFC"] = getNPFCinJet;
+  m_jetWideFuncMap["MaxPtFrac"] = getMaxPtFracJet;
 
   m_pfInJetFuncMap["PFSpectrum"] = getEnergySpectrum;
 
   // Link jet observables to static functions in the header file.
   // This is very similar to m_funcMap, but for jets instead.
   m_jetFuncMap["pt"] = getJetPt;
+  m_jetFuncMap["chargeFrac"] = getJetChargeFrac;
+
+
+  m_particleTypeName[reco::PFCandidate::ParticleType::h]  = "chargedHadPFC";
+  m_particleTypeName[reco::PFCandidate::ParticleType::h0]  = "neutralHadPFC";
+  m_particleTypeName[reco::PFCandidate::ParticleType::e]  = "electronPFC";
+  m_particleTypeName[reco::PFCandidate::ParticleType::mu]  = "muonPFC";
+  m_particleTypeName[reco::PFCandidate::ParticleType::gamma]  = "gammaPFC";
+  m_particleTypeName[reco::PFCandidate::ParticleType::h_HF]  = "hadHFPFC";
+  m_particleTypeName[reco::PFCandidate::ParticleType::egamma_HF]  = "emHFPFC";
 
   // Convert the cutList strings into real cuts that can be applied
   // The format should be three comma separated values
@@ -98,8 +140,8 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   //
   for (unsigned int i = 0; i < m_cutList.size(); i++) {
     m_fullCutList.push_back(std::vector<std::string>());
-    while (m_cutList[i].find(']') != std::string::npos) {
-      size_t pos = m_cutList[i].find(']');
+    while (m_cutList[i].find("]") != std::string::npos) {
+      size_t pos = m_cutList[i].find("]");
       m_fullCutList[i].push_back(m_cutList[i].substr(1, pos));
       m_cutList[i].erase(0, pos + 1);
     }
@@ -108,12 +150,34 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   for (unsigned int i = 0; i < m_fullCutList.size(); i++) {
     m_binList.push_back(std::vector<std::vector<double>>());
     for (unsigned int j = 0; j < m_fullCutList[i].size(); j++) {
-      size_t pos = m_fullCutList[i][j].find(';');
+      size_t pos = m_fullCutList[i][j].find(";");
       std::string observableName = m_fullCutList[i][j].substr(0, pos);
       m_fullCutList[i][j].erase(0, pos + 1);
 
       m_binList[i].push_back(getBinList(m_fullCutList[i][j]));
       m_fullCutList[i][j] = observableName;
+    }
+  }
+
+
+  for (unsigned int i = 0; i < m_cutList2D.size(); i++) {
+    m_fullCutList2D.push_back(std::vector<std::string>());
+    while (m_cutList2D[i].find("]") != std::string::npos) {
+      size_t pos = m_cutList2D[i].find("]");
+      m_fullCutList2D[i].push_back(m_cutList2D[i].substr(1, pos));
+      m_cutList2D[i].erase(0, pos + 1);
+    }
+  }
+
+  for (unsigned int i = 0; i < m_fullCutList2D.size(); i++) {
+    m_binList2D.push_back(std::vector<std::vector<double>>());
+    for (unsigned int j = 0; j < m_fullCutList2D[i].size(); j++) {
+      size_t pos = m_fullCutList2D[i][j].find(";");
+      std::string observableName = m_fullCutList2D[i][j].substr(0, pos);
+      m_fullCutList2D[i][j].erase(0, pos + 1);
+
+      m_binList2D[i].push_back(getBinList(m_fullCutList2D[i][j]));
+      m_fullCutList2D[i][j] = observableName;
     }
   }
 
@@ -125,8 +189,8 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   //
   for (unsigned int i = 0; i < m_jetCutList.size(); i++) {
     m_fullJetCutList.push_back(std::vector<std::string>());
-    while (m_jetCutList[i].find(']') != std::string::npos) {
-      size_t pos = m_jetCutList[i].find(']');
+    while (m_jetCutList[i].find("]") != std::string::npos) {
+      size_t pos = m_jetCutList[i].find("]");
       m_fullJetCutList[i].push_back(m_jetCutList[i].substr(1, pos));
       m_jetCutList[i].erase(0, pos + 1);
     }
@@ -135,7 +199,7 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   for (unsigned int i = 0; i < m_fullJetCutList.size(); i++) {
     m_jetBinList.push_back(std::vector<std::vector<double>>());
     for (unsigned int j = 0; j < m_fullJetCutList[i].size(); j++) {
-      size_t pos = m_fullJetCutList[i][j].find(';');
+      size_t pos = m_fullJetCutList[i][j].find(";");
       std::string observableName = m_fullJetCutList[i][j].substr(0, pos);
       m_fullJetCutList[i][j].erase(0, pos + 1);
 
@@ -158,6 +222,25 @@ void PFAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
 
   for (unsigned int i = 0; i < m_fullJetCutList.size(); i++) {
     m_allJetSuffixes.push_back(getAllSuffixes(m_fullJetCutList[i], m_jetBinList[i]));
+  }
+
+  // Books a 2D histogram for each histogram in the config file.
+  // The format for the observables should be four comma separated values,
+  // with the first being the observable name (corresponding to one of
+  // the keys in m_funcMap), the second being the number of bins,
+  // and the last two being the min and max value for the histogram respectively.
+
+  for(unsigned int i=0; i<m_fullCutList2D.size(); i++){
+    // Loop over all of the different types of PF candidates
+    for (unsigned int m = 0; m < m_pfNames.size(); m++) {
+      // For each observable, we make a couple histograms based on a few generic categorizations.
+      // In all cases, the PFCs that go into these histograms must pass the PFC selection from m_cutList.
+      std::string histName = Form("%s_%s_%s",
+                                  m_pfNames[m].c_str(), m_fullCutList2D[i][0].c_str(), m_fullCutList2D[i][1].c_str());
+      MonitorElement* mHist = ibooker.book2D(
+          histName, Form(";%s;%s", m_fullCutList2D[i][0].c_str(), m_fullCutList2D[i][1].c_str()), m_binList2D[i][0].size(), m_binList2D[i][0][0], m_binList2D[i][0][m_binList2D[i][0].size()-1], m_binList2D[i][1].size(), m_binList2D[i][1][0], m_binList2D[i][1][m_binList2D[i][0].size()-1]);
+      map_of_MEs.insert(std::pair<std::string, MonitorElement*>(m_directory + "/" + histName, mHist));
+    }
   }
 
   for (unsigned int npv = 0; npv < m_npvBins.size() - 1; npv++) {
@@ -219,31 +302,31 @@ void PFAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
     // Do the same for global observables (things like the number of PFCs in an event, or in a jet, etc)
     for (unsigned int i = 0; i < m_eventObservables.size(); i++) {
       std::string cEventObservable = m_eventObservables[i];
-      size_t pos = cEventObservable.find(';');
+      size_t pos = cEventObservable.find(";");
       std::string observableName = cEventObservable.substr(0, pos);
       cEventObservable.erase(0, pos + 1);
 
-      pos = cEventObservable.find(';');
+      pos = cEventObservable.find(";");
       std::string axisString = cEventObservable.substr(0, pos);
       cEventObservable.erase(0, pos + 1);
 
-      pos = cEventObservable.find(';');
+      pos = cEventObservable.find(";");
       int nBins = atoi(cEventObservable.substr(0, pos).c_str());
       cEventObservable.erase(0, pos + 1);
 
-      pos = cEventObservable.find(';');
+      pos = cEventObservable.find(";");
       float binMin = atof(cEventObservable.substr(0, pos).c_str());
       cEventObservable.erase(0, pos + 1);
 
-      pos = cEventObservable.find(';');
+      pos = cEventObservable.find(";");
       float binMax = atof(cEventObservable.substr(0, pos).c_str());
       cEventObservable.erase(0, pos + 1);
 
-      pos = cEventObservable.find(';');
+      pos = cEventObservable.find(";");
       int nBinsJet = atoi(cEventObservable.substr(0, pos).c_str());
       cEventObservable.erase(0, pos + 1);
 
-      pos = cEventObservable.find(';');
+      pos = cEventObservable.find(";");
       float binMinJet = atof(cEventObservable.substr(0, pos).c_str());
       cEventObservable.erase(0, pos + 1);
 
@@ -333,20 +416,20 @@ void PFAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
 PFAnalyzer::binInfo PFAnalyzer::getBinInfo(std::string observableString) {
   PFAnalyzer::binInfo binningDetails;
 
-  size_t pos = observableString.find(';');
+  size_t pos = observableString.find(";");
   binningDetails.observable = observableString.substr(0, pos);
   observableString.erase(0, pos + 1);
 
   std::vector<double> binList = getBinList(observableString);
-  pos = observableString.find(';');
+  pos = observableString.find(";");
   binningDetails.axisName = observableString.substr(0, pos);
   observableString.erase(0, pos + 1);
 
-  pos = observableString.find(';');
+  pos = observableString.find(";");
   binningDetails.nBins = atoi(observableString.substr(0, pos).c_str());
   observableString.erase(0, pos + 1);
 
-  pos = observableString.find(';');
+  pos = observableString.find(";");
   binningDetails.binMin = atof(observableString.substr(0, pos).c_str());
   observableString.erase(0, pos + 1);
 
@@ -362,7 +445,6 @@ void PFAnalyzer::bookMESetSelection(std::string DirName, DQMStore::IBooker& iboo
 // ***********************************************************
 void PFAnalyzer::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {}
 
-bool PFAnalyzer::passesEventSelection(const edm::Event& iEvent) { return true; }
 
 // How many significant digits do we need to save for the values to be distinct?
 std::string PFAnalyzer::stringWithDecimals(int bin, std::vector<double> bins) {
@@ -379,28 +461,32 @@ std::string PFAnalyzer::stringWithDecimals(int bin, std::vector<double> bins) {
   int nDecimals = int(-1 * sigFigs) + 1;
   // We do not want to use decimals since these can mess up histogram retrieval in some cases.
   // Instead, we use a 'p' to indicate the decimal.
-  double newDigit = abs((bins[bin] - int(bins[bin])) * pow(10, nDecimals));
-  double newDigit2 = (bins[bin + 1] - int(bins[bin + 1])) * pow(10, nDecimals);
+  double newDigit = std::abs((bins[bin] - int(bins[bin])) * pow(10, nDecimals));
+  double newDigit2 = std::abs((bins[bin + 1] - int(bins[bin + 1])) * pow(10, nDecimals));
   std::string signStringLow = "";
   std::string signStringHigh = "";
   if (bins[bin] < 0)
     signStringLow = "m";
   if (bins[bin + 1] < 0)
     signStringHigh = "m";
-  return Form("%s%.0fp%.0f_%s%.0fp%.0f",
+
+  int higherDigitsLow = (bins[bin]>0)?floor(bins[bin]):ceil(bins[bin]);
+  int higherDigitsHigh = (bins[bin+1]>0)?floor(bins[bin+1]):ceil(bins[bin+1]);
+
+  return Form("%s%dp%.0f_%s%dp%.0f",
               signStringLow.c_str(),
-              abs(bins[bin]),
+              std::abs(higherDigitsLow),
               newDigit,
               signStringHigh.c_str(),
-              abs(bins[bin + 1]),
+              std::abs(higherDigitsHigh),
               newDigit2);
 }
 
 std::vector<double> PFAnalyzer::getBinList(std::string binString) {
   std::vector<double> binList;
 
-  while (binString.find(';') != std::string::npos) {
-    size_t pos = binString.find(';');
+  while (binString.find(";") != std::string::npos) {
+    size_t pos = binString.find(";");
     binList.push_back(atof(binString.substr(0, pos).c_str()));
     binString.erase(0, pos + 1);
   }
@@ -420,6 +506,7 @@ std::vector<double> PFAnalyzer::getBinList(std::string binString) {
   return binList;
 }
 
+
 std::vector<std::string> PFAnalyzer::getAllSuffixes(std::vector<std::string> observables,
                                                     std::vector<std::vector<double>> binnings) {
   int nTotalBins = 1;
@@ -431,7 +518,6 @@ std::vector<std::string> PFAnalyzer::getAllSuffixes(std::vector<std::string> obs
 
   std::vector<std::vector<int>> binList;
 
-  binList.reserve(nTotalBins);
   for (int i = 0; i < nTotalBins; i++) {
     binList.push_back(std::vector<int>());
   }
@@ -441,10 +527,11 @@ std::vector<std::string> PFAnalyzer::getAllSuffixes(std::vector<std::string> obs
   for (unsigned int i = 0; i < binnings.size(); i++) {
     factor = factor / nBins[i];
 
-    for (int j = 0; j < nBins[i]; j++) {
-      for (int k = 0; k < factor; k++) {
+    for (int k = 0; k < factor; k++) {
+      for (int j = 0; j < nBins[i]; j++) {
         for (int m = 0; m < otherFactor; m++) {
-          binList[m * otherFactor + j * factor + k].push_back(j);
+          int binNumber = k*nBins[i] + j * otherFactor + m;
+          binList[binNumber].push_back(j);
         }
       }
     }
@@ -452,7 +539,6 @@ std::vector<std::string> PFAnalyzer::getAllSuffixes(std::vector<std::string> obs
   }
 
   std::vector<std::string> allSuffixes;
-  allSuffixes.reserve(nTotalBins);
   for (int i = 0; i < nTotalBins; i++) {
     allSuffixes.push_back(getSuffix(binList[i], observables, binnings));
   }
@@ -532,27 +618,9 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   double eventWeight = 1;
   if (genEventInfo.isValid()) {
     eventWeight = genEventInfo->weight();
-  }
 
-  weights_ = &iEvent.get(weightsToken_);
+  //weights_ = &iEvent.get(weightsToken_);
 
-  // **** Get the TriggerResults container
-  edm::Handle<edm::TriggerResults> triggerResults;
-  iEvent.getByToken(triggerResultsToken_, triggerResults);
-
-  // Hack to make it pass the lowest unprescaled HLT?
-  Int_t JetHiPass = 0;
-
-  if (triggerResults.isValid()) {
-    const edm::TriggerNames& triggerNames = iEvent.triggerNames(*triggerResults);
-
-    const unsigned int nTrig(triggerNames.size());
-    for (unsigned int i = 0; i < nTrig; ++i) {
-      if (triggerNames.triggerName(i).find(highPtJetExpr_.label()) != std::string::npos && triggerResults->accept(i)) {
-        JetHiPass = 1;
-      }
-    }
-  }
 
   //Vertex information
   edm::Handle<reco::VertexCollection> vertexHandle;
@@ -581,10 +649,16 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     return;
   std::string npvString = Form("npv_%.0f_%.0f", m_npvBins[npvBin], m_npvBins[npvBin + 1]);
 
-  if (!JetHiPass)
-    return;
+    // **** Get the TriggerResults container
+    edm::Handle<edm::TriggerResults> triggerResults;
+    iEvent.getByToken(triggerResultsToken_, triggerResults);
+  if(!triggerResults.isValid()){
+      edm::LogError("PFAnalyzer") << "invalid trigger result \n";
+      return;
+  }
+  const edm::TriggerNames& triggerNames = iEvent.triggerNames(*triggerResults);
 
-  // Retrieve the PFCs
+
   edm::Handle<reco::PFCandidateCollection> pfCollection;
   iEvent.getByToken(thePfCandidateCollection_, pfCollection);
   if (!pfCollection.isValid()) {
@@ -599,17 +673,16 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     return;
   }
 
-  // Probably we want to define a few different options for how the selection will work
-  // Currently it is just a dummy function, and we hardcode the other cuts.
-  if (pfJets->size() < 2)
+  if(!passesTriggerSelection(pfJets, triggerResults, triggerNames, m_triggerOptions)){
     return;
-  if (pfJets->at(0).pt() < 450)
-    return;
-  if (pfJets->at(0).pt() / pfJets->at(1).pt() > 2)
-    return;
+  }
 
-  if (!passesEventSelection(iEvent))
+  if(!m_eventSelectionMap[m_selection](pfJets)){
     return;
+  }
+
+  //Jet calibration stuff
+  edm::Handle<reco::JetCorrector> jetCorr;
 
   for (reco::PFCandidateCollection::const_iterator recoPF = pfCollection->begin(); recoPF != pfCollection->end();
        ++recoPF) {
@@ -622,6 +695,17 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
       }
       std::string binString = m_allSuffixes[j][binNumber];
 
+      for(unsigned int i=0; i<m_fullCutList2D.size(); i++){
+        // For each observable, we make a couple histograms based on a few generic categorizations.
+        // In all cases, the PFCs that go into these histograms must pass the PFC selection from m_cutList.
+        std::string histName = Form("%s_%s", m_fullCutList2D[i][0].c_str(), m_fullCutList2D[i][1].c_str());
+        map_of_MEs[m_directory + "/allPFC_" + histName]->Fill(m_funcMap[m_fullCutList2D[i][0]](*recoPF), m_funcMap[m_fullCutList2D[i][1]](*recoPF), eventWeight);
+        if(m_particleTypeName.find(recoPF->particleId()) != m_particleTypeName.end()){
+          map_of_MEs[m_directory + "/" + m_particleTypeName[recoPF->particleId()]  + "_" + histName]->Fill(m_funcMap[m_fullCutList2D[i][0]](*recoPF), m_funcMap[m_fullCutList2D[i][1]](*recoPF), eventWeight);
+        }
+
+      }
+
       // Eventually, we might want the hist name to include the cuts that we are applying,
       // so I am keepking it as a separate string for now, even though it is redundant.
       // Make plots of all observables
@@ -629,38 +713,10 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
         std::string histName = Form("%s%s_%s", m_observableNames[i].c_str(), binString.c_str(), npvString.c_str());
         map_of_MEs[m_directory + "/allPFC_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF), eventWeight);
 
-        switch (recoPF->particleId()) {
-          case reco::PFCandidate::ParticleType::h:
-            map_of_MEs[m_directory + "/chargedHadPFC_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF),
-                                                                         eventWeight);
-            break;
-          case reco::PFCandidate::ParticleType::h0:
-            map_of_MEs[m_directory + "/neutralHadPFC_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF),
-                                                                         eventWeight);
-            break;
-          case reco::PFCandidate::ParticleType::e:
-            map_of_MEs[m_directory + "/electronPFC_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF),
-                                                                       eventWeight);
-            break;
-          case reco::PFCandidate::ParticleType::mu:
-            map_of_MEs[m_directory + "/muonPFC_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF),
-                                                                   eventWeight);
-            break;
-          case reco::PFCandidate::ParticleType::gamma:
-            map_of_MEs[m_directory + "/gammaPFC_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF),
-                                                                    eventWeight);
-            break;
-          case reco::PFCandidate::ParticleType::h_HF:
-            map_of_MEs[m_directory + "/hadHFPFC_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF),
-                                                                    eventWeight);
-            break;
-          case reco::PFCandidate::ParticleType::egamma_HF:
-            map_of_MEs[m_directory + "/emHFPFC_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF),
-                                                                   eventWeight);
-            break;
-          default:
-            break;
+        if(m_particleTypeName.find(recoPF->particleId()) != m_particleTypeName.end()){
+          map_of_MEs[m_directory + "/" + m_particleTypeName[recoPF->particleId()]  + "_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF), eventWeight);
         }
+
       }
     }
   }
@@ -669,21 +725,11 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     std::string histName = Form("%s_%s", m_eventObservableNames[i].c_str(), npvString.c_str());
     map_of_MEs[m_directory + "/allPFC_" + histName]->Fill(
         m_eventFuncMap[m_eventObservableNames[i]](*pfCollection, reco::PFCandidate::ParticleType::X), eventWeight);
-    map_of_MEs[m_directory + "/chargedHadPFC_" + histName]->Fill(
-        m_eventFuncMap[m_eventObservableNames[i]](*pfCollection, reco::PFCandidate::ParticleType::h), eventWeight);
-    map_of_MEs[m_directory + "/neutralHadPFC_" + histName]->Fill(
-        m_eventFuncMap[m_eventObservableNames[i]](*pfCollection, reco::PFCandidate::ParticleType::h0), eventWeight);
-    map_of_MEs[m_directory + "/electronPFC_" + histName]->Fill(
-        m_eventFuncMap[m_eventObservableNames[i]](*pfCollection, reco::PFCandidate::ParticleType::e), eventWeight);
-    map_of_MEs[m_directory + "/muonPFC_" + histName]->Fill(
-        m_eventFuncMap[m_eventObservableNames[i]](*pfCollection, reco::PFCandidate::ParticleType::mu), eventWeight);
-    map_of_MEs[m_directory + "/gammaPFC_" + histName]->Fill(
-        m_eventFuncMap[m_eventObservableNames[i]](*pfCollection, reco::PFCandidate::ParticleType::gamma), eventWeight);
-    map_of_MEs[m_directory + "/hadHFPFC_" + histName]->Fill(
-        m_eventFuncMap[m_eventObservableNames[i]](*pfCollection, reco::PFCandidate::ParticleType::h_HF), eventWeight);
-    map_of_MEs[m_directory + "/emHFPFC_" + histName]->Fill(
-        m_eventFuncMap[m_eventObservableNames[i]](*pfCollection, reco::PFCandidate::ParticleType::egamma_HF),
-        eventWeight);
+
+    for(const auto &mypair : m_particleTypeName){
+      map_of_MEs[m_directory + "/" + mypair.second + "_" + histName]->Fill(
+          m_eventFuncMap[m_eventObservableNames[i]](*pfCollection, mypair.first), eventWeight);
+    }
   }
 
   // Plots for generic debugging
@@ -698,13 +744,16 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
 
     for (unsigned int k = 0; k < m_fullJetCutList.size(); k++) {
       int jetBinNumber = getJetBin(*cjet, k);
+      double scale = jetCorr->correction(*cjet);
+      std::cout << scale << std::endl;
+
       if (jetBinNumber < 0)
         continue;
       std::string jetBinString = m_allJetSuffixes[k][jetBinNumber];
 
       std::vector<reco::PFCandidatePtr> pfConstits = cjet->getPFConstituents();
 
-      for (const auto& recoPF : pfConstits) {
+      for (auto recoPF : pfConstits) {
         for (unsigned int j = 0; j < m_fullCutList.size(); j++) {
           int binNumber = getPFBin(*recoPF, j);
           if (binNumber < 0)
@@ -722,38 +771,9 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
                                         npvString.c_str());
             map_of_MEs[m_directory + "/allPFC_jetMatched_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF),
                                                                              eventWeight);
-
-            switch (recoPF->particleId()) {
-              case reco::PFCandidate::ParticleType::h:
-                map_of_MEs[m_directory + "/chargedHadPFC_jetMatched_" + histName]->Fill(
-                    m_funcMap[m_observableNames[i]](*recoPF), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::h0:
-                map_of_MEs[m_directory + "/neutralHadPFC_jetMatched_" + histName]->Fill(
-                    m_funcMap[m_observableNames[i]](*recoPF), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::e:
-                map_of_MEs[m_directory + "/electronPFC_jetMatched_" + histName]->Fill(
-                    m_funcMap[m_observableNames[i]](*recoPF), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::mu:
-                map_of_MEs[m_directory + "/muonPFC_jetMatched_" + histName]->Fill(
-                    m_funcMap[m_observableNames[i]](*recoPF), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::gamma:
-                map_of_MEs[m_directory + "/gammaPFC_jetMatched_" + histName]->Fill(
-                    m_funcMap[m_observableNames[i]](*recoPF), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::h_HF:
-                map_of_MEs[m_directory + "/hadHFPFC_jetMatched_" + histName]->Fill(
-                    m_funcMap[m_observableNames[i]](*recoPF), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::egamma_HF:
-                map_of_MEs[m_directory + "/emHFPFC_jetMatched_" + histName]->Fill(
-                    m_funcMap[m_observableNames[i]](*recoPF), eventWeight);
-                break;
-              default:
-                break;
+            if(m_particleTypeName.find(recoPF->particleId()) != m_particleTypeName.end()){
+              map_of_MEs[m_directory + "/" + m_particleTypeName[recoPF->particleId()] + "_jetMatched_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF),
+                                                                             eventWeight);
             }
           }
 
@@ -766,38 +786,11 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
             map_of_MEs[m_directory + "/allPFC_jetMatched_" + histName]->Fill(
                 m_pfInJetFuncMap[m_pfInJetObservableNames[i]](*recoPF, *cjet), eventWeight);
 
-            switch (recoPF->particleId()) {
-              case reco::PFCandidate::ParticleType::h:
-                map_of_MEs[m_directory + "/chargedHadPFC_jetMatched_" + histName]->Fill(
-                    m_pfInJetFuncMap[m_pfInJetObservableNames[i]](*recoPF, *cjet), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::h0:
-                map_of_MEs[m_directory + "/neutralHadPFC_jetMatched_" + histName]->Fill(
-                    m_pfInJetFuncMap[m_pfInJetObservableNames[i]](*recoPF, *cjet), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::e:
-                map_of_MEs[m_directory + "/electronPFC_jetMatched_" + histName]->Fill(
-                    m_pfInJetFuncMap[m_pfInJetObservableNames[i]](*recoPF, *cjet), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::mu:
-                map_of_MEs[m_directory + "/muonPFC_jetMatched_" + histName]->Fill(
-                    m_pfInJetFuncMap[m_pfInJetObservableNames[i]](*recoPF, *cjet), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::gamma:
-                map_of_MEs[m_directory + "/gammaPFC_jetMatched_" + histName]->Fill(
-                    m_pfInJetFuncMap[m_pfInJetObservableNames[i]](*recoPF, *cjet), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::h_HF:
-                map_of_MEs[m_directory + "/hadHFPFC_jetMatched_" + histName]->Fill(
-                    m_pfInJetFuncMap[m_pfInJetObservableNames[i]](*recoPF, *cjet), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::egamma_HF:
-                map_of_MEs[m_directory + "/emHFPFC_jetMatched_" + histName]->Fill(
-                    m_pfInJetFuncMap[m_pfInJetObservableNames[i]](*recoPF, *cjet), eventWeight);
-                break;
-              default:
-                break;
+            if(m_particleTypeName.find(recoPF->particleId()) != m_particleTypeName.end()){
+              map_of_MEs[m_directory + "/" + m_particleTypeName[recoPF->particleId()] + "_jetMatched_" + histName]->Fill(
+                m_pfInJetFuncMap[m_pfInJetObservableNames[i]](*recoPF, *cjet), eventWeight);
             }
+
           }
         }
 
@@ -805,28 +798,14 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
           std::string histName =
               Form("%s_jetCuts%s_%s", m_eventObservableNames[i].c_str(), jetBinString.c_str(), npvString.c_str());
           map_of_MEs[m_directory + "/allPFC_jetMatched_" + histName]->Fill(
-              m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, reco::PFCandidate::ParticleType::X), eventWeight);
-          map_of_MEs[m_directory + "/chargedHadPFC_jetMatched_" + histName]->Fill(
-              m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, reco::PFCandidate::ParticleType::h), eventWeight);
-          map_of_MEs[m_directory + "/neutralHadPFC_jetMatched_" + histName]->Fill(
-              m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, reco::PFCandidate::ParticleType::h0),
-              eventWeight);
-          map_of_MEs[m_directory + "/electronPFC_jetMatched_" + histName]->Fill(
-              m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, reco::PFCandidate::ParticleType::e), eventWeight);
-          map_of_MEs[m_directory + "/muonPFC_jetMatched_" + histName]->Fill(
-              m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, reco::PFCandidate::ParticleType::mu),
-              eventWeight);
-          map_of_MEs[m_directory + "/gammaPFC_jetMatched_" + histName]->Fill(
-              m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, reco::PFCandidate::ParticleType::gamma),
-              eventWeight);
-          map_of_MEs[m_directory + "/hadHFPFC_jetMatched_" + histName]->Fill(
-              m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, reco::PFCandidate::ParticleType::h_HF),
-              eventWeight);
-          map_of_MEs[m_directory + "/emHFPFC_jetMatched_" + histName]->Fill(
-              m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, reco::PFCandidate::ParticleType::egamma_HF),
-              eventWeight);
+              m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, reco::PFCandidate::ParticleType::X, *cjet), eventWeight);
+          for(const auto &mypair : m_particleTypeName){
+            map_of_MEs[m_directory + "/" + mypair.second + "_jetMatched_" + histName]->Fill(
+                m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, mypair.first, *cjet), eventWeight);
+          }
         }
       }
     }
+  }
   }
 }

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
@@ -614,6 +614,7 @@ int PFAnalyzer::getJetBin(const reco::PFJet jetCand, int i) {
 
 // ***********************************************************
 void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  std::cout << __LINE__ << std::endl;
   const edm::Handle<GenEventInfoProduct> genEventInfo = iEvent.getHandle(tok_ew_);
   double eventWeight = 1;
   if (genEventInfo.isValid()) {
@@ -644,9 +645,11 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     }
   }
 
+  std::cout << __LINE__ << std::endl;
   int npvBin = getBinNumber(numPV, m_npvBins);
   if (npvBin < 0)
     return;
+  std::cout << __LINE__ << std::endl;
   std::string npvString = Form("npv_%.0f_%.0f", m_npvBins[npvBin], m_npvBins[npvBin + 1]);
 
     // **** Get the TriggerResults container
@@ -659,12 +662,14 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   const edm::TriggerNames& triggerNames = iEvent.triggerNames(*triggerResults);
 
 
+  std::cout << __LINE__ << std::endl;
   edm::Handle<reco::PFCandidateCollection> pfCollection;
   iEvent.getByToken(thePfCandidateCollection_, pfCollection);
   if (!pfCollection.isValid()) {
     edm::LogError("PFAnalyzer") << "invalid collection: PF candidate \n";
     return;
   }
+  std::cout << __LINE__ << std::endl;
 
   edm::Handle<reco::PFJetCollection> pfJets;
   iEvent.getByToken(pfJetsToken_, pfJets);
@@ -673,13 +678,16 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     return;
   }
 
+  std::cout << __LINE__ << std::endl;
   if(!passesTriggerSelection(pfJets, triggerResults, triggerNames, m_triggerOptions)){
     return;
   }
+  std::cout << __LINE__ << std::endl;
 
   if(!m_eventSelectionMap[m_selection](pfJets)){
     return;
   }
+  std::cout << __LINE__ << std::endl;
 
   //Jet calibration stuff
   edm::Handle<reco::JetCorrector> jetCorr;
@@ -737,15 +745,17 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   map_of_MEs[m_directory + Form("/jetPtLead_%s", npvString.c_str())]->Fill(pfJets->begin()->pt(), eventWeight);
   map_of_MEs[m_directory + Form("/jetEtaLead_%s", npvString.c_str())]->Fill(pfJets->begin()->eta(), eventWeight);
 
+  std::cout << "Passed event selection" << std::endl;
   // Make plots of all observables, this time for PF candidates within jets
   for (reco::PFJetCollection::const_iterator cjet = pfJets->begin(); cjet != pfJets->end(); ++cjet) {
     map_of_MEs[m_directory + Form("/jetPt_%s", npvString.c_str())]->Fill(cjet->pt(), eventWeight);
     map_of_MEs[m_directory + Form("/jetEta_%s", npvString.c_str())]->Fill(cjet->eta(), eventWeight);
 
+    double scale = jetCorr->correction(*cjet);
+    std::cout << scale << std::endl;
+
     for (unsigned int k = 0; k < m_fullJetCutList.size(); k++) {
       int jetBinNumber = getJetBin(*cjet, k);
-      double scale = jetCorr->correction(*cjet);
-      std::cout << scale << std::endl;
 
       if (jetBinNumber < 0)
         continue;

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
@@ -46,6 +46,10 @@
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+
+// For jets
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
 class PFAnalyzer;
 
 class PFAnalyzer : public DQMEDAnalyzer {
@@ -73,18 +77,25 @@ private:
   std::map<std::string, std::function<double(const reco::PFCandidate)>> m_funcMap;
   std::map<std::string, std::function<double(const reco::PFCandidateCollection, reco::PFCandidate::ParticleType pfType)>>
       m_eventFuncMap;
+
   std::map<std::string,
-           std::function<double(const std::vector<reco::PFCandidatePtr> pfCands, reco::PFCandidate::ParticleType pfType)>>
+           std::function<double(const std::vector<reco::PFCandidatePtr> pfCands, reco::PFCandidate::ParticleType pfType, const reco::PFJet)>>
       m_jetWideFuncMap;
+
   std::map<std::string, std::function<double(const reco::PFCandidate, const reco::PFJet)>> m_pfInJetFuncMap;
   std::map<std::string, std::function<double(const reco::PFJet)>> m_jetFuncMap;
 
+  std::map<std::string, std::function<bool(const edm::Handle<std::vector<reco::PFJet> >& pfJets)>> m_eventSelectionMap;
+
   binInfo getBinInfo(std::string);
+
+  //Jet calibration stuff
+  static bool jetSortingRule(reco::Jet x, reco::Jet y) { return x.pt() > y.pt(); }
+  edm::InputTag jetCorrectorTag_;
+  edm::EDGetTokenT<reco::JetCorrector> jetCorrectorToken_;
 
   // Book MonitorElements
   void bookMESetSelection(std::string, DQMStore::IBooker&);
-
-  bool passesEventSelection(const edm::Event& iEvent);
 
   int getPFBin(const reco::PFCandidate pfCand, int i);
   int getJetBin(const reco::PFJet jetCand, int i);
@@ -118,7 +129,7 @@ private:
     return nPF;
   }
 
-  static double getNPFCinJet(const std::vector<reco::PFCandidatePtr> pfCands, reco::PFCandidate::ParticleType pfType) {
+  static double getNPFCinJet(const std::vector<reco::PFCandidatePtr> pfCands, reco::PFCandidate::ParticleType pfType, const reco::PFJet jet) {
     int nPF = 0;
     for (auto pfCand : pfCands) {
       if (!pfCand)
@@ -129,6 +140,30 @@ private:
     }
     return nPF;
   }
+
+  static double getMaxPt(const reco::PFCandidateCollection pfCands, reco::PFCandidate::ParticleType pfType) {
+    double maxPt = 0;
+    for (auto pfCand : pfCands) {
+      // We use X to indicate all
+      if (pfCand.particleId() == pfType || pfType == reco::PFCandidate::ParticleType::X) {
+        if(pfCand.pt() > maxPt ) maxPt = pfCand.pt();
+      }
+    }
+    return maxPt;
+  }
+
+  static double getMaxPtFracJet(const std::vector<reco::PFCandidatePtr> pfCands, reco::PFCandidate::ParticleType pfType, const reco::PFJet jet) {
+    double maxPt = 0;
+    for (auto pfCand : pfCands) {
+      if (!pfCand)
+        continue;
+      // We use X to indicate all
+      if (pfCand->particleId() == pfType || pfType == reco::PFCandidate::ParticleType::X)
+        if(pfCand->pt() > maxPt ) maxPt = pfCand->pt();
+    }
+    return maxPt / jet.pt();
+  }
+
 
   // Various functions designed to get information from a PF canddidate
   static double getPt(const reco::PFCandidate pfCand) { return pfCand.pt(); }
@@ -176,11 +211,105 @@ private:
 
   static double getECalEFrac(const reco::PFCandidate pfCand) { return pfCand.ecalEnergy() / pfCand.energy(); }
   static double getHCalEFrac(const reco::PFCandidate pfCand) { return pfCand.hcalEnergy() / pfCand.energy(); }
+  static double getPS1Energy(const reco::PFCandidate pfCand) { return pfCand.pS1Energy();}
+  static double getPS2Energy(const reco::PFCandidate pfCand) { return pfCand.pS2Energy();}
+  static double getPSEnergy(const reco::PFCandidate pfCand) {
+      if(pfCand.particleId() == reco::PFCandidate::ParticleType::gamma){ 
+       double energy =0 ;
+        for (unsigned iele = 0; iele < pfCand.elementsInBlocks().size(); ++iele) {
+          // first get the block
+          reco::PFBlockRef blockRef = pfCand.elementsInBlocks()[iele].first;
+          //
+          unsigned elementIndex = pfCand.elementsInBlocks()[iele].second;
+          // check it actually exists
+          if (blockRef.isNull())
+            continue;
+  
+  
+          // then get the elements of the block
+          const edm::OwnVector<reco::PFBlockElement>& elements = (*blockRef).elements();
+    
+          const reco::PFBlockElement& pfbe(elements[elementIndex]);
+          if (pfbe.type() == reco::PFBlockElement::PS1) {
+                reco::PFClusterRef clusterref = pfbe.clusterRef();
+                if(!clusterref.isNull()){
+                reco::PFCluster cluster = *clusterref;
+                energy += cluster.energy();
+                }
+          }
+        }
+
+        std::cout << energy << "\t" <<  pfCand.pS1Energy() << std::endl;
+      } 
+      return pfCand.pS1Energy()+pfCand.pS2Energy();}
+
   static double getTrackPt(const reco::PFCandidate pfCand) {
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->pt();
     return 0;
   }
+
+  static double getTrackNStripHits(const reco::PFCandidate pfCand) {
+    if (pfCand.trackRef().isNonnull())
+      return (pfCand.trackRef())->hitPattern().numberOfValidStripHits();
+    return -1;
+  }
+
+  static double getTrackNPixHits(const reco::PFCandidate pfCand) {
+    if (pfCand.trackRef().isNonnull())
+      return (pfCand.trackRef())->hitPattern().numberOfValidPixelHits();
+
+    return -1;
+  }
+
+  static double getTrackChi2(const reco::PFCandidate pfCand) {
+    if (pfCand.trackRef().isNonnull())
+      return (pfCand.trackRef())->chi2();
+    return -1;
+  }
+
+  static double getTrackPtError(const reco::PFCandidate pfCand) {
+    if (pfCand.trackRef().isNonnull())
+      return (pfCand.trackRef())->ptError();
+    return -1;
+  }
+
+  static double getTrackRelPtError(const reco::PFCandidate pfCand) {
+    if (pfCand.trackRef().isNonnull())
+      return (pfCand.trackRef())->ptError() / (pfCand.trackRef())->pt();
+    return -1;
+  }
+
+  static double getTrackD0(const reco::PFCandidate pfCand) {
+    if (pfCand.trackRef().isNonnull())
+      return (pfCand.trackRef())->d0();
+    return -1;
+  }
+
+  static double getTrackZ0(const reco::PFCandidate pfCand) {
+    if (pfCand.trackRef().isNonnull())
+      return (pfCand.trackRef())->d0();
+    return -1;
+  }
+
+  static double getTrackThetaError(const reco::PFCandidate pfCand) {
+    if (pfCand.trackRef().isNonnull())
+      return (pfCand.trackRef())->thetaError();
+    return -1;
+  }
+
+  static double getTrackEtaError(const reco::PFCandidate pfCand) {
+    if (pfCand.trackRef().isNonnull())
+      return (pfCand.trackRef())->etaError();
+    return -1;
+  }
+
+  static double getTrackPhiError(const reco::PFCandidate pfCand) {
+    if (pfCand.trackRef().isNonnull())
+      return (pfCand.trackRef())->phiError();
+    return -1;
+  }
+
 
   static double getEoverP(const reco::PFCandidate pfCand) {
     double energy = 0;
@@ -267,6 +396,86 @@ private:
   }
 
   static double getJetPt(const reco::PFJet jet) { return jet.pt(); }
+  static double getJetChargeFrac(const reco::PFJet jet) { 
+    double chargeFrac = 0;
+    std::vector<reco::PFCandidatePtr> pfConstits = jet.getPFConstituents();
+
+    for (auto recoPF : pfConstits) {
+      if(recoPF->particleId() == reco::PFCandidate::ParticleType::h || recoPF->particleId() == reco::PFCandidate::ParticleType::e || recoPF->particleId() == reco::PFCandidate::ParticleType::mu) chargeFrac += recoPF->pt();
+    }
+    return chargeFrac / jet.pt();
+  }
+
+  bool passesTriggerSelection(const edm::Handle<std::vector<reco::PFJet> >& pfJets, const edm::Handle<edm::TriggerResults>& triggerResults, const edm::TriggerNames& triggerNames, const std::vector<std::string> triggerOptions){
+
+    // Hack to make it pass the lowest unprescaled HLT?
+    Int_t JetHiPass = 0;
+
+    const unsigned int nTrig(triggerNames.size());
+    for (unsigned int i = 0; i < nTrig; ++i) {
+      for (unsigned int j = 0; j < triggerOptions.size(); ++j) {
+        if(triggerOptions[j] == "") {
+          JetHiPass=1;
+          break;
+        }
+        if (triggerNames.triggerName(i).find(triggerOptions[j]) != std::string::npos && triggerResults->accept(i)) {
+          JetHiPass = 1;
+          break;
+        }
+      }
+      if(JetHiPass) break;
+    }
+
+    if (!JetHiPass)
+      return false;
+    return true;
+  }
+
+
+  static bool passesEventSelection(const edm::Handle<std::vector<reco::PFJet> >& pfJets) {
+    if (pfJets->size() < 2)
+      return false;
+    if (pfJets->at(0).pt() < 450)
+      return false;
+    if (pfJets->at(0).pt() / pfJets->at(1).pt() > 2)
+      return false;
+
+    return true;
+  }
+
+  static bool passesNoCutSelection(const edm::Handle<std::vector<reco::PFJet> >& pfJets) {
+    //if (pfJets->size() < 2)
+    //  return false;
+    //if (pfJets->at(0).pt() < 450)
+    //  return false;
+    //if (pfJets->at(0).pt() / pfJets->at(1).pt() > 2)
+    //  return false;
+
+    return true;
+  }
+
+  static bool passesDijetSelection(const edm::Handle<std::vector<reco::PFJet> >& pfJets) {
+    if (pfJets->size() < 2)
+      return false;
+    if (pfJets->at(0).pt() < 450)
+      return false;
+    if (pfJets->at(0).pt() / pfJets->at(1).pt() > 2)
+      return false;
+    
+    return true;
+  } 
+
+  static bool passesAnomalousSelection(const edm::Handle<std::vector<reco::PFJet> >& pfJets) {
+    if (pfJets->size() < 2)
+      return false;
+    if (pfJets->at(0).pt() < 450)
+      return false;
+    if (pfJets->at(1).pt() / pfJets->at(0).pt() >0.5)
+      return false;
+    
+    return true;
+  } 
+
 
   edm::EDGetTokenT<reco::PFCandidateCollection> thePfCandidateCollection_;
   edm::EDGetTokenT<std::vector<reco::Vertex>> vertexToken_;
@@ -280,8 +489,9 @@ private:
 
   edm::InputTag theTriggerResultsLabel_;
   edm::InputTag vertexTag_;
-  edm::InputTag highPtJetExpr_;
   edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;
+  std::string m_selection;
+
 
   std::vector<std::vector<std::string>> m_allSuffixes;
   std::vector<std::vector<std::string>> m_allJetSuffixes;
@@ -292,11 +502,17 @@ private:
   // All of the histograms, stored as a map between the histogram name and the histogram
   std::map<std::string, MonitorElement*> map_of_MEs;
 
+  std::map<reco::PFCandidate::ParticleType, std::string> m_particleTypeName;
+
+
+
   //check later if we need only one set of parameters
   edm::ParameterSet parameters_;
 
   typedef std::vector<std::string> vstring;
   typedef std::vector<double> vDouble;
+
+  vstring m_triggerOptions;
   // Information on which observables to make histograms for.
   // In the config file, this should come as a comma-separated list of
   // the observable name, the number of bins for the histogram, and
@@ -311,6 +527,7 @@ private:
   vstring m_eventObservableNames;
   vstring m_pfInJetObservableNames;
 
+
   // Information on what cuts should be applied to PFCandidates that are
   // being monitored. In the config file, this should come as a comma-separated list of
   // the observable name, and the lowest and highest values for the histogram.
@@ -319,6 +536,13 @@ private:
   vstring m_cutList;
   std::vector<std::vector<std::string>> m_fullCutList;
   std::vector<std::vector<std::vector<double>>> m_binList;
+
+  // Binning information for 2D histograms
+  // Technically, these could be made using just the 1D cuts, 
+  // but this is useful for saving a bit of memory by creating fewer histograms.
+  vstring m_cutList2D;
+  std::vector<std::vector<std::string>> m_fullCutList2D;
+  std::vector<std::vector<std::vector<double>>> m_binList2D;
 
   // Information on what cuts should be applied to PFJets, in the case that we
   // match PFCs to jets.In the config file, this should come as a comma-separated list of

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
@@ -49,7 +49,7 @@
 
 // For jets
 #include "FWCore/Utilities/interface/EDGetToken.h"
-#include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
+
 class PFAnalyzer;
 
 class PFAnalyzer : public DQMEDAnalyzer {
@@ -91,8 +91,6 @@ private:
 
   //Jet calibration stuff
   static bool jetSortingRule(reco::Jet x, reco::Jet y) { return x.pt() > y.pt(); }
-  edm::InputTag jetCorrectorTag_;
-  edm::EDGetTokenT<reco::JetCorrector> jetCorrectorToken_;
 
   // Book MonitorElements
   void bookMESetSelection(std::string, DQMStore::IBooker&);

--- a/DQMOffline/ParticleFlow/python/runBasic_cfg.py
+++ b/DQMOffline/ParticleFlow/python/runBasic_cfg.py
@@ -1,10 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-# jet calibration stuff
-from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFPuppiL1FastL2L3ResidualCorrectorChain,ak4PFPuppiL1FastL2L3ResidualCorrector,ak4PFPuppiL1FastL2L3Corrector,ak4PFPuppiResidualCorrector,ak4PFPuppiL3AbsoluteCorrector,ak4PFPuppiL2RelativeCorrector,ak4PFPuppiL1FastjetCorrector
-
-dqmAk4PFPuppiL1FastL2L3ResidualCorrector = ak4PFPuppiL1FastL2L3ResidualCorrector.clone()
-
 process = cms.Process('ParticleFlowDQMOffline')
 
 # import of standard configurations
@@ -20,43 +15,98 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.load("DQMServices.Core.DQM_cfg")
 process.load("DQMServices.Components.DQMEnvironment_cfi")
 
+# load jet correctors
+process.load('JetMETCorrections.Configuration.JetCorrectors_cff')
+
 # my analyzer
 process.load('DQMOffline.ParticleFlow.runBasic_cfi')
 
 
+#
+# This GT for MC should have "JetCorrectorParametersCollection_Winter25_AK4PFPuppi_offline_v1"
+# https://cms-talk.web.cern.ch/t/gt-mc-gt-request-for-winter25-miniv6-nanov15-reprocessing-in-150x-for-2025-data-monitoring-for-jme-and-btv/124962
+# https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_mcRun3_2025_realistic_v4
+#
+# GT = "150X_mcRun3_2025_realistic_v4"
+# TAG_JEC = ""
+# inputFile="/store/mc/Run3Winter25Reco/QCD_Bin-PT-15to7000_Par-PT-flat2022_TuneCP5_13p6TeV_pythia8/AODSIM/142X_mcRun3_2025_realistic_v9-v4/2810001/6a556fcb-beac-4ef4-9ed3-95df061cf1b1.root"
+# outputFile="OUT_step1_MC.root"
+# goldenJSONPath="" # Keep empty. Do not use for MC
+
+#
+# Use Prompt GT for Data then we manually replace the corrections in Prompt GT.
+#
+GT = "150X_dataRun3_Prompt_v1"
+TAG_JEC = "JetCorrectorParametersCollection_Winter25Prompt25_RunC_V1_DATA_AK4PFPuppi_v1"
+inputFile="/store/data/Run2025E/JetMET0/AOD/PromptReco-v1/000/395/987/00000/68ce8c81-1fc0-48a6-b71f-d2c93c1d3787.root"
+outputFile="OUT_step1_Data.root"
+goldenJSONPath="/eos/user/c/cmsdqm/www/CAF/certification/Collisions25/Cert_Collisions2025_391658_397294_Golden.json"
+
+#
+# Setup Global Tag
+#
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, GT, '')
+
+#
+# Here we explicitly override the corrections in a Global Tag
+#
+if TAG_JEC != "":
+    process.GlobalTag.toGet = cms.VPSet(
+      cms.PSet(
+        record = cms.string("JetCorrectionsRecord"),
+        tag = cms.string(TAG_JEC),
+        label = cms.untracked.string('AK4PFPuppi'),
+        connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
+      )
+    )
+
+#
+# "CorrectedPFJetProducer" module applies the jet energy corrections
+# on the jet collection and sort the collection according to pt
+# https://cmssdt.cern.ch/lxr/source/JetMETCorrections/Modules/plugins/CorrectedJetProducers.cc#0014
+# https://cmssdt.cern.ch/lxr/source/JetMETCorrections/Modules/interface/CorrectedJetProducer.h
+#
+process.ak4PFJetsPuppiCorrected = cms.EDProducer('CorrectedPFJetProducer',
+    src        = cms.InputTag('ak4PFJetsPuppi'),
+    correctors = cms.VInputTag('ak4PFPuppiL1FastL2L3ResidualCorrector')
+)
+
 from DQMOffline.ParticleFlow.runBasic_cfi import *
 
 # back to original script
-with open('fileList_2.log') as f:
-    lines = f.readlines()
-#Input source
-process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(lines))
+# with open('fileList_2.log') as f:
+#     lines = f.readlines()
 
+#Input source
+process.source = cms.Source("PoolSource",
+    # fileNames = cms.untracked.vstring(lines),
+    fileNames = cms.untracked.vstring(inputFile)
+)
+###################################################################
+# GoldenJSON Filtering
+###################################################################
+if goldenJSONPath != "":
+    import FWCore.PythonUtilities.LumiList as LumiList
+    process.source.lumisToProcess = LumiList.LumiList(filename = goldenJSONPath).getVLuminosityBlockRange()
 
 from DQMOffline.ParticleFlow.runBasic_cfi import *
 
 process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
-                                     fileName = cms.untracked.string("OUT_step1.root"))
-
-
-process.p = cms.Path(process.PFAnalyzer)
-process.DQMoutput_step = cms.EndPath(process.DQMoutput)
-
-dqmAk4PFPuppiL1FastL2L3ResidualCorrectorChain = cms.Sequence(
-    dqmAk4PFPuppiL1FastL2L3ResidualCorrector*PFAnalyzer
+    fileName = cms.untracked.string(outputFile)
 )
+
+process.p = cms.Path(
+    process.ak4PFPuppiL1FastL2L3ResidualCorrectorChain+
+    process.ak4PFJetsPuppiCorrected+
+    process.PFAnalyzer
+)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
 
 ## Schedule definition
 process.schedule = cms.Schedule(
     process.p,
     process.DQMoutput_step
-    )
-
-
-
-
-
-
-
+)
 
 

--- a/DQMOffline/ParticleFlow/python/runBasic_cfg.py
+++ b/DQMOffline/ParticleFlow/python/runBasic_cfg.py
@@ -18,8 +18,16 @@ process.load("DQMServices.Components.DQMEnvironment_cfi")
 # my analyzer
 process.load('DQMOffline.ParticleFlow.runBasic_cfi')
 
+# jet calibration stuff
+from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFPuppiL1FastL2L3ResidualCorrectorChain,ak4PFPuppiL1FastL2L3ResidualCorrector,ak4PFPuppiL1FastL2L3Corrector,ak4PFPuppiResidualCorrector,ak4PFPuppiL3AbsoluteCorrector,ak4PFPuppiL2RelativeCorrector,ak4PFPuppiL1FastjetCorrector
 
-with open('fileList.log') as f:
+dqmAk4PFPuppiL1FastL2L3ResidualCorrector = ak4PFPuppiL1FastL2L3ResidualCorrector.clone()
+dqmAk4PFPuppiL1FastL2L3ResidualCorrectorChain = cms.Sequence(
+    dqmAk4PFPuppiL1FastL2L3ResidualCorrector
+)
+
+# back to original script
+with open('fileList_2.log') as f:
     lines = f.readlines()
 #Input source
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(lines))

--- a/DQMOffline/ParticleFlow/python/runBasic_cfg.py
+++ b/DQMOffline/ParticleFlow/python/runBasic_cfg.py
@@ -1,5 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+# jet calibration stuff
+from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFPuppiL1FastL2L3ResidualCorrectorChain,ak4PFPuppiL1FastL2L3ResidualCorrector,ak4PFPuppiL1FastL2L3Corrector,ak4PFPuppiResidualCorrector,ak4PFPuppiL3AbsoluteCorrector,ak4PFPuppiL2RelativeCorrector,ak4PFPuppiL1FastjetCorrector
+
+dqmAk4PFPuppiL1FastL2L3ResidualCorrector = ak4PFPuppiL1FastL2L3ResidualCorrector.clone()
+
 process = cms.Process('ParticleFlowDQMOffline')
 
 # import of standard configurations
@@ -18,13 +23,8 @@ process.load("DQMServices.Components.DQMEnvironment_cfi")
 # my analyzer
 process.load('DQMOffline.ParticleFlow.runBasic_cfi')
 
-# jet calibration stuff
-from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFPuppiL1FastL2L3ResidualCorrectorChain,ak4PFPuppiL1FastL2L3ResidualCorrector,ak4PFPuppiL1FastL2L3Corrector,ak4PFPuppiResidualCorrector,ak4PFPuppiL3AbsoluteCorrector,ak4PFPuppiL2RelativeCorrector,ak4PFPuppiL1FastjetCorrector
 
-dqmAk4PFPuppiL1FastL2L3ResidualCorrector = ak4PFPuppiL1FastL2L3ResidualCorrector.clone()
-dqmAk4PFPuppiL1FastL2L3ResidualCorrectorChain = cms.Sequence(
-    dqmAk4PFPuppiL1FastL2L3ResidualCorrector
-)
+from DQMOffline.ParticleFlow.runBasic_cfi import *
 
 # back to original script
 with open('fileList_2.log') as f:
@@ -42,6 +42,9 @@ process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
 process.p = cms.Path(process.PFAnalyzer)
 process.DQMoutput_step = cms.EndPath(process.DQMoutput)
 
+dqmAk4PFPuppiL1FastL2L3ResidualCorrectorChain = cms.Sequence(
+    dqmAk4PFPuppiL1FastL2L3ResidualCorrector*PFAnalyzer
+)
 
 ## Schedule definition
 process.schedule = cms.Schedule(

--- a/DQMOffline/ParticleFlow/python/runBasic_cfi.py
+++ b/DQMOffline/ParticleFlow/python/runBasic_cfi.py
@@ -2,17 +2,15 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
 PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
-    pfJetCollection        = cms.InputTag("ak4PFJetsCHS"),
-    pfCandidates             = cms.InputTag("particleFlow"),
-    PVCollection             = cms.InputTag("offlinePrimaryVertices"),
-    JetCorrections = cms.InputTag("dqmAk4PFPuppiL1FastL2L3ResidualCorrector"),
-
-    eventSelection = cms.string("none"),
+    # JEC-applied, pt-sorted AK4 Puppi jets
+    pfJetCollection   = cms.InputTag("ak4PFJetsPuppiCorrected"),
+    pfCandidates      = cms.InputTag("particleFlow"),
+    PVCollection      = cms.InputTag("offlinePrimaryVertices"),
+    eventSelection    = cms.string("none"),
     TriggerNames = cms.vstring("HLT_PFJet450"),
     TriggerResultsLabel        = cms.InputTag("TriggerResults::HLT"),
     TriggerName = cms.InputTag(""),
     srcWeights = cms.InputTag("puppi"),
-
 
     pfAnalysis = cms.PSet(
       # Bins of NPV for plots

--- a/DQMOffline/ParticleFlow/python/runBasic_cfi.py
+++ b/DQMOffline/ParticleFlow/python/runBasic_cfi.py
@@ -5,9 +5,12 @@ PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
     pfJetCollection        = cms.InputTag("ak4PFJetsCHS"),
     pfCandidates             = cms.InputTag("particleFlow"),
     PVCollection             = cms.InputTag("offlinePrimaryVertices"),
+    JetCorrections = cms.InputTag("dqmAk4PFPuppiL1FastL2L3ResidualCorrector"),
 
+    eventSelection = cms.string("none"),
+    TriggerNames = cms.vstring("HLT_PFJet450"),
     TriggerResultsLabel        = cms.InputTag("TriggerResults::HLT"),
-    TriggerName = cms.InputTag("HLT_PFJet450"),
+    TriggerName = cms.InputTag(""),
     srcWeights = cms.InputTag("puppi"),
 
 
@@ -51,6 +54,7 @@ PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
                                          'PFSpectrum;E_{PF}/E_{jet};50;0;1',
                                         ),
 
+      binList2D = cms.vstring('[eta;30;-5;5][phi;30;-3.14;3.14]'),
 
       # This is a list of multidimensional cuts that are applied for the plots.
       # In the case of multiple bins, every combination of bin is tested.


### PR DESCRIPTION
#### PR description:

This PR makes a few key changes to the PF monitoring code. 

* Enables the use of the framework with MiniAOD, as discussed in a recent [PF meeting](https://indico.cern.ch/event/1592159/)
* Adds the use of jet calibrations, with the help of @nurfikri89 and Julia Marrinan (who I do not seem to be able to tag).

#### PR validation:

This code has been tested on MiniAOD samples to confirm the expected behavior both inside and outside jets. Note that there is reduced functionality for MiniAODs, since some information about PF is not included in this format.

The calibrations have been tested, and @nurfikri89 has checked the configuration.

I am also tagging the PF conveners for reference: @ahinzmann @stahlleiton 

I am guessing this should get merged into master, but the diff is very large, so I would appreciate any guidance on how to handle that.

