### PR TITLE
Bug Fix in Ecal/Hcal Digitizers for FASTPU aka Hybrid PU Mixing 

### DIFF
--- a/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
@@ -186,6 +186,7 @@ EcalDigiProducer::EcalDigiProducer(const edm::ParameterSet &params, edm::Consume
   // mixMod.produces<EEDigiCollection>(m_EEdigiCollection);
   // mixMod.produces<ESDigiCollection>(m_ESdigiCollection);
 
+  // Get the tokens for signal
   if (m_doEB)
     m_HitsEBToken_ = iC.consumes<std::vector<PCaloHit>>(edm::InputTag(m_hitsProducerTag, "EcalHitsEB"));
   if (m_doEE)

--- a/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
@@ -185,22 +185,10 @@ EcalDigiProducer::EcalDigiProducer(const edm::ParameterSet &params, edm::Consume
   // mixMod.produces<EBDigiCollection>(m_EBdigiCollection);
   // mixMod.produces<EEDigiCollection>(m_EEdigiCollection);
   // mixMod.produces<ESDigiCollection>(m_ESdigiCollection);
-  const std::set<std::string> producers = {m_hitsProducerTag, m_hitsProducerTagPU};
-  std::vector<edm::EDGetTokenT<std::vector<PCaloHit>>> eb_list, ee_list, es_list;
-  for (const auto &prod : producers) {
-    if (m_doEB)
-      eb_list.push_back(iC.consumes<std::vector<PCaloHit>>(edm::InputTag(prod, "EcalHitsEB")));
-    if (m_doEE)
-      ee_list.push_back(iC.consumes<std::vector<PCaloHit>>(edm::InputTag(prod, "EcalHitsEE")));
-    if (m_doES)
-      es_list.push_back(iC.consumes<std::vector<PCaloHit>>(edm::InputTag(prod, "EcalHitsES")));
-  }
-  if (m_doEB)
-    m_HitsEBToken_ = eb_list[0];
-  if (m_doEE)
-    m_HitsEEToken_ = ee_list[0];
-  if (m_doES)
-    m_HitsESToken_ = es_list[0];
+
+  if (m_doEB) m_HitsEBToken_ = iC.consumes<std::vector<PCaloHit>>(edm::InputTag(m_hitsProducerTag, "EcalHitsEB"));
+  if (m_doEE) m_HitsEEToken_ = iC.consumes<std::vector<PCaloHit>>(edm::InputTag(m_hitsProducerTag, "EcalHitsEE"));
+  if (m_doES) m_HitsESToken_ = iC.consumes<std::vector<PCaloHit>>(edm::InputTag(m_hitsProducerTag, "EcalHitsES"));
 
   if (m_doES) {
     m_esGainToken = iC.esConsumes();

--- a/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
@@ -186,9 +186,12 @@ EcalDigiProducer::EcalDigiProducer(const edm::ParameterSet &params, edm::Consume
   // mixMod.produces<EEDigiCollection>(m_EEdigiCollection);
   // mixMod.produces<ESDigiCollection>(m_ESdigiCollection);
 
-  if (m_doEB) m_HitsEBToken_ = iC.consumes<std::vector<PCaloHit>>(edm::InputTag(m_hitsProducerTag, "EcalHitsEB"));
-  if (m_doEE) m_HitsEEToken_ = iC.consumes<std::vector<PCaloHit>>(edm::InputTag(m_hitsProducerTag, "EcalHitsEE"));
-  if (m_doES) m_HitsESToken_ = iC.consumes<std::vector<PCaloHit>>(edm::InputTag(m_hitsProducerTag, "EcalHitsES"));
+  if (m_doEB)
+    m_HitsEBToken_ = iC.consumes<std::vector<PCaloHit>>(edm::InputTag(m_hitsProducerTag, "EcalHitsEB"));
+  if (m_doEE)
+    m_HitsEEToken_ = iC.consumes<std::vector<PCaloHit>>(edm::InputTag(m_hitsProducerTag, "EcalHitsEE"));
+  if (m_doES)
+    m_HitsESToken_ = iC.consumes<std::vector<PCaloHit>>(edm::InputTag(m_hitsProducerTag, "EcalHitsES"));
 
   if (m_doES) {
     m_esGainToken = iC.esConsumes();

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -117,7 +117,7 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet &ps, edm::ConsumesCollector
     mcParamsToken_ = iC.esConsumes();
   }
 
-  zdcToken_  = iC.consumes<std::vector<PCaloHit>>(edm::InputTag(hitsProducer_, "ZDCHITS"));
+  zdcToken_ = iC.consumes<std::vector<PCaloHit>>(edm::InputTag(hitsProducer_, "ZDCHITS"));
   hcalToken_ = iC.consumes<std::vector<PCaloHit>>(edm::InputTag(hitsProducer_, "HcalHits"));
   bool doNoise = ps.getParameter<bool>("doNoise");
 

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -117,14 +117,8 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet &ps, edm::ConsumesCollector
     mcParamsToken_ = iC.esConsumes();
   }
 
-  const std::set<std::string> producers = {hitsProducer_, hitsProducerPU_};
-  std::vector<edm::EDGetTokenT<std::vector<PCaloHit>>> zdc_list, hcal_list;
-  for (const auto &prod : producers) {
-    zdc_list.push_back(iC.consumes<std::vector<PCaloHit>>(edm::InputTag(prod, "ZDCHITS")));
-    hcal_list.push_back(iC.consumes<std::vector<PCaloHit>>(edm::InputTag(prod, "HcalHits")));
-  }
-  zdcToken_ = zdc_list[0];
-  hcalToken_ = hcal_list[0];
+  zdcToken_  = iC.consumes<std::vector<PCaloHit>>(edm::InputTag(hitsProducer_, "ZDCHITS"));
+  hcalToken_ = iC.consumes<std::vector<PCaloHit>>(edm::InputTag(hitsProducer_, "HcalHits"));
   bool doNoise = ps.getParameter<bool>("doNoise");
 
   bool PreMix1 = ps.getParameter<bool>("HcalPreMixStage1");  // special threshold/pedestal treatment

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -117,6 +117,7 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet &ps, edm::ConsumesCollector
     mcParamsToken_ = iC.esConsumes();
   }
 
+  // Get the tokens for signal
   zdcToken_ = iC.consumes<std::vector<PCaloHit>>(edm::InputTag(hitsProducer_, "ZDCHITS"));
   hcalToken_ = iC.consumes<std::vector<PCaloHit>>(edm::InputTag(hitsProducer_, "HcalHits"));
   bool doNoise = ps.getParameter<bool>("doNoise");


### PR DESCRIPTION
#### PR description:
A bug was found in Ecal and Hcal Digitizers where std::set was being used to hold the SimHit InputTag for signal and PU events. The order was found to be wrong. The std::set is now removed and the token for signal is directly created from the signal simHit InputTag.

#### PR validation:
Bug found during validation with officially produced data samples. Post bug-fix validation done with a small privately produced TTbar dataset

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

@suchandradutta @kpedro88 @bsunanda 