### PR TITLE
[RECONSTRUCTION] [LLVM21] Apply clang-tidy changes

### DIFF
--- a/DataFormats/JetReco/src/CaloJet.cc
+++ b/DataFormats/JetReco/src/CaloJet.cc
@@ -77,6 +77,7 @@ CaloTowerPtr CaloJet::getCaloConstituent(unsigned fIndex) const {
 
 std::vector<CaloTowerPtr> CaloJet::getCaloConstituents() const {
   std::vector<CaloTowerPtr> result;
+  result.reserve(numberOfDaughters());
   for (unsigned i = 0; i < numberOfDaughters(); i++)
     result.push_back(getCaloConstituent(i));
   return result;
@@ -115,6 +116,7 @@ std::string CaloJet::print() const {
 std::vector<CaloTowerDetId> CaloJet::getTowerIndices() const {
   std::vector<CaloTowerDetId> result;
   std::vector<CaloTowerPtr> towers = getCaloConstituents();
+  result.reserve(towers.size());
   for (unsigned i = 0; i < towers.size(); ++i) {
     result.push_back(towers[i]->id());
   }

--- a/DataFormats/JetReco/src/GenJet.cc
+++ b/DataFormats/JetReco/src/GenJet.cc
@@ -50,6 +50,7 @@ const GenParticle* GenJet::getGenConstituent(unsigned fIndex) const {
 
 std::vector<const GenParticle*> GenJet::getGenConstituents() const {
   std::vector<const GenParticle*> result;
+  result.reserve(numberOfDaughters());
   for (unsigned i = 0; i < numberOfDaughters(); i++)
     result.push_back(getGenConstituent(i));
   return result;

--- a/DataFormats/JetReco/src/PFJet.cc
+++ b/DataFormats/JetReco/src/PFJet.cc
@@ -40,6 +40,7 @@ reco::PFCandidatePtr PFJet::getPFConstituent(unsigned fIndex) const {
 
 std::vector<reco::PFCandidatePtr> PFJet::getPFConstituents() const {
   std::vector<PFCandidatePtr> result;
+  result.reserve(numberOfDaughters());
   for (unsigned i = 0; i < numberOfDaughters(); i++)
     result.push_back(getPFConstituent(i));
   return result;

--- a/DataFormats/JetReco/src/TrackJet.cc
+++ b/DataFormats/JetReco/src/TrackJet.cc
@@ -41,6 +41,7 @@ edm::Ptr<reco::Track> reco::TrackJet::track(size_t i) const {
 
 std::vector<edm::Ptr<reco::Track> > reco::TrackJet::tracks() const {
   std::vector<edm::Ptr<reco::Track> > result;
+  result.reserve(numberOfDaughters());
   for (unsigned i = 0; i < numberOfDaughters(); i++)
     result.push_back(track(i));
   return result;

--- a/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
+++ b/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
@@ -332,7 +332,7 @@ ostream& reco::operator<<(ostream& out, const PFCandidate& c) {
 
   out << ", blocks/iele: ";
 
-  PFCandidate::ElementsInBlocks eleInBlocks = c.elementsInBlocks();
+  const PFCandidate::ElementsInBlocks& eleInBlocks = c.elementsInBlocks();
   for (unsigned i = 0; i < eleInBlocks.size(); i++) {
     PFBlockRef blockRef = eleInBlocks[i].first;
     unsigned indexInBlock = eleInBlocks[i].second;

--- a/DataFormats/TauReco/src/PFTauDecayMode.cc
+++ b/DataFormats/TauReco/src/PFTauDecayMode.cc
@@ -45,6 +45,7 @@ namespace reco {
   std::vector<const Candidate*> PFTauDecayMode::chargedPionCandidates() const {
     size_type numberOfChargedPions = chargedPions_.numberOfDaughters();
     std::vector<const Candidate*> output;
+    output.reserve(numberOfChargedPions);
     for (size_type iterCand = 0; iterCand < numberOfChargedPions; ++iterCand)
       output.push_back(chargedPions_.daughter(iterCand));
     return output;
@@ -53,6 +54,7 @@ namespace reco {
   std::vector<const Candidate*> PFTauDecayMode::neutralPionCandidates() const {
     size_type numberOfChargedPions = piZeroes_.numberOfDaughters();
     std::vector<const Candidate*> output;
+    output.reserve(numberOfChargedPions);
     for (size_type iterCand = 0; iterCand < numberOfChargedPions; ++iterCand)
       output.push_back(piZeroes_.daughter(iterCand));
     return output;

--- a/EventFilter/CSCRawToDigi/src/CSCCFEBData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCCFEBData.cc
@@ -80,7 +80,7 @@ CSCCFEBData::CSCCFEBData(unsigned number, bool sixteenSamples, uint16_t format_v
 }
 
 void CSCCFEBData::add(const CSCStripDigi &digi, int layer) {
-  std::vector<int> scaCounts = digi.getADCCounts();
+  const std::vector<int> &scaCounts = digi.getADCCounts();
   for (unsigned itime = 0; itime < theNumberOfSamples; ++itime) {
     unsigned channel = (digi.getStrip() - 1) % 16 + 1;
     unsigned value = scaCounts[itime] & 0xFFF;  // 12-bit

--- a/JetMETCorrections/Modules/plugins/JetResolutionDemo.cc
+++ b/JetMETCorrections/Modules/plugins/JetResolutionDemo.cc
@@ -120,6 +120,7 @@ void JetResolutionDemo::analyze(const edm::Event& iEvent, const edm::EventSetup&
       }
 
       std::vector<float> res;
+      res.reserve(40);
       for (std::size_t i = 0; i < 40; i++) {
         res.push_back(i * 0.005);
       }

--- a/MagneticField/GeomBuilder/src/bLayer.cc
+++ b/MagneticField/GeomBuilder/src/bLayer.cc
@@ -141,6 +141,7 @@ MagBLayer* bLayer::buildMagBLayer() const {
 
     // If we have several sectors, create the MagBSector
     std::vector<MagBSector*> mSectors;
+    mSectors.reserve(sectors.size());
     for (unsigned int i = 0; i < sectors.size(); ++i) {
       mSectors.push_back(sectors[i].buildMagBSector());
     }

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -546,6 +546,7 @@ void TemplatedSecondaryVertexProducer<IPTI, VTX>::produce(edm::Event &event, con
 
           std::vector<double> dR2toSubjets;
 
+          dR2toSubjets.reserve(subjetIndices.at(i).size());
           for (size_t sj = 0; sj < subjetIndices.at(i).size(); ++sj)
             dR2toSubjets.push_back(Geom::deltaR2(p.rapidity(),
                                                  p.phi_std(),
@@ -671,6 +672,7 @@ void TemplatedSecondaryVertexProducer<IPTI, VTX>::produce(edm::Event &event, con
 
         std::vector<double> dR2toSubjets;
 
+        dR2toSubjets.reserve(subjetIndices.at(i).size());
         for (size_t sj = 0; sj < subjetIndices.at(i).size(); ++sj)
           dR2toSubjets.push_back(Geom::deltaR2(p.rapidity(),
                                                p.phi_std(),

--- a/RecoEcal/EgammaClusterAlgos/src/HybridClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/HybridClusterAlgo.cc
@@ -390,7 +390,7 @@ void HybridClusterAlgo::mainSearch(const EcalRecHitCollection* hits, const CaloS
       int nhits = 0;
       for (int j = 0; j < int(dominoEnergy.size()); ++j) {
         if (OwnerShip[j] == i) {
-          std::vector<EcalRecHit> temp = dominoCells[j];
+          const std::vector<EcalRecHit>& temp = dominoCells[j];
           for (int k = 0; k < int(temp.size()); ++k) {
             dets.push_back(std::pair<DetId, float>(temp[k].id(), 1.));  // by default energy fractions are 1
             if (temp[k].id() == itID)
@@ -471,7 +471,7 @@ reco::SuperClusterCollection HybridClusterAlgo::makeSuperClusters(const reco::Ca
     //supercluster.  This could be somehow more efficient.
 
     for (int i = 0; i < int(thiscoll.size()); ++i) {
-      reco::BasicCluster thisclus = thiscoll[i];  //The Cluster in question.
+      const reco::BasicCluster& thisclus = thiscoll[i];  //The Cluster in question.
       for (int j = 0; j < int(clustersCollection.size()); ++j) {
         //Find the appropriate cluster from the list of references
         reco::BasicCluster cluster_p = *clustersCollection[j];

--- a/RecoEcal/EgammaClusterProducers/src/EcalBasicClusterLocalContCorrection.cc
+++ b/RecoEcal/EgammaClusterProducers/src/EcalBasicClusterLocalContCorrection.cc
@@ -54,7 +54,7 @@ float EcalBasicClusterLocalContCorrection::operator()(const reco::BasicCluster &
 
   //search which crystal is closest to the cluster position and call it crystalseed:
   //std::vector<DetId> crystals_vector = *scRef.getHitsByDetId();   //deprecated
-  std::vector<std::pair<DetId, float> > crystals_vector = basicCluster.hitsAndFractions();
+  const std::vector<std::pair<DetId, float> > &crystals_vector = basicCluster.hitsAndFractions();
   float dphimin = 999.;
   float detamin = 999.;
   int ietaclosest = 0;

--- a/RecoEcal/EgammaClusterProducers/src/EcalDigiSelector.cc
+++ b/RecoEcal/EgammaClusterProducers/src/EcalDigiSelector.cc
@@ -155,7 +155,7 @@ void EcalDigiSelector::produce(edm::Event& evt, const edm::EventSetup& es) {
         std::vector<DetId> saveTheseDetIds;
         //pick out the detids for the 3x3 in each of the selected superclusters
         for (int loop = 0; loop < int(saveBarrelSuperClusters.size()); loop++) {
-          SuperCluster clus1 = saveBarrelSuperClusters[loop];
+          const SuperCluster& clus1 = saveBarrelSuperClusters[loop];
           const CaloClusterPtr& bcref = clus1.seed();
           const BasicCluster* bc = bcref.get();
           //Get the maximum detid
@@ -206,7 +206,7 @@ void EcalDigiSelector::produce(edm::Event& evt, const edm::EventSetup& es) {
         std::set<DetId> saveTheseDetIds;
         //pick out the digis for the 3x3 in each of the selected superclusters
         for (int loop = 0; loop < int(saveEndcapSuperClusters.size()); loop++) {
-          SuperCluster clus1 = saveEndcapSuperClusters[loop];
+          const SuperCluster& clus1 = saveEndcapSuperClusters[loop];
           const CaloClusterPtr& bcref = clus1.seed();
           const BasicCluster* bc = bcref.get();
           //Get the maximum detid

--- a/RecoEcal/EgammaClusterProducers/src/UncleanSCRecoveryProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/UncleanSCRecoveryProducer.cc
@@ -220,7 +220,7 @@ void UncleanSCRecoveryProducer::produce(edm::StreamID, edm::Event& evt, const ed
   // the new collection
   LogTrace("EcalCleaning") << "The new SC clean collection with size " << superClusters.size();
   for (unsigned int i = 0; i < superClusters.size(); ++i) {
-    const reco::SuperCluster nsc = superClusters[i];
+    const reco::SuperCluster& nsc = superClusters[i];
     LogTrace("EcalCleaning") << " >>> newSC    #" << i << "; Energy: " << nsc.energy() << " eta: " << nsc.eta()
                              << " isClean=" << nsc.isInClean() << " isUnclean=" << nsc.isInUnclean()
                              << " sc seed detid: " << nsc.seed()->seed().rawId();

--- a/RecoEcal/EgammaClusterProducers/src/UnifiedSCCollectionProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/UnifiedSCCollectionProducer.cc
@@ -432,7 +432,7 @@ void UnifiedSCCollectionProducer::produce(edm::Event& evt, const edm::EventSetup
   }
   LogTrace("UnifiedSC") << "The new SC unclean only collection with size " << superClustersUncleanOnly.size();
   for (int i = 0; i < (int)superClustersUncleanOnly.size(); ++i) {
-    const reco::SuperCluster nsc = superClustersUncleanOnly[i];
+    const reco::SuperCluster& nsc = superClustersUncleanOnly[i];
     LogTrace("UnifiedSC") << " >>> newSC    #" << i << "; Energy: " << nsc.energy() << " eta: " << nsc.eta()
                           << " isClean=" << nsc.isInClean() << " isUnclean=" << nsc.isInUnclean()
                           << " sc seed detid: " << nsc.seed()->seed().rawId();

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterCrackCorrection.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterCrackCorrection.cc
@@ -95,7 +95,7 @@ float EcalClusterCrackCorrection::getValue(const reco::CaloCluster &seedbclus) c
 
   //search which crystal is closest to the cluster position and call it crystalseed:
   //std::vector<DetId> crystals_vector = seedbclus.getHitsByDetId();   //deprecated
-  std::vector<std::pair<DetId, float> > crystals_vector = seedbclus.hitsAndFractions();
+  const std::vector<std::pair<DetId, float> > &crystals_vector = seedbclus.hitsAndFractions();
   float dphimin = 999.;
   float detamin = 999.;
   int ietaclosest = 0;

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedValueMapsProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedValueMapsProducer.cc
@@ -80,6 +80,7 @@ void LowPtGsfElectronSeedValueMapsProducer::produce(edm::Event& event, const edm
 
     // Iterate through GsfTracks, extract BDT output, and store result in ValueMap for each model
     std::vector<std::vector<float> > output;
+    output.reserve(names_.size());
     for (unsigned int iname = 0; iname < names_.size(); ++iname) {
       output.push_back(std::vector<float>(gsfTracks->size(), -999.));
     }

--- a/RecoEgamma/EgammaIsolationAlgos/src/ElectronTkIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/ElectronTkIsolation.cc
@@ -47,7 +47,7 @@ std::pair<int, double> ElectronTkIsolation::getIso(const reco::Track* tmpTrack) 
   int counter = 0;
   double ptSum = 0.;
   //Take the electron track
-  math::XYZVector tmpElectronMomentumAtVtx = (*tmpTrack).momentum();
+  const math::XYZVector& tmpElectronMomentumAtVtx = (*tmpTrack).momentum();
   double tmpElectronEtaAtVertex = (*tmpTrack).eta();
 
   for (reco::TrackCollection::const_iterator itrTr = (*trackCollection_).begin(); itrTr != (*trackCollection_).end();

--- a/RecoEgamma/EgammaPhotonAlgos/src/ConversionVertexFinder.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/ConversionVertexFinder.cc
@@ -34,7 +34,7 @@ ConversionVertexFinder::~ConversionVertexFinder() {
 }
 
 bool ConversionVertexFinder::run(const std::vector<reco::TransientTrack>& _pair, reco::Vertex& the_vertex) {
-  std::vector<reco::TransientTrack> pair = _pair;
+  const std::vector<reco::TransientTrack>& pair = _pair;
   bool found = false;
 
   if (pair.size() < 2)

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackMerger.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackMerger.cc
@@ -111,10 +111,12 @@ void ConversionTrackMerger::produce(edm::Event& e, const edm::EventSetup& es) {
   int i;
 
   std::vector<int> selected1;
+  selected1.reserve(tC1.size());
   for (unsigned int i = 0; i < tC1.size(); ++i) {
     selected1.push_back(1);
   }
   std::vector<int> selected2;
+  selected2.reserve(tC2.size());
   for (unsigned int i = 0; i < tC2.size(); ++i) {
     selected2.push_back(1);
   }

--- a/RecoEgamma/EgammaTools/src/EcalClusterLocal.cc
+++ b/RecoEgamma/EgammaTools/src/EcalClusterLocal.cc
@@ -35,7 +35,7 @@ namespace egammaTools {
     double depth = X0 * (T0 + log(bclus.energy()));
 
     //find max energy crystal
-    std::vector<std::pair<DetId, float> > crystals_vector = bclus.hitsAndFractions();
+    const std::vector<std::pair<DetId, float> > &crystals_vector = bclus.hitsAndFractions();
     float drmin = 999.;
     EBDetId crystalseed;
     //printf("starting loop over crystals, etot = %5f:\n",bclus.energy());
@@ -115,7 +115,7 @@ namespace egammaTools {
     double depth = X0 * (T0 + log(bclus.energy()));
 
     //find max energy crystal
-    std::vector<std::pair<DetId, float> > crystals_vector = bclus.hitsAndFractions();
+    const std::vector<std::pair<DetId, float> > &crystals_vector = bclus.hitsAndFractions();
     float drmin = 999.;
     EEDetId crystalseed;
     //printf("starting loop over crystals, etot = %5f:\n",bclus.energy());

--- a/RecoHGCal/TICL/plugins/TICLDumper.cc
+++ b/RecoHGCal/TICL/plugins/TICLDumper.cc
@@ -391,6 +391,7 @@ public:
       }
 
       std::vector<float> id_probs;
+      id_probs.reserve(8);
       for (size_t i = 0; i < 8; i++)
         id_probs.push_back(trackster_iterator->id_probabilities(i));
       trackster_id_probabilities.push_back(id_probs);

--- a/RecoHGCal/TICL/plugins/TracksterLinkingbySkeletons.cc
+++ b/RecoHGCal/TICL/plugins/TracksterLinkingbySkeletons.cc
@@ -448,6 +448,7 @@ void TracksterLinkingbySkeletons::linkTracksters(
   std::vector<int> isRootTracksters(tracksters.size(), 1);
 
   std::vector<ticl::Node> allNodes;
+  allNodes.reserve(tracksters.size());
   for (size_t it = 0; it < tracksters.size(); ++it) {
     allNodes.emplace_back(it);
   }

--- a/RecoHI/HiJetAlgos/plugins/HiPuRhoProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiPuRhoProducer.cc
@@ -501,6 +501,7 @@ void HiPuRhoProducer::putRho(edm::Event& iEvent, const edm::EventSetup& iSetup) 
   std::size_t size = etaEdgeLow_.size();
 
   std::vector<std::pair<std::size_t, double>> order;
+  order.reserve(size);
   for (std::size_t i = 0; i < size; ++i) {
     order.emplace_back(i, etaEdgeLow_[i]);
   }

--- a/RecoJets/JetAlgorithms/src/CATopJetAlgorithm.cc
+++ b/RecoJets/JetAlgorithms/src/CATopJetAlgorithm.cc
@@ -116,7 +116,7 @@ void CATopJetAlgorithm::run(const vector<fastjet::PseudoJet>& cell_particles,
     if (verbose_)
       cout << "\nJet " << i << endl;
     i++;
-    fastjet::PseudoJet localJet = *jetIt;
+    const fastjet::PseudoJet& localJet = *jetIt;
 
     // Get the 4-vector for this jet
     p4_hardJets.push_back(math::XYZTLorentzVector(localJet.px(), localJet.py(), localJet.pz(), localJet.e()));

--- a/RecoJets/JetAlgorithms/src/CATopJetHelper.cc
+++ b/RecoJets/JetAlgorithms/src/CATopJetHelper.cc
@@ -23,13 +23,13 @@ reco::CATopJetProperties CATopJetHelper::operator()(reco::Jet const& ihardJet) c
     // Now look at the subjets that were formed
     for (int isub = 0; isub < 2; ++isub) {
       // Get this subjet
-      reco::Jet::Constituent icandJet = subjets[isub];
+      const reco::Jet::Constituent& icandJet = subjets[isub];
 
       // Now look at the "other" subjets than this one, form the minimum invariant mass
       // pairing, as well as the "closest" combination to the W mass
       for (int jsub = isub + 1; jsub < 3; ++jsub) {
         // Get the second subjet
-        reco::Jet::Constituent jcandJet = subjets[jsub];
+        const reco::Jet::Constituent& jcandJet = subjets[jsub];
 
         reco::Candidate::LorentzVector wCand = icandJet->p4() + jcandJet->p4();
 

--- a/RecoJets/JetProducers/src/JetMatchingTools.cc
+++ b/RecoJets/JetProducers/src/JetMatchingTools.cc
@@ -155,6 +155,7 @@ const reco::CandidateCollection* JetMatchingTools::getGenParticlesCollection() {
 std::vector<const CaloTower*> JetMatchingTools::getConstituents(const reco::CaloJet& fJet) {
   std::vector<const CaloTower*> result;
   std::vector<CaloTowerPtr> constituents = fJet.getCaloConstituents();
+  result.reserve(constituents.size());
   for (unsigned i = 0; i < constituents.size(); ++i)
     result.push_back(&*(constituents[i]));
   return result;

--- a/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
@@ -108,7 +108,7 @@ namespace cms {
       std::cout << "================    jetEta   =  " << (*jet).eta() << std::endl;
     }
 
-    const edm::RefToBase<reco::Jet> jptjetRef = jet->getCaloJetRef();
+    const edm::RefToBase<reco::Jet>& jptjetRef = jet->getCaloJetRef();
     reco::CaloJet const* rawcalojet = dynamic_cast<reco::CaloJet const*>(&*jptjetRef);
 
     int ncalotowers = 0.;
@@ -196,7 +196,7 @@ namespace cms {
     double detatr1 = 0.;
     double dphidetatr = 0.;
 
-    const reco::TrackRefVector pioninin = (*jet).getPionsInVertexInCalo();
+    const reco::TrackRefVector& pioninin = (*jet).getPionsInVertexInCalo();
 
     for (reco::TrackRefVector::const_iterator it = pioninin.begin(); it != pioninin.end(); it++) {
       if ((*it)->pt() > 0.5 && ((*it)->ptError() / (*it)->pt()) < 0.05) {
@@ -221,7 +221,7 @@ namespace cms {
       }
     }  // pioninin
 
-    const reco::TrackRefVector pioninout = (*jet).getPionsInVertexOutCalo();
+    const reco::TrackRefVector& pioninout = (*jet).getPionsInVertexOutCalo();
 
     for (reco::TrackRefVector::const_iterator it = pioninout.begin(); it != pioninout.end(); it++) {
       if ((*it)->pt() > 0.5 && ((*it)->ptError() / (*it)->pt()) < 0.05) {

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
@@ -526,6 +526,7 @@ void CaloTowersCreationAlgo::rescaleTowers(const CaloTowerCollection& ctc, CaloT
                                 theTowerTopology->lastHORing());
 
     std::vector<DetId> contains;
+    contains.reserve(ctcItr->constituentsSize());
     for (unsigned int iConst = 0; iConst < ctcItr->constituentsSize(); ++iConst) {
       contains.push_back(ctcItr->constituent(iConst));
     }

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -608,6 +608,7 @@ void EcalUncalibRecHitWorkerMultiFit::run(const edm::Event& evt,
       } else if (timealgo_ == weightsMethod) {
         //  weights method on the PU subtracted pulse shape
         std::vector<double> amplitudes;
+        amplitudes.reserve(activeBX.size());
         for (unsigned int ibx = 0; ibx < activeBX.size(); ++ibx)
           amplitudes.push_back(uncalibRecHit.outOfTimeAmplitude(ibx));
 

--- a/RecoLocalCalo/HcalLaserReco/src/HcalLaserUnpacker.cc
+++ b/RecoLocalCalo/HcalLaserReco/src/HcalLaserUnpacker.cc
@@ -22,6 +22,7 @@ void HcalLaserUnpacker::unpack(const FEDRawData& raw, HcalLaserDigi& digi) const
 
   // first, we do the QADC
   std::vector<uint16_t> qadcvals;
+  qadcvals.reserve(qdctdc->n_qdc_hits);
   for (unsigned int i = 0; i < qdctdc->n_qdc_hits; i++) {
     qadcvals.push_back(qdctdc->qdc_values[i] & 0xFFF);
   }

--- a/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.cc
+++ b/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.cc
@@ -1559,7 +1559,7 @@ TrajectoryStateOnSurface CSCEfficiency::propagate(FreeTrajectoryState &ftsStart,
 //
 bool CSCEfficiency::applyTrigger(edm::Handle<edm::TriggerResults> &hltR, const edm::TriggerNames &triggerNames) {
   bool triggerPassed = true;
-  std::vector<std::string> hlNames = triggerNames.triggerNames();
+  const std::vector<std::string> &hlNames = triggerNames.triggerNames();
   pointToTriggers.clear();
   for (size_t imyT = 0; imyT < myTriggers.size(); ++imyT) {
     for (size_t iT = 0; iT < hlNames.size(); ++iT) {

--- a/RecoLocalMuon/DTSegment/src/DTCombinatorialPatternReco4D.cc
+++ b/RecoLocalMuon/DTSegment/src/DTCombinatorialPatternReco4D.cc
@@ -297,7 +297,7 @@ DTRecSegment4D* DTCombinatorialPatternReco4D::segmentSpecialZed(const DTRecSegme
 
   // pick up a hit "in the middle", where the single hit will be put.
   int nHits = hits.size();
-  DTRecHit1D middle = hits[static_cast<int>(nHits / 2.)];
+  const DTRecHit1D& middle = hits[static_cast<int>(nHits / 2.)];
 
   // Need to extrapolate pos to the middle layer z
   LocalPoint posInSL = zedSeg->localPosition();

--- a/RecoLuminosity/LumiProducer/plugins/CMSRunSummary2DB.cc
+++ b/RecoLuminosity/LumiProducer/plugins/CMSRunSummary2DB.cc
@@ -85,7 +85,7 @@ namespace lumi {
       std::string fillnum = record[0];
       if (fillnum == result.fillnumber) {
         result.fillscheme = record[1];
-        std::string ncollidingbunchesStr = record[2];
+        const std::string& ncollidingbunchesStr = record[2];
         result.ncollidingbunches = str2int(ncollidingbunchesStr);
         break;
       }

--- a/RecoMET/METPUSubtraction/src/PFMETAlgorithmMVA.cc
+++ b/RecoMET/METPUSubtraction/src/PFMETAlgorithmMVA.cc
@@ -84,6 +84,7 @@ const GBRForest* PFMETAlgorithmMVA::loadMVAfromFile(const edm::FileInPath& input
   }
 
   std::vector<std::string> variableNames;
+  variableNames.reserve(lVec->size());
   for (unsigned int i = 0; i < lVec->size(); ++i) {
     variableNames.push_back(updateVariableNames(lVec->at(i)));
   }

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -1410,9 +1410,9 @@ void MuonIdProducer::fillMuonIsolation(edm::Event& iEvent,
     return;
   }
 
-  reco::IsoDeposit depEcal = caloDeps.at(0);
-  reco::IsoDeposit depHcal = caloDeps.at(1);
-  reco::IsoDeposit depHo = caloDeps.at(2);
+  const reco::IsoDeposit& depEcal = caloDeps.at(0);
+  const reco::IsoDeposit& depHcal = caloDeps.at(1);
+  const reco::IsoDeposit& depHo = caloDeps.at(2);
 
   //no need to copy outside if we don't write them
   if (writeIsoDeposits_) {

--- a/RecoMuon/MuonSeedGenerator/src/RPCSeedGenerator.cc
+++ b/RecoMuon/MuonSeedGenerator/src/RPCSeedGenerator.cc
@@ -190,14 +190,14 @@ void RPCSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
   MuonDetLayerGeometry const& muonLayers = iSetup.getData(muonLayersToken);
 
   // Get the RPC layers
-  vector<const DetLayer*> RPCBarrelLayers = muonLayers.barrelRPCLayers();
+  const vector<const DetLayer*>& RPCBarrelLayers = muonLayers.barrelRPCLayers();
   const DetLayer* RB4L = RPCBarrelLayers[5];
   const DetLayer* RB3L = RPCBarrelLayers[4];
   const DetLayer* RB22L = RPCBarrelLayers[3];
   const DetLayer* RB21L = RPCBarrelLayers[2];
   const DetLayer* RB12L = RPCBarrelLayers[1];
   const DetLayer* RB11L = RPCBarrelLayers[0];
-  vector<const DetLayer*> RPCEndcapLayers = muonLayers.endcapRPCLayers();
+  const vector<const DetLayer*>& RPCEndcapLayers = muonLayers.endcapRPCLayers();
   const DetLayer* REM3L = RPCEndcapLayers[0];
   const DetLayer* REM2L = RPCEndcapLayers[1];
   const DetLayer* REM1L = RPCEndcapLayers[2];

--- a/RecoMuon/TrackingTools/src/MuonTrajectoryUpdator.cc
+++ b/RecoMuon/TrackingTools/src/MuonTrajectoryUpdator.cc
@@ -101,7 +101,7 @@ pair<bool, TrajectoryStateOnSurface> MuonTrajectoryUpdator::update(const Traject
   const DetLayer* detLayer = measurement->layer();
 
   // these are the 4D segment for the CSC/DT and a point for the RPC
-  TransientTrackingRecHit::ConstRecHitPointer muonRecHit = measurement->recHit();
+  const TransientTrackingRecHit::ConstRecHitPointer& muonRecHit = measurement->recHit();
 
   // The KFUpdator takes TransientTrackingRecHits as arg.
   TransientTrackingRecHit::ConstRecHitContainer recHitsForFit =

--- a/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
+++ b/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
@@ -100,6 +100,7 @@ CTPPSPixelLocalTrackProducer::CTPPSPixelLocalTrackProducer(const edm::ParameterS
   }
 
   std::vector<uint32_t> listOfAllPlanes;
+  listOfAllPlanes.reserve(numberOfPlanesPerPot_);
   for (uint32_t i = 0; i < numberOfPlanesPerPot_; ++i) {
     listOfAllPlanes.push_back(i);
   }

--- a/RecoPPS/Local/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoPPS/Local/src/RPixPlaneCombinatoryTracking.cc
@@ -648,7 +648,7 @@ bool RPixPlaneCombinatoryTracking::calculatePointOnDetector(CTPPSPixelLocalTrack
                                                             CTPPSPixelDetId planeId,
                                                             GlobalPoint &planeLineIntercept) {
   double z0 = track->z0();
-  CTPPSPixelLocalTrack::ParameterVector parameters = track->parameterVector();
+  const CTPPSPixelLocalTrack::ParameterVector &parameters = track->parameterVector();
 
   math::Vector<3>::type pointOnLine(parameters[0], parameters[1], z0);
   GlobalVector tmpLineUnitVector = track->directionVector();

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
@@ -59,6 +59,7 @@ public:
       logWeightDenom.push_back(conf.getParameter<double>("logWeightDenominator"));
     }
 
+    logWeightDenomInv.reserve(depths.size());
     for (unsigned int i = 0; i < depths.size(); ++i) {
       logWeightDenomInv.push_back(1. / logWeightDenom[i]);
     }

--- a/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.cc
@@ -78,6 +78,7 @@ LocalMaximumSeedFinder::LocalMaximumSeedFinder(const edm::ParameterSet& conf)
       thresh_pT.push_back(pset.getParameter<double>("seedingThresholdPt"));
     }
 
+    thresh_pT2.reserve(thresh_pT.size());
     for (unsigned int i = 0; i < thresh_pT.size(); ++i) {
       thresh_pT2.push_back(thresh_pT[i] * thresh_pT[i]);
     }

--- a/RecoParticleFlow/PFProducer/src/MLPFModel.cc
+++ b/RecoParticleFlow/PFProducer/src/MLPFModel.cc
@@ -66,7 +66,7 @@ namespace reco::mlpf {
       charge = ref->charge();
       num_hits = ref->recHitsSize();
 
-      reco::MuonRef muonRef = orig.muonRef();
+      const reco::MuonRef& muonRef = orig.muonRef();
       if (muonRef.isNonnull()) {
         reco::TrackRef standAloneMu = muonRef->standAloneMuon();
         if (standAloneMu.isNonnull()) {

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -790,7 +790,7 @@ bool PFEGammaAlgo::unwrapSuperCluster(const PFSCElement* thesc,
                                                  << " This is a bug we should fix this!" << std::endl;
     return false;
   }
-  reco::SuperClusterRef scref = thesc->superClusterRef();
+  const reco::SuperClusterRef& scref = thesc->superClusterRef();
   const bool is_pf_sc = thesc->fromPFSuperCluster();
   if (!(scref.isAvailable() && scref.isNonnull())) {
     throw cms::Exception("PFEGammaAlgo::unwrapSuperCluster()")

--- a/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
@@ -829,6 +829,7 @@ std::pair<double, double> PFMuonAlgo::getMinMaxMET2(const reco::PFCandidate& pfc
   double METXNO = METX_ - pfc.px();
   double METYNO = METY_ - pfc.py();
   std::vector<double> met2;
+  met2.reserve(tracks.size());
   for (unsigned int i = 0; i < tracks.size(); ++i) {
     met2.push_back(pow(METXNO + tracks.at(i).first->px(), 2) + pow(METYNO + tracks.at(i).first->py(), 2));
   }

--- a/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
@@ -869,8 +869,8 @@ bool PFElecTkProducer::resolveGsfTracks(const vector<reco::GsfPFRecTrack>& GsfPF
 float PFElecTkProducer::minTangDist(const reco::GsfPFRecTrack& primGsf, const reco::GsfPFRecTrack& secGsf) {
   float minDphi = 1000.;
 
-  std::vector<reco::PFBrem> primPFBrem = primGsf.PFRecBrem();
-  std::vector<reco::PFBrem> secPFBrem = secGsf.PFRecBrem();
+  const std::vector<reco::PFBrem>& primPFBrem = primGsf.PFRecBrem();
+  const std::vector<reco::PFBrem>& secPFBrem = secGsf.PFRecBrem();
 
   unsigned int cbrem = 0;
   for (unsigned isbrem = 0; isbrem < secPFBrem.size(); isbrem++) {
@@ -994,7 +994,7 @@ bool PFElecTkProducer::isSharingEcalEnergyWithEgSC(const reco::GsfPFRecTrack& nG
         }
         // check if it touch the Brem-tangents
         else {
-          vector<PFBrem> primPFBrem = gsfPfTrack.PFRecBrem();
+          const vector<PFBrem>& primPFBrem = gsfPfTrack.PFRecBrem();
           for (unsigned ipbrem = 0; ipbrem < primPFBrem.size(); ipbrem++) {
             if (primPFBrem[ipbrem].indTrajPoint() == 99)
               continue;
@@ -1081,7 +1081,7 @@ bool PFElecTkProducer::isSharingEcalEnergyWithEgSC(const reco::GsfPFRecTrack& nG
           iPFCluster.push_back(clust);
           iEnergy += clust.energy();
         } else {
-          vector<PFBrem> primPFBrem = iGsfPFRecTrack.PFRecBrem();
+          const vector<PFBrem>& primPFBrem = iGsfPFRecTrack.PFRecBrem();
           for (unsigned ipbrem = 0; ipbrem < primPFBrem.size(); ipbrem++) {
             if (primPFBrem[ipbrem].indTrajPoint() == 99)
               continue;

--- a/RecoParticleFlow/PFTracking/src/ConvBremPFTrackFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/ConvBremPFTrackFinder.cc
@@ -57,7 +57,7 @@ void ConvBremPFTrackFinder::runConvBremFinder(const Handle<PFRecTrackCollection>
   float refGsfPtMode = refGsf->ptMode();
 
   const reco::PFRecTrackRef& pfTrackRef = gsfpfrectk.kfPFRecTrackRef();
-  vector<PFBrem> primPFBrem = gsfpfrectk.PFRecBrem();
+  const vector<PFBrem>& primPFBrem = gsfpfrectk.PFRecBrem();
 
   const PFRecTrackCollection& PfRTkColl = *(thePfRecTrackCol.product());
   reco::PFRecTrackCollection::const_iterator pft = PfRTkColl.begin();

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
@@ -659,8 +659,8 @@ reco::PFDisplacedVertex::VertexTrackType PFDisplacedVertexFinder::getVertexTrack
 }
 
 unsigned PFDisplacedVertexFinder::commonTracks(const PFDisplacedVertex& v1, const PFDisplacedVertex& v2) const {
-  vector<Track> vt1 = v1.refittedTracks();
-  vector<Track> vt2 = v2.refittedTracks();
+  const vector<Track>& vt1 = v1.refittedTracks();
+  const vector<Track>& vt2 = v2.refittedTracks();
 
   unsigned commonTracks = 0;
 

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexHelper.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexHelper.cc
@@ -214,13 +214,13 @@ reco::PFDisplacedVertex::VertexType PFDisplacedVertexHelper::identifyVertex(cons
 int PFDisplacedVertexHelper::lambdaCP(const PFDisplacedVertex& v) const {
   int lambdaCP = 0;
 
-  vector<Track> refittedTracks = v.refittedTracks();
+  const vector<Track>& refittedTracks = v.refittedTracks();
 
   math::XYZTLorentzVector totalMomentumDcaRefit_lambda;
   math::XYZTLorentzVector totalMomentumDcaRefit_lambdabar;
 
-  reco::Track tMomentumDcaRefit_0 = refittedTracks[0];
-  reco::Track tMomentumDcaRefit_1 = refittedTracks[1];
+  const reco::Track& tMomentumDcaRefit_0 = refittedTracks[0];
+  const reco::Track& tMomentumDcaRefit_1 = refittedTracks[1];
 
   double mass2_0 = 0, mass2_1 = 0;
 

--- a/RecoParticleFlow/PFTracking/src/PFTrackTransformer.cc
+++ b/RecoParticleFlow/PFTracking/src/PFTrackTransformer.cc
@@ -95,7 +95,7 @@ bool PFTrackTransformer::addPoints(reco::PFRecTrack& pftrack,
 
   if (!onlyprop_) {
     bool direction = (traj.direction() == alongMomentum);
-    vector<TrajectoryMeasurement> measurements = traj.measurements();
+    const vector<TrajectoryMeasurement>& measurements = traj.measurements();
     int iTrajFirst = (direction) ? 0 : measurements.size() - 1;
     int increment = (direction) ? +1 : -1;
     int iTrajLast = (direction) ? int(measurements.size()) : -1;
@@ -239,7 +239,7 @@ bool PFTrackTransformer::addPointsAndBrems(reco::GsfPFRecTrack& pftrack,
   // Trajectory for each trajectory point
 
   bool direction = (traj.direction() == alongMomentum);
-  vector<TrajectoryMeasurement> measurements = traj.measurements();
+  const vector<TrajectoryMeasurement>& measurements = traj.measurements();
   int iTrajFirst = (direction) ? 0 : measurements.size() - 1;
   int increment = (direction) ? +1 : -1;
   int iTrajLast = (direction) ? int(measurements.size()) : -1;

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
@@ -148,7 +148,7 @@ namespace reco {
       for (size_t candId = 0; candId < numCands; ++candId) {
         if ((!candFlags[candId]) &&
             candIdsCurrentStrip.find(candId) == candIdsCurrentStrip.end()) {  // do not include same cand twice
-          reco::CandidatePtr cand = cands[candId];
+          const reco::CandidatePtr& cand = cands[candId];
           if (fabs(strip.eta() - cand->eta()) <
                   etaAssociationDistance_ &&  // check if cand is within eta-phi window centered on strip
               fabs(strip.phi() - cand->phi()) < phiAssociationDistance_) {

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin3.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin3.cc
@@ -169,7 +169,7 @@ namespace reco {
       for (size_t candId = 0; candId < numCands; ++candId) {
         if ((!candFlags[candId]) &&
             candIdsCurrentStrip.find(candId) == candIdsCurrentStrip.end()) {  // do not include same cand twice
-          reco::CandidatePtr cand = cands[candId];
+          const reco::CandidatePtr& cand = cands[candId];
           double etaAssociationDistance_value =
               etaAssociationDistance_->Eval(strip.pt()) + etaAssociationDistance_->Eval(cand->pt());
           double phiAssociationDistance_value =

--- a/RecoTracker/DeDx/src/DeDxTools.cc
+++ b/RecoTracker/DeDx/src/DeDxTools.cc
@@ -432,7 +432,7 @@ namespace deDxTools {
     LocalPoint HitLocalPos = trajState.localPosition();
     LocalError HitLocalError = trajState.localError().positionError();
 
-    const BoundPlane plane = it->surface();
+    const BoundPlane& plane = it->surface();
     const TrapezoidalPlaneBounds* trapezoidalBounds(dynamic_cast<const TrapezoidalPlaneBounds*>(&(plane.bounds())));
     const RectangularPlaneBounds* rectangularBounds(dynamic_cast<const RectangularPlaneBounds*>(&(plane.bounds())));
 

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
@@ -572,7 +572,7 @@ namespace reco {
     }
 
     bool TrackerTrackHitFilter::isFirstValidHitInLayer(const reco::Track &tk, std::vector<bool> isNotValidVec) {
-      reco::HitPattern hp = tk.hitPattern();
+      const reco::HitPattern &hp = tk.hitPattern();
 
       int vecSize = static_cast<int>(isNotValidVec.size());
       // If hit is not valid, it will not count as a tracker layer with measurement -> don't increase sequLayers

--- a/RecoTracker/PixelTrackFitting/src/PixelTrackBuilder.cc
+++ b/RecoTracker/PixelTrackFitting/src/PixelTrackBuilder.cc
@@ -70,7 +70,7 @@ namespace {
     float phi_v = state.globalMomentum().phi();
     float theta_v = state.globalMomentum().theta();
 
-    CurvilinearTrajectoryError curv = state.curvilinearError();
+    const CurvilinearTrajectoryError& curv = state.curvilinearError();
     float errPhi2 = curv.matrix()(3, 3);
     float errLambda2 = curv.matrix()(2, 2);
     float errInvP2 = curv.matrix()(1, 1);

--- a/RecoTracker/SingleTrackPattern/src/CRackTrajectoryBuilder.cc
+++ b/RecoTracker/SingleTrackPattern/src/CRackTrajectoryBuilder.cc
@@ -794,7 +794,7 @@ std::pair<TrajectoryStateOnSurface, const GeomDet*> CRackTrajectoryBuilder::inne
   if (nhits < lastFitted + 1)
     lastFitted = nhits - 1;
 
-  std::vector<TrajectoryMeasurement> measvec = traj.measurements();
+  const std::vector<TrajectoryMeasurement>& measvec = traj.measurements();
   TransientTrackingRecHit::ConstRecHitContainer firstHits;
 
   bool foundLast = false;

--- a/RecoTracker/SpecialSeedGenerators/src/SeedFromGenericPairOrTriplet.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/SeedFromGenericPairOrTriplet.cc
@@ -295,6 +295,7 @@ bool SeedFromGenericPairOrTriplet::qualityFilter(const SeedingHitSet& hits) cons
     if (hits.size() == 3) {
       std::vector<GlobalPoint> gPoints;
       unsigned int nHits = hits.size();
+      gPoints.reserve(nHits);
       for (unsigned int iHit = 0; iHit < nHits; ++iHit)
         gPoints.push_back(hits[iHit]->globalPosition());
       unsigned int subid = (*hits[0]).geographicalId().subdetId();

--- a/RecoTracker/TkDetLayers/src/PixelBarrelLayerBuilder.cc
+++ b/RecoTracker/TkDetLayers/src/PixelBarrelLayerBuilder.cc
@@ -9,7 +9,7 @@ PixelBarrelLayer* PixelBarrelLayerBuilder::build(const GeometricDet* aPixelBarre
   // This builder is very similar to TOBLayer one. Most of the code should be put in a
   // common place.
 
-  vector<const GeometricDet*> theGeometricDetRods = aPixelBarrelLayer->components();
+  const vector<const GeometricDet*>& theGeometricDetRods = aPixelBarrelLayer->components();
   //edm::LogInfo(TkDetLayers) << "theGeometricDetRods has size: " << theGeometricDetRods.size() ;
 
   PixelRodBuilder myPixelRodBuilder;

--- a/RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc
@@ -250,7 +250,7 @@ void DeepCoreSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& i
           }
         }  //end of TensorFlow tensors init
 
-        GlobalVector bigClustDir = splitClustDirSet[cc];
+        const GlobalVector& bigClustDir = splitClustDirSet[cc];
 
         jetEta_ = jet.eta();
         jetPt_ = jet.pt();

--- a/RecoTracker/TrackProducer/src/DAFTrackProducerAlgorithm.cc
+++ b/RecoTracker/TrackProducer/src/DAFTrackProducerAlgorithm.cc
@@ -396,7 +396,7 @@ float DAFTrackProducerAlgorithm::calculateNdof(const Trajectory vtraj) const {
 //------------------------------------------------------------------------------------------------
 int DAFTrackProducerAlgorithm::checkHits(Trajectory iInitTraj, const Trajectory iFinalTraj) const {
   std::vector<TrajectoryMeasurement> initmeasurements = iInitTraj.measurements();
-  std::vector<TrajectoryMeasurement> finalmeasurements = iFinalTraj.measurements();
+  const std::vector<TrajectoryMeasurement>& finalmeasurements = iFinalTraj.measurements();
   std::vector<TrajectoryMeasurement>::iterator jmeas;
   int nSame = 0;
   int ihit = 0;
@@ -419,7 +419,7 @@ int DAFTrackProducerAlgorithm::checkHits(Trajectory iInitTraj, const Trajectory 
       continue;
 
     if (initHit->isValid()) {
-      TrajectoryMeasurement imeas = finalmeasurements.at(ihit);
+      const TrajectoryMeasurement& imeas = finalmeasurements.at(ihit);
       const TrackingRecHit* finalHit = imeas.recHit()->hit();
       const TrackingRecHit* MaxWeightHit = nullptr;
       float maxweight = 0;
@@ -458,7 +458,7 @@ int DAFTrackProducerAlgorithm::checkHits(Trajectory iInitTraj, const Trajectory 
         }
       }
     } else {
-      TrajectoryMeasurement imeas = finalmeasurements.at(ihit);
+      const TrajectoryMeasurement& imeas = finalmeasurements.at(ihit);
       const TrackingRecHit* finalHit = imeas.recHit()->hit();
       if (!finalHit->isValid()) {
         nSame++;

--- a/RecoVertex/KinematicFit/plugins/KineExample.cc
+++ b/RecoVertex/KinematicFit/plugins/KineExample.cc
@@ -157,10 +157,10 @@ void KineExample::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
         else
           edm::LogPrint("KineExample") << "KVF fit Position: " << Vertex::Point(tv.position()) << "\n";
 
-        TransientTrack ttMuPlus = t_tks[0];
-        TransientTrack ttMuMinus = t_tks[1];
-        TransientTrack ttKPlus = t_tks[2];
-        TransientTrack ttKMinus = t_tks[3];
+        const TransientTrack& ttMuPlus = t_tks[0];
+        const TransientTrack& ttMuMinus = t_tks[1];
+        const TransientTrack& ttKPlus = t_tks[2];
+        const TransientTrack& ttKMinus = t_tks[3];
 
         //the final state muons and kaons from the Bs->J/PsiPhi->mumuKK decay
         //Creating a KinematicParticleFactory

--- a/RecoVertex/LinearizationPointFinders/src/CrossingPtBasedLinearizationPointFinder.cc
+++ b/RecoVertex/LinearizationPointFinders/src/CrossingPtBasedLinearizationPointFinder.cc
@@ -233,8 +233,8 @@ GlobalPoint CrossingPtBasedLinearizationPointFinder::getLinearizationPoint(
   bool dir = false;
 
   while (vgp.size() < ((unsigned int)(theNPairs))) {
-    reco::TransientTrack rt1 = goodtracks[t_first];
-    reco::TransientTrack rt2 = goodtracks[t_first + t_interval];
+    const reco::TransientTrack& rt1 = goodtracks[t_first];
+    const reco::TransientTrack& rt2 = goodtracks[t_first + t_interval];
     // std::cout << "Considering now: " << t_first << ", " << t_first+t_interval << std::endl;
     if (useMatrix) {
       PointAndDistance v(theMatrix->crossingPoint(rt1, rt2), theMatrix->distance(rt1, rt2));

--- a/RecoVertex/PrimaryVertexProducer/src/AdaptiveChisquarePrimaryVertexFitter.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/AdaptiveChisquarePrimaryVertexFitter.cc
@@ -515,6 +515,7 @@ TransientVertex AdaptiveChisquarePrimaryVertexFitter::refit(const TransientVerte
 
   // put the result into a transient vertex
   std::vector<std::pair<unsigned int, float>> vertex_track_weights;
+  vertex_track_weights.reserve(nt);
   for (unsigned int i = 0; i < nt; i++) {
     vertex_track_weights.emplace_back(i, tkweight_[i]);
   }

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -937,6 +937,7 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices_no_blocks(const vector<r
 vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<reco::TransientTrack>& tracks) const {
   vector<reco::TransientTrack> sorted_tracks;
   vector<pair<float, float>> vertices_tot;  // z, rho for each vertex
+  sorted_tracks.reserve(tracks.size());
   for (unsigned int i = 0; i < tracks.size(); i++) {
     sorted_tracks.push_back(tracks[i]);
   }

--- a/TrackingTools/TrackRefitter/src/TrackTransformerForGlobalCosmicMuons.cc
+++ b/TrackingTools/TrackRefitter/src/TrackTransformerForGlobalCosmicMuons.cc
@@ -227,7 +227,7 @@ vector<Trajectory> TrackTransformerForGlobalCosmicMuons::transform(const reco::T
     return vector<Trajectory>();
   }
 
-  Trajectory trajectoryBW = trajectories.front();
+  const Trajectory& trajectoryBW = trajectories.front();
 
   vector<Trajectory> trajectoriesSM = smoother(up)->trajectories(trajectoryBW);
 

--- a/TrackingTools/TrajectoryState/src/PerigeeConversions.cc
+++ b/TrackingTools/TrajectoryState/src/PerigeeConversions.cc
@@ -62,7 +62,7 @@ CurvilinearTrajectoryError PerigeeConversions::curvilinearError(const PerigeeTra
 
 GlobalPoint PerigeeConversions::positionFromPerigee(const PerigeeTrajectoryParameters& parameters,
                                                     const GlobalPoint& referencePoint) {
-  AlgebraicVector5 theVector = parameters.vector();
+  const AlgebraicVector5& theVector = parameters.vector();
   return GlobalPoint(theVector[3] * vdt::fast_sin(theVector[2]) + referencePoint.x(),
                      -theVector[3] * vdt::fast_cos(theVector[2]) + referencePoint.y(),
                      theVector[4] + referencePoint.z());


### PR DESCRIPTION
This PR suggests to apply the `clang-tidy` changes proposed by LLVM21 ( from CLANG_X IB). 