### PR TITLE
L1-uGT emulator: fix value of 3-muon mass with "duplicate" muons

### DIFF
--- a/L1Trigger/L1TGlobal/src/CorrThreeBodyCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrThreeBodyCondition.cc
@@ -678,7 +678,6 @@ const bool l1t::CorrThreeBodyCondition::evaluateCondition(const int bxEval) cons
                                 << "  sqrt(|massSq|) = " << sqrt(fabs(2. * massSqPhy_12)) << std::endl;
 
           LogDebug("L1TGlobal") << "\n ########### THREE-BODY INVARIANT MASS #########################\n";
-          long long massSq = 0;
 
           if (preShift_01 == preShift_02 && preShift_01 == preShift_12 && preShift_02 == preShift_12) {
             LogDebug("L1TGlobal") << "Check the preshift value: " << preShift_01 << " = " << preShift_02 << " = "
@@ -689,15 +688,15 @@ const bool l1t::CorrThreeBodyCondition::evaluateCondition(const int bxEval) cons
                 << "Preshift values considered for the sum of the dimuon invariant masses are different!" << std::endl;
           }
 
-          if ((massSq_01 != massSq_02) && (massSq_01 != massSq_12) && (massSq_02 != massSq_12)) {
-            massSq = massSq_01 + massSq_02 + massSq_12;
-            LogDebug("L1TGlobal") << "massSq = " << massSq << std::endl;
-          } else {
-            LogDebug("L1TGlobal") << "Same pair of muons considered, three-body invariant mass do not computed"
-                                  << std::endl;
+          long long const massSq{massSq_01 + massSq_02 + massSq_12};
+
+          LogDebug("L1TGlobal") << "massSq = " << massSq;
+
+          if (massSq_01 == massSq_02 or massSq_01 == massSq_12 or massSq_02 == massSq_12) {
+            LogDebug("L1TGlobal") << "At least two dimuon masses have identical values";
           }
 
-          if (massSq >= 0 && massSq >= (long long)(corrPar.minMassCutValue * pow(10, preShift)) &&
+          if (massSq >= (long long)(corrPar.minMassCutValue * pow(10, preShift)) &&
               massSq <= (long long)(corrPar.maxMassCutValue * pow(10, preShift))) {
             LogDebug("L1TGlobal") << "    Passed Invariant Mass Cut ["
                                   << (long long)(corrPar.minMassCutValue * pow(10, preShift)) << ","


### PR DESCRIPTION
#### PR description:

https://github.com/cms-sw/cmssw/issues/49056#issuecomment-3414537143 showed data-emulator mismatches in the L1T decisions for three "tau to 3 muons" algorithms of the current Run-3 menu, i.e.
```
L1_TripleMu_3SQ_2p5SQ_0_Mass_Max12
L1_TripleMu_3SQ_2p5SQ_0_OS_Mass_Max12
L1_TripleMu_4SQ_2p5SQ_0_OS_Mass_Max12
```
This data-emulator discrepancy is also visibile in DQM, e.g. [run-395924](https://cern.ch/yyx7g).

<img width="1919" height="853" alt="run395924_l1tEmu_Tau3Mu" src="https://github.com/user-attachments/assets/5daa0c72-9b39-456f-b3dd-7d90f67a7df3" />

[#49056 (comment)](https://github.com/cms-sw/cmssw/issues/49056#issuecomment-3414537143) and a few additional checks show the following.
 - The level of data-emulator disagreement is around 0.3%, so a small effect.
 - The events showing the disagreement are rejected in the firmware implementation, and accepted by the emulator. This means that these discrepancies are of no consequence for data-taking (the events in question are rejected based on the L1T decisions from the hardware, regardless of the emulator), they just might lead to a slightly higher accept rate in MC simulations, and to data-emulator mismatches in the L1-uGT DQM.
 - The events where firmware and emulator disagree are all characterised by the presence of 2 muons with the same values of (`hwPt`, `hwEta(AtVtx)`, `hwPhi(AtVtx)`). For such events, the emulator returns a 3-muon mass equal to zero because [this "extra condition"](https://github.com/cms-sw/cmssw/blob/712e925576cdaabfc2bc3abfb2162b38756f09ee/L1Trigger/L1TGlobal/src/CorrThreeBodyCondition.cc#L692) fails (leaving `massSq == 0` based on its initialization value), so those events always pass the mass cut in the "tau to 3 muons" seeds (i.e. $0 \leq M \text{[GeV]} \leq 12$).

This PR removes the aforementioned "extra condition" from the L1-uGT emulator. If I checked correctly, the firmware implementation comes from [here](https://github.com/cms-l1-globaltrigger/mp7_ugt_legacy/blob/bff2f5e47d18b669d52ce40594dfb5a42408db5b/firmware/hdl/payload/gtl/common/sum_mass.vhd) (could anyone please confirm ?), and it does not include this "extra condition".

#### PR validation:

Running on the same 300K events used for https://github.com/cms-sw/cmssw/issues/49056#issuecomment-3414537143, the data-emulator mismatches for the 3 seeds in question disappear after including this PR. This was verified using [this config](https://github.com/missirol/hltScripts/blob/9ae02dcbb0f7559d67008eb8e4d70806ecf5467e/hltTests/test_l1tDataEmulatorMismatchesGT_cfg.py).

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

I think the only potential reason to backport this is Run-3 MC productions involving older release cycles. Since (a) the effect is quantitatively small, and (b) even if these events with "duplicate" muons are present in MC, in principle the HLT should be able to reject them, I do not plan to open any backports (except for backporting to `16_0_X` if this PR is moved to the `16_1_X` queue).
