### PR TITLE
Fix ownership of HepMC3::GenEvent

### DIFF
--- a/GeneratorInterface/Core/interface/GeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/GeneratorFilter.h
@@ -261,7 +261,7 @@ namespace edm {
       ev.put(std::move(genEventInfo3));
 
       std::unique_ptr<HepMC3Product> bare_product(new HepMC3Product());
-      bare_product->addHepMCData(event3.release());
+      bare_product->addHepMCData(*event3);
       ev.put(std::move(bare_product), "unsmeared");
     }
 

--- a/GeneratorInterface/Core/interface/HadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/HadronizerFilter.h
@@ -340,7 +340,7 @@ namespace edm {
       ev.put(std::move(finalGenEventInfo3));
 
       std::unique_ptr<HepMC3Product> bare_product(new HepMC3Product());
-      bare_product->addHepMCData(finalEvent3.release());
+      bare_product->addHepMCData(*finalEvent3);
       ev.put(std::move(bare_product), "unsmeared");
     }
 

--- a/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
+++ b/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
@@ -240,7 +240,7 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
   }
 
   // Finalize HepMC event record
-  auto hepmc_product = std::make_unique<edm::HepMC3Product>(&hepmc_event);
+  auto hepmc_product = std::make_unique<edm::HepMC3Product>(hepmc_event);
   event.put(std::move(hepmc_product), "unsmeared");
 }
 

--- a/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
@@ -69,9 +69,9 @@ void BaseEvtVtxGenerator::produce(Event& evt, const EventSetup&) {
     if (!found)
       throw cms::Exception("ProductAbsent") << "No HepMCProduct, tried to get HepMC3Product, but it is also absent.";
 
-    HepMC3::GenEvent* genevt3 = new HepMC3::GenEvent();
-    genevt3->read_data(*HepUnsmearedMCEvt3->GetEvent());
-    HepMC3Product* productcopy3 = new HepMC3Product(genevt3);
+    HepMC3::GenEvent genevt3;
+    genevt3.read_data(*HepUnsmearedMCEvt3->GetEvent());
+    auto productcopy3 = std::make_unique<HepMC3Product>(genevt3);
     ROOT::Math::XYZTVector VertexShift = vertexShift(engine);
     productcopy3->applyVtxGen(HepMC3::FourVector(VertexShift.x(), VertexShift.y(), VertexShift.z(), VertexShift.t()));
 
@@ -91,8 +91,7 @@ void BaseEvtVtxGenerator::produce(Event& evt, const EventSetup&) {
       }
     }
 
-    std::unique_ptr<edm::HepMC3Product> HepMC3Evt(productcopy3);
-    evt.put(std::move(HepMC3Evt));
+    evt.put(std::move(productcopy3));
   }
 
   return;

--- a/SimDataFormats/GeneratorProducts/interface/HepMC3Product.h
+++ b/SimDataFormats/GeneratorProducts/interface/HepMC3Product.h
@@ -23,10 +23,10 @@ namespace edm {
   public:
     HepMC3Product() : isVtxGenApplied_(false), isVtxBoostApplied_(false), isPBoostApplied_(false) {}
 
-    explicit HepMC3Product(const HepMC3::GenEvent *evt);
+    explicit HepMC3Product(const HepMC3::GenEvent &evt);
     ~HepMC3Product();
 
-    void addHepMCData(const HepMC3::GenEvent *evt);
+    void addHepMCData(const HepMC3::GenEvent &evt);
 
     void applyVtxGen(HepMC3::FourVector const *vtxShift) { applyVtxGen(*vtxShift); }
     void applyVtxGen(HepMC3::FourVector const &vtxShift);

--- a/SimDataFormats/GeneratorProducts/src/HepMC3Product.cc
+++ b/SimDataFormats/GeneratorProducts/src/HepMC3Product.cc
@@ -16,14 +16,14 @@
 using namespace edm;
 using namespace std;
 
-HepMC3Product::HepMC3Product(const HepMC3::GenEvent* evt)
+HepMC3Product::HepMC3Product(const HepMC3::GenEvent& evt)
     : isVtxGenApplied_(false), isVtxBoostApplied_(false), isPBoostApplied_(false) {
   addHepMCData(evt);
 }
 
 HepMC3Product::~HepMC3Product() = default;
 
-void HepMC3Product::addHepMCData(const HepMC3::GenEvent* evt) { evt->write_data(evt_); }
+void HepMC3Product::addHepMCData(const HepMC3::GenEvent& evt) { evt.write_data(evt_); }
 
 void HepMC3Product::applyVtxGen(HepMC3::FourVector const& vtxShift) {
   //std::cout<< " applyVtxGen called " << isVtxGenApplied_ << endl;


### PR DESCRIPTION
#### PR description:

The HepMC3Product has never taken ownership of the HepMC3::GenEvent. Callers no longer use `release()` and the interface has been changed to take a reference to make non-ownership clearer.

#### PR validation:

Checking memory after the fix shows memory stays constant.

resolves https://github.com/cms-sw/framework-team/issues/1704