### PR TITLE
[FWLite] Updated BeamSpot BuildFile.xml to have DataFormats/TrivialSerialisation

### DIFF
--- a/DataFormats/BeamSpot/BuildFile.xml
+++ b/DataFormats/BeamSpot/BuildFile.xml
@@ -6,6 +6,7 @@
 <use name="DataFormats/GeometrySurface"/>
 <use name="DataFormats/Math"/>
 <use name="DataFormats/Portable"/>
+<use name="DataFormats/TrivialSerialisation"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>
 <flags ALPAKA_BACKENDS="!serial"/>
 <export>


### PR DESCRIPTION
#### PR description:

FWLite compilation gets terminated with
gmake: *** [tmp/el8_amd64_gcc13/src/DataFormats/BeamSpot/src/DataFormatsBeamSpot/classes.cc.o] Error 1
due to missing `DataFormats/TrivialSerialisation`
```BASH
>> Compiling  src/DataFormats/BeamSpot/src/classes.cc
/data/cmsbld/jenkins/workspace/build-fwlite-ib/cms/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/c++ -c -DCMS_MICRO_ARCH='x86-64-v3' -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=130400 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DBOOST_MPL_IGNORE_PARENTHESES_WARNING -DCMSSW_GIT_HASH='CMSSW_16_0_X_2025-12-18-1100' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_16_0_X_2025-12-18-1100_FWLITE' -Isrc -I/data/cmsbld/jenkins/workspace/build-fwlite-ib/cms/el8_amd64_gcc13/external/pcre/8.43-6d98fda3bfd074ebb583e2d6a2c75d25/include -isystem/data/cmsbld/jenkins/workspace/build-fwlite-ib/cms/el8_amd64_gcc13/external/boost/1.80.0-b819d3899535842b3b08dcd6a725af1a/include -I/data/cmsbld/jenkins/workspace/build-fwlite-ib/cms/el8_amd64_gcc13/external/bz2lib/1.0.6-d113e1c6278c07eeaff5f84db9548446/include -isystem/data/cmsbld/jenkins/workspace/build-fwlite-ib/cms/el8_amd64_gcc13/external/clhep/2.4.7.1-caf57578c24c3884afdedd94a88b58d7/include -I/data/cmsbld/jenkins/workspace/build-fwlite-ib/cms/el8_amd64_gcc13/external/gsl/2.6-9011a41928244b609ca4c22c439b3fef/include -I/data/cmsbld/jenkins/workspace/build-fwlite-ib/cms/el8_amd64_gcc13/external/libuuid/2.34-5ba7a8abfc0c5fecdc448cca360c25ff/include -isystem/data/cmsbld/jenkins/workspace/build-fwlite-ib/cms/el8_amd64_gcc13/lcg/root/6.36.07-e0ce66fada32a38695cf14867f0ab7a8/include -isystem/data/cmsbld/jenkins/workspace/build-fwlite-ib/cms/el8_amd64_gcc13/external/tbb/v2022.3.0-88eb7be4ee320d604a798a914aea6359/include -I/data/cmsbld/jenkins/workspace/build-fwlite-ib/cms/el8_amd64_gcc13/external/xz/5.6.4-b9c4ffbc390ed320a5d57fd552e29a05/include -I/data/cmsbld/jenkins/workspace/build-fwlite-ib/cms/el8_amd64_gcc13/external/zlib/1.2.13-589f6bb51bbeba38a7adf5a10ea8a093/include -I/data/cmsbld/jenkins/workspace/build-fwlite-ib/cms/el8_amd64_gcc13/external/alpaka/2.0.0-8493f1d11d0378dc14d6ea6ecfc69ac5/include -I/data/cmsbld/jenkins/workspace/build-fwlite-ib/cms/el8_amd64_gcc13/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-95c02b8a883b2934decb8bb53ff9b486/include -I/data/cmsbld/jenkins/workspace/build-fwlite-ib/cms/el8_amd64_gcc13/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-95c02b8a883b2934decb8bb53ff9b486/include/eigen3 -I/data/cmsbld/jenkins/workspace/build-fwlite-ib/cms/el8_amd64_gcc13/external/fmt/10.2.1-31d67b0504b4ba2262f03d3c5cad83c1/include -I/data/cmsbld/jenkins/workspace/build-fwlite-ib/cms/el8_amd64_gcc13/external/md5/1.0.0-26057075013e190e56dad37d35219376/include -I/data/cmsbld/jenkins/workspace/build-fwlite-ib/cms/el8_amd64_gcc13/external/OpenBLAS/0.3.27-da4a3c2bb8ae43f3913a4a44acdb1b50/include -I/data/cmsbld/jenkins/workspace/build-fwlite-ib/cms/el8_amd64_gcc13/external/tinyxml2/6.2.0-67924ead96ecb4e69aad321b767979a5/include -O3 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++20 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -march=x86-64-v3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DEIGEN_DONT_PARALLELIZE -DEIGEN_MAX_ALIGN_BYTES=64 -DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 -DALPAKA_DISABLE_VENDOR_RNG -DALPAKA_HAS_STD_ATOMIC_REF -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS -flto=auto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -fPIC -MMD -MF tmp/el8_amd64_gcc13/src/DataFormats/BeamSpot/src/DataFormatsBeamSpot/classes.cc.d src/DataFormats/BeamSpot/src/classes.cc -o tmp/el8_amd64_gcc13/src/DataFormats/BeamSpot/src/DataFormatsBeamSpot/classes.cc.o
In file included from src/DataFormats/BeamSpot/interface/BeamSpotHost.h:5,
                 from src/DataFormats/BeamSpot/src/classes.cc:1:
src/DataFormats/Portable/interface/PortableHostObject.h:11:10: fatal error: DataFormats/TrivialSerialisation/interface/MemoryCopyTraits.h: No such file or directory
   11 | #include "DataFormats/TrivialSerialisation/interface/MemoryCopyTraits.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
In file included from src/DataFormats/BeamSpot/interface/BeamSpotHost.h:5,
                 from src/DataFormats/BeamSpot/src/classes.cc:1:
src/DataFormats/Portable/interface/PortableHostObject.h:11:10: fatal error: DataFormats/TrivialSerialisation/interface/MemoryCopyTraits.h: No such file or directory
   11 | #include "DataFormats/TrivialSerialisation/interface/MemoryCopyTraits.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
  gmake: *** [tmp/el8_amd64_gcc13/src/DataFormats/BeamSpot/src/DataFormatsBeamSpot/classes.cc.o] Error 1
  ```

