### PR TITLE
[DQM-GENERATORS] [LLVM21] Apply clang-tidy changes

### DIFF
--- a/Validation/EventGenerator/plugins/BPhysicsValidation.cc
+++ b/Validation/EventGenerator/plugins/BPhysicsValidation.cc
@@ -18,7 +18,7 @@ BPhysicsValidation::BPhysicsValidation(const edm::ParameterSet& iPSet)
   genparticleCollectionToken_ = consumes<reco::GenParticleCollection>(genparticleCollection_);
   std::vector<std::string> daughterNames = iPSet.getParameter<std::vector<std::string> >("daughters");
   for (unsigned int i = 0; i < daughterNames.size(); i++) {
-    std::string curSet = daughterNames[i];
+    const std::string& curSet = daughterNames[i];
     daughters.push_back(ParticleMonitor(name + curSet, iPSet.getUntrackedParameter<ParameterSet>(curSet)));
   }
 }

--- a/Validation/EventGenerator/plugins/GenWeightValidation.cc
+++ b/Validation/EventGenerator/plugins/GenWeightValidation.cc
@@ -154,7 +154,7 @@ void GenWeightValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   std::sort(leptons.begin(), leptons.end(), HepMCValidationHelper::sortByPtRef<reco::GenParticleRef>);
 
   if (!leptons.empty()) {
-    reco::GenParticleRef leadLep = leptons.at(0);
+    const reco::GenParticleRef& leadLep = leptons.at(0);
     fillTemplates(leadLepPtTemp_, leadLep->pt());
     fillTemplates(leadLepEtaTemp_, leadLep->eta());
   }

--- a/Validation/EventGenerator/plugins/LheWeightValidation.cc
+++ b/Validation/EventGenerator/plugins/LheWeightValidation.cc
@@ -198,7 +198,7 @@ void LheWeightValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   std::sort(leptons.begin(), leptons.end(), HepMCValidationHelper::sortByPtRef<reco::GenParticleRef>);
 
   if (!leptons.empty()) {
-    reco::GenParticleRef leadLep = leptons.at(0);
+    const reco::GenParticleRef& leadLep = leptons.at(0);
     fillTemplates(leadLepPtScaleVar_, leadLepPtPdfVar_, leadLepPtTemp_, leadLep->pt());
     fillTemplates(leadLepEtaScaleVar_, leadLepEtaPdfVar_, leadLepEtaTemp_, leadLep->eta());
   }


### PR DESCRIPTION
This PR suggests to apply the `clang-tidy` changes proposed by LLVM21 ( from CLANG_X IB). 