### PR TITLE
[DB-DQM] [LLVM21] Apply clang-tidy changes

### DIFF
--- a/CondFormats/DQMObjects/src/HDQMSummary.cc
+++ b/CondFormats/DQMObjects/src/HDQMSummary.cc
@@ -103,7 +103,7 @@ void HDQMSummary::setObj(const uint32_t& detID, std::string elementName, float v
 }
 
 std::vector<float> HDQMSummary::getSummaryObj(uint32_t& detID, const std::vector<std::string>& _list) const {
-  std::vector<std::string> list = _list;
+  const std::vector<std::string>& list = _list;
   std::vector<float> SummaryObj;
   const HDQMSummary::Range range = getRange(detID);
   if (range.first != range.second) {


### PR DESCRIPTION
This PR suggests to apply the `clang-tidy` changes proposed by LLVM21 ( from CLANG_X IB). 