### PR TITLE
[15_1_X]: Disable ZDC digitization for simulation

### DIFF
--- a/Configuration/ProcessModifiers/python/zdcDigi_cff.py
+++ b/Configuration/ProcessModifiers/python/zdcDigi_cff.py
@@ -1,3 +1,3 @@
 import FWCore.ParameterSet.Config as cms
 
-zdcNoDigi =  cms.Modifier()
+zdcDigi =  cms.Modifier()

--- a/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
@@ -10,7 +10,7 @@ hcalSimBlock = cms.PSet(
     # whether cells with MC signal get noise added
     doNoise = cms.bool(True),
     killHE = cms.bool(False),
-    doZDCDigi = cms.bool(True),
+    doZDCDigi = cms.bool(False),
     HcalPreMixStage1 = cms.bool(False),
     HcalPreMixStage2 = cms.bool(False),
     # whether cells with no MC signal get an empty signal created
@@ -63,13 +63,11 @@ from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 (run2_HCAL_2017 & ~fastSim).toModify( hcalSimBlock, TestNumbering = True )
 
 # remove HE processing for phase 2, completely put in HGCal land
-# Also inhibit ZDC digitization
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toModify(hcalSimBlock,
-                      doZDCDigi = False,
                       killHE = True
 )
 
-# inhibit ZDC digitization
-from Configuration.Eras.Modifier_zdcNoDigi_cff import zdcNoDigi
-zdcNoDigi.toModify(hcalSimBlock, doZDCDigi = False )
+# enable ZDC digitization
+from Configuration.ProcessModifiers.zdcDigi_cff import zdcDigi
+zdcDigi.toModify(hcalSimBlock, doZDCDigi = True )


### PR DESCRIPTION
#### PR description:

This PR disables ZDC digitization in simulation in order to prevent runtime errors (see https://github.com/cms-sw/cmssw/issues/43582). The ZDC is not incorporated fully into CMSSW and therefore this has no impact on analysis. Additionally, an era modifier has been implemented such that the ZDC digitization can be re-implemented for special cases in the event that it is needed.

#### PR validation:

The PR validation is documented in this [dropbox paper](https://www.dropbox.com/scl/fi/qh9hj2l1vdmy4i2f5r865/Disabling-ZDC-Digitization.paper?rlkey=80q18mmkvr8j7rfwjpgk5kzwq&st=nfao3zvi&dl=0) and was tests using 2025 MC workflow.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/49612

Tagging HIN colleagues: @mandrenguyen
Tagging HCAL colleagues:@abdoulline @yildirayk
