### PR TITLE
Fix issue in makeHGCalValidationPlots.py

### DIFF
--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -2397,7 +2397,7 @@ lc_zplus_extended = [
   _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_BH_zplus
 ]
 
-def append_hgcalLayerClustersPlots(collection = hgcalValidator.label_layerClustersPlots, name_collection = layerClustersLabel, extended = False):
+def append_hgcalLayerClustersPlots(collection = hgcalValidator.label_layerClustersPlots.value(), name_collection = layerClustersLabel, extended = False):
   print('extended : ',extended)
   regions_ClusterLevel       = ["General: Cluster Level", "Z-minus: Cluster Level", "Z-plus: Cluster Level"]
   regions_CellLevel          = ["Z-minus: Cell Level", "Z-plus: Cell Level"]
@@ -2536,16 +2536,16 @@ sc_ticltracksters = [
 hgcalSimClustersPlotter = Plotter()
 
 def append_hgcalSimClustersPlots(collection, name_collection):
-  if collection == hgcalValidator.label_SimClustersLevel:
+  if collection == hgcalValidator.label_SimClustersLevel.value():
       hgcalSimClustersPlotter.append(collection, [
-                  _hgcalFolders(hgcalValidator.label_SimClusters +"/"+ collection)
+                  _hgcalFolders(hgcalValidator.label_SimClusters.value() +"/"+ collection)
                   ], PlotFolder(
                   *sc_clusterlevel,
                   loopSubFolders=False,
                   purpose=PlotPurpose.Timing, page="SimClusters", section=name_collection))
   else:
       hgcalSimClustersPlotter.append(collection, [
-                  _hgcalFolders(hgcalValidator.label_SimClusters +"/"+collection)
+                  _hgcalFolders(hgcalValidator.label_SimClusters.value() +"/"+collection)
                   ], PlotFolder(
                   *sc_ticltracksters,
                   loopSubFolders=False,

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -2694,17 +2694,19 @@ def append_hgcalCaloParticlesPlots(files, collection = '-211', name_collection =
 
   dqmfolder = hgcVal_dqm + "SelectedCaloParticles/" + collection
   templateFile = ROOT.TFile.Open(files[0]) # assuming all files have same structure
-  if not gDirectory.GetDirectory(dqmfolder):
+  if not templateFile.GetDirectory(dqmfolder):
     print("Error: GeneralInfo directory %s not found in DQM file, exit"%dqmfolder)
     return hgcalTrackstersPlotter
 
-  keys = gDirectory.GetDirectory(dqmfolder,True).GetListOfKeys()
+  keys = templateFile.GetDirectory(dqmfolder,True).GetListOfKeys()
   key = keys[0]
   while key:
     obj = key.ReadObj()
     name = obj.GetName()
     fileName = TString(name)
     fileName.ReplaceAll(" ","_")
+    plotName = TString(name)
+    plotName.ReplaceAll(" ","_")
     pg = PlotGroup(fileName.Data(),[
                   Plot(name,
                        drawCommand = "",
@@ -2746,11 +2748,11 @@ def create_hgcalTrackstersPlotter(files, collection = 'ticlTrackstersMerge', nam
   _common["ymin"] = 0.0
   _common["staty"] = 0.85
   templateFile = ROOT.TFile.Open(files[0]) # assuming all files have same structure
-  if not gDirectory.GetDirectory(dqmfolder):
+  if not templateFile.GetDirectory(dqmfolder):
     print("Error: GeneralInfo directory %s not found in DQM file, exit"%dqmfolder)
     return hgcalTrackstersPlotter
 
-  keys = gDirectory.GetDirectory(dqmfolder,True).GetListOfKeys()
+  keys = templateFile.GetDirectory(dqmfolder,True).GetListOfKeys()
   key = keys[0]
   while key:
     obj = key.ReadObj()

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -2807,54 +2807,6 @@ def create_hgcalTrackstersPlotter(files, collection = 'ticlTrackstersMerge', nam
   return hgcalTrackstersPlotter
 
 #=================================================================================================
-_common_Calo = {"stat": False, "drawStyle": "hist", "staty": 0.65, "ymin": 0.0, "ylog": False, "xtitle": "Default", "ytitle": "Default"}
-
-hgcalCaloParticlesPlotter = Plotter()
-
-def append_hgcalCaloParticlesPlots(files, collection = '-211', name_collection = "pion-"):
-  dqmfolder = hgcVal_dqm + "SelectedCaloParticles/" + collection
-  print(dqmfolder)
-#  _common["ymin"] = 0.0
-  templateFile = ROOT.TFile.Open(files[0]) # assuming all files have same structure
-  keys = gDirectory.GetDirectory(dqmfolder,True).GetListOfKeys()
-  key = keys[0]
-  while key:
-    obj = key.ReadObj()
-    name = obj.GetName()
-    plotName = TString(name)
-    plotName.ReplaceAll(" ","_")
-
-    pg = None
-    if obj.InheritsFrom("TH2"):
-        pg = PlotOnSideGroup(plotName.Data(),
-                      Plot(name,
-                           drawCommand = "COLZ",
-                           normalizeToNumberOfEvents = True, **_common_Calo),
-                      ncols=1)
-    elif obj.InheritsFrom("TH1"):
-        pg = PlotGroup(plotName.Data(),[
-                      Plot(name,
-                           drawCommand = "", # may want to customize for TH2 (colz, etc.)
-                           normalizeToNumberOfEvents = True, **_common_Calo)
-                      ],
-                      ncols=1)
-
-    if (pg is not None):
-        hgcalCaloParticlesPlotter.append("CaloParticles_"+name_collection, [
-                  dqmfolder
-                  ], PlotFolder(
-                    pg,
-                    loopSubFolders=False,
-                    purpose=PlotPurpose.Timing, page="CaloParticles", section=name_collection)
-                  )
-
-    key = keys.After(key)
-
-  templateFile.Close()
-
-  return hgcalCaloParticlesPlotter
-
-#=================================================================================================
 # hitValidation
 def _hgcalHitFolders(dirName="HGCalSimHitsV/HGCalEESensitive"):
     return "DQMData/Run 1/HGCAL/Run summary/"+dirName

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -11,7 +11,7 @@ from Validation.HGCalValidation.HGCalValidator_cff import hgcalValidator
 import Validation.HGCalValidation.hgcalPlots as hgcalPlots
 import Validation.RecoTrack.plotting.plotting as plotting
 
-simClustersIters = [hgcalValidator.label_SimClustersLevel, "ticlSimTracksters"]
+simClustersIters = [hgcalValidator.label_SimClustersLevel.value(), "ticlSimTracksters"]
 
 hitCalLabel = 'hitCalibration'
 hitValLabel = 'hitValidation'
@@ -62,7 +62,7 @@ def main(opts):
     #layerClusters
     def plot_LC():
         hgclayclus = [hgcalPlots.hgcalLayerClustersPlotter]
-        hgcalPlots.append_hgcalLayerClustersPlots(hgcalValidator.label_layerClustersPlots, "Layer Clusters", extendedFlag)
+        hgcalPlots.append_hgcalLayerClustersPlots(hgcalValidator.label_layerClustersPlots.value(), "Layer Clusters", extendedFlag)
         val.doPlots(hgclayclus, plotterDrawArgs=drawArgs)
 
     #simClusters

--- a/Validation/HGCalValidation/test/BuildFile.xml
+++ b/Validation/HGCalValidation/test/BuildFile.xml
@@ -14,3 +14,4 @@
 <flags EDM_PLUGIN="1"/>
 <library file="*.cc" name="testValidationHGCalValidation">
 </library>
+<test name="testMakeHGCalValidationPlots" command="test_makeHGCalValidationPlots.sh"/>

--- a/Validation/HGCalValidation/test/test_makeHGCalValidationPlots.sh
+++ b/Validation/HGCalValidation/test/test_makeHGCalValidationPlots.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+function die { cat 29690*/*.log; echo $1: status $2; exit $2; }
+
+# --command="-s HARVESTING:@HGCalValidation" overwrites the default "-s" to run only HGCAL harvesting
+# 29690.0 is SingleGamma eta1p7to2p7 D110
+runTheMatrix.py -w upgrade -l 29690.0 --startFrom HARVESTING --maxSteps 4 --recycle das:/RelValTTbar_14TeV/CMSSW_15_1_0-150X_mcRun4_realistic_v1_STD_RecycledGS_Run4D110_noPU-v2/DQMIO --command="-s HARVESTING:@HGCalValidation" || die "Could not run HARVESTING" $?
+
+(makeHGCalValidationPlots.py --collection all --jobs 4 --ticlv 4 29690.0*/DQM*.root) || die "makeHGCalValidationPlots.py failed" $?


### PR DESCRIPTION
#### PR description:
The HGCAL validation script was not working anymore (following a bug introduced in #48565). The labels in HGCALValidator were changed from InputTag to string but the python scripts were not updated. 
Also fixed the CaloParticle plots.

#### PR validation
Before : running `makeHGCalValidationPlots.py`  outputs `TypeError: unsupported operand type(s) for +: 'string' and 'str'`. 
With this PR it succeeds
