### PR TITLE
Extend an exception message to mention fillDescriptions() function

### DIFF
--- a/FWCore/ParameterSet/src/ParameterSetDescription.cc
+++ b/FWCore/ParameterSet/src/ParameterSetDescription.cc
@@ -226,12 +226,14 @@ namespace edm {
       throw edm::Exception(errors::Configuration)
           << "Illegal parameter found in configuration.  The parameter is named:\n"
           << ss.str() << "You could be trying to use a parameter name that is not\n"
-          << "allowed for this plugin or it could be misspelled.\n";
+          << "allowed for this plugin, or it could be misspelled, or this parameter\n"
+          << "needs to be defined in the fillDescription() method of the plugin.\n";
     } else {
       throw edm::Exception(errors::Configuration)
           << "Illegal parameters found in configuration.  The parameters are named:\n"
           << ss.str() << "You could be trying to use parameter names that are not\n"
-          << "allowed for this plugin or they could be misspelled.\n";
+          << "allowed for this plugin, or they could be misspelled, or these parameters\n"
+          << "need to be defined in the fillDescription() method of the plugin.\n";
     }
   }
 


### PR DESCRIPTION
#### PR description:

Resolves https://github.com/cms-sw/cmssw/issues/49642
Resolves https://github.com/cms-sw/framework-team/issues/1723

#### PR validation:

Code compiles