### PR TITLE
Fix for cuda/eigen unit test

### DIFF
--- a/DataFormats/Math/test/simpleCholeskyTest.cu
+++ b/DataFormats/Math/test/simpleCholeskyTest.cu
@@ -24,13 +24,15 @@ __global__ void invert(M* mm, int n) {
   if (i >= n)
     return;
 
-  auto& m = mm[i];
+  auto& src = mm[i];
+  M dst;
 
-  printf("before %d %f %f %f\n", N, m(0, 0), m(1, 0), m(1, 1));
+  printf("before %d %f %f %f\n", N, src(0, 0), src(1, 0), src(1, 1));
 
-  invertNN(m, m);
+  invertNN(src, dst);
+  src = dst;
 
-  printf("after %d %f %f %f\n", N, m(0, 0), m(1, 0), m(1, 1));
+  printf("after %d %f %f %f\n", N, src(0, 0), src(1, 0), src(1, 1));
 }
 
 template <typename M, int N>
@@ -87,7 +89,11 @@ int main() {
 
   printf("on CPU before %d %f %f %f\n", DIM, m(0, 0), m(1, 0), m(1, 1));
 
-  invertNN(m, m);
+  {
+    M tmp;
+    invertNN(m, tmp);
+    m = tmp;
+  }
 
   printf("on CPU after %d %f %f %f\n", DIM, m(0, 0), m(1, 0), m(1, 1));
 
@@ -95,8 +101,6 @@ int main() {
   cudaMalloc(&d, sizeof(M));
   cudaMemcpy(d, &m, sizeof(M), cudaMemcpyHostToDevice);
   invert<M, DIM><<<1, 1>>>((M*)d, 1);
-  cudaCheck(cudaDeviceSynchronize());
-  invertE<M, DIM><<<1, 1>>>((M*)d, 1);
   cudaCheck(cudaDeviceSynchronize());
 
   return 0;

--- a/RecoTracker/PixelTrackFitting/test/testEigenGPU.cu
+++ b/RecoTracker/PixelTrackFitting/test/testEigenGPU.cu
@@ -37,8 +37,8 @@ namespace riemannFit {
 template <int N>
 __global__ void kernelPrintSizes(double* __restrict__ phits, float* __restrict__ phits_ge) {
   auto i = blockIdx.x * blockDim.x + threadIdx.x;
-  riemannFit::Map3xNd<N> hits(phits + i, 3, 4);
-  riemannFit::Map6xNf<N> hits_ge(phits_ge + i, 6, 4);
+  riemannFit::Map3xNd<N> hits(phits + i);
+  riemannFit::Map6xNf<N> hits_ge(phits_ge + i);
   if (i != 0)
     return;
   printf("GPU sizes %lu %lu %lu %lu %lu\n",
@@ -52,8 +52,8 @@ __global__ void kernelPrintSizes(double* __restrict__ phits, float* __restrict__
 template <int N>
 __global__ void kernelFastFit(double* __restrict__ phits, double* __restrict__ presults) {
   auto i = blockIdx.x * blockDim.x + threadIdx.x;
-  riemannFit::Map3xNd<N> hits(phits + i, 3, N);
-  riemannFit::Map4d result(presults + i, 4);
+  riemannFit::Map3xNd<N> hits(phits + i);
+  riemannFit::Map4d result(presults + i);
 #ifdef USE_BL
   brokenline::fastFit(hits, result);
 #else
@@ -71,9 +71,9 @@ __global__ void kernelBrokenLineFit(double* __restrict__ phits,
                                     riemannFit::CircleFit* circle_fit,
                                     riemannFit::LineFit* line_fit) {
   auto i = blockIdx.x * blockDim.x + threadIdx.x;
-  riemannFit::Map3xNd<N> hits(phits + i, 3, N);
-  riemannFit::Map4d fast_fit_input(pfast_fit_input + i, 4);
-  riemannFit::Map6xNf<N> hits_ge(phits_ge + i, 6, N);
+  riemannFit::Map3xNd<N> hits(phits + i);
+  riemannFit::Map4d fast_fit_input(pfast_fit_input + i);
+  riemannFit::Map6xNf<N> hits_ge(phits_ge + i);
 
   brokenline::PreparedBrokenLineData<N> data;
   riemannFit::Matrix3d Jacob;
@@ -105,9 +105,9 @@ __global__ void kernel_CircleFit(double* __restrict__ phits,
                                  double B,
                                  riemannFit::CircleFit* circle_fit_resultsGPU) {
   auto i = blockIdx.x * blockDim.x + threadIdx.x;
-  riemannFit::Map3xNd<N> hits(phits + i, 3, N);
-  riemannFit::Map4d fast_fit_input(pfast_fit_input + i, 4);
-  riemannFit::Map6xNf<N> hits_ge(phits_ge + i, 6, N);
+  riemannFit::Map3xNd<N> hits(phits + i);
+  riemannFit::Map4d fast_fit_input(pfast_fit_input + i);
+  riemannFit::Map6xNf<N> hits_ge(phits_ge + i);
 
   constexpr auto n = N;
 
@@ -152,9 +152,9 @@ __global__ void kernelLineFit(double* __restrict__ phits,
                               double* __restrict__ pfast_fit_input,
                               riemannFit::LineFit* line_fit) {
   auto i = blockIdx.x * blockDim.x + threadIdx.x;
-  riemannFit::Map3xNd<N> hits(phits + i, 3, N);
-  riemannFit::Map4d fast_fit_input(pfast_fit_input + i, 4);
-  riemannFit::Map6xNf<N> hits_ge(phits_ge + i, 6, N);
+  riemannFit::Map3xNd<N> hits(phits + i);
+  riemannFit::Map4d fast_fit_input(pfast_fit_input + i);
+  riemannFit::Map6xNf<N> hits_ge(phits_ge + i);
   line_fit[i] = riemannFit::lineFit(hits, hits_ge, circle_fit[i], fast_fit_input, B, true);
 }
 #endif

--- a/RecoTracker/PixelTrackFitting/test/testEigenGPUNoFit.cu
+++ b/RecoTracker/PixelTrackFitting/test/testEigenGPUNoFit.cu
@@ -3,6 +3,7 @@
 #include <Eigen/Core>
 #include <Eigen/Eigenvalues>
 
+#include "DataFormats/Math/interface/choleskyInversion.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"
 #include "test_common.h"
@@ -31,7 +32,9 @@ __global__ void kernelInverse3x3(Matrix3d *in, Matrix3d *out) { (*out) = in->inv
 
 __global__ void kernelInverse4x4(Matrix4d *in, Matrix4d *out) { (*out) = in->inverse(); }
 
-__global__ void kernelInverse5x5(Matrix5d *in, Matrix5d *out) { (*out) = in->inverse(); }
+__global__ void kernelInverse5x5(Matrix5d *in, Matrix5d *out) {
+  math::cholesky::invertNN(*in, *out);
+}
 
 template <typename M1, typename M2, typename M3>
 __global__ void kernelMultiply(M1 *J, M2 *C, M3 *result) {

--- a/RecoTracker/PixelTrackFitting/test/testEigenGPUNoFit.cu
+++ b/RecoTracker/PixelTrackFitting/test/testEigenGPUNoFit.cu
@@ -32,9 +32,7 @@ __global__ void kernelInverse3x3(Matrix3d *in, Matrix3d *out) { (*out) = in->inv
 
 __global__ void kernelInverse4x4(Matrix4d *in, Matrix4d *out) { (*out) = in->inverse(); }
 
-__global__ void kernelInverse5x5(Matrix5d *in, Matrix5d *out) {
-  math::cholesky::invertNN(*in, *out);
-}
+__global__ void kernelInverse5x5(Matrix5d *in, Matrix5d *out) { math::cholesky::invertNN(*in, *out); }
 
 template <typename M1, typename M2, typename M3>
 __global__ void kernelMultiply(M1 *J, M2 *C, M3 *result) {


### PR DESCRIPTION
This is a possible fix for failed CUDA/GPU tests with newer eigen which we see in PY312_X IBs.
- simpleCholeskyTest.cu: Use different objects for `src` and `dst` while calling `invertNN` .  Chatgppt identifies
```
What goes wrong with invertNN(m, m)
  - src(i,j) and dst(i,j) refer to the same object
   - Writes to dst happen before all reads from src are finished
   - On CPU, this happens to limp along
   -  On GPU:
        Different instruction ordering
        Different register pressure
        Different memory model
        Guaranteed corruption
```

- testEigenGPUNoFit.cu: Again chatgpt identifies the following and suggest to use the invertNN for large matrix
```
CUDA cannot fully support all Eigen expressions on the device, especially:
        Matrix.inverse()
        SelfAdjointEigenSolver::computeDirect()
    When you call in->inverse() in a __global__ kernel (like in kernelInverse5x5), Eigen will internally use permutation matrices (for LU or LDLT) on the GPU memory.

    Eigen's permutation matrices use bounds-checked indexing. When they run on the device, some of these bounds checks fail because device memory isn't tracked the same way as host memory.

    This triggers the applyTranspositionOnTheRight assertion failure.
```

- testEigenGPU.cu: Eigen already knows the dimensions at compile time. This change matches the rest of cmssw code where we use `riemannFit::Map*`

This is an attempt to fix these unit tests for new eigen but I am not sure if these are the correct fixes. 
FYI @fwyzard 
