### PR TITLE
demangle type name in warnings in `HLTCaloObjInRegionsProducer`

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/plugins/HLTCaloObjInRegionsProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/HLTCaloObjInRegionsProducer.cc
@@ -1,15 +1,16 @@
 #include <memory>
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/TypeDemangler.h"
 
 #include "DataFormats/RecoCandidate/interface/RecoEcalCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
@@ -196,8 +197,9 @@ void HLTCaloObjInRegionsProducer<CaloObjType, CaloObjCollType>::produce(edm::Eve
     event.getByToken(inputTokens_[inputCollNr], inputColl);
 
     if (!(inputColl.isValid())) {
-      edm::LogError("ProductNotFound") << "could not get a handle on the " << typeid(CaloObjCollType).name()
-                                       << " named " << inputCollTags_[inputCollNr].encode() << std::endl;
+      edm::LogError("ProductNotFound") << "could not get a handle on the "
+                                       << edm::typeDemangle(typeid(CaloObjCollType).name()) << " named "
+                                       << inputCollTags_[inputCollNr].encode() << std::endl;
       continue;
     }
     auto outputColl = makeFilteredColl(inputColl, caloGeom, regions);
@@ -224,8 +226,9 @@ std::unique_ptr<CaloObjCollType> HLTCaloObjInRegionsProducer<CaloObjType, CaloOb
           //so we check if the ID is valid
           if (validIDForGeom(obj.id())) {
             edm::LogError("HLTCaloObjInRegionsProducer")
-                << "for an object of type " << typeid(CaloObjType).name() << " the geometry returned null for id "
-                << DetId(obj.id()).rawId() << " with initial ID " << DetId(inputColl->begin()->id()).rawId()
+                << "for an object of type " << edm::typeDemangle(typeid(CaloObjType).name())
+                << " the geometry returned null for id " << DetId(obj.id()).rawId() << " with initial ID "
+                << DetId(inputColl->begin()->id()).rawId()
                 << " in HLTCaloObjsInRegion, this shouldnt be possible and something has gone wrong, auto accepting "
                    "hit";
           }


### PR DESCRIPTION
#### PR description:

Title says it all.

#### PR validation:

Run the following script

```bash
#!/bin/bash -ex

cmsDriver.py Phase2 -s L1P2GT,HLT:75e33_timing \
	     --processName=HLTX \
	     --conditions auto:phase2_realistic_T33 \
	     --eventcontent FEVTDEBUGHLT \
	     --geometry ExtendedRun4D110 \
	     --era Phase2C17I13M9 \
	     --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
	     --filein file:/eos/cms/store/relval/CMSSW_16_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_150X_mcRun4_realistic_v1_STD_Run4D110_PU-v1/2580000/001dbc89-418f-4460-9ba5-2592713f13f6.root \
	     --mc \
	     --inputCommands="keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT" \
	     -n 10 \
	     --no_exec \
	     --output={} \
	     --python_filename test_cfg.py

cmsRun test_cfg.py >& test.log
```

in `CMSSW_16_1_X_2026-01-18-0000` and observed demangled type in the warnings (as reported at https://github.com/cms-sw/cmssw/issues/49864).
 
#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A