### PR TITLE
Fix residualDecay code and 3 test configurations in /test

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8HepMC3Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8HepMC3Hadronizer.cc
@@ -1041,12 +1041,11 @@ bool Pythia8HepMC3Hadronizer::residualDecay() {
                                p->production_vertex()->position().t()));
         prod_vtx0->add_particle_in(p);
         (event3().get())->add_vertex(prod_vtx0);
-        HepMC3::GenParticle *pnew;
         Pythia8::Event pyev = fDecayer->event;
         double momFac = 1.;
         for (int i = 2; i < pyev.size(); ++i) {
           // Fill the particle.
-          pnew = new HepMC3::GenParticle(
+          HepMC3::GenParticlePtr pnew = make_shared<HepMC3::GenParticle>(
               HepMC3::FourVector(
                   momFac * pyev[i].px(), momFac * pyev[i].py(), momFac * pyev[i].pz(), momFac * pyev[i].e()),
               pyev[i].id(),

--- a/GeneratorInterface/Pythia8Interface/test/pythia8hmc3_photos_ZToTauTau_13TeV_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/pythia8hmc3_photos_ZToTauTau_13TeV_cfg.py
@@ -46,7 +46,8 @@ process.generator = cms.EDFilter("Pythia8HepMC3GeneratorFilter",
             'PhaseSpace:mHatMin = 50.',
             '23:onMode = off',
             '23:onIfAny = 15',
-            'ParticleDecays:allowPhotonRadiation = on',
+            #'ParticleDecays:allowPhotonRadiation = on', # allow photons from hadron decays (OBSOLETE in pythia8316)
+            'HadronLevel:QED = on', # allow photons from hadron decays
             'TimeShower:QEDshowerByL = off',
             ),
 		parameterSets = cms.vstring('pythia8CommonSettings',


### PR DESCRIPTION
#### PR description:

 This fixes a possible memory leak by changing the code to a proper one
 3 test configurations in /test did not work, two of them broke after the upgrade to pythia8 316. This is fixed.

#### PR validation:

 Validated by running test configurations in /test. The residualDecay code is tested by running with a temporary test code