### PR TITLE
[JMENano] Backport of #49518 (Fix buggy configuration for Run2 UL JMENanoV15) to 15_1_X

### DIFF
--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -1179,6 +1179,7 @@ def ConfigureAK4GenJets(proc, genJA):
       filter = cms.bool(False)
     )
     proc.jetMCTask.add(proc.AK4GenJetsNoNu)
+    proc.genJetTable.src = "AK4GenJetsNoNu"
     proc.genJetTable.cut = ""
     proc.genJetTable.doc = "AK4 Gen jets (made with visible genparticles) with pt > 5 GeV. Sourced from slimmedGenJets"
     proc.genJetFlavourTable.cut = proc.genJetTable.cut

--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -1468,5 +1468,11 @@ def PrepJMECustomNanoAOD(process):
   if runOnMC:
     process.genWeightsTable.keepAllPSWeights = True
 
-  return process
+  ###########################################################################
+  # Make sure that the Puppi weights are recomputed with the latest version
+  ###########################################################################
+  (run2_nanoAOD_106Xv2 | run3_nanoAOD_pre142X | nanoAOD_rePuppi).toModify(
+    process, lambda p: RecomputePuppiWeights(p)
+  )
 
+  return process


### PR DESCRIPTION
Backport of #49518

#### Original PR description:

This PR cleans up the modifiers for Run2 UL JMENanoV15 production, fixing Issue #49513. It also sets up puppi weights to be recomputed for Run2 UL MiniAODv2 and pre142X MiniAODs, thus eliminating the need for cmsDriver customization commands.
