### PR TITLE
[15_1_0_patch3_X] Propagate cache disable to 2025 eras

### DIFF
--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -97,6 +97,10 @@ def customisePostEra_Run3_2024(process):
 def customisePostEra_Run3_2025(process):
     #start with a repeat of 2024
     customisePostEra_Run3_2024(process)
+    process.source.cacheSize = cms.untracked.uint32(0)
+    process.add_(cms.Service("SiteLocalConfigService",
+                             overrideSourceCacheHintDir = cms.untracked.string("lazy-download")
+                             ))
     return process
 
 def customisePostEra_Run3_express_trackingOnly(process):
@@ -143,18 +147,10 @@ def customisePostEra_Run3_2024_ppRef(process):
 
 def customisePostEra_Run3_pp_on_PbPb_2025(process):
     customisePostEra_Run3_2025(process)
-    process.source.cacheSize = cms.untracked.uint32(0)
-    process.add_(cms.Service("SiteLocalConfigService",
-                             overrideSourceCacheHintDir = cms.untracked.string("lazy-download")
-                             ))
     return process
 
 def customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters_2025(process):
     customisePostEra_Run3_pp_on_PbPb_2025(process)
-    process.source.cacheSize = cms.untracked.uint32(0)
-    process.add_(cms.Service("SiteLocalConfigService",
-                             overrideSourceCacheHintDir = cms.untracked.string("lazy-download")
-                             ))
     return process
 
 def customisePostEra_Run3_2025_UPC(process):


### PR DESCRIPTION
#### PR description:
Propagate cache disable to 2025 eras (include ones used in pp)

#### PR validation:
-

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
No need of backport
