### PR TITLE
Phase 2 - Add new tracker DQM histograms showing OT cluster position in 2S modules & ladders

### DIFF
--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
@@ -59,8 +59,8 @@ private:
     MonitorElement* XYGlobalPositionMap_S = nullptr;
     MonitorElement* XYLocalPositionMap_S = nullptr;
 
-    std::vector<MonitorElement*> PositionOfClusters_2S {77, nullptr};
-    std::vector<MonitorElement*> PositionOfClusters_2SLadder {77, nullptr};
+    std::vector<MonitorElement*> PositionOfClusters_2S{77, nullptr};
+    std::vector<MonitorElement*> PositionOfClusters_2SLadder{77, nullptr};
   };
   MonitorElement* numberClusters_;
   MonitorElement* globalXY_P_;
@@ -176,21 +176,22 @@ void Phase2OTMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventS
           local_mes.XYGlobalPositionMap_S->Fill(gx, gy);
       }
       if (mType == TrackerGeometry::ModuleType::Ph2SS) {
-	int module = tTopo_->module(rawid);
-	//If column is on the bottom of the sensor, *-1 to distinguish it from top
-        int topOrBottomColumn = (tTopo_->isLower(rawid) ? (clusterItr.column()+1)*-1 : (clusterItr.column()+1));
-	if (local_mes.PositionOfClusters_2S[module] != nullptr) {
-		for (int width = 0; width < clusterItr.size(); width++) {
-			local_mes.PositionOfClusters_2S[module]->Fill(clusterItr.firstStrip()+width, topOrBottomColumn);
-		}
-	}
-	if (tTopo_->getOTLayerNumber(rawid) < 100) {
-		if (local_mes.PositionOfClusters_2SLadder[module] != nullptr) {
-			unsigned int ladder = tTopo_->tobRod(rawid);
-			//Change the module nums from 1 - 24 to -12 - 12 so that ladder 'before' the collision point is negative
-			local_mes.PositionOfClusters_2SLadder[ladder]->Fill((module < 13 ? module-13 : module-12), topOrBottomColumn);
-		}
-	}
+        int module = tTopo_->module(rawid);
+        //If column is on the bottom of the sensor, *-1 to distinguish it from top
+        int topOrBottomColumn = (tTopo_->isLower(rawid) ? (clusterItr.column() + 1) * -1 : (clusterItr.column() + 1));
+        if (local_mes.PositionOfClusters_2S[module] != nullptr) {
+          for (int width = 0; width < clusterItr.size(); width++) {
+            local_mes.PositionOfClusters_2S[module]->Fill(clusterItr.firstStrip() + width, topOrBottomColumn);
+          }
+        }
+        if (tTopo_->getOTLayerNumber(rawid) < 100) {
+          if (local_mes.PositionOfClusters_2SLadder[module] != nullptr) {
+            unsigned int ladder = tTopo_->tobRod(rawid);
+            //Change the module nums from 1 - 24 to -12 - 12 so that ladder 'before' the collision point is negative
+            local_mes.PositionOfClusters_2SLadder[ladder]->Fill((module < 13 ? module - 13 : module - 12),
+                                                                topOrBottomColumn);
+          }
+        }
       }
     }
   }
@@ -271,89 +272,107 @@ void Phase2OTMonitorCluster::bookLayerHistos(DQMStore::IBooker& ibooker, uint32_
           phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("LocalPositionXY_P"), ibooker);
     }
     if (mType == TrackerGeometry::ModuleType::Ph2SS) {
-	    //Book the right number of histograms per layer
-	    int nModules = 0;
-	    int nLadders = 0;
+      //Book the right number of histograms per layer
+      int nModules = 0;
+      int nLadders = 0;
 
-	    if (tTopo_->getOTLayerNumber(det_id) > 100) {
-		    if (tTopo_->tidWheel(det_id) < 3) {
-			    //TEDD 1
-			    switch (tTopo_->tidRing(det_id)) {
-				    case 11: nModules = 52;
-					     break;
-				    case 12: nModules = 60;
-					     break;
-				    case 13: nModules = 64;
-					     break;
-				    case 14: nModules = 72;
-					     break;
-				    case 15: nModules = 76;
-					     break;
-				    default: nModules = 76;
-			    }
-		    } else {
-			    //TEDD 2
-			    switch (tTopo_->tidRing(det_id)) {
-				    case 8: nModules = 52;
-					    break;
-				    case 9: nModules = 56;
-					    break;
-				    case 10: nModules = 64;
-					     break;
-				    case 11: nModules = 68;
-					     break;
-				    case 12: nModules = 76;
-					     break;
-				    default: nModules = 76;
-			    }
-		    }
-	    } else {
-		    nModules = 24;
-	    }
-	    switch (tTopo_->getOTLayerNumber(det_id)) {
-		    case 4: nLadders = 48;
-			    break;
-		    case 5: nLadders = 60;
-			    break;
-		    case 6: nLadders = 76;
-			    break;
-		    default: nLadders = 0;
-	    }
+      if (tTopo_->getOTLayerNumber(det_id) > 100) {
+        if (tTopo_->tidWheel(det_id) < 3) {
+          //TEDD 1
+          switch (tTopo_->tidRing(det_id)) {
+            case 11:
+              nModules = 52;
+              break;
+            case 12:
+              nModules = 60;
+              break;
+            case 13:
+              nModules = 64;
+              break;
+            case 14:
+              nModules = 72;
+              break;
+            case 15:
+              nModules = 76;
+              break;
+            default:
+              nModules = 76;
+          }
+        } else {
+          //TEDD 2
+          switch (tTopo_->tidRing(det_id)) {
+            case 8:
+              nModules = 52;
+              break;
+            case 9:
+              nModules = 56;
+              break;
+            case 10:
+              nModules = 64;
+              break;
+            case 11:
+              nModules = 68;
+              break;
+            case 12:
+              nModules = 76;
+              break;
+            default:
+              nModules = 76;
+          }
+        }
+      } else {
+        nModules = 24;
+      }
+      switch (tTopo_->getOTLayerNumber(det_id)) {
+        case 4:
+          nLadders = 48;
+          break;
+        case 5:
+          nLadders = 60;
+          break;
+        case 6:
+          nLadders = 76;
+          break;
+        default:
+          nLadders = 0;
+      }
 
-	    //Book the histograms
-	    std::ostringstream HistoName;
-	    std::ostringstream HistoTitle;
+      //Book the histograms
+      std::ostringstream HistoName;
+      std::ostringstream HistoTitle;
 
-	    for (int moduleNum = 1; moduleNum <= nModules; moduleNum++) {
-		    HistoName.str("PositionOfClusters_2S_" + std::to_string(moduleNum));
-		    HistoTitle.str("PositionOfClusters_2S_" + std::to_string(moduleNum) + ";strip ;half-module ;");
-		    local_mes.PositionOfClusters_2S[moduleNum] = ibooker.book2D(HistoName.str(),
-				    HistoTitle.str(),
-				    config_.getParameter<edm::ParameterSet>("PositionOfClusters_2S").getParameter<int32_t>("NxBins"),
-				    config_.getParameter<edm::ParameterSet>("PositionOfClusters_2S").getParameter<double>("xmin"),
-				    config_.getParameter<edm::ParameterSet>("PositionOfClusters_2S").getParameter<double>("xmax"),
-				    config_.getParameter<edm::ParameterSet>("PositionOfClusters_2S").getParameter<int32_t>("NyBins"),
-				    config_.getParameter<edm::ParameterSet>("PositionOfClusters_2S").getParameter<double>("ymin"),
-				    config_.getParameter<edm::ParameterSet>("PositionOfClusters_2S").getParameter<double>("ymax"));
-		    local_mes.PositionOfClusters_2S[moduleNum]->getTH2F()->SetStats(0); //Remove stats box so you can see the whole module
-		    local_mes.PositionOfClusters_2S[moduleNum]->setOption("z");
-
-	    }
-	    for (int ladderNum = 1; ladderNum <= nLadders; ladderNum++) {
-                    HistoName.str("PositionOfClusters_2SLadder_" + std::to_string(ladderNum));
-                    HistoTitle.str("PositionOfClusters_2SLadder_" + std::to_string(ladderNum) + ";module ;half-module ;");
-                    local_mes.PositionOfClusters_2SLadder[ladderNum] = ibooker.book2D(HistoName.str(),
-                                    HistoTitle.str(),
-                                    config_.getParameter<edm::ParameterSet>("PositionOfClusters_2SLadder").getParameter<int32_t>("NxBins"),
-                                    config_.getParameter<edm::ParameterSet>("PositionOfClusters_2SLadder").getParameter<double>("xmin"),
-                                    config_.getParameter<edm::ParameterSet>("PositionOfClusters_2SLadder").getParameter<double>("xmax"),
-                                    config_.getParameter<edm::ParameterSet>("PositionOfClusters_2SLadder").getParameter<int32_t>("NyBins"),
-                                    config_.getParameter<edm::ParameterSet>("PositionOfClusters_2SLadder").getParameter<double>("ymin"),
-                                    config_.getParameter<edm::ParameterSet>("PositionOfClusters_2SLadder").getParameter<double>("ymax"));
-		    local_mes.PositionOfClusters_2SLadder[ladderNum]->getTH2F()->SetStats(0); //Remove stats box so you can see whole ladder
-		    local_mes.PositionOfClusters_2SLadder[ladderNum]->setOption("z");
-
-            }
+      for (int moduleNum = 1; moduleNum <= nModules; moduleNum++) {
+        HistoName.str("PositionOfClusters_2S_" + std::to_string(moduleNum));
+        HistoTitle.str("PositionOfClusters_2S_" + std::to_string(moduleNum) + ";strip ;half-module ;");
+        local_mes.PositionOfClusters_2S[moduleNum] = ibooker.book2D(
+            HistoName.str(),
+            HistoTitle.str(),
+            config_.getParameter<edm::ParameterSet>("PositionOfClusters_2S").getParameter<int32_t>("NxBins"),
+            config_.getParameter<edm::ParameterSet>("PositionOfClusters_2S").getParameter<double>("xmin"),
+            config_.getParameter<edm::ParameterSet>("PositionOfClusters_2S").getParameter<double>("xmax"),
+            config_.getParameter<edm::ParameterSet>("PositionOfClusters_2S").getParameter<int32_t>("NyBins"),
+            config_.getParameter<edm::ParameterSet>("PositionOfClusters_2S").getParameter<double>("ymin"),
+            config_.getParameter<edm::ParameterSet>("PositionOfClusters_2S").getParameter<double>("ymax"));
+        local_mes.PositionOfClusters_2S[moduleNum]->getTH2F()->SetStats(
+            false);  //Remove stats box so you can see the whole module
+        local_mes.PositionOfClusters_2S[moduleNum]->setOption("z");
+      }
+      for (int ladderNum = 1; ladderNum <= nLadders; ladderNum++) {
+        HistoName.str("PositionOfClusters_2SLadder_" + std::to_string(ladderNum));
+        HistoTitle.str("PositionOfClusters_2SLadder_" + std::to_string(ladderNum) + ";module ;half-module ;");
+        local_mes.PositionOfClusters_2SLadder[ladderNum] = ibooker.book2D(
+            HistoName.str(),
+            HistoTitle.str(),
+            config_.getParameter<edm::ParameterSet>("PositionOfClusters_2SLadder").getParameter<int32_t>("NxBins"),
+            config_.getParameter<edm::ParameterSet>("PositionOfClusters_2SLadder").getParameter<double>("xmin"),
+            config_.getParameter<edm::ParameterSet>("PositionOfClusters_2SLadder").getParameter<double>("xmax"),
+            config_.getParameter<edm::ParameterSet>("PositionOfClusters_2SLadder").getParameter<int32_t>("NyBins"),
+            config_.getParameter<edm::ParameterSet>("PositionOfClusters_2SLadder").getParameter<double>("ymin"),
+            config_.getParameter<edm::ParameterSet>("PositionOfClusters_2SLadder").getParameter<double>("ymax"));
+        local_mes.PositionOfClusters_2SLadder[ladderNum]->getTH2F()->SetStats(
+            false);  //Remove stats box so you can see whole ladder
+        local_mes.PositionOfClusters_2SLadder[ladderNum]->setOption("z");
+      }
     }
 
     local_mes.nClusters_S =
@@ -532,30 +551,30 @@ void Phase2OTMonitorCluster::fillDescriptions(edm::ConfigurationDescriptions& de
     desc.add<edm::ParameterSetDescription>("LocalPositionXY_S", psd0);
   }
   {
-	  edm::ParameterSetDescription psd0;
-	psd0.add<std::string>("name", "PositionOfClusters_2S");
-      psd0.add<std::string>("title", "PositionsOfClusters_2S;strip ;half-sensor	;");
-      psd0.add<int>("NxBins", 1016);
-      psd0.add<double>("xmin", 0.5);
-      psd0.add<double>("xmax", 1016.5);
-      psd0.add<int>("NyBins", 5);
-      psd0.add<double>("ymin", -2.5);
-      psd0.add<double>("ymax", 2.5);
-      psd0.add<bool>("switch", true);
-      desc.add<edm::ParameterSetDescription>("PositionOfClusters_2S", psd0);
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "PositionOfClusters_2S");
+    psd0.add<std::string>("title", "PositionsOfClusters_2S;strip ;half-sensor	;");
+    psd0.add<int>("NxBins", 1016);
+    psd0.add<double>("xmin", 0.5);
+    psd0.add<double>("xmax", 1016.5);
+    psd0.add<int>("NyBins", 5);
+    psd0.add<double>("ymin", -2.5);
+    psd0.add<double>("ymax", 2.5);
+    psd0.add<bool>("switch", true);
+    desc.add<edm::ParameterSetDescription>("PositionOfClusters_2S", psd0);
   }
   {
-          edm::ParameterSetDescription psd0;
-        psd0.add<std::string>("name", "PositionOfClusters_2SLadder");
-      psd0.add<std::string>("title", "PositionsOfClusters_Ladder;module ;half-sensor ;");
-      psd0.add<int>("NxBins", 25);
-      psd0.add<double>("xmin", -12.5);
-      psd0.add<double>("xmax", 12.5);
-      psd0.add<int>("NyBins", 5);
-      psd0.add<double>("ymin", -2.5);
-      psd0.add<double>("ymax", 2.5);
-      psd0.add<bool>("switch", true);
-      desc.add<edm::ParameterSetDescription>("PositionOfClusters_2SLadder", psd0);
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "PositionOfClusters_2SLadder");
+    psd0.add<std::string>("title", "PositionsOfClusters_Ladder;module ;half-sensor ;");
+    psd0.add<int>("NxBins", 25);
+    psd0.add<double>("xmin", -12.5);
+    psd0.add<double>("xmax", 12.5);
+    psd0.add<int>("NyBins", 5);
+    psd0.add<double>("ymin", -2.5);
+    psd0.add<double>("ymax", 2.5);
+    psd0.add<bool>("switch", true);
+    desc.add<edm::ParameterSetDescription>("PositionOfClusters_2SLadder", psd0);
   }
 
   desc.add<std::string>("TopFolderName", "TrackerPhase2OTCluster");

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
@@ -273,75 +273,28 @@ void Phase2OTMonitorCluster::bookLayerHistos(DQMStore::IBooker& ibooker, uint32_
     }
     if (mType == TrackerGeometry::ModuleType::Ph2SS) {
       //Book the right number of histograms per layer
-      int nModules = 0;
-      int nLadders = 0;
+      unsigned int nModules = 0;
+      unsigned int nLadders = 0;
 
-      if (tTopo_->getOTLayerNumber(det_id) > 100) {
-        if (tTopo_->tidWheel(det_id) < 3) {
-          //TEDD 1
-          switch (tTopo_->tidRing(det_id)) {
-            case 11:
-              nModules = 52;
-              break;
-            case 12:
-              nModules = 60;
-              break;
-            case 13:
-              nModules = 64;
-              break;
-            case 14:
-              nModules = 72;
-              break;
-            case 15:
-              nModules = 76;
-              break;
-            default:
-              nModules = 76;
-          }
-        } else {
-          //TEDD 2
-          switch (tTopo_->tidRing(det_id)) {
-            case 8:
-              nModules = 52;
-              break;
-            case 9:
-              nModules = 56;
-              break;
-            case 10:
-              nModules = 64;
-              break;
-            case 11:
-              nModules = 68;
-              break;
-            case 12:
-              nModules = 76;
-              break;
-            default:
-              nModules = 76;
+      TrackerGeometry::DetIdContainer theDetIds = tkGeom_->detIds();
+      for (auto detid : theDetIds) {
+        if (tkGeom_->getDetectorType(detid) == TrackerGeometry::ModuleType::Ph2SS &&
+            tTopo_->getOTLayerNumber(det_id) == tTopo_->getOTLayerNumber(detid)) {
+          if ((tTopo_->getOTLayerNumber(detid) < 100) ||
+              (tTopo_->getOTLayerNumber(detid) > 100 && tTopo_->tidRing(det_id) == tTopo_->tidRing(detid))) {
+            nModules = (tTopo_->module(detid) > nModules) ? tTopo_->module(detid) : nModules;
+            nLadders = ((tTopo_->getOTLayerNumber(detid) < 100) && (tTopo_->tobRod(detid) > nLadders))
+                           ? tTopo_->tobRod(detid)
+                           : nLadders;
           }
         }
-      } else {
-        nModules = 24;
-      }
-      switch (tTopo_->getOTLayerNumber(det_id)) {
-        case 4:
-          nLadders = 48;
-          break;
-        case 5:
-          nLadders = 60;
-          break;
-        case 6:
-          nLadders = 76;
-          break;
-        default:
-          nLadders = 0;
       }
 
       //Book the histograms
       std::ostringstream HistoName;
       std::ostringstream HistoTitle;
 
-      for (int moduleNum = 1; moduleNum <= nModules; moduleNum++) {
+      for (unsigned int moduleNum = 1; moduleNum <= nModules; moduleNum++) {
         HistoName.str("PositionOfClusters_2S_" + std::to_string(moduleNum));
         HistoTitle.str("PositionOfClusters_2S_" + std::to_string(moduleNum) + ";strip ;half-module ;");
         local_mes.PositionOfClusters_2S[moduleNum] = ibooker.book2D(
@@ -357,7 +310,7 @@ void Phase2OTMonitorCluster::bookLayerHistos(DQMStore::IBooker& ibooker, uint32_
             false);  //Remove stats box so you can see the whole module
         local_mes.PositionOfClusters_2S[moduleNum]->setOption("z");
       }
-      for (int ladderNum = 1; ladderNum <= nLadders; ladderNum++) {
+      for (unsigned int ladderNum = 1; ladderNum <= nLadders; ladderNum++) {
         HistoName.str("PositionOfClusters_2SLadder_" + std::to_string(ladderNum));
         HistoTitle.str("PositionOfClusters_2SLadder_" + std::to_string(ladderNum) + ";module ;half-module ;");
         local_mes.PositionOfClusters_2SLadder[ladderNum] = ibooker.book2D(


### PR DESCRIPTION
#### PR description:

Adds 2 types of histogram to SiTrackerPhase2 OT Clusters: 
**PositionOfClusters_2S** shows _all strips_ that constitute clusters in 2S modules. Each module number has its own histogram named as PositionOfClusters_2S_<module number>. This creates 24 histograms in barrel layers 4-6 and the following amount in the endcaps:

TEDD 1
Ring 11: 52
Ring 12: 60
Ring 13: 64
Ring 14: 72
Ring 15: 76

TEDD 2
Ring 8: 52 
Ring 9: 56 
Ring 10: 64
Ring 11: 68
Ring 12: 76

<img width="1401" height="835" alt="image" src="https://github.com/user-attachments/assets/2e73330f-df6e-404b-bcec-18b7fc516a38" />

Positive y bins are on the top sensor of the module, with negative y bins on the bottom. 1 or 2 indicates the half-sensor. It is possible to view the whole 2S module on one plot.

**PositionOfClusters_2SLadder** shows the total number of clusters in each module in a ladder. Similarly to the module view it produces different number of histograms per layer:
Layer 4: 48 ladders
Layer 5: 60 ladders
Layer 6: 76 ladders

This histogram shows modules before the collision point with a negative value and after the collision point with a positive value. Technically, it displays 2 ladders per plot as the - and + ladders are not the same structure.
<img width="1401" height="835" alt="image" src="https://github.com/user-attachments/assets/ce29ebf5-f3cb-452c-878f-431b184732c4" />

These histograms are proposed to show data primarily from the cosmic rack.

PR was validated by running the Phase-2 tracker DQM and checking the ROOT result