### PR TITLE
Change threshold for ECAL DQM Laser quality plot

### DIFF
--- a/DQM/EcalMonitorClient/python/LaserClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/LaserClient_cfi.py
@@ -7,7 +7,7 @@ from DQM.EcalMonitorTasks.LaserTask_cfi import ecalLaserTask
 forwardFactor = 0.5
 minChannelEntries = 3
 expectedAmplitude = [1700.0, 1300.0, 1700.0, 1700.0]
-toleranceAmplitudeLo = 0.1
+toleranceAmplitudeLo = 0.06
 toleranceAmplitudeFwdLo = 0.01
 toleranceAmplitudeHi = 2.06
 toleranceAmpRMSRatio = 0.3


### PR DESCRIPTION
#### PR description:

This PR adjusts the threshold on amplitude of the Laser quality plots in ECAL DQM to remove red spots in the endcaps.

#### PR validation:

PR is validated by running the ECAL online DQM configuration and verifying the plots on a test DQM GUI.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is to Master. The backport to 151X in production is https://github.com/cms-sw/cmssw/pull/49467

