### PR TITLE
Use RNTuple streamer storage for deque and list

### DIFF
--- a/DataFormats/StdDictionaries/src/classes_def_others.xml
+++ b/DataFormats/StdDictionaries/src/classes_def_others.xml
@@ -13,11 +13,11 @@
  <class name="std::bitset<64>"/>
  <class name="std::bitset<96>"/>
  <class name="std::bitset<128>"/>
- <class name="std::deque<int>"/>
+ <class name="std::deque<int>" rntupleStreamerMode="true"/>
  <class name="std::forward_iterator_tag"/>
  <class name="std::input_iterator_tag"/>
  <class name="std::less<int>"/>
- <class name="std::list<int>"/>
+ <class name="std::list<int>" rntupleStreamerMode="true"/>
  <class name="std::multimap<double,double>"/>
  <class name="std::output_iterator_tag"/>
  <class name="std::random_access_iterator_tag"/>


### PR DESCRIPTION
#### PR description:

These are primarily used for testing just to be sure those types can be stored.

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/1700