### PR TITLE
Add include needed for c++23 compilation

### DIFF
--- a/FWCore/Framework/interface/ESProductResolverFactoryProducer.h
+++ b/FWCore/Framework/interface/ESProductResolverFactoryProducer.h
@@ -59,6 +59,7 @@ BarProd::BarProd(const edm::ParameterSet& iPS) {
 
 // forward declarations
 #include "FWCore/Framework/interface/ESProductResolverProvider.h"
+#include "FWCore/Framework/interface/ESProductResolverFactoryBase.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 
 namespace edm {


### PR DESCRIPTION
#### PR description:

The c++23 IB was complaining about the use of a forward declared type. This change includes the required header.

#### PR validation:

Building the code in the CPP23 work area now compiles.

resolves https://github.com/cms-sw/framework-team/issues/1760