### PR TITLE
Include Eigen core library before the SoA definitions

### DIFF
--- a/DataFormats/ParticleFlowReco/interface/CaloRecHitSoA.h
+++ b/DataFormats/ParticleFlowReco/interface/CaloRecHitSoA.h
@@ -1,9 +1,6 @@
 #ifndef DataFormats_ParticleFlowReco_interface_CaloRecHitSoA_h
 #define DataFormats_ParticleFlowReco_interface_CaloRecHitSoA_h
 
-#include <Eigen/Core>
-#include <Eigen/Dense>
-
 #include "DataFormats/SoATemplate/interface/SoACommon.h"
 #include "DataFormats/SoATemplate/interface/SoALayout.h"
 

--- a/DataFormats/ParticleFlowReco/src/alpaka/classes_cuda.h
+++ b/DataFormats/ParticleFlowReco/src/alpaka/classes_cuda.h
@@ -1,3 +1,6 @@
+// Include Eigen core library before include the SoA definitions
+#include <Eigen/Core>
+
 #include "DataFormats/Common/interface/DeviceProduct.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/ParticleFlowReco/interface/CaloRecHitSoA.h"

--- a/DataFormats/ParticleFlowReco/src/alpaka/classes_rocm.h
+++ b/DataFormats/ParticleFlowReco/src/alpaka/classes_rocm.h
@@ -1,3 +1,6 @@
+// Include Eigen core library before include the SoA definitions
+#include <Eigen/Core>
+
 #include "DataFormats/Common/interface/DeviceProduct.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/ParticleFlowReco/interface/CaloRecHitSoA.h"

--- a/DataFormats/ParticleFlowReco/src/classes_serial.cc
+++ b/DataFormats/ParticleFlowReco/src/classes_serial.cc
@@ -1,3 +1,6 @@
+// Include Eigen core library before include the SoA definitions
+#include <Eigen/Core>
+
 #include "DataFormats/ParticleFlowReco/interface/CaloRecHitHostCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/PFClusterHostCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFractionHostCollection.h"

--- a/DataFormats/ParticleFlowReco/src/classes_serial.h
+++ b/DataFormats/ParticleFlowReco/src/classes_serial.h
@@ -1,3 +1,6 @@
+// Include Eigen core library before include the SoA definitions
+#include <Eigen/Core>
+
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/ParticleFlowReco/interface/CaloRecHitHostCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/CaloRecHitSoA.h"

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.h
@@ -1,6 +1,9 @@
 #ifndef RecoParticleFlow_PFClusterProducer_PFClusterProducerAlpakaKernel_h
 #define RecoParticleFlow_PFClusterProducer_PFClusterProducerAlpakaKernel_h
 
+// Include Eigen core library before include the SoA definitions
+#include <Eigen/Core>
+
 #include "DataFormats/ParticleFlowReco/interface/alpaka/PFClusterDeviceCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitDeviceCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitFractionDeviceCollection.h"

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CalorimeterDefinitions.h
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CalorimeterDefinitions.h
@@ -3,20 +3,22 @@
 
 #include <limits>
 
+// Include Eigen core library before include the SoA definitions
+#include <Eigen/Core>
+
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 #include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitHostCollection.h"
+#include "DataFormats/HcalRecHit/interface/alpaka/HcalRecHitDeviceCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/CaloRecHitHostCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/alpaka/CaloRecHitDeviceCollection.h"
 #include "RecoParticleFlow/PFRecHitProducer/interface/PFRecHitTopologyHostCollection.h"
 #include "RecoParticleFlow/PFRecHitProducer/interface/alpaka/PFRecHitParamsDeviceCollection.h"
 #include "RecoParticleFlow/PFRecHitProducer/interface/alpaka/PFRecHitTopologyDeviceCollection.h"
-
-#include "DataFormats/HcalRecHit/interface/HcalRecHitHostCollection.h"
-#include "DataFormats/HcalRecHit/interface/alpaka/HcalRecHitDeviceCollection.h"
 
 // Forward declaration of EventSetup records, to avoid propagating the dependency on framework headers to device code
 class PFRecHitHCALParamsRecord;

--- a/RecoParticleFlow/PFRecHitProducer/test/PFRecHitProducerTest.cc
+++ b/RecoParticleFlow/PFRecHitProducer/test/PFRecHitProducerTest.cc
@@ -7,6 +7,9 @@
 #include <utility>
 #include <variant>
 
+// Include Eigen core library before include the SoA definitions
+#include <Eigen/Core>
+
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/Common/interface/Handle.h"


### PR DESCRIPTION
#### PR description:

Remove the inclusion of Eigen from the SoA data formats that do not use it, and add it in the files that include multiple SoA data formats so it always comes before the SoA definitions.

#### PR validation:

None.