### PR TITLE
NanoAOD: handle Sherpa PS weights consistently

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -190,7 +190,7 @@ namespace {
     std::vector<unsigned int> psWeightIDs;
     unsigned int psBaselineID = 1;
     std::string psWeightsDoc;
-    bool isSherpa = false; 
+    bool isSherpa = false;
 
     void setMissingWeight(int idx) { psWeightIDs[idx] = (matchPS_alt) ? defPSWeightIDs_alt[idx] : defPSWeightIDs[idx]; }
 
@@ -497,9 +497,9 @@ public:
   }
 
   void setPSWeightInfo(const std::vector<double>& genWeights,
-                      const DynamicWeightChoiceGenInfo* genWeightChoice,
-                      std::vector<double>& wPS,
-                      std::string& psWeightDocStr) const {
+                       const DynamicWeightChoiceGenInfo* genWeightChoice,
+                       std::vector<double>& wPS,
+                       std::string& psWeightDocStr) const {
     wPS.clear();
 
     const bool isSherpa = (genWeightChoice && genWeightChoice->isSherpa);
@@ -513,7 +513,8 @@ public:
 
       wPS.reserve(genWeights.size());
       for (std::size_t i = 0; i < genWeights.size(); ++i) {
-        if (i == genWeightChoice->psBaselineID) continue;
+        if (i == genWeightChoice->psBaselineID)
+          continue;
         wPS.push_back(genWeights.at(i) / nominal);
       }
 
@@ -522,7 +523,7 @@ public:
     }
 
     // ============================================================
-    // NON-SHERPA: 
+    // NON-SHERPA:
     // ============================================================
 
     // isRegularPSSet = keeping all weights and the weights are a usual size, ie
@@ -537,25 +538,24 @@ public:
       }
     } else {
       int vectorSize =
-          keepAllPSWeights_ ? (genWeights.size() - 2)
-                            : ((genWeights.size() == 14 || genWeights.size() == 46) ? 4 : 1);
+          keepAllPSWeights_ ? (genWeights.size() - 2) : ((genWeights.size() == 14 || genWeights.size() == 46) ? 4 : 1);
 
       if (vectorSize > 1) {
-        double nominal = genWeights.at(genWeightChoice->psBaselineID); // Called 'Baseline' in GenLumiInfoHeader
+        double nominal = genWeights.at(genWeightChoice->psBaselineID);  // Called 'Baseline' in GenLumiInfoHeader
 
         if (keepAllPSWeights_) {
           for (int i = 0; i < vectorSize; i++) {
             wPS.push_back(genWeights.at(i + 2) / nominal);
           }
           psWeightDocStr = ((int)genWeightChoice->psWeightIDs.size() == vectorSize)
-                              ? genWeightChoice->psWeightsDoc
-                              : "All PS weights (w_var / w_nominal)";
+                               ? genWeightChoice->psWeightsDoc
+                               : "All PS weights (w_var / w_nominal)";
         } else {
           if (!psWeightWarning_.exchange(true))
             edm::LogWarning("LHETablesProducer")
                 << "GenLumiInfoHeader not found: Central PartonShower weights will fill with the 6-10th entries \n"
                 << "    This may incorrect for some mcs (madgraph 2.6.1 with its `isr:murfact=0.5` have a differnt "
-                  "order )";
+                   "order )";
           for (std::size_t i = 6; i < 10; i++) {
             wPS.push_back(genWeights.at(i) / nominal);
           }
@@ -1026,25 +1026,22 @@ public:
 
       // --- Detect Sherpa from the first 4 weights ---
       auto contains = [&](const std::string& key) {
-        return std::any_of(weightNames.begin(), weightNames.end(),
-                          [&](const std::string& s) { return s.find(key) != std::string::npos; });
+        return std::any_of(weightNames.begin(), weightNames.end(), [&](const std::string& s) {
+          return s.find(key) != std::string::npos;
+        });
       };
 
-      bool Sherpa = weightNames.size() >= 4 &&
-                    contains("Weight") &&
-                    contains("MEWeight") &&
-                    contains("WeightNormalisation") &&
-                    contains("NTrials");
+      bool Sherpa = weightNames.size() >= 4 && contains("Weight") && contains("MEWeight") &&
+                    contains("WeightNormalisation") && contains("NTrials");
 
       if (Sherpa) {
-        edm::LogInfo("SherpaDetection")
-            << "Detected Sherpa structure in GenLumiInfoHeader with " << weightNames.size()
-            << " weights (matched Weight/MEWeight/WeightNormalisation/NTrials).";
+        edm::LogInfo("SherpaDetection") << "Detected Sherpa structure in GenLumiInfoHeader with " << weightNames.size()
+                                        << " weights (matched Weight/MEWeight/WeightNormalisation/NTrials).";
 
         weightChoice->isSherpa = true;
         weightChoice->psBaselineID = 0;  // Nominal weight is always the first one
-        edm::LogInfo("SherpaDetection") << "Detected Sherpa structure in GenLumiInfoHeader with "
-                                        << weightNames.size() << " weights.";
+        edm::LogInfo("SherpaDetection") << "Detected Sherpa structure in GenLumiInfoHeader with " << weightNames.size()
+                                        << " weights.";
 
         weightChoice->psWeightIDs.clear();
         weightChoice->scaleWeightIDs.clear();
@@ -1067,9 +1064,9 @@ public:
         weightChoice->psWeightsDoc = psdoc.str();
 
         weightChoice->scaleWeightsDoc = "[Sherpa detected] scale weights not split (stored in PS container).";
-        weightChoice->pdfWeightsDoc   = "[Sherpa detected] pdf weights not split (stored in PS container).";
-      
-      // --- Non-Sherpa processing ---
+        weightChoice->pdfWeightsDoc = "[Sherpa detected] pdf weights not split (stored in PS container).";
+
+        // --- Non-Sherpa processing ---
       } else {
         unsigned int weightIter = 0;
         for (const auto& line : weightNames) {

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -190,6 +190,7 @@ namespace {
     std::vector<unsigned int> psWeightIDs;
     unsigned int psBaselineID = 1;
     std::string psWeightsDoc;
+    bool isSherpa = false; 
 
     void setMissingWeight(int idx) { psWeightIDs[idx] = (matchPS_alt) ? defPSWeightIDs_alt[idx] : defPSWeightIDs[idx]; }
 
@@ -496,13 +497,38 @@ public:
   }
 
   void setPSWeightInfo(const std::vector<double>& genWeights,
-                       const DynamicWeightChoiceGenInfo* genWeightChoice,
-                       std::vector<double>& wPS,
-                       std::string& psWeightDocStr) const {
+                      const DynamicWeightChoiceGenInfo* genWeightChoice,
+                      std::vector<double>& wPS,
+                      std::string& psWeightDocStr) const {
     wPS.clear();
+
+    const bool isSherpa = (genWeightChoice && genWeightChoice->isSherpa);
+
+    // ============================================================
+    // Sherpa: all the weight are stored, normalized to [0] (which is not normalized!)
+    // No matter if keepAllPSWeights_ is true or false.
+    // ============================================================
+    if (isSherpa) {
+      const double nominal = genWeights.at(genWeightChoice->psBaselineID);
+
+      wPS.reserve(genWeights.size());
+      for (std::size_t i = 0; i < genWeights.size(); ++i) {
+        if (i == genWeightChoice->psBaselineID) continue;
+        wPS.push_back(genWeights.at(i) / nominal);
+      }
+
+      psWeightDocStr = "Sherpa: all generator weights stored in PS (w_var / w_nominal)";
+      return;
+    }
+
+    // ============================================================
+    // NON-SHERPA: 
+    // ============================================================
+
     // isRegularPSSet = keeping all weights and the weights are a usual size, ie
     //                  all weights are PS weights (don't use header incase missing names)
     bool isRegularPSSet = keepAllPSWeights_ && (genWeights.size() == 14 || genWeights.size() == 46);
+
     if (!genWeightChoice->psWeightIDs.empty() && !isRegularPSSet) {
       psWeightDocStr = genWeightChoice->psWeightsDoc;
       double psNom = genWeights.at(genWeightChoice->psBaselineID);
@@ -511,23 +537,25 @@ public:
       }
     } else {
       int vectorSize =
-          keepAllPSWeights_ ? (genWeights.size() - 2) : ((genWeights.size() == 14 || genWeights.size() == 46) ? 4 : 1);
+          keepAllPSWeights_ ? (genWeights.size() - 2)
+                            : ((genWeights.size() == 14 || genWeights.size() == 46) ? 4 : 1);
 
       if (vectorSize > 1) {
-        double nominal = genWeights.at(1);  // Called 'Baseline' in GenLumiInfoHeader
+        double nominal = genWeights.at(genWeightChoice->psBaselineID); // Called 'Baseline' in GenLumiInfoHeader
+
         if (keepAllPSWeights_) {
           for (int i = 0; i < vectorSize; i++) {
             wPS.push_back(genWeights.at(i + 2) / nominal);
           }
           psWeightDocStr = ((int)genWeightChoice->psWeightIDs.size() == vectorSize)
-                               ? genWeightChoice->psWeightsDoc
-                               : "All PS weights (w_var / w_nominal)";
+                              ? genWeightChoice->psWeightsDoc
+                              : "All PS weights (w_var / w_nominal)";
         } else {
           if (!psWeightWarning_.exchange(true))
             edm::LogWarning("LHETablesProducer")
                 << "GenLumiInfoHeader not found: Central PartonShower weights will fill with the 6-10th entries \n"
                 << "    This may incorrect for some mcs (madgraph 2.6.1 with its `isr:murfact=0.5` have a differnt "
-                   "order )";
+                  "order )";
           for (std::size_t i = 6; i < 10; i++) {
             wPS.push_back(genWeights.at(i) / nominal);
           }
@@ -995,101 +1023,150 @@ public:
       std::smatch groups;
       auto weightNames = genLumiInfoHead->weightNames();
       std::unordered_map<std::string, uint32_t> knownPDFSetsFromGenInfo_;
-      unsigned int weightIter = 0;
-      for (const auto& line : weightNames) {
-        if (std::regex_search(line, groups, scalew)) {  // scale variation
-          auto id = groups.str(1);
-          auto group = groups.str(2);
-          auto mur = groups.str(3);
-          auto muf = groups.str(4);
-          if (group.find("Central scale variation") != std::string::npos)
-            scaleVariationIDs.emplace_back(groups.str(1), groups.str(2), groups.str(3), groups.str(4));
-        } else if (std::regex_search(line, groups, pdfw)) {  // PDF variation
-          auto id = groups.str(1);
-          auto group = groups.str(2);
-          auto memberid = groups.str(3);
-          auto pdfset = groups.str(4);
-          if (group.find(pdfset) != std::string::npos) {
-            if (knownPDFSetsFromGenInfo_.find(pdfset) == knownPDFSetsFromGenInfo_.end()) {
-              knownPDFSetsFromGenInfo_[pdfset] = std::atoi(id.c_str());
-              pdfSetWeightIDs.emplace_back(id, std::atoi(id.c_str()));
-            } else
-              pdfSetWeightIDs.back().add(id, std::atoi(id.c_str()));
-          }
-        } else if (line == "Baseline") {
-          weightChoice->psBaselineID = weightIter;
-        } else if (line.find("isr") != std::string::npos || line.find("fsr") != std::string::npos) {
-          weightChoice->matchPS_alt = line.find("sr:") != std::string::npos ||
-                                      line.find("sr.") != std::string::npos;  // (f/i)sr: for new weights
-          if (keepAllPSWeights_) {
-            weightChoice->psWeightIDs.push_back(weightIter);  // PS variations
-          } else if (std::regex_search(line, groups, mainPSw)) {
-            if (weightChoice->psWeightIDs.empty())
-              weightChoice->psWeightIDs = std::vector<unsigned int>(4, -1);
-            int psIdx = (line.find("fsr") != std::string::npos) ? 1 : 0;
-            psIdx += (groups.str(2) == "Hi" || groups.str(2) == "_up" || groups.str(2) == "2.0") ? 0 : 2;
-            weightChoice->psWeightIDs[psIdx] = weightIter;
-          }
-        }
-        weightIter++;
-      }
-      if (keepAllPSWeights_) {
-        weightChoice->psWeightsDoc = "All PS weights (w_var / w_nominal) ";
-      } else if (weightChoice->psWeightIDs.size() == 4) {
-        weightChoice->psWeightsDoc = "PS weights (w_var / w_nominal) ";
-        for (int i = 0; i < 4; i++) {
-          if (static_cast<int>(weightChoice->psWeightIDs[i]) == -1)
-            weightChoice->setMissingWeight(i);
-        }
+
+      // --- Detect Sherpa from the first 4 weights ---
+      auto contains = [&](const std::string& key) {
+        return std::any_of(weightNames.begin(), weightNames.end(),
+                          [&](const std::string& s) { return s.find(key) != std::string::npos; });
+      };
+
+      bool Sherpa = weightNames.size() >= 4 &&
+                    contains("Weight") &&
+                    contains("MEWeight") &&
+                    contains("WeightNormalisation") &&
+                    contains("NTrials");
+
+      if (Sherpa) {
+        edm::LogInfo("SherpaDetection")
+            << "Detected Sherpa structure in GenLumiInfoHeader with " << weightNames.size()
+            << " weights (matched Weight/MEWeight/WeightNormalisation/NTrials).";
+
+        weightChoice->isSherpa = true;
+        weightChoice->psBaselineID = 0;  // Nominal weight is always the first one
+        edm::LogInfo("SherpaDetection") << "Detected Sherpa structure in GenLumiInfoHeader with "
+                                        << weightNames.size() << " weights.";
+
+        weightChoice->psWeightIDs.clear();
+        weightChoice->scaleWeightIDs.clear();
+        weightChoice->pdfWeightIDs.clear();
+
+        // Include ALL the weights, even the "standard" ones: Weight, MEWeight, WeightNormalisation, NTrials
+        // in PS weights
+        for (unsigned int i = 0; i < weightNames.size(); ++i)
+          weightChoice->psWeightIDs.push_back(i);
+
+        std::ostringstream psdoc;
+        psdoc << "[Sherpa detected] All generator weights are stored in the PSWeight table.\n"
+              << "  - Baseline weight (index " << weightChoice->psBaselineID << ") is kept UNNORMALIZED\n"
+              << "    to allow post-hoc renormalization or alternative reference choices.\n"
+              << "  - All other weights are stored as w_i / w_baseline.\n"
+              << "  - This includes internal Sherpa weights (Weight, MEWeight, WeightNormalisation, NTrials)\n"
+              << "    as well as all additional variation weights.\n"
+              << "  - No splitting into scale/PDF containers is performed for Sherpa samples.\n"
+              << "  Stored indices: [0 .. " << (weightNames.size() ? weightNames.size() - 1 : 0) << "]\n";
+        weightChoice->psWeightsDoc = psdoc.str();
+
+        weightChoice->scaleWeightsDoc = "[Sherpa detected] scale weights not split (stored in PS container).";
+        weightChoice->pdfWeightsDoc   = "[Sherpa detected] pdf weights not split (stored in PS container).";
+      
+      // --- Non-Sherpa processing ---
       } else {
-        weightChoice->psWeightsDoc = "dummy PS weight (1.0) ";
-      }
-      for (unsigned i = 0; i < weightChoice->psWeightIDs.size(); ++i) {
-        weightChoice->psWeightsDoc +=
-            "[" + std::to_string(i) + "] " + weightNames.at(weightChoice->psWeightIDs.at(i)) + "; ";
-      }
-
-      weightChoice->scaleWeightIDs.clear();
-      weightChoice->pdfWeightIDs.clear();
-
-      std::sort(scaleVariationIDs.begin(), scaleVariationIDs.end());
-      std::stringstream scaleDoc;
-      scaleDoc << "LHE scale variation weights (w_var / w_nominal); ";
-      for (unsigned int isw = 0, nsw = scaleVariationIDs.size(); isw < nsw; ++isw) {
-        const auto& sw = scaleVariationIDs[isw];
-        if (isw)
-          scaleDoc << "; ";
-        scaleDoc << "[" << isw << "] is " << sw.label;
-        weightChoice->scaleWeightIDs.push_back(std::atoi(sw.wid.c_str()));
-      }
-      if (!scaleVariationIDs.empty())
-        weightChoice->scaleWeightsDoc = scaleDoc.str();
-      std::stringstream pdfDoc;
-      pdfDoc << "LHE pdf variation weights (w_var / w_nominal) for LHA names ";
-      bool found = false;
-      for (const auto& pw : pdfSetWeightIDs) {
-        if (pw.wids.size() == 1)
-          continue;  // only consider error sets
-        for (const auto& wantedpdf : lhaNameToID_) {
-          auto pdfname = wantedpdf.first;
-          if (knownPDFSetsFromGenInfo_.find(pdfname) == knownPDFSetsFromGenInfo_.end())
-            continue;
-          uint32_t lhaid = knownPDFSetsFromGenInfo_.at(pdfname);
-          if (pw.lhaIDs.first != lhaid)
-            continue;
-          pdfDoc << pdfname;
-          for (const auto& x : pw.wids)
-            weightChoice->pdfWeightIDs.push_back(std::atoi(x.c_str()));
-          if (maxPdfWeights_ < pw.wids.size()) {
-            weightChoice->pdfWeightIDs.resize(maxPdfWeights_);  // drop some replicas
-            pdfDoc << ", truncated to the first " << maxPdfWeights_ << " replicas";
+        unsigned int weightIter = 0;
+        for (const auto& line : weightNames) {
+          if (std::regex_search(line, groups, scalew)) {  // scale variation
+            auto id = groups.str(1);
+            auto group = groups.str(2);
+            auto mur = groups.str(3);
+            auto muf = groups.str(4);
+            if (group.find("Central scale variation") != std::string::npos)
+              scaleVariationIDs.emplace_back(groups.str(1), groups.str(2), groups.str(3), groups.str(4));
+          } else if (std::regex_search(line, groups, pdfw)) {  // PDF variation
+            auto id = groups.str(1);
+            auto group = groups.str(2);
+            auto memberid = groups.str(3);
+            auto pdfset = groups.str(4);
+            if (group.find(pdfset) != std::string::npos) {
+              if (knownPDFSetsFromGenInfo_.find(pdfset) == knownPDFSetsFromGenInfo_.end()) {
+                knownPDFSetsFromGenInfo_[pdfset] = std::atoi(id.c_str());
+                pdfSetWeightIDs.emplace_back(id, std::atoi(id.c_str()));
+              } else
+                pdfSetWeightIDs.back().add(id, std::atoi(id.c_str()));
+            }
+          } else if (line == "Baseline") {
+            weightChoice->psBaselineID = weightIter;
+          } else if (line.find("isr") != std::string::npos || line.find("fsr") != std::string::npos) {
+            weightChoice->matchPS_alt = line.find("sr:") != std::string::npos ||
+                                        line.find("sr.") != std::string::npos;  // (f/i)sr: for new weights
+            if (keepAllPSWeights_) {
+              weightChoice->psWeightIDs.push_back(weightIter);  // PS variations
+            } else if (std::regex_search(line, groups, mainPSw)) {
+              if (weightChoice->psWeightIDs.empty())
+                weightChoice->psWeightIDs = std::vector<unsigned int>(4, -1);
+              int psIdx = (line.find("fsr") != std::string::npos) ? 1 : 0;
+              psIdx += (groups.str(2) == "Hi" || groups.str(2) == "_up" || groups.str(2) == "2.0") ? 0 : 2;
+              weightChoice->psWeightIDs[psIdx] = weightIter;
+            }
           }
-          weightChoice->pdfWeightsDoc = pdfDoc.str();
-          found = true;
-          break;
+          weightIter++;
         }
-        if (found)
-          break;
+        if (keepAllPSWeights_) {
+          weightChoice->psWeightsDoc = "All PS weights (w_var / w_nominal) ";
+        } else if (weightChoice->psWeightIDs.size() == 4) {
+          weightChoice->psWeightsDoc = "PS weights (w_var / w_nominal) ";
+          for (int i = 0; i < 4; i++) {
+            if (static_cast<int>(weightChoice->psWeightIDs[i]) == -1)
+              weightChoice->setMissingWeight(i);
+          }
+        } else {
+          weightChoice->psWeightsDoc = "dummy PS weight (1.0) ";
+        }
+        for (unsigned i = 0; i < weightChoice->psWeightIDs.size(); ++i) {
+          weightChoice->psWeightsDoc +=
+              "[" + std::to_string(i) + "] " + weightNames.at(weightChoice->psWeightIDs.at(i)) + "; ";
+        }
+
+        weightChoice->scaleWeightIDs.clear();
+        weightChoice->pdfWeightIDs.clear();
+
+        std::sort(scaleVariationIDs.begin(), scaleVariationIDs.end());
+        std::stringstream scaleDoc;
+        scaleDoc << "LHE scale variation weights (w_var / w_nominal); ";
+        for (unsigned int isw = 0, nsw = scaleVariationIDs.size(); isw < nsw; ++isw) {
+          const auto& sw = scaleVariationIDs[isw];
+          if (isw)
+            scaleDoc << "; ";
+          scaleDoc << "[" << isw << "] is " << sw.label;
+          weightChoice->scaleWeightIDs.push_back(std::atoi(sw.wid.c_str()));
+        }
+        if (!scaleVariationIDs.empty())
+          weightChoice->scaleWeightsDoc = scaleDoc.str();
+        std::stringstream pdfDoc;
+        pdfDoc << "LHE pdf variation weights (w_var / w_nominal) for LHA names ";
+        bool found = false;
+        for (const auto& pw : pdfSetWeightIDs) {
+          if (pw.wids.size() == 1)
+            continue;  // only consider error sets
+          for (const auto& wantedpdf : lhaNameToID_) {
+            auto pdfname = wantedpdf.first;
+            if (knownPDFSetsFromGenInfo_.find(pdfname) == knownPDFSetsFromGenInfo_.end())
+              continue;
+            uint32_t lhaid = knownPDFSetsFromGenInfo_.at(pdfname);
+            if (pw.lhaIDs.first != lhaid)
+              continue;
+            pdfDoc << pdfname;
+            for (const auto& x : pw.wids)
+              weightChoice->pdfWeightIDs.push_back(std::atoi(x.c_str()));
+            if (maxPdfWeights_ < pw.wids.size()) {
+              weightChoice->pdfWeightIDs.resize(maxPdfWeights_);  // drop some replicas
+              pdfDoc << ", truncated to the first " << maxPdfWeights_ << " replicas";
+            }
+            weightChoice->pdfWeightsDoc = pdfDoc.str();
+            found = true;
+            break;
+          }
+          if (found)
+            break;
+        }
       }
     }
     return dynamicWeightChoiceGenInfo;

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -1055,9 +1055,9 @@ public:
         std::ostringstream psdoc;
         psdoc << "[Sherpa detected] All generator weights are stored in the PSWeight table.\n"
               << "  - Baseline weight (index " << weightChoice->psBaselineID << ") is kept UNNORMALIZED\n"
-              << "    to allow post-hoc renormalization or alternative reference choices.\n"
+              << "    and saved in 'genWeight' branch.\n"
               << "  - All other weights are stored as w_i / w_baseline.\n"
-              << "  - This includes internal Sherpa weights (Weight, MEWeight, WeightNormalisation, NTrials)\n"
+              << "  - This includes internal Sherpa weights (MEWeight, WeightNormalisation, NTrials)\n"
               << "    as well as all additional variation weights.\n"
               << "  - No splitting into scale/PDF containers is performed for Sherpa samples.\n"
               << "  Stored indices: [0 .. " << (!weightNames.empty() ? weightNames.size() - 1 : 0) << "]\n";

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -1060,7 +1060,7 @@ public:
               << "  - This includes internal Sherpa weights (Weight, MEWeight, WeightNormalisation, NTrials)\n"
               << "    as well as all additional variation weights.\n"
               << "  - No splitting into scale/PDF containers is performed for Sherpa samples.\n"
-              << "  Stored indices: [0 .. " << (weightNames.size() ? weightNames.size() - 1 : 0) << "]\n";
+              << "  Stored indices: [0 .. " << (!weightNames.empty() ? weightNames.size() - 1 : 0) << "]\n";
         weightChoice->psWeightsDoc = psdoc.str();
 
         weightChoice->scaleWeightsDoc = "[Sherpa detected] scale weights not split (stored in PS container).";


### PR DESCRIPTION
This PR improves the handling of generator weights for Sherpa-produced samples in the NanoAOD GenWeightsTableProducer.

Sherpa encodes all generator weights (including the nominal weight, matrix-element weight, normalisation, number of trials, parton shower variations, and theory-related variations) in a single, ordered list, which does not follow the assumptions used for MadGraph/powheg-based samples.
In the previous implementation, these weights were normalised with respect to the wrong reference weight, leading to inconsistent relative weights.

This PR introduces an explicit Sherpa detection at the GenLumiInfoHeader level and enforces a dedicated treatment:
	•	Sherpa samples are identified via their characteristic weight-name structure.
	•	All Sherpa generator weights are stored in the PSWeight table (always, not using keepAllPSWeights_).
	•	All weights are normalized to a configurable baseline (default index 0 for Sherpa).
	•	Scale and PDF containers are left empty for Sherpa, with clear documentation strings indicating that these weights are stored in the PS container instead.
	•	The existing logic for non-Sherpa generators is preserved unchanged.

No changes are expected for non-Sherpa samples.