### PR TITLE
[Not to merge] Update L1TPh2 ntuple sequence and eventcontent

### DIFF
--- a/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2Nanotables_cff.py
+++ b/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2Nanotables_cff.py
@@ -359,7 +359,7 @@ EMTFDisplaceMuTable = staMuTable.clone(
 )
 
 ### Jets
-jetTable = cms.EDProducer(
+l1jetTable = cms.EDProducer(
     "SimpleCandidateFlatTableProducer",
     src = cms.InputTag('__src__'),
     cut = cms.string(""),
@@ -431,14 +431,14 @@ sc4NGJetTable = pfJetTable.clone(
     )
 )
 
-histoJetTable = jetTable.clone(
+histoJetTable = l1jetTable.clone(
     src = cms.InputTag("l1tPhase1JetCalibrator9x9trimmed" ,   "Phase1L1TJetFromPfCandidates"),
     name = cms.string("L1puppiJetHisto"),
     doc = cms.string("Puppi Jets histogrammed 9x9, trimmed, origin: Correlator"),
 )
 
 
-caloJetTable = jetTable.clone(
+caloJetTable = l1jetTable.clone(
     src = cms.InputTag("l1tPhase2CaloJetEmulator","GCTJet"),
     name = cms.string("L1caloJet"),
     doc = cms.string("Calo Jets, origin: GCT"),
@@ -447,7 +447,7 @@ caloJetTable = jetTable.clone(
 
 ### SUMS
 
-puppiMetTable = cms.EDProducer(
+l1puppiMetTable = cms.EDProducer(
     "SimpleCandidateFlatTableProducer",
     src = cms.InputTag("l1tMETPFProducer",""),
     name = cms.string("L1puppiMET"),
@@ -585,7 +585,7 @@ p2L1TablesTask = cms.Task(
     histoJetTable,
     caloJetTable,
     # ## sums
-    puppiMetTable,
+    l1puppiMetTable,
     puppiMLMetTable,
     sc4SumsTable,
     histoSumsTable,

--- a/PhysicsTools/NanoAOD/python/autoNANO.py
+++ b/PhysicsTools/NanoAOD/python/autoNANO.py
@@ -64,8 +64,8 @@ autoNANO = {
                          'DPGAnalysis/Phase2L1TNanoAOD/l1tPh2Nano_cff.addPh2GTObjects',
                         #  'DPGAnalysis/Phase2L1TNanoAOD/l1tPh2Nano_cff.addGenObjects', # <- not included here as requires reco vertices and cannot be run in workflows w/o MINIAOD
                          ])},
-    'Phase2L1DPGwithGen' : {'sequence': '@Phase2L1DPG',
-                            'customize': '@Phase2L1DPG+DPGAnalysis/Phase2L1TNanoAOD/l1tPh2Nano_cff.addGenObjects',},
+    'Phase2L1DPGwithGen' : {'sequence': '@PHYS+@Phase2L1DPG',
+                            'customize': '@PHYS+@Phase2L1DPG+DPGAnalysis/Phase2L1TNanoAOD/l1tPh2Nano_cff.addGenObjects',},
     # Muon POG flavours : add tables through customize, supposed to be combined with PHYS
     'MUPOG': {'sequence': '@PHYS',
               'customize': '@PHYS+PhysicsTools/NanoAOD/custom_muon_cff.PrepMuonCustomNanoAOD'},


### PR DESCRIPTION
#### PR description:
Draft PR to update Phase-2 L1T ntuple sequence and eventcontent.

#### PR validation:
Try to run with following cmsDriver:
```
cmsDriver.py -s RAW2DIGI,L1TrackTrigger,L1,L1P2GT,RECO,RECOSIM,PAT,NANO:@Phase2L1DPGwithGen \
--processName BRSTesting \
--conditions auto:phase2_realistic_T33 \
--geometry ExtendedRun4D110 \
--era Phase2C17I13M9 \
--eventcontent NANOEDMAODSIM \
--datatier GEN-L1NANO \
--customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,Configuration/DataProcessing/Utils.addMonitoring,L1Trigger/Configuration/customisePhase2TTOn110.customisePhase2TTOn110 \
--filein /store/mc/Phase2Spring24DIGIRECOMiniAOD/QCD_Pt-20To30_TuneCP5_14TeV-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_Trk1GeV_140X_mcRun4_realistic_v4-v1/120000/000e6684-7f91-49e0-befb-0a7793ce1ce4.root \
--fileout file:test_L1Nano.root \
--python_filename rerunL1wNano_v2_cfg.py \
--inputCommands="keep *, drop l1tPFJets_*_*_*, drop l1tTrackerMuons_l1tTkMuonsGmt*_*_HLT" \
--mc -n 10 --nThreads 4 --no_exec
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Draft PR.
