### PR TITLE
Make the container-in-container feature optional

### DIFF
--- a/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh
+++ b/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh
@@ -26,6 +26,19 @@ echo "%MSG-MG5 random seed used for the run = $rnum"
 ncpu=${4}
 echo "%MSG-MG5 thread count requested = $ncpu"
 
+use_singularity=0
+
+for arg in "${@:5}"; do
+  if [ "$arg" = "use_singularity" ]; then
+      use_singularity=1
+  else
+      extra_args+=("$arg")
+  fi
+done
+
+# Rebuild all positional parameters excluding the use_singularity keyword
+set -- "$path" "$nevt" "$rnum" "$ncpu" "${extra_args[@]}"
+
 echo "%MSG-MG5 residual/optional arguments = ${@:5}"
 
 if [ -n "${5}" ]; then
@@ -82,7 +95,12 @@ if [ "$use_gridpack_env" != false ]; then
 fi
 
 #generate events
-${sing} ./runcmsgrid.sh $nevt $rnum $ncpu ${@:5}
+if [ "$use_singularity" -eq 1 ]; then
+    echo "Using singularity for running events"
+    ${sing} ./runcmsgrid.sh $nevt $rnum $ncpu ${@:5}
+else
+    ./runcmsgrid.sh $nevt $rnum $ncpu ${@:5}
+fi
 
 mv cmsgrid_final.lhe $LHEWORKDIR/
 


### PR DESCRIPTION
This PR aims at making optional the container-in-container feature previously included.

The logic behind this implementation is:
- keep the `run_generic_tarball_cvmfs.sh` back-compatible and include only minimal changes, e.g. without adding new optional positional parameters and altering the order of the existing ones.
- change only the `run_generic_tarball_cvmfs.sh` script without touching the `ExternalLHEProducer`.

The solution I came up with is adding the `use_singularity` keyword as an optional argument. If this keyword is found, it will switch the corresponding flag and the event generation will be run through singularity, but all the additional optional parameters will be kept as they were previously (using the `set`  builtin).

There are for sure alternative solutions, so I would like to hear other experts opinion and I'm happy to adapt the script if needed.

Using this implementation, the singularity run will be triggered using the following ExternalLHEProducer snippet:
```python
externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/PATH_TO_GRIDPACK','use_singularity'),
    nEvents = cms.untracked.uint32(5000),
    numberOfParameters = cms.uint32(2),
    outputFile = cms.string('cmsgrid_final.lhe'),
    generateConcurrently = cms.untracked.bool(False),
    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
)
```
Which contains the additional `'use_singularity'` string in `args` and `numberOfParameters = cms.uint32(2)` instead of `1`.

FYI: @DickyChant @vlimant @stlammel @srimanob @ckoraka 