### PR TITLE
[SIMULATION] [LLVM21] Apply clang-tidy changes

### DIFF
--- a/DataFormats/ForwardDetId/src/HFNoseTriggerDetId.cc
+++ b/DataFormats/ForwardDetId/src/HFNoseTriggerDetId.cc
@@ -132,6 +132,7 @@ std::vector<std::pair<int, int> > HFNoseTriggerDetId::cellUV() const {
   std::vector<int> uc = cellU();
   std::vector<int> vc = cellV();
   std::vector<std::pair<int, int> > uv;
+  uv.reserve(uc.size());
   for (unsigned int k = 0; k < uc.size(); ++k) {
     uv.emplace_back(uc[k], vc[k]);
   }

--- a/DataFormats/ForwardDetId/src/HGCalTriggerDetId.cc
+++ b/DataFormats/ForwardDetId/src/HGCalTriggerDetId.cc
@@ -139,6 +139,7 @@ std::vector<std::pair<int, int> > HGCalTriggerDetId::cellUV() const {
   std::vector<int> uc = cellU();
   std::vector<int> vc = cellV();
   std::vector<std::pair<int, int> > uv;
+  uv.reserve(uc.size());
   for (unsigned int k = 0; k < uc.size(); ++k) {
     uv.emplace_back(std::pair<int, int>(uc[k], vc[k]));
   }

--- a/SimCalorimetry/HGCalSimAlgos/src/HGCalECONDEmulatorParameters.cc
+++ b/SimCalorimetry/HGCalSimAlgos/src/HGCalECONDEmulatorParameters.cc
@@ -41,6 +41,7 @@ edm::ParameterSetDescription EmulatorParameters::description() {
   {  // list the enabled eRxs in all ECON-Ds
     const unsigned int max_erxs_per_econd = 12;
     std::vector<unsigned int> default_enabled_erxs;
+    default_enabled_erxs.reserve(max_erxs_per_econd);
     for (size_t i = 0; i < max_erxs_per_econd; ++i)
       default_enabled_erxs.emplace_back(i);
     desc.add<std::vector<unsigned int> >("enabledERxs", default_enabled_erxs)

--- a/SimG4Core/CustomPhysics/src/CustomProcessHelper.cc
+++ b/SimG4Core/CustomPhysics/src/CustomProcessHelper.cc
@@ -70,7 +70,7 @@ CustomProcessHelper::CustomProcessHelper(const edm::ParameterSet& p, CustomParti
     // Making a ReactionProduct
     ReactionProduct prod;
     for (std::size_t i = 2; i != tokens.size(); i++) {
-      G4String part = tokens[i];
+      const G4String& part = tokens[i];
       if (particleTable->contains(part)) {
         prod.push_back(particleTable->FindParticle(part)->GetPDGEncoding());
       } else {

--- a/SimG4Core/CustomPhysics/src/HadronicProcessHelper.cc
+++ b/SimG4Core/CustomPhysics/src/HadronicProcessHelper.cc
@@ -40,7 +40,7 @@ HadronicProcessHelper::HadronicProcessHelper(const std::string& fileName) {
     // Making a ReactionProduct
     ReactionProduct prod;
     for (size_t i = 2; i != tokens.size(); i++) {
-      G4String part = tokens[i];
+      const G4String& part = tokens[i];
       if (m_particleTable->contains(part)) {
         prod.push_back(m_particleTable->FindParticle(part)->GetPDGEncoding());
       } else {

--- a/SimG4Core/Geometry/src/DDG4Builder.cc
+++ b/SimG4Core/Geometry/src/DDG4Builder.cc
@@ -198,7 +198,7 @@ int DDG4Builder::getInt(const std::string &ss, const DDLogicalPart &part) {
       break;
   }
   if (foundIt) {
-    std::vector<double> temp = val.doubles();
+    const std::vector<double> &temp = val.doubles();
     if (temp.size() != 1) {
       throw cms::Exception("SimG4CoreGeometry",
                            " DDG4Builder::getInt() Problem with Region tags - "
@@ -220,7 +220,7 @@ double DDG4Builder::getDouble(const std::string &ss, const DDLogicalPart &part) 
       break;
   }
   if (foundIt) {
-    std::vector<std::string> temp = val.strings();
+    const std::vector<std::string> &temp = val.strings();
     if (temp.size() != 1) {
       throw cms::Exception("SimG4CoreGeometry",
                            " DDG4Builder::getDouble() Problem with Region tags "

--- a/SimG4Core/Geometry/src/DDG4SolidConverter.cc
+++ b/SimG4Core/Geometry/src/DDG4SolidConverter.cc
@@ -249,8 +249,10 @@ G4VSolid *DDG4SolidConverter::extrudedpolygon(const DDSolid &solid) {
 
   std::vector<G4TwoVector> polygon;
   std::vector<G4ExtrudedSolid::ZSection> zsections;
+  polygon.reserve(x.size());
   for (unsigned int it = 0; it < x.size(); ++it)
     polygon.emplace_back(x[it], y[it]);
+  zsections.reserve(z.size());
   for (unsigned int it = 0; it < z.size(); ++it)
     zsections.emplace_back(z[it], G4TwoVector(zx[it], zy[it]), zs[it]);
   return new G4ExtrudedSolid(solid.name().name(), polygon, zsections);

--- a/SimG4Core/Notification/src/TrackWithHistory.cc
+++ b/SimG4Core/Notification/src/TrackWithHistory.cc
@@ -21,7 +21,7 @@ TrackWithHistory::TrackWithHistory(const G4Track* g4trk, int pID) {
   auto mom = g4trk->GetMomentum();
   momentum_ = math::XYZVectorD(mom.x(), mom.y(), mom.z());
   totalEnergy_ = g4trk->GetTotalEnergy();
-  auto pos = g4trk->GetPosition();
+  const auto& pos = g4trk->GetPosition();
   vertexPosition_ = math::XYZVectorD(pos.x(), pos.y(), pos.z());
   time_ = g4trk->GetGlobalTime();
   auto p = g4trk->GetCreatorProcess();

--- a/SimG4Core/PhysicsLists/src/MonopoleTransportation.cc
+++ b/SimG4Core/PhysicsLists/src/MonopoleTransportation.cc
@@ -124,7 +124,7 @@ G4double MonopoleTransportation::AlongStepGetPhysicalInteractionLength(const G4T
   //
   const G4DynamicParticle* pParticle = track.GetDynamicParticle();
   const G4ThreeVector& startMomentumDir = pParticle->GetMomentumDirection();
-  G4ThreeVector startPosition = track.GetPosition();
+  const G4ThreeVector& startPosition = track.GetPosition();
 
   // The Step Point safety can be limited by other geometries and/or the
   // assumptions of any process - it's not always the geometrical safety.
@@ -233,7 +233,7 @@ G4double MonopoleTransportation::AlongStepGetPhysicalInteractionLength(const G4T
                                             restMass);
     // SetChargeMomentumMass now passes both the electric and magnetic charge - in chargeState
 
-    G4ThreeVector spin = track.GetPolarization();
+    const G4ThreeVector& spin = track.GetPolarization();
     G4FieldTrack aFieldTrack = G4FieldTrack(startPosition,
                                             track.GetMomentumDirection(),
                                             0.0,

--- a/SimGeneral/MixingModule/plugins/HiMixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/HiMixingModule.cc
@@ -187,7 +187,7 @@ namespace edm {
 
       std::string signal;
       for (size_t itag = 0; itag < tags.size(); ++itag) {
-        InputTag tag = tags[itag];
+        const InputTag& tag = tags[itag];
         std::vector<InputTag> inputs;
 
         for (size_t input = 0; input < simtags.size(); ++input) {


### PR DESCRIPTION
This PR suggests to apply the `clang-tidy` changes proposed by LLVM21 ( from CLANG_X IB). 