### PR TITLE
fix unit test `createTestDBObjects` after integration of #49725

### DIFF
--- a/CondTools/SiPixel/test/SiPixelLorentzAngleDBLoader_Phase2_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelLorentzAngleDBLoader_Phase2_cfg.py
@@ -70,6 +70,14 @@ elif tGeometry == 'T33':
     has3DinL1 = True
     LA_value = 0.0503
     tag = 'SiPixelLorentzAngle_Phase2_T33_v1'
+
+elif tGeometry == 'T35':
+    geometry_cff = 'GeometryExtendedRun4D110_cff'
+    recoGeometry_cff = 'GeometryExtendedRun4D110Reco_cff'
+    has3DinL1 = True
+    LA_value = 0.0503
+    tag = 'SiPixelLorentzAngle_Phase2_T35_v1'
+
 else:
     print("Unknown tracker geometry")
     print("What are you doing ?!?!?!?!")
@@ -83,13 +91,19 @@ sqlite_file = 'sqlite_file:' + tag + '.db'
 geometry_cff = 'Configuration.Geometry.' + geometry_cff
 recoGeometry_cff = 'Configuration.Geometry.' + recoGeometry_cff
 
-
 process.load(recoGeometry_cff)
 process.load(geometry_cff)
 
+# trick to get the T33 GT instead
+geomSwap = {
+    "T35": "T33",
+}
+
+effectiveGeometry = geomSwap.get(tGeometry, tGeometry)
+
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_'+tGeometry, '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_'+effectiveGeometry, '')
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 

--- a/CondTools/SiPixel/test/createTestDBObjects.sh
+++ b/CondTools/SiPixel/test/createTestDBObjects.sh
@@ -23,7 +23,7 @@ echo -e "TESTING Pixel Template DB Object Reader ... \n\n"
 cmsRun  ${SCRAM_TEST_PATH}/SiPixelTemplateDBObjectReader_cfg.py MagField=3.8 readFromGT=True || die "Failure running SiPixelTemplateDBObjectReader_cfg.py MagField=3.8 readFromGT=True" $?
 
 echo -e "TESTING Pixel LorentzAngle DB for Phase-2 ... \n\n"
-cmsRun  ${SCRAM_TEST_PATH}/SiPixelLorentzAngleDBLoader_Phase2_cfg.py geometry=T33 || die "Failure running SiPixelLorentzAngleDBLoader_Phase2_cfg.py geometry=T33" $?
+cmsRun  ${SCRAM_TEST_PATH}/SiPixelLorentzAngleDBLoader_Phase2_cfg.py geometry=T35 || die "Failure running SiPixelLorentzAngleDBLoader_Phase2_cfg.py geometry=T35" $?
 
 echo -e "TESTING SiPixelVCal DB codes ... \n\n"
 


### PR DESCRIPTION
fixes https://github.com/cms-sw/cmssw/issues/49772

#### PR description:

Title says it all.

#### PR validation:

`scram b runtests_createDBObjects` runs fine

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A