### PR TITLE
[16.0.X] bug-fix: use `hltOnlineBeamSpot` in `hltWithPixelTracks` and `hltPixelLessTracks`

### DIFF
--- a/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
+++ b/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
@@ -20,6 +20,7 @@ hltTrackValidator = hltMultiTrackValidator.clone(
 hltPixelLessTracks = _cutsRecoTracks.clone(
     throwOnMissing = cms.bool(False), # HLT collection might be missing
     src = "hltMergedTracks",
+    beamSpot = "hltOnlineBeamSpot",
     minLayer = 3,
     maxPixelHit = 0
 )
@@ -28,6 +29,7 @@ hltPixelLessTracks = _cutsRecoTracks.clone(
 hltWithPixelTracks = _cutsRecoTracks.clone(
     throwOnMissing = cms.bool(False), # HLT collection might be missing
     src = "hltMergedTracks",
+    beamSpot = "hltOnlineBeamSpot",
     minLayer = 3,
     minPixelHit = 1
 )

--- a/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
+++ b/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
@@ -40,8 +40,6 @@ hltMultiTrackValidationTask = cms.Task(
     , hltTrackAssociatorByHits
 )
 hltMultiTrackValidation = cms.Sequence(
-    hltPixelLessTracks+
-    hltWithPixelTracks+
     hltTrackValidator,
     hltMultiTrackValidationTask
 )
@@ -59,6 +57,17 @@ from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(hltTrackValidator, _modifyForPhase2)
 phase2_tracker.toModify(hltPixelLessTracks, src = "hltGeneralTracks")
 phase2_tracker.toModify(hltWithPixelTracks, src = "hltGeneralTracks")
+
+## for Phase 2 only (no pixelless tracks in Run3) run the track selectors
+phase2_tracker.toReplaceWith(
+    hltMultiTrackValidation,
+    cms.Sequence(
+        hltPixelLessTracks +
+        hltWithPixelTracks +
+        hltTrackValidator,
+        hltMultiTrackValidationTask
+    )
+)
 
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 from Configuration.ProcessModifiers.ngtScouting_cff import ngtScouting


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/49777

#### PR description:

This is a follow-up to https://github.com/cms-sw/cmssw/pull/49517. 
Title says it all. Use proper online HLT beamspot for selection.

#### PR validation:

Run the following test script from @pietroGru:

```bash
#!/bin/bash -ex

hltGetConfiguration /dev/CMSSW_16_0_0/GRun --cff --data --type GRun --paths MC_ReducedIterativeTracking_v* > HLTrigger/Configuration/python/HLT_TrackingOnly_cff.py

cmsDriver.py baseline --no_exec --nThreads 1 -n 10 --mc --datatier DQMIO --eventcontent DQM --step HLT:TrackingOnly,VALIDATION:hltMultiTrackValidation --process reHLT --era Run3_2025 --geometry DB:Extende
d --conditions 150X_mcRun3_2025_realistic_2024_EOY_old_conditions_no_morph --filein /store/relval/CMSSW_15_0_10_patch2/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_150X_mcRun3_2025_realistic_2024_EOY_old_conditi
ons_no_morph_RV280_PU-v1/2590000/20f031ae-d1fc-4019-9b61-716a21d0e532.root --fileout file:DQMIO_baseline.root

cmsRun baseline_HLT_VALIDATION.py >& baseline_HLT_VALIDATION.log
```

Also tested via `runTheMatrix.py -l 34434.755 -t 4 -j 8 --nEvents 100`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/49777 to the 2026 data-taking release.
