### PR TITLE
[GEOMETRY] [LLVM21] Apply clang-tidy changes

### DIFF
--- a/DetectorDescription/Parser/src/DDLParser.cc
+++ b/DetectorDescription/Parser/src/DDLParser.cc
@@ -133,7 +133,7 @@ int DDLParser::parse(const DDLDocumentProvider& dp) {
   const std::vector<std::string>& urlList = dp.getURLList();
 
   for (; fileIndex < fileList.size(); ++fileIndex) {
-    std::string ts = urlList[fileIndex];
+    const std::string& ts = urlList[fileIndex];
     std::string tf = fileList[fileIndex];
     if (!ts.empty()) {
       if (ts[ts.size() - 1] == '/') {

--- a/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryLoaderFromDDD.cc
+++ b/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryLoaderFromDDD.cc
@@ -98,7 +98,7 @@ void EcalTBHodoscopeGeometryLoaderFromDDD::makeGeometry(const DDCompactView* cpv
 unsigned int EcalTBHodoscopeGeometryLoaderFromDDD::getDetIdForDDDNode(const DDFilteredView& fv) {
   // perform some consistency checks
   // get the parents and grandparents of this node
-  DDGeoHistory parents = fv.geoHistory();
+  const DDGeoHistory& parents = fv.geoHistory();
 
   assert(parents.size() >= 3);
 

--- a/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilder.cc
@@ -230,7 +230,7 @@ ME0Chamber* ME0GeometryBuilder::buildChamber(DDFilteredView& fv, ME0DetId detId)
   LogTrace("ME0Geometry") << "buildChamber " << fv.logicalPart().name().name() << " " << detId << std::endl;
   DDBooleanSolid solid = (DDBooleanSolid)(fv.logicalPart().solid());
 
-  std::vector<double> dpar = solid.parameters();
+  const std::vector<double>& dpar = solid.parameters();
 
   double L = convertMmToCm(dpar[0]);  // length is along local Y
   double T = convertMmToCm(dpar[3]);  // thickness is long local Z
@@ -258,7 +258,7 @@ ME0Layer* ME0GeometryBuilder::buildLayer(DDFilteredView& fv, ME0DetId detId) con
 
   DDBooleanSolid solid = (DDBooleanSolid)(fv.logicalPart().solid());
 
-  std::vector<double> dpar = solid.parameters();
+  const std::vector<double>& dpar = solid.parameters();
   double L = convertMmToCm(dpar[0]);  // length is along local Y
   double t = convertMmToCm(dpar[3]);  // thickness is long local Z
   double b = convertMmToCm(dpar[4]);  // bottom width is along local X

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -568,6 +568,7 @@ HGCalParameters::hgtrap HGCalDDDConstants::getModule(unsigned int indx, bool hex
 
 std::vector<HGCalParameters::hgtrap> HGCalDDDConstants::getModules() const {
   std::vector<HGCalParameters::hgtrap> mytrs;
+  mytrs.reserve(hgpar_->moduleLayR_.size());
   for (unsigned int k = 0; k < hgpar_->moduleLayR_.size(); ++k)
     mytrs.emplace_back(hgpar_->getModule(k, true));
   return mytrs;
@@ -606,6 +607,7 @@ std::pair<int, int> HGCalDDDConstants::getREtaRange(int lay) const {
 
 std::vector<HGCalParameters::hgtrform> HGCalDDDConstants::getTrForms() const {
   std::vector<HGCalParameters::hgtrform> mytrs;
+  mytrs.reserve(hgpar_->trformIndex_.size());
   for (unsigned int k = 0; k < hgpar_->trformIndex_.size(); ++k)
     mytrs.emplace_back(hgpar_->getTrForm(k));
   return mytrs;

--- a/Geometry/HGCalMapping/plugins/alpaka/HGCalMappingModuleESProducer.cc
+++ b/Geometry/HGCalMapping/plugins/alpaka/HGCalMappingModuleESProducer.cc
@@ -45,7 +45,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       //
       std::optional<HGCalMappingModuleParamHost> produce(const HGCalElectronicsMappingRcd& iRecord) {
         //get cell and module indexer
-        auto modIndexer = iRecord.get(moduleIndexTkn_);
+        const auto& modIndexer = iRecord.get(moduleIndexTkn_);
 
         // load dense indexing
         const uint32_t size = modIndexer.maxModulesCount();

--- a/Geometry/HGCalTBCommonData/src/HGCalTBDDDConstants.cc
+++ b/Geometry/HGCalTBCommonData/src/HGCalTBDDDConstants.cc
@@ -237,6 +237,7 @@ HGCalTBParameters::hgtrap HGCalTBDDDConstants::getModule(unsigned int indx, bool
 
 std::vector<HGCalTBParameters::hgtrap> HGCalTBDDDConstants::getModules() const {
   std::vector<HGCalTBParameters::hgtrap> mytrs;
+  mytrs.reserve(hgpar_->moduleLayR_.size());
   for (unsigned int k = 0; k < hgpar_->moduleLayR_.size(); ++k)
     mytrs.emplace_back(hgpar_->getModule(k, true));
   return mytrs;
@@ -244,6 +245,7 @@ std::vector<HGCalTBParameters::hgtrap> HGCalTBDDDConstants::getModules() const {
 
 std::vector<HGCalTBParameters::hgtrform> HGCalTBDDDConstants::getTrForms() const {
   std::vector<HGCalTBParameters::hgtrform> mytrs;
+  mytrs.reserve(hgpar_->trformIndex_.size());
   for (unsigned int k = 0; k < hgpar_->trformIndex_.size(); ++k)
     mytrs.emplace_back(hgpar_->getTrForm(k));
   return mytrs;

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalLinearXY.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalLinearXY.cc
@@ -38,7 +38,7 @@ static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext
       unsigned int k = (childName.size() == 1) ? 0 : copy;
       ++copy;
       if (k < childName.size() && (childName[k] != " " && childName[k] != "Null")) {
-        std::string child = childName[k];
+        const std::string& child = childName[k];
         dd4hep::Position tran(xoff + i * deltaX, yoff + j * deltaY, centre[2]);
         parent.placeVolume(ns.volume(child), copy, tran);
 #ifdef EDM_ML_DEBUG

--- a/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
+++ b/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
@@ -63,6 +63,7 @@ std::vector<int> HcalDDDRecConstants::getDepth(const unsigned int& eta, const bo
     std::map<int, int> layers;
     hcons.ldMap()->getLayerDepth(eta + 1, layers);
     std::vector<int> depths;
+    depths.reserve(layers.size());
     for (unsigned int lay = 0; lay < layers.size(); ++lay)
       depths.emplace_back(layers[lay + 1]);
     return depths;
@@ -79,6 +80,7 @@ std::vector<int> HcalDDDRecConstants::getDepth(const int& det,
     return getDepth(eta, false);
   } else {
     std::vector<int> depths;
+    depths.reserve(layers.size());
     for (unsigned int lay = 0; lay < layers.size(); ++lay)
       depths.emplace_back(layers[lay + 1]);
     return depths;

--- a/Geometry/MTDGeometryBuilder/src/MTDGeomBuilderFromGeometricTimingDet.cc
+++ b/Geometry/MTDGeometryBuilder/src/MTDGeomBuilderFromGeometricTimingDet.cc
@@ -44,7 +44,7 @@ MTDGeometry* MTDGeomBuilderFromGeometricTimingDet::build(const GeometricTimingDe
 
   std::vector<GeometricTimingDet::GTDEnumType> gdsubdetmap(
       2, GeometricTimingDet::unknown);  // hardcoded "2" should not be a surprise...
-  GeometricTimingDet::ConstGeometricTimingDetContainer subdetgd = gd->components();
+  const GeometricTimingDet::ConstGeometricTimingDetContainer& subdetgd = gd->components();
 
   LogDebug("SubDetectorGeometricTimingDetType") << "MTD GeometricTimingDet enumerator values of the subdetectors";
   for (unsigned int i = 0; i < subdetgd.size(); ++i) {

--- a/Geometry/MTDGeometryBuilder/src/MTDGeometry.cc
+++ b/Geometry/MTDGeometryBuilder/src/MTDGeometry.cc
@@ -44,7 +44,7 @@ MTDGeometry::MTDGeometry(GeometricTimingDet const* gd) : theTrackerDet(gd) {
     theSubDetTypeMap[i] = GeomDetEnumerators::invalidDet;
     theNumberOfLayers[i] = 0;
   }
-  GeometricTimingDet::ConstGeometricTimingDetContainer subdetgd = gd->components();
+  const GeometricTimingDet::ConstGeometricTimingDetContainer& subdetgd = gd->components();
 
 #ifdef EDM_ML_DEBUG
   edm::LogInfo("BuildingSubDetTypeMap")

--- a/Geometry/MuonNumbering/src/MuonGeometryNumbering.cc
+++ b/Geometry/MuonNumbering/src/MuonGeometryNumbering.cc
@@ -95,7 +95,7 @@ int MuonGeometryNumbering::getInt(const std::string &s, const DDLogicalPart &par
       break;
   }
   if (foundIt) {
-    std::vector<double> temp = val.doubles();
+    const std::vector<double> &temp = val.doubles();
     if (temp.size() != 1) {
       edm::LogError("MuonGeom") << "MuonGeometryNumbering:: ERROR: I need only 1 " << s << " in DDLogicalPart "
                                 << part.name();

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDPixBarLayerAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDPixBarLayerAlgo.cc
@@ -83,8 +83,8 @@ static long algorithm(Detector& description, cms::DDParsingContext& ctxt, xml_h 
   edm::LogVerbatim("PixelGeom") << "Cool " << cool.name() << " number 1 positioned in " << coolTube.name()
                                 << " at (0,0,0) with no rotation";
 
-  string ladderFull = ladder[0];
-  string ladderHalf = ladder[1];
+  const string& ladderFull = ladder[0];
+  const string& ladderHalf = ladder[1];
   int nphi = number / 2, copy = 1, iup = -1;
   double phi0 = 90_deg;
   Volume ladderHalfVol = ns.volume(ladderHalf);

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
@@ -71,7 +71,7 @@ TrackerGeometry* TrackerGeomBuilderFromGeometricDet::build(const GeometricDet* g
 
   std::vector<GeometricDet::GDEnumType> gdsubdetmap(
       6, GeometricDet::unknown);  // hardcoded "6" should not be a surprise...
-  GeometricDet::ConstGeometricDetContainer subdetgd = gd->components();
+  const GeometricDet::ConstGeometricDetContainer& subdetgd = gd->components();
 
   LogDebug("SubDetectorGeometricDetType") << "GeometriDet enumerator values of the subdetectors";
   for (unsigned int i = 0; i < subdetgd.size(); ++i) {

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
@@ -60,7 +60,7 @@ TrackerGeometry::TrackerGeometry(GeometricDet const* gd) : theTrackerDet(gd) {
     theSubDetTypeMap[i] = GeomDetEnumerators::invalidDet;
     theNumberOfLayers[i] = 0;
   }
-  GeometricDet::ConstGeometricDetContainer subdetgd = gd->components();
+  const GeometricDet::ConstGeometricDetContainer& subdetgd = gd->components();
 
   LogDebug("BuildingSubDetTypeMap") << "GeometriDet and GeomDetEnumerators enumerator values of the subdetectors";
   for (unsigned int i = 0; i < subdetgd.size(); ++i) {


### PR DESCRIPTION
This PR suggests to apply the `clang-tidy` changes proposed by LLVM21 ( from CLANG_X IB). 