### PR TITLE
Use more requires in EventSetup code

### DIFF
--- a/FWCore/Framework/interface/DependentRecordImplementation.h
+++ b/FWCore/Framework/interface/DependentRecordImplementation.h
@@ -28,6 +28,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/NoRecordException.h"
 #include "FWCore/Framework/interface/DependentRecordTag.h"
+#include "FWCore/Framework/interface/data_default_record_trait.h"
 #include "FWCore/Utilities/interface/mplVector.h"
 
 //This is here only because too many modules depend no
@@ -79,22 +80,36 @@ namespace edm {
 
       template <typename ProductT, typename DepRecordT>
       ESHandle<ProductT> getHandle(ESGetToken<ProductT, DepRecordT> const& iToken) const {
-        //Make sure that DepRecordT is a type in ListT
-        static_assert((list_type::template contains<DepRecordT>()),
-                      "Trying to get a product with an ESGetToken specifying a Record from another Record where the "
-                      "second Record is not dependent on the first Record.");
-        return getRecord<DepRecordT>().getHandle(iToken);
+        if constexpr (std::is_same_v<DepRecordT, edm::DefaultRecord>) {
+          static_assert((list_type::template contains<eventsetup::default_record_t<ESHandle<ProductT>>>()),
+                        "Trying to get a product with an ESGetToken use DefaultRecord from another Record where the "
+                        "actual default Record is not dependent on the first Record.");
+          return getRecord<eventsetup::default_record_t<ESHandle<ProductT>>>().getHandle(iToken);
+        } else {
+          //Make sure that DepRecordT is a type in ListT
+          static_assert((list_type::template contains<DepRecordT>()),
+                        "Trying to get a product with an ESGetToken specifying a Record from another Record where the "
+                        "second Record is not dependent on the first Record.");
+          return getRecord<DepRecordT>().getHandle(iToken);
+        }
       }
 
       using EventSetupRecordImplementation<RecordT>::getTransientHandle;
 
       template <typename ProductT, typename DepRecordT>
       ESTransientHandle<ProductT> getTransientHandle(ESGetToken<ProductT, DepRecordT> const& iToken) const {
-        //Make sure that DepRecordT is a type in ListT
-        static_assert((list_type::template contains<DepRecordT>()),
-                      "Trying to get a product with an ESGetToken specifying a Record from another Record where the "
-                      "second Record is not dependent on the first Record.");
-        return getRecord<DepRecordT>().getTransientHandle(iToken);
+        if constexpr (std::is_same_v<DepRecordT, edm::DefaultRecord>) {
+          static_assert((list_type::template contains<eventsetup::default_record_t<ESHandle<ProductT>>>()),
+                        "Trying to get a product with an ESGetToken use DefaultRecord from another Record where the "
+                        "actual default Record is not dependent on the first Record.");
+          return getRecord<eventsetup::default_record_t<ESHandle<ProductT>>>().getTransientHandle(iToken);
+        } else {
+          //Make sure that DepRecordT is a type in ListT
+          static_assert((list_type::template contains<DepRecordT>()),
+                        "Trying to get a product with an ESGetToken specifying a Record from another Record where the "
+                        "second Record is not dependent on the first Record.");
+          return getRecord<DepRecordT>().getTransientHandle(iToken);
+        }
       }
 
       using EventSetupRecordImplementation<RecordT>::get;

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -37,13 +37,12 @@
 #include "FWCore/Framework/interface/data_default_record_trait.h"
 #include "FWCore/Utilities/interface/Transition.h"
 #include "FWCore/Utilities/interface/ESIndices.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 // forward declarations
 
 namespace edm {
 
-  template <class T, class R>
-  class ESGetToken;
   class PileUp;
   class ESParentContext;
 
@@ -76,13 +75,10 @@ namespace edm {
     /** returns the Record of type T.  If no such record available
           a eventsetup::NoRecordException<T> is thrown */
     template <typename T>
+      requires std::is_base_of_v<edm::eventsetup::EventSetupRecord, T>
     T get() const {
       using namespace eventsetup;
       using namespace eventsetup::heterocontainer;
-      //NOTE: this will catch the case where T does not inherit from EventSetupRecord
-      //  HOWEVER the error message under gcc 3.x is awful
-      static_assert(std::is_base_of_v<edm::eventsetup::EventSetupRecord, T>,
-                    "Trying to get a class that is not a Record from EventSetup");
 
       auto const temp = m_setup.findImpl(makeKey<typename type_from_itemtype<eventsetup::EventSetupRecordKey, T>::Type,
                                                  eventsetup::EventSetupRecordKey>());
@@ -97,13 +93,11 @@ namespace edm {
     /** returns the Record of type T.  If no such record available
        a null optional is returned */
     template <typename T>
+      requires std::is_base_of_v<edm::eventsetup::EventSetupRecord, T>
     std::optional<T> tryToGet() const {
       using namespace eventsetup;
       using namespace eventsetup::heterocontainer;
 
-      //NOTE: this will catch the case where T does not inherit from EventSetupRecord
-      static_assert(std::is_base_of_v<edm::eventsetup::EventSetupRecord, T>,
-                    "Trying to get a class that is not a Record from EventSetup");
       auto const temp = impl().findImpl(makeKey<typename type_from_itemtype<eventsetup::EventSetupRecordKey, T>::Type,
                                                 eventsetup::EventSetupRecordKey>());
       if (temp != nullptr) {

--- a/FWCore/Framework/interface/data_default_record_trait.h
+++ b/FWCore/Framework/interface/data_default_record_trait.h
@@ -40,13 +40,12 @@
 // Created:     Thu Apr  7 07:59:56 CDT 2005
 //
 
+#include "FWCore/Utilities/interface/DefaultRecord.h"
+
 namespace edm {
 
   template <typename T>
   class ESHandle;
-
-  // Special class to denote that the default record should be used.
-  struct DefaultRecord {};
 
   namespace eventsetup {
     template <class T>

--- a/FWCore/Utilities/interface/DefaultRecord.h
+++ b/FWCore/Utilities/interface/DefaultRecord.h
@@ -1,0 +1,15 @@
+#ifndef FWCore_Utilities_DefaultRecord_h
+#define FWCore_Utilities_DefaultRecord_h
+// -*- C++ -*-
+// Package:     FWCore/Utilities
+// Class  :     DefaultRecord
+/// Description: Special type used to indicate the default Record for a data type
+// Usage:
+// An ESGetToken can be created with DefaultRecord to indicate
+// the default Record for the data type should be used.
+//
+
+namespace edm {
+  struct DefaultRecord {};
+}  // namespace edm
+#endif


### PR DESCRIPTION
#### PR description:

- Enforce that templates which are supposed to be related to EventSetup Records are the appropriate type.
- Have DependentRecordImplementation handle edm::DefaultRecord to make it consistent with other uses.

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/1770