### PR TITLE
Additional info when tests fail in DQMOffline/Configuration

### DIFF
--- a/DQMOffline/Configuration/scripts/cmsswSequenceInfo.py
+++ b/DQMOffline/Configuration/scripts/cmsswSequenceInfo.py
@@ -70,6 +70,8 @@ def inspectsequence(seq):
     # for HARVESTING, the code in endJob makes most jobs crash. But that is fine,
     # we have the data we need by then.
     if proc.returncode and seq.step not in ("HARVESTING", "ALCAHARVEST"):
+        nl = '\n'
+        print(f"cmsRun failed with output \n {nl.join(tracedump.decode('utf-8').splitlines())}");
         raise Exception("cmsRun failed for cmsDriver command %s" % driverargs)
 
     lines = tracedump.splitlines()


### PR DESCRIPTION
#### PR description:

- If cmsRun fails during the test, now reports what the cmsRun logged.
- This additional information was useful when trying to diagnose the recent failures in the IB of some of the unit tests.

#### PR validation:

When used during the recent failures, now shows why cmsRun is failing. The IB failures are related to the failure seen in the RelVals.

resolves https://github.com/cms-sw/framework-team/issues/1756