### PR TITLE
Fix for c++23 build errors

### DIFF
--- a/CalibFormats/SiPixelObjects/src/PixelTKFECConfig.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelTKFECConfig.cc
@@ -209,7 +209,7 @@ std::string PixelTKFECConfig::typeFromTKFECID(std::string TKFECID) const {
 
   assert(0);
 
-  return nullptr;
+  return {};
 }
 
 unsigned int PixelTKFECConfig::addressFromTKFECID(std::string TKFECID) const {

--- a/FWStorage/XrdAdaptor/src/XrdSource.cc
+++ b/FWStorage/XrdAdaptor/src/XrdSource.cc
@@ -80,8 +80,6 @@ private:
  * thread to timeout).
  */
 class QueryAttrHandler : public XrdCl::ResponseHandler {
-  friend std::unique_ptr<QueryAttrHandler> std::make_unique<QueryAttrHandler>();
-
 public:
   QueryAttrHandler() = delete;
   ~QueryAttrHandler() override = default;

--- a/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
@@ -87,7 +87,7 @@ MultiTrackSelector::MultiTrackSelector(const edm::ParameterSet& cfg)
     qualityToSet_.push_back(TrackBase::undefQuality);
     // parameters for vertex selection
     vtxNumber_.push_back(useVertices_ ? trkSelectors[i].getParameter<int32_t>("vtxNumber") : 0);
-    vertexCut_.push_back(useVertices_ ? trkSelectors[i].getParameter<std::string>("vertexCut") : nullptr);
+    vertexCut_.push_back(useVertices_ ? trkSelectors[i].getParameter<std::string>("vertexCut") : "");
     //  parameters for adapted optimal cuts on chi2 and primary vertex compatibility
     res_par_.push_back(trkSelectors[i].getParameter<std::vector<double>>("res_par"));
     chi2n_par_.push_back(trkSelectors[i].getParameter<double>("chi2n_par"));


### PR DESCRIPTION
This fixes few of build errors for c++23
- [CalibFormats/SiPixelObjects/src/PixelTKFECConfig.cc](https://github.com/cms-sw/cmssw/compare/master...smuzaffar:fix-cpp23-r1?expand=1#diff-c966e23f1360464f9cd9ace062e38015c23f1ad91e6da5309bfea6ad4701237f) : `error: use of deleted function` [a]

- [FWStorage/XrdAdaptor/src/XrdSource.cc](https://github.com/cms-sw/cmssw/compare/master...smuzaffar:fix-cpp23-r1?expand=1#diff-951c69f5306bb43bd211ce2501973034877340f0b973892bef9b234581d9fc12): This might not work as default constructor `QueryAttrHandler()` is marked with `delete`. PR proposes to remove the `friend std::unique_ptr<QueryAttrHandler> std::make_unique<QueryAttrHandler>();` statement [b]

- [RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc](https://github.com/cms-sw/cmssw/compare/master...smuzaffar:fix-cpp23-r1?expand=1#diff-85d2e2509f6bb33867dd526fe6cef60fd8796332ffafea13d6ef1f365543b4e3):  `use of deleted function   basic_string(nullptr_t) = delete` . Pr proposes to use empty string [c]

[a]
```
src/CalibFormats/SiPixelObjects/src/PixelTKFECConfig.cc: In member function 'std::string pos::PixelTKFECConfig::typeFromTKFECID(std::string) const':
  [src/CalibFormats/SiPixelObjects/src/PixelTKFECConfig.cc:212](https://github.com/cms-sw/cmssw/blob/CMSSW_16_0_CPP23_X_2025-12-12-1100/CalibFormats/SiPixelObjects/src/PixelTKFECConfig.cc#L212):10: error: use of deleted function 'std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(std::nullptr_t) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; std::nullptr_t = std::nullptr_t]'
   212 |   return nullptr;
      |          ^~~~~~~
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.3.1-724da22786638848892aa9ded8fcd995/include/c++/14.3.1/string:54,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.3.1-724da22786638848892aa9ded8fcd995/include/c++/14.3.1/bits/locale_classes.h:40,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.3.1-724da22786638848892aa9ded8fcd995/include/c++/14.3.1/bits/ios_base.h:41,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.3.1-724da22786638848892aa9ded8fcd995/include/c++/14.3.1/ios:44,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.3.1-724da22786638848892aa9ded8fcd995/include/c++/14.3.1/ostream:40,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.3.1-724da22786638848892aa9ded8fcd995/include/c++/14.3.1/iostream:41,
                 from src/CalibFormats/SiPixelObjects/interface/PixelTKFECConfig.h:10,
                 from src/CalibFormats/SiPixelObjects/src/PixelTKFECConfig.cc:7:
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.3.1-724da22786638848892aa9ded8fcd995/include/c++/14.3.1/bits/basic_string.h:748:7: note: declared here
  748 |       basic_string(nullptr_t) = delete;
      |       ^~~~~~~~~~~~
src/CalibFormats/SiPixelObjects/src/PixelTKFECConfig.cc:212:10: note: use '-fdiagnostics-all-candidates' to display considered candidates
  212 |   return nullptr;
```

[b]
```
[src/Utilities/XrdAdaptor/src/XrdSource.cc:83](https://github.com/cms-sw/cmssw/blob/CMSSW_16_0_CPP23_X_2025-12-12-1100/Utilities/XrdAdaptor/src/XrdSource.cc#L83):44: error: redeclaration 'std::__detail::__unique_ptr_t<_Tp> std::make_unique(_Args&& ...) [with _Tp = QueryAttrHandler; _Args = {}; __detail::__unique_ptr_t<_Tp> = __detail::__unique_ptr_t<QueryAttrHandler>]' differs in 'constexpr' from previous declaration
    83 |   friend std::unique_ptr<QueryAttrHandler> std::make_unique<QueryAttrHandler>();
      |                                            ^~~
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.3.1-724da22786638848892aa9ded8fcd995/include/c++/14.3.1/memory:78,
                 from src/Utilities/XrdAdaptor/src/XrdSource.cc:4:
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.3.1-724da22786638848892aa9ded8fcd995/include/c++/14.3.1/bits/unique_ptr.h:1076:5: note: previous declaration 'constexpr std::__detail::__unique_ptr_t<_Tp> std::make_unique(_Args&& ...) [with _Tp = QueryAttrHandler; _Args = {}; __detail::__unique_ptr_t<_Tp> = __detail::__unique_ptr_t<QueryAttrHandler>]'
 1076 |     make_unique(_Args&&... __args)
```

[c]
```
[src/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc:90](https://github.com/cms-sw/cmssw/blob/CMSSW_16_0_CPP23_X_2025-12-12-1100/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc#L90):98: error: use of deleted function 'std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(std::nullptr_t) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; std::nullptr_t = std::nullptr_t]'
    90 |     vertexCut_.push_back(useVertices_ ? trkSelectors[i].getParameter<std::string>("vertexCut") : nullptr);
      |                                                                                                  ^~~~~~~
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.3.1-724da22786638848892aa9ded8fcd995/include/c++/14.3.1/string:54,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.3.1-724da22786638848892aa9ded8fcd995/include/c++/14.3.1/bits/locale_classes.h:40,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.3.1-724da22786638848892aa9ded8fcd995/include/c++/14.3.1/bits/ios_base.h:41,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.3.1-724da22786638848892aa9ded8fcd995/include/c++/14.3.1/ios:44,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.3.1-724da22786638848892aa9ded8fcd995/include/c++/14.3.1/ostream:40,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.3.1-724da22786638848892aa9ded8fcd995/include/c++/14.3.1/bits/unique_ptr.h:43,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.3.1-724da22786638848892aa9ded8fcd995/include/c++/14.3.1/memory:78,
                 from src/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.h:15:
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.3.1-724da22786638848892aa9ded8fcd995/include/c++/14.3.1/bits/basic_string.h:748:7: note: declared here
  748 |       basic_string(nullptr_t) = delete;
```