### PR TITLE
update unit test Miscellanea post integration of #49725

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/defaultInputFiles_cff.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/defaultInputFiles_cff.py
@@ -20,7 +20,7 @@ filesDefaultMC_MinBiasPUPhase2 = cms.untracked.vstring(
     '/store/relval/CMSSW_12_5_3/RelValMinBias_14TeV/ALCARECO/TkAlMinBias-125X_mcRun4_realistic_v5_2026D88PU-v1/2590000/27b7ab93-1d2b-4f4a-a98e-68386c314b5e.root',
 )
 
-filesDefaultMC_DoubleMuonPUPhase_string = '/store/mc/Phase2Fall22DRMiniAOD/DYJetsToMuMu_M-50_TuneCP5_14TeV-madgraphMLM-pythia8/ALCARECO/TkAlZMuMu-PU200ALCA_TkAlPU200_125X_mcRun4_realistic_v5-v1/60000/9382696c-70fd-4b37-8a0f-24bd02aeda5f.root'
+filesDefaultMC_DoubleMuonPUPhase_string = '/store/mc/Phase2Spring24DIGIRECOMiniAOD/DYJetsToMuMu_M-50_TuneCP5_14TeV-madgraphMLM-pythia8/ALCARECO/TkAlZMuMu-noPUALCA_TkAlnoPU_140X_mcRun4_realistic_v6_ext1-v2/110000/1022ba4a-65f7-4409-9069-f35247a7a8e3.root'
 
 filesDefaultMC_MinBiasPUPhase2RECO = cms.untracked.vstring(
     '/store/relval/CMSSW_14_1_0_pre6/RelValMinBias_14TeV/GEN-SIM-RECO/PU_141X_mcRun4_realistic_v1_STD_2026D110_PU-v3/2560000/c22f1cbd-50e3-458e-aba9-b0a327e4c971.root'

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitMiscellanea.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitMiscellanea.sh
@@ -5,7 +5,7 @@ echo "TESTING inspect ALCARECO data ..."
 cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/inspectData_cfg.py unitTest=True isCosmics=True trackCollection=ALCARECOTkAlCosmicsCTF0T || die "Failure running inspectData_cfg.py" $?
 
 echo "TESTING inspect Phase2 ALCARECO data ..."
-cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/inspectData_cfg.py unitTest=True isCosmics=False globalTag='' trackCollection=ALCARECOTkAlZMuMu isDiMuonData=True Detector='Run4D98' || die "Failure running inspectData_cfg.py on Phase-2 input" $?
+cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/inspectData_cfg.py unitTest=True isCosmics=False globalTag='' trackCollection=ALCARECOTkAlZMuMu isDiMuonData=True Detector='Run4D110' || die "Failure running inspectData_cfg.py on Phase-2 input" $?
 
 echo "TESTING G4e refitter ..."
 cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/testG4Refitter_cfg.py maxEvents=10  || die "Failure running testG4Refitter_cfg.py" $?


### PR DESCRIPTION
#### PR description:

In partial reply to https://github.com/cms-sw/cmssw/issues/49772. Update inputs for unit test `Miscellanea` of `Alignment/OfflineValidation` using [the last library of phase-2 `TkAlZMuMu` ALCARECO files](https://cmsweb.cern.ch/das/request?view=list&input=%2FDYJetsToMuMu_M-50_TuneCP5_14TeV-madgraphMLM-pythia8%2FPhase2Spring24DIGIRECOMiniAOD-TkAlZMuMu-noPUALCA_TkAlnoPU_140X_mcRun4_realistic_v6_ext1-v2%2FALCARECO) (from geometry `D110`, Tracker `T35`, which was spared at #49725).

#### PR validation:

`scram b runtests_Miscellanea` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A