### PR TITLE
rename dxy(z)Error to dxy(z)Sig as their are significances and not abs values [16.0.X]

### DIFF
--- a/HLTrigger/JetMET/plugins/HLTScoutingPFProducer.cc
+++ b/HLTrigger/JetMET/plugins/HLTScoutingPFProducer.cc
@@ -166,7 +166,7 @@ void HLTScoutingPFProducer::produce(edm::StreamID sid, edm::Event &iEvent, edm::
             break;
           ++index_counter;
         }
-        float normchi2{0}, dz{0}, dxy{0}, dzError{0}, dxyError{0}, trk_pt{0}, trk_eta{0}, trk_phi{0};
+        float normchi2{0}, dz{0}, dxy{0}, dzSig{0}, dxySig{0}, trk_pt{0}, trk_eta{0}, trk_phi{0};
         uint8_t lostInnerHits{0}, quality{0};
         if (doTrackVars_) {
           const auto *trk = cand.bestTrack();
@@ -187,11 +187,11 @@ void HLTScoutingPFProducer::produce(edm::StreamID sid, edm::Event &iEvent, edm::
               const reco::Vertex &pv = (*vertexCollection)[0];
 
               dz = trk->dz(pv.position());
-              dzError = MiniFloatConverter::reduceMantissaToNbitsRounding(dz / trk->dzError(), mantissaPrecision_);
+              dzSig = MiniFloatConverter::reduceMantissaToNbitsRounding(dz / trk->dzError(), mantissaPrecision_);
               dz = MiniFloatConverter::reduceMantissaToNbitsRounding(dz, mantissaPrecision_);
 
               dxy = trk->dxy(pv.position());
-              dxyError = MiniFloatConverter::reduceMantissaToNbitsRounding(dxy / trk->dxyError(), mantissaPrecision_);
+              dxySig = MiniFloatConverter::reduceMantissaToNbitsRounding(dxy / trk->dxyError(), mantissaPrecision_);
               dxy = MiniFloatConverter::reduceMantissaToNbitsRounding(dxy, mantissaPrecision_);
             }
           } else {
@@ -206,8 +206,8 @@ void HLTScoutingPFProducer::produce(edm::StreamID sid, edm::Event &iEvent, edm::
                                       normchi2,
                                       dz,
                                       dxy,
-                                      dzError,
-                                      dxyError,
+                                      dzSig,
+                                      dxySig,
                                       lostInnerHits,
                                       quality,
                                       trk_pt,


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/49735

#### PR description:

In `HLTScoutingPFProducer.cc` the variables `dzError` and `dxyError` contain the displacement significance instead of the displacement error.
This PR simply renames the variables `dzError` -> `dzSig` and `dxyError` -> `dxySig`.
No changes are expected.

Note: The variables are supposed to be indeed the displacement significance, and not the displacement error, as it can be seen in the Run3ScoutingParticle [constructor](https://github.com/cms-sw/cmssw/blob/CMSSW_16_0_0_pre4/DataFormats/Scouting/interface/Run3ScoutingParticle.h#L12-L27).

#### PR validation:

This is just a renaming, I simply checked that the PR compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of https://github.com/cms-sw/cmssw/pull/49735