### PR TITLE
update phase-2 HLT timing script and use `alpaka` modifier in NGT workflows

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2121,7 +2121,7 @@ upgradeWFs['NGTScoutingWithNano'].offset = 0.772
 upgradeWFs['NGTScoutingWithNano'].step2 = {
     '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:NGTScouting,NANO:@NGTScouting',
     '--datatier':'NANOAODSIM',
-    '--procModifiers': 'ngtScouting',
+    '--procModifiers': 'alpaka,ngtScouting',
     '--eventcontent':'NANOAODSIM'
 }
 
@@ -2131,7 +2131,7 @@ upgradeWFs['NGTScoutingWithNanoValid'].offset = 0.773
 upgradeWFs['NGTScoutingWithNanoValid'].step2 = {
     '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:NGTScouting,VALIDATION:@hltValidation,NANO:@NGTScoutingVal',
     '--datatier':'NANOAODSIM',
-    '--procModifiers': 'ngtScouting',
+    '--procModifiers': 'alpaka,ngtScouting',
     '--eventcontent':'NANOAODSIM'
 }
 
@@ -2195,12 +2195,12 @@ upgradeWFs['NGTScouting'] = UpgradeWorkflow_NGTScouting(
 )
 upgradeWFs['NGTScouting'].step2 = {
     '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:NGTScouting,VALIDATION:@hltValidation',
-    '--procModifiers': 'ngtScouting',
+    '--procModifiers': 'alpaka,ngtScouting',
     '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
     '--eventcontent':'FEVTDEBUGHLT,DQMIO'
 }
 upgradeWFs['NGTScouting'].step3 = {
-    '--procModifiers': 'ngtScouting',
+    '--procModifiers': 'alpaka,ngtScouting',
     '-s':'HARVESTING:@hltValidation'
 }
 
@@ -2223,7 +2223,7 @@ upgradeWFs['NGTScoutingCAExtensionMergeT5'].suffix = '_NGTScoutingCAExtensionMer
 upgradeWFs['NGTScoutingCAExtensionMergeT5'].offset = 0.775
 upgradeWFs['NGTScoutingCAExtensionMergeT5'].step2 = {
     '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing,VALIDATION:@hltValidation',
-    '--procModifiers': 'ngtScouting,trackingLST',
+    '--procModifiers': 'alpaka,ngtScouting,trackingLST',
     '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
     '--eventcontent':'FEVTDEBUGHLT,DQMIO'
 }

--- a/HLTrigger/Configuration/python/HLT_75e33/test/runHLTTiming.sh
+++ b/HLTrigger/Configuration/python/HLT_75e33/test/runHLTTiming.sh
@@ -373,7 +373,7 @@ run_ngt_scouting() {
 	"L1P2GT,HLT:NGTScouting" \
 	"NLTX" \
 	"NGTScouting_L1P2GT_HLT.py" \
-	"--procModifiers ngtScouting"
+	"--procModifiers alpaka,ngtScouting"
 
     run_benchmark \
 	"NGTScouting_L1P2GT_HLT.py" \


### PR DESCRIPTION
#### PR description:

Following the discussion had at the NGT meeting of [Jan 13 2025](https://indico.cern.ch/event/1631854/#sc-1-1-task-311) this PR implements:
- use **explicitly** the `alpaka` process modifier in all the NGT scouting related workflows offload part of the HGCal reconstruction to GPUs 

#### PR validation:

To be tested by the bot.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, no backport needed.
