### PR TITLE
Remove unused flag from standalone LST

### DIFF
--- a/RecoTracker/LSTCore/standalone/bin/lst.cc
+++ b/RecoTracker/LSTCore/standalone/bin/lst.cc
@@ -66,7 +66,6 @@ int main(int argc, char **argv) {
       "w,write_ntuple", "Write Ntuple", cxxopts::value<int>()->default_value("1"))(
       "s,streams", "Set number of streams", cxxopts::value<int>()->default_value("1"))(
       "d,debug", "Run debug job. i.e. overrides output option to 'debug.root' and 'recreate's the file.")(
-      "l,lower_level", "write lower level objects ntuple results")(
       "j,nsplit_jobs", "Enable splitting jobs by N blocks (--job_index must be set)", cxxopts::value<int>())(
       "I,job_index",
       "job_index of split jobs (--nsplit_jobs must be set. index starts from 0. i.e. 0, 1, 2, 3, etc...)",
@@ -244,14 +243,6 @@ int main(int argc, char **argv) {
 
   //_______________________________________________________________________________
   // --optimization
-
-  //_______________________________________________________________________________
-  // --lower_level
-  if (result.count("lower_level")) {
-    ana.do_lower_level = true;
-  } else {
-    ana.do_lower_level = false;
-  }
 
   //_______________________________________________________________________________
   // --tc_pls_triplets


### PR DESCRIPTION
This is a small PR to clean unused code in the standalone of LST. These changes do not affect the CMSSW part, and the standalone part has been tested and gives identical results.

### CMSSW
<img width="996" height="1847" alt="image" src="https://github.com/user-attachments/assets/05568b1f-daf8-41a1-8373-9d4fa0214e4b" />
 
### Standalone
<img width="696" height="472" alt="image" src="https://github.com/user-attachments/assets/4d526b4b-fceb-4254-af44-5f2b53a9709b" />
<img width="696" height="472" alt="image" src="https://github.com/user-attachments/assets/6aedaff6-eebd-4ede-ad20-ad1cdaa96dd3" />

