### PR TITLE
Add HCAL TDC time to MAHI ALPAKA recHits

### DIFF
--- a/DQM/HcalCommon/interface/ValueQuantity.h
+++ b/DQM/HcalCommon/interface/ValueQuantity.h
@@ -72,6 +72,8 @@ namespace hcaldqm {
       fDiffRatio,  // (v2-v1)/v1
       fCPUenergy,
       fGPUenergy,
+      fCPUtime,
+      fGPUtime,
       fNbins,
     };
     const std::map<ValueQuantityType, std::string> name_value = {
@@ -139,6 +141,8 @@ namespace hcaldqm {
         {fDiffRatio, "(GPU energy - CPU energy)/CPU energy"},
         {fCPUenergy, "CPU energy"},
         {fGPUenergy, "GPU energy"},
+        {fCPUtime, "CPU time"},
+        {fGPUtime, "GPU time"},
         {fNbins, "Nbins"},
     };
     const std::map<ValueQuantityType, double> min_value = {
@@ -206,6 +210,8 @@ namespace hcaldqm {
         {fDiffRatio, -2.5},
         {fCPUenergy, 0},
         {fGPUenergy, 0},
+        {fCPUtime, 0},
+        {fGPUtime, 0},
         {fNbins, 0},
     };
     const std::map<ValueQuantityType, double> max_value = {
@@ -273,6 +279,8 @@ namespace hcaldqm {
         {fDiffRatio, 2.5},
         {fCPUenergy, 200},
         {fGPUenergy, 200},
+        {fCPUtime, 200},
+        {fGPUtime, 200},
         {fNbins, 50},
     };
     const std::map<ValueQuantityType, int> nbins_value = {
@@ -339,6 +347,8 @@ namespace hcaldqm {
         {fDiffRatio, 50},
         {fCPUenergy, 1000},
         {fGPUenergy, 1000},
+        {fCPUtime, 1000},
+        {fGPUtime, 1000},
         {fNbins, 50},
     };
     class ValueQuantity : public Quantity {

--- a/RecoLocalCalo/HcalRecProducers/src/HcalRecHitSoAToLegacy.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalRecHitSoAToLegacy.cc
@@ -56,7 +56,7 @@ void HcalRecHitSoAToLegacy::produce(edm::Event& event, edm::EventSetup const& se
     // build a legacy rechit with the computed detid and MAHI energy
     recHitsLegacy->emplace_back(HcalDetId{rechit.detId()},
                                 rechit.energy(),
-                                0  // timeRising
+                                rechit.timeM0()  // timeRising
     );
     // update the legacy rechit with the Chi2 and M0 values
     recHitsLegacy->back().setChiSquared(rechit.chi2());


### PR DESCRIPTION
#### PR description:

  - This PR is to add HCAL TDC time to MAHI ALPAKA recHits, following the request from HLT and HCAL [JIRA ticket](https://its.cern.ch/jira/browse/CMSHLT-3603).
  - Details of this PR can be found in [HLT meeting](https://indico.cern.ch/event/1589198/) and [HCAL meeting](https://indico.cern.ch/event/1614046/).
  - The change on scouting event size and HLT timing is tested, and approved by TSG, O&C, and PC.
  - The implementation of adding the recHit time to ScoutingHBHERecHit will be taken care of by Patin Inkaew in another PR. This PR takes care of the HCAL side: implementation in ALPAKA recHits, conversion to legacy HBHErecHit, and also adding timing comparisons in HCAL DQM.
  - This PR is expected to be merged into CMSSW_16_0_0, which will be used for 2026 datataking.

#### PR validation:

The PR validation follows the instruction in [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).
