### PR TITLE
[XPOG] [LLVM21] Apply clang-tidy changes

### DIFF
--- a/PhysicsTools/BPHNano/plugins/KinVtxFitter.cc
+++ b/PhysicsTools/BPHNano/plugins/KinVtxFitter.cc
@@ -12,6 +12,7 @@ KinVtxFitter::KinVtxFitter(const std::vector<reco::TransientTrack> tracks,
     : n_particles_{masses.size()} {
   KinematicParticleFactoryFromTransientTrack factory;
   std::vector<RefCountedKinematicParticle> particles;
+  particles.reserve(tracks.size());
   for (size_t i = 0; i < tracks.size(); ++i) {
     particles.emplace_back(factory.particle(tracks.at(i), masses.at(i), kin_chi2_, kin_ndof_, sigmas[i]));
   }
@@ -48,6 +49,7 @@ KinVtxFitter::KinVtxFitter(const std::vector<reco::TransientTrack> tracks,
     : n_particles_{masses.size()} {
   KinematicParticleFactoryFromTransientTrack factory;
   std::vector<RefCountedKinematicParticle> particles;
+  particles.reserve(tracks.size());
   for (size_t i = 0; i < tracks.size(); ++i) {
     particles.emplace_back(factory.particle(tracks.at(i), masses.at(i), kin_chi2_, kin_ndof_, sigmas[i]));
   }

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -449,7 +449,7 @@ public:
     const std::vector<unsigned int>& scaleWeightIDs = weightChoice->scaleWeightIDs;
     const std::vector<unsigned int>& pdfWeightIDs = weightChoice->pdfWeightIDs;
 
-    auto weights = genProd.weights();
+    const auto& weights = genProd.weights();
     double w0 = (weights.size() > 1) ? weights.at(1) : 1.;
     double originalXWGTUP = (weights.size() > 1) ? weights.at(1) : 1.;
 


### PR DESCRIPTION
This PR suggests to apply the `clang-tidy` changes proposed by LLVM21 ( from CLANG_X IB). 