### PR TITLE
[NGT] Add `ScoutingRecHitAnalyzer` and integrate Calo RecHit monitoring into DQM for scouting 2025 era

### DIFF
--- a/DQM/HLTEvF/python/ScoutingRechitMonitoring_cff.py
+++ b/DQM/HLTEvF/python/ScoutingRechitMonitoring_cff.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+## See DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
+
+from HLTriggerOffline.Scouting.ScoutingRecHitAnalyzers_cff import *
+
+ScoutingEBRechitAnalyzerOnline = ScoutingEBRechitAnalyzer.clone()
+ScoutingHBHERechitAnalyzerOnline = ScoutingHBHERechitAnalyzer.clone()
+
+ScoutingRecHitsMonitoring = cms.Sequence(ScoutingEBRechitAnalyzerOnline +
+                                         ScoutingHBHERechitAnalyzerOnline)
+                                         

--- a/DQM/HLTEvF/python/ScoutingRechitMonitoring_cff.py
+++ b/DQM/HLTEvF/python/ScoutingRechitMonitoring_cff.py
@@ -4,9 +4,24 @@ import FWCore.ParameterSet.Config as cms
 
 from HLTriggerOffline.Scouting.ScoutingRecHitAnalyzers_cff import *
 
-ScoutingEBRechitAnalyzerOnline = ScoutingEBRechitAnalyzer.clone()
-ScoutingHBHERechitAnalyzerOnline = ScoutingHBHERechitAnalyzer.clone()
+################################################
+# unpack and pack back the L1T results
+################################################
+from EventFilter.L1TRawToDigi.gtStage2Digis_cfi import gtStage2Digis as _gtStage2Digis
+# Take L1T Raw data from HLT Scouting event content
+gtStage2DigisScouting = _gtStage2Digis.clone(InputLabel="hltFEDSelectorL1")
+from PhysicsTools.NanoAOD.triggerObjects_cff import l1bits as _l1bits
+L1BitsScoutingOnline = _l1bits.clone(src="gtStage2DigisScouting")
+L1BitsSequence = cms.Sequence(gtStage2DigisScouting + L1BitsScoutingOnline)
 
-ScoutingRecHitsMonitoring = cms.Sequence(ScoutingEBRechitAnalyzerOnline +
+ScoutingEBRechitAnalyzerOnline = ScoutingEBRechitAnalyzer.clone(
+    L1TriggerResults = cms.InputTag('L1BitsScoutingOnline')
+)
+ScoutingHBHERechitAnalyzerOnline = ScoutingHBHERechitAnalyzer.clone(
+    L1TriggerResults = cms.InputTag('L1BitsScoutingOnline')
+)
+
+ScoutingRecHitsMonitoring = cms.Sequence(L1BitsSequence +
+                                         ScoutingEBRechitAnalyzerOnline +
                                          ScoutingHBHERechitAnalyzerOnline)
                                          

--- a/DQM/HLTEvF/python/ScoutingRechitMonitoring_cff.py
+++ b/DQM/HLTEvF/python/ScoutingRechitMonitoring_cff.py
@@ -15,13 +15,15 @@ L1BitsScoutingOnline = _l1bits.clone(src="gtStage2DigisScouting")
 L1BitsSequence = cms.Sequence(gtStage2DigisScouting + L1BitsScoutingOnline)
 
 ScoutingEBRechitAnalyzerOnline = ScoutingEBRechitAnalyzer.clone(
-    L1TriggerResults = cms.InputTag('L1BitsScoutingOnline')
+    L1TriggerResults = cms.InputTag('L1BitsScoutingOnline'),
+    topFolderName = cms.string('HLT/ScoutingOnline/EBRechits')
 )
+
 ScoutingHBHERechitAnalyzerOnline = ScoutingHBHERechitAnalyzer.clone(
-    L1TriggerResults = cms.InputTag('L1BitsScoutingOnline')
+    L1TriggerResults = cms.InputTag('L1BitsScoutingOnline'),
+    topFolderName = cms.string('HLT/ScoutingOnline/HBHERechits')
 )
 
 ScoutingRecHitsMonitoring = cms.Sequence(L1BitsSequence +
                                          ScoutingEBRechitAnalyzerOnline +
                                          ScoutingHBHERechitAnalyzerOnline)
-                                         

--- a/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
@@ -56,6 +56,7 @@ process.dqmcommon = cms.Sequence(process.dqmEnv
 process.load("DQM.HLTEvF.ScoutingMuonMonitoring_cff")
 process.load("DQM.HLTEvF.ScoutingJetMonitoring_cff")
 process.load("DQM.HLTEvF.ScoutingElectronMonitoring_cff")
+process.load("DQM.HLTEvF.ScoutingRechitMonitoring_cff")
 ## Run-1 L1TGT required by ScoutingJetMonitoring https://github.com/cms-sw/cmssw/blob/master/DQMOffline/JetMET/src/JetAnalyzer.cc#L2603-L2611
 process.GlobalTag.toGet.append(
  cms.PSet(
@@ -69,7 +70,8 @@ process.p = cms.Path(process.dqmcommon *
                      process.scoutingCollectionMonitor *
                      process.ScoutingMuonMonitoring *
                      process.ScoutingJetMonitoring *
-                     process.ScoutingElectronMonitoring)
+                     process.ScoutingElectronMonitoring *
+                     process.ScoutingRecHitsMonitoring)
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *

--- a/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
+++ b/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
@@ -21,6 +21,9 @@ from DQMOffline.JetMET.jetMETDQMOfflineSource_cff import *
 ### Miscellaneous monitoring
 from DQM.HLTEvF.ScoutingCollectionMonitor_cfi import *
 
+### RecHits monitoring
+from DQMOffline.Scouting.ScoutingRecHitAnalyzers_cff import *
+
 hltScoutingMuonDqmOffline = cms.Sequence(scoutingMonitoringTagProbeMuonNoVtx *
                                          scoutingMonitoringTagProbeMuonVtx *
                                          scoutingMonitoringTriggerMuon_DoubleMu *
@@ -33,6 +36,6 @@ hltScoutingJetDqmOfflineForRelVals = cms.Sequence(jetMETDQMOfflineSourceScouting
 
 hltScoutingCollectionMonitor = cms.Sequence(scoutingCollectionMonitor)
 
-hltScoutingDqmOffline = cms.Sequence(hltScoutingMuonDqmOffline + hltScoutingEGammaDqmOffline + hltScoutingJetDqmOffline + hltScoutingCollectionMonitor)
+hltScoutingDqmOffline = cms.Sequence(hltScoutingMuonDqmOffline + hltScoutingEGammaDqmOffline + hltScoutingJetDqmOffline + hltScoutingCollectionMonitor + hltScoutingMonitoringRecHits)
 hltScoutingDqmOfflineForRelVals = hltScoutingDqmOffline.copy()
 hltScoutingDqmOfflineForRelVals.replace(hltScoutingJetDqmOffline, hltScoutingJetDqmOfflineForRelVals)

--- a/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
+++ b/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
@@ -36,6 +36,19 @@ hltScoutingJetDqmOfflineForRelVals = cms.Sequence(jetMETDQMOfflineSourceScouting
 
 hltScoutingCollectionMonitor = cms.Sequence(scoutingCollectionMonitor)
 
-hltScoutingDqmOffline = cms.Sequence(hltScoutingMuonDqmOffline + hltScoutingEGammaDqmOffline + hltScoutingJetDqmOffline + hltScoutingCollectionMonitor + hltScoutingMonitoringRecHits)
+hltScoutingDqmOffline = cms.Sequence(hltScoutingMuonDqmOffline +
+                                     hltScoutingEGammaDqmOffline +
+                                     hltScoutingJetDqmOffline +
+                                     hltScoutingCollectionMonitor)
+
+## Add the scouting rechits monitoring (only for 2025, integrated in menu GRun 2025 V1.3)
+## See https://its.cern.ch/jira/browse/CMSHLT-3607
+_hltScoutingDqmOffline = hltScoutingDqmOffline.copy()
+_hltScoutingDqmOffline += hltScoutingMonitoringRecHits
+
+# Append the RecHits monitoring only in the 2025 scouting era
+from Configuration.Eras.Modifier_run3_scouting_2025_cff import run3_scouting_2025
+run3_scouting_2025.toReplaceWith(hltScoutingDqmOffline, _hltScoutingDqmOffline)
+
 hltScoutingDqmOfflineForRelVals = hltScoutingDqmOffline.copy()
 hltScoutingDqmOfflineForRelVals.replace(hltScoutingJetDqmOffline, hltScoutingJetDqmOfflineForRelVals)

--- a/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
+++ b/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
@@ -22,7 +22,7 @@ from DQMOffline.JetMET.jetMETDQMOfflineSource_cff import *
 from DQM.HLTEvF.ScoutingCollectionMonitor_cfi import *
 
 ### RecHits monitoring
-from DQMOffline.Scouting.ScoutingRecHitAnalyzers_cff import *
+from HLTriggerOffline.Scouting.ScoutingRecHitAnalyzers_cff import *
 
 hltScoutingMuonDqmOffline = cms.Sequence(scoutingMonitoringTagProbeMuonNoVtx *
                                          scoutingMonitoringTagProbeMuonVtx *

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -547,6 +547,21 @@ namespace dqm {
         });
       }
       template <typename FUNC = NOOP, std::enable_if_t<not std::is_arithmetic<FUNC>::value, int> = 0>
+      MonitorElement* bookProfile2D(TString const& name,
+                                    TString const& title,
+                                    int nchX,
+                                    double const* xbinsize,
+                                    int nchY,
+                                    double const* ybinsize,
+                                    char const* option = "s",
+                                    FUNC onbooking = NOOP()) {
+        return bookME(name, MonitorElementData::Kind::TPROFILE2D, [=]() {
+          auto tprofile = new TProfile2D(name, title, nchX, xbinsize, nchY, ybinsize, option);
+          onbooking(tprofile);
+          return tprofile;
+        });
+      }
+      template <typename FUNC = NOOP, std::enable_if_t<not std::is_arithmetic<FUNC>::value, int> = 0>
       MonitorElement* bookProfile2D(TString const& name, TProfile2D* object, FUNC onbooking = NOOP()) {
         return bookME(
             name,

--- a/HLTriggerOffline/Scouting/plugins/ScoutingRecHitAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingRecHitAnalyzer.cc
@@ -1,0 +1,354 @@
+// system include files
+#include <memory>
+
+// FW include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+// DQM include files
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+// Trigger bits
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "FWCore/Common/interface/TriggerResultsByName.h"
+
+// cut and function
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "CommonTools/Utils/interface/StringObjectFunction.h"
+
+// Dataformats
+#include "DataFormats/EcalDetId/interface/EBDetId.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingEBRecHit.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingHBHERecHit.h"
+
+// C++ include files
+#include <cmath>
+#include <numeric>
+#include <iostream>
+#include <string>
+#include <type_traits>
+#include <vector>
+#include <boost/algorithm/string/join.hpp>
+
+// Trigger bits utlities
+namespace util {
+  bool isAnyTriggerAccept(const std::vector<std::string>& triggers,
+                          const edm::TriggerResults& l1TriggerResults,
+                          const edm::TriggerResultsByName& hltTriggerResultsByName) {
+    for (auto const& trigger : triggers) {
+      if (trigger.starts_with("L1_")) {
+        const auto& trigger_names = l1TriggerResults.getTriggerNames();
+        for (size_t itrigger = 0; itrigger < trigger_names.size(); itrigger++) {
+          const std::string& trigger_name = trigger_names[itrigger];
+          if (trigger_name.compare(0, trigger.length(), trigger) == 0) {
+            if (l1TriggerResults.accept(itrigger))
+              return true;
+          }
+        }
+      } else {
+        for (size_t itrigger = 0; itrigger < hltTriggerResultsByName.size(); itrigger++) {
+          const std::string& trigger_name = hltTriggerResultsByName.triggerName(itrigger);
+          if (trigger_name.compare(0, trigger.length() + 2, trigger + "_v") == 0) {  // ignore _v*
+            if (hltTriggerResultsByName.accept(itrigger))
+              return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+}  // namespace util
+
+template <typename RecHitType>
+class ScoutingRecHitAnalyzer : public DQMEDAnalyzer {
+public:
+  using RecHitCollection = std::vector<RecHitType>;
+
+  ScoutingRecHitAnalyzer(const edm::ParameterSet&);
+  ~ScoutingRecHitAnalyzer() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+protected:
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+
+  void decodeDetId(const RecHitType& rechit, int& ieta, float& eta, int& iphi, float& phi);
+
+  // input tokens
+  edm::EDGetTokenT<RecHitCollection> rechit_collection_token_;
+
+  // trigger tokens
+  edm::EDGetTokenT<edm::TriggerResults> l1TriggerResults_token_;
+  edm::EDGetTokenT<edm::TriggerResults> hltTriggerResults_token_;
+
+  // functor
+  StringCutObjectSelector<RecHitType> cut_;  // general cut applied to all object
+
+  // triggers
+  std::vector<std::vector<std::string>> triggers_;  // trigger expressions
+
+  // other parameters
+
+  // histograms
+  std::vector<MonitorElement*> number_histograms_;
+  std::vector<MonitorElement*> energy_histograms_;
+  std::vector<MonitorElement*> ieta_iphi_histograms_;
+  std::vector<MonitorElement*> eta_phi_histograms_;
+  std::vector<MonitorElement*> ieta_iphi_energy_profiles_;
+  std::vector<MonitorElement*> eta_phi_energy_profiles_;
+
+  // trigger names
+  std::vector<std::string> trigger_names_;
+};
+
+template <typename RecHitType>
+ScoutingRecHitAnalyzer<RecHitType>::ScoutingRecHitAnalyzer(const edm::ParameterSet& iConfig)
+    : rechit_collection_token_(consumes(iConfig.getParameter<edm::InputTag>("src"))),
+      l1TriggerResults_token_(consumes(iConfig.getParameter<edm::InputTag>("L1TriggerResults"))),
+      hltTriggerResults_token_(consumes(iConfig.getParameter<edm::InputTag>("HLTTriggerResults"))),
+      cut_(iConfig.getParameter<std::string>("cut"), iConfig.getUntrackedParameter<bool>("lazy_eval")) {
+  static_assert(
+      std::is_same<RecHitType, Run3ScoutingEBRecHit>::value || std::is_same<RecHitType, Run3ScoutingHBHERecHit>::value,
+      "Unsupported Type of RecHit");
+
+  std::string no_trigger_name = "No_Trigger";
+  trigger_names_.push_back(no_trigger_name);
+
+  const auto& trigger_vpset = iConfig.getParameter<std::vector<edm::ParameterSet>>("triggers");
+  for (auto const& trigger_pset : trigger_vpset) {
+    std::vector<std::string> trigger = trigger_pset.getParameter<std::vector<std::string>>("expr");
+    std::string trigger_name = trigger_pset.getParameter<std::string>("name");
+    if (trigger_name.empty())
+      trigger_name = boost::algorithm::join(trigger, "-or-");
+    triggers_.push_back(trigger);
+    trigger_names_.push_back(trigger_name);
+  }
+}
+
+template <typename RecHitType>
+void ScoutingRecHitAnalyzer<RecHitType>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src");
+  desc.add<edm::InputTag>("L1TriggerResults", edm::InputTag("l1bits"));
+  desc.add<edm::InputTag>("HLTTriggerResults", edm::InputTag("TriggerResults", "", "HLT"));
+  desc.addUntracked<bool>("lazy_eval", false);
+  desc.add<std::string>("cut", "");
+
+  edm::ParameterSetDescription trigger_desc;
+  trigger_desc.add<std::string>("name", "");
+  trigger_desc.add<std::vector<std::string>>("expr");
+  edm::ParameterSet trigger_pset;
+  trigger_pset.addParameter<std::string>("name", "");
+  trigger_pset.addParameter<std::vector<std::string>>("expr", {"DST_PFScouting_JetHT"});
+  std::vector<edm::ParameterSet> trigger_vpset;
+  trigger_vpset.push_back(trigger_pset);
+  desc.addVPSet("triggers", trigger_desc, trigger_vpset);
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+template <typename RecHitType>
+void ScoutingRecHitAnalyzer<RecHitType>::bookHistograms(DQMStore::IBooker& ibooker,
+                                                        edm::Run const&,
+                                                        edm::EventSetup const&) {
+  for (auto const& trigger_name : trigger_names_) {
+    ibooker.setCurrentFolder(trigger_name);
+    if constexpr (std::is_same<RecHitType, Run3ScoutingEBRecHit>()) {
+      number_histograms_.push_back(ibooker.book1D("number", "Number;Events", 100, 0., 1000.));
+      energy_histograms_.push_back(ibooker.book1D("energy", "Energy (GeV);Events", 100, 0., 20.));
+      ieta_iphi_histograms_.push_back(
+          ibooker.book2D("ieta_iphi", "i#eta;i#phi;Entries", 171, -85.5, 85.5, 360, 0.5, 360.5));
+      eta_phi_histograms_.push_back(ibooker.book2D(
+          "eta_phi", "#eta;#phi;Entries", 170, -85 * 0.017453292519943295, 85 * 0.017453292519943295, 360, -M_PI, M_PI));
+      ieta_iphi_energy_profiles_.push_back(ibooker.bookProfile2D(
+          "ieta_iphi_energy", "i#eta;i#phi;mean Energy", 171, -85.5, 85.5, 360, 0.5, 360.5, 0, 20));
+      eta_phi_energy_profiles_.push_back(ibooker.bookProfile2D("eta_phi_energy",
+                                                               "#eta;#phi;mean Energy",
+                                                               170,
+                                                               -85 * 0.017453292519943295,
+                                                               85 * 0.017453292519943295,
+                                                               360,
+                                                               -M_PI,
+                                                               M_PI,
+                                                               0,
+                                                               20));
+    } else if constexpr (std::is_same<RecHitType, Run3ScoutingHBHERecHit>()) {
+      std::vector<double> eta_edges(59);
+      eta_edges[29] = 0.0;
+      double deta = 0.087266462599716475;
+      double eta_edge = 0;
+      for (unsigned int ieta = 1; ieta <= 29; ieta++) {
+        if (ieta == 21)
+          deta *= 2;
+        eta_edge += deta;
+        eta_edges[29 + ieta] = eta_edge;
+        eta_edges[29 - ieta] = -1 * eta_edge;
+      }
+
+      // Build uniform phi bin edges
+      int nPhiBins = 72;
+      std::vector<double> phi_edges(nPhiBins + 1);
+      double phiMin = -M_PI;
+      double phiMax = M_PI;
+      double dphi = (phiMax - phiMin) / nPhiBins;
+      std::iota(phi_edges.begin(), phi_edges.end(), 0);  // fill with 0,1,2,...
+      std::transform(phi_edges.begin(), phi_edges.end(), phi_edges.begin(), [phiMin, dphi](double i) {
+        return phiMin + i * dphi;
+      });
+
+      number_histograms_.push_back(ibooker.book1D("number", "Number;Events", 100, 0., 2000.));
+      energy_histograms_.push_back(ibooker.book1D("energy", "Energy (GeV);Events", 100, 0., 20.));
+      ieta_iphi_histograms_.push_back(
+          ibooker.book2D("ieta_iphi", "i#eta;i#phi;Entries", 59, -29.5, 29.5, 72, 0.5, 72.5));
+      ieta_iphi_energy_profiles_.push_back(
+          ibooker.bookProfile2D("ieta_iphi_energy", "i#eta;i#phi;mean Energy", 59, -29.5, 29.5, 72, 0.5, 72.5, 0, 20));
+
+      // demote edges from double to float
+      std::vector<float> eta_edges_f(eta_edges.begin(), eta_edges.end());
+      std::vector<float> phi_edges_f(phi_edges.begin(), phi_edges.end());
+      eta_phi_histograms_.push_back(ibooker.book2D("eta_phi",
+                                                   "#eta;#phi;Entries",
+                                                   eta_edges_f.size() - 1,
+                                                   eta_edges_f.data(),
+                                                   phi_edges_f.size() - 1,
+                                                   phi_edges_f.data()));
+
+      eta_phi_energy_profiles_.push_back(ibooker.bookProfile2D("eta_phi_energy",
+                                                               "#eta;#phi;mean Energy",
+                                                               eta_edges.size() - 1,
+                                                               eta_edges.data(),
+                                                               phi_edges.size() - 1,
+                                                               phi_edges.data()));
+    }
+  }
+}
+
+template <typename RecHitType>
+void ScoutingRecHitAnalyzer<RecHitType>::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  const auto& l1TriggerResults_handle = iEvent.getHandle(l1TriggerResults_token_);
+  if (!l1TriggerResults_handle.isValid()) {
+    edm::LogWarning("Handle") << "L1 TriggerResults is invalid";
+    return;
+  }
+
+  const auto& hltTriggerResults_handle = iEvent.getHandle(hltTriggerResults_token_);
+  if (!hltTriggerResults_handle.isValid()) {
+    edm::LogWarning("Handle") << "HLT TriggerResults is invalid";
+    return;
+  }
+
+  const auto& hltTriggerResultsByName = iEvent.triggerResultsByName(*hltTriggerResults_handle);
+
+  const auto& rechit_collection_handle = iEvent.getHandle(rechit_collection_token_);
+  if (!rechit_collection_handle.isValid()) {
+    edm::LogWarning("Handle") << "rechit is invalid";
+    return;
+  }
+
+  std::vector<bool> trigger_decisions(triggers_.size(), false);
+  for (unsigned int itrigger = 0; itrigger < triggers_.size(); itrigger++) {
+    const auto& trigger = triggers_[itrigger];
+    trigger_decisions[itrigger] = util::isAnyTriggerAccept(trigger, *l1TriggerResults_handle, hltTriggerResultsByName);
+  }
+
+  unsigned int number_passed = 0;
+
+  for (unsigned int irechit = 0; irechit < rechit_collection_handle->size(); irechit++) {
+    const auto& rechit = rechit_collection_handle->at(irechit);
+    int ieta, iphi;
+    float eta, phi;
+    decodeDetId(rechit, ieta, eta, iphi, phi);
+    const auto& energy = rechit.energy();
+
+    if (cut_(rechit)) {
+      energy_histograms_[0]->Fill(energy);
+      ieta_iphi_histograms_[0]->Fill(ieta, iphi);
+      eta_phi_histograms_[0]->Fill(eta, phi);
+      ieta_iphi_energy_profiles_[0]->Fill(ieta, iphi, energy);
+      eta_phi_energy_profiles_[0]->Fill(eta, phi, energy);
+      if (std::is_same<RecHitType, Run3ScoutingHBHERecHit>()) {
+        if (std::abs(ieta) >= 21) {
+          float phi2 = (iphi + 0.5) * 5 * M_PI / 180.;
+          if (phi2 > M_PI)
+            phi2 = phi2 - 2 * M_PI;
+          eta_phi_histograms_[0]->Fill(eta, phi2);
+          eta_phi_energy_profiles_[0]->Fill(eta, phi2, energy);
+        }
+      }
+      unsigned int itrigger = 0;
+      for (const bool& trigger_accept : trigger_decisions) {
+        itrigger++;
+        if (trigger_accept) {
+          energy_histograms_[itrigger]->Fill(energy);
+          ieta_iphi_histograms_[itrigger]->Fill(ieta, iphi);
+          eta_phi_histograms_[itrigger]->Fill(eta, phi);
+          ieta_iphi_energy_profiles_[itrigger]->Fill(ieta, iphi, energy);
+          eta_phi_energy_profiles_[itrigger]->Fill(eta, phi, energy);
+          if (std::is_same<RecHitType, Run3ScoutingHBHERecHit>()) {
+            if (std::abs(ieta) >= 21) {
+              float phi2 = (iphi + 0.5) * 5 * M_PI / 180.;
+              if (phi2 > M_PI)
+                phi2 = phi2 - 2 * M_PI;
+              eta_phi_histograms_[itrigger]->Fill(eta, phi2);
+              eta_phi_energy_profiles_[itrigger]->Fill(eta, phi2, energy);
+            }
+          }
+        }
+      }
+      number_passed++;
+    }
+  }
+
+  number_histograms_[0]->Fill(number_passed);
+  unsigned int itrigger = 0;
+  for (const bool& trigger_accept : trigger_decisions) {
+    itrigger++;
+    if (trigger_accept) {
+      number_histograms_[itrigger]->Fill(number_passed);
+    }
+  }
+}
+
+template <typename RecHitType>
+void ScoutingRecHitAnalyzer<RecHitType>::decodeDetId(
+    const RecHitType& rechit, int& ieta, float& eta, int& iphi, float& phi) {
+  if constexpr (std::is_same<RecHitType, Run3ScoutingEBRecHit>()) {
+    const auto& detId = EBDetId(rechit.detId());
+    ieta = detId.ieta();
+    const auto& ietaAbs = detId.ietaAbs();
+    const auto& zside = detId.zside();
+    eta = zside * (ietaAbs - 0.5) * 0.017453292519943295;
+    iphi = detId.iphi();
+    phi = (iphi - 0.5) * M_PI / 180.;
+    if (phi > M_PI)
+      phi = phi - 2 * M_PI;
+  } else if constexpr (std::is_same<RecHitType, Run3ScoutingHBHERecHit>()) {
+    const auto& detId = HcalDetId(rechit.detId());
+    ieta = detId.ieta();
+    const auto& ietaAbs = detId.ietaAbs();
+    const auto& zside = detId.zside();
+    if (ietaAbs <= 20) {
+      eta = zside * (ietaAbs - 0.5) * 0.087266462599716475;
+    } else {
+      eta = zside * ((20 * 0.087266462599716475) + (ietaAbs - 20 - 0.5) * 0.087266462599716475 * 2);
+    }
+    iphi = detId.iphi();
+    phi = (iphi - 0.5) * 5 * M_PI / 180.;
+    if (phi > M_PI)
+      phi = phi - 2 * M_PI;
+  }
+}
+
+using ScoutingEBRecHitAnalyzer = ScoutingRecHitAnalyzer<Run3ScoutingEBRecHit>;
+DEFINE_FWK_MODULE(ScoutingEBRecHitAnalyzer);
+
+using ScoutingHBHERecHitAnalyzer = ScoutingRecHitAnalyzer<Run3ScoutingHBHERecHit>;
+DEFINE_FWK_MODULE(ScoutingHBHERecHitAnalyzer);

--- a/HLTriggerOffline/Scouting/python/ScoutingRecHitAnalyzers_cff.py
+++ b/HLTriggerOffline/Scouting/python/ScoutingRecHitAnalyzers_cff.py
@@ -1,0 +1,30 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+
+ScoutingEBRechitAnalyzer = DQMEDAnalyzer('ScoutingEBRecHitAnalyzer',
+                                         src = cms.InputTag ("hltScoutingRecHitPacker", "EB"),
+                                         L1TriggerResults = cms.InputTag('*'),
+                                         HLTTriggerResults = cms.InputTag('TriggerResults', '', 'HLT'),
+                                         lazy_eval = cms.untracked.bool(False),
+                                         cut = cms.string(''),
+                                         triggers = cms.VPSet(
+                                             cms.PSet(
+                                                 expr = cms.vstring('DST_PFScouting_JetHT'),
+                                                 name = cms.string('')
+                                             )                                             
+                                         ))
+
+ScoutingHBHERechitAnalyzer = DQMEDAnalyzer('ScoutingHBHERecHitAnalyzer',
+                                         src = cms.InputTag("hltScoutingRecHitPacker", "HBHE"),
+                                         L1TriggerResults = cms.InputTag('*'),
+                                         HLTTriggerResults = cms.InputTag('TriggerResults', '', 'HLT'),
+                                         lazy_eval = cms.untracked.bool(False),
+                                         cut = cms.string(''),
+                                         triggers = cms.VPSet(
+                                             cms.PSet(
+                                                 expr = cms.vstring('DST_PFScouting_JetHT'),
+                                                 name = cms.string('')
+                                             )                                             
+                                         ))
+
+hltScoutingMonitoringRecHits = cms.Sequence(ScoutingEBRechitAnalyzer + ScoutingHBHERechitAnalyzer)

--- a/HLTriggerOffline/Scouting/python/ScoutingRecHitAnalyzers_cff.py
+++ b/HLTriggerOffline/Scouting/python/ScoutingRecHitAnalyzers_cff.py
@@ -3,7 +3,7 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
 ScoutingEBRechitAnalyzer = DQMEDAnalyzer('ScoutingEBRecHitAnalyzer',
                                          src = cms.InputTag ("hltScoutingRecHitPacker", "EB"),
-                                         L1TriggerResults = cms.InputTag('*'),
+                                         L1TriggerResults = cms.InputTag('L1BitsScouting'),
                                          HLTTriggerResults = cms.InputTag('TriggerResults', '', 'HLT'),
                                          lazy_eval = cms.untracked.bool(False),
                                          cut = cms.string(''),
@@ -15,16 +15,24 @@ ScoutingEBRechitAnalyzer = DQMEDAnalyzer('ScoutingEBRecHitAnalyzer',
                                          ))
 
 ScoutingHBHERechitAnalyzer = DQMEDAnalyzer('ScoutingHBHERecHitAnalyzer',
-                                         src = cms.InputTag("hltScoutingRecHitPacker", "HBHE"),
-                                         L1TriggerResults = cms.InputTag('*'),
-                                         HLTTriggerResults = cms.InputTag('TriggerResults', '', 'HLT'),
-                                         lazy_eval = cms.untracked.bool(False),
-                                         cut = cms.string(''),
-                                         triggers = cms.VPSet(
-                                             cms.PSet(
-                                                 expr = cms.vstring('DST_PFScouting_JetHT'),
-                                                 name = cms.string('')
-                                             )                                             
-                                         ))
+                                           src = cms.InputTag("hltScoutingRecHitPacker", "HBHE"),
+                                           L1TriggerResults = cms.InputTag('L1BitsScouting'),
+                                           HLTTriggerResults = cms.InputTag('TriggerResults', '', 'HLT'),
+                                           lazy_eval = cms.untracked.bool(False),
+                                           cut = cms.string(''),
+                                           triggers = cms.VPSet(
+                                               cms.PSet(
+                                                   expr = cms.vstring('DST_PFScouting_JetHT'),
+                                                   name = cms.string('')
+                                               )                                             
+                                           ))
 
-hltScoutingMonitoringRecHits = cms.Sequence(ScoutingEBRechitAnalyzer + ScoutingHBHERechitAnalyzer)
+################################################
+# unpack and pack back the L1T results
+################################################
+from PhysicsTools.NanoAOD.triggerObjects_cff import l1bits as _l1bits
+L1BitsScouting = _l1bits.clone(src="gtStage2Digis")
+
+hltScoutingMonitoringRecHits = cms.Sequence(L1BitsScouting +
+                                            ScoutingEBRechitAnalyzer +
+                                            ScoutingHBHERechitAnalyzer)

--- a/HLTriggerOffline/Scouting/python/ScoutingRecHitAnalyzers_cff.py
+++ b/HLTriggerOffline/Scouting/python/ScoutingRecHitAnalyzers_cff.py
@@ -5,26 +5,28 @@ ScoutingEBRechitAnalyzer = DQMEDAnalyzer('ScoutingEBRecHitAnalyzer',
                                          src = cms.InputTag ("hltScoutingRecHitPacker", "EB"),
                                          L1TriggerResults = cms.InputTag('L1BitsScouting'),
                                          HLTTriggerResults = cms.InputTag('TriggerResults', '', 'HLT'),
+                                         topFolderName = cms.string('HLT/ScoutingOffline/EBRechits'),
                                          lazy_eval = cms.untracked.bool(False),
                                          cut = cms.string(''),
                                          triggers = cms.VPSet(
                                              cms.PSet(
                                                  expr = cms.vstring('DST_PFScouting_JetHT'),
                                                  name = cms.string('')
-                                             )                                             
+                                             )
                                          ))
 
 ScoutingHBHERechitAnalyzer = DQMEDAnalyzer('ScoutingHBHERecHitAnalyzer',
                                            src = cms.InputTag("hltScoutingRecHitPacker", "HBHE"),
                                            L1TriggerResults = cms.InputTag('L1BitsScouting'),
                                            HLTTriggerResults = cms.InputTag('TriggerResults', '', 'HLT'),
+                                           topFolderName = cms.string('HLT/ScoutingOffline/HBHERechits'),
                                            lazy_eval = cms.untracked.bool(False),
                                            cut = cms.string(''),
                                            triggers = cms.VPSet(
                                                cms.PSet(
                                                    expr = cms.vstring('DST_PFScouting_JetHT'),
                                                    name = cms.string('')
-                                               )                                             
+                                               )
                                            ))
 
 ################################################


### PR DESCRIPTION
#### PR description:

This PR introduces the following changes:

- Introduce a new module `ScoutingRecHitAnalyzer` for monitoring reconstructed EB and HBHE rechits in scouting data.
- Add infrastructure to run the `ScoutingRecHitAnalyzer` within the DQM framework.
- Refactor L1 bits handling for scouting in both online and offline sequences.
- Make the top-level folder name configurable to support calo RecHit monitoring outputs.
- Update HLT DQM offline sequences to include `hltScoutingMonitoringRecHits` only for the Run3 Scouting 2025 era via the appropriate era modifier.
- Support new `bookProfile2D` method in `DQMStore` for variable bin size histograms.

#### PR validation:

Run successfully the following tests:
- DQM online: `scram b runtests_TestDQMOnlineClient-scouting_dqm_sourceclient`
- DQM offfline: `runTheMatrix.py -l  16834.0 -t 4 -j 8`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, no backport needed. Foreseen to be used in the 2026 pp run.