### PR TITLE
PPS direct simulation as standalone module

### DIFF
--- a/SimPPS/DirectSimProducer/BuildFile.xml
+++ b/SimPPS/DirectSimProducer/BuildFile.xml
@@ -3,8 +3,7 @@
 <use name="Geometry/VeryForwardGeometryBuilder"/>
 <use name="Geometry/VeryForwardRPTopology"/>
 <use name="SimDataFormats/GeneratorProducts"/>
-<use name="SimPPS/DirectSimProducer"/>
 <use name="rootcore"/>
-<library name="SimPPSDirectSimProducerPlugins" file="*.cc">
-  <flags EDM_PLUGIN="1"/>
-</library>
+<export>
+  <lib name="1"/>
+</export>

--- a/SimPPS/DirectSimProducer/interface/DirectSimulator.h
+++ b/SimPPS/DirectSimProducer/interface/DirectSimulator.h
@@ -1,0 +1,91 @@
+/****************************************************************************
+ * Authors:
+ *   Jan Kašpar
+ *   Laurent Forthomme
+ ****************************************************************************/
+
+#ifndef SimPPS_DirectSimProducer_DirectSimulator_h
+#define SimPPS_DirectSimProducer_DirectSimulator_h
+
+#include <map>
+
+#include <TF2.h>
+#include <TH2F.h>
+
+#include "DataFormats/CTPPSDetId/interface/CTPPSDetId.h"
+
+// forward definitions
+class CTPPSBeamParameters;
+class CTPPSGeometry;
+class CTPPSLocalTrackLite;
+class LHCInfo;
+class LHCInterpolatedOpticalFunctionsSetCollection;
+class PPSDirectSimulationData;
+namespace edm {
+  class ParameterSet;
+}  // namespace edm
+namespace CLHEP {
+  class HepRandomEngine;
+}  // namespace CLHEP
+
+class DirectSimulator {
+public:
+  explicit DirectSimulator(const edm::ParameterSet& iConfig);
+
+  void setGeometry(const CTPPSGeometry& geometry) { geometry_ = &geometry; }
+  void setLHCInfo(const LHCInfo&);
+  void setBeamParameters(const CTPPSBeamParameters&);
+  void setOpticalFunctions(const LHCInterpolatedOpticalFunctionsSetCollection& optical_functions) {
+    optical_functions_ = &optical_functions;
+  }
+  void setRandomEngine(CLHEP::HepRandomEngine& random_engine) { random_engine_ = &random_engine; }
+  void setDirectSimulationData(const PPSDirectSimulationData&);
+
+  void setCrossingAngle(double crossing_angle) { crossing_angle_ = crossing_angle; }
+
+  struct Parameters {
+    double ax{0.}, ay{0.}, bx{0.}, by{0.};
+    double z{0.};
+  };
+  /// Compute the per-pot parameters for a given particle with a given vertex
+  /// \param[in] vtx_cms 4-vector (x, y, z, t) in mm/s for the particle vertex
+  /// \param[in] mom_cms 4-momentum (px, py, pz, E) in GeV for the particle
+  /// \param[out] out_params collection of parameters for each pot position encountered
+  /// \return a boolean stating whether the particle was properly propagated to the pots location
+  bool operator()(const std::array<double, 4>& vtx_cms /*mm*/,
+                  const std::array<double, 4>& mom_cms,
+                  std::map<CTPPSDetId, Parameters>& out_params) const;
+  /// Produce track objects from each pot computed parameters
+  void produceLiteTracks(const std::map<CTPPSDetId, Parameters>&, std::vector<CTPPSLocalTrackLite>&) const;
+
+private:
+  const CTPPSBeamParameters* beam_parameters_{nullptr};
+  const LHCInterpolatedOpticalFunctionsSetCollection* optical_functions_{nullptr};
+  const CTPPSGeometry* geometry_{nullptr};
+  CLHEP::HepRandomEngine* random_engine_{nullptr};
+
+  double crossing_angle_{0.};
+  struct SectorBeamlineParameters {
+    double beam_momentum{0.}, half_crossing_angle_x{0.};
+  };
+  std::array<SectorBeamlineParameters, 2> beamline_parameters_;
+
+  // settings of LHC aperture limitations (high xi)
+  bool useEmpiricalApertures_;
+  std::unique_ptr<TF2> empiricalAperture45_;
+  std::unique_ptr<TF2> empiricalAperture56_;
+
+  // efficiency flags
+  bool useTrackingEfficiencyPerRP_;
+  bool useTimingEfficiencyPerRP_;
+
+  // efficiency maps
+  std::map<unsigned int, std::unique_ptr<TH2F>> efficiencyMapsPerRP_;
+
+  // other parameters
+  bool produceHitsRelativeToBeam_;
+
+  unsigned int verbosity_;
+};
+
+#endif

--- a/SimPPS/DirectSimProducer/interface/NanoAODDirectSimulator.h
+++ b/SimPPS/DirectSimProducer/interface/NanoAODDirectSimulator.h
@@ -5,6 +5,7 @@
 
 #ifndef SimPPS_DirectSimProducer_NanoAODDirectSimulator_h
 
+#include "CondFormats/PPSObjects/interface/CTPPSBeamParameters.h"
 #include "CondFormats/PPSObjects/interface/LHCInterpolatedOpticalFunctionsSetCollection.h"
 #include "CondFormats/RunInfo/interface/LHCInfo.h"
 #include "SimPPS/DirectSimProducer/interface/DirectSimulator.h"
@@ -18,9 +19,11 @@ public:
   void addCrossingAngleOpticalFunctions(double crossing_angle,
                                         const std::string& filename);  ///< Add a new crossing angle value
   void addScoringPlane(unsigned int, double, const std::string&);      ///< Add a RP position with its optical functions
-  void setBeamEnergy(double);                                          ///< Set the current beam energy, in GeV
-  void setBetaStar(double);                                            ///< Set the current beta*, in m
-  void setCrossingAngle(double);                                       ///< Set the current crossing angle, in urad
+
+  void setVerbosity(int verbosity) { verbosity_ = verbosity; }  ///< Set the algorithm verbosity level
+  void setBeamEnergy(double);                                   ///< Set the current beam energy, in GeV
+  void setBetaStar(double);                                     ///< Set the current beta*, in m
+  void setCrossingAngle(double);                                ///< Set the current crossing angle, in urad
   void initialise();
 
   /// Compute the per-pot parameters for a given particle with a given vertex
@@ -44,6 +47,9 @@ private:
   std::vector<ScoringPlaneInfo> scoring_planes_;  ///< list of RP stations to be simulated
   LHCInterpolatedOpticalFunctionsSetCollection interpolated_optical_functions_;  ///< optical functions
   LHCInfo lhc_info_;                                                             ///< LHC optics metadata
+  CTPPSBeamParameters beam_parameters_;                                          ///< PPS-specific beam parameters
+
+  int verbosity_{0};  ///< algorithm verbosity level
 };
 
 #endif

--- a/SimPPS/DirectSimProducer/interface/NanoAODDirectSimulator.h
+++ b/SimPPS/DirectSimProducer/interface/NanoAODDirectSimulator.h
@@ -1,0 +1,49 @@
+/****************************************************************************
+ * Authors:
+ *   Laurent Forthomme
+ ****************************************************************************/
+
+#ifndef SimPPS_DirectSimProducer_NanoAODDirectSimulator_h
+
+#include "CondFormats/PPSObjects/interface/LHCInterpolatedOpticalFunctionsSetCollection.h"
+#include "CondFormats/RunInfo/interface/LHCInfo.h"
+#include "SimPPS/DirectSimProducer/interface/DirectSimulator.h"
+
+#include <TLorentzVector.h>
+
+class NanoAODDirectSimulator {
+public:
+  NanoAODDirectSimulator();
+
+  void addCrossingAngleOpticalFunctions(double crossing_angle,
+                                        const std::string& filename);  ///< Add a new crossing angle value
+  void addScoringPlane(unsigned int, double, const std::string&);      ///< Add a RP position with its optical functions
+  void setBeamEnergy(double);                                          ///< Set the current beam energy, in GeV
+  void setBetaStar(double);                                            ///< Set the current beta*, in m
+  void setCrossingAngle(double);                                       ///< Set the current crossing angle, in urad
+  void initialise();
+
+  /// Compute the per-pot parameters for a given particle with a given vertex
+  /// \param[in] vtx_cms 4-vector (x, y, z, t) in mm/s for the particle vertex
+  /// \param[in] mom_cms 4-momentum (px, py, pz, E) in GeV for the particle
+  /// \return a collection of tracks information for each pot location
+  std::vector<CTPPSLocalTrackLite> computeProton(const TLorentzVector& vtx_cms /*mm*/,
+                                                 const TLorentzVector& mom_cms) const;
+
+private:
+  void buildInterpolatedOpticalFunctions();
+
+  std::unique_ptr<DirectSimulator> simulator_;
+
+  std::map<double, std::string> optical_functions_files_;  ///< location of per-xangle optical functions
+  struct ScoringPlaneInfo {
+    unsigned int rp_id{0};
+    double z_position{0.};
+    std::string directory_name;
+  };
+  std::vector<ScoringPlaneInfo> scoring_planes_;  ///< list of RP stations to be simulated
+  LHCInterpolatedOpticalFunctionsSetCollection interpolated_optical_functions_;  ///< optical functions
+  LHCInfo lhc_info_;                                                             ///< LHC optics metadata
+};
+
+#endif

--- a/SimPPS/DirectSimProducer/python/NanoAODDirectSimProducer.py
+++ b/SimPPS/DirectSimProducer/python/NanoAODDirectSimProducer.py
@@ -11,8 +11,9 @@ ROOT.PyConfig.IgnoreCommandLineOptions = True
 class NanoAODDirectSimProducer(Module):
     beam_energy: float = 0.
 
-    def __init__(self, profile):
+    def __init__(self, profile, verbosity=0):
         self.worker = ROOT.NanoAODDirectSimulator()
+        self.worker.setVerbosity(verbosity)
         # feed the worker with configuration retrieved from conditions
         if not hasattr(profile, 'ctppsLHCInfo'):
             raise AttributeError('Failed to retrieve the LHC info from the profile.')
@@ -94,7 +95,6 @@ class NanoAODDirectSimProducer(Module):
             xi = 1. - proton_mom.Pz() / self.beam_energy  #FIXME
             for track in self.worker.computeProton(ROOT.TLorentzVector(), proton_mom):
                 detid = ROOT.CTPPSDetId(track.rpId())
-                print(track.x())
                 nProton_singleRP += 1
                 Proton_singleRP_arm.append(detid.arm())
                 Proton_singleRP_decRPId.append(100 * detid.arm() + 10 * detid.station() + detid.rp())
@@ -122,4 +122,4 @@ class NanoAODDirectSimProducer(Module):
 
 
 # define modules using the syntax 'name = lambda : constructor' to avoid having them loaded when not needed
-directSimModuleConstr = lambda profile: NanoAODDirectSimProducer(profile)
+directSimModuleConstr = lambda profile, verbosity=0: NanoAODDirectSimProducer(profile, verbosity)

--- a/SimPPS/DirectSimProducer/python/NanoAODDirectSimProducer.py
+++ b/SimPPS/DirectSimProducer/python/NanoAODDirectSimProducer.py
@@ -49,6 +49,15 @@ class NanoAODDirectSimProducer(Module):
 
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree
+        self.out.branch("nPPSLocalTracks", "I")
+        self.out.branch("PPSLocalTracks_x", "F", lenVar="nPPSLocalTracks")
+        self.out.branch("PPSLocalTracks_y", "F", lenVar="nPPSLocalTracks")
+        self.out.branch("PPSLocalTracks_time", "F", lenVar="nPPSLocalTracks")
+        self.out.branch("PPSLocalTracks_timeUnc", "F", lenVar="nPPSLocalTracks")
+        self.out.branch("PPSLocalTracks_multiRPProtonIdx", "F", lenVar="nPPSLocalTracks")
+        self.out.branch("PPSLocalTracks_singleRPProtonIdx", "F", lenVar="nPPSLocalTracks")
+        self.out.branch("PPSLocalTracks_decRPId", "I", lenVar="nPPSLocalTracks")
+        self.out.branch("PPSLocalTracks_rpType", "I", lenVar="nPPSLocalTracks")
         self.out.branch("nProton_singleRP", "I")
         self.out.branch("Proton_singleRP_arm", "F", lenVar="nProton_singleRP")
         self.out.branch("Proton_singleRP_decRPId", "I", lenVar="nProton_singleRP")
@@ -77,6 +86,16 @@ class NanoAODDirectSimProducer(Module):
         if len(proton_candidates) == 0:
             return False
 
+        # initialise collections to be filled
+        nPPSLocalTracks = 0
+        PPSLocalTracks_x = []
+        PPSLocalTracks_y = []
+        PPSLocalTracks_time = []
+        PPSLocalTracks_timeUnc = []
+        PPSLocalTracks_multiRPProtonIdx = []
+        PPSLocalTracks_singleRPProtonIdx = []
+        PPSLocalTracks_decRPId = []
+        PPSLocalTracks_rpType = []
         nProton_singleRP = 0
         Proton_singleRP_arm = []
         Proton_singleRP_decRPId = []
@@ -95,10 +114,21 @@ class NanoAODDirectSimProducer(Module):
             xi = 1. - proton_mom.Pz() / self.beam_energy  #FIXME
             for track in self.worker.computeProton(ROOT.TLorentzVector(), proton_mom):
                 detid = ROOT.CTPPSDetId(track.rpId())
+                dec_detid = 100 * detid.arm() + 10 * detid.station() + detid.rp()
+                rp_type = detid.subdetId()
+                nPPSLocalTracks += 1
+                PPSLocalTracks_x.append(track.x())
+                PPSLocalTracks_y.append(track.y())
+                PPSLocalTracks_time.append(track.time())
+                PPSLocalTracks_timeUnc.append(track.timeUnc())
+                PPSLocalTracks_multiRPProtonIdx.append(0.)   #FIXME
+                PPSLocalTracks_singleRPProtonIdx.append(nPPSLocalTracks)
+                PPSLocalTracks_decRPId.append(dec_detid)
+                PPSLocalTracks_rpType.append(rp_type)
                 nProton_singleRP += 1
                 Proton_singleRP_arm.append(detid.arm())
-                Proton_singleRP_decRPId.append(100 * detid.arm() + 10 * detid.station() + detid.rp())
-                Proton_singleRP_rpType.append(0)  #FIXME
+                Proton_singleRP_decRPId.append(dec_detid)
+                Proton_singleRP_rpType.append(rp_type)
                 Proton_singleRP_x.append(track.x())
                 Proton_singleRP_y.append(track.y())
                 Proton_singleRP_time.append(track.time())
@@ -107,6 +137,15 @@ class NanoAODDirectSimProducer(Module):
                 Proton_singleRP_thetaX.append(0.)  #FIXME
                 Proton_singleRP_thetaY.append(0.)  #FIXME
 
+        self.out.fillBranch("nPPSLocalTracks", nPPSLocalTracks)
+        self.out.fillBranch("PPSLocalTracks_x", PPSLocalTracks_x)
+        self.out.fillBranch("PPSLocalTracks_y", PPSLocalTracks_y)
+        self.out.fillBranch("PPSLocalTracks_time", PPSLocalTracks_time)
+        self.out.fillBranch("PPSLocalTracks_timeUnc", PPSLocalTracks_timeUnc)
+        self.out.fillBranch("PPSLocalTracks_multiRPProtonIdx", PPSLocalTracks_multiRPProtonIdx)
+        self.out.fillBranch("PPSLocalTracks_singleRPProtonIdx", PPSLocalTracks_singleRPProtonIdx)
+        self.out.fillBranch("PPSLocalTracks_decRPId", PPSLocalTracks_decRPId)
+        self.out.fillBranch("PPSLocalTracks_rpType", PPSLocalTracks_rpType)
         self.out.fillBranch("nProton_singleRP", nProton_singleRP)
         self.out.fillBranch("Proton_singleRP_arm", Proton_singleRP_arm)
         self.out.fillBranch("Proton_singleRP_decRPId", Proton_singleRP_decRPId)

--- a/SimPPS/DirectSimProducer/python/NanoAODDirectSimProducer.py
+++ b/SimPPS/DirectSimProducer/python/NanoAODDirectSimProducer.py
@@ -1,0 +1,125 @@
+from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection, Object
+from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
+import math
+import os
+import ROOT
+
+
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+
+
+class NanoAODDirectSimProducer(Module):
+    beam_energy: float = 0.
+
+    def __init__(self, profile):
+        self.worker = ROOT.NanoAODDirectSimulator()
+        # feed the worker with configuration retrieved from conditions
+        if not hasattr(profile, 'ctppsLHCInfo'):
+            raise AttributeError('Failed to retrieve the LHC info from the profile.')
+        if hasattr(profile.ctppsLHCInfo, 'beamEnergy'):
+            self.beam_energy = float(profile.ctppsLHCInfo.beamEnergy.value())
+            self.worker.setBeamEnergy(self.beam_energy)
+        if hasattr(profile.ctppsLHCInfo, 'betaStar'):
+            self.worker.setBetaStar(float(profile.ctppsLHCInfo.betaStar.value()))
+        if hasattr(profile.ctppsLHCInfo, 'xangle'):
+            self.worker.setCrossingAngle(float(profile.ctppsLHCInfo.xangle.value()))
+        if not hasattr(profile, 'ctppsOpticalFunctions'):
+            raise AttributeError('Failed to retrieve the optics configuration from the profile.')
+        if not hasattr(profile.ctppsOpticalFunctions, 'opticalFunctions'):
+            raise AttributeError('Failed to retrieve the list of optical functions from the optics configuration.')
+        if not hasattr(profile.ctppsOpticalFunctions, 'scoringPlanes'):
+            raise AttributeError('Failed to retrieve the list of scoring planes from the optics configuration.')
+        for crossing_angle_functions in profile.ctppsOpticalFunctions.opticalFunctions:
+            if hasattr(crossing_angle_functions, 'fileName') and hasattr(crossing_angle_functions, 'xangle'):
+                self.worker.addCrossingAngleOpticalFunctions(float(crossing_angle_functions.xangle.value()),
+                                                             str(crossing_angle_functions.fileName.value()))
+        for scoring_plane in profile.ctppsOpticalFunctions.scoringPlanes:
+            if hasattr(scoring_plane, 'rpId') and hasattr(scoring_plane, 'z') and hasattr(scoring_plane, 'dirName'):
+                self.worker.addScoringPlane(int(scoring_plane.rpId.value()),
+                                            float(scoring_plane.z.value()),
+                                            str(scoring_plane.dirName.value()))
+
+    def beginJob(self):
+        self.worker.initialise()
+        pass
+
+    def endJob(self):
+        pass
+
+    def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        self.out = wrappedOutputTree
+        self.out.branch("nProton_singleRP", "I")
+        self.out.branch("Proton_singleRP_arm", "F", lenVar="nProton_singleRP")
+        self.out.branch("Proton_singleRP_decRPId", "I", lenVar="nProton_singleRP")
+        self.out.branch("Proton_singleRP_rpType", "I", lenVar="nProton_singleRP")
+        self.out.branch("Proton_singleRP_x", "F", lenVar="nProton_singleRP")
+        self.out.branch("Proton_singleRP_y", "F", lenVar="nProton_singleRP")
+        self.out.branch("Proton_singleRP_time", "F", lenVar="nProton_singleRP")
+        self.out.branch("Proton_singleRP_timeUnc", "F", lenVar="nProton_singleRP")
+        self.out.branch("Proton_singleRP_xi", "F", lenVar="nProton_singleRP")
+        self.out.branch("Proton_singleRP_thetaX", "F", lenVar="nProton_singleRP")
+        self.out.branch("Proton_singleRP_thetaY", "F", lenVar="nProton_singleRP")
+
+    def endFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        pass
+
+    def analyze(self, event):
+        """process event, return True (go to next module) or False (fail, go to next event)"""
+
+        proton_candidates = []
+        genparts = Collection(event, "GenPart")
+        for part in genparts:
+            if part.pdgId == 2212 and (part.status == 1 or part.status > 83):
+                proton_candidates.append(part)
+            #if part.pdgId == 22 and part.status == 21:  # photon as incoming parton
+            #    photon_mom = ROOT.TLorentzVector(part.pt * math.cos(part.phi), part.pt * math.sin(part.phi), 0., part.mass)
+        if len(proton_candidates) == 0:
+            return False
+
+        nProton_singleRP = 0
+        Proton_singleRP_arm = []
+        Proton_singleRP_decRPId = []
+        Proton_singleRP_rpType = []
+        Proton_singleRP_x = []
+        Proton_singleRP_y = []
+        Proton_singleRP_time = []
+        Proton_singleRP_timeUnc = []
+        Proton_singleRP_xi = []
+        Proton_singleRP_thetaX = []
+        Proton_singleRP_thetaY = []
+
+        for proton in proton_candidates:
+            proton_mom = ROOT.TLorentzVector()
+            proton_mom.SetPtEtaPhiM(proton.pt, proton.eta, proton.phi, proton.mass)
+            xi = 1. - proton_mom.Pz() / self.beam_energy  #FIXME
+            for track in self.worker.computeProton(ROOT.TLorentzVector(), proton_mom):
+                detid = ROOT.CTPPSDetId(track.rpId())
+                print(track.x())
+                nProton_singleRP += 1
+                Proton_singleRP_arm.append(detid.arm())
+                Proton_singleRP_decRPId.append(100 * detid.arm() + 10 * detid.station() + detid.rp())
+                Proton_singleRP_rpType.append(0)  #FIXME
+                Proton_singleRP_x.append(track.x())
+                Proton_singleRP_y.append(track.y())
+                Proton_singleRP_time.append(track.time())
+                Proton_singleRP_timeUnc.append(track.timeUnc())
+                Proton_singleRP_xi.append(xi)
+                Proton_singleRP_thetaX.append(0.)  #FIXME
+                Proton_singleRP_thetaY.append(0.)  #FIXME
+
+        self.out.fillBranch("nProton_singleRP", nProton_singleRP)
+        self.out.fillBranch("Proton_singleRP_arm", Proton_singleRP_arm)
+        self.out.fillBranch("Proton_singleRP_decRPId", Proton_singleRP_decRPId)
+        self.out.fillBranch("Proton_singleRP_rpType", Proton_singleRP_rpType)
+        self.out.fillBranch("Proton_singleRP_x", Proton_singleRP_x)
+        self.out.fillBranch("Proton_singleRP_y", Proton_singleRP_y)
+        self.out.fillBranch("Proton_singleRP_time", Proton_singleRP_time)
+        self.out.fillBranch("Proton_singleRP_timeUnc", Proton_singleRP_timeUnc)
+        self.out.fillBranch("Proton_singleRP_xi", Proton_singleRP_xi)
+        self.out.fillBranch("Proton_singleRP_thetaX", Proton_singleRP_thetaX)
+        self.out.fillBranch("Proton_singleRP_thetaY", Proton_singleRP_thetaY)
+        return True
+
+
+# define modules using the syntax 'name = lambda : constructor' to avoid having them loaded when not needed
+directSimModuleConstr = lambda profile: NanoAODDirectSimProducer(profile)

--- a/SimPPS/DirectSimProducer/python/NanoAODDirectSimProducer.py
+++ b/SimPPS/DirectSimProducer/python/NanoAODDirectSimProducer.py
@@ -58,6 +58,14 @@ class NanoAODDirectSimProducer(Module):
         self.out.branch("PPSLocalTracks_singleRPProtonIdx", "F", lenVar="nPPSLocalTracks")
         self.out.branch("PPSLocalTracks_decRPId", "I", lenVar="nPPSLocalTracks")
         self.out.branch("PPSLocalTracks_rpType", "I", lenVar="nPPSLocalTracks")
+        self.out.branch("nProton_multiRP", "I")
+        self.out.branch("Proton_multiRP_arm", "F", lenVar="nProton_multiRP")
+        self.out.branch("Proton_multiRP_xi", "F", lenVar="nProton_multiRP")
+        self.out.branch("Proton_multiRP_thetaX", "F", lenVar="nProton_multiRP")
+        self.out.branch("Proton_multiRP_thetaY", "F", lenVar="nProton_multiRP")
+        self.out.branch("Proton_multiRP_t", "F", lenVar="nProton_multiRP")
+        self.out.branch("Proton_multiRP_time", "F", lenVar="nProton_multiRP")
+        self.out.branch("Proton_multiRP_timeUnc", "F", lenVar="nProton_multiRP")
         self.out.branch("nProton_singleRP", "I")
         self.out.branch("Proton_singleRP_arm", "F", lenVar="nProton_singleRP")
         self.out.branch("Proton_singleRP_decRPId", "I", lenVar="nProton_singleRP")
@@ -96,6 +104,14 @@ class NanoAODDirectSimProducer(Module):
         PPSLocalTracks_singleRPProtonIdx = []
         PPSLocalTracks_decRPId = []
         PPSLocalTracks_rpType = []
+        nProton_multiRP = 0
+        Proton_multiRP_arm = []
+        Proton_multiRP_xi = []
+        Proton_multiRP_thetaX = []
+        Proton_multiRP_thetaY = []
+        Proton_multiRP_t = []
+        Proton_multiRP_time = []
+        Proton_multiRP_timeUnc = []
         nProton_singleRP = 0
         Proton_singleRP_arm = []
         Proton_singleRP_decRPId = []
@@ -121,10 +137,12 @@ class NanoAODDirectSimProducer(Module):
                 PPSLocalTracks_y.append(track.y())
                 PPSLocalTracks_time.append(track.time())
                 PPSLocalTracks_timeUnc.append(track.timeUnc())
-                PPSLocalTracks_multiRPProtonIdx.append(0.)   #FIXME
-                PPSLocalTracks_singleRPProtonIdx.append(nPPSLocalTracks)
+                PPSLocalTracks_multiRPProtonIdx.append(nProton_multiRP)
+                PPSLocalTracks_singleRPProtonIdx.append(nProton_singleRP)
                 PPSLocalTracks_decRPId.append(dec_detid)
                 PPSLocalTracks_rpType.append(rp_type)
+                # TODO: multi-RP proton objects
+                # for now, single-RP protons are assumed to be a clone of local tracks
                 nProton_singleRP += 1
                 Proton_singleRP_arm.append(detid.arm())
                 Proton_singleRP_decRPId.append(dec_detid)
@@ -146,6 +164,14 @@ class NanoAODDirectSimProducer(Module):
         self.out.fillBranch("PPSLocalTracks_singleRPProtonIdx", PPSLocalTracks_singleRPProtonIdx)
         self.out.fillBranch("PPSLocalTracks_decRPId", PPSLocalTracks_decRPId)
         self.out.fillBranch("PPSLocalTracks_rpType", PPSLocalTracks_rpType)
+        self.out.fillBranch("nProton_multiRP", nProton_multiRP)
+        self.out.fillBranch("Proton_multiRP_arm", Proton_multiRP_arm)
+        self.out.fillBranch("Proton_multiRP_xi", Proton_multiRP_xi)
+        self.out.fillBranch("Proton_multiRP_thetaX", Proton_multiRP_thetaX)
+        self.out.fillBranch("Proton_multiRP_thetaY", Proton_multiRP_thetaY)
+        self.out.fillBranch("Proton_multiRP_t", Proton_multiRP_t)
+        self.out.fillBranch("Proton_multiRP_time", Proton_multiRP_time)
+        self.out.fillBranch("Proton_multiRP_timeUnc", Proton_multiRP_timeUnc)
         self.out.fillBranch("nProton_singleRP", nProton_singleRP)
         self.out.fillBranch("Proton_singleRP_arm", Proton_singleRP_arm)
         self.out.fillBranch("Proton_singleRP_decRPId", Proton_singleRP_decRPId)

--- a/SimPPS/DirectSimProducer/src/DirectSimulator.cc
+++ b/SimPPS/DirectSimProducer/src/DirectSimulator.cc
@@ -1,0 +1,179 @@
+/****************************************************************************
+ * Authors:
+ *   Jan Kašpar
+ *   Laurent Forthomme
+ ****************************************************************************/
+
+#include <CLHEP/Random/RandFlat.h>
+#include <CLHEP/Random/RandGauss.h>
+#include <CLHEP/Units/GlobalPhysicalConstants.h>
+#include <HepMC/SimpleVector.h>
+
+#include "CondFormats/PPSObjects/interface/LHCInterpolatedOpticalFunctionsSetCollection.h"
+#include "CondFormats/PPSObjects/interface/CTPPSBeamParameters.h"
+#include "CondFormats/RunInfo/interface/LHCInfo.h"
+#include "CondFormats/PPSObjects/interface/PPSDirectSimulationData.h"
+#include "DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h"
+#include "SimPPS/DirectSimProducer/interface/DirectSimulator.h"
+
+DirectSimulator::DirectSimulator(const edm::ParameterSet& iConfig)
+    : useEmpiricalApertures_(iConfig.getParameter<bool>("useEmpiricalApertures")),
+      produceHitsRelativeToBeam_(iConfig.getParameter<bool>("produceHitsRelativeToBeam")),
+      verbosity_(iConfig.getUntrackedParameter<unsigned int>("verbosity", 0)) {}
+
+void DirectSimulator::setLHCInfo(const LHCInfo& lhc_info) { crossing_angle_ = lhc_info.crossingAngle(); }
+
+void DirectSimulator::setBeamParameters(const CTPPSBeamParameters& beam_parameters) {
+  beamline_parameters_ = {
+      {{.beam_momentum = beam_parameters.getBeamMom45(), .half_crossing_angle_x = beam_parameters.getHalfXangleX45()},
+       {.beam_momentum = beam_parameters.getBeamMom56(), .half_crossing_angle_x = beam_parameters.getHalfXangleX56()}}};
+}
+
+void DirectSimulator::setDirectSimulationData(const PPSDirectSimulationData& data) {
+  empiricalAperture45_ = std::make_unique<TF2>("empiricalAperture45", data.getEmpiricalAperture45().c_str());
+  empiricalAperture56_ = std::make_unique<TF2>("empiricalAperture56", data.getEmpiricalAperture56().c_str());
+  if (useTrackingEfficiencyPerRP_)  // load the efficiency maps
+    efficiencyMapsPerRP_ = data.loadEffeciencyHistogramsPerRP();
+}
+
+bool DirectSimulator::operator()(const std::array<double, 4>& vtx_cms /*mm*/,
+                                 const std::array<double, 4>& mom_cms,
+                                 std::map<CTPPSDetId, DirectSimulator::Parameters>& out_params) const {
+  out_params.clear();
+  if (!optical_functions_)
+    throw cms::Exception("DirectSimulator")
+        << "Optical functions collection was not provided to the direct simulator algorithm.";
+
+  std::stringstream ssLog;
+  // transformation to LHC/TOTEM convention
+  const auto vtx_lhc = HepMC::FourVector(-vtx_cms.at(0), vtx_cms.at(1), -vtx_cms.at(2), vtx_cms.at(3)),
+             mom_lhc = HepMC::FourVector(-mom_cms.at(0), mom_cms.at(1), -mom_cms.at(2), mom_cms.at(3));
+
+  // determine the LHC arm and related parameters
+  unsigned int arm = 3;
+  const std::unique_ptr<TF2>* empiricalAperture{nullptr};
+  if (mom_lhc.z() < 0) {  // sector 45
+    arm = 0;
+    empiricalAperture = &empiricalAperture45_;
+  } else {  // sector 56
+    arm = 1;
+    empiricalAperture = &empiricalAperture56_;
+  }
+
+  // calculate kinematics for optics parametrisation
+  const double p = mom_lhc.rho(),  /// horizontal component of proton momentum: p_x = th_x * (1-xi) * p_nom
+      xi = 1. -
+           p / beamline_parameters_.at(arm)
+                   .beam_momentum;  /// xi is positive for diffractive protons, thus proton momentum p = (1-xi) * p_nom
+  const double th_x_phys = mom_lhc.x() / p, th_y_phys = mom_lhc.y() / p;
+  const double vtx_lhc_eff_x = vtx_lhc.x() - vtx_lhc.z() * (mom_lhc.x() / mom_lhc.z() +
+                                                            beamline_parameters_.at(arm).half_crossing_angle_x),
+               vtx_lhc_eff_y = vtx_lhc.y() - vtx_lhc.z() * (mom_lhc.y() / mom_lhc.z());
+
+  if (verbosity_)
+    ssLog << "simu: xi = " << xi << ", th_x_phys = " << th_x_phys << ", th_y_phys = " << th_y_phys
+          << ", vtx_lhc_eff_x = " << vtx_lhc_eff_x << ", vtx_lhc_eff_y = " << vtx_lhc_eff_y << std::endl;
+
+  // check empirical aperture
+  if (empiricalAperture && useEmpiricalApertures_) {
+    (*empiricalAperture)->SetParameter("xi", xi);
+    (*empiricalAperture)->SetParameter("xangle", crossing_angle_);
+    if (const double th_x_th = (*empiricalAperture)->EvalPar(nullptr); th_x_th > th_x_phys) {
+      if (verbosity_) {
+        ssLog << "stop because of empirical apertures";
+        edm::LogInfo("DirectSimulator") << ssLog.str();
+      }
+      return false;
+    }
+  }
+
+  // transport the proton into each pot/scoring plane
+  for (const auto& [detid, optical_function] : *optical_functions_) {
+    const CTPPSDetId rpId(detid);
+    if (rpId.arm() != arm)  // first check the arm
+      continue;
+
+    if (verbosity_)
+      ssLog << "  RP " << rpId.arm() * 100 + rpId.station() * 10 + rpId.rp() << std::endl;
+
+    // transport proton
+    LHCInterpolatedOpticalFunctionsSet::Kinematics k_in = {vtx_lhc_eff_x * 1.e-1,  // conversions: mm -> cm
+                                                           th_x_phys,
+                                                           vtx_lhc_eff_y * 1.e-1,  // conversions: mm -> cm
+                                                           th_y_phys,
+                                                           xi},
+                                                   k_out;
+    optical_function.transport(k_in, k_out, true);
+
+    Parameters scoring_parameters{
+        .ax = k_out.th_x,
+        .ay = k_out.th_y,
+        .bx = k_out.x * 1.e1,                            // conversion: cm -> mm
+        .by = k_out.y * 1.e1,                            // conversion: cm -> mm
+        .z = optical_function.getScoringPlaneZ() * 1.e1  // conversion: cm -> mm
+    };
+
+    if (produceHitsRelativeToBeam_) {  // if needed, subtract beam position and angle
+      LHCInterpolatedOpticalFunctionsSet::Kinematics k_be_in = {0., 0., 0., 0., 0.}, k_be_out;
+      optical_function.transport(k_be_in, k_be_out, true);  // determine beam position
+      scoring_parameters.ax -= k_be_out.th_x;
+      scoring_parameters.ay -= k_be_out.th_y;
+      scoring_parameters.bx -= k_be_out.x * 1.e1;  // conversion: cm -> mm
+      scoring_parameters.by -= k_be_out.y * 1.e1;  // conversion: cm -> mm
+    }
+
+    if (verbosity_)
+      ssLog << "    proton transported: "
+            << "a_x = " << scoring_parameters.ax << " rad, "
+            << "a_y = " << scoring_parameters.ay << " rad, "
+            << "b_x = " << scoring_parameters.bx << " mm, "
+            << "b_y = " << scoring_parameters.by << " mm, "
+            << "z = " << scoring_parameters.z << " mm" << std::endl;
+
+    // RP type
+    const bool isTrackingRP =
+                   rpId.subdetId() == CTPPSDetId::sdTrackingStrip || rpId.subdetId() == CTPPSDetId::sdTrackingPixel,
+               isTimingRP = rpId.subdetId() == CTPPSDetId::sdTimingDiamond;
+
+    // apply per-RP efficiency
+    if ((useTimingEfficiencyPerRP_ && isTimingRP) || (useTrackingEfficiencyPerRP_ && isTrackingRP)) {
+      if (const auto it = efficiencyMapsPerRP_.find(rpId); it != efficiencyMapsPerRP_.end()) {
+        const double r = CLHEP::RandFlat::shoot(random_engine_, 0., 1.);
+        auto* effMap = it->second.get();
+        const double eff = effMap->GetBinContent(effMap->FindBin(scoring_parameters.bx, scoring_parameters.by));
+        if (r > eff) {
+          if (verbosity_)
+            ssLog << "    stop due to per-RP efficiency" << std::endl;
+          continue;
+        }
+      }
+    }
+    out_params[rpId] = scoring_parameters;
+  }
+
+  if (verbosity_)
+    edm::LogInfo("DirectSimulator") << ssLog.str();
+  return true;
+}
+
+void DirectSimulator::produceLiteTracks(const std::map<CTPPSDetId, Parameters>& simulated_parameters,
+                                        std::vector<CTPPSLocalTrackLite>& tracks) const {
+  for (const auto& [detid, scoring_parameters] : simulated_parameters)
+    tracks.emplace_back(detid.rawId(),
+                        scoring_parameters.bx,
+                        0.,
+                        scoring_parameters.by,
+                        0.,
+                        0.,
+                        0.,
+                        0.,
+                        0.,
+                        0.,
+                        CTPPSpixelLocalTrackReconstructionInfo::invalid,
+                        0,
+                        0.,
+                        0.);
+}

--- a/SimPPS/DirectSimProducer/src/NanoAODDirectSimulator.cc
+++ b/SimPPS/DirectSimProducer/src/NanoAODDirectSimulator.cc
@@ -1,0 +1,136 @@
+/****************************************************************************
+ * Authors:
+ *   Laurent Forthomme
+ ****************************************************************************/
+
+#include "CondFormats/DataRecord/interface/CTPPSOpticsRcd.h"
+#include "CondFormats/PPSObjects/interface/LHCOpticalFunctionsSetCollection.h"
+#include "DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h"
+#include "FWCore/Framework/interface/SourceFactory.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "SimPPS/DirectSimProducer/interface/NanoAODDirectSimulator.h"
+
+class CTPPSOpticalFunctionsESSource;
+
+NanoAODDirectSimulator::NanoAODDirectSimulator() {
+  auto params = edm::ParameterSet{};
+  params.addParameter<bool>("useEmpiricalApertures", false);
+  params.addParameter<bool>("produceHitsRelativeToBeam", false);
+  params.addUntrackedParameter<unsigned int>("verbosity", 0);
+  simulator_ = std::make_unique<DirectSimulator>(params);
+}
+
+void NanoAODDirectSimulator::initialise() {
+  buildInterpolatedOpticalFunctions();
+  simulator_->setOpticalFunctions(interpolated_optical_functions_);
+
+  std::cout << "aha" << std::endl;
+}
+
+void NanoAODDirectSimulator::addScoringPlane(unsigned int detid, double zpos, const std::string& dir_name) {
+  scoring_planes_.emplace_back(ScoringPlaneInfo{.rp_id = detid, .z_position = zpos, .directory_name = dir_name});
+}
+
+void NanoAODDirectSimulator::addCrossingAngleOpticalFunctions(double crossing_angle, const std::string& filename) {
+  optical_functions_files_[crossing_angle] = filename;
+}
+
+void NanoAODDirectSimulator::setBeamEnergy(double beam_energy) { lhc_info_.setEnergy(beam_energy); }
+
+void NanoAODDirectSimulator::setBetaStar(double beta_ast) { lhc_info_.setBetaStar(beta_ast); }
+
+void NanoAODDirectSimulator::setCrossingAngle(double crossing_angle) { lhc_info_.setCrossingAngle(crossing_angle); }
+
+std::vector<CTPPSLocalTrackLite> NanoAODDirectSimulator::computeProton(const TLorentzVector& vtx_cms /*mm*/,
+                                                                       const TLorentzVector& mom_cms) const {
+  std::vector<CTPPSLocalTrackLite> out_tracks;
+  std::map<CTPPSDetId, DirectSimulator::Parameters> simulated_parameters;
+  if (!(*simulator_)({{vtx_cms.X(), vtx_cms.Y(), vtx_cms.Z(), vtx_cms.T()}},
+                     {{mom_cms.Px(), mom_cms.Py(), mom_cms.Pz(), mom_cms.E()}},
+                     simulated_parameters)) {
+    std::cout << "Failed to propagate a proton to the pots." << std::endl;
+    return out_tracks;
+  }
+  simulator_->produceLiteTracks(simulated_parameters, out_tracks);
+  return out_tracks;
+}
+
+struct LHCOpticalFunctionsSetBuilder : LHCOpticalFunctionsSet {
+  explicit LHCOpticalFunctionsSetBuilder(double z,
+                                         const std::vector<double>& xi_values,
+                                         const std::vector<std::vector<double>>& fcn_values) {
+    m_z = z, m_xi_values = xi_values, m_fcn_values = fcn_values;
+  }
+};
+
+void NanoAODDirectSimulator::buildInterpolatedOpticalFunctions() {
+  const auto cms_data_path = std::filesystem::path(getenv("CMSSW_DATA_PATH"));
+  LHCOpticalFunctionsSetCollection optical_functions;
+  for (const auto& [xangle, filename] : optical_functions_files_) {
+    auto& crossing_angle_functions = optical_functions[xangle];
+    for (const auto& [rp_id, z_position, directory_name] : scoring_planes_)
+      crossing_angle_functions[rp_id] = LHCOpticalFunctionsSet(
+          cms_data_path / "data-CalibPPS-ESProducers/V01-05-00" / filename, directory_name, z_position);
+  }
+  if (optical_functions.size() == 1)
+    for (const auto& [rpId, rp_optical_functions] : optical_functions.begin()->second) {
+      interpolated_optical_functions_[rpId] = LHCInterpolatedOpticalFunctionsSet(rp_optical_functions);
+      interpolated_optical_functions_[rpId].initializeSplines();
+    }
+  else {
+    const auto first_crossing_angle = optical_functions.begin()->first,
+               last_crossing_angle = optical_functions.rbegin()->first;
+    if (lhc_info_.crossingAngle() < first_crossing_angle || lhc_info_.crossingAngle() > last_crossing_angle)
+      throw cms::Exception("NanoAODDirectSimulator")
+          << "Crossing angle " << lhc_info_.crossingAngle() << " is not within acceptable range ["
+          << first_crossing_angle << ", " << last_crossing_angle << "].";
+    auto it_low = optical_functions.begin(), it_high = it_low;
+    for (; it_low != optical_functions.end(); ++it_low) {
+      if (it_high = std::next(it_low); it_high == optical_functions.end())
+        break;
+      if (it_low->first <= lhc_info_.crossingAngle() && it_high->first >= lhc_info_.crossingAngle())
+        break;
+    }
+    const auto& [xangle1, scoring_planes_low] = *it_low;
+    const auto& [xangle2, scoring_planes_high] = *it_high;
+
+    // do the interpolation RP by RP
+    for (const auto& [rpId, optical_functions_low] : scoring_planes_low) {
+      if (!scoring_planes_high.count(rpId))
+        throw cms::Exception("NanoAODDirectSimulator") << "RP mismatch between scoring planes 1 and 2.";
+
+      const auto& optical_functions_high = scoring_planes_high.at(rpId);
+
+      const size_t num_xi_vals = optical_functions_low.getXiValues().size();
+      if (optical_functions_high.getXiValues().size() != num_xi_vals)
+        throw cms::Exception("NanoAODDirectSimulator") << "Size mismatch between scoring planes 1 and 2.";
+
+      std::vector<double> xi_values;
+      std::vector<std::vector<double>> fcn_values;
+      xi_values.resize(num_xi_vals);
+      fcn_values.resize(LHCInterpolatedOpticalFunctionsSet::nFunctions);
+      for (size_t fi = 0; fi < optical_functions_low.getFcnValues().size(); ++fi) {
+        fcn_values[fi].resize(num_xi_vals);
+        for (size_t pi = 0; pi < num_xi_vals; ++pi) {
+          xi_values[pi] = optical_functions_low.getXiValues()[pi];
+          if (const auto xi_control = optical_functions_high.getXiValues()[pi];
+              std::fabs(xi_values[pi] - xi_control) > 1e-6)
+            throw cms::Exception("NanoAODDirectSimulator") << "xi mismatch between scoring planes 1 and 2.";
+          const auto v1 = optical_functions_low.getFcnValues()[fi][pi],
+                     v2 = optical_functions_high.getFcnValues()[fi][pi];
+          fcn_values[fi][pi] = v1 + (v2 - v1) / (xangle2 - xangle1) * (lhc_info_.crossingAngle() - xangle1);
+        }
+      }
+      interpolated_optical_functions_[rpId] = LHCInterpolatedOpticalFunctionsSet(
+          LHCOpticalFunctionsSetBuilder(optical_functions_low.getScoringPlaneZ(), xi_values, fcn_values));
+      interpolated_optical_functions_[rpId].initializeSplines();
+    }
+  }
+  /*const auto optical_functions_source =
+      edm::eventsetup::SourcePluginFactory::get()->create("ctppsOpticalFunctionsESSource");
+  CTPPSOpticsRcd optics_rcd{};
+  const auto optical_functions = optical_functions_source->addTo();*/
+
+  /*for (const auto& xangle) {
+  }*/
+}

--- a/SimPPS/DirectSimProducer/src/NanoAODDirectSimulator.cc
+++ b/SimPPS/DirectSimProducer/src/NanoAODDirectSimulator.cc
@@ -3,28 +3,27 @@
  *   Laurent Forthomme
  ****************************************************************************/
 
-#include "CondFormats/DataRecord/interface/CTPPSOpticsRcd.h"
 #include "CondFormats/PPSObjects/interface/LHCOpticalFunctionsSetCollection.h"
 #include "DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h"
 #include "FWCore/Framework/interface/SourceFactory.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimPPS/DirectSimProducer/interface/NanoAODDirectSimulator.h"
 
-class CTPPSOpticalFunctionsESSource;
+NanoAODDirectSimulator::NanoAODDirectSimulator() {}
 
-NanoAODDirectSimulator::NanoAODDirectSimulator() {
+void NanoAODDirectSimulator::initialise() {
   auto params = edm::ParameterSet{};
   params.addParameter<bool>("useEmpiricalApertures", false);
   params.addParameter<bool>("produceHitsRelativeToBeam", false);
-  params.addUntrackedParameter<unsigned int>("verbosity", 0);
+  params.addUntrackedParameter<unsigned int>("verbosity", verbosity_);
   simulator_ = std::make_unique<DirectSimulator>(params);
-}
 
-void NanoAODDirectSimulator::initialise() {
+  simulator_->setBeamParameters(beam_parameters_);
+  simulator_->setLHCInfo(lhc_info_);
+
   buildInterpolatedOpticalFunctions();
   simulator_->setOpticalFunctions(interpolated_optical_functions_);
-
-  std::cout << "aha" << std::endl;
 }
 
 void NanoAODDirectSimulator::addScoringPlane(unsigned int detid, double zpos, const std::string& dir_name) {
@@ -35,11 +34,23 @@ void NanoAODDirectSimulator::addCrossingAngleOpticalFunctions(double crossing_an
   optical_functions_files_[crossing_angle] = filename;
 }
 
-void NanoAODDirectSimulator::setBeamEnergy(double beam_energy) { lhc_info_.setEnergy(beam_energy); }
+void NanoAODDirectSimulator::setBeamEnergy(double beam_energy) {
+  lhc_info_.setEnergy(beam_energy);
+  beam_parameters_.setBeamMom45(beam_energy);  //FIXME symmetric for now
+  beam_parameters_.setBeamMom56(beam_energy);
+}
 
-void NanoAODDirectSimulator::setBetaStar(double beta_ast) { lhc_info_.setBetaStar(beta_ast); }
+void NanoAODDirectSimulator::setBetaStar(double beta_ast) {
+  lhc_info_.setBetaStar(beta_ast);
+  beam_parameters_.setBetaStarX45(beta_ast);  //FIXME symmetric for now
+  beam_parameters_.setBetaStarX56(beta_ast);
+}
 
-void NanoAODDirectSimulator::setCrossingAngle(double crossing_angle) { lhc_info_.setCrossingAngle(crossing_angle); }
+void NanoAODDirectSimulator::setCrossingAngle(double crossing_angle) {
+  lhc_info_.setCrossingAngle(crossing_angle);
+  beam_parameters_.setHalfXangleX45(0.5 * crossing_angle);  //FIXME symmetric for now
+  beam_parameters_.setHalfXangleX56(0.5 * crossing_angle);
+}
 
 std::vector<CTPPSLocalTrackLite> NanoAODDirectSimulator::computeProton(const TLorentzVector& vtx_cms /*mm*/,
                                                                        const TLorentzVector& mom_cms) const {
@@ -48,13 +59,14 @@ std::vector<CTPPSLocalTrackLite> NanoAODDirectSimulator::computeProton(const TLo
   if (!(*simulator_)({{vtx_cms.X(), vtx_cms.Y(), vtx_cms.Z(), vtx_cms.T()}},
                      {{mom_cms.Px(), mom_cms.Py(), mom_cms.Pz(), mom_cms.E()}},
                      simulated_parameters)) {
-    std::cout << "Failed to propagate a proton to the pots." << std::endl;
+    edm::LogWarning("NanoAODDirectSimulator") << "Failed to propagate a proton to the pots." << std::endl;
     return out_tracks;
   }
   simulator_->produceLiteTracks(simulated_parameters, out_tracks);
   return out_tracks;
 }
 
+/// Helper to gain access to protected members of the LHCOpticalFunctionsSet object
 struct LHCOpticalFunctionsSetBuilder : LHCOpticalFunctionsSet {
   explicit LHCOpticalFunctionsSetBuilder(double z,
                                          const std::vector<double>& xi_values,
@@ -72,12 +84,13 @@ void NanoAODDirectSimulator::buildInterpolatedOpticalFunctions() {
       crossing_angle_functions[rp_id] = LHCOpticalFunctionsSet(
           cms_data_path / "data-CalibPPS-ESProducers/V01-05-00" / filename, directory_name, z_position);
   }
-  if (optical_functions.size() == 1)
+  if (optical_functions.size() == 1)  // trivial case: pick this set
+    //TODO: introduce some checks on the crossing angle value
     for (const auto& [rpId, rp_optical_functions] : optical_functions.begin()->second) {
       interpolated_optical_functions_[rpId] = LHCInterpolatedOpticalFunctionsSet(rp_optical_functions);
       interpolated_optical_functions_[rpId].initializeSplines();
     }
-  else {
+  else {  // have to extrapolate from the two surrounding crossing angle values
     const auto first_crossing_angle = optical_functions.begin()->first,
                last_crossing_angle = optical_functions.rbegin()->first;
     if (lhc_info_.crossingAngle() < first_crossing_angle || lhc_info_.crossingAngle() > last_crossing_angle)
@@ -91,34 +104,30 @@ void NanoAODDirectSimulator::buildInterpolatedOpticalFunctions() {
       if (it_low->first <= lhc_info_.crossingAngle() && it_high->first >= lhc_info_.crossingAngle())
         break;
     }
-    const auto& [xangle1, scoring_planes_low] = *it_low;
-    const auto& [xangle2, scoring_planes_high] = *it_high;
+    const auto& [xangle_low, scoring_planes_low] = *it_low;
+    const auto& [xangle_high, scoring_planes_high] = *it_high;
 
-    // do the interpolation RP by RP
-    for (const auto& [rpId, optical_functions_low] : scoring_planes_low) {
+    for (const auto& [rpId, optical_functions_low] : scoring_planes_low) {  // do the interpolation RP by RP
       if (!scoring_planes_high.count(rpId))
         throw cms::Exception("NanoAODDirectSimulator") << "RP mismatch between scoring planes 1 and 2.";
 
-      const auto& optical_functions_high = scoring_planes_high.at(rpId);
-
       const size_t num_xi_vals = optical_functions_low.getXiValues().size();
+      const auto& optical_functions_high = scoring_planes_high.at(rpId);
       if (optical_functions_high.getXiValues().size() != num_xi_vals)
         throw cms::Exception("NanoAODDirectSimulator") << "Size mismatch between scoring planes 1 and 2.";
 
-      std::vector<double> xi_values;
-      std::vector<std::vector<double>> fcn_values;
-      xi_values.resize(num_xi_vals);
-      fcn_values.resize(LHCInterpolatedOpticalFunctionsSet::nFunctions);
+      std::vector<double> xi_values(num_xi_vals);
+      std::vector<std::vector<double>> fcn_values(LHCInterpolatedOpticalFunctionsSet::nFunctions);
       for (size_t fi = 0; fi < optical_functions_low.getFcnValues().size(); ++fi) {
         fcn_values[fi].resize(num_xi_vals);
-        for (size_t pi = 0; pi < num_xi_vals; ++pi) {
+        for (size_t pi = 0; pi < num_xi_vals; ++pi) {  // linear extrapolation of each xi-dependent function
           xi_values[pi] = optical_functions_low.getXiValues()[pi];
           if (const auto xi_control = optical_functions_high.getXiValues()[pi];
               std::fabs(xi_values[pi] - xi_control) > 1e-6)
             throw cms::Exception("NanoAODDirectSimulator") << "xi mismatch between scoring planes 1 and 2.";
           const auto v1 = optical_functions_low.getFcnValues()[fi][pi],
                      v2 = optical_functions_high.getFcnValues()[fi][pi];
-          fcn_values[fi][pi] = v1 + (v2 - v1) / (xangle2 - xangle1) * (lhc_info_.crossingAngle() - xangle1);
+          fcn_values[fi][pi] = v1 + (v2 - v1) / (xangle_high - xangle_low) * (lhc_info_.crossingAngle() - xangle_low);
         }
       }
       interpolated_optical_functions_[rpId] = LHCInterpolatedOpticalFunctionsSet(
@@ -126,11 +135,7 @@ void NanoAODDirectSimulator::buildInterpolatedOpticalFunctions() {
       interpolated_optical_functions_[rpId].initializeSplines();
     }
   }
+  //TODO: ideal case would be to retrieve these values from conditions database
   /*const auto optical_functions_source =
-      edm::eventsetup::SourcePluginFactory::get()->create("ctppsOpticalFunctionsESSource");
-  CTPPSOpticsRcd optics_rcd{};
-  const auto optical_functions = optical_functions_source->addTo();*/
-
-  /*for (const auto& xangle) {
-  }*/
+      edm::eventsetup::SourcePluginFactory::get()->create("ctppsOpticalFunctionsESSource");*/
 }

--- a/SimPPS/DirectSimProducer/src/classes.h
+++ b/SimPPS/DirectSimProducer/src/classes.h
@@ -1,0 +1,1 @@
+#include "SimPPS/DirectSimProducer/interface/NanoAODDirectSimulator.h"

--- a/SimPPS/DirectSimProducer/src/classes_def.xml
+++ b/SimPPS/DirectSimProducer/src/classes_def.xml
@@ -1,0 +1,5 @@
+<lcgdict>
+  <class name="NanoAODDirectSimulator" ClassVersion="2">
+    <version ClassVersion="2" checksum="3944969853"/>
+  </class>
+</lcgdict>

--- a/SimPPS/DirectSimProducer/src/classes_def.xml
+++ b/SimPPS/DirectSimProducer/src/classes_def.xml
@@ -1,5 +1,5 @@
 <lcgdict>
   <class name="NanoAODDirectSimulator" ClassVersion="2">
-    <version ClassVersion="2" checksum="3944969853"/>
+    <version ClassVersion="2" checksum="1570137886"/>
   </class>
 </lcgdict>

--- a/SimPPS/DirectSimProducer/test/test_NanoAOD_cfg.py
+++ b/SimPPS/DirectSimProducer/test/test_NanoAOD_cfg.py
@@ -1,0 +1,29 @@
+from PhysicsTools.NanoAODTools.postprocessing.framework.postprocessor import PostProcessor
+from SimPPS.DirectSimProducer.NanoAODDirectSimProducer import *
+from importlib import import_module
+import os
+import sys
+import ROOT
+
+#from SimPPS.DirectSimProducer.simPPS2018_cfi import *
+from SimPPS.DirectSimProducer.simPPS2022_cfi import *
+
+
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+
+#fnames = ["root://eoscms.cern.ch//eos/cms/store/user/cmsbuild/store/group/cat/datasets/NANOAODSIM/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/7B930101-EB91-4F4E-9B90-0861460DBD94.root"]
+#fnames = ["root://eoscms.cern.ch//eos/cms/store/data/Run2025A/HLTPhysics/NANOAOD/PromptReco-v2/000/391/312/00000/34d2039d-c580-4e19-bacc-3b6b115dc20c.root"]
+#fnames = ["root://eoscms.cern.ch//eos/cms/store/mc/Run3Summer23NanoAODv12/GGToMuMu_PT-25_Inel-El_13p6TeV_superchic/NANOAODSIM/NoPU_130X_mcRun3_2023_realistic_v14-v1/70000/83268898-0f98-443d-b080-bc6cc7d5b298.root"]
+fnames = ["root://eoscms.cern.ch//eos/cms/store/mc/Run3Winter22NanoAOD/GGToMuMu_Pt-25_El-El_13p6TeV-lpair/NANOAODSIM/122X_mcRun3_2021_realistic_v9-v3/30000/e29c388c-4a6d-46ac-abe4-4c8529361c24.root"]
+
+profile_2022_default.ctppsLHCInfo.xangle = 130.
+
+p = PostProcessor(outputDir=".",
+                  inputFiles=fnames,
+                  cut="",
+                  #modules=[directSimModuleConstr(profile_2018_postTS2)],
+                  modules=[directSimModuleConstr(profile_2022_default)],
+                  provenance=True,
+                  maxEntries=5000, #just read the first maxEntries events
+                  )
+p.run()

--- a/SimPPS/DirectSimProducer/test/test_NanoAOD_cfg.py
+++ b/SimPPS/DirectSimProducer/test/test_NanoAOD_cfg.py
@@ -22,7 +22,7 @@ p = PostProcessor(outputDir=".",
                   inputFiles=fnames,
                   cut="",
                   #modules=[directSimModuleConstr(profile_2018_postTS2)],
-                  modules=[directSimModuleConstr(profile_2022_default)],
+                  modules=[directSimModuleConstr(profile_2022_default, verbosity=1)],
                   provenance=True,
                   maxEntries=5000, #just read the first maxEntries events
                   )


### PR DESCRIPTION
#### PR description:

This PR strips the algorithmic part of the PPS direct simulation (currently embedded in a single EDProducer) to allow it to be reused in external toolsets.
The goal is to allow a "lite" version of this simulation to be run on NanoAOD-level collections.

#### PR validation:

The code compiles, runs, and gives 1-to-1 agreement for the standard `SimPPS/DirectSimProducer/test/test_miniAOD_cfg.py` configuration. Additionally, a new `SimPPS/DirectSimProducer/test/test_NanoAOD_cfg.py` test configuration is provided for a LPAIR NanoAOD sample generated centrally, allowing to produce NanoAOD-level collections from generator level information.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: N/A