### PR TITLE
update the DQM legacy root file used in a bunch of SiStrip unit tests

### DIFF
--- a/CalibTracker/SiStripQuality/test/test_makeMergedBadComponentsWithFedErr.sh
+++ b/CalibTracker/SiStripQuality/test/test_makeMergedBadComponentsWithFedErr.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 function die { echo $1: status $2 ;  exit $2; }
-run="319176"
-dqmFile="/eos/cms/store/group/comm_dqm/DQMGUI_data/Run2018/ZeroBias/R0003191xx/DQM_V0001_R000319176__ZeroBias__Run2018B-PromptReco-v2__DQMIO.root"
+run="398593"
+dqmFile="/eos/cms/store/group/comm_dqm/DQMGUI_data/Run2025/ZeroBias/0003985xx/DQM_V0001_R000398593__ZeroBias__Run2025G-PromptReco-v1__DQMIO.root"
 if [ ! -f "${dqmFile}" ]; then
   die "SKIPPING test, file ${dqmFile} not found" 0
 fi
-runStartTime=$( (python "${SCRAM_TEST_PATH}/cfg/getRunStartTime.py" "${run}" | tail -n1 ) || die "Failed to get run start time" $? )
+runStartTime=$( (python3 "${SCRAM_TEST_PATH}/cfg/getRunStartTime.py" "${run}" | tail -n1 ) || die "Failed to get run start time" $? )
 echo "DEBUG: Run ${run} started at ${runStartTime}"
 (cmsRun "${SCRAM_TEST_PATH}/cfg/makeMergeBadComponentPayload_example_cfg.py" globalTag=auto:run3_data_prompt runNumber="${run}"  runStartTime="${runStartTime}" dqmFile="${dqmFile}" dbfile="test.db" outputTag="TestBadComponents" ) || die "Failure running cmsRun makeMergeBadComponentPayload_example_cfg.py" $?
 # get the hash
@@ -13,5 +13,5 @@ plEntryLn=$( (conddb --db sqlite_file:test.db list TestBadComponents | grep SiSt
 read -a plEntryLn_split <<< "${plEntryLn}"
 plHash="${plEntryLn_split[-2]}"
 (conddb --db sqlite_file:test.db dump "${plHash}" --format=xml -d test_dump.log ) || die "Could not dump test payload" $?
-(conddb dump 750b6c7049ccd4d2448944b22c2d4d16bf9cc30c --format=xml -d ref_dump.log ) || die "Could not dump reference payload" $?  # from SiStripBadComponents_2018_forSpecialBetaRun_v0_mc
+(conddb --db dev dump 6b4b48e52cca67791dbd5e988c61da5a429e9b22 --format=xml -d ref_dump.log ) || die "Could not dump reference payload" $?  # from SiStripBadComponents_Merged_Run398593_ForUnitTest_v0
 (diff -u ref_dump.log test_dump.log ) || die "Different payloads" $?

--- a/DQM/SiStripMonitorClient/test/test_SiStripDQM_OfflineTkMap.sh
+++ b/DQM/SiStripMonitorClient/test/test_SiStripDQM_OfflineTkMap.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 function die { echo $1: status $2; exit $2; }
 GT=`echo ${@} | python3 -c 'import Configuration.AlCa.autoCond as AC;print(AC.autoCond["run3_data_prompt"])'`
-RUN="319176"
-DQMFILE="/store/group/comm_dqm/DQMGUI_data/Run2018/ZeroBias/R0003191xx/DQM_V0001_R000319176__ZeroBias__Run2018B-PromptReco-v2__DQMIO.root"
+RUN="398593"
+DQMFILE="/store/group/comm_dqm/DQMGUI_data/Run2025/ZeroBias/0003985xx/DQM_V0001_R000398593__ZeroBias__Run2025G-PromptReco-v1__DQMIO.root"
 COMMMAND=`xrdfs cms-xrd-global.cern.ch locate $DQMFILE`
 STATUS=$?
 echo "xrdfs command status = "$STATUS

--- a/DQM/SiStripMonitorClient/test/test_TreeAndTkMapProducer.sh
+++ b/DQM/SiStripMonitorClient/test/test_TreeAndTkMapProducer.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 function die { echo $1: status $2; exit $2; }
-DQMFILE="/store/group/comm_dqm/DQMGUI_data/Run2018/ZeroBias/R0003191xx/DQM_V0001_R000319176__ZeroBias__Run2018B-PromptReco-v2__DQMIO.root"
+DQMFILE="/store/group/comm_dqm/DQMGUI_data/Run2025/ZeroBias/0003985xx/DQM_V0001_R000398593__ZeroBias__Run2025G-PromptReco-v1__DQMIO.root"
 COMMMAND=`xrdfs cms-xrd-global.cern.ch locate $DQMFILE`
 STATUS=$?
 echo "xrdfs command status = "$STATUS
 if [ $STATUS -eq 0 ]; then
     echo "Using file ${DQMFILE} Running in ${SCRAM_TEST_PATH}."
-    xrdcp root://cms-xrd-global.cern.ch//$DQMFILE DQM_V0001_R000319176__ZeroBias__Run2018B-PromptReco-v2__DQMIO.root 
-    (python3 ${SCRAM_TEST_PATH}/../scripts/PhaseITreeProducer.py DQM_V0001_R000319176__ZeroBias__Run2018B-PromptReco-v2__DQMIO.root) || die 'failed running PhaseITreeProducer.py' $?
-    (python3 ${SCRAM_TEST_PATH}/../scripts/TH2PolyOfflineMaps.py DQM_V0001_R000319176__ZeroBias__Run2018B-PromptReco-v2__DQMIO.root 3000 2000 ) || die 'failed running TH2PolyOfflineMaps.py' $?
+    xrdcp root://cms-xrd-global.cern.ch//$DQMFILE DQM_V0001_R000398593__ZeroBias__Run2025G-PromptReco-v1__DQMIO.root
+    (python3 ${SCRAM_TEST_PATH}/../scripts/PhaseITreeProducer.py DQM_V0001_R000398593__ZeroBias__Run2025G-PromptReco-v1__DQMIO.root) || die 'failed running PhaseITreeProducer.py' $?
+    (python3 ${SCRAM_TEST_PATH}/../scripts/TH2PolyOfflineMaps.py DQM_V0001_R000398593__ZeroBias__Run2025G-PromptReco-v1__DQMIO.root 3000 2000 ) || die 'failed running TH2PolyOfflineMaps.py' $?
 else 
   die "SKIPPING test, file ${DQMFILE} not found" 0
 fi


### PR DESCRIPTION
#### PR description:

I noticed that few DQM-related unit tests were not being executed because the input file was stale and was removed from `eos`.
I update the test to use new files. 

#### PR validation:

`scram b runtests` runs

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
