### PR TITLE
Use the alpaka Acc concept

### DIFF
--- a/DataFormats/Portable/test/alpaka/test_catch2_heterogeneousDeepCopy.dev.cc
+++ b/DataFormats/Portable/test/alpaka/test_catch2_heterogeneousDeepCopy.dev.cc
@@ -47,7 +47,7 @@ using GenericSoAConstView = GenericSoA::ConstView;
 
 // Kernel for filling the SoA
 struct FillSoA {
-  template <typename TAcc, typename PositionView, typename PCAView>
+  template <alpaka::concepts::Acc TAcc, typename PositionView, typename PCAView>
   ALPAKA_FN_ACC void operator()(TAcc const& acc, PositionView positionView, PCAView pcaView) const {
     constexpr float interval = 0.01f;
     if (cms::alpakatools::once_per_grid(acc))

--- a/HeterogeneousCore/AlpakaInterface/interface/AtomicPairCounter.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/AtomicPairCounter.h
@@ -28,7 +28,7 @@ namespace cms::alpakatools {
     ALPAKA_FN_HOST_ACC constexpr Counters get() const { return counter_.as_counters; }
 
     // atomically add as_counters, and return the previous value
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC ALPAKA_FN_INLINE constexpr Counters add(const TAcc& acc, Counters c) {
       Packer value{pack(c.first, c.second)};
       Packer ret{0};
@@ -38,7 +38,7 @@ namespace cms::alpakatools {
     }
 
     // atomically increment first and add i to second, and return the previous value
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC ALPAKA_FN_INLINE Counters constexpr inc_add(const TAcc& acc, uint32_t i) {
       return add(acc, {1u, i});
     }

--- a/HeterogeneousCore/AlpakaInterface/interface/HistoContainer.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/HistoContainer.h
@@ -18,7 +18,7 @@
 namespace cms::alpakatools {
 
   struct countFromVector {
-    template <typename TAcc, typename Histo, typename T>
+    template <alpaka::concepts::Acc TAcc, typename Histo, typename T>
     ALPAKA_FN_ACC void operator()(const TAcc &acc,
                                   Histo *__restrict__ h,
                                   uint32_t nh,
@@ -37,7 +37,7 @@ namespace cms::alpakatools {
   };
 
   struct fillFromVector {
-    template <typename TAcc, typename Histo, typename T>
+    template <alpaka::concepts::Acc TAcc, typename Histo, typename T>
     ALPAKA_FN_ACC void operator()(const TAcc &acc,
                                   Histo *__restrict__ h,
                                   uint32_t nh,
@@ -55,7 +55,7 @@ namespace cms::alpakatools {
     }
   };
 
-  template <typename TAcc, typename Histo, typename T, typename TQueue>
+  template <alpaka::concepts::Acc TAcc, typename Histo, typename T, typename TQueue>
   ALPAKA_FN_INLINE void fillManyFromVector(Histo *__restrict__ h,
                                            uint32_t nh,
                                            T const *__restrict__ v,
@@ -75,7 +75,7 @@ namespace cms::alpakatools {
     alpaka::exec<TAcc>(queue, workDiv, fillFromVector(), h, nh, v, offsets);
   }
 
-  template <typename TAcc, typename Histo, typename T, typename TQueue>
+  template <alpaka::concepts::Acc TAcc, typename Histo, typename T, typename TQueue>
   ALPAKA_FN_INLINE void fillManyFromVector(Histo *__restrict__ h,
                                            typename Histo::View hv,
                                            uint32_t nh,
@@ -97,7 +97,7 @@ namespace cms::alpakatools {
   }
 
   // iteratate over N bins left and right of the one containing "v"
-  template <typename TAcc, typename Hist, typename V, typename Func>
+  template <alpaka::concepts::Acc TAcc, typename Hist, typename V, typename Func>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void forEachInBins(const TAcc &acc, Hist const &hist, V value, int n, Func func) {
     int bs = Hist::bin(value);
     int be = alpaka::math::min(acc, int(Hist::nbins() - 1), bs + n);
@@ -161,14 +161,14 @@ namespace cms::alpakatools {
       return (t >> shift) & mask;
     }
 
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC ALPAKA_FN_INLINE void count(const TAcc &acc, T t) {
       uint32_t b = bin(t);
       ALPAKA_ASSERT_ACC(b < nbins());
       Base::atomicIncrement(acc, this->off[b]);
     }
 
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC ALPAKA_FN_INLINE void fill(const TAcc &acc, T t, index_type j) {
       uint32_t b = bin(t);
       ALPAKA_ASSERT_ACC(b < nbins());
@@ -177,7 +177,7 @@ namespace cms::alpakatools {
       this->content[w - 1] = j;
     }
 
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC ALPAKA_FN_INLINE void count(const TAcc &acc, T t, uint32_t nh) {
       uint32_t b = bin(t);
       ALPAKA_ASSERT_ACC(b < nbins());
@@ -186,7 +186,7 @@ namespace cms::alpakatools {
       Base::atomicIncrement(acc, this->off[b]);
     }
 
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC ALPAKA_FN_INLINE void fill(const TAcc &acc, T t, index_type j, uint32_t nh) {
       uint32_t b = bin(t);
       ALPAKA_ASSERT_ACC(b < nbins());

--- a/HeterogeneousCore/AlpakaInterface/interface/SimpleVector.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/SimpleVector.h
@@ -56,7 +56,7 @@ namespace cms::alpakatools {
     }
 
     // thread-safe version of the vector, when used in a CUDA kernel
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC int push_back(const TAcc &acc, const T &element) {
       auto previousSize = alpaka::atomicAdd(acc, &m_size, 1, alpaka::hierarchy::Blocks{});
       if (previousSize < m_capacity) {
@@ -68,7 +68,7 @@ namespace cms::alpakatools {
       }
     }
 
-    template <typename TAcc, class... Ts>
+    template <alpaka::concepts::Acc TAcc, class... Ts>
     ALPAKA_FN_ACC int emplace_back(const TAcc &acc, Ts &&...args) {
       auto previousSize = alpaka::atomicAdd(acc, &m_size, 1, alpaka::hierarchy::Blocks{});
       if (previousSize < m_capacity) {
@@ -81,7 +81,7 @@ namespace cms::alpakatools {
     }
 
     // thread safe version of resize
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC int extend(const TAcc &acc, int size = 1) {
       auto previousSize = alpaka::atomicAdd(acc, &m_size, size, alpaka::hierarchy::Blocks{});
       if (previousSize < m_capacity) {
@@ -92,7 +92,7 @@ namespace cms::alpakatools {
       }
     }
 
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC int shrink(const TAcc &acc, int size = 1) {
       auto previousSize = alpaka::atomicSub(acc, &m_size, size, alpaka::hierarchy::Blocks{});
       if (previousSize >= size) {

--- a/HeterogeneousCore/AlpakaInterface/interface/VecArray.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/VecArray.h
@@ -57,7 +57,7 @@ namespace cms::alpakatools {
     }
 
     // thread-safe version of the vector, when used in a kernel
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC int push_back(const TAcc &acc, const T &element) {
       auto previousSize = alpaka::atomicAdd(acc, &m_size, 1, alpaka::hierarchy::Blocks{});
       if (previousSize < maxSize) {
@@ -69,7 +69,7 @@ namespace cms::alpakatools {
       }
     }
 
-    template <typename TAcc, class... Ts>
+    template <alpaka::concepts::Acc TAcc, class... Ts>
     ALPAKA_FN_ACC int emplace_back(const TAcc &acc, Ts &&...args) {
       auto previousSize = alpaka::atomicAdd(acc, &m_size, 1, alpaka::hierarchy::Blocks{});
       if (previousSize < maxSize) {

--- a/HeterogeneousCore/AlpakaInterface/interface/atomicMaxF.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/atomicMaxF.h
@@ -7,7 +7,7 @@
 
 // FIXME: this should be rewritten using the correct template specialisation for the different accelerator types
 
-template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
+template <alpaka::concepts::Acc TAcc>
 ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE static float atomicMaxF(const TAcc& acc, float* address, float val) {
 #if defined(__CUDA_ARCH__) or defined(__HIP_DEVICE_COMPILE__)
   // GPU implementation uses __float_as_int / __int_as_float

--- a/HeterogeneousCore/AlpakaInterface/interface/atomicMaxPair.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/atomicMaxPair.h
@@ -6,7 +6,7 @@
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 
 // Note: Does not compile with ALPAKA_FN_ACC on ROCm
-template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>, typename F>
+template <alpaka::concepts::Acc TAcc, typename F>
 ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void atomicMaxPair(const TAcc& acc,
                                                        unsigned long long int* address,
                                                        std::pair<unsigned int, float> value,

--- a/HeterogeneousCore/AlpakaInterface/interface/prefixScan.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/prefixScan.h
@@ -19,7 +19,7 @@ namespace cms::alpakatools {
     return false;
   }
 
-  template <typename TAcc, typename T, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
+  template <alpaka::concepts::Acc TAcc, typename T>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void warpPrefixScan(
       const TAcc& acc, int32_t laneId, T const* ci, T* co, uint32_t i, bool active = true) {
     // ci and co may be the same
@@ -36,14 +36,14 @@ namespace cms::alpakatools {
       co[i] = x;
   }
 
-  template <typename TAcc, typename T, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
+  template <alpaka::concepts::Acc TAcc, typename T>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void warpPrefixScan(
       const TAcc& acc, int32_t laneId, T* c, uint32_t i, bool active = true) {
     warpPrefixScan(acc, laneId, c, c, i, active);
   }
 
   // limited to warpSize² elements
-  template <typename TAcc, typename T>
+  template <alpaka::concepts::Acc TAcc, typename T>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void blockPrefixScan(
       const TAcc& acc, T const* ci, T* co, int32_t size, T* ws = nullptr) {
     if constexpr (!requires_single_thread_per_block_v<TAcc>) {
@@ -88,7 +88,7 @@ namespace cms::alpakatools {
     }
   }
 
-  template <typename TAcc, typename T>
+  template <alpaka::concepts::Acc TAcc, typename T>
   ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void blockPrefixScan(const TAcc& acc,
                                                            T* __restrict__ c,
                                                            int32_t size,
@@ -136,7 +136,7 @@ namespace cms::alpakatools {
   // in principle not limited....
   template <typename T>
   struct multiBlockPrefixScan {
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC void operator()(
         const TAcc& acc, T const* ci, T* co, uint32_t size, int32_t numBlocks, int32_t* pc, std::size_t warpSize) const {
       // Get shared variable. The workspace is needed only for multi-threaded accelerators.
@@ -225,7 +225,7 @@ namespace cms::alpakatools {
 // declare the amount of block shared memory used by the multiBlockPrefixScan kernel
 namespace alpaka::trait {
   // Variable size shared mem
-  template <typename TAcc, typename T>
+  template <alpaka::concepts::Acc TAcc, typename T>
   struct BlockSharedMemDynSizeBytes<cms::alpakatools::multiBlockPrefixScan<T>, TAcc> {
     template <typename TVec>
     ALPAKA_FN_HOST_ACC static std::size_t getBlockSharedMemDynSizeBytes(

--- a/HeterogeneousCore/AlpakaInterface/interface/radixSort.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/radixSort.h
@@ -13,11 +13,11 @@
 
 namespace cms::alpakatools {
 
-  template <typename TAcc, typename T>
+  template <alpaka::concepts::Acc TAcc, typename T>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void dummyReorder(
       const TAcc& acc, T const* a, uint16_t* ind, uint16_t* ind2, uint32_t size) {}
 
-  template <typename TAcc, typename T>
+  template <alpaka::concepts::Acc TAcc, typename T>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void reorderSigned(
       const TAcc& acc, T const* a, uint16_t* ind, uint16_t* ind2, uint32_t size) {
     //move negative first...
@@ -50,7 +50,7 @@ namespace cms::alpakatools {
     }
   }
 
-  template <typename TAcc, typename T>
+  template <alpaka::concepts::Acc TAcc, typename T>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void reorderFloat(
       const TAcc& acc, T const* a, uint16_t* ind, uint16_t* ind2, uint32_t size) {
     //move negative first...
@@ -90,7 +90,7 @@ namespace cms::alpakatools {
   // most significant bit for signed types, integer or floating point).
   // The floating point numbers are reinterpret_cast into integers in the calling wrapper
   // This algorithm requires to run in a single block
-  template <typename TAcc,
+  template <alpaka::concepts::Acc TAcc,
             typename T,   // shall be integer, signed or not does not matter here
             int NS,       // number of significant bytes to use in sorting.
             typename RF>  // The post processing reorder function.
@@ -316,7 +316,7 @@ namespace cms::alpakatools {
     }
   }
 
-  template <typename TAcc,
+  template <alpaka::concepts::Acc TAcc,
             typename T,
             int NS = sizeof(T),  // number of significant bytes to use in sorting
             typename std::enable_if<std::is_unsigned<T>::value && !requires_single_thread_per_block_v<TAcc>, T>::type* =
@@ -326,7 +326,7 @@ namespace cms::alpakatools {
     radixSortImpl<TAcc, T, NS>(acc, a, ind, ind2, size, dummyReorder<TAcc, T>);
   }
 
-  template <typename TAcc,
+  template <alpaka::concepts::Acc TAcc,
             typename T,
             int NS = sizeof(T),  // number of significant bytes to use in sorting
             typename std::enable_if<std::is_integral<T>::value && std::is_signed<T>::value &&
@@ -337,7 +337,7 @@ namespace cms::alpakatools {
     radixSortImpl<TAcc, T, NS>(acc, a, ind, ind2, size, reorderSigned<TAcc, T>);
   }
 
-  template <typename TAcc,
+  template <alpaka::concepts::Acc TAcc,
             typename T,
             int NS = sizeof(T),  // number of significant bytes to use in sorting
             typename std::enable_if<std::is_floating_point<T>::value && !requires_single_thread_per_block_v<TAcc>,
@@ -349,7 +349,7 @@ namespace cms::alpakatools {
     radixSortImpl<TAcc, I, NS>(acc, (I const*)(a), ind, ind2, size, reorderFloat<TAcc, I>);
   }
 
-  template <typename TAcc,
+  template <alpaka::concepts::Acc TAcc,
             typename T,
             int NS = sizeof(T),  // number of significant bytes to use in sorting
             typename std::enable_if<requires_single_thread_per_block_v<TAcc>, T>::type* = nullptr>
@@ -378,7 +378,7 @@ namespace cms::alpakatools {
     */
   }
 
-  template <typename TAcc, typename T, int NS = sizeof(T)>
+  template <alpaka::concepts::Acc TAcc, typename T, int NS = sizeof(T)>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void radixSortMulti(
       const TAcc& acc, T const* v, uint16_t* index, uint32_t const* offsets, uint16_t* workspace) {
     // TODO: check
@@ -403,7 +403,7 @@ namespace cms::alpakatools {
     //__global__ void __launch_bounds__(256, 4)
 #endif
 */
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC void operator()(const TAcc& acc,
                                   T const* v,
                                   uint16_t* index,
@@ -416,7 +416,7 @@ namespace cms::alpakatools {
 
   template <typename T, int NS = sizeof(T)>
   struct radixSortMultiWrapper2 {
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC void operator()(const TAcc& acc,
                                   T const* v,
                                   uint16_t* index,
@@ -431,7 +431,7 @@ namespace cms::alpakatools {
 namespace alpaka::trait {
   // specialize the BlockSharedMemDynSizeBytes trait to specify the amount of
   // block shared dynamic memory for the radixSortMultiWrapper kernel
-  template <typename TAcc, typename T, int NS>
+  template <alpaka::concepts::Acc TAcc, typename T, int NS>
   struct BlockSharedMemDynSizeBytes<cms::alpakatools::radixSortMultiWrapper<T, NS>, TAcc> {
     // the size in bytes of the shared memory allocated for a block
     ALPAKA_FN_HOST_ACC static std::size_t getBlockSharedMemDynSizeBytes(

--- a/HeterogeneousCore/AlpakaMath/interface/deltaPhi.h
+++ b/HeterogeneousCore/AlpakaMath/interface/deltaPhi.h
@@ -6,7 +6,7 @@
 namespace cms::alpakatools {
 
   // reduce to [-pi,pi]
-  template <typename TAcc, std::floating_point T>
+  template <alpaka::concepts::Acc TAcc, std::floating_point T>
   ALPAKA_FN_HOST_ACC inline T reducePhiRange(TAcc const& acc, T x) {
     constexpr T o2pi = T{1.} / (T{2.} * std::numbers::pi_v<T>);
     if (alpaka::math::abs(acc, x) <= std::numbers::pi_v<T>)
@@ -15,17 +15,17 @@ namespace cms::alpakatools {
     return x - n * T{2.} * std::numbers::pi_v<T>;
   }
 
-  template <typename TAcc, typename T>
+  template <alpaka::concepts::Acc TAcc, typename T>
   ALPAKA_FN_HOST_ACC inline T phi(TAcc const& acc, T x, T y) {
     return reducePhiRange(acc, std::numbers::pi_v<T> + alpaka::math::atan2(acc, -y, -x));
   }
 
-  template <typename TAcc, typename T>
+  template <alpaka::concepts::Acc TAcc, typename T>
   ALPAKA_FN_HOST_ACC inline T deltaPhi(TAcc const& acc, T x1, T y1, T x2, T y2) {
     return reducePhiRange(acc, alpaka::math::atan2(acc, -y2, -x2) - alpaka::math::atan2(acc, -y1, -x1));
   }
 
-  template <typename TAcc, typename T>
+  template <alpaka::concepts::Acc TAcc, typename T>
   ALPAKA_FN_HOST_ACC inline T deltaPhi(TAcc const& acc, T phi1, T phi2) {
     return reducePhiRange(acc, phi1 - phi2);
   }

--- a/HeterogeneousCore/AlpakaMath/test/alpaka/testDeltaPhi.dev.cc
+++ b/HeterogeneousCore/AlpakaMath/test/alpaka/testDeltaPhi.dev.cc
@@ -12,7 +12,7 @@ using namespace cms::alpakatools;
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
 struct phiFuncsUnitTestsKernel {
-  template <typename TAcc, typename T>
+  template <alpaka::concepts::Acc TAcc, typename T>
   ALPAKA_FN_ACC void operator()(TAcc const& acc, T* out) const {
     // Unit circle typical values
     out[0] = phi<TAcc, T>(acc, 1.0, 0.0);          // x = 1.0, y = 0.0 => phi = 0

--- a/PhysicsTools/PyTorchAlpaka/test/alpaka/testSoADataTypes.dev.cc
+++ b/PhysicsTools/PyTorchAlpaka/test/alpaka/testSoADataTypes.dev.cc
@@ -60,8 +60,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
 
   class FillKernel {
   public:
-    template <typename TAcc>
-      requires ::alpaka::isAccelerator<TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC void operator()(TAcc const& acc, SoACollectionView view) const {
       if (cms::alpakatools::once_per_grid(acc)) {
         view.type() = 4;
@@ -91,8 +90,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
 
   class InputVerifyKernel {
   public:
-    template <typename TAcc>
-      requires ::alpaka::isAccelerator<TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC void operator()(TAcc const& acc, SoACollectionView view) const {
       if (cms::alpakatools::once_per_grid(acc)) {
         ALPAKA_ASSERT_ACC(view.type() == 4);
@@ -122,8 +120,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
 
   class TestOutputVerifyKernel {
   public:
-    template <typename TAcc>
-      requires ::alpaka::isAccelerator<TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC void operator()(TAcc const& acc, SoACollectionView view) const {
       for (auto i : cms::alpakatools::uniform_elements(acc, view.metadata().size())) {
         ALPAKA_ASSERT_ACC(view.x()[i] - view.v()[i] < tol);

--- a/PhysicsTools/PyTorchAlpaka/test/alpaka/testSoAToTorch.dev.cc
+++ b/PhysicsTools/PyTorchAlpaka/test/alpaka/testSoAToTorch.dev.cc
@@ -42,7 +42,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
 
   class FillKernel {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC void operator()(TAcc const& acc, PositionDeviceCollectionView view) const {
       float input[4][3] = {{1.f, 2.f, 1.f}, {2.f, 4.f, 3.f}, {3.f, 4.f, 1.f}, {2.f, 3.f, 2.f}};
       for (auto i : cms::alpakatools::uniform_elements(acc, view.metadata().size())) {

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/CalibPixel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/CalibPixel.h
@@ -24,7 +24,7 @@ namespace calibPixel {
 
   template <bool debug = false>
   struct CalibDigis {
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC void operator()(const TAcc& acc,
                                   SiPixelClusterThresholds clusterThresholds,
                                   SiPixelDigisSoAView view,
@@ -90,7 +90,7 @@ namespace calibPixel {
   };
 
   struct CalibDigisPhase2 {
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC void operator()(const TAcc& acc,
                                   SiPixelClusterThresholds clusterThresholds,
                                   SiPixelDigisSoAView view,

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/ClusterChargeCut.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/ClusterChargeCut.h
@@ -19,7 +19,7 @@ namespace pixelClustering {
 
   template <typename TrackerTraits>
   struct ClusterChargeCut {
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC void operator()(TAcc const& acc,
                                   SiPixelDigisSoAView digi_view,
                                   SiPixelClustersSoAView clus_view,

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
@@ -21,7 +21,7 @@
 //#define GPU_DEBUG
 
 // TODO move to HeterogeneousCore/AlpakaInterface or upstream to alpaka
-template <typename TAcc, typename T>
+template <alpaka::concepts::Acc TAcc, typename T>
 ALPAKA_FN_ACC inline T atomicLoadFromShared(TAcc const& acc [[maybe_unused]], T* arg) {
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) or defined(ALPAKA_ACC_GPU_HIP_ENABLED)
   // GPU backend, use a volatile read to force a non-cached acess

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
@@ -432,7 +432,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     // just for debugging
     template <typename TrackerTraits>
     struct ShowHitsModuleStart {
-      template <typename TAcc>
+      template <alpaka::concepts::Acc TAcc>
       ALPAKA_FN_ACC void operator()(const TAcc &acc, SiPixelClustersSoAView clus_view) const {
         if (cms::alpakatools::once_per_grid(acc)) {
           for (int i = 0; i < TrackerTraits::numberOfModules; i++)

--- a/RecoTracker/LSTCore/interface/Circle.h
+++ b/RecoTracker/LSTCore/interface/Circle.h
@@ -7,7 +7,7 @@
 
 namespace lst {
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE std::tuple<float, float, float> computeRadiusFromThreeAnchorHits(
       TAcc const& acc, float x1, float y1, float x2, float y2, float x3, float y3) {
     float radius = 0.f;

--- a/RecoTracker/LSTCore/src/alpaka/Hit.h
+++ b/RecoTracker/LSTCore/src/alpaka/Hit.h
@@ -11,7 +11,7 @@
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE float deltaPhiChange(TAcc const& acc, float x1, float y1, float x2, float y2) {
     return cms::alpakatools::deltaPhi(acc, x1, y1, x2 - x1, y2 - y1);
   }

--- a/RecoTracker/LSTCore/src/alpaka/MiniDoublet.h
+++ b/RecoTracker/LSTCore/src/alpaka/MiniDoublet.h
@@ -13,7 +13,7 @@
 #include "RecoTracker/LSTCore/interface/ObjectRangesSoA.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void addMDToMemory(TAcc const& acc,
                                                     MiniDoublets mds,
                                                     HitsBaseConst hitsBase,
@@ -127,7 +127,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return moduleSeparation;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE float dPhiThreshold(TAcc const& acc,
                                                      float rt,
                                                      ModulesConst modules,
@@ -191,7 +191,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     }
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_INLINE ALPAKA_FN_ACC void shiftStripHits(TAcc const& acc,
                                                      ModulesConst modules,
                                                      uint16_t lowerModuleIndex,
@@ -359,7 +359,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     shiftedCoords[2] = zn;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC bool runMiniDoubletDefaultAlgoBarrel(TAcc const& acc,
                                                      ModulesConst modules,
                                                      uint16_t lowerModuleIndex,
@@ -487,7 +487,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return alpaka::math::abs(acc, dPhiChange) < miniCut;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC bool runMiniDoubletDefaultAlgoEndcap(TAcc const& acc,
                                                      ModulesConst modules,
                                                      uint16_t lowerModuleIndex,
@@ -599,7 +599,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return alpaka::math::abs(acc, dPhiChange) < miniCut;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC bool runMiniDoubletDefaultAlgo(TAcc const& acc,
                                                ModulesConst modules,
                                                uint16_t lowerModuleIndex,

--- a/RecoTracker/LSTCore/src/alpaka/NeuralNetwork.h
+++ b/RecoTracker/LSTCore/src/alpaka/NeuralNetwork.h
@@ -16,7 +16,7 @@
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
-  template <int FEATURES, typename TAcc>
+  template <int FEATURES, alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void softmax_activation(TAcc const& acc, float (&input)[FEATURES]) {
     float sum = 0.f;
     // Compute exp and sum
@@ -41,7 +41,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     }
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE float sigmoid_activation(TAcc const& acc, const float x) {
     return alpaka::math::exp(acc, x) / (alpaka::math::exp(acc, x) + 1.f);
   }
@@ -62,7 +62,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
   }
 
   namespace t3dnn {
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runInference(TAcc const& acc,
                                                      MiniDoubletsConst mds,
                                                      const unsigned int mdIndex1,
@@ -141,7 +141,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
   namespace pt3dnn {
 
-    template <typename WP, typename TAcc>
+    template <typename WP, alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runInference(TAcc const& acc,
                                                      const float rPhiChiSquared,
                                                      const float tripletRadius,
@@ -192,7 +192,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
   }  // namespace pt3dnn
 
   namespace t5dnn {
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runInference(TAcc const& acc,
                                                      MiniDoubletsConst mds,
                                                      const unsigned int mdIndex1,
@@ -296,7 +296,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
   }  // namespace t5dnn
 
   namespace t5embdnn {
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC ALPAKA_FN_INLINE void runEmbed(TAcc const& acc,
                                                  MiniDoubletsConst mds,
                                                  unsigned int mdIndex1,
@@ -393,7 +393,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
   }  // namespace t5embdnn
 
   namespace plsembdnn {
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC ALPAKA_FN_INLINE void runEmbed(TAcc const& acc,
                                                  const float eta,
                                                  const float etaErr,
@@ -435,7 +435,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
   }  // namespace plsembdnn
 
   namespace t4dnn {
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runInference(TAcc const& acc,
                                                      MiniDoubletsConst mds,
                                                      ModulesConst modules,

--- a/RecoTracker/LSTCore/src/alpaka/PixelQuintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/PixelQuintuplet.h
@@ -254,7 +254,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return true;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE float computePT5RPhiChiSquared(TAcc const& acc,
                                                                 ModulesConst modules,
                                                                 uint16_t* lowerModuleIndices,
@@ -377,7 +377,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return true;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE float computePT5RZChiSquared(TAcc const& acc,
                                                               ModulesConst modules,
                                                               const uint16_t* lowerModuleIndices,
@@ -464,7 +464,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return RMSE;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runPixelQuintupletDefaultAlgo(TAcc const& acc,
                                                                     ModulesConst modules,
                                                                     ObjectRangesConst ranges,

--- a/RecoTracker/LSTCore/src/alpaka/PixelTriplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/PixelTriplet.h
@@ -15,7 +15,7 @@
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runTripletDefaultAlgoPPBB(TAcc const& acc,
                                                                 ModulesConst modules,
                                                                 ObjectRangesConst ranges,
@@ -32,7 +32,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                                 unsigned int thirdMDIndex,
                                                                 unsigned int fourthMDIndex,
                                                                 const float ptCut);
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runTripletDefaultAlgoPPEE(TAcc const& acc,
                                                                 ModulesConst modules,
                                                                 ObjectRangesConst ranges,
@@ -117,7 +117,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     pixelTriplets.rzChiSquared()[pixelTripletIndex] = rzChiSquared;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runPixelTrackletDefaultAlgopT3(TAcc const& acc,
                                                                      ModulesConst modules,
                                                                      ObjectRangesConst ranges,
@@ -230,7 +230,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
   }
 
   //TODO: merge this one and the pT5 function later into a single function
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE float computePT3RPhiChiSquared(TAcc const& acc,
                                                                 ModulesConst modules,
                                                                 uint16_t* lowerModuleIndices,
@@ -320,7 +320,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
   }
 
   /*bounds for high Pt taken from : http://uaf-10.t2.ucsd.edu/~bsathian/SDL/T5_efficiency/efficiencies/new_efficiencies/efficiencies_20210513_T5_recovering_high_Pt_efficiencies/highE_radius_matching/highE_bounds.txt */
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool passRadiusCriterionBBB(TAcc const& acc,
                                                              float pixelRadius,
                                                              float pixelRadiusError,
@@ -344,7 +344,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return checkIntervalOverlappT3(tripletRadiusInvMin, tripletRadiusInvMax, pixelRadiusInvMin, pixelRadiusInvMax);
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool passRadiusCriterionBBE(TAcc const& acc,
                                                              float pixelRadius,
                                                              float pixelRadiusError,
@@ -368,7 +368,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return checkIntervalOverlappT3(tripletRadiusInvMin, tripletRadiusInvMax, pixelRadiusInvMin, pixelRadiusInvMax);
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool passRadiusCriterionBEE(TAcc const& acc,
                                                              float pixelRadius,
                                                              float pixelRadiusError,
@@ -394,7 +394,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return checkIntervalOverlappT3(tripletRadiusInvMin, tripletRadiusInvMax, pixelRadiusInvMin, pixelRadiusInvMax);
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool passRadiusCriterionEEE(TAcc const& acc,
                                                              float pixelRadius,
                                                              float pixelRadiusError,
@@ -420,7 +420,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return checkIntervalOverlappT3(tripletRadiusInvMin, tripletRadiusInvMax, pixelRadiusInvMin, pixelRadiusInvMax);
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool passRadiusCriterion(TAcc const& acc,
                                                           ModulesConst modules,
                                                           float pixelRadius,
@@ -440,7 +440,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     }
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE float computePT3RZChiSquared(TAcc const& acc,
                                                               ModulesConst modules,
                                                               const uint16_t* lowerModuleIndices,
@@ -529,7 +529,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return RMSE;
   }
 
-  template <typename WP = dnn::pt3dnn::pT3WP, typename TAcc>
+  template <typename WP = dnn::pt3dnn::pT3WP, alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runPixelTripletDefaultAlgo(TAcc const& acc,
                                                                  ModulesConst modules,
                                                                  ObjectRangesConst ranges,
@@ -836,7 +836,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     }
   };
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runTripletDefaultAlgoPPBB(TAcc const& acc,
                                                                 ModulesConst modules,
                                                                 ObjectRangesConst ranges,
@@ -1095,7 +1095,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return dBeta * dBeta <= dBetaCut2;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runTripletDefaultAlgoPPEE(TAcc const& acc,
                                                                 ModulesConst modules,
                                                                 ObjectRangesConst ranges,

--- a/RecoTracker/LSTCore/src/alpaka/Quadruplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quadruplet.h
@@ -87,7 +87,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     quadruplets.regressionCenterY()[quadrupletIndex] = regressionCenterY;
   };
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool passT4RZConstraint(TAcc const& acc,
                                                          ModulesConst modules,
                                                          MiniDoubletsConst mds,
@@ -299,7 +299,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return rzChiSquared < chi2_cuts[bin_index];
   };
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runQuadrupletDefaultAlgo(TAcc const& acc,
                                                                ModulesConst modules,
                                                                MiniDoubletsConst mds,

--- a/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
@@ -98,7 +98,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
   }
 
   //bounds can be found at http://uaf-10.t2.ucsd.edu/~bsathian/SDL/T5_RZFix/t5_rz_thresholds.txt
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool passT5RZConstraint(TAcc const& acc,
                                                          ModulesConst modules,
                                                          MiniDoubletsConst mds,
@@ -530,7 +530,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return true;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool T5HasCommonMiniDoublet(TripletsConst triplets,
                                                              SegmentsConst segments,
                                                              unsigned int innerTripletIndex,
@@ -545,7 +545,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return (innerOuterOuterMiniDoubletIndex == outerInnerInnerMiniDoubletIndex);
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void computeSigmasForRegression(TAcc const& acc,
                                                                  ModulesConst modules,
                                                                  const uint16_t* lowerModuleIndices,
@@ -632,7 +632,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     }
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE float computeRadiusUsingRegression(TAcc const& acc,
                                                                     unsigned int nPoints,
                                                                     float* xs,
@@ -731,7 +731,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return radius;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE float computeChiSquared(TAcc const& acc,
                                                          unsigned int nPoints,
                                                          float* xs,
@@ -778,7 +778,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return chiSquared;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void runDeltaBetaIterations(TAcc const& acc,
                                                              float& betaIn,
                                                              float& betaOut,
@@ -877,7 +877,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     }
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runQuintupletdBetaCutBBBB(TAcc const& acc,
                                                                 ModulesConst modules,
                                                                 MiniDoubletsConst mds,
@@ -1056,7 +1056,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return dBeta * dBeta <= dBetaCut2;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runQuintupletdBetaCutBBEE(TAcc const& acc,
                                                                 ModulesConst modules,
                                                                 MiniDoubletsConst mds,
@@ -1222,7 +1222,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return dBeta * dBeta <= dBetaCut2;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runQuintupletdBetaCutEEEE(TAcc const& acc,
                                                                 ModulesConst modules,
                                                                 MiniDoubletsConst mds,
@@ -1352,7 +1352,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return dBeta * dBeta <= dBetaCut2;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runQuintupletdBetaAlgoSelector(TAcc const& acc,
                                                                      ModulesConst modules,
                                                                      MiniDoubletsConst mds,
@@ -1469,7 +1469,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return false;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runQuintupletDefaultAlgo(TAcc const& acc,
                                                                ModulesConst modules,
                                                                MiniDoubletsConst mds,

--- a/RecoTracker/LSTCore/src/alpaka/Segment.h
+++ b/RecoTracker/LSTCore/src/alpaka/Segment.h
@@ -85,7 +85,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return moduleSeparation;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void dAlphaThreshold(TAcc const& acc,
                                                       float* dAlphaThresholdValues,
                                                       ModulesConst modules,
@@ -227,7 +227,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 #endif
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void addPixelSegmentToMemory(TAcc const& acc,
                                                               Segments segments,
                                                               PixelSegments pixelSegments,
@@ -306,7 +306,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     }
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool passDeltaPhiCutsBarrel(TAcc const& acc,
                                                              ModulesConst modules,
                                                              MiniDoubletsConst mds,
@@ -336,7 +336,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return alpaka::math::abs(acc, dPhiChange) < sdCut;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool passDeltaPhiCutsEndcap(TAcc const& acc,
                                                              ModulesConst modules,
                                                              MiniDoubletsConst mds,
@@ -361,7 +361,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return alpaka::math::abs(acc, dPhiChange) < sdSlope;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runSegmentDefaultAlgoBarrel(TAcc const& acc,
                                                                   ModulesConst modules,
                                                                   MiniDoubletsConst mds,
@@ -465,7 +465,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return alpaka::math::abs(acc, dAlphaInnerMDOuterMD) < dAlphaInnerMDOuterMDThreshold;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runSegmentDefaultAlgoEndcap(TAcc const& acc,
                                                                   ModulesConst modules,
                                                                   MiniDoubletsConst mds,
@@ -600,7 +600,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return alpaka::math::abs(acc, dAlphaInnerMDOuterMD) < dAlphaInnerMDOuterMDThreshold;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runSegmentDefaultAlgo(TAcc const& acc,
                                                             ModulesConst modules,
                                                             MiniDoubletsConst mds,
@@ -795,7 +795,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     }
   };
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool passDeltaPhiCutsSelector(TAcc const& acc,
                                                                ModulesConst modules,
                                                                MiniDoubletsConst mds,

--- a/RecoTracker/LSTCore/src/alpaka/Triplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Triplet.h
@@ -69,7 +69,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     triplets.displacedScore()[tripletIndex] = t3Scores[2];
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool passRZConstraint(TAcc const& acc,
                                                        ModulesConst modules,
                                                        MiniDoubletsConst mds,
@@ -325,7 +325,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return false;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool passPointingConstraint(TAcc const& acc,
                                                              ModulesConst modules,
                                                              MiniDoubletsConst mds,
@@ -388,7 +388,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return alpaka::math::abs(acc, betaInRHmin) < betaInCut;
   }
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runTripletConstraintsAndAlgo(TAcc const& acc,
                                                                    ModulesConst modules,
                                                                    MiniDoubletsConst mds,

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAPixelDoubletsAlgos.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAPixelDoubletsAlgos.h
@@ -67,7 +67,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caPixelDoublets {
     return moduleIsOuterLadderPhase2(moduleId);
   }
 
-  template <typename TrackerTraits, typename TAcc>
+  template <typename TrackerTraits, alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool zSizeCut(
       const TAcc& acc, HitsConstView hh, ::reco::CALayersSoAConstView ll, AlgoParams const& params, int i, int o) {
     const uint32_t mi = hh[i].detectorIndex();
@@ -118,7 +118,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caPixelDoublets {
                : innerBarrel && std::abs(mes - int(std::abs(dz / dr) * params.dzdrFact_ + 0.5f)) > params.maxDYPred_;
   }
 
-  template <typename TrackerTraits, typename TAcc>
+  template <typename TrackerTraits, alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool clusterCut(
       const TAcc& acc, HitsConstView hh, ::reco::CALayersSoAConstView ll, AlgoParams const& params, uint32_t i) {
     const uint32_t mi = hh[i].detectorIndex();
@@ -158,7 +158,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caPixelDoublets {
     return false;
   }
 
-  template <typename TrackerTraits, typename TAcc>
+  template <typename TrackerTraits, alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void doubletsFromHisto(const TAcc& acc,
                                                         uint32_t maxNumOfDoublets,
                                                         CACell<TrackerTraits>* cells,

--- a/RecoTracker/PixelTrackFitting/interface/alpaka/BrokenLine.h
+++ b/RecoTracker/PixelTrackFitting/interface/alpaka/BrokenLine.h
@@ -58,7 +58,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::brokenline {
     
     \return the variance of the planar angle ((theta_0)^2 /3).
   */
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE double multScatt(
       const TAcc& acc, const double& length, const double bField, const double radius, int layer, double slope) {
     // limit R to 20GeV...
@@ -83,7 +83,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::brokenline {
     
     \return 2D rotation matrix.
   */
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE riemannFit::Matrix2d rotationMatrix(const TAcc& acc, double slope) {
     riemannFit::Matrix2d rot;
     rot(0, 0) = 1. / alpaka::math::sqrt(acc, 1. + riemannFit::sqr(slope));
@@ -104,7 +104,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::brokenline {
     \param y0 y coordinate of the translation vector.
     \param jacobian passed by reference in order to save stack.
   */
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void translateKarimaki(
       const TAcc& acc, karimaki_circle_fit& circle, double x0, double y0, riemannFit::Matrix3d& jacobian) {
     // Avoid multiple access to the circle.par vector.
@@ -155,7 +155,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::brokenline {
     \param bField magnetic field in Gev/cm/c.
     \param results PreparedBrokenLineData to be filled (see description of PreparedBrokenLineData).
   */
-  template <typename TAcc, typename M3xN, typename V4, int n>
+  template <alpaka::concepts::Acc TAcc, typename M3xN, typename V4, int n>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void __attribute__((always_inline)) prepareBrokenLineData(
       const TAcc& acc, const M3xN& hits, const V4& fast_fit, const double bField, PreparedBrokenLineData<n>& results) {
     riemannFit::Vector2d dVec;
@@ -234,7 +234,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::brokenline {
     
     \return the n-by-n matrix of the linear system
   */
-  template <typename TAcc, int n>
+  template <alpaka::concepts::Acc TAcc, int n>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE riemannFit::MatrixNd<n> matrixC_u(const TAcc& acc,
                                                                    const riemannFit::VectorNd<n>& weights,
                                                                    const riemannFit::VectorNd<n>& sTotal,
@@ -278,7 +278,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::brokenline {
     \warning sign of theta is (intentionally, for now) mistaken for negative charges.
   */
 
-  template <typename TAcc, typename M3xN, typename V4>
+  template <alpaka::concepts::Acc TAcc, typename M3xN, typename V4>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void fastFit(const TAcc& acc, const M3xN& hits, V4& result) {
     constexpr uint32_t n = M3xN::ColsAtCompileTime;
 
@@ -338,7 +338,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::brokenline {
    * in which the first hit is the origin) and then the parameters and their 
    * covariance matrix are transformed to the original coordinate system.
   */
-  template <typename TAcc, typename M3xN, typename M6xN, typename V4, int n>
+  template <alpaka::concepts::Acc TAcc, typename M3xN, typename M6xN, typename V4, int n>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void circleFit(const TAcc& acc,
                                                 const M3xN& hits,
                                                 const M6xN& hits_ge,
@@ -487,7 +487,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::brokenline {
    * in which the first hit is the origin) and then the parameters and their covariance 
    * matrix are transformed to the original coordinate system.
    */
-  template <typename TAcc, typename V4, typename M6xN, int n>
+  template <alpaka::concepts::Acc TAcc, typename V4, typename M6xN, int n>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void lineFit(const TAcc& acc,
                                               const M6xN& hits_ge,
                                               const V4& fast_fit,
@@ -616,7 +616,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::brokenline {
   template <int n>
   class helixFit {
   public:
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC ALPAKA_FN_INLINE void operator()(const TAcc& acc,
                                                    const riemannFit::Matrix3xNd<n>* hits,
                                                    const Eigen::Matrix<float, 6, 4>* hits_ge,

--- a/RecoTracker/PixelTrackFitting/interface/alpaka/FitUtils.h
+++ b/RecoTracker/PixelTrackFitting/interface/alpaka/FitUtils.h
@@ -86,8 +86,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   namespace riemannFit {
     using namespace ::riemannFit;
 
-    template <typename TAcc, class C>
-    ALPAKA_FN_ACC void printIt(const TAcc& acc, C* m, const char* prefix = "") {
+    template <typename C>
+    ALPAKA_FN_ACC void printIt(C* m, const char* prefix = "") {
 #ifdef RFIT_DEBUG
       for (uint r = 0; r < m->rows(); ++r) {
         for (uint c = 0; c < m->cols(); ++c) {
@@ -99,7 +99,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     /*!
     \brief raise to square.
-  */
+    */
     template <typename T>
     constexpr T sqr(const T a) {
       return a * a;
@@ -111,9 +111,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     \param a first 2D vector in the product.
     \param b second 2D vector in the product.
     \return z component of the cross product.
-  */
+    */
 
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC ALPAKA_FN_INLINE double cross2D(const TAcc& acc, const Vector2d& a, const Vector2d& b) {
       return a.x() * b.y() - a.y() * b.x();
     }
@@ -122,7 +122,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
    *  load error in CMSSW format to our formalism
    *  
    */
-    template <typename TAcc, typename M6xNf, typename M2Nd>
+    template <alpaka::concepts::Acc TAcc, typename M6xNf, typename M2Nd>
     ALPAKA_FN_ACC void loadCovariance2D(const TAcc& acc, M6xNf const& ge, M2Nd& hits_cov) {
       // Index numerology:
       // i: index of the hits/point (0,..,3)
@@ -154,7 +154,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       }
     }
 
-    template <typename TAcc, typename M6xNf, typename M3xNd>
+    template <alpaka::concepts::Acc TAcc, typename M6xNf, typename M3xNd>
     ALPAKA_FN_ACC void loadCovariance(const TAcc& acc, M6xNf const& ge, M3xNd& hits_cov) {
       // Index numerology:
       // i: index of the hits/point (0,..,3)
@@ -208,7 +208,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     \param B magnetic field in Gev/cm/c unit.
     \param error flag for errors computation.
   */
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC ALPAKA_FN_INLINE void par_uvrtopak(const TAcc& acc,
                                                      CircleFit& circle,
                                                      const double B,
@@ -235,7 +235,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     \param circle_uvr parameter (X0,Y0,R), covariance matrix to
     be transformed and particle charge.
   */
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC ALPAKA_FN_INLINE void fromCircleToPerigee(const TAcc& acc, CircleFit& circle) {
       Vector3d par_pak;
       const double temp0 = circle.par.head(2).squaredNorm();

--- a/RecoTracker/PixelTrackFitting/interface/alpaka/RiemannFit.h
+++ b/RecoTracker/PixelTrackFitting/interface/alpaka/RiemannFit.h
@@ -34,7 +34,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::riemannFit {
  * \return incremental radiation lengths that correspond to each segment.
  */
 
-  template <typename TAcc, typename VNd1, typename VNd2>
+  template <alpaka::concepts::Acc TAcc, typename VNd1, typename VNd2>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void computeRadLenUniformMaterial(const TAcc& acc,
                                                                    const VNd1& length_values,
                                                                    VNd2& rad_lengths) {
@@ -67,7 +67,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::riemannFit {
     correspond to the case at eta = 0.
  */
 
-  template <typename TAcc, typename V4, typename VNd1, typename VNd2, int N>
+  template <alpaka::concepts::Acc TAcc, typename V4, typename VNd1, typename VNd2, int N>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE auto scatterCovLine(const TAcc& acc,
                                                      Matrix2d const* cov_sz,
                                                      const V4& fast_fit,
@@ -130,7 +130,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::riemannFit {
     \details Only the tangential component is computed (the radial one is
     negligible).
  */
-  template <typename TAcc, typename M2xN, typename V4, int N>
+  template <alpaka::concepts::Acc TAcc, typename M2xN, typename V4, int N>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE MatrixNd<N> scatter_cov_rad(
       const TAcc& acc, const M2xN& p2D, const V4& fast_fit, VectorNd<N> const& rad, double B) {
     constexpr uint n = N;
@@ -176,7 +176,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::riemannFit {
     \return cov_cart covariance matrix in Cartesian coordinates.
 */
 
-  template <typename TAcc, typename M2xN, int N>
+  template <alpaka::concepts::Acc TAcc, typename M2xN, int N>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE Matrix2Nd<N> cov_radtocart(const TAcc& acc,
                                                             const M2xN& p2D,
                                                             const MatrixNd<N>& cov_rad,
@@ -214,7 +214,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::riemannFit {
     \return cov_rad covariance matrix in raidal coordinate.
     \warning correlation between different point are not computed.
 */
-  template <typename TAcc, typename M2xN, int N>
+  template <alpaka::concepts::Acc TAcc, typename M2xN, int N>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE VectorNd<N> cov_carttorad(const TAcc& acc,
                                                            const M2xN& p2D,
                                                            const Matrix2Nd<N>& cov_cart,
@@ -246,7 +246,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::riemannFit {
     \return cov_rad covariance matrix in the pre-fitted circle's
     orthogonal system.
 */
-  template <typename TAcc, typename M2xN, typename V4, int N>
+  template <alpaka::concepts::Acc TAcc, typename M2xN, typename V4, int N>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE VectorNd<N> cov_carttorad_prefit(
       const TAcc& acc, const M2xN& p2D, const Matrix2Nd<N>& cov_cart, V4& fast_fit, const VectorNd<N>& rad) {
     constexpr uint n = N;
@@ -280,7 +280,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::riemannFit {
     diagonal cov matrix. Further investigation needed.
 */
 
-  template <typename TAcc, int N>
+  template <alpaka::concepts::Acc TAcc, int N>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE VectorNd<N> weightCircle(const TAcc& acc, const MatrixNd<N>& cov_rad_inv) {
     return cov_rad_inv.colwise().sum().transpose();
   }
@@ -293,7 +293,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::riemannFit {
     \param par_uvr result of the circle fit in this form: (X0,Y0,R).
     \return q int 1 or -1.
 */
-  template <typename TAcc, typename M2xN>
+  template <alpaka::concepts::Acc TAcc, typename M2xN>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE int32_t charge(const TAcc& acc, const M2xN& p2D, const Vector3d& par_uvr) {
     return ((p2D(0, 1) - p2D(0, 0)) * (par_uvr.y() - p2D(1, 0)) - (p2D(1, 1) - p2D(1, 0)) * (par_uvr.x() - p2D(0, 0)) >
             0)
@@ -315,7 +315,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::riemannFit {
     fast closed-form algorithm.
     For this optimization the matrix type must be known at compiling time.
 */
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE Vector3d min_eigen3D(const TAcc& acc, const Matrix3d& A, double& chi2) {
 #ifdef RFIT_DEBUG
     printf("min_eigen3D - enter\n");
@@ -341,7 +341,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::riemannFit {
     speed up in  single precision.
 */
 
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE Vector3d min_eigen3D_fast(const TAcc& acc, const Matrix3d& A) {
     Eigen::SelfAdjointEigenSolver<Matrix3f> solver(3);
     solver.computeDirect(A.cast<float>());
@@ -359,7 +359,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::riemannFit {
     do not use special math function (just sqrt) therefore it doesn't speed up
     significantly in single precision.
 */
-  template <typename TAcc>
+  template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE Vector2d min_eigen2D(const TAcc& acc, const Matrix2d& aMat, double& chi2) {
     Eigen::SelfAdjointEigenSolver<Matrix2d> solver(2);
     solver.computeDirect(aMat);
@@ -381,7 +381,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::riemannFit {
     - computation of error due to multiple scattering.
 */
 
-  template <typename TAcc, typename M3xN, typename V4>
+  template <alpaka::concepts::Acc TAcc, typename M3xN, typename V4>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void fastFit(const TAcc& acc, const M3xN& hits, V4& result) {
     constexpr uint32_t N = M3xN::ColsAtCompileTime;
     constexpr auto n = N;  // get the number of hits
@@ -461,7 +461,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::riemannFit {
     \bug further investigation needed for error propagation with multiple
     scattering.
 */
-  template <typename TAcc, typename M2xN, typename V4, int N>
+  template <alpaka::concepts::Acc TAcc, typename M2xN, typename V4, int N>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE CircleFit circleFit(const TAcc& acc,
                                                      const M2xN& hits2D,
                                                      const Matrix2Nd<N>& hits_cov2D,
@@ -792,7 +792,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::riemannFit {
  * what is done in the same fit in the Broken Line approach.
  */
 
-  template <typename TAcc, typename M3xN, typename M6xN, typename V4>
+  template <alpaka::concepts::Acc TAcc, typename M3xN, typename M6xN, typename V4>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE LineFit lineFit(const TAcc& acc,
                                                  const M3xN& hits,
                                                  const M6xN& hits_ge,
@@ -989,7 +989,7 @@ namespace riemannFit {
   template <int N>
   class helixFit {
   public:
-    template <typename TAcc>
+    template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC ALPAKA_FN_INLINE void operator()(const TAcc& acc,
                                                    const Matrix3xNd<N>* hits,
                                                    const Eigen::Matrix<float, 6, N>* hits_ge,


### PR DESCRIPTION
#### PR description:

Replace the use of the `isAcc` type trait with the `Acc` concept introduced in alpaka 2.2 (cms-sw/cmsdist#10250)

#### PR validation:

Code builds, no changes expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Potentially to be backported to 16.0.x together with alpaka 2.2.1.
