### PR TITLE
[15.1.X] bugfix: use correct `alignmentTokenSrc` for SiPixelAli HG flavours

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvesterHGCombined_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvesterHGCombined_cff.py
@@ -80,6 +80,7 @@ SiPixelAliDQMModuleHGCombined = SiPixelAliDQMModule.clone()
 SiPixelAliDQMModuleHGCombined.outputFolder = "AlCaReco/SiPixelAliHGCombined"
 SiPixelAliDQMModuleHGCombined.MillePedeFileReader.fileDir = "HGCombinedAlignment/"
 SiPixelAliDQMModuleHGCombined.MillePedeFileReader.isHG = True
+SiPixelAliDQMModuleHGCombined.alignmentTokenSrc = "SiPixelAliPedeAlignmentProducerHGCombined"
 
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 dqmEnvSiPixelAliHGCombined = DQMEDHarvester('DQMHarvestingMetadata',

--- a/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvesterHG_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvesterHG_cff.py
@@ -69,6 +69,7 @@ SiPixelAliDQMModuleHG = SiPixelAliDQMModule.clone()
 SiPixelAliDQMModuleHG.outputFolder = "AlCaReco/SiPixelAliHG"
 SiPixelAliDQMModuleHG.MillePedeFileReader.fileDir = "HGalignment/"
 SiPixelAliDQMModuleHG.MillePedeFileReader.isHG = True
+SiPixelAliDQMModuleHG.alignmentTokenSrc = "SiPixelAliPedeAlignmentProducerHG"
 
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 dqmEnvSiPixelAliHG = DQMEDHarvester('DQMHarvestingMetadata',

--- a/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvesterHLTHGCombined_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvesterHLTHGCombined_cff.py
@@ -80,6 +80,7 @@ SiPixelAliDQMModuleHLTHGCombined = SiPixelAliDQMModule.clone()
 SiPixelAliDQMModuleHLTHGCombined.outputFolder = "AlCaReco/SiPixelAliHLTHGCombined"
 SiPixelAliDQMModuleHLTHGCombined.MillePedeFileReader.fileDir = "HLTHGCombinedAlignment/"
 SiPixelAliDQMModuleHLTHGCombined.MillePedeFileReader.isHG = True
+SiPixelAliDQMModuleHLTHGCombined.alignmentTokenSrc = "SiPixelAliPedeAlignmentProducerHLTHGCombined"
 
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 dqmEnvSiPixelAliHLTHGCombined = DQMEDHarvester('DQMHarvestingMetadata',


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/49514

#### PR description:

Title say it all.
This extends the mechanism used in https://github.com/cms-sw/cmssw/pull/31411 (which fixed https://github.com/cms-sw/cmssw/issues/31381) to all the SiPixelAligment High Granularity flavours.
This was noticed by the Tracker Alignment group during the 2025 PbPb run

> For all HI runs till now, the GUI shows no movements for any of the structures. No binaries are found and there is no valid pede exit code. For example: https://cern.ch/uq5mn.
But looking at the [SiPixelAliHG_PCL_v0_hlt](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/SiPixelAliHG_PCL_v0_hlt) tag, HG seems to be producing new payloads quite frequently.

For some reason this went unnoticed in the past couple of years.

#### PR validation:

Run successfully

```bash
#!/bin/bash -ex

cmsDriver.py stepHarvestBlock \
             -s ALCAHARVEST:SiPixelAliHG \
             --conditions 150X_dataRun3_Express_v2 \
             --scenario pp \
             --data \
             --dasquery='file dataset=/StreamExpress/Run2025G-PromptCalibProdSiPixelAliHG-Express-v1/ALCAPROMPT run=398859' \
             --era Run3_2025 \
             --customise_command "process.DQMStore.collateHistograms = cms.untracked.bool(True)\nprocess.dqmSaver.saveByRun=cms.untracked.int32(-1)\n process.dqmSaver.saveAtJobEnd=cms.untracked.bool(True)
\nprocess.dqmSaver.forceRunNumber=cms.untracked.int32(999999)" \
             --no_exec

cmsRun stepHarvestBlock_ALCAHARVEST.py >& stepHarvestBlock_ALCAHARVEST.log
```

and observed that the output DQM file is correctly filled.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

plain backport of https://github.com/cms-sw/cmssw/pull/49514 to the 2025 PbPb production release.