### PR TITLE
Define dictionaries for `X::Layout` type aliases in `DataFormats/EcalDigi`

### DIFF
--- a/DataFormats/EcalDigi/src/classes_def.xml
+++ b/DataFormats/EcalDigi/src/classes_def.xml
@@ -148,6 +148,8 @@
    <class name="edm::Wrapper<edm::SortedCollection<EcalMatacqDigi,edm::StrictWeakOrdering<EcalMatacqDigi> > >" id="09B54EAE-7A1A-B892-117A-EFE5E32AF982"/>
 
    <class name="EcalDataArray"/>
+   <!-- ::Layout alias must be listed before the aliased-to type -->
+   <class name="EcalDigiHostCollection::Layout"/>
    <class name="EcalDigiSoA"/>
    <class name="EcalDigiSoA::View"/>
    <class name="EcalDigiHostCollection" ClassVersion="3">
@@ -156,6 +158,8 @@
    <class name="edm::Wrapper<EcalDigiHostCollection>" splitLevel="0"/>
 
    <class name="EcalDataArrayPhase2"/>
+   <!-- ::Layout alias must be listed before the aliased-to type -->
+   <class name="EcalDigiPhase2HostCollection::Layout"/>
    <class name="EcalDigiPhase2SoA"/>
    <class name="EcalDigiPhase2SoA::View"/>
    <class name="EcalDigiPhase2HostCollection" ClassVersion="3">


### PR DESCRIPTION
#### PR description:

In response to https://github.com/cms-sw/cmssw/issues/49568, follows the same spirit as https://github.com/cms-sw/cmssw/pull/49473, taking https://github.com/cms-sw/cmssw/issues/49568#issuecomment-3632877546.
Visual inspection of the `classes_def.xml` file showed that the `X::Layout` type alias has not been specified, while the read rule explicitly uses the `X::Layout` in a string form, and therefore a dictionary has to be specified in order to avoid header parsing. This PR adds entries for the `X::Layout` type aliases.

#### PR validation:

`cmssw` compiles.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, no backport needed.