### PR TITLE
Reuse the device queue from produce in transform

### DIFF
--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/EDMetadata.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/EDMetadata.h
@@ -46,6 +46,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     // TODO: Returning non-const reference here is BAD
     Queue& queue() const { return *queue_; }
 
+    // Used by ProducerBase to reuse the product's queue for enqueueing
+    // the host copy.
+    std::shared_ptr<Queue> shared_queue() const { return queue_; }
+
     void recordEvent() {}
     void discardEvent() {}
 
@@ -69,6 +73,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     // Alpaka operations do not accept a temporary as an argument
     // TODO: Returning non-const reference here is BAD
     Queue& queue() const { return *queue_; }
+
+    // Used by ProducerBase to reuse the product's queue for enqueueing
+    // the host copy.
+    std::shared_ptr<Queue> shared_queue() const { return queue_; }
 
     void enqueueCallback(edm::WaitingTaskWithArenaHolder holder);
 

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/EDMetadataAcquireSentry.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/EDMetadataAcquireSentry.h
@@ -1,6 +1,8 @@
 #ifndef HeterogeneousCore_AlpakaCore_interface_alpaka_EDMetadataAcquireSentry_h
 #define HeterogeneousCore_AlpakaCore_interface_alpaka_EDMetadataAcquireSentry_h
 
+#include <memory>
+
 #include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/EDMetadata.h"
@@ -19,7 +21,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       EDMetadataAcquireSentry(edm::StreamID stream, edm::WaitingTaskWithArenaHolder holder, bool synchronize);
 
       // Constructor overload to be called from registerTransformAsync()
-      EDMetadataAcquireSentry(Device const& device, edm::WaitingTaskWithArenaHolder holder, bool synchronize = false);
+      EDMetadataAcquireSentry(std::shared_ptr<Queue> queue,
+                              edm::WaitingTaskWithArenaHolder holder,
+                              bool synchronize = false);
 
       EDMetadataAcquireSentry(EDMetadataAcquireSentry const&) = delete;
       EDMetadataAcquireSentry& operator=(EDMetadataAcquireSentry const&) = delete;

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
@@ -134,14 +134,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         this->registerTransformAsync(
             token,
             [](edm::StreamID, TToken const& deviceProduct, edm::WaitingTaskWithArenaHolder holder) {
-              auto const& device = alpaka::getDev(deviceProduct.template metadata<EDMetadata>().queue());
-              detail::EDMetadataAcquireSentry sentry(device, std::move(holder));
+              auto& queue = deviceProduct.template metadata<EDMetadata>().queue();
+              detail::EDMetadataAcquireSentry sentry(std::make_shared<Queue>(queue), std::move(holder));
               auto metadataPtr = sentry.metadata();
               constexpr bool tryReuseQueue = true;
               TProduct const& productOnDevice =
                   deviceProduct.template getSynchronized<EDMetadata>(*metadataPtr, tryReuseQueue);
 
-              auto productOnHost = CopyT::copyAsync(metadataPtr->queue(), productOnDevice);
+              auto productOnHost = CopyT::copyAsync(queue, productOnDevice);
 
               // Need to keep the EDMetadata object from sentry.finish()
               // alive until the synchronization

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
@@ -134,14 +134,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         this->registerTransformAsync(
             token,
             [](edm::StreamID, TToken const& deviceProduct, edm::WaitingTaskWithArenaHolder holder) {
-              auto& queue = deviceProduct.template metadata<EDMetadata>().queue();
-              detail::EDMetadataAcquireSentry sentry(std::make_shared<Queue>(queue), std::move(holder));
+              auto queue = deviceProduct.template metadata<EDMetadata>().shared_queue();
+              detail::EDMetadataAcquireSentry sentry(queue, std::move(holder));
               auto metadataPtr = sentry.metadata();
               constexpr bool tryReuseQueue = true;
               TProduct const& productOnDevice =
                   deviceProduct.template getSynchronized<EDMetadata>(*metadataPtr, tryReuseQueue);
 
-              auto productOnHost = CopyT::copyAsync(queue, productOnDevice);
+              auto productOnHost = CopyT::copyAsync(*queue, productOnDevice);
 
               // Need to keep the EDMetadata object from sentry.finish()
               // alive until the synchronization


### PR DESCRIPTION
#### PR description:

Modify the "transform" that the framework uses to automatically copy device products to the host to reuse the same device queue associated with the product, instead of an independent one.

This make the host copy use the same queue as any potential module that consumes the device product, slightly reducing the potential parallelism. On the other hand it cuts the number of device queues by about 30%, potentially improving the performance of the GPU runtime:

  * on an AMD MI300X GPU with a "reduced" HLT menu running with 16 threads and 16 streams, this gives a speed-up of over 10%.

  * on an NVIDIA L40S GPU with the same "reduced" HLT menu running with 32 threads and 32 streams, the changes do not have any measurable impact (maybe a speed-up of 0.1~0.2%, well within the error).

  * on an NVIDIA L40S GPU with the same "reduced" HLT menu running with 2 jobs, each with 16 threads and 16 streams, there is a small but measurable speed-up: from `909.4 ± 1.5 ev/s` to `913.9 ± 0.6 ev/s`.

  * on an NVIDIA L40S GPU with the _full_ HLT menu running with 2 jobs, each with 16 threads and 16 streams, there is no impact on the performance.

  * with a realistic HLT menu, that tests on the timing server with NVIDIA T4 GPUs without and with this PR did not show any differences in performance.


#### PR validation:

Code builds, a reduced HLT menu runs correctly, with a speed-up of about 10% observed on an AMD MI300X GPU.