### PR TITLE
Added GenD0ToKPiFilter for Official MC Request for DDbar in PbPb analysis

### DIFF
--- a/PhysicsTools/GenFilters/plugins/BuildFile.xml
+++ b/PhysicsTools/GenFilters/plugins/BuildFile.xml
@@ -1,0 +1,10 @@
+<library file="GenD0PairToKPiFilter.cc" name="PhysicsToolsGenFiltersPlugins">
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/MessageLogger"/>
+  <use name="FWCore/Utilities"/>
+  <use name="SimDataFormats/GeneratorProducts"/>
+  <use name="DataFormats/HepMCCandidate"/>
+  <use name="root"/>
+</library>
+

--- a/PhysicsTools/GenFilters/plugins/GenD0PairToKPiFilter.cc
+++ b/PhysicsTools/GenFilters/plugins/GenD0PairToKPiFilter.cc
@@ -1,0 +1,66 @@
+// File: GenD0PairToKPiFilter.cc
+
+#include "FWCore/Framework/interface/stream/EDFilter.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include <vector>
+
+class GenD0PairToKPiFilter : public edm::stream::EDFilter<> {
+	public:
+		explicit GenD0PairToKPiFilter(const edm::ParameterSet&);
+		bool filter(edm::Event&, const edm::EventSetup&) override;
+
+	private:
+		edm::EDGetTokenT<reco::GenParticleCollection> genParticlesToken_;
+};
+
+GenD0PairToKPiFilter::GenD0PairToKPiFilter(const edm::ParameterSet& iConfig) {
+	genParticlesToken_ = consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("src"));
+}
+
+bool GenD0PairToKPiFilter::filter(edm::Event& iEvent, const edm::EventSetup&) {
+	edm::Handle<reco::GenParticleCollection> genParticles;
+	iEvent.getByToken(genParticlesToken_, genParticles);
+
+	int D_count=0;
+
+
+	for (const auto& p : *genParticles) {
+		if (std::abs(p.pdgId()) != 421 || p.numberOfDaughters() != 2)
+			continue;
+		if (abs(p.pt()) < 1) continue; 
+
+		const reco::Candidate* d1 = p.daughter(0);
+		const reco::Candidate* d2 = p.daughter(1);
+
+		int pdg1 = d1->pdgId();
+		int pdg2 = d2->pdgId();
+
+		//std::cout << "-----------------------------------------------" << std::endl;
+
+		if (p.pdgId() == 421) {  // D0
+			if (((pdg1 == -321 && pdg2 == 211) || (pdg1 == 211 && pdg2 == -321)) && abs(d1->eta()) < 2.6 && abs(d2->eta()) < 2.6)
+			{       
+				D_count++;
+			}
+		}
+		
+		if (p.pdgId() == -421) {  // D0bar
+			if (((pdg1 == 321 && pdg2 == -211) || (pdg1 == -211 && pdg2 == 321)) && abs(d1->eta()) < 2.6 && abs(d2->eta()) < 2.6)
+			{      
+				D_count++;
+			}
+		}
+		if (D_count >= 2) return true;
+
+	}
+
+	return false;
+}
+
+DEFINE_FWK_MODULE(GenD0PairToKPiFilter);


### PR DESCRIPTION
…ysis

#### PR description:
This PR is needed to for creating an official MC in `CMSSW_13_0_23_HeavyIon`.  I am doing a physics analysis in PbPb of studying the DDbar delta_phi correlation.  For my analysis I need an official MC of only events containing at least 2 D0->k,pi decays
  - in the PR I added a specific filter that only permits events with at least 2 decays of D0->k,pi 
  - `PhysicsTools/GenFilters/plugins/GenD0PairToKPiFilter.cc`
  - it does not depend on other PR or externals
  - as far as I could tell the existing CMSSW filters are not compatible with requiring pairs
  - to be clear, this filter (and PR) will be used when I request the official MC

#### PR validation:

I produced 3M+ events with this filter according to the GEN/SIM steps and wrote a python script that analyzes all the outputted events to ensure that all of them  do, in fact, have at least 2 instances of D0->k,pi

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

It is intended to backport to `CMSSW_13_0_X`
