### PR TITLE
[CPP23][FW] Fix for non-const lvalue reference of type E

### DIFF
--- a/FWCore/TestModules/plugins/GlobalVectorAnalyzer.cc
+++ b/FWCore/TestModules/plugins/GlobalVectorAnalyzer.cc
@@ -12,10 +12,10 @@
 namespace {
 
   template <typename T>
-  T& operator<<(T& out, std::vector<double> const& values) {
+  decltype(auto) operator<<(T&& out, std::vector<double> const& values) {
     if (values.empty()) {
       out << "{}";
-      return out;
+      return std::forward<T>(out);
     }
 
     auto it = values.begin();
@@ -26,7 +26,7 @@ namespace {
       ++it;
     }
     out << " }";
-    return out;
+    return std::forward<T>(out);
   }
 
 }  // namespace

--- a/FWCore/Utilities/interface/Exception.h
+++ b/FWCore/Utilities/interface/Exception.h
@@ -40,6 +40,7 @@
 #include <type_traits>
 #include <string_view>
 #include <concepts>
+#include <utility>
 
 #include <format>
 
@@ -112,15 +113,15 @@ namespace cms {
 
     template <typename E, typename T>
       requires std::derived_from<std::remove_reference_t<E>, Exception>
-    friend E& operator<<(E&& e, T const& stuff);
+    friend decltype(auto) operator<<(E&& e, T const& stuff);
 
     template <typename E>
       requires std::derived_from<std::remove_reference_t<E>, Exception>
-    friend E& operator<<(E&& e, std::ostream& (*f)(std::ostream&));
+    friend decltype(auto) operator<<(E&& e, std::ostream& (*f)(std::ostream&));
 
     template <typename E>
       requires std::derived_from<std::remove_reference_t<E>, Exception>
-    friend E& operator<<(E&& e, std::ios_base& (*f)(std::ios_base&));
+    friend decltype(auto) operator<<(E&& e, std::ios_base& (*f)(std::ios_base&));
 
     template <typename... Args>
     inline void format(std::format_string<Args...> format, Args&&... args);
@@ -161,23 +162,23 @@ namespace cms {
 
   template <typename E, typename T>
     requires std::derived_from<std::remove_reference_t<E>, Exception>
-  inline E& operator<<(E&& e, T const& stuff) {
+  inline decltype(auto) operator<<(E&& e, T const& stuff) {
     e.ost_ << stuff;
-    return e;
+    return std::forward<E>(e);
   }
 
   template <typename E>
     requires std::derived_from<std::remove_reference_t<E>, Exception>
-  inline E& operator<<(E&& e, std::ostream& (*f)(std::ostream&)) {
+  inline decltype(auto) operator<<(E&& e, std::ostream& (*f)(std::ostream&)) {
     f(e.ost_);
-    return e;
+    return std::forward<E>(e);
   }
 
   template <typename E>
     requires std::derived_from<std::remove_reference_t<E>, Exception>
-  inline E& operator<<(E&& e, std::ios_base& (*f)(std::ios_base&)) {
+  inline decltype(auto) operator<<(E&& e, std::ios_base& (*f)(std::ios_base&)) {
     f(e.ost_);
-    return e;
+    return std::forward<E>(e);
   }
 
 }  // namespace cms


### PR DESCRIPTION
In CPP23_X, there are many build errors like [a]. This change should fix all these error. 

[a]
```
  48868 FWCore/Utilities/interface/Exception.h:166</a>:12: error: cannot bind non-const lvalue reference of type 'cms::Exception&amp;' to an rvalue of type 'cms::Exception'
      2 FWCore/Utilities/interface/Exception.h:166</a>:12: error: cannot bind non-const lvalue reference of type 'cond::persistency::Exception&amp;' to an rvalue of type 'cond::persistency::Exception'
   2216 FWCore/Utilities/interface/Exception.h:166</a>:12: error: cannot bind non-const lvalue reference of type 'edm::Exception&amp;' to an rvalue of type 'edm::Exception'
     26 FWCore/Utilities/interface/Exception.h:166</a>:12: error: cannot bind non-const lvalue reference of type 'TritonException&amp;' to an rvalue of type 'TritonException'
      2 FWCore/Utilities/interface/Exception.h:166</a>:12: error: cannot bind non-const lvalue reference of type 'VertexException&amp;' to an rvalue of type 'VertexException'
    251 FWCore/Utilities/interface/Exception.h:166</a>:12: error: non-const lvalue reference to type 'cms::Exception' cannot bind to a temporary of type 'cms::Exception'
      7 FWCore/Utilities/interface/Exception.h:166</a>:12: error: non-const lvalue reference to type 'edm::Exception' cannot bind to a temporary of type 'edm::Exception'
      4 FWCore/Utilities/interface/Exception.h:173</a>:12: error: cannot bind non-const lvalue reference of type 'cms::Exception&amp;' to an rvalue of type 'cms::Exception'
      2 FWCore/Utilities/interface/Exception.h:180</a>:12: error: cannot bind non-const lvalue reference of type 'cms::Exception&amp;' to an rvalue of type 'cms::Exception'

```