### PR TITLE
Remove TH1::AddDirectory(true) from Alignment

### DIFF
--- a/Alignment/CommonAlignmentProducer/plugins/GlobalTrackerMuonAlignment.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/GlobalTrackerMuonAlignment.cc
@@ -396,8 +396,6 @@ void GlobalTrackerMuonAlignment::beginJob() {
   file = new TFile(rootOutFile_.c_str(), "recreate");
   const bool oldAddDir = TH1::AddDirectoryStatus();
 
-  TH1::AddDirectory(true);
-
   this->bookHist();
 
   TH1::AddDirectory(oldAddDir);


### PR DESCRIPTION
#### PR description:

Fixes https://github.com/cms-sw/cmssw/issues/49543 in Alignment (other AlCa-related packages seem not to be affected as all occurences of AddDirectory are with `false`). 

#### PR validation:

code compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:


