### PR TITLE
Draft: allow using ROOT I/O in Millepede alignment jobs

### DIFF
--- a/Alignment/CommonAlignmentAlgorithm/src/AlignmentIORootBase.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/AlignmentIORootBase.cc
@@ -105,8 +105,8 @@ int AlignmentIORootBase::closeRoot(void) {
 // returns highest existing iteration in file
 // if file does not exist: return -1
 
-int AlignmentIORootBase::testFile(const char* filename, const TString& tname) {  
-  std::unique_ptr<TFile> aFile ( TFile::Open(filename, "read"));
+int AlignmentIORootBase::testFile(const char* filename, const TString& tname) {
+  std::unique_ptr<TFile> aFile(TFile::Open(filename, "read"));
   if (!aFile || !aFile->IsOpen()) {
     return -1;
   } else {

--- a/Alignment/CommonAlignmentAlgorithm/src/AlignmentIORootBase.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/AlignmentIORootBase.cc
@@ -105,20 +105,16 @@ int AlignmentIORootBase::closeRoot(void) {
 // returns highest existing iteration in file
 // if file does not exist: return -1
 
-int AlignmentIORootBase::testFile(const char* filename, const TString& tname) {
-  FILE* testFILE;
-  testFILE = fopen(filename, "r");
-  if (testFILE == nullptr) {
+int AlignmentIORootBase::testFile(const char* filename, const TString& tname) {  
+  std::unique_ptr<TFile> aFile ( TFile::Open(filename, "read"));
+  if (!aFile || !aFile->IsOpen()) {
     return -1;
   } else {
-    fclose(testFILE);
     int ihighest = -2;
-    TFile* aFile = TFile::Open(filename, "read");
     for (int iter = 0; iter < itermax; iter++) {
       if ((nullptr != (TTree*)aFile->Get(treeName(iter, tname))) && (iter > ihighest))
         ihighest = iter;
     }
-    delete aFile;
     return ihighest;
   }
 }

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
@@ -455,7 +455,8 @@ std::vector<std::string> MillePedeAlignmentAlgorithm::getExistingFormattedFiles(
       const auto strippedInputFileName = theCompleteInputFileName.substr(0, endOfStrippedFileName);
       // Check if the file exists
       struct stat buffer;
-      if (stat(strippedInputFileName.c_str(), &buffer) == 0) {
+      // skip stat if we are using xrootd paths. 
+      if (plainFile.find("root://") == 0 || stat(strippedInputFileName.c_str(), &buffer) == 0) {
         // If the file exists, add it to the list
         files.push_back(theCompleteInputFileName);
         if (theNumberedInputFileName == theInputFileName) {

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
@@ -455,7 +455,7 @@ std::vector<std::string> MillePedeAlignmentAlgorithm::getExistingFormattedFiles(
       const auto strippedInputFileName = theCompleteInputFileName.substr(0, endOfStrippedFileName);
       // Check if the file exists
       struct stat buffer;
-      // skip stat if we are using xrootd paths. 
+      // skip stat if we are using xrootd paths.
       if (plainFile.find("root://") == 0 || stat(strippedInputFileName.c_str(), &buffer) == 0) {
         // If the file exists, add it to the list
         files.push_back(theCompleteInputFileName);

--- a/Alignment/MillePedeAlignmentAlgorithm/python/mpslib/Mpslibclass.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/mpslib/Mpslibclass.py
@@ -19,9 +19,9 @@
 #       elapsedTime     - seconds since last update
 #       mssDirPool      - pool for $mssDir (e.g. cmscaf/cmscafuser)
 #       pedeMem         - Memory allocated for pede
-#       rootIO
-#       mp2loc
-#       spare3
+#       rootIO          - flag to enable xrootd-based I/O with ROOT binaries 
+#       mp2loc          - specify local MP2 installation to use 
+#       extraSetup      - additional commands to run for setting up runtime environment
 
 # (2) Job-level variables/lists
 #       JOBNUMBER   - ADDED, selfexplanatory
@@ -53,7 +53,7 @@ class jobdatabase:
     JOBREMARK, JOBSP1, JOBSP2, JOBSP3 = ([] for i in range(13))
 
     header, batchScript, cfgTemplate, infiList, classInf, addFiles, driver, mergeScript, \
-    mssDir, updateTimeHuman, mssDirPool, rootIO, mp2loc, spare3 = ('' for i in range(14))
+    mssDir, updateTimeHuman, mssDirPool, rootIO, mp2loc, extraSetup = ('' for i in range(14))
 
     updateTime, elapsedTime, pedeMem , nJobs = -1, -1, -1, -1
 
@@ -92,7 +92,7 @@ class jobdatabase:
         self.pedeMem         = int(DBFILE.readline())
         self.rootIO          = DBFILE.readline().rstrip('\n')
         self.mp2loc          = DBFILE.readline().rstrip('\n')
-        self.spare3          = DBFILE.readline().rstrip('\n')
+        self.extraSetup          = DBFILE.readline().rstrip('\n')
 
         #read actual jobinfo into arrays
         self.nJobs = 0
@@ -147,6 +147,7 @@ class jobdatabase:
         print('pedeMem:\t',             self.pedeMem, '\n')
         print('rootIO:\t',             bool(self.rootIO), '\n')
         print('mp2loc:\t',             self.mp2loc, '\n')
+        print('extraSetup:\t',             self.extraSetup, '\n')
 
         #print interesting Job-level lists ---- to add: t/evt, fix remarks
         headFmt = '###     dir      jobid    stat  try  rtime      nevt  remark   weight  name'
@@ -220,7 +221,6 @@ class jobdatabase:
             self.elapsedTime = self.currentTime - self.updateTime
         self.updateTime = self.currentTime
         self.updateTimeHuman = str(datetime.datetime.today())   #no timezone :(
-        self.spare3 = "-- unused --"
 
         #if mps.db already exists, backup as mps.db~ (in case of interupt during write)
         os.system('[[ -a mps.db ]] && cp -p mps.db mps.db~')
@@ -231,7 +231,7 @@ class jobdatabase:
                      self.classInf, self.addFiles, self.driver, self.mergeScript,
                      self.mssDir, self.updateTime, self.updateTimeHuman,
                      self.elapsedTime, self.mssDirPool, self.pedeMem,
-                     self.rootIO, self.mp2loc, self.spare3 ]
+                     self.rootIO, self.mp2loc, self.extraSetup ]
         for item in headData:
             DBFILE.write("%s\n" % item)
 

--- a/Alignment/MillePedeAlignmentAlgorithm/python/mpslib/Mpslibclass.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/mpslib/Mpslibclass.py
@@ -19,8 +19,8 @@
 #       elapsedTime     - seconds since last update
 #       mssDirPool      - pool for $mssDir (e.g. cmscaf/cmscafuser)
 #       pedeMem         - Memory allocated for pede
-#       spare1
-#       spare2
+#       rootIO
+#       mp2loc
 #       spare3
 
 # (2) Job-level variables/lists
@@ -53,7 +53,7 @@ class jobdatabase:
     JOBREMARK, JOBSP1, JOBSP2, JOBSP3 = ([] for i in range(13))
 
     header, batchScript, cfgTemplate, infiList, classInf, addFiles, driver, mergeScript, \
-    mssDir, updateTimeHuman, mssDirPool, spare1, spare2, spare3 = ('' for i in range(14))
+    mssDir, updateTimeHuman, mssDirPool, rootIO, mp2loc, spare3 = ('' for i in range(14))
 
     updateTime, elapsedTime, pedeMem , nJobs = -1, -1, -1, -1
 
@@ -90,8 +90,8 @@ class jobdatabase:
         self.elapsedTime     = int(DBFILE.readline())
         self.mssDirPool      = DBFILE.readline().rstrip('\n')
         self.pedeMem         = int(DBFILE.readline())
-        self.spare1          = DBFILE.readline().rstrip('\n')
-        self.spare2          = DBFILE.readline().rstrip('\n')
+        self.rootIO          = DBFILE.readline().rstrip('\n')
+        self.mp2loc          = DBFILE.readline().rstrip('\n')
         self.spare3          = DBFILE.readline().rstrip('\n')
 
         #read actual jobinfo into arrays
@@ -145,6 +145,8 @@ class jobdatabase:
         print('elapsed:\t',     self.elapsedTime)
         print('mssDirPool:\t',  self.mssDirPool)
         print('pedeMem:\t',             self.pedeMem, '\n')
+        print('rootIO:\t',             bool(self.rootIO), '\n')
+        print('mp2loc:\t',             self.mp2loc, '\n')
 
         #print interesting Job-level lists ---- to add: t/evt, fix remarks
         headFmt = '###     dir      jobid    stat  try  rtime      nevt  remark   weight  name'
@@ -218,8 +220,6 @@ class jobdatabase:
             self.elapsedTime = self.currentTime - self.updateTime
         self.updateTime = self.currentTime
         self.updateTimeHuman = str(datetime.datetime.today())   #no timezone :(
-        self.spare1 = "-- unused --"
-        self.spare2 = "-- unused --"
         self.spare3 = "-- unused --"
 
         #if mps.db already exists, backup as mps.db~ (in case of interupt during write)
@@ -231,7 +231,7 @@ class jobdatabase:
                      self.classInf, self.addFiles, self.driver, self.mergeScript,
                      self.mssDir, self.updateTime, self.updateTimeHuman,
                      self.elapsedTime, self.mssDirPool, self.pedeMem,
-                     self.spare1, self.spare2, self.spare3 ]
+                     self.rootIO, self.mp2loc, self.spare3 ]
         for item in headData:
             DBFILE.write("%s\n" % item)
 

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_check.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_check.py
@@ -197,55 +197,59 @@ for i in range(len(lib.JOBID)):
             # open the input file
             with open(eazeLog,'r') as INFILE:
                 # scan records in input file
-                for line in INFILE:
-                    # check whether any file could not be opened
-                    if re.search(re.compile('Failed to open the file',re.M), line):
-                        badInputFile = 1
-                        break
-                    # check if end of file has been reached
-                    if re.search(re.compile('\<StorageStatistics\>',re.M), line):
-                        eofile = 1
-                    if re.search(re.compile('EAZE\. Time limit reached\.',re.M), line):
-                        timel = 1
-                    if re.search(re.compile('GAF gives I\/O problem',re.M), line):
-                        ioprob = 1
-                    if re.search(re.compile('FrameworkError ExitStatus=[\'\"]8001[\'\"]',re.M), line):
-                        fw8001 = 1
-                    if re.search(re.compile('too many tracks',re.M), line):
-                        tooManyTracks = 1
-                    if re.search(re.compile('segmentation violation',re.M), line):
-                        segviol = 1
-                    if re.search(re.compile('failed RFIO error',re.M), line):
-                        rfioerr = 1
-                    if re.search(re.compile('Request exceeds quota',re.M), line):
-                        quota = 1
-                    # check for newer (e.g. CMSSW_5_1_X) and older CMSSW:
-                    if re.search(re.compile('Fatal Exception',re.M), line):
-                        exceptionCaught = 1
-                    if re.search(re.compile('Exception caught in cmsRun',re.M), line):
-                        exceptionCaught = 1
-                    # AP 07.09.2009 - Check that the job got to a normal end
-                    if re.search(re.compile('AlignmentProducerAsAnalyzer::endJob\(\)',re.M), line):
-                        endofjob = 1
-                    if re.search(re.compile('MismatchedInputFiles',re.M), line):
-                        mismatchedInputFiles = 1
-                    if re.search(re.compile('Did not process any events',re.M), line):
-                        zeroEvents = 1
-                    if re.search(re.compile('FwkReport            -i main_input:sourc',re.M), line):
-                        array = line.split()
-                        nEvent = int(array[5])
-                    if nEvent==0 and re.search(re.compile('FwkReport            -i PostSource',re.M), line):
-                        array = line.split()
-                        nEvent = int(array[5])
-                    # AP 31.07.2009 - To read number of events in CMSSW_3_2_2_patch2
-                    if nEvent==0 and re.search(re.compile('FwkReport            -i AfterSource',re.M), line):
-                        array = line.split()
-                        nEvent = int(array[5])
-                    # RM 03.02.2023
-                    if nEvent==0:
-                        x = re.search(r"FwkReport            -f AfterSource\s+(\d+)",line)
-                        if x:
-                            nEvent = int(x.group(1))
+                try:
+                    for line in INFILE:
+                        # check whether any file could not be opened
+                        if re.search(re.compile('Failed to open the file',re.M), line):
+                            badInputFile = 1
+                            break
+                        # check if end of file has been reached
+                        if re.search(re.compile('\<StorageStatistics\>',re.M), line):
+                            eofile = 1
+                        if re.search(re.compile('EAZE\. Time limit reached\.',re.M), line):
+                            timel = 1
+                        if re.search(re.compile('GAF gives I\/O problem',re.M), line):
+                            ioprob = 1
+                        if re.search(re.compile('FrameworkError ExitStatus=[\'\"]8001[\'\"]',re.M), line):
+                            fw8001 = 1
+                        if re.search(re.compile('too many tracks',re.M), line):
+                            tooManyTracks = 1
+                        if re.search(re.compile('segmentation violation',re.M), line):
+                            segviol = 1
+                        if re.search(re.compile('failed RFIO error',re.M), line):
+                            rfioerr = 1
+                        if re.search(re.compile('Request exceeds quota',re.M), line):
+                            quota = 1
+                        # check for newer (e.g. CMSSW_5_1_X) and older CMSSW:
+                        if re.search(re.compile('Fatal Exception',re.M), line):
+                            exceptionCaught = 1
+                        if re.search(re.compile('Exception caught in cmsRun',re.M), line):
+                            exceptionCaught = 1
+                        # AP 07.09.2009 - Check that the job got to a normal end
+                        if re.search(re.compile('AlignmentProducerAsAnalyzer::endJob\(\)',re.M), line):
+                            endofjob = 1
+                        if re.search(re.compile('MismatchedInputFiles',re.M), line):
+                            mismatchedInputFiles = 1
+                        if re.search(re.compile('Did not process any events',re.M), line):
+                            zeroEvents = 1
+                        if re.search(re.compile('FwkReport            -i main_input:sourc',re.M), line):
+                            array = line.split()
+                            nEvent = int(array[5])
+                        if nEvent==0 and re.search(re.compile('FwkReport            -i PostSource',re.M), line):
+                            array = line.split()
+                            nEvent = int(array[5])
+                        # AP 31.07.2009 - To read number of events in CMSSW_3_2_2_patch2
+                        if nEvent==0 and re.search(re.compile('FwkReport            -i AfterSource',re.M), line):
+                            array = line.split()
+                            nEvent = int(array[5])
+                        # RM 03.02.2023
+                        if nEvent==0:
+                            x = re.search(r"FwkReport            -f AfterSource\s+(\d+)",line)
+                            if x:
+                                nEvent = int(x.group(1))
+                except UnicodeDecodeError:
+                    print ("Decode error - assuming things are ok ")
+                    endofjob = 1
 
             if logZipped == 'true':
                 os.system('gzip -f '+eazeLog)

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_fire.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_fire.py
@@ -489,8 +489,8 @@ else:
                 command ='mps_merge.py -w -c '+inCfgPath+' '+Path+'/'+mergeCfg+' '+Path+' '+str(lib.nJobs)
                 os.system(command)
 
-                # rewrite theScript.sh using inly 'OK' jobs
-                command = 'mps_scriptm.pl -c '+lib.mergeScript+' '+scriptPath+' '+Path+' '+mergeCfg+' '+str(lib.nJobs)+' '+lib.mssDir+' '+lib.mssDirPool
+                # rewrite theScript.sh using only 'OK' jobs
+                command = 'mps_scriptm.pl -c '+lib.mergeScript+' '+scriptPath+' '+Path+' '+mergeCfg+' '+str(lib.nJobs)+' '+lib.mssDir+' '+lib.mssDirPool+ ' '+lib.mp2loc
                 os.system(command)
 
             else:

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_merge.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_merge.py
@@ -74,6 +74,9 @@ else:
 # build list of binary files
 binaryList = ''
 firstentry = True
+prefix=""
+if lib.rootIO:
+    prefix=f"root://eoscms.cern.ch/{lib.mssDir}/binaries/" 
 for i in range(nJobs):
     separator = ',\n                '
     if firstentry:
@@ -81,8 +84,8 @@ for i in range(nJobs):
     if checkok and lib.JOBSTATUS[i]!='OK':
         continue
     firstentry = False
-
-    newName = 'milleBinary%03d.dat' % (i+1)
+    suffix = "dat" if not lib.rootIO else "root" 
+    newName = f"{prefix}milleBinary{i+1:03d}.{suffix}"
     if checkweight and (lib.JOBSP2[i]!='' and lib.JOBSP2[i]!='1.0'):
         weight = lib.JOBSP2[i]
         print('Adding %s to list of binary files using weight %s' % (newName,weight))
@@ -105,6 +108,9 @@ else:
 # build list of tree files
 treeList =''
 firstentry = True
+prefix=""
+if lib.rootIO:
+    prefix=f"root://eoscms.cern.ch/{lib.mssDir}/tree_files/" 
 for i in range(nJobs):
     separator = ',\n                '
     if firstentry:
@@ -113,7 +119,7 @@ for i in range(nJobs):
         continue
     firstentry = False
 
-    newName = 'treeFile%03d.root' % (i+1)
+    newName = f"{prefix}treeFile{i+1:03d}.root"
     print('Adding %s to list of tree files.' % newName)
     treeList = '%s%s\'%s\'' % (treeList, separator, newName)
 

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_script.pl
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_script.pl
@@ -27,6 +27,7 @@ $isn = "undefined";
 $mssDirLocal = "undefined"; # not to confuse with mssDir from 'mpslib'.
 $castorPool = "undefined";
 $cmsCafPool = 0;
+$mp2dir = "undefined";
 
 # parse the arguments
 while (@ARGV) {
@@ -69,6 +70,9 @@ while (@ARGV) {
     elsif ($i eq 8) {
       $castorPool = $arg;
     }
+    elsif ($i eq 9) {
+      $mp2dir = $arg;
+    }
   }
 }
 
@@ -101,6 +105,11 @@ if ($nn != 1) {
   print "mps_script.pl: no (unambiguous) MSSDIR directive found in runscript\n";
 }
 $nn = ($body =~ s/MSSDIR=(.+)$/MSSDIR=$mssDirLocal/m);
+
+#replace MP2LOC setting 
+if ($mp2dir ne "undefined") {
+  $nn = ($body =~ s/MP2LOC=(.+)$/MP2LOC=$mp2dir/m);
+} 
 
 if ($castorPool ne "undefined") {
 # replace MSSDIRPOOL setting...

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_script.pl
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_script.pl
@@ -28,6 +28,7 @@ $mssDirLocal = "undefined"; # not to confuse with mssDir from 'mpslib'.
 $castorPool = "undefined";
 $cmsCafPool = 0;
 $mp2dir = "undefined";
+$extraSetup = "undefined";
 
 # parse the arguments
 while (@ARGV) {
@@ -73,6 +74,9 @@ while (@ARGV) {
     elsif ($i eq 9) {
       $mp2dir = $arg;
     }
+    elsif ($i eq 10) {
+      $extraSetup = $arg;
+    }
   }
 }
 
@@ -109,6 +113,12 @@ $nn = ($body =~ s/MSSDIR=(.+)$/MSSDIR=$mssDirLocal/m);
 #replace MP2LOC setting 
 if ($mp2dir ne "undefined") {
   $nn = ($body =~ s/MP2LOC=(.+)$/MP2LOC=$mp2dir/m);
+} 
+
+#replace EXTRASETUP setting 
+if ($extraSetup ne "undefined") {
+  print "mps_script.pl: extraSetup is: '$extraSetup'\n";
+  $nn = ($body =~ s/EXTRASETUP=(.+)$/EXTRASETUP=$extraSetup/m);
 } 
 
 if ($castorPool ne "undefined") {

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_scriptm.pl
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_scriptm.pl
@@ -80,9 +80,7 @@ if ($cfgName eq "undefined") {
   exit 1;
 }
 
-if ($checkok == 1) {
-  read_db();
-}
+read_db();
 
 # open the input file
 open INFILE,"$inScript";
@@ -122,22 +120,28 @@ if ($castorPool ne "undefined") {
 #... or empty the field.
   $nn = ($body =~ s/MSSDIRPOOL=(.*)$/MSSDIRPOOL=/m);
 }
-
+#replace MP2LOC setting 
+if ($mp2loc ne "") {
+  $nn = ($body =~ s/MP2LOC=(.+)$/MP2LOC=$mp2loc/m);
+} 
 # now we have to expand lines that contain the ISN directive
 @LINES = split "\n",$body;
 
 foreach $theLine (@LINES) {
   if ($theLine =~ m/ISN/) {
-    $newBlock = "";
-    for ($i = 1; $i <= $nJobs; ++$i) {
+    $newBlock = "";    
+    # only duplicate these lines if not directly loading files with xrootd
+    if (not $rootIO){
+      for ($i = 1; $i <= $nJobs; ++$i) {
 
-      if ($checkok==1 && @JOBSTATUS[$i-1] ne "OK") {next;}
+        if ($checkok==1 && @JOBSTATUS[$i-1] ne "OK") {next;}
 
-      $newLine = $theLine;
-      $isnRep = sprintf "%03d",$i;
-      $newLine =~ s/ISN/$isnRep/g;
-      if ($i != 1) { $newBlock = $newBlock . "\n"; }
-      $newBlock = $newBlock . $newLine;
+        $newLine = $theLine;
+        $isnRep = sprintf "%03d",$i;
+        $newLine =~ s/ISN/$isnRep/g;
+        if ($i != 1) { $newBlock = $newBlock . "\n"; }
+        $newBlock = $newBlock . $newLine;
+      }
     }
     $theLine = $newBlock;
   } 

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_scriptm.pl
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_scriptm.pl
@@ -124,6 +124,10 @@ if ($castorPool ne "undefined") {
 if ($mp2loc ne "") {
   $nn = ($body =~ s/MP2LOC=(.+)$/MP2LOC=$mp2loc/m);
 } 
+#replace EXTRASETUP setting
+if ($extraSetup ne "") {
+  $nn = ($body =~ s/EXTRASETUP=(.+)$/EXTRASETUP=$extraSetup/m);
+} 
 # now we have to expand lines that contain the ISN directive
 @LINES = split "\n",$body;
 

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_setup.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_setup.py
@@ -26,7 +26,10 @@ parser.add_argument("-w", "--weight", type = float,
                     help = "assign statistical weight")
 parser.add_argument("-e", "--max-events", dest = "max_events", type = int,
                     help = "maximum number of events to process")
-
+parser.add_argument("-r", "--rootIO", dest="rootIO",action="store_true",default=False,
+                    help="Enable ROOT-based I/O")
+parser.add_argument("--mp2loc", dest="mp2loc",type=str,default="",
+                    help="Set a custom Millepede-II installation location")
 parser.add_argument("batch_script",
                     help = "path to the mille batch script template")
 parser.add_argument("config_template",
@@ -65,6 +68,8 @@ lib.mergeScript = args.merge_script
 lib.mssDirPool = ""
 lib.mssDir = args.mss_dir
 lib.pedeMem = args.memory
+lib.rootIO = "True" if args.rootIO else ""
+lib.mp2loc = args.mp2loc
 
 
 if not os.access(args.batch_script, os.R_OK):
@@ -185,6 +190,7 @@ if args.append:
     tmpClass       = lib.classInf
     tmpMergeScript = lib.mergeScript
     tmpDriver      = lib.driver
+    tmpRoot        = lib.rootIO
 
     # Read DB file
     lib.read_db()
@@ -213,6 +219,7 @@ if args.append:
     lib.classInf    = tmpClass
     lib.mergeScript = tmpMergeScript
     lib.driver      = tmpDriver
+    lib.rootIO      = tmpRoot
 
 
 # Create (update) the local database
@@ -270,7 +277,7 @@ for j in range(1, args.n_jobs + 1):
                            "jobData/{}/theScript.sh".format(jobdir),
                            os.path.join(theJobData, jobdir), "the.py",
                            "jobData/{}/theSplit".format(jobdir), theIsn,
-                           args.mss_dir, lib.mssDirPool])
+                           args.mss_dir, lib.mssDirPool, lib.mp2loc])
 
 
 # create the merge job entry. This is always done. Whether it is used depends on the "merge" option.

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_setup.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_setup.py
@@ -30,6 +30,8 @@ parser.add_argument("-r", "--rootIO", dest="rootIO",action="store_true",default=
                     help="Enable ROOT-based I/O")
 parser.add_argument("--mp2loc", dest="mp2loc",type=str,default="",
                     help="Set a custom Millepede-II installation location")
+parser.add_argument("--extraSetup", dest="extraSetup",type=str,default="",
+                    help="Set a custom script for additional environment setup")
 parser.add_argument("batch_script",
                     help = "path to the mille batch script template")
 parser.add_argument("config_template",
@@ -70,6 +72,7 @@ lib.mssDir = args.mss_dir
 lib.pedeMem = args.memory
 lib.rootIO = "True" if args.rootIO else ""
 lib.mp2loc = args.mp2loc
+lib.extraSetup = args.extraSetup
 
 
 if not os.access(args.batch_script, os.R_OK):
@@ -191,6 +194,8 @@ if args.append:
     tmpMergeScript = lib.mergeScript
     tmpDriver      = lib.driver
     tmpRoot        = lib.rootIO
+    tmpMp2loc      = lib.mp2loc
+    tmpExtraSetup  = lib.extraSetup
 
     # Read DB file
     lib.read_db()
@@ -220,6 +225,8 @@ if args.append:
     lib.mergeScript = tmpMergeScript
     lib.driver      = tmpDriver
     lib.rootIO      = tmpRoot
+    lib.mp2loc      = tmpMp2loc
+    lib.extraSetup  = tmpExtraSetup
 
 
 # Create (update) the local database
@@ -272,12 +279,12 @@ for j in range(1, args.n_jobs + 1):
 
 
     # create the run script
-    print("mps_script.pl {}  jobData/{}/theScript.sh {}/{} the.py jobData/{}/theSplit {} {} {}".format(args.batch_script, jobdir, theJobData, jobdir, jobdir, theIsn, args.mss_dir, lib.mssDirPool))
+    print("mps_script.pl {}  jobData/{}/theScript.sh {}/{} the.py jobData/{}/theSplit {} {} {} {} {}".format(args.batch_script, jobdir, theJobData, jobdir, jobdir, theIsn, args.mss_dir, lib.mssDirPool, lib.mp2loc, lib.extraSetup))
     mps_tools.run_checked(["mps_script.pl", args.batch_script,
                            "jobData/{}/theScript.sh".format(jobdir),
                            os.path.join(theJobData, jobdir), "the.py",
                            "jobData/{}/theSplit".format(jobdir), theIsn,
-                           args.mss_dir, lib.mssDirPool, lib.mp2loc])
+                           args.mss_dir, lib.mssDirPool, lib.mp2loc, lib.extraSetup])
 
 
 # create the merge job entry. This is always done. Whether it is used depends on the "merge" option.

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_setupm.pl
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_setupm.pl
@@ -125,8 +125,8 @@ my $tmpc = "";
 $tmpc = " -c" if($onlyactivejobs == 1);
 
 # create merge job script
-print "mps_scriptm.pl${tmpc} $mergeScript jobData/$theJobDir/theScript.sh $theJobData/$theJobDir alignment_merge.py $nJobs $mssDir $mssDirPool\n";
-system "mps_scriptm.pl${tmpc} $mergeScript jobData/$theJobDir/theScript.sh $theJobData/$theJobDir alignment_merge.py $nJobs $mssDir $mssDirPool";
+print "mps_scriptm.pl${tmpc} $mergeScript jobData/$theJobDir/theScript.sh $theJobData/$theJobDir alignment_merge.py $nJobs $mssDir $mssDirPool $mp2loc\n";
+system "mps_scriptm.pl${tmpc} $mergeScript jobData/$theJobDir/theScript.sh $theJobData/$theJobDir alignment_merge.py $nJobs $mssDir $mssDirPool $mp2loc";
 
 # Write to DB
 write_db();

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mpslib/Mpslib.pm
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mpslib/Mpslib.pm
@@ -23,7 +23,7 @@ package Mpslib;  # assumes Some/Module.pm
 #  $pedeMem - Memory allocated for pede
 #  $rootIO  - use ROOT I/O
 #  $mp2loc  - custom location of Millepede-II installation
-#  $spare3
+#  $extraSetup      - additional commands to run for setting up runtime environment
 #
 # (2) Job-level variables
 #  
@@ -54,7 +54,7 @@ package Mpslib;  # assumes Some/Module.pm
 		    @JOBID
 		    $header 
 		    $batchScript $cfgTemplate $infiList $class $addFiles $driver $nJobs
-                    $mergeScript $mssDir $updateTime $updateTimeHuman $elapsedTime $mssDirPool $pedeMem $rootIO $mp2loc $spare3
+                    $mergeScript $mssDir $updateTime $updateTimeHuman $elapsedTime $mssDirPool $pedeMem $rootIO $mp2loc $extraSetup
 		    @JOBDIR 
 		    @JOBSTATUS @JOBNTRY @JOBRUNTIME @JOBNEVT @JOBHOST @JOBINCR @JOBREMARK @JOBSP1 @JOBSP2 @JOBSP3
                    );
@@ -70,7 +70,6 @@ sub write_db() {
   $updateTime = $currentTime;
   $updateTimeHuman = `date`;
   chomp $updateTimeHuman;
-  $spare3 = "-- unused --";
 
   system "[[ -a mps.db ]] && cp -p mps.db mps.db~"; # GF: backup if exists (in case of interupt during write)
   open DBFILE,">mps.db";
@@ -90,7 +89,7 @@ sub write_db() {
   printf DBFILE "%d\n",$pedeMem;
   printf DBFILE "%s\n",$rootIO;
   printf DBFILE "%s\n",$mp2loc;
-  printf DBFILE "%s\n",$spare3;
+  printf DBFILE "%s\n",$extraSetup;
   my $i;
   for ($i = 0; $i < @JOBID; ++$i) {
     printf DBFILE "%03d:%s:%s:%s:%d:%d:%d:%s:%d:%s:%s:%s:%s\n",
@@ -131,7 +130,7 @@ sub read_db() {
   $pedeMem = <DBFILE>;
   $rootIO = <DBFILE>;
   $mp2loc = <DBFILE>;
-  $spare3 = <DBFILE>;
+  $extraSetup = <DBFILE>;
   chomp $header;
   chomp $batchScript;
   chomp $cfgTemplate;
@@ -148,7 +147,7 @@ sub read_db() {
   chomp $pedeMem;
   chomp $rootIO;
   chomp $mp2loc;
-  chomp $spare3;
+  chomp $extraSetup;
 
   my $nMilleJobs = 0;
   $nJobs = 0; 
@@ -172,8 +171,8 @@ sub read_db() {
 sub print_memdb() {
   print "=== mps database printout ===\n";
   print "$header\n";
-  printf "Script: %s\ncfg: %s\nfiles: %s\nclass: %s\nname: %s\ndriver: %s\nmergeScript: %s\nmssDir: %s\nupdateTime: %s\nelapsed: %d\nmssDirPool: %s\npedeMem: %d\nrootIO: %s\nmp2loc: %ds\n",$batchScript,
-  $cfgTemplate,$infiList,$class,$addFiles,$driver,$mergeScript,$mssDir,$updateTimeHuman,$elapsedTime,$mssDirPool,$pedeMem,$rootIO,$mp2loc;
+  printf "Script: %s\ncfg: %s\nfiles: %s\nclass: %s\nname: %s\ndriver: %s\nmergeScript: %s\nmssDir: %s\nupdateTime: %s\nelapsed: %d\nmssDirPool: %s\npedeMem: %d\nrootIO: %s\nmp2loc: %s\nextraSetup: %s\n",$batchScript,
+  $cfgTemplate,$infiList,$class,$addFiles,$driver,$mergeScript,$mssDir,$updateTimeHuman,$elapsedTime,$mssDirPool,$pedeMem,$rootIO,$mp2loc,$extraSetup;
   printf "%3s %6s %9s %6s %3s %5s %8s %6s %8s %s\n",
   '###',"dir","jobid","stat","try","rtime","nevt","t/evt","remark","name";
   my $i;

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mpslib/Mpslib.pm
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mpslib/Mpslib.pm
@@ -21,8 +21,8 @@ package Mpslib;  # assumes Some/Module.pm
 #  $elapsedTime - seconds since last update
 #  $mssDirPool - pool for $mssDir (e.g. cmscaf/cmscafuser)
 #  $pedeMem - Memory allocated for pede
-#  $spare1
-#  $spare2
+#  $rootIO  - use ROOT I/O
+#  $mp2loc  - custom location of Millepede-II installation
 #  $spare3
 #
 # (2) Job-level variables
@@ -54,7 +54,7 @@ package Mpslib;  # assumes Some/Module.pm
 		    @JOBID
 		    $header 
 		    $batchScript $cfgTemplate $infiList $class $addFiles $driver $nJobs
-                    $mergeScript $mssDir $updateTime $updateTimeHuman $elapsedTime $mssDirPool $pedeMem $spare1 $spare2 $spare3
+                    $mergeScript $mssDir $updateTime $updateTimeHuman $elapsedTime $mssDirPool $pedeMem $rootIO $mp2loc $spare3
 		    @JOBDIR 
 		    @JOBSTATUS @JOBNTRY @JOBRUNTIME @JOBNEVT @JOBHOST @JOBINCR @JOBREMARK @JOBSP1 @JOBSP2 @JOBSP3
                    );
@@ -70,8 +70,6 @@ sub write_db() {
   $updateTime = $currentTime;
   $updateTimeHuman = `date`;
   chomp $updateTimeHuman;
-  $spare1 = "-- unused --";
-  $spare2 = "-- unused --";
   $spare3 = "-- unused --";
 
   system "[[ -a mps.db ]] && cp -p mps.db mps.db~"; # GF: backup if exists (in case of interupt during write)
@@ -90,8 +88,8 @@ sub write_db() {
   printf DBFILE "%d\n",$elapsedTime;
   printf DBFILE "%s\n",$mssDirPool;
   printf DBFILE "%d\n",$pedeMem;
-  printf DBFILE "%s\n",$spare1;
-  printf DBFILE "%s\n",$spare2;
+  printf DBFILE "%s\n",$rootIO;
+  printf DBFILE "%s\n",$mp2loc;
   printf DBFILE "%s\n",$spare3;
   my $i;
   for ($i = 0; $i < @JOBID; ++$i) {
@@ -131,8 +129,8 @@ sub read_db() {
   $elapsedTime = <DBFILE>;
   $mssDirPool = <DBFILE>;
   $pedeMem = <DBFILE>;
-  $spare1 = <DBFILE>;
-  $spare2 = <DBFILE>;
+  $rootIO = <DBFILE>;
+  $mp2loc = <DBFILE>;
   $spare3 = <DBFILE>;
   chomp $header;
   chomp $batchScript;
@@ -148,8 +146,8 @@ sub read_db() {
   chomp $elapsedTime;
   chomp $mssDirPool;
   chomp $pedeMem;
-  chomp $spare1;
-  chomp $spare2;
+  chomp $rootIO;
+  chomp $mp2loc;
   chomp $spare3;
 
   my $nMilleJobs = 0;
@@ -174,8 +172,8 @@ sub read_db() {
 sub print_memdb() {
   print "=== mps database printout ===\n";
   print "$header\n";
-  printf "Script: %s\ncfg: %s\nfiles: %s\nclass: %s\nname: %s\ndriver: %s\nmergeScript: %s\nmssDir: %s\nupdateTime: %s\nelapsed: %d\nmssDirPool: %s\npedeMem: %d\n",$batchScript,
-  $cfgTemplate,$infiList,$class,$addFiles,$driver,$mergeScript,$mssDir,$updateTimeHuman,$elapsedTime,$mssDirPool,$pedeMem;
+  printf "Script: %s\ncfg: %s\nfiles: %s\nclass: %s\nname: %s\ndriver: %s\nmergeScript: %s\nmssDir: %s\nupdateTime: %s\nelapsed: %d\nmssDirPool: %s\npedeMem: %d\nrootIO: %s\nmp2loc: %ds\n",$batchScript,
+  $cfgTemplate,$infiList,$class,$addFiles,$driver,$mergeScript,$mssDir,$updateTimeHuman,$elapsedTime,$mssDirPool,$pedeMem,$rootIO,$mp2loc;
   printf "%3s %6s %9s %6s %3s %5s %8s %6s %8s %s\n",
   '###',"dir","jobid","stat","try","rtime","nevt","t/evt","remark","name";
   my $i;

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.cc
@@ -768,13 +768,13 @@ std::string PedeSteerer::buildMasterSteer(const std::vector<std::string> &binary
   }
 
   // add binary files to master steering file
-  std::vector<std::string> rootFiles = {}; 
+  std::vector<std::string> rootFiles = {};
   mainSteerRef << "\nCfiles\n";
   for (unsigned int iFile = 0; iFile < binaryFiles.size(); ++iFile) {
     // if we find a ROOT file, we remember it for later (separate config block)
-    if (binaryFiles[iFile].find(".root") != std::string::npos){
+    if (binaryFiles[iFile].find(".root") != std::string::npos) {
       rootFiles.push_back(binaryFiles[iFile]);
-      continue; 
+      continue;
     }
     if (myRunDirectory.empty())
       mainSteerRef << binaryFiles[iFile] << "\n";
@@ -782,10 +782,10 @@ std::string PedeSteerer::buildMasterSteer(const std::vector<std::string> &binary
       mainSteerRef << "../" + binaryFiles[iFile] << "\n";
   }
   // now add ROOT binaries if we have any (safe to mix with C-binaries)
-  if (!rootFiles.empty()){
+  if (!rootFiles.empty()) {
     mainSteerRef << "\nrootfiles\n";
-    for (const std::string & rootFile : rootFiles ) {
-        mainSteerRef << rootFile << "\n";
+    for (const std::string &rootFile : rootFiles) {
+      mainSteerRef << rootFile << "\n";
     }
   }
 
@@ -832,21 +832,20 @@ int PedeSteerer::runPede(const std::string &masterSteer) const {
 
   edm::LogInfo("Alignment") << "@SUB=PedeSteerer::runPede"
                             << "Start running " << command;
-  // FIXME: Recommended interface to system commands?  
-  int shellReturn = 99; 
+  // FIXME: Recommended interface to system commands?
+  int shellReturn = 99;
   (void)gSystem->Exec(command.c_str());
-  // Pede as a fortran binary does not return an exit code. 
-  // Instead, we get a millepede.end file with a single 
-  // integer entry denoting the exit status. Pick this up here. 
-  std::ifstream mpend ("millepede.end"); 
-  // catch catastrophic failures where we do not get a status. 
+  // Pede as a fortran binary does not return an exit code.
+  // Instead, we get a millepede.end file with a single
+  // integer entry denoting the exit status. Pick this up here.
+  std::ifstream mpend("millepede.end");
+  // catch catastrophic failures where we do not get a status.
   if (!mpend.is_open()) {
-      edm::LogInfo("Alignment") << "@SUB=PedeSteerer::runPede" 
-                                << "Failed to read Pede command return"; 
-  }
-  else {
-    mpend >> shellReturn; 
-    mpend.close(); 
+    edm::LogInfo("Alignment") << "@SUB=PedeSteerer::runPede"
+                              << "Failed to read Pede command return";
+  } else {
+    mpend >> shellReturn;
+    mpend.close();
   }
   edm::LogInfo("Alignment") << "@SUB=PedeSteerer::runPede"
                             << "Command returns " << shellReturn;

--- a/Alignment/MillePedeAlignmentAlgorithm/templates/alignment_config.ini
+++ b/Alignment/MillePedeAlignmentAlgorithm/templates/alignment_config.ini
@@ -50,6 +50,10 @@
 ;# millepedeLocation:   Specify the path to the install directory of a local 
 ;#                      Millepede-II installation to use (overrides the release). 
 ;#                      This variable is optional. 
+;# 
+;# extraSetup:          Specify a quoted command to run for additional environment setup.  
+;#                      For example, you can use this to set up MKL. 
+;#                      This variable is optional. 
 
 
 [general]

--- a/Alignment/MillePedeAlignmentAlgorithm/templates/alignment_config.ini
+++ b/Alignment/MillePedeAlignmentAlgorithm/templates/alignment_config.ini
@@ -43,6 +43,13 @@
 ;# pedesettings: Specify a comma-separated list of files which contain different
 ;#               pede settings that are appended to the config.
 ;# This variable is optional.
+;# useRootIO:         If specified, makes Pede use xrootd-based network I/O rather 
+;#                    than copying files to the local node. 
+;#                    This variable is optional. 
+;#
+;# millepedeLocation:   Specify the path to the install directory of a local 
+;#                      Millepede-II installation to use (overrides the release). 
+;#                      This variable is optional. 
 
 
 [general]

--- a/Alignment/MillePedeAlignmentAlgorithm/templates/mps_runMille_template.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/templates/mps_runMille_template.sh
@@ -119,8 +119,10 @@ then
     source ${MP2LOC}/mp2setup.sh
 fi 
 
-# convert to ROOT 
-cToRoot milleBinaryISN.root milleBinaryISN.dat 
+# convert to ROOT if we have cToROOT
+if which cToRoot 2>/dev/null
+then cToRoot milleBinaryISN.root milleBinaryISN.dat  
+fi 
 
 
 gzip -f *.log
@@ -177,7 +179,11 @@ else
   # copy the files
   echo "xrdcp -f milleBinaryISN.dat.gz ${MSSCAFDIR}/binaries/milleBinaryISN.dat.gz > /dev/null"
   untilSuccess xrdcp milleBinaryISN.dat.gz    ${MSSCAFDIR}/binaries/milleBinaryISN.dat.gz  1
-  untilSuccess xrdcp milleBinaryISN.root      ${MSSCAFDIR}/binaries/milleBinaryISN.root  1
+  # copy over ROOT binary if present
+  if [[ -e milleBinaryISN.root ]] 
+  then 
+    untilSuccess xrdcp milleBinaryISN.root      ${MSSCAFDIR}/binaries/milleBinaryISN.root  1
+  fi 
   untilSuccess xrdcp treeFile.root            ${MSSCAFDIR}/tree_files/treeFileISN.root 1
   untilSuccess xrdcp millePedeMonitorISN.root ${MSSCAFDIR}/monitors/millePedeMonitorISN.root 1
 fi

--- a/Alignment/MillePedeAlignmentAlgorithm/templates/mps_runMille_template.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/templates/mps_runMille_template.sh
@@ -12,6 +12,8 @@ MSSDIR=/castor/cern.ch/user/u/username/another/path
 MSSDIRPOOL=
 # Custom MP-II install - will be potentially overwritten by steering 
 MP2LOC=""
+# Extra setup script - will be potentially overwritten by steering 
+EXTRASETUP=""   
 
 clean_up () {
 #try to recover log files and root files
@@ -117,6 +119,13 @@ if [[ ! -z "${MP2LOC}" ]]
 then 
     echo -e "Using custom Millepede-II installation from\n        ${MP2LOC}"
     source ${MP2LOC}/mp2setup.sh
+fi 
+
+# extra setup if required
+if [[ ! -z "${EXTRASETUP}" ]]
+then 
+    echo -e "Running extra environment setup:\n        ${EXTRASETUP}"
+    eval ${EXTRASETUP}
 fi 
 
 # convert to ROOT if we have cToROOT

--- a/Alignment/MillePedeAlignmentAlgorithm/templates/mps_runMille_template.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/templates/mps_runMille_template.sh
@@ -10,6 +10,8 @@
 RUNDIR=$HOME/scratch0/some/path
 MSSDIR=/castor/cern.ch/user/u/username/another/path
 MSSDIRPOOL=
+# Custom MP-II install - will be potentially overwritten by steering 
+MP2LOC=""
 
 clean_up () {
 #try to recover log files and root files
@@ -106,6 +108,21 @@ echo The running directory is $(pwd).
 # Execute. The cfg file name will be overwritten by MPS
 time cmsRun the.cfg
 
+# setup custom MP-II installation if specified
+# For now, do it *after* cmsRun, as we would otherwise
+# override the CMSSW custom Mille version.
+# FIXME: Unify Mille implementations and use external one
+# in CMSSW
+if [[ ! -z "${MP2LOC}" ]] 
+then 
+    echo -e "Using custom Millepede-II installation from\n        ${MP2LOC}"
+    source ${MP2LOC}/mp2setup.sh
+fi 
+
+# convert to ROOT 
+cToRoot milleBinaryISN.root milleBinaryISN.dat 
+
+
 gzip -f *.log
 gzip milleBinaryISN.dat
 echo "\nDirectory content after running cmsRun and zipping log+dat files:"
@@ -160,6 +177,7 @@ else
   # copy the files
   echo "xrdcp -f milleBinaryISN.dat.gz ${MSSCAFDIR}/binaries/milleBinaryISN.dat.gz > /dev/null"
   untilSuccess xrdcp milleBinaryISN.dat.gz    ${MSSCAFDIR}/binaries/milleBinaryISN.dat.gz  1
+  untilSuccess xrdcp milleBinaryISN.root      ${MSSCAFDIR}/binaries/milleBinaryISN.root  1
   untilSuccess xrdcp treeFile.root            ${MSSCAFDIR}/tree_files/treeFileISN.root 1
   untilSuccess xrdcp millePedeMonitorISN.root ${MSSCAFDIR}/monitors/millePedeMonitorISN.root 1
 fi

--- a/Alignment/MillePedeAlignmentAlgorithm/templates/mps_runPede_rfcp_template.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/templates/mps_runPede_rfcp_template.sh
@@ -10,6 +10,8 @@ echo -e "Running at $(date) \n        on ${HOSTNAME} \n        in directory ${BA
 
 # Custom MP-II install - will be potentially overwritten by steering 
 MP2LOC=""   
+# Extra setup script - will be potentially overwritten by steering 
+EXTRASETUP=""   
 
 # in singularity containers, source baseline setup script
 if [[ ! -z "${SINGULARITY_NAME}" ]] 
@@ -27,6 +29,13 @@ if [[ ! -z "${MP2LOC}" ]]
 then 
     echo -e "Using custom Millepede-II installation from\n        ${MP2LOC}"
     source ${MP2LOC}/mp2setup.sh
+fi 
+
+# extra setup if required
+if [[ ! -z "${EXTRASETUP}" ]]
+then 
+    echo -e "Running extra environment setup:\n        ${EXTRASETUP}"
+    eval ${EXTRASETUP}
 fi 
 
 

--- a/Alignment/MillePedeAlignmentAlgorithm/templates/mps_runPede_rfcp_template.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/templates/mps_runPede_rfcp_template.sh
@@ -8,6 +8,9 @@
 BATCH_DIR=$(pwd)
 echo -e "Running at $(date) \n        on ${HOSTNAME} \n        in directory ${BATCH_DIR}."
 
+# Custom MP-II install - will be potentially overwritten by steering 
+MP2LOC=""   
+
 # in singularity containers, source baseline setup script
 if [[ ! -z "${SINGULARITY_NAME}" ]] 
 then 
@@ -18,6 +21,14 @@ fi
 cd CMSSW_RELEASE_AREA
 eval `scram runtime -sh`
 hash -r
+
+# setup custom MP-II installation if specified
+if [[ ! -z "${MP2LOC}" ]] 
+then 
+    echo -e "Using custom Millepede-II installation from\n        ${MP2LOC}"
+    source ${MP2LOC}/mp2setup.sh
+fi 
+
 
 cd ${BATCH_DIR}
 echo Running directory changed to $(pwd).

--- a/Alignment/MillePedeAlignmentAlgorithm/templates/universalConfigTemplate.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/templates/universalConfigTemplate.py
@@ -324,3 +324,19 @@ else:
                binary_files = merge_binary_files,
                tree_files = merge_tree_files,
                run_start_geometry = setupRunStartGeometry)
+
+
+################################################################################
+## Uncomment the following if the jobs fail with ROOT-related exceptions
+## (FileReadError - fCurrentClusterStart=X  fEntryCurrent=Y fNextClusterStart=Z 
+## but fEntryCurrent should not be in between the two) - https://github.com/cms-sw/cmssw/issues/49398 
+# # 
+# # to disable the cache
+# process.source.cacheSize = cms.untracked.uint32(0)
+# # download and cache the file locally to prevent a storm of singular reads to EOS
+# process.add_(cms.Service("SiteLocalConfigService",
+#                             overrideSourceCacheHintDir = cms.untracked.string("lazy-download")
+#                             ))
+
+# ------------------------------------------------------------------------------
+


### PR DESCRIPTION
#### PR description:

This PR enables optional support for ROOT-based Millepede binaries in alignment jobs.
Requires an up-to-date (V04-19-00 or later) Millepede-II installation, and deactivated by default. 
- The new binaries can be enabled by specifying the keyword `useRootIO` in the `alignment_config.ini`, with any value. 
If enabled, ROOT binaries and tree files will be read directly from EOS using xrootd, and no files will be locally staged to the `pede` runner node. This allows to avoid disk quota limitations. 
- The PR also adds a second new option to the `alignment_config` - `millepedeLocation` allows to specify a custom Millepede-II installation to use. This removes the need to copy locally modified run scripts / configs to use the MKL-capable local Millepede on the CAF. 
- A third option, `extraSetup`, allows to specify any additional required environment setup commands as a quoted string. This is intended for steps such as setting up intel MKL via cvmfs, which is currently done by manually adjusting the configs. 

Changes leave output fully invariant, regardless of the `useRootIO` setting.  

#### PR validation:

- Tested running an alignment campaign with the modified code and the "new" V04-19 series Millepede - standard binaires
- Tested running an alignment campaign with the modified code and the "new" V04-19 series Millepede - ROOT binaires with xrootd I/O 
- Testing running an alignment campaign with the modified code and the "old" V04-16 series Millepede (only supports standard binaries)

Identical outputs, residuals, and fit metrics in all cases, and all three match the result obtained in the original campaign with production CMSSW and V04-16 Millepede. 

Ongoing test:
- Large campaign with long run-time to quantify performance impact

MR marked as `Draft` until the final test finishes. In case of success, no further code changes foreseen.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport is foreseen to be needed. 

Before submitting your pull requests, make sure you followed this checklist :heavy_check_mark: 

