### PR TITLE
Delete obsolete TTTrack::stubPtConsistency function

### DIFF
--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTTrack.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTTrack.cc
@@ -140,7 +140,7 @@ void Phase2OTMonitorTTTrack::analyze(const edm::Event &iEvent, const edm::EventS
 
     float track_eta = tempTrackPtr->momentum().eta();
     float track_d0 = tempTrackPtr->d0();
-    float track_bendchi2 = tempTrackPtr->stubPtConsistency();
+    float track_bendchi2 = tempTrackPtr->chi2BendRed();
     float track_chi2 = tempTrackPtr->chi2();
     float track_chi2dof = tempTrackPtr->chi2Red();
     float track_chi2rz = tempTrackPtr->chi2Z();

--- a/DQMOffline/L1Trigger/src/L1TPhase2OuterTrackerTkMET.cc
+++ b/DQMOffline/L1Trigger/src/L1TPhase2OuterTrackerTkMET.cc
@@ -101,7 +101,7 @@ void L1TPhase2OuterTrackerTkMET::analyze(const edm::Event& iEvent, const edm::Ev
     int nstubs = (int)theStubs.size();
 
     float chi2dof = tempTrackPtr->chi2Red();
-    float bendchi2 = tempTrackPtr->stubPtConsistency();
+    float bendchi2 = tempTrackPtr->chi2BendRed();
     float z0 = tempTrackPtr->z0();
 
     if (pt < minPt || fabs(z0) > maxZ0 || fabs(eta) > maxEta || chi2dof > chi2dofMax || bendchi2 > bendchi2Max)

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -39,7 +39,7 @@ private:
   double theZ0_;
   unsigned int thePhiSector_;
   unsigned int theEtaSector_;
-  double theStubPtConsistency_;
+  double theStubPtConsistency_;  // stub bend chi2/dof
   double theChi2_;
   double theChi2_XY_;
   double theChi2_Z_;
@@ -152,13 +152,10 @@ public:
   double chi2XYRed() const;
 
   /// Stub Pt consistency (i.e. stub bend chi2/dof)
-  /// Note: The "stubPtConsistency" names are historic and people are encouraged
-  ///       to adopt the "chi2Bend" names.
-  double stubPtConsistency() const;
-  void setStubPtConsistency(double aPtConsistency);
-  double chi2BendRed() { return stubPtConsistency(); }
-  void setChi2BendRed(double aChi2BendRed) { setStubPtConsistency(aChi2BendRed); }
-  double chi2Bend() { return chi2BendRed() * theStubRefs.size(); }
+  /// N.B. Function chi2BendRed() was previously known as stubPtConsistency().
+  double chi2BendRed() const { return theStubPtConsistency_; }
+  double chi2Bend() const { return chi2BendRed() * theStubRefs.size(); }
+  void setChi2BendRed(double aChi2BendRed) { theStubPtConsistency_ = aChi2BendRed; }
 
   void setFitParNo(unsigned int aFitParNo);
   int nFitPars() const { return theNumFitPars_; }
@@ -238,7 +235,7 @@ TTTrack<T>::TTTrack(double aRinv,
   theTrkMVA1_ = trkMVA1;
   theTrkMVA2_ = trkMVA2;
   theTrkMVA3_ = trkMVA3;
-  theStubPtConsistency_ = 0.0;  // must be set externally
+  theStubPtConsistency_ = 0.0;  // must be set externally = bend chi2/dof
   theNumFitPars_ = nPar;
   theHitPattern_ = aHitPattern;
   theBField_ = aBfield;
@@ -404,19 +401,6 @@ template <typename T>
 void TTTrack<T>::settrkMVA3(double atrkMVA3) {
   theTrkMVA3_ = atrkMVA3;
   return;
-}
-
-/// StubPtConsistency
-template <typename T>
-void TTTrack<T>::setStubPtConsistency(double aStubPtConsistency) {
-  theStubPtConsistency_ = aStubPtConsistency;
-  return;
-}
-
-/// StubPtConsistency
-template <typename T>
-double TTTrack<T>::stubPtConsistency() const {
-  return theStubPtConsistency_;
 }
 
 /// Hit Pattern

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -235,7 +235,7 @@ TTTrack<T>::TTTrack(double aRinv,
   theTrkMVA1_ = trkMVA1;
   theTrkMVA2_ = trkMVA2;
   theTrkMVA3_ = trkMVA3;
-  theStubPtConsistency_ = 0.0;  // must be set externally = bend chi2/dof
+  theStubPtConsistency_ = 0.0;  // must be set externally
   theNumFitPars_ = nPar;
   theHitPattern_ = aHitPattern;
   theBField_ = aBfield;

--- a/L1Trigger/L1TTrackMatch/plugins/DisplacedVertexProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/DisplacedVertexProducer.cc
@@ -225,7 +225,7 @@ void DisplacedVertexProducer::produce(edm::StreamID, edm::Event& iEvent, const e
       rho = 1 / l1track_ptr->rInv();
       chi2rphi = l1track_ptr->chi2XYRed();
       chi2rz = l1track_ptr->chi2ZRed();
-      bendchi2 = l1track_ptr->stubPtConsistency();
+      bendchi2 = l1track_ptr->chi2BendRed();
       MVA1 = l1track_ptr->trkMVA1();
       std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
           stubRefs = l1track_ptr->getStubRefs();

--- a/L1Trigger/L1TTrackMatch/plugins/L1FastTrackingJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1FastTrackingJetProducer.cc
@@ -158,7 +158,7 @@ void L1FastTrackingJetProducer::produce(edm::Event& iEvent, const edm::EventSetu
     float trk_pt = iterL1Track->momentum().perp();
     float trk_z0 = iterL1Track->z0();
     float trk_chi2dof = iterL1Track->chi2Red();
-    float trk_bendchi2 = iterL1Track->stubPtConsistency();
+    float trk_bendchi2 = iterL1Track->chi2BendRed();
     std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
         theStubs = iterL1Track->getStubRefs();
     int trk_nstub = (int)theStubs.size();

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackSelectionProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackSelectionProducer.cc
@@ -226,7 +226,7 @@ private:
     TTTrackBendChi2MaxSelector(double bendChi2Max) : bendChi2Max_(bendChi2Max) {}
     TTTrackBendChi2MaxSelector(const edm::ParameterSet& cfg)
         : bendChi2Max_(cfg.template getParameter<double>("reducedBendChi2Max")) {}
-    bool operator()(const L1Track& t) const { return t.stubPtConsistency() < bendChi2Max_; }
+    bool operator()(const L1Track& t) const { return t.chi2BendRed() < bendChi2Max_; }
 
   private:
     double bendChi2Max_;
@@ -343,8 +343,8 @@ private:
         : reducedBendChi2MaxNstub4_(cfg.template getParameter<double>("reducedBendChi2MaxNstub4")),
           reducedBendChi2MaxNstub5_(cfg.template getParameter<double>("reducedBendChi2MaxNstub5")) {}
     bool operator()(const L1Track& t) const {
-      return (((t.stubPtConsistency() < reducedBendChi2MaxNstub4_) && (t.getStubRefs().size() == 4)) ||
-              ((t.stubPtConsistency() < reducedBendChi2MaxNstub5_) && (t.getStubRefs().size() > 4)));
+      return (((t.chi2BendRed() < reducedBendChi2MaxNstub4_) && (t.getStubRefs().size() == 4)) ||
+              ((t.chi2BendRed() < reducedBendChi2MaxNstub5_) && (t.getStubRefs().size() > 4)));
     }
 
   private:
@@ -498,7 +498,7 @@ void L1TrackSelectionProducer::printDebugInfo(const TTTrackCollectionHandle& l1T
 
 void L1TrackSelectionProducer::printTrackInfo(edm::LogInfo& log, const L1Track& track, bool printEmulation) const {
   log << "\t(" << track.momentum().perp() << ", " << track.momentum().eta() << ", " << track.momentum().phi() << ", "
-      << track.getStubRefs().size() << ", " << track.stubPtConsistency() << ", " << track.chi2ZRed() << ", "
+      << track.getStubRefs().size() << ", " << track.chi2BendRed() << ", " << track.chi2ZRed() << ", "
       << track.chi2XYRed() << ", " << track.z0() << ")\n";
 
   if (printEmulation) {

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
@@ -458,7 +458,7 @@ void L1TrackVertexAssociationProducer::printTrackInfo(edm::LogInfo& log,
                                                       const TTTrackType& track,
                                                       bool printEmulation) const {
   log << "\t(" << track.momentum().perp() << ", " << track.momentum().eta() << ", " << track.momentum().phi() << ", "
-      << track.getStubRefs().size() << ", " << track.stubPtConsistency() << ", " << track.chi2ZRed() << ", "
+      << track.getStubRefs().size() << ", " << track.chi2BendRed() << ", " << track.chi2ZRed() << ", "
       << track.chi2XYRed() << ", " << track.z0() << ")\n";
 
   if (printEmulation) {

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
@@ -2532,7 +2532,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
       float tmp_trk_chi2dof = iterL1Track->chi2Red();
       float tmp_trk_chi2rphi = iterL1Track->chi2XYRed();
       float tmp_trk_chi2rz = iterL1Track->chi2ZRed();
-      float tmp_trk_bendchi2 = iterL1Track->stubPtConsistency();
+      float tmp_trk_bendchi2 = iterL1Track->chi2BendRed();
       float tmp_trk_MVA1 = iterL1Track->trkMVA1();
 
       std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
@@ -2755,7 +2755,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
       float tmp_trk_chi2dof = iterL1Track->chi2Red();
       float tmp_trk_chi2rphi = iterL1Track->chi2XYRed();
       float tmp_trk_chi2rz = iterL1Track->chi2ZRed();
-      float tmp_trk_bendchi2 = iterL1Track->stubPtConsistency();
+      float tmp_trk_bendchi2 = iterL1Track->chi2BendRed();
       float tmp_trk_MVA1 = iterL1Track->trkMVA1();
 
       std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
@@ -3210,7 +3210,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
                                          << " eta = " << matchedTracks.at(it)->momentum().eta()
                                          << " phi = " << matchedTracks.at(it)->momentum().phi()
                                          << " chi2 = " << matchedTracks.at(it)->chi2()
-                                         << " consistency = " << matchedTracks.at(it)->stubPtConsistency()
+                                         << " consistency = " << matchedTracks.at(it)->chi2BendRed()
                                          << " z0 = " << matchedTracks.at(it)->z0()
                                          << " nstub = " << matchedTracks.at(it)->getStubRefs().size();
             if (tmp_trk_genuine)
@@ -3291,7 +3291,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
         tmp_matchtrk_chi2dof = matchedTracks.at(i_track)->chi2Red();
         tmp_matchtrk_chi2rphi = matchedTracks.at(i_track)->chi2XYRed();
         tmp_matchtrk_chi2rz = matchedTracks.at(i_track)->chi2ZRed();
-        tmp_matchtrk_bendchi2 = matchedTracks.at(i_track)->stubPtConsistency();
+        tmp_matchtrk_bendchi2 = matchedTracks.at(i_track)->chi2BendRed();
         tmp_matchtrk_MVA1 = matchedTracks.at(i_track)->trkMVA1();
         tmp_matchtrk_nstub = (int)matchedTracks.at(i_track)->getStubRefs().size();
         tmp_matchtrk_seed = (int)matchedTracks.at(i_track)->trackSeedType();
@@ -3382,7 +3382,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
                                          << " eta = " << matchedTracks.at(it)->momentum().eta()
                                          << " phi = " << matchedTracks.at(it)->momentum().phi()
                                          << " chi2 = " << matchedTracks.at(it)->chi2()
-                                         << " consistency = " << matchedTracks.at(it)->stubPtConsistency()
+                                         << " consistency = " << matchedTracks.at(it)->chi2BendRed()
                                          << " z0 = " << matchedTracks.at(it)->z0()
                                          << " nstub = " << matchedTracks.at(it)->getStubRefs().size();
             if (tmp_trk_genuine)
@@ -3492,7 +3492,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
         tmp_matchtrkExt_chi2dof = matchedTracks.at(i_track)->chi2Red();
         tmp_matchtrkExt_chi2rphi = matchedTracks.at(i_track)->chi2XYRed();
         tmp_matchtrkExt_chi2rz = matchedTracks.at(i_track)->chi2ZRed();
-        tmp_matchtrkExt_bendchi2 = matchedTracks.at(i_track)->stubPtConsistency();
+        tmp_matchtrkExt_bendchi2 = matchedTracks.at(i_track)->chi2BendRed();
         tmp_matchtrkExt_MVA = matchedTracks.at(i_track)->trkMVA1();
         tmp_matchtrkExt_nstub = (int)matchedTracks.at(i_track)->getStubRefs().size();
         tmp_matchtrkExt_seed = (int)matchedTracks.at(i_track)->trackSeedType();

--- a/L1Trigger/TrackFindingTMTT/src/ConverterToTTTrack.cc
+++ b/L1Trigger/TrackFindingTMTT/src/ConverterToTTTrack.cc
@@ -55,7 +55,7 @@ namespace tmtt {
     track.setPhiSector(iPhiSec);
     track.setEtaSector(iEtaReg);
 
-    track.setStubPtConsistency(-1);  // not yet filled.
+    track.setChi2BendRed(-1);  // not yet filled.
 
     return track;
   }

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -732,9 +732,10 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
       }
     }
 
-    // pt consistency
-    aTrack.setStubPtConsistency(
-        StubPtConsistency::getConsistency(aTrack, theTrackerGeom, tTopo, settings_.bfield(), settings_.nHelixPar()));
+    // stub bend pt consistency chi2/ndf
+    float chi2BendRed =
+        StubPtConsistency::getConsistency(aTrack, theTrackerGeom, tTopo, settings_.bfield(), settings_.nHelixPar());
+    aTrack.setChi2BendRed(chi2BendRed);
 
     // set track word before TQ MVA calculated which uses track word variables
     aTrack.setTrackWordBits();

--- a/L1Trigger/TrackFindingTracklet/src/KalmanFilter.cc
+++ b/L1Trigger/TrackFindingTracklet/src/KalmanFilter.cc
@@ -389,7 +389,7 @@ namespace trklet {
         ttTracks_.back().setPhiSector(ttTrackRef->phiSector());
         ttTracks_.back().setEtaSector(ttTrackRef->etaSector());
         ttTracks_.back().setTrackSeedType(ttTrackRef->trackSeedType());
-        ttTracks_.back().setStubPtConsistency(ttTrackRef->stubPtConsistency());
+        ttTracks_.back().setChi2BendRed(ttTrackRef->chi2BendRed());
         ttTracks_.back().setStubRefs(ttTrackRef->getStubRefs());
       }
     }

--- a/L1Trigger/TrackFindingTracklet/src/TrackFindingProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackFindingProcessor.cc
@@ -246,7 +246,7 @@ namespace trklet {
       ttTrack.setEtaSector(ttTrackRef->etaSector());
       ttTrack.setTrackSeedType(ttTrackRef->trackSeedType());
       ttTrack.setStubRefs(it->ttStubRefs_);
-      ttTrack.setStubPtConsistency(StubPtConsistency::getConsistency(
+      ttTrack.setChi2BendRed(StubPtConsistency::getConsistency(
           ttTrack, setup_->trackerGeometry(), setup_->trackerTopology(), bfield_, nPar));
     }
   }

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -1118,7 +1118,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       float tmp_trk_chi2 = iterL1Track->chi2();
       float tmp_trk_chi2rphi = iterL1Track->chi2XY();
       float tmp_trk_chi2rz = iterL1Track->chi2Z();
-      float tmp_trk_bendchi2 = iterL1Track->stubPtConsistency();
+      float tmp_trk_bendchi2 = iterL1Track->chi2BendRed();
       float tmp_trk_MVA1 = iterL1Track->trkMVA1();
 
       std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
@@ -1567,7 +1567,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
                                        << " eta = " << matchedTracks.at(it)->momentum().eta()
                                        << " phi = " << matchedTracks.at(it)->momentum().phi()
                                        << " chi2 = " << matchedTracks.at(it)->chi2()
-                                       << " consistency = " << matchedTracks.at(it)->stubPtConsistency()
+                                       << " consistency = " << matchedTracks.at(it)->chi2BendRed()
                                        << " z0 = " << matchedTracks.at(it)->z0()
                                        << " nstub = " << matchedTracks.at(it)->getStubRefs().size();
           if (tmp_trk_genuine)
@@ -1665,7 +1665,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       tmp_matchtrk_chi2 = matchedTracks.at(i_track)->chi2();
       tmp_matchtrk_chi2rphi = matchedTracks.at(i_track)->chi2XY();
       tmp_matchtrk_chi2rz = matchedTracks.at(i_track)->chi2Z();
-      tmp_matchtrk_bendchi2 = matchedTracks.at(i_track)->stubPtConsistency();
+      tmp_matchtrk_bendchi2 = matchedTracks.at(i_track)->chi2BendRed();
       tmp_matchtrk_MVA1 = matchedTracks.at(i_track)->trkMVA1();
       tmp_matchtrk_nstub = (int)matchedTracks.at(i_track)->getStubRefs().size();
       tmp_matchtrk_seed = (int)matchedTracks.at(i_track)->trackSeedType();

--- a/L1Trigger/TrackerTFP/src/TrackFindingProcessor.cc
+++ b/L1Trigger/TrackerTFP/src/TrackFindingProcessor.cc
@@ -246,7 +246,7 @@ namespace trackerTFP {
       ttTrack.setEtaSector(dfZT.toUnsigned(dfZT.integer(it->zT_)));
       ttTrack.setTrackSeedType(ttTrackRef->trackSeedType());
       ttTrack.setStubRefs(it->ttStubRefs_);
-      ttTrack.setStubPtConsistency(StubPtConsistency::getConsistency(
+      ttTrack.setChi2BendRed(StubPtConsistency::getConsistency(
           ttTrack, setup_->trackerGeometry(), setup_->trackerTopology(), bfield_, nPar));
     }
   }

--- a/L1Trigger/TrackerTFP/src/TrackQuality.cc
+++ b/L1Trigger/TrackerTFP/src/TrackQuality.cc
@@ -139,7 +139,7 @@ namespace trackerTFP {
     TTTrack<Ref_Phase2TrackerDigi_> ttTrack(
         aRinv, aphi, aTanLambda, az0, ad0, aChi2xyfit, aChi2zfit, trkMVA1, trkMVA2, trkMVA3, aHitpattern, nPar, Bfield);
     ttTrack.setStubRefs(ttStubRefs);
-    ttTrack.setStubPtConsistency(
+    ttTrack.setChi2BendRed(
         StubPtConsistency::getConsistency(ttTrack, setup->trackerGeometry(), setup->trackerTopology(), Bfield, nPar));
     const int chi2B = tq->toBinChi2B(ttTrack.chi2Bend());
     const int chi2rphi = tq->toBinchi2rphi(trackchi2rphi);

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -684,7 +684,7 @@ namespace l1tVertexFinder {
       float chi2dof = track.getTTTrackPtr()->chi2() / (2 * trk_nstub - 4);
 
       if (settings_->vx_DoPtComp()) {
-        float trk_consistency = track.getTTTrackPtr()->stubPtConsistency();
+        float trk_consistency = track.getTTTrackPtr()->chi2BendRed();
         if (trk_nstub == 4) {
           if (std::abs(track.eta()) < 2.2 && trk_consistency > 10)
             continue;


### PR DESCRIPTION
#### PR description:

Some years ago, In the TTTrack class, which represents L1 tracks, the function stubPtConsistency() was renamed chi2BendRed(). The new name gave a clearer idea what this function did, which is to return a chi2/dof (also known as reduced chi2) that was formed from the stub bend information.
However, at that time a duplicate function with the original name was retained in TTTrack, to avoid breaking anyone's code. 

This PR finally finally deletes function stubPtConsistency(), and updates the few classes that had not yet migrated to the new function name.

This has no effect on L1 tracking performance, since it is only a name change,
