### PR TITLE
FastSim calorimetry bug fixes

### DIFF
--- a/FastSimulation/Calorimetry/interface/CalorimetryManager.h
+++ b/FastSimulation/Calorimetry/interface/CalorimetryManager.h
@@ -89,7 +89,10 @@ private:
   void readParameters(const edm::ParameterSet& fastCalo);
 
   void updateECAL(const std::map<CaloHitID, float>& hitMap, int onEcal, int trackID = 0, float corr = 1.0);
-  void updateHCAL(const std::map<CaloHitID, float>& hitMap, bool usedShowerLibrary = false, int trackID = 0, float corr = 1.0);
+  void updateHCAL(const std::map<CaloHitID, float>& hitMap,
+                  bool usedShowerLibrary = false,
+                  int trackID = 0,
+                  float corr = 1.0);
   void updatePreshower(const std::map<CaloHitID, float>& hitMap, int trackID = 0, float corr = 1.0);
 
   void respCorr(double);

--- a/FastSimulation/Calorimetry/interface/CalorimetryManager.h
+++ b/FastSimulation/Calorimetry/interface/CalorimetryManager.h
@@ -89,7 +89,7 @@ private:
   void readParameters(const edm::ParameterSet& fastCalo);
 
   void updateECAL(const std::map<CaloHitID, float>& hitMap, int onEcal, int trackID = 0, float corr = 1.0);
-  void updateHCAL(const std::map<CaloHitID, float>& hitMap, int trackID = 0, float corr = 1.0);
+  void updateHCAL(const std::map<CaloHitID, float>& hitMap, bool usedShowerLibrary = false, int trackID = 0, float corr = 1.0);
   void updatePreshower(const std::map<CaloHitID, float>& hitMap, int trackID = 0, float corr = 1.0);
 
   void respCorr(double);

--- a/FastSimulation/Calorimetry/interface/HCALResponse.h
+++ b/FastSimulation/Calorimetry/interface/HCALResponse.h
@@ -44,6 +44,7 @@ public:
 
   // correct HF response for SL
   void correctHF(double e, int type);
+  void clearHF();
   vec1& getCorrHFem() { return corrHFem; }
   vec1& getCorrHFhad() { return corrHFhad; }
 

--- a/FastSimulation/Calorimetry/src/CalorimetryManager.cc
+++ b/FastSimulation/Calorimetry/src/CalorimetryManager.cc
@@ -1103,7 +1103,10 @@ void CalorimetryManager::updateECAL(const std::map<CaloHitID, float>& hitMap, in
   }
 }
 
-void CalorimetryManager::updateHCAL(const std::map<CaloHitID, float>& hitMap, bool usedShowerLibrary, int trackID, float corr) {
+void CalorimetryManager::updateHCAL(const std::map<CaloHitID, float>& hitMap,
+                                    bool usedShowerLibrary,
+                                    int trackID,
+                                    float corr) {
   std::vector<double> hfcorrEm = myHDResponse_->getCorrHFem();
   std::vector<double> hfcorrHad = myHDResponse_->getCorrHFhad();
   std::map<CaloHitID, float>::const_iterator mapitr;

--- a/FastSimulation/Calorimetry/src/CalorimetryManager.cc
+++ b/FastSimulation/Calorimetry/src/CalorimetryManager.cc
@@ -204,6 +204,7 @@ void CalorimetryManager::reconstructTrack(FSimTrack& myTrack, RandomEngineAndDis
           myHDResponse_->correctHF(myTrack.hcalEntrance().e(), abs(myTrack.type()));
           updateHCAL(theHFShowerLibrary->getHitsMap(), true, myTrack.id());
           theHFShowerLibrary->clear();
+          myHDResponse_->clearHF();
         } else
           reconstructHCAL(myTrack, random);
       }
@@ -702,6 +703,7 @@ void CalorimetryManager::HDShowerSimulation(const FSimTrack& myTrack, RandomEngi
         myHDResponse_->correctHF(eGen, abs(myTrack.type()));
         updateHCAL(theHFShowerLibrary->getHitsMap(), true, myTrack.id());
         theHFShowerLibrary->clear();
+        myHDResponse_->clearHF();
       } else
         updateHCAL(myHcalHitMaker.getHits(), false, myTrack.id(), correction * hcorr);
 

--- a/FastSimulation/Calorimetry/src/CalorimetryManager.cc
+++ b/FastSimulation/Calorimetry/src/CalorimetryManager.cc
@@ -203,6 +203,7 @@ void CalorimetryManager::reconstructTrack(FSimTrack& myTrack, RandomEngineAndDis
           theHFShowerLibrary->recoHFShowerLibrary(myTrack);
           myHDResponse_->correctHF(myTrack.hcalEntrance().e(), abs(myTrack.type()));
           updateHCAL(theHFShowerLibrary->getHitsMap(), myTrack.id());
+          theHFShowerLibrary->clear();
         } else
           reconstructHCAL(myTrack, random);
       }
@@ -700,6 +701,7 @@ void CalorimetryManager::HDShowerSimulation(const FSimTrack& myTrack, RandomEngi
       if (myTrack.onVFcal() && useShowerLibrary) {
         myHDResponse_->correctHF(eGen, abs(myTrack.type()));
         updateHCAL(theHFShowerLibrary->getHitsMap(), myTrack.id());
+        theHFShowerLibrary->clear();
       } else
         updateHCAL(myHcalHitMaker.getHits(), myTrack.id(), correction * hcorr);
 

--- a/FastSimulation/Calorimetry/src/CalorimetryManager.cc
+++ b/FastSimulation/Calorimetry/src/CalorimetryManager.cc
@@ -698,7 +698,7 @@ void CalorimetryManager::HDShowerSimulation(const FSimTrack& myTrack, RandomEngi
       }
 
       // Save HCAL hits
-      if (myTrack.onVFcal() && useShowerLibrary) {
+      if (!myTrack.onEcal() && !myTrack.onHcal() && useShowerLibrary) {
         myHDResponse_->correctHF(eGen, abs(myTrack.type()));
         updateHCAL(theHFShowerLibrary->getHitsMap(), myTrack.id());
         theHFShowerLibrary->clear();

--- a/FastSimulation/Calorimetry/src/HCALResponse.cc
+++ b/FastSimulation/Calorimetry/src/HCALResponse.cc
@@ -677,3 +677,8 @@ void HCALResponse::correctHF(double ee, int type) {
     }
   }
 }
+
+void HCALResponse::clearHF() {
+  corrHFem = vec1(maxEta, 0);
+  corrHFhad = vec1(maxEta, 0);
+}

--- a/FastSimulation/ShowerDevelopment/interface/FastHFShowerLibrary.h
+++ b/FastSimulation/ShowerDevelopment/interface/FastHFShowerLibrary.h
@@ -47,6 +47,7 @@ public:
   void recoHFShowerLibrary(const FSimTrack& myTrack);
   void modifyDepth(HcalNumberingFromDDD::HcalID& id);
   const std::map<CaloHitID, float>& getHitsMap() { return hitMap; };
+  void clear() { hitMap.clear(); }
 
   void SetRandom(const RandomEngineAndDistribution*);
 

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
@@ -466,31 +466,31 @@ FSimTrack FastSimProducer::createFSimTrack(fastsim::Particle* particle,
     // Save the hit
     if (caloLayer->getCaloType() == fastsim::SimplifiedGeometry::PRESHOWER1) {
       if (!myFSimTrack.onLayer1()) {
-        myFSimTrack.setLayer1(PP, success);
+        myFSimTrack.setLayer1(PP, abs(success));
       }
     }
 
     if (caloLayer->getCaloType() == fastsim::SimplifiedGeometry::PRESHOWER2) {
       if (!myFSimTrack.onLayer2()) {
-        myFSimTrack.setLayer2(PP, success);
+        myFSimTrack.setLayer2(PP, abs(success));
       }
     }
 
     if (caloLayer->getCaloType() == fastsim::SimplifiedGeometry::ECAL) {
       if (!myFSimTrack.onEcal()) {
-        myFSimTrack.setEcal(PP, success);
+        myFSimTrack.setEcal(PP, abs(success));
       }
     }
 
     if (caloLayer->getCaloType() == fastsim::SimplifiedGeometry::HCAL) {
       if (!myFSimTrack.onHcal()) {
-        myFSimTrack.setHcal(PP, success);
+        myFSimTrack.setHcal(PP, abs(success));
       }
     }
 
     if (caloLayer->getCaloType() == fastsim::SimplifiedGeometry::VFCAL) {
       if (!myFSimTrack.onVFcal()) {
-        myFSimTrack.setVFcal(PP, success);
+        myFSimTrack.setVFcal(PP, abs(success));
       }
     }
 


### PR DESCRIPTION
#### PR description:

Recent technical work on the FastSim codebase has revealed several bugs in the calorimetry routines:
1. Particles with negative values for `on*cal` (Ecal, Hcal, VFcal = HF) did not have their energy deposited / hits stored (roughly a per mille effect). Fix: use `abs(on*cal)`.
2. Particles with nonzero values for both `onVFcal` and at least one other `on*cal` (in the endcap-forward transition region) had random hits stored (whatever was leftover in the hit map member variable in the HF shower library class). Fix:
    * `clear()` the hit map immediately after storing its hits
    * make the logic used for hit storage consistent: check `onEcal` and `onHcal` instead of `onVFcal`, in order to store the hits from the endcap shower simulation, which is actually used to simulate these transition region particles
3. Hits in the HF had shower library corrections applied, even if the hits were not from the shower library simulation (again, whatever was leftover in the energy correction member variables in the HCAL response class). Fix:
    * reset the energy correction member variables immediately after storing hits
    * make the logic used for corrections more specific: only apply to hits that actually came from the shower library

The latter two bugs, which are more impactful, have existed since the introduction of the shower library in FastSim for Run 2 (#6854). The first bug may have existed even longer, since even the original FastSim particle propagation routine from Run 1 could potentially produce negative values for `on*cal`.

#### PR validation:

The bug fixes implemented here lead to changes in the physics. These have been tested to ensure their impact looks physically reasonable.

FastSim before vs. after the fixes, at the SimHit level:
<details>
<summary>HCAL hit multiplicity</summary>

<img width="1276" height="1252" alt="HcalIeta" src="https://github.com/user-attachments/assets/d2f03718-0ec9-4c20-b820-d60b8fea4c2b" />
</details>
<details>
<summary>HCAL hit energy</summary>

<img width="1276" height="1252" alt="HcalIetaWt" src="https://github.com/user-attachments/assets/4b8f24fd-719e-4168-b118-0d0068271a41" />
</details>

FastSim vs. FullSim for MET:

<details>
<summary>Before fixes</summary>

<img width="1276" height="1252" alt="PuppiMET_pt" src="https://github.com/user-attachments/assets/3ac4d179-c187-41d6-97b2-5f648e886479" />
</details>
<details>
<summary>After fixes</summary>

<img width="1276" height="1252" alt="PuppiMET_pt" src="https://github.com/user-attachments/assets/8f065f12-50b3-45cc-bb5c-fd4e22d224ce" />
</details>

More detailed step-by-step validation of each bug fix was presented in the SIM meeting: https://indico.cern.ch/event/1618164/

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport. It may be backported to earlier releases for production, depending on inputs from other areas (PPD, PC).
