### PR TITLE
Fix: remove dependencies of trackingNutple sequence for phase-2 HLT

### DIFF
--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -55,6 +55,7 @@ The offsets currently in use are:
 * 0.704: LST tracking (Phase-2 only), initialStep+HighPtTripletStep only, on GPU (if available)
 * 0.75: HLT phase-2 timing menu
 * 0.7501: HLT phase-2 tracking-only menu
+* 0.7502: HLT phase-2 menu, with tracking ntuple
 * 0.751: HLT phase-2 timing menu Alpaka variant
 * 0.7511: HLT phase-2 timing menu, with PixelTracks CA Extension
 * 0.752: HLT phase-2 timing menu ticl_v5 variant

--- a/Configuration/PyReleaseValidation/python/relval_Run4.py
+++ b/Configuration/PyReleaseValidation/python/relval_Run4.py
@@ -71,6 +71,7 @@ numWFIB.extend([prefixDet+234.703])  #LST tracking on CPU (initialStep+HighPtTri
 
 # Phase-2 HLT tests
 numWFIB.extend([prefixDet+34.7501])# HLTTrackingOnly75e33
+numWFIB.extend([prefixDet+34.7502])# HLTTrackingNtuple75e33
 numWFIB.extend([prefixDet+34.751]) # HLTTiming75e33, alpaka
 numWFIB.extend([prefixDet+34.7511])# HLTTiming75e33, phase2CAExtension
 numWFIB.extend([prefixDet+34.752]) # HLTTiming75e33, ticl_v5

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1943,6 +1943,63 @@ upgradeWFs['HLTTrackingOnly75e33'].step2 = {
     '--eventcontent':'FEVTDEBUGHLT,DQMIO'
 }
 
+class UpgradeWorkflow_HLT75e33TrackingNtuple(UpgradeWorkflow):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        # skip RECO, ALCA and HLT
+        if ('ALCA' in step) or ('Reco' in step) or ('HLT' in step):
+            stepDict[stepName][k] = None
+        elif 'DigiTrigger' in step:
+            # Add the aging customization
+            mergedStep = merge([self.step2, stepDict[step][k]])
+            if '--customise' in mergedStep:
+                mergedStep['--customise'] += ',SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000'
+            else:
+                mergedStep['--customise'] = 'SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000'
+            stepDict[stepName][k] = mergedStep
+        elif 'HARVEST' in step:
+                stepDict[stepName][k] = None
+        else:
+            stepDict[stepName][k] = merge([stepDict[step][k]])
+    def condition(self, fragment, stepList, key, hasHarvest):
+        fragments = ["TTbar_14","ZMM_14","ZEE_14","NuGun","SingleMu"]
+        return any(f in fragment for f in fragments) and 'Run4' in key
+
+upgradeWFs['HLTTrackingNtuple75e33'] = UpgradeWorkflow_HLT75e33TrackingNtuple(
+    steps = [
+        'Reco',
+        'RecoGlobal',
+        'RecoNano',
+        'DigiTrigger',
+        'ALCA',
+        'ALCAPhase2',
+        'RecoGlobalFakeHLT',
+        'HLT75e33',
+        'HARVESTGlobal',
+        'HARVESTGlobalFakeHLT',
+    ],
+    PU = [
+        'Reco',
+        'RecoGlobal',
+        'RecoNano',
+        'DigiTrigger',
+        'ALCA',
+        'ALCAPhase2',
+        'HARVESTGlobal',
+        'RecoGlobalFakeHLT',
+        'HLT75e33',
+        'HARVESTGlobal',
+        'HARVESTGlobalFakeHLT',
+    ],
+    suffix = '_HLT75e33TrackingNtuple',
+    offset = 0.7502,
+)
+upgradeWFs['HLTTrackingNtuple75e33'].step2 = {
+    '-s':'DIGI:pdigi_valid,DIGI2RAW,L1TrackTrigger,L1,L1P2GT,HLT:75e33,VALIDATION:@hltValidation',
+    '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
+    '--eventcontent':'FEVTDEBUGHLT,DQMIO',
+    '--customise' : 'Validation/RecoTrack/customiseTrackingNtuple.customiseTrackingNtupleHLT,Validation/RecoTrack/customiseTrackingNtuple.extendedContent'
+}
+
 upgradeWFs['HLTTiming75e33TiclV5'] = deepcopy(upgradeWFs['HLTTiming75e33'])
 upgradeWFs['HLTTiming75e33TiclV5'].suffix = '_HLT75e33TimingTiclV5'
 upgradeWFs['HLTTiming75e33TiclV5'].offset = 0.752

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -160,6 +160,7 @@ if __name__ == '__main__':
 
         'ph2_hlt' : [prefixDet+34.75,    # HLT phase-2 timing menu
                      prefixDet+34.7501,  # HLT phase-2 tracking-only menu
+                     prefixDet+34.7502,  # HLT phase-2 tracking menu with tracking ntuple
                      prefixDet+34.751,   # HLT phase-2 timing menu Alpaka variant
                      prefixDet+34.7511,  # HLT phase-2 timing menu Phase2CAExtension variant
                      prefixDet+34.752,   # HLT phase-2 timing menu ticl_v5 variant

--- a/Validation/RecoTrack/python/customiseTrackingNtuple.py
+++ b/Validation/RecoTrack/python/customiseTrackingNtuple.py
@@ -32,9 +32,8 @@ def customiseTrackingNtupleTool(process, isRECO = True, mergeIters = False):
     if not isRECO:
         if not hasattr(process,"hltMultiTrackValidation"):
             process.load("Validation.RecoTrack.HLTmultiTrackValidator_cff")
-        process.trackingNtupleSequence = process.hltMultiTrackValidation.copy()
+        process.trackingNtupleSequence = cms.Sequence(process.hltMultiTrackValidationTask)
         process.trackingNtupleSequence.insert(0,process.trackingParticlesIntime+process.simHitTPAssocProducer)
-        process.trackingNtupleSequence.remove(process.hltTrackValidator)
 
         if hasattr(process, "HLTIterativeTrackingIter02"):
             if not hasattr(process, "hltSiStripRecHits"):


### PR DESCRIPTION
### PR description:

As per title, this is to avoid that tracking ntuple for phase-2 HLT crashes, due to the missed removal of two modules added in PR #49517.
A dedicated workflow was added for testing, with offset 0.7502.

### PR validation:

Tested with `runTheMatrix.py -w upgrade -l 34434.7502`. 