### PR TITLE
AXOL1TL Input/Output Recording

### DIFF
--- a/DataFormats/L1TGlobal/interface/AXOL1TLScore.h
+++ b/DataFormats/L1TGlobal/interface/AXOL1TLScore.h
@@ -17,7 +17,7 @@
 #include <vector>
 #include <iostream>
 #include <iomanip>
-#include <array> 
+#include <array>
 
 // user include files
 #include "FWCore/Utilities/interface/typedefs.h"
@@ -39,8 +39,8 @@ typedef l1t::ObjectRefBxCollection<AXOL1TLScore> AXOL1TLScoreRefBxCollection;
 // class interface
 class AXOL1TLScore {
 public:
- static constexpr unsigned int kNInputs = 57; 
-  
+  static constexpr unsigned int kNInputs = 57;
+
   /// constructors
   AXOL1TLScore();  //empty constructor
 
@@ -72,7 +72,7 @@ private:
 
   // preprocessed inputs given to the NN
   std::array<float, kNInputs> inputs_{{0.f}};
-  
+
   //store version or type of network?
   // std::string nnversion;
 };

--- a/DataFormats/L1TGlobal/interface/AXOL1TLScore.h
+++ b/DataFormats/L1TGlobal/interface/AXOL1TLScore.h
@@ -17,6 +17,7 @@
 #include <vector>
 #include <iostream>
 #include <iomanip>
+#include <array> 
 
 // user include files
 #include "FWCore/Utilities/interface/typedefs.h"
@@ -38,6 +39,8 @@ typedef l1t::ObjectRefBxCollection<AXOL1TLScore> AXOL1TLScoreRefBxCollection;
 // class interface
 class AXOL1TLScore {
 public:
+ static constexpr unsigned int kNInputs = 57; 
+  
   /// constructors
   AXOL1TLScore();  //empty constructor
 
@@ -55,6 +58,9 @@ public:
   inline float const& getAXOScore() const { return axoscore_; }
   inline const int getbxInEventNr() const { return m_bxInEvent; }
 
+  inline const std::array<float, kNInputs>& getInputs() const { return inputs_; }
+  inline void setInputs(const std::array<float, kNInputs>& v) { inputs_ = v; }
+
   void reset();
 
 private:
@@ -64,6 +70,9 @@ private:
   //axo score value
   float axoscore_;
 
+  // preprocessed inputs given to the NN
+  std::array<float, kNInputs> inputs_{{0.f}};
+  
   //store version or type of network?
   // std::string nnversion;
 };

--- a/DataFormats/L1TGlobal/src/AXOL1TLScore.cc
+++ b/DataFormats/L1TGlobal/src/AXOL1TLScore.cc
@@ -14,6 +14,7 @@
 void AXOL1TLScore::reset() {
   axoscore_ = 0.0;
   m_bxInEvent = 0;
+  inputs_.fill(0.f);
 }
 
 AXOL1TLScore::AXOL1TLScore() { reset(); }

--- a/DataFormats/L1TGlobal/src/classes_def.xml
+++ b/DataFormats/L1TGlobal/src/classes_def.xml
@@ -19,7 +19,8 @@
   <class name="edm::Wrapper<GlobalExtBlkBxCollection>"/>
   <class name="std::vector<GlobalExtBlk>"/>
 
-  <class name="AXOL1TLScore" ClassVersion="3">
+  <class name="AXOL1TLScore" ClassVersion="4">
+   <version ClassVersion="4" checksum="863322233"/>
    <version ClassVersion="3" checksum="1744705474"/>
   </class>
   <class name="AXOL1TLScoreBxCollection"/>

--- a/L1Trigger/Configuration/python/customiseUtils.py
+++ b/L1Trigger/Configuration/python/customiseUtils.py
@@ -75,7 +75,7 @@ def L1TGlobalDigisSummary(process):
 def L1TGlobalMenuXML(process):
     process.load('L1Trigger.L1TGlobal.GlobalParameters_cff')
     process.load('L1Trigger.L1TGlobal.TriggerMenu_cff')
-    process.TriggerMenu.L1TriggerMenuFile = cms.string('L1Menu_Collisions2022_v1_2_0.xml')
+    process.TriggerMenu.L1TriggerMenuFile = cms.string('L1Menu_Collisions2025_v1_2_0.xml')
     return process
 
 def L1TGlobalSimDigisSummary(process):

--- a/L1Trigger/Configuration/python/customiseUtils.py
+++ b/L1Trigger/Configuration/python/customiseUtils.py
@@ -75,7 +75,7 @@ def L1TGlobalDigisSummary(process):
 def L1TGlobalMenuXML(process):
     process.load('L1Trigger.L1TGlobal.GlobalParameters_cff')
     process.load('L1Trigger.L1TGlobal.TriggerMenu_cff')
-    process.TriggerMenu.L1TriggerMenuFile = cms.string('L1Menu_Collisions2025_v1_2_0.xml')
+    process.TriggerMenu.L1TriggerMenuFile = cms.string('L1Menu_Collisions2022_v1_2_0.xml')
     return process
 
 def L1TGlobalSimDigisSummary(process):

--- a/L1Trigger/L1TGlobal/interface/AXOL1TLCondition.h
+++ b/L1Trigger/L1TGlobal/interface/AXOL1TLCondition.h
@@ -10,6 +10,8 @@
 #include <iosfwd>
 #include <string>
 #include <utility>
+#include <array>
+
 
 #include "L1Trigger/L1TGlobal/interface/ConditionEvaluation.h"
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
@@ -27,6 +29,10 @@ namespace l1t {
 
   // class declaration
   class AXOL1TLCondition : public ConditionEvaluation {
+  private:
+    //total # inputs in vector is (4+10+4+1)*3 = 57    
+    static constexpr unsigned int NInputs = 57;
+    
   public:
     /// constructors
     ///     default
@@ -68,6 +74,8 @@ namespace l1t {
 
     inline hls4mlEmulator::ModelLoader const& model_loader() const { return m_model_loader; }
 
+    const std::array<float, NInputs>& getLastInputs() const { return m_lastInputs_; }
+
   private:
     /// copy function for copy constructor and operator=
     void copy(const AXOL1TLCondition& cp);
@@ -83,6 +91,9 @@ namespace l1t {
     hls4mlEmulator::ModelLoader m_model_loader;
     std::shared_ptr<hls4mlEmulator::Model> m_model;
 
+    mutable std::array<float, NInputs> m_lastInputs_{};
+    
+    
     ///axo score for possible score saving
     mutable float m_savedscore;
   };

--- a/L1Trigger/L1TGlobal/interface/AXOL1TLCondition.h
+++ b/L1Trigger/L1TGlobal/interface/AXOL1TLCondition.h
@@ -12,7 +12,6 @@
 #include <utility>
 #include <array>
 
-
 #include "L1Trigger/L1TGlobal/interface/ConditionEvaluation.h"
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 
@@ -30,9 +29,9 @@ namespace l1t {
   // class declaration
   class AXOL1TLCondition : public ConditionEvaluation {
   private:
-    //total # inputs in vector is (4+10+4+1)*3 = 57    
+    //total # inputs in vector is (4+10+4+1)*3 = 57
     static constexpr unsigned int NInputs = 57;
-    
+
   public:
     /// constructors
     ///     default
@@ -92,8 +91,7 @@ namespace l1t {
     std::shared_ptr<hls4mlEmulator::Model> m_model;
 
     mutable std::array<float, NInputs> m_lastInputs_{};
-    
-    
+
     ///axo score for possible score saving
     mutable float m_savedscore;
   };

--- a/L1Trigger/L1TGlobal/interface/AXOL1TLCondition.h
+++ b/L1Trigger/L1TGlobal/interface/AXOL1TLCondition.h
@@ -14,6 +14,7 @@
 
 #include "L1Trigger/L1TGlobal/interface/ConditionEvaluation.h"
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
+#include "DataFormats/L1TGlobal/interface/AXOL1TLScore.h"
 
 #include "hls4ml/emulator.h"
 
@@ -28,10 +29,6 @@ namespace l1t {
 
   // class declaration
   class AXOL1TLCondition : public ConditionEvaluation {
-  private:
-    //total # inputs in vector is (4+10+4+1)*3 = 57
-    static constexpr unsigned int NInputs = 57;
-
   public:
     /// constructors
     ///     default
@@ -73,7 +70,7 @@ namespace l1t {
 
     inline hls4mlEmulator::ModelLoader const& model_loader() const { return m_model_loader; }
 
-    const std::array<float, NInputs>& getLastInputs() const { return m_lastInputs_; }
+    const std::array<float, AXOL1TLScore::kNInputs>& getLastInputs() const { return m_lastInputs_; }
 
   private:
     /// copy function for copy constructor and operator=
@@ -90,7 +87,7 @@ namespace l1t {
     hls4mlEmulator::ModelLoader m_model_loader;
     std::shared_ptr<hls4mlEmulator::Model> m_model;
 
-    mutable std::array<float, NInputs> m_lastInputs_{};
+    mutable std::array<float, AXOL1TLScore::kNInputs> m_lastInputs_{};
 
     ///axo score for possible score saving
     mutable float m_savedscore;

--- a/L1Trigger/L1TGlobal/interface/GlobalBoard.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalBoard.h
@@ -10,6 +10,7 @@
  */
 
 // system include files
+#include <array>
 #include <bitset>
 #include <cassert>
 #include <vector>
@@ -241,6 +242,7 @@ namespace l1t {
     //for optional software-only saving of axol1tl score
     AXOL1TLScore m_uGtAXOScore;       //score dataformat
     float m_storedAXOScore = -999.f;  //score from cond class
+    std::array<float, AXOL1TLScore::kNInputs> m_storedAXOInputs{};
     bool m_saveAXOScore = false;
     std::string m_axoScoreConditionName;
 

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -75,7 +75,7 @@ void L1TGlobalProducer::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.add<bool>("useMuonShowers", false);
 
   //switch for saving AXO score
-  desc.add<bool>("produceAXOL1TLScore", false);
+  desc.add<bool>("produceAXOL1TLScore", true);
 
   // disables resetting the prescale counters each lumisection (needed for offline)
   //  originally, the L1T firmware applied the reset of prescale counters at the end of every LS;

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -75,7 +75,7 @@ void L1TGlobalProducer::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.add<bool>("useMuonShowers", false);
 
   //switch for saving AXO score
-  desc.add<bool>("produceAXOL1TLScore", true);
+  desc.add<bool>("produceAXOL1TLScore", false);
 
   // disables resetting the prescale counters each lumisection (needed for offline)
   //  originally, the L1T firmware applied the reset of prescale counters at the end of every LS;

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -425,6 +425,8 @@ void L1TGlobalProducer::beginRun(edm::Run const& iRun, const edm::EventSetup& ev
 */
 
   // initialise Trigger Conditions
+  m_uGtBrd->enableAXOScoreSaving(m_produceAXOL1TLScore);
+
   m_uGtBrd->initTriggerConditions(evSetup, m_l1GtMenu.get(), m_nrL1Mu, m_nrL1MuShower, m_nrL1EG, m_nrL1Tau, m_nrL1Jet);
 }
 
@@ -529,7 +531,7 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
 
   std::unique_ptr<AXOL1TLScoreBxCollection> uGtAXOScoreRecord(nullptr);
   if (m_produceAXOL1TLScore) {
-    uGtAXOScoreRecord = std::make_unique<AXOL1TLScoreBxCollection>();
+    uGtAXOScoreRecord = std::make_unique<AXOL1TLScoreBxCollection>(0, minEmulBxInEvent, maxEmulBxInEvent);
   }
 
   // fill the boards not depending on the BxInEvent in the L1 GT DAQ record
@@ -603,8 +605,6 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
     m_uGtBrd->receiveMuonShowerObjectData(iEvent, m_muShowerInputToken, receiveMuShower, m_nrL1MuShower);
 
   //tell board to save axo scores when running GTL
-  m_uGtBrd->enableAXOScoreSaving(m_produceAXOL1TLScore);
-
   m_uGtBrd->receiveExternalData(iEvent, m_extInputToken, receiveExt);
 
   // loop over BxInEvent

--- a/L1Trigger/L1TGlobal/src/AXOL1TLCondition.cc
+++ b/L1Trigger/L1TGlobal/src/AXOL1TLCondition.cc
@@ -135,9 +135,6 @@ const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   const int EGVecSize = 12;    //NEgammas * 3;    //so 12
   const int EtSumVecSize = 3;  //NEtSums * 3;    //so 3
 
-  //total # inputs in vector is (4+10+4+1)*3 = 57
-  const int NInputs = 57;
-
   //types of inputs and outputs
   typedef ap_fixed<18, 13> inputtype;
   typedef ap_ufixed<18, 14> losstype;
@@ -256,6 +253,10 @@ const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   score = ((loss).to_float()) * 16.0;  //scaling to match threshold
   //save score to class variable in case score saving needed
   setScore(score);
+
+  for (unsigned int i = 0; i < NInputs; ++i) {
+    m_lastInputs_[i] = ADModelInput[i].to_float();
+  }
 
   //number of objects/thrsholds to check
   int iCondition = 0;  // number of conditions: there is only one

--- a/L1Trigger/L1TGlobal/src/AXOL1TLCondition.cc
+++ b/L1Trigger/L1TGlobal/src/AXOL1TLCondition.cc
@@ -124,6 +124,15 @@ const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   const BXVector<const l1t::L1Candidate*>* candEGVec = m_gtGTB->getCandL1EG();
   const BXVector<const l1t::EtSum*>* candEtSumVec = m_gtGTB->getCandL1EtSum();
 
+  m_lastInputs_.fill(0.f);
+
+  if (useBx < candMuVec->getFirstBX() || useBx > candMuVec->getLastBX() || useBx < candJetVec->getFirstBX() ||
+      useBx > candJetVec->getLastBX() || useBx < candEGVec->getFirstBX() || useBx > candEGVec->getLastBX() ||
+      useBx < candEtSumVec->getFirstBX() || useBx > candEtSumVec->getLastBX()) {
+    setScore(-1.f);
+    return false;
+  }
+
   const int NMuons = 4;
   const int NJets = 10;
   const int NEgammas = 4;

--- a/L1Trigger/L1TGlobal/src/AXOL1TLCondition.cc
+++ b/L1Trigger/L1TGlobal/src/AXOL1TLCondition.cc
@@ -152,7 +152,7 @@ const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   inputtype fillzero = 0.0;
 
   //AD vector declaration, will fill later
-  inputtype ADModelInput[NInputs] = {};
+  inputtype ADModelInput[AXOL1TLScore::kNInputs] = {};
 
   //initializing vector by type for my sanity
   inputtype MuInput[MuVecSize];
@@ -177,7 +177,7 @@ const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   std::fill(MuInput, MuInput + MuVecSize, fillzero);
   std::fill(JetInput, JetInput + JVecSize, fillzero);
   std::fill(EgammaInput, EgammaInput + EGVecSize, fillzero);
-  std::fill(ADModelInput, ADModelInput + NInputs, fillzero);
+  std::fill(ADModelInput, ADModelInput + AXOL1TLScore::kNInputs, fillzero);
 
   //then fill the object vectors
   //NOTE assume candidates are already sorted by pt
@@ -263,7 +263,7 @@ const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   //save score to class variable in case score saving needed
   setScore(score);
 
-  for (unsigned int i = 0; i < NInputs; ++i) {
+  for (unsigned int i = 0; i < AXOL1TLScore::kNInputs; ++i) {
     m_lastInputs_[i] = ADModelInput[i].to_float();
   }
 

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -643,7 +643,7 @@ void l1t::GlobalBoard::initTriggerConditions(const edm::EventSetup& evSetup,
           theCondition = std::make_unique<AXOL1TLCondition>(itCond.second, this);
           theCondition->setVerbosity(m_verbosity);
 
-          if (m_saveAXOScore and not m_axoScoreConditionName.empty()) {
+          if (m_saveAXOScore and m_axoScoreConditionName.empty()) {
             m_axoScoreConditionName = itCond.first;
           }
 
@@ -1161,7 +1161,7 @@ void l1t::GlobalBoard::reset() {
   //reset AXO score
   m_storedAXOScore = -999.f;
   m_uGtAXOScore.reset();
-  m_axoScoreConditionName = "";
+  //  m_axoScoreConditionName = "";
 
   m_gtlDecisionWord.reset();
   m_gtlAlgorithmOR.reset();

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -1163,7 +1163,6 @@ void l1t::GlobalBoard::reset() {
   m_storedAXOScore = -999.f;
   m_storedAXOInputs.fill(0.f);
   m_uGtAXOScore.reset();
-  //  m_axoScoreConditionName = "";
 
   m_gtlDecisionWord.reset();
   m_gtlAlgorithmOR.reset();

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -522,6 +522,7 @@ void l1t::GlobalBoard::fillAXOScore(int iBxInEvent, std::unique_ptr<AXOL1TLScore
   float scorevalue = 0.0;
   if (iBxInEvent == 0) {
     scorevalue = m_storedAXOScore;
+    m_uGtAXOScore.setInputs(m_storedAXOInputs);
   }
 
   //set dataformat value
@@ -906,12 +907,12 @@ void l1t::GlobalBoard::runGTL(const edm::Event&,
     for (auto& cond : condMap) {
       cond.second->evaluateConditionStoreResult(iBxInEvent);
 
-      // for optional software-only saving of axol1tl score
-      // m_storedAXOScore < 0.0 ensures this gets set only once per condition if score not default of -999
-      if (m_saveAXOScore and m_storedAXOScore < 0 and cond.first == m_axoScoreConditionName and
+      // for optional software-only saving of axol1tl score and inputs
+      if (m_saveAXOScore and iBxInEvent == 0 and m_storedAXOScore < 0 and cond.first == m_axoScoreConditionName and
           not m_axoScoreConditionName.empty()) {
         auto const* theCondition = dynamic_cast<AXOL1TLCondition*>(cond.second.get());
         m_storedAXOScore = theCondition->getScore();
+        m_storedAXOInputs = theCondition->getLastInputs();
       }
     }
   }
@@ -1160,6 +1161,7 @@ void l1t::GlobalBoard::reset() {
 
   //reset AXO score
   m_storedAXOScore = -999.f;
+  m_storedAXOInputs.fill(0.f);
   m_uGtAXOScore.reset();
   //  m_axoScoreConditionName = "";
 

--- a/L1Trigger/L1TNtuples/plugins/L1AXOTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1AXOTreeProducer.cc
@@ -41,7 +41,7 @@ private:
 
   // pointers to the objects that will be stored as branches within the tree
   float anomaly_score;
-  float anomaly_inputs[AXOL1TLScore::kNInputs]; 
+  float anomaly_inputs[AXOL1TLScore::kNInputs];
 
   // tree
   TTree *tree_;
@@ -59,9 +59,7 @@ L1AXOTreeProducer::L1AXOTreeProducer(edm::ParameterSet const &config)
   tree_ = fs_->make<TTree>("L1AXOTree", "L1AXOTree");
   tree_->Branch("axo_score", &anomaly_score, "axo_score/F");
 
-  tree_->Branch("axo_inputs",
-                anomaly_inputs,
-                fmt::sprintf("axo_inputs[%d]/F", AXOL1TLScore::kNInputs).c_str());
+  tree_->Branch("axo_inputs", anomaly_inputs, fmt::sprintf("axo_inputs[%d]/F", AXOL1TLScore::kNInputs).c_str());
 }
 
 //
@@ -88,8 +86,7 @@ void L1AXOTreeProducer::analyze(edm::Event const &event, edm::EventSetup const &
     }
 
   } else {
-    edm::LogWarning("MissingProduct")
-        << "AXOL1TLScoreBxCollection not found. Branches will not be filled";
+    edm::LogWarning("MissingProduct") << "AXOL1TLScoreBxCollection not found. Branches will not be filled";
 
     anomaly_score = 0.f;
     for (unsigned int i = 0; i < AXOL1TLScore::kNInputs; ++i) {

--- a/L1Trigger/L1TNtuples/plugins/L1AXOTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1AXOTreeProducer.cc
@@ -76,13 +76,11 @@ void L1AXOTreeProducer::analyze(edm::Event const &event, edm::EventSetup const &
       anomaly_inputs[i] = inputs[i];
     }
 
-
     static unsigned int nDebugEvents = 0;
 
     if (nDebugEvents < 20) {
-
-      LogDebug("AXOL1TL") << "event=" << event.id().event() << " run=" << event.id().run() << " lumi=" << event.luminosityBlock()
-          << " score=" << anomaly_score << " nonzero inputs:";
+      LogDebug("AXOL1TL") << "event=" << event.id().event() << " run=" << event.id().run()
+                          << " lumi=" << event.luminosityBlock() << " score=" << anomaly_score << " nonzero inputs:";
 
       bool any = false;
       for (unsigned int i = 0; i < AXOL1TLScore::kNInputs; ++i) {
@@ -107,8 +105,8 @@ void L1AXOTreeProducer::analyze(edm::Event const &event, edm::EventSetup const &
     }
 
     edm::LogPrint("AXOL1TL") << "event=" << event.id().event() << " run=" << event.id().run()
-                              << " lumi=" << event.luminosityBlock()
-                              << " AXOL1TLScoreBxCollection missing or empty at BX 0";
+                             << " lumi=" << event.luminosityBlock()
+                             << " AXOL1TLScoreBxCollection missing or empty at BX 0";
 
     edm::LogWarning("MissingProduct") << "AXOL1TLScoreBxCollection missing or empty at BX 0";
   }

--- a/L1Trigger/L1TNtuples/plugins/L1AXOTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1AXOTreeProducer.cc
@@ -88,11 +88,8 @@ void L1AXOTreeProducer::analyze(edm::Event const &event, edm::EventSetup const &
     if (nDebugEvents < 20) {
       std::ostringstream msg;
 
-      msg << "event=" << event.id().event()
-          << " run=" << event.id().run()
-          << " lumi=" << event.luminosityBlock()
-          << " score=" << anomaly_score
-          << " nonzero inputs:";
+      msg << "event=" << event.id().event() << " run=" << event.id().run() << " lumi=" << event.luminosityBlock()
+          << " score=" << anomaly_score << " nonzero inputs:";
 
       bool any = false;
       for (unsigned int i = 0; i < AXOL1TLScore::kNInputs; ++i) {
@@ -119,15 +116,12 @@ void L1AXOTreeProducer::analyze(edm::Event const &event, edm::EventSetup const &
     }
 
 #ifdef AXO_DEBUG
-    edm::LogPrint("AXODebug")
-      << "event=" << event.id().event()
-      << " run=" << event.id().run()
-      << " lumi=" << event.luminosityBlock()
-      << " AXOL1TLScoreBxCollection missing or empty at BX 0";
+    edm::LogPrint("AXODebug") << "event=" << event.id().event() << " run=" << event.id().run()
+                              << " lumi=" << event.luminosityBlock()
+                              << " AXOL1TLScoreBxCollection missing or empty at BX 0";
 #endif
 
-    edm::LogWarning("MissingProduct")
-      << "AXOL1TLScoreBxCollection missing or empty at BX 0";
+    edm::LogWarning("MissingProduct") << "AXOL1TLScoreBxCollection missing or empty at BX 0";
   }
 
   tree_->Fill();
@@ -137,10 +131,7 @@ void L1AXOTreeProducer::analyze(edm::Event const &event, edm::EventSetup const &
 void L1AXOTreeProducer::beginJob() {
   tree_ = fs_->make<TTree>("L1AXOTree", "L1AXOTree");
   tree_->Branch("axo_score", &anomaly_score, "axo_score/F");
-  tree_->Branch(
-      "axo_inputs",
-      anomaly_inputs,
-      fmt::sprintf("axo_inputs[%d]/F", AXOL1TLScore::kNInputs).c_str());
+  tree_->Branch("axo_inputs", anomaly_inputs, fmt::sprintf("axo_inputs[%d]/F", AXOL1TLScore::kNInputs).c_str());
 }
 
 // ------------ method called once each job just after ending the event loop  ------------

--- a/L1Trigger/L1TNtuples/plugins/L1AXOTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1AXOTreeProducer.cc
@@ -21,6 +21,12 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
+// Uncomment to enable verbose AXO debugging
+#define AXO_DEBUG
+#ifdef AXO_DEBUG
+#include <sstream>
+#endif
+
 //
 // class declaration
 //
@@ -55,11 +61,6 @@ L1AXOTreeProducer::L1AXOTreeProducer(edm::ParameterSet const &config)
       tree_(nullptr),
       scoreToken_(consumes<AXOL1TLScoreBxCollection>(config.getUntrackedParameter<edm::InputTag>("axoscoreToken"))) {
   usesResource(TFileService::kSharedResource);
-  // set up the TTree and its branches
-  tree_ = fs_->make<TTree>("L1AXOTree", "L1AXOTree");
-  tree_->Branch("axo_score", &anomaly_score, "axo_score/F");
-
-  tree_->Branch("axo_inputs", anomaly_inputs, fmt::sprintf("axo_inputs[%d]/F", AXOL1TLScore::kNInputs).c_str());
 }
 
 //
@@ -68,37 +69,79 @@ L1AXOTreeProducer::L1AXOTreeProducer(edm::ParameterSet const &config)
 
 // ------------ method called to for each event  ------------
 void L1AXOTreeProducer::analyze(edm::Event const &event, edm::EventSetup const &setup) {
-  //save axo score
+  // save axo score
   edm::Handle<AXOL1TLScoreBxCollection> axo;
   event.getByToken(scoreToken_, axo);
 
-  if (axo.isValid()) {
-    // Take bx = 0, index = 0 as before
+  if (axo.isValid() && axo->getFirstBX() <= 0 && axo->getLastBX() >= 0 && axo->size(0) > 0) {
     const AXOL1TLScore &scoreObj = axo->at(0, 0);
-
-    // score
     anomaly_score = scoreObj.getAXOScore();
 
-    // inputs
     const auto &inputs = scoreObj.getInputs();
     for (unsigned int i = 0; i < AXOL1TLScore::kNInputs; ++i) {
       anomaly_inputs[i] = inputs[i];
     }
 
-  } else {
-    edm::LogWarning("MissingProduct") << "AXOL1TLScoreBxCollection not found. Branches will not be filled";
+#ifdef AXO_DEBUG
+    static unsigned int nDebugEvents = 0;
 
+    if (nDebugEvents < 20) {
+      std::ostringstream msg;
+
+      msg << "event=" << event.id().event()
+          << " run=" << event.id().run()
+          << " lumi=" << event.luminosityBlock()
+          << " score=" << anomaly_score
+          << " nonzero inputs:";
+
+      bool any = false;
+      for (unsigned int i = 0; i < AXOL1TLScore::kNInputs; ++i) {
+        if (anomaly_inputs[i] != 0.f) {
+          msg << " [" << i << "]=" << anomaly_inputs[i];
+          any = true;
+        }
+      }
+
+      if (!any) {
+        msg << " <none>";
+      }
+
+      edm::LogPrint("AXODebug") << msg.str();
+      ++nDebugEvents;
+    }
+#endif
+
+  } else {
     anomaly_score = 0.f;
+
     for (unsigned int i = 0; i < AXOL1TLScore::kNInputs; ++i) {
       anomaly_inputs[i] = 0.f;
     }
+
+#ifdef AXO_DEBUG
+    edm::LogPrint("AXODebug")
+      << "event=" << event.id().event()
+      << " run=" << event.id().run()
+      << " lumi=" << event.luminosityBlock()
+      << " AXOL1TLScoreBxCollection missing or empty at BX 0";
+#endif
+
+    edm::LogWarning("MissingProduct")
+      << "AXOL1TLScoreBxCollection missing or empty at BX 0";
   }
 
   tree_->Fill();
 }
 
 // ------------ method called once each job just before starting event loop  ------------
-void L1AXOTreeProducer::beginJob(void) {}
+void L1AXOTreeProducer::beginJob() {
+  tree_ = fs_->make<TTree>("L1AXOTree", "L1AXOTree");
+  tree_->Branch("axo_score", &anomaly_score, "axo_score/F");
+  tree_->Branch(
+      "axo_inputs",
+      anomaly_inputs,
+      fmt::sprintf("axo_inputs[%d]/F", AXOL1TLScore::kNInputs).c_str());
+}
 
 // ------------ method called once each job just after ending the event loop  ------------
 void L1AXOTreeProducer::endJob() {}

--- a/L1Trigger/L1TNtuples/plugins/L1AXOTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1AXOTreeProducer.cc
@@ -21,12 +21,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
-// Uncomment to enable verbose AXO debugging
-// #define AXO_DEBUG
-#ifdef AXO_DEBUG
-#include <sstream>
-#endif
-
 //
 // class declaration
 //
@@ -82,31 +76,28 @@ void L1AXOTreeProducer::analyze(edm::Event const &event, edm::EventSetup const &
       anomaly_inputs[i] = inputs[i];
     }
 
-#ifdef AXO_DEBUG
+
     static unsigned int nDebugEvents = 0;
 
     if (nDebugEvents < 20) {
-      std::ostringstream msg;
 
-      msg << "event=" << event.id().event() << " run=" << event.id().run() << " lumi=" << event.luminosityBlock()
+      LogDebug("AXOL1TL") << "event=" << event.id().event() << " run=" << event.id().run() << " lumi=" << event.luminosityBlock()
           << " score=" << anomaly_score << " nonzero inputs:";
 
       bool any = false;
       for (unsigned int i = 0; i < AXOL1TLScore::kNInputs; ++i) {
         if (anomaly_inputs[i] != 0.f) {
-          msg << " [" << i << "]=" << anomaly_inputs[i];
+          LogDebug("AXOL1TL") << " [" << i << "]=" << anomaly_inputs[i];
           any = true;
         }
       }
 
       if (!any) {
-        msg << " <none>";
+        LogDebug("AXOL1TL") << " <none>";
       }
 
-      edm::LogPrint("AXODebug") << msg.str();
       ++nDebugEvents;
     }
-#endif
 
   } else {
     anomaly_score = 0.f;
@@ -115,11 +106,9 @@ void L1AXOTreeProducer::analyze(edm::Event const &event, edm::EventSetup const &
       anomaly_inputs[i] = 0.f;
     }
 
-#ifdef AXO_DEBUG
-    edm::LogPrint("AXODebug") << "event=" << event.id().event() << " run=" << event.id().run()
+    edm::LogPrint("AXOL1TL") << "event=" << event.id().event() << " run=" << event.id().run()
                               << " lumi=" << event.luminosityBlock()
                               << " AXOL1TLScoreBxCollection missing or empty at BX 0";
-#endif
 
     edm::LogWarning("MissingProduct") << "AXOL1TLScoreBxCollection missing or empty at BX 0";
   }

--- a/L1Trigger/L1TNtuples/plugins/L1AXOTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1AXOTreeProducer.cc
@@ -22,7 +22,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
 // Uncomment to enable verbose AXO debugging
-#define AXO_DEBUG
+// #define AXO_DEBUG
 #ifdef AXO_DEBUG
 #include <sstream>
 #endif

--- a/L1Trigger/L1TNtuples/plugins/L1AXOTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1AXOTreeProducer.cc
@@ -98,11 +98,9 @@ void L1AXOTreeProducer::analyze(edm::Event const &event, edm::EventSetup const &
     }
 
   } else {
-    edm::LogWarning("MissingProduct")
-      << "AXOL1TLScoreBxCollection not found for run " << event.id().run()
-      << ", luminosity block " << event.id().luminosityBlock()
-      << ", event " << event.id().event()
-      << ". Branches will be filled with zero values.";
+    edm::LogWarning("MissingProduct") << "AXOL1TLScoreBxCollection not found for run " << event.id().run()
+                                      << ", luminosity block " << event.id().luminosityBlock() << ", event "
+                                      << event.id().event() << ". Branches will be filled with zero values.";
 
     anomaly_score = 0.f;
     for (unsigned int i = 0; i < AXOL1TLScore::kNInputs; ++i) {

--- a/L1Trigger/L1TNtuples/plugins/L1AXOTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1AXOTreeProducer.cc
@@ -98,17 +98,16 @@ void L1AXOTreeProducer::analyze(edm::Event const &event, edm::EventSetup const &
     }
 
   } else {
-    anomaly_score = 0.f;
+    edm::LogWarning("MissingProduct")
+      << "AXOL1TLScoreBxCollection not found for run " << event.id().run()
+      << ", luminosity block " << event.id().luminosityBlock()
+      << ", event " << event.id().event()
+      << ". Branches will be filled with zero values.";
 
+    anomaly_score = 0.f;
     for (unsigned int i = 0; i < AXOL1TLScore::kNInputs; ++i) {
       anomaly_inputs[i] = 0.f;
     }
-
-    edm::LogPrint("AXOL1TL") << "event=" << event.id().event() << " run=" << event.id().run()
-                             << " lumi=" << event.luminosityBlock()
-                             << " AXOL1TLScoreBxCollection missing or empty at BX 0";
-
-    edm::LogWarning("MissingProduct") << "AXOL1TLScoreBxCollection missing or empty at BX 0";
   }
 
   tree_->Fill();


### PR DESCRIPTION
#### PR description

This PR extends the L1TGlobal AXOL1TL support to allow proper monitoring and offline validation of the AXOL1TL anomaly-detection (AD) trigger.

Specifically, it introduces the following functionality:

- Adds storage of **all AXOL1TL neural-network input features** inside `AXOL1TLScore`, together with a public accessor method.
- Adds recording of the **per-event input vector used by the emulator** (`m_lastInputs_`) inside `AXOL1TLCondition`, enabling downstream ntuple production and debugging.
- Updates `AXOL1TLCondition` to fill `m_lastInputs_` during `evaluateCondition()`.
- Extends the L1TNtuples plugin `L1AXOTreeProducer` to:
  - write a new branch `axo_inputs[57]` containing the full input vector,
  - write the `axo_score` as before,
  - ensure consistent branch filling even when the product is missing.
- Ensures that the AXOL1TL input dimensionality is expressed through a single constant (`kNInputs`) and is used consistently across all classes.

No changes are expected to physics outputs of any existing L1T algorithms.  
This PR only affects debug/monitoring structures and ntuple content.

This PR does not depend on other open PRs or external packages.

---

#### PR validation

Validation steps performed:

1. **CMSSW compiles successfully** with `scram b -j 8` in a fresh `CMSSW_16_0_X` area.
2. A RAW→DIGI L1T emulation configuration was run using:
   ```
   cmsDriver.py l1Ntuple -s RAW2DIGI --python_filename=data.py -n -1 --data        --conditions=140X_dataRun3_v20 --era=Run3        --customise=L1Trigger/Configuration/customiseReEmul.L1TReEmulFromRAW        --customise=L1Trigger/L1TNtuples/customiseL1Ntuple.L1NtupleRAWEMU        --filein=/path/to/RAW --fileout=L1Ntuple.root
   ```
3. The resulting ntuple was inspected manually; the new branches  
   - `axo_score`  
   - `axo_inputs[57]`  
   are present and contain the expected placeholder values when the score product is missing.
4. The tree structure and branch types were verified by scanning the ntuple in ROOT.
5. A standalone analysis script using `ROOT.RDataFrame` was used to read and plot all new branches, confirming correct storage and array dimensionality.

No changes to runTheMatrix outputs are expected, as this code is only exercised when the L1TNtuples workflow is explicitly enabled.

---

#### Backport

This PR is **not** a backport.

If backports are requested, it would be appropriate for the Run-3 production cycles (13_2_X, 14_0_X), as the changes affect monitoring and offline validation of the AXOL1TL trigger.

---

#### Checklist reminder (for submission)

- [x] PR targets the correct branch  
- [ ] Code follows CMS Naming, Coding & Style Rules  
- [ ] PR passes the basic tests described in the CMSSW PR instructions  
