### PR TITLE
Phase2-hgx364S Remove D110 from the default names in many of the test scripts of HGCal

### DIFF
--- a/Geometry/CaloTopology/test/testHGCalTopology_cfg.py
+++ b/Geometry/CaloTopology/test/testHGCalTopology_cfg.py
@@ -1,10 +1,18 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("PROD")
+geomName = "Run4D121"
+geomFile = "Configuration.Geometry.GeometryExtended" + geomName + "Reco_cff"
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+GLOBAL_TAG, ERA = _settings.get_era_and_conditions(geomName)
+
+process = cms.Process("PROD", ERA)
 process.load("SimGeneral.HepPDTESSource.pdt_cfi")
-process.load("Configuration.Geometry.GeometryExtendedRun4D110Reco_cff")
+process.load(geomFile)
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.load("Geometry.CaloTopology.hgcalTopologyTester_cfi")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, GLOBAL_TAG, '')
 
 if 'MessageLogger' in process.__dict__:
     process.MessageLogger.HGCalGeom=dict()

--- a/Geometry/HGCalCommonData/test/python/dumpHGCalGeometryDD4hep_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/dumpHGCalGeometryDD4hep_cfg.py
@@ -1,10 +1,11 @@
 ###############################################################################
 # Way to use this:
-#   cmsRun dumpHGCalGeometryDD4hep_cfg.py geometry=D110
+#   cmsRun dumpHGCalGeometryDD4hep_cfg.py geometry=D121
 #
 #   Options for geometry D95, D96, D98, D99, D100, D101, D102, D103, D104,
 #                        D105, D106, D107, D108, D109, D110, D111, D112, D113,
-#                        D114, D115, D116, D117, D118, D119, D120
+#                        D114, D115, D116, D117, D118, D119, D120, D121, D122,
+#                        D123, D124, D125
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
@@ -15,10 +16,10 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 ### SETUP OPTIONS
 options = VarParsing.VarParsing('standard')
 options.register('geometry',
-                 "D110",
+                 "D121",
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
-                  "geometry of operations: D95, D96, D98, D99, D100, D101, D102, D103, D104, D105, D106, D107, D108, D109, D110, D111, D112, D113, D114, D115, D116, D117, D118, D119, D120")
+                  "geometry of operations: D95, D96, D98, D99, D100, D101, D102, D103, D104, D105, D106, D107, D108, D109, D110, D111, D112, D113, D114, D115, D116, D117, D118, D119, D120, D121, D122, D123, D124, D125")
 
 ### get and parse the command line arguments
 options.parseArguments()
@@ -27,14 +28,21 @@ print(options)
 
 ####################################################################
 # Use the options
-from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
-process = cms.Process('GeomDump',Phase2C17I13M9)
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+geomName = "Run4" + options.geometry
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+GLOBAL_TAG, ERA = _settings.get_era_and_conditions(geomName)
 
-geomFile = "Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometryRun4" + options.geometry + ".xml"
-fileName = "CMSRun4" + options.geometry + "DD4hep.root"
+geomFile = "Configuration.Geometry.GeometryDD4hepExtended" + geomName + "Reco_cff"
+fileName = "CMS" + geomName + "DD4hep.root"
 
-print("Geometry file: ", geomFile)
-print("Output file:   ", fileName)
+print("Geometry Name:   ", geomName)
+print("Geometry file:   ", geomFile)
+print("Output file:     ", fileName)
+print("Global Tag Name: ", GLOBAL_TAG)
+print("Era Name:        ", ERA)
+
+process = cms.Process('GeomDump',ERA)
 
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.source = cms.Source("EmptySource")

--- a/Geometry/HGCalCommonData/test/python/dumpHGCalGeometryDDD_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/dumpHGCalGeometryDDD_cfg.py
@@ -1,10 +1,11 @@
 ###############################################################################
 # Way to use this:
-#   cmsRun dumpHGCalGeometryDDD_cfg.py geometry=D110
+#   cmsRun dumpHGCalGeometryDDD_cfg.py geometry=D121
 #
 #   Options for geometry D95, D96, D98, D99, D100, D101, D102, D103, D104,
 #                        D105, D106, D107, D108, D109, D110, D111, D112, D113,
-#                        D114, D115, D116, D117, D118, D119, D120
+#                        D114, D115, D116, D117, D118, D119, D120, D121, D122,
+#                        D123, D124, D125
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
@@ -15,10 +16,10 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 ### SETUP OPTIONS
 options = VarParsing.VarParsing('standard')
 options.register('geometry',
-                 "D110",
+                 "D121",
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
-                  "geometry of operations: D95, D96, D98, D99, D100, D101, D102, D103, D104, D105, D106, D107, D108, D109, D110, D111, D112, D113, D114, D115, D116, D117, D118, D119, D120")
+                  "geometry of operations: D95, D96, D98, D99, D100, D101, D102, D103, D104, D105, D106, D107, D108, D109, D110, D111, D112, D113, D114, D115, D116, D117, D118, D119, D120, D121, D122, D123, D124, D125")
 
 ### get and parse the command line arguments
 options.parseArguments()
@@ -27,14 +28,19 @@ print(options)
 
 ####################################################################
 # Use the options
-from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
-process = cms.Process('GeomDump',Phase2C17I13M9)
+geomName = "Run4" + options.geometry
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+GLOBAL_TAG, ERA = _settings.get_era_and_conditions(geomName)
 
-geomFile = "Configuration.Geometry.GeometryExtendedRun4" + options.geometry + "Reco_cff"
-fileName = "CMSRun4" + options.geometry + "DDD.root"
+process = cms.Process('GeomDump',ERA)
+geomFile = "Configuration.Geometry.GeometryExtended" + geomName + "Reco_cff"
+fileName = "CMS" + geomName + "DDD.root"
 
-print("Geometry file: ", geomFile)
-print("Output file:   ", fileName)
+print("Geometry Name:   ", geomName)
+print("Geometry file:   ", geomFile)
+print("Output file:     ", fileName)
+print("Global Tag Name: ", GLOBAL_TAG)
+print("Era Name:        ", ERA)
 
 process.load(geomFile)
 process.load('FWCore.MessageService.MessageLogger_cfi')

--- a/Geometry/HGCalCommonData/test/python/runHGCalDD4hep_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/runHGCalDD4hep_cfg.py
@@ -1,10 +1,11 @@
 ###############################################################################
 # Way to use this:
-#   cmsRun runHGCalDD4hep_cfg.py geometry=D110
+#   cmsRun runHGCalDD4hep_cfg.py geometry=D120
 #
 #   Options for geometry D95, D96, D98, D99, D100, D101, D102, D103, D104,
 #                        D105, D106, D107, D108, D109, D110, D111, D112, D113,
-#                        D114, D115, D116, D117, D118, D119, D120
+#                        D114, D115, D116, D117, D118, D119, D120, D121, D122,
+#                        D123, D124, D125
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
@@ -15,10 +16,10 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 ### SETUP OPTIONS
 options = VarParsing.VarParsing('standard')
 options.register('geometry',
-                 "D110",
+                 "D121",
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
-                  "geometry of operations: D95, D96, D98, D99, D100, D101, D102, D103, D104, D105, D106, D107, D108, D109, D110, D111, D112, D113, D114, D115, D116, D117, D118, D119, D120")
+                  "geometry of operations: D95, D96, D98, D99, D100, D101, D102, D103, D104, D105, D106, D107, D108, D109, D110, D111, D112, D113, D114, D115, D116, D117, D118, D119, D120, D121, D122, D123, D124, D125")
 
 ### get and parse the command line arguments
 options.parseArguments()
@@ -27,13 +28,18 @@ print(options)
 
 ####################################################################
 # Use the options
-from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
-process = cms.Process('SIM',Phase2C17I13M9,dd4hep)
+geomName = "Run4" + options.geometry
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+GLOBAL_TAG, ERA = _settings.get_era_and_conditions(geomName)
 
-geomFile = "Configuration.Geometry.GeometryDD4hepExtendedRun4" + options.geometry + "Reco_cff"
+process = cms.Process('SIM',ERA,dd4hep)
+geomFile = "Configuration.Geometry.GeometryDD4hepExtended" + geomName + "Reco_cff"
 
-print("Geometry file: ", geomFile)
+print("Geometry Name:   ", geomName)
+print("Geometry file:   ", geomFile)
+print("Global Tag Name: ", GLOBAL_TAG)
+print("Era Name:        ", ERA)
 
 # import of standard configurations
 process.load(geomFile)
@@ -98,7 +104,7 @@ process.configurationMetadata = cms.untracked.PSet(
 # Other statements
 process.genstepfilter.triggerConditions=cms.vstring("generation_step")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, GLOBAL_TAG, '')
 
 process.generator = cms.EDFilter("Pythia8GeneratorFilter",
     PythiaParameters = cms.PSet(

--- a/Geometry/HGCalCommonData/test/python/runHGCalDDD_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/runHGCalDDD_cfg.py
@@ -4,7 +4,8 @@
 #
 #   Options for geometry D95, D96, D98, D99, D100, D101, D102, D103, D104,
 #                        D105, D106, D107, D108, D109, D110, D111, D112, D113,
-#                        D114, D115, D116, D117, D118, D119, D120
+#                        D114, D115, D116, D117, D118, D119, D120, D121, D122,
+#                        D123, D124, D125
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
@@ -15,10 +16,10 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 ### SETUP OPTIONS
 options = VarParsing.VarParsing('standard')
 options.register('geometry',
-                 "D110",
+                 "D121",
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
-                  "geometry of operations: D95, D96, D98, D99, D100, D101, D102, D103, D104, D105, D106, D107, D108, D109, D110, D111, D112, D113, D114, D115, D116, D117, D118, D119, D120")
+                  "geometry of operations: D95, D96, D98, D99, D100, D101, D102, D103, D104, D105, D106, D107, D108, D109, D110, D111, D112, D113, D114, D115, D116, D117, D118, D119, D120, D121, D122, D123, D124, D125")
 
 ### get and parse the command line arguments
 options.parseArguments()
@@ -27,10 +28,17 @@ print(options)
 
 ####################################################################
 # Use the options
-from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
-process = cms.Process('SIM',Phase2C17I13M9)
+geomName = "Run4" + options.geometry
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+GLOBAL_TAG, ERA = _settings.get_era_and_conditions(geomName)
 
-geomFile = "Configuration.Geometry.GeometryExtendedRun4" + options.geometry + "Reco_cff"
+geomFile = "Configuration.Geometry.GeometryExtended" + geomName + "Reco_cff"
+
+print("Geometry Name:   ", geomName)
+print("Geometry file:   ", geomFile)
+print("Global Tag Name: ", GLOBAL_TAG)
+print("Era Name:        ", ERA)
+process = cms.Process('SIM',ERA)
 
 print("Geometry file: ", geomFile)
 
@@ -97,7 +105,7 @@ process.configurationMetadata = cms.untracked.PSet(
 # Other statements
 process.genstepfilter.triggerConditions=cms.vstring("generation_step")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, GLOBAL_TAG, '')
 
 process.generator = cms.EDFilter("Pythia8GeneratorFilter",
     PythiaParameters = cms.PSet(

--- a/Geometry/HGCalCommonData/test/python/testHGCGeometry_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/testHGCGeometry_cfg.py
@@ -1,10 +1,10 @@
 ###############################################################################
 # Way to use this:
-#   cmsRun testHGCGeometry_cfg.py geometry=D110
+#   cmsRun testHGCGeometry_cfg.py geometry=D121
 #
 #   Options for geometry D95, D96, D98, D99, D100, D101, D102, D103, D104,
 #                        D105, D106, D107, D108, D109, D110, D111, D112, D113,
-#                        D114, D115, D116, D120
+#                        D114, D115, D116, D120, D121, D122, D123, D124, D125
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
@@ -15,10 +15,10 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 ### SETUP OPTIONS
 options = VarParsing.VarParsing('standard')
 options.register('geometry',
-                 "D110",
+                 "D121",
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
-                  "geometry of operations: D95, D96, D98, D99, D100, D101, D102, D103, D104, D105, D106, D107, D108, D109, D110, D111, D112, D113, D114, D115, D116, D120")
+                  "geometry of operations: D95, D96, D98, D99, D100, D101, D102, D103, D104, D105, D106, D107, D108, D109, D110, D111, D112, D113, D114, D115, D116, D120, D121, D122, D123, D124, D125")
 
 ### get and parse the command line arguments
 options.parseArguments()
@@ -27,21 +27,21 @@ print(options)
 
 ####################################################################
 # Use the options
-from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
-process = cms.Process('TestHGCalGeometry',Phase2C17I13M9)
+geomName = "Run4" + options.geometry
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+GLOBAL_TAG, ERA = _settings.get_era_and_conditions(geomName)
 
-geomFile = "Geometry.CMSCommonData.cmsExtendedGeometryRun4" + options.geometry + "XML_cfi"
+geomFile = "Configuration.Geometry.GeometryExtended" + geomName + "Reco_cff"
 
-print("Geometry file: ", geomFile)
+print("Geometry Name:   ", geomName)
+print("Geometry file:   ", geomFile)
+print("Global Tag Name: ", GLOBAL_TAG)
+print("Era Name:        ", ERA)
+
+process = cms.Process('TestHGCalGeometry',ERA)
 
 process.load("SimGeneral.HepPDTESSource.pdt_cfi")
 process.load(geomFile)
-process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
-process.load("Geometry.MuonNumbering.muonNumberingInitialization_cfi")
-process.load("Geometry.EcalCommonData.ecalSimulationParameters_cff")
-process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cff")
-process.load("Geometry.HGCalCommonData.hgcalParametersInitialization_cfi")
-process.load("Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi")
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load("Geometry.HGCalCommonData.hgcGeometryTester_cfi")
 

--- a/Geometry/HGCalCommonData/test/python/testHGCalPartialMissingIDTester_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/testHGCalPartialMissingIDTester_cfg.py
@@ -14,10 +14,10 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 ### SETUP OPTIONS
 options = VarParsing.VarParsing('standard')
 options.register('geometry',
-                 "D110",
+                 "D121",
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
-                  "geometry of operations: D98, D99, D110")
+                  "geometry of operations: D98, D99, D121")
 options.register('type',
                  "DDD",
                   VarParsing.VarParsing.multiplicity.singleton,
@@ -31,22 +31,26 @@ print(options)
 
 ####################################################################
 # Use the options
+geomName = "Run4" + options.geometry
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+GLOBAL_TAG, ERA = _settings.get_era_and_conditions(geomName)
 
 from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 if (options.type == "DD4hep"):
     from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
-    process = cms.Process('SimRun4',Phase2C17I13M9,dd4hep)
-    geomFile = "Configuration.Geometry.Geometry" + options.type +"ExtendedRun4" + options.geometry + "Reco_cff"
+    process = cms.Process('SimRun4',ERA,dd4hep)
+    geomFile = "Configuration.Geometry.Geometry" + options.type + geomName + "Reco_cff"
 else:
-    process = cms.Process('SimRun4',Phase2C17I13M9)
-    geomFile = "Configuration.Geometry.GeometryExtendedRun4" + options.geometry + "Reco_cff"
+    process = cms.Process('SimRun4',ERA)
+    geomFile = "Configuration.Geometry.GeometryExtended" + geomName + "Reco_cff"
 
-globalTag = "auto:phase2_realistic_T25"
 inFile = "partialMiss" + options.geometry + ".txt"
 
-print("Geometry file: ", geomFile)
-print("Global Tag:    ", globalTag)
-print("Input file:    ", inFile)
+print("Geometry Name:   ", geomName)
+print("Geometry file:   ", geomFile)
+print("Global Tag Name: ", GLOBAL_TAG)
+print("Era Name:        ", ERA)
+print("Input file:      ", inFile)
 
 process.load(geomFile)
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
@@ -57,7 +61,7 @@ process.load("Configuration.EventContent.EventContent_cff")
 process.load("Configuration.StandardSequences.SimIdeal_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, globalTag, '')
+process.GlobalTag = GlobalTag(process.GlobalTag, GLOBAL_TAG, '')
 
 process.source = cms.Source("EmptySource")
 

--- a/Geometry/HGCalCommonData/test/python/testHGCalPartialWaferTester_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/testHGCalPartialWaferTester_cfg.py
@@ -4,7 +4,8 @@
 #
 #   Options for geometry D95, D96, D98, D99, D100, D101, D102, D103, D104,
 #                        D105, D106, D107, D108, D109, D110, D111, D112,
-#                        D113, D114, D115, D116, D120
+#                        D113, D114, D115, D116, D120, D121, D122, D123,
+#                        D124, D125
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
@@ -15,10 +16,10 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 ### SETUP OPTIONS
 options = VarParsing.VarParsing('standard')
 options.register('geometry',
-                 "D110",
+                 "D121",
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
-                  "geometry of operations: D95, D96, D98, D99, D100, D101, D102, D103, D104, D105, D106, D107, D108, D109, D110, D111, D112, D113, D114, D115, D116, D120")
+                  "geometry of operations: D95, D96, D98, D99, D100, D101, D102, D103, D104, D105, D106, D107, D108, D109, D110, D111, D112, D113, D114, D115, D116, D120, D121, D122, D123, D124, D125")
 
 ### get and parse the command line arguments
 options.parseArguments()
@@ -26,10 +27,13 @@ print(options)
 
 ####################################################################
 # Use the options
-from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
-process = cms.Process('PartailWaferTester',Phase2C17I13M9)
+geomName = "Run4" + options.geometry
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+GLOBAL_TAG, ERA = _settings.get_era_and_conditions(geomName)
 
-geomFile = "Configuration.Geometry.GeometryExtendedRun4" + options.geometry + "Reco_cff"
+process = cms.Process('PartialWaferTester',ERA)
+
+geomFile = "Configuration.Geometry.GeometryExtended" + geomName + "Reco_cff"
 
 print("Geometry file: ", geomFile)
 

--- a/Geometry/HGCalCommonData/test/python/testHGCalScintID_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/testHGCalScintID_cfg.py
@@ -1,6 +1,6 @@
 ###############################################################################
 # Way to use this:
-#   cmsRun testHGCalScintID_cfg.py geometry=D110
+#   cmsRun testHGCalScintID_cfg.py geometry=D121
 #
 #   Options for geometry D88
 #
@@ -13,10 +13,10 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 ### SETUP OPTIONS
 options = VarParsing.VarParsing('standard')
 options.register('geometry',
-                 "D88",
+                 "D121",
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
-                  "geometry of operations: D88")
+                  "geometry of operations: D88, D110, D121")
 
 ### get and parse the command line arguments
 options.parseArguments()
@@ -25,10 +25,12 @@ print(options)
 
 ####################################################################
 # Use the options
-from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
-process = cms.Process('TestHGCalScintID',Phase2C17I13M9)
+geomName = "Run4" + options.geometry
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+GLOBAL_TAG, ERA = _settings.get_era_and_conditions(geomName)
+process = cms.Process('TestHGCalScintID',ERA)
 
-geomFile = "Configuration.Geometry.GeometryExtendedRun4" + options.geometry + "_cff"
+geomFile = "Configuration.Geometry.GeometryExtended" + geomName + "_cff"
 inputFile = "errorScint" + options.geometry + ".txt"
 
 print("Geometry file: ", geomFile)

--- a/Geometry/HGCalCommonData/test/python/testHGCalValidHex_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/testHGCalValidHex_cfg.py
@@ -1,10 +1,10 @@
 ###############################################################################
 # Way to use this:
-#   cmsRun testHGCalValidHex_cfg.py geometry=D110
+#   cmsRun testHGCalValidHex_cfg.py geometry=D121
 #
 #   Options for geometry D95, D96, D98, D99, D100, D101, D102, D103, D104,
 #                        D105, D106, D107, D108, D109, D110, D111, D112, D113,
-#                        D114, D115, D116, D120
+#                        D114, D115, D116, D120, D121, D122, D123, D124, D125
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
@@ -15,10 +15,10 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 ### SETUP OPTIONS
 options = VarParsing.VarParsing('standard')
 options.register('geometry',
-                 "D110",
+                 "D121",
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
-                  "geometry of operations: D95, D96, D98, D99, D100, D101, D102, D103, D104, D105, D106, D107, D108, D109, D110, D111, D112, D113, D114, D115, D116, D120")
+                  "geometry of operations: D95, D96, D98, D99, D100, D101, D102, D103, D104, D105, D106, D107, D108, D109, D110, D111, D112, D113, D114, D115, D116, D120, D121, D122, D123, D124, D125")
 
 ### get and parse the command line arguments
 options.parseArguments()
@@ -27,10 +27,12 @@ print(options)
 
 ####################################################################
 # Use the options
-from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
-process = cms.Process('HGCalVlaidHex',Phase2C17I13M9)
+geomName = "Run4" + options.geometry
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+GLOBAL_TAG, ERA = _settings.get_era_and_conditions(geomName)
+process = cms.Process('HGCalValidHex',ERA)
 
-geomFile = "Configuration.Geometry.GeometryExtendedRun4" + options.geometry + "_cff"
+geomFile = "Configuration.Geometry.GeometryExtended" + geomName + "_cff"
 
 print("Geometry file: ", geomFile)
 

--- a/Geometry/HGCalCommonData/test/python/testHGCalValidity_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/testHGCalValidity_cfg.py
@@ -1,6 +1,6 @@
 ###############################################################################
 # Way to use this:
-#   cmsRun testHGCalValidityCheck_cfg.py geometry=D110
+#   cmsRun testHGCalValidityCheck_cfg.py geometry=D121
 #
 #   Options for geometry D88, D92
 #
@@ -13,10 +13,10 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 ### SETUP OPTIONS
 options = VarParsing.VarParsing('standard')
 options.register('geometry',
-                 "D110",
+                 "D121",
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
-                  "geometry of operations: D88, D92, D110")
+                  "geometry of operations: D88, D92, D110, D121")
 
 ### get and parse the command line arguments
 options.parseArguments()
@@ -24,10 +24,12 @@ print(options)
 
 ####################################################################
 # Use the options
-from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
-process = cms.Process('GeomCheck',Phase2C17I13M9)
+geomName = "Run4" + options.geometry
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+GLOBAL_TAG, ERA = _settings.get_era_and_conditions(geomName)
+process = cms.Process('HGCalValidity',ERA)
 
-geomFile = "Configuration.Geometry.GeometryExtendedRun4" + options.geometry + "Reco_cff"
+geomFile = "Configuration.Geometry.GeometryExtended" + geomName + "Reco_cff"
 inFile = "miss" + options.geometry + ".txt"
 
 print("Geometry file: ", geomFile)

--- a/Geometry/HGCalCommonData/test/python/testHGCalWaferID_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/testHGCalWaferID_cfg.py
@@ -43,7 +43,7 @@ elif (options.type == "V16"):
 elif (options.type == "V19"):
     geomFile = "Configuration.Geometry.GeometryExtendedRun4D120_cff"
 else:
-    geomFile = "Configuration.Geometry.GeometryExtendedRun4D110_cff"
+    geomFile = "Configuration.Geometry.GeometryExtendedRun4D121_cff"
 
 print("Geometry file: ", geomFile)
 

--- a/Geometry/HGCalCommonData/test/python/testHGCalWafer_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/testHGCalWafer_cfg.py
@@ -1,10 +1,11 @@
 ###############################################################################
 # Way to use this:
-#   cmsRun testHGCalWafer_cfg.py geometry=D110
+#   cmsRun testHGCalWafer_cfg.py geometry=D121
 #
 #   Options for geometry D95, D96, D98, D99, D100, D101, D102, D103, D104,
 #                        D105, D106, D107, D108, D109, D110, D111, D112,
-#                        D113, D114, D115, D116, D117, D118, D119, D120
+#                        D113, D114, D115, D116, D117, D118, D119, D120,
+#                        D121, D122, D123, D124, D125
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
@@ -15,10 +16,10 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 ### SETUP OPTIONS
 options = VarParsing.VarParsing('standard')
 options.register('geometry',
-                 "D110",
+                 "D121",
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
-                  "geometry of operations: D95, D96, D98, D99, D100, D101, D102, D103, D104, D105, D106, D107, D108, D109, D110, D111, D112, D113, D114, D115, D116, D117, D118, D119, D120")
+                  "geometry of operations: D95, D96, D98, D99, D100, D101, D102, D103, D104, D105, D106, D107, D108, D109, D110, D111, D112, D113, D114, D115, D116, D117, D118, D119, D120, D121, D122, D123, D124, D125")
 
 ### get and parse the command line arguments
 options.parseArguments()
@@ -27,9 +28,13 @@ print(options)
 
 ####################################################################
 # Use the options
-from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
-process = cms.Process('HGCalWafer',Phase2C17I13M9)
+geomName = "Run4" + options.geometry
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+GLOBAL_TAG, ERA = _settings.get_era_and_conditions(geomName)
 
+process = cms.Process('HGCalWafer',ERA)
+
+geomFile = "Configuration.Geometry.GeometryExtended" + geomName + "Reco_cff"
 geomFile = "Configuration.Geometry.GeometryExtendedRun4" + options.geometry + "_cff"
 
 print("Geometry file: ", geomFile)


### PR DESCRIPTION
#### PR description:

Remove D110 from the default names in many of the test scripts of HGCal

#### PR validation:

Tested the scripts

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special