### PR TITLE
LST: T5-T5 Duplicate Merging

### DIFF
--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -205,10 +205,18 @@
  </class>
  <class name="edm::Wrapper<std::map<edm::ParameterSetID,edm::ParameterSetBlob>>"/>
 
+ <class name="edm::StdArray<uint8_t, 13>"/>
+
  <class name="edm::StdArray<short, 4>"/>
- <class name="edm::StdArray<unsigned short, 11>"/>
+
+ <class name="edm::StdArray<uint16_t, 11>"/>
+ <class name="edm::StdArray<uint16_t, 13>"/>
+
+ <class name="edm::StdArray<unsigned int, 2>"/>
  <class name="edm::StdArray<unsigned int, 4>"/>
  <class name="edm::StdArray<unsigned int, 14>"/>
+
+ <class name="edm::StdArray<edm::StdArray<unsigned int, 2>, 13>"/>
 
  <class name="edm::PathStateToken" ClassVersion="3">
    <version ClassVersion="3" checksum="2219165191"/>

--- a/RecoTracker/LSTCore/interface/Common.h
+++ b/RecoTracker/LSTCore/interface/Common.h
@@ -35,6 +35,9 @@ namespace lst {
 
   constexpr unsigned int size_superbins = 45000;
 
+  constexpr uint16_t kTCEmptyLowerModule = 0xFFFF;     // Sentinel for empty lowerModule index
+  constexpr unsigned int kTCEmptyHitIdx = 0xFFFFFFFF;  // Sentinel for empty hit slots
+
 // Half precision wrapper functions.
 #if defined(FP16_Base)
 #define __F2H __float2half
@@ -94,10 +97,15 @@ namespace lst {
     using ArrayUxHits = edm::StdArray<unsigned int, kHits>;
   };
   struct Params_TC {
-    static constexpr int kLayers = 7, kHits = 14;
+    static constexpr int kLayers = 13;
+    static constexpr int kHitsPerLayer = 2;
+    // Number of layers resevered for pixel hits.
+    static constexpr int kPixelLayerSlots = 2;
+    static constexpr int kHits = kLayers * kHitsPerLayer;
     using ArrayU8xLayers = edm::StdArray<uint8_t, kLayers>;
     using ArrayU16xLayers = edm::StdArray<uint16_t, kLayers>;
-    using ArrayUxHits = edm::StdArray<unsigned int, kHits>;
+    using ArrayUHitsPerLayer = edm::StdArray<unsigned int, kHitsPerLayer>;
+    using ArrayUxHits = edm::StdArray<ArrayUHitsPerLayer, kLayers>;
   };
 
   using ArrayIx2 = edm::StdArray<int, 2>;

--- a/RecoTracker/LSTCore/interface/QuintupletsSoA.h
+++ b/RecoTracker/LSTCore/interface/QuintupletsSoA.h
@@ -32,6 +32,7 @@ namespace lst {
                       SOA_COLUMN(float, rzChiSquared),  // r-z only chi2
                       SOA_COLUMN(float, chiSquared),
                       SOA_COLUMN(float, nonAnchorChiSquared),
+                      SOA_COLUMN(float, dnnScore),
                       SOA_COLUMN(float, dBeta1),
                       SOA_COLUMN(float, dBeta2));
 

--- a/RecoTracker/LSTCore/interface/alpaka/Common.h
+++ b/RecoTracker/LSTCore/interface/alpaka/Common.h
@@ -45,6 +45,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
   HOST_DEVICE_CONSTANT int kNTripletThreshold = 1000;
   // To be updated with std::numeric_limits<float>::infinity() in the code and data files
   HOST_DEVICE_CONSTANT float kVerticalModuleSlope = 123456789.0;
+  HOST_DEVICE_CONSTANT int kLogicalOTLayers = 11;  // logical OT layers are 1..11
 
   HOST_DEVICE_CONSTANT float kMiniDeltaTilted[3] = {0.26f, 0.26f, 0.26f};
   HOST_DEVICE_CONSTANT float kMiniDeltaFlat[6] = {0.26f, 0.16f, 0.16f, 0.18f, 0.18f, 0.18f};

--- a/RecoTracker/LSTCore/src/alpaka/NeuralNetwork.h
+++ b/RecoTracker/LSTCore/src/alpaka/NeuralNetwork.h
@@ -202,7 +202,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                      const unsigned int mdIndex5,
                                                      const float innerRadius,
                                                      const float outerRadius,
-                                                     const float bridgeRadius) {
+                                                     const float bridgeRadius,
+                                                     float& dnnScore) {
       // Constants
       constexpr unsigned int kInputFeatures = 23;
       constexpr unsigned int kHiddenFeatures = 32;
@@ -281,7 +282,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
       // Layer 3: Linear + Sigmoid
       linear_layer<kHiddenFeatures, 1>(x_2, x_3, dnn::t5dnn::wgtT_output_layer, dnn::t5dnn::bias_output_layer);
-      float x_5 = sigmoid_activation(acc, x_3[0]);
+      dnnScore = sigmoid_activation(acc, x_3[0]);
 
       // Get the bin index based on abs(eta) of first hit and t5_pt
       float t5_pt = innerRadius * lst::k2Rinv1GeVf * 2;
@@ -289,8 +290,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
       uint8_t pt_index = (t5_pt > 5.0f);
       uint8_t bin_index = (eta1 > 2.5f) ? (dnn::kEtaBins - 1) : static_cast<unsigned int>(eta1 / dnn::kEtaSize);
 
-      // Compare x_5 to the cut value for the relevant bin
-      return x_5 > dnn::t5dnn::kWp[pt_index][bin_index];
+      // Compare output to the cut value for the relevant bin
+      return dnnScore > dnn::t5dnn::kWp[pt_index][bin_index];
     }
   }  // namespace t5dnn
 

--- a/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
@@ -46,7 +46,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                             uint8_t layer,
                                                             unsigned int quintupletIndex,
                                                             const float (&t5Embed)[Params_T5::kEmbed],
-                                                            bool tightCutFlag) {
+                                                            bool tightCutFlag,
+                                                            float dnnScore) {
     quintuplets.tripletIndices()[quintupletIndex][0] = innerTripletIndex;
     quintuplets.tripletIndices()[quintupletIndex][1] = outerTripletIndex;
 
@@ -88,6 +89,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     quintuplets.nonAnchorChiSquared()[quintupletIndex] = nonAnchorChiSquared;
     quintuplets.dBeta1()[quintupletIndex] = dBeta1;
     quintuplets.dBeta2()[quintupletIndex] = dBeta2;
+    quintuplets.dnnScore()[quintupletIndex] = dnnScore;
 
     CMS_UNROLL_LOOP
     for (unsigned int i = 0; i < Params_T5::kEmbed; ++i) {
@@ -1491,6 +1493,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                                float& nonAnchorChiSquared,
                                                                float& dBeta1,
                                                                float& dBeta2,
+                                                               float& dnnScore,
                                                                bool& tightCutFlag,
                                                                float (&t5Embed)[Params_T5::kEmbed],
                                                                const float ptCut) {
@@ -1531,7 +1534,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                               fifthMDIndex,
                                               innerRadius,
                                               outerRadius,
-                                              bridgeRadius);
+                                              bridgeRadius,
+                                              dnnScore);
     tightCutFlag = tightCutFlag and inference;  // T5-in-TC cut
     if (!inference)                             // T5-building cut
       return false;
@@ -1754,7 +1758,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
               uint16_t lowerModule5 = triplets.lowerModuleIndices()[outerTripletIndex][2];
 
               float innerRadius, outerRadius, bridgeRadius, regressionCenterX, regressionCenterY, regressionRadius,
-                  rzChiSquared, chiSquared, nonAnchorChiSquared, dBeta1, dBeta2;  //required for making distributions
+                  rzChiSquared, chiSquared, nonAnchorChiSquared, dBeta1, dBeta2,
+                  dnnScore;  //required for making distributions
 
               float t5Embed[Params_T5::kEmbed] = {0.f};
 
@@ -1783,6 +1788,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                       nonAnchorChiSquared,
                                                       dBeta1,
                                                       dBeta2,
+                                                      dnnScore,
                                                       tightCutFlag,
                                                       t5Embed,
                                                       ptCut);
@@ -1841,7 +1847,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                           layer,
                                           quintupletIndex,
                                           t5Embed,
-                                          tightCutFlag);
+                                          tightCutFlag,
+                                          dnnScore);
 
                     triplets.partOfT5()[quintuplets.tripletIndices()[quintupletIndex][0]] = true;
                     triplets.partOfT5()[quintuplets.tripletIndices()[quintupletIndex][1]] = true;
@@ -1890,7 +1897,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           uint16_t lowerModule5 = triplets.lowerModuleIndices()[outerTripletIndex][2];
 
           float innerRadius, outerRadius, bridgeRadius, regressionCenterX, regressionCenterY, regressionRadius,
-              rzChiSquared, chiSquared, nonAnchorChiSquared, dBeta1, dBeta2;  //required for making distributions
+              rzChiSquared, chiSquared, nonAnchorChiSquared, dBeta1, dBeta2,
+              dnnScore;  //required for making distributions
 
           float t5Embed[Params_T5::kEmbed] = {0.f};
 
@@ -1919,6 +1927,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                   nonAnchorChiSquared,
                                                   dBeta1,
                                                   dBeta2,
+                                                  dnnScore,
                                                   tightCutFlag,
                                                   t5Embed,
                                                   ptCut);
@@ -1974,7 +1983,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                       layer,
                                       quintupletIndex,
                                       t5Embed,
-                                      tightCutFlag);
+                                      tightCutFlag,
+                                      dnnScore);
 
                 triplets.partOfT5()[quintuplets.tripletIndices()[quintupletIndex][0]] = true;
                 triplets.partOfT5()[quintuplets.tripletIndices()[quintupletIndex][1]] = true;
@@ -2045,7 +2055,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
                 float innerRadius, outerRadius, bridgeRadius;
                 float regCx, regCy, regR;
-                float rzChi2, chi2, nonAnchorChi2, dBeta1, dBeta2;
+                float rzChi2, chi2, nonAnchorChi2, dBeta1, dBeta2, dnnScore;
                 float t5Embed[Params_T5::kEmbed] = {0.f};
                 bool tightFlag = false;
 
@@ -2072,6 +2082,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                          nonAnchorChi2,
                                                          dBeta1,
                                                          dBeta2,
+                                                         dnnScore,
                                                          tightFlag,
                                                          t5Embed,
                                                          ptCut);

--- a/RecoTracker/LSTCore/standalone/code/core/AccessHelper.h
+++ b/RecoTracker/LSTCore/standalone/code/core/AccessHelper.h
@@ -94,5 +94,7 @@ std::vector<unsigned int> getLSsFromTC(LSTEvent* event, unsigned int TC);
 std::vector<unsigned int> getHitsFromTC(LSTEvent* event, unsigned int TC);
 std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHitTypesFromTC(LSTEvent* event,
                                                                                              unsigned int TC);
+std::pair<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndTypesFromTC(LSTEvent* event,
+                                                                                         unsigned int tc_idx);
 
 #endif

--- a/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.h
+++ b/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.h
@@ -101,6 +101,7 @@ std::tuple<int, float, float, float, int, std::vector<int>, std::vector<float>> 
     std::vector<int> const& trk_simhit_simTrkIdx,
     std::vector<std::vector<int>> const& trk_ph2_simHitIdx,
     std::vector<std::vector<int>> const& trk_pix_simHitIdx,
+    float& percent_matched,
     float matchfrac = 0.75);
 std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned int>> parsepT5(LSTEvent* event,
                                                                                                unsigned int);

--- a/RecoTracker/LSTCore/standalone/efficiency/python/lst_plot_performance.py
+++ b/RecoTracker/LSTCore/standalone/efficiency/python/lst_plot_performance.py
@@ -8,7 +8,7 @@ import sys
 from math import sqrt
 
 sel_choices = ["base", "loweta", "xtr", "vtr", "none"]
-metric_choices = ["eff", "fakerate", "duplrate", "fakeorduplrate"]
+metric_choices = ["eff", "fakerate", "duplrate", "fakeorduplrate", "avgOTlen"]
 variable_choices = ["pt", "ptmtv", "ptlow", "eta", "phi", "dxy", "dz", "vxy", "deltaEta", "deltaPhi", "deltaR", "jet_eta", "jet_phi", "jet_pt"]
 objecttype_choices = ["TC", "pT5", "T5", "pT3", "pLS", "T4", "pT5_lower", "pT3_lower", "T5_lower", "pLS_lower"]
 #lowerObjectType = ["pT5_lower", "pT3_lower", "T5_lower"]
@@ -82,6 +82,10 @@ def plot(args):
 
     params = process_arguments_into_params(args)
 
+    if params["metric"] == "avgOTlen":
+        params["objecttype"] = "TC"
+        params["breakdown"] = False
+
     if params["metric"] == "eff":
         params["output_name"] = "{objecttype}_{selection}_{pdgid}_{charge}_{metric}_{variable}".format(**params)
     else:
@@ -123,7 +127,12 @@ def plot(args):
 
     # Numerator histograms
     numer = []
-    numer.append(params["input_file"].Get(params["numer"]).Clone())
+    if params["metric"] == "avgOTlen":
+        h_num = params["input_file"].Get(params["numer"]).Clone()
+        h_numSq = params["input_file"].Get(params["numer"].replace("numer", "numerSq")).Clone()
+        numer.append((h_num, h_numSq))
+    else:
+        numer.append(params["input_file"].Get(params["numer"]).Clone())
 
     breakdown_hist_types = ["pT5", "pT3", "T5", "pLS", "T4"]
     print("breakdown = ", params["breakdown"])
@@ -136,8 +145,13 @@ def plot(args):
 
     if params["compare"]:
         for f in params["additional_input_files"]:
-            hist = f.Get(params["numer"])
-            numer.append(hist.Clone())
+            if params["metric"] == "avgOTlen":
+                h_num = f.Get(params["numer"]).Clone()
+                h_numSq = f.Get(params["numer"].replace("numer", "numerSq")).Clone()
+                numer.append((h_num, h_numSq))
+            else:
+                hist = f.Get(params["numer"])
+                numer.append(hist.Clone())
             hist = f.Get(params["denom"])
             denom.append(hist.Clone())
 
@@ -243,6 +257,7 @@ def process_arguments_into_params(args):
     if params["metric"] == "duplrate": params["metricsuffix"] = "dr"
     if params["metric"] == "fakerate": params["metricsuffix"] = "fr"
     if params["metric"] == "fakeorduplrate": params["metricsuffix"] = "fdr"
+    if params["metric"] == "avgOTlen": params["metricsuffix"] = "ol"
 
     # If breakdown it must be object type of TC
     params["breakdown"] = args.breakdown
@@ -302,24 +317,34 @@ def draw_ratio(nums, dens, params):
     # Rebin if necessary
     if "scalar" in params["output_name"] and "ptscalar" not in params["output_name"]:
         for num in nums:
-            num.Rebin(180)
+            if isinstance(num, tuple):
+                num[0].Rebin(180)
+                num[1].Rebin(180)
+            else:
+                num.Rebin(180)
         for den in dens:
             den.Rebin(180)
 
     # Rebin if necessary
     if "coarse" in params["output_name"] and "ptcoarse" not in params["output_name"]:
         for num in nums:
-            num.Rebin(6)
+            if isinstance(num, tuple):
+                num[0].Rebin(6)
+                num[1].Rebin(6)
+            else:
+                num.Rebin(6)
         for den in dens:
             den.Rebin(6)
 
     # Deal with overflow bins for pt plots
     if "pt" in params["output_name"] or "vxy" in params["output_name"]:
         for num in nums:
-            overFlowBin = num.GetBinContent(num.GetNbinsX() + 1)
-            lastBin = num.GetBinContent(num.GetNbinsX())
-            num.SetBinContent(num.GetNbinsX(), lastBin + overFlowBin)
-            num.SetBinError(num.GetNbinsX(), sqrt(lastBin + overFlowBin))
+            h_list = num if isinstance(num, tuple) else [num]
+            for h in h_list:
+                overFlowBin = h.GetBinContent(h.GetNbinsX() + 1)
+                lastBin = h.GetBinContent(h.GetNbinsX())
+                h.SetBinContent(h.GetNbinsX(), lastBin + overFlowBin)
+                h.SetBinError(h.GetNbinsX(), sqrt(lastBin + overFlowBin))
         for den in dens:
             overFlowBin = den.GetBinContent(den.GetNbinsX() + 1)
             lastBin = den.GetBinContent(den.GetNbinsX())
@@ -329,15 +354,39 @@ def draw_ratio(nums, dens, params):
     # Create efficiency graphs
     teffs = []
     effs = []
-    for num, den in zip(nums, dens):
-        teff = r.TEfficiency(num, den)
-        eff = teff.CreateGraph()
-        teffs.append(teff)
-        effs.append(eff)
+    if params["metric"] == "avgOTlen":
+        for (num, num2), den in zip(nums, dens):
+            g = r.TGraphErrors()
+            ip = 0
+            nb = den.GetNbinsX()
+            for ib in range(1, nb + 1):
+                cnt = den.GetBinContent(ib)
+                S = num.GetBinContent(ib)
+                S2 = num2.GetBinContent(ib)
+                if cnt > 0:
+                    x = den.GetXaxis().GetBinCenter(ib)
+                    ex = den.GetXaxis().GetBinWidth(ib) / 2.0
+                    mean = S / cnt
+                    y = mean
+                    mean2 = S2 / cnt
+                    variance = mean2 - (mean * mean)
+                    if variance < 0: variance = 0.0
+                    stddev = sqrt(variance)
+                    ey = stddev / sqrt(cnt)
+                    g.SetPoint(ip, x, y)
+                    g.SetPointError(ip, ex, ey)
+                    ip += 1
+            if g.GetN() == 0:
+                g.SetPoint(0, 0.0, 0.0)
+                g.SetPointError(0, 0.0, 0.0)
+            effs.append(g)
+    else:
+        for num, den in zip(nums, dens):
+            teff = r.TEfficiency(num, den)
+            eff = teff.CreateGraph()
+            teffs.append(teff)
+            effs.append(eff)
 
-    # print(effs)
-
-    #
     hist_name_suffix = ""
     if params["xcoarse"]:
         hist_name_suffix += "coarse"
@@ -348,14 +397,12 @@ def draw_ratio(nums, dens, params):
     outputname = params["output_name"]
     for den in dens:
         den.Write(den.GetName() + hist_name_suffix, r.TObject.kOverwrite)
-        # eff_den = r.TGraphAsymmErrors(den)
-        # eff_den.SetName(outputname+"_den")
-        # eff_den.Write("", r.TObject.kOverwrite)
     for num in nums:
-        num.Write(num.GetName() + hist_name_suffix, r.TObject.kOverwrite)
-        # eff_num = r.TGraphAsymmErrors(num)
-        # eff_num.SetName(outputname+"_num")
-        # eff_num.Write("", r.TObject.kOverwrite)
+        if isinstance(num, tuple):
+            num[0].Write(num[0].GetName() + hist_name_suffix, r.TObject.kOverwrite)
+            num[1].Write(num[1].GetName() + hist_name_suffix, r.TObject.kOverwrite)
+        else:
+            num.Write(num.GetName() + hist_name_suffix, r.TObject.kOverwrite)
     for eff in effs:
         eff.SetName(outputname)
         eff.Write("", r.TObject.kOverwrite)
@@ -369,6 +416,8 @@ def parse_plot_name(output_name):
         rtnstr = ["Fake-or-duplicate Rate of"]
     elif "fake" in output_name:
         rtnstr = ["Fake Rate of"]
+    elif "avgOTlen" in output_name:
+        rtnstr = ["Average OT length of"]
     elif "dup" in output_name:
         rtnstr = ["Duplicate Rate of"]
     elif "inefficiency" in output_name:
@@ -452,6 +501,8 @@ def set_label(eff, output_name, raw_number):
     eff.GetXaxis().SetTitle(title)
     if "fakeorduplrate" in output_name:
         eff.GetYaxis().SetTitle("Fake-or-duplicate Rate")
+    elif "avgOTlen" in output_name:
+        eff.GetYaxis().SetTitle("<Number of OT hits>")
     elif "fakerate" in output_name:
         eff.GetYaxis().SetTitle("Fake Rate")
     elif "duplrate" in output_name:
@@ -518,7 +569,7 @@ def draw_label(params):
         particleselection = ((", Particle:" + pdgidstr) if pdgidstr else "" ) + ((", Charge:" + chargestr) if chargestr else "" )
         fiducial_label += particleselection
     # If fake rate or duplicate rate plot follow the following fiducial label rule
-    elif "fakerate" in output_name or "duplrate" in output_name or "fakeorduplrate" in output_name:
+    elif "fakerate" in output_name or "duplrate" in output_name or "fakeorduplrate" in output_name or "avgOTlen" in output_name:
         if "_pt" in output_name:
             fiducial_label = "|#eta| < {eta}".format(eta=etacut)
         elif "_eta" in output_name:
@@ -595,18 +646,22 @@ def draw_plot(effs, nums, dens, params):
             yaxis_min = effs[0].GetY()[i]
 
     # Set Yaxis range
-    effs[0].GetYaxis().SetRangeUser(0, 1.02)
-    if "zoom" not in output_name:
-        effs[0].GetYaxis().SetRangeUser(0, 1.02)
-    else:
-        if "fakeorduplrate" in output_name:
-            effs[0].GetYaxis().SetRangeUser(0.0, yaxis_max * 1.1)
-        elif "fakerate" in output_name:
-            effs[0].GetYaxis().SetRangeUser(0.0, yaxis_max * 1.1)
-        elif "duplrate" in output_name:
+    if "avgOTlen" in output_name:
+        if "zoom" not in output_name:
             effs[0].GetYaxis().SetRangeUser(0.0, yaxis_max * 1.1)
         else:
-            effs[0].GetYaxis().SetRangeUser(0.6, 1.02)
+            effs[0].GetYaxis().SetRangeUser(8.0, 12.0)
+    else:
+        effs[0].GetYaxis().SetRangeUser(0, 1.02)
+        if "zoom" not in output_name:
+            effs[0].GetYaxis().SetRangeUser(0, 1.02)
+        else:
+            if "fakerate" in output_name or "fakeorduplrate" in output_name:
+                effs[0].GetYaxis().SetRangeUser(0.0, yaxis_max * 1.1)
+            elif "duplrate" in output_name:
+                effs[0].GetYaxis().SetRangeUser(0.0, yaxis_max * 1.1)
+            else:
+                effs[0].GetYaxis().SetRangeUser(0.6, 1.02)
 
     # Set xaxis range
     if "_eta" in output_name:
@@ -625,8 +680,10 @@ def draw_plot(effs, nums, dens, params):
     effs[0].SetName(output_name)
 
     for i, num in enumerate(nums):
-        set_label(num, output_name, raw_number=True)
-        num.Draw("hist")
+        # Extract the Histogram if it's a tuple (sum, sumSq)
+        h_to_draw = num[0] if isinstance(num, tuple) else num
+        set_label(h_to_draw, output_name, raw_number=True)
+        h_to_draw.Draw("hist")
         c1.SaveAs("{}".format(output_fullpath.replace("/mtv/var/", "/mtv/num/").replace(".pdf", "_num{}.pdf".format(i))))
         c1.SaveAs("{}".format(output_fullpath.replace("/mtv/var/", "/mtv/num/").replace(".pdf", "_num{}.png".format(i))))
 
@@ -639,11 +696,13 @@ def draw_plot(effs, nums, dens, params):
     # Double ratio if more than one nums are provided
     # Take the first num as the base
     if len(nums) > 1:
-        base = nums[0].Clone()
-        base.Divide(nums[0], dens[0], 1, 1, "B") #Binomial
+        base_obj = nums[0][0] if isinstance(nums[0], tuple) else nums[0]
+        base = base_obj.Clone()
+        base.Divide(base, dens[0], 1, 1, "B") #Binomial
         others = []
         for num, den in zip(nums[1:], dens[1:]):
-            other = num.Clone()
+            other_obj = num[0] if isinstance(num, tuple) else num
+            other = other_obj.Clone()
             other.Divide(other, den, 1, 1, "B")
             others.append(other)
 
@@ -674,6 +733,7 @@ def plot_standard_performance_plots(args):
             "fakerate": ["pt", "ptlow", "ptmtv", "eta", "phi"],
             "duplrate": ["pt", "ptlow", "ptmtv", "eta", "phi"],
             "fakeorduplrate": ["pt", "ptlow", "ptmtv", "eta", "phi"],
+            "avgOTlen": ["eta"],
             }
     if (args.jet_branches): variables["eff"] = ["pt", "ptlow", "ptmtv", "eta", "phi", "dxy", "dz", "vxy", "deltaEta", "deltaPhi", "deltaR", "jet_eta", "jet_phi", "jet_pt"]
     sels = {
@@ -681,6 +741,7 @@ def plot_standard_performance_plots(args):
             "fakerate": ["none"],
             "duplrate": ["none"],
             "fakeorduplrate": ["none"],
+            "avgOTlen": ["none"],
             }
     xcoarses = {
             "pt": [False],
@@ -750,18 +811,31 @@ def plot_standard_performance_plots(args):
                 "T5_lower":[False],
                 "pLS_lower":[False],
             },
+            "avgOTlen":{
+                "TC":[False],
+                "pT5":[False],
+                "pT3":[False],
+                "T5":[False],
+                "pLS":[False],
+                "pT5_lower":[False],
+                "pT3_lower":[False],
+                "T5_lower":[False],
+                "pLS_lower":[False],
+            },
     }
     pdgids = {
             "eff": [0, 11, 13, 211, 321],
             "fakerate": [0],
             "duplrate": [0],
             "fakeorduplrate": [0],
+            "avgOTlen": [0],
             }
     charges = {
             "eff":[0, 1, -1],
             "fakerate":[0],
             "duplrate":[0],
             "fakeorduplrate":[0],
+            "avgOTlen":[0],
             }
 
     if args.metric:
@@ -806,15 +880,15 @@ def plot_standard_performance_plots(args):
         breakdowns = {"eff":{"TC":[False], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False], "pLS_lower":[False]},
                 "fakerate": {"TC":[False], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False], "pLS_lower":[False]},
                 "duplrate": {"TC":[False], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False], "pLS_lower":[False]},
-                "fakeorduplrate": {"TC":[False], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False], "pLS_lower":[False]}}
-
-
+                "fakeorduplrate": {"TC":[False], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False], "pLS_lower":[False]},
+                "avgOTlen":{"TC":[False], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False], "pLS_lower":[False]}}
     else:
         # Only eff / TC matters here
         breakdowns = {"eff":{"TC":[True], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False], "pLS_lower":[False]},
                 "fakerate": {"TC":[True], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False], "pLS_lower":[False]},
                 "duplrate": {"TC":[True], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False], "pLS_lower":[False]},
-                "fakeorduplrate": {"TC":[True], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False], "pLS_lower":[False]}}
+                "fakeorduplrate": {"TC":[True], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False], "pLS_lower":[False]},
+                "avgOTlen":{"TC":[False], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False], "pLS_lower":[False]}}
     if args.yzoom:
         args.yzooms = [args.yzoom]
 
@@ -826,7 +900,7 @@ def plot_standard_performance_plots(args):
             for variable in variables[metric]:
                 for yzoom in yzooms:
                     for xcoarse in xcoarses[variable]:
-                        for typ in types:
+                        for typ in (["TC"] if metric == "avgOTlen" else types):
                             print("type = ",typ)
                             for breakdown in breakdowns[metric][typ]:
                                 for pdgid in pdgids[metric]:

--- a/RecoTracker/LSTCore/standalone/efficiency/src/performance.h
+++ b/RecoTracker/LSTCore/standalone/efficiency/src/performance.h
@@ -14,6 +14,8 @@ void bookDuplicateRateSets(std::vector<RecoTrackSetDefinition>& DRset);
 void bookDuplicateRateSet(RecoTrackSetDefinition& DRset);
 void bookFakeOrDuplicateRateSets(std::vector<RecoTrackSetDefinition>& FDRset);
 void bookFakeOrDuplicateRateSet(RecoTrackSetDefinition& FDRset);
+void bookOTLengthSets(std::vector<RecoTrackSetDefinition>& OLsets);
+void bookOTLengthSet(RecoTrackSetDefinition& OLset);
 
 void fillEfficiencySets(std::vector<SimTrackSetDefinition>& effset);
 
@@ -48,6 +50,8 @@ void fillEfficiencySet(int isimtrk,
                        float vtx_y,
                        float vtx_z);
 
+void fillOTLengthSets(std::vector<RecoTrackSetDefinition>& OLsets);
+void fillOTLengthSet(int itc, RecoTrackSetDefinition& OLset, float pt, float eta);
 void fillFakeRateSets(std::vector<RecoTrackSetDefinition>& FRset);
 void fillFakeRateSet(int isimtrk, RecoTrackSetDefinition& FRset, float pt, float eta, float phi);
 void fillDuplicateRateSets(std::vector<RecoTrackSetDefinition>& DRset);


### PR DESCRIPTION
#### PR description:

This PR introduces a duplicate merging strategy for Line Segment Tracking (LST) that extends track candidates by recovering hits from duplicate T5 tracklets that were previously discarded. The algorithm iterates over T5s to identify duplicates eligible for merging, requiring that they pass a set of selections and originate from different layers. A new kernel, ExtendTrackCandidatesFromDupT5, merges hits from the highest-scoring duplicates into LST track candidates. About 70% of LST T5 and pT5 track candidates gain additional hits, improving pT resolution and increasing track candidate length with negligible impact on timing.

More info:  [LST Duplicate Merging.pdf](https://github.com/user-attachments/files/24135950/LST.Duplicate.Merging.pdf)

<img height="400" alt="Screenshot 2025-12-11 at 11 40 44 PM" src="https://github.com/user-attachments/assets/b71b8253-b17b-4228-a070-136035e9f7d1" />

cc. @slava77 