### PR TITLE
[VISUALIZATION] [LLVM21] Apply clang-tidy changes

### DIFF
--- a/Fireworks/Calo/src/FWECALCaloDataDetailViewBuilder.cc
+++ b/Fireworks/Calo/src/FWECALCaloDataDetailViewBuilder.cc
@@ -209,6 +209,7 @@ void FWECALCaloDataDetailViewBuilder::setColor(Color_t color, const std::vector<
 void FWECALCaloDataDetailViewBuilder::showSuperCluster(const reco::SuperCluster& cluster, Color_t color) {
   std::vector<DetId> clusterDetIds;
   const std::vector<std::pair<DetId, float> >& hitsAndFractions = cluster.hitsAndFractions();
+  clusterDetIds.reserve(hitsAndFractions.size());
   for (size_t j = 0; j < hitsAndFractions.size(); ++j) {
     clusterDetIds.push_back(hitsAndFractions[j].first);
   }

--- a/Fireworks/Calo/src/FWECALDetailViewBuilder.cc
+++ b/Fireworks/Calo/src/FWECALDetailViewBuilder.cc
@@ -146,6 +146,7 @@ void FWECALDetailViewBuilder::setColor(Color_t color, const std::vector<DetId> &
 void FWECALDetailViewBuilder::showSuperCluster(const reco::SuperCluster &cluster, Color_t color) {
   std::vector<DetId> clusterDetIds;
   const std::vector<std::pair<DetId, float> > &hitsAndFractions = cluster.hitsAndFractions();
+  clusterDetIds.reserve(hitsAndFractions.size());
   for (size_t j = 0; j < hitsAndFractions.size(); ++j) {
     clusterDetIds.push_back(hitsAndFractions[j].first);
   }

--- a/Fireworks/ParticleFlow/plugins/FWPFCandidateWithHitsProxyBuilder.cc
+++ b/Fireworks/ParticleFlow/plugins/FWPFCandidateWithHitsProxyBuilder.cc
@@ -217,7 +217,7 @@ namespace {
 void FWPFCandidateWithHitsProxyBuilder::addHitsForCandidate(const reco::PFCandidate& cand,
                                                             TEveElement* holder,
                                                             const FWViewContext* vc) {
-  reco::PFCandidate::ElementsInBlocks eleInBlocks = cand.elementsInBlocks();
+  const reco::PFCandidate::ElementsInBlocks& eleInBlocks = cand.elementsInBlocks();
 
   TEveBoxSet* boxset = nullptr;
   TEveStraightLineSet* lineset = nullptr;

--- a/Fireworks/Vertices/plugins/FWSecVertexCandidateProxyBuilder.cc
+++ b/Fireworks/Vertices/plugins/FWSecVertexCandidateProxyBuilder.cc
@@ -73,7 +73,7 @@ void FWSecVertexCandidateProxyBuilder::build(const reco::CandSecondaryVertexTagI
       for (int j = 0; j < 3; j++) {
         t(i + 1, j + 1) = mm(i, j);
       }
-    TVectorD vv(eig.GetEigenValuesRe());
+    const TVectorD& vv(eig.GetEigenValuesRe());
     t.Scale(sqrt(vv(0)) * 1000., sqrt(vv(1)) * 1000., sqrt(vv(2)) * 1000.);
     t.SetPos(v.vx(), v.vy(), v.vz());
 

--- a/Fireworks/Vertices/plugins/FWSecVertexProxyBuilder.cc
+++ b/Fireworks/Vertices/plugins/FWSecVertexProxyBuilder.cc
@@ -71,7 +71,7 @@ void FWSecVertexProxyBuilder::build(const reco::SecondaryVertexTagInfo& iData,
       for (int j = 0; j < 3; j++) {
         t(i + 1, j + 1) = mm(i, j);
       }
-    TVectorD vv(eig.GetEigenValuesRe());
+    const TVectorD& vv(eig.GetEigenValuesRe());
     t.Scale(sqrt(vv(0)) * 1000., sqrt(vv(1)) * 1000., sqrt(vv(2)) * 1000.);
     t.SetPos(v.x(), v.y(), v.z());
 

--- a/Fireworks/Vertices/plugins/FWVertexCandidateProxyBuilder.cc
+++ b/Fireworks/Vertices/plugins/FWVertexCandidateProxyBuilder.cc
@@ -108,7 +108,7 @@ void FWVertexCandidateProxyBuilder::build(const reco::VertexCompositePtrCandidat
 
     // cache 3D extend used in eval bbox and render 3D
     TMatrixDEigen eig(m);
-    TVectorD vv(eig.GetEigenValuesRe());
+    const TVectorD& vv(eig.GetEigenValuesRe());
     eveEllipsoid->RefExtent3D().Set(sqrt(vv(0)) * ellipseScale, sqrt(vv(1)) * ellipseScale, sqrt(vv(2)) * ellipseScale);
 
     eveEllipsoid->SetLineWidth(2);

--- a/Fireworks/Vertices/plugins/FWVertexProxyBuilder.cc
+++ b/Fireworks/Vertices/plugins/FWVertexProxyBuilder.cc
@@ -106,7 +106,7 @@ void FWVertexProxyBuilder::build(const reco::Vertex& iData,
 
     // cache 3D extend used in eval bbox and render 3D
     TMatrixDEigen eig(m);
-    TVectorD vv(eig.GetEigenValuesRe());
+    const TVectorD& vv(eig.GetEigenValuesRe());
     eveEllipsoid->RefExtent3D().Set(sqrt(vv(0)) * ellipseScale, sqrt(vv(1)) * ellipseScale, sqrt(vv(2)) * ellipseScale);
 
     eveEllipsoid->SetLineWidth(2);

--- a/Fireworks/Vertices/src/TEveEllipsoidGL.cc
+++ b/Fireworks/Vertices/src/TEveEllipsoidGL.cc
@@ -174,7 +174,7 @@ void TEveEllipsoidProjectedGL::DrawRhoPhi() const {
     }
 
   TMatrixDEigen eig(xxx);
-  TVectorD xxxEig(eig.GetEigenValuesRe());
+  const TVectorD& xxxEig(eig.GetEigenValuesRe());
 
   // Projection supports only floats  :(
   TEveVector v0(fE->RefPos()[0], fE->RefPos()[1], 0);
@@ -233,7 +233,7 @@ void TEveEllipsoidProjectedGL::DrawRhoZ() const {
       xxx(i, j) = fE->RefEMtx()(i + 1, j + 1);
     }
   TMatrixDEigen eig(xxx);
-  TVectorD xxxEig(eig.GetEigenValuesRe());
+  const TVectorD& xxxEig(eig.GetEigenValuesRe());
 
   TEveVector v1(0, eig.GetEigenVectors()(1, 2), eig.GetEigenVectors()(2, 2));
   v1 *= fE->fEScale * sqrt(TMath::Abs(xxxEig[2]));


### PR DESCRIPTION
This PR suggests to apply the `clang-tidy` changes proposed by LLVM21 ( from CLANG_X IB). 