### PR TITLE
[DAQ] [LLVM21] Apply clang-tidy changes

### DIFF
--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -820,6 +820,7 @@ namespace evf {
 
         if (fastMonIntervals_ && (snapCounter_ % fastMonIntervals_) == 0) {
           std::vector<std::string> CSVv;
+          CSVv.reserve(nMonThreads_);
           for (unsigned int i = 0; i < nMonThreads_; i++) {
             CSVv.push_back(fmt_->jsonMonitor_->getCSVString((int)i));
           }

--- a/L1TriggerScouting/Utilities/plugins/SimpleOrbitFlatTableProducer.cc
+++ b/L1TriggerScouting/Utilities/plugins/SimpleOrbitFlatTableProducer.cc
@@ -112,7 +112,7 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
     edm::ParameterSetDescription desc;
-    std::string classname = ClassName<T>::name();
+    const std::string &classname = ClassName<T>::name();
     desc.add<std::string>("name")->setComment("name of the branch in the flat table output for " + classname);
     desc.add<std::string>("doc", "")->setComment("few words of self documentation");
     desc.ifValue(


### PR DESCRIPTION
This PR suggests to apply the `clang-tidy` changes proposed by LLVM21 ( from CLANG_X IB). 