### PR TITLE
Add pythia8 EGun producing HepMC3 event record

### DIFF
--- a/GeneratorInterface/Pythia8Interface/interface/Py8HMC3GunBase.h
+++ b/GeneratorInterface/Pythia8Interface/interface/Py8HMC3GunBase.h
@@ -1,0 +1,67 @@
+// -*- C++ -*-
+//
+//
+
+//
+// This class is a "Hadronizer" template (see GeneratorInterface/Core)
+//
+
+#ifndef gen_Py8HMC3GunBase_h
+#define gen_Py8HMC3GunBase_h
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "SimDataFormats/GeneratorProducts/interface/HepMC3Product.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct3.h"
+
+#include "GeneratorInterface/Pythia8Interface/interface/Py8HMC3InterfaceBase.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+
+#include <Pythia8/Pythia.h>
+#include <Pythia8Plugins/HepMC3.h>
+
+// foward declarations
+namespace edm {
+  class Event;
+}
+
+namespace CLHEP {
+  class HepRandomEngine;
+}
+
+namespace gen {
+
+  class Py8HMC3GunBase : public Py8HMC3InterfaceBase {
+  public:
+    Py8HMC3GunBase(edm::ParameterSet const& ps);
+    ~Py8HMC3GunBase() override {}
+
+    virtual bool residualDecay();  // common func
+    bool initializeForInternalPartons() override;
+    void finalizeEvent() override;
+    void statistics() override;
+
+    void setRandomEngine(CLHEP::HepRandomEngine* v) { p8SetRandomEngine(v); }
+    std::vector<std::string> const& sharedResources() const { return p8SharedResources; }
+    //void evtGenDecay();
+
+  protected:
+    // (some of) PGun parameters
+    //
+    std::vector<int> fPartIDs;
+    double fMinPhi;
+    double fMaxPhi;
+
+  private:
+    static const std::vector<std::string> p8SharedResources;
+  };
+
+}  // namespace gen
+
+#endif  // gen_Py8HMC3GunBase_h

--- a/GeneratorInterface/Pythia8Interface/src/Py8HMC3GunBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8HMC3GunBase.cc
@@ -1,0 +1,180 @@
+#include <memory>
+
+#include "GeneratorInterface/Pythia8Interface/interface/Py8HMC3GunBase.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Concurrency/interface/SharedResourceNames.h"
+
+#include "HepMC3/Print.h"
+
+// EvtGen plugin
+//
+//#include "Pythia8Plugins/EvtGen.h"
+
+using namespace Pythia8;
+
+const std::vector<std::string> gen::Py8HMC3GunBase::p8SharedResources = {edm::SharedResourceNames::kPythia8};
+
+namespace gen {
+
+  Py8HMC3GunBase::Py8HMC3GunBase(edm::ParameterSet const& ps) : Py8HMC3InterfaceBase(ps) {
+    // PGun specs
+    //
+    edm::ParameterSet pgun_params = ps.getParameter<edm::ParameterSet>("PGunParameters");
+
+    // although there's the method ParameterSet::empty(),
+    // it looks like it's NOT even necessary to check if it is,
+    // before trying to extract parameters - if it is empty,
+    // the default values seem to be taken
+    //
+    fPartIDs = pgun_params.getParameter<std::vector<int> >("ParticleID");
+    fMinPhi = pgun_params.getParameter<double>("MinPhi");  // ,-3.14159265358979323846);
+    fMaxPhi = pgun_params.getParameter<double>("MaxPhi");  // , 3.14159265358979323846);
+    ivhepmc = 3;
+  }
+
+  // specific to Py8GunHad !!!
+  //
+  bool Py8HMC3GunBase::initializeForInternalPartons() {
+    // NO MATTER what was this setting below, override it before init
+    // - this is essencial for the PGun mode
+
+    // Key requirement: switch off ProcessLevel, and thereby also PartonLevel.
+    fMasterGen->readString("ProcessLevel:all = off");
+    fMasterGen->readString("ProcessLevel::resonanceDecays=on");
+    fMasterGen->init();
+
+    // init decayer
+    fDecayer->readString("ProcessLevel:all = off");  // Same trick!
+    fDecayer->readString("ProcessLevel::resonanceDecays=on");
+    fDecayer->init();
+
+#if 0
+    if (useEvtGen) {
+      edm::LogInfo("Pythia8Interface") << "Creating and initializing pythia8 EvtGen plugin";
+      evtgenDecays = std::make_shared<EvtGenDecays>(fMasterGen.get(), evtgenDecFile, evtgenPdlFile);
+      for (unsigned int i = 0; i < evtgenUserFiles.size(); i++)
+        evtgenDecays->readDecayFile(evtgenUserFiles.at(i));
+    }
+#endif
+
+    return true;
+  }
+
+  bool Py8HMC3GunBase::residualDecay() {
+    Event* pythiaEvent = &(fMasterGen->event);
+
+    int NPartsBeforeDecays = pythiaEvent->size() - 1;  // do NOT count the very 1st "system" particle
+                                                       // in Pythia8::Event record; it does NOT even
+                                                       // get translated by the HepMCInterface to the
+                                                       // HepMC::GenEvent record !!!
+    int NPartsAfterDecays = ((event3().get())->particles()).size();
+
+    if (NPartsAfterDecays == NPartsBeforeDecays)
+      return true;
+
+    bool result = true;
+
+    for (const auto &p : (event3().get())->particles()) {
+      if (p->id() > NPartsBeforeDecays) {
+        if (p->status() == 1 && (fDecayer->particleData).canDecay(p->pid())) {
+          fDecayer->event.reset();
+          Particle py8part(p->pid(),
+                         93,
+                         0,
+                         0,
+                         0,
+                         0,
+                         0,
+                         0,
+                         p->momentum().x(),
+                         p->momentum().y(),
+                         p->momentum().z(),
+                         p->momentum().t(),
+                         p->generated_mass());
+
+          py8part.vProd(p->production_vertex()->position().x(),
+                        p->production_vertex()->position().y(),
+                        p->production_vertex()->position().z(),
+                        p->production_vertex()->position().t());
+
+          py8part.tau((fDecayer->particleData).tau0(p->pid()));
+          fDecayer->event.append(py8part);
+          int nentries = fDecayer->event.size();
+          if (!fDecayer->event[nentries - 1].mayDecay())
+            continue;
+          result = fDecayer->next();
+          int nentries1 = fDecayer->event.size();
+          if (nentries1 <= nentries)
+            continue;  //same number of particles, no decays...
+
+          p->set_status(2);
+
+          HepMC3::GenVertexPtr prod_vtx0 = make_shared<HepMC3::GenVertex>(  // neglect particle path to decay
+              HepMC3::FourVector(p->production_vertex()->position().x(),
+                                 p->production_vertex()->position().y(),
+                                 p->production_vertex()->position().z(),
+                                 p->production_vertex()->position().t()));
+          prod_vtx0->add_particle_in(p);
+          (event3().get())->add_vertex(prod_vtx0);
+          Pythia8::Event pyev = fDecayer->event;
+          double momFac = 1.;
+          for (int i = 2; i < pyev.size(); ++i) {
+            // Fill the particle.
+            HepMC3::GenParticlePtr pnew = make_shared<HepMC3::GenParticle>(
+                HepMC3::FourVector(
+                    momFac * pyev[i].px(), momFac * pyev[i].py(), momFac * pyev[i].pz(), momFac * pyev[i].e()),
+                pyev[i].id(),
+                pyev[i].statusHepMC());
+            pnew->set_generated_mass(momFac * pyev[i].m());
+            prod_vtx0->add_particle_out(pnew);
+          }
+        }
+      }
+    }
+
+    return result;
+  }
+
+  void Py8HMC3GunBase::finalizeEvent() {
+    //******** Verbosity ********
+
+    if (maxEventsToPrint > 0 && (pythiaPylistVerbosity || pythiaHepMCVerbosity || pythiaHepMCVerbosityParticles)) {
+      maxEventsToPrint--;
+      if (pythiaPylistVerbosity) {
+        fMasterGen->info.list();
+        fMasterGen->event.list();
+      }
+
+      if (pythiaHepMCVerbosity) {
+        std::cout << "Event process = " << fMasterGen->info.code() << "\n"
+                  << "----------------------" << std::endl;
+        HepMC3::Print::listing(*(event3().get()));
+      }
+      if (pythiaHepMCVerbosityParticles) {
+        std::cout << "Event process = " << fMasterGen->info.code() << "\n"
+                  << "----------------------" << std::endl;
+        for (const auto &p : (event3().get())->particles()) {
+          HepMC3::Print::line(p, true);
+        }
+      }
+    }
+    return;
+  }
+
+  void Py8HMC3GunBase::statistics() {
+    fMasterGen->stat();
+
+    double xsec = fMasterGen->info.sigmaGen();  // cross section in mb
+    xsec *= 1.0e9;                              // translate to pb (CMS/Gen "convention" as of May 2009)
+    runInfo().setInternalXSec(xsec);
+    return;
+  }
+
+#if 0
+  void Py8HMC3GunBase::evtGenDecay() {
+    if (evtgenDecays.get())
+      evtgenDecays->decay();
+  }
+#endif
+
+}  // namespace gen

--- a/GeneratorInterface/Pythia8Interface/src/Py8HMC3GunBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8HMC3GunBase.cc
@@ -74,23 +74,23 @@ namespace gen {
 
     bool result = true;
 
-    for (const auto &p : (event3().get())->particles()) {
+    for (const auto& p : (event3().get())->particles()) {
       if (p->id() > NPartsBeforeDecays) {
         if (p->status() == 1 && (fDecayer->particleData).canDecay(p->pid())) {
           fDecayer->event.reset();
           Particle py8part(p->pid(),
-                         93,
-                         0,
-                         0,
-                         0,
-                         0,
-                         0,
-                         0,
-                         p->momentum().x(),
-                         p->momentum().y(),
-                         p->momentum().z(),
-                         p->momentum().t(),
-                         p->generated_mass());
+                           93,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           p->momentum().x(),
+                           p->momentum().y(),
+                           p->momentum().z(),
+                           p->momentum().t(),
+                           p->generated_mass());
 
           py8part.vProd(p->production_vertex()->position().x(),
                         p->production_vertex()->position().y(),
@@ -153,7 +153,7 @@ namespace gen {
       if (pythiaHepMCVerbosityParticles) {
         std::cout << "Event process = " << fMasterGen->info.code() << "\n"
                   << "----------------------" << std::endl;
-        for (const auto &p : (event3().get())->particles()) {
+        for (const auto& p : (event3().get())->particles()) {
           HepMC3::Print::line(p, true);
         }
       }

--- a/GeneratorInterface/Pythia8Interface/test/Py8EGun_Z2tau_Tauola_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/Py8EGun_Z2tau_Tauola_cfg.py
@@ -24,13 +24,26 @@ process.generator = cms.EDFilter("Pythia8EGun",
        MinEta = cms.double(0.0),
        MaxEta = cms.double(2.4)
     ),
+        
+    ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+	     UseTauolaPolarization = cms.bool(True),
+	     InputCards = cms.PSet
+	     ( 
+	        pjak1 = cms.int32(0), # 1 = electron mode
+		pjak2 = cms.int32(0), # 2 = muon mode
+		mdtau = cms.int32(240)  # (any) tau -> nu pi+- 
+	     )
+	),
+        parameterSets = cms.vstring('Tauola')
+    ),
 
     PythiaParameters = cms.PSet(
 	py8ZDecaySettings = cms.vstring(  '23:onMode = off', # turn OFF all Z decays
 					  '23:onIfAny = 15'  # turn ON Z->tautau
 	),
-        parameterSets = cms.vstring(
-	                              'py8ZDecaySettings'
+        parameterSets = cms.vstring(  
+	                              'py8ZDecaySettings' 
 				   )
     )
 )

--- a/GeneratorInterface/Pythia8Interface/test/Py8hmc3EGun_Z2tau_G4_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/Py8hmc3EGun_Z2tau_G4_cfg.py
@@ -1,0 +1,141 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('SIM')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.Geometry.GeometrySimDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic8TeVCollision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring(),
+    accelerators = cms.untracked.vstring('*'),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
+    dumpOptions = cms.untracked.bool(False),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(0)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(0),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('TTbar_8TeV_TuneCUETP8M1_cfi nevts:10'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+#        SelectEvents = cms.vstring('generation_step')
+    ),
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(1),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('GEN-SIM'),
+        filterName = cms.untracked.string('')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(20971520),
+    fileName = cms.untracked.string('file:pythia8hmc3G4.root'),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run1_mc', '')
+
+process.generator = cms.EDFilter("Pythia8HepMC3EGun",
+
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(True),
+    pythiaHepMCVerbosityParticles = cms.untracked.bool(True),
+
+    PGunParameters = cms.PSet(
+       ParticleID = cms.vint32(23),
+       AddAntiParticle = cms.bool(True),
+       MinPhi = cms.double(-3.14159265359),
+       MaxPhi = cms.double(3.14159265359),
+       MinE = cms.double(100.0),
+       MaxE = cms.double(200.0),
+       MinEta = cms.double(0.0),
+       MaxEta = cms.double(2.4)
+    ),
+
+    PythiaParameters = cms.PSet(
+        py8ZDecaySettings = cms.vstring(  '23:onMode = off', # turn OFF all Z decays
+                                          '23:onIfAny = 15'  # turn ON Z->tautau
+        ),
+	parameterSets = cms.vstring(
+                                      'py8ZDecaySettings'
+                                   )
+    )
+)
+
+process.ProductionFilterSequence = cms.Sequence(process.generator)
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen)
+process.simulation_step = cms.Path(process.psim)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RAWSIMoutput_step = cms.EndPath(process.RAWSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.simulation_step,process.endjob_step,process.RAWSIMoutput_step)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+# filter all path with the production filter sequence
+for path in process.paths:
+	getattr(process,path).insert(0, process.ProductionFilterSequence)
+
+
+
+# Customisation from command line
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion

--- a/GeneratorInterface/Pythia8Interface/test/Py8hmc3EGun_Z2tau_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/Py8hmc3EGun_Z2tau_cfg.py
@@ -7,7 +7,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 process.source = cms.Source("EmptySource")
 
-process.generator = cms.EDFilter("Pythia8EGun",
+process.generator = cms.EDFilter("Pythia8HepMC3EGun",
 
     maxEventsToPrint = cms.untracked.int32(1),
     pythiaPylistVerbosity = cms.untracked.int32(1),


### PR DESCRIPTION
#### PR description:

 Added a pythia8 EGun similar to the existing EGun, but producing HepMC3 products.
 EGun testing configurations in /test added. The gun with tau decays by tauola is remained, the gun with tau decays by pythia8 is added. The corresponding configurations with HepMC3 interface and with a SIM step are added.

#### PR validation:

 Validated using the added test configurations