### PR TITLE
[RECONSTRUCTION-XPOG] [LLVM21] Apply clang-tidy changes

### DIFF
--- a/DataFormats/PatCandidates/src/TriggerCondition.cc
+++ b/DataFormats/PatCandidates/src/TriggerCondition.cc
@@ -31,6 +31,7 @@ TriggerCondition::TriggerCondition(const std::string& name, bool accept)
 // Get the trigger object types
 std::vector<int> TriggerCondition::triggerObjectTypes() const {
   std::vector<int> triggerObjectTypes;
+  triggerObjectTypes.reserve(triggerObjectTypes_.size());
   for (size_t iT = 0; iT < triggerObjectTypes_.size(); ++iT) {
     triggerObjectTypes.push_back(int(triggerObjectTypes_.at(iT)));
   }

--- a/DataFormats/PatCandidates/src/TriggerFilter.cc
+++ b/DataFormats/PatCandidates/src/TriggerFilter.cc
@@ -40,6 +40,7 @@ bool TriggerFilter::setStatus(int status) {
 // Get all trigger object type identifiers
 std::vector<int> TriggerFilter::triggerObjectTypes() const {
   std::vector<int> triggerObjectTypes;
+  triggerObjectTypes.reserve(triggerObjectTypes_.size());
   for (size_t iTo = 0; iTo < triggerObjectTypes_.size(); ++iTo) {
     triggerObjectTypes.push_back(triggerObjectTypes_.at(iTo));
   }

--- a/DataFormats/PatCandidates/src/TriggerObject.cc
+++ b/DataFormats/PatCandidates/src/TriggerObject.cc
@@ -44,6 +44,7 @@ TriggerObject::TriggerObject(const reco::Particle::PolarLorentzVector& vec, int 
 // Get all trigger object type identifiers
 std::vector<int> TriggerObject::triggerObjectTypes() const {
   std::vector<int> triggerObjectTypes;
+  triggerObjectTypes.reserve(triggerObjectTypes_.size());
   for (size_t iTo = 0; iTo < triggerObjectTypes_.size(); ++iTo) {
     triggerObjectTypes.push_back(triggerObjectTypes_.at(iTo));
   }

--- a/PhysicsTools/PatAlgos/src/SoftMuonMvaRun3Estimator.cc
+++ b/PhysicsTools/PatAlgos/src/SoftMuonMvaRun3Estimator.cc
@@ -90,6 +90,7 @@ void fillMatchInfo(pat::XGBooster& booster, const pat::Muon& muon) {
   // Initiate containter for results
   const int n_stations = 2;
   std::vector<MatchPair> matches;
+  matches.reserve(n_stations);
   for (unsigned int i = 0; i < n_stations; ++i)
     matches.push_back(std::pair(nullptr, nullptr));
 


### PR DESCRIPTION
This PR suggests to apply the `clang-tidy` changes proposed by LLVM21 ( from CLANG_X IB). 