### PR TITLE
[L1T] DT Trigger Phase-2 Analytical Method (AM) v2.3

### DIFF
--- a/DataFormats/L1DTTrackFinder/BuildFile.xml
+++ b/DataFormats/L1DTTrackFinder/BuildFile.xml
@@ -2,4 +2,5 @@
 <use name="DataFormats/L1GlobalMuonTrigger"/>
 <export>
   <lib name="1"/>
+  <lib name="DataFormatsL1DTTrackFinder"/>
 </export>

--- a/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhDigi.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhDigi.h
@@ -56,7 +56,7 @@ public:
                         int tdc[8] = nullptr,
                         int lat[8] = nullptr);
 
-  L1Phase2MuDTExtPhDigi(const L1Phase2MuDTExtPhDigi &digi);
+  L1Phase2MuDTExtPhDigi(const L1Phase2MuDTExtPhDigi& digi);
   L1Phase2MuDTExtPhDigi& operator=(const L1Phase2MuDTExtPhDigi&) = default;
   L1Phase2MuDTExtPhDigi& operator=(L1Phase2MuDTExtPhDigi&&) = default;
 

--- a/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhDigi.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhDigi.h
@@ -57,6 +57,8 @@ public:
                         int lat[8] = nullptr);
 
   L1Phase2MuDTExtPhDigi(const L1Phase2MuDTExtPhDigi &digi);
+  L1Phase2MuDTExtPhDigi& operator=(const L1Phase2MuDTExtPhDigi&) = default;
+  L1Phase2MuDTExtPhDigi& operator=(L1Phase2MuDTExtPhDigi&&) = default;
 
   ~L1Phase2MuDTExtPhDigi() override {}
 

--- a/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPair.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPair.h
@@ -21,28 +21,19 @@ public:
   L1Phase2MuDTExtPhiThetaPair() = default;
 
   /// Constructor with digis and quality
-  L1Phase2MuDTExtPhiThetaPair(const L1Phase2MuDTExtPhDigi& phi,
-                            const L1Phase2MuDTExtThDigi& theta,
-                            int quality);
+  L1Phase2MuDTExtPhiThetaPair(const L1Phase2MuDTExtPhDigi& phi, const L1Phase2MuDTExtThDigi& theta, int quality);
 
-    // Explicitly allow copy/move
-    L1Phase2MuDTExtPhiThetaPair(const L1Phase2MuDTExtPhiThetaPair&) = default;
-    L1Phase2MuDTExtPhiThetaPair& operator=(const L1Phase2MuDTExtPhiThetaPair&) = default;
-    L1Phase2MuDTExtPhiThetaPair(L1Phase2MuDTExtPhiThetaPair&&) = default;
-    L1Phase2MuDTExtPhiThetaPair& operator=(L1Phase2MuDTExtPhiThetaPair&&) = default;
+  // Explicitly allow copy/move
+  L1Phase2MuDTExtPhiThetaPair(const L1Phase2MuDTExtPhiThetaPair&) = default;
+  L1Phase2MuDTExtPhiThetaPair& operator=(const L1Phase2MuDTExtPhiThetaPair&) = default;
+  L1Phase2MuDTExtPhiThetaPair(L1Phase2MuDTExtPhiThetaPair&&) = default;
+  L1Phase2MuDTExtPhiThetaPair& operator=(L1Phase2MuDTExtPhiThetaPair&&) = default;
 
   /// Accessors
   const L1Phase2MuDTExtPhDigi& phiDigi() const { return phi_; }
   const L1Phase2MuDTExtThDigi& thetaDigi() const { return theta_; }
   int quality() const { return quality_; }
 
-/*  /// Static utility: retrieve closest-N time-position pairs per chamber ordered by Phi quality
-  static std::vector<L1Phase2MuDTExtPhiThetaPair> topPairsPerChamber(
-      const std::vector<L1Phase2MuDTExtPhDigi>& phiDigis,
-      const std::vector<L1Phase2MuDTExtThDigi>& thetaDigis,
-      unsigned int chamberId,
-      unsigned int maxPairs = 4);
-*/
 private:
   L1Phase2MuDTExtPhDigi phi_;
   L1Phase2MuDTExtThDigi theta_;
@@ -50,4 +41,3 @@ private:
 };
 
 #endif
-

--- a/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPair.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPair.h
@@ -1,0 +1,47 @@
+#ifndef DataFormats_L1DTTrackFinder_L1Phase2MuDTExtPhiThetaPair_h
+#define DataFormats_L1DTTrackFinder_L1Phase2MuDTExtPhiThetaPair_h
+
+/** \class L1Phase2MuDTExtPhiThetaPair
+ *
+ *  Data container for a matched pair of Phase-2 DT Phi and Theta digis.
+ *  Provides utilities to retrieve the closest-N time-position pairs per chamber ordered by Phi quality.
+ *
+ *  \author J. Fernandez
+ *  \date   2025-11-19
+ */
+
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhDigi.h"
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtThDigi.h"
+#include <vector>
+#include <algorithm>
+
+class L1Phase2MuDTExtPhiThetaPair {
+public:
+  /// Default constructor
+  L1Phase2MuDTExtPhiThetaPair() = default;
+
+  /// Constructor with digis and quality
+  L1Phase2MuDTExtPhiThetaPair(const L1Phase2MuDTExtPhDigi& phi,
+                            const L1Phase2MuDTExtThDigi& theta,
+                            int quality);
+
+  /// Accessors
+  const L1Phase2MuDTExtPhDigi& phiDigi() const { return phi_; }
+  const L1Phase2MuDTExtThDigi& thetaDigi() const { return theta_; }
+  int quality() const { return quality_; }
+
+/*  /// Static utility: retrieve closest-N time-position pairs per chamber ordered by Phi quality
+  static std::vector<L1Phase2MuDTExtPhiThetaPair> topPairsPerChamber(
+      const std::vector<L1Phase2MuDTExtPhDigi>& phiDigis,
+      const std::vector<L1Phase2MuDTExtThDigi>& thetaDigis,
+      unsigned int chamberId,
+      unsigned int maxPairs = 4);
+*/
+private:
+  L1Phase2MuDTExtPhDigi phi_;
+  L1Phase2MuDTExtThDigi theta_;
+  int quality_;
+};
+
+#endif
+

--- a/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPair.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPair.h
@@ -25,6 +25,12 @@ public:
                             const L1Phase2MuDTExtThDigi& theta,
                             int quality);
 
+    // Explicitly allow copy/move
+    L1Phase2MuDTExtPhiThetaPair(const L1Phase2MuDTExtPhiThetaPair&) = default;
+    L1Phase2MuDTExtPhiThetaPair& operator=(const L1Phase2MuDTExtPhiThetaPair&) = default;
+    L1Phase2MuDTExtPhiThetaPair(L1Phase2MuDTExtPhiThetaPair&&) = default;
+    L1Phase2MuDTExtPhiThetaPair& operator=(L1Phase2MuDTExtPhiThetaPair&&) = default;
+
   /// Accessors
   const L1Phase2MuDTExtPhDigi& phiDigi() const { return phi_; }
   const L1Phase2MuDTExtThDigi& thetaDigi() const { return theta_; }

--- a/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPair.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPair.h
@@ -12,8 +12,6 @@
 
 #include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhDigi.h"
 #include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtThDigi.h"
-#include <vector>
-#include <algorithm>
 
 class L1Phase2MuDTExtPhiThetaPair {
 public:

--- a/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPairContainer.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPairContainer.h
@@ -1,0 +1,50 @@
+//-------------------------------------------------
+//
+//   Class L1Phase2MuDTExtPhiThetaPairContainer
+//
+//   Description: trigger primtive data for the
+//                muon barrel Phase2 trigger
+//
+//
+//   Author List: J. Fernandez - Oviedo ICTEA
+//
+//
+//--------------------------------------------------
+#ifndef L1Phase2MuDTExtPhiThetaPairContainer_H
+#define L1Phase2MuDTExtPhiThetaPairContainer_H
+
+//------------------------------------
+// Collaborating Class Declarations --
+//------------------------------------
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPair.h"
+
+//----------------------
+// Base Class Headers --
+//----------------------
+#include <vector>
+
+//---------------
+// C++ Headers --
+//---------------
+
+//---------------------
+//-- Class Interface --
+//---------------------
+
+class L1Phase2MuDTExtPhiThetaPairContainer {
+public:
+  typedef std::vector<L1Phase2MuDTExtPhiThetaPair> Segment_Container;
+  typedef Segment_Container::const_iterator Segment_iterator;
+
+  //  Constructor
+  L1Phase2MuDTExtPhiThetaPairContainer();
+
+  void setContainer(const Segment_Container& inputSegments);
+
+  Segment_Container const* getContainer() const;
+
+private:
+  Segment_Container m_segments;
+};
+
+#endif

--- a/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPairContainer.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPairContainer.h
@@ -41,7 +41,7 @@ public:
 
   void setContainer(const Segment_Container& inputSegments);
 
-  Segment_Container const* getContainer() const;
+  Segment_Container const& getContainer() const;
 
 private:
   Segment_Container m_segments;

--- a/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtThDigi.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtThDigi.h
@@ -54,7 +54,7 @@ public:
                         int tdc[4] = nullptr,
                         int lat[4] = nullptr);
 
-  L1Phase2MuDTExtThDigi(const L1Phase2MuDTExtThDigi &digi);
+  L1Phase2MuDTExtThDigi(const L1Phase2MuDTExtThDigi& digi);
   L1Phase2MuDTExtThDigi& operator=(const L1Phase2MuDTExtThDigi&) = default;
   L1Phase2MuDTExtThDigi& operator=(L1Phase2MuDTExtThDigi&&) = default;
 

--- a/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtThDigi.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtThDigi.h
@@ -55,6 +55,8 @@ public:
                         int lat[4] = nullptr);
 
   L1Phase2MuDTExtThDigi(const L1Phase2MuDTExtThDigi &digi);
+  L1Phase2MuDTExtThDigi& operator=(const L1Phase2MuDTExtThDigi&) = default;
+  L1Phase2MuDTExtThDigi& operator=(L1Phase2MuDTExtThDigi&&) = default;
 
   ~L1Phase2MuDTExtThDigi() override {}
 

--- a/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTExtPhiThetaPair.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTExtPhiThetaPair.cc
@@ -1,8 +1,6 @@
 #include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPair.h"
 
-L1Phase2MuDTExtPhiThetaPair::L1Phase2MuDTExtPhiThetaPair(
-    const L1Phase2MuDTExtPhDigi& phi,
-    const L1Phase2MuDTExtThDigi& theta,
-    int quality)
+L1Phase2MuDTExtPhiThetaPair::L1Phase2MuDTExtPhiThetaPair(const L1Phase2MuDTExtPhDigi& phi,
+                                                         const L1Phase2MuDTExtThDigi& theta,
+                                                         int quality)
     : phi_(phi), theta_(theta), quality_(quality) {}
-

--- a/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTExtPhiThetaPair.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTExtPhiThetaPair.cc
@@ -1,0 +1,8 @@
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPair.h"
+
+L1Phase2MuDTExtPhiThetaPair::L1Phase2MuDTExtPhiThetaPair(
+    const L1Phase2MuDTExtPhDigi& phi,
+    const L1Phase2MuDTExtThDigi& theta,
+    int quality)
+    : phi_(phi), theta_(theta), quality_(quality) {}
+

--- a/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTExtPhiThetaPairContainer.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTExtPhiThetaPairContainer.cc
@@ -40,7 +40,7 @@ void L1Phase2MuDTExtPhiThetaPairContainer::setContainer(const Segment_Container&
   m_segments = inputSegments;
 }
 
-L1Phase2MuDTExtPhiThetaPairContainer::Segment_Container const* L1Phase2MuDTExtPhiThetaPairContainer::getContainer()
+L1Phase2MuDTExtPhiThetaPairContainer::Segment_Container const& L1Phase2MuDTExtPhiThetaPairContainer::getContainer()
     const {
-  return &m_segments;
+  return m_segments;
 }

--- a/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTExtPhiThetaPairContainer.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTExtPhiThetaPairContainer.cc
@@ -1,0 +1,43 @@
+//-------------------------------------------------
+//
+//   Class L1Phase2MuDTExtPhiThetaPairContainer
+//
+//   Description: trigger primtive data for the
+//                muon barrel Phase2 trigger
+//
+//
+//   Author List: J. Fernandez - Oviedo ICTEA
+//
+//
+//--------------------------------------------------
+
+//-----------------------
+// This Class's Header --
+//-----------------------
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPairContainer.h"
+
+//-------------------------------
+// Collaborating Class Headers --
+//-------------------------------
+
+//---------------
+// C++ Headers --
+//---------------
+
+//-------------------
+// Initializations --
+//-------------------
+
+//----------------
+// Constructors --
+//----------------
+L1Phase2MuDTExtPhiThetaPairContainer::L1Phase2MuDTExtPhiThetaPairContainer() {}
+
+//--------------
+// Operations --
+//--------------
+void L1Phase2MuDTExtPhiThetaPairContainer::setContainer(const Segment_Container& inputSegments) { m_segments = inputSegments; }
+
+L1Phase2MuDTExtPhiThetaPairContainer::Segment_Container const* L1Phase2MuDTExtPhiThetaPairContainer::getContainer() const {
+  return &m_segments;
+}

--- a/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTExtPhiThetaPairContainer.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTExtPhiThetaPairContainer.cc
@@ -36,8 +36,11 @@ L1Phase2MuDTExtPhiThetaPairContainer::L1Phase2MuDTExtPhiThetaPairContainer() {}
 //--------------
 // Operations --
 //--------------
-void L1Phase2MuDTExtPhiThetaPairContainer::setContainer(const Segment_Container& inputSegments) { m_segments = inputSegments; }
+void L1Phase2MuDTExtPhiThetaPairContainer::setContainer(const Segment_Container& inputSegments) {
+  m_segments = inputSegments;
+}
 
-L1Phase2MuDTExtPhiThetaPairContainer::Segment_Container const* L1Phase2MuDTExtPhiThetaPairContainer::getContainer() const {
+L1Phase2MuDTExtPhiThetaPairContainer::Segment_Container const* L1Phase2MuDTExtPhiThetaPairContainer::getContainer()
+    const {
   return &m_segments;
 }

--- a/DataFormats/L1DTTrackFinder/src/classes.h
+++ b/DataFormats/L1DTTrackFinder/src/classes.h
@@ -14,4 +14,6 @@
 #include <DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtThDigi.h>
 #include <DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtThContainer.h>
 #include <DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTShowerContainer.h>
+#include <DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPair.h>
+#include <DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPairContainer.h>
 #include <DataFormats/Common/interface/Wrapper.h>

--- a/DataFormats/L1DTTrackFinder/src/classes_def.xml
+++ b/DataFormats/L1DTTrackFinder/src/classes_def.xml
@@ -24,6 +24,7 @@
  <class name="L1Phase2MuDTExtPhDigi"/>
  <class name="L1Phase2MuDTThDigi"/>
  <class name="L1Phase2MuDTExtThDigi"/>
+ <class name="L1Phase2MuDTExtPhiThetaPair"/>
 
  <class name="std::vector<L1MuDTChambPhDigi>"/>
  <class name="std::vector<L1MuDTChambThDigi>"/>
@@ -34,6 +35,7 @@
  <class name="std::vector<L1Phase2MuDTExtPhDigi>"/>
  <class name="std::vector<L1Phase2MuDTExtThDigi>"/>
  <class name="std::vector<L1Phase2MuDTShower>"/>
+ <class name="std::vector<L1Phase2MuDTExtPhiThetaPair>"/>
 
  <class name="L1MuDTChambPhContainer" ClassVersion="10">
   <version ClassVersion="10" checksum="407874824"/>
@@ -56,7 +58,7 @@
  <class name="L1Phase2MuDTThContainer"/>
  <class name="L1Phase2MuDTExtPhContainer"/>
  <class name="L1Phase2MuDTExtThContainer"/>
-
+ <class name="L1Phase2MuDTExtPhiThetaPairContainer"/>
 
  <class name="edm::Wrapper<L1MuDTChambPhContainer>" splitLevel="0"/>
  <class name="edm::Wrapper<L1MuDTChambThContainer>" splitLevel="0"/>
@@ -67,10 +69,12 @@
  <class name="edm::Wrapper<L1Phase2MuDTExtPhContainer>" splitLevel="0"/>
  <class name="edm::Wrapper<L1Phase2MuDTExtThContainer>" splitLevel="0"/>
  <class name="edm::Wrapper<L1Phase2MuDTShowerContainer>" splitLevel="0"/>
+ <class name="edm::Wrapper<L1Phase2MuDTExtPhiThetaPairContainer>" splitLevel="0"/>
 
  <class name="edm::Wrapper<std::vector<L1Phase2MuDTPhDigi> >" />
  <class name="edm::Wrapper<std::vector<L1Phase2MuDTThDigi> >" />
  <class name="edm::Wrapper<std::vector<L1Phase2MuDTExtPhDigi> >" />
  <class name="edm::Wrapper<std::vector<L1Phase2MuDTExtThDigi> >" />
+ <class name="edm::Wrapper<std::vector<L1Phase2MuDTExtPhiThetaPair> >" />
 
 </lcgdict>

--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -258,6 +258,9 @@ def _appendPhase2Digis(obj):
 	'keep *_l1tPhase2L1CaloEGammaEmulator_*_*',
         'keep *_l1tGTProducer_*_*',
         'keep *_l1tGTAlgoBlockProducer_*_*',
+        'keep *_dtTriggerPhase2PrimitiveDigis_*_*',
+        'keep *_dtTriggerPhase2Showers_*_*',
+        'keep *_dtTriggerPhase2PrimitivePairDigis_*_*'
         ]
     obj.outputCommands += l1Phase2Digis
 

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -79,6 +79,8 @@ from L1Trigger.DTTriggerPhase2.dtTriggerPhase2PrimitiveDigis_cfi import *
 _phase2_siml1emulator.add(dtTriggerPhase2PrimitiveDigis)
 from L1Trigger.DTTriggerPhase2.dtTriggerPhase2Showers_cfi import *
 _phase2_siml1emulator.add(dtTriggerPhase2Shower)
+from L1Trigger.DTTriggerPhase2.dtTriggerPhase2PrimitivePairDigis_cfi import *
+_phase2_siml1emulator.add(dtTriggerPhase2PrimitivePairDigis)
 
 # HGCAL TP 
 # ########################################################################

--- a/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2PairsProd.cc
+++ b/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2PairsProd.cc
@@ -251,7 +251,7 @@ void DTTrigPhase2PairsProd::produce(Event& iEvent, const EventSetup& iEventSetup
       LogDebug("DTTrigPhase2PairsProd") << "Sorting";
 
     auto [wheel, sector, station] = key;
-    chamberPairs = std::move(bestPairsPerChamber(phiDigis, thetaDigis, max_index_, wheel, sector, station));
+    chamberPairs = bestPairsPerChamber(phiDigis, thetaDigis, max_index_, wheel, sector, station);
 
     if (debug_)
       LogDebug("DTTrigPhase2PairsProd") << "Saving top 4";

--- a/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2PairsProd.cc
+++ b/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2PairsProd.cc
@@ -199,6 +199,12 @@ void DTTrigPhase2PairsProd::produce(Event& iEvent, const EventSetup& iEventSetup
   edm::Handle<L1Phase2MuDTExtThContainer> theThetaDigis;
   iEvent.getByToken(digiThToken_, theThetaDigis);
 
+  if (!thePhiDigis || !theThetaDigis) {
+    throw cms::Exception("NullPointer") << "Phi or Theta container is null!";
+  }
+
+  cout<<"DTTrigPhase2PairsProd" << " produced"<<endl;
+
   //Order Theta Digis by quality in the same chamber
   //sortThetaDigis(theThetaDigis);
   //Order Phi Digis by quality in the same chamber
@@ -229,7 +235,8 @@ void DTTrigPhase2PairsProd::produce(Event& iEvent, const EventSetup& iEventSetup
 
   if (debug_)
     LogDebug("DTTrigPhase2PairsProd") << "Grouping per chamber";
-
+  
+   cout<<"DTTrigPhase2PairsProd: Grouping per chamber"<<endl;
   std::vector<L1Phase2MuDTExtPhiThetaPair> allPairs;
 
   // Process each chamber key from phi digis
@@ -250,24 +257,24 @@ void DTTrigPhase2PairsProd::produce(Event& iEvent, const EventSetup& iEventSetup
 
      if (debug_)
          LogDebug("DTTrigPhase2PairsProd") << "Working on chamber:";
-      
+      cout<<"DTTrigPhase2PairsProd: Working on chamber"<<endl;
      std::sort(phiDigis.begin(), phiDigis.end(), comparePhiDigis);
      std::sort(thetaDigis.begin(), thetaDigis.end(), compareThetaDigis);
  
      if (debug_)
        LogDebug("DTTrigPhase2PairsProd") << "Sorting";
-
+      cout<<"DTTrigPhase2PairsProd: Sorting"<<endl;
      auto [wheel, sector, station] = key; // unpack tuple
      chamberPairs = std::move(bestPairsPerChamber(phiDigis,thetaDigis,max_index_,wheel,sector,station));
      if (debug_)
          LogDebug("DTTrigPhase2PairsProd") << "Saving top 4";
-
+       cout<<"DTTrigPhase2PairsProd: Saving top 4"<<endl;
     for (const auto& pair : chamberPairs) 
           allPairs.emplace_back(pair);
         }
      if (debug_)
        LogDebug("DTTrigPhase2PairsProd") << "Saved";
-     
+        cout<<"DTTrigPhase2PairsProd: Saved"<<endl;
 
   // Storing results in the event
     std::unique_ptr<L1Phase2MuDTExtPhiThetaPairContainer> resultPhiThetaPair(new L1Phase2MuDTExtPhiThetaPairContainer);
@@ -275,7 +282,7 @@ void DTTrigPhase2PairsProd::produce(Event& iEvent, const EventSetup& iEventSetup
   iEvent.put(std::move(resultPhiThetaPair));
     if (debug_)
     LogDebug("DTTrigPhase2PairsProd") << "Saved in the event";
-
+    cout<<"DTTrigPhase2PairsProd: Saved in the event"<<endl;
   allPairs.clear();
   allPairs.erase(allPairs.begin(), allPairs.end());
 }
@@ -335,8 +342,15 @@ std::vector<L1Phase2MuDTExtPhiThetaPair> DTTrigPhase2PairsProd::bestPairsPerCham
         if(closestDistance > currentDistance){
           closestDistance = currentDistance;
           closestTheta = &theta;
-        }                        
+        }             
+      
+	if (!closestTheta) {
+         cout << "[ERROR] closestTheta is null for phi digi with quality " << phi.quality() << " Current distance is:" << currentDistance<< "and closest distance is: "<< closestDistance<<endl;
+          continue; // or throw an exception
+         }
+           
       int phiQuality = phi.quality();
+      if(closestTheta)
       pairs.emplace_back(phi, *closestTheta, phiQuality);
     }
   }

--- a/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2PairsProd.cc
+++ b/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2PairsProd.cc
@@ -156,7 +156,7 @@ DTTrigPhase2PairsProd::DTTrigPhase2PairsProd(const ParameterSet& pset) {
 
   debug_ = pset.getUntrackedParameter<bool>("debug");
   scenario_ = pset.getParameter<int>("scenario");
-  max_index_ = 4; //Not configurable due to hardware capacities
+  max_index_ = 4;  //Not configurable due to hardware capacities
 
   digiPhToken_ = consumes<L1Phase2MuDTExtPhContainer>(pset.getParameter<edm::InputTag>("digiPhTag"));
   digiThToken_ = consumes<L1Phase2MuDTExtThContainer>(pset.getParameter<edm::InputTag>("digiThTag"));
@@ -250,7 +250,7 @@ void DTTrigPhase2PairsProd::produce(Event& iEvent, const EventSetup& iEventSetup
     if (debug_)
       LogDebug("DTTrigPhase2PairsProd") << "Sorting";
 
-    auto [wheel, sector, station] = key;  // unpack tuple
+    auto [wheel, sector, station] = key;
     chamberPairs = std::move(bestPairsPerChamber(phiDigis, thetaDigis, max_index_, wheel, sector, station));
 
     if (debug_)
@@ -329,11 +329,10 @@ std::vector<L1Phase2MuDTExtPhiThetaPair> DTTrigPhase2PairsProd::bestPairsPerCham
           closestDistance = currentDistance;
           closestTheta = &theta;
         }
-
-        int phiQuality = phi.quality();
-        if (closestTheta)
-          pairs.emplace_back(phi, *closestTheta, phiQuality);
       }
+      int phiQuality = phi.quality();
+      if (closestTheta)
+        pairs.emplace_back(phi, *closestTheta, phiQuality);
     }
   }
   // Sort by quality descending

--- a/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2PairsProd.cc
+++ b/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2PairsProd.cc
@@ -200,16 +200,11 @@ void DTTrigPhase2PairsProd::produce(Event& iEvent, const EventSetup& iEventSetup
   iEvent.getByToken(digiThToken_, theThetaDigis);
 
   if (!thePhiDigis || !theThetaDigis) {
-    throw cms::Exception("NullPointer") << "Phi or Theta container is null!";
+    throw cms::Exception("DTTrigPhase2PairsProd") << "Phi or Theta container is null!";
   }
 
-  cout<<"DTTrigPhase2PairsProd" << " produced"<<endl;
-
-  //Order Theta Digis by quality in the same chamber
-  //sortThetaDigis(theThetaDigis);
-  //Order Phi Digis by quality in the same chamber
-  //sortPhiDigis(thePhiDigis);
-  //Not needed, we sort later based on quality once we have keys (chambers)
+  if (debug_)
+    LogDebug("DTTrigPhase2PairsProd") <<" Containers read";
 
   using ChamberKey = std::tuple<int, int, int>; // (wheel, sector, station)
 
@@ -217,7 +212,7 @@ void DTTrigPhase2PairsProd::produce(Event& iEvent, const EventSetup& iEventSetup
   std::map<ChamberKey, std::vector<L1Phase2MuDTExtThDigi>> thetaByChamber;
 
   if (debug_)
-    LogDebug("DTTrigPhase2PairsProd") << "Variables declaration";
+    LogDebug("DTTrigPhase2PairsProd") << "Variables declared";
 
   // Group phi digis
   for (auto phiIte = thePhiDigis->getContainer()->begin();
@@ -236,7 +231,6 @@ void DTTrigPhase2PairsProd::produce(Event& iEvent, const EventSetup& iEventSetup
   if (debug_)
     LogDebug("DTTrigPhase2PairsProd") << "Grouping per chamber";
   
-   cout<<"DTTrigPhase2PairsProd: Grouping per chamber"<<endl;
   std::vector<L1Phase2MuDTExtPhiThetaPair> allPairs;
 
   // Process each chamber key from phi digis
@@ -246,35 +240,36 @@ void DTTrigPhase2PairsProd::produce(Event& iEvent, const EventSetup& iEventSetup
     std::vector<L1Phase2MuDTExtThDigi> thetaDigis;
 
     auto thetaListIt = thetaByChamber.find(key);
-//    if (thetaListIt != thetaByChamber.end()) {
-//    Both phi and theta exist
-//
+
      for (const auto& phi : phiList) 
             phiDigis.emplace_back(phi);
-   
+
+     if (thetaListIt != thetaByChamber.end()) { //    Both phi and theta exist 
      for (const auto& theta : thetaListIt->second) 
             thetaDigis.emplace_back(theta);     
+     }
 
      if (debug_)
          LogDebug("DTTrigPhase2PairsProd") << "Working on chamber:";
-      cout<<"DTTrigPhase2PairsProd: Working on chamber"<<endl;
+
      std::sort(phiDigis.begin(), phiDigis.end(), comparePhiDigis);
      std::sort(thetaDigis.begin(), thetaDigis.end(), compareThetaDigis);
  
      if (debug_)
        LogDebug("DTTrigPhase2PairsProd") << "Sorting";
-      cout<<"DTTrigPhase2PairsProd: Sorting"<<endl;
+
      auto [wheel, sector, station] = key; // unpack tuple
      chamberPairs = std::move(bestPairsPerChamber(phiDigis,thetaDigis,max_index_,wheel,sector,station));
+
      if (debug_)
          LogDebug("DTTrigPhase2PairsProd") << "Saving top 4";
-       cout<<"DTTrigPhase2PairsProd: Saving top 4"<<endl;
+
     for (const auto& pair : chamberPairs) 
           allPairs.emplace_back(pair);
         }
+
      if (debug_)
-       LogDebug("DTTrigPhase2PairsProd") << "Saved";
-        cout<<"DTTrigPhase2PairsProd: Saved"<<endl;
+       LogDebug("DTTrigPhase2PairsProd") << "Saving products";
 
   // Storing results in the event
     std::unique_ptr<L1Phase2MuDTExtPhiThetaPairContainer> resultPhiThetaPair(new L1Phase2MuDTExtPhiThetaPairContainer);
@@ -282,7 +277,7 @@ void DTTrigPhase2PairsProd::produce(Event& iEvent, const EventSetup& iEventSetup
   iEvent.put(std::move(resultPhiThetaPair));
     if (debug_)
     LogDebug("DTTrigPhase2PairsProd") << "Saved in the event";
-    cout<<"DTTrigPhase2PairsProd: Saved in the event"<<endl;
+
   allPairs.clear();
   allPairs.erase(allPairs.begin(), allPairs.end());
 }
@@ -334,7 +329,7 @@ std::vector<L1Phase2MuDTExtPhiThetaPair> DTTrigPhase2PairsProd::bestPairsPerCham
   else{  // phi and theta digis in chamber
 
   for (const auto& phi : phiDigis) {
-    float closestDistance = 9999.;
+    float closestDistance = numeric_limits<float>::infinity();
     const L1Phase2MuDTExtThDigi *closestTheta=nullptr;
 
     for (const auto& theta : thetaDigis) {
@@ -344,11 +339,6 @@ std::vector<L1Phase2MuDTExtPhiThetaPair> DTTrigPhase2PairsProd::bestPairsPerCham
           closestTheta = &theta;
         }             
       
-	if (!closestTheta) {
-         cout << "[ERROR] closestTheta is null for phi digi with quality " << phi.quality() << " Current distance is:" << currentDistance<< "and closest distance is: "<< closestDistance<<endl;
-          continue; // or throw an exception
-         }
-           
       int phiQuality = phi.quality();
       if(closestTheta)
       pairs.emplace_back(phi, *closestTheta, phiQuality);

--- a/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2PairsProd.cc
+++ b/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2PairsProd.cc
@@ -44,7 +44,6 @@
 //
 // (*) Requires df_extended>0 in L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2Prod.cc
 
-using namespace edm;
 using namespace std;
 using namespace cmsdt;
 
@@ -121,8 +120,6 @@ public:
   void endRun(edm::Run const& iRun, const edm::EventSetup& iEventSetup) override;
 
   // Methods
-  void sortPhiDigis(const edm::Handle<L1Phase2MuDTExtPhContainer>& thePhiDigis);
-  void sortThetaDigis(const edm::Handle<L1Phase2MuDTExtThContainer>& theThetaDigis);
   std::vector<L1Phase2MuDTExtPhiThetaPair> bestPairsPerChamber(const std::vector<L1Phase2MuDTExtPhDigi>& phiDigis,
                                                                const std::vector<L1Phase2MuDTExtThDigi>& thetaDigis,
                                                                unsigned int maxPairs,
@@ -130,7 +127,7 @@ public:
                                                                int sector,
                                                                int station);
   float computeTimePosDistance(
-      const L1Phase2MuDTExtPhDigi phiDigi, const L1Phase2MuDTExtThDigi thetaDigi, int sector, int wheel, int station);
+      const L1Phase2MuDTExtPhDigi& phiDigi, const L1Phase2MuDTExtThDigi& thetaDigi, int sector, int wheel, int station);
 
   // Setter-methods
 
@@ -151,7 +148,7 @@ private:
   edm::EDGetTokenT<L1Phase2MuDTExtThContainer> digiThToken_;
 };
 
-DTTrigPhase2PairsProd::DTTrigPhase2PairsProd(const ParameterSet& pset) {
+DTTrigPhase2PairsProd::DTTrigPhase2PairsProd(const edm::ParameterSet& pset) {
   produces<L1Phase2MuDTExtPhiThetaPairContainer>();
 
   debug_ = pset.getUntrackedParameter<bool>("debug");
@@ -182,7 +179,7 @@ void DTTrigPhase2PairsProd::beginRun(edm::Run const& iRun, const edm::EventSetup
     LogDebug("DTTrigPhase2PairsProd") << "beginRun " << iRun.id().run();
 }
 
-void DTTrigPhase2PairsProd::produce(Event& iEvent, const EventSetup& iEventSetup) {
+void DTTrigPhase2PairsProd::produce(edm::Event& iEvent, const edm::EventSetup& iEventSetup) {
   if (debug_)
     LogDebug("DTTrigPhase2PairsProd") << "produce";
 
@@ -346,7 +343,7 @@ std::vector<L1Phase2MuDTExtPhiThetaPair> DTTrigPhase2PairsProd::bestPairsPerCham
 }
 
 float DTTrigPhase2PairsProd::computeTimePosDistance(
-    const L1Phase2MuDTExtPhDigi phiDigi, const L1Phase2MuDTExtThDigi thetaDigi, int sector, int wheel, int station) {
+    const L1Phase2MuDTExtPhDigi& phiDigi, const L1Phase2MuDTExtThDigi& thetaDigi, int sector, int wheel, int station) {
   float t01 = ((int)round(thetaDigi.t0() / (float)LHC_CLK_FREQ)) - shift_back;
   float posRefZ = zFE[wheel + 2];
 

--- a/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2PairsProd.cc
+++ b/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2PairsProd.cc
@@ -247,7 +247,7 @@ void DTTrigPhase2PairsProd::produce(Event& iEvent, const EventSetup& iEventSetup
      std::sort(phiDigis.begin(), phiDigis.end(), comparePhiDigis);
      std::sort(thetaDigis.begin(), thetaDigis.end(), compareThetaDigis);
      auto [wheel, sector, station] = key; // unpack tuple
-     chamberPairs = bestPairsPerChamber(phiDigis,thetaDigis,max_index_,wheel,sector,station);
+     chamberPairs = std::move(bestPairsPerChamber(phiDigis,thetaDigis,max_index_,wheel,sector,station));
 
     for (const auto& pair : chamberPairs) 
           allPairs.emplace_back(pair);

--- a/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2PairsProd.cc
+++ b/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2PairsProd.cc
@@ -1,0 +1,395 @@
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESProducts.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "Geometry/DTGeometry/interface/DTLayer.h"
+
+#include "L1Trigger/DTTriggerPhase2/interface/constants.h"
+
+//inputs
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhContainer.h"
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhDigi.h"
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhContainer.h"
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhDigi.h"
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtThContainer.h"
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtThDigi.h"
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtThContainer.h"
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtThDigi.h"
+
+//outputs
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPair.h"
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPair.h"
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPairContainer.h"
+
+#include <fstream>
+#include <iostream>
+#include <queue>
+#include <cmath>
+
+using namespace edm;
+using namespace std;
+using namespace cmsdt;
+
+namespace {
+  struct {
+    bool operator()(const L1Phase2MuDTExtPhDigi &mp1, const L1Phase2MuDTExtPhDigi &mp2) const {
+
+      int sector1 = mp1.scNum();
+      int wheel1 = mp1.whNum();
+      int station1 = mp1.stNum();
+
+      int sector2 = mp2.scNum();
+      int wheel2 = mp2.whNum();
+      int station2 = mp2.stNum();
+
+      // First, compare by chamber
+      if (sector1 != sector2)
+        return sector1 < sector2;
+      if (wheel1 != wheel2)
+        return wheel1 < wheel2;
+      if (station1 != station2)
+        return station1 < station2;
+
+      // If they are in the same category, sort by the value (4th index)
+      return mp1.quality() > mp2.quality();
+    }
+  } const comparePhiDigis;
+
+  struct {
+    bool operator()(const L1Phase2MuDTThDigi &mp1, const L1Phase2MuDTThDigi &mp2) const {
+
+      int sector1 = mp1.scNum();
+      int wheel1 = mp1.whNum();
+      int station1 = mp1.stNum();
+
+      int sector2 = mp2.scNum();
+      int wheel2 = mp2.whNum();
+      int station2 = mp2.stNum();
+
+      // First, compare by chamber
+      if (sector1 != sector2)
+        return sector1 < sector2;
+      if (wheel1 != wheel2)
+        return wheel1 < wheel2;
+      if (station1 != station2)
+        return station1 < station2;
+
+      // If they are in the same category, sort by the value (4th index)
+      return mp1.quality() > mp2.quality();
+    }
+  } const compareThetaDigis;
+
+  struct {
+    bool operator()(const L1Phase2MuDTExtPhiThetaPair &mp1, const L1Phase2MuDTExtPhiThetaPair &mp2) const {
+      return mp1.quality() > mp2.quality();
+    }
+  } const comparePairs;
+
+}  //namespace
+
+
+class DTTrigPhase2PairsProd : public edm::stream::EDProducer<> {
+
+public:
+  //! Constructor
+  DTTrigPhase2PairsProd(const edm::ParameterSet& pset);
+
+  //! Destructor
+  ~DTTrigPhase2PairsProd() override;
+
+  //! Create Trigger Units before starting event processing
+  void beginRun(edm::Run const& iRun, const edm::EventSetup& iEventSetup) override;
+
+  //! Producer: process every event and generates trigger data
+  void produce(edm::Event& iEvent, const edm::EventSetup& iEventSetup) override;
+
+  //! endRun: finish things
+  void endRun(edm::Run const& iRun, const edm::EventSetup& iEventSetup) override;
+
+  // Methods
+  void sortPhiDigis(const edm::Handle<L1Phase2MuDTExtPhContainer> &thePhiDigis);
+  void sortThetaDigis(const edm::Handle<L1Phase2MuDTExtThContainer> &theThetaDigis);
+  std::vector<L1Phase2MuDTExtPhiThetaPair> bestPairsPerChamber(
+    const std::vector<L1Phase2MuDTExtPhDigi>& phiDigis,
+    const std::vector<L1Phase2MuDTExtThDigi>& thetaDigis,
+    unsigned int maxPairs, int wheel, int sector, int station);
+  float computeTimePosDistance(
+   const L1Phase2MuDTExtPhDigi phiDigi,
+   const L1Phase2MuDTExtThDigi thetaDigi,
+   int sector, int wheel, int station);
+  // Getter-methods
+
+  // Setter-methods
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  // data-members
+
+  double shift_back;
+
+private:
+
+  // Debug Flag
+  int debug_;
+  int scenario_;
+  int max_index_;
+
+  // ParameterSet
+  edm::EDGetTokenT<L1Phase2MuDTExtPhContainer> digiPhToken_;
+  edm::EDGetTokenT<L1Phase2MuDTExtThContainer> digiThToken_;
+
+};
+
+
+DTTrigPhase2PairsProd::DTTrigPhase2PairsProd(const ParameterSet& pset){
+  produces<L1Phase2MuDTExtPhiThetaPairContainer>();
+//  produces<L1Phase2MuDTExtPhiThetaPairContainer>();
+
+  debug_    = pset.getUntrackedParameter<bool>("debug");
+  scenario_ = pset.getParameter<int>("scenario");
+//  df_extended_ = pset.getParameter<int>("df_extended"); //it must be at least 1 to have x local position from Phi
+//  max_index_ = pset.getParameter<int>("max_primitives") - 1;
+  max_index_ = 4;
+
+  digiPhToken_ = consumes<L1Phase2MuDTExtPhContainer>(pset.getParameter<edm::InputTag>("digiPhTag"));
+  digiThToken_ = consumes<L1Phase2MuDTExtThContainer>(pset.getParameter<edm::InputTag>("digiThTag"));
+
+  double temp_shift = 0;
+  if (scenario_ == MC)
+    temp_shift = 400;  // value used in standard CMSSW simulation
+  else if (scenario_ == DATA)
+    temp_shift = 0;
+  else if (scenario_ == SLICE_TEST)
+    temp_shift = 400;  // slice test mimics simulation
+
+  shift_back = temp_shift; 
+
+}
+
+DTTrigPhase2PairsProd::~DTTrigPhase2PairsProd() {
+  if (debug_)
+    LogDebug("DTTrigPhase2PairsProd") << "calling destructor" << std::endl;
+}
+
+void DTTrigPhase2PairsProd::beginRun(edm::Run const& iRun, const edm::EventSetup& iEventSetup) {
+  if (debug_)
+    LogDebug("DTTrigPhase2PairsProd") << "beginRun " << iRun.id().run();
+}
+
+void DTTrigPhase2PairsProd::produce(Event& iEvent, const EventSetup& iEventSetup) {
+  if (debug_)
+    LogDebug("DTTrigPhase2PairsProd") << "produce";
+
+  edm::Handle<L1Phase2MuDTExtPhContainer> thePhiDigis;
+  iEvent.getByToken(digiPhToken_, thePhiDigis);
+
+  edm::Handle<L1Phase2MuDTExtThContainer> theThetaDigis;
+  iEvent.getByToken(digiThToken_, theThetaDigis);
+
+  //Order Theta Digis by quality in the same chamber
+  //sortThetaDigis(theThetaDigis);
+  //Order Phi Digis by quality in the same chamber
+  //sortPhiDigis(thePhiDigis);
+  //Not needed, we sort later based on quality once we have keys (chambers)
+
+  using ChamberKey = std::tuple<int, int, int>; // (wheel, sector, station)
+
+  std::map<ChamberKey, std::vector<L1Phase2MuDTExtPhDigi>> phiByChamber;
+  std::map<ChamberKey, std::vector<L1Phase2MuDTExtThDigi>> thetaByChamber;
+
+  // Group phi digis
+  for (auto phiIte = thePhiDigis->getContainer()->begin();
+     phiIte != thePhiDigis->getContainer()->end(); ++phiIte) {
+    ChamberKey key(phiIte->whNum(), phiIte->scNum(), phiIte->stNum());
+    phiByChamber[key].push_back(*phiIte);
+  }
+
+  // Group theta digis
+  for (auto thetaIte = theThetaDigis->getContainer()->begin();
+     thetaIte != theThetaDigis->getContainer()->end(); ++thetaIte) {
+    ChamberKey key(thetaIte->whNum(), thetaIte->scNum(), thetaIte->stNum());
+    thetaByChamber[key].push_back(*thetaIte);
+  }
+
+  std::vector<L1Phase2MuDTExtPhiThetaPair> allPairs;
+
+  // Process each chamber key from phi digis
+  for (const auto& [key, phiList] : phiByChamber) {
+    std::vector<L1Phase2MuDTExtPhiThetaPair> chamberPairs;
+    std::vector<L1Phase2MuDTExtPhDigi> phiDigis;
+    std::vector<L1Phase2MuDTExtThDigi> thetaDigis;
+
+    auto thetaListIt = thetaByChamber.find(key);
+//    if (thetaListIt != thetaByChamber.end()) {
+//    Both phi and theta exist
+//
+     for (const auto& phi : phiList) 
+            phiDigis.emplace_back(phi);
+   
+     for (const auto& theta : thetaListIt->second) 
+            thetaDigis.emplace_back(theta);     
+           
+     std::sort(phiDigis.begin(), phiDigis.end(), comparePhiDigis);
+     std::sort(thetaDigis.begin(), thetaDigis.end(), compareThetaDigis);
+     auto [wheel, sector, station] = key; // unpack tuple
+     chamberPairs = bestPairsPerChamber(phiDigis,thetaDigis,max_index_,wheel,sector,station);
+
+    for (const auto& pair : chamberPairs) 
+          allPairs.emplace_back(pair);
+        }
+     
+
+  // Storing results in the event
+    std::unique_ptr<L1Phase2MuDTExtPhiThetaPairContainer> resultPhiThetaPair(new L1Phase2MuDTExtPhiThetaPairContainer);
+    resultPhiThetaPair->setContainer(allPairs);
+  iEvent.put(std::move(resultPhiThetaPair));
+  allPairs.clear();
+  allPairs.erase(allPairs.begin(), allPairs.end());
+}
+
+void DTTrigPhase2PairsProd::endRun(edm::Run const& iRun, const edm::EventSetup& iEventSetup) {
+};
+
+void DTTrigPhase2PairsProd::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // dtTriggerPhase2PrimitivePairDigis
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("digiTag", edm::InputTag("CalibratedDigis"));
+  desc.add<int>("scenario", 0);
+  desc.add<int>("df_extended", 0);
+  desc.addUntracked<bool>("debug", false);
+  descriptions.add("dtTriggerPhase2PrimitivePairDigis", desc);
+}
+
+DEFINE_FWK_MODULE(DTTrigPhase2PairsProd);
+
+
+std::vector<L1Phase2MuDTExtPhiThetaPair> DTTrigPhase2PairsProd::bestPairsPerChamber(
+    const std::vector<L1Phase2MuDTExtPhDigi>& phiDigis,
+    const std::vector<L1Phase2MuDTExtThDigi>& thetaDigis,
+    unsigned int maxPairs, int wheel, int sector, int station) {
+
+  std::vector<L1Phase2MuDTExtPhiThetaPair> pairs;
+
+  if (station == 4 || thetaDigis.empty()) { // no theta digis in chamber
+
+  L1Phase2MuDTExtThDigi emptyTheta; 
+  for (const auto& phi : phiDigis){
+    int phiQuality = phi.quality();
+    pairs.emplace_back(phi, emptyTheta, phiQuality);
+  }
+ 
+  }
+
+  else if ( phiDigis.empty() && !(thetaDigis.empty())){ // no phi digis in chamber
+
+  L1Phase2MuDTExtPhDigi emptyPhi;
+  for (const auto& theta : thetaDigis){
+    int thetaQuality = theta.quality();
+    pairs.emplace_back(emptyPhi, theta, thetaQuality);
+
+  } 
+
+}
+
+  else{  // phi and theta digis in chamber
+
+  for (const auto& phi : phiDigis) {
+    float closestDistance = 9999.;
+    const L1Phase2MuDTExtThDigi *closestTheta=nullptr;
+
+    for (const auto& theta : thetaDigis) {
+        float currentDistance = computeTimePosDistance(phi,theta,sector,wheel,station);
+        if(closestDistance > currentDistance){
+          closestDistance = currentDistance;
+          closestTheta = &theta;
+        }                        
+      int phiQuality = phi.quality();
+      pairs.emplace_back(phi, *closestTheta, phiQuality);
+    }
+  }
+}
+  // Sort by quality descending
+  std::sort(pairs.begin(), pairs.end(),comparePairs);
+
+  // Keep only top-N
+  if (pairs.size() > maxPairs)
+    pairs.resize(maxPairs);
+
+  return pairs;
+}
+
+
+float DTTrigPhase2PairsProd::computeTimePosDistance(
+   const L1Phase2MuDTExtPhDigi phiDigi,
+   const L1Phase2MuDTExtThDigi thetaDigi,
+   int sector, int wheel, int station) {
+
+   float t01 = ((int)round(thetaDigi.t0() / (float)LHC_CLK_FREQ)) - shift_back;
+   float posRefZ = zFE[wheel + 2];
+ 
+   if (wheel == 0 && (sector == 1 || sector == 4 || sector == 5 || sector == 8 || sector == 9 || sector == 12))
+      posRefZ = -posRefZ;
+
+   float posZ = abs(thetaDigi.z());
+
+   float t02 = ((int)round(phiDigi.t0() / (float)LHC_CLK_FREQ)) - shift_back;
+
+   float tphi = t02 - abs(posZ / ZRES_CONV - posRefZ) / vwire;
+
+   int LR = -1;
+   if (wheel == 0 && (sector == 3 || sector == 4 || sector == 7 || sector == 8 || sector == 11 || sector == 12))
+        LR = +1;
+   else if (wheel > 0)
+        LR = pow(-1, wheel + sector + 1);
+   else if (wheel < 0)
+        LR = pow(-1, -wheel + sector);
+
+   float posRefX = LR * xFE[station - 1];
+   float ttheta = t01 - (phiDigi.xLocal() / 1000 - posRefX) / vwire;
+
+   return abs(tphi - ttheta);
+}
+   
+/*void DTTrigPhase2PairsProd::sortThetaDigis(const edm::Handle<L1Phase2MuDTExtThContainer> &theThetaDigis) {
+  // Copy to a vector for sorting
+  std::vector<L1Phase2MuDTThDigi> sortedThetaDigis(theThetaDigis->begin(), theThetaDigis->end());
+
+  // Sort using comparator
+  std::sort(sortedThetaDigis.begin(), sortedThetaDigis.end(), compareThetaDigis);
+
+  for (const auto &theta : sortedThetaDigis) {
+    edm::LogInfo("ThetaSorting") << "Wheel=" << theta.whNum()
+                                 << " Sector=" << theta.scNum()
+                                 << " Station=" << theta.stNum();
+  }
+}
+
+void DTTrigPhase2PairsProd::sortPhiDigis(const edm::Handle<L1Phase2MuDTExtPhContainer> &thePhiDigis) {
+  // Copy to a vector for sorting
+  std::vector<L1Phase2MuDTExtPhDigi> sortedThetaDigis(thePhiDigis->begin(), thePhiDigis->end());
+
+  // Sort using comparator
+  std::sort(sortedPhiDigis.begin(), sortedPhiDigis.end(), comparePhiDigis());
+
+  for (const auto &theta : sortedPhiDigis) {
+    edm::LogInfo("PhiSorting") << "Wheel=" << theta.whNum()
+                                 << " Sector=" << theta.scNum()
+                                 << " Station=" << theta.stNum();
+  }
+}
+*/

--- a/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2PairsProd.cc
+++ b/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2PairsProd.cc
@@ -30,9 +30,6 @@
 #include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPair.h"
 #include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTExtPhiThetaPairContainer.h"
 
-#include <fstream>
-#include <iostream>
-#include <queue>
 #include <cmath>
 
 // Plugin which takes Phi and Theta DT Phase2 digi Extended collections(*) and
@@ -44,8 +41,6 @@
 //
 // (*) Requires df_extended>0 in L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2Prod.cc
 
-using namespace std;
-using namespace cmsdt;
 
 namespace {
   struct {
@@ -159,11 +154,11 @@ DTTrigPhase2PairsProd::DTTrigPhase2PairsProd(const edm::ParameterSet& pset) {
   digiThToken_ = consumes<L1Phase2MuDTExtThContainer>(pset.getParameter<edm::InputTag>("digiThTag"));
 
   double temp_shift = 0;
-  if (scenario_ == MC)
+  if (scenario_ == cmsdt::MC)
     temp_shift = 400;  // value used in standard CMSSW simulation
-  else if (scenario_ == DATA)
+  else if (scenario_ == cmsdt::DATA)
     temp_shift = 0;
-  else if (scenario_ == SLICE_TEST)
+  else if (scenario_ == cmsdt::SLICE_TEST)
     temp_shift = 400;  // slice test mimics simulation
 
   shift_back = temp_shift;
@@ -317,7 +312,7 @@ std::vector<L1Phase2MuDTExtPhiThetaPair> DTTrigPhase2PairsProd::bestPairsPerCham
   else {  // phi and theta digis in chamber
 
     for (const auto& phi : phiDigis) {
-      float closestDistance = numeric_limits<float>::infinity();
+      float closestDistance = std::numeric_limits<float>::infinity();
       const L1Phase2MuDTExtThDigi* closestTheta = nullptr;
 
       for (const auto& theta : thetaDigis) {
@@ -344,17 +339,17 @@ std::vector<L1Phase2MuDTExtPhiThetaPair> DTTrigPhase2PairsProd::bestPairsPerCham
 
 float DTTrigPhase2PairsProd::computeTimePosDistance(
     const L1Phase2MuDTExtPhDigi& phiDigi, const L1Phase2MuDTExtThDigi& thetaDigi, int sector, int wheel, int station) {
-  float t01 = ((int)round(thetaDigi.t0() / (float)LHC_CLK_FREQ)) - shift_back;
-  float posRefZ = zFE[wheel + 2];
+  float t01 = ((int)round(thetaDigi.t0() / (float)cmsdt::LHC_CLK_FREQ)) - shift_back;
+  float posRefZ = cmsdt::zFE[wheel + 2];
 
   if (wheel == 0 && (sector == 1 || sector == 4 || sector == 5 || sector == 8 || sector == 9 || sector == 12))
     posRefZ = -posRefZ;
 
   float posZ = abs(thetaDigi.z());
 
-  float t02 = ((int)round(phiDigi.t0() / (float)LHC_CLK_FREQ)) - shift_back;
+  float t02 = ((int)round(phiDigi.t0() / (float)cmsdt::LHC_CLK_FREQ)) - shift_back;
 
-  float tphi = t02 - abs(posZ / ZRES_CONV - posRefZ) / vwire;
+  float tphi = t02 - abs(posZ / cmsdt::ZRES_CONV - posRefZ) / cmsdt::vwire;
 
   int LR = -1;
   if (wheel == 0 && (sector == 3 || sector == 4 || sector == 7 || sector == 8 || sector == 11 || sector == 12))
@@ -364,8 +359,8 @@ float DTTrigPhase2PairsProd::computeTimePosDistance(
   else if (wheel < 0)
     LR = pow(-1, -wheel + sector);
 
-  float posRefX = LR * xFE[station - 1];
-  float ttheta = t01 - (phiDigi.xLocal() / 1000 - posRefX) / vwire;
+  float posRefX = LR * cmsdt::xFE[station - 1];
+  float ttheta = t01 - (phiDigi.xLocal() / 1000 - posRefX) / cmsdt::vwire;
 
   return abs(tphi - ttheta);
 }

--- a/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2PairsProd.cc
+++ b/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2PairsProd.cc
@@ -41,7 +41,6 @@
 //
 // (*) Requires df_extended>0 in L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2Prod.cc
 
-
 namespace {
   struct {
     bool operator()(const L1Phase2MuDTExtPhDigi& mp1, const L1Phase2MuDTExtPhDigi& mp2) const {

--- a/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2Prod.cc
+++ b/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2Prod.cc
@@ -122,7 +122,6 @@ public:
   // data-members
   const DTGeometry* dtGeo_;
   edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomH;
-  std::vector<std::pair<int, MuonPath>> primitives_;
 
 private:
   // Trigger Configuration Manager CCB validity flag

--- a/L1Trigger/DTTriggerPhase2/python/dtTriggerPhase2PrimitiveDigis_cfi.py
+++ b/L1Trigger/DTTriggerPhase2/python/dtTriggerPhase2PrimitiveDigis_cfi.py
@@ -23,7 +23,7 @@ dtTriggerPhase2PrimitiveDigis = cms.EDProducer("DTTrigPhase2Prod",
                                                allow_confirmation = cms.bool(True),
                                                minx_match_2digis = cms.double(1.),
                                                scenario = cms.int32(0), #0 for mc, 1 for data, 2 for slice test
-                                               df_extended = cms.int32(0), # DF: 0 for standard, 1 for extended, 2 for both 
+                                               df_extended = cms.int32(2), # DF: 0 for standard, 1 for extended, 2 for both 
                                                co_option = cms.int32(1), # coincidence w.r.t. : -1 = off, 0 = co all, 1 = co phi, 2 = co theta
                                                co_quality = cms.int32(1), # quality cut (>X) for coincidence TP: request TPs to be above this cut
                                                co_wh2option = cms.int32(1),#0 (filter all stations in Wh2), 1(pass Wh2 St1), 2(pass Wh2 St1+2)

--- a/L1Trigger/DTTriggerPhase2/python/dtTriggerPhase2PrimitivePairDigis_cfi.py
+++ b/L1Trigger/DTTriggerPhase2/python/dtTriggerPhase2PrimitivePairDigis_cfi.py
@@ -1,0 +1,11 @@
+
+import FWCore.ParameterSet.Config as cms
+
+dtTriggerPhase2PrimitivePairDigis = cms.EDProducer("DTTrigPhase2PairsProd",
+                                               scenario = cms.int32(0), #0 for mc, 1 for data, 2 for slice test
+                                               digiPhTag = cms.InputTag("dtTriggerPhase2PrimitiveDigis",""),
+                                               digiThTag  = cms.InputTag("dtTriggerPhase2PrimitiveDigis",""),
+
+                                               #debugging
+                                               debug = cms.untracked.bool(False),
+)

--- a/L1Trigger/DTTriggerPhase2/src/MPThetaMatching.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MPThetaMatching.cc
@@ -47,11 +47,11 @@ namespace {
       if (mp1.quality != mp2.quality)
         return mp1.quality > mp2.quality;
 
-      if (mp1.x != mp2.x)
-        return mp1.x < mp2.x;
+      if (mp1.phi != mp2.phi)
+        return mp1.phi < mp2.phi;
 
-      if (mp1.tanPhi != mp2.tanPhi)
-        return mp1.tanPhi < mp2.tanPhi;
+      if (mp1.phiB != mp2.phiB)
+        return mp1.phiB < mp2.phiB;
 
       if (mp1.chi2 != mp2.chi2)
         return mp1.chi2 < mp2.chi2;
@@ -63,7 +63,7 @@ namespace {
   struct {
     bool operator()(const metaPrimitive &mp1, const metaPrimitive &mp2) const {
       // Use main characteristics to know if it is the same metaPrimitive
-      if (mp1.rawId != mp2.rawId || mp1.quality != mp2.quality || mp1.x != mp2.x || mp1.tanPhi != mp2.tanPhi ||
+      if (mp1.rawId != mp2.rawId || mp1.quality != mp2.quality || mp1.phi != mp2.phi || mp1.phiB != mp2.phiB ||
           mp1.chi2 != mp2.chi2 || mp1.t0 != mp2.t0)
         return false;
       else
@@ -122,7 +122,7 @@ void MPThetaMatching::run(edm::Event &iEvent,
 
   ///////////////////////////
   // Filter out duplicates
-  // Sort by key so equal keys become adjacent
+  // Sort by features so that equal keys become adjacent
   std::sort(outMPaths.begin(), outMPaths.end(), deepCompareMPs);
   // Unique-erase adjacent duplicates
   outMPaths.erase(std::unique(outMPaths.begin(), outMPaths.end(), sameMPs), outMPaths.end());
@@ -344,7 +344,7 @@ void MPThetaMatching::orderAndSave(std::vector<std::tuple<metaPrimitive, metaPri
 
     if ((abs(chId.wheel()) == 2 && chId.station() < 3 && count < th_option_ + 1) ||  //save an extra pair for WH+-2MB1/2
         count < th_option_) {
-      std::get<0>(p).t0 = std::get<1>(p).t0;     //replace t0 by associated phi t0
+      //std::get<0>(p).t0 = std::get<1>(p).t0;     //replace t0 by associated phi t0
       outMPs->push_back(std::get<1>(p));         //add PhiMP
       outMPs->push_back(std::get<0>(p));         //add ThetaMP
       savedThetaMPs->push_back(std::get<0>(p));  //for accounting
@@ -358,8 +358,7 @@ void MPThetaMatching::orderAndSave(std::vector<std::tuple<metaPrimitive, metaPri
     DTChamberId chId(std::get<1>(p).rawId);
     if (count < th_option_ || (abs(chId.wheel()) == 2 && chId.station() < 3 && count < (th_option_ + 1))) {
       if (std::get<1>(p).quality > th_quality_) {
-        //if (abs(chId.wheel())!=0)
-        std::get<0>(p).t0 = std::get<1>(p).t0;  //replace t0 by associated phi t0
+        //std::get<0>(p).t0 = std::get<1>(p).t0;  //replace t0 by associated phi t0
         outMPs->push_back(std::get<0>(p));      //add ThetaMP
         savedThetaMPs->push_back(std::get<0>(p));
         count++;

--- a/L1Trigger/DTTriggerPhase2/src/MPThetaMatching.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MPThetaMatching.cc
@@ -359,7 +359,7 @@ void MPThetaMatching::orderAndSave(std::vector<std::tuple<metaPrimitive, metaPri
     if (count < th_option_ || (abs(chId.wheel()) == 2 && chId.station() < 3 && count < (th_option_ + 1))) {
       if (std::get<1>(p).quality > th_quality_) {
         //std::get<0>(p).t0 = std::get<1>(p).t0;  //replace t0 by associated phi t0
-        outMPs->push_back(std::get<0>(p));      //add ThetaMP
+        outMPs->push_back(std::get<0>(p));  //add ThetaMP
         savedThetaMPs->push_back(std::get<0>(p));
         count++;
       }

--- a/L1Trigger/DTTriggerPhase2/src/MPThetaMatching.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MPThetaMatching.cc
@@ -8,10 +8,12 @@ namespace {
   struct {
     bool operator()(const metaPrimitive &mp1, const metaPrimitive &mp2) const {
       DTChamberId chId1(mp1.rawId);
+      DTSuperLayerId slId1(mp1.rawId);
 
       int sector1 = chId1.sector();
       int wheel1 = chId1.wheel();
       int station1 = chId1.station();
+      int sl1 = slId1.superLayer();
 
       DTChamberId chId2(mp2.rawId);
       DTSuperLayerId slId2(mp2.rawId);
@@ -19,6 +21,7 @@ namespace {
       int sector2 = chId2.sector();
       int wheel2 = chId2.wheel();
       int station2 = chId2.station();
+      int sl2 = slId2.superLayer();
 
       // First, compare by chamber
       if (sector1 != sector2)
@@ -27,11 +30,47 @@ namespace {
         return wheel1 < wheel2;
       if (station1 != station2)
         return station1 < station2;
+      if (sl1 != sl2)
+        return sl1 < sl2;
 
-      // If they are in the same category, sort by the value (4th index)
+      // If they are in the same chamber and SL, sort by the quality
       return mp1.quality > mp2.quality;
     }
   } const compareMPs;
+
+  struct {
+    bool operator()(const metaPrimitive &mp1, const metaPrimitive &mp2) const {
+      // Use main characteristics to know if it is the same metaPrimitive
+      if (mp1.rawId != mp2.rawId)
+        return mp1.rawId < mp2.rawId;
+
+      if (mp1.quality != mp2.quality)
+        return mp1.quality > mp2.quality;
+
+      if (mp1.x != mp2.x)
+        return mp1.x < mp2.x;
+
+      if (mp1.tanPhi != mp2.tanPhi)
+        return mp1.tanPhi < mp2.tanPhi;
+
+      if (mp1.chi2 != mp2.chi2)
+        return mp1.chi2 < mp2.chi2;
+
+      return mp1.t0 < mp2.t0;
+    }
+  } const deepCompareMPs;
+
+  struct {
+    bool operator()(const metaPrimitive &mp1, const metaPrimitive &mp2) const {
+      // Use main characteristics to know if it is the same metaPrimitive
+      if (mp1.rawId != mp2.rawId || mp1.quality != mp2.quality || mp1.x != mp2.x || mp1.tanPhi != mp2.tanPhi ||
+          mp1.chi2 != mp2.chi2 || mp1.t0 != mp2.t0)
+        return false;
+      else
+        return true;
+    }
+  } const sameMPs;
+
 }  //namespace
 
 // ============================================================================
@@ -80,6 +119,13 @@ void MPThetaMatching::run(edm::Event &iEvent,
           << std::endl;
     outMPaths = inMPaths;  //no filter at all
   }
+
+  ///////////////////////////
+  // Filter out duplicates
+  // Sort by key so equal keys become adjacent
+  std::sort(outMPaths.begin(), outMPaths.end(), deepCompareMPs);
+  // Unique-erase adjacent duplicates
+  outMPaths.erase(std::unique(outMPaths.begin(), outMPaths.end(), sameMPs), outMPaths.end());
 }
 
 void MPThetaMatching::finish() {};

--- a/L1Trigger/DTTriggerPhase2/src/MPThetaMatching.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MPThetaMatching.cc
@@ -344,7 +344,7 @@ void MPThetaMatching::orderAndSave(std::vector<std::tuple<metaPrimitive, metaPri
 
     if ((abs(chId.wheel()) == 2 && chId.station() < 3 && count < th_option_ + 1) ||  //save an extra pair for WH+-2MB1/2
         count < th_option_) {
-      //std::get<0>(p).t0 = std::get<1>(p).t0;     //replace t0 by associated phi t0
+      //alternatively we could replace t0 by associated phi t0 std::get<0>(p).t0 = std::get<1>(p).t0;  
       outMPs->push_back(std::get<1>(p));         //add PhiMP
       outMPs->push_back(std::get<0>(p));         //add ThetaMP
       savedThetaMPs->push_back(std::get<0>(p));  //for accounting
@@ -358,7 +358,7 @@ void MPThetaMatching::orderAndSave(std::vector<std::tuple<metaPrimitive, metaPri
     DTChamberId chId(std::get<1>(p).rawId);
     if (count < th_option_ || (abs(chId.wheel()) == 2 && chId.station() < 3 && count < (th_option_ + 1))) {
       if (std::get<1>(p).quality > th_quality_) {
-        //std::get<0>(p).t0 = std::get<1>(p).t0;  //replace t0 by associated phi t0
+        //alternatively we could replace t0 by associated phi t0 std::get<0>(p).t0 = std::get<1>(p).t0;
         outMPs->push_back(std::get<0>(p));  //add ThetaMP
         savedThetaMPs->push_back(std::get<0>(p));
         count++;

--- a/L1Trigger/DTTriggerPhase2/src/MPThetaMatching.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MPThetaMatching.cc
@@ -344,7 +344,7 @@ void MPThetaMatching::orderAndSave(std::vector<std::tuple<metaPrimitive, metaPri
 
     if ((abs(chId.wheel()) == 2 && chId.station() < 3 && count < th_option_ + 1) ||  //save an extra pair for WH+-2MB1/2
         count < th_option_) {
-      //alternatively we could replace t0 by associated phi t0 std::get<0>(p).t0 = std::get<1>(p).t0;  
+      //alternatively we could replace t0 by associated phi t0 std::get<0>(p).t0 = std::get<1>(p).t0;
       outMPs->push_back(std::get<1>(p));         //add PhiMP
       outMPs->push_back(std::get<0>(p));         //add ThetaMP
       savedThetaMPs->push_back(std::get<0>(p));  //for accounting


### PR DESCRIPTION
#### PR description:

This PR implements recent changes with bug fixes and upgrades in the L1T DT Trigger Phase-2 emulator:

- Fix to DT Digis plugin from Karol Bunkowski ( @kbunkow ) which prevents crashes due to pointers to local variables stored in vectors, and then these vectors (so also the pointers) were used outside those methods 

- Removed t0 Phi replacement in theta Digis at the ThetaMatching filter to preserve original t0 for the Barrel Filter objects pairing

- New DataFormat collection for DT Phase Phi-Theta matched pairs L1Phase2MuDTExtPhiThetaPair and its container L1Phase2MuDTExtPhiThetaPairContainer to be used by the Phase2 Barrel Filter 

- Create new plugin DTTrigPhase2PairsProd which takes Phi and Theta DT Phase-2 digi Extended collections[1] and creates a new class container of the 4 best closest Phi-Theta digi pairs per DT chamber based on the time-position phase-space distance and ordered by Phi quality. For those cases where there is no Phi/Theta partner, 4 best quality single Phi/Theta digis are saved and counterpart in pair is set to default values of the constructor digi class (quality = -1, positions = 0). 
[1] Requires df_extended>0 in L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2Prod.cc

- Add DT Phase-2 Digi pair production to the standard L1 Trigger sequence

- Add DT Phase-2 Digi and Digi pair collections to the L1 Trigger default Event Content

- General cleaning of the code

[Link ](https://indico.cern.ch/event/1639762/#sc-2-35-dt-phi-theta-pair-matc)to the presentation in the Phase-2 L1T Muon Subsystem group meeting on 22/01/2026

#### PR validation:

Local validation within CMSSW and w.r.t. firmware (w.i.p.)
