### PR TITLE
update run to be used for the `scouting_dqm_sourceclient` unit test [16.0.X]

### DIFF
--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -14,7 +14,7 @@
 <test name="TestDQMOnlineClient-hlt_dqm_clientPB" command="runtest.sh hlt_dqm_clientPB-live_cfg.py"/>
 <test name="TestDQMOnlineClient-hlt_dqm_sourceclient" command="runtest.sh hlt_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-ngt_dqm_sourceclient" command="runtest.sh ngt_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-scouting_dqm_sourceclient" command="runtest.sh scouting_dqm_sourceclient-live_cfg.py 392642"/>
+<test name="TestDQMOnlineClient-scouting_dqm_sourceclient" command="runtest.sh scouting_dqm_sourceclient-live_cfg.py 398183"/>
 <test name="TestDQMOnlineClient-info_dqm_sourceclient" command="runtest.sh info_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-l1tstage2_dqm_sourceclient" command="runtest.sh l1tstage2_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-l1tstage2emulator_dqm_sourceclient" command="runtest.sh l1tstage2emulator_dqm_sourceclient-live_cfg.py"/>


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/49746

#### PR description:

Title says it all, necessary for the merge of https://github.com/cms-sw/cmssw/pull/49718.
See https://github.com/cms-sw/cmssw/pull/49715#issuecomment-3722939573 for a rationale.
To be tested together with the companion `cms-data` https://github.com/cms-sw/cmsdist/pull/10272.

#### PR validation:

`scram b runtests_TestDQMOnlineClient-scouting_dqm_sourceclient` runs correctly in conjunction of the update of the unit test input files (see https://github.com/cms-sw/cmsdist/pull/10272)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/49746 to the 2026 data-taking cycle