### PR TITLE
[15_1_0_patch3_X] Disable the cache for HIN processing

### DIFF
--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -143,10 +143,18 @@ def customisePostEra_Run3_2024_ppRef(process):
 
 def customisePostEra_Run3_pp_on_PbPb_2025(process):
     customisePostEra_Run3_2025(process)
+    process.source.cacheSize = cms.untracked.uint32(0)
+    process.add_(cms.Service("SiteLocalConfigService",
+                             overrideSourceCacheHintDir = cms.untracked.string("lazy-download")
+                             ))
     return process
 
 def customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters_2025(process):
     customisePostEra_Run3_pp_on_PbPb_2025(process)
+    process.source.cacheSize = cms.untracked.uint32(0)
+    process.add_(cms.Service("SiteLocalConfigService",
+                             overrideSourceCacheHintDir = cms.untracked.string("lazy-download")
+                             ))
     return process
 
 def customisePostEra_Run3_2025_UPC(process):


### PR DESCRIPTION
#### PR description:
As discussed in the Joint Meeting on Nov 24, we will provide a workaround release for jobs affected by the ROOT issue described in https://github.com/cms-sw/cmssw/issues/49398

A new release will be prepared based on CMSSW_15_1_0_patch3, with this PR applied on top. This is to avoid using lazy-download to all jobs.

#### PR validation:
Tested in https://github.com/cms-sw/cmssw/pull/49443
This PR is a carbon copy of it.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
This is a backport PR.
