### PR TITLE
Safely write THF1 to file in BMixingModule

### DIFF
--- a/Mixing/Base/src/BMixingModule.cc
+++ b/Mixing/Base/src/BMixingModule.cc
@@ -148,12 +148,13 @@ namespace {
                 << " The histogram created from the x, P(x) values will be written into the root file "
                 << histoFileName;
 
-            TFile* outfile = new TFile(histoFileName.c_str(), "RECREATE");
-            hprob->Write();
-            outfile->Write();
-            outfile->Close();
-            outfile->Delete();
-
+            {
+              TFile outfile(histoFileName.c_str(), "RECREATE");
+              hprob->SetDirectory(&outfile);
+              outfile.Write();  //this forces the histogram to be written
+              hprob->SetDirectory(nullptr);
+              outfile.Close();
+            }
             pileupconfig = std::make_shared<edm::PileUpConfig>(sourceName, averageNumber, hprob, playback);
             edm::LogInfo("MixingModule") << " Created source " << sourceName << " with averageNumber " << averageNumber;
           }


### PR DESCRIPTION
#### PR description:

The module writes a histogram containing the probability distribution. It was unclear how it worked before as the HF1 should not have been attached to the TFile. Now the connection is obvious.

#### PR validation:

I ran WF 12634.21 and checked that the created root file holds the histogram and the histogram had entries.

resolves https://github.com/cms-sw/framework-team/issues/1707