### PR TITLE
LST: Ensure quadruplet 'dBeta' initialization

### DIFF
--- a/RecoTracker/LSTCore/src/alpaka/Quadruplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quadruplet.h
@@ -464,6 +464,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                              dBeta,
                                              ptCut))
         return false;
+    } else {
+      dBeta = 0;
     }
 
     if (not passT4RZConstraint(acc,


### PR DESCRIPTION
#### PR description:

Fix to ensure that the `dBeta` value is always initialized for quadruplet objects. In the case where `dBeta` is not computed, it is set to 0.

Resolves cms-sw/cmssw#49650
