### PR TITLE
Converted EGM PFID model inference from TensorFlow to ONNX

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
@@ -309,11 +309,11 @@ void GsfElectronProducer::fillDescriptions(edm::ConfigurationDescriptions& descr
 
     psd1.add<std::vector<std::string>>(
         "modelsFiles",
-        {"RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/lowpT/lowpT_modelDNN.pb",
-         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/highpTEB/highpTEB_modelDNN.pb",
-         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/highpTEE/highpTEE_modelDNN.pb",
-         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta1/modelDNN.pb",
-         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta2/modelDNN.pb"});
+        {"RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/lowpT/lowpT_modelDNN.onnx",
+         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/highpTEB/highpTEB_modelDNN.onnx",
+         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/highpTEE/highpTEE_modelDNN.onnx",
+         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta1/modelDNN.onnx",
+         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta2/modelDNN.onnx"});
     psd1.add<std::vector<std::string>>(
         "scalersFiles",
         {"RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/lowpT/lowpT_scaler.txt",

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
@@ -304,8 +304,8 @@ void GsfElectronProducer::fillDescriptions(edm::ConfigurationDescriptions& descr
     edm::ParameterSetDescription psd1;
     psd1.add<bool>("enabled", false);
     psd1.add<double>("extetaboundary", 2.65);
-    psd1.add<std::string>("inputTensorName", "FirstLayer_input");
-    psd1.add<std::string>("outputTensorName", "sequential/FinalLayer/Softmax");
+    psd1.add<std::string>("inputTensorName", "FirstLayer_input:0");
+    psd1.add<std::string>("outputTensorName", "sequential/FinalLayer/Softmax:0");
 
     psd1.add<std::vector<std::string>>(
         "modelsFiles",

--- a/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
@@ -22,7 +22,7 @@ gedGsfElectronsTmp = ecalDrivenGsfElectrons.clone(
 
     #Egamma PFID DNN model configuration
     EleDNNPFid= dict(
-        outputTensorName = "sequential_1/FinalLayer/Softmax",
+        outputTensorName = "sequential_1/FinalLayer/Softmax:0",
         modelsFiles = [
             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/lowpT/lowpT_modelDNN.onnx",
             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EB_highpT/barrel_highpT_modelDNN.onnx",

--- a/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
@@ -24,11 +24,11 @@ gedGsfElectronsTmp = ecalDrivenGsfElectrons.clone(
     EleDNNPFid= dict(
         outputTensorName = "sequential_1/FinalLayer/Softmax",
         modelsFiles = [
-            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/lowpT/lowpT_modelDNN.pb",
-            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EB_highpT/barrel_highpT_modelDNN.pb",
-            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EE_highpT/endcap_highpT_modelDNN.pb",
-            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta1/modelDNN.pb",
-            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta2/modelDNN.pb"
+            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/lowpT/lowpT_modelDNN.onnx",
+            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EB_highpT/barrel_highpT_modelDNN.onnx",
+            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EE_highpT/endcap_highpT_modelDNN.onnx",
+            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta1/modelDNN.onnx",
+            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta2/modelDNN.onnx"
         ],
         scalersFiles = [
             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/lowpT/lowpT_scaler.txt",

--- a/RecoEgamma/EgammaPhotonProducers/BuildFile.xml
+++ b/RecoEgamma/EgammaPhotonProducers/BuildFile.xml
@@ -22,5 +22,5 @@
 <use name="DataFormats/HcalRecHit"/>
 <use name="RecoCaloTools/Selectors" source_only="1"/>
 <use name="clhep"/>
-<use name="PhysicsTools/TensorFlow" />
+<use name="PhysicsTools/ONNXRuntime" />
 <flags EDM_PLUGIN="1"/>

--- a/RecoEgamma/EgammaPhotonProducers/python/gedPhotonSequence_cff.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/gedPhotonSequence_cff.py
@@ -16,8 +16,8 @@ gedPhotonsTmp = RecoEgamma.EgammaPhotonProducers.gedPhotons_cfi.gedPhotons.clone
     reconstructionStep     = "tmp",
     #Photon PFID DNN model configuration
     PhotonDNNPFid = dict(
-        modelsFiles = [ "RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/Run3Summer21_120X/EB/barrel_modelDNN.pb",
-                        "RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/Run3Summer21_120X/EE/endcap_modelDNN.pb"],
+        modelsFiles = [ "RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/Run3Summer21_120X/EB/barrel_modelDNN.onnx",
+                        "RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/Run3Summer21_120X/EE/endcap_modelDNN.onnx"],
         scalersFiles = [
                     "RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/Run3Summer21_120X/EB/barrel_scaler.txt",
                     "RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/Run3Summer21_120X/EE/endcap_scaler.txt"]

--- a/RecoEgamma/EgammaPhotonProducers/python/gedPhotons_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/gedPhotons_cfi.py
@@ -105,8 +105,8 @@ gedPhotons = cms.EDProducer("GEDPhotonProducer",
     checkHcalStatus = cms.bool(True),
     PhotonDNNPFid = cms.PSet(
         enabled = cms.bool(False),
-        inputTensorName = cms.string("FirstLayer_input"),
-        outputTensorName = cms.string("sequential/FinalLayer/Sigmoid"),
+        inputTensorName = cms.string("FirstLayer_input:0"),
+        outputTensorName = cms.string("sequential/FinalLayer/Sigmoid:0"),
         modelsFiles = cms.vstring(
                                 'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EB/EB_modelDNN.onnx',
                                 'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EE/EE_modelDNN.onnx'),

--- a/RecoEgamma/EgammaPhotonProducers/python/gedPhotons_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/gedPhotons_cfi.py
@@ -108,8 +108,8 @@ gedPhotons = cms.EDProducer("GEDPhotonProducer",
         inputTensorName = cms.string("FirstLayer_input"),
         outputTensorName = cms.string("sequential/FinalLayer/Sigmoid"),
         modelsFiles = cms.vstring(
-                                'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EB/EB_modelDNN.pb',
-                                'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EE/EE_modelDNN.pb'),
+                                'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EB/EB_modelDNN.onnx',
+                                'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EE/EE_modelDNN.onnx'),
         scalersFiles = cms.vstring(
                     'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EB/EB_scaler.txt',
                     'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EE/EE_scaler.txt'

--- a/RecoEgamma/EgammaPhotonProducers/python/photons_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/photons_cfi.py
@@ -96,8 +96,8 @@ photons = cms.EDProducer("GEDPhotonProducer",
     checkHcalStatus = cms.bool(True),
     PhotonDNNPFid = cms.PSet(
         enabled = cms.bool(False),
-        inputTensorName = cms.string("FirstLayer_input"),
-        outputTensorName = cms.string("sequential/FinalLayer/Sigmoid"),
+        inputTensorName = cms.string("FirstLayer_input:0"),
+        outputTensorName = cms.string("sequential/FinalLayer/Sigmoid:0"),
         modelsFiles = cms.vstring(
                                 'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EB/EB_modelDNN.pb',
                                 'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EE/EE_modelDNN.pb'),

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -48,7 +48,6 @@
 #include "RecoEcal/EgammaCoreTools/interface/EgammaLocalCovParamDefaults.h"
 #include "RecoEgamma/EgammaElectronAlgos/interface/ElectronHcalHelper.h"
 #include "RecoEgamma/PhotonIdentification/interface/PhotonDNNEstimator.h"
-#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EcalPFClusterIsolation.h"
 #include "RecoEgamma/EgammaIsolationAlgos/interface/HcalPFClusterIsolation.h"
 #include "CondFormats/GBRForest/interface/GBRForest.h"

--- a/RecoEgamma/EgammaTools/BuildFile.xml
+++ b/RecoEgamma/EgammaTools/BuildFile.xml
@@ -16,7 +16,7 @@
 <use name="CondFormats/GBRForest"/>
 <use name="RecoEcal/EgammaCoreTools"/>
 <use name="DataFormats/ParticleFlowReco"/>
-<use name="PhysicsTools/TensorFlow" />
+<use name="PhysicsTools/ONNXRuntime" />
 <export>
   <lib name="1"/>
 </export>

--- a/RecoEgamma/EgammaTools/interface/EgammaDNNHelper.h
+++ b/RecoEgamma/EgammaTools/interface/EgammaDNNHelper.h
@@ -1,7 +1,7 @@
 #ifndef RecoEgamma_ElectronTools_EgammaDNNHelper_h
 #define RecoEgamma_ElectronTools_EgammaDNNHelper_h
 
-#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
+#include "PhysicsTools/ONNXRuntime/interface/ONNXRuntime.h"
 #include <vector>
 #include <memory>
 #include <string>
@@ -9,7 +9,7 @@
 
 //author: Davide Valsecchi
 //description:
-// Handles Tensorflow DNN graphs and variables scaler configuration.
+// Handles ONNXRuntime DNN graphs and variables scaler configuration.
 // To be used for PFID egamma DNNs
 
 namespace egammaTools {
@@ -52,7 +52,7 @@ namespace egammaTools {
         const std::vector<std::map<std::string, float>>& candidates) const;
 
   private:
-    void initTensorFlowSessions();
+    void initONNXRuntimeSessions();
     void initScalerFiles(const std::vector<std::string>& availableVars);
 
     const DNNConfiguration cfg_;
@@ -62,8 +62,8 @@ namespace egammaTools {
     // Number of inputs for each loaded model
     std::vector<uint> nInputs_;
 
-    // TF SessionCache stores both the grapha and the session of each model
-    std::vector<std::unique_ptr<tensorflow::SessionCache>> tf_sessions_cache_;
+    // ONNXRuntime sessions
+    std::vector<std::unique_ptr<cms::Ort::ONNXRuntime>> onnx_sessions_;
 
     // List of input variables for each of the model;
     std::vector<std::vector<ScalerConfiguration>> featuresMap_;

--- a/RecoEgamma/ElectronIdentification/BuildFile.xml
+++ b/RecoEgamma/ElectronIdentification/BuildFile.xml
@@ -7,7 +7,7 @@
 <use name="DataFormats/GsfTrackReco"/>
 <use name="DataFormats/PatCandidates"/>
 <use name="DataFormats/VertexReco"/>
-<use name="PhysicsTools/TensorFlow" />
+<use name="PhysicsTools/ONNXRuntime" />
 <export>
   <lib name="1"/>
 </export>

--- a/RecoEgamma/ElectronIdentification/interface/ElectronDNNEstimator.h
+++ b/RecoEgamma/ElectronIdentification/interface/ElectronDNNEstimator.h
@@ -2,7 +2,6 @@
 #define RecoEgamma_ElectronIdentification_ElectronDNNEstimator_h
 
 #include "RecoEgamma/EgammaTools/interface/EgammaDNNHelper.h"
-#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 
 #include <vector>

--- a/RecoEgamma/PhotonIdentification/BuildFile.xml
+++ b/RecoEgamma/PhotonIdentification/BuildFile.xml
@@ -16,7 +16,7 @@
 <use name="Geometry/CaloGeometry"/>
 <use name="Geometry/CaloTopology"/>
 <use name="Geometry/Records"/>
-<use name="PhysicsTools/TensorFlow" />
+<use name="PhysicsTools/ONNXRuntime" />
 <use name="PhysicsTools/XGBoost" />
 <use name="RecoEcal/EgammaCoreTools"/>
 <use name="RecoEgamma/EgammaIsolationAlgos"/>

--- a/RecoEgamma/PhotonIdentification/interface/PhotonDNNEstimator.h
+++ b/RecoEgamma/PhotonIdentification/interface/PhotonDNNEstimator.h
@@ -2,7 +2,6 @@
 #define RecoEgamma_PhotonIdentification_PhotonDNNEstimator_h
 
 #include "RecoEgamma/EgammaTools/interface/EgammaDNNHelper.h"
-#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 


### PR DESCRIPTION
#### PR description:
Technical PR to convert EGM PF ID from TensorFlow to ONNX. 
The PFID is set as multiple small DNNs applied in the EGM PFAlgo.  A general EgannaDNNHelper class is available for both electrons and photons producers. The helper class has been migrated to ONNX. 

#### PR validation:
We will use the PR DQM tests to check for 1-to-1 comparison.

Related to issues https://github.com/cms-sw/cmssw/issues/49678
