### PR TITLE
set `relval2025` autoHLT key to `Fake2` [16.0.X]

### DIFF
--- a/Configuration/HLT/python/autoHLT.py
+++ b/Configuration/HLT/python/autoHLT.py
@@ -13,7 +13,7 @@ autoHLT = {
   'relval2022'          : 'Fake2',
   'relval2023'          : 'Fake2',
   'relval2024'          : 'Fake2',
-  'relval2025'          : '2025v13',
+  'relval2025'          : 'Fake2',
   'relval2026'          : 'GRun',
   'relvalHI2022'        : 'Fake2',
   'relvalHI2023'        : 'Fake2',

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2397,7 +2397,7 @@ steps['HLTDR3_2022']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2022,},{'--con
 
 hltKey2023='relval2023' # currently points to Fake2
 hltKey2024='relval2024' # currently points to Fake2
-hltKey2025='relval2025' # currently points to GRUN (hacky solution to keep running GRun on real data)
+hltKey2025='relval2026' # currently points to GRun (hacky solution to keep running GRun on real data)
 
 steps['HLTDR3_2023']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2023,},{'--conditions':'auto:run3_hlt_relval'},{'--era' : 'Run3_2023'},steps['HLTD'] ] )
 

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -3536,7 +3536,7 @@ upgradeProperties[2017] = {
         'HLTmenu': '@relval2025',
         'Era' : 'Run3_2025',
         'BeamSpot': 'DBrealistic',
-        'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],
+        'ScenToRun' : ['GenSim','Digi','RecoNanoFakeHLT','HARVESTNanoFakeHLT','ALCA'],
     },
     '2025HLTOnDigi' : {
         'Geom' : 'DB:Extended',
@@ -3544,7 +3544,7 @@ upgradeProperties[2017] = {
         'HLTmenu': '@relval2025',
         'Era' : 'Run3_2025',
         'BeamSpot': 'DBrealistic',
-        'ScenToRun' : ['GenSim','DigiNoHLT','HLTOnly','RecoNano','HARVESTNano','ALCA'],
+        'ScenToRun' : ['GenSim','DigiNoHLT','HLTOnly','RecoNanoFakeHLT','HARVESTNanoFakeHLT','ALCA'],
     },
     '2025GenOnly' : {
         'Geom' : 'DB:Extended',
@@ -3560,7 +3560,7 @@ upgradeProperties[2017] = {
         'HLTmenu': '@relval2025',
         'Era' : 'Run3_2025',
         'BeamSpot': 'DBrealistic',
-        'ScenToRun' : ['Gen','Sim','Digi','RecoNano','HARVESTNano','ALCA'],
+        'ScenToRun' : ['Gen','Sim','Digi','RecoNanoFakeHLT','HARVESTNanoFakeHLT','ALCA'],
     },
     '2025FS' : {
         'Geom' : 'DB:Extended',


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/49747

#### PR description:

In 16.1.X and 16.0.X we can rely on the 2026 `GRun`-based relvals for validation. 2025 can go back to use `Fake`.

#### PR validation:

see master PR for validation.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/49747 of the 2026 production cycle.
