### PR TITLE
Initialize member data of SelectedBxTableOutputBranches

### DIFF
--- a/L1TriggerScouting/Utilities/plugins/SelectedBxTableOutputBranches.h
+++ b/L1TriggerScouting/Utilities/plugins/SelectedBxTableOutputBranches.h
@@ -13,7 +13,7 @@
 class SelectedBxTableOutputBranches {
 public:
   SelectedBxTableOutputBranches(const edm::BranchDescription *desc, const edm::EDGetToken &token)
-      : m_token(token), m_name("SelBx_" + desc->moduleLabel()), m_branch(nullptr) {
+      : m_token(token), m_name("SelBx_" + desc->moduleLabel()), m_value(false), m_branch(nullptr) {
     if (desc->className() != "std::vector<unsigned int>")
       throw cms::Exception("Configuration", "SelectedBxTableOutputBranches can only write out vector<unsigned int>");
     if (desc->productInstanceName() != "SelBx") {


### PR DESCRIPTION
#### PR description:

This should fix a UBSAN warning about invalid values of a bool.

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/1720