### PR TITLE
Avoid test name clashes

### DIFF
--- a/FWIO/RNTupleTempTests/test/BuildFile.xml
+++ b/FWIO/RNTupleTempTests/test/BuildFile.xml
@@ -114,6 +114,6 @@
 <test name="TestRNTupleTempMissingDictionary" command="Run_MissingDictionary.sh"/>
 
 <test name="TestRNTupleTempProvenance" command ="provenance_test.sh"/>
-<test name="TestMaybeUninitializedIntProduct" command="cmsRun ${LOCALTOP}/src/FWIO/RNTupleTempTests/test/testMaybeUninitializedIntProductPart1_cfg.py &amp;&amp; cmsRun ${LOCALTOP}/src/FWIO/RNTupleTempTests/test/testMaybeUninitializedIntProductPart2_cfg.py"/>
+<test name="TestRNTupleTempMaybeUninitializedIntProduct" command="cmsRun ${LOCALTOP}/src/FWIO/RNTupleTempTests/test/testMaybeUninitializedIntProductPart1_cfg.py &amp;&amp; cmsRun ${LOCALTOP}/src/FWIO/RNTupleTempTests/test/testMaybeUninitializedIntProductPart2_cfg.py"/>
 
 <test name="TestRNTupleTempUnscheduledFailOnOutput" command="run_unscheduledFailOnOutput.sh"/>


### PR DESCRIPTION
#### PR description:

Changed name of test to avoid clashing with test in IOPool/

#### PR validation:

New test name is accessible.

resolves https://github.com/cms-sw/framework-team/issues/1795