### PR TITLE
Add time info to Run3ScoutingHBHERecHit

### DIFF
--- a/DataFormats/Scouting/interface/Run3ScoutingHBHERecHit.h
+++ b/DataFormats/Scouting/interface/Run3ScoutingHBHERecHit.h
@@ -11,15 +11,17 @@
 
 class Run3ScoutingHBHERecHit {
 public:
-  Run3ScoutingHBHERecHit(float energy, unsigned int detId) : energy_{energy}, detId_{detId} {}
+  Run3ScoutingHBHERecHit(float energy, float time, unsigned int detId) : energy_{energy}, time_{time}, detId_{detId} {}
 
-  Run3ScoutingHBHERecHit() : energy_{0}, detId_{0} {}
+  Run3ScoutingHBHERecHit() : energy_{0}, time_{0}, detId_{0} {}
 
   float energy() const { return energy_; }
+  float time() const { return time_; }
   unsigned int detId() const { return detId_; }
 
 private:
   float energy_;
+  float time_;
   unsigned int detId_;
 };
 

--- a/DataFormats/Scouting/src/classes_def.xml
+++ b/DataFormats/Scouting/src/classes_def.xml
@@ -70,8 +70,9 @@
   <class name="Run3ScoutingEERecHit" ClassVersion="3">
       <version ClassVersion="3" checksum="343593247"/>
   </class>
-  <class name="Run3ScoutingHBHERecHit" ClassVersion="3">
+  <class name="Run3ScoutingHBHERecHit" ClassVersion="4">
       <version ClassVersion="3" checksum="1840081356"/>
+      <version ClassVersion="4" checksum="3439505242"/> 
   </class>
   <class name="ScoutingCaloJet" ClassVersion="3">
       <version ClassVersion="2" checksum="2705685116"/>

--- a/DataFormats/Scouting/test/TestReadRun3Scouting.cc
+++ b/DataFormats/Scouting/test/TestReadRun3Scouting.cc
@@ -224,9 +224,9 @@ namespace edmtest {
     if (expectedEERecHitIntegralValues_.size() != 1) {
       throwWithMessageFromConstructor("test configuration error, expectedEERecHitIntegralValues must have size 1");
     }
-    if (expectedHBHERecHitFloatingPointValues_.size() != 1) {
+    if (expectedHBHERecHitFloatingPointValues_.size() != 2) {
       throwWithMessageFromConstructor(
-          "test configuration error, expectedHBHERecHitFloatingPointValues must have size 1");
+          "test configuration error, expectedHBHERecHitFloatingPointValues must have size 2");
     }
     if (expectedHBHERecHitIntegralValues_.size() != 1) {
       throwWithMessageFromConstructor("test configuration error, expectedHBHERecHitIntegralValues must have size 1");
@@ -1327,6 +1327,11 @@ namespace edmtest {
       }
       if (hbheRecHit.detId() != static_cast<unsigned int>(expectedHBHERecHitIntegralValues_[0] + iOffset)) {
         throwWithMessage("analyzeHBHERecHits, detId does not equal expected value");
+      }
+      if (inputHBHERecHitClassVersion_ == 4) {
+        if (hbheRecHit.time() != expectedHBHERecHitFloatingPointValues_[1] + offset) {
+          throwWithMessage("analyzeHBHERecHits, time does not equal expected value");
+        }
       }
       ++i;
     }

--- a/DataFormats/Scouting/test/TestWriteRun3Scouting.cc
+++ b/DataFormats/Scouting/test/TestWriteRun3Scouting.cc
@@ -199,8 +199,8 @@ namespace edmtest {
     if (eeRecHitsIntegralValues_.size() != 1) {
       throwWithMessage("eeRecHitsIntegralValues must have 1 elements and it does not");
     }
-    if (hbheRecHitsFloatingPointValues_.size() != 1) {
-      throwWithMessage("hbheRecHitsFloatingPointValues must have 1 elements and it does not");
+    if (hbheRecHitsFloatingPointValues_.size() != 2) {
+      throwWithMessage("hbheRecHitsFloatingPointValues must have 2 elements and it does not");
     }
     if (hbheRecHitsIntegralValues_.size() != 1) {
       throwWithMessage("hbheRecHitsIntegralValues must have 1 elements and it does not");
@@ -696,6 +696,7 @@ namespace edmtest {
       int iOffset = static_cast<int>(iEvent.id().event() + i);
 
       run3ScoutingHBHERecHits->emplace_back(static_cast<float>(hbheRecHitsFloatingPointValues_[0] + offset),
+                                            static_cast<float>(hbheRecHitsFloatingPointValues_[1] + offset),
                                             static_cast<unsigned int>(hbheRecHitsIntegralValues_[0] + iOffset));
     }
     iEvent.put(hbheRecHitsPutToken_, std::move(run3ScoutingHBHERecHits));

--- a/DataFormats/Scouting/test/create_Run3Scouting_test_file_cfg.py
+++ b/DataFormats/Scouting/test/create_Run3Scouting_test_file_cfg.py
@@ -105,7 +105,7 @@ process.run3ScoutingProducer = cms.EDProducer("TestWriteRun3Scouting",
         17
     ),
     hbheRecHitsFloatingPointValues = cms.vdouble(
-        18.0
+        18.0,   28.0
     ),
     hbheRecHitsIntegralValues = cms.vint32(
         18

--- a/DataFormats/Scouting/test/test_readRun3Scouting_cfg.py
+++ b/DataFormats/Scouting/test/test_readRun3Scouting_cfg.py
@@ -10,7 +10,7 @@ parser.add_argument("--photonVersion", type=int, help="photon data format versio
 parser.add_argument("--vertexVersion", type=int, help="vertex data format version (default: 4)", default=4)
 parser.add_argument("--ebRecHitVersion", type=int, help="EBRecHit data format version (default: 3)", default=3)
 parser.add_argument("--eeRecHitVersion", type=int, help="EERecHit data format version (default: 3)", default=3)
-parser.add_argument("--hbheRecHitVersion", type=int, help="HBHERecHit data format version (default: 3)", default=3)
+parser.add_argument("--hbheRecHitVersion", type=int, help="HBHERecHit data format version (default: 4)", default=4)
 parser.add_argument("--inputFile", type=str, help="Input file name (default: testRun3Scouting.root)", default="testRun3Scouting.root")
 parser.add_argument("--outputFileName", type=str, help="Output file name (default: testRun3Scouting2.root)", default="testRun3Scouting2.root")
 parser.add_argument("-f", "--fixStreamerInfo", action="store_true")

--- a/DataFormats/Scouting/test/test_readRun3Scouting_cfg.py
+++ b/DataFormats/Scouting/test/test_readRun3Scouting_cfg.py
@@ -132,7 +132,7 @@ process.testReadRun3Scouting = cms.EDAnalyzer("TestReadRun3Scouting",
     eeRecHitsTag = cms.InputTag("run3ScoutingProducer", "", "PROD"),
     hbheRecHitClassVersion = cms.int32(args.hbheRecHitVersion),
     expectedHBHERecHitFloatingPointValues = cms.vdouble(
-        18.0
+        18.0,  28.0
     ),
     expectedHBHERecHitIntegralValues = cms.vint32(
         18

--- a/HLTrigger/special/plugins/HLTScoutingRecHitProducer.cc
+++ b/HLTrigger/special/plugins/HLTScoutingRecHitProducer.cc
@@ -129,7 +129,9 @@ void HLTScoutingRecHitProducer::produceHcal(edm::Event& iEvent,
     }
 
     run3ScoutHBHERecHits->emplace_back(
-        MiniFloatConverter::reduceMantissaToNbitsRounding(rh.energy(), mantissaPrecision), rh.detId());
+        MiniFloatConverter::reduceMantissaToNbitsRounding(rh.energy(), mantissaPrecision),
+        MiniFloatConverter::reduceMantissaToNbitsRounding(rh.time(), mantissaPrecision),
+        rh.detId());
   }
 
   iEvent.put(std::move(run3ScoutHBHERecHits), "HBHE" + tag);


### PR DESCRIPTION
#### PR description:

This PR complements https://github.com/cms-sw/cmssw/pull/49702 by adding ```time``` to ```Run3ScoutingHBHERecHit``` format so updated HCAL TDC time is saved.

#### PR validation:

Passed ```scram b runtests use-ibeos```.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport, but backport to ```16_0_X``` will follow for 2026 data-taking.

FYI @silviodonato @wang-hui 
