### PR TITLE
Simulation: prevent exception if trackId larger than 200M

### DIFF
--- a/SimG4CMS/Forward/src/MtdSD.cc
+++ b/SimG4CMS/Forward/src/MtdSD.cc
@@ -111,6 +111,10 @@ int MtdSD::getTrackID(const G4Track* aTrack) {
     if (!trkInfo->storeTrack()) {
       theID = trkInfo->idLastStoredAncestor();
     }
+    if (theID >= static_cast<int>(PSimHit::k_tidOffset)) {
+      edm::LogError("MtdSim") << " SimTrack ID " << theID << " exceeds maximum allowed by PSimHit identifier"
+                              << PSimHit::k_tidOffset << " unreliable MTD hit type";
+    }
     if (rname == "FastTimerRegionSensBTL") {
       if (trkInfo->isInTrkFromBackscattering()) {
         theID = PSimHit::addTrackIdOffset(theID, k_idFromCaloOffset);

--- a/SimG4Core/Notification/src/SimTrackManager.cc
+++ b/SimG4Core/Notification/src/SimTrackManager.cc
@@ -176,7 +176,7 @@ void SimTrackManager::reallyStoreTracks() {
     }
 
     if (id >= static_cast<int>(PSimHit::k_tidOffset)) {
-      throw cms::Exception("SimTrackManager::reallyStoreTracks")
+      edm::LogWarning("SimTrackManager::reallyStoreTracks")
           << " SimTrack ID " << id << " exceeds maximum allowed by PSimHit identifier" << PSimHit::k_tidOffset;
     }
     TmpSimTrack* g4simtrack =


### PR DESCRIPTION
#### PR description:

This PR effectively addresses https://github.com/cms-sw/cmssw/issues/49732 by removing the exception if the ```trackId``` of a stored ```SimTrack``` exceeds ```PSimHit::k_tidOffset```, currently 200M, replacing it with a ```LogWarning```. As this is affecting the classification of hits, at present adopted only by MTD for Phase2 simulation, a ```LogError``` is added in ```MtdSD``` for hits associated to tracks with such an id.

This is not meant to be a long-term solution, but a fast workaround to allow the production blocked by this issue. This is the first problem reported in 2.5 years during which this mechanism has been in place. Alternative long term solutions can be discussed with more calm after this patch is back-ported to releases used in production.

#### PR validation:

Code compiles and runs (wf. 34434.0).