### PR TITLE
Fix HGCAL EM scale factor application

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationESProducer.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationESProducer.cc
@@ -4,6 +4,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 // includes for Alpaka
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESGetToken.h"
@@ -190,11 +191,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           edm::LogInfo("HGCalCalibrationESProducer")
               << "layer = " << layer << ", celltype = " << celltype << ", isSiPM = " << isSiPM << ", dEdx = " << dEdx
               << ", sf_from_config = " << sf_from_config << std::endl;
-          float sf = (sf_from_config > 0 ? 1. / sf_from_config : 1.);
-          edm::LogWarning("HGCalCalibrationESProducer")
-              << "EM reconstruction scale factor (SF_thickness_Si) is not positive. Using 1 instead.\n"
-              << "SF_thickness_Si = " << sf_from_config << std::endl;
+          if (sf_from_config <= 0)
+            throw cms::Exception("ConfigError") << "EM reconstruction scale factor (SF_thickness_Si) is not positive.";
 
+          float sf = 1. / sf_from_config;
           dEdx *= sf * 1e-3;  // apply correction and convert from MeV to GeV
           fill_SoA_column_single<float>(product.view().EM_scale().data(), dEdx, offset, nrows);
 

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationESProducer.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationESProducer.cc
@@ -185,15 +185,16 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           if (isSiPM)  // scintillator
             sf_from_config = energy_data["SF_thickness_SiPM"][0];
           else  // Si module
-            sf_from_config = getThicknessCorrection(energy_data["SF_thickness_Si"], detid, celltype, filenameEnergy_.fullPath());
+            sf_from_config =
+                getThicknessCorrection(energy_data["SF_thickness_Si"], detid, celltype, filenameEnergy_.fullPath());
           edm::LogInfo("HGCalCalibrationESProducer")
               << "layer = " << layer << ", celltype = " << celltype << ", isSiPM = " << isSiPM << ", dEdx = " << dEdx
               << ", sf_from_config = " << sf_from_config << std::endl;
-	  float sf = (sf_from_config > 0 ? 1./sf_from_config : 1.);
-	  edm::LogWarning("HGCalCalibrationESProducer")
-	    << "EM reconstruction scale factor (SF_thickness_Si) is not positive\n"
-	    << "SF_thickness_Si = " << sf_from_config << std::endl; 
-  
+          float sf = (sf_from_config > 0 ? 1. / sf_from_config : 1.);
+          edm::LogWarning("HGCalCalibrationESProducer")
+              << "EM reconstruction scale factor (SF_thickness_Si) is not positive. Using 1 instead.\n"
+              << "SF_thickness_Si = " << sf_from_config << std::endl;
+
           dEdx *= sf * 1e-3;  // apply correction and convert from MeV to GeV
           fill_SoA_column_single<float>(product.view().EM_scale().data(), dEdx, offset, nrows);
 


### PR DESCRIPTION
#### PR description:

This PR:
- fixes a bug in the calibration of the HGCAL RecHits, for which a scale factor obtained from config file was used directly as a multiplicative factor, whereas its reciprocal should be used;
- throws an exception if the SF from config is not positive;
- removes an unnecessary averaging over consecutive dEdx values (still taken from the same config file), since they are provided already averaged.

#### PR validation:

Validated by reprocessing 2025 HGCAL test beam data. The results we obtain are as expected.

@fabio-mon @pfs 
