### PR TITLE
Set rntupleStreamerMode for Wrapper of deque and list

### DIFF
--- a/DataFormats/WrappedStdDictionaries/src/classes_def.xml
+++ b/DataFormats/WrappedStdDictionaries/src/classes_def.xml
@@ -9,8 +9,8 @@
  <class name="edm::Wrapper<long long>"/>
  <class name="edm::Wrapper<short>"/>
  <class name="edm::Wrapper<std::basic_string<char> >"/>
- <class name="edm::Wrapper<std::deque<int> >"/>
- <class name="edm::Wrapper<std::list<int> >"/>
+ <class name="edm::Wrapper<std::deque<int> >" rntupleStreamerMode="true"/>
+ <class name="edm::Wrapper<std::list<int> >" rntupleStreamerMode="true"/>
  <class name="edm::Wrapper<std::map<int,int> >"/>
  <class name="edm::Wrapper<std::map<std::basic_string<char>,bool> >"/>
  <class name="edm::Wrapper<std::map<std::basic_string<char>,std::vector<std::pair<std::basic_string<char>,double> > > >"/>


### PR DESCRIPTION
#### PR description:

- Adding the streamer mode for the container itself was insufficient.
- This fixes the failing unit test TestRNTupleTempEventHistory

#### PR validation:

Code compiles, the unit test TestRNTupleTempEventHistory now passes.

resolves https://github.com/cms-sw/framework-team/issues/1700