### PR TITLE
Remove alpaka procModfier from workflows in which it is no longer useful

### DIFF
--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -58,15 +58,14 @@ The offsets currently in use are:
 * 0.751: HLT phase-2 timing menu Alpaka variant
 * 0.7511: HLT phase-2 timing menu, with PixelTracks CA Extension
 * 0.752: HLT phase-2 timing menu ticl_v5 variant
-* 0.753: HLT phase-2 timing menu Alpaka, single tracking iteration variant
-* 0.754: HLT phase-2 timing menu Alpaka, single tracking iteration, LST building variant
-* 0.755: HLT phase-2 timing menu Alpaka, LST building variant
+* 0.753: HLT phase-2 timing menu single tracking iteration variant
+* 0.754: HLT phase-2 timing menu single tracking iteration, LST building variant
+* 0.755: HLT phase-2 timing menu LST building variant
 * 0.756 HLT phase-2 timing menu trimmed tracking
-* 0.7561 HLT phase-2 timing menu Alpaka, trimmed tracking
-* 0.7562 HLT phase-2 timing menu Alpaka, trimmed tracking, single tracking iteration variant
-* 0.757: HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + CKF building variant
-* 0.7571: HLT phase-2 timing menu Alpaka, single tracking iteration, Phase2CAExtension+LST seeding + mkFit building variant
-* 0.7572: HLT phase-2 timing menu Alpaka, single tracking iteration, Phase2CAExtension+LST seeding + mkFit building and fitting variant
+* 0.7561 HLT phase-2 timing menu trimmed tracking, single tracking iteration variant
+* 0.757: HLT phase-2 timing menu single tracking iteration, LST seeding + CKF building variant
+* 0.7571: HLT phase-2 timing menu single tracking iteration, Phase2CAExtension+LST seeding + mkFit building variant
+* 0.7572: HLT phase-2 timing menu single tracking iteration, Phase2CAExtension+LST seeding + mkFit building and fitting variant
 * 0.758 HLT phase-2 timing menu ticl_barrel variant
 * 0.759: HLT phase-2 timing menu, with NANO:@Phase2HLT
 * 0.76: HLT phase-2 reduced menu, with DIGI step

--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -58,6 +58,7 @@ The offsets currently in use are:
 * 0.751: HLT phase-2 timing menu Alpaka variant
 * 0.7511: HLT phase-2 timing menu, with PixelTracks CA Extension
 * 0.752: HLT phase-2 timing menu ticl_v5 variant
+* 0.7521: HLT phase-2 timing menu ticl_v5, ticlv5TrackLinkingGNN variant
 * 0.753: HLT phase-2 timing menu single tracking iteration variant
 * 0.754: HLT phase-2 timing menu single tracking iteration, LST building variant
 * 0.755: HLT phase-2 timing menu LST building variant

--- a/Configuration/PyReleaseValidation/python/relval_Run4.py
+++ b/Configuration/PyReleaseValidation/python/relval_Run4.py
@@ -58,15 +58,14 @@ numWFIB.extend([prefixDet+34.751]) # HLTTiming75e33, alpaka
 numWFIB.extend([prefixDet+34.7511])# HLTTiming75e33, phase2CAExtension
 numWFIB.extend([prefixDet+34.752]) # HLTTiming75e33, ticl_v5
 numWFIB.extend([prefixDet+34.7521])# HLTTiming75e33, ticl_v5, ticlv5TrackLinkingGNN
-numWFIB.extend([prefixDet+34.753]) # HLTTiming75e33, alpaka,singleIterPatatrack
-numWFIB.extend([prefixDet+34.754]) # HLTTiming75e33, alpaka,singleIterPatatrack,trackingLST
-numWFIB.extend([prefixDet+34.755]) # HLTTiming75e33, alpaka,trackingLST
+numWFIB.extend([prefixDet+34.753]) # HLTTiming75e33, singleIterPatatrack
+numWFIB.extend([prefixDet+34.754]) # HLTTiming75e33, singleIterPatatrack,trackingLST
+numWFIB.extend([prefixDet+34.755]) # HLTTiming75e33, trackingLST
 numWFIB.extend([prefixDet+34.756]) # HLTTiming75e33, phase2_hlt_vertexTrimming
-numWFIB.extend([prefixDet+34.7561])# HLTTiming75e33, alpaka,phase2_hlt_vertexTrimming
-numWFIB.extend([prefixDet+34.7562])# HLTTiming75e33, alpaka,phase2_hlt_vertexTrimming,singleIterPatatrack
-numWFIB.extend([prefixDet+34.757]) # HLTTiming75e33, alpaka,singleIterPatatrack,trackingLST,seedingLST
-numWFIB.extend([prefixDet+34.7571]) # HLTTiming75e33, alpaka,singleIterPatatrack,Phase2CAExtension,trackingLST,seedingLST,buildingMkFit
-numWFIB.extend([prefixDet+34.7572]) # HLTTiming75e33, alpaka,singleIterPatatrack,Phase2CAExtension,trackingLST,seedingLST,buildingMkFit,fittingMkFit
+numWFIB.extend([prefixDet+34.7561])# HLTTiming75e33, phase2_hlt_vertexTrimming,singleIterPatatrack
+numWFIB.extend([prefixDet+34.757]) # HLTTiming75e33, singleIterPatatrack,trackingLST,seedingLST
+numWFIB.extend([prefixDet+34.7571]) # HLTTiming75e33, singleIterPatatrack,Phase2CAExtension,trackingLST,seedingLST,buildingMkFit
+numWFIB.extend([prefixDet+34.7572]) # HLTTiming75e33, singleIterPatatrack,Phase2CAExtension,trackingLST,seedingLST,buildingMkFit,fittingMkFit
 numWFIB.extend([prefixDet+34.758]) # HLTTiming75e33, ticl_barrel
 numWFIB.extend([prefixDet+34.759]) # HLTTiming75e33 + NANO
 numWFIB.extend([prefixDet+34.77])  # NGTScouting

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1970,42 +1970,42 @@ upgradeWFs['HLTTiming75e33TiclV5TrackLinkingGNN'].step3 = {
 }
 
 
-upgradeWFs['HLTTiming75e33AlpakaSingleIter'] = deepcopy(upgradeWFs['HLTTiming75e33'])
-upgradeWFs['HLTTiming75e33AlpakaSingleIter'].suffix = '_HLT75e33TimingAlpakaSingleIter'
-upgradeWFs['HLTTiming75e33AlpakaSingleIter'].offset = 0.753
-upgradeWFs['HLTTiming75e33AlpakaSingleIter'].step2 = {
+upgradeWFs['HLTTiming75e33SingleIter'] = deepcopy(upgradeWFs['HLTTiming75e33'])
+upgradeWFs['HLTTiming75e33SingleIter'].suffix = '_HLT75e33TimingSingleIter'
+upgradeWFs['HLTTiming75e33SingleIter'].offset = 0.753
+upgradeWFs['HLTTiming75e33SingleIter'].step2 = {
     '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing,VALIDATION:@hltValidation',
-    '--procModifiers': 'alpaka,singleIterPatatrack',
+    '--procModifiers': 'singleIterPatatrack',
     '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
     '--eventcontent':'FEVTDEBUGHLT,DQMIO'
 }
-upgradeWFs['HLTTiming75e33AlpakaSingleIter'].step3 = {
+upgradeWFs['HLTTiming75e33SingleIter'].step3 = {
     '-s':'HARVESTING:@hltValidation'
 }
 
-upgradeWFs['HLTTiming75e33AlpakaSingleIterLST'] = deepcopy(upgradeWFs['HLTTiming75e33'])
-upgradeWFs['HLTTiming75e33AlpakaSingleIterLST'].suffix = '_HLT75e33TimingAlpakaSingleIterLST'
-upgradeWFs['HLTTiming75e33AlpakaSingleIterLST'].offset = 0.754
-upgradeWFs['HLTTiming75e33AlpakaSingleIterLST'].step2 = {
+upgradeWFs['HLTTiming75e33SingleIterLST'] = deepcopy(upgradeWFs['HLTTiming75e33'])
+upgradeWFs['HLTTiming75e33SingleIterLST'].suffix = '_HLT75e33TimingSingleIterLST'
+upgradeWFs['HLTTiming75e33SingleIterLST'].offset = 0.754
+upgradeWFs['HLTTiming75e33SingleIterLST'].step2 = {
     '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing,VALIDATION:@hltValidation',
-    '--procModifiers': 'alpaka,singleIterPatatrack,trackingLST',
+    '--procModifiers': 'singleIterPatatrack,trackingLST',
     '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
     '--eventcontent':'FEVTDEBUGHLT,DQMIO'
 }
-upgradeWFs['HLTTiming75e33AlpakaSingleIterLST'].step3 = {
+upgradeWFs['HLTTiming75e33SingleIterLST'].step3 = {
     '-s':'HARVESTING:@hltValidation'
 }
 
-upgradeWFs['HLTTiming75e33AlpakaLST'] = deepcopy(upgradeWFs['HLTTiming75e33'])
-upgradeWFs['HLTTiming75e33AlpakaLST'].suffix = '_HLT75e33TimingAlpakaLST'
-upgradeWFs['HLTTiming75e33AlpakaLST'].offset = 0.755
-upgradeWFs['HLTTiming75e33AlpakaLST'].step2 = {
+upgradeWFs['HLTTiming75e33LST'] = deepcopy(upgradeWFs['HLTTiming75e33'])
+upgradeWFs['HLTTiming75e33LST'].suffix = '_HLT75e33TimingLST'
+upgradeWFs['HLTTiming75e33LST'].offset = 0.755
+upgradeWFs['HLTTiming75e33LST'].step2 = {
     '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing,VALIDATION:@hltValidation',
-    '--procModifiers': 'alpaka,trackingLST',
+    '--procModifiers': 'trackingLST',
     '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
     '--eventcontent':'FEVTDEBUGHLT,DQMIO'
 }
-upgradeWFs['HLTTiming75e33AlpakaLST'].step3 = {
+upgradeWFs['HLTTiming75e33LST'].step3 = {
     '-s':'HARVESTING:@hltValidation'
 }
 
@@ -2019,62 +2019,52 @@ upgradeWFs['HLTTiming75e33TrimmedTracking'].step2 = {
     '--eventcontent':'FEVTDEBUGHLT,DQMIO'
 }
 
-upgradeWFs['HLTTiming75e33AlpakaTrimmedTracking'] = deepcopy(upgradeWFs['HLTTiming75e33'])
-upgradeWFs['HLTTiming75e33AlpakaTrimmedTracking'].suffix = '_HLT75e33TimingAlpakaTrimmedTracking'
-upgradeWFs['HLTTiming75e33AlpakaTrimmedTracking'].offset = 0.7561
-upgradeWFs['HLTTiming75e33AlpakaTrimmedTracking'].step2 = {
+upgradeWFs['HLTTiming75e33TrimmedTrackingSingleIter'] = deepcopy(upgradeWFs['HLTTiming75e33'])
+upgradeWFs['HLTTiming75e33TrimmedTrackingSingleIter'].suffix = '_HLT75e33TimingTrimmedTrackingSingleIter'
+upgradeWFs['HLTTiming75e33TrimmedTrackingSingleIter'].offset = 0.7561
+upgradeWFs['HLTTiming75e33TrimmedTrackingSingleIter'].step2 = {
     '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing,VALIDATION:@hltValidation',
-    '--procModifiers': 'alpaka,phase2_hlt_vertexTrimming',
+    '--procModifiers': 'phase2_hlt_vertexTrimming,singleIterPatatrack',
     '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
     '--eventcontent':'FEVTDEBUGHLT,DQMIO'
 }
 
-upgradeWFs['HLTTiming75e33AlpakaTrimmedTrackingSingleIter'] = deepcopy(upgradeWFs['HLTTiming75e33'])
-upgradeWFs['HLTTiming75e33AlpakaTrimmedTrackingSingleIter'].suffix = '_HLT75e33TimingAlpakaTrimmedTrackingSingleIter'
-upgradeWFs['HLTTiming75e33AlpakaTrimmedTrackingSingleIter'].offset = 0.7562
-upgradeWFs['HLTTiming75e33AlpakaTrimmedTrackingSingleIter'].step2 = {
+upgradeWFs['HLTTiming75e33SingleIterLSTSeeding'] = deepcopy(upgradeWFs['HLTTiming75e33'])
+upgradeWFs['HLTTiming75e33SingleIterLSTSeeding'].suffix = '_HLT75e33TimingSingleIterLSTSeeding'
+upgradeWFs['HLTTiming75e33SingleIterLSTSeeding'].offset = 0.757
+upgradeWFs['HLTTiming75e33SingleIterLSTSeeding'].step2 = {
     '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing,VALIDATION:@hltValidation',
-    '--procModifiers': 'alpaka,phase2_hlt_vertexTrimming,singleIterPatatrack',
+    '--procModifiers': 'singleIterPatatrack,trackingLST,seedingLST',
     '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
     '--eventcontent':'FEVTDEBUGHLT,DQMIO'
 }
-
-upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeeding'] = deepcopy(upgradeWFs['HLTTiming75e33'])
-upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeeding'].suffix = '_HLT75e33TimingAlpakaSingleIterLSTSeeding'
-upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeeding'].offset = 0.757
-upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeeding'].step2 = {
-    '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing,VALIDATION:@hltValidation',
-    '--procModifiers': 'alpaka,singleIterPatatrack,trackingLST,seedingLST',
-    '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
-    '--eventcontent':'FEVTDEBUGHLT,DQMIO'
-}
-upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeeding'].step3 = {
+upgradeWFs['HLTTiming75e33SingleIterLSTSeeding'].step3 = {
     '-s':'HARVESTING:@hltValidation'
 }
 
-upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuilding'] = deepcopy(upgradeWFs['HLTTiming75e33'])
-upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuilding'].suffix = '_HLT75e33TimingAlpakaSingleIterLSTSeedingMkFitBuilding'
-upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuilding'].offset = 0.7571
-upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuilding'].step2 = {
+upgradeWFs['HLTTiming75e33SingleIterCAExtLSTSeedingMkFitBuilding'] = deepcopy(upgradeWFs['HLTTiming75e33'])
+upgradeWFs['HLTTiming75e33SingleIterCAExtLSTSeedingMkFitBuilding'].suffix = '_HLT75e33TimingSingleIterCAExtLSTSeedingMkFitBuilding'
+upgradeWFs['HLTTiming75e33SingleIterCAExtLSTSeedingMkFitBuilding'].offset = 0.7571
+upgradeWFs['HLTTiming75e33SingleIterCAExtLSTSeedingMkFitBuilding'].step2 = {
     '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing,VALIDATION:@hltValidation',
-    '--procModifiers': 'alpaka,phase2CAExtension,singleIterPatatrack,trackingLST,seedingLST,trackingMkFitCommon,hltTrackingMkFitInitialStep',
+    '--procModifiers': 'phase2CAExtension,singleIterPatatrack,trackingLST,seedingLST,trackingMkFitCommon,hltTrackingMkFitInitialStep',
     '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
     '--eventcontent':'FEVTDEBUGHLT,DQMIO'
 }
-upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuilding'].step3 = {
+upgradeWFs['HLTTiming75e33SingleIterCAExtLSTSeedingMkFitBuilding'].step3 = {
     '-s':'HARVESTING:@hltValidation'
 }
 
-upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuildingFitting'] = deepcopy(upgradeWFs['HLTTiming75e33'])
-upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuildingFitting'].suffix = '_HLT75e33TimingAlpakaSingleIterLSTSeedingMkFitBuildingFitting'
-upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuildingFitting'].offset = 0.7572
-upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuildingFitting'].step2 = {
+upgradeWFs['HLTTiming75e33SingleIterCAExtLSTSeedingMkFitBuildingFitting'] = deepcopy(upgradeWFs['HLTTiming75e33'])
+upgradeWFs['HLTTiming75e33SingleIterCAExtLSTSeedingMkFitBuildingFitting'].suffix = '_HLT75e33TimingSingleIterCAExtLSTSeedingMkFitBuildingFitting'
+upgradeWFs['HLTTiming75e33SingleIterCAExtLSTSeedingMkFitBuildingFitting'].offset = 0.7572
+upgradeWFs['HLTTiming75e33SingleIterCAExtLSTSeedingMkFitBuildingFitting'].step2 = {
     '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing,VALIDATION:@hltValidation',
-    '--procModifiers': 'alpaka,phase2CAExtension,singleIterPatatrack,trackingLST,seedingLST,trackingMkFitCommon,hltTrackingMkFitInitialStep,trackingMkFitFit',
+    '--procModifiers': 'phase2CAExtension,singleIterPatatrack,trackingLST,seedingLST,trackingMkFitCommon,hltTrackingMkFitInitialStep,trackingMkFitFit',
     '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
     '--eventcontent':'FEVTDEBUGHLT,DQMIO'
 }
-upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuilding'].step3 = {
+upgradeWFs['HLTTiming75e33SingleIterCAExtLSTSeedingMkFitBuilding'].step3 = {
     '-s':'HARVESTING:@hltValidation'
 }
 

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -164,15 +164,14 @@ if __name__ == '__main__':
                      prefixDet+34.7511,  # HLT phase-2 timing menu Phase2CAExtension variant
                      prefixDet+34.752,   # HLT phase-2 timing menu ticl_v5 variant
                      prefixDet+34.7521,  # HLT phase-2 timing menu ticlv5TrackLinkGNN variant   
-                     prefixDet+34.753,   # HLT phase-2 timing menu Alpaka, single tracking iteration variant
-                     prefixDet+34.754,   # HLT phase-2 timing menu Alpaka, single tracking iteration, LST building variant
-                     prefixDet+34.755,   # HLT phase-2 timing menu Alpaka, LST building variant
+                     prefixDet+34.753,   # HLT phase-2 timing menu single tracking iteration variant
+                     prefixDet+34.754,   # HLT phase-2 timing menu single tracking iteration, LST building variant
+                     prefixDet+34.755,   # HLT phase-2 timing menu LST building variant
                      prefixDet+34.756,   # HLT phase-2 timing menu trimmed tracking
-                     prefixDet+34.7561,  # HLT phase-2 timing menu Alpaka, trimmed tracking
-                     prefixDet+34.7562,  # HLT phase-2 timing menu Alpaka, trimmed tracking, single tracking iteration variant
-                     prefixDet+34.757,   # HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + CKF building variant
-                     prefixDet+34.7571,  # HLT phase-2 timing menu Alpaka, single tracking iteration, Phase2CAExtension+LST seeding + mkFit building variant
-                     prefixDet+34.7572,  # HLT phase-2 timing menu Alpaka, single tracking iteration, Phase2CAExtension+LST seeding + mkFit building and fitting variant
+                     prefixDet+34.7561,  # HLT phase-2 timing menu trimmed tracking, single tracking iteration variant
+                     prefixDet+34.757,   # HLT phase-2 timing menu single tracking iteration, LST seeding + CKF building variant
+                     prefixDet+34.7571,  # HLT phase-2 timing menu single tracking iteration, Phase2CAExtension+LST seeding + mkFit building variant
+                     prefixDet+34.7572,  # HLT phase-2 timing menu single tracking iteration, Phase2CAExtension+LST seeding + mkFit building and fitting variant
                      prefixDet+34.758,   # HLT phase-2 timing menu ticl_barrel variant
                      prefixDet+34.759,   # HLT phase-2 timing menu, with NANO:@Phase2HLT
                      prefixDet+34.77,    # HLT phase-2 NGT Scouting menu


### PR DESCRIPTION
In #48921, Patatrack quadraplet pixel tracks were made the default in CMSSW, so the alpaka modifier was rendered useless in a quite a few workflows which were using it to enable Patatrack pixel tracking. This PR removes the alpaka procModifier from these workflows. One workflow is completely removed, as it was duplicate of another, and that leads to a small change in the workflow numbering.

The PR was validated by making sure that all the modified workflows succeed.

FYI @rovere and @waredjeb: Since the `alpaka` procModifier is used in Phase 2 HLT to enable the HGCal heterogeneous reconstruction, I wanted to ask whether it is useful to keep it in any of the modified workflows.
