### PR TITLE
[15_0_X] GenParticles2HepMC: connect orphans to beams

### DIFF
--- a/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
+++ b/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
@@ -188,6 +188,15 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
     if (p == parton1 or p == parton2)
       continue;
 
+    // No mother info: connect to the incident proton vertex
+    if (p->numberOfMothers() == 0) {
+      if (p->pz() > 0) {
+        vertex1->add_particle_out(genCandToHepMCMap[p]);
+      } else {
+        vertex2->add_particle_out(genCandToHepMCMap[p]);
+      }
+      continue;
+    }
     // Connect mother-daughters for the other cases
     for (unsigned int j = 0, nMothers = p->numberOfMothers(); j < nMothers; ++j) {
       // Mother-daughter hierarchy defines vertex


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/49447

Fixing https://github.com/cms-sw/cmssw/issues/49256 by connecting orphaned particles to the beam.
(LPAIR is an extreme case were **all** particles are orphaned and HepMC3 considers these events invalid)

Note that this is a "hotfix" for the Nano V15 reprocessing, will port to master afterwards.

#### PR validation:

Runs problematic request
```
Begin processing the 1030th record. Run 1, Event 1012, LumiSection 11 on stream 1 at 22-Nov-2025 17:45:27.643 CET                              
Begin processing the 1031st record. Run 1, Event 1030, LumiSection 11 on stream 2 at 22-Nov-2025 17:45:27.675 CET                              
^C%MSG-s ShutdownSignal:  PostProcessPath 22-Nov-2025 17:45:27 CET  PostProcessEvent                                                           
an external signal was sent to shutdown the job early.                                                                                         
...                                    
22-Nov-2025 17:45:27 CET  Closed file root://xrootd-cms.infn.it//store/mc/RunIISummer20UL16MiniAODAPVv2/GGToEE_Pt-35_Elastic_13TeV-lpair/MINIAO
DSIM/106X_mcRun2_asymptotic_preVFP_v11-v1/120000/D961557E-1D75-2B44-9DC2-D72F60FB80D1.root                                                     
TimeReport> Time report complete in 112.82 seconds   
```

Passes existing tests
```
Pass    3s ... GeneratorInterface/RivetInterface/test-particleLevel_fromPtGun
Pass    7s ... GeneratorInterface/RivetInterface/test-HTXS
Pass   10s ... GeneratorInterface/RivetInterface/test-particleLevel_fromHepMC3
Pass   13s ... GeneratorInterface/RivetInterface/test-particleLevel_fromMiniAod
Pass   13s ... GeneratorInterface/RivetInterface/test-particleLevel_fromGenParticles
Pass   15s ... GeneratorInterface/RivetInterface/test-rivet-run
Pass    2s ... GeneratorInterface/RivetInterface/test-yoda-merge
Pass    2s ... GeneratorInterface/RivetInterface/test-yoda-root
Pass   25s ... GeneratorInterface/RivetInterface/test-rivet-list
Pass   16s ... GeneratorInterface/RivetInterface/test-rivet-plot
>> Test sequence completed for CMSSW CMSSW_15_0_15_patch4
```
