### PR TITLE
[ALCA-DB-L1] [LLVM21] Apply clang-tidy changes

### DIFF
--- a/CondFormats/L1TObjects/src/L1GctJetFinderParams.cc
+++ b/CondFormats/L1TObjects/src/L1GctJetFinderParams.cc
@@ -353,8 +353,8 @@ std::ostream& operator<<(std::ostream& os, const L1GctJetFinderParams& fn) {
         os << "Unrecognised" << std::endl;
         break;
     }
-    std::vector<std::vector<double> > jetCoeffs = fn.getJetCorrCoeffs();
-    std::vector<std::vector<double> > tauCoeffs = fn.getTauCorrCoeffs();
+    const std::vector<std::vector<double> >& jetCoeffs = fn.getJetCorrCoeffs();
+    const std::vector<std::vector<double> >& tauCoeffs = fn.getTauCorrCoeffs();
 
     os << "Non-tau jet correction coefficients" << std::endl;
     for (unsigned i = 0; i < jetCoeffs.size(); i++) {


### PR DESCRIPTION
This PR suggests to apply the `clang-tidy` changes proposed by LLVM21 ( from CLANG_X IB). 