### PR TITLE
MTD validation: optional plots for entry angle in ETL

### DIFF
--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -372,6 +372,8 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       (simHitIt->second).x = hit_pos.x();
       (simHitIt->second).y = hit_pos.y();
       (simHitIt->second).z = hit_pos.z();
+
+      (simHitIt->second).thetaAtEntry = simHit.thetaAtEntry();
     }
 
   }  // simHit loop

--- a/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
@@ -199,6 +199,8 @@ void BtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
       m_btlHitsPerCellAndModule[geoId.rawId()][id.rawId()][globalTrkID].x = hit_pos.x();
       m_btlHitsPerCellAndModule[geoId.rawId()][id.rawId()][globalTrkID].y = hit_pos.y();
       m_btlHitsPerCellAndModule[geoId.rawId()][id.rawId()][globalTrkID].z = hit_pos.z();
+
+      m_btlHitsPerCellAndModule[geoId.rawId()][id.rawId()][globalTrkID].thetaAtEntry = simHit.thetaAtEntry();
     }
 
   }  // simHit loop

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -263,6 +263,8 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       (simHitIt->second).x = hit_pos.x();
       (simHitIt->second).y = hit_pos.y();
       (simHitIt->second).z = hit_pos.z();
+
+      (simHitIt->second).thetaAtEntry = simHit.thetaAtEntry();
     }
 
   }  // simHit loop

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -183,6 +183,9 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
       if (simHit.offsetTrackId() == 0) {
         (simHitIt->second).thetaAtEntry =
             angle_units::operators::convertRadToDeg((simHit.exitPoint() - simHit.entryPoint()).bareTheta());
+        if (id.discSide() == 1) {
+          (simHitIt->second).thetaAtEntry = 180. - (simHitIt->second).thetaAtEntry;
+        }
       } else {
         (simHitIt->second).thetaAtEntry = -90.;
       }

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -181,10 +181,12 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
       (simHitIt->second).z = hit_pos.z();
 
       if (simHit.offsetTrackId() == 0) {
-        (simHitIt->second).thetaAtEntry =
-            angle_units::operators::convertRadToDeg((simHit.exitPoint() - simHit.entryPoint()).bareTheta());
-        if (id.discSide() == 1) {
-          (simHitIt->second).thetaAtEntry = 180. - (simHitIt->second).thetaAtEntry;
+        if (simHit.exitPoint() != simHit.entryPoint()) {
+          (simHitIt->second).thetaAtEntry =
+              angle_units::operators::convertRadToDeg((simHit.exitPoint() - simHit.entryPoint()).bareTheta());
+          if (id.discSide() == 1) {
+            (simHitIt->second).thetaAtEntry = 180. - (simHitIt->second).thetaAtEntry;
+          }
         }
       } else {
         (simHitIt->second).thetaAtEntry = -90.;

--- a/Validation/MtdValidation/plugins/MTDHit.h
+++ b/Validation/MtdValidation/plugins/MTDHit.h
@@ -7,6 +7,7 @@ struct MTDHit {
   float x;
   float y;
   float z;
+  float thetaAtEntry;
 };
 
 #endif  //Validation_MtdValidation_MTDHit_h

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -554,10 +554,6 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   auto btlRecCluHandle = makeValid(iEvent.getHandle(btlRecCluToken_));
   auto etlRecCluHandle = makeValid(iEvent.getHandle(etlRecCluToken_));
 
-  std::unordered_map<uint32_t, MTDHit> m_btlHits;
-  std::unordered_map<uint32_t, MTDHit> m_etlHits;
-  std::unordered_map<uint32_t, std::set<unsigned long int>> m_btlTrkPerCell;
-  std::unordered_map<uint32_t, std::set<unsigned long int>> m_etlTrkPerCell;
   const auto& tp2SimAssociationMap = iEvent.get(tp2SimAssociationMapToken_);
   const auto& Sim2tpAssociationMap = iEvent.get(Sim2tpAssociationMapToken_);
   const auto& r2sAssociationMap = iEvent.get(r2sAssociationMapToken_);


### PR DESCRIPTION
#### PR description:

This PR fills a set of optional validation plots for ETL Sim Hits, showing the entry angle of particles from the front of ETL. This is useful to support realistic test beam studies. Entry and exit point coordinates for charged particles in MtdSD are used, as the entry angle stored in TimingS is essentially useless so far, see https://cms-talk.web.cern.ch/t/definition-of-psimhit-direction-at-entry-for-timingsd/139703 .

#### PR validation:

When the ```optionalPlots``` flag is activated, plots are correctly filled, e.g.:
[D1_eta1.pdf](https://github.com/user-attachments/files/24072078/D1_eta1.pdf)

