### PR TITLE
L1-uGT emulator: fix to `AXOL1TL`'s "Pt" inputs

### DIFF
--- a/L1Trigger/L1TGlobal/src/AXOL1TLCondition.cc
+++ b/L1Trigger/L1TGlobal/src/AXOL1TLCondition.cc
@@ -179,8 +179,8 @@ const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   if (NCandEtSum > 0) {  //check if not empty
     for (int iEtSum = 0; iEtSum < NCandEtSum; iEtSum++) {
       if ((candEtSumVec->at(useBx, iEtSum))->getType() == l1t::EtSum::EtSumType::kMissingEt) {
-        EtSumInput[0] =
-            ((candEtSumVec->at(useBx, iEtSum))->hwPt()) / 2;  //have to do hwPt/2 in order to match original et inputs
+        // have to do hwPt/2 in order to match original et inputs
+        EtSumInput[0] = (candEtSumVec->at(useBx, iEtSum))->hwPt() * .5;
         // EtSumInput[1] = (candEtSumVec->at(useBx, iEtSum))->hwEta(); //this one is zero, so leave it zero
         EtSumInput[2] = (candEtSumVec->at(useBx, iEtSum))->hwPhi();
       }
@@ -191,10 +191,10 @@ const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   if (NCandEG > 0) {  //check if not empty
     for (int iEG = 0; iEG < NCandEG; iEG++) {
       if (iEG < NEgammas) {  //stop if fill the Nobjects we need
-        EgammaInput[0 + (3 * iEG)] = ((candEGVec->at(useBx, iEG))->hwPt()) /
-                                     2;  //index 0,3,6,9 //have to do hwPt/2 in order to match original et inputs
-        EgammaInput[1 + (3 * iEG)] = (candEGVec->at(useBx, iEG))->hwEta();  //index 1,4,7,10
-        EgammaInput[2 + (3 * iEG)] = (candEGVec->at(useBx, iEG))->hwPhi();  //index 2,5,8,11
+        // have to do hwPt/2 in order to match original et inputs
+        EgammaInput[0 + (3 * iEG)] = (candEGVec->at(useBx, iEG))->hwPt() * .5;  //index 0,3,6,9
+        EgammaInput[1 + (3 * iEG)] = (candEGVec->at(useBx, iEG))->hwEta();      //index 1,4,7,10
+        EgammaInput[2 + (3 * iEG)] = (candEGVec->at(useBx, iEG))->hwPhi();      //index 2,5,8,11
       }
     }
   }
@@ -203,8 +203,8 @@ const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   if (NCandMu > 0) {  //check if not empty
     for (int iMu = 0; iMu < NCandMu; iMu++) {
       if (iMu < NMuons) {  //stop if fill the Nobjects we need
-        MuInput[0 + (3 * iMu)] = ((candMuVec->at(useBx, iMu))->hwPt()) /
-                                 2;  //index 0,3,6,9 //have to do hwPt/2 in order to match original et inputs
+        // have to do hwPt/2 in order to match original et inputs
+        MuInput[0 + (3 * iMu)] = (candMuVec->at(useBx, iMu))->hwPt() * .5;   //index 0,3,6,9
         MuInput[1 + (3 * iMu)] = (candMuVec->at(useBx, iMu))->hwEtaAtVtx();  //index 1,4,7,10
         MuInput[2 + (3 * iMu)] = (candMuVec->at(useBx, iMu))->hwPhiAtVtx();  //index 2,5,8,11
       }
@@ -215,10 +215,10 @@ const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   if (NCandJet > 0) {  //check if not empty
     for (int iJet = 0; iJet < NCandJet; iJet++) {
       if (iJet < NJets) {  //stop if fill the Nobjects we need
-        JetInput[0 + (3 * iJet)] = ((candJetVec->at(useBx, iJet))->hwPt()) /
-                                   2;  //index 0,3,6,9...27 //have to do hwPt/2 in order to match original et inputs
-        JetInput[1 + (3 * iJet)] = (candJetVec->at(useBx, iJet))->hwEta();  //index 1,4,7,10...28
-        JetInput[2 + (3 * iJet)] = (candJetVec->at(useBx, iJet))->hwPhi();  //index 2,5,8,11...29
+        // have to do hwPt/2 in order to match original et inputs
+        JetInput[0 + (3 * iJet)] = (candJetVec->at(useBx, iJet))->hwPt() * .5;  //index 0,3,6,9...27
+        JetInput[1 + (3 * iJet)] = (candJetVec->at(useBx, iJet))->hwEta();      //index 1,4,7,10...28
+        JetInput[2 + (3 * iJet)] = (candJetVec->at(useBx, iJet))->hwPhi();      //index 2,5,8,11...29
       }
     }
   }


### PR DESCRIPTION
#### PR description:

This PR fixes the "Pt" inputs used in the inference of AXOL1TL models in the L1-uGT emulation.
 - Without this PR, these "Pt" values are truncated to integers (which is unintended, as far as I understand).
 - With this PR, the data-emulator mismatches for L1T algorithms involving AXOL1TL (recently mentioned in [#49056 (comment)](https://github.com/cms-sw/cmssw/issues/49056#issuecomment-3414537143) are reduced by ~10x (see the validation section in [#49754 (comment)](https://github.com/cms-sw/cmssw/pull/49754#issue-3797825068)).

This is a bugfix. It affects only the results of the L1-uGT emulation for AXOL1TL seeds.

#### PR validation:

None beyond the validation done for #49754.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

To be backported at least to `CMSSW_16_0_X` for 2026 data-taking purposes (e.g. L1-uGT online DQM). Might also be backported to earlier releases (down to ~`CMSSW_14_0_X`~ `CMSSW_13_3_X`) to fix the L1T decisions of AXOL1TL seeds in MC.
