### PR TITLE
Propagate templates for SoABlocks

### DIFF
--- a/DataFormats/SoATemplate/README.md
+++ b/DataFormats/SoATemplate/README.md
@@ -80,16 +80,14 @@ and `SOA_CONST_ELEMENT_METHODS` macros. Each of these macros can be called only 
 
 `SoABlocks` is a macro-generated templated class that enables structured composition of multiple `SoALayouts` into a single
 container, referred to as "blocks". Each block is a Layout, and the structure itself looks like multiple contigous memory 
-buffers of different sizes. The alignment is ensured to be the same for every block. 
-`SoABlocks` also supports `View` and `ConstView` classes, mirroring the structure of the underlying structs. The blocks 
-are built via composition and access to individual layouts and views is provided by name.
-
-It is also possible to generate methods inside `View` and `ConstView` using the `SOA_VIEW_METHODS` and 
-`SOA_CONST_VIEW_METHODS` in the same way as described in [Customized methods](#customized-methods).
+buffers of different sizes. The alignment is ensured to be the same for every block. `SoABlocks` also supports 
+`View` and `ConstView` classes. In addition to those fully parametrized templates, two further levels of parametrization are provided:
+`ViewTemplate`, `ViewTemplateFreeParams` and respectively `ConstViewTemplate`, `ConstViewTemplateFreeParams`, 
+mirroring the structure of the underlying structs. The blocks are built via composition and access to individual layouts 
+and views is provided by name.
 
 TODOs:
 - Add introspection utilities to print the structure and layout of a `SoABlocks` instance.
-- Extend support for fully templated `View`/`ConstView` classes beyond the default parameters.
 - Implement support for heterogeneous `deepCopy()` operations between different but compatible `SoABlocks` configurations.
 
 [An example of utilization is showed below.](#examples)

--- a/DataFormats/SoATemplate/interface/SoACommon.h
+++ b/DataFormats/SoATemplate/interface/SoACommon.h
@@ -196,6 +196,16 @@ namespace cms::soa {
   };
 
   // Matryoshka template to avoid commas inside macros
+  template <CMS_SOA_BYTE_SIZE_TYPE ALIGNMENT>
+  struct LayoutParameters {
+    template <bool ALIGNMENT_ENFORCEMENT>
+    struct AlignmentEnforcement {
+      template <template <CMS_SOA_BYTE_SIZE_TYPE, bool> typename T>
+      using Layout = T<ALIGNMENT, ALIGNMENT_ENFORCEMENT>;
+    };
+  };
+
+  // Matryoshka template to avoid commas inside macros
   template <SoAColumnType COLUMN_TYPE>
   struct SoAConstParameters_ColumnType {
     template <typename T>

--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -1795,8 +1795,11 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
     }                                                                                                                  \
                                                                                                                        \
     /* Helper to implement View as derived from ConstView in SoABlocks implementation */                               \
-    SOA_HOST_DEVICE SOA_INLINE static View const_cast_View(ConstView const& view)  {                                   \
-      return View{view.metadata().size(), _ITERATE_ON_ALL_COMMA(_DECLARE_CONST_CAST_COLUMNS, ~, __VA_ARGS__)};         \
+    template <bool RESTRICT_QUALIFY, bool RANGE_CHECKING>                                                              \
+    SOA_HOST_DEVICE SOA_INLINE static ViewTemplate<RESTRICT_QUALIFY, RANGE_CHECKING> const_cast_View(                  \
+      ConstViewTemplate<RESTRICT_QUALIFY, RANGE_CHECKING> const& view)  {                                              \
+      return ViewTemplate<RESTRICT_QUALIFY, RANGE_CHECKING>{                                                           \
+        view.metadata().size(), _ITERATE_ON_ALL_COMMA(_DECLARE_CONST_CAST_COLUMNS, ~, __VA_ARGS__)};                   \
     }                                                                                                                  \
                                                                                                                        \
     /*                                                                                                                 \


### PR DESCRIPTION
This PR propagates the templates of the `SoABlocks` and its `View` to the sub-layouts and their views. In Particular the template parameter `ALIGNMENT_ENFORCEMENT` was not propagated to the sub-layouts. Also the `SoABlocks` only had a `View` and a `ConstView`, without templates. This means for the sub-layouts only the default `View` and `ConstView` was usably. With this PR the `SoABlocks` is extended with the `ConstViewTemplateFreeParams`, `ConstViewTemplate`, `ViewTemplateFreeParams` and `ViewTemplate`. 


@felicepantaleo fyi