### PR TITLE
[ML] [LLVM21] Apply clang-tidy changes

### DIFF
--- a/PhysicsTools/MVAComputer/src/ProcSort.cc
+++ b/PhysicsTools/MVAComputer/src/ProcSort.cc
@@ -116,6 +116,7 @@ namespace {  // anonymous
     LeaderLookup lookup(leaderIter.begin());
 
     std::vector<int> sort;
+    sort.reserve(size);
     for (unsigned int i = 0; i < size; i++)
       sort.push_back((int)i);
 


### PR DESCRIPTION
This PR suggests to apply the `clang-tidy` changes proposed by LLVM21 ( from CLANG_X IB). 