### PR TITLE
GenParticles2HepMC: connect orphans to beams (15_1)

### DIFF
--- a/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
+++ b/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
@@ -188,6 +188,15 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
     if (p == parton1 or p == parton2)
       continue;
 
+    // No mother info: connect to the incident proton vertex
+    if (p->numberOfMothers() == 0) {
+      if (p->pz() > 0) {
+        vertex1->add_particle_out(genCandToHepMCMap[p]);
+      } else {
+        vertex2->add_particle_out(genCandToHepMCMap[p]);
+      }
+      continue;
+    }
     // Connect mother-daughters for the other cases
     for (unsigned int j = 0, nMothers = p->numberOfMothers(); j < nMothers; ++j) {
       // Mother-daughter hierarchy defines vertex


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/49447
