### PR TITLE
[14_0_X] Extend MC list in prunedGenParticles for HIN analyses

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
@@ -47,3 +47,6 @@ prunedGenParticles = cms.EDProducer("GenParticlePruner",
         "keep isHardProcess() || fromHardProcessFinalState() || fromHardProcessDecayed() || fromHardProcessBeforeFSR() || (statusFlags().fromHardProcess() && statusFlags().isLastCopy())",  #keep event summary based on status flags
     )
 )
+
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+pp_on_AA.toModify(prunedGenParticles.select, func = lambda list: list.append('keep++ abs(pdgId) == 9920443 || abs(pdgId) == 20443 || abs(pdgId) == 511'))


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/49561

@Legoinha

The ppRef_2024 era change had to be removed in this backport because this era modifier does not exist in this release.

#### PR validation:

Tested with relval 160