### PR TITLE
Fix phase-2 HLT workflow with mkFit fit, reintroducing HP selection to relevant sequence

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
@@ -132,6 +132,8 @@ _HLTInitialStepSequenceSingleIterPatatrackLSTSeedingMkFitFitTracking = cms.Seque
     +hltInitialStepTrackCandidatesMkFit
     +hltInitialStepTrackCandidatesMkFitFit
     +hltInitialStepTracks
+    +hltInitialStepTrackCutClassifier
+    +hltInitialStepTrackSelectionHighPurity
 )
 
 from Configuration.ProcessModifiers.trackingMkFitFit_cff import trackingMkFitFit


### PR DESCRIPTION
### PR description:

As per title, this PR is meant to fix phase-2 HLT workflow with mkFit fit, reintroducing HP selection to relevant sequence, following PRs #49382, #49383 and #49339.

**URGENT**: ideally to go to 16_0_0_pre3, too.

### PR validation:

It fixes workflow offset 0.7572 (https://github.com/trackreco/cmssw/blob/master/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py#L2048), where the corresponding (procModifiers modified) tracking sequence is otherwise incomplete.
