### PR TITLE
[L1] [LLVM21] Apply clang-tidy changes

### DIFF
--- a/DataFormats/L1GlobalTrigger/src/L1GtfeExtWord.cc
+++ b/DataFormats/L1GlobalTrigger/src/L1GtfeExtWord.cc
@@ -73,7 +73,7 @@ L1GtfeExtWord::~L1GtfeExtWord() {
 bool L1GtfeExtWord::operator==(const L1GtfeExtWord& result) const {
   // base class
 
-  const L1GtfeWord gtfeResult = result;
+  const L1GtfeWord& gtfeResult = result;
   const L1GtfeWord gtfeThis = *this;
 
   if (gtfeThis != gtfeResult) {

--- a/EventFilter/L1TRawToDigi/plugins/OmtfUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/OmtfUnpacker.cc
@@ -281,7 +281,7 @@ namespace omtf {
       // loop over AMC's
       //
       unsigned int blockNum = 0;
-      for (auto amc : packetAmc13.payload()) {
+      for (const auto& amc : packetAmc13.payload()) {
         amc::BlockHeader bh = amc.blockHeader();
         if (debug) {
           std::ostringstream str;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockCounters.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockCounters.cc
@@ -32,7 +32,7 @@ namespace l1t {
     namespace emtf {
 
       int CountersBlockUnpacker::checkFormat(const Block& block) {
-        auto payload = block.payload();
+        const auto& payload = block.payload();
         int errors = 0;
 
         //Check the number of 16-bit words
@@ -91,7 +91,7 @@ namespace l1t {
         // Get the payload for this block, made up of 16-bit words (0xffff)
         // Format defined in MTF7Payload::getBlock() in src/Block.cc
         // payload[0] = bits 0-15, payload[1] = 16-31, payload[3] = 32-47, etc.
-        auto payload = block.payload();
+        const auto& payload = block.payload();
 
         // Check Format of Payload
         l1t::emtf::Counters Counters_;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockGEM.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockGEM.cc
@@ -31,7 +31,7 @@ namespace l1t {
     namespace emtf {
 
       int GEMBlockUnpacker::checkFormat(const Block& block) {
-        auto payload = block.payload();
+        const auto& payload = block.payload();
         int errors = 0;
 
         // Check the number of 16-bit words
@@ -125,7 +125,7 @@ namespace l1t {
         // Get the payload for this block, made up of 16-bit words (0xffff)
         // Format defined in MTF7Payload::getBlock() in src/Block.cc
         // payload[0] = bits 0-15, payload[1] = 16-31, payload[3] = 32-47, etc.
-        auto payload = block.payload();
+        const auto& payload = block.payload();
 
         // Run 3 has a different EMTF DAQ output format since August 26th
         // Computed as (Year - 2000)*2^9 + Month*2^5 + Day (see Block.cc and EMTFBlockTrailers.cc)

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockHeaders.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockHeaders.cc
@@ -32,7 +32,7 @@ namespace l1t {
     namespace emtf {
 
       int HeadersBlockUnpacker::checkFormat(const Block& block) {
-        auto payload = block.payload();
+        const auto& payload = block.payload();
         int errors = 0;
 
         //Check the number of 16-bit words
@@ -163,7 +163,7 @@ namespace l1t {
         // Get the payload for this block, made up of 16-bit words (0xffff)
         // Format defined in MTF7Payload::getBlock() in src/Block.cc
         // payload[0] = bits 0-15, payload[1] = 16-31, payload[3] = 32-47, etc.
-        auto payload = block.payload();
+        const auto& payload = block.payload();
 
         // Check Format of Payload
         l1t::emtf::AMC13Header AMC13Header_;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
@@ -32,7 +32,7 @@ namespace l1t {
     namespace emtf {
 
       int MEBlockUnpacker::checkFormat(const Block& block) {
-        auto payload = block.payload();
+        const auto& payload = block.payload();
         int errors = 0;
 
         // Check the number of 16-bit words
@@ -151,7 +151,7 @@ namespace l1t {
         // Get the payload for this block, made up of 16-bit words (0xffff)
         // Format defined in MTF7Payload::getBlock() in src/Block.cc
         // payload[0] = bits 0-15, payload[1] = 16-31, payload[3] = 32-47, etc.
-        auto payload = block.payload();
+        const auto& payload = block.payload();
 
         // Assign payload to 16-bit words
         uint16_t MEa = payload[0];

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
@@ -33,7 +33,7 @@ namespace l1t {
     namespace emtf {
 
       int RPCBlockUnpacker::checkFormat(const Block& block) {
-        auto payload = block.payload();
+        const auto& payload = block.payload();
         int errors = 0;
 
         // Check the number of 16-bit words
@@ -119,7 +119,7 @@ namespace l1t {
         // Get the payload for this block, made up of 16-bit words (0xffff)
         // Format defined in MTF7Payload::getBlock() in src/Block.cc
         // payload[0] = bits 0-15, payload[1] = 16-31, payload[3] = 32-47, etc.
-        auto payload = block.payload();
+        const auto& payload = block.payload();
 
         // Run 3 has a different EMTF DAQ output format since August 26th
         // Computed as (Year - 2000)*2^9 + Month*2^5 + Day (see Block.cc and EMTFBlockTrailers.cc)

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
@@ -32,7 +32,7 @@ namespace l1t {
     namespace emtf {
 
       int SPBlockUnpacker::checkFormat(const Block& block) {
-        auto payload = block.payload();
+        const auto& payload = block.payload();
         int errors = 0;
 
         // Check the number of 16-bit words
@@ -174,7 +174,7 @@ namespace l1t {
         // Get the payload for this block, made up of 16-bit words (0xffff)
         // Format defined in MTF7Payload::getBlock() in src/Block.cc
         // payload[0] = bits 0-15, payload[1] = 16-31, payload[3] = 32-47, etc.
-        auto payload = block.payload();
+        const auto& payload = block.payload();
 
         // FW version is computed as (Year - 2000)*2^9 + Month*2^5 + Day (see Block.cc and EMTFBlockTrailers.cc)
         bool useNNBits_ = getAlgoVersion() >= 11098;   // FW versions >= 26.10.2021

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockTrailers.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockTrailers.cc
@@ -32,7 +32,7 @@ namespace l1t {
     namespace emtf {
 
       int TrailersBlockUnpacker::checkFormat(const Block& block) {
-        auto payload = block.payload();
+        const auto& payload = block.payload();
         int errors = 0;
 
         //Check the number of 16-bit words
@@ -128,7 +128,7 @@ namespace l1t {
         // Get the payload for this block, made up of 16-bit words (0xffff)
         // Format defined in MTF7Payload::getBlock() in src/Block.cc
         // payload[0] = bits 0-15, payload[1] = 16-31, payload[3] = 32-47, etc.
-        auto payload = block.payload();
+        const auto& payload = block.payload();
 
         // Check Format of Payload
         l1t::emtf::AMC13Trailer AMC13Trailer_;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/IntermediateMuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/IntermediateMuonUnpacker.cc
@@ -19,7 +19,7 @@ namespace l1t {
         return true;
       }
 
-      auto payload = block.payload();
+      const auto& payload = block.payload();
 
       int nBX, firstBX, lastBX;
       // Check if per BX zero suppression was enabled

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
@@ -18,7 +18,7 @@ namespace l1t {
         return true;
       }
 
-      auto payload = block.payload();
+      const auto& payload = block.payload();
 
       int nBX, firstBX, lastBX;
       // Check if per BX zero suppression was enabled

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
@@ -16,7 +16,7 @@ namespace l1t {
         return true;
       }
 
-      auto payload = block.payload();
+      const auto& payload = block.payload();
 
       int nBX, firstBX, lastBX;
       // Check if per BX zero suppression was enabled

--- a/EventFilter/L1TRawToDigi/src/AMC13Spec.cc
+++ b/EventFilter/L1TRawToDigi/src/AMC13Spec.cc
@@ -141,6 +141,7 @@ namespace amc13 {
       Header block_h(data++);
       std::vector<amc::BlockHeader> headers;
 
+      headers.reserve(block_h.getNumberOfAMCs());
       for (unsigned int i = 0; i < block_h.getNumberOfAMCs(); ++i)
         headers.push_back(amc::BlockHeader(data++));
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMatcher.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMatcher.cc
@@ -277,7 +277,7 @@ uint16_t CSCGEMMatcher::mitigatedSlopeByConsistency(const CSCCLCTDigi& clct,
   const bool isME1a(station_ == 1 and clct.getKeyStrip() > CSCConstants::MAX_HALF_STRIP_ME1B);
 
   // extract hit values from CLCT hit matrix
-  std::vector<std::vector<uint16_t>> CLCTHitMatrix = clct.getHits();
+  const std::vector<std::vector<uint16_t>>& CLCTHitMatrix = clct.getHits();
   int CLCTHits[6] = {-1, -1, -1, -1, -1, -1};
 
   for (unsigned layer = 0; layer < CLCTHitMatrix.size(); ++layer) {

--- a/L1Trigger/DTTriggerPhase2/src/LateralityCoarsedProvider.cc
+++ b/L1Trigger/DTTriggerPhase2/src/LateralityCoarsedProvider.cc
@@ -249,6 +249,7 @@ std::vector<std::vector<short>> LateralityCoarsedProvider::convertString(std::st
 
   for (size_t i = 0; i < chain.size(); i += 4) {
     std::vector<short> group;
+    group.reserve(4);
     for (size_t j = 0; j < 4; j++) {
       group.push_back(chain[i + j] - '0');  // Convert the character to integer
     }

--- a/L1Trigger/DTTriggerPhase2/src/MuonPathCorFitter.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MuonPathCorFitter.cc
@@ -407,6 +407,7 @@ void MuonPathCorFitter::fillLuts() {
     ifin2sl >> line;
 
     std::vector<int> myNumbers;
+    myNumbers.reserve(line.size());
     for (size_t i = 0; i < line.size(); i++) {
       // This converts the char into an int and pushes it into vec
       myNumbers.push_back(line[i] - '0');  // The digits will be in the same order as before

--- a/L1Trigger/DTTriggerPhase2/src/MuonPathSLFitter.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MuonPathSLFitter.cc
@@ -68,7 +68,7 @@ void MuonPathSLFitter::run(edm::Event &iEvent,
   // fit per SL (need to allow for multiple outputs for a single mpath)
   // for (auto &muonpath : muonpaths) {
   if (!muonpaths.empty()) {
-    auto muonpath = muonpaths[0];
+    const auto &muonpath = muonpaths[0];
     int rawId = muonpath->primitive(0)->cameraId();
     if (muonpath->primitive(0)->cameraId() == -1) {
       rawId = muonpath->primitive(1)->cameraId();
@@ -79,7 +79,7 @@ void MuonPathSLFitter::run(edm::Event &iEvent,
 
   for (size_t i = 0; i < muonpaths.size(); i++) {
     auto muonpath = muonpaths[i];
-    auto lats = lateralities[i];
+    const auto &lats = lateralities[i];
     analyze(muonpath, lats, metaPrimitives);
   }
 }
@@ -448,6 +448,7 @@ void MuonPathSLFitter::fillLuts() {
     ifinsl1 >> line;
 
     std::vector<int> myNumbers;
+    myNumbers.reserve(line.size());
     for (size_t i = 0; i < line.size(); i++) {
       // This converts the char into an int and pushes it into vec
       myNumbers.push_back(line[i] - '0');  // The digits will be in the same order as before
@@ -461,6 +462,7 @@ void MuonPathSLFitter::fillLuts() {
     ifinsl2 >> line;
 
     std::vector<int> myNumbers;
+    myNumbers.reserve(line.size());
     for (size_t i = 0; i < line.size(); i++) {
       // This converts the char into an int and pushes it into vec
       myNumbers.push_back(line[i] - '0');  // The digits will be in the same order as before
@@ -474,6 +476,7 @@ void MuonPathSLFitter::fillLuts() {
     ifinsl3 >> line;
 
     std::vector<int> myNumbers;
+    myNumbers.reserve(line.size());
     for (size_t i = 0; i < line.size(); i++) {
       // This converts the char into an int and pushes it into vec
       myNumbers.push_back(line[i] - '0');  // The digits will be in the same order as before

--- a/L1Trigger/L1CaloTrigger/plugins/L1NNCaloTauEmulator.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/L1NNCaloTauEmulator.cc
@@ -789,7 +789,7 @@ void L1NNCaloTauEmulator::produce(edm::Event& iEvent, const edm::EventSetup& eSe
 
   for (int clNxMIdx = 0; clNxMIdx < Nclusters_CE; clNxMIdx++) {
     // Indexing of cl3ds is the same as the one of clNxMs
-    InputHGCluster HGClu = HGClusters[clNxMIdx];
+    const InputHGCluster& HGClu = HGClusters[clNxMIdx];
 
     // Fill inputs for Tensorflow inference
     for (int eta = 0; eta < IEta_dim; ++eta) {

--- a/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.cc
+++ b/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.cc
@@ -27,15 +27,15 @@
 using namespace l1tcalo;
 
 bool L1TCaloLayer1FetchLUTs(
-    const L1TCaloLayer1FetchLUTsTokens &iTokens,
-    const edm::EventSetup &iSetup,
-    std::vector<std::array<std::array<std::array<uint32_t, nEtBins>, nCalSideBins>, nCalEtaBins> > &eLUT,
-    std::vector<std::array<std::array<std::array<uint32_t, nEtBins>, nCalSideBins>, nCalEtaBins> > &hLUT,
-    std::vector<std::array<std::array<uint32_t, nEtBins>, nHfEtaBins> > &hfLUT,
-    std::vector<unsigned long long int> &hcalFBLUT,
-    std::vector<unsigned int> &ePhiMap,
-    std::vector<unsigned int> &hPhiMap,
-    std::vector<unsigned int> &hfPhiMap,
+    const L1TCaloLayer1FetchLUTsTokens& iTokens,
+    const edm::EventSetup& iSetup,
+    std::vector<std::array<std::array<std::array<uint32_t, nEtBins>, nCalSideBins>, nCalEtaBins> >& eLUT,
+    std::vector<std::array<std::array<std::array<uint32_t, nEtBins>, nCalSideBins>, nCalEtaBins> >& hLUT,
+    std::vector<std::array<std::array<uint32_t, nEtBins>, nHfEtaBins> >& hfLUT,
+    std::vector<unsigned long long int>& hcalFBLUT,
+    std::vector<unsigned int>& ePhiMap,
+    std::vector<unsigned int>& hPhiMap,
+    std::vector<unsigned int>& hfPhiMap,
     bool useLSB,
     bool useCalib,
     bool useECALLUT,
@@ -44,7 +44,7 @@ bool L1TCaloLayer1FetchLUTs(
     bool useHCALFBLUT,
     int fwVersion) {
   int hfValid = 1;
-  const HcalTrigTowerGeometry &pG = iSetup.getData(iTokens.geom_);
+  const HcalTrigTowerGeometry& pG = iSetup.getData(iTokens.geom_);
   if (!pG.use1x1()) {
     edm::LogError("L1TCaloLayer1FetchLUTs")
         << "Using Stage2-Layer1 but HCAL Geometry has use1x1 = 0! HF will be suppressed.  Check Global Tag, etc.";
@@ -71,7 +71,7 @@ bool L1TCaloLayer1FetchLUTs(
   //   etBin = size of Real ET Bins vector
   //   phiBin = max(Real Phi Bins vector)
   //   So, index = phiBin*etBin*28+etBin*28+ieta
-  auto ecalScaleETBins = caloParams.layer1ECalScaleETBins();
+  const auto& ecalScaleETBins = caloParams.layer1ECalScaleETBins();
   auto ecalScalePhiBins = caloParams.layer1ECalScalePhiBins();
   if (ecalScalePhiBins.empty()) {
     // Backwards-compatibility (no phi binning)
@@ -81,14 +81,14 @@ bool L1TCaloLayer1FetchLUTs(
     return false;
   }
   size_t numEcalPhiBins = (*std::max_element(ecalScalePhiBins.begin(), ecalScalePhiBins.end())) + 1;
-  auto ecalSF = caloParams.layer1ECalScaleFactors();
-  auto ecalZSF = caloParams.layer1ECalZSFactors();
+  const auto& ecalSF = caloParams.layer1ECalScaleFactors();
+  const auto& ecalZSF = caloParams.layer1ECalZSFactors();
   if (ecalSF.size() != ecalScaleETBins.size() * numEcalPhiBins * 28) {
     edm::LogError("L1TCaloLayer1FetchLUTs") << "caloParams.layer1ECalScaleFactors().size() != "
                                                "caloParams.layer1ECalScaleETBins().size()*numEcalPhiBins*28 !!";
     return false;
   }
-  auto hcalScaleETBins = caloParams.layer1HCalScaleETBins();
+  const auto& hcalScaleETBins = caloParams.layer1HCalScaleETBins();
   auto hcalScalePhiBins = caloParams.layer1HCalScalePhiBins();
   if (hcalScalePhiBins.empty()) {
     hcalScalePhiBins.resize(36, 0);
@@ -97,8 +97,8 @@ bool L1TCaloLayer1FetchLUTs(
     return false;
   }
   size_t numHcalPhiBins = (*std::max_element(hcalScalePhiBins.begin(), hcalScalePhiBins.end())) + 1;
-  auto hcalSF = caloParams.layer1HCalScaleFactors();
-  auto hcalZSF = caloParams.layer1HCalZSFactors();
+  const auto& hcalSF = caloParams.layer1HCalScaleFactors();
+  const auto& hcalZSF = caloParams.layer1HCalZSFactors();
   if (hcalSF.size() != hcalScaleETBins.size() * numHcalPhiBins * 28) {
     edm::LogError("L1TCaloLayer1FetchLUTs") << "caloParams.layer1HCalScaleFactors().size() != "
                                                "caloParams.layer1HCalScaleETBins().size()*numHcalPhiBins*28 !!";
@@ -110,7 +110,7 @@ bool L1TCaloLayer1FetchLUTs(
   //   etBin = size of Real ET Bins vector
   //   phiBin = max(Real Phi Bins vector)
   //   So, index = phiBin*etBin*12+etBin*12+ieta
-  auto hfScaleETBins = caloParams.layer1HFScaleETBins();
+  const auto& hfScaleETBins = caloParams.layer1HFScaleETBins();
   auto hfScalePhiBins = caloParams.layer1HFScalePhiBins();
   if (hfScalePhiBins.empty()) {
     hfScalePhiBins.resize(36, 0);
@@ -119,7 +119,7 @@ bool L1TCaloLayer1FetchLUTs(
     return false;
   }
   size_t numHFPhiBins = (*std::max_element(hfScalePhiBins.begin(), hfScalePhiBins.end())) + 1;
-  auto hfSF = caloParams.layer1HFScaleFactors();
+  const auto& hfSF = caloParams.layer1HFScaleFactors();
   if (hfSF.size() != hfScaleETBins.size() * numHFPhiBins * 12) {
     edm::LogError("L1TCaloLayer1FetchLUTs")
         << "caloParams.layer1HFScaleFactors().size() != caloParams.layer1HFScaleETBins().size()*numHFPhiBins*12 !!";
@@ -136,8 +136,8 @@ bool L1TCaloLayer1FetchLUTs(
   // HCAL FB LUT will be a 1*28 array:
   //   ieta = 28 eta scale factors (1 .. 28)
   //   So, index = ieta
-  auto fbLUTUpper = caloParams.layer1HCalFBLUTUpper();
-  auto fbLUTLower = caloParams.layer1HCalFBLUTLower();
+  const auto& fbLUTUpper = caloParams.layer1HCalFBLUTUpper();
+  const auto& fbLUTLower = caloParams.layer1HCalFBLUTLower();
   // Only check for HCAL FB LUT if useHCALFBLUT = true
   if (useHCALFBLUT) {
     if (fbLUTUpper.size() != nCalEtaBins) {

--- a/L1Trigger/L1TCalorimeter/src/HardwareSortingMethods.cc
+++ b/L1Trigger/L1TCalorimeter/src/HardwareSortingMethods.cc
@@ -544,8 +544,8 @@ namespace l1t {
         super_sort_matrix_rows(non_iso_stage2_row_sorted_matrix_sig, N_EGAMMA_SECOND_GROUP_SIZE, N_KEEP_EGAMMA);
 
     //Prepare output
-    std::vector<l1t::L1Candidate> sorted_iso_egammas = iso_stage2_super_sorted_matrix_sig[0];
-    std::vector<l1t::L1Candidate> sorted_noniso_egammas = non_iso_stage2_super_sorted_matrix_sig[0];
+    const std::vector<l1t::L1Candidate>& sorted_iso_egammas = iso_stage2_super_sorted_matrix_sig[0];
+    const std::vector<l1t::L1Candidate>& sorted_noniso_egammas = non_iso_stage2_super_sorted_matrix_sig[0];
 
     //verbose = false;
 

--- a/L1Trigger/L1TCalorimeter/src/PUSubtractionMethods.cc
+++ b/L1Trigger/L1TCalorimeter/src/PUSubtractionMethods.cc
@@ -69,7 +69,7 @@ namespace l1t {
   void RegionCorrection(const std::vector<l1t::CaloRegion> &regions,
                         std::vector<l1t::CaloRegion> *subRegions,
                         CaloParamsHelper const *params) {
-    std::string regionPUSType = params->regionPUSType();
+    const std::string &regionPUSType = params->regionPUSType();
 
     if (regionPUSType == "None") {
       for (std::vector<CaloRegion>::const_iterator notCorrectedRegion = regions.begin();

--- a/L1Trigger/L1TGEM/src/ME0StubAlgoPatUnit.cc
+++ b/L1Trigger/L1TGEM/src/ME0StubAlgoPatUnit.cc
@@ -17,7 +17,7 @@ std::pair<std::vector<double>, double> l1t::me0::calculateCentroids(
   std::vector<int> bxs;
   for (int ly = 0; ly < static_cast<int>(maskedData.size()); ++ly) {
     auto data = maskedData[ly];
-    auto bxData = partitionBxData[ly];
+    const auto& bxData = partitionBxData[ly];
     const auto temp = findCentroid(data);
     double curCentroid = temp.first;
     std::vector<int> hitsIndices = temp.second;

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosESProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosESProducer.cc
@@ -237,6 +237,7 @@ L1TGlobalPrescalesVetosESProducer::L1TGlobalPrescalesVetosESProducer(const edm::
 
   // veto mask
   // Setting veto mask to default 0 (no veto)
+  triggerVetoMasks.reserve(m_numberPhysTriggers);
   for (unsigned int iAlg = 0; iAlg < m_numberPhysTriggers; iAlg++)
     triggerVetoMasks.push_back(0);
 

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosFractESProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosFractESProducer.cc
@@ -237,6 +237,7 @@ L1TGlobalPrescalesVetosFractESProducer::L1TGlobalPrescalesVetosFractESProducer(c
 
   // veto mask
   // Setting veto mask to default 0 (no veto)
+  triggerVetoMasks.reserve(m_numberPhysTriggers);
   for (unsigned int iAlg = 0; iAlg < m_numberPhysTriggers; iAlg++)
     triggerVetoMasks.push_back(0);
 

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
@@ -30,6 +30,7 @@ public:
 
     /* create a persistent vector of pointers to the towerMaps */
     std::vector<edm::Ptr<l1t::HGCalTowerMap>> towerMapsPtrs;
+    towerMapsPtrs.reserve(towerMapCollHandle->size());
     for (unsigned i = 0; i < towerMapCollHandle->size(); ++i) {
       towerMapsPtrs.emplace_back(towerMapCollHandle, i);
     }

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor_SA.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor_SA.cc
@@ -26,6 +26,7 @@ public:
 
     /* create a persistent vector of pointers to the towerMaps */
     std::vector<edm::Ptr<l1t::HGCalTowerMap>> towerMapsPtrs;
+    towerMapsPtrs.reserve(towerMapCollHandle->size());
     for (unsigned i = 0; i < towerMapCollHandle->size(); ++i) {
       towerMapsPtrs.emplace_back(towerMapCollHandle, i);
     }

--- a/L1Trigger/L1TMuonOverlap/src/OMTFSorter.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFSorter.cc
@@ -12,12 +12,12 @@
 ///////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////
 AlgoMuon OMTFSorter::sortSingleResult(const OMTFResult& aResult) {
-  OMTFResult::vector1D pdfValsVec = aResult.getSummaryVals();
+  const OMTFResult::vector1D& pdfValsVec = aResult.getSummaryVals();
   OMTFResult::vector1D nHitsVec = aResult.getSummaryHits();
-  OMTFResult::vector1D refPhiVec = aResult.getRefPhis();
-  OMTFResult::vector1D refEtaVec = aResult.getRefEtas();
-  OMTFResult::vector1D hitsVec = aResult.getHitsWord();
-  OMTFResult::vector1D refPhiRHitVec = aResult.getRefPhiRHits();
+  const OMTFResult::vector1D& refPhiVec = aResult.getRefPhis();
+  const OMTFResult::vector1D& refEtaVec = aResult.getRefEtas();
+  const OMTFResult::vector1D& hitsVec = aResult.getHitsWord();
+  const OMTFResult::vector1D& refPhiRHitVec = aResult.getRefPhiRHits();
 
   assert(pdfValsVec.size() == nHitsVec.size());
 

--- a/L1Trigger/L1TMuonOverlap/src/XMLConfigWriter.cc
+++ b/L1Trigger/L1TMuonOverlap/src/XMLConfigWriter.cc
@@ -311,7 +311,7 @@ void XMLConfigWriter::writeResultsData(xercesc::DOMElement* aTopElement,
                                        unsigned int iRegion,
                                        const Key& aKey,
                                        const OMTFResult& aResult) {
-  OMTFResult::vector2D results = aResult.getResults();
+  const OMTFResult::vector2D& results = aResult.getResults();
 
   std::ostringstream stringStr;
   ///Write GP key parameters

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
@@ -190,8 +190,8 @@ void L1TrackJetEmulatorProducer::produce(Event &iEvent, const EventSetup &iSetup
   // logic: loop over z bins find tracks in this bin and arrange them in a 2D eta-phi matrix
   for (unsigned int zbin = 0; zbin < zmins.size(); ++zbin) {
     // initialize matrices for every z bin
-    z0_intern zmin = zmins[zbin];
-    z0_intern zmax = zmaxs[zbin];
+    const z0_intern &zmin = zmins[zbin];
+    const z0_intern &zmax = zmaxs[zbin];
 
     TrackJetEmulationEtaPhiBin epbins[phiBins_][etaBins_];
 

--- a/L1Trigger/L1TTrackMatch/src/pTFrom2Stubs.cc
+++ b/L1Trigger/L1TTrackMatch/src/pTFrom2Stubs.cc
@@ -23,7 +23,7 @@ namespace pTFrom2Stubs {
     //loop over L1Track's stubs
     int rsize = vecStubRefs.size();
     for (int j = 0; j < rsize; ++j) {
-      edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > stubRef =
+      const edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> >& stubRef =
           vecStubRefs.at(j);
       const TTStub<Ref_Phase2TrackerDigi_>* stub = &(*stubRef);
       MeasurementPoint localPos = stub->clusterRef(0)->findAverageLocalCoordinates();

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1HPSPFTauProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1HPSPFTauProducer.cc
@@ -76,12 +76,14 @@ void L1HPSPFTauProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::E
 
   //adding collection
   std::vector<edm::Ptr<l1t::PFCandidate>> particles;
+  particles.reserve((*l1PFCandidates).size());
   for (unsigned i = 0; i < (*l1PFCandidates).size(); i++) {
     particles.push_back(edm::Ptr<l1t::PFCandidate>(l1PFCandidates, i));
   }
 
   //get the jets
   std::vector<edm::Ptr<reco::CaloJet>> jets;
+  jets.reserve((*l1PFJets).size());
   for (unsigned int i = 0; i < (*l1PFJets).size(); i++) {
     jets.push_back(edm::Ptr<reco::CaloJet>(l1PFJets, i));
     //

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1SeedConePFJetProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1SeedConePFJetProducer.cc
@@ -80,6 +80,7 @@ void L1SeedConePFJetProducer::produce(edm::StreamID /*unused*/,
   edm::Handle<l1t::PFCandidateCollection> l1PFCandidates;
   iEvent.getByToken(l1PFToken, l1PFCandidates);
   std::vector<edm::Ptr<l1t::PFCandidate>> particles;
+  particles.reserve((*l1PFCandidates).size());
   for (unsigned i = 0; i < (*l1PFCandidates).size(); i++) {
     particles.push_back(edm::Ptr<l1t::PFCandidate>(l1PFCandidates, i));
   }

--- a/L1Trigger/Phase2L1ParticleFlow/src/pf/pfalgo2hgc_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/pf/pfalgo2hgc_ref.cpp
@@ -205,7 +205,7 @@ void l1ct::PFAlgo2HGCEmulator::run(const PFInputRegion& in, OutputRegion& out) c
   for (unsigned int ic = 0; ic < nCALO; ++ic) {
     if (calo_sumtk[ic] > 0) {
       pt_t ptdiff = in.hadcalo[ic].hwPt - calo_sumtk[ic];
-      pt2_t sigmamult =
+      const pt2_t& sigmamult =
           calo_sumtkErr2[ic];  //  + (calo_sumtkErr2[ic] >> 1)); // this multiplies by 1.5 = sqrt(1.5)^2 ~ (1.2)^2
       if (debug_ && (in.hadcalo[ic].hwPt > 0)) {
         dbgPrintf(

--- a/L1Trigger/Phase2L1ParticleFlow/src/pf/pfalgo3_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/pf/pfalgo3_ref.cpp
@@ -461,7 +461,7 @@ void l1ct::PFAlgo3Emulator::run(const PFInputRegion& in, OutputRegion& out) cons
   for (unsigned int ic = 0; ic < nCALO; ++ic) {
     if (calo_sumtk[ic] > 0) {
       dpt_t ptdiff = dpt_t(hadcalo_subem[ic].hwPt) - dpt_t(calo_sumtk[ic]);
-      pt2_t sigmamult = calo_sumtkErr2
+      const pt2_t& sigmamult = calo_sumtkErr2
           [ic];  // before we did (calo_sumtkErr2[ic] + (calo_sumtkErr2[ic] >> 1)); to multiply by 1.5 = sqrt(1.5)^2 ~ (1.2)^2
       if (debug_ && (hadcalo_subem[ic].hwPt > 0)) {
         dbgPrintf(

--- a/L1Trigger/TrackFindingTMTT/src/HTrphi.cc
+++ b/L1Trigger/TrackFindingTMTT/src/HTrphi.cc
@@ -166,6 +166,7 @@ namespace tmtt {
     cellCenters_.clear();
     for (unsigned int m = 0; m < nBinsQoverPtAxis_; m++) {
       std::vector<std::pair<float, float> > binCenters;
+      binCenters.reserve(nBinsPhiTrkAxis_);
       for (unsigned int c = 0; c < nBinsPhiTrkAxis_; c++)
         binCenters.push_back(this->helix2Dhough(m, c));
       cellCenters_.push_back(binCenters);

--- a/L1Trigger/TrackFindingTMTT/src/KFParamsComb.cc
+++ b/L1Trigger/TrackFindingTMTT/src/KFParamsComb.cc
@@ -185,7 +185,7 @@ namespace tmtt {
   /* Get physical helix params */
 
   TVectorD KFParamsComb::trackParams(const KalmanState* state) const {
-    TVectorD vecX = state->vectorX();
+    const TVectorD& vecX = state->vectorX();
     TVectorD vecY(nHelixPar_);
     vecY[QOVERPT] = 2. * vecX[INV2R] / settings_->invPtToInvR();
     vecY[PHI0] = reco::deltaPhi(vecX[PHI0] + sectorPhi(), 0.);

--- a/L1Trigger/TrackFindingTMTT/src/KFbase.cc
+++ b/L1Trigger/TrackFindingTMTT/src/KFbase.cc
@@ -407,8 +407,8 @@ namespace tmtt {
     numUpdateCalls_++;  // For monitoring, count calls to updator per track.
 
     // Helix params & their covariance.
-    TVectorD vecX = state->vectorX();
-    TMatrixD matC = state->matrixC();
+    const TVectorD &vecX = state->vectorX();
+    const TMatrixD &matC = state->matrixC();
     if (state->barrel() && !stub->barrel()) {
       if (settings_->kalmanDebugLevel() >= 4) {
         PrintL1trk() << "STATE BARREL TO ENDCAP BEFORE ";

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -340,9 +340,11 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
                 std::vector<const Stub*> stubsTrk2 = inputstublists_[rejetrk];
                 std::vector<unsigned int> stubsTrk1indices;
                 std::vector<unsigned int> stubsTrk2indices;
+                stubsTrk1indices.reserve(stubsTrk1.size());
                 for (unsigned int stub1it = 0; stub1it < stubsTrk1.size(); stub1it++) {
                   stubsTrk1indices.push_back(stubsTrk1[stub1it]->l1tstub()->uniqueIndex());
                 }
+                stubsTrk2indices.reserve(stubsTrk2.size());
                 for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
                   stubsTrk2indices.push_back(stubsTrk2[stub2it]->l1tstub()->uniqueIndex());
                 }

--- a/L1Trigger/TrackTrigger/src/TTStubAlgorithm_official.cc
+++ b/L1Trigger/TrackTrigger/src/TTStubAlgorithm_official.cc
@@ -169,6 +169,7 @@ float TTStubAlgorithm_official<Ref_Phase2TrackerDigi_>::degradeBend(bool psModul
     // Then you alternate large-small-large-small....large. In the middle, you
     // put either large or small, depending if group size is odd or not
 
+    groups.reserve(numLargeGroups / 2);
     for (unsigned int i = 0; i < numLargeGroups / 2; i++)
       groups.push_back(inLargeGroup);
     for (unsigned int i = 0; i < numSmallGroups / 2; i++)

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -285,7 +285,7 @@ namespace l1tVertexFinder {
         }
 
         if (removing) {
-          const L1Track badTrack = *badTrackIt;
+          const L1Track& badTrack = *badTrackIt;
           if (settings_->debug() > 2)
             edm::LogInfo("VertexFinder") << "PVR::Removing track " << badTrack.z0() << " at distance " << oldDistance;
           discardedTracks.push_back(badTrack);
@@ -321,13 +321,13 @@ namespace l1tVertexFinder {
       start = false;
       discardedTracks2.clear();
       FitTrackCollection::iterator it = discardedTracks.begin();
-      const L1Track track = *it;
+      const L1Track& track = *it;
       acceptedTracks.push_back(track);
       float z0sum = track.z0();
 
       for (FitTrackCollection::iterator it2 = discardedTracks.begin(); it2 < discardedTracks.end(); ++it2) {
         if (it2 != it) {
-          const L1Track secondTrack = *it2;
+          const L1Track& secondTrack = *it2;
           // Calculate new vertex z0 adding this track
           z0sum += secondTrack.z0();
           float z0vertex = z0sum / (acceptedTracks.size() + 1);
@@ -533,9 +533,9 @@ namespace l1tVertexFinder {
     out.push_back(std::string(intervalswidth + valueswidth + 2, ' ') + scale);
     out.push_back(capstone);
     for (int i = 0; i < tableSize; i++) {
-      std::string interval = intervals[i];
-      std::string value = values[i];
-      data_type x = data[i];
+      const std::string& interval = intervals[i];
+      const std::string& value = values[i];
+      const data_type& x = data[i];
       std::fill_n(line.begin(), plotwidth, ' ');
 
       int pos = std::round((float(x) - minimum) * norm);

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosOnlineProd.cc
@@ -224,7 +224,7 @@ std::unique_ptr<const L1TGlobalPrescalesVetosFract> L1TGlobalPrescalesVetosOnlin
             settings_prescale.at("prescales").getTableColumn<double>(col.first.c_str());
         for (unsigned int row = 0; row < prescalesForSet.size(); row++) {
           double prescale = prescalesForSet[row];
-          std::string algoName = algoNames[row];
+          const std::string &algoName = algoNames[row];
           unsigned int algoBit = algoName2bit[algoName];
           prescales[iSet][algoBit] = prescale;
         }
@@ -276,7 +276,7 @@ std::unique_ptr<const L1TGlobalPrescalesVetosFract> L1TGlobalPrescalesVetosOnlin
       triggerMasks.push_back(default_finor_mask);
 
     for (unsigned int row = 0; row < algo_mask_finor.size(); row++) {
-      std::string algoName = algo_mask_finor[row];
+      const std::string &algoName = algo_mask_finor[row];
       if (strcasecmp("all", algoName.c_str()) == 0)
         continue;
       unsigned int algoBit = algoName2bit[algoName];
@@ -328,7 +328,7 @@ std::unique_ptr<const L1TGlobalPrescalesVetosFract> L1TGlobalPrescalesVetosOnlin
       triggerVetoMasks.push_back(default_veto_mask);
 
     for (unsigned int row = 0; row < algo_mask_veto.size(); row++) {
-      std::string algoName = algo_mask_veto[row];
+      const std::string &algoName = algo_mask_veto[row];
       if (strcasecmp("all", algoName.c_str()) == 0)
         continue;
       unsigned int algoBit = algoName2bit[algoName];


### PR DESCRIPTION
This PR suggests to apply the `clang-tidy` changes proposed by LLVM21 ( from CLANG_X IB). 