### PR TITLE
Fix LHEPtFilter default parameters

### DIFF
--- a/GeneratorInterface/GenFilters/plugins/LHEPtFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/LHEPtFilter.cc
@@ -122,7 +122,11 @@ bool LHEPtFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
 
 void LHEPtFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
+  desc.add<std::vector<int>>("selectedPdgIds", {});
+  desc.add<double>("ptMin", 0);
+  desc.add<double>("ptMax", -1);      // default is -1, meaning no max
   desc.add<bool>("isScalar", false);  // default is false
+  desc.add<edm::InputTag>("src", edm::InputTag("externalLHEProducer"));
   descriptions.addDefault(desc);
 }
 


### PR DESCRIPTION
#### PR description:

This PR fixes the functionality of the `LHEPtFilter` which will encounter illegal parameters due to missing entries from the fillDescriptions defaults. The bad behavior was mistakenly introduced in  #48505

#### PR validation:

Auto generated `cfi` looks correct. Main validation on generation done with equivalent changes for `10_6_X` .

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Another PR will be opened for a backport to `CMSSW_10_6_X`
