### PR TITLE
Check that entries for missing FEDs have zero length

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.h
@@ -129,8 +129,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             fedId_{cms::alpakatools::make_host_buffer<unsigned char[]>(queue, words)} {};
 
       void initializeWordFed(int fedId, unsigned int wordCounterGPU, const uint32_t* src, unsigned int length) {
-        if (src == nullptr)
+        if (src == nullptr) {
+          // A nullptr src value should indicate a non-present FED, and should always come with a zero length.
+          assert(length == 0);
           return;
+        }
         std::memcpy(word_.data() + wordCounterGPU, src, sizeof(uint32_t) * length);
         std::memset(fedId_.data() + wordCounterGPU / 2, fedId - 1200, length / 2);
       }


### PR DESCRIPTION
#### PR description:

A `nullptr` source value should indicate a non-present FED, and should always come with a zero length.

Follow-up to https://github.com/cms-sw/cmssw/pull/49631.

#### PR validation:

None.