### PR TITLE
Enable persistency of maps and pairs of <DetId, const unsigned int>.

### DIFF
--- a/DataFormats/DetId/src/classes_def.xml
+++ b/DataFormats/DetId/src/classes_def.xml
@@ -14,7 +14,7 @@
   <class name="std::pair<const DetId,float>"/>
   <class name="std::map<DetId,float>"/>
   <class name="edm::Wrapper<std::map<DetId,float> >"/>
-  <class name="std::unordered_map<DetId,const unsigned int>" persistent="false"/>
-  <class name="edm::Wrapper<std::unordered_map<DetId, const unsigned int>>" persistent="false"/>
-  <class name="std::pair<const DetId, const unsigned int>" persistent="false"/>
+  <class name="std::unordered_map<DetId,const unsigned int>"/>
+  <class name="edm::Wrapper<std::unordered_map<DetId, const unsigned int>>"/>
+  <class name="std::pair<const DetId, const unsigned int>"/>
 </lcgdict>


### PR DESCRIPTION
It is now possible to persist `std::pair<DetId, const unsigned int>` and `std:unordered_map<DetId, const unsigned int>`.

Tested by producing a file containing the products of `RecHitMapProducer`, which stores the map above as products.