### PR TITLE
[10_6_X] Fix LHEPtFilter default parameters

### DIFF
--- a/GeneratorInterface/GenFilters/src/LHEPtFilter.cc
+++ b/GeneratorInterface/GenFilters/src/LHEPtFilter.cc
@@ -122,7 +122,11 @@ bool LHEPtFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
 
 void LHEPtFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
+  desc.add<std::vector<int>>("selectedPdgIds", {});
+  desc.add<double>("ptMin", 0);
+  desc.add<double>("ptMax", -1);  // default is -1, meaning no max
   desc.add<bool>("isScalar", false);  // default is false
+  desc.add<edm::InputTag>("src", edm::InputTag("externalLHEProducer"));
   descriptions.addDefault(desc);
 }
 


### PR DESCRIPTION
#### PR description:

This PR fixes the functionality of the LHEPtFilter which will encounter illegal parameters due to missing entries from the fillDescriptions defaults.

The exception message is:
```
----- Begin Fatal Exception 09-Dec-2025 13:15:04 CST-----------------------
An exception of category 'Configuration' occurred while
   [0] Constructing the EventProcessor
   [1] Validating configuration of module: class=LHEPtFilter label='LHEPtFilter'
Exception Message:
Illegal parameters found in configuration.  The parameters are named:
 'ptMax'
 'ptMin'
 'selectedPdgIds'
 'src'
You could be trying to use parameter names that are not
allowed for this plugin or they could be misspelled.
----- End Fatal Exception -------------------------------------------------
```

#### PR validation:

Tested in fragment fed to cmsDriver for generation in `CMSSW_10_6_48_patch1`. An example config is located here: https://[cernbox.cern.ch/s/QKgZpKsv1r0ogHq](https://cernbox.cern.ch/s/QKgZpKsv1r0ogHq)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is the backport of #49533, and is intended for CMSSW_10_6_X.
