### PR TITLE
[Backport 14_1_X] Simulation: prevent exception if trackId larger than 200M

### DIFF
--- a/SimG4CMS/Forward/src/MtdSD.cc
+++ b/SimG4CMS/Forward/src/MtdSD.cc
@@ -106,8 +106,16 @@ int MtdSD::getTrackID(const G4Track* aTrack) {
 #ifdef EDM_ML_DEBUG
     trkInfo->Print();
 #endif
+    if (theID >= static_cast<int>(PSimHit::k_tidOffset)) {
+      edm::LogError("MtdSim") << " SimTrack ID " << theID << " exceeds maximum allowed by PSimHit identifier"
+                              << PSimHit::k_tidOffset << " unreliable MTD hit type";
+    }
     if (rname == "FastTimerRegionSensBTL") {
       theID = trkInfo->mcTruthID();
+    if (theID >= static_cast<int>(PSimHit::k_tidOffset)) {
+      edm::LogError("MtdSim") << " SimTrack ID " << theID << " exceeds maximum allowed by PSimHit identifier"
+                              << PSimHit::k_tidOffset << " unreliable MTD hit type";
+    }
       if (trkInfo->isExtSecondary() && !trkInfo->isInTrkFromBackscattering()) {
         theID = PSimHit::addTrackIdOffset(theID, k_idsecOffset);
       } else if (trkInfo->isInTrkFromBackscattering()) {
@@ -121,6 +129,10 @@ int MtdSD::getTrackID(const G4Track* aTrack) {
 #endif
     } else if (rname == "FastTimerRegionSensETL") {
       theID = trkInfo->getIDonCaloSurface();
+    if (theID >= static_cast<int>(PSimHit::k_tidOffset)) {
+      edm::LogError("MtdSim") << " SimTrack ID " << theID << " exceeds maximum allowed by PSimHit identifier"
+                              << PSimHit::k_tidOffset << " unreliable MTD hit type";
+    }
 #ifdef EDM_ML_DEBUG
       edm::LogVerbatim("MtdSim") << "MtdSD: Track ID: " << aTrack->GetTrackID()
                                  << " ETL Track ID: " << trkInfo->mcTruthID() << ":" << theID;

--- a/SimG4CMS/Forward/src/MtdSD.cc
+++ b/SimG4CMS/Forward/src/MtdSD.cc
@@ -112,10 +112,10 @@ int MtdSD::getTrackID(const G4Track* aTrack) {
     }
     if (rname == "FastTimerRegionSensBTL") {
       theID = trkInfo->mcTruthID();
-    if (theID >= static_cast<int>(PSimHit::k_tidOffset)) {
-      edm::LogError("MtdSim") << " SimTrack ID " << theID << " exceeds maximum allowed by PSimHit identifier"
-                              << PSimHit::k_tidOffset << " unreliable MTD hit type";
-    }
+      if (theID >= static_cast<int>(PSimHit::k_tidOffset)) {
+        edm::LogError("MtdSim") << " SimTrack ID " << theID << " exceeds maximum allowed by PSimHit identifier"
+                                << PSimHit::k_tidOffset << " unreliable MTD hit type";
+      }
       if (trkInfo->isExtSecondary() && !trkInfo->isInTrkFromBackscattering()) {
         theID = PSimHit::addTrackIdOffset(theID, k_idsecOffset);
       } else if (trkInfo->isInTrkFromBackscattering()) {
@@ -129,10 +129,10 @@ int MtdSD::getTrackID(const G4Track* aTrack) {
 #endif
     } else if (rname == "FastTimerRegionSensETL") {
       theID = trkInfo->getIDonCaloSurface();
-    if (theID >= static_cast<int>(PSimHit::k_tidOffset)) {
-      edm::LogError("MtdSim") << " SimTrack ID " << theID << " exceeds maximum allowed by PSimHit identifier"
-                              << PSimHit::k_tidOffset << " unreliable MTD hit type";
-    }
+      if (theID >= static_cast<int>(PSimHit::k_tidOffset)) {
+        edm::LogError("MtdSim") << " SimTrack ID " << theID << " exceeds maximum allowed by PSimHit identifier"
+                                << PSimHit::k_tidOffset << " unreliable MTD hit type";
+      }
 #ifdef EDM_ML_DEBUG
       edm::LogVerbatim("MtdSim") << "MtdSD: Track ID: " << aTrack->GetTrackID()
                                  << " ETL Track ID: " << trkInfo->mcTruthID() << ":" << theID;

--- a/SimG4Core/Notification/src/SimTrackManager.cc
+++ b/SimG4Core/Notification/src/SimTrackManager.cc
@@ -164,7 +164,7 @@ void SimTrackManager::reallyStoreTracks() {
     }
 
     if (id >= static_cast<int>(PSimHit::k_tidOffset)) {
-      throw cms::Exception("SimTrackManager::reallyStoreTracks")
+      edm::LogWarning("SimTrackManager::reallyStoreTracks")
           << " SimTrack ID " << id << " exceeds maximum allowed by PSimHit identifier" << PSimHit::k_tidOffset;
     }
     TmpSimTrack* g4simtrack =


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/49801
to 14_1_X branch. The code has been adapted for the MtdSD part as the structure was originally different.

#### PR validation:

Code compiles, simple addition of MessageLogger printouts.