### PR TITLE
[GENERATORS] [LLVM21] Apply clang-tidy changes

### DIFF
--- a/GeneratorInterface/EvtGenInterface/plugins/EvtGen/EvtGenInterface.cc
+++ b/GeneratorInterface/EvtGenInterface/plugins/EvtGen/EvtGenInterface.cc
@@ -464,6 +464,7 @@ HepMC::GenEvent* EvtGenInterface::decay(HepMC::GenEvent* evt) {
   // decay all request unforced particles and store the forced decays to later decay one per event
   unsigned int nisforced = 0;
   std::vector<std::vector<HepMC::GenParticle*> > forcedparticles;
+  forcedparticles.reserve(forced_pdgids.size());
   for (unsigned int i = 0; i < forced_pdgids.size(); i++)
     forcedparticles.push_back(std::vector<HepMC::GenParticle*>());
 

--- a/GeneratorInterface/ExternalDecays/src/ConcurrentExternalDecayDriver.cc
+++ b/GeneratorInterface/ExternalDecays/src/ConcurrentExternalDecayDriver.cc
@@ -24,7 +24,7 @@ ConcurrentExternalDecayDriver::ConcurrentExternalDecayDriver(const ParameterSet&
   std::vector<std::string> extGenNames = pset.getParameter<std::vector<std::string> >("parameterSets");
 
   for (unsigned int ip = 0; ip < extGenNames.size(); ++ip) {
-    std::string curSet = extGenNames[ip];
+    const std::string& curSet = extGenNames[ip];
     throw cms::Exception("ThreadUnsafeDecayer") << "The decayer " << curSet << " is not thread-friendly.";
     /*
     if (curSet == "EvtGen") {

--- a/GeneratorInterface/ExternalDecays/src/ExternalDecayDriver.cc
+++ b/GeneratorInterface/ExternalDecays/src/ExternalDecayDriver.cc
@@ -26,7 +26,7 @@ ExternalDecayDriver::ExternalDecayDriver(const ParameterSet& pset, edm::Consumes
   std::vector<std::string> extGenNames = pset.getParameter<std::vector<std::string> >("parameterSets");
 
   for (unsigned int ip = 0; ip < extGenNames.size(); ++ip) {
-    std::string curSet = extGenNames[ip];
+    const std::string& curSet = extGenNames[ip];
     if (curSet == "EvtGen") {
       fEvtGenInterface = std::unique_ptr<EvtGenInterfaceBase>(
           EvtGenFactory::get()->create("EvtGen", pset.getUntrackedParameter<ParameterSet>(curSet)));

--- a/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.cc
+++ b/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.cc
@@ -26,7 +26,7 @@ bool BCToEFilterAlgo::filter(const edm::Event& iEvent) const {
   reco::GenParticleCollection genPars = *genParsHandle;
 
   for (uint32_t ig = 0; ig < genPars.size(); ig++) {
-    reco::GenParticle gp = genPars.at(ig);
+    const reco::GenParticle& gp = genPars.at(ig);
     if (gp.status() == 1 && std::abs(gp.pdgId()) == 11 && gp.et() > eTThreshold_ && std::fabs(gp.eta()) < maxAbsEta_) {
       if (hasBCAncestors(gp)) {
         result = true;

--- a/GeneratorInterface/GenFilters/plugins/MCParticlePairFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/MCParticlePairFilter.cc
@@ -53,6 +53,7 @@ MCParticlePairFilter::MCParticlePairFilter(const edm::ParameterSet& iConfig)
   // if ptMin size smaller than 2, fill up further with defaults
   if (2 > ptMin.size()) {
     vector<double> defptmin2;
+    defptmin2.reserve(2);
     for (unsigned int i = 0; i < 2; i++) {
       defptmin2.push_back(0.);
     }
@@ -61,6 +62,7 @@ MCParticlePairFilter::MCParticlePairFilter(const edm::ParameterSet& iConfig)
   // if pMin size smaller than 2, fill up further with defaults
   if (2 > pMin.size()) {
     vector<double> defpmin2;
+    defpmin2.reserve(2);
     for (unsigned int i = 0; i < 2; i++) {
       defpmin2.push_back(0.);
     }
@@ -69,6 +71,7 @@ MCParticlePairFilter::MCParticlePairFilter(const edm::ParameterSet& iConfig)
   // if etaMin size smaller than 2, fill up further with defaults
   if (2 > etaMin.size()) {
     vector<double> defetamin2;
+    defetamin2.reserve(2);
     for (unsigned int i = 0; i < 2; i++) {
       defetamin2.push_back(-10.);
     }
@@ -77,6 +80,7 @@ MCParticlePairFilter::MCParticlePairFilter(const edm::ParameterSet& iConfig)
   // if etaMax size smaller than 2, fill up further with defaults
   if (2 > etaMax.size()) {
     vector<double> defetamax2;
+    defetamax2.reserve(2);
     for (unsigned int i = 0; i < 2; i++) {
       defetamax2.push_back(10.);
     }
@@ -85,6 +89,7 @@ MCParticlePairFilter::MCParticlePairFilter(const edm::ParameterSet& iConfig)
   // if status size smaller than 2, fill up further with defaults
   if (2 > status.size()) {
     vector<int> defstat2;
+    defstat2.reserve(2);
     for (unsigned int i = 0; i < 2; i++) {
       defstat2.push_back(0);
     }

--- a/GeneratorInterface/GenFilters/plugins/MCProcessFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/MCProcessFilter.cc
@@ -66,6 +66,7 @@ MCProcessFilter::MCProcessFilter(const edm::ParameterSet& iConfig)
   // if pthatMin size smaller than processID , fill up further with defaults
   if (processID.size() > pthatMin.size()) {
     vector<double> defpthatmin2;
+    defpthatmin2.reserve(processID.size());
     for (unsigned int i = 0; i < processID.size(); i++) {
       defpthatmin2.push_back(0.);
     }
@@ -74,6 +75,7 @@ MCProcessFilter::MCProcessFilter(const edm::ParameterSet& iConfig)
   // if pthatMax size smaller than processID , fill up further with defaults
   if (processID.size() > pthatMax.size()) {
     vector<double> defpthatmax2;
+    defpthatmax2.reserve(processID.size());
     for (unsigned int i = 0; i < processID.size(); i++) {
       defpthatmax2.push_back(10000.);
     }

--- a/GeneratorInterface/GenFilters/plugins/MCSingleParticleFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/MCSingleParticleFilter.cc
@@ -42,6 +42,7 @@ MCSingleParticleFilter::MCSingleParticleFilter(const edm::ParameterSet& iConfig)
   // if ptMin size smaller than particleID , fill up further with defaults
   if (particleID.size() > ptMin.size()) {
     vector<double> defptmin2;
+    defptmin2.reserve(particleID.size());
     for (unsigned int i = 0; i < particleID.size(); i++) {
       defptmin2.push_back(0.);
     }
@@ -50,6 +51,7 @@ MCSingleParticleFilter::MCSingleParticleFilter(const edm::ParameterSet& iConfig)
   // if etaMin size smaller than particleID , fill up further with defaults
   if (particleID.size() > etaMin.size()) {
     vector<double> defetamin2;
+    defetamin2.reserve(particleID.size());
     for (unsigned int i = 0; i < particleID.size(); i++) {
       defetamin2.push_back(-10.);
     }
@@ -58,6 +60,7 @@ MCSingleParticleFilter::MCSingleParticleFilter(const edm::ParameterSet& iConfig)
   // if etaMax size smaller than particleID , fill up further with defaults
   if (particleID.size() > etaMax.size()) {
     vector<double> defetamax2;
+    defetamax2.reserve(particleID.size());
     for (unsigned int i = 0; i < particleID.size(); i++) {
       defetamax2.push_back(10.);
     }
@@ -66,6 +69,7 @@ MCSingleParticleFilter::MCSingleParticleFilter(const edm::ParameterSet& iConfig)
   // if status size smaller than particleID , fill up further with defaults
   if (particleID.size() > status.size()) {
     vector<int> defstat2;
+    defstat2.reserve(particleID.size());
     for (unsigned int i = 0; i < particleID.size(); i++) {
       defstat2.push_back(0);
     }

--- a/GeneratorInterface/GenFilters/plugins/MCSingleParticleYPt.cc
+++ b/GeneratorInterface/GenFilters/plugins/MCSingleParticleYPt.cc
@@ -86,6 +86,7 @@ MCSingleParticleYPt::MCSingleParticleYPt(const edm::ParameterSet& iConfig)
   // if ptMin size smaller than particleID , fill up further with defaults
   if (particleID.size() > ptMin.size()) {
     vector<double> defptmin2;
+    defptmin2.reserve(particleID.size());
     for (unsigned int i = 0; i < particleID.size(); i++) {
       defptmin2.push_back(0.);
     }
@@ -94,6 +95,7 @@ MCSingleParticleYPt::MCSingleParticleYPt(const edm::ParameterSet& iConfig)
   // if etaMin size smaller than particleID , fill up further with defaults
   if (particleID.size() > rapMin.size()) {
     vector<double> defrapmin2;
+    defrapmin2.reserve(particleID.size());
     for (unsigned int i = 0; i < particleID.size(); i++) {
       defrapmin2.push_back(-10.);
     }
@@ -102,6 +104,7 @@ MCSingleParticleYPt::MCSingleParticleYPt(const edm::ParameterSet& iConfig)
   // if etaMax size smaller than particleID , fill up further with defaults
   if (particleID.size() > rapMax.size()) {
     vector<double> defrapmax2;
+    defrapmax2.reserve(particleID.size());
     for (unsigned int i = 0; i < particleID.size(); i++) {
       defrapmax2.push_back(10.);
     }
@@ -110,6 +113,7 @@ MCSingleParticleYPt::MCSingleParticleYPt(const edm::ParameterSet& iConfig)
   // if status size smaller than particleID , fill up further with defaults
   if (particleID.size() > status.size()) {
     vector<int> defstat2;
+    defstat2.reserve(particleID.size());
     for (unsigned int i = 0; i < particleID.size(); i++) {
       defstat2.push_back(0);
     }

--- a/GeneratorInterface/LHEInterface/src/LHEEvent.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEEvent.cc
@@ -249,6 +249,7 @@ namespace lhef {
     std::vector<HepMC::GenVertex *> genVertices;
 
     // I. convert particles
+    genParticles.reserve(nup);
     for (unsigned int i = 0; i < nup; i++)
       genParticles.push_back(makeHepMCParticle(i));
 

--- a/GeneratorInterface/PartonShowerVeto/src/JetMatchingMadgraph.cc
+++ b/GeneratorInterface/PartonShowerVeto/src/JetMatchingMadgraph.cc
@@ -263,7 +263,7 @@ namespace gen {
       throw cms::Exception("Generator|PartonShowerVeto") << "Run not initialized in JetMatchingMadgraph" << std::endl;
 
     if (uppriv_.ickkw) {
-      std::vector<std::string> comments = event->getComments();
+      const std::vector<std::string> &comments = event->getComments();
       if (comments.size() == 1) {
         std::istringstream ss(comments[0].substr(1));
         for (int i = 0; i < 1000; i++) {

--- a/GeneratorInterface/PhotosInterface/plugins/PhotosppInterface.cc
+++ b/GeneratorInterface/PhotosInterface/plugins/PhotosppInterface.cc
@@ -27,7 +27,7 @@ PhotosppInterface::PhotosppInterface(const edm::ParameterSet& pset)
   fPSet = new ParameterSet(pset);
   std::vector<std::string> par = fPSet->getParameter<std::vector<std::string> >("parameterSets");
   for (unsigned int ip = 0; ip < par.size(); ++ip) {
-    std::string curSet = par[ip];
+    const std::string& curSet = par[ip];
     // Physics settings
     if (curSet == "UseHadronizerQEDBrem")
       UseHadronizerQEDBrem = true;
@@ -53,7 +53,7 @@ void PhotosppInterface::init() {
   Photospp::Photos::createHistoryEntries(true, 746);  // P-H-O
   std::vector<std::string> par = fPSet->getParameter<std::vector<std::string> >("parameterSets");
   for (unsigned int ip = 0; ip < par.size(); ++ip) {
-    std::string curSet = par[ip];
+    const std::string& curSet = par[ip];
 
     // Physics settings
     if (curSet == "maxWtInterference")
@@ -107,7 +107,7 @@ void PhotosppInterface::init() {
       edm::ParameterSet cfg = fPSet->getParameter<edm::ParameterSet>(curSet);
       std::vector<std::string> v = cfg.getParameter<std::vector<std::string> >("parameterSets");
       for (unsigned int i = 0; i < v.size(); i++) {
-        std::string vs = v[i];
+        const std::string& vs = v[i];
         std::vector<int> vpar = cfg.getParameter<std::vector<int> >(vs);
         if (vpar.size() == 1)
           Photospp::Photos::suppressBremForBranch(0, vpar[0]);
@@ -138,7 +138,7 @@ void PhotosppInterface::init() {
       edm::ParameterSet cfg = fPSet->getParameter<edm::ParameterSet>(curSet);
       std::vector<std::string> v = cfg.getParameter<std::vector<std::string> >("parameterSets");
       for (unsigned int i = 0; i < v.size(); i++) {
-        std::string vs = v[i];
+        const std::string& vs = v[i];
         std::vector<int> vpar = cfg.getParameter<std::vector<int> >(vs);
         if (vpar.size() == 1)
           Photospp::Photos::suppressBremForDecay(0, vpar[0]);
@@ -170,7 +170,7 @@ void PhotosppInterface::init() {
       edm::ParameterSet cfg = fPSet->getParameter<edm::ParameterSet>(curSet);
       std::vector<std::string> v = cfg.getParameter<std::vector<std::string> >("parameterSets");
       for (unsigned int i = 0; i < v.size(); i++) {
-        std::string vs = v[i];
+        const std::string& vs = v[i];
         std::vector<int> vpar = cfg.getParameter<std::vector<int> >(vs);
         if (vpar.size() == 1)
           Photospp::Photos::forceBremForBranch(0, vpar[0]);
@@ -200,7 +200,7 @@ void PhotosppInterface::init() {
       edm::ParameterSet cfg = fPSet->getParameter<edm::ParameterSet>(curSet);
       std::vector<std::string> v = cfg.getParameter<std::vector<std::string> >("parameterSets");
       for (unsigned int i = 0; i < v.size(); i++) {
-        std::string vs = v[i];
+        const std::string& vs = v[i];
         std::vector<int> vpar = cfg.getParameter<std::vector<int> >(vs);
         if (vpar.size() == 1)
           Photospp::Photos::forceBremForDecay(0, vpar[0]);
@@ -231,7 +231,7 @@ void PhotosppInterface::init() {
       edm::ParameterSet cfg = fPSet->getParameter<edm::ParameterSet>(curSet);
       std::vector<std::string> v = cfg.getParameter<std::vector<std::string> >("parameterSets");
       for (unsigned int i = 0; i < v.size(); i++) {
-        std::string vs = v[i];
+        const std::string& vs = v[i];
         std::vector<double> vpar = cfg.getParameter<std::vector<double> >(vs);
         if (vpar.size() == 2)
           Photospp::Photos::forceMass((int)vpar[0], vpar[1]);

--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -184,7 +184,7 @@ void HTXSRivetProducer::beginRun(edm::Run const& iRun, edm::EventSetup const& es
            iter++) {
         std::vector<std::string> lines = iter->lines();
         for (unsigned int iLine = 0; iLine < lines.size(); iLine++) {
-          std::string line = lines.at(iLine);
+          const std::string& line = lines.at(iLine);
           // POWHEG
           if (line.find("gg_H_quark-mass-effects") != std::string::npos) {
             edm::LogInfo("HTXSRivetProducer") << iLine << " " << line << std::endl;

--- a/GeneratorInterface/RivetInterface/plugins/RivetAnalyzer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/RivetAnalyzer.cc
@@ -139,6 +139,7 @@ void RivetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
   genEvent->read_data(*genEventData);
 
   std::vector<double> mergedWeights;
+  mergedWeights.reserve(genEvent->weights().size());
   for (unsigned int i = 0; i < genEvent->weights().size(); i++) {
     mergedWeights.push_back(genEvent->weights()[i]);
   }

--- a/GeneratorInterface/TauolaInterface/plugins/Tauolapp/TauolappInterface.cc
+++ b/GeneratorInterface/TauolaInterface/plugins/Tauolapp/TauolappInterface.cc
@@ -119,7 +119,7 @@ void TauolappInterface::init(const edm::EventSetup& es) {
   if (fPSet->exists("parameterSets")) {
     std::vector<std::string> par = fPSet->getParameter<std::vector<std::string> >("parameterSets");
     for (unsigned int ip = 0; ip < par.size(); ++ip) {
-      std::string curSet = par[ip];
+      const std::string& curSet = par[ip];
       if (curSet == "setNewCurrents")
         Tauolapp::Tauola::setNewCurrents(fPSet->getParameter<int>(curSet));
     }
@@ -133,7 +133,7 @@ void TauolappInterface::init(const edm::EventSetup& es) {
   if (fPSet->exists("parameterSets")) {
     std::vector<std::string> par = fPSet->getParameter<std::vector<std::string> >("parameterSets");
     for (unsigned int ip = 0; ip < par.size(); ++ip) {
-      std::string curSet = par[ip];
+      const std::string& curSet = par[ip];
       if (curSet == "spinCorrelationSetAll")
         Tauolapp::Tauola::spin_correlation.setAll(fPSet->getParameter<bool>(curSet));
       if (curSet == "spinCorrelationGAMMA")


### PR DESCRIPTION
This PR suggests to apply the `clang-tidy` changes proposed by LLVM21 ( from CLANG_X IB). 