### PR TITLE
Added OutputModuleCore::finalSelection

### DIFF
--- a/FWCore/Framework/interface/OutputModuleCore.h
+++ b/FWCore/Framework/interface/OutputModuleCore.h
@@ -249,6 +249,8 @@ namespace edm {
 
       virtual void setProcessesWithSelectedMergeableRunProducts(std::set<std::string> const&) {}
 
+      virtual bool finalSelection(ProductDescription const& desc) const;
+
       bool hasAccumulator() const noexcept { return false; }
 
       void keepThisBranch(ProductDescription const& desc,


### PR DESCRIPTION

#### PR description:

Now inheriting classes can get the final say as to what exact data products they want to store. The default just uses the `transient` information from the ProductDescription.

#### PR validation:

Code compiles and framework unit tests pass.