### PR TITLE
Evolve `auto_ptr<gen::PdfInfo>`-to-`unique_ptr` read rules to avoid `std::auto_ptr`

### DIFF
--- a/SimDataFormats/GeneratorProducts/src/classes.h
+++ b/SimDataFormats/GeneratorProducts/src/classes.h
@@ -39,3 +39,19 @@ namespace hepmc_rootio {
     }
   }
 }  // namespace hepmc_rootio
+
+// needed for backwards compatibility for auto_ptr<gen::PdfInfo>
+namespace pdfinfo_autoptr_rootio {
+  // Following the pattern in DataFormats/TestObjects/src/classes.h
+  template <typename T>
+  struct deprecated_auto_ptr {
+    // We use compat_auto_ptr only to assign the wrapped raw pointer
+    // to a unique pointer in an I/O customization rule.
+    // Therefore, we don't delete on destruction (because ownership
+    // gets transferred to the unique pointer).
+
+    // ~deprecated_auto_ptr() { delete _M_ptr; }
+
+    T* _M_ptr = nullptr;
+  };
+}  // namespace pdfinfo_autoptr_rootio

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -241,7 +241,7 @@
   <version ClassVersion="14" checksum="905719452"/>
   <version ClassVersion="15" checksum="898288635"/>
  </class>
- <ioread sourceClass = "LHEEventProduct" version="[13]" targetClass="LHEEventProduct" source = "std::auto_ptr<gen::PdfInfo> pdf_;" target="pdf_">
+ <ioread sourceClass = "LHEEventProduct" version="[-13]" targetClass="LHEEventProduct" source = "std::auto_ptr<gen::PdfInfo> pdf_;" target="pdf_">
    <![CDATA[pdf_.reset(onfile.pdf_.get()); onfile.pdf_.release();]]>
  </ioread> 
  <ioread sourceClass = "LHEEventProduct" version="[-12]" targetClass="LHEEventProduct" source = "" target="npLO_">

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -121,7 +121,8 @@
         <class name="gen::PdfInfo" ClassVersion="10">
   <version ClassVersion="10" checksum="876888052"/>
  </class>
-        <class name="std::auto_ptr&lt;gen::PdfInfo&gt;"/>
+        <class name="pdfinfo_autoptr_rootio::deprecated_auto_ptr<gen::PdfInfo>"/>
+        <ioread sourceClass="std::auto_ptr<gen::PdfInfo>" targetClass="pdfinfo_autoptr_rootio::deprecated_auto_ptr<gen::PdfInfo>"/>
 
 	<!-- GenRunInfoProduct -->
 
@@ -193,8 +194,8 @@
   <version ClassVersion="11" checksum="4154339631"/>
   <version ClassVersion="10" checksum="2479857328"/>
  </class>
- <ioread sourceClass = "GenEventInfoProduct" version="[-11]" targetClass="GenEventInfoProduct" source = "std::auto_ptr<gen::PdfInfo> pdf_;" target="pdf_">
-   <![CDATA[pdf_.reset(onfile.pdf_.get()); onfile.pdf_.release();]]>
+ <ioread sourceClass = "GenEventInfoProduct" version="[-11]" targetClass="GenEventInfoProduct" source = "pdfinfo_autoptr_rootio::deprecated_auto_ptr<gen::PdfInfo> pdf_;" target="pdf_">
+   <![CDATA[pdf_.reset(onfile.pdf_._M_ptr); onfile.pdf_._M_ptr = nullptr;]]>
  </ioread>
  <ioread sourceClass = "GenEventInfoProduct" version="[-10]" targetClass="GenEventInfoProduct" source = "" target="nMEPartons_">
     <![CDATA[nMEPartons_ = -1;]]>
@@ -241,8 +242,8 @@
   <version ClassVersion="14" checksum="905719452"/>
   <version ClassVersion="15" checksum="898288635"/>
  </class>
- <ioread sourceClass = "LHEEventProduct" version="[-13]" targetClass="LHEEventProduct" source = "std::auto_ptr<gen::PdfInfo> pdf_;" target="pdf_">
-   <![CDATA[pdf_.reset(onfile.pdf_.get()); onfile.pdf_.release();]]>
+ <ioread sourceClass = "LHEEventProduct" version="[-13]" targetClass="LHEEventProduct" source = "pdfinfo_autoptr_rootio::deprecated_auto_ptr<gen::PdfInfo> pdf_;" target="pdf_">
+   <![CDATA[pdf_.reset(onfile.pdf_._M_ptr); onfile.pdf_._M_ptr = nullptr;]]>
  </ioread> 
  <ioread sourceClass = "LHEEventProduct" version="[-12]" targetClass="LHEEventProduct" source = "" target="npLO_">
     <![CDATA[npLO_ = -99;]]>


### PR DESCRIPTION
#### PR description:

This PR applies the ROOT schema evolution pattern that avoids the use of `std::auto_ptr` (that was formally removed in C++17), for which a test was developed in https://github.com/cms-sw/cmssw/pull/48817, to the `std::auto_ptr<gen::PdfInfo>` -to-`std::unique_ptr<gen::PdfInfo>` read rules for `GenEventInfoProduct` and `LHEEventProduct`.

In addition, the first commit fixes the `LHEEventProduct` read rule to include all versions before `13` (that came up in https://github.com/cms-sw/cmssw/issues/49538). I included it here to because I had to touch the same line in `classes_def.xml`, and doing that change first makes the backporting easier.

Fixes https://github.com/cms-sw/cmssw/issues/43422
Fixes https://github.com/cms-sw/cmssw/issues/43923
Resolves https://github.com/cms-sw/framework-team/issues/1538
Resolves https://github.com/cms-sw/framework-team/issues/1714

#### PR validation:

Code  compiles, and the deprecation warnings along
```
>> Compiling scram_x86-64-v2 LCG dictionary: tmp/el8_amd64_gcc13/src/SimDataFormats/GeneratorProducts/src/SimDataFormatsGeneratorProducts/lcgdict/SimDataFormatsGeneratorProducts_xr.cc
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/c++ -MMD -MF tmp/el8_amd64_gcc13/src/SimDataFormats/GeneratorProducts/src/SimDataFormatsGeneratorProducts/scram_x86-64-v2/lcgdict/SimDataFormatsGeneratorProducts_xr.cc.d -I. -c -DCMS_MICRO_ARCH='x86-64-v2' -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=130400 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DBOOST_MPL_IGNORE_PARENTHESES_WARNING -DCMSSW_GIT_HASH='CMSSW_16_0_X_2025-12-09-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_16_0_X_2025-12-09-2300' -Isrc -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc13/external/pcre/8.43-6d98fda3bfd074ebb583e2d6a2c75d25/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc13/external/boost/1.80.0-6fb83b2bac2398768f2cc6374a639c37/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc13/external/bz2lib/1.0.6-d113e1c6278c07eeaff5f84db9548446/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc13/external/hepmc/2.06.10-903e23142392c852f3df97c32fbd4659/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc13/external/libuuid/2.34-5ba7a8abfc0c5fecdc448cca360c25ff/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc13/lcg/root/6.36.07-0490e78b33943d48f9af1c19441a9d2e/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc13/external/tbb/v2022.3.0-54089f7aad511dfcd272d65c5ee4b3ab/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc13/external/xz/5.6.4-b9c4ffbc390ed320a5d57fd552e29a05/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc13/external/zlib/1.2.13-589f6bb51bbeba38a7adf5a10ea8a093/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc13/external/hepmc3/3.2.7-f8f0da18d94695d72ff740910e834c9f/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc13/external/md5/1.0.0-26057075013e190e56dad37d35219376/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc13/external/tinyxml2/6.2.0-67924ead96ecb4e69aad321b767979a5/include -DCMSSW_REFLEX_DICT -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++20 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS -Os -Wno-unused-variable -march=x86-64-v2 -flto=auto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr  -fPIC  tmp/el8_amd64_gcc13/src/SimDataFormats/GeneratorProducts/src/SimDataFormatsGeneratorProducts/lcgdict/SimDataFormatsGeneratorProducts_xr.cc -o tmp/el8_amd64_gcc13/src/SimDataFormats/GeneratorProducts/src/SimDataFormatsGeneratorProducts/scram_x86-64-v2/lcgdict/SimDataFormatsGeneratorProducts_xr.cc.o
  tmp/el8_amd64_gcc13/src/SimDataFormats/GeneratorProducts/src/SimDataFormatsGeneratorProducts/lcgdict/SimDataFormatsGeneratorProducts_xr.cc:234:62: warning: 'template<class> class std::auto_ptr' is deprecated: use 'std::unique_ptr' instead [-Wdeprecated-declarations]
   234 |    static TGenericClassInfo *GenerateInitInstanceLocal(const auto_ptr<gen::PdfInfo>*)
      |                                                              ^~~~~~~~
```
are gone. Testing of the actual behavior relies of the test of the pattern added in https://github.com/cms-sw/cmssw/pull/48817, and in existing tests (including runTheMatrix) in PR and IB tests.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

The first commit will be backported (at least down to 15_0_X).