### PR TITLE
[FASTSIM] [LLVM21] Apply clang-tidy changes

### DIFF
--- a/FastSimulation/Muons/plugins/FastTSGFromL2Muon.cc
+++ b/FastSimulation/Muons/plugins/FastTSGFromL2Muon.cc
@@ -72,7 +72,7 @@ void FastTSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es) {
     std::set<unsigned> tkIds;
     tkSeeds.reserve(seed_size);
     for (unsigned iseed = 0; iseed < seedCollections; ++iseed) {
-      edm::Handle<edm::View<TrajectorySeed> > aSeedCollection = theSeeds[iseed];
+      const edm::Handle<edm::View<TrajectorySeed> >& aSeedCollection = theSeeds[iseed];
       unsigned nSeeds = aSeedCollection->size();
       for (unsigned seednr = 0; seednr < nSeeds; ++seednr) {
         // The seed

--- a/FastSimulation/ParticleDecay/plugins/TestPythiaDecays.cc
+++ b/FastSimulation/ParticleDecay/plugins/TestPythiaDecays.cc
@@ -325,6 +325,7 @@ void TestPythiaDecays::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 
     // fill br hist
     std::vector<int> prod;
+    prod.reserve(childIndices.size());
     for (size_t d = 0; d < childIndices.size(); ++d) {
       prod.push_back(abs(simtracks->at(childIndices[d]).type()));
     }

--- a/FastSimulation/Utilities/src/Looses.cc
+++ b/FastSimulation/Utilities/src/Looses.cc
@@ -19,6 +19,7 @@ Looses::~Looses() { summary(); }
 void Looses::count(const std::string& name, unsigned cut) {
   if (theLosses.find(name) == theLosses.end()) {
     std::vector<unsigned> myCounts;
+    myCounts.reserve(20);
     for (unsigned i = 0; i < 20; ++i)
       myCounts.push_back(0);
     theLosses[name] = myCounts;


### PR DESCRIPTION
This PR suggests to apply the `clang-tidy` changes proposed by LLVM21 ( from CLANG_X IB). 