### PR TITLE
Add MIPs sum and noise quadratic sum to HGCAL calibration cell handler

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationAlgorithms.dev.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationAlgorithms.dev.cc
@@ -181,7 +181,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
         recHits[idx + offset].energy() += (negative_energy_correction + recHits[idx].energy());
         recHits[idx + offset].mipEnergy() += (negative_mipEnergy_correction + recHits[idx].mipEnergy());
-        float quadratic_noise_sum = sqrt(recHits[idx].sigmaNoise()*recHits[idx].sigmaNoise() + recHits[idx + offset].sigmaNoise()*recHits[idx + offset].sigmaNoise());
+        float quadratic_noise_sum = sqrt(recHits[idx].sigmaNoise() * recHits[idx].sigmaNoise() +
+                                         recHits[idx + offset].sigmaNoise() * recHits[idx + offset].sigmaNoise());
         recHits[idx + offset].sigmaNoise() = quadratic_noise_sum;
       }
     }

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationAlgorithms.dev.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationAlgorithms.dev.cc
@@ -177,8 +177,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
         bool is_negative_surr_energy(recHits[idx + offset].energy() < 0);
         auto negative_energy_correction = (-1.0 * recHits[idx + offset].energy()) * is_negative_surr_energy;
+        auto negative_mipEnergy_correction = (-1.0 * recHits[idx + offset].mipEnergy()) * is_negative_surr_energy;
 
         recHits[idx + offset].energy() += (negative_energy_correction + recHits[idx].energy());
+        recHits[idx + offset].mipEnergy() += (negative_mipEnergy_correction + recHits[idx].mipEnergy());
+        float quadratic_noise_sum = sqrt(recHits[idx].sigmaNoise()*recHits[idx].sigmaNoise() + recHits[idx + offset].sigmaNoise()*recHits[idx + offset].sigmaNoise());
+        recHits[idx + offset].sigmaNoise() = quadratic_noise_sum;
       }
     }
   };


### PR DESCRIPTION
#### PR description:

The kernel `handleCalibCell` performs the energy sum and the weighted timing average of rechits in calibration and surrounding cells in HGCAL Si sensors. This PR adds:
- the sum operation for the energy expressed in number of MIPs;
- the sum in quadrature of the noise between calibration and surrounding cells.

#### PR validation:

Validated with some private tests using the [hgcal-comm](https://gitlab.cern.ch/hgcal-dpg/hgcal-comm) package, ~~as this piece of code isn't currently exercised by any CMSSW workflow~~ (this is not true anymore). In any case, this PR builds on top of PR #47829 and only adds similar, straightforward sum operations.

@pfs @fabio-mon
