### PR TITLE
TkAl add maxclusters for PV validation

### DIFF
--- a/Alignment/OfflineValidation/README_PV.md
+++ b/Alignment/OfflineValidation/README_PV.md
@@ -29,6 +29,7 @@ dataset | See defaultInputFiles_cff.py | Path to txt file containing list of dat
 goodlumi | cms.untracked.VLuminosityBlockRange() | Path to json file containing lumi information about selected IoV - must contain list of runs under particular IoV with lumiblock info. Format: `IOV_Vali_{}.json`
 maxevents | 1 | Maximum number of events before cmsRun terminates.
 maxtracks | 1 | Maximum number of tracks per event before next event is processed.
+maxclusters | None | Maximum number of pixel clusters per event at HLT. Events with more clusters are skipped.
 trackcollection | "generalTracks" | Track collection to be specified here, e.g. "ALCARECOTkAlMuonIsolated" or "ALCARECOTkAlMinBias" ... 
 tthrbuilder | "WithAngleAndTemplate" | Specify TTRH Builder
 usePixelQualityFlag | True | Use pixel quality flag?

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/PV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/PV_cfg.py
@@ -161,6 +161,19 @@ process.noscraping = cms.EDFilter("FilterOutScraping",
                                   thresh = cms.untracked.double(0.25)
                                   )
 
+# Select events based on the pixel cluster multiplicity
+process.filterSeq = cms.Sequence()
+
+maxclusters = config["validation"].get("maxclusters", None)
+if(maxclusters is not None):
+    import  HLTrigger.special.hltPixelActivityFilter_cfi
+    process.multFilter = HLTrigger.special.hltPixelActivityFilter_cfi.hltPixelActivityFilter.clone(
+        inputTag = 'ALCARECOTkAlMinBias',
+        minClusters = 1,
+        maxClusters = maxclusters
+    )
+    process.filterSeq += process.multFilter
+
 ###################################################################
 # Beamspot compatibility check
 ###################################################################
@@ -256,6 +269,7 @@ process.TFileService = cms.Service("TFileService",
 # Path
 ####################################################################
 process.p = cms.Path(process.goodvertexSkim*
+                     process.filterSeq*
                      process.seqTrackselRefit*
                      process.BeamSpotChecker*
                      process.PVValidation)

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/PV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/PV_cfg.py
@@ -56,7 +56,7 @@ if "goodlumi" in config["validation"]:
         goodLumiSecs = cms.untracked.VLuminosityBlockRange(LumiList.LumiList(filename = config["validation"]["goodlumi"]).getCMSSWString().split(','))
         
     else:
-        print("Does not exist: {}. Continue without good lumi section file.")
+        print("Does not exist: {}. Continue without good lumi section file.".format(config["validation"]["goodlumi"]))
         goodLumiSecs = cms.untracked.VLuminosityBlockRange()
 
 else:


### PR DESCRIPTION
#### PR description:
This introduces the possibility to pass the parameter `maxclusters` in the PV validation, which prevents events with more clusters from being processed further. This is useful in Heavy Ion runs, where large events make the job exceed the allowed runtime.

#### PR validation:
Tested by running several validation campaigns in CMSSW_15_1_0_patch3, e.g. [[1](https://amecca.web.cern.ch/Alignment/Validation/2025/HI_prompt_PCL_run399925/PV/)] [[2](https://amecca.web.cern.ch/Alignment/Validation/2025/DMR_PV_GC_HI2025_PCL/PV/)].

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
N.A.
