### PR TITLE
Define dictionaries for `X::Layout` type aliases in DataFormats/HGCalDigi

### DIFF
--- a/DataFormats/HGCalDigi/src/classes_def.xml
+++ b/DataFormats/HGCalDigi/src/classes_def.xml
@@ -41,9 +41,11 @@
   </class>
   <class name="edm::Wrapper<HGCalSlinkEmulatorInfo>"/>
 
+  <class name="hgcaldigi::HGCalDigiHost"/>
+  <!-- ::Layout alias must be listed before the aliased-to type -->
+  <class name="hgcaldigi::HGCalDigiHost::Layout"/>
   <class name="hgcaldigi::HGCalDigiSoA"/>
   <class name="hgcaldigi::HGCalDigiSoA::View"/>
-  <class name="hgcaldigi::HGCalDigiHost"/>
 
   <class name="hgcaldigi::HGCalDigiSoALayout<128,false>"/>
   <class name="edm::Wrapper<PortableHostCollection<hgcaldigi::HGCalDigiSoALayout<128,false> > >" splitLevel="0" rntupleStreamerMode="true"/>
@@ -51,19 +53,25 @@
   <!-- Recursive templates implementing the association of indices and layouts, and containing the data -->
   <class name="portablecollection::CollectionLeaf<0, hgcaldigi::HGCalDigiSoALayout<128, false>>"/>
 
+  <class name="hgcaldigi::HGCalECONDPacketInfoHost" rntupleStreamerMode="true"/>
+  <!-- ::Layout alias must be listed before the aliased-to type -->
+  <class name="hgcaldigi::HGCalECONDPacketInfoHost::Layout"/>
   <class name="hgcaldigi::HGCalECONDPacketInfoSoA"/>
   <class name="hgcaldigi::HGCalECONDPacketInfoSoA::View"/>
-  <class name="hgcaldigi::HGCalECONDPacketInfoHost" rntupleStreamerMode="true"/>
   <class name="edm::Wrapper<hgcaldigi::HGCalECONDPacketInfoHost>" splitLevel="0"/>
 
+  <class name="hgcaldigi::HGCalFEDPacketInfoHost" rntupleStreamerMode="true"/>
+  <!-- ::Layout alias must be listed before the aliased-to type -->
+  <class name="hgcaldigi::HGCalFEDPacketInfoHost::Layout"/>
   <class name="hgcaldigi::HGCalFEDPacketInfoSoA"/>
   <class name="hgcaldigi::HGCalFEDPacketInfoSoA::View"/>
-  <class name="hgcaldigi::HGCalFEDPacketInfoHost" rntupleStreamerMode="true"/>
   <class name="edm::Wrapper<hgcaldigi::HGCalFEDPacketInfoHost>" splitLevel="0"/>
 
+  <class name="hgcaldigi::HGCalDigiTriggerHost"/>
+  <!-- ::Layout alias must be listed before the aliased-to type -->
+  <class name="hgcaldigi::HGCalDigiTriggerHost::Layout"/>
   <class name="hgcaldigi::HGCalDigiTriggerSoA"/>
   <class name="hgcaldigi::HGCalDigiTriggerSoA::View"/>
-  <class name="hgcaldigi::HGCalDigiTriggerHost"/>
   <class name="hgcaldigi::HGCalDigiTriggerSoALayout<128,false>"/>
   <class name="edm::Wrapper<PortableHostCollection<hgcaldigi::HGCalDigiTriggerSoALayout<128,false> > >" splitLevel="0"/>
   <class name="portablecollection::CollectionLeaf<0, hgcaldigi::HGCalDigiTriggerSoALayout<128, false>>"/>

--- a/DataFormats/HGCalDigi/src/classes_def.xml
+++ b/DataFormats/HGCalDigi/src/classes_def.xml
@@ -41,14 +41,14 @@
   </class>
   <class name="edm::Wrapper<HGCalSlinkEmulatorInfo>"/>
 
-  <class name="hgcaldigi::HGCalDigiHost"/>
+  <class name="hgcaldigi::HGCalDigiHost"  rntupleStreamerMode="true"/>
   <!-- ::Layout alias must be listed before the aliased-to type -->
   <class name="hgcaldigi::HGCalDigiHost::Layout"/>
   <class name="hgcaldigi::HGCalDigiSoA"/>
   <class name="hgcaldigi::HGCalDigiSoA::View"/>
 
   <class name="hgcaldigi::HGCalDigiSoALayout<128,false>"/>
-  <class name="edm::Wrapper<PortableHostCollection<hgcaldigi::HGCalDigiSoALayout<128,false> > >" splitLevel="0" rntupleStreamerMode="true"/>
+  <class name="edm::Wrapper<PortableHostCollection<hgcaldigi::HGCalDigiSoALayout<128,false> > >" splitLevel="0"/>
 
   <!-- Recursive templates implementing the association of indices and layouts, and containing the data -->
   <class name="portablecollection::CollectionLeaf<0, hgcaldigi::HGCalDigiSoALayout<128, false>>"/>
@@ -67,7 +67,7 @@
   <class name="hgcaldigi::HGCalFEDPacketInfoSoA::View"/>
   <class name="edm::Wrapper<hgcaldigi::HGCalFEDPacketInfoHost>" splitLevel="0"/>
 
-  <class name="hgcaldigi::HGCalDigiTriggerHost"/>
+  <class name="hgcaldigi::HGCalDigiTriggerHost" rntupleStreamerMode="true"/>
   <!-- ::Layout alias must be listed before the aliased-to type -->
   <class name="hgcaldigi::HGCalDigiTriggerHost::Layout"/>
   <class name="hgcaldigi::HGCalDigiTriggerSoA"/>


### PR DESCRIPTION
#### PR description:

https://github.com/cms-sw/cmssw/issues/49470 reported auto-parsing failures related to `HGCalECONDPacketInfoSoALayout` (and somehow specific to using RNTuple output). Visual inspection of the `classes_def.xml` file showed that the `X::Layout` type alias has not been specified, while the read rule explicitly uses the `X::Layout` in a string form, and therefore a dictionary has to be specified in order to avoid header parsing. This PR adds entries for the `X::Layout` type aliases.

In addition this PR uses the `rntupleStreamerMode` attribute consistently for the `PortableHostCollection` types.

For more information on "why" see https://github.com/cms-sw/cmssw/issues/49458, https://github.com/cms-sw/cmssw/pull/48824.

Resolves https://github.com/cms-sw/cmssw/issues/49470
Resolves https://github.com/cms-sw/framework-team/issues/1703

#### PR validation:

The `DataFormatsHGCalDigi_xr.rootmap` file has entries for all the four `X::Layout` type aliases. Workflow 77.0 runs successfully in CMSSW_16_0_RNTUPLE_X_2025-11-24-2300 and this PR.