### PR TITLE
Explicitly call rntuple::Writer::CommitDataset

### DIFF
--- a/FWIO/RNTupleTempOutput/src/RootOutputFile.cc
+++ b/FWIO/RNTupleTempOutput/src/RootOutputFile.cc
@@ -600,9 +600,10 @@ namespace edm::rntuple_temp {
     try {
       // close the file -- mfp
       // Just to play it safe, zero all pointers to objects in the TFile to be closed.
-      status = "closing RNTuples";
+      status = "closing RNTuple ";
       value = "";
       for (auto& treePointer : treePointers_) {
+        value = treePointer->name();
         treePointer->close();
         treePointer = nullptr;
       }

--- a/FWIO/RNTupleTempOutput/src/RootOutputRNTuple.cc
+++ b/FWIO/RNTupleTempOutput/src/RootOutputRNTuple.cc
@@ -212,6 +212,7 @@ explicitly pass the correct variable to `SetColumnRepresentatives`).
     // Just to play it safe, zero all pointers to quantities in the file.
     auxBranches_.clear();
     producedBranches_.clear();
+    writer_->CommitDataset();
     writer_ = nullptr;   // propagate_const<T> has no reset() function
     filePtr_ = nullptr;  // propagate_const<T> has no reset() function
   }


### PR DESCRIPTION
#### PR description:

If an exception happens at the end, this should give us a clearer message instead of having an exception happen during a destructor.

#### PR validation:

Code compiles and framework unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/1706