### PR TITLE
Move Track and TrackExtra to io_v1 namespace [EVOLUTION_X]

### DIFF
--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h
@@ -36,6 +36,7 @@ class Trajectory;
 #include "Alignment/LaserAlignment/interface/TsosVectorCollection.h"
 #include "DataFormats/Alignment/interface/TkFittedLasBeamCollectionFwd.h"
 #include "DataFormats/Alignment/interface/AliClusterValueMapFwd.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
@@ -44,7 +45,6 @@ namespace edm {
   class ParameterSet;
 }  // namespace edm
 namespace reco {
-  class Track;
   class BeamSpot;
 }  // namespace reco
 

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentGlobalTrackSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentGlobalTrackSelector.h
@@ -3,6 +3,7 @@
 
 #include "DataFormats/JetReco/interface/CaloJetCollection.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 //Framework
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -12,9 +13,6 @@
 //STL
 #include <vector>
 
-namespace reco {
-  class Track;
-}
 namespace edm {
   class Event;
   class EventSetup;

--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeMonitor.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeMonitor.h
@@ -13,6 +13,7 @@
 
 #include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
 
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "Alignment/ReferenceTrajectories/interface/ReferenceTrajectoryBase.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -32,10 +33,6 @@ class TDirectory;
 class Trajectory;
 
 class TrackerTopology;
-
-namespace reco {
-  class Track;
-}
 
 class Alignable;
 class AlignableDetOrUnitPtr;

--- a/AnalysisDataFormats/SUSYBSMObjects/src/classes_def.xml
+++ b/AnalysisDataFormats/SUSYBSMObjects/src/classes_def.xml
@@ -1,6 +1,6 @@
 <lcgdict>
-   <class name="susybsm::HSCParticle" ClassVersion="12">
-    <version ClassVersion="12" checksum="3951465682"/>
+   <class name="susybsm::HSCParticle" ClassVersion="3">
+    <version ClassVersion="3" checksum="2568887826"/>
    </class>
    <class name="susybsm::RPCBetaMeasurement" ClassVersion="10">
     <version ClassVersion="10" checksum="2621605308"/>

--- a/AnalysisDataFormats/TrackInfo/src/classes_def.xml
+++ b/AnalysisDataFormats/TrackInfo/src/classes_def.xml
@@ -24,16 +24,16 @@
   </class>
   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<std::vector<reco::Track>,std::vector<reco::TrackInfo>,unsigned int> > >" />
 
-  <class name="TPtoRecoTrack" ClassVersion="10">
-   <version ClassVersion="10" checksum="909265596"/>
+  <class name="TPtoRecoTrack" ClassVersion="3">
+   <version ClassVersion="3" checksum="560670808"/>
   </class>
   <class name="edm::Wrapper<TPtoRecoTrack>"/>
   
   <class name="std::vector<TPtoRecoTrack>"/>
   <class name="edm::Wrapper<std::vector<TPtoRecoTrack> >"/>
 
-  <class name="RecoTracktoTP" ClassVersion="10">
-   <version ClassVersion="10" checksum="3470602586"/>
+  <class name="RecoTracktoTP" ClassVersion="3">
+   <version ClassVersion="3" checksum="612992052"/>
   </class>
   <class name="edm::Wrapper<RecoTracktoTP>"/>
   

--- a/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayTOF.h
+++ b/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayTOF.h
@@ -1,9 +1,7 @@
 #ifndef CalibTracker_SiSitripLorentzAngle_SiStripFineDelayTOF_h
 #define CalibTracker_SiSitripLorentzAngle_SiStripFineDelayTOF_h
 
-namespace reco {
-  class Track;
-}
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 class TrackingRecHit;
 

--- a/DQM/TrackingMonitorSource/interface/TrackToTrackComparisonHists.h
+++ b/DQM/TrackingMonitorSource/interface/TrackToTrackComparisonHists.h
@@ -29,7 +29,6 @@
 //
 class DQMStore;
 namespace reco {
-  class Track;
   class BeamSpot;
   class Vertex;
 }  // namespace reco

--- a/DataFormats/BTauReco/src/classes_def.xml
+++ b/DataFormats/BTauReco/src/classes_def.xml
@@ -21,9 +21,8 @@
   <class name="reco::JetTagInfoRefVector"/>
   <class name="edm::Wrapper<reco::JetTagInfoCollection>"/>
 
-  <class name="reco::JTATagInfo" ClassVersion="11">
-   <version ClassVersion="11" checksum="3077814749"/>
-   <version ClassVersion="10" checksum="1485737861"/>
+  <class name="reco::JTATagInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="2626339357"/>
   </class>
   <class name="reco::JTATagInfoCollection"/>
   <class name="reco::JTATagInfoRef"/>
@@ -84,9 +83,8 @@
   <class name="edm::Wrapper<reco::ShallowTagInfoCollection>"/>
   <class name="edm::Wrapper<std::vector<reco::ShallowTagInfo> >"/>
 
-  <class name="reco::CombinedTauTagInfo" ClassVersion="11">
-   <version ClassVersion="11" checksum="224969361"/>
-   <version ClassVersion="10" checksum="3920242404"/>
+  <class name="reco::CombinedTauTagInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="2237505417"/>
   </class>
   <class name="reco::CombinedTauTagInfoCollection"/>
   <class name="reco::CombinedTauTagInfoRef"/>
@@ -95,9 +93,8 @@
   <class name="reco::CombinedTauTagInfoRefVector"/>
   <class name="edm::Wrapper<reco::CombinedTauTagInfoCollection>"/>
 
-  <class name="reco::IsolatedTauTagInfo" ClassVersion="11">
-   <version ClassVersion="11" checksum="1582752903"/>
-   <version ClassVersion="10" checksum="3305352842"/>
+  <class name="reco::IsolatedTauTagInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="2139950407"/>
   </class>
   <class name="reco::IsolatedTauTagInfoCollection"/>
   <class name="reco::IsolatedTauTagInfoRef"/>
@@ -126,8 +123,8 @@
     <![CDATA[sip3d = 0;]]>
   </ioread>
   
-  <class name="std::pair<edm::RefToBase<reco::Track>, reco::SoftLeptonProperties>"/>
-  <class name="reco::TemplatedSoftLeptonTagInfo<edm::RefToBase<reco::Track> >::LeptonMap"/>
+  <class name="std::pair<edm::RefToBase<reco::io_v1::Track>, reco::SoftLeptonProperties>"/>
+  <class name="reco::TemplatedSoftLeptonTagInfo<edm::RefToBase<reco::io_v1::Track> >::LeptonMap"/>
   <class name="reco::SoftLeptonTagInfo" />
   <class name="reco::SoftLeptonTagInfoCollection"/>
   <class name="reco::SoftLeptonTagInfoRef"/>
@@ -214,8 +211,8 @@
   <class name="reco::TauImpactParameterTrackData" ClassVersion="10">
    <version ClassVersion="10" checksum="3058583707"/>
   </class>
-  <class name="reco::TauImpactParameterInfo" ClassVersion="10">
-   <version ClassVersion="10" checksum="2113839025"/>
+  <class name="reco::TauImpactParameterInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="3204581905"/>
   </class>
   <class name="reco::TauImpactParameterInfoCollection"/>
   <class name="reco::TauImpactParameterInfoRef"/>
@@ -231,9 +228,8 @@
   <!--commented out because the typedef resolves to std containers of built in types-->
   <!--class name="reco::TauMassTagInfo_ClusterTrackAssociationMapType"/-->
   <class name="reco::TauMassTagInfo_ClusterTrackAssociationRefType"/>
-  <class name="reco::TauMassTagInfo" ClassVersion="11">
-   <version ClassVersion="11" checksum="2786100405"/>
-   <version ClassVersion="10" checksum="2019622266"/>
+  <class name="reco::TauMassTagInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="1251178229"/>
   </class>
   <class name="reco::TauMassTagInfoCollection"/>
   <class name="reco::TauMassTagInfoRef"/>
@@ -242,9 +238,8 @@
   <class name="reco::TauMassTagInfoRefVector"/>
   <class name="edm::Wrapper<reco::TauMassTagInfoCollection>"/>
 
-  <class name="reco::TrackCountingTagInfo" ClassVersion="11">
-   <version ClassVersion="11" checksum="2205881990"/>
-   <version ClassVersion="10" checksum="4189230159"/>
+  <class name="reco::TrackCountingTagInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="4167605446"/>
   </class>
   <class name="reco::TrackCountingTagInfoCollection"/>
   <class name="reco::TrackCountingTagInfoRef"/>
@@ -253,9 +248,8 @@
   <class name="reco::TrackCountingTagInfoRefVector"/>
   <class name="edm::Wrapper<reco::TrackCountingTagInfoCollection>"/>
 
-  <class name="reco::TrackProbabilityTagInfo" ClassVersion="11">
-   <version ClassVersion="11" checksum="1102826734"/>
-   <version ClassVersion="10" checksum="2989842515"/>
+  <class name="reco::TrackProbabilityTagInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="366358830"/>
   </class>
   <class name="reco::TrackProbabilityTagInfoCollection"/>
   <class name="reco::TrackProbabilityTagInfoRef"/>

--- a/DataFormats/Candidate/interface/Candidate.h
+++ b/DataFormats/Candidate/interface/Candidate.h
@@ -23,7 +23,11 @@
 class OverlapChecker;
 
 namespace reco {
-  class Track;
+  namespace io_v1 {
+    class Track;
+  }
+  using Track = io_v1::Track;
+
   class Candidate {
   public:
     typedef size_t size_type;

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -17,17 +17,11 @@
    <version ClassVersion="13" checksum="2963666409"/>
    <version ClassVersion="14" checksum="753726370"/>
   </class>
-  <class name="reco::Conversion" ClassVersion="11">
-   <version ClassVersion="10" checksum="2140222741"/>
-   <version ClassVersion="11" checksum="598717096"/>
+  <class name="reco::Conversion" ClassVersion="3">
+   <version ClassVersion="3" checksum="2072110730"/>
   </class>
-  <ioread sourceClass = "reco::Conversion" version="[1-10]" targetClass="reco::Conversion" source="std::vector<reco::TrackRef> tracks_; std::vector<edm::RefToBase<reco::Track> > trackToBaseRefs_" target="trackToBaseRefs_">
-     <![CDATA[trackToBaseRefs_=onfile.trackToBaseRefs_; if(onfile.tracks_.size()>onfile.trackToBaseRefs_.size()) { for(auto const& t: onfile.tracks_) { trackToBaseRefs_.emplace_back(t);} }]]>
-  </ioread>
-  <class name="reco::Electron" ClassVersion="13">
-   <version ClassVersion="13" checksum="827670837"/>
-   <version ClassVersion="12" checksum="1547192125"/>
-   <version ClassVersion="11" checksum="1178796923"/>
+  <class name="reco::Electron" ClassVersion="3">
+   <version ClassVersion="3" checksum="3447704829"/>
   </class>
   <class name="reco::SiStripElectron" ClassVersion="13">
    <version ClassVersion="13" checksum="1547231262"/>
@@ -130,14 +124,9 @@
 
 
 
-  <class name="reco::GsfElectronCore" ClassVersion="12">
-   <version ClassVersion="10" checksum="2226610106"/>
-   <version ClassVersion="11" checksum="2637403054"/>
-   <version ClassVersion="12" checksum="2885797746"/>
+  <class name="reco::GsfElectronCore" ClassVersion="3">
+   <version ClassVersion="3" checksum="1298688554"/>
   </class>
-  <ioread sourceClass="reco::GsfElectronCore" version="[1-10]" targetClass="reco::GsfElectronCore" source="reco::SuperClusterRef pflowSuperCluster_;" target="parentSuperCluster_">
-    <![CDATA[parentSuperCluster_ = onfile.pflowSuperCluster_;]]>
-  </ioread>
 
   <class name="std::vector<reco::GsfElectronCore>"/>
   <class name="edm::reftobase::BaseHolder<reco::GsfElectronCore>"/>
@@ -157,8 +146,8 @@
   <class name="reco::GsfElectron::TrackExtrapolations" ClassVersion="10">
    <version ClassVersion="10" checksum="517526181"/>
   </class>
-  <class name="reco::GsfElectron::ClosestCtfTrack" ClassVersion="10">
-   <version ClassVersion="10" checksum="1307042460"/>
+  <class name="reco::GsfElectron::ClosestCtfTrack" ClassVersion="3">
+   <version ClassVersion="3" checksum="3122967300"/>
   </class>
   <class name="reco::GsfElectron::FiducialFlags" ClassVersion="10">
    <version ClassVersion="10" checksum="2564471186"/>
@@ -176,9 +165,8 @@
    <version ClassVersion="11" checksum="1799511018"/>
    <version ClassVersion="10" checksum="4260674990"/>
   </class>
-  <class name="reco::GsfElectron::ConversionRejection" ClassVersion="11">
-   <version ClassVersion="11" checksum="2813508647"/>
-   <version ClassVersion="10" checksum="190549577"/>
+  <class name="reco::GsfElectron::ConversionRejection" ClassVersion="3">
+   <version ClassVersion="3" checksum="2253948903"/>
   </class>
   <class name="reco::GsfElectron::Corrections" ClassVersion="12">
    <version ClassVersion="12" checksum="796270676"/>

--- a/DataFormats/EgammaReco/src/classes.h
+++ b/DataFormats/EgammaReco/src/classes.h
@@ -1,4 +1,5 @@
 #include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Common/interface/AtomicPtrCache.h"
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 #include "Math/Cartesian3D.h"
 #include "DataFormats/Common/interface/RefProd.h"

--- a/DataFormats/EgammaReco/src/classes_def.xml
+++ b/DataFormats/EgammaReco/src/classes_def.xml
@@ -91,15 +91,9 @@
   <class name="edm::RefVector<std::vector<reco::PreshowerClusterShape>,reco::PreshowerClusterShape,edm::refhelper::FindUsingAdvance<std::vector<reco::PreshowerClusterShape>,reco::PreshowerClusterShape> >"/>
   <class name="edm::Wrapper<edm::RefVector<std::vector<reco::PreshowerClusterShape>,reco::PreshowerClusterShape,edm::refhelper::FindUsingAdvance<std::vector<reco::PreshowerClusterShape>,reco::PreshowerClusterShape> > >" splitLevel="0"/>
 
-  <class name="reco::ElectronSeed" ClassVersion="13">
-   <version ClassVersion="13" checksum="3112955595"/> 
-   <version ClassVersion="12" checksum="536071409"/>
-   <version ClassVersion="11" checksum="3831394066"/>
-   <version ClassVersion="10" checksum="534580602"/>
+  <class name="reco::ElectronSeed" ClassVersion="3">
+    <version ClassVersion="3" checksum="567408035"/>
   </class>
-  <ioread sourceClass="reco::ElectronSeed" version="[1-12]" targetClass="reco::ElectronSeed" source="float dRz2_; float dPhi2_; float dRz2Pos_; float dPhi2Pos_; float dRz1_; float dPhi1_; float dRz1Pos_; float dPhi1Pos_; unsigned char hitsMask_;" target="hitInfo_">
-    <![CDATA[hitInfo_ = reco::ElectronSeed::createHitInfo(onfile.dPhi1Pos_,onfile.dPhi1_,onfile.dRz1Pos_,onfile.dRz1_,onfile.dPhi2Pos_,onfile.dPhi2_,onfile.dRz2Pos_,onfile.dRz2_,onfile.hitsMask_,newObj->recHits());]]>
-  </ioread>
   <class name="reco::ElectronSeed::PMVars" ClassVersion="3">
     <version ClassVersion="3" checksum="1322802316"/>
   </class>

--- a/DataFormats/EgammaReco/src/classes_def.xml
+++ b/DataFormats/EgammaReco/src/classes_def.xml
@@ -36,6 +36,9 @@
   <class name="edm::Wrapper<edm::RefVector<std::vector<reco::SuperCluster>,reco::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster> > >"/>
   <class name="std::vector<edm::Ref<std::vector<reco::SuperCluster>,reco::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster> > >"/>
   <class name="edm::Wrapper<std::vector<edm::Ref<std::vector<reco::SuperCluster>,reco::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster> > > >"/>
+  <class name="edm::AtomicPtrCache<std::vector<reco::SuperCluster> >">
+   <field name="m_data" transient="true"/>
+  </class>
 
   <class name="reco::ClusterShape" ClassVersion="11">
    <version ClassVersion="11" checksum="3739311734"/>

--- a/DataFormats/EgammaTrackReco/src/classes_def.xml
+++ b/DataFormats/EgammaTrackReco/src/classes_def.xml
@@ -1,7 +1,6 @@
 <lcgdict>
-   <class name="reco::ConversionTrack" ClassVersion="11">
-    <version ClassVersion="11" checksum="1446912891"/>
-    <version ClassVersion="10" checksum="2951396223"/>
+  <class name="reco::ConversionTrack" ClassVersion="3">
+    <version ClassVersion="3" checksum="3168503251"/>
      <field name="traj_" transient="true" />
    </class>
    <class name="reco::ConversionTrackCollection" />

--- a/DataFormats/GsfTrackReco/src/classes_def.xml
+++ b/DataFormats/GsfTrackReco/src/classes_def.xml
@@ -24,17 +24,8 @@
   <class name="edm::Ref<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
   <class name="edm::RefVector<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
 
-  <class name="reco::GsfTrack" ClassVersion="20">
-   <version ClassVersion="20" checksum="3090385640"/>
-   <version ClassVersion="19" checksum="2111870580"/>
-   <version ClassVersion="18" checksum="1193413886"/>
-   <version ClassVersion="17" checksum="2463004588"/>
-   <version ClassVersion="16" checksum="4129402716"/>
-   <version ClassVersion="15" checksum="2494468278"/>
-   <version ClassVersion="14" checksum="3085391575"/>
-   <version ClassVersion="13" checksum="1287963871"/>
-   <version ClassVersion="12" checksum="1456169080"/>
-   <version ClassVersion="11" checksum="1456169080"/>
+  <class name="reco::GsfTrack" ClassVersion="3">
+    <version ClassVersion="3" checksum="916246232"/>
     <field name="momentumMode_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
   </class>
   <class name="std::vector<reco::GsfTrack>"/>

--- a/DataFormats/GsfTrackReco/src/classes_def.xml
+++ b/DataFormats/GsfTrackReco/src/classes_def.xml
@@ -25,7 +25,7 @@
   <class name="edm::RefVector<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
 
   <class name="reco::GsfTrack" ClassVersion="3">
-    <version ClassVersion="3" checksum="916246232"/>
+    <version ClassVersion="3" checksum="100950784"/>
     <field name="momentumMode_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
   </class>
   <class name="std::vector<reco::GsfTrack>"/>

--- a/DataFormats/HGCalReco/src/classes_def.xml
+++ b/DataFormats/HGCalReco/src/classes_def.xml
@@ -67,10 +67,8 @@
   <class name="edm::Wrapper<TICLSeedingRegion>" />
   <class name="edm::Wrapper<std::vector<TICLSeedingRegion> >" />
 
-  <class name="TICLCandidate" ClassVersion="5">
-   <version ClassVersion="5" checksum="809321696"/>
-   <version ClassVersion="4" checksum="2260471800"/>
-   <version ClassVersion="3" checksum="450468662"/>
+  <class name="TICLCandidate" ClassVersion="3">
+   <version ClassVersion="3" checksum="1404708640"/>
   </class>
   <class name="std::vector<TICLCandidate>" />
   <class name="edm::Wrapper<TICLCandidate>" />

--- a/DataFormats/HcalIsolatedTrack/src/classes_def.xml
+++ b/DataFormats/HcalIsolatedTrack/src/classes_def.xml
@@ -2,12 +2,8 @@
 
   <class name="edm::Wrapper<std::map <int,std::pair<double,double> > >"/> 
 
-  <class name="reco::IsolatedPixelTrackCandidate" ClassVersion="14">
-   <version ClassVersion="14" checksum="4036611259"/>
-   <version ClassVersion="13" checksum="2098110013"/>
-   <version ClassVersion="12" checksum="2817631301"/>
-   <version ClassVersion="10" checksum="3865088611"/>
-   <version ClassVersion="11" checksum="264617237"/>
+  <class name="reco::IsolatedPixelTrackCandidate" ClassVersion="3">
+   <version ClassVersion="3" checksum="3796960819"/>
   </class>
   <class name="reco::IsolatedPixelTrackCandidateCollection"/>
   <class name="reco::IsolatedPixelTrackCandidateRef"/>
@@ -31,9 +27,8 @@
   <class name="edm::Wrapper<reco::EcalIsolatedParticleCandidateCollection>"/>
   <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::EcalIsolatedParticleCandidate>,reco::EcalIsolatedParticleCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::EcalIsolatedParticleCandidate>,reco::EcalIsolatedParticleCandidate> > >" />
 
-  <class name="reco::HcalIsolatedTrackCandidate" ClassVersion="13">
-   <version ClassVersion="14" checksum="3313409542"/>
-   <version ClassVersion="13" checksum="3313409542"/>
+  <class name="reco::HcalIsolatedTrackCandidate" ClassVersion="3">
+   <version ClassVersion="3" checksum="201453806"/>
   </class>
   <class name="reco::HcalIsolatedTrackCandidateCollection"/>
   <class name="reco::HcalIsolatedTrackCandidateRef"/>

--- a/DataFormats/JetReco/src/classes_def_1.xml
+++ b/DataFormats/JetReco/src/classes_def_1.xml
@@ -47,9 +47,8 @@
    <version ClassVersion="11" checksum="2945806860"/>
    <version ClassVersion="10" checksum="456342263"/>
   </class>
-  <class name="reco::JPTJet::Specific" ClassVersion="11">
-   <version ClassVersion="11" checksum="3661452230"/>
-   <version ClassVersion="10" checksum="3095396018"/>
+  <class name="reco::JPTJet::Specific" ClassVersion="3">
+   <version ClassVersion="3" checksum="1528463198"/>
   </class>
   <class name="std::vector<reco::JPTJet>"/>
   <class name="edm::RefProd<std::vector<reco::JPTJet> >"/>

--- a/DataFormats/JetReco/src/classes_def_4.xml
+++ b/DataFormats/JetReco/src/classes_def_4.xml
@@ -62,8 +62,8 @@
   <class name="std::vector<reco::PFJet::Specific>"   />
   <class name="std::vector<reco::JPTJet::Specific>" />
 
-  <class name="reco::TrackExtrapolation"  ClassVersion="10">
-   <version ClassVersion="10" checksum="4193842732"/>
+  <class name="reco::TrackExtrapolation"  ClassVersion="3">
+   <version ClassVersion="3" checksum="1386552340"/>
   </class>
   <class name="std::vector<reco::TrackExtrapolation>" />
   <class name="edm::Ref<std::vector<reco::TrackExtrapolation>,reco::TrackExtrapolation,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtrapolation>,reco::TrackExtrapolation>  >" />

--- a/DataFormats/METReco/src/classes_def.xml
+++ b/DataFormats/METReco/src/classes_def.xml
@@ -188,10 +188,8 @@
   <class name="std::vector<HaloTowerStrip>"/>
   <class name="edm::Wrapper<std::vector<HaloTowerStrip> >"/>
 
-  <class name="reco::CSCHaloData" ClassVersion="12">
-   <version ClassVersion="12" checksum="299049274"/>
-   <version ClassVersion="11" checksum="1723373351"/>
-   <version ClassVersion="10" checksum="3522217120"/>
+  <class name="reco::CSCHaloData" ClassVersion="3">
+   <version ClassVersion="3" checksum="4033210994"/>
   </class>
   <class name="edm::Wrapper<reco::CSCHaloData>"/>
 

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -8,18 +8,8 @@ not be used as version numbers. By convention, CMS will use 3 as the
 initial version number of a class which has never been stored before.
 -->
 <lcgdict>
-  <class name="reco::Muon" ClassVersion="20">
-   <version ClassVersion="20" checksum="1015091642"/>
-   <version ClassVersion="19" checksum="3201675353"/>
-   <version ClassVersion="18" checksum="2257088106"/>
-   <version ClassVersion="17" checksum="2296096670"/>
-   <version ClassVersion="16" checksum="1808419014"/>
-   <version ClassVersion="15" checksum="4145317518"/>
-   <version ClassVersion="11" checksum="199341143"/>
-   <version ClassVersion="12" checksum="1157850969"/>
-   <version ClassVersion="13" checksum="73400658"/>
-   <version ClassVersion="14" checksum="3316837126"/>
-
+  <class name="reco::Muon" ClassVersion="3">
+   <version ClassVersion="3" checksum="2185262810"/>
   </class>
   <class name="std::vector<reco::Muon>"/>
   <class name="edm::Wrapper<std::vector<reco::Muon> >"/>
@@ -30,8 +20,8 @@ initial version number of a class which has never been stored before.
   <class name="edm::Wrapper<edm::RefVector<std::vector<reco::Muon>,reco::Muon,edm::refhelper::FindUsingAdvance<std::vector<reco::Muon>,reco::Muon> > >"/>
   <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::Muon>,reco::Muon,edm::refhelper::FindUsingAdvance<std::vector<reco::Muon>,reco::Muon> > >" />
 
-<class name="reco::MuonTrackLinks" ClassVersion="10">
- <version ClassVersion="10" checksum="1800265585"/>
+<class name="reco::MuonTrackLinks" ClassVersion="3">
+ <version ClassVersion="3" checksum="4185047177"/>
 </class>
   <class name="std::vector<reco::MuonTrackLinks>"/>
   <class name="edm::Wrapper<std::vector<reco::MuonTrackLinks> >"/>
@@ -92,8 +82,8 @@ initial version number of a class which has never been stored before.
 
   <class name="reco::Muon::MuonTrackRefMap"/>
 
-  <class name="reco::CaloMuon" ClassVersion="10">
-   <version ClassVersion="10" checksum="3458815810"/>
+  <class name="reco::CaloMuon" ClassVersion="3">
+   <version ClassVersion="3" checksum="4152762730"/>
   </class>
   <class name="std::vector<reco::CaloMuon>"/>
   <class name="edm::Wrapper<std::vector<reco::CaloMuon> >"/>

--- a/DataFormats/MuonSeed/src/classes_def.xml
+++ b/DataFormats/MuonSeed/src/classes_def.xml
@@ -28,10 +28,8 @@
       <class name="edm::helpers::KeyVal<edm::Ref<std::vector<L2MuonTrajectorySeed>,L2MuonTrajectorySeed,edm::refhelper::FindUsingAdvance<std::vector<L2MuonTrajectorySeed>,L2MuonTrajectorySeed> >,edm::RefVector<std::vector<L2MuonTrajectorySeed>,L2MuonTrajectorySeed,edm::refhelper::FindUsingAdvance<std::vector<L2MuonTrajectorySeed>,L2MuonTrajectorySeed> > >"/>
 
 
-      <class name="L3MuonTrajectorySeed"  ClassVersion="12">
-       <version ClassVersion="12" checksum="3249417346"/>
-       <version ClassVersion="11" checksum="981061883"/>
-       <version ClassVersion="10" checksum="2200485484"/>
+      <class name="L3MuonTrajectorySeed"  ClassVersion="3">
+        <version ClassVersion="3" checksum="4139547450"/>
       </class>
       <class name="edm::reftobase::BaseHolder<L3MuonTrajectorySeed>" />
       <class name="edm::reftobase::IndirectHolder<L3MuonTrajectorySeed>" />

--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -26,7 +26,9 @@
     <![CDATA[refsCollectionCache_.clear();refsCollectionCache_.resize(onfile.refsInfo_.size(),0); ]]>
   </ioread>
 
-
+   <class name="edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> >">
+     <field name="m_data" transient="true"/>
+  </class>
   <class name="std::vector<reco::PFCandidate>"/>
   <class name="edm::Wrapper<reco::PFCandidate>"/>
   <class name="edm::Wrapper<std::vector<reco::PFCandidate> >"/>

--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -96,8 +96,8 @@
   <class name="std::vector<reco::PFCandidateFwdPtr>"/>
   <class name="edm::Wrapper<std::vector<reco::PFCandidateFwdPtr> >"/>
 
-  <class name="reco::PFCandidateElectronExtra" ClassVersion="10">
-   <version ClassVersion="10" checksum="1297637479"/>
+  <class name="reco::PFCandidateElectronExtra" ClassVersion="3">
+   <version ClassVersion="3" checksum="450244063"/>
 <!-- 
   <field name="mvaVariables_" transient="true"/>
 -->
@@ -108,13 +108,8 @@
   <class name="reco::PFCandidateElectronExtraRefProd"/>
   <class name="reco::PFCandidateElectronExtraRefVector"/>
 
-  <class name="reco::PFCandidatePhotonExtra" ClassVersion="11">
-   <version ClassVersion="10" checksum="536762407"/>
-   <version ClassVersion="11" checksum="1782832559"/>
-<!-- 
-  <field name="assoSingleLegRefTrack_" transient="true"/>
-  <field name="assoSingleLegMva_" transient="true"/>
--->
+  <class name="reco::PFCandidatePhotonExtra" ClassVersion="3">
+   <version ClassVersion="3" checksum="2283262343"/>
   </class>
   <class name="std::vector<reco::PFCandidatePhotonExtra>"/>
   <class name="edm::Wrapper<std::vector<reco::PFCandidatePhotonExtra> >"/>

--- a/DataFormats/ParticleFlowReco/src/classes_def_1.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_1.xml
@@ -31,8 +31,8 @@
   <class name="edm::RefVector<std::vector<reco::PFConversion>,reco::PFConversion,edm::refhelper::FindUsingAdvance<std::vector<reco::PFConversion>,reco::PFConversion> >"/>
   <class name="std::vector<edm::Ref<std::vector<reco::PFRecTrack>,reco::PFRecTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::PFRecTrack>,reco::PFRecTrack> > >"/>
 
- <class name="reco::PFV0"  ClassVersion="10">
-  <version ClassVersion="10" checksum="40832700"/>
+ <class name="reco::PFV0"  ClassVersion="3">
+  <version ClassVersion="3" checksum="1009242484"/>
  </class>
   <class name="std::vector<reco::PFV0>" />
   <class name="edm::Wrapper<std::vector<reco::PFV0> >" />

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -98,29 +98,20 @@
   <class name="edm::Wrapper<std::vector<reco::PFTrajectoryPoint> >"/>
 
   <class name="edm::RefVector<std::vector<reco::PFBlock>,reco::PFBlock,edm::refhelper::FindUsingAdvance<std::vector<reco::PFBlock>,reco::PFBlock> >"/>
-  <class name="reco::PFRecTrack" ClassVersion="13">
-   <version ClassVersion="13" checksum="2549841209"/>
-   <version ClassVersion="12" checksum="2850643502"/>
-   <version ClassVersion="11" checksum="2924298092"/>
-   <version ClassVersion="10" checksum="2979491836"/>
+  <class name="reco::PFRecTrack" ClassVersion="3">
+   <version ClassVersion="3" checksum="3356916753"/>
   </class>
   <class name="std::vector<reco::PFRecTrack>"/>
   <class name="edm::Wrapper<std::vector<reco::PFRecTrack> >"/>
 
-  <class name="reco::GsfPFRecTrack" ClassVersion="13">
-   <version ClassVersion="13" checksum="974620889"/>
-   <version ClassVersion="12" checksum="2203231294"/>
-   <version ClassVersion="11" checksum="2592328732"/>
-   <version ClassVersion="10" checksum="3411096264"/>
+  <class name="reco::GsfPFRecTrack" ClassVersion="3">
+   <version ClassVersion="3" checksum="997076017"/>
   </class>
   <class name="std::vector<reco::GsfPFRecTrack>"/>
   <class name="edm::Wrapper<std::vector<reco::GsfPFRecTrack> >"/>
 
-  <class name="reco::PFBrem" ClassVersion="13">
-   <version ClassVersion="13" checksum="1718201023"/>
-   <version ClassVersion="12" checksum="3001582852"/>
-   <version ClassVersion="11" checksum="1785919010"/>
-   <version ClassVersion="10" checksum="3922569476"/>
+  <class name="reco::PFBrem" ClassVersion="3">
+   <version ClassVersion="3" checksum="3811198743"/>
   </class>
   <class name="std::vector<reco::PFBrem>"/>
 
@@ -153,17 +144,8 @@
   <class name="edm::OwnVector<reco::PFBlockElement, edm::ClonePolicy<reco::PFBlockElement> >" rntupleStreamerMode="true"/>
   <class name="edm::Wrapper<edm::OwnVector<reco::PFBlockElement, edm::ClonePolicy<reco::PFBlockElement> > >" />
 
-  <class name="reco::PFBlockElementTrack" ClassVersion="16">
-   <version ClassVersion="16" checksum="700008520"/>
-   <version ClassVersion="15" checksum="1577934967"/>
-   <version ClassVersion="14" checksum="3952424659"/>
-   <version ClassVersion="13" checksum="1449646331"/>
-   <version ClassVersion="12" checksum="417575083"/>
-   <version ClassVersion="10" checksum="2342660248"/>
-   <version ClassVersion="11" checksum="1450496342"/>
-<!-- removed by Florian. It useful to have this Ref (especially for a reprocessing)   
-    <field name="trackRefPF_" transient="true"/>
--->
+  <class name="reco::PFBlockElementTrack" ClassVersion="3">
+   <version ClassVersion="3" checksum="764868352"/>
   </class>
 
   <class name="reco::PFBlockElementGsfTrack" ClassVersion="15">
@@ -238,19 +220,16 @@
    <version ClassVersion="10" checksum="1506624066"/>
   </class>
   <class name="reco::PFDisplacedVertexCandidate::DistMap"/>
-  <class name="reco::PFDisplacedVertexCandidate" ClassVersion="10">
-   <version ClassVersion="10" checksum="165857237"/>
+  <class name="reco::PFDisplacedVertexCandidate" ClassVersion="3">
+   <version ClassVersion="3" checksum="3588517525"/>
   </class>
 
   <class name="std::vector<reco::PFDisplacedVertexCandidate>"/>
   <class name="edm::Wrapper<std::vector<reco::PFDisplacedVertexCandidate> >"/>
   <class name="edm::Ref< std::vector<reco::PFDisplacedVertexCandidate>, reco::PFDisplacedVertexCandidate, edm::refhelper::FindUsingAdvance<std::vector<reco::PFDisplacedVertexCandidate>,reco::PFDisplacedVertexCandidate> >"/>
 
-  <class name="reco::PFDisplacedVertex" ClassVersion="13">
-   <version ClassVersion="13" checksum="3552936040"/>
-   <version ClassVersion="12" checksum="2818127737"/>
-   <version ClassVersion="11" checksum="4172417049"/>
-   <version ClassVersion="10" checksum="4202892065"/>
+  <class name="reco::PFDisplacedVertex" ClassVersion="3">
+   <version ClassVersion="3" checksum="2807110114"/>
   </class>
 
   <class name="std::vector<reco::PFDisplacedVertex>"/>
@@ -263,8 +242,8 @@
 
   <class name="std::pair<std::pair<unsigned int,unsigned int>,std::pair<unsigned int,unsigned int> >"/>
 
-  <class name="reco::PreId" ClassVersion="10">
-   <version ClassVersion="10" checksum="1753132977"/>
+  <class name="reco::PreId" ClassVersion="3">
+   <version ClassVersion="3" checksum="2607778601"/>
   </class>
   <class name="std::vector<reco::PreId>"/>
   <class name="edm::Wrapper<std::vector<reco::PreId> >"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -43,10 +43,6 @@
    <version ClassVersion="15" checksum="990589145"/>
    <version ClassVersion="10" checksum="1662079993"/>
   </class>
-  <!--NOTE: the declaration of AtomicPtrCache are a temporary work around until ROOT 6 where they will not be needed -->
-  <class name="edm::AtomicPtrCache<std::vector<reco::SuperCluster> >">
-   <field name="m_data" transient="true"/>
-  </class>
   <ioread sourceClass="pat::Electron" targetClass="pat::Electron" version="[1-]" source="" target="superClusterRelinked_">
     <![CDATA[superClusterRelinked_.reset();]]>
   </ioread>
@@ -134,13 +130,6 @@
     <version ClassVersion="3" checksum="2961562419" />
   </class>
 
-  <!--NOTE: the declaration of AtomicPtrCache are a temporary work around until ROOT 6 where they will not be needed -->
-   <class name="edm::AtomicPtrCache<reco::TrackRefVector>">
-     <field name="m_data" transient="true"/>
-  </class>
-   <class name="edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> >">
-     <field name="m_data" transient="true"/>
-  </class>
   <ioread sourceClass="pat::Tau" targetClass="pat::Tau" version="[1-]" source="" target="isolationTracksTransientRefVector_">
   <![CDATA[isolationTracksTransientRefVector_.reset();]]>
   </ioread>
@@ -241,7 +230,6 @@
    <version ClassVersion="11" checksum="3277818926"/>
    <version ClassVersion="10" checksum="865744757"/>
   </class>
-  <!--NOTE: the declaration of AtomicPtrCache are a temporary work around until ROOT 6 where they will not be needed -->
   <ioread sourceClass="pat::Photon" targetClass="pat::Photon" version="[1-]" source="" target="superClusterRelinked_">
     <![CDATA[superClusterRelinked_.reset();]]>
   </ioread>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml.hold
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml.hold
@@ -17,7 +17,7 @@
 
   <!-- PAT Objects, and embedded data  -->
   <class name="pat::Electron"  ClassVersion="3">
-   <version ClassVersion="3" checksum="2417779180"/>
+   <version ClassVersion="3" checksum="1391266265"/>
    <field name="superClusterRelinked_" transient="true"/>
    <version ClassVersion="26" checksum="2045819644"/>
    <version ClassVersion="25" checksum="1488101799"/>
@@ -35,12 +35,14 @@
   <ioread sourceClass="pat::Electron" targetClass="pat::Electron" version="[1-]" source="" target="superClusterRelinked_">
     <![CDATA[superClusterRelinked_.reset();]]>
   </ioread>
+
+
   <class name="pat::Muon"  ClassVersion="3">
-   <version ClassVersion="3" checksum="4185602613"/>
+   <version ClassVersion="3" checksum="1844520953"/>
   </class>
 
   <class name="pat::Tau"  ClassVersion="3">
-   <version ClassVersion="3" checksum="1081551115"/>
+   <version ClassVersion="3" checksum="1567397432"/>
    <field name="isolationTracksTransientRefVector_" transient="true"/>
    <field name="signalTracksTransientRefVector_" transient="true"/>
    <field name="signalPFCandsTransientPtrs_" transient="true"/>
@@ -94,7 +96,7 @@
   <![CDATA[isolationPFGammaCandsTransientPtrs_.reset();]]>
   </ioread>
   <class name="pat::tau::TauPFSpecific"  ClassVersion="3">
-   <version ClassVersion="3" checksum="2664182121"/>
+   <version ClassVersion="3" checksum="2573572161"/>
   </class>
   <class name="std::vector<pat::tau::TauPFSpecific>" />
 
@@ -168,7 +170,7 @@
   </ioread>
 
   <class name="pat::Jet"  ClassVersion="3">
-   <version ClassVersion="3" checksum="1924074509"/>
+   <version ClassVersion="3" checksum="2779345797"/>
    <field name="daughtersTemp_" transient="true"/>
    <field name="caloTowersTemp_" transient="true"/>
    <field name="pfCandidatesTemp_" transient="true"/>
@@ -225,7 +227,7 @@
    <version ClassVersion="10" checksum="2240381542"/>
   </class>
   <class name="pat::GenericParticle"  ClassVersion="3">
-   <version ClassVersion="3" checksum="581922746"/>
+   <version ClassVersion="3" checksum="1195315270"/>
   </class>
   <class name="pat::Hemisphere"  ClassVersion="12">
    <version ClassVersion="12" checksum="1827958121"/>

--- a/DataFormats/PatCandidates/src/classes_def_other.xml
+++ b/DataFormats/PatCandidates/src/classes_def_other.xml
@@ -23,8 +23,8 @@
   </class>
   <class name="edm::Wrapper<StringMap>" />
 
-  <class name="pat::VertexAssociation"  ClassVersion="10">
-   <version ClassVersion="10" checksum="1319279281"/>
+  <class name="pat::VertexAssociation"  ClassVersion="3">
+   <version ClassVersion="3" checksum="3351303165"/>
   </class>
   <class name="std::vector<pat::VertexAssociation>" />
   <class name="edm::ValueMap<pat::VertexAssociation>" />

--- a/DataFormats/RecoCandidate/src/classes_def.xml
+++ b/DataFormats/RecoCandidate/src/classes_def.xml
@@ -5,10 +5,8 @@
    <version ClassVersion="11" checksum="1478341962"/>
    <version ClassVersion="10" checksum="1183963017"/>
   </class>
-  <class name="reco::RecoChargedCandidate"  ClassVersion="12">
-   <version ClassVersion="12" checksum="3730584585"/>
-   <version ClassVersion="11" checksum="2262215505"/>
-   <version ClassVersion="10" checksum="2818554415"/>
+  <class name="reco::RecoChargedCandidate"  ClassVersion="3">
+   <version ClassVersion="3" checksum="3697403153"/>
   </class>
   <class name="reco::RecoChargedRefCandidate"  ClassVersion="12">
    <version ClassVersion="12" checksum="2499408251"/>

--- a/DataFormats/TauReco/src/classes_def_1.xml
+++ b/DataFormats/TauReco/src/classes_def_1.xml
@@ -9,8 +9,8 @@
   </class>
 
 
-  <class name="reco::BaseTauTagInfo" ClassVersion="10">
-   <version ClassVersion="10" checksum="2717397101"/>
+  <class name="reco::BaseTauTagInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="738906165"/>
   </class>
   <class name="std::vector<reco::BaseTauTagInfo>"/>
   <class name="edm::Wrapper<std::vector<reco::BaseTauTagInfo> >"/>
@@ -18,11 +18,8 @@
   <class name="edm::RefProd<std::vector<reco::BaseTauTagInfo> >"/>
   <class name="edm::RefVector<std::vector<reco::BaseTauTagInfo>,reco::BaseTauTagInfo,edm::refhelper::FindUsingAdvance<std::vector<reco::BaseTauTagInfo>,reco::BaseTauTagInfo> >"/>
   
-  <class name="reco::PFTauTagInfo" ClassVersion="13">
-   <version ClassVersion="13" checksum="1453697092"/>
-   <version ClassVersion="12" checksum="3598523528"/>
-   <version ClassVersion="11" checksum="2849126593"/>
-   <version ClassVersion="10" checksum="2791906466"/>
+  <class name="reco::PFTauTagInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="1535484060"/>
   </class>
   <class name="std::vector<reco::PFTauTagInfo>"/>
   <class name="edm::Wrapper<std::vector<reco::PFTauTagInfo> >"/>
@@ -106,10 +103,8 @@ for(auto const& ref : onfile.PFGammaCands_) {
 
 
   
-  <class name="reco::BaseTau" ClassVersion="12">
-   <version ClassVersion="12" checksum="240869876"/>
-   <version ClassVersion="10" checksum="3887454152"/>
-   <version ClassVersion="11" checksum="3609212284"/>
+  <class name="reco::BaseTau" ClassVersion="3">
+   <version ClassVersion="3" checksum="1151169052"/>
   </class>
   <class name="std::vector<reco::BaseTau>"/>
   <class name="edm::Wrapper<std::vector<reco::BaseTau> >"/>

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -1,7 +1,7 @@
 <lcgdict>
   
-  <class name="reco::PFTau" ClassVersion="21">
-   <version ClassVersion="21" checksum="759808483"/>
+  <class name="reco::PFTau" ClassVersion="3">
+   <version ClassVersion="3" checksum="3358760451"/>
      <field name="leadPFChargedHadrCand_" transient="true"/>
      <field name="leadPFNeutralCand_" transient="true"/>
      <field name="leadPFCand_" transient="true"/>
@@ -13,21 +13,10 @@
      <field name="selectedTransientIsolationPFChargedHadrCands_" transient="true"/>
      <field name="selectedTransientIsolationPFNeutrHadrCands_" transient="true"/>
      <field name="selectedTransientIsolationPFGammaCands_" transient="true"/>
-   <version ClassVersion="20" checksum="3395041825"/>
-   <version ClassVersion="19" checksum="4003955973"/>
-   <version ClassVersion="18" checksum="1318776182"/>
-   <version ClassVersion="17" checksum="1523260402"/>
-    <version ClassVersion="16" checksum="2695990650"/>
-    <version ClassVersion="15" checksum="4105994460"/>
-    <version ClassVersion="14" checksum="3087106015"/>
-    <version ClassVersion="13" checksum="1088944403"/>
-    <version ClassVersion="12" checksum="3369965409"/>
-    <version ClassVersion="11" checksum="2334259986"/>
      <field name="signalPiZeroCandidates_" transient="true"/>
      <field name="isolationPiZeroCandidates_" transient="true"/>
      <field name="signalTauChargedHadronCandidates_" transient="true"/>
      <field name="isolationTauChargedHadronCandidates_" transient="true"/>
-    <version ClassVersion="10" checksum="2369119060"/>
   </class>
 
   <class name="std::vector<reco::PFTau>"/>
@@ -47,195 +36,8 @@
   <class name="edm::reftobase::Holder<reco::PFTau, reco::PFTauRef>" />
   <class name="edm::reftobase::RefHolder<reco::PFTauRef>" />
 
-<ioread sourceClass="reco::PFTau" version="[12-20]" 
-  source="edm::Ptr<reco::PFCandidate> leadPFChargedHadrCand_; edm::Ptr<reco::PFCandidate> leadPFNeutralCand_; edm::Ptr<reco::PFCandidate> leadPFCand_; std::vector<reco::PFCandidatePtr> selectedSignalPFCands_; std::vector<edm::Ptr<reco::PFCandidate> > selectedSignalPFChargedHadrCands_; std::vector<edm::Ptr<reco::PFCandidate> > selectedSignalPFNeutrHadrCands_; std::vector<edm::Ptr<reco::PFCandidate> > selectedSignalPFGammaCands_; std::vector<edm::Ptr<reco::PFCandidate> > selectedIsolationPFCands_; std::vector<edm::Ptr<reco::PFCandidate> > selectedIsolationPFChargedHadrCands_; std::vector<edm::Ptr<reco::PFCandidate> > selectedIsolationPFNeutrHadrCands_; std::vector<edm::Ptr<reco::PFCandidate> > selectedIsolationPFGammaCands_;  edm::RefVector<std::vector<reco::PFRecoTauChargedHadron> > isolationTauChargedHadronCandidatesRefs_;"
-  targetClass="reco::PFTau"
-  target="leadChargedHadrCand_,leadNeutralCand_,leadCand_,selectedSignalCands_,selectedSignalChargedHadrCands_,selectedSignalNeutrHadrCands_,selectedSignalGammaCands_,selectedIsolationCands_,selectedIsolationChargedHadrCands_,selectedIsolationNeutrHadrCands_,selectedIsolationGammaCands_,leadPFChargedHadrCand_,leadPFNeutralCand_,leadPFCand_">
-  <![CDATA[
-    selectedSignalCands_.clear();
-    selectedSignalCands_.reserve(onfile.selectedSignalPFCands_.size());
-    for (const edm::Ptr<reco::PFCandidate>& cand : onfile.selectedSignalPFCands_) {
-      selectedSignalCands_.push_back(edm::Ptr<reco::Candidate>(cand));}
 
-    selectedSignalChargedHadrCands_.clear();
-    selectedSignalChargedHadrCands_.reserve(onfile.selectedSignalPFChargedHadrCands_.size());
-    for (const auto& cand : onfile.selectedSignalPFChargedHadrCands_)
-      selectedSignalChargedHadrCands_.push_back(edm::Ptr<reco::Candidate>(cand));
-
-    selectedSignalNeutrHadrCands_.clear();
-    selectedSignalNeutrHadrCands_.reserve(onfile.selectedSignalPFNeutrHadrCands_.size());
-    for (const auto& cand : onfile.selectedSignalPFNeutrHadrCands_)
-      selectedSignalNeutrHadrCands_.push_back(edm::Ptr<reco::Candidate>(cand));;
-
-    selectedSignalGammaCands_.clear();
-    selectedSignalGammaCands_.reserve(onfile.selectedSignalPFGammaCands_.size());
-    for (const auto& cand : onfile.selectedSignalPFGammaCands_)
-      selectedSignalGammaCands_.push_back(edm::Ptr<reco::Candidate>(cand));
-
-    selectedIsolationCands_.clear();
-    selectedIsolationCands_.reserve(onfile.selectedIsolationPFCands_.size());
-    for (const auto& cand : onfile.selectedIsolationPFCands_)
-      selectedIsolationCands_.push_back(edm::Ptr<reco::Candidate>(cand));
-
-    selectedIsolationChargedHadrCands_.clear();
-    selectedIsolationChargedHadrCands_.reserve(onfile.selectedIsolationPFChargedHadrCands_.size());
-    for (const auto& cand : onfile.selectedIsolationPFChargedHadrCands_)
-      selectedIsolationChargedHadrCands_.push_back(edm::Ptr<reco::Candidate>(cand));
-
-    selectedIsolationNeutrHadrCands_.clear();
-    selectedIsolationNeutrHadrCands_.reserve(onfile.selectedIsolationPFNeutrHadrCands_.size());
-    for (const auto& cand : onfile.selectedIsolationPFNeutrHadrCands_)
-      selectedIsolationNeutrHadrCands_.push_back(edm::Ptr<reco::Candidate>(cand));
-
-    selectedIsolationGammaCands_.clear();
-    selectedIsolationGammaCands_.reserve(onfile.selectedIsolationPFGammaCands_.size());
-    for (const auto& cand : onfile.selectedIsolationPFGammaCands_)
-      selectedIsolationGammaCands_.push_back(edm::Ptr<reco::Candidate>(cand));
-
-    if (selectedSignalChargedHadrCands_.size() > 0) {
-      leadChargedHadrCand_ = selectedSignalChargedHadrCands_[0];
-    } else {
-      leadChargedHadrCand_ = edm::Ptr<reco::Candidate>();
-    }
-    if (selectedSignalGammaCands_.size() > 0) {
-      leadNeutralCand_ = selectedSignalGammaCands_[0];
-    } else {
-      leadNeutralCand_ = edm::Ptr<reco::Candidate>();
-    }
-    if (selectedSignalCands_.size() > 0) {
-      leadCand_ = selectedSignalCands_[0];
-    } else {
-      leadCand_ = edm::Ptr<reco::Candidate>();
-    }
-
-    leadPFChargedHadrCand_.reset();
-    leadPFNeutralCand_.reset();
-    leadPFCand_.reset();
-  ]]>
-  </ioread>
-
-<ioread sourceClass="reco::PFTau" version="[-20]" source="edm::Ref<vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<vector<reco::PFJet>,reco::PFJet> > jetRef_;" targetClass="reco::PFTau" target="jetRef_" include="DataFormats/JetReco/interface/PFJet.h">
-    <![CDATA[jetRef_ = reco::JetBaseRef(onfile.jetRef_);]]>
-  </ioread>
-
- <ioread sourceClass="reco::PFTau" version="[-11]" source="reco::PFCandidateRef leadPFChargedHadrCand_;" targetClass="reco::PFTau" target="leadChargedHadrCand_" include="DataFormats/Common/interface/RefToPtr.h">
-    <![CDATA[leadChargedHadrCand_ = edm::refToPtr(onfile.leadPFChargedHadrCand_);]]>
-  </ioread>
-
-<ioread sourceClass="reco::PFTau" version="[-11]" source="reco::PFCandidateRef leadPFNeutralCand_;" targetClass="reco::PFTau" target="leadNeutralCand_" include="DataFormats/Common/interface/RefToPtr.h">
-    <![CDATA[leadNeutralCand_ = edm::refToPtr(onfile.leadPFNeutralCand_);]]>
-  </ioread>
-
-<ioread sourceClass="reco::PFTau" version="[-11]" source="reco::PFCandidateRef leadPFCand_;" targetClass="reco::PFTau" target="leadCand_" include="DataFormats/Common/interface/RefToPtr.h">
-    <![CDATA[leadCand_ = edm::refToPtr(onfile.leadPFCand_);]]>
-  </ioread>
-
-<ioread sourceClass="reco::PFTau" version="[-11]"
-source="reco::PFCandidateRefVector selectedSignalPFCands_;"
- targetClass="reco::PFTau"
-target="selectedSignalCands_"
-include="DataFormats/Common/interface/RefToPtr.h">
-    <![CDATA[
-   selectedSignalCands_.reserve(onfile.selectedSignalPFCands_.size());
-for(auto const& ref : onfile.selectedSignalPFCands_) { 
-   selectedSignalCands_.push_back(edm::refToPtr(ref));
-}
-]]>
-</ioread>
-
-<ioread sourceClass="reco::PFTau" version="[-11]"
-source="reco::PFCandidateRefVector selectedSignalPFChargedHadrCands_;"
- targetClass="reco::PFTau"
-target="selectedSignalChargedHadrCands_"
-include="DataFormats/Common/interface/RefToPtr.h">
-    <![CDATA[
-selectedSignalChargedHadrCands_.reserve(onfile.selectedSignalPFChargedHadrCands_.size());
-for(auto const& ref : onfile.selectedSignalPFChargedHadrCands_) { 
-   selectedSignalChargedHadrCands_.push_back(edm::refToPtr(ref));
-}
-]]>
-</ioread>
-
-<ioread sourceClass="reco::PFTau" version="[-11]"
-source="reco::PFCandidateRefVector selectedSignalPFNeutrHadrCands_;"
- targetClass="reco::PFTau"
-target="selectedSignalNeutrHadrCands_"
-include="DataFormats/Common/interface/RefToPtr.h">
-    <![CDATA[
-selectedSignalNeutrHadrCands_.reserve(onfile.selectedSignalPFNeutrHadrCands_.size());
-for(auto const& ref : onfile.selectedSignalPFNeutrHadrCands_) { 
-   selectedSignalNeutrHadrCands_.push_back(edm::refToPtr(ref));
-}
-]]>
-</ioread>
-
-<ioread sourceClass="reco::PFTau" version="[-11]"
-source="reco::PFCandidateRefVector selectedSignalPFGammaCands_;"
- targetClass="reco::PFTau"
-target="selectedSignalGammaCands_"
-include="DataFormats/Common/interface/RefToPtr.h">
-    <![CDATA[
-selectedSignalGammaCands_.reserve(onfile.selectedSignalPFGammaCands_.size());
-for(auto const& ref : onfile.selectedSignalPFGammaCands_) { 
-   selectedSignalGammaCands_.push_back(edm::refToPtr(ref));
-}
-]]>
-</ioread>
-
-<ioread sourceClass="reco::PFTau" version="[-11]"
-source="reco::PFCandidateRefVector selectedIsolationPFCands_;"
- targetClass="reco::PFTau"
-target="selectedIsolationCands_"
-include="DataFormats/Common/interface/RefToPtr.h">
-    <![CDATA[
-selectedIsolationCands_.reserve(onfile.selectedIsolationPFCands_.size());
-for(auto const& ref : onfile.selectedIsolationPFCands_) { 
-   selectedIsolationCands_.push_back(edm::refToPtr(ref));
-}
-]]>
-</ioread>
-
-<ioread sourceClass="reco::PFTau" version="[-11]"
-source="reco::PFCandidateRefVector selectedIsolationPFChargedHadrCands_;"
- targetClass="reco::PFTau"
-target="selectedIsolationChargedHadrCands_"
-include="DataFormats/Common/interface/RefToPtr.h">
-    <![CDATA[
-selectedIsolationChargedHadrCands_.reserve(onfile.selectedIsolationPFChargedHadrCands_.size());
-for(auto const& ref : onfile.selectedIsolationPFChargedHadrCands_) { 
-   selectedIsolationChargedHadrCands_.push_back(edm::refToPtr(ref));
-}
-]]>
-</ioread>
-
-<ioread sourceClass="reco::PFTau" version="[-11]"
-source="reco::PFCandidateRefVector selectedIsolationPFNeutrHadrCands_;"
- targetClass="reco::PFTau"
-target="selectedIsolationNeutrHadrCands_"
-include="DataFormats/Common/interface/RefToPtr.h">
-    <![CDATA[
-selectedIsolationNeutrHadrCands_.reserve(onfile.selectedIsolationPFNeutrHadrCands_.size());
-for(auto const& ref : onfile.selectedIsolationPFNeutrHadrCands_) { 
-   selectedIsolationNeutrHadrCands_.push_back(edm::refToPtr(ref));
-}
-]]>
-</ioread>
-
-<ioread sourceClass="reco::PFTau" version="[-11]"
-source="reco::PFCandidateRefVector selectedIsolationPFGammaCands_;"
- targetClass="reco::PFTau"
-target="selectedIsolationGammaCands_"
-include="DataFormats/Common/interface/RefToPtr.h">
-    <![CDATA[
-selectedIsolationGammaCands_.reserve(onfile.selectedIsolationPFGammaCands_.size());
-for(auto const& ref : onfile.selectedIsolationPFGammaCands_) { 
-   selectedIsolationGammaCands_.push_back(edm::refToPtr(ref));
-}
-]]>
-</ioread>
-
-
-<ioread sourceClass = "reco::PFTau" version="[21-]"
+<ioread sourceClass = "reco::PFTau" version="[1-]"
  targetClass="reco::PFTau"
 source = ""
 target="leadPFChargedHadrCand_,leadPFNeutralCand_,leadPFCand_,selectedTransientSignalPFCands_,selectedTransientSignalPFChargedHadrCands_,selectedTransientSignalPFNeutrHadrCands_,selectedTransientSignalPFGammaCands_,selectedTransientIsolationPFCands_,selectedTransientIsolationPFChargedHadrCands_,selectedTransientIsolationPFNeutrHadrCands_,selectedTransientIsolationPFGammaCands_">
@@ -293,56 +95,6 @@ isolationTauChargedHadronCandidates_.reset();
 
 
 
-<!-- <ioread sourceClass="reco::PFTau" version="[-11]" -->
-<!-- source="reco::PFCandidateRefVector selectedIsolationPFCands_;" -->
-<!--  targetClass="reco::PFTau" -->
-<!-- target="selectedIsolationPFCands_" -->
-<!-- include="DataFormats/Common/interface/RefToPtr.h"> -->
-<!--     <![CDATA[ -->
-<!-- for(size_t it=0; it<onfile.selectedIsolationPFCands_.size();it++) -->
-<!--  selectedIsolationPFCands_.at(it) = -->
-<!--  edm::refToPtr(onfile.selectedIsolationPFCands_.at(it)); -->
-<!-- ]]> -->
-<!-- </ioread> -->
-
-<!-- <ioread sourceClass="reco::PFTau" version="[-11]" -->
-<!-- source="reco::PFCandidateRefVector selectedIsolationPFChargedHadrCands_;" -->
-<!--  targetClass="reco::PFTau" -->
-<!-- target="selectedIsolationPFChargedHadrCands_" -->
-<!-- include="DataFormats/Common/interface/RefToPtr.h"> -->
-<!--     <![CDATA[ -->
-<!-- for(size_t it=0; -->
-<!--  it<onfile.selectedIsolationPFChargedHadrCands_.size();it++) -->
-<!--  selectedIsolationPFChargedHadrCands_.at(it) = -->
-<!--  edm::refToPtr(onfile.selectedIsolationPFChargedHadrCands_.at(it)); -->
-<!-- ]]> -->
-<!-- </ioread> -->
-
-<!-- <ioread sourceClass="reco::PFTau" version="[-11]" -->
-<!-- source="reco::PFCandidateRefVector selectedIsolationPFNeutrHadrCands_;" -->
-<!--  targetClass="reco::PFTau" -->
-<!-- target="selectedIsolationPFNeutrHadrCands_" -->
-<!-- include="DataFormats/Common/interface/RefToPtr.h"> -->
-<!--     <![CDATA[ -->
-<!-- for(size_t it=0; -->
-<!--  it<onfile.selectedIsolationPFNeutrHadrCands_.size();it++) -->
-<!--  selectedIsolationPFNeutrHadrCands_.at(it) = -->
-<!--  edm::refToPtr(onfile.selectedIsolationPFNeutrHadrCands_.at(it)); -->
-<!-- ]]> -->
-<!-- </ioread> -->
-
-<!-- <ioread sourceClass="reco::PFTau" version="[-11]" -->
-<!-- source="reco::PFCandidateRefVector selectedIsolationPFGammaCands_;" -->
-<!--  targetClass="reco::PFTau" -->
-<!-- target="selectedIsolationPFGammaCands_" -->
-<!-- include="DataFormats/Common/interface/RefToPtr.h"> -->
-<!--     <![CDATA[ -->
-<!-- for(size_t it=0; it<onfile.selectedIsolationPFGammaCands_.size();it++) -->
-<!--  selectedIsolationPFGammaCands_.at(it) = -->
-<!--  edm::refToPtr(onfile.selectedIsolationPFGammaCands_.at(it)); -->
-<!-- ]]> -->
-<!-- </ioread> -->
-
 
   <class name="reco::PFTauDecayMode" ClassVersion="13">
    <version ClassVersion="13" checksum="3507751092"/>
@@ -378,13 +130,8 @@ isolationTauChargedHadronCandidates_.reset();
   <class name="edm::RefVector<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero> >"/>
   <class name="edm::reftobase::Holder<reco::CompositePtrCandidate, edm::Ref<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero> > >" />
 
-  <class name="reco::PFRecoTauChargedHadron" ClassVersion="15">
-   <version ClassVersion="15" checksum="377961877"/>
-   <version ClassVersion="14" checksum="3665832588"/>
-   <version ClassVersion="13" checksum="591384956"/>
-   <version ClassVersion="12" checksum="2480143236" />
-   <version ClassVersion="11" checksum="858406271" />
-   <version ClassVersion="10" checksum="4027987990"/>
+  <class name="reco::PFRecoTauChargedHadron" ClassVersion="3">
+   <version ClassVersion="3" checksum="2202387059"/>
   </class>
   <class name="std::vector<reco::PFRecoTauChargedHadron>"/>
   <class name="edm::AtomicPtrCache<std::vector<reco::PFRecoTauChargedHadron> >"/>
@@ -395,16 +142,6 @@ isolationTauChargedHadronCandidates_.reset();
   <class name="edm::RefVector<std::vector<reco::PFRecoTauChargedHadron>,reco::PFRecoTauChargedHadron,edm::refhelper::FindUsingAdvance<std::vector<reco::PFRecoTauChargedHadron>,reco::PFRecoTauChargedHadron> >"/>
   <class name="edm::reftobase::Holder<reco::CompositePtrCandidate, edm::Ref<std::vector<reco::PFRecoTauChargedHadron>,reco::PFRecoTauChargedHadron,edm::refhelper::FindUsingAdvance<std::vector<reco::PFRecoTauChargedHadron>,reco::PFRecoTauChargedHadron> > >" />
 
-<ioread sourceClass="reco::PFRecoTauChargedHadron" version="[-14]" source="edm::Ptr<reco::PFCandidate> chargedPFCandidate_;" targetClass="reco::PFRecoTauChargedHadron" target="chargedPFCandidate_">
-   <![CDATA[chargedPFCandidate_ = edm::Ptr<reco::Candidate>(onfile.chargedPFCandidate_);]]>
-  </ioread>
-
-<ioread sourceClass="reco::PFRecoTauChargedHadron" version="[-14]" source="std::vector<edm::Ptr<reco::PFCandidate> > neutralPFCandidates_;" targetClass="reco::PFRecoTauChargedHadron" target="neutralPFCandidates_">
-    <![CDATA[
-    neutralPFCandidates_.reserve(onfile.neutralPFCandidates_.size());
-    for (const auto& cand : onfile.neutralPFCandidates_)
-      neutralPFCandidates_.push_back(edm::Ptr<reco::Candidate>(cand));]]>
-  </ioread>
 
 
 </lcgdict>

--- a/DataFormats/TrackReco/BuildFile.xml
+++ b/DataFormats/TrackReco/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="DataFormats/BeamSpot"/>
-<use name="DataFormats/Candidate"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/DetId"/>
 <use name="DataFormats/ForwardDetId"/>

--- a/DataFormats/TrackReco/interface/Track.h
+++ b/DataFormats/TrackReco/interface/Track.h
@@ -24,147 +24,149 @@
 
 namespace reco {
 
-  class Track : public TrackBase {
-  public:
-    /// default constructor
-    Track() {}
+  namespace io_v1 {
+    class Track : public TrackBase {
+    public:
+      /// default constructor
+      Track() {}
 
-    /// virtual destructor
-    ~Track() override;
+      /// virtual destructor
+      ~Track() override;
 
-    /// constructor from fit parameters and error matrix
-    Track(double chi2,
-          double ndof,
-          const Point& referencePoint,
-          const Vector& momentum,
-          int charge,
-          const CovarianceMatrix&,
-          TrackAlgorithm = undefAlgorithm,
-          TrackQuality quality = undefQuality,
-          float t0 = 0,
-          float beta = 0,
-          float covt0t0 = -1.,
-          float covbetabeta = -1.);
+      /// constructor from fit parameters and error matrix
+      Track(double chi2,
+            double ndof,
+            const Point& referencePoint,
+            const Vector& momentum,
+            int charge,
+            const CovarianceMatrix&,
+            TrackAlgorithm = undefAlgorithm,
+            TrackQuality quality = undefQuality,
+            float t0 = 0,
+            float beta = 0,
+            float covt0t0 = -1.,
+            float covbetabeta = -1.);
 
-    /// return true if the outermost hit is valid
-    bool outerOk() const { return extra_.isNonnull() && extra_.isAvailable() && extra_->outerOk(); }
+      /// return true if the outermost hit is valid
+      bool outerOk() const { return extra_.isNonnull() && extra_.isAvailable() && extra_->outerOk(); }
 
-    /// return true if the innermost hit is valid
-    bool innerOk() const { return extra_.isNonnull() && extra_.isAvailable() && extra_->innerOk(); }
+      /// return true if the innermost hit is valid
+      bool innerOk() const { return extra_.isNonnull() && extra_.isAvailable() && extra_->innerOk(); }
 
-    /// position of the innermost hit
-    const math::XYZPoint& innerPosition() const { return extra_->innerPosition(); }
+      /// position of the innermost hit
+      const math::XYZPoint& innerPosition() const { return extra_->innerPosition(); }
 
-    /// momentum vector at the innermost hit position
-    const math::XYZVector& innerMomentum() const { return extra_->innerMomentum(); }
+      /// momentum vector at the innermost hit position
+      const math::XYZVector& innerMomentum() const { return extra_->innerMomentum(); }
 
-    /// position of the outermost hit
-    const math::XYZPoint& outerPosition() const { return extra_->outerPosition(); }
+      /// position of the outermost hit
+      const math::XYZPoint& outerPosition() const { return extra_->outerPosition(); }
 
-    /// momentum vector at the outermost hit position
-    const math::XYZVector& outerMomentum() const { return extra_->outerMomentum(); }
+      /// momentum vector at the outermost hit position
+      const math::XYZVector& outerMomentum() const { return extra_->outerMomentum(); }
 
-    /// outermost trajectory state curvilinear errors
-    CovarianceMatrix outerStateCovariance() const { return extra_->outerStateCovariance(); }
+      /// outermost trajectory state curvilinear errors
+      CovarianceMatrix outerStateCovariance() const { return extra_->outerStateCovariance(); }
 
-    /// innermost trajectory state curvilinear errors
-    CovarianceMatrix innerStateCovariance() const { return extra_->innerStateCovariance(); }
+      /// innermost trajectory state curvilinear errors
+      CovarianceMatrix innerStateCovariance() const { return extra_->innerStateCovariance(); }
 
-    /// fill outermost trajectory state curvilinear errors
-    CovarianceMatrix& fillOuter CMS_THREAD_SAFE(CovarianceMatrix& v) const { return extra_->fillOuter(v); }
+      /// fill outermost trajectory state curvilinear errors
+      CovarianceMatrix& fillOuter CMS_THREAD_SAFE(CovarianceMatrix& v) const { return extra_->fillOuter(v); }
 
-    CovarianceMatrix& fillInner CMS_THREAD_SAFE(CovarianceMatrix& v) const { return extra_->fillInner(v); }
+      CovarianceMatrix& fillInner CMS_THREAD_SAFE(CovarianceMatrix& v) const { return extra_->fillInner(v); }
 
-    /// DetId of the detector on which surface the outermost state is located
-    unsigned int outerDetId() const { return extra_->outerDetId(); }
+      /// DetId of the detector on which surface the outermost state is located
+      unsigned int outerDetId() const { return extra_->outerDetId(); }
 
-    /// DetId of the detector on which surface the innermost state is located
-    unsigned int innerDetId() const { return extra_->innerDetId(); }
+      /// DetId of the detector on which surface the innermost state is located
+      unsigned int innerDetId() const { return extra_->innerDetId(); }
 
-    /// Access to reconstructed hits on the track.
-    auto recHits() const { return extra_->recHits(); }
+      /// Access to reconstructed hits on the track.
+      auto recHits() const { return extra_->recHits(); }
 
-    /// Iterator to first hit on the track.
-    trackingRecHit_iterator recHitsBegin() const { return extra_->recHitsBegin(); }
+      /// Iterator to first hit on the track.
+      trackingRecHit_iterator recHitsBegin() const { return extra_->recHitsBegin(); }
 
-    /// Iterator to last hit on the track.
-    trackingRecHit_iterator recHitsEnd() const { return extra_->recHitsEnd(); }
+      /// Iterator to last hit on the track.
+      trackingRecHit_iterator recHitsEnd() const { return extra_->recHitsEnd(); }
 
-    /// Get i-th hit on the track.
-    TrackingRecHitRef recHit(size_t i) const { return extra_->recHit(i); }
+      /// Get i-th hit on the track.
+      TrackingRecHitRef recHit(size_t i) const { return extra_->recHit(i); }
 
-    /// Get number of RecHits. (Warning, this includes invalid hits, which are not physical hits).
-    size_t recHitsSize() const { return extra_->recHitsSize(); }
+      /// Get number of RecHits. (Warning, this includes invalid hits, which are not physical hits).
+      size_t recHitsSize() const { return extra_->recHitsSize(); }
 
-    /// x coordinate of momentum vector at the outermost hit position
-    double outerPx() const { return extra_->outerPx(); }
+      /// x coordinate of momentum vector at the outermost hit position
+      double outerPx() const { return extra_->outerPx(); }
 
-    /// y coordinate of momentum vector at the outermost hit position
-    double outerPy() const { return extra_->outerPy(); }
+      /// y coordinate of momentum vector at the outermost hit position
+      double outerPy() const { return extra_->outerPy(); }
 
-    /// z coordinate of momentum vector at the outermost hit position
-    double outerPz() const { return extra_->outerPz(); }
+      /// z coordinate of momentum vector at the outermost hit position
+      double outerPz() const { return extra_->outerPz(); }
 
-    /// x coordinate of the outermost hit position
-    double outerX() const { return extra_->outerX(); }
+      /// x coordinate of the outermost hit position
+      double outerX() const { return extra_->outerX(); }
 
-    /// y coordinate of the outermost hit position
-    double outerY() const { return extra_->outerY(); }
+      /// y coordinate of the outermost hit position
+      double outerY() const { return extra_->outerY(); }
 
-    /// z coordinate of the outermost hit position
-    double outerZ() const { return extra_->outerZ(); }
+      /// z coordinate of the outermost hit position
+      double outerZ() const { return extra_->outerZ(); }
 
-    /// magnitude of momentum vector at the outermost hit position
-    double outerP() const { return extra_->outerP(); }
+      /// magnitude of momentum vector at the outermost hit position
+      double outerP() const { return extra_->outerP(); }
 
-    /// transverse momentum at the outermost hit position
-    double outerPt() const { return extra_->outerPt(); }
+      /// transverse momentum at the outermost hit position
+      double outerPt() const { return extra_->outerPt(); }
 
-    /// azimuthal angle of the  momentum vector at the outermost hit position
-    double outerPhi() const { return extra_->outerPhi(); }
+      /// azimuthal angle of the  momentum vector at the outermost hit position
+      double outerPhi() const { return extra_->outerPhi(); }
 
-    /// pseudorapidity of the  momentum vector at the outermost hit position
-    double outerEta() const { return extra_->outerEta(); }
+      /// pseudorapidity of the  momentum vector at the outermost hit position
+      double outerEta() const { return extra_->outerEta(); }
 
-    /// polar angle of the  momentum vector at the outermost hit position
-    double outerTheta() const { return extra_->outerTheta(); }
+      /// polar angle of the  momentum vector at the outermost hit position
+      double outerTheta() const { return extra_->outerTheta(); }
 
-    /// polar radius of the outermost hit position
-    double outerRadius() const { return extra_->outerRadius(); }
+      /// polar radius of the outermost hit position
+      double outerRadius() const { return extra_->outerRadius(); }
 
-    /// set reference to "extra" object
-    void setExtra(const TrackExtraRef& ref) { extra_ = ref; }
+      /// set reference to "extra" object
+      void setExtra(const TrackExtraRef& ref) { extra_ = ref; }
 
-    /// reference to "extra" object
-    const TrackExtraRef& extra() const { return extra_; }
+      /// reference to "extra" object
+      const TrackExtraRef& extra() const { return extra_; }
 
-    /// Number of valid hits on track.
-    unsigned short found() const { return numberOfValidHits(); }
+      /// Number of valid hits on track.
+      unsigned short found() const { return numberOfValidHits(); }
 
-    /// Number of lost (=invalid) hits on track.
-    unsigned short lost() const { return numberOfLostHits(); }
+      /// Number of lost (=invalid) hits on track.
+      unsigned short lost() const { return numberOfLostHits(); }
 
-    /// direction of how the hits were sorted in the original seed
-    const PropagationDirection& seedDirection() const { return extra_->seedDirection(); }
+      /// direction of how the hits were sorted in the original seed
+      const PropagationDirection& seedDirection() const { return extra_->seedDirection(); }
 
-    /**  return the edm::reference to the trajectory seed in the original
+      /**  return the edm::reference to the trajectory seed in the original
      *   seeds collection. If the collection has been dropped from the
      *   Event, the reference may be invalid. Its validity should be tested,
      *   before the reference is actually used.
      */
-    const edm::RefToBase<TrajectorySeed>& seedRef() const { return extra_->seedRef(); }
+      const edm::RefToBase<TrajectorySeed>& seedRef() const { return extra_->seedRef(); }
 
-    /// get the residuals
-    const TrackResiduals& residuals() const { return extra_->residuals(); }
+      /// get the residuals
+      const TrackResiduals& residuals() const { return extra_->residuals(); }
 
-    // Check validity of track extra and rechits
-    bool recHitsOk() const { return extra_.isNonnull() && extra_.isAvailable() && extra_->recHitsOk(); }
+      // Check validity of track extra and rechits
+      bool recHitsOk() const { return extra_.isNonnull() && extra_.isAvailable() && extra_->recHitsOk(); }
 
-  private:
-    /// Reference to additional information stored only on RECO.
-    TrackExtraRef extra_;
-  };
-
+    private:
+      /// Reference to additional information stored only on RECO.
+      TrackExtraRef extra_;
+    };
+  }  // namespace v1
+  using Track = io_v1::Track;
 }  // namespace reco
 
 #endif

--- a/DataFormats/TrackReco/interface/Track.h
+++ b/DataFormats/TrackReco/interface/Track.h
@@ -165,7 +165,7 @@ namespace reco {
       /// Reference to additional information stored only on RECO.
       TrackExtraRef extra_;
     };
-  }  // namespace v1
+  }  // namespace io_v1
   using Track = io_v1::Track;
 }  // namespace reco
 

--- a/DataFormats/TrackReco/interface/TrackExtra.h
+++ b/DataFormats/TrackReco/interface/TrackExtra.h
@@ -23,144 +23,147 @@
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 namespace reco {
-  class TrackExtra : public TrackExtraBase {
-  public:
-    /// tracker parameter dimension
-    enum { dimension = 5 };
-    /// track error matrix size
-    enum { covarianceSize = dimension * (dimension + 1) / 2 };
-    /// point in the space
-    typedef math::XYZPoint Point;
-    /// spatial vector
-    typedef math::XYZVector Vector;
-    /// 5 parameter covariance matrix
-    typedef math::Error<5>::type CovarianceMatrix;
-    /// index type
-    typedef unsigned int index;
+  namespace io_v1 {
+    class TrackExtra : public TrackExtraBase {
+    public:
+      /// tracker parameter dimension
+      enum { dimension = 5 };
+      /// track error matrix size
+      enum { covarianceSize = dimension * (dimension + 1) / 2 };
+      /// point in the space
+      typedef math::XYZPoint Point;
+      /// spatial vector
+      typedef math::XYZVector Vector;
+      /// 5 parameter covariance matrix
+      typedef math::Error<5>::type CovarianceMatrix;
+      /// index type
+      typedef unsigned int index;
 
-    /// default constructor
-    TrackExtra()
-        : outerMomentum_(),
-          outerOk_(false),
-          outerDetId_(0),
-          innerPosition_(),
-          innerMomentum_(),
-          innerOk_(false),
-          innerDetId_(0),
-          seedDir_(anyDirection),
-          seedRef_() {
-      for (index i = 0; i < covarianceSize; ++i) {
-        outerCovariance_[i] = 0;
-        innerCovariance_[i] = 0;
+      /// default constructor
+      TrackExtra()
+          : outerMomentum_(),
+            outerOk_(false),
+            outerDetId_(0),
+            innerPosition_(),
+            innerMomentum_(),
+            innerOk_(false),
+            innerDetId_(0),
+            seedDir_(anyDirection),
+            seedRef_() {
+        for (index i = 0; i < covarianceSize; ++i) {
+          outerCovariance_[i] = 0;
+          innerCovariance_[i] = 0;
+        }
       }
-    }
 
-    /// constructor from outermost/innermost position and momentum and Seed information
-    TrackExtra(const Point &outerPosition,
-               const Vector &outerMomentum,
-               bool ok,
-               const Point &innerPosition,
-               const Vector &innerMomentum,
-               bool iok,
-               const CovarianceMatrix &outerState,
-               unsigned int outerId,
-               const CovarianceMatrix &innerState,
-               unsigned int innerId,
-               PropagationDirection seedDir,
-               edm::RefToBase<TrajectorySeed> seedRef = edm::RefToBase<TrajectorySeed>());
+      /// constructor from outermost/innermost position and momentum and Seed information
+      TrackExtra(const Point &outerPosition,
+                 const Vector &outerMomentum,
+                 bool ok,
+                 const Point &innerPosition,
+                 const Vector &innerMomentum,
+                 bool iok,
+                 const CovarianceMatrix &outerState,
+                 unsigned int outerId,
+                 const CovarianceMatrix &innerState,
+                 unsigned int innerId,
+                 PropagationDirection seedDir,
+                 edm::RefToBase<TrajectorySeed> seedRef = edm::RefToBase<TrajectorySeed>());
 
-    /// outermost hit position
-    const Point &outerPosition() const { return outerPosition_; }
-    /// momentum vector at outermost hit position
-    const Vector &outerMomentum() const { return outerMomentum_; }
-    /// returns true if the outermost hit is valid
-    bool outerOk() const { return outerOk_; }
-    /// innermost hit position
-    const Point &innerPosition() const { return innerPosition_; }
-    /// momentum vector at innermost hit position
-    const Vector &innerMomentum() const { return innerMomentum_; }
-    /// returns true if the innermost hit is valid
-    bool innerOk() const { return innerOk_; }
-    /// x coordinate of momentum vector at the outermost hit position
-    double outerPx() const { return outerMomentum_.X(); }
-    /// y coordinate of momentum vector at the outermost hit position
-    double outerPy() const { return outerMomentum_.Y(); }
-    /// z coordinate of momentum vector at the outermost hit position
-    double outerPz() const { return outerMomentum_.Z(); }
-    /// x coordinate the outermost hit position
-    double outerX() const { return outerPosition_.X(); }
-    /// y coordinate the outermost hit position
-    double outerY() const { return outerPosition_.Y(); }
-    /// z coordinate the outermost hit position
-    double outerZ() const { return outerPosition_.Z(); }
-    /// magnitude of momentum vector at the outermost hit position
-    double outerP() const { return outerMomentum().R(); }
-    /// transverse momentum at the outermost hit position
-    double outerPt() const { return outerMomentum().Rho(); }
-    /// azimuthal angle of the  momentum vector at the outermost hit position
-    double outerPhi() const { return outerMomentum().Phi(); }
-    /// pseudorapidity the  momentum vector at the outermost hit position
-    double outerEta() const { return outerMomentum().Eta(); }
-    /// polar angle of the  momentum vector at the outermost hit position
-    double outerTheta() const { return outerMomentum().Theta(); }
-    /// polar radius of the outermost hit position
-    double outerRadius() const { return outerPosition().Rho(); }
+      /// outermost hit position
+      const Point &outerPosition() const { return outerPosition_; }
+      /// momentum vector at outermost hit position
+      const Vector &outerMomentum() const { return outerMomentum_; }
+      /// returns true if the outermost hit is valid
+      bool outerOk() const { return outerOk_; }
+      /// innermost hit position
+      const Point &innerPosition() const { return innerPosition_; }
+      /// momentum vector at innermost hit position
+      const Vector &innerMomentum() const { return innerMomentum_; }
+      /// returns true if the innermost hit is valid
+      bool innerOk() const { return innerOk_; }
+      /// x coordinate of momentum vector at the outermost hit position
+      double outerPx() const { return outerMomentum_.X(); }
+      /// y coordinate of momentum vector at the outermost hit position
+      double outerPy() const { return outerMomentum_.Y(); }
+      /// z coordinate of momentum vector at the outermost hit position
+      double outerPz() const { return outerMomentum_.Z(); }
+      /// x coordinate the outermost hit position
+      double outerX() const { return outerPosition_.X(); }
+      /// y coordinate the outermost hit position
+      double outerY() const { return outerPosition_.Y(); }
+      /// z coordinate the outermost hit position
+      double outerZ() const { return outerPosition_.Z(); }
+      /// magnitude of momentum vector at the outermost hit position
+      double outerP() const { return outerMomentum().R(); }
+      /// transverse momentum at the outermost hit position
+      double outerPt() const { return outerMomentum().Rho(); }
+      /// azimuthal angle of the  momentum vector at the outermost hit position
+      double outerPhi() const { return outerMomentum().Phi(); }
+      /// pseudorapidity the  momentum vector at the outermost hit position
+      double outerEta() const { return outerMomentum().Eta(); }
+      /// polar angle of the  momentum vector at the outermost hit position
+      double outerTheta() const { return outerMomentum().Theta(); }
+      /// polar radius of the outermost hit position
+      double outerRadius() const { return outerPosition().Rho(); }
 
-    /// outermost trajectory state curvilinear errors
-    CovarianceMatrix outerStateCovariance() const;
-    /// innermost trajectory state curvilinear errors
-    CovarianceMatrix innerStateCovariance() const;
-    /// fill outermost trajectory state curvilinear errors
-    CovarianceMatrix &fillOuter CMS_THREAD_SAFE(CovarianceMatrix &v) const;
-    /// fill outermost trajectory state curvilinear errors
-    CovarianceMatrix &fillInner CMS_THREAD_SAFE(CovarianceMatrix &v) const;
-    /// DetId of the detector on which surface the outermost state is located
-    unsigned int outerDetId() const { return outerDetId_; }
-    /// DetId of the detector on which surface the innermost state is located
-    unsigned int innerDetId() const { return innerDetId_; }
-    // direction how the hits were sorted in the original seed
-    const PropagationDirection &seedDirection() const { return seedDir_; }
+      /// outermost trajectory state curvilinear errors
+      CovarianceMatrix outerStateCovariance() const;
+      /// innermost trajectory state curvilinear errors
+      CovarianceMatrix innerStateCovariance() const;
+      /// fill outermost trajectory state curvilinear errors
+      CovarianceMatrix &fillOuter CMS_THREAD_SAFE(CovarianceMatrix &v) const;
+      /// fill outermost trajectory state curvilinear errors
+      CovarianceMatrix &fillInner CMS_THREAD_SAFE(CovarianceMatrix &v) const;
+      /// DetId of the detector on which surface the outermost state is located
+      unsigned int outerDetId() const { return outerDetId_; }
+      /// DetId of the detector on which surface the innermost state is located
+      unsigned int innerDetId() const { return innerDetId_; }
+      // direction how the hits were sorted in the original seed
+      const PropagationDirection &seedDirection() const { return seedDir_; }
 
-    /**  return the edm::reference to the trajectory seed in the original
+      /**  return the edm::reference to the trajectory seed in the original
      *   seeds collection. If the collection has been dropped from the
      *   Event, the reference may be invalid. Its validity should be tested,
      *   before the reference is actually used.
      */
-    const edm::RefToBase<TrajectorySeed> &seedRef() const { return seedRef_; }
-    void setSeedRef(const edm::RefToBase<TrajectorySeed> &r) { seedRef_ = r; }
-    /// set the residuals
-    void setResiduals(const TrackResiduals &r) { trackResiduals_ = r; }
+      const edm::RefToBase<TrajectorySeed> &seedRef() const { return seedRef_; }
+      void setSeedRef(const edm::RefToBase<TrajectorySeed> &r) { seedRef_ = r; }
+      /// set the residuals
+      void setResiduals(const TrackResiduals &r) { trackResiduals_ = r; }
 
-    /// get the residuals
-    const TrackResiduals &residuals() const { return trackResiduals_; }
+      /// get the residuals
+      const TrackResiduals &residuals() const { return trackResiduals_; }
 
-  private:
-    /// outermost hit position
-    Point outerPosition_;
-    /// momentum vector at outermost hit position
-    Vector outerMomentum_;
-    /// outermost hit validity flag
-    bool outerOk_;
-    /// outermost trajectory state curvilinear errors
-    float outerCovariance_[covarianceSize];
-    unsigned int outerDetId_;
+    private:
+      /// outermost hit position
+      Point outerPosition_;
+      /// momentum vector at outermost hit position
+      Vector outerMomentum_;
+      /// outermost hit validity flag
+      bool outerOk_;
+      /// outermost trajectory state curvilinear errors
+      float outerCovariance_[covarianceSize];
+      unsigned int outerDetId_;
 
-    /// innermost hit position
-    Point innerPosition_;
-    /// momentum vector at innermost hit position
-    Vector innerMomentum_;
-    /// innermost hit validity flag
-    bool innerOk_;
-    /// innermost trajectory state
-    float innerCovariance_[covarianceSize];
-    unsigned int innerDetId_;
+      /// innermost hit position
+      Point innerPosition_;
+      /// momentum vector at innermost hit position
+      Vector innerMomentum_;
+      /// innermost hit validity flag
+      bool innerOk_;
+      /// innermost trajectory state
+      float innerCovariance_[covarianceSize];
+      unsigned int innerDetId_;
 
-    PropagationDirection seedDir_;
-    edm::RefToBase<TrajectorySeed> seedRef_;
+      PropagationDirection seedDir_;
+      edm::RefToBase<TrajectorySeed> seedRef_;
 
-    /// unbiased track residuals
-    TrackResiduals trackResiduals_;
-  };
+      /// unbiased track residuals
+      TrackResiduals trackResiduals_;
+    };
+  }  // namespace io_v1
+  using TrackExtra = io_v1::TrackExtra;
 
 }  // namespace reco
 

--- a/DataFormats/TrackReco/interface/TrackExtraFwd.h
+++ b/DataFormats/TrackReco/interface/TrackExtraFwd.h
@@ -7,7 +7,10 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 namespace reco {
-  class TrackExtra;
+  namespace io_v1 {
+    class TrackExtra;
+  }
+  using TrackExtra = io_v1::TrackExtra;
 
   /// collection of TrackExtra objects
   typedef std::vector<TrackExtra> TrackExtraCollection;

--- a/DataFormats/TrackReco/interface/TrackFwd.h
+++ b/DataFormats/TrackReco/interface/TrackFwd.h
@@ -10,8 +10,10 @@
 #include "DataFormats/Common/interface/Association.h"
 
 namespace reco {
-
-  class Track;
+  namespace io_v1 {
+    class Track;
+  }
+  using Track = io_v1::Track;
 
   /// collection of Tracks
   typedef std::vector<Track> TrackCollection;

--- a/DataFormats/TrackReco/src/classes.h
+++ b/DataFormats/TrackReco/src/classes.h
@@ -26,7 +26,7 @@
 #include "DataFormats/Common/interface/OneToManyWithQuality.h"
 #include "DataFormats/Common/interface/OneToManyWithQualityGeneric.h"
 #include "DataFormats/Common/interface/View.h"
-#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Common/interface/AtomicPtrCache.h"
 #include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
 #include "DataFormats/TrackReco/interface/DeDxHitInfo.h"
 #include "DataFormats/TrackReco/interface/SeedStopInfo.h"

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -336,30 +336,20 @@
   <class name="edm::Ref<std::vector<reco::TrackExtra>,reco::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra> >"/>
   <class name="edm::RefVector<std::vector<reco::TrackExtra>,reco::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra> >"/>
 
-  <class name="reco::Track" ClassVersion="20">
-   <version ClassVersion="20" checksum="2864582648"/>
-   <version ClassVersion="19" checksum="362503460"/>
-   <version ClassVersion="18" checksum="3235158110"/>
-   <version ClassVersion="17" checksum="3387867292"/>
-   <version ClassVersion="16" checksum="697987788"/>
-   <version ClassVersion="15" checksum="3694119510"/>
-   <version ClassVersion="14" checksum="4228121071"/>
-   <version ClassVersion="13" checksum="36410295"/>
-   <version ClassVersion="12" checksum="1190637787"/>
-   <version ClassVersion="11" checksum="1190637787"/>
-   <version ClassVersion="10" checksum="1190637787"/>
+  <class name="reco::io_v1::Track" ClassVersion="3">
+   <version ClassVersion="3" checksum="3782984338"/>
   </class>
-  <class name="std::vector<reco::Track>"/>
-  <class name="edm::Wrapper<std::vector<reco::Track> >"/>
-  <class name="edm::RefProd<std::vector<reco::Track> >"/>
-  <class name="edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track>"/>
-  <class name="edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >"/>
-  <class name="edm::RefVector<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >"/>
-  <class name="std::vector<edm::RefVector<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> > >"/>
-  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> > >"/>
-  <class name="std::vector<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> > >"/>
-  <class name="edm::Ptr<reco::Track>" />
-  <class name="std::vector<edm::Ptr<reco::Track> >" />
+  <class name="std::vector<reco::io_v1::Track>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::Track> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::Track> >"/>
+  <class name="edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track>"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >"/>
+  <class name="std::vector<edm::RefVector<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> > >"/>
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> > >"/>
+  <class name="std::vector<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> > >"/>
+  <class name="edm::Ptr<reco::io_v1::Track>" />
+  <class name="std::vector<edm::Ptr<reco::io_v1::Track> >" />
   <class name="edm::Association<reco::TrackCollection>"/>
   <class name="edm::Wrapper<edm::Association<reco::TrackCollection> >"/>
 
@@ -368,36 +358,36 @@
   </class>
 
   <!-- <class pattern="edm::Wrapper<edm::AssociationMap<*>" /> -->
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToMany<vector<reco::Track>,vector<TrajectorySeed>,unsigned int> > >" />
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<vector<reco::Track>,vector<reco::Track>,unsigned int> > >" />
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<vector<reco::Track>,bool,unsigned int> > >" />
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<vector<reco::Track>,double,unsigned int> > >" />
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<vector<reco::Track>,float,unsigned int> > >" />
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<vector<reco::Track>,int,unsigned int> > >" />
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToMany<vector<reco::io_v1::Track>,vector<TrajectorySeed>,unsigned int> > >" />
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<vector<reco::io_v1::Track>,vector<reco::io_v1::Track>,unsigned int> > >" />
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<vector<reco::io_v1::Track>,bool,unsigned int> > >" />
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<vector<reco::io_v1::Track>,double,unsigned int> > >" />
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<vector<reco::io_v1::Track>,float,unsigned int> > >" />
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<vector<reco::io_v1::Track>,int,unsigned int> > >" />
 
-  <class name="edm::helpers::Key<edm::RefProd <std::vector <reco::Track> > >" />
+  <class name="edm::helpers::Key<edm::RefProd <std::vector <reco::io_v1::Track> > >" />
 
-  <class name="edm::AssociationMap<edm::OneToValue<std::vector<reco::Track>,double,unsigned int> >">
+  <class name="edm::AssociationMap<edm::OneToValue<std::vector<reco::io_v1::Track>,double,unsigned int> >">
     <field name="transientMap_" transient="true" /> 
   </class>
 
-  <class name="edm::AssociationMap<edm::OneToValue<std::vector<reco::Track>,bool,unsigned int> >">
+  <class name="edm::AssociationMap<edm::OneToValue<std::vector<reco::io_v1::Track>,bool,unsigned int> >">
     <field name="transientMap_" transient="true" />
   </class>
 
-  <class name="edm::AssociationMap<edm::OneToValue<std::vector<reco::Track>,int,unsigned int> >">
+  <class name="edm::AssociationMap<edm::OneToValue<std::vector<reco::io_v1::Track>,int,unsigned int> >">
     <field name="transientMap_" transient="true" />
   </class>
 
-  <class name="edm::AssociationMap<edm::OneToValue<std::vector<reco::Track>,float,unsigned int> >">
+  <class name="edm::AssociationMap<edm::OneToValue<std::vector<reco::io_v1::Track>,float,unsigned int> >">
     <field name="transientMap_" transient="true" />
   </class>
 
-  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> > >" />
+  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> > >" />
  
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::Track> >,edm::RefProd<std::vector<reco::Track> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::io_v1::Track> >,edm::RefProd<std::vector<reco::io_v1::Track> > >" />
 
-  <class name="edm::AssociationMap<edm::OneToOne<std::vector<reco::Track>,std::vector<reco::Track>,unsigned int> >">
+  <class name="edm::AssociationMap<edm::OneToOne<std::vector<reco::io_v1::Track>,std::vector<reco::io_v1::Track>,unsigned int> >">
     <field name="transientMap_" transient="true" />
   </class>
 
@@ -413,22 +403,22 @@
   <!-- <class pattern="edm::AssociationVector<*>">
     <field name="transientVector_" transient="true"/>
   </class> -->
-  <class name="edm::AssociationVector<edm::RefProd<std::vector<reco::Track> >,std::vector<bool>,edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>" >
+  <class name="edm::AssociationVector<edm::RefProd<std::vector<reco::io_v1::Track> >,std::vector<bool>,edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>" >
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="edm::AssociationVector<edm::RefProd<std::vector<reco::Track> >,std::vector<double>,edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>" >
+  <class name="edm::AssociationVector<edm::RefProd<std::vector<reco::io_v1::Track> >,std::vector<double>,edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>" >
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="edm::AssociationVector<edm::RefProd<std::vector<reco::Track> >,std::vector<float>,edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>" >
+  <class name="edm::AssociationVector<edm::RefProd<std::vector<reco::io_v1::Track> >,std::vector<float>,edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>" >
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="edm::AssociationVector<edm::RefProd<std::vector<reco::Track> >,std::vector<int>,edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>" >
+  <class name="edm::AssociationVector<edm::RefProd<std::vector<reco::io_v1::Track> >,std::vector<int>,edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>" >
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="edm::AssociationVector<edm::RefProd<std::vector<reco::Track> >,std::vector<std::vector<reco::DeDxHit> >,edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>" >
+  <class name="edm::AssociationVector<edm::RefProd<std::vector<reco::io_v1::Track> >,std::vector<std::vector<reco::DeDxHit> >,edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>" >
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,std::vector<reco::DeDxHit> >" />
+  <class name="std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,std::vector<reco::DeDxHit> >" />
      <!--   <class name="reco::DeDxDataCollection"/> -->
      <class name="reco::DeDxData" ClassVersion="11">
       <version ClassVersion="11" checksum="30657010"/>
@@ -443,57 +433,57 @@
 
 
 
-     <!-- RefToBase<reco::Track> -->
-     <class name="edm::RefToBase<reco::Track>" rntupleStreamerMode="true"/>
-     <class name="edm::reftobase::IndirectHolder<reco::Track>"/>
-     <class name="edm::reftobase::BaseHolder<reco::Track>"/>
+     <!-- RefToBase<reco::io_v1::Track> -->
+     <class name="edm::RefToBase<reco::io_v1::Track>" rntupleStreamerMode="true"/>
+     <class name="edm::reftobase::IndirectHolder<reco::io_v1::Track>"/>
+     <class name="edm::reftobase::BaseHolder<reco::io_v1::Track>"/>
      <class name="edm::reftobase::RefHolder<reco::TrackRef>"/>
-     <class name="edm::reftobase::RefHolder<edm::Ptr<reco::Track> >"/>
-     <class name="edm::reftobase::Holder<reco::Track, reco::TrackRef>"/>
+     <class name="edm::reftobase::RefHolder<edm::Ptr<reco::io_v1::Track> >"/>
+     <class name="edm::reftobase::Holder<reco::io_v1::Track, reco::TrackRef>"/>
 
-     <class name="std::vector<edm::RefToBase<reco::Track> >" />
+     <class name="std::vector<edm::RefToBase<reco::io_v1::Track> >" />
 
-     <class name="std::pair<edm::RefToBase<reco::Track>,double>" />
-     <class name="std::vector<std::pair<edm::RefToBase<reco::Track>,double> >" />
+     <class name="std::pair<edm::RefToBase<reco::io_v1::Track>,double>" />
+     <class name="std::vector<std::pair<edm::RefToBase<reco::io_v1::Track>,double> >" />
 
-     <class name="edm::reftobase::BaseVectorHolder<reco::Track>" />
+     <class name="edm::reftobase::BaseVectorHolder<reco::io_v1::Track>" />
      <class name="reco::TrackBaseRefVector"/>
      <class name="edm::Wrapper<reco::TrackBaseRefVector>"/>
 
-     <!-- RefToBaseProd<reco::Track> -->
-     <class name="edm::RefToBaseProd<reco::Track>" />
+     <!-- RefToBaseProd<reco::io_v1::Track> -->
+     <class name="edm::RefToBaseProd<reco::io_v1::Track>" />
 
-     <!-- ValueMap<reco::Track> -->
+     <!-- ValueMap<reco::io_v1::Track> -->
      <class name="edm::ValueMap<reco::TrackRefVector>" />
      <class name="edm::Wrapper<edm::ValueMap<reco::TrackRefVector> >" />
 
 
-     <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::Track> >,edm::RefProd<std::vector<TrajectorySeed> > >"/>
-     <class name="edm::AssociationMap<edm::OneToMany<std::vector<reco::Track>,std::vector<TrajectorySeed>,unsigned int> >">
+     <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::io_v1::Track> >,edm::RefProd<std::vector<TrajectorySeed> > >"/>
+     <class name="edm::AssociationMap<edm::OneToMany<std::vector<reco::io_v1::Track>,std::vector<TrajectorySeed>,unsigned int> >">
        <field name="transientMap_" transient="true"/>
      </class>
 
-     <class name="std::vector<std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,float> >" />
-     <class name="std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,float>" />
+     <class name="std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,float> >" />
+     <class name="std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,float>" />
 
 
-     <class name="std::vector<std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,int> >" />
-     <class name="std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,int>" />
+     <class name="std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,int> >" />
+     <class name="std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,int>" />
 
 
-     <class name="std::pair<reco::Track,reco::Track>"/>
-     <class name="edm::Wrapper<std::pair<reco::Track,reco::Track> >"/>
-     <class name="std::pair<TrackCandidate,std::pair<reco::Track,reco::Track> >" />
-     <class name="edm::Wrapper<std::pair<TrackCandidate,std::pair<reco::Track,reco::Track> > >" />
-     <class name="std::vector<std::pair<TrackCandidate,std::pair<reco::Track,reco::Track> > >"/>
-     <class name="edm::Wrapper<std::vector<std::pair<TrackCandidate,std::pair<reco::Track,reco::Track> > > >"/>
+     <class name="std::pair<reco::io_v1::Track,reco::io_v1::Track>"/>
+     <class name="edm::Wrapper<std::pair<reco::io_v1::Track,reco::io_v1::Track> >"/>
+     <class name="std::pair<TrackCandidate,std::pair<reco::io_v1::Track,reco::io_v1::Track> >" />
+     <class name="edm::Wrapper<std::pair<TrackCandidate,std::pair<reco::io_v1::Track,reco::io_v1::Track> > >" />
+     <class name="std::vector<std::pair<TrackCandidate,std::pair<reco::io_v1::Track,reco::io_v1::Track> > >"/>
+     <class name="edm::Wrapper<std::vector<std::pair<TrackCandidate,std::pair<reco::io_v1::Track,reco::io_v1::Track> > > >"/>
 
-     <class name="std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> > >"/>
-     <class name="edm::Wrapper<std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> > > >"/>
-     <class name="std::pair<TrackCandidate,std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> > > >" />
-     <class name="edm::Wrapper<std::pair<TrackCandidate,std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> > > > >" />
-     <class name="std::vector<std::pair<TrackCandidate,std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> > > > >"/>
-     <class name="edm::Wrapper<std::vector<std::pair<TrackCandidate,std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> > > > > >"/>
+     <class name="std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> > >"/>
+     <class name="edm::Wrapper<std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> > > >"/>
+     <class name="std::pair<TrackCandidate,std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> > > >" />
+     <class name="edm::Wrapper<std::pair<TrackCandidate,std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> > > > >" />
+     <class name="std::vector<std::pair<TrackCandidate,std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> > > > >"/>
+     <class name="edm::Wrapper<std::vector<std::pair<TrackCandidate,std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> > > > > >"/>
 
     <class name="edm::Association<std::vector<reco::TrackExtra>>"/>
     <class name="edm::Wrapper<edm::Association<std::vector<reco::TrackExtra>>>"/>

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -318,26 +318,22 @@
   </ioread>
 
 
-  <class name="reco::TrackExtra" ClassVersion="14">
-   <version ClassVersion="14" checksum="388593738"/>
-   <version ClassVersion="13" checksum="2526033150"/>
-   <version ClassVersion="12" checksum="106004853"/>
-   <version ClassVersion="11" checksum="2586227274"/>
-   <version ClassVersion="10" checksum="1613098482"/>
+  <class name="reco::io_v1::TrackExtra" ClassVersion="3">
+   <version ClassVersion="3" checksum="1477568196"/>
     <field name="outerPosition_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
     <field name="outerMomentum_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
     <field name="innerPosition_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
     <field name="innerMomentum_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
   </class>
-  <class name="std::vector<reco::TrackExtra>"/>
-  <class name="edm::Wrapper<std::vector<reco::TrackExtra> >"/>
-  <class name="edm::RefProd<std::vector<reco::TrackExtra> >"/>
-  <class name="edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra>"/>
-  <class name="edm::Ref<std::vector<reco::TrackExtra>,reco::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra> >"/>
-  <class name="edm::RefVector<std::vector<reco::TrackExtra>,reco::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra> >"/>
+  <class name="std::vector<reco::io_v1::TrackExtra>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::TrackExtra> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::TrackExtra> >"/>
+  <class name="edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::TrackExtra>,reco::io_v1::TrackExtra>"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::TrackExtra>,reco::io_v1::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::TrackExtra>,reco::io_v1::TrackExtra> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::TrackExtra>,reco::io_v1::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::TrackExtra>,reco::io_v1::TrackExtra> >"/>
 
   <class name="reco::io_v1::Track" ClassVersion="3">
-   <version ClassVersion="3" checksum="3782984338"/>
+   <version ClassVersion="3" checksum="874879354"/>
   </class>
   <class name="std::vector<reco::io_v1::Track>"/>
   <class name="edm::Wrapper<std::vector<reco::io_v1::Track> >"/>
@@ -485,8 +481,8 @@
      <class name="std::vector<std::pair<TrackCandidate,std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> > > > >"/>
      <class name="edm::Wrapper<std::vector<std::pair<TrackCandidate,std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> > > > > >"/>
 
-    <class name="edm::Association<std::vector<reco::TrackExtra>>"/>
-    <class name="edm::Wrapper<edm::Association<std::vector<reco::TrackExtra>>>"/>
+    <class name="edm::Association<std::vector<reco::io_v1::TrackExtra>>"/>
+    <class name="edm::Wrapper<edm::Association<std::vector<reco::io_v1::TrackExtra>>>"/>
 
    <class name="reco::DeDxHitInfo::DeDxHitInfoContainer" ClassVersion="3">
     <version ClassVersion="2" checksum="3964047764"/>

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -363,6 +363,10 @@
   <class name="edm::Association<reco::TrackCollection>"/>
   <class name="edm::Wrapper<edm::Association<reco::TrackCollection> >"/>
 
+  <class name="edm::AtomicPtrCache<reco::TrackRefVector>">
+     <field name="m_data" transient="true"/>
+  </class>
+
   <!-- <class pattern="edm::Wrapper<edm::AssociationMap<*>" /> -->
   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToMany<vector<reco::Track>,vector<TrajectorySeed>,unsigned int> > >" />
   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<vector<reco::Track>,vector<reco::Track>,unsigned int> > >" />

--- a/DataFormats/VertexReco/interface/Vertex.h
+++ b/DataFormats/VertexReco/interface/Vertex.h
@@ -30,8 +30,6 @@
 
 namespace reco {
 
-  class Track;
-
   class Vertex {
   public:
     /// The iteratator for the vector<TrackRef>

--- a/DataFormats/VertexReco/src/classes_def.xml
+++ b/DataFormats/VertexReco/src/classes_def.xml
@@ -1,7 +1,6 @@
 <lcgdict>
-  <class name="reco::Vertex"  ClassVersion="11">
-   <version ClassVersion="11" checksum="4120119845"/>
-   <version ClassVersion="10" checksum="414871454"/>
+  <class name="reco::Vertex"  ClassVersion="3">
+   <version ClassVersion="3" checksum="1003958319"/>
   </class>
   <class name="std::vector<reco::Vertex>" />
   <class name="edm::Wrapper<std::vector<reco::Vertex> >" />
@@ -18,29 +17,29 @@
   <class name="edm::RefProd<std::vector<reco::NuclearInteraction> >" />
   <class name="edm::RefVector<std::vector<reco::NuclearInteraction>, reco::NuclearInteraction, edm::refhelper::FindUsingAdvance<std::vector<reco::NuclearInteraction>, reco::NuclearInteraction> >" />
 
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::Vertex> >,edm::RefProd<std::vector<reco::Track> > >" />  
-  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,float> > >" />
-  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,float> > > >" />
-  <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Vertex>,std::vector<reco::Track>,float,unsigned int> >" >
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::Vertex> >,edm::RefProd<std::vector<reco::io_v1::Track> > >" />  
+  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,float> > >" />
+  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,float> > > >" />
+  <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Vertex>,std::vector<reco::io_v1::Track>,float,unsigned int> >" >
     <field name="transientMap_" transient="true"/>
   </class>
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Vertex>,std::vector<reco::Track>,float,unsigned int> > >" />
-  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,int> > >" />
-  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,int> > > >" />
-  <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Vertex>,std::vector<reco::Track>,int,unsigned int> >" >
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Vertex>,std::vector<reco::io_v1::Track>,float,unsigned int> > >" />
+  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,int> > >" />
+  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,int> > > >" />
+  <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Vertex>,std::vector<reco::io_v1::Track>,int,unsigned int> >" >
     <field name="transientMap_" transient="true"/>
   </class>
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Vertex>,std::vector<reco::Track>,int,unsigned int> > >" >
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Vertex>,std::vector<reco::io_v1::Track>,int,unsigned int> > >" >
     <field name="transientMap_" transient="true"/>
   </class>
 
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::Track> >,edm::RefProd<std::vector<reco::Vertex> > >" />  
-  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,std::vector<std::pair<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,int> > >" />
-  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,std::vector<std::pair<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,int> > > >" />
-  <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Track>,std::vector<reco::Vertex>,int,unsigned int> >" >
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::io_v1::Track> >,edm::RefProd<std::vector<reco::Vertex> > >" />  
+  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,std::vector<std::pair<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,int> > >" />
+  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,std::vector<std::pair<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,int> > > >" />
+  <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::io_v1::Track>,std::vector<reco::Vertex>,int,unsigned int> >" >
     <field name="transientMap_" transient="true"/>
   </class>
-<!--      <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Track>,std::vector<reco::Vertex>,int,unsigned int> > >" /> -->
+<!--      <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::io_v1::Track>,std::vector<reco::Vertex>,int,unsigned int> > >" /> -->
 
 
  <class name="edm::Association<std::vector<reco::Vertex> >"/>

--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -43,6 +43,7 @@ namespace edm {
       return std::regex_replace(iIn, reAllSpaces, emptyString);
     }
     static std::regex const reWrapper("edm::Wrapper<(.*)>");
+    static std::regex const reVersion("::io_v[0-9]+::");
     static std::regex const reString("std::basic_string<char>");
     static std::regex const reString2("std::string");
     static std::regex const reString3("std::basic_string<char,std::char_traits<char> >");
@@ -116,6 +117,7 @@ namespace edm {
       static std::regex const reArray("\\[\\]");
 
       std::string name = regex_replace(iIn, reWrapper, "$1");
+      name = regex_replace(name, reVersion, "::");
       name = regex_replace(name, rePointer, "ptr");
       name = regex_replace(name, reArray, "As");
       name = regex_replace(name, reAIKR, "");

--- a/Fireworks/Tracks/interface/TrackUtils.h
+++ b/Fireworks/Tracks/interface/TrackUtils.h
@@ -9,11 +9,9 @@
 // system include files
 #include "TEveVSDStructs.h"
 #include <set>
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 // forward declarations
-namespace reco {
-  class Track;
-}
 class RecSegment;
 
 class FWEventItem;

--- a/Fireworks/Tracks/interface/estimate_field.h
+++ b/Fireworks/Tracks/interface/estimate_field.h
@@ -5,9 +5,7 @@
 // Package:     Tracks
 // Class  :     estimate_field
 //
-namespace reco {
-  class Track;
-}
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 namespace fw {
   double estimate_field(const reco::Track& track, bool highQuality = false);

--- a/Fireworks/Tracks/plugins/FWTrackHitsDetailView.h
+++ b/Fireworks/Tracks/plugins/FWTrackHitsDetailView.h
@@ -7,13 +7,11 @@
 #include "TVector3.h"
 #include "Fireworks/Core/interface/FWDetailViewGL.h"
 #include "Fireworks/Core/interface/CSGActionSupervisor.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 class TGLEmbeddedViewer;
 class FWIntValueListener;
 class TGSlider;
-namespace reco {
-  class Track;
-}
 
 class FWTrackHitsDetailView : public FWDetailViewGL<reco::Track>, public CSGActionSupervisor {
 public:

--- a/Fireworks/Tracks/plugins/FWTrackResidualDetailView.h
+++ b/Fireworks/Tracks/plugins/FWTrackResidualDetailView.h
@@ -36,15 +36,12 @@
 #include <vector>
 #include "Rtypes.h"
 #include "Fireworks/Core/interface/FWDetailViewCanvas.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 class FWGeometry;
 class FWModelId;
 class TEveWindowSlot;
 class TEveWindow;
-
-namespace reco {
-  class Track;
-}
 
 class FWTrackResidualDetailView : public FWDetailViewCanvas<reco::Track> {
 public:

--- a/HLTrigger/btau/plugins/HLTmmkFilter.h
+++ b/HLTrigger/btau/plugins/HLTmmkFilter.h
@@ -23,6 +23,7 @@
 #include "HLTrigger/HLTcore/interface/HLTFilter.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
@@ -34,7 +35,6 @@ namespace edm {
 
 namespace reco {
   class Candidate;
-  class Track;
 }  // namespace reco
 
 class FreeTrajectoryState;

--- a/HLTrigger/btau/plugins/HLTmmkkFilter.h
+++ b/HLTrigger/btau/plugins/HLTmmkkFilter.h
@@ -23,6 +23,7 @@
 #include "HLTrigger/HLTcore/interface/HLTFilter.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
@@ -34,7 +35,6 @@ namespace edm {
 
 namespace reco {
   class Candidate;
-  class Track;
 }  // namespace reco
 
 class FreeTrajectoryState;

--- a/HLTrigger/btau/plugins/HLTmumutkVtxProducer.h
+++ b/HLTrigger/btau/plugins/HLTmumutkVtxProducer.h
@@ -37,7 +37,6 @@ namespace edm {
 
 namespace reco {
   class Candidate;
-  class Track;
 }  // namespace reco
 
 class FreeTrajectoryState;

--- a/HLTrigger/btau/plugins/HLTmumutktkVtxProducer.h
+++ b/HLTrigger/btau/plugins/HLTmumutktkVtxProducer.h
@@ -33,7 +33,6 @@ namespace edm {
 
 namespace reco {
   class Candidate;
-  class Track;
 }  // namespace reco
 
 class FreeTrajectoryState;

--- a/PhysicsTools/PatUtils/interface/CaloIsolationEnergy.h
+++ b/PhysicsTools/PatUtils/interface/CaloIsolationEnergy.h
@@ -17,13 +17,10 @@
 */
 #include <vector>
 
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 class MagneticField;
 class TrackToEcalPropagator;
 class CaloTower;
-
-namespace reco {
-  class Track;
-}
 
 namespace pat {
   class Muon;

--- a/PhysicsTools/PatUtils/interface/LeptonVertexSignificance.h
+++ b/PhysicsTools/PatUtils/interface/LeptonVertexSignificance.h
@@ -16,13 +16,10 @@
 
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 class TransientTrackBuilder;
-
-namespace reco {
-  class Track;
-}
 
 namespace pat {
   class Electron;

--- a/PhysicsTools/PatUtils/interface/TrackerIsolationPt.h
+++ b/PhysicsTools/PatUtils/interface/TrackerIsolationPt.h
@@ -15,9 +15,7 @@
   \version  $Id: TrackerIsolationPt.h,v 1.3 2008/02/28 14:54:24 llista Exp $
 */
 
-namespace reco {
-  class Track;
-}
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 namespace edm {
   template <typename T>

--- a/RecoEgamma/EgammaElectronProducers/interface/LowPtGsfElectronFeatures.h
+++ b/RecoEgamma/EgammaElectronProducers/interface/LowPtGsfElectronFeatures.h
@@ -8,12 +8,9 @@
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/ParticleFlowReco/interface/PreId.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
 #include <vector>
-
-namespace reco {
-  class Track;
-}
 
 namespace lowptgsfeleseed {
 

--- a/RecoMuon/MuonIdentification/plugins/GlobalMuonToMuonProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/GlobalMuonToMuonProducer.h
@@ -11,9 +11,7 @@
 //#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-namespace reco {
-  class Track;
-}
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"

--- a/RecoMuon/MuonIdentification/plugins/MuonProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonProducer.h
@@ -17,9 +17,7 @@
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/MuonTimeExtra.h"
 
-namespace reco {
-  class Track;
-}
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 

--- a/RecoMuon/MuonIsolation/interface/MuIsoByTrackPt.h
+++ b/RecoMuon/MuonIsolation/interface/MuIsoByTrackPt.h
@@ -3,6 +3,7 @@
 
 #include "RecoMuon/MuonIsolation/interface/MuIsoBaseAlgorithm.h"
 #include "RecoMuon/MuonIsolation/interface/CutsConeSizeFunction.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 namespace reco {
   namespace isodeposit {
@@ -11,9 +12,6 @@ namespace reco {
 }  // namespace reco
 namespace muonisolation {
   class IsolatorByDeposit;
-}
-namespace reco {
-  class Track;
 }
 namespace edm {
   class Event;

--- a/RecoMuon/TrackerSeedGenerator/interface/L1MuonPixelTrackFitter.h
+++ b/RecoMuon/TrackerSeedGenerator/interface/L1MuonPixelTrackFitter.h
@@ -8,12 +8,9 @@
 #include "DataFormats/GeometryVector/interface/Point3DBase.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 #include <vector>
-
-namespace reco {
-  class Track;
-}
 
 class TrackingRegion;
 class TrackingRecHit;

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
@@ -33,7 +33,6 @@
 
 // #include "TMVA/Reader.h"
 
-
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
@@ -48,7 +47,7 @@
 
 namespace {
   using namespace reco;
-  
+
   class DuplicateListMerger final : public edm::global::EDProducer<> {
   public:
     /// constructor

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
@@ -33,9 +33,22 @@
 
 // #include "TMVA/Reader.h"
 
-using namespace reco;
+
+#include "TrackingTools/PatternTools/interface/Trajectory.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "TrackingTools/PatternTools/interface/ClusterRemovalRefSetter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
+
+#include <tuple>
+#include <array>
+#include "CommonTools/Utils/interface/DynArray.h"
 
 namespace {
+  using namespace reco;
+  
   class DuplicateListMerger final : public edm::global::EDProducer<> {
   public:
     /// constructor
@@ -73,21 +86,6 @@ namespace {
 
     int diffHitsCut_;
   };
-}  // namespace
-
-#include "TrackingTools/PatternTools/interface/Trajectory.h"
-#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
-#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
-#include "TrackingTools/PatternTools/interface/ClusterRemovalRefSetter.h"
-
-#include "FWCore/Framework/interface/Event.h"
-#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
-
-#include <tuple>
-#include <array>
-#include "CommonTools/Utils/interface/DynArray.h"
-
-namespace {
   void DuplicateListMerger::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
     desc.add<edm::InputTag>("mergedSource", edm::InputTag());

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionFilterCloner.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionFilterCloner.cc
@@ -18,9 +18,22 @@
 #include <iostream>
 #include <memory>
 
-using namespace reco;
+#include "TrackingTools/PatternTools/interface/Trajectory.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "TrackingTools/PatternTools/interface/ClusterRemovalRefSetter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
+
+#include <tuple>
+#include <array>
+#include "CommonTools/Utils/interface/DynArray.h"
+
 
 namespace {
+  using namespace reco;
+
   class TrackCollectionFilterCloner final : public edm::global::EDProducer<> {
   public:
     /// constructor
@@ -51,21 +64,7 @@ namespace {
 
     const reco::TrackBase::TrackQuality minQuality_;
   };
-}  // namespace
 
-#include "TrackingTools/PatternTools/interface/Trajectory.h"
-#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
-#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
-#include "TrackingTools/PatternTools/interface/ClusterRemovalRefSetter.h"
-
-#include "FWCore/Framework/interface/Event.h"
-#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
-
-#include <tuple>
-#include <array>
-#include "CommonTools/Utils/interface/DynArray.h"
-
-namespace {
   void TrackCollectionFilterCloner::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
     desc.add<edm::InputTag>("originalSource", edm::InputTag());

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionFilterCloner.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionFilterCloner.cc
@@ -30,7 +30,6 @@
 #include <array>
 #include "CommonTools/Utils/interface/DynArray.h"
 
-
 namespace {
   using namespace reco;
 

--- a/RecoTracker/PixelTrackFitting/interface/KFBasedPixelFitter.h
+++ b/RecoTracker/PixelTrackFitting/interface/KFBasedPixelFitter.h
@@ -4,11 +4,11 @@
 #include "RecoTracker/PixelTrackFitting/interface/PixelFitterBase.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TValidTrackingRecHit.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 #include <vector>
 
 namespace reco {
-  class Track;
   class BeamSpot;
 }  // namespace reco
 

--- a/RecoTracker/PixelTrackFitting/interface/PixelTrackFilterBase.h
+++ b/RecoTracker/PixelTrackFitting/interface/PixelTrackFilterBase.h
@@ -1,9 +1,7 @@
 #ifndef RecoTracker_PixelTrackFitting_PixelTrackFilterBase_h
 #define RecoTracker_PixelTrackFitting_PixelTrackFilterBase_h
 
-namespace reco {
-  class Track;
-}
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 namespace edm {
   class Event;
   class EventSetup;

--- a/RecoTracker/TkSeedGenerator/interface/SeedFromProtoTrack.h
+++ b/RecoTracker/TkSeedGenerator/interface/SeedFromProtoTrack.h
@@ -3,13 +3,11 @@
 
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 
-namespace reco {
-  class Track;
-}
 namespace edm {
   class EventSetup;
   class ConsumesCollector;

--- a/RecoTracker/TrackProducer/interface/DAFTrackProducerAlgorithm.h
+++ b/RecoTracker/TrackProducer/interface/DAFTrackProducerAlgorithm.h
@@ -13,6 +13,7 @@
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h"
 #include "DataFormats/TrajectorySeed/interface/PropagationDirection.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -29,9 +30,6 @@ class TrajectoryStateOnSurface;
 class TransientTrackingRecHitBuilder;
 class MultiRecHitCollector;
 class SiTrackerMultiRecHitUpdator;
-namespace reco {
-  class Track;
-}
 
 class DAFTrackProducerAlgorithm : public AlgoProductTraits<reco::Track> {
 public:

--- a/SimDataFormats/TrackingAnalysis/src/classes_def.xml
+++ b/SimDataFormats/TrackingAnalysis/src/classes_def.xml
@@ -24,13 +24,13 @@
   <class name="TrackingParticleRefVector" />
   <class name="edm::Wrapper<TrackingParticleRefVector>"/>
 
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<TrackingParticle> >,edm::RefToBaseProd<reco::Track> >" />
-  <class name="edm::helpers::KeyVal<edm::RefToBaseProd<reco::Track>,edm::RefProd<std::vector<TrackingParticle> > >" />
-  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>,TrackingParticle> >,std::vector<std::pair<edm::RefToBase<reco::Track>,double> > > >" />
-  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::RefToBase<reco::Track>,std::vector<std::pair<edm::Ref<std::vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>,TrackingParticle> >,double> > > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<TrackingParticle> >,edm::RefToBaseProd<reco::io_v1::Track> >" />
+  <class name="edm::helpers::KeyVal<edm::RefToBaseProd<reco::io_v1::Track>,edm::RefProd<std::vector<TrackingParticle> > >" />
+  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>,TrackingParticle> >,std::vector<std::pair<edm::RefToBase<reco::io_v1::Track>,double> > > >" />
+  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::RefToBase<reco::io_v1::Track>,std::vector<std::pair<edm::Ref<std::vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>,TrackingParticle> >,double> > > >" />
 
-  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>,TrackingParticle> >,std::vector<std::pair<edm::RefToBase<reco::Track>,double> > >" />
-  <class name="edm::helpers::KeyVal<edm::RefToBase<reco::Track>,std::vector<std::pair<edm::Ref<std::vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>,TrackingParticle> >,double> > >" />
+  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>,TrackingParticle> >,std::vector<std::pair<edm::RefToBase<reco::io_v1::Track>,double> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefToBase<reco::io_v1::Track>,std::vector<std::pair<edm::Ref<std::vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>,TrackingParticle> >,double> > >" />
 
   <class name="std::vector<std::pair<edm::Ref<std::vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>,TrackingParticle> >,double> >" />
   <class name="std::pair<edm::Ref<std::vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>,TrackingParticle> >,double>" />

--- a/Validation/RecoMuon/src/GlobalMuonMatchAnalyzer.h
+++ b/Validation/RecoMuon/src/GlobalMuonMatchAnalyzer.h
@@ -15,18 +15,12 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-
-#
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
-
-namespace reco {
-  class Track;
-}
 
 class InputTag;
 class TrackAssociatorBase;

--- a/Validation/RecoMuon/src/MuonSeedTrack.h
+++ b/Validation/RecoMuon/src/MuonSeedTrack.h
@@ -26,15 +26,12 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
 #include <DQMServices/Core/interface/DQMEDAnalyzer.h>
-
-namespace reco {
-  class Track;
-}
 
 class MuonServiceProxy;
 class TrajectorySeed;


### PR DESCRIPTION
#### PR description:

- moved classes to io_v1 namespace
- corrected placement of classes in class_def*.xml files
- have friendly class name building ignore the io_vN namespaces for now.


This is based on the plan discussed here:
 https://indico.cern.ch/event/1550918/#7-phase-2-software-days-releas

#### PR validation:

Code compiles. Running the 1.0 workflow worked and showed the classes are being written to the output files.

resolves https://github.com/cms-sw/framework-team/issues/1768