### PR TITLE
classlib cleanup: Remove unused headers and deps

### DIFF
--- a/DQMServices/Components/plugins/MEtoEDMConverter.cc
+++ b/DQMServices/Components/plugins/MEtoEDMConverter.cc
@@ -28,9 +28,6 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
-#include "classlib/utils/StringList.h"
-#include "classlib/utils/StringOps.h"
-
 // helper files
 #include <iostream>
 #include <cstdlib>

--- a/DQMServices/Core/src/DQMNet.cc
+++ b/DQMServices/Core/src/DQMNet.cc
@@ -3,7 +3,6 @@
 #include "classlib/iobase/LocalServerSocket.h"
 #include "classlib/sysapi/InetSocket.h"  // for completing InetAddress
 #include "classlib/utils/SystemError.h"
-#include "classlib/utils/Regexp.h"
 #include <fmt/format.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -29,8 +28,6 @@
 #define SOCKET_READ_GROWTH (SOCKET_BUF_SIZE)
 
 using namespace lat;
-
-static const Regexp s_rxmeval("<(.*)>(i|f|s|qr)=(.*)</\\1>");
 
 // TODO: Can't include the header file since that leads to ambiguities.
 namespace dqm {

--- a/RecoLocalTracker/SiPhase2VectorHitBuilder/test/BuildFile.xml
+++ b/RecoLocalTracker/SiPhase2VectorHitBuilder/test/BuildFile.xml
@@ -1,6 +1,5 @@
 <use   name="boost"/>
 <use   name="root"/>
-<use   name="classlib"/>
 <use   name="clhep"/>
 <use   name="SimDataFormats/Track"/>
 <use   name="SimDataFormats/TrackerDigiSimLink"/>

--- a/Validation/RecoTau/plugins/BuildFile.xml
+++ b/Validation/RecoTau/plugins/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/PluginManager"/>
-<use name="classlib"/>
 <use name="FWCore/ParameterSet"/>
 <use name="DQMServices/Core"/>
 <use name="rootgraphics"/>


### PR DESCRIPTION
Fixes https://github.com/cms-sw/cmssw/issues/17977

This PR removes unnecessary classlib dependency ( by cleaning up BuildFiles and removing unused includes)

Removed `static const Regexp s_rxmeval` is not used any where and looks like it was  leftover from 16 years ago [cleanup](https://cmscvs.web.cern.ch/cgi/viewvc.cgi/cvsroot/CMSSW/DQMServices/Core/src/DQMNet.cc?r1=1.26&r2=1.27)