### PR TITLE
Implement network packet labels

### DIFF
--- a/FWCore/Catalog/interface/InputFileCatalog.h
+++ b/FWCore/Catalog/interface/InputFileCatalog.h
@@ -24,6 +24,7 @@
 #include <utility>
 #include <vector>
 
+#include "FWCore/Catalog/interface/StorageURLModifier.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 
 namespace edm {
@@ -47,7 +48,8 @@ namespace edm {
   public:
     InputFileCatalog(std::vector<std::string> logicalFileNames,
                      std::string const& override,
-                     bool useLFNasPFNifLFNnotFound = false);
+                     bool useLFNasPFNifLFNnotFound = false,
+                     SciTagCategory sciTagCategory = SciTagCategory::Primary);
     ~InputFileCatalog();
 
     std::vector<FileCatalogItem> const& fileCatalogItems() const { return fileCatalogItems_; }
@@ -56,11 +58,12 @@ namespace edm {
     static bool isPhysical(std::string const& name) { return (name.empty() || name.find(':') != std::string::npos); }
 
   private:
-    void findFile(std::string const& lfn, std::vector<std::string>& pfns, bool useLFNasPFNifLFNnotFound);
+    void findFile(std::string const& lfn, std::vector<std::string>& pfns, bool useLFNasPFNifLFNnotFound) const;
 
     std::vector<FileCatalogItem> fileCatalogItems_;
     propagate_const<std::unique_ptr<FileLocator>> overrideFileLocator_;
     std::vector<propagate_const<std::unique_ptr<FileLocator>>> fileLocators_;
+    SciTagCategory sciTagCategory_;
   };
 }  // namespace edm
 #endif

--- a/FWCore/Catalog/interface/StorageURLModifier.h
+++ b/FWCore/Catalog/interface/StorageURLModifier.h
@@ -1,0 +1,31 @@
+#ifndef FWCore_Catalog_StorageURLModifier_h
+#define FWCore_Catalog_StorageURLModifier_h
+
+/**\class edm::StorageURLModifier
+
+Description: This is a virtual base class for a services
+providing the ability to modify PFN URLs.
+
+*/
+//
+// Original Author: W. David Dagenhart
+//         Created: 29 Dec 2025
+
+#include <string>
+
+namespace edm {
+  // These enum values are used in classes derived from StorageURLModifier
+  // as indexes into vectors. Do not modify them without making corresponding
+  // changes in those derived classes.
+  enum class SciTagCategory : unsigned char { Primary, Embedded, PreMixedPileup, Undefined };
+
+  class StorageURLModifier {
+  public:
+    virtual ~StorageURLModifier() = default;
+
+    virtual void modify(SciTagCategory sciTagCategory, std::string& url) const = 0;
+  };
+
+}  // namespace edm
+
+#endif

--- a/FWCore/Catalog/test/InputFileCatalog_t.cpp
+++ b/FWCore/Catalog/test/InputFileCatalog_t.cpp
@@ -1,13 +1,19 @@
+#include <string>
+#include <vector>
+
 #include "FWCore/Catalog/interface/InputFileCatalog.h"
+#include "FWCore/Catalog/interface/StorageURLModifier.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 
 #include "TestSiteLocalConfig.h"
+#include "TestScitagConfig.h"
 
 #include "catch2/catch_all.hpp"
 
 TEST_CASE("InputFileCatalog with Rucio data catalog", "[FWCore/Catalog]") {
   edm::ServiceToken tempToken = edmtest::catalog::makeTestSiteLocalConfigToken();
+  edm::ServiceToken testToken = edmtest::catalog::makeTestScitagConfigToken(tempToken);
 
   SECTION("Empty") {
     edm::ServiceRegistry::Operate operate(tempToken);
@@ -21,9 +27,15 @@ TEST_CASE("InputFileCatalog with Rucio data catalog", "[FWCore/Catalog]") {
     REQUIRE(edm::InputFileCatalog::isPhysical("file:/foo/bar"));
   }
 
-  SECTION("Default behavior") {
-    edm::ServiceRegistry::Operate operate(tempToken);
+  // NOTE: This file is testing InputFileCatalog and it is not intended
+  // to test the ScitagConfig service itself (there is a separate unit test
+  // for that elsewhere). It is using a test replacement for the ScitagConfig
+  // service NOT the actual ScitagConfig service.
 
+  SECTION("Default behavior") {
+    edm::ServiceRegistry::Operate operate(testToken);
+
+    // Default SciTagCategory is Primary
     edm::InputFileCatalog catalog(std::vector<std::string>{"/store/foo/bar", "   file:/foo/bar", "root://foobar "}, "");
     REQUIRE(!catalog.empty());
 
@@ -31,9 +43,9 @@ TEST_CASE("InputFileCatalog with Rucio data catalog", "[FWCore/Catalog]") {
       SECTION("Catalog 0") {
         auto const names = catalog.fileNames(0);
         REQUIRE(names.size() == 3);
-        CHECK(names[0] == "root://cmsxrootd.fnal.gov/store/foo/bar");
+        CHECK(names[0] == "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=196664");
         CHECK(names[1] == "file:/foo/bar");
-        CHECK(names[2] == "root://foobar");
+        CHECK(names[2] == "root://foobar?scitag.flow=196664");
       }
       // The fileNames() works only for catalog 0
       // Catalog 1 or 2 leads to a crash because the input file list
@@ -53,20 +65,70 @@ TEST_CASE("InputFileCatalog with Rucio data catalog", "[FWCore/Catalog]") {
       REQUIRE(items[2].fileNames().size() == 1);
 
       SECTION("Catalog 0") {
-        CHECK(items[0].fileName(0) == "root://cmsxrootd.fnal.gov/store/foo/bar");
+        CHECK(items[0].fileName(0) == "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=196664");
         CHECK(items[1].fileName(0) == "file:/foo/bar");
-        CHECK(items[2].fileName(0) == "root://foobar");
+        CHECK(items[2].fileName(0) == "root://foobar?scitag.flow=196664");
       }
       SECTION("Catalog 1") {
-        CHECK(items[0].fileName(1) == "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar");
-        CHECK(items[0].fileNames()[1] == "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar");
+        CHECK(items[0].fileName(1) == "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar?scitag.flow=196664");
+        CHECK(items[0].fileNames()[1] ==
+              "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar?scitag.flow=196664");
       }
-      SECTION("Catalog 2") { CHECK(items[0].fileName(2) == "root://host.domain//pnfs/cms/store/foo/bar"); }
+      SECTION("Catalog 2") {
+        CHECK(items[0].fileName(2) == "root://host.domain//pnfs/cms/store/foo/bar?scitag.flow=196664");
+      }
     }
   }
 
-  SECTION("Override catalog") {
+  SECTION("Embedded behavior") {
+    edm::ServiceRegistry::Operate operate(testToken);
+
+    edm::InputFileCatalog catalog(std::vector<std::string>{"   file:/foo/bar", "/store/foo/bar", "root://foobar "},
+                                  "",
+                                  false,
+                                  edm::SciTagCategory::Embedded);
+    REQUIRE(!catalog.empty());
+
+    SECTION("fileCatalogItems") {
+      auto const& items = catalog.fileCatalogItems();
+      SECTION("Embedded Catalog 0") {
+        CHECK(items[0].fileName(0) == "file:/foo/bar");
+        CHECK(items[1].fileName(0) == "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=196700");
+        CHECK(items[2].fileName(0) == "root://foobar?scitag.flow=196700");
+      }
+      SECTION("Embedded Catalog 1") {
+        CHECK(items[1].fileName(1) == "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar?scitag.flow=196700");
+      }
+      SECTION("Embedded Catalog 2") {
+        CHECK(items[1].fileName(2) == "root://host.domain//pnfs/cms/store/foo/bar?scitag.flow=196700");
+      }
+    }
+  }
+
+  SECTION("PreMixedPileup behavior") {
+    edm::ServiceRegistry::Operate operate(testToken);
+
+    edm::InputFileCatalog catalog(std::vector<std::string>{"   file:/foo/bar", "/store/foo/bar", "root://foobar "},
+                                  "",
+                                  false,
+                                  edm::SciTagCategory::PreMixedPileup);
+    auto const& items = catalog.fileCatalogItems();
+    CHECK(items[1].fileName(0) == "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=196704");
+  }
+
+  SECTION("Behavior of 'Undefined' category") {
     edm::ServiceRegistry::Operate operate(tempToken);
+
+    edm::InputFileCatalog catalog(std::vector<std::string>{"   file:/foo/bar", "/store/foo/bar", "root://foobar "},
+                                  "",
+                                  false,
+                                  edm::SciTagCategory::Undefined);
+    auto const& items = catalog.fileCatalogItems();
+    CHECK(items[1].fileName(0) == "root://cmsxrootd.fnal.gov/store/foo/bar");
+  }
+
+  SECTION("Override catalog") {
+    edm::ServiceRegistry::Operate operate(testToken);
 
     edm::InputFileCatalog catalog(std::vector<std::string>{"/store/foo/bar", "   file:/foo/bar", "root://foobar "},
                                   "T1_US_FNAL,,T1_US_FNAL,FNAL_dCache_EOS,XRootD");
@@ -74,9 +136,9 @@ TEST_CASE("InputFileCatalog with Rucio data catalog", "[FWCore/Catalog]") {
     SECTION("fileNames") {
       auto const names = catalog.fileNames(0);
       REQUIRE(names.size() == 3);
-      CHECK(names[0] == "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar");
+      CHECK(names[0] == "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar?scitag.flow=196664");
       CHECK(names[1] == "file:/foo/bar");
-      CHECK(names[2] == "root://foobar");
+      CHECK(names[2] == "root://foobar?scitag.flow=196664");
     }
 
     SECTION("fileCatalogItems") {
@@ -91,25 +153,26 @@ TEST_CASE("InputFileCatalog with Rucio data catalog", "[FWCore/Catalog]") {
       REQUIRE(items[1].fileNames().size() == 1);
       REQUIRE(items[2].fileNames().size() == 1);
 
-      CHECK(items[0].fileName(0) == "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar");
+      CHECK(items[0].fileName(0) == "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar?scitag.flow=196664");
       CHECK(items[1].fileName(0) == "file:/foo/bar");
-      CHECK(items[2].fileName(0) == "root://foobar");
+      CHECK(items[2].fileName(0) == "root://foobar?scitag.flow=196664");
     }
   }
 
   SECTION("useLFNasPFNifLFNnotFound") {
-    edm::ServiceRegistry::Operate operate(tempToken);
+    edm::ServiceRegistry::Operate operate(testToken);
 
+    bool useLFNasPFNifLFNnotFound = true;
     edm::InputFileCatalog catalog(
-        std::vector<std::string>{"/store/foo/bar", "/tmp/foo/bar", "root://foobar "}, "", true);
+        std::vector<std::string>{"/store/foo/bar", "/tmp/foo/bar", "root://foobar "}, "", useLFNasPFNifLFNnotFound);
 
     SECTION("fileNames") {
       SECTION("Catalog 0") {
         auto const names = catalog.fileNames(0);
         REQUIRE(names.size() == 3);
-        CHECK(names[0] == "root://cmsxrootd.fnal.gov/store/foo/bar");
+        CHECK(names[0] == "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=196664");
         CHECK(names[1] == "/tmp/foo/bar");
-        CHECK(names[2] == "root://foobar");
+        CHECK(names[2] == "root://foobar?scitag.flow=196664");
       }
     }
 
@@ -125,16 +188,16 @@ TEST_CASE("InputFileCatalog with Rucio data catalog", "[FWCore/Catalog]") {
       REQUIRE(items[2].fileNames().size() == 1);
 
       SECTION("Catalog 0") {
-        CHECK(items[0].fileName(0) == "root://cmsxrootd.fnal.gov/store/foo/bar");
+        CHECK(items[0].fileName(0) == "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=196664");
         CHECK(items[1].fileName(0) == "/tmp/foo/bar");
-        CHECK(items[2].fileName(0) == "root://foobar");
+        CHECK(items[2].fileName(0) == "root://foobar?scitag.flow=196664");
       }
       SECTION("Catalog 1") {
-        CHECK(items[0].fileName(1) == "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar");
+        CHECK(items[0].fileName(1) == "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar?scitag.flow=196664");
         CHECK(items[1].fileName(1) == "/tmp/foo/bar");
       }
       SECTION("Catalog 2") {
-        CHECK(items[0].fileName(2) == "root://host.domain//pnfs/cms/store/foo/bar");
+        CHECK(items[0].fileName(2) == "root://host.domain//pnfs/cms/store/foo/bar?scitag.flow=196664");
         CHECK(items[1].fileName(2) == "/tmp/foo/bar");
       }
     }

--- a/FWCore/Catalog/test/TestScitagConfig.h
+++ b/FWCore/Catalog/test/TestScitagConfig.h
@@ -1,0 +1,34 @@
+#ifndef FWCore_Catalog_test_TestScitagConfig_h
+#define FWCore_Catalog_test_TestScitagConfig_h
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "FWCore/Catalog/interface/StorageURLModifier.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ServiceToken.h"
+
+namespace edmtest::catalog {
+
+  class TestScitagConfig : public edm::StorageURLModifier {
+  public:
+    TestScitagConfig() : testSuffixes_{"?scitag.flow=196664", "?scitag.flow=196700", "?scitag.flow=196704"} {}
+
+    void modify(edm::SciTagCategory sciTagCategory, std::string& url) const override {
+      if (url.starts_with("root:")) {
+        url += testSuffixes_.at(static_cast<unsigned char>(sciTagCategory));
+      }
+    }
+
+  private:
+    std::vector<std::string> testSuffixes_;
+  };
+
+  inline edm::ServiceToken makeTestScitagConfigToken(edm::ServiceToken const& token) {
+    return edm::ServiceToken(edm::ServiceRegistry::createContaining(
+        std::unique_ptr<edm::StorageURLModifier>(std::make_unique<TestScitagConfig>()), token, true));
+  }
+}  // namespace edmtest::catalog
+
+#endif

--- a/FWCore/Framework/src/defaultCmsRunServices.cc
+++ b/FWCore/Framework/src/defaultCmsRunServices.cc
@@ -22,6 +22,7 @@ namespace edm {
                                             "UnixSignalService",
                                             "TFileAdaptor",
                                             "SiteLocalConfigService",
+                                            "ScitagConfig",
                                             "StatisticsSenderService",
                                             "ResourceInformationService",
                                             "CPU",

--- a/FWCore/Sources/interface/SciTagCategoryForEmbeddedSources.h
+++ b/FWCore/Sources/interface/SciTagCategoryForEmbeddedSources.h
@@ -1,0 +1,8 @@
+#ifndef FWCore_Sources_SciTagCategoryForEmbeddedSources_h
+#define FWCore_Sources_SciTagCategoryForEmbeddedSources_h
+
+namespace edm {
+  enum class SciTagCategoryForEmbeddedSources : unsigned char { Embedded, PreMixedPileup };
+}  // namespace edm
+
+#endif

--- a/FWCore/Sources/interface/VectorInputSourceDescription.h
+++ b/FWCore/Sources/interface/VectorInputSourceDescription.h
@@ -8,6 +8,7 @@ a VectorinputSource that does not come in through the ParameterSet
 ----------------------------------------------------------------------*/
 
 #include "FWCore/Framework/interface/PreallocationConfiguration.h"
+#include "FWCore/Sources/interface/SciTagCategoryForEmbeddedSources.h"
 
 #include <memory>
 
@@ -18,11 +19,14 @@ namespace edm {
   struct VectorInputSourceDescription {
     VectorInputSourceDescription() : productRegistry_(nullptr) {}
 
-    VectorInputSourceDescription(std::shared_ptr<ProductRegistry> preg, PreallocationConfiguration const& allocations)
-        : productRegistry_(preg), allocations_(&allocations) {}
+    VectorInputSourceDescription(std::shared_ptr<ProductRegistry> preg,
+                                 PreallocationConfiguration const& allocations,
+                                 SciTagCategoryForEmbeddedSources cat = SciTagCategoryForEmbeddedSources::Embedded)
+        : productRegistry_(preg), allocations_(&allocations), cat_(cat) {}
 
     std::shared_ptr<ProductRegistry> productRegistry_;
     PreallocationConfiguration const* allocations_;
+    SciTagCategoryForEmbeddedSources cat_;
   };
 }  // namespace edm
 

--- a/FWIO/RNTupleTempInput/bin/EdmRNTupleTempFileUtil.cpp
+++ b/FWIO/RNTupleTempInput/bin/EdmRNTupleTempFileUtil.cpp
@@ -14,6 +14,7 @@
 #include "DataFormats/Provenance/interface/BranchType.h"
 #include "FWCore/Catalog/interface/InputFileCatalog.h"
 #include "FWCore/Catalog/interface/SiteLocalConfig.h"
+#include "FWCore/Catalog/interface/StorageURLModifier.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
@@ -134,7 +135,7 @@ int main(int argc, char* argv[]) {
       }
     }
 
-    edm::InputFileCatalog catalog(in, catalogIn, true);
+    edm::InputFileCatalog catalog(in, catalogIn, true, edm::SciTagCategory::Undefined);
     std::vector<std::string> const& filesIn = catalog.fileNames(0);
 
     if (json) {

--- a/FWIO/RNTupleTempInput/bin/EdmRNTupleTempProvDump.cc
+++ b/FWIO/RNTupleTempInput/bin/EdmRNTupleTempProvDump.cc
@@ -13,6 +13,7 @@
 #include "DataFormats/Provenance/interface/StoredProductProvenance.h"
 #include "DataFormats/Provenance/interface/ParentageRegistry.h"
 #include "FWCore/Catalog/interface/InputFileCatalog.h"
+#include "FWCore/Catalog/interface/StorageURLModifier.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
 #include "FWStorage/Services/interface/setupSiteLocalConfig.h"
@@ -190,7 +191,7 @@ namespace {
     std::string override;
     std::vector<std::string> fileNames;
     fileNames.push_back(filename);
-    edm::InputFileCatalog catalog(fileNames, override, true);
+    edm::InputFileCatalog catalog(fileNames, override, true, edm::SciTagCategory::Undefined);
     if (catalog.fileNames(0)[0] == filename) {
       throw cms::Exception("FileNotFound", "RootFile::RootFile()")
           << "File " << filename << " was not found or could not be opened.\n";

--- a/FWIO/RNTupleTempInput/src/EmbeddedRNTupleTempSource.cc
+++ b/FWIO/RNTupleTempInput/src/EmbeddedRNTupleTempSource.cc
@@ -3,10 +3,12 @@
 #include "EmbeddedRNTupleTempSource.h"
 #include "InputFile.h"
 #include "RootEmbeddedFileSequence.h"
+#include "FWCore/Catalog/interface/StorageURLModifier.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Sources/interface/VectorInputSourceDescription.h"
 #include "FWCore/Sources/interface/InputSourceRunHelper.h"
+#include "FWCore/Sources/interface/SciTagCategoryForEmbeddedSources.h"
 
 namespace edm {
 
@@ -43,7 +45,10 @@ namespace edm::rntuple_temp {
         productSelectorRules_(pset, "inputCommands", "InputSource"),
         runHelper_(new DefaultInputSourceRunHelper()),
         catalog_(pset.getUntrackedParameter<std::vector<std::string> >("fileNames"),
-                 pset.getUntrackedParameter<std::string>("overrideCatalog", std::string())),
+                 pset.getUntrackedParameter<std::string>("overrideCatalog", std::string()),
+                 false,
+                 desc.cat_ == SciTagCategoryForEmbeddedSources::PreMixedPileup ? SciTagCategory::PreMixedPileup
+                                                                               : SciTagCategory::Embedded),
         // Note: fileSequence_ needs to be initialized last, because it uses data members
         // initialized previously in its own initialization.
         fileSequence_(new RootEmbeddedFileSequence(pset, *this, catalog_)) {}

--- a/FWStorage/Services/plugins/ScitagConfig.cc
+++ b/FWStorage/Services/plugins/ScitagConfig.cc
@@ -1,0 +1,159 @@
+/**\class edm::service::ScitagConfig
+
+Description: This is the implementation for a service
+that will append scitags to Physical File Names (PFNs).
+The scitags are implemented as CGI parameters that
+are appended to the PFN URL. A scitag looks like
+"?scitag.flow=<scitag_id>", where <scitag_id> is
+a numerical value that identifies a CMS use case.
+
+XRootD is the only protocol that currently supports
+this feature and knows how to use these scitags.
+A PFN that uses XRootD starts with the prefix "root:".
+Currently, for other protocols nothing is appended
+to the PFN (some protocols would ignore the scitag
+and for others its presence would cause an error).
+
+The service can be configured to use different scitags
+for analysis and production use cases. The WM system
+is expected to set the "productionCase" parameter
+appropriately when configuring the service. It defaults
+to the analysis case.
+
+The Framework will automatically select
+a scitag from 3 possible choices.
+
+  - PreMixedPileup scitag: An embedded source run by
+   the PreMixingModule
+  - Embedded scitag: All other embedded sources
+  - Primary scitag: Everything else
+
+For each of the 6 cases (analysis/production x 3 scitag types)
+the numerical value in the scitag can be independently
+configured. The default values are in the fillDescriptions
+function below.
+
+The enable parameter can be used to turn off scitags
+(nothing is appended to the PFN). Independent of that
+a source can use the "Undefined" scitag category
+and that will also disable scitags.
+
+XRootD reads the scitag value from the CGI parameter
+and uses it to label packets it sends out over the network.
+There are network monitoring tools that can use the
+packet labels to analyze network traffic not only for CMS
+but also for many other scientific projects that label
+their network packets in this way. CMS is only responsible
+for setting the scitag value in the PFN sent to XRootD.
+Other organizations handle the network monitoring.
+*/
+//
+// Original Author: W. David Dagenhart
+//         Created: 29 Dec 2025
+
+#include <format>
+#include <string>
+#include <vector>
+
+#include "FWCore/Catalog/interface/StorageURLModifier.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+namespace {
+  constexpr char const* const kXRootPrefix = "root:";
+  // These are the values assigned to CMS.
+  // Values outside this range are used by other organizations.
+  constexpr int kCMSSciTagRangeStart = 196612;
+  constexpr int kCMSSciTagRangeEnd = 196860;
+}  // namespace
+
+namespace edm {
+  namespace service {
+
+    class ScitagConfig : public StorageURLModifier {
+    public:
+      explicit ScitagConfig(ParameterSet const& pset);
+
+      void modify(SciTagCategory sciTagCategory, std::string& url) const override;
+
+      static void fillDescriptions(ConfigurationDescriptions& descriptions);
+
+    private:
+      std::vector<unsigned int> sciTags_;
+      bool enable_;
+    };
+
+    ScitagConfig::ScitagConfig(ParameterSet const& pset) : enable_(pset.getUntrackedParameter<bool>("enable")) {
+      bool productionCase = pset.getUntrackedParameter<bool>("productionCase");
+      if (enable_) {
+        if (productionCase) {
+          ParameterSet productionPSet = pset.getUntrackedParameter<ParameterSet>("production");
+          sciTags_ = {productionPSet.getUntrackedParameter<unsigned int>("primarySciTag"),
+                      productionPSet.getUntrackedParameter<unsigned int>("embeddedSciTag"),
+                      productionPSet.getUntrackedParameter<unsigned int>("preMixedPileupSciTag")};
+        } else {
+          ParameterSet analysisPSet = pset.getUntrackedParameter<ParameterSet>("analysis");
+          sciTags_ = {analysisPSet.getUntrackedParameter<unsigned int>("primarySciTag"),
+                      analysisPSet.getUntrackedParameter<unsigned int>("embeddedSciTag"),
+                      analysisPSet.getUntrackedParameter<unsigned int>("preMixedPileupSciTag")};
+        }
+        for (const auto& tag : sciTags_) {
+          if (tag < kCMSSciTagRangeStart || tag > kCMSSciTagRangeEnd) {
+            throw cms::Exception("ScitagConfig") << "SciTag value " << tag << " is outside the CMS assigned range of "
+                                                 << kCMSSciTagRangeStart << " to " << kCMSSciTagRangeEnd << ".";
+          }
+        }
+      }
+    }
+
+    void ScitagConfig::modify(SciTagCategory sciTagCategory, std::string& url) const {
+      if (!enable_ || sciTagCategory == SciTagCategory::Undefined) {
+        return;
+      }
+
+      if (url.starts_with(kXRootPrefix)) {
+        unsigned char index = static_cast<unsigned char>(sciTagCategory);
+        if (index > static_cast<unsigned char>(SciTagCategory::Undefined)) {
+          // This should never happen unless there is a bug elsewhere
+          throw cms::Exception("ScitagConfig") << "Invalid SciTagCategory value in modify.";
+        }
+
+        // If there are multiple CGI parameters, then only the
+        // first one starts with '?' and rest start with '&'.
+        bool const isFirst = url.find('?') == std::string::npos;
+        url += (isFirst ? '?' : '&');
+        url += "scitag.flow=";
+
+        url.append(std::format("{}", sciTags_[index]));
+      }
+    }
+
+    void ScitagConfig::fillDescriptions(ConfigurationDescriptions& descriptions) {
+      ParameterSetDescription desc;
+
+      ParameterSetDescription analysisDesc;
+      analysisDesc.addUntracked<unsigned int>("primarySciTag", 196664);
+      analysisDesc.addUntracked<unsigned int>("embeddedSciTag", 196700);
+      analysisDesc.addUntracked<unsigned int>("preMixedPileupSciTag", 196704);
+      desc.addUntracked<ParameterSetDescription>("analysis", analysisDesc);
+
+      ParameterSetDescription productionDesc;
+      productionDesc.addUntracked<unsigned int>("primarySciTag", 196656);
+      productionDesc.addUntracked<unsigned int>("embeddedSciTag", 196700);
+      productionDesc.addUntracked<unsigned int>("preMixedPileupSciTag", 196704);
+      desc.addUntracked<ParameterSetDescription>("production", productionDesc);
+
+      desc.addUntracked<bool>("enable", true);
+      desc.addUntracked<bool>("productionCase", false);
+
+      descriptions.add("ScitagConfig", desc);
+    }
+  }  // namespace service
+}  // namespace edm
+
+using edm::service::ScitagConfig;
+using StorageURLModifierMaker = edm::serviceregistry::ParameterSetMaker<edm::StorageURLModifier, ScitagConfig>;
+DEFINE_FWK_SERVICE_MAKER(ScitagConfig, StorageURLModifierMaker);

--- a/FWStorage/Services/test/BuildFile.xml
+++ b/FWStorage/Services/test/BuildFile.xml
@@ -9,4 +9,5 @@
 <bin file="test_catch2_*.cc" name="testFWStorageServicesCatch2">
   <use name="catch2"/>
   <use name="FWStorage/Services"/>
+  <use name="FWCore/PluginManager"/>
 </bin>

--- a/FWStorage/Services/test/test_catch2_ScitagConfig.cc
+++ b/FWStorage/Services/test/test_catch2_ScitagConfig.cc
@@ -1,0 +1,206 @@
+#include <string>
+#include <vector>
+
+#include "FWCore/Catalog/interface/StorageURLModifier.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ServiceToken.h"
+
+#define CATCH_CONFIG_MAIN
+#include "catch2/catch_all.hpp"
+
+void configurePluginManagerOnce() {
+  static bool configured = false;
+  if (!configured) {
+    edmplugin::PluginManager::configure(edmplugin::standard::config());
+    configured = true;
+  }
+}
+
+TEST_CASE("Test ScitagConfig", "[scitagconfig]") {
+  configurePluginManagerOnce();
+
+  edm::ParameterSet defaultPSet;
+  std::string typeName("ScitagConfig");
+  defaultPSet.addParameter("@service_type", typeName);
+
+  SECTION("scitagconfig default parameters") {
+    std::vector<edm::ParameterSet> psets = {defaultPSet};
+    edm::ServiceToken token = edm::ServiceRegistry::createSet(psets);
+    edm::ServiceRegistry::Operate operate(token);
+
+    edm::Service<edm::StorageURLModifier> scitagConfig;
+
+    std::string pfn1 = "root://example.com//store/data/file.root";
+    scitagConfig->modify(edm::SciTagCategory::Primary, pfn1);
+    CHECK(pfn1 == "root://example.com//store/data/file.root?scitag.flow=196664");
+
+    std::string pfn2 = "root://example.com//store/data/file.root";
+    scitagConfig->modify(edm::SciTagCategory::Embedded, pfn2);
+    CHECK(pfn2 == "root://example.com//store/data/file.root?scitag.flow=196700");
+
+    std::string pfn3 = "root://example.com//store/data/file.root";
+    scitagConfig->modify(edm::SciTagCategory::PreMixedPileup, pfn3);
+    CHECK(pfn3 == "root://example.com//store/data/file.root?scitag.flow=196704");
+  }
+
+  SECTION("scitagconfig default parameters except production case") {
+    edm::ParameterSet pset = defaultPSet;
+    pset.addUntrackedParameter<bool>("productionCase", true);
+
+    std::vector<edm::ParameterSet> psets = {pset};
+    edm::ServiceToken token = edm::ServiceRegistry::createSet(psets);
+    edm::ServiceRegistry::Operate operate(token);
+
+    edm::Service<edm::StorageURLModifier> scitagConfig;
+
+    std::string pfn1 = "root://example.com//store/data/file.root";
+    scitagConfig->modify(edm::SciTagCategory::Primary, pfn1);
+    CHECK(pfn1 == "root://example.com//store/data/file.root?scitag.flow=196656");
+
+    std::string pfn2 = "root://example.com//store/data/file.root";
+    scitagConfig->modify(edm::SciTagCategory::Embedded, pfn2);
+    CHECK(pfn2 == "root://example.com//store/data/file.root?scitag.flow=196700");
+
+    std::string pfn3 = "root://example.com//store/data/file.root";
+    scitagConfig->modify(edm::SciTagCategory::PreMixedPileup, pfn3);
+    CHECK(pfn3 == "root://example.com//store/data/file.root?scitag.flow=196704");
+  }
+
+  SECTION("scitagconfig analysis case") {
+    edm::ParameterSet pset = defaultPSet;
+    pset.addUntrackedParameter<bool>("enable", true);
+    pset.addUntrackedParameter<bool>("productionCase", false);
+    edm::ParameterSet analysisPSet;
+    analysisPSet.addUntrackedParameter<unsigned int>("primarySciTag", 196612);
+    analysisPSet.addUntrackedParameter<unsigned int>("embeddedSciTag", 196860);
+    analysisPSet.addUntrackedParameter<unsigned int>("preMixedPileupSciTag", 196705);
+    pset.addUntrackedParameter<edm::ParameterSet>("analysis", analysisPSet);
+    edm::ParameterSet productionPSet;
+    productionPSet.addUntrackedParameter<unsigned int>("primarySciTag", 396656);
+    productionPSet.addUntrackedParameter<unsigned int>("embeddedSciTag", 396700);
+    productionPSet.addUntrackedParameter<unsigned int>("preMixedPileupSciTag", 396704);
+    pset.addUntrackedParameter<edm::ParameterSet>("production", productionPSet);
+
+    std::vector<edm::ParameterSet> psets = {pset};
+    edm::ServiceToken token = edm::ServiceRegistry::createSet(psets);
+    edm::ServiceRegistry::Operate operate(token);
+
+    edm::Service<edm::StorageURLModifier> scitagConfig;
+
+    std::string pfn1 = "root://example.com//store/data/file.root";
+    scitagConfig->modify(edm::SciTagCategory::Primary, pfn1);
+    CHECK(pfn1 == "root://example.com//store/data/file.root?scitag.flow=196612");
+
+    std::string pfn2 = "root://example.com//store/data/file.root";
+    scitagConfig->modify(edm::SciTagCategory::Embedded, pfn2);
+    CHECK(pfn2 == "root://example.com//store/data/file.root?scitag.flow=196860");
+
+    std::string pfn3 = "root://example.com//store/data/file.root";
+    scitagConfig->modify(edm::SciTagCategory::PreMixedPileup, pfn3);
+    CHECK(pfn3 == "root://example.com//store/data/file.root?scitag.flow=196705");
+
+    std::string pfn4 = "root://example.com//store/data/file.root";
+    scitagConfig->modify(edm::SciTagCategory::Undefined, pfn4);
+    CHECK(pfn4 == "root://example.com//store/data/file.root");
+
+    std::string pfn5 = "file://example.com//store/data/file.root";
+    scitagConfig->modify(edm::SciTagCategory::Primary, pfn5);
+    CHECK(pfn5 == "file://example.com//store/data/file.root");
+
+    std::string pfn6 = "file.root";
+    scitagConfig->modify(edm::SciTagCategory::Primary, pfn6);
+    CHECK(pfn6 == "file.root");
+
+    std::string pfn7 = "root://example.com//store/data/file.root?eos.app=cmst0";
+    scitagConfig->modify(edm::SciTagCategory::Primary, pfn7);
+    CHECK(pfn7 == "root://example.com//store/data/file.root?eos.app=cmst0&scitag.flow=196612");
+
+    std::string pfn8 = "root://example.com//store/data/file.root?eos.app=cmst0";
+    CHECK_THROWS(scitagConfig->modify(static_cast<edm::SciTagCategory>(4), pfn8));
+  }
+
+  SECTION("scitagconfig production case") {
+    edm::ParameterSet pset = defaultPSet;
+    pset.addUntrackedParameter<bool>("productionCase", true);
+    edm::ParameterSet productionPSet;
+    productionPSet.addUntrackedParameter<unsigned int>("primarySciTag", 196656);
+    productionPSet.addUntrackedParameter<unsigned int>("embeddedSciTag", 196702);
+    productionPSet.addUntrackedParameter<unsigned int>("preMixedPileupSciTag", 196706);
+    pset.addUntrackedParameter<edm::ParameterSet>("production", productionPSet);
+
+    std::vector<edm::ParameterSet> psets = {pset};
+    edm::ServiceToken token = edm::ServiceRegistry::createSet(psets);
+    edm::ServiceRegistry::Operate operate(token);
+
+    edm::Service<edm::StorageURLModifier> scitagConfig;
+
+    std::string pfn1 = "root://example.com//store/data/file.root";
+    scitagConfig->modify(edm::SciTagCategory::Primary, pfn1);
+    CHECK(pfn1 == "root://example.com//store/data/file.root?scitag.flow=196656");
+
+    std::string pfn2 = "root://example.com//store/data/file.root";
+    scitagConfig->modify(edm::SciTagCategory::Embedded, pfn2);
+    CHECK(pfn2 == "root://example.com//store/data/file.root?scitag.flow=196702");
+
+    std::string pfn3 = "root://example.com//store/data/file.root";
+    scitagConfig->modify(edm::SciTagCategory::PreMixedPileup, pfn3);
+    CHECK(pfn3 == "root://example.com//store/data/file.root?scitag.flow=196706");
+
+    std::string pfn4 = "root://example.com//store/data/file.root";
+    scitagConfig->modify(edm::SciTagCategory::Undefined, pfn4);
+    CHECK(pfn4 == "root://example.com//store/data/file.root");
+
+    std::string pfn5 = "file://example.com//store/data/file.root";
+    scitagConfig->modify(edm::SciTagCategory::Primary, pfn5);
+    CHECK(pfn5 == "file://example.com//store/data/file.root");
+
+    std::string pfn6 = "file.root";
+    scitagConfig->modify(edm::SciTagCategory::Primary, pfn6);
+    CHECK(pfn6 == "file.root");
+
+    std::string pfn7 = "root://example.com//store/data/file.root?eos.app=cmst0";
+    scitagConfig->modify(edm::SciTagCategory::Primary, pfn7);
+    CHECK(pfn7 == "root://example.com//store/data/file.root?eos.app=cmst0&scitag.flow=196656");
+  }
+
+  SECTION("scitagconfig enable is false") {
+    edm::ParameterSet pset = defaultPSet;
+    pset.addUntrackedParameter<bool>("enable", false);
+
+    std::vector<edm::ParameterSet> psets = {pset};
+    edm::ServiceToken token = edm::ServiceRegistry::createSet(psets);
+    edm::ServiceRegistry::Operate operate(token);
+
+    edm::Service<edm::StorageURLModifier> scitagConfig;
+
+    std::string pfn = "root://example.com//store/data/file.root";
+    scitagConfig->modify(edm::SciTagCategory::Primary, pfn);
+    CHECK(pfn == "root://example.com//store/data/file.root");
+  }
+
+  SECTION("scitagconfig out of range low case") {
+    edm::ParameterSet pset = defaultPSet;
+
+    edm::ParameterSet analysisPSet;
+    analysisPSet.addUntrackedParameter<unsigned int>("primarySciTag", 196611);
+    pset.addUntrackedParameter<edm::ParameterSet>("analysis", analysisPSet);
+
+    std::vector<edm::ParameterSet> psets = {pset};
+    CHECK_THROWS(edm::ServiceRegistry::createSet(psets));
+  }
+
+  SECTION("scitagconfig out of range high case") {
+    edm::ParameterSet pset = defaultPSet;
+
+    edm::ParameterSet analysisPSet;
+    analysisPSet.addUntrackedParameter<unsigned int>("embeddedSciTag", 196861);
+    pset.addUntrackedParameter<edm::ParameterSet>("analysis", analysisPSet);
+
+    std::vector<edm::ParameterSet> psets = {pset};
+    CHECK_THROWS(edm::ServiceRegistry::createSet(psets));
+  }
+}

--- a/FWStorage/Services/test/test_sitelocalconfig_catalog_cfg.py
+++ b/FWStorage/Services/test/test_sitelocalconfig_catalog_cfg.py
@@ -9,12 +9,12 @@ process.tester = cms.EDAnalyzer("SiteLocalConfigServiceCatalogTester",
         cms.untracked.PSet(
             file = cms.untracked.string("/store/a/b.root"),
             catalogIndex = cms.untracked.uint32(0),
-            expectResult = cms.untracked.string("root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/a/b.root")
+            expectResult = cms.untracked.string("root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/a/b.root?scitag.flow=196664")
         ),
         cms.untracked.PSet(
             file = cms.untracked.string("/store/a/b.root"),
             catalogIndex = cms.untracked.uint32(1),
-            expectResult = cms.untracked.string("root://xrootd-cms.infn.it//store/a/b.root")
+            expectResult = cms.untracked.string("root://xrootd-cms.infn.it//store/a/b.root?scitag.flow=196664")
         ),
     )
 )

--- a/IOPool/Common/bin/EdmCopyUtil.cpp
+++ b/IOPool/Common/bin/EdmCopyUtil.cpp
@@ -18,6 +18,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Catalog/interface/InputFileCatalog.h"
 #include "FWCore/Catalog/interface/SiteLocalConfig.h"
+#include "FWCore/Catalog/interface/StorageURLModifier.h"
 
 static int copy_files(const boost::program_options::variables_map& vm) {
   auto operate = edm::setupSiteLocalConfig();
@@ -39,7 +40,7 @@ static int copy_files(const boost::program_options::variables_map& vm) {
   }
 
   std::string catalogIn = (vm.count("catalog") ? vm["catalog"].as<std::string>() : std::string());
-  edm::InputFileCatalog catalog(in, catalogIn, true);
+  edm::InputFileCatalog catalog(in, catalogIn, true, edm::SciTagCategory::Undefined);
   std::vector<std::string> const& filesIn = catalog.fileNames(0);
 
   for (unsigned int j = 0; j < in.size(); ++j) {

--- a/IOPool/Common/bin/EdmFileUtil.cpp
+++ b/IOPool/Common/bin/EdmFileUtil.cpp
@@ -14,6 +14,7 @@
 #include "DataFormats/Provenance/interface/BranchType.h"
 #include "FWCore/Catalog/interface/InputFileCatalog.h"
 #include "FWCore/Catalog/interface/SiteLocalConfig.h"
+#include "FWCore/Catalog/interface/StorageURLModifier.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
@@ -131,7 +132,7 @@ int main(int argc, char* argv[]) {
       }
     }
 
-    edm::InputFileCatalog catalog(in, catalogIn, true);
+    edm::InputFileCatalog catalog(in, catalogIn, true, edm::SciTagCategory::Undefined);
     std::vector<std::string> const& filesIn = catalog.fileNames(0);
 
     if (json) {

--- a/IOPool/Common/bin/EdmProvDump.cc
+++ b/IOPool/Common/bin/EdmProvDump.cc
@@ -13,6 +13,7 @@
 #include "DataFormats/Provenance/interface/StoredProductProvenance.h"
 #include "DataFormats/Provenance/interface/ParentageRegistry.h"
 #include "FWCore/Catalog/interface/InputFileCatalog.h"
+#include "FWCore/Catalog/interface/StorageURLModifier.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
 #include "FWStorage/Services/interface/setupSiteLocalConfig.h"
@@ -188,7 +189,7 @@ namespace {
     std::string override;
     std::vector<std::string> fileNames;
     fileNames.push_back(filename);
-    edm::InputFileCatalog catalog(fileNames, override, true);
+    edm::InputFileCatalog catalog(fileNames, override, true, edm::SciTagCategory::Undefined);
     if (catalog.fileNames(0)[0] == filename) {
       throw cms::Exception("FileNotFound", "RootFile::RootFile()")
           << "File " << filename << " was not found or could not be opened.\n";

--- a/IOPool/Common/test/test_catch2_output2input.cc
+++ b/IOPool/Common/test/test_catch2_output2input.cc
@@ -39,6 +39,7 @@ process = TestSourceProcess()
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(''))
 process.add_(cms.Service("InitRootHandlers"))
 process.add_(cms.Service("SiteLocalConfigService"))
+process.add_(cms.Service("ScitagConfig"))
 process.add_(cms.Service("JobReportService"))
     )_"};
 

--- a/IOPool/Input/src/EmbeddedRootSource.cc
+++ b/IOPool/Input/src/EmbeddedRootSource.cc
@@ -3,10 +3,12 @@
 #include "EmbeddedRootSource.h"
 #include "InputFile.h"
 #include "RootEmbeddedFileSequence.h"
+#include "FWCore/Catalog/interface/StorageURLModifier.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Sources/interface/VectorInputSourceDescription.h"
 #include "FWCore/Sources/interface/InputSourceRunHelper.h"
+#include "FWCore/Sources/interface/SciTagCategoryForEmbeddedSources.h"
 
 namespace edm {
 
@@ -31,7 +33,10 @@ namespace edm {
         productSelectorRules_(pset, "inputCommands", "InputSource"),
         runHelper_(new DefaultInputSourceRunHelper()),
         catalog_(pset.getUntrackedParameter<std::vector<std::string> >("fileNames"),
-                 pset.getUntrackedParameter<std::string>("overrideCatalog", std::string())),
+                 pset.getUntrackedParameter<std::string>("overrideCatalog", std::string()),
+                 false,
+                 desc.cat_ == SciTagCategoryForEmbeddedSources::PreMixedPileup ? SciTagCategory::PreMixedPileup
+                                                                               : SciTagCategory::Embedded),
         // Note: fileSequence_ needs to be initialized last, because it uses data members
         // initialized previously in its own initialization.
         fileSequence_(new RootEmbeddedFileSequence(pset, *this, catalog_)) {}

--- a/IOPool/Streamer/test/ReadStreamerFile.cpp
+++ b/IOPool/Streamer/test/ReadStreamerFile.cpp
@@ -30,6 +30,7 @@ Disclaimer: Most of the code here is randomly written during
 #include "IOPool/Streamer/interface/StreamerInputFile.h"
 #include "FWCore/Catalog/interface/InputFileCatalog.h"
 #include "FWCore/Catalog/interface/SiteLocalConfig.h"
+#include "FWCore/Catalog/interface/StorageURLModifier.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
@@ -80,7 +81,7 @@ int readMultipleStreams(bool verbose) {
     streamFiles.push_back("file:teststreamfile.dat");
     streamFiles.push_back("file:teststreamfile.dat");
 
-    edm::InputFileCatalog catalog(streamFiles, "");
+    edm::InputFileCatalog catalog(streamFiles, "", false, edm::SciTagCategory::Undefined);
 
     StreamerInputFile stream_reader(catalog.fileCatalogItems());
 
@@ -126,7 +127,7 @@ int readInvalidLFN(bool verbose) {
     std::vector<std::string> streamFiles;
     streamFiles.push_back("teststreamfile.dat");
 
-    edm::InputFileCatalog catalog(streamFiles, "");
+    edm::InputFileCatalog catalog(streamFiles, "", false, edm::SciTagCategory::Undefined);
 
     StreamerInputFile stream_reader(catalog.fileCatalogItems());
 

--- a/Mixing/Base/interface/BMixingModule.h
+++ b/Mixing/Base/interface/BMixingModule.h
@@ -20,6 +20,7 @@
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Sources/interface/SciTagCategoryForEmbeddedSources.h"
 #include "Mixing/Base/interface/PileUp.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "CondFormats/DataRecord/interface/MixingRcd.h"
@@ -41,7 +42,9 @@ namespace edm {
   class BMixingModule : public stream::EDProducer<GlobalCache<MixingCache::Config>> {
   public:
     /** standard constructor*/
-    explicit BMixingModule(const edm::ParameterSet& ps, MixingCache::Config const* globalConf);
+    explicit BMixingModule(const edm::ParameterSet& ps,
+                           MixingCache::Config const* globalConf,
+                           SciTagCategoryForEmbeddedSources cat = SciTagCategoryForEmbeddedSources::Embedded);
 
     /**Default destructor*/
     ~BMixingModule() override;

--- a/Mixing/Base/interface/PileUp.h
+++ b/Mixing/Base/interface/PileUp.h
@@ -7,6 +7,7 @@
 #include <optional>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Sources/interface/SciTagCategoryForEmbeddedSources.h"
 #include "FWCore/Sources/interface/VectorInputSource.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "DataFormats/Provenance/interface/EventID.h"
@@ -47,7 +48,8 @@ namespace edm {
     explicit PileUp(ParameterSet const& pset,
                     const std::shared_ptr<PileUpConfig>& config,
                     edm::ConsumesCollector iC,
-                    const bool mixingConfigFromDB);
+                    const bool mixingConfigFromDB,
+                    SciTagCategoryForEmbeddedSources cat = SciTagCategoryForEmbeddedSources::Embedded);
     ~PileUp();
 
     template <typename T>

--- a/Mixing/Base/src/BMixingModule.cc
+++ b/Mixing/Base/src/BMixingModule.cc
@@ -177,7 +177,9 @@ namespace {
 namespace edm {
 
   // Constructor
-  BMixingModule::BMixingModule(const edm::ParameterSet& pset, MixingCache::Config const* globalConf)
+  BMixingModule::BMixingModule(const edm::ParameterSet& pset,
+                               MixingCache::Config const* globalConf,
+                               SciTagCategoryForEmbeddedSources cat)
       : bunchSpace_(globalConf->bunchSpace_),
         vertexOffset_(0),
         minBunch_(globalConf->minBunch_),
@@ -191,7 +193,7 @@ namespace edm {
         const edm::ParameterSet& psin =
             pset.getParameter<edm::ParameterSet>(globalConf->inputConfigs_[makeIdx]->sourcename_);
         inputSources_.push_back(
-            std::make_shared<PileUp>(psin, globalConf->inputConfigs_[makeIdx], consumesCollector(), readDB_));
+            std::make_shared<PileUp>(psin, globalConf->inputConfigs_[makeIdx], consumesCollector(), readDB_, cat));
         inputSources_.back()->input(makeIdx);
       } else {
         inputSources_.push_back(nullptr);

--- a/Mixing/Base/src/PileUp.cc
+++ b/Mixing/Base/src/PileUp.cc
@@ -70,7 +70,8 @@ namespace edm {
   PileUp::PileUp(ParameterSet const& pset,
                  const std::shared_ptr<PileUpConfig>& config,
                  edm::ConsumesCollector iC,
-                 const bool mixingConfigFromDB)
+                 const bool mixingConfigFromDB,
+                 SciTagCategoryForEmbeddedSources cat)
       : type_(pset.getParameter<std::string>("type")),
         Source_type_(config->sourcename_),
         averageNumber_(config->averageNumber_),
@@ -85,7 +86,8 @@ namespace edm {
         productRegistry_(),
         input_(VectorInputSourceFactory::get()->makeVectorInputSource(
             pset,
-            VectorInputSourceDescription(std::make_shared<edm::ProductRegistry>(), edm::PreallocationConfiguration()))),
+            VectorInputSourceDescription(
+                std::make_shared<edm::ProductRegistry>(), edm::PreallocationConfiguration(), cat))),
         // hardware information is not needed for the "overlay"
         processConfiguration_(std::make_shared<ProcessConfiguration>(
             "@MIXING", getReleaseVersion(), edm::HardwareResourcesDescription())),

--- a/SimGeneral/PreMixingModule/plugins/PreMixingModule.cc
+++ b/SimGeneral/PreMixingModule/plugins/PreMixingModule.cc
@@ -20,7 +20,7 @@
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-
+#include "FWCore/Sources/interface/SciTagCategoryForEmbeddedSources.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "SimDataFormats/CrossingFrame/interface/CrossingFramePlaybackInfoNew.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
@@ -103,7 +103,7 @@ namespace edm {
   };
 
   PreMixingModule::PreMixingModule(const edm::ParameterSet& ps, MixingCache::Config const* globalConf)
-      : BMixingModule(ps, globalConf),
+      : BMixingModule(ps, globalConf, SciTagCategoryForEmbeddedSources::PreMixedPileup),
         puWorker_(ps.getParameter<edm::ParameterSet>("workers").getParameter<edm::ParameterSet>("pileup"),
                   producesCollector(),
                   consumesCollector()),


### PR DESCRIPTION
#### PR description:

Implement network packet labels. See issue #47517 for further discussion and the initial request for this feature. This PR will cause a CGI parameter to be appended to PFNs (Physical File Names) of the form

```"?scitag.flow=<scitag_id>"```

scitag_id  is a string that must be a number in the range 196612 to 196860. This is the range assigned to the CMS organization. Values outside that range are assigned to other organizations.

This only works with XRootD as that is the only protocol that has implemented this feature so far (for other protocols nothing is appended to the PFN). When the CGI parameter is present, XRootD includes packet labels in packets sent out over the network. This allows monitoring of network traffic and identifying network traffic from CMS.

This PR only implements the part of this that adds the CGI parameters to the PFNs. The responsibility for the rest of this monitoring system lies outside the Core software group.

The default values are:

```
Primary input 196664
Production input 196656
PreMixingModule 196704
Embedded input (mixing other than from the PreMixingModule) 196700
```

The Framework will automatically know the type of source being used and this cannot be configured (Primary, Embedded, or Premixing), but the numerical values associated with those source types can be configured to different values.

For production use cases, the Workflow Management system must explicitly configure the value of the configuration parameter ```productionCase``` to true in the new service named ```ScitagConfig```.  One can also configure the 3 values associated with the source type using the same service. The values for the analysis and production use cases can be configured independently.

If configured values are outside the range assigned to CMS then an exception will be thrown.

It is possible for a class using the InputFileCatalog to pass the ```Undefined``` enumeration value as an argument and then nothing is added to the PFN. Some utility executables and tests are modified to do that. In that case, nothing is appended to the PFN

If there is already a CGI tag appended to the PFN, the appended value starts with a "&" instead of "?" (standard CGI convention when there are multiple parameters).

The new ```ScitagConfig``` service was added to the list of default services in ```cmsRun```. It will always run in any cmsRun job even if not configured. Any other executable that uses ```InputFileCatalog``` will either need that service running or need to use the ```Undefined``` enum value in the ```InputFileCatalog``` constructor.

There is enable parameter in the new service that can be configured to turn this off which means nothing is appended to the PFNs and there is no packet labeling.

FYI @stlammel

Resolves https://github.com/cms-sw/framework-team/issues/1616

#### PR validation:

There are new or extended unit tests to verify the proper strings are being appended to the PFN and that the new service is working.

