### PR TITLE
Extend MC list in prunedGenParticles for HIN analyses

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
@@ -47,3 +47,7 @@ prunedGenParticles = cms.EDProducer("GenParticlePruner",
         "keep isHardProcess() || fromHardProcessFinalState() || fromHardProcessDecayed() || fromHardProcessBeforeFSR() || (statusFlags().fromHardProcess() && statusFlags().isLastCopy())",  #keep event summary based on status flags
     )
 )
+
+from Configuration.Eras.Modifier_ppRef_2024_cff import ppRef_2024
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+(pp_on_AA | ppRef_2024).toModify(prunedGenParticles.select, func = lambda list: list.append('keep++ abs(pdgId) == 9920443 || abs(pdgId) == 20443 || abs(pdgId) == 511'))


### PR DESCRIPTION
#### PR description:

This PR extends the collection of pruned gen particles to also include all the decay products of X(3872), B and ChiC mesons, needed for analyses in HIN PAG. The change is done through the PbPb and pp reference era modifiers to avoid changing the standard production workflows.

@Legoinha

#### PR validation:

Tested with relvals 160 and 149.1 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR will be backported to previous releases used for Run3 PbPb and pp reference MC production.