### PR TITLE
Use of emit() instead of operator() for signals emission.

### DIFF
--- a/FWCore/Framework/interface/ModuleRegistry.h
+++ b/FWCore/Framework/interface/ModuleRegistry.h
@@ -72,7 +72,7 @@ namespace edm {
       try {
         std::shared_ptr<T> module;
         convertException::wrap([&]() {
-          iPre(md);
+          iPre.emit(md);
           module = std::make_shared<T>(std::forward<Args>(args)...);
 
           auto holder = std::make_shared<maker::ModuleHolderT<typename T::ModuleType>>(module);
@@ -84,12 +84,12 @@ namespace edm {
           }
           // if exception then post will be called in the catch block
           postCalled = true;
-          iPost(md);
+          iPost.emit(md);
         });
         return module;
       } catch (cms::Exception& iException) {
         if (!postCalled) {
-          CMS_SA_ALLOW try { iPost(md); } catch (...) {
+          CMS_SA_ALLOW try { iPost.emit(md); } catch (...) {
             // If post throws an exception ignore it because we are already handling another exception
           }
         }

--- a/FWCore/Framework/interface/OccurrenceTraits.h
+++ b/FWCore/Framework/interface/OccurrenceTraits.h
@@ -52,16 +52,16 @@ namespace edm {
     }
 
     static void preScheduleSignal(ActivityRegistry* a, StreamContext const* streamContext) {
-      a->preEventSignal_(*streamContext);
+      a->preEventSignal_.emit(*streamContext);
     }
     static void postScheduleSignal(ActivityRegistry* a, StreamContext const* streamContext) {
-      a->postEventSignal_(*streamContext);
+      a->postEventSignal_.emit(*streamContext);
     }
     static void prePathSignal(ActivityRegistry* a, PathContext const* pathContext) {
-      a->prePathEventSignal_(*pathContext->streamContext(), *pathContext);
+      a->prePathEventSignal_.emit(*pathContext->streamContext(), *pathContext);
     }
     static void postPathSignal(ActivityRegistry* a, HLTPathStatus const& status, PathContext const* pathContext) {
-      a->postPathEventSignal_(*pathContext->streamContext(), *pathContext, status);
+      a->postPathEventSignal_.emit(*pathContext->streamContext(), *pathContext, status);
     }
 
     static const char* transitionName() { return "Event"; }
@@ -88,22 +88,22 @@ namespace edm {
     }
 
     static void preScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
-      a->preGlobalBeginRunSignal_(*globalContext);
+      a->preGlobalBeginRunSignal_.emit(*globalContext);
     }
     static void postScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
-      a->postGlobalBeginRunSignal_(*globalContext);
+      a->postGlobalBeginRunSignal_.emit(*globalContext);
     }
     static void prePathSignal(ActivityRegistry*, PathContext const*) {}
     static void postPathSignal(ActivityRegistry*, HLTPathStatus const&, PathContext const*) {}
     static void preModuleSignal(ActivityRegistry* a,
                                 GlobalContext const* globalContext,
                                 ModuleCallingContext const* moduleCallingContext) {
-      a->preModuleGlobalBeginRunSignal_(*globalContext, *moduleCallingContext);
+      a->preModuleGlobalBeginRunSignal_.emit(*globalContext, *moduleCallingContext);
     }
     static void postModuleSignal(ActivityRegistry* a,
                                  GlobalContext const* globalContext,
                                  ModuleCallingContext const* moduleCallingContext) {
-      a->postModuleGlobalBeginRunSignal_(*globalContext, *moduleCallingContext);
+      a->postModuleGlobalBeginRunSignal_.emit(*globalContext, *moduleCallingContext);
     }
     static const char* transitionName() { return "global begin Run"; }
   };
@@ -128,22 +128,22 @@ namespace edm {
     }
 
     static void preScheduleSignal(ActivityRegistry* a, StreamContext const* streamContext) {
-      a->preStreamBeginRunSignal_(*streamContext);
+      a->preStreamBeginRunSignal_.emit(*streamContext);
     }
     static void postScheduleSignal(ActivityRegistry* a, StreamContext const* streamContext) {
-      a->postStreamBeginRunSignal_(*streamContext);
+      a->postStreamBeginRunSignal_.emit(*streamContext);
     }
     static void prePathSignal(ActivityRegistry*, PathContext const*) {}
     static void postPathSignal(ActivityRegistry*, HLTPathStatus const&, PathContext const*) {}
     static void preModuleSignal(ActivityRegistry* a,
                                 StreamContext const* streamContext,
                                 ModuleCallingContext const* moduleCallingContext) {
-      a->preModuleStreamBeginRunSignal_(*streamContext, *moduleCallingContext);
+      a->preModuleStreamBeginRunSignal_.emit(*streamContext, *moduleCallingContext);
     }
     static void postModuleSignal(ActivityRegistry* a,
                                  StreamContext const* streamContext,
                                  ModuleCallingContext const* moduleCallingContext) {
-      a->postModuleStreamBeginRunSignal_(*streamContext, *moduleCallingContext);
+      a->postModuleStreamBeginRunSignal_.emit(*streamContext, *moduleCallingContext);
     }
     static const char* transitionName() { return "stream begin Run"; }
   };
@@ -168,22 +168,22 @@ namespace edm {
     }
 
     static void preScheduleSignal(ActivityRegistry* a, StreamContext const* streamContext) {
-      a->preStreamEndRunSignal_(*streamContext);
+      a->preStreamEndRunSignal_.emit(*streamContext);
     }
     static void postScheduleSignal(ActivityRegistry* a, StreamContext const* streamContext) {
-      a->postStreamEndRunSignal_(*streamContext);
+      a->postStreamEndRunSignal_.emit(*streamContext);
     }
     static void prePathSignal(ActivityRegistry*, PathContext const*) {}
     static void postPathSignal(ActivityRegistry*, HLTPathStatus const&, PathContext const*) {}
     static void preModuleSignal(ActivityRegistry* a,
                                 StreamContext const* streamContext,
                                 ModuleCallingContext const* moduleCallingContext) {
-      a->preModuleStreamEndRunSignal_(*streamContext, *moduleCallingContext);
+      a->preModuleStreamEndRunSignal_.emit(*streamContext, *moduleCallingContext);
     }
     static void postModuleSignal(ActivityRegistry* a,
                                  StreamContext const* streamContext,
                                  ModuleCallingContext const* moduleCallingContext) {
-      a->postModuleStreamEndRunSignal_(*streamContext, *moduleCallingContext);
+      a->postModuleStreamEndRunSignal_.emit(*streamContext, *moduleCallingContext);
     }
     static const char* transitionName() { return "stream end Run"; }
   };
@@ -209,22 +209,22 @@ namespace edm {
     }
 
     static void preScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
-      a->preGlobalEndRunSignal_(*globalContext);
+      a->preGlobalEndRunSignal_.emit(*globalContext);
     }
     static void postScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
-      a->postGlobalEndRunSignal_(*globalContext);
+      a->postGlobalEndRunSignal_.emit(*globalContext);
     }
     static void prePathSignal(ActivityRegistry*, PathContext const*) {}
     static void postPathSignal(ActivityRegistry*, HLTPathStatus const&, PathContext const*) {}
     static void preModuleSignal(ActivityRegistry* a,
                                 GlobalContext const* globalContext,
                                 ModuleCallingContext const* moduleCallingContext) {
-      a->preModuleGlobalEndRunSignal_(*globalContext, *moduleCallingContext);
+      a->preModuleGlobalEndRunSignal_.emit(*globalContext, *moduleCallingContext);
     }
     static void postModuleSignal(ActivityRegistry* a,
                                  GlobalContext const* globalContext,
                                  ModuleCallingContext const* moduleCallingContext) {
-      a->postModuleGlobalEndRunSignal_(*globalContext, *moduleCallingContext);
+      a->postModuleGlobalEndRunSignal_.emit(*globalContext, *moduleCallingContext);
     }
     static const char* transitionName() { return "global end Run"; }
   };
@@ -250,22 +250,22 @@ namespace edm {
     }
 
     static void preScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
-      a->preGlobalBeginLumiSignal_(*globalContext);
+      a->preGlobalBeginLumiSignal_.emit(*globalContext);
     }
     static void postScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
-      a->postGlobalBeginLumiSignal_(*globalContext);
+      a->postGlobalBeginLumiSignal_.emit(*globalContext);
     }
     static void prePathSignal(ActivityRegistry*, PathContext const*) {}
     static void postPathSignal(ActivityRegistry*, HLTPathStatus const&, PathContext const*) {}
     static void preModuleSignal(ActivityRegistry* a,
                                 GlobalContext const* globalContext,
                                 ModuleCallingContext const* moduleCallingContext) {
-      a->preModuleGlobalBeginLumiSignal_(*globalContext, *moduleCallingContext);
+      a->preModuleGlobalBeginLumiSignal_.emit(*globalContext, *moduleCallingContext);
     }
     static void postModuleSignal(ActivityRegistry* a,
                                  GlobalContext const* globalContext,
                                  ModuleCallingContext const* moduleCallingContext) {
-      a->postModuleGlobalBeginLumiSignal_(*globalContext, *moduleCallingContext);
+      a->postModuleGlobalBeginLumiSignal_.emit(*globalContext, *moduleCallingContext);
     }
     static const char* transitionName() { return "global begin LuminosityBlock"; }
   };
@@ -290,22 +290,22 @@ namespace edm {
     }
 
     static void preScheduleSignal(ActivityRegistry* a, StreamContext const* streamContext) {
-      a->preStreamBeginLumiSignal_(*streamContext);
+      a->preStreamBeginLumiSignal_.emit(*streamContext);
     }
     static void postScheduleSignal(ActivityRegistry* a, StreamContext const* streamContext) {
-      a->postStreamBeginLumiSignal_(*streamContext);
+      a->postStreamBeginLumiSignal_.emit(*streamContext);
     }
     static void prePathSignal(ActivityRegistry*, PathContext const*) {}
     static void postPathSignal(ActivityRegistry*, HLTPathStatus const&, PathContext const*) {}
     static void preModuleSignal(ActivityRegistry* a,
                                 StreamContext const* streamContext,
                                 ModuleCallingContext const* moduleCallingContext) {
-      a->preModuleStreamBeginLumiSignal_(*streamContext, *moduleCallingContext);
+      a->preModuleStreamBeginLumiSignal_.emit(*streamContext, *moduleCallingContext);
     }
     static void postModuleSignal(ActivityRegistry* a,
                                  StreamContext const* streamContext,
                                  ModuleCallingContext const* moduleCallingContext) {
-      a->postModuleStreamBeginLumiSignal_(*streamContext, *moduleCallingContext);
+      a->postModuleStreamBeginLumiSignal_.emit(*streamContext, *moduleCallingContext);
     }
     static const char* transitionName() { return "stream begin LuminosityBlock"; }
   };
@@ -332,22 +332,22 @@ namespace edm {
     }
 
     static void preScheduleSignal(ActivityRegistry* a, StreamContext const* streamContext) {
-      a->preStreamEndLumiSignal_(*streamContext);
+      a->preStreamEndLumiSignal_.emit(*streamContext);
     }
     static void postScheduleSignal(ActivityRegistry* a, StreamContext const* streamContext) {
-      a->postStreamEndLumiSignal_(*streamContext);
+      a->postStreamEndLumiSignal_.emit(*streamContext);
     }
     static void prePathSignal(ActivityRegistry*, PathContext const*) {}
     static void postPathSignal(ActivityRegistry*, HLTPathStatus const&, PathContext const*) {}
     static void preModuleSignal(ActivityRegistry* a,
                                 StreamContext const* streamContext,
                                 ModuleCallingContext const* moduleCallingContext) {
-      a->preModuleStreamEndLumiSignal_(*streamContext, *moduleCallingContext);
+      a->preModuleStreamEndLumiSignal_.emit(*streamContext, *moduleCallingContext);
     }
     static void postModuleSignal(ActivityRegistry* a,
                                  StreamContext const* streamContext,
                                  ModuleCallingContext const* moduleCallingContext) {
-      a->postModuleStreamEndLumiSignal_(*streamContext, *moduleCallingContext);
+      a->postModuleStreamEndLumiSignal_.emit(*streamContext, *moduleCallingContext);
     }
     static const char* transitionName() { return "end stream LuminosityBlock"; }
   };
@@ -373,22 +373,22 @@ namespace edm {
     }
 
     static void preScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
-      a->preGlobalEndLumiSignal_(*globalContext);
+      a->preGlobalEndLumiSignal_.emit(*globalContext);
     }
     static void postScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
-      a->postGlobalEndLumiSignal_(*globalContext);
+      a->postGlobalEndLumiSignal_.emit(*globalContext);
     }
     static void prePathSignal(ActivityRegistry*, PathContext const*) {}
     static void postPathSignal(ActivityRegistry*, HLTPathStatus const&, PathContext const*) {}
     static void preModuleSignal(ActivityRegistry* a,
                                 GlobalContext const* globalContext,
                                 ModuleCallingContext const* moduleCallingContext) {
-      a->preModuleGlobalEndLumiSignal_(*globalContext, *moduleCallingContext);
+      a->preModuleGlobalEndLumiSignal_.emit(*globalContext, *moduleCallingContext);
     }
     static void postModuleSignal(ActivityRegistry* a,
                                  GlobalContext const* globalContext,
                                  ModuleCallingContext const* moduleCallingContext) {
-      a->postModuleGlobalEndLumiSignal_(*globalContext, *moduleCallingContext);
+      a->postModuleGlobalEndLumiSignal_.emit(*globalContext, *moduleCallingContext);
     }
     static const char* transitionName() { return "end global LuminosityBlock"; }
   };
@@ -413,20 +413,20 @@ namespace edm {
     }
 
     static void preScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
-      a->preBeginProcessBlockSignal_(*globalContext);
+      a->preBeginProcessBlockSignal_.emit(*globalContext);
     }
     static void postScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
-      a->postBeginProcessBlockSignal_(*globalContext);
+      a->postBeginProcessBlockSignal_.emit(*globalContext);
     }
     static void preModuleSignal(ActivityRegistry* a,
                                 GlobalContext const* globalContext,
                                 ModuleCallingContext const* moduleCallingContext) {
-      a->preModuleBeginProcessBlockSignal_(*globalContext, *moduleCallingContext);
+      a->preModuleBeginProcessBlockSignal_.emit(*globalContext, *moduleCallingContext);
     }
     static void postModuleSignal(ActivityRegistry* a,
                                  GlobalContext const* globalContext,
                                  ModuleCallingContext const* moduleCallingContext) {
-      a->postModuleBeginProcessBlockSignal_(*globalContext, *moduleCallingContext);
+      a->postModuleBeginProcessBlockSignal_.emit(*globalContext, *moduleCallingContext);
     }
     static const char* transitionName() { return "begin ProcessBlock"; }
   };
@@ -451,20 +451,20 @@ namespace edm {
     }
 
     static void preScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
-      a->preAccessInputProcessBlockSignal_(*globalContext);
+      a->preAccessInputProcessBlockSignal_.emit(*globalContext);
     }
     static void postScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
-      a->postAccessInputProcessBlockSignal_(*globalContext);
+      a->postAccessInputProcessBlockSignal_.emit(*globalContext);
     }
     static void preModuleSignal(ActivityRegistry* a,
                                 GlobalContext const* globalContext,
                                 ModuleCallingContext const* moduleCallingContext) {
-      a->preModuleAccessInputProcessBlockSignal_(*globalContext, *moduleCallingContext);
+      a->preModuleAccessInputProcessBlockSignal_.emit(*globalContext, *moduleCallingContext);
     }
     static void postModuleSignal(ActivityRegistry* a,
                                  GlobalContext const* globalContext,
                                  ModuleCallingContext const* moduleCallingContext) {
-      a->postModuleAccessInputProcessBlockSignal_(*globalContext, *moduleCallingContext);
+      a->postModuleAccessInputProcessBlockSignal_.emit(*globalContext, *moduleCallingContext);
     }
     static const char* transitionName() { return "access input ProcessBlock"; }
   };
@@ -489,20 +489,20 @@ namespace edm {
     }
 
     static void preScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
-      a->preEndProcessBlockSignal_(*globalContext);
+      a->preEndProcessBlockSignal_.emit(*globalContext);
     }
     static void postScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
-      a->postEndProcessBlockSignal_(*globalContext);
+      a->postEndProcessBlockSignal_.emit(*globalContext);
     }
     static void preModuleSignal(ActivityRegistry* a,
                                 GlobalContext const* globalContext,
                                 ModuleCallingContext const* moduleCallingContext) {
-      a->preModuleEndProcessBlockSignal_(*globalContext, *moduleCallingContext);
+      a->preModuleEndProcessBlockSignal_.emit(*globalContext, *moduleCallingContext);
     }
     static void postModuleSignal(ActivityRegistry* a,
                                  GlobalContext const* globalContext,
                                  ModuleCallingContext const* moduleCallingContext) {
-      a->postModuleEndProcessBlockSignal_(*globalContext, *moduleCallingContext);
+      a->postModuleEndProcessBlockSignal_.emit(*globalContext, *moduleCallingContext);
     }
     static const char* transitionName() { return "end ProcessBlock"; }
   };

--- a/FWCore/Framework/src/ComponentConstructionSentry.cc
+++ b/FWCore/Framework/src/ComponentConstructionSentry.cc
@@ -8,13 +8,13 @@ namespace edm {
     ComponentConstructionSentry::ComponentConstructionSentry(EventSetupProvider const& iProvider,
                                                              ComponentDescription const& iDescription)
         : provider_(iProvider), description_(iDescription) {
-      provider_.activityRegistry()->preESModuleConstructionSignal_(description_);
+      provider_.activityRegistry()->preESModuleConstructionSignal_.emit(description_);
       // Here would be where the construction signal would go
     }
 
     ComponentConstructionSentry::~ComponentConstructionSentry() noexcept(false) {
       try {
-        provider_.activityRegistry()->postESModuleConstructionSignal_(description_);
+        provider_.activityRegistry()->postESModuleConstructionSignal_.emit(description_);
       } catch (...) {
         if (succeeded_) {
           // no exception happened during construction so can rethrow the exception from the post construction signal

--- a/FWCore/Framework/src/EventAcquireSignalsSentry.h
+++ b/FWCore/Framework/src/EventAcquireSignalsSentry.h
@@ -30,10 +30,12 @@ namespace edm {
   public:
     EventAcquireSignalsSentry(ActivityRegistry* iReg, ModuleCallingContext const* iContext)
         : m_reg(iReg), m_context(iContext) {
-      iReg->preModuleEventAcquireSignal_(*(iContext->getStreamContext()), *iContext);
+      iReg->preModuleEventAcquireSignal_.emit(*(iContext->getStreamContext()), *iContext);
     }
 
-    ~EventAcquireSignalsSentry() { m_reg->postModuleEventAcquireSignal_(*(m_context->getStreamContext()), *m_context); }
+    ~EventAcquireSignalsSentry() {
+      m_reg->postModuleEventAcquireSignal_.emit(*(m_context->getStreamContext()), *m_context);
+    }
 
   private:
     // ---------- member data --------------------------------

--- a/FWCore/Framework/src/EventSetupProvider.cc
+++ b/FWCore/Framework/src/EventSetupProvider.cc
@@ -98,7 +98,7 @@ namespace edm {
       assert(iProvider.get() != nullptr);
       dataProviders_->push_back(iProvider);
       if (activityRegistry_) {
-        activityRegistry_->postESModuleRegistrationSignal_(iProvider->description());
+        activityRegistry_->postESModuleRegistrationSignal_.emit(iProvider->description());
       }
     }
 

--- a/FWCore/Framework/src/EventSignalsSentry.h
+++ b/FWCore/Framework/src/EventSignalsSentry.h
@@ -30,10 +30,10 @@ namespace edm {
   public:
     EventSignalsSentry(ActivityRegistry* iReg, ModuleCallingContext const* iContext)
         : m_reg(iReg), m_context(iContext) {
-      iReg->preModuleEventSignal_(*(iContext->getStreamContext()), *iContext);
+      iReg->preModuleEventSignal_.emit(*(iContext->getStreamContext()), *iContext);
     }
 
-    ~EventSignalsSentry() { m_reg->postModuleEventSignal_(*(m_context->getStreamContext()), *m_context); }
+    ~EventSignalsSentry() { m_reg->postModuleEventSignal_.emit(*(m_context->getStreamContext()), *m_context); }
 
   private:
     // ---------- member data --------------------------------

--- a/FWCore/Framework/src/GlobalSchedule.cc
+++ b/FWCore/Framework/src/GlobalSchedule.cc
@@ -81,7 +81,7 @@ namespace edm {
     GlobalContext gc(GlobalContext::Transition::kBeginJob, processContext_);
     std::exception_ptr exceptionPtr;
     try {
-      convertException::wrap([this]() { actReg_->preBeginJobSignal_(*processContext_); });
+      convertException::wrap([this]() { actReg_->preBeginJobSignal_.emit(*processContext_); });
     } catch (cms::Exception& ex) {
       ex.addContext("Handling pre signal, likely in a service function");
       ex.addContext(globalContext);
@@ -96,7 +96,7 @@ namespace edm {
       }
     }
     try {
-      convertException::wrap([this]() { actReg_->postBeginJobSignal_(); });
+      convertException::wrap([this]() { actReg_->postBeginJobSignal_.emit(); });
     } catch (cms::Exception& ex) {
       if (!exceptionPtr) {
         ex.addContext("Handling post signal, likely in a service function");
@@ -114,7 +114,7 @@ namespace edm {
     GlobalContext gc(GlobalContext::Transition::kEndJob, processContext_);
     std::exception_ptr exceptionPtr;
     try {
-      convertException::wrap([this]() { actReg_->preEndJobSignal_(); });
+      convertException::wrap([this]() { actReg_->preEndJobSignal_.emit(); });
     } catch (cms::Exception& ex) {
       ex.addContext("Handling pre signal, likely in a service function");
       ex.addContext(context);
@@ -125,7 +125,7 @@ namespace edm {
     }
 
     try {
-      convertException::wrap([this]() { actReg_->postEndJobSignal_(); });
+      convertException::wrap([this]() { actReg_->postEndJobSignal_.emit(); });
     } catch (cms::Exception& ex) {
       if (!exceptionPtr) {
         ex.addContext("Handling post signal, likely in a service function");
@@ -198,7 +198,7 @@ namespace edm {
     CMS_SA_ALLOW try {
       if (actReg_) {
         ServiceRegistry::Operate op(weakToken.lock());
-        actReg_->preGlobalEarlyTerminationSignal_(*globalContext, TerminationOrigin::ExceptionFromThisContext);
+        actReg_->preGlobalEarlyTerminationSignal_.emit(*globalContext, TerminationOrigin::ExceptionFromThisContext);
       }
     } catch (...) {
     }

--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -466,46 +466,46 @@ namespace edm {
 
   InputSource::EventSourceSentry::EventSourceSentry(InputSource const& source, StreamContext& sc)
       : source_(source), sc_(sc) {
-    source.actReg()->preSourceSignal_(sc_.streamID());
+    source.actReg()->preSourceSignal_.emit(sc_.streamID());
   }
 
-  InputSource::EventSourceSentry::~EventSourceSentry() { source_.actReg()->postSourceSignal_(sc_.streamID()); }
+  InputSource::EventSourceSentry::~EventSourceSentry() { source_.actReg()->postSourceSignal_.emit(sc_.streamID()); }
 
   InputSource::LumiSourceSentry::LumiSourceSentry(InputSource const& source, LuminosityBlockIndex index)
       : source_(source), index_(index) {
-    source_.actReg()->preSourceLumiSignal_(index_);
+    source_.actReg()->preSourceLumiSignal_.emit(index_);
   }
 
-  InputSource::LumiSourceSentry::~LumiSourceSentry() { source_.actReg()->postSourceLumiSignal_(index_); }
+  InputSource::LumiSourceSentry::~LumiSourceSentry() { source_.actReg()->postSourceLumiSignal_.emit(index_); }
 
   InputSource::RunSourceSentry::RunSourceSentry(InputSource const& source, RunIndex index)
       : source_(source), index_(index) {
-    source_.actReg()->preSourceRunSignal_(index_);
+    source_.actReg()->preSourceRunSignal_.emit(index_);
   }
 
-  InputSource::RunSourceSentry::~RunSourceSentry() { source_.actReg()->postSourceRunSignal_(index_); }
+  InputSource::RunSourceSentry::~RunSourceSentry() { source_.actReg()->postSourceRunSignal_.emit(index_); }
 
   InputSource::ProcessBlockSourceSentry::ProcessBlockSourceSentry(InputSource const& source,
                                                                   std::string const& processName)
       : source_(source), processName_(processName) {
-    source_.actReg()->preSourceProcessBlockSignal_();
+    source_.actReg()->preSourceProcessBlockSignal_.emit();
   }
 
   InputSource::ProcessBlockSourceSentry::~ProcessBlockSourceSentry() {
-    source_.actReg()->postSourceProcessBlockSignal_(processName_);
+    source_.actReg()->postSourceProcessBlockSignal_.emit(processName_);
   }
 
   InputSource::FileOpenSentry::FileOpenSentry(InputSource const& source, std::string const& lfn)
       : post_(source.actReg()->postOpenFileSignal_), lfn_(lfn) {
-    source.actReg()->preOpenFileSignal_(lfn);
+    source.actReg()->preOpenFileSignal_.emit(lfn);
   }
 
-  InputSource::FileOpenSentry::~FileOpenSentry() { post_(lfn_); }
+  InputSource::FileOpenSentry::~FileOpenSentry() { post_.emit(lfn_); }
 
   InputSource::FileCloseSentry::FileCloseSentry(InputSource const& source, std::string const& lfn)
       : post_(source.actReg()->postCloseFileSignal_), lfn_(lfn) {
-    source.actReg()->preCloseFileSignal_(lfn);
+    source.actReg()->preCloseFileSignal_.emit(lfn);
   }
 
-  InputSource::FileCloseSentry::~FileCloseSentry() { post_(lfn_); }
+  InputSource::FileCloseSentry::~FileCloseSentry() { post_.emit(lfn_); }
 }  // namespace edm

--- a/FWCore/Framework/src/ModuleMaker.cc
+++ b/FWCore/Framework/src/ModuleMaker.cc
@@ -83,16 +83,16 @@ namespace edm {
     bool postCalled = false;
     try {
       convertException::wrap([&]() {
-        pre(md);
+        pre.emit(md);
         module = makeModule(*(p.pset_));
         module->finishModuleInitialization(md, *p.preallocate_, p.reg_);
         // if exception then post will be called in the catch block
         postCalled = true;
-        post(md);
+        post.emit(md);
       });
     } catch (cms::Exception& iException) {
       if (!postCalled) {
-        CMS_SA_ALLOW try { post(md); } catch (...) {
+        CMS_SA_ALLOW try { post.emit(md); } catch (...) {
           // If post throws an exception ignore it because we are already handling another exception
         }
       }

--- a/FWCore/Framework/src/ModuleRegistry.cc
+++ b/FWCore/Framework/src/ModuleRegistry.cc
@@ -77,18 +77,18 @@ namespace edm {
     // If deletion throws an exception, capture it and call iPost before throwing an exception
     // If iPost throws an exception, let it propagate
     auto md = modItr->second->moduleDescription();
-    iPre(modItr->second->moduleDescription());
+    iPre.emit(modItr->second->moduleDescription());
     bool postCalled = false;
     // exception is rethrown
     CMS_SA_ALLOW try {
       labelToModule_.erase(modItr);
       // if exception then post will be called in the catch block
       postCalled = true;
-      iPost(md);
+      iPost.emit(md);
     } catch (...) {
       if (not postCalled) {
         // we're already handling exception, nothing we can do if iPost throws
-        CMS_SA_ALLOW try { iPost(md); } catch (...) {
+        CMS_SA_ALLOW try { iPost.emit(md); } catch (...) {
         }
       }
       throw;

--- a/FWCore/Framework/src/ModuleRegistryUtilities.cc
+++ b/FWCore/Framework/src/ModuleRegistryUtilities.cc
@@ -79,12 +79,12 @@ namespace edm {
       static void preModuleSignal(ActivityRegistry* activityRegistry,
                                   GlobalContext const*,
                                   ModuleCallingContext const* moduleCallingContext) {
-        activityRegistry->preModuleBeginJobSignal_(*moduleCallingContext->moduleDescription());
+        activityRegistry->preModuleBeginJobSignal_.emit(*moduleCallingContext->moduleDescription());
       }
       static void postModuleSignal(ActivityRegistry* activityRegistry,
                                    GlobalContext const*,
                                    ModuleCallingContext const* moduleCallingContext) {
-        activityRegistry->postModuleBeginJobSignal_(*moduleCallingContext->moduleDescription());
+        activityRegistry->postModuleBeginJobSignal_.emit(*moduleCallingContext->moduleDescription());
       }
     };
 
@@ -94,12 +94,12 @@ namespace edm {
       static void preModuleSignal(ActivityRegistry* activityRegistry,
                                   GlobalContext const*,
                                   ModuleCallingContext const* moduleCallingContext) {
-        activityRegistry->preModuleEndJobSignal_(*moduleCallingContext->moduleDescription());
+        activityRegistry->preModuleEndJobSignal_.emit(*moduleCallingContext->moduleDescription());
       }
       static void postModuleSignal(ActivityRegistry* activityRegistry,
                                    GlobalContext const*,
                                    ModuleCallingContext const* moduleCallingContext) {
-        activityRegistry->postModuleEndJobSignal_(*moduleCallingContext->moduleDescription());
+        activityRegistry->postModuleEndJobSignal_.emit(*moduleCallingContext->moduleDescription());
       }
     };
 
@@ -109,12 +109,12 @@ namespace edm {
       static void preModuleSignal(ActivityRegistry* activityRegistry,
                                   StreamContext const* streamContext,
                                   ModuleCallingContext const* moduleCallingContext) {
-        activityRegistry->preModuleBeginStreamSignal_(*streamContext, *moduleCallingContext);
+        activityRegistry->preModuleBeginStreamSignal_.emit(*streamContext, *moduleCallingContext);
       }
       static void postModuleSignal(ActivityRegistry* activityRegistry,
                                    StreamContext const* streamContext,
                                    ModuleCallingContext const* moduleCallingContext) {
-        activityRegistry->postModuleBeginStreamSignal_(*streamContext, *moduleCallingContext);
+        activityRegistry->postModuleBeginStreamSignal_.emit(*streamContext, *moduleCallingContext);
       }
     };
 
@@ -124,12 +124,12 @@ namespace edm {
       static void preModuleSignal(ActivityRegistry* activityRegistry,
                                   StreamContext const* streamContext,
                                   ModuleCallingContext const* moduleCallingContext) {
-        activityRegistry->preModuleEndStreamSignal_(*streamContext, *moduleCallingContext);
+        activityRegistry->preModuleEndStreamSignal_.emit(*streamContext, *moduleCallingContext);
       }
       static void postModuleSignal(ActivityRegistry* activityRegistry,
                                    StreamContext const* streamContext,
                                    ModuleCallingContext const* moduleCallingContext) {
-        activityRegistry->postModuleEndStreamSignal_(*streamContext, *moduleCallingContext);
+        activityRegistry->postModuleEndStreamSignal_.emit(*streamContext, *moduleCallingContext);
       }
     };
 

--- a/FWCore/Framework/src/OutputModuleCommunicatorT.cc
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.cc
@@ -88,9 +88,9 @@ namespace edm {
         ParentContext parentContext(&globalContext);
         ModuleCallingContext mcc(desc);
         ModuleContextSentry moduleContextSentry(&mcc, parentContext);
-        activityRegistry->preModuleWriteProcessBlockSignal_(globalContext, mcc);
+        activityRegistry->preModuleWriteProcessBlockSignal_.emit(globalContext, mcc);
         auto sentry(make_sentry(activityRegistry, [&globalContext, &mcc](ActivityRegistry* ar) {
-          ar->postModuleWriteProcessBlockSignal_(globalContext, mcc);
+          ar->postModuleWriteProcessBlockSignal_.emit(globalContext, mcc);
         }));
         mod.doWriteProcessBlock(processBlockPrincipal, &mcc);
       } catch (...) {
@@ -130,9 +130,9 @@ namespace edm {
         ParentContext parentContext(&globalContext);
         ModuleCallingContext mcc(desc);
         ModuleContextSentry moduleContextSentry(&mcc, parentContext);
-        activityRegistry->preModuleWriteRunSignal_(globalContext, mcc);
+        activityRegistry->preModuleWriteRunSignal_.emit(globalContext, mcc);
         auto sentry(make_sentry(activityRegistry, [&globalContext, &mcc](ActivityRegistry* ar) {
-          ar->postModuleWriteRunSignal_(globalContext, mcc);
+          ar->postModuleWriteRunSignal_.emit(globalContext, mcc);
         }));
         mod.doWriteRun(rp, &mcc, mergeableRunProductMetadata);
       } catch (...) {
@@ -164,9 +164,9 @@ namespace edm {
         ParentContext parentContext(&globalContext);
         ModuleCallingContext mcc(desc);
         ModuleContextSentry moduleContextSentry(&mcc, parentContext);
-        activityRegistry->preModuleWriteLumiSignal_(globalContext, mcc);
+        activityRegistry->preModuleWriteLumiSignal_.emit(globalContext, mcc);
         auto sentry(make_sentry(activityRegistry, [&globalContext, &mcc](ActivityRegistry* ar) {
-          ar->postModuleWriteLumiSignal_(globalContext, mcc);
+          ar->postModuleWriteLumiSignal_.emit(globalContext, mcc);
         }));
         mod.doWriteLuminosityBlock(lbp, &mcc);
       } catch (...) {

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -213,7 +213,7 @@ namespace edm {
     printedException_ = false;
     if (actReg_) {
       ServiceRegistry::Operate guard(iToken);
-      actReg_->prePathEventSignal_(*iStreamContext, pathContext_);
+      actReg_->prePathEventSignal_.emit(*iStreamContext, pathContext_);
     }
     //If the Path succeeds, these are the values we have at the end
     state_ = hlt::Pass;
@@ -318,7 +318,7 @@ namespace edm {
           iException = jException;
         }
       }
-      actReg_->postPathEventSignal_(*iContext, pathContext_, status);
+      actReg_->postPathEventSignal_.emit(*iContext, pathContext_, status);
     } catch (...) {
       if (not iException) {
         iException = std::current_exception();

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -808,7 +808,7 @@ namespace edm {
       ServiceRegistry::Operate op(token);
 
       // Propagating the exception would be nontrivial, and signal actions are not supposed to throw exceptions
-      CMS_SA_ALLOW try { activityRegistry->preGlobalWriteRunSignal_(globalContext); } catch (...) {
+      CMS_SA_ALLOW try { activityRegistry->preGlobalWriteRunSignal_.emit(globalContext); } catch (...) {
       }
       for (auto& c : all_output_communicators_) {
         c->writeRunAsync(nextTask, rp, processContext, activityRegistry, mergeableRunProductMetadata);
@@ -817,7 +817,7 @@ namespace edm {
       //services can depend on other services
       ServiceRegistry::Operate op(token);
 
-      activityRegistry->postGlobalWriteRunSignal_(globalContext);
+      activityRegistry->postGlobalWriteRunSignal_.emit(globalContext);
     })) |
         chain::runLast(task);
   }
@@ -838,7 +838,7 @@ namespace edm {
     chain::first([&](auto nextTask) {
       // Propagating the exception would be nontrivial, and signal actions are not supposed to throw exceptions
       ServiceRegistry::Operate op(token);
-      CMS_SA_ALLOW try { activityRegistry->preWriteProcessBlockSignal_(globalContext); } catch (...) {
+      CMS_SA_ALLOW try { activityRegistry->preWriteProcessBlockSignal_.emit(globalContext); } catch (...) {
       }
       for (auto& c : all_output_communicators_) {
         c->writeProcessBlockAsync(nextTask, pbp, processContext, activityRegistry);
@@ -847,7 +847,7 @@ namespace edm {
       //services can depend on other services
       ServiceRegistry::Operate op(token);
 
-      activityRegistry->postWriteProcessBlockSignal_(globalContext);
+      activityRegistry->postWriteProcessBlockSignal_.emit(globalContext);
     })) |
         chain::runLast(std::move(task));
   }
@@ -867,7 +867,7 @@ namespace edm {
     using namespace edm::waiting_task;
     chain::first([&](auto nextTask) {
       ServiceRegistry::Operate op(token);
-      CMS_SA_ALLOW try { activityRegistry->preGlobalWriteLumiSignal_(globalContext); } catch (...) {
+      CMS_SA_ALLOW try { activityRegistry->preGlobalWriteLumiSignal_.emit(globalContext); } catch (...) {
       }
       for (auto& c : all_output_communicators_) {
         c->writeLumiAsync(nextTask, lbp, processContext, activityRegistry);
@@ -876,7 +876,7 @@ namespace edm {
       //services can depend on other services
       ServiceRegistry::Operate op(token);
 
-      activityRegistry->postGlobalWriteLumiSignal_(globalContext);
+      activityRegistry->postGlobalWriteLumiSignal_.emit(globalContext);
     })) |
         chain::runLast(task);
   }
@@ -903,8 +903,8 @@ namespace edm {
                           ProcessBlockHelperBase const& processBlockHelperBase,
                           std::string const& iProcessName) {
     {
-      preModulesInitializationFinalizedSignal_();
-      auto post = [this](void*) { postModulesInitializationFinalizedSignal_(); };
+      preModulesInitializationFinalizedSignal_.emit();
+      auto post = [this](void*) { postModulesInitializationFinalizedSignal_.emit(); };
       std::unique_ptr<void, decltype(post)> const postGuard(this, post);
       finishModulesInitialization(*moduleRegistry_, iRegistry, iESIndices, processBlockHelperBase, iProcessName);
     }

--- a/FWCore/Framework/src/SendSourceTerminationSignalIfException.h
+++ b/FWCore/Framework/src/SendSourceTerminationSignalIfException.h
@@ -21,7 +21,7 @@ namespace edm {
     SendSourceTerminationSignalIfException(ActivityRegistry* iReg) : reg_(iReg) {}
     ~SendSourceTerminationSignalIfException() {
       if (reg_) {
-        reg_->preSourceEarlyTerminationSignal_(TerminationOrigin::ExceptionFromThisContext);
+        reg_->preSourceEarlyTerminationSignal_.emit(TerminationOrigin::ExceptionFromThisContext);
       }
     }
     void completedSuccessfully() { reg_ = nullptr; }

--- a/FWCore/Framework/src/SignallingProductRegistryFiller.cc
+++ b/FWCore/Framework/src/SignallingProductRegistryFiller.cc
@@ -56,5 +56,5 @@ void SignallingProductRegistryFiller::addCalled(ProductDescription const& iProd,
         << "This can lead to circular Event::get* calls.\n"
         << "Please reconfigure job so it does not contain both of the modules.";
   }
-  productAddedSignal_(iProd);
+  productAddedSignal_.emit(iProd);
 }

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -73,20 +73,20 @@ namespace edm {
     class BeginStreamTraits {
     public:
       static void preScheduleSignal(ActivityRegistry* activityRegistry, StreamContext const* streamContext) {
-        activityRegistry->preBeginStreamSignal_(*streamContext);
+        activityRegistry->preBeginStreamSignal_.emit(*streamContext);
       }
       static void postScheduleSignal(ActivityRegistry* activityRegistry, StreamContext const* streamContext) {
-        activityRegistry->postBeginStreamSignal_(*streamContext);
+        activityRegistry->postBeginStreamSignal_.emit(*streamContext);
       }
     };
 
     class EndStreamTraits {
     public:
       static void preScheduleSignal(ActivityRegistry* activityRegistry, StreamContext const* streamContext) {
-        activityRegistry->preEndStreamSignal_(*streamContext);
+        activityRegistry->preEndStreamSignal_.emit(*streamContext);
       }
       static void postScheduleSignal(ActivityRegistry* activityRegistry, StreamContext const* streamContext) {
-        activityRegistry->postEndStreamSignal_(*streamContext);
+        activityRegistry->postEndStreamSignal_.emit(*streamContext);
       }
     };
 
@@ -739,7 +739,7 @@ namespace edm {
         iExcept = std::current_exception();
       }
 
-      actReg_->preStreamEarlyTerminationSignal_(streamContext_, TerminationOrigin::ExceptionFromThisContext);
+      actReg_->preStreamEarlyTerminationSignal_.emit(streamContext_, TerminationOrigin::ExceptionFromThisContext);
     }
     // Caught exception is propagated to the caller
     CMS_SA_ALLOW try { Traits::postScheduleSignal(actReg_.get(), &streamContext_); } catch (...) {
@@ -929,7 +929,7 @@ namespace edm {
     // We are already handling an earlier exception, so ignore it
     // if this signal results in another exception being thrown.
     CMS_SA_ALLOW try {
-      actReg_->preStreamEarlyTerminationSignal_(streamContext, TerminationOrigin::ExceptionFromThisContext);
+      actReg_->preStreamEarlyTerminationSignal_.emit(streamContext, TerminationOrigin::ExceptionFromThisContext);
     } catch (...) {
     }
   }

--- a/FWCore/Framework/src/TransformerBase.cc
+++ b/FWCore/Framework/src/TransformerBase.cc
@@ -19,11 +19,11 @@ namespace {
     TransformSignalSentry(edm::ActivityRegistry* a, edm::StreamContext const& sc, edm::ModuleCallingContext const& mcc)
         : a_(a), sc_(sc), mcc_(mcc) {
       if (a_)
-        a_->preModuleTransformSignal_(sc_, mcc_);
+        a_->preModuleTransformSignal_.emit(sc_, mcc_);
     }
     ~TransformSignalSentry() {
       if (a_)
-        a_->postModuleTransformSignal_(sc_, mcc_);
+        a_->postModuleTransformSignal_.emit(sc_, mcc_);
     }
 
   private:
@@ -39,11 +39,11 @@ namespace {
                                    edm::ModuleCallingContext const& mcc)
         : a_(a), sc_(sc), mcc_(mcc) {
       if (a_)
-        a_->preModuleTransformAcquiringSignal_(sc_, mcc_);
+        a_->preModuleTransformAcquiringSignal_.emit(sc_, mcc_);
     }
     ~TransformAcquiringSignalSentry() {
       if (a_)
-        a_->postModuleTransformAcquiringSignal_(sc_, mcc_);
+        a_->postModuleTransformAcquiringSignal_.emit(sc_, mcc_);
     }
 
   private:

--- a/FWCore/PluginManager/src/PluginCapabilities.cc
+++ b/FWCore/PluginManager/src/PluginCapabilities.cc
@@ -75,7 +75,7 @@ namespace edmplugin {
       //  we haven't yet returned from PluginManager::load method
       info.name_ = name;
       info.loadable_ = iLoadable.path();
-      this->newPluginAdded_(category(), info);
+      this->newPluginAdded_.emit(category(), info);
     }
     return true;
   }

--- a/FWCore/PluginManager/src/PluginFactoryBase.cc
+++ b/FWCore/PluginManager/src/PluginFactoryBase.cc
@@ -60,7 +60,7 @@ namespace edmplugin {
     PluginInfo info;
     info.loadable_ = std::filesystem::path(PluginManager::loadingFile());
     info.name_ = iName;
-    newPluginAdded_(category(), info);
+    newPluginAdded_.emit(category(), info);
   }
 
   void* PluginFactoryBase::findPMaker(const std::string& iName) const {

--- a/FWCore/PluginManager/src/PluginFactoryManager.cc
+++ b/FWCore/PluginManager/src/PluginFactoryManager.cc
@@ -54,7 +54,7 @@ namespace edmplugin {
   //
   void PluginFactoryManager::addFactory(const PluginFactoryBase* iFactory) {
     factories_.push_back(iFactory);
-    newFactory_(iFactory);
+    newFactory_.emit(iFactory);
   }
 
   //

--- a/FWCore/PluginManager/src/PluginManager.cc
+++ b/FWCore/PluginManager/src/PluginManager.cc
@@ -230,7 +230,7 @@ namespace edmplugin {
   }  // namespace
 
   const SharedLibrary& PluginManager::load(const std::string& iCategory, const std::string& iPlugin) {
-    askedToLoadCategoryWithPlugin_(iCategory, iPlugin);
+    askedToLoadCategoryWithPlugin_.emit(iCategory, iPlugin);
     const std::filesystem::path& p = loadableFor(iCategory, iPlugin);
 
     //have we already loaded this?
@@ -242,7 +242,7 @@ namespace edmplugin {
       itLoaded = loadables_.find(p);
       if (itLoaded == loadables_.end()) {
         //try to make one
-        goingToLoad_(p);
+        goingToLoad_.emit(p);
         Sentry s(loadingLibraryNamed_(), p.string());
         //std::filesystem::path native(p.string());
         std::shared_ptr<SharedLibrary> ptr;
@@ -258,7 +258,7 @@ namespace edmplugin {
           }
         }
         loadables_.emplace(p, ptr);
-        justLoaded_(*ptr);
+        justLoaded_.emit(*ptr);
         return *ptr;
       }
     }
@@ -266,7 +266,7 @@ namespace edmplugin {
   }
 
   const SharedLibrary* PluginManager::tryToLoad(const std::string& iCategory, const std::string& iPlugin) {
-    askedToLoadCategoryWithPlugin_(iCategory, iPlugin);
+    askedToLoadCategoryWithPlugin_.emit(iCategory, iPlugin);
     bool ioThrowIfFailElseSucceedStatus = false;
     const std::filesystem::path& p = loadableFor_(iCategory, iPlugin, ioThrowIfFailElseSucceedStatus);
 
@@ -283,7 +283,7 @@ namespace edmplugin {
       itLoaded = loadables_.find(p);
       if (itLoaded == loadables_.end()) {
         //try to make one
-        goingToLoad_(p);
+        goingToLoad_.emit(p);
         Sentry s(loadingLibraryNamed_(), p.string());
         //std::filesystem::path native(p.string());
         std::shared_ptr<SharedLibrary> ptr;
@@ -299,7 +299,7 @@ namespace edmplugin {
           }
         }
         loadables_[p] = ptr;
-        justLoaded_(*ptr);
+        justLoaded_.emit(*ptr);
         return ptr.get();
       }
     }

--- a/FWCore/ServiceRegistry/test/connect_but_block_self_t.cppunit.cc
+++ b/FWCore/ServiceRegistry/test/connect_but_block_self_t.cppunit.cc
@@ -38,7 +38,7 @@ namespace {
     void operator()() {
       //std::cout <<"see signal"<<std::endl;
       ++seen_;
-      (*signal_)();
+      (*signal_).emit();
     }
   };
 }  // namespace
@@ -55,7 +55,7 @@ void testConnectButBlockSelf::test() {
   ReSignaller two(theSignal, iTwo);
   connect_but_block_self(theSignal, two);
 
-  theSignal();
+  theSignal.emit();
 
   //std::cout <<"one "<<iOne <<std::endl;
   //std::cout <<"two "<<iTwo <<std::endl;

--- a/FWCore/ServiceRegistry/test/servicesmanager_order.cpp
+++ b/FWCore/ServiceRegistry/test/servicesmanager_order.cpp
@@ -85,8 +85,8 @@ int main() try {
 
   edm::ActivityRegistry actReg;
   sm.connectTo(actReg);
-  actReg.postBeginJobSignal_();
-  actReg.postEndJobSignal_();
+  actReg.postBeginJobSignal_.emit();
+  actReg.postEndJobSignal_.emit();
 
   return 0;
 } catch (cms::Exception const& e) {

--- a/FWCore/ServiceRegistry/test/servicesmanager_t.cppunit.cc
+++ b/FWCore/ServiceRegistry/test/servicesmanager_t.cppunit.cc
@@ -201,7 +201,7 @@ void testServicesManager::legacyTest() {
       CPPUNIT_ASSERT(!sm.get<TestService>().beginJobCalled());
       edm::ActivityRegistry ar;
       sm.connectTo(ar);
-      ar.postBeginJobSignal_();
+      ar.postBeginJobSignal_.emit();
 
       CPPUNIT_ASSERT(sm.get<TestService>().beginJobCalled());
     } catch (const edm::Exception& iException) {

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -429,11 +429,11 @@ namespace edm {
                                    preallocations_.numberOfLuminosityBlocks(),
                                    preallocations_.numberOfRuns(),
                                    preallocations_.numberOfThreads());
-      actReg_->preallocateSignal_(bounds);
+      actReg_->preallocateSignal_.emit(bounds);
       schedule_->convertCurrentProcessAlias(processConfiguration_->processName());
 
       espController_->finishConfiguration();
-      actReg_->eventSetupConfigurationSignal_(esp_->recordsToResolverIndices(), processContext_);
+      actReg_->eventSetupConfigurationSignal_.emit(esp_->recordsToResolverIndices(), processContext_);
 
       schedule_->beginJob(
           *preg_, esp_->recordsToResolverIndices(), *processBlockHelper_, processContext_.processName());
@@ -687,9 +687,9 @@ namespace edm {
         schedule_->endStream(i, c, collectorMutex);
       }
       auto actReg = actReg_.get();
-      c.call([actReg]() { actReg->preEndJobSignal_(); });
+      c.call([actReg]() { actReg->preEndJobSignal_.emit(); });
       schedule_->endJob(c);
-      c.call([actReg]() { actReg->postEndJobSignal_(); });
+      c.call([actReg]() { actReg->postEndJobSignal_.emit(); });
       if (c.hasThrown()) {
         c.rethrow();
       }


### PR DESCRIPTION
#### PR description:

In the current framework code, signal emission is done with a mix of `emit()`  and `operator()`. `Operator()` 
is also used in the signal connecting mechanisms. This commit makes `operator()` private in the context of emission
while still allowing its use for connection.

Having emit calls explicit in the framework code allows easier location of signals emission, and easier context checking.

The bulk of this PR is in `FWCore/Utilities/interface/Signal.h`. The rests is just the conversion from`operator()` to `emit()`
as a consequence.

This is a technical change that does not affect the behavior of the code.

#### PR validation:

This has been used for validating profiler services development (for a different PR) without any noticeable changes in
behavior. Re compiling the ~900 affected modules (as this is touching FWCore) went fine.

This PR does not change physics code.
