### PR TITLE
[15_1_X] Fix LHEPtFilter default parameters

### DIFF
--- a/GeneratorInterface/GenFilters/plugins/LHEPtFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/LHEPtFilter.cc
@@ -122,7 +122,11 @@ bool LHEPtFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
 
 void LHEPtFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
+  desc.add<std::vector<int>>("selectedPdgIds", {});
+  desc.add<double>("ptMin", 0);
+  desc.add<double>("ptMax", -1);      // default is -1, meaning no max
   desc.add<bool>("isScalar", false);  // default is false
+  desc.add<edm::InputTag>("src", edm::InputTag("externalLHEProducer"));
   descriptions.addDefault(desc);
 }
 


### PR DESCRIPTION
#### PR description:

Verbatim backport of #49533 for `15_1_X`. The PR which these changes now fix was initially introduced with the `CMSSW_15_1_0_pre5` release.

#### PR validation:

Auto generated cfi looks correct. Main validation on generation done with equivalent changes for `10_6_X` .

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Original PR is #49533, this backport is needed to fix the functionality of the LHEPtFilter in the `15_1_X` releases