### PR TITLE
[NGT] Add MC truth labels support to NanoAOD `reco::Track`s and introduce PixelTracks+RecHits ntuples

### DIFF
--- a/HLTrigger/NGTScouting/plugins/HLTTracksRecHitsTableProducer.cc
+++ b/HLTrigger/NGTScouting/plugins/HLTTracksRecHitsTableProducer.cc
@@ -1,0 +1,124 @@
+/**  \class HLTTracksRecHitsTableProducer
+ *
+ *   \brief Produces a nanoAOD flat table with recHits information for HLT tracks
+ *
+ *   This producer creates a nanoAOD flat table containing the recHits global positions and errors
+ *   starting from a collection of reco::Track.
+ *   This data can be added as an extension to the HLTTracks table.
+ *   The maximum number of recHits per track is fixed to a configurable value;
+ *   if a track has more recHits, a warning is issued and the extra recHits are ignored.
+ *
+ *   \author Luca Ferragina (INFN BO), 2025
+ */
+
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+class HLTTracksRecHitsTableProducer : public edm::stream::EDProducer<> {
+public:
+  explicit HLTTracksRecHitsTableProducer(const edm::ParameterSet&);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  const edm::EDGetTokenT<std::vector<reco::Track>> tracks_;
+
+  const std::string tableName_;
+  const unsigned int maxRecHits_;
+  const unsigned int precision_;
+  const bool skipNonExistingSrc_;
+};
+
+HLTTracksRecHitsTableProducer::HLTTracksRecHitsTableProducer(const edm::ParameterSet& params)
+    : tracks_(consumes<std::vector<reco::Track>>(params.getParameter<edm::InputTag>("tracksSrc"))),
+      tableName_(params.getParameter<std::string>("tableName")),
+      maxRecHits_(params.getParameter<uint>("maxRecHits")),
+      precision_(params.getParameter<int>("precision")),
+      skipNonExistingSrc_(params.getParameter<bool>("skipNonExistingSrc")) {
+  produces<nanoaod::FlatTable>(tableName_);
+}
+
+void HLTTracksRecHitsTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  auto tracksIn = iEvent.getHandle(tracks_);
+  const size_t nTracks = tracksIn.isValid() ? (*tracksIn).size() : 0;
+
+  static constexpr float default_value = std::numeric_limits<float>::quiet_NaN();
+
+  std::vector<float> globalX(maxRecHits_ * nTracks, default_value);
+  std::vector<float> globalY(maxRecHits_ * nTracks, default_value);
+  std::vector<float> globalZ(maxRecHits_ * nTracks, default_value);
+  std::vector<float> globalErrX(maxRecHits_ * nTracks, default_value);
+  std::vector<float> globalErrY(maxRecHits_ * nTracks, default_value);
+  std::vector<float> globalErrZ(maxRecHits_ * nTracks, default_value);
+
+  if (tracksIn.isValid() || !(this->skipNonExistingSrc_)) {
+    const auto& tracks = *tracksIn;
+    for (size_t tkIndex = 0; tkIndex < nTracks; ++tkIndex) {
+      const auto& track = tracks[tkIndex];
+      for (auto it = track.recHitsBegin(); it != track.recHitsEnd(); ++it) {
+        auto hit = *it;
+        auto globalPoint = hit->globalPosition();
+        auto globalError = hit->globalPositionError();
+        auto hitIndex = std::distance(track.recHitsBegin(), it);
+        if (hitIndex >= maxRecHits_) {
+          edm::LogWarning("HLTTracksRecHitsTableProducer")
+              << " Track " << tkIndex << " has more (" << track.recHitsSize() << ") than " << maxRecHits_
+              << " recHits, skipping the rest.";
+          break;
+        }
+        globalX[tkIndex * maxRecHits_ + hitIndex] = globalPoint.x();
+        globalY[tkIndex * maxRecHits_ + hitIndex] = globalPoint.y();
+        globalZ[tkIndex * maxRecHits_ + hitIndex] = globalPoint.z();
+        globalErrX[tkIndex * maxRecHits_ + hitIndex] = globalError.cxx();
+        globalErrY[tkIndex * maxRecHits_ + hitIndex] = globalError.cyy();
+        globalErrZ[tkIndex * maxRecHits_ + hitIndex] = globalError.czz();
+      }
+    }
+  } else {
+    edm::LogWarning("HLTTracksRecHitsTableProducer")
+        << " Invalid handle for " << tableName_ << " in tracks input collection";
+  }
+
+  assert(globalX.size() == globalY.size() && globalX.size() == globalZ.size() && globalX.size() == globalErrX.size() &&
+         globalX.size() == globalErrY.size() && globalX.size() == globalErrZ.size());
+
+  // Table for tracks recHits
+  auto tracksTable =
+      std::make_unique<nanoaod::FlatTable>(nTracks * maxRecHits_, tableName_, /*singleton*/ false, /*extension*/ false);
+  tracksTable->addColumn<float>("globalX", globalX, "RecHits global x coordinate", precision_);
+  tracksTable->addColumn<float>("globalY", globalY, "RecHits global y coordinate", precision_);
+  tracksTable->addColumn<float>("globalZ", globalZ, "RecHits global z coordinate", precision_);
+  tracksTable->addColumn<float>("globalErrX", globalErrX, "RecHits global x error", precision_);
+  tracksTable->addColumn<float>("globalErrY", globalErrY, "RecHits global y error", precision_);
+  tracksTable->addColumn<float>("globalErrZ", globalErrZ, "RecHits global z error", precision_);
+
+  iEvent.put(std::move(tracksTable), tableName_);
+}
+
+void HLTTracksRecHitsTableProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<uint>("maxRecHits", 16)->setComment("maximum number of recHits per track to be stored in the table");
+  desc.add<bool>("skipNonExistingSrc", false)
+      ->setComment("whether or not to skip producing the table on absent input product");
+  desc.add<std::string>("tableName")->setComment("name of the flat table ouput");
+  desc.add<edm::InputTag>("tracksSrc")->setComment("std::vector<reco::Track> input collection");
+  desc.add<int>("precision", 7);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+// Define this as a plug-in
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(HLTTracksRecHitsTableProducer);

--- a/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
+++ b/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
@@ -77,8 +77,10 @@ NanoHGCalTables = cms.Sequence(
 
 # Store PixelTracks objects
 NanoPixelTables = cms.Sequence(
-    hltPixelTrackTable
+    pixelTrackAssoc
+    + hltPixelTrackTable
     + hltPixelTrackExtTable
+    + hltPixelTrackRecHitsTable
 )
 
 # Store variables and associators for validation purposes
@@ -122,6 +124,12 @@ hltValidationNanoFlavour = cms.Sequence(
     + NanoPixelTables
     + NanoHGCalTables
     + NanoValTables
+)
+
+# Phase-2 HLT Nano flavour for pixel tracking validation / optimization
+hltPixelOnlyNanoFlavour = cms.Sequence(
+    NanoGenTables
+    + NanoPixelTables
 )
 
 ######################################

--- a/HLTrigger/NGTScouting/python/hltTracks_cfi.py
+++ b/HLTrigger/NGTScouting/python/hltTracks_cfi.py
@@ -1,6 +1,37 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
 
+from PhysicsTools.NanoAOD.trackingAssocValueMapsProducer_cfi import trackingAssocValueMapsProducer
+
+tpSelectorPixelTracks = cms.PSet(
+    lip = cms.double(30.0),
+    chargedOnly = cms.bool(True),
+    stableOnly = cms.bool(False),
+    pdgId = cms.vint32(),
+    signalOnly = cms.bool(False),
+    intimeOnly = cms.bool(True),
+    minRapidity = cms.double(-4.5),
+    minHit = cms.int32(0),
+    ptMin = cms.double(0.9),
+    ptMax = cms.double(1e100),
+    maxRapidity = cms.double(4.5),
+    tip = cms.double(2.5),
+    invertRapidityCut = cms.bool(False),
+    minPhi = cms.double(-3.2),
+    maxPhi = cms.double(3.2),
+)
+
+pixelTrackAssoc = trackingAssocValueMapsProducer.clone(
+    trackCollection =  cms.InputTag("hltPhase2PixelTracks"),
+    associator = cms.InputTag("hltTrackAssociatorByHits"),
+    trackingParticles = cms.InputTag("mix", "MergedTrackTruth"),
+    tpSelectorPSet = tpSelectorPixelTracks,
+    storeTPKinematics = cms.bool(True),
+)
+
+from Configuration.ProcessModifiers.phase2CAExtension_cff import phase2CAExtension
+phase2CAExtension.toModify(pixelTrackAssoc, trackCollection = "hltPhase2PixelTracksCAExtension")
+
 hltPixelTrackTable = cms.EDProducer(
     "SimpleTriggerTrackFlatTableProducer",
     skipNonExistingSrc = cms.bool(True),
@@ -8,7 +39,6 @@ hltPixelTrackTable = cms.EDProducer(
     cut = cms.string(""),
     name = cms.string("hltPixelTrack"),
     doc = cms.string("HLT Pixel Track information"),
-    extension = cms.bool(False),
     variables = cms.PSet(
         pt = Var("pt()", "float", doc = "p_T (GeV)"),
         eta = Var("eta()", "float", doc = "#eta"),
@@ -29,6 +59,37 @@ hltPixelTrackTable = cms.EDProducer(
         #isLoose = Var("quality('loose')", "bool", doc = "Loose track flag"),
         isTight = Var("quality('tight')", "bool", doc = "Tight track flag"),
         isHighPurity = Var("quality('highPurity')", "bool", doc = "High-purity track flag"),
+        qoverp = Var("qoverp()", "float", doc = "q/p"),
+        dsz = Var("dsz()", "float", doc = "dsz (cm)"),
+        qoverpErr = Var("qoverpError()", "float", doc = ""),
+        ptErr = Var("ptError()", "float", doc = ""),
+        lambdaErr = Var("lambdaError()", "float", doc = ""),
+        dszErr = Var("dszError()", "float", doc = ""),
+        etaErr = Var("etaError()", "float", doc = ""),
+        phiErr = Var("phiError()", "float", doc = ""),
+    ),
+        externalVariables = cms.PSet(
+        matched   = cms.PSet(src = cms.InputTag("pixelTrackAssoc","matched"),
+                             doc = cms.string("1 if matched to a TrackingParticle"),
+                             type = cms.string("uint8")),
+        duplicate = cms.PSet(src = cms.InputTag("pixelTrackAssoc","duplicate"),
+                             doc = cms.string("1 if multiple reco tracks map to same TP"),
+                             type = cms.string("uint8")),
+        tpPdgId  = cms.PSet(src = cms.InputTag("pixelTrackAssoc","tpPdgId"),
+                             doc = cms.string("pdgId of matched TrackingParticle"),
+                             type = cms.string("int16")),
+        tpCharge = cms.PSet(src = cms.InputTag("pixelTrackAssoc","tpCharge"),
+                             doc = cms.string("charge of matched TrackingParticle"),
+                             type = cms.string("int16")),
+        tpPt     = cms.PSet(src = cms.InputTag("pixelTrackAssoc","tpPt"),
+                             doc = cms.string("pt of matched TrackingParticle"),
+                             type = cms.string("float")),
+        tpEta    = cms.PSet(src = cms.InputTag("pixelTrackAssoc","tpEta"),
+                             doc = cms.string("eta of matched TrackingParticle"),
+                             type = cms.string("float")),
+        tpPhi    = cms.PSet(src = cms.InputTag("pixelTrackAssoc","tpPhi"),
+                             doc = cms.string("phi of matched TrackingParticle"),
+                             type = cms.string("float"))
     )
 )
 
@@ -38,6 +99,19 @@ hltPixelTrackExtTable = cms.EDProducer("HLTTracksExtraTableProducer",
                                        tracksSrc = cms.InputTag("hltPhase2PixelTracks"),
                                        beamSpot = cms.InputTag("hltOnlineBeamSpot"),
                                        precision = cms.int32(7))
+
+hltPixelTrackRecHitsTable = cms.EDProducer("HLTTracksRecHitsTableProducer",
+                                            tableName = cms.string("hltPixelTrackRecHits"),
+                                            skipNonExistingSrc = cms.bool(True),
+                                            tracksSrc = cms.InputTag("hltPhase2PixelTracks"),
+                                            maxRecHits = cms.uint32(16),
+                                            precision = cms.int32(7)
+)
+
+
+phase2CAExtension.toModify(hltPixelTrackTable, src = "hltPhase2PixelTracksCAExtension")
+phase2CAExtension.toModify(hltPixelTrackExtTable, tracksSrc = "hltPhase2PixelTracksCAExtension")
+phase2CAExtension.toModify(hltPixelTrackRecHitsTable, tracksSrc = "hltPhase2PixelTracksCAExtension")
 
 hltGeneralTrackTable = cms.EDProducer(
     "SimpleTriggerTrackFlatTableProducer",

--- a/PhysicsTools/NanoAOD/plugins/BuildFile.xml
+++ b/PhysicsTools/NanoAOD/plugins/BuildFile.xml
@@ -18,6 +18,7 @@
 <use name="DataFormats/OnlineMetaData"/>
 <use name="DataFormats/PatCandidates"/>
 <use name="DataFormats/ProtonReco"/>
+<use name="DataFormats/TrackReco"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>
@@ -36,6 +37,9 @@
   <use name="RecoJets/JetAlgorithms"/>
   <use name="TrackingTools/Records"/>
   <use name="roottmva"/>
+  <use name="SimDataFormats/Associations"/>
+  <use name="SimDataFormats/TrackingAnalysis"/>
+  <use name="SimTracker/Common"/>
   <flags EDM_PLUGIN="1"/>
 </library>
 <!-- Disable RNuple plugin: https://github.com/cms-sw/cmsdist/pull/9451#issuecomment-2393861542

--- a/PhysicsTools/NanoAOD/plugins/TrackingAssocValueMapsProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/TrackingAssocValueMapsProducer.cc
@@ -1,0 +1,226 @@
+/**  \class TrackingAssocValueMapsProducer
+ *
+ *  \brief Produces ValueMaps with tracking particle association info for tracks
+ *
+ *  This producer creates ValueMaps for a collection of reco::Track containing
+ *  information about their association to TrackingParticles:
+ *  - whether the track is matched to a TP
+ *  - whether the track is a duplicate (i.e. the matched TP is also matched to other tracks)
+ *  - the PDG ID and charge of the matched TP
+ *  - optionally, the kinematic variables (pt, eta, phi) of the matched TP
+ *  The association is performed using a TrackToTrackingParticleAssociator.
+ *  The TrackingParticles considered for the association can be filtered
+ *  using a set of selection criteria provided via a ParameterSet.
+ *
+ *   \author Luca Ferragina (INFN BO), 2025
+ */
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "SimDataFormats/Associations/interface/TrackAssociation.h"
+#include "SimTracker/Common/interface/TrackingParticleSelector.h"
+#include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
+#include "SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h"
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
+#include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
+
+class TrackingAssocValueMapsProducer : public edm::one::EDProducer<edm::one::SharedResources> {
+public:
+  explicit TrackingAssocValueMapsProducer(const edm::ParameterSet&);
+  ~TrackingAssocValueMapsProducer() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+private:
+  const edm::EDGetTokenT<edm::View<reco::Track>> tracksToken_;
+  const edm::EDGetTokenT<reco::TrackToTrackingParticleAssociator> trackAssociatorToken_;
+  const edm::EDGetTokenT<TrackingParticleCollection> tpToken_;
+
+  edm::ParameterSet tpSet_;
+  TrackingParticleSelector tpSelector_;
+
+  bool storeTPKinematics_;
+};
+
+namespace {
+  template <typename T>
+  void fillAndPut(edm::Event& evt,
+                  const edm::Handle<edm::View<reco::Track>>& tracksH,
+                  std::unique_ptr<edm::ValueMap<T>> product,
+                  const std::vector<T>& values,
+                  const std::string& label) {
+    typename edm::ValueMap<T>::Filler filler(*product);
+    filler.insert(tracksH, values.begin(), values.end());
+    filler.fill();
+    evt.put(std::move(product), label);
+  }
+}  // namespace
+
+TrackingAssocValueMapsProducer::TrackingAssocValueMapsProducer(const edm::ParameterSet& cfg)
+    : tracksToken_(consumes<edm::View<reco::Track>>(cfg.getParameter<edm::InputTag>("trackCollection"))),
+      trackAssociatorToken_(
+          consumes<reco::TrackToTrackingParticleAssociator>(cfg.getParameter<edm::InputTag>("associator"))),
+      tpToken_(consumes<TrackingParticleCollection>(cfg.getParameter<edm::InputTag>("trackingParticles"))),
+      tpSet_(cfg.getParameter<edm::ParameterSet>("tpSelectorPSet")),
+      storeTPKinematics_(cfg.getParameter<bool>("storeTPKinematics")) {
+  tpSelector_ = TrackingParticleSelector(tpSet_.getParameter<double>("ptMin"),
+                                         tpSet_.getParameter<double>("ptMax"),
+                                         tpSet_.getParameter<double>("minRapidity"),
+                                         tpSet_.getParameter<double>("maxRapidity"),
+                                         tpSet_.getParameter<double>("tip"),
+                                         tpSet_.getParameter<double>("lip"),
+                                         tpSet_.getParameter<int>("minHit"),
+                                         tpSet_.getParameter<bool>("signalOnly"),
+                                         tpSet_.getParameter<bool>("intimeOnly"),
+                                         tpSet_.getParameter<bool>("chargedOnly"),
+                                         tpSet_.getParameter<bool>("stableOnly"),
+                                         tpSet_.getParameter<std::vector<int>>("pdgId"),
+                                         tpSet_.getParameter<bool>("invertRapidityCut"),
+                                         tpSet_.getParameter<double>("minPhi"),
+                                         tpSet_.getParameter<double>("maxPhi"));
+
+  produces<edm::ValueMap<int>>("matched");
+  produces<edm::ValueMap<int>>("duplicate");
+  produces<edm::ValueMap<int>>("tpPdgId");
+  produces<edm::ValueMap<int>>("tpCharge");
+  if (storeTPKinematics_) {
+    produces<edm::ValueMap<float>>("tpPt");
+    produces<edm::ValueMap<float>>("tpEta");
+    produces<edm::ValueMap<float>>("tpPhi");
+  }
+}
+
+void TrackingAssocValueMapsProducer::produce(edm::Event& iEvent, const edm::EventSetup&) {
+  edm::Handle<edm::View<reco::Track>> tracksH;
+  iEvent.getByToken(tracksToken_, tracksH);
+
+  edm::Handle<reco::TrackToTrackingParticleAssociator> associatorH;
+  iEvent.getByToken(trackAssociatorToken_, associatorH);
+
+  edm::Handle<TrackingParticleCollection> tpH;
+  iEvent.getByToken(tpToken_, tpH);
+
+  const size_t nTracks = tracksH->size();
+
+  if (nTracks == 0 || !tracksH.isValid() || !associatorH.isValid() || !tpH.isValid()) {
+    // No tracks or invalid handles, put empty ValueMaps and return
+    fillAndPut<int>(iEvent, tracksH, std::make_unique<edm::ValueMap<int>>(), {}, "matched");
+    fillAndPut<int>(iEvent, tracksH, std::make_unique<edm::ValueMap<int>>(), {}, "duplicate");
+    fillAndPut<int>(iEvent, tracksH, std::make_unique<edm::ValueMap<int>>(), {}, "tpPdgId");
+    fillAndPut<int>(iEvent, tracksH, std::make_unique<edm::ValueMap<int>>(), {}, "tpCharge");
+    if (storeTPKinematics_) {
+      fillAndPut<float>(iEvent, tracksH, std::make_unique<edm::ValueMap<float>>(), {}, "tpPt");
+      fillAndPut<float>(iEvent, tracksH, std::make_unique<edm::ValueMap<float>>(), {}, "tpEta");
+      fillAndPut<float>(iEvent, tracksH, std::make_unique<edm::ValueMap<float>>(), {}, "tpPhi");
+    }
+    return;
+  }
+
+  std::vector<int> matched(nTracks, 0);
+  std::vector<int> duplicate(nTracks, 0);
+  std::vector<int> tpPdgId(nTracks, 0);
+  std::vector<int> tpCharge(nTracks, 0);
+
+  std::vector<float> tpPt, tpEta, tpPhi;
+  if (storeTPKinematics_) {
+    tpPt.assign(nTracks, -1.f);
+    tpEta.assign(nTracks, -10.f);
+    tpPhi.assign(nTracks, -10.f);
+  }
+
+  TrackingParticleRefVector tpCollection;
+  for (size_t i = 0, size = tpH->size(); i < size; ++i) {
+    auto tp = TrackingParticleRef(tpH, i);
+    if (tpSelector_(*tp)) {
+      tpCollection.push_back(tp);
+    }
+  }
+
+  edm::RefToBaseVector<reco::Track> trackRefs;
+  for (edm::View<reco::Track>::size_type i = 0; i < nTracks; ++i) {
+    trackRefs.push_back(tracksH->refAt(i));
+  }
+
+  reco::RecoToSimCollection const& recoToSimColl = associatorH->associateRecoToSim(trackRefs, tpCollection);
+  reco::SimToRecoCollection const& simToRecoColl = associatorH->associateSimToReco(trackRefs, tpCollection);
+
+  for (edm::View<reco::Track>::size_type i = 0; i < trackRefs.size(); ++i) {
+    const auto& track = trackRefs[i];
+    auto foundTp = recoToSimColl.find(track);
+    if (foundTp != recoToSimColl.end()) {
+      const auto& tp = foundTp->val;
+      if (!tp.empty()) {
+        matched[i] = 1;
+        tpPdgId[i] = static_cast<int16_t>(tp[0].first->pdgId());
+        tpCharge[i] = static_cast<int8_t>(tp[0].first->charge());
+        if (storeTPKinematics_) {
+          tpPt[i] = tp[0].first->pt();
+          tpEta[i] = tp[0].first->eta();
+          tpPhi[i] = tp[0].first->phi();
+        }
+      }
+      if (simToRecoColl.find(tp[0].first) != simToRecoColl.end()) {
+        if (simToRecoColl[tp[0].first].size() > 1) {
+          duplicate[i] = 1;
+        }
+      }
+    }
+  }
+
+  // Produce ValueMaps and store in the event
+  fillAndPut<int>(iEvent, tracksH, std::make_unique<edm::ValueMap<int>>(), matched, "matched");
+  fillAndPut<int>(iEvent, tracksH, std::make_unique<edm::ValueMap<int>>(), duplicate, "duplicate");
+  fillAndPut<int>(iEvent, tracksH, std::make_unique<edm::ValueMap<int>>(), tpPdgId, "tpPdgId");
+  fillAndPut<int>(iEvent, tracksH, std::make_unique<edm::ValueMap<int>>(), tpCharge, "tpCharge");
+  if (storeTPKinematics_) {
+    fillAndPut<float>(iEvent, tracksH, std::make_unique<edm::ValueMap<float>>(), tpPt, "tpPt");
+    fillAndPut<float>(iEvent, tracksH, std::make_unique<edm::ValueMap<float>>(), tpEta, "tpEta");
+    fillAndPut<float>(iEvent, tracksH, std::make_unique<edm::ValueMap<float>>(), tpPhi, "tpPhi");
+  }
+}
+
+void TrackingAssocValueMapsProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<edm::InputTag>("trackCollection", edm::InputTag("generalTracks"));
+  desc.add<edm::InputTag>("associator", edm::InputTag("trackingParticleRecoTrackAsssociation"));
+  desc.add<edm::InputTag>("trackingParticles", edm::InputTag("mix", "MergedTrackTruth"));
+
+  // TP Selector parameters
+  edm::ParameterSetDescription tpSet;
+  tpSet.add<double>("ptMin", 0.005);
+  tpSet.add<double>("ptMax", 1e100);
+  tpSet.add<double>("minRapidity", -2.5);
+  tpSet.add<double>("maxRapidity", 2.5);
+  tpSet.add<double>("tip", 60);
+  tpSet.add<double>("lip", 30.0);
+  tpSet.add<int>("minHit", 0);
+  tpSet.add<bool>("signalOnly", false);
+  tpSet.add<bool>("intimeOnly", true);
+  tpSet.add<bool>("chargedOnly", true);
+  tpSet.add<bool>("stableOnly", false);
+  tpSet.add<std::vector<int>>("pdgId", {});
+  tpSet.add<bool>("invertRapidityCut", false);
+  tpSet.add<double>("minPhi", -3.2);
+  tpSet.add<double>("maxPhi", 3.2);
+
+  desc.add<edm::ParameterSetDescription>("tpSelectorPSet", tpSet);
+  desc.add<bool>("storeTPKinematics", true);
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(TrackingAssocValueMapsProducer);

--- a/PhysicsTools/NanoAOD/python/autoNANO.py
+++ b/PhysicsTools/NanoAOD/python/autoNANO.py
@@ -79,6 +79,10 @@ autoNANO = {
                    'customize': 'HLTrigger/NGTScouting/HLTNanoProducer_cff.hltNanoCustomize'},
     'Phase2HLTVal' : {'sequence': 'HLTrigger/NGTScouting/HLTNanoProducer_cff.hltValidationNanoFlavour',
                       'customize': 'HLTrigger/NGTScouting/HLTNanoProducer_cff.hltNanoCustomize'},
+
+    # HLT Nano PixelOnly with TP association
+    'Phase2HLTPixelOnly' : {'sequence': 'HLTrigger/NGTScouting/HLTNanoProducer_cff.hltPixelOnlyNanoFlavour',
+                            'customize': 'HLTrigger/NGTScouting/HLTNanoProducer_cff.hltNanoCustomize'},
     # NGT scouting Nano
     'NGTScouting' : {'sequence': 'HLTrigger/NGTScouting/HLTNanoProducer_cff.dstNanoFlavour',
                      'customize': 'HLTrigger/NGTScouting/HLTNanoProducer_cff.hltNanoCustomize'},


### PR DESCRIPTION
#### PR description:

This PR adds new tools and NanoAOD content to support Phase-2 HLT pixel-tracking studies with MC truth information:
- `TrackingAssocValueMapProducer` allows to add MC Truth matching labels to `reco::Track` objects, by providing the corresponding associator, the TP collection, and TP selector parameters. It produces value maps based on the usual reco-to-sim and sim-to-reco matching already used for validation.
- The produced value map and auxiliary features are then fed to the PixelTracks flat table as external variables. This is just an example use case, the aforementioned module can be used for generic reco::Track collections.
- A new flat table is added for per-track rec-hit features (up to a fixed maximum number of hits)

All these features are used in a newly added NanoAOD worfklow: `NANO:@Phase2HLTPixelOnly` which produces PixelTracks + RecHits ntuples with MC truth label, intended for Phase-2 HLT development.

#### PR validation:

There is no change to existing workflows of physics-related code. The pixel-track NanoAOD tables produce the expected per-track truth labels and hit-level information in local tests.
