### PR TITLE
[15_1_X] Fix LHEEventProduct auto_ptr<PdfInfo> read rule to cover all previous versions

### DIFF
--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -241,7 +241,7 @@
   <version ClassVersion="14" checksum="905719452"/>
   <version ClassVersion="15" checksum="898288635"/>
  </class>
- <ioread sourceClass = "LHEEventProduct" version="[13]" targetClass="LHEEventProduct" source = "std::auto_ptr<gen::PdfInfo> pdf_;" target="pdf_">
+ <ioread sourceClass = "LHEEventProduct" version="[-13]" targetClass="LHEEventProduct" source = "std::auto_ptr<gen::PdfInfo> pdf_;" target="pdf_">
    <![CDATA[pdf_.reset(onfile.pdf_.get()); onfile.pdf_.release();]]>
  </ioread> 
  <ioread sourceClass = "LHEEventProduct" version="[-12]" targetClass="LHEEventProduct" source = "" target="npLO_">


### PR DESCRIPTION
#### PR description:

This PR backports the first commit of https://github.com/cms-sw/cmssw/pull/49593 to address https://github.com/cms-sw/cmssw/issues/49538

#### PR validation:

None beyond https://github.com/cms-sw/cmssw/pull/49593

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport from https://github.com/cms-sw/cmssw/pull/49593