### PR TITLE
[NGT] add "pixel-less" and "withPixels" track validation monitoring for HLT

### DIFF
--- a/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
+++ b/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
@@ -28,6 +28,7 @@ public:
         maxChi2_(cfg.getParameter<double>("maxChi2")),
         minHit_(cfg.getParameter<int>("minHit")),
         minPixelHit_(cfg.getParameter<int>("minPixelHit")),
+        maxPixelHit_(cfg.getParameter<int>("maxPixelHit")),
         minLayer_(cfg.getParameter<int>("minLayer")),
         min3DLayer_(cfg.getParameter<int>("min3DLayer")),
         usePV_(false),
@@ -97,6 +98,7 @@ public:
     desc.add<int>("minHit", 0);
     desc.add<int>("minLayer", 3);
     desc.add<int>("minPixelHit", 0);
+    desc.add<int>("maxPixelHit", 99);
     desc.add<std::vector<std::string> >("algorithm", {});
     desc.add<std::vector<std::string> >("algorithmMaskContains", {});
     desc.add<std::vector<std::string> >("originalAlgorithm", {});
@@ -149,6 +151,7 @@ public:
 
     return ((algo_ok & quality_ok) && t.hitPattern().numberOfValidHits() >= minHit_ &&
             t.hitPattern().numberOfValidPixelHits() >= minPixelHit_ &&
+            t.hitPattern().numberOfValidPixelHits() <= maxPixelHit_ &&
             t.hitPattern().trackerLayersWithMeasurement() >= minLayer_ &&
             t.hitPattern().pixelLayersWithMeasurement() + t.hitPattern().numberOfValidStripLayersWithMonoAndStereo() >=
                 min3DLayer_ &&
@@ -167,6 +170,7 @@ private:
   double maxChi2_;
   int minHit_;
   int minPixelHit_;
+  int maxPixelHit_;
   int minLayer_;
   int min3DLayer_;
   bool usePV_;

--- a/CommonTools/RecoAlgos/python/recoTrackSelectorPSet_cfi.py
+++ b/CommonTools/RecoAlgos/python/recoTrackSelectorPSet_cfi.py
@@ -18,6 +18,7 @@ recoTrackSelectorPSet = cms.PSet(
     min3DLayer = cms.int32(0),
     minHit = cms.int32(0),
     minPixelHit = cms.int32(0),
+    maxPixelHit = cms.int32(99),
     beamSpot = cms.InputTag("offlineBeamSpot"),
     usePV = cms.bool(False),
     vertexTag = cms.InputTag('offlinePrimaryVertices'),

--- a/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
+++ b/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Validation.RecoTrack.HLTmultiTrackValidator_cfi import *
 from SimGeneral.TrackingAnalysis.trackingParticleNumberOfLayersProducer_cff import *
+from Validation.RecoTrack.cutsRecoTracks_cfi import cutsRecoTracks as _cutsRecoTracks
 
 hltTrackValidator = hltMultiTrackValidator.clone(
     label = [
@@ -15,12 +16,30 @@ hltTrackValidator = hltMultiTrackValidator.clone(
     ]
 )
 
+# Pixel-less track selector
+hltPixelLessTracks = _cutsRecoTracks.clone(
+    throwOnMissing = cms.bool(False), # HLT collection might be missing
+    src = "hltMergedTracks",
+    minLayer = 3,
+    maxPixelHit = 0
+)
+
+# Tracks with at least one pixel hit
+hltWithPixelTracks = _cutsRecoTracks.clone(
+    throwOnMissing = cms.bool(False), # HLT collection might be missing
+    src = "hltMergedTracks",
+    minLayer = 3,
+    minPixelHit = 1
+)
+
 hltMultiTrackValidationTask = cms.Task(
     hltTPClusterProducer
     , trackingParticleNumberOfLayersProducer
     , hltTrackAssociatorByHits
 )
 hltMultiTrackValidation = cms.Sequence(
+    hltPixelLessTracks+
+    hltWithPixelTracks+
     hltTrackValidator,
     hltMultiTrackValidationTask
 )
@@ -32,17 +51,19 @@ from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(hltTrackValidator, _modifyForRun3)
 
 def _modifyForPhase2(trackvalidator):
-    trackvalidator.label = ["hltGeneralTracks", "hltPhase2PixelTracks", "hltInitialStepTrackSelectionHighPurity", "hltHighPtTripletStepTrackSelectionHighPurity"]
+    trackvalidator.label = ["hltGeneralTracks", "hltPhase2PixelTracks", "hltInitialStepTrackSelectionHighPurity", "hltHighPtTripletStepTrackSelectionHighPurity", "hltPixelLessTracks", "hltWithPixelTracks"]
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(hltTrackValidator, _modifyForPhase2)
+phase2_tracker.toModify(hltPixelLessTracks, src = "hltGeneralTracks")
+phase2_tracker.toModify(hltWithPixelTracks, src = "hltGeneralTracks")
 
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 from Configuration.ProcessModifiers.ngtScouting_cff import ngtScouting
 from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
 
 def _modifyForSingleIterPatatrack(trackvalidator):
-    trackvalidator.label = ["hltGeneralTracks", "hltPhase2PixelTracks", "hltInitialStepTrackSelectionHighPurity"]
+    trackvalidator.label = ["hltGeneralTracks", "hltPhase2PixelTracks", "hltInitialStepTrackSelectionHighPurity", "hltPixelLessTracks", "hltWithPixelTracks"]
 singleIterPatatrack.toModify(hltTrackValidator, _modifyForSingleIterPatatrack)
 
 def _modifyForNGTScouting(trackvalidator):
@@ -50,5 +71,5 @@ def _modifyForNGTScouting(trackvalidator):
 (ngtScouting & ~trackingLST).toModify(hltTrackValidator, _modifyForNGTScouting)
 
 def _modifyForNGTScoutingLST(trackvalidator):
-    trackvalidator.label = ["hltGeneralTracks", "hltPhase2PixelTracks", "hltInitialStepTracksT5TCLST"]
+    trackvalidator.label = ["hltGeneralTracks", "hltPhase2PixelTracks", "hltInitialStepTracksT5TCLST", "hltPixelLessTracks", "hltWithPixelTracks"]
 (ngtScouting & trackingLST).toModify(hltTrackValidator, _modifyForNGTScoutingLST)

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -379,6 +379,7 @@ std::unique_ptr<RecoTrackSelectorBase> MTVHistoProducerAlgoForTracker::makeRecoT
   psetTrack.addParameter("maxChi2", 1e10);
   psetTrack.addParameter("minHit", 0);
   psetTrack.addParameter("minPixelHit", 0);
+  psetTrack.addParameter("maxPixelHit", 99);
   psetTrack.addParameter("minLayer", 0);
   psetTrack.addParameter("min3DLayer", 0);
   psetTrack.addParameter("quality", std::vector<std::string>{});


### PR DESCRIPTION
#### PR description:

Along the lines of what discussed at https://github.com/cms-sw/cmssw/pull/49382#issuecomment-3552909165 I have implemented the monitoring of pixel-less HLT tracks for phase-2 validation purposes.

#### PR validation:

I've run `runTheMatrix.py -l 34434.755 -t 4 -j 8 --nEvents 100` and been able to see the contribution of T5s as

<img width="1851" height="1166" alt="Screenshot from 2025-11-27 15-07-55" src="https://github.com/user-attachments/assets/fa3f298d-392e-4479-ad6a-ed7baefc935e" />

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A