### PR TITLE
[HGCAL] Update SiPM typecode regex to support optional suffix

### DIFF
--- a/Geometry/HGCalMapping/plugins/HGCalMappingESProducer.cc
+++ b/Geometry/HGCalMapping/plugins/HGCalMappingESProducer.cc
@@ -111,7 +111,7 @@ void HGCalMappingESProducer::prepareModuleMapperIndexer() {
     if (matched) {
       wtypecode = typecode_match[1].str();  // wafer type following MM-T pattern, e.g. "MH-F"
     } else {
-      const std::regex sipm_typecode_regex(R"(T[LH]-L\d{2}S\d)");
+      const std::regex sipm_typecode_regex(R"(^T(.*)-L([0-9]+)S([0-9]+)(?:-(.*))?$)");
       std::smatch sipm_typecode_match;  // match object for string objects
       matched = std::regex_match(typecode, sipm_typecode_match, sipm_typecode_regex);
       if (matched) {


### PR DESCRIPTION
#### PR description:
This PR updates the format of the HGCAL tileboard typecode.

The regular expression for parsing SIPM typecode is updated to correctly handle the tileboard naming pattern (e.g., "TL-L44S1" format with optional series number).

#### PR validation:
Tested with TB2025 and FNAL data using tile boards in the silicon system.
- TB2025: run=112157, era=TB2025/v7
- FNAL: run=30000129, era=FNAL/v4

The runtime error "unable to find typecode=TL-L44S1-TB2025" is now resolved.
cmsRun completes successfully for both test cases.

Related to https://github.com/CMS-HGCAL/cmssw/pull/197