### PR TITLE
Units tests for Jet and MET validation.

### DIFF
--- a/Validation/RecoJets/test/BuildFile.xml
+++ b/Validation/RecoJets/test/BuildFile.xml
@@ -1,0 +1,1 @@
+<test name="testMakeJetValidationPlots" command="test_makeJetValidationPlots.sh"/>

--- a/Validation/RecoJets/test/test_makeJetValidationPlots.sh
+++ b/Validation/RecoJets/test/test_makeJetValidationPlots.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+function die { echo $1: status $2; exit $2; }
+LOCAL_TEST_DIR="$PWD"
+REMOTE="/store/group/phys_jetmet/cmssw_unittests/"
+REDIRECTOR="root://eoscms.cern.ch/" # root://cms-xrd-global.cern.ch
+DQMFILE="DQM_RelValQCD_FlatPt_15_3000HS_14_CMSSW_16_0_0_pre4.root"
+OUTDIR="."
+SCRIPT="makeJetValidationPlots.py"
+
+COMMMAND=`xrdfs ${REDIRECTOR} locate ${REMOTE}${DQMFILE}`
+STATUS=$?
+echo "xrdfs command status = "$STATUS
+
+if [ $STATUS -eq 0 ]; then
+    printf "Using file ${DQMFILE}.\nRunning in ${LOCAL_TEST_DIR}.\n"
+    xrdcp ${REDIRECTOR}/${REMOTE}${DQMFILE} .
+    (${SCRIPT} --file ./${DQMFILE} --odir ./${OUTDIR} --jet hltAK4PFPuppiJets) || die 'failed running ${SCRIPT} ${DQMFILE}' $?
+    rm -fr ./${DQMFILE}
+else 
+	die "SKIPPING test, file ${DQMFILE} not found" 0
+fi

--- a/Validation/RecoJets/test/test_makeJetValidationPlots.sh
+++ b/Validation/RecoJets/test/test_makeJetValidationPlots.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 function die { echo $1: status $2; exit $2; }
-LOCAL_TEST_DIR="$PWD"
+LOCAL_TEST_DIR="${LOCAL_TEST_DIR:-${PWD}}"
 REMOTE="/store/group/phys_jetmet/cmssw_unittests/"
 REDIRECTOR="root://eoscms.cern.ch/" # root://cms-xrd-global.cern.ch
 DQMFILE="DQM_RelValQCD_FlatPt_15_3000HS_14_CMSSW_16_0_0_pre4.root"

--- a/Validation/RecoMET/test/BuildFile.xml
+++ b/Validation/RecoMET/test/BuildFile.xml
@@ -1,0 +1,1 @@
+<test name="testMakeHLTMETValidationPlots" command="test_makeHLTMETValidationPlots.sh"/>

--- a/Validation/RecoMET/test/test_makeHLTMETValidationPlots.sh
+++ b/Validation/RecoMET/test/test_makeHLTMETValidationPlots.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+function die { echo $1: status $2; exit $2; }
+LOCAL_TEST_DIR="$PWD"
+REMOTE="/store/group/phys_jetmet/cmssw_unittests/"
+REDIRECTOR="root://eoscms.cern.ch/" # root://cms-xrd-global.cern.ch
+DQMFILE="DQM_RelValQCD_FlatPt_15_3000HS_14_CMSSW_16_0_0_pre4.root"
+OUTDIR="."
+SCRIPT="makeHLTMETValidationPlots.py"
+
+COMMMAND=`xrdfs ${REDIRECTOR} locate ${REMOTE}${DQMFILE}`
+STATUS=$?
+echo "xrdfs command status = "$STATUS
+
+if [ $STATUS -eq 0 ]; then
+    printf "Using file ${DQMFILE}.\nRunning in ${LOCAL_TEST_DIR}.\n"
+    xrdcp ${REDIRECTOR}/${REMOTE}${DQMFILE} .
+    (${SCRIPT} --file ./${DQMFILE} --odir ./${OUTDIR} --met hltPFPuppiMETTypeOne) || die 'failed running ${SCRIPT} ${DQMFILE}' $?
+    rm -fr ./${DQMFILE}
+else 
+	die "SKIPPING test, file ${DQMFILE} not found" 0
+fi

--- a/Validation/RecoMET/test/test_makeHLTMETValidationPlots.sh
+++ b/Validation/RecoMET/test/test_makeHLTMETValidationPlots.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 function die { echo $1: status $2; exit $2; }
-LOCAL_TEST_DIR="$PWD"
+LOCAL_TEST_DIR="${LOCAL_TEST_DIR:-${PWD}}"
 REMOTE="/store/group/phys_jetmet/cmssw_unittests/"
 REDIRECTOR="root://eoscms.cern.ch/" # root://cms-xrd-global.cern.ch
 DQMFILE="DQM_RelValQCD_FlatPt_15_3000HS_14_CMSSW_16_0_0_pre4.root"


### PR DESCRIPTION
#### PR description:

This PR adds unit tests for the Jet and MET validation scripts. It stems from the issue found in https://github.com/cms-sw/cmssw/pull/49775.
The scripts run on a DQM QCD RelVal file which was added to the `/store/group/phys_jetmet/cmssw_unittests` folder, and was produced with:

```bash
#!/usr/bin/env bash

GEOMETRY="ExtendedRun4D110"
CONDITIONS="auto:phase2_realistic_T33"
VALIDSEQ="@hltValidation"
ERA="Phase2C17I13M9"
RELVAL="/eos/cms/store/relval/CMSSW_16_0_0_pre4/RelValQCD_FlatPt_15_3000HS_14/GEN-SIM-DIGI-RAW/PU_150X_mcRun4_realistic_v1_STD_Run4D110_PU-v2/2580000/ffd716a4-ebc9-4f88-8534-b62a75aeaa9f.root"
NEVENTS=100

function mystep2() {
    cmsDriver.py step2 --step L1P2GT,HLT:@relvalRun4,VALIDATION:"${VALIDSEQ}" \
		 --conditions ${CONDITIONS} \
		 --datatier GEN-SIM-DIGI-RAW,DQMIO \
		 -n ${NEVENTS} \
		 --procModifier ticl_v5 \
		 --eventcontent FEVTDEBUGHLT,DQMIO \
		 --geometry ${GEOMETRY} \
		 --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
		 --era ${ERA} \
		 --filein file:${RELVAL} \
		 --fileout file:step2.root \
		 --nThreads 0 \
		 --process HLTX \
		 --inputCommands='keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT'
}

function mystep3() {
    cmsDriver.py step3 -s HARVESTING:"${VALIDSEQ}" \
		 --conditions "${CONDITIONS}" \
		 --mc \
		 --geometry "${GEOMETRY}" \
		 --scenario pp \
		 --filetype DQM \
		 --era "${ERA}" \
		 --procModifier ticl_v5 \
		 -n ${NEVENTS} \
		 --filein file:step2_inDQM.root \
		 --fileout file:step3.root
}

mystep2 && mystep3
```

The unit test scripts were inspired by [this unit test](https://github.com/cms-sw/cmssw/blob/283f511ce2e67fcdf6ef538db7db55be204d409a/Validation/RecoTrack/test/test_makeTrackValidationPlots.sh).

#### PR validation:

The validation scripts were manually tested on the produced DQM file, and then `scram b runtests` was successfully tested as follows:

```shell
bfontana@nv:/cms-hlt-nfs/user/bfontana/UnitTests/src  (feature/unit_tests) $ ll
total 0MB
drwxr-xr-x. 4 bfontana zh 1MB Jan 14 11:40 Validation/
bfontana@nv:/cms-hlt-nfs/user/bfontana/UnitTests/src  (feature/unit_tests) $ ll Validation/
total 0MB
drwxr-xr-x. 6 bfontana zh 1MB Jan 13 15:27 RecoJets/
drwxr-xr-x. 6 bfontana zh 1MB Jan 14 11:40 RecoMET/
bfontana@nv:/cms-hlt-nfs/user/bfontana/UnitTests/src  (feature/unit_tests) $ scram b runtests
>> Local Products Rules ..... started
>> Local Products Rules ..... done
>> Creating project symlinks
Creating test log file logs/el9_amd64_gcc13/testing.log
Pass   25s ... Validation/RecoJets/testMakeJetValidationPlots
Pass   14s ... Validation/RecoMET/testMakeHLTMETValidationPlots
>> Test sequence completed for CMSSW CMSSW_16_0_0_pre4
bfontana@nv:/cms-hlt-nfs/user/bfontana/UnitTests/src  (feature/unit_tests) $ ll ../unit_tests/
total 1MB
drwxr-xr-x. 2 bfontana zh 1MB Jan 14 12:06 testMakeJetValidationPlots/
-rw-r--r--. 1 bfontana zh 1MB Jan 14 12:06 testMakeJetValidationPlots.log
drwxr-xr-x. 4 bfontana zh 1MB Jan 14 12:06 testMakeHLTMETValidationPlots/
-rw-r--r--. 1 bfontana zh 1MB Jan 14 12:06 testMakeHLTMETValidationPlots.log
bfontana@nv:/cms-hlt-nfs/user/bfontana/UnitTests/src  (feature/unit_tests) $ ll ../unit_tests/testMakeJetValidationPlots
total 8MB
-rw-r--r--. 1 bfontana zh 1MB Jan 14 12:05 JetPt.png
-rw-r--r--. 1 bfontana zh 1MB Jan 14 12:05 JetPt.pdf
-rw-r--r--. 1 bfontana zh 1MB Jan 14 12:05 CorrJetPt.png
-rw-r--r--. 1 bfontana zh 1MB Jan 14 12:05 CorrJetPt.pdf
-rw-r--r--. 1 bfontana zh 1MB Jan 14 12:05 GenPt.png
-rw-r--r--. 1 bfontana zh 1MB Jan 14 12:05 GenPt.pdf
...
bfontana@nv:/cms-hlt-nfs/user/bfontana/UnitTests/src  (feature/unit_tests) $ head -n5 ../unit_tests/testMakeJetValidationPlots.log 
 
===== Test "testMakeJetValidationPlots" ====
xrdfs command status = 0
Using file DQM_RelValQCD_FlatPt_15_3000HS_14_CMSSW_16_0_0_pre4.root.
Running in /cms-hlt-nfs/user/bfontana/UnitTests/unit_tests/testMakeJetValidationPlots.
```
