### PR TITLE
[DQM-L1] [LLVM21] Apply clang-tidy changes

### DIFF
--- a/DQMOffline/L1Trigger/src/L1TCommon.cc
+++ b/DQMOffline/L1Trigger/src/L1TCommon.cc
@@ -74,7 +74,7 @@ namespace dqmoffline {
 
     trigger::TriggerObjectCollection getTriggerObjects(const std::vector<edm::InputTag> &hltFilters,
                                                        const trigger::TriggerEvent &triggerEvent) {
-      trigger::TriggerObjectCollection triggerObjects = triggerEvent.getObjects();
+      const trigger::TriggerObjectCollection &triggerObjects = triggerEvent.getObjects();
       trigger::TriggerObjectCollection results;
 
       for (const auto &filter : hltFilters) {

--- a/DQMOffline/L1Trigger/src/L1TTauOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TTauOffline.cc
@@ -143,7 +143,7 @@ void L1TTauOffline::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
   bookTauHistos(ibooker);
 
   for (auto trigNamesIt = triggerPath_.begin(); trigNamesIt != triggerPath_.end(); trigNamesIt++) {
-    std::string tNameTmp = (*trigNamesIt);
+    const std::string& tNameTmp = (*trigNamesIt);
     std::string tNamePattern = "";
     std::size_t found0 = tNameTmp.find('*');
     if (found0 != std::string::npos)


### PR DESCRIPTION
This PR suggests to apply the `clang-tidy` changes proposed by LLVM21 ( from CLANG_X IB). 