### PR TITLE
Add trigger summary to HcalCalIterativePhiSym output

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIterativePhiSym_Output_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIterativePhiSym_Output_cff.py
@@ -15,6 +15,7 @@ OutALCARECOHcalCalIterativePhiSym_noDrop = cms.PSet(
                                             "keep *_offlinePrimaryVertices_*_*",
                                             'keep HcalNoiseSummary_hcalnoise_*_*',
                                             "keep *_scalersRawToDigi_*_*",
+                                            "keep triggerTriggerEvent_hltTriggerSummaryAOD__HLT",
                                             "keep edmTriggerResults_*_*_HLT")
 
 )


### PR DESCRIPTION
Need to keep that for reweighting based on trigger HLT paths in the HCAL PhiSym calibration workflow implemented at the automation level.

#### PR description:

It adds `"keep triggerTriggerEvent_hltTriggerSummaryAOD__HLT"` to the file `ALCARECOHcalCalIterativePhiSym_Output_cff.py`.

#### PR validation:

We have already tested that in `CMSSW_15_0_X`, and the changes produce the additional information required for the calibration process.

The target is 2026 data-taking; however, we might proceed with a backport to `CMSSW_15_0_X` if needed.

Thanks,
Jordan
