### PR TITLE
Disable the cache for HIN processing

### DIFF
--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -143,10 +143,18 @@ def customisePostEra_Run3_2024_ppRef(process):
 
 def customisePostEra_Run3_pp_on_PbPb_2025(process):
     customisePostEra_Run3_2025(process)
+    process.source.cacheSize = cms.untracked.uint32(0)
+    process.add_(cms.Service("SiteLocalConfigService",
+                             overrideSourceCacheHintDir = cms.untracked.string("lazy-download")
+                             ))
     return process
 
 def customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters_2025(process):
     customisePostEra_Run3_pp_on_PbPb_2025(process)
+    process.source.cacheSize = cms.untracked.uint32(0)
+    process.add_(cms.Service("SiteLocalConfigService",
+                             overrideSourceCacheHintDir = cms.untracked.string("lazy-download")
+                             ))
     return process
 
 def customisePostEra_Run3_2025_UPC(process):


### PR DESCRIPTION
#### PR description:

A work around to fix https://github.com/cms-sw/cmssw/issues/49398

Note: Just wondering, if we add this to prompt-reco config, the lazy-download will cause issue when we reconstruct file remotely (e.g. in Tier-1). This should be clarified before using this PR.

#### PR validation:
Run configuration dumped from the following script
`python3 RunPromptReco.py --scenario=ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2025 --aod --miniaod --dqmio --global-tag 151X_dataRun3_Prompt_v1 --lfn=/store/group/offcomp_upgrade-sw/srimanob/tier-0/50b15664-e318-495a-bcfe-985014b38be3.root --nThreads=8 --no-output`
(need to add `skipEvents = 833` to reach the error)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Need backport to 15_1