### PR TITLE
PF Offline DQM MiniAOD compatibility and jet calibration addition

### DIFF
--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
@@ -12,11 +12,12 @@
 // ***********************************************************
 PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   m_directory = "ParticleFlow";
-  m_isMiniAOD= true;
+  m_isMiniAOD = true;
   parameters_ = pSet.getParameter<edm::ParameterSet>("pfAnalysis");
 
   //patPfCandidateCollection_ = consumes<pat::PFParticleCollection>(pSet.getParameter<edm::InputTag>("pfCandidates"));
-  patPfCandidateCollection_ = consumes<pat::PackedCandidateCollection>(pSet.getParameter<edm::InputTag>("pfCandidates"));
+  patPfCandidateCollection_ =
+      consumes<pat::PackedCandidateCollection>(pSet.getParameter<edm::InputTag>("pfCandidates"));
   patJetsToken_ = consumes<pat::JetCollection>(pSet.getParameter<edm::InputTag>("pfJetCollection"));
 
   thePfCandidateCollection_ = consumes<reco::PFCandidateCollection>(pSet.getParameter<edm::InputTag>("pfCandidates"));
@@ -68,7 +69,6 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   m_funcMap["HCalE_depth5"] = getHcalEnergy_depth5;
   m_funcMap["HCalE_depth6"] = getHcalEnergy_depth6;
   m_funcMap["HCalE_depth7"] = getHcalEnergy_depth7;
-
 
   m_funcMap["PS1_E"] = getPS1Energy;
   m_funcMap["PS2_E"] = getPS2Energy;
@@ -123,14 +123,13 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   m_jetFuncMap["pt"] = getJetPt;
   m_jetFuncMap["chargeFrac"] = getJetChargeFrac;
 
-
-  m_particleTypeName[reco::PFCandidate::ParticleType::h]  = "chargedHadPFC";
-  m_particleTypeName[reco::PFCandidate::ParticleType::h0]  = "neutralHadPFC";
-  m_particleTypeName[reco::PFCandidate::ParticleType::e]  = "electronPFC";
-  m_particleTypeName[reco::PFCandidate::ParticleType::mu]  = "muonPFC";
-  m_particleTypeName[reco::PFCandidate::ParticleType::gamma]  = "gammaPFC";
-  m_particleTypeName[reco::PFCandidate::ParticleType::h_HF]  = "hadHFPFC";
-  m_particleTypeName[reco::PFCandidate::ParticleType::egamma_HF]  = "emHFPFC";
+  m_particleTypeName[reco::PFCandidate::ParticleType::h] = "chargedHadPFC";
+  m_particleTypeName[reco::PFCandidate::ParticleType::h0] = "neutralHadPFC";
+  m_particleTypeName[reco::PFCandidate::ParticleType::e] = "electronPFC";
+  m_particleTypeName[reco::PFCandidate::ParticleType::mu] = "muonPFC";
+  m_particleTypeName[reco::PFCandidate::ParticleType::gamma] = "gammaPFC";
+  m_particleTypeName[reco::PFCandidate::ParticleType::h_HF] = "hadHFPFC";
+  m_particleTypeName[reco::PFCandidate::ParticleType::egamma_HF] = "emHFPFC";
 
   // Convert the cutList strings into real cuts that can be applied
   // The format should be three comma separated values
@@ -159,11 +158,10 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
     }
   }
 
-
   for (unsigned int i = 0; i < m_cutList2D.size(); i++) {
     m_fullCutList2D.push_back(std::vector<std::string>());
-    while (m_cutList2D[i].find("]") != std::string::npos) {
-      size_t pos = m_cutList2D[i].find("]");
+    while (m_cutList2D[i].find(']') != std::string::npos) {
+      size_t pos = m_cutList2D[i].find(']');
       m_fullCutList2D[i].push_back(m_cutList2D[i].substr(1, pos));
       m_cutList2D[i].erase(0, pos + 1);
     }
@@ -172,7 +170,7 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   for (unsigned int i = 0; i < m_fullCutList2D.size(); i++) {
     m_binList2D.push_back(std::vector<std::vector<double>>());
     for (unsigned int j = 0; j < m_fullCutList2D[i].size(); j++) {
-      size_t pos = m_fullCutList2D[i][j].find(";");
+      size_t pos = m_fullCutList2D[i][j].find(';');
       std::string observableName = m_fullCutList2D[i][j].substr(0, pos);
       m_fullCutList2D[i][j].erase(0, pos + 1);
 
@@ -230,15 +228,22 @@ void PFAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
   // the keys in m_funcMap), the second being the number of bins,
   // and the last two being the min and max value for the histogram respectively.
 
-  for(unsigned int i=0; i<m_fullCutList2D.size(); i++){
+  for (unsigned int i = 0; i < m_fullCutList2D.size(); i++) {
     // Loop over all of the different types of PF candidates
     for (unsigned int m = 0; m < m_pfNames.size(); m++) {
       // For each observable, we make a couple histograms based on a few generic categorizations.
       // In all cases, the PFCs that go into these histograms must pass the PFC selection from m_cutList.
-      std::string histName = Form("%s_%s_%s",
-                                  m_pfNames[m].c_str(), m_fullCutList2D[i][0].c_str(), m_fullCutList2D[i][1].c_str());
-      MonitorElement* mHist = ibooker.book2D(
-          histName, Form(";%s;%s", m_fullCutList2D[i][0].c_str(), m_fullCutList2D[i][1].c_str()), m_binList2D[i][0].size(), m_binList2D[i][0][0], m_binList2D[i][0][m_binList2D[i][0].size()-1], m_binList2D[i][1].size(), m_binList2D[i][1][0], m_binList2D[i][1][m_binList2D[i][0].size()-1]);
+      std::string histName =
+          Form("%s_%s_%s", m_pfNames[m].c_str(), m_fullCutList2D[i][0].c_str(), m_fullCutList2D[i][1].c_str());
+      MonitorElement* mHist =
+          ibooker.book2D(histName,
+                         Form(";%s;%s", m_fullCutList2D[i][0].c_str(), m_fullCutList2D[i][1].c_str()),
+                         m_binList2D[i][0].size(),
+                         m_binList2D[i][0][0],
+                         m_binList2D[i][0][m_binList2D[i][0].size() - 1],
+                         m_binList2D[i][1].size(),
+                         m_binList2D[i][1][0],
+                         m_binList2D[i][1][m_binList2D[i][0].size() - 1]);
       map_of_MEs.insert(std::pair<std::string, MonitorElement*>(m_directory + "/" + histName, mHist));
     }
   }
@@ -445,7 +450,6 @@ void PFAnalyzer::bookMESetSelection(std::string DirName, DQMStore::IBooker& iboo
 // ***********************************************************
 void PFAnalyzer::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {}
 
-
 // How many significant digits do we need to save for the values to be distinct?
 std::string PFAnalyzer::stringWithDecimals(int bin, std::vector<double> bins) {
   double diff = bins[bin + 1] - bins[bin];
@@ -470,8 +474,8 @@ std::string PFAnalyzer::stringWithDecimals(int bin, std::vector<double> bins) {
   if (bins[bin + 1] < 0)
     signStringHigh = "m";
 
-  int higherDigitsLow = (bins[bin]>0)?floor(bins[bin]):ceil(bins[bin]);
-  int higherDigitsHigh = (bins[bin+1]>0)?floor(bins[bin+1]):ceil(bins[bin+1]);
+  int higherDigitsLow = (bins[bin] > 0) ? floor(bins[bin]) : ceil(bins[bin]);
+  int higherDigitsHigh = (bins[bin + 1] > 0) ? floor(bins[bin + 1]) : ceil(bins[bin + 1]);
 
   return Form("%s%dp%.0f_%s%dp%.0f",
               signStringLow.c_str(),
@@ -506,7 +510,6 @@ std::vector<double> PFAnalyzer::getBinList(std::string binString) {
   return binList;
 }
 
-
 std::vector<std::string> PFAnalyzer::getAllSuffixes(std::vector<std::string> observables,
                                                     std::vector<std::vector<double>> binnings) {
   int nTotalBins = 1;
@@ -531,7 +534,7 @@ std::vector<std::string> PFAnalyzer::getAllSuffixes(std::vector<std::string> obs
     for (int k = 0; k < factor; k++) {
       for (int j = 0; j < nBins[i]; j++) {
         for (int m = 0; m < otherFactor; m++) {
-          int binNumber = k*nBins[i] + j * otherFactor + m;
+          int binNumber = k * nBins[i] + j * otherFactor + m;
           binList[binNumber].push_back(j);
         }
       }
@@ -596,7 +599,11 @@ int PFAnalyzer::getBinNumbers(std::vector<double> binVal, std::vector<std::vecto
   return bin;
 }
 
-int PFAnalyzer::getPFBin(const reco::PFCandidate pfCand, const pat::PackedCandidate packedCand, const reco::CandidatePtr cand, int partType, int i) {
+int PFAnalyzer::getPFBin(const reco::PFCandidate pfCand,
+                         const pat::PackedCandidate packedCand,
+                         const reco::CandidatePtr cand,
+                         int partType,
+                         int i) {
   std::vector<double> binVals;
   for (unsigned int j = 0; j < m_fullCutList[i].size(); j++) {
     binVals.push_back(m_funcMap[m_fullCutList[i][j]](pfCand, packedCand, cand, partType));
@@ -652,17 +659,15 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   // **** Get the TriggerResults container
   edm::Handle<edm::TriggerResults> triggerResults;
   iEvent.getByToken(triggerResultsToken_, triggerResults);
-  if(!triggerResults.isValid()){
-      edm::LogError("PFAnalyzer") << "invalid trigger result \n";
-      return;
+  if (!triggerResults.isValid()) {
+    edm::LogError("PFAnalyzer") << "invalid trigger result \n";
+    return;
   }
   const edm::TriggerNames& triggerNames = iEvent.triggerNames(*triggerResults);
-
 
   edm::Handle<reco::PFCandidateCollection> recoPfCollection;
   edm::Handle<pat::PackedCandidateCollection> patPfCollection;
   std::vector<reco::PFCandidate> pfCollection;
-
 
   edm::Handle<pat::JetCollection> patJets;
   edm::Handle<reco::PFJetCollection> pfJets;
@@ -670,18 +675,17 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
 
   unsigned int numJets = 0;
   unsigned int numPFCands = 0;
-  m_isMiniAOD= true;
-  if(!m_isMiniAOD){
+  m_isMiniAOD = true;
+  if (!m_isMiniAOD) {
     iEvent.getByToken(thePfCandidateCollection_, recoPfCollection);
     if (!recoPfCollection.isValid()) {
       edm::LogError("PFAnalyzer") << "invalid collection: PF candidate \n";
       return;
     }
-    for(unsigned int i=0; i<recoPfCollection->size(); i++){
+    for (unsigned int i = 0; i < recoPfCollection->size(); i++) {
       pfCollection.push_back(recoPfCollection->at(i));
     }
     numPFCands = recoPfCollection->size();
-
 
     iEvent.getByToken(pfJetsToken_, pfJets);
     if (!pfJets.isValid()) {
@@ -689,18 +693,17 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
       return;
     }
     numJets = pfJets->size();
-    for(unsigned int i=0; i<numJets; i++){
+    for (unsigned int i = 0; i < numJets; i++) {
       jets.push_back(pfJets->at(i));
     }
-  }
-  else{
+  } else {
     iEvent.getByToken(patJetsToken_, patJets);
     if (!patJets.isValid()) {
       edm::LogError("PFAnalyzer") << "invalid collection: PF jets \n";
       return;
     }
     numJets = patJets->size();
-    for(unsigned int i=0; i<numJets; i++){
+    for (unsigned int i = 0; i < numJets; i++) {
       jets.push_back(patJets->at(i));
     }
 
@@ -717,24 +720,24 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   //  edm::LogError("PFAnalyzer") << "invalid collection: Puppi weights \n";
   //}
 
-  if(!passesTriggerSelection(jets, triggerResults, triggerNames, m_triggerOptions)){
+  if (!passesTriggerSelection(jets, triggerResults, triggerNames, m_triggerOptions)) {
     return;
   }
 
-  if(!m_eventSelectionMap[m_selection](jets)){
+  if (!m_eventSelectionMap[m_selection](jets)) {
     return;
   }
 
-  for (unsigned int i_pfcand=0; i_pfcand < numPFCands; i_pfcand++){
+  for (unsigned int i_pfcand = 0; i_pfcand < numPFCands; i_pfcand++) {
     reco::PFCandidate recoPF;
     pat::PackedCandidate packedCand;
     reco::CandidatePtr cand;
     int partType = 0;
-    if(m_isMiniAOD){
-     packedCand = patPfCollection->at(i_pfcand);
-     partType = 1;
-    } else{
-     recoPF = pfCollection[i_pfcand];
+    if (m_isMiniAOD) {
+      packedCand = patPfCollection->at(i_pfcand);
+      partType = 1;
+    } else {
+      recoPF = pfCollection[i_pfcand];
     }
 
     for (unsigned int j = 0; j < m_fullCutList.size(); j++) {
@@ -747,7 +750,7 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
       }
       std::string binString = m_allSuffixes[j][binNumber];
 
-      for(unsigned int i=0; i<m_fullCutList2D.size(); i++){
+      for (unsigned int i = 0; i < m_fullCutList2D.size(); i++) {
         // For each observable, we make a couple histograms based on a few generic categorizations.
         // In all cases, the PFCs that go into these histograms must pass the PFC selection from m_cutList.
         std::string histName = Form("%s_%s", m_fullCutList2D[i][0].c_str(), m_fullCutList2D[i][1].c_str());
@@ -755,10 +758,10 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
         double valY = m_funcMap[m_fullCutList2D[i][1]](recoPF, packedCand, cand, partType);
 
         map_of_MEs[m_directory + "/allPFC_" + histName]->Fill(valX, valY, eventWeight);
-        if(partType == 0 && m_particleTypeName.find(recoPF.particleId()) != m_particleTypeName.end()){
-          map_of_MEs[m_directory + "/" + m_particleTypeName[recoPF.particleId()]  + "_" + histName]->Fill(valX, valY, eventWeight);
+        if (partType == 0 && m_particleTypeName.find(recoPF.particleId()) != m_particleTypeName.end()) {
+          map_of_MEs[m_directory + "/" + m_particleTypeName[recoPF.particleId()] + "_" + histName]->Fill(
+              valX, valY, eventWeight);
         }
-
       }
 
       // Eventually, we might want the hist name to include the cuts that we are applying,
@@ -769,8 +772,9 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
         double val = m_funcMap[m_observableNames[i]](recoPF, packedCand, cand, partType);
         map_of_MEs[m_directory + "/allPFC_" + histName]->Fill(val, eventWeight);
 
-        if(partType == 0 && m_particleTypeName.find(recoPF.particleId()) != m_particleTypeName.end()){
-          map_of_MEs[m_directory + "/" + m_particleTypeName[recoPF.particleId()]  + "_" + histName]->Fill(val, eventWeight);
+        if (partType == 0 && m_particleTypeName.find(recoPF.particleId()) != m_particleTypeName.end()) {
+          map_of_MEs[m_directory + "/" + m_particleTypeName[recoPF.particleId()] + "_" + histName]->Fill(val,
+                                                                                                         eventWeight);
         }
       }
     }
@@ -781,7 +785,7 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     map_of_MEs[m_directory + "/allPFC_" + histName]->Fill(
         m_eventFuncMap[m_eventObservableNames[i]](pfCollection, reco::PFCandidate::ParticleType::X), eventWeight);
 
-    for(const auto &mypair : m_particleTypeName){
+    for (const auto& mypair : m_particleTypeName) {
       map_of_MEs[m_directory + "/" + mypair.second + "_" + histName]->Fill(
           m_eventFuncMap[m_eventObservableNames[i]](pfCollection, mypair.first), eventWeight);
     }
@@ -789,31 +793,30 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
 
   // Plots for generic debugging
   map_of_MEs[m_directory + "/NPV"]->Fill(numPV, eventWeight);
-  reco::Jet leadJet;  
-  if(m_isMiniAOD){
+  reco::Jet leadJet;
+  if (m_isMiniAOD) {
     leadJet = *patJets->begin();
-  } else{
+  } else {
     leadJet = *pfJets->begin();
   }
   map_of_MEs[m_directory + Form("/jetPtLead_%s", npvString.c_str())]->Fill(leadJet.pt(), eventWeight);
   map_of_MEs[m_directory + Form("/jetEtaLead_%s", npvString.c_str())]->Fill(leadJet.eta(), eventWeight);
 
-
   // Make plots of all observables, this time for PF candidates within jets
-  for (unsigned int index=0; index < numJets; index++) {
+  for (unsigned int index = 0; index < numJets; index++) {
     reco::Jet cjet;
-    if(m_isMiniAOD){
+    if (m_isMiniAOD) {
       cjet = patJets->at(index);
-    } else{
+    } else {
       cjet = pfJets->at(index);
     }
     std::vector<reco::PFCandidatePtr> pfConstits;
     std::vector<reco::CandidatePtr> patConstits;
     unsigned int nConstit = 0;
-    if(m_isMiniAOD){
+    if (m_isMiniAOD) {
       patConstits = patJets->at(index).daughterPtrVector();
       nConstit = patConstits.size();
-    } else{
+    } else {
       pfConstits = pfJets->at(index).getPFConstituents();
       nConstit = pfConstits.size();
     }
@@ -831,12 +834,12 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
         continue;
       std::string jetBinString = m_allJetSuffixes[k][jetBinNumber];
 
-      for (unsigned int iConstit=0; iConstit < nConstit; iConstit++) {
+      for (unsigned int iConstit = 0; iConstit < nConstit; iConstit++) {
         int partType = 0;
-        if(m_isMiniAOD) {
+        if (m_isMiniAOD) {
           cand = patConstits[iConstit];
           partType = 2;
-        } else{
+        } else {
           recoPFPtr = pfConstits[iConstit];
           recoPF = *recoPFPtr;
         }
@@ -855,11 +858,11 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
                                         binString.c_str(),
                                         jetBinString.c_str(),
                                         npvString.c_str());
-            map_of_MEs[m_directory + "/allPFC_jetMatched_" + histName]->Fill(m_funcMap[m_observableNames[i]](recoPF, packedCand, cand, partType),
-                                                                             eventWeight);
-            if(partType == 0 && m_particleTypeName.find(recoPF.particleId()) != m_particleTypeName.end()){
-              map_of_MEs[m_directory + "/" + m_particleTypeName[recoPF.particleId()] + "_jetMatched_" + histName]->Fill(m_funcMap[m_observableNames[i]](recoPF, packedCand, cand, partType),
-                                                                             eventWeight);
+            map_of_MEs[m_directory + "/allPFC_jetMatched_" + histName]->Fill(
+                m_funcMap[m_observableNames[i]](recoPF, packedCand, cand, partType), eventWeight);
+            if (partType == 0 && m_particleTypeName.find(recoPF.particleId()) != m_particleTypeName.end()) {
+              map_of_MEs[m_directory + "/" + m_particleTypeName[recoPF.particleId()] + "_jetMatched_" + histName]->Fill(
+                  m_funcMap[m_observableNames[i]](recoPF, packedCand, cand, partType), eventWeight);
             }
           }
 
@@ -872,9 +875,9 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
             map_of_MEs[m_directory + "/allPFC_jetMatched_" + histName]->Fill(
                 m_pfInJetFuncMap[m_pfInJetObservableNames[i]](recoPF, cjet), eventWeight);
 
-            if(partType == 0 && m_particleTypeName.find(recoPF.particleId()) != m_particleTypeName.end()){
+            if (partType == 0 && m_particleTypeName.find(recoPF.particleId()) != m_particleTypeName.end()) {
               map_of_MEs[m_directory + "/" + m_particleTypeName[recoPF.particleId()] + "_jetMatched_" + histName]->Fill(
-                m_pfInJetFuncMap[m_pfInJetObservableNames[i]](recoPF, cjet), eventWeight);
+                  m_pfInJetFuncMap[m_pfInJetObservableNames[i]](recoPF, cjet), eventWeight);
             }
           }
         }
@@ -883,8 +886,9 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
           std::string histName =
               Form("%s_jetCuts%s_%s", m_eventObservableNames[i].c_str(), jetBinString.c_str(), npvString.c_str());
           map_of_MEs[m_directory + "/allPFC_jetMatched_" + histName]->Fill(
-              m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, reco::PFCandidate::ParticleType::X, cjet), eventWeight);
-          for(const auto &mypair : m_particleTypeName){
+              m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, reco::PFCandidate::ParticleType::X, cjet),
+              eventWeight);
+          for (const auto& mypair : m_particleTypeName) {
             map_of_MEs[m_directory + "/" + mypair.second + "_jetMatched_" + histName]->Fill(
                 m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, mypair.first, cjet), eventWeight);
           }
@@ -893,4 +897,3 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     }
   }
 }
-

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
@@ -7,6 +7,7 @@
  */
 
 #include "DQMOffline/ParticleFlow/plugins/PFAnalyzer.h"
+#include <iostream>
 
 // ***********************************************************
 PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
@@ -17,8 +18,10 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   pfJetsToken_ = consumes<reco::PFJetCollection>(pSet.getParameter<edm::InputTag>("pfJetCollection"));
 
   theTriggerResultsLabel_ = pSet.getParameter<edm::InputTag>("TriggerResultsLabel");
+  m_selection = pSet.getParameter<std::string>("eventSelection");
+
   triggerResultsToken_ = consumes<edm::TriggerResults>(edm::InputTag(theTriggerResultsLabel_));
-  highPtJetExpr_ = pSet.getParameter<edm::InputTag>("TriggerName");
+  m_triggerOptions = pSet.getParameter<vstring>("TriggerNames");
 
   srcWeights = pSet.getParameter<edm::InputTag>("srcWeights");
   weightsToken_ = consumes<edm::ValueMap<float>>(srcWeights);
@@ -36,8 +39,14 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
 
   // List of cuts applied to PFCs that we want to plot
   m_cutList = parameters_.getParameter<vstring>("cutList");
+  m_cutList2D = parameters_.getParameter<vstring>("binList2D");
   // List of jet cuts that we apply for the case of plotting PFCs in jets
   m_jetCutList = parameters_.getParameter<vstring>("jetCutList");
+
+  m_eventSelectionMap["none"] = &passesEventSelection;
+  m_eventSelectionMap["dijet"] = &passesDijetSelection;
+  m_eventSelectionMap["nocut"] = &passesNoCutSelection;
+  m_eventSelectionMap["anomalous"] = &passesAnomalousSelection;
 
   // Link observable strings to the static functions defined in the header file
   // Many of these are quite trivial, but this enables a simple way to include a
@@ -45,6 +54,7 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   m_funcMap["pt"] = &getPt;
   m_funcMap["energy"] = getEnergy;
   m_funcMap["eta"] = getEta;
+  m_funcMap["abseta"] = getAbsEta;
   m_funcMap["phi"] = getPhi;
 
   m_funcMap["HCalE_depth1"] = getHcalEnergy_depth1;
@@ -54,6 +64,11 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   m_funcMap["HCalE_depth5"] = getHcalEnergy_depth5;
   m_funcMap["HCalE_depth6"] = getHcalEnergy_depth6;
   m_funcMap["HCalE_depth7"] = getHcalEnergy_depth7;
+
+
+  m_funcMap["PS1_E"] = getPS1Energy;
+  m_funcMap["PS2_E"] = getPS2Energy;
+  m_funcMap["PS_E"] = getPSEnergy;
 
   m_funcMap["ECal_E"] = getEcalEnergy;
   m_funcMap["RawECal_E"] = getRawEcalEnergy;
@@ -81,14 +96,37 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   m_funcMap["eOverP"] = getEoverP;
   m_funcMap["nTrkInBlock"] = getNTracksInBlock;
 
+  m_funcMap["trk_nStripHits"] = getTrackNStripHits;
+  m_funcMap["trk_nPixHits"] = getTrackNPixHits;
+  m_funcMap["trk_chi2"] = getTrackChi2;
+  m_funcMap["trk_ptError"] = getTrackPtError;
+  m_funcMap["trk_relPtError"] = getTrackRelPtError;
+  m_funcMap["trk_d0"] = getTrackD0;
+  m_funcMap["trk_z0"] = getTrackZ0;
+  m_funcMap["trk_thetaError"] = getTrackThetaError;
+  m_funcMap["trk_etaError"] = getTrackEtaError;
+  m_funcMap["trk_phiError"] = getTrackPhiError;
+
   m_eventFuncMap["NPFC"] = getNPFC;
+  m_eventFuncMap["MaxPtFrac"] = getMaxPt;
   m_jetWideFuncMap["NPFC"] = getNPFCinJet;
+  m_jetWideFuncMap["MaxPtFrac"] = getMaxPtFracJet;
 
   m_pfInJetFuncMap["PFSpectrum"] = getEnergySpectrum;
 
   // Link jet observables to static functions in the header file.
   // This is very similar to m_funcMap, but for jets instead.
   m_jetFuncMap["pt"] = getJetPt;
+  m_jetFuncMap["chargeFrac"] = getJetChargeFrac;
+
+
+  m_particleTypeName[reco::PFCandidate::ParticleType::h]  = "chargedHadPFC";
+  m_particleTypeName[reco::PFCandidate::ParticleType::h0]  = "neutralHadPFC";
+  m_particleTypeName[reco::PFCandidate::ParticleType::e]  = "electronPFC";
+  m_particleTypeName[reco::PFCandidate::ParticleType::mu]  = "muonPFC";
+  m_particleTypeName[reco::PFCandidate::ParticleType::gamma]  = "gammaPFC";
+  m_particleTypeName[reco::PFCandidate::ParticleType::h_HF]  = "hadHFPFC";
+  m_particleTypeName[reco::PFCandidate::ParticleType::egamma_HF]  = "emHFPFC";
 
   // Convert the cutList strings into real cuts that can be applied
   // The format should be three comma separated values
@@ -114,6 +152,28 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
 
       m_binList[i].push_back(getBinList(m_fullCutList[i][j]));
       m_fullCutList[i][j] = observableName;
+    }
+  }
+
+
+  for (unsigned int i = 0; i < m_cutList2D.size(); i++) {
+    m_fullCutList2D.push_back(std::vector<std::string>());
+    while (m_cutList2D[i].find("]") != std::string::npos) {
+      size_t pos = m_cutList2D[i].find("]");
+      m_fullCutList2D[i].push_back(m_cutList2D[i].substr(1, pos));
+      m_cutList2D[i].erase(0, pos + 1);
+    }
+  }
+
+  for (unsigned int i = 0; i < m_fullCutList2D.size(); i++) {
+    m_binList2D.push_back(std::vector<std::vector<double>>());
+    for (unsigned int j = 0; j < m_fullCutList2D[i].size(); j++) {
+      size_t pos = m_fullCutList2D[i][j].find(";");
+      std::string observableName = m_fullCutList2D[i][j].substr(0, pos);
+      m_fullCutList2D[i][j].erase(0, pos + 1);
+
+      m_binList2D[i].push_back(getBinList(m_fullCutList2D[i][j]));
+      m_fullCutList2D[i][j] = observableName;
     }
   }
 
@@ -158,6 +218,25 @@ void PFAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
 
   for (unsigned int i = 0; i < m_fullJetCutList.size(); i++) {
     m_allJetSuffixes.push_back(getAllSuffixes(m_fullJetCutList[i], m_jetBinList[i]));
+  }
+
+  // Books a 2D histogram for each histogram in the config file.
+  // The format for the observables should be four comma separated values,
+  // with the first being the observable name (corresponding to one of
+  // the keys in m_funcMap), the second being the number of bins,
+  // and the last two being the min and max value for the histogram respectively.
+
+  for(unsigned int i=0; i<m_fullCutList2D.size(); i++){
+    // Loop over all of the different types of PF candidates
+    for (unsigned int m = 0; m < m_pfNames.size(); m++) {
+      // For each observable, we make a couple histograms based on a few generic categorizations.
+      // In all cases, the PFCs that go into these histograms must pass the PFC selection from m_cutList.
+      std::string histName = Form("%s_%s_%s",
+                                  m_pfNames[m].c_str(), m_fullCutList2D[i][0].c_str(), m_fullCutList2D[i][1].c_str());
+      MonitorElement* mHist = ibooker.book2D(
+          histName, Form(";%s;%s", m_fullCutList2D[i][0].c_str(), m_fullCutList2D[i][1].c_str()), m_binList2D[i][0].size(), m_binList2D[i][0][0], m_binList2D[i][0][m_binList2D[i][0].size()-1], m_binList2D[i][1].size(), m_binList2D[i][1][0], m_binList2D[i][1][m_binList2D[i][0].size()-1]);
+      map_of_MEs.insert(std::pair<std::string, MonitorElement*>(m_directory + "/" + histName, mHist));
+    }
   }
 
   for (unsigned int npv = 0; npv < m_npvBins.size() - 1; npv++) {
@@ -362,7 +441,6 @@ void PFAnalyzer::bookMESetSelection(std::string DirName, DQMStore::IBooker& iboo
 // ***********************************************************
 void PFAnalyzer::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {}
 
-bool PFAnalyzer::passesEventSelection(const edm::Event& iEvent) { return true; }
 
 // How many significant digits do we need to save for the values to be distinct?
 std::string PFAnalyzer::stringWithDecimals(int bin, std::vector<double> bins) {
@@ -379,20 +457,24 @@ std::string PFAnalyzer::stringWithDecimals(int bin, std::vector<double> bins) {
   int nDecimals = int(-1 * sigFigs) + 1;
   // We do not want to use decimals since these can mess up histogram retrieval in some cases.
   // Instead, we use a 'p' to indicate the decimal.
-  double newDigit = abs((bins[bin] - int(bins[bin])) * pow(10, nDecimals));
-  double newDigit2 = (bins[bin + 1] - int(bins[bin + 1])) * pow(10, nDecimals);
+  double newDigit = std::abs((bins[bin] - int(bins[bin])) * pow(10, nDecimals));
+  double newDigit2 = std::abs((bins[bin + 1] - int(bins[bin + 1])) * pow(10, nDecimals));
   std::string signStringLow = "";
   std::string signStringHigh = "";
   if (bins[bin] < 0)
     signStringLow = "m";
   if (bins[bin + 1] < 0)
     signStringHigh = "m";
-  return Form("%s%.0fp%.0f_%s%.0fp%.0f",
+
+  int higherDigitsLow = (bins[bin]>0)?floor(bins[bin]):ceil(bins[bin]);
+  int higherDigitsHigh = (bins[bin+1]>0)?floor(bins[bin+1]):ceil(bins[bin+1]);
+
+  return Form("%s%dp%.0f_%s%dp%.0f",
               signStringLow.c_str(),
-              std::abs(bins[bin]),
+              std::abs(higherDigitsLow),
               newDigit,
               signStringHigh.c_str(),
-              std::abs(bins[bin + 1]),
+              std::abs(higherDigitsHigh),
               newDigit2);
 }
 
@@ -420,6 +502,7 @@ std::vector<double> PFAnalyzer::getBinList(std::string binString) {
   return binList;
 }
 
+
 std::vector<std::string> PFAnalyzer::getAllSuffixes(std::vector<std::string> observables,
                                                     std::vector<std::vector<double>> binnings) {
   int nTotalBins = 1;
@@ -441,10 +524,11 @@ std::vector<std::string> PFAnalyzer::getAllSuffixes(std::vector<std::string> obs
   for (unsigned int i = 0; i < binnings.size(); i++) {
     factor = factor / nBins[i];
 
-    for (int j = 0; j < nBins[i]; j++) {
-      for (int k = 0; k < factor; k++) {
+    for (int k = 0; k < factor; k++) {
+      for (int j = 0; j < nBins[i]; j++) {
         for (int m = 0; m < otherFactor; m++) {
-          binList[m * otherFactor + j * factor + k].push_back(j);
+          int binNumber = k*nBins[i] + j * otherFactor + m;
+          binList[binNumber].push_back(j);
         }
       }
     }
@@ -534,25 +618,8 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     eventWeight = genEventInfo->weight();
   }
 
-  weights_ = &iEvent.get(weightsToken_);
+  //weights_ = &iEvent.get(weightsToken_);
 
-  // **** Get the TriggerResults container
-  edm::Handle<edm::TriggerResults> triggerResults;
-  iEvent.getByToken(triggerResultsToken_, triggerResults);
-
-  // Hack to make it pass the lowest unprescaled HLT?
-  Int_t JetHiPass = 0;
-
-  if (triggerResults.isValid()) {
-    const edm::TriggerNames& triggerNames = iEvent.triggerNames(*triggerResults);
-
-    const unsigned int nTrig(triggerNames.size());
-    for (unsigned int i = 0; i < nTrig; ++i) {
-      if (triggerNames.triggerName(i).find(highPtJetExpr_.label()) != std::string::npos && triggerResults->accept(i)) {
-        JetHiPass = 1;
-      }
-    }
-  }
 
   //Vertex information
   edm::Handle<reco::VertexCollection> vertexHandle;
@@ -581,10 +648,16 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     return;
   std::string npvString = Form("npv_%.0f_%.0f", m_npvBins[npvBin], m_npvBins[npvBin + 1]);
 
-  if (!JetHiPass)
-    return;
+    // **** Get the TriggerResults container
+    edm::Handle<edm::TriggerResults> triggerResults;
+    iEvent.getByToken(triggerResultsToken_, triggerResults);
+  if(!triggerResults.isValid()){
+      edm::LogError("PFAnalyzer") << "invalid trigger result \n";
+      return;
+  }
+  const edm::TriggerNames& triggerNames = iEvent.triggerNames(*triggerResults);
 
-  // Retrieve the PFCs
+
   edm::Handle<reco::PFCandidateCollection> pfCollection;
   iEvent.getByToken(thePfCandidateCollection_, pfCollection);
   if (!pfCollection.isValid()) {
@@ -599,17 +672,13 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     return;
   }
 
-  // Probably we want to define a few different options for how the selection will work
-  // Currently it is just a dummy function, and we hardcode the other cuts.
-  if (pfJets->size() < 2)
+  if(!passesTriggerSelection(pfJets, triggerResults, triggerNames, m_triggerOptions)){
     return;
-  if (pfJets->at(0).pt() < 450)
-    return;
-  if (pfJets->at(0).pt() / pfJets->at(1).pt() > 2)
-    return;
+  }
 
-  if (!passesEventSelection(iEvent))
+  if(!m_eventSelectionMap[m_selection](pfJets)){
     return;
+  }
 
   for (reco::PFCandidateCollection::const_iterator recoPF = pfCollection->begin(); recoPF != pfCollection->end();
        ++recoPF) {
@@ -622,6 +691,17 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
       }
       std::string binString = m_allSuffixes[j][binNumber];
 
+      for(unsigned int i=0; i<m_fullCutList2D.size(); i++){
+        // For each observable, we make a couple histograms based on a few generic categorizations.
+        // In all cases, the PFCs that go into these histograms must pass the PFC selection from m_cutList.
+        std::string histName = Form("%s_%s", m_fullCutList2D[i][0].c_str(), m_fullCutList2D[i][1].c_str());
+        map_of_MEs[m_directory + "/allPFC_" + histName]->Fill(m_funcMap[m_fullCutList2D[i][0]](*recoPF), m_funcMap[m_fullCutList2D[i][1]](*recoPF), eventWeight);
+        if(m_particleTypeName.find(recoPF->particleId()) != m_particleTypeName.end()){
+          map_of_MEs[m_directory + "/" + m_particleTypeName[recoPF->particleId()]  + "_" + histName]->Fill(m_funcMap[m_fullCutList2D[i][0]](*recoPF), m_funcMap[m_fullCutList2D[i][1]](*recoPF), eventWeight);
+        }
+
+      }
+
       // Eventually, we might want the hist name to include the cuts that we are applying,
       // so I am keepking it as a separate string for now, even though it is redundant.
       // Make plots of all observables
@@ -629,38 +709,10 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
         std::string histName = Form("%s%s_%s", m_observableNames[i].c_str(), binString.c_str(), npvString.c_str());
         map_of_MEs[m_directory + "/allPFC_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF), eventWeight);
 
-        switch (recoPF->particleId()) {
-          case reco::PFCandidate::ParticleType::h:
-            map_of_MEs[m_directory + "/chargedHadPFC_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF),
-                                                                         eventWeight);
-            break;
-          case reco::PFCandidate::ParticleType::h0:
-            map_of_MEs[m_directory + "/neutralHadPFC_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF),
-                                                                         eventWeight);
-            break;
-          case reco::PFCandidate::ParticleType::e:
-            map_of_MEs[m_directory + "/electronPFC_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF),
-                                                                       eventWeight);
-            break;
-          case reco::PFCandidate::ParticleType::mu:
-            map_of_MEs[m_directory + "/muonPFC_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF),
-                                                                   eventWeight);
-            break;
-          case reco::PFCandidate::ParticleType::gamma:
-            map_of_MEs[m_directory + "/gammaPFC_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF),
-                                                                    eventWeight);
-            break;
-          case reco::PFCandidate::ParticleType::h_HF:
-            map_of_MEs[m_directory + "/hadHFPFC_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF),
-                                                                    eventWeight);
-            break;
-          case reco::PFCandidate::ParticleType::egamma_HF:
-            map_of_MEs[m_directory + "/emHFPFC_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF),
-                                                                   eventWeight);
-            break;
-          default:
-            break;
+        if(m_particleTypeName.find(recoPF->particleId()) != m_particleTypeName.end()){
+          map_of_MEs[m_directory + "/" + m_particleTypeName[recoPF->particleId()]  + "_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF), eventWeight);
         }
+
       }
     }
   }
@@ -669,21 +721,11 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     std::string histName = Form("%s_%s", m_eventObservableNames[i].c_str(), npvString.c_str());
     map_of_MEs[m_directory + "/allPFC_" + histName]->Fill(
         m_eventFuncMap[m_eventObservableNames[i]](*pfCollection, reco::PFCandidate::ParticleType::X), eventWeight);
-    map_of_MEs[m_directory + "/chargedHadPFC_" + histName]->Fill(
-        m_eventFuncMap[m_eventObservableNames[i]](*pfCollection, reco::PFCandidate::ParticleType::h), eventWeight);
-    map_of_MEs[m_directory + "/neutralHadPFC_" + histName]->Fill(
-        m_eventFuncMap[m_eventObservableNames[i]](*pfCollection, reco::PFCandidate::ParticleType::h0), eventWeight);
-    map_of_MEs[m_directory + "/electronPFC_" + histName]->Fill(
-        m_eventFuncMap[m_eventObservableNames[i]](*pfCollection, reco::PFCandidate::ParticleType::e), eventWeight);
-    map_of_MEs[m_directory + "/muonPFC_" + histName]->Fill(
-        m_eventFuncMap[m_eventObservableNames[i]](*pfCollection, reco::PFCandidate::ParticleType::mu), eventWeight);
-    map_of_MEs[m_directory + "/gammaPFC_" + histName]->Fill(
-        m_eventFuncMap[m_eventObservableNames[i]](*pfCollection, reco::PFCandidate::ParticleType::gamma), eventWeight);
-    map_of_MEs[m_directory + "/hadHFPFC_" + histName]->Fill(
-        m_eventFuncMap[m_eventObservableNames[i]](*pfCollection, reco::PFCandidate::ParticleType::h_HF), eventWeight);
-    map_of_MEs[m_directory + "/emHFPFC_" + histName]->Fill(
-        m_eventFuncMap[m_eventObservableNames[i]](*pfCollection, reco::PFCandidate::ParticleType::egamma_HF),
-        eventWeight);
+
+    for(const auto &mypair : m_particleTypeName){
+      map_of_MEs[m_directory + "/" + mypair.second + "_" + histName]->Fill(
+          m_eventFuncMap[m_eventObservableNames[i]](*pfCollection, mypair.first), eventWeight);
+    }
   }
 
   // Plots for generic debugging
@@ -722,38 +764,9 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
                                         npvString.c_str());
             map_of_MEs[m_directory + "/allPFC_jetMatched_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF),
                                                                              eventWeight);
-
-            switch (recoPF->particleId()) {
-              case reco::PFCandidate::ParticleType::h:
-                map_of_MEs[m_directory + "/chargedHadPFC_jetMatched_" + histName]->Fill(
-                    m_funcMap[m_observableNames[i]](*recoPF), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::h0:
-                map_of_MEs[m_directory + "/neutralHadPFC_jetMatched_" + histName]->Fill(
-                    m_funcMap[m_observableNames[i]](*recoPF), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::e:
-                map_of_MEs[m_directory + "/electronPFC_jetMatched_" + histName]->Fill(
-                    m_funcMap[m_observableNames[i]](*recoPF), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::mu:
-                map_of_MEs[m_directory + "/muonPFC_jetMatched_" + histName]->Fill(
-                    m_funcMap[m_observableNames[i]](*recoPF), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::gamma:
-                map_of_MEs[m_directory + "/gammaPFC_jetMatched_" + histName]->Fill(
-                    m_funcMap[m_observableNames[i]](*recoPF), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::h_HF:
-                map_of_MEs[m_directory + "/hadHFPFC_jetMatched_" + histName]->Fill(
-                    m_funcMap[m_observableNames[i]](*recoPF), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::egamma_HF:
-                map_of_MEs[m_directory + "/emHFPFC_jetMatched_" + histName]->Fill(
-                    m_funcMap[m_observableNames[i]](*recoPF), eventWeight);
-                break;
-              default:
-                break;
+            if(m_particleTypeName.find(recoPF->particleId()) != m_particleTypeName.end()){
+              map_of_MEs[m_directory + "/" + m_particleTypeName[recoPF->particleId()] + "_jetMatched_" + histName]->Fill(m_funcMap[m_observableNames[i]](*recoPF),
+                                                                             eventWeight);
             }
           }
 
@@ -766,38 +779,11 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
             map_of_MEs[m_directory + "/allPFC_jetMatched_" + histName]->Fill(
                 m_pfInJetFuncMap[m_pfInJetObservableNames[i]](*recoPF, *cjet), eventWeight);
 
-            switch (recoPF->particleId()) {
-              case reco::PFCandidate::ParticleType::h:
-                map_of_MEs[m_directory + "/chargedHadPFC_jetMatched_" + histName]->Fill(
-                    m_pfInJetFuncMap[m_pfInJetObservableNames[i]](*recoPF, *cjet), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::h0:
-                map_of_MEs[m_directory + "/neutralHadPFC_jetMatched_" + histName]->Fill(
-                    m_pfInJetFuncMap[m_pfInJetObservableNames[i]](*recoPF, *cjet), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::e:
-                map_of_MEs[m_directory + "/electronPFC_jetMatched_" + histName]->Fill(
-                    m_pfInJetFuncMap[m_pfInJetObservableNames[i]](*recoPF, *cjet), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::mu:
-                map_of_MEs[m_directory + "/muonPFC_jetMatched_" + histName]->Fill(
-                    m_pfInJetFuncMap[m_pfInJetObservableNames[i]](*recoPF, *cjet), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::gamma:
-                map_of_MEs[m_directory + "/gammaPFC_jetMatched_" + histName]->Fill(
-                    m_pfInJetFuncMap[m_pfInJetObservableNames[i]](*recoPF, *cjet), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::h_HF:
-                map_of_MEs[m_directory + "/hadHFPFC_jetMatched_" + histName]->Fill(
-                    m_pfInJetFuncMap[m_pfInJetObservableNames[i]](*recoPF, *cjet), eventWeight);
-                break;
-              case reco::PFCandidate::ParticleType::egamma_HF:
-                map_of_MEs[m_directory + "/emHFPFC_jetMatched_" + histName]->Fill(
-                    m_pfInJetFuncMap[m_pfInJetObservableNames[i]](*recoPF, *cjet), eventWeight);
-                break;
-              default:
-                break;
+            if(m_particleTypeName.find(recoPF->particleId()) != m_particleTypeName.end()){
+              map_of_MEs[m_directory + "/" + m_particleTypeName[recoPF->particleId()] + "_jetMatched_" + histName]->Fill(
+                m_pfInJetFuncMap[m_pfInJetObservableNames[i]](*recoPF, *cjet), eventWeight);
             }
+
           }
         }
 
@@ -805,26 +791,11 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
           std::string histName =
               Form("%s_jetCuts%s_%s", m_eventObservableNames[i].c_str(), jetBinString.c_str(), npvString.c_str());
           map_of_MEs[m_directory + "/allPFC_jetMatched_" + histName]->Fill(
-              m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, reco::PFCandidate::ParticleType::X), eventWeight);
-          map_of_MEs[m_directory + "/chargedHadPFC_jetMatched_" + histName]->Fill(
-              m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, reco::PFCandidate::ParticleType::h), eventWeight);
-          map_of_MEs[m_directory + "/neutralHadPFC_jetMatched_" + histName]->Fill(
-              m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, reco::PFCandidate::ParticleType::h0),
-              eventWeight);
-          map_of_MEs[m_directory + "/electronPFC_jetMatched_" + histName]->Fill(
-              m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, reco::PFCandidate::ParticleType::e), eventWeight);
-          map_of_MEs[m_directory + "/muonPFC_jetMatched_" + histName]->Fill(
-              m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, reco::PFCandidate::ParticleType::mu),
-              eventWeight);
-          map_of_MEs[m_directory + "/gammaPFC_jetMatched_" + histName]->Fill(
-              m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, reco::PFCandidate::ParticleType::gamma),
-              eventWeight);
-          map_of_MEs[m_directory + "/hadHFPFC_jetMatched_" + histName]->Fill(
-              m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, reco::PFCandidate::ParticleType::h_HF),
-              eventWeight);
-          map_of_MEs[m_directory + "/emHFPFC_jetMatched_" + histName]->Fill(
-              m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, reco::PFCandidate::ParticleType::egamma_HF),
-              eventWeight);
+              m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, reco::PFCandidate::ParticleType::X, *cjet), eventWeight);
+          for(const auto &mypair : m_particleTypeName){
+            map_of_MEs[m_directory + "/" + mypair.second + "_jetMatched_" + histName]->Fill(
+                m_jetWideFuncMap[m_eventObservableNames[i]](pfConstits, mypair.first, *cjet), eventWeight);
+          }
         }
       }
     }

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
@@ -72,23 +72,26 @@ public:
   void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
 
 private:
-
-
   struct binInfo;
   // A map between an observable name and a function that obtains that observable from a  PFCandidate.
   // This allows us to construct more complicated observables easily, and have it more configurable
   // in the config file.
-  std::map<std::string, std::function<double(const reco::PFCandidate, const pat::PackedCandidate, const reco::CandidatePtr, int)>> m_funcMap;
+  std::map<std::string,
+           std::function<double(const reco::PFCandidate, const pat::PackedCandidate, const reco::CandidatePtr, int)>>
+      m_funcMap;
   //std::map<std::string, std::function<double(const reco::PFCandidateCollection, reco::PFCandidate::ParticleType pfType)>>
-  std::map<std::string, std::function<double(const std::vector<reco::PFCandidate>, reco::PFCandidate::ParticleType pfType)>>
+  std::map<std::string,
+           std::function<double(const std::vector<reco::PFCandidate>, reco::PFCandidate::ParticleType pfType)>>
       m_eventFuncMap;
 
   std::map<std::string,
-           std::function<double(const std::vector<reco::PFCandidatePtr> pfCands, reco::PFCandidate::ParticleType pfType, const reco::Jet)>>
+           std::function<double(
+               const std::vector<reco::PFCandidatePtr> pfCands, reco::PFCandidate::ParticleType pfType, const reco::Jet)>>
       m_jetWideFuncMap;
 
   std::map<std::string, std::function<double(const reco::PFCandidate, const reco::Jet)>> m_pfInJetFuncMap;
-  std::map<std::string, std::function<double(const reco::Jet, const std::vector<reco::PFCandidatePtr> pfCands)>> m_jetFuncMap;
+  std::map<std::string, std::function<double(const reco::Jet, const std::vector<reco::PFCandidatePtr> pfCands)>>
+      m_jetFuncMap;
 
   //std::map<std::string, std::function<bool(const edm::Handle<std::vector<reco::Jet> >& pfJets)>> m_eventSelectionMap;
   std::map<std::string, std::function<bool(const std::vector<reco::Jet>& pfJets)>> m_eventSelectionMap;
@@ -98,8 +101,11 @@ private:
   // Book MonitorElements
   void bookMESetSelection(std::string, DQMStore::IBooker&);
 
-
-  int getPFBin(const reco::PFCandidate pfCand, const pat::PackedCandidate packedCand, const reco::CandidatePtr cand, int partType, int i);
+  int getPFBin(const reco::PFCandidate pfCand,
+               const pat::PackedCandidate packedCand,
+               const reco::CandidatePtr cand,
+               int partType,
+               int i);
   int getJetBin(const reco::Jet jetCand, const std::vector<reco::PFCandidatePtr> pfCands, int i);
 
   int getBinNumber(double binVal, std::vector<double> bins);
@@ -122,7 +128,7 @@ private:
 
   static double getNPFC(const std::vector<reco::PFCandidate> pfCands, reco::PFCandidate::ParticleType pfType) {
     int nPF = 0;
-    for (auto pfCand : pfCands) {
+    for (const auto& pfCand : pfCands) {
       // We use X to indicate all
       if (pfCand.particleId() == pfType || pfType == reco::PFCandidate::ParticleType::X) {
         nPF++;
@@ -131,9 +137,11 @@ private:
     return nPF;
   }
 
-  static double getNPFCinJet(const std::vector<reco::PFCandidatePtr> pfCands, reco::PFCandidate::ParticleType pfType, const reco::Jet jet) {
+  static double getNPFCinJet(const std::vector<reco::PFCandidatePtr> pfCands,
+                             reco::PFCandidate::ParticleType pfType,
+                             const reco::Jet jet) {
     int nPF = 0;
-    for (auto pfCand : pfCands) {
+    for (const auto& pfCand : pfCands) {
       if (!pfCand)
         continue;
       // We use X to indicate all
@@ -145,203 +153,536 @@ private:
 
   static double getMaxPt(const std::vector<reco::PFCandidate> pfCands, reco::PFCandidate::ParticleType pfType) {
     double maxPt = 0;
-    for (auto pfCand : pfCands) {
+    for (const auto& pfCand : pfCands) {
       // We use X to indicate all
       if (pfCand.particleId() == pfType || pfType == reco::PFCandidate::ParticleType::X) {
-        if(pfCand.pt() > maxPt ) maxPt = pfCand.pt();
+        if (pfCand.pt() > maxPt)
+          maxPt = pfCand.pt();
       }
     }
     return maxPt;
   }
 
-  static double getMaxPtFracJet(const std::vector<reco::PFCandidatePtr> pfCands, reco::PFCandidate::ParticleType pfType, const reco::Jet jet) {
+  static double getMaxPtFracJet(const std::vector<reco::PFCandidatePtr> pfCands,
+                                reco::PFCandidate::ParticleType pfType,
+                                const reco::Jet jet) {
     double maxPt = 0;
-    for (auto pfCand : pfCands) {
+    for (const auto& pfCand : pfCands) {
       if (!pfCand)
         continue;
       // We use X to indicate all
       if (pfCand->particleId() == pfType || pfType == reco::PFCandidate::ParticleType::X)
-        if(pfCand->pt() > maxPt ) maxPt = pfCand->pt();
+        if (pfCand->pt() > maxPt)
+          maxPt = pfCand->pt();
     }
     return maxPt / jet.pt();
   }
 
-
   // Various functions designed to get information from a PF canddidate
-  static double getPt(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { 
-                      if(partType==1) {return packedPart.pt();} 
-                      if(partType==2) {return cand->pt(); } 
-                      return pfCand.pt(); 
-                     }
-  static double getEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType==1) {return packedPart.energy();} return pfCand.energy(); }
-  static double getEta(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { 
-                        if(partType==1) { return packedPart.eta();}
-                        if(partType==2) { return cand->eta(); } 
-                        return pfCand.eta(); 
-                      }
-  static double getAbsEta(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { 
-                            if(partType==1) {return std::abs(packedPart.eta());}
-                            if(partType==2) { return std::abs(cand->eta()); } 
-                            return std::abs(pfCand.eta()); 
-                         }
-  static double getPhi(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { 
-                         if(partType==1) {return packedPart.phi();}
-                         if(partType==2) { return cand->phi(); } 
-                         return pfCand.phi(); 
-                       }
+  static double getPt(const reco::PFCandidate pfCand,
+                      const pat::PackedCandidate packedPart,
+                      const reco::CandidatePtr cand,
+                      int partType) {
+    if (partType == 1) {
+      return packedPart.pt();
+    }
+    if (partType == 2) {
+      return cand->pt();
+    }
+    return pfCand.pt();
+  }
+  static double getEnergy(const reco::PFCandidate pfCand,
+                          const pat::PackedCandidate packedPart,
+                          const reco::CandidatePtr cand,
+                          int partType) {
+    if (partType == 1) {
+      return packedPart.energy();
+    }
+    return pfCand.energy();
+  }
+  static double getEta(const reco::PFCandidate pfCand,
+                       const pat::PackedCandidate packedPart,
+                       const reco::CandidatePtr cand,
+                       int partType) {
+    if (partType == 1) {
+      return packedPart.eta();
+    }
+    if (partType == 2) {
+      return cand->eta();
+    }
+    return pfCand.eta();
+  }
+  static double getAbsEta(const reco::PFCandidate pfCand,
+                          const pat::PackedCandidate packedPart,
+                          const reco::CandidatePtr cand,
+                          int partType) {
+    if (partType == 1) {
+      return std::abs(packedPart.eta());
+    }
+    if (partType == 2) {
+      return std::abs(cand->eta());
+    }
+    return std::abs(pfCand.eta());
+  }
+  static double getPhi(const reco::PFCandidate pfCand,
+                       const pat::PackedCandidate packedPart,
+                       const reco::CandidatePtr cand,
+                       int partType) {
+    if (partType == 1) {
+      return packedPart.phi();
+    }
+    if (partType == 2) {
+      return cand->phi();
+    }
+    return pfCand.phi();
+  }
 
-  static double getHadCalibration(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
+  static double getHadCalibration(const reco::PFCandidate pfCand,
+                                  const pat::PackedCandidate packedPart,
+                                  const reco::CandidatePtr cand,
+                                  int partType) {
     if (pfCand.rawHcalEnergy() == 0)
       return -1;
     return pfCand.hcalEnergy() / pfCand.rawHcalEnergy();
   }
-  static double getPuppiWeight(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType==1){return packedPart.puppiWeight();} return 1; }
+  static double getPuppiWeight(const reco::PFCandidate pfCand,
+                               const pat::PackedCandidate packedPart,
+                               const reco::CandidatePtr cand,
+                               int partType) {
+    if (partType == 1) {
+      return packedPart.puppiWeight();
+    }
+    return 1;
+  }
 
-  static double getTime(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType==1){return packedPart.time();} return pfCand.time(); }
+  static double getTime(const reco::PFCandidate pfCand,
+                        const pat::PackedCandidate packedPart,
+                        const reco::CandidatePtr cand,
+                        int partType) {
+    if (partType == 1) {
+      return packedPart.time();
+    }
+    return pfCand.time();
+  }
 
-  static double getHcalEnergy_depth1(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {  return pfCand.hcalDepthEnergyFraction(1); }
-  static double getHcalEnergy_depth2(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { return pfCand.hcalDepthEnergyFraction(2); }
-  static double getHcalEnergy_depth3(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { return pfCand.hcalDepthEnergyFraction(3); }
-  static double getHcalEnergy_depth4(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { return pfCand.hcalDepthEnergyFraction(4); }
-  static double getHcalEnergy_depth5(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { return pfCand.hcalDepthEnergyFraction(5); }
-  static double getHcalEnergy_depth6(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { return pfCand.hcalDepthEnergyFraction(6); }
-  static double getHcalEnergy_depth7(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { return pfCand.hcalDepthEnergyFraction(7); }
+  static double getHcalEnergy_depth1(const reco::PFCandidate pfCand,
+                                     const pat::PackedCandidate packedPart,
+                                     const reco::CandidatePtr cand,
+                                     int partType) {
+    return pfCand.hcalDepthEnergyFraction(1);
+  }
+  static double getHcalEnergy_depth2(const reco::PFCandidate pfCand,
+                                     const pat::PackedCandidate packedPart,
+                                     const reco::CandidatePtr cand,
+                                     int partType) {
+    return pfCand.hcalDepthEnergyFraction(2);
+  }
+  static double getHcalEnergy_depth3(const reco::PFCandidate pfCand,
+                                     const pat::PackedCandidate packedPart,
+                                     const reco::CandidatePtr cand,
+                                     int partType) {
+    return pfCand.hcalDepthEnergyFraction(3);
+  }
+  static double getHcalEnergy_depth4(const reco::PFCandidate pfCand,
+                                     const pat::PackedCandidate packedPart,
+                                     const reco::CandidatePtr cand,
+                                     int partType) {
+    return pfCand.hcalDepthEnergyFraction(4);
+  }
+  static double getHcalEnergy_depth5(const reco::PFCandidate pfCand,
+                                     const pat::PackedCandidate packedPart,
+                                     const reco::CandidatePtr cand,
+                                     int partType) {
+    return pfCand.hcalDepthEnergyFraction(5);
+  }
+  static double getHcalEnergy_depth6(const reco::PFCandidate pfCand,
+                                     const pat::PackedCandidate packedPart,
+                                     const reco::CandidatePtr cand,
+                                     int partType) {
+    return pfCand.hcalDepthEnergyFraction(6);
+  }
+  static double getHcalEnergy_depth7(const reco::PFCandidate pfCand,
+                                     const pat::PackedCandidate packedPart,
+                                     const reco::CandidatePtr cand,
+                                     int partType) {
+    return pfCand.hcalDepthEnergyFraction(7);
+  }
 
-  static double getEcalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType==1){ return (1.0-packedPart.hcalFraction())*packedPart.energy();} return pfCand.ecalEnergy(); }
-  static double getRawEcalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType==1){ return (1.0-packedPart.rawHcalFraction())*packedPart.energy();}return pfCand.rawEcalEnergy(); }
-  static double getHcalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {  if(partType==1){return packedPart.hcalFraction()*packedPart.energy();}return pfCand.hcalEnergy(); }
-  static double getRawHcalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {  if(partType==1){ return packedPart.rawHcalFraction()*packedPart.energy();}return pfCand.rawHcalEnergy(); }
-  static double getHOEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.hoEnergy(); }
-  static double getRawHOEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.rawHoEnergy(); }
+  static double getEcalEnergy(const reco::PFCandidate pfCand,
+                              const pat::PackedCandidate packedPart,
+                              const reco::CandidatePtr cand,
+                              int partType) {
+    if (partType == 1) {
+      return (1.0 - packedPart.hcalFraction()) * packedPart.energy();
+    }
+    return pfCand.ecalEnergy();
+  }
+  static double getRawEcalEnergy(const reco::PFCandidate pfCand,
+                                 const pat::PackedCandidate packedPart,
+                                 const reco::CandidatePtr cand,
+                                 int partType) {
+    if (partType == 1) {
+      return (1.0 - packedPart.rawHcalFraction()) * packedPart.energy();
+    }
+    return pfCand.rawEcalEnergy();
+  }
+  static double getHcalEnergy(const reco::PFCandidate pfCand,
+                              const pat::PackedCandidate packedPart,
+                              const reco::CandidatePtr cand,
+                              int partType) {
+    if (partType == 1) {
+      return packedPart.hcalFraction() * packedPart.energy();
+    }
+    return pfCand.hcalEnergy();
+  }
+  static double getRawHcalEnergy(const reco::PFCandidate pfCand,
+                                 const pat::PackedCandidate packedPart,
+                                 const reco::CandidatePtr cand,
+                                 int partType) {
+    if (partType == 1) {
+      return packedPart.rawHcalFraction() * packedPart.energy();
+    }
+    return pfCand.rawHcalEnergy();
+  }
+  static double getHOEnergy(const reco::PFCandidate pfCand,
+                            const pat::PackedCandidate packedPart,
+                            const reco::CandidatePtr cand,
+                            int partType) {
+    if (partType) {
+      return 0;
+    }
+    return pfCand.hoEnergy();
+  }
+  static double getRawHOEnergy(const reco::PFCandidate pfCand,
+                               const pat::PackedCandidate packedPart,
+                               const reco::CandidatePtr cand,
+                               int partType) {
+    if (partType) {
+      return 0;
+    }
+    return pfCand.rawHoEnergy();
+  }
 
-  static double getMVAIsolated(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.mva_Isolated(); }
-  static double getMVAEPi(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.mva_e_pi(); }
-  static double getMVAEMu(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.mva_e_mu(); }
-  static double getMVAPiMu(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.mva_pi_mu(); }
-  static double getMVANothingGamma(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.mva_nothing_gamma(); }
-  static double getMVANothingNH(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.mva_nothing_nh(); }
-  static double getMVAGammaNH(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.mva_gamma_nh(); }
+  static double getMVAIsolated(const reco::PFCandidate pfCand,
+                               const pat::PackedCandidate packedPart,
+                               const reco::CandidatePtr cand,
+                               int partType) {
+    if (partType) {
+      return 0;
+    }
+    return pfCand.mva_Isolated();
+  }
+  static double getMVAEPi(const reco::PFCandidate pfCand,
+                          const pat::PackedCandidate packedPart,
+                          const reco::CandidatePtr cand,
+                          int partType) {
+    if (partType) {
+      return 0;
+    }
+    return pfCand.mva_e_pi();
+  }
+  static double getMVAEMu(const reco::PFCandidate pfCand,
+                          const pat::PackedCandidate packedPart,
+                          const reco::CandidatePtr cand,
+                          int partType) {
+    if (partType) {
+      return 0;
+    }
+    return pfCand.mva_e_mu();
+  }
+  static double getMVAPiMu(const reco::PFCandidate pfCand,
+                           const pat::PackedCandidate packedPart,
+                           const reco::CandidatePtr cand,
+                           int partType) {
+    if (partType) {
+      return 0;
+    }
+    return pfCand.mva_pi_mu();
+  }
+  static double getMVANothingGamma(const reco::PFCandidate pfCand,
+                                   const pat::PackedCandidate packedPart,
+                                   const reco::CandidatePtr cand,
+                                   int partType) {
+    if (partType) {
+      return 0;
+    }
+    return pfCand.mva_nothing_gamma();
+  }
+  static double getMVANothingNH(const reco::PFCandidate pfCand,
+                                const pat::PackedCandidate packedPart,
+                                const reco::CandidatePtr cand,
+                                int partType) {
+    if (partType) {
+      return 0;
+    }
+    return pfCand.mva_nothing_nh();
+  }
+  static double getMVAGammaNH(const reco::PFCandidate pfCand,
+                              const pat::PackedCandidate packedPart,
+                              const reco::CandidatePtr cand,
+                              int partType) {
+    if (partType) {
+      return 0;
+    }
+    return pfCand.mva_gamma_nh();
+  }
 
-  static double getDNNESigIsolated(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.dnn_e_sigIsolated(); }
-  static double getDNNESigNonIsolated(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.dnn_e_sigNonIsolated(); }
-  static double getDNNEBkgNonIsolated(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.dnn_e_bkgNonIsolated(); }
-  static double getDNNEBkgTauIsolated(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.dnn_e_bkgTau(); }
-  static double getDNNEBkgPhotonIsolated(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.dnn_e_bkgPhoton(); }
+  static double getDNNESigIsolated(const reco::PFCandidate pfCand,
+                                   const pat::PackedCandidate packedPart,
+                                   const reco::CandidatePtr cand,
+                                   int partType) {
+    if (partType) {
+      return 0;
+    }
+    return pfCand.dnn_e_sigIsolated();
+  }
+  static double getDNNESigNonIsolated(const reco::PFCandidate pfCand,
+                                      const pat::PackedCandidate packedPart,
+                                      const reco::CandidatePtr cand,
+                                      int partType) {
+    if (partType) {
+      return 0;
+    }
+    return pfCand.dnn_e_sigNonIsolated();
+  }
+  static double getDNNEBkgNonIsolated(const reco::PFCandidate pfCand,
+                                      const pat::PackedCandidate packedPart,
+                                      const reco::CandidatePtr cand,
+                                      int partType) {
+    if (partType) {
+      return 0;
+    }
+    return pfCand.dnn_e_bkgNonIsolated();
+  }
+  static double getDNNEBkgTauIsolated(const reco::PFCandidate pfCand,
+                                      const pat::PackedCandidate packedPart,
+                                      const reco::CandidatePtr cand,
+                                      int partType) {
+    if (partType) {
+      return 0;
+    }
+    return pfCand.dnn_e_bkgTau();
+  }
+  static double getDNNEBkgPhotonIsolated(const reco::PFCandidate pfCand,
+                                         const pat::PackedCandidate packedPart,
+                                         const reco::CandidatePtr cand,
+                                         int partType) {
+    if (partType) {
+      return 0;
+    }
+    return pfCand.dnn_e_bkgPhoton();
+  }
 
-  static double getECalEFrac(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.ecalEnergy() / pfCand.energy(); }
-  static double getHCalEFrac(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.hcalEnergy() / pfCand.energy(); }
-  static double getPS1Energy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.pS1Energy();}
-  static double getPS2Energy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.pS2Energy();}
-  static double getPSEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {  
-      if(partType){return 0;} 
-      if(pfCand.particleId() == reco::PFCandidate::ParticleType::gamma){ 
-       double energy =0 ;
-        for (unsigned iele = 0; iele < pfCand.elementsInBlocks().size(); ++iele) {
-          // first get the block
-          reco::PFBlockRef blockRef = pfCand.elementsInBlocks()[iele].first;
-          //
-          unsigned elementIndex = pfCand.elementsInBlocks()[iele].second;
-          // check it actually exists
-          if (blockRef.isNull())
-            continue;
-  
-  
-          // then get the elements of the block
-          const edm::OwnVector<reco::PFBlockElement>& elements = (*blockRef).elements();
-    
-          const reco::PFBlockElement& pfbe(elements[elementIndex]);
-          if (pfbe.type() == reco::PFBlockElement::PS1) {
-                reco::PFClusterRef clusterref = pfbe.clusterRef();
-                if(!clusterref.isNull()){
-                reco::PFCluster cluster = *clusterref;
-                energy += cluster.energy();
-                }
+  static double getECalEFrac(const reco::PFCandidate pfCand,
+                             const pat::PackedCandidate packedPart,
+                             const reco::CandidatePtr cand,
+                             int partType) {
+    if (partType) {
+      return 0;
+    }
+    return pfCand.ecalEnergy() / pfCand.energy();
+  }
+  static double getHCalEFrac(const reco::PFCandidate pfCand,
+                             const pat::PackedCandidate packedPart,
+                             const reco::CandidatePtr cand,
+                             int partType) {
+    if (partType) {
+      return 0;
+    }
+    return pfCand.hcalEnergy() / pfCand.energy();
+  }
+  static double getPS1Energy(const reco::PFCandidate pfCand,
+                             const pat::PackedCandidate packedPart,
+                             const reco::CandidatePtr cand,
+                             int partType) {
+    if (partType) {
+      return 0;
+    }
+    return pfCand.pS1Energy();
+  }
+  static double getPS2Energy(const reco::PFCandidate pfCand,
+                             const pat::PackedCandidate packedPart,
+                             const reco::CandidatePtr cand,
+                             int partType) {
+    if (partType) {
+      return 0;
+    }
+    return pfCand.pS2Energy();
+  }
+  static double getPSEnergy(const reco::PFCandidate pfCand,
+                            const pat::PackedCandidate packedPart,
+                            const reco::CandidatePtr cand,
+                            int partType) {
+    if (partType) {
+      return 0;
+    }
+    if (pfCand.particleId() == reco::PFCandidate::ParticleType::gamma) {
+      double energy = 0;
+      for (unsigned iele = 0; iele < pfCand.elementsInBlocks().size(); ++iele) {
+        // first get the block
+        reco::PFBlockRef blockRef = pfCand.elementsInBlocks()[iele].first;
+        //
+        unsigned elementIndex = pfCand.elementsInBlocks()[iele].second;
+        // check it actually exists
+        if (blockRef.isNull())
+          continue;
+
+        // then get the elements of the block
+        const edm::OwnVector<reco::PFBlockElement>& elements = (*blockRef).elements();
+
+        const reco::PFBlockElement& pfbe(elements[elementIndex]);
+        if (pfbe.type() == reco::PFBlockElement::PS1) {
+          reco::PFClusterRef clusterref = pfbe.clusterRef();
+          if (!clusterref.isNull()) {
+            const reco::PFCluster& cluster = *clusterref;
+            energy += cluster.energy();
           }
         }
-      } 
-      return pfCand.pS1Energy()+pfCand.pS2Energy();}
+      }
+    }
+    return pfCand.pS1Energy() + pfCand.pS2Energy();
+  }
 
-  static double getTrackPt(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
-    if(partType){return 0;} 
+  static double getTrackPt(const reco::PFCandidate pfCand,
+                           const pat::PackedCandidate packedPart,
+                           const reco::CandidatePtr cand,
+                           int partType) {
+    if (partType) {
+      return 0;
+    }
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->pt();
     return 0;
   }
 
-  static double getTrackNStripHits(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
-    if(partType){return 0;} 
+  static double getTrackNStripHits(const reco::PFCandidate pfCand,
+                                   const pat::PackedCandidate packedPart,
+                                   const reco::CandidatePtr cand,
+                                   int partType) {
+    if (partType) {
+      return 0;
+    }
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->hitPattern().numberOfValidStripHits();
     return -1;
   }
 
-  static double getTrackNPixHits(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
-    if(partType){return 0;} 
+  static double getTrackNPixHits(const reco::PFCandidate pfCand,
+                                 const pat::PackedCandidate packedPart,
+                                 const reco::CandidatePtr cand,
+                                 int partType) {
+    if (partType) {
+      return 0;
+    }
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->hitPattern().numberOfValidPixelHits();
 
     return -1;
   }
 
-  static double getTrackChi2(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
-    if(partType){return 0;} 
+  static double getTrackChi2(const reco::PFCandidate pfCand,
+                             const pat::PackedCandidate packedPart,
+                             const reco::CandidatePtr cand,
+                             int partType) {
+    if (partType) {
+      return 0;
+    }
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->chi2();
     return -1;
   }
 
-  static double getTrackPtError(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
-    if(partType){return 0;} 
+  static double getTrackPtError(const reco::PFCandidate pfCand,
+                                const pat::PackedCandidate packedPart,
+                                const reco::CandidatePtr cand,
+                                int partType) {
+    if (partType) {
+      return 0;
+    }
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->ptError();
     return -1;
   }
 
-  static double getTrackRelPtError(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
-    if(partType){return 0;} 
+  static double getTrackRelPtError(const reco::PFCandidate pfCand,
+                                   const pat::PackedCandidate packedPart,
+                                   const reco::CandidatePtr cand,
+                                   int partType) {
+    if (partType) {
+      return 0;
+    }
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->ptError() / (pfCand.trackRef())->pt();
     return -1;
   }
 
-  static double getTrackD0(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
-    if(partType){return 0;} 
+  static double getTrackD0(const reco::PFCandidate pfCand,
+                           const pat::PackedCandidate packedPart,
+                           const reco::CandidatePtr cand,
+                           int partType) {
+    if (partType) {
+      return 0;
+    }
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->d0();
     return -1;
   }
 
-  static double getTrackZ0(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
-    if(partType){return 0;} 
+  static double getTrackZ0(const reco::PFCandidate pfCand,
+                           const pat::PackedCandidate packedPart,
+                           const reco::CandidatePtr cand,
+                           int partType) {
+    if (partType) {
+      return 0;
+    }
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->d0();
     return -1;
   }
 
-  static double getTrackThetaError(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
-    if(partType){return 0;} 
+  static double getTrackThetaError(const reco::PFCandidate pfCand,
+                                   const pat::PackedCandidate packedPart,
+                                   const reco::CandidatePtr cand,
+                                   int partType) {
+    if (partType) {
+      return 0;
+    }
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->thetaError();
     return -1;
   }
 
-  static double getTrackEtaError(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
-    if(partType){return 0;} 
+  static double getTrackEtaError(const reco::PFCandidate pfCand,
+                                 const pat::PackedCandidate packedPart,
+                                 const reco::CandidatePtr cand,
+                                 int partType) {
+    if (partType) {
+      return 0;
+    }
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->etaError();
     return -1;
   }
 
-  static double getTrackPhiError(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
-    if(partType){return 0;} 
+  static double getTrackPhiError(const reco::PFCandidate pfCand,
+                                 const pat::PackedCandidate packedPart,
+                                 const reco::CandidatePtr cand,
+                                 int partType) {
+    if (partType) {
+      return 0;
+    }
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->phiError();
     return -1;
   }
 
-
-  static double getEoverP(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
-    if(partType){return 0;} 
+  static double getEoverP(const reco::PFCandidate pfCand,
+                          const pat::PackedCandidate packedPart,
+                          const reco::CandidatePtr cand,
+                          int partType) {
+    if (partType) {
+      return 0;
+    }
     double energy = 0;
     int maxElement = pfCand.elementsInBlocks().size();
     for (int e = 0; e < maxElement; ++e) {
@@ -353,7 +694,7 @@ private:
           if (elements[iEle].type() == reco::PFBlockElement::HCAL ||
               elements[iEle].type() == reco::PFBlockElement::ECAL) {  // Element is HB or HE
             reco::PFClusterRef clusterref = elements[iEle].clusterRef();
-            reco::PFCluster cluster = *clusterref;
+            const reco::PFCluster& cluster = *clusterref;
             energy += cluster.energy();
           }
         }
@@ -362,8 +703,13 @@ private:
     return energy / pfCand.p();
   }
 
-  static double getHCalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
-    if(partType){return 0;} 
+  static double getHCalEnergy(const reco::PFCandidate pfCand,
+                              const pat::PackedCandidate packedPart,
+                              const reco::CandidatePtr cand,
+                              int partType) {
+    if (partType) {
+      return 0;
+    }
     double energy = 0;
     int maxElement = pfCand.elementsInBlocks().size();
     for (int e = 0; e < maxElement; ++e) {
@@ -375,7 +721,7 @@ private:
           if (elements[iEle].type() == reco::PFBlockElement::HCAL) {  // Element is HB or HE
             // Get cluster and hits
             reco::PFClusterRef clusterref = elements[iEle].clusterRef();
-            reco::PFCluster cluster = *clusterref;
+            const reco::PFCluster& cluster = *clusterref;
             energy += cluster.energy();
           }
         }
@@ -384,8 +730,13 @@ private:
     return energy;
   }
 
-  static double getECalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
-    if(partType){return 0;} 
+  static double getECalEnergy(const reco::PFCandidate pfCand,
+                              const pat::PackedCandidate packedPart,
+                              const reco::CandidatePtr cand,
+                              int partType) {
+    if (partType) {
+      return 0;
+    }
     double energy = 0;
     int maxElement = pfCand.elementsInBlocks().size();
     for (int e = 0; e < maxElement; ++e) {
@@ -398,7 +749,7 @@ private:
             // Get cluster and hits
             reco::PFClusterRef clusterref = elements[iEle].clusterRef();
             // When we don't have isolated tracks, this will be a bit useless, since the energy is shared across multiple tracks
-            reco::PFCluster cluster = *clusterref;
+            const reco::PFCluster& cluster = *clusterref;
             energy += cluster.energy();
           }
         }
@@ -407,8 +758,13 @@ private:
     return energy;
   }
 
-  static double getNTracksInBlock(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
-    if(partType){return 0;} 
+  static double getNTracksInBlock(const reco::PFCandidate pfCand,
+                                  const pat::PackedCandidate packedPart,
+                                  const reco::CandidatePtr cand,
+                                  int partType) {
+    if (partType) {
+      return 0;
+    }
     // We need this function to return a double, even though this is an integer value
     double nTrack = 0;
     int maxElement = pfCand.elementsInBlocks().size();
@@ -428,27 +784,32 @@ private:
   }
 
   static double getJetPt(const reco::Jet jet, const std::vector<reco::PFCandidatePtr> pfCands) { return jet.pt(); }
-  static double getJetChargeFrac(const reco::Jet jet, const std::vector<reco::PFCandidatePtr> pfCands) { 
+  static double getJetChargeFrac(const reco::Jet jet, const std::vector<reco::PFCandidatePtr> pfCands) {
     double chargeFrac = 0;
     //std::vector<reco::PFCandidatePtr> pfConstits = jet.getPFConstituents();
     //std::vector<edm::Ptr<reco::Candidate>> pfConstits = jet.getJetConstituents();
 
-    for (auto recoPF : pfCands) {
-      if(recoPF->particleId() == reco::PFCandidate::ParticleType::h || recoPF->particleId() == reco::PFCandidate::ParticleType::e || recoPF->particleId() == reco::PFCandidate::ParticleType::mu) chargeFrac += recoPF->pt();
+    for (const auto& recoPF : pfCands) {
+      if (recoPF->particleId() == reco::PFCandidate::ParticleType::h ||
+          recoPF->particleId() == reco::PFCandidate::ParticleType::e ||
+          recoPF->particleId() == reco::PFCandidate::ParticleType::mu)
+        chargeFrac += recoPF->pt();
     }
     return chargeFrac / jet.pt();
   }
 
-  bool passesTriggerSelection(const std::vector<reco::Jet>& pfJets, const edm::Handle<edm::TriggerResults>& triggerResults, const edm::TriggerNames& triggerNames, const std::vector<std::string> triggerOptions){
-
+  bool passesTriggerSelection(const std::vector<reco::Jet>& pfJets,
+                              const edm::Handle<edm::TriggerResults>& triggerResults,
+                              const edm::TriggerNames& triggerNames,
+                              const std::vector<std::string> triggerOptions) {
     // Hack to make it pass the lowest unprescaled HLT?
     Int_t JetHiPass = 0;
 
     const unsigned int nTrig(triggerNames.size());
     for (unsigned int i = 0; i < nTrig; ++i) {
       for (unsigned int j = 0; j < triggerOptions.size(); ++j) {
-        if(triggerOptions[j] == "") {
-          JetHiPass=1;
+        if (triggerOptions[j].empty()) {
+          JetHiPass = 1;
           break;
         }
         if (triggerNames.triggerName(i).find(triggerOptions[j]) != std::string::npos && triggerResults->accept(i)) {
@@ -456,7 +817,8 @@ private:
           break;
         }
       }
-      if(JetHiPass) break;
+      if (JetHiPass)
+        break;
     }
 
     if (!JetHiPass)
@@ -464,10 +826,7 @@ private:
     return true;
   }
 
-
-  static bool passesNoCutSelection(const std::vector<reco::Jet>& pfJets) {
-    return true;
-  }
+  static bool passesNoCutSelection(const std::vector<reco::Jet>& pfJets) { return true; }
 
   static bool passesDijetSelection(const std::vector<reco::Jet>& pfJets) {
     if (pfJets.size() < 2)
@@ -476,20 +835,20 @@ private:
       return false;
     if (pfJets[0].pt() / pfJets[1].pt() > 2)
       return false;
-    
+
     return true;
-  } 
+  }
 
   static bool passesAnomalousSelection(const std::vector<reco::Jet>& pfJets) {
     if (pfJets.size() < 2)
       return false;
     if (pfJets[0].pt() < 450)
       return false;
-    if (pfJets[1].pt() / pfJets[0].pt() >0.5)
+    if (pfJets[1].pt() / pfJets[0].pt() > 0.5)
       return false;
-    
+
     return true;
-  } 
+  }
 
   bool m_isMiniAOD;
 
@@ -512,7 +871,6 @@ private:
   edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;
   std::string m_selection;
 
-
   std::vector<std::vector<std::string>> m_allSuffixes;
   std::vector<std::vector<std::string>> m_allJetSuffixes;
 
@@ -523,8 +881,6 @@ private:
   std::map<std::string, MonitorElement*> map_of_MEs;
 
   std::map<reco::PFCandidate::ParticleType, std::string> m_particleTypeName;
-
-
 
   //check later if we need only one set of parameters
   edm::ParameterSet parameters_;
@@ -547,7 +903,6 @@ private:
   vstring m_eventObservableNames;
   vstring m_pfInJetObservableNames;
 
-
   // Information on what cuts should be applied to PFCandidates that are
   // being monitored. In the config file, this should come as a comma-separated list of
   // the observable name, and the lowest and highest values for the histogram.
@@ -558,7 +913,7 @@ private:
   std::vector<std::vector<std::vector<double>>> m_binList;
 
   // Binning information for 2D histograms
-  // Technically, these could be made using just the 1D cuts, 
+  // Technically, these could be made using just the 1D cuts,
   // but this is useful for saving a bit of memory by creating fewer histograms.
   vstring m_cutList2D;
   std::vector<std::vector<std::string>> m_fullCutList2D;

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
@@ -78,7 +78,7 @@ private:
   // A map between an observable name and a function that obtains that observable from a  PFCandidate.
   // This allows us to construct more complicated observables easily, and have it more configurable
   // in the config file.
-  std::map<std::string, std::function<double(const reco::PFCandidate, const pat::PackedCandidate, const reco::CandidatePtr, bool)>> m_funcMap;
+  std::map<std::string, std::function<double(const reco::PFCandidate, const pat::PackedCandidate, const reco::CandidatePtr, int)>> m_funcMap;
   //std::map<std::string, std::function<double(const reco::PFCandidateCollection, reco::PFCandidate::ParticleType pfType)>>
   std::map<std::string, std::function<double(const std::vector<reco::PFCandidate>, reco::PFCandidate::ParticleType pfType)>>
       m_eventFuncMap;
@@ -120,7 +120,6 @@ private:
     return pfCand.pt() / jet.pt();
   }
 
-  //static double getNPFC(const reco::PFCandidateCollection pfCands, reco::PFCandidate::ParticleType pfType) {
   static double getNPFC(const std::vector<reco::PFCandidate> pfCands, reco::PFCandidate::ParticleType pfType) {
     int nPF = 0;
     for (auto pfCand : pfCands) {
@@ -144,7 +143,6 @@ private:
     return nPF;
   }
 
-  //static double getMaxPt(const reco::PFCandidateCollection pfCands, reco::PFCandidate::ParticleType pfType) {
   static double getMaxPt(const std::vector<reco::PFCandidate> pfCands, reco::PFCandidate::ParticleType pfType) {
     double maxPt = 0;
     for (auto pfCand : pfCands) {
@@ -170,20 +168,36 @@ private:
 
 
   // Various functions designed to get information from a PF canddidate
-  static double getPt(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType) {return packedPart.pt();} return pfCand.pt(); }
-  static double getEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType) {return packedPart.energy();} return pfCand.energy(); }
-  static double getEta(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType) {return packedPart.eta();}return pfCand.eta(); }
-  static double getAbsEta(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType) {return std::abs(packedPart.eta());}return std::abs(pfCand.eta()); }
-  static double getPhi(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType) {return packedPart.phi();}return pfCand.phi(); }
+  static double getPt(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { 
+                      if(partType==1) {return packedPart.pt();} 
+                      if(partType==2) {return cand->pt(); } 
+                      return pfCand.pt(); 
+                     }
+  static double getEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType==1) {return packedPart.energy();} return pfCand.energy(); }
+  static double getEta(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { 
+                        if(partType==1) { return packedPart.eta();}
+                        if(partType==2) { return cand->eta(); } 
+                        return pfCand.eta(); 
+                      }
+  static double getAbsEta(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { 
+                            if(partType==1) {return std::abs(packedPart.eta());}
+                            if(partType==2) { return std::abs(cand->eta()); } 
+                            return std::abs(pfCand.eta()); 
+                         }
+  static double getPhi(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { 
+                         if(partType==1) {return packedPart.phi();}
+                         if(partType==2) { return cand->phi(); } 
+                         return pfCand.phi(); 
+                       }
 
   static double getHadCalibration(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
     if (pfCand.rawHcalEnergy() == 0)
       return -1;
     return pfCand.hcalEnergy() / pfCand.rawHcalEnergy();
   }
-  static double getPuppiWeight(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return packedPart.puppiWeight();} return 1; }
+  static double getPuppiWeight(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType==1){return packedPart.puppiWeight();} return 1; }
 
-  static double getTime(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return packedPart.time();} return pfCand.time(); }
+  static double getTime(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType==1){return packedPart.time();} return pfCand.time(); }
 
   static double getHcalEnergy_depth1(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {  return pfCand.hcalDepthEnergyFraction(1); }
   static double getHcalEnergy_depth2(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { return pfCand.hcalDepthEnergyFraction(2); }
@@ -193,10 +207,10 @@ private:
   static double getHcalEnergy_depth6(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { return pfCand.hcalDepthEnergyFraction(6); }
   static double getHcalEnergy_depth7(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { return pfCand.hcalDepthEnergyFraction(7); }
 
-  static double getEcalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){ return (1.0-packedPart.hcalFraction())*packedPart.energy();} return pfCand.ecalEnergy(); }
-  static double getRawEcalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){ return (1.0-packedPart.rawHcalFraction())*packedPart.energy();}return pfCand.rawEcalEnergy(); }
-  static double getHcalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {  if(partType){return packedPart.hcalFraction()*packedPart.energy();}return pfCand.hcalEnergy(); }
-  static double getRawHcalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {  if(partType){ return packedPart.rawHcalFraction()*packedPart.energy();}return pfCand.rawHcalEnergy(); }
+  static double getEcalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType==1){ return (1.0-packedPart.hcalFraction())*packedPart.energy();} return pfCand.ecalEnergy(); }
+  static double getRawEcalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType==1){ return (1.0-packedPart.rawHcalFraction())*packedPart.energy();}return pfCand.rawEcalEnergy(); }
+  static double getHcalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {  if(partType==1){return packedPart.hcalFraction()*packedPart.energy();}return pfCand.hcalEnergy(); }
+  static double getRawHcalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {  if(partType==1){ return packedPart.rawHcalFraction()*packedPart.energy();}return pfCand.rawHcalEnergy(); }
   static double getHOEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.hoEnergy(); }
   static double getRawHOEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.rawHoEnergy(); }
 
@@ -244,8 +258,6 @@ private:
                 }
           }
         }
-
-        std::cout << energy << "\t" <<  pfCand.pS1Energy() << std::endl;
       } 
       return pfCand.pS1Energy()+pfCand.pS2Energy();}
 
@@ -364,7 +376,6 @@ private:
             // Get cluster and hits
             reco::PFClusterRef clusterref = elements[iEle].clusterRef();
             reco::PFCluster cluster = *clusterref;
-            //std::vector<std::pair<DetId, float>> hitsAndFracs = cluster.hitsAndFractions();
             energy += cluster.energy();
           }
         }
@@ -454,17 +465,6 @@ private:
   }
 
 
-  static bool passesEventSelection(const std::vector<reco::Jet>& pfJets) {
-    if (pfJets.size() < 2)
-      return false;
-    if (pfJets[0].pt() < 450)
-      return false;
-    if (pfJets[0].pt() / pfJets[1].pt() > 2)
-      return false;
-
-    return true;
-  }
-
   static bool passesNoCutSelection(const std::vector<reco::Jet>& pfJets) {
     return true;
   }
@@ -494,7 +494,6 @@ private:
   bool m_isMiniAOD;
 
   edm::EDGetTokenT<reco::PFCandidateCollection> thePfCandidateCollection_;
-  //edm::EDGetTokenT<pat::PFParticleCollection> patPfCandidateCollection_;
   edm::EDGetTokenT<pat::PackedCandidateCollection> patPfCandidateCollection_;
 
   edm::EDGetTokenT<reco::PFJetCollection> pfJetsToken_;

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
@@ -45,6 +45,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 
 #include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -180,6 +181,7 @@ private:
       return -1;
     return pfCand.hcalEnergy() / pfCand.rawHcalEnergy();
   }
+  static double getPuppiWeight(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return packedPart.puppiWeight();} return 1; }
 
   static double getTime(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return packedPart.time();} return pfCand.time(); }
 
@@ -501,8 +503,8 @@ private:
   edm::EDGetTokenT<std::vector<reco::Vertex>> vertexToken_;
   edm::InputTag srcWeights;
 
-  edm::EDGetTokenT<edm::ValueMap<float>> weightsToken_;
-  edm::ValueMap<float> const* weights_;
+  edm::EDGetTokenT<edm::ValueMap<float>> puppiWeightToken_;
+  edm::Handle<edm::ValueMap<float>> puppiWeight;
 
   edm::EDGetTokenT<GenEventInfoProduct> tok_ew_;
 

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
@@ -516,30 +516,6 @@ private:
     if (partType) {
       return 0;
     }
-    if (pfCand.particleId() == reco::PFCandidate::ParticleType::gamma) {
-      double energy = 0;
-      for (unsigned iele = 0; iele < pfCand.elementsInBlocks().size(); ++iele) {
-        // first get the block
-        reco::PFBlockRef blockRef = pfCand.elementsInBlocks()[iele].first;
-        //
-        unsigned elementIndex = pfCand.elementsInBlocks()[iele].second;
-        // check it actually exists
-        if (blockRef.isNull())
-          continue;
-
-        // then get the elements of the block
-        const edm::OwnVector<reco::PFBlockElement>& elements = (*blockRef).elements();
-
-        const reco::PFBlockElement& pfbe(elements[elementIndex]);
-        if (pfbe.type() == reco::PFBlockElement::PS1) {
-          reco::PFClusterRef clusterref = pfbe.clusterRef();
-          if (!clusterref.isNull()) {
-            const reco::PFCluster& cluster = *clusterref;
-            energy += cluster.energy();
-          }
-        }
-      }
-    }
     return pfCand.pS1Energy() + pfCand.pS2Energy();
   }
 

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
@@ -73,18 +73,21 @@ private:
   std::map<std::string, std::function<double(const reco::PFCandidate)>> m_funcMap;
   std::map<std::string, std::function<double(const reco::PFCandidateCollection, reco::PFCandidate::ParticleType pfType)>>
       m_eventFuncMap;
+
   std::map<std::string,
-           std::function<double(const std::vector<reco::PFCandidatePtr> pfCands, reco::PFCandidate::ParticleType pfType)>>
+           std::function<double(const std::vector<reco::PFCandidatePtr> pfCands, reco::PFCandidate::ParticleType pfType, const reco::PFJet)>>
       m_jetWideFuncMap;
+
   std::map<std::string, std::function<double(const reco::PFCandidate, const reco::PFJet)>> m_pfInJetFuncMap;
   std::map<std::string, std::function<double(const reco::PFJet)>> m_jetFuncMap;
+
+  std::map<std::string, std::function<bool(const edm::Handle<std::vector<reco::PFJet> >& pfJets)>> m_eventSelectionMap;
 
   binInfo getBinInfo(std::string);
 
   // Book MonitorElements
   void bookMESetSelection(std::string, DQMStore::IBooker&);
 
-  bool passesEventSelection(const edm::Event& iEvent);
 
   int getPFBin(const reco::PFCandidate pfCand, int i);
   int getJetBin(const reco::PFJet jetCand, int i);
@@ -118,7 +121,7 @@ private:
     return nPF;
   }
 
-  static double getNPFCinJet(const std::vector<reco::PFCandidatePtr> pfCands, reco::PFCandidate::ParticleType pfType) {
+  static double getNPFCinJet(const std::vector<reco::PFCandidatePtr> pfCands, reco::PFCandidate::ParticleType pfType, const reco::PFJet jet) {
     int nPF = 0;
     for (auto pfCand : pfCands) {
       if (!pfCand)
@@ -129,6 +132,30 @@ private:
     }
     return nPF;
   }
+
+  static double getMaxPt(const reco::PFCandidateCollection pfCands, reco::PFCandidate::ParticleType pfType) {
+    double maxPt = 0;
+    for (auto pfCand : pfCands) {
+      // We use X to indicate all
+      if (pfCand.particleId() == pfType || pfType == reco::PFCandidate::ParticleType::X) {
+        if(pfCand.pt() > maxPt ) maxPt = pfCand.pt();
+      }
+    }
+    return maxPt;
+  }
+
+  static double getMaxPtFracJet(const std::vector<reco::PFCandidatePtr> pfCands, reco::PFCandidate::ParticleType pfType, const reco::PFJet jet) {
+    double maxPt = 0;
+    for (auto pfCand : pfCands) {
+      if (!pfCand)
+        continue;
+      // We use X to indicate all
+      if (pfCand->particleId() == pfType || pfType == reco::PFCandidate::ParticleType::X)
+        if(pfCand->pt() > maxPt ) maxPt = pfCand->pt();
+    }
+    return maxPt / jet.pt();
+  }
+
 
   // Various functions designed to get information from a PF canddidate
   static double getPt(const reco::PFCandidate pfCand) { return pfCand.pt(); }
@@ -176,11 +203,105 @@ private:
 
   static double getECalEFrac(const reco::PFCandidate pfCand) { return pfCand.ecalEnergy() / pfCand.energy(); }
   static double getHCalEFrac(const reco::PFCandidate pfCand) { return pfCand.hcalEnergy() / pfCand.energy(); }
+  static double getPS1Energy(const reco::PFCandidate pfCand) { return pfCand.pS1Energy();}
+  static double getPS2Energy(const reco::PFCandidate pfCand) { return pfCand.pS2Energy();}
+  static double getPSEnergy(const reco::PFCandidate pfCand) {
+      if(pfCand.particleId() == reco::PFCandidate::ParticleType::gamma){ 
+       double energy =0 ;
+        for (unsigned iele = 0; iele < pfCand.elementsInBlocks().size(); ++iele) {
+          // first get the block
+          reco::PFBlockRef blockRef = pfCand.elementsInBlocks()[iele].first;
+          //
+          unsigned elementIndex = pfCand.elementsInBlocks()[iele].second;
+          // check it actually exists
+          if (blockRef.isNull())
+            continue;
+  
+  
+          // then get the elements of the block
+          const edm::OwnVector<reco::PFBlockElement>& elements = (*blockRef).elements();
+    
+          const reco::PFBlockElement& pfbe(elements[elementIndex]);
+          if (pfbe.type() == reco::PFBlockElement::PS1) {
+                reco::PFClusterRef clusterref = pfbe.clusterRef();
+                if(!clusterref.isNull()){
+                reco::PFCluster cluster = *clusterref;
+                energy += cluster.energy();
+                }
+          }
+        }
+
+        std::cout << energy << "\t" <<  pfCand.pS1Energy() << std::endl;
+      } 
+      return pfCand.pS1Energy()+pfCand.pS2Energy();}
+
   static double getTrackPt(const reco::PFCandidate pfCand) {
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->pt();
     return 0;
   }
+
+  static double getTrackNStripHits(const reco::PFCandidate pfCand) {
+    if (pfCand.trackRef().isNonnull())
+      return (pfCand.trackRef())->hitPattern().numberOfValidStripHits();
+    return -1;
+  }
+
+  static double getTrackNPixHits(const reco::PFCandidate pfCand) {
+    if (pfCand.trackRef().isNonnull())
+      return (pfCand.trackRef())->hitPattern().numberOfValidPixelHits();
+
+    return -1;
+  }
+
+  static double getTrackChi2(const reco::PFCandidate pfCand) {
+    if (pfCand.trackRef().isNonnull())
+      return (pfCand.trackRef())->chi2();
+    return -1;
+  }
+
+  static double getTrackPtError(const reco::PFCandidate pfCand) {
+    if (pfCand.trackRef().isNonnull())
+      return (pfCand.trackRef())->ptError();
+    return -1;
+  }
+
+  static double getTrackRelPtError(const reco::PFCandidate pfCand) {
+    if (pfCand.trackRef().isNonnull())
+      return (pfCand.trackRef())->ptError() / (pfCand.trackRef())->pt();
+    return -1;
+  }
+
+  static double getTrackD0(const reco::PFCandidate pfCand) {
+    if (pfCand.trackRef().isNonnull())
+      return (pfCand.trackRef())->d0();
+    return -1;
+  }
+
+  static double getTrackZ0(const reco::PFCandidate pfCand) {
+    if (pfCand.trackRef().isNonnull())
+      return (pfCand.trackRef())->d0();
+    return -1;
+  }
+
+  static double getTrackThetaError(const reco::PFCandidate pfCand) {
+    if (pfCand.trackRef().isNonnull())
+      return (pfCand.trackRef())->thetaError();
+    return -1;
+  }
+
+  static double getTrackEtaError(const reco::PFCandidate pfCand) {
+    if (pfCand.trackRef().isNonnull())
+      return (pfCand.trackRef())->etaError();
+    return -1;
+  }
+
+  static double getTrackPhiError(const reco::PFCandidate pfCand) {
+    if (pfCand.trackRef().isNonnull())
+      return (pfCand.trackRef())->phiError();
+    return -1;
+  }
+
 
   static double getEoverP(const reco::PFCandidate pfCand) {
     double energy = 0;
@@ -267,6 +388,86 @@ private:
   }
 
   static double getJetPt(const reco::PFJet jet) { return jet.pt(); }
+  static double getJetChargeFrac(const reco::PFJet jet) { 
+    double chargeFrac = 0;
+    std::vector<reco::PFCandidatePtr> pfConstits = jet.getPFConstituents();
+
+    for (auto recoPF : pfConstits) {
+      if(recoPF->particleId() == reco::PFCandidate::ParticleType::h || recoPF->particleId() == reco::PFCandidate::ParticleType::e || recoPF->particleId() == reco::PFCandidate::ParticleType::mu) chargeFrac += recoPF->pt();
+    }
+    return chargeFrac / jet.pt();
+  }
+
+  bool passesTriggerSelection(const edm::Handle<std::vector<reco::PFJet> >& pfJets, const edm::Handle<edm::TriggerResults>& triggerResults, const edm::TriggerNames& triggerNames, const std::vector<std::string> triggerOptions){
+
+    // Hack to make it pass the lowest unprescaled HLT?
+    Int_t JetHiPass = 0;
+
+    const unsigned int nTrig(triggerNames.size());
+    for (unsigned int i = 0; i < nTrig; ++i) {
+      for (unsigned int j = 0; j < triggerOptions.size(); ++j) {
+        if(triggerOptions[j] == "") {
+          JetHiPass=1;
+          break;
+        }
+        if (triggerNames.triggerName(i).find(triggerOptions[j]) != std::string::npos && triggerResults->accept(i)) {
+          JetHiPass = 1;
+          break;
+        }
+      }
+      if(JetHiPass) break;
+    }
+
+    if (!JetHiPass)
+      return false;
+    return true;
+  }
+
+
+  static bool passesEventSelection(const edm::Handle<std::vector<reco::PFJet> >& pfJets) {
+    if (pfJets->size() < 2)
+      return false;
+    if (pfJets->at(0).pt() < 450)
+      return false;
+    if (pfJets->at(0).pt() / pfJets->at(1).pt() > 2)
+      return false;
+
+    return true;
+  }
+
+  static bool passesNoCutSelection(const edm::Handle<std::vector<reco::PFJet> >& pfJets) {
+    //if (pfJets->size() < 2)
+    //  return false;
+    //if (pfJets->at(0).pt() < 450)
+    //  return false;
+    //if (pfJets->at(0).pt() / pfJets->at(1).pt() > 2)
+    //  return false;
+
+    return true;
+  }
+
+  static bool passesDijetSelection(const edm::Handle<std::vector<reco::PFJet> >& pfJets) {
+    if (pfJets->size() < 2)
+      return false;
+    if (pfJets->at(0).pt() < 450)
+      return false;
+    if (pfJets->at(0).pt() / pfJets->at(1).pt() > 2)
+      return false;
+    
+    return true;
+  } 
+
+  static bool passesAnomalousSelection(const edm::Handle<std::vector<reco::PFJet> >& pfJets) {
+    if (pfJets->size() < 2)
+      return false;
+    if (pfJets->at(0).pt() < 450)
+      return false;
+    if (pfJets->at(1).pt() / pfJets->at(0).pt() >0.5)
+      return false;
+    
+    return true;
+  } 
+
 
   edm::EDGetTokenT<reco::PFCandidateCollection> thePfCandidateCollection_;
   edm::EDGetTokenT<std::vector<reco::Vertex>> vertexToken_;
@@ -280,8 +481,9 @@ private:
 
   edm::InputTag theTriggerResultsLabel_;
   edm::InputTag vertexTag_;
-  edm::InputTag highPtJetExpr_;
   edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;
+  std::string m_selection;
+
 
   std::vector<std::vector<std::string>> m_allSuffixes;
   std::vector<std::vector<std::string>> m_allJetSuffixes;
@@ -292,11 +494,17 @@ private:
   // All of the histograms, stored as a map between the histogram name and the histogram
   std::map<std::string, MonitorElement*> map_of_MEs;
 
+  std::map<reco::PFCandidate::ParticleType, std::string> m_particleTypeName;
+
+
+
   //check later if we need only one set of parameters
   edm::ParameterSet parameters_;
 
   typedef std::vector<std::string> vstring;
   typedef std::vector<double> vDouble;
+
+  vstring m_triggerOptions;
   // Information on which observables to make histograms for.
   // In the config file, this should come as a comma-separated list of
   // the observable name, the number of bins for the histogram, and
@@ -311,6 +519,7 @@ private:
   vstring m_eventObservableNames;
   vstring m_pfInJetObservableNames;
 
+
   // Information on what cuts should be applied to PFCandidates that are
   // being monitored. In the config file, this should come as a comma-separated list of
   // the observable name, and the lowest and highest values for the histogram.
@@ -319,6 +528,13 @@ private:
   vstring m_cutList;
   std::vector<std::vector<std::string>> m_fullCutList;
   std::vector<std::vector<std::vector<double>>> m_binList;
+
+  // Binning information for 2D histograms
+  // Technically, these could be made using just the 1D cuts, 
+  // but this is useful for saving a bit of memory by creating fewer histograms.
+  vstring m_cutList2D;
+  std::vector<std::vector<std::string>> m_fullCutList2D;
+  std::vector<std::vector<std::vector<double>>> m_binList2D;
 
   // Information on what cuts should be applied to PFJets, in the case that we
   // match PFCs to jets.In the config file, this should come as a comma-separated list of

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
@@ -77,7 +77,7 @@ private:
   // A map between an observable name and a function that obtains that observable from a  PFCandidate.
   // This allows us to construct more complicated observables easily, and have it more configurable
   // in the config file.
-  std::map<std::string, std::function<double(const reco::PFCandidate, const pat::PackedCandidate, bool)>> m_funcMap;
+  std::map<std::string, std::function<double(const reco::PFCandidate, const pat::PackedCandidate, const reco::CandidatePtr, bool)>> m_funcMap;
   //std::map<std::string, std::function<double(const reco::PFCandidateCollection, reco::PFCandidate::ParticleType pfType)>>
   std::map<std::string, std::function<double(const std::vector<reco::PFCandidate>, reco::PFCandidate::ParticleType pfType)>>
       m_eventFuncMap;
@@ -98,7 +98,7 @@ private:
   void bookMESetSelection(std::string, DQMStore::IBooker&);
 
 
-  int getPFBin(const reco::PFCandidate pfCand, const pat::PackedCandidate packedCand, bool isMini, int i);
+  int getPFBin(const reco::PFCandidate pfCand, const pat::PackedCandidate packedCand, const reco::CandidatePtr cand, int partType, int i);
   int getJetBin(const reco::Jet jetCand, const std::vector<reco::PFCandidatePtr> pfCands, int i);
 
   int getBinNumber(double binVal, std::vector<double> bins);
@@ -169,55 +169,55 @@ private:
 
 
   // Various functions designed to get information from a PF canddidate
-  static double getPt(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini) {return packedPart.pt();} return pfCand.pt(); }
-  static double getEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini) {return packedPart.energy();} return pfCand.energy(); }
-  static double getEta(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini) {return packedPart.eta();}return pfCand.eta(); }
-  static double getAbsEta(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini) {return std::abs(packedPart.eta());}return std::abs(pfCand.eta()); }
-  static double getPhi(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini) {return packedPart.phi();}return pfCand.phi(); }
+  static double getPt(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType) {return packedPart.pt();} return pfCand.pt(); }
+  static double getEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType) {return packedPart.energy();} return pfCand.energy(); }
+  static double getEta(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType) {return packedPart.eta();}return pfCand.eta(); }
+  static double getAbsEta(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType) {return std::abs(packedPart.eta());}return std::abs(pfCand.eta()); }
+  static double getPhi(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType) {return packedPart.phi();}return pfCand.phi(); }
 
-  static double getHadCalibration(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) {
+  static double getHadCalibration(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
     if (pfCand.rawHcalEnergy() == 0)
       return -1;
     return pfCand.hcalEnergy() / pfCand.rawHcalEnergy();
   }
 
-  static double getTime(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini){return packedPart.time();} return pfCand.time(); }
+  static double getTime(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return packedPart.time();} return pfCand.time(); }
 
-  static double getHcalEnergy_depth1(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) {  return pfCand.hcalDepthEnergyFraction(1); }
-  static double getHcalEnergy_depth2(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { return pfCand.hcalDepthEnergyFraction(2); }
-  static double getHcalEnergy_depth3(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { return pfCand.hcalDepthEnergyFraction(3); }
-  static double getHcalEnergy_depth4(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { return pfCand.hcalDepthEnergyFraction(4); }
-  static double getHcalEnergy_depth5(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { return pfCand.hcalDepthEnergyFraction(5); }
-  static double getHcalEnergy_depth6(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { return pfCand.hcalDepthEnergyFraction(6); }
-  static double getHcalEnergy_depth7(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { return pfCand.hcalDepthEnergyFraction(7); }
+  static double getHcalEnergy_depth1(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {  return pfCand.hcalDepthEnergyFraction(1); }
+  static double getHcalEnergy_depth2(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { return pfCand.hcalDepthEnergyFraction(2); }
+  static double getHcalEnergy_depth3(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { return pfCand.hcalDepthEnergyFraction(3); }
+  static double getHcalEnergy_depth4(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { return pfCand.hcalDepthEnergyFraction(4); }
+  static double getHcalEnergy_depth5(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { return pfCand.hcalDepthEnergyFraction(5); }
+  static double getHcalEnergy_depth6(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { return pfCand.hcalDepthEnergyFraction(6); }
+  static double getHcalEnergy_depth7(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { return pfCand.hcalDepthEnergyFraction(7); }
 
-  static double getEcalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini){ return (1.0-packedPart.hcalFraction())*packedPart.energy();} return pfCand.ecalEnergy(); }
-  static double getRawEcalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini){ return (1.0-packedPart.rawHcalFraction())*packedPart.energy();}return pfCand.rawEcalEnergy(); }
-  static double getHcalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) {  if(isMini){return packedPart.hcalFraction()*packedPart.energy();}return pfCand.hcalEnergy(); }
-  static double getRawHcalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) {  if(isMini){ return packedPart.rawHcalFraction()*packedPart.energy();}return pfCand.rawHcalEnergy(); }
-  static double getHOEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini){return 0;} return pfCand.hoEnergy(); }
-  static double getRawHOEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini){return 0;} return pfCand.rawHoEnergy(); }
+  static double getEcalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){ return (1.0-packedPart.hcalFraction())*packedPart.energy();} return pfCand.ecalEnergy(); }
+  static double getRawEcalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){ return (1.0-packedPart.rawHcalFraction())*packedPart.energy();}return pfCand.rawEcalEnergy(); }
+  static double getHcalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {  if(partType){return packedPart.hcalFraction()*packedPart.energy();}return pfCand.hcalEnergy(); }
+  static double getRawHcalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {  if(partType){ return packedPart.rawHcalFraction()*packedPart.energy();}return pfCand.rawHcalEnergy(); }
+  static double getHOEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.hoEnergy(); }
+  static double getRawHOEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.rawHoEnergy(); }
 
-  static double getMVAIsolated(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini){return 0;} return pfCand.mva_Isolated(); }
-  static double getMVAEPi(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini){return 0;} return pfCand.mva_e_pi(); }
-  static double getMVAEMu(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini){return 0;} return pfCand.mva_e_mu(); }
-  static double getMVAPiMu(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini){return 0;} return pfCand.mva_pi_mu(); }
-  static double getMVANothingGamma(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini){return 0;} return pfCand.mva_nothing_gamma(); }
-  static double getMVANothingNH(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini){return 0;} return pfCand.mva_nothing_nh(); }
-  static double getMVAGammaNH(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini){return 0;} return pfCand.mva_gamma_nh(); }
+  static double getMVAIsolated(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.mva_Isolated(); }
+  static double getMVAEPi(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.mva_e_pi(); }
+  static double getMVAEMu(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.mva_e_mu(); }
+  static double getMVAPiMu(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.mva_pi_mu(); }
+  static double getMVANothingGamma(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.mva_nothing_gamma(); }
+  static double getMVANothingNH(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.mva_nothing_nh(); }
+  static double getMVAGammaNH(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.mva_gamma_nh(); }
 
-  static double getDNNESigIsolated(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini){return 0;} return pfCand.dnn_e_sigIsolated(); }
-  static double getDNNESigNonIsolated(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini){return 0;} return pfCand.dnn_e_sigNonIsolated(); }
-  static double getDNNEBkgNonIsolated(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini){return 0;} return pfCand.dnn_e_bkgNonIsolated(); }
-  static double getDNNEBkgTauIsolated(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini){return 0;} return pfCand.dnn_e_bkgTau(); }
-  static double getDNNEBkgPhotonIsolated(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini){return 0;} return pfCand.dnn_e_bkgPhoton(); }
+  static double getDNNESigIsolated(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.dnn_e_sigIsolated(); }
+  static double getDNNESigNonIsolated(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.dnn_e_sigNonIsolated(); }
+  static double getDNNEBkgNonIsolated(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.dnn_e_bkgNonIsolated(); }
+  static double getDNNEBkgTauIsolated(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.dnn_e_bkgTau(); }
+  static double getDNNEBkgPhotonIsolated(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.dnn_e_bkgPhoton(); }
 
-  static double getECalEFrac(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini){return 0;} return pfCand.ecalEnergy() / pfCand.energy(); }
-  static double getHCalEFrac(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini){return 0;} return pfCand.hcalEnergy() / pfCand.energy(); }
-  static double getPS1Energy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini){return 0;} return pfCand.pS1Energy();}
-  static double getPS2Energy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) { if(isMini){return 0;} return pfCand.pS2Energy();}
-  static double getPSEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) {  
-      if(isMini){return 0;} 
+  static double getECalEFrac(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.ecalEnergy() / pfCand.energy(); }
+  static double getHCalEFrac(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.hcalEnergy() / pfCand.energy(); }
+  static double getPS1Energy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.pS1Energy();}
+  static double getPS2Energy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) { if(partType){return 0;} return pfCand.pS2Energy();}
+  static double getPSEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {  
+      if(partType){return 0;} 
       if(pfCand.particleId() == reco::PFCandidate::ParticleType::gamma){ 
        double energy =0 ;
         for (unsigned iele = 0; iele < pfCand.elementsInBlocks().size(); ++iele) {
@@ -247,87 +247,87 @@ private:
       } 
       return pfCand.pS1Energy()+pfCand.pS2Energy();}
 
-  static double getTrackPt(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) {
-    if(isMini){return 0;} 
+  static double getTrackPt(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
+    if(partType){return 0;} 
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->pt();
     return 0;
   }
 
-  static double getTrackNStripHits(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) {
-    if(isMini){return 0;} 
+  static double getTrackNStripHits(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
+    if(partType){return 0;} 
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->hitPattern().numberOfValidStripHits();
     return -1;
   }
 
-  static double getTrackNPixHits(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) {
-    if(isMini){return 0;} 
+  static double getTrackNPixHits(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
+    if(partType){return 0;} 
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->hitPattern().numberOfValidPixelHits();
 
     return -1;
   }
 
-  static double getTrackChi2(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) {
-    if(isMini){return 0;} 
+  static double getTrackChi2(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
+    if(partType){return 0;} 
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->chi2();
     return -1;
   }
 
-  static double getTrackPtError(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) {
-    if(isMini){return 0;} 
+  static double getTrackPtError(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
+    if(partType){return 0;} 
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->ptError();
     return -1;
   }
 
-  static double getTrackRelPtError(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) {
-    if(isMini){return 0;} 
+  static double getTrackRelPtError(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
+    if(partType){return 0;} 
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->ptError() / (pfCand.trackRef())->pt();
     return -1;
   }
 
-  static double getTrackD0(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) {
-    if(isMini){return 0;} 
+  static double getTrackD0(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
+    if(partType){return 0;} 
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->d0();
     return -1;
   }
 
-  static double getTrackZ0(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) {
-    if(isMini){return 0;} 
+  static double getTrackZ0(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
+    if(partType){return 0;} 
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->d0();
     return -1;
   }
 
-  static double getTrackThetaError(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) {
-    if(isMini){return 0;} 
+  static double getTrackThetaError(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
+    if(partType){return 0;} 
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->thetaError();
     return -1;
   }
 
-  static double getTrackEtaError(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) {
-    if(isMini){return 0;} 
+  static double getTrackEtaError(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
+    if(partType){return 0;} 
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->etaError();
     return -1;
   }
 
-  static double getTrackPhiError(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) {
-    if(isMini){return 0;} 
+  static double getTrackPhiError(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
+    if(partType){return 0;} 
     if (pfCand.trackRef().isNonnull())
       return (pfCand.trackRef())->phiError();
     return -1;
   }
 
 
-  static double getEoverP(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) {
-    if(isMini){return 0;} 
+  static double getEoverP(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
+    if(partType){return 0;} 
     double energy = 0;
     int maxElement = pfCand.elementsInBlocks().size();
     for (int e = 0; e < maxElement; ++e) {
@@ -348,8 +348,8 @@ private:
     return energy / pfCand.p();
   }
 
-  static double getHCalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) {
-    if(isMini){return 0;} 
+  static double getHCalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
+    if(partType){return 0;} 
     double energy = 0;
     int maxElement = pfCand.elementsInBlocks().size();
     for (int e = 0; e < maxElement; ++e) {
@@ -371,8 +371,8 @@ private:
     return energy;
   }
 
-  static double getECalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) {
-    if(isMini){return 0;} 
+  static double getECalEnergy(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
+    if(partType){return 0;} 
     double energy = 0;
     int maxElement = pfCand.elementsInBlocks().size();
     for (int e = 0; e < maxElement; ++e) {
@@ -394,8 +394,8 @@ private:
     return energy;
   }
 
-  static double getNTracksInBlock(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, bool isMini) {
-    if(isMini){return 0;} 
+  static double getNTracksInBlock(const reco::PFCandidate pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType) {
+    if(partType){return 0;} 
     // We need this function to return a double, even though this is an integer value
     double nTrack = 0;
     int maxElement = pfCand.elementsInBlocks().size();

--- a/DQMOffline/ParticleFlow/python/runBasic_cfg.py
+++ b/DQMOffline/ParticleFlow/python/runBasic_cfg.py
@@ -15,15 +15,46 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.load("DQMServices.Core.DQM_cfg")
 process.load("DQMServices.Components.DQMEnvironment_cfi")
 
+# load jet correctors
+process.load('JetMETCorrections.Configuration.JetCorrectors_cff')
+
 # my analyzer
 process.load('DQMOffline.ParticleFlow.runBasic_cfi')
 
+# Setup Global Tag
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '150X_dataRun3_Prompt_v1', '')
+
+# Here we explicitly override the jet energy corrections (JECs) in a Global Tag
+process.GlobalTag.toGet = cms.VPSet(
+  cms.PSet(
+    record = cms.string("JetCorrectionsRecord"),
+    tag = cms.string("JetCorrectorParametersCollection_Winter25Prompt25_RunC_V1_DATA_AK4PFPuppi_v1"),
+    label = cms.untracked.string('AK4PFPuppi'),
+    connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
+  )
+)
 
 with open('fileList.log') as f:
     lines = f.readlines()
 #Input source
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(lines))
 
+# "CorrectedPFJetProducer" module applies the jet energy
+# corrections on the jet collection and sort the collection
+# according to pt
+process.ak4PFJetsPuppiCorrected = cms.EDProducer('CorrectedPFJetProducer',
+    src        = cms.InputTag('ak4PFJetsPuppi'),
+    correctors = cms.VInputTag('ak4PFPuppiL1FastL2L3ResidualCorrector')
+)
+
+###################################################################
+# Data certification GoldenJSON filtering
+###################################################################
+goldenJSONPath="/eos/user/c/cmsdqm/www/CAF/certification/Collisions25/Cert_Collisions2025_391658_397294_Golden.json"
+if goldenJSONPath != "":
+    import FWCore.PythonUtilities.LumiList as LumiList
+    process.source.lumisToProcess = LumiList.LumiList(filename = goldenJSONPath).getVLuminosityBlockRange()
 
 from DQMOffline.ParticleFlow.runBasic_cfi import *
 
@@ -31,7 +62,10 @@ process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
                                      fileName = cms.untracked.string("OUT_step1.root"))
 
 
-process.p = cms.Path(process.PFAnalyzer)
+process.p = cms.Path(
+    process.ak4PFPuppiL1FastL2L3ResidualCorrectorChain+
+    process.ak4PFJetsPuppiCorrected+
+    process.PFAnalyzer)
 process.DQMoutput_step = cms.EndPath(process.DQMoutput)
 
 

--- a/DQMOffline/ParticleFlow/python/runBasic_cfg.py
+++ b/DQMOffline/ParticleFlow/python/runBasic_cfg.py
@@ -51,7 +51,8 @@ process.ak4PFJetsPuppiCorrected = cms.EDProducer('CorrectedPFJetProducer',
 ###################################################################
 # Data certification GoldenJSON filtering
 ###################################################################
-goldenJSONPath="/eos/user/c/cmsdqm/www/CAF/certification/Collisions25/Cert_Collisions2025_391658_397294_Golden.json"
+#goldenJSONPath="/eos/user/c/cmsdqm/www/CAF/certification/Collisions25/Cert_Collisions2025_391658_397294_Golden.json"
+goldenJSONPath=""
 if goldenJSONPath != "":
     import FWCore.PythonUtilities.LumiList as LumiList
     process.source.lumisToProcess = LumiList.LumiList(filename = goldenJSONPath).getVLuminosityBlockRange()

--- a/DQMOffline/ParticleFlow/python/runBasic_cfg.py
+++ b/DQMOffline/ParticleFlow/python/runBasic_cfg.py
@@ -51,8 +51,7 @@ process.ak4PFJetsPuppiCorrected = cms.EDProducer('CorrectedPFJetProducer',
 ###################################################################
 # Data certification GoldenJSON filtering
 ###################################################################
-#goldenJSONPath="/eos/user/c/cmsdqm/www/CAF/certification/Collisions25/Cert_Collisions2025_391658_397294_Golden.json"
-goldenJSONPath=""
+goldenJSONPath="/eos/user/c/cmsdqm/www/CAF/certification/Collisions25/Cert_Collisions2025_391658_397294_Golden.json"
 if goldenJSONPath != "":
     import FWCore.PythonUtilities.LumiList as LumiList
     process.source.lumisToProcess = LumiList.LumiList(filename = goldenJSONPath).getVLuminosityBlockRange()

--- a/DQMOffline/ParticleFlow/python/runBasic_cfi.py
+++ b/DQMOffline/ParticleFlow/python/runBasic_cfi.py
@@ -2,18 +2,19 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
 PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
-    #pfJetCollection        = cms.InputTag("ak4PFJetsPuppiCorrected"),
-    # For Mini
-    pfJetCollection        = cms.InputTag("slimmedJets"),
     #pfCandidates             = cms.InputTag("particleFlow"),
+    #pfJetCollection        = cms.InputTag("ak4PFJetsPuppiCorrected"),
+
     # For Mini
     pfCandidates             = cms.InputTag("packedPFCandidates"),
+    pfJetCollection        = cms.InputTag("slimmedJets"),
+
     PVCollection             = cms.InputTag("offlinePrimaryVertices"),
 
     TriggerResultsLabel        = cms.InputTag("TriggerResults::HLT"),
-    TriggerNames = cms.vstring("HLT_PFJet450"),
-    #TriggerNames = cms.vstring(""),
-    #srcWeights = cms.InputTag("puppi"),
+    #TriggerNames = cms.vstring("HLT_PFJet450"),
+    TriggerNames = cms.vstring(""),
+    #puppiWeight  = cms.InputTag("packedPuppiweight"),
     #eventSelection = cms.string("nocut"),
     #eventSelection = cms.string("dijet"),
     eventSelection = cms.string("nocut"),
@@ -34,9 +35,10 @@ PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
       # in order, are the number of bins, the lowest, and the highest values.
       # If any other number is given, this is just a list of bins for the histogram.
       observables     = cms.vstring('pt;p_{T,PFC};50.;0.;350.', 
-      #                              'eta;#eta;50;-5;5',
-      #                              'phi;#phi;50;-3.14;3.14',
-      #                              'energy;E;50;0;300',
+                                    'eta;#eta;50;-5;5',
+                                    'phi;#phi;50;-3.14;3.14',
+                                    'energy;E;50;0;300',
+                                    'puppi;E;50;0;1',
       #                              'RawHCal_E;Raw E_{hcal};50;0;300', 
       #                              'HCal_E;E_{hcal};50;0;300', 
       #                              'PFHad_calibration;E_{Hcal,calib} / E_{Hcal, raw};50;0;4',
@@ -113,7 +115,7 @@ PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
       # Just like for cutList, multiple sets of cuts can be applied, using the same formulation.
       jetCutList     = cms.vstring(
       #                             '[pt;20;30;50;100;200;450;1000]',
-      #                             '[pt;20;10000]',
+                                   '[pt;20;10000]',
                                   ),
     )
 

--- a/DQMOffline/ParticleFlow/python/runBasic_cfi.py
+++ b/DQMOffline/ParticleFlow/python/runBasic_cfi.py
@@ -2,9 +2,11 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
 PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
-    #pfJetCollection        = cms.InputTag("ak4PFJetsCHS"),
+    #pfJetCollection        = cms.InputTag("ak4PFJetsPuppiCorrected"),
+    # For Mini
     pfJetCollection        = cms.InputTag("slimmedJets"),
     #pfCandidates             = cms.InputTag("particleFlow"),
+    # For Mini
     pfCandidates             = cms.InputTag("packedPFCandidates"),
     PVCollection             = cms.InputTag("offlinePrimaryVertices"),
 

--- a/DQMOffline/ParticleFlow/python/runBasic_cfi.py
+++ b/DQMOffline/ParticleFlow/python/runBasic_cfi.py
@@ -7,13 +7,18 @@ PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
     PVCollection             = cms.InputTag("offlinePrimaryVertices"),
 
     TriggerResultsLabel        = cms.InputTag("TriggerResults::HLT"),
-    TriggerName = cms.InputTag("HLT_PFJet450"),
+    TriggerNames = cms.vstring("HLT_PFJet450"),
+    #TriggerNames = cms.vstring(""),
     srcWeights = cms.InputTag("puppi"),
+    #eventSelection = cms.string("nocut"),
+    eventSelection = cms.string("dijet"),
+
 
 
     pfAnalysis = cms.PSet(
       # Bins of NPV for plots
-      NPVBins = cms.vdouble(0, 25, 45, 100),
+      #NPVBins = cms.vdouble(0, 25, 45, 100),
+      NPVBins = cms.vdouble(0,100),
 
       # A list of observables for which plots should be made.
       # The format should be a list of semicolon-separated values.
@@ -23,13 +28,20 @@ PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
       # The last values are the bins. If three values are given, then the values,
       # in order, are the number of bins, the lowest, and the highest values.
       # If any other number is given, this is just a list of bins for the histogram.
-      observables     = cms.vstring('pt;p_{T,PFC};50.;0.;300.', 
+      observables     = cms.vstring('pt;p_{T,PFC};50.;0.;350.', 
                                     'eta;#eta;50;-5;5',
                                     'phi;#phi;50;-3.14;3.14',
                                     'energy;E;50;0;300',
                                     'RawHCal_E;Raw E_{hcal};50;0;300', 
                                     'HCal_E;E_{hcal};50;0;300', 
                                     'PFHad_calibration;E_{Hcal,calib} / E_{Hcal, raw};50;0;4',
+                                    'HCalE_depth1;HCal E, depth 1;50;0;1',
+                                    'HCalE_depth2;HCal E, depth 2;50;0;1',
+                                    'HCalE_depth3;HCal E, depth 3;50;0;1',
+                                    'HCalE_depth4;HCal E, depth 4;50;0;1',
+                                    'HCalE_depth5;HCal E, depth 5;50;0;1',
+                                    'HCalE_depth6;HCal E, depth 6;50;0;1',
+                                    'HCalE_depth7;HCal E, depth 7;50;0;1',
                                    ),
 
       # A list of event- or jet-wide observables for which plots should be made.
@@ -52,6 +64,17 @@ PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
                                         ),
 
 
+      
+      # This is a list of multidimensional cuts that are applied for the plots.
+      # In the case of multiple bins, every combination of bin is tested.
+      # The format should be a list of semicolon-separated values.
+      # The first is the observable name, corresponding to a key in m_funcMap 
+      # in PFAnalysis. The last values are the bins, following the same
+      # conventions as the observables.
+      binList2D     = cms.vstring(
+                                '[eta;30;-5;5][phi;30;-3.14;3.14]',
+                               ),
+
       # This is a list of multidimensional cuts that are applied for the plots.
       # In the case of multiple bins, every combination of bin is tested.
       # The format should be a list of semicolon-separated values.
@@ -70,8 +93,10 @@ PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
      
       cutList     = cms.vstring(
                                 '[pt;1;0;10000]',
-                                '[pt;0;1;2;4;10;50;10000]',
-                                '[pt;1;0;10000][eta;-5;-4;-3;-2.5;-2;-1;0;1;2;2.5;3;4;5]',
+                                #'[pt;0;1;2;4;6;10;20;40;60;100][abseta;0;1.5;2.0;2.5;2.8;2.85;2.9;2.95;3]',
+                                '[pt;0;2;5;10;20;50;100;1000]',
+                                #'[pt;1;0;10000][abseta;0;1;2;2.5;2.6;2.7;2.8;2.9;3;3.5;4.0;4.5]',
+                                '[pt;1;0;10000][abseta;0;1;1.5;2;2.5;3;3.5;4.0]',
                                ),
 
       # This is a list of multidimensional cuts on the jets that are applied for the plots.
@@ -82,8 +107,8 @@ PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
       #
       # Just like for cutList, multiple sets of cuts can be applied, using the same formulation.
       jetCutList     = cms.vstring(
-                                   '[pt;20;50;100;450;10000]',
-                                   '[pt;20;10000]'
+                                   '[pt;20;30;50;100;200;450;1000]',
+                                   '[pt;20;10000]',
                                   ),
     )
 

--- a/DQMOffline/ParticleFlow/python/runBasic_cfi.py
+++ b/DQMOffline/ParticleFlow/python/runBasic_cfi.py
@@ -2,16 +2,19 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
 PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
-    pfJetCollection        = cms.InputTag("ak4PFJetsCHS"),
-    pfCandidates             = cms.InputTag("particleFlow"),
+    #pfJetCollection        = cms.InputTag("ak4PFJetsCHS"),
+    pfJetCollection        = cms.InputTag("slimmedJets"),
+    #pfCandidates             = cms.InputTag("particleFlow"),
+    pfCandidates             = cms.InputTag("packedPFCandidates"),
     PVCollection             = cms.InputTag("offlinePrimaryVertices"),
 
     TriggerResultsLabel        = cms.InputTag("TriggerResults::HLT"),
     TriggerNames = cms.vstring("HLT_PFJet450"),
     #TriggerNames = cms.vstring(""),
-    srcWeights = cms.InputTag("puppi"),
+    #srcWeights = cms.InputTag("puppi"),
     #eventSelection = cms.string("nocut"),
-    eventSelection = cms.string("dijet"),
+    #eventSelection = cms.string("dijet"),
+    eventSelection = cms.string("nocut"),
 
 
 
@@ -29,19 +32,19 @@ PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
       # in order, are the number of bins, the lowest, and the highest values.
       # If any other number is given, this is just a list of bins for the histogram.
       observables     = cms.vstring('pt;p_{T,PFC};50.;0.;350.', 
-                                    'eta;#eta;50;-5;5',
-                                    'phi;#phi;50;-3.14;3.14',
-                                    'energy;E;50;0;300',
-                                    'RawHCal_E;Raw E_{hcal};50;0;300', 
-                                    'HCal_E;E_{hcal};50;0;300', 
-                                    'PFHad_calibration;E_{Hcal,calib} / E_{Hcal, raw};50;0;4',
-                                    'HCalE_depth1;HCal E, depth 1;50;0;1',
-                                    'HCalE_depth2;HCal E, depth 2;50;0;1',
-                                    'HCalE_depth3;HCal E, depth 3;50;0;1',
-                                    'HCalE_depth4;HCal E, depth 4;50;0;1',
-                                    'HCalE_depth5;HCal E, depth 5;50;0;1',
-                                    'HCalE_depth6;HCal E, depth 6;50;0;1',
-                                    'HCalE_depth7;HCal E, depth 7;50;0;1',
+      #                              'eta;#eta;50;-5;5',
+      #                              'phi;#phi;50;-3.14;3.14',
+      #                              'energy;E;50;0;300',
+      #                              'RawHCal_E;Raw E_{hcal};50;0;300', 
+      #                              'HCal_E;E_{hcal};50;0;300', 
+      #                              'PFHad_calibration;E_{Hcal,calib} / E_{Hcal, raw};50;0;4',
+      #                              'HCalE_depth1;HCal E, depth 1;50;0;1',
+      #                              'HCalE_depth2;HCal E, depth 2;50;0;1',
+      #                              'HCalE_depth3;HCal E, depth 3;50;0;1',
+      #                              'HCalE_depth4;HCal E, depth 4;50;0;1',
+      #                              'HCalE_depth5;HCal E, depth 5;50;0;1',
+      #                              'HCalE_depth6;HCal E, depth 6;50;0;1',
+      #                              'HCalE_depth7;HCal E, depth 7;50;0;1',
                                    ),
 
       # A list of event- or jet-wide observables for which plots should be made.
@@ -55,12 +58,12 @@ PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
       # Since the binning may be very different for events and jets, the first list
       # of bins is for the event histograms, and the second set is for the jets
       eventObservables     = cms.vstring(
-                                         'NPFC;N_{PFC};500;0;10000;100;0;100',
+      #                                   'NPFC;N_{PFC};500;0;10000;100;0;100',
                                         ),
 
 
       pfInJetObservables     = cms.vstring(
-                                         'PFSpectrum;E_{PF}/E_{jet};50;0;1',
+      #                                   'PFSpectrum;E_{PF}/E_{jet};50;0;1',
                                         ),
 
 
@@ -107,8 +110,8 @@ PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
       #
       # Just like for cutList, multiple sets of cuts can be applied, using the same formulation.
       jetCutList     = cms.vstring(
-                                   '[pt;20;30;50;100;200;450;1000]',
-                                   '[pt;20;10000]',
+      #                             '[pt;20;30;50;100;200;450;1000]',
+      #                             '[pt;20;10000]',
                                   ),
     )
 

--- a/DQMOffline/ParticleFlow/python/runMini_cfg.py
+++ b/DQMOffline/ParticleFlow/python/runMini_cfg.py
@@ -16,7 +16,7 @@ process.load("DQMServices.Core.DQM_cfg")
 process.load("DQMServices.Components.DQMEnvironment_cfi")
 
 # my analyzer
-process.load('DQMOffline.ParticleFlow.runBasic_cfi')
+process.load('DQMOffline.ParticleFlow.runMini_cfi')
 
 
 with open('fileList.log') as f:

--- a/DQMOffline/ParticleFlow/python/runMini_cfg.py
+++ b/DQMOffline/ParticleFlow/python/runMini_cfg.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('ParticleFlowDQMOffline')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.EDMtoMEAtRunEnd_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+# load DQM
+process.load("DQMServices.Core.DQM_cfg")
+process.load("DQMServices.Components.DQMEnvironment_cfi")
+
+# my analyzer
+process.load('DQMOffline.ParticleFlow.runBasic_cfi')
+
+
+with open('fileList.log') as f:
+    lines = f.readlines()
+#Input source
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(lines))
+
+process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
+                                     fileName = cms.untracked.string("OUT_step1.root"))
+
+
+process.p = cms.Path(
+    process.PFAnalyzer)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+
+## Schedule definition
+process.schedule = cms.Schedule(
+    process.p,
+    process.DQMoutput_step
+    )
+
+
+
+
+
+
+
+
+

--- a/DQMOffline/ParticleFlow/python/runMini_cfi.py
+++ b/DQMOffline/ParticleFlow/python/runMini_cfi.py
@@ -2,15 +2,18 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
 PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
-    pfCandidates             = cms.InputTag("particleFlow"),
-    pfJetCollection        = cms.InputTag("ak4PFJetsPuppiCorrected"),
+    # For Mini
+    pfCandidates             = cms.InputTag("packedPFCandidates"),
+    pfJetCollection        = cms.InputTag("slimmedJets"),
+
     PVCollection             = cms.InputTag("offlinePrimaryVertices"),
 
     TriggerResultsLabel        = cms.InputTag("TriggerResults::HLT"),
-    TriggerNames = cms.vstring("HLT_PFJet450"),
-    #puppiWeight  = cms.InputTag("packedPuppiweight"),
-    eventSelection = cms.string("dijet"),
-    #eventSelection = cms.string("nocut"),
+    TriggerNames = cms.vstring(""),
+    #eventSelection = cms.string("dijet"),
+    eventSelection = cms.string("nocut"),
+
+
 
     pfAnalysis = cms.PSet(
       # Bins of NPV for plots


### PR DESCRIPTION
PR description:

This PR makes a few key changes to the PF monitoring code, and replaces an incorrect PR that I made a couple days ago.

    Enables the use of the framework with MiniAOD, as discussed in a recent [PF meeting](https://indico.cern.ch/event/1592159/)
    Adds the use of jet calibrations, with the help of @nurfikri89 and Julia Marrinan (who I do not seem to be able to tag).

PR validation:

This code has been tested on MiniAOD samples to confirm the expected behavior both inside and outside jets. Note that there is reduced functionality for MiniAODs, since some information about PF is not included in this format.

The calibrations have been tested, and @nurfikri89 has checked the configuration.

I have gone through the checklist, and the code passes the tests, aside from some problems accessing input files.

I am also tagging the PF conveners for reference: @ahinzmann @stahlleiton
