### PR TITLE
Pointer safety protection in XrdAdaptor error reporting

### DIFF
--- a/FWStorage/XrdAdaptor/src/XrdRequestManager.cc
+++ b/FWStorage/XrdAdaptor/src/XrdRequestManager.cc
@@ -146,7 +146,7 @@ namespace {
         std::string type_resource = "endpoint";
         std::string authentication;
         // Organize redirection info
-        if (!auth_method->empty()) {
+        if (auth_method && !auth_method->empty()) {
           authentication = *auth_method;
         } else {
           authentication = "no auth";
@@ -154,11 +154,12 @@ namespace {
         if (host.loadBalancer == 1) {
           type_resource = "load balancer";
         };
+        const std::string noresp{"(null)"};
         li.format("{}. || {} / {} / {} / {} / {} / {} ||\n",
                   idx_redirection,
-                  *hostname_method,
-                  *stack_ip_method,
-                  *ip_method,
+                  hostname_method ? *hostname_method : noresp,
+                  stack_ip_method ? *stack_ip_method : noresp,
+                  ip_method ? *ip_method : noresp,
                   host.url.GetPort(),
                   authentication,
                   type_resource);

--- a/FWStorage/XrdAdaptor/src/XrdRequestManager.cc
+++ b/FWStorage/XrdAdaptor/src/XrdRequestManager.cc
@@ -128,7 +128,7 @@ namespace {
   std::unique_ptr<std::string> getQueryTransport(const XrdCl::URL &url, uint16_t query) {
     XrdCl::AnyObject result;
     XrdCl::DefaultEnv::GetPostMaster()->QueryTransport(url, query, result);
-    std::string *tmp;
+    std::string *tmp{nullptr};
     result.Get(tmp);
     return std::unique_ptr<std::string>(tmp);
   }


### PR DESCRIPTION
#### PR description:

This PR adds pointer safety tests to the `tracerouteRedirections()` function, which is called to report xrootd open failures.  Prior to this, tests (from Cornell) were segfaulting due to empty responses for items to be reported:
```
(gdb) p auth_method
$3 = std::unique_ptr<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >> = {
  get() = 0x0
}
(gdb) p stack_ip_method
$4 = std::unique_ptr<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >> = {
  get() = 0x0
}
(gdb) p ip_method
$5 = std::unique_ptr<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >> = {
  get() = 0x0
}
(gdb) p hostname_method
$6 = std::unique_ptr<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >> = {
  get() = 0x0
}
(gdb) p host
$7 = (const XrdCl::HostInfo &) @0x7f25fbe2b5c8: {
  flags = 3610247169,
  protocol = 1297,
  loadBalancer = false,
  url = {
    pHostId = "cmsxrootd-site2.fnal.gov:1093",
    pProtocol = "root",
    pUserName = "",
    pPassword = "",
    pHostName = "cmsxrootd-site2.fnal.gov",
    pPort = 1093,
    pPath = "",
    pParams = std::map with 1 element = {
      ["xrdcl.requuid"] = "b8f755b2-a314-48cd-a6e4-c7459fa9cdf3"
    },
    pURL = "root://cmsxrootd-site2.fnal.gov:1093/?xrdcl.requuid=b8f755b2-a314-48cd-a6e4-c7459fa9cdf3"
  }
}
```

#### PR validation:

Trivial technical fix.  Test jobs that previously failed xrootd file opens fairly frequently and segfaulted now consistently report the error and exit properly.

Resolves https://github.com/cms-sw/framework-team/issues/1754