### PR TITLE
[ROOT639] TF1 changes required to build root639

### DIFF
--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -669,12 +669,14 @@ SiPixelLAHarvest::fitResults SiPixelLorentzAnglePCLHarvester::fitAndStore(
   if (doChebyshevFit_) {
     const int npar = order_ + 1;
     auto cheb = std::make_unique<siPixelLACalibration::Chebyshev>(order_, theFitRange_.first, theFitRange_.second);
-    f1_ = std::make_unique<TF1>("f1", cheb.release(), theFitRange_.first, theFitRange_.second, npar);
+    f1_ = std::make_unique<TF1>(
+        "f1", cheb.release(), theFitRange_.first, theFitRange_.second, npar, 1, TF1::EAddToList::kNo);
   } else {
     f1_ = std::make_unique<TF1>("f1",
                                 "[0] + [1]*x + [2]*x*x + [3]*x*x*x + [4]*x*x*x*x + [5]*x*x*x*x*x",
                                 theFitRange_.first,
-                                theFitRange_.second);
+                                theFitRange_.second,
+                                TF1::EAddToList::kNo);
   }
 
   // DO NOT REMOVE

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -669,7 +669,7 @@ SiPixelLAHarvest::fitResults SiPixelLorentzAnglePCLHarvester::fitAndStore(
   if (doChebyshevFit_) {
     const int npar = order_ + 1;
     auto cheb = std::make_unique<siPixelLACalibration::Chebyshev>(order_, theFitRange_.first, theFitRange_.second);
-    f1_ = std::make_unique<TF1>("f1", cheb.release(), theFitRange_.first, theFitRange_.second, npar, "Chebyshev");
+    f1_ = std::make_unique<TF1>("f1", cheb.release(), theFitRange_.first, theFitRange_.second, npar);
   } else {
     f1_ = std::make_unique<TF1>("f1",
                                 "[0] + [1]*x + [2]*x*x + [3]*x*x*x + [4]*x*x*x*x + [5]*x*x*x*x*x",

--- a/SimG4CMS/Calo/src/EvolutionECAL.cc
+++ b/SimG4CMS/Calo/src/EvolutionECAL.cc
@@ -228,12 +228,8 @@ double EvolutionECAL::InducedAbsorptionEM(double lumi, double eta) {
   double mu_max = 2.0;
   double alpha1 = 3.41488e+00;
 
-  std::unique_ptr<TF1> ftmp1 = std::make_unique<TF1>("ftmp1",
-                                                     this,
-                                                     &EvolutionECAL::EquilibriumFractionColorCentersEM,
-                                                     0.0,
-                                                     22.0,
-                                                     3);
+  std::unique_ptr<TF1> ftmp1 = std::make_unique<TF1>(
+      "ftmp1", this, &EvolutionECAL::EquilibriumFractionColorCentersEM, 0.0, 22.0, 3, 1, TF1::EAddToList::kNo);
   ftmp1->SetParameters(lumi, eta, alpha1);
   double muEM = mu_max * ftmp1->Integral(0.0, 22.0) / 22.0;
 

--- a/SimG4CMS/Calo/src/EvolutionECAL.cc
+++ b/SimG4CMS/Calo/src/EvolutionECAL.cc
@@ -233,9 +233,7 @@ double EvolutionECAL::InducedAbsorptionEM(double lumi, double eta) {
                                                      &EvolutionECAL::EquilibriumFractionColorCentersEM,
                                                      0.0,
                                                      22.0,
-                                                     3,
-                                                     "EvolutionECAL",
-                                                     "EquilibriumFractionColorCentersEM");
+                                                     3);
   ftmp1->SetParameters(lumi, eta, alpha1);
   double muEM = mu_max * ftmp1->Integral(0.0, 22.0) / 22.0;
 


### PR DESCRIPTION
#### PR description:
Changes needed as the constructor of TF1 was modified in ROOT639.
[Remove CINT compatibility constructors from TF1, THF2, and TF3](https://github.com/root-project/root/commit/bec6eb3ce50f160e60f271b8721ba570fe9e80a3)
