### PR TITLE
CPU vs. GPU for LST in HLT and updates to the offline

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -281,7 +281,9 @@ from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+from Configuration.ProcessModifiers.alpakaValidationLST_cff import alpakaValidationLST
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 from RecoLocalFastTime.Configuration.RecoLocalFastTime_EventContent_cff import *
 from RecoMTD.Configuration.RecoMTD_EventContent_cff import *
 
@@ -718,6 +720,11 @@ phase2_tracker.toModify(FEVTDEBUGHLTEventContent,
                             'keep *_hltInitialStepTracksT4T5TCLST_*_*',
                             'keep *_hltOfflinePrimaryVertices_*_*',
                         ])
+(trackingLST & alpakaValidationLST).toModify(FEVTDEBUGHLTEventContent,
+    outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[
+         'keep *_hltInitialStepTracks_*_*',
+         'keep *_hltInitialStepTracksSerialSync_*_*',
+    ])
 
 phase2_common.toModify(FEVTDEBUGHLTEventContent,
                        outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[

--- a/Configuration/ProcessModifiers/python/alpakaValidationLST_cff.py
+++ b/Configuration/ProcessModifiers/python/alpakaValidationLST_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier performs the host/device validation for the LST algorithm
+alpakaValidationLST = cms.Modifier()
+

--- a/Configuration/ProcessModifiers/python/alpakaValidation_cff.py
+++ b/Configuration/ProcessModifiers/python/alpakaValidation_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.ProcessModifiers.alpaka_cff import *
 from Configuration.ProcessModifiers.alpakaValidationEcal_cff import *
+from Configuration.ProcessModifiers.alpakaValidationLST_cff import *
 from Configuration.ProcessModifiers.alpakaValidationPixel_cff import *
 
 # This modifier chain is for turning on DQM modules used for alpaka device/host validation
@@ -9,5 +10,6 @@ from Configuration.ProcessModifiers.alpakaValidationPixel_cff import *
 alpakaValidation =  cms.ModifierChain(
     alpaka,
     alpakaValidationEcal,
+    alpakaValidationLST,
     alpakaValidationPixel
 )

--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -51,8 +51,9 @@ The offsets currently in use are:
 * 0.7: trackingMkFit modifier
 * 0.701: DisplacedRegionalStep tracking iteration for Run-3
 * 0.702: trackingMkFit modifier for Phase-2 (initialStep only)
-* 0.703: LST tracking (Phase-2 only), initialStep+HighPtTripletStep only, on CPU
-* 0.704: LST tracking (Phase-2 only), initialStep+HighPtTripletStep only, on GPU (if available)
+* 0.711: LST tracking (Phase-2 only), initialStep+HighPtTripletStep only, on CPU
+* 0.712: LST tracking (Phase-2 only), initialStep+HighPtTripletStep only, on GPU (if available)
+* 0.713: LST tracking (Phase-2 only), initialStep+HighPtTripletStep only, on GPU (if available), CPU vs. GPU
 * 0.75: HLT phase-2 timing menu
 * 0.7501: HLT phase-2 tracking-only menu
 * 0.751: HLT phase-2 timing menu Alpaka variant
@@ -60,6 +61,7 @@ The offsets currently in use are:
 * 0.752: HLT phase-2 timing menu ticl_v5 variant
 * 0.753: HLT phase-2 timing menu Alpaka, single tracking iteration variant
 * 0.754: HLT phase-2 timing menu Alpaka, single tracking iteration, LST building variant
+* 0.7541: HLT phase-2 timing menu single tracking iteration, LST building variant, CPU vs. GPU
 * 0.755: HLT phase-2 timing menu Alpaka, LST building variant
 * 0.756 HLT phase-2 timing menu trimmed tracking
 * 0.7561 HLT phase-2 timing menu Alpaka, trimmed tracking
@@ -67,6 +69,7 @@ The offsets currently in use are:
 * 0.757: HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + CKF building variant
 * 0.7571: HLT phase-2 timing menu Alpaka, single tracking iteration, Phase2CAExtension+LST seeding + mkFit building variant
 * 0.7572: HLT phase-2 timing menu Alpaka, single tracking iteration, Phase2CAExtension+LST seeding + mkFit building and fitting variant
+* 0.7573: HLT phase-2 timing menu single tracking iteration, Phase2CAExtension+LST seeding + mkFit building variant, CPU vs. GPU
 * 0.758 HLT phase-2 timing menu ticl_barrel variant
 * 0.759: HLT phase-2 timing menu, with NANO:@Phase2HLT
 * 0.76: HLT phase-2 reduced menu, with DIGI step

--- a/Configuration/PyReleaseValidation/python/relval_Run4.py
+++ b/Configuration/PyReleaseValidation/python/relval_Run4.py
@@ -36,7 +36,7 @@ numWFIB.extend([prefixDet+34.702]) #mkFit tracking (initialStep)
 numWFIB.extend([prefixDet+34.5])   #pixelTrackingOnly
 numWFIB.extend([prefixDet+34.9])   #vector hits
 numWFIB.extend([prefixDet+34.402]) #Alpaka local reconstruction offloaded on device (GPU if available)
-numWFIB.extend([prefixDet+34.703]) #LST tracking on CPU (initialStep+HighPtTripletStep only)
+numWFIB.extend([prefixDet+34.711]) #LST tracking on CPU (initialStep+HighPtTripletStep only)
 numWFIB.extend([prefixDet+34.21])  #prodlike
 numWFIB.extend([prefixDet+96.0])   #CloseByPGun CE_E_Front_120um
 numWFIB.extend([prefixDet+100.0])  #CloseByPGun CE_H_Coarse_Scint
@@ -50,7 +50,7 @@ numWFIB.extend([prefixDet+234.999])  #premixing combined stage1+stage2 ttbar+PU5
 numWFIB.extend([prefixDet+234.21])   #prodlike PU
 numWFIB.extend([prefixDet+234.9921]) #prodlike premix stage1+stage2
 numWFIB.extend([prefixDet+234.114])  #PU, with 10% OT inefficiency
-numWFIB.extend([prefixDet+234.703])  #LST tracking on CPU (initialStep+HighPtTripletStep only)
+numWFIB.extend([prefixDet+234.711])  #LST tracking on CPU (initialStep+HighPtTripletStep only)
 
 # Phase-2 HLT tests
 numWFIB.extend([prefixDet+34.7501])# HLTTrackingOnly75e33

--- a/Configuration/PyReleaseValidation/python/relval_gpu.py
+++ b/Configuration/PyReleaseValidation/python/relval_gpu.py
@@ -81,14 +81,17 @@ numWFIB = [
            prefixDet+34.402, prefixDet+34.4021, prefixDet+34.403, prefixDet+34.404, prefixDet+34.406,
            prefixDet+34.612,
            prefixDet+61.402,
-           prefixDet+34.704,
+           prefixDet+34.712, prefixDet+34.713,
            prefixDet+34.751,
            prefixDet+61.751,
+           prefixDet+34.7541, prefixDet+34.7573,
+           prefixDet+61.7541, prefixDet+61.7573,
 
            # Run4, Alpaka-based PU
            prefixDet+234.402, prefixDet+234.4021, prefixDet+234.403, prefixDet+234.404,
-           prefixDet+234.704,
+           prefixDet+234.712, prefixDet+234.713,
            prefixDet+234.751,
+           prefixDet+234.7541, prefixDet+234.7573,
         ]
 
 for numWF in numWFIB:

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -525,7 +525,7 @@ upgradeWFs['lstOnCPUIters01TrackingOnly'] = UpgradeWorkflow_lstOnCPUIters01Track
         'HARVESTGlobal',
     ],
     suffix = '_lstOnCPUIters01TrackingOnly',
-    offset = 0.703,
+    offset = 0.711,
 )
 upgradeWFs['lstOnCPUIters01TrackingOnly'].step3 = upgradeWFs['trackingOnly'].step3 | {
     '--procModifiers': 'trackingIters01,trackingLST',
@@ -554,10 +554,20 @@ upgradeWFs['lstOnGPUIters01TrackingOnly'] = UpgradeWorkflow_lstOnGPUIters01Track
         'HARVESTGlobal',
     ],
     suffix = '_lstOnGPUIters01TrackingOnly',
-    offset = 0.704,
+    offset = 0.712,
 )
 upgradeWFs['lstOnGPUIters01TrackingOnly'].step3 = upgradeWFs['trackingOnly'].step3 | {
     '--procModifiers': 'trackingIters01,trackingLST',
+}
+
+# LST on GPU (if available), initialStep+highPtTripletStep-only tracking-only, CPU vs. GPU comparison
+class UpgradeWorkflow_lstOnGPUIters01TrackingOnlyAlpakaValidationLST(UpgradeWorkflow_lstOnGPUIters01TrackingOnly):
+    pass
+upgradeWFs['lstOnGPUIters01TrackingOnlyAlpakaValidationLST'] = deepcopy(upgradeWFs['lstOnGPUIters01TrackingOnly'])
+upgradeWFs['lstOnGPUIters01TrackingOnlyAlpakaValidationLST'].suffix = '_lstOnGPUIters01TrackingOnlyAlpakaValidationLST'
+upgradeWFs['lstOnGPUIters01TrackingOnlyAlpakaValidationLST'].offset = 0.713
+upgradeWFs['lstOnGPUIters01TrackingOnlyAlpakaValidationLST'].step3 = upgradeWFs['trackingOnly'].step3 | {
+    '--procModifiers': 'alpakaValidationLST,trackingIters01,trackingLST',
 }
 
 #DeepCore seeding for JetCore iteration workflow
@@ -1996,6 +2006,20 @@ upgradeWFs['HLTTiming75e33AlpakaSingleIterLST'].step3 = {
     '-s':'HARVESTING:@hltValidation'
 }
 
+upgradeWFs['HLTTiming75e33SingleIterLSTAlpakaValidationLST'] = deepcopy(upgradeWFs['HLTTiming75e33'])
+upgradeWFs['HLTTiming75e33SingleIterLSTAlpakaValidationLST'].suffix = '_HLT75e33TimingSingleIterLSTAlpakaValidationLST'
+upgradeWFs['HLTTiming75e33SingleIterLSTAlpakaValidationLST'].offset = 0.7541
+upgradeWFs['HLTTiming75e33SingleIterLSTAlpakaValidationLST'].step2 = {
+    # This workflow is meant to and only works for the tracking validation
+    '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing,VALIDATION:hltMultiTrackValidation',
+    '--procModifiers': 'alpakaValidationLST,singleIterPatatrack,trackingLST',
+    '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
+    '--eventcontent':'FEVTDEBUGHLT,DQMIO'
+}
+upgradeWFs['HLTTiming75e33SingleIterLSTAlpakaValidationLST'].step3 = {
+    '-s':'HARVESTING:@hltValidation'
+}
+
 upgradeWFs['HLTTiming75e33AlpakaLST'] = deepcopy(upgradeWFs['HLTTiming75e33'])
 upgradeWFs['HLTTiming75e33AlpakaLST'].suffix = '_HLT75e33TimingAlpakaLST'
 upgradeWFs['HLTTiming75e33AlpakaLST'].offset = 0.755
@@ -2075,6 +2099,20 @@ upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuildingFitting'].step2
     '--eventcontent':'FEVTDEBUGHLT,DQMIO'
 }
 upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeedingMkFitBuilding'].step3 = {
+    '-s':'HARVESTING:@hltValidation'
+}
+
+upgradeWFs['HLTTiming75e33SingleIterCAExtLSTSeedingMkFitBuildingAlpakaValidationLST'] = deepcopy(upgradeWFs['HLTTiming75e33'])
+upgradeWFs['HLTTiming75e33SingleIterCAExtLSTSeedingMkFitBuildingAlpakaValidationLST'].suffix = '_HLT75e33TimingSingleIterCAExtLSTSeedingMkFitBuildingAlpakaValidationLST'
+upgradeWFs['HLTTiming75e33SingleIterCAExtLSTSeedingMkFitBuildingAlpakaValidationLST'].offset = 0.7573
+upgradeWFs['HLTTiming75e33SingleIterCAExtLSTSeedingMkFitBuildingAlpakaValidationLST'].step2 = {
+    # This workflow is meant to and only works for the tracking validation
+    '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing,VALIDATION:hltMultiTrackValidation',
+    '--procModifiers': 'alpakaValidationLST,singleIterPatatrack,phase2CAExtension,trackingLST,seedingLST,trackingMkFitCommon,hltTrackingMkFitInitialStep',
+    '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
+    '--eventcontent':'FEVTDEBUGHLT,DQMIO'
+}
+upgradeWFs['HLTTiming75e33SingleIterCAExtLSTSeedingMkFitBuildingAlpakaValidationLST'].step3 = {
     '-s':'HARVESTING:@hltValidation'
 }
 

--- a/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_cff.py
@@ -98,8 +98,9 @@ highPtTripletStepTrackToTrackSerialSyncAnalyzer = _t2t.clone(
 trackToTrackCPUAnalyzer = cms.Sequence()
 _trackToTrackCPUAnalyzer_trackingLST = cms.Sequence(highPtTripletStepTrackToTrackSerialSyncAnalyzer)
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
+from Configuration.ProcessModifiers.alpakaValidationLST_cff import alpakaValidationLST
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
-(trackingPhase2PU140 & trackingLST).toReplaceWith(trackToTrackCPUAnalyzer, _trackToTrackCPUAnalyzer_trackingLST)
+(trackingPhase2PU140 & alpakaValidationLST & trackingLST).toReplaceWith(trackToTrackCPUAnalyzer, _trackToTrackCPUAnalyzer_trackingLST)
 
 
 TrackingOfflineDQMClient = cms.Sequence(trackingQTester*trackingOfflineAnalyser*trackingEffFromHitPattern*voMonitoringClientSequence*primaryVertexResolutionClient*TrackEffClient*foldedMapClientSeq*trackToTrackCPUAnalyzer)

--- a/DQM/TrackingMonitorSource/interface/TrackToTrackComparisonHists.h
+++ b/DQM/TrackingMonitorSource/interface/TrackToTrackComparisonHists.h
@@ -110,6 +110,7 @@ private:
   double dxyCutForPlateau_;
   double dzWRTPvCut_;
   bool requireValidHLTPaths_;
+  bool ignoreLumiPUPlots_;
   bool hltPathsAreValid_ = false;
   std::unique_ptr<GenericTriggerEventFlag> genTriggerEventFlag_;
 

--- a/DQM/TrackingMonitorSource/python/trackToTrackCPU_cff.py
+++ b/DQM/TrackingMonitorSource/python/trackToTrackCPU_cff.py
@@ -17,5 +17,6 @@ _trackToTrackCPUTask_trackingLST = cms.Sequence(HighPtTripletStepTaskSerialSync)
 _trackToTrackCPUTask_trackingLST += highPtTripletStepTrackToTrackSerialSync
 
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
+from Configuration.ProcessModifiers.alpakaValidationLST_cff import alpakaValidationLST
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
-(trackingPhase2PU140 & trackingLST).toReplaceWith(trackToTrackCPUSequence, _trackToTrackCPUTask_trackingLST)
+(trackingPhase2PU140 & alpakaValidationLST & trackingLST).toReplaceWith(trackToTrackCPUSequence, _trackToTrackCPUTask_trackingLST)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepMkFitSeeds_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepMkFitSeeds_cfi.py
@@ -12,3 +12,7 @@ from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
 from Configuration.ProcessModifiers.hltTrackingMkFitInitialStep_cff import hltTrackingMkFitInitialStep
 (trackingLST & seedingLST & hltTrackingMkFitInitialStep).toModify(hltInitialStepMkFitSeeds, seeds = "hltInitialStepTrajectorySeedsLST")
+
+hltInitialStepMkFitSeedsSerialSync = hltInitialStepMkFitSeeds.clone(
+        seeds = "hltInitialStepTrajectorySeedsLSTSerialSync"
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidatesMkFit_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidatesMkFit_cfi.py
@@ -17,3 +17,7 @@ hltInitialStepTrackCandidatesMkFit = cms.EDProducer("MkFitProducer",
         seeds = cms.InputTag("hltInitialStepMkFitSeeds"),
         stripHits = cms.InputTag("hltMkFitSiPhase2Hits")
 )
+
+hltInitialStepTrackCandidatesMkFitSerialSync = hltInitialStepTrackCandidatesMkFit.clone(
+    seeds = "hltInitialStepMkFitSeedsSerialSync"
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidates_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidates_cfi.py
@@ -86,4 +86,22 @@ from Configuration.ProcessModifiers.hltTrackingMkFitInitialStep_cff import hltTr
 (~(singleIterPatatrack & seedingLST) & trackingLST).toReplaceWith(hltInitialStepTrackCandidates, _hltInitialStepTrackCandidatesLST)
 (singleIterPatatrack & trackingLST & seedingLST).toModify(hltInitialStepTrackCandidates, src = "hltInitialStepTrajectorySeedsLST") # All LST seeds
 (~seedingLST & ~trackingLST & hltTrackingMkFitInitialStep).toReplaceWith(hltInitialStepTrackCandidates, _hltInitialStepTrackCandidatesMkFit)
-(singleIterPatatrack & seedingLST & trackingLST & hltTrackingMkFitInitialStep).toReplaceWith(hltInitialStepTrackCandidates, _hltInitialStepTrackCandidatesMkFitLSTSeeds)
+_singlePataLSTMkFit = singleIterPatatrack & trackingLST & seedingLST & hltTrackingMkFitInitialStep
+_singlePataLSTMkFit.toReplaceWith(hltInitialStepTrackCandidates, _hltInitialStepTrackCandidatesMkFitLSTSeeds)
+
+# Supported combinations for LST CPU vs. GPU validation
+# The default hltInitialStepTrackCandidatesSerialSync is defined
+# for the _singlePataLSTMkFit procModifier combination.
+# Avoids config duplication warnings.
+hltInitialStepTrackCandidatesSerialSync = _hltInitialStepTrackCandidatesMkFitLSTSeeds.clone(
+    mkFitSeeds = "hltInitialStepMkFitSeedsSerialSync",
+    seeds = "hltInitialStepTrajectorySeedsLSTSerialSync",
+    tracks = "hltInitialStepTrackCandidatesMkFitSerialSync",
+)
+(singleIterPatatrack & trackingLST & ~seedingLST).toReplaceWith(hltInitialStepTrackCandidatesSerialSync,
+    _hltInitialStepTrackCandidatesLST.clone(
+        lstOutput = "hltLSTSerialSync",
+        lstInput = "hltInputLSTSerialSync",
+        lstPixelSeeds = "hltInputLSTSerialSync"
+    )
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTracks_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTracks_cfi.py
@@ -18,6 +18,10 @@ hltInitialStepTracks = cms.EDProducer("TrackProducer",
     useSimpleMF = cms.bool(False)
 )
 
+hltInitialStepTracksSerialSync = hltInitialStepTracks.clone(
+    src = "hltInitialStepTrackCandidatesSerialSync",
+)
+
 from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 from Configuration.ProcessModifiers.seedingLST_cff import seedingLST

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrajectorySeedsLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrajectorySeedsLST_cfi.py
@@ -19,3 +19,9 @@ hltInitialStepTrajectorySeedsLST = cms.EDProducer('LSTOutputConverter',
         forceKinematicWithRegionDirection = cms.bool(False)
     )
 )
+
+hltInitialStepTrajectorySeedsLSTSerialSync = hltInitialStepTrajectorySeedsLST.clone(
+    lstOutput = "hltLSTSerialSync",
+    lstInput = "hltInputLSTSerialSync",
+    lstPixelSeeds = "hltInputLSTSerialSync"
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInputLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInputLST_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from HeterogeneousCore.AlpakaCore.functions import makeSerialClone
 
 hltInputLST = cms.EDProducer('LSTInputProducer@alpaka',
     ptCut = cms.double(0.8),
@@ -19,6 +20,8 @@ _hltInputLSTSingleIterPatatrack = hltInputLST.clone(
 
 from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
 singleIterPatatrack.toReplaceWith(hltInputLST, _hltInputLSTSingleIterPatatrack)
+
+hltInputLSTSerialSync = makeSerialClone(hltInputLST)
 
 _hltInputLSTNGTScouting = hltInputLST.clone(
     seedTracks = ['hltInitialStepSeedTracksLST']

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltLST_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from HeterogeneousCore.AlpakaCore.functions import makeSerialClone
 
 hltLST = cms.EDProducer('LSTProducer@alpaka',
     lstInput = cms.InputTag('hltInputLST'),
@@ -16,3 +17,7 @@ from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
 (seedingLST & trackingLST).toModify(hltLST, nopLSDupClean = True,
                                             tcpLSTriplets = True )
+
+hltLSTSerialSync = makeSerialClone(hltLST,
+    lstInput = "hltInputLSTSerialSync"
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
@@ -38,6 +38,15 @@ from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 
 (~singleIterPatatrack & trackingLST).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLST)
 
+from Configuration.ProcessModifiers.alpakaValidationLST_cff import alpakaValidationLST
+alpakaValidationLST.toReplaceWith(_HLTInitialStepSequenceLST, cms.Sequence(
+    _HLTInitialStepSequenceLST.copy()
+    +hltInputLSTSerialSync
+    +hltLSTSerialSync
+    +hltInitialStepTrackCandidatesSerialSync
+    +hltInitialStepTracksSerialSync
+    )
+)
 (singleIterPatatrack & trackingLST & ~seedingLST).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLST.copyAndExclude([HLTHighPtTripletStepSeedingSequence,hltHighPtTripletStepSeedTracksLST]))
 
 from ..modules.hltInitialStepTrajectorySeedsLST_cfi import *
@@ -91,7 +100,7 @@ from Configuration.ProcessModifiers.hltTrackingMkFitInitialStep_cff import hltTr
 _HLTInitialStepSequenceSingleIterPatatrackLSTSeedingMkFitTracking = cms.Sequence(
      hltInitialStepSeeds
     +hltInitialStepSeedTracksLST
-    +hltSiPhase2RecHits # Probably need to move elsewhere in the final setup                                                 
+    +hltSiPhase2RecHits # Probably need to move elsewhere in the final setup 
     +hltInputLST
     +hltLST
     +hltInitialStepTrajectorySeedsLST
@@ -104,7 +113,20 @@ _HLTInitialStepSequenceSingleIterPatatrackLSTSeedingMkFitTracking = cms.Sequence
     +hltInitialStepTrackSelectionHighPurity
 )
 
-(singleIterPatatrack & trackingLST & seedingLST & hltTrackingMkFitInitialStep).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceSingleIterPatatrackLSTSeedingMkFitTracking)
+_singlePataLSTMkFit = singleIterPatatrack & trackingLST & seedingLST & hltTrackingMkFitInitialStep
+_singlePataLSTMkFit.toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceSingleIterPatatrackLSTSeedingMkFitTracking)
+
+(alpakaValidationLST & _singlePataLSTMkFit).toReplaceWith(HLTInitialStepSequence, cms.Sequence(
+    HLTInitialStepSequence.copy()
+    +hltInputLSTSerialSync
+    +hltLSTSerialSync
+    +hltInitialStepTrajectorySeedsLSTSerialSync
+    +hltInitialStepMkFitSeedsSerialSync
+    +hltInitialStepTrackCandidatesMkFitSerialSync
+    +hltInitialStepTrackCandidatesSerialSync
+    +hltInitialStepTracksSerialSync
+    )
+)
 
 from ..modules.hltInitialStepTrackCandidatesMkFitFit_cfi import *
 
@@ -138,4 +160,4 @@ _HLTInitialStepSequenceSingleIterPatatrackLSTSeedingMkFitFitTracking = cms.Seque
 
 from Configuration.ProcessModifiers.trackingMkFitFit_cff import trackingMkFitFit
 (~seedingLST & ~trackingLST & hltTrackingMkFitInitialStep & trackingMkFitFit).toReplaceWith(HLTInitialStepSequence,_HLTInitialStepSequenceMkFitFitTracking)
-(singleIterPatatrack & trackingLST & seedingLST & hltTrackingMkFitInitialStep & trackingMkFitFit).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceSingleIterPatatrackLSTSeedingMkFitFitTracking)
+(_singlePataLSTMkFit & trackingMkFitFit).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceSingleIterPatatrackLSTSeedingMkFitFitTracking)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTMkFitInputSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTMkFitInputSequence_cfi.py
@@ -1,7 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from ..modules.hltMkFitSiPixelHits_cfi import *
-from ..modules.hltMkFitSiStripHits_cfi import *
 from ..modules.hltMkFitSiPhase2Hits_cfi import *
 from ..modules.hltMkFitEventOfHits_cfi import *
 

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -433,25 +433,26 @@ _HighPtTripletStepTask_LST.add(siPhase2RecHits, lstInitialStepSeedTracks, lstHig
                                lstProducerTask, highPtTripletStepLSTpTracks, highPtTripletStepLSTT4T5Tracks, highPtTripletStepSelectorLSTT4T5)
 (trackingPhase2PU140 & trackingLST).toReplaceWith(HighPtTripletStepTask, _HighPtTripletStepTask_LST)
 
+from Configuration.ProcessModifiers.alpakaValidationLST_cff import alpakaValidationLST
 from HeterogeneousCore.AlpakaCore.functions import makeSerialClone
 lstInputProducerSerialSync = makeSerialClone(lstInputProducer)
 lstProducerSerialSync = makeSerialClone(lstProducer, lstInput = "lstInputProducerSerialSync")
 
 highPtTripletStepTrackCandidatesSerialSync = highPtTripletStepTrackCandidates.clone()
-(trackingPhase2PU140 & trackingLST).toModify(highPtTripletStepTrackCandidatesSerialSync,
+(trackingPhase2PU140 & alpakaValidationLST & trackingLST).toModify(highPtTripletStepTrackCandidatesSerialSync,
     lstOutput = "lstProducerSerialSync",
     lstInput = "lstInputProducerSerialSync",
     lstPixelSeeds = "lstInputProducerSerialSync"
 )
 highPtTripletStepLSTpTracksSerialSync = highPtTripletStepLSTpTracks.clone(
-    src    = 'highPtTripletStepTrackCandidatesSerialSync:pTCsLST')
+    src = 'highPtTripletStepTrackCandidatesSerialSync:pTCsLST')
 highPtTripletStepLSTT4T5TracksSerialSync = highPtTripletStepLSTT4T5Tracks.clone(
-    src    = 'highPtTripletStepTrackCandidatesSerialSync:t4t5TCsLST')
+    src = 'highPtTripletStepTrackCandidatesSerialSync:t4t5TCsLST')
 highPtTripletStepSelectorSerialSync = highPtTripletStepSelector.clone()
-(trackingPhase2PU140 & trackingLST).toModify(highPtTripletStepSelectorSerialSync, src = "highPtTripletStepLSTpTracksSerialSync" )
+(trackingPhase2PU140 & alpakaValidationLST & trackingLST).toModify(highPtTripletStepSelectorSerialSync, src = "highPtTripletStepLSTpTracksSerialSync" )
 highPtTripletStepSelectorLSTT4T5SerialSync = highPtTripletStepSelectorLSTT4T5.clone(src = "highPtTripletStepLSTT4T5TracksSerialSync")
 highPtTripletStepTracksSerialSync = highPtTripletStepTracks.clone()
-(trackingPhase2PU140 & trackingLST).toModify(highPtTripletStepTracksSerialSync,
+(trackingPhase2PU140 & alpakaValidationLST & trackingLST).toModify(highPtTripletStepTracksSerialSync,
     TrackProducers     = ['highPtTripletStepLSTpTracksSerialSync',
                           'highPtTripletStepLSTT4T5TracksSerialSync'],
     selectedTrackQuals = ['highPtTripletStepSelectorSerialSync:highPtTripletStep',
@@ -465,7 +466,7 @@ _HighPtTripletStepTask_LSTSerialSync.add(siPhase2RecHits, lstInitialStepSeedTrac
                                          highPtTripletStepTracksSerialSync
 )
 HighPtTripletStepTaskSerialSync = cms.Task()
-(trackingPhase2PU140 & trackingLST).toReplaceWith(HighPtTripletStepTaskSerialSync, _HighPtTripletStepTask_LSTSerialSync)
+(trackingPhase2PU140 & alpakaValidationLST & trackingLST).toReplaceWith(HighPtTripletStepTaskSerialSync, _HighPtTripletStepTask_LSTSerialSync)
 
 # fast tracking mask producer 
 from FastSimulation.Tracking.FastTrackerRecHitMaskProducer_cfi import maskProducerFromClusterRemover

--- a/RecoTracker/LSTCore/standalone/README.md
+++ b/RecoTracker/LSTCore/standalone/README.md
@@ -154,25 +154,19 @@ Follow the instructions in the ["Setting up LST within CMSSW" section](#setting-
 
 ## Run the LST reconstruction in CMSSW (read to the end, before running)
 
-Two complete workflows have been implemented within CMSSW to run a two-iteration, tracking-only reconstruction with LST:
- - 24834.703 (CPU)
- - 24834.704 (GPU)
+A two-iteration, tracking-only offline workflow with PU, running LST (on GPU if available, otherwise on CPU), 34634.712, has been implemented within CMSSW. More LST workflows can be found in https://github.com/cms-sw/cmssw/tree/master/Configuration/PyReleaseValidation.
 
-We will use the second one in the example below. To get the commands of this workflow, one can run:
+To get the commands for the workflow mentioned above, one can run:
 
-    runTheMatrix.py -w upgrade -n -e -l 24834.704
-
-For convenience, the workflow has been run for 100 events and the output is stored here:
-
-    /data2/segmentlinking/step2_29834.1_100Events.root
+    runTheMatrix.py -w upgrade -n -e -l 34634.712
 
 The input files in each step may need to be properly adjusted to match the ones produced by the previous step/provided externally, hence it is better to run the commands with the `--no_exec` option included.
 
 Running the configuration file with `cmsRun`, the output file will have a name starting with `DQM`. The name is the same every time this step runs,
-so it is good practice to rename the file, e.g. to `step4_24834.704.root`.
+so it is good practice to rename the file, e.g. to `step4_34634.712.root`.
 The MTV plots can be produced with the command:
 
-    makeTrackValidationPlots.py --extended step4_24834.704.root
+    makeTrackValidationPlots.py --extended step4_34634.712.root
 
 Comparison plots can be made by including multiple ROOT files as arguments.
 

--- a/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
+++ b/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
@@ -69,6 +69,28 @@ phase2_tracker.toReplaceWith(
     )
 )
 
+
+from DQM.TrackingMonitorSource.TrackToTrackComparisonHists_cfi import TrackToTrackComparisonHists as _TrackToTrackComparisonHists
+hltInitialStepTrackToTrackSerialSync = _TrackToTrackComparisonHists.clone(
+    requireValidHLTPaths = False,
+    ignoreLumiPUPlots = True,
+    monitoredTrack = "hltInitialStepTracks",
+    monitoredBeamSpot = "hltOnlineBeamSpot",
+    monitoredPrimaryVertices = "hltPhase2PixelVertices",
+    referenceTrack = "hltInitialStepTracksSerialSync",
+    referenceBeamSpot = "hltOnlineBeamSpot",
+    referencePrimaryVertices = "hltPhase2PixelVertices",
+    topDirName = cms.string('HLT/Tracking/ValidationWRTSerialSync/initialStepTracks'),
+)
+
+from Configuration.ProcessModifiers.alpakaValidationLST_cff import alpakaValidationLST
+alpakaValidationLST.toReplaceWith(hltMultiTrackValidation, cms.Sequence(
+    hltMultiTrackValidation.copy()
+    +hltInitialStepTrackToTrackSerialSync
+    )
+)
+
+
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 from Configuration.ProcessModifiers.ngtScouting_cff import ngtScouting
 from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack


### PR DESCRIPTION
The goal of this PR is to introduce two HLT workflows to monitor the agreement between LST on CPU and LST on GPU:
1. Workflow 0.7541 monitors the LST output tracks when LST is used for track building (most direct comparison of LST), i.e. for `alpakaValidationLST,singleIterPatatrack,trackingLST`.
2. Workflow 0.7573 monitors the built tracks in the upcoming new tracking baseline, where LST is used as an extended seeding algorithm (comparison of LST output in a "production" configuration), i.e. for `singleIterPatatrack,phase2CAExtension,trackingLST,seedingLST,trackingMkFitCommon,hltTrackingMkFitInitialStep`.

The additional CPU reconstruction (`SerialSync`) and comparison plots are implemented with a new procModifier, `alpakaValidationLST`. This procModifier needs to be run only in the procModifier combinations mentioned above to take effect, otherwise it produces neither the additional products nor the comparison plots. It is also included in the `alpakaValidation` modifier chain.

The analyzer that produces the comparison plots has been improved with a new parameter option to skip luminosity and PU plots.

With the introduction of the `alpakaValidationLST` modifier, the offline workflow testing LST on CPU vs. LST on GPU can be made explicit. The code is changed so that the heterogeneous workflow `0.712` (previously `0.704`) runs the offline reconstruction without any additional CPU reconstruction, while a new workflow, `0.713`, runs the comparison. Workflow `0.703` has also been renamed to `0.711`.  The workflow numbering changes are made so that the offline LST workflows follow the numbering conventions for Alpaka workflows.

Some screenshots of the content of the DQM file:
<img width="678" height="654" alt="Screenshot from 2026-01-07 19-38-56" src="https://github.com/user-attachments/assets/e61aeba0-219e-4864-b6ec-310b454eba9c" />
<img width="1069" height="736" alt="image" src="https://github.com/user-attachments/assets/51c2b892-bd45-47f1-9b17-8d7e18da16bd" />
<img width="1069" height="736" alt="image" src="https://github.com/user-attachments/assets/252c6494-666d-4159-baad-d110993c226d" />
