### PR TITLE
Phase 2 Tracker: Summary histograms for release validation

### DIFF
--- a/Validation/SiTrackerPhase2V/interface/Phase2ITValidateRecHitBase.h
+++ b/Validation/SiTrackerPhase2V/interface/Phase2ITValidateRecHitBase.h
@@ -64,6 +64,9 @@ protected:
     MonitorElement* deltaY = nullptr;
     MonitorElement* pullX = nullptr;
     MonitorElement* pullY = nullptr;
+    MonitorElement* deltaPhi = nullptr;
+    MonitorElement* deltaPhi_barrel = nullptr;
+    MonitorElement* deltaPhi_endcaps = nullptr;
     MonitorElement* deltaX_eta = nullptr;
     MonitorElement* deltaX_phi = nullptr;
     MonitorElement* deltaY_eta = nullptr;

--- a/Validation/SiTrackerPhase2V/interface/Phase2OTValidateRecHitBase.h
+++ b/Validation/SiTrackerPhase2V/interface/Phase2OTValidateRecHitBase.h
@@ -91,6 +91,13 @@ protected:
     MonitorElement* deltaY_phi_P = nullptr;
     MonitorElement* deltaY_phi_S = nullptr;
 
+    MonitorElement* delta_phi_P = nullptr;
+    MonitorElement* delta_phi_P_barrel = nullptr;
+    MonitorElement* delta_phi_P_endcaps = nullptr;
+    MonitorElement* delta_phi_S = nullptr;
+    MonitorElement* delta_phi_S_barrel = nullptr;
+    MonitorElement* delta_phi_S_endcaps = nullptr;
+
     /*
       As the error is a constant these for now are not needed
 

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateCluster.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateCluster.cc
@@ -397,7 +397,7 @@ void Phase2ITValidateCluster::fillDescriptions(edm::ConfigurationDescriptions& d
   }
   {
     edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_Phi_Pixel_Endcap");
+    psd0.add<std::string>("name", "Delta_Phi_Pixel_Endcaps");
     psd0.add<std::string>("title", "#Delta Phi pixel sensor Endcaps;phi");
     psd0.add<double>("xmin", -3.14159);
     psd0.add<bool>("switch", true);

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateCluster.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateCluster.cc
@@ -379,9 +379,9 @@ void Phase2ITValidateCluster::fillDescriptions(edm::ConfigurationDescriptions& d
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Pixel");
     psd0.add<std::string>("title", "#Delta Phi pixel sensor;phi");
-    psd0.add<double>("xmin", -3.14159);
+    psd0.add<double>("xmin", -0.1);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 3.14159);
+    psd0.add<double>("xmax", 0.1);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel", psd0);
   }
@@ -389,9 +389,9 @@ void Phase2ITValidateCluster::fillDescriptions(edm::ConfigurationDescriptions& d
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Pixel_Barrel");
     psd0.add<std::string>("title", "#Delta Phi pixel sensor Barrel;phi");
-    psd0.add<double>("xmin", -3.14159);
+    psd0.add<double>("xmin", -0.1);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 3.14159);
+    psd0.add<double>("xmax", 0.1);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel_Barrel", psd0);
   }
@@ -399,9 +399,9 @@ void Phase2ITValidateCluster::fillDescriptions(edm::ConfigurationDescriptions& d
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Pixel_Endcaps");
     psd0.add<std::string>("title", "#Delta Phi pixel sensor Endcaps;phi");
-    psd0.add<double>("xmin", -3.14159);
+    psd0.add<double>("xmin", -0.1);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 3.14159);
+    psd0.add<double>("xmax", 0.1);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel_Endcap", psd0);
   }

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateCluster.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateCluster.cc
@@ -64,6 +64,10 @@ private:
     MonitorElement* deltaY_P = nullptr;
     MonitorElement* deltaX_P_primary = nullptr;
     MonitorElement* deltaY_P_primary = nullptr;
+
+    MonitorElement* delta_Phi_P = nullptr;
+    MonitorElement* delta_Phi_P_Barrel = nullptr;
+    MonitorElement* delta_Phi_P_Endcaps = nullptr;
   };
 
   void fillITHistos(const edm::Event& iEvent,
@@ -226,6 +230,9 @@ void Phase2ITValidateCluster::fillITHistos(const edm::Event& iEvent,
       const double deltaX = phase2tkutil::cmtomicron * (localPosCluster.x() - localPosSimHit.x());
       const double deltaY = phase2tkutil::cmtomicron * (localPosCluster.y() - localPosSimHit.y());
 
+      const float deltaPhi = geomDetUnit->surface().toGlobal(localPosCluster).phi() -
+                             geomDetUnit->surface().toGlobal(localPosSimHit).phi();
+
       auto layerMEIt = layerMEs_.find(folderkey);
       if (layerMEIt == layerMEs_.end())
         continue;
@@ -233,6 +240,13 @@ void Phase2ITValidateCluster::fillITHistos(const edm::Event& iEvent,
       ClusterMEs& local_mes = layerMEIt->second;
       local_mes.deltaX_P->Fill(deltaX);
       local_mes.deltaY_P->Fill(deltaY);
+      local_mes.delta_Phi_P->Fill(deltaPhi);
+
+      if (tTopo_->getITPixelLayerNumber(detId) < 100) {
+        local_mes.delta_Phi_P_Barrel->Fill(deltaPhi);
+      } else {
+        local_mes.delta_Phi_P_Endcaps->Fill(deltaPhi);
+      }
       // Primary particles only
       if (phase2tkutil::isPrimary(simTrackIt->second, closestSimHit)) {
         local_mes.deltaX_P_primary->Fill(deltaX);
@@ -274,15 +288,23 @@ void Phase2ITValidateCluster::bookLayerHistos(DQMStore::IBooker& ibooker, uint32
 
   if (layerMEs_.find(folderName) == layerMEs_.end()) {
     ibooker.cd();
+    ClusterMEs local_mes;
+    ibooker.setCurrentFolder(subdir);
+    local_mes.delta_Phi_P_Barrel =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Phi_Pixel_Barrel"), ibooker);
+    local_mes.delta_Phi_P_Endcaps =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Phi_Pixel_Endcap"), ibooker);
+
     ibooker.setCurrentFolder(subdir + '/' + folderName);
     edm::LogInfo("Phase2TrackerValidateDigi") << " Booking Histograms in: " << subdir + '/' + folderName;
-    ClusterMEs local_mes;
-
     local_mes.deltaX_P =
         phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_Pixel"), ibooker);
 
     local_mes.deltaY_P =
         phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_Pixel"), ibooker);
+
+    local_mes.delta_Phi_P =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Phi_Pixel"), ibooker);
 
     // Puting primary digis in a subfolder
     ibooker.setCurrentFolder(subdir + '/' + folderName + "/PrimarySimHits");
@@ -352,6 +374,36 @@ void Phase2ITValidateCluster::fillDescriptions(edm::ConfigurationDescriptions& d
     psd0.add<bool>("switch", true);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Y_Pixel_Primary", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Phi_Pixel");
+    psd0.add<std::string>("title", "#Delta Phi pixel sensor;phi");
+    psd0.add<double>("xmin", -3.14159);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 3.14159);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Phi_Pixel_Barrel");
+    psd0.add<std::string>("title", "#Delta Phi pixel sensor Barrel;phi");
+    psd0.add<double>("xmin", -3.14159);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 3.14159);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel_Barrel", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Phi_Pixel_Endcap");
+    psd0.add<std::string>("title", "#Delta Phi pixel sensor Endcaps;phi");
+    psd0.add<double>("xmin", -3.14159);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 3.14159);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel_Endcap", psd0);
   }
 
   desc.add<std::string>("TopFolderName", "TrackerPhase2ITClusterV");

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateCluster.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateCluster.cc
@@ -459,7 +459,7 @@ void Phase2OTValidateCluster::fillDescriptions(edm::ConfigurationDescriptions& d
   }
   {
     edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_Phi_Pixel_Endcap");
+    psd0.add<std::string>("name", "Delta_Phi_Pixel_Endcaps");
     psd0.add<std::string>("title", "#Delta Phi " + mptag + " Endcaps;phi");
     psd0.add<double>("xmin", -3.14159);
     psd0.add<bool>("switch", true);
@@ -531,7 +531,7 @@ void Phase2OTValidateCluster::fillDescriptions(edm::ConfigurationDescriptions& d
   }
   {
     edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_Phi_Strip_Endcap");
+    psd0.add<std::string>("name", "Delta_Phi_Strip_Endcaps");
     psd0.add<std::string>("title", "#Delta Phi " + striptag + " Endcaps;phi");
     psd0.add<double>("xmin", -3.14159);
     psd0.add<bool>("switch", true);

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateCluster.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateCluster.cc
@@ -441,9 +441,9 @@ void Phase2OTValidateCluster::fillDescriptions(edm::ConfigurationDescriptions& d
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Pixel");
     psd0.add<std::string>("title", "#Delta Phi " + mptag + ";phi");
-    psd0.add<double>("xmin", -3.14159);
+    psd0.add<double>("xmin", -0.1);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 3.14159);
+    psd0.add<double>("xmax", 0.1);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel", psd0);
   }
@@ -451,9 +451,9 @@ void Phase2OTValidateCluster::fillDescriptions(edm::ConfigurationDescriptions& d
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Pixel_Barrel");
     psd0.add<std::string>("title", "#Delta Phi " + mptag + " Barrel;phi");
-    psd0.add<double>("xmin", -3.14159);
+    psd0.add<double>("xmin", -0.1);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 3.14159);
+    psd0.add<double>("xmax", 0.1);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel_Barrel", psd0);
   }
@@ -461,9 +461,9 @@ void Phase2OTValidateCluster::fillDescriptions(edm::ConfigurationDescriptions& d
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Pixel_Endcaps");
     psd0.add<std::string>("title", "#Delta Phi " + mptag + " Endcaps;phi");
-    psd0.add<double>("xmin", -3.14159);
+    psd0.add<double>("xmin", -0.1);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 3.14159);
+    psd0.add<double>("xmax", 0.1);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel_Endcap", psd0);
   }
@@ -513,9 +513,9 @@ void Phase2OTValidateCluster::fillDescriptions(edm::ConfigurationDescriptions& d
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Strip");
     psd0.add<std::string>("title", "#Delta Phi " + striptag + ";phi");
-    psd0.add<double>("xmin", -3.14159);
+    psd0.add<double>("xmin", -0.1);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 3.14159);
+    psd0.add<double>("xmax", 0.1);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Strip", psd0);
   }
@@ -523,9 +523,9 @@ void Phase2OTValidateCluster::fillDescriptions(edm::ConfigurationDescriptions& d
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Strip_Barrel");
     psd0.add<std::string>("title", "#Delta Phi " + striptag + " Barrel;phi");
-    psd0.add<double>("xmin", -3.14159);
+    psd0.add<double>("xmin", -0.1);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 3.14159);
+    psd0.add<double>("xmax", 0.1);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Strip_Barrel", psd0);
   }
@@ -533,9 +533,9 @@ void Phase2OTValidateCluster::fillDescriptions(edm::ConfigurationDescriptions& d
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Strip_Endcaps");
     psd0.add<std::string>("title", "#Delta Phi " + striptag + " Endcaps;phi");
-    psd0.add<double>("xmin", -3.14159);
+    psd0.add<double>("xmin", -0.1);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 3.14159);
+    psd0.add<double>("xmax", 0.1);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Strip_Endcap", psd0);
   }

--- a/Validation/SiTrackerPhase2V/src/Phase2ITValidateRecHitBase.cc
+++ b/Validation/SiTrackerPhase2V/src/Phase2ITValidateRecHitBase.cc
@@ -410,8 +410,8 @@ void Phase2ITValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
   psd18.add<std::string>("title", "Delta Phi macro pixel sensor;phi;");
   psd18.add<int>("NxBins", 100);
   psd18.add<bool>("switch", true);
-  psd18.add<double>("xmax", 3.14159);
-  psd18.add<double>("xmin", -3.14159);
+  psd18.add<double>("xmax", 0.5);
+  psd18.add<double>("xmin", -0.5);
   desc.add<edm::ParameterSetDescription>("Delta_Phi", psd18);
 
   edm::ParameterSetDescription psd18b;
@@ -419,8 +419,8 @@ void Phase2ITValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
   psd18b.add<std::string>("title", "Delta Phi macro pixel sensor barrel;phi;");
   psd18b.add<int>("NxBins", 100);
   psd18b.add<bool>("switch", true);
-  psd18b.add<double>("xmax", 3.14159);
-  psd18b.add<double>("xmin", -3.14159);
+  psd18b.add<double>("xmax", 0.5);
+  psd18b.add<double>("xmin", -0.5);
   desc.add<edm::ParameterSetDescription>("Delta_Phi_barrel", psd18b);
 
   edm::ParameterSetDescription psd18e;
@@ -428,7 +428,7 @@ void Phase2ITValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
   psd18e.add<std::string>("title", "Delta Phi macro pixel sensor endcaps;phi;");
   psd18e.add<int>("NxBins", 100);
   psd18e.add<bool>("switch", true);
-  psd18e.add<double>("xmax", 3.14159);
-  psd18e.add<double>("xmin", -3.14159);
+  psd18e.add<double>("xmax", 0.5);
+  psd18e.add<double>("xmin", -0.5);
   desc.add<edm::ParameterSetDescription>("Delta_Phi_endcaps", psd18e);
 }

--- a/Validation/SiTrackerPhase2V/src/Phase2ITValidateRecHitBase.cc
+++ b/Validation/SiTrackerPhase2V/src/Phase2ITValidateRecHitBase.cc
@@ -415,7 +415,7 @@ void Phase2ITValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
   desc.add<edm::ParameterSetDescription>("Delta_Phi", psd18);
 
   edm::ParameterSetDescription psd18b;
-  psd18b.add<std::string>("name", "Delta_phi_barrel");
+  psd18b.add<std::string>("name", "Delta_Phi_Pixel_Barrel");
   psd18b.add<std::string>("title", "Delta Phi macro pixel sensor barrel;phi;");
   psd18b.add<int>("NxBins", 100);
   psd18b.add<bool>("switch", true);
@@ -424,7 +424,7 @@ void Phase2ITValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
   desc.add<edm::ParameterSetDescription>("Delta_Phi_barrel", psd18b);
 
   edm::ParameterSetDescription psd18e;
-  psd18e.add<std::string>("name", "Delta_phi_endcaps");
+  psd18e.add<std::string>("name", "Delta_Phi_Pixel_Endcaps");
   psd18e.add<std::string>("title", "Delta Phi macro pixel sensor endcaps;phi;");
   psd18e.add<int>("NxBins", 100);
   psd18e.add<bool>("switch", true);

--- a/Validation/SiTrackerPhase2V/src/Phase2ITValidateRecHitBase.cc
+++ b/Validation/SiTrackerPhase2V/src/Phase2ITValidateRecHitBase.cc
@@ -56,6 +56,11 @@ void Phase2ITValidateRecHitBase::bookLayerHistos(DQMStore::IBooker& ibooker, uns
   if (layerMEs_.find(key) == layerMEs_.end()) {
     ibooker.cd();
     RecHitME local_histos;
+    ibooker.setCurrentFolder(subdir);
+    local_histos.deltaPhi_barrel =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Phi_barrel"), ibooker);
+    local_histos.deltaPhi_endcaps =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Phi_endcaps"), ibooker);
     ibooker.setCurrentFolder(subdir + "/" + key);
     edm::LogInfo("Phase2ITValidateRecHit") << " Booking Histograms in : " << (subdir + "/" + key);
 
@@ -66,6 +71,8 @@ void Phase2ITValidateRecHitBase::bookLayerHistos(DQMStore::IBooker& ibooker, uns
     local_histos.pullX = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("PullX"), ibooker);
 
     local_histos.pullY = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("PullY"), ibooker);
+
+    local_histos.deltaPhi = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Phi"), ibooker);
 
     local_histos.deltaX_eta =
         phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_eta"), ibooker);
@@ -149,10 +156,17 @@ void Phase2ITValidateRecHitBase::fillRechitHistos(const PSimHit* simhitClosest,
     pully = (lp.y() - simlp.y()) / std::sqrt(lperr.yy());
   float eta = geomDetunit->surface().toGlobal(lp).eta();
   float phi = geomDetunit->surface().toGlobal(lp).phi();
+  float dphi = phi - geomDetunit->surface().toGlobal(simlp).phi();
   layerMEs_[key].deltaX->Fill(dx);
   layerMEs_[key].deltaY->Fill(dy);
   layerMEs_[key].pullX->Fill(pullx);
   layerMEs_[key].pullY->Fill(pully);
+  layerMEs_[key].deltaPhi->Fill(dphi);
+  if (tTopo_->getITPixelLayerNumber(id) < 100) {
+    layerMEs_[key].deltaPhi_barrel->Fill(dphi);
+  } else {
+    layerMEs_[key].deltaPhi_endcaps->Fill(dphi);
+  }
 
   layerMEs_[key].deltaX_eta->Fill(std::abs(eta), dx);
   layerMEs_[key].deltaY_eta->Fill(std::abs(eta), dy);
@@ -390,4 +404,31 @@ void Phase2ITValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
   psd17.add<double>("xmin", -4.1);
   psd17.add<double>("ymin", -4.0);
   desc.add<edm::ParameterSetDescription>("PullY_primary", psd17);
+
+  edm::ParameterSetDescription psd18;
+  psd18.add<std::string>("name", "Delta_phi");
+  psd18.add<std::string>("title", "Delta Phi macro pixel sensor;phi;");
+  psd18.add<int>("NxBins", 100);
+  psd18.add<bool>("switch", true);
+  psd18.add<double>("xmax", 3.14159);
+  psd18.add<double>("xmin", -3.14159);
+  desc.add<edm::ParameterSetDescription>("Delta_Phi", psd18);
+
+  edm::ParameterSetDescription psd18b;
+  psd18b.add<std::string>("name", "Delta_phi_barrel");
+  psd18b.add<std::string>("title", "Delta Phi macro pixel sensor barrel;phi;");
+  psd18b.add<int>("NxBins", 100);
+  psd18b.add<bool>("switch", true);
+  psd18b.add<double>("xmax", 3.14159);
+  psd18b.add<double>("xmin", -3.14159);
+  desc.add<edm::ParameterSetDescription>("Delta_Phi_barrel", psd18b);
+
+  edm::ParameterSetDescription psd18e;
+  psd18e.add<std::string>("name", "Delta_phi_endcaps");
+  psd18e.add<std::string>("title", "Delta Phi macro pixel sensor endcaps;phi;");
+  psd18e.add<int>("NxBins", 100);
+  psd18e.add<bool>("switch", true);
+  psd18e.add<double>("xmax", 3.14159);
+  psd18e.add<double>("xmin", -3.14159);
+  desc.add<edm::ParameterSetDescription>("Delta_Phi_endcaps", psd18e);
 }

--- a/Validation/SiTrackerPhase2V/src/Phase2OTValidateRecHitBase.cc
+++ b/Validation/SiTrackerPhase2V/src/Phase2OTValidateRecHitBase.cc
@@ -612,7 +612,7 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
   }
   {
     edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_Phi_Pixel_Endcap");
+    psd0.add<std::string>("name", "Delta_Phi_Pixel_Endcaps");
     psd0.add<std::string>("title", "#Delta Phi " + mptag + " Endcaps;phi");
     psd0.add<double>("xmin", -3.14159);
     psd0.add<bool>("switch", true);
@@ -890,7 +890,7 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
   }
   {
     edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_Phi_Strip_Endcap");
+    psd0.add<std::string>("name", "Delta_Phi_Strip_Endcaps");
     psd0.add<std::string>("title", "#Delta Phi " + striptag + " Endcaps;phi");
     psd0.add<double>("xmin", -3.14159);
     psd0.add<bool>("switch", true);

--- a/Validation/SiTrackerPhase2V/src/Phase2OTValidateRecHitBase.cc
+++ b/Validation/SiTrackerPhase2V/src/Phase2OTValidateRecHitBase.cc
@@ -83,6 +83,7 @@ void Phase2OTValidateRecHitBase::fillOTRecHitHistos(const PSimHit* simhitClosest
     pully = (dx) / std::sqrt(lperr.yy());
   float eta = geomDetunit->surface().toGlobal(lp).eta();
   float phi = geomDetunit->surface().toGlobal(lp).phi();
+  float dphi = phi - geomDetunit->surface().toGlobal(simlp).phi();
 
   //scale for plotting
   dx *= phase2tkutil::cmtomicron;  //this is always the case
@@ -104,6 +105,13 @@ void Phase2OTValidateRecHitBase::fillOTRecHitHistos(const PSimHit* simhitClosest
     layerMEs_[key].deltaY_eta_P->Fill(std::abs(eta), dy);
     layerMEs_[key].deltaX_phi_P->Fill(phi, dx);
     layerMEs_[key].deltaY_phi_P->Fill(phi, dy);
+
+    layerMEs_[key].delta_phi_P->Fill(dphi);
+    if (tTopo_->getOTLayerNumber(detId) < 100) {
+      layerMEs_[key].delta_phi_P_barrel->Fill(dphi);
+    } else {
+      layerMEs_[key].delta_phi_P_endcaps->Fill(dphi);
+    }
 
     /*
       constant error, not needed for now
@@ -138,6 +146,13 @@ void Phase2OTValidateRecHitBase::fillOTRecHitHistos(const PSimHit* simhitClosest
     layerMEs_[key].deltaY_eta_S->Fill(std::abs(eta), dy);
     layerMEs_[key].deltaX_phi_S->Fill(phi, dx);
     layerMEs_[key].deltaY_phi_S->Fill(phi, dy);
+
+    layerMEs_[key].delta_phi_S->Fill(dphi);
+    if (tTopo_->getOTLayerNumber(detId) < 100) {
+      layerMEs_[key].delta_phi_S_barrel->Fill(dphi);
+    } else {
+      layerMEs_[key].delta_phi_S_endcaps->Fill(dphi);
+    }
 
     /*
       contant error for now, not needed
@@ -188,6 +203,16 @@ void Phase2OTValidateRecHitBase::bookLayerHistos(DQMStore::IBooker& ibooker, uns
   if (layerMEs_.find(key) == layerMEs_.end()) {
     ibooker.cd();
     RecHitME local_histos;
+    ibooker.setCurrentFolder(subdir);
+    local_histos.delta_phi_P_barrel =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Phi_Pixel_Barrel"), ibooker);
+    local_histos.delta_phi_P_endcaps =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Phi_Pixel_Endcaps"), ibooker);
+    local_histos.delta_phi_S_barrel =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Phi_Strip_Barrel"), ibooker);
+    local_histos.delta_phi_S_endcaps =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Phi_Strip_Endcaps"), ibooker);
+
     ibooker.setCurrentFolder(subdir + "/" + key);
     edm::LogInfo("Phase2OTValidateRecHitBase") << " Booking Histograms in : " << key;
 
@@ -207,6 +232,8 @@ void Phase2OTValidateRecHitBase::bookLayerHistos(DQMStore::IBooker& ibooker, uns
       local_histos.pullY_P =
           phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_Y_Pixel"), ibooker);
 
+      local_histos.delta_phi_P =
+          phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Phi_Pixel"), ibooker);
       /* residuals */
 
       local_histos.deltaX_eta_P =
@@ -267,6 +294,9 @@ void Phase2OTValidateRecHitBase::bookLayerHistos(DQMStore::IBooker& ibooker, uns
         phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Strip"), ibooker);
     local_histos.pullY_S =
         phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_Y_Strip"), ibooker);
+
+    local_histos.delta_phi_S =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Phi_Strip"), ibooker);
 
     /* delta */
 
@@ -559,6 +589,37 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
     psd0.add<double>("ymin", -4.0);
     desc.add<edm::ParameterSetDescription>("Pull_Y_vs_eta_Pixel", psd0);
   }
+  // Delta phi pixels
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Phi_Pixel");
+    psd0.add<std::string>("title", "#Delta Phi " + mptag + ";phi");
+    psd0.add<double>("xmin", -3.14159);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 3.14159);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Phi_Pixel_Barrel");
+    psd0.add<std::string>("title", "#Delta Phi " + mptag + " Barrel;phi");
+    psd0.add<double>("xmin", -3.14159);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 3.14159);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel_Barrel", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Phi_Pixel_Endcap");
+    psd0.add<std::string>("title", "#Delta Phi " + mptag + " Endcaps;phi");
+    psd0.add<double>("xmin", -3.14159);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 3.14159);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel_Endcaps", psd0);
+  }
   {
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Number_RecHits_matched_PrimarySimTrack");
@@ -806,6 +867,38 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
     psd0.add<double>("ymin", -4.0);
     desc.add<edm::ParameterSetDescription>("Pull_Y_vs_eta_Strip", psd0);
   }
+  // Delta phi strips
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Phi_Strip");
+    psd0.add<std::string>("title", "#Delta Phi " + striptag + ";phi");
+    psd0.add<double>("xmin", -3.14159);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 3.14159);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_Phi_Strip", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Phi_Strip_Barrel");
+    psd0.add<std::string>("title", "#Delta Phi " + striptag + " Barrel;phi");
+    psd0.add<double>("xmin", -3.14159);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 3.14159);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_Phi_Strip_Barrel", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Phi_Strip_Endcap");
+    psd0.add<std::string>("title", "#Delta Phi " + striptag + " Endcaps;phi");
+    psd0.add<double>("xmin", -3.14159);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 3.14159);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_Phi_Strip_Endcaps", psd0);
+  }
+  // N matched rechits
   {
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Number_RecHits_matched_PrimarySimTrack");

--- a/Validation/SiTrackerPhase2V/src/Phase2OTValidateRecHitBase.cc
+++ b/Validation/SiTrackerPhase2V/src/Phase2OTValidateRecHitBase.cc
@@ -594,9 +594,9 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Pixel");
     psd0.add<std::string>("title", "#Delta Phi " + mptag + ";phi");
-    psd0.add<double>("xmin", -3.14159);
+    psd0.add<double>("xmin", -0.5);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 3.14159);
+    psd0.add<double>("xmax", 0.5);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel", psd0);
   }
@@ -604,9 +604,9 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Pixel_Barrel");
     psd0.add<std::string>("title", "#Delta Phi " + mptag + " Barrel;phi");
-    psd0.add<double>("xmin", -3.14159);
+    psd0.add<double>("xmin", -0.5);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 3.14159);
+    psd0.add<double>("xmax", 0.5);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel_Barrel", psd0);
   }
@@ -614,9 +614,9 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Pixel_Endcaps");
     psd0.add<std::string>("title", "#Delta Phi " + mptag + " Endcaps;phi");
-    psd0.add<double>("xmin", -3.14159);
+    psd0.add<double>("xmin", -0.5);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 3.14159);
+    psd0.add<double>("xmax", 0.5);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel_Endcaps", psd0);
   }
@@ -872,9 +872,9 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Strip");
     psd0.add<std::string>("title", "#Delta Phi " + striptag + ";phi");
-    psd0.add<double>("xmin", -3.14159);
+    psd0.add<double>("xmin", -0.5);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 3.14159);
+    psd0.add<double>("xmax", 0.5);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Strip", psd0);
   }
@@ -882,9 +882,9 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Strip_Barrel");
     psd0.add<std::string>("title", "#Delta Phi " + striptag + " Barrel;phi");
-    psd0.add<double>("xmin", -3.14159);
+    psd0.add<double>("xmin", -0.5);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 3.14159);
+    psd0.add<double>("xmax", 0.5);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Strip_Barrel", psd0);
   }
@@ -892,9 +892,9 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Strip_Endcaps");
     psd0.add<std::string>("title", "#Delta Phi " + striptag + " Endcaps;phi");
-    psd0.add<double>("xmin", -3.14159);
+    psd0.add<double>("xmin", -0.5);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 3.14159);
+    psd0.add<double>("xmax", 0.5);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Strip_Endcaps", psd0);
   }


### PR DESCRIPTION
Adds Delta Phi histograms to IT/OT Cluster, RecHit, and TrackingRecHit validation. Histograms are split by module type. Summary histograms for the endcaps and barrel will be used in the DQMGUI for release validation.
The Phase-2 DQM code runs without errors and produces the expected histograms.
Example histogram:
<img width="1557" height="829" alt="Screenshot from 2026-01-07 13-46-07" src="https://github.com/user-attachments/assets/74dc0acc-78af-461c-a3dd-f3f5a56310c6" />