### PR TITLE
LST basic standalone compilation unit test

### DIFF
--- a/RecoTracker/LSTCore/test/BuildFile.xml
+++ b/RecoTracker/LSTCore/test/BuildFile.xml
@@ -1,0 +1,1 @@
+<test name="RecoTrackerLSTCore-standalone-compilation" command="runCompilationTest.sh"/>

--- a/RecoTracker/LSTCore/test/runCompilationTest.sh
+++ b/RecoTracker/LSTCore/test/runCompilationTest.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cp -r $CMSSW_BASE/src/RecoTracker/LSTCore ./
+find LSTCore -type d | xargs chmod +w
+cd LSTCore/standalone
+source setup.sh
+echo "Building LST CPU backend..."
+lst_make_tracklooper -mCs


### PR DESCRIPTION
Adding a scam-able unit test to compile LST standalone code.

this PR is roughly following the discussion in https://github.com/cms-sw/cmssw/pull/48236#issuecomment-2951217437; to resolve the concern of building with different logic on different backends, the proposed unit test is for the CPU backends. This should cover a large fraction of cases.

@ariostas @VourMa 