### PR TITLE
auto detect first vertex with Higgs in children list

### DIFF
--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -81,7 +81,21 @@ void HTXSRivetProducer::produce(edm::Event& iEvent, const edm::EventSetup&) {
         unsigned nBs = 0;
         unsigned nHs = 0;
 
-        ConstGenVertexPtr HSvtx = myGenEvent->vertices()[0];
+        // Find Higgs production vertex automatically
+        ConstGenVertexPtr HSvtx = nullptr;
+        // Loop through all vertices and find the FIRST one where Higgs is an outgoing particle
+        int totlv = int(myGenEvent->vertices().size());
+        for (auto i = 0; i < totlv; i++) {
+          ConstGenVertexPtr vtx = myGenEvent->vertices()[i];
+          for (const auto& ptcl : HepMCUtils::particles(vtx, Relatives::CHILDREN)) {
+            if (ptcl->pdg_id() == 25) {  // Higgs found as outgoing
+              HSvtx = vtx;
+              break;  // break inner loop
+            }
+          }
+          if (HSvtx)
+            break;  // break outer loop when we found the first Higgs vertex
+        }
 
         if (HSvtx) {
           for (const auto& ptcl : HepMCUtils::particles(HSvtx, Relatives::CHILDREN)) {
@@ -146,7 +160,6 @@ void HTXSRivetProducer::produce(edm::Event& iEvent, const edm::EventSetup&) {
             << "ProductionMode must be one of: GGF,VBF,WH,ZH,QQ2ZH,GG2ZH,TTH,BBH,TH,AUTO ";
       }
       _HTXS->setHiggsProdMode(m_HiggsProdMode);
-
       // at this point the production mode must be known
       if (m_HiggsProdMode == HTXS::UNKNOWN) {
         edm::LogInfo("HTXSRivetProducer") << "HTXSRivetProducer WARNING: HiggsProduction mode is UNKNOWN" << endl;


### PR DESCRIPTION
#### PR description:

The current HTXS production-mode identification relies on inspecting GenEvent::vertices()[0] to determine the Higgs boson’s production topology. However, for certain `MG5_aMC@NLO FxFx` samples—such as `TTH-Hto2G_Par-M-125_TuneCP5_13p6TeV_amcatnloFXFX-pythia8`—the Higgs does not appear among the children of vertices()[0].

As a result, the HTXS Rivet module fails to assign a valid Higgs production mode, which propagates to a failure in HTXS categorization during MiniAOD→NanoAOD production. This PR updates the logic to automatically identify the first GenVertex that contains a Higgs boson among its outgoing particles, rather than assuming it is located at vertices()[0].

#### PR validation:

The updated logic was validated by running MiniAOD → NanoAOD workflows on both:
- MG5_aMC@NLO FxFx samples (e.g. problematic TTH FxFx datasets)
- POWHEG samples

In all tested samples, the HTXS production mode and category are now correctly assigned.

@mseidel42 

