### PR TITLE
[mkFit] fix charge flip bug in propagationToPlane

### DIFF
--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
@@ -1887,6 +1887,10 @@ namespace mkfit {
         jacCurv2CCS(n, 3, 1) = outPar(n, 3, 0) * cosT(n, 0, 0) / sinT(n, 0, 0);
         jacCurv2CCS(n, 4, 2) = 1.f;
         jacCurv2CCS(n, 5, 1) = -1.f;
+	if((lp_upd(n, 0, 0)/lp(n, 0, 0))<0){
+         outPar(n, 0, 3) = -outPar(n, 0, 3);
+         jacCurv2CCS(n, 3, 0) =  -jacCurv2CCS(n, 3, 0);
+        }
       }
 
       //now we need the jacobian from local to curv

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
@@ -1887,9 +1887,9 @@ namespace mkfit {
         jacCurv2CCS(n, 3, 1) = outPar(n, 3, 0) * cosT(n, 0, 0) / sinT(n, 0, 0);
         jacCurv2CCS(n, 4, 2) = 1.f;
         jacCurv2CCS(n, 5, 1) = -1.f;
-	if((lp_upd(n, 0, 0)/lp(n, 0, 0))<0){
-         outPar(n, 0, 3) = -outPar(n, 0, 3);
-         jacCurv2CCS(n, 3, 0) =  -jacCurv2CCS(n, 3, 0);
+        if (std::signbit(lp_upd(n, 0, 0)) != std::signbit(lp(n, 0, 0))) {
+          outPar(n, 0, 3) = -outPar(n, 0, 3);
+          jacCurv2CCS(n, 3, 0) = -jacCurv2CCS(n, 3, 0);
         }
       }
 


### PR DESCRIPTION
#### PR description:

This PR fixes the mkFit propagation to plane to allow for charge flips during the propagation.

- inside kalmanOperationPlaneLocal the sign of 1/pT (outPar(n,3,0) is set negative in case of charge flips, so that the safeguard can catch the charge flip [here](https://github.com/leonardogiannini/cmssw/blob/e97630413c53d5ee6e47a6e80092f6737f8850c2/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc#L1355-L1358)

- the sign of the jacobian element jacCurv2CCS(n, 3, 0) is also changed as the charge enters it directly.


#### PR validation:

The change has a small effect on mkFit built tracks, visible for instance at HLT with legacy tracking ([MTV_TTPU](http://uaf-10.t2.ucsd.edu/~legianni/checkFitPt/newBaseline_crosschecks/plots_TTPU_fix_vs_nofix_BuildLegacy)), where the number of hits increases slightly (blue=before, red=after fix)

<img width="651" height="421" alt="image" src="https://github.com/user-attachments/assets/87a48523-e4f9-4802-9317-052f69126b97" />

The effect is negligible in the HLT tracking proposed new baseline, or patatrack extension + LST seeding single iteration (see [plots](http://uaf-10.t2.ucsd.edu/~legianni/checkFitPt/newBaseline_crosschecks/plots_TTPU_fix_vs_nofix_Build)) 

The most noticeable improvement is observed when mkFit is used in the final fit, where the problem was found.
E.g. for 10 GeV muons (blue = CKF fit, red = mkFit, with legacy HLT tracking, hltInitialStepTracks), we can see that right tail at high pT due to the missing charge flips disappears in right plot, after the fix.

<img width="1094" height="650" alt="image" src="https://github.com/user-attachments/assets/b0793c9e-03e0-423a-b3cb-0879c661070a" />

NB: the mkFit fit is not currently part of any baseline tracking configuration.

