### PR TITLE
Phase2 Single_Tau_Trigger Path Added

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHpsPFTau150LooseTauWPDeepTau_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHpsPFTau150LooseTauWPDeepTau_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+hltHpsPFTau150LooseTauWPDeepTau = cms.EDFilter("HLT1PFTau",
+    MaxEta = cms.double(2.1),
+    MaxMass = cms.double(-1.0),
+    MinE = cms.double(-1.0),
+    MinEta = cms.double(-1.0),
+    MinMass = cms.double(-1.0),
+    MinN = cms.int32(1),
+    MinPt = cms.double(150.0),
+    inputTag = cms.InputTag("hltHpsSelectedPFTauLooseTauWPDeepTau"),
+    saveTags = cms.bool(True),
+    triggerType = cms.int32(84)
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_LooseDeepTauPFTauHPS150_L2NN_eta2p1_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_LooseDeepTauPFTauHPS150_L2NN_eta2p1_cfi.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..sequences.HLTBeginSequence_cfi import *
+from ..sequences.HLTRawToDigiSequence_cfi import *
+from ..sequences.HLTTICLLocalRecoSequence_cfi import *
+from ..sequences.HLTLocalrecoSequence_cfi import *
+from ..sequences.HLTTrackingSequence_cfi import *
+from ..sequences.HLTMuonsSequence_cfi import *
+from ..sequences.HLTParticleFlowSequence_cfi import *
+from ..sequences.HLTAK4PFJetsReconstruction_cfi import *
+from ..sequences.HLTPFTauHPS_cfi import *
+from ..sequences.HLTHPSDeepTauPFTauSequence_cfi import *
+from ..sequences.HLTEndSequence_cfi import *
+from ..modules.hltL1SingleNNTau150_cfi import *
+from ..modules.hltParticleFlowRecHitECALUnseeded_cfi import *
+from ..modules.hltParticleFlowClusterECALUncorrectedUnseeded_cfi import *
+from ..modules.hltParticleFlowClusterECALUnseeded_cfi import *
+from ..modules.hltAK4PFJetsForTaus_cfi import *
+from ..modules.hltHpsSelectedPFTauLooseTauWPDeepTau_cfi import *
+from ..modules.hltHpsPFTau150LooseTauWPDeepTau_cfi import *
+
+HLT_LooseDeepTauPFTauHPS150_L2NN_eta2p1 = cms.Path(
+    HLTBeginSequence 
+    + hltL1SingleNNTau150                              
+    + HLTRawToDigiSequence 
+    + HLTLocalrecoSequence 
+    + HLTTICLLocalRecoSequence 
+    + HLTTrackingSequence 
+    + HLTMuonsSequence 
+    + HLTParticleFlowSequence 
+    + hltParticleFlowRecHitECALUnseeded
+    + hltParticleFlowClusterECALUncorrectedUnseeded
+    + hltParticleFlowClusterECALUnseeded
+    + HLTAK4PFJetsReconstruction 
+    + hltAK4PFJetsForTaus 
+    + HLTPFTauHPS 
+    + HLTHPSDeepTauPFTauSequence 
+    + hltHpsSelectedPFTauLooseTauWPDeepTau 
+    + hltHpsPFTau150LooseTauWPDeepTau 
+    + HLTEndSequence 
+)

--- a/HLTrigger/Configuration/python/HLT_75e33_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_cff.py
@@ -120,6 +120,7 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Ele32_WPTight_Unseede
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Ele30_WPTight_L1Seeded_LooseDeepTauPFTauHPS30_eta2p1_CrossL1_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_IsoMu20_eta2p1_LooseDeepTauPFTauHPS27_eta2p1_CrossL1_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_IsoMu24_FromL1TkMuon_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_LooseDeepTauPFTauHPS150_L2NN_eta2p1_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_FromL1TkMuon_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Mu37_Mu27_FromL1TkMuon_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Mu50_FromL1TkMuon_cfi")
@@ -317,6 +318,10 @@ fragment.schedule = cms.Schedule(*[
     fragment.HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1,
     fragment.HLT_IsoMu20_eta2p1_LooseDeepTauPFTauHPS27_eta2p1_CrossL1,
     fragment.HLT_Ele30_WPTight_L1Seeded_LooseDeepTauPFTauHPS30_eta2p1_CrossL1,
+    fragment.HLT_LooseDeepTauPFTauHPS150_L2NN_eta2p1,
+    ### Removed temporarily until final decision on L1T tau Phase-2
+    #fragment.L1T_DoubleNNTau52,
+    #fragment.L1T_SingleNNTau150,
 
     fragment.MC_JME,
     fragment.MC_BTV,

--- a/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
@@ -119,6 +119,7 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Ele32_WPTight_L1Seede
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Ele30_WPTight_L1Seeded_LooseDeepTauPFTauHPS30_eta2p1_CrossL1_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_IsoMu20_eta2p1_LooseDeepTauPFTauHPS27_eta2p1_CrossL1_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_IsoMu24_FromL1TkMuon_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_LooseDeepTauPFTauHPS150_L2NN_eta2p1_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_FromL1TkMuon_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Mu37_Mu27_FromL1TkMuon_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Mu50_FromL1TkMuon_cfi")
@@ -282,6 +283,11 @@ fragment.schedule = cms.Schedule(*[
     fragment.HLT_DoubleMediumChargedIsoPFTauHPS40_eta2p1,
     fragment.HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1,
     fragment.HLT_IsoMu20_eta2p1_LooseDeepTauPFTauHPS27_eta2p1_CrossL1,
+    fragment.HLT_LooseDeepTauPFTauHPS150_L2NN_eta2p1,
+    
+    ### Removed temporarily until final decision on L1T tau Phase-2
+    #fragment.L1T_DoubleNNTau52,
+    #fragment.L1T_SingleNNTau150,
 
     fragment.HLTriggerFinalPath,
     fragment.HLTAnalyzerEndpath,

--- a/Validation/HLTrigger/python/HLTGenValidation_cff.py
+++ b/Validation/HLTrigger/python/HLTGenValidation_cff.py
@@ -561,7 +561,8 @@ HLTGenValSourceTAU = cms.EDProducer("HLTGenValSource",
     ),
     hltPathsToCheck = cms.vstring(
         'HLT_DoubleMediumChargedIsoPFTauHPS40_eta2p1',
-        'HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1'
+        'HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1',
+        'HLT_LooseDeepTauPFTauHPS150_L2NN_eta2p1'
     ),
     hltProcessName = cms.string('HLT'),
     objType = cms.string('tauHAD'),


### PR DESCRIPTION
Added Single Tau Trigger path for Phase2 , worked with Tau HLT Phase2 development group.

It was tested in miniAOD in CMSSW_15_1_0_pre4 and NanoAOD in CMSSW_16_0_0_pre2 , with Z'to tautau samples.

Trigger Efficiency had 48.7% .


* #49569 was submitted before.
    - MinEta for HLT1PFTau EDFilters has a default value of -1.0, which the config understands it as being -2.1. 
* [Slides](https://mattermost.web.cern.ch/files/w9xa1zkcjtf48ejuqi1etq1dgw/public?h=MJCc9wYFJm_ItqMkJMVt0hFs5H5-Zy2r11s6_XBi5lo) are not shared with TSG group yet , shared with Tau HLT phase2 group . 