### PR TITLE
[ANALYSIS] [LLVM21] Apply clang-tidy changes

### DIFF
--- a/DPGAnalysis/SiStripTools/plugins/TrackerDpgAnalysis.cc
+++ b/DPGAnalysis/SiStripTools/plugins/TrackerDpgAnalysis.cc
@@ -713,6 +713,7 @@ void TrackerDpgAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup
 
   // build the reverse map tracks -> vertex
   std::vector<std::map<size_t, int> > trackVertices;
+  trackVertices.reserve(trackSize);
   for (size_t i = 0; i < trackSize; ++i) {
     trackVertices.push_back(inVertex(trackCollection[0], vertexColl, globalvertexid_ + 1));
   }
@@ -775,10 +776,12 @@ void TrackerDpgAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup
 
   // determine if each cluster is on a track or not, and record the trackid
   std::vector<std::vector<int> > stripClusterOntrackIndices;
+  stripClusterOntrackIndices.reserve(trackSize);
   for (size_t i = 0; i < trackSize; ++i) {
     stripClusterOntrackIndices.push_back(onTrack(clusters, trackCollection[i], globaltrackid_[i] + 1));
   }
   std::vector<std::vector<int> > pixelClusterOntrackIndices;
+  pixelClusterOntrackIndices.reserve(trackSize);
   for (size_t i = 0; i < trackSize; ++i) {
     pixelClusterOntrackIndices.push_back(onTrack(pixelclusters, trackCollection[i], globaltrackid_[i] + 1));
   }

--- a/DPGAnalysis/SiStripTools/src/EventShape.cc
+++ b/DPGAnalysis/SiStripTools/src/EventShape.cc
@@ -27,7 +27,7 @@ EventShape::EventShape(reco::TrackCollection& tracks) : eigenvalues(3) {
   MomentumTensor *= 1 / (MomentumTensor[0][0] + MomentumTensor[1][1] + MomentumTensor[2][2]);
   // find the eigen values
   TMatrixDSymEigen eigen(MomentumTensor);
-  TVectorD eigenvals = eigen.GetEigenValues();
+  const TVectorD& eigenvals = eigen.GetEigenValues();
   eigenvalues[0] = eigenvals[0];
   eigenvalues[1] = eigenvals[1];
   eigenvalues[2] = eigenvals[2];
@@ -232,7 +232,7 @@ float EventShape::sphericity(const reco::TrackCollection& tracks) {
   MomentumTensor *= 1 / (MomentumTensor[0][0] + MomentumTensor[1][1] + MomentumTensor[2][2]);
   // find the eigen values
   TMatrixDSymEigen eigen(MomentumTensor);
-  TVectorD eigenvals = eigen.GetEigenValues();
+  const TVectorD& eigenvals = eigen.GetEigenValues();
   vector<float> eigenvaluess(3);
   eigenvaluess[0] = eigenvals[0];
   eigenvaluess[1] = eigenvals[1];
@@ -262,7 +262,7 @@ float EventShape::aplanarity(const reco::TrackCollection& tracks) {
   MomentumTensor *= 1 / (MomentumTensor[0][0] + MomentumTensor[1][1] + MomentumTensor[2][2]);
   // find the eigen values
   TMatrixDSymEigen eigen(MomentumTensor);
-  TVectorD eigenvals = eigen.GetEigenValues();
+  const TVectorD& eigenvals = eigen.GetEigenValues();
   vector<float> eigenvaluess(3);
   eigenvaluess[0] = eigenvals[0];
   eigenvaluess[1] = eigenvals[1];
@@ -291,7 +291,7 @@ float EventShape::planarity(const reco::TrackCollection& tracks) {
   MomentumTensor *= 1 / (MomentumTensor[0][0] + MomentumTensor[1][1] + MomentumTensor[2][2]);
   // find the eigen values
   TMatrixDSymEigen eigen(MomentumTensor);
-  TVectorD eigenvals = eigen.GetEigenValues();
+  const TVectorD& eigenvals = eigen.GetEigenValues();
   vector<float> eigenvaluess(3);
   eigenvaluess[0] = eigenvals[0];
   eigenvaluess[1] = eigenvals[1];

--- a/HeavyFlavorAnalysis/Onia2MuMu/src/OniaVtxReProducer.cc
+++ b/HeavyFlavorAnalysis/Onia2MuMu/src/OniaVtxReProducer.cc
@@ -18,7 +18,7 @@ OniaVtxReProducer::OniaVtxReProducer(const edm::Handle<reco::VertexCollection> &
   if (edm::moduleName(prov->stable(), iEvent.processHistory()) != "PrimaryVertexProducer") {
     std::vector<edm::BranchID> parents = prov->productProvenance()->parentage().parents();
     for (std::vector<edm::BranchID>::const_iterator it = parents.begin(), ed = parents.end(); it != ed; ++it) {
-      edm::Provenance parprov = iEvent.getProvenance(*it);
+      const edm::Provenance &parprov = iEvent.getProvenance(*it);
       if (parprov.friendlyClassName() == "recoVertexs") {  // for AOD actually this the parent we should look for
         parent_prov = &parprov;
         psetFromProvenance = edm::parameterSet(parprov.stable(), iEvent.processHistory());

--- a/HeavyFlavorAnalysis/SpecificDecay/src/BPHDecayToChargedXXbarBuilder.cc
+++ b/HeavyFlavorAnalysis/SpecificDecay/src/BPHDecayToChargedXXbarBuilder.cc
@@ -158,7 +158,7 @@ void BPHDecayToChargedXXbarBuilder::addParticle(const BPHRecoBuilder::BPHGeneric
       continue;
     if ((charge < 0) && (q >= 0))
       continue;
-    const reco::Candidate::LorentzVector p4 = cand.p4();
+    const reco::Candidate::LorentzVector& p4 = cand.p4();
     if (p4.pt() < ptMin)
       continue;
     if (p4.eta() > etaMax)

--- a/HeavyFlavorAnalysis/SpecificDecay/src/BPHDecayToTkpTknSymChargeBuilder.cc
+++ b/HeavyFlavorAnalysis/SpecificDecay/src/BPHDecayToTkpTknSymChargeBuilder.cc
@@ -201,7 +201,7 @@ void BPHDecayToTkpTknSymChargeBuilder::addParticle(const BPHRecoBuilder::BPHGene
       continue;
     if ((charge < 0) && (q >= 0))
       continue;
-    const reco::Candidate::LorentzVector p4 = cand.p4();
+    const reco::Candidate::LorentzVector& p4 = cand.p4();
     const reco::Track* tk = BPHTrackReference::getTrack(cand, "cfhp");
     if (tk == nullptr)
       continue;

--- a/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
@@ -899,7 +899,7 @@ int GenHFHadronMatcher::findInMothers(int idx,
   if (std::abs(hadMothers.at(idx).pdgId()) > 10 && std::abs(hadMothers.at(idx).pdgId()) < 19)
     printf("Lepton: %d\n", hadMothers.at(idx).pdgId());
 
-  std::vector<int> mothers = hadMothersIndices.at(idx);
+  const std::vector<int> &mothers = hadMothersIndices.at(idx);
   unsigned int nMothers = mothers.size();
   bool isCorrect = false;  // Whether current particle is what is being searched
   if (verbose) {

--- a/PhysicsTools/JetMCAlgos/plugins/JetFlavourClustering.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/JetFlavourClustering.cc
@@ -737,6 +737,7 @@ void JetFlavourClustering::assignToSubjets(const reco::GenParticleRefVector& clu
        ++it) {
     std::vector<double> dR2toSubjets;
 
+    dR2toSubjets.reserve(subjetIndices.size());
     for (size_t sj = 0; sj < subjetIndices.size(); ++sj)
       dR2toSubjets.push_back(reco::deltaR2((*it)->rapidity(),
                                            (*it)->phi(),

--- a/PhysicsTools/UtilAlgos/bin/mergeTFileServiceHistograms.cpp
+++ b/PhysicsTools/UtilAlgos/bin/mergeTFileServiceHistograms.cpp
@@ -115,7 +115,7 @@ int main(int argc, char *argv[]) {
 
   bool empty = true;
   for (size_t i = 0; i < fileNames.size(); ++i) {
-    string fileName = fileNames[i];
+    const string &fileName = fileNames[i];
     TFile file(fileName.c_str(), "read");
     if (!file.IsOpen()) {
       cerr << "can't open input file: " << fileName << endl;

--- a/TopQuarkAnalysis/TopEventProducers/src/TtSemiEvtSolutionMaker.cc
+++ b/TopQuarkAnalysis/TopEventProducers/src/TtSemiEvtSolutionMaker.cc
@@ -376,6 +376,7 @@ TtSemiLepKinFitter::Constraint TtSemiEvtSolutionMaker::constraint(unsigned val) 
 
 std::vector<TtSemiLepKinFitter::Constraint> TtSemiEvtSolutionMaker::constraints(std::vector<unsigned>& val) {
   std::vector<TtSemiLepKinFitter::Constraint> result;
+  result.reserve(val.size());
   for (unsigned i = 0; i < val.size(); ++i) {
     result.push_back(constraint(val[i]));
   }

--- a/TopQuarkAnalysis/TopHitFit/plugins/TtSemiLepHitFitProducer.cc
+++ b/TopQuarkAnalysis/TopHitFit/plugins/TtSemiLepHitFitProducer.cc
@@ -253,6 +253,7 @@ void TtSemiLepHitFitProducer<LeptonCollection>::produce(edm::Event& evt, const e
     pNeutrinos->push_back(pat::Particle());
     // indices referring to the jet combination
     std::vector<int> invalidCombi;
+    invalidCombi.reserve(nPartons);
     for (unsigned int i = 0; i < nPartons; ++i)
       invalidCombi.push_back(-1);
     pCombi->push_back(invalidCombi);
@@ -420,6 +421,7 @@ void TtSemiLepHitFitProducer<LeptonCollection>::produce(edm::Event& evt, const e
     pNeutrinos->push_back(pat::Particle());
     // indices referring to the jet combination
     std::vector<int> invalidCombi;
+    invalidCombi.reserve(nPartons);
     for (unsigned int i = 0; i < nPartons; ++i)
       invalidCombi.push_back(-1);
     pCombi->push_back(invalidCombi);

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombGeom.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombGeom.cc
@@ -51,6 +51,7 @@ void TtSemiLepJetCombGeom::produce(edm::StreamID, edm::Event& evt, const edm::Ev
   auto pJetsConsidered = std::make_unique<int>(0);
 
   std::vector<int> match;
+  match.reserve(4);
   for (unsigned int i = 0; i < 4; ++i)
     match.push_back(-1);
 

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.cc
@@ -47,6 +47,7 @@ void TtSemiLepJetCombMVAComputer::produce(edm::Event& evt, const edm::EventSetup
   // empty METs vector or less jets than partons
   if (leptons->empty() || mets->empty() || jets->size() < nPartons) {
     std::vector<int> invalidCombi;
+    invalidCombi.reserve(nPartons);
     for (unsigned int i = 0; i < nPartons; ++i)
       invalidCombi.push_back(-1);
     pOut->push_back(invalidCombi);
@@ -73,6 +74,7 @@ void TtSemiLepJetCombMVAComputer::produce(edm::Event& evt, const edm::EventSetup
   }
 
   std::vector<int> combi;
+  combi.reserve(nPartons);
   for (unsigned int i = 0; i < nPartons; ++i)
     combi.push_back(i);
 

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMaxSumPtWMass.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMaxSumPtWMass.cc
@@ -48,6 +48,7 @@ void TtSemiLepJetCombMaxSumPtWMass::produce(edm::StreamID, edm::Event& evt, cons
   auto pJetsConsidered = std::make_unique<int>(0);
 
   std::vector<int> match;
+  match.reserve(4);
   for (unsigned int i = 0; i < 4; ++i)
     match.push_back(-1);
 

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombWMassDeltaTopMass.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombWMassDeltaTopMass.cc
@@ -57,6 +57,7 @@ void TtSemiLepJetCombWMassDeltaTopMass::produce(edm::StreamID, edm::Event& evt, 
   auto pJetsConsidered = std::make_unique<int>(0);
 
   std::vector<int> match;
+  match.reserve(4);
   for (unsigned int i = 0; i < 4; ++i)
     match.push_back(-1);
 

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombWMassMaxSumPt.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombWMassMaxSumPt.cc
@@ -48,6 +48,7 @@ void TtSemiLepJetCombWMassMaxSumPt::produce(edm::StreamID, edm::Event& evt, cons
   auto pJetsConsidered = std::make_unique<int>(0);
 
   std::vector<int> match;
+  match.reserve(4);
   for (unsigned int i = 0; i < 4; ++i)
     match.push_back(-1);
 

--- a/TopQuarkAnalysis/TopJetCombination/src/TtFullHadHypothesis.cc
+++ b/TopQuarkAnalysis/TopJetCombination/src/TtFullHadHypothesis.cc
@@ -28,6 +28,7 @@ void TtFullHadHypothesis::produce(edm::Event& evt, const edm::EventSetup& setup)
     matchVec = *matchHandle;
   } else {
     std::vector<int> dummyMatch;
+    dummyMatch.reserve(4);
     for (unsigned int i = 0; i < 4; ++i)
       dummyMatch.push_back(-1);
     matchVec.push_back(dummyMatch);

--- a/TopQuarkAnalysis/TopJetCombination/src/TtFullLepHypothesis.cc
+++ b/TopQuarkAnalysis/TopJetCombination/src/TtFullLepHypothesis.cc
@@ -45,6 +45,7 @@ void TtFullLepHypothesis::produce(edm::Event& evt, const edm::EventSetup& setup)
     matchVec = *matchHandle;
   } else {
     std::vector<int> dummyMatch;
+    dummyMatch.reserve(4);
     for (unsigned int i = 0; i < 4; ++i)
       dummyMatch.push_back(-1);
     matchVec.push_back(dummyMatch);

--- a/TopQuarkAnalysis/TopJetCombination/src/TtSemiLepHypothesis.cc
+++ b/TopQuarkAnalysis/TopJetCombination/src/TtSemiLepHypothesis.cc
@@ -52,6 +52,7 @@ void TtSemiLepHypothesis::produce(edm::Event& evt, const edm::EventSetup& setup)
     matchVec = *matchHandle;
   } else {
     std::vector<int> dummyMatch;
+    dummyMatch.reserve(4);
     for (unsigned int i = 0; i < 4; ++i)
       dummyMatch.push_back(-1);
     matchVec.push_back(dummyMatch);

--- a/TopQuarkAnalysis/TopKinFitter/plugins/TtSemiLepKinFitProducer.cc
+++ b/TopQuarkAnalysis/TopKinFitter/plugins/TtSemiLepKinFitProducer.cc
@@ -237,6 +237,7 @@ void TtSemiLepKinFitProducer<LeptonCollection>::produce(edm::Event& evt, const e
     pNeutrinos->push_back(fitter->fittedNeutrino());
     // indices referring to the jet combination
     std::vector<int> invalidCombi;
+    invalidCombi.reserve(nPartons);
     for (unsigned int i = 0; i < nPartons; ++i)
       invalidCombi.push_back(-1);
     pCombi->push_back(invalidCombi);
@@ -346,6 +347,7 @@ void TtSemiLepKinFitProducer<LeptonCollection>::produce(edm::Event& evt, const e
     pNeutrinos->push_back(fitter->fittedNeutrino());
     // indices referring to the jet combination
     std::vector<int> invalidCombi;
+    invalidCombi.reserve(nPartons);
     for (unsigned int i = 0; i < nPartons; ++i)
       invalidCombi.push_back(-1);
     pCombi->push_back(invalidCombi);
@@ -450,6 +452,7 @@ template <typename LeptonCollection>
 std::vector<TtSemiLepKinFitter::Constraint> TtSemiLepKinFitProducer<LeptonCollection>::constraints(
     std::vector<unsigned>& val) {
   std::vector<TtSemiLepKinFitter::Constraint> result;
+  result.reserve(val.size());
   for (unsigned i = 0; i < val.size(); ++i) {
     result.push_back(constraint(val[i]));
   }

--- a/TopQuarkAnalysis/TopKinFitter/src/TtFullHadKinFitter.cc
+++ b/TopQuarkAnalysis/TopKinFitter/src/TtFullHadKinFitter.cc
@@ -480,6 +480,7 @@ std::list<TtFullHadKinFitter::KinFitResult> TtFullHadKinFitter::KinFit::fit(cons
   if (jets.size() < nPartons || invalidMatch_) {
     // indices referring to the jet combination
     std::vector<int> invalidCombi;
+    invalidCombi.reserve(nPartons);
     for (unsigned int i = 0; i < nPartons; ++i)
       invalidCombi.push_back(-1);
 
@@ -661,6 +662,7 @@ TtFullHadKinFitter::Constraint TtFullHadKinFitter::KinFit::constraint(unsigned c
 std::vector<TtFullHadKinFitter::Constraint> TtFullHadKinFitter::KinFit::constraints(
     const std::vector<unsigned>& configParameters) {
   std::vector<TtFullHadKinFitter::Constraint> result;
+  result.reserve(configParameters.size());
   for (unsigned i = 0; i < configParameters.size(); ++i) {
     result.push_back(constraint(configParameters[i]));
   }

--- a/TopQuarkAnalysis/TopTools/src/JetPartonMatching.cc
+++ b/TopQuarkAnalysis/TopTools/src/JetPartonMatching.cc
@@ -10,6 +10,7 @@ JetPartonMatching::JetPartonMatching(const std::vector<const reco::Candidate*>& 
                                      const double maxDist = 0.3)
     : partons(p), algorithm_(algorithm), useMaxDist_(useMaxDist), useDeltaR_(useDeltaR), maxDist_(maxDist) {
   std::vector<const reco::Candidate*> js;
+  js.reserve(j.size());
   for (unsigned int i = 0; i < j.size(); ++i)
     js.push_back(&(j[i]));
   jets = js;
@@ -24,6 +25,7 @@ JetPartonMatching::JetPartonMatching(const std::vector<const reco::Candidate*>& 
                                      const double maxDist = 0.3)
     : partons(p), algorithm_(algorithm), useMaxDist_(useMaxDist), useDeltaR_(useDeltaR), maxDist_(maxDist) {
   std::vector<const reco::Candidate*> js;
+  js.reserve(j.size());
   for (unsigned int i = 0; i < j.size(); ++i)
     js.push_back(&(j[i]));
   jets = js;
@@ -38,6 +40,7 @@ JetPartonMatching::JetPartonMatching(const std::vector<const reco::Candidate*>& 
                                      const double maxDist = 0.3)
     : partons(p), algorithm_(algorithm), useMaxDist_(useMaxDist), useDeltaR_(useDeltaR), maxDist_(maxDist) {
   std::vector<const reco::Candidate*> js;
+  js.reserve(j.size());
   for (unsigned int i = 0; i < j.size(); ++i)
     js.push_back(&(j[i]));
   jets = js;
@@ -234,6 +237,7 @@ void JetPartonMatching::matchingMinSumDist() {
   std::vector<std::pair<double, MatchingCollection> > distMatchVec;
 
   std::vector<bool> usedJets;
+  usedJets.reserve(jets.size());
   for (unsigned int i = 0; i < jets.size(); ++i) {
     usedJets.push_back(false);
   }
@@ -265,6 +269,7 @@ void JetPartonMatching::matchingPtOrderedMinDist() {
   // order partons in pt first
   std::vector<std::pair<double, unsigned int> > ptOrderedPartons;
 
+  ptOrderedPartons.reserve(partons.size());
   for (unsigned int ip = 0; ip < partons.size(); ++ip)
     ptOrderedPartons.push_back(std::make_pair(partons[ip]->pt(), ip));
 
@@ -272,6 +277,7 @@ void JetPartonMatching::matchingPtOrderedMinDist() {
   std::reverse(ptOrderedPartons.begin(), ptOrderedPartons.end());
 
   std::vector<unsigned int> jetIndices;
+  jetIndices.reserve(jets.size());
   for (unsigned int ij = 0; ij < jets.size(); ++ij)
     jetIndices.push_back(ij);
 
@@ -307,6 +313,7 @@ void JetPartonMatching::matchingUnambiguousOnly() {
   // match partons to jets, only accept event
   // if there are no ambiguities
   std::vector<bool> jetMatched;
+  jetMatched.reserve(jets.size());
   for (unsigned int ij = 0; ij < jets.size(); ++ij)
     jetMatched.push_back(false);
 
@@ -350,6 +357,7 @@ std::vector<int> JetPartonMatching::getMatchesForPartons(const unsigned int comb
   // return a vector with the indices of the matched jets
   // (ordered according to the vector of partons)
   std::vector<int> jetIndices;
+  jetIndices.reserve(partons.size());
   for (unsigned int part = 0; part < partons.size(); ++part)
     jetIndices.push_back(getMatchForParton(part, comb));
   return jetIndices;


### PR DESCRIPTION
This PR suggests to apply the `clang-tidy` changes proposed by LLVM21 ( from CLANG_X IB). 