### PR TITLE
Fix CloseBy default configuration.

### DIFF
--- a/Configuration/Generator/python/CE_E_Front_300um_cfi.py
+++ b/Configuration/Generator/python/CE_E_Front_300um_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 generator = cms.EDProducer("CloseByParticleGunProducer",
     PGunParameters = cms.PSet(PartID = cms.vint32(22),
+        ControlledByREta = cms.bool(False),
         ControlledByEta = cms.bool(False),
         VarMin = cms.double(25.),
         VarMax = cms.double(200.),

--- a/Configuration/Generator/python/CloseByPGun_Barrel_Front_cfi.py
+++ b/Configuration/Generator/python/CloseByPGun_Barrel_Front_cfi.py
@@ -3,11 +3,11 @@ from .CE_E_Front_300um_cfi import generator
 
 _pgunPSet = generator.PGunParameters
 
-_pgunPSet.ControlledByEta = cms.bool(True)
+_pgunPSet.ControlledByREta = cms.bool(True)
 _pgunPSet.MinEta = cms.double(-1.479)
 _pgunPSet.MaxEta = cms.double(1.479)
-_pgunPSet.RMin = cms.double(128.5)
-_pgunPSet.RMax = cms.double(128.4)
+_pgunPSet.RMin = cms.double(128.4)
+_pgunPSet.RMax = cms.double(128.5)
 _pgunPSet.ZMin = cms.double(-230)
 _pgunPSet.ZMax = cms.double(230)
 


### PR DESCRIPTION
#### PR description

Fixed minor bugs related to the default CloseBy configuration:

+ `RMax` must be larger than `RMin`
+ The distance `R` is considered only if `ControlledByREta` is `True` (and `ControlledByEta` must accordingly be `False`) . Otherwise, particles are not guaranteed to be shot from the surface of ECAL.