### PR TITLE
Remove `cutTk` condition from `interpretationDescPSet`

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltTiclCandidate_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltTiclCandidate_cfi.py
@@ -28,7 +28,6 @@ hltTiclCandidate = cms.EDProducer("TICLCandidateProducer",
     general_tracksters_collections = cms.VInputTag("hltTiclTracksterLinks"),
     interpretationDescPSet = cms.PSet(
         algo_verbosity = cms.int32(0),
-        cutTk = cms.string('1.48 < abs(eta) < 3.0 && pt > 1. && quality("highPurity") && hitPattern().numberOfLostHits("MISSING_OUTER_HITS") < 5'),
         delta_tk_ts_interface = cms.double(0.03),
         delta_tk_ts_layer1 = cms.double(0.02),
         timing_quality_threshold = cms.double(0.5),

--- a/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
@@ -401,9 +401,6 @@ void GeneralInterpretationAlgo::makeCandidates(const Inputs &input,
 };
 
 void GeneralInterpretationAlgo::fillPSetDescription(edm::ParameterSetDescription &desc) {
-  desc.add<std::string>("cutTk",
-                        "1.48 < abs(eta) < 3.0 && pt > 1. && quality(\"highPurity\") && "
-                        "hitPattern().numberOfLostHits(\"MISSING_OUTER_HITS\") < 5");
   desc.add<double>("delta_tk_ts_layer1", 0.02);
   desc.add<double>("delta_tk_ts_interface", 0.03);
   desc.add<double>("timing_quality_threshold", 0.5);


### PR DESCRIPTION
#### PR description:

Clean-up of unused configuration.
Spotted while reviewing https://github.com/cms-sw/cmssw/pull/49652

#### PR validation:

```
runTheMatrix.py -l 34434.75,34434.752
```

runs fine.


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A