### PR TITLE
L1-uGT emulator: fix to `AXOL1TL`'s "Pt" inputs [`16_0_X`]

### DIFF
--- a/L1Trigger/L1TGlobal/src/AXOL1TLCondition.cc
+++ b/L1Trigger/L1TGlobal/src/AXOL1TLCondition.cc
@@ -179,8 +179,8 @@ const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   if (NCandEtSum > 0) {  //check if not empty
     for (int iEtSum = 0; iEtSum < NCandEtSum; iEtSum++) {
       if ((candEtSumVec->at(useBx, iEtSum))->getType() == l1t::EtSum::EtSumType::kMissingEt) {
-        EtSumInput[0] =
-            ((candEtSumVec->at(useBx, iEtSum))->hwPt()) / 2;  //have to do hwPt/2 in order to match original et inputs
+        // have to do hwPt/2 in order to match original et inputs
+        EtSumInput[0] = (candEtSumVec->at(useBx, iEtSum))->hwPt() * .5;
         // EtSumInput[1] = (candEtSumVec->at(useBx, iEtSum))->hwEta(); //this one is zero, so leave it zero
         EtSumInput[2] = (candEtSumVec->at(useBx, iEtSum))->hwPhi();
       }
@@ -191,10 +191,10 @@ const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   if (NCandEG > 0) {  //check if not empty
     for (int iEG = 0; iEG < NCandEG; iEG++) {
       if (iEG < NEgammas) {  //stop if fill the Nobjects we need
-        EgammaInput[0 + (3 * iEG)] = ((candEGVec->at(useBx, iEG))->hwPt()) /
-                                     2;  //index 0,3,6,9 //have to do hwPt/2 in order to match original et inputs
-        EgammaInput[1 + (3 * iEG)] = (candEGVec->at(useBx, iEG))->hwEta();  //index 1,4,7,10
-        EgammaInput[2 + (3 * iEG)] = (candEGVec->at(useBx, iEG))->hwPhi();  //index 2,5,8,11
+        // have to do hwPt/2 in order to match original et inputs
+        EgammaInput[0 + (3 * iEG)] = (candEGVec->at(useBx, iEG))->hwPt() * .5;  //index 0,3,6,9
+        EgammaInput[1 + (3 * iEG)] = (candEGVec->at(useBx, iEG))->hwEta();      //index 1,4,7,10
+        EgammaInput[2 + (3 * iEG)] = (candEGVec->at(useBx, iEG))->hwPhi();      //index 2,5,8,11
       }
     }
   }
@@ -203,8 +203,8 @@ const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   if (NCandMu > 0) {  //check if not empty
     for (int iMu = 0; iMu < NCandMu; iMu++) {
       if (iMu < NMuons) {  //stop if fill the Nobjects we need
-        MuInput[0 + (3 * iMu)] = ((candMuVec->at(useBx, iMu))->hwPt()) /
-                                 2;  //index 0,3,6,9 //have to do hwPt/2 in order to match original et inputs
+        // have to do hwPt/2 in order to match original et inputs
+        MuInput[0 + (3 * iMu)] = (candMuVec->at(useBx, iMu))->hwPt() * .5;   //index 0,3,6,9
         MuInput[1 + (3 * iMu)] = (candMuVec->at(useBx, iMu))->hwEtaAtVtx();  //index 1,4,7,10
         MuInput[2 + (3 * iMu)] = (candMuVec->at(useBx, iMu))->hwPhiAtVtx();  //index 2,5,8,11
       }
@@ -215,10 +215,10 @@ const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   if (NCandJet > 0) {  //check if not empty
     for (int iJet = 0; iJet < NCandJet; iJet++) {
       if (iJet < NJets) {  //stop if fill the Nobjects we need
-        JetInput[0 + (3 * iJet)] = ((candJetVec->at(useBx, iJet))->hwPt()) /
-                                   2;  //index 0,3,6,9...27 //have to do hwPt/2 in order to match original et inputs
-        JetInput[1 + (3 * iJet)] = (candJetVec->at(useBx, iJet))->hwEta();  //index 1,4,7,10...28
-        JetInput[2 + (3 * iJet)] = (candJetVec->at(useBx, iJet))->hwPhi();  //index 2,5,8,11...29
+        // have to do hwPt/2 in order to match original et inputs
+        JetInput[0 + (3 * iJet)] = (candJetVec->at(useBx, iJet))->hwPt() * .5;  //index 0,3,6,9...27
+        JetInput[1 + (3 * iJet)] = (candJetVec->at(useBx, iJet))->hwEta();      //index 1,4,7,10...28
+        JetInput[2 + (3 * iJet)] = (candJetVec->at(useBx, iJet))->hwPhi();      //index 2,5,8,11...29
       }
     }
   }


### PR DESCRIPTION
backport of #49753

#### PR description:

From the description of #49753.
> This PR fixes the "Pt" inputs used in the inference of AXOL1TL models in the L1-uGT emulation.
>  - Without this PR, these "Pt" values are truncated to integers (which is unintended, as far as I understand).
>  - With this PR, the data-emulator mismatches for L1T algorithms involving AXOL1TL (recently mentioned in [#49056 (comment)](https://github.com/cms-sw/cmssw/issues/49056#issuecomment-3414537143) are reduced by ~10x (see the validation section below).
>
> This is a bugfix. It affects only the results of the L1-uGT emulation for AXOL1TL seeds.

#### PR validation:

Running [this config](https://github.com/user-attachments/files/24532533/test_l1tDataEmulatorMismatchesGT_cfg.py) with [1] without (with) this PR in `CMSSW_16_0_0_pre4`, one gets the output in [2] ([3]). `TestL1TMismatchAnyPath` shows that running on 20K events of Run2025G (`EphemeralHLTPhysics*` PDs) without this PR there are 157 events with at least one data-emulator mismatch for the AXOL1TL seeds in the 2025 menu. With this PR, that number goes down to 17 (events). Similar checks were made on larger stats (~200K events of 2025 data from files that are no longer on EOS), and the results were similar (~10x reduction in data-emulator mismatches).

[1]
```bash
#!/bin/bash

cmsRun test_l1tDataEmulatorMismatchesGT_cfg.py \
 -t 32 -n 20000 \
 -a L1_AXO_VLoose L1_AXO_Loose L1_AXO_Medium L1_AXO_Tight L1_AXO_VTight L1_AXO_VVTight L1_AXO_VVVTight \
 -i "/eos/cms/store/data/Run2025G/EphemeralHLTPhysics*/RAW/*/*/398/183/*/*.root" \
 -o tmp.root
```

[2]
```
TrigReport ---------- Event  Summary ------------
TrigReport Events total = 20000 passed = 1990 failed = 18010

TrigReport ---------- Path   Summary ------------
TrigReport  Trig Bit#   Executed     Passed     Failed      Error Name
TrigReport     1    0      20000       1987      18013          0 TestL1TDigisPath0
TrigReport     1    1      20000       1950      18050          0 TestL1uGTEmuPath0
TrigReport     1    2      20000         43      19957          0 TestL1TMismatchPath0
TrigReport     1    3      20000       1594      18406          0 TestL1TDigisPath1
TrigReport     1    4      20000       1545      18455          0 TestL1uGTEmuPath1
TrigReport     1    5      20000         53      19947          0 TestL1TMismatchPath1
TrigReport     1    6      20000       1252      18748          0 TestL1TDigisPath2
TrigReport     1    7      20000       1226      18774          0 TestL1uGTEmuPath2
TrigReport     1    8      20000         26      19974          0 TestL1TMismatchPath2
TrigReport     1    9      20000        975      19025          0 TestL1TDigisPath3
TrigReport     1   10      20000        950      19050          0 TestL1uGTEmuPath3
TrigReport     1   11      20000         25      19975          0 TestL1TMismatchPath3
TrigReport     1   12      20000        566      19434          0 TestL1TDigisPath4
TrigReport     1   13      20000        556      19444          0 TestL1uGTEmuPath4
TrigReport     1   14      20000         10      19990          0 TestL1TMismatchPath4
TrigReport     1   15      20000         87      19913          0 TestL1TDigisPath5
TrigReport     1   16      20000         87      19913          0 TestL1uGTEmuPath5
TrigReport     1   17      20000          0      20000          0 TestL1TMismatchPath5
TrigReport     1   18      20000         10      19990          0 TestL1TDigisPath6
TrigReport     1   19      20000         10      19990          0 TestL1uGTEmuPath6
TrigReport     1   20      20000          0      20000          0 TestL1TMismatchPath6
TrigReport     1   21      20000        157      19843          0 TestL1TMismatchAnyPath
```

[3]
```
TrigReport ---------- Event  Summary ------------
TrigReport Events total = 20000 passed = 1990 failed = 18010

TrigReport ---------- Path   Summary ------------
TrigReport  Trig Bit#   Executed     Passed     Failed      Error Name
TrigReport     1    0      20000       1987      18013          0 TestL1TDigisPath0
TrigReport     1    1      20000       1988      18012          0 TestL1uGTEmuPath0
TrigReport     1    2      20000          5      19995          0 TestL1TMismatchPath0
TrigReport     1    3      20000       1594      18406          0 TestL1TDigisPath1
TrigReport     1    4      20000       1597      18403          0 TestL1uGTEmuPath1
TrigReport     1    5      20000          5      19995          0 TestL1TMismatchPath1
TrigReport     1    6      20000       1252      18748          0 TestL1TDigisPath2
TrigReport     1    7      20000       1253      18747          0 TestL1uGTEmuPath2
TrigReport     1    8      20000          1      19999          0 TestL1TMismatchPath2
TrigReport     1    9      20000        975      19025          0 TestL1TDigisPath3
TrigReport     1   10      20000        975      19025          0 TestL1uGTEmuPath3
TrigReport     1   11      20000          4      19996          0 TestL1TMismatchPath3
TrigReport     1   12      20000        566      19434          0 TestL1TDigisPath4
TrigReport     1   13      20000        566      19434          0 TestL1uGTEmuPath4
TrigReport     1   14      20000          2      19998          0 TestL1TMismatchPath4
TrigReport     1   15      20000         87      19913          0 TestL1TDigisPath5
TrigReport     1   16      20000         87      19913          0 TestL1uGTEmuPath5
TrigReport     1   17      20000          0      20000          0 TestL1TMismatchPath5
TrigReport     1   18      20000         10      19990          0 TestL1TDigisPath6
TrigReport     1   19      20000         10      19990          0 TestL1uGTEmuPath6
TrigReport     1   20      20000          0      20000          0 TestL1TMismatchPath6
TrigReport     1   21      20000         17      19983          0 TestL1TMismatchAnyPath
```

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#49753

Backport of a bugfix to the L1-uGT emulator for 2026 data-taking purposes (e.g. L1-uGT online DQM).