### PR TITLE
Use string_view to fix constexpr std::string comp error in UBSAN_X IBs

### DIFF
--- a/BigProducts/Simulation/BuildFile.xml
+++ b/BigProducts/Simulation/BuildFile.xml
@@ -1,5 +1,3 @@
-<use name="Geometry/HcalTowerAlgo"/>
-<use name="CondFormats/HcalObjects"/>
 <use name="SimG4CMS/Calo"/>
 <use name="SimG4CMS/CherenkovAnalysis"/>
 <use name="SimG4CMS/EcalTestBeam"/>

--- a/BigProducts/Simulation/BuildFile.xml
+++ b/BigProducts/Simulation/BuildFile.xml
@@ -1,3 +1,5 @@
+<use name="Geometry/HcalTowerAlgo"/>
+<use name="CondFormats/HcalObjects"/>
 <use name="SimG4CMS/Calo"/>
 <use name="SimG4CMS/CherenkovAnalysis"/>
 <use name="SimG4CMS/EcalTestBeam"/>

--- a/Geometry/HGCalCommonData/interface/HGCalTypes.h
+++ b/Geometry/HGCalCommonData/interface/HGCalTypes.h
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <cstdint>
 #include <string>
+#include <string_view>
 #include <vector>
 
 class HGCalTypes {
@@ -140,9 +141,9 @@ public:
   // LD vs HD and Fullvs Partial wafer
   static constexpr bool waferHD(int32_t type) { return ((type == WaferHD120) || (type == WaferHD200)); }
   static constexpr bool waferFull(int32_t type) { return (type == WaferFull); }
-  static std::string layerTypeX(int32_t type);
-  static std::string waferType(int32_t type);
-  static std::string waferTypeX(int32_t type);
+  static std::string_view layerTypeX(int32_t type);
+  static std::string_view waferType(int32_t type);
+  static std::string_view waferTypeX(int32_t type);
 
 private:
   static constexpr int32_t facu_ = 1;
@@ -156,6 +157,20 @@ private:
   static constexpr int32_t faccell_ = 100;
   static constexpr int32_t faccelltype_ = 10000;
   static constexpr int32_t faccell6_ = 1000;
+  static constexpr int32_t layerType_[7] = {HGCalTypes::WaferCenter,
+                                            HGCalTypes::WaferCenterB,
+                                            HGCalTypes::WaferCenterR,
+                                            HGCalTypes::CornerCenterYp,
+                                            HGCalTypes::CornerCenterYm,
+                                            HGCalTypes::CornerCenterXp,
+                                            HGCalTypes::CornerCenterXm};
+  static constexpr std::string_view layerTypes_[7] = {
+      "Center", "CenterB", "CenterYp", "CenterYm", "CenterR", "CenterXp", "CenterXm"};
+  static constexpr std::string_view waferType_[4] = {"HD120", "LD200", "LD300", "HD200"};
+  static constexpr std::string_view waferTypeX_[27] = {
+      "Full",      "Five",      "ChopTwo",   "ChopTwoM", "Half",     "Semi",    "Semi2",   "Three",   "Half2",
+      "Five2",     "Unknown10", "LDTop",     "LDBottom", "LDLeft",   "LDRight", "LDFive",  "LDThree", "Unknown17",
+      "Unknown18", "Unknown19", "Unknown20", "HDTop",    "HDBottom", "HDLeft",  "HDRight", "HDFive",  "Out"};
 };
 
 #endif

--- a/Geometry/HGCalCommonData/src/HGCalTypes.cc
+++ b/Geometry/HGCalCommonData/src/HGCalTypes.cc
@@ -50,21 +50,12 @@ int32_t HGCalTypes::layerType(int type) {
   return ((type >= 0) && (type < 7)) ? layerTypeX[type] : HGCalTypes::WaferCenter;
 }
 
-std::string HGCalTypes::layerTypeX(int32_t type) {
-  static const std::string layerTypes[7] = {
-      "Center", "CenterB", "CenterYp", "CenterYm", "CenterR", "CenterXp", "CenterXm"};
-  return layerTypes[layerType(type)];
+std::string_view HGCalTypes::layerTypeX(int32_t type) { return layerTypes_[HGCalTypes::layerType(type)]; }
+
+std::string_view HGCalTypes::waferType(int32_t type) {
+  return (((type >= 0) && (type < 4)) ? HGCalTypes::waferType_[type] : "Undefined");
 }
 
-std::string HGCalTypes::waferType(int32_t type) {
-  static const std::string waferType[4] = {"HD120", "LD200", "LD300", "HD200"};
-  return (((type >= 0) && (type < 4)) ? waferType[type] : "Undefined");
-}
-
-std::string HGCalTypes::waferTypeX(int32_t type) {
-  static const std::string waferTypeX[27] = {
-      "Full",      "Five",      "ChopTwo",   "ChopTwoM", "Half",     "Semi",    "Semi2",   "Three",   "Half2",
-      "Five2",     "Unknown10", "LDTop",     "LDBottom", "LDLeft",   "LDRight", "LDFive",  "LDThree", "Unknown17",
-      "Unknown18", "Unknown19", "Unknown20", "HDTop",    "HDBottom", "HDLeft",  "HDRight", "HDFive",  "Out"};
-  return (((type >= 0) && (type < 27)) ? waferTypeX[type] : "UnknownXX");
+std::string_view HGCalTypes::waferTypeX(int32_t type) {
+  return (((type >= 0) && (type < 27)) ? HGCalTypes::waferTypeX_[type] : "UnknownXX");
 }


### PR DESCRIPTION
#### PR description:

- Converted static constexpr arrays (layerTypes_, waferType_, waferTypeX_) to use std::string_view

Refer: https://github.com/cms-sw/cmssw/pull/49763#issuecomment-3743025104