### PR TITLE
Fix hard-scatter vertex ID in HTXSRivetProducer

### DIFF
--- a/GeneratorInterface/RivetInterface/interface/HardScatterIdentification.h
+++ b/GeneratorInterface/RivetInterface/interface/HardScatterIdentification.h
@@ -1,0 +1,69 @@
+#ifndef GeneratorInterface_RivetInterface_HardScatterIdentification_h
+#define GeneratorInterface_RivetInterface_HardScatterIdentification_h
+
+#include "Rivet/Particle.hh"
+#include "Rivet/Tools/ParticleUtils.hh"
+
+namespace HepMC3 {
+  class GenEvent;
+}
+
+namespace Rivet {
+  namespace HTXSUtils {
+
+    inline bool hasChildWithPDG(const ConstGenParticlePtr &ptcl, int pdgID) {
+      if (!ptcl || !ptcl->end_vertex())
+        return false;
+      for (const auto &child : Particle(*ptcl).children()) {
+        if (child.pid() == pdgID)
+          return true;
+      }
+      return false;
+    }
+
+    inline bool hasParentWithPDG(const ConstGenParticlePtr &ptcl, int pdgID) {
+      if (!ptcl)
+        return false;
+      const ConstGenVertexPtr prodVtx = ptcl->production_vertex();
+      if (!prodVtx)
+        return false;
+      for (const auto &parent : HepMCUtils::particles(prodVtx, Relatives::PARENTS)) {
+        if (parent->pdg_id() == pdgID)
+          return true;
+      }
+      return false;
+    }
+
+    struct HardScatterResult {
+      ConstGenVertexPtr vertex = nullptr;
+      ConstGenParticlePtr higgs = nullptr;
+      unsigned int higgsCount = 0;
+    };
+
+    inline HardScatterResult identifyHardScatter(const HepMC3::GenEvent *genEvent) {
+      HardScatterResult result;
+      if (!genEvent)
+        return result;
+
+      for (const ConstGenParticlePtr &ptcl : HepMCUtils::particles(genEvent)) {
+        // a) Reject all non-Higgs particles
+        if (!PID::isHiggs(ptcl->pdg_id()))
+          continue;
+        // b) select only the final Higgs boson copy, prior to decay
+        if (ptcl->end_vertex() && !hasChildWithPDG(ptcl, PID::HIGGS)) {
+          result.higgs = ptcl;
+          ++result.higgsCount;
+        }
+        // c) HepMC3 does not provide signal_process_vertex anymore
+        //    set hard-scatter vertex based on first Hiigs boson
+        if (!result.vertex && ptcl->production_vertex() && !hasParentWithPDG(ptcl, PID::HIGGS))
+          result.vertex = ptcl->production_vertex();
+      }
+
+      return result;
+    }
+
+  }  // namespace HTXSUtils
+}  // namespace Rivet
+
+#endif

--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -17,6 +17,7 @@
 
 #include "Rivet/Particle.hh"
 #include "Rivet/AnalysisHandler.hh"
+#include "GeneratorInterface/RivetInterface/interface/HardScatterIdentification.h"
 #include "GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc"
 #include "SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h"
 
@@ -81,7 +82,16 @@ void HTXSRivetProducer::produce(edm::Event& iEvent, const edm::EventSetup&) {
         unsigned nBs = 0;
         unsigned nHs = 0;
 
-        ConstGenVertexPtr HSvtx = myGenEvent->vertices()[0];
+        const auto hsInfo = HTXSUtils::identifyHardScatter(myGenEvent.get());
+        ConstGenVertexPtr HSvtx = hsInfo.vertex;
+        if (HSvtx)
+          edm::LogInfo("HTXSRivetProducer") << "Found HSvtx, ID: " << HSvtx->id() << endl;
+
+        if (!HSvtx && !myGenEvent->vertices().empty()) {
+          edm::LogWarning("HTXSRivetProducer")
+              << "Unable to identify HS vertex from status/PDG selection, falling back to first vertex." << endl;
+          HSvtx = myGenEvent->vertices()[0];
+        }
 
         if (HSvtx) {
           for (const auto& ptcl : HepMCUtils::particles(HSvtx, Relatives::CHILDREN)) {


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

In certain 2024 MC samples, the HTXS labels for all events are set to `0: UNKNOWN`, see e.g. [`ZH-Hto2G`](https://cms-pdmv-prod.web.cern.ch/mcm/requests?prepid=HIG-RunIII2024Summer24NanoAODv15-00022):

```python
with uproot.open("root://xrootd-cms.infn.it//store/mc/RunIII2024Summer24NanoAODv15/ZH-Hto2G_Par-M-125_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/NANOAODSIM/150X_mcRun3_2024_realistic_v2-v2/2530000/2e868471-3ed9-461f-b633-7034cc80b492.root") as f:
    tree = f["Events"]
    print(tree["HTXS_stage1_2_cat_pTjet30GeV"].array()) # 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ..., 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
```

This stems from changes made to transition from HepMC2 -> HepMC3 for these samples, where `signal_process_vertex()` was removed. Instead, it was assumed that the first vertex in `GenEvent` is the hard-scatter vertex. This is not always the case and causes the Rivet routine to fail. This PR moves the existing (correct) logic from the Rivet routine itself into a utility function that can then be used by the producer. 

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

- Sanity check: Following these changes, a re-nano of the affected Hgg samples contain no `0: UNKNOWN` labels
- Eventwise check: Re-nano of some known good samples (from 2023) with these changes produce the same HTXS labels for each event
- Distribution check: The HTXS distributions for a known good sample (from 2023) and a re-nano 2024 sample with these changes (for the same process) agree within statistical uncertainties.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

- Intended backport: CMSSW_15_X_X
