### PR TITLE
Refactor of PortableCollections

### DIFF
--- a/CalibTracker/SiPixelESProducers/plugins/alpaka/SiPixelCablingSoAESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/alpaka/SiPixelCablingSoAESProducer.cc
@@ -50,7 +50,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       }
 
       auto geom = iRecord.getTransientHandle(geometryToken_);
-      SiPixelMappingHost product(pixelgpudetails::MAX_SIZE, cms::alpakatools::host());
+      SiPixelMappingHost product(cms::alpakatools::host(), pixelgpudetails::MAX_SIZE);
       std::vector<unsigned int> const& fedIds = cablingMap->fedIds();
       std::unique_ptr<SiPixelFedCablingTree> const& cabling = cablingMap->cablingTree();
 

--- a/CalibTracker/SiPixelESProducers/plugins/alpaka/SiPixelGainCalibrationForHLTSoAESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/alpaka/SiPixelGainCalibrationForHLTSoAESProducer.cc
@@ -51,7 +51,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     auto const& gains = iRecord.get(gainsToken_);
     auto const& geom = iRecord.get(geometryToken_);
 
-    auto product = std::make_unique<SiPixelGainCalibrationForHLTHost>(gains.data().size(), cms::alpakatools::host());
+    auto product = std::make_unique<SiPixelGainCalibrationForHLTHost>(cms::alpakatools::host(), gains.data().size());
 
     // bizzarre logic (looking for fist strip-det) don't ask
     auto const& dus = geom.detUnits();

--- a/CondFormats/HcalObjects/interface/HcalRecoParamWithPulseShapeT.h
+++ b/CondFormats/HcalObjects/interface/HcalRecoParamWithPulseShapeT.h
@@ -9,8 +9,8 @@ namespace hcal {
   template <typename TDev>
   class HcalRecoParamWithPulseShapeT {
   public:
-    using RecoParamCollection = PortableCollection<HcalRecoParamSoA, TDev>;
-    using PulseShapeCollection = PortableCollection<HcalPulseShapeSoA, TDev>;
+    using RecoParamCollection = PortableCollection<TDev, HcalRecoParamSoA>;
+    using PulseShapeCollection = PortableCollection<TDev, HcalPulseShapeSoA>;
 
     using PulseShapeConstElement = typename PulseShapeCollection::ConstView::const_element;
 
@@ -34,10 +34,10 @@ namespace hcal {
     };
 
     HcalRecoParamWithPulseShapeT(size_t recoSize, size_t pulseSize, TDev const& dev)
-        : recoParam_(recoSize, dev), pulseShape_(pulseSize, dev) {}
+        : recoParam_(dev, recoSize), pulseShape_(dev, pulseSize) {}
     template <typename TQueue, typename = std::enable_if_t<alpaka::isQueue<TQueue>>>
     HcalRecoParamWithPulseShapeT(size_t recoSize, size_t pulseSize, TQueue const& queue)
-        : recoParam_(recoSize, queue), pulseShape_(pulseSize, queue) {}
+        : recoParam_(queue, recoSize), pulseShape_(queue, pulseSize) {}
     HcalRecoParamWithPulseShapeT(RecoParamCollection reco, PulseShapeCollection pulse)
         : recoParam_(std::move(reco)), pulseShape_(std::move(pulse)) {}
 

--- a/DataFormats/Portable/interface/PortableCollectionCommon.h
+++ b/DataFormats/Portable/interface/PortableCollectionCommon.h
@@ -1,15 +1,26 @@
 #ifndef DataFormats_Portable_interface_PortableCollectionCommon_h
 #define DataFormats_Portable_interface_PortableCollectionCommon_h
 
-#include <array>
-#include <cstddef>
-#include <type_traits>
+#include <format>
+#include <limits>
+#include <stdexcept>
+#include <typeinfo>
+
+#include "FWCore/Utilities/interface/TypeDemangler.h"
 
 namespace portablecollection {
 
-  // concept to check if a Layout has a static member blocksNumber
-  template <class L>
-  concept hasBlocksNumber = requires { L::blocksNumber; };
+  template <std::integral Int>
+  constexpr int size_cast(Int input) {
+    if ((std::is_signed_v<Int> && input < 0) || input > std::numeric_limits<int>::max()) {
+      throw std::runtime_error(
+          std::format("Invalid input value for size of PortableCollection: cannot be narrowed to positive int32. "
+                      "Source type: {}, value: {} ",
+                      edm::typeDemangle(typeid(Int).name()),
+                      input));
+    }
+    return static_cast<int>(input);
+  }
 
 }  // namespace portablecollection
 

--- a/DataFormats/Portable/interface/PortableDeviceObject.h
+++ b/DataFormats/Portable/interface/PortableDeviceObject.h
@@ -12,7 +12,7 @@
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 
 // generic object in device memory
-template <typename T, typename TDev, typename = std::enable_if_t<alpaka::isDevice<TDev>>>
+template <typename TDev, typename T, typename = std::enable_if_t<alpaka::isDevice<TDev>>>
 class PortableDeviceObject {
   static_assert(not std::is_same_v<TDev, alpaka_common::DevHost>,
                 "Use PortableHostObject<T> instead of PortableDeviceObject<T, DevHost>");

--- a/DataFormats/Portable/interface/PortableObject.h
+++ b/DataFormats/Portable/interface/PortableObject.h
@@ -14,31 +14,31 @@
 namespace traits {
 
   // trait for a generic struct-based product
-  template <typename T, typename TDev, typename = std::enable_if_t<alpaka::isDevice<TDev>>>
+  template <typename TDev, typename T, typename = std::enable_if_t<alpaka::isDevice<TDev>>>
   struct PortableObjectTrait {
-    using ProductType = PortableDeviceObject<T, TDev>;
+    using ProductType = PortableDeviceObject<TDev, T>;
   };
 
   // specialise for host device
   template <typename T>
-  struct PortableObjectTrait<T, alpaka_common::DevHost> {
+  struct PortableObjectTrait<alpaka_common::DevHost, T> {
     using ProductType = PortableHostObject<T>;
   };
 
 }  // namespace traits
 
 // type alias for a generic struct-based product
-template <typename T, typename TDev, typename = std::enable_if_t<alpaka::isDevice<TDev>>>
-using PortableObject = typename traits::PortableObjectTrait<T, TDev>::ProductType;
+template <typename TDev, typename T, typename = std::enable_if_t<alpaka::isDevice<TDev>>>
+using PortableObject = typename traits::PortableObjectTrait<TDev, T>::ProductType;
 
 // define how to copy PortableObject between host and device
 namespace cms::alpakatools {
-  template <typename TProduct, typename TDevice>
+  template <typename TDevice, typename TProduct>
     requires alpaka::isDevice<TDevice>
-  struct CopyToHost<PortableDeviceObject<TProduct, TDevice>> {
+  struct CopyToHost<PortableDeviceObject<TDevice, TProduct>> {
     template <typename TQueue>
       requires alpaka::isQueue<TQueue>
-    static auto copyAsync(TQueue& queue, PortableDeviceObject<TProduct, TDevice> const& srcData) {
+    static auto copyAsync(TQueue& queue, PortableDeviceObject<TDevice, TProduct> const& srcData) {
       PortableHostObject<TProduct> dstData(queue);
       alpaka::memcpy(queue, dstData.buffer(), srcData.buffer());
       return dstData;
@@ -50,7 +50,7 @@ namespace cms::alpakatools {
     template <cms::alpakatools::NonCPUQueue TQueue>
     static auto copyAsync(TQueue& queue, PortableHostObject<TProduct> const& srcData) {
       using TDevice = typename alpaka::trait::DevType<TQueue>::type;
-      PortableDeviceObject<TProduct, TDevice> dstData(queue);
+      PortableDeviceObject<TDevice, TProduct> dstData(queue);
       alpaka::memcpy(queue, dstData.buffer(), srcData.buffer());
       return dstData;
     }

--- a/DataFormats/Portable/interface/alpaka/PortableCollection.h
+++ b/DataFormats/Portable/interface/alpaka/PortableCollection.h
@@ -14,7 +14,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   // generic SoA-based product in the device (that may be host) memory
   template <typename T>
-  using PortableCollection = ::PortableCollection<T, Device>;
+  using PortableCollection = ::PortableCollection<Device, T>;
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 

--- a/DataFormats/Portable/interface/alpaka/PortableObject.h
+++ b/DataFormats/Portable/interface/alpaka/PortableObject.h
@@ -14,7 +14,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   // generic struct-based product in the device (that may be host) memory
   template <typename T>
-  using PortableObject = ::PortableObject<T, Device>;
+  using PortableObject = ::PortableObject<Device, T>;
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 

--- a/DataFormats/Portable/test/alpaka/test_catch2_SoAMethods.dev.cc
+++ b/DataFormats/Portable/test/alpaka/test_catch2_SoAMethods.dev.cc
@@ -96,11 +96,11 @@ TEST_CASE("SoACustomizedMethods Alpaka", "[SoACustomizedMethods][Alpaka]") {
 
     constexpr unsigned int elems = 10;
 
-    PortableHostCollection<SoA> hostCollection(elems, cms::alpakatools::host());
+    PortableHostCollection<SoA> hostCollection(cms::alpakatools::host(), elems);
     auto h_view = hostCollection.view();
     const auto h_Constview = hostCollection.const_view();
 
-    PortableHostCollection<ResultSoA> hostResultCollection(elems, cms::alpakatools::host());
+    PortableHostCollection<ResultSoA> hostResultCollection(cms::alpakatools::host(), elems);
     auto h_result_view = hostResultCollection.view();
 
     // fill up
@@ -114,12 +114,12 @@ TEST_CASE("SoACustomizedMethods Alpaka", "[SoACustomizedMethods][Alpaka]") {
     }
     h_view.detectorType() = 42;
 
-    PortableCollection<SoA, Device> deviceCollection(elems, queue);
+    PortableCollection<Device, SoA> deviceCollection(queue, elems);
     auto d_view = deviceCollection.view();
     auto d_Constview = deviceCollection.const_view();
     alpaka::memcpy(queue, deviceCollection.buffer(), hostCollection.buffer());
 
-    PortableCollection<ResultSoA, Device> deviceResultCollection(elems, queue);
+    PortableCollection<Device, ResultSoA> deviceResultCollection(queue, elems);
     auto d_result_view = deviceResultCollection.view();
     alpaka::wait(queue);
 

--- a/DataFormats/Portable/test/alpaka/test_catch2_heterogeneousDeepCopy.dev.cc
+++ b/DataFormats/Portable/test/alpaka/test_catch2_heterogeneousDeepCopy.dev.cc
@@ -86,8 +86,8 @@ TEST_CASE("Deep copy from SoA Generic View") {
     const std::size_t elems = 10;
 
     // Portable Collections
-    PortableCollection<SoAPosition, Device> positionCollection(elems, queue);
-    PortableCollection<SoAPCA, Device> pcaCollection(elems, queue);
+    PortableCollection<Device, SoAPosition> positionCollection(queue, elems);
+    PortableCollection<Device, SoAPCA> pcaCollection(queue, elems);
 
     // Portable Collection Views
     SoAPositionView& positionCollectionView = positionCollection.view();
@@ -122,8 +122,8 @@ TEST_CASE("Deep copy from SoA Generic View") {
               pcaCollectionView.metadata().addressOf_candidateDirection());
 
       // PortableCollection that will host the aggregated columns
-      PortableCollection<GenericSoA, Device> genericCollection(elems, queue);
-      genericCollection.deepCopy(genericView, queue);
+      PortableCollection<Device, GenericSoA> genericCollection(queue, elems);
+      genericCollection.deepCopy(queue, genericView);
 
       // Check for inequality of memory addresses[`View` section](../../DataFormats/SoATemplate/README.md#view)
       REQUIRE(genericCollection.view().metadata().addressOf_x() != positionCollectionView.metadata().addressOf_x());
@@ -149,8 +149,8 @@ TEST_CASE("Deep copy from SoA Generic View") {
               pcaCollectionView.metadata().addressOf_candidateDirection());
 
       // PortableCollection that will host the aggregated columns
-      PortableCollection<GenericSoA, Device> genericCollection(elems, queue);
-      genericCollection.deepCopy(genericConstView, queue);
+      PortableCollection<Device, GenericSoA> genericCollection(queue, elems);
+      genericCollection.deepCopy(queue, genericConstView);
 
       // Check for inequality of memory addresses
       REQUIRE(genericCollection.view().metadata().addressOf_x() != positionCollectionView.metadata().addressOf_x());
@@ -160,9 +160,9 @@ TEST_CASE("Deep copy from SoA Generic View") {
               pcaCollectionView.metadata().addressOf_candidateDirection());
 
       // Check for correctness of the copy
-      PortableHostCollection<GenericSoA> genericHostCollection(elems, queue);
-      PortableHostCollection<SoAPosition> positionHostCollection(elems, queue);
-      PortableHostCollection<SoAPCA> pcaHostCollection(elems, queue);
+      PortableHostCollection<GenericSoA> genericHostCollection(queue, elems);
+      PortableHostCollection<SoAPosition> positionHostCollection(queue, elems);
+      PortableHostCollection<SoAPCA> pcaHostCollection(queue, elems);
 
       alpaka::memcpy(queue, genericHostCollection.buffer(), genericCollection.buffer());
       alpaka::memcpy(queue, positionHostCollection.buffer(), positionCollection.buffer());
@@ -203,8 +203,8 @@ TEST_CASE("Deep copy from SoA Generic View") {
               pcaCollectionView.metadata().addressOf_candidateDirection());
 
       // PortableCollection that will host the aggregated columns
-      PortableHostCollection<GenericSoA> genericCollection(elems, queue);
-      genericCollection.deepCopy(genericConstView, queue);
+      PortableHostCollection<GenericSoA> genericCollection(queue, elems);
+      genericCollection.deepCopy(queue, genericConstView);
 
       // Check for inequality of memory addresses
       REQUIRE(genericCollection.view().metadata().addressOf_x() != positionCollectionView.metadata().addressOf_x());
@@ -214,8 +214,8 @@ TEST_CASE("Deep copy from SoA Generic View") {
               pcaCollectionView.metadata().addressOf_candidateDirection());
 
       // Check for correctness of the copy
-      PortableHostCollection<SoAPosition> positionHostCollection(elems, queue);
-      PortableHostCollection<SoAPCA> pcaHostCollection(elems, queue);
+      PortableHostCollection<SoAPosition> positionHostCollection(queue, elems);
+      PortableHostCollection<SoAPCA> pcaHostCollection(queue, elems);
 
       alpaka::memcpy(queue, positionHostCollection.buffer(), positionCollection.buffer());
       alpaka::memcpy(queue, pcaHostCollection.buffer(), pcaCollection.buffer());
@@ -237,8 +237,8 @@ TEST_CASE("Deep copy from SoA Generic View") {
     }
 
     SECTION("Deep copy the ConstView host to device") {
-      PortableHostCollection<SoAPosition> positionHostCollection(elems, queue);
-      PortableHostCollection<SoAPCA> pcaHostCollection(elems, queue);
+      PortableHostCollection<SoAPosition> positionHostCollection(queue, elems);
+      PortableHostCollection<SoAPCA> pcaHostCollection(queue, elems);
 
       alpaka::memcpy(queue, positionHostCollection.buffer(), positionCollection.buffer());
       alpaka::memcpy(queue, pcaHostCollection.buffer(), pcaCollection.buffer());
@@ -261,8 +261,8 @@ TEST_CASE("Deep copy from SoA Generic View") {
               pcaViewHostCollection.metadata().addressOf_candidateDirection());
 
       // PortableCollection that will host the aggregated columns
-      PortableCollection<GenericSoA, Device> genericCollection(elems, queue);
-      genericCollection.deepCopy(genericConstView, queue);
+      PortableCollection<Device, GenericSoA> genericCollection(queue, elems);
+      genericCollection.deepCopy(queue, genericConstView);
 
       // Check for inequality of memory addresses
       REQUIRE(genericCollection.view().metadata().addressOf_x() != positionViewHostCollection.metadata().addressOf_x());
@@ -272,7 +272,7 @@ TEST_CASE("Deep copy from SoA Generic View") {
               pcaViewHostCollection.metadata().addressOf_candidateDirection());
 
       // Check for correctness of the copy
-      PortableHostCollection<GenericSoA> genericHostCollection(elems, queue);
+      PortableHostCollection<GenericSoA> genericHostCollection(queue, elems);
 
       alpaka::memcpy(queue, genericHostCollection.buffer(), genericCollection.buffer());
 

--- a/DataFormats/Portable/test/test_catch2_blocks.cc
+++ b/DataFormats/Portable/test/test_catch2_blocks.cc
@@ -35,8 +35,8 @@ TEST_CASE("Deep copy from SoABlocks Generic View") {
   const std::size_t elemsPCA = 20;
 
   // Portable Collections
-  PortableHostCollection<SoAPosition> positionCollection(elemsPos, cms::alpakatools::host());
-  PortableHostCollection<SoAPCA> pcaCollection(elemsPCA, cms::alpakatools::host());
+  PortableHostCollection<SoAPosition> positionCollection(cms::alpakatools::host(), elemsPos);
+  PortableHostCollection<SoAPCA> pcaCollection(cms::alpakatools::host(), elemsPCA);
 
   // Portable Collection Views
   SoAPosition::View& positionCollectionView = positionCollection.view();
@@ -73,7 +73,7 @@ TEST_CASE("Deep copy from SoABlocks Generic View") {
             pcaCollectionView.metadata().addressOf_candidateDirection());
 
     // PortableHostCollection that will host the aggregated columns
-    std::array<cms::soa::size_type, 2> sizes{{elemsPos, elemsPCA}};
+    std::array<SoAGenericBlocks::size_type, 2> sizes{{elemsPos, elemsPCA}};
     PortableHostCollection<SoAGenericBlocks> genericCollection(cms::alpakatools::host(), sizes);
     genericCollection.deepCopy(genericBlocksView);
 

--- a/DataFormats/Portable/test/test_catch2_checkInput.cc
+++ b/DataFormats/Portable/test/test_catch2_checkInput.cc
@@ -1,0 +1,146 @@
+#include <catch2/catch_all.hpp>
+
+#include "DataFormats/Portable/interface/PortableCollection.h"
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/SoATemplate/interface/SoACommon.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "DataFormats/SoATemplate/interface/SoABlocks.h"
+#include "DataFormats/Portable/interface/PortableCollectionCommon.h"
+
+using namespace portablecollection;
+
+namespace {
+  GENERATE_SOA_LAYOUT(TestLayout, SOA_COLUMN(double, x), SOA_COLUMN(int32_t, id))
+
+  using TestSoA = TestLayout<>;
+
+  GENERATE_SOA_BLOCKS(Blocks4Layout,
+                      SOA_BLOCK(first, TestLayout),
+                      SOA_BLOCK(second, TestLayout),
+                      SOA_BLOCK(third, TestLayout),
+                      SOA_BLOCK(fourth, TestLayout))
+
+  using Blocks4 = Blocks4Layout<>;
+
+  using TestCollection1 = PortableHostCollection<TestSoA>;
+  using TestCollection2 = PortableHostCollection<Blocks4>;
+}  // namespace
+
+// Check that invalid inputs for the elements parameter of the PortableHostCollection constructor
+// cause narrow_cast to throw a std::runtime_error.
+TEST_CASE("checked_int_cast enforces non-negative narrowing to int", "[checked_int_cast]") {
+  SECTION("signed integer sources") {
+    SECTION("valid signed values") {
+      REQUIRE_NOTHROW([&] { TestCollection1 check(0); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(1); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<int8_t>(1)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<int16_t>(2)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<int32_t>(3)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<int64_t>(4)); }());
+
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<int_fast8_t>(5)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<int_fast16_t>(6)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<int_fast32_t>(7)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<int_fast64_t>(8)); }());
+
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<int_least8_t>(9)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<int_least16_t>(10)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<int_least32_t>(11)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<int_least64_t>(12)); }());
+
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<signed char>(13)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<short>(14)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<short int>(15)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<signed short>(16)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<signed short int>(17)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<int>(18)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<signed>(19)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<long>(20)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<long int>(21)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<signed long>(22)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<signed long int>(23)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<long long>(24)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<long long int>(25)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<signed long long>(26)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<signed long long int>(27)); }());
+      // To not allocate too much memory we just check the cast not the actual object creation
+      REQUIRE_NOTHROW(size_cast(std::numeric_limits<int>::max()));
+    }
+
+    SECTION("valid unsigned values") {
+      REQUIRE_NOTHROW([&] { TestCollection1 check(0); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(1); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<uint8_t>(1)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<uint16_t>(2)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<uint32_t>(3)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<uint64_t>(4)); }());
+
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<uint_fast8_t>(5)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<uint_fast16_t>(6)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<uint_fast32_t>(7)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<uint_fast64_t>(8)); }());
+
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<uint_least8_t>(9)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<uint_least16_t>(10)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<uint_least32_t>(11)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<uint_least64_t>(12)); }());
+
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<unsigned char>(13)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<unsigned short>(14)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<unsigned short int>(15)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<unsigned>(16)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<unsigned int>(17)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<unsigned long>(18)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<unsigned long int>(19)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<unsigned long long>(20)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<unsigned long long int>(21)); }());
+    }
+
+    SECTION("invalid negative values") {
+      REQUIRE_THROWS_AS([&] { TestCollection1 check(-1); }(), std::runtime_error);
+      REQUIRE_THROWS_AS([&] { TestCollection1 check(-42); }(), std::runtime_error);
+      REQUIRE_THROWS_AS([&] { TestCollection1 check(std::numeric_limits<int>::min()); }(), std::runtime_error);
+      REQUIRE_THROWS_AS([&] { TestCollection1 check(int8_t{-1}); }(), std::runtime_error);
+      REQUIRE_THROWS_AS([&] { TestCollection1 check(int16_t{-1}); }(), std::runtime_error);
+      REQUIRE_THROWS_AS([&] { TestCollection1 check(int64_t{-1}); }(), std::runtime_error);
+    }
+
+    SECTION("signed values exceeding int max are rejected") {
+      REQUIRE_THROWS_AS([&] { TestCollection1 check(static_cast<long long>(std::numeric_limits<int>::max()) + 1); }(),
+                        std::runtime_error);
+
+      REQUIRE_THROWS_AS([&] { TestCollection1 check(std::numeric_limits<int64_t>::max()); }(), std::runtime_error);
+    }
+  }
+
+  SECTION("character types") {
+    SECTION("signed char") {
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<signed char>(0)); }());
+      REQUIRE_THROWS_AS([&] { TestCollection1 check(static_cast<signed char>(-1)); }(), std::runtime_error);
+    }
+
+    SECTION("unsigned char") {
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<unsigned char>(0)); }());
+      REQUIRE_NOTHROW([&] { TestCollection1 check(static_cast<unsigned char>(255)); }());
+    }
+  }
+
+  SECTION("BlocksCollection") {
+    REQUIRE_NOTHROW([&] {
+      TestCollection2 check(
+          static_cast<int8_t>(1), static_cast<int16_t>(2), static_cast<int32_t>(3), static_cast<int64_t>(42));
+    }());
+
+    REQUIRE_NOTHROW([&] {
+      TestCollection2 check(
+          static_cast<uint8_t>(1), static_cast<uint16_t>(2), static_cast<uint32_t>(3), static_cast<uint64_t>(42));
+    }());
+
+    REQUIRE_THROWS_AS(
+        [&] {
+          TestCollection2 check(
+              static_cast<uint8_t>(1), static_cast<uint16_t>(2), static_cast<uint32_t>(3), static_cast<int64_t>(-1));
+        }(),
+        std::runtime_error);
+  }
+}

--- a/DataFormats/Portable/test/test_catch2_deepCopyOnHost.cc
+++ b/DataFormats/Portable/test/test_catch2_deepCopyOnHost.cc
@@ -42,8 +42,8 @@ TEST_CASE("Deep copy from SoA Generic View") {
   const std::size_t elems = 10;
 
   // Portable Collections
-  PortableHostCollection<SoAPosition> positionCollection(elems, cms::alpakatools::host());
-  PortableHostCollection<SoAPCA> pcaCollection(elems, cms::alpakatools::host());
+  PortableHostCollection<SoAPosition> positionCollection(cms::alpakatools::host(), elems);
+  PortableHostCollection<SoAPCA> pcaCollection(cms::alpakatools::host(), elems);
 
   // Portable Collection Views
   SoAPositionView& positionCollectionView = positionCollection.view();
@@ -84,7 +84,7 @@ TEST_CASE("Deep copy from SoA Generic View") {
             pcaCollectionView.metadata().addressOf_candidateDirection());
 
     // PortableHostCollection that will host the aggregated columns
-    PortableHostCollection<GenericSoA> genericCollection(elems, cms::alpakatools::host());
+    PortableHostCollection<GenericSoA> genericCollection(cms::alpakatools::host(), elems);
     genericCollection.deepCopy(genericView);
 
     // Check for inequality of memory addresses
@@ -111,7 +111,7 @@ TEST_CASE("Deep copy from SoA Generic View") {
             pcaCollectionView.metadata().addressOf_candidateDirection());
 
     // PortableHostCollection that will host the aggregated columns
-    PortableHostCollection<GenericSoA> genericCollection(elems, cms::alpakatools::host());
+    PortableHostCollection<GenericSoA> genericCollection(cms::alpakatools::host(), elems);
     genericCollection.deepCopy(genericConstView);
 
     // Check for inequality of memory addresses

--- a/DataFormats/Portable/test/test_catch2_portableCollectionOnHost.cc
+++ b/DataFormats/Portable/test/test_catch2_portableCollectionOnHost.cc
@@ -16,9 +16,9 @@ namespace {
 // This test is currently mostly about the code compiling
 TEST_CASE("Use of PortableCollection<T, TDev> on host code", s_tag) {
   auto const size = 10;
-  PortableCollection<TestSoA, alpaka::DevCpu> coll(size, cms::alpakatools::host());
+  PortableCollection<alpaka::DevCpu, TestSoA> coll(cms::alpakatools::host(), size);
 
   SECTION("Tests") { REQUIRE(coll->metadata().size() == size); }
 
-  static_assert(std::is_same_v<PortableCollection<TestSoA, alpaka::DevCpu>, PortableHostCollection<TestSoA>>);
+  static_assert(std::is_same_v<PortableCollection<alpaka::DevCpu, TestSoA>, PortableHostCollection<TestSoA>>);
 }

--- a/DataFormats/Portable/test/test_catch2_portableObjectOnHost.cc
+++ b/DataFormats/Portable/test/test_catch2_portableObjectOnHost.cc
@@ -14,11 +14,11 @@ namespace {
 
 // This test is currently mostly about the code compiling
 TEST_CASE("Use of PortableObject<T> on host code", s_tag) {
-  static_assert(std::is_same_v<PortableObject<Test, alpaka::DevCpu>, PortableHostObject<Test>>);
+  static_assert(std::is_same_v<PortableObject<alpaka::DevCpu, Test>, PortableHostObject<Test>>);
 
   SECTION("Initialize by setting members") {
     SECTION("With device") {
-      PortableObject<Test, alpaka::DevCpu> obj(cms::alpakatools::host());
+      PortableObject<alpaka::DevCpu, Test> obj(cms::alpakatools::host());
       obj->a = 42;
 
       REQUIRE(obj->a == 42);
@@ -27,7 +27,7 @@ TEST_CASE("Use of PortableObject<T> on host code", s_tag) {
     SECTION("With queue") {
       alpaka::QueueCpuBlocking queue(cms::alpakatools::host());
 
-      PortableObject<Test, alpaka::DevCpu> obj(queue);
+      PortableObject<alpaka::DevCpu, Test> obj(queue);
       obj->a = 42;
 
       REQUIRE(obj->a == 42);
@@ -36,7 +36,7 @@ TEST_CASE("Use of PortableObject<T> on host code", s_tag) {
 
   SECTION("Initialize via constructor") {
     SECTION("With device") {
-      PortableObject<Test, alpaka::DevCpu> obj(cms::alpakatools::host(), Test{42, 3.14f});
+      PortableObject<alpaka::DevCpu, Test> obj(cms::alpakatools::host(), Test{42, 3.14f});
 
       REQUIRE(obj->a == 42);
       REQUIRE(obj->b == 3.14f);
@@ -44,7 +44,7 @@ TEST_CASE("Use of PortableObject<T> on host code", s_tag) {
 
     SECTION("With queue") {
       alpaka::QueueCpuBlocking queue(cms::alpakatools::host());
-      PortableObject<Test, alpaka::DevCpu> obj(queue, Test{42, 3.14f});
+      PortableObject<alpaka::DevCpu, Test> obj(queue, Test{42, 3.14f});
 
       REQUIRE(obj->a == 42);
       REQUIRE(obj->b == 3.14f);

--- a/DataFormats/PortableTestObjects/interface/TestProductWithPtr.h
+++ b/DataFormats/PortableTestObjects/interface/TestProductWithPtr.h
@@ -21,7 +21,7 @@ namespace portabletest {
   using TestSoAWithPtr = TestSoALayoutWithPtr<>;
 
   template <typename TDev>
-  using TestProductWithPtr = PortableCollection<TestSoAWithPtr, TDev>;
+  using TestProductWithPtr = PortableCollection<TDev, TestSoAWithPtr>;
 
   ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void setPtrInTestProductWithPtr(TestSoAWithPtr::View view) {
     view.ptr() = &view.buffer(0);
@@ -30,10 +30,10 @@ namespace portabletest {
 
 namespace cms::alpakatools {
   template <typename TDev>
-  struct CopyToHost<PortableDeviceCollection<portabletest::TestSoAWithPtr, TDev>> {
+  struct CopyToHost<PortableDeviceCollection<TDev, portabletest::TestSoAWithPtr>> {
     template <typename TQueue>
-    static auto copyAsync(TQueue& queue, PortableDeviceCollection<portabletest::TestSoAWithPtr, TDev> const& src) {
-      PortableHostCollection<portabletest::TestSoAWithPtr> dst(src->metadata().size(), queue);
+    static auto copyAsync(TQueue& queue, PortableDeviceCollection<TDev, portabletest::TestSoAWithPtr> const& src) {
+      PortableHostCollection<portabletest::TestSoAWithPtr> dst(queue, src->metadata().size());
       alpaka::memcpy(queue, dst.buffer(), src.buffer());
       return dst;
     }

--- a/DataFormats/PortableTestObjects/test/TestSoA.cc
+++ b/DataFormats/PortableTestObjects/test/TestSoA.cc
@@ -12,7 +12,7 @@ int main() {
   constexpr const int size = 42;
   constexpr const int size2 = 21;
   constexpr const int size3 = 69;
-  portabletest::TestHostCollection collection(size, cms::alpakatools::host());
+  portabletest::TestHostCollection collection(cms::alpakatools::host(), size);
 
   const portabletest::Matrix matrix{{1, 2, 3, 4, 5, 6}, {2, 4, 6, 8, 10, 12}, {3, 6, 9, 12, 15, 18}};
   const portabletest::Array flags = {{6, 4, 2, 0}};

--- a/DataFormats/SiPixelClusterSoA/interface/SiPixelClustersDevice.h
+++ b/DataFormats/SiPixelClusterSoA/interface/SiPixelClustersDevice.h
@@ -13,17 +13,17 @@
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 
 template <typename TDev>
-class SiPixelClustersDevice : public PortableDeviceCollection<SiPixelClustersSoA, TDev> {
+class SiPixelClustersDevice : public PortableDeviceCollection<TDev, SiPixelClustersSoA> {
 public:
-  SiPixelClustersDevice(edm::Uninitialized) : PortableDeviceCollection<SiPixelClustersSoA, TDev>{edm::kUninitialized} {}
+  SiPixelClustersDevice(edm::Uninitialized) : PortableDeviceCollection<TDev, SiPixelClustersSoA>{edm::kUninitialized} {}
 
   template <typename TQueue>
   explicit SiPixelClustersDevice(size_t maxModules, TQueue queue)
-      : PortableDeviceCollection<SiPixelClustersSoA, TDev>(maxModules + 1, queue) {}
+      : PortableDeviceCollection<TDev, SiPixelClustersSoA>(queue, maxModules + 1) {}
 
   // Constructor which specifies the SoA size
   explicit SiPixelClustersDevice(size_t maxModules, TDev const &device)
-      : PortableDeviceCollection<SiPixelClustersSoA, TDev>(maxModules + 1, device) {}
+      : PortableDeviceCollection<TDev, SiPixelClustersSoA>(device, maxModules + 1) {}
 
   void setNClusters(uint32_t nClusters, int32_t offsetBPIX2) {
     nClusters_h = nClusters;

--- a/DataFormats/SiPixelClusterSoA/interface/SiPixelClustersHost.h
+++ b/DataFormats/SiPixelClusterSoA/interface/SiPixelClustersHost.h
@@ -19,7 +19,7 @@ public:
   // FIXME add an explicit overload for the host case
   template <typename TQueue>
   explicit SiPixelClustersHost(size_t maxModules, TQueue queue)
-      : PortableHostCollection<SiPixelClustersSoA>(maxModules + 1, queue) {}
+      : PortableHostCollection<SiPixelClustersSoA>(queue, maxModules + 1) {}
 
   void setNClusters(uint32_t nClusters, int32_t offsetBPIX2) {
     nClusters_h = nClusters;

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsDevice.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsDevice.h
@@ -13,18 +13,18 @@
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 
 template <typename TDev>
-class SiPixelDigiErrorsDevice : public PortableDeviceCollection<SiPixelDigiErrorsSoA, TDev> {
+class SiPixelDigiErrorsDevice : public PortableDeviceCollection<TDev, SiPixelDigiErrorsSoA> {
 public:
   SiPixelDigiErrorsDevice(edm::Uninitialized)
-      : PortableDeviceCollection<SiPixelDigiErrorsSoA, TDev>{edm::kUninitialized} {}
+      : PortableDeviceCollection<TDev, SiPixelDigiErrorsSoA>{edm::kUninitialized} {}
 
   template <typename TQueue>
   explicit SiPixelDigiErrorsDevice(size_t maxFedWords, TQueue queue)
-      : PortableDeviceCollection<SiPixelDigiErrorsSoA, TDev>(maxFedWords, queue), maxFedWords_(maxFedWords) {}
+      : PortableDeviceCollection<TDev, SiPixelDigiErrorsSoA>(queue, maxFedWords), maxFedWords_(maxFedWords) {}
 
   // Constructor which specifies the SoA size
   explicit SiPixelDigiErrorsDevice(size_t maxFedWords, TDev const& device)
-      : PortableDeviceCollection<SiPixelDigiErrorsSoA, TDev>(maxFedWords, device) {}
+      : PortableDeviceCollection<TDev, SiPixelDigiErrorsSoA>(device, maxFedWords) {}
 
   auto maxFedWords() const { return maxFedWords_; }
 

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsHost.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsHost.h
@@ -19,7 +19,7 @@ public:
 
   template <typename TQueue>
   explicit SiPixelDigiErrorsHost(int maxFedWords, TQueue queue)
-      : PortableHostCollection<SiPixelDigiErrorsSoA>(maxFedWords, queue), maxFedWords_(maxFedWords) {}
+      : PortableHostCollection<SiPixelDigiErrorsSoA>(queue, maxFedWords), maxFedWords_(maxFedWords) {}
 
   int maxFedWords() const { return maxFedWords_; }
 

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisDevice.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisDevice.h
@@ -11,17 +11,17 @@
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 
 template <typename TDev>
-class SiPixelDigisDevice : public PortableDeviceCollection<SiPixelDigisSoA, TDev> {
+class SiPixelDigisDevice : public PortableDeviceCollection<TDev, SiPixelDigisSoA> {
 public:
-  SiPixelDigisDevice(edm::Uninitialized) : PortableDeviceCollection<SiPixelDigisSoA, TDev>{edm::kUninitialized} {}
+  SiPixelDigisDevice(edm::Uninitialized) : PortableDeviceCollection<TDev, SiPixelDigisSoA>{edm::kUninitialized} {}
 
   template <typename TQueue>
   explicit SiPixelDigisDevice(size_t maxFedWords, TQueue queue)
-      : PortableDeviceCollection<SiPixelDigisSoA, TDev>(maxFedWords + 1, queue) {}
+      : PortableDeviceCollection<TDev, SiPixelDigisSoA>(queue, maxFedWords + 1) {}
 
   // Constructor which specifies the SoA size
   explicit SiPixelDigisDevice(size_t maxFedWords, TDev const &device)
-      : PortableDeviceCollection<SiPixelDigisSoA, TDev>(maxFedWords + 1, device) {}
+      : PortableDeviceCollection<TDev, SiPixelDigisSoA>(device, maxFedWords + 1) {}
 
   void setNModules(uint32_t nModules) { nModules_h = nModules; }
 

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h
@@ -15,7 +15,7 @@ public:
 
   template <typename TQueue>
   explicit SiPixelDigisHost(size_t maxFedWords, TQueue queue)
-      : PortableHostCollection<SiPixelDigisSoA>(maxFedWords + 1, queue) {}
+      : PortableHostCollection<SiPixelDigisSoA>(queue, maxFedWords + 1) {}
 
   void setNModules(uint32_t nModules) { nModules_h = nModules; }
 

--- a/DataFormats/TrackSoA/interface/TracksDevice.h
+++ b/DataFormats/TrackSoA/interface/TracksDevice.h
@@ -12,7 +12,7 @@
 
 namespace reco {
   template <typename TDev>
-  using TracksDevice = PortableDeviceCollection<TrackBlocks, TDev>;
+  using TracksDevice = PortableDeviceCollection<TDev, TrackBlocks>;
 }
 
 #endif  // DataFormats_Track_TracksDevice_H

--- a/DataFormats/TrackSoA/test/TestWriteHostTrackSoA.cc
+++ b/DataFormats/TrackSoA/test/TestWriteHostTrackSoA.cc
@@ -31,8 +31,7 @@ namespace edmtest {
       : trackSize_(iPSet.getParameter<unsigned int>("trackSize")), putToken_(produces()) {}
 
   void TestWriteHostTrackSoA::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const {
-    ::reco::TracksHost tracks(
-        cms::alpakatools::host(), static_cast<int32_t>(trackSize_), static_cast<int32_t>(4 * trackSize_));
+    ::reco::TracksHost tracks(cms::alpakatools::host(), trackSize_, 4 * trackSize_);
     auto tracksBlocksView = tracks.view();
     for (unsigned int i = 0; i < trackSize_; ++i) {
       tracksBlocksView.tracks()[i].eta() = float(i);

--- a/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsDevice.h
+++ b/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsDevice.h
@@ -18,7 +18,7 @@
 namespace reco {
 
   template <typename TDev>
-  using HitPortableCollectionDevice = PortableDeviceCollection<reco::TrackingBlocksSoA, TDev>;
+  using HitPortableCollectionDevice = PortableDeviceCollection<TDev, reco::TrackingBlocksSoA>;
 
   template <typename TDev>
   class TrackingRecHitDevice : public HitPortableCollectionDevice<TDev> {
@@ -30,7 +30,7 @@ namespace reco {
     // Constructor which specifies only the SoA size, to be used when copying the results from host to device
     template <typename TQueue>
     explicit TrackingRecHitDevice(TQueue queue, uint32_t nHits, uint32_t nModules)
-        : HitPortableCollectionDevice<TDev>(queue, static_cast<int32_t>(nHits), static_cast<int32_t>(nModules + 1)) {}
+        : HitPortableCollectionDevice<TDev>(queue, nHits, nModules + 1) {}
 
     // N.B. why this + 1? Because the HitModulesLayout is holding the
     // moduleStart vector that is a cumulative sum of all the hits
@@ -42,8 +42,7 @@ namespace reco {
     // Constructor from clusters
     template <typename TQueue>
     explicit TrackingRecHitDevice(TQueue queue, SiPixelClustersDevice<TDev> const &clusters)
-        : HitPortableCollectionDevice<TDev>(
-              queue, static_cast<int32_t>(clusters.nClusters()), clusters.view().metadata().size()),
+        : HitPortableCollectionDevice<TDev>(queue, clusters.nClusters(), clusters.view().metadata().size()),
           offsetBPIX2_{clusters.offsetBPIX2()} {
       auto hitsView = this->view().trackingHits();
       auto modsView = this->view().hitModules();

--- a/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsHost.h
+++ b/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsHost.h
@@ -28,15 +28,13 @@ namespace reco {
     // FIXME add an explicit overload for the host case
     template <typename TQueue>
     explicit TrackingRecHitHost(TQueue queue, uint32_t nHits, uint32_t nModules)
-        : HitPortableCollectionHost(queue, static_cast<int32_t>(nHits), static_cast<int32_t>(nModules + 1)) {}
+        : HitPortableCollectionHost(queue, nHits, nModules + 1) {}
     // Why this +1? See TrackingRecHitDevice.h constructor for an explanation
 
     // Constructor from clusters
     template <typename TQueue>
     explicit TrackingRecHitHost(TQueue queue, SiPixelClustersHost const& clusters)
-        : HitPortableCollectionHost(queue,
-                                    static_cast<int32_t>(clusters.nClusters()),
-                                    static_cast<int32_t>(clusters.view().metadata().size())) {
+        : HitPortableCollectionHost(queue, clusters.nClusters(), clusters.view().metadata().size()) {
       auto hitsView = view().trackingHits();
       auto modsView = view().hitModules();
 

--- a/DataFormats/VertexSoA/interface/ZVertexDevice.h
+++ b/DataFormats/VertexSoA/interface/ZVertexDevice.h
@@ -11,7 +11,7 @@
 
 namespace reco {
   template <typename TDev>
-  using ZVertexDevice = PortableDeviceCollection<reco::ZVertexBlocks, TDev>;
+  using ZVertexDevice = PortableDeviceCollection<TDev, reco::ZVertexBlocks>;
 }  // namespace reco
 
 #endif  // DataFormats_VertexSoA_interface_ZVertexDevice_h

--- a/EventFilter/EcalRawToDigi/plugins/alpaka/EcalElectronicsMappingHostESProducer.cc
+++ b/EventFilter/EcalRawToDigi/plugins/alpaka/EcalElectronicsMappingHostESProducer.cc
@@ -32,7 +32,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       // TODO: 0x3FFFFF * 4B ~= 16MB
       // tmp solution for linear mapping of eid -> did
       int const size = 0x3FFFFF;
-      auto product = std::make_unique<EcalElectronicsMappingHost>(size, cms::alpakatools::host());
+      auto product = std::make_unique<EcalElectronicsMappingHost>(cms::alpakatools::host(), size);
 
       // fill the whole collection with null detids
       alpaka::QueueCpuBlocking queue{cms::alpakatools::host()};

--- a/EventFilter/EcalRawToDigi/plugins/alpaka/EcalRawToDigiPortable.cc
+++ b/EventFilter/EcalRawToDigi/plugins/alpaka/EcalRawToDigiPortable.cc
@@ -95,8 +95,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     ecal::raw::InputDataHost inputHost(queue, size, feds);
 
     // output device collections
-    OutputProduct digisDevEB{static_cast<int32_t>(config_.maxChannelsEB), queue};
-    OutputProduct digisDevEE{static_cast<int32_t>(config_.maxChannelsEE), queue};
+    OutputProduct digisDevEB{queue, config_.maxChannelsEB};
+    OutputProduct digisDevEE{queue, config_.maxChannelsEE};
     // reset the size scalar of the SoA
     // memset takes an alpaka view that is created from the scalar in a view to the device collection
     auto digiViewEB = cms::alpakatools::make_device_view<uint32_t>(queue, digisDevEB.view().size());

--- a/EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc
+++ b/EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc
@@ -91,9 +91,9 @@ void HGCalRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
   //const auto& cellIndexer = iSetup.getData(cellIndexToken_);
   const auto& config = iSetup.getData(configToken_);
 
-  hgcaldigi::HGCalDigiHost digis(moduleIndexer.maxDataSize(), cms::alpakatools::host());
-  hgcaldigi::HGCalECONDPacketInfoHost econdPacketInfo(moduleIndexer.maxModulesCount(), cms::alpakatools::host());
-  hgcaldigi::HGCalFEDPacketInfoHost fedPacketInfo(moduleIndexer.fedCount(), cms::alpakatools::host());
+  hgcaldigi::HGCalDigiHost digis(cms::alpakatools::host(), moduleIndexer.maxDataSize());
+  hgcaldigi::HGCalECONDPacketInfoHost econdPacketInfo(cms::alpakatools::host(), moduleIndexer.maxModulesCount());
+  hgcaldigi::HGCalFEDPacketInfoHost fedPacketInfo(cms::alpakatools::host(), moduleIndexer.fedCount());
 
   // retrieve the FED raw data
   const auto& fedBuffer = iEvent.get(fedRawToken_);

--- a/EventFilter/HcalRawToDigi/plugins/alpaka/HcalDigisSoAProducer.cc
+++ b/EventFilter/HcalRawToDigi/plugins/alpaka/HcalDigisSoAProducer.cc
@@ -81,7 +81,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const int size = hbheDigis.size() * stride;  // number of channels * stride
 
     // stack host memory in the queue
-    HostCollectionPhase0 hf5_(size, event.queue());
+    HostCollectionPhase0 hf5_(event.queue(), size);
 
     // set SoA_Scalar;
     hf5_.view().stride() = stride;
@@ -108,8 +108,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     event.emplace(digisF5HBToken_, std::move(hf5_));
 
     if (qie11Digis.empty()) {
-      event.emplace(digisF01HEToken_, 0, event.queue());
-      event.emplace(digisF3HBToken_, 0, event.queue());
+      event.emplace(digisF01HEToken_, event.queue(), 0);
+      event.emplace(digisF3HBToken_, event.queue(), 0);
 
     } else {
       auto size_f1 = 0;
@@ -133,8 +133,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       auto const stride01 = nsamples * QIE11DataFrame::WORDS_PER_SAMPLE + QIE11DataFrame::HEADER_WORDS;
 
       // stack host memory in the queue
-      HostCollectionPhase1 hf1_(size_f1, event.queue());
-      HostCollectionPhase1 hf3_(size_f3, event.queue());
+      HostCollectionPhase1 hf1_(event.queue(), size_f1);
+      HostCollectionPhase1 hf3_(event.queue(), size_f3);
 
       // set SoA_Scalar;
       hf1_.view().stride() = stride01;

--- a/Geometry/HGCalMapping/plugins/alpaka/HGCalDenseIndexInfoESProducer.cc
+++ b/Geometry/HGCalMapping/plugins/alpaka/HGCalDenseIndexInfoESProducer.cc
@@ -68,7 +68,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         //declare the dense index info collection to be produced
         //the size is determined by the module indexer
         const uint32_t nIndices = modIndexer.maxDataSize();
-        HGCalDenseIndexInfoHost denseIdxInfo(nIndices, cms::alpakatools::host());
+        HGCalDenseIndexInfoHost denseIdxInfo(cms::alpakatools::host(), nIndices);
         for (auto fedRS : modIndexer.fedReadoutSequences()) {
           uint32_t fedId = fedRS.id;
           for (size_t imod = 0; imod < fedRS.readoutTypes_.size(); imod++) {

--- a/Geometry/HGCalMapping/plugins/alpaka/HGCalDenseIndexTriggerInfoESProducer.cc
+++ b/Geometry/HGCalMapping/plugins/alpaka/HGCalDenseIndexTriggerInfoESProducer.cc
@@ -62,7 +62,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         //declare the dense index info collection to be produced
         //the size is determined by the module indexer
         const uint32_t nIndices = modIndexer.maxDataSize();
-        HGCalDenseIndexTriggerInfoHost denseIdxInfo(nIndices, cms::alpakatools::host());
+        HGCalDenseIndexTriggerInfoHost denseIdxInfo(cms::alpakatools::host(), nIndices);
         for (const auto& fedRS : modIndexer.fedReadoutSequences()) {
           uint32_t fedId = fedRS.id;
           for (size_t imod = 0; imod < fedRS.readoutTypes_.size(); imod++) {

--- a/Geometry/HGCalMapping/plugins/alpaka/HGCalMappingCellESProducer.cc
+++ b/Geometry/HGCalMapping/plugins/alpaka/HGCalMappingCellESProducer.cc
@@ -94,7 +94,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         const HGCalMappingCellIndexer& cellIndexer = iRecord.get(cellIndexTkn_);
         const HGCalMappingModuleIndexer& moduleIndexer = iRecord.get(moduleIndexTkn_);
         const uint32_t size = cellIndexer.maxDenseIndex();  // channel-level size
-        HGCalMappingCellParamHost cellParams(size, cms::alpakatools::host());
+        HGCalMappingCellParamHost cellParams(cms::alpakatools::host(), size);
         for (uint32_t i = 0; i < size; i++)
           cellParams.view()[i].valid() = false;
 

--- a/Geometry/HGCalMapping/plugins/alpaka/HGCalMappingModuleESProducer.cc
+++ b/Geometry/HGCalMapping/plugins/alpaka/HGCalMappingModuleESProducer.cc
@@ -49,7 +49,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
         // load dense indexing
         const uint32_t size = modIndexer.maxModulesCount();
-        HGCalMappingModuleParamHost moduleParams(size, cms::alpakatools::host());
+        HGCalMappingModuleParamHost moduleParams(cms::alpakatools::host(), size);
         for (size_t i = 0; i < size; i++)
           moduleParams.view()[i].valid() = false;
 

--- a/Geometry/HGCalMapping/plugins/alpaka/HGCalMappingTriggerModuleESProducer.cc
+++ b/Geometry/HGCalMapping/plugins/alpaka/HGCalMappingTriggerModuleESProducer.cc
@@ -50,7 +50,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
         // load dense indexing
         const uint32_t size = modIndexer.maxModulesIndex();
-        HGCalMappingModuleTriggerParamHost moduleParams(size, cms::alpakatools::host());
+        HGCalMappingModuleTriggerParamHost moduleParams(cms::alpakatools::host(), size);
         for (size_t i = 0; i < size; i++)
           moduleParams.view()[i].valid() = false;
 

--- a/HeterogeneousCore/AlpakaTest/interface/AlpakaESTestData.h
+++ b/HeterogeneousCore/AlpakaTest/interface/AlpakaESTestData.h
@@ -41,8 +41,8 @@ namespace cms::alpakatest {
   template <typename TDev>
   class AlpakaESTestDataE {
   public:
-    using ECollection = PortableCollection<AlpakaESTestSoAE, TDev>;
-    using EDataCollection = PortableCollection<AlpakaESTestSoAEData, TDev>;
+    using ECollection = PortableCollection<TDev, AlpakaESTestSoAE>;
+    using EDataCollection = PortableCollection<TDev, AlpakaESTestSoAEData>;
 
     class ConstView {
     public:

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
@@ -332,7 +332,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   portabletest::TestDeviceCollection TestAlgo::update(Queue& queue,
                                                       portabletest::TestDeviceCollection const& input,
                                                       AlpakaESTestDataEDevice const& esData) const {
-    portabletest::TestDeviceCollection collection{input.size(), queue};
+    portabletest::TestDeviceCollection collection{queue, input.size()};
 
     // use 64 items per group (this value is arbitrary, but it's a reasonable starting point)
     uint32_t items = 64;
@@ -418,7 +418,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   portabletest::TestDeviceCollection TestAlgo::update(Queue& queue,
                                                       portabletest::TestDeviceCollection const& input,
                                                       UpdateInfo const* d_updateInfo) const {
-    portabletest::TestDeviceCollection collection{input.size(), queue};
+    portabletest::TestDeviceCollection collection{queue, input.size()};
 
     // use 64 items per group (this value is arbitrary, but it's a reasonable starting point)
     uint32_t items = 64;

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerA.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerA.cc
@@ -34,7 +34,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       int const size = 10;
       // TODO: pinned allocation?
       // TODO: cached allocation?
-      auto product = std::make_unique<AlpakaESTestDataAHost>(size, cms::alpakatools::host());
+      auto product = std::make_unique<AlpakaESTestDataAHost>(cms::alpakatools::host(), size);
       for (int i = 0; i < size; ++i) {
         product->view()[i].z() = input.value() - i;
       }

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerC.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerC.cc
@@ -34,7 +34,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       int const size = 5;
       // TODO: pinned allocation?
       // TODO: cached allocation?
-      AlpakaESTestDataCHost product(size, cms::alpakatools::host());
+      AlpakaESTestDataCHost product(cms::alpakatools::host(), size);
       for (int i = 0; i < size; ++i) {
         product.view()[i].x() = input.value() - i;
       }

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerE.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerE.cc
@@ -34,7 +34,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       auto const& input = iRecord.get(token_);
 
       int const edatasize = 2;
-      AlpakaESTestDataEHost::EDataCollection data(edatasize, cms::alpakatools::host());
+      AlpakaESTestDataEHost::EDataCollection data(cms::alpakatools::host(), edatasize);
       for (int i = 0; i < edatasize; ++i) {
         data.view()[i].val2() = i * 10 + 1;
       }
@@ -42,7 +42,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       int const esize = 5;
       // TODO: pinned allocation?
       // TODO: cached allocation?
-      AlpakaESTestDataEHost::ECollection e(esize, cms::alpakatools::host());
+      AlpakaESTestDataEHost::ECollection e(cms::alpakatools::host(), esize);
       for (int i = 0; i < esize; ++i) {
         e.view()[i].val() = std::abs(input.value()) + i * 2;
         e.view()[i].ind() = i % edatasize;

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducer.cc
@@ -38,7 +38,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       [[maybe_unused]] auto const& esData = iSetup.getData(esToken_);
       [[maybe_unused]] auto const& esBlocksData = iSetup.getData(esBlocksToken_);
 
-      portabletest::TestDeviceCollection deviceProduct{size_, iEvent.queue()};
+      portabletest::TestDeviceCollection deviceProduct{iEvent.queue(), size_};
       portabletest::TestDeviceCollection2 deviceProductMulti2{iEvent.queue(), size_, size2_};
       portabletest::TestDeviceCollection3 deviceProductMulti3{iEvent.queue(), size_, size2_, size3_};
 

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducerOffset.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducerOffset.cc
@@ -31,7 +31,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     void produce(edm::StreamID, device::Event& iEvent, device::EventSetup const& iSetup) const override {
       auto const& esData = iSetup.getData(esToken_);
 
-      portabletest::TestDeviceCollection deviceProduct{esData->metadata().size(), iEvent.queue()};
+      portabletest::TestDeviceCollection deviceProduct{iEvent.queue(), esData->metadata().size()};
 
       // run the algorithm, potentially asynchronously
       algo_.fill(iEvent.queue(), deviceProduct, x_);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaProducer.cc
@@ -30,7 +30,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     void produce(edm::StreamID sid, device::Event& event, device::EventSetup const&) const override {
       // run the algorithm, potentially asynchronously
-      portabletest::TestDeviceCollection deviceCollection{size_, event.queue()};
+      portabletest::TestDeviceCollection deviceCollection{event.queue(), size_};
       deviceCollection.zeroInitialise(event.queue());
       algo_.checkZero(event.queue(), deviceCollection);
       algo_.fill(event.queue(), deviceCollection);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamProducer.cc
@@ -42,7 +42,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       [[maybe_unused]] auto inpData = iEvent.getHandle(getToken_);
       [[maybe_unused]] auto const& esData = iSetup.getData(esToken_);
 
-      auto deviceProduct = std::make_unique<portabletest::TestDeviceCollection>(size_, iEvent.queue());
+      auto deviceProduct = std::make_unique<portabletest::TestDeviceCollection>(iEvent.queue(), size_);
       auto deviceProductMulti2 = std::make_unique<portabletest::TestDeviceCollection2>(iEvent.queue(), size_, size2_);
       auto deviceProductMulti3 =
           std::make_unique<portabletest::TestDeviceCollection3>(iEvent.queue(), size_, size2_, size3_);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamSynchronizingProducerToDevice.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamSynchronizingProducerToDevice.cc
@@ -25,7 +25,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
               EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE))} {}
 
     void acquire(device::Event const& iEvent, device::EventSetup const& iSetup) override {
-      deviceProduct_ = std::make_unique<portabletest::TestDeviceCollection>(size_, iEvent.queue());
+      deviceProduct_ = std::make_unique<portabletest::TestDeviceCollection>(iEvent.queue(), size_);
 
       // run the algorithm, potentially asynchronously
       algo_.fill(iEvent.queue(), *deviceProduct_);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestHelperClass.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestHelperClass.cc
@@ -19,7 +19,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     portabletest::TestDeviceCollection2 const& deviceProductMulti2 = iEvent.get(getTokenMulti2_);
     portabletest::TestDeviceCollection3 const& deviceProductMulti3 = iEvent.get(getTokenMulti3_);
 
-    hostProduct_ = portabletest::TestHostCollection{deviceProduct.size(), iEvent.queue()};
+    hostProduct_ = portabletest::TestHostCollection{iEvent.queue(), deviceProduct.size()};
     hostProductMulti2_ = portabletest::TestHostCollection2{iEvent.queue(), deviceProductMulti2.size()};
     hostProductMulti3_ = portabletest::TestHostCollection3{iEvent.queue(), deviceProductMulti3.size()};
     alpaka::memcpy(iEvent.queue(), hostProduct_->buffer(), deviceProduct.const_buffer());

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/testESAlgoAsync.dev.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/testESAlgoAsync.dev.cc
@@ -5,7 +5,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                           AlpakaESTestDataADevice const& dataA,
                                           cms::alpakatest::AlpakaESTestDataB<Device> const& dataB) {
     auto const size = std::min(dataA->metadata().size(), static_cast<int>(dataB.size()));
-    AlpakaESTestDataDDevice ret(size, queue);
+    AlpakaESTestDataDDevice ret(queue, size);
 
     auto const& deviceProperties = alpaka::getAccDevProps<Acc1D>(alpaka::getDev(queue));
     uint32_t maxThreadsPerBlock = deviceProperties.m_blockThreadExtentMax[0];

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/testPtrAlgoAsync.dev.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/testPtrAlgoAsync.dev.cc
@@ -4,7 +4,7 @@
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
   portabletest::TestProductWithPtr<Device> testPtrAlgoAsync(Queue& queue, int size) {
-    portabletest::TestProductWithPtr<Device> ret{size, queue};
+    portabletest::TestProductWithPtr<Device> ret{queue, size};
     using View = portabletest::TestProductWithPtr<Device>::View;
     alpaka::exec<Acc1D>(
         queue,

--- a/PhysicsTools/PyTorchAlpaka/test/alpaka/testSoADataTypes.dev.cc
+++ b/PhysicsTools/PyTorchAlpaka/test/alpaka/testSoADataTypes.dev.cc
@@ -51,8 +51,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
 
   using SoA = SoATemplate<>;
   using SoAView = SoA::View;
-  using SoACollection = PortableCollection<SoA, Device>;
-  using SoACollectionView = PortableCollection<SoA, Device>::View;
+  using SoACollection = PortableCollection<Device, SoA>;
+  using SoACollectionView = PortableCollection<Device, SoA>::View;
   using SoAHostCollection = PortableHostCollection<SoA>;
   using SoAHostCollectionView = PortableHostCollection<SoA>::View;
 
@@ -203,7 +203,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
     const std::size_t batch_size = 64;
 
     // Create and fill needed portable collections
-    SoACollection deviceCollection(batch_size, queue);
+    SoACollection deviceCollection(queue, batch_size);
     fill(queue, deviceCollection);
     auto records = deviceCollection.view().records();
 
@@ -218,7 +218,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
 
     std::vector<::torch::IValue> tensors = cms::torch::alpakatools::detail::convertInput(input, torchDevice);
 
-    SoAHostCollection hostCollection(batch_size, queue);
+    SoAHostCollection hostCollection(queue, batch_size);
     alpaka::memcpy(queue, hostCollection.buffer(), deviceCollection.buffer());
     alpaka::wait(queue);
 
@@ -238,7 +238,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
     const std::size_t batch_size = 64;
 
     // Create and fill needed portable collections
-    SoACollection deviceCollection(batch_size, queue);
+    SoACollection deviceCollection(queue, batch_size);
     fill(queue, deviceCollection);
 
     auto records = deviceCollection.view().records();
@@ -267,7 +267,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
 
     // Create and fill portable collections
     const std::size_t batch_size = 1;
-    SoACollection deviceCollection(batch_size, queue);
+    SoACollection deviceCollection(queue, batch_size);
     fill(queue, deviceCollection);
     auto records = deviceCollection.view().records();
 
@@ -287,7 +287,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
     std::vector<::torch::IValue> tensors = cms::torch::alpakatools::detail::convertInput(input, torchDevice);
 
     // Check if tensor list built correctly
-    SoAHostCollection hostCollection(batch_size, queue);
+    SoAHostCollection hostCollection(queue, batch_size);
     ::alpaka::memcpy(queue, hostCollection.buffer(), deviceCollection.buffer());
     check(hostCollection.view(), tensors);
   };
@@ -302,7 +302,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
 
     //Create empty portable collection
     const std::size_t batch_size = 0;
-    SoACollection deviceCollection(batch_size, queue);
+    SoACollection deviceCollection(queue, batch_size);
     auto records = deviceCollection.view().records();
 
     // Run Converter
@@ -333,7 +333,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
 
     // Create and fill portable collections
     const std::size_t batch_size = 32;
-    SoACollection deviceCollection(batch_size, queue);
+    SoACollection deviceCollection(queue, batch_size);
     fill(queue, deviceCollection);
 
     // Run Converter for empty metadata

--- a/PhysicsTools/PyTorchAlpaka/test/alpaka/testSoAToTorch.dev.cc
+++ b/PhysicsTools/PyTorchAlpaka/test/alpaka/testSoAToTorch.dev.cc
@@ -19,15 +19,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
   GENERATE_SOA_LAYOUT(SoAPositionTemplate, SOA_COLUMN(float, x), SOA_COLUMN(float, y), SOA_COLUMN(float, z))
 
   using SoAPosition = SoAPositionTemplate<>;
-  using PositionDeviceCollection = PortableCollection<SoAPosition, Device>;
-  using PositionDeviceCollectionView = PortableCollection<SoAPosition, Device>::View;
+  using PositionDeviceCollection = PortableCollection<Device, SoAPosition>;
+  using PositionDeviceCollectionView = PortableCollection<Device, SoAPosition>::View;
 
   // Output SOA
   GENERATE_SOA_LAYOUT(SoAResultTemplate, SOA_COLUMN(float, x), SOA_COLUMN(float, y))
 
   using SoAResult = SoAResultTemplate<>;
-  using ResultDeviceCollection = PortableCollection<SoAResult, Device>;
-  using ResultDeviceCollectionView = PortableCollection<SoAResult, Device>::View;
+  using ResultDeviceCollection = PortableCollection<Device, SoAResult>;
+  using ResultDeviceCollectionView = PortableCollection<Device, SoAResult>::View;
 
   class testSOAToTorch : public CppUnit::TestFixture {
     CPPUNIT_TEST_SUITE(testSOAToTorch);
@@ -92,8 +92,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
     const std::size_t batch_size = 4;
 
     // Create and fill needed portable collections
-    PositionDeviceCollection positionCollection(batch_size, alpakaDevice);
-    ResultDeviceCollection resultCollection(batch_size, alpakaDevice);
+    PositionDeviceCollection positionCollection(alpakaDevice, batch_size);
+    ResultDeviceCollection resultCollection(alpakaDevice, batch_size);
     fill(queue, positionCollection);
 
     // Deserialize the ScriptModule

--- a/PhysicsTools/PyTorchAlpakaTest/plugins/alpaka/DataSource.cc
+++ b/PhysicsTools/PyTorchAlpakaTest/plugins/alpaka/DataSource.cc
@@ -25,8 +25,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
 
     void produce(device::Event &event, const device::EventSetup &event_setup) override {
       // allocate data sources
-      auto particles = portabletest::ParticleDeviceCollection(batch_size_, event.queue());
-      auto images = portabletest::ImageDeviceCollection(batch_size_, event.queue());
+      auto particles = portabletest::ParticleDeviceCollection(event.queue(), batch_size_);
+      auto images = portabletest::ImageDeviceCollection(event.queue(), batch_size_);
 
       // fill data
       kernels::randomFillParticleCollection(event.queue(), particles);

--- a/PhysicsTools/PyTorchAlpakaTest/plugins/alpaka/MaskedNet.cc
+++ b/PhysicsTools/PyTorchAlpakaTest/plugins/alpaka/MaskedNet.cc
@@ -39,10 +39,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
       // in/out collections
       const auto &particles = event.get(particles_token_);
       const auto batch_size = particles.const_view().metadata().size();
-      auto masked_net_output = portabletest::SimpleNetDeviceCollection(batch_size, event.queue());
+      auto masked_net_output = portabletest::SimpleNetDeviceCollection(event.queue(), batch_size);
 
       // mask
-      auto mask = portabletest::MaskDeviceCollection(batch_size, event.queue());
+      auto mask = portabletest::MaskDeviceCollection(event.queue(), batch_size);
       kernels::fillMask(event.queue(), mask);
       // note that scalar mask can be used to mask out entire batch at once (scalars are broadcasted)
       // auto scalar_mask = ScalarMaskDeviceCollection(batch_size, event.queue());

--- a/PhysicsTools/PyTorchAlpakaTest/plugins/alpaka/MultiHeadNet.cc
+++ b/PhysicsTools/PyTorchAlpakaTest/plugins/alpaka/MultiHeadNet.cc
@@ -37,7 +37,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
       // in/out collections
       const auto &particles = event.get(particles_token_);
       const auto batch_size = particles.const_view().metadata().size();
-      auto multi_head_output = portabletest::MultiHeadNetDeviceCollection(batch_size, event.queue());
+      auto multi_head_output = portabletest::MultiHeadNetDeviceCollection(event.queue(), batch_size);
 
       // records
       auto input_records = particles.const_view().records();

--- a/PhysicsTools/PyTorchAlpakaTest/plugins/alpaka/SimpleNet.cc
+++ b/PhysicsTools/PyTorchAlpakaTest/plugins/alpaka/SimpleNet.cc
@@ -37,7 +37,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
       // in/out collections
       const auto &particles = event.get(particles_token_);
       const auto batch_size = particles.const_view().metadata().size();
-      auto regression_collection = portabletest::SimpleNetDeviceCollection(batch_size, event.queue());
+      auto regression_collection = portabletest::SimpleNetDeviceCollection(event.queue(), batch_size);
 
       // records
       auto input_records = particles.const_view().records();

--- a/PhysicsTools/PyTorchAlpakaTest/plugins/alpaka/TinyResNet.cc
+++ b/PhysicsTools/PyTorchAlpakaTest/plugins/alpaka/TinyResNet.cc
@@ -37,7 +37,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
       // in/out collections
       const auto &images = event.get(images_token_);
       const auto batch_size = images.const_view().metadata().size();
-      auto logits = portabletest::LogitsDeviceCollection(batch_size, event.queue());
+      auto logits = portabletest::LogitsDeviceCollection(event.queue(), batch_size);
 
       // records
       auto input_records = images.const_view().records();

--- a/RecoHGCal/TICL/plugins/MTDSoAProducer.cc
+++ b/RecoHGCal/TICL/plugins/MTDSoAProducer.cc
@@ -100,7 +100,7 @@ void MTDSoAProducer::produce(edm::Event& ev, const edm::EventSetup& es) {
   const auto& probK = ev.get(probKToken_);
   const auto& probP = ev.get(probPToken_);
 
-  auto MtdInfo = std::make_unique<MtdHostCollection>(tracks.size(), cms::alpakatools::host());
+  auto MtdInfo = std::make_unique<MtdHostCollection>(cms::alpakatools::host(), tracks.size());
 
   auto& MtdInfoView = MtdInfo->view();
   for (unsigned int iTrack = 0; iTrack < tracks.size(); ++iTrack) {

--- a/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalMultifitConditionsHostESProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalMultifitConditionsHostESProducer.cc
@@ -71,7 +71,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       size_t numberOfXtals = pedestalsData.size();
 
-      auto product = std::make_unique<EcalMultifitConditionsHost>(numberOfXtals, cms::alpakatools::host());
+      auto product = std::make_unique<EcalMultifitConditionsHost>(cms::alpakatools::host(), numberOfXtals);
       auto view = product->view();
 
       // Filling pedestals

--- a/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalPhase2DigiToPortableProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalPhase2DigiToPortableProducer.cc
@@ -48,7 +48,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const uint32_t size = inputDigis.size();
 
     //create host and device Digi collections of required size
-    EcalDigiPhase2HostCollection digisHostColl{static_cast<int32_t>(size), event.queue()};
+    EcalDigiPhase2HostCollection digisHostColl{event.queue(), size};
     auto digisHostCollView = digisHostColl.view();
 
     //iterate over digis

--- a/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalRecHitConditionsESProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalRecHitConditionsESProducer.cc
@@ -77,7 +77,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         numberOfXtals += channelStatusData.endcapItems().size();
       }
 
-      auto product = std::make_unique<EcalRecHitConditionsHost>(numberOfXtals, cms::alpakatools::host());
+      auto product = std::make_unique<EcalRecHitConditionsHost>(cms::alpakatools::host(), numberOfXtals);
       auto view = product->view();
 
       // Filling crystal level conditions

--- a/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalRecHitProducerPortable.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalRecHitProducerPortable.cc
@@ -185,9 +185,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     auto const uncalibRecHitsSizeEE = isPhase2_ ? 0 : uncalibRecHitsDevEE->const_view().metadata().size();
 
     // output device collections with the same size than the input collections
-    auto recHitsDevEB = std::make_unique<OutputProduct>(uncalibRecHitsSizeEB, queue);
+    auto recHitsDevEB = std::make_unique<OutputProduct>(queue, uncalibRecHitsSizeEB);
     auto recHitsDevEE =
-        isPhase2_ ? std::unique_ptr<OutputProduct>() : std::make_unique<OutputProduct>(uncalibRecHitsSizeEE, queue);
+        isPhase2_ ? std::unique_ptr<OutputProduct>() : std::make_unique<OutputProduct>(queue, uncalibRecHitsSizeEE);
     // reset the size scalar of the SoA
     // memset takes an alpaka view that is created from the scalar in a view to the portable device collection
     auto recHitSizeViewEB = cms::alpakatools::make_device_view<uint32_t>(queue, recHitsDevEB->view().size());

--- a/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitPhase2WeightsProducerPortable.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitPhase2WeightsProducerPortable.cc
@@ -126,7 +126,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const uint32_t size = digis->metadata().size();
 
     //allocate output product on the device
-    OutputProduct uncalibratedRecHits{static_cast<int32_t>(size), event.queue()};
+    OutputProduct uncalibratedRecHits{event.queue(), size};
 
     //do not run the algo if there are no digis
     if (size > 0) {

--- a/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitProducerPortable.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitProducerPortable.cc
@@ -240,8 +240,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     auto const eeDigisSize = static_cast<int>(*eeDigisSizeHostBuf_.data());
 
     // output device collections
-    OutputProduct uncalibRecHitsDevEB{ebDigisSize, queue};
-    OutputProduct uncalibRecHitsDevEE{eeDigisSize, queue};
+    OutputProduct uncalibRecHitsDevEB{queue, ebDigisSize};
+    OutputProduct uncalibRecHitsDevEE{queue, eeDigisSize};
     // reset the size scalar of the SoA
     // memset takes an alpaka view that is created from the scalar in a view to the portable device collection
     auto uncalibRecHitSizeViewEB =

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationAlgorithms.dev.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationAlgorithms.dev.cc
@@ -278,12 +278,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     LogDebug("HGCalRecHitCalibrationAlgorithms") << "\n\nINFO -- Copying the digis to the device\n\n" << std::endl;
     auto const ndigis = host_digis.view().metadata().size();
-    HGCalDigiDevice device_digis(ndigis, queue);
+    HGCalDigiDevice device_digis(queue, ndigis);
     alpaka::memcpy(queue, device_digis.buffer(), host_digis.const_buffer());
 
     LogDebug("HGCalRecHitCalibrationAlgorithms")
         << "\n\nINFO -- Allocating rechits buffer and initiating values" << std::endl;
-    HGCalSoARecHitsDeviceCollection device_recHits(ndigis, queue);
+    HGCalSoARecHitsDeviceCollection device_recHits(queue, ndigis);
 
     // number of items per group
     uint32_t items = n_threads_;
@@ -351,7 +351,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     //   - elements within a single thread on a CPU backend
     auto grid = make_workdiv<Acc1D>(groups, items);
 
-    HGCalSoARecHitsDeviceCollection device_selRecHits(*nsel, queue);
+    HGCalSoARecHitsDeviceCollection device_selRecHits(queue, *nsel);
     alpaka::exec<Acc1D>(queue,
                         grid,
                         HGCalRecHitCalibrationKernel_copyRecHits{},

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationESProducer.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationESProducer.cc
@@ -97,7 +97,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
         // load dense indexing
         const uint32_t nchans = moduleIndexer.maxDataSize();  // channel-level size
-        hgcalrechit::HGCalCalibParamHost product(nchans, cms::alpakatools::host());
+        hgcalrechit::HGCalCalibParamHost product(cms::alpakatools::host(), nchans);
 
         // load calib parameters from JSON
         std::ifstream infile(filename_.fullPath().c_str());

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitProducers.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitProducers.cc
@@ -168,7 +168,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 #endif
 
     LogDebug("HGCalRecHitsProducer") << "\n\nINFO -- Copying the calib to the device\n\n" << std::endl;
-    HGCalCalibParamDevice deviceCalibParam(hostCalibParam.view().metadata().size(), queue);
+    HGCalCalibParamDevice deviceCalibParam(queue, hostCalibParam.view().metadata().size());
     alpaka::memcpy(queue, deviceCalibParam.buffer(), hostCalibParam.const_buffer());
 
 #ifdef HGCAL_PERF_TEST

--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalSoALayerClustersProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalSoALayerClustersProducer.cc
@@ -58,10 +58,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       auto const& deviceInputClusters = iEvent.get(getTokenDeviceClusters_);
       auto const inputClusters_v = deviceInputClusters.view();
 
-      HGCalSoAClustersDeviceCollection output(num_clusters_, iEvent.queue());
+      HGCalSoAClustersDeviceCollection output(iEvent.queue(), num_clusters_);
       auto output_v = output.view();
       // Allocate workspace SoA cluster
-      HGCalSoAClustersExtraDeviceCollection outputWorkspace(num_clusters_, iEvent.queue());
+      HGCalSoAClustersExtraDeviceCollection outputWorkspace(iEvent.queue(), num_clusters_);
       auto output_workspace_v = outputWorkspace.view();
 
       algo_.run(iEvent.queue(),

--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalSoARecHitsLayerClustersProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalSoARecHitsLayerClustersProducer.cc
@@ -43,7 +43,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       //std::cout << "Size of device collection: " << deviceInput->metadata().size() << std::endl;
       auto const input_v = deviceInput.view();
       // Allocate output SoA
-      HGCalSoARecHitsExtraDeviceCollection output(deviceInput->metadata().size(), iEvent.queue());
+      HGCalSoARecHitsExtraDeviceCollection output(iEvent.queue(), deviceInput->metadata().size());
       auto output_v = output.view();
 
       algo_.run(

--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalSoARecHitsProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalSoARecHitsProducer.cc
@@ -66,7 +66,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       }
 
       // Allocate Host SoA will contain one entry for each RecHit above threshold
-      HGCalSoARecHitsHostCollection cells(index, iEvent.queue());
+      HGCalSoARecHitsHostCollection cells(iEvent.queue(), index);
       auto cellsView = cells.view();
 
       // loop over all hits and create the Hexel structure, skip energies below ecut
@@ -126,7 +126,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       if constexpr (!std::is_same_v<Device, alpaka_common::DevHost>) {
         // Trigger copy async to GPU
         //std::cout << "GPU" << std::endl;
-        HGCalSoARecHitsDeviceCollection deviceProduct{cells->metadata().size(), iEvent.queue()};
+        HGCalSoARecHitsDeviceCollection deviceProduct{iEvent.queue(), cells->metadata().size()};
         alpaka::memcpy(iEvent.queue(), deviceProduct.buffer(), cells.const_buffer());
         iEvent.emplace(deviceToken_, std::move(deviceProduct));
       } else {

--- a/RecoLocalCalo/HcalRecProducers/plugins/alpaka/HBHERecHitProducerPortable.cc
+++ b/RecoLocalCalo/HcalRecProducers/plugins/alpaka/HBHERecHitProducerPortable.cc
@@ -130,7 +130,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       edm::ParameterSet const& ps) {
     std::vector<int> offsets = ps.getParameter<std::vector<int>>("pulseOffsets");
 
-    PortableHostCollection<hcal::HcalMahiPulseOffsetsSoA> obj(offsets.size(), cms::alpakatools::host());
+    PortableHostCollection<hcal::HcalMahiPulseOffsetsSoA> obj(cms::alpakatools::host(), offsets.size());
     auto view = obj.view();
 
     for (uint32_t i = 0; i < offsets.size(); i++) {
@@ -153,7 +153,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     auto const f3DigisSize = f3HBDigisDev->metadata().size();
 
     auto const totalChannels = f01DigisSize + f5DigisSize + f3DigisSize;
-    OProductType outputGPU_{totalChannels, queue};
+    OProductType outputGPU_{queue, totalChannels};
 
     if (totalChannels > 0) {
       // conditions

--- a/RecoLocalCalo/HcalRecProducers/plugins/alpaka/HcalMahiConditionsESProducer.cc
+++ b/RecoLocalCalo/HcalRecProducers/plugins/alpaka/HcalMahiConditionsESProducer.cc
@@ -109,7 +109,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       size_t const totalChannels =
           pedestals.getAllContainers()[0].second.size() + pedestals.getAllContainers()[1].second.size();
 
-      auto product = std::make_unique<hcal::HcalMahiConditionsPortableHost>(totalChannels, cms::alpakatools::host());
+      auto product = std::make_unique<hcal::HcalMahiConditionsPortableHost>(cms::alpakatools::host(), totalChannels);
 
       auto view = product->view();
 

--- a/RecoLocalCalo/HcalRecProducers/plugins/alpaka/HcalSiPMCharacteristicsESProducer.cc
+++ b/RecoLocalCalo/HcalRecProducers/plugins/alpaka/HcalSiPMCharacteristicsESProducer.cc
@@ -29,7 +29,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       size_t const totalItems = sipmCharacteristics.getTypes();
 
-      auto product = std::make_unique<hcal::HcalSiPMCharacteristicsPortableHost>(totalItems, cms::alpakatools::host());
+      auto product = std::make_unique<hcal::HcalSiPMCharacteristicsPortableHost>(cms::alpakatools::host(), totalItems);
 
       auto view = product->view();
 

--- a/RecoLocalTracker/SiStripClusterizer/plugins/alpaka/SiStripRawToCluster.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/alpaka/SiStripRawToCluster.cc
@@ -128,8 +128,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::sistrip {
     auto nStrips = algo_.unpackStrips(iEvent.queue(), stripDataCond.const_data());
     if (nStrips == 0) {
       // No strips to unpack, empty cluster collection
-      iEvent.emplace(stripClustPutToken_, 0, iEvent.queue());
-      iEvent.emplace(stripDigiPutToken_, 0, iEvent.queue());
+      iEvent.emplace(stripClustPutToken_, iEvent.queue(), 0);
+      iEvent.emplace(stripDigiPutToken_, iEvent.queue(), 0);
     } else {
       // Run the clusterization algorithm (ThreeThresholdAlgorithm)
       auto cluster_d = algo_.makeClusters(iEvent.queue(), stripDataCond.const_data());

--- a/RecoLocalTracker/SiStripClusterizer/plugins/alpaka/SiStripRawToClusterAlgo.h
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/alpaka/SiStripRawToClusterAlgo.h
@@ -67,7 +67,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::sistrip {
   public:
     PortableFEDMover(Queue& queue, uint32_t rawBufferSize, uint32_t fedChannelsNb)
         : buffer_(cms::alpakatools::make_host_buffer<uint8_t[]>(queue, rawBufferSize)),
-          mapping_(fedChannelsNb, queue),
+          mapping_(queue, fedChannelsNb),
           bufferSize_(0),
           channelNb_(fedChannelsNb),
           offset4FedId_(sistrip::FED_ID_MAX + 1) {}

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CaloRecHitSoAProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CaloRecHitSoAProducer.cc
@@ -37,7 +37,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       if (DEBUG)
         printf("Found %d recHits\n", num_recHits);
 
-      hcal::RecHitHostCollection hostProduct{num_recHits, event.queue()};
+      hcal::RecHitHostCollection hostProduct{event.queue(), num_recHits};
       auto& view = hostProduct.view();
 
       for (int i = 0; i < num_recHits; i++) {
@@ -47,7 +47,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           printf("recHit %4d %u %f %f\n", i, view.detId(i), view.energy(i), view.timeM0(i));
       }
 
-      hcal::RecHitDeviceCollection deviceProduct{num_recHits, event.queue()};
+      hcal::RecHitDeviceCollection deviceProduct{event.queue(), num_recHits};
       alpaka::memcpy(event.queue(), deviceProduct.buffer(), hostProduct.buffer());
       if (synchronise_)
         alpaka::wait(event.queue());

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitECALParamsESProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitECALParamsESProducer.cc
@@ -27,7 +27,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     std::unique_ptr<reco::PFRecHitECALParamsHostCollection> produce(const EcalPFRecHitThresholdsRcd& iRecord) {
       const auto& thresholds = iRecord.get(thresholdsToken_);
-      auto product = std::make_unique<reco::PFRecHitECALParamsHostCollection>(ECAL::kSize, cms::alpakatools::host());
+      auto product = std::make_unique<reco::PFRecHitECALParamsHostCollection>(cms::alpakatools::host(), ECAL::kSize);
       for (uint32_t denseId = 0; denseId < ECAL::Barrel::kSize; denseId++)
         product->view().energyThresholds()[denseId] = thresholds.barrel(denseId);
       for (uint32_t denseId = 0; denseId < ECAL::Endcap::kSize; denseId++)

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitHCALParamsESProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitHCALParamsESProducer.cc
@@ -29,8 +29,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     }
 
     std::unique_ptr<reco::PFRecHitHCALParamsHostCollection> produce(PFRecHitHCALParamsRecord const& iRecord) {
-      auto product = std::make_unique<reco::PFRecHitHCALParamsHostCollection>(HCAL::kMaxDepthHB + HCAL::kMaxDepthHE,
-                                                                              cms::alpakatools::host());
+      auto product = std::make_unique<reco::PFRecHitHCALParamsHostCollection>(cms::alpakatools::host(),
+                                                                              HCAL::kMaxDepthHB + HCAL::kMaxDepthHE);
       for (uint32_t idx = 0; idx < HCAL::kMaxDepthHB; ++idx) {
         product->view().energyThresholds()[idx] = energyThresholdsHB_[idx];
       }

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
@@ -43,7 +43,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       for (const auto& token : recHitsToken_)
         num_recHits += event.get(token.first)->metadata().size();
 
-      pfRecHits_.emplace((int)num_recHits, event.queue());
+      pfRecHits_.emplace(event.queue(), num_recHits);
       *size_ = 0;
 
       if (num_recHits != 0) {

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitTopologyESProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitTopologyESProducer.cc
@@ -50,7 +50,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     std::unique_ptr<typename CAL::TopologyTypeHost> produce(const typename CAL::TopologyRecordType& iRecord) {
       const auto& geom = iRecord.get(geomToken_);
-      auto product = std::make_unique<typename CAL::TopologyTypeHost>(CAL::kSize, cms::alpakatools::host());
+      auto product = std::make_unique<typename CAL::TopologyTypeHost>(cms::alpakatools::host(), CAL::kSize);
       auto view = product->view();
       const int calEnums[2] = {CAL::kSubdetectorBarrelId, CAL::kSubdetectorEndcapId};
       for (const auto subdet : calEnums) {

--- a/RecoTracker/LSTCore/interface/LSTESData.h
+++ b/RecoTracker/LSTCore/interface/LSTESData.h
@@ -19,8 +19,8 @@ namespace lst {
     unsigned int nPixels;
     unsigned int nEndCapMap;
     // Using shared_ptr so that for the serial backend all streams can use the same data
-    std::shared_ptr<const PortableCollection<ModulesSoABlocks, TDev>> modules;
-    std::shared_ptr<const PortableCollection<EndcapGeometryDevSoA, TDev>> endcapGeometry;
+    std::shared_ptr<const PortableCollection<TDev, ModulesSoABlocks>> modules;
+    std::shared_ptr<const PortableCollection<TDev, EndcapGeometryDevSoA>> endcapGeometry;
     // Host-side object that is shared between the LSTESData<TDev> objects for different devices
     std::shared_ptr<const PixelMap> pixelMapping;
 
@@ -28,8 +28,8 @@ namespace lst {
               uint16_t const& nLowerModulesIn,
               unsigned int const& nPixelsIn,
               unsigned int const& nEndCapMapIn,
-              std::shared_ptr<const PortableCollection<ModulesSoABlocks, TDev>> modulesIn,
-              std::shared_ptr<const PortableCollection<EndcapGeometryDevSoA, TDev>> endcapGeometryIn,
+              std::shared_ptr<const PortableCollection<TDev, ModulesSoABlocks>> modulesIn,
+              std::shared_ptr<const PortableCollection<TDev, EndcapGeometryDevSoA>> endcapGeometryIn,
               std::shared_ptr<const PixelMap> const& pixelMappingIn)
         : nModules(nModulesIn),
           nLowerModules(nLowerModulesIn),
@@ -52,16 +52,16 @@ namespace cms::alpakatools {
     static lst::LSTESData<alpaka::Dev<TQueue>> copyAsync(TQueue& queue,
                                                          lst::LSTESData<alpaka_common::DevHost> const& srcData) {
       using TDev = alpaka::Dev<TQueue>;
-      std::shared_ptr<const PortableCollection<lst::ModulesSoABlocks, TDev>> deviceModules;
-      std::shared_ptr<const PortableCollection<lst::EndcapGeometryDevSoA, TDev>> deviceEndcapGeometry;
+      std::shared_ptr<const PortableCollection<TDev, lst::ModulesSoABlocks>> deviceModules;
+      std::shared_ptr<const PortableCollection<TDev, lst::EndcapGeometryDevSoA>> deviceEndcapGeometry;
 
       if constexpr (std::is_same_v<TDev, alpaka_common::DevHost>) {
         deviceModules = srcData.modules;
         deviceEndcapGeometry = srcData.endcapGeometry;
       } else {
-        deviceModules = std::make_shared<PortableCollection<lst::ModulesSoABlocks, TDev>>(
+        deviceModules = std::make_shared<PortableCollection<TDev, lst::ModulesSoABlocks>>(
             CopyToDevice<PortableHostCollection<lst::ModulesSoABlocks>>::copyAsync(queue, *srcData.modules));
-        deviceEndcapGeometry = std::make_shared<PortableCollection<lst::EndcapGeometryDevSoA, TDev>>(
+        deviceEndcapGeometry = std::make_shared<PortableCollection<TDev, lst::EndcapGeometryDevSoA>>(
             CopyToDevice<PortableHostCollection<lst::EndcapGeometryDevSoA>>::copyAsync(queue, *srcData.endcapGeometry));
       }
 

--- a/RecoTracker/LSTCore/interface/LSTPrepareInput.h
+++ b/RecoTracker/LSTCore/interface/LSTPrepareInput.h
@@ -213,8 +213,7 @@ namespace lst {
       nPixelSeeds = n_max_pixel_segments_per_module;
     }
 
-    LSTInputHostCollection lstInputHC(
-        queue, static_cast<int32_t>(nHitsIT + nHitsOT), static_cast<int32_t>(nPixelSeeds));
+    LSTInputHostCollection lstInputHC(queue, nHitsIT + nHitsOT, nPixelSeeds);
 
     auto hits = lstInputHC.view().hits();
     std::memcpy(hits.xs().data(), ph2_x.data(), nHitsOT * sizeof(float));

--- a/RecoTracker/LSTCore/src/LSTESData.cc
+++ b/RecoTracker/LSTCore/src/LSTESData.cc
@@ -91,7 +91,7 @@ std::unique_ptr<lst::LSTESData<alpaka_common::DevHost>> lst::loadAndFillESHost(s
   ::loadMapsHost(pLStoLayer, endcapGeometry, tiltedGeometry, moduleConnectionMap, ptCutLabel);
 
   auto endcapGeometryDev =
-      std::make_shared<EndcapGeometryDevHostCollection>(endcapGeometry.nEndCapMap, cms::alpakatools::host());
+      std::make_shared<EndcapGeometryDevHostCollection>(cms::alpakatools::host(), endcapGeometry.nEndCapMap);
   std::memcpy(endcapGeometryDev->view().geoMapDetId().data(),
               endcapGeometry.geoMapDetId_buf.data(),
               endcapGeometry.nEndCapMap * sizeof(unsigned int));

--- a/RecoTracker/LSTCore/src/ModuleMethods.h
+++ b/RecoTracker/LSTCore/src/ModuleMethods.h
@@ -239,8 +239,7 @@ namespace lst {
           totalSizes_neg,
           connectedModuleDetIds_neg] = getConnectedPixels(nModules, nPixels, pixelMapping, pLStoLayer);
 
-    auto modulesHC = std::make_shared<ModulesHostCollection>(
-        cms::alpakatools::host(), static_cast<int32_t>(nModules), static_cast<int32_t>(nPixels));
+    auto modulesHC = std::make_shared<ModulesHostCollection>(cms::alpakatools::host(), nModules, nPixels);
 
     auto modules_view = modulesHC->view().modules();
 

--- a/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
@@ -99,13 +99,13 @@ void LSTEvent::addInputToEvent(LSTInputDeviceCollection const* lstInputDC) {
 void LSTEvent::addHitToEvent() {
   if (!hitsDC_) {
     const int32_t nHits = lstInputDC_->size()[0];
-    hitsDC_.emplace(queue_, nHits, static_cast<int32_t>(nModules_));
+    hitsDC_.emplace(queue_, nHits, nModules_);
     auto buf = hitsDC_->buffer();
     alpaka::memset(queue_, buf, 0xff);
   }
 
   if (!rangesDC_) {
-    rangesDC_.emplace(nLowerModules_ + 1, queue_);
+    rangesDC_.emplace(queue_, nLowerModules_ + 1);
     auto buf = rangesDC_->buffer();
     alpaka::memset(queue_, buf, 0xff);
   }
@@ -146,7 +146,7 @@ void LSTEvent::addPixelSegmentToEventStart() {
   }
 
   if (!pixelSegmentsDC_) {
-    pixelSegmentsDC_.emplace(pixelSize_, queue_);
+    pixelSegmentsDC_.emplace(queue_, pixelSize_);
   }
 }
 
@@ -204,7 +204,7 @@ void LSTEvent::createMiniDoublets() {
     *nTotalMDs_buf_h.data() += n_max_pixel_md_per_modules;
     unsigned int nTotalMDs = *nTotalMDs_buf_h.data();
 
-    miniDoubletsDC_.emplace(queue_, static_cast<int32_t>(nTotalMDs), static_cast<int32_t>(nLowerModules_ + 1));
+    miniDoubletsDC_.emplace(queue_, nTotalMDs, nLowerModules_ + 1);
 
     auto mdsOccupancy = miniDoubletsDC_->view().miniDoubletsOccupancy();
     auto nMDs_view = cms::alpakatools::make_device_view(queue_, mdsOccupancy.nMDs());
@@ -293,7 +293,7 @@ void LSTEvent::createSegmentsWithModuleMap() {
 
     nTotalSegments_ += n_max_pixel_segments_per_module;
 
-    segmentsDC_.emplace(queue_, static_cast<int32_t>(nTotalSegments_), static_cast<int32_t>(nLowerModules_ + 1));
+    segmentsDC_.emplace(queue_, nTotalSegments_, nLowerModules_ + 1);
 
     auto segmentsOccupancy = segmentsDC_->view().segmentsOccupancy();
     auto segments = segmentsDC_->view().segments();
@@ -373,7 +373,7 @@ void LSTEvent::createTriplets() {
     alpaka::memcpy(queue_, maxTriplets_buf_h, maxTriplets_buf_d);
     alpaka::wait(queue_);  // wait to get the value before using it
 
-    tripletsDC_.emplace(queue_, static_cast<int32_t>(*maxTriplets_buf_h.data()), static_cast<int32_t>(nLowerModules_));
+    tripletsDC_.emplace(queue_, *maxTriplets_buf_h.data(), nLowerModules_);
 
     auto tripletsOccupancy = tripletsDC_->view().tripletsOccupancy();
     auto nTriplets_view = cms::alpakatools::make_device_view(queue_, tripletsOccupancy.nTriplets());
@@ -469,10 +469,10 @@ void LSTEvent::createTriplets() {
 
 void LSTEvent::createTrackCandidates(bool no_pls_dupclean, bool tc_pls_triplets) {
   if (!trackCandidatesBaseDC_) {
-    trackCandidatesBaseDC_.emplace(n_max_nonpixel_track_candidates + n_max_pixel_track_candidates, queue_);
+    trackCandidatesBaseDC_.emplace(queue_, n_max_nonpixel_track_candidates + n_max_pixel_track_candidates);
     trackCandidatesBaseDC_->zeroInitialise(queue_);
 
-    trackCandidatesExtendedDC_.emplace(n_max_nonpixel_track_candidates + n_max_pixel_track_candidates, queue_);
+    trackCandidatesExtendedDC_.emplace(queue_, n_max_nonpixel_track_candidates + n_max_pixel_track_candidates);
     trackCandidatesExtendedDC_->zeroInitialise(queue_);
   }
 
@@ -701,7 +701,7 @@ void LSTEvent::createTrackCandidates(bool no_pls_dupclean, bool tc_pls_triplets)
 
 void LSTEvent::createPixelTriplets() {
   if (!pixelTripletsDC_) {
-    pixelTripletsDC_.emplace(n_max_pixel_triplets, queue_);
+    pixelTripletsDC_.emplace(queue_, n_max_pixel_triplets);
     auto nPixelTriplets_view = cms::alpakatools::make_device_view(queue_, (*pixelTripletsDC_)->nPixelTriplets());
     alpaka::memset(queue_, nPixelTriplets_view, 0u);
     auto totOccupancyPixelTriplets_view =
@@ -859,7 +859,7 @@ void LSTEvent::createQuintuplets() {
   auto nTotalQuintuplets = *nTotalQuintuplets_buf.data();
 
   if (!quintupletsDC_) {
-    quintupletsDC_.emplace(queue_, static_cast<int32_t>(nTotalQuintuplets), static_cast<int32_t>(nLowerModules_));
+    quintupletsDC_.emplace(queue_, nTotalQuintuplets, nLowerModules_);
     auto quintupletsOccupancy = quintupletsDC_->view().quintupletsOccupancy();
     auto nQuintuplets_view = cms::alpakatools::make_device_view(queue_, quintupletsOccupancy.nQuintuplets());
     alpaka::memset(queue_, nQuintuplets_view, 0u);
@@ -934,7 +934,7 @@ void LSTEvent::pixelLineSegmentCleaning(bool no_pls_dupclean) {
 
 void LSTEvent::createPixelQuintuplets() {
   if (!pixelQuintupletsDC_) {
-    pixelQuintupletsDC_.emplace(n_max_pixel_quintuplets, queue_);
+    pixelQuintupletsDC_.emplace(queue_, n_max_pixel_quintuplets);
     auto nPixelQuintuplets_view =
         cms::alpakatools::make_device_view(queue_, (*pixelQuintupletsDC_)->nPixelQuintuplets());
     alpaka::memset(queue_, nPixelQuintuplets_view, 0u);
@@ -943,10 +943,10 @@ void LSTEvent::createPixelQuintuplets() {
     alpaka::memset(queue_, totOccupancyPixelQuintuplets_view, 0u);
   }
   if (!trackCandidatesBaseDC_) {
-    trackCandidatesBaseDC_.emplace(n_max_nonpixel_track_candidates + n_max_pixel_track_candidates, queue_);
+    trackCandidatesBaseDC_.emplace(queue_, n_max_nonpixel_track_candidates + n_max_pixel_track_candidates);
     trackCandidatesBaseDC_->zeroInitialise(queue_);
 
-    trackCandidatesExtendedDC_.emplace(n_max_nonpixel_track_candidates + n_max_pixel_track_candidates, queue_);
+    trackCandidatesExtendedDC_.emplace(queue_, n_max_nonpixel_track_candidates + n_max_pixel_track_candidates);
     trackCandidatesExtendedDC_->zeroInitialise(queue_);
   }
   SegmentsOccupancy segmentsOccupancy = segmentsDC_->view().segmentsOccupancy();
@@ -1116,7 +1116,7 @@ void LSTEvent::createQuadruplets() {
   auto nTotalQuadruplets = *nTotalQuadruplets_buf.data();
 
   if (!quadrupletsDC_) {
-    quadrupletsDC_.emplace(queue_, static_cast<int32_t>(nTotalQuadruplets), static_cast<int32_t>(nLowerModules_));
+    quadrupletsDC_.emplace(queue_, nTotalQuadruplets, nLowerModules_);
     auto quadrupletsOccupancy = quadrupletsDC_->view().quadrupletsOccupancy();
     auto nQuadruplets_view = cms::alpakatools::make_device_view(
         queue_, quadrupletsOccupancy.nQuadruplets(), quadrupletsOccupancy.metadata().size());
@@ -1575,7 +1575,7 @@ typename TSoA::ConstView LSTEvent::getInput(bool sync) {
     // In case getTrimmedInput was called first
     if (!lstInputHC_ || lstInputHC_->size()[1] == 0) {
       lstInputHC_.emplace(
-          cms::alpakatools::CopyToHost<PortableDeviceCollection<LSTInputSoA, TDev>>::copyAsync(queue_, *lstInputDC_));
+          cms::alpakatools::CopyToHost<PortableDeviceCollection<TDev, LSTInputSoA>>::copyAsync(queue_, *lstInputDC_));
       if (sync)
         alpaka::wait(queue_);  // host consumers expect filled data
     }
@@ -1592,7 +1592,7 @@ typename TSoA::ConstView LSTEvent::getHits(bool sync) {
   } else {
     if (!hitsHC_) {
       hitsHC_.emplace(
-          cms::alpakatools::CopyToHost<PortableDeviceCollection<HitsSoA, TDev>>::copyAsync(queue_, *hitsDC_));
+          cms::alpakatools::CopyToHost<PortableDeviceCollection<TDev, HitsSoA>>::copyAsync(queue_, *hitsDC_));
       if (sync)
         alpaka::wait(queue_);  // host consumers expect filled data
     }
@@ -1609,7 +1609,7 @@ ObjectRangesConst LSTEvent::getRanges(bool sync) {
   } else {
     if (!rangesHC_) {
       rangesHC_.emplace(
-          cms::alpakatools::CopyToHost<PortableDeviceCollection<ObjectRangesSoA, TDev>>::copyAsync(queue_, *rangesDC_));
+          cms::alpakatools::CopyToHost<PortableDeviceCollection<TDev, ObjectRangesSoA>>::copyAsync(queue_, *rangesDC_));
       if (sync)
         alpaka::wait(queue_);  // host consumers expect filled data
     }
@@ -1625,7 +1625,7 @@ typename TSoA::ConstView LSTEvent::getMiniDoublets(bool sync) {
   } else {
     if (!miniDoubletsHC_) {
       miniDoubletsHC_.emplace(
-          cms::alpakatools::CopyToHost<PortableDeviceCollection<MiniDoubletsSoABlocks, TDev>>::copyAsync(
+          cms::alpakatools::CopyToHost<PortableDeviceCollection<TDev, MiniDoubletsSoABlocks>>::copyAsync(
               queue_, *miniDoubletsDC_));
       if (sync)
         alpaka::wait(queue_);  // host consumers expect filled data
@@ -1642,7 +1642,7 @@ typename TSoA::ConstView LSTEvent::getSegments(bool sync) {
     return SegmentsViewAccessor<TSoA>::get(segmentsDC_->const_view());
   } else {
     if (!segmentsHC_) {
-      segmentsHC_.emplace(cms::alpakatools::CopyToHost<PortableDeviceCollection<SegmentsSoABlocks, TDev>>::copyAsync(
+      segmentsHC_.emplace(cms::alpakatools::CopyToHost<PortableDeviceCollection<TDev, SegmentsSoABlocks>>::copyAsync(
           queue_, *segmentsDC_));
       if (sync)
         alpaka::wait(queue_);  // host consumers expect filled data
@@ -1659,7 +1659,7 @@ PixelSegmentsConst LSTEvent::getPixelSegments(bool sync) {
     return pixelSegmentsDC_->const_view();
   } else {
     if (!pixelSegmentsHC_) {
-      pixelSegmentsHC_.emplace(cms::alpakatools::CopyToHost<::PortableCollection<PixelSegmentsSoA, TDev>>::copyAsync(
+      pixelSegmentsHC_.emplace(cms::alpakatools::CopyToHost<::PortableCollection<TDev, PixelSegmentsSoA>>::copyAsync(
           queue_, *pixelSegmentsDC_));
 
       if (sync)
@@ -1676,7 +1676,7 @@ typename TSoA::ConstView LSTEvent::getTriplets(bool sync) {
     return TripletsViewAccessor<TSoA>::get(tripletsDC_->const_view());
   } else {
     if (!tripletsHC_) {
-      tripletsHC_.emplace(cms::alpakatools::CopyToHost<PortableDeviceCollection<TripletsSoABlocks, TDev>>::copyAsync(
+      tripletsHC_.emplace(cms::alpakatools::CopyToHost<PortableDeviceCollection<TDev, TripletsSoABlocks>>::copyAsync(
           queue_, *tripletsDC_));
       if (sync)
         alpaka::wait(queue_);  // host consumers expect filled data
@@ -1694,7 +1694,7 @@ typename TSoA::ConstView LSTEvent::getQuadruplets(bool sync) {
   } else {
     if (!quadrupletsHC_) {
       quadrupletsHC_.emplace(
-          cms::alpakatools::CopyToHost<PortableDeviceCollection<QuadrupletsSoABlocks, TDev>>::copyAsync(
+          cms::alpakatools::CopyToHost<PortableDeviceCollection<TDev, QuadrupletsSoABlocks>>::copyAsync(
               queue_, *quadrupletsDC_));
       if (sync)
         alpaka::wait(queue_);  // host consumers expect filled data
@@ -1712,7 +1712,7 @@ typename TSoA::ConstView LSTEvent::getQuintuplets(bool sync) {
   } else {
     if (!quintupletsHC_) {
       quintupletsHC_.emplace(
-          cms::alpakatools::CopyToHost<PortableDeviceCollection<QuintupletsSoABlocks, TDev>>::copyAsync(
+          cms::alpakatools::CopyToHost<PortableDeviceCollection<TDev, QuintupletsSoABlocks>>::copyAsync(
               queue_, *quintupletsDC_));
       if (sync)
         alpaka::wait(queue_);  // host consumers expect filled data
@@ -1729,7 +1729,7 @@ PixelTripletsConst LSTEvent::getPixelTriplets(bool sync) {
     return pixelTripletsDC_->const_view();
   } else {
     if (!pixelTripletsHC_) {
-      pixelTripletsHC_.emplace(cms::alpakatools::CopyToHost<::PortableCollection<PixelTripletsSoA, TDev>>::copyAsync(
+      pixelTripletsHC_.emplace(cms::alpakatools::CopyToHost<::PortableCollection<TDev, PixelTripletsSoA>>::copyAsync(
           queue_, *pixelTripletsDC_));
 
       if (sync)
@@ -1747,7 +1747,7 @@ PixelQuintupletsConst LSTEvent::getPixelQuintuplets(bool sync) {
   } else {
     if (!pixelQuintupletsHC_) {
       pixelQuintupletsHC_.emplace(
-          cms::alpakatools::CopyToHost<::PortableCollection<PixelQuintupletsSoA, TDev>>::copyAsync(
+          cms::alpakatools::CopyToHost<::PortableCollection<TDev, PixelQuintupletsSoA>>::copyAsync(
               queue_, *pixelQuintupletsDC_));
 
       if (sync)
@@ -1765,7 +1765,7 @@ TrackCandidatesBaseConst LSTEvent::getTrackCandidatesBase(bool sync) {
   } else {
     if (!trackCandidatesBaseHC_) {
       trackCandidatesBaseHC_.emplace(
-          cms::alpakatools::CopyToHost<::PortableCollection<TrackCandidatesBaseSoA, TDev>>::copyAsync(
+          cms::alpakatools::CopyToHost<::PortableCollection<TDev, TrackCandidatesBaseSoA>>::copyAsync(
               queue_, *trackCandidatesBaseDC_));
 
       if (sync)
@@ -1783,7 +1783,7 @@ TrackCandidatesExtendedConst LSTEvent::getTrackCandidatesExtended(bool sync) {
   } else {
     if (!trackCandidatesExtendedHC_) {
       trackCandidatesExtendedHC_.emplace(
-          cms::alpakatools::CopyToHost<::PortableCollection<TrackCandidatesExtendedSoA, TDev>>::copyAsync(
+          cms::alpakatools::CopyToHost<::PortableCollection<TDev, TrackCandidatesExtendedSoA>>::copyAsync(
               queue_, *trackCandidatesExtendedDC_));
 
       if (sync)
@@ -1805,7 +1805,7 @@ typename TSoA::ConstView LSTEvent::getModules(bool sync) {
   } else {
     if (!modulesHC_) {
       modulesHC_.emplace(
-          cms::alpakatools::CopyToHost<PortableDeviceCollection<ModulesSoABlocks, TDev>>::copyAsync(queue_, modules_));
+          cms::alpakatools::CopyToHost<PortableDeviceCollection<TDev, ModulesSoABlocks>>::copyAsync(queue_, modules_));
       if (sync)
         alpaka::wait(queue_);  // host consumers expect filled data
     }

--- a/RecoTracker/PixelSeeding/interface/CAGeometryDevice.h
+++ b/RecoTracker/PixelSeeding/interface/CAGeometryDevice.h
@@ -11,6 +11,6 @@
 
 namespace reco {
   template <typename TDev>
-  using CAGeometryDevice = PortableDeviceCollection<CALayout, TDev>;
+  using CAGeometryDevice = PortableDeviceCollection<TDev, CALayout>;
 }
 #endif  // RecoTracker_PixelSeeding_interface_CAGeometryDevice_H

--- a/RecoTracker/PixelSeeding/interface/CAPairDevice.h
+++ b/RecoTracker/PixelSeeding/interface/CAPairDevice.h
@@ -11,7 +11,7 @@
 
 namespace caStructures {
   template <typename TDev>
-  using CAPairDevice = PortableDeviceCollection<CAPairSoA, TDev>;
+  using CAPairDevice = PortableDeviceCollection<TDev, CAPairSoA>;
 }
 
 #endif  // RecoTracker_PixelSeeding_interface_CAPairDevice_H

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGenerator.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGenerator.cc
@@ -395,7 +395,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     const int32_t H = m_params.algoParams_.avgHitsPerTrack_;
 
-    reco::TracksSoACollection trackCollection(queue, static_cast<int32_t>(nTracks), static_cast<int32_t>(nTracks * H));
+    reco::TracksSoACollection trackCollection(queue, nTracks, nTracks * H);
 
     auto tracks = trackCollection.view().tracks();
 

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernels.dev.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernels.dev.cc
@@ -169,8 +169,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     device_nCellTracks_ =
         cms::alpakatools::make_device_view(queue, *reinterpret_cast<uint32_t *>(device_extraStorage_->data() + 4));
 
-    deviceTriplets_ = CAPairSoACollection(maxDoublets * algoParams.avgCellsPerCell_, queue);
-    deviceTracksCells_ = CAPairSoACollection(nCellsToTracks, queue);
+    deviceTriplets_ = CAPairSoACollection(queue, std::lrint(maxDoublets * algoParams.avgCellsPerCell_));
+    deviceTracksCells_ = CAPairSoACollection(queue, nCellsToTracks);
 
     //TODO: if doStats?
     alpaka::memset(queue, *counters_, 0);
@@ -274,7 +274,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 #endif
 
     auto threadsPerBlock = 1024;
-    auto blocks = cms::alpakatools::divide_up_by(maxDoublets * m_params.algoParams_.avgCellsPerCell_, threadsPerBlock);
+    auto blocks = cms::alpakatools::divide_up_by(std::lrint(maxDoublets * m_params.algoParams_.avgCellsPerCell_),
+                                                 threadsPerBlock);
     auto workDiv1D = cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock);
 
     alpaka::exec<Acc1D>(queue,
@@ -339,7 +340,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     CellToTracks::template launchFinalize<Acc1D>(this->device_cellToTracksView_, queue);
 
-    blocks = cms::alpakatools::divide_up_by(maxDoublets * m_params.algoParams_.avgCellsPerCell_, threadsPerBlock);
+    blocks = cms::alpakatools::divide_up_by(std::lrint(maxDoublets * m_params.algoParams_.avgCellsPerCell_),
+                                            threadsPerBlock);
     workDiv1D = cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock);
 
     alpaka::exec<Acc1D>(queue,

--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/vertexFinder.dev.cc
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/vertexFinder.dev.cc
@@ -131,11 +131,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       std::cout << "producing Vertices on GPU" << std::endl;
 #endif  // PIXVERTEX_DEBUG_PRODUCE
       const auto maxTracks = tracks_view.metadata().size();
-      reco::ZVertexSoACollection vertices(queue, static_cast<int32_t>(maxVertices), static_cast<int32_t>(maxTracks));
+      reco::ZVertexSoACollection vertices(queue, maxVertices, maxTracks);
       auto data = vertices.view().zvertex();
       auto trkdata = vertices.view().zvertexTracks();
 
-      PixelVertexWorkSpaceSoADevice workspace(maxTracks, queue);
+      PixelVertexWorkSpaceSoADevice workspace(queue, maxTracks);
       auto ws = workspace.view();
 
       // Initialize

--- a/RecoVertex/PixelVertexFinding/test/alpaka/VertexFinder_t.dev.cc
+++ b/RecoVertex/PixelVertexFinding/test/alpaka/VertexFinder_t.dev.cc
@@ -121,8 +121,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       constexpr int32_t maxTracks = 32 * 1024;
       constexpr int32_t maxVertices = 1024;
 
-      vertexFinder::PixelVertexWorkSpaceSoADevice ws_d(maxTracks, queue);
-      vertexFinder::PixelVertexWorkSpaceSoAHost ws_h(maxTracks, queue);
+      vertexFinder::PixelVertexWorkSpaceSoADevice ws_d(queue, maxTracks);
+      vertexFinder::PixelVertexWorkSpaceSoAHost ws_h(queue, maxTracks);
       reco::ZVertexHost vertices_h(queue, maxVertices, maxTracks);
       reco::ZVertexSoACollection vertices_d(queue, maxVertices, maxTracks);
 


### PR DESCRIPTION
The `PortableCollections` have an inconsistent interface if used with a normal `Layout` or with an `SoABlocks Layout`. In the later case, the `Alpaka Queue` is the first argument, while in the first case it is the other way around. This PR addresses the problem and sets the `Alpaka Queue` always as the **first** argument. 

Furthermore, the constructors of the `PortableCollections` are streamlined to always use `std::integal` as the input type for the elements. Then a `checked_cast` has been implemented that checks if casting to `int` is safe. If so, the inputs are casted to `int`. Casting to `int` is necessary since the `SoA Layouts` use `int` for the number of elements due to the dependency on `ROOT`. 

This PR has to be addressed after #49734. 

@felicepantaleo fyi