### PR TITLE
Improved exception message coming from RNTupleTempOutputModule

### DIFF
--- a/FWIO/RNTupleTempOutput/src/RootOutputFile.cc
+++ b/FWIO/RNTupleTempOutput/src/RootOutputFile.cc
@@ -38,6 +38,7 @@
 #include "FWCore/ParameterSet/interface/Registry.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/ExceptionPropagate.h"
+#include "FWCore/Utilities/interface/ConvertException.h"
 #include "IOPool/Common/interface/getWrapperBasePtr.h"
 #include "IOPool/Provenance/interface/CommonProvenanceFiller.h"
 
@@ -177,11 +178,18 @@ namespace edm::rntuple_temp {
       for (auto& item : om_->selectedOutputItemList()[i]) {
         item.setProduct(nullptr);
         ProductDescription const& desc = *item.productDescription();
-        theRNTuple->addField(fixName(desc.branchName()),
-                             desc.wrappedName(),
-                             item.productPtr(),
-                             item.streamerProduct() or om_->allProductsUseStreamer(),
-                             om_->noSplitSubFields());
+        try {
+          edm::convertException::wrap([&]() {
+            theRNTuple->addField(fixName(desc.branchName()),
+                                 desc.wrappedName(),
+                                 item.productPtr(),
+                                 item.streamerProduct() or om_->allProductsUseStreamer(),
+                                 om_->noSplitSubFields());
+          });
+        } catch (cms::Exception& iExcept) {
+          iExcept.addContext(std::format("adding field {} with class type {}", desc.branchName(), desc.className()));
+          throw;
+        }
         //make sure we always store product registry info for all branches we create
         branchesWithStoredHistory_.insert(item.branchID());
       }


### PR DESCRIPTION
#### PR description:

When adding a field fails, now include which branch caused the problem.

#### PR validation:

Tested on failing IB RelVal 77.0 and exception included expected information.

resolves https://github.com/cms-sw/framework-team/issues/1802