### PR TITLE
do not optimize `HistoContainer` size in `PixelClustering`

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
@@ -16,6 +16,7 @@
 #include "HeterogeneousCore/AlpakaInterface/interface/SimpleVector.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/warpsize.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/debug.h"
 
 //#define GPU_DEBUG
 
@@ -579,6 +580,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
 
         [[maybe_unused]] const uint32_t blockDimension = alpaka::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u];
         // assume that we can cover the whole module with up to maxIterClustering blockDimension-wide iterations
+        ALPAKA_ACCELERATOR_NAMESPACE::debug::do_not_optimise(hist.size());
         ALPAKA_ASSERT_ACC((hist.size() / blockDimension) < TrackerTraits::maxIterClustering);
 
         // number of elements per thread


### PR DESCRIPTION
#### PR description:

Proposed solution for https://github.com/cms-sw/cmssw/issues/49464, according to the suggestion at https://github.com/cms-sw/cmssw/issues/49464#issuecomment-3581729197.

#### PR validation:

Run `runTheMatrix.py --what gpu -l 18434.402` on a machine within the NGT farm (equipped with a `AMD Instinct MI300X 192GB`) and no crashes observed.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A