### PR TITLE
Fix memory leak in `auto_ptr` read rule test

### DIFF
--- a/DataFormats/TestObjects/src/classes.h
+++ b/DataFormats/TestObjects/src/classes.h
@@ -48,16 +48,17 @@
 // related to SchemaEvolutionTestObjects.h
 #ifndef DataFormats_TestObjects_USE_OLD
 
-// The following is from an example by Jakob Blomer from the ROOT team
+// The following is from an example from ROOT team
+// roottest/root/io/autoptr/TestAutoPtr_v3.hxx
 namespace edmtest::compat {
   template <typename T>
   struct deprecated_auto_ptr {
-    // We use compat_auto_ptr only to assign the wrapped raw pointer
+    // We use deprecated_auto_ptr only to assign the wrapped raw pointer
     // to a unique pointer in an I/O customization rule.
-    // Therefore, we don't delete on destruction (because ownership
-    // gets transferred to the unique pointer).
+    // However, since the deprecated_auto_ptr object can be reused, it is essential to always reset the
+    // value after using it, so we can safely delete it (it should always be nullptr)
 
-    // ~deprecated_auto_ptr() { delete _M_ptr; }
+    ~deprecated_auto_ptr() { delete _M_ptr; }
 
     T *_M_ptr = nullptr;
   };

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -418,7 +418,7 @@ exception when running testMissingDictionaryChecking_cfg.py.
  <ioread sourceClass="std::auto_ptr<edmtest::SchemaEvolutionContained>" targetClass="edmtest::compat::deprecated_auto_ptr<edmtest::SchemaEvolutionContained>"/>
  <ioread sourceClass="edmtest::SchemaEvolutionAutoPtrToUniquePtr" version="[3]" targetClass="edmtest::SchemaEvolutionAutoPtrToUniquePtr" source="edmtest::compat::deprecated_auto_ptr<edmtest::SchemaEvolutionContained> contained_" target="contained_">
   <![CDATA[
-   contained_.release(); contained_.reset(onfile.contained_._M_ptr);
+   contained_.reset(onfile.contained_._M_ptr); onfile.contained_._M_ptr = nullptr;
   ]]>
  </ioread>
  <class name="edmtest::SchemaEvolutionCArrayToStdArray" ClassVersion="4">


### PR DESCRIPTION
#### PR description:

ROOT team informed us that the `auto_ptr` read rule recipe applied to a test in https://github.com/cms-sw/cmssw/pull/48817 contains a memory leak. The memory leak occurs when the objects are reused when reading, which is not how `PoolSource` works. This PR fixes the memory leak. ~~(I opened it as a draft because presently it seems to have a leak).~~

Related to https://github.com/cms-sw/cmssw/issues/43422, https://github.com/cms-sw/cmssw/issues/43923
Resolves https://github.com/cms-sw/framework-team/issues/1718

#### PR validation:

The test runs. ~~I modified the test to repeat the the 10-event file for 1000 times, and ran it through the [MaxMemoryPreload](https://github.com/cms-sw/cmssw/blob/master/PerfTools/MaxMemoryPreload/README.md). The code in `master` seems to have a \~42 B/event leak, but so seems to have the present version of this PR. Adding back the direct schema evolution from `auto_ptr`->`unique_ptr` does not leak.~~ See https://github.com/cms-sw/cmssw/pull/49621#issuecomment-3647897623.


