### PR TITLE
update dqm online scouting unit test

### DIFF
--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -14,7 +14,7 @@
 <test name="TestDQMOnlineClient-hlt_dqm_clientPB" command="runtest.sh hlt_dqm_clientPB-live_cfg.py"/>
 <test name="TestDQMOnlineClient-hlt_dqm_sourceclient" command="runtest.sh hlt_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-ngt_dqm_sourceclient" command="runtest.sh ngt_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-scouting_dqm_sourceclient" command="runtest.sh scouting_dqm_sourceclient-live_cfg.py 392642"/>
+<test name="TestDQMOnlineClient-scouting_dqm_sourceclient" command="runtest.sh scouting_dqm_sourceclient-live_cfg.py 398183"/>
 <test name="TestDQMOnlineClient-info_dqm_sourceclient" command="runtest.sh info_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-l1tstage2_dqm_sourceclient" command="runtest.sh l1tstage2_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-l1tstage2emulator_dqm_sourceclient" command="runtest.sh l1tstage2emulator_dqm_sourceclient-live_cfg.py"/>


### PR DESCRIPTION
#### PR description:

Title says it all, necessary after the merge of https://github.com/cms-sw/cmssw/pull/49715.
See https://github.com/cms-sw/cmssw/pull/49715#issuecomment-3722939573 for a rationale.
To be tested together with the companion `cms-data` PR https://github.com/cms-data/DQM-Integration/pull/16

#### PR validation:

`scram b runtests_TestDQMOnlineClient-scouting_dqm_sourceclient` runs correctly in conjunction of the update of the unit test input files (see https://github.com/cms-data/DQM-Integration/pull/16)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backport to CMSSW_16_0_X (necessary for https://github.com/cms-sw/cmssw/pull/49718)
