### PR TITLE
suppress loop unroll warning in LSTCore

### DIFF
--- a/RecoTracker/LSTCore/src/alpaka/TrackCandidate.h
+++ b/RecoTracker/LSTCore/src/alpaka/TrackCandidate.h
@@ -663,8 +663,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
       bool hit0InBase = false;
       bool hit1InBase = false;
-
+      // Suppress compiler warning with HIP backend
+#ifndef ALPAKA_ACC_GPU_HIP_ENABLED
       CMS_UNROLL_LOOP
+#endif
       for (int baseHitIndex = 0; baseHitIndex < Params_T5::kHits; ++baseHitIndex) {
         const unsigned int baseHit = quintuplets.hitIndices()[refT5Index][baseHitIndex];
         if (candidateHit0 == baseHit)


### PR DESCRIPTION
The fix involves disabling the CMS_UNROLL_LOOP pragma specifically for the HIP backend using #ifndef ALPAKA_ACC_GPU_HIP_ENABLED. This suppresses the warning while maintaining the optimization for other backends.

Resolves https://github.com/cms-sw/cmssw/issues/49664