### PR TITLE
Corrections to Center of gravity for v19 HGCAL cells

### DIFF
--- a/Geometry/HGCalCommonData/src/HGCalCellOffset.cc
+++ b/Geometry/HGCalCommonData/src/HGCalCellOffset.cc
@@ -68,7 +68,8 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
 
           double xMag = 1.42; //0.5 * xMag1 + sqrt3By2_ * yMag1;
           double yMag = 2.46; //sqrt3By2_ * xMag1 - 0.5 * yMag1;
-          std::cout << "HD Corner "<< xMag << "  " << yMag << std::endl;
+          //std::cout << "HD Corner "<< xMag << "  " << yMag << std::endl;
+
           std::array<double, 6> tempOffsetX = {{(sqrt3By2_ * xMag - 0.5 * yMag),
                                                 yMag,
                                                 yMag,
@@ -123,9 +124,9 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
           double yMag1 = ((-5 * cellX_[k] / 42) * totalArea - (cutArea1 * y1) - (cutArea2 * y2) - (cutArea3 * y3)) /
                          (cellArea[k][j]);
 
-          double xMag = 1.15; //-0.5 * xMag1 - sqrt3By2_ * yMag1;
-          double yMag = 2.38; //sqrt3By2_ * xMag1 - 0.5 * yMag1;
-          std::cout << "LD Corner "<< xMag << "  " << yMag << std::endl;
+          double xMag = 1.48; //-0.5 * xMag1 - sqrt3By2_ * yMag1;
+          double yMag = 2.18; //sqrt3By2_ * xMag1 - 0.5 * yMag1; '-2.38', 'deltaY': '1.15'
+          //std::cout << "LD Corner "<< xMag << "  " << yMag << std::endl;
 
           std::array<double, 6> tempOffsetX = {{(sqrt3By2_ * xMag - 0.5 * yMag),
                                                 yMag,
@@ -186,7 +187,7 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
       } else if (j == HGCalCell::truncatedMBCell) {
         double H = mouseBiteCut_ - (1 / sqrt3By2_ * guardRingSizeOffset_);
         double h = H - (sqrt3_ / 2 * cellX_[k]) + (guardRingSizeOffset_ / (2 * sqrt3_));
-	std::cout << "Truncated MB " << k << "  " << h << " H " << H << " s " << cellX_[k] << " G " << guardRingSizeOffset_ << std::endl;
+	//std::cout << "Truncated MB " << k << "  " << h << " H " << H << " s " << cellX_[k] << " G " << guardRingSizeOffset_ << std::endl;
         if (h > 0) {
           double totalArea = 5.0 * sqrt3_ * std::pow(cellX_[k], 2) / 4.0;
 
@@ -203,7 +204,7 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
           double yMag1 = ((cellX_[k] / 15.0) * totalArea - (cutArea1 * y1) - (cutArea2 * y2)) / (cellArea[k][j]);
           double xMag = -yMag1;
           double yMag = -xMag1;
-          std::cout << "HD trun Corner " << xMag << "  " << yMag << std::endl;
+          //std::cout << "HD trun Corner " << xMag << "  " << yMag << std::endl;
           if (k == 0){
             xMag = -0.05;
 	    yMag = -1.33;
@@ -262,10 +263,14 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
 
         double xMag = yMag1;
         double yMag = -xMag1;
-        std::cout << "HD ext Corner " << xMag << "  " << yMag << std::endl;
+        //std::cout << "HD ext Corner " << xMag << "  " << yMag << std::endl;
         if (k == 0){
-            xMag = 0.27;
-            yMag = 0.61;
+            xMag = 0.40;
+            yMag = 0.54;
+          }
+        else if (k == 1){
+	    xMag = 0.12;
+            yMag = -0.04;
           }
         std::array<double, 6> tempOffsetX = {{(sqrt3By2_ * xMag - 0.5 * yMag),
                                               yMag,
@@ -298,7 +303,7 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
                       (cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset]);
         double yMag = (0 * totalArea - (cutArea * y1)) / (cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset]);
 
-        std::cout << "Half Cell k " << k << " xy " << x1 << "   " << y1 << " mag " << xMag << "  " << yMag << std::endl;
+        //std::cout << "Half Cell k " << k << " xy " << x1 << "   " << y1 << " mag " << xMag << "  " << yMag << std::endl;
         std::array<double, 6> tempOffsetX = {{(-sqrt3By2_ * xMag - 0.5 * yMag),
                                               (-sqrt3By2_ * xMag + 0.5 * yMag),
                                               yMag,

--- a/Geometry/HGCalCommonData/src/HGCalCellOffset.cc
+++ b/Geometry/HGCalCommonData/src/HGCalCellOffset.cc
@@ -66,8 +66,10 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
               ((19.0 * cellX_[k] / 132.0) * totalArea - (cutArea1 * y1) - (cutArea2 * y2) - (cutArea3 * y3)) /
               (cellArea[k][j]);
 
-          double xMag = 1.42;  //0.5 * xMag1 + sqrt3By2_ * yMag1;
-          double yMag = 2.46;  //sqrt3By2_ * xMag1 - 0.5 * yMag1;
+          double xMag = 0.5 * xMag1 + sqrt3By2_ * yMag1;
+          double yMag = sqrt3By2_ * xMag1 - 0.5 * yMag1;
+          xMag = 1.42;
+          yMag = 2.46;
           //std::cout << "HD Corner "<< xMag << "  " << yMag << std::endl;
 
           std::array<double, 6> tempOffsetX = {{(sqrt3By2_ * xMag - 0.5 * yMag),
@@ -124,8 +126,10 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
           double yMag1 = ((-5 * cellX_[k] / 42) * totalArea - (cutArea1 * y1) - (cutArea2 * y2) - (cutArea3 * y3)) /
                          (cellArea[k][j]);
 
-          double xMag = 1.48;  //-0.5 * xMag1 - sqrt3By2_ * yMag1;
-          double yMag = 2.18;  //sqrt3By2_ * xMag1 - 0.5 * yMag1; '-2.38', 'deltaY': '1.15'
+          double xMag = -0.5 * xMag1 - sqrt3By2_ * yMag1;
+          double yMag = sqrt3By2_ * xMag1 - 0.5 * yMag1;
+          xMag = 1.48;
+          yMag = 2.18;
           //std::cout << "LD Corner "<< xMag << "  " << yMag << std::endl;
 
           std::array<double, 6> tempOffsetX = {{(sqrt3By2_ * xMag - 0.5 * yMag),

--- a/Geometry/HGCalCommonData/src/HGCalCellOffset.cc
+++ b/Geometry/HGCalCommonData/src/HGCalCellOffset.cc
@@ -15,7 +15,8 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
   ncell_[0] = nFine;
   ncell_[1] = nCoarse;
   hgcalcell_ = std::make_unique<HGCalCell>(waferSize, nFine, nCoarse);
-  double guardRingSizeOffset_ = guardRingOffset_ + sizeOffset_;
+  double guardRingSizeOffset_ = guardRingOffset_ + 0.5 * sizeOffset_;
+  //mouseBiteCut_ = mouseBiteCut_ - guardRingOffset_;
   for (int k = 0; k < 2; ++k) {  // k refers to type of wafer fine or coarse
     cellX_[k] = waferSize / (3 * ncell_[k]);
     cellY_[k] = sqrt3By2_ * cellX_[k];
@@ -30,6 +31,7 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
       } else if (j == HGCalCell::cornerCell) {  // Offset for corner cells
         if (k == 0) {
           double h = (mouseBiteCut_ - sqrt3By2_ * cellX_[k]);
+          //double h = (mouseBiteCut_ - guardRingSizeOffset_) / sqrt3By2_ - cellX_[k] / 2;
           double H = mouseBiteCut_ - (1 / sqrt3By2_ * guardRingSizeOffset_);
           double h1 = H - (sqrt3_ / 4 * cellX_[k]) + (guardRingSizeOffset_ / (2 * sqrt3_));
           double h2 = H - (sqrt3_ / 2 * cellX_[k]) + (guardRingSizeOffset_ / (2 * sqrt3_));
@@ -50,10 +52,10 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
           double x3_3 = -(cellX_[k] * sqrt3_ / 4.0);
           double y3_3 = cellX_[k] * 11.0 / 12.0;
 
-          double x1 = -(3.0 * sqrt3_ * cellX_[k] / 8.0 - sqrt3_ * guardRingOffset_ / 4.0);
-          double y1 = 5.0 * cellX_[k] / 12.0 - guardRingOffset_ / 4.0;
-          double x2 = -((0.5 * cellX_[k] - 0.5 * guardRingOffset_) * sqrt3By2_);
-          double y2 = -(0.5 * cellX_[k] - 0.5 * guardRingOffset_) * 0.5;
+          double x1 = -(3.0 * sqrt3_ * cellX_[k] / 8.0 - sqrt3_ * guardRingSizeOffset_ / 4.0);
+          double y1 = 5.0 * cellX_[k] / 12.0 - guardRingSizeOffset_ / 4.0;
+          double x2 = -((0.5 * cellX_[k] - 0.5 * guardRingSizeOffset_) * sqrt3By2_);
+          double y2 = -(0.5 * cellX_[k] - 0.5 * guardRingSizeOffset_) * 0.5;
           double x3 = (A1 * x3_1 + A2 * x3_2 + A3 * x3_3) / cutArea3;
           double y3 = (A1 * y3_1 + A2 * y3_2 + A3 * y3_3) / cutArea3;
           cellArea[k][j] = totalArea - cutArea1 - cutArea2 - cutArea3;
@@ -64,9 +66,9 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
               ((19.0 * cellX_[k] / 132.0) * totalArea - (cutArea1 * y1) - (cutArea2 * y2) - (cutArea3 * y3)) /
               (cellArea[k][j]);
 
-          double xMag = 0.5 * xMag1 + sqrt3By2_ * yMag1;
-          double yMag = sqrt3By2_ * xMag1 - 0.5 * yMag1;
-
+          double xMag = 1.42; //0.5 * xMag1 + sqrt3By2_ * yMag1;
+          double yMag = 2.46; //sqrt3By2_ * xMag1 - 0.5 * yMag1;
+          std::cout << "HD Corner "<< xMag << "  " << yMag << std::endl;
           std::array<double, 6> tempOffsetX = {{(sqrt3By2_ * xMag - 0.5 * yMag),
                                                 yMag,
                                                 yMag,
@@ -85,7 +87,7 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
             offsetY[k][j][i] = tempOffsetY[i];
           }
         } else if (k == 1) {
-          double h = (mouseBiteCut_ - guardRingOffset_) / sqrt3By2_ - cellX_[k] / 2;
+          double h = (mouseBiteCut_ - guardRingSizeOffset_) / sqrt3By2_ - cellX_[k] / 2;
           double H = mouseBiteCut_ - (1 / sqrt3By2_ * guardRingSizeOffset_);
           double h1 = H - ((sqrt3_ / 4) * cellX_[k]) + (guardRingSizeOffset_ / (2 * sqrt3_));
           double totalArea = 11.0 * sqrt3_ * std::pow(cellX_[k], 2) / 8.0;
@@ -96,20 +98,22 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
           double cutArea3 = sqrt3_ * std::pow(H, 2) - (1 / sqrt3By2_ * std::pow(h1, 2));
           //double cutArea3 = sqrt3_ * std::pow((mouseBiteCut_ - guardRingOffset_), 2) - sqrt3By2_ * std::pow(h, 2);
 
-          double x2_0 = (0.375 * cellX_[k] * cellX_[k] - (0.25 * cellX_[k] * guardRingOffset_) +
-                         std::pow(guardRingOffset_, 2) / 18) /
-                        (sqrt3By2_ * cellX_[k] + guardRingOffset_ / (2 * sqrt3_));
-          double y2_0 = (sqrt3_ * cellX_[k] * guardRingOffset_ / 4 + std::pow(guardRingOffset_, 2) / (6 * sqrt3_)) /
-                        (sqrt3By2_ * cellX_[k] + guardRingOffset_ / (2 * sqrt3_));
-          double x3_1 = -(cellX_[k] - guardRingOffset_ - 2 * (mouseBiteCut_ - guardRingOffset_) / 3) * sqrt3By2_;
-          double y3_1 = 0.5 * (cellX_[k] - guardRingOffset_ - 2 * (mouseBiteCut_ - guardRingOffset_) / 3);
+          double x2_0 = (0.375 * cellX_[k] * cellX_[k] - (0.25 * cellX_[k] * guardRingSizeOffset_) +
+                         std::pow(guardRingSizeOffset_, 2) / 18) /
+                        (sqrt3By2_ * cellX_[k] + guardRingSizeOffset_ / (2 * sqrt3_));
+          double y2_0 =
+              (sqrt3_ * cellX_[k] * guardRingSizeOffset_ / 4 + std::pow(guardRingSizeOffset_, 2) / (6 * sqrt3_)) /
+              (sqrt3By2_ * cellX_[k] + guardRingSizeOffset_ / (2 * sqrt3_));
+          double x3_1 =
+              -(cellX_[k] - guardRingSizeOffset_ - 2 * (mouseBiteCut_ - guardRingSizeOffset_) / 3) * sqrt3By2_;
+          double y3_1 = 0.5 * (cellX_[k] - guardRingSizeOffset_ - 2 * (mouseBiteCut_ - guardRingSizeOffset_) / 3);
           double x3_2 = -((3 * cellX_[k] / 2 - h / 3) * sqrt3By2_ + sqrt3_ * h / 6);
           double y3_2 = -(cellX_[k] / 4 + 4 * h / 6);
-          double A1 = sqrt3_ * std::pow((mouseBiteCut_ - guardRingOffset_), 2);
+          double A1 = sqrt3_ * std::pow((mouseBiteCut_ - guardRingSizeOffset_), 2);
           double A2 = sqrt3By2_ * std::pow(h, 2);
 
           double x1 = 0;
-          double y1 = 0.5 * cellX_[k] - 0.5 * guardRingOffset_;
+          double y1 = 0.5 * cellX_[k] - 0.5 * guardRingSizeOffset_;
           double x2 = -(1.5 * sqrt3By2_ * cellX_[k] - x2_0 * 0.5 - y2_0 * sqrt3By2_);
           double y2 = -(0.25 * cellX_[k] - x2_0 * sqrt3By2_ + y2_0 / 2);
           double x3 = (A1 * x3_1 - A2 * x3_2) / (A1 - A2);
@@ -119,8 +123,9 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
           double yMag1 = ((-5 * cellX_[k] / 42) * totalArea - (cutArea1 * y1) - (cutArea2 * y2) - (cutArea3 * y3)) /
                          (cellArea[k][j]);
 
-          double xMag = -0.5 * xMag1 - sqrt3By2_ * yMag1;
-          double yMag = sqrt3By2_ * xMag1 - 0.5 * yMag1;
+          double xMag = 1.15; //-0.5 * xMag1 - sqrt3By2_ * yMag1;
+          double yMag = 2.38; //sqrt3By2_ * xMag1 - 0.5 * yMag1;
+          std::cout << "LD Corner "<< xMag << "  " << yMag << std::endl;
 
           std::array<double, 6> tempOffsetX = {{(sqrt3By2_ * xMag - 0.5 * yMag),
                                                 yMag,
@@ -144,11 +149,13 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
         double cutArea =
             cellX_[k] * sqrt3_ * guardRingSizeOffset_;  // Area of inactive region form guardring and other effects
         cellArea[k][j] = totalArea - cutArea;
-        double offMag = (((-2.0 / 15.0) * totalArea * cellX_[k]) - ((cellX_[k] - (0.5 * guardRingOffset_)) * cutArea)) /
-                        (cellArea[k][j]);  // Magnitude of offset
+        double offMag =
+            (((-2.0 / 15.0) * totalArea * cellX_[k]) - ((0.5 * cellX_[k] - (0.5 * guardRingSizeOffset_)) * cutArea)) /
+            (cellArea[k][j]);  // Magnitude of offset
         // (x, y) coordinates of offset for 6 sides of wafer starting from bottom left edge in clockwise direction
         // offset_x = -Offset_magnitude * sin(30 + 60*i) i in (0-6)
         // offset_y = -Offset_magnitude * cos(30 + 60*i) i in (0-6)
+	//offMag = (k == 0) ? 1.9044 : 1.61; 
         std::array<double, 6> tempOffsetX = {
             {-0.5 * offMag, -offMag, -0.5 * offMag, 0.5 * offMag, offMag, 0.5 * offMag}};
         std::array<double, 6> tempOffsetY = {
@@ -163,7 +170,7 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
             cellX_[k] * sqrt3_ * guardRingSizeOffset_;  // Area of inactive region form guardring and other effects
         cellArea[k][j] = totalArea - cutArea;
         double offMag =  // Magnitude of offset
-            (((5.0 / 42.0) * totalArea * cellX_[k]) - ((cellX_[k] - (0.5 * guardRingOffset_))) * (cutArea)) /
+            (((5.0 / 42.0) * totalArea * cellX_[k]) - ((cellX_[k] - (0.5 * guardRingSizeOffset_)) * cutArea)) /
             (cellArea[k][j]);
         // (x, y) coordinates of offset for 6 sides of wafer starting from bottom left edge in clockwise direction
         // offset_x = -Offset_magnitude * sin(30 + 60*i) i in (0-6)
@@ -179,14 +186,15 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
       } else if (j == HGCalCell::truncatedMBCell) {
         double H = mouseBiteCut_ - (1 / sqrt3By2_ * guardRingSizeOffset_);
         double h = H - (sqrt3_ / 2 * cellX_[k]) + (guardRingSizeOffset_ / (2 * sqrt3_));
+	std::cout << "Truncated MB " << k << "  " << h << " H " << H << " s " << cellX_[k] << " G " << guardRingSizeOffset_ << std::endl;
         if (h > 0) {
           double totalArea = 5.0 * sqrt3_ * std::pow(cellX_[k], 2) / 4.0;
 
           double cutArea1 = (sqrt3_ * cellX_[k] * guardRingSizeOffset_);
           double cutArea2 = std::pow(h, 2) / sqrt3By2_;
 
-          double x1 = -(0.5 * cellX_[k] - 0.5 * guardRingOffset_) * sqrt3By2_;
-          double y1 = -(0.5 * cellX_[k] - 0.5 * guardRingOffset_) * 0.5;
+          double x1 = -(0.5 * cellX_[k] - 0.5 * guardRingSizeOffset_) * sqrt3By2_;
+          double y1 = -(0.5 * cellX_[k] - 0.5 * guardRingSizeOffset_) * 0.5;
           double x2 = -((sqrt3By2_ * cellX_[k]) - (2.0 * h) / 3.0);
           double y2 = 0.5 * cellX_[k] - (2.0 * h) / (3.0 * sqrt3_);
           cellArea[k][j] = totalArea - cutArea1 - cutArea2;
@@ -195,7 +203,11 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
           double yMag1 = ((cellX_[k] / 15.0) * totalArea - (cutArea1 * y1) - (cutArea2 * y2)) / (cellArea[k][j]);
           double xMag = -yMag1;
           double yMag = -xMag1;
-
+          std::cout << "HD trun Corner " << xMag << "  " << yMag << std::endl;
+          if (k == 0){
+            xMag = -0.05;
+	    yMag = -1.33;
+	  }
           std::array<double, 6> tempOffsetX = {{(sqrt3By2_ * xMag - 0.5 * yMag),
                                                 (-sqrt3By2_ * xMag - 0.5 * yMag),
                                                 (-sqrt3By2_ * xMag - 0.5 * yMag),
@@ -239,8 +251,8 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
         double cutArea1 = (sqrt3_ * cellX_[k] * guardRingSizeOffset_);
         double cutArea2 = std::pow(h, 2) / sqrt3By2_;
 
-        double x1 = -(sqrt3By2_ * cellX_[k] - sqrt3By2_ * guardRingOffset_ / 2.0);
-        double y1 = (0.5 * cellX_[k] - 0.25 * guardRingOffset_);
+        double x1 = -(sqrt3By2_ * cellX_[k] - sqrt3By2_ * guardRingSizeOffset_ / 2.0);
+        double y1 = (0.5 * cellX_[k] - 0.25 * guardRingSizeOffset_);
         double x2 = -(sqrt3By2_ * 1.5 * cellX_[k] - h / sqrt3_);
         double y2 = -0.25 * cellX_[k] + h / 3.0;
         cellArea[k][j] = totalArea - cutArea1 - cutArea2;
@@ -250,7 +262,11 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
 
         double xMag = yMag1;
         double yMag = -xMag1;
-
+        std::cout << "HD ext Corner " << xMag << "  " << yMag << std::endl;
+        if (k == 0){
+            xMag = 0.27;
+            yMag = 0.61;
+          }
         std::array<double, 6> tempOffsetX = {{(sqrt3By2_ * xMag - 0.5 * yMag),
                                               yMag,
                                               yMag,
@@ -282,6 +298,7 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
                       (cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset]);
         double yMag = (0 * totalArea - (cutArea * y1)) / (cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset]);
 
+        std::cout << "Half Cell k " << k << " xy " << x1 << "   " << y1 << " mag " << xMag << "  " << yMag << std::endl;
         std::array<double, 6> tempOffsetX = {{(-sqrt3By2_ * xMag - 0.5 * yMag),
                                               (-sqrt3By2_ * xMag + 0.5 * yMag),
                                               yMag,
@@ -304,8 +321,8 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
         double cutArea1 = (sqrt3By2_ * cellX_[k] * guardRingSizeOffset_) - guardRingOffset_ * guardRingSizeOffset_;
         double cutArea2 = (2 * cellX_[k] * guardRingOffset_) - std::pow(guardRingOffset_, 2) / (2 * sqrt3_);
 
-        double x1 = -sqrt3_ * cellX_[k] / 4;
-        double y1 = (0.5 * cellX_[k] - 0.5 * guardRingOffset_);
+        double x1 = 0.5 * ((-sqrt3By2_ * cellX_[k]) - guardRingOffset_);
+        double y1 = (0.5 * cellX_[k] - 0.5 * guardRingSizeOffset_);
         double x2 = (-3 * cellX_[k] * guardRingOffset_ / 4 + std::pow(guardRingOffset_, 2) / (3 * sqrt3_)) /
                     (3 * cellX_[k] / 2 - guardRingOffset_ / (2 * sqrt3_));
         double y2 = (-cellX_[k] * guardRingOffset_ / (2 * sqrt3_) + std::pow(guardRingOffset_, 2) / 18 -
@@ -340,8 +357,8 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
         double cutArea2 = (2 * cellX_[k] * guardRingOffset_) - std::pow(guardRingOffset_, 2) / (2 * sqrt3_);
         cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset] = totalArea - cutArea1 - cutArea2;
 
-        double x1 = -sqrt3By2_ * cellX_[k] / 2;
-        double y1 = -(cellX_[k] - guardRingOffset_ / 2);
+        double x1 = 0.5 * ((-sqrt3By2_ * cellX_[k]) - guardRingOffset_);
+        double y1 = -(cellX_[k] - guardRingSizeOffset_ / 2);
         double x2 = (-cellX_[k] * guardRingOffset_ + std::pow(guardRingOffset_, 2) / (3 * sqrt3_)) /
                     (2 * cellX_[k] - guardRingOffset_ / (2 * sqrt3_));
         double y2 = (-cellX_[k] * guardRingOffset_ / (2 * sqrt3_) + std::pow(guardRingOffset_, 2) / 18) /
@@ -369,25 +386,11 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
           offsetPartialY[k][j - HGCalCell::partiaclWaferCellsOffset][i] = tempOffsetY[i];
         }
       } else if (j == (HGCalCell::extTrunCellCenCut)) {
-        double totalArea = 5 * sqrt3_ * std::pow(cellX_[k], 2) / 8;
-        double cutArea1 = (sqrt3By2_ * cellX_[k] * guardRingSizeOffset_) - guardRingOffset_ * guardRingSizeOffset_;
-        double cutArea2 = (cellX_[k] * guardRingOffset_) - std::pow(guardRingOffset_, 2) / (2 * sqrt3_);
-
-        double x1 = -sqrt3_ * cellX_[k] / 4;
-        double y1 = (0.5 * cellX_[k] - 0.5 * guardRingOffset_);
-        double x2 = (-3 * cellX_[k] * guardRingOffset_ / 4 + std::pow(guardRingOffset_, 2) / (3 * sqrt3_)) /
-                    (3 * cellX_[k] / 2 - guardRingOffset_ / (2 * sqrt3_));
-        double y2 = (-cellX_[k] * guardRingOffset_ / (2 * sqrt3_) + std::pow(guardRingOffset_, 2) / 18 -
-                     3 * std::pow(cellX_[k], 2) / 8) /
-                    (3 * cellX_[k] / 2 - guardRingOffset_ / (2 * sqrt3_));
         cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset] =
             2 * cellAreaPartial[k][HGCalCell::extHalfTrunCell - HGCalCell::partiaclWaferCellsOffset];
-        double xMag1 = ((-7 * sqrt3_ * cellX_[k] / 30) * totalArea - (cutArea1 * x1) - (cutArea2 * x2)) /
-                       (cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset]);
-        double yMag = ((-2 * cellX_[k] / 15) * totalArea - (cutArea1 * y1) - (cutArea2 * y2)) /
-                      (cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset]);
-        double xMag = -xMag1;
 
+        double xMag = 0.0;
+        double yMag = offsetPartialX[k][HGCalCell::extHalfTrunCell - HGCalCell::partiaclWaferCellsOffset][2];
         std::array<double, 6> tempOffsetX = {{(-sqrt3By2_ * xMag - 0.5 * yMag),
                                               (-sqrt3By2_ * xMag + 0.5 * yMag),
                                               yMag,
@@ -405,22 +408,11 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
           offsetPartialY[k][j - HGCalCell::partiaclWaferCellsOffset][i] = tempOffsetY[i];
         }
       } else if (j == (HGCalCell::extExtCellCenCut)) {
-        double totalArea = (7.0 * sqrt3_ / 8.0) * std::pow(cellX_[k], 2);
-        double cutArea1 = (sqrt3By2_ * cellX_[k] * guardRingSizeOffset_) - guardRingOffset_ * guardRingSizeOffset_;
-        double cutArea2 = (2 * cellX_[k] * guardRingOffset_) - std::pow(guardRingOffset_, 2) / (2 * sqrt3_);
         cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset] =
             2 * cellAreaPartial[k][HGCalCell::extHalfExtCell - HGCalCell::partiaclWaferCellsOffset];
 
-        double x1 = -sqrt3By2_ * cellX_[k] / 2;
-        double y1 = -(cellX_[k] - guardRingOffset_ / 2);
-        double x2 = (-cellX_[k] * guardRingOffset_ + std::pow(guardRingOffset_, 2) / (3 * sqrt3_)) /
-                    (2 * cellX_[k] - guardRingOffset_ / (2 * sqrt3_));
-        double y2 = (-cellX_[k] * guardRingOffset_ / (2 * sqrt3_) + std::pow(guardRingOffset_, 2) / 18) /
-                    (2 * cellX_[k] - guardRingOffset_ / (2 * sqrt3_));
-        double xMag = ((-5 * sqrt3_ * cellX_[k] / 21.0) * totalArea - (cutArea1 * x1) - (cutArea2 * x2)) /
-                      (cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset]);
-        double yMag = ((-5 * cellX_[k] / 42.0) * totalArea - (cutArea1 * y1) - (cutArea2 * y2)) /
-                      (cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset]);
+        double xMag = 0.0;
+        double yMag = offsetPartialX[k][HGCalCell::extHalfExtCell - HGCalCell::partiaclWaferCellsOffset][2];
 
         std::array<double, 6> tempOffsetX = {{(-sqrt3By2_ * xMag - 0.5 * yMag),
                                               (-sqrt3By2_ * xMag + 0.5 * yMag),
@@ -444,8 +436,8 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
         double cutArea1 = (sqrt3_ * cellX_[k] * guardRingSizeOffset_) - guardRingOffset_ * guardRingSizeOffset_;
         double cutArea2 = (cellX_[k] * guardRingOffset_) - std::pow(guardRingOffset_, 2) / (2 * sqrt3_);
 
-        double x1 = -sqrt3_ * cellX_[k] / 4;
-        double y1 = (0.5 * cellX_[k] - 0.5 * guardRingOffset_);
+        double x1 = -0.5 * guardRingOffset_;
+        double y1 = (0.5 * cellX_[k] - 0.5 * guardRingSizeOffset_);
         double x2 = (-3 * cellX_[k] * guardRingOffset_ / 4 + std::pow(guardRingOffset_, 2) / (3 * sqrt3_)) /
                     (3 * cellX_[k] / 2 - guardRingOffset_ / (2 * sqrt3_));
         double y2 = (-cellX_[k] * guardRingOffset_ / (2 * sqrt3_) + std::pow(guardRingOffset_, 2) / 18 -
@@ -480,8 +472,8 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
         double cutArea2 = (1.5 * cellX_[k] * guardRingOffset_) - std::pow(guardRingOffset_, 2) / (2 * sqrt3_);
         cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset] = totalArea - cutArea1 - cutArea2;
 
-        double x1 = -sqrt3By2_ * cellX_[k] / 2;
-        double y1 = -(cellX_[k] - guardRingOffset_ / 2);
+        double x1 = -0.5 * guardRingOffset_;
+        double y1 = -(cellX_[k] - guardRingSizeOffset_ / 2);
         double x2 = (-cellX_[k] * guardRingOffset_ + std::pow(guardRingOffset_, 2) / (3 * sqrt3_)) /
                     (2 * cellX_[k] - guardRingOffset_ / (2 * sqrt3_));
         double y2 = (-cellX_[k] * guardRingOffset_ / (2 * sqrt3_) + std::pow(guardRingOffset_, 2) / 18) /
@@ -512,29 +504,9 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
         double totalArea = (3.0 * sqrt3_ / 2.0) * std::pow(cellX_[k], 2);
         double cutArea = cellX_[k] * 4.0 * guardRingOffset_ - std::pow(guardRingOffset_, 2) / sqrt3By2_;
         cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset] = totalArea - cutArea;
-        double x1 = (-cellX_[k] * guardRingOffset_ + 2 * std::pow(guardRingOffset_, 2) / (3 * sqrt3_)) /
-                    (2 * cellX_[k] - guardRingOffset_ / sqrt3_);
-        double y1 = 0;
-        double xMag = ((-2.0 * sqrt3_ * cellX_[k] / 9.0) * totalArea - (cutArea * x1)) /
-                      (cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset]);
-        double yMag = (0 * totalArea - (cutArea * y1)) / (cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset]);
-
-        std::array<double, 6> tempOffsetX = {{(-sqrt3By2_ * xMag - 0.5 * yMag),
-                                              (-sqrt3By2_ * xMag + 0.5 * yMag),
-                                              yMag,
-                                              (sqrt3By2_ * xMag + 0.5 * yMag),
-                                              (sqrt3By2_ * xMag - 0.5 * yMag),
-                                              -yMag}};
-        std::array<double, 6> tempOffsetY = {{(0.5 * xMag - sqrt3By2_ * yMag),
-                                              (-sqrt3By2_ * yMag - 0.5 * xMag),
-                                              -xMag,
-                                              (-0.5 * xMag + sqrt3By2_ * yMag),
-                                              (0.5 * xMag + sqrt3By2_ * yMag),
-                                              xMag}};
-
         for (int i = 0; i < 6; ++i) {
-          offsetPartialX[k][j - HGCalCell::partiaclWaferCellsOffset][i] = tempOffsetX[i];
-          offsetPartialY[k][j - HGCalCell::partiaclWaferCellsOffset][i] = tempOffsetY[i];
+          offsetPartialX[k][j - HGCalCell::partiaclWaferCellsOffset][i] = 0.0;
+          offsetPartialY[k][j - HGCalCell::partiaclWaferCellsOffset][i] = 0.0;
         }
       } else if (j == (HGCalCell::fullCellEdgeCut)) {
         double totalArea = (3.0 * sqrt3_ / 2.0) * std::pow(cellX_[k], 2);
@@ -606,7 +578,7 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
         double cutArea1 = (sqrt3By2_ * cellX_[k] * guardRingOffset_) - guardRingOffset_ * guardRingOffset_;
         double cutArea2 = (2 * cellX_[k] * guardRingOffset_) - std::pow(guardRingOffset_, 2) / (2 * sqrt3_);
         cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset] = totalArea - cutArea1 - cutArea2;
-        double x1 = -sqrt3By2_ * cellX_[k] / 2;
+        double x1 = 0.5 * ((-sqrt3By2_ * cellX_[k]) - guardRingOffset_);
         double y1 = -(cellX_[k] - guardRingOffset_ / 2);
         double x2 = (-cellX_[k] * guardRingOffset_ + std::pow(guardRingOffset_, 2) / (3 * sqrt3_)) /
                     (2 * cellX_[k] - guardRingOffset_ / (2 * sqrt3_));
@@ -638,7 +610,7 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
         double totalArea = 5 * sqrt3_ * std::pow(cellX_[k], 2) / 8;
         double cutArea1 = (sqrt3By2_ * cellX_[k] * guardRingOffset_) - guardRingOffset_ * guardRingOffset_;
         double cutArea2 = (2 * cellX_[k] * guardRingOffset_) - std::pow(guardRingOffset_, 2) / (2 * sqrt3_);
-        double x1 = -sqrt3_ * cellX_[k] / 4;
+        double x1 = 0.5 * ((-sqrt3By2_ * cellX_[k]) - guardRingOffset_);
         double y1 = (0.5 * cellX_[k] - 0.5 * guardRingOffset_);
         double x2 = (-3 * cellX_[k] * guardRingOffset_ / 4 + std::pow(guardRingOffset_, 2) / (3 * sqrt3_)) /
                     (3 * cellX_[k] / 2 - guardRingOffset_ / (2 * sqrt3_));
@@ -669,22 +641,11 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
           offsetPartialY[k][j - HGCalCell::partiaclWaferCellsOffset][i] = tempOffsetY[i];
         }
       } else if (j == (HGCalCell::intTrunCellCenCut)) {
-        double totalArea = (7.0 * sqrt3_ / 4.0) * std::pow(cellX_[k], 2);
-        double cutArea1 = (sqrt3By2_ * cellX_[k] * guardRingOffset_) - guardRingOffset_ * guardRingOffset_;
-        double cutArea2 = (2 * cellX_[k] * guardRingOffset_) - std::pow(guardRingOffset_, 2) / (2 * sqrt3_);
         cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset] =
             2 * cellAreaPartial[k][HGCalCell::intHalfTrunCell - HGCalCell::partiaclWaferCellsOffset];
 
-        double x1 = -sqrt3By2_ * cellX_[k] / 2;
-        double y1 = -(cellX_[k] - guardRingOffset_ / 2);
-        double x2 = (-cellX_[k] * guardRingOffset_ + std::pow(guardRingOffset_, 2) / (3 * sqrt3_)) /
-                    (2 * cellX_[k] - guardRingOffset_ / (2 * sqrt3_));
-        double y2 = (-cellX_[k] * guardRingOffset_ / (2 * sqrt3_) + std::pow(guardRingOffset_, 2) / 18) /
-                    (2 * cellX_[k] - guardRingOffset_ / (2 * sqrt3_));
-        double xMag = ((-5 * sqrt3_ * cellX_[k] / 21.0) * totalArea - (cutArea1 * x1) - (cutArea2 * x2)) /
-                      (cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset]);
-        double yMag = ((-5 * cellX_[k] / 42.0) * totalArea - (cutArea1 * y1) - (cutArea2 * y2)) /
-                      (cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset]);
+        double xMag = 0.0;
+        double yMag = offsetPartialX[k][HGCalCell::intHalfTrunCell - HGCalCell::partiaclWaferCellsOffset][2];
 
         std::array<double, 6> tempOffsetX = {{(-sqrt3By2_ * xMag - 0.5 * yMag),
                                               (-sqrt3By2_ * xMag + 0.5 * yMag),
@@ -704,23 +665,11 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
           offsetPartialY[k][j - HGCalCell::partiaclWaferCellsOffset][i] = tempOffsetY[i];
         }
       } else if (j == (HGCalCell::intExtCellCenCut)) {
-        double totalArea = 5 * sqrt3_ * std::pow(cellX_[k], 2) / 8;
-        double cutArea1 = (sqrt3By2_ * cellX_[k] * guardRingOffset_) - guardRingOffset_ * guardRingOffset_;
-        double cutArea2 = (2 * cellX_[k] * guardRingOffset_) - std::pow(guardRingOffset_, 2) / (2 * sqrt3_);
-        double x1 = -sqrt3_ * cellX_[k] / 4;
-        double y1 = (0.5 * cellX_[k] - 0.5 * guardRingOffset_);
-        double x2 = (-3 * cellX_[k] * guardRingOffset_ / 4 + std::pow(guardRingOffset_, 2) / (3 * sqrt3_)) /
-                    (3 * cellX_[k] / 2 - guardRingOffset_ / (2 * sqrt3_));
-        double y2 = (-cellX_[k] * guardRingOffset_ / (2 * sqrt3_) + std::pow(guardRingOffset_, 2) / 18 -
-                     3 * std::pow(cellX_[k], 2) / 8) /
-                    (3 * cellX_[k] / 2 - guardRingOffset_ / (2 * sqrt3_));
         cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset] =
             2 * cellAreaPartial[k][HGCalCell::intHalfExtCell - HGCalCell::partiaclWaferCellsOffset];
-        double xMag1 = ((-7 * sqrt3_ * cellX_[k] / 30) * totalArea - (cutArea1 * x1) - (cutArea2 * x2)) /
-                       (cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset]);
-        double yMag = ((-2 * cellX_[k] / 15) * totalArea - (cutArea1 * y1) - (cutArea2 * y2)) /
-                      (cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset]);
-        double xMag = -xMag1;
+
+        double xMag = 0.0;
+        double yMag = offsetPartialX[k][HGCalCell::intHalfExtCell - HGCalCell::partiaclWaferCellsOffset][2];
 
         std::array<double, 6> tempOffsetX = {{(-sqrt3By2_ * xMag - 0.5 * yMag),
                                               (-sqrt3By2_ * xMag + 0.5 * yMag),
@@ -816,24 +765,25 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
           double cutArea2 = (3 * cellX_[k] * sqrt3By2_ * guardRingOffset_);
           double cutArea3 = (sqrt3_ * std::pow((mouseBiteCut_ - (guardRingSizeOffset_ / sqrt3By2_)), 2) / 2) -
                             (mouseBiteCut_ * guardRingOffset_);
-          double x1_0 = ((3.375 * cellX_[k] * cellX_[k]) - (cellX_[k] * 0.75 * guardRingOffset_) +
-                         (std::pow(guardRingOffset_, 2) / 18)) /
-                        ((3 * cellX_[k] * sqrt3By2_) - (guardRingOffset_ / (2 * sqrt3_)));
-          double y1_0 =
-              ((3 * cellX_[k] * sqrt3By2_ * guardRingOffset_ / 2) - (std::pow(guardRingOffset_, 2) / (6 * sqrt3_))) /
-              ((3 * cellX_[k] * sqrt3By2_) - (guardRingOffset_ / (2 * sqrt3_)));
+          double x1_0 = ((3.375 * cellX_[k] * cellX_[k]) - (cellX_[k] * 0.75 * guardRingSizeOffset_) +
+                         (std::pow(guardRingSizeOffset_, 2) / 18)) /
+                        ((3 * cellX_[k] * sqrt3By2_) - (guardRingSizeOffset_ / (2 * sqrt3_)));
+          double y1_0 = ((3 * cellX_[k] * sqrt3By2_ * guardRingSizeOffset_ / 2) -
+                         (std::pow(guardRingSizeOffset_, 2) / (6 * sqrt3_))) /
+                        ((3 * cellX_[k] * sqrt3By2_) - (guardRingSizeOffset_ / (2 * sqrt3_)));
 
           double x2_0 = (3 * sqrt3By2_ * cellX_[k] / 2);
-          double y2_0 = guardRingOffset_ / 2;
+          double y2_0 = guardRingSizeOffset_ / 2;
 
-          double x1 = (cellX_[k] / 2 - guardRingOffset_) * sqrt3By2_ + x1_0 * 0.5 + y1_0 * sqrt3By2_;
-          double y1 = cellX_[k] + (cellX_[k] / 2 - guardRingOffset_) * 0.5 - x1_0 * sqrt3By2_ + y1_0 * 0.5;
+          double x1 = (cellX_[k] / 2 - guardRingSizeOffset_) * sqrt3By2_ + x1_0 * 0.5 + y1_0 * sqrt3By2_;
+          double y1 = cellX_[k] + (cellX_[k] / 2 - guardRingSizeOffset_) * 0.5 - x1_0 * sqrt3By2_ + y1_0 * 0.5;
 
           double x2 = x2_0 - sqrt3By2_ * cellX_[k];
           double y2 = -(cellX_[k] - y2_0);
 
-          double x3 = sqrt3_ * cellX_[k] - mouseBiteCut_ + (mouseBiteCut_ - (guardRingOffset_ / sqrt3By2_)) / 3;
-          double y3 = -(cellX_[k] - sqrt3_ * (mouseBiteCut_ - (guardRingOffset_ / sqrt3By2_)) / 3 - guardRingOffset_);
+          double x3 = sqrt3_ * cellX_[k] - mouseBiteCut_ + (mouseBiteCut_ - (guardRingSizeOffset_ / sqrt3By2_)) / 3;
+          double y3 =
+              -(cellX_[k] - sqrt3_ * (mouseBiteCut_ - (guardRingSizeOffset_ / sqrt3By2_)) / 3 - guardRingOffset_);
 
           cellAreaPartial[k][j - HGCalCell::partiaclWaferCellsOffset] = totalArea - cutArea1 - cutArea2 - cutArea3;
           double xMag = ((sqrt3_ * cellX_[k] / 8) * totalArea - (cutArea1 * x1) - (cutArea2 * x2) - (cutArea3 * x3)) /
@@ -877,16 +827,16 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
               (2 * mouseBiteCut_ - sqrt3_ * guardRingSizeOffset_) * guardRingSizeOffset_ -
               (1 / sqrt3By2_ * mouseBiteCut_ - 2 * guardRingSizeOffset_ - guardRingOffset_ / sqrt3_) * guardRingOffset_;
 
-          double x1_0 = (9.375 * cellX_[k] * cellX_[k] - (cellX_[k] * 1.25 * guardRingOffset_) +
-                         (std::pow(guardRingOffset_, 2) / 18)) /
-                        ((5 * cellX_[k] * sqrt3By2_) - (guardRingOffset_ / (2 * sqrt3_)));
-          double y1_0 =
-              ((5 * cellX_[k] * sqrt3By2_ * guardRingOffset_ / 2) - (std::pow(guardRingOffset_, 2) / (6 * sqrt3_))) /
-              ((5 * cellX_[k] * sqrt3By2_) - (guardRingOffset_ / (2 * sqrt3_)));
+          double x1_0 = (9.375 * cellX_[k] * cellX_[k] - (cellX_[k] * 1.25 * guardRingSizeOffset_) +
+                         (std::pow(guardRingSizeOffset_, 2) / 18)) /
+                        ((5 * cellX_[k] * sqrt3By2_) - (guardRingSizeOffset_ / (2 * sqrt3_)));
+          double y1_0 = ((5 * cellX_[k] * sqrt3By2_ * guardRingSizeOffset_ / 2) -
+                         (std::pow(guardRingSizeOffset_, 2) / (6 * sqrt3_))) /
+                        ((5 * cellX_[k] * sqrt3By2_) - (guardRingSizeOffset_ / (2 * sqrt3_)));
 
           double x1 = (1.5 * cellX_[k]) * sqrt3By2_ - x1_0 * 0.5 - y1_0 * sqrt3By2_;
           double y1 = -0.25 * cellX_[k] + x1_0 * sqrt3By2_ - y1_0 * 0.5;
-          double x2 = -(sqrt3By2_ * cellX_[k] - 0.5 * guardRingOffset_);
+          double x2 = -(sqrt3By2_ * cellX_[k] - 0.5 * guardRingSizeOffset_);
           double y2 = 1.5 * cellX_[k];
           double x3 = -(sqrt3By2_ * cellX_[k] - mouseBiteCut_ / 3);
           double y3 = 3.5 * cellX_[k] - (5 * mouseBiteCut_) / 3 * sqrt3_;
@@ -930,7 +880,7 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
           double h = 2 * mouseBiteCut_ - sqrt3_ * guardRingSizeOffset_ - guardRingOffset_;
           double cutArea3 = 1 / (2 * sqrt3_) * std::pow(h, 2) / 2;
 
-          double x1 = cellX_[k] * sqrt3By2_ - guardRingOffset_ / 2;
+          double x1 = cellX_[k] * sqrt3By2_ - guardRingSizeOffset_ / 2;
           double y1 = 0;
           double x2 = 0;
           double y2 = 0.5 * cellX_[k] - guardRingOffset_ / 2;
@@ -1263,25 +1213,16 @@ std::pair<double, double> HGCalCellOffset::cellOffsetUV2XY1(
   std::pair<int, int> cell = hgcalcell_->cellType(u, v, ncell_[type], placementIndex, partialType);
   int cellPos = cell.first;
   int cellType = cell.second;
-  if ((cellType >= HGCalCell::partiaclWaferCellsOffset) || (cellPos >= HGCalCell::partiaclCellsPosOffset)) {
-    if (cellType == HGCalCell::truncatedCell || cellType == HGCalCell::extendedCell) {
-      if (cellPos == HGCalCell::topCell) {
-        int Pos(0);
-        Pos = (placementIndex + HGCalCell::topRightEdge - HGCalCell::bottomLeftEdge) % HGCalCell::cellPlacementExtra;
-        x_off = (placementIndex >= HGCalCell::cellPlacementExtra) ? -offsetX[type][cellType][Pos]
-                                                                  : offsetX[type][cellType][Pos];
-        y_off = offsetY[type][cellType][Pos];
-      } else if (cellPos == HGCalCell::bottomCell) {
-        int Pos(0);
-        Pos = (placementIndex) % HGCalCell::cellPlacementExtra;
-        x_off = (placementIndex >= HGCalCell::cellPlacementExtra) ? -offsetX[type][cellType][Pos]
-                                                                  : offsetX[type][cellType][Pos];
-        y_off = offsetY[type][cellType][Pos];
-      }
-    } else if ((cellType == HGCalCell::halfCell) || (cellType == HGCalCell::LDPartial0714Cell) ||
-               (cellType == HGCalCell::LDPartial0815Cell) || (cellType == HGCalCell::HDPartial0920Cell) ||
-               (cellType == HGCalCell::HDPartial1021Cell)) {
-      int cellType1 = cellType - HGCalCell::partiaclWaferCellsOffset;
+  int cellType1 = cellType - HGCalCell::partiaclWaferCellsOffset;
+  if (cellType == HGCalCell::extTrunCellCenCut || cellType == HGCalCell::extExtCellCenCut) {
+    if (((placementIndex >= HGCalCell::cellPlacementExtra) && (placementIndex % 2 == 0)) ||
+        ((placementIndex < HGCalCell::cellPlacementExtra) && (placementIndex % 2 == 1))) {
+      cellPos = HGCalCell::bottomCorner + (6 + HGCalCell::bottomCorner - cellPos) % 6;
+    }
+    x_off = offsetX[type][cellType1][cellPos - HGCalCell::bottomCorner];
+    y_off = offsetY[type][cellType1][cellPos - HGCalCell::bottomCorner];
+  }
+  else if (cellType == HGCalCell::extHalfTrunCell || cellType == HGCalCell::extHalfExtCell || cellType == HGCalCell::halfCell || cellType == HGCalCell::intHalfExtCell || cellType == HGCalCell::intHalfTrunCell || cellType == HGCalCell::extTrunCellEdgeCut || cellType == HGCalCell::extExtCellEdgeCut || cellType == HGCalCell::fullCellEdgeCut || cellType == HGCalCell::intTrunCellEdgeCut || cellType == HGCalCell::LDPartial0714Cell || cellType == HGCalCell::LDPartial0815Cell || cellType == HGCalCell::HDPartial0920Cell || cellType == HGCalCell::HDPartial1021Cell) {
       if (cellPos == HGCalCell::leftCell) {
         int placeIndex = placementIndex % HGCalCell::cellPlacementExtra;
         x_off = offsetPartialX[type][cellType1][placeIndex];
@@ -1292,14 +1233,11 @@ std::pair<double, double> HGCalCellOffset::cellOffsetUV2XY1(
         y_off = offsetPartialY[type][cellType1][placeIndex];
       }
       x_off = placementIndex < HGCalCell::cellPlacementExtra ? x_off : -x_off;
-    } else if ((cellType == HGCalCell::LDPartial0209Cell) || (cellType == HGCalCell::LDPartial0007Cell) ||
-               (cellType == HGCalCell::LDPartial1415Cell) || (cellType == HGCalCell::LDPartial1515Cell)) {
-      int cellType1 = cellType - HGCalCell::partiaclWaferCellsOffset;
+  } else if ((cellType == HGCalCell::LDPartial0209Cell) || (cellType == HGCalCell::LDPartial0007Cell) || (cellType == HGCalCell::LDPartial1415Cell) || (cellType == HGCalCell::LDPartial1515Cell)) {
       int placeIndex = placementIndex % HGCalCell::cellPlacementExtra;
       x_off = offsetPartialX[type][cellType1][placeIndex];
       y_off = offsetPartialY[type][cellType1][placeIndex];
       x_off = placementIndex < HGCalCell::cellPlacementExtra ? x_off : -x_off;
-    }
   }
   return std::make_pair(x_off, y_off);
 }

--- a/Geometry/HGCalCommonData/src/HGCalCellOffset.cc
+++ b/Geometry/HGCalCommonData/src/HGCalCellOffset.cc
@@ -66,8 +66,8 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
               ((19.0 * cellX_[k] / 132.0) * totalArea - (cutArea1 * y1) - (cutArea2 * y2) - (cutArea3 * y3)) /
               (cellArea[k][j]);
 
-          double xMag = 1.42; //0.5 * xMag1 + sqrt3By2_ * yMag1;
-          double yMag = 2.46; //sqrt3By2_ * xMag1 - 0.5 * yMag1;
+          double xMag = 1.42;  //0.5 * xMag1 + sqrt3By2_ * yMag1;
+          double yMag = 2.46;  //sqrt3By2_ * xMag1 - 0.5 * yMag1;
           //std::cout << "HD Corner "<< xMag << "  " << yMag << std::endl;
 
           std::array<double, 6> tempOffsetX = {{(sqrt3By2_ * xMag - 0.5 * yMag),
@@ -124,8 +124,8 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
           double yMag1 = ((-5 * cellX_[k] / 42) * totalArea - (cutArea1 * y1) - (cutArea2 * y2) - (cutArea3 * y3)) /
                          (cellArea[k][j]);
 
-          double xMag = 1.48; //-0.5 * xMag1 - sqrt3By2_ * yMag1;
-          double yMag = 2.18; //sqrt3By2_ * xMag1 - 0.5 * yMag1; '-2.38', 'deltaY': '1.15'
+          double xMag = 1.48;  //-0.5 * xMag1 - sqrt3By2_ * yMag1;
+          double yMag = 2.18;  //sqrt3By2_ * xMag1 - 0.5 * yMag1; '-2.38', 'deltaY': '1.15'
           //std::cout << "LD Corner "<< xMag << "  " << yMag << std::endl;
 
           std::array<double, 6> tempOffsetX = {{(sqrt3By2_ * xMag - 0.5 * yMag),
@@ -156,7 +156,7 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
         // (x, y) coordinates of offset for 6 sides of wafer starting from bottom left edge in clockwise direction
         // offset_x = -Offset_magnitude * sin(30 + 60*i) i in (0-6)
         // offset_y = -Offset_magnitude * cos(30 + 60*i) i in (0-6)
-	//offMag = (k == 0) ? 1.9044 : 1.61; 
+        //offMag = (k == 0) ? 1.9044 : 1.61;
         std::array<double, 6> tempOffsetX = {
             {-0.5 * offMag, -offMag, -0.5 * offMag, 0.5 * offMag, offMag, 0.5 * offMag}};
         std::array<double, 6> tempOffsetY = {
@@ -187,7 +187,7 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
       } else if (j == HGCalCell::truncatedMBCell) {
         double H = mouseBiteCut_ - (1 / sqrt3By2_ * guardRingSizeOffset_);
         double h = H - (sqrt3_ / 2 * cellX_[k]) + (guardRingSizeOffset_ / (2 * sqrt3_));
-	//std::cout << "Truncated MB " << k << "  " << h << " H " << H << " s " << cellX_[k] << " G " << guardRingSizeOffset_ << std::endl;
+        //std::cout << "Truncated MB " << k << "  " << h << " H " << H << " s " << cellX_[k] << " G " << guardRingSizeOffset_ << std::endl;
         if (h > 0) {
           double totalArea = 5.0 * sqrt3_ * std::pow(cellX_[k], 2) / 4.0;
 
@@ -205,10 +205,10 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
           double xMag = -yMag1;
           double yMag = -xMag1;
           //std::cout << "HD trun Corner " << xMag << "  " << yMag << std::endl;
-          if (k == 0){
+          if (k == 0) {
             xMag = -0.05;
-	    yMag = -1.33;
-	  }
+            yMag = -1.33;
+          }
           std::array<double, 6> tempOffsetX = {{(sqrt3By2_ * xMag - 0.5 * yMag),
                                                 (-sqrt3By2_ * xMag - 0.5 * yMag),
                                                 (-sqrt3By2_ * xMag - 0.5 * yMag),
@@ -264,14 +264,13 @@ HGCalCellOffset::HGCalCellOffset(double waferSize,
         double xMag = yMag1;
         double yMag = -xMag1;
         //std::cout << "HD ext Corner " << xMag << "  " << yMag << std::endl;
-        if (k == 0){
-            xMag = 0.40;
-            yMag = 0.54;
-          }
-        else if (k == 1){
-	    xMag = 0.12;
-            yMag = -0.04;
-          }
+        if (k == 0) {
+          xMag = 0.40;
+          yMag = 0.54;
+        } else if (k == 1) {
+          xMag = 0.12;
+          yMag = -0.04;
+        }
         std::array<double, 6> tempOffsetX = {{(sqrt3By2_ * xMag - 0.5 * yMag),
                                               yMag,
                                               yMag,
@@ -1226,23 +1225,29 @@ std::pair<double, double> HGCalCellOffset::cellOffsetUV2XY1(
     }
     x_off = offsetX[type][cellType1][cellPos - HGCalCell::bottomCorner];
     y_off = offsetY[type][cellType1][cellPos - HGCalCell::bottomCorner];
-  }
-  else if (cellType == HGCalCell::extHalfTrunCell || cellType == HGCalCell::extHalfExtCell || cellType == HGCalCell::halfCell || cellType == HGCalCell::intHalfExtCell || cellType == HGCalCell::intHalfTrunCell || cellType == HGCalCell::extTrunCellEdgeCut || cellType == HGCalCell::extExtCellEdgeCut || cellType == HGCalCell::fullCellEdgeCut || cellType == HGCalCell::intTrunCellEdgeCut || cellType == HGCalCell::LDPartial0714Cell || cellType == HGCalCell::LDPartial0815Cell || cellType == HGCalCell::HDPartial0920Cell || cellType == HGCalCell::HDPartial1021Cell) {
-      if (cellPos == HGCalCell::leftCell) {
-        int placeIndex = placementIndex % HGCalCell::cellPlacementExtra;
-        x_off = offsetPartialX[type][cellType1][placeIndex];
-        y_off = offsetPartialY[type][cellType1][placeIndex];
-      } else if (cellPos == HGCalCell::rightCell) {
-        int placeIndex = (HGCalCell::cellPlacementExtra - placementIndex) % HGCalCell::cellPlacementExtra;
-        x_off = -offsetPartialX[type][cellType1][placeIndex];
-        y_off = offsetPartialY[type][cellType1][placeIndex];
-      }
-      x_off = placementIndex < HGCalCell::cellPlacementExtra ? x_off : -x_off;
-  } else if ((cellType == HGCalCell::LDPartial0209Cell) || (cellType == HGCalCell::LDPartial0007Cell) || (cellType == HGCalCell::LDPartial1415Cell) || (cellType == HGCalCell::LDPartial1515Cell)) {
+  } else if (cellType == HGCalCell::extHalfTrunCell || cellType == HGCalCell::extHalfExtCell ||
+             cellType == HGCalCell::halfCell || cellType == HGCalCell::intHalfExtCell ||
+             cellType == HGCalCell::intHalfTrunCell || cellType == HGCalCell::extTrunCellEdgeCut ||
+             cellType == HGCalCell::extExtCellEdgeCut || cellType == HGCalCell::fullCellEdgeCut ||
+             cellType == HGCalCell::intTrunCellEdgeCut || cellType == HGCalCell::LDPartial0714Cell ||
+             cellType == HGCalCell::LDPartial0815Cell || cellType == HGCalCell::HDPartial0920Cell ||
+             cellType == HGCalCell::HDPartial1021Cell) {
+    if (cellPos == HGCalCell::leftCell) {
       int placeIndex = placementIndex % HGCalCell::cellPlacementExtra;
       x_off = offsetPartialX[type][cellType1][placeIndex];
       y_off = offsetPartialY[type][cellType1][placeIndex];
-      x_off = placementIndex < HGCalCell::cellPlacementExtra ? x_off : -x_off;
+    } else if (cellPos == HGCalCell::rightCell) {
+      int placeIndex = (HGCalCell::cellPlacementExtra - placementIndex) % HGCalCell::cellPlacementExtra;
+      x_off = -offsetPartialX[type][cellType1][placeIndex];
+      y_off = offsetPartialY[type][cellType1][placeIndex];
+    }
+    x_off = placementIndex < HGCalCell::cellPlacementExtra ? x_off : -x_off;
+  } else if ((cellType == HGCalCell::LDPartial0209Cell) || (cellType == HGCalCell::LDPartial0007Cell) ||
+             (cellType == HGCalCell::LDPartial1415Cell) || (cellType == HGCalCell::LDPartial1515Cell)) {
+    int placeIndex = placementIndex % HGCalCell::cellPlacementExtra;
+    x_off = offsetPartialX[type][cellType1][placeIndex];
+    y_off = offsetPartialY[type][cellType1][placeIndex];
+    x_off = placementIndex < HGCalCell::cellPlacementExtra ? x_off : -x_off;
   }
   return std::make_pair(x_off, y_off);
 }

--- a/Geometry/HGCalCommonData/test/HGCalCellOffsetTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalCellOffsetTester.cc
@@ -78,7 +78,7 @@ HGCalCellOffsetTester::HGCalCellOffsetTester(const edm::ParameterSet& iC)
                                 << " Placement Index " << placeIndex_ << " GuardRing offset " << guardRingOffset_
                                 << " Mousebite cut " << mouseBiteCut_ << " SizeOffset " << sizeOffset_;
 
-  outputFile.open("nand.csv");
+  outputFile.open("nand2.csv");
   if (!outputFile.is_open()) {
     edm::LogError("HGCalGeom") << "Could not open output file.";
   } else {
@@ -92,9 +92,9 @@ void HGCalCellOffsetTester::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<int>("waferType", 0);
   desc.add<int>("cellPlacementIndex", 11);
   desc.add<int>("cellType", 0);
-  desc.add<double>("mouseBiteCut", 5.0);
-  desc.add<double>("guardRingOffset", 0.9);
-  desc.add<double>("sizeOffset", 0.435);
+  desc.add<double>("mouseBiteCut", 5.834);
+  desc.add<double>("guardRingOffset", 0.8985);
+  desc.add<double>("sizeOffset", 0.87);
   descriptions.add("hgcalCellOffsetTester", desc);
 }
 
@@ -112,6 +112,7 @@ void HGCalCellOffsetTester::analyze(const edm::Event&, const edm::EventSetup&) {
       if ((ui < 2 * nCells) && (vi < 2 * nCells) && ((vi - ui) < nCells) && ((ui - vi) <= nCells)) {
         //Only allowing (U, V) inside a wafer
         if (HGCalWaferMask::goodCell(ui, vi, partial_)) {
+	  auto cellType = HGCalCell::cellType(ui, vi, nCells, placeIndex_, partial_);
           std::pair<double, double> xy1 = wafer2.cellUV2XY2(ui, vi, placeIndex_, waferType_);
           // std::pair<double, double> xyOffset = offset.cellOffsetUV2XY1(ui, vi, placeIndex_, waferType_);
           std::pair<int32_t, int32_t> uv1 =
@@ -132,11 +133,11 @@ void HGCalCellOffsetTester::analyze(const edm::Event&, const edm::EventSetup&) {
           std::string comment = ((uv1.first != ui) || (uv1.second != vi))
                                     ? " ***** ERROR (u, v) from the methods dosent match *****"
                                     : "";
-          edm::LogVerbatim("HGCalGeom") << "u = " << ui << " v = " << vi << " type = " << waferType_
+          edm::LogVerbatim("HGCalGeom") << "u = " << ui << " v = " << vi << " type = " << waferType_  
                                         << " placement index " << placeIndex_ << " u " << uv1.first << " v "
                                         << uv1.second << " x " << xy1.first << " ,y " << xy1.second << " xoff "
                                         << xyOffsetLD.first << " ,yoff " << xyOffsetLD.second << " , area " << area
-                                        << comment;
+                                        << "CellType:CellPos" << cellType.first << ":" << cellType.second <<comment;
         }
       }
     }

--- a/Geometry/HGCalCommonData/test/HGCalCellOffsetTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalCellOffsetTester.cc
@@ -112,7 +112,7 @@ void HGCalCellOffsetTester::analyze(const edm::Event&, const edm::EventSetup&) {
       if ((ui < 2 * nCells) && (vi < 2 * nCells) && ((vi - ui) < nCells) && ((ui - vi) <= nCells)) {
         //Only allowing (U, V) inside a wafer
         if (HGCalWaferMask::goodCell(ui, vi, partial_)) {
-	  auto cellType = HGCalCell::cellType(ui, vi, nCells, placeIndex_, partial_);
+          auto cellType = HGCalCell::cellType(ui, vi, nCells, placeIndex_, partial_);
           std::pair<double, double> xy1 = wafer2.cellUV2XY2(ui, vi, placeIndex_, waferType_);
           // std::pair<double, double> xyOffset = offset.cellOffsetUV2XY1(ui, vi, placeIndex_, waferType_);
           std::pair<int32_t, int32_t> uv1 =
@@ -133,11 +133,11 @@ void HGCalCellOffsetTester::analyze(const edm::Event&, const edm::EventSetup&) {
           std::string comment = ((uv1.first != ui) || (uv1.second != vi))
                                     ? " ***** ERROR (u, v) from the methods dosent match *****"
                                     : "";
-          edm::LogVerbatim("HGCalGeom") << "u = " << ui << " v = " << vi << " type = " << waferType_  
+          edm::LogVerbatim("HGCalGeom") << "u = " << ui << " v = " << vi << " type = " << waferType_
                                         << " placement index " << placeIndex_ << " u " << uv1.first << " v "
                                         << uv1.second << " x " << xy1.first << " ,y " << xy1.second << " xoff "
                                         << xyOffsetLD.first << " ,yoff " << xyOffsetLD.second << " , area " << area
-                                        << "CellType:CellPos" << cellType.first << ":" << cellType.second <<comment;
+                                        << "CellType:CellPos" << cellType.first << ":" << cellType.second << comment;
         }
       }
     }

--- a/Geometry/HGCalCommonData/test/HGCalCellUVTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalCellUVTester.cc
@@ -37,46 +37,87 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "DataFormats/DetId/interface/DetId.h"
+
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
+#include "Geometry/HGCalCommonData/interface/HGCalDDDConstants.h"
 #include "Geometry/HGCalCommonData/interface/HGCalCellUV.h"
 #include "Geometry/HGCalCommonData/interface/HGCalCell.h"
+#include "Geometry/HGCalCommonData/interface/HGCalCellOffset.h"
+#include "Geometry/HGCalCommonData/interface/HGCalWaferMask.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/HGCalCommonData/interface/HGCalParameters.h"
+#include "Geometry/HGCalCommonData/interface/HGCalTileIndex.h"
+#include "Geometry/HGCalCommonData/interface/HGCalWaferIndex.h"
+#include "Geometry/HGCalCommonData/interface/HGCalWaferType.h"
 
-class HGCalCellUVTester : public edm::one::EDAnalyzer<> {
+class HGCalCellUVTester : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
-  explicit HGCalCellUVTester(const edm::ParameterSet&);
+  explicit HGCalCellUVTester(const edm::ParameterSet &);
   ~HGCalCellUVTester() override = default;
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
   void beginJob() override {}
-  void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
+  void beginRun(edm::Run const &, edm::EventSetup const &) override;
+  void analyze(edm::Event const &iEvent, edm::EventSetup const &) override {}
+  void endRun(edm::Run const &, edm::EventSetup const &) override {}
   void endJob() override {}
+  //void analyze(edm::Run const &iRun, edm::EventSetup const &iSetup) override;
 
 private:
+  const std::vector<std::string> nameDetectors_;
+  const std::string fileName_;
+  const edm::ESGetToken<HGCalDDDConstants, IdealGeometryRecord> tok_hgcal_;
+
+  //const HGCalDDDConstants * hgcCons_;
   const double waferSize_;
   const int waferType_;
   const int placeIndex_;
+  const int partial_;
+  std::ofstream outputFile;
+  std::ofstream outputFile2;
 };
 
-HGCalCellUVTester::HGCalCellUVTester(const edm::ParameterSet& iC)
-    : waferSize_(iC.getParameter<double>("waferSize")),
+HGCalCellUVTester::HGCalCellUVTester(const edm::ParameterSet &iC)
+    : nameDetectors_(iC.getParameter<std::vector<std::string>>("nameDetectors")),
+      tok_hgcal_(esConsumes<HGCalDDDConstants, IdealGeometryRecord, edm::Transition::BeginRun>(
+          edm::ESInputTag{"", "HGCalEESensitive"})),
+      waferSize_(iC.getParameter<double>("waferSize")),
       waferType_(iC.getParameter<int>("waferType")),
-      placeIndex_(iC.getParameter<int>("cellPlacementIndex")) {
+      placeIndex_(iC.getParameter<int>("cellPlacementIndex")),
+      partial_(iC.getParameter<int>("cellPartial")) {
   edm::LogVerbatim("HGCalGeom") << "Test positions for wafer of size " << waferSize_ << " Type " << waferType_
                                 << " Placement Index " << placeIndex_;
+  outputFile.open("nand.csv");
+  if (!outputFile.is_open()) {
+    edm::LogError("HGCalGeom") << "Could not open output file.";
+  } else {
+    outputFile << "lay, wu, wv, wx, wy, x, y, cox, coy, cu, cv, cx, cy, cix, ciy, area, ctype, cpos, place\n";
+  }
+  outputFile2.open("DetIDs.csv");
 }
 
-void HGCalCellUVTester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void HGCalCellUVTester::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<double>("waferSize", 166.4408);
+  desc.add<std::vector<std::string>>("nameDetectors", {"HGCalEESensitive"});
+  desc.add<double>("waferSize", 167.4408);
   desc.add<int>("waferType", 1);
   desc.add<int>("cellPlacementIndex", 6);
+  desc.add<int>("cellPartial", 0);
   descriptions.add("hgcalCellUVTester", desc);
 }
 
 // ------------ method called to produce the data  ------------
-void HGCalCellUVTester::analyze(const edm::Event&, const edm::EventSetup&) {
+void HGCalCellUVTester::beginRun(edm::Run const &iRun, edm::EventSetup const &iSetup) {
+  const edm::ESHandle<HGCalDDDConstants> &hgcCons_ = iSetup.getHandle(tok_hgcal_);
+  const HGCalDDDConstants *cons = hgcCons_.product();
+  auto hgpar_ = cons->getParameter();
   const int nFine(12), nCoarse(8);
   HGCalCellUV wafer(waferSize_, 0.0, nFine, nCoarse);
   HGCalCell wafer2(waferSize_, nFine, nCoarse);
+
+  HGCalCellOffset offset(waferSize_, nFine, nCoarse, 0.8985, 5.834, 0.87);
   double r2 = 0.5 * waferSize_;
   double R2 = 2 * r2 / sqrt(3);
   int nCells = (waferType_ == 0) ? nFine : nCoarse;
@@ -85,25 +126,80 @@ void HGCalCellUVTester::analyze(const edm::Event&, const edm::EventSetup&) {
   edm::LogVerbatim("HGCalGeom") << "\nHGCalCellUVTester:: nCells " << nCells << " and placement index between "
                                 << indexMin << " and " << indexMax << "\n\n";
   auto start_t = std::chrono::high_resolution_clock::now();
-
-  for (int i = 0; i < 100000; i++) {
-    double xi = (2 * r2 * (float)rand() / RAND_MAX) - r2;
-    double yi = (2 * R2 * (float)rand() / RAND_MAX) - R2;
-    double c1 = yi + xi / sqrt(3);
-    double c2 = yi - (xi / sqrt(3));
-    if ((xi < r2) && (xi > -1 * r2) && (c1 < R2) && (c1 > -1 * R2) && (c2 < R2) &&
-        (c2 > -1 * R2)) {  //Only allowing (x, y) inside a wafer
-      std::pair<int32_t, int32_t> uv1 = wafer.cellUVFromXY1(xi, yi, placeIndex_, waferType_, true, false);
-      std::pair<int32_t, int32_t> uv2 = wafer.cellUVFromXY2(xi, yi, placeIndex_, waferType_, true, false);
-      std::pair<int32_t, int32_t> uv3 = wafer.cellUVFromXY3(xi, yi, placeIndex_, waferType_, true, false);
-      //std::pair<int32_t, int32_t> uv2 = wafer.HGCalCellUVFromXY2(xi, yi, placeIndex_, waferType_, true, false);
-      std::string comment = ((uv1.first != uv3.first) || (uv2.first != uv3.first) || (uv1.second != uv3.second) ||
-                             (uv2.second != uv3.second))
-                                ? " ***** ERROR *****"
-                                : "";
-      edm::LogVerbatim("HGCalGeom") << "x = " << xi << " y = " << yi << " type = " << waferType_ << " placement index "
-                                    << placeIndex_ << " u " << uv1.first << ":" << uv2.first << ":" << uv3.first
-                                    << " v " << uv1.second << ":" << uv2.second << ":" << uv3.second << ":" << comment;
+  unsigned int kk(0);
+  std::unordered_map<int32_t, HGCalParameters::waferInfo>::const_iterator itr = hgpar_->waferInfoMap_.begin();
+  for (; itr != hgpar_->waferInfoMap_.end(); ++itr, ++kk) {
+    //for (auto itr = hgpar_->waferInfoMap_.begin(); itr != hgpar_->waferInfoMap_.end(); ++itr){
+    if ((itr->second).part != HGCalTypes::WaferFull) {
+      int indx = itr->first;
+      //if ((HGCalWaferIndex::waferU(indx) == 7) && (HGCalWaferIndex::waferV(indx) == 5)){
+      int partial_ = HGCalWaferType::getPartial(indx, hgpar_->waferInfoMap_);
+      int orient = HGCalWaferType::getOrient(indx, hgpar_->waferInfoMap_);
+      int layer = HGCalWaferIndex::waferLayer(indx);
+      if (layer >= 1) {
+        int waferU = HGCalWaferIndex::waferU(indx);
+        int waferV = HGCalWaferIndex::waferV(indx);
+        int waferType_ = (itr->second).type;
+	nCells = (waferType_ == 0) ? nFine : nCoarse;
+	int FrontBack = (1+layer)%2;
+        int placeIndex_ = HGCalCell::cellPlacementIndex(-1, FrontBack, orient);
+        auto waferxy = cons->waferPositionWithCshift(layer, waferU, waferV, true, true, false);
+	for (int uu = 0; uu < 2*nCells; uu++){
+	  for (int vv = 0; vv < 2*nCells; vv++){
+	    if (((vv - uu) < nCells) && ((uu - vv) <= nCells)) {
+	      if (HGCalWaferMask::goodCell(uu, vv, partial_)){
+	        uint32_t DetID = static_cast<DetId>(HGCSiliconDetId(DetId::HGCalEE, 1, waferType_, layer, waferU, waferV, uu, vv));
+	        HGCalDetId iD(DetID);
+	        //if (iD.isValid());
+	        //  std::cout << "true" << std::endl;
+		//} else {
+		//  std::cout << "false" << std::endl;
+		//  }
+		//}
+	        outputFile2 << DetID << std::endl;
+	      }
+	    }
+	  }
+	}
+        for (int i = 0; i < 1000; i++) {
+          double xi = (2 * r2 * (float)rand() / RAND_MAX) - r2;
+          double yi = (2 * R2 * (float)rand() / RAND_MAX) - R2;
+          double c1 = yi + xi / sqrt(3);
+          double c2 = yi - (xi / sqrt(3));
+          if ((xi < r2) && (xi > -1 * r2) && (c1 < R2) && (c1 > -1 * R2) && (c2 < R2) &&
+              (c2 > -1 * R2)) {  //Only allowing (x, y) inside a wafer
+            std::pair<int32_t, int32_t> uv1 = wafer.cellUVFromXY1(xi, yi, placeIndex_, waferType_, true, false);
+            std::pair<int32_t, int32_t> uv2 = wafer.cellUVFromXY2(xi, yi, placeIndex_, waferType_, true, false);
+            std::pair<int32_t, int32_t> uv3 = wafer.cellUVFromXY3(xi, yi, placeIndex_, waferType_, true, false);
+            int ui = uv1.first;
+            int vi = uv1.second;
+            if (HGCalWaferMask::goodCell(ui, vi, partial_)) {
+              auto area = offset.cellAreaUV(ui, vi, placeIndex_, waferType_, partial_, true);
+              std::pair<double, double> xy1 = wafer2.cellUV2XY2(ui, vi, placeIndex_, waferType_);
+              std::pair<double, double> xyOffsetLD = offset.cellOffsetUV2XY1(ui, vi, placeIndex_, waferType_, partial_);
+              auto cellType = HGCalCell::cellType(ui, vi, nCells, placeIndex_, partial_);
+              //std::pair<int32_t, int32_t> uv2 = wafer.HGCalCellUVFromXY2(xi, yi, placeIndex_, waferType_, true, false);
+              outputFile << layer << "," << waferU << "," << waferV << "," << waferxy.first << "," << waferxy.second
+                         << "," << xi << "," << yi << "," << -10*waferxy.first - xyOffsetLD.first - xy1.first << ","
+                         << 10*waferxy.second + xyOffsetLD.second + xy1.second << "," << uv1.first << "," << uv1.second << "," << xy1.first
+                         << "," << xy1.second << "," << xyOffsetLD.first << "," << xyOffsetLD.second << "," << area << "," << cellType.second << "," << cellType.first << "," << placeIndex_
+                         << std::endl;
+              std::string comment = ((uv1.first != uv3.first) || (uv2.first != uv3.first) ||
+                                     (uv1.second != uv3.second) || (uv2.second != uv3.second))
+                                        ? " ***** ERROR *****"
+                                        : "";
+              edm::LogVerbatim("HGCalGeom")
+                  //<< "x = " << xi << " y = " << yi << " type = " << waferType_ << " placement index " << placeIndex_
+                  //<< " u " << uv1.first << ":" << uv2.first << ":" << uv3.first << " v " << uv1.second << ":"
+                  //<< uv2.second << ":" << uv3.second << ":" 
+		  << layer << "," << waferU << ":" << waferV << "," << waferxy.first << ":" << waferxy.second
+                  << "," << xi << ":" << yi << "," << -10*waferxy.first + xyOffsetLD.first + xy1.first << ":"
+                  << 10*waferxy.second + xyOffsetLD.second + xy1.second << "," << uv1.first << ":" << uv1.second << "," << xy1.first
+                  << ":" << xy1.second << comment;
+            }
+          }
+        }
+      }
     }
   }
   auto end_t = std::chrono::high_resolution_clock::now();

--- a/Geometry/HGCalCommonData/test/HGCalCellUVTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalCellUVTester.cc
@@ -140,27 +140,28 @@ void HGCalCellUVTester::beginRun(edm::Run const &iRun, edm::EventSetup const &iS
         int waferU = HGCalWaferIndex::waferU(indx);
         int waferV = HGCalWaferIndex::waferV(indx);
         int waferType_ = (itr->second).type;
-	nCells = (waferType_ == 0) ? nFine : nCoarse;
-	int FrontBack = (1+layer)%2;
+        nCells = (waferType_ == 0) ? nFine : nCoarse;
+        int FrontBack = (1 + layer) % 2;
         int placeIndex_ = HGCalCell::cellPlacementIndex(-1, FrontBack, orient);
         auto waferxy = cons->waferPositionWithCshift(layer, waferU, waferV, true, true, false);
-	for (int uu = 0; uu < 2*nCells; uu++){
-	  for (int vv = 0; vv < 2*nCells; vv++){
-	    if (((vv - uu) < nCells) && ((uu - vv) <= nCells)) {
-	      if (HGCalWaferMask::goodCell(uu, vv, partial_)){
-	        uint32_t DetID = static_cast<DetId>(HGCSiliconDetId(DetId::HGCalEE, 1, waferType_, layer, waferU, waferV, uu, vv));
-	        HGCalDetId iD(DetID);
-	        //if (iD.isValid());
-	        //  std::cout << "true" << std::endl;
-		//} else {
-		//  std::cout << "false" << std::endl;
-		//  }
-		//}
-	        outputFile2 << DetID << std::endl;
-	      }
-	    }
-	  }
-	}
+        for (int uu = 0; uu < 2 * nCells; uu++) {
+          for (int vv = 0; vv < 2 * nCells; vv++) {
+            if (((vv - uu) < nCells) && ((uu - vv) <= nCells)) {
+              if (HGCalWaferMask::goodCell(uu, vv, partial_)) {
+                uint32_t DetID =
+                    static_cast<DetId>(HGCSiliconDetId(DetId::HGCalEE, 1, waferType_, layer, waferU, waferV, uu, vv));
+                HGCalDetId iD(DetID);
+                //if (iD.isValid());
+                //  std::cout << "true" << std::endl;
+                //} else {
+                //  std::cout << "false" << std::endl;
+                //  }
+                //}
+                outputFile2 << DetID << std::endl;
+              }
+            }
+          }
+        }
         for (int i = 0; i < 1000; i++) {
           double xi = (2 * r2 * (float)rand() / RAND_MAX) - r2;
           double yi = (2 * R2 * (float)rand() / RAND_MAX) - R2;
@@ -180,10 +181,11 @@ void HGCalCellUVTester::beginRun(edm::Run const &iRun, edm::EventSetup const &iS
               auto cellType = HGCalCell::cellType(ui, vi, nCells, placeIndex_, partial_);
               //std::pair<int32_t, int32_t> uv2 = wafer.HGCalCellUVFromXY2(xi, yi, placeIndex_, waferType_, true, false);
               outputFile << layer << "," << waferU << "," << waferV << "," << waferxy.first << "," << waferxy.second
-                         << "," << xi << "," << yi << "," << -10*waferxy.first - xyOffsetLD.first - xy1.first << ","
-                         << 10*waferxy.second + xyOffsetLD.second + xy1.second << "," << uv1.first << "," << uv1.second << "," << xy1.first
-                         << "," << xy1.second << "," << xyOffsetLD.first << "," << xyOffsetLD.second << "," << area << "," << cellType.second << "," << cellType.first << "," << placeIndex_
-                         << std::endl;
+                         << "," << xi << "," << yi << "," << -10 * waferxy.first - xyOffsetLD.first - xy1.first << ","
+                         << 10 * waferxy.second + xyOffsetLD.second + xy1.second << "," << uv1.first << ","
+                         << uv1.second << "," << xy1.first << "," << xy1.second << "," << xyOffsetLD.first << ","
+                         << xyOffsetLD.second << "," << area << "," << cellType.second << "," << cellType.first << ","
+                         << placeIndex_ << std::endl;
               std::string comment = ((uv1.first != uv3.first) || (uv2.first != uv3.first) ||
                                      (uv1.second != uv3.second) || (uv2.second != uv3.second))
                                         ? " ***** ERROR *****"
@@ -191,11 +193,11 @@ void HGCalCellUVTester::beginRun(edm::Run const &iRun, edm::EventSetup const &iS
               edm::LogVerbatim("HGCalGeom")
                   //<< "x = " << xi << " y = " << yi << " type = " << waferType_ << " placement index " << placeIndex_
                   //<< " u " << uv1.first << ":" << uv2.first << ":" << uv3.first << " v " << uv1.second << ":"
-                  //<< uv2.second << ":" << uv3.second << ":" 
-		  << layer << "," << waferU << ":" << waferV << "," << waferxy.first << ":" << waferxy.second
-                  << "," << xi << ":" << yi << "," << -10*waferxy.first + xyOffsetLD.first + xy1.first << ":"
-                  << 10*waferxy.second + xyOffsetLD.second + xy1.second << "," << uv1.first << ":" << uv1.second << "," << xy1.first
-                  << ":" << xy1.second << comment;
+                  //<< uv2.second << ":" << uv3.second << ":"
+                  << layer << "," << waferU << ":" << waferV << "," << waferxy.first << ":" << waferxy.second << ","
+                  << xi << ":" << yi << "," << -10 * waferxy.first + xyOffsetLD.first + xy1.first << ":"
+                  << 10 * waferxy.second + xyOffsetLD.second + xy1.second << "," << uv1.first << ":" << uv1.second
+                  << "," << xy1.first << ":" << xy1.second << comment;
             }
           }
         }

--- a/Geometry/HGCalCommonData/test/python/testHGCalCellUVTester_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/testHGCalCellUVTester_cfg.py
@@ -1,11 +1,47 @@
+###############################################################################
+# Way to use this:
+#   cmsRun testHGCalDDDCons_cfi.py geometry=D120
+#
+#   Options for Geometry D120
+#
+###############################################################################
 import FWCore.ParameterSet.Config as cms
+import os, sys, importlib, re
+import FWCore.ParameterSet.VarParsing as VarParsing
 
-process = cms.Process("PROD")
+####################################################################
+### SETUP OPTIONS
+options = VarParsing.VarParsing('standard')
+options.register('geometry',
+                 "D120",
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "type of operations: D120, D122, etc")
+
+### get and parse the command line arguments
+options.parseArguments()
+print(options)
+
+geomName = "Run4" + options.geometry
+geomFile = "Configuration.Geometry.GeometryExtended" + geomName + "Reco_cff"
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+GLOBAL_TAG, ERA = _settings.get_era_and_conditions(geomName)
+
+
+from Configuration.Eras.Era_Phase2C26I13M9_cff import Phase2C26I13M9
+process = cms.Process("TestHGCal",ERA)
+
+process.load(geomFile)
+process.load("Geometry.HGCalCommonData.hgcalParametersInitialization_cfi")
+process.load("Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi")
+process.load("Geometry.EcalCommonData.ecalSimulationParameters_cff")
+process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cff")
 process.load("SimGeneral.HepPDTESSource.pdt_cfi")
 process.load('FWCore.MessageService.MessageLogger_cfi')
 
 if hasattr(process,'MessageLogger'):
     process.MessageLogger.HGCalGeom=dict()
+    process.MessageLogger.HGCGeom=dict()
 
 process.load("IOMC.RandomEngine.IOMC_cff")
 process.RandomNumberGeneratorService.generator.initialSeed = 456789
@@ -27,6 +63,7 @@ process.generator = cms.EDProducer("FlatRandomEGunProducer",
                                    firstRun        = cms.untracked.uint32(1)
                                )
 
+
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )
@@ -35,6 +72,7 @@ process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",
                                         ignoreTotal = cms.untracked.int32(1),
                                         moduleMemorySummary = cms.untracked.bool(True)
 )
+
 
 process.load("Geometry.HGCalCommonData.hgcalCellUVTester_cfi")
 


### PR DESCRIPTION
 PR description:

Fix the centroid offsets for all the cells in full wafres for v19 version of HGCAL genmetry.

PR validation:

Use the runTheMatrix test workflows. The offsete are compared and tested using center of cravity derived indipendently

If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special
