### PR TITLE
[ALCA-DB] [LLVM21] Apply clang-tidy changes

### DIFF
--- a/Alignment/CocoaFit/src/Fit.cc
+++ b/Alignment/CocoaFit/src/Fit.cc
@@ -1311,7 +1311,7 @@ void Fit::printCentreInOptOFrame(const OpticalObject* opto,
               << " parent GLOB " << optoAncestor->centreGlob() << std::endl;
     ALIUtils::dumprm(optoAncestor->rmGlob(), " parent rm ");
   }
-  std::vector<Entry*> entries = opto->CoordinateEntryList();
+  const std::vector<Entry*>& entries = opto->CoordinateEntryList();
   for (ALIuint ii = 0; ii < 3; ii++) {
     /* double entryvalue = getEntryValue( entries[ii] );
        ALIdouble entryvalue;
@@ -1333,7 +1333,7 @@ void Fit::printRotationAnglesInOptOFrame(const OpticalObject* opto,
                                          ALIFileOut& fileout,
                                          ALIbool printErrors,
                                          ALIbool printOrig) {
-  std::vector<Entry*> entries = opto->CoordinateEntryList();
+  const std::vector<Entry*>& entries = opto->CoordinateEntryList();
   std::vector<double> entryvalues = opto->getRotationAnglesInOptOFrame(optoAncestor, entries);
   //-    std::cout << " after return entryvalues[0] " << entryvalues[0] << " entryvalues[1] " << entryvalues[1] << " entryvalues[2] " << entryvalues[2] << std::endl;
   for (ALIuint ii = 3; ii < entries.size(); ii++) {

--- a/Alignment/CocoaFit/src/NtupleManager.cc
+++ b/Alignment/CocoaFit/src/NtupleManager.cc
@@ -291,7 +291,7 @@ void NtupleManager::FillMeasurements() {
   for (vmcite = Model::MeasurementList().begin(); vmcite != Model::MeasurementList().end(); ++vmcite) {
     std::vector<ALIstring> optonamelist = (*vmcite)->OptONameList();
     int last = optonamelist.size() - 1;
-    ALIstring LastOptOName = optonamelist[last];
+    const ALIstring& LastOptOName = optonamelist[last];
     int optoind = -999;
     for (int no = 0; no < NOptObjects; no++) {
       OptObject* optobj = (OptObject*)CloneOptObject->At(no);

--- a/Alignment/CocoaModel/src/CocoaDaqReaderRoot.cc
+++ b/Alignment/CocoaModel/src/CocoaDaqReaderRoot.cc
@@ -124,11 +124,7 @@ OpticalAlignMeasurementInfo CocoaDaqReaderRoot::GetMeasFromPosition2D(AliDaqPosi
   meas.type_ = "SENSOR2D";
   meas.name_ = std::string(pos2D->GetID().Data());
   //-   std::vector<std::string> measObjectNames_;
-  std::vector<bool> isSimu;
-  isSimu.reserve(2);
-  for (size_t jj = 0; jj < 2; jj++) {
-    isSimu.push_back(false);
-  }
+  std::vector<bool> isSimu(2, false);
   meas.isSimulatedValue_ = isSimu;
   std::vector<OpticalAlignParam> paramList;
   OpticalAlignParam oaParam1;
@@ -155,11 +151,7 @@ OpticalAlignMeasurementInfo CocoaDaqReaderRoot::GetMeasFromPositionCOPS(AliDaqPo
   meas.type_ = "COPS";
   meas.name_ = std::string(posCOPS->GetID().Data());
   //-   std::vector<std::string> measObjectNames_;
-  std::vector<bool> isSimu;
-  isSimu.reserve(4);
-  for (size_t jj = 0; jj < 4; jj++) {
-    isSimu.push_back(false);
-  }
+  std::vector<bool> isSimu(4, false);
   meas.isSimulatedValue_ = isSimu;
 
   std::vector<OpticalAlignParam> paramList;
@@ -199,11 +191,7 @@ OpticalAlignMeasurementInfo CocoaDaqReaderRoot::GetMeasFromTilt(AliDaqTilt* tilt
   meas.type_ = "TILTMETER";
   meas.name_ = std::string(tilt->GetID().Data());
   //-   std::vector<std::string> measObjectNames_;
-  std::vector<bool> isSimu;
-  isSimu.reserve(2);
-  for (size_t jj = 0; jj < 2; jj++) {
-    isSimu.push_back(false);
-  }
+  std::vector<bool> isSimu(2, false);
   meas.isSimulatedValue_ = isSimu;
   std::vector<OpticalAlignParam> paramList;
   OpticalAlignParam oaParam;
@@ -224,11 +212,7 @@ OpticalAlignMeasurementInfo CocoaDaqReaderRoot::GetMeasFromDist(AliDaqDistance* 
   meas.type_ = "DISTANCEMETER";
   meas.name_ = std::string(dist->GetID().Data());
   //-   std::vector<std::string> measObjectNames_;
-  std::vector<bool> isSimu;
-  isSimu.reserve(2);
-  for (size_t jj = 0; jj < 2; jj++) {
-    isSimu.push_back(false);
-  }
+  std::vector<bool> isSimu(2, false);
   meas.isSimulatedValue_ = isSimu;
   std::vector<OpticalAlignParam> paramList;
   OpticalAlignParam oaParam;

--- a/Alignment/CocoaModel/src/CocoaDaqReaderRoot.cc
+++ b/Alignment/CocoaModel/src/CocoaDaqReaderRoot.cc
@@ -125,6 +125,7 @@ OpticalAlignMeasurementInfo CocoaDaqReaderRoot::GetMeasFromPosition2D(AliDaqPosi
   meas.name_ = std::string(pos2D->GetID().Data());
   //-   std::vector<std::string> measObjectNames_;
   std::vector<bool> isSimu;
+  isSimu.reserve(2);
   for (size_t jj = 0; jj < 2; jj++) {
     isSimu.push_back(false);
   }
@@ -155,6 +156,7 @@ OpticalAlignMeasurementInfo CocoaDaqReaderRoot::GetMeasFromPositionCOPS(AliDaqPo
   meas.name_ = std::string(posCOPS->GetID().Data());
   //-   std::vector<std::string> measObjectNames_;
   std::vector<bool> isSimu;
+  isSimu.reserve(4);
   for (size_t jj = 0; jj < 4; jj++) {
     isSimu.push_back(false);
   }
@@ -198,6 +200,7 @@ OpticalAlignMeasurementInfo CocoaDaqReaderRoot::GetMeasFromTilt(AliDaqTilt* tilt
   meas.name_ = std::string(tilt->GetID().Data());
   //-   std::vector<std::string> measObjectNames_;
   std::vector<bool> isSimu;
+  isSimu.reserve(2);
   for (size_t jj = 0; jj < 2; jj++) {
     isSimu.push_back(false);
   }
@@ -222,6 +225,7 @@ OpticalAlignMeasurementInfo CocoaDaqReaderRoot::GetMeasFromDist(AliDaqDistance* 
   meas.name_ = std::string(dist->GetID().Data());
   //-   std::vector<std::string> measObjectNames_;
   std::vector<bool> isSimu;
+  isSimu.reserve(2);
   for (size_t jj = 0; jj < 2; jj++) {
     isSimu.push_back(false);
   }
@@ -265,7 +269,7 @@ void CocoaDaqReaderRoot::BuildMeasurementsFromOptAlign(std::vector<OpticalAlignM
     //---------- loop measurements read from ROOT
     ALIint ii;
     for (ii = 0; ii < nMeasRoot; ii++) {
-      OpticalAlignMeasurementInfo measInfo = measList[ii];
+      const OpticalAlignMeasurementInfo& measInfo = measList[ii];
       std::cout << " measurement name ROOT " << measInfo.name_ << " Model= " << (*vmcite)->name() << " short " << oname
                 << std::endl;
 

--- a/Alignment/CocoaModel/src/Model.cc
+++ b/Alignment/CocoaModel/src/Model.cc
@@ -372,7 +372,7 @@ void Model::readSystemDescription() {
         if (ALIUtils::debug >= 3) {
           std::vector<std::vector<ALIstring> >::iterator itevs;
           for (itevs = OptODictionary().begin(); itevs != OptODictionary().end(); ++itevs) {
-            std::vector<ALIstring> ptemp = *itevs;
+            const std::vector<ALIstring>& ptemp = *itevs;
             ALIUtils::dumpVS(ptemp, " SYSTEM TREE DESCRIPTION: after ordering: OBJECT ", std::cout);
           }
         }

--- a/Alignment/CommonAlignmentParametrization/src/TwoBowedSurfacesAlignmentParameters.cc
+++ b/Alignment/CommonAlignmentParametrization/src/TwoBowedSurfacesAlignmentParameters.cc
@@ -222,7 +222,7 @@ double TwoBowedSurfacesAlignmentParameters::ySplitFromAlignable(const Alignable 
   if (!ali)
     return 0.;
 
-  const align::PositionType pos(ali->globalPosition());
+  const align::PositionType &pos(ali->globalPosition());
   const double r = pos.perp();
 
   // The returned numbers for TEC are calculated as stated below from

--- a/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
+++ b/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
@@ -801,7 +801,7 @@ void HIPAlignmentAlgorithm::run(const edm::EventSetup& setup, const EventInfo& e
     // loop over measurements
     std::vector<TrajectoryMeasurement> measurements = traj->measurements();
     for (std::vector<TrajectoryMeasurement>::iterator im = measurements.begin(); im != measurements.end(); ++im) {
-      TrajectoryMeasurement meas = *im;
+      const TrajectoryMeasurement& meas = *im;
 
       // const TransientTrackingRecHit* ttrhit = &(*meas.recHit());
       // const TrackingRecHit *hit = ttrhit->hit();

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeMonitor.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeMonitor.cc
@@ -591,7 +591,7 @@ void MillePedeMonitor::fillTrack(const reco::Track *track,
   if (!track)
     return;
 
-  const reco::TrackBase::Vector p(track->momentum());
+  const reco::TrackBase::Vector &p(track->momentum());
 
   static const int iPtLog = this->GetIndex(trackHists1D, "ptTrackLogBins");
   trackHists1D[iPtLog]->Fill(track->pt());

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.cc
@@ -463,7 +463,7 @@ double PedeSteererWeakModeConstraints::getX0(const std::pair<Alignable*, std::li
   double x0 = 0.0;
 
   for (const auto& ali : iHLS.second) {
-    align::PositionType pos = ali->globalPosition();
+    const align::PositionType& pos = ali->globalPosition();
     bool alignableIsFloating = false;  //means: true=alignable is able to move in at least one direction
 
     //test whether at least one variable has been selected in the configuration

--- a/Alignment/OfflineValidation/plugins/JetHTAnalyzer.cc
+++ b/Alignment/OfflineValidation/plugins/JetHTAnalyzer.cc
@@ -186,7 +186,7 @@ void JetHTAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
     h_ntrks->Fill(ntrks);
 
     for (uint tracksIt = 0; tracksIt < ntrks; tracksIt++) {
-      auto tk = allTracks.at(tracksIt);
+      const auto& tk = allTracks.at(tracksIt);
 
       double dxyRes = tk.dxy(pos_) * cmToum;
       double dzRes = tk.dz(pos_) * cmToum;

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -331,7 +331,7 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
     double chi2prob = 0.;
 
     if (!vsorted.at(0).isFake()) {
-      Vertex pv = vsorted.at(0);
+      const Vertex& pv = vsorted.at(0);
 
       ntracks = pv.tracksSize();
       chi2ndf = pv.normalizedChi2();

--- a/Alignment/OfflineValidation/plugins/SplitVertexResolution.cc
+++ b/Alignment/OfflineValidation/plugins/SplitVertexResolution.cc
@@ -458,8 +458,8 @@ void SplitVertexResolution::analyze(const edm::Event& iEvent, const edm::EventSe
 
     // split into two sets equally populated
     for (uint tracksIt = 0; tracksIt < even_ntrks; tracksIt = tracksIt + 2) {
-      reco::Track firstTrk = allTracks.at(tracksIt);
-      reco::Track secondTrk = allTracks.at(tracksIt + 1);
+      const reco::Track& firstTrk = allTracks.at(tracksIt);
+      const reco::Track& secondTrk = allTracks.at(tracksIt + 1);
       auto dis = std::uniform_int_distribution<>(0, 1);  // [0, 1]
 
       if (dis(engine_) > 0.5) {

--- a/Alignment/OfflineValidation/src/PrepareDMRTrends.cc
+++ b/Alignment/OfflineValidation/src/PrepareDMRTrends.cc
@@ -124,6 +124,7 @@ void PrepareDMRTrends::compileDMRTrends(vector<int> IOVlist,
         vector<float> runs = geom.Run();
         size_t n = runs.size();
         vector<float> emptyvec;
+        emptyvec.reserve(runs.size());
         for (size_t i = 0; i < runs.size(); i++)
           emptyvec.push_back(0.);
         for (size_t iVar = 0; iVar < variables.size(); iVar++) {

--- a/Alignment/OfflineValidation/src/PrepareDMRTrends.cc
+++ b/Alignment/OfflineValidation/src/PrepareDMRTrends.cc
@@ -123,10 +123,7 @@ void PrepareDMRTrends::compileDMRTrends(vector<int> IOVlist,
             "mu", "sigma", "muplus", "sigmaplus", "muminus", "sigmaminus", "deltamu", "sigmadeltamu"};
         vector<float> runs = geom.Run();
         size_t n = runs.size();
-        vector<float> emptyvec;
-        emptyvec.reserve(runs.size());
-        for (size_t i = 0; i < runs.size(); i++)
-          emptyvec.push_back(0.);
+        vector<float> emptyvec(n, 0);
         for (size_t iVar = 0; iVar < variables.size(); iVar++) {
           Trend trend = trends.at(iVar);
           g = new TGraphErrors(n, runs.data(), (geom.*trend)().data(), emptyvec.data(), emptyvec.data());

--- a/Alignment/SurveyAnalysis/plugins/SurveyAlignmentAlgorithm.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyAlignmentAlgorithm.cc
@@ -19,6 +19,7 @@ void SurveyAlignmentAlgorithm::initialize(
   //        - check this, when resurrecting this code in the future
   AlignableObjectId alignableObjectId{AlignableObjectId::Geometry::General};
 
+  levels.reserve(theLevels.size());
   for (unsigned int l = 0; l < theLevels.size(); ++l) {
     levels.push_back(alignableObjectId.stringToId(theLevels[l].c_str()));
   }

--- a/CalibFormats/SiPixelObjects/src/PixelCalibConfiguration.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelCalibConfiguration.cc
@@ -543,7 +543,7 @@ void PixelCalibConfiguration::buildROCAndModuleLists(const PixelNameTranslation*
   for (std::vector<std::string>::iterator rocListInstructions_itr = rocListInstructions_.begin();
        rocListInstructions_itr != rocListInstructions_.end();
        ++rocListInstructions_itr) {
-    std::string instruction = *rocListInstructions_itr;
+    const std::string& instruction = *rocListInstructions_itr;
 
     if (instruction == "+") {
       addNext = true;

--- a/CalibFormats/SiPixelObjects/src/PixelDACSettings.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelDACSettings.cc
@@ -178,7 +178,7 @@ PixelDACSettings::PixelDACSettings(std::vector<std::vector<std::string> >& table
 */
   //   std::multimap<std::string,std::pair<std::string,int > > pDSM;
   //  std::stringstream currentRocName;
-  std::vector<std::string> ins = tableMat[0];
+  const std::vector<std::string>& ins = tableMat[0];
   std::string mthn("[PixelDACSettings::PixelDACSettings()] ");
   std::string dacName;
   std::istringstream dbin;

--- a/CalibFormats/SiPixelObjects/src/PixelDetectorConfig.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelDetectorConfig.cc
@@ -21,7 +21,7 @@ using namespace pos;
 PixelDetectorConfig::PixelDetectorConfig(std::vector<std::vector<std::string> > &tableMat)
     : PixelConfigBase("", "", "") {
   std::string mthn = "]\t[PixelDetectorConfig::PixelDetectorConfig()]\t\t    ";
-  std::vector<std::string> ins = tableMat[0];
+  const std::vector<std::string> &ins = tableMat[0];
   std::map<std::string, int> colM;
   std::vector<std::string> colNames;
   /*

--- a/CalibFormats/SiPixelObjects/src/PixelFEDCard.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelFEDCard.cc
@@ -392,7 +392,7 @@ PixelFEDCard::PixelFEDCard(vector<vector<string> > &tableMat) : PixelConfigBase(
 
 void PixelFEDCard::readDBTBMLevels(std::vector<std::vector<std::string> > &tableMat, int firstRow, int lastRow) {
   string mthn = "[PixelFEDCard::readDBTBMLevels()] ";
-  vector<string> ins = tableMat[firstRow];
+  const vector<string> &ins = tableMat[firstRow];
   map<string, int> colM;
   vector<string> colNames;
 

--- a/CalibFormats/SiPixelObjects/src/PixelFEDConfig.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelFEDConfig.cc
@@ -18,7 +18,6 @@ using namespace std;
 PixelFEDConfig::PixelFEDConfig(std::vector<std::vector<std::string> > &tableMat) : PixelConfigBase(" ", " ", " ") {
   std::string mthn = "[PixelFEDConfig::PixelFEDConfig()]\t\t\t    ";
 
-  std::vector<std::string> ins = tableMat[0];
   std::map<std::string, int> colM;
   std::vector<std::string> colNames;
   /*

--- a/CalibFormats/SiPixelObjects/src/PixelGlobalDelay25.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelGlobalDelay25.cc
@@ -19,7 +19,7 @@ using namespace std;
 
 PixelGlobalDelay25::PixelGlobalDelay25(vector<vector<string> > &tableMat) : PixelConfigBase(" ", " ", " ") {
   std::string mthn = "[PixelGlobalDelay25::PixelGlobalDelay25()]\t\t    ";
-  vector<string> ins = tableMat[0];
+  const vector<string> &ins = tableMat[0];
   map<string, int> colM;
   vector<string> colNames;
 

--- a/CalibFormats/SiPixelObjects/src/PixelMaskAllPixels.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelMaskAllPixels.cc
@@ -28,7 +28,7 @@ PixelMaskAllPixels::PixelMaskAllPixels(std::vector<std::vector<std::string> > &t
   std::string mthn = "[PixelMaskAllPixels::PixelMaskAllPixels()]\t\t    ";
   //std::cout << __LINE__ << "]\t" << mthn << "Table Size in const: " << tableMat.size() << std::endl;
 
-  std::vector<std::string> ins = tableMat[0];
+  const std::vector<std::string> &ins = tableMat[0];
   std::map<std::string, int> colM;
   std::vector<std::string> colNames;
 

--- a/CalibFormats/SiPixelObjects/src/PixelPortcardMap.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelPortcardMap.cc
@@ -18,7 +18,7 @@ using namespace std;
 
 PixelPortcardMap::PixelPortcardMap(std::vector<std::vector<std::string> > &tableMat) : PixelConfigBase(" ", " ", " ") {
   std::string mthn = "[PixelPortcardMap::PixelPortcardMap()]\t\t\t    ";
-  std::vector<std::string> ins = tableMat[0];
+  const std::vector<std::string> &ins = tableMat[0];
   std::map<std::string, int> colM;
   std::vector<std::string> colNames;
   /*

--- a/CalibFormats/SiPixelObjects/src/PixelTBMSettings.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelTBMSettings.cc
@@ -19,7 +19,7 @@ using namespace pos;
 
 PixelTBMSettings::PixelTBMSettings(std::vector<std::vector<std::string> > &tableMat) : PixelConfigBase("", "", "") {
   std::string mthn = "]\t[PixelTBMSettings::PixelTBMSettings()]\t\t\t    ";
-  std::vector<std::string> ins = tableMat[0];
+  const std::vector<std::string> &ins = tableMat[0];
   std::map<std::string, int> colM;
   std::vector<std::string> colNames;
 

--- a/CalibPPS/AlignmentRelative/src/JanAlignmentAlgorithm.cc
+++ b/CalibPPS/AlignmentRelative/src/JanAlignmentAlgorithm.cc
@@ -434,7 +434,7 @@ unsigned int JanAlignmentAlgorithm::solve(const std::vector<AlignmentConstraint>
 
   // eigen analysis of CS matrix
   TMatrixDSymEigen CS_eig(CS);
-  TVectorD CS_eigVal = CS_eig.GetEigenValues();
+  const TVectorD &CS_eigVal = CS_eig.GetEigenValues();
   TMatrixD CS_eigVec = CS_eig.GetEigenVectors();
 
   // check regularity of CS matrix

--- a/CalibTracker/SiStripHitEfficiency/plugins/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/HitEff.cc
@@ -662,7 +662,7 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es) {
             }
           }
           if (!tmpTmeas.empty() && !foundConsMissingHits) {
-            TrajectoryMeasurement TM_tmp(tmpTmeas.back());
+            const TrajectoryMeasurement& TM_tmp(tmpTmeas.back());
             unsigned int iidd_tmp = TM_tmp.recHit()->geographicalId().rawId();
             if (iidd_tmp != 0) {
               LogDebug("SiStripHitEfficiency:HitEff") << " hit actually being added to TM vector";
@@ -779,7 +779,7 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es) {
             // take the last of the TMs, which is always an invalid hit
             // if no detId is available, ie detId==0, then no compatible layer was crossed
             // otherwise, use that TM for the efficiency measurement
-            TrajectoryMeasurement tob6TM(tmp.back());
+            const TrajectoryMeasurement& tob6TM(tmp.back());
             const auto& tob6Hit = tob6TM.recHit();
 
             if (tob6Hit->geographicalId().rawId() != 0) {
@@ -827,7 +827,7 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es) {
             // take the last of the TMs, which is always an invalid hit
             // if no detId is available, ie detId==0, then no compatible layer was crossed
             // otherwise, use that TM for the efficiency measurement
-            TrajectoryMeasurement tec9TM(tmp.back());
+            const TrajectoryMeasurement& tec9TM(tmp.back());
             const auto& tec9Hit = tec9TM.recHit();
 
             unsigned int tec9id = tec9Hit->geographicalId().rawId();

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyWorker.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyWorker.cc
@@ -791,7 +791,7 @@ void SiStripHitEfficiencyWorker::analyze(const edm::Event& e, const edm::EventSe
             }
           }
           if (!tmpTmeas.empty() && !foundConsMissingHits) {
-            TrajectoryMeasurement TM_tmp(tmpTmeas.back());
+            const TrajectoryMeasurement& TM_tmp(tmpTmeas.back());
             unsigned int iidd_tmp = TM_tmp.recHit()->geographicalId().rawId();
             if (iidd_tmp != 0) {
               LogDebug("SiStripHitEfficiency:HitEff") << " hit actually being added to TM vector";

--- a/Calibration/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.cc
+++ b/Calibration/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.cc
@@ -576,7 +576,7 @@ void SelectedElectronFEDListProducer<TEle, TCand>::produce(edm::Event& iEvent, c
                 if (R - sqrt(pow(regionDimension_.first / 2, 2) + pow(regionDimension_.second / 2, 2)) > dRStripRegion_)
                   continue;
                 //get vector of subdets within region
-                const SiStripRegionCabling::RegionCabling regSubdets = SiStripCabling[iCabling];
+                const SiStripRegionCabling::RegionCabling& regSubdets = SiStripCabling[iCabling];
                 //cycle on subdets
                 for (uint32_t idet = 0; idet < SiStripRegionCabling::ALLSUBDETS; idet++) {  //cicle between 1 and 4
                   //get vector of layers whin subdet of region

--- a/Calibration/IsolatedParticles/plugins/IsoTrig.cc
+++ b/Calibration/IsolatedParticles/plugins/IsoTrig.cc
@@ -1837,6 +1837,7 @@ void IsoTrig::chgIsolation(double &etaTriggered,
   spr::propagateCALO(trkCollection, geo_, bField_, theTrackQuality_, trkCaloDirections1, ((verbosity_ / 100) % 10 > 2));
   if (verbosity_ % 10 > 0)
     edm::LogVerbatim("IsoTrack") << "Propagated TrkCollection";
+  maxP.reserve(pixelIsolationConeSizeAtEC_.size());
   for (unsigned int k = 0; k < pixelIsolationConeSizeAtEC_.size(); ++k)
     maxP.push_back(0);
   unsigned i = pixelTrackRefsHE_.size();

--- a/Calibration/LumiAlCaRecoProducers/plugins/CorrPCCProducer.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/CorrPCCProducer.cc
@@ -208,6 +208,7 @@ float CorrPCCProducer::getMaximum(std::vector<float> lumi_vector) {
 // the follow non-active bunch crossing to estimate the spill over fraction (type 1 afterglow).
 void CorrPCCProducer::estimateType1Frac(std::vector<float> uncorrPCCPerBX, float& type1Frac) {
   std::vector<float> corrected_tmp_;
+  corrected_tmp_.reserve(uncorrPCCPerBX.size());
   for (size_t i = 0; i < uncorrPCCPerBX.size(); i++) {
     corrected_tmp_.push_back(uncorrPCCPerBX.at(i));
   }
@@ -309,6 +310,7 @@ void CorrPCCProducer::calculateCorrections(std::vector<float> uncorrected,
   type1Frac = std::max(0.0, (double)type1Frac);
 
   std::vector<float> corrected_tmp_;
+  corrected_tmp_.reserve(uncorrected.size());
   for (size_t i = 0; i < uncorrected.size(); i++) {
     corrected_tmp_.push_back(uncorrected.at(i));
   }

--- a/CaloOnlineTools/EcalTools/bin/TPGTreeReader.cpp
+++ b/CaloOnlineTools/EcalTools/bin/TPGTreeReader.cpp
@@ -146,6 +146,7 @@ int main(int argc, char** argv) {
 
   std::vector<int> algobits;
   std::vector<std::string> algos = split(l1algo, ",");
+  algobits.reserve(algos.size());
   for (unsigned int i = 0; i < algos.size(); i++)
     algobits.push_back(atoi(algos[i].c_str()));
 

--- a/CaloOnlineTools/EcalTools/plugins/EcalTPGAnalyzer.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalTPGAnalyzer.cc
@@ -112,7 +112,7 @@ void EcalTPGAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const& i
   DecisionWord dWord = gtRecord->decisionWord();  // this will get the decision word *before* masking disabled bits
 
   const auto& l1GtTmAlgo = iSetup.getData(l1GtMaskToken_);
-  std::vector<unsigned int> triggerMaskAlgoTrig = l1GtTmAlgo.gtTriggerMask();
+  const std::vector<unsigned int>& triggerMaskAlgoTrig = l1GtTmAlgo.gtTriggerMask();
 
   // apply masks on algo
   int iDaq = 0;

--- a/CaloOnlineTools/HcalOnlineDb/plugins/HcalLutComparer.cc
+++ b/CaloOnlineTools/HcalOnlineDb/plugins/HcalLutComparer.cc
@@ -186,7 +186,7 @@ void HcalLutComparer::dumpLutDiff(LutXml &xmls1, LutXml &xmls2, bool testFormat 
     std::cout << Form("%9s  %6s  %6s  %6s", "Det", "total", "zeroes", "extra") << std::endl;
     for (unsigned int i = 0; i < detCodes.size(); i++) {
       int detCode = detCodes.at(i);
-      std::string detName = detNames.at(i);
+      const std::string &detName = detNames.at(i);
       std::cout << Form("%9s  %6d  %6d  %6d", detName.c_str(), n[detCode][total], n[detCode][zeros], n[detCode][extra])
                 << std::endl;
       if (detCode < 0) {
@@ -211,7 +211,7 @@ void HcalLutComparer::dumpLutDiff(LutXml &xmls1, LutXml &xmls2, bool testFormat 
               << std::endl;
     for (unsigned int i = 0; i < detCodes.size(); i++) {
       int detCode = detCodes.at(i);
-      std::string detName = detNames.at(i);
+      const std::string &detName = detNames.at(i);
       std::cout << Form("%9s  %6d  %6d  %8d  %8d  %11d",
                         detName.c_str(),
                         n[detCode][total],

--- a/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseStandardXMLParser.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseStandardXMLParser.cc
@@ -252,6 +252,7 @@ std::vector<unsigned int> ConfigurationDatabaseStandardXMLParser::Item::convert(
     strtol_base = 10;
 
   // convert the data
+  values.reserve(items.size());
   for (unsigned int j = 0; j < items.size(); j++)
     values.push_back(strtol(items[j].c_str(), nullptr, strtol_base));
   return values;

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
@@ -353,10 +353,7 @@ std::map<int, std::shared_ptr<LutXml>> HcalLutManager::getLinearizationLutXmlFro
   edm::LogInfo("HcalLutManager") << "  ==> " << lut_set_size << " sets of different LUTs read from the master file";
 
   // setup "zero" LUT for channel masking
-  std::vector<unsigned int> zeroLut;
-  zeroLut.reserve(128);
-  for (size_t adc = 0; adc < 128; adc++)
-    zeroLut.push_back(0);
+  std::vector<unsigned int> zeroLut(128, 0);
 
   RooGKCounter _counter;
   //loop over all EMap channels

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
@@ -354,6 +354,7 @@ std::map<int, std::shared_ptr<LutXml>> HcalLutManager::getLinearizationLutXmlFro
 
   // setup "zero" LUT for channel masking
   std::vector<unsigned int> zeroLut;
+  zeroLut.reserve(128);
   for (size_t adc = 0; adc < 128; adc++)
     zeroLut.push_back(0);
 

--- a/CondCore/EcalPlugins/plugins/EcalADCToGeVConstant_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalADCToGeVConstant_PayloadInspector.cc
@@ -40,7 +40,7 @@ namespace {
       if (payload.get()) {
         NbRows = 1;
         align = new TH2F("ADC To GeV [GeV/ADC count]", "EB          EE", 2, 0, 2, NbRows, 0, NbRows);
-        EcalADCToGeVConstant it = (*payload);
+        const EcalADCToGeVConstant& it = (*payload);
 
         double row = NbRows - 0.5;
 

--- a/CondCore/EcalPlugins/plugins/EcalSampleMask_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalSampleMask_PayloadInspector.cc
@@ -39,7 +39,7 @@ namespace {
       if (payload.get()) {
         NbRows = 1;
         align = new TH2F("Ecal Sample Mask", "EB          EE", 2, 0, 2, NbRows, 0, NbRows);
-        EcalSampleMask it = (*payload);
+        const EcalSampleMask& it = (*payload);
 
         double row = NbRows - 0.5;
 

--- a/CondCore/EcalPlugins/plugins/EcalSamplesCorrelation_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalSamplesCorrelation_PayloadInspector.cc
@@ -40,7 +40,7 @@ namespace {
       int NbRows;
 
       if (payload.get()) {
-        EcalSamplesCorrelation it = (*payload);
+        const EcalSamplesCorrelation& it = (*payload);
         NbRows = it.EBG12SamplesCorrelation.size();
         if (NbRows == 0)
           return false;
@@ -143,7 +143,7 @@ namespace {
         }
 
         if (payload.get()) {
-          EcalSamplesCorrelation it = (*payload);
+          const EcalSamplesCorrelation& it = (*payload);
           NbRows = it.EBG12SamplesCorrelation.size();
 
           if (irun == 1) {

--- a/CondCore/EcalPlugins/plugins/EcalTimeBiasCorrections_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalTimeBiasCorrections_PayloadInspector.cc
@@ -151,7 +151,7 @@ std::cout<<str.str()<<std::endl;
           payload = this->fetchPayload(std::get<1>(lastiov));
         }
         if (payload.get()) {
-          EcalTimeBiasCorrections it = (*payload);
+          const EcalTimeBiasCorrections& it = (*payload);
 
           NbRows = it.EBTimeCorrAmplitudeBins.size();
           if (irun == 1) {

--- a/CondCore/EcalPlugins/plugins/EcalTimeOffsetConstant_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalTimeOffsetConstant_PayloadInspector.cc
@@ -40,7 +40,7 @@ namespace {
       if (payload.get()) {
         NbRows = 1;
         align = new TH2F("Time Offset Constant [ns]", "EB          EE", 2, 0, 2, NbRows, 0, NbRows);
-        EcalTimeOffsetConstant it = (*payload);
+        const EcalTimeOffsetConstant& it = (*payload);
 
         double row = NbRows - 0.5;
 
@@ -121,7 +121,7 @@ namespace {
           if (irun == 1)
             align = new TH2F("Ecal Time Offset Constant [ns]", "EB          EE", 2, 0, 2, NbRows, 0, NbRows);
 
-          EcalTimeOffsetConstant it = (*payload);
+          const EcalTimeOffsetConstant& it = (*payload);
 
           if (irun == 0) {
             val[0] = it.getEBValue();

--- a/CondCore/PhysicsToolsPlugins/plugins/PfCalibration_PayloadInspector.cc
+++ b/CondCore/PhysicsToolsPlugins/plugins/PfCalibration_PayloadInspector.cc
@@ -80,8 +80,8 @@ public:
 
     int pos = ((PerformancePayloadFromTFormulaExposed*)payload.get())->resultPos(T);
     auto formula = payload->formulaPayload();
-    auto formula_vec = formula.formulas();
-    auto limits_vec = formula.limits();
+    const auto& formula_vec = formula.formulas();
+    const auto& limits_vec = formula.limits();
     if (pos < 0 || pos > (int)formula_vec.size()) {
       edm::LogError("PfCalibration") << "Will not display image for " << functType[T]
                                      << " as it's not contained in the payload!";
@@ -89,7 +89,7 @@ public:
     }
     TCanvas canvas("PfCalibration", "PfCalibration", 1500, 800);
     canvas.cd();
-    auto formula_string = formula_vec[pos];
+    const auto& formula_string = formula_vec[pos];
     auto limits = limits_vec[pos];
 
     auto function_plot = new TF1("f1", formula_string.c_str(), limits.first, limits.second);

--- a/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
@@ -385,6 +385,7 @@ namespace {
           canvas.cd(index)->Update();
 
           std::vector<int> boundaries;
+          boundaries.reserve(v_nAPVs.at(index));
           for (size_t b = 0; b < v_nAPVs.at(index); b++) {
             boundaries.push_back(b * sistrip::STRIPS_PER_APV);
           }

--- a/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
@@ -345,6 +345,7 @@ namespace {
           canvas.cd(index)->Update();
 
           std::vector<int> boundaries;
+          boundaries.reserve(v_nAPVs.at(index));
           for (size_t b = 0; b < v_nAPVs.at(index); b++) {
             boundaries.push_back(b * sistrip::STRIPS_PER_APV);
           }

--- a/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
+++ b/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
@@ -50,7 +50,7 @@ JetCorrectorParameters::Definitions::Definitions(const std::string& fLine) {
     for (unsigned i = 0; i < npar; i++)
       mParVar.push_back(tokens[nvar + 2 + i]);
     mFormula = tokens[npar + nvar + 2];
-    std::string ss = tokens[npar + nvar + 3];
+    const std::string& ss = tokens[npar + nvar + 3];
     if (ss == "Response")
       mIsResponse = true;
     else if (ss == "Correction")
@@ -268,6 +268,7 @@ unsigned JetCorrectorParameters::size(unsigned fVar) const {
 //------------------------------------------------------------------------
 std::vector<float> JetCorrectorParameters::binCenters(unsigned fVar) const {
   std::vector<float> result;
+  result.reserve(size());
   for (unsigned i = 0; i < size(); ++i)
     result.push_back(record(i).xMiddle(fVar));
   return result;

--- a/CondFormats/SiPixelObjects/src/SiPixelCalibConfiguration.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelCalibConfiguration.cc
@@ -75,8 +75,8 @@ SiPixelCalibConfiguration::SiPixelCalibConfiguration(const pos::PixelCalibConfig
   }
   // copy row and column patterns
 
-  std::vector<std::vector<uint32_t> > cols = fancyConfig.columnList();
-  std::vector<std::vector<uint32_t> > rows = fancyConfig.rowList();
+  const std::vector<std::vector<uint32_t> > &cols = fancyConfig.columnList();
+  const std::vector<std::vector<uint32_t> > &rows = fancyConfig.rowList();
   for (uint32_t i = 0; i < cols.size(); ++i) {
     for (uint32_t j = 0; j < cols[i].size(); ++j) {
       short colval = cols[i][j];

--- a/CondTools/Ecal/src/EcalChannelStatusHandler.cc
+++ b/CondTools/Ecal/src/EcalChannelStatusHandler.cc
@@ -454,7 +454,7 @@ void popcon::EcalChannelStatusHandler::daqOut(const RunIOV& _myRun) {
                                              "EE_crystal_number");
 
       for (size_t mycrys = 0; mycrys < badCrystals.size(); mycrys++) {
-        EcalLogicID ecid_xt = badCrystals[mycrys];
+        const EcalLogicID& ecid_xt = badCrystals[mycrys];
         int zSide = 999;
         int log_id = ecid_xt.getLogicID();
         int yt2 = log_id % 1000;              //  EE_crystal_number:   2010100060 -> z=-1, x=100, y=60
@@ -488,7 +488,7 @@ void popcon::EcalChannelStatusHandler::daqOut(const RunIOV& _myRun) {
                                              "EB_crystal_number");
 
       for (size_t mycrys = 0; mycrys < badCrystals.size(); mycrys++) {
-        EcalLogicID ecid_xt = badCrystals[mycrys];
+        const EcalLogicID& ecid_xt = badCrystals[mycrys];
         int sm_num = ecid_xt.getID1();
         int log_id = ecid_xt.getLogicID();
         int xt2_num = log_id % 10000;

--- a/CondTools/Hcal/bin/corrGains.cc
+++ b/CondTools/Hcal/bin/corrGains.cc
@@ -38,7 +38,7 @@ corrGains::corrGains(const edm::ParameterSet& iConfig) {
 corrGains::~corrGains() {}
 
 void corrGains::analyze(edm::Event const&, edm::EventSetup const& iSetup) {
-  HcalTopology topo = iSetup.getData(tok_htopo_);
+  const HcalTopology& topo = iSetup.getData(tok_htopo_);
 
   HcalGains gainsIn(&topo);
   ;

--- a/CondTools/Hcal/bin/corrResps.cc
+++ b/CondTools/Hcal/bin/corrResps.cc
@@ -36,7 +36,7 @@ corrResps::corrResps(const edm::ParameterSet& iConfig) {
 corrResps::~corrResps() {}
 
 void corrResps::analyze(edm::Event const&, edm::EventSetup const& iSetup) {
-  HcalTopology topo = iSetup.getData(tok_htopo_);
+  const HcalTopology& topo = iSetup.getData(tok_htopo_);
 
   HcalRespCorrs respIn(&topo);
   std::ifstream inStream(fileIn.c_str());

--- a/CondTools/Hcal/bin/modGains.cc
+++ b/CondTools/Hcal/bin/modGains.cc
@@ -58,7 +58,7 @@ modGains::modGains(const edm::ParameterSet& iConfig) : vectorop(false) {
 modGains::~modGains() {}
 
 void modGains::analyze(edm::Event const&, edm::EventSetup const& iSetup) {
-  HcalTopology topo = iSetup.getData(tok_htopo_);
+  const HcalTopology& topo = iSetup.getData(tok_htopo_);
 
   // get base conditions
   std::cerr << fileIn << std::endl;

--- a/CondTools/Hcal/bin/scaleGains.cc
+++ b/CondTools/Hcal/bin/scaleGains.cc
@@ -37,7 +37,7 @@ scaleGains::scaleGains(const edm::ParameterSet& iConfig) {
 scaleGains::~scaleGains() {}
 
 void scaleGains::analyze(edm::Event const&, edm::EventSetup const& iSetup) {
-  HcalTopology topo = iSetup.getData(tok_htopo_);
+  const HcalTopology& topo = iSetup.getData(tok_htopo_);
 
   HcalGains gainsIn(&topo);
   ;


### PR DESCRIPTION
This PR suggests to apply the `clang-tidy` changes proposed by LLVM21 ( from CLANG_X IB). 
Also apply changes suggested by @perrotta to improve few `std::vector` initialization 