### PR TITLE
[NGT] Extend `TrackingAssocValueMapsProducer` to support Muon collections and associators

### DIFF
--- a/HLTrigger/NGTScouting/python/hltTracks_cfi.py
+++ b/HLTrigger/NGTScouting/python/hltTracks_cfi.py
@@ -27,6 +27,7 @@ pixelTrackAssoc = trackingAssocValueMapsProducer.clone(
     trackingParticles = cms.InputTag("mix", "MergedTrackTruth"),
     tpSelectorPSet = tpSelectorPixelTracks,
     storeTPKinematics = cms.bool(True),
+    useMuonAssociators = cms.bool(False)
 )
 
 from Configuration.ProcessModifiers.phase2CAExtension_cff import phase2CAExtension


### PR DESCRIPTION
#### PR description:
This PR extends the `TrackingAssocValueMapsProducer` to optionally consume pre-computed association maps (`reco::RecoToSimCollection` and `reco::SimToRecoCollection`) instead of always running the `TrackToTrackingParticleAssociator` internally.

A new boolean parameter `useMuonAssociators` has been added:
- When `False` (default): The producer preserves the original behavior: it consumes a `TrackToTrackingParticleAssociator` and a `TrackingParticle` collection, filters the TPs using the `tpSelectorPSet`, and computes the associations on the fly (as is commonly done by Tracking associators).
- When `True`: The producer consumes existing `reco::RecoToSimCollection` and `reco::SimToRecoCollection` products directly. This mode bypasses the internal `TrackingParticleSelector` logic as the associations maps are consumed directly (as is commonly done and required by Muon associators)

**Changes:**
- Updated `PhysicsTools/NanoAOD/plugins/TrackingAssocValueMapsProducer.cc` to handle the different interfaces required by different associators
- Updated `HLTrigger/NGTScouting/python/hltTracks_cfi.py` to include the new parameter `useMuonAssociators` as an example. 

#### PR validation:
- Verified that the code compiles.
- Verified that the default behavior (`useMuonAssociators=False`) remains unchanged, ensuring no regressions for existing workflows using this producer (in particular, the `NANO:@Phase2HLTPixelOnly` specifier behaves as expected).
- Tested muon associators locally (no specific configuration added at this time)