### PR TITLE
[EVO] Moved data products in reco:: namespace to reco::io_v1

### DIFF
--- a/AnalysisDataFormats/SUSYBSMObjects/src/classes_def.xml
+++ b/AnalysisDataFormats/SUSYBSMObjects/src/classes_def.xml
@@ -1,6 +1,6 @@
 <lcgdict>
    <class name="susybsm::HSCParticle" ClassVersion="3">
-    <version ClassVersion="3" checksum="2568887826"/>
+    <version ClassVersion="3" checksum="3189720800"/>
    </class>
    <class name="susybsm::RPCBetaMeasurement" ClassVersion="10">
     <version ClassVersion="10" checksum="2621605308"/>

--- a/AnalysisDataFormats/TopObjects/src/classes_def.xml
+++ b/AnalysisDataFormats/TopObjects/src/classes_def.xml
@@ -1,30 +1,24 @@
 <lcgdict>
-  <class name="TtGenEvent"  ClassVersion="12">
-   <version ClassVersion="12" checksum="3953108735"/>
-   <version ClassVersion="11" checksum="3979818069"/>
-   <version ClassVersion="10" checksum="2353612425"/>
+  <class name="TtGenEvent"  ClassVersion="3">
+   <version ClassVersion="3" checksum="2709360007"/>
   </class>
-  <class name="StGenEvent"  ClassVersion="11">
-   <version ClassVersion="11" checksum="712808804"/>
-   <version ClassVersion="10" checksum="3161795320"/>
+  <class name="StGenEvent"  ClassVersion="3">
+   <version ClassVersion="3" checksum="816344636"/>
   </class>
-  <class name="TopGenEvent"  ClassVersion="10">
-   <version ClassVersion="10" checksum="4112324732"/>
+  <class name="TopGenEvent"  ClassVersion="3">
+   <version ClassVersion="3" checksum="4215860564"/>
   </class>
-  <class name="TtEvent"  ClassVersion="11">
-   <version ClassVersion="11" checksum="1688727696"/>
+  <class name="TtEvent"  ClassVersion="3">
+   <version ClassVersion="3" checksum="67438550"/>
   </class>
-  <class name="TtFullLeptonicEvent"  ClassVersion="11">
-   <version ClassVersion="11" checksum="4030394490"/>
-   <version ClassVersion="10" checksum="1854988496"/>
+  <class name="TtFullLeptonicEvent"  ClassVersion="3">
+   <version ClassVersion="3" checksum="3754713216"/>
   </class>
-  <class name="TtSemiLeptonicEvent"  ClassVersion="11">
-   <version ClassVersion="11" checksum="3559376459"/>
-   <version ClassVersion="10" checksum="4150310883"/>
+  <class name="TtSemiLeptonicEvent"  ClassVersion="3">
+   <version ClassVersion="3" checksum="2068896689"/>
   </class>
-  <class name="TtFullHadronicEvent"  ClassVersion="11">
-   <version ClassVersion="11" checksum="350583477"/>
-   <version ClassVersion="10" checksum="3848919223"/>
+  <class name="TtFullHadronicEvent"  ClassVersion="3">
+   <version ClassVersion="3" checksum="3024261627"/>
   </class>
   <class name="edm::Wrapper<TtGenEvent>" />
   <class name="edm::Wrapper<StGenEvent>" />
@@ -32,7 +26,6 @@
   <class name="edm::Wrapper<TtFullLeptonicEvent>" />
   <class name="edm::Wrapper<TtSemiLeptonicEvent>" />
   <class name="edm::Wrapper<TtFullHadronicEvent>" />
-  <class name="edm::Wrapper<reco::CompositeCandidate>" />
 
   <class name="edm::RefProd<TtGenEvent>" />
   <class name="edm::RefProd<StGenEvent>" />
@@ -42,18 +35,15 @@
   <class name="edm::RefProd<TtFullHadronicEvent>" />
 
   <class name="std::pair<WDecay::LeptonType, WDecay::LeptonType>" />
-  <class name="std::pair<reco::CompositeCandidate, std::vector<int> >" />
-  <class name="std::vector<std::pair<reco::CompositeCandidate, std::vector<int> > >" />
-  <class name="edm::Wrapper<std::vector<std::pair<reco::CompositeCandidate, std::vector<int> > > >" />
 
   <class name="std::map<TtEvent::HypoClassKey, int>" />
-  <class name="std::map<TtEvent::HypoClassKey, std::vector<std::pair<reco::CompositeCandidate, std::vector<int> > > >" />
+  <class name="std::map<TtEvent::HypoClassKey, std::vector<std::pair<reco::io_v1::CompositeCandidate, std::vector<int> > > >" />
 
   <class name="TtDilepEvtSolution"  ClassVersion="10">
    <version ClassVersion="10" checksum="3903965368"/>
   </class>
-  <class name="TtSemiEvtSolution"  ClassVersion="10">
-   <version ClassVersion="10" checksum="702702553"/>
+  <class name="TtSemiEvtSolution"  ClassVersion="3">
+   <version ClassVersion="3" checksum="3559385149"/>
   </class>
   <class name="TtHadEvtSolution"  ClassVersion="10">
    <version ClassVersion="10" checksum="4003976374"/>

--- a/AnalysisDataFormats/TrackInfo/src/classes_def.xml
+++ b/AnalysisDataFormats/TrackInfo/src/classes_def.xml
@@ -25,7 +25,7 @@
   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<std::vector<reco::Track>,std::vector<reco::TrackInfo>,unsigned int> > >" />
 
   <class name="TPtoRecoTrack" ClassVersion="3">
-   <version ClassVersion="3" checksum="560670808"/>
+   <version ClassVersion="3" checksum="2952712808"/>
   </class>
   <class name="edm::Wrapper<TPtoRecoTrack>"/>
   
@@ -33,7 +33,7 @@
   <class name="edm::Wrapper<std::vector<TPtoRecoTrack> >"/>
 
   <class name="RecoTracktoTP" ClassVersion="3">
-   <version ClassVersion="3" checksum="612992052"/>
+   <version ClassVersion="3" checksum="2837854068"/>
   </class>
   <class name="edm::Wrapper<RecoTracktoTP>"/>
   

--- a/DataFormats/BTauReco/interface/BaseTagInfo.h
+++ b/DataFormats/BTauReco/interface/BaseTagInfo.h
@@ -8,28 +8,32 @@
 #include "DataFormats/BTauReco/interface/TaggingVariable.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  class BaseTagInfo {
-  public:
-    BaseTagInfo(void) {}
+    class BaseTagInfo {
+    public:
+      BaseTagInfo(void) {}
 
-    virtual ~BaseTagInfo(void) {}
+      virtual ~BaseTagInfo(void) {}
 
-    /// clone
-    virtual BaseTagInfo* clone(void) const { return new BaseTagInfo(*this); }
+      /// clone
+      virtual BaseTagInfo* clone(void) const { return new BaseTagInfo(*this); }
 
-    /// returns a polymorphic reference to the tagged jet
-    virtual edm::RefToBase<Jet> jet(void) const { return edm::RefToBase<Jet>(); }
+      /// returns a polymorphic reference to the tagged jet
+      virtual edm::RefToBase<Jet> jet(void) const { return edm::RefToBase<Jet>(); }
 
-    /// returns a list of tracks associated to the jet
-    virtual TrackRefVector tracks(void) const { return TrackRefVector(); }
+      /// returns a list of tracks associated to the jet
+      virtual TrackRefVector tracks(void) const { return TrackRefVector(); }
 
-    /// check if the algorithm is using the tracks or not
-    virtual bool hasTracks(void) const { return false; }
+      /// check if the algorithm is using the tracks or not
+      virtual bool hasTracks(void) const { return false; }
 
-    /// returns a description of the extended informations in a TaggingVariableList
-    virtual TaggingVariableList taggingVariables(void) const { return TaggingVariableList(); }
-  };
+      /// returns a description of the extended informations in a TaggingVariableList
+      virtual TaggingVariableList taggingVariables(void) const { return TaggingVariableList(); }
+    };
+
+  }  // namespace io_v1
+  using BaseTagInfo = io_v1::BaseTagInfo;
 
   DECLARE_EDM_REFS(BaseTagInfo)
 

--- a/DataFormats/BTauReco/interface/JetTagInfo.h
+++ b/DataFormats/BTauReco/interface/JetTagInfo.h
@@ -5,35 +5,37 @@
 #include "DataFormats/BTauReco/interface/BaseTagInfo.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  class JetTagInfo : public BaseTagInfo {
-  public:
-    JetTagInfo(void) : m_jet() {}
+    class JetTagInfo : public BaseTagInfo {
+    public:
+      JetTagInfo(void) : m_jet() {}
 
-    template <typename T>
-    JetTagInfo(const edm::Ref<T>& jetRef) : m_jet(jetRef) {}
+      template <typename T>
+      JetTagInfo(const edm::Ref<T>& jetRef) : m_jet(jetRef) {}
 
-    JetTagInfo(const edm::RefToBase<Jet>& jetRef) : m_jet(jetRef) {}
+      JetTagInfo(const edm::RefToBase<Jet>& jetRef) : m_jet(jetRef) {}
 
-    ~JetTagInfo(void) override {}
+      ~JetTagInfo(void) override {}
 
-    JetTagInfo* clone(void) const override { return new JetTagInfo(*this); }
+      JetTagInfo* clone(void) const override { return new JetTagInfo(*this); }
 
-    edm::RefToBase<Jet> jet(void) const override { return m_jet; }
+      edm::RefToBase<Jet> jet(void) const override { return m_jet; }
 
-    template <typename T>
-    void setJetRef(const edm::Ref<T>& jetRef) {
-      m_jet = edm::RefToBase<Jet>(jetRef);
-    }
+      template <typename T>
+      void setJetRef(const edm::Ref<T>& jetRef) {
+        m_jet = edm::RefToBase<Jet>(jetRef);
+      }
 
-    void setJetRef(const edm::RefToBase<Jet>& jetRef) { m_jet = edm::RefToBase<Jet>(jetRef); }
+      void setJetRef(const edm::RefToBase<Jet>& jetRef) { m_jet = edm::RefToBase<Jet>(jetRef); }
 
-  protected:
-    edm::RefToBase<Jet> m_jet;
-  };
+    protected:
+      edm::RefToBase<Jet> m_jet;
+    };
 
+  }  // namespace io_v1
+  using JetTagInfo = io_v1::JetTagInfo;
   DECLARE_EDM_REFS(JetTagInfo)
-
 }  // namespace reco
 
 #endif  // DataFormats_BTauReco_JetTagInfo_h

--- a/DataFormats/BTauReco/interface/PixelClusterTagInfo.h
+++ b/DataFormats/BTauReco/interface/PixelClusterTagInfo.h
@@ -6,69 +6,70 @@
 #include "DataFormats/BTauReco/interface/BaseTagInfo.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  struct PixelClusterProperties {
-    float x = 0;
-    float y = 0;
-    float z = 0;
-    int charge = 0;
-    unsigned int layer = 0;
-  };
+    struct PixelClusterProperties {
+      float x = 0;
+      float y = 0;
+      float z = 0;
+      int charge = 0;
+      unsigned int layer = 0;
+    };
 
-  struct PixelClusterData {
-    std::vector<int8_t> r004;
-    std::vector<int8_t> r006;
-    std::vector<int8_t> r008;
-    std::vector<int8_t> r010;
-    std::vector<int8_t> r016;
-    std::vector<int8_t> rvar;
-    std::vector<unsigned int> rvwt;
-    PixelClusterData(unsigned int l = 4) {
-      r004 = std::vector<int8_t>(l, 0);
-      r006 = std::vector<int8_t>(l, 0);
-      r008 = std::vector<int8_t>(l, 0);
-      r010 = std::vector<int8_t>(l, 0);
-      r016 = std::vector<int8_t>(l, 0);
-      rvar = std::vector<int8_t>(l, 0);
-      rvwt = std::vector<unsigned int>(l, 0);
-    }
-    CMS_CLASS_VERSION(3)
-  };
+    struct PixelClusterData {
+      std::vector<int8_t> r004;
+      std::vector<int8_t> r006;
+      std::vector<int8_t> r008;
+      std::vector<int8_t> r010;
+      std::vector<int8_t> r016;
+      std::vector<int8_t> rvar;
+      std::vector<unsigned int> rvwt;
+      PixelClusterData(unsigned int l = 4) {
+        r004 = std::vector<int8_t>(l, 0);
+        r006 = std::vector<int8_t>(l, 0);
+        r008 = std::vector<int8_t>(l, 0);
+        r010 = std::vector<int8_t>(l, 0);
+        r016 = std::vector<int8_t>(l, 0);
+        rvar = std::vector<int8_t>(l, 0);
+        rvwt = std::vector<unsigned int>(l, 0);
+      }
+    };
 
-  class PixelClusterTagInfo : public BaseTagInfo {
-  public:
-    PixelClusterTagInfo() {}
+    class PixelClusterTagInfo : public BaseTagInfo {
+    public:
+      PixelClusterTagInfo() {}
 
-    PixelClusterTagInfo(const PixelClusterData& data, const edm::RefToBase<Jet>& ref)
-        : pixelClusters_(data), jetRef_(ref) {}
+      PixelClusterTagInfo(const PixelClusterData& data, const edm::RefToBase<Jet>& ref)
+          : pixelClusters_(data), jetRef_(ref) {}
 
-    ~PixelClusterTagInfo() override {}
+      ~PixelClusterTagInfo() override {}
 
-    // without overriding clone from base class will be store/retrieved
-    PixelClusterTagInfo* clone(void) const override { return new PixelClusterTagInfo(*this); }
+      // without overriding clone from base class will be store/retrieved
+      PixelClusterTagInfo* clone(void) const override { return new PixelClusterTagInfo(*this); }
 
-    // method to set the jet RefToBase
-    void setJetRef(const edm::RefToBase<Jet>& ref) { jetRef_ = ref; }
+      // method to set the jet RefToBase
+      void setJetRef(const edm::RefToBase<Jet>& ref) { jetRef_ = ref; }
 
-    // method to jet the jet RefToBase
-    edm::RefToBase<Jet> jet() const override { return jetRef_; }
+      // method to jet the jet RefToBase
+      edm::RefToBase<Jet> jet() const override { return jetRef_; }
 
-    // method to set the PixelClusterData
-    void setData(const PixelClusterData& data) { pixelClusters_ = data; }
+      // method to set the PixelClusterData
+      void setData(const PixelClusterData& data) { pixelClusters_ = data; }
 
-    // method to get the PixelClusterData struct
-    const PixelClusterData& data() const { return pixelClusters_; }
+      // method to get the PixelClusterData struct
+      const PixelClusterData& data() const { return pixelClusters_; }
 
-    CMS_CLASS_VERSION(3)
+    private:
+      PixelClusterData pixelClusters_;
 
-  private:
-    PixelClusterData pixelClusters_;
+      edm::RefToBase<Jet> jetRef_;
+    };
 
-    edm::RefToBase<Jet> jetRef_;
-  };
-
-  typedef std::vector<reco::PixelClusterTagInfo> PixelClusterTagInfoCollection;
-
+  }  // namespace io_v1
+  using PixelClusterProperties = io_v1::PixelClusterProperties;
+  using PixelClusterData = io_v1::PixelClusterData;
+  using PixelClusterTagInfo = io_v1::PixelClusterTagInfo;
+  using PixelClusterTagInfoCollection = std::vector<reco::PixelClusterTagInfo>;
 }  // namespace reco
 
 #endif  // DataFormats_BTauReco_PixelClusterTagInfo_h

--- a/DataFormats/BTauReco/src/classes_def.xml
+++ b/DataFormats/BTauReco/src/classes_def.xml
@@ -1,7 +1,7 @@
 <lcgdict>
   <enum name="reco::btau::TaggingVariableName"/>
-  <class name="reco::BaseTagInfo" ClassVersion="10">
-   <version ClassVersion="10" checksum="2760058808"/>
+  <class name="reco::io_v1::BaseTagInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="2873039314"/>
   </class>
   <class name="reco::BaseTagInfoCollection"/>
   <class name="reco::BaseTagInfoRef"/>
@@ -10,9 +10,8 @@
   <class name="reco::BaseTagInfoRefVector"/>
   <class name="edm::Wrapper<reco::BaseTagInfoCollection>"/>
 
-  <class name="reco::JetTagInfo" ClassVersion="11">
-   <version ClassVersion="11" checksum="1187716230"/>
-   <version ClassVersion="10" checksum="2733970706"/>
+  <class name="reco::io_v1::JetTagInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="398162194"/>
   </class>
   <class name="reco::JetTagInfoCollection"/>
   <class name="reco::JetTagInfoRef"/>
@@ -22,7 +21,7 @@
   <class name="edm::Wrapper<reco::JetTagInfoCollection>"/>
 
   <class name="reco::JTATagInfo" ClassVersion="3">
-   <version ClassVersion="3" checksum="2626339357"/>
+   <version ClassVersion="3" checksum="1301168175"/>
   </class>
   <class name="reco::JTATagInfoCollection"/>
   <class name="reco::JTATagInfoRef"/>
@@ -41,7 +40,7 @@
   <class name="reco::btag::IndexedTrackData"/>
   <class name="std::vector<reco::btag::IndexedTrackData>"/>
 
-  <class name="reco::TemplatedSecondaryVertexTagInfo<reco::TrackIPTagInfo,reco::Vertex>::VertexData"/>
+  <class name="reco::TemplatedSecondaryVertexTagInfo<reco::TrackIPTagInfo,reco::io_v1::Vertex>::VertexData"/>
   <class name="std::vector<reco::SecondaryVertexTagInfo::VertexData>"/>
   <class name="reco::SecondaryVertexTagInfo"/>
   <class name="reco::SecondaryVertexTagInfoCollection"/>
@@ -51,7 +50,7 @@
   <class name="reco::SecondaryVertexTagInfoRefVector"/>
   <class name="edm::Wrapper<reco::SecondaryVertexTagInfoCollection>"/>
 
-  <class name="reco::TemplatedSecondaryVertexTagInfo<reco::CandIPTagInfo,reco::VertexCompositePtrCandidate>::VertexData"/>
+  <class name="reco::TemplatedSecondaryVertexTagInfo<reco::CandIPTagInfo,reco::io_v1::VertexCompositePtrCandidate>::VertexData"/>
   <class name="std::vector<reco::CandSecondaryVertexTagInfo::VertexData>"/>
   <class name="reco::CandSecondaryVertexTagInfo"/>
   <class name="reco::CandSecondaryVertexTagInfoCollection"/>
@@ -62,7 +61,7 @@
   <class name="edm::Wrapper<reco::CandSecondaryVertexTagInfoCollection>"/>
 
   <class name="reco::BoostedDoubleSVTagInfo" ClassVersion="3">
-   <version ClassVersion="3" checksum="1146731392"/>
+   <version ClassVersion="3" checksum="2378940590"/>
   </class>
   <class name="reco::BoostedDoubleSVTagInfoCollection"/>
   <class name="reco::BoostedDoubleSVTagInfoRef"/>
@@ -73,7 +72,7 @@
   <class name="edm::Wrapper<std::vector<reco::BoostedDoubleSVTagInfo> >"/>
 
   <class name="reco::ShallowTagInfo" ClassVersion="3">
-		<version ClassVersion="3" checksum="3904302444"/>
+		<version ClassVersion="3" checksum="963908996"/>
   </class>
   <class name="reco::ShallowTagInfoCollection"/>
   <class name="reco::ShallowTagInfoRef"/>
@@ -84,7 +83,7 @@
   <class name="edm::Wrapper<std::vector<reco::ShallowTagInfo> >"/>
 
   <class name="reco::CombinedTauTagInfo" ClassVersion="3">
-   <version ClassVersion="3" checksum="2237505417"/>
+   <version ClassVersion="3" checksum="1170584203"/>
   </class>
   <class name="reco::CombinedTauTagInfoCollection"/>
   <class name="reco::CombinedTauTagInfoRef"/>
@@ -94,7 +93,7 @@
   <class name="edm::Wrapper<reco::CombinedTauTagInfoCollection>"/>
 
   <class name="reco::IsolatedTauTagInfo" ClassVersion="3">
-   <version ClassVersion="3" checksum="2139950407"/>
+   <version ClassVersion="3" checksum="2093744889"/>
   </class>
   <class name="reco::IsolatedTauTagInfoCollection"/>
   <class name="reco::IsolatedTauTagInfoRef"/>
@@ -133,8 +132,8 @@
   <class name="reco::SoftLeptonTagInfoRefVector"/>
   <class name="edm::Wrapper<reco::SoftLeptonTagInfoCollection>"/>
 
-  <class name="std::pair<edm::Ptr<reco::Candidate>, reco::SoftLeptonProperties>"/>
-  <class name="reco::TemplatedSoftLeptonTagInfo<edm::Ptr<reco::Candidate> >::LeptonMap"/>
+  <class name="std::pair<edm::Ptr<reco::io_v1::Candidate>, reco::SoftLeptonProperties>"/>
+  <class name="reco::TemplatedSoftLeptonTagInfo<edm::Ptr<reco::io_v1::Candidate> >::LeptonMap"/>
   <class name="reco::CandSoftLeptonTagInfo" />
   <class name="reco::CandSoftLeptonTagInfoCollection"/>
   <class name="reco::CandSoftLeptonTagInfoRef"/>
@@ -144,14 +143,13 @@
   <class name="edm::Wrapper<reco::CandSoftLeptonTagInfoCollection>"/>
 
 
-  <class name="reco::CATopJetProperties" ClassVersion="10">
-   <version ClassVersion="10" checksum="4096516518"/>
+  <class name="reco::CATopJetProperties" ClassVersion="3">
+   <version ClassVersion="3" checksum="4096516518"/>
   </class>
-  <class name="std::pair<edm::RefToBase<reco::Jet>, reco::CATopJetProperties>"/>
+  <class name="std::pair<edm::RefToBase<reco::io_v1::Jet>, reco::CATopJetProperties>"/>
 
-  <class name="reco::CATopJetTagInfo" ClassVersion="11">
-   <version ClassVersion="10" checksum="3059833435"/>
-   <version ClassVersion="11" checksum="241737491"/>
+  <class name="reco::CATopJetTagInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="1392563819"/>
   </class>
   <class name="reco::CATopJetTagInfoCollection"/>
   <class name="reco::CATopJetTagInfoRef"/>
@@ -162,17 +160,17 @@
   <class name="reco::HTTTopJetProperties" ClassVersion="3">
     <version ClassVersion="3" checksum="3737009156"/>
   </class>
-  <class name="std::pair<edm::RefToBase<reco::Jet>, reco::HTTTopJetProperties>"/>
+  <class name="std::pair<edm::RefToBase<reco::io_v1::Jet>, reco::HTTTopJetProperties>"/>
  
   <class name="reco::HTTTopJetTagInfo" ClassVersion="3">
-    <version ClassVersion="3" checksum="3013029993"/>
+    <version ClassVersion="3" checksum="3688420857"/>
   </class>
   <class name="reco::HTTTopJetTagInfoCollection"/>
   <class name="reco::HTTTopJetTagInfoRef"/>
   <class name="reco::HTTTopJetTagInfoRefProd"/>
   <class name="reco::HTTTopJetTagInfoRefVector"/>
   <class name="edm::Wrapper<reco::HTTTopJetTagInfoCollection>"/>
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::HTTTopJetTagInfoRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::HTTTopJetTagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::HTTTopJetTagInfoRef>" />
 
   <class name="std::pair< reco::btau::TaggingVariableName, float >"/>
@@ -188,16 +186,16 @@
   <class name="edm::Wrapper<reco::TaggingVariableListCollection>"/>
 
   <!-- Dictionary for the association in SVTagInfoProxy-->
-  <class name="edm::Wrapper<edm::helpers::KeyVal<edm::RefProd<std::vector<reco::SecondaryVertexTagInfo> >, edm::RefProd<std::vector<reco::Vertex> > > >" persistent="false"/>
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::SecondaryVertexTagInfo> >, edm::RefProd<std::vector<reco::Vertex> > >"/>
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToMany<std::vector<reco::SecondaryVertexTagInfo>, std::vector<reco::Vertex>, unsigned int > > >" persistent="false"/>
-  <class name="edm::AssociationMap<edm::OneToMany<std::vector<reco::SecondaryVertexTagInfo>, std::vector<reco::Vertex>, unsigned int > >">
+  <class name="edm::Wrapper<edm::helpers::KeyVal<edm::RefProd<std::vector<reco::SecondaryVertexTagInfo> >, edm::RefProd<std::vector<reco::io_v1::Vertex> > > >" persistent="false"/>
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::SecondaryVertexTagInfo> >, edm::RefProd<std::vector<reco::io_v1::Vertex> > >"/>
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToMany<std::vector<reco::SecondaryVertexTagInfo>, std::vector<reco::io_v1::Vertex>, unsigned int > > >" persistent="false"/>
+  <class name="edm::AssociationMap<edm::OneToMany<std::vector<reco::SecondaryVertexTagInfo>, std::vector<reco::io_v1::Vertex>, unsigned int > >">
     <field name="transientMap_" transient="true" />
   </class>
-  <class name="edm::Wrapper<edm::helpers::KeyVal<edm::RefProd<std::vector<reco::CandSecondaryVertexTagInfo> >, edm::RefProd<std::vector<reco::VertexCompositePtrCandidate> > > >" persistent="false"/>
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::CandSecondaryVertexTagInfo> >, edm::RefProd<std::vector<reco::VertexCompositePtrCandidate> > >"/>
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToMany<std::vector<reco::CandSecondaryVertexTagInfo>, std::vector<reco::VertexCompositePtrCandidate>, unsigned int > > >" persistent="false"/>
-  <class name="edm::AssociationMap<edm::OneToMany<std::vector<reco::CandSecondaryVertexTagInfo>, std::vector<reco::VertexCompositePtrCandidate>, unsigned int > >">
+  <class name="edm::Wrapper<edm::helpers::KeyVal<edm::RefProd<std::vector<reco::CandSecondaryVertexTagInfo> >, edm::RefProd<std::vector<reco::io_v1::VertexCompositePtrCandidate> > > >" persistent="false"/>
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::CandSecondaryVertexTagInfo> >, edm::RefProd<std::vector<reco::io_v1::VertexCompositePtrCandidate> > >"/>
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToMany<std::vector<reco::CandSecondaryVertexTagInfo>, std::vector<reco::io_v1::VertexCompositePtrCandidate>, unsigned int > > >" persistent="false"/>
+  <class name="edm::AssociationMap<edm::OneToMany<std::vector<reco::CandSecondaryVertexTagInfo>, std::vector<reco::io_v1::VertexCompositePtrCandidate>, unsigned int > >">
     <field name="transientMap_" transient="true" />
   </class>
 
@@ -229,7 +227,7 @@
   <!--class name="reco::TauMassTagInfo_ClusterTrackAssociationMapType"/-->
   <class name="reco::TauMassTagInfo_ClusterTrackAssociationRefType"/>
   <class name="reco::TauMassTagInfo" ClassVersion="3">
-   <version ClassVersion="3" checksum="1251178229"/>
+   <version ClassVersion="3" checksum="3554191277"/>
   </class>
   <class name="reco::TauMassTagInfoCollection"/>
   <class name="reco::TauMassTagInfoRef"/>
@@ -239,7 +237,7 @@
   <class name="edm::Wrapper<reco::TauMassTagInfoCollection>"/>
 
   <class name="reco::TrackCountingTagInfo" ClassVersion="3">
-   <version ClassVersion="3" checksum="4167605446"/>
+   <version ClassVersion="3" checksum="3001913416"/>
   </class>
   <class name="reco::TrackCountingTagInfoCollection"/>
   <class name="reco::TrackCountingTagInfoRef"/>
@@ -249,7 +247,7 @@
   <class name="edm::Wrapper<reco::TrackCountingTagInfoCollection>"/>
 
   <class name="reco::TrackProbabilityTagInfo" ClassVersion="3">
-   <version ClassVersion="3" checksum="366358830"/>
+   <version ClassVersion="3" checksum="3100149024"/>
   </class>
   <class name="reco::TrackProbabilityTagInfoCollection"/>
   <class name="reco::TrackProbabilityTagInfoRef"/>
@@ -296,116 +294,116 @@
   <class name="std::vector<Measurement1D>"/>
 
   <!-- RefToBase stuff -->
-  <class name="edm::reftobase::BaseHolder<reco::BaseTagInfo>" />
-  <class name="edm::reftobase::IndirectHolder<reco::BaseTagInfo>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::BaseTagInfoRef>" />
+  <class name="edm::reftobase::BaseHolder<reco::io_v1::BaseTagInfo>" />
+  <class name="edm::reftobase::IndirectHolder<reco::io_v1::BaseTagInfo>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::BaseTagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::BaseTagInfoRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::JTATagInfoRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::JTATagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::JTATagInfoRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::JetTagInfoRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::JetTagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::JetTagInfoRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::TrackCountingTagInfoRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::TrackCountingTagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::TrackCountingTagInfoRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::TrackIPTagInfoRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::TrackIPTagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::TrackIPTagInfoRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::CandIPTagInfoRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::CandIPTagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::CandIPTagInfoRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::SecondaryVertexTagInfoRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::SecondaryVertexTagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::SecondaryVertexTagInfoRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::CandSecondaryVertexTagInfoRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::CandSecondaryVertexTagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::CandSecondaryVertexTagInfoRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::BoostedDoubleSVTagInfoRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::BoostedDoubleSVTagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::BoostedDoubleSVTagInfoRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::ShallowTagInfoRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::ShallowTagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::ShallowTagInfoRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::DeepFlavourTagInfoRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::DeepFlavourTagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::DeepFlavourTagInfoRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::ParticleTransformerAK4TagInfoRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::ParticleTransformerAK4TagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::ParticleTransformerAK4TagInfoRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::UnifiedParticleTransformerAK4TagInfoRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::UnifiedParticleTransformerAK4TagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::UnifiedParticleTransformerAK4TagInfoRef>" />  
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::CombinedTauTagInfoRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::CombinedTauTagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::CombinedTauTagInfoRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::IsolatedTauTagInfoRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::IsolatedTauTagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::IsolatedTauTagInfoRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::SoftLeptonTagInfoRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::SoftLeptonTagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::SoftLeptonTagInfoRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::CandSoftLeptonTagInfoRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::CandSoftLeptonTagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::CandSoftLeptonTagInfoRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::TauMassTagInfoRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::TauMassTagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::TauMassTagInfoRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::TrackProbabilityTagInfoRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::TrackProbabilityTagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::TrackProbabilityTagInfoRef>" />
 
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::BaseTagInfoFwdRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::BaseTagInfoFwdRef>" />
   <class name="edm::reftobase::RefHolder<reco::BaseTagInfoFwdRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::JTATagInfoFwdRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::JTATagInfoFwdRef>" />
   <class name="edm::reftobase::RefHolder<reco::JTATagInfoFwdRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::JetTagInfoFwdRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::JetTagInfoFwdRef>" />
   <class name="edm::reftobase::RefHolder<reco::JetTagInfoFwdRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::TrackCountingTagInfoFwdRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::TrackCountingTagInfoFwdRef>" />
   <class name="edm::reftobase::RefHolder<reco::TrackCountingTagInfoFwdRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::TrackIPTagInfoFwdRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::TrackIPTagInfoFwdRef>" />
   <class name="edm::reftobase::RefHolder<reco::TrackIPTagInfoFwdRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::CandIPTagInfoFwdRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::CandIPTagInfoFwdRef>" />
   <class name="edm::reftobase::RefHolder<reco::CandIPTagInfoFwdRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::SecondaryVertexTagInfoFwdRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::SecondaryVertexTagInfoFwdRef>" />
   <class name="edm::reftobase::RefHolder<reco::SecondaryVertexTagInfoFwdRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::CandSecondaryVertexTagInfoFwdRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::CandSecondaryVertexTagInfoFwdRef>" />
   <class name="edm::reftobase::RefHolder<reco::CandSecondaryVertexTagInfoFwdRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::BoostedDoubleSVTagInfoFwdRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::BoostedDoubleSVTagInfoFwdRef>" />
   <class name="edm::reftobase::RefHolder<reco::BoostedDoubleSVTagInfoFwdRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::ShallowTagInfoFwdRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::ShallowTagInfoFwdRef>" />
   <class name="edm::reftobase::RefHolder<reco::ShallowTagInfoFwdRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::DeepFlavourTagInfoFwdRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::DeepFlavourTagInfoFwdRef>" />
   <class name="edm::reftobase::RefHolder<reco::DeepFlavourTagInfoFwdRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::ParticleTransformerAK4TagInfoFwdRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::ParticleTransformerAK4TagInfoFwdRef>" />
   <class name="edm::reftobase::RefHolder<reco::ParticleTransformerAK4TagInfoFwdRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::UnifiedParticleTransformerAK4TagInfoFwdRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::UnifiedParticleTransformerAK4TagInfoFwdRef>" />
   <class name="edm::reftobase::RefHolder<reco::UnifiedParticleTransformerAK4TagInfoFwdRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::CombinedTauTagInfoFwdRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::CombinedTauTagInfoFwdRef>" />
   <class name="edm::reftobase::RefHolder<reco::CombinedTauTagInfoFwdRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::IsolatedTauTagInfoFwdRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::IsolatedTauTagInfoFwdRef>" />
   <class name="edm::reftobase::RefHolder<reco::IsolatedTauTagInfoFwdRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::SoftLeptonTagInfoFwdRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::SoftLeptonTagInfoFwdRef>" />
   <class name="edm::reftobase::RefHolder<reco::SoftLeptonTagInfoFwdRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::CandSoftLeptonTagInfoFwdRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::CandSoftLeptonTagInfoFwdRef>" />
   <class name="edm::reftobase::RefHolder<reco::CandSoftLeptonTagInfoFwdRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::TauMassTagInfoFwdRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::TauMassTagInfoFwdRef>" />
   <class name="edm::reftobase::RefHolder<reco::TauMassTagInfoFwdRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::TrackProbabilityTagInfoFwdRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::TrackProbabilityTagInfoFwdRef>" />
   <class name="edm::reftobase::RefHolder<reco::TrackProbabilityTagInfoFwdRef>" />
-  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::CATopJetTagInfoRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::BaseTagInfo, reco::CATopJetTagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::CATopJetTagInfoRef>" />
 
 
-  <class name="edm::Ptr<reco::BaseTagInfo>" />
-  <class name="std::vector<edm::Ptr<reco::BaseTagInfo> >" />
-  <class name="edm::FwdPtr<reco::BaseTagInfo>" />
-  <class name="std::vector<edm::FwdPtr<reco::BaseTagInfo> >" />
-  <class name="edm::ValueMap<edm::Ptr<reco::BaseTagInfo> >" />
-  <class name="edm::Wrapper<edm::ValueMap<edm::Ptr<reco::BaseTagInfo> > >" />
-  <class name="std::vector<reco::BaseTagInfo *>" />
-  <class name="edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo> >" rntupleStreamerMode="true"/>
+  <class name="edm::Ptr<reco::io_v1::BaseTagInfo>" />
+  <class name="std::vector<edm::Ptr<reco::io_v1::BaseTagInfo> >" />
+  <class name="edm::FwdPtr<reco::io_v1::BaseTagInfo>" />
+  <class name="std::vector<edm::FwdPtr<reco::io_v1::BaseTagInfo> >" />
+  <class name="edm::ValueMap<edm::Ptr<reco::io_v1::BaseTagInfo> >" />
+  <class name="edm::Wrapper<edm::ValueMap<edm::Ptr<reco::io_v1::BaseTagInfo> > >" />
+  <class name="std::vector<reco::io_v1::BaseTagInfo *>" />
+  <class name="edm::OwnVector<reco::io_v1::BaseTagInfo, edm::ClonePolicy<reco::io_v1::BaseTagInfo> >" rntupleStreamerMode="true"/>
  <exclusion>
-  <class name="edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo> >">
+  <class name="edm::OwnVector<reco::io_v1::BaseTagInfo, edm::ClonePolicy<reco::io_v1::BaseTagInfo> >">
    <method name="sort" />
   </class>
  </exclusion>
 
-  <class name="edm::Wrapper<edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo> > >" />
+  <class name="edm::Wrapper<edm::OwnVector<reco::io_v1::BaseTagInfo, edm::ClonePolicy<reco::io_v1::BaseTagInfo> > >" />
 
 
- <class name="edm::FwdRef<edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo>>,reco::BaseTagInfo,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo> >,reco::BaseTagInfo> >"/>
- <class name="edm::Ref<edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo>>,reco::BaseTagInfo,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo> >,reco::BaseTagInfo> >"/>
- <class name="std::vector<edm::FwdRef<edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo>>,reco::BaseTagInfo,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo> >,reco::BaseTagInfo> > >"/>
- <class name="std::vector<edm::Ref<edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo>>,reco::BaseTagInfo,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo> >,reco::BaseTagInfo> > >"/>
+ <class name="edm::FwdRef<edm::OwnVector<reco::io_v1::BaseTagInfo, edm::ClonePolicy<reco::io_v1::BaseTagInfo>>,reco::io_v1::BaseTagInfo,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::io_v1::BaseTagInfo, edm::ClonePolicy<reco::io_v1::BaseTagInfo> >,reco::io_v1::BaseTagInfo> >"/>
+ <class name="edm::Ref<edm::OwnVector<reco::io_v1::BaseTagInfo, edm::ClonePolicy<reco::io_v1::BaseTagInfo>>,reco::io_v1::BaseTagInfo,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::io_v1::BaseTagInfo, edm::ClonePolicy<reco::io_v1::BaseTagInfo> >,reco::io_v1::BaseTagInfo> >"/>
+ <class name="std::vector<edm::FwdRef<edm::OwnVector<reco::io_v1::BaseTagInfo, edm::ClonePolicy<reco::io_v1::BaseTagInfo>>,reco::io_v1::BaseTagInfo,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::io_v1::BaseTagInfo, edm::ClonePolicy<reco::io_v1::BaseTagInfo> >,reco::io_v1::BaseTagInfo> > >"/>
+ <class name="std::vector<edm::Ref<edm::OwnVector<reco::io_v1::BaseTagInfo, edm::ClonePolicy<reco::io_v1::BaseTagInfo>>,reco::io_v1::BaseTagInfo,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::io_v1::BaseTagInfo, edm::ClonePolicy<reco::io_v1::BaseTagInfo> >,reco::io_v1::BaseTagInfo> > >"/>
 
 
- <class name="edm::Wrapper<edm::FwdRef<edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo>>,reco::BaseTagInfo,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo> >,reco::BaseTagInfo> > >"/>
- <class name="edm::Wrapper<edm::Ref<edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo>>,reco::BaseTagInfo,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo> >,reco::BaseTagInfo> > >"/>
- <class name="edm::Wrapper<std::vector<edm::FwdRef<edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo>>,reco::BaseTagInfo,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo> >,reco::BaseTagInfo> > > >"/>
- <class name="edm::Wrapper<std::vector<edm::Ref<edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo>>,reco::BaseTagInfo,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo> >,reco::BaseTagInfo> > > >"/>
+ <class name="edm::Wrapper<edm::FwdRef<edm::OwnVector<reco::io_v1::BaseTagInfo, edm::ClonePolicy<reco::io_v1::BaseTagInfo>>,reco::io_v1::BaseTagInfo,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::io_v1::BaseTagInfo, edm::ClonePolicy<reco::io_v1::BaseTagInfo> >,reco::io_v1::BaseTagInfo> > >"/>
+ <class name="edm::Wrapper<edm::Ref<edm::OwnVector<reco::io_v1::BaseTagInfo, edm::ClonePolicy<reco::io_v1::BaseTagInfo>>,reco::io_v1::BaseTagInfo,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::io_v1::BaseTagInfo, edm::ClonePolicy<reco::io_v1::BaseTagInfo> >,reco::io_v1::BaseTagInfo> > >"/>
+ <class name="edm::Wrapper<std::vector<edm::FwdRef<edm::OwnVector<reco::io_v1::BaseTagInfo, edm::ClonePolicy<reco::io_v1::BaseTagInfo>>,reco::io_v1::BaseTagInfo,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::io_v1::BaseTagInfo, edm::ClonePolicy<reco::io_v1::BaseTagInfo> >,reco::io_v1::BaseTagInfo> > > >"/>
+ <class name="edm::Wrapper<std::vector<edm::Ref<edm::OwnVector<reco::io_v1::BaseTagInfo, edm::ClonePolicy<reco::io_v1::BaseTagInfo>>,reco::io_v1::BaseTagInfo,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::io_v1::BaseTagInfo, edm::ClonePolicy<reco::io_v1::BaseTagInfo> >,reco::io_v1::BaseTagInfo> > > >"/>
 
   <class name="btagbtvdeep::JetFeatures" ClassVersion="4">
     <version ClassVersion="3" checksum="386672900"/>
@@ -500,12 +498,12 @@
   <class name="reco::DeepBoostedJetTagInfoRefVector"/>
   <class name="edm::Wrapper<reco::DeepBoostedJetTagInfoCollection>" persistent="false"/>
 
-  <class name="reco::PixelClusterProperties"/>
-  <class name="reco::PixelClusterData" ClassVersion="3">
-    <version ClassVersion="3" checksum="525314740"/>
+  <class name="reco::io_v1::PixelClusterProperties"/>
+  <class name="reco::io_v1::PixelClusterData" ClassVersion="3">
+    <version ClassVersion="3" checksum="88772050"/>
   </class>
-  <class name="reco::PixelClusterTagInfo" ClassVersion="3">
-    <version ClassVersion="3" checksum="2876828956"/>
+  <class name="reco::io_v1::PixelClusterTagInfo" ClassVersion="3">
+    <version ClassVersion="3" checksum="2609794082"/>
   </class>
   <class name="reco::PixelClusterTagInfoCollection"/>
   <class name="edm::Wrapper<reco::PixelClusterTagInfoCollection>"/>

--- a/DataFormats/BeamSpot/interface/BeamSpot.h
+++ b/DataFormats/BeamSpot/interface/BeamSpot.h
@@ -17,148 +17,152 @@
 #include <sstream>
 
 namespace reco {
+  namespace io_v1 {
 
-  class BeamSpot {
-  public:
-    /// beam spot flags
-    enum BeamType { Unknown = -1, Fake = 0, LHC = 1, Tracker = 2 };
+    class BeamSpot {
+    public:
+      /// beam spot flags
+      enum BeamType { Unknown = -1, Fake = 0, LHC = 1, Tracker = 2 };
 
-    /// point in the space
-    typedef math::XYZPoint Point;
-    enum { dimension = 7 };
-    typedef math::Error<dimension>::type CovarianceMatrix;
-    enum { dim3 = 3 };
-    typedef math::Error<dim3>::type Covariance3DMatrix;
-    enum { resdim = 2 };
-    typedef math::Error<resdim>::type ResCovMatrix;
+      /// point in the space
+      typedef math::XYZPoint Point;
+      enum { dimension = 7 };
+      typedef math::Error<dimension>::type CovarianceMatrix;
+      enum { dim3 = 3 };
+      typedef math::Error<dim3>::type Covariance3DMatrix;
+      enum { resdim = 2 };
+      typedef math::Error<resdim>::type ResCovMatrix;
 
-    /// default constructor
-    BeamSpot();
+      /// default constructor
+      BeamSpot();
 
-    /// constructor from values
-    BeamSpot(const Point& point,
-             double sigmaZ,
-             double dxdz,
-             double dydz,
-             double BeamWidthX,
-             const CovarianceMatrix& error,
-             BeamType type = Unknown) {
-      position_ = point;
-      sigmaZ_ = sigmaZ;
-      dxdz_ = dxdz;
-      dydz_ = dydz;
-      BeamWidthX_ = BeamWidthX;
-      BeamWidthY_ = BeamWidthX;
-      error_ = error;
-      type_ = type;
-      emittanceX_ = emittanceY_ = 0;
-      betaStar_ = 0;
-    };
+      /// constructor from values
+      BeamSpot(const Point& point,
+               double sigmaZ,
+               double dxdz,
+               double dydz,
+               double BeamWidthX,
+               const CovarianceMatrix& error,
+               BeamType type = Unknown) {
+        position_ = point;
+        sigmaZ_ = sigmaZ;
+        dxdz_ = dxdz;
+        dydz_ = dydz;
+        BeamWidthX_ = BeamWidthX;
+        BeamWidthY_ = BeamWidthX;
+        error_ = error;
+        type_ = type;
+        emittanceX_ = emittanceY_ = 0;
+        betaStar_ = 0;
+      };
 
-    /// position
-    const Point& position() const { return position_; }
-    /// x coordinate
-    double x0() const { return position_.X(); }
-    /// y coordinate
-    double y0() const { return position_.Y(); }
-    /// z coordinate
-    double z0() const { return position_.Z(); }
+      /// position
+      const Point& position() const { return position_; }
+      /// x coordinate
+      double x0() const { return position_.X(); }
+      /// y coordinate
+      double y0() const { return position_.Y(); }
+      /// z coordinate
+      double z0() const { return position_.Z(); }
 
-    /// x coordinate of the beeam spot position at a given z value (it takes into account the dxdz slope)
-    double x(const double z) const { return x0() + dxdz() * (z - z0()); }
-    /// y coordinate of the beeam spot position at a given z value (it takes into account the dydz slope)
-    double y(const double z) const { return y0() + dydz() * (z - z0()); }
-    /// position of the beam spot at a given z value (it takes into account the dxdz and dydz slopes)
-    const Point position(const double z) const;
-    //    const Point position(const double z) const {Point pos(x(z),y(z),z);    return pos;}
+      /// x coordinate of the beeam spot position at a given z value (it takes into account the dxdz slope)
+      double x(const double z) const { return x0() + dxdz() * (z - z0()); }
+      /// y coordinate of the beeam spot position at a given z value (it takes into account the dydz slope)
+      double y(const double z) const { return y0() + dydz() * (z - z0()); }
+      /// position of the beam spot at a given z value (it takes into account the dxdz and dydz slopes)
+      const Point position(const double z) const;
+      //    const Point position(const double z) const {Point pos(x(z),y(z),z);    return pos;}
 
-    /// sigma z
-    double sigmaZ() const { return sigmaZ_; }
-    /// dxdz slope
-    double dxdz() const { return dxdz_; }
-    /// dydz slope
-    double dydz() const { return dydz_; }
-    /// beam width X
-    double BeamWidthX() const { return BeamWidthX_; }
-    /// beam width Y
-    double BeamWidthY() const { return BeamWidthY_; }
-    /// error on x
-    double x0Error() const { return sqrt(error_(0, 0)); }
-    /// error on y
-    double y0Error() const { return sqrt(error_(1, 1)); }
-    /// error on z
-    double z0Error() const { return sqrt(error_(2, 2)); }
-    /// error on sigma z
-    double sigmaZ0Error() const { return sqrt(error_(3, 3)); }
-    /// error on dxdz
-    double dxdzError() const { return sqrt(error_(4, 4)); }
-    /// error on dydz
-    double dydzError() const { return sqrt(error_(5, 5)); }
+      /// sigma z
+      double sigmaZ() const { return sigmaZ_; }
+      /// dxdz slope
+      double dxdz() const { return dxdz_; }
+      /// dydz slope
+      double dydz() const { return dydz_; }
+      /// beam width X
+      double BeamWidthX() const { return BeamWidthX_; }
+      /// beam width Y
+      double BeamWidthY() const { return BeamWidthY_; }
+      /// error on x
+      double x0Error() const { return sqrt(error_(0, 0)); }
+      /// error on y
+      double y0Error() const { return sqrt(error_(1, 1)); }
+      /// error on z
+      double z0Error() const { return sqrt(error_(2, 2)); }
+      /// error on sigma z
+      double sigmaZ0Error() const { return sqrt(error_(3, 3)); }
+      /// error on dxdz
+      double dxdzError() const { return sqrt(error_(4, 4)); }
+      /// error on dydz
+      double dydzError() const { return sqrt(error_(5, 5)); }
 
-    /// error on beam width X, assume error in X = Y
-    double BeamWidthXError() const { return sqrt(error_(6, 6)); }
-    /// error on beam width Y, assume error in X = Y
-    double BeamWidthYError() const { return sqrt(error_(6, 6)); }
+      /// error on beam width X, assume error in X = Y
+      double BeamWidthXError() const { return sqrt(error_(6, 6)); }
+      /// error on beam width Y, assume error in X = Y
+      double BeamWidthYError() const { return sqrt(error_(6, 6)); }
 
-    ///
-    void setBeamWidthX(double v) { BeamWidthX_ = v; }
-    void setBeamWidthY(double v) { BeamWidthY_ = v; }
+      ///
+      void setBeamWidthX(double v) { BeamWidthX_ = v; }
+      void setBeamWidthY(double v) { BeamWidthY_ = v; }
 
-    /// (i,j)-th element of error matrix
-    double covariance(int i, int j) const { return error_(i, j); }
-    /// return full covariance matrix of dim 7
-    CovarianceMatrix covariance() const { return error_; }
-    /// return only 3D position covariance matrix
-    Covariance3DMatrix covariance3D() const {
-      Covariance3DMatrix matrix;
-      for (int j = 0; j < 3; j++) {
-        for (int k = j; k < 3; k++) {
-          matrix(j, k) = error_(j, k);
+      /// (i,j)-th element of error matrix
+      double covariance(int i, int j) const { return error_(i, j); }
+      /// return full covariance matrix of dim 7
+      CovarianceMatrix covariance() const { return error_; }
+      /// return only 3D position covariance matrix
+      Covariance3DMatrix covariance3D() const {
+        Covariance3DMatrix matrix;
+        for (int j = 0; j < 3; j++) {
+          for (int k = j; k < 3; k++) {
+            matrix(j, k) = error_(j, k);
+          }
         }
+        return matrix;
+      };
+      /// return beam type
+      BeamType type() const { return type_; }
+      /// set beam type
+      void setType(BeamType type) { type_ = type; }
+      ///
+      Covariance3DMatrix rotatedCovariance3D() const;
+
+      /// additional information
+      double emittanceX() const { return emittanceX_; }
+      double emittanceY() const { return emittanceY_; }
+      double betaStar() const { return betaStar_; }
+      double beamWidthFromBeta(double z, double e) const {
+        return sqrt(e * betaStar_ * (1 + pow((z - position_.Z()) / betaStar_, 2)));
       }
-      return matrix;
+      ///
+      void setEmittanceX(double v) { emittanceX_ = v; }
+      void setEmittanceY(double v) { emittanceY_ = v; }
+      void setbetaStar(double v) { betaStar_ = v; }
+
+      /// print information
+      void print(std::stringstream& ss) const;
+
+    private:
+      /// position
+      Point position_;
+      /// errors
+      CovarianceMatrix error_;
+
+      Double32_t sigmaZ_;
+      Double32_t BeamWidthX_;
+      Double32_t BeamWidthY_;
+      Double32_t dxdz_;
+      Double32_t dydz_;
+      Double32_t emittanceX_;
+      Double32_t emittanceY_;
+      Double32_t betaStar_;
+
+      BeamType type_;
     };
-    /// return beam type
-    BeamType type() const { return type_; }
-    /// set beam type
-    void setType(BeamType type) { type_ = type; }
     ///
-    Covariance3DMatrix rotatedCovariance3D() const;
+    std::ostream& operator<<(std::ostream&, BeamSpot beam);
 
-    /// additional information
-    double emittanceX() const { return emittanceX_; }
-    double emittanceY() const { return emittanceY_; }
-    double betaStar() const { return betaStar_; }
-    double beamWidthFromBeta(double z, double e) const {
-      return sqrt(e * betaStar_ * (1 + pow((z - position_.Z()) / betaStar_, 2)));
-    }
-    ///
-    void setEmittanceX(double v) { emittanceX_ = v; }
-    void setEmittanceY(double v) { emittanceY_ = v; }
-    void setbetaStar(double v) { betaStar_ = v; }
-
-    /// print information
-    void print(std::stringstream& ss) const;
-
-  private:
-    /// position
-    Point position_;
-    /// errors
-    CovarianceMatrix error_;
-
-    Double32_t sigmaZ_;
-    Double32_t BeamWidthX_;
-    Double32_t BeamWidthY_;
-    Double32_t dxdz_;
-    Double32_t dydz_;
-    Double32_t emittanceX_;
-    Double32_t emittanceY_;
-    Double32_t betaStar_;
-
-    BeamType type_;
-  };
-  ///
-  std::ostream& operator<<(std::ostream&, BeamSpot beam);
+  }  // namespace io_v1
+  using BeamSpot = io_v1::BeamSpot;
 
 }  // namespace reco
 

--- a/DataFormats/BeamSpot/interface/BeamSpotFwd.h
+++ b/DataFormats/BeamSpot/interface/BeamSpotFwd.h
@@ -1,6 +1,9 @@
 #ifndef DataFormats_BeamSpot_BeamSpotFwd_h
 #define DataFormats_BeamSpot_BeamSpotFwd_h
 namespace reco {
-  class BeamSpot;
-}
+  namespace io_v1 {
+    class BeamSpot;
+  }
+  using BeamSpot = io_v1::BeamSpot;
+}  // namespace reco
 #endif

--- a/DataFormats/BeamSpot/src/BeamSpot.cc
+++ b/DataFormats/BeamSpot/src/BeamSpot.cc
@@ -17,85 +17,85 @@
 #include <iostream>
 
 namespace reco {
+  namespace io_v1 {
+    using namespace math;
 
-  using namespace math;
-
-  BeamSpot::BeamSpot() {
-    // initialize
-    position_ = Point(0., 0., 0.);
-    sigmaZ_ = 0.;
-    dxdz_ = 0.;
-    dydz_ = 0.;
-    BeamWidthX_ = 0.;
-    BeamWidthY_ = 0;
-    for (int j = 0; j < 7; j++) {
-      for (int k = j; k < 7; k++) {
-        error_(j, k) = 0.;
+    BeamSpot::BeamSpot() {
+      // initialize
+      position_ = Point(0., 0., 0.);
+      sigmaZ_ = 0.;
+      dxdz_ = 0.;
+      dydz_ = 0.;
+      BeamWidthX_ = 0.;
+      BeamWidthY_ = 0;
+      for (int j = 0; j < 7; j++) {
+        for (int k = j; k < 7; k++) {
+          error_(j, k) = 0.;
+        }
       }
+      type_ = Unknown;
+      emittanceX_ = 0;
+      emittanceY_ = 0;
+      betaStar_ = 0;
     }
-    type_ = Unknown;
-    emittanceX_ = 0;
-    emittanceY_ = 0;
-    betaStar_ = 0;
-  }
 
-  const BeamSpot::Point BeamSpot::position(const double z) const {
-    Point pos(x(z), y(z), z);
-    return pos;
-  }
+    const BeamSpot::Point BeamSpot::position(const double z) const {
+      Point pos(x(z), y(z), z);
+      return pos;
+    }
 
-  void BeamSpot::print(std::stringstream& ss) const {
-    ss << "-----------------------------------------------------\n"
-       << "              Beam Spot Data\n\n"
-       << " Beam type    = " << type() << "\n"
-       << "       X0     = " << x0() << " +/- " << x0Error() << " [cm]\n"
-       << "       Y0     = " << y0() << " +/- " << y0Error() << " [cm]\n"
-       << "       Z0     = " << z0() << " +/- " << z0Error() << " [cm]\n"
-       << " Sigma Z0     = " << sigmaZ() << " +/- " << sigmaZ0Error() << " [cm]\n"
-       << " dxdz         = " << dxdz() << " +/- " << dxdzError() << " [radians]\n"
-       << " dydz         = " << dydz() << " +/- " << dydzError() << " [radians]\n"
-       << " Beam width X = " << BeamWidthX() << " +/- " << BeamWidthXError() << " [cm]\n"
-       << " Beam width Y = " << BeamWidthY() << " +/- " << BeamWidthYError() << " [cm]\n"
-       << " EmittanceX   = " << emittanceX() << " [cm]\n"
-       << " EmittanceY   = " << emittanceY() << " [cm]\n"
-       << " beta-star    = " << betaStar() << " [cm]\n"
-       << "-----------------------------------------------------\n\n";
-  }
+    void BeamSpot::print(std::stringstream& ss) const {
+      ss << "-----------------------------------------------------\n"
+         << "              Beam Spot Data\n\n"
+         << " Beam type    = " << type() << "\n"
+         << "       X0     = " << x0() << " +/- " << x0Error() << " [cm]\n"
+         << "       Y0     = " << y0() << " +/- " << y0Error() << " [cm]\n"
+         << "       Z0     = " << z0() << " +/- " << z0Error() << " [cm]\n"
+         << " Sigma Z0     = " << sigmaZ() << " +/- " << sigmaZ0Error() << " [cm]\n"
+         << " dxdz         = " << dxdz() << " +/- " << dxdzError() << " [radians]\n"
+         << " dydz         = " << dydz() << " +/- " << dydzError() << " [radians]\n"
+         << " Beam width X = " << BeamWidthX() << " +/- " << BeamWidthXError() << " [cm]\n"
+         << " Beam width Y = " << BeamWidthY() << " +/- " << BeamWidthYError() << " [cm]\n"
+         << " EmittanceX   = " << emittanceX() << " [cm]\n"
+         << " EmittanceY   = " << emittanceY() << " [cm]\n"
+         << " beta-star    = " << betaStar() << " [cm]\n"
+         << "-----------------------------------------------------\n\n";
+    }
 
-  //
-  std::ostream& operator<<(std::ostream& os, BeamSpot beam) {
-    std::stringstream ss;
-    beam.print(ss);
-    os << ss.str();
-    return os;
-  }
+    //
+    std::ostream& operator<<(std::ostream& os, BeamSpot beam) {
+      std::stringstream ss;
+      beam.print(ss);
+      os << ss.str();
+      return os;
+    }
 
-  BeamSpot::Covariance3DMatrix BeamSpot::rotatedCovariance3D() const {
-    AlgebraicVector3 newZ(dxdz(), dydz(), 1.);
-    AlgebraicVector3 globalZ(0., 0., 1.);
-    AlgebraicVector3 rotationAxis = ROOT::Math::Cross(globalZ.Unit(), newZ.Unit());
-    float rotationAngle = -acos(ROOT::Math::Dot(globalZ.Unit(), newZ.Unit()));
-    Basic3DVector<float> aa(rotationAxis[0], rotationAxis[1], rotationAxis[2]);
-    TkRotation<float> rotation(aa, rotationAngle);
-    AlgebraicMatrix33 rotationMatrix;
-    rotationMatrix(0, 0) = rotation.xx();
-    rotationMatrix(0, 1) = rotation.xy();
-    rotationMatrix(0, 2) = rotation.xz();
-    rotationMatrix(1, 0) = rotation.yx();
-    rotationMatrix(1, 1) = rotation.yy();
-    rotationMatrix(1, 2) = rotation.yz();
-    rotationMatrix(2, 0) = rotation.zx();
-    rotationMatrix(2, 1) = rotation.zy();
-    rotationMatrix(2, 2) = rotation.zz();
+    BeamSpot::Covariance3DMatrix BeamSpot::rotatedCovariance3D() const {
+      AlgebraicVector3 newZ(dxdz(), dydz(), 1.);
+      AlgebraicVector3 globalZ(0., 0., 1.);
+      AlgebraicVector3 rotationAxis = ROOT::Math::Cross(globalZ.Unit(), newZ.Unit());
+      float rotationAngle = -acos(ROOT::Math::Dot(globalZ.Unit(), newZ.Unit()));
+      Basic3DVector<float> aa(rotationAxis[0], rotationAxis[1], rotationAxis[2]);
+      TkRotation<float> rotation(aa, rotationAngle);
+      AlgebraicMatrix33 rotationMatrix;
+      rotationMatrix(0, 0) = rotation.xx();
+      rotationMatrix(0, 1) = rotation.xy();
+      rotationMatrix(0, 2) = rotation.xz();
+      rotationMatrix(1, 0) = rotation.yx();
+      rotationMatrix(1, 1) = rotation.yy();
+      rotationMatrix(1, 2) = rotation.yz();
+      rotationMatrix(2, 0) = rotation.zx();
+      rotationMatrix(2, 1) = rotation.zy();
+      rotationMatrix(2, 2) = rotation.zz();
 
-    AlgebraicSymMatrix33 diagError;
-    diagError(0, 0) = pow(BeamWidthX(), 2);
-    diagError(1, 1) = pow(BeamWidthY(), 2);
-    diagError(2, 2) = pow(sigmaZ(), 2);
+      AlgebraicSymMatrix33 diagError;
+      diagError(0, 0) = pow(BeamWidthX(), 2);
+      diagError(1, 1) = pow(BeamWidthY(), 2);
+      diagError(2, 2) = pow(sigmaZ(), 2);
 
-    Covariance3DMatrix matrix;
-    matrix = ROOT::Math::Similarity(rotationMatrix, diagError) + covariance3D();
-    return matrix;
-  }
-
+      Covariance3DMatrix matrix;
+      matrix = ROOT::Math::Similarity(rotationMatrix, diagError) + covariance3D();
+      return matrix;
+    }
+  }  // namespace io_v1
 }  // namespace reco

--- a/DataFormats/BeamSpot/src/classes_def.xml
+++ b/DataFormats/BeamSpot/src/classes_def.xml
@@ -1,9 +1,8 @@
 <lcgdict>
-  <class name="reco::BeamSpot" ClassVersion="11">
-   <version ClassVersion="11" checksum="1497064974"/>
-   <version ClassVersion="10" checksum="915260007"/>
+  <class name="reco::io_v1::BeamSpot" ClassVersion="3">
+   <version ClassVersion="3" checksum="1710795988"/>
   </class>
-  <class name="edm::Wrapper<reco::BeamSpot>"/>
+  <class name="edm::Wrapper<reco::io_v1::BeamSpot>"/>
 
   <class name="BeamSpotHost" rntupleStreamerMode="true"/>
   <!-- BeamSpotHost::Product must be listed before the aliased-to type -->

--- a/DataFormats/CaloRecHit/interface/CaloCluster.h
+++ b/DataFormats/CaloRecHit/interface/CaloCluster.h
@@ -24,231 +24,234 @@
 #include <iostream>
 
 namespace reco {
+  namespace io_v1 {
 
-  class CaloCluster;
-  std::ostream& operator<<(std::ostream& out, const CaloCluster& cluster);
+    class CaloCluster {
+    public:
+      enum AlgoId {
+        island = 0,
+        hybrid = 1,
+        fixedMatrix = 2,
+        dynamicHybrid = 3,
+        multi5x5 = 4,
+        particleFlow = 5,
+        hgcal_em = 6,
+        hgcal_had = 7,
+        hgcal_scintillator = 8,
+        hfnose = 9,
+        barrel_em = 10,
+        barrel_had = 11,
+        undefined = 1000
+      };
 
-  class CaloCluster {
-  public:
-    enum AlgoId {
-      island = 0,
-      hybrid = 1,
-      fixedMatrix = 2,
-      dynamicHybrid = 3,
-      multi5x5 = 4,
-      particleFlow = 5,
-      hgcal_em = 6,
-      hgcal_had = 7,
-      hgcal_scintillator = 8,
-      hfnose = 9,
-      barrel_em = 10,
-      barrel_had = 11,
-      undefined = 1000
+      // super-cluster flags
+      enum SCFlags { cleanOnly = 0, common = 100, uncleanOnly = 200 };
+      // hcal cluster flags (used for pf)
+      enum HCalFlags { badHcalMarker = 1 };
+
+      //FIXME:
+      //temporary fix... to be removed before 310 final
+      typedef AlgoId AlgoID;
+
+      /// default constructor. Sets energy and position to zero
+      CaloCluster()
+          : energy_(0), correctedEnergy_(-1.0), correctedEnergyUncertainty_(-1.0), algoID_(undefined), flags_(0) {}
+
+      /// constructor with algoId, to be used in all child classes
+      CaloCluster(AlgoID algoID)
+          : energy_(0), correctedEnergy_(-1.0), correctedEnergyUncertainty_(-1.0), algoID_(algoID), flags_(0) {}
+
+      CaloCluster(double energy, const math::XYZPoint& position, const CaloID& caloID)
+          : energy_(energy),
+            correctedEnergy_(-1.0),
+            correctedEnergyUncertainty_(-1.0),
+            position_(position),
+            caloID_(caloID),
+            algoID_(undefined),
+            flags_(0) {}
+
+      /// resets the CaloCluster (position, energy, hitsAndFractions)
+      void reset();
+
+      /// constructor from values
+      CaloCluster(double energy, const math::XYZPoint& position)
+          : energy_(energy),
+            correctedEnergy_(-1.0),
+            correctedEnergyUncertainty_(-1.0),
+            position_(position),
+            algoID_(undefined),
+            flags_(0) {}
+
+      CaloCluster(
+          double energy, const math::XYZPoint& position, const CaloID& caloID, const AlgoID& algoID, uint32_t flags = 0)
+          : energy_(energy),
+            correctedEnergy_(-1.0),
+            correctedEnergyUncertainty_(-1.0),
+            position_(position),
+            caloID_(caloID),
+            algoID_(algoID) {
+        flags_ = flags & flagsMask_;
+      }
+
+      CaloCluster(double energy,
+                  const math::XYZPoint& position,
+                  const CaloID& caloID,
+                  const std::vector<std::pair<DetId, float> >& usedHitsAndFractions,
+                  const AlgoId algoId,
+                  const DetId seedId = DetId(0),
+                  uint32_t flags = 0)
+          : energy_(energy),
+            correctedEnergy_(-1.0),
+            correctedEnergyUncertainty_(-1.0),
+            position_(position),
+            caloID_(caloID),
+            hitsAndFractions_(usedHitsAndFractions),
+            algoID_(algoId),
+            seedId_(seedId) {
+        flags_ = flags & flagsMask_;
+      }
+
+      //FIXME:
+      /// temporary compatibility constructor
+      CaloCluster(double energy,
+                  const math::XYZPoint& position,
+                  float chi2,
+                  const std::vector<DetId>& usedHits,
+                  const AlgoId algoId,
+                  uint32_t flags = 0)
+          : energy_(energy),
+            correctedEnergy_(-1.0),
+            correctedEnergyUncertainty_(-1.0),
+            position_(position),
+            algoID_(algoId) {
+        hitsAndFractions_.reserve(usedHits.size());
+        for (size_t i = 0; i < usedHits.size(); i++)
+          hitsAndFractions_.push_back(std::pair<DetId, float>(usedHits[i], 1.));
+        flags_ = flags & flagsMask_;
+      }
+
+      /// destructor
+      virtual ~CaloCluster() {}
+
+      void setEnergy(double energy) { energy_ = energy; }
+      void setCorrectedEnergy(double cenergy) { correctedEnergy_ = cenergy; }
+      void setCorrectedEnergyUncertainty(float energyerr) { correctedEnergyUncertainty_ = energyerr; }
+
+      void setPosition(const math::XYZPoint& p) { position_ = p; }
+
+      void setCaloId(const CaloID& id) { caloID_ = id; }
+
+      void setAlgoId(const AlgoId& id) { algoID_ = id; }
+
+      void setSeed(const DetId& id) { seedId_ = id; }
+
+      /// cluster energy
+      double energy() const { return energy_; }
+      double correctedEnergy() const { return correctedEnergy_; }
+      float correctedEnergyUncertainty() const { return correctedEnergyUncertainty_; }
+
+      /// cluster centroid position
+      const math::XYZPoint& position() const { return position_; }
+
+      /// comparison >= operator
+      bool operator>=(const CaloCluster& rhs) const { return (energy_ >= rhs.energy_); }
+
+      /// comparison > operator
+      bool operator>(const CaloCluster& rhs) const { return (energy_ > rhs.energy_); }
+
+      /// comparison <= operator
+      bool operator<=(const CaloCluster& rhs) const { return (energy_ <= rhs.energy_); }
+
+      /// comparison < operator
+      bool operator<(const CaloCluster& rhs) const { return (energy_ < rhs.energy_); }
+
+      /// comparison == operator
+      bool operator==(const CaloCluster& rhs) const { return (energy_ == rhs.energy_); };
+
+      /// x coordinate of cluster centroid
+      double x() const { return position_.x(); }
+
+      /// y coordinate of cluster centroid
+      double y() const { return position_.y(); }
+
+      /// z coordinate of cluster centroid
+      double z() const { return position_.z(); }
+
+      /// pseudorapidity of cluster centroid
+      double eta() const { return position_.eta(); }
+
+      /// azimuthal angle of cluster centroid
+      double phi() const { return position_.phi(); }
+
+      /// size in number of hits (e.g. in crystals for ECAL)
+      size_t size() const { return hitsAndFractions_.size(); }
+
+      /// algorithm identifier
+      AlgoId algo() const { return algoID_; }
+      AlgoID algoID() const { return algo(); }
+
+      uint32_t flags() const { return flags_ & flagsMask_; }
+      void setFlags(uint32_t flags) {
+        uint32_t reserved = (flags_ & ~flagsMask_);
+        flags_ = (reserved) | (flags & flagsMask_);
+      }
+      bool isInClean() const { return flags() < uncleanOnly; }
+      bool isInUnclean() const { return flags() >= common; }
+
+      const CaloID& caloID() const { return caloID_; }
+
+      void addHitAndFraction(DetId id, float fraction) {
+        hitsAndFractions_.push_back(std::pair<DetId, float>(id, fraction));
+      }
+
+      /// replace getHitsByDetId() : return hits by DetId
+      /// and their corresponding fraction of energy considered
+      /// to compute the total cluster energy
+      const std::vector<std::pair<DetId, float> >& hitsAndFractions() const { return hitsAndFractions_; }
+
+      /// print hitAndFraction
+      std::string printHitAndFraction(unsigned i) const;
+
+      /// print me
+      friend std::ostream& operator<<(std::ostream& out, const CaloCluster& cluster);
+
+      /// return DetId of seed
+      DetId seed() const { return seedId_; }
+
+    protected:
+      /// cluster energy
+      double energy_;
+      double correctedEnergy_;
+      float correctedEnergyUncertainty_;
+
+      /// cluster centroid position
+      math::XYZPoint position_;
+
+      /// bitmask for detector information
+      CaloID caloID_;
+
+      // used hits by detId
+      std::vector<std::pair<DetId, float> > hitsAndFractions_;
+
+      // cluster algorithm Id
+      AlgoID algoID_;
+
+      /// DetId of seed
+      DetId seedId_;
+
+      /// flags (e.g. for handling of cleaned/uncleaned SC)
+      /// 4  most significant bits  reserved
+      /// 28 bits for handling of cleaned/uncleaned
+      uint32_t flags_;
+
+      static const uint32_t flagsMask_ = 0x0FFFFFFF;
+      static const uint32_t flagsOffset_ = 28;
     };
 
-    // super-cluster flags
-    enum SCFlags { cleanOnly = 0, common = 100, uncleanOnly = 200 };
-    // hcal cluster flags (used for pf)
-    enum HCalFlags { badHcalMarker = 1 };
+    std::ostream& operator<<(std::ostream& out, const CaloCluster& cluster);
 
-    //FIXME:
-    //temporary fix... to be removed before 310 final
-    typedef AlgoId AlgoID;
-
-    /// default constructor. Sets energy and position to zero
-    CaloCluster()
-        : energy_(0), correctedEnergy_(-1.0), correctedEnergyUncertainty_(-1.0), algoID_(undefined), flags_(0) {}
-
-    /// constructor with algoId, to be used in all child classes
-    CaloCluster(AlgoID algoID)
-        : energy_(0), correctedEnergy_(-1.0), correctedEnergyUncertainty_(-1.0), algoID_(algoID), flags_(0) {}
-
-    CaloCluster(double energy, const math::XYZPoint& position, const CaloID& caloID)
-        : energy_(energy),
-          correctedEnergy_(-1.0),
-          correctedEnergyUncertainty_(-1.0),
-          position_(position),
-          caloID_(caloID),
-          algoID_(undefined),
-          flags_(0) {}
-
-    /// resets the CaloCluster (position, energy, hitsAndFractions)
-    void reset();
-
-    /// constructor from values
-    CaloCluster(double energy, const math::XYZPoint& position)
-        : energy_(energy),
-          correctedEnergy_(-1.0),
-          correctedEnergyUncertainty_(-1.0),
-          position_(position),
-          algoID_(undefined),
-          flags_(0) {}
-
-    CaloCluster(
-        double energy, const math::XYZPoint& position, const CaloID& caloID, const AlgoID& algoID, uint32_t flags = 0)
-        : energy_(energy),
-          correctedEnergy_(-1.0),
-          correctedEnergyUncertainty_(-1.0),
-          position_(position),
-          caloID_(caloID),
-          algoID_(algoID) {
-      flags_ = flags & flagsMask_;
-    }
-
-    CaloCluster(double energy,
-                const math::XYZPoint& position,
-                const CaloID& caloID,
-                const std::vector<std::pair<DetId, float> >& usedHitsAndFractions,
-                const AlgoId algoId,
-                const DetId seedId = DetId(0),
-                uint32_t flags = 0)
-        : energy_(energy),
-          correctedEnergy_(-1.0),
-          correctedEnergyUncertainty_(-1.0),
-          position_(position),
-          caloID_(caloID),
-          hitsAndFractions_(usedHitsAndFractions),
-          algoID_(algoId),
-          seedId_(seedId) {
-      flags_ = flags & flagsMask_;
-    }
-
-    //FIXME:
-    /// temporary compatibility constructor
-    CaloCluster(double energy,
-                const math::XYZPoint& position,
-                float chi2,
-                const std::vector<DetId>& usedHits,
-                const AlgoId algoId,
-                uint32_t flags = 0)
-        : energy_(energy),
-          correctedEnergy_(-1.0),
-          correctedEnergyUncertainty_(-1.0),
-          position_(position),
-          algoID_(algoId) {
-      hitsAndFractions_.reserve(usedHits.size());
-      for (size_t i = 0; i < usedHits.size(); i++)
-        hitsAndFractions_.push_back(std::pair<DetId, float>(usedHits[i], 1.));
-      flags_ = flags & flagsMask_;
-    }
-
-    /// destructor
-    virtual ~CaloCluster() {}
-
-    void setEnergy(double energy) { energy_ = energy; }
-    void setCorrectedEnergy(double cenergy) { correctedEnergy_ = cenergy; }
-    void setCorrectedEnergyUncertainty(float energyerr) { correctedEnergyUncertainty_ = energyerr; }
-
-    void setPosition(const math::XYZPoint& p) { position_ = p; }
-
-    void setCaloId(const CaloID& id) { caloID_ = id; }
-
-    void setAlgoId(const AlgoId& id) { algoID_ = id; }
-
-    void setSeed(const DetId& id) { seedId_ = id; }
-
-    /// cluster energy
-    double energy() const { return energy_; }
-    double correctedEnergy() const { return correctedEnergy_; }
-    float correctedEnergyUncertainty() const { return correctedEnergyUncertainty_; }
-
-    /// cluster centroid position
-    const math::XYZPoint& position() const { return position_; }
-
-    /// comparison >= operator
-    bool operator>=(const CaloCluster& rhs) const { return (energy_ >= rhs.energy_); }
-
-    /// comparison > operator
-    bool operator>(const CaloCluster& rhs) const { return (energy_ > rhs.energy_); }
-
-    /// comparison <= operator
-    bool operator<=(const CaloCluster& rhs) const { return (energy_ <= rhs.energy_); }
-
-    /// comparison < operator
-    bool operator<(const CaloCluster& rhs) const { return (energy_ < rhs.energy_); }
-
-    /// comparison == operator
-    bool operator==(const CaloCluster& rhs) const { return (energy_ == rhs.energy_); };
-
-    /// x coordinate of cluster centroid
-    double x() const { return position_.x(); }
-
-    /// y coordinate of cluster centroid
-    double y() const { return position_.y(); }
-
-    /// z coordinate of cluster centroid
-    double z() const { return position_.z(); }
-
-    /// pseudorapidity of cluster centroid
-    double eta() const { return position_.eta(); }
-
-    /// azimuthal angle of cluster centroid
-    double phi() const { return position_.phi(); }
-
-    /// size in number of hits (e.g. in crystals for ECAL)
-    size_t size() const { return hitsAndFractions_.size(); }
-
-    /// algorithm identifier
-    AlgoId algo() const { return algoID_; }
-    AlgoID algoID() const { return algo(); }
-
-    uint32_t flags() const { return flags_ & flagsMask_; }
-    void setFlags(uint32_t flags) {
-      uint32_t reserved = (flags_ & ~flagsMask_);
-      flags_ = (reserved) | (flags & flagsMask_);
-    }
-    bool isInClean() const { return flags() < uncleanOnly; }
-    bool isInUnclean() const { return flags() >= common; }
-
-    const CaloID& caloID() const { return caloID_; }
-
-    void addHitAndFraction(DetId id, float fraction) {
-      hitsAndFractions_.push_back(std::pair<DetId, float>(id, fraction));
-    }
-
-    /// replace getHitsByDetId() : return hits by DetId
-    /// and their corresponding fraction of energy considered
-    /// to compute the total cluster energy
-    const std::vector<std::pair<DetId, float> >& hitsAndFractions() const { return hitsAndFractions_; }
-
-    /// print hitAndFraction
-    std::string printHitAndFraction(unsigned i) const;
-
-    /// print me
-    friend std::ostream& operator<<(std::ostream& out, const CaloCluster& cluster);
-
-    /// return DetId of seed
-    DetId seed() const { return seedId_; }
-
-  protected:
-    /// cluster energy
-    double energy_;
-    double correctedEnergy_;
-    float correctedEnergyUncertainty_;
-
-    /// cluster centroid position
-    math::XYZPoint position_;
-
-    /// bitmask for detector information
-    CaloID caloID_;
-
-    // used hits by detId
-    std::vector<std::pair<DetId, float> > hitsAndFractions_;
-
-    // cluster algorithm Id
-    AlgoID algoID_;
-
-    /// DetId of seed
-    DetId seedId_;
-
-    /// flags (e.g. for handling of cleaned/uncleaned SC)
-    /// 4  most significant bits  reserved
-    /// 28 bits for handling of cleaned/uncleaned
-    uint32_t flags_;
-
-    static const uint32_t flagsMask_ = 0x0FFFFFFF;
-    static const uint32_t flagsOffset_ = 28;
-  };
+  }  // namespace io_v1
+  using CaloCluster = io_v1::CaloCluster;
 
 }  // namespace reco
 

--- a/DataFormats/CaloRecHit/interface/CaloClusterFwd.h
+++ b/DataFormats/CaloRecHit/interface/CaloClusterFwd.h
@@ -7,7 +7,10 @@ namespace edm {
 }
 
 namespace reco {
-  class CaloCluster;
-}
+  namespace io_v1 {
+    class CaloCluster;
+  }
+  using CaloCluster = io_v1::CaloCluster;
+}  // namespace reco
 
 #endif

--- a/DataFormats/CaloRecHit/src/CaloCluster.cc
+++ b/DataFormats/CaloRecHit/src/CaloCluster.cc
@@ -21,7 +21,7 @@ string CaloCluster::printHitAndFraction(unsigned i) const {
   return out.str();
 }
 
-std::ostream& reco::operator<<(std::ostream& out, const CaloCluster& cluster) {
+std::ostream& reco::io_v1::operator<<(std::ostream& out, const CaloCluster& cluster) {
   if (!out)
     return out;
 

--- a/DataFormats/CaloRecHit/src/classes_def.xml
+++ b/DataFormats/CaloRecHit/src/classes_def.xml
@@ -2,30 +2,28 @@
   <class name="CaloRecHit" ClassVersion="10">
    <version ClassVersion="10" checksum="582597904"/>
   </class>
-  <class name="reco::CaloCluster" ClassVersion="13">
-   <version ClassVersion="10" checksum="3936140"/>
-   <version ClassVersion="11" checksum="2938838489"/>
-   <version ClassVersion="12" checksum="4229965835"/>
-   <version ClassVersion="13" checksum="3477374013"/>
+  <class name="reco::io_v1::CaloCluster" ClassVersion="3">
+   <version ClassVersion="3" checksum="2132548181"/>
   </class>
-  <class name="edm::Wrapper<std::vector<std::pair<unsigned long,edm::Ptr<reco::CaloCluster> > > >"/>
-  <class name="std::vector<std::pair<unsigned long,edm::Ptr<reco::CaloCluster> > >"/>
-  <class name="std::pair<unsigned long, edm::Ptr<reco::CaloCluster> >"/>
+  <class name="edm::Wrapper<std::vector<std::pair<unsigned long,edm::Ptr<reco::io_v1::CaloCluster> > > >"/>
+  <class name="std::vector<std::pair<unsigned long,edm::Ptr<reco::io_v1::CaloCluster> > >"/>
+  <class name="std::pair<unsigned long, edm::Ptr<reco::io_v1::CaloCluster> >"/>
   <class name="edm::Ptr<CaloRecHit>"/>
-  <class name="edm::Ptr<reco::CaloCluster>"/>
-  <class name="edm::PtrVector<reco::CaloCluster>"/>
-  <class name="edm::Wrapper<edm::PtrVector<reco::CaloCluster> >"/>
-  <class name="std::vector<edm::Ptr<reco::CaloCluster> >"/>
+  <class name="edm::Ptr<reco::io_v1::CaloCluster>"/>
+  <class name="edm::PtrVector<reco::io_v1::CaloCluster>"/>
+  <class name="edm::Wrapper<edm::PtrVector<reco::io_v1::CaloCluster> >"/>
+  <class name="std::vector<edm::Ptr<reco::io_v1::CaloCluster> >"/>
+  
   <!-- FIXME: The following 2 entries are found already in DataFormats/EgammaReco with the typedef 'reco::BasicCluster' -->
-  <!-- <class name="std::vector<reco::CaloCluster>" /> -->
-  <!-- <class name="edm::Wrapper<std::vector<reco::CaloCluster> >" /> -->
+  <!-- <class name="std::vector<reco::io_v1::CaloCluster>" /> -->
+  <!-- <class name="edm::Wrapper<std::vector<reco::io_v1::CaloCluster> >" /> -->
   <class name="reco::CaloID" ClassVersion="10">
    <version ClassVersion="10" checksum="2360607337"/>
   </class>
   <class name="edm::reftobase::BaseHolder<CaloRecHit>"/>
 
-  <class name="edm::ValueMap<reco::CaloCluster>" />
-  <class name="edm::Wrapper<edm::ValueMap<reco::CaloCluster> >" />
+  <class name="edm::ValueMap<reco::io_v1::CaloCluster>" />
+  <class name="edm::Wrapper<edm::ValueMap<reco::io_v1::CaloCluster> >" />
 
   <class name="edm::ValueMap<reco::CaloClusterPtr>" />
   <class name="edm::ValueMap<reco::CaloClusterPtrVector>" />

--- a/DataFormats/CaloTowers/src/classes_def.xml
+++ b/DataFormats/CaloTowers/src/classes_def.xml
@@ -3,11 +3,8 @@
    <version ClassVersion="11" checksum="4063982642"/>
    <version ClassVersion="10" checksum="2444816232"/>
   </class>
-  <class name="CaloTower" ClassVersion="13">
-   <version ClassVersion="13" checksum="2436724497"/>
-   <version ClassVersion="12" checksum="3702399054"/>
-   <version ClassVersion="11" checksum="565241750"/>
-   <version ClassVersion="10" checksum="17125795"/>
+  <class name="CaloTower" ClassVersion="3">
+   <version ClassVersion="3" checksum="3730265685"/>
   </class>
   <class name="CaloTowerPtr"/>
   <class name="CaloTowerFwdPtr"/>
@@ -24,9 +21,9 @@
   <class name="std::vector<edm::FwdRef<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower, edm::refhelper::FindUsingAdvance<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower > > >"/>
   <class name="edm::Wrapper< std::vector<edm::FwdRef<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower, edm::refhelper::FindUsingAdvance<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower > > > >"/>
 
-  <class name="edm::reftobase::Holder<reco::Candidate, CaloTowerRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, CaloTowerRef>" />
   <class name="edm::reftobase::RefHolder<CaloTowerRef>" />
-  <class name="edm::reftobase::VectorHolder<reco::Candidate, CaloTowerRefs>" />
+  <class name="edm::reftobase::VectorHolder<reco::io_v1::Candidate, CaloTowerRefs>" />
   <class name="edm::reftobase::RefVectorHolder<CaloTowerRefs>" />
   <class name="edm::Ptr<CaloTower>"/>
   <class name="edm::PtrVector<CaloTower>"/>

--- a/DataFormats/Candidate/interface/Candidate.h
+++ b/DataFormats/Candidate/interface/Candidate.h
@@ -23,282 +23,291 @@
 class OverlapChecker;
 
 namespace reco {
+  class ShallowCloneCandidate;
+  class ShallowClonePtrCandidate;
+
   namespace io_v1 {
     class Track;
   }
   using Track = io_v1::Track;
 
-  class Candidate {
-  public:
-    typedef size_t size_type;
-    typedef candidate::const_iterator const_iterator;
-    typedef candidate::iterator iterator;
+  namespace io_v1 {
 
-    /// electric charge type
-    typedef int Charge;
-    /// Lorentz vector
-    typedef math::XYZTLorentzVector LorentzVector;
-    /// Lorentz vector
-    typedef math::PtEtaPhiMLorentzVector PolarLorentzVector;
-    /// point in the space
-    typedef math::XYZPoint Point;
-    /// point in the space
-    typedef math::XYZVector Vector;
+    class Candidate {
+    public:
+      typedef size_t size_type;
+      typedef candidate::const_iterator const_iterator;
+      typedef candidate::iterator iterator;
 
-    enum { dimension = 3 };
-    /// covariance error matrix (3x3)
-    typedef math::Error<dimension>::type CovarianceMatrix;
-    /// matix size
-    enum { size = dimension * (dimension + 1) / 2 };
-    /// index type
-    typedef unsigned int index;
+      /// electric charge type
+      typedef int Charge;
+      /// Lorentz vector
+      typedef math::XYZTLorentzVector LorentzVector;
+      /// Lorentz vector
+      typedef math::PtEtaPhiMLorentzVector PolarLorentzVector;
+      /// point in the space
+      typedef math::XYZPoint Point;
+      /// point in the space
+      typedef math::XYZVector Vector;
 
-    /// default constructor
-    Candidate() {}
-    /// destructor
-    virtual ~Candidate();
-    /// electric charge
-    virtual int charge() const = 0;
-    /// set electric charge
-    virtual void setCharge(Charge q) = 0;
-    /// electric charge
-    virtual int threeCharge() const = 0;
-    /// set electric charge
-    virtual void setThreeCharge(Charge qx3) = 0;
-    /// four-momentum Lorentz vector
-    virtual const LorentzVector& p4() const = 0;
-    /// four-momentum Lorentz vector
-    virtual const PolarLorentzVector& polarP4() const = 0;
-    /// spatial momentum vector
-    virtual Vector momentum() const = 0;
-    /// boost vector to boost a Lorentz vector
-    /// to the particle center of mass system
-    virtual Vector boostToCM() const = 0;
-    /// magnitude of momentum vector
-    virtual double p() const = 0;
-    /// energy
-    virtual double energy() const = 0;
-    /// transverse energy
-    virtual double et() const = 0;
-    /// transverse energy squared (use this for cut!)
-    virtual double et2() const = 0;
-    /// mass
-    virtual double mass() const = 0;
-    /// mass squared
-    virtual double massSqr() const = 0;
-    /// transverse mass
-    virtual double mt() const = 0;
-    /// transverse mass squared
-    virtual double mtSqr() const = 0;
-    /// x coordinate of momentum vector
-    virtual double px() const = 0;
-    /// y coordinate of momentum vector
-    virtual double py() const = 0;
-    /// z coordinate of momentum vector
-    virtual double pz() const = 0;
-    /// transverse momentum
-    virtual double pt() const = 0;
-    /// momentum azimuthal angle
-    virtual double phi() const = 0;
-    /// momentum polar angle
-    virtual double theta() const = 0;
-    /// momentum pseudorapidity
-    virtual double eta() const = 0;
-    /// rapidity
-    virtual double rapidity() const = 0;
-    /// rapidity
-    virtual double y() const = 0;
-    /// set 4-momentum
-    virtual void setP4(const LorentzVector& p4) = 0;
-    /// set 4-momentum
-    virtual void setP4(const PolarLorentzVector& p4) = 0;
-    /// set particle mass
-    virtual void setMass(double m) = 0;
-    virtual void setPz(double pz) = 0;
-    /// vertex position
-    virtual const Point& vertex() const = 0;
-    /// x coordinate of vertex position
-    virtual double vx() const = 0;
-    /// y coordinate of vertex position
-    virtual double vy() const = 0;
-    /// z coordinate of vertex position
-    virtual double vz() const = 0;
-    /// set vertex
-    virtual void setVertex(const Point& vertex) = 0;
-    /// PDG identifier
-    virtual int pdgId() const = 0;
-    // set PDG identifier
-    virtual void setPdgId(int pdgId) = 0;
-    /// status word
-    virtual int status() const = 0;
-    /// set status word
-    virtual void setStatus(int status) = 0;
-    /// set long lived flag
-    virtual void setLongLived() = 0;
-    /// is long lived?
-    virtual bool longLived() const = 0;
-    /// set mass constraint flag
-    virtual void setMassConstraint() = 0;
-    /// do mass constraint?
-    virtual bool massConstraint() const = 0;
-    /// returns a clone of the Candidate object
-    virtual Candidate* clone() const = 0;
-    /// first daughter const_iterator
-    const_iterator begin() const { return const_iterator(this, 0); }
-    /// last daughter const_iterator
-    const_iterator end() const { return const_iterator(this, numberOfDaughters()); }
-    /// first daughter iterator
-    iterator begin() { return iterator(this, 0); }
-    /// last daughter iterator
-    iterator end() { return iterator(this, numberOfDaughters()); }
-    /// number of daughters
-    virtual size_type numberOfDaughters() const = 0;
-    /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1 (read only mode)
-    virtual const Candidate* daughter(size_type i) const = 0;
-    /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1
-    virtual Candidate* daughter(size_type i) = 0;
-    /// return daughter with a specified role name
-    virtual Candidate* daughter(const std::string& s) = 0;
-    /// return daughter with a specified role name
-    virtual const Candidate* daughter(const std::string& s) const = 0;
-    /// number of mothers (zero or one in most of but not all the cases)
-    virtual size_type numberOfMothers() const = 0;
-    /// return pointer to mother
-    virtual const Candidate* mother(size_type i = 0) const = 0;
-    /// return the number of source Candidates
-    /// ( the candidates used to construct this Candidate)
-    virtual size_t numberOfSourceCandidatePtrs() const = 0;
-    /// return a Ptr to one of the source Candidates
-    /// ( the candidates used to construct this Candidate)
-    virtual CandidatePtr sourceCandidatePtr(size_type i) const { return CandidatePtr(); }
-    /// \brief Set the ptr to the source Candidate.
-    ///
-    /// necessary, to allow a parallel treatment of all candidates
-    /// in PF2PAT. Does nothing for most Candidate classes, including
-    /// CompositePtrCandidates, where the source information is in fact
-    /// the collection of ptrs to daughters. For non-Composite Candidates,
-    /// this function can be used to set the ptr to the source of the
-    /// Candidate, which will allow to keep track
-    /// of the reconstruction history.
-    virtual void setSourceCandidatePtr(const CandidatePtr& ptr) {}
+      enum { dimension = 3 };
+      /// covariance error matrix (3x3)
+      typedef math::Error<dimension>::type CovarianceMatrix;
+      /// matix size
+      enum { size = dimension * (dimension + 1) / 2 };
+      /// index type
+      typedef unsigned int index;
 
-    /// chi-squares
-    virtual double vertexChi2() const = 0;
-    /** Number of degrees of freedom
+      /// default constructor
+      Candidate() {}
+      /// destructor
+      virtual ~Candidate();
+      /// electric charge
+      virtual int charge() const = 0;
+      /// set electric charge
+      virtual void setCharge(Charge q) = 0;
+      /// electric charge
+      virtual int threeCharge() const = 0;
+      /// set electric charge
+      virtual void setThreeCharge(Charge qx3) = 0;
+      /// four-momentum Lorentz vector
+      virtual const LorentzVector& p4() const = 0;
+      /// four-momentum Lorentz vector
+      virtual const PolarLorentzVector& polarP4() const = 0;
+      /// spatial momentum vector
+      virtual Vector momentum() const = 0;
+      /// boost vector to boost a Lorentz vector
+      /// to the particle center of mass system
+      virtual Vector boostToCM() const = 0;
+      /// magnitude of momentum vector
+      virtual double p() const = 0;
+      /// energy
+      virtual double energy() const = 0;
+      /// transverse energy
+      virtual double et() const = 0;
+      /// transverse energy squared (use this for cut!)
+      virtual double et2() const = 0;
+      /// mass
+      virtual double mass() const = 0;
+      /// mass squared
+      virtual double massSqr() const = 0;
+      /// transverse mass
+      virtual double mt() const = 0;
+      /// transverse mass squared
+      virtual double mtSqr() const = 0;
+      /// x coordinate of momentum vector
+      virtual double px() const = 0;
+      /// y coordinate of momentum vector
+      virtual double py() const = 0;
+      /// z coordinate of momentum vector
+      virtual double pz() const = 0;
+      /// transverse momentum
+      virtual double pt() const = 0;
+      /// momentum azimuthal angle
+      virtual double phi() const = 0;
+      /// momentum polar angle
+      virtual double theta() const = 0;
+      /// momentum pseudorapidity
+      virtual double eta() const = 0;
+      /// rapidity
+      virtual double rapidity() const = 0;
+      /// rapidity
+      virtual double y() const = 0;
+      /// set 4-momentum
+      virtual void setP4(const LorentzVector& p4) = 0;
+      /// set 4-momentum
+      virtual void setP4(const PolarLorentzVector& p4) = 0;
+      /// set particle mass
+      virtual void setMass(double m) = 0;
+      virtual void setPz(double pz) = 0;
+      /// vertex position
+      virtual const Point& vertex() const = 0;
+      /// x coordinate of vertex position
+      virtual double vx() const = 0;
+      /// y coordinate of vertex position
+      virtual double vy() const = 0;
+      /// z coordinate of vertex position
+      virtual double vz() const = 0;
+      /// set vertex
+      virtual void setVertex(const Point& vertex) = 0;
+      /// PDG identifier
+      virtual int pdgId() const = 0;
+      // set PDG identifier
+      virtual void setPdgId(int pdgId) = 0;
+      /// status word
+      virtual int status() const = 0;
+      /// set status word
+      virtual void setStatus(int status) = 0;
+      /// set long lived flag
+      virtual void setLongLived() = 0;
+      /// is long lived?
+      virtual bool longLived() const = 0;
+      /// set mass constraint flag
+      virtual void setMassConstraint() = 0;
+      /// do mass constraint?
+      virtual bool massConstraint() const = 0;
+      /// returns a clone of the Candidate object
+      virtual Candidate* clone() const = 0;
+      /// first daughter const_iterator
+      const_iterator begin() const { return const_iterator(this, 0); }
+      /// last daughter const_iterator
+      const_iterator end() const { return const_iterator(this, numberOfDaughters()); }
+      /// first daughter iterator
+      iterator begin() { return iterator(this, 0); }
+      /// last daughter iterator
+      iterator end() { return iterator(this, numberOfDaughters()); }
+      /// number of daughters
+      virtual size_type numberOfDaughters() const = 0;
+      /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1 (read only mode)
+      virtual const Candidate* daughter(size_type i) const = 0;
+      /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1
+      virtual Candidate* daughter(size_type i) = 0;
+      /// return daughter with a specified role name
+      virtual Candidate* daughter(const std::string& s) = 0;
+      /// return daughter with a specified role name
+      virtual const Candidate* daughter(const std::string& s) const = 0;
+      /// number of mothers (zero or one in most of but not all the cases)
+      virtual size_type numberOfMothers() const = 0;
+      /// return pointer to mother
+      virtual const Candidate* mother(size_type i = 0) const = 0;
+      /// return the number of source Candidates
+      /// ( the candidates used to construct this Candidate)
+      virtual size_t numberOfSourceCandidatePtrs() const = 0;
+      /// return a Ptr to one of the source Candidates
+      /// ( the candidates used to construct this Candidate)
+      virtual CandidatePtr sourceCandidatePtr(size_type i) const { return CandidatePtr(); }
+      /// \brief Set the ptr to the source Candidate.
+      ///
+      /// necessary, to allow a parallel treatment of all candidates
+      /// in PF2PAT. Does nothing for most Candidate classes, including
+      /// CompositePtrCandidates, where the source information is in fact
+      /// the collection of ptrs to daughters. For non-Composite Candidates,
+      /// this function can be used to set the ptr to the source of the
+      /// Candidate, which will allow to keep track
+      /// of the reconstruction history.
+      virtual void setSourceCandidatePtr(const CandidatePtr& ptr) {}
+
+      /// chi-squares
+      virtual double vertexChi2() const = 0;
+      /** Number of degrees of freedom
      *  Meant to be Double32_t for soft-assignment fitters: 
      *  tracks may contribute to the vertex with fractional weights.
      *  The ndof is then = to the sum of the track weights.
      *  see e.g. CMS NOTE-2006/032, CMS NOTE-2004/002
      */
-    virtual double vertexNdof() const = 0;
-    /// chi-squared divided by n.d.o.f.
-    virtual double vertexNormalizedChi2() const = 0;
-    /// (i, j)-th element of error matrix, i, j = 0, ... 2
-    virtual double vertexCovariance(int i, int j) const = 0;
-    /// fill SMatrix
-    virtual CovarianceMatrix vertexCovariance() const {
-      CovarianceMatrix m;
-      fillVertexCovariance(m);
-      return m;
-    }  //TODO
-    virtual void fillVertexCovariance(CovarianceMatrix& v) const = 0;
-    /// returns true if this candidate has a reference to a master clone.
-    /// This only happens if the concrete Candidate type is ShallowCloneCandidate
-    virtual bool hasMasterClone() const = 0;
-    /// returns ptr to master clone, if existing.
-    /// Throws an exception unless the concrete Candidate type is ShallowCloneCandidate
-    virtual const CandidateBaseRef& masterClone() const = 0;
-    /// returns true if this candidate has a ptr to a master clone.
-    /// This only happens if the concrete Candidate type is ShallowClonePtrCandidate
-    virtual bool hasMasterClonePtr() const = 0;
-    /// returns ptr to master clone, if existing.
-    /// Throws an exception unless the concrete Candidate type is ShallowClonePtrCandidate
-    virtual const CandidatePtr& masterClonePtr() const = 0;
-    /// cast master clone reference to a concrete type
-    template <typename Ref>
-    Ref masterRef() const {
-      return masterClone().template castTo<Ref>();
-    }
-    /// get a component
+      virtual double vertexNdof() const = 0;
+      /// chi-squared divided by n.d.o.f.
+      virtual double vertexNormalizedChi2() const = 0;
+      /// (i, j)-th element of error matrix, i, j = 0, ... 2
+      virtual double vertexCovariance(int i, int j) const = 0;
+      /// fill SMatrix
+      virtual CovarianceMatrix vertexCovariance() const {
+        CovarianceMatrix m;
+        fillVertexCovariance(m);
+        return m;
+      }  //TODO
+      virtual void fillVertexCovariance(CovarianceMatrix& v) const = 0;
+      /// returns true if this candidate has a reference to a master clone.
+      /// This only happens if the concrete Candidate type is ShallowCloneCandidate
+      virtual bool hasMasterClone() const = 0;
+      /// returns ptr to master clone, if existing.
+      /// Throws an exception unless the concrete Candidate type is ShallowCloneCandidate
+      virtual const CandidateBaseRef& masterClone() const = 0;
+      /// returns true if this candidate has a ptr to a master clone.
+      /// This only happens if the concrete Candidate type is ShallowClonePtrCandidate
+      virtual bool hasMasterClonePtr() const = 0;
+      /// returns ptr to master clone, if existing.
+      /// Throws an exception unless the concrete Candidate type is ShallowClonePtrCandidate
+      virtual const CandidatePtr& masterClonePtr() const = 0;
+      /// cast master clone reference to a concrete type
+      template <typename Ref>
+      Ref masterRef() const {
+        return masterClone().template castTo<Ref>();
+      }
+      /// get a component
 
-    template <typename T>
-    T get() const {
-      if (hasMasterClone())
-        return masterClone()->get<T>();
-      else
-        return reco::get<T>(*this);
-    }
-    /// get a component
-    template <typename T, typename Tag>
-    T get() const {
-      if (hasMasterClone())
-        return masterClone()->get<T, Tag>();
-      else
-        return reco::get<T, Tag>(*this);
-    }
-    /// get a component
-    template <typename T>
-    T get(size_type i) const {
-      if (hasMasterClone())
-        return masterClone()->get<T>(i);
-      else
-        return reco::get<T>(*this, i);
-    }
-    /// get a component
-    template <typename T, typename Tag>
-    T get(size_type i) const {
-      if (hasMasterClone())
-        return masterClone()->get<T, Tag>(i);
-      else
-        return reco::get<T, Tag>(*this, i);
-    }
-    /// number of components
-    template <typename T>
-    size_type numberOf() const {
-      if (hasMasterClone())
-        return masterClone()->numberOf<T>();
-      else
-        return reco::numberOf<T>(*this);
-    }
-    /// number of components
-    template <typename T, typename Tag>
-    size_type numberOf() const {
-      if (hasMasterClone())
-        return masterClone()->numberOf<T, Tag>();
-      else
-        return reco::numberOf<T, Tag>(*this);
-    }
+      template <typename T>
+      T get() const {
+        if (hasMasterClone())
+          return masterClone()->get<T>();
+        else
+          return reco::get<T>(*this);
+      }
+      /// get a component
+      template <typename T, typename Tag>
+      T get() const {
+        if (hasMasterClone())
+          return masterClone()->get<T, Tag>();
+        else
+          return reco::get<T, Tag>(*this);
+      }
+      /// get a component
+      template <typename T>
+      T get(size_type i) const {
+        if (hasMasterClone())
+          return masterClone()->get<T>(i);
+        else
+          return reco::get<T>(*this, i);
+      }
+      /// get a component
+      template <typename T, typename Tag>
+      T get(size_type i) const {
+        if (hasMasterClone())
+          return masterClone()->get<T, Tag>(i);
+        else
+          return reco::get<T, Tag>(*this, i);
+      }
+      /// number of components
+      template <typename T>
+      size_type numberOf() const {
+        if (hasMasterClone())
+          return masterClone()->numberOf<T>();
+        else
+          return reco::numberOf<T>(*this);
+      }
+      /// number of components
+      template <typename T, typename Tag>
+      size_type numberOf() const {
+        if (hasMasterClone())
+          return masterClone()->numberOf<T, Tag>();
+        else
+          return reco::numberOf<T, Tag>(*this);
+      }
 
-    virtual const Track* bestTrack() const { return nullptr; }
+      virtual const Track* bestTrack() const { return nullptr; }
 
-    /// uncertainty on dz
-    virtual float dzError() const {
-      return 0;
-    }  // { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dzError(); else return 0; }
-    /// uncertainty on dxy
-    virtual float dxyError() const {
-      return 0;
-    }  // { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dxyError(); else return 0; }
+      /// uncertainty on dz
+      virtual float dzError() const {
+        return 0;
+      }  // { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dzError(); else return 0; }
+      /// uncertainty on dxy
+      virtual float dxyError() const {
+        return 0;
+      }  // { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dxyError(); else return 0; }
 
-    virtual bool isElectron() const = 0;
-    virtual bool isMuon() const = 0;
-    virtual bool isStandAloneMuon() const = 0;
-    virtual bool isGlobalMuon() const = 0;
-    virtual bool isTrackerMuon() const = 0;
-    virtual bool isCaloMuon() const = 0;
-    virtual bool isPhoton() const = 0;
-    virtual bool isConvertedPhoton() const = 0;
-    virtual bool isJet() const = 0;
+      virtual bool isElectron() const = 0;
+      virtual bool isMuon() const = 0;
+      virtual bool isStandAloneMuon() const = 0;
+      virtual bool isGlobalMuon() const = 0;
+      virtual bool isTrackerMuon() const = 0;
+      virtual bool isCaloMuon() const = 0;
+      virtual bool isPhoton() const = 0;
+      virtual bool isConvertedPhoton() const = 0;
+      virtual bool isJet() const = 0;
 
-  protected:
-    /// check overlap with another Candidate
-    virtual bool overlap(const Candidate&) const = 0;
-    template <typename, typename, typename>
-    friend struct component;
-    friend class ::OverlapChecker;
-    friend class ShallowCloneCandidate;
-    friend class ShallowClonePtrCandidate;
-  };
+    protected:
+      /// check overlap with another Candidate
+      virtual bool overlap(const Candidate&) const = 0;
+      template <typename, typename, typename>
+      friend struct component;
+      friend class ::OverlapChecker;
+      friend class reco::ShallowCloneCandidate;
+      friend class reco::ShallowClonePtrCandidate;
+    };
+
+  }  // namespace io_v1
+
+  using Candidate = io_v1::Candidate;
 
   namespace candidate {
 

--- a/DataFormats/Candidate/interface/CandidateFwd.h
+++ b/DataFormats/Candidate/interface/CandidateFwd.h
@@ -2,10 +2,6 @@
 #define Candidate_CandidateFwd_h
 #include "DataFormats/Common/interface/OwnVector.h"
 
-namespace reco {
-  class Candidate;
-}
-
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/Ptr.h"
 #include "DataFormats/Common/interface/PtrVector.h"
@@ -15,6 +11,8 @@ namespace reco {
 #include "DataFormats/Common/interface/RefToBaseVector.h"
 #include "DataFormats/Common/interface/RefToBaseProd.h"
 #include "DataFormats/Common/interface/View.h"
+
+#include "DataFormats/Candidate/interface/CandidateOnlyFwd.h"
 
 namespace reco {
   /// collection of Candidate objects

--- a/DataFormats/Candidate/interface/CandidateOnlyFwd.h
+++ b/DataFormats/Candidate/interface/CandidateOnlyFwd.h
@@ -1,6 +1,9 @@
 #ifndef DataFormats_Candidate_CandidateOnlyFwd_h
 #define DataFormats_Candidate_CandidateOnlyFwd_h
 namespace reco {
-  class Candidate;
-}
+  namespace io_v1 {
+    class Candidate;
+  }
+  using Candidate = io_v1::Candidate;
+}  // namespace reco
 #endif

--- a/DataFormats/Candidate/interface/CompositeCandidate.h
+++ b/DataFormats/Candidate/interface/CompositeCandidate.h
@@ -17,77 +17,81 @@
 #include <vector>
 
 namespace reco {
+  namespace io_v1 {
 
-  class CompositeCandidate : public LeafCandidate {
-  public:
-    /// collection of daughters
-    typedef CandidateCollection daughters;
-    typedef std::vector<std::string> role_collection;
-    /// default constructor
-    CompositeCandidate(std::string name = "") : LeafCandidate(), name_(name) {}
-    /// constructor from values
-    template <typename P4>
-    CompositeCandidate(Charge q,
-                       const P4& p4,
-                       const Point& vtx = Point(0, 0, 0),
-                       int pdgId = 0,
-                       int status = 0,
-                       bool integerCharge = true,
-                       std::string name = "")
-        : LeafCandidate(q, p4, vtx, pdgId, status, integerCharge), name_(name) {}
-    /// constructor from values
-    explicit CompositeCandidate(const Candidate& p, const std::string& name = "");
-    /// constructor from values
-    explicit CompositeCandidate(const Candidate& p, const std::string& name, role_collection const& roles);
-    /// destructor
-    ~CompositeCandidate() override;
-    /// get the name of the candidate
-    std::string name() const { return name_; }
-    /// set the name of the candidate
-    void setName(std::string name) { name_ = name; }
-    /// get the roles
-    role_collection const& roles() const { return roles_; }
-    /// set the roles
-    void setRoles(const role_collection& roles) {
-      roles_.clear();
-      roles_ = roles;
-    }
-    /// returns a clone of the candidate
-    CompositeCandidate* clone() const override;
-    /// number of daughters
-    size_type numberOfDaughters() const override;
-    /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1 (read only mode)
-    const Candidate* daughter(size_type) const override;
-    /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1
-    Candidate* daughter(size_type) override;
-    // Get candidate based on role
-    Candidate* daughter(const std::string& s) override;
-    const Candidate* daughter(const std::string& s) const override;
-    /// add a clone of the passed candidate as daughter
-    void addDaughter(const Candidate&, const std::string& s = "");
-    /// add a clone of the passed candidate as daughter
-    void addDaughter(std::unique_ptr<Candidate>, const std::string& s = "");
-    /// clear daughters
-    void clearDaughters() { dau.clear(); }
-    // clear roles
-    void clearRoles() { roles_.clear(); }
-    // Apply the roles to the objects
-    void applyRoles();
-    /// number of mothers (zero or one in most of but not all the cases)
-    size_type numberOfMothers() const override;
-    /// return pointer to mother
-    const Candidate* mother(size_type i = 0) const override;
+    class CompositeCandidate : public LeafCandidate {
+    public:
+      /// collection of daughters
+      typedef CandidateCollection daughters;
+      typedef std::vector<std::string> role_collection;
+      /// default constructor
+      CompositeCandidate(std::string name = "") : LeafCandidate(), name_(name) {}
+      /// constructor from values
+      template <typename P4>
+      CompositeCandidate(Charge q,
+                         const P4& p4,
+                         const Point& vtx = Point(0, 0, 0),
+                         int pdgId = 0,
+                         int status = 0,
+                         bool integerCharge = true,
+                         std::string name = "")
+          : LeafCandidate(q, p4, vtx, pdgId, status, integerCharge), name_(name) {}
+      /// constructor from values
+      explicit CompositeCandidate(const Candidate& p, const std::string& name = "");
+      /// constructor from values
+      explicit CompositeCandidate(const Candidate& p, const std::string& name, role_collection const& roles);
+      /// destructor
+      ~CompositeCandidate() override;
+      /// get the name of the candidate
+      std::string name() const { return name_; }
+      /// set the name of the candidate
+      void setName(std::string name) { name_ = name; }
+      /// get the roles
+      role_collection const& roles() const { return roles_; }
+      /// set the roles
+      void setRoles(const role_collection& roles) {
+        roles_.clear();
+        roles_ = roles;
+      }
+      /// returns a clone of the candidate
+      CompositeCandidate* clone() const override;
+      /// number of daughters
+      size_type numberOfDaughters() const override;
+      /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1 (read only mode)
+      const Candidate* daughter(size_type) const override;
+      /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1
+      Candidate* daughter(size_type) override;
+      // Get candidate based on role
+      Candidate* daughter(const std::string& s) override;
+      const Candidate* daughter(const std::string& s) const override;
+      /// add a clone of the passed candidate as daughter
+      void addDaughter(const Candidate&, const std::string& s = "");
+      /// add a clone of the passed candidate as daughter
+      void addDaughter(std::unique_ptr<Candidate>, const std::string& s = "");
+      /// clear daughters
+      void clearDaughters() { dau.clear(); }
+      // clear roles
+      void clearRoles() { roles_.clear(); }
+      // Apply the roles to the objects
+      void applyRoles();
+      /// number of mothers (zero or one in most of but not all the cases)
+      size_type numberOfMothers() const override;
+      /// return pointer to mother
+      const Candidate* mother(size_type i = 0) const override;
 
-  private:
-    /// collection of daughters
-    daughters dau;
-    /// check overlap with another daughter
-    bool overlap(const Candidate&) const override;
-    /// candidate name
-    std::string name_;
-    /// candidate roles
-    role_collection roles_;
-  };
+    private:
+      /// collection of daughters
+      daughters dau;
+      /// check overlap with another daughter
+      bool overlap(const Candidate&) const override;
+      /// candidate name
+      std::string name_;
+      /// candidate roles
+      role_collection roles_;
+    };
+
+  }  // namespace io_v1
+  using CompositeCandidate = io_v1::CompositeCandidate;
 
 }  // namespace reco
 

--- a/DataFormats/Candidate/interface/CompositeCandidateFwd.h
+++ b/DataFormats/Candidate/interface/CompositeCandidateFwd.h
@@ -3,8 +3,11 @@
 #include "DataFormats/Common/interface/OwnVector.h"
 
 namespace reco {
-  class CompositeCandidate;
-}
+  namespace io_v1 {
+    class CompositeCandidate;
+  }
+  using CompositeCandidate = io_v1::CompositeCandidate;
+}  // namespace reco
 
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefProd.h"

--- a/DataFormats/Candidate/interface/LeafRefCandidateT.h
+++ b/DataFormats/Candidate/interface/LeafRefCandidateT.h
@@ -157,8 +157,6 @@ namespace reco {
     bool isConvertedPhoton() const final { return false; }
     bool isJet() const final { return false; }
 
-    CMS_CLASS_VERSION(13)
-
   protected:
     /// check overlap with another Candidate
     bool overlap(const Candidate&) const override;

--- a/DataFormats/Candidate/interface/VertexCompositeCandidate.h
+++ b/DataFormats/Candidate/interface/VertexCompositeCandidate.h
@@ -13,69 +13,72 @@
 #include "DataFormats/Candidate/interface/CompositeCandidate.h"
 
 namespace reco {
-  class VertexCompositeCandidate : public CompositeCandidate {
-  public:
-    VertexCompositeCandidate() : CompositeCandidate() {}
-    /// constructor from values
-    VertexCompositeCandidate(
-        Charge q, const LorentzVector &p4, const Point &vtx, int pdgId = 0, int status = 0, bool integerCharge = true)
-        : CompositeCandidate(q, p4, vtx, pdgId, status, integerCharge), chi2_(0), ndof_(0) {}
-    /// constructor from values
-    VertexCompositeCandidate(Charge q,
-                             const LorentzVector &p4,
-                             const Point &vtx,
-                             const CovarianceMatrix &err,
-                             double chi2,
-                             double ndof,
-                             int pdgId = 0,
-                             int status = 0,
-                             bool integerCharge = true);
-    /// constructor from values
-    explicit VertexCompositeCandidate(const Candidate &p) : CompositeCandidate(p), chi2_(0), ndof_(0) {}
-    /// constructor from values
-    explicit VertexCompositeCandidate(const CompositeCandidate &p) : CompositeCandidate(p), chi2_(0), ndof_(0) {}
-    /// destructor
-    ~VertexCompositeCandidate() override;
-    /// returns a clone of the candidate
-    VertexCompositeCandidate *clone() const override;
-    /// chi-squares
-    double vertexChi2() const override { return chi2_; }
-    /** Number of degrees of freedom
+  namespace io_v1 {
+    class VertexCompositeCandidate : public CompositeCandidate {
+    public:
+      VertexCompositeCandidate() : CompositeCandidate() {}
+      /// constructor from values
+      VertexCompositeCandidate(
+          Charge q, const LorentzVector &p4, const Point &vtx, int pdgId = 0, int status = 0, bool integerCharge = true)
+          : CompositeCandidate(q, p4, vtx, pdgId, status, integerCharge), chi2_(0), ndof_(0) {}
+      /// constructor from values
+      VertexCompositeCandidate(Charge q,
+                               const LorentzVector &p4,
+                               const Point &vtx,
+                               const CovarianceMatrix &err,
+                               double chi2,
+                               double ndof,
+                               int pdgId = 0,
+                               int status = 0,
+                               bool integerCharge = true);
+      /// constructor from values
+      explicit VertexCompositeCandidate(const Candidate &p) : CompositeCandidate(p), chi2_(0), ndof_(0) {}
+      /// constructor from values
+      explicit VertexCompositeCandidate(const CompositeCandidate &p) : CompositeCandidate(p), chi2_(0), ndof_(0) {}
+      /// destructor
+      ~VertexCompositeCandidate() override;
+      /// returns a clone of the candidate
+      VertexCompositeCandidate *clone() const override;
+      /// chi-squares
+      double vertexChi2() const override { return chi2_; }
+      /** Number of degrees of freedom
      *  Meant to be Double32_t for soft-assignment fitters: 
      *  tracks may contribute to the vertex with fractional weights.
      *  The ndof is then = to the sum of the track weights.
      *  see e.g. CMS NOTE-2006/032, CMS NOTE-2004/002
      */
-    double vertexNdof() const override { return ndof_; }
-    /// chi-squared divided by n.d.o.f.
-    double vertexNormalizedChi2() const override { return chi2_ / ndof_; }
-    /// (i, j)-th element of error matrix, i, j = 0, ... 2
-    double vertexCovariance(int i, int j) const override { return covariance_[idx(i, j)]; }
-    using reco::LeafCandidate::vertexCovariance;  // avoid hiding the
-    /// fill SMatrix
-    void fillVertexCovariance(CovarianceMatrix &v) const override;
-    /// set chi2 and ndof
-    void setChi2AndNdof(double chi2, double ndof) {
-      chi2_ = chi2;
-      ndof_ = ndof;
-    }
-    /// set covariance matrix
-    void setCovariance(const CovarianceMatrix &m);
+      double vertexNdof() const override { return ndof_; }
+      /// chi-squared divided by n.d.o.f.
+      double vertexNormalizedChi2() const override { return chi2_ / ndof_; }
+      /// (i, j)-th element of error matrix, i, j = 0, ... 2
+      double vertexCovariance(int i, int j) const override { return covariance_[idx(i, j)]; }
+      using reco::LeafCandidate::vertexCovariance;  // avoid hiding the
+      /// fill SMatrix
+      void fillVertexCovariance(CovarianceMatrix &v) const override;
+      /// set chi2 and ndof
+      void setChi2AndNdof(double chi2, double ndof) {
+        chi2_ = chi2;
+        ndof_ = ndof;
+      }
+      /// set covariance matrix
+      void setCovariance(const CovarianceMatrix &m);
 
-  private:
-    /// chi-sqared
-    Double32_t chi2_;
-    /// number of degrees of freedom
-    Double32_t ndof_;
-    /// covariance matrix (3x3) as vector
-    Double32_t covariance_[size];
-    /// position index
-    index idx(index i, index j) const {
-      int a = (i <= j ? i : j), b = (i <= j ? j : i);
-      return b * (b + 1) / 2 + a;
-    }
-  };
+    private:
+      /// chi-sqared
+      Double32_t chi2_;
+      /// number of degrees of freedom
+      Double32_t ndof_;
+      /// covariance matrix (3x3) as vector
+      Double32_t covariance_[size];
+      /// position index
+      index idx(index i, index j) const {
+        int a = (i <= j ? i : j), b = (i <= j ? j : i);
+        return b * (b + 1) / 2 + a;
+      }
+    };
 
+  }  // namespace io_v1
+  using VertexCompositeCandidate = io_v1::VertexCompositeCandidate;
 }  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/VertexCompositeCandidateFwd.h
+++ b/DataFormats/Candidate/interface/VertexCompositeCandidateFwd.h
@@ -2,10 +2,7 @@
 #define DataFormats_Candidate_VertexCompositeCandidateFwd_h
 #include "DataFormats/Common/interface/OwnVector.h"
 
-namespace reco {
-  class VertexCompositeCandidate;
-}
-
+#include "DataFormats/Candidate/interface/VertexCompositeCandidateOnlyFwd.h"
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefProd.h"
 #include "DataFormats/Common/interface/RefVector.h"

--- a/DataFormats/Candidate/interface/VertexCompositeCandidateOnlyFwd.h
+++ b/DataFormats/Candidate/interface/VertexCompositeCandidateOnlyFwd.h
@@ -1,6 +1,9 @@
 #ifndef DataFormats_Candidate_VertexCompositeCandidateOnlyFwd_h
 #define DataFormats_Candidate_VertexCompositeCandidateOnlyFwd_h
 namespace reco {
-  class VertexCompositeCandidate;
-}
+  namespace io_v1 {
+    class VertexCompositeCandidate;
+  }
+  using VertexCompositeCandidate = io_v1::VertexCompositeCandidate;
+}  // namespace reco
 #endif

--- a/DataFormats/Candidate/interface/VertexCompositePtrCandidate.h
+++ b/DataFormats/Candidate/interface/VertexCompositePtrCandidate.h
@@ -13,130 +13,134 @@
 #include "DataFormats/Candidate/interface/CompositePtrCandidate.h"
 
 namespace reco {
-  class VertexCompositePtrCandidate : public CompositePtrCandidate {
-  public:
-    enum { dimension4D = 4 };
-    /// covariance error matrix (3x3)
-    typedef math::Error<dimension4D>::type CovarianceMatrix4D;
-    /// matix size
-    enum { size4D = dimension4D * (dimension4D + 1) / 2 };
+  namespace io_v1 {
+    class VertexCompositePtrCandidate : public CompositePtrCandidate {
+    public:
+      enum { dimension4D = 4 };
+      /// covariance error matrix (3x3)
+      typedef math::Error<dimension4D>::type CovarianceMatrix4D;
+      /// matix size
+      enum { size4D = dimension4D * (dimension4D + 1) / 2 };
 
-    VertexCompositePtrCandidate() : CompositePtrCandidate(), chi2_(0), ndof_(0), time_(0) {}
-    /// constructor from values
-    VertexCompositePtrCandidate(
-        Charge q, const LorentzVector &p4, const Point &vtx, int pdgId = 0, int status = 0, bool integerCharge = true)
-        : CompositePtrCandidate(q, p4, vtx, pdgId, status, integerCharge), chi2_(0), ndof_(0), time_(0) {}
-    VertexCompositePtrCandidate(Charge q,
-                                const LorentzVector &p4,
-                                const Point &vtx,
-                                double time,
-                                int pdgId = 0,
-                                int status = 0,
-                                bool integerCharge = true)
-        : CompositePtrCandidate(q, p4, vtx, pdgId, status, integerCharge), chi2_(0), ndof_(0), time_(time) {}
-    /// constructor from values
-    VertexCompositePtrCandidate(Charge q,
-                                const LorentzVector &p4,
-                                const Point &vtx,
-                                const CovarianceMatrix &err,
-                                double chi2,
-                                double ndof,
-                                int pdgId = 0,
-                                int status = 0,
-                                bool integerCharge = true);
-    VertexCompositePtrCandidate(Charge q,
-                                const LorentzVector &p4,
-                                const Point &vtx,
-                                double time,
-                                const CovarianceMatrix4D &err,
-                                double chi2,
-                                double ndof,
-                                int pdgId = 0,
-                                int status = 0,
-                                bool integerCharge = true);
-    /// constructor from values
-    explicit VertexCompositePtrCandidate(const Candidate &p) : CompositePtrCandidate(p), chi2_(0), ndof_(0), time_(0) {}
-    /// constructor from values
-    explicit VertexCompositePtrCandidate(const CompositePtrCandidate &p)
-        : CompositePtrCandidate(p), chi2_(0), ndof_(0), time_(0) {}
-    /// destructor
-    ~VertexCompositePtrCandidate() override;
-    /// returns a clone of the candidate
-    VertexCompositePtrCandidate *clone() const override;
+      VertexCompositePtrCandidate() : CompositePtrCandidate(), chi2_(0), ndof_(0), time_(0) {}
+      /// constructor from values
+      VertexCompositePtrCandidate(
+          Charge q, const LorentzVector &p4, const Point &vtx, int pdgId = 0, int status = 0, bool integerCharge = true)
+          : CompositePtrCandidate(q, p4, vtx, pdgId, status, integerCharge), chi2_(0), ndof_(0), time_(0) {}
+      VertexCompositePtrCandidate(Charge q,
+                                  const LorentzVector &p4,
+                                  const Point &vtx,
+                                  double time,
+                                  int pdgId = 0,
+                                  int status = 0,
+                                  bool integerCharge = true)
+          : CompositePtrCandidate(q, p4, vtx, pdgId, status, integerCharge), chi2_(0), ndof_(0), time_(time) {}
+      /// constructor from values
+      VertexCompositePtrCandidate(Charge q,
+                                  const LorentzVector &p4,
+                                  const Point &vtx,
+                                  const CovarianceMatrix &err,
+                                  double chi2,
+                                  double ndof,
+                                  int pdgId = 0,
+                                  int status = 0,
+                                  bool integerCharge = true);
+      VertexCompositePtrCandidate(Charge q,
+                                  const LorentzVector &p4,
+                                  const Point &vtx,
+                                  double time,
+                                  const CovarianceMatrix4D &err,
+                                  double chi2,
+                                  double ndof,
+                                  int pdgId = 0,
+                                  int status = 0,
+                                  bool integerCharge = true);
+      /// constructor from values
+      explicit VertexCompositePtrCandidate(const Candidate &p)
+          : CompositePtrCandidate(p), chi2_(0), ndof_(0), time_(0) {}
+      /// constructor from values
+      explicit VertexCompositePtrCandidate(const CompositePtrCandidate &p)
+          : CompositePtrCandidate(p), chi2_(0), ndof_(0), time_(0) {}
+      /// destructor
+      ~VertexCompositePtrCandidate() override;
+      /// returns a clone of the candidate
+      VertexCompositePtrCandidate *clone() const override;
 
-    /// chi-squares
-    double vertexChi2() const override { return chi2_; }
-    /** Number of degrees of freedom
+      /// chi-squares
+      double vertexChi2() const override { return chi2_; }
+      /** Number of degrees of freedom
      *  Meant to be Double32_t for soft-assignment fitters: 
      *  tracks may contribute to the vertex with fractional weights.
      *  The ndof is then = to the sum of the track weights.
      *  see e.g. CMS NOTE-2006/032, CMS NOTE-2004/002
      */
-    double vertexNdof() const override { return ndof_; }
-    /// chi-squared divided by n.d.o.f.
-    double vertexNormalizedChi2() const override { return chi2_ / ndof_; }
-    /// (i, j)-th element of error matrix, i, j = 0, ... 3
-    double vertexCovariance(int i, int j) const override { return covariance_[idx(i, j)]; }
-    using reco::LeafCandidate::vertexCovariance;  // avoid hiding the
-    /// return SMatrix 4D
-    CovarianceMatrix4D vertexCovariance4D() const {
-      CovarianceMatrix4D m;
-      fillVertexCovariance(m);
-      return m;
-    }
+      double vertexNdof() const override { return ndof_; }
+      /// chi-squared divided by n.d.o.f.
+      double vertexNormalizedChi2() const override { return chi2_ / ndof_; }
+      /// (i, j)-th element of error matrix, i, j = 0, ... 3
+      double vertexCovariance(int i, int j) const override { return covariance_[idx(i, j)]; }
+      using reco::LeafCandidate::vertexCovariance;  // avoid hiding the
+      /// return SMatrix 4D
+      CovarianceMatrix4D vertexCovariance4D() const {
+        CovarianceMatrix4D m;
+        fillVertexCovariance(m);
+        return m;
+      }
 
-    /// fill SMatrix
-    void fillVertexCovariance(CovarianceMatrix &v) const override;
-    /// 4D version
-    void fillVertexCovariance(CovarianceMatrix4D &v) const;
+      /// fill SMatrix
+      void fillVertexCovariance(CovarianceMatrix &v) const override;
+      /// 4D version
+      void fillVertexCovariance(CovarianceMatrix4D &v) const;
 
-    /// set chi2 and ndof
-    void setChi2AndNdof(double chi2, double ndof) {
-      chi2_ = chi2;
-      ndof_ = ndof;
-    }
-    /// set covariance matrix
-    void setCovariance(const CovarianceMatrix &m);
-    /// set covariance matrix
-    void setCovariance(const CovarianceMatrix4D &m);
+      /// set chi2 and ndof
+      void setChi2AndNdof(double chi2, double ndof) {
+        chi2_ = chi2;
+        ndof_ = ndof;
+      }
+      /// set covariance matrix
+      void setCovariance(const CovarianceMatrix &m);
+      /// set covariance matrix
+      void setCovariance(const CovarianceMatrix4D &m);
 
-    // set time
-    void setTime(double time) { time_ = time; }
+      // set time
+      void setTime(double time) { time_ = time; }
 
-    /// the following functions are implemented to have a more consistent interface with the one of reco::Vertex
-    typedef math::Error<dimension>::type Error;
-    typedef math::Error<dimension4D>::type Error4D;
-    const Point &position() const { return vertex(); }
-    double t() const { return time_; }
-    double tError() const { return std::sqrt(vertexCovariance(3, 3)); }
-    Error error() const {
-      Error m;
-      fillVertexCovariance(m);
-      return m;
-    }
-    /// return SMatrix 4D
-    Error4D error4D() const {
-      Error4D m;
-      fillVertexCovariance(m);
-      return m;
-    }
+      /// the following functions are implemented to have a more consistent interface with the one of reco::Vertex
+      typedef math::Error<dimension>::type Error;
+      typedef math::Error<dimension4D>::type Error4D;
+      const Point &position() const { return vertex(); }
+      double t() const { return time_; }
+      double tError() const { return std::sqrt(vertexCovariance(3, 3)); }
+      Error error() const {
+        Error m;
+        fillVertexCovariance(m);
+        return m;
+      }
+      /// return SMatrix 4D
+      Error4D error4D() const {
+        Error4D m;
+        fillVertexCovariance(m);
+        return m;
+      }
 
-  private:
-    /// chi-sqared
-    Double32_t chi2_;
-    /// number of degrees of freedom
-    Double32_t ndof_;
-    /// covariance matrix (4x4) as vector
-    Double32_t covariance_[size4D];
-    /// vertex time
-    Double32_t time_;
-    /// position index
-    index idx(index i, index j) const {
-      int a = (i <= j ? i : j), b = (i <= j ? j : i);
-      return b * (b + 1) / 2 + a;
-    }
-  };
+    private:
+      /// chi-sqared
+      Double32_t chi2_;
+      /// number of degrees of freedom
+      Double32_t ndof_;
+      /// covariance matrix (4x4) as vector
+      Double32_t covariance_[size4D];
+      /// vertex time
+      Double32_t time_;
+      /// position index
+      index idx(index i, index j) const {
+        int a = (i <= j ? i : j), b = (i <= j ? j : i);
+        return b * (b + 1) / 2 + a;
+      }
+    };
 
+  }  // namespace io_v1
+  using VertexCompositePtrCandidate = io_v1::VertexCompositePtrCandidate;
 }  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/VertexCompositePtrCandidateFwd.h
+++ b/DataFormats/Candidate/interface/VertexCompositePtrCandidateFwd.h
@@ -3,8 +3,11 @@
 #include "DataFormats/Common/interface/OwnVector.h"
 
 namespace reco {
-  class VertexCompositePtrCandidate;
-}
+  namespace io_v1 {
+    class VertexCompositePtrCandidate;
+  }
+  using VertexCompositePtrCandidate = io_v1::VertexCompositePtrCandidate;
+}  // namespace reco
 
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefProd.h"

--- a/DataFormats/Candidate/src/classes_def.xml
+++ b/DataFormats/Candidate/src/classes_def.xml
@@ -25,95 +25,56 @@
   </ioread>
 
 
-  <class name="reco::Candidate" ClassVersion="10">
-   <version ClassVersion="10" checksum="783896264"/>
+  <class name="reco::io_v1::Candidate" ClassVersion="3">
+   <version ClassVersion="3" checksum="1273668242"/>
   </class>
 
-  <class name="reco::LeafCandidate"  ClassVersion="13">
-   <version ClassVersion="13" checksum="286262695"/>
-   <version ClassVersion="12" checksum="3932037675"/>
-   <version ClassVersion="11" checksum="1947948955"/>
-   <version ClassVersion="10" checksum="4128105563"/>
-  </class>
-  <ioread sourceClass = "reco::LeafCandidate" version="[1-12]" targetClass="reco::LeafCandidate" 
-	  source="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>  vertex_; float pt_; float eta_; float phi_; float mass_; int qx3_; int pdgId_; int status_;" 
-          target="m_state">
-    <![CDATA[
-	     newObj->construct(onfile.qx3_, onfile.pt_,onfile.eta_,onfile.phi_,onfile.mass_,onfile.vertex_, onfile.pdgId_, onfile.status_);
-    ]]>
-  </ioread>
-
-  <class name="reco::CompositeCandidate" ClassVersion="12">
-   <version ClassVersion="12" checksum="1318508193"/>
-   <version ClassVersion="11" checksum="1985736233"/>
-   <version ClassVersion="10" checksum="2953566340"/>
+  <class name="reco::LeafCandidate"  ClassVersion="3">
+   <version ClassVersion="3" checksum="495188715"/>
   </class>
 
-  <class name="reco::LeafRefCandidateT" ClassVersion="13">
-    <version ClassVersion="13" checksum="2417932556"/>
-    <version ClassVersion="11" checksum="2417932556"/>
-    <version ClassVersion="10" checksum="2404784677"/>
+  <class name="reco::io_v1::CompositeCandidate" ClassVersion="3">
+   <version ClassVersion="3" checksum="78520017"/>
+  </class>
+  <class name="edm::Wrapper<reco::io_v1::CompositeCandidate>" />
+  <class name="std::pair<reco::io_v1::CompositeCandidate, std::vector<int> >" />
+  <class name="std::vector<std::pair<reco::io_v1::CompositeCandidate, std::vector<int> > >" />
+  <class name="edm::Wrapper<std::vector<std::pair<reco::io_v1::CompositeCandidate, std::vector<int> > > >" />
+
+  <class name="reco::LeafRefCandidateT" ClassVersion="3">
+    <version ClassVersion="3" checksum="2164853592"/>
    </class>
 
-  <class name="reco::VertexCompositePtrCandidate" ClassVersion="14">
-   <version ClassVersion="14" checksum="2052765294"/>
-   <version ClassVersion="13" checksum="3584734005"/>
-   <version ClassVersion="12" checksum="3253990857"/>
-   <version ClassVersion="11" checksum="2070976353"/>
-   <version ClassVersion="10" checksum="955269040"/>
+  <class name="reco::io_v1::VertexCompositePtrCandidate" ClassVersion="3">
+   <version ClassVersion="3" checksum="2009437832"/>
   </class>  
-  <ioread sourceClass="reco::VertexCompositePtrCandidate" version="[-13]" targetClass="reco::VertexCompositePtrCandidate" 
-	  source="Double32_t covariance_[6]" 
-          target="covariance_">
-    <![CDATA[
-	   for( unsigned i = 0; i < 4; ++i ) { for( unsigned j = i; j< 4; ++j ) { unsigned a = (i <= j ? i : j), b = (i <= j ? j : i); unsigned idx = b * (b + 1)/2 + a; covariance_[idx] = ( i == 3 || j == 3 ) ? 0.0 : onfile.covariance_[idx]; } }
-    ]]>
-  </ioread>  
 
-  <class name="reco::VertexCompositeCandidate" ClassVersion="13">
-   <version ClassVersion="13" checksum="1561694123"/>
-   <version ClassVersion="12" checksum="1204062111"/>
-   <version ClassVersion="11" checksum="2801258535"/>
-   <version ClassVersion="10" checksum="4177206274"/>
+  <class name="reco::io_v1::VertexCompositeCandidate" ClassVersion="3">
+   <version ClassVersion="3" checksum="1399322933"/>
   </class>
-  <class name="reco::CompositeRefCandidate"  ClassVersion="12">
-   <version ClassVersion="12" checksum="2573277496"/>
-   <version ClassVersion="11" checksum="3325042432"/>
-   <version ClassVersion="10" checksum="502055765"/>
+  <class name="reco::CompositeRefCandidate"  ClassVersion="3">
+   <version ClassVersion="3" checksum="134608244"/>
   </class>
-  <class name="reco::CompositePtrCandidate"  ClassVersion="12">
-   <version ClassVersion="12" checksum="1693316545"/>
-   <version ClassVersion="11" checksum="900138073"/>
-   <version ClassVersion="10" checksum="240358262"/>
+  <class name="reco::CompositePtrCandidate"  ClassVersion="3">
+   <version ClassVersion="3" checksum="3593770037"/>
   </class>
-  <class name="reco::CompositeRefBaseCandidate"  ClassVersion="12">
-   <version ClassVersion="12" checksum="419605458"/>
-   <version ClassVersion="11" checksum="2013084330"/>
-   <version ClassVersion="10" checksum="382235387"/>
+  <class name="reco::CompositeRefBaseCandidate"  ClassVersion="3">
+   <version ClassVersion="3" checksum="2593606352"/>
   </class>
-  <class name="reco::ShallowCloneCandidate"  ClassVersion="12">
-   <version ClassVersion="12" checksum="3760837537"/>
-   <version ClassVersion="11" checksum="1059349113"/>
-   <version ClassVersion="10" checksum="4127213986"/>
+  <class name="reco::ShallowCloneCandidate"  ClassVersion="3">
+   <version ClassVersion="3" checksum="2987364689"/>
   </class>
-  <class name="reco::ShallowClonePtrCandidate"  ClassVersion="12">
-   <version ClassVersion="12" checksum="917739380"/>
-   <version ClassVersion="11" checksum="124560908"/>
-   <version ClassVersion="10" checksum="2575892329"/>
+  <class name="reco::ShallowClonePtrCandidate"  ClassVersion="3">
+   <version ClassVersion="3" checksum="2777164162"/>
   </class>
-  <class name="reco::NamedCompositeCandidate" ClassVersion="12">
-   <version ClassVersion="12" checksum="1682589651"/>
-   <version ClassVersion="11" checksum="1100712875"/>
-   <version ClassVersion="10" checksum="604924170"/>
+  <class name="reco::NamedCompositeCandidate" ClassVersion="3">
+   <version ClassVersion="3" checksum="3875073405"/>
   </class>
-  <class name="reco::candidate::iterator"  ClassVersion="11">
-   <version ClassVersion="11" checksum="2805432001"/>
-   <version ClassVersion="10" checksum="547616838"/>
+  <class name="reco::io_v1::Candidate::iterator"  ClassVersion="3">
+   <version ClassVersion="3" checksum="3107512183"/>
   </class>
-  <class name="reco::candidate::const_iterator"  ClassVersion="12">
-   <version ClassVersion="12" checksum="870110996"/>
-   <version ClassVersion="11" checksum="1840645481"/>
-   <version ClassVersion="10" checksum="473157534"/>
+  <class name="reco::io_v1::Candidate::const_iterator"  ClassVersion="3">
+   <version ClassVersion="3 " checksum="1103260808"/>
   </class>
 
   <class name="reco::CandidateRef" />
@@ -125,83 +86,83 @@
   <class name="reco::VertexCompositePtrCandidateRefVector" />
   <class name="reco::CandidateRefProd" />
 
-  <class name="edm::reftobase::BaseHolder<reco::Candidate>" />
-  <class name="edm::reftobase::Holder<reco::Candidate, reco::CandidateRef>" />
-  <class name="edm::reftobase::IndirectHolder<reco::Candidate>"/>
+  <class name="edm::reftobase::BaseHolder<reco::io_v1::Candidate>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::CandidateRef>" />
+  <class name="edm::reftobase::IndirectHolder<reco::io_v1::Candidate>"/>
   <class name="edm::reftobase::RefHolder<reco::CandidateRef>"/>
   <class name="edm::reftobase::RefHolder<reco::CandidatePtr>"/>
 
-  <class name="std::vector<edm::RefToBase<reco::Candidate> >" />
-  <class name="std::vector<edm::Ptr<reco::Candidate> >" />
-  <class name="edm::AtomicPtrCache<std::vector<edm::Ptr<reco::Candidate> > >"/>
-  <class name="std::vector<edm::PtrVector<reco::Candidate> >" />
-  <class name="edm::reftobase::BaseVectorHolder<reco::Candidate>" />
-  <class name="edm::reftobase::BaseVectorHolder<reco::Candidate>::const_iterator_imp" />
-  <class name="edm::reftobase::BaseVectorHolder<reco::Candidate>::const_iterator" />
-  <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::CandidateRefVector>" />
-  <class name="edm::reftobase::IndirectVectorHolder<reco::Candidate>"/>
-  <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::CandidateRefVector>::const_iterator_imp_specific" />
+  <class name="std::vector<edm::RefToBase<reco::io_v1::Candidate> >" />
+  <class name="std::vector<edm::Ptr<reco::io_v1::Candidate> >" />
+  <class name="edm::AtomicPtrCache<std::vector<edm::Ptr<reco::io_v1::Candidate> > >"/>
+  <class name="std::vector<edm::PtrVector<reco::io_v1::Candidate> >" />
+  <class name="edm::reftobase::BaseVectorHolder<reco::io_v1::Candidate>" />
+  <class name="edm::reftobase::BaseVectorHolder<reco::io_v1::Candidate>::const_iterator_imp" />
+  <class name="edm::reftobase::BaseVectorHolder<reco::io_v1::Candidate>::const_iterator" />
+  <class name="edm::reftobase::VectorHolder<reco::io_v1::Candidate, reco::CandidateRefVector>" />
+  <class name="edm::reftobase::IndirectVectorHolder<reco::io_v1::Candidate>"/>
+  <class name="edm::reftobase::VectorHolder<reco::io_v1::Candidate, reco::CandidateRefVector>::const_iterator_imp_specific" />
   <class name="edm::reftobase::RefVectorHolder<reco::CandidateRefVector>"/>
 
-  <class name="edm::RefToBaseVector<reco::Candidate>" />
-  <class name="edm::PtrVector<reco::Candidate>" />
+  <class name="edm::RefToBaseVector<reco::io_v1::Candidate>" />
+  <class name="edm::PtrVector<reco::io_v1::Candidate>" />
 
-  <class name="edm::RefToBaseProd<reco::Candidate>">
+  <class name="edm::RefToBaseProd<reco::io_v1::Candidate>">
     <!-- <field name="view_" transient="true" /> -->
   </class>
-  <class name="std::map<const reco::Candidate *, const reco::Candidate *>" />
-  <class name="std::vector<const reco::Candidate *>" />
+  <class name="std::map<const reco::io_v1::Candidate *, const reco::io_v1::Candidate *>" />
+  <class name="std::vector<const reco::io_v1::Candidate *>" />
 
   <class name="edm::helpers::KeyVal<reco::CandidateRef, reco::CandidateRef>" /> 
   <class name="edm::helpers::KeyVal<reco::CandidateRefProd, reco::CandidateRefProd>" />
   <class name="edm::helpers::KeyVal<reco::CandidateBaseRefProd, reco::CandidateBaseRefProd>" />
   <class name="edm::helpers::KeyVal<reco::CandidateBaseRef, reco::CandidateBaseRef>" />
   <class name="std::map<unsigned int,edm::helpers::KeyVal<reco::CandidateBaseRef, reco::CandidateBaseRef> >" />
-  <class name="edm::AssociationMap<edm::OneToOne<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,unsigned int> >">
+  <class name="edm::AssociationMap<edm::OneToOne<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,unsigned int> >">
     <field name="transientMap_" transient="true" />
   </class>
-  <class name="edm::AssociationMap<edm::OneToOne<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,unsigned int> >::const_iterator" />
-  <class name="edm::AssociationMap<edm::OneToOneGeneric<edm::View<reco::Candidate>,edm::View<reco::Candidate>,unsigned int,edm::RefToBaseProd<reco::Candidate>,edm::RefToBaseProd<reco::Candidate>,edm::RefToBase<reco::Candidate>,edm::RefToBase<reco::Candidate> > >">
+  <class name="edm::AssociationMap<edm::OneToOne<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,unsigned int> >::const_iterator" />
+  <class name="edm::AssociationMap<edm::OneToOneGeneric<edm::View<reco::io_v1::Candidate>,edm::View<reco::io_v1::Candidate>,unsigned int,edm::RefToBaseProd<reco::io_v1::Candidate>,edm::RefToBaseProd<reco::io_v1::Candidate>,edm::RefToBase<reco::io_v1::Candidate>,edm::RefToBase<reco::io_v1::Candidate> > >">
     <field name="transientMap_" transient="true" />
   </class>
-  <class name="edm::AssociationMap<edm::OneToOneGeneric<edm::View<reco::Candidate>,edm::View<reco::Candidate>,unsigned int,edm::RefToBaseProd<reco::Candidate>,edm::RefToBaseProd<reco::Candidate>,edm::RefToBase<reco::Candidate>,edm::RefToBase<reco::Candidate> > >::const_iterator" />
-  <class name="edm::AssociationMap<edm::OneToManyWithQuality<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,double,unsigned int> >">
+  <class name="edm::AssociationMap<edm::OneToOneGeneric<edm::View<reco::io_v1::Candidate>,edm::View<reco::io_v1::Candidate>,unsigned int,edm::RefToBaseProd<reco::io_v1::Candidate>,edm::RefToBaseProd<reco::io_v1::Candidate>,edm::RefToBase<reco::io_v1::Candidate>,edm::RefToBase<reco::io_v1::Candidate> > >::const_iterator" />
+  <class name="edm::AssociationMap<edm::OneToManyWithQuality<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,double,unsigned int> >">
     <field name="transientMap_" transient="true" />
   </class>
-  <class name="edm::AssociationMap<edm::OneToManyWithQuality<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,double,unsigned int> >::const_iterator" />
+  <class name="edm::AssociationMap<edm::OneToManyWithQuality<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,double,unsigned int> >::const_iterator" />
 <!--
   <class pattern="edm::AssociationVector<*>">
     <field name="transientVector_" transient="true"/>
   </class>
 -->
-  <class name ="edm::AssociationVector<edm::RefProd<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> > >,vector<double>,edm::Ref<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,reco::Candidate,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,reco::Candidate> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>">
+  <class name ="edm::AssociationVector<edm::RefProd<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> > >,vector<double>,edm::Ref<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,reco::io_v1::Candidate,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,reco::io_v1::Candidate> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>">
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="edm::AssociationVector<edm::RefProd<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> > >,vector<float>,edm::Ref<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,reco::Candidate,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,reco::Candidate> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>">
+  <class name="edm::AssociationVector<edm::RefProd<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> > >,vector<float>,edm::Ref<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,reco::io_v1::Candidate,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,reco::io_v1::Candidate> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>">
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="edm::AssociationVector<edm::RefProd<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> > >,vector<int>,edm::Ref<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,reco::Candidate,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,reco::Candidate> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>">
+  <class name="edm::AssociationVector<edm::RefProd<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> > >,vector<int>,edm::Ref<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,reco::io_v1::Candidate,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,reco::io_v1::Candidate> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>">
     <field name="transientVector_" transient="true"/>
   </class>
- <class name="edm::AssociationVector<edm::RefProd<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> > >,vector<unsigned int>,edm::Ref<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,reco::Candidate,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,reco::Candidate> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>">
+ <class name="edm::AssociationVector<edm::RefProd<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> > >,vector<unsigned int>,edm::Ref<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,reco::io_v1::Candidate,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,reco::io_v1::Candidate> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>">
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="edm::AssociationVector<edm::RefToBaseProd<reco::Candidate>,vector<double>,edm::RefToBase<reco::Candidate>,unsigned int,edm::helper::AssociationIdenticalKeyReference>">
+  <class name="edm::AssociationVector<edm::RefToBaseProd<reco::io_v1::Candidate>,vector<double>,edm::RefToBase<reco::io_v1::Candidate>,unsigned int,edm::helper::AssociationIdenticalKeyReference>">
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="edm::AssociationVector<edm::RefToBaseProd<reco::Candidate>,vector<float>,edm::RefToBase<reco::Candidate>,unsigned int,edm::helper::AssociationIdenticalKeyReference>">
+  <class name="edm::AssociationVector<edm::RefToBaseProd<reco::io_v1::Candidate>,vector<float>,edm::RefToBase<reco::io_v1::Candidate>,unsigned int,edm::helper::AssociationIdenticalKeyReference>">
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="edm::AssociationVector<edm::RefToBaseProd<reco::Candidate>,vector<int>,edm::RefToBase<reco::Candidate>,unsigned int,edm::helper::AssociationIdenticalKeyReference>">
+  <class name="edm::AssociationVector<edm::RefToBaseProd<reco::io_v1::Candidate>,vector<int>,edm::RefToBase<reco::io_v1::Candidate>,unsigned int,edm::helper::AssociationIdenticalKeyReference>">
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="edm::AssociationVector<edm::RefToBaseProd<reco::Candidate>,vector<unsigned int>,edm::RefToBase<reco::Candidate>,unsigned int,edm::helper::AssociationIdenticalKeyReference>">
+  <class name="edm::AssociationVector<edm::RefToBaseProd<reco::io_v1::Candidate>,vector<unsigned int>,edm::RefToBase<reco::io_v1::Candidate>,unsigned int,edm::helper::AssociationIdenticalKeyReference>">
     <field name="transientVector_" transient="true"/>
   </class>
   <class name="reco::CandRefValueMap" /> 
 
   <class name="std::vector<reco::Particle>" />
-  <class name="std::vector<reco::Candidate *>" />
+  <class name="std::vector<reco::io_v1::Candidate *>" />
   <class name="std::vector<reco::LeafCandidate>" />
   <class name="reco::CandidateCollection"  rntupleStreamerMode="true"/>
   <class name="reco::CandidateBaseRef"  rntupleStreamerMode="true"/>
@@ -216,53 +177,53 @@
   <class name="edm::Wrapper<reco::CandViewMatchMap>" />
   <class name="edm::Wrapper<reco::CandMatchMapMany>" /> 
   <class name="edm::Wrapper<reco::CandRefValueMap>" /> 
-  <class name="edm::Wrapper<std::vector<edm::RefToBase<reco::Candidate> > >" />
-  <class name="edm::Wrapper<std::vector<edm::Ptr<reco::Candidate> > >" />
+  <class name="edm::Wrapper<std::vector<edm::RefToBase<reco::io_v1::Candidate> > >" />
+  <class name="edm::Wrapper<std::vector<edm::Ptr<reco::io_v1::Candidate> > >" />
   <!-- <class pattern="edm::AssociationMap<*>::const_iterator" /> -->
 
   <!-- <class pattern="edm::Wrapper<edm::AssociationVector<*>"/> -->
-  <class name="edm::Wrapper<edm::AssociationVector<edm::RefProd<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> > >,vector<double>,edm::Ref<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,reco::Candidate,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,reco::Candidate> >,unsigned int,edm::helper::AssociationIdenticalKeyReference> >" />
-  <class name="edm::Wrapper<edm::AssociationVector<edm::RefProd<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> > >,vector<float>,edm::Ref<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,reco::Candidate,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,reco::Candidate> >,unsigned int,edm::helper::AssociationIdenticalKeyReference> >" />
-  <class name="edm::Wrapper<edm::AssociationVector<edm::RefProd<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> > >,vector<int>,edm::Ref<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,reco::Candidate,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,reco::Candidate> >,unsigned int,edm::helper::AssociationIdenticalKeyReference> >" />
-  <class name="edm::Wrapper<edm::AssociationVector<edm::RefProd<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> > >,vector<unsigned int>,edm::Ref<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,reco::Candidate,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,reco::Candidate> >,unsigned int,edm::helper::AssociationIdenticalKeyReference> >" />
-  <class name="edm::Wrapper<edm::AssociationVector<edm::RefToBaseProd<reco::Candidate>,vector<double>,edm::RefToBase<reco::Candidate>,unsigned int,edm::helper::AssociationIdenticalKeyReference> >"/>
-  <class name="edm::Wrapper<edm::AssociationVector<edm::RefToBaseProd<reco::Candidate>,vector<float>,edm::RefToBase<reco::Candidate>,unsigned int,edm::helper::AssociationIdenticalKeyReference> >"/>
-  <class name="edm::Wrapper<edm::AssociationVector<edm::RefToBaseProd<reco::Candidate>,vector<int>,edm::RefToBase<reco::Candidate>,unsigned int,edm::helper::AssociationIdenticalKeyReference> >"/>
-  <class name="edm::Wrapper<edm::AssociationVector<edm::RefToBaseProd<reco::Candidate>,vector<unsigned int>,edm::RefToBase<reco::Candidate>,unsigned int,edm::helper::AssociationIdenticalKeyReference> >"/>
+  <class name="edm::Wrapper<edm::AssociationVector<edm::RefProd<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> > >,vector<double>,edm::Ref<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,reco::io_v1::Candidate,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,reco::io_v1::Candidate> >,unsigned int,edm::helper::AssociationIdenticalKeyReference> >" />
+  <class name="edm::Wrapper<edm::AssociationVector<edm::RefProd<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> > >,vector<float>,edm::Ref<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,reco::io_v1::Candidate,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,reco::io_v1::Candidate> >,unsigned int,edm::helper::AssociationIdenticalKeyReference> >" />
+  <class name="edm::Wrapper<edm::AssociationVector<edm::RefProd<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> > >,vector<int>,edm::Ref<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,reco::io_v1::Candidate,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,reco::io_v1::Candidate> >,unsigned int,edm::helper::AssociationIdenticalKeyReference> >" />
+  <class name="edm::Wrapper<edm::AssociationVector<edm::RefProd<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> > >,vector<unsigned int>,edm::Ref<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,reco::io_v1::Candidate,edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,reco::io_v1::Candidate> >,unsigned int,edm::helper::AssociationIdenticalKeyReference> >" />
+  <class name="edm::Wrapper<edm::AssociationVector<edm::RefToBaseProd<reco::io_v1::Candidate>,vector<double>,edm::RefToBase<reco::io_v1::Candidate>,unsigned int,edm::helper::AssociationIdenticalKeyReference> >"/>
+  <class name="edm::Wrapper<edm::AssociationVector<edm::RefToBaseProd<reco::io_v1::Candidate>,vector<float>,edm::RefToBase<reco::io_v1::Candidate>,unsigned int,edm::helper::AssociationIdenticalKeyReference> >"/>
+  <class name="edm::Wrapper<edm::AssociationVector<edm::RefToBaseProd<reco::io_v1::Candidate>,vector<int>,edm::RefToBase<reco::io_v1::Candidate>,unsigned int,edm::helper::AssociationIdenticalKeyReference> >"/>
+  <class name="edm::Wrapper<edm::AssociationVector<edm::RefToBaseProd<reco::io_v1::Candidate>,vector<unsigned int>,edm::RefToBase<reco::io_v1::Candidate>,unsigned int,edm::helper::AssociationIdenticalKeyReference> >"/>
 
-  <class name="edm::Association<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> > >" />
-  <class name="edm::Wrapper<edm::Association<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> > > >" />
+  <class name="edm::Association<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> > >" />
+  <class name="edm::Wrapper<edm::Association<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> > > >" />
 
-  <class name="std::vector<edm::Ref<std::vector<reco::CompositeCandidate>,reco::CompositeCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::CompositeCandidate>,reco::CompositeCandidate> > >"/>
+  <class name="std::vector<edm::Ref<std::vector<reco::io_v1::CompositeCandidate>,reco::io_v1::CompositeCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::CompositeCandidate>,reco::io_v1::CompositeCandidate> > >"/>
   <class name="reco::CompositeCandidateCollection" />
   <class name="edm::Wrapper<reco::CompositeCandidateCollection>" />
-  <class name="edm::reftobase::Holder<reco::Candidate, reco::CompositeCandidateRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::CompositeCandidateRef>" />
   <class name="edm::reftobase::RefHolder<reco::CompositeCandidateRef>" />
-  <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::CompositeCandidateRefVector>" />
+  <class name="edm::reftobase::VectorHolder<reco::io_v1::Candidate, reco::CompositeCandidateRefVector>" />
   <class name="edm::reftobase::RefVectorHolder<reco::CompositeCandidateRefVector>" />
 
   <class name="reco::VertexCompositeCandidateCollection" />
   <class name="edm::Wrapper<reco::VertexCompositeCandidateCollection>" />
-  <class name="edm::reftobase::Holder<reco::Candidate, reco::VertexCompositeCandidateRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::VertexCompositeCandidateRef>" />
   <class name="edm::reftobase::RefHolder<reco::VertexCompositeCandidateRef>" />
-  <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::VertexCompositeCandidateRefVector>" />
+  <class name="edm::reftobase::VectorHolder<reco::io_v1::Candidate, reco::VertexCompositeCandidateRefVector>" />
   <class name="edm::reftobase::RefVectorHolder<reco::VertexCompositeCandidateRefVector>" />
 
   <class name="reco::VertexCompositePtrCandidateCollection" />
   <class name="edm::Wrapper<reco::VertexCompositePtrCandidateCollection>" />
-  <class name="edm::reftobase::Holder<reco::Candidate, reco::VertexCompositePtrCandidateRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::VertexCompositePtrCandidateRef>" />
   <class name="edm::reftobase::RefHolder<reco::VertexCompositePtrCandidateRef>" />
-  <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::VertexCompositePtrCandidateRefVector>" />
+  <class name="edm::reftobase::VectorHolder<reco::io_v1::Candidate, reco::VertexCompositePtrCandidateRefVector>" />
   <class name="edm::reftobase::RefVectorHolder<reco::VertexCompositePtrCandidateRefVector>" />
-  <class name="edm::PtrVector<reco::VertexCompositePtrCandidate>" />
-  <class name="edm::Wrapper<edm::PtrVector<reco::VertexCompositePtrCandidate> >" />
+  <class name="edm::PtrVector<reco::io_v1::VertexCompositePtrCandidate>" />
+  <class name="edm::Wrapper<edm::PtrVector<reco::io_v1::VertexCompositePtrCandidate> >" />
 
 
   <class name="reco::NamedCompositeCandidateCollection" />
   <class name="edm::Wrapper<reco::NamedCompositeCandidateCollection>" />
-  <class name="edm::reftobase::Holder<reco::Candidate, reco::NamedCompositeCandidateRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::NamedCompositeCandidateRef>" />
   <class name="edm::reftobase::RefHolder<reco::NamedCompositeCandidateRef>" />
-  <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::NamedCompositeCandidateRefVector>" />
+  <class name="edm::reftobase::VectorHolder<reco::io_v1::Candidate, reco::NamedCompositeCandidateRefVector>" />
   <class name="edm::reftobase::RefVectorHolder<reco::NamedCompositeCandidateRefVector>" />
 
    <class name="edm::Wrapper<reco::CandViewCandViewAssociation>"/>
@@ -270,26 +231,26 @@
      <field name="transientMap_" transient="true" />
    </class>
 
-   <class name="std::vector<std::pair<edm::RefToBase<reco::Candidate>,bool> >" />
-   <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::RefToBase<reco::Candidate>,std::vector<std::pair<edm::RefToBase<reco::Candidate>,bool> > > >" />
+   <class name="std::vector<std::pair<edm::RefToBase<reco::io_v1::Candidate>,bool> >" />
+   <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::RefToBase<reco::io_v1::Candidate>,std::vector<std::pair<edm::RefToBase<reco::io_v1::Candidate>,bool> > > >" />
 
-   <class name="edm::helpers::KeyVal<edm::RefToBase<reco::Candidate>,std::vector<std::pair<edm::RefToBase<reco::Candidate>,bool> > >" /> 
+   <class name="edm::helpers::KeyVal<edm::RefToBase<reco::io_v1::Candidate>,std::vector<std::pair<edm::RefToBase<reco::io_v1::Candidate>,bool> > >" /> 
  
-   <class name="std::pair<edm::RefToBase<reco::Candidate>,bool>" />
-   <class name="std::pair<edm::RefToBase<reco::Candidate>,double>" />
-   <class name="std::pair<edm::RefToBaseProd<reco::Candidate>,double>" />
+   <class name="std::pair<edm::RefToBase<reco::io_v1::Candidate>,bool>" />
+   <class name="std::pair<edm::RefToBase<reco::io_v1::Candidate>,double>" />
+   <class name="std::pair<edm::RefToBaseProd<reco::io_v1::Candidate>,double>" />
 
   <class name="edm::ValueMap<reco::CandidatePtr>" />
   <class name="edm::Wrapper<edm::ValueMap<reco::CandidatePtr> >" />
-  <class name="std::pair<std::basic_string<char>,edm::Ptr<reco::Candidate> >" />
-  <class name="std::vector<std::pair<std::basic_string<char>,edm::Ptr<reco::Candidate> > >" />
+  <class name="std::pair<std::basic_string<char>,edm::Ptr<reco::io_v1::Candidate> >" />
+  <class name="std::vector<std::pair<std::basic_string<char>,edm::Ptr<reco::io_v1::Candidate> > >" />
 
-  <!--<class pattern="std::iterator<std::random_access_iterator_tag,edm::RefToBase<reco::Candidate>*>" /> -->
-  <!-- this can not be parsed by edmCheckClassVersion <class name="std::iterator<std::random_access_iterator_tag,edm::RefToBase<reco::Candidate>,long,edm::RefToBase<reco::Candidate>*,edm::RefToBase<reco::Candidate>&>" /> -->
+  <!--<class pattern="std::iterator<std::random_access_iterator_tag,edm::RefToBase<reco::io_v1::Candidate>*>" /> -->
+  <!-- this can not be parsed by edmCheckClassVersion <class name="std::iterator<std::random_access_iterator_tag,edm::RefToBase<reco::io_v1::Candidate>,long,edm::RefToBase<reco::io_v1::Candidate>*,edm::RefToBase<reco::io_v1::Candidate>&>" /> -->
 
 </selection>
 <exclusion>
-  <class name="edm::OwnVector<reco::Candidate, edm::ClonePolicy<reco::Candidate> >">
+  <class name="edm::OwnVector<reco::io_v1::Candidate, edm::ClonePolicy<reco::io_v1::Candidate> >">
     <method name="sort" />
   </class>
 </exclusion>

--- a/DataFormats/CastorReco/src/classes_def.xml
+++ b/DataFormats/CastorReco/src/classes_def.xml
@@ -13,10 +13,8 @@
   <class name="edm::auto_ptr<edm::Ref<std::vector<reco::CastorCell>,reco::CastorCell,edm::refhelper::FindUsingAdvance<std::vector<reco::CastorCell>,reco::CastorCell> > >"/>-->
 
 
-  <class name="reco::CastorTower" ClassVersion="12">
-   <version ClassVersion="12" checksum="887582159"/>
-   <version ClassVersion="11" checksum="2444453847"/>
-   <version ClassVersion="10" checksum="3103051284"/>
+  <class name="reco::CastorTower" ClassVersion="3">
+   <version ClassVersion="3" checksum="706864019"/>
   </class>
   <class name="std::vector<reco::CastorTower>"/>
   <class name="edm::Wrapper<std::vector<reco::CastorTower> >"/>

--- a/DataFormats/EgammaCandidates/interface/Conversion.h
+++ b/DataFormats/EgammaCandidates/interface/Conversion.h
@@ -20,228 +20,232 @@
 #include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"
 
 namespace reco {
-  class Conversion {
-  public:
-    enum ConversionAlgorithm { undefined = 0, ecalSeeded = 1, trackerOnly = 2, mixed = 3, pflow = 4, algoSize = 5 };
+  namespace io_v1 {
+    class Conversion {
+    public:
+      enum ConversionAlgorithm { undefined = 0, ecalSeeded = 1, trackerOnly = 2, mixed = 3, pflow = 4, algoSize = 5 };
 
-    enum ConversionQuality {
-      generalTracksOnly = 0,
-      arbitratedEcalSeeded = 1,
-      arbitratedMerged = 2,
-      arbitratedMergedEcalGeneral = 3,
-      gsfTracksOpenOnly = 4,
-      highPurity = 8,
-      highEfficiency = 9,
-      ecalMatched1Track = 10,
-      ecalMatched2Track = 11
+      enum ConversionQuality {
+        generalTracksOnly = 0,
+        arbitratedEcalSeeded = 1,
+        arbitratedMerged = 2,
+        arbitratedMergedEcalGeneral = 3,
+        gsfTracksOpenOnly = 4,
+        highPurity = 8,
+        highEfficiency = 9,
+        ecalMatched1Track = 10,
+        ecalMatched2Track = 11
+      };
+
+      static const std::string algoNames[];
+
+      // Default constructor
+      Conversion();
+
+      Conversion(const reco::CaloClusterPtrVector& clu,
+                 const std::vector<edm::RefToBase<reco::Track> >& tr,
+                 const std::vector<math::XYZPointF>& trackPositionAtEcal,
+                 const reco::Vertex& convVtx,
+                 const std::vector<reco::CaloClusterPtr>& matchingBC,
+                 const float DCA,
+                 const std::vector<math::XYZPointF>& innPoint,
+                 const std::vector<math::XYZVectorF>& trackPin,
+                 const std::vector<math::XYZVectorF>& trackPout,
+                 const std::vector<uint8_t>& nHitsBeforeVtx,
+                 const std::vector<Measurement1DFloat>& dlClosestHitToVtx,
+                 uint8_t nSharedHits,
+                 const float mva,
+                 ConversionAlgorithm = undefined);
+
+      Conversion(const reco::CaloClusterPtrVector& clu,
+                 const std::vector<reco::TrackRef>& tr,
+                 const std::vector<math::XYZPointF>& trackPositionAtEcal,
+                 const reco::Vertex& convVtx,
+                 const std::vector<reco::CaloClusterPtr>& matchingBC,
+                 const float DCA,
+                 const std::vector<math::XYZPointF>& innPoint,
+                 const std::vector<math::XYZVectorF>& trackPin,
+                 const std::vector<math::XYZVectorF>& trackPout,
+                 const float mva,
+                 ConversionAlgorithm = undefined);
+
+      Conversion(const reco::CaloClusterPtrVector& clu,
+                 const std::vector<reco::TrackRef>& tr,
+                 const reco::Vertex& convVtx,
+                 ConversionAlgorithm = undefined);
+
+      Conversion(const reco::CaloClusterPtrVector& clu,
+                 const std::vector<edm::RefToBase<reco::Track> >& tr,
+                 const reco::Vertex& convVtx,
+                 ConversionAlgorithm = undefined);
+
+      /// returns a clone of the candidate
+      Conversion* clone() const;
+      /// Pointer to CaloCluster (foe Egamma Conversions it points to  a SuperCluster)
+      reco::CaloClusterPtrVector caloCluster() const { return caloCluster_; }
+      /// vector of track to base references
+      std::vector<edm::RefToBase<reco::Track> > const& tracks() const;
+      /// returns  the reco conversion vertex
+      const reco::Vertex& conversionVertex() const { return theConversionVertex_; }
+      /// Bool flagging objects having track size >0
+      bool isConverted() const;
+      /// Number of tracks= 0,1,2
+      unsigned int nTracks() const { return tracks().size(); }
+      /// get the value  of the TMVA output
+      double MVAout() const { return theMVAout_; }
+      /// get the MVS output from PF for one leg conversions
+      std::vector<float> const oneLegMVA() { return theOneLegMVA_; }
+      /// if nTracks=2 returns the pair invariant mass. Original tracks are used here
+      double pairInvariantMass() const;
+      /// Delta cot(Theta) where Theta is the angle in the (y,z) plane between the two tracks. Original tracks are used
+      double pairCotThetaSeparation() const;
+      /// Conversion tracks momentum from the tracks inner momentum
+      math::XYZVectorF pairMomentum() const;
+      /// Conversion track pair 4-momentum from the tracks refitted with vertex constraint
+      math::XYZTLorentzVectorF refittedPair4Momentum() const;
+      /// Conversion tracks momentum from the tracks refitted with vertex constraint
+      math::XYZVectorF refittedPairMomentum() const;
+      /// Super Cluster energy divided by track pair momentum if Standard seeding method. If a pointer to two (or more clusters)
+      /// is stored in the conversion, this method returns the energy sum of clusters divided by the track pair momentum
+      /// Track innermost momentum is used here
+      double EoverP() const;
+      /// Super Cluster energy divided by track pair momentum if Standard seeing method. If a pointer to two (or more clusters)
+      /// is stored in the conversion, this method returns the energy sum of clusters divided by the track pair momentum
+      ///  Track momentum refitted with vertex constraint is used
+      double EoverPrefittedTracks() const;
+      // Dist of minimum approach between tracks
+      double distOfMinimumApproach() const { return theMinDistOfApproach_; }
+      // deltaPhi tracks at innermost point
+      double dPhiTracksAtVtx() const;
+      // deltaPhi tracks at ECAl
+      double dPhiTracksAtEcal() const;
+      // deltaEta tracks at ECAl
+      double dEtaTracksAtEcal() const;
+
+      //impact parameter and decay length computed with respect to given beamspot or vertex
+      //computed from refittedPairMomentum
+
+      //transverse impact parameter
+      double dxy(const math::XYZPoint& myBeamSpot = math::XYZPoint()) const;
+      //longitudinal impact parameter
+      double dz(const math::XYZPoint& myBeamSpot = math::XYZPoint()) const;
+      //transverse decay length
+      double lxy(const math::XYZPoint& myBeamSpot = math::XYZPoint()) const;
+      //longitudinal decay length
+      double lz(const math::XYZPoint& myBeamSpot = math::XYZPoint()) const;
+      //z position of intersection with beamspot in rz plane (possible tilt of beamspot is neglected)
+      double zOfPrimaryVertexFromTracks(const math::XYZPoint& myBeamSpot = math::XYZPoint()) const {
+        return dz(myBeamSpot) + myBeamSpot.z();
+      }
+
+      ///// The following are variables provided per each track
+      /// positions of the track extrapolation at the ECAL front face
+      const std::vector<math::XYZPointF>& ecalImpactPosition() const { return thePositionAtEcal_; }
+      //  pair of BC matching a posteriori the tracks
+      const std::vector<reco::CaloClusterPtr>& bcMatchingWithTracks() const { return theMatchingBCs_; }
+      /// signed transverse impact parameter for each track
+      std::vector<double> tracksSigned_d0() const;
+      /// Vector containing the position of the innermost hit of each track
+      const std::vector<math::XYZPointF>& tracksInnerPosition() const { return theTrackInnerPosition_; }
+      /// Vector of track momentum measured at the outermost hit
+      const std::vector<math::XYZVectorF>& tracksPout() const { return theTrackPout_; }
+      /// Vector of track momentum measured at the innermost hit
+      const std::vector<math::XYZVectorF>& tracksPin() const { return theTrackPin_; }
+      ///Vector of the number of hits before the vertex along each track trajector
+      const std::vector<uint8_t>& nHitsBeforeVtx() const { return nHitsBeforeVtx_; }
+      ///Vector of signed decay length with uncertainty from nearest hit on track to the conversion vtx positions
+      const std::vector<Measurement1DFloat>& dlClosestHitToVtx() const { return dlClosestHitToVtx_; }
+      ///number of shared hits btw the two track
+      uint8_t nSharedHits() const { return nSharedHits_; }
+
+      /// set the value  of the TMVA output
+      void setMVAout(const float& mva) { theMVAout_ = mva; }
+      /// set the MVS output from PF for one leg conversions
+      void setOneLegMVA(const std::vector<float>& mva) { theOneLegMVA_ = mva; }
+      // Set the ptr to the Super cluster if not set in the constructor
+      void setMatchingSuperCluster(const reco::CaloClusterPtrVector& sc) { caloCluster_ = sc; }
+      /// Conversion Track algorithm/provenance
+      void setConversionAlgorithm(const ConversionAlgorithm a, bool set = true) {
+        if (set)
+          algorithm_ = a;
+        else
+          algorithm_ = undefined;
+      }
+      ConversionAlgorithm algo() const;
+      std::string algoName() const;
+      static std::string algoName(ConversionAlgorithm);
+      static ConversionAlgorithm algoByName(const std::string& name);
+
+      bool quality(ConversionQuality q) const { return (qualityMask_ & (1 << q)) >> q; }
+      void setQuality(ConversionQuality q, bool b);
+
+    private:
+      /// vector pointer to a/multiple seed CaloCluster(s)
+      reco::CaloClusterPtrVector caloCluster_;
+      /// vector Track RefToBase
+      std::vector<edm::RefToBase<reco::Track> > trackToBaseRefs_;
+      /// position at the ECAl surface of the track extrapolation
+      std::vector<math::XYZPointF> thePositionAtEcal_;
+      /// Fitted Kalman conversion vertex
+      reco::Vertex theConversionVertex_;
+      /// Clusters mathing the tracks (these are not the seeds)
+      std::vector<reco::CaloClusterPtr> theMatchingBCs_;
+      /// P_in of tracks
+      std::vector<math::XYZPointF> theTrackInnerPosition_;
+      /// P_in of tracks
+      std::vector<math::XYZVectorF> theTrackPin_;
+      /// P_out of tracks
+      std::vector<math::XYZVectorF> theTrackPout_;
+      ///number of hits before the vertex on each trackerOnly
+      std::vector<uint8_t> nHitsBeforeVtx_;
+      ///signed decay length and uncertainty from nearest hit on track to conversion vertex
+      std::vector<Measurement1DFloat> dlClosestHitToVtx_;
+      /// vectors of TMVA outputs from pflow for one leg conversions
+      std::vector<float> theOneLegMVA_;
+      /// Distance of min approach of the two tracks
+      float theMinDistOfApproach_;
+      /// TMVA output
+      float theMVAout_;
+      uint16_t qualityMask_;
+      ///number of shared hits between tracks
+      uint8_t nSharedHits_;
+      /// conversion algorithm/provenance
+      uint8_t algorithm_;
     };
 
-    static const std::string algoNames[];
+    inline Conversion::ConversionAlgorithm Conversion::algo() const { return (ConversionAlgorithm)algorithm_; }
 
-    // Default constructor
-    Conversion();
-
-    Conversion(const reco::CaloClusterPtrVector& clu,
-               const std::vector<edm::RefToBase<reco::Track> >& tr,
-               const std::vector<math::XYZPointF>& trackPositionAtEcal,
-               const reco::Vertex& convVtx,
-               const std::vector<reco::CaloClusterPtr>& matchingBC,
-               const float DCA,
-               const std::vector<math::XYZPointF>& innPoint,
-               const std::vector<math::XYZVectorF>& trackPin,
-               const std::vector<math::XYZVectorF>& trackPout,
-               const std::vector<uint8_t>& nHitsBeforeVtx,
-               const std::vector<Measurement1DFloat>& dlClosestHitToVtx,
-               uint8_t nSharedHits,
-               const float mva,
-               ConversionAlgorithm = undefined);
-
-    Conversion(const reco::CaloClusterPtrVector& clu,
-               const std::vector<reco::TrackRef>& tr,
-               const std::vector<math::XYZPointF>& trackPositionAtEcal,
-               const reco::Vertex& convVtx,
-               const std::vector<reco::CaloClusterPtr>& matchingBC,
-               const float DCA,
-               const std::vector<math::XYZPointF>& innPoint,
-               const std::vector<math::XYZVectorF>& trackPin,
-               const std::vector<math::XYZVectorF>& trackPout,
-               const float mva,
-               ConversionAlgorithm = undefined);
-
-    Conversion(const reco::CaloClusterPtrVector& clu,
-               const std::vector<reco::TrackRef>& tr,
-               const reco::Vertex& convVtx,
-               ConversionAlgorithm = undefined);
-
-    Conversion(const reco::CaloClusterPtrVector& clu,
-               const std::vector<edm::RefToBase<reco::Track> >& tr,
-               const reco::Vertex& convVtx,
-               ConversionAlgorithm = undefined);
-
-    /// returns a clone of the candidate
-    Conversion* clone() const;
-    /// Pointer to CaloCluster (foe Egamma Conversions it points to  a SuperCluster)
-    reco::CaloClusterPtrVector caloCluster() const { return caloCluster_; }
-    /// vector of track to base references
-    std::vector<edm::RefToBase<reco::Track> > const& tracks() const;
-    /// returns  the reco conversion vertex
-    const reco::Vertex& conversionVertex() const { return theConversionVertex_; }
-    /// Bool flagging objects having track size >0
-    bool isConverted() const;
-    /// Number of tracks= 0,1,2
-    unsigned int nTracks() const { return tracks().size(); }
-    /// get the value  of the TMVA output
-    double MVAout() const { return theMVAout_; }
-    /// get the MVS output from PF for one leg conversions
-    std::vector<float> const oneLegMVA() { return theOneLegMVA_; }
-    /// if nTracks=2 returns the pair invariant mass. Original tracks are used here
-    double pairInvariantMass() const;
-    /// Delta cot(Theta) where Theta is the angle in the (y,z) plane between the two tracks. Original tracks are used
-    double pairCotThetaSeparation() const;
-    /// Conversion tracks momentum from the tracks inner momentum
-    math::XYZVectorF pairMomentum() const;
-    /// Conversion track pair 4-momentum from the tracks refitted with vertex constraint
-    math::XYZTLorentzVectorF refittedPair4Momentum() const;
-    /// Conversion tracks momentum from the tracks refitted with vertex constraint
-    math::XYZVectorF refittedPairMomentum() const;
-    /// Super Cluster energy divided by track pair momentum if Standard seeding method. If a pointer to two (or more clusters)
-    /// is stored in the conversion, this method returns the energy sum of clusters divided by the track pair momentum
-    /// Track innermost momentum is used here
-    double EoverP() const;
-    /// Super Cluster energy divided by track pair momentum if Standard seeing method. If a pointer to two (or more clusters)
-    /// is stored in the conversion, this method returns the energy sum of clusters divided by the track pair momentum
-    ///  Track momentum refitted with vertex constraint is used
-    double EoverPrefittedTracks() const;
-    // Dist of minimum approach between tracks
-    double distOfMinimumApproach() const { return theMinDistOfApproach_; }
-    // deltaPhi tracks at innermost point
-    double dPhiTracksAtVtx() const;
-    // deltaPhi tracks at ECAl
-    double dPhiTracksAtEcal() const;
-    // deltaEta tracks at ECAl
-    double dEtaTracksAtEcal() const;
-
-    //impact parameter and decay length computed with respect to given beamspot or vertex
-    //computed from refittedPairMomentum
-
-    //transverse impact parameter
-    double dxy(const math::XYZPoint& myBeamSpot = math::XYZPoint()) const;
-    //longitudinal impact parameter
-    double dz(const math::XYZPoint& myBeamSpot = math::XYZPoint()) const;
-    //transverse decay length
-    double lxy(const math::XYZPoint& myBeamSpot = math::XYZPoint()) const;
-    //longitudinal decay length
-    double lz(const math::XYZPoint& myBeamSpot = math::XYZPoint()) const;
-    //z position of intersection with beamspot in rz plane (possible tilt of beamspot is neglected)
-    double zOfPrimaryVertexFromTracks(const math::XYZPoint& myBeamSpot = math::XYZPoint()) const {
-      return dz(myBeamSpot) + myBeamSpot.z();
+    inline std::string Conversion::algoName() const {
+      switch (algorithm_) {
+        case undefined:
+          return "undefined";
+        case ecalSeeded:
+          return "ecalSeeded";
+        case trackerOnly:
+          return "trackerOnly";
+        case mixed:
+          return "mixed";
+        case pflow:
+          return "pflow";
+      }
+      return "undefined";
     }
 
-    ///// The following are variables provided per each track
-    /// positions of the track extrapolation at the ECAL front face
-    const std::vector<math::XYZPointF>& ecalImpactPosition() const { return thePositionAtEcal_; }
-    //  pair of BC matching a posteriori the tracks
-    const std::vector<reco::CaloClusterPtr>& bcMatchingWithTracks() const { return theMatchingBCs_; }
-    /// signed transverse impact parameter for each track
-    std::vector<double> tracksSigned_d0() const;
-    /// Vector containing the position of the innermost hit of each track
-    const std::vector<math::XYZPointF>& tracksInnerPosition() const { return theTrackInnerPosition_; }
-    /// Vector of track momentum measured at the outermost hit
-    const std::vector<math::XYZVectorF>& tracksPout() const { return theTrackPout_; }
-    /// Vector of track momentum measured at the innermost hit
-    const std::vector<math::XYZVectorF>& tracksPin() const { return theTrackPin_; }
-    ///Vector of the number of hits before the vertex along each track trajector
-    const std::vector<uint8_t>& nHitsBeforeVtx() const { return nHitsBeforeVtx_; }
-    ///Vector of signed decay length with uncertainty from nearest hit on track to the conversion vtx positions
-    const std::vector<Measurement1DFloat>& dlClosestHitToVtx() const { return dlClosestHitToVtx_; }
-    ///number of shared hits btw the two track
-    uint8_t nSharedHits() const { return nSharedHits_; }
-
-    /// set the value  of the TMVA output
-    void setMVAout(const float& mva) { theMVAout_ = mva; }
-    /// set the MVS output from PF for one leg conversions
-    void setOneLegMVA(const std::vector<float>& mva) { theOneLegMVA_ = mva; }
-    // Set the ptr to the Super cluster if not set in the constructor
-    void setMatchingSuperCluster(const reco::CaloClusterPtrVector& sc) { caloCluster_ = sc; }
-    /// Conversion Track algorithm/provenance
-    void setConversionAlgorithm(const ConversionAlgorithm a, bool set = true) {
-      if (set)
-        algorithm_ = a;
-      else
-        algorithm_ = undefined;
+    inline std::string Conversion::algoName(ConversionAlgorithm a) {
+      if (int(a) < int(algoSize) && int(a) > 0)
+        return algoNames[int(a)];
+      return "undefined";
     }
-    ConversionAlgorithm algo() const;
-    std::string algoName() const;
-    static std::string algoName(ConversionAlgorithm);
-    static ConversionAlgorithm algoByName(const std::string& name);
 
-    bool quality(ConversionQuality q) const { return (qualityMask_ & (1 << q)) >> q; }
-    void setQuality(ConversionQuality q, bool b);
-
-  private:
-    /// vector pointer to a/multiple seed CaloCluster(s)
-    reco::CaloClusterPtrVector caloCluster_;
-    /// vector Track RefToBase
-    std::vector<edm::RefToBase<reco::Track> > trackToBaseRefs_;
-    /// position at the ECAl surface of the track extrapolation
-    std::vector<math::XYZPointF> thePositionAtEcal_;
-    /// Fitted Kalman conversion vertex
-    reco::Vertex theConversionVertex_;
-    /// Clusters mathing the tracks (these are not the seeds)
-    std::vector<reco::CaloClusterPtr> theMatchingBCs_;
-    /// P_in of tracks
-    std::vector<math::XYZPointF> theTrackInnerPosition_;
-    /// P_in of tracks
-    std::vector<math::XYZVectorF> theTrackPin_;
-    /// P_out of tracks
-    std::vector<math::XYZVectorF> theTrackPout_;
-    ///number of hits before the vertex on each trackerOnly
-    std::vector<uint8_t> nHitsBeforeVtx_;
-    ///signed decay length and uncertainty from nearest hit on track to conversion vertex
-    std::vector<Measurement1DFloat> dlClosestHitToVtx_;
-    /// vectors of TMVA outputs from pflow for one leg conversions
-    std::vector<float> theOneLegMVA_;
-    /// Distance of min approach of the two tracks
-    float theMinDistOfApproach_;
-    /// TMVA output
-    float theMVAout_;
-    uint16_t qualityMask_;
-    ///number of shared hits between tracks
-    uint8_t nSharedHits_;
-    /// conversion algorithm/provenance
-    uint8_t algorithm_;
-  };
-
-  inline Conversion::ConversionAlgorithm Conversion::algo() const { return (ConversionAlgorithm)algorithm_; }
-
-  inline std::string Conversion::algoName() const {
-    switch (algorithm_) {
-      case undefined:
-        return "undefined";
-      case ecalSeeded:
-        return "ecalSeeded";
-      case trackerOnly:
-        return "trackerOnly";
-      case mixed:
-        return "mixed";
-      case pflow:
-        return "pflow";
+    inline void Conversion::setQuality(ConversionQuality q, bool b) {
+      if (b)  //regular OR if setting value to true
+        qualityMask_ |= (1 << q);
+      else  // doing "half-XOR" if unsetting value
+        qualityMask_ &= (~(1 << q));
     }
-    return "undefined";
-  }
 
-  inline std::string Conversion::algoName(ConversionAlgorithm a) {
-    if (int(a) < int(algoSize) && int(a) > 0)
-      return algoNames[int(a)];
-    return "undefined";
-  }
-
-  inline void Conversion::setQuality(ConversionQuality q, bool b) {
-    if (b)  //regular OR if setting value to true
-      qualityMask_ |= (1 << q);
-    else  // doing "half-XOR" if unsetting value
-      qualityMask_ &= (~(1 << q));
-  }
+  }  // namespace io_v1
+  using Conversion = io_v1::Conversion;
 
 }  // namespace reco
 

--- a/DataFormats/EgammaCandidates/interface/ConversionFwd.h
+++ b/DataFormats/EgammaCandidates/interface/ConversionFwd.h
@@ -6,7 +6,10 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 namespace reco {
-  class Conversion;
+  namespace io_v1 {
+    class Conversion;
+  }
+  using Conversion = io_v1::Conversion;
 
   /// collectin of Conversion objects
   typedef std::vector<Conversion> ConversionCollection;

--- a/DataFormats/EgammaCandidates/interface/Electron.h
+++ b/DataFormats/EgammaCandidates/interface/Electron.h
@@ -12,44 +12,48 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  class Electron : public RecoCandidate {
-  public:
-    /// default constructor
-    Electron() : RecoCandidate() {}
-    /// constructor from values
-    Electron(Charge q, const LorentzVector& p4, const Point& vtx = Point(0, 0, 0))
-        : RecoCandidate(q, p4, vtx, -11 * q) {}
-    /// destructor
-    ~Electron() override;
-    /// returns a clone of the candidate
-    Electron* clone() const override;
-    /// reference to a Track
-    using reco::RecoCandidate::track;  // avoid hiding the base
-    reco::TrackRef track() const override;
-    /// reference to a SuperCluster
-    reco::SuperClusterRef superCluster() const override;
-    /// reference to a GsfTrack
-    reco::GsfTrackRef gsfTrack() const override;
-    /// set refrence to Photon component
-    void setSuperCluster(const reco::SuperClusterRef& r) { superCluster_ = r; }
-    /// set refrence to Track component
-    void setTrack(const reco::TrackRef& r) { track_ = r; }
-    /// set reference to GsfTrack component
-    void setGsfTrack(const reco::GsfTrackRef& r) { gsfTrack_ = r; }
+    class Electron : public RecoCandidate {
+    public:
+      /// default constructor
+      Electron() : RecoCandidate() {}
+      /// constructor from values
+      Electron(Charge q, const LorentzVector& p4, const Point& vtx = Point(0, 0, 0))
+          : RecoCandidate(q, p4, vtx, -11 * q) {}
+      /// destructor
+      ~Electron() override;
+      /// returns a clone of the candidate
+      Electron* clone() const override;
+      /// reference to a Track
+      using reco::RecoCandidate::track;  // avoid hiding the base
+      reco::TrackRef track() const override;
+      /// reference to a SuperCluster
+      reco::SuperClusterRef superCluster() const override;
+      /// reference to a GsfTrack
+      reco::GsfTrackRef gsfTrack() const override;
+      /// set refrence to Photon component
+      void setSuperCluster(const reco::SuperClusterRef& r) { superCluster_ = r; }
+      /// set refrence to Track component
+      void setTrack(const reco::TrackRef& r) { track_ = r; }
+      /// set reference to GsfTrack component
+      void setGsfTrack(const reco::GsfTrackRef& r) { gsfTrack_ = r; }
 
-    bool isElectron() const override;
+      bool isElectron() const override;
 
-  private:
-    /// check overlap with another candidate
-    bool overlap(const Candidate&) const override;
-    /// reference to a SuperCluster
-    reco::SuperClusterRef superCluster_;
-    /// reference to a Track
-    reco::TrackRef track_;
-    /// reference to a GsfTrack;
-    reco::GsfTrackRef gsfTrack_;
-  };
+    private:
+      /// check overlap with another candidate
+      bool overlap(const Candidate&) const override;
+      /// reference to a SuperCluster
+      reco::SuperClusterRef superCluster_;
+      /// reference to a Track
+      reco::TrackRef track_;
+      /// reference to a GsfTrack;
+      reco::GsfTrackRef gsfTrack_;
+    };
+
+  }  // namespace io_v1
+  using Electron = io_v1::Electron;
 
 }  // namespace reco
 

--- a/DataFormats/EgammaCandidates/interface/ElectronFwd.h
+++ b/DataFormats/EgammaCandidates/interface/ElectronFwd.h
@@ -6,7 +6,10 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 namespace reco {
-  class Electron;
+  namespace io_v1 {
+    class Electron;
+  }
+  using Electron = io_v1::Electron;
 
   /// collectin of Electron objects
   typedef std::vector<Electron> ElectronCollection;

--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -20,8 +20,9 @@
 #include <numeric>
 
 namespace reco {
+  namespace io_v1 {
 
-  /****************************************************************************
+    /****************************************************************************
  * \class reco::GsfElectron
  *
  * An Electron with a GsfTrack seeded from an ElectronSeed.
@@ -33,915 +34,919 @@ namespace reco {
  *
  ****************************************************************************/
 
-  class GsfElectron : public RecoCandidate {
-    //=======================================================
-    // Constructors
-    //
-    // The clone() method with arguments, and the copy
-    // constructor with edm references is designed for
-    // someone which want to duplicates all
-    // collections.
-    //=======================================================
-
-  public:
-    // some nested structures defined later on
-    struct ChargeInfo;
-    struct TrackClusterMatching;
-    struct TrackExtrapolations;
-    struct ClosestCtfTrack;
-    struct FiducialFlags;
-    struct ShowerShape;
-    struct IsolationVariables;
-    struct ConversionRejection;
-    struct ClassificationVariables;
-    struct SaturationInfo;
-
-    GsfElectron();
-    GsfElectron(const GsfElectronCoreRef &);
-    GsfElectron(const GsfElectron &, const GsfElectronCoreRef &);
-    GsfElectron(const GsfElectron &electron,
-                const GsfElectronCoreRef &core,
-                const CaloClusterPtr &electronCluster,
-                const TrackRef &closestCtfTrack,
-                const TrackBaseRef &conversionPartner,
-                const GsfTrackRefVector &ambiguousTracks);
-    GsfElectron(int charge,
-                const ChargeInfo &,
-                const GsfElectronCoreRef &,
-                const TrackClusterMatching &,
-                const TrackExtrapolations &,
-                const ClosestCtfTrack &,
-                const FiducialFlags &,
-                const ShowerShape &,
-                const ConversionRejection &);
-    GsfElectron(int charge,
-                const ChargeInfo &,
-                const GsfElectronCoreRef &,
-                const TrackClusterMatching &,
-                const TrackExtrapolations &,
-                const ClosestCtfTrack &,
-                const FiducialFlags &,
-                const ShowerShape &,
-                const ShowerShape &,
-                const ConversionRejection &,
-                const SaturationInfo &);
-    GsfElectron *clone() const override;
-    GsfElectron *clone(const GsfElectronCoreRef &core,
-                       const CaloClusterPtr &electronCluster,
-                       const TrackRef &closestCtfTrack,
-                       const TrackBaseRef &conversionPartner,
-                       const GsfTrackRefVector &ambiguousTracks) const;
-    ~GsfElectron() override {}
-
-  private:
-    void init();
-
-    //=======================================================
-    // Candidate methods and complementary information
-    //
-    // The gsf electron producer has tried to best evaluate
-    // the four momentum and charge and given those values to
-    // the GsfElectron constructor, which forwarded them to
-    // the Candidate constructor. Those values can be retreived
-    // with getters inherited from Candidate : p4() and charge().
-    //=======================================================
-
-  public:
-    // Inherited from Candidate
-    // const LorentzVector & charge() const ;
-    // const LorentzVector & p4() const ;
-
-    // Complementary struct
-    struct ChargeInfo {
-      int scPixCharge;
-      bool isGsfCtfScPixConsistent;
-      bool isGsfScPixConsistent;
-      bool isGsfCtfConsistent;
-      ChargeInfo()
-          : scPixCharge(0), isGsfCtfScPixConsistent(false), isGsfScPixConsistent(false), isGsfCtfConsistent(false) {}
-    };
-
-    // Charge info accessors
-    // to get gsf track charge: gsfTrack()->charge()
-    // to get ctf track charge, if closestCtfTrackRef().isNonnull(): closestCtfTrackRef()->charge()
-    int scPixCharge() const { return chargeInfo_.scPixCharge; }
-    bool isGsfCtfScPixChargeConsistent() const { return chargeInfo_.isGsfCtfScPixConsistent; }
-    bool isGsfScPixChargeConsistent() const { return chargeInfo_.isGsfScPixConsistent; }
-    bool isGsfCtfChargeConsistent() const { return chargeInfo_.isGsfCtfConsistent; }
-    const ChargeInfo &chargeInfo() const { return chargeInfo_; }
-
-    // Candidate redefined methods
-    bool isElectron() const override { return true; }
-    bool overlap(const Candidate &) const override;
-
-  private:
-    // Complementary attributes
-    ChargeInfo chargeInfo_;
-
-    //=======================================================
-    // Core Attributes
-    //
-    // They all have been computed before, when building the
-    // collection of GsfElectronCore instances. Each GsfElectron
-    // has a reference toward a GsfElectronCore.
-    //=======================================================
-
-  public:
-    // accessors
-    virtual GsfElectronCoreRef core() const;
-    void setCore(const reco::GsfElectronCoreRef &core) { core_ = core; }
-
-    // forward core methods
-    SuperClusterRef superCluster() const override { return core()->superCluster(); }
-    GsfTrackRef gsfTrack() const override { return core()->gsfTrack(); }
-    float ctfGsfOverlap() const { return core()->ctfGsfOverlap(); }
-    bool ecalDrivenSeed() const { return core()->ecalDrivenSeed(); }
-    bool trackerDrivenSeed() const { return core()->trackerDrivenSeed(); }
-    virtual SuperClusterRef parentSuperCluster() const { return core()->parentSuperCluster(); }
-    bool closestCtfTrackRefValid() const {
-      return closestCtfTrackRef().isAvailable() && closestCtfTrackRef().isNonnull();
-    }
-    //methods used for MVA variables
-    float closestCtfTrackNormChi2() const {
-      return closestCtfTrackRefValid() ? closestCtfTrackRef()->normalizedChi2() : 0;
-    }
-    int closestCtfTrackNLayers() const {
-      return closestCtfTrackRefValid() ? closestCtfTrackRef()->hitPattern().trackerLayersWithMeasurement() : -1;
-    }
-
-    // backward compatibility
-    struct ClosestCtfTrack {
-      TrackRef ctfTrack;      // best matching ctf track
-      float shFracInnerHits;  // fraction of common hits between the ctf and gsf tracks
-      ClosestCtfTrack() : shFracInnerHits(0.) {}
-      ClosestCtfTrack(TrackRef track, float sh) : ctfTrack(track), shFracInnerHits(sh) {}
-    };
-    float shFracInnerHits() const { return core()->ctfGsfOverlap(); }
-    virtual TrackRef closestCtfTrackRef() const { return core()->ctfTrack(); }
-    virtual ClosestCtfTrack closestCtfTrack() const {
-      return ClosestCtfTrack(core()->ctfTrack(), core()->ctfGsfOverlap());
-    }
-
-  private:
-    // attributes
-    GsfElectronCoreRef core_;
-
-    //=======================================================
-    // Track-Cluster Matching Attributes
-    //=======================================================
-
-  public:
-    struct TrackClusterMatching {
-      CaloClusterPtr electronCluster;  // basic cluster best matching gsf track
-      float eSuperClusterOverP;        // the supercluster energy / track momentum at the PCA to the beam spot
-      float eSeedClusterOverP;         // the seed cluster energy / track momentum at the PCA to the beam spot
-      float eSeedClusterOverPout;  // the seed cluster energy / track momentum at calo extrapolated from the outermost track state
-      float eEleClusterOverPout;  // the electron cluster energy / track momentum at calo extrapolated from the outermost track state
-      float deltaEtaSuperClusterAtVtx;  // the supercluster eta - track eta position at calo extrapolated from innermost track state
-      float deltaEtaSeedClusterAtCalo;  // the seed cluster eta - track eta position at calo extrapolated from the outermost track state
-      float deltaEtaEleClusterAtCalo;  // the electron cluster eta - track eta position at calo extrapolated from the outermost state
-      float deltaPhiEleClusterAtCalo;  // the electron cluster phi - track phi position at calo extrapolated from the outermost track state
-      float deltaPhiSuperClusterAtVtx;  // the supercluster phi - track phi position at calo extrapolated from the innermost track state
-      float deltaPhiSeedClusterAtCalo;  // the seed cluster phi - track phi position at calo extrapolated from the outermost track state
-      TrackClusterMatching()
-          : eSuperClusterOverP(0.),
-            eSeedClusterOverP(0.),
-            eSeedClusterOverPout(0.),
-            eEleClusterOverPout(0.),
-            deltaEtaSuperClusterAtVtx(std::numeric_limits<float>::max()),
-            deltaEtaSeedClusterAtCalo(std::numeric_limits<float>::max()),
-            deltaEtaEleClusterAtCalo(std::numeric_limits<float>::max()),
-            deltaPhiEleClusterAtCalo(std::numeric_limits<float>::max()),
-            deltaPhiSuperClusterAtVtx(std::numeric_limits<float>::max()),
-            deltaPhiSeedClusterAtCalo(std::numeric_limits<float>::max()) {}
-    };
-
-    // accessors
-    CaloClusterPtr electronCluster() const { return trackClusterMatching_.electronCluster; }
-    float eSuperClusterOverP() const { return trackClusterMatching_.eSuperClusterOverP; }
-    float eSeedClusterOverP() const { return trackClusterMatching_.eSeedClusterOverP; }
-    float eSeedClusterOverPout() const { return trackClusterMatching_.eSeedClusterOverPout; }
-    float eEleClusterOverPout() const { return trackClusterMatching_.eEleClusterOverPout; }
-    float deltaEtaSuperClusterTrackAtVtx() const { return trackClusterMatching_.deltaEtaSuperClusterAtVtx; }
-    float deltaEtaSeedClusterTrackAtCalo() const { return trackClusterMatching_.deltaEtaSeedClusterAtCalo; }
-    float deltaEtaEleClusterTrackAtCalo() const { return trackClusterMatching_.deltaEtaEleClusterAtCalo; }
-    float deltaPhiSuperClusterTrackAtVtx() const { return trackClusterMatching_.deltaPhiSuperClusterAtVtx; }
-    float deltaPhiSeedClusterTrackAtCalo() const { return trackClusterMatching_.deltaPhiSeedClusterAtCalo; }
-    float deltaPhiEleClusterTrackAtCalo() const { return trackClusterMatching_.deltaPhiEleClusterAtCalo; }
-    float deltaEtaSeedClusterTrackAtVtx() const {
-      return superCluster().isNonnull() && superCluster()->seed().isNonnull()
-                 ? trackClusterMatching_.deltaEtaSuperClusterAtVtx - superCluster()->eta() +
-                       superCluster()->seed()->eta()
-                 : std::numeric_limits<float>::max();
-    }
-    const TrackClusterMatching &trackClusterMatching() const { return trackClusterMatching_; }
-
-    // for backward compatibility, usefull ?
-    void setDeltaEtaSuperClusterAtVtx(float de) { trackClusterMatching_.deltaEtaSuperClusterAtVtx = de; }
-    void setDeltaPhiSuperClusterAtVtx(float dphi) { trackClusterMatching_.deltaPhiSuperClusterAtVtx = dphi; }
-
-  private:
-    // attributes
-    TrackClusterMatching trackClusterMatching_;
-
-    //=======================================================
-    // Track extrapolations
-    //=======================================================
-
-  public:
-    struct TrackExtrapolations {
-      math::XYZPointF positionAtVtx;   // the track PCA to the beam spot
-      math::XYZPointF positionAtCalo;  // the track PCA to the supercluster position
-      math::XYZVectorF momentumAtVtx;  // the track momentum at the PCA to the beam spot
-      // the track momentum extrapolated at the supercluster position from the innermost track state
-      math::XYZVectorF momentumAtCalo;
-      // the track momentum extrapolated at the seed cluster position from the outermost track state
-      math::XYZVectorF momentumOut;
-      // the track momentum extrapolated at the ele cluster position from the outermost track state
-      math::XYZVectorF momentumAtEleClus;
-      math::XYZVectorF momentumAtVtxWithConstraint;  // the track momentum at the PCA to the beam spot using bs constraint
-    };
-
-    // accessors
-    math::XYZPointF trackPositionAtVtx() const { return trackExtrapolations_.positionAtVtx; }
-    math::XYZPointF trackPositionAtCalo() const { return trackExtrapolations_.positionAtCalo; }
-    math::XYZVectorF trackMomentumAtVtx() const { return trackExtrapolations_.momentumAtVtx; }
-    math::XYZVectorF trackMomentumAtCalo() const { return trackExtrapolations_.momentumAtCalo; }
-    math::XYZVectorF trackMomentumOut() const { return trackExtrapolations_.momentumOut; }
-    math::XYZVectorF trackMomentumAtEleClus() const { return trackExtrapolations_.momentumAtEleClus; }
-    math::XYZVectorF trackMomentumAtVtxWithConstraint() const {
-      return trackExtrapolations_.momentumAtVtxWithConstraint;
-    }
-    const TrackExtrapolations &trackExtrapolations() const { return trackExtrapolations_; }
-
-    // setter (if you know what you're doing)
-    void setTrackExtrapolations(const TrackExtrapolations &te) { trackExtrapolations_ = te; }
-
-    // for backward compatibility
-    math::XYZPointF TrackPositionAtVtx() const { return trackPositionAtVtx(); }
-    math::XYZPointF TrackPositionAtCalo() const { return trackPositionAtCalo(); }
-
-  private:
-    // attributes
-    TrackExtrapolations trackExtrapolations_;
-
-    //=======================================================
-    // SuperCluster direct access
-    //=======================================================
-
-  public:
-    // direct accessors
-    math::XYZPoint superClusterPosition() const { return superCluster()->position(); }  // the super cluster position
-    int basicClustersSize() const {
-      return superCluster()->clustersSize();
-    }  // number of basic clusters inside the supercluster
-    CaloCluster_iterator basicClustersBegin() const { return superCluster()->clustersBegin(); }
-    CaloCluster_iterator basicClustersEnd() const { return superCluster()->clustersEnd(); }
-
-    // for backward compatibility
-    math::XYZPoint caloPosition() const { return superCluster()->position(); }
-
-    //=======================================================
-    // Fiducial Flags
-    //=======================================================
-
-  public:
-    struct FiducialFlags {
-      bool isEB;         // true if particle is in ECAL Barrel
-      bool isEE;         // true if particle is in ECAL Endcaps
-      bool isEBEEGap;    // true if particle is in the crack between EB and EE
-      bool isEBEtaGap;   // true if particle is in EB, and inside the eta gaps between modules
-      bool isEBPhiGap;   // true if particle is in EB, and inside the phi gaps between modules
-      bool isEEDeeGap;   // true if particle is in EE, and inside the gaps between dees
-      bool isEERingGap;  // true if particle is in EE, and inside the gaps between rings
-      FiducialFlags()
-          : isEB(false),
-            isEE(false),
-            isEBEEGap(false),
-            isEBEtaGap(false),
-            isEBPhiGap(false),
-            isEEDeeGap(false),
-            isEERingGap(false) {}
-    };
-
-    // accessors
-    bool isEB() const { return fiducialFlags_.isEB; }
-    bool isEE() const { return fiducialFlags_.isEE; }
-    bool isGap() const { return ((isEBEEGap()) || (isEBGap()) || (isEEGap())); }
-    bool isEBEEGap() const { return fiducialFlags_.isEBEEGap; }
-    bool isEBGap() const { return (isEBEtaGap() || isEBPhiGap()); }
-    bool isEBEtaGap() const { return fiducialFlags_.isEBEtaGap; }
-    bool isEBPhiGap() const { return fiducialFlags_.isEBPhiGap; }
-    bool isEEGap() const { return (isEEDeeGap() || isEERingGap()); }
-    bool isEEDeeGap() const { return fiducialFlags_.isEEDeeGap; }
-    bool isEERingGap() const { return fiducialFlags_.isEERingGap; }
-    const FiducialFlags &fiducialFlags() const { return fiducialFlags_; }
-    // setters... not necessary in regular situations
-    // but handy for late stage modifications of electron objects
-    void setFFlagIsEB(const bool b) { fiducialFlags_.isEB = b; }
-    void setFFlagIsEE(const bool b) { fiducialFlags_.isEE = b; }
-    void setFFlagIsEBEEGap(const bool b) { fiducialFlags_.isEBEEGap = b; }
-    void setFFlagIsEBEtaGap(const bool b) { fiducialFlags_.isEBEtaGap = b; }
-    void setFFlagIsEBPhiGap(const bool b) { fiducialFlags_.isEBPhiGap = b; }
-    void setFFlagIsEEDeeGap(const bool b) { fiducialFlags_.isEEDeeGap = b; }
-    void setFFlagIsEERingGap(const bool b) { fiducialFlags_.isEERingGap = b; }
-
-  private:
-    // attributes
-    FiducialFlags fiducialFlags_;
-
-    //=======================================================
-    // Shower Shape Variables
-    //=======================================================
-
-  public:
-    struct ShowerShape {
-      float sigmaEtaEta;    // weighted cluster rms along eta and inside 5x5 (absolute eta)
-      float sigmaIetaIeta;  // weighted cluster rms along eta and inside 5x5 (Xtal eta)
-      float sigmaIphiIphi;  // weighted cluster rms along phi and inside 5x5 (Xtal phi)
-      float e1x5;           // energy inside 1x5 in etaxphi around the seed Xtal
-      float e2x5Max;        // energy inside 2x5 in etaxphi around the seed Xtal (max bwt the 2 possible sums)
-      float e5x5;           // energy inside 5x5 in etaxphi around the seed Xtal
-      float r9;             // ratio of the 3x3 energy and supercluster energy
-      float hcalDepth1OverEcal;  // run2 hcal over ecal seed cluster energy using 1st hcal depth (using hcal towers within a cone)
-      float hcalDepth2OverEcal;  // run2 hcal over ecal seed cluster energy using 2nd hcal depth (using hcal towers within a cone)
-      float hcalDepth1OverEcalBc;  // run2 hcal over ecal seed cluster energy using 1st hcal depth (using hcal towers behind clusters)
-      float hcalDepth2OverEcalBc;  // run2 hcal over ecal seed cluster energy using 2nd hcal depth (using hcal towers behind clusters)
-      std::array<float, 7>
-          hcalOverEcal;  // run3 hcal over ecal seed cluster energy per depth (using rechits within a cone)
-      std::array<float, 7>
-          hcalOverEcalBc;  // run3 hcal over ecal seed cluster energy per depth (using rechits behind clusters)
-      std::vector<CaloTowerDetId> hcalTowersBehindClusters;
-      bool invalidHcal;  // set to true if the hcal energy estimate is not valid (e.g. the corresponding tower was off or masked)
-      bool pre7DepthHcal;  // to work around an ioread rule issue on legacy RECO files
-      float sigmaIetaIphi;
-      float eMax;
-      float e2nd;
-      float eTop;
-      float eLeft;
-      float eRight;
-      float eBottom;
-      float e2x5Top;
-      float e2x5Left;
-      float e2x5Right;
-      float e2x5Bottom;
-      ShowerShape()
-          : sigmaEtaEta(std::numeric_limits<float>::max()),
-            sigmaIetaIeta(std::numeric_limits<float>::max()),
-            sigmaIphiIphi(std::numeric_limits<float>::max()),
-            e1x5(0.f),
-            e2x5Max(0.f),
-            e5x5(0.f),
-            r9(-std::numeric_limits<float>::max()),
-            hcalDepth1OverEcal(0.f),
-            hcalDepth2OverEcal(0.f),
-            hcalDepth1OverEcalBc(0.f),
-            hcalDepth2OverEcalBc(0.f),
-            hcalOverEcal{{0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}},
-            hcalOverEcalBc{{0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}},
-            invalidHcal(false),
-            pre7DepthHcal(true),
-            sigmaIetaIphi(0.f),
-            eMax(0.f),
-            e2nd(0.f),
-            eTop(0.f),
-            eLeft(0.f),
-            eRight(0.f),
-            eBottom(0.f),
-            e2x5Top(0.f),
-            e2x5Left(0.f),
-            e2x5Right(0.f),
-            e2x5Bottom(0.f) {}
-    };
-
-    // accessors
-    float sigmaEtaEta() const { return showerShape_.sigmaEtaEta; }
-    float sigmaIetaIeta() const { return showerShape_.sigmaIetaIeta; }
-    float sigmaIphiIphi() const { return showerShape_.sigmaIphiIphi; }
-    float e1x5() const { return showerShape_.e1x5; }
-    float e2x5Max() const { return showerShape_.e2x5Max; }
-    float e5x5() const { return showerShape_.e5x5; }
-    float r9() const { return showerShape_.r9; }
-    float hcalOverEcal(const ShowerShape &ss, int depth) const {
-      if (ss.pre7DepthHcal) {
-        if (depth == 0)
-          return ss.hcalDepth1OverEcal + ss.hcalDepth2OverEcal;
-        else if (depth == 1)
-          return ss.hcalDepth1OverEcal;
-        else if (depth == 2)
-          return ss.hcalDepth2OverEcal;
-
-        return 0.f;
-      } else {
-        const auto &hovere = ss.hcalOverEcal;
-        return (!(depth > 0 and depth < 8)) ? std::accumulate(std::begin(hovere), std::end(hovere), 0.f)
-                                            : hovere[depth - 1];
-      }
-    }
-    float hcalOverEcal(int depth = 0) const { return hcalOverEcal(showerShape_, depth); }
-    float hcalOverEcalBc(const ShowerShape &ss, int depth) const {
-      if (ss.pre7DepthHcal) {
-        if (depth == 0)
-          return ss.hcalDepth1OverEcalBc + ss.hcalDepth2OverEcalBc;
-        else if (depth == 1)
-          return ss.hcalDepth1OverEcalBc;
-        else if (depth == 2)
-          return ss.hcalDepth2OverEcalBc;
-
-        return 0.f;
-      } else {
-        const auto &hovere = ss.hcalOverEcalBc;
-        return (!(depth > 0 and depth < 8)) ? std::accumulate(std::begin(hovere), std::end(hovere), 0.f)
-                                            : hovere[depth - 1];
-      }
-    }
-    float hcalOverEcalBc(int depth = 0) const { return hcalOverEcalBc(showerShape_, depth); }
-    const std::vector<CaloTowerDetId> &hcalTowersBehindClusters() const {
-      return showerShape_.hcalTowersBehindClusters;
-    }
-    bool hcalOverEcalValid() const { return !showerShape_.invalidHcal; }
-    float eLeft() const { return showerShape_.eLeft; }
-    float eRight() const { return showerShape_.eRight; }
-    float eTop() const { return showerShape_.eTop; }
-    float eBottom() const { return showerShape_.eBottom; }
-    const ShowerShape &showerShape() const { return showerShape_; }
-    // non-zero-suppressed and no-fractions shower shapes
-    // ecal energy is always that from the full 5x5
-    float full5x5_sigmaEtaEta() const { return full5x5_showerShape_.sigmaEtaEta; }
-    float full5x5_sigmaIetaIeta() const { return full5x5_showerShape_.sigmaIetaIeta; }
-    float full5x5_sigmaIphiIphi() const { return full5x5_showerShape_.sigmaIphiIphi; }
-    float full5x5_e1x5() const { return full5x5_showerShape_.e1x5; }
-    float full5x5_e2x5Max() const { return full5x5_showerShape_.e2x5Max; }
-    float full5x5_e5x5() const { return full5x5_showerShape_.e5x5; }
-    float full5x5_r9() const { return full5x5_showerShape_.r9; }
-    float full5x5_hcalOverEcal(int depth = 0) const { return hcalOverEcal(full5x5_showerShape_, depth); }
-    float full5x5_hcalOverEcalBc(int depth = 0) const { return hcalOverEcalBc(full5x5_showerShape_, depth); }
-    bool full5x5_hcalOverEcalValid() const { return !full5x5_showerShape_.invalidHcal; }
-    float full5x5_e2x5Left() const { return full5x5_showerShape_.e2x5Left; }
-    float full5x5_e2x5Right() const { return full5x5_showerShape_.e2x5Right; }
-    float full5x5_e2x5Top() const { return full5x5_showerShape_.e2x5Top; }
-    float full5x5_e2x5Bottom() const { return full5x5_showerShape_.e2x5Bottom; }
-    float full5x5_eLeft() const { return full5x5_showerShape_.eLeft; }
-    float full5x5_eRight() const { return full5x5_showerShape_.eRight; }
-    float full5x5_eTop() const { return full5x5_showerShape_.eTop; }
-    float full5x5_eBottom() const { return full5x5_showerShape_.eBottom; }
-    const ShowerShape &full5x5_showerShape() const { return full5x5_showerShape_; }
-
-    // setters (if you know what you're doing)
-    void setShowerShape(const ShowerShape &s) { showerShape_ = s; }
-    void full5x5_setShowerShape(const ShowerShape &s) { full5x5_showerShape_ = s; }
-
-    // for backward compatibility (this will only ever be the ZS shapes!)
-    float scSigmaEtaEta() const { return sigmaEtaEta(); }
-    float scSigmaIEtaIEta() const { return sigmaIetaIeta(); }
-    float scE1x5() const { return e1x5(); }
-    float scE2x5Max() const { return e2x5Max(); }
-    float scE5x5() const { return e5x5(); }
-    float hadronicOverEm() const { return hcalOverEcal(); }
-
-  private:
-    // attributes
-    ShowerShape showerShape_;
-    ShowerShape full5x5_showerShape_;
-
-    //=======================================================
-    // SaturationInfo
-    //=======================================================
-
-  public:
-    struct SaturationInfo {
-      int nSaturatedXtals;
-      bool isSeedSaturated;
-      SaturationInfo() : nSaturatedXtals(0), isSeedSaturated(false) {}
-    };
-
-    // accessors
-    float nSaturatedXtals() const { return saturationInfo_.nSaturatedXtals; }
-    float isSeedSaturated() const { return saturationInfo_.isSeedSaturated; }
-    const SaturationInfo &saturationInfo() const { return saturationInfo_; }
-    void setSaturationInfo(const SaturationInfo &s) { saturationInfo_ = s; }
-
-  private:
-    SaturationInfo saturationInfo_;
-
-    //=======================================================
-    // Isolation Variables
-    //=======================================================
-
-  public:
-    struct IsolationVariables {
-      float tkSumPt;                           // track iso with electron footprint removed
-      float tkSumPtHEEP;                       // track iso used for the HEEP ID
-      float ecalRecHitSumEt;                   // ecal iso deposit with electron footprint removed
-      float hcalDepth1TowerSumEt;              // hcal depth 1 iso deposit with electron footprint removed
-      float hcalDepth2TowerSumEt;              // hcal depth 2 iso deposit with electron footprint removed
-      float hcalDepth1TowerSumEtBc;            // hcal depth 1 iso deposit without towers behind clusters
-      float hcalDepth2TowerSumEtBc;            // hcal depth 2 iso deposit without towers behind clusters
-      std::array<float, 7> hcalRecHitSumEt;    // ...per depth, with electron footprint removed
-      std::array<float, 7> hcalRecHitSumEtBc;  // ...per depth, with hcal rechit behind cluster removed
-      bool pre7DepthHcal;                      // to work around an ioread rule issue on legacy RECO files
-      IsolationVariables()
-          : tkSumPt(0.),
-            tkSumPtHEEP(0.),
-            ecalRecHitSumEt(0.),
-            hcalDepth1TowerSumEt(0.f),
-            hcalDepth2TowerSumEt(0.f),
-            hcalDepth1TowerSumEtBc(0.f),
-            hcalDepth2TowerSumEtBc(0.f),
-            hcalRecHitSumEt{{0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}},
-            hcalRecHitSumEtBc{{0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}},
-            pre7DepthHcal(true) {}
-    };
-
-    // 03 accessors
-    float dr03TkSumPt() const { return dr03_.tkSumPt; }
-    float dr03TkSumPtHEEP() const { return dr03_.tkSumPtHEEP; }
-    float dr03EcalRecHitSumEt() const { return dr03_.ecalRecHitSumEt; }
-    float hcalTowerSumEt(const IsolationVariables &iv, int depth) const {
-      if (iv.pre7DepthHcal) {
-        if (depth == 0)
-          return iv.hcalDepth1TowerSumEt + iv.hcalDepth2TowerSumEt;
-        else if (depth == 1)
-          return iv.hcalDepth1TowerSumEt;
-        else if (depth == 2)
-          return iv.hcalDepth2TowerSumEt;
-
-        return 0.f;
-      } else {
-        const auto &hcaliso = iv.hcalRecHitSumEt;
-        return (!(depth > 0 and depth < 8)) ? std::accumulate(std::begin(hcaliso), std::end(hcaliso), 0.f)
-                                            : hcaliso[depth - 1];
-      }
-    }
-    float dr03HcalTowerSumEt(int depth = 0) const { return hcalTowerSumEt(dr03_, depth); }
-    float hcalTowerSumEtBc(const IsolationVariables &iv, int depth) const {
-      if (iv.pre7DepthHcal) {
-        if (depth == 0)
-          return iv.hcalDepth1TowerSumEtBc + iv.hcalDepth2TowerSumEtBc;
-        else if (depth == 1)
-          return iv.hcalDepth1TowerSumEtBc;
-        else if (depth == 2)
-          return iv.hcalDepth2TowerSumEtBc;
-
-        return 0.f;
-      } else {
-        const auto &hcaliso = iv.hcalRecHitSumEtBc;
-        return (!(depth > 0 and depth < 8)) ? std::accumulate(std::begin(hcaliso), std::end(hcaliso), 0.f)
-                                            : hcaliso[depth - 1];
-      }
-    }
-    float dr03HcalTowerSumEtBc(int depth = 0) const { return hcalTowerSumEtBc(dr03_, depth); }
-    const IsolationVariables &dr03IsolationVariables() const { return dr03_; }
-
-    // 04 accessors
-    float dr04TkSumPt() const { return dr04_.tkSumPt; }
-    float dr04TkSumPtHEEP() const { return dr04_.tkSumPtHEEP; }
-    float dr04EcalRecHitSumEt() const { return dr04_.ecalRecHitSumEt; }
-    float dr04HcalTowerSumEt(int depth = 0) const { return hcalTowerSumEt(dr04_, depth); }
-    float dr04HcalTowerSumEtBc(int depth = 0) const { return hcalTowerSumEtBc(dr04_, depth); }
-    const IsolationVariables &dr04IsolationVariables() const { return dr04_; }
-
-    // setters ?!?
-    void setDr03Isolation(const IsolationVariables &dr03) { dr03_ = dr03; }
-    void setDr04Isolation(const IsolationVariables &dr04) { dr04_ = dr04; }
-
-    // for backward compatibility
-    void setIsolation03(const IsolationVariables &dr03) { dr03_ = dr03; }
-    void setIsolation04(const IsolationVariables &dr04) { dr04_ = dr04; }
-    const IsolationVariables &isolationVariables03() const { return dr03_; }
-    const IsolationVariables &isolationVariables04() const { return dr04_; }
-
-    // go back to run2-like 2 effective depths if desired - depth 1 is the normal depth 1, depth 2 is the sum over the rest
-    void hcalToRun2EffDepth();
-
-  private:
-    // attributes
-    IsolationVariables dr03_;
-    IsolationVariables dr04_;
-
-    //=======================================================
-    // Conversion Rejection Information
-    //=======================================================
-
-  public:
-    struct ConversionRejection {
-      int flags;             // -max:not-computed, other: as computed by Puneeth conversion code
-      TrackBaseRef partner;  // conversion partner
-      float dist;            // distance to the conversion partner
-      float dcot;            // difference of cot(angle) with the conversion partner track
-      float radius;          // signed conversion radius
-      float vtxFitProb;      //fit probablity (chi2/ndof) of the matched conversion vtx
-      ConversionRejection()
-          : flags(-1),
-            dist(std::numeric_limits<float>::max()),
-            dcot(std::numeric_limits<float>::max()),
-            radius(std::numeric_limits<float>::max()),
-            vtxFitProb(std::numeric_limits<float>::max()) {}
-    };
-
-    // accessors
-    int convFlags() const { return conversionRejection_.flags; }
-    TrackBaseRef convPartner() const { return conversionRejection_.partner; }
-    float convDist() const { return conversionRejection_.dist; }
-    float convDcot() const { return conversionRejection_.dcot; }
-    float convRadius() const { return conversionRejection_.radius; }
-    float convVtxFitProb() const { return conversionRejection_.vtxFitProb; }
-    const ConversionRejection &conversionRejectionVariables() const { return conversionRejection_; }
-    void setConversionRejectionVariables(const ConversionRejection &convRej) { conversionRejection_ = convRej; }
-
-  private:
-    // attributes
-    ConversionRejection conversionRejection_;
-
-    //=======================================================
-    // Pflow Information
-    //=======================================================
-
-  public:
-    struct PflowIsolationVariables {
-      //first three data members that changed names, according to DataFormats/MuonReco/interface/MuonPFIsolation.h
-      float sumChargedHadronPt;  //!< sum-pt of charged Hadron    // old float chargedHadronIso ;
-      float sumNeutralHadronEt;  //!< sum pt of neutral hadrons  // old float neutralHadronIso ;
-      float sumPhotonEt;         //!< sum pt of PF photons              // old float photonIso ;
-      //then four new data members, corresponding to DataFormats/MuonReco/interface/MuonPFIsolation.h
-      float sumChargedParticlePt;             //!< sum-pt of charged Particles(inludes e/mu)
-      float sumNeutralHadronEtHighThreshold;  //!< sum pt of neutral hadrons with a higher threshold
-      float sumPhotonEtHighThreshold;         //!< sum pt of PF photons with a higher threshold
-      float sumPUPt;                          //!< sum pt of charged Particles not from PV  (for Pu corrections)
-      //new pf cluster based isolation values
-      float sumEcalClusterEt;  //sum pt of ecal clusters, vetoing clusters part of electron
-      float sumHcalClusterEt;  //sum pt of hcal clusters, vetoing clusters part of electron
-      PflowIsolationVariables()
-          : sumChargedHadronPt(0),
-            sumNeutralHadronEt(0),
-            sumPhotonEt(0),
-            sumChargedParticlePt(0),
-            sumNeutralHadronEtHighThreshold(0),
-            sumPhotonEtHighThreshold(0),
-            sumPUPt(0),
-            sumEcalClusterEt(0),
-            sumHcalClusterEt(0) {}
-    };
-
-    struct MvaInput {
-      int earlyBrem;                // Early Brem detected (-2=>unknown,-1=>could not be evaluated,0=>wrong,1=>true)
-      int lateBrem;                 // Late Brem detected (-2=>unknown,-1=>could not be evaluated,0=>wrong,1=>true)
-      float sigmaEtaEta;            // Sigma-eta-eta with the PF cluster
-      float hadEnergy;              // Associated PF Had Cluster energy
-      float deltaEta;               // PF-cluster GSF track delta-eta
-      int nClusterOutsideMustache;  // -2 => unknown, -1 =>could not be evaluated, 0 and more => number of clusters
-      float etOutsideMustache;
-      MvaInput()
-          : earlyBrem(-2),
-            lateBrem(-2),
-            sigmaEtaEta(std::numeric_limits<float>::max()),
-            hadEnergy(0.),
-            deltaEta(std::numeric_limits<float>::max()),
-            nClusterOutsideMustache(-2),
-            etOutsideMustache(-std::numeric_limits<float>::max()) {}
-    };
-
-    static constexpr float mvaPlaceholder = -999999999.;
-
-    struct MvaOutput {
-      int status;  // see PFCandidateElectronExtra::StatusFlag
-      float mva_Isolated;
-      float mva_e_pi;
-      float mvaByPassForIsolated;  // complementary MVA used in preselection
-      float dnn_e_sigIsolated;
-      float dnn_e_sigNonIsolated;
-      float dnn_e_bkgNonIsolated;
-      float dnn_e_bkgTau;
-      float dnn_e_bkgPhoton;
-      MvaOutput()
-          : status(-1),
-            mva_Isolated(mvaPlaceholder),
-            mva_e_pi(mvaPlaceholder),
-            mvaByPassForIsolated(mvaPlaceholder),
-            dnn_e_sigIsolated(mvaPlaceholder),
-            dnn_e_sigNonIsolated(mvaPlaceholder),
-            dnn_e_bkgNonIsolated(mvaPlaceholder),
-            dnn_e_bkgTau(mvaPlaceholder),
-            dnn_e_bkgPhoton(mvaPlaceholder) {}
-    };
-
-    // accessors
-    const PflowIsolationVariables &pfIsolationVariables() const { return pfIso_; }
-    //backwards compat functions for pat::Electron
-    float ecalPFClusterIso() const { return pfIso_.sumEcalClusterEt; };
-    float hcalPFClusterIso() const { return pfIso_.sumHcalClusterEt; };
-
-    const MvaInput &mvaInput() const { return mvaInput_; }
-    const MvaOutput &mvaOutput() const { return mvaOutput_; }
-
-    // setters
-    void setPfIsolationVariables(const PflowIsolationVariables &iso) { pfIso_ = iso; }
-    void setMvaInput(const MvaInput &mi) { mvaInput_ = mi; }
-    void setMvaOutput(const MvaOutput &mo) { mvaOutput_ = mo; }
-
-    // for backward compatibility
-    float mva_Isolated() const { return mvaOutput_.mva_Isolated; }
-    float mva_e_pi() const { return mvaOutput_.mva_e_pi; }
-    float dnn_signal_Isolated() const { return mvaOutput_.dnn_e_sigIsolated; }
-    float dnn_signal_nonIsolated() const { return mvaOutput_.dnn_e_sigNonIsolated; }
-    float dnn_bkg_nonIsolated() const { return mvaOutput_.dnn_e_bkgNonIsolated; }
-    float dnn_bkg_Tau() const { return mvaOutput_.dnn_e_bkgTau; }
-    float dnn_bkg_Photon() const { return mvaOutput_.dnn_e_bkgPhoton; }
-
-  private:
-    PflowIsolationVariables pfIso_;
-    MvaInput mvaInput_;
-    MvaOutput mvaOutput_;
-
-    //=======================================================
-    // Preselection and Ambiguity
-    //=======================================================
-
-  public:
-    // accessors
-    bool ecalDriven() const;  // return true if ecalDrivenSeed() and passingCutBasedPreselection()
-    bool passingCutBasedPreselection() const { return passCutBasedPreselection_; }
-    bool passingPflowPreselection() const { return passPflowPreselection_; }
-    bool ambiguous() const { return ambiguous_; }
-    GsfTrackRefVector::size_type ambiguousGsfTracksSize() const { return ambiguousGsfTracks_.size(); }
-    auto const &ambiguousGsfTracks() const { return ambiguousGsfTracks_; }
-
-    // setters
-    void setPassCutBasedPreselection(bool flag) { passCutBasedPreselection_ = flag; }
-    void setPassPflowPreselection(bool flag) { passPflowPreselection_ = flag; }
-    void setAmbiguous(bool flag) { ambiguous_ = flag; }
-    void clearAmbiguousGsfTracks() { ambiguousGsfTracks_.clear(); }
-    void addAmbiguousGsfTrack(const reco::GsfTrackRef &t) { ambiguousGsfTracks_.push_back(t); }
-
-    // backward compatibility
-    void setPassMvaPreselection(bool flag) { passMvaPreslection_ = flag; }
-    bool passingMvaPreselection() const { return passMvaPreslection_; }
-
-  private:
-    // attributes
-    bool passCutBasedPreselection_;
-    bool passPflowPreselection_;
-    bool passMvaPreslection_;  // to be removed : passPflowPreslection_
-    bool ambiguous_;
-    GsfTrackRefVector ambiguousGsfTracks_;  // ambiguous gsf tracks
-
-    //=======================================================
-    // Brem Fractions and Classification
-    //=======================================================
-
-  public:
-    struct ClassificationVariables {
-      float trackFbrem;  // the brem fraction from gsf fit: (track momentum in - track momentum out) / track momentum in
-      float superClusterFbrem;  // the brem fraction from supercluster: (supercluster energy - electron cluster energy) / supercluster energy
-      constexpr static float kDefaultValue = -1.e30;
-      ClassificationVariables() : trackFbrem(kDefaultValue), superClusterFbrem(kDefaultValue) {}
-    };
-    enum Classification { UNKNOWN = -1, GOLDEN = 0, BIGBREM = 1, BADTRACK = 2, SHOWERING = 3, GAP = 4 };
-
-    // accessors
-    float trackFbrem() const { return classVariables_.trackFbrem; }
-    float superClusterFbrem() const { return classVariables_.superClusterFbrem; }
-    const ClassificationVariables &classificationVariables() const { return classVariables_; }
-    Classification classification() const { return class_; }
-
-    // utilities
-    int numberOfBrems() const { return basicClustersSize() - 1; }
-    float fbrem() const { return trackFbrem(); }
-
-    // setters
-    void setTrackFbrem(float fbrem) { classVariables_.trackFbrem = fbrem; }
-    void setSuperClusterFbrem(float fbrem) { classVariables_.superClusterFbrem = fbrem; }
-    void setClassificationVariables(const ClassificationVariables &cv) { classVariables_ = cv; }
-    void setClassification(Classification myclass) { class_ = myclass; }
-
-  private:
-    // attributes
-    ClassificationVariables classVariables_;
-    Classification class_;  // fbrem and number of clusters based electron classification
-
-    //=======================================================
-    // Corrections
-    //
-    // The only methods, with classification, which modify
-    // the electrons after they have been constructed.
-    // They change a given characteristic, such as the super-cluster
-    // energy, and propagate the change consistently
-    // to all the depending attributes.
-    // We expect the methods to be called in a given order
-    // and so to store specific kind of corrections
-    // 1) classify()
-    // 2) correctEcalEnergy() : depending on classification and eta
-    // 3) correctMomemtum() : depending on classification and ecal energy and tracker momentum errors
-    //
-    // Beware that correctEcalEnergy() is modifying few attributes which
-    // were potentially used for preselection, whose value used in
-    // preselection will not be available any more :
-    // hcalOverEcal, eSuperClusterOverP,
-    // eSeedClusterOverP, eEleClusterOverPout.
-    //=======================================================
-
-  public:
-    enum P4Kind { P4_UNKNOWN = -1, P4_FROM_SUPER_CLUSTER = 0, P4_COMBINATION = 1, P4_PFLOW_COMBINATION = 2 };
-
-    struct Corrections {
-      bool isEcalEnergyCorrected;  // true if ecal energy has been corrected
-      float correctedEcalEnergy;  // corrected energy (if !isEcalEnergyCorrected this value is identical to the supercluster energy)
-      float correctedEcalEnergyError;  // error on energy
-      //bool isMomentumCorrected ;     // DEPRECATED
-      float trackMomentumError;  // track momentum error from gsf fit
+    class GsfElectron : public RecoCandidate {
+      //=======================================================
+      // Constructors
       //
-      LorentzVector fromSuperClusterP4;  // for P4_FROM_SUPER_CLUSTER
-      float fromSuperClusterP4Error;     // for P4_FROM_SUPER_CLUSTER
-      LorentzVector combinedP4;          // for P4_COMBINATION
-      float combinedP4Error;             // for P4_COMBINATION
-      LorentzVector pflowP4;             // for P4_PFLOW_COMBINATION
-      float pflowP4Error;                // for P4_PFLOW_COMBINATION
-      P4Kind candidateP4Kind;            // say which momentum has been stored in reco::Candidate
+      // The clone() method with arguments, and the copy
+      // constructor with edm references is designed for
+      // someone which want to duplicates all
+      // collections.
+      //=======================================================
+
+    public:
+      // some nested structures defined later on
+      struct ChargeInfo;
+      struct TrackClusterMatching;
+      struct TrackExtrapolations;
+      struct ClosestCtfTrack;
+      struct FiducialFlags;
+      struct ShowerShape;
+      struct IsolationVariables;
+      struct ConversionRejection;
+      struct ClassificationVariables;
+      struct SaturationInfo;
+
+      GsfElectron();
+      GsfElectron(const GsfElectronCoreRef &);
+      GsfElectron(const GsfElectron &, const GsfElectronCoreRef &);
+      GsfElectron(const GsfElectron &electron,
+                  const GsfElectronCoreRef &core,
+                  const CaloClusterPtr &electronCluster,
+                  const TrackRef &closestCtfTrack,
+                  const TrackBaseRef &conversionPartner,
+                  const GsfTrackRefVector &ambiguousTracks);
+      GsfElectron(int charge,
+                  const ChargeInfo &,
+                  const GsfElectronCoreRef &,
+                  const TrackClusterMatching &,
+                  const TrackExtrapolations &,
+                  const ClosestCtfTrack &,
+                  const FiducialFlags &,
+                  const ShowerShape &,
+                  const ConversionRejection &);
+      GsfElectron(int charge,
+                  const ChargeInfo &,
+                  const GsfElectronCoreRef &,
+                  const TrackClusterMatching &,
+                  const TrackExtrapolations &,
+                  const ClosestCtfTrack &,
+                  const FiducialFlags &,
+                  const ShowerShape &,
+                  const ShowerShape &,
+                  const ConversionRejection &,
+                  const SaturationInfo &);
+      GsfElectron *clone() const override;
+      GsfElectron *clone(const GsfElectronCoreRef &core,
+                         const CaloClusterPtr &electronCluster,
+                         const TrackRef &closestCtfTrack,
+                         const TrackBaseRef &conversionPartner,
+                         const GsfTrackRefVector &ambiguousTracks) const;
+      ~GsfElectron() override {}
+
+    private:
+      void init();
+
+      //=======================================================
+      // Candidate methods and complementary information
       //
-      Corrections()
-          : isEcalEnergyCorrected(false),
-            correctedEcalEnergy(0.),
-            correctedEcalEnergyError(999.),
-            /*isMomentumCorrected(false),*/ trackMomentumError(999.),
-            fromSuperClusterP4Error(999.),
-            combinedP4Error(999.),
-            pflowP4Error(999.),
-            candidateP4Kind(P4_UNKNOWN) {}
+      // The gsf electron producer has tried to best evaluate
+      // the four momentum and charge and given those values to
+      // the GsfElectron constructor, which forwarded them to
+      // the Candidate constructor. Those values can be retreived
+      // with getters inherited from Candidate : p4() and charge().
+      //=======================================================
+
+    public:
+      // Inherited from Candidate
+      // const LorentzVector & charge() const ;
+      // const LorentzVector & p4() const ;
+
+      // Complementary struct
+      struct ChargeInfo {
+        int scPixCharge;
+        bool isGsfCtfScPixConsistent;
+        bool isGsfScPixConsistent;
+        bool isGsfCtfConsistent;
+        ChargeInfo()
+            : scPixCharge(0), isGsfCtfScPixConsistent(false), isGsfScPixConsistent(false), isGsfCtfConsistent(false) {}
+      };
+
+      // Charge info accessors
+      // to get gsf track charge: gsfTrack()->charge()
+      // to get ctf track charge, if closestCtfTrackRef().isNonnull(): closestCtfTrackRef()->charge()
+      int scPixCharge() const { return chargeInfo_.scPixCharge; }
+      bool isGsfCtfScPixChargeConsistent() const { return chargeInfo_.isGsfCtfScPixConsistent; }
+      bool isGsfScPixChargeConsistent() const { return chargeInfo_.isGsfScPixConsistent; }
+      bool isGsfCtfChargeConsistent() const { return chargeInfo_.isGsfCtfConsistent; }
+      const ChargeInfo &chargeInfo() const { return chargeInfo_; }
+
+      // Candidate redefined methods
+      bool isElectron() const override { return true; }
+      bool overlap(const Candidate &) const override;
+
+    private:
+      // Complementary attributes
+      ChargeInfo chargeInfo_;
+
+      //=======================================================
+      // Core Attributes
+      //
+      // They all have been computed before, when building the
+      // collection of GsfElectronCore instances. Each GsfElectron
+      // has a reference toward a GsfElectronCore.
+      //=======================================================
+
+    public:
+      // accessors
+      virtual GsfElectronCoreRef core() const;
+      void setCore(const reco::GsfElectronCoreRef &core) { core_ = core; }
+
+      // forward core methods
+      SuperClusterRef superCluster() const override { return core()->superCluster(); }
+      GsfTrackRef gsfTrack() const override { return core()->gsfTrack(); }
+      float ctfGsfOverlap() const { return core()->ctfGsfOverlap(); }
+      bool ecalDrivenSeed() const { return core()->ecalDrivenSeed(); }
+      bool trackerDrivenSeed() const { return core()->trackerDrivenSeed(); }
+      virtual SuperClusterRef parentSuperCluster() const { return core()->parentSuperCluster(); }
+      bool closestCtfTrackRefValid() const {
+        return closestCtfTrackRef().isAvailable() && closestCtfTrackRef().isNonnull();
+      }
+      //methods used for MVA variables
+      float closestCtfTrackNormChi2() const {
+        return closestCtfTrackRefValid() ? closestCtfTrackRef()->normalizedChi2() : 0;
+      }
+      int closestCtfTrackNLayers() const {
+        return closestCtfTrackRefValid() ? closestCtfTrackRef()->hitPattern().trackerLayersWithMeasurement() : -1;
+      }
+
+      // backward compatibility
+      struct ClosestCtfTrack {
+        TrackRef ctfTrack;      // best matching ctf track
+        float shFracInnerHits;  // fraction of common hits between the ctf and gsf tracks
+        ClosestCtfTrack() : shFracInnerHits(0.) {}
+        ClosestCtfTrack(TrackRef track, float sh) : ctfTrack(track), shFracInnerHits(sh) {}
+      };
+      float shFracInnerHits() const { return core()->ctfGsfOverlap(); }
+      virtual TrackRef closestCtfTrackRef() const { return core()->ctfTrack(); }
+      virtual ClosestCtfTrack closestCtfTrack() const {
+        return ClosestCtfTrack(core()->ctfTrack(), core()->ctfGsfOverlap());
+      }
+
+    private:
+      // attributes
+      GsfElectronCoreRef core_;
+
+      //=======================================================
+      // Track-Cluster Matching Attributes
+      //=======================================================
+
+    public:
+      struct TrackClusterMatching {
+        CaloClusterPtr electronCluster;  // basic cluster best matching gsf track
+        float eSuperClusterOverP;        // the supercluster energy / track momentum at the PCA to the beam spot
+        float eSeedClusterOverP;         // the seed cluster energy / track momentum at the PCA to the beam spot
+        float eSeedClusterOverPout;  // the seed cluster energy / track momentum at calo extrapolated from the outermost track state
+        float eEleClusterOverPout;  // the electron cluster energy / track momentum at calo extrapolated from the outermost track state
+        float deltaEtaSuperClusterAtVtx;  // the supercluster eta - track eta position at calo extrapolated from innermost track state
+        float deltaEtaSeedClusterAtCalo;  // the seed cluster eta - track eta position at calo extrapolated from the outermost track state
+        float deltaEtaEleClusterAtCalo;  // the electron cluster eta - track eta position at calo extrapolated from the outermost state
+        float deltaPhiEleClusterAtCalo;  // the electron cluster phi - track phi position at calo extrapolated from the outermost track state
+        float deltaPhiSuperClusterAtVtx;  // the supercluster phi - track phi position at calo extrapolated from the innermost track state
+        float deltaPhiSeedClusterAtCalo;  // the seed cluster phi - track phi position at calo extrapolated from the outermost track state
+        TrackClusterMatching()
+            : eSuperClusterOverP(0.),
+              eSeedClusterOverP(0.),
+              eSeedClusterOverPout(0.),
+              eEleClusterOverPout(0.),
+              deltaEtaSuperClusterAtVtx(std::numeric_limits<float>::max()),
+              deltaEtaSeedClusterAtCalo(std::numeric_limits<float>::max()),
+              deltaEtaEleClusterAtCalo(std::numeric_limits<float>::max()),
+              deltaPhiEleClusterAtCalo(std::numeric_limits<float>::max()),
+              deltaPhiSuperClusterAtVtx(std::numeric_limits<float>::max()),
+              deltaPhiSeedClusterAtCalo(std::numeric_limits<float>::max()) {}
+      };
+
+      // accessors
+      CaloClusterPtr electronCluster() const { return trackClusterMatching_.electronCluster; }
+      float eSuperClusterOverP() const { return trackClusterMatching_.eSuperClusterOverP; }
+      float eSeedClusterOverP() const { return trackClusterMatching_.eSeedClusterOverP; }
+      float eSeedClusterOverPout() const { return trackClusterMatching_.eSeedClusterOverPout; }
+      float eEleClusterOverPout() const { return trackClusterMatching_.eEleClusterOverPout; }
+      float deltaEtaSuperClusterTrackAtVtx() const { return trackClusterMatching_.deltaEtaSuperClusterAtVtx; }
+      float deltaEtaSeedClusterTrackAtCalo() const { return trackClusterMatching_.deltaEtaSeedClusterAtCalo; }
+      float deltaEtaEleClusterTrackAtCalo() const { return trackClusterMatching_.deltaEtaEleClusterAtCalo; }
+      float deltaPhiSuperClusterTrackAtVtx() const { return trackClusterMatching_.deltaPhiSuperClusterAtVtx; }
+      float deltaPhiSeedClusterTrackAtCalo() const { return trackClusterMatching_.deltaPhiSeedClusterAtCalo; }
+      float deltaPhiEleClusterTrackAtCalo() const { return trackClusterMatching_.deltaPhiEleClusterAtCalo; }
+      float deltaEtaSeedClusterTrackAtVtx() const {
+        return superCluster().isNonnull() && superCluster()->seed().isNonnull()
+                   ? trackClusterMatching_.deltaEtaSuperClusterAtVtx - superCluster()->eta() +
+                         superCluster()->seed()->eta()
+                   : std::numeric_limits<float>::max();
+      }
+      const TrackClusterMatching &trackClusterMatching() const { return trackClusterMatching_; }
+
+      // for backward compatibility, usefull ?
+      void setDeltaEtaSuperClusterAtVtx(float de) { trackClusterMatching_.deltaEtaSuperClusterAtVtx = de; }
+      void setDeltaPhiSuperClusterAtVtx(float dphi) { trackClusterMatching_.deltaPhiSuperClusterAtVtx = dphi; }
+
+    private:
+      // attributes
+      TrackClusterMatching trackClusterMatching_;
+
+      //=======================================================
+      // Track extrapolations
+      //=======================================================
+
+    public:
+      struct TrackExtrapolations {
+        math::XYZPointF positionAtVtx;   // the track PCA to the beam spot
+        math::XYZPointF positionAtCalo;  // the track PCA to the supercluster position
+        math::XYZVectorF momentumAtVtx;  // the track momentum at the PCA to the beam spot
+        // the track momentum extrapolated at the supercluster position from the innermost track state
+        math::XYZVectorF momentumAtCalo;
+        // the track momentum extrapolated at the seed cluster position from the outermost track state
+        math::XYZVectorF momentumOut;
+        // the track momentum extrapolated at the ele cluster position from the outermost track state
+        math::XYZVectorF momentumAtEleClus;
+        math::XYZVectorF
+            momentumAtVtxWithConstraint;  // the track momentum at the PCA to the beam spot using bs constraint
+      };
+
+      // accessors
+      math::XYZPointF trackPositionAtVtx() const { return trackExtrapolations_.positionAtVtx; }
+      math::XYZPointF trackPositionAtCalo() const { return trackExtrapolations_.positionAtCalo; }
+      math::XYZVectorF trackMomentumAtVtx() const { return trackExtrapolations_.momentumAtVtx; }
+      math::XYZVectorF trackMomentumAtCalo() const { return trackExtrapolations_.momentumAtCalo; }
+      math::XYZVectorF trackMomentumOut() const { return trackExtrapolations_.momentumOut; }
+      math::XYZVectorF trackMomentumAtEleClus() const { return trackExtrapolations_.momentumAtEleClus; }
+      math::XYZVectorF trackMomentumAtVtxWithConstraint() const {
+        return trackExtrapolations_.momentumAtVtxWithConstraint;
+      }
+      const TrackExtrapolations &trackExtrapolations() const { return trackExtrapolations_; }
+
+      // setter (if you know what you're doing)
+      void setTrackExtrapolations(const TrackExtrapolations &te) { trackExtrapolations_ = te; }
+
+      // for backward compatibility
+      math::XYZPointF TrackPositionAtVtx() const { return trackPositionAtVtx(); }
+      math::XYZPointF TrackPositionAtCalo() const { return trackPositionAtCalo(); }
+
+    private:
+      // attributes
+      TrackExtrapolations trackExtrapolations_;
+
+      //=======================================================
+      // SuperCluster direct access
+      //=======================================================
+
+    public:
+      // direct accessors
+      math::XYZPoint superClusterPosition() const { return superCluster()->position(); }  // the super cluster position
+      int basicClustersSize() const {
+        return superCluster()->clustersSize();
+      }  // number of basic clusters inside the supercluster
+      CaloCluster_iterator basicClustersBegin() const { return superCluster()->clustersBegin(); }
+      CaloCluster_iterator basicClustersEnd() const { return superCluster()->clustersEnd(); }
+
+      // for backward compatibility
+      math::XYZPoint caloPosition() const { return superCluster()->position(); }
+
+      //=======================================================
+      // Fiducial Flags
+      //=======================================================
+
+    public:
+      struct FiducialFlags {
+        bool isEB;         // true if particle is in ECAL Barrel
+        bool isEE;         // true if particle is in ECAL Endcaps
+        bool isEBEEGap;    // true if particle is in the crack between EB and EE
+        bool isEBEtaGap;   // true if particle is in EB, and inside the eta gaps between modules
+        bool isEBPhiGap;   // true if particle is in EB, and inside the phi gaps between modules
+        bool isEEDeeGap;   // true if particle is in EE, and inside the gaps between dees
+        bool isEERingGap;  // true if particle is in EE, and inside the gaps between rings
+        FiducialFlags()
+            : isEB(false),
+              isEE(false),
+              isEBEEGap(false),
+              isEBEtaGap(false),
+              isEBPhiGap(false),
+              isEEDeeGap(false),
+              isEERingGap(false) {}
+      };
+
+      // accessors
+      bool isEB() const { return fiducialFlags_.isEB; }
+      bool isEE() const { return fiducialFlags_.isEE; }
+      bool isGap() const { return ((isEBEEGap()) || (isEBGap()) || (isEEGap())); }
+      bool isEBEEGap() const { return fiducialFlags_.isEBEEGap; }
+      bool isEBGap() const { return (isEBEtaGap() || isEBPhiGap()); }
+      bool isEBEtaGap() const { return fiducialFlags_.isEBEtaGap; }
+      bool isEBPhiGap() const { return fiducialFlags_.isEBPhiGap; }
+      bool isEEGap() const { return (isEEDeeGap() || isEERingGap()); }
+      bool isEEDeeGap() const { return fiducialFlags_.isEEDeeGap; }
+      bool isEERingGap() const { return fiducialFlags_.isEERingGap; }
+      const FiducialFlags &fiducialFlags() const { return fiducialFlags_; }
+      // setters... not necessary in regular situations
+      // but handy for late stage modifications of electron objects
+      void setFFlagIsEB(const bool b) { fiducialFlags_.isEB = b; }
+      void setFFlagIsEE(const bool b) { fiducialFlags_.isEE = b; }
+      void setFFlagIsEBEEGap(const bool b) { fiducialFlags_.isEBEEGap = b; }
+      void setFFlagIsEBEtaGap(const bool b) { fiducialFlags_.isEBEtaGap = b; }
+      void setFFlagIsEBPhiGap(const bool b) { fiducialFlags_.isEBPhiGap = b; }
+      void setFFlagIsEEDeeGap(const bool b) { fiducialFlags_.isEEDeeGap = b; }
+      void setFFlagIsEERingGap(const bool b) { fiducialFlags_.isEERingGap = b; }
+
+    private:
+      // attributes
+      FiducialFlags fiducialFlags_;
+
+      //=======================================================
+      // Shower Shape Variables
+      //=======================================================
+
+    public:
+      struct ShowerShape {
+        float sigmaEtaEta;    // weighted cluster rms along eta and inside 5x5 (absolute eta)
+        float sigmaIetaIeta;  // weighted cluster rms along eta and inside 5x5 (Xtal eta)
+        float sigmaIphiIphi;  // weighted cluster rms along phi and inside 5x5 (Xtal phi)
+        float e1x5;           // energy inside 1x5 in etaxphi around the seed Xtal
+        float e2x5Max;        // energy inside 2x5 in etaxphi around the seed Xtal (max bwt the 2 possible sums)
+        float e5x5;           // energy inside 5x5 in etaxphi around the seed Xtal
+        float r9;             // ratio of the 3x3 energy and supercluster energy
+        float hcalDepth1OverEcal;  // run2 hcal over ecal seed cluster energy using 1st hcal depth (using hcal towers within a cone)
+        float hcalDepth2OverEcal;  // run2 hcal over ecal seed cluster energy using 2nd hcal depth (using hcal towers within a cone)
+        float hcalDepth1OverEcalBc;  // run2 hcal over ecal seed cluster energy using 1st hcal depth (using hcal towers behind clusters)
+        float hcalDepth2OverEcalBc;  // run2 hcal over ecal seed cluster energy using 2nd hcal depth (using hcal towers behind clusters)
+        std::array<float, 7>
+            hcalOverEcal;  // run3 hcal over ecal seed cluster energy per depth (using rechits within a cone)
+        std::array<float, 7>
+            hcalOverEcalBc;  // run3 hcal over ecal seed cluster energy per depth (using rechits behind clusters)
+        std::vector<CaloTowerDetId> hcalTowersBehindClusters;
+        bool invalidHcal;  // set to true if the hcal energy estimate is not valid (e.g. the corresponding tower was off or masked)
+        bool pre7DepthHcal;  // to work around an ioread rule issue on legacy RECO files
+        float sigmaIetaIphi;
+        float eMax;
+        float e2nd;
+        float eTop;
+        float eLeft;
+        float eRight;
+        float eBottom;
+        float e2x5Top;
+        float e2x5Left;
+        float e2x5Right;
+        float e2x5Bottom;
+        ShowerShape()
+            : sigmaEtaEta(std::numeric_limits<float>::max()),
+              sigmaIetaIeta(std::numeric_limits<float>::max()),
+              sigmaIphiIphi(std::numeric_limits<float>::max()),
+              e1x5(0.f),
+              e2x5Max(0.f),
+              e5x5(0.f),
+              r9(-std::numeric_limits<float>::max()),
+              hcalDepth1OverEcal(0.f),
+              hcalDepth2OverEcal(0.f),
+              hcalDepth1OverEcalBc(0.f),
+              hcalDepth2OverEcalBc(0.f),
+              hcalOverEcal{{0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}},
+              hcalOverEcalBc{{0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}},
+              invalidHcal(false),
+              pre7DepthHcal(true),
+              sigmaIetaIphi(0.f),
+              eMax(0.f),
+              e2nd(0.f),
+              eTop(0.f),
+              eLeft(0.f),
+              eRight(0.f),
+              eBottom(0.f),
+              e2x5Top(0.f),
+              e2x5Left(0.f),
+              e2x5Right(0.f),
+              e2x5Bottom(0.f) {}
+      };
+
+      // accessors
+      float sigmaEtaEta() const { return showerShape_.sigmaEtaEta; }
+      float sigmaIetaIeta() const { return showerShape_.sigmaIetaIeta; }
+      float sigmaIphiIphi() const { return showerShape_.sigmaIphiIphi; }
+      float e1x5() const { return showerShape_.e1x5; }
+      float e2x5Max() const { return showerShape_.e2x5Max; }
+      float e5x5() const { return showerShape_.e5x5; }
+      float r9() const { return showerShape_.r9; }
+      float hcalOverEcal(const ShowerShape &ss, int depth) const {
+        if (ss.pre7DepthHcal) {
+          if (depth == 0)
+            return ss.hcalDepth1OverEcal + ss.hcalDepth2OverEcal;
+          else if (depth == 1)
+            return ss.hcalDepth1OverEcal;
+          else if (depth == 2)
+            return ss.hcalDepth2OverEcal;
+
+          return 0.f;
+        } else {
+          const auto &hovere = ss.hcalOverEcal;
+          return (!(depth > 0 and depth < 8)) ? std::accumulate(std::begin(hovere), std::end(hovere), 0.f)
+                                              : hovere[depth - 1];
+        }
+      }
+      float hcalOverEcal(int depth = 0) const { return hcalOverEcal(showerShape_, depth); }
+      float hcalOverEcalBc(const ShowerShape &ss, int depth) const {
+        if (ss.pre7DepthHcal) {
+          if (depth == 0)
+            return ss.hcalDepth1OverEcalBc + ss.hcalDepth2OverEcalBc;
+          else if (depth == 1)
+            return ss.hcalDepth1OverEcalBc;
+          else if (depth == 2)
+            return ss.hcalDepth2OverEcalBc;
+
+          return 0.f;
+        } else {
+          const auto &hovere = ss.hcalOverEcalBc;
+          return (!(depth > 0 and depth < 8)) ? std::accumulate(std::begin(hovere), std::end(hovere), 0.f)
+                                              : hovere[depth - 1];
+        }
+      }
+      float hcalOverEcalBc(int depth = 0) const { return hcalOverEcalBc(showerShape_, depth); }
+      const std::vector<CaloTowerDetId> &hcalTowersBehindClusters() const {
+        return showerShape_.hcalTowersBehindClusters;
+      }
+      bool hcalOverEcalValid() const { return !showerShape_.invalidHcal; }
+      float eLeft() const { return showerShape_.eLeft; }
+      float eRight() const { return showerShape_.eRight; }
+      float eTop() const { return showerShape_.eTop; }
+      float eBottom() const { return showerShape_.eBottom; }
+      const ShowerShape &showerShape() const { return showerShape_; }
+      // non-zero-suppressed and no-fractions shower shapes
+      // ecal energy is always that from the full 5x5
+      float full5x5_sigmaEtaEta() const { return full5x5_showerShape_.sigmaEtaEta; }
+      float full5x5_sigmaIetaIeta() const { return full5x5_showerShape_.sigmaIetaIeta; }
+      float full5x5_sigmaIphiIphi() const { return full5x5_showerShape_.sigmaIphiIphi; }
+      float full5x5_e1x5() const { return full5x5_showerShape_.e1x5; }
+      float full5x5_e2x5Max() const { return full5x5_showerShape_.e2x5Max; }
+      float full5x5_e5x5() const { return full5x5_showerShape_.e5x5; }
+      float full5x5_r9() const { return full5x5_showerShape_.r9; }
+      float full5x5_hcalOverEcal(int depth = 0) const { return hcalOverEcal(full5x5_showerShape_, depth); }
+      float full5x5_hcalOverEcalBc(int depth = 0) const { return hcalOverEcalBc(full5x5_showerShape_, depth); }
+      bool full5x5_hcalOverEcalValid() const { return !full5x5_showerShape_.invalidHcal; }
+      float full5x5_e2x5Left() const { return full5x5_showerShape_.e2x5Left; }
+      float full5x5_e2x5Right() const { return full5x5_showerShape_.e2x5Right; }
+      float full5x5_e2x5Top() const { return full5x5_showerShape_.e2x5Top; }
+      float full5x5_e2x5Bottom() const { return full5x5_showerShape_.e2x5Bottom; }
+      float full5x5_eLeft() const { return full5x5_showerShape_.eLeft; }
+      float full5x5_eRight() const { return full5x5_showerShape_.eRight; }
+      float full5x5_eTop() const { return full5x5_showerShape_.eTop; }
+      float full5x5_eBottom() const { return full5x5_showerShape_.eBottom; }
+      const ShowerShape &full5x5_showerShape() const { return full5x5_showerShape_; }
+
+      // setters (if you know what you're doing)
+      void setShowerShape(const ShowerShape &s) { showerShape_ = s; }
+      void full5x5_setShowerShape(const ShowerShape &s) { full5x5_showerShape_ = s; }
+
+      // for backward compatibility (this will only ever be the ZS shapes!)
+      float scSigmaEtaEta() const { return sigmaEtaEta(); }
+      float scSigmaIEtaIEta() const { return sigmaIetaIeta(); }
+      float scE1x5() const { return e1x5(); }
+      float scE2x5Max() const { return e2x5Max(); }
+      float scE5x5() const { return e5x5(); }
+      float hadronicOverEm() const { return hcalOverEcal(); }
+
+    private:
+      // attributes
+      ShowerShape showerShape_;
+      ShowerShape full5x5_showerShape_;
+
+      //=======================================================
+      // SaturationInfo
+      //=======================================================
+
+    public:
+      struct SaturationInfo {
+        int nSaturatedXtals;
+        bool isSeedSaturated;
+        SaturationInfo() : nSaturatedXtals(0), isSeedSaturated(false) {}
+      };
+
+      // accessors
+      float nSaturatedXtals() const { return saturationInfo_.nSaturatedXtals; }
+      float isSeedSaturated() const { return saturationInfo_.isSeedSaturated; }
+      const SaturationInfo &saturationInfo() const { return saturationInfo_; }
+      void setSaturationInfo(const SaturationInfo &s) { saturationInfo_ = s; }
+
+    private:
+      SaturationInfo saturationInfo_;
+
+      //=======================================================
+      // Isolation Variables
+      //=======================================================
+
+    public:
+      struct IsolationVariables {
+        float tkSumPt;                           // track iso with electron footprint removed
+        float tkSumPtHEEP;                       // track iso used for the HEEP ID
+        float ecalRecHitSumEt;                   // ecal iso deposit with electron footprint removed
+        float hcalDepth1TowerSumEt;              // hcal depth 1 iso deposit with electron footprint removed
+        float hcalDepth2TowerSumEt;              // hcal depth 2 iso deposit with electron footprint removed
+        float hcalDepth1TowerSumEtBc;            // hcal depth 1 iso deposit without towers behind clusters
+        float hcalDepth2TowerSumEtBc;            // hcal depth 2 iso deposit without towers behind clusters
+        std::array<float, 7> hcalRecHitSumEt;    // ...per depth, with electron footprint removed
+        std::array<float, 7> hcalRecHitSumEtBc;  // ...per depth, with hcal rechit behind cluster removed
+        bool pre7DepthHcal;                      // to work around an ioread rule issue on legacy RECO files
+        IsolationVariables()
+            : tkSumPt(0.),
+              tkSumPtHEEP(0.),
+              ecalRecHitSumEt(0.),
+              hcalDepth1TowerSumEt(0.f),
+              hcalDepth2TowerSumEt(0.f),
+              hcalDepth1TowerSumEtBc(0.f),
+              hcalDepth2TowerSumEtBc(0.f),
+              hcalRecHitSumEt{{0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}},
+              hcalRecHitSumEtBc{{0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}},
+              pre7DepthHcal(true) {}
+      };
+
+      // 03 accessors
+      float dr03TkSumPt() const { return dr03_.tkSumPt; }
+      float dr03TkSumPtHEEP() const { return dr03_.tkSumPtHEEP; }
+      float dr03EcalRecHitSumEt() const { return dr03_.ecalRecHitSumEt; }
+      float hcalTowerSumEt(const IsolationVariables &iv, int depth) const {
+        if (iv.pre7DepthHcal) {
+          if (depth == 0)
+            return iv.hcalDepth1TowerSumEt + iv.hcalDepth2TowerSumEt;
+          else if (depth == 1)
+            return iv.hcalDepth1TowerSumEt;
+          else if (depth == 2)
+            return iv.hcalDepth2TowerSumEt;
+
+          return 0.f;
+        } else {
+          const auto &hcaliso = iv.hcalRecHitSumEt;
+          return (!(depth > 0 and depth < 8)) ? std::accumulate(std::begin(hcaliso), std::end(hcaliso), 0.f)
+                                              : hcaliso[depth - 1];
+        }
+      }
+      float dr03HcalTowerSumEt(int depth = 0) const { return hcalTowerSumEt(dr03_, depth); }
+      float hcalTowerSumEtBc(const IsolationVariables &iv, int depth) const {
+        if (iv.pre7DepthHcal) {
+          if (depth == 0)
+            return iv.hcalDepth1TowerSumEtBc + iv.hcalDepth2TowerSumEtBc;
+          else if (depth == 1)
+            return iv.hcalDepth1TowerSumEtBc;
+          else if (depth == 2)
+            return iv.hcalDepth2TowerSumEtBc;
+
+          return 0.f;
+        } else {
+          const auto &hcaliso = iv.hcalRecHitSumEtBc;
+          return (!(depth > 0 and depth < 8)) ? std::accumulate(std::begin(hcaliso), std::end(hcaliso), 0.f)
+                                              : hcaliso[depth - 1];
+        }
+      }
+      float dr03HcalTowerSumEtBc(int depth = 0) const { return hcalTowerSumEtBc(dr03_, depth); }
+      const IsolationVariables &dr03IsolationVariables() const { return dr03_; }
+
+      // 04 accessors
+      float dr04TkSumPt() const { return dr04_.tkSumPt; }
+      float dr04TkSumPtHEEP() const { return dr04_.tkSumPtHEEP; }
+      float dr04EcalRecHitSumEt() const { return dr04_.ecalRecHitSumEt; }
+      float dr04HcalTowerSumEt(int depth = 0) const { return hcalTowerSumEt(dr04_, depth); }
+      float dr04HcalTowerSumEtBc(int depth = 0) const { return hcalTowerSumEtBc(dr04_, depth); }
+      const IsolationVariables &dr04IsolationVariables() const { return dr04_; }
+
+      // setters ?!?
+      void setDr03Isolation(const IsolationVariables &dr03) { dr03_ = dr03; }
+      void setDr04Isolation(const IsolationVariables &dr04) { dr04_ = dr04; }
+
+      // for backward compatibility
+      void setIsolation03(const IsolationVariables &dr03) { dr03_ = dr03; }
+      void setIsolation04(const IsolationVariables &dr04) { dr04_ = dr04; }
+      const IsolationVariables &isolationVariables03() const { return dr03_; }
+      const IsolationVariables &isolationVariables04() const { return dr04_; }
+
+      // go back to run2-like 2 effective depths if desired - depth 1 is the normal depth 1, depth 2 is the sum over the rest
+      void hcalToRun2EffDepth();
+
+    private:
+      // attributes
+      IsolationVariables dr03_;
+      IsolationVariables dr04_;
+
+      //=======================================================
+      // Conversion Rejection Information
+      //=======================================================
+
+    public:
+      struct ConversionRejection {
+        int flags;             // -max:not-computed, other: as computed by Puneeth conversion code
+        TrackBaseRef partner;  // conversion partner
+        float dist;            // distance to the conversion partner
+        float dcot;            // difference of cot(angle) with the conversion partner track
+        float radius;          // signed conversion radius
+        float vtxFitProb;      //fit probablity (chi2/ndof) of the matched conversion vtx
+        ConversionRejection()
+            : flags(-1),
+              dist(std::numeric_limits<float>::max()),
+              dcot(std::numeric_limits<float>::max()),
+              radius(std::numeric_limits<float>::max()),
+              vtxFitProb(std::numeric_limits<float>::max()) {}
+      };
+
+      // accessors
+      int convFlags() const { return conversionRejection_.flags; }
+      TrackBaseRef convPartner() const { return conversionRejection_.partner; }
+      float convDist() const { return conversionRejection_.dist; }
+      float convDcot() const { return conversionRejection_.dcot; }
+      float convRadius() const { return conversionRejection_.radius; }
+      float convVtxFitProb() const { return conversionRejection_.vtxFitProb; }
+      const ConversionRejection &conversionRejectionVariables() const { return conversionRejection_; }
+      void setConversionRejectionVariables(const ConversionRejection &convRej) { conversionRejection_ = convRej; }
+
+    private:
+      // attributes
+      ConversionRejection conversionRejection_;
+
+      //=======================================================
+      // Pflow Information
+      //=======================================================
+
+    public:
+      struct PflowIsolationVariables {
+        //first three data members that changed names, according to DataFormats/MuonReco/interface/MuonPFIsolation.h
+        float sumChargedHadronPt;  //!< sum-pt of charged Hadron    // old float chargedHadronIso ;
+        float sumNeutralHadronEt;  //!< sum pt of neutral hadrons  // old float neutralHadronIso ;
+        float sumPhotonEt;         //!< sum pt of PF photons              // old float photonIso ;
+        //then four new data members, corresponding to DataFormats/MuonReco/interface/MuonPFIsolation.h
+        float sumChargedParticlePt;             //!< sum-pt of charged Particles(inludes e/mu)
+        float sumNeutralHadronEtHighThreshold;  //!< sum pt of neutral hadrons with a higher threshold
+        float sumPhotonEtHighThreshold;         //!< sum pt of PF photons with a higher threshold
+        float sumPUPt;                          //!< sum pt of charged Particles not from PV  (for Pu corrections)
+        //new pf cluster based isolation values
+        float sumEcalClusterEt;  //sum pt of ecal clusters, vetoing clusters part of electron
+        float sumHcalClusterEt;  //sum pt of hcal clusters, vetoing clusters part of electron
+        PflowIsolationVariables()
+            : sumChargedHadronPt(0),
+              sumNeutralHadronEt(0),
+              sumPhotonEt(0),
+              sumChargedParticlePt(0),
+              sumNeutralHadronEtHighThreshold(0),
+              sumPhotonEtHighThreshold(0),
+              sumPUPt(0),
+              sumEcalClusterEt(0),
+              sumHcalClusterEt(0) {}
+      };
+
+      struct MvaInput {
+        int earlyBrem;                // Early Brem detected (-2=>unknown,-1=>could not be evaluated,0=>wrong,1=>true)
+        int lateBrem;                 // Late Brem detected (-2=>unknown,-1=>could not be evaluated,0=>wrong,1=>true)
+        float sigmaEtaEta;            // Sigma-eta-eta with the PF cluster
+        float hadEnergy;              // Associated PF Had Cluster energy
+        float deltaEta;               // PF-cluster GSF track delta-eta
+        int nClusterOutsideMustache;  // -2 => unknown, -1 =>could not be evaluated, 0 and more => number of clusters
+        float etOutsideMustache;
+        MvaInput()
+            : earlyBrem(-2),
+              lateBrem(-2),
+              sigmaEtaEta(std::numeric_limits<float>::max()),
+              hadEnergy(0.),
+              deltaEta(std::numeric_limits<float>::max()),
+              nClusterOutsideMustache(-2),
+              etOutsideMustache(-std::numeric_limits<float>::max()) {}
+      };
+
+      static constexpr float mvaPlaceholder = -999999999.;
+
+      struct MvaOutput {
+        int status;  // see PFCandidateElectronExtra::StatusFlag
+        float mva_Isolated;
+        float mva_e_pi;
+        float mvaByPassForIsolated;  // complementary MVA used in preselection
+        float dnn_e_sigIsolated;
+        float dnn_e_sigNonIsolated;
+        float dnn_e_bkgNonIsolated;
+        float dnn_e_bkgTau;
+        float dnn_e_bkgPhoton;
+        MvaOutput()
+            : status(-1),
+              mva_Isolated(mvaPlaceholder),
+              mva_e_pi(mvaPlaceholder),
+              mvaByPassForIsolated(mvaPlaceholder),
+              dnn_e_sigIsolated(mvaPlaceholder),
+              dnn_e_sigNonIsolated(mvaPlaceholder),
+              dnn_e_bkgNonIsolated(mvaPlaceholder),
+              dnn_e_bkgTau(mvaPlaceholder),
+              dnn_e_bkgPhoton(mvaPlaceholder) {}
+      };
+
+      // accessors
+      const PflowIsolationVariables &pfIsolationVariables() const { return pfIso_; }
+      //backwards compat functions for pat::Electron
+      float ecalPFClusterIso() const { return pfIso_.sumEcalClusterEt; };
+      float hcalPFClusterIso() const { return pfIso_.sumHcalClusterEt; };
+
+      const MvaInput &mvaInput() const { return mvaInput_; }
+      const MvaOutput &mvaOutput() const { return mvaOutput_; }
+
+      // setters
+      void setPfIsolationVariables(const PflowIsolationVariables &iso) { pfIso_ = iso; }
+      void setMvaInput(const MvaInput &mi) { mvaInput_ = mi; }
+      void setMvaOutput(const MvaOutput &mo) { mvaOutput_ = mo; }
+
+      // for backward compatibility
+      float mva_Isolated() const { return mvaOutput_.mva_Isolated; }
+      float mva_e_pi() const { return mvaOutput_.mva_e_pi; }
+      float dnn_signal_Isolated() const { return mvaOutput_.dnn_e_sigIsolated; }
+      float dnn_signal_nonIsolated() const { return mvaOutput_.dnn_e_sigNonIsolated; }
+      float dnn_bkg_nonIsolated() const { return mvaOutput_.dnn_e_bkgNonIsolated; }
+      float dnn_bkg_Tau() const { return mvaOutput_.dnn_e_bkgTau; }
+      float dnn_bkg_Photon() const { return mvaOutput_.dnn_e_bkgPhoton; }
+
+    private:
+      PflowIsolationVariables pfIso_;
+      MvaInput mvaInput_;
+      MvaOutput mvaOutput_;
+
+      //=======================================================
+      // Preselection and Ambiguity
+      //=======================================================
+
+    public:
+      // accessors
+      bool ecalDriven() const;  // return true if ecalDrivenSeed() and passingCutBasedPreselection()
+      bool passingCutBasedPreselection() const { return passCutBasedPreselection_; }
+      bool passingPflowPreselection() const { return passPflowPreselection_; }
+      bool ambiguous() const { return ambiguous_; }
+      GsfTrackRefVector::size_type ambiguousGsfTracksSize() const { return ambiguousGsfTracks_.size(); }
+      auto const &ambiguousGsfTracks() const { return ambiguousGsfTracks_; }
+
+      // setters
+      void setPassCutBasedPreselection(bool flag) { passCutBasedPreselection_ = flag; }
+      void setPassPflowPreselection(bool flag) { passPflowPreselection_ = flag; }
+      void setAmbiguous(bool flag) { ambiguous_ = flag; }
+      void clearAmbiguousGsfTracks() { ambiguousGsfTracks_.clear(); }
+      void addAmbiguousGsfTrack(const reco::GsfTrackRef &t) { ambiguousGsfTracks_.push_back(t); }
+
+      // backward compatibility
+      void setPassMvaPreselection(bool flag) { passMvaPreslection_ = flag; }
+      bool passingMvaPreselection() const { return passMvaPreslection_; }
+
+    private:
+      // attributes
+      bool passCutBasedPreselection_;
+      bool passPflowPreselection_;
+      bool passMvaPreslection_;  // to be removed : passPflowPreslection_
+      bool ambiguous_;
+      GsfTrackRefVector ambiguousGsfTracks_;  // ambiguous gsf tracks
+
+      //=======================================================
+      // Brem Fractions and Classification
+      //=======================================================
+
+    public:
+      struct ClassificationVariables {
+        float trackFbrem;  // the brem fraction from gsf fit: (track momentum in - track momentum out) / track momentum in
+        float superClusterFbrem;  // the brem fraction from supercluster: (supercluster energy - electron cluster energy) / supercluster energy
+        constexpr static float kDefaultValue = -1.e30;
+        ClassificationVariables() : trackFbrem(kDefaultValue), superClusterFbrem(kDefaultValue) {}
+      };
+      enum Classification { UNKNOWN = -1, GOLDEN = 0, BIGBREM = 1, BADTRACK = 2, SHOWERING = 3, GAP = 4 };
+
+      // accessors
+      float trackFbrem() const { return classVariables_.trackFbrem; }
+      float superClusterFbrem() const { return classVariables_.superClusterFbrem; }
+      const ClassificationVariables &classificationVariables() const { return classVariables_; }
+      Classification classification() const { return class_; }
+
+      // utilities
+      int numberOfBrems() const { return basicClustersSize() - 1; }
+      float fbrem() const { return trackFbrem(); }
+
+      // setters
+      void setTrackFbrem(float fbrem) { classVariables_.trackFbrem = fbrem; }
+      void setSuperClusterFbrem(float fbrem) { classVariables_.superClusterFbrem = fbrem; }
+      void setClassificationVariables(const ClassificationVariables &cv) { classVariables_ = cv; }
+      void setClassification(Classification myclass) { class_ = myclass; }
+
+    private:
+      // attributes
+      ClassificationVariables classVariables_;
+      Classification class_;  // fbrem and number of clusters based electron classification
+
+      //=======================================================
+      // Corrections
+      //
+      // The only methods, with classification, which modify
+      // the electrons after they have been constructed.
+      // They change a given characteristic, such as the super-cluster
+      // energy, and propagate the change consistently
+      // to all the depending attributes.
+      // We expect the methods to be called in a given order
+      // and so to store specific kind of corrections
+      // 1) classify()
+      // 2) correctEcalEnergy() : depending on classification and eta
+      // 3) correctMomemtum() : depending on classification and ecal energy and tracker momentum errors
+      //
+      // Beware that correctEcalEnergy() is modifying few attributes which
+      // were potentially used for preselection, whose value used in
+      // preselection will not be available any more :
+      // hcalOverEcal, eSuperClusterOverP,
+      // eSeedClusterOverP, eEleClusterOverPout.
+      //=======================================================
+
+    public:
+      enum P4Kind { P4_UNKNOWN = -1, P4_FROM_SUPER_CLUSTER = 0, P4_COMBINATION = 1, P4_PFLOW_COMBINATION = 2 };
+
+      struct Corrections {
+        bool isEcalEnergyCorrected;  // true if ecal energy has been corrected
+        float correctedEcalEnergy;  // corrected energy (if !isEcalEnergyCorrected this value is identical to the supercluster energy)
+        float correctedEcalEnergyError;  // error on energy
+        //bool isMomentumCorrected ;     // DEPRECATED
+        float trackMomentumError;  // track momentum error from gsf fit
+        //
+        LorentzVector fromSuperClusterP4;  // for P4_FROM_SUPER_CLUSTER
+        float fromSuperClusterP4Error;     // for P4_FROM_SUPER_CLUSTER
+        LorentzVector combinedP4;          // for P4_COMBINATION
+        float combinedP4Error;             // for P4_COMBINATION
+        LorentzVector pflowP4;             // for P4_PFLOW_COMBINATION
+        float pflowP4Error;                // for P4_PFLOW_COMBINATION
+        P4Kind candidateP4Kind;            // say which momentum has been stored in reco::Candidate
+        //
+        Corrections()
+            : isEcalEnergyCorrected(false),
+              correctedEcalEnergy(0.),
+              correctedEcalEnergyError(999.),
+              /*isMomentumCorrected(false),*/ trackMomentumError(999.),
+              fromSuperClusterP4Error(999.),
+              combinedP4Error(999.),
+              pflowP4Error(999.),
+              candidateP4Kind(P4_UNKNOWN) {}
+      };
+
+      // setters
+      void setCorrectedEcalEnergyError(float newEnergyError);
+      void setCorrectedEcalEnergy(float newEnergy);
+      void setCorrectedEcalEnergy(float newEnergy, bool rescaleDependentValues);
+      void setTrackMomentumError(float trackMomentumError);
+      void setP4(P4Kind kind, const LorentzVector &p4, float p4Error, bool setCandidate);
+      using RecoCandidate::setP4;
+
+      // accessors
+      bool isEcalEnergyCorrected() const { return corrections_.isEcalEnergyCorrected; }
+      float correctedEcalEnergy() const { return corrections_.correctedEcalEnergy; }
+      float correctedEcalEnergyError() const { return corrections_.correctedEcalEnergyError; }
+      float trackMomentumError() const { return corrections_.trackMomentumError; }
+      const LorentzVector &p4(P4Kind kind) const;
+      using RecoCandidate::p4;
+      float p4Error(P4Kind kind) const;
+      P4Kind candidateP4Kind() const { return corrections_.candidateP4Kind; }
+      const Corrections &corrections() const { return corrections_; }
+
+      // bare setter (if you know what you're doing)
+      void setCorrections(const Corrections &c) { corrections_ = c; }
+
+      // for backward compatibility
+      void setEcalEnergyError(float energyError) { setCorrectedEcalEnergyError(energyError); }
+      float ecalEnergy() const { return correctedEcalEnergy(); }
+      float ecalEnergyError() const { return correctedEcalEnergyError(); }
+      //bool isMomentumCorrected() const { return corrections_.isMomentumCorrected ; }
+      float caloEnergy() const { return correctedEcalEnergy(); }
+      bool isEnergyScaleCorrected() const { return isEcalEnergyCorrected(); }
+      void correctEcalEnergy(float newEnergy, float newEnergyError, bool corrEovP = true) {
+        setCorrectedEcalEnergy(newEnergy, corrEovP);
+        setEcalEnergyError(newEnergyError);
+      }
+      void correctMomentum(const LorentzVector &p4, float trackMomentumError, float p4Error) {
+        setTrackMomentumError(trackMomentumError);
+        setP4(P4_COMBINATION, p4, p4Error, true);
+      }
+
+    private:
+      // attributes
+      Corrections corrections_;
+
+    public:
+      struct PixelMatchVariables {
+        //! Pixel match variable: deltaPhi for innermost hit
+        float dPhi1;
+        //! Pixel match variable: deltaPhi for second hit
+        float dPhi2;
+        //! Pixel match variable: deltaRz for innermost hit
+        float dRz1;
+        //! Pixel match variable: deltaRz for second hit
+        float dRz2;
+        //! Subdetectors for first and second pixel hit
+        unsigned char subdetectors;
+        PixelMatchVariables() : dPhi1(-999), dPhi2(-999), dRz1(-999), dRz2(-999), subdetectors(0) {}
+        ~PixelMatchVariables() {}
+      };
+      void setPixelMatchSubdetectors(int sd1, int sd2) { pixelMatchVariables_.subdetectors = 10 * sd1 + sd2; }
+      void setPixelMatchDPhi1(float dPhi1) { pixelMatchVariables_.dPhi1 = dPhi1; }
+      void setPixelMatchDPhi2(float dPhi2) { pixelMatchVariables_.dPhi2 = dPhi2; }
+      void setPixelMatchDRz1(float dRz1) { pixelMatchVariables_.dRz1 = dRz1; }
+      void setPixelMatchDRz2(float dRz2) { pixelMatchVariables_.dRz2 = dRz2; }
+
+      int pixelMatchSubdetector1() const { return pixelMatchVariables_.subdetectors / 10; }
+      int pixelMatchSubdetector2() const { return pixelMatchVariables_.subdetectors % 10; }
+      float pixelMatchDPhi1() const { return pixelMatchVariables_.dPhi1; }
+      float pixelMatchDPhi2() const { return pixelMatchVariables_.dPhi2; }
+      float pixelMatchDRz1() const { return pixelMatchVariables_.dRz1; }
+      float pixelMatchDRz2() const { return pixelMatchVariables_.dRz2; }
+
+    private:
+      PixelMatchVariables pixelMatchVariables_;
     };
 
-    // setters
-    void setCorrectedEcalEnergyError(float newEnergyError);
-    void setCorrectedEcalEnergy(float newEnergy);
-    void setCorrectedEcalEnergy(float newEnergy, bool rescaleDependentValues);
-    void setTrackMomentumError(float trackMomentumError);
-    void setP4(P4Kind kind, const LorentzVector &p4, float p4Error, bool setCandidate);
-    using RecoCandidate::setP4;
-
-    // accessors
-    bool isEcalEnergyCorrected() const { return corrections_.isEcalEnergyCorrected; }
-    float correctedEcalEnergy() const { return corrections_.correctedEcalEnergy; }
-    float correctedEcalEnergyError() const { return corrections_.correctedEcalEnergyError; }
-    float trackMomentumError() const { return corrections_.trackMomentumError; }
-    const LorentzVector &p4(P4Kind kind) const;
-    using RecoCandidate::p4;
-    float p4Error(P4Kind kind) const;
-    P4Kind candidateP4Kind() const { return corrections_.candidateP4Kind; }
-    const Corrections &corrections() const { return corrections_; }
-
-    // bare setter (if you know what you're doing)
-    void setCorrections(const Corrections &c) { corrections_ = c; }
-
-    // for backward compatibility
-    void setEcalEnergyError(float energyError) { setCorrectedEcalEnergyError(energyError); }
-    float ecalEnergy() const { return correctedEcalEnergy(); }
-    float ecalEnergyError() const { return correctedEcalEnergyError(); }
-    //bool isMomentumCorrected() const { return corrections_.isMomentumCorrected ; }
-    float caloEnergy() const { return correctedEcalEnergy(); }
-    bool isEnergyScaleCorrected() const { return isEcalEnergyCorrected(); }
-    void correctEcalEnergy(float newEnergy, float newEnergyError, bool corrEovP = true) {
-      setCorrectedEcalEnergy(newEnergy, corrEovP);
-      setEcalEnergyError(newEnergyError);
-    }
-    void correctMomentum(const LorentzVector &p4, float trackMomentumError, float p4Error) {
-      setTrackMomentumError(trackMomentumError);
-      setP4(P4_COMBINATION, p4, p4Error, true);
-    }
-
-  private:
-    // attributes
-    Corrections corrections_;
-
-  public:
-    struct PixelMatchVariables {
-      //! Pixel match variable: deltaPhi for innermost hit
-      float dPhi1;
-      //! Pixel match variable: deltaPhi for second hit
-      float dPhi2;
-      //! Pixel match variable: deltaRz for innermost hit
-      float dRz1;
-      //! Pixel match variable: deltaRz for second hit
-      float dRz2;
-      //! Subdetectors for first and second pixel hit
-      unsigned char subdetectors;
-      PixelMatchVariables() : dPhi1(-999), dPhi2(-999), dRz1(-999), dRz2(-999), subdetectors(0) {}
-      ~PixelMatchVariables() {}
-    };
-    void setPixelMatchSubdetectors(int sd1, int sd2) { pixelMatchVariables_.subdetectors = 10 * sd1 + sd2; }
-    void setPixelMatchDPhi1(float dPhi1) { pixelMatchVariables_.dPhi1 = dPhi1; }
-    void setPixelMatchDPhi2(float dPhi2) { pixelMatchVariables_.dPhi2 = dPhi2; }
-    void setPixelMatchDRz1(float dRz1) { pixelMatchVariables_.dRz1 = dRz1; }
-    void setPixelMatchDRz2(float dRz2) { pixelMatchVariables_.dRz2 = dRz2; }
-
-    int pixelMatchSubdetector1() const { return pixelMatchVariables_.subdetectors / 10; }
-    int pixelMatchSubdetector2() const { return pixelMatchVariables_.subdetectors % 10; }
-    float pixelMatchDPhi1() const { return pixelMatchVariables_.dPhi1; }
-    float pixelMatchDPhi2() const { return pixelMatchVariables_.dPhi2; }
-    float pixelMatchDRz1() const { return pixelMatchVariables_.dRz1; }
-    float pixelMatchDRz2() const { return pixelMatchVariables_.dRz2; }
-
-  private:
-    PixelMatchVariables pixelMatchVariables_;
-  };
+  }  // namespace io_v1
+  using GsfElectron = io_v1::GsfElectron;
 
 }  // namespace reco
 

--- a/DataFormats/EgammaCandidates/interface/GsfElectronCore.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectronCore.h
@@ -21,71 +21,74 @@
  ****************************************************************************/
 
 namespace reco {
+  namespace io_v1 {
 
-  class GsfElectronCore {
-  public:
-    // construction
-    GsfElectronCore();
-    GsfElectronCore(const GsfTrackRef&);
-    GsfElectronCore* clone() const;
-    ~GsfElectronCore() {}
+    class GsfElectronCore {
+    public:
+      // construction
+      GsfElectronCore();
+      GsfElectronCore(const GsfTrackRef&);
+      GsfElectronCore* clone() const;
+      ~GsfElectronCore() {}
 
-    // accessors
-    const GsfTrackRef& gsfTrack() const { return gsfTrack_; }
-    const SuperClusterRef& superCluster() const {
-      return (superCluster_.isNull() ? parentSuperCluster_ : superCluster_);
-    }
-    TrackRef ctfTrack() const {
-      return closestCtfTrack_;
-    }  // get the CTF track best matching the GTF associated to this electron
-    float ctfGsfOverlap() const {
-      return ctfGsfOverlap_;
-    }  // measure the fraction of common hits between the GSF and CTF tracks
-    bool ecalDrivenSeed() const { return isEcalDrivenSeed_; }
-    bool trackerDrivenSeed() const { return isTrackerDrivenSeed_; }
+      // accessors
+      const GsfTrackRef& gsfTrack() const { return gsfTrack_; }
+      const SuperClusterRef& superCluster() const {
+        return (superCluster_.isNull() ? parentSuperCluster_ : superCluster_);
+      }
+      TrackRef ctfTrack() const {
+        return closestCtfTrack_;
+      }  // get the CTF track best matching the GTF associated to this electron
+      float ctfGsfOverlap() const {
+        return ctfGsfOverlap_;
+      }  // measure the fraction of common hits between the GSF and CTF tracks
+      bool ecalDrivenSeed() const { return isEcalDrivenSeed_; }
+      bool trackerDrivenSeed() const { return isTrackerDrivenSeed_; }
 
-    /// get vector of references to  Conversion's
-    reco::ConversionRefVector conversions() const { return conversions_; }
-    /// get vector of references to one leg Conversion's
-    reco::ConversionRefVector conversionsOneLeg() const { return conversionsOneLeg_; }
+      /// get vector of references to  Conversion's
+      reco::ConversionRefVector conversions() const { return conversions_; }
+      /// get vector of references to one leg Conversion's
+      reco::ConversionRefVector conversionsOneLeg() const { return conversionsOneLeg_; }
 
-    // setters
-    void setGsfTrack(const GsfTrackRef& gsfTrack) { gsfTrack_ = gsfTrack; }
-    void setSuperCluster(const SuperClusterRef& scl) { superCluster_ = scl; }
-    void setCtfTrack(const TrackRef& closestCtfTrack, float ctfGsfOverlap) {
-      closestCtfTrack_ = closestCtfTrack;
-      ctfGsfOverlap_ = ctfGsfOverlap;
-    }
+      // setters
+      void setGsfTrack(const GsfTrackRef& gsfTrack) { gsfTrack_ = gsfTrack; }
+      void setSuperCluster(const SuperClusterRef& scl) { superCluster_ = scl; }
+      void setCtfTrack(const TrackRef& closestCtfTrack, float ctfGsfOverlap) {
+        closestCtfTrack_ = closestCtfTrack;
+        ctfGsfOverlap_ = ctfGsfOverlap;
+      }
 
-    /// add  single ConversionRef to the vector of Refs
-    void addConversion(const reco::ConversionRef& r) { conversions_.push_back(r); }
-    /// add  single ConversionRef to the vector of Refs
-    void addOneLegConversion(const reco::ConversionRef& r) { conversionsOneLeg_.push_back(r); }
+      /// add  single ConversionRef to the vector of Refs
+      void addConversion(const reco::ConversionRef& r) { conversions_.push_back(r); }
+      /// add  single ConversionRef to the vector of Refs
+      void addOneLegConversion(const reco::ConversionRef& r) { conversionsOneLeg_.push_back(r); }
 
-    // pflow eventual additionnal info
-    const SuperClusterRef& parentSuperCluster() const { return parentSuperCluster_; }
-    void setParentSuperCluster(const SuperClusterRef& scl) { parentSuperCluster_ = scl; }
+      // pflow eventual additionnal info
+      const SuperClusterRef& parentSuperCluster() const { return parentSuperCluster_; }
+      void setParentSuperCluster(const SuperClusterRef& scl) { parentSuperCluster_ = scl; }
 
-  private:
-    GsfTrackRef gsfTrack_;
-    SuperClusterRef superCluster_;
-    SuperClusterRef parentSuperCluster_;
-    TrackRef closestCtfTrack_;  // best matching ctf track
-    // vector of references to Conversions
-    reco::ConversionRefVector conversions_;
-    //vector of references for 1-leg
-    reco::ConversionRefVector conversionsOneLeg_;
-    float ctfGsfOverlap_;  // fraction of common hits between the ctf and gsf tracks
-    bool isEcalDrivenSeed_;
-    bool isTrackerDrivenSeed_;
-  };
+    private:
+      GsfTrackRef gsfTrack_;
+      SuperClusterRef superCluster_;
+      SuperClusterRef parentSuperCluster_;
+      TrackRef closestCtfTrack_;  // best matching ctf track
+      // vector of references to Conversions
+      reco::ConversionRefVector conversions_;
+      //vector of references for 1-leg
+      reco::ConversionRefVector conversionsOneLeg_;
+      float ctfGsfOverlap_;  // fraction of common hits between the ctf and gsf tracks
+      bool isEcalDrivenSeed_;
+      bool isTrackerDrivenSeed_;
+    };
 
+  }  // namespace io_v1
+  using GsfElectronCore = io_v1::GsfElectronCore;
 }  // namespace reco
 
 //*****************************************************************************
 //
-// \author David Chamont  - Laboratoire Leprince-Ringuet - École polytechnique, CNRS/IN2P3
-// \author Claude Charlot - Laboratoire Leprince-Ringuet - École polytechnique, CNRS/IN2P3
+// \author David Chamont  - Laboratoire Leprince-Ringuet - ï¿½cole polytechnique, CNRS/IN2P3
+// \author Claude Charlot - Laboratoire Leprince-Ringuet - ï¿½cole polytechnique, CNRS/IN2P3
 //
 //
 // Revision 1.11.2.1  2011/03/04 18:22:31  chamont

--- a/DataFormats/EgammaCandidates/interface/GsfElectronCoreFwd.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectronCoreFwd.h
@@ -9,7 +9,10 @@
 
 namespace reco {
 
-  class GsfElectronCore;
+  namespace io_v1 {
+    class GsfElectronCore;
+  }
+  using GsfElectronCore = io_v1::GsfElectronCore;
   typedef std::vector<GsfElectronCore> GsfElectronCoreCollection;
   typedef edm::Ref<GsfElectronCoreCollection> GsfElectronCoreRef;
   typedef edm::RefProd<GsfElectronCoreCollection> GsfElectronCoreRefProd;

--- a/DataFormats/EgammaCandidates/interface/GsfElectronFwd.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectronFwd.h
@@ -10,9 +10,10 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 
 namespace reco {
-
-  class GsfElectron;
-
+  namespace io_v1 {
+    class GsfElectron;
+  }
+  using GsfElectron = io_v1::GsfElectron;
   /// collection of GsfElectron objects
   typedef std::vector<GsfElectron> GsfElectronCollection;
   //typedef GsfElectronCollection PixelMatchGsfElectronCollection ;

--- a/DataFormats/EgammaCandidates/interface/Photon.h
+++ b/DataFormats/EgammaCandidates/interface/Photon.h
@@ -18,602 +18,611 @@
 #include <numeric>
 
 namespace reco {
+  namespace io_v1 {
 
-  class Photon : public RecoCandidate {
-  public:
-    /// Forward declaration of data structures included in the object
-    struct FiducialFlags;
-    struct IsolationVariables;
-    struct ShowerShape;
-    struct MIPVariables;
-    struct SaturationInfo;
+    class Photon : public RecoCandidate {
+    public:
+      /// Forward declaration of data structures included in the object
+      struct FiducialFlags;
+      struct IsolationVariables;
+      struct ShowerShape;
+      struct MIPVariables;
+      struct SaturationInfo;
 
-    /// default constructor
-    Photon() : RecoCandidate() {
-      pixelSeed_ = false;
-      haloTaggerMVAVal_ = 99;
-    }
-
-    /// copy constructor
-    Photon(const Photon&);
-
-    /// constructor from values
-    Photon(const LorentzVector& p4, const Point& caloPos, const PhotonCoreRef& core, const Point& vtx = Point(0, 0, 0));
-
-    /// assignment operator
-    Photon& operator=(const Photon&) = default;
-
-    /// destructor
-    ~Photon() override;
-
-    /// returns a clone of the candidate
-    Photon* clone() const override;
-
-    /// returns a reference to the core photon object
-    reco::PhotonCoreRef photonCore() const { return photonCore_; }
-    void setPhotonCore(const reco::PhotonCoreRef& photonCore) { photonCore_ = photonCore; }
-
-    //
-    /// Retrieve photonCore attributes
-    //
-    // retrieve provenance
-    bool isPFlowPhoton() const { return this->photonCore()->isPFlowPhoton(); }
-    bool isStandardPhoton() const { return this->photonCore()->isStandardPhoton(); }
-    /// Ref to SuperCluster
-    reco::SuperClusterRef superCluster() const override;
-    /// Ref to PFlow SuperCluster
-    reco::SuperClusterRef parentSuperCluster() const { return this->photonCore()->parentSuperCluster(); }
-    /// vector of references to  Conversion's
-    reco::ConversionRefVector conversions() const { return this->photonCore()->conversions(); }
-    enum ConversionProvenance { egamma = 0, pflow = 1, both = 2 };
-
-    /// vector of references to  one leg Conversion's
-    reco::ConversionRefVector conversionsOneLeg() const { return this->photonCore()->conversionsOneLeg(); }
-    /// Bool flagging photons with a vector of refereces to conversions with size >0
-    bool hasConversionTracks() const {
-      if (!this->photonCore()->conversions().empty() || !this->photonCore()->conversionsOneLeg().empty())
-        return true;
-      else
-        return false;
-    }
-    /// reference to electron Pixel seed
-    reco::ElectronSeedRefVector electronPixelSeeds() const { return this->photonCore()->electronPixelSeeds(); }
-    /// Bool flagging photons having a non-zero size vector of Ref to electornPixel seeds
-    bool hasPixelSeed() const {
-      if (!(this->photonCore()->electronPixelSeeds()).empty())
-        return true;
-      else
-        return false;
-    }
-    int conversionTrackProvenance(const edm::RefToBase<reco::Track>& convTrack) const;
-
-    /// position in ECAL: this is th SC position if r9<0.93. If r8>0.93 is position of seed BasicCluster taking shower depth for unconverted photon
-    math::XYZPointF caloPosition() const { return caloPosition_; }
-    /// set primary event vertex used to define photon direction
-    void setVertex(const Point& vertex) override;
-    /// Implement Candidate method for particle species
-    bool isPhoton() const override { return true; }
-
-    //=======================================================
-    // Fiducial Flags
-    //=======================================================
-    struct FiducialFlags {
-      //Fiducial flags
-      bool isEB;         //Photon is in EB
-      bool isEE;         //Photon is in EE
-      bool isEBEtaGap;   //Photon is in supermodule/supercrystal eta gap in EB
-      bool isEBPhiGap;   //Photon is in supermodule/supercrystal phi gap in EB
-      bool isEERingGap;  //Photon is in crystal ring gap in EE
-      bool isEEDeeGap;   //Photon is in crystal dee gap in EE
-      bool isEBEEGap;    //Photon is in border between EB and EE.
-
-      FiducialFlags()
-          : isEB(false),
-            isEE(false),
-            isEBEtaGap(false),
-            isEBPhiGap(false),
-            isEERingGap(false),
-            isEEDeeGap(false),
-            isEBEEGap(false)
-
-      {}
-    };
-
-    /// set flags for photons in the ECAL fiducial volume
-    void setFiducialVolumeFlags(const FiducialFlags& a) { fiducialFlagBlock_ = a; }
-    /// Ritrievs fiducial flags
-    /// true if photon is in ECAL barrel
-    bool isEB() const { return fiducialFlagBlock_.isEB; }
-    // true if photon is in ECAL endcap
-    bool isEE() const { return fiducialFlagBlock_.isEE; }
-    /// true if photon is in EB, and inside the boundaries in super crystals/modules
-    bool isEBGap() const { return (isEBEtaGap() || isEBPhiGap()); }
-    bool isEBEtaGap() const { return fiducialFlagBlock_.isEBEtaGap; }
-    bool isEBPhiGap() const { return fiducialFlagBlock_.isEBPhiGap; }
-    /// true if photon is in EE, and inside the boundaries in supercrystal/D
-    bool isEEGap() const { return (isEERingGap() || isEEDeeGap()); }
-    bool isEERingGap() const { return fiducialFlagBlock_.isEERingGap; }
-    bool isEEDeeGap() const { return fiducialFlagBlock_.isEEDeeGap; }
-    /// true if photon is in boundary between EB and EE
-    bool isEBEEGap() const { return fiducialFlagBlock_.isEBEEGap; }
-
-    //=======================================================
-    // Shower Shape Variables
-    //=======================================================
-
-    struct ShowerShape {
-      float sigmaEtaEta;
-      float sigmaIetaIeta;
-      float e1x5;
-      float e2x5;
-      float e3x3;
-      float e5x5;
-      float maxEnergyXtal;
-      float hcalDepth1OverEcal;  // hcal over ecal energy using first hcal depth
-      float hcalDepth2OverEcal;  // hcal over ecal energy using 2nd hcal depth
-      float hcalDepth1OverEcalBc;
-      float hcalDepth2OverEcalBc;
-      std::array<float, 7> hcalOverEcal;  // hcal over ecal seed cluster energy per depth (using rechits within a cone)
-      std::array<float, 7>
-          hcalOverEcalBc;  // hcal over ecal seed cluster energy per depth (using rechits behind clusters)
-      std::vector<CaloTowerDetId> hcalTowersBehindClusters;
-      bool invalidHcal;
-      bool pre7DepthHcal;  // to work around an ioread rule issue on legacy RECO files
-      float effSigmaRR;
-      float sigmaIetaIphi;
-      float sigmaIphiIphi;
-      float e2nd;
-      float eTop;
-      float eLeft;
-      float eRight;
-      float eBottom;
-      float e1x3;
-      float e2x2;
-      float e2x5Max;
-      float e2x5Left;
-      float e2x5Right;
-      float e2x5Top;
-      float e2x5Bottom;
-      float smMajor;
-      float smMinor;
-      float smAlpha;
-      ShowerShape()
-          : sigmaEtaEta(std::numeric_limits<float>::max()),
-            sigmaIetaIeta(std::numeric_limits<float>::max()),
-            e1x5(0.f),
-            e2x5(0.f),
-            e3x3(0.f),
-            e5x5(0.f),
-            maxEnergyXtal(0.f),
-            hcalDepth1OverEcal(0.f),
-            hcalDepth2OverEcal(0.f),
-            hcalDepth1OverEcalBc(0.f),
-            hcalDepth2OverEcalBc(0.f),
-            hcalOverEcal{{0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}},
-            hcalOverEcalBc{{0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}},
-            invalidHcal(false),
-            pre7DepthHcal(true),
-            effSigmaRR(std::numeric_limits<float>::max()),
-            sigmaIetaIphi(std::numeric_limits<float>::max()),
-            sigmaIphiIphi(std::numeric_limits<float>::max()),
-            e2nd(0.f),
-            eTop(0.f),
-            eLeft(0.f),
-            eRight(0.f),
-            eBottom(0.f),
-            e1x3(0.f),
-            e2x2(0.f),
-            e2x5Max(0.f),
-            e2x5Left(0.f),
-            e2x5Right(0.f),
-            e2x5Top(0.f),
-            e2x5Bottom(0.f),
-            smMajor(0.f),
-            smMinor(0.f),
-            smAlpha(0.f) {}
-    };
-    const ShowerShape& showerShapeVariables() const { return showerShapeBlock_; }
-    const ShowerShape& full5x5_showerShapeVariables() const { return full5x5_showerShapeBlock_; }
-
-    void setShowerShapeVariables(const ShowerShape& a) { showerShapeBlock_ = a; }
-    void full5x5_setShowerShapeVariables(const ShowerShape& a) { full5x5_showerShapeBlock_ = a; }
-
-    /// the total hadronic over electromagnetic fraction
-    float hcalOverEcal(const ShowerShape& ss, int depth) const {
-      if (ss.pre7DepthHcal) {
-        if (depth == 0)
-          return ss.hcalDepth1OverEcal + ss.hcalDepth2OverEcal;
-        else if (depth == 1)
-          return ss.hcalDepth1OverEcal;
-        else if (depth == 2)
-          return ss.hcalDepth2OverEcal;
-
-        return 0.f;
-      } else {
-        const auto& hovere = ss.hcalOverEcal;
-        return (!(depth > 0 and depth < 8)) ? std::accumulate(std::begin(hovere), std::end(hovere), 0.f)
-                                            : hovere[depth - 1];
+      /// default constructor
+      Photon() : RecoCandidate() {
+        pixelSeed_ = false;
+        haloTaggerMVAVal_ = 99;
       }
-    }
-    float hcalOverEcal(int depth = 0) const { return hcalOverEcal(showerShapeBlock_, depth); }
-    float hadronicOverEm(int depth = 0) const { return hcalOverEcal(depth); }
 
-    /// the ratio of total energy of hcal rechits behind the SC and the SC energy
-    float hcalOverEcalBc(const ShowerShape& ss, int depth) const {
-      if (ss.pre7DepthHcal) {
-        if (depth == 0)
-          return ss.hcalDepth1OverEcalBc + ss.hcalDepth2OverEcalBc;
-        else if (depth == 1)
-          return ss.hcalDepth1OverEcalBc;
-        else if (depth == 2)
-          return ss.hcalDepth2OverEcalBc;
+      /// copy constructor
+      Photon(const Photon&);
 
-        return 0.f;
-      } else {
-        const auto& hovere = ss.hcalOverEcalBc;
-        return (!(depth > 0 and depth < 8)) ? std::accumulate(std::begin(hovere), std::end(hovere), 0.f)
-                                            : hovere[depth - 1];
+      /// constructor from values
+      Photon(const LorentzVector& p4,
+             const Point& caloPos,
+             const PhotonCoreRef& core,
+             const Point& vtx = Point(0, 0, 0));
+
+      /// assignment operator
+      Photon& operator=(const Photon&) = default;
+
+      /// destructor
+      ~Photon() override;
+
+      /// returns a clone of the candidate
+      Photon* clone() const override;
+
+      /// returns a reference to the core photon object
+      reco::PhotonCoreRef photonCore() const { return photonCore_; }
+      void setPhotonCore(const reco::PhotonCoreRef& photonCore) { photonCore_ = photonCore; }
+
+      //
+      /// Retrieve photonCore attributes
+      //
+      // retrieve provenance
+      bool isPFlowPhoton() const { return this->photonCore()->isPFlowPhoton(); }
+      bool isStandardPhoton() const { return this->photonCore()->isStandardPhoton(); }
+      /// Ref to SuperCluster
+      reco::SuperClusterRef superCluster() const override;
+      /// Ref to PFlow SuperCluster
+      reco::SuperClusterRef parentSuperCluster() const { return this->photonCore()->parentSuperCluster(); }
+      /// vector of references to  Conversion's
+      reco::ConversionRefVector conversions() const { return this->photonCore()->conversions(); }
+      enum ConversionProvenance { egamma = 0, pflow = 1, both = 2 };
+
+      /// vector of references to  one leg Conversion's
+      reco::ConversionRefVector conversionsOneLeg() const { return this->photonCore()->conversionsOneLeg(); }
+      /// Bool flagging photons with a vector of refereces to conversions with size >0
+      bool hasConversionTracks() const {
+        if (!this->photonCore()->conversions().empty() || !this->photonCore()->conversionsOneLeg().empty())
+          return true;
+        else
+          return false;
       }
-    }
-    float hcalOverEcalBc(int depth = 0) const { return hcalOverEcalBc(showerShapeBlock_, depth); }
-    float hadTowOverEm(int depth = 0) const { return hcalOverEcalBc(depth); }
-
-    const std::vector<CaloTowerDetId>& hcalTowersBehindClusters() const {
-      return showerShapeBlock_.hcalTowersBehindClusters;
-    }
-
-    /// returns false if H/E is not reliably estimated (e.g. because hcal was off or masked)
-    bool hadronicOverEmValid() const { return !showerShapeBlock_.invalidHcal; }
-    bool hadTowOverEmValid() const { return !showerShapeBlock_.invalidHcal; }
-
-    ///  Shower shape variables
-    float e1x5() const { return showerShapeBlock_.e1x5; }
-    float e2x5() const { return showerShapeBlock_.e2x5; }
-    float e3x3() const { return showerShapeBlock_.e3x3; }
-    float e5x5() const { return showerShapeBlock_.e5x5; }
-    float maxEnergyXtal() const { return showerShapeBlock_.maxEnergyXtal; }
-    float sigmaEtaEta() const { return showerShapeBlock_.sigmaEtaEta; }
-    float sigmaIetaIeta() const { return showerShapeBlock_.sigmaIetaIeta; }
-    float r1x5() const { return showerShapeBlock_.e1x5 / showerShapeBlock_.e5x5; }
-    float r2x5() const { return showerShapeBlock_.e2x5 / showerShapeBlock_.e5x5; }
-    float r9() const { return showerShapeBlock_.e3x3 / this->superCluster()->rawEnergy(); }
-
-    ///full5x5 Shower shape variables
-    float full5x5_e1x5() const { return full5x5_showerShapeBlock_.e1x5; }
-    float full5x5_e2x5() const { return full5x5_showerShapeBlock_.e2x5; }
-    float full5x5_e3x3() const { return full5x5_showerShapeBlock_.e3x3; }
-    float full5x5_e5x5() const { return full5x5_showerShapeBlock_.e5x5; }
-    float full5x5_maxEnergyXtal() const { return full5x5_showerShapeBlock_.maxEnergyXtal; }
-    float full5x5_sigmaEtaEta() const { return full5x5_showerShapeBlock_.sigmaEtaEta; }
-    float full5x5_sigmaIetaIeta() const { return full5x5_showerShapeBlock_.sigmaIetaIeta; }
-    float full5x5_r1x5() const { return full5x5_showerShapeBlock_.e1x5 / full5x5_showerShapeBlock_.e5x5; }
-    float full5x5_r2x5() const { return full5x5_showerShapeBlock_.e2x5 / full5x5_showerShapeBlock_.e5x5; }
-    float full5x5_r9() const { return full5x5_showerShapeBlock_.e3x3 / this->superCluster()->rawEnergy(); }
-
-    /// the total hadronic over electromagnetic fraction
-    float full5x5_hcalOverEcal(int depth = 0) const { return hcalOverEcal(full5x5_showerShapeBlock_, depth); }
-    float full5x5_hadronicOverEm(int depth = 0) const { return full5x5_hcalOverEcal(depth); }
-
-    /// the ratio of total energy of hcal rechits behind the SC and the SC energy
-    float full5x5_hcalOverEcalBc(int depth = 0) const { return hcalOverEcalBc(full5x5_showerShapeBlock_, depth); }
-    float full5x5_hadTowOverEm(int depth = 0) const { return full5x5_hcalOverEcalBc(depth); }
-
-    //=======================================================
-    // SaturationInfo
-    //=======================================================
-
-    struct SaturationInfo {
-      int nSaturatedXtals;
-      bool isSeedSaturated;
-      SaturationInfo() : nSaturatedXtals(0), isSeedSaturated(false) {}
-    };
-
-    // accessors
-    float nSaturatedXtals() const { return saturationInfo_.nSaturatedXtals; }
-    float isSeedSaturated() const { return saturationInfo_.isSeedSaturated; }
-    const SaturationInfo& saturationInfo() const { return saturationInfo_; }
-    void setSaturationInfo(const SaturationInfo& s) { saturationInfo_ = s; }
-
-    //=======================================================
-    // Energy Determinations
-    //=======================================================
-    enum P4type { undefined = -1, ecal_standard = 0, ecal_photons = 1, regression1 = 2, regression2 = 3 };
-
-    struct EnergyCorrections {
-      float scEcalEnergy;
-      float scEcalEnergyError;
-      LorentzVector scEcalP4;
-      float phoEcalEnergy;
-      float phoEcalEnergyError;
-      LorentzVector phoEcalP4;
-      float regression1Energy;
-      float regression1EnergyError;
-      LorentzVector regression1P4;
-      float regression2Energy;
-      float regression2EnergyError;
-      LorentzVector regression2P4;
-      P4type candidateP4type;
-      EnergyCorrections()
-          : scEcalEnergy(0.),
-            scEcalEnergyError(999.),
-            scEcalP4(0., 0., 0., 0.),
-            phoEcalEnergy(0.),
-            phoEcalEnergyError(999.),
-            phoEcalP4(0., 0., 0., 0.),
-            regression1Energy(0.),
-            regression1EnergyError(999.),
-            regression1P4(0., 0., 0., 0.),
-            regression2Energy(0.),
-            regression2EnergyError(999.),
-            regression2P4(0., 0., 0., 0.),
-            candidateP4type(undefined) {}
-    };
-
-    using RecoCandidate::p4;
-    using RecoCandidate::setP4;
-
-    //sets both energy and its uncertainty
-    void setCorrectedEnergy(P4type type, float E, float dE, bool toCand = true);
-    void setP4(P4type type, const LorentzVector& p4, float p4Error, bool setToRecoCandidate);
-    void setEnergyCorrections(const EnergyCorrections& e) { eCorrections_ = e; }
-    void setCandidateP4type(const P4type type) { eCorrections_.candidateP4type = type; }
-
-    float getCorrectedEnergy(P4type type) const;
-    float getCorrectedEnergyError(P4type type) const;
-    P4type getCandidateP4type() const { return eCorrections_.candidateP4type; }
-    const LorentzVector& p4(P4type type) const;
-    const EnergyCorrections& energyCorrections() const { return eCorrections_; }
-
-    //=======================================================
-    // MIP Variables
-    //=======================================================
-
-    struct MIPVariables {
-      float mipChi2;
-      float mipTotEnergy;
-      float mipSlope;
-      float mipIntercept;
-      int mipNhitCone;
-      bool mipIsHalo;
-
-      MIPVariables()
-          :
-
-            mipChi2(0),
-            mipTotEnergy(0),
-            mipSlope(0),
-            mipIntercept(0),
-            mipNhitCone(0),
-            mipIsHalo(false) {}
-    };
-
-    ///  MIP variables
-    float mipChi2() const { return mipVariableBlock_.mipChi2; }
-    float mipTotEnergy() const { return mipVariableBlock_.mipTotEnergy; }
-    float mipSlope() const { return mipVariableBlock_.mipSlope; }
-    float mipIntercept() const { return mipVariableBlock_.mipIntercept; }
-    int mipNhitCone() const { return mipVariableBlock_.mipNhitCone; }
-    bool mipIsHalo() const { return mipVariableBlock_.mipIsHalo; }
-
-    ///set mip Variables
-    void setMIPVariables(const MIPVariables& mipVar) { mipVariableBlock_ = mipVar; }
-
-    //=======================================================
-    // Isolation Variables
-    //=======================================================
-
-    struct IsolationVariables {
-      //These are analysis quantities calculated in the PhotonIDAlgo class
-
-      //EcalRecHit isolation
-      float ecalRecHitSumEt;
-      //HcalTower isolation
-      float hcalTowerSumEt;
-      //HcalDepth1Tower isolation
-      float hcalDepth1TowerSumEt;
-      //HcalDepth2Tower isolation
-      float hcalDepth2TowerSumEt;
-      //HcalTower isolation subtracting the hadronic energy in towers behind the BCs in the SC
-      float hcalTowerSumEtBc;
-      //HcalDepth1Tower isolation subtracting the hadronic energy in towers behind the BCs in the SC
-      float hcalDepth1TowerSumEtBc;
-      //HcalDepth2Tower isolation subtracting the hadronic energy in towers behind the BCs in the SC
-      float hcalDepth2TowerSumEtBc;
-      std::array<float, 7> hcalRecHitSumEt;    // ...per depth, with photon footprint within a cone removed
-      std::array<float, 7> hcalRecHitSumEtBc;  // ...per depth, with hcal rechits behind cluster removed
-      bool pre7DepthHcal;                      // to work around an ioread rule issue on legacy RECO files
-      //Sum of track pT in a cone of dR
-      float trkSumPtSolidCone;
-      //Sum of track pT in a hollow cone of outer radius, inner radius
-      float trkSumPtHollowCone;
-      //Number of tracks in a cone of dR
-      int nTrkSolidCone;
-      //Number of tracks in a hollow cone of outer radius, inner radius
-      int nTrkHollowCone;
-      IsolationVariables()
-          :
-
-            ecalRecHitSumEt(0.f),
-            hcalTowerSumEt(0.f),
-            hcalDepth1TowerSumEt(0.f),
-            hcalDepth2TowerSumEt(0.f),
-            hcalTowerSumEtBc(0.f),
-            hcalDepth1TowerSumEtBc(0.f),
-            hcalDepth2TowerSumEtBc(0.f),
-            hcalRecHitSumEt{{0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}},
-            hcalRecHitSumEtBc{{0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}},
-            pre7DepthHcal(true),
-            trkSumPtSolidCone(0.f),
-            trkSumPtHollowCone(0.f),
-            nTrkSolidCone(0),
-            nTrkHollowCone(0) {}
-    };
-
-    /// set relevant isolation variables
-    void setIsolationVariables(const IsolationVariables& isolInDr04, const IsolationVariables& isolInDr03) {
-      isolationR04_ = isolInDr04;
-      isolationR03_ = isolInDr03;
-    }
-
-    /// Egamma Isolation variables in cone dR=0.4
-    ///Ecal isolation sum calculated from recHits
-    float ecalRecHitSumEtConeDR04() const { return isolationR04_.ecalRecHitSumEt; }
-    /// Hcal isolation sum for each depth excluding the region containing the rechits used for hcalOverEcal()
-    float hcalTowerSumEt(const IsolationVariables& iv, int depth) const {
-      if (iv.pre7DepthHcal) {
-        if (depth == 0)
-          return iv.hcalTowerSumEt;
-        else if (depth == 1)
-          return iv.hcalDepth1TowerSumEt;
-        else if (depth == 2)
-          return iv.hcalDepth2TowerSumEt;
-
-        return 0.f;
-      } else {
-        const auto& hcaliso = iv.hcalRecHitSumEt;
-        return (!(depth > 0 and depth < 8)) ? std::accumulate(std::begin(hcaliso), std::end(hcaliso), 0.f)
-                                            : hcaliso[depth - 1];
+      /// reference to electron Pixel seed
+      reco::ElectronSeedRefVector electronPixelSeeds() const { return this->photonCore()->electronPixelSeeds(); }
+      /// Bool flagging photons having a non-zero size vector of Ref to electornPixel seeds
+      bool hasPixelSeed() const {
+        if (!(this->photonCore()->electronPixelSeeds()).empty())
+          return true;
+        else
+          return false;
       }
-    }
-    float hcalTowerSumEtConeDR04(int depth = 0) const { return hcalTowerSumEt(isolationR04_, depth); }
-    /// Hcal isolation sum for each depth excluding the region containing the rechits used for hcalOverEcalBc()
-    float hcalTowerSumEtBc(const IsolationVariables& iv, int depth) const {
-      if (iv.pre7DepthHcal) {
-        if (depth == 0)
-          return iv.hcalTowerSumEtBc;
-        else if (depth == 1)
-          return iv.hcalDepth1TowerSumEtBc;
-        else if (depth == 2)
-          return iv.hcalDepth2TowerSumEtBc;
+      int conversionTrackProvenance(const edm::RefToBase<reco::Track>& convTrack) const;
 
-        return 0.f;
-      } else {
-        const auto& hcaliso = iv.hcalRecHitSumEtBc;
-        return (!(depth > 0 and depth < 8)) ? std::accumulate(std::begin(hcaliso), std::end(hcaliso), 0.f)
-                                            : hcaliso[depth - 1];
+      /// position in ECAL: this is th SC position if r9<0.93. If r8>0.93 is position of seed BasicCluster taking shower depth for unconverted photon
+      math::XYZPointF caloPosition() const { return caloPosition_; }
+      /// set primary event vertex used to define photon direction
+      void setVertex(const Point& vertex) override;
+      /// Implement Candidate method for particle species
+      bool isPhoton() const override { return true; }
+
+      //=======================================================
+      // Fiducial Flags
+      //=======================================================
+      struct FiducialFlags {
+        //Fiducial flags
+        bool isEB;         //Photon is in EB
+        bool isEE;         //Photon is in EE
+        bool isEBEtaGap;   //Photon is in supermodule/supercrystal eta gap in EB
+        bool isEBPhiGap;   //Photon is in supermodule/supercrystal phi gap in EB
+        bool isEERingGap;  //Photon is in crystal ring gap in EE
+        bool isEEDeeGap;   //Photon is in crystal dee gap in EE
+        bool isEBEEGap;    //Photon is in border between EB and EE.
+
+        FiducialFlags()
+            : isEB(false),
+              isEE(false),
+              isEBEtaGap(false),
+              isEBPhiGap(false),
+              isEERingGap(false),
+              isEEDeeGap(false),
+              isEBEEGap(false)
+
+        {}
+      };
+
+      /// set flags for photons in the ECAL fiducial volume
+      void setFiducialVolumeFlags(const FiducialFlags& a) { fiducialFlagBlock_ = a; }
+      /// Ritrievs fiducial flags
+      /// true if photon is in ECAL barrel
+      bool isEB() const { return fiducialFlagBlock_.isEB; }
+      // true if photon is in ECAL endcap
+      bool isEE() const { return fiducialFlagBlock_.isEE; }
+      /// true if photon is in EB, and inside the boundaries in super crystals/modules
+      bool isEBGap() const { return (isEBEtaGap() || isEBPhiGap()); }
+      bool isEBEtaGap() const { return fiducialFlagBlock_.isEBEtaGap; }
+      bool isEBPhiGap() const { return fiducialFlagBlock_.isEBPhiGap; }
+      /// true if photon is in EE, and inside the boundaries in supercrystal/D
+      bool isEEGap() const { return (isEERingGap() || isEEDeeGap()); }
+      bool isEERingGap() const { return fiducialFlagBlock_.isEERingGap; }
+      bool isEEDeeGap() const { return fiducialFlagBlock_.isEEDeeGap; }
+      /// true if photon is in boundary between EB and EE
+      bool isEBEEGap() const { return fiducialFlagBlock_.isEBEEGap; }
+
+      //=======================================================
+      // Shower Shape Variables
+      //=======================================================
+
+      struct ShowerShape {
+        float sigmaEtaEta;
+        float sigmaIetaIeta;
+        float e1x5;
+        float e2x5;
+        float e3x3;
+        float e5x5;
+        float maxEnergyXtal;
+        float hcalDepth1OverEcal;  // hcal over ecal energy using first hcal depth
+        float hcalDepth2OverEcal;  // hcal over ecal energy using 2nd hcal depth
+        float hcalDepth1OverEcalBc;
+        float hcalDepth2OverEcalBc;
+        std::array<float, 7> hcalOverEcal;  // hcal over ecal seed cluster energy per depth (using rechits within a cone)
+        std::array<float, 7>
+            hcalOverEcalBc;  // hcal over ecal seed cluster energy per depth (using rechits behind clusters)
+        std::vector<CaloTowerDetId> hcalTowersBehindClusters;
+        bool invalidHcal;
+        bool pre7DepthHcal;  // to work around an ioread rule issue on legacy RECO files
+        float effSigmaRR;
+        float sigmaIetaIphi;
+        float sigmaIphiIphi;
+        float e2nd;
+        float eTop;
+        float eLeft;
+        float eRight;
+        float eBottom;
+        float e1x3;
+        float e2x2;
+        float e2x5Max;
+        float e2x5Left;
+        float e2x5Right;
+        float e2x5Top;
+        float e2x5Bottom;
+        float smMajor;
+        float smMinor;
+        float smAlpha;
+        ShowerShape()
+            : sigmaEtaEta(std::numeric_limits<float>::max()),
+              sigmaIetaIeta(std::numeric_limits<float>::max()),
+              e1x5(0.f),
+              e2x5(0.f),
+              e3x3(0.f),
+              e5x5(0.f),
+              maxEnergyXtal(0.f),
+              hcalDepth1OverEcal(0.f),
+              hcalDepth2OverEcal(0.f),
+              hcalDepth1OverEcalBc(0.f),
+              hcalDepth2OverEcalBc(0.f),
+              hcalOverEcal{{0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}},
+              hcalOverEcalBc{{0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}},
+              invalidHcal(false),
+              pre7DepthHcal(true),
+              effSigmaRR(std::numeric_limits<float>::max()),
+              sigmaIetaIphi(std::numeric_limits<float>::max()),
+              sigmaIphiIphi(std::numeric_limits<float>::max()),
+              e2nd(0.f),
+              eTop(0.f),
+              eLeft(0.f),
+              eRight(0.f),
+              eBottom(0.f),
+              e1x3(0.f),
+              e2x2(0.f),
+              e2x5Max(0.f),
+              e2x5Left(0.f),
+              e2x5Right(0.f),
+              e2x5Top(0.f),
+              e2x5Bottom(0.f),
+              smMajor(0.f),
+              smMinor(0.f),
+              smAlpha(0.f) {}
+      };
+      const ShowerShape& showerShapeVariables() const { return showerShapeBlock_; }
+      const ShowerShape& full5x5_showerShapeVariables() const { return full5x5_showerShapeBlock_; }
+
+      void setShowerShapeVariables(const ShowerShape& a) { showerShapeBlock_ = a; }
+      void full5x5_setShowerShapeVariables(const ShowerShape& a) { full5x5_showerShapeBlock_ = a; }
+
+      /// the total hadronic over electromagnetic fraction
+      float hcalOverEcal(const ShowerShape& ss, int depth) const {
+        if (ss.pre7DepthHcal) {
+          if (depth == 0)
+            return ss.hcalDepth1OverEcal + ss.hcalDepth2OverEcal;
+          else if (depth == 1)
+            return ss.hcalDepth1OverEcal;
+          else if (depth == 2)
+            return ss.hcalDepth2OverEcal;
+
+          return 0.f;
+        } else {
+          const auto& hovere = ss.hcalOverEcal;
+          return (!(depth > 0 and depth < 8)) ? std::accumulate(std::begin(hovere), std::end(hovere), 0.f)
+                                              : hovere[depth - 1];
+        }
       }
-    }
-    float hcalTowerSumEtBcConeDR04(int depth = 0) const { return hcalTowerSumEtBc(isolationR04_, depth); }
-    //  Track pT sum
-    float trkSumPtSolidConeDR04() const { return isolationR04_.trkSumPtSolidCone; }
-    //As above, excluding the core at the center of the cone
-    float trkSumPtHollowConeDR04() const { return isolationR04_.trkSumPtHollowCone; }
-    //Returns number of tracks in a cone of dR
-    int nTrkSolidConeDR04() const { return isolationR04_.nTrkSolidCone; }
-    //As above, excluding the core at the center of the cone
-    int nTrkHollowConeDR04() const { return isolationR04_.nTrkHollowCone; }
-    //
-    /// Isolation variables in cone dR=0.3
-    float ecalRecHitSumEtConeDR03() const { return isolationR03_.ecalRecHitSumEt; }
-    /// Hcal isolation sum for each depth excluding the region containing the rechits used for hcalOverEcal()
-    float hcalTowerSumEtConeDR03(int depth = 0) const { return hcalTowerSumEt(isolationR03_, depth); }
-    /// Hcal isolation sum for each depth excluding the region containing the rechits used for hcalOverEcalBc()
-    float hcalTowerSumEtBcConeDR03(int depth = 0) const { return hcalTowerSumEtBc(isolationR03_, depth); }
-    //  Track pT sum c
-    float trkSumPtSolidConeDR03() const { return isolationR03_.trkSumPtSolidCone; }
-    //As above, excluding the core at the center of the cone
-    float trkSumPtHollowConeDR03() const { return isolationR03_.trkSumPtHollowCone; }
-    //Returns number of tracks in a cone of dR
-    int nTrkSolidConeDR03() const { return isolationR03_.nTrkSolidCone; }
-    //As above, excluding the core at the center of the cone
-    int nTrkHollowConeDR03() const { return isolationR03_.nTrkHollowCone; }
+      float hcalOverEcal(int depth = 0) const { return hcalOverEcal(showerShapeBlock_, depth); }
+      float hadronicOverEm(int depth = 0) const { return hcalOverEcal(depth); }
 
-    //=======================================================
-    // PFlow based Isolation Variables
-    //=======================================================
+      /// the ratio of total energy of hcal rechits behind the SC and the SC energy
+      float hcalOverEcalBc(const ShowerShape& ss, int depth) const {
+        if (ss.pre7DepthHcal) {
+          if (depth == 0)
+            return ss.hcalDepth1OverEcalBc + ss.hcalDepth2OverEcalBc;
+          else if (depth == 1)
+            return ss.hcalDepth1OverEcalBc;
+          else if (depth == 2)
+            return ss.hcalDepth2OverEcalBc;
 
-    struct PflowIsolationVariables {
-      float chargedHadronIso;                  //charged hadron isolation with dxy,dz match to pv
-      float chargedHadronWorstVtxIso;          //max charged hadron isolation when dxy/dz matching to given vtx
-      float chargedHadronWorstVtxGeomVetoIso;  //as chargedHadronWorstVtxIso but an additional geometry based veto cone
-      float chargedHadronPFPVIso;  //only considers particles assigned to the primary vertex (PV) by particle flow, corresponds to <10_6 chargedHadronIso
-      float neutralHadronIso;
-      float photonIso;
-      float sumEcalClusterEt;  //sum pt of ecal clusters, vetoing clusters part of photon
-      float sumHcalClusterEt;  //sum pt of hcal clusters, vetoing clusters part of photon
-      PflowIsolationVariables()
-          :
+          return 0.f;
+        } else {
+          const auto& hovere = ss.hcalOverEcalBc;
+          return (!(depth > 0 and depth < 8)) ? std::accumulate(std::begin(hovere), std::end(hovere), 0.f)
+                                              : hovere[depth - 1];
+        }
+      }
+      float hcalOverEcalBc(int depth = 0) const { return hcalOverEcalBc(showerShapeBlock_, depth); }
+      float hadTowOverEm(int depth = 0) const { return hcalOverEcalBc(depth); }
 
-            chargedHadronIso(0.),
-            chargedHadronWorstVtxIso(0.),
-            chargedHadronWorstVtxGeomVetoIso(0.),
-            chargedHadronPFPVIso(0.),
-            neutralHadronIso(0.),
-            photonIso(0.),
-            sumEcalClusterEt(0.),
-            sumHcalClusterEt(0.) {}
+      const std::vector<CaloTowerDetId>& hcalTowersBehindClusters() const {
+        return showerShapeBlock_.hcalTowersBehindClusters;
+      }
+
+      /// returns false if H/E is not reliably estimated (e.g. because hcal was off or masked)
+      bool hadronicOverEmValid() const { return !showerShapeBlock_.invalidHcal; }
+      bool hadTowOverEmValid() const { return !showerShapeBlock_.invalidHcal; }
+
+      ///  Shower shape variables
+      float e1x5() const { return showerShapeBlock_.e1x5; }
+      float e2x5() const { return showerShapeBlock_.e2x5; }
+      float e3x3() const { return showerShapeBlock_.e3x3; }
+      float e5x5() const { return showerShapeBlock_.e5x5; }
+      float maxEnergyXtal() const { return showerShapeBlock_.maxEnergyXtal; }
+      float sigmaEtaEta() const { return showerShapeBlock_.sigmaEtaEta; }
+      float sigmaIetaIeta() const { return showerShapeBlock_.sigmaIetaIeta; }
+      float r1x5() const { return showerShapeBlock_.e1x5 / showerShapeBlock_.e5x5; }
+      float r2x5() const { return showerShapeBlock_.e2x5 / showerShapeBlock_.e5x5; }
+      float r9() const { return showerShapeBlock_.e3x3 / this->superCluster()->rawEnergy(); }
+
+      ///full5x5 Shower shape variables
+      float full5x5_e1x5() const { return full5x5_showerShapeBlock_.e1x5; }
+      float full5x5_e2x5() const { return full5x5_showerShapeBlock_.e2x5; }
+      float full5x5_e3x3() const { return full5x5_showerShapeBlock_.e3x3; }
+      float full5x5_e5x5() const { return full5x5_showerShapeBlock_.e5x5; }
+      float full5x5_maxEnergyXtal() const { return full5x5_showerShapeBlock_.maxEnergyXtal; }
+      float full5x5_sigmaEtaEta() const { return full5x5_showerShapeBlock_.sigmaEtaEta; }
+      float full5x5_sigmaIetaIeta() const { return full5x5_showerShapeBlock_.sigmaIetaIeta; }
+      float full5x5_r1x5() const { return full5x5_showerShapeBlock_.e1x5 / full5x5_showerShapeBlock_.e5x5; }
+      float full5x5_r2x5() const { return full5x5_showerShapeBlock_.e2x5 / full5x5_showerShapeBlock_.e5x5; }
+      float full5x5_r9() const { return full5x5_showerShapeBlock_.e3x3 / this->superCluster()->rawEnergy(); }
+
+      /// the total hadronic over electromagnetic fraction
+      float full5x5_hcalOverEcal(int depth = 0) const { return hcalOverEcal(full5x5_showerShapeBlock_, depth); }
+      float full5x5_hadronicOverEm(int depth = 0) const { return full5x5_hcalOverEcal(depth); }
+
+      /// the ratio of total energy of hcal rechits behind the SC and the SC energy
+      float full5x5_hcalOverEcalBc(int depth = 0) const { return hcalOverEcalBc(full5x5_showerShapeBlock_, depth); }
+      float full5x5_hadTowOverEm(int depth = 0) const { return full5x5_hcalOverEcalBc(depth); }
+
+      //=======================================================
+      // SaturationInfo
+      //=======================================================
+
+      struct SaturationInfo {
+        int nSaturatedXtals;
+        bool isSeedSaturated;
+        SaturationInfo() : nSaturatedXtals(0), isSeedSaturated(false) {}
+      };
+
+      // accessors
+      float nSaturatedXtals() const { return saturationInfo_.nSaturatedXtals; }
+      float isSeedSaturated() const { return saturationInfo_.isSeedSaturated; }
+      const SaturationInfo& saturationInfo() const { return saturationInfo_; }
+      void setSaturationInfo(const SaturationInfo& s) { saturationInfo_ = s; }
+
+      //=======================================================
+      // Energy Determinations
+      //=======================================================
+      enum P4type { undefined = -1, ecal_standard = 0, ecal_photons = 1, regression1 = 2, regression2 = 3 };
+
+      struct EnergyCorrections {
+        float scEcalEnergy;
+        float scEcalEnergyError;
+        LorentzVector scEcalP4;
+        float phoEcalEnergy;
+        float phoEcalEnergyError;
+        LorentzVector phoEcalP4;
+        float regression1Energy;
+        float regression1EnergyError;
+        LorentzVector regression1P4;
+        float regression2Energy;
+        float regression2EnergyError;
+        LorentzVector regression2P4;
+        P4type candidateP4type;
+        EnergyCorrections()
+            : scEcalEnergy(0.),
+              scEcalEnergyError(999.),
+              scEcalP4(0., 0., 0., 0.),
+              phoEcalEnergy(0.),
+              phoEcalEnergyError(999.),
+              phoEcalP4(0., 0., 0., 0.),
+              regression1Energy(0.),
+              regression1EnergyError(999.),
+              regression1P4(0., 0., 0., 0.),
+              regression2Energy(0.),
+              regression2EnergyError(999.),
+              regression2P4(0., 0., 0., 0.),
+              candidateP4type(undefined) {}
+      };
+
+      using RecoCandidate::p4;
+      using RecoCandidate::setP4;
+
+      //sets both energy and its uncertainty
+      void setCorrectedEnergy(P4type type, float E, float dE, bool toCand = true);
+      void setP4(P4type type, const LorentzVector& p4, float p4Error, bool setToRecoCandidate);
+      void setEnergyCorrections(const EnergyCorrections& e) { eCorrections_ = e; }
+      void setCandidateP4type(const P4type type) { eCorrections_.candidateP4type = type; }
+
+      float getCorrectedEnergy(P4type type) const;
+      float getCorrectedEnergyError(P4type type) const;
+      P4type getCandidateP4type() const { return eCorrections_.candidateP4type; }
+      const LorentzVector& p4(P4type type) const;
+      const EnergyCorrections& energyCorrections() const { return eCorrections_; }
+
+      //=======================================================
+      // MIP Variables
+      //=======================================================
+
+      struct MIPVariables {
+        float mipChi2;
+        float mipTotEnergy;
+        float mipSlope;
+        float mipIntercept;
+        int mipNhitCone;
+        bool mipIsHalo;
+
+        MIPVariables()
+            :
+
+              mipChi2(0),
+              mipTotEnergy(0),
+              mipSlope(0),
+              mipIntercept(0),
+              mipNhitCone(0),
+              mipIsHalo(false) {}
+      };
+
+      ///  MIP variables
+      float mipChi2() const { return mipVariableBlock_.mipChi2; }
+      float mipTotEnergy() const { return mipVariableBlock_.mipTotEnergy; }
+      float mipSlope() const { return mipVariableBlock_.mipSlope; }
+      float mipIntercept() const { return mipVariableBlock_.mipIntercept; }
+      int mipNhitCone() const { return mipVariableBlock_.mipNhitCone; }
+      bool mipIsHalo() const { return mipVariableBlock_.mipIsHalo; }
+
+      ///set mip Variables
+      void setMIPVariables(const MIPVariables& mipVar) { mipVariableBlock_ = mipVar; }
+
+      //=======================================================
+      // Isolation Variables
+      //=======================================================
+
+      struct IsolationVariables {
+        //These are analysis quantities calculated in the PhotonIDAlgo class
+
+        //EcalRecHit isolation
+        float ecalRecHitSumEt;
+        //HcalTower isolation
+        float hcalTowerSumEt;
+        //HcalDepth1Tower isolation
+        float hcalDepth1TowerSumEt;
+        //HcalDepth2Tower isolation
+        float hcalDepth2TowerSumEt;
+        //HcalTower isolation subtracting the hadronic energy in towers behind the BCs in the SC
+        float hcalTowerSumEtBc;
+        //HcalDepth1Tower isolation subtracting the hadronic energy in towers behind the BCs in the SC
+        float hcalDepth1TowerSumEtBc;
+        //HcalDepth2Tower isolation subtracting the hadronic energy in towers behind the BCs in the SC
+        float hcalDepth2TowerSumEtBc;
+        std::array<float, 7> hcalRecHitSumEt;    // ...per depth, with photon footprint within a cone removed
+        std::array<float, 7> hcalRecHitSumEtBc;  // ...per depth, with hcal rechits behind cluster removed
+        bool pre7DepthHcal;                      // to work around an ioread rule issue on legacy RECO files
+        //Sum of track pT in a cone of dR
+        float trkSumPtSolidCone;
+        //Sum of track pT in a hollow cone of outer radius, inner radius
+        float trkSumPtHollowCone;
+        //Number of tracks in a cone of dR
+        int nTrkSolidCone;
+        //Number of tracks in a hollow cone of outer radius, inner radius
+        int nTrkHollowCone;
+        IsolationVariables()
+            :
+
+              ecalRecHitSumEt(0.f),
+              hcalTowerSumEt(0.f),
+              hcalDepth1TowerSumEt(0.f),
+              hcalDepth2TowerSumEt(0.f),
+              hcalTowerSumEtBc(0.f),
+              hcalDepth1TowerSumEtBc(0.f),
+              hcalDepth2TowerSumEtBc(0.f),
+              hcalRecHitSumEt{{0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}},
+              hcalRecHitSumEtBc{{0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}},
+              pre7DepthHcal(true),
+              trkSumPtSolidCone(0.f),
+              trkSumPtHollowCone(0.f),
+              nTrkSolidCone(0),
+              nTrkHollowCone(0) {}
+      };
+
+      /// set relevant isolation variables
+      void setIsolationVariables(const IsolationVariables& isolInDr04, const IsolationVariables& isolInDr03) {
+        isolationR04_ = isolInDr04;
+        isolationR03_ = isolInDr03;
+      }
+
+      /// Egamma Isolation variables in cone dR=0.4
+      ///Ecal isolation sum calculated from recHits
+      float ecalRecHitSumEtConeDR04() const { return isolationR04_.ecalRecHitSumEt; }
+      /// Hcal isolation sum for each depth excluding the region containing the rechits used for hcalOverEcal()
+      float hcalTowerSumEt(const IsolationVariables& iv, int depth) const {
+        if (iv.pre7DepthHcal) {
+          if (depth == 0)
+            return iv.hcalTowerSumEt;
+          else if (depth == 1)
+            return iv.hcalDepth1TowerSumEt;
+          else if (depth == 2)
+            return iv.hcalDepth2TowerSumEt;
+
+          return 0.f;
+        } else {
+          const auto& hcaliso = iv.hcalRecHitSumEt;
+          return (!(depth > 0 and depth < 8)) ? std::accumulate(std::begin(hcaliso), std::end(hcaliso), 0.f)
+                                              : hcaliso[depth - 1];
+        }
+      }
+      float hcalTowerSumEtConeDR04(int depth = 0) const { return hcalTowerSumEt(isolationR04_, depth); }
+      /// Hcal isolation sum for each depth excluding the region containing the rechits used for hcalOverEcalBc()
+      float hcalTowerSumEtBc(const IsolationVariables& iv, int depth) const {
+        if (iv.pre7DepthHcal) {
+          if (depth == 0)
+            return iv.hcalTowerSumEtBc;
+          else if (depth == 1)
+            return iv.hcalDepth1TowerSumEtBc;
+          else if (depth == 2)
+            return iv.hcalDepth2TowerSumEtBc;
+
+          return 0.f;
+        } else {
+          const auto& hcaliso = iv.hcalRecHitSumEtBc;
+          return (!(depth > 0 and depth < 8)) ? std::accumulate(std::begin(hcaliso), std::end(hcaliso), 0.f)
+                                              : hcaliso[depth - 1];
+        }
+      }
+      float hcalTowerSumEtBcConeDR04(int depth = 0) const { return hcalTowerSumEtBc(isolationR04_, depth); }
+      //  Track pT sum
+      float trkSumPtSolidConeDR04() const { return isolationR04_.trkSumPtSolidCone; }
+      //As above, excluding the core at the center of the cone
+      float trkSumPtHollowConeDR04() const { return isolationR04_.trkSumPtHollowCone; }
+      //Returns number of tracks in a cone of dR
+      int nTrkSolidConeDR04() const { return isolationR04_.nTrkSolidCone; }
+      //As above, excluding the core at the center of the cone
+      int nTrkHollowConeDR04() const { return isolationR04_.nTrkHollowCone; }
+      //
+      /// Isolation variables in cone dR=0.3
+      float ecalRecHitSumEtConeDR03() const { return isolationR03_.ecalRecHitSumEt; }
+      /// Hcal isolation sum for each depth excluding the region containing the rechits used for hcalOverEcal()
+      float hcalTowerSumEtConeDR03(int depth = 0) const { return hcalTowerSumEt(isolationR03_, depth); }
+      /// Hcal isolation sum for each depth excluding the region containing the rechits used for hcalOverEcalBc()
+      float hcalTowerSumEtBcConeDR03(int depth = 0) const { return hcalTowerSumEtBc(isolationR03_, depth); }
+      //  Track pT sum c
+      float trkSumPtSolidConeDR03() const { return isolationR03_.trkSumPtSolidCone; }
+      //As above, excluding the core at the center of the cone
+      float trkSumPtHollowConeDR03() const { return isolationR03_.trkSumPtHollowCone; }
+      //Returns number of tracks in a cone of dR
+      int nTrkSolidConeDR03() const { return isolationR03_.nTrkSolidCone; }
+      //As above, excluding the core at the center of the cone
+      int nTrkHollowConeDR03() const { return isolationR03_.nTrkHollowCone; }
+
+      //=======================================================
+      // PFlow based Isolation Variables
+      //=======================================================
+
+      struct PflowIsolationVariables {
+        float chargedHadronIso;                  //charged hadron isolation with dxy,dz match to pv
+        float chargedHadronWorstVtxIso;          //max charged hadron isolation when dxy/dz matching to given vtx
+        float chargedHadronWorstVtxGeomVetoIso;  //as chargedHadronWorstVtxIso but an additional geometry based veto cone
+        float chargedHadronPFPVIso;  //only considers particles assigned to the primary vertex (PV) by particle flow, corresponds to <10_6 chargedHadronIso
+        float neutralHadronIso;
+        float photonIso;
+        float sumEcalClusterEt;  //sum pt of ecal clusters, vetoing clusters part of photon
+        float sumHcalClusterEt;  //sum pt of hcal clusters, vetoing clusters part of photon
+        PflowIsolationVariables()
+            :
+
+              chargedHadronIso(0.),
+              chargedHadronWorstVtxIso(0.),
+              chargedHadronWorstVtxGeomVetoIso(0.),
+              chargedHadronPFPVIso(0.),
+              neutralHadronIso(0.),
+              photonIso(0.),
+              sumEcalClusterEt(0.),
+              sumHcalClusterEt(0.) {}
+      };
+
+      /// Accessors for Particle Flow Isolation variables
+      float chargedHadronIso() const { return pfIsolation_.chargedHadronIso; }
+      float chargedHadronWorstVtxIso() const { return pfIsolation_.chargedHadronWorstVtxIso; }
+      float chargedHadronWorstVtxGeomVetoIso() const { return pfIsolation_.chargedHadronWorstVtxGeomVetoIso; }
+      float chargedHadronPFPVIso() const { return pfIsolation_.chargedHadronPFPVIso; }
+      float neutralHadronIso() const { return pfIsolation_.neutralHadronIso; }
+      float photonIso() const { return pfIsolation_.photonIso; }
+
+      //backwards compat functions for pat::Photon
+      float ecalPFClusterIso() const { return pfIsolation_.sumEcalClusterEt; };
+      float hcalPFClusterIso() const { return pfIsolation_.sumHcalClusterEt; };
+
+      /// Get Particle Flow Isolation variables block
+      const PflowIsolationVariables& getPflowIsolationVariables() const { return pfIsolation_; }
+
+      /// Set Particle Flow Isolation variables
+      void setPflowIsolationVariables(const PflowIsolationVariables& pfisol) { pfIsolation_ = pfisol; }
+
+      static constexpr float mvaPlaceholder = -999999999.;
+
+      struct PflowIDVariables {
+        int nClusterOutsideMustache;
+        float etOutsideMustache;
+        float mva;
+        float dnn;
+
+        PflowIDVariables()
+            : nClusterOutsideMustache(-1),
+              etOutsideMustache(mvaPlaceholder),
+              mva(mvaPlaceholder),
+              dnn(mvaPlaceholder) {}
+      };
+
+      // getters
+      int nClusterOutsideMustache() const { return pfID_.nClusterOutsideMustache; }
+      float etOutsideMustache() const { return pfID_.etOutsideMustache; }
+      float pfMVA() const { return pfID_.mva; }
+      float pfDNN() const { return pfID_.dnn; }
+      // setters
+      void setPflowIDVariables(const PflowIDVariables& pfid) { pfID_ = pfid; }
+
+      // go back to run2-like 2 effective depths if desired - depth 1 is the normal depth 1, depth 2 is the sum over the rest
+      void hcalToRun2EffDepth();
+
+      ///MVA based beam halo tagger - trained for EE and for pT > 200 GeV
+      float haloTaggerMVAVal() const { return haloTaggerMVAVal_; }
+
+      ///set the haloTaggerMVAVal here
+      void setHaloTaggerMVAVal(float x) { haloTaggerMVAVal_ = x; }
+
+    private:
+      /// check overlap with another candidate
+      bool overlap(const Candidate&) const override;
+      /// position of seed BasicCluster for shower depth of unconverted photon
+      math::XYZPointF caloPosition_;
+      /// reference to the PhotonCore
+      reco::PhotonCoreRef photonCore_;
+      //
+      bool pixelSeed_;
+      //
+      FiducialFlags fiducialFlagBlock_;
+      IsolationVariables isolationR04_;
+      IsolationVariables isolationR03_;
+      ShowerShape showerShapeBlock_;
+      ShowerShape full5x5_showerShapeBlock_;
+      SaturationInfo saturationInfo_;
+      EnergyCorrections eCorrections_;
+      MIPVariables mipVariableBlock_;
+      PflowIsolationVariables pfIsolation_;
+      PflowIDVariables pfID_;
+      float haloTaggerMVAVal_;
     };
 
-    /// Accessors for Particle Flow Isolation variables
-    float chargedHadronIso() const { return pfIsolation_.chargedHadronIso; }
-    float chargedHadronWorstVtxIso() const { return pfIsolation_.chargedHadronWorstVtxIso; }
-    float chargedHadronWorstVtxGeomVetoIso() const { return pfIsolation_.chargedHadronWorstVtxGeomVetoIso; }
-    float chargedHadronPFPVIso() const { return pfIsolation_.chargedHadronPFPVIso; }
-    float neutralHadronIso() const { return pfIsolation_.neutralHadronIso; }
-    float photonIso() const { return pfIsolation_.photonIso; }
-
-    //backwards compat functions for pat::Photon
-    float ecalPFClusterIso() const { return pfIsolation_.sumEcalClusterEt; };
-    float hcalPFClusterIso() const { return pfIsolation_.sumHcalClusterEt; };
-
-    /// Get Particle Flow Isolation variables block
-    const PflowIsolationVariables& getPflowIsolationVariables() const { return pfIsolation_; }
-
-    /// Set Particle Flow Isolation variables
-    void setPflowIsolationVariables(const PflowIsolationVariables& pfisol) { pfIsolation_ = pfisol; }
-
-    static constexpr float mvaPlaceholder = -999999999.;
-
-    struct PflowIDVariables {
-      int nClusterOutsideMustache;
-      float etOutsideMustache;
-      float mva;
-      float dnn;
-
-      PflowIDVariables()
-          : nClusterOutsideMustache(-1), etOutsideMustache(mvaPlaceholder), mva(mvaPlaceholder), dnn(mvaPlaceholder) {}
-    };
-
-    // getters
-    int nClusterOutsideMustache() const { return pfID_.nClusterOutsideMustache; }
-    float etOutsideMustache() const { return pfID_.etOutsideMustache; }
-    float pfMVA() const { return pfID_.mva; }
-    float pfDNN() const { return pfID_.dnn; }
-    // setters
-    void setPflowIDVariables(const PflowIDVariables& pfid) { pfID_ = pfid; }
-
-    // go back to run2-like 2 effective depths if desired - depth 1 is the normal depth 1, depth 2 is the sum over the rest
-    void hcalToRun2EffDepth();
-
-    ///MVA based beam halo tagger - trained for EE and for pT > 200 GeV
-    float haloTaggerMVAVal() const { return haloTaggerMVAVal_; }
-
-    ///set the haloTaggerMVAVal here
-    void setHaloTaggerMVAVal(float x) { haloTaggerMVAVal_ = x; }
-
-  private:
-    /// check overlap with another candidate
-    bool overlap(const Candidate&) const override;
-    /// position of seed BasicCluster for shower depth of unconverted photon
-    math::XYZPointF caloPosition_;
-    /// reference to the PhotonCore
-    reco::PhotonCoreRef photonCore_;
-    //
-    bool pixelSeed_;
-    //
-    FiducialFlags fiducialFlagBlock_;
-    IsolationVariables isolationR04_;
-    IsolationVariables isolationR03_;
-    ShowerShape showerShapeBlock_;
-    ShowerShape full5x5_showerShapeBlock_;
-    SaturationInfo saturationInfo_;
-    EnergyCorrections eCorrections_;
-    MIPVariables mipVariableBlock_;
-    PflowIsolationVariables pfIsolation_;
-    PflowIDVariables pfID_;
-    float haloTaggerMVAVal_;
-  };
-
+  }  // namespace io_v1
+  using Photon = io_v1::Photon;
 }  // namespace reco
 
 #endif

--- a/DataFormats/EgammaCandidates/interface/PhotonCore.h
+++ b/DataFormats/EgammaCandidates/interface/PhotonCore.h
@@ -20,82 +20,86 @@
 #include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  class PhotonCore {
-  public:
-    /// default constructor
-    //    PhotonCore() { }
+    class PhotonCore {
+    public:
+      /// default constructor
+      //    PhotonCore() { }
 
-    /// To be deleted: Internal comment for Florian
-    /// I would reserve this constructor to build the standard photons, as it was before, plus I add the initialization of the provenance
-    PhotonCore(const reco::SuperClusterRef &scl) : superCluster_(scl), isPFlowPhoton_(false), isStandardPhoton_(true) {}
+      /// To be deleted: Internal comment for Florian
+      /// I would reserve this constructor to build the standard photons, as it was before, plus I add the initialization of the provenance
+      PhotonCore(const reco::SuperClusterRef &scl)
+          : superCluster_(scl), isPFlowPhoton_(false), isStandardPhoton_(true) {}
 
-    // while for building photons from pf I would use the default constructor
-    PhotonCore() : isPFlowPhoton_(false), isStandardPhoton_(false) {}
-    // followed by the setters of the provenance and of the Ref to the wanted supercluster
-    // at that point if in PF you have found a photon which correspond to a standard SC yuo can
-    // set both supercluster and the two flags to true
-    // if you have found an object which does not have a standard SC associated you set only the
-    // one from pflow.
-    // How does this sound ?
+      // while for building photons from pf I would use the default constructor
+      PhotonCore() : isPFlowPhoton_(false), isStandardPhoton_(false) {}
+      // followed by the setters of the provenance and of the Ref to the wanted supercluster
+      // at that point if in PF you have found a photon which correspond to a standard SC yuo can
+      // set both supercluster and the two flags to true
+      // if you have found an object which does not have a standard SC associated you set only the
+      // one from pflow.
+      // How does this sound ?
 
-    /// destructor
-    virtual ~PhotonCore() {}
+      /// destructor
+      virtual ~PhotonCore() {}
 
-    PhotonCore *clone() const { return new PhotonCore(*this); }
+      PhotonCore *clone() const { return new PhotonCore(*this); }
 
-    /// set reference to SuperCluster
-    void setSuperCluster(const reco::SuperClusterRef &r) { superCluster_ = r; }
-    /// set reference to PFlow SuperCluster
-    void setParentSuperCluster(const reco::SuperClusterRef &r) { parentSuperCluster_ = r; }
-    /// add  single ConversionRef to the vector of Refs
-    void addConversion(const reco::ConversionRef &r) { conversions_.push_back(r); }
-    /// add  single ConversionRef to the vector of Refs
-    void addOneLegConversion(const reco::ConversionRef &r) { conversionsOneLeg_.push_back(r); }
-    /// set electron pixel seed ref
-    void addElectronPixelSeed(const reco::ElectronSeedRef &r) { electronSeed_.push_back(r); }
-    /// set the provenance
-    void setPFlowPhoton(const bool prov) { isPFlowPhoton_ = prov; }
-    void setStandardPhoton(const bool prov) { isStandardPhoton_ = prov; }
+      /// set reference to SuperCluster
+      void setSuperCluster(const reco::SuperClusterRef &r) { superCluster_ = r; }
+      /// set reference to PFlow SuperCluster
+      void setParentSuperCluster(const reco::SuperClusterRef &r) { parentSuperCluster_ = r; }
+      /// add  single ConversionRef to the vector of Refs
+      void addConversion(const reco::ConversionRef &r) { conversions_.push_back(r); }
+      /// add  single ConversionRef to the vector of Refs
+      void addOneLegConversion(const reco::ConversionRef &r) { conversionsOneLeg_.push_back(r); }
+      /// set electron pixel seed ref
+      void addElectronPixelSeed(const reco::ElectronSeedRef &r) { electronSeed_.push_back(r); }
+      /// set the provenance
+      void setPFlowPhoton(const bool prov) { isPFlowPhoton_ = prov; }
+      void setStandardPhoton(const bool prov) { isStandardPhoton_ = prov; }
 
-    /// get reference to SuperCluster
-    reco::SuperClusterRef superCluster() const { return superCluster_; }
-    /// get reference to PFlow SuperCluster
-    reco::SuperClusterRef parentSuperCluster() const { return parentSuperCluster_; }
+      /// get reference to SuperCluster
+      reco::SuperClusterRef superCluster() const { return superCluster_; }
+      /// get reference to PFlow SuperCluster
+      reco::SuperClusterRef parentSuperCluster() const { return parentSuperCluster_; }
 
-    //// comment for Florian. I have seen that in GsfElectronCore they have a getter for the supercluster
-    // which returns the pfSuperCluster only if the standard supeclsuter is not null
-    // But I had udnerstood from you when we spke last time that we wish to be free
-    // to have both SCs available. Or not ?
+      //// comment for Florian. I have seen that in GsfElectronCore they have a getter for the supercluster
+      // which returns the pfSuperCluster only if the standard supeclsuter is not null
+      // But I had udnerstood from you when we spke last time that we wish to be free
+      // to have both SCs available. Or not ?
 
-    /// get vector of references to  Conversion's
-    reco::ConversionRefVector conversions() const { return conversions_; }
-    /// get vector of references to one leg Conversion's
-    reco::ConversionRefVector conversionsOneLeg() const { return conversionsOneLeg_; }
+      /// get vector of references to  Conversion's
+      reco::ConversionRefVector conversions() const { return conversions_; }
+      /// get vector of references to one leg Conversion's
+      reco::ConversionRefVector conversionsOneLeg() const { return conversionsOneLeg_; }
 
-    void setConversions(const reco::ConversionRefVector &conversions) { conversions_ = conversions; }
-    void setConversionsOneLeg(const reco::ConversionRefVector &conversions) { conversionsOneLeg_ = conversions; }
+      void setConversions(const reco::ConversionRefVector &conversions) { conversions_ = conversions; }
+      void setConversionsOneLeg(const reco::ConversionRefVector &conversions) { conversionsOneLeg_ = conversions; }
 
-    /// get reference to electron seed if existing
-    reco::ElectronSeedRefVector electronPixelSeeds() const { return electronSeed_; }
-    bool isPFlowPhoton() const { return isPFlowPhoton_; }
-    bool isStandardPhoton() const { return isStandardPhoton_; }
+      /// get reference to electron seed if existing
+      reco::ElectronSeedRefVector electronPixelSeeds() const { return electronSeed_; }
+      bool isPFlowPhoton() const { return isPFlowPhoton_; }
+      bool isStandardPhoton() const { return isStandardPhoton_; }
 
-  private:
-    /// reference to a SuperCluster
-    reco::SuperClusterRef superCluster_;
-    // vector of references to Conversions
-    reco::ConversionRefVector conversions_;
-    //vector of references for 1-leg
-    reco::ConversionRefVector conversionsOneLeg_;
-    // vector of references to ElectronPixelSeeds
-    reco::ElectronSeedRefVector electronSeed_;
-    /// reference to a Particle flow SuperCluster
-    reco::SuperClusterRef parentSuperCluster_;
-    bool isPFlowPhoton_;
-    bool isStandardPhoton_;
-  };
+    private:
+      /// reference to a SuperCluster
+      reco::SuperClusterRef superCluster_;
+      // vector of references to Conversions
+      reco::ConversionRefVector conversions_;
+      //vector of references for 1-leg
+      reco::ConversionRefVector conversionsOneLeg_;
+      // vector of references to ElectronPixelSeeds
+      reco::ElectronSeedRefVector electronSeed_;
+      /// reference to a Particle flow SuperCluster
+      reco::SuperClusterRef parentSuperCluster_;
+      bool isPFlowPhoton_;
+      bool isStandardPhoton_;
+    };
 
+  }  // namespace io_v1
+  using PhotonCore = io_v1::PhotonCore;
 }  // namespace reco
 
 #endif

--- a/DataFormats/EgammaCandidates/interface/PhotonCoreFwd.h
+++ b/DataFormats/EgammaCandidates/interface/PhotonCoreFwd.h
@@ -6,7 +6,10 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 namespace reco {
-  class PhotonCore;
+  namespace io_v1 {
+    class PhotonCore;
+  }
+  using PhotonCore = io_v1::PhotonCore;
 
   /// collectin of PhotonCore objects
   typedef std::vector<PhotonCore> PhotonCoreCollection;

--- a/DataFormats/EgammaCandidates/interface/PhotonFwd.h
+++ b/DataFormats/EgammaCandidates/interface/PhotonFwd.h
@@ -6,7 +6,10 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 namespace reco {
-  class Photon;
+  namespace io_v1 {
+    class Photon;
+  }
+  using Photon = io_v1::Photon;
 
   /// collectin of Photon objects
   typedef std::vector<Photon> PhotonCollection;

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -1,274 +1,196 @@
 <lcgdict>
 
-  <class name="reco::PhotonCore" ClassVersion="11">
-   <version ClassVersion="10" checksum="1420264349"/>
-   <version ClassVersion="11" checksum="3079004489"/>
-  </class>
-  <ioread sourceClass="reco::PhotonCore" version="[1-10]" targetClass="reco::PhotonCore" source="reco::SuperClusterRef pfSuperCluster_;" target="parentSuperCluster_">
-    <![CDATA[parentSuperCluster_ = onfile.pfSuperCluster_;]]>
-  </ioread>
-
-
-  <class name="reco::Photon" ClassVersion="18">
-   <version ClassVersion="18" checksum="2393532952"/>
-   <version ClassVersion="17" checksum="4077732720"/>
-   <version ClassVersion="16" checksum="3459546220"/>
-   <version ClassVersion="15" checksum="577991108"/>
-   <version ClassVersion="13" checksum="2963666409"/>
-   <version ClassVersion="14" checksum="753726370"/>
-  </class>
-  <class name="reco::Conversion" ClassVersion="3">
-   <version ClassVersion="3" checksum="2072110730"/>
-  </class>
-  <class name="reco::Electron" ClassVersion="3">
-   <version ClassVersion="3" checksum="3447704829"/>
-  </class>
-  <class name="reco::SiStripElectron" ClassVersion="13">
-   <version ClassVersion="13" checksum="1547231262"/>
-   <version ClassVersion="12" checksum="634532726"/>
-   <version ClassVersion="10" checksum="371046486"/>
-   <version ClassVersion="11" checksum="2363574304"/>
+  <class name="reco::io_v1::PhotonCore" ClassVersion="3">
+   <version ClassVersion="3" checksum="1300611279"/>
   </class>
 
-  <class name="reco::Photon::FiducialFlags" ClassVersion="10">
-   <version ClassVersion="10" checksum="2148735796"/>
+
+  <class name="reco::io_v1::Photon" ClassVersion="3">
+   <version ClassVersion="3" checksum="3470488874"/>
   </class>
-  <class name="reco::Photon::ShowerShape" ClassVersion="15">
-   <version ClassVersion="15" checksum="36297517"/>
-    <version ClassVersion="14" checksum="228715893"/>
-    <version ClassVersion="13" checksum="641067911"/>
-   <version ClassVersion="12" checksum="1586705784"/>
-   <version ClassVersion="11" checksum="2494542444"/>
+  <class name="reco::io_v1::Conversion" ClassVersion="3">
+   <version ClassVersion="3" checksum="1301674564"/>
   </class>
-  <class name="reco::Photon::SaturationInfo" ClassVersion="3">
-   <version ClassVersion="3" checksum="2679714023"/>
+  <class name="reco::io_v1::Electron" ClassVersion="3">
+   <version ClassVersion="3" checksum="1174764927"/>
   </class>
-  <class name="reco::Photon::MIPVariables" ClassVersion="10">
-   <version ClassVersion="10" checksum="1613378413"/>
+  <class name="reco::SiStripElectron" ClassVersion="3">
+   <version ClassVersion="3" checksum="352922418"/>
   </class>
-  <class name="reco::Photon::IsolationVariables" ClassVersion="12">
-   <version ClassVersion="12" checksum="4086704735"/>
-   <version ClassVersion="10" checksum="3308689624"/>
-   <version ClassVersion="11" checksum="3649971983"/>
+
+  <class name="reco::io_v1::Photon::FiducialFlags" ClassVersion="3">
+   <version ClassVersion="3" checksum="1270126670"/>
   </class>
-  <class name="reco::Photon::PflowIsolationVariables"  ClassVersion="14">
-   <version ClassVersion="11" checksum="3200292660"/>
-   <version ClassVersion="12" checksum="114160170"/>
-   <version ClassVersion="13" checksum="3959509359"/>
-   <version ClassVersion="14" checksum="4260050122"/>
-   <ioread sourceClass="reco::Photon::PflowIsolationVariables"
-	   version="[1-13]"
-	   source="float chargedHadronIso"
-	   targetClass="reco::Photon::PflowIsolationVariables"
-	   target="chargedHadronPFPVIso">
-     <![CDATA[chargedHadronPFPVIso = onfile.chargedHadronIso;]]>
-   </ioread>
+  <class name="reco::io_v1::Photon::ShowerShape" ClassVersion="3">
+   <version ClassVersion="3" checksum="696094487"/>
   </class>
-  <class name="reco::Photon::PflowIDVariables"  ClassVersion="4">
-   <version ClassVersion="4" checksum="1852864461"/>
-   <version ClassVersion="3" checksum="2819734289"/>
+  <class name="reco::io_v1::Photon::SaturationInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="3416397953"/>
   </class>
-  <class name="reco::Photon::EnergyCorrections"  ClassVersion="16">
-   <version ClassVersion="16" checksum="1544393913"/>
-   <version ClassVersion="15" checksum="2042715570"/>
+  <class name="reco::io_v1::Photon::MIPVariables" ClassVersion="3">
+   <version ClassVersion="3" checksum="4183820235"/>
+  </class>
+  <class name="reco::io_v1::Photon::IsolationVariables" ClassVersion="3">
+   <version ClassVersion="3" checksum="2155364521"/>
+  </class>
+  <class name="reco::io_v1::Photon::PflowIsolationVariables"  ClassVersion="3">
+   <version ClassVersion="3" checksum="3726336664"/>
+  </class>
+  <class name="reco::io_v1::Photon::PflowIDVariables"  ClassVersion="3">
+   <version ClassVersion="3" checksum="361867067"/>
+  </class>
+  <class name="reco::io_v1::Photon::EnergyCorrections"  ClassVersion="3">
+   <version ClassVersion="3" checksum="1790527641"/>
   </class>
   
-  <class name="std::vector<reco::PhotonCore>"/>
-  <class name="edm::reftobase::BaseHolder<reco::PhotonCore>"/>
-  <class name="edm::reftobase::IndirectHolder<reco::PhotonCore>" />
-  <class name="edm::RefToBaseProd<reco::PhotonCore>" />
-  <class name="edm::reftobase::BaseVectorHolder<reco::PhotonCore>" />
-  <class name="edm::Wrapper<std::vector<reco::PhotonCore> >"/>
-  <class name="edm::Ref<std::vector<reco::PhotonCore>,reco::PhotonCore,edm::refhelper::FindUsingAdvance<std::vector<reco::PhotonCore>,reco::PhotonCore> >"/>
-  <class name="edm::RefProd<std::vector<reco::PhotonCore> >"/>
-  <class name="edm::RefVector<std::vector<reco::PhotonCore>,reco::PhotonCore,edm::refhelper::FindUsingAdvance<std::vector<reco::PhotonCore>,reco::PhotonCore> >"/>
-  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::PhotonCore>,reco::PhotonCore,edm::refhelper::FindUsingAdvance<std::vector<reco::PhotonCore>,reco::PhotonCore> > >"/>
+  <class name="std::vector<reco::io_v1::PhotonCore>"/>
+  <class name="edm::reftobase::BaseHolder<reco::io_v1::PhotonCore>"/>
+  <class name="edm::reftobase::IndirectHolder<reco::io_v1::PhotonCore>" />
+  <class name="edm::RefToBaseProd<reco::io_v1::PhotonCore>" />
+  <class name="edm::reftobase::BaseVectorHolder<reco::io_v1::PhotonCore>" />
+  <class name="edm::Wrapper<std::vector<reco::io_v1::PhotonCore> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::PhotonCore>,reco::io_v1::PhotonCore,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PhotonCore>,reco::io_v1::PhotonCore> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::PhotonCore> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::PhotonCore>,reco::io_v1::PhotonCore,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PhotonCore>,reco::io_v1::PhotonCore> >"/>
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::io_v1::PhotonCore>,reco::io_v1::PhotonCore,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PhotonCore>,reco::io_v1::PhotonCore> > >"/>
 
 
 
-  <class name="std::vector<reco::Photon>"/>
-  <class name="edm::Wrapper<std::vector<reco::Photon> >"/>
-  <class name="edm::Ref<std::vector<reco::Photon>,reco::Photon,edm::refhelper::FindUsingAdvance<std::vector<reco::Photon>,reco::Photon> >"/>
-  <class name="std::vector<edm::Ref<std::vector<reco::Photon>,reco::Photon,edm::refhelper::FindUsingAdvance<std::vector<reco::Photon>,reco::Photon> > >"/>
-  <class name="edm::RefProd<std::vector<reco::Photon> >"/>
-  <class name="edm::RefVector<std::vector<reco::Photon>,reco::Photon,edm::refhelper::FindUsingAdvance<std::vector<reco::Photon>,reco::Photon> >"/>
-  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::Photon>,reco::Photon,edm::refhelper::FindUsingAdvance<std::vector<reco::Photon>,reco::Photon> > >"/>
-  <class name="edm::reftobase::BaseHolder<reco::Photon>"/>
-  <class name="edm::RefToBase<reco::Photon>"/>
-  <class name="edm::reftobase::IndirectHolder<reco::Photon>" />
-  <class name="edm::RefToBaseProd<reco::Photon>" />
-  <class name="edm::RefToBaseVector<reco::Photon>" />
-  <class name="edm::Wrapper<edm::RefToBaseVector<reco::Photon> >" />
-  <class name="edm::reftobase::BaseVectorHolder<reco::Photon>" />
-  <class name="edm::Wrapper<edm::ValueMap<edm::Ref<std::vector<reco::Photon>,reco::Photon,edm::refhelper::FindUsingAdvance<std::vector<reco::Photon>,reco::Photon> > > >"/>
-  <class name="edm::ValueMap<edm::Ref<std::vector<reco::Photon>,reco::Photon,edm::refhelper::FindUsingAdvance<std::vector<reco::Photon>,reco::Photon> > >"/>
+  <class name="std::vector<reco::io_v1::Photon>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::Photon> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::Photon>,reco::io_v1::Photon,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Photon>,reco::io_v1::Photon> >"/>
+  <class name="std::vector<edm::Ref<std::vector<reco::io_v1::Photon>,reco::io_v1::Photon,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Photon>,reco::io_v1::Photon> > >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::Photon> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::Photon>,reco::io_v1::Photon,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Photon>,reco::io_v1::Photon> >"/>
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::io_v1::Photon>,reco::io_v1::Photon,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Photon>,reco::io_v1::Photon> > >"/>
+  <class name="edm::reftobase::BaseHolder<reco::io_v1::Photon>"/>
+  <class name="edm::RefToBase<reco::io_v1::Photon>"/>
+  <class name="edm::reftobase::IndirectHolder<reco::io_v1::Photon>" />
+  <class name="edm::RefToBaseProd<reco::io_v1::Photon>" />
+  <class name="edm::RefToBaseVector<reco::io_v1::Photon>" />
+  <class name="edm::Wrapper<edm::RefToBaseVector<reco::io_v1::Photon> >" />
+  <class name="edm::reftobase::BaseVectorHolder<reco::io_v1::Photon>" />
+  <class name="edm::Wrapper<edm::ValueMap<edm::Ref<std::vector<reco::io_v1::Photon>,reco::io_v1::Photon,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Photon>,reco::io_v1::Photon> > > >"/>
+  <class name="edm::ValueMap<edm::Ref<std::vector<reco::io_v1::Photon>,reco::io_v1::Photon,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Photon>,reco::io_v1::Photon> > >"/>
 
 
-  <class name="std::vector<reco::Electron>"/>
-  <class name="edm::Wrapper<std::vector<reco::Electron> >"/>
-  <class name="edm::Ref<std::vector<reco::Electron>,reco::Electron,edm::refhelper::FindUsingAdvance<std::vector<reco::Electron>,reco::Electron> >"/>
-  <class name="edm::RefProd<std::vector<reco::Electron> >"/>
-  <class name="edm::RefVector<std::vector<reco::Electron>,reco::Electron,edm::refhelper::FindUsingAdvance<std::vector<reco::Electron>,reco::Electron> >"/>
-  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::Electron>,reco::Electron,edm::refhelper::FindUsingAdvance<std::vector<reco::Electron>,reco::Electron> > >"/>
+  <class name="std::vector<reco::io_v1::Electron>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::Electron> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::Electron>,reco::io_v1::Electron,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Electron>,reco::io_v1::Electron> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::Electron> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::Electron>,reco::io_v1::Electron,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Electron>,reco::io_v1::Electron> >"/>
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::io_v1::Electron>,reco::io_v1::Electron,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Electron>,reco::io_v1::Electron> > >"/>
 
 
-  <class name="edm::reftobase::BaseHolder<reco::Electron>"/>
-  <class name="edm::RefToBase<reco::Electron>"/>
-  <class name="edm::reftobase::IndirectHolder<reco::Electron>" />
-  <class name="edm::RefToBaseProd<reco::Electron>" />
-  <class name="edm::RefToBaseVector<reco::Electron>" />
-  <class name="edm::Wrapper<edm::RefToBaseVector<reco::Electron> >" />
-  <class name="edm::reftobase::BaseVectorHolder<reco::Electron>" />
+  <class name="edm::reftobase::BaseHolder<reco::io_v1::Electron>"/>
+  <class name="edm::RefToBase<reco::io_v1::Electron>"/>
+  <class name="edm::reftobase::IndirectHolder<reco::io_v1::Electron>" />
+  <class name="edm::RefToBaseProd<reco::io_v1::Electron>" />
+  <class name="edm::RefToBaseVector<reco::io_v1::Electron>" />
+  <class name="edm::Wrapper<edm::RefToBaseVector<reco::io_v1::Electron> >" />
+  <class name="edm::reftobase::BaseVectorHolder<reco::io_v1::Electron>" />
+  <class name="std::vector<edm::Ref<std::vector<reco::io_v1::Electron>,reco::io_v1::Electron,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Electron>,reco::io_v1::Electron> > >"/>
 
 
 
 
 
-  <class name="reco::GsfElectronCore" ClassVersion="3">
-   <version ClassVersion="3" checksum="1298688554"/>
+  <class name="reco::io_v1::GsfElectronCore" ClassVersion="3">
+   <version ClassVersion="3" checksum="3636860912"/>
   </class>
 
-  <class name="std::vector<reco::GsfElectronCore>"/>
-  <class name="edm::reftobase::BaseHolder<reco::GsfElectronCore>"/>
-  <class name="edm::reftobase::IndirectHolder<reco::GsfElectronCore>" />
-  <class name="edm::RefToBaseProd<reco::GsfElectronCore>" />
-  <class name="edm::reftobase::BaseVectorHolder<reco::GsfElectronCore>" />
-  <class name="edm::Wrapper<std::vector<reco::GsfElectronCore> >"/>
-  <class name="edm::Ref<std::vector<reco::GsfElectronCore>,reco::GsfElectronCore,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfElectronCore>,reco::GsfElectronCore> >"/>
-  <class name="edm::RefProd<std::vector<reco::GsfElectronCore> >"/>
-  <class name="edm::RefVector<std::vector<reco::GsfElectronCore>,reco::GsfElectronCore,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfElectronCore>,reco::GsfElectronCore> >"/>
-  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::GsfElectronCore>,reco::GsfElectronCore,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfElectronCore>,reco::GsfElectronCore> > >"/>
+  <class name="std::vector<reco::io_v1::GsfElectronCore>"/>
+  <class name="edm::reftobase::BaseHolder<reco::io_v1::GsfElectronCore>"/>
+  <class name="edm::reftobase::IndirectHolder<reco::io_v1::GsfElectronCore>" />
+  <class name="edm::RefToBaseProd<reco::io_v1::GsfElectronCore>" />
+  <class name="edm::reftobase::BaseVectorHolder<reco::io_v1::GsfElectronCore>" />
+  <class name="edm::Wrapper<std::vector<reco::io_v1::GsfElectronCore> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::GsfElectronCore>,reco::io_v1::GsfElectronCore,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GsfElectronCore>,reco::io_v1::GsfElectronCore> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::GsfElectronCore> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::GsfElectronCore>,reco::io_v1::GsfElectronCore,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GsfElectronCore>,reco::io_v1::GsfElectronCore> >"/>
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::io_v1::GsfElectronCore>,reco::io_v1::GsfElectronCore,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GsfElectronCore>,reco::io_v1::GsfElectronCore> > >"/>
 
 
-  <class name="reco::GsfElectron::TrackClusterMatching" ClassVersion="10">
-   <version ClassVersion="10" checksum="1073796225"/>
+  <class name="reco::io_v1::GsfElectron::TrackClusterMatching" ClassVersion="3">
+   <version ClassVersion="3" checksum="716311359"/>
   </class>
-  <class name="reco::GsfElectron::TrackExtrapolations" ClassVersion="10">
-   <version ClassVersion="10" checksum="517526181"/>
+  <class name="reco::io_v1::GsfElectron::TrackExtrapolations" ClassVersion="3">
+   <version ClassVersion="3" checksum="1397861923"/>
   </class>
-  <class name="reco::GsfElectron::ClosestCtfTrack" ClassVersion="3">
-   <version ClassVersion="3" checksum="3122967300"/>
+  <class name="reco::io_v1::GsfElectron::ClosestCtfTrack" ClassVersion="3">
+   <version ClassVersion="3" checksum="1255700018"/>
   </class>
-  <class name="reco::GsfElectron::FiducialFlags" ClassVersion="10">
-   <version ClassVersion="10" checksum="2564471186"/>
+  <class name="reco::io_v1::GsfElectron::FiducialFlags" ClassVersion="3">
+   <version ClassVersion="3" checksum="3810818368"/>
   </class>
-  <class name="reco::GsfElectron::ShowerShape" ClassVersion="15">
-   <version ClassVersion="15" checksum="4284492495"/>
-   <version ClassVersion="14" checksum="1877043619"/>
-   <version ClassVersion="13" checksum="1955217576"/>
-   <version ClassVersion="12" checksum="1486422105"/>
-   <version ClassVersion="11" checksum="3451347438"/>
-   <version ClassVersion="10" checksum="3070677812"/>
+  <class name="reco::io_v1::GsfElectron::ShowerShape" ClassVersion="3">
+   <version ClassVersion="3" checksum="3650979097"/>
   </class>
-  <class name="reco::GsfElectron::IsolationVariables" ClassVersion="12">
-   <version ClassVersion="12" checksum="1722203108"/>
-   <version ClassVersion="11" checksum="1799511018"/>
-   <version ClassVersion="10" checksum="4260674990"/>
+  <class name="reco::io_v1::GsfElectron::IsolationVariables" ClassVersion="3">
+   <version ClassVersion="3" checksum="2152813426"/>
   </class>
-  <class name="reco::GsfElectron::ConversionRejection" ClassVersion="3">
-   <version ClassVersion="3" checksum="2253948903"/>
+  <class name="reco::io_v1::GsfElectron::ConversionRejection" ClassVersion="3">
+   <version ClassVersion="3" checksum="2727800401"/>
   </class>
-  <class name="reco::GsfElectron::Corrections" ClassVersion="12">
-   <version ClassVersion="12" checksum="796270676"/>
-   <version ClassVersion="11" checksum="4279379731"/>
+  <class name="reco::io_v1::GsfElectron::Corrections" ClassVersion="3">
+   <version ClassVersion="3" checksum="2767668970"/>
   </class>
-  <class name="reco::GsfElectron::ChargeInfo" ClassVersion="10">
-   <version ClassVersion="10" checksum="1415326811"/>
+  <class name="reco::io_v1::GsfElectron::ChargeInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="3462684185"/>
   </class>
-  <class name="reco::GsfElectron::PflowIsolationVariables" ClassVersion="12">
-   <version ClassVersion="12" checksum="2416379203"/>
-   <version ClassVersion="11" checksum="2389048798"/>
-   <version ClassVersion="10" checksum="4270399196"/>
-  <ioread sourceClass="reco::GsfElectron::PflowIsolationVariables" version="[1-10]" source="float chargedHadronIso" targetClass="reco::GsfElectron::PflowIsolationVariables" target="sumChargedHadronPt">
-   <![CDATA[sumChargedHadronPt = onfile.chargedHadronIso;]]>
-   </ioread>
-  <ioread sourceClass="reco::GsfElectron::PflowIsolationVariables" version="[1-10]" source="float neutralHadronIso" targetClass="reco::GsfElectron::PflowIsolationVariables" target="sumNeutralHadronEt">
-   <![CDATA[sumNeutralHadronEt = onfile.neutralHadronIso;]]>
-   </ioread>
-  <ioread sourceClass="reco::GsfElectron::PflowIsolationVariables" version="[1-10]" source="float photonIso" targetClass="reco::GsfElectron::PflowIsolationVariables" target="sumPhotonEt">
-   <![CDATA[sumPhotonEt = onfile.photonIso;]]>
-   </ioread>
-  <ioread sourceClass="reco::GsfElectron::PflowIsolationVariables" version="[1-10]" source="" targetClass="reco::GsfElectron::PflowIsolationVariables" target="sumChargedParticlePt">
-   <![CDATA[sumChargedParticlePt = 0.;]]>
-   </ioread>
-  <ioread sourceClass="reco::GsfElectron::PflowIsolationVariables" version="[1-10]" source="" targetClass="reco::GsfElectron::PflowIsolationVariables" target="sumNeutralHadronEtHighThreshold">
-   <![CDATA[sumNeutralHadronEtHighThreshold = 0.;]]>
-   </ioread>
-  <ioread sourceClass="reco::GsfElectron::PflowIsolationVariables" version="[1-10]" source="" targetClass="reco::GsfElectron::PflowIsolationVariables" target="sumPhotonEtHighThreshold">
-   <![CDATA[sumPhotonEtHighThreshold = 0.;]]>
-   </ioread>
-  <ioread sourceClass="reco::GsfElectron::PflowIsolationVariables" version="[1-10]" source="" targetClass="reco::GsfElectron::PflowIsolationVariables" target="sumPUPt">
-   <![CDATA[sumPUPt = 0.;]]>
-   </ioread>
+  <class name="reco::io_v1::GsfElectron::PflowIsolationVariables" ClassVersion="3">
+   <version ClassVersion="3" checksum="2792558177"/>
   </class>
-  <class name="reco::GsfElectron::MvaInput" ClassVersion="11">
-   <version ClassVersion="11" checksum="2106253688"/>
-   <version ClassVersion="10" checksum="2786166332"/>
+  <class name="reco::io_v1::GsfElectron::MvaInput" ClassVersion="3">
+   <version ClassVersion="3" checksum="851425650"/>
   </class>
-  <class name="reco::GsfElectron::MvaOutput" ClassVersion="14">
-   <version ClassVersion="14" checksum="2762940185"/>
-   <version ClassVersion="13" checksum="632217271"/>
-   <version ClassVersion="12" checksum="3102257169"/>
-   <version ClassVersion="11" checksum="1838996036"/>
-   <version ClassVersion="10" checksum="2145829729"/>
-  </class>
-  <ioread sourceClass="reco::GsfElectron::MvaOutput" version="[1-12]" targetClass="reco::GsfElectron::MvaOutput" source="float mva;" target="mva_e_pi">
-    <![CDATA[mva_e_pi = onfile.mva;]]>
-  </ioread>
-
-  <class name="reco::GsfElectron::ClassificationVariables" ClassVersion="12">
-   <version ClassVersion="12" checksum="1990926670"/>
-   <version ClassVersion="11" checksum="2094185381"/>
-  </class>
-  <class name="reco::GsfElectron::PixelMatchVariables" ClassVersion="2">
-    <version ClassVersion="2" checksum="3522539867"/>
-  </class>
-  <class name="reco::GsfElectron::SaturationInfo" ClassVersion="3">
-   <version ClassVersion="3" checksum="3868678681"/>
+  <class name="reco::io_v1::GsfElectron::MvaOutput" ClassVersion="3">
+   <version ClassVersion="3" checksum="3886331123"/>
   </class>
 
-  <class name="reco::GsfElectron" ClassVersion="20">
-   <version ClassVersion="20" checksum="2375747450"/>
-   <version ClassVersion="19" checksum="1682285704"/>
-   <version ClassVersion="18" checksum="2072747263"/>
-   <version ClassVersion="17" checksum="1861965703"/>
-   <version ClassVersion="16" checksum="1022265405"/>
-   <version ClassVersion="15" checksum="515498629"/>
-   <version ClassVersion="14" checksum="3918953183"/>
-   <version ClassVersion="13" checksum="2991498573"/>
-   <version ClassVersion="12" checksum="2835360780"/>
-   <version ClassVersion="11" checksum="1755683850"/>
+  <class name="reco::io_v1::GsfElectron::ClassificationVariables" ClassVersion="3">
+   <version ClassVersion="3" checksum="3055851288"/>
   </class>
-  <class name="std::vector<reco::GsfElectron>"/>
-  <class name="edm::reftobase::BaseHolder<reco::GsfElectron>"/>
-  <class name="edm::RefToBase<reco::GsfElectron>"/>
-  <class name="edm::reftobase::IndirectHolder<reco::GsfElectron>" />
-  <class name="edm::RefToBaseProd<reco::GsfElectron>" />
-  <class name="edm::RefToBaseVector<reco::GsfElectron>" />
-  <class name="edm::Wrapper<edm::RefToBaseVector<reco::GsfElectron> >" />
-  <class name="edm::reftobase::BaseVectorHolder<reco::GsfElectron>" />
-  <class name="edm::Wrapper<std::vector<reco::GsfElectron> >"/>
-  <class name="edm::Ref<std::vector<reco::GsfElectron>,reco::GsfElectron,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfElectron>,reco::GsfElectron> >"/>
-  <class name="std::vector<edm::Ref<std::vector<reco::GsfElectron>,reco::GsfElectron,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfElectron>,reco::GsfElectron> > >"/>
-  <class name="edm::RefProd<std::vector<reco::GsfElectron> >"/>
-  <class name="edm::RefVector<std::vector<reco::GsfElectron>,reco::GsfElectron,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfElectron>,reco::GsfElectron> >"/>
-  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::GsfElectron>,reco::GsfElectron,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfElectron>,reco::GsfElectron> > >"/>
+  <class name="reco::io_v1::GsfElectron::PixelMatchVariables" ClassVersion="3">
+    <version ClassVersion="3" checksum="2591416853"/>
+  </class>
+  <class name="reco::io_v1::GsfElectron::SaturationInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="2494247239"/>
+  </class>
 
-  <class name="edm::Ptr<reco::GsfElectron>" />
-  <class name="edm::Wrapper<edm::Ptr<reco::GsfElectron> >" />
-  <class name="edm::PtrVector<reco::GsfElectron>" />
-  <class name="edm::Wrapper<edm::PtrVector<reco::GsfElectron> >" />
-  <class name="edm::ValueMap<edm::Ref<std::vector<reco::GsfElectron>,reco::GsfElectron,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfElectron>,reco::GsfElectron> > >"/>
-  <class name="edm::Wrapper<edm::ValueMap<edm::Ref<std::vector<reco::GsfElectron>,reco::GsfElectron,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfElectron>,reco::GsfElectron> > > >"/>
+  <class name="reco::io_v1::GsfElectron" ClassVersion="3">
+   <version ClassVersion="3" checksum="3072367774"/>
+  </class>
+  <class name="std::vector<reco::io_v1::GsfElectron>"/>
+  <class name="edm::reftobase::BaseHolder<reco::io_v1::GsfElectron>"/>
+  <class name="edm::RefToBase<reco::io_v1::GsfElectron>"/>
+  <class name="edm::reftobase::IndirectHolder<reco::io_v1::GsfElectron>" />
+  <class name="edm::RefToBaseProd<reco::io_v1::GsfElectron>" />
+  <class name="edm::RefToBaseVector<reco::io_v1::GsfElectron>" />
+  <class name="edm::Wrapper<edm::RefToBaseVector<reco::io_v1::GsfElectron> >" />
+  <class name="edm::reftobase::BaseVectorHolder<reco::io_v1::GsfElectron>" />
+  <class name="edm::Wrapper<std::vector<reco::io_v1::GsfElectron> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::GsfElectron>,reco::io_v1::GsfElectron,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GsfElectron>,reco::io_v1::GsfElectron> >"/>
+  <class name="std::vector<edm::Ref<std::vector<reco::io_v1::GsfElectron>,reco::io_v1::GsfElectron,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GsfElectron>,reco::io_v1::GsfElectron> > >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::GsfElectron> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::GsfElectron>,reco::io_v1::GsfElectron,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GsfElectron>,reco::io_v1::GsfElectron> >"/>
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::io_v1::GsfElectron>,reco::io_v1::GsfElectron,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GsfElectron>,reco::io_v1::GsfElectron> > >"/>
+
+  <class name="edm::Ptr<reco::io_v1::GsfElectron>" />
+  <class name="edm::Wrapper<edm::Ptr<reco::io_v1::GsfElectron> >" />
+  <class name="edm::PtrVector<reco::io_v1::GsfElectron>" />
+  <class name="edm::Wrapper<edm::PtrVector<reco::io_v1::GsfElectron> >" />
+  <class name="edm::ValueMap<edm::Ref<std::vector<reco::io_v1::GsfElectron>,reco::io_v1::GsfElectron,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GsfElectron>,reco::io_v1::GsfElectron> > >"/>
+  <class name="edm::Wrapper<edm::ValueMap<edm::Ref<std::vector<reco::io_v1::GsfElectron>,reco::io_v1::GsfElectron,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GsfElectron>,reco::io_v1::GsfElectron> > > >"/>
 
 
 
-  <class name="std::vector<reco::Conversion>"/>
-  <class name="edm::Wrapper<std::vector<reco::Conversion> >"/>
-  <class name="edm::Ref<std::vector<reco::Conversion>,reco::Conversion,edm::refhelper::FindUsingAdvance<std::vector<reco::Conversion>,reco::Conversion> >"/>
-  <class name="edm::RefProd<std::vector<reco::Conversion> >"/>
-  <class name="edm::RefVector<std::vector<reco::Conversion>,reco::Conversion,edm::refhelper::FindUsingAdvance<std::vector<reco::Conversion>,reco::Conversion> >"/>
-  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::Conversion>,reco::Conversion,edm::refhelper::FindUsingAdvance<std::vector<reco::Conversion>,reco::Conversion> > >"/>
+  <class name="std::vector<reco::io_v1::Conversion>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::Conversion> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::Conversion>,reco::io_v1::Conversion,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Conversion>,reco::io_v1::Conversion> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::Conversion> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::Conversion>,reco::io_v1::Conversion,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Conversion>,reco::io_v1::Conversion> >"/>
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::io_v1::Conversion>,reco::io_v1::Conversion,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Conversion>,reco::io_v1::Conversion> > >"/>
 
 
   <class name="std::vector<reco::SiStripElectron>"/>
@@ -279,18 +201,18 @@
   <class name="edm::Wrapper<edm::RefVector<std::vector<reco::SiStripElectron>,reco::SiStripElectron,edm::refhelper::FindUsingAdvance<std::vector<reco::SiStripElectron>,reco::SiStripElectron> > >"/>
 
 
-  <class name="edm::AssociationMap<edm::OneToValue<std::vector<reco::Photon>, float, unsigned int > >">
+  <class name="edm::AssociationMap<edm::OneToValue<std::vector<reco::io_v1::Photon>, float, unsigned int > >">
       <field name="transientMap_" transient="true" />
   </class>
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<std::vector<reco::Photon>, float, unsigned int > > >" />
-  <class name="edm::helpers::Key<edm::RefProd<std::vector<reco::Photon> > >" />
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<std::vector<reco::io_v1::Photon>, float, unsigned int > > >" />
+  <class name="edm::helpers::Key<edm::RefProd<std::vector<reco::io_v1::Photon> > >" />
 
 
-  <class name="edm::AssociationMap<edm::OneToValue<std::vector<reco::Electron>, float, unsigned int > >">
+  <class name="edm::AssociationMap<edm::OneToValue<std::vector<reco::io_v1::Electron>, float, unsigned int > >">
       <field name="transientMap_" transient="true" />
   </class>
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<std::vector<reco::Electron>, float, unsigned int > > >" />
-  <class name="edm::helpers::Key<edm::RefProd<std::vector<reco::Electron> > >" />
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<std::vector<reco::io_v1::Electron>, float, unsigned int > > >" />
+  <class name="edm::helpers::Key<edm::RefProd<std::vector<reco::io_v1::Electron> > >" />
 
 
   <class name="std::pair<reco::GsfElectronRef,double>"/>
@@ -315,24 +237,24 @@
   <class name="reco::GsfElectronIsoNumCollectionRefVector"/>
   <class name="edm::Wrapper<reco::GsfElectronIsoNumCollection>"/>
 
-  <class name="edm::reftobase::Holder<reco::Candidate, reco::GsfElectronRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::GsfElectronRef>" />
   <class name="edm::reftobase::RefHolder<reco::GsfElectronRef>" />
-  <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::GsfElectronRefVector>" />
+  <class name="edm::reftobase::VectorHolder<reco::io_v1::Candidate, reco::GsfElectronRefVector>" />
   <class name="edm::reftobase::RefVectorHolder<reco::GsfElectronRefVector>" />
 
-  <class name="edm::reftobase::Holder<reco::Candidate, reco::PhotonRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::PhotonRef>" />
   <class name="edm::reftobase::RefHolder<reco::PhotonRef>" />
-  <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::PhotonRefVector>" />
+  <class name="edm::reftobase::VectorHolder<reco::io_v1::Candidate, reco::PhotonRefVector>" />
   <class name="edm::reftobase::RefVectorHolder<reco::PhotonRefVector>" />
 
-  <class name="edm::AssociationMap<edm::OneToOne<std::vector<reco::Photon>,edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,unsigned int> >">
+  <class name="edm::AssociationMap<edm::OneToOne<std::vector<reco::io_v1::Photon>,edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,unsigned int> >">
      <field name="transientMap_" transient="true" />
   </class>
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::Photon> >,edm::RefProd<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> > > >" />
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<std::vector<reco::Photon>,edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,unsigned int> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::io_v1::Photon> >,edm::RefProd<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> > > >" />
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<std::vector<reco::io_v1::Photon>,edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,unsigned int> > >" />
 
-  <class name="edm::Ptr<reco::Photon>" />
-  <class name="edm::PtrVector<reco::Photon>" />
+  <class name="edm::Ptr<reco::io_v1::Photon>" />
+  <class name="edm::PtrVector<reco::io_v1::Photon>" />
 
   <class name="reco::HIPhotonIsolation" ClassVersion="2">
     <version ClassVersion="2" checksum="1971638020"/>

--- a/DataFormats/EgammaReco/interface/ElectronSeed.h
+++ b/DataFormats/EgammaReco/interface/ElectronSeed.h
@@ -47,112 +47,115 @@
 #include <limits>
 
 namespace reco {
+  namespace io_v1 {
 
-  class ElectronSeed : public TrajectorySeed {
-  public:
-    struct PMVars {
-      float dRZPos;
-      float dRZNeg;
-      float dPhiPos;
-      float dPhiNeg;
-      int detId;          //this is already stored as the hit is stored in traj seed but a useful sanity check
-      int layerOrDiskNr;  //redundant as stored in detId but its a huge pain to hence why its saved here
+    class ElectronSeed : public TrajectorySeed {
+    public:
+      struct PMVars {
+        float dRZPos;
+        float dRZNeg;
+        float dPhiPos;
+        float dPhiNeg;
+        int detId;          //this is already stored as the hit is stored in traj seed but a useful sanity check
+        int layerOrDiskNr;  //redundant as stored in detId but its a huge pain to hence why its saved here
 
-      PMVars();
+        PMVars();
 
-      void setDPhi(float pos, float neg);
-      void setDRZ(float pos, float neg);
-      void setDet(int iDetId, int iLayerOrDiskNr);
+        void setDPhi(float pos, float neg);
+        void setDRZ(float pos, float neg);
+        void setDet(int iDetId, int iLayerOrDiskNr);
+      };
+
+      typedef edm::RefToBase<CaloCluster> CaloClusterRef;
+      typedef edm::Ref<TrackCollection> CtfTrackRef;
+
+      static std::string const& name() {
+        static std::string const name_("ElectronSeed");
+        return name_;
+      }
+
+      //! Construction of base attributes
+      ElectronSeed();
+      ElectronSeed(const TrajectorySeed&);
+      ElectronSeed(PTrajectoryStateOnDet& pts, RecHitContainer& rh, PropagationDirection& dir);
+      ElectronSeed* clone() const override { return new ElectronSeed(*this); }
+      ~ElectronSeed() override;
+
+      //! Set additional info
+      void setCtfTrack(const CtfTrackRef&);
+      void setCaloCluster(const CaloClusterRef& clus) {
+        caloCluster_ = clus;
+        isEcalDriven_ = true;
+      }
+      void addHitInfo(const PMVars& hitVars) { hitInfo_.push_back(hitVars); }
+      void setNrLayersAlongTraj(int val) { nrLayersAlongTraj_ = val; }
+      //! Accessors
+      const CtfTrackRef& ctfTrack() const { return ctfTrack_; }
+      const CaloClusterRef& caloCluster() const { return caloCluster_; }
+
+      //! Utility
+      TrackCharge getCharge() const { return startingState().parameters().charge(); }
+
+      bool isEcalDriven() const { return isEcalDriven_; }
+      bool isTrackerDriven() const { return isTrackerDriven_; }
+
+      const std::vector<PMVars>& hitInfo() const { return hitInfo_; }
+      float dPhiNeg(size_t hitNr) const { return getVal(hitNr, &PMVars::dPhiNeg); }
+      float dPhiPos(size_t hitNr) const { return getVal(hitNr, &PMVars::dPhiPos); }
+      float dPhiBest(size_t hitNr) const { return bestVal(dPhiNeg(hitNr), dPhiPos(hitNr)); }
+      float dRZPos(size_t hitNr) const { return getVal(hitNr, &PMVars::dRZPos); }
+      float dRZNeg(size_t hitNr) const { return getVal(hitNr, &PMVars::dRZNeg); }
+      float dRZBest(size_t hitNr) const { return bestVal(dRZNeg(hitNr), dRZPos(hitNr)); }
+      int detId(size_t hitNr) const { return hitNr < hitInfo_.size() ? hitInfo_[hitNr].detId : 0; }
+      int subDet(size_t hitNr) const { return DetId(detId(hitNr)).subdetId(); }
+      int layerOrDiskNr(size_t hitNr) const { return getVal(hitNr, &PMVars::layerOrDiskNr); }
+      int nrLayersAlongTraj() const { return nrLayersAlongTraj_; }
+
+      unsigned int hitsMask() const;
+      void initTwoHitSeed(const unsigned char hitMask);
+      void setNegAttributes(const float dRZ2 = std::numeric_limits<float>::max(),
+                            const float dPhi2 = std::numeric_limits<float>::max(),
+                            const float dRZ1 = std::numeric_limits<float>::max(),
+                            const float dPhi1 = std::numeric_limits<float>::max());
+      void setPosAttributes(const float dRZ2 = std::numeric_limits<float>::max(),
+                            const float dPhi2 = std::numeric_limits<float>::max(),
+                            const float dRZ1 = std::numeric_limits<float>::max(),
+                            const float dPhi1 = std::numeric_limits<float>::max());
+
+      //this is a backwards compatible function designed to
+      //convert old format ElectronSeeds to the new format
+      //only public due to root io rules, not intended for any other use
+      //also in theory not necessary to part of this class
+      static std::vector<PMVars> createHitInfo(const float dPhi1Pos,
+                                               const float dPhi1Neg,
+                                               const float dRZ1Pos,
+                                               const float dRZ1Neg,
+                                               const float dPhi2Pos,
+                                               const float dPhi2Neg,
+                                               const float dRZ2Pos,
+                                               const float dRZ2Neg,
+                                               const char hitMask,
+                                               TrajectorySeed::RecHitRange const& recHits);
+
+    private:
+      static float bestVal(float val1, float val2) { return std::abs(val1) < std::abs(val2) ? val1 : val2; }
+      template <typename T>
+      T getVal(unsigned int hitNr, T PMVars::*val) const {
+        return hitNr < hitInfo_.size() ? hitInfo_[hitNr].*val : std::numeric_limits<T>::max();
+      }
+      static std::vector<unsigned int> hitNrsFromMask(unsigned int hitMask);
+
+    private:
+      CtfTrackRef ctfTrack_;
+      CaloClusterRef caloCluster_;
+      std::vector<PMVars> hitInfo_;
+      int nrLayersAlongTraj_;
+
+      bool isEcalDriven_;
+      bool isTrackerDriven_;
     };
-
-    typedef edm::RefToBase<CaloCluster> CaloClusterRef;
-    typedef edm::Ref<TrackCollection> CtfTrackRef;
-
-    static std::string const& name() {
-      static std::string const name_("ElectronSeed");
-      return name_;
-    }
-
-    //! Construction of base attributes
-    ElectronSeed();
-    ElectronSeed(const TrajectorySeed&);
-    ElectronSeed(PTrajectoryStateOnDet& pts, RecHitContainer& rh, PropagationDirection& dir);
-    ElectronSeed* clone() const override { return new ElectronSeed(*this); }
-    ~ElectronSeed() override;
-
-    //! Set additional info
-    void setCtfTrack(const CtfTrackRef&);
-    void setCaloCluster(const CaloClusterRef& clus) {
-      caloCluster_ = clus;
-      isEcalDriven_ = true;
-    }
-    void addHitInfo(const PMVars& hitVars) { hitInfo_.push_back(hitVars); }
-    void setNrLayersAlongTraj(int val) { nrLayersAlongTraj_ = val; }
-    //! Accessors
-    const CtfTrackRef& ctfTrack() const { return ctfTrack_; }
-    const CaloClusterRef& caloCluster() const { return caloCluster_; }
-
-    //! Utility
-    TrackCharge getCharge() const { return startingState().parameters().charge(); }
-
-    bool isEcalDriven() const { return isEcalDriven_; }
-    bool isTrackerDriven() const { return isTrackerDriven_; }
-
-    const std::vector<PMVars>& hitInfo() const { return hitInfo_; }
-    float dPhiNeg(size_t hitNr) const { return getVal(hitNr, &PMVars::dPhiNeg); }
-    float dPhiPos(size_t hitNr) const { return getVal(hitNr, &PMVars::dPhiPos); }
-    float dPhiBest(size_t hitNr) const { return bestVal(dPhiNeg(hitNr), dPhiPos(hitNr)); }
-    float dRZPos(size_t hitNr) const { return getVal(hitNr, &PMVars::dRZPos); }
-    float dRZNeg(size_t hitNr) const { return getVal(hitNr, &PMVars::dRZNeg); }
-    float dRZBest(size_t hitNr) const { return bestVal(dRZNeg(hitNr), dRZPos(hitNr)); }
-    int detId(size_t hitNr) const { return hitNr < hitInfo_.size() ? hitInfo_[hitNr].detId : 0; }
-    int subDet(size_t hitNr) const { return DetId(detId(hitNr)).subdetId(); }
-    int layerOrDiskNr(size_t hitNr) const { return getVal(hitNr, &PMVars::layerOrDiskNr); }
-    int nrLayersAlongTraj() const { return nrLayersAlongTraj_; }
-
-    unsigned int hitsMask() const;
-    void initTwoHitSeed(const unsigned char hitMask);
-    void setNegAttributes(const float dRZ2 = std::numeric_limits<float>::max(),
-                          const float dPhi2 = std::numeric_limits<float>::max(),
-                          const float dRZ1 = std::numeric_limits<float>::max(),
-                          const float dPhi1 = std::numeric_limits<float>::max());
-    void setPosAttributes(const float dRZ2 = std::numeric_limits<float>::max(),
-                          const float dPhi2 = std::numeric_limits<float>::max(),
-                          const float dRZ1 = std::numeric_limits<float>::max(),
-                          const float dPhi1 = std::numeric_limits<float>::max());
-
-    //this is a backwards compatible function designed to
-    //convert old format ElectronSeeds to the new format
-    //only public due to root io rules, not intended for any other use
-    //also in theory not necessary to part of this class
-    static std::vector<PMVars> createHitInfo(const float dPhi1Pos,
-                                             const float dPhi1Neg,
-                                             const float dRZ1Pos,
-                                             const float dRZ1Neg,
-                                             const float dPhi2Pos,
-                                             const float dPhi2Neg,
-                                             const float dRZ2Pos,
-                                             const float dRZ2Neg,
-                                             const char hitMask,
-                                             TrajectorySeed::RecHitRange const& recHits);
-
-  private:
-    static float bestVal(float val1, float val2) { return std::abs(val1) < std::abs(val2) ? val1 : val2; }
-    template <typename T>
-    T getVal(unsigned int hitNr, T PMVars::*val) const {
-      return hitNr < hitInfo_.size() ? hitInfo_[hitNr].*val : std::numeric_limits<T>::max();
-    }
-    static std::vector<unsigned int> hitNrsFromMask(unsigned int hitMask);
-
-  private:
-    CtfTrackRef ctfTrack_;
-    CaloClusterRef caloCluster_;
-    std::vector<PMVars> hitInfo_;
-    int nrLayersAlongTraj_;
-
-    bool isEcalDriven_;
-    bool isTrackerDriven_;
-  };
+  }  // namespace io_v1
+  using ElectronSeed = io_v1::ElectronSeed;
 }  // namespace reco
 
 #endif

--- a/DataFormats/EgammaReco/interface/ElectronSeedFwd.h
+++ b/DataFormats/EgammaReco/interface/ElectronSeedFwd.h
@@ -7,7 +7,10 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 namespace reco {
-  class ElectronSeed;
+  namespace io_v1 {
+    class ElectronSeed;
+  }
+  using ElectronSeed = io_v1::ElectronSeed;
   /// collection of ElectronSeed objects
   typedef std::vector<ElectronSeed> ElectronSeedCollection;
   /// reference to an object in a collection of ElectronSeed objects

--- a/DataFormats/EgammaReco/interface/HFEMClusterShape.h
+++ b/DataFormats/EgammaReco/interface/HFEMClusterShape.h
@@ -16,57 +16,60 @@
  */
 
 namespace reco {
+  namespace io_v1 {
 
-  class HFEMClusterShape {
-  public:
-    HFEMClusterShape() {}
+    class HFEMClusterShape {
+    public:
+      HFEMClusterShape() {}
 
-    HFEMClusterShape(double eLong1x1,
-                     double eShort1x1,
-                     double eLong3x3,
-                     double eShort3x3,
-                     double eLong5x5,
-                     double eShort5x5,
-                     double eLongCore,
-                     double CellEta,
-                     double CellPhi,
-                     DetId seed);
+      HFEMClusterShape(double eLong1x1,
+                       double eShort1x1,
+                       double eLong3x3,
+                       double eShort3x3,
+                       double eLong5x5,
+                       double eShort5x5,
+                       double eLongCore,
+                       double CellEta,
+                       double CellPhi,
+                       DetId seed);
 
-    //energy in long or short fibers various cluster sizes
-    double eLong1x1() const { return eLong1x1_; }
-    double eShort1x1() const { return eShort1x1_; }
-    double eLong3x3() const { return eLong3x3_; }
-    double eShort3x3() const { return eShort3x3_; }
-    double eLong5x5() const { return eLong5x5_; }
-    double eShort5x5() const { return eShort5x5_; }
+      //energy in long or short fibers various cluster sizes
+      double eLong1x1() const { return eLong1x1_; }
+      double eShort1x1() const { return eShort1x1_; }
+      double eLong3x3() const { return eLong3x3_; }
+      double eShort3x3() const { return eShort3x3_; }
+      double eLong5x5() const { return eLong5x5_; }
+      double eShort5x5() const { return eShort5x5_; }
 
-    //total energy in various clusters
-    double e1x1() const;
-    double e3x3() const;
-    double e5x5() const;
+      //total energy in various clusters
+      double e1x1() const;
+      double e3x3() const;
+      double e5x5() const;
 
-    //Identification Variables
-    //Longetudinal variable: E(3x3,short fibers)/E(3x3,long fibers)
-    double eSeL() const;
-    //Transverse Variable: E(Core of cluster)/E(3x3)
-    double eCOREe9() const;
-    //Shower Exclusion Variable: E(3x3)/E(5x5)
-    double e9e25() const;
+      //Identification Variables
+      //Longetudinal variable: E(3x3,short fibers)/E(3x3,long fibers)
+      double eSeL() const;
+      //Transverse Variable: E(Core of cluster)/E(3x3)
+      double eCOREe9() const;
+      //Shower Exclusion Variable: E(3x3)/E(5x5)
+      double e9e25() const;
 
-    //energy in central highest energy cells (at least 50% energy of previous total energy startign with seed cell)
-    double eCore() const { return eLongCore_; }
+      //energy in central highest energy cells (at least 50% energy of previous total energy startign with seed cell)
+      double eCore() const { return eLongCore_; }
 
-    double CellEta() const { return CellEta_; }
-    double CellPhi() const { return CellPhi_; }
+      double CellEta() const { return CellEta_; }
+      double CellPhi() const { return CellPhi_; }
 
-    //seed cell of cluster DetId
-    DetId seed() const { return seed_; }
+      //seed cell of cluster DetId
+      DetId seed() const { return seed_; }
 
-  private:
-    double eLong1x1_, eShort1x1_, eLong3x3_, eShort3x3_, eLong5x5_, eShort5x5_, eLongCore_, CellEta_, CellPhi_;
-    DetId seed_;
-  };
+    private:
+      double eLong1x1_, eShort1x1_, eLong3x3_, eShort3x3_, eLong5x5_, eShort5x5_, eLongCore_, CellEta_, CellPhi_;
+      DetId seed_;
+    };
 
+  }  // namespace io_v1
+  using HFEMClusterShape = io_v1::HFEMClusterShape;
 }  // namespace reco
 
 #endif

--- a/DataFormats/EgammaReco/interface/HFEMClusterShapeFwd.h
+++ b/DataFormats/EgammaReco/interface/HFEMClusterShapeFwd.h
@@ -5,7 +5,10 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 namespace reco {
-  class HFEMClusterShape;
+  namespace io_v1 {
+    class HFEMClusterShape;
+  }
+  using HFEMClusterShape = io_v1::HFEMClusterShape;
   // collection of HFEMClusterShape objects
   typedef std::vector<HFEMClusterShape> HFEMClusterShapeCollection;
 

--- a/DataFormats/EgammaReco/interface/PreshowerCluster.h
+++ b/DataFormats/EgammaReco/interface/PreshowerCluster.h
@@ -13,53 +13,56 @@
 #include <cmath>
 
 namespace reco {
+  namespace io_v1 {
 
-  class PreshowerCluster : public CaloCluster {
-  public:
-    typedef math::XYZPoint Point;
+    class PreshowerCluster : public CaloCluster {
+    public:
+      typedef math::XYZPoint Point;
 
-    /// default constructor
-    PreshowerCluster() : CaloCluster(0., Point(0., 0., 0.)) {}
+      /// default constructor
+      PreshowerCluster() : CaloCluster(0., Point(0., 0., 0.)) {}
 
-    ~PreshowerCluster() override;
+      ~PreshowerCluster() override;
 
-    /// Constructor from EcalRecHits
-    PreshowerCluster(const double E,
-                     const Point& pos,
-                     const std::vector<std::pair<DetId, float> >& usedHits,
-                     const int plane);
+      /// Constructor from EcalRecHits
+      PreshowerCluster(const double E,
+                       const Point& pos,
+                       const std::vector<std::pair<DetId, float> >& usedHits,
+                       const int plane);
 
-    /// Constructor from cluster
-    PreshowerCluster(const PreshowerCluster&);
+      /// Constructor from cluster
+      PreshowerCluster(const PreshowerCluster&);
 
-    /// Number of RecHits the cluster
-    int nhits() const { return hitsAndFractions_.size(); }
+      /// Number of RecHits the cluster
+      int nhits() const { return hitsAndFractions_.size(); }
 
-    /// Preshower plane
-    int plane() const { return plane_; }
+      /// Preshower plane
+      int plane() const { return plane_; }
 
-    double et() const { return energy() / cosh(eta()); }
+      double et() const { return energy() / cosh(eta()); }
 
-    /// Comparisons
-    bool operator==(const PreshowerCluster&) const;
-    bool operator<(const PreshowerCluster&) const;
+      /// Comparisons
+      bool operator==(const PreshowerCluster&) const;
+      bool operator<(const PreshowerCluster&) const;
 
-    /// Associated basic cluster;
-    CaloClusterPtr basicCluster() const { return bc_ref_; }
+      /// Associated basic cluster;
+      CaloClusterPtr basicCluster() const { return bc_ref_; }
 
-    /// DetIds of component RecHits -- now inherited from CaloCluster
-    //std::vector<DetId> getHitsByDetId() const { return usedHits_; }
+      /// DetIds of component RecHits -- now inherited from CaloCluster
+      //std::vector<DetId> getHitsByDetId() const { return usedHits_; }
 
-    void setBCRef(const CaloClusterPtr& r) { bc_ref_ = r; }
+      void setBCRef(const CaloClusterPtr& r) { bc_ref_ = r; }
 
-  private:
-    int plane_;
+    private:
+      int plane_;
 
-    /// Associated basic cluster;
-    CaloClusterPtr bc_ref_;
+      /// Associated basic cluster;
+      CaloClusterPtr bc_ref_;
 
-    /// used hits by detId -- now inherited from CaloCluster
-    //std::vector<DetId> usedHits_;
-  };
+      /// used hits by detId -- now inherited from CaloCluster
+      //std::vector<DetId> usedHits_;
+    };
+  }  // namespace io_v1
+  using PreshowerCluster = io_v1::PreshowerCluster;
 }  // namespace reco
 #endif

--- a/DataFormats/EgammaReco/interface/PreshowerClusterFwd.h
+++ b/DataFormats/EgammaReco/interface/PreshowerClusterFwd.h
@@ -9,7 +9,10 @@
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 
 namespace reco {
-  class PreshowerCluster;
+  namespace io_v1 {
+    class PreshowerCluster;
+  }
+  using PreshowerCluster = io_v1::PreshowerCluster;
 
   /// collection of PreshowerCluster objects
   typedef std::vector<PreshowerCluster> PreshowerClusterCollection;

--- a/DataFormats/EgammaReco/interface/PreshowerClusterShape.h
+++ b/DataFormats/EgammaReco/interface/PreshowerClusterShape.h
@@ -10,39 +10,42 @@
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  class PreshowerClusterShape {
-  public:
-    /// default constructor
-    PreshowerClusterShape() {}
+    class PreshowerClusterShape {
+    public:
+      /// default constructor
+      PreshowerClusterShape() {}
 
-    virtual ~PreshowerClusterShape();
+      virtual ~PreshowerClusterShape();
 
-    /// constructor from strip energies
-    PreshowerClusterShape(const std::vector<float>& stripEnergies, const int plane);
+      /// constructor from strip energies
+      PreshowerClusterShape(const std::vector<float>& stripEnergies, const int plane);
 
-    /// Copy contructor
-    PreshowerClusterShape(const PreshowerClusterShape&);
+      /// Copy contructor
+      PreshowerClusterShape(const PreshowerClusterShape&);
 
-    /// Preshower plane
-    int plane() const { return plane_; }
+      /// Preshower plane
+      int plane() const { return plane_; }
 
-    /// Associated SuperCluster;
-    SuperClusterRef superCluster() const { return sc_ref_; }
+      /// Associated SuperCluster;
+      SuperClusterRef superCluster() const { return sc_ref_; }
 
-    /// Energies of component strips
-    virtual std::vector<float> getStripEnergies() const { return stripEnergies_; }
+      /// Energies of component strips
+      virtual std::vector<float> getStripEnergies() const { return stripEnergies_; }
 
-    void setSCRef(const SuperClusterRef& r) { sc_ref_ = r; }
+      void setSCRef(const SuperClusterRef& r) { sc_ref_ = r; }
 
-  private:
-    int plane_;
+    private:
+      int plane_;
 
-    /// Associated super cluster;
-    SuperClusterRef sc_ref_;
+      /// Associated super cluster;
+      SuperClusterRef sc_ref_;
 
-    /// used strip energies
-    std::vector<float> stripEnergies_;
-  };
+      /// used strip energies
+      std::vector<float> stripEnergies_;
+    };
+  }  // namespace io_v1
+  using PreshowerClusterShape = io_v1::PreshowerClusterShape;
 }  // namespace reco
 #endif

--- a/DataFormats/EgammaReco/interface/PreshowerClusterShapeFwd.h
+++ b/DataFormats/EgammaReco/interface/PreshowerClusterShapeFwd.h
@@ -10,7 +10,10 @@
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 
 namespace reco {
-  class PreshowerClusterShape;
+  namespace io_v1 {
+    class PreshowerClusterShape;
+  }
+  using PreshowerClusterShape = io_v1::PreshowerClusterShape;
 
   /// collection of PreshowerClusterShape objects
   typedef std::vector<PreshowerClusterShape> PreshowerClusterShapeCollection;

--- a/DataFormats/EgammaReco/interface/SuperCluster.h
+++ b/DataFormats/EgammaReco/interface/SuperCluster.h
@@ -17,187 +17,190 @@
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 
 namespace reco {
-  class SuperCluster : public CaloCluster {
-  public:
-    typedef math::XYZPoint Point;
+  namespace io_v1 {
+    class SuperCluster : public CaloCluster {
+    public:
+      typedef math::XYZPoint Point;
 
-    /// default constructor
-    SuperCluster()
-        : CaloCluster(0., Point(0., 0., 0.)),
-          preshowerEnergy_(0),
-          rawEnergy_(-1.),
-          phiWidth_(0),
-          etaWidth_(0),
-          preshowerEnergy1_(0),
-          preshowerEnergy2_(0) {}
+      /// default constructor
+      SuperCluster()
+          : CaloCluster(0., Point(0., 0., 0.)),
+            preshowerEnergy_(0),
+            rawEnergy_(-1.),
+            phiWidth_(0),
+            etaWidth_(0),
+            preshowerEnergy1_(0),
+            preshowerEnergy2_(0) {}
 
-    /// constructor defined by CaloCluster - will have to use setSeed and add() separately
-    SuperCluster(double energy, const Point& position);
+      /// constructor defined by CaloCluster - will have to use setSeed and add() separately
+      SuperCluster(double energy, const Point& position);
 
-    SuperCluster(double energy,
-                 const Point& position,
-                 const CaloClusterPtr& seed,
-                 const CaloClusterPtrVector& clusters,
-                 double Epreshower = 0.,
-                 double phiWidth = 0.,
-                 double etaWidth = 0.,
-                 double Epreshower1 = 0.,
-                 double Epreshower2 = 0.);
+      SuperCluster(double energy,
+                   const Point& position,
+                   const CaloClusterPtr& seed,
+                   const CaloClusterPtrVector& clusters,
+                   double Epreshower = 0.,
+                   double phiWidth = 0.,
+                   double etaWidth = 0.,
+                   double Epreshower1 = 0.,
+                   double Epreshower2 = 0.);
 
-    // to be merged in the previous one? -- FIXME
-    SuperCluster(double energy,
-                 const Point& position,
-                 const CaloClusterPtr& seed,
-                 const CaloClusterPtrVector& clusters,
-                 const CaloClusterPtrVector& preshowerClusters,
-                 double Epreshower = 0.,
-                 double phiWidth = 0.,
-                 double etaWidth = 0.,
-                 double Epreshower1 = 0.,
-                 double Epreshower2 = 0.);
+      // to be merged in the previous one? -- FIXME
+      SuperCluster(double energy,
+                   const Point& position,
+                   const CaloClusterPtr& seed,
+                   const CaloClusterPtrVector& clusters,
+                   const CaloClusterPtrVector& preshowerClusters,
+                   double Epreshower = 0.,
+                   double phiWidth = 0.,
+                   double etaWidth = 0.,
+                   double Epreshower1 = 0.,
+                   double Epreshower2 = 0.);
 
-    /// raw uncorrected energy (sum of energies of component BasicClusters)
-    double rawEnergy() const { return rawEnergy_; }
+      /// raw uncorrected energy (sum of energies of component BasicClusters)
+      double rawEnergy() const { return rawEnergy_; }
 
-    /// energy deposited in preshower
-    double preshowerEnergy() const { return preshowerEnergy_; }
-    double preshowerEnergyPlane1() const { return preshowerEnergy1_; }
-    double preshowerEnergyPlane2() const { return preshowerEnergy2_; }
+      /// energy deposited in preshower
+      double preshowerEnergy() const { return preshowerEnergy_; }
+      double preshowerEnergyPlane1() const { return preshowerEnergy1_; }
+      double preshowerEnergyPlane2() const { return preshowerEnergy2_; }
 
-    /// obtain phi and eta width of the Super Cluster
-    double phiWidth() const { return phiWidth_; }
-    double etaWidth() const { return etaWidth_; }
+      /// obtain phi and eta width of the Super Cluster
+      double phiWidth() const { return phiWidth_; }
+      double etaWidth() const { return etaWidth_; }
 
-    //Assign new variables to supercluster
-    void setPreshowerEnergy(double preshowerEnergy) { preshowerEnergy_ = preshowerEnergy; };
-    void setPreshowerEnergyPlane1(double preshowerEnergy1) { preshowerEnergy1_ = preshowerEnergy1; };
-    void setPreshowerEnergyPlane2(double preshowerEnergy2) { preshowerEnergy2_ = preshowerEnergy2; };
-    void setPhiWidth(double pw) { phiWidth_ = pw; }
-    void setEtaWidth(double ew) { etaWidth_ = ew; }
+      //Assign new variables to supercluster
+      void setPreshowerEnergy(double preshowerEnergy) { preshowerEnergy_ = preshowerEnergy; };
+      void setPreshowerEnergyPlane1(double preshowerEnergy1) { preshowerEnergy1_ = preshowerEnergy1; };
+      void setPreshowerEnergyPlane2(double preshowerEnergy2) { preshowerEnergy2_ = preshowerEnergy2; };
+      void setPhiWidth(double pw) { phiWidth_ = pw; }
+      void setEtaWidth(double ew) { etaWidth_ = ew; }
 
-    /// seed BasicCluster
-    const CaloClusterPtr& seed() const { return seed_; }
+      /// seed BasicCluster
+      const CaloClusterPtr& seed() const { return seed_; }
 
-    /// const access to the cluster list itself
-    const CaloClusterPtrVector& clusters() const { return clusters_; }
+      /// const access to the cluster list itself
+      const CaloClusterPtrVector& clusters() const { return clusters_; }
 
-    /// const access to the preshower cluster list itself
-    const CaloClusterPtrVector& preshowerClusters() const { return preshowerClusters_; }
+      /// const access to the preshower cluster list itself
+      const CaloClusterPtrVector& preshowerClusters() const { return preshowerClusters_; }
 
-    /// fist iterator over BasicCluster constituents
-    CaloCluster_iterator clustersBegin() const { return clusters_.begin(); }
+      /// fist iterator over BasicCluster constituents
+      CaloCluster_iterator clustersBegin() const { return clusters_.begin(); }
 
-    /// last iterator over BasicCluster constituents
-    CaloCluster_iterator clustersEnd() const { return clusters_.end(); }
+      /// last iterator over BasicCluster constituents
+      CaloCluster_iterator clustersEnd() const { return clusters_.end(); }
 
-    /// fist iterator over PreshowerCluster constituents
-    CaloCluster_iterator preshowerClustersBegin() const { return preshowerClusters_.begin(); }
+      /// fist iterator over PreshowerCluster constituents
+      CaloCluster_iterator preshowerClustersBegin() const { return preshowerClusters_.begin(); }
 
-    /// last iterator over PreshowerCluster constituents
-    CaloCluster_iterator preshowerClustersEnd() const { return preshowerClusters_.end(); }
+      /// last iterator over PreshowerCluster constituents
+      CaloCluster_iterator preshowerClustersEnd() const { return preshowerClusters_.end(); }
 
-    /// number of BasicCluster constituents
-    size_t clustersSize() const { return clusters_.size(); }
+      /// number of BasicCluster constituents
+      size_t clustersSize() const { return clusters_.size(); }
 
-    /// number of BasicCluster PreShower constituents
-    size_t preshowerClustersSize() const { return preshowerClusters_.size(); }
+      /// number of BasicCluster PreShower constituents
+      size_t preshowerClustersSize() const { return preshowerClusters_.size(); }
 
-    /// list of used xtals by DetId // now inherited by CaloCluster
-    //std::vector<DetId> getHitsByDetId() const { return usedHits_; }
+      /// list of used xtals by DetId // now inherited by CaloCluster
+      //std::vector<DetId> getHitsByDetId() const { return usedHits_; }
 
-    /// set reference to seed BasicCluster
-    void setSeed(const CaloClusterPtr& r) { seed_ = r; }
+      /// set reference to seed BasicCluster
+      void setSeed(const CaloClusterPtr& r) { seed_ = r; }
 
-    //(re)-set clusters
-    void setClusters(const CaloClusterPtrVector& clusters) {
-      clusters_ = clusters;
-      computeRawEnergy();
-    }
+      //(re)-set clusters
+      void setClusters(const CaloClusterPtrVector& clusters) {
+        clusters_ = clusters;
+        computeRawEnergy();
+      }
 
-    //(re)-set preshower clusters
-    void setPreshowerClusters(const CaloClusterPtrVector& clusters) { preshowerClusters_ = clusters; }
+      //(re)-set preshower clusters
+      void setPreshowerClusters(const CaloClusterPtrVector& clusters) { preshowerClusters_ = clusters; }
 
-    //clear hits and fractions vector (for slimming)
-    void clearHitsAndFractions() { hitsAndFractions_.clear(); }
+      //clear hits and fractions vector (for slimming)
+      void clearHitsAndFractions() { hitsAndFractions_.clear(); }
 
-    /// add reference to constituent BasicCluster
-    void addCluster(const CaloClusterPtr& r) {
-      clusters_.push_back(r);
-      computeRawEnergy();
-    }
+      /// add reference to constituent BasicCluster
+      void addCluster(const CaloClusterPtr& r) {
+        clusters_.push_back(r);
+        computeRawEnergy();
+      }
 
-    /// add reference to constituent BasicCluster
-    void addPreshowerCluster(const CaloClusterPtr& r) { preshowerClusters_.push_back(r); }
+      /// add reference to constituent BasicCluster
+      void addPreshowerCluster(const CaloClusterPtr& r) { preshowerClusters_.push_back(r); }
 
-    /** Set preshower planes status :
+      /** Set preshower planes status :
         0 : both planes working
         1 : only first plane working
         2 : only second plane working
         3 : both planes dead */
 
-    void setPreshowerPlanesStatus(const uint32_t& status) {
-      uint32_t flags = flags_ & flagsMask_;
-      flags_ = flags | (status << flagsOffset_);
-    }
+      void setPreshowerPlanesStatus(const uint32_t& status) {
+        uint32_t flags = flags_ & flagsMask_;
+        flags_ = flags | (status << flagsOffset_);
+      }
 
-    /** Get preshower planes status :
+      /** Get preshower planes status :
         0 : both planes working
         1 : only first plane working
         2 : only second plane working
         3 : both planes dead */
-    const int getPreshowerPlanesStatus() const { return (flags_ >> flagsOffset_); }
+      const int getPreshowerPlanesStatus() const { return (flags_ >> flagsOffset_); }
 
-    const int seedCrysIEtaOrIx() const {
-      auto detid = seed_->seed();
-      int ietaorix = 0;
-      if (detid.subdetId() == EcalBarrel) {
-        EBDetId ebdetid(detid);
-        ietaorix = ebdetid.ieta();
-      } else if (detid.subdetId() == EcalEndcap) {
-        EEDetId eedetid(detid);
-        ietaorix = eedetid.ix();
+      const int seedCrysIEtaOrIx() const {
+        auto detid = seed_->seed();
+        int ietaorix = 0;
+        if (detid.subdetId() == EcalBarrel) {
+          EBDetId ebdetid(detid);
+          ietaorix = ebdetid.ieta();
+        } else if (detid.subdetId() == EcalEndcap) {
+          EEDetId eedetid(detid);
+          ietaorix = eedetid.ix();
+        }
+        return ietaorix;
       }
-      return ietaorix;
-    }
 
-    const int seedCrysIPhiOrIy() const {
-      auto detid = seed_->seed();
-      int iphioriy = 0;
-      if (detid.subdetId() == EcalBarrel) {
-        EBDetId ebdetid(detid);
-        iphioriy = ebdetid.iphi();
-      } else if (detid.subdetId() == EcalEndcap) {
-        EEDetId eedetid(detid);
-        iphioriy = eedetid.iy();
+      const int seedCrysIPhiOrIy() const {
+        auto detid = seed_->seed();
+        int iphioriy = 0;
+        if (detid.subdetId() == EcalBarrel) {
+          EBDetId ebdetid(detid);
+          iphioriy = ebdetid.iphi();
+        } else if (detid.subdetId() == EcalEndcap) {
+          EEDetId eedetid(detid);
+          iphioriy = eedetid.iy();
+        }
+        return iphioriy;
       }
-      return iphioriy;
-    }
 
-  private:
-    void computeRawEnergy();
+    private:
+      void computeRawEnergy();
 
-    /// reference to BasicCluster seed
-    CaloClusterPtr seed_;
+      /// reference to BasicCluster seed
+      CaloClusterPtr seed_;
 
-    /// references to BasicCluster constitunets
-    CaloClusterPtrVector clusters_;
+      /// references to BasicCluster constitunets
+      CaloClusterPtrVector clusters_;
 
-    /// references to BasicCluster constitunets
-    CaloClusterPtrVector preshowerClusters_;
+      /// references to BasicCluster constitunets
+      CaloClusterPtrVector preshowerClusters_;
 
-    /// used hits by detId - retrieved from BC constituents -- now inherited from CaloCluster
-    //std::vector<DetId> usedHits_;
+      /// used hits by detId - retrieved from BC constituents -- now inherited from CaloCluster
+      //std::vector<DetId> usedHits_;
 
-    double preshowerEnergy_;
+      double preshowerEnergy_;
 
-    double rawEnergy_;
+      double rawEnergy_;
 
-    double phiWidth_;
-    double etaWidth_;
+      double phiWidth_;
+      double etaWidth_;
 
-    double preshowerEnergy1_;
-    double preshowerEnergy2_;
-  };
+      double preshowerEnergy1_;
+      double preshowerEnergy2_;
+    };
 
+  }  // namespace io_v1
+  using SuperCluster = io_v1::SuperCluster;
 }  // namespace reco
 #endif

--- a/DataFormats/EgammaReco/interface/SuperClusterFwd.h
+++ b/DataFormats/EgammaReco/interface/SuperClusterFwd.h
@@ -6,7 +6,10 @@
 #include "DataFormats/Common/interface/RefProd.h"
 
 namespace reco {
-  class SuperCluster;
+  namespace io_v1 {
+    class SuperCluster;
+  }
+  using SuperCluster = io_v1::SuperCluster;
 
   /// collection of SuperCluser objectr
   typedef std::vector<SuperCluster> SuperClusterCollection;

--- a/DataFormats/EgammaReco/src/classes_def.xml
+++ b/DataFormats/EgammaReco/src/classes_def.xml
@@ -1,12 +1,12 @@
 <lcgdict>
 
-  <class name="edm::RefToBase<reco::CaloCluster>"  rntupleStreamerMode="true"/>
-  <class name="edm::reftobase::BaseHolder<reco::CaloCluster>"/>
-  <class name="edm::reftobase::IndirectHolder<reco::CaloCluster>" />
+  <class name="edm::RefToBase<reco::io_v1::CaloCluster>"  rntupleStreamerMode="true"/>
+  <class name="edm::reftobase::BaseHolder<reco::io_v1::CaloCluster>"/>
+  <class name="edm::reftobase::IndirectHolder<reco::io_v1::CaloCluster>" />
 
-  <class name="edm::reftobase::Holder<reco::CaloCluster, edm::Ref<std::vector<reco::SuperCluster>, reco::SuperCluster, edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster> > >"/>
-  <class name="edm::reftobase::RefHolder<edm::Ref<std::vector<reco::SuperCluster>, reco::SuperCluster, edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster> > >"/>
-  <class name="edm::reftobase::Holder<reco::CaloCluster, edm::Ref<std::vector<reco::BasicCluster>, reco::BasicCluster, edm::refhelper::FindUsingAdvance<std::vector<reco::BasicCluster>,reco::BasicCluster> > >"/>
+  <class name="edm::reftobase::Holder<reco::io_v1::CaloCluster, edm::Ref<std::vector<reco::io_v1::SuperCluster>, reco::io_v1::SuperCluster, edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::SuperCluster>,reco::io_v1::SuperCluster> > >"/>
+  <class name="edm::reftobase::RefHolder<edm::Ref<std::vector<reco::io_v1::SuperCluster>, reco::io_v1::SuperCluster, edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::SuperCluster>,reco::io_v1::SuperCluster> > >"/>
+  <class name="edm::reftobase::Holder<reco::io_v1::CaloCluster, edm::Ref<std::vector<reco::BasicCluster>, reco::BasicCluster, edm::refhelper::FindUsingAdvance<std::vector<reco::BasicCluster>,reco::BasicCluster> > >"/>
   <class name="edm::reftobase::RefHolder<edm::Ref<std::vector<reco::BasicCluster>, reco::BasicCluster, edm::refhelper::FindUsingAdvance<std::vector<reco::BasicCluster>,reco::BasicCluster> > >"/>
 
   <class name="std::vector<reco::BasicCluster>"/>
@@ -17,26 +17,21 @@
   <class name="edm::Wrapper<edm::RefVector<std::vector<reco::BasicCluster>,reco::BasicCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::BasicCluster>,reco::BasicCluster> > >"/>
   <class name="std::vector<edm::Ref<std::vector<reco::BasicCluster>,reco::BasicCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::BasicCluster>,reco::BasicCluster> > >"/>
 
-  <class name="reco::SuperCluster" ClassVersion="15">
-   <version ClassVersion="15" checksum="705520405"/>
-   <version ClassVersion="14" checksum="3716250139"/>
-   <version ClassVersion="13" checksum="1878352437"/>
-   <version ClassVersion="12" checksum="83023066"/>
-   <version ClassVersion="11" checksum="83023066"/>
-   <version ClassVersion="10" checksum="3131732439"/>
+  <class name="reco::io_v1::SuperCluster" ClassVersion="3">
+   <version ClassVersion="3" checksum="1761520577"/>
     <field name="rawEnergy_" iotype="Double32_t"/>
     <field name="phiWidth_" iotype="Double32_t"/>
     <field name="etaWidth_" iotype="Double32_t"/>
   </class>
-  <class name="std::vector<reco::SuperCluster>"/>
-  <class name="edm::Wrapper<std::vector<reco::SuperCluster> >"/>
-  <class name="edm::Ref<std::vector<reco::SuperCluster>,reco::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster> >"/>
-  <class name="edm::RefProd<std::vector<reco::SuperCluster> >"/>
-  <class name="edm::RefVector<std::vector<reco::SuperCluster>,reco::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster> >"/>
-  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::SuperCluster>,reco::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster> > >"/>
-  <class name="std::vector<edm::Ref<std::vector<reco::SuperCluster>,reco::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster> > >"/>
-  <class name="edm::Wrapper<std::vector<edm::Ref<std::vector<reco::SuperCluster>,reco::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster> > > >"/>
-  <class name="edm::AtomicPtrCache<std::vector<reco::SuperCluster> >">
+  <class name="std::vector<reco::io_v1::SuperCluster>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::SuperCluster> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::SuperCluster>,reco::io_v1::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::SuperCluster>,reco::io_v1::SuperCluster> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::SuperCluster> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::SuperCluster>,reco::io_v1::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::SuperCluster>,reco::io_v1::SuperCluster> >"/>
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::io_v1::SuperCluster>,reco::io_v1::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::SuperCluster>,reco::io_v1::SuperCluster> > >"/>
+  <class name="std::vector<edm::Ref<std::vector<reco::io_v1::SuperCluster>,reco::io_v1::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::SuperCluster>,reco::io_v1::SuperCluster> > >"/>
+  <class name="edm::Wrapper<std::vector<edm::Ref<std::vector<reco::io_v1::SuperCluster>,reco::io_v1::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::SuperCluster>,reco::io_v1::SuperCluster> > > >"/>
+  <class name="edm::AtomicPtrCache<std::vector<reco::io_v1::SuperCluster> >">
    <field name="m_data" transient="true"/>
   </class>
 
@@ -71,86 +66,82 @@
   <class name="edm::RefVector<std::vector<reco::ClusterShape>,reco::ClusterShape,edm::refhelper::FindUsingAdvance<std::vector<reco::ClusterShape>,reco::ClusterShape> >"/>
   <class name="edm::Wrapper<edm::RefVector<std::vector<reco::ClusterShape>,reco::ClusterShape,edm::refhelper::FindUsingAdvance<std::vector<reco::ClusterShape>,reco::ClusterShape> > >"/>
 
-  <class name="reco::HFEMClusterShape" ClassVersion="10">
-   <version ClassVersion="10" checksum="1841315109"/>
+  <class name="reco::io_v1::HFEMClusterShape" ClassVersion="3">
+   <version ClassVersion="3" checksum="1635686911"/>
   </class>
-  <class name="std::vector<reco::HFEMClusterShape>"/>
-  <class name="edm::Wrapper<std::vector<reco::HFEMClusterShape> >"/>
-  <class name="edm::Ref<std::vector<reco::HFEMClusterShape>,reco::HFEMClusterShape,edm::refhelper::FindUsingAdvance<std::vector<reco::HFEMClusterShape>,reco::HFEMClusterShape> >"/>
-  <class name="edm::RefProd<std::vector<reco::HFEMClusterShape> >"/>
-  <class name="edm::RefVector<std::vector<reco::HFEMClusterShape>,reco::HFEMClusterShape,edm::refhelper::FindUsingAdvance<std::vector<reco::HFEMClusterShape>,reco::HFEMClusterShape> >"/>
-  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::HFEMClusterShape>,reco::HFEMClusterShape,edm::refhelper::FindUsingAdvance<std::vector<reco::HFEMClusterShape>,reco::HFEMClusterShape> > >"/>
+  <class name="std::vector<reco::io_v1::HFEMClusterShape>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::HFEMClusterShape> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::HFEMClusterShape>,reco::io_v1::HFEMClusterShape,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::HFEMClusterShape>,reco::io_v1::HFEMClusterShape> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::HFEMClusterShape> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::HFEMClusterShape>,reco::io_v1::HFEMClusterShape,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::HFEMClusterShape>,reco::io_v1::HFEMClusterShape> >"/>
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::io_v1::HFEMClusterShape>,reco::io_v1::HFEMClusterShape,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::HFEMClusterShape>,reco::io_v1::HFEMClusterShape> > >"/>
 
-  <class name="reco::PreshowerClusterShape" ClassVersion="10">
-   <version ClassVersion="10" checksum="1713788487"/>
+  <class name="reco::io_v1::PreshowerClusterShape" ClassVersion="3">
+   <version ClassVersion="3" checksum="487684717"/>
   </class>
-  <class name="std::vector<reco::PreshowerClusterShape>"/>
-  <class name="edm::Wrapper<std::vector<reco::PreshowerClusterShape> >" splitLevel="0"/>
-  <class name="edm::Ref<std::vector<reco::PreshowerClusterShape>,reco::PreshowerClusterShape,edm::refhelper::FindUsingAdvance<std::vector<reco::PreshowerClusterShape>,reco::PreshowerClusterShape> >"/>
-  <class name="edm::RefProd<std::vector<reco::PreshowerClusterShape> >"/>
-  <class name="edm::RefVector<std::vector<reco::PreshowerClusterShape>,reco::PreshowerClusterShape,edm::refhelper::FindUsingAdvance<std::vector<reco::PreshowerClusterShape>,reco::PreshowerClusterShape> >"/>
-  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::PreshowerClusterShape>,reco::PreshowerClusterShape,edm::refhelper::FindUsingAdvance<std::vector<reco::PreshowerClusterShape>,reco::PreshowerClusterShape> > >" splitLevel="0"/>
+  <class name="std::vector<reco::io_v1::PreshowerClusterShape>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::PreshowerClusterShape> >" splitLevel="0"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::PreshowerClusterShape>,reco::io_v1::PreshowerClusterShape,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PreshowerClusterShape>,reco::io_v1::PreshowerClusterShape> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::PreshowerClusterShape> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::PreshowerClusterShape>,reco::io_v1::PreshowerClusterShape,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PreshowerClusterShape>,reco::io_v1::PreshowerClusterShape> >"/>
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::io_v1::PreshowerClusterShape>,reco::io_v1::PreshowerClusterShape,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PreshowerClusterShape>,reco::io_v1::PreshowerClusterShape> > >" splitLevel="0"/>
 
-  <class name="reco::ElectronSeed" ClassVersion="3">
-    <version ClassVersion="3" checksum="567408035"/>
+  <class name="reco::io_v1::ElectronSeed" ClassVersion="3">
+    <version ClassVersion="3" checksum="360647555"/>
   </class>
-  <class name="reco::ElectronSeed::PMVars" ClassVersion="3">
-    <version ClassVersion="3" checksum="1322802316"/>
+  <class name="reco::io_v1::ElectronSeed::PMVars" ClassVersion="3">
+    <version ClassVersion="3" checksum="788727658"/>
   </class>
 
-  <class name="std::vector<reco::ElectronSeed>"/>
-  <class name="edm::Ref<std::vector<reco::ElectronSeed>,reco::ElectronSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::ElectronSeed>,reco::ElectronSeed> >"/>
-  <class name="edm::RefProd<std::vector<reco::ElectronSeed> >"/>
-  <class name="edm::Wrapper<std::vector<reco::ElectronSeed> >"/>
-  <class name="edm::RefVector<std::vector<reco::ElectronSeed>,reco::ElectronSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::ElectronSeed>,reco::ElectronSeed> >"/>
-  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::ElectronSeed>,reco::ElectronSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::ElectronSeed>,reco::ElectronSeed> > >"/>
-  <class name="edm::reftobase::BaseHolder<reco::ElectronSeed>" />
-  <class name="edm::reftobase::IndirectHolder<reco::ElectronSeed>" />
-  <class name="edm::reftobase::RefHolder<edm::Ref<std::vector<reco::ElectronSeed>,reco::ElectronSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::ElectronSeed>,reco::ElectronSeed> > >"/>
-  <class name="edm::reftobase::Holder<reco::ElectronSeed,edm::Ref<std::vector<reco::ElectronSeed>,reco::ElectronSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::ElectronSeed>,reco::ElectronSeed> > >"/>
+  <class name="std::vector<reco::io_v1::ElectronSeed>"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::ElectronSeed>,reco::io_v1::ElectronSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::ElectronSeed>,reco::io_v1::ElectronSeed> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::ElectronSeed> >"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::ElectronSeed> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::ElectronSeed>,reco::io_v1::ElectronSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::ElectronSeed>,reco::io_v1::ElectronSeed> >"/>
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::io_v1::ElectronSeed>,reco::io_v1::ElectronSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::ElectronSeed>,reco::io_v1::ElectronSeed> > >"/>
+  <class name="edm::reftobase::BaseHolder<reco::io_v1::ElectronSeed>" />
+  <class name="edm::reftobase::IndirectHolder<reco::io_v1::ElectronSeed>" />
+  <class name="edm::reftobase::RefHolder<edm::Ref<std::vector<reco::io_v1::ElectronSeed>,reco::io_v1::ElectronSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::ElectronSeed>,reco::io_v1::ElectronSeed> > >"/>
+  <class name="edm::reftobase::Holder<reco::io_v1::ElectronSeed,edm::Ref<std::vector<reco::io_v1::ElectronSeed>,reco::io_v1::ElectronSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::ElectronSeed>,reco::io_v1::ElectronSeed> > >"/>
 
-  <class name="reco::PreshowerCluster" ClassVersion="14">
-   <version ClassVersion="14" checksum="3782728123"/>
-   <version ClassVersion="13" checksum="2894694325"/>
-   <version ClassVersion="12" checksum="1992137647"/>
-   <version ClassVersion="11" checksum="469230288"/>
-   <version ClassVersion="10" checksum="469230288"/>
+  <class name="reco::io_v1::PreshowerCluster" ClassVersion="3">
+   <version ClassVersion="3" checksum="3663825999"/>
   </class>
-  <class name="std::vector<reco::PreshowerCluster>"/>
-  <class name="edm::Wrapper<std::vector<reco::PreshowerCluster> >" splitLevel="0"/>
-  <class name="edm::Ref<std::vector<reco::PreshowerCluster>,reco::PreshowerCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::PreshowerCluster>,reco::PreshowerCluster> >"/>
-  <class name="edm::RefProd<std::vector<reco::PreshowerCluster> >"/>
-  <class name="edm::RefVector<std::vector<reco::PreshowerCluster>,reco::PreshowerCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::PreshowerCluster>,reco::PreshowerCluster> >"/>
-  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::PreshowerCluster>,reco::PreshowerCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::PreshowerCluster>,reco::PreshowerCluster> > >" splitLevel="0"/>
+  <class name="std::vector<reco::io_v1::PreshowerCluster>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::PreshowerCluster> >" splitLevel="0"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::PreshowerCluster>,reco::io_v1::PreshowerCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PreshowerCluster>,reco::io_v1::PreshowerCluster> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::PreshowerCluster> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::PreshowerCluster>,reco::io_v1::PreshowerCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PreshowerCluster>,reco::io_v1::PreshowerCluster> >"/>
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::io_v1::PreshowerCluster>,reco::io_v1::PreshowerCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PreshowerCluster>,reco::io_v1::PreshowerCluster> > >" splitLevel="0"/>
 
   <class name="edm::AssociationMap<edm::OneToOne<std::vector<reco::BasicCluster>, std::vector<reco::ClusterShape>, unsigned int > >">
     <field name="transientMap_" transient="true" />
   </class>
   <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::BasicCluster> >, edm::RefProd<std::vector<reco::ClusterShape> > >"/>
 
-  <class name="edm::AssociationMap<edm::OneToOne<std::vector<reco::SuperCluster>, std::vector<reco::HFEMClusterShape>, unsigned int > >">
+  <class name="edm::AssociationMap<edm::OneToOne<std::vector<reco::io_v1::SuperCluster>, std::vector<reco::io_v1::HFEMClusterShape>, unsigned int > >">
     <field name="transientMap_" transient="true" />
   </class>
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::SuperCluster> >, edm::RefProd<std::vector<reco::HFEMClusterShape> > >"/>
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::io_v1::SuperCluster> >, edm::RefProd<std::vector<reco::io_v1::HFEMClusterShape> > >"/>
 
   <!-- <class pattern="edm::Wrapper<edm::AssociationMap<*>" /> -->
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<vector<reco::CaloCluster>,vector<reco::ClusterShape>,unsigned int> > >" />
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<vector<reco::SuperCluster>,vector<reco::HFEMClusterShape>,unsigned int> > >" />
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<vector<reco::io_v1::CaloCluster>,vector<reco::ClusterShape>,unsigned int> > >" />
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<vector<reco::io_v1::SuperCluster>,vector<reco::io_v1::HFEMClusterShape>,unsigned int> > >" />
 
   <!-- <class pattern="edm::Ref<edm::AssociationMap<*>" /> -->
-  <class name="edm::Ref<edm::AssociationMap<edm::OneToOne<vector<reco::CaloCluster>,vector<reco::ClusterShape>,unsigned int> >,edm::helpers::KeyVal<edm::Ref<vector<reco::CaloCluster>,reco::CaloCluster,edm::refhelper::FindUsingAdvance<vector<reco::CaloCluster>,reco::CaloCluster> >,edm::Ref<vector<reco::ClusterShape>,reco::ClusterShape,edm::refhelper::FindUsingAdvance<vector<reco::ClusterShape>,reco::ClusterShape> > >,edm::AssociationMap<edm::OneToOne<vector<reco::CaloCluster>,vector<reco::ClusterShape>,unsigned int> >::Find>" />
-  <class name="edm::Ref<edm::AssociationMap<edm::OneToOne<vector<reco::SuperCluster>,vector<reco::HFEMClusterShape>,unsigned int> >,edm::helpers::KeyVal<edm::Ref<vector<reco::SuperCluster>,reco::SuperCluster,edm::refhelper::FindUsingAdvance<vector<reco::SuperCluster>,reco::SuperCluster> >,edm::Ref<vector<reco::HFEMClusterShape>,reco::HFEMClusterShape,edm::refhelper::FindUsingAdvance<vector<reco::HFEMClusterShape>,reco::HFEMClusterShape> > >,edm::AssociationMap<edm::OneToOne<vector<reco::SuperCluster>,vector<reco::HFEMClusterShape>,unsigned int> >::Find>" />
+  <class name="edm::Ref<edm::AssociationMap<edm::OneToOne<vector<reco::io_v1::CaloCluster>,vector<reco::ClusterShape>,unsigned int> >,edm::helpers::KeyVal<edm::Ref<vector<reco::io_v1::CaloCluster>,reco::io_v1::CaloCluster,edm::refhelper::FindUsingAdvance<vector<reco::io_v1::CaloCluster>,reco::io_v1::CaloCluster> >,edm::Ref<vector<reco::ClusterShape>,reco::ClusterShape,edm::refhelper::FindUsingAdvance<vector<reco::ClusterShape>,reco::ClusterShape> > >,edm::AssociationMap<edm::OneToOne<vector<reco::io_v1::CaloCluster>,vector<reco::ClusterShape>,unsigned int> >::Find>" />
+  <class name="edm::Ref<edm::AssociationMap<edm::OneToOne<vector<reco::io_v1::SuperCluster>,vector<reco::io_v1::HFEMClusterShape>,unsigned int> >,edm::helpers::KeyVal<edm::Ref<vector<reco::io_v1::SuperCluster>,reco::io_v1::SuperCluster,edm::refhelper::FindUsingAdvance<vector<reco::io_v1::SuperCluster>,reco::io_v1::SuperCluster> >,edm::Ref<vector<reco::io_v1::HFEMClusterShape>,reco::io_v1::HFEMClusterShape,edm::refhelper::FindUsingAdvance<vector<reco::io_v1::HFEMClusterShape>,reco::io_v1::HFEMClusterShape> > >,edm::AssociationMap<edm::OneToOne<vector<reco::io_v1::SuperCluster>,vector<reco::io_v1::HFEMClusterShape>,unsigned int> >::Find>" />
 
   <!-- <class pattern="edm::RefProd<edm::AssociationMap<*>" /> -->
-  <class name="edm::RefProd<edm::AssociationMap<edm::OneToOne<vector<reco::CaloCluster>,vector<reco::ClusterShape>,unsigned int> > >" />
-  <class name="edm::RefProd<edm::AssociationMap<edm::OneToOne<vector<reco::SuperCluster>,vector<reco::HFEMClusterShape>,unsigned int> > >" />
+  <class name="edm::RefProd<edm::AssociationMap<edm::OneToOne<vector<reco::io_v1::CaloCluster>,vector<reco::ClusterShape>,unsigned int> > >" />
+  <class name="edm::RefProd<edm::AssociationMap<edm::OneToOne<vector<reco::io_v1::SuperCluster>,vector<reco::io_v1::HFEMClusterShape>,unsigned int> > >" />
 
   <!-- <class pattern="edm::RefVector<edm::AssociationMap<*>" /> -->
-  <class name="edm::RefVector<edm::AssociationMap<edm::OneToOne<vector<reco::CaloCluster>,vector<reco::ClusterShape>,unsigned int> >,edm::helpers::KeyVal<edm::Ref<vector<reco::CaloCluster>,reco::CaloCluster,edm::refhelper::FindUsingAdvance<vector<reco::CaloCluster>,reco::CaloCluster> >,edm::Ref<vector<reco::ClusterShape>,reco::ClusterShape,edm::refhelper::FindUsingAdvance<vector<reco::ClusterShape>,reco::ClusterShape> > >,edm::AssociationMap<edm::OneToOne<vector<reco::CaloCluster>,vector<reco::ClusterShape>,unsigned int> >::Find>" />
-  <class name="edm::RefVector<edm::AssociationMap<edm::OneToOne<vector<reco::SuperCluster>,vector<reco::HFEMClusterShape>,unsigned int> >,edm::helpers::KeyVal<edm::Ref<vector<reco::SuperCluster>,reco::SuperCluster,edm::refhelper::FindUsingAdvance<vector<reco::SuperCluster>,reco::SuperCluster> >,edm::Ref<vector<reco::HFEMClusterShape>,reco::HFEMClusterShape,edm::refhelper::FindUsingAdvance<vector<reco::HFEMClusterShape>,reco::HFEMClusterShape> > >,edm::AssociationMap<edm::OneToOne<vector<reco::SuperCluster>,vector<reco::HFEMClusterShape>,unsigned int> >::Find>" />
+  <class name="edm::RefVector<edm::AssociationMap<edm::OneToOne<vector<reco::io_v1::CaloCluster>,vector<reco::ClusterShape>,unsigned int> >,edm::helpers::KeyVal<edm::Ref<vector<reco::io_v1::CaloCluster>,reco::io_v1::CaloCluster,edm::refhelper::FindUsingAdvance<vector<reco::io_v1::CaloCluster>,reco::io_v1::CaloCluster> >,edm::Ref<vector<reco::ClusterShape>,reco::ClusterShape,edm::refhelper::FindUsingAdvance<vector<reco::ClusterShape>,reco::ClusterShape> > >,edm::AssociationMap<edm::OneToOne<vector<reco::io_v1::CaloCluster>,vector<reco::ClusterShape>,unsigned int> >::Find>" />
+  <class name="edm::RefVector<edm::AssociationMap<edm::OneToOne<vector<reco::io_v1::SuperCluster>,vector<reco::io_v1::HFEMClusterShape>,unsigned int> >,edm::helpers::KeyVal<edm::Ref<vector<reco::io_v1::SuperCluster>,reco::io_v1::SuperCluster,edm::refhelper::FindUsingAdvance<vector<reco::io_v1::SuperCluster>,reco::io_v1::SuperCluster> >,edm::Ref<vector<reco::io_v1::HFEMClusterShape>,reco::io_v1::HFEMClusterShape,edm::refhelper::FindUsingAdvance<vector<reco::io_v1::HFEMClusterShape>,reco::io_v1::HFEMClusterShape> > >,edm::AssociationMap<edm::OneToOne<vector<reco::io_v1::SuperCluster>,vector<reco::io_v1::HFEMClusterShape>,unsigned int> >::Find>" />
   <!-- <class pattern="edm::Wrapper<edm::RefVector<edm::AssociationMap<*>" /> -->
-  <class name="edm::Wrapper<edm::RefVector<edm::AssociationMap<edm::OneToOne<vector<reco::CaloCluster>,vector<reco::ClusterShape>,unsigned int> >,edm::helpers::KeyVal<edm::Ref<vector<reco::CaloCluster>,reco::CaloCluster,edm::refhelper::FindUsingAdvance<vector<reco::CaloCluster>,reco::CaloCluster> >,edm::Ref<vector<reco::ClusterShape>,reco::ClusterShape,edm::refhelper::FindUsingAdvance<vector<reco::ClusterShape>,reco::ClusterShape> > >,edm::AssociationMap<edm::OneToOne<vector<reco::CaloCluster>,vector<reco::ClusterShape>,unsigned int> >::Find> >" />
-  <class name="edm::Wrapper<edm::RefVector<edm::AssociationMap<edm::OneToOne<vector<reco::SuperCluster>,vector<reco::HFEMClusterShape>,unsigned int> >,edm::helpers::KeyVal<edm::Ref<vector<reco::SuperCluster>,reco::SuperCluster,edm::refhelper::FindUsingAdvance<vector<reco::SuperCluster>,reco::SuperCluster> >,edm::Ref<vector<reco::HFEMClusterShape>,reco::HFEMClusterShape,edm::refhelper::FindUsingAdvance<vector<reco::HFEMClusterShape>,reco::HFEMClusterShape> > >,edm::AssociationMap<edm::OneToOne<vector<reco::SuperCluster>,vector<reco::HFEMClusterShape>,unsigned int> >::Find> >" />
+  <class name="edm::Wrapper<edm::RefVector<edm::AssociationMap<edm::OneToOne<vector<reco::io_v1::CaloCluster>,vector<reco::ClusterShape>,unsigned int> >,edm::helpers::KeyVal<edm::Ref<vector<reco::io_v1::CaloCluster>,reco::io_v1::CaloCluster,edm::refhelper::FindUsingAdvance<vector<reco::io_v1::CaloCluster>,reco::io_v1::CaloCluster> >,edm::Ref<vector<reco::ClusterShape>,reco::ClusterShape,edm::refhelper::FindUsingAdvance<vector<reco::ClusterShape>,reco::ClusterShape> > >,edm::AssociationMap<edm::OneToOne<vector<reco::io_v1::CaloCluster>,vector<reco::ClusterShape>,unsigned int> >::Find> >" />
+  <class name="edm::Wrapper<edm::RefVector<edm::AssociationMap<edm::OneToOne<vector<reco::io_v1::SuperCluster>,vector<reco::io_v1::HFEMClusterShape>,unsigned int> >,edm::helpers::KeyVal<edm::Ref<vector<reco::io_v1::SuperCluster>,reco::io_v1::SuperCluster,edm::refhelper::FindUsingAdvance<vector<reco::io_v1::SuperCluster>,reco::io_v1::SuperCluster> >,edm::Ref<vector<reco::io_v1::HFEMClusterShape>,reco::io_v1::HFEMClusterShape,edm::refhelper::FindUsingAdvance<vector<reco::io_v1::HFEMClusterShape>,reco::io_v1::HFEMClusterShape> > >,edm::AssociationMap<edm::OneToOne<vector<reco::io_v1::SuperCluster>,vector<reco::io_v1::HFEMClusterShape>,unsigned int> >::Find> >" />
 
    <class name="std::vector<reco::SuperClusterRef>" />
    <class name="edm::ValueMap<reco::SuperClusterRef>" />

--- a/DataFormats/GsfTrackReco/interface/GsfTrack.h
+++ b/DataFormats/GsfTrackReco/interface/GsfTrack.h
@@ -8,107 +8,111 @@
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  class GsfTrack : public Track {
-  public:
-    /// parameter dimension mode
-    enum { dimensionMode = 3 };
-    /// error matrix size mode
-    enum { covarianceSizeMode = dimensionMode * (dimensionMode + 1) / 2 };
-    /// parameter vector (momentum part) from mode
-    typedef math::Vector<dimensionMode>::type ParameterVectorMode;
-    /// 3 parameter covariance matrix (momentum part) from mode
-    typedef math::Error<dimensionMode>::type CovarianceMatrixMode;
-    /// default constructor
-    GsfTrack();
-    /// constructor from fit parameters and error matrix
-    /// notice that the reference point must be
-    /// the point of closest approch to the beamline.
-    GsfTrack(double chi2, double ndof, const Point&, const Vector&, int charge, const CovarianceMatrix&);
-    /// set reference to GSF "extra" object
-    void setGsfExtra(const GsfTrackExtraRef& ref) { gsfExtra_ = ref; }
-    /// reference to "extra" object
-    const GsfTrackExtraRef& gsfExtra() const { return gsfExtra_; }
+    class GsfTrack : public Track {
+    public:
+      /// parameter dimension mode
+      enum { dimensionMode = 3 };
+      /// error matrix size mode
+      enum { covarianceSizeMode = dimensionMode * (dimensionMode + 1) / 2 };
+      /// parameter vector (momentum part) from mode
+      typedef math::Vector<dimensionMode>::type ParameterVectorMode;
+      /// 3 parameter covariance matrix (momentum part) from mode
+      typedef math::Error<dimensionMode>::type CovarianceMatrixMode;
+      /// default constructor
+      GsfTrack();
+      /// constructor from fit parameters and error matrix
+      /// notice that the reference point must be
+      /// the point of closest approch to the beamline.
+      GsfTrack(double chi2, double ndof, const Point&, const Vector&, int charge, const CovarianceMatrix&);
+      /// set reference to GSF "extra" object
+      void setGsfExtra(const GsfTrackExtraRef& ref) { gsfExtra_ = ref; }
+      /// reference to "extra" object
+      const GsfTrackExtraRef& gsfExtra() const { return gsfExtra_; }
 
-    /// set mode parameters
-    void setMode(int chargeMode, const Vector& momentumMode, const CovarianceMatrixMode& covarianceMode);
+      /// set mode parameters
+      void setMode(int chargeMode, const Vector& momentumMode, const CovarianceMatrixMode& covarianceMode);
 
-    /// track electric charge from mode
-    int chargeMode() const { return chargeMode_; }
-    /// q/p  from mode
-    double qoverpMode() const { return chargeMode() / pMode(); }
-    /// polar angle   from mode
-    double thetaMode() const { return momentumMode_.theta(); }
-    /// Lambda angle from mode
-    double lambdaMode() const { return M_PI / 2 - momentumMode_.theta(); }
-    /// momentum vector magnitude from mode
-    double pMode() const { return momentumMode_.R(); }
-    /// track transverse momentum from mode
-    double ptMode() const { return sqrt(momentumMode_.Perp2()); }
-    /// x coordinate of momentum vector from mode
-    double pxMode() const { return momentumMode_.x(); }
-    /// y coordinate of momentum vector from mode
-    double pyMode() const { return momentumMode_.y(); }
-    /// z coordinate of momentum vector from mode
-    double pzMode() const { return momentumMode_.z(); }
-    /// azimuthal angle of momentum vector from mode
-    double phiMode() const { return momentumMode_.Phi(); }
-    /// pseudorapidity of momentum vector from mode
-    double etaMode() const { return momentumMode_.Eta(); }
+      /// track electric charge from mode
+      int chargeMode() const { return chargeMode_; }
+      /// q/p  from mode
+      double qoverpMode() const { return chargeMode() / pMode(); }
+      /// polar angle   from mode
+      double thetaMode() const { return momentumMode_.theta(); }
+      /// Lambda angle from mode
+      double lambdaMode() const { return M_PI / 2 - momentumMode_.theta(); }
+      /// momentum vector magnitude from mode
+      double pMode() const { return momentumMode_.R(); }
+      /// track transverse momentum from mode
+      double ptMode() const { return sqrt(momentumMode_.Perp2()); }
+      /// x coordinate of momentum vector from mode
+      double pxMode() const { return momentumMode_.x(); }
+      /// y coordinate of momentum vector from mode
+      double pyMode() const { return momentumMode_.y(); }
+      /// z coordinate of momentum vector from mode
+      double pzMode() const { return momentumMode_.z(); }
+      /// azimuthal angle of momentum vector from mode
+      double phiMode() const { return momentumMode_.Phi(); }
+      /// pseudorapidity of momentum vector from mode
+      double etaMode() const { return momentumMode_.Eta(); }
 
-    /// track momentum vector from mode
-    const Vector& momentumMode() const { return momentumMode_; }
+      /// track momentum vector from mode
+      const Vector& momentumMode() const { return momentumMode_; }
 
-    /// Track parameters with one-to-one correspondence to the covariance matrix from mode
-    ParameterVectorMode parametersMode() const { return ParameterVectorMode(qoverpMode(), lambdaMode(), phiMode()); }
-    /// return track covariance matrix from mode
-    CovarianceMatrixMode covarianceMode() const {
-      CovarianceMatrixMode m;
-      fill(m);
-      return m;
-    }
+      /// Track parameters with one-to-one correspondence to the covariance matrix from mode
+      ParameterVectorMode parametersMode() const { return ParameterVectorMode(qoverpMode(), lambdaMode(), phiMode()); }
+      /// return track covariance matrix from mode
+      CovarianceMatrixMode covarianceMode() const {
+        CovarianceMatrixMode m;
+        fill(m);
+        return m;
+      }
 
-    /// i-th parameter ( i = 0, ... 2 ) from mode
-    double parameterMode(int i) const { return parametersMode()[i]; }
-    /// (i,j)-th element of covarianve matrix ( i, j = 0, ... 2 ) from mode
-    double covarianceMode(int i, int j) const { return covarianceMode_[covIndex(i, j)]; }
-    /// error on specified element from mode
-    double errorMode(int i) const { return sqrt(covarianceMode_[covIndex(i, i)]); }
+      /// i-th parameter ( i = 0, ... 2 ) from mode
+      double parameterMode(int i) const { return parametersMode()[i]; }
+      /// (i,j)-th element of covarianve matrix ( i, j = 0, ... 2 ) from mode
+      double covarianceMode(int i, int j) const { return covarianceMode_[covIndex(i, j)]; }
+      /// error on specified element from mode
+      double errorMode(int i) const { return sqrt(covarianceMode_[covIndex(i, i)]); }
 
-    /// error on signed transverse curvature from mode
-    double qoverpModeError() const { return errorMode(i_qoverp); }
-    /// error on Pt (set to 1000 TeV if charge==0 for safety) from mode
-    double ptModeError() const {
-      return (chargeMode() != 0)
-                 ? sqrt(ptMode() * ptMode() * pMode() * pMode() / chargeMode() / chargeMode() *
-                            covarianceMode(i_qoverp, i_qoverp) +
-                        2 * ptMode() * pMode() / chargeMode() * pzMode() * covarianceMode(i_qoverp, i_lambda) +
-                        pzMode() * pzMode() * covarianceMode(i_lambda, i_lambda))
-                 : 1.e6;
-    }
-    /// error on theta from mode
-    double thetaModeError() const { return errorMode(i_lambda); }
-    /// error on lambda from mode
-    double lambdaModeError() const { return errorMode(i_lambda); }
-    /// error on eta from mode
-    double etaModeError() const { return errorMode(i_lambda) * pMode() / ptMode(); }
-    /// error on phi from mode
-    double phiModeError() const { return errorMode(i_phi); }
+      /// error on signed transverse curvature from mode
+      double qoverpModeError() const { return errorMode(i_qoverp); }
+      /// error on Pt (set to 1000 TeV if charge==0 for safety) from mode
+      double ptModeError() const {
+        return (chargeMode() != 0)
+                   ? sqrt(ptMode() * ptMode() * pMode() * pMode() / chargeMode() / chargeMode() *
+                              covarianceMode(i_qoverp, i_qoverp) +
+                          2 * ptMode() * pMode() / chargeMode() * pzMode() * covarianceMode(i_qoverp, i_lambda) +
+                          pzMode() * pzMode() * covarianceMode(i_lambda, i_lambda))
+                   : 1.e6;
+      }
+      /// error on theta from mode
+      double thetaModeError() const { return errorMode(i_lambda); }
+      /// error on lambda from mode
+      double lambdaModeError() const { return errorMode(i_lambda); }
+      /// error on eta from mode
+      double etaModeError() const { return errorMode(i_lambda) * pMode() / ptMode(); }
+      /// error on phi from mode
+      double phiModeError() const { return errorMode(i_phi); }
 
-  private:
-    /// fill 3x3 SMatrix
-    CovarianceMatrixMode& fill CMS_THREAD_SAFE(CovarianceMatrixMode& v) const;
+    private:
+      /// fill 3x3 SMatrix
+      CovarianceMatrixMode& fill CMS_THREAD_SAFE(CovarianceMatrixMode& v) const;
 
-  private:
-    /// reference to GSF "extra" extension
-    GsfTrackExtraRef gsfExtra_;
-    /// electric charge from mode
-    char chargeMode_;
-    /// momentum vector from mode
-    Vector momentumMode_;
-    /// 3x3 momentum part of covariance (in q/p, lambda, phi)
-    float covarianceMode_[covarianceSizeMode];
-  };
+    private:
+      /// reference to GSF "extra" extension
+      GsfTrackExtraRef gsfExtra_;
+      /// electric charge from mode
+      char chargeMode_;
+      /// momentum vector from mode
+      Vector momentumMode_;
+      /// 3x3 momentum part of covariance (in q/p, lambda, phi)
+      float covarianceMode_[covarianceSizeMode];
+    };
+
+  }  // namespace io_v1
+  using GsfTrack = io_v1::GsfTrack;
 
 }  // namespace reco
 

--- a/DataFormats/GsfTrackReco/interface/GsfTrackExtra.h
+++ b/DataFormats/GsfTrackReco/interface/GsfTrackExtra.h
@@ -13,74 +13,78 @@
 #include <iostream>
 
 namespace reco {
-  class GsfTrackExtra {
-  public:
-    /// parameter dimension
-    enum { dimension = 5 };
-    /// local parameter vector
-    typedef math::Vector<dimension>::type LocalParameterVector;
-    /// local covariance matrix
-    typedef math::Error<dimension>::type LocalCovarianceMatrix;
-    /// point in the space
-    typedef math::XYZPoint Point;
-    /// spatial vector
-    typedef math::XYZVector Vector;
+  namespace io_v1 {
+    class GsfTrackExtra {
+    public:
+      /// parameter dimension
+      enum { dimension = 5 };
+      /// local parameter vector
+      typedef math::Vector<dimension>::type LocalParameterVector;
+      /// local covariance matrix
+      typedef math::Error<dimension>::type LocalCovarianceMatrix;
+      /// point in the space
+      typedef math::XYZPoint Point;
+      /// spatial vector
+      typedef math::XYZVector Vector;
 
-    /// default constructor
-    GsfTrackExtra() {}
-    /// constructor from outermost position and momentum
-    GsfTrackExtra(const std::vector<GsfComponent5D>& outerStates,
-                  const double& outerLocalPzSign,
-                  const std::vector<GsfComponent5D>& innerStates,
-                  const double& innerLocalPzSign,
-                  const std::vector<GsfTangent>& tangents);
-    /// sign of local P_z at outermost state
-    double outerStateLocalPzSign() const { return positiveOuterStatePz_ ? 1. : -1.; }
-    /// weights at outermost state
-    std::vector<double> outerStateWeights() const { return weights(outerStates_); }
-    /// local parameters at outermost state
-    std::vector<LocalParameterVector> outerStateLocalParameters() const { return parameters(outerStates_); }
-    /// local covariance matrices at outermost state
-    std::vector<LocalCovarianceMatrix> outerStateCovariances() const { return covariances(outerStates_); }
-    /// sign of local P_z at innermost state
-    double innerStateLocalPzSign() const { return positiveInnerStatePz_ ? 1. : -1.; }
-    /// weights at innermost state
-    std::vector<double> innerStateWeights() const { return weights(innerStates_); }
-    /// local parameters at innermost state
-    std::vector<LocalParameterVector> innerStateLocalParameters() const { return parameters(innerStates_); }
-    /// local covariance matrices at innermost state
-    std::vector<LocalCovarianceMatrix> innerStateCovariances() const { return covariances(innerStates_); }
-    /// number of objects with information for tangents to the electron track
-    inline unsigned int tangentsSize() const { return tangents_.size(); }
-    /// access to tangent information
-    const std::vector<GsfTangent>& tangents() const { return tangents_; }
-    /// global position for tangent
-    const Point& tangentPosition(unsigned int index) const { return tangents_[index].position(); }
-    /// global momentum for tangent
-    const Vector& tangentMomentum(unsigned int index) const { return tangents_[index].momentum(); }
-    /// deltaP for tangent
-    Measurement1D tangentDeltaP(unsigned int index) const { return tangents_[index].deltaP(); }
+      /// default constructor
+      GsfTrackExtra() {}
+      /// constructor from outermost position and momentum
+      GsfTrackExtra(const std::vector<GsfComponent5D>& outerStates,
+                    const double& outerLocalPzSign,
+                    const std::vector<GsfComponent5D>& innerStates,
+                    const double& innerLocalPzSign,
+                    const std::vector<GsfTangent>& tangents);
+      /// sign of local P_z at outermost state
+      double outerStateLocalPzSign() const { return positiveOuterStatePz_ ? 1. : -1.; }
+      /// weights at outermost state
+      std::vector<double> outerStateWeights() const { return weights(outerStates_); }
+      /// local parameters at outermost state
+      std::vector<LocalParameterVector> outerStateLocalParameters() const { return parameters(outerStates_); }
+      /// local covariance matrices at outermost state
+      std::vector<LocalCovarianceMatrix> outerStateCovariances() const { return covariances(outerStates_); }
+      /// sign of local P_z at innermost state
+      double innerStateLocalPzSign() const { return positiveInnerStatePz_ ? 1. : -1.; }
+      /// weights at innermost state
+      std::vector<double> innerStateWeights() const { return weights(innerStates_); }
+      /// local parameters at innermost state
+      std::vector<LocalParameterVector> innerStateLocalParameters() const { return parameters(innerStates_); }
+      /// local covariance matrices at innermost state
+      std::vector<LocalCovarianceMatrix> innerStateCovariances() const { return covariances(innerStates_); }
+      /// number of objects with information for tangents to the electron track
+      inline unsigned int tangentsSize() const { return tangents_.size(); }
+      /// access to tangent information
+      const std::vector<GsfTangent>& tangents() const { return tangents_; }
+      /// global position for tangent
+      const Point& tangentPosition(unsigned int index) const { return tangents_[index].position(); }
+      /// global momentum for tangent
+      const Vector& tangentMomentum(unsigned int index) const { return tangents_[index].momentum(); }
+      /// deltaP for tangent
+      Measurement1D tangentDeltaP(unsigned int index) const { return tangents_[index].deltaP(); }
 
-  private:
-    /// extract weights from states
-    std::vector<double> weights(const std::vector<GsfComponent5D>& states) const;
-    /// extract parameters from states
-    std::vector<LocalParameterVector> parameters(const std::vector<GsfComponent5D>& states) const;
-    /// extract covariance matrices from states
-    std::vector<LocalCovarianceMatrix> covariances(const std::vector<GsfComponent5D>& states) const;
+    private:
+      /// extract weights from states
+      std::vector<double> weights(const std::vector<GsfComponent5D>& states) const;
+      /// extract parameters from states
+      std::vector<LocalParameterVector> parameters(const std::vector<GsfComponent5D>& states) const;
+      /// extract covariance matrices from states
+      std::vector<LocalCovarianceMatrix> covariances(const std::vector<GsfComponent5D>& states) const;
 
-  private:
-    /// states at outermost point
-    std::vector<GsfComponent5D> outerStates_;
-    /// positive sign of P_z(local) at outermost State?
-    bool positiveOuterStatePz_;
-    /// states at innermost point
-    std::vector<GsfComponent5D> innerStates_;
-    /// positive sign of P_z(local) at innermost State?
-    bool positiveInnerStatePz_;
-    /// information for tangents
-    std::vector<GsfTangent> tangents_;
-  };
+    private:
+      /// states at outermost point
+      std::vector<GsfComponent5D> outerStates_;
+      /// positive sign of P_z(local) at outermost State?
+      bool positiveOuterStatePz_;
+      /// states at innermost point
+      std::vector<GsfComponent5D> innerStates_;
+      /// positive sign of P_z(local) at innermost State?
+      bool positiveInnerStatePz_;
+      /// information for tangents
+      std::vector<GsfTangent> tangents_;
+    };
+
+  }  // namespace io_v1
+  using GsfTrackExtra = io_v1::GsfTrackExtra;
 
 }  // namespace reco
 

--- a/DataFormats/GsfTrackReco/interface/GsfTrackExtraFwd.h
+++ b/DataFormats/GsfTrackReco/interface/GsfTrackExtraFwd.h
@@ -6,7 +6,10 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 namespace reco {
-  class GsfTrackExtra;
+  namespace io_v1 {
+    class GsfTrackExtra;
+  }
+  using GsfTrackExtra = io_v1::GsfTrackExtra;
   /// collection of GsfTrackExtra objects
   typedef std::vector<GsfTrackExtra> GsfTrackExtraCollection;
   /// persistent reference to a GsfTrackExtra

--- a/DataFormats/GsfTrackReco/interface/GsfTrackFwd.h
+++ b/DataFormats/GsfTrackReco/interface/GsfTrackFwd.h
@@ -6,7 +6,10 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 namespace reco {
-  class GsfTrack;
+  namespace io_v1 {
+    class GsfTrack;
+  }
+  using GsfTrack = io_v1::GsfTrack;
   /// collection of GsfTracks
   typedef std::vector<GsfTrack> GsfTrackCollection;
   /// persistent reference to a GsfTrack

--- a/DataFormats/GsfTrackReco/src/classes_def.xml
+++ b/DataFormats/GsfTrackReco/src/classes_def.xml
@@ -15,39 +15,39 @@
    <class name="std::vector<reco::GsfTangent>"/>
 
 
-  <class name="reco::GsfTrackExtra" ClassVersion="10">
-   <version ClassVersion="10" checksum="1516446662"/>
+  <class name="reco::io_v1::GsfTrackExtra" ClassVersion="3">
+   <version ClassVersion="3" checksum="2899597684"/>
   </class>
-  <class name="std::vector<reco::GsfTrackExtra>"/>
-  <class name="edm::Wrapper<std::vector<reco::GsfTrackExtra> >" splitLevel="0"/>
-  <class name="edm::RefProd<std::vector<reco::GsfTrackExtra> >"/>
-  <class name="edm::Ref<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
-  <class name="edm::RefVector<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
+  <class name="std::vector<reco::io_v1::GsfTrackExtra>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::GsfTrackExtra> >" splitLevel="0"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::GsfTrackExtra> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::GsfTrackExtra>,reco::io_v1::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GsfTrackExtra>,reco::io_v1::GsfTrackExtra> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::GsfTrackExtra>,reco::io_v1::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GsfTrackExtra>,reco::io_v1::GsfTrackExtra> >"/>
 
-  <class name="reco::GsfTrack" ClassVersion="3">
-    <version ClassVersion="3" checksum="100950784"/>
+  <class name="reco::io_v1::GsfTrack" ClassVersion="3">
+    <version ClassVersion="3" checksum="3989888370"/>
     <field name="momentumMode_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
   </class>
-  <class name="std::vector<reco::GsfTrack>"/>
-  <class name="edm::Wrapper<std::vector<reco::GsfTrack> >"/>
-  <class name="edm::RefProd<std::vector<reco::GsfTrack> >"/>
-  <class name="edm::Ref<std::vector<reco::GsfTrack>,reco::GsfTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrack>,reco::GsfTrack> >"/>
-  <class name="edm::RefVector<std::vector<reco::GsfTrack>,reco::GsfTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrack>,reco::GsfTrack> >"/>
+  <class name="std::vector<reco::io_v1::GsfTrack>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::GsfTrack> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::GsfTrack> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::GsfTrack>,reco::io_v1::GsfTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GsfTrack>,reco::io_v1::GsfTrack> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::GsfTrack>,reco::io_v1::GsfTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GsfTrack>,reco::io_v1::GsfTrack> >"/>
 
-  <class name="edm::helpers::Key< edm::RefProd < std::vector < reco::GsfTrack > > >" />
+  <class name="edm::helpers::Key< edm::RefProd < std::vector < reco::io_v1::GsfTrack > > >" />
 
-  <class name="edm::AssociationMap<edm::OneToValue< std::vector<reco::GsfTrack>, double, unsigned int > >">
+  <class name="edm::AssociationMap<edm::OneToValue< std::vector<reco::io_v1::GsfTrack>, double, unsigned int > >">
     <field name="transientMap_" transient="true" /> 
   </class>
 
   <class name="edm::reftobase::Holder<reco::Track, reco::GsfTrackRef>" />
   <class name="edm::reftobase::RefHolder<reco::GsfTrackRef>" />
 
-  <!-- ValueMap<reco::GsfTrack> -->
+  <!-- ValueMap<reco::io_v1::GsfTrack> -->
   <class name="edm::ValueMap<reco::GsfTrackRefVector>" />
   <class name="edm::Wrapper<edm::ValueMap<reco::GsfTrackRefVector> >" />
-  <class name="std::vector<edm::RefVector<std::vector<reco::GsfTrack>,reco::GsfTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrack>,reco::GsfTrack> > >"/>
-  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::GsfTrack>,reco::GsfTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrack>,reco::GsfTrack> > >"/>
-  <class name="std::vector<edm::Ref<std::vector<reco::GsfTrack>,reco::GsfTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrack>,reco::GsfTrack> > >"/>
+  <class name="std::vector<edm::RefVector<std::vector<reco::io_v1::GsfTrack>,reco::io_v1::GsfTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GsfTrack>,reco::io_v1::GsfTrack> > >"/>
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::io_v1::GsfTrack>,reco::io_v1::GsfTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GsfTrack>,reco::io_v1::GsfTrack> > >"/>
+  <class name="std::vector<edm::Ref<std::vector<reco::io_v1::GsfTrack>,reco::io_v1::GsfTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GsfTrack>,reco::io_v1::GsfTrack> > >"/>
 
   </lcgdict>

--- a/DataFormats/HGCalReco/src/classes_def.xml
+++ b/DataFormats/HGCalReco/src/classes_def.xml
@@ -68,7 +68,7 @@
   <class name="edm::Wrapper<std::vector<TICLSeedingRegion> >" />
 
   <class name="TICLCandidate" ClassVersion="3">
-   <version ClassVersion="3" checksum="1404708640"/>
+   <version ClassVersion="3" checksum="1904138988"/>
   </class>
   <class name="std::vector<TICLCandidate>" />
   <class name="edm::Wrapper<TICLCandidate>" />

--- a/DataFormats/HLTReco/src/classes_def.xml
+++ b/DataFormats/HLTReco/src/classes_def.xml
@@ -27,13 +27,6 @@
   <class name="std::vector<HLTPerformanceInfo::Path>"/>
   <class name="std::vector<HLTPerformanceInfo::Path>::const_iterator"/>
 
-
-  <class name="std::vector<edm::Ref<std::vector<reco::RecoEcalCandidate>,reco::RecoEcalCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoEcalCandidate>,reco::RecoEcalCandidate> > >"/>
-  <class name="std::vector<edm::Ref<std::vector<reco::Electron>,reco::Electron,edm::refhelper::FindUsingAdvance<std::vector<reco::Electron>,reco::Electron> > >"/>
-  <class name="std::vector<edm::Ref<std::vector<reco::RecoChargedCandidate>,reco::RecoChargedCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoChargedCandidate>,reco::RecoChargedCandidate> > >"/>
-
-  <class name="std::vector<edm::Ref<std::vector<reco::PFTau>,reco::PFTau,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTau>,reco::PFTau> > >"/>
-
   <enum name="trigger::TriggerObjectType" />
   <class name="std::vector<trigger::TriggerObjectType>" />
   <class name="std::vector<trigger::TriggerObjectType>::const_iterator" />
@@ -43,24 +36,11 @@
   </class>
 
   <class name="trigger::TriggerObjectCollection"/>
-  <class name="trigger::TriggerRefsCollections" ClassVersion="18">
-   <version ClassVersion="18" checksum="1144412089"/>
-   <version ClassVersion="17" checksum="2974272653"/>
-   <version ClassVersion="16" checksum="3574724031"/>
-   <version ClassVersion="15" checksum="1920377523"/>
-   <version ClassVersion="14" checksum="874193725"/>
-   <version ClassVersion="13" checksum="3831523881"/>
-   <version ClassVersion="12" checksum="4231679693"/>
+  <class name="trigger::TriggerRefsCollections" ClassVersion="3">
+   <version ClassVersion="3" checksum="2127445073"/>
   </class>
-  <class name="trigger::TriggerFilterObjectWithRefs" ClassVersion="17">
-   <version ClassVersion="17" checksum="3541298866"/>
-   <version ClassVersion="16" checksum="1634484558"/>
-   <version ClassVersion="15" checksum="2946786356"/>
-   <version ClassVersion="14" checksum="4087045168"/>
-   <version ClassVersion="13" checksum="2951644382"/>
-   <version ClassVersion="12" checksum="2645314434"/>
-   <version ClassVersion="11" checksum="1437602318"/>
-   <version ClassVersion="10" checksum="1741228815"/>
+  <class name="trigger::TriggerFilterObjectWithRefs" ClassVersion="3">
+   <version ClassVersion="3" checksum="579919418"/>
   </class>
 
   <class name="trigger::TriggerEvent::TriggerFilterObject" ClassVersion="10">
@@ -81,15 +61,8 @@
    <version ClassVersion="12" checksum="2301242282"/>
   </class>
   <class name="std::vector<trigger::TriggerEventWithRefs::TriggerFilterObject>"/>
-  <class name="trigger::TriggerEventWithRefs" ClassVersion="17">
-   <version ClassVersion="17" checksum="482613136"/>
-   <version ClassVersion="16" checksum="3502028356"/>
-   <version ClassVersion="15" checksum="3947606822"/>
-   <version ClassVersion="14" checksum="2001321210"/>
-   <version ClassVersion="13" checksum="1258968436"/>
-   <version ClassVersion="12" checksum="3347721344"/>
-   <version ClassVersion="11" checksum="2025606788"/>
-   <version ClassVersion="10" checksum="4075310205"/>
+  <class name="trigger::TriggerEventWithRefs" ClassVersion="3">
+   <version ClassVersion="3" checksum="3617316456"/>
   </class>
 
   <class name="edm::Wrapper<trigger::TriggerObjectCollection>" splitLevel="0"/>
@@ -104,7 +77,7 @@
   <class name="edm::Wrapper<trigger::HLTPrescaleTable>"/>
   
   <class name="trigger::EgammaObject" ClassVersion="3">
-   <version ClassVersion="3" checksum="2024664439"/>
+   <version ClassVersion="3" checksum="2290830575"/>
   </class>
   <class name="std::vector<trigger::EgammaObject>"/>
   <class name="edm::Wrapper<std::vector<trigger::EgammaObject> >"/>

--- a/DataFormats/HcalIsolatedTrack/src/classes_def.xml
+++ b/DataFormats/HcalIsolatedTrack/src/classes_def.xml
@@ -3,39 +3,36 @@
   <class name="edm::Wrapper<std::map <int,std::pair<double,double> > >"/> 
 
   <class name="reco::IsolatedPixelTrackCandidate" ClassVersion="3">
-   <version ClassVersion="3" checksum="3796960819"/>
+   <version ClassVersion="3" checksum="369629847"/>
   </class>
   <class name="reco::IsolatedPixelTrackCandidateCollection"/>
   <class name="reco::IsolatedPixelTrackCandidateRef"/>
   <class name="reco::IsolatedPixelTrackCandidateRefVector"/>
   <class name="reco::IsolatedPixelTrackCandidateRefProd"/>
   <class name="edm::Wrapper<reco::IsolatedPixelTrackCandidateCollection>"/>
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::IsolatedPixelTrackCandidate>,reco::IsolatedPixelTrackCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::IsolatedPixelTrackCandidate>,reco::IsolatedPixelTrackCandidate> > >" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<reco::IsolatedPixelTrackCandidate>,reco::IsolatedPixelTrackCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::IsolatedPixelTrackCandidate>,reco::IsolatedPixelTrackCandidate> > >" />
   <class name="edm::Ref<std::vector<reco::IsolatedPixelTrackCandidate>,reco::IsolatedPixelTrackCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::IsolatedPixelTrackCandidate>,reco::IsolatedPixelTrackCandidate> >"/>
   <class name="std::vector<edm::Ref<std::vector<reco::IsolatedPixelTrackCandidate>,reco::IsolatedPixelTrackCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::IsolatedPixelTrackCandidate>,reco::IsolatedPixelTrackCandidate> > >"/>
 
-  <class name="reco::EcalIsolatedParticleCandidate" ClassVersion="13">
-   <version ClassVersion="13" checksum="929444430"/>
-   <version ClassVersion="12" checksum="554168470"/>
-   <version ClassVersion="10" checksum="4174683084"/>
-   <version ClassVersion="11" checksum="928263435"/>
+  <class name="reco::EcalIsolatedParticleCandidate" ClassVersion="3">
+   <version ClassVersion="3" checksum="36843570"/>
   </class>
   <class name="reco::EcalIsolatedParticleCandidateCollection"/>
   <class name="reco::EcalIsolatedParticleCandidateRef"/>
   <class name="reco::EcalIsolatedParticleCandidateRefVector"/>
   <class name="reco::EcalIsolatedParticleCandidateRefProd"/>
   <class name="edm::Wrapper<reco::EcalIsolatedParticleCandidateCollection>"/>
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::EcalIsolatedParticleCandidate>,reco::EcalIsolatedParticleCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::EcalIsolatedParticleCandidate>,reco::EcalIsolatedParticleCandidate> > >" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<reco::EcalIsolatedParticleCandidate>,reco::EcalIsolatedParticleCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::EcalIsolatedParticleCandidate>,reco::EcalIsolatedParticleCandidate> > >" />
 
   <class name="reco::HcalIsolatedTrackCandidate" ClassVersion="3">
-   <version ClassVersion="3" checksum="201453806"/>
+   <version ClassVersion="3" checksum="3839867770"/>
   </class>
   <class name="reco::HcalIsolatedTrackCandidateCollection"/>
   <class name="reco::HcalIsolatedTrackCandidateRef"/>
   <class name="reco::HcalIsolatedTrackCandidateRefVector"/>
   <class name="reco::HcalIsolatedTrackCandidateRefProd"/>
   <class name="edm::Wrapper<reco::HcalIsolatedTrackCandidateCollection>"/>
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::HcalIsolatedTrackCandidate>,reco::HcalIsolatedTrackCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::HcalIsolatedTrackCandidate>,reco::HcalIsolatedTrackCandidate> > >" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<reco::HcalIsolatedTrackCandidate>,reco::HcalIsolatedTrackCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::HcalIsolatedTrackCandidate>,reco::HcalIsolatedTrackCandidate> > >" />
   <class name="edm::Ref<std::vector<reco::HcalIsolatedTrackCandidate>,reco::HcalIsolatedTrackCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::HcalIsolatedTrackCandidate>,reco::HcalIsolatedTrackCandidate> >"/>
   <class name="std::vector<edm::Ref<std::vector<reco::HcalIsolatedTrackCandidate>,reco::HcalIsolatedTrackCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::HcalIsolatedTrackCandidate>,reco::HcalIsolatedTrackCandidate> > >"/>
 

--- a/DataFormats/HepMCCandidate/interface/GenParticle.h
+++ b/DataFormats/HepMCCandidate/interface/GenParticle.h
@@ -17,100 +17,104 @@ namespace HepMC {
 }
 
 namespace reco {
+  namespace io_v1 {
 
-  class GenParticle : public CompositeRefCandidateT<GenParticleRefVector> {
-  public:
-    /// default constructor
-    GenParticle() {}
-    /// default constructor
-    GenParticle(const LeafCandidate &c) : CompositeRefCandidateT<GenParticleRefVector>(c) {}
-    /// constrocturo from values
-    GenParticle(Charge q, const LorentzVector &p4, const Point &vtx, int pdgId, int status, bool integerCharge);
-    /// constrocturo from values
-    GenParticle(Charge q, const PolarLorentzVector &p4, const Point &vtx, int pdgId, int status, bool integerCharge);
-    /// destructor
-    ~GenParticle() override;
-    /// return a clone
-    GenParticle *clone() const override;
-    void setCollisionId(int s) { collisionId_ = s; }
-    int collisionId() const { return collisionId_; }
+    class GenParticle : public CompositeRefCandidateT<GenParticleRefVector> {
+    public:
+      /// default constructor
+      GenParticle() {}
+      /// default constructor
+      GenParticle(const LeafCandidate &c) : CompositeRefCandidateT<GenParticleRefVector>(c) {}
+      /// constrocturo from values
+      GenParticle(Charge q, const LorentzVector &p4, const Point &vtx, int pdgId, int status, bool integerCharge);
+      /// constrocturo from values
+      GenParticle(Charge q, const PolarLorentzVector &p4, const Point &vtx, int pdgId, int status, bool integerCharge);
+      /// destructor
+      ~GenParticle() override;
+      /// return a clone
+      GenParticle *clone() const override;
+      void setCollisionId(int s) { collisionId_ = s; }
+      int collisionId() const { return collisionId_; }
 
-    const GenStatusFlags &statusFlags() const { return statusFlags_; }
-    GenStatusFlags &statusFlags() { return statusFlags_; }
+      const GenStatusFlags &statusFlags() const { return statusFlags_; }
+      GenStatusFlags &statusFlags() { return statusFlags_; }
 
-    /////////////////////////////////////////////////////////////////////////////
-    //basic set of gen status flags accessible directly here
-    //the rest accessible through statusFlags()
-    //(see GenStatusFlags.h for their meaning)
+      /////////////////////////////////////////////////////////////////////////////
+      //basic set of gen status flags accessible directly here
+      //the rest accessible through statusFlags()
+      //(see GenStatusFlags.h for their meaning)
 
-    /////////////////////////////////////////////////////////////////////////////
-    //these are robust, generator-independent functions for categorizing
-    //mainly final state particles, but also intermediate hadrons/taus
+      /////////////////////////////////////////////////////////////////////////////
+      //these are robust, generator-independent functions for categorizing
+      //mainly final state particles, but also intermediate hadrons/taus
 
-    //is particle prompt (not from hadron, muon, or tau decay) and final state
-    bool isPromptFinalState() const { return status() == 1 && statusFlags_.isPrompt(); }
+      //is particle prompt (not from hadron, muon, or tau decay) and final state
+      bool isPromptFinalState() const { return status() == 1 && statusFlags_.isPrompt(); }
 
-    //is particle prompt (not from hadron, muon, or tau decay) and decayed
-    //such as a prompt tau
-    bool isPromptDecayed() const { return statusFlags_.isDecayedLeptonHadron() && statusFlags_.isPrompt(); }
+      //is particle prompt (not from hadron, muon, or tau decay) and decayed
+      //such as a prompt tau
+      bool isPromptDecayed() const { return statusFlags_.isDecayedLeptonHadron() && statusFlags_.isPrompt(); }
 
-    //this particle is a direct decay product of a prompt tau and is final state
-    //(eg an electron or muon from a leptonic decay of a prompt tau)
-    bool isDirectPromptTauDecayProductFinalState() const {
-      return status() == 1 && statusFlags_.isDirectPromptTauDecayProduct();
-    }
+      //this particle is a direct decay product of a prompt tau and is final state
+      //(eg an electron or muon from a leptonic decay of a prompt tau)
+      bool isDirectPromptTauDecayProductFinalState() const {
+        return status() == 1 && statusFlags_.isDirectPromptTauDecayProduct();
+      }
 
-    /////////////////////////////////////////////////////////////////////////////
-    //these are generator history-dependent functions for tagging particles
-    //associated with the hard process
-    //Currently implemented for Pythia 6 and Pythia 8 status codes and history
-    //and may not have 100% consistent meaning across all types of processes
-    //Users are strongly encouraged to stick to the more robust flags above,
-    //as well as the expanded set available in GenStatusFlags.h
+      /////////////////////////////////////////////////////////////////////////////
+      //these are generator history-dependent functions for tagging particles
+      //associated with the hard process
+      //Currently implemented for Pythia 6 and Pythia 8 status codes and history
+      //and may not have 100% consistent meaning across all types of processes
+      //Users are strongly encouraged to stick to the more robust flags above,
+      //as well as the expanded set available in GenStatusFlags.h
 
-    //this particle is part of the hard process
-    bool isHardProcess() const { return statusFlags_.isHardProcess(); }
+      //this particle is part of the hard process
+      bool isHardProcess() const { return statusFlags_.isHardProcess(); }
 
-    //this particle is the final state direct descendant of a hard process particle
-    bool fromHardProcessFinalState() const { return status() == 1 && statusFlags_.fromHardProcess(); }
+      //this particle is the final state direct descendant of a hard process particle
+      bool fromHardProcessFinalState() const { return status() == 1 && statusFlags_.fromHardProcess(); }
 
-    //this particle is the decayed direct descendant of a hard process particle
-    //such as a tau from the hard process
-    bool fromHardProcessDecayed() const {
-      return statusFlags_.isDecayedLeptonHadron() && statusFlags_.fromHardProcess();
-    }
+      //this particle is the decayed direct descendant of a hard process particle
+      //such as a tau from the hard process
+      bool fromHardProcessDecayed() const {
+        return statusFlags_.isDecayedLeptonHadron() && statusFlags_.fromHardProcess();
+      }
 
-    //this particle is a direct decay product of a hardprocess tau and is final state
-    //(eg an electron or muon from a leptonic decay of a tau from the hard process)
-    bool isDirectHardProcessTauDecayProductFinalState() const {
-      return status() == 1 && statusFlags_.isDirectHardProcessTauDecayProduct();
-    }
+      //this particle is a direct decay product of a hardprocess tau and is final state
+      //(eg an electron or muon from a leptonic decay of a tau from the hard process)
+      bool isDirectHardProcessTauDecayProductFinalState() const {
+        return status() == 1 && statusFlags_.isDirectHardProcessTauDecayProduct();
+      }
 
-    //this particle is the direct descendant of a hard process particle of the same pdg id.
-    //For outgoing particles the kinematics are those before QCD or QED FSR
-    //This corresponds roughly to status code 3 in pythia 6
-    //This is the most complex and error prone of all the flags and you are strongly encouraged
-    //to consider using the others to fill your needs.
-    bool fromHardProcessBeforeFSR() const { return statusFlags_.fromHardProcessBeforeFSR(); }
+      //this particle is the direct descendant of a hard process particle of the same pdg id.
+      //For outgoing particles the kinematics are those before QCD or QED FSR
+      //This corresponds roughly to status code 3 in pythia 6
+      //This is the most complex and error prone of all the flags and you are strongly encouraged
+      //to consider using the others to fill your needs.
+      bool fromHardProcessBeforeFSR() const { return statusFlags_.fromHardProcessBeforeFSR(); }
 
-    //provided for convenience.  Use this one if you were using status 3 before and didn't know or care what it exactly meant
-    bool isMostlyLikePythia6Status3() { return fromHardProcessBeforeFSR(); }
+      //provided for convenience.  Use this one if you were using status 3 before and didn't know or care what it exactly meant
+      bool isMostlyLikePythia6Status3() { return fromHardProcessBeforeFSR(); }
 
-    //this particle is the last copy of the particle in the chain  with the same pdg id
-    //(and therefore is more likely, but not guaranteed, to carry the final physical momentum)
-    bool isLastCopy() const { return statusFlags_.isLastCopy(); }
+      //this particle is the last copy of the particle in the chain  with the same pdg id
+      //(and therefore is more likely, but not guaranteed, to carry the final physical momentum)
+      bool isLastCopy() const { return statusFlags_.isLastCopy(); }
 
-    //this particle is the last copy of the particle in the chain with the same pdg id
-    //before QED or QCD FSR
-    //(and therefore is more likely, but not guaranteed, to carry the momentum after ISR)
-    bool isLastCopyBeforeFSR() const { return statusFlags_.isLastCopyBeforeFSR(); }
+      //this particle is the last copy of the particle in the chain with the same pdg id
+      //before QED or QCD FSR
+      //(and therefore is more likely, but not guaranteed, to carry the momentum after ISR)
+      bool isLastCopyBeforeFSR() const { return statusFlags_.isLastCopyBeforeFSR(); }
 
-  private:
-    /// checp overlap with another candidate
-    bool overlap(const Candidate &) const override;
-    int collisionId_;
-    GenStatusFlags statusFlags_;
-  };
+    private:
+      /// checp overlap with another candidate
+      bool overlap(const Candidate &) const override;
+      int collisionId_;
+      GenStatusFlags statusFlags_;
+    };
+
+  }  // namespace io_v1
+  using GenParticle = io_v1::GenParticle;
 
 }  // namespace reco
 

--- a/DataFormats/HepMCCandidate/interface/GenParticleFwd.h
+++ b/DataFormats/HepMCCandidate/interface/GenParticleFwd.h
@@ -10,7 +10,10 @@
 #include "DataFormats/Common/interface/Association.h"
 
 namespace reco {
-  class GenParticle;
+  namespace io_v1 {
+    class GenParticle;
+  }
+  using GenParticle = io_v1::GenParticle;
   /// collection of GenParticles
   typedef std::vector<GenParticle> GenParticleCollection;
   /// persistent reference to a GenParticle

--- a/DataFormats/HepMCCandidate/src/classes_def.xml
+++ b/DataFormats/HepMCCandidate/src/classes_def.xml
@@ -1,15 +1,12 @@
 <lcgdict>
   <class name="reco::CompositeRefCandidateT<reco::GenParticleRefVector>" />
-  <class name="reco::GenParticle"  ClassVersion="13">
-   <version ClassVersion="13" checksum="1588260052"/>
-   <version ClassVersion="12" checksum="3369685722"/>
-   <version ClassVersion="11" checksum="446025970"/>
-   <version ClassVersion="10" checksum="2736964676"/>
+  <class name="reco::io_v1::GenParticle"  ClassVersion="3">
+   <version ClassVersion="3" checksum="3117626542"/>
   </class>
-  <class name="std::vector<reco::GenParticle>" />
-  <class name="edm::Wrapper<std::vector<reco::GenParticle> >" />
-  <class name="edm::Association<std::vector<reco::GenParticle> >" />
-  <class name="edm::Wrapper<edm::Association<std::vector<reco::GenParticle> > >" />
+  <class name="std::vector<reco::io_v1::GenParticle>" />
+  <class name="edm::Wrapper<std::vector<reco::io_v1::GenParticle> >" />
+  <class name="edm::Association<std::vector<reco::io_v1::GenParticle> >" />
+  <class name="edm::Wrapper<edm::Association<std::vector<reco::io_v1::GenParticle> > >" />
 
 
   <class name="reco::GenParticleRef" />
@@ -18,13 +15,13 @@
   <class name="std::vector<std::vector<reco::GenParticleRef> >"/>
   <class name="std::vector<reco::GenParticleRef>" />
   <class name="edm::Wrapper<reco::GenParticleRefVector>" />
-  <class name="edm::Ptr<reco::GenParticle>" />
-  <class name="edm::FwdPtr<reco::GenParticle>" />
-  <class name="std::vector<edm::FwdPtr<reco::GenParticle> >" />
-  <class name="edm::Wrapper<std::vector<edm::FwdPtr<reco::GenParticle> > >" />  
-  <class name="edm::reftobase::Holder<reco::Candidate, reco::GenParticleRef>" />
+  <class name="edm::Ptr<reco::io_v1::GenParticle>" />
+  <class name="edm::FwdPtr<reco::io_v1::GenParticle>" />
+  <class name="std::vector<edm::FwdPtr<reco::io_v1::GenParticle> >" />
+  <class name="edm::Wrapper<std::vector<edm::FwdPtr<reco::io_v1::GenParticle> > >" />  
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::GenParticleRef>" />
   <class name="edm::reftobase::RefHolder<reco::GenParticleRef>" />
-  <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::GenParticleRefVector>" />
+  <class name="edm::reftobase::VectorHolder<reco::io_v1::Candidate, reco::GenParticleRefVector>" />
   <class name="edm::reftobase::RefVectorHolder<reco::GenParticleRefVector>" />
   <class name="reco::GenStatusFlags"  ClassVersion="10">
    <version ClassVersion="10" checksum="3329737103"/>
@@ -33,10 +30,8 @@
    <version ClassVersion="10" checksum="1002280074"/>
   </class>
   <class name="edm::Wrapper<reco::PdfInfo>" />
-  <class name="reco::FlavorHistory"  ClassVersion="12">
-   <version ClassVersion="12" checksum="699034420"/>
-   <version ClassVersion="11" checksum="425358630"/>
-   <version ClassVersion="10" checksum="425358630"/>
+  <class name="reco::FlavorHistory"  ClassVersion="3">
+   <version ClassVersion="3" checksum="726979366"/>
   </class>
   <class name="std::vector<reco::FlavorHistory>" />
   <class name="edm::Wrapper<std::vector<reco::FlavorHistory> >" />
@@ -51,9 +46,9 @@
   <class name="edm::Wrapper<reco::FlavorHistoryEvent >" />
   <class name="edm::ValueMap<reco::FlavorHistoryEvent >" />
   <class name="edm::Wrapper<edm::ValueMap<reco::FlavorHistoryEvent > >" />
-  <class name="edm::RefVectorIterator<std::vector<reco::GenParticle>,reco::GenParticle,edm::refhelper::FindUsingAdvance<std::vector<reco::GenParticle>,reco::GenParticle> >"/>
-  <class name="edm::ValueMap<edm::Ref<std::vector<reco::GenParticle>,reco::GenParticle,edm::refhelper::FindUsingAdvance<std::vector<reco::GenParticle>,reco::GenParticle> > >" />
-  <class name="edm::Wrapper<edm::ValueMap<edm::Ref<std::vector<reco::GenParticle>,reco::GenParticle,edm::refhelper::FindUsingAdvance<std::vector<reco::GenParticle>,reco::GenParticle> > > >" />
+  <class name="edm::RefVectorIterator<std::vector<reco::io_v1::GenParticle>,reco::io_v1::GenParticle,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GenParticle>,reco::io_v1::GenParticle> >"/>
+  <class name="edm::ValueMap<edm::Ref<std::vector<reco::io_v1::GenParticle>,reco::io_v1::GenParticle,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GenParticle>,reco::io_v1::GenParticle> > >" />
+  <class name="edm::Wrapper<edm::ValueMap<edm::Ref<std::vector<reco::io_v1::GenParticle>,reco::io_v1::GenParticle,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GenParticle>,reco::io_v1::GenParticle> > > >" />
   <!--<class pattern="std::iterator<*edm::Ref*GenParticle*>"/>-->
 </lcgdict>
  

--- a/DataFormats/JetMatching/src/classes_def.xml
+++ b/DataFormats/JetMatching/src/classes_def.xml
@@ -1,16 +1,15 @@
 <lcgdict>
-  <class name="reco::JetFlavourInfo" ClassVersion="10">
-   <version ClassVersion="10" checksum="1683584268"/>
+  <class name="reco::JetFlavourInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="2786652764"/>
   </class>
   <class name="std::vector<reco::JetFlavourInfo>"/>
-  <class name="std::pair<edm::RefToBase<reco::Jet>, reco::JetFlavourInfo>"/>
-  <class name="std::vector<std::pair<edm::RefToBase<reco::Jet>, reco::JetFlavourInfo> >"/>
+  <class name="std::pair<edm::RefToBase<reco::io_v1::Jet>, reco::JetFlavourInfo>"/>
+  <class name="std::vector<std::pair<edm::RefToBase<reco::io_v1::Jet>, reco::JetFlavourInfo> >"/>
   <class name="reco::JetFlavourInfoMatchingCollectionBase">
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="reco::JetFlavourInfoMatchingCollection" ClassVersion="11">
-   <version ClassVersion="11" checksum="2491721971"/>
-   <version ClassVersion="10" checksum="581152871"/>
+  <class name="reco::JetFlavourInfoMatchingCollection" ClassVersion="3">
+   <version ClassVersion="3" checksum="4221335161"/>
     <!-- <field name="transientVector_" transient="true"/> -->
     <!-- <field name="fixed_" transient="true"/> -->
   </class>
@@ -26,14 +25,13 @@
    <version ClassVersion="10" checksum="1787336562"/>
   </class>
   <class name="std::vector<reco::JetFlavour>"/>
-  <class name="std::pair<edm::RefToBase<reco::Jet>, reco::JetFlavour>"/>
-  <class name="std::vector<std::pair<edm::RefToBase<reco::Jet>, reco::JetFlavour> >"/>
+  <class name="std::pair<edm::RefToBase<reco::io_v1::Jet>, reco::JetFlavour>"/>
+  <class name="std::vector<std::pair<edm::RefToBase<reco::io_v1::Jet>, reco::JetFlavour> >"/>
   <class name="reco::JetFlavourMatchingCollectionBase">
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="reco::JetFlavourMatchingCollection" ClassVersion="11">
-   <version ClassVersion="11" checksum="392469271"/>
-   <version ClassVersion="10" checksum="344297371"/>
+  <class name="reco::JetFlavourMatchingCollection" ClassVersion="3">
+   <version ClassVersion="3" checksum="100619317"/>
     <!-- <field name="transientVector_" transient="true"/> -->
     <!-- <field name="fixed_" transient="true"/> -->
   </class>
@@ -42,18 +40,17 @@
   <class name="reco::JetFlavourMatchingRefVector"/>
   <class name="edm::Wrapper<reco::JetFlavourMatchingCollection>"/>
 
-  <class name="reco::MatchedPartons" ClassVersion="10">
-   <version ClassVersion="10" checksum="4065573666"/>
+  <class name="reco::MatchedPartons" ClassVersion="3">
+   <version ClassVersion="3" checksum="4053838322"/>
   </class>
   <class name="std::vector<reco::MatchedPartons>"/>
-  <class name="std::pair<edm::RefToBase<reco::Jet>, reco::MatchedPartons>"/>
-  <class name="std::vector<std::pair<edm::RefToBase<reco::Jet>, reco::MatchedPartons> >"/>
+  <class name="std::pair<edm::RefToBase<reco::io_v1::Jet>, reco::MatchedPartons>"/>
+  <class name="std::vector<std::pair<edm::RefToBase<reco::io_v1::Jet>, reco::MatchedPartons> >"/>
   <class name="reco::JetMatchedPartonsCollectionBase">
     <field name="transientVector_" transient="true"/>  
   </class>
-  <class name="reco::JetMatchedPartonsCollection" ClassVersion="11">
-   <version ClassVersion="11" checksum="3945783503"/>
-   <version ClassVersion="10" checksum="1343220703"/>
+  <class name="reco::JetMatchedPartonsCollection" ClassVersion="3">
+   <version ClassVersion="3" checksum="120689249"/>
     <!-- <field name="transientVector_" transient="true"/> -->
     <!-- <field name="fixed_" transient="true"/> -->
   </class>

--- a/DataFormats/JetReco/interface/BasicJet.h
+++ b/DataFormats/JetReco/interface/BasicJet.h
@@ -16,27 +16,30 @@
 #include "DataFormats/JetReco/interface/Jet.h"
 
 namespace reco {
-  class BasicJet : public Jet {
-  public:
-    /** Default constructor*/
-    BasicJet() {}
+  namespace io_v1 {
+    class BasicJet : public Jet {
+    public:
+      /** Default constructor*/
+      BasicJet() {}
 
-    /** Constructor from values*/
-    BasicJet(const LorentzVector& fP4, const Point& fVertex);
-    BasicJet(const LorentzVector& fP4, const Point& fVertex, const Jet::Constituents& fConstituents);
+      /** Constructor from values*/
+      BasicJet(const LorentzVector& fP4, const Point& fVertex);
+      BasicJet(const LorentzVector& fP4, const Point& fVertex, const Jet::Constituents& fConstituents);
 
-    ~BasicJet() override {}
+      ~BasicJet() override {}
 
-    /// Polymorphic clone
-    BasicJet* clone() const override;
+      /// Polymorphic clone
+      BasicJet* clone() const override;
 
-    /// Print object
-    std::string print() const override;
+      /// Print object
+      std::string print() const override;
 
-  private:
-    /// Polymorphic overlap
-    bool overlap(const Candidate&) const override;
-  };
+    private:
+      /// Polymorphic overlap
+      bool overlap(const Candidate&) const override;
+    };
+  }  // namespace io_v1
+  using BasicJet = io_v1::BasicJet;
 }  // namespace reco
 // temporary fix before include_checcker runs globally
 #include "DataFormats/JetReco/interface/BasicJetCollection.h"  //INCLUDECHECKER:SKIP

--- a/DataFormats/JetReco/interface/CaloJet.h
+++ b/DataFormats/JetReco/interface/CaloJet.h
@@ -24,140 +24,143 @@
 #include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
 
 namespace reco {
-  class CaloJet : public Jet {
-  public:
-    typedef CaloTowerPtr ConstituentTypePtr;
-    typedef CaloTowerFwdPtr ConstituentTypeFwdPtr;
+  namespace io_v1 {
+    class CaloJet : public Jet {
+    public:
+      typedef CaloTowerPtr ConstituentTypePtr;
+      typedef CaloTowerFwdPtr ConstituentTypeFwdPtr;
 
-    struct Specific {
-      Specific()
-          : mMaxEInEmTowers(0),
-            mMaxEInHadTowers(0),
-            mHadEnergyInHO(0),
-            mHadEnergyInHB(0),
-            mHadEnergyInHF(0),
-            mHadEnergyInHE(0),
-            mEmEnergyInEB(0),
-            mEmEnergyInEE(0),
-            mEmEnergyInHF(0),
-            mEnergyFractionHadronic(0),
-            mEnergyFractionEm(0),
-            mTowersArea(0) {}
+      struct Specific {
+        Specific()
+            : mMaxEInEmTowers(0),
+              mMaxEInHadTowers(0),
+              mHadEnergyInHO(0),
+              mHadEnergyInHB(0),
+              mHadEnergyInHF(0),
+              mHadEnergyInHE(0),
+              mEmEnergyInEB(0),
+              mEmEnergyInEE(0),
+              mEmEnergyInHF(0),
+              mEnergyFractionHadronic(0),
+              mEnergyFractionEm(0),
+              mTowersArea(0) {}
 
-      /// Maximum energy in EM towers
-      float mMaxEInEmTowers;
-      /// Maximum energy in HCAL towers
-      float mMaxEInHadTowers;
-      /// Hadronic nergy fraction in HO
-      float mHadEnergyInHO;
-      /// Hadronic energy in HB
-      float mHadEnergyInHB;
-      /// Hadronic energy in HF
-      float mHadEnergyInHF;
-      /// Hadronic energy in HE
-      float mHadEnergyInHE;
-      /// Em energy in EB
-      float mEmEnergyInEB;
-      /// Em energy in EE
-      float mEmEnergyInEE;
-      /// Em energy in HF
-      float mEmEnergyInHF;
-      /// Hadronic energy fraction
-      float mEnergyFractionHadronic;
-      /// Em energy fraction
-      float mEnergyFractionEm;
-      /// Area of contributing CaloTowers
-      float mTowersArea;
+        /// Maximum energy in EM towers
+        float mMaxEInEmTowers;
+        /// Maximum energy in HCAL towers
+        float mMaxEInHadTowers;
+        /// Hadronic nergy fraction in HO
+        float mHadEnergyInHO;
+        /// Hadronic energy in HB
+        float mHadEnergyInHB;
+        /// Hadronic energy in HF
+        float mHadEnergyInHF;
+        /// Hadronic energy in HE
+        float mHadEnergyInHE;
+        /// Em energy in EB
+        float mEmEnergyInEB;
+        /// Em energy in EE
+        float mEmEnergyInEE;
+        /// Em energy in HF
+        float mEmEnergyInHF;
+        /// Hadronic energy fraction
+        float mEnergyFractionHadronic;
+        /// Em energy fraction
+        float mEnergyFractionEm;
+        /// Area of contributing CaloTowers
+        float mTowersArea;
+      };
+
+      /** Default constructor*/
+      CaloJet() {}
+
+      /** Constructor from values*/
+      CaloJet(const LorentzVector& fP4,
+              const Point& fVertex,
+              const Specific& fSpecific,
+              const Jet::Constituents& fConstituents);
+
+      /** Constructor from values*/
+      CaloJet(const LorentzVector& fP4, const Point& fVertex, const Specific& fSpecific);
+
+      /** backward compatible, vertex=(0,0,0) */
+      CaloJet(const LorentzVector& fP4, const Specific& fSpecific, const Jet::Constituents& fConstituents);
+
+      ~CaloJet() override {}
+
+      /** Returns the maximum energy deposited in ECAL towers*/
+      float maxEInEmTowers() const { return m_specific.mMaxEInEmTowers; }
+      /** Returns the maximum energy deposited in HCAL towers*/
+      float maxEInHadTowers() const { return m_specific.mMaxEInHadTowers; }
+      /** Returns the jet hadronic energy fraction*/
+      float energyFractionHadronic() const { return m_specific.mEnergyFractionHadronic; }
+      /** Returns the jet electromagnetic energy fraction*/
+      float emEnergyFraction() const { return m_specific.mEnergyFractionEm; }
+      /** Returns the jet hadronic energy in HB*/
+      float hadEnergyInHB() const { return m_specific.mHadEnergyInHB; }
+      /** Returns the jet hadronic energy in HO*/
+      float hadEnergyInHO() const { return m_specific.mHadEnergyInHO; }
+      /** Returns the jet hadronic energy in HE*/
+      float hadEnergyInHE() const { return m_specific.mHadEnergyInHE; }
+      /** Returns the jet hadronic energy in HF*/
+      float hadEnergyInHF() const { return m_specific.mHadEnergyInHF; }
+      /** Returns the jet electromagnetic energy in EB*/
+      float emEnergyInEB() const { return m_specific.mEmEnergyInEB; }
+      /** Returns the jet electromagnetic energy in EE*/
+      float emEnergyInEE() const { return m_specific.mEmEnergyInEE; }
+      /** Returns the jet electromagnetic energy extracted from HF*/
+      float emEnergyInHF() const { return m_specific.mEmEnergyInHF; }
+      /** Returns area of contributing towers */
+      float towersArea() const { return m_specific.mTowersArea; }
+      /** Returns the number of constituents carrying a 90% of the total Jet energy*/
+      int n90() const { return nCarrying(0.9); }
+      /** Returns the number of constituents carrying a 60% of the total Jet energy*/
+      int n60() const { return nCarrying(0.6); }
+
+      /// Physics Eta (use jet Z and kinematics only)
+      //  float physicsEtaQuick (float fZVertex) const;
+      /// Physics Eta (use jet Z and kinematics only)
+      //float physicsEta (float fZVertex) const {return physicsEtaQuick (fZVertex);}
+      /// Physics p4 (use jet Z and kinematics only)
+      //LorentzVector physicsP4 (float fZVertex) const;
+      /// Physics p4 for full 3d vertex corretion
+      LorentzVector physicsP4(const Particle::Point& vertex) const;
+      /// detector p4 for full 3d vertex correction.
+      LorentzVector detectorP4() const;
+
+      /// Physics Eta (loop over constituents)
+      //float physicsEtaDetailed (float fZVertex) const;
+
+      /// Detector Eta (default for CaloJets)
+      //float detectorEta () const {return eta();}
+
+      /// get specific constituent
+      virtual CaloTowerPtr getCaloConstituent(unsigned fIndex) const;
+      /// get all constituents
+      virtual std::vector<CaloTowerPtr> getCaloConstituents() const;
+
+      // block accessors
+
+      const Specific& getSpecific() const { return m_specific; }
+
+      /// Polymorphic clone
+      CaloJet* clone() const override;
+
+      /// Print object
+      std::string print() const override;
+
+      /// CaloTowers indexes
+      std::vector<CaloTowerDetId> getTowerIndices() const;
+
+    private:
+      /// Polymorphic overlap
+      bool overlap(const Candidate&) const override;
+
+      //Variables specific to to the CaloJet class
+      Specific m_specific;
     };
-
-    /** Default constructor*/
-    CaloJet() {}
-
-    /** Constructor from values*/
-    CaloJet(const LorentzVector& fP4,
-            const Point& fVertex,
-            const Specific& fSpecific,
-            const Jet::Constituents& fConstituents);
-
-    /** Constructor from values*/
-    CaloJet(const LorentzVector& fP4, const Point& fVertex, const Specific& fSpecific);
-
-    /** backward compatible, vertex=(0,0,0) */
-    CaloJet(const LorentzVector& fP4, const Specific& fSpecific, const Jet::Constituents& fConstituents);
-
-    ~CaloJet() override {}
-
-    /** Returns the maximum energy deposited in ECAL towers*/
-    float maxEInEmTowers() const { return m_specific.mMaxEInEmTowers; }
-    /** Returns the maximum energy deposited in HCAL towers*/
-    float maxEInHadTowers() const { return m_specific.mMaxEInHadTowers; }
-    /** Returns the jet hadronic energy fraction*/
-    float energyFractionHadronic() const { return m_specific.mEnergyFractionHadronic; }
-    /** Returns the jet electromagnetic energy fraction*/
-    float emEnergyFraction() const { return m_specific.mEnergyFractionEm; }
-    /** Returns the jet hadronic energy in HB*/
-    float hadEnergyInHB() const { return m_specific.mHadEnergyInHB; }
-    /** Returns the jet hadronic energy in HO*/
-    float hadEnergyInHO() const { return m_specific.mHadEnergyInHO; }
-    /** Returns the jet hadronic energy in HE*/
-    float hadEnergyInHE() const { return m_specific.mHadEnergyInHE; }
-    /** Returns the jet hadronic energy in HF*/
-    float hadEnergyInHF() const { return m_specific.mHadEnergyInHF; }
-    /** Returns the jet electromagnetic energy in EB*/
-    float emEnergyInEB() const { return m_specific.mEmEnergyInEB; }
-    /** Returns the jet electromagnetic energy in EE*/
-    float emEnergyInEE() const { return m_specific.mEmEnergyInEE; }
-    /** Returns the jet electromagnetic energy extracted from HF*/
-    float emEnergyInHF() const { return m_specific.mEmEnergyInHF; }
-    /** Returns area of contributing towers */
-    float towersArea() const { return m_specific.mTowersArea; }
-    /** Returns the number of constituents carrying a 90% of the total Jet energy*/
-    int n90() const { return nCarrying(0.9); }
-    /** Returns the number of constituents carrying a 60% of the total Jet energy*/
-    int n60() const { return nCarrying(0.6); }
-
-    /// Physics Eta (use jet Z and kinematics only)
-    //  float physicsEtaQuick (float fZVertex) const;
-    /// Physics Eta (use jet Z and kinematics only)
-    //float physicsEta (float fZVertex) const {return physicsEtaQuick (fZVertex);}
-    /// Physics p4 (use jet Z and kinematics only)
-    //LorentzVector physicsP4 (float fZVertex) const;
-    /// Physics p4 for full 3d vertex corretion
-    LorentzVector physicsP4(const Particle::Point& vertex) const;
-    /// detector p4 for full 3d vertex correction.
-    LorentzVector detectorP4() const;
-
-    /// Physics Eta (loop over constituents)
-    //float physicsEtaDetailed (float fZVertex) const;
-
-    /// Detector Eta (default for CaloJets)
-    //float detectorEta () const {return eta();}
-
-    /// get specific constituent
-    virtual CaloTowerPtr getCaloConstituent(unsigned fIndex) const;
-    /// get all constituents
-    virtual std::vector<CaloTowerPtr> getCaloConstituents() const;
-
-    // block accessors
-
-    const Specific& getSpecific() const { return m_specific; }
-
-    /// Polymorphic clone
-    CaloJet* clone() const override;
-
-    /// Print object
-    std::string print() const override;
-
-    /// CaloTowers indexes
-    std::vector<CaloTowerDetId> getTowerIndices() const;
-
-  private:
-    /// Polymorphic overlap
-    bool overlap(const Candidate&) const override;
-
-    //Variables specific to to the CaloJet class
-    Specific m_specific;
-  };
+  }  // namespace io_v1
+  using CaloJet = io_v1::CaloJet;
 }  // namespace reco
 // temporary fix before include_checcker runs globally
 #include "DataFormats/JetReco/interface/CaloJetCollection.h"  //INCLUDECHECKER:SKIP

--- a/DataFormats/JetReco/interface/CaloJetFwd.h
+++ b/DataFormats/JetReco/interface/CaloJetFwd.h
@@ -1,7 +1,10 @@
 #ifndef DataFormats_JetReco_CaloJetFwd_h
 #define DataFormats_JetReco_CaloJetFwd_h
 namespace reco {
-  class CaloJet;
-}
+  namespace io_v1 {
+    class CaloJet;
+  }
+  using CaloJet = io_v1::CaloJet;
+}  // namespace reco
 
 #endif

--- a/DataFormats/JetReco/interface/GenJet.h
+++ b/DataFormats/JetReco/interface/GenJet.h
@@ -16,124 +16,126 @@
  ************************************************************/
 
 #include "DataFormats/JetReco/interface/Jet.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
 
 namespace reco {
-  class GenParticle;
+  namespace io_v1 {
+    class GenJet : public Jet {
+    public:
+      struct Specific {
+        Specific()
+            : m_EmEnergy(0),
+              m_HadEnergy(0),
+              m_InvisibleEnergy(0),
+              m_AuxiliaryEnergy(0),
+              m_ChargedHadronEnergy(0),
+              m_NeutralHadronEnergy(0),
+              m_ChargedEmEnergy(0),
+              m_NeutralEmEnergy(0),
+              m_MuonEnergy(0),
+              m_ChargedHadronMultiplicity(0),
+              m_NeutralHadronMultiplicity(0),
+              m_ChargedEmMultiplicity(0),
+              m_NeutralEmMultiplicity(0),
+              m_MuonMultiplicity(0) {}
 
-  class GenJet : public Jet {
-  public:
-    struct Specific {
-      Specific()
-          : m_EmEnergy(0),
-            m_HadEnergy(0),
-            m_InvisibleEnergy(0),
-            m_AuxiliaryEnergy(0),
-            m_ChargedHadronEnergy(0),
-            m_NeutralHadronEnergy(0),
-            m_ChargedEmEnergy(0),
-            m_NeutralEmEnergy(0),
-            m_MuonEnergy(0),
-            m_ChargedHadronMultiplicity(0),
-            m_NeutralHadronMultiplicity(0),
-            m_ChargedEmMultiplicity(0),
-            m_NeutralEmMultiplicity(0),
-            m_MuonMultiplicity(0) {}
+        /// Calo-like definitions:
+        /// Energy of EM particles
+        float m_EmEnergy;
+        /// Energy of Hadrons
+        float m_HadEnergy;
+        /// Invisible energy (mu, nu, ...)
+        float m_InvisibleEnergy;
+        /// Anything else (undecayed Sigmas etc.)
+        float m_AuxiliaryEnergy;
 
-      /// Calo-like definitions:
-      /// Energy of EM particles
-      float m_EmEnergy;
-      /// Energy of Hadrons
-      float m_HadEnergy;
-      /// Invisible energy (mu, nu, ...)
-      float m_InvisibleEnergy;
-      /// Anything else (undecayed Sigmas etc.)
-      float m_AuxiliaryEnergy;
+        /// PF-like definitions:
+        /// pi+, K+, etc
+        float m_ChargedHadronEnergy;
+        /// K0, etc
+        float m_NeutralHadronEnergy;
+        /// Electrons
+        float m_ChargedEmEnergy;
+        /// Photons
+        float m_NeutralEmEnergy;
+        /// Muons
+        float m_MuonEnergy;
+        /// Corresponding multiplicities:
+        int m_ChargedHadronMultiplicity;
+        int m_NeutralHadronMultiplicity;
+        int m_ChargedEmMultiplicity;
+        int m_NeutralEmMultiplicity;
+        int m_MuonMultiplicity;
+      };
 
-      /// PF-like definitions:
-      /// pi+, K+, etc
-      float m_ChargedHadronEnergy;
-      /// K0, etc
-      float m_NeutralHadronEnergy;
-      /// Electrons
-      float m_ChargedEmEnergy;
-      /// Photons
-      float m_NeutralEmEnergy;
-      /// Muons
-      float m_MuonEnergy;
-      /// Corresponding multiplicities:
-      int m_ChargedHadronMultiplicity;
-      int m_NeutralHadronMultiplicity;
-      int m_ChargedEmMultiplicity;
-      int m_NeutralEmMultiplicity;
-      int m_MuonMultiplicity;
+      /** Default constructor*/
+      GenJet() {}
+
+      /** Constructor from values*/
+      GenJet(const LorentzVector& fP4,
+             const Point& fVertex,
+             const Specific& fSpecific,
+             const Jet::Constituents& fConstituents);
+      GenJet(const LorentzVector& fP4, const Point& fVertex, const Specific& fSpecific);
+
+      /** backward compatible, vertex=(0,0,0) */
+      GenJet(const LorentzVector& fP4, const Specific& fSpecific, const Jet::Constituents& fConstituents);
+
+      ~GenJet() override {}
+      /** Returns energy of electromagnetic particles*/
+      float emEnergy() const { return m_specific.m_EmEnergy; };
+      /** Returns energy of hadronic particles*/
+      float hadEnergy() const { return m_specific.m_HadEnergy; };
+      /** Returns invisible energy*/
+      float invisibleEnergy() const { return m_specific.m_InvisibleEnergy; };
+      /** Returns other energy (undecayed Sigmas etc.)*/
+      float auxiliaryEnergy() const { return m_specific.m_AuxiliaryEnergy; };
+
+      // PF-like definitions
+      float chargedHadronEnergy() const { return m_specific.m_ChargedHadronEnergy; }
+      float neutralHadronEnergy() const { return m_specific.m_NeutralHadronEnergy; }
+      float chargedEmEnergy() const { return m_specific.m_ChargedEmEnergy; }
+      float neutralEmEnergy() const { return m_specific.m_NeutralEmEnergy; }
+      float muonEnergy() const { return m_specific.m_MuonEnergy; }
+      int chargedHadronMultiplicity() const { return m_specific.m_ChargedHadronMultiplicity; }
+      int neutralHadronMultiplicity() const { return m_specific.m_NeutralHadronMultiplicity; }
+      int chargedEmMultiplicity() const { return m_specific.m_ChargedEmMultiplicity; }
+      int neutralEmMultiplicity() const { return m_specific.m_NeutralEmMultiplicity; }
+      int muonMultiplicity() const { return m_specific.m_MuonMultiplicity; }
+
+      /// Detector Eta (use reference Z and jet kinematics only)
+      float detectorEta(float fZVertex) const;
+
+      /// convert generic constituent to specific type
+      static const GenParticle* genParticle(const reco::Candidate* fConstituent);
+      /// get specific constituent
+      virtual const GenParticle* getGenConstituent(unsigned fIndex) const;
+      /// get all constituents
+      virtual std::vector<const GenParticle*> getGenConstituents() const;
+
+      // block accessors
+
+      const Specific& getSpecific() const { return m_specific; }
+
+      /// set the specific (note: responsibility of keeping it consistent with the jet daughers belongs to the caller)
+      void setSpecific(const Specific& spec) { m_specific = spec; }
+
+      /// Polymorphic clone
+      GenJet* clone() const override;
+
+      /// Print object
+      std::string print() const override;
+
+    private:
+      /// Polymorphic overlap
+      bool overlap(const Candidate&) const override;
+
+      // Data members
+      //Variables specific to to the GenJet class
+      Specific m_specific;
     };
-
-    /** Default constructor*/
-    GenJet() {}
-
-    /** Constructor from values*/
-    GenJet(const LorentzVector& fP4,
-           const Point& fVertex,
-           const Specific& fSpecific,
-           const Jet::Constituents& fConstituents);
-    GenJet(const LorentzVector& fP4, const Point& fVertex, const Specific& fSpecific);
-
-    /** backward compatible, vertex=(0,0,0) */
-    GenJet(const LorentzVector& fP4, const Specific& fSpecific, const Jet::Constituents& fConstituents);
-
-    ~GenJet() override {}
-    /** Returns energy of electromagnetic particles*/
-    float emEnergy() const { return m_specific.m_EmEnergy; };
-    /** Returns energy of hadronic particles*/
-    float hadEnergy() const { return m_specific.m_HadEnergy; };
-    /** Returns invisible energy*/
-    float invisibleEnergy() const { return m_specific.m_InvisibleEnergy; };
-    /** Returns other energy (undecayed Sigmas etc.)*/
-    float auxiliaryEnergy() const { return m_specific.m_AuxiliaryEnergy; };
-
-    // PF-like definitions
-    float chargedHadronEnergy() const { return m_specific.m_ChargedHadronEnergy; }
-    float neutralHadronEnergy() const { return m_specific.m_NeutralHadronEnergy; }
-    float chargedEmEnergy() const { return m_specific.m_ChargedEmEnergy; }
-    float neutralEmEnergy() const { return m_specific.m_NeutralEmEnergy; }
-    float muonEnergy() const { return m_specific.m_MuonEnergy; }
-    int chargedHadronMultiplicity() const { return m_specific.m_ChargedHadronMultiplicity; }
-    int neutralHadronMultiplicity() const { return m_specific.m_NeutralHadronMultiplicity; }
-    int chargedEmMultiplicity() const { return m_specific.m_ChargedEmMultiplicity; }
-    int neutralEmMultiplicity() const { return m_specific.m_NeutralEmMultiplicity; }
-    int muonMultiplicity() const { return m_specific.m_MuonMultiplicity; }
-
-    /// Detector Eta (use reference Z and jet kinematics only)
-    float detectorEta(float fZVertex) const;
-
-    /// convert generic constituent to specific type
-    static const GenParticle* genParticle(const reco::Candidate* fConstituent);
-    /// get specific constituent
-    virtual const GenParticle* getGenConstituent(unsigned fIndex) const;
-    /// get all constituents
-    virtual std::vector<const GenParticle*> getGenConstituents() const;
-
-    // block accessors
-
-    const Specific& getSpecific() const { return m_specific; }
-
-    /// set the specific (note: responsibility of keeping it consistent with the jet daughers belongs to the caller)
-    void setSpecific(const Specific& spec) { m_specific = spec; }
-
-    /// Polymorphic clone
-    GenJet* clone() const override;
-
-    /// Print object
-    std::string print() const override;
-
-  private:
-    /// Polymorphic overlap
-    bool overlap(const Candidate&) const override;
-
-    // Data members
-    //Variables specific to to the GenJet class
-    Specific m_specific;
-  };
+  }  // namespace io_v1
+  using GenJet = io_v1::GenJet;
 }  // namespace reco
 // temporary fix before include_checcker runs globally
 #include "DataFormats/JetReco/interface/GenJetCollection.h"  //INCLUDECHECKER:SKIP

--- a/DataFormats/JetReco/interface/GenJetFwd.h
+++ b/DataFormats/JetReco/interface/GenJetFwd.h
@@ -1,6 +1,9 @@
 #ifndef DataFormats_JetReco_GenJetFwd_h
 #define DataFormats_JetReco_GenJetFwd_h
 namespace reco {
-  class GenJet;
-}
+  namespace io_v1 {
+    class GenJet;
+  }
+  using GenJet = io_v1::GenJet;
+}  // namespace reco
 #endif

--- a/DataFormats/JetReco/interface/JPTJet.h
+++ b/DataFormats/JetReco/interface/JPTJet.h
@@ -25,120 +25,123 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 namespace reco {
-  class JPTJet : public Jet {
-  public:
-    struct Specific {
-      Specific()
-          : mChargedHadronEnergy(0),
-            mChargedEmEnergy(0),
-            mResponseOfChargedWithEff(0),
-            mResponseOfChargedWithoutEff(0),
-            mSumPtOfChargedWithEff(0),
-            mSumPtOfChargedWithoutEff(0),
-            mSumEnergyOfChargedWithEff(0),
-            mSumEnergyOfChargedWithoutEff(0),
-            R2momtr(0),
-            Eta2momtr(0),
-            Phi2momtr(0),
-            Pout(0),
-            Zch(0),
-            JPTSeed(0) {}
-      edm::RefToBase<reco::Jet> theCaloJetRef;
-      reco::TrackRefVector pionsInVertexInCalo;
-      reco::TrackRefVector pionsInVertexOutCalo;
-      reco::TrackRefVector pionsOutVertexInCalo;
-      reco::TrackRefVector muonsInVertexInCalo;
-      reco::TrackRefVector muonsInVertexOutCalo;
-      reco::TrackRefVector muonsOutVertexInCalo;
-      reco::TrackRefVector elecsInVertexInCalo;
-      reco::TrackRefVector elecsInVertexOutCalo;
-      reco::TrackRefVector elecsOutVertexInCalo;
-      float mChargedHadronEnergy;
-      float mChargedEmEnergy;
-      float mResponseOfChargedWithEff;
-      float mResponseOfChargedWithoutEff;
-      float mSumPtOfChargedWithEff;
-      float mSumPtOfChargedWithoutEff;
-      float mSumEnergyOfChargedWithEff;
-      float mSumEnergyOfChargedWithoutEff;
-      float R2momtr;
-      float Eta2momtr;
-      float Phi2momtr;
-      float Pout;
-      float Zch;
-      int JPTSeed;
+  namespace io_v1 {
+    class JPTJet : public Jet {
+    public:
+      struct Specific {
+        Specific()
+            : mChargedHadronEnergy(0),
+              mChargedEmEnergy(0),
+              mResponseOfChargedWithEff(0),
+              mResponseOfChargedWithoutEff(0),
+              mSumPtOfChargedWithEff(0),
+              mSumPtOfChargedWithoutEff(0),
+              mSumEnergyOfChargedWithEff(0),
+              mSumEnergyOfChargedWithoutEff(0),
+              R2momtr(0),
+              Eta2momtr(0),
+              Phi2momtr(0),
+              Pout(0),
+              Zch(0),
+              JPTSeed(0) {}
+        edm::RefToBase<reco::Jet> theCaloJetRef;
+        reco::TrackRefVector pionsInVertexInCalo;
+        reco::TrackRefVector pionsInVertexOutCalo;
+        reco::TrackRefVector pionsOutVertexInCalo;
+        reco::TrackRefVector muonsInVertexInCalo;
+        reco::TrackRefVector muonsInVertexOutCalo;
+        reco::TrackRefVector muonsOutVertexInCalo;
+        reco::TrackRefVector elecsInVertexInCalo;
+        reco::TrackRefVector elecsInVertexOutCalo;
+        reco::TrackRefVector elecsOutVertexInCalo;
+        float mChargedHadronEnergy;
+        float mChargedEmEnergy;
+        float mResponseOfChargedWithEff;
+        float mResponseOfChargedWithoutEff;
+        float mSumPtOfChargedWithEff;
+        float mSumPtOfChargedWithoutEff;
+        float mSumEnergyOfChargedWithEff;
+        float mSumEnergyOfChargedWithoutEff;
+        float R2momtr;
+        float Eta2momtr;
+        float Phi2momtr;
+        float Pout;
+        float Zch;
+        int JPTSeed;
+      };
+
+      /** Default constructor*/
+      JPTJet() {}
+
+      /** Constructor from values*/
+      JPTJet(const LorentzVector& fP4,
+             const Point& fVertex,
+             const Specific& fSpecific,
+             const Jet::Constituents& fConstituents);
+
+      /** backward compatible, vertex=(0,0,0) */
+      JPTJet(const LorentzVector& fP4, const Specific& fSpecific, const Jet::Constituents& fConstituents);
+
+      ~JPTJet() override {}
+      /// chargedHadronEnergy
+      float chargedHadronEnergy() const { return mspecific.mChargedHadronEnergy; }
+      ///  chargedHadronEnergyFraction
+      float chargedHadronEnergyFraction() const { return chargedHadronEnergy() / energy(); }
+      /// chargedEmEnergy
+      float chargedEmEnergy() const { return mspecific.mChargedEmEnergy; }
+      /// chargedEmEnergyFraction
+      float chargedEmEnergyFraction() const { return chargedEmEnergy() / energy(); }
+      /// chargedMultiplicity
+      int chargedMultiplicity() const {
+        return mspecific.muonsInVertexInCalo.size() + mspecific.muonsInVertexOutCalo.size() +
+               mspecific.pionsInVertexInCalo.size() + mspecific.pionsInVertexOutCalo.size() +
+               mspecific.elecsInVertexInCalo.size() + mspecific.elecsInVertexOutCalo.size();
+      }
+      /// muonMultiplicity
+      int muonMultiplicity() const {
+        return mspecific.muonsInVertexInCalo.size() + mspecific.muonsInVertexOutCalo.size();
+      }
+      /// elecMultiplicity
+      int elecMultiplicity() const {
+        return mspecific.elecsInVertexInCalo.size() + mspecific.elecsInVertexOutCalo.size();
+      }
+      /// Tracks
+      const reco::TrackRefVector& getPionsInVertexInCalo() const { return mspecific.pionsInVertexInCalo; }
+      const reco::TrackRefVector& getPionsInVertexOutCalo() const { return mspecific.pionsInVertexOutCalo; }
+      const reco::TrackRefVector& getPionsOutVertexInCalo() const { return mspecific.pionsOutVertexInCalo; }
+      const reco::TrackRefVector& getMuonsInVertexInCalo() const { return mspecific.muonsInVertexInCalo; }
+      const reco::TrackRefVector& getMuonsInVertexOutCalo() const { return mspecific.muonsInVertexOutCalo; }
+      const reco::TrackRefVector& getMuonsOutVertexInCalo() const { return mspecific.muonsOutVertexInCalo; }
+      const reco::TrackRefVector& getElecsInVertexInCalo() const { return mspecific.elecsInVertexInCalo; }
+      const reco::TrackRefVector& getElecsInVertexOutCalo() const { return mspecific.elecsInVertexOutCalo; }
+      const reco::TrackRefVector& getElecsOutVertexInCalo() const { return mspecific.elecsOutVertexInCalo; }
+
+      const edm::RefToBase<reco::Jet>& getCaloJetRef() const { return mspecific.theCaloJetRef; }
+      /// block accessors
+
+      const Specific& getSpecific() const { return mspecific; }
+
+      /// Polymorphic clone
+      JPTJet* clone() const override;
+
+      /// Print object in details
+      virtual void printJet() const;
+
+      std::string print() const override;
+
+    private:
+      /// Polymorphic overlap
+      bool overlap(const Candidate&) const override;
+
+      //Variables specific to to the JPTJet class
+
+      Specific mspecific;
     };
 
-    /** Default constructor*/
-    JPTJet() {}
-
-    /** Constructor from values*/
-    JPTJet(const LorentzVector& fP4,
-           const Point& fVertex,
-           const Specific& fSpecific,
-           const Jet::Constituents& fConstituents);
-
-    /** backward compatible, vertex=(0,0,0) */
-    JPTJet(const LorentzVector& fP4, const Specific& fSpecific, const Jet::Constituents& fConstituents);
-
-    ~JPTJet() override {}
-    /// chargedHadronEnergy
-    float chargedHadronEnergy() const { return mspecific.mChargedHadronEnergy; }
-    ///  chargedHadronEnergyFraction
-    float chargedHadronEnergyFraction() const { return chargedHadronEnergy() / energy(); }
-    /// chargedEmEnergy
-    float chargedEmEnergy() const { return mspecific.mChargedEmEnergy; }
-    /// chargedEmEnergyFraction
-    float chargedEmEnergyFraction() const { return chargedEmEnergy() / energy(); }
-    /// chargedMultiplicity
-    int chargedMultiplicity() const {
-      return mspecific.muonsInVertexInCalo.size() + mspecific.muonsInVertexOutCalo.size() +
-             mspecific.pionsInVertexInCalo.size() + mspecific.pionsInVertexOutCalo.size() +
-             mspecific.elecsInVertexInCalo.size() + mspecific.elecsInVertexOutCalo.size();
-    }
-    /// muonMultiplicity
-    int muonMultiplicity() const {
-      return mspecific.muonsInVertexInCalo.size() + mspecific.muonsInVertexOutCalo.size();
-    }
-    /// elecMultiplicity
-    int elecMultiplicity() const {
-      return mspecific.elecsInVertexInCalo.size() + mspecific.elecsInVertexOutCalo.size();
-    }
-    /// Tracks
-    const reco::TrackRefVector& getPionsInVertexInCalo() const { return mspecific.pionsInVertexInCalo; }
-    const reco::TrackRefVector& getPionsInVertexOutCalo() const { return mspecific.pionsInVertexOutCalo; }
-    const reco::TrackRefVector& getPionsOutVertexInCalo() const { return mspecific.pionsOutVertexInCalo; }
-    const reco::TrackRefVector& getMuonsInVertexInCalo() const { return mspecific.muonsInVertexInCalo; }
-    const reco::TrackRefVector& getMuonsInVertexOutCalo() const { return mspecific.muonsInVertexOutCalo; }
-    const reco::TrackRefVector& getMuonsOutVertexInCalo() const { return mspecific.muonsOutVertexInCalo; }
-    const reco::TrackRefVector& getElecsInVertexInCalo() const { return mspecific.elecsInVertexInCalo; }
-    const reco::TrackRefVector& getElecsInVertexOutCalo() const { return mspecific.elecsInVertexOutCalo; }
-    const reco::TrackRefVector& getElecsOutVertexInCalo() const { return mspecific.elecsOutVertexInCalo; }
-
-    const edm::RefToBase<reco::Jet>& getCaloJetRef() const { return mspecific.theCaloJetRef; }
-    /// block accessors
-
-    const Specific& getSpecific() const { return mspecific; }
-
-    /// Polymorphic clone
-    JPTJet* clone() const override;
-
-    /// Print object in details
-    virtual void printJet() const;
-
-    std::string print() const override;
-
-  private:
-    /// Polymorphic overlap
-    bool overlap(const Candidate&) const override;
-
-    //Variables specific to to the JPTJet class
-
-    Specific mspecific;
-  };
-
-  // streamer
-  //std::ostream& operator<<(std::ostream& out, const reco::JPTJet& jet);
+    // streamer
+    //std::ostream& operator<<(std::ostream& out, const reco::JPTJet& jet);
+  }  // namespace io_v1
+  using JPTJet = io_v1::JPTJet;
 }  // namespace reco
 // temporary fix before include_checcker runs globally
 #include "DataFormats/JetReco/interface/JPTJetCollection.h"  //INCLUDECHECKER:SKIP

--- a/DataFormats/JetReco/interface/Jet.h
+++ b/DataFormats/JetReco/interface/Jet.h
@@ -17,113 +17,116 @@
 #include "DataFormats/Candidate/interface/CompositePtrCandidate.h"
 
 namespace reco {
-  class Jet : public CompositePtrCandidate {
-  public:
-    typedef edm::Ptr<Candidate> Constituent;
-    typedef std::vector<Constituent> Constituents;
-
-    /// record to store eta-phi first and second moments
-    class EtaPhiMoments {
+  namespace io_v1 {
+    class Jet : public CompositePtrCandidate {
     public:
-      float etaMean;
-      float phiMean;
-      float etaEtaMoment;
-      float phiPhiMoment;
-      float etaPhiMoment;
+      typedef edm::Ptr<Candidate> Constituent;
+      typedef std::vector<Constituent> Constituents;
+
+      /// record to store eta-phi first and second moments
+      class EtaPhiMoments {
+      public:
+        float etaMean;
+        float phiMean;
+        float etaEtaMoment;
+        float phiPhiMoment;
+        float etaPhiMoment;
+      };
+
+      /// Default constructor
+      Jet() : mJetArea(0), mPileupEnergy(0), mPassNumber(0), mIsWeighted(false) {}
+      /// Initiator
+      Jet(const LorentzVector& fP4, const Point& fVertex);
+      Jet(const LorentzVector& fP4, const Point& fVertex, const Constituents& fConstituents);
+      /// Destructor
+      ~Jet() override {}
+
+      /// eta-phi statistics, ET weighted
+      EtaPhiMoments etaPhiStatistics() const;
+
+      /// eta-eta second moment, ET weighted
+      float etaetaMoment() const;
+
+      /// phi-phi second moment, ET weighted
+      float phiphiMoment() const;
+
+      /// eta-phi second moment, ET weighted
+      float etaphiMoment() const;
+
+      /// ET in annulus between rmin and rmax around jet direction
+      float etInAnnulus(float fRmin, float fRmax) const;
+
+      /// return # of constituent carrying fraction of energy
+      int nCarrying(float fFraction) const;
+
+      /// maximum distance from jet to constituent
+      float maxDistance() const;
+
+      /// # of constituents
+      virtual int nConstituents() const { return numberOfDaughters(); }
+
+      /// static function to convert detector eta to physics eta
+      static float physicsEta(float fZVertex, float fDetectorEta);
+
+      /// static function to convert physics eta to detector eta
+      static float detectorEta(float fZVertex, float fPhysicsEta);
+
+      static Candidate::LorentzVector physicsP4(const Candidate::Point& newVertex,
+                                                const Candidate& inParticle,
+                                                const Candidate::Point& oldVertex = Candidate::Point(0, 0, 0));
+
+      static Candidate::LorentzVector detectorP4(const Candidate::Point& vertex, const Candidate& inParticle);
+
+      /// list of constituents
+      virtual Constituents getJetConstituents() const;
+
+      /// quick list of constituents
+      virtual std::vector<const reco::Candidate*> getJetConstituentsQuick() const;
+
+      // jet structure variables:
+      // constituentPtDistribution is the pT distribution among the jet constituents
+      // (ptDistribution = 1 if jet made by one constituent carrying all its momentum,
+      //  ptDistribution = 0 if jet made by infinite constituents carrying an infinitesimal fraction of pt):
+      float constituentPtDistribution() const;
+
+      // rmsCand is the rms of the eta-phi spread of the jet's constituents wrt the jet axis:
+      float constituentEtaPhiSpread() const;
+
+      /// Print object
+      virtual std::string print() const;
+
+      /// scale energy of the jet
+      virtual void scaleEnergy(double fScale);
+
+      /// set jet area
+      virtual void setJetArea(float fArea) { mJetArea = fArea; }
+      /// get jet area
+      virtual float jetArea() const { return mJetArea; }
+
+      ///  Set pileup energy contribution as calculated by algorithm
+      virtual void setPileup(float fEnergy) { mPileupEnergy = fEnergy; }
+      ///  pileup energy contribution as calculated by algorithm
+      virtual float pileup() const { return mPileupEnergy; }
+
+      ///  Set number of passes taken by algorithm
+      virtual void setNPasses(int fPasses) { mPassNumber = fPasses; }
+      ///  number of passes taken by algorithm
+      virtual int nPasses() const { return mPassNumber; }
+
+      ///  Set boolean if weights were applied by algorithm (e.g. PUPPI weights)
+      virtual void setIsWeighted(bool isWeighted) { mIsWeighted = isWeighted; }
+      ///  boolean if weights were applied by algorithm (e.g. PUPPI weights)
+      virtual int isWeighted() const { return mIsWeighted; }
+
+      bool isJet() const override;
+
+    private:
+      float mJetArea;
+      float mPileupEnergy;
+      int mPassNumber;
+      bool mIsWeighted;
     };
-
-    /// Default constructor
-    Jet() : mJetArea(0), mPileupEnergy(0), mPassNumber(0), mIsWeighted(false) {}
-    /// Initiator
-    Jet(const LorentzVector& fP4, const Point& fVertex);
-    Jet(const LorentzVector& fP4, const Point& fVertex, const Constituents& fConstituents);
-    /// Destructor
-    ~Jet() override {}
-
-    /// eta-phi statistics, ET weighted
-    EtaPhiMoments etaPhiStatistics() const;
-
-    /// eta-eta second moment, ET weighted
-    float etaetaMoment() const;
-
-    /// phi-phi second moment, ET weighted
-    float phiphiMoment() const;
-
-    /// eta-phi second moment, ET weighted
-    float etaphiMoment() const;
-
-    /// ET in annulus between rmin and rmax around jet direction
-    float etInAnnulus(float fRmin, float fRmax) const;
-
-    /// return # of constituent carrying fraction of energy
-    int nCarrying(float fFraction) const;
-
-    /// maximum distance from jet to constituent
-    float maxDistance() const;
-
-    /// # of constituents
-    virtual int nConstituents() const { return numberOfDaughters(); }
-
-    /// static function to convert detector eta to physics eta
-    static float physicsEta(float fZVertex, float fDetectorEta);
-
-    /// static function to convert physics eta to detector eta
-    static float detectorEta(float fZVertex, float fPhysicsEta);
-
-    static Candidate::LorentzVector physicsP4(const Candidate::Point& newVertex,
-                                              const Candidate& inParticle,
-                                              const Candidate::Point& oldVertex = Candidate::Point(0, 0, 0));
-
-    static Candidate::LorentzVector detectorP4(const Candidate::Point& vertex, const Candidate& inParticle);
-
-    /// list of constituents
-    virtual Constituents getJetConstituents() const;
-
-    /// quick list of constituents
-    virtual std::vector<const reco::Candidate*> getJetConstituentsQuick() const;
-
-    // jet structure variables:
-    // constituentPtDistribution is the pT distribution among the jet constituents
-    // (ptDistribution = 1 if jet made by one constituent carrying all its momentum,
-    //  ptDistribution = 0 if jet made by infinite constituents carrying an infinitesimal fraction of pt):
-    float constituentPtDistribution() const;
-
-    // rmsCand is the rms of the eta-phi spread of the jet's constituents wrt the jet axis:
-    float constituentEtaPhiSpread() const;
-
-    /// Print object
-    virtual std::string print() const;
-
-    /// scale energy of the jet
-    virtual void scaleEnergy(double fScale);
-
-    /// set jet area
-    virtual void setJetArea(float fArea) { mJetArea = fArea; }
-    /// get jet area
-    virtual float jetArea() const { return mJetArea; }
-
-    ///  Set pileup energy contribution as calculated by algorithm
-    virtual void setPileup(float fEnergy) { mPileupEnergy = fEnergy; }
-    ///  pileup energy contribution as calculated by algorithm
-    virtual float pileup() const { return mPileupEnergy; }
-
-    ///  Set number of passes taken by algorithm
-    virtual void setNPasses(int fPasses) { mPassNumber = fPasses; }
-    ///  number of passes taken by algorithm
-    virtual int nPasses() const { return mPassNumber; }
-
-    ///  Set boolean if weights were applied by algorithm (e.g. PUPPI weights)
-    virtual void setIsWeighted(bool isWeighted) { mIsWeighted = isWeighted; }
-    ///  boolean if weights were applied by algorithm (e.g. PUPPI weights)
-    virtual int isWeighted() const { return mIsWeighted; }
-
-    bool isJet() const override;
-
-  private:
-    float mJetArea;
-    float mPileupEnergy;
-    int mPassNumber;
-    bool mIsWeighted;
-  };
+  }  // namespace io_v1
+  using Jet = io_v1::Jet;
 }  // namespace reco
 #endif

--- a/DataFormats/JetReco/interface/JetExtendedAssociation.h
+++ b/DataFormats/JetReco/interface/JetExtendedAssociation.h
@@ -22,9 +22,12 @@ namespace fwlite {
 
 namespace reco {
   namespace JetExtendedAssociation {
-    class JetExtendedData;
+    namespace io_v1 {
+      class JetExtendedData;
+    }
+    using io_v1::JetExtendedData;
     typedef math::PtEtaPhiELorentzVectorF LorentzVector;
-    typedef reco::JetExtendedAssociation::JetExtendedData Value;
+    typedef reco::JetExtendedAssociation::io_v1::JetExtendedData Value;
     typedef std::vector<Value> Values;
     typedef edm::AssociationVector<reco::JetRefBaseProd, Values> Container;
     typedef Container::value_type value_type;
@@ -64,15 +67,17 @@ namespace reco {
     /// check if jet is associated
     bool hasJet(const Container&, const reco::Jet&);
 
-    class JetExtendedData {
-    public:
-      JetExtendedData();
-      ~JetExtendedData() {}
-      int mTracksAtVertexNumber;
-      LorentzVector mTracksAtVertexP4;
-      int mTracksAtCaloNumber;
-      LorentzVector mTracksAtCaloP4;
-    };
+    namespace io_v1 {
+      class JetExtendedData {
+      public:
+        JetExtendedData();
+        ~JetExtendedData() {}
+        int mTracksAtVertexNumber;
+        LorentzVector mTracksAtVertexP4;
+        int mTracksAtCaloNumber;
+        LorentzVector mTracksAtCaloP4;
+      };
+    }  // namespace io_v1
   }  // namespace JetExtendedAssociation
 }  // namespace reco
 

--- a/DataFormats/JetReco/interface/JetFwd.h
+++ b/DataFormats/JetReco/interface/JetFwd.h
@@ -1,6 +1,9 @@
 #ifndef DataFormats_JetReco_JetFwd_h
 #define DataFormats_JetReco_JetFwd_h
 namespace reco {
-  class Jet;
+  namespace io_v1 {
+    class Jet;
+  }
+  using Jet = io_v1::Jet;
 }  // namespace reco
 #endif

--- a/DataFormats/JetReco/interface/JetID.h
+++ b/DataFormats/JetReco/interface/JetID.h
@@ -13,54 +13,58 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 
 namespace reco {
-  struct JetID {
-    // initialize
-    JetID() {
-      fHPD = 0.0;
-      fRBX = 0.0;
-      n90Hits = 0;
-      fSubDetector1 = 0.0;
-      fSubDetector2 = 0.0;
-      fSubDetector3 = 0.0;
-      fSubDetector4 = 0.0;
-      restrictedEMF = 0.0;
-      nHCALTowers = 0;
-      nECALTowers = 0;
-      approximatefHPD = 0.0;
-      approximatefRBX = 0.0;
-      hitsInN90 = 0;
-      numberOfHits2RPC = 0;
-      numberOfHits3RPC = 0;
-      numberOfHitsRPC = 0;
+  namespace io_v1 {
+    struct JetID {
+      // initialize
+      JetID() {
+        fHPD = 0.0;
+        fRBX = 0.0;
+        n90Hits = 0;
+        fSubDetector1 = 0.0;
+        fSubDetector2 = 0.0;
+        fSubDetector3 = 0.0;
+        fSubDetector4 = 0.0;
+        restrictedEMF = 0.0;
+        nHCALTowers = 0;
+        nECALTowers = 0;
+        approximatefHPD = 0.0;
+        approximatefRBX = 0.0;
+        hitsInN90 = 0;
+        numberOfHits2RPC = 0;
+        numberOfHits3RPC = 0;
+        numberOfHitsRPC = 0;
 
-      fEB = fEE = fHB = fHE = fHO = fLong = fShort = 0.0;
-      fLS = fHFOOT = 0.0;
-    }
+        fEB = fEE = fHB = fHE = fHO = fLong = fShort = 0.0;
+        fLS = fHFOOT = 0.0;
+      }
 
-    // hcal+ecal id
-    float fHPD;
-    float fRBX;
-    short n90Hits;
-    float fSubDetector1;
-    float fSubDetector2;
-    float fSubDetector3;
-    float fSubDetector4;
-    float restrictedEMF;
-    short nHCALTowers;
-    short nECALTowers;
-    float approximatefHPD;
-    float approximatefRBX;
-    short hitsInN90;
-    // muon hits id
-    short numberOfHits2RPC;
-    short numberOfHits3RPC;
-    short numberOfHitsRPC;
+      // hcal+ecal id
+      float fHPD;
+      float fRBX;
+      short n90Hits;
+      float fSubDetector1;
+      float fSubDetector2;
+      float fSubDetector3;
+      float fSubDetector4;
+      float restrictedEMF;
+      short nHCALTowers;
+      short nECALTowers;
+      float approximatefHPD;
+      float approximatefRBX;
+      short hitsInN90;
+      // muon hits id
+      short numberOfHits2RPC;
+      short numberOfHits3RPC;
+      short numberOfHitsRPC;
 
-    float fEB, fEE, fHB, fHE, fHO, fLong, fShort;
-    float fLS, fHFOOT;
-  };
+      float fEB, fEE, fHB, fHE, fHO, fLong, fShort;
+      float fLS, fHFOOT;
+    };
 
-  typedef edm::ValueMap<JetID> JetIDValueMap;
+    typedef edm::ValueMap<JetID> JetIDValueMap;
+  }  // namespace io_v1
+  using JetID = io_v1::JetID;
+  using JetIDValueMap = io_v1::JetIDValueMap;
 }  // namespace reco
 
 #endif

--- a/DataFormats/JetReco/interface/PFJet.h
+++ b/DataFormats/JetReco/interface/PFJet.h
@@ -17,178 +17,181 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 namespace reco {
-  class PFJet : public Jet {
-  public:
-    typedef reco::PFCandidatePtr ConstituentTypePtr;
-    typedef reco::PFCandidateFwdPtr ConstituentTypeFwdPtr;
+  namespace io_v1 {
+    class PFJet : public Jet {
+    public:
+      typedef reco::PFCandidatePtr ConstituentTypePtr;
+      typedef reco::PFCandidateFwdPtr ConstituentTypeFwdPtr;
 
-    struct Specific {
-      Specific()
-          : mChargedHadronEnergy(0),
-            mNeutralHadronEnergy(0),
-            mPhotonEnergy(0),
-            mElectronEnergy(0),
-            mMuonEnergy(0),
-            mHFHadronEnergy(0),
-            mHFEMEnergy(0),
+      struct Specific {
+        Specific()
+            : mChargedHadronEnergy(0),
+              mNeutralHadronEnergy(0),
+              mPhotonEnergy(0),
+              mElectronEnergy(0),
+              mMuonEnergy(0),
+              mHFHadronEnergy(0),
+              mHFEMEnergy(0),
 
-            mChargedHadronMultiplicity(0),
-            mNeutralHadronMultiplicity(0),
-            mPhotonMultiplicity(0),
-            mElectronMultiplicity(0),
-            mMuonMultiplicity(0),
-            mHFHadronMultiplicity(0),
-            mHFEMMultiplicity(0),
+              mChargedHadronMultiplicity(0),
+              mNeutralHadronMultiplicity(0),
+              mPhotonMultiplicity(0),
+              mElectronMultiplicity(0),
+              mMuonMultiplicity(0),
+              mHFHadronMultiplicity(0),
+              mHFEMMultiplicity(0),
 
-            mChargedEmEnergy(0),
-            mChargedMuEnergy(0),
-            mNeutralEmEnergy(0),
+              mChargedEmEnergy(0),
+              mChargedMuEnergy(0),
+              mNeutralEmEnergy(0),
 
-            mChargedMultiplicity(0),
-            mNeutralMultiplicity(0),
+              mChargedMultiplicity(0),
+              mNeutralMultiplicity(0),
 
-            mHOEnergy(0) {}
-      float mChargedHadronEnergy;
-      float mNeutralHadronEnergy;
-      float mPhotonEnergy;
-      float mElectronEnergy;
-      float mMuonEnergy;
-      float mHFHadronEnergy;
-      float mHFEMEnergy;
+              mHOEnergy(0) {}
+        float mChargedHadronEnergy;
+        float mNeutralHadronEnergy;
+        float mPhotonEnergy;
+        float mElectronEnergy;
+        float mMuonEnergy;
+        float mHFHadronEnergy;
+        float mHFEMEnergy;
 
-      int mChargedHadronMultiplicity;
-      int mNeutralHadronMultiplicity;
-      int mPhotonMultiplicity;
-      int mElectronMultiplicity;
-      int mMuonMultiplicity;
-      int mHFHadronMultiplicity;
-      int mHFEMMultiplicity;
+        int mChargedHadronMultiplicity;
+        int mNeutralHadronMultiplicity;
+        int mPhotonMultiplicity;
+        int mElectronMultiplicity;
+        int mMuonMultiplicity;
+        int mHFHadronMultiplicity;
+        int mHFEMMultiplicity;
 
-      //old (deprecated) data members
-      //kept only for backwards compatibility:
-      float mChargedEmEnergy;
-      float mChargedMuEnergy;
-      float mNeutralEmEnergy;
-      int mChargedMultiplicity;
-      int mNeutralMultiplicity;
+        //old (deprecated) data members
+        //kept only for backwards compatibility:
+        float mChargedEmEnergy;
+        float mChargedMuEnergy;
+        float mNeutralEmEnergy;
+        int mChargedMultiplicity;
+        int mNeutralMultiplicity;
 
-      float mHOEnergy;
+        float mHOEnergy;
+      };
+
+      /** Default constructor*/
+      PFJet() {}
+
+      /** Constructor from values*/
+      PFJet(const LorentzVector& fP4,
+            const Point& fVertex,
+            const Specific& fSpecific,
+            const Jet::Constituents& fConstituents);
+
+      PFJet(const LorentzVector& fP4, const Point& fVertex, const Specific& fSpecific);
+
+      /** backward compatible, vertex=(0,0,0) */
+      PFJet(const LorentzVector& fP4, const Specific& fSpecific, const Jet::Constituents& fConstituents);
+
+      ~PFJet() override {}
+
+      /// chargedHadronEnergy
+      float chargedHadronEnergy() const { return m_specific.mChargedHadronEnergy; }
+      ///  chargedHadronEnergyFraction
+      float chargedHadronEnergyFraction() const { return chargedHadronEnergy() / energy(); }
+      /// neutralHadronEnergy
+      float neutralHadronEnergy() const { return m_specific.mNeutralHadronEnergy; }
+      /// neutralHadronEnergyFraction
+      float neutralHadronEnergyFraction() const { return neutralHadronEnergy() / energy(); }
+      /// photonEnergy
+      float photonEnergy() const { return m_specific.mPhotonEnergy; }
+      /// photonEnergyFraction
+      float photonEnergyFraction() const { return photonEnergy() / energy(); }
+      /// electronEnergy
+      float electronEnergy() const { return m_specific.mElectronEnergy; }
+      /// electronEnergyFraction
+      float electronEnergyFraction() const { return electronEnergy() / energy(); }
+      /// muonEnergy
+      float muonEnergy() const { return m_specific.mMuonEnergy; }
+      /// muonEnergyFraction
+      float muonEnergyFraction() const { return muonEnergy() / energy(); }
+      /// HFHadronEnergy
+      float HFHadronEnergy() const { return m_specific.mHFHadronEnergy; }
+      /// HFHadronEnergyFraction
+      float HFHadronEnergyFraction() const { return HFHadronEnergy() / energy(); }
+      /// HFEMEnergy
+      float HFEMEnergy() const { return m_specific.mHFEMEnergy; }
+      /// HFEMEnergyFraction
+      float HFEMEnergyFraction() const { return HFEMEnergy() / energy(); }
+
+      /// chargedHadronMultiplicity
+      int chargedHadronMultiplicity() const { return m_specific.mChargedHadronMultiplicity; }
+      /// neutralHadronMultiplicity
+      int neutralHadronMultiplicity() const { return m_specific.mNeutralHadronMultiplicity; }
+      /// photonMultiplicity
+      int photonMultiplicity() const { return m_specific.mPhotonMultiplicity; }
+      /// electronMultiplicity
+      int electronMultiplicity() const { return m_specific.mElectronMultiplicity; }
+      /// muonMultiplicity
+      int muonMultiplicity() const { return m_specific.mMuonMultiplicity; }
+      /// HFHadronMultiplicity
+      int HFHadronMultiplicity() const { return m_specific.mHFHadronMultiplicity; }
+      /// HFEMMultiplicity
+      int HFEMMultiplicity() const { return m_specific.mHFEMMultiplicity; }
+
+      /// chargedEmEnergy
+      float chargedEmEnergy() const { return m_specific.mChargedEmEnergy; }
+      /// chargedEmEnergyFraction
+      float chargedEmEnergyFraction() const { return chargedEmEnergy() / energy(); }
+      /// chargedMuEnergy
+      float chargedMuEnergy() const { return m_specific.mChargedMuEnergy; }
+      /// chargedMuEnergyFraction
+      float chargedMuEnergyFraction() const { return chargedMuEnergy() / energy(); }
+      /// neutralEmEnergy
+      float neutralEmEnergy() const { return m_specific.mNeutralEmEnergy; }
+      /// neutralEmEnergyFraction
+      float neutralEmEnergyFraction() const { return neutralEmEnergy() / energy(); }
+
+      /// chargedMultiplicity
+      int chargedMultiplicity() const { return m_specific.mChargedMultiplicity; }
+      /// neutralMultiplicity
+      int neutralMultiplicity() const { return m_specific.mNeutralMultiplicity; }
+
+      /// hoEnergy
+      float hoEnergy() const { return m_specific.mHOEnergy; }
+      /// hoEnergyFraction
+      float hoEnergyFraction() const { return hoEnergy() / energy(); }
+
+      /// get specific constituent
+      virtual reco::PFCandidatePtr getPFConstituent(unsigned fIndex) const;
+
+      /// get all constituents
+      virtual std::vector<reco::PFCandidatePtr> getPFConstituents() const;
+
+      /// \ brief get all tracks in the jets
+      /// All PFCandidates hold a reference to a track. All the non-null
+      /// references are added to the returned TrackRefVector
+      reco::TrackRefVector getTrackRefs() const;
+
+      // block accessors
+
+      const Specific& getSpecific() const { return m_specific; }
+
+      /// Polymorphic clone
+      PFJet* clone() const override;
+
+      /// Print object in details
+      std::string print() const override;
+
+    private:
+      /// Polymorphic overlap
+      bool overlap(const Candidate&) const override;
+
+      //Variables specific to to the PFJet class
+      Specific m_specific;
     };
 
-    /** Default constructor*/
-    PFJet() {}
-
-    /** Constructor from values*/
-    PFJet(const LorentzVector& fP4,
-          const Point& fVertex,
-          const Specific& fSpecific,
-          const Jet::Constituents& fConstituents);
-
-    PFJet(const LorentzVector& fP4, const Point& fVertex, const Specific& fSpecific);
-
-    /** backward compatible, vertex=(0,0,0) */
-    PFJet(const LorentzVector& fP4, const Specific& fSpecific, const Jet::Constituents& fConstituents);
-
-    ~PFJet() override {}
-
-    /// chargedHadronEnergy
-    float chargedHadronEnergy() const { return m_specific.mChargedHadronEnergy; }
-    ///  chargedHadronEnergyFraction
-    float chargedHadronEnergyFraction() const { return chargedHadronEnergy() / energy(); }
-    /// neutralHadronEnergy
-    float neutralHadronEnergy() const { return m_specific.mNeutralHadronEnergy; }
-    /// neutralHadronEnergyFraction
-    float neutralHadronEnergyFraction() const { return neutralHadronEnergy() / energy(); }
-    /// photonEnergy
-    float photonEnergy() const { return m_specific.mPhotonEnergy; }
-    /// photonEnergyFraction
-    float photonEnergyFraction() const { return photonEnergy() / energy(); }
-    /// electronEnergy
-    float electronEnergy() const { return m_specific.mElectronEnergy; }
-    /// electronEnergyFraction
-    float electronEnergyFraction() const { return electronEnergy() / energy(); }
-    /// muonEnergy
-    float muonEnergy() const { return m_specific.mMuonEnergy; }
-    /// muonEnergyFraction
-    float muonEnergyFraction() const { return muonEnergy() / energy(); }
-    /// HFHadronEnergy
-    float HFHadronEnergy() const { return m_specific.mHFHadronEnergy; }
-    /// HFHadronEnergyFraction
-    float HFHadronEnergyFraction() const { return HFHadronEnergy() / energy(); }
-    /// HFEMEnergy
-    float HFEMEnergy() const { return m_specific.mHFEMEnergy; }
-    /// HFEMEnergyFraction
-    float HFEMEnergyFraction() const { return HFEMEnergy() / energy(); }
-
-    /// chargedHadronMultiplicity
-    int chargedHadronMultiplicity() const { return m_specific.mChargedHadronMultiplicity; }
-    /// neutralHadronMultiplicity
-    int neutralHadronMultiplicity() const { return m_specific.mNeutralHadronMultiplicity; }
-    /// photonMultiplicity
-    int photonMultiplicity() const { return m_specific.mPhotonMultiplicity; }
-    /// electronMultiplicity
-    int electronMultiplicity() const { return m_specific.mElectronMultiplicity; }
-    /// muonMultiplicity
-    int muonMultiplicity() const { return m_specific.mMuonMultiplicity; }
-    /// HFHadronMultiplicity
-    int HFHadronMultiplicity() const { return m_specific.mHFHadronMultiplicity; }
-    /// HFEMMultiplicity
-    int HFEMMultiplicity() const { return m_specific.mHFEMMultiplicity; }
-
-    /// chargedEmEnergy
-    float chargedEmEnergy() const { return m_specific.mChargedEmEnergy; }
-    /// chargedEmEnergyFraction
-    float chargedEmEnergyFraction() const { return chargedEmEnergy() / energy(); }
-    /// chargedMuEnergy
-    float chargedMuEnergy() const { return m_specific.mChargedMuEnergy; }
-    /// chargedMuEnergyFraction
-    float chargedMuEnergyFraction() const { return chargedMuEnergy() / energy(); }
-    /// neutralEmEnergy
-    float neutralEmEnergy() const { return m_specific.mNeutralEmEnergy; }
-    /// neutralEmEnergyFraction
-    float neutralEmEnergyFraction() const { return neutralEmEnergy() / energy(); }
-
-    /// chargedMultiplicity
-    int chargedMultiplicity() const { return m_specific.mChargedMultiplicity; }
-    /// neutralMultiplicity
-    int neutralMultiplicity() const { return m_specific.mNeutralMultiplicity; }
-
-    /// hoEnergy
-    float hoEnergy() const { return m_specific.mHOEnergy; }
-    /// hoEnergyFraction
-    float hoEnergyFraction() const { return hoEnergy() / energy(); }
-
-    /// get specific constituent
-    virtual reco::PFCandidatePtr getPFConstituent(unsigned fIndex) const;
-
-    /// get all constituents
-    virtual std::vector<reco::PFCandidatePtr> getPFConstituents() const;
-
-    /// \ brief get all tracks in the jets
-    /// All PFCandidates hold a reference to a track. All the non-null
-    /// references are added to the returned TrackRefVector
-    reco::TrackRefVector getTrackRefs() const;
-
-    // block accessors
-
-    const Specific& getSpecific() const { return m_specific; }
-
-    /// Polymorphic clone
-    PFJet* clone() const override;
-
-    /// Print object in details
-    std::string print() const override;
-
-  private:
-    /// Polymorphic overlap
-    bool overlap(const Candidate&) const override;
-
-    //Variables specific to to the PFJet class
-    Specific m_specific;
-  };
-
-  // streamer
-  std::ostream& operator<<(std::ostream& out, const reco::PFJet& jet);
+    // streamer
+    std::ostream& operator<<(std::ostream& out, const reco::io_v1::PFJet& jet);
+  }  // namespace io_v1
+  using PFJet = io_v1::PFJet;
 }  // namespace reco
 // temporary fix before include_checcker runs globally
 #include "DataFormats/JetReco/interface/PFJetCollection.h"  //INCLUDECHECKER:SKIP

--- a/DataFormats/JetReco/interface/PFJetCollection.h
+++ b/DataFormats/JetReco/interface/PFJetCollection.h
@@ -11,7 +11,10 @@
 #include "DataFormats/JetReco/interface/PFJet.h"  //INCLUDECHECKER:SKIP
 
 namespace reco {
-  class PFJet;
+  namespace io_v1 {
+    class PFJet;
+  }
+  using PFJet = io_v1::PFJet;
   /// collection of PFJet objects
   typedef std::vector<PFJet> PFJetCollection;
   /// edm references

--- a/DataFormats/JetReco/interface/TrackExtrapolation.h
+++ b/DataFormats/JetReco/interface/TrackExtrapolation.h
@@ -19,34 +19,37 @@
 #include <vector>
 
 namespace reco {
-  class TrackExtrapolation {
-    // Next two typedefs use double in ROOT 6 rather than Double32_t due to a bug in ROOT 5,
-    // which otherwise would make ROOT5 files unreadable in ROOT6.  This does not increase
-    // the size on disk, because due to the bug, double was actually stored on disk in ROOT 5.
-    typedef ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double> > Point;
-    typedef ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double> > Vector;
+  namespace io_v1 {
+    class TrackExtrapolation {
+      // Next two typedefs use double in ROOT 6 rather than Double32_t due to a bug in ROOT 5,
+      // which otherwise would make ROOT5 files unreadable in ROOT6.  This does not increase
+      // the size on disk, because due to the bug, double was actually stored on disk in ROOT 5.
+      typedef ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double> > Point;
+      typedef ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double> > Vector;
 
-  public:
-    TrackExtrapolation() {}
-    TrackExtrapolation(reco::TrackRef const& track, std::vector<Point> const& pos, std::vector<Vector> const& mom)
-        : track_(track) {
-      pos_.resize(pos.size());
-      copy(pos.begin(), pos.end(), pos_.begin());
-      mom_.resize(mom.size());
-      copy(mom.begin(), mom.end(), mom_.begin());
-    }
+    public:
+      TrackExtrapolation() {}
+      TrackExtrapolation(reco::TrackRef const& track, std::vector<Point> const& pos, std::vector<Vector> const& mom)
+          : track_(track) {
+        pos_.resize(pos.size());
+        copy(pos.begin(), pos.end(), pos_.begin());
+        mom_.resize(mom.size());
+        copy(mom.begin(), mom.end(), mom_.begin());
+      }
 
-    ~TrackExtrapolation() {}
+      ~TrackExtrapolation() {}
 
-    reco::TrackRef const& track() const { return track_; }
-    std::vector<Point> const& positions() const { return pos_; }
-    std::vector<Vector> const& momenta() const { return mom_; }
+      reco::TrackRef const& track() const { return track_; }
+      std::vector<Point> const& positions() const { return pos_; }
+      std::vector<Vector> const& momenta() const { return mom_; }
 
-  protected:
-    reco::TrackRef track_;
-    std::vector<Point> pos_;
-    std::vector<Vector> mom_;
-  };
+    protected:
+      reco::TrackRef track_;
+      std::vector<Point> pos_;
+      std::vector<Vector> mom_;
+    };
+  }  // namespace io_v1
+  using TrackExtrapolation = io_v1::TrackExtrapolation;
 }  // namespace reco
 
 #endif

--- a/DataFormats/JetReco/interface/TrackJet.h
+++ b/DataFormats/JetReco/interface/TrackJet.h
@@ -20,48 +20,51 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  class TrackJet : public Jet {
-  public:
-    /// Default constructor
-    TrackJet();
-    /// Constructor without constituents
-    TrackJet(const LorentzVector& fP4, const Point& fVertex);
-    /// Constructor from RecoChargedRefCandidate constituents
-    TrackJet(const LorentzVector& fP4, const Point& fVertex, const Jet::Constituents& fConstituents);
-    /// Destructor
-    ~TrackJet() override {}
-    /// Polymorphic clone
-    TrackJet* clone() const override;
+    class TrackJet : public Jet {
+    public:
+      /// Default constructor
+      TrackJet();
+      /// Constructor without constituents
+      TrackJet(const LorentzVector& fP4, const Point& fVertex);
+      /// Constructor from RecoChargedRefCandidate constituents
+      TrackJet(const LorentzVector& fP4, const Point& fVertex, const Jet::Constituents& fConstituents);
+      /// Destructor
+      ~TrackJet() override {}
+      /// Polymorphic clone
+      TrackJet* clone() const override;
 
-    /// Number of track daughters
-    size_t numberOfTracks() const { return numberOfDaughters(); }
-    /// Return Ptr to the track costituent
-    virtual edm::Ptr<reco::Track> track(size_t i) const;
-    /// Return pointers to all track costituents
-    std::vector<edm::Ptr<reco::Track> > tracks() const;
+      /// Number of track daughters
+      size_t numberOfTracks() const { return numberOfDaughters(); }
+      /// Return Ptr to the track costituent
+      virtual edm::Ptr<reco::Track> track(size_t i) const;
+      /// Return pointers to all track costituents
+      std::vector<edm::Ptr<reco::Track> > tracks() const;
 
-    /// calculate and set the charge by adding up the constituting track charges
-    void resetCharge();
-    /// get associated primary vertex
-    const reco::VertexRef primaryVertex() const;
-    /// set associated primary vertex
-    void setPrimaryVertex(const reco::VertexRef& vtx);
-    /// check jet to be associated to the hard primary vertex
-    bool fromHardVertex() const { return (this->primaryVertex().index() == 0); }
+      /// calculate and set the charge by adding up the constituting track charges
+      void resetCharge();
+      /// get associated primary vertex
+      const reco::VertexRef primaryVertex() const;
+      /// set associated primary vertex
+      void setPrimaryVertex(const reco::VertexRef& vtx);
+      /// check jet to be associated to the hard primary vertex
+      bool fromHardVertex() const { return (this->primaryVertex().index() == 0); }
 
-    /// Print object
-    std::string print() const override;
+      /// Print object
+      std::string print() const override;
 
-  private:
-    /// Polymorphic overlap
-    bool overlap(const Candidate& dummy) const override;
+    private:
+      /// Polymorphic overlap
+      bool overlap(const Candidate& dummy) const override;
 
-  private:
-    /// Associated primary vertex
-    reco::VertexRef vtx_;
-  };
+    private:
+      /// Associated primary vertex
+      reco::VertexRef vtx_;
+    };
 
+  }  // namespace io_v1
+  using TrackJet = io_v1::TrackJet;
 }  // namespace reco
 
 #endif

--- a/DataFormats/JetReco/src/PFJet.cc
+++ b/DataFormats/JetReco/src/PFJet.cc
@@ -11,6 +11,7 @@
 #include "DataFormats/JetReco/interface/PFJet.h"
 
 using namespace reco;
+using namespace reco::io_v1;
 
 PFJet::PFJet(const LorentzVector& fP4,
              const Point& fVertex,
@@ -95,7 +96,7 @@ std::string PFJet::print() const {
   return out.str();
 }
 
-std::ostream& reco::operator<<(std::ostream& out, const reco::PFJet& jet) {
+std::ostream& reco::io_v1::operator<<(std::ostream& out, const reco::io_v1::PFJet& jet) {
   if (out) {
     out << "PFJet "
         << "(pt, eta, phi) = " << jet.pt() << "," << jet.eta() << "," << jet.phi()

--- a/DataFormats/JetReco/src/classes_def_1.xml
+++ b/DataFormats/JetReco/src/classes_def_1.xml
@@ -1,142 +1,122 @@
 <lcgdict>
-  <class name="reco::Jet" ClassVersion="13">
-   <version ClassVersion="13" checksum="921384601"/>
-   <version ClassVersion="12" checksum="1247035343"/>
-   <version ClassVersion="11" checksum="1537319703"/>
-   <version ClassVersion="10" checksum="1996172778"/>
+  <class name="reco::io_v1::Jet" ClassVersion="3">
+   <version ClassVersion="3" checksum="718784871"/>
   </class>
-  <class name="reco::Jet::EtaPhiMoments" ClassVersion="10">
-   <version ClassVersion="10" checksum="1092387980"/>
+  <class name="reco::io_v1::Jet::EtaPhiMoments" ClassVersion="3">
+   <version ClassVersion="3" checksum="3852241398"/>
   </class>
 
-  <class name="reco::CaloJet" ClassVersion="13">
-   <version ClassVersion="13" checksum="3570116631"/>
-   <version ClassVersion="12" checksum="3191984313"/>
-   <version ClassVersion="11" checksum="3081844369"/>
-   <version ClassVersion="10" checksum="715843310"/>
+  <class name="reco::io_v1::CaloJet" ClassVersion="3">
+   <version ClassVersion="3" checksum="1484483325"/>
   </class>
-  <class name="reco::CaloJet::Specific" ClassVersion="10">
-   <version ClassVersion="10" checksum="2617452651"/>
+  <class name="reco::io_v1::CaloJet::Specific" ClassVersion="3">
+   <version ClassVersion="3" checksum="1704847273"/>
   </class>
-  <class name="std::vector<reco::CaloJet>"/>
-  <class name="edm::RefProd<std::vector<reco::CaloJet> >"/>
-  <class name="edm::RefVector<std::vector<reco::CaloJet>,reco::CaloJet,edm::refhelper::FindUsingAdvance<std::vector<reco::CaloJet>,reco::CaloJet> >"/>
-  <class name="std::vector<edm::Ref<std::vector<reco::CaloJet>,reco::CaloJet,edm::refhelper::FindUsingAdvance<std::vector<reco::CaloJet>,reco::CaloJet> > >"/>
-  <class name="edm::Ref<std::vector<reco::CaloJet>,reco::CaloJet,edm::refhelper::FindUsingAdvance<std::vector<reco::CaloJet>,reco::CaloJet> >"/>
-  <class name="edm::Wrapper<std::vector<reco::CaloJet> >"/>
+  <class name="std::vector<reco::io_v1::CaloJet>"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::CaloJet> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::CaloJet>,reco::io_v1::CaloJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::CaloJet>,reco::io_v1::CaloJet> >"/>
+  <class name="std::vector<edm::Ref<std::vector<reco::io_v1::CaloJet>,reco::io_v1::CaloJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::CaloJet>,reco::io_v1::CaloJet> > >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::CaloJet>,reco::io_v1::CaloJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::CaloJet>,reco::io_v1::CaloJet> >"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::CaloJet> >"/>
   <class name="edm::Wrapper<reco::CaloJetRefVector>"/>
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::CaloJet>,reco::CaloJet,edm::refhelper::FindUsingAdvance<std::vector<reco::CaloJet>,reco::CaloJet> > >" />
-  <class name="reco::JetTrackMatch<std::vector<reco::CaloJet> >"/>
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<reco::io_v1::CaloJet>,reco::io_v1::CaloJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::CaloJet>,reco::io_v1::CaloJet> > >" />
+  <class name="reco::JetTrackMatch<std::vector<reco::io_v1::CaloJet> >"/>
   <class name="edm::AssociationMap<edm::OneToMany<reco::CaloJetCollection, std::vector<reco::Track>, unsigned int> >">
       <field name="transientMap_" transient="true"/>
   </class>
   <class name="edm::helpers::Key<edm::RefProd<reco::CaloJetCollection > >"/>
   <class name="edm::helpers::KeyVal<edm::RefProd<reco::CaloJetCollection>,edm::RefProd<std::vector<reco::Track> > >"/>
-  <class name="edm::FwdRef<std::vector<reco::CaloJet>,reco::CaloJet,edm::refhelper::FindUsingAdvance<std::vector<reco::CaloJet>,reco::CaloJet> >"/>
+  <class name="edm::FwdRef<std::vector<reco::io_v1::CaloJet>,reco::io_v1::CaloJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::CaloJet>,reco::io_v1::CaloJet> >"/>
   <class name="reco::CaloJetFwdRefVector"/>
   <class name="edm::Wrapper<reco::CaloJetFwdRefVector>"/>
-  <class name="edm::FwdPtr<reco::CaloJet>"/>
+  <class name="edm::FwdPtr<reco::io_v1::CaloJet>"/>
   <class name="reco::CaloJetFwdPtrVector"/>
   <class name="edm::Wrapper<reco::CaloJetFwdPtrVector>"/>
   <class name="std::vector<reco::CaloJetRefVector>"/>
   <class name="edm::Wrapper<std::vector<reco::CaloJetRefVector> >"/>
 
-  <class name="reco::JPTJet" ClassVersion="13">
-   <version ClassVersion="13" checksum="3477277922"/>
-   <version ClassVersion="12" checksum="3435263220"/>
-   <version ClassVersion="11" checksum="2945806860"/>
-   <version ClassVersion="10" checksum="456342263"/>
+  <class name="reco::io_v1::JPTJet" ClassVersion="3">
+   <version ClassVersion="3" checksum="2313687382"/>
   </class>
-  <class name="reco::JPTJet::Specific" ClassVersion="3">
-   <version ClassVersion="3" checksum="1528463198"/>
+  <class name="reco::io_v1::JPTJet::Specific" ClassVersion="3">
+   <version ClassVersion="3" checksum="1084724008"/>
   </class>
-  <class name="std::vector<reco::JPTJet>"/>
-  <class name="edm::RefProd<std::vector<reco::JPTJet> >"/>
-  <class name="edm::RefVector<std::vector<reco::JPTJet>,reco::JPTJet,edm::refhelper::FindUsingAdvance<std::vector<reco::JPTJet>,reco::JPTJet> >"/>
-  <class name="edm::Ref<std::vector<reco::JPTJet>,reco::JPTJet,edm::refhelper::FindUsingAdvance<std::vector<reco::JPTJet>,reco::JPTJet> >"/>
-  <class name="edm::Wrapper<std::vector<reco::JPTJet> >"/>
+  <class name="std::vector<reco::io_v1::JPTJet>"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::JPTJet> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::JPTJet>,reco::io_v1::JPTJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::JPTJet>,reco::io_v1::JPTJet> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::JPTJet>,reco::io_v1::JPTJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::JPTJet>,reco::io_v1::JPTJet> >"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::JPTJet> >"/>
   <class name="edm::Wrapper<reco::JPTJetRefVector>"/>
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::JPTJet>,reco::JPTJet,edm::refhelper::FindUsingAdvance<std::vector<reco::JPTJet>,reco::JPTJet> > >" />
-  <class name="reco::JetTrackMatch<std::vector<reco::JPTJet> >"/>
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<reco::io_v1::JPTJet>,reco::io_v1::JPTJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::JPTJet>,reco::io_v1::JPTJet> > >" />
+  <class name="reco::JetTrackMatch<std::vector<reco::io_v1::JPTJet> >"/>
   <class name="edm::AssociationMap<edm::OneToMany<reco::JPTJetCollection, std::vector<reco::Track>, unsigned int> >">
       <field name="transientMap_" transient="true"/>
   </class>
   <class name="edm::helpers::KeyVal<edm::RefProd<reco::JPTJetCollection>,edm::RefProd<std::vector<reco::Track> > >"/>
 
-  <class name="reco::PFJet" ClassVersion="13">
-   <version ClassVersion="13" checksum="2538804571"/>
-   <version ClassVersion="12" checksum="2496789869"/>
-   <version ClassVersion="11" checksum="2007333509"/>
-   <version ClassVersion="10" checksum="3657319332"/>
+  <class name="reco::io_v1::PFJet" ClassVersion="3">
+   <version ClassVersion="3" checksum="988205209"/>
   </class>
-  <class name="reco::PFJet::Specific" ClassVersion="11">
-   <version ClassVersion="11" checksum="3865393003"/>
-   <version ClassVersion="10" checksum="3345092571"/>
+  <class name="reco::io_v1::PFJet::Specific" ClassVersion="3">
+   <version ClassVersion="3" checksum="1839745193"/>
   </class>
-  <class name="std::vector<reco::PFJet>"/>
-  <class name="edm::RefVector<std::vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFJet>,reco::PFJet> >"/>
-  <class name="edm::Ref<std::vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFJet>,reco::PFJet> >"/>
-  <class name="edm::RefProd<std::vector<reco::PFJet> >"/>
-  <class name="edm::Wrapper<std::vector<reco::PFJet> >"/>
+  <class name="std::vector<reco::io_v1::PFJet>"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::PFJet>,reco::io_v1::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFJet>,reco::io_v1::PFJet> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::PFJet>,reco::io_v1::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFJet>,reco::io_v1::PFJet> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::PFJet> >"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::PFJet> >"/>
   <class name="edm::Wrapper<reco::PFJetRefVector>"/>
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFJet>,reco::PFJet> > >" />
-  <class name="reco::JetTrackMatch<std::vector<reco::PFJet> >"/>
-  <class name="edm::FwdRef<std::vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFJet>,reco::PFJet> >"/>
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<reco::io_v1::PFJet>,reco::io_v1::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFJet>,reco::io_v1::PFJet> > >" />
+  <class name="reco::JetTrackMatch<std::vector<reco::io_v1::PFJet> >"/>
+  <class name="edm::FwdRef<std::vector<reco::io_v1::PFJet>,reco::io_v1::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFJet>,reco::io_v1::PFJet> >"/>
   <class name="reco::PFJetFwdRefVector"/>
   <class name="edm::Wrapper<reco::PFJetFwdRefVector>"/>
-  <class name="edm::FwdPtr<reco::PFJet>"/>
+  <class name="edm::FwdPtr<reco::io_v1::PFJet>"/>
   <class name="reco::PFJetFwdPtrVector"/>
   <class name="edm::Wrapper<reco::PFJetFwdPtrVector>"/>
-  <class name="std::vector<edm::Ref<std::vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFJet>,reco::PFJet> > >"/>
+  <class name="std::vector<edm::Ref<std::vector<reco::io_v1::PFJet>,reco::io_v1::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFJet>,reco::io_v1::PFJet> > >"/>
   <class name="std::vector<reco::PFJetRefVector>"/>
   <class name="edm::Wrapper<std::vector<reco::PFJetRefVector> >"/>
   <class name="edm::reftobase::RefVectorHolder<reco::PFJetRefVector>"/>
 
-  <class name="reco::GenJet" ClassVersion="13">
-   <version ClassVersion="13" checksum="3754101333"/>
-   <version ClassVersion="12" checksum="3628057227"/>
-   <version ClassVersion="11" checksum="2159688147"/>
-   <version ClassVersion="10" checksum="1136403928"/>
+  <class name="reco::io_v1::GenJet" ClassVersion="3">
+   <version ClassVersion="3" checksum="2544745155"/>
   </class>
-  <class name="reco::GenJet::Specific" ClassVersion="11">
-    <version ClassVersion="11" checksum="1280150924"/>
-   <version ClassVersion="10" checksum="3126154868"/>
+  <class name="reco::io_v1::GenJet::Specific" ClassVersion="3">
+   <version ClassVersion="3" checksum="477291414"/>
   </class>
-  <class name="std::vector<reco::GenJet>"/>
-  <class name="edm::RefVector<std::vector<reco::GenJet>,reco::GenJet,edm::refhelper::FindUsingAdvance<std::vector<reco::GenJet>,reco::GenJet> >"/>
-  <class name="edm::Ref<std::vector<reco::GenJet>,reco::GenJet,edm::refhelper::FindUsingAdvance<std::vector<reco::GenJet>,reco::GenJet> >"/>
-  <class name="edm::RefProd<std::vector<reco::GenJet> >"/>
-  <class name="edm::Wrapper<std::vector<reco::GenJet> >"/>
+  <class name="std::vector<reco::io_v1::GenJet>"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::GenJet>,reco::io_v1::GenJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GenJet>,reco::io_v1::GenJet> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::GenJet>,reco::io_v1::GenJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GenJet>,reco::io_v1::GenJet> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::GenJet> >"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::GenJet> >"/>
   <class name="edm::Wrapper<reco::GenJetRefVector>"/>
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::GenJet>,reco::GenJet,edm::refhelper::FindUsingAdvance<std::vector<reco::GenJet>,reco::GenJet> > >" />
-  <class name="reco::JetTrackMatch<std::vector<reco::GenJet> >"/>
-  <class name="edm::FwdRef<std::vector<reco::GenJet>,reco::GenJet,edm::refhelper::FindUsingAdvance<std::vector<reco::GenJet>,reco::GenJet> >"/>
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<reco::io_v1::GenJet>,reco::io_v1::GenJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GenJet>,reco::io_v1::GenJet> > >" />
+  <class name="reco::JetTrackMatch<std::vector<reco::io_v1::GenJet> >"/>
+  <class name="edm::FwdRef<std::vector<reco::io_v1::GenJet>,reco::io_v1::GenJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GenJet>,reco::io_v1::GenJet> >"/>
   <class name="reco::GenJetFwdRefVector"/>
   <class name="edm::Wrapper<reco::GenJetFwdRefVector>"/>
-  <class name="edm::FwdPtr<reco::GenJet>"/>
+  <class name="edm::FwdPtr<reco::io_v1::GenJet>"/>
   <class name="reco::GenJetFwdPtrVector"/>
   <class name="edm::Wrapper<reco::GenJetFwdPtrVector>"/>
 
-  <class name="reco::BasicJet" ClassVersion="13">
-   <version ClassVersion="13" checksum="2774104101"/>
-   <version ClassVersion="12" checksum="3099754843"/>
-   <version ClassVersion="11" checksum="3390039203"/>
-   <version ClassVersion="10" checksum="2049228932"/>
+  <class name="reco::io_v1::BasicJet" ClassVersion="3">
+   <version ClassVersion="3" checksum="526930831"/>
   </class>
-  <class name="std::vector<reco::BasicJet>"/>
-  <class name="edm::RefVector<std::vector<reco::BasicJet>,reco::BasicJet,edm::refhelper::FindUsingAdvance<std::vector<reco::BasicJet>,reco::BasicJet> >"/>
-  <class name="edm::Ref<std::vector<reco::BasicJet>,reco::BasicJet,edm::refhelper::FindUsingAdvance<std::vector<reco::BasicJet>,reco::BasicJet> >"/>
-  <class name="edm::RefProd<std::vector<reco::BasicJet> >"/>
-  <class name="edm::Wrapper<std::vector<reco::BasicJet> >"/>
+  <class name="std::vector<reco::io_v1::BasicJet>"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::BasicJet>,reco::io_v1::BasicJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::BasicJet>,reco::io_v1::BasicJet> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::BasicJet>,reco::io_v1::BasicJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::BasicJet>,reco::io_v1::BasicJet> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::BasicJet> >"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::BasicJet> >"/>
   <class name="edm::Wrapper<reco::BasicJetRefVector>"/>
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::BasicJet>,reco::BasicJet,edm::refhelper::FindUsingAdvance<std::vector<reco::BasicJet>,reco::BasicJet> > >" />
-  <class name="reco::JetTrackMatch<std::vector<reco::BasicJet> >"/>
-  <class name="edm::FwdRef<std::vector<reco::BasicJet>,reco::BasicJet,edm::refhelper::FindUsingAdvance<std::vector<reco::BasicJet>,reco::BasicJet> >"/>
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<reco::io_v1::BasicJet>,reco::io_v1::BasicJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::BasicJet>,reco::io_v1::BasicJet> > >" />
+  <class name="reco::JetTrackMatch<std::vector<reco::io_v1::BasicJet> >"/>
+  <class name="edm::FwdRef<std::vector<reco::io_v1::BasicJet>,reco::io_v1::BasicJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::BasicJet>,reco::io_v1::BasicJet> >"/>
   <class name="reco::BasicJetFwdRefVector"/>
   <class name="edm::Wrapper<reco::BasicJetFwdRefVector>"/>
-  <class name="edm::FwdPtr<reco::BasicJet>"/>
+  <class name="edm::FwdPtr<reco::io_v1::BasicJet>"/>
   <class name="reco::BasicJetFwdPtrVector"/>
   <class name="edm::Wrapper<reco::BasicJetFwdPtrVector>"/>
-  <class name="edm::reftobase::Holder<reco::Jet, reco::BasicJetRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Jet, reco::BasicJetRef>" />
   <class name="edm::reftobase::RefHolder<reco::BasicJetRef>" />
 </lcgdict>

--- a/DataFormats/JetReco/src/classes_def_2.xml
+++ b/DataFormats/JetReco/src/classes_def_2.xml
@@ -12,9 +12,9 @@
    <class name="edm::Wrapper<reco::FFTBasicJetRefVector>" />
    <class name="edm::Wrapper<reco::FFTBasicJetFwdRefVector>" />
    <class name="edm::Wrapper<reco::FFTBasicJetFwdPtrVector>" />
-   <class name="edm::reftobase::Holder<reco::Candidate, reco::FFTBasicJetRef>" />
+   <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::FFTBasicJetRef>" />
    <class name="reco::JetTrackMatch<reco::FFTBasicJetCollection>" />
-   <class name="edm::reftobase::Holder<reco::Jet, reco::FFTBasicJetRef>" />
+   <class name="edm::reftobase::Holder<reco::io_v1::Jet, reco::FFTBasicJetRef>" />
    <class name="edm::reftobase::RefHolder<reco::FFTBasicJetRef>" />
    <class name="edm::Ptr<reco::FFTBasicJet>" />
    <class name="edm::PtrVector<reco::FFTBasicJet>" />
@@ -34,9 +34,9 @@
    <class name="edm::Wrapper<reco::FFTPFJetRefVector>" />
    <class name="edm::Wrapper<reco::FFTPFJetFwdRefVector>" />
    <class name="edm::Wrapper<reco::FFTPFJetFwdPtrVector>" />
-   <class name="edm::reftobase::Holder<reco::Candidate, reco::FFTPFJetRef>" />
+   <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::FFTPFJetRef>" />
    <class name="reco::JetTrackMatch<reco::FFTPFJetCollection>" />
-   <class name="edm::reftobase::Holder<reco::Jet, reco::FFTPFJetRef>" />
+   <class name="edm::reftobase::Holder<reco::io_v1::Jet, reco::FFTPFJetRef>" />
    <class name="edm::reftobase::RefHolder<reco::FFTPFJetRef>" />
    <class name="edm::Ptr<reco::FFTPFJet>" />
    <class name="edm::PtrVector<reco::FFTPFJet>" />
@@ -56,9 +56,9 @@
    <class name="edm::Wrapper<reco::FFTTrackJetRefVector>" />
    <class name="edm::Wrapper<reco::FFTTrackJetFwdRefVector>" />
    <class name="edm::Wrapper<reco::FFTTrackJetFwdPtrVector>" />
-   <class name="edm::reftobase::Holder<reco::Candidate, reco::FFTTrackJetRef>" />
+   <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::FFTTrackJetRef>" />
    <class name="reco::JetTrackMatch<reco::FFTTrackJetCollection>" />
-   <class name="edm::reftobase::Holder<reco::Jet, reco::FFTTrackJetRef>" />
+   <class name="edm::reftobase::Holder<reco::io_v1::Jet, reco::FFTTrackJetRef>" />
    <class name="edm::reftobase::RefHolder<reco::FFTTrackJetRef>" />
    <class name="edm::Ptr<reco::FFTTrackJet>" />
    <class name="edm::PtrVector<reco::FFTTrackJet>" />
@@ -78,9 +78,9 @@
    <class name="edm::Wrapper<reco::FFTJPTJetRefVector>" />
    <class name="edm::Wrapper<reco::FFTJPTJetFwdRefVector>" />
    <class name="edm::Wrapper<reco::FFTJPTJetFwdPtrVector>" />
-   <class name="edm::reftobase::Holder<reco::Candidate, reco::FFTJPTJetRef>" />
+   <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::FFTJPTJetRef>" />
    <class name="reco::JetTrackMatch<reco::FFTJPTJetCollection>" />
-   <class name="edm::reftobase::Holder<reco::Jet, reco::FFTJPTJetRef>" />
+   <class name="edm::reftobase::Holder<reco::io_v1::Jet, reco::FFTJPTJetRef>" />
    <class name="edm::reftobase::RefHolder<reco::FFTJPTJetRef>" />
    <class name="edm::Ptr<reco::FFTJPTJet>" />
    <class name="edm::PtrVector<reco::FFTJPTJet>" />
@@ -97,12 +97,12 @@
    </class>
    <class name="edm::Wrapper<reco::FFTJetPileupSummary>" />
 
-   <class name="edm::AssociationMap<edm::OneToMany<std::vector<reco::PFJet>,std::vector<reco::PFCandidate>,unsigned int> >">
+   <class name="edm::AssociationMap<edm::OneToMany<std::vector<reco::io_v1::PFJet>,std::vector<reco::io_v1::PFCandidate>,unsigned int> >">
      <field name="transientMap_" transient="true"/>
    </class>
-   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToMany<std::vector<reco::PFJet>,std::vector<reco::PFCandidate>,unsigned int> > >"/>
-   <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::PFJet> >,edm::RefProd<std::vector<reco::PFCandidate> > >"/>
-   <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFJet>,reco::PFJet> >,edm::RefVector<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > >"/>
-   <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFJet>,reco::PFJet> >,edm::RefVector<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > >"/>
+   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToMany<std::vector<reco::io_v1::PFJet>,std::vector<reco::io_v1::PFCandidate>,unsigned int> > >"/>
+   <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::io_v1::PFJet> >,edm::RefProd<std::vector<reco::io_v1::PFCandidate> > >"/>
+   <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::io_v1::PFJet>,reco::io_v1::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFJet>,reco::io_v1::PFJet> >,edm::RefVector<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate> > >"/>
+   <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::io_v1::PFJet>,reco::io_v1::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFJet>,reco::io_v1::PFJet> >,edm::RefVector<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate> > > >"/>
 
 </lcgdict>

--- a/DataFormats/JetReco/src/classes_def_3.xml
+++ b/DataFormats/JetReco/src/classes_def_3.xml
@@ -1,26 +1,24 @@
 <lcgdict>
-  <class name="reco::TrackJet" ClassVersion="13">
-   <version ClassVersion="13" checksum="791871228"/>
-   <version ClassVersion="12" checksum="2485634450"/>
-   <version ClassVersion="11" checksum="4018705754"/>
-   <version ClassVersion="10" checksum="3049495721"/>
+  <class name="reco::io_v1::TrackJet" ClassVersion="3">
+   <version ClassVersion="3" checksum="87636228"/>
   </class>
-  <class name="std::vector<reco::TrackJet>"/>
-  <class name="edm::RefVector<std::vector<reco::TrackJet>,reco::TrackJet,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackJet>,reco::TrackJet> >"/>
-  <class name="edm::Ref<std::vector<reco::TrackJet>,reco::TrackJet,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackJet>,reco::TrackJet> >"/>
-  <class name="edm::RefProd<std::vector<reco::TrackJet> >"/>
-  <class name="edm::Wrapper<std::vector<reco::TrackJet> >"/>
+  <class name="std::vector<reco::io_v1::TrackJet>"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::TrackJet>,reco::io_v1::TrackJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::TrackJet>,reco::io_v1::TrackJet> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::TrackJet>,reco::io_v1::TrackJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::TrackJet>,reco::io_v1::TrackJet> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::TrackJet> >"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::TrackJet> >"/>
   <class name="edm::Wrapper<reco::TrackJetRefVector>"/>
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::TrackJet>,reco::TrackJet,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackJet>,reco::TrackJet> > >" />
-  <class name="reco::JetTrackMatch<std::vector<reco::TrackJet> >"/>
-  <class name="edm::FwdRef<std::vector<reco::TrackJet>,reco::TrackJet,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackJet>,reco::TrackJet> >"/>
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<reco::io_v1::TrackJet>,reco::io_v1::TrackJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::TrackJet>,reco::io_v1::TrackJet> > >" />
+  <class name="reco::JetTrackMatch<std::vector<reco::io_v1::TrackJet> >"/>
+  <class name="edm::FwdRef<std::vector<reco::io_v1::TrackJet>,reco::io_v1::TrackJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::TrackJet>,reco::io_v1::TrackJet> >"/>
   <class name="reco::TrackJetFwdRefVector"/>
   <class name="edm::Wrapper<reco::TrackJetFwdRefVector>"/>
-  <class name="edm::FwdPtr<reco::TrackJet>"/>
+  <class name="edm::FwdPtr<reco::io_v1::TrackJet>"/>
   <class name="reco::TrackJetFwdPtrVector"/>
   <class name="edm::Wrapper<reco::TrackJetFwdPtrVector>"/>
 
-  <class name="reco::PFClusterJet" ClassVersion="13">
+  <class name="reco::PFClusterJet" ClassVersion="14">
+   <version ClassVersion="14" checksum="2428041643"/>
    <version ClassVersion="13" checksum="2563954199"/>
    <version ClassVersion="12" checksum="2889604941"/>
    <version ClassVersion="11" checksum="3179889301"/>
@@ -32,7 +30,7 @@
   <class name="edm::RefProd<std::vector<reco::PFClusterJet> >"/>
   <class name="edm::Wrapper<std::vector<reco::PFClusterJet> >"/>
   <class name="edm::Wrapper<reco::PFClusterJetRefVector>"/>
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::PFClusterJet>,reco::PFClusterJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFClusterJet>,reco::PFClusterJet> > >" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<reco::PFClusterJet>,reco::PFClusterJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFClusterJet>,reco::PFClusterJet> > >" />
   <class name="reco::JetTrackMatch<std::vector<reco::PFClusterJet> >"/>
   <class name="edm::FwdRef<std::vector<reco::PFClusterJet>,reco::PFClusterJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFClusterJet>,reco::PFClusterJet> >"/>
   <class name="reco::PFClusterJetFwdRefVector"/>
@@ -46,13 +44,13 @@
   <class name="edm::ValueMap<StoredPileupJetIdentifier>"/>
   <class name="edm::Wrapper<edm::ValueMap<StoredPileupJetIdentifier> >"/>
   
-  <class name="edm::AssociationVector<edm::RefToBaseProd<reco::Jet>,std::vector<edm::RefVector<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> > >,edm::RefToBase<reco::Jet>,unsigned int,edm::helper::AssociationIdenticalKeyReference>" >
+  <class name="edm::AssociationVector<edm::RefToBaseProd<reco::io_v1::Jet>,std::vector<edm::RefVector<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> > >,edm::RefToBase<reco::io_v1::Jet>,unsigned int,edm::helper::AssociationIdenticalKeyReference>" >
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="edm::AssociationVector<edm::RefToBaseProd<reco::Jet>,std::vector<float>,edm::RefToBase<reco::Jet>,unsigned int,edm::helper::AssociationIdenticalKeyReference>" >
+  <class name="edm::AssociationVector<edm::RefToBaseProd<reco::io_v1::Jet>,std::vector<float>,edm::RefToBase<reco::io_v1::Jet>,unsigned int,edm::helper::AssociationIdenticalKeyReference>" >
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="edm::AssociationVector<edm::RefToBaseProd<reco::Jet>,std::vector<reco::JetExtendedAssociation::JetExtendedData>,edm::RefToBase<reco::Jet>,unsigned int,edm::helper::AssociationIdenticalKeyReference>">
+  <class name="edm::AssociationVector<edm::RefToBaseProd<reco::io_v1::Jet>,std::vector<reco::JetExtendedAssociation::io_v1::JetExtendedData>,edm::RefToBase<reco::io_v1::Jet>,unsigned int,edm::helper::AssociationIdenticalKeyReference>">
     <field name="transientVector_" transient="true"/>
   </class>
 
@@ -85,8 +83,8 @@
   <function name="reco::JetTracksAssociation::hasJet"/>
 
   <class name="edm::Wrapper<reco::JetExtendedAssociation::Container>" />
-  <class name="reco::JetExtendedAssociation::JetExtendedData" ClassVersion="10">
-   <version ClassVersion="10" checksum="2863467760"/>
+  <class name="reco::JetExtendedAssociation::io_v1::JetExtendedData" ClassVersion="3">
+   <version ClassVersion="3" checksum="2804756308"/>
   </class>
   <class name="reco::JetExtendedAssociation::Values"/>
   <class name="reco::JetExtendedAssociation::value_type"/>
@@ -103,33 +101,33 @@
   <function name="reco::JetExtendedAssociation::allJets"/>
   <function name="reco::JetExtendedAssociation::hasJet"/>
   
-  <class name="edm::RefToBaseProd<reco::Jet>" >
+  <class name="edm::RefToBaseProd<reco::io_v1::Jet>" >
      <!-- <field name="view_" transient="true" /> -->
   </class>
-  <class name="edm::RefToBase<reco::Jet>" rntupleStreamerMode="true"/>
-  <class name="edm::reftobase::BaseHolder<reco::Jet>" />
-  <class name="edm::reftobase::IndirectHolder<reco::Jet>" />
-  <class name="edm::reftobase::IndirectVectorHolder<reco::Jet>" />
-  <class name="edm::reftobase::Holder<reco::Candidate,edm::RefToBase<reco::Jet> >"/>
-  <class name="edm::RefToBaseVector<reco::Jet>"/>
-  <class name="edm::Wrapper<edm::RefToBaseVector<reco::Jet> >"/>
-  <class name="edm::reftobase::BaseVectorHolder<reco::Jet>"/>
-  <class name="edm::reftobase::Holder<reco::Jet, reco::CaloJetRef>" />
+  <class name="edm::RefToBase<reco::io_v1::Jet>" rntupleStreamerMode="true"/>
+  <class name="edm::reftobase::BaseHolder<reco::io_v1::Jet>" />
+  <class name="edm::reftobase::IndirectHolder<reco::io_v1::Jet>" />
+  <class name="edm::reftobase::IndirectVectorHolder<reco::io_v1::Jet>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate,edm::RefToBase<reco::io_v1::Jet> >"/>
+  <class name="edm::RefToBaseVector<reco::io_v1::Jet>"/>
+  <class name="edm::Wrapper<edm::RefToBaseVector<reco::io_v1::Jet> >"/>
+  <class name="edm::reftobase::BaseVectorHolder<reco::io_v1::Jet>"/>
+  <class name="edm::reftobase::Holder<reco::io_v1::Jet, reco::CaloJetRef>" />
   <class name="edm::reftobase::RefHolder<reco::CaloJetRef>" />
-  <class name="edm::reftobase::Holder<reco::Jet, reco::GenJetRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Jet, reco::GenJetRef>" />
   <class name="edm::reftobase::RefHolder<reco::GenJetRef>" />
-  <class name="edm::reftobase::Holder<reco::Jet, reco::PFJetRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Jet, reco::PFJetRef>" />
   <class name="edm::reftobase::RefHolder<reco::PFJetRef>" />
-  <class name="edm::reftobase::Holder<reco::Jet, reco::TrackJetRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Jet, reco::TrackJetRef>" />
   <class name="edm::reftobase::RefHolder<reco::TrackJetRef>" />
-  <class name="edm::reftobase::Holder<reco::Jet, reco::PFClusterJetRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Jet, reco::PFClusterJetRef>" />
   <class name="edm::reftobase::RefHolder<reco::PFClusterJetRef>" />
-  <class name="edm::reftobase::Holder<reco::Jet, reco::JPTJetRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Jet, reco::JPTJetRef>" />
   <class name="edm::reftobase::RefHolder<reco::JPTJetRef>" />
 
-  <class name="edm::AssociationMap<edm::OneToOne<edm::View<reco::Jet>,edm::View<reco::Jet>,unsigned int> >">
+  <class name="edm::AssociationMap<edm::OneToOne<edm::View<reco::io_v1::Jet>,edm::View<reco::io_v1::Jet>,unsigned int> >">
       <field name="transientMap_" transient="true" />
   </class>
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<edm::View<reco::Jet>,edm::View<reco::Jet>,unsigned int> > >"/>
-  <class name="edm::helpers::KeyVal<edm::RefToBaseProd<reco::Jet>,edm::RefToBaseProd<reco::Jet> >"/>
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<edm::View<reco::io_v1::Jet>,edm::View<reco::io_v1::Jet>,unsigned int> > >"/>
+  <class name="edm::helpers::KeyVal<edm::RefToBaseProd<reco::io_v1::Jet>,edm::RefToBaseProd<reco::io_v1::Jet> >"/>
 </lcgdict>

--- a/DataFormats/JetReco/src/classes_def_4.xml
+++ b/DataFormats/JetReco/src/classes_def_4.xml
@@ -1,14 +1,14 @@
 <lcgdict>
-  <class name="reco::JetID"  ClassVersion="10">
-   <version ClassVersion="10" checksum="3012457232"/>
+  <class name="reco::io_v1::JetID"  ClassVersion="3">
+   <version ClassVersion="3" checksum="1642836378"/>
   </class>
-  <class name="std::vector<reco::JetID>" />
-  <class name="edm::RefVector<std::vector<reco::JetID>,reco::JetID,edm::refhelper::FindUsingAdvance<std::vector<reco::JetID>,reco::JetID> >"/>
-  <class name="edm::Ref<std::vector<reco::JetID>,reco::JetID,edm::refhelper::FindUsingAdvance<std::vector<reco::JetID>,reco::JetID> >"/>
-  <class name="edm::RefProd<std::vector<reco::JetID> >"/>
-  <class name="edm::Wrapper<std::vector<reco::JetID> >"/>
-  <class name="edm::ValueMap<reco::JetID>" />
-  <class name="edm::Wrapper< edm::ValueMap<reco::JetID> >" />
+  <class name="std::vector<reco::io_v1::JetID>" />
+  <class name="edm::RefVector<std::vector<reco::io_v1::JetID>,reco::io_v1::JetID,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::JetID>,reco::io_v1::JetID> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::JetID>,reco::io_v1::JetID,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::JetID>,reco::io_v1::JetID> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::JetID> >"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::JetID> >"/>
+  <class name="edm::ValueMap<reco::io_v1::JetID>" />
+  <class name="edm::Wrapper< edm::ValueMap<reco::io_v1::JetID> >" />
   
   <class name="reco::CastorJetID"  ClassVersion="10">
    <version ClassVersion="10" checksum="3017993717"/>
@@ -21,34 +21,32 @@
   <class name="edm::ValueMap<reco::CastorJetID>" />
   <class name="edm::Wrapper< edm::ValueMap<reco::CastorJetID> >" />
 
-  <class name="edm::Ptr<reco::Jet>" />
-  <class name="edm::reftobase::RefHolder<edm::Ptr<reco::Jet> >" />
-  <class name="edm::PtrVector<reco::Jet>" />
+  <class name="edm::Ptr<reco::io_v1::Jet>" />
+  <class name="edm::reftobase::RefHolder<edm::Ptr<reco::io_v1::Jet> >" />
+  <class name="edm::PtrVector<reco::io_v1::Jet>" />
 
-  <class name="edm::Ptr<reco::CaloJet>" />
-  <class name="edm::PtrVector<reco::CaloJet>" />
-  <class name="edm::reftobase::RefHolder<edm::Ptr<reco::CaloJet> >" />
+  <class name="edm::Ptr<reco::io_v1::CaloJet>" />
+  <class name="edm::PtrVector<reco::io_v1::CaloJet>" />
+  <class name="edm::reftobase::RefHolder<edm::Ptr<reco::io_v1::CaloJet> >" />
 
-  <class name="edm::Ptr<reco::PFJet>" />
-  <class name="edm::PtrVector<reco::PFJet>" />
+  <class name="edm::Ptr<reco::io_v1::PFJet>" />
+  <class name="edm::PtrVector<reco::io_v1::PFJet>" />
 
   <class name="edm::Ptr<reco::BasicJet>" />
   <class name="edm::PtrVector<reco::BasicJet>" />
 
-  <class name="edm::Ptr<reco::GenJet>" />
-  <class name="edm::PtrVector<reco::GenJet>" />
+  <class name="edm::Ptr<reco::io_v1::GenJet>" />
+  <class name="edm::PtrVector<reco::io_v1::GenJet>" />
 
   <class name="edm::Ptr<reco::TrackJet>" />
   <class name="edm::PtrVector<reco::TrackJet>" />
 
   <class name="edm::Ptr<reco::PFClusterJet>" />
   <class name="edm::PtrVector<reco::PFClusterJet>" />
-  <class name="edm::Ptr<reco::PFCluster>" />
-  <class name="std::vector<edm::Ptr<reco::PFCluster> >" />
 
 
-  <class name="edm::Ptr<reco::JetID>" />
-  <class name="edm::PtrVector<reco::JetID>" />
+  <class name="edm::Ptr<reco::io_v1::JetID>" />
+  <class name="edm::PtrVector<reco::io_v1::JetID>" />
   <class name="edm::Ptr<reco::CastorJetID>" />
   <class name="edm::PtrVector<reco::CastorJetID>" />
   
@@ -58,22 +56,22 @@
   <class name="edm::Association<reco::PFJetCollection>" />
   <class name="edm::Wrapper<edm::Association<reco::PFJetCollection> >" />
 
-  <class name="std::vector<reco::CaloJet::Specific>" />
-  <class name="std::vector<reco::PFJet::Specific>"   />
-  <class name="std::vector<reco::JPTJet::Specific>" />
+  <class name="std::vector<reco::io_v1::CaloJet::Specific>" />
+  <class name="std::vector<reco::io_v1::PFJet::Specific>"   />
+  <class name="std::vector<reco::io_v1::JPTJet::Specific>" />
 
-  <class name="reco::TrackExtrapolation"  ClassVersion="3">
-   <version ClassVersion="3" checksum="1386552340"/>
+  <class name="reco::io_v1::TrackExtrapolation"  ClassVersion="3">
+   <version ClassVersion="3" checksum="3399449618"/>
   </class>
-  <class name="std::vector<reco::TrackExtrapolation>" />
-  <class name="edm::Ref<std::vector<reco::TrackExtrapolation>,reco::TrackExtrapolation,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtrapolation>,reco::TrackExtrapolation>  >" />
-  <class name="edm::RefVector<std::vector<reco::TrackExtrapolation>,reco::TrackExtrapolation,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtrapolation>,reco::TrackExtrapolation>   >" />
-  <class name="edm::RefProd<std::vector<reco::TrackExtrapolation> >" />
-  <class name="edm::Wrapper<reco::TrackExtrapolation>" />
-  <class name="edm::Wrapper<std::vector<reco::TrackExtrapolation> >" />
-  <class name="edm::Wrapper<edm::Ref<std::vector<reco::TrackExtrapolation>,reco::TrackExtrapolation,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtrapolation>,reco::TrackExtrapolation>   > >" />
-  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::TrackExtrapolation>,reco::TrackExtrapolation,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtrapolation>,reco::TrackExtrapolation> > >" />
-  <class name="edm::Wrapper<edm::RefProd<std::vector<reco::TrackExtrapolation> > >" />
+  <class name="std::vector<reco::io_v1::TrackExtrapolation>" />
+  <class name="edm::Ref<std::vector<reco::io_v1::TrackExtrapolation>,reco::io_v1::TrackExtrapolation,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::TrackExtrapolation>,reco::io_v1::TrackExtrapolation>  >" />
+  <class name="edm::RefVector<std::vector<reco::io_v1::TrackExtrapolation>,reco::io_v1::TrackExtrapolation,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::TrackExtrapolation>,reco::io_v1::TrackExtrapolation>   >" />
+  <class name="edm::RefProd<std::vector<reco::io_v1::TrackExtrapolation> >" />
+  <class name="edm::Wrapper<reco::io_v1::TrackExtrapolation>" />
+  <class name="edm::Wrapper<std::vector<reco::io_v1::TrackExtrapolation> >" />
+  <class name="edm::Wrapper<edm::Ref<std::vector<reco::io_v1::TrackExtrapolation>,reco::io_v1::TrackExtrapolation,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::TrackExtrapolation>,reco::io_v1::TrackExtrapolation>   > >" />
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::io_v1::TrackExtrapolation>,reco::io_v1::TrackExtrapolation,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::TrackExtrapolation>,reco::io_v1::TrackExtrapolation> > >" />
+  <class name="edm::Wrapper<edm::RefProd<std::vector<reco::io_v1::TrackExtrapolation> > >" />
   
 
 
@@ -90,7 +88,8 @@
    <class name="edm::Wrapper<reco::PattRecoTree<float,reco::PattRecoPeak<float> > >" />
    <class name="edm::Wrapper<reco::PattRecoTree<double,reco::PattRecoPeak<double> > >" />
 
-   <class name="reco::FFTJetProducerSummary"  ClassVersion="10">
+   <class name="reco::FFTJetProducerSummary"  ClassVersion="11">
+    <version ClassVersion="11" checksum="445367308"/>
     <version ClassVersion="10" checksum="603545432"/>
    </class>
    <class name="edm::Wrapper<reco::FFTJetProducerSummary>" />
@@ -108,9 +107,9 @@
    <class name="edm::Wrapper<reco::FFTGenJetRefVector>" />
    <class name="edm::Wrapper<reco::FFTGenJetFwdRefVector>" />
    <class name="edm::Wrapper<reco::FFTGenJetFwdPtrVector>" />
-   <class name="edm::reftobase::Holder<reco::Candidate, reco::FFTGenJetRef>" />
+   <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::FFTGenJetRef>" />
    <class name="reco::JetTrackMatch<reco::FFTGenJetCollection>" />
-   <class name="edm::reftobase::Holder<reco::Jet, reco::FFTGenJetRef>" />
+   <class name="edm::reftobase::Holder<reco::io_v1::Jet, reco::FFTGenJetRef>" />
    <class name="edm::reftobase::RefHolder<reco::FFTGenJetRef>" />
    <class name="edm::Ptr<reco::FFTGenJet>" />
    <class name="edm::PtrVector<reco::FFTGenJet>" />
@@ -130,9 +129,9 @@
    <class name="edm::Wrapper<reco::FFTCaloJetRefVector>" />
    <class name="edm::Wrapper<reco::FFTCaloJetFwdRefVector>" />
    <class name="edm::Wrapper<reco::FFTCaloJetFwdPtrVector>" />
-   <class name="edm::reftobase::Holder<reco::Candidate, reco::FFTCaloJetRef>" />
+   <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::FFTCaloJetRef>" />
    <class name="reco::JetTrackMatch<reco::FFTCaloJetCollection>" />
-   <class name="edm::reftobase::Holder<reco::Jet, reco::FFTCaloJetRef>" />
+   <class name="edm::reftobase::Holder<reco::io_v1::Jet, reco::FFTCaloJetRef>" />
    <class name="edm::reftobase::RefHolder<reco::FFTCaloJetRef>" />
    <class name="edm::Ptr<reco::FFTCaloJet>" />
    <class name="edm::PtrVector<reco::FFTCaloJet>" />

--- a/DataFormats/JetReco/src/classes_def_4.xml
+++ b/DataFormats/JetReco/src/classes_def_4.xml
@@ -88,9 +88,8 @@
    <class name="edm::Wrapper<reco::PattRecoTree<float,reco::PattRecoPeak<float> > >" />
    <class name="edm::Wrapper<reco::PattRecoTree<double,reco::PattRecoPeak<double> > >" />
 
-   <class name="reco::FFTJetProducerSummary"  ClassVersion="11">
-    <version ClassVersion="11" checksum="445367308"/>
-    <version ClassVersion="10" checksum="603545432"/>
+   <class name="reco::FFTJetProducerSummary"  ClassVersion="3">
+    <version ClassVersion="3" checksum="445367308"/>
    </class>
    <class name="edm::Wrapper<reco::FFTJetProducerSummary>" />
 

--- a/DataFormats/L1TCalorimeterPhase2/src/classes_def.xml
+++ b/DataFormats/L1TCalorimeterPhase2/src/classes_def.xml
@@ -5,7 +5,7 @@
 <lcgdict>
 
   <class name="l1tp2::CaloCrystalCluster"  ClassVersion="3">
-         <version ClassVersion="3" checksum="811222139"/>
+         <version ClassVersion="3" checksum="3612859615"/>
   </class>
   <class name="std::vector<l1tp2::CaloCrystalCluster>" />
   <class name="l1tp2::CaloCrystalClusterCollection" />
@@ -13,14 +13,14 @@
   <class name="edm::Ref<l1tp2::CaloCrystalClusterCollection>" />
 
   <class name="l1tp2::CaloJet"  ClassVersion="3">
-         <version ClassVersion="3" checksum="2520028496"/>
+         <version ClassVersion="3" checksum="1771236956"/>
   </class>
   <class name="std::vector<l1tp2::CaloJet>" />
   <class name="l1tp2::CaloJetsCollection" />
   <class name="edm::Wrapper<l1tp2::CaloJetsCollection>" />
 
   <class name="l1tp2::CaloPFCluster"  ClassVersion="3">
-         <version ClassVersion="3" checksum="4176166177"/>
+         <version ClassVersion="3" checksum="2510893573"/>
   </class>
   <class name="std::vector<l1tp2::CaloPFCluster>" />
   <class name="l1tp2::CaloPFClusterCollection" />
@@ -35,7 +35,7 @@
   <class name="edm::Wrapper<std::vector<std::vector<l1tp2::GCTHadDigiCluster> > >" /> 
 
   <class name="l1tp2::CaloTower"  ClassVersion="3">
-         <version ClassVersion="3" checksum="2608605419"/>
+         <version ClassVersion="3" checksum="351125807"/>
   </class>
   <class name="std::vector<l1tp2::CaloTower>" />
   <class name="l1tp2::CaloTowerCollection" />
@@ -71,7 +71,7 @@
   <class name="edm::Wrapper<std::vector<std::vector<l1tp2::GCTEmDigiCluster> > >" />  
 
   <class name="l1tp2::Phase2L1CaloJet"  ClassVersion="3">
-         <version ClassVersion="3" checksum="289384850"/>
+         <version ClassVersion="3" checksum="3359793942"/>
   </class>
   <class name="std::vector<l1tp2::Phase2L1CaloJet>" />
   <class name="l1tp2::Phase2L1CaloJetCollection" />

--- a/DataFormats/L1TCorrelator/src/classes_def.xml
+++ b/DataFormats/L1TCorrelator/src/classes_def.xml
@@ -1,20 +1,15 @@
 
 <lcgdict>
 
-  <class name="l1t::TkEtMiss" ClassVersion="5">
-   <version ClassVersion="5" checksum="1279701762"/>
-   <version ClassVersion="4" checksum="2694422826"/>
-   <version ClassVersion="3" checksum="77762919"/>
+  <class name="l1t::TkEtMiss" ClassVersion="3">
+   <version ClassVersion="3" checksum="1845575470"/>
   </class>
   <class name="std::vector<l1t::TkEtMiss>"/>
   <class name="edm::Wrapper<l1t::TkEtMiss>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkEtMiss> >"/>
 
-  <class name="l1t::TkEm" ClassVersion="6">
-   <version ClassVersion="6" checksum="3709420594"/>
-   <version ClassVersion="5" checksum="2211175625"/>
-   <version ClassVersion="4" checksum="1043577432"/>
-   <version ClassVersion="3" checksum="2161257944"/>
+  <class name="l1t::TkEm" ClassVersion="3">
+   <version ClassVersion="3" checksum="153037750"/>
   </class>
   <class name="std::vector<l1t::TkEm>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkEm> >"/>
@@ -24,40 +19,29 @@
   <class name="l1t::RegionalOutput<l1t::TkEmCollection>" />
   <class name="edm::Wrapper<l1t::RegionalOutput<l1t::TkEmCollection>>" />
 
-  <ioread sourceClass="l1t::TkEm" targetClass="l1t::TkEm" version="[-5]" target="" source="edm::Ref<l1t::EGammaBxCollection> egRef_" include="DataFormats/Common/interface/RefToPtr.h">
-  <![CDATA[
-   newObj->setEgCaloPtr(edm::refToPtr(onfile.egRef_));
-  ]]>
-  </ioread>
-
   <class name="l1t::TkEGTau" ClassVersion="3">
-   <version ClassVersion="3" checksum="3759113668"/>
+   <version ClassVersion="3" checksum="2842566824"/>
   </class>
   <class name="std::vector<l1t::TkEGTau>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkEGTau> >"/>
   <class name="edm::Ref<std::vector<l1t::TkEGTau>,l1t::TkEGTau,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkEGTau>,l1t::TkEGTau> >"/>
 
   <class name="l1t::L1TrkTau" ClassVersion="3">
-   <version ClassVersion="3" checksum="3769006094"/>
+   <version ClassVersion="3" checksum="622855378"/>
   </class>
   <class name="std::vector<l1t::L1TrkTau>"/>
   <class name="edm::Wrapper<std::vector<l1t::L1TrkTau> >"/>
   <class name="edm::Ref<std::vector<l1t::L1TrkTau>,l1t::L1TrkTau,edm::refhelper::FindUsingAdvance<std::vector<l1t::L1TrkTau>,l1t::L1TrkTau> >"/>
 
   <class name="l1t::L1CaloTkTau" ClassVersion="3">
-   <version ClassVersion="3" checksum="1899265791"/>
+   <version ClassVersion="3" checksum="1330286603"/>
   </class>
   <class name="std::vector<l1t::L1CaloTkTau>"/>
   <class name="edm::Wrapper<std::vector<l1t::L1CaloTkTau> >"/>
   <class name="edm::Ref<std::vector<l1t::L1CaloTkTau>,l1t::L1CaloTkTau,edm::refhelper::FindUsingAdvance<std::vector<l1t::L1CaloTkTau>,l1t::L1CaloTkTau> >"/>
 
-  <class name="l1t::TkElectron" ClassVersion="8">
-   <version ClassVersion="8" checksum="3565138561"/>
-   <version ClassVersion="7" checksum="3055953431"/>
-   <version ClassVersion="6" checksum="3899336964"/>
-   <version ClassVersion="5" checksum="965807884"/>
-   <version ClassVersion="4" checksum="3922083203"/>
-   <version ClassVersion="3" checksum="3970647299"/>
+  <class name="l1t::TkElectron" ClassVersion="3">
+   <version ClassVersion="3" checksum="2125012453"/>
   </class>
   <class name="std::vector<l1t::TkElectron>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkElectron> >"/>
@@ -67,9 +51,8 @@
   <class name="l1t::RegionalOutput<l1t::TkElectronCollection>" />
   <class name="edm::Wrapper<l1t::RegionalOutput<l1t::TkElectronCollection>>" />
 
-  <class name="l1t::TkJet" ClassVersion="4">
-   <version ClassVersion="4" checksum="1528601883"/>
-   <version ClassVersion="3" checksum="3336007399"/>
+  <class name="l1t::TkJet" ClassVersion="3">
+   <version ClassVersion="3" checksum="1844772127"/>
   </class>
   <class name="std::vector<l1t::TkJet>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkJet> >"/>
@@ -77,7 +60,7 @@
   <class name="edm::RefProd< std::vector<l1t::TkJet> >"/>
 
   <class name="l1t::TkTriplet" ClassVersion="3">
-    <version ClassVersion="3" checksum="3181606259"/>
+    <version ClassVersion="3" checksum="584260087"/>
   </class>
   <class name="std::vector<l1t::TkTriplet>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkTriplet> >"/>
@@ -85,17 +68,15 @@
   <class name="edm::RefProd< std::vector<l1t::TkTriplet> >"/>
 
 
-  <class name="l1t::TkHTMiss" ClassVersion="4">
-    <version ClassVersion="4" checksum="4116208712"/>
-    <version ClassVersion="3" checksum="1471145680"/>
+  <class name="l1t::TkHTMiss" ClassVersion="3">
+    <version ClassVersion="3" checksum="1186463572"/>
   </class>
   <class name="std::vector<l1t::TkHTMiss>"/>
   <class name="edm::Wrapper<l1t::TkHTMiss>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkHTMiss> >"/>
 
-  <class name="l1t::TkMuon" ClassVersion="4">
-   <version ClassVersion="4" checksum="2325700664"/>
-   <version ClassVersion="3" checksum="4118337663"/>
+  <class name="l1t::TkMuon" ClassVersion="3">
+   <version ClassVersion="3" checksum="3695336860"/>
 
   </class>
   <class name="std::vector<l1t::TkMuon>"/>
@@ -105,28 +86,28 @@
   <class name="edm::Ref<vector<l1t::EMTFTrack>,l1t::EMTFTrack,edm::refhelper::FindUsingAdvance<vector<l1t::EMTFTrack>,l1t::EMTFTrack> >" />
 
   <class name="l1t::TkGlbMuon" ClassVersion="3">
-   <version ClassVersion="3"  checksum="2811548892"/>
+   <version ClassVersion="3"  checksum="3979821352"/>
   </class>
   <class name="std::vector<l1t::TkGlbMuon>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkGlbMuon> >"/>
   <class name="edm::Ref<std::vector<l1t::TkGlbMuon>,l1t::TkGlbMuon,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkGlbMuon>,l1t::TkGlbMuon> >"/>
 
   <class name="l1t::TkTau" ClassVersion="3">
-   <version ClassVersion="3" checksum="701136464"/>
+   <version ClassVersion="3" checksum="2194039764"/>
   </class>
   <class name="std::vector<l1t::TkTau>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkTau> >"/>
   <class name="edm::Ref<std::vector<l1t::TkTau>,l1t::TkTau,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkTau>,l1t::TkTau> >"/>
 
   <class name="l1t::TkPhiCandidate" ClassVersion="3">
-   <version ClassVersion="3" checksum="1398617427"/>
+   <version ClassVersion="3" checksum="2112391799"/>
   </class>
   <class name="std::vector<l1t::TkPhiCandidate>" />
   <class name="edm::Wrapper<std::vector<l1t::TkPhiCandidate>>" />
   <class name="edm::Ref<std::vector<l1t::TkPhiCandidate>, l1t::TkPhiCandidate, edm::refhelper::FindUsingAdvance<std::vector<l1t::TkPhiCandidate>, l1t::TkPhiCandidate>>" />
 
   <class name="l1t::TkBsCandidate" ClassVersion="3">
-   <version ClassVersion="3" checksum="3257789432"/>
+   <version ClassVersion="3" checksum="2539550588"/>
   </class>
   <class name="std::vector<l1t::TkBsCandidate>" />
   <class name="edm::Wrapper<std::vector<l1t::TkBsCandidate>>" />

--- a/DataFormats/L1THGCal/src/classes_def.xml
+++ b/DataFormats/L1THGCal/src/classes_def.xml
@@ -30,17 +30,8 @@
 
   <class name="l1t::HGCalClusterT<l1t::HGCalTriggerCell>" />
   <class name="l1t::HGCalClusterT<l1t::HGCalTriggerSums>" />
-  <class name="l1t::HGCalCluster" ClassVersion="19">
-   <version ClassVersion="19" checksum="1681737349"/>
-   <version ClassVersion="18" checksum="3346067797"/>
-   <version ClassVersion="17" checksum="2841504063"/>
-   <version ClassVersion="16" checksum="1572558185"/>
-  <version ClassVersion="15" checksum="2522149132"/>
-  <version ClassVersion="14" checksum="3289642235"/>
-  <version ClassVersion="13" checksum="3397489079"/>
-  <version ClassVersion="12" checksum="623703096"/>
-  <version ClassVersion="11" checksum="354623225"/>
-  <version ClassVersion="10" checksum="607544984"/>
+  <class name="l1t::HGCalCluster" ClassVersion="3">
+   <version ClassVersion="3" checksum="2326865641"/>
   </class>
   <class name="std::vector<l1t::HGCalCluster>" />
   <class name="l1t::HGCalClusterBxCollection"/>
@@ -48,37 +39,22 @@
 
   <class name="l1t::HGCalClusterT<l1t::HGCalCluster>" />
 
-  <class name="l1t::HGCalMulticluster" ClassVersion="20">
-   <version ClassVersion="20" checksum="266999929"/>
-   <version ClassVersion="19" checksum="2270821353"/>
-   <version ClassVersion="18" checksum="3914904215"/>
-   <version ClassVersion="17" checksum="460658789"/>
-  <version ClassVersion="16" checksum="1276395758"/>
-  <version ClassVersion="15" checksum="777879934"/>
-  <version ClassVersion="14" checksum="2315302819"/>
-  <version ClassVersion="13" checksum="816077951"/>
-  <version ClassVersion="12" checksum="4221677522"/>
-  <version ClassVersion="11" checksum="1508179045"/>
-  <version ClassVersion="10" checksum="1878482802"/>
+  <class name="l1t::HGCalMulticluster" ClassVersion="3">
+   <version ClassVersion="3" checksum="4257118597"/>
   </class>
-  <ioread sourceClass="l1t::HGCalMulticluster"  targetClass="l1t::HGCalMulticluster" version="[-15]" target="hOverE_" source="" embed="false"> <![CDATA[ hOverE_ = -99; ]]> </ioread>
-  <ioread sourceClass="l1t::HGCalMulticluster"  targetClass="l1t::HGCalMulticluster" version="[-15]" target="hOverEValid_" source="" embed="false"> <![CDATA[ hOverEValid_ = false; ]]> </ioread>
   <class name="std::vector<l1t::HGCalMulticluster>" />
   <class name="l1t::HGCalMulticlusterBxCollection"/>
   <class name="edm::Wrapper<l1t::HGCalMulticlusterBxCollection>"/>
 
-  <class name="l1t::HGCalTriggerCell" ClassVersion="12">
-   <version ClassVersion="12" checksum="3538848072"/>
-   <version ClassVersion="11" checksum="646735227"/>
-    <version ClassVersion="10" checksum="1275348814"/>
+  <class name="l1t::HGCalTriggerCell" ClassVersion="3">
+   <version ClassVersion="3" checksum="4122001108"/>
   </class>
   <class name="std::vector<l1t::HGCalTriggerCell>" />
   <class name="l1t::HGCalTriggerCellBxCollection"/>
   <class name="edm::Wrapper<l1t::HGCalTriggerCellBxCollection>"/>
 
-  <class name="l1t::HGCalTriggerSums" ClassVersion="12">
-   <version ClassVersion="12" checksum="1802885417"/>
-    <version ClassVersion="11" checksum="4058188392"/>
+  <class name="l1t::HGCalTriggerSums" ClassVersion="3">
+   <version ClassVersion="3" checksum="3641159285"/>
   </class>
   <class name="std::vector<l1t::HGCalTriggerSums>" />
   <class name="l1t::HGCalTriggerSumsBxCollection"/>

--- a/DataFormats/L1TMuonPhase2/src/classes_def.xml
+++ b/DataFormats/L1TMuonPhase2/src/classes_def.xml
@@ -7,26 +7,23 @@
     <class name="edm::Wrapper<std::vector<l1t::MuonStub > >"/>
     <class name="edm::Ref<l1t::MuonStubCollection>" splitLevel="0"/>
 
-     <class name="l1t::TrackerMuon" ClassVersion="5">
-       <version ClassVersion="5" checksum="3871400620"/>
-       <version ClassVersion="4" checksum="3437073036"/>
-       <version ClassVersion="3" checksum="2397458791"/>
+     <class name="l1t::TrackerMuon" ClassVersion="3">
+       <version ClassVersion="3" checksum="872327352"/>
      </class>
      <class name="std::vector<l1t::TrackerMuon>"/>
      <class name="edm::Wrapper<std::vector<l1t::TrackerMuon > >"/>
      <class name="edm::Ref<l1t::TrackerMuonCollection>" splitLevel="0"/>
      <class name="std::vector<edm::Ref<l1t::TrackerMuonCollection> >"/>
      
-     <class name="l1t::SAMuon" ClassVersion="4">
-       <version ClassVersion="4" checksum="837992405"/>
-       <version ClassVersion="3" checksum="3294978731"/>
+     <class name="l1t::SAMuon" ClassVersion="3">
+       <version ClassVersion="3" checksum="3053745761"/>
      </class>
      <class name="std::vector<l1t::SAMuon>"/>
      <class name="edm::Wrapper<std::vector<l1t::SAMuon > >"/>
      <class name="edm::Ref<l1t::SAMuonCollection>" splitLevel="0"/>
 
    <class name="l1t::KMTFTrack" ClassVersion="3">
-    <version ClassVersion="3" checksum="502486181"/>
+    <version ClassVersion="3" checksum="2839714417"/>
    </class>
    <class name="std::vector<l1t::KMTFTrack>"/>
    <class name="l1t::KMTFTrackCollection"/>

--- a/DataFormats/L1TParticleFlow/src/classes_def.xml
+++ b/DataFormats/L1TParticleFlow/src/classes_def.xml
@@ -1,11 +1,7 @@
 <lcgdict>
                       
-  <class name="l1t::PFCluster" ClassVersion="7">
-   <version ClassVersion="7" checksum="3070928172"/>
-   <version ClassVersion="6" checksum="439598246"/>
-   <version ClassVersion="5" checksum="3527085893"/>
-   <version ClassVersion="4" checksum="3917005656"/>
-        <version ClassVersion="3" checksum="1668592434"/>
+  <class name="l1t::PFCluster" ClassVersion="3">
+   <version ClassVersion="3" checksum="335262928"/>
   </class> 
   <class name="l1t::PFClusterCollection"/>
   <class name="edm::Wrapper<l1t::PFClusterCollection>" />
@@ -13,9 +9,8 @@
   <class name="edm::RefVector<l1t::PFClusterCollection>" /> 
 
   <class name="l1t::PFTrack::TrackRef" />
-  <class name="l1t::PFTrack"  ClassVersion="4">
-        <version ClassVersion="4" checksum="1055891431"/>
-        <version ClassVersion="3" checksum="2332162612"/>
+  <class name="l1t::PFTrack"  ClassVersion="3">
+      <version ClassVersion="3" checksum="605458195"/>
   </class>
   <class name="l1t::PFTrackCollection" />
   <class name="edm::Wrapper<l1t::PFTrackCollection>" />
@@ -23,13 +18,8 @@
   <class name="edm::RefVector<l1t::PFTrackCollection>" /> 
   <class name="std::vector<edm::Ref<l1t::PFTrackCollection> >" />
 
-  <class name="l1t::PFCandidate"  ClassVersion="8">
-        <version ClassVersion="8" checksum="2078921607"/>
-        <version ClassVersion="7" checksum="2118795037"/>
-        <version ClassVersion="6" checksum="2195440462"/>
-        <version ClassVersion="5" checksum="3777180193"/>
-        <version ClassVersion="4" checksum="3798885201"/>
-        <version ClassVersion="3" checksum="4253860178"/>
+  <class name="l1t::PFCandidate"  ClassVersion="3">
+        <version ClassVersion="3" checksum="3889891979"/>
   </class>
   <class name="l1t::PFCandidateCollection" />
   <class name="edm::Wrapper<l1t::PFCandidateCollection>" />
@@ -39,20 +29,8 @@
   <class name="l1t::RegionalOutput<l1t::PFCandidateCollection>" />
   <class name="edm::Wrapper<l1t::RegionalOutput<l1t::PFCandidateCollection>>" />
 
-
-  <ioread sourceClass="l1t::PFCandidate" targetClass="l1t::PFCandidate" version="[-7]" target="" source="edm::Ref<l1t::PFClusterCollection> clusterRef_" include="DataFormats/Common/interface/RefToPtr.h,DataFormats/L1TParticleFlow/interface/PFCluster.h">
-  <![CDATA[
-   newObj->setCaloPtr(edm::refToPtr(onfile.clusterRef_));
-  ]]>
-  </ioread>
-
-  <class name="l1t::PFJet"  ClassVersion="8">
-        <version ClassVersion="8" checksum="2216717794"/>
-        <version ClassVersion="7" checksum="2216717791"/>
-        <version ClassVersion="6" checksum="2599349078"/>
-        <version ClassVersion="5" checksum="2270932343"/>
-        <version ClassVersion="4" checksum="1424452548"/>
-        <version ClassVersion="3" checksum="133342988"/>
+  <class name="l1t::PFJet"  ClassVersion="3">
+        <version ClassVersion="3" checksum="2122710094"/>
   </class>
   <class name="l1t::PFJetCollection" />
   <class name="edm::Wrapper<l1t::PFJetCollection>" />
@@ -60,10 +38,8 @@
   <class name="edm::RefVector<l1t::PFJetCollection>" />
   <class name="std::vector<edm::Ref<std::vector<l1t::PFJet>,l1t::PFJet,edm::refhelper::FindUsingAdvance<std::vector<l1t::PFJet>,l1t::PFJet> > >" />
 
-  <class name="l1t::PFTau"  ClassVersion="5">
-        <version ClassVersion="5" checksum="549313204"/>
-        <version ClassVersion="4" checksum="2045755946"/>
-        <version ClassVersion="3" checksum="1410157160"/>
+  <class name="l1t::PFTau"  ClassVersion="3">
+        <version ClassVersion="3" checksum="1092559384"/>
   </class>
   <class name="l1t::PFTauCollection" />
   <class name="edm::Wrapper<l1t::PFTauCollection>" />
@@ -71,11 +47,8 @@
   <class name="edm::RefVector<l1t::PFTauCollection>" /> 
   <class name="std::vector<edm::Ref<l1t::PFTauCollection> >" /> 
 
-  <class name="l1t::HPSPFTau" ClassVersion="14">
-    <version ClassVersion="14" checksum="927489833"/>
-    <version ClassVersion="13" checksum="588131857"/>
-    <version ClassVersion="12" checksum="1127525942"/>
-    <version ClassVersion="11" checksum="98678086"/>
+  <class name="l1t::HPSPFTau" ClassVersion="3">
+    <version ClassVersion="3" checksum="1687030309"/>
   </class>
   <class name="l1t::HPSPFTauCollection"/>
   <class name="edm::Wrapper<l1t::HPSPFTauCollection>"/>

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -1,8 +1,6 @@
 <lcgdict>
-  <class name="l1t::L1Candidate" ClassVersion="12">
-   <version ClassVersion="12" checksum="939575486"/>
-   <version ClassVersion="11" checksum="2395983446"/>
-   <version ClassVersion="10" checksum="3629668391"/>
+  <class name="l1t::L1Candidate" ClassVersion="3">
+   <version ClassVersion="3" checksum="4267141578"/>
   </class>
   <class name="l1t::L1CandidateBxCollection"/>
   <class name="edm::Wrapper<l1t::L1CandidateBxCollection>"/>
@@ -16,9 +14,8 @@
 
 
   <class name="l1t::P2GTCandidate::Optional<int>"/>
-  <class name="l1t::P2GTCandidate" ClassVersion="11">
-    <version ClassVersion="11" checksum="2947772579"/>
-    <version ClassVersion="10" checksum="2728416623"/>
+  <class name="l1t::P2GTCandidate" ClassVersion="3">
+    <version ClassVersion="3" checksum="2509933543"/>
   </class>
   <class name="l1t::P2GTCandidateCollection"/>
   <class name="edm::Wrapper<l1t::P2GTCandidateCollection>"/>
@@ -37,11 +34,8 @@
   <class name="edm::Wrapper<l1t::P2GTAlgoBlockMap>"/>
 
 
-  <class name="l1t::Jet" ClassVersion="13">
-   <version ClassVersion="13" checksum="3915457337"/>
-   <version ClassVersion="12" checksum="380555501"/>
-   <version ClassVersion="11" checksum="1836963461"/>
-   <version ClassVersion="10" checksum="4108627301"/>
+  <class name="l1t::Jet" ClassVersion="3">
+   <version ClassVersion="3" checksum="1812905789"/>
   </class>
   <class name="l1t::JetBxCollection"/>
   <class name="edm::Wrapper<l1t::JetBxCollection>"/>
@@ -61,12 +55,8 @@
   <class name="std::vector<l1t::TkTripletWord>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkTripletWord> >"/>
 
-  <class name="l1t::EGamma" ClassVersion="14">
-   <version ClassVersion="14" checksum="1235149790"/>
-   <version ClassVersion="13" checksum="2044674704"/>
-   <version ClassVersion="12" checksum="1332125006"/>
-   <version ClassVersion="11" checksum="2788532966"/>
-   <version ClassVersion="10" checksum="130849840"/>
+  <class name="l1t::EGamma" ClassVersion="3">
+   <version ClassVersion="3" checksum="80208738"/>
   </class>
   <class name="l1t::EGammaBxCollection"/>
   <class name="std::vector<l1t::EGamma>"/>
@@ -78,11 +68,8 @@
   <class name="l1t::EGammaVectorRef"/>
   <class name="edm::Wrapper<l1t::EGammaVectorRef>"/>
 
-  <class name="l1t::EtSum" ClassVersion="13">
-   <version ClassVersion="13" checksum="914893879"/>
-   <version ClassVersion="12" checksum="2853072620"/>
-   <version ClassVersion="11" checksum="2043464580"/>
-   <version ClassVersion="10" checksum="3389025278"/>
+  <class name="l1t::EtSum" ClassVersion="3">
+   <version ClassVersion="3" checksum="621331451"/>
   </class>
   <class name="l1t::EtSumBxCollection"/>
   <class name="std::vector<l1t::EtSum>"/>
@@ -101,11 +88,8 @@
   <class name="l1t::EtSumVectorP2Ref"/>
   <class name="edm::Wrapper<l1t::EtSumVectorP2Ref>"/>
 
-  <class name="l1t::Tau" ClassVersion="13">
-   <version ClassVersion="13" checksum="3236083459"/>
-   <version ClassVersion="12" checksum="1992693786"/>
-   <version ClassVersion="11" checksum="3449101746"/>
-   <version ClassVersion="10" checksum="3214350964"/>
+  <class name="l1t::Tau" ClassVersion="3">
+   <version ClassVersion="3" checksum="3417165519"/>
   </class>
   <class name="l1t::TauBxCollection"/>
   <class name="std::vector<l1t::Tau>"/>
@@ -117,16 +101,8 @@
   <class name="l1t::TauVectorRef"/>
   <class name="edm::Wrapper<l1t::TauVectorRef>"/>
 
-  <class name="l1t::Muon" ClassVersion="18">
-   <version ClassVersion="18" checksum="2723313197"/>
-   <version ClassVersion="17" checksum="3946815604"/>
-   <version ClassVersion="16" checksum="1302394108"/>
-   <version ClassVersion="15" checksum="957467775"/>
-   <version ClassVersion="14" checksum="1302394108"/>
-   <version ClassVersion="13" checksum="957467775"/>
-   <version ClassVersion="12" checksum="2662600115"/>
-   <version ClassVersion="11" checksum="2449295419"/>
-   <version ClassVersion="10" checksum="1956355507"/>
+  <class name="l1t::Muon" ClassVersion="3">
+   <version ClassVersion="3" checksum="2524012369"/>
   </class>
   <class name="edm::Ptr<l1t::Muon>"/>
   <class name="l1t::MuonBxCollection"/>
@@ -139,11 +115,8 @@
   <class name="l1t::MuonVectorRef"/>
   <class name="edm::Wrapper<l1t::MuonVectorRef>"/>
 
-  <class name="l1t::MuonShower" ClassVersion="13">
-   <version ClassVersion="13" checksum="39793345"/>
-   <version ClassVersion="12" checksum="2452991184"/>
-   <version ClassVersion="11" checksum="3610959089"/>
-   <version ClassVersion="10" checksum="3869296059"/>
+  <class name="l1t::MuonShower" ClassVersion="3">
+   <version ClassVersion="3" checksum="3216123309"/>
   </class>
   <class name="edm::Ptr<l1t::MuonShower>"/>
   <class name="l1t::MuonShowerBxCollection"/>
@@ -156,38 +129,24 @@
   <class name="l1t::MuonShowerVectorRef"/>
   <class name="edm::Wrapper<l1t::MuonShowerVectorRef>"/>
 
-  <class name="l1t::CaloSpare" ClassVersion="13">
-   <version ClassVersion="13" checksum="50826133"/>
-   <version ClassVersion="12" checksum="3118488206"/>
-   <version ClassVersion="11" checksum="2308880166"/>
-   <version ClassVersion="10" checksum="3477497140"/>
+  <class name="l1t::CaloSpare" ClassVersion="3">
+   <version ClassVersion="3" checksum="2428051929"/>
   </class>
   <class name="l1t::CaloSpareBxCollection"/>
   <class name="std::vector<l1t::CaloSpare>"/>
   <class name="edm::Wrapper<l1t::CaloSpareBxCollection>"/>
 
-  <class name="l1extra::L1EmParticle" ClassVersion="13">
-   <version ClassVersion="13" checksum="3236372598"/>
-   <version ClassVersion="12" checksum="3931086678"/>
-   <version ClassVersion="11" checksum="711885342"/>
-   <version ClassVersion="10" checksum="2019457791"/>
+  <class name="l1extra::L1EmParticle" ClassVersion="3">
+   <version ClassVersion="3" checksum="1758571202"/>
   </class>
-  <class name="l1extra::L1JetParticle" ClassVersion="13">
-   <version ClassVersion="13" checksum="2428218521"/>
-   <version ClassVersion="12" checksum="4036782287"/>
-   <version ClassVersion="11" checksum="979511831"/>
-   <version ClassVersion="10" checksum="2992828146"/>
+  <class name="l1extra::L1JetParticle" ClassVersion="3">
+   <version ClassVersion="3" checksum="3147792133"/>
   </class>
-  <class name="l1extra::L1MuonParticle" ClassVersion="12">
-   <version ClassVersion="12" checksum="3630739036"/>
-   <version ClassVersion="11" checksum="3788189108"/>
-   <version ClassVersion="10" checksum="404862417"/>
+  <class name="l1extra::L1MuonParticle" ClassVersion="3">
+   <version ClassVersion="3" checksum="2101229128"/>
   </class>
-  <class name="l1extra::L1EtMissParticle" ClassVersion="13">
-   <version ClassVersion="13" checksum="2570765761"/>
-   <version ClassVersion="12" checksum="3702781837"/>
-   <version ClassVersion="11" checksum="2391271061"/>
-   <version ClassVersion="10" checksum="256436604"/>
+  <class name="l1extra::L1EtMissParticle" ClassVersion="3">
+   <version ClassVersion="3" checksum="878707437"/>
   </class>
   <class name="l1extra::L1ParticleMap" ClassVersion="11">
    <version ClassVersion="11" checksum="3029280877"/>
@@ -239,15 +198,15 @@
 
   <class name="edm::RefProd<l1extra::L1EtMissParticle>"/>
 
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<l1extra::L1EmParticle>,l1extra::L1EmParticle,edm::refhelper::FindUsingAdvance<std::vector<l1extra::L1EmParticle>,l1extra::L1EmParticle> > >" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<l1extra::L1EmParticle>,l1extra::L1EmParticle,edm::refhelper::FindUsingAdvance<std::vector<l1extra::L1EmParticle>,l1extra::L1EmParticle> > >" />
 
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<l1extra::L1MuonParticle>,l1extra::L1MuonParticle,edm::refhelper::FindUsingAdvance<std::vector<l1extra::L1MuonParticle>,l1extra::L1MuonParticle> > >" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<l1extra::L1MuonParticle>,l1extra::L1MuonParticle,edm::refhelper::FindUsingAdvance<std::vector<l1extra::L1MuonParticle>,l1extra::L1MuonParticle> > >" />
 
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<l1extra::L1JetParticle>,l1extra::L1JetParticle,edm::refhelper::FindUsingAdvance<std::vector<l1extra::L1JetParticle>,l1extra::L1JetParticle> > >" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<l1extra::L1JetParticle>,l1extra::L1JetParticle,edm::refhelper::FindUsingAdvance<std::vector<l1extra::L1JetParticle>,l1extra::L1JetParticle> > >" />
 
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<l1extra::L1EtMissParticle>,l1extra::L1EtMissParticle,edm::refhelper::FindUsingAdvance<std::vector<l1extra::L1EtMissParticle>,l1extra::L1EtMissParticle> > >" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<l1extra::L1EtMissParticle>,l1extra::L1EtMissParticle,edm::refhelper::FindUsingAdvance<std::vector<l1extra::L1EtMissParticle>,l1extra::L1EtMissParticle> > >" />
 
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::RefProd<l1extra::L1EtMissParticle> >"/>
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::RefProd<l1extra::L1EtMissParticle> >"/>
 
   <class name="std::vector<l1extra::L1ParticleMap::L1ObjectType>"/>
 

--- a/DataFormats/METReco/interface/BeamHaloSummary.h
+++ b/DataFormats/METReco/interface/BeamHaloSummary.h
@@ -22,80 +22,86 @@
 
 namespace reco {
   class BeamHaloInfoProducer;
+  namespace io_v1 {
 
-  class BeamHaloSummary {
-    friend class reco::BeamHaloInfoProducer;
+    class BeamHaloSummary {
+      friend class reco::BeamHaloInfoProducer;
 
-  public:
-    //constructors
-    BeamHaloSummary();
-    BeamHaloSummary(CSCHaloData& csc, EcalHaloData& ecal, HcalHaloData& hcal, GlobalHaloData& global);
+    public:
+      //constructors
+      BeamHaloSummary();
+      BeamHaloSummary(CSCHaloData& csc, EcalHaloData& ecal, HcalHaloData& hcal, GlobalHaloData& global);
 
-    //destructor
-    virtual ~BeamHaloSummary() {}
+      //destructor
+      virtual ~BeamHaloSummary() {}
 
-    const bool HcalLooseHaloId() const { return !HcalHaloReport.empty() ? HcalHaloReport[0] : false; }
-    const bool HcalTightHaloId() const { return HcalHaloReport.size() > 1 ? HcalHaloReport[1] : false; }
+      const bool HcalLooseHaloId() const { return !HcalHaloReport.empty() ? HcalHaloReport[0] : false; }
+      const bool HcalTightHaloId() const { return HcalHaloReport.size() > 1 ? HcalHaloReport[1] : false; }
 
-    const bool EcalLooseHaloId() const { return !EcalHaloReport.empty() ? EcalHaloReport[0] : false; }
-    const bool EcalTightHaloId() const { return EcalHaloReport.size() > 1 ? EcalHaloReport[1] : false; }
+      const bool EcalLooseHaloId() const { return !EcalHaloReport.empty() ? EcalHaloReport[0] : false; }
+      const bool EcalTightHaloId() const { return EcalHaloReport.size() > 1 ? EcalHaloReport[1] : false; }
 
-    const bool CSCLooseHaloId() const { return !CSCHaloReport.empty() ? CSCHaloReport[0] : false; }
-    const bool CSCTightHaloId() const { return CSCHaloReport.size() > 1 ? CSCHaloReport[1] : false; }
-    const bool CSCTightHaloIdTrkMuUnveto() const { return CSCHaloReport.size() > 4 ? CSCHaloReport[4] : false; }
-    const bool CSCTightHaloId2015() const { return CSCHaloReport.size() > 5 ? CSCHaloReport[5] : false; }
+      const bool CSCLooseHaloId() const { return !CSCHaloReport.empty() ? CSCHaloReport[0] : false; }
+      const bool CSCTightHaloId() const { return CSCHaloReport.size() > 1 ? CSCHaloReport[1] : false; }
+      const bool CSCTightHaloIdTrkMuUnveto() const { return CSCHaloReport.size() > 4 ? CSCHaloReport[4] : false; }
+      const bool CSCTightHaloId2015() const { return CSCHaloReport.size() > 5 ? CSCHaloReport[5] : false; }
 
-    const bool GlobalLooseHaloId() const { return !GlobalHaloReport.empty() ? GlobalHaloReport[0] : false; }
-    const bool GlobalTightHaloId() const { return GlobalHaloReport.size() > 1 ? GlobalHaloReport[1] : false; }
-    const bool GlobalTightHaloId2016() const { return GlobalHaloReport.size() > 2 ? GlobalHaloReport[2] : false; }
-    const bool GlobalSuperTightHaloId2016() const { return GlobalHaloReport.size() > 3 ? GlobalHaloReport[3] : false; }
+      const bool GlobalLooseHaloId() const { return !GlobalHaloReport.empty() ? GlobalHaloReport[0] : false; }
+      const bool GlobalTightHaloId() const { return GlobalHaloReport.size() > 1 ? GlobalHaloReport[1] : false; }
+      const bool GlobalTightHaloId2016() const { return GlobalHaloReport.size() > 2 ? GlobalHaloReport[2] : false; }
+      const bool GlobalSuperTightHaloId2016() const {
+        return GlobalHaloReport.size() > 3 ? GlobalHaloReport[3] : false;
+      }
 
-    const bool EventSmellsLikeHalo() const {
-      return HcalLooseHaloId() || EcalLooseHaloId() || CSCLooseHaloId() || GlobalLooseHaloId();
-    }
-    const bool LooseId() const { return EventSmellsLikeHalo(); }
-    const bool TightId() const {
-      return HcalTightHaloId() || EcalTightHaloId() || CSCTightHaloId() || GlobalTightHaloId();
-    }
-    const bool ExtremeTightId() const { return GlobalTightHaloId(); }
+      const bool EventSmellsLikeHalo() const {
+        return HcalLooseHaloId() || EcalLooseHaloId() || CSCLooseHaloId() || GlobalLooseHaloId();
+      }
+      const bool LooseId() const { return EventSmellsLikeHalo(); }
+      const bool TightId() const {
+        return HcalTightHaloId() || EcalTightHaloId() || CSCTightHaloId() || GlobalTightHaloId();
+      }
+      const bool ExtremeTightId() const { return GlobalTightHaloId(); }
 
-    //  Getters
-    std::vector<char>& GetHcalHaloReport() { return HcalHaloReport; }
-    const std::vector<char>& GetHcalHaloReport() const { return HcalHaloReport; }
+      //  Getters
+      std::vector<char>& GetHcalHaloReport() { return HcalHaloReport; }
+      const std::vector<char>& GetHcalHaloReport() const { return HcalHaloReport; }
 
-    std::vector<char>& GetEcalHaloReport() { return EcalHaloReport; }
-    const std::vector<char>& GetEcalHaloReport() const { return EcalHaloReport; }
+      std::vector<char>& GetEcalHaloReport() { return EcalHaloReport; }
+      const std::vector<char>& GetEcalHaloReport() const { return EcalHaloReport; }
 
-    std::vector<char>& GetCSCHaloReport() { return CSCHaloReport; }
-    const std::vector<char>& GetCSCHaloReport() const { return CSCHaloReport; }
+      std::vector<char>& GetCSCHaloReport() { return CSCHaloReport; }
+      const std::vector<char>& GetCSCHaloReport() const { return CSCHaloReport; }
 
-    std::vector<char>& GetGlobalHaloReport() { return GlobalHaloReport; }
-    const std::vector<char>& GetGlobalHaloReport() const { return GlobalHaloReport; }
+      std::vector<char>& GetGlobalHaloReport() { return GlobalHaloReport; }
+      const std::vector<char>& GetGlobalHaloReport() const { return GlobalHaloReport; }
 
-    std::vector<int>& GetHcaliPhiSuspects() { return HcaliPhiSuspects; }
-    const std::vector<int>& GetHcaliPhiSuspects() const { return HcaliPhiSuspects; }
+      std::vector<int>& GetHcaliPhiSuspects() { return HcaliPhiSuspects; }
+      const std::vector<int>& GetHcaliPhiSuspects() const { return HcaliPhiSuspects; }
 
-    std::vector<int>& GetEcaliPhiSuspects() { return EcaliPhiSuspects; }
-    const std::vector<int>& GetEcaliPhiSuspects() const { return EcaliPhiSuspects; }
+      std::vector<int>& GetEcaliPhiSuspects() { return EcaliPhiSuspects; }
+      const std::vector<int>& GetEcaliPhiSuspects() const { return EcaliPhiSuspects; }
 
-    std::vector<int>& GetGlobaliPhiSuspects() { return GlobaliPhiSuspects; }
-    const std::vector<int>& GetGlobaliPhiSuspects() const { return GlobaliPhiSuspects; }
+      std::vector<int>& GetGlobaliPhiSuspects() { return GlobaliPhiSuspects; }
+      const std::vector<int>& GetGlobaliPhiSuspects() const { return GlobaliPhiSuspects; }
 
-    std::vector<HaloTowerStrip>& getProblematicStrips() { return problematicStrips; }
-    const std::vector<HaloTowerStrip>& getProblematicStrips() const { return problematicStrips; }
+      std::vector<HaloTowerStrip>& getProblematicStrips() { return problematicStrips; }
+      const std::vector<HaloTowerStrip>& getProblematicStrips() const { return problematicStrips; }
 
-  private:
-    std::vector<char> HcalHaloReport;
-    std::vector<char> EcalHaloReport;
-    std::vector<char> CSCHaloReport;
-    std::vector<char> GlobalHaloReport;
+    private:
+      std::vector<char> HcalHaloReport;
+      std::vector<char> EcalHaloReport;
+      std::vector<char> CSCHaloReport;
+      std::vector<char> GlobalHaloReport;
 
-    std::vector<int> HcaliPhiSuspects;
-    std::vector<int> EcaliPhiSuspects;
-    std::vector<int> GlobaliPhiSuspects;
+      std::vector<int> HcaliPhiSuspects;
+      std::vector<int> EcaliPhiSuspects;
+      std::vector<int> GlobaliPhiSuspects;
 
-    std::vector<HaloTowerStrip> problematicStrips;
-  };
+      std::vector<HaloTowerStrip> problematicStrips;
+    };
+
+  }  // namespace io_v1
+  using BeamHaloSummary = io_v1::BeamHaloSummary;
 
 }  // namespace reco
 

--- a/DataFormats/METReco/interface/CSCHaloData.h
+++ b/DataFormats/METReco/interface/CSCHaloData.h
@@ -20,144 +20,148 @@
 */
 
 namespace reco {
+  namespace io_v1 {
 
-  class CSCHaloData {
-  public:
-    // Default constructor
-    CSCHaloData();
+    class CSCHaloData {
+    public:
+      // Default constructor
+      CSCHaloData();
 
-    virtual ~CSCHaloData() {}
+      virtual ~CSCHaloData() {}
 
-    // Number of HaloTriggers in +/- endcap
-    int NumberOfHaloTriggers(HaloData::Endcap z = HaloData::both) const;
-    int NumberOfHaloTriggers_TrkMuUnVeto(HaloData::Endcap z = HaloData::both) const;
-    int NHaloTriggers(HaloData::Endcap z = HaloData::both) const { return NumberOfHaloTriggers(z); }
+      // Number of HaloTriggers in +/- endcap
+      int NumberOfHaloTriggers(HaloData::Endcap z = HaloData::both) const;
+      int NumberOfHaloTriggers_TrkMuUnVeto(HaloData::Endcap z = HaloData::both) const;
+      int NHaloTriggers(HaloData::Endcap z = HaloData::both) const { return NumberOfHaloTriggers(z); }
 
-    // Number of Halo Tracks in +/-  endcap
-    int NumberOfHaloTracks(HaloData::Endcap z = HaloData::both) const;
-    int NHaloTracks(HaloData::Endcap z = HaloData::both) const { return NumberOfHaloTracks(z); }
+      // Number of Halo Tracks in +/-  endcap
+      int NumberOfHaloTracks(HaloData::Endcap z = HaloData::both) const;
+      int NHaloTracks(HaloData::Endcap z = HaloData::both) const { return NumberOfHaloTracks(z); }
 
-    // Halo trigger bit from the HLT
-    bool CSCHaloHLTAccept() const { return HLTAccept; }
+      // Halo trigger bit from the HLT
+      bool CSCHaloHLTAccept() const { return HLTAccept; }
 
-    // Number of chamber-level triggers with non-collision timing
-    short int NumberOfOutOfTimeTriggers(HaloData::Endcap z = HaloData::both) const;
-    short int NOutOfTimeTriggers(HaloData::Endcap z = HaloData::both) const { return NumberOfOutOfTimeTriggers(z); }
-    // Number of CSCRecHits with non-collision timing
-    short int NumberOfOutTimeHits() const { return nOutOfTimeHits; }
-    short int NOutOfTimeHits() const { return nOutOfTimeHits; }
-    // Look at number of muons with timing consistent with incoming particles
-    short int NTracksSmalldT() const { return nTracks_Small_dT; }
-    short int NTracksSmallBeta() const { return nTracks_Small_beta; }
-    short int NTracksSmallBetaAndSmalldT() const { return nTracks_Small_dT_Small_beta; }
+      // Number of chamber-level triggers with non-collision timing
+      short int NumberOfOutOfTimeTriggers(HaloData::Endcap z = HaloData::both) const;
+      short int NOutOfTimeTriggers(HaloData::Endcap z = HaloData::both) const { return NumberOfOutOfTimeTriggers(z); }
+      // Number of CSCRecHits with non-collision timing
+      short int NumberOfOutTimeHits() const { return nOutOfTimeHits; }
+      short int NOutOfTimeHits() const { return nOutOfTimeHits; }
+      // Look at number of muons with timing consistent with incoming particles
+      short int NTracksSmalldT() const { return nTracks_Small_dT; }
+      short int NTracksSmallBeta() const { return nTracks_Small_beta; }
+      short int NTracksSmallBetaAndSmalldT() const { return nTracks_Small_dT_Small_beta; }
 
-    // MLR
-    short int NFlatHaloSegments() const { return nFlatHaloSegments; }
-    bool GetSegmentsInBothEndcaps() const { return segments_in_both_endcaps; }
-    bool GetSegmentIsCaloMatched() const { return segmentiscalomatched; }
-    bool GetSegmentIsHCaloMatched() const { return segmentisHcalomatched; }
-    bool GetSegmentIsEBCaloMatched() const { return segmentisEBcalomatched; }
-    bool GetSegmentIsEECaloMatched() const { return segmentisEEcalomatched; }
-    // End MLR
-    short int NFlatHaloSegments_TrkMuUnVeto() const { return nFlatHaloSegments_TrkMuUnVeto; }
-    bool GetSegmentsInBothEndcaps_Loose_TrkMuUnVeto() const { return segments_in_both_endcaps_loose_TrkMuUnVeto; }
-    bool GetSegmentsInBothEndcaps_Loose_dTcut_TrkMuUnVeto() const {
-      return segments_in_both_endcaps_loose_dtcut_TrkMuUnVeto;
-    }
+      // MLR
+      short int NFlatHaloSegments() const { return nFlatHaloSegments; }
+      bool GetSegmentsInBothEndcaps() const { return segments_in_both_endcaps; }
+      bool GetSegmentIsCaloMatched() const { return segmentiscalomatched; }
+      bool GetSegmentIsHCaloMatched() const { return segmentisHcalomatched; }
+      bool GetSegmentIsEBCaloMatched() const { return segmentisEBcalomatched; }
+      bool GetSegmentIsEECaloMatched() const { return segmentisEEcalomatched; }
+      // End MLR
+      short int NFlatHaloSegments_TrkMuUnVeto() const { return nFlatHaloSegments_TrkMuUnVeto; }
+      bool GetSegmentsInBothEndcaps_Loose_TrkMuUnVeto() const { return segments_in_both_endcaps_loose_TrkMuUnVeto; }
+      bool GetSegmentsInBothEndcaps_Loose_dTcut_TrkMuUnVeto() const {
+        return segments_in_both_endcaps_loose_dtcut_TrkMuUnVeto;
+      }
 
-    // Get Reference to the Tracks
-    edm::RefVector<reco::TrackCollection>& GetTracks() { return TheTrackRefs; }
-    const edm::RefVector<reco::TrackCollection>& GetTracks() const { return TheTrackRefs; }
+      // Get Reference to the Tracks
+      edm::RefVector<reco::TrackCollection>& GetTracks() { return TheTrackRefs; }
+      const edm::RefVector<reco::TrackCollection>& GetTracks() const { return TheTrackRefs; }
 
-    // Set Number of Halo Triggers
-    void SetNumberOfHaloTriggers(int PlusZ, int MinusZ) {
-      nTriggers_PlusZ = PlusZ;
-      nTriggers_MinusZ = MinusZ;
-    }
-    void SetNumberOfHaloTriggers_TrkMuUnVeto(int PlusZ, int MinusZ) {
-      nTriggers_PlusZ_TrkMuUnVeto = PlusZ;
-      nTriggers_MinusZ_TrkMuUnVeto = MinusZ;
-    }
-    // Set number of chamber-level triggers with non-collision timing
-    void SetNOutOfTimeTriggers(short int PlusZ, short int MinusZ) {
-      nOutOfTimeTriggers_PlusZ = PlusZ;
-      nOutOfTimeTriggers_MinusZ = MinusZ;
-    }
-    // Set number of CSCRecHits with non-collision timing
-    void SetNOutOfTimeHits(short int num) { nOutOfTimeHits = num; }
-    // Set number of tracks with timing consistent with incoming particles
-    void SetNIncomingTracks(short int n_small_dT, short int n_small_beta, short int n_small_both) {
-      nTracks_Small_dT = n_small_dT;
-      nTracks_Small_beta = n_small_beta;
-      nTracks_Small_dT_Small_beta = n_small_both;
-    }
+      // Set Number of Halo Triggers
+      void SetNumberOfHaloTriggers(int PlusZ, int MinusZ) {
+        nTriggers_PlusZ = PlusZ;
+        nTriggers_MinusZ = MinusZ;
+      }
+      void SetNumberOfHaloTriggers_TrkMuUnVeto(int PlusZ, int MinusZ) {
+        nTriggers_PlusZ_TrkMuUnVeto = PlusZ;
+        nTriggers_MinusZ_TrkMuUnVeto = MinusZ;
+      }
+      // Set number of chamber-level triggers with non-collision timing
+      void SetNOutOfTimeTriggers(short int PlusZ, short int MinusZ) {
+        nOutOfTimeTriggers_PlusZ = PlusZ;
+        nOutOfTimeTriggers_MinusZ = MinusZ;
+      }
+      // Set number of CSCRecHits with non-collision timing
+      void SetNOutOfTimeHits(short int num) { nOutOfTimeHits = num; }
+      // Set number of tracks with timing consistent with incoming particles
+      void SetNIncomingTracks(short int n_small_dT, short int n_small_beta, short int n_small_both) {
+        nTracks_Small_dT = n_small_dT;
+        nTracks_Small_beta = n_small_beta;
+        nTracks_Small_dT_Small_beta = n_small_both;
+      }
 
-    // Set HLT Bit
-    void SetHLTBit(bool status) { HLTAccept = status; }
+      // Set HLT Bit
+      void SetHLTBit(bool status) { HLTAccept = status; }
 
-    // Get GlobalPoints of CSC tracking rechits nearest to the calorimeters
-    //std::vector<const GlobalPoint>& GetCSCTrackImpactPositions() const {return TheGlobalPositions;}
-    const std::vector<GlobalPoint>& GetCSCTrackImpactPositions() const { return TheGlobalPositions; }
-    std::vector<GlobalPoint>& GetCSCTrackImpactPositions() { return TheGlobalPositions; }
+      // Get GlobalPoints of CSC tracking rechits nearest to the calorimeters
+      //std::vector<const GlobalPoint>& GetCSCTrackImpactPositions() const {return TheGlobalPositions;}
+      const std::vector<GlobalPoint>& GetCSCTrackImpactPositions() const { return TheGlobalPositions; }
+      std::vector<GlobalPoint>& GetCSCTrackImpactPositions() { return TheGlobalPositions; }
 
-    // MLR
-    // Set # of CSCSegments that appear to be part of a halo muon
-    // If there is more than 1 muon, this is the number of segments in the halo muon
-    // with the largest number of segments that pass the cut.
-    void SetNFlatHaloSegments(short int nSegments) { nFlatHaloSegments = nSegments; }
-    void SetSegmentsBothEndcaps(bool b) { segments_in_both_endcaps = b; }
-    // End MLR
-    void SetNFlatHaloSegments_TrkMuUnVeto(short int nSegments) { nFlatHaloSegments_TrkMuUnVeto = nSegments; }
-    void SetSegmentsBothEndcaps_Loose_TrkMuUnVeto(bool b) { segments_in_both_endcaps_loose_TrkMuUnVeto = b; }
-    void SetSegmentsBothEndcaps_Loose_dTcut_TrkMuUnVeto(bool b) {
-      segments_in_both_endcaps_loose_dtcut_TrkMuUnVeto = b;
-    }
-    void SetSegmentIsCaloMatched(bool b) { segmentiscalomatched = b; }
-    void SetSegmentIsHCaloMatched(bool b) { segmentisHcalomatched = b; }
-    void SetSegmentIsEBCaloMatched(bool b) { segmentisEBcalomatched = b; }
-    void SetSegmentIsEECaloMatched(bool b) { segmentisEEcalomatched = b; }
+      // MLR
+      // Set # of CSCSegments that appear to be part of a halo muon
+      // If there is more than 1 muon, this is the number of segments in the halo muon
+      // with the largest number of segments that pass the cut.
+      void SetNFlatHaloSegments(short int nSegments) { nFlatHaloSegments = nSegments; }
+      void SetSegmentsBothEndcaps(bool b) { segments_in_both_endcaps = b; }
+      // End MLR
+      void SetNFlatHaloSegments_TrkMuUnVeto(short int nSegments) { nFlatHaloSegments_TrkMuUnVeto = nSegments; }
+      void SetSegmentsBothEndcaps_Loose_TrkMuUnVeto(bool b) { segments_in_both_endcaps_loose_TrkMuUnVeto = b; }
+      void SetSegmentsBothEndcaps_Loose_dTcut_TrkMuUnVeto(bool b) {
+        segments_in_both_endcaps_loose_dtcut_TrkMuUnVeto = b;
+      }
+      void SetSegmentIsCaloMatched(bool b) { segmentiscalomatched = b; }
+      void SetSegmentIsHCaloMatched(bool b) { segmentisHcalomatched = b; }
+      void SetSegmentIsEBCaloMatched(bool b) { segmentisEBcalomatched = b; }
+      void SetSegmentIsEECaloMatched(bool b) { segmentisEEcalomatched = b; }
 
-  private:
-    edm::RefVector<reco::TrackCollection> TheTrackRefs;
+    private:
+      edm::RefVector<reco::TrackCollection> TheTrackRefs;
 
-    // The GlobalPoints from constituent rechits nearest to the calorimeter of CSC tracks
-    std::vector<GlobalPoint> TheGlobalPositions;
-    int nTriggers_PlusZ;
-    int nTriggers_MinusZ;
-    int nTriggers_PlusZ_TrkMuUnVeto;
-    int nTriggers_MinusZ_TrkMuUnVeto;
-    // CSC halo trigger reported by the HLT
-    bool HLTAccept;
+      // The GlobalPoints from constituent rechits nearest to the calorimeter of CSC tracks
+      std::vector<GlobalPoint> TheGlobalPositions;
+      int nTriggers_PlusZ;
+      int nTriggers_MinusZ;
+      int nTriggers_PlusZ_TrkMuUnVeto;
+      int nTriggers_MinusZ_TrkMuUnVeto;
+      // CSC halo trigger reported by the HLT
+      bool HLTAccept;
 
-    int nTracks_PlusZ;
-    int nTracks_MinusZ;
+      int nTracks_PlusZ;
+      int nTracks_MinusZ;
 
-    // number of  out-of-time chamber-level triggers (assumes the event triggered at the bx of the beam crossing)
-    short int nOutOfTimeTriggers_PlusZ;
-    short int nOutOfTimeTriggers_MinusZ;
-    // number of out-of-time CSCRecHit2Ds (assumes the event triggered at the bx of the beam crossing)
-    short int nOutOfTimeHits;
-    // number of cosmic muon outer (CSC) tracks with (T_segment_outer - T_segment_inner) < max_dt_muon_segment
-    short int nTracks_Small_dT;
-    // number of cosmic muon outer (CSC) tracks with free inverse beta < max_free_inverse_beta
-    short int nTracks_Small_beta;
-    // number of cosmic muon outer (CSC) tracks with both
-    // (T_segment_outer - T_segment_inner) <  max_dt_muon_segment and free inverse beta < max_free_inverse_beta
-    short int nTracks_Small_dT_Small_beta;
+      // number of  out-of-time chamber-level triggers (assumes the event triggered at the bx of the beam crossing)
+      short int nOutOfTimeTriggers_PlusZ;
+      short int nOutOfTimeTriggers_MinusZ;
+      // number of out-of-time CSCRecHit2Ds (assumes the event triggered at the bx of the beam crossing)
+      short int nOutOfTimeHits;
+      // number of cosmic muon outer (CSC) tracks with (T_segment_outer - T_segment_inner) < max_dt_muon_segment
+      short int nTracks_Small_dT;
+      // number of cosmic muon outer (CSC) tracks with free inverse beta < max_free_inverse_beta
+      short int nTracks_Small_beta;
+      // number of cosmic muon outer (CSC) tracks with both
+      // (T_segment_outer - T_segment_inner) <  max_dt_muon_segment and free inverse beta < max_free_inverse_beta
+      short int nTracks_Small_dT_Small_beta;
 
-    // MLR
-    // number of CSCSegments that are flat and have the same (r,phi)
-    short int nFlatHaloSegments;
-    bool segments_in_both_endcaps;
-    // end MLR
-    short int nFlatHaloSegments_TrkMuUnVeto;
-    bool segments_in_both_endcaps_loose_TrkMuUnVeto;
-    bool segments_in_both_endcaps_loose_dtcut_TrkMuUnVeto;
-    bool segmentiscalomatched;
-    bool segmentisHcalomatched;
-    bool segmentisEBcalomatched;
-    bool segmentisEEcalomatched;
-  };
+      // MLR
+      // number of CSCSegments that are flat and have the same (r,phi)
+      short int nFlatHaloSegments;
+      bool segments_in_both_endcaps;
+      // end MLR
+      short int nFlatHaloSegments_TrkMuUnVeto;
+      bool segments_in_both_endcaps_loose_TrkMuUnVeto;
+      bool segments_in_both_endcaps_loose_dtcut_TrkMuUnVeto;
+      bool segmentiscalomatched;
+      bool segmentisHcalomatched;
+      bool segmentisEBcalomatched;
+      bool segmentisEEcalomatched;
+    };
+
+  }  // namespace io_v1
+  using CSCHaloData = io_v1::CSCHaloData;
 
 }  // namespace reco
 

--- a/DataFormats/METReco/interface/CaloMET.h
+++ b/DataFormats/METReco/interface/CaloMET.h
@@ -18,69 +18,72 @@
 #include "DataFormats/METReco/interface/CorrMETData.h"
 
 namespace reco {
-  class CaloMET : public MET {
-  public:
-    /* Constructors*/
-    CaloMET();
-    CaloMET(const SpecificCaloMETData& calo_data_, double sumet_, const LorentzVector& fP4, const Point& fVertex)
-        : MET(sumet_, fP4, fVertex), calo_data(calo_data_) {}
-    CaloMET(const SpecificCaloMETData& calo_data_,
-            double sumet_,
-            const std::vector<CorrMETData>& corr_,
-            const LorentzVector& fP4,
-            const Point& fVertex)
-        : MET(sumet_, corr_, fP4, fVertex), calo_data(calo_data_) {}
-    /* Default destructor*/
-    ~CaloMET() override {}
+  namespace io_v1 {
+    class CaloMET : public MET {
+    public:
+      /* Constructors*/
+      CaloMET();
+      CaloMET(const SpecificCaloMETData& calo_data_, double sumet_, const LorentzVector& fP4, const Point& fVertex)
+          : MET(sumet_, fP4, fVertex), calo_data(calo_data_) {}
+      CaloMET(const SpecificCaloMETData& calo_data_,
+              double sumet_,
+              const std::vector<CorrMETData>& corr_,
+              const LorentzVector& fP4,
+              const Point& fVertex)
+          : MET(sumet_, corr_, fP4, fVertex), calo_data(calo_data_) {}
+      /* Default destructor*/
+      ~CaloMET() override {}
 
-    /* Returns the maximum energy deposited in ECAL towers */
-    double maxEtInEmTowers() const { return calo_data.MaxEtInEmTowers; };
-    /* Returns the maximum energy deposited in HCAL towers */
-    double maxEtInHadTowers() const { return calo_data.MaxEtInHadTowers; };
-    /* Returns the event hadronic energy fraction          */
-    double etFractionHadronic() const { return calo_data.EtFractionHadronic; };
-    /* Returns the event electromagnetic energy fraction   */
-    double emEtFraction() const { return calo_data.EtFractionEm; };
-    /* Returns the event hadronic energy in HB             */
-    double hadEtInHB() const { return calo_data.HadEtInHB; };
-    /* Returns the event hadronic energy in HO             */
-    double hadEtInHO() const { return calo_data.HadEtInHO; };
-    /* Returns the event hadronic energy in HE             */
-    double hadEtInHE() const { return calo_data.HadEtInHE; };
-    /* Returns the event hadronic energy in HF             */
-    double hadEtInHF() const { return calo_data.HadEtInHF; };
-    /* Returns the event electromagnetic energy in EB      */
-    double emEtInEB() const { return calo_data.EmEtInEB; };
-    /* Returns the event electromagnetic energy in EE      */
-    double emEtInEE() const { return calo_data.EmEtInEE; };
-    /* Returns the event electromagnetic energy extracted from HF */
-    double emEtInHF() const { return calo_data.EmEtInHF; };
-    /* Returns the event MET Significance */
-    double metSignificance() const { return this->significance(); };
-    /* Returns the event SET in HF+ */
-    double CaloSETInpHF() const { return calo_data.CaloSETInpHF; };
-    /* Returns the event SET in HF- */
-    double CaloSETInmHF() const { return calo_data.CaloSETInmHF; };
-    /* Returns the event MET in HF+ */
-    double CaloMETInpHF() const { return calo_data.CaloMETInpHF; };
-    /* Returns the event MET in HF- */
-    double CaloMETInmHF() const { return calo_data.CaloMETInmHF; };
-    /* Returns the event MET-phi in HF+ */
-    double CaloMETPhiInpHF() const { return calo_data.CaloMETPhiInpHF; };
-    /* Returns the event MET-phi in HF- */
-    double CaloMETPhiInmHF() const { return calo_data.CaloMETPhiInmHF; };
+      /* Returns the maximum energy deposited in ECAL towers */
+      double maxEtInEmTowers() const { return calo_data.MaxEtInEmTowers; };
+      /* Returns the maximum energy deposited in HCAL towers */
+      double maxEtInHadTowers() const { return calo_data.MaxEtInHadTowers; };
+      /* Returns the event hadronic energy fraction          */
+      double etFractionHadronic() const { return calo_data.EtFractionHadronic; };
+      /* Returns the event electromagnetic energy fraction   */
+      double emEtFraction() const { return calo_data.EtFractionEm; };
+      /* Returns the event hadronic energy in HB             */
+      double hadEtInHB() const { return calo_data.HadEtInHB; };
+      /* Returns the event hadronic energy in HO             */
+      double hadEtInHO() const { return calo_data.HadEtInHO; };
+      /* Returns the event hadronic energy in HE             */
+      double hadEtInHE() const { return calo_data.HadEtInHE; };
+      /* Returns the event hadronic energy in HF             */
+      double hadEtInHF() const { return calo_data.HadEtInHF; };
+      /* Returns the event electromagnetic energy in EB      */
+      double emEtInEB() const { return calo_data.EmEtInEB; };
+      /* Returns the event electromagnetic energy in EE      */
+      double emEtInEE() const { return calo_data.EmEtInEE; };
+      /* Returns the event electromagnetic energy extracted from HF */
+      double emEtInHF() const { return calo_data.EmEtInHF; };
+      /* Returns the event MET Significance */
+      double metSignificance() const { return this->significance(); };
+      /* Returns the event SET in HF+ */
+      double CaloSETInpHF() const { return calo_data.CaloSETInpHF; };
+      /* Returns the event SET in HF- */
+      double CaloSETInmHF() const { return calo_data.CaloSETInmHF; };
+      /* Returns the event MET in HF+ */
+      double CaloMETInpHF() const { return calo_data.CaloMETInpHF; };
+      /* Returns the event MET in HF- */
+      double CaloMETInmHF() const { return calo_data.CaloMETInmHF; };
+      /* Returns the event MET-phi in HF+ */
+      double CaloMETPhiInpHF() const { return calo_data.CaloMETPhiInpHF; };
+      /* Returns the event MET-phi in HF- */
+      double CaloMETPhiInmHF() const { return calo_data.CaloMETPhiInmHF; };
 
-    //Set Met Significance
-    void SetMetSignificance(double metsig) { calo_data.METSignificance = metsig; }
+      //Set Met Significance
+      void SetMetSignificance(double metsig) { calo_data.METSignificance = metsig; }
 
-    // block accessors
-    SpecificCaloMETData getSpecific() const { return calo_data; }
+      // block accessors
+      SpecificCaloMETData getSpecific() const { return calo_data; }
 
-  private:
-    bool overlap(const Candidate&) const override;
-    // Data members
-    //Variables specific to to the CaloMET class
-    SpecificCaloMETData calo_data;
-  };
+    private:
+      bool overlap(const Candidate&) const override;
+      // Data members
+      //Variables specific to to the CaloMET class
+      SpecificCaloMETData calo_data;
+    };
+  }  // namespace io_v1
+  using CaloMET = io_v1::CaloMET;
 }  // namespace reco
 #endif

--- a/DataFormats/METReco/interface/CaloMETFwd.h
+++ b/DataFormats/METReco/interface/CaloMETFwd.h
@@ -6,7 +6,10 @@
 #include "DataFormats/Common/interface/RefProd.h"
 
 namespace reco {
-  class CaloMET;
+  namespace io_v1 {
+    class CaloMET;
+  }
+  using CaloMET = io_v1::CaloMET;
   /// collection of CaloMET objects
   typedef std::vector<CaloMET> CaloMETCollection;
   /// edm references

--- a/DataFormats/METReco/interface/EcalHaloData.h
+++ b/DataFormats/METReco/interface/EcalHaloData.h
@@ -18,50 +18,53 @@
 #include "DataFormats/METReco/interface/HaloClusterCandidateECAL.h"
 
 namespace reco {
-  class EcalHaloData {
-  public:
-    //Constructor
-    EcalHaloData();
-    //Destructor
-    ~EcalHaloData() {}
+  namespace io_v1 {
+    class EcalHaloData {
+    public:
+      //Constructor
+      EcalHaloData();
+      //Destructor
+      ~EcalHaloData() {}
 
-    // Number of Halo-like superclusters as a function of the roundness and angular cuts
-    //int NumberOfHaloSuperClusters(int iRoundness=2, int iAngle=2) const;
-    int NumberOfHaloSuperClusters(float roundness = 100., float angle = 4.0) const;
+      // Number of Halo-like superclusters as a function of the roundness and angular cuts
+      //int NumberOfHaloSuperClusters(int iRoundness=2, int iAngle=2) const;
+      int NumberOfHaloSuperClusters(float roundness = 100., float angle = 4.0) const;
 
-    // Return collection of 5-degree Phi Wedges built from Ecal RecHits
-    const std::vector<PhiWedge>& GetPhiWedges() const { return PhiWedgeCollection; }
-    std::vector<PhiWedge>& GetPhiWedges() { return PhiWedgeCollection; }
+      // Return collection of 5-degree Phi Wedges built from Ecal RecHits
+      const std::vector<PhiWedge>& GetPhiWedges() const { return PhiWedgeCollection; }
+      std::vector<PhiWedge>& GetPhiWedges() { return PhiWedgeCollection; }
 
-    // Get Reference to the SuperClusters
-    edm::RefVector<reco::SuperClusterCollection>& GetSuperClusters() { return TheSuperClusterRefs; }
-    const edm::RefVector<reco::SuperClusterCollection>& GetSuperClusters() const { return TheSuperClusterRefs; }
+      // Get Reference to the SuperClusters
+      edm::RefVector<reco::SuperClusterCollection>& GetSuperClusters() { return TheSuperClusterRefs; }
+      const edm::RefVector<reco::SuperClusterCollection>& GetSuperClusters() const { return TheSuperClusterRefs; }
 
-    // Store Shower Shape variables for SuperClusters
-    edm::ValueMap<float>& GetShowerShapesRoundness() { return ShowerShapes_Roundness; }
-    const edm::ValueMap<float>& GetShowerShapesRoundness() const { return ShowerShapes_Roundness; }
+      // Store Shower Shape variables for SuperClusters
+      edm::ValueMap<float>& GetShowerShapesRoundness() { return ShowerShapes_Roundness; }
+      const edm::ValueMap<float>& GetShowerShapesRoundness() const { return ShowerShapes_Roundness; }
 
-    edm::ValueMap<float>& GetShowerShapesAngle() { return ShowerShapes_Angle; }
-    const edm::ValueMap<float>& GetShowerShapesAngle() const { return ShowerShapes_Angle; }
+      edm::ValueMap<float>& GetShowerShapesAngle() { return ShowerShapes_Angle; }
+      const edm::ValueMap<float>& GetShowerShapesAngle() const { return ShowerShapes_Angle; }
 
-    const std::vector<HaloClusterCandidateECAL>& getHaloClusterCandidatesEB() const { return thehaloclustercands_eb; }
-    std::vector<HaloClusterCandidateECAL>& getHaloClusterCandidatesEB() { return thehaloclustercands_eb; }
-    const std::vector<HaloClusterCandidateECAL>& getHaloClusterCandidatesEE() const { return thehaloclustercands_ee; }
-    std::vector<HaloClusterCandidateECAL>& getHaloClusterCandidatesEE() { return thehaloclustercands_ee; }
+      const std::vector<HaloClusterCandidateECAL>& getHaloClusterCandidatesEB() const { return thehaloclustercands_eb; }
+      std::vector<HaloClusterCandidateECAL>& getHaloClusterCandidatesEB() { return thehaloclustercands_eb; }
+      const std::vector<HaloClusterCandidateECAL>& getHaloClusterCandidatesEE() const { return thehaloclustercands_ee; }
+      std::vector<HaloClusterCandidateECAL>& getHaloClusterCandidatesEE() { return thehaloclustercands_ee; }
 
-    void setHaloClusterCandidatesEB(const std::vector<HaloClusterCandidateECAL>& x) { thehaloclustercands_eb = x; }
-    void setHaloClusterCandidatesEE(const std::vector<HaloClusterCandidateECAL>& x) { thehaloclustercands_ee = x; }
+      void setHaloClusterCandidatesEB(const std::vector<HaloClusterCandidateECAL>& x) { thehaloclustercands_eb = x; }
+      void setHaloClusterCandidatesEE(const std::vector<HaloClusterCandidateECAL>& x) { thehaloclustercands_ee = x; }
 
-  private:
-    std::vector<PhiWedge> PhiWedgeCollection;
-    edm::RefVector<reco::SuperClusterCollection> TheSuperClusterRefs;
+    private:
+      std::vector<PhiWedge> PhiWedgeCollection;
+      edm::RefVector<reco::SuperClusterCollection> TheSuperClusterRefs;
 
-    edm::ValueMap<float> ShowerShapes_Roundness;
-    edm::ValueMap<float> ShowerShapes_Angle;
+      edm::ValueMap<float> ShowerShapes_Roundness;
+      edm::ValueMap<float> ShowerShapes_Angle;
 
-    std::vector<HaloClusterCandidateECAL> thehaloclustercands_eb;
-    std::vector<HaloClusterCandidateECAL> thehaloclustercands_ee;
-  };
+      std::vector<HaloClusterCandidateECAL> thehaloclustercands_eb;
+      std::vector<HaloClusterCandidateECAL> thehaloclustercands_ee;
+    };
+  }  // namespace io_v1
+  using EcalHaloData = io_v1::EcalHaloData;
 }  // namespace reco
 
 #endif

--- a/DataFormats/METReco/interface/GenMET.h
+++ b/DataFormats/METReco/interface/GenMET.h
@@ -17,68 +17,71 @@
 #include "DataFormats/METReco/interface/MET.h"
 
 namespace reco {
-  class GenMET : public MET {
-  public:
-    /* Constructors*/
-    GenMET();
-    GenMET(const SpecificGenMETData& gen_data_, double sumet_, const LorentzVector& fP4, const Point& fVertex)
-        : MET(sumet_, fP4, fVertex), gen_data(gen_data_) {}
-    /* Default destructor*/
-    ~GenMET() override {}
+  namespace io_v1 {
+    class GenMET : public MET {
+    public:
+      /* Constructors*/
+      GenMET();
+      GenMET(const SpecificGenMETData& gen_data_, double sumet_, const LorentzVector& fP4, const Point& fVertex)
+          : MET(sumet_, fP4, fVertex), gen_data(gen_data_) {}
+      /* Default destructor*/
+      ~GenMET() override {}
 
-    //Get Neutral EM Et Fraction
-    double NeutralEMEtFraction() const { return gen_data.NeutralEMEtFraction; }
+      //Get Neutral EM Et Fraction
+      double NeutralEMEtFraction() const { return gen_data.NeutralEMEtFraction; }
 
-    //Get Neutral EM Et
-    double NeutralEMEt() const { return gen_data.NeutralEMEtFraction * sumEt(); }
+      //Get Neutral EM Et
+      double NeutralEMEt() const { return gen_data.NeutralEMEtFraction * sumEt(); }
 
-    //Get Charged EM Et Fraction
-    double ChargedEMEtFraction() const { return gen_data.ChargedEMEtFraction; }
+      //Get Charged EM Et Fraction
+      double ChargedEMEtFraction() const { return gen_data.ChargedEMEtFraction; }
 
-    //Get Charged EM Et
-    double ChargedEMEt() const { return gen_data.ChargedEMEtFraction * sumEt(); }
+      //Get Charged EM Et
+      double ChargedEMEt() const { return gen_data.ChargedEMEtFraction * sumEt(); }
 
-    //Get Neutral Had Et Fraction
-    double NeutralHadEtFraction() const { return gen_data.NeutralHadEtFraction; }
+      //Get Neutral Had Et Fraction
+      double NeutralHadEtFraction() const { return gen_data.NeutralHadEtFraction; }
 
-    //Get Neutral Had Et
-    double NeutralHadEt() const { return gen_data.NeutralHadEtFraction * sumEt(); }
+      //Get Neutral Had Et
+      double NeutralHadEt() const { return gen_data.NeutralHadEtFraction * sumEt(); }
 
-    //Get Charged Had Et Fraction
-    double ChargedHadEtFraction() const { return gen_data.ChargedHadEtFraction; }
+      //Get Charged Had Et Fraction
+      double ChargedHadEtFraction() const { return gen_data.ChargedHadEtFraction; }
 
-    //Get Charged Had Et
-    double ChargedHadEt() const { return gen_data.ChargedHadEtFraction * sumEt(); }
+      //Get Charged Had Et
+      double ChargedHadEt() const { return gen_data.ChargedHadEtFraction * sumEt(); }
 
-    //Get Muon Et Fraction
-    double MuonEtFraction() const { return gen_data.MuonEtFraction; }
+      //Get Muon Et Fraction
+      double MuonEtFraction() const { return gen_data.MuonEtFraction; }
 
-    //Get Muon Et
-    double MuonEt() const { return gen_data.MuonEtFraction * sumEt(); }
+      //Get Muon Et
+      double MuonEt() const { return gen_data.MuonEtFraction * sumEt(); }
 
-    //Get Invisible Et Fraction
-    double InvisibleEtFraction() const { return gen_data.InvisibleEtFraction; }
+      //Get Invisible Et Fraction
+      double InvisibleEtFraction() const { return gen_data.InvisibleEtFraction; }
 
-    //Get Invisible Et
-    double InvisibleEt() const { return gen_data.InvisibleEtFraction * sumEt(); }
+      //Get Invisible Et
+      double InvisibleEt() const { return gen_data.InvisibleEtFraction * sumEt(); }
 
-    // Old Accessors (to be removed as soon as possible)
-    /** Returns energy of electromagnetic particles*/
-    double emEnergy() const { return gen_data.m_EmEnergy; };
-    /** Returns energy of hadronic particles*/
-    double hadEnergy() const { return gen_data.m_HadEnergy; };
-    /** Returns invisible energy*/
-    double invisibleEnergy() const { return gen_data.m_InvisibleEnergy; };
-    /** Returns other energy (undecayed Sigmas etc.)*/
-    double auxiliaryEnergy() const { return gen_data.m_AuxiliaryEnergy; };
-    // block accessors
+      // Old Accessors (to be removed as soon as possible)
+      /** Returns energy of electromagnetic particles*/
+      double emEnergy() const { return gen_data.m_EmEnergy; };
+      /** Returns energy of hadronic particles*/
+      double hadEnergy() const { return gen_data.m_HadEnergy; };
+      /** Returns invisible energy*/
+      double invisibleEnergy() const { return gen_data.m_InvisibleEnergy; };
+      /** Returns other energy (undecayed Sigmas etc.)*/
+      double auxiliaryEnergy() const { return gen_data.m_AuxiliaryEnergy; };
+      // block accessors
 
-    // block accessors
-  private:
-    bool overlap(const Candidate&) const override;
-    // Data members
-    //Variables specific to to the GenMET class
-    SpecificGenMETData gen_data;
-  };
+      // block accessors
+    private:
+      bool overlap(const Candidate&) const override;
+      // Data members
+      //Variables specific to to the GenMET class
+      SpecificGenMETData gen_data;
+    };
+  }  // namespace io_v1
+  using GenMET = io_v1::GenMET;
 }  // namespace reco
 #endif

--- a/DataFormats/METReco/interface/GenMETFwd.h
+++ b/DataFormats/METReco/interface/GenMETFwd.h
@@ -6,7 +6,10 @@
 #include "DataFormats/Common/interface/RefProd.h"
 
 namespace reco {
-  class GenMET;
+  namespace io_v1 {
+    class GenMET;
+  }
+  using io_v1::GenMET;
   /// collection of GenMET objects
   typedef std::vector<GenMET> GenMETCollection;
   /// edm references

--- a/DataFormats/METReco/interface/GlobalHaloData.h
+++ b/DataFormats/METReco/interface/GlobalHaloData.h
@@ -14,84 +14,87 @@
 #include "DataFormats/METReco/interface/MET.h"
 
 namespace reco {
-  class GlobalHaloData {
-  public:
-    // Constructor
-    GlobalHaloData();
-    // Destructor
-    ~GlobalHaloData() {}
+  namespace io_v1 {
+    class GlobalHaloData {
+    public:
+      // Constructor
+      GlobalHaloData();
+      // Destructor
+      ~GlobalHaloData() {}
 
-    //A good cut-variable to isolate halo events with no overlapping physics from collisions
-    float METOverSumEt() const { return METOverSumEt_; }
+      //A good cut-variable to isolate halo events with no overlapping physics from collisions
+      float METOverSumEt() const { return METOverSumEt_; }
 
-    //Correction to CaloMET x-component
-    float DeltaMEx() const { return dMEx_; }
+      //Correction to CaloMET x-component
+      float DeltaMEx() const { return dMEx_; }
 
-    //Correction to CaloMET y-component
-    float DeltaMEy() const { return dMEy_; }
+      //Correction to CaloMET y-component
+      float DeltaMEy() const { return dMEy_; }
 
-    //Correction to SumEt
-    float DeltaSumEt() const { return dSumEt_; }
+      //Correction to SumEt
+      float DeltaSumEt() const { return dSumEt_; }
 
-    //Get CaloMET Object corrected for BeamHalo
-    reco::CaloMET GetCorrectedCaloMET(const reco::CaloMET& RawMET) const;
+      //Get CaloMET Object corrected for BeamHalo
+      reco::CaloMET GetCorrectedCaloMET(const reco::CaloMET& RawMET) const;
 
-    std::vector<PhiWedge>& GetMatchedHcalPhiWedges() { return HcalPhiWedges; }
-    const std::vector<PhiWedge>& GetMatchedHcalPhiWedges() const { return HcalPhiWedges; }
+      std::vector<PhiWedge>& GetMatchedHcalPhiWedges() { return HcalPhiWedges; }
+      const std::vector<PhiWedge>& GetMatchedHcalPhiWedges() const { return HcalPhiWedges; }
 
-    std::vector<PhiWedge>& GetMatchedEcalPhiWedges() { return EcalPhiWedges; }
-    const std::vector<PhiWedge>& GetMatchedEcalPhiWedges() const { return EcalPhiWedges; }
+      std::vector<PhiWedge>& GetMatchedEcalPhiWedges() { return EcalPhiWedges; }
+      const std::vector<PhiWedge>& GetMatchedEcalPhiWedges() const { return EcalPhiWedges; }
 
-    edm::RefVector<EcalRecHitCollection>& GetEBRechits() { return ecalebrhRefs; }
-    const edm::RefVector<EcalRecHitCollection>& GetEBRechits() const { return ecalebrhRefs; }
+      edm::RefVector<EcalRecHitCollection>& GetEBRechits() { return ecalebrhRefs; }
+      const edm::RefVector<EcalRecHitCollection>& GetEBRechits() const { return ecalebrhRefs; }
 
-    edm::RefVector<EcalRecHitCollection>& GetEERechits() { return ecaleerhRefs; }
-    const edm::RefVector<EcalRecHitCollection>& GetEERechits() const { return ecaleerhRefs; }
+      edm::RefVector<EcalRecHitCollection>& GetEERechits() { return ecaleerhRefs; }
+      const edm::RefVector<EcalRecHitCollection>& GetEERechits() const { return ecaleerhRefs; }
 
-    edm::RefVector<HBHERecHitCollection>& GetHBHERechits() { return hbherhRefs; }
-    const edm::RefVector<HBHERecHitCollection>& GetHBHERechits() const { return hbherhRefs; }
+      edm::RefVector<HBHERecHitCollection>& GetHBHERechits() { return hbherhRefs; }
+      const edm::RefVector<HBHERecHitCollection>& GetHBHERechits() const { return hbherhRefs; }
 
-    bool GetSegmentIsHBCaloMatched() const { return segmentisHBcalomatched; }
-    bool GetSegmentIsHECaloMatched() const { return segmentisHEcalomatched; }
-    bool GetSegmentIsEBCaloMatched() const { return segmentisEBcalomatched; }
-    bool GetSegmentIsEECaloMatched() const { return segmentisEEcalomatched; }
+      bool GetSegmentIsHBCaloMatched() const { return segmentisHBcalomatched; }
+      bool GetSegmentIsHECaloMatched() const { return segmentisHEcalomatched; }
+      bool GetSegmentIsEBCaloMatched() const { return segmentisEBcalomatched; }
+      bool GetSegmentIsEECaloMatched() const { return segmentisEEcalomatched; }
 
-    bool GetHaloPatternFoundEB() const { return halopatternfoundEB; }
-    bool GetHaloPatternFoundEE() const { return halopatternfoundEE; }
-    bool GetHaloPatternFoundHB() const { return halopatternfoundHB; }
-    bool GetHaloPatternFoundHE() const { return halopatternfoundHE; }
+      bool GetHaloPatternFoundEB() const { return halopatternfoundEB; }
+      bool GetHaloPatternFoundEE() const { return halopatternfoundEE; }
+      bool GetHaloPatternFoundHB() const { return halopatternfoundHB; }
+      bool GetHaloPatternFoundHE() const { return halopatternfoundHE; }
 
-    //Setters
-    void SetMETOverSumEt(float x) { METOverSumEt_ = x; }
-    void SetMETCorrections(float x, float y) {
-      dMEx_ = x;
-      dMEy_ = y;
-    }
+      //Setters
+      void SetMETOverSumEt(float x) { METOverSumEt_ = x; }
+      void SetMETCorrections(float x, float y) {
+        dMEx_ = x;
+        dMEy_ = y;
+      }
 
-    void SetSegmentIsHBCaloMatched(bool b) { segmentisHBcalomatched = b; }
-    void SetSegmentIsHECaloMatched(bool b) { segmentisHEcalomatched = b; }
-    void SetSegmentIsEBCaloMatched(bool b) { segmentisEBcalomatched = b; }
-    void SetSegmentIsEECaloMatched(bool b) { segmentisEEcalomatched = b; }
-    void SetHaloPatternFoundEB(bool b) { halopatternfoundEB = b; }
-    void SetHaloPatternFoundEE(bool b) { halopatternfoundEE = b; }
-    void SetHaloPatternFoundHB(bool b) { halopatternfoundHB = b; }
-    void SetHaloPatternFoundHE(bool b) { halopatternfoundHE = b; }
+      void SetSegmentIsHBCaloMatched(bool b) { segmentisHBcalomatched = b; }
+      void SetSegmentIsHECaloMatched(bool b) { segmentisHEcalomatched = b; }
+      void SetSegmentIsEBCaloMatched(bool b) { segmentisEBcalomatched = b; }
+      void SetSegmentIsEECaloMatched(bool b) { segmentisEEcalomatched = b; }
+      void SetHaloPatternFoundEB(bool b) { halopatternfoundEB = b; }
+      void SetHaloPatternFoundEE(bool b) { halopatternfoundEE = b; }
+      void SetHaloPatternFoundHB(bool b) { halopatternfoundHB = b; }
+      void SetHaloPatternFoundHE(bool b) { halopatternfoundHE = b; }
 
-  private:
-    float METOverSumEt_;
-    float dMEx_;
-    float dMEy_;
-    float dSumEt_;
+    private:
+      float METOverSumEt_;
+      float dMEx_;
+      float dMEy_;
+      float dSumEt_;
 
-    std::vector<PhiWedge> HcalPhiWedges;
-    std::vector<PhiWedge> EcalPhiWedges;
+      std::vector<PhiWedge> HcalPhiWedges;
+      std::vector<PhiWedge> EcalPhiWedges;
 
-    bool segmentisEBcalomatched, segmentisEEcalomatched, segmentisHBcalomatched, segmentisHEcalomatched;
-    bool halopatternfoundEB, halopatternfoundEE, halopatternfoundHB, halopatternfoundHE;
+      bool segmentisEBcalomatched, segmentisEEcalomatched, segmentisHBcalomatched, segmentisHEcalomatched;
+      bool halopatternfoundEB, halopatternfoundEE, halopatternfoundHB, halopatternfoundHE;
 
-    edm::RefVector<EcalRecHitCollection> ecalebrhRefs;
-    edm::RefVector<EcalRecHitCollection> ecaleerhRefs;
-    edm::RefVector<HBHERecHitCollection> hbherhRefs;
-  };
+      edm::RefVector<EcalRecHitCollection> ecalebrhRefs;
+      edm::RefVector<EcalRecHitCollection> ecaleerhRefs;
+      edm::RefVector<HBHERecHitCollection> hbherhRefs;
+    };
+  }  // namespace io_v1
+  using GlobalHaloData = io_v1::GlobalHaloData;
 }  // namespace reco
 #endif

--- a/DataFormats/METReco/interface/HcalHaloData.h
+++ b/DataFormats/METReco/interface/HcalHaloData.h
@@ -34,36 +34,39 @@ struct HaloTowerStrip {
 };
 
 namespace reco {
+  namespace io_v1 {
 
-  class HcalHaloData {
-  public:
-    //constructor
-    HcalHaloData();
-    //destructor
-    ~HcalHaloData() {}
+    class HcalHaloData {
+    public:
+      //constructor
+      HcalHaloData();
+      //destructor
+      ~HcalHaloData() {}
 
-    // Return collection of 5-degree Phi Wedges built from Hcal RecHits
-    const std::vector<PhiWedge>& GetPhiWedges() const { return PhiWedgeCollection; }
-    std::vector<PhiWedge>& GetPhiWedges() { return PhiWedgeCollection; }
+      // Return collection of 5-degree Phi Wedges built from Hcal RecHits
+      const std::vector<PhiWedge>& GetPhiWedges() const { return PhiWedgeCollection; }
+      std::vector<PhiWedge>& GetPhiWedges() { return PhiWedgeCollection; }
 
-    // Return collection of problematic strips (pairs of # of problematic HCAL cells and CaloTowerDetId)
-    const std::vector<HaloTowerStrip>& getProblematicStrips() const { return problematicStripCollection; }
-    std::vector<HaloTowerStrip>& getProblematicStrips() { return problematicStripCollection; }
+      // Return collection of problematic strips (pairs of # of problematic HCAL cells and CaloTowerDetId)
+      const std::vector<HaloTowerStrip>& getProblematicStrips() const { return problematicStripCollection; }
+      std::vector<HaloTowerStrip>& getProblematicStrips() { return problematicStripCollection; }
 
-    const std::vector<HaloClusterCandidateHCAL>& getHaloClusterCandidatesHB() const { return thehaloclustercands_hb; }
-    std::vector<HaloClusterCandidateHCAL>& getHaloClusterCandidatesHB() { return thehaloclustercands_hb; }
+      const std::vector<HaloClusterCandidateHCAL>& getHaloClusterCandidatesHB() const { return thehaloclustercands_hb; }
+      std::vector<HaloClusterCandidateHCAL>& getHaloClusterCandidatesHB() { return thehaloclustercands_hb; }
 
-    const std::vector<HaloClusterCandidateHCAL>& getHaloClusterCandidatesHE() const { return thehaloclustercands_he; }
-    std::vector<HaloClusterCandidateHCAL>& getHaloClusterCandidatesHE() { return thehaloclustercands_he; }
+      const std::vector<HaloClusterCandidateHCAL>& getHaloClusterCandidatesHE() const { return thehaloclustercands_he; }
+      std::vector<HaloClusterCandidateHCAL>& getHaloClusterCandidatesHE() { return thehaloclustercands_he; }
 
-    void setHaloClusterCandidatesHB(const std::vector<HaloClusterCandidateHCAL>& x) { thehaloclustercands_hb = x; };
-    void setHaloClusterCandidatesHE(const std::vector<HaloClusterCandidateHCAL>& x) { thehaloclustercands_he = x; };
+      void setHaloClusterCandidatesHB(const std::vector<HaloClusterCandidateHCAL>& x) { thehaloclustercands_hb = x; };
+      void setHaloClusterCandidatesHE(const std::vector<HaloClusterCandidateHCAL>& x) { thehaloclustercands_he = x; };
 
-  private:
-    std::vector<PhiWedge> PhiWedgeCollection;
-    std::vector<HaloTowerStrip> problematicStripCollection;
-    std::vector<HaloClusterCandidateHCAL> thehaloclustercands_hb;
-    std::vector<HaloClusterCandidateHCAL> thehaloclustercands_he;
-  };
+    private:
+      std::vector<PhiWedge> PhiWedgeCollection;
+      std::vector<HaloTowerStrip> problematicStripCollection;
+      std::vector<HaloClusterCandidateHCAL> thehaloclustercands_hb;
+      std::vector<HaloClusterCandidateHCAL> thehaloclustercands_he;
+    };
+  }  // namespace io_v1
+  using HcalHaloData = io_v1::HcalHaloData;
 }  // namespace reco
 #endif

--- a/DataFormats/METReco/interface/MET.h
+++ b/DataFormats/METReco/interface/MET.h
@@ -37,59 +37,62 @@
 //____________________________________________________________________________||
 namespace reco {
   typedef ROOT::Math::SMatrix<double, 2> METCovMatrix;
+  namespace io_v1 {
 
-  class MET : public RecoCandidate {
-  public:
-    MET();
-    MET(const LorentzVector& p4_, const Point& vtx_, bool isWeighted = false);
-    MET(double sumet_, const LorentzVector& p4_, const Point& vtx_, bool isWeighted = false);
-    MET(double sumet_,
-        const std::vector<CorrMETData>& corr_,
-        const LorentzVector& p4_,
-        const Point& vtx_,
-        bool isWeighted = false);
+    class MET : public RecoCandidate {
+    public:
+      MET();
+      MET(const LorentzVector& p4_, const Point& vtx_, bool isWeighted = false);
+      MET(double sumet_, const LorentzVector& p4_, const Point& vtx_, bool isWeighted = false);
+      MET(double sumet_,
+          const std::vector<CorrMETData>& corr_,
+          const LorentzVector& p4_,
+          const Point& vtx_,
+          bool isWeighted = false);
 
-    MET* clone() const override;
+      MET* clone() const override;
 
-    //________________________________________________________________________||
-    //scalar sum of transverse energy over all objects
-    double sumEt() const { return sumet; }
-    //MET Significance = MET / std::sqrt(SumET)
-    double mEtSig() const { return (sumet ? (this->et() / std::sqrt(sumet)) : (0.0)); }
-    //real MET significance
-    double significance() const;
-    //longitudinal component of the vector sum of energy over all object
-    //(useful for data quality monitoring)
-    double e_longitudinal() const { return elongit; }
+      //________________________________________________________________________||
+      //scalar sum of transverse energy over all objects
+      double sumEt() const { return sumet; }
+      //MET Significance = MET / std::sqrt(SumET)
+      double mEtSig() const { return (sumet ? (this->et() / std::sqrt(sumet)) : (0.0)); }
+      //real MET significance
+      double significance() const;
+      //longitudinal component of the vector sum of energy over all object
+      //(useful for data quality monitoring)
+      double e_longitudinal() const { return elongit; }
 
-    //________________________________________________________________________||
-    //Define different methods for the corrections to individual MET elements
-    std::vector<double> dmEx() const;
-    std::vector<double> dmEy() const;
-    std::vector<double> dsumEt() const;
-    std::vector<CorrMETData> mEtCorr() const { return corr; }
+      //________________________________________________________________________||
+      //Define different methods for the corrections to individual MET elements
+      std::vector<double> dmEx() const;
+      std::vector<double> dmEy() const;
+      std::vector<double> dsumEt() const;
+      std::vector<CorrMETData> mEtCorr() const { return corr; }
 
-    //________________________________________________________________________||
-    void setSignificanceMatrix(const reco::METCovMatrix& matrix);
-    reco::METCovMatrix getSignificanceMatrix(void) const;
+      //________________________________________________________________________||
+      void setSignificanceMatrix(const reco::METCovMatrix& matrix);
+      reco::METCovMatrix getSignificanceMatrix(void) const;
 
-    ///  Set boolean if weights were applied by algorithm (e.g. PUPPI weights)
-    void setIsWeighted(bool isWeighted) { mIsWeighted = isWeighted; }
-    ///  boolean if weights were applied by algorithm (e.g. PUPPI weights)
-    int isWeighted() const { return mIsWeighted; }
+      ///  Set boolean if weights were applied by algorithm (e.g. PUPPI weights)
+      void setIsWeighted(bool isWeighted) { mIsWeighted = isWeighted; }
+      ///  boolean if weights were applied by algorithm (e.g. PUPPI weights)
+      int isWeighted() const { return mIsWeighted; }
 
-  private:
-    bool overlap(const Candidate&) const override;
-    double sumet;
-    double elongit;
-    // bookkeeping for the significance
-    double signif_dxx;
-    double signif_dyy;
-    double signif_dyx;
-    double signif_dxy;
-    std::vector<CorrMETData> corr;
-    bool mIsWeighted;
-  };
+    private:
+      bool overlap(const Candidate&) const override;
+      double sumet;
+      double elongit;
+      // bookkeeping for the significance
+      double signif_dxx;
+      double signif_dyy;
+      double signif_dyx;
+      double signif_dxy;
+      std::vector<CorrMETData> corr;
+      bool mIsWeighted;
+    };
+  }  // namespace io_v1
+  using MET = io_v1::MET;
 }  // namespace reco
 
 //____________________________________________________________________________||

--- a/DataFormats/METReco/interface/METFwd.h
+++ b/DataFormats/METReco/interface/METFwd.h
@@ -6,7 +6,10 @@
 #include "DataFormats/Common/interface/RefProd.h"
 
 namespace reco {
-  class MET;
+  namespace io_v1 {
+    class MET;
+  }
+  using MET = io_v1::MET;
   /// collection of MET objects
   typedef std::vector<MET> METCollection;
   /// edm references

--- a/DataFormats/METReco/interface/PFMET.h
+++ b/DataFormats/METReco/interface/PFMET.h
@@ -15,66 +15,69 @@ date: 10/27/08
 #include "DataFormats/METReco/interface/MET.h"
 #include "DataFormats/METReco/interface/SpecificPFMETData.h"
 namespace reco {
-  class PFMET : public MET {
-  public:
-    PFMET();
-    PFMET(const SpecificPFMETData& pf_data_,
-          double sumet_,
-          const LorentzVector& fP4,
-          const Point& fVertex,
-          bool isWeighted = false)
-        : MET(sumet_, fP4, fVertex, isWeighted), pf_data(pf_data_) {}
+  namespace io_v1 {
+    class PFMET : public MET {
+    public:
+      PFMET();
+      PFMET(const SpecificPFMETData& pf_data_,
+            double sumet_,
+            const LorentzVector& fP4,
+            const Point& fVertex,
+            bool isWeighted = false)
+          : MET(sumet_, fP4, fVertex, isWeighted), pf_data(pf_data_) {}
 
-    ~PFMET() override {}
+      ~PFMET() override {}
 
-    //getters
-    double photonEtFraction() const { return pf_data.NeutralEMFraction; }
-    double photonEt() const { return pf_data.NeutralEMFraction * sumEt(); }
+      //getters
+      double photonEtFraction() const { return pf_data.NeutralEMFraction; }
+      double photonEt() const { return pf_data.NeutralEMFraction * sumEt(); }
 
-    double neutralHadronEtFraction() const { return pf_data.NeutralHadFraction; }
-    double neutralHadronEt() const { return pf_data.NeutralHadFraction * sumEt(); }
+      double neutralHadronEtFraction() const { return pf_data.NeutralHadFraction; }
+      double neutralHadronEt() const { return pf_data.NeutralHadFraction * sumEt(); }
 
-    double electronEtFraction() const { return pf_data.ChargedEMFraction; }
-    double electronEt() const { return pf_data.ChargedEMFraction * sumEt(); }
+      double electronEtFraction() const { return pf_data.ChargedEMFraction; }
+      double electronEt() const { return pf_data.ChargedEMFraction * sumEt(); }
 
-    double chargedHadronEtFraction() const { return pf_data.ChargedHadFraction; }
-    double chargedHadronEt() const { return pf_data.ChargedHadFraction * sumEt(); }
+      double chargedHadronEtFraction() const { return pf_data.ChargedHadFraction; }
+      double chargedHadronEt() const { return pf_data.ChargedHadFraction * sumEt(); }
 
-    double muonEtFraction() const { return pf_data.MuonFraction; }
-    double muonEt() const { return pf_data.MuonFraction * sumEt(); }
+      double muonEtFraction() const { return pf_data.MuonFraction; }
+      double muonEt() const { return pf_data.MuonFraction * sumEt(); }
 
-    double HFHadronEtFraction() const { return pf_data.Type6Fraction; }
-    double HFHadronEt() const { return pf_data.Type6Fraction * sumEt(); }
+      double HFHadronEtFraction() const { return pf_data.Type6Fraction; }
+      double HFHadronEt() const { return pf_data.Type6Fraction * sumEt(); }
 
-    double HFEMEtFraction() const { return pf_data.Type7Fraction; }
-    double HFEMEt() const { return pf_data.Type7Fraction * sumEt(); }
+      double HFEMEtFraction() const { return pf_data.Type7Fraction; }
+      double HFEMEt() const { return pf_data.Type7Fraction * sumEt(); }
 
-    // Old accessors (should be removed in future)
-    double NeutralEMEtFraction() const { return pf_data.NeutralEMFraction; }
-    double NeutralEMEt() const { return pf_data.NeutralEMFraction * sumEt(); }
-    double NeutralHadEtFraction() const { return pf_data.NeutralHadFraction; }
-    double NeutralHadEt() const { return pf_data.NeutralHadFraction * sumEt(); }
-    double ChargedEMEtFraction() const { return pf_data.ChargedEMFraction; }
-    double ChargedEMEt() const { return pf_data.ChargedEMFraction * sumEt(); }
-    double ChargedHadEtFraction() const { return pf_data.ChargedHadFraction; }
-    double ChargedHadEt() const { return pf_data.ChargedHadFraction * sumEt(); }
-    double MuonEtFraction() const { return pf_data.MuonFraction; }
-    double MuonEt() const { return pf_data.MuonFraction * sumEt(); }
-    double Type6EtFraction() const { return pf_data.Type6Fraction; }
-    double Type6Et() const { return pf_data.Type6Fraction * sumEt(); }
-    double Type7EtFraction() const { return pf_data.Type7Fraction; }
-    double Type7Et() const { return pf_data.Type7Fraction * sumEt(); }
-    double NeutralEMFraction() const { return pf_data.NeutralEMFraction; }
-    double NeutralHadFraction() const { return pf_data.NeutralHadFraction; }
-    double ChargedEMFraction() const { return pf_data.ChargedEMFraction; }
-    double ChargedHadFraction() const { return pf_data.ChargedHadFraction; }
-    double MuonFraction() const { return pf_data.MuonFraction; }
+      // Old accessors (should be removed in future)
+      double NeutralEMEtFraction() const { return pf_data.NeutralEMFraction; }
+      double NeutralEMEt() const { return pf_data.NeutralEMFraction * sumEt(); }
+      double NeutralHadEtFraction() const { return pf_data.NeutralHadFraction; }
+      double NeutralHadEt() const { return pf_data.NeutralHadFraction * sumEt(); }
+      double ChargedEMEtFraction() const { return pf_data.ChargedEMFraction; }
+      double ChargedEMEt() const { return pf_data.ChargedEMFraction * sumEt(); }
+      double ChargedHadEtFraction() const { return pf_data.ChargedHadFraction; }
+      double ChargedHadEt() const { return pf_data.ChargedHadFraction * sumEt(); }
+      double MuonEtFraction() const { return pf_data.MuonFraction; }
+      double MuonEt() const { return pf_data.MuonFraction * sumEt(); }
+      double Type6EtFraction() const { return pf_data.Type6Fraction; }
+      double Type6Et() const { return pf_data.Type6Fraction * sumEt(); }
+      double Type7EtFraction() const { return pf_data.Type7Fraction; }
+      double Type7Et() const { return pf_data.Type7Fraction * sumEt(); }
+      double NeutralEMFraction() const { return pf_data.NeutralEMFraction; }
+      double NeutralHadFraction() const { return pf_data.NeutralHadFraction; }
+      double ChargedEMFraction() const { return pf_data.ChargedEMFraction; }
+      double ChargedHadFraction() const { return pf_data.ChargedHadFraction; }
+      double MuonFraction() const { return pf_data.MuonFraction; }
 
-    // block accessors
-    SpecificPFMETData getSpecific() const { return pf_data; }
+      // block accessors
+      SpecificPFMETData getSpecific() const { return pf_data; }
 
-  private:
-    SpecificPFMETData pf_data;
-  };
+    private:
+      SpecificPFMETData pf_data;
+    };
+  }  // namespace io_v1
+  using PFMET = io_v1::PFMET;
 }  // namespace reco
 #endif

--- a/DataFormats/METReco/interface/PFMETFwd.h
+++ b/DataFormats/METReco/interface/PFMETFwd.h
@@ -9,7 +9,10 @@
 #include "DataFormats/Common/interface/RefProd.h"
 
 namespace reco {
-  class PFMET;
+  namespace io_v1 {
+    class PFMET;
+  }
+  using PFMET = io_v1::PFMET;
   /// collection of PFMET objects
   typedef std::vector<PFMET> PFMETCollection;
   /// edm references

--- a/DataFormats/METReco/src/classes_def.xml
+++ b/DataFormats/METReco/src/classes_def.xml
@@ -46,72 +46,57 @@
    <version ClassVersion="11" checksum="2260055190"/>
   </class>
 
-  <class name="reco::MET" ClassVersion="13">
-   <version ClassVersion="13" checksum="3178745935"/>
-   <version ClassVersion="12" checksum="2052216433"/>
-   <version ClassVersion="11" checksum="1997832393"/>
-   <version ClassVersion="10" checksum="3898304931"/>
+  <class name="reco::io_v1::MET" ClassVersion="3">
+   <version ClassVersion="3" checksum="2308865949"/>
   </class>
-  <class name="edm::Wrapper<reco::MET>"/>
-  <class name="edm::Wrapper<std::vector<reco::MET> >"/>
-  <class name="std::vector<reco::MET>"/>
+  <class name="edm::Wrapper<reco::io_v1::MET>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::MET> >"/>
+  <class name="std::vector<reco::io_v1::MET>"/>
 
-  <class name="std::vector<edm::Ref<std::vector<reco::CaloMET>,reco::CaloMET,edm::refhelper::FindUsingAdvance<std::vector<reco::CaloMET>,reco::CaloMET> > >"/>
-  <class name="std::vector<edm::Ref<std::vector<reco::MET>,reco::MET,edm::refhelper::FindUsingAdvance<std::vector<reco::MET>,reco::MET> > >"/>
+  <class name="std::vector<edm::Ref<std::vector<reco::io_v1::CaloMET>,reco::io_v1::CaloMET,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::CaloMET>,reco::io_v1::CaloMET> > >"/>
+  <class name="std::vector<edm::Ref<std::vector<reco::io_v1::MET>,reco::io_v1::MET,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::MET>,reco::io_v1::MET> > >"/>
 
-  <class name="reco::CaloMET" ClassVersion="13">
-   <version ClassVersion="13" checksum="2658524417"/>
-   <version ClassVersion="12" checksum="3921700739"/>
-   <version ClassVersion="11" checksum="159132251"/>
-   <version ClassVersion="10" checksum="3207121440"/>
+  <class name="reco::io_v1::CaloMET" ClassVersion="3">
+   <version ClassVersion="3" checksum="271366923"/>
   </class>
-  <class name="edm::Wrapper<reco::CaloMET>"/>
-  <class name="edm::Wrapper<std::vector<reco::CaloMET> >"/>
-  <class name="std::vector<reco::CaloMET>"/>
+  <class name="edm::Wrapper<reco::io_v1::CaloMET>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::CaloMET> >"/>
+  <class name="std::vector<reco::io_v1::CaloMET>"/>
 
-  <class name="reco::PFMET" ClassVersion="13">
-   <version ClassVersion="13" checksum="1267179224"/>
-   <version ClassVersion="12" checksum="3350721210"/>
-   <version ClassVersion="11" checksum="3463342610"/>
-   <version ClassVersion="10" checksum="3708270533"/>
+  <class name="reco::io_v1::PFMET" ClassVersion="3">
+   <version ClassVersion="3" checksum="1535596016"/>
   </class>
-  <class name="edm::Wrapper<reco::PFMET>"/>
-  <class name="edm::Wrapper<std::vector<reco::PFMET> >"/>
-  <class name="std::vector<reco::PFMET>"/>
-  <class name="std::vector<edm::Ref<std::vector<reco::PFMET> > >"/>
+  <class name="edm::Wrapper<reco::io_v1::PFMET>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::PFMET> >"/>
+  <class name="std::vector<reco::io_v1::PFMET>"/>
+  <class name="std::vector<edm::Ref<std::vector<reco::io_v1::PFMET> > >"/>
 
-  <class name="reco::PFClusterMET" ClassVersion="13">
-   <version ClassVersion="13" checksum="520383985"/>
-   <version ClassVersion="12" checksum="3688821779"/>
-   <version ClassVersion="11" checksum="3634437739"/>
-   <version ClassVersion="10" checksum="3408846646"/>
+  <class name="reco::PFClusterMET" ClassVersion="3">
+   <version ClassVersion="3" checksum="3859867843"/>
   </class>
   <class name="edm::Wrapper<reco::PFClusterMET>"/>
   <class name="edm::Wrapper<std::vector<reco::PFClusterMET> >"/>
   <class name="std::vector<reco::PFClusterMET>"/>
 
 
-  <class name="reco::GenMET" ClassVersion="13">
-   <version ClassVersion="13" checksum="2800901046"/>
-   <version ClassVersion="12" checksum="77942440"/>
-   <version ClassVersion="11" checksum="1091535040"/>
-   <version ClassVersion="10" checksum="595237107"/>
+  <class name="reco::io_v1::GenMET" ClassVersion="3">
+   <version ClassVersion="3" checksum="2887868242"/>
   </class>
-  <class name="edm::Wrapper<reco::GenMET>"/>
-  <class name="edm::Wrapper<std::vector<reco::GenMET> >"/>
-  <class name="std::vector<reco::GenMET>"/>
+  <class name="edm::Wrapper<reco::io_v1::GenMET>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::GenMET> >"/>
+  <class name="std::vector<reco::io_v1::GenMET>"/>
 
-  <class name="edm::RefProd<std::vector<reco::MET> >"/>
-  <class name="edm::RefVector<std::vector<reco::MET>,reco::MET,edm::refhelper::FindUsingAdvance<std::vector<reco::MET>,reco::MET> >"/>
-  <class name="edm::Ref<std::vector<reco::MET>,reco::MET,edm::refhelper::FindUsingAdvance<std::vector<reco::MET>,reco::MET> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::MET> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::MET>,reco::io_v1::MET,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::MET>,reco::io_v1::MET> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::MET>,reco::io_v1::MET,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::MET>,reco::io_v1::MET> >"/>
 
-  <class name="edm::RefProd<std::vector<reco::CaloMET> >"/>
-  <class name="edm::RefVector<std::vector<reco::CaloMET>,reco::CaloMET,edm::refhelper::FindUsingAdvance<std::vector<reco::CaloMET>,reco::CaloMET> >"/>
-  <class name="edm::Ref<std::vector<reco::CaloMET>,reco::CaloMET,edm::refhelper::FindUsingAdvance<std::vector<reco::CaloMET>,reco::CaloMET> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::CaloMET> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::CaloMET>,reco::io_v1::CaloMET,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::CaloMET>,reco::io_v1::CaloMET> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::CaloMET>,reco::io_v1::CaloMET,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::CaloMET>,reco::io_v1::CaloMET> >"/>
 
-  <class name="edm::RefProd<std::vector<reco::PFMET> >"/>
-  <class name="edm::RefVector<std::vector<reco::PFMET>,reco::PFMET,edm::refhelper::FindUsingAdvance<std::vector<reco::PFMET>,reco::PFMET> >"/>
-  <class name="edm::Ref<std::vector<reco::PFMET>,reco::PFMET,edm::refhelper::FindUsingAdvance<std::vector<reco::PFMET>,reco::PFMET> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::PFMET> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::PFMET>,reco::io_v1::PFMET,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFMET>,reco::io_v1::PFMET> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::PFMET>,reco::io_v1::PFMET,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFMET>,reco::io_v1::PFMET> >"/>
 
   <class name="edm::RefProd<std::vector<reco::PFClusterMET> >"/>
   <class name="edm::RefVector<std::vector<reco::PFClusterMET>,reco::PFClusterMET,edm::refhelper::FindUsingAdvance<std::vector<reco::PFClusterMET>,reco::PFClusterMET> >"/>
@@ -133,25 +118,20 @@
   <class name="reco::HcalNoiseRBXCollection"/>
   <class name="edm::Wrapper<reco::HcalNoiseRBXCollection>"/>
 
-  <class name="HcalNoiseSummary" ClassVersion="16">
-   <version ClassVersion="11" checksum="664452001"/>
-   <version ClassVersion="12" checksum="4280559065"/>
-   <version ClassVersion="13" checksum="382065414"/>
-   <version ClassVersion="14" checksum="651605939"/>
-   <version ClassVersion="15" checksum="2415916091"/>
-   <version ClassVersion="16" checksum="1886001321"/>
+  <class name="HcalNoiseSummary" ClassVersion="3">
+   <version ClassVersion="3" checksum="932955705"/>
   </class>
   <class name="edm::Wrapper<HcalNoiseSummary>"/>
 
-  <class name="edm::RefProd<std::vector<reco::GenMET> >"/>
-  <class name="edm::RefVector<std::vector<reco::GenMET>,reco::GenMET,edm::refhelper::FindUsingAdvance<std::vector<reco::GenMET>,reco::GenMET> >"/>
-  <class name="edm::Ref<std::vector<reco::GenMET>,reco::GenMET,edm::refhelper::FindUsingAdvance<std::vector<reco::GenMET>,reco::GenMET> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::GenMET> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::GenMET>,reco::io_v1::GenMET,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GenMET>,reco::io_v1::GenMET> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::GenMET>,reco::io_v1::GenMET,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GenMET>,reco::io_v1::GenMET> >"/>
 
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::MET>,reco::MET,edm::refhelper::FindUsingAdvance<std::vector<reco::MET>,reco::MET> > >" />
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::CaloMET>,reco::CaloMET,edm::refhelper::FindUsingAdvance<std::vector<reco::CaloMET>,reco::CaloMET> > >" />
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::PFMET>,reco::PFMET,edm::refhelper::FindUsingAdvance<std::vector<reco::PFMET>,reco::PFMET> > >" />
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::PFClusterMET>,reco::PFClusterMET,edm::refhelper::FindUsingAdvance<std::vector<reco::PFClusterMET>,reco::PFClusterMET> > >" />
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::GenMET>,reco::GenMET,edm::refhelper::FindUsingAdvance<std::vector<reco::GenMET>,reco::GenMET> > >" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<reco::io_v1::MET>,reco::io_v1::MET,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::MET>,reco::io_v1::MET> > >" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<reco::io_v1::CaloMET>,reco::io_v1::CaloMET,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::CaloMET>,reco::io_v1::CaloMET> > >" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<reco::io_v1::PFMET>,reco::io_v1::PFMET,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFMET>,reco::io_v1::PFMET> > >" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<reco::PFClusterMET>,reco::PFClusterMET,edm::refhelper::FindUsingAdvance<std::vector<reco::PFClusterMET>,reco::PFClusterMET> > >" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<reco::io_v1::GenMET>,reco::io_v1::GenMET,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GenMET>,reco::io_v1::GenMET> > >" />
 
   <class name="edm::reftobase::RefHolder<reco::METRef>" />
   <class name="edm::reftobase::RefHolder<reco::CaloMETRef>" />
@@ -166,20 +146,15 @@
   <class name="std::vector<reco::PhiWedge>"/>
   <class name="std::vector<reco::PhiWedge>::iterator"/>
 
-  <class name="reco::EcalHaloData" ClassVersion="11">
-   <version ClassVersion="11" checksum="3422191835"/>
-   <version ClassVersion="10" checksum="520399124"/>
+  <class name="reco::io_v1::EcalHaloData" ClassVersion="3">
+   <version ClassVersion="3" checksum="2280589981"/>
   </class>
-  <class name="edm::Wrapper<reco::EcalHaloData>"/>
+  <class name="edm::Wrapper<reco::io_v1::EcalHaloData>"/>
 
-  <class name="reco::HcalHaloData" ClassVersion="14">
-   <version ClassVersion="14" checksum="4287321322"/>
-   <version ClassVersion="13" checksum="3305429659"/>
-   <version ClassVersion="12" checksum="3928363167"/>
-   <version ClassVersion="10" checksum="3928363167"/>
-   <version ClassVersion="11" checksum="3305429659"/>
+  <class name="reco::io_v1::HcalHaloData" ClassVersion="3">
+   <version ClassVersion="3" checksum="3753607864"/>
   </class>
-  <class name="edm::Wrapper<reco::HcalHaloData>"/>
+  <class name="edm::Wrapper<reco::io_v1::HcalHaloData>"/>
 
   <class name="HaloTowerStrip" ClassVersion="3">
    <version ClassVersion="3" checksum="3149281836"/>
@@ -188,30 +163,26 @@
   <class name="std::vector<HaloTowerStrip>"/>
   <class name="edm::Wrapper<std::vector<HaloTowerStrip> >"/>
 
-  <class name="reco::CSCHaloData" ClassVersion="3">
-   <version ClassVersion="3" checksum="4033210994"/>
+  <class name="reco::io_v1::CSCHaloData" ClassVersion="3">
+   <version ClassVersion="3" checksum="3612104444"/>
   </class>
-  <class name="edm::Wrapper<reco::CSCHaloData>"/>
+  <class name="edm::Wrapper<reco::io_v1::CSCHaloData>"/>
 
-  <class name="reco::GlobalHaloData" ClassVersion="11">
-   <version ClassVersion="11" checksum="2525701804"/>
-   <version ClassVersion="10" checksum="4148277690"/>
+  <class name="reco::io_v1::GlobalHaloData" ClassVersion="3">
+   <version ClassVersion="3" checksum="3627454218"/>
   </class>
-  <class name="edm::Wrapper<reco::GlobalHaloData>"/>
+  <class name="edm::Wrapper<reco::io_v1::GlobalHaloData>"/>
 
-  <class name="reco::BeamHaloSummary" ClassVersion="13">
-   <version ClassVersion="13" checksum="146570384"/>
-   <version ClassVersion="12" checksum="1514181401"/>
-   <version ClassVersion="10" checksum="1514181401"/>
-   <version ClassVersion="11" checksum="146570384"/>
+  <class name="reco::io_v1::BeamHaloSummary" ClassVersion="3">
+   <version ClassVersion="3" checksum="522749358"/>
   </class>
-  <class name="edm::Wrapper<reco::BeamHaloSummary>"/>
+  <class name="edm::Wrapper<reco::io_v1::BeamHaloSummary>"/>
 
   <class name="std::vector<Point3DBase<float,GlobalTag> >"/>
   <class name="edm::Wrapper<std::vector<Point3DBase<float,GlobalTag> > >"/>
 
-  <class name="edm::Ptr<reco::MET>" />
-  <class name="edm::PtrVector<reco::MET>" />
+  <class name="edm::Ptr<reco::io_v1::MET>" />
+  <class name="edm::PtrVector<reco::io_v1::MET>" />
 
   <class name="AnomalousECALVariables"/>
   <class name="edm::Wrapper<AnomalousECALVariables>"/>

--- a/DataFormats/MuonReco/interface/CaloMuon.h
+++ b/DataFormats/MuonReco/interface/CaloMuon.h
@@ -17,63 +17,67 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  class CaloMuon {
-  public:
-    CaloMuon();
-    virtual ~CaloMuon() {}
+    class CaloMuon {
+    public:
+      CaloMuon();
+      virtual ~CaloMuon() {}
 
-    /// reference to Track reconstructed in the tracker only
-    virtual TrackRef innerTrack() const { return innerTrack_; }
-    virtual TrackRef track() const { return innerTrack(); }
-    /// set reference to Track
-    virtual void setInnerTrack(const TrackRef& t) { innerTrack_ = t; }
-    virtual void setTrack(const TrackRef& t) { setInnerTrack(t); }
-    /// energy deposition
-    bool isEnergyValid() const { return energyValid_; }
-    /// get energy deposition information
-    MuonEnergy calEnergy() const { return calEnergy_; }
-    /// set energy deposition information
-    void setCalEnergy(const MuonEnergy& calEnergy) {
-      calEnergy_ = calEnergy;
-      energyValid_ = true;
-    }
+      /// reference to Track reconstructed in the tracker only
+      virtual TrackRef innerTrack() const { return innerTrack_; }
+      virtual TrackRef track() const { return innerTrack(); }
+      /// set reference to Track
+      virtual void setInnerTrack(const TrackRef& t) { innerTrack_ = t; }
+      virtual void setTrack(const TrackRef& t) { setInnerTrack(t); }
+      /// energy deposition
+      bool isEnergyValid() const { return energyValid_; }
+      /// get energy deposition information
+      MuonEnergy calEnergy() const { return calEnergy_; }
+      /// set energy deposition information
+      void setCalEnergy(const MuonEnergy& calEnergy) {
+        calEnergy_ = calEnergy;
+        energyValid_ = true;
+      }
 
-    /// Muon hypothesis compatibility block
-    /// Relative likelihood based on ECAL, HCAL, HO energy defined as
-    /// L_muon/(L_muon+L_not_muon)
-    float caloCompatibility() const { return caloCompatibility_; }
-    void setCaloCompatibility(float input) { caloCompatibility_ = input; }
-    bool isCaloCompatibilityValid() const { return caloCompatibility_ >= 0; }
+      /// Muon hypothesis compatibility block
+      /// Relative likelihood based on ECAL, HCAL, HO energy defined as
+      /// L_muon/(L_muon+L_not_muon)
+      float caloCompatibility() const { return caloCompatibility_; }
+      void setCaloCompatibility(float input) { caloCompatibility_ = input; }
+      bool isCaloCompatibilityValid() const { return caloCompatibility_ >= 0; }
 
-    /// a bunch of useful accessors
-    int charge() const { return innerTrack_.get()->charge(); }
-    /// polar angle
-    double theta() const { return innerTrack_.get()->theta(); }
-    /// momentum vector magnitude
-    double p() const { return innerTrack_.get()->p(); }
-    /// track transverse momentum
-    double pt() const { return innerTrack_.get()->pt(); }
-    /// x coordinate of momentum vector
-    double px() const { return innerTrack_.get()->px(); }
-    /// y coordinate of momentum vector
-    double py() const { return innerTrack_.get()->py(); }
-    /// z coordinate of momentum vector
-    double pz() const { return innerTrack_.get()->pz(); }
-    /// azimuthal angle of momentum vector
-    double phi() const { return innerTrack_.get()->phi(); }
-    /// pseudorapidity of momentum vector
-    double eta() const { return innerTrack_.get()->eta(); }
+      /// a bunch of useful accessors
+      int charge() const { return innerTrack_.get()->charge(); }
+      /// polar angle
+      double theta() const { return innerTrack_.get()->theta(); }
+      /// momentum vector magnitude
+      double p() const { return innerTrack_.get()->p(); }
+      /// track transverse momentum
+      double pt() const { return innerTrack_.get()->pt(); }
+      /// x coordinate of momentum vector
+      double px() const { return innerTrack_.get()->px(); }
+      /// y coordinate of momentum vector
+      double py() const { return innerTrack_.get()->py(); }
+      /// z coordinate of momentum vector
+      double pz() const { return innerTrack_.get()->pz(); }
+      /// azimuthal angle of momentum vector
+      double phi() const { return innerTrack_.get()->phi(); }
+      /// pseudorapidity of momentum vector
+      double eta() const { return innerTrack_.get()->eta(); }
 
-  private:
-    /// reference to Track reconstructed in the tracker only
-    TrackRef innerTrack_;
-    /// energy deposition
-    MuonEnergy calEnergy_;
-    bool energyValid_;
-    /// muon hypothesis compatibility with observer calorimeter energy
-    float caloCompatibility_;
-  };
+    private:
+      /// reference to Track reconstructed in the tracker only
+      TrackRef innerTrack_;
+      /// energy deposition
+      MuonEnergy calEnergy_;
+      bool energyValid_;
+      /// muon hypothesis compatibility with observer calorimeter energy
+      float caloCompatibility_;
+    };
+
+  }  // namespace io_v1
+  using CaloMuon = io_v1::CaloMuon;
 
 }  // namespace reco
 

--- a/DataFormats/MuonReco/interface/Muon.h
+++ b/DataFormats/MuonReco/interface/Muon.h
@@ -23,418 +23,421 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  class Muon : public RecoCandidate {
-  public:
-    Muon();
-    /// constructor from values
-    Muon(Charge, const LorentzVector&, const Point& = Point(0, 0, 0));
-    /// create a clone
-    Muon* clone() const override;
+    class Muon : public RecoCandidate {
+    public:
+      Muon();
+      /// constructor from values
+      Muon(Charge, const LorentzVector&, const Point& = Point(0, 0, 0));
+      /// create a clone
+      Muon* clone() const override;
 
-    /// map for Global Muon refitters
-    enum MuonTrackType { None, InnerTrack, OuterTrack, CombinedTrack, TPFMS, Picky, DYT };
-    typedef std::map<MuonTrackType, reco::TrackRef> MuonTrackRefMap;
-    typedef std::pair<TrackRef, Muon::MuonTrackType> MuonTrackTypePair;
+      /// map for Global Muon refitters
+      enum MuonTrackType { None, InnerTrack, OuterTrack, CombinedTrack, TPFMS, Picky, DYT };
+      typedef std::map<MuonTrackType, reco::TrackRef> MuonTrackRefMap;
+      typedef std::pair<TrackRef, Muon::MuonTrackType> MuonTrackTypePair;
 
-    ///
-    /// ====================== TRACK BLOCK ===========================
-    ///
-    /// reference to Track reconstructed in the tracker only
-    using reco::RecoCandidate::track;
-    virtual TrackRef innerTrack() const { return innerTrack_; }
-    TrackRef track() const override { return innerTrack(); }
-    /// reference to Track reconstructed in the muon detector only
-    virtual TrackRef outerTrack() const { return outerTrack_; }
-    TrackRef standAloneMuon() const override { return outerTrack(); }
-    /// reference to Track reconstructed in both tracked and muon detector
-    virtual TrackRef globalTrack() const { return globalTrack_; }
-    TrackRef combinedMuon() const override { return globalTrack(); }
+      ///
+      /// ====================== TRACK BLOCK ===========================
+      ///
+      /// reference to Track reconstructed in the tracker only
+      using reco::RecoCandidate::track;
+      virtual TrackRef innerTrack() const { return innerTrack_; }
+      TrackRef track() const override { return innerTrack(); }
+      /// reference to Track reconstructed in the muon detector only
+      virtual TrackRef outerTrack() const { return outerTrack_; }
+      TrackRef standAloneMuon() const override { return outerTrack(); }
+      /// reference to Track reconstructed in both tracked and muon detector
+      virtual TrackRef globalTrack() const { return globalTrack_; }
+      TrackRef combinedMuon() const override { return globalTrack(); }
 
-    virtual TrackRef tpfmsTrack() const { return muonTrackFromMap(TPFMS); }
-    virtual TrackRef pickyTrack() const { return muonTrackFromMap(Picky); }
-    virtual TrackRef dytTrack() const { return muonTrackFromMap(DYT); }
+      virtual TrackRef tpfmsTrack() const { return muonTrackFromMap(TPFMS); }
+      virtual TrackRef pickyTrack() const { return muonTrackFromMap(Picky); }
+      virtual TrackRef dytTrack() const { return muonTrackFromMap(DYT); }
 
-    const Track* bestTrack() const override { return muonTrack(bestTrackType_).get(); }
-    TrackBaseRef bestTrackRef() const override { return reco::TrackBaseRef(muonTrack(bestTrackType_)); }
-    virtual TrackRef muonBestTrack() const { return muonTrack(bestTrackType_); }
-    virtual MuonTrackType muonBestTrackType() const { return bestTrackType_; }
-    virtual TrackRef tunePMuonBestTrack() const { return muonTrack(bestTunePTrackType_); }
-    virtual MuonTrackType tunePMuonBestTrackType() const { return bestTunePTrackType_; }
+      const Track* bestTrack() const override { return muonTrack(bestTrackType_).get(); }
+      TrackBaseRef bestTrackRef() const override { return reco::TrackBaseRef(muonTrack(bestTrackType_)); }
+      virtual TrackRef muonBestTrack() const { return muonTrack(bestTrackType_); }
+      virtual MuonTrackType muonBestTrackType() const { return bestTrackType_; }
+      virtual TrackRef tunePMuonBestTrack() const { return muonTrack(bestTunePTrackType_); }
+      virtual MuonTrackType tunePMuonBestTrackType() const { return bestTunePTrackType_; }
 
-    bool isAValidMuonTrack(const MuonTrackType& type) const;
-    TrackRef muonTrack(const MuonTrackType&) const;
+      bool isAValidMuonTrack(const MuonTrackType& type) const;
+      TrackRef muonTrack(const MuonTrackType&) const;
 
-    TrackRef muonTrackFromMap(const MuonTrackType& type) const {
-      MuonTrackRefMap::const_iterator iter = refittedTrackMap_.find(type);
-      if (iter != refittedTrackMap_.end())
-        return iter->second;
-      else
-        return TrackRef();
-    }
-
-    /// set reference to Track
-    virtual void setInnerTrack(const TrackRef& t);
-    virtual void setTrack(const TrackRef& t);
-    /// set reference to Track
-    virtual void setOuterTrack(const TrackRef& t);
-    virtual void setStandAlone(const TrackRef& t);
-    /// set reference to Track
-    virtual void setGlobalTrack(const TrackRef& t);
-    virtual void setCombined(const TrackRef& t);
-    // set reference to the Best Track
-    virtual void setBestTrack(MuonTrackType muonType) { bestTrackType_ = muonType; }
-    // set reference to the Best Track by PF
-    virtual void setTunePBestTrack(MuonTrackType muonType) { bestTunePTrackType_ = muonType; }
-
-    void setMuonTrack(const MuonTrackType&, const TrackRef&);
-
-    ///set reference to PFCandidate
-    ///
-    /// ====================== PF BLOCK ===========================
-    ///
-
-    reco::Candidate::LorentzVector pfP4() const { return pfP4_; }
-    virtual void setPFP4(const reco::Candidate::LorentzVector& p4_);
-
-    ///
-    /// ====================== ENERGY BLOCK ===========================
-    ///
-    /// energy deposition
-    bool isEnergyValid() const { return energyValid_; }
-    /// get energy deposition information
-    MuonEnergy calEnergy() const { return calEnergy_; }
-    /// set energy deposition information
-    void setCalEnergy(const MuonEnergy& calEnergy) {
-      calEnergy_ = calEnergy;
-      energyValid_ = true;
-    }
-
-    ///
-    /// ====================== Quality BLOCK ===========================
-    ///
-    /// energy deposition
-    bool isQualityValid() const { return qualityValid_; }
-    /// get energy deposition information
-    MuonQuality combinedQuality() const { return combinedQuality_; }
-    /// set energy deposition information
-    void setCombinedQuality(const MuonQuality& combinedQuality) {
-      combinedQuality_ = combinedQuality;
-      qualityValid_ = true;
-    }
-
-    ///
-    /// ====================== TIMING BLOCK ===========================
-    ///
-    /// timing information
-    bool isTimeValid() const { return (time_.nDof > 0); }
-    /// get DT/CSC combined timing information
-    MuonTime time() const { return time_; }
-    /// set DT/CSC combined timing information
-    void setTime(const MuonTime& time) { time_ = time; }
-    /// get RPC timing information
-    MuonTime rpcTime() const { return rpcTime_; }
-    /// set RPC timing information
-    void setRPCTime(const MuonTime& time) { rpcTime_ = time; }
-
-    ///
-    /// ====================== MUON MATCH BLOCK ===========================
-    ///
-    bool isMatchesValid() const { return matchesValid_; }
-    /// get muon matching information
-    std::vector<MuonChamberMatch>& matches() { return muMatches_; }
-    const std::vector<MuonChamberMatch>& matches() const { return muMatches_; }
-    /// set muon matching information
-    void setMatches(const std::vector<MuonChamberMatch>& matches) {
-      muMatches_ = matches;
-      matchesValid_ = true;
-    }
-
-    ///
-    /// ====================== MUON COMPATIBILITY BLOCK ===========================
-    ///
-    /// Relative likelihood based on ECAL, HCAL, HO energy defined as
-    /// L_muon/(L_muon+L_not_muon)
-    float caloCompatibility() const { return caloCompatibility_; }
-    void setCaloCompatibility(float input) { caloCompatibility_ = input; }
-    bool isCaloCompatibilityValid() const { return caloCompatibility_ >= 0; }
-
-    ///
-    /// ====================== ISOLATION BLOCK ===========================
-    ///
-    /// Summary of muon isolation information
-    const MuonIsolation& isolationR03() const { return isolationR03_; }
-    const MuonIsolation& isolationR05() const { return isolationR05_; }
-
-    const MuonPFIsolation& pfIsolationR03() const { return pfIsolationR03_; }
-    const MuonPFIsolation& pfMeanDRIsoProfileR03() const { return pfIsoMeanDRR03_; }
-    const MuonPFIsolation& pfSumDRIsoProfileR03() const { return pfIsoSumDRR03_; }
-    const MuonPFIsolation& pfIsolationR04() const { return pfIsolationR04_; }
-    const MuonPFIsolation& pfMeanDRIsoProfileR04() const { return pfIsoMeanDRR04_; }
-    const MuonPFIsolation& pfSumDRIsoProfileR04() const { return pfIsoSumDRR04_; }
-
-    void setIsolation(const MuonIsolation& isoR03, const MuonIsolation& isoR05);
-    bool isIsolationValid() const { return isolationValid_; }
-    void setPFIsolation(const std::string& label, const reco::MuonPFIsolation& deposit);
-
-    bool isPFIsolationValid() const { return pfIsolationValid_; }
-
-    /// define arbitration schemes
-    // WARNING: There can be not more than 7 arbritration types. If
-    //          have more it will break the matching logic for types
-    //          defined in MuonSegmentMatch
-
-    enum ArbitrationType {
-      NoArbitration,
-      SegmentArbitration,
-      SegmentAndTrackArbitration,
-      SegmentAndTrackArbitrationCleaned,
-      RPCHitAndTrackArbitration,
-      GEMSegmentAndTrackArbitration,
-      ME0SegmentAndTrackArbitration,
-      GEMHitAndTrackArbitration
-    };
-
-    ///
-    /// ====================== STANDARD SELECTORS ===========================
-    ///
-    // When adding new selectors, also update DataFormats/MuonReco/interface/MuonSelectors.h string to enum map
-    enum Selector {
-      CutBasedIdLoose = 0,
-      CutBasedIdMedium = 1,
-      CutBasedIdMediumPrompt = 2,  // medium with IP cuts
-      CutBasedIdTight = 3,
-      CutBasedIdGlobalHighPt = 4,  // high pt muon for Z',W' (better momentum resolution)
-      CutBasedIdTrkHighPt = 5,     // high pt muon for boosted Z (better efficiency)
-      PFIsoVeryLoose = 6,          // reliso<0.40
-      PFIsoLoose = 7,              // reliso<0.25
-      PFIsoMedium = 8,             // reliso<0.20
-      PFIsoTight = 9,              // reliso<0.15
-      PFIsoVeryTight = 10,         // reliso<0.10
-      TkIsoLoose = 11,             // reliso<0.10
-      TkIsoTight = 12,             // reliso<0.05
-      SoftCutBasedId = 13,
-      SoftMvaId = 14,
-      MvaLoose = 15,
-      MvaMedium = 16,
-      MvaTight = 17,
-      MiniIsoLoose = 18,      // reliso<0.40
-      MiniIsoMedium = 19,     // reliso<0.20
-      MiniIsoTight = 20,      // reliso<0.10
-      MiniIsoVeryTight = 21,  // reliso<0.05
-      TriggerIdLoose = 22,    // robust selector for HLT
-      InTimeMuon = 23,
-      PFIsoVeryVeryTight = 24,  // reliso<0.05
-      MultiIsoLoose = 25,       // miniIso with ptRatio and ptRel
-      MultiIsoMedium = 26,      // miniIso with ptRatio and ptRel
-      PuppiIsoLoose = 27,
-      PuppiIsoMedium = 28,
-      PuppiIsoTight = 29,
-      MvaVTight = 30,
-      MvaVVTight = 31,
-      LowPtMvaLoose = 32,
-      LowPtMvaMedium = 33,
-      MvaIDwpMedium = 34,
-      MvaIDwpTight = 35,
-    };
-
-    bool passed(uint64_t selection) const { return (selectors_ & selection) == selection; }
-    bool passed(Selector selection) const { return passed(static_cast<uint64_t>(1UL << selection)); }
-    uint64_t selectors() const { return selectors_; }
-    void setSelectors(uint64_t selectors) { selectors_ = selectors; }
-    void setSelector(Selector selector, bool passed) {
-      auto selector64 = 1UL << selector;
-      if (passed)
-        selectors_ |= selector64;
-      else
-        selectors_ &= ~selector64;
-    }
-
-    ///
-    /// ====================== USEFUL METHODs ===========================
-    ///
-    /// number of chambers (MuonChamberMatches include RPC rolls, GEM and ME0 segments)
-    int numberOfChambers() const { return muMatches_.size(); }
-    /// number of chambers CSC or DT matches only (MuonChamberMatches include RPC rolls)
-    int numberOfChambersCSCorDT() const;
-    /// get number of chambers with matched segments
-    int numberOfMatches(ArbitrationType type = SegmentAndTrackArbitration) const;
-    /// get number of stations with matched segments
-    /// just adds the bits returned by stationMask
-    int numberOfMatchedStations(ArbitrationType type = SegmentAndTrackArbitration) const;
-    /// expected number of stations with matching segments based on the absolute
-    /// distance from the edge of a chamber
-    unsigned int expectedNnumberOfMatchedStations(float minDistanceFromEdge = 10.0) const;
-    /// get bit map of stations with matched segments
-    /// bits 0-1-2-3 = DT stations 1-2-3-4
-    /// bits 4-5-6-7 = CSC stations 1-2-3-4
-    unsigned int stationMask(ArbitrationType type = SegmentAndTrackArbitration) const;
-    /// get bit map of stations with tracks within
-    /// given distance (in cm) of chamber edges
-    /// bit assignments are same as above
-    int numberOfMatchedRPCLayers(ArbitrationType type = RPCHitAndTrackArbitration) const;
-    unsigned int RPClayerMask(ArbitrationType type = RPCHitAndTrackArbitration) const;
-    unsigned int stationGapMaskDistance(float distanceCut = 10.) const;
-    /// same as above for given number of sigmas
-    unsigned int stationGapMaskPull(float sigmaCut = 3.) const;
-    /// # of digis in a given station layer
-    int nDigisInStation(int station, int muonSubdetId) const;
-    /// tag a shower in a given station layer
-    bool hasShowerInStation(int station, int muonSubdetId, int nDtDigisCut = 20, int nCscDigisCut = 36) const;
-    /// count the number of showers along a muon track
-    int numberOfShowers(int nDtDigisCut = 20, int nCscDigisCut = 36) const;
-
-    /// muon type - type of the algorithm that reconstructed this muon
-    /// multiple algorithms can reconstruct the same muon
-    static const unsigned int GlobalMuon = 1 << 1;
-    static const unsigned int TrackerMuon = 1 << 2;
-    static const unsigned int StandAloneMuon = 1 << 3;
-    static const unsigned int CaloMuon = 1 << 4;
-    static const unsigned int PFMuon = 1 << 5;
-    static const unsigned int RPCMuon = 1 << 6;
-    static const unsigned int GEMMuon = 1 << 7;
-    static const unsigned int ME0Muon = 1 << 8;
-
-    void setType(unsigned int type) { type_ = type; }
-    unsigned int type() const { return type_; }
-
-    // override of method in base class reco::Candidate
-    bool isMuon() const override { return true; }
-    bool isGlobalMuon() const override { return type_ & GlobalMuon; }
-    bool isTrackerMuon() const override { return type_ & TrackerMuon; }
-    bool isStandAloneMuon() const override { return type_ & StandAloneMuon; }
-    bool isCaloMuon() const override { return type_ & CaloMuon; }
-    bool isPFMuon() const { return type_ & PFMuon; }  //fix me ! Has to go to type
-    bool isRPCMuon() const { return type_ & RPCMuon; }
-    bool isGEMMuon() const { return type_ & GEMMuon; }
-    bool isME0Muon() const { return type_ & ME0Muon; }
-
-  private:
-    /// check overlap with another candidate
-    bool overlap(const Candidate&) const override;
-    /// reference to Track reconstructed in the tracker only
-    TrackRef innerTrack_;
-    /// reference to Track reconstructed in the muon detector only
-    TrackRef outerTrack_;
-    /// reference to Track reconstructed in both tracked and muon detector
-    TrackRef globalTrack_;
-    /// reference to the Global Track refitted with dedicated TeV reconstructors
-    MuonTrackRefMap refittedTrackMap_;
-    /// reference to the Track chosen to assign the momentum value to the muon
-    MuonTrackType bestTrackType_;
-    /// reference to the Track chosen to assign the momentum value to the muon by PF
-    MuonTrackType bestTunePTrackType_;
-
-    /// energy deposition
-    MuonEnergy calEnergy_;
-    /// quality block
-    MuonQuality combinedQuality_;
-    /// Information on matching between tracks and segments
-    std::vector<MuonChamberMatch> muMatches_;
-    /// timing
-    MuonTime time_;
-    MuonTime rpcTime_;
-    bool energyValid_;
-    bool matchesValid_;
-    bool isolationValid_;
-    bool pfIsolationValid_;
-    bool qualityValid_;
-    /// muon hypothesis compatibility with observer calorimeter energy
-    float caloCompatibility_;
-    /// Isolation information for two cones with dR=0.3 and dR=0.5
-    MuonIsolation isolationR03_;
-    MuonIsolation isolationR05_;
-
-    /// PF Isolation information for two cones with dR=0.3 and dR=0.4
-    MuonPFIsolation pfIsolationR03_;
-    MuonPFIsolation pfIsoMeanDRR03_;
-    MuonPFIsolation pfIsoSumDRR03_;
-    MuonPFIsolation pfIsolationR04_;
-    MuonPFIsolation pfIsoMeanDRR04_;
-    MuonPFIsolation pfIsoSumDRR04_;
-
-    /// muon type mask
-    unsigned int type_;
-
-    //PF muon p4
-    reco::Candidate::LorentzVector pfP4_;
-
-    // FixMe: Still missing trigger information
-
-    /// get vector of muon chambers for given station and detector
-    const std::vector<const MuonChamberMatch*> chambers(int station, int muonSubdetId) const;
-    /// get pointers to best segment and corresponding chamber in vector of chambers
-    std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> pair(
-        const std::vector<const MuonChamberMatch*>&, ArbitrationType type = SegmentAndTrackArbitration) const;
-    /// selector bitmap
-    uint64_t selectors_;
-
-  public:
-    /// get number of segments
-    int numberOfSegments(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    /// get deltas between (best) segment and track
-    /// If no chamber or no segment returns 999999
-    float dX(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float dY(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float dDxDz(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float dDyDz(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float pullX(int station,
-                int muonSubdetId,
-                ArbitrationType type = SegmentAndTrackArbitration,
-                bool includeSegmentError = true) const;
-    float pullY(int station,
-                int muonSubdetId,
-                ArbitrationType type = SegmentAndTrackArbitration,
-                bool includeSegmentError = true) const;
-    float pullDxDz(int station,
-                   int muonSubdetId,
-                   ArbitrationType type = SegmentAndTrackArbitration,
-                   bool includeSegmentError = true) const;
-    float pullDyDz(int station,
-                   int muonSubdetId,
-                   ArbitrationType type = SegmentAndTrackArbitration,
-                   bool includeSegmentError = true) const;
-    /// get (best) segment information
-    /// If no segment returns 999999
-    float segmentX(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float segmentY(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float segmentDxDz(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float segmentDyDz(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float segmentXErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float segmentYErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float segmentDxDzErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float segmentDyDzErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    /// get track information in chamber that contains (best) segment
-    /// If no segment, get track information in chamber that has the most negative distance between the track
-    /// and the nearest chamber edge (the chamber with the deepest track)
-    /// If no chamber returns 999999
-    float trackEdgeX(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float trackEdgeY(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float trackX(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float trackY(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float trackDxDz(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float trackDyDz(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float trackXErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float trackYErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float trackDxDzErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float trackDyDzErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float trackDist(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-    float trackDistErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
-
-    float t0(int n = 0) {
-      int i = 0;
-      for (auto& chamber : muMatches_) {
-        int segmentMatchesSize = (int)chamber.segmentMatches.size();
-        if (i + segmentMatchesSize < n) {
-          i += segmentMatchesSize;
-          continue;
-        }
-        return chamber.segmentMatches[n - i].t0;
+      TrackRef muonTrackFromMap(const MuonTrackType& type) const {
+        MuonTrackRefMap::const_iterator iter = refittedTrackMap_.find(type);
+        if (iter != refittedTrackMap_.end())
+          return iter->second;
+        else
+          return TrackRef();
       }
-      return 0;
-    }
-  };
 
+      /// set reference to Track
+      virtual void setInnerTrack(const TrackRef& t);
+      virtual void setTrack(const TrackRef& t);
+      /// set reference to Track
+      virtual void setOuterTrack(const TrackRef& t);
+      virtual void setStandAlone(const TrackRef& t);
+      /// set reference to Track
+      virtual void setGlobalTrack(const TrackRef& t);
+      virtual void setCombined(const TrackRef& t);
+      // set reference to the Best Track
+      virtual void setBestTrack(MuonTrackType muonType) { bestTrackType_ = muonType; }
+      // set reference to the Best Track by PF
+      virtual void setTunePBestTrack(MuonTrackType muonType) { bestTunePTrackType_ = muonType; }
+
+      void setMuonTrack(const MuonTrackType&, const TrackRef&);
+
+      ///set reference to PFCandidate
+      ///
+      /// ====================== PF BLOCK ===========================
+      ///
+
+      reco::Candidate::LorentzVector pfP4() const { return pfP4_; }
+      virtual void setPFP4(const reco::Candidate::LorentzVector& p4_);
+
+      ///
+      /// ====================== ENERGY BLOCK ===========================
+      ///
+      /// energy deposition
+      bool isEnergyValid() const { return energyValid_; }
+      /// get energy deposition information
+      MuonEnergy calEnergy() const { return calEnergy_; }
+      /// set energy deposition information
+      void setCalEnergy(const MuonEnergy& calEnergy) {
+        calEnergy_ = calEnergy;
+        energyValid_ = true;
+      }
+
+      ///
+      /// ====================== Quality BLOCK ===========================
+      ///
+      /// energy deposition
+      bool isQualityValid() const { return qualityValid_; }
+      /// get energy deposition information
+      MuonQuality combinedQuality() const { return combinedQuality_; }
+      /// set energy deposition information
+      void setCombinedQuality(const MuonQuality& combinedQuality) {
+        combinedQuality_ = combinedQuality;
+        qualityValid_ = true;
+      }
+
+      ///
+      /// ====================== TIMING BLOCK ===========================
+      ///
+      /// timing information
+      bool isTimeValid() const { return (time_.nDof > 0); }
+      /// get DT/CSC combined timing information
+      MuonTime time() const { return time_; }
+      /// set DT/CSC combined timing information
+      void setTime(const MuonTime& time) { time_ = time; }
+      /// get RPC timing information
+      MuonTime rpcTime() const { return rpcTime_; }
+      /// set RPC timing information
+      void setRPCTime(const MuonTime& time) { rpcTime_ = time; }
+
+      ///
+      /// ====================== MUON MATCH BLOCK ===========================
+      ///
+      bool isMatchesValid() const { return matchesValid_; }
+      /// get muon matching information
+      std::vector<MuonChamberMatch>& matches() { return muMatches_; }
+      const std::vector<MuonChamberMatch>& matches() const { return muMatches_; }
+      /// set muon matching information
+      void setMatches(const std::vector<MuonChamberMatch>& matches) {
+        muMatches_ = matches;
+        matchesValid_ = true;
+      }
+
+      ///
+      /// ====================== MUON COMPATIBILITY BLOCK ===========================
+      ///
+      /// Relative likelihood based on ECAL, HCAL, HO energy defined as
+      /// L_muon/(L_muon+L_not_muon)
+      float caloCompatibility() const { return caloCompatibility_; }
+      void setCaloCompatibility(float input) { caloCompatibility_ = input; }
+      bool isCaloCompatibilityValid() const { return caloCompatibility_ >= 0; }
+
+      ///
+      /// ====================== ISOLATION BLOCK ===========================
+      ///
+      /// Summary of muon isolation information
+      const MuonIsolation& isolationR03() const { return isolationR03_; }
+      const MuonIsolation& isolationR05() const { return isolationR05_; }
+
+      const MuonPFIsolation& pfIsolationR03() const { return pfIsolationR03_; }
+      const MuonPFIsolation& pfMeanDRIsoProfileR03() const { return pfIsoMeanDRR03_; }
+      const MuonPFIsolation& pfSumDRIsoProfileR03() const { return pfIsoSumDRR03_; }
+      const MuonPFIsolation& pfIsolationR04() const { return pfIsolationR04_; }
+      const MuonPFIsolation& pfMeanDRIsoProfileR04() const { return pfIsoMeanDRR04_; }
+      const MuonPFIsolation& pfSumDRIsoProfileR04() const { return pfIsoSumDRR04_; }
+
+      void setIsolation(const MuonIsolation& isoR03, const MuonIsolation& isoR05);
+      bool isIsolationValid() const { return isolationValid_; }
+      void setPFIsolation(const std::string& label, const reco::MuonPFIsolation& deposit);
+
+      bool isPFIsolationValid() const { return pfIsolationValid_; }
+
+      /// define arbitration schemes
+      // WARNING: There can be not more than 7 arbritration types. If
+      //          have more it will break the matching logic for types
+      //          defined in MuonSegmentMatch
+
+      enum ArbitrationType {
+        NoArbitration,
+        SegmentArbitration,
+        SegmentAndTrackArbitration,
+        SegmentAndTrackArbitrationCleaned,
+        RPCHitAndTrackArbitration,
+        GEMSegmentAndTrackArbitration,
+        ME0SegmentAndTrackArbitration,
+        GEMHitAndTrackArbitration
+      };
+
+      ///
+      /// ====================== STANDARD SELECTORS ===========================
+      ///
+      // When adding new selectors, also update DataFormats/MuonReco/interface/MuonSelectors.h string to enum map
+      enum Selector {
+        CutBasedIdLoose = 0,
+        CutBasedIdMedium = 1,
+        CutBasedIdMediumPrompt = 2,  // medium with IP cuts
+        CutBasedIdTight = 3,
+        CutBasedIdGlobalHighPt = 4,  // high pt muon for Z',W' (better momentum resolution)
+        CutBasedIdTrkHighPt = 5,     // high pt muon for boosted Z (better efficiency)
+        PFIsoVeryLoose = 6,          // reliso<0.40
+        PFIsoLoose = 7,              // reliso<0.25
+        PFIsoMedium = 8,             // reliso<0.20
+        PFIsoTight = 9,              // reliso<0.15
+        PFIsoVeryTight = 10,         // reliso<0.10
+        TkIsoLoose = 11,             // reliso<0.10
+        TkIsoTight = 12,             // reliso<0.05
+        SoftCutBasedId = 13,
+        SoftMvaId = 14,
+        MvaLoose = 15,
+        MvaMedium = 16,
+        MvaTight = 17,
+        MiniIsoLoose = 18,      // reliso<0.40
+        MiniIsoMedium = 19,     // reliso<0.20
+        MiniIsoTight = 20,      // reliso<0.10
+        MiniIsoVeryTight = 21,  // reliso<0.05
+        TriggerIdLoose = 22,    // robust selector for HLT
+        InTimeMuon = 23,
+        PFIsoVeryVeryTight = 24,  // reliso<0.05
+        MultiIsoLoose = 25,       // miniIso with ptRatio and ptRel
+        MultiIsoMedium = 26,      // miniIso with ptRatio and ptRel
+        PuppiIsoLoose = 27,
+        PuppiIsoMedium = 28,
+        PuppiIsoTight = 29,
+        MvaVTight = 30,
+        MvaVVTight = 31,
+        LowPtMvaLoose = 32,
+        LowPtMvaMedium = 33,
+        MvaIDwpMedium = 34,
+        MvaIDwpTight = 35,
+      };
+
+      bool passed(uint64_t selection) const { return (selectors_ & selection) == selection; }
+      bool passed(Selector selection) const { return passed(static_cast<uint64_t>(1UL << selection)); }
+      uint64_t selectors() const { return selectors_; }
+      void setSelectors(uint64_t selectors) { selectors_ = selectors; }
+      void setSelector(Selector selector, bool passed) {
+        auto selector64 = 1UL << selector;
+        if (passed)
+          selectors_ |= selector64;
+        else
+          selectors_ &= ~selector64;
+      }
+
+      ///
+      /// ====================== USEFUL METHODs ===========================
+      ///
+      /// number of chambers (MuonChamberMatches include RPC rolls, GEM and ME0 segments)
+      int numberOfChambers() const { return muMatches_.size(); }
+      /// number of chambers CSC or DT matches only (MuonChamberMatches include RPC rolls)
+      int numberOfChambersCSCorDT() const;
+      /// get number of chambers with matched segments
+      int numberOfMatches(ArbitrationType type = SegmentAndTrackArbitration) const;
+      /// get number of stations with matched segments
+      /// just adds the bits returned by stationMask
+      int numberOfMatchedStations(ArbitrationType type = SegmentAndTrackArbitration) const;
+      /// expected number of stations with matching segments based on the absolute
+      /// distance from the edge of a chamber
+      unsigned int expectedNnumberOfMatchedStations(float minDistanceFromEdge = 10.0) const;
+      /// get bit map of stations with matched segments
+      /// bits 0-1-2-3 = DT stations 1-2-3-4
+      /// bits 4-5-6-7 = CSC stations 1-2-3-4
+      unsigned int stationMask(ArbitrationType type = SegmentAndTrackArbitration) const;
+      /// get bit map of stations with tracks within
+      /// given distance (in cm) of chamber edges
+      /// bit assignments are same as above
+      int numberOfMatchedRPCLayers(ArbitrationType type = RPCHitAndTrackArbitration) const;
+      unsigned int RPClayerMask(ArbitrationType type = RPCHitAndTrackArbitration) const;
+      unsigned int stationGapMaskDistance(float distanceCut = 10.) const;
+      /// same as above for given number of sigmas
+      unsigned int stationGapMaskPull(float sigmaCut = 3.) const;
+      /// # of digis in a given station layer
+      int nDigisInStation(int station, int muonSubdetId) const;
+      /// tag a shower in a given station layer
+      bool hasShowerInStation(int station, int muonSubdetId, int nDtDigisCut = 20, int nCscDigisCut = 36) const;
+      /// count the number of showers along a muon track
+      int numberOfShowers(int nDtDigisCut = 20, int nCscDigisCut = 36) const;
+
+      /// muon type - type of the algorithm that reconstructed this muon
+      /// multiple algorithms can reconstruct the same muon
+      static const unsigned int GlobalMuon = 1 << 1;
+      static const unsigned int TrackerMuon = 1 << 2;
+      static const unsigned int StandAloneMuon = 1 << 3;
+      static const unsigned int CaloMuon = 1 << 4;
+      static const unsigned int PFMuon = 1 << 5;
+      static const unsigned int RPCMuon = 1 << 6;
+      static const unsigned int GEMMuon = 1 << 7;
+      static const unsigned int ME0Muon = 1 << 8;
+
+      void setType(unsigned int type) { type_ = type; }
+      unsigned int type() const { return type_; }
+
+      // override of method in base class reco::Candidate
+      bool isMuon() const override { return true; }
+      bool isGlobalMuon() const override { return type_ & GlobalMuon; }
+      bool isTrackerMuon() const override { return type_ & TrackerMuon; }
+      bool isStandAloneMuon() const override { return type_ & StandAloneMuon; }
+      bool isCaloMuon() const override { return type_ & CaloMuon; }
+      bool isPFMuon() const { return type_ & PFMuon; }  //fix me ! Has to go to type
+      bool isRPCMuon() const { return type_ & RPCMuon; }
+      bool isGEMMuon() const { return type_ & GEMMuon; }
+      bool isME0Muon() const { return type_ & ME0Muon; }
+
+    private:
+      /// check overlap with another candidate
+      bool overlap(const Candidate&) const override;
+      /// reference to Track reconstructed in the tracker only
+      TrackRef innerTrack_;
+      /// reference to Track reconstructed in the muon detector only
+      TrackRef outerTrack_;
+      /// reference to Track reconstructed in both tracked and muon detector
+      TrackRef globalTrack_;
+      /// reference to the Global Track refitted with dedicated TeV reconstructors
+      MuonTrackRefMap refittedTrackMap_;
+      /// reference to the Track chosen to assign the momentum value to the muon
+      MuonTrackType bestTrackType_;
+      /// reference to the Track chosen to assign the momentum value to the muon by PF
+      MuonTrackType bestTunePTrackType_;
+
+      /// energy deposition
+      MuonEnergy calEnergy_;
+      /// quality block
+      MuonQuality combinedQuality_;
+      /// Information on matching between tracks and segments
+      std::vector<MuonChamberMatch> muMatches_;
+      /// timing
+      MuonTime time_;
+      MuonTime rpcTime_;
+      bool energyValid_;
+      bool matchesValid_;
+      bool isolationValid_;
+      bool pfIsolationValid_;
+      bool qualityValid_;
+      /// muon hypothesis compatibility with observer calorimeter energy
+      float caloCompatibility_;
+      /// Isolation information for two cones with dR=0.3 and dR=0.5
+      MuonIsolation isolationR03_;
+      MuonIsolation isolationR05_;
+
+      /// PF Isolation information for two cones with dR=0.3 and dR=0.4
+      MuonPFIsolation pfIsolationR03_;
+      MuonPFIsolation pfIsoMeanDRR03_;
+      MuonPFIsolation pfIsoSumDRR03_;
+      MuonPFIsolation pfIsolationR04_;
+      MuonPFIsolation pfIsoMeanDRR04_;
+      MuonPFIsolation pfIsoSumDRR04_;
+
+      /// muon type mask
+      unsigned int type_;
+
+      //PF muon p4
+      reco::Candidate::LorentzVector pfP4_;
+
+      // FixMe: Still missing trigger information
+
+      /// get vector of muon chambers for given station and detector
+      const std::vector<const MuonChamberMatch*> chambers(int station, int muonSubdetId) const;
+      /// get pointers to best segment and corresponding chamber in vector of chambers
+      std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> pair(
+          const std::vector<const MuonChamberMatch*>&, ArbitrationType type = SegmentAndTrackArbitration) const;
+      /// selector bitmap
+      uint64_t selectors_;
+
+    public:
+      /// get number of segments
+      int numberOfSegments(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      /// get deltas between (best) segment and track
+      /// If no chamber or no segment returns 999999
+      float dX(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float dY(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float dDxDz(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float dDyDz(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float pullX(int station,
+                  int muonSubdetId,
+                  ArbitrationType type = SegmentAndTrackArbitration,
+                  bool includeSegmentError = true) const;
+      float pullY(int station,
+                  int muonSubdetId,
+                  ArbitrationType type = SegmentAndTrackArbitration,
+                  bool includeSegmentError = true) const;
+      float pullDxDz(int station,
+                     int muonSubdetId,
+                     ArbitrationType type = SegmentAndTrackArbitration,
+                     bool includeSegmentError = true) const;
+      float pullDyDz(int station,
+                     int muonSubdetId,
+                     ArbitrationType type = SegmentAndTrackArbitration,
+                     bool includeSegmentError = true) const;
+      /// get (best) segment information
+      /// If no segment returns 999999
+      float segmentX(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float segmentY(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float segmentDxDz(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float segmentDyDz(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float segmentXErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float segmentYErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float segmentDxDzErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float segmentDyDzErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      /// get track information in chamber that contains (best) segment
+      /// If no segment, get track information in chamber that has the most negative distance between the track
+      /// and the nearest chamber edge (the chamber with the deepest track)
+      /// If no chamber returns 999999
+      float trackEdgeX(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float trackEdgeY(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float trackX(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float trackY(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float trackDxDz(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float trackDyDz(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float trackXErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float trackYErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float trackDxDzErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float trackDyDzErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float trackDist(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+      float trackDistErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+
+      float t0(int n = 0) {
+        int i = 0;
+        for (auto& chamber : muMatches_) {
+          int segmentMatchesSize = (int)chamber.segmentMatches.size();
+          if (i + segmentMatchesSize < n) {
+            i += segmentMatchesSize;
+            continue;
+          }
+          return chamber.segmentMatches[n - i].t0;
+        }
+        return 0;
+      }
+    };
+
+  }  // namespace io_v1
+  using Muon = io_v1::Muon;
 }  // namespace reco
 
 #endif

--- a/DataFormats/MuonReco/interface/MuonCosmicCompatibility.h
+++ b/DataFormats/MuonReco/interface/MuonCosmicCompatibility.h
@@ -2,27 +2,30 @@
 #define MuonReco_MuonCosmicCompatibility_h
 
 namespace reco {
-  struct MuonCosmicCompatibility {
-    /// combined cosmic-likeness: 0 == not cosmic-like
-    float cosmicCompatibility;
-    /// cosmic-likeness based on time: 0 == prompt-like
-    float timeCompatibility;
-    /// cosmic-likeness based on presence of a track in opp side: 0 == no matching opp tracks
-    float backToBackCompatibility;
-    /// cosmic-likeness based on overlap with traversing cosmic muon (only muon/STA hits are used)
-    float overlapCompatibility;
-    /// cosmic-likeness based on the 2D impact parameters (dxy, dz wrt to PV). 0 == cosmic-like
-    float ipCompatibility;
-    /// cosmic-likeness based on the event activity information: tracker track multiplicity and vertex quality. 0 == cosmic-like
-    float vertexCompatibility;
+  namespace io_v1 {
+    struct MuonCosmicCompatibility {
+      /// combined cosmic-likeness: 0 == not cosmic-like
+      float cosmicCompatibility;
+      /// cosmic-likeness based on time: 0 == prompt-like
+      float timeCompatibility;
+      /// cosmic-likeness based on presence of a track in opp side: 0 == no matching opp tracks
+      float backToBackCompatibility;
+      /// cosmic-likeness based on overlap with traversing cosmic muon (only muon/STA hits are used)
+      float overlapCompatibility;
+      /// cosmic-likeness based on the 2D impact parameters (dxy, dz wrt to PV). 0 == cosmic-like
+      float ipCompatibility;
+      /// cosmic-likeness based on the event activity information: tracker track multiplicity and vertex quality. 0 == cosmic-like
+      float vertexCompatibility;
 
-    MuonCosmicCompatibility()
-        : cosmicCompatibility(0),
-          timeCompatibility(0),
-          backToBackCompatibility(0),
-          overlapCompatibility(0),
-          ipCompatibility(0),
-          vertexCompatibility(0) {}
-  };
+      MuonCosmicCompatibility()
+          : cosmicCompatibility(0),
+            timeCompatibility(0),
+            backToBackCompatibility(0),
+            overlapCompatibility(0),
+            ipCompatibility(0),
+            vertexCompatibility(0) {}
+    };
+  }  // namespace io_v1
+  using MuonCosmicCompatibility = io_v1::MuonCosmicCompatibility;
 }  // namespace reco
 #endif

--- a/DataFormats/MuonReco/interface/MuonFwd.h
+++ b/DataFormats/MuonReco/interface/MuonFwd.h
@@ -6,7 +6,10 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 namespace reco {
-  class Muon;
+  namespace io_v1 {
+    class Muon;
+  }
+  using Muon = io_v1::Muon;
   /// collection of Muon objects
   typedef std::vector<Muon> MuonCollection;
   /// presistent reference to a Muon
@@ -19,12 +22,16 @@ namespace reco {
   typedef MuonRefVector::iterator muon_iterator;
 
   /// Links between the three tracks which can define a muon
-  class MuonTrackLinks;
-
+  namespace io_v1 {
+    class MuonTrackLinks;
+  }
+  using MuonTrackLinks = io_v1::MuonTrackLinks;
   /// collection of MuonTrackLinks
   typedef std::vector<MuonTrackLinks> MuonTrackLinksCollection;
-
-  class CaloMuon;
+  namespace io_v1 {
+    class CaloMuon;
+  }
+  using CaloMuon = io_v1::CaloMuon;
   /// collection of Muon objects
   typedef std::vector<CaloMuon> CaloMuonCollection;
 }  // namespace reco

--- a/DataFormats/MuonReco/interface/MuonMETCorrectionData.h
+++ b/DataFormats/MuonReco/interface/MuonMETCorrectionData.h
@@ -4,37 +4,40 @@
 #include <cmath>
 
 namespace reco {
-  class MuonMETCorrectionData {
-  public:
-    enum Type {
-      NotUsed = 0,
-      CombinedTrackUsed = 1,
-      GlobalTrackUsed = 1,
-      InnerTrackUsed = 2,
-      TrackUsed = 2,
-      OuterTrackUsed = 3,
-      StandAloneTrackUsed = 3,
-      TreatedAsPion = 4,
-      MuonP4V4QUsed = 5,
-      MuonCandidateValuesUsed = 5
+  namespace io_v1 {
+    class MuonMETCorrectionData {
+    public:
+      enum Type {
+        NotUsed = 0,
+        CombinedTrackUsed = 1,
+        GlobalTrackUsed = 1,
+        InnerTrackUsed = 2,
+        TrackUsed = 2,
+        OuterTrackUsed = 3,
+        StandAloneTrackUsed = 3,
+        TreatedAsPion = 4,
+        MuonP4V4QUsed = 5,
+        MuonCandidateValuesUsed = 5
+      };
+
+      MuonMETCorrectionData() : type_(0), corrX_(0), corrY_(0) {}
+      MuonMETCorrectionData(Type type, float corrX, float corrY) : type_(type), corrX_(corrX), corrY_(corrY) {}
+
+      Type type() { return Type(type_); }
+      float corrX() { return corrX_; }
+      float corrY() { return corrY_; }
+      float x() { return corrX_; }
+      float y() { return corrY_; }
+      float pt() { return sqrt(x() * x() + y() * y()); }
+
+    protected:
+      int type_;
+      float corrX_;
+      float corrY_;
     };
 
-    MuonMETCorrectionData() : type_(0), corrX_(0), corrY_(0) {}
-    MuonMETCorrectionData(Type type, float corrX, float corrY) : type_(type), corrX_(corrX), corrY_(corrY) {}
-
-    Type type() { return Type(type_); }
-    float corrX() { return corrX_; }
-    float corrY() { return corrY_; }
-    float x() { return corrX_; }
-    float y() { return corrY_; }
-    float pt() { return sqrt(x() * x() + y() * y()); }
-
-  protected:
-    int type_;
-    float corrX_;
-    float corrY_;
-  };
-
+  }  // namespace io_v1
+  using MuonMETCorrectionData = io_v1::MuonMETCorrectionData;
 }  // namespace reco
 
 #endif  //MuonReco_MuonMETCorrectionData_h

--- a/DataFormats/MuonReco/interface/MuonShower.h
+++ b/DataFormats/MuonReco/interface/MuonShower.h
@@ -4,17 +4,20 @@
 #include <vector>
 
 namespace reco {
-  struct MuonShower {
-    /// number of all the muon RecHits per chamber crossed by a track (1D hits)
-    std::vector<int> nStationHits;
-    /// number of the muon RecHits used by segments per chamber crossed by a track
-    std::vector<int> nStationCorrelatedHits;
-    /// the transverse size of the hit cluster
-    std::vector<float> stationShowerSizeT;
-    /// the radius of the cone containing the all the hits around the track
-    std::vector<float> stationShowerDeltaR;
+  namespace io_v1 {
+    struct MuonShower {
+      /// number of all the muon RecHits per chamber crossed by a track (1D hits)
+      std::vector<int> nStationHits;
+      /// number of the muon RecHits used by segments per chamber crossed by a track
+      std::vector<int> nStationCorrelatedHits;
+      /// the transverse size of the hit cluster
+      std::vector<float> stationShowerSizeT;
+      /// the radius of the cone containing the all the hits around the track
+      std::vector<float> stationShowerDeltaR;
 
-    MuonShower() : nStationHits(0), nStationCorrelatedHits(0), stationShowerSizeT(0), stationShowerDeltaR(0) {}
-  };
+      MuonShower() : nStationHits(0), nStationCorrelatedHits(0), stationShowerSizeT(0), stationShowerDeltaR(0) {}
+    };
+  }  // namespace io_v1
+  using MuonShower = io_v1::MuonShower;
 }  // namespace reco
 #endif

--- a/DataFormats/MuonReco/interface/MuonSimInfo.h
+++ b/DataFormats/MuonReco/interface/MuonSimInfo.h
@@ -71,31 +71,35 @@ namespace reco {
 
   };
 
-  class MuonSimInfo {
-  public:
-    MuonSimInfo();
-    typedef math::XYZPointD Point;                   ///< point in the space
-    typedef math::XYZTLorentzVectorD LorentzVector;  ///< Lorentz vector
-    MuonSimType primaryClass;
-    ExtendedMuonSimType extendedClass;
-    int flavour;
-    int pdgId;          // pdg ID of matching tracking particle
-    int g4processType;  // Geant process producing the particle
-    int motherPdgId;
-    int motherFlavour;
-    int motherStatus;  // Status of the first gen particle
-    int grandMotherPdgId;
-    int grandMotherFlavour;
-    int heaviestMotherFlavour;
-    int tpId;
-    int tpEvent;
-    int tpBX;  // bunch crossing
-    int charge;
-    LorentzVector p4;
-    Point vertex;
-    Point motherVertex;
-    float tpAssoQuality;
-  };
+  namespace io_v1 {
+
+    class MuonSimInfo {
+    public:
+      MuonSimInfo();
+      typedef math::XYZPointD Point;                   ///< point in the space
+      typedef math::XYZTLorentzVectorD LorentzVector;  ///< Lorentz vector
+      MuonSimType primaryClass;
+      ExtendedMuonSimType extendedClass;
+      int flavour;
+      int pdgId;          // pdg ID of matching tracking particle
+      int g4processType;  // Geant process producing the particle
+      int motherPdgId;
+      int motherFlavour;
+      int motherStatus;  // Status of the first gen particle
+      int grandMotherPdgId;
+      int grandMotherFlavour;
+      int heaviestMotherFlavour;
+      int tpId;
+      int tpEvent;
+      int tpBX;  // bunch crossing
+      int charge;
+      LorentzVector p4;
+      Point vertex;
+      Point motherVertex;
+      float tpAssoQuality;
+    };
+  }  // namespace io_v1
+  using MuonSimInfo = io_v1::MuonSimInfo;
 }  // namespace reco
 
 #endif

--- a/DataFormats/MuonReco/interface/MuonTimeExtra.h
+++ b/DataFormats/MuonReco/interface/MuonTimeExtra.h
@@ -11,73 +11,76 @@
  */
 
 namespace reco {
+  namespace io_v1 {
 
-  class MuonTimeExtra {
-  public:
-    MuonTimeExtra();
+    class MuonTimeExtra {
+    public:
+      MuonTimeExtra();
 
-    enum Direction { OutsideIn = -1, Undefined = 0, InsideOut = 1 };
+      enum Direction { OutsideIn = -1, Undefined = 0, InsideOut = 1 };
 
-    /// number of measurements used in timing calculation
-    int nDof() const { return nDof_; };
-    void setNDof(const int nDof) { nDof_ = nDof; };
+      /// number of measurements used in timing calculation
+      int nDof() const { return nDof_; };
+      void setNDof(const int nDof) { nDof_ = nDof; };
 
-    /// 1/beta for prompt particle hypothesis
-    /// (time is constraint to the bunch crossing time)
-    float inverseBeta() const { return inverseBeta_; };
-    float inverseBetaErr() const { return inverseBetaErr_; };
-    void setInverseBeta(const float iBeta) { inverseBeta_ = iBeta; };
-    void setInverseBetaErr(const float iBetaErr) { inverseBetaErr_ = iBetaErr; };
+      /// 1/beta for prompt particle hypothesis
+      /// (time is constraint to the bunch crossing time)
+      float inverseBeta() const { return inverseBeta_; };
+      float inverseBetaErr() const { return inverseBetaErr_; };
+      void setInverseBeta(const float iBeta) { inverseBeta_ = iBeta; };
+      void setInverseBetaErr(const float iBetaErr) { inverseBetaErr_ = iBetaErr; };
 
-    /// unconstrained 1/beta (time is free)
-    /// Sign convention:
-    ///   positive - outward moving particle
-    ///   negative - inward moving particle
-    float freeInverseBeta() const { return freeInverseBeta_; };
-    float freeInverseBetaErr() const { return freeInverseBetaErr_; };
-    void setFreeInverseBeta(const float iBeta) { freeInverseBeta_ = iBeta; };
-    void setFreeInverseBetaErr(const float iBetaErr) { freeInverseBetaErr_ = iBetaErr; };
+      /// unconstrained 1/beta (time is free)
+      /// Sign convention:
+      ///   positive - outward moving particle
+      ///   negative - inward moving particle
+      float freeInverseBeta() const { return freeInverseBeta_; };
+      float freeInverseBetaErr() const { return freeInverseBetaErr_; };
+      void setFreeInverseBeta(const float iBeta) { freeInverseBeta_ = iBeta; };
+      void setFreeInverseBetaErr(const float iBetaErr) { freeInverseBetaErr_ = iBetaErr; };
 
-    /// time of arrival at the IP for the Beta=1 hypothesis
-    ///  a) particle is moving from inside out
-    float timeAtIpInOut() const { return timeAtIpInOut_; };
-    float timeAtIpInOutErr() const { return timeAtIpInOutErr_; };
-    void setTimeAtIpInOut(const float timeIp) { timeAtIpInOut_ = timeIp; };
-    void setTimeAtIpInOutErr(const float timeErr) { timeAtIpInOutErr_ = timeErr; };
-    ///  b) particle is moving from outside in
-    float timeAtIpOutIn() const { return timeAtIpOutIn_; };
-    float timeAtIpOutInErr() const { return timeAtIpOutInErr_; };
-    void setTimeAtIpOutIn(const float timeIp) { timeAtIpOutIn_ = timeIp; };
-    void setTimeAtIpOutInErr(const float timeErr) { timeAtIpOutInErr_ = timeErr; };
+      /// time of arrival at the IP for the Beta=1 hypothesis
+      ///  a) particle is moving from inside out
+      float timeAtIpInOut() const { return timeAtIpInOut_; };
+      float timeAtIpInOutErr() const { return timeAtIpInOutErr_; };
+      void setTimeAtIpInOut(const float timeIp) { timeAtIpInOut_ = timeIp; };
+      void setTimeAtIpInOutErr(const float timeErr) { timeAtIpInOutErr_ = timeErr; };
+      ///  b) particle is moving from outside in
+      float timeAtIpOutIn() const { return timeAtIpOutIn_; };
+      float timeAtIpOutInErr() const { return timeAtIpOutInErr_; };
+      void setTimeAtIpOutIn(const float timeIp) { timeAtIpOutIn_ = timeIp; };
+      void setTimeAtIpOutInErr(const float timeErr) { timeAtIpOutInErr_ = timeErr; };
 
-    /// direction estimation based on time dispersion
-    Direction direction() const {
-      if (nDof_ < 2)
-        return Undefined;
-      if (timeAtIpInOutErr_ > timeAtIpOutInErr_)
-        return OutsideIn;
-      return InsideOut;
-    }
+      /// direction estimation based on time dispersion
+      Direction direction() const {
+        if (nDof_ < 2)
+          return Undefined;
+        if (timeAtIpInOutErr_ > timeAtIpOutInErr_)
+          return OutsideIn;
+        return InsideOut;
+      }
 
-  private:
-    /// number of measurements used in timing calculation
-    int nDof_;
+    private:
+      /// number of measurements used in timing calculation
+      int nDof_;
 
-    /// 1/beta for prompt particle hypothesis
-    float inverseBeta_;
-    float inverseBetaErr_;
+      /// 1/beta for prompt particle hypothesis
+      float inverseBeta_;
+      float inverseBetaErr_;
 
-    /// unconstrained 1/beta (time is free)
-    float freeInverseBeta_;
-    float freeInverseBetaErr_;
+      /// unconstrained 1/beta (time is free)
+      float freeInverseBeta_;
+      float freeInverseBetaErr_;
 
-    /// time of arrival at the IP for the Beta=1 hypothesis
-    float timeAtIpInOut_;
-    float timeAtIpInOutErr_;
-    float timeAtIpOutIn_;
-    float timeAtIpOutInErr_;
-  };
+      /// time of arrival at the IP for the Beta=1 hypothesis
+      float timeAtIpInOut_;
+      float timeAtIpInOutErr_;
+      float timeAtIpOutIn_;
+      float timeAtIpOutInErr_;
+    };
 
+  }  // namespace io_v1
+  using MuonTimeExtra = io_v1::MuonTimeExtra;
 }  // namespace reco
 
 #endif

--- a/DataFormats/MuonReco/interface/MuonTimeExtraFwd.h
+++ b/DataFormats/MuonReco/interface/MuonTimeExtraFwd.h
@@ -7,7 +7,10 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 
 namespace reco {
-  class MuonTimeExtra;
+  namespace io_v1 {
+    class MuonTimeExtra;
+  }
+  using MuonTimeExtra = io_v1::MuonTimeExtra;
   /// collection of MuonTimeExtra objects
 
   /*  typedef std::vector<MuonTimeExtra> MuonTimeExtraCollection;

--- a/DataFormats/MuonReco/interface/MuonTrackLinks.h
+++ b/DataFormats/MuonReco/interface/MuonTrackLinks.h
@@ -12,49 +12,52 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  class MuonTrackLinks {
-  public:
-    /// Default Constructor
-    MuonTrackLinks() {}
+    class MuonTrackLinks {
+    public:
+      /// Default Constructor
+      MuonTrackLinks() {}
 
-    /// Constructor
-    MuonTrackLinks(reco::TrackRef tk, reco::TrackRef sta, reco::TrackRef glb)
-        : theTkTrack(tk), theStaTrack(sta), theGlbTrack(glb) {}
+      /// Constructor
+      MuonTrackLinks(reco::TrackRef tk, reco::TrackRef sta, reco::TrackRef glb)
+          : theTkTrack(tk), theStaTrack(sta), theGlbTrack(glb) {}
 
-    /// Destructor
-    virtual ~MuonTrackLinks() {}
+      /// Destructor
+      virtual ~MuonTrackLinks() {}
 
-    // Operations
+      // Operations
 
-    /// get the tracker's track which match with the stand alone muon tracks
-    inline reco::TrackRef trackerTrack() const { return theTkTrack; }
+      /// get the tracker's track which match with the stand alone muon tracks
+      inline reco::TrackRef trackerTrack() const { return theTkTrack; }
 
-    /// get the track built with the muon spectrometer alone
-    inline reco::TrackRef standAloneTrack() const { return theStaTrack; }
+      /// get the track built with the muon spectrometer alone
+      inline reco::TrackRef standAloneTrack() const { return theStaTrack; }
 
-    /// get the combined track
-    inline reco::TrackRef globalTrack() const { return theGlbTrack; }
+      /// get the combined track
+      inline reco::TrackRef globalTrack() const { return theGlbTrack; }
 
-    /// set the ref to tracker's track
-    inline void setTrackerTrack(reco::TrackRef tk) { theTkTrack = tk; }
+      /// set the ref to tracker's track
+      inline void setTrackerTrack(reco::TrackRef tk) { theTkTrack = tk; }
 
-    /// set the ref to stand alone track
-    inline void setStandAloneTrack(reco::TrackRef sta) { theStaTrack = sta; }
+      /// set the ref to stand alone track
+      inline void setStandAloneTrack(reco::TrackRef sta) { theStaTrack = sta; }
 
-    /// set the ref to combined track
-    inline void setGlobalTrack(reco::TrackRef glb) { theGlbTrack = glb; }
+      /// set the ref to combined track
+      inline void setGlobalTrack(reco::TrackRef glb) { theGlbTrack = glb; }
 
-  protected:
-  private:
-    /// ref to tracker's track which match with the stand alone muon tracks
-    reco::TrackRef theTkTrack;
+    protected:
+    private:
+      /// ref to tracker's track which match with the stand alone muon tracks
+      reco::TrackRef theTkTrack;
 
-    /// ref to the track built with the muon spectrometer alone
-    reco::TrackRef theStaTrack;
+      /// ref to the track built with the muon spectrometer alone
+      reco::TrackRef theStaTrack;
 
-    /// ref to the combined track
-    reco::TrackRef theGlbTrack;
-  };
+      /// ref to the combined track
+      reco::TrackRef theGlbTrack;
+    };
+  }  // namespace io_v1
+  using MuonTrackLinks = io_v1::MuonTrackLinks;
 }  // namespace reco
 #endif

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -8,37 +8,37 @@ not be used as version numbers. By convention, CMS will use 3 as the
 initial version number of a class which has never been stored before.
 -->
 <lcgdict>
-  <class name="reco::Muon" ClassVersion="3">
-   <version ClassVersion="3" checksum="2185262810"/>
+  <class name="reco::io_v1::Muon" ClassVersion="3">
+   <version ClassVersion="3" checksum="1255314174"/>
   </class>
-  <class name="std::vector<reco::Muon>"/>
-  <class name="edm::Wrapper<std::vector<reco::Muon> >"/>
-  <class name="edm::Ref<std::vector<reco::Muon>,reco::Muon,edm::refhelper::FindUsingAdvance<std::vector<reco::Muon>,reco::Muon> >"/>
-  <class name="edm::RefProd<std::vector<reco::Muon> >"/>
-  <class name="edm::helpers::Key<edm::RefProd<std::vector<reco::Muon> > >"/>
-  <class name="edm::RefVector<std::vector<reco::Muon>,reco::Muon,edm::refhelper::FindUsingAdvance<std::vector<reco::Muon>,reco::Muon> >"/>
-  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::Muon>,reco::Muon,edm::refhelper::FindUsingAdvance<std::vector<reco::Muon>,reco::Muon> > >"/>
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::Muon>,reco::Muon,edm::refhelper::FindUsingAdvance<std::vector<reco::Muon>,reco::Muon> > >" />
+  <class name="std::vector<reco::io_v1::Muon>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::Muon> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::Muon>,reco::io_v1::Muon,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Muon>,reco::io_v1::Muon> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::Muon> >"/>
+  <class name="edm::helpers::Key<edm::RefProd<std::vector<reco::io_v1::Muon> > >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::Muon>,reco::io_v1::Muon,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Muon>,reco::io_v1::Muon> >"/>
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::io_v1::Muon>,reco::io_v1::Muon,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Muon>,reco::io_v1::Muon> > >"/>
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<reco::io_v1::Muon>,reco::io_v1::Muon,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Muon>,reco::io_v1::Muon> > >" />
 
-<class name="reco::MuonTrackLinks" ClassVersion="3">
- <version ClassVersion="3" checksum="4185047177"/>
+<class name="reco::io_v1::MuonTrackLinks" ClassVersion="3">
+ <version ClassVersion="3" checksum="2538579591"/>
 </class>
-  <class name="std::vector<reco::MuonTrackLinks>"/>
-  <class name="edm::Wrapper<std::vector<reco::MuonTrackLinks> >"/>
-<class name="edm::Ref<std::vector<reco::MuonTrackLinks>,reco::MuonTrackLinks,edm::refhelper::FindUsingAdvance<std::vector<reco::MuonTrackLinks>,reco::MuonTrackLinks> >"/>
-  <class name="edm::RefProd<std::vector<reco::MuonTrackLinks> >"/>
-  <class name="edm::RefVector<std::vector<reco::MuonTrackLinks>,reco::MuonTrackLinks,edm::refhelper::FindUsingAdvance<std::vector<reco::MuonTrackLinks>,reco::MuonTrackLinks> >"/>
-  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::MuonTrackLinks>,reco::MuonTrackLinks,edm::refhelper::FindUsingAdvance<std::vector<reco::MuonTrackLinks>,reco::MuonTrackLinks> > >"/>
+  <class name="std::vector<reco::io_v1::MuonTrackLinks>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::MuonTrackLinks> >"/>
+<class name="edm::Ref<std::vector<reco::io_v1::MuonTrackLinks>,reco::io_v1::MuonTrackLinks,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::MuonTrackLinks>,reco::io_v1::MuonTrackLinks> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::MuonTrackLinks> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::MuonTrackLinks>,reco::io_v1::MuonTrackLinks,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::MuonTrackLinks>,reco::io_v1::MuonTrackLinks> >"/>
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::io_v1::MuonTrackLinks>,reco::io_v1::MuonTrackLinks,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::MuonTrackLinks>,reco::io_v1::MuonTrackLinks> > >"/>
   
   <class name="reco::MuonTime" ClassVersion="10">
    <version ClassVersion="10" checksum="799301851"/>
   </class>
-  <class name="reco::MuonTimeExtra" ClassVersion="10">
-   <version ClassVersion="10" checksum="1523685726"/>
+  <class name="reco::io_v1::MuonTimeExtra" ClassVersion="3">
+   <version ClassVersion="3" checksum="287562408"/>
   </class>
-  <class name="std::vector<reco::MuonTimeExtra>"/>
+  <class name="std::vector<reco::io_v1::MuonTimeExtra>"/>
   <class name="reco::MuonTimeExtraMap"/>
-  <class name="edm::Wrapper<std::vector<reco::MuonTimeExtra> >"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::MuonTimeExtra> >"/>
   <class name="edm::Wrapper<reco::MuonTimeExtraMap>"/>
 
   <class name="reco::MuonEnergy" ClassVersion="11">
@@ -80,40 +80,40 @@ initial version number of a class which has never been stored before.
    <version ClassVersion="15" checksum="838139830"/>
   </class>
 
-  <class name="reco::Muon::MuonTrackRefMap"/>
+  <class name="reco::io_v1::Muon::MuonTrackRefMap"/>
 
-  <class name="reco::CaloMuon" ClassVersion="3">
-   <version ClassVersion="3" checksum="4152762730"/>
+  <class name="reco::io_v1::CaloMuon" ClassVersion="3">
+   <version ClassVersion="3" checksum="3619049272"/>
   </class>
-  <class name="std::vector<reco::CaloMuon>"/>
-  <class name="edm::Wrapper<std::vector<reco::CaloMuon> >"/>
+  <class name="std::vector<reco::io_v1::CaloMuon>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::CaloMuon> >"/>
 
-  <class name="edm::reftobase::Holder<reco::Candidate, reco::MuonRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::MuonRef>" />
   <class name="edm::reftobase::RefHolder<reco::MuonRef>" />
-  <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::MuonRefVector>" />
+  <class name="edm::reftobase::VectorHolder<reco::io_v1::Candidate, reco::MuonRefVector>" />
   <class name="edm::reftobase::RefVectorHolder<reco::MuonRefVector>" />
 
-  <class name="edm::reftobase::BaseHolder<reco::Muon>"/>
-  <class name="edm::RefToBase<reco::Muon>"/>
-  <class name="edm::reftobase::IndirectHolder<reco::Muon>" />
-  <class name="edm::RefToBaseProd<reco::Muon>" />
-  <class name="edm::RefToBaseVector<reco::Muon>" />
-  <class name="edm::Wrapper<edm::RefToBaseVector<reco::Muon> >" />
-  <class name="edm::reftobase::BaseVectorHolder<reco::Muon>" />
+  <class name="edm::reftobase::BaseHolder<reco::io_v1::Muon>"/>
+  <class name="edm::RefToBase<reco::io_v1::Muon>"/>
+  <class name="edm::reftobase::IndirectHolder<reco::io_v1::Muon>" />
+  <class name="edm::RefToBaseProd<reco::io_v1::Muon>" />
+  <class name="edm::RefToBaseVector<reco::io_v1::Muon>" />
+  <class name="edm::Wrapper<edm::RefToBaseVector<reco::io_v1::Muon> >" />
+  <class name="edm::reftobase::BaseVectorHolder<reco::io_v1::Muon>" />
   
-  <class name="reco::MuonMETCorrectionData" ClassVersion="10">
-   <version ClassVersion="10" checksum="1486369093"/>
+  <class name="reco::io_v1::MuonMETCorrectionData" ClassVersion="3">
+   <version ClassVersion="3" checksum="90175135"/>
   </class>
-  <class name="std::vector<reco::MuonMETCorrectionData>"/>
-  <class name="std::vector<reco::MuonMETCorrectionData>::const_iterator"/>
-  <class name="edm::Wrapper<std::vector<reco::MuonMETCorrectionData> >"/>
-  <class name="edm::ValueMap<reco::MuonMETCorrectionData>"/>
-  <class name="edm::ValueMap<reco::MuonMETCorrectionData>::const_iterator">
+  <class name="std::vector<reco::io_v1::MuonMETCorrectionData>"/>
+  <class name="std::vector<reco::io_v1::MuonMETCorrectionData>::const_iterator"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::MuonMETCorrectionData> >"/>
+  <class name="edm::ValueMap<reco::io_v1::MuonMETCorrectionData>"/>
+  <class name="edm::ValueMap<reco::io_v1::MuonMETCorrectionData>::const_iterator">
     <field name="values_" transient="true"/>
     <field name="i_" transient="true"/>
     <field name="end_" transient="true"/>
   </class>
-  <class name="edm::Wrapper<edm::ValueMap<reco::MuonMETCorrectionData> >"/>
+  <class name="edm::Wrapper<edm::ValueMap<reco::io_v1::MuonMETCorrectionData> >"/>
 
   <class name="edm::Association<reco::MuonCollection>" />
   <class name="edm::Wrapper<edm::Association<reco::MuonCollection>>" />
@@ -132,33 +132,33 @@ initial version number of a class which has never been stored before.
   </class>
   <class name="edm::Wrapper<edm::ValueMap<reco::MuonQuality> >"/>
 
-  <class name="reco::MuonCosmicCompatibility" ClassVersion="10">
-   <version ClassVersion="10" checksum="3519151418"/>
+  <class name="reco::io_v1::MuonCosmicCompatibility" ClassVersion="3">
+   <version ClassVersion="3" checksum="2262157368"/>
   </class>
-  <class name="std::vector<reco::MuonCosmicCompatibility>"/>
-  <class name="std::vector<reco::MuonCosmicCompatibility>::const_iterator"/>
-  <class name="edm::Wrapper<std::vector<reco::MuonCosmicCompatibility> >"/>
-  <class name="edm::ValueMap<reco::MuonCosmicCompatibility>"/>
-  <class name="edm::ValueMap<reco::MuonCosmicCompatibility>::const_iterator">
+  <class name="std::vector<reco::io_v1::MuonCosmicCompatibility>"/>
+  <class name="std::vector<reco::io_v1::MuonCosmicCompatibility>::const_iterator"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::MuonCosmicCompatibility> >"/>
+  <class name="edm::ValueMap<reco::io_v1::MuonCosmicCompatibility>"/>
+  <class name="edm::ValueMap<reco::io_v1::MuonCosmicCompatibility>::const_iterator">
     <field name="values_" transient="true"/>
     <field name="i_" transient="true"/>
     <field name="end_" transient="true"/>
   </class>
-  <class name="edm::Wrapper<edm::ValueMap<reco::MuonCosmicCompatibility> >"/>
+  <class name="edm::Wrapper<edm::ValueMap<reco::io_v1::MuonCosmicCompatibility> >"/>
 
-  <class name="reco::MuonShower" ClassVersion="10">
-   <version ClassVersion="10" checksum="371813366"/>
+  <class name="reco::io_v1::MuonShower" ClassVersion="3">
+   <version ClassVersion="3" checksum="99079040"/>
   </class>
-  <class name="std::vector<reco::MuonShower>"/>
-  <class name="std::vector<reco::MuonShower>::const_iterator"/>
-  <class name="edm::Wrapper<std::vector<reco::MuonShower> >"/>
-  <class name="edm::ValueMap<reco::MuonShower>"/>
-  <class name="edm::ValueMap<reco::MuonShower>::const_iterator">
+  <class name="std::vector<reco::io_v1::MuonShower>"/>
+  <class name="std::vector<reco::io_v1::MuonShower>::const_iterator"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::MuonShower> >"/>
+  <class name="edm::ValueMap<reco::io_v1::MuonShower>"/>
+  <class name="edm::ValueMap<reco::io_v1::MuonShower>::const_iterator">
     <field name="values_" transient="true"/>
     <field name="i_" transient="true"/>
     <field name="end_" transient="true"/>
   </class>
-  <class name="edm::Wrapper<edm::ValueMap<reco::MuonShower> >"/>
+  <class name="edm::Wrapper<edm::ValueMap<reco::io_v1::MuonShower> >"/>
 
   <class name="reco::MuonRecHitCluster" ClassVersion="3">
     <version ClassVersion="3" checksum="2080298867"/>
@@ -190,24 +190,24 @@ initial version number of a class which has never been stored before.
   <class name="edm::Wrapper<edm::ValueMap<reco::DYTInfo> >"/>
 
   <!-- 
-  <class name="edm::reftobase::BaseHolder<reco::Muon>" />
-  <class name="edm::reftobase::IndirectVectorHolder<reco::Muon>" />
-  <class name="edm::reftobase::Holder<reco::Muon, reco::MuonRef>" />
-  <class name="edm::reftobase::VectorHolder<reco::Muon, reco::MuonRefVector>" />
+  <class name="edm::reftobase::BaseHolder<reco::io_v1::Muon>" />
+  <class name="edm::reftobase::IndirectVectorHolder<reco::io_v1::Muon>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Muon, reco::MuonRef>" />
+  <class name="edm::reftobase::VectorHolder<reco::io_v1::Muon, reco::MuonRefVector>" />
   -->
 
-  <class name="edm::Ptr<reco::Muon>" />
-  <class name="edm::Wrapper<edm::Ptr<reco::Muon> >" />
-  <class name="edm::PtrVector<reco::Muon>" />
-  <class name="edm::Wrapper<edm::PtrVector<reco::Muon> >" />
+  <class name="edm::Ptr<reco::io_v1::Muon>" />
+  <class name="edm::Wrapper<edm::Ptr<reco::io_v1::Muon> >" />
+  <class name="edm::PtrVector<reco::io_v1::Muon>" />
+  <class name="edm::Wrapper<edm::PtrVector<reco::io_v1::Muon> >" />
   
-  <class name="reco::MuonSimInfo" ClassVersion="3">
-   <version ClassVersion="3" checksum="2552652034"/>
+  <class name="reco::io_v1::MuonSimInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="638791164"/>
   </class>
-  <class name="std::vector<reco::MuonSimInfo>"/>
-  <class name="edm::Wrapper<std::vector<reco::MuonSimInfo> >"/>
-  <class name="edm::ValueMap<reco::MuonSimInfo>"/>
-  <class name="edm::Wrapper<edm::ValueMap<reco::MuonSimInfo> >"/>
+  <class name="std::vector<reco::io_v1::MuonSimInfo>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::MuonSimInfo> >"/>
+  <class name="edm::ValueMap<reco::io_v1::MuonSimInfo>"/>
+  <class name="edm::Wrapper<edm::ValueMap<reco::io_v1::MuonSimInfo> >"/>
 
 
 </lcgdict>

--- a/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
+++ b/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
@@ -31,549 +31,551 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateEGammaExtraFwd.h"
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 namespace reco {
-  /**\class PFCandidate
+  namespace io_v1 {
+    /**\class PFCandidate
      \brief Particle reconstructed by the particle flow algorithm.
           
      \author Colin Bernet
      \date   February 2007
   */
 
-  class PFCandidate : public CompositeCandidate {
-  public:
-    /// particle types
-    enum ParticleType {
-      X = 0,     // undefined
-      h,         // charged hadron
-      e,         // electron
-      mu,        // muon
-      gamma,     // photon
-      h0,        // neutral hadron
-      h_HF,      // HF tower identified as a hadron
-      egamma_HF  // HF tower identified as an EM particle
-    };
-
-    enum Flags {
-      NORMAL = 0,
-      E_PHI_SMODULES,
-      E_ETA_0,
-      E_ETA_MODULES,
-      E_BARREL_ENDCAP,
-      E_PRESHOWER_EDGE,
-      E_PRESHOWER,
-      E_ENDCAP_EDGE,
-      H_ETA_0,
-      H_BARREL_ENDCAP,
-      H_ENDCAP_VFCAL,
-      H_VFCAL_EDGE,
-      T_TO_DISP,
-      T_FROM_DISP,
-      T_FROM_V0,
-      T_FROM_GAMMACONV,
-      GAMMA_TO_GAMMACONV
-    };
-
-    enum PFVertexType {
-      kCandVertex = 0,
-      kTrkVertex = 1,
-      kComMuonVertex = 2,
-      kSAMuonVertex = 3,
-      kTrkMuonVertex = 4,
-      kGSFVertex = 5,
-      kTPFMSMuonVertex = 6,
-      kPickyMuonVertex = 7,
-      kDYTMuonVertex = 8
-    };
-
-    /// default constructor
-    PFCandidate();
-
-    /// constructor from a reference (keeps track of source relationship)
-    PFCandidate(const PFCandidatePtr& sourcePtr);
-
-    /*     PFCandidate( Charge q,  */
-    /*                  const LorentzVector & p4,  */
-    /*                  ParticleType particleId,  */
-    /*                  reco::PFBlockRef blockRef ); */
-    PFCandidate(Charge q, const LorentzVector& p4, ParticleType particleId);
-
-    /// copy constructor
-    PFCandidate(const PFCandidate&);
-
-    /// destructor
-    ~PFCandidate() override;
-
-    PFCandidate& operator=(PFCandidate const&);
-
-    /// return a clone
-    PFCandidate* clone() const override;
-
-    /*    /// set source ref */
-    /*     void setSourceRef(const PFCandidateRef& ref) { sourceRef_ = ref; } */
-
-    /*     size_type numberOfSourceCandidateRefs() const {return 1;} */
-
-    /*     CandidateBaseRef sourceCandidateRef( size_type i ) const { */
-    /*       return  CandidateBaseRef(sourceRef_); */
-    /*     } */
-
-    using reco::Candidate::setSourceCandidatePtr;
-    void setSourceCandidatePtr(const PFCandidatePtr& ptr) { sourcePtr_ = ptr; }
-
-    size_t numberOfSourceCandidatePtrs() const override { return 1; }
-
-    CandidatePtr sourceCandidatePtr(size_type i) const override { return sourcePtr_; }
-
-    /// returns the pdg id corresponding to the particle type.
-    /// the particle type could be removed at some point to gain some space.
-    /// low priority
-    int translateTypeToPdgId(ParticleType type) const;
-    ParticleType translatePdgIdToType(int pdgid) const;
-
-    /// set Particle Type
-    void setParticleType(ParticleType type);
-
-    /// add an element to the current PFCandidate
-    /*     void addElement( const reco::PFBlockElement* element ); */
-
-    /// add element in block
-    void addElementInBlock(const reco::PFBlockRef& blockref, unsigned elementIndex);
-
-    /// set track reference
-    void setTrackRef(const reco::TrackRef& ref);
-
-    /// return a reference to the corresponding track, if charged.
-    /// otherwise, return a null reference
-    reco::TrackRef trackRef() const;
-
-    /// return a pointer to the best track, if available.
-    /// otherwise, return a null pointer
-    const reco::Track* bestTrack() const override {
-      if ((abs(pdgId()) == 11 || pdgId() == 22) && gsfTrackRef().isNonnull() && gsfTrackRef().isAvailable())
-        return &(*gsfTrackRef());
-      else if (trackRef().isNonnull() && trackRef().isAvailable())
-        return &(*trackRef());
-      else
-        return nullptr;
-    }
-    /// uncertainty on dz
-    float dzError() const override {
-      const Track* tr = bestTrack();
-      if (tr != nullptr)
-        return tr->dzError();
-      else
-        return 0;
-    }
-    /// uncertainty on dxy
-    float dxyError() const override {
-      const Track* tr = bestTrack();
-      if (tr != nullptr)
-        return tr->dxyError();
-      else
-        return 0;
-    }
-
-    /// set gsftrack reference
-    void setGsfTrackRef(const reco::GsfTrackRef& ref);
-
-    /// return a reference to the corresponding GSF track, if an electron.
-    /// otherwise, return a null reference
-    reco::GsfTrackRef gsfTrackRef() const;
-
-    /// set muon reference
-    void setMuonRef(const reco::MuonRef& ref);
-
-    /// return a reference to the corresponding muon, if a muon.
-    /// otherwise, return a null reference
-    reco::MuonRef muonRef() const;
+    class PFCandidate : public CompositeCandidate {
+    public:
+      /// particle types
+      enum ParticleType {
+        X = 0,     // undefined
+        h,         // charged hadron
+        e,         // electron
+        mu,        // muon
+        gamma,     // photon
+        h0,        // neutral hadron
+        h_HF,      // HF tower identified as a hadron
+        egamma_HF  // HF tower identified as an EM particle
+      };
+
+      enum Flags {
+        NORMAL = 0,
+        E_PHI_SMODULES,
+        E_ETA_0,
+        E_ETA_MODULES,
+        E_BARREL_ENDCAP,
+        E_PRESHOWER_EDGE,
+        E_PRESHOWER,
+        E_ENDCAP_EDGE,
+        H_ETA_0,
+        H_BARREL_ENDCAP,
+        H_ENDCAP_VFCAL,
+        H_VFCAL_EDGE,
+        T_TO_DISP,
+        T_FROM_DISP,
+        T_FROM_V0,
+        T_FROM_GAMMACONV,
+        GAMMA_TO_GAMMACONV
+      };
+
+      enum PFVertexType {
+        kCandVertex = 0,
+        kTrkVertex = 1,
+        kComMuonVertex = 2,
+        kSAMuonVertex = 3,
+        kTrkMuonVertex = 4,
+        kGSFVertex = 5,
+        kTPFMSMuonVertex = 6,
+        kPickyMuonVertex = 7,
+        kDYTMuonVertex = 8
+      };
+
+      /// default constructor
+      PFCandidate();
+
+      /// constructor from a reference (keeps track of source relationship)
+      PFCandidate(const PFCandidatePtr& sourcePtr);
+
+      /*     PFCandidate( Charge q,  */
+      /*                  const LorentzVector & p4,  */
+      /*                  ParticleType particleId,  */
+      /*                  reco::PFBlockRef blockRef ); */
+      PFCandidate(Charge q, const LorentzVector& p4, ParticleType particleId);
+
+      /// copy constructor
+      PFCandidate(const PFCandidate&);
+
+      /// destructor
+      ~PFCandidate() override;
+
+      PFCandidate& operator=(PFCandidate const&);
+
+      /// return a clone
+      PFCandidate* clone() const override;
+
+      /*    /// set source ref */
+      /*     void setSourceRef(const PFCandidateRef& ref) { sourceRef_ = ref; } */
+
+      /*     size_type numberOfSourceCandidateRefs() const {return 1;} */
+
+      /*     CandidateBaseRef sourceCandidateRef( size_type i ) const { */
+      /*       return  CandidateBaseRef(sourceRef_); */
+      /*     } */
+
+      using reco::Candidate::setSourceCandidatePtr;
+      void setSourceCandidatePtr(const PFCandidatePtr& ptr) { sourcePtr_ = ptr; }
+
+      size_t numberOfSourceCandidatePtrs() const override { return 1; }
+
+      CandidatePtr sourceCandidatePtr(size_type i) const override { return sourcePtr_; }
+
+      /// returns the pdg id corresponding to the particle type.
+      /// the particle type could be removed at some point to gain some space.
+      /// low priority
+      int translateTypeToPdgId(ParticleType type) const;
+      ParticleType translatePdgIdToType(int pdgid) const;
+
+      /// set Particle Type
+      void setParticleType(ParticleType type);
+
+      /// add an element to the current PFCandidate
+      /*     void addElement( const reco::PFBlockElement* element ); */
+
+      /// add element in block
+      void addElementInBlock(const reco::PFBlockRef& blockref, unsigned elementIndex);
+
+      /// set track reference
+      void setTrackRef(const reco::TrackRef& ref);
+
+      /// return a reference to the corresponding track, if charged.
+      /// otherwise, return a null reference
+      reco::TrackRef trackRef() const;
+
+      /// return a pointer to the best track, if available.
+      /// otherwise, return a null pointer
+      const reco::Track* bestTrack() const override {
+        if ((abs(pdgId()) == 11 || pdgId() == 22) && gsfTrackRef().isNonnull() && gsfTrackRef().isAvailable())
+          return &(*gsfTrackRef());
+        else if (trackRef().isNonnull() && trackRef().isAvailable())
+          return &(*trackRef());
+        else
+          return nullptr;
+      }
+      /// uncertainty on dz
+      float dzError() const override {
+        const Track* tr = bestTrack();
+        if (tr != nullptr)
+          return tr->dzError();
+        else
+          return 0;
+      }
+      /// uncertainty on dxy
+      float dxyError() const override {
+        const Track* tr = bestTrack();
+        if (tr != nullptr)
+          return tr->dxyError();
+        else
+          return 0;
+      }
+
+      /// set gsftrack reference
+      void setGsfTrackRef(const reco::GsfTrackRef& ref);
+
+      /// return a reference to the corresponding GSF track, if an electron.
+      /// otherwise, return a null reference
+      reco::GsfTrackRef gsfTrackRef() const;
+
+      /// set muon reference
+      void setMuonRef(const reco::MuonRef& ref);
+
+      /// return a reference to the corresponding muon, if a muon.
+      /// otherwise, return a null reference
+      reco::MuonRef muonRef() const;
 
-    /// set displaced vertex reference
-    void setDisplacedVertexRef(const reco::PFDisplacedVertexRef& ref, Flags flag);
+      /// set displaced vertex reference
+      void setDisplacedVertexRef(const reco::PFDisplacedVertexRef& ref, Flags flag);
 
-    /// return a reference to the corresponding displaced vertex,
-    /// otherwise, return a null reference
-    reco::PFDisplacedVertexRef displacedVertexRef(Flags type) const;
+      /// return a reference to the corresponding displaced vertex,
+      /// otherwise, return a null reference
+      reco::PFDisplacedVertexRef displacedVertexRef(Flags type) const;
 
-    /// set ref to original reco conversion
-    void setConversionRef(const reco::ConversionRef& ref);
+      /// set ref to original reco conversion
+      void setConversionRef(const reco::ConversionRef& ref);
 
-    /// return a reference to the original conversion
-    reco::ConversionRef conversionRef() const;
+      /// return a reference to the original conversion
+      reco::ConversionRef conversionRef() const;
 
-    /// set ref to original reco conversion
-    void setV0Ref(const reco::VertexCompositeCandidateRef& ref);
+      /// set ref to original reco conversion
+      void setV0Ref(const reco::VertexCompositeCandidateRef& ref);
 
-    /// return a reference to the original conversion
-    reco::VertexCompositeCandidateRef v0Ref() const;
+      /// return a reference to the original conversion
+      reco::VertexCompositeCandidateRef v0Ref() const;
 
-    /// return a reference to the corresponding GsfElectron if any
-    reco::GsfElectronRef gsfElectronRef() const;
+      /// return a reference to the corresponding GsfElectron if any
+      reco::GsfElectronRef gsfElectronRef() const;
 
-    /// return a reference to the electron extra
-    reco::PFCandidateElectronExtraRef electronExtraRef() const;
+      /// return a reference to the electron extra
+      reco::PFCandidateElectronExtraRef electronExtraRef() const;
 
-    /// set corrected Ecal energy
-    void setEcalEnergy(float eeRaw, float eeCorr) {
-      rawEcalEnergy_ = eeRaw;
-      ecalERatio_ = std::abs(eeRaw) < 1.e-6 ? 1.0 : eeCorr / eeRaw;
-    }
+      /// set corrected Ecal energy
+      void setEcalEnergy(float eeRaw, float eeCorr) {
+        rawEcalEnergy_ = eeRaw;
+        ecalERatio_ = std::abs(eeRaw) < 1.e-6 ? 1.0 : eeCorr / eeRaw;
+      }
 
-    /// return corrected Ecal energy
-    double ecalEnergy() const { return ecalERatio_ * rawEcalEnergy_; }
+      /// return corrected Ecal energy
+      double ecalEnergy() const { return ecalERatio_ * rawEcalEnergy_; }
 
-    /// return corrected Ecal energy
-    double rawEcalEnergy() const { return rawEcalEnergy_; }
+      /// return corrected Ecal energy
+      double rawEcalEnergy() const { return rawEcalEnergy_; }
 
-    /// set corrected Hcal energy
-    void setHcalEnergy(float ehRaw, float ehCorr) {
-      rawHcalEnergy_ = ehRaw;
-      hcalERatio_ = std::abs(ehRaw) < 1.e-6 ? 1.0 : ehCorr / ehRaw;
-    }
+      /// set corrected Hcal energy
+      void setHcalEnergy(float ehRaw, float ehCorr) {
+        rawHcalEnergy_ = ehRaw;
+        hcalERatio_ = std::abs(ehRaw) < 1.e-6 ? 1.0 : ehCorr / ehRaw;
+      }
 
-    /// return corrected Hcal energy
-    double hcalEnergy() const { return hcalERatio_ * rawHcalEnergy_; }
+      /// return corrected Hcal energy
+      double hcalEnergy() const { return hcalERatio_ * rawHcalEnergy_; }
 
-    /// return raw Hcal energy
-    double rawHcalEnergy() const { return rawHcalEnergy_; }
+      /// return raw Hcal energy
+      double rawHcalEnergy() const { return rawHcalEnergy_; }
 
-    /// set corrected Hcal energy
-    void setHoEnergy(float eoRaw, float eoCorr) {
-      rawHoEnergy_ = eoRaw;
-      hoERatio_ = std::abs(eoRaw) < 1.e-6 ? 1.0 : eoCorr / eoRaw;
-    }
+      /// set corrected Hcal energy
+      void setHoEnergy(float eoRaw, float eoCorr) {
+        rawHoEnergy_ = eoRaw;
+        hoERatio_ = std::abs(eoRaw) < 1.e-6 ? 1.0 : eoCorr / eoRaw;
+      }
 
-    /// return corrected Hcal energy
-    double hoEnergy() const { return hoERatio_ * rawHoEnergy_; }
+      /// return corrected Hcal energy
+      double hoEnergy() const { return hoERatio_ * rawHoEnergy_; }
 
-    /// return raw Hcal energy
-    double rawHoEnergy() const { return rawHoEnergy_; }
+      /// return raw Hcal energy
+      double rawHoEnergy() const { return rawHoEnergy_; }
 
-    /// set GsfElectronRef
-    void setGsfElectronRef(const reco::GsfElectronRef& ref);
+      /// set GsfElectronRef
+      void setGsfElectronRef(const reco::GsfElectronRef& ref);
 
-    void setSuperClusterRef(const reco::SuperClusterRef& scRef);
+      void setSuperClusterRef(const reco::SuperClusterRef& scRef);
 
-    /// return a reference to the corresponding SuperCluster if any
-    reco::SuperClusterRef superClusterRef() const;
+      /// return a reference to the corresponding SuperCluster if any
+      reco::SuperClusterRef superClusterRef() const;
 
-    /// set ref to the corresponding reco::Photon if any
-    void setPhotonRef(const reco::PhotonRef& phRef);
+      /// set ref to the corresponding reco::Photon if any
+      void setPhotonRef(const reco::PhotonRef& phRef);
 
-    /// return a reference to the corresponding Photon if any
-    reco::PhotonRef photonRef() const;
+      /// return a reference to the corresponding Photon if any
+      reco::PhotonRef photonRef() const;
 
-    /// set the PF Photon Extra Ref
-    void setPFPhotonExtraRef(const reco::PFCandidatePhotonExtraRef& ref);
+      /// set the PF Photon Extra Ref
+      void setPFPhotonExtraRef(const reco::PFCandidatePhotonExtraRef& ref);
 
-    /// return a reference to the photon extra
-    reco::PFCandidatePhotonExtraRef photonExtraRef() const;
+      /// return a reference to the photon extra
+      reco::PFCandidatePhotonExtraRef photonExtraRef() const;
 
-    /// set the PF EGamma Extra Ref
-    void setPFEGammaExtraRef(const reco::PFCandidateEGammaExtraRef& ref);
+      /// set the PF EGamma Extra Ref
+      void setPFEGammaExtraRef(const reco::PFCandidateEGammaExtraRef& ref);
 
-    /// return a reference to the EGamma extra
-    reco::PFCandidateEGammaExtraRef egammaExtraRef() const;
+      /// return a reference to the EGamma extra
+      reco::PFCandidateEGammaExtraRef egammaExtraRef() const;
 
-    /// set corrected PS1 energy
-    void setPs1Energy(float e1) { ps1Energy_ = e1; }
+      /// set corrected PS1 energy
+      void setPs1Energy(float e1) { ps1Energy_ = e1; }
 
-    /// return corrected PS1 energy
-    double pS1Energy() const { return ps1Energy_; }
+      /// return corrected PS1 energy
+      double pS1Energy() const { return ps1Energy_; }
 
-    /// set corrected PS2 energy
-    void setPs2Energy(float e2) { ps2Energy_ = e2; }
+      /// set corrected PS2 energy
+      void setPs2Energy(float e2) { ps2Energy_ = e2; }
 
-    /// return corrected PS2 energy
-    double pS2Energy() const { return ps2Energy_; }
+      /// return corrected PS2 energy
+      double pS2Energy() const { return ps2Energy_; }
 
-    /// particle momentum *= rescaleFactor
-    void rescaleMomentum(double rescaleFactor);
+      /// particle momentum *= rescaleFactor
+      void rescaleMomentum(double rescaleFactor);
 
-    /// set a given flag
-    void setFlag(Flags theFlag, bool value);
+      /// set a given flag
+      void setFlag(Flags theFlag, bool value);
 
-    /// return a given flag
-    bool flag(Flags theFlag) const;
+      /// return a given flag
+      bool flag(Flags theFlag) const;
 
-    /// set uncertainty on momentum
-    void setDeltaP(double dp) { deltaP_ = dp; }
+      /// set uncertainty on momentum
+      void setDeltaP(double dp) { deltaP_ = dp; }
 
-    /// uncertainty on 3-momentum
-    double deltaP() const { return deltaP_; }
+      /// uncertainty on 3-momentum
+      double deltaP() const { return deltaP_; }
 
-    //  int pdgId() const { return translateTypeToPdgId( particleId_ ); }
+      //  int pdgId() const { return translateTypeToPdgId( particleId_ ); }
 
-    /// set mva for electron-pion discrimination.
-    /// For charged particles, this variable is set
-    ///   to 0 for particles that are not preided
-    ///   to 1 otherwise
-    /// For neutral particles, it is set to the default value
+      /// set mva for electron-pion discrimination.
+      /// For charged particles, this variable is set
+      ///   to 0 for particles that are not preided
+      ///   to 1 otherwise
+      /// For neutral particles, it is set to the default value
 
-    void set_mva_Isolated(float mvaI) { mva_Isolated_ = mvaI; }
-    // mva for isolated electrons
-    float mva_Isolated() const { return mva_Isolated_; }
+      void set_mva_Isolated(float mvaI) { mva_Isolated_ = mvaI; }
+      // mva for isolated electrons
+      float mva_Isolated() const { return mva_Isolated_; }
 
-    void set_mva_e_pi(float mvaNI) { mva_e_pi_ = mvaNI; }
-    /// mva for electron-pion discrimination
-    float mva_e_pi() const { return mva_e_pi_; }
+      void set_mva_e_pi(float mvaNI) { mva_e_pi_ = mvaNI; }
+      /// mva for electron-pion discrimination
+      float mva_e_pi() const { return mva_e_pi_; }
 
-    /// set mva for electron-muon discrimination
-    void set_mva_e_mu(float mva) { mva_e_mu_ = mva; }
+      /// set mva for electron-muon discrimination
+      void set_mva_e_mu(float mva) { mva_e_mu_ = mva; }
 
-    /// mva for electron-muon discrimination
-    float mva_e_mu() const { return mva_e_mu_; }
+      /// mva for electron-muon discrimination
+      float mva_e_mu() const { return mva_e_mu_; }
 
-    /// set mva for pi-muon discrimination
-    void set_mva_pi_mu(float mva) { mva_pi_mu_ = mva; }
+      /// set mva for pi-muon discrimination
+      void set_mva_pi_mu(float mva) { mva_pi_mu_ = mva; }
 
-    /// mva for pi-muon discrimination
-    float mva_pi_mu() const { return mva_pi_mu_; }
+      /// mva for pi-muon discrimination
+      float mva_pi_mu() const { return mva_pi_mu_; }
 
-    /// set mva for gamma detection
-    void set_mva_nothing_gamma(float mva) { mva_nothing_gamma_ = mva; }
+      /// set mva for gamma detection
+      void set_mva_nothing_gamma(float mva) { mva_nothing_gamma_ = mva; }
 
-    /// mva for gamma detection
-    float mva_nothing_gamma() const { return mva_nothing_gamma_; }
+      /// mva for gamma detection
+      float mva_nothing_gamma() const { return mva_nothing_gamma_; }
 
-    /// set mva for neutral hadron detection
-    void set_mva_nothing_nh(float mva) { mva_nothing_nh_ = mva; }
+      /// set mva for neutral hadron detection
+      void set_mva_nothing_nh(float mva) { mva_nothing_nh_ = mva; }
 
-    /// mva for neutral hadron detection
-    float mva_nothing_nh() const { return mva_nothing_nh_; }
+      /// mva for neutral hadron detection
+      float mva_nothing_nh() const { return mva_nothing_nh_; }
 
-    /// set mva for neutral hadron - gamma discrimination
-    void set_mva_gamma_nh(float mva) { mva_gamma_nh_ = mva; }
+      /// set mva for neutral hadron - gamma discrimination
+      void set_mva_gamma_nh(float mva) { mva_gamma_nh_ = mva; }
 
-    // set DNN for electron PFID
-    // mva for ele PFID DNN sigIsolated class
-    float dnn_e_sigIsolated() const { return dnn_e_sigIsolated_; }
-    void set_dnn_e_sigIsolated(float mva) { dnn_e_sigIsolated_ = mva; }
+      // set DNN for electron PFID
+      // mva for ele PFID DNN sigIsolated class
+      float dnn_e_sigIsolated() const { return dnn_e_sigIsolated_; }
+      void set_dnn_e_sigIsolated(float mva) { dnn_e_sigIsolated_ = mva; }
 
-    // mva for ele PFID DNN sigNonIsolated class
-    float dnn_e_sigNonIsolated() const { return dnn_e_sigNonIsolated_; }
-    void set_dnn_e_sigNonIsolated(float mva) { dnn_e_sigNonIsolated_ = mva; }
+      // mva for ele PFID DNN sigNonIsolated class
+      float dnn_e_sigNonIsolated() const { return dnn_e_sigNonIsolated_; }
+      void set_dnn_e_sigNonIsolated(float mva) { dnn_e_sigNonIsolated_ = mva; }
 
-    // mva for ele PFID DNN bkgNonIsolated class
-    float dnn_e_bkgNonIsolated() const { return dnn_e_bkgNonIsolated_; }
-    void set_dnn_e_bkgNonIsolated(float mva) { dnn_e_bkgNonIsolated_ = mva; }
+      // mva for ele PFID DNN bkgNonIsolated class
+      float dnn_e_bkgNonIsolated() const { return dnn_e_bkgNonIsolated_; }
+      void set_dnn_e_bkgNonIsolated(float mva) { dnn_e_bkgNonIsolated_ = mva; }
 
-    // mva for ele PFID DNN bkgTau class
-    float dnn_e_bkgTau() const { return dnn_e_bkgTau_; }
-    void set_dnn_e_bkgTau(float mva) { dnn_e_bkgTau_ = mva; }
+      // mva for ele PFID DNN bkgTau class
+      float dnn_e_bkgTau() const { return dnn_e_bkgTau_; }
+      void set_dnn_e_bkgTau(float mva) { dnn_e_bkgTau_ = mva; }
 
-    // mva for ele PFID DNN bkgPhoton class
-    float dnn_e_bkgPhoton() const { return dnn_e_bkgPhoton_; }
-    void set_dnn_e_bkgPhoton(float mva) { dnn_e_bkgPhoton_ = mva; }
+      // mva for ele PFID DNN bkgPhoton class
+      float dnn_e_bkgPhoton() const { return dnn_e_bkgPhoton_; }
+      void set_dnn_e_bkgPhoton(float mva) { dnn_e_bkgPhoton_ = mva; }
 
-    // set DNN for gamma PFID
-    float dnn_gamma() const { return dnn_gamma_; }
-    void set_dnn_gamma(float mva) { dnn_gamma_ = mva; }
+      // set DNN for gamma PFID
+      float dnn_gamma() const { return dnn_gamma_; }
+      void set_dnn_gamma(float mva) { dnn_gamma_ = mva; }
 
-    /// mva for neutral hadron - gamma discrimination
-    float mva_gamma_nh() const { return mva_gamma_nh_; }
+      /// mva for neutral hadron - gamma discrimination
+      float mva_gamma_nh() const { return mva_gamma_nh_; }
 
-    /// set position at ECAL entrance
-    void setPositionAtECALEntrance(const math::XYZPointF& pos) { positionAtECALEntrance_ = pos; }
+      /// set position at ECAL entrance
+      void setPositionAtECALEntrance(const math::XYZPointF& pos) { positionAtECALEntrance_ = pos; }
 
-    /// set the PF Electron Extra Ref
-    void setPFElectronExtraRef(const reco::PFCandidateElectronExtraRef& ref);
+      /// set the PF Electron Extra Ref
+      void setPFElectronExtraRef(const reco::PFCandidateElectronExtraRef& ref);
 
-    /// set the Best Muon Track Ref
-    void setMuonTrackType(const reco::Muon::MuonTrackType& type) { muonTrackType_ = type; }
+      /// set the Best Muon Track Ref
+      void setMuonTrackType(const reco::Muon::MuonTrackType& type) { muonTrackType_ = type; }
 
-    /// get the Best Muon Track Ref
+      /// get the Best Muon Track Ref
 
-    const reco::Muon::MuonTrackType bestMuonTrackType() const { return muonTrackType_; }
+      const reco::Muon::MuonTrackType bestMuonTrackType() const { return muonTrackType_; }
 
-    /// \return position at ECAL entrance
-    const math::XYZPointF& positionAtECALEntrance() const { return positionAtECALEntrance_; }
+      /// \return position at ECAL entrance
+      const math::XYZPointF& positionAtECALEntrance() const { return positionAtECALEntrance_; }
 
-    /// particle identification code
-    /// \todo use Particle::pdgId_ and remove this data member
-    virtual ParticleType particleId() const { return translatePdgIdToType(pdgId()); }
+      /// particle identification code
+      /// \todo use Particle::pdgId_ and remove this data member
+      virtual ParticleType particleId() const { return translatePdgIdToType(pdgId()); }
 
-    /// return indices of elements used in the block
-    /*     const std::vector<unsigned>& elementIndices() const {  */
-    /*       return elementIndices_; */
-    /*     } */
-    /// return elements
-    /*     const edm::OwnVector< reco::PFBlockElement >& elements() const  */
-    /*       {return elements_;} */
+      /// return indices of elements used in the block
+      /*     const std::vector<unsigned>& elementIndices() const {  */
+      /*       return elementIndices_; */
+      /*     } */
+      /// return elements
+      /*     const edm::OwnVector< reco::PFBlockElement >& elements() const  */
+      /*       {return elements_;} */
 
-    /// return elements in blocks
-    typedef std::pair<reco::PFBlockRef, unsigned> ElementInBlock;
-    typedef std::vector<ElementInBlock> ElementsInBlocks;
+      /// return elements in blocks
+      typedef std::pair<reco::PFBlockRef, unsigned> ElementInBlock;
+      typedef std::vector<ElementInBlock> ElementsInBlocks;
 
-    typedef edm::RefVector<reco::PFBlockCollection> Blocks;
-    typedef std::vector<unsigned> Elements;
+      typedef edm::RefVector<reco::PFBlockCollection> Blocks;
+      typedef std::vector<unsigned> Elements;
 
-    const ElementsInBlocks& elementsInBlocks() const;
+      const ElementsInBlocks& elementsInBlocks() const;
 
-    static constexpr float bigMva_ = -999.;
+      static constexpr float bigMva_ = -999.;
 
-    friend std::ostream& operator<<(std::ostream& out, const PFCandidate& c);
+      friend std::ostream& operator<<(std::ostream& out, const PFCandidate& c);
 
-    const Point& vertex() const override;
-    double vx() const override { return vertex().x(); }
-    double vy() const override { return vertex().y(); }
-    double vz() const override { return vertex().z(); }
+      const Point& vertex() const override;
+      double vx() const override { return vertex().x(); }
+      double vy() const override { return vertex().y(); }
+      double vz() const override { return vertex().z(); }
 
-    /// do we have a valid time information
-    bool isTimeValid() const { return timeError_ >= 0.f; }
-    /// \return the timing
-    float time() const { return time_; }
-    /// \return the timing uncertainty
-    float timeError() const { return timeError_; }
-    /// \set the timing information
-    void setTime(float time, float timeError = 0.f) {
-      time_ = time;
-      timeError_ = timeError;
-    }
+      /// do we have a valid time information
+      bool isTimeValid() const { return timeError_ >= 0.f; }
+      /// \return the timing
+      float time() const { return time_; }
+      /// \return the timing uncertainty
+      float timeError() const { return timeError_; }
+      /// \set the timing information
+      void setTime(float time, float timeError = 0.f) {
+        time_ = time;
+        timeError_ = timeError;
+      }
 
-    /// fraction of hcal energy at a given depth  (depth = 1 .. 7)
-    float hcalDepthEnergyFraction(unsigned int depth) const { return hcalDepthEnergyFractions_[depth - 1]; }
-    /// fraction of hcal energy at a given depth (index 0..6 for depth 1..7)
-    const std::array<float, 7>& hcalDepthEnergyFractions() const { return hcalDepthEnergyFractions_; }
-    /// set the fraction of hcal energy as function of depth (index 0..6 for depth 1..7)
-    void setHcalDepthEnergyFractions(const std::array<float, 7>& fracs) { hcalDepthEnergyFractions_ = fracs; }
+      /// fraction of hcal energy at a given depth  (depth = 1 .. 7)
+      float hcalDepthEnergyFraction(unsigned int depth) const { return hcalDepthEnergyFractions_[depth - 1]; }
+      /// fraction of hcal energy at a given depth (index 0..6 for depth 1..7)
+      const std::array<float, 7>& hcalDepthEnergyFractions() const { return hcalDepthEnergyFractions_; }
+      /// set the fraction of hcal energy as function of depth (index 0..6 for depth 1..7)
+      void setHcalDepthEnergyFractions(const std::array<float, 7>& fracs) { hcalDepthEnergyFractions_ = fracs; }
 
-  private:
-    //function used before PR #31456, retained for backwards compatibility with old AOD where the vertex was not embedded
-    const math::XYZPoint& vertexLegacy(PFCandidate::PFVertexType vertexType) const;
+    private:
+      //function used before PR #31456, retained for backwards compatibility with old AOD where the vertex was not embedded
+      const math::XYZPoint& vertexLegacy(PFCandidate::PFVertexType vertexType) const;
 
-    /// Polymorphic overlap
-    bool overlap(const Candidate&) const override;
+      /// Polymorphic overlap
+      bool overlap(const Candidate&) const override;
 
-    void setFlag(unsigned shift, unsigned flag, bool value);
+      void setFlag(unsigned shift, unsigned flag, bool value);
 
-    bool flag(unsigned shift, unsigned flag) const;
+      bool flag(unsigned shift, unsigned flag) const;
 
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
-    mutable std::atomic<ElementsInBlocks*> elementsInBlocks_;
+      mutable std::atomic<ElementsInBlocks*> elementsInBlocks_;
 #else
-    mutable ElementsInBlocks* elementsInBlocks_;
+      mutable ElementsInBlocks* elementsInBlocks_;
 #endif
-    Blocks blocksStorage_;
-    Elements elementsStorage_;
+      Blocks blocksStorage_;
+      Elements elementsStorage_;
 
-    /// reference to the source PFCandidate, if any
-    /*     PFCandidateRef sourceRef_; */
-    PFCandidatePtr sourcePtr_;
+      /// reference to the source PFCandidate, if any
+      /*     PFCandidateRef sourceRef_; */
+      PFCandidatePtr sourcePtr_;
 
-    ///Reference to the best track if it is a muon
-    ///pF is allowed to switch the default muon track
-    reco::Muon::MuonTrackType muonTrackType_;
+      ///Reference to the best track if it is a muon
+      ///pF is allowed to switch the default muon track
+      reco::Muon::MuonTrackType muonTrackType_;
 
-    /// corrected ECAL energy ratio (corrected/raw)
-    float ecalERatio_;
+      /// corrected ECAL energy ratio (corrected/raw)
+      float ecalERatio_;
 
-    /// corrected HCAL energy ratio (corrected/raw)
-    float hcalERatio_;
+      /// corrected HCAL energy ratio (corrected/raw)
+      float hcalERatio_;
 
-    /// corrected HO energy ratio (corrected/raw)
-    float hoERatio_;
+      /// corrected HO energy ratio (corrected/raw)
+      float hoERatio_;
 
-    /// raw ECAL energy
-    float rawEcalEnergy_;
+      /// raw ECAL energy
+      float rawEcalEnergy_;
 
-    /// raw HCAL energy
-    float rawHcalEnergy_;
+      /// raw HCAL energy
+      float rawHcalEnergy_;
 
-    /// raw HO energy
-    float rawHoEnergy_;
+      /// raw HO energy
+      float rawHoEnergy_;
 
-    /// corrected PS1 energy
-    float ps1Energy_;
+      /// corrected PS1 energy
+      float ps1Energy_;
 
-    /// corrected PS2 energy
-    float ps2Energy_;
+      /// corrected PS2 energy
+      float ps2Energy_;
 
-    /// all flags, packed (ecal regional, hcal regional, tracking)
-    unsigned flags_;
+      /// all flags, packed (ecal regional, hcal regional, tracking)
+      unsigned flags_;
 
-    /// uncertainty on 3-momentum
-    float deltaP_;
+      /// uncertainty on 3-momentum
+      float deltaP_;
 
-    //legacy vertex type to read AOD created before PR #31456
-    PFVertexType vertexType_;
+      //legacy vertex type to read AOD created before PR #31456
+      PFVertexType vertexType_;
 
-    // mva for isolated electrons
-    float mva_Isolated_;
+      // mva for isolated electrons
+      float mva_Isolated_;
 
-    /// mva for electron-pion discrimination
-    float mva_e_pi_;
+      /// mva for electron-pion discrimination
+      float mva_e_pi_;
 
-    /// mva for electron-muon discrimination
-    float mva_e_mu_;
+      /// mva for electron-muon discrimination
+      float mva_e_mu_;
 
-    /// mva for pi-muon discrimination
-    float mva_pi_mu_;
+      /// mva for pi-muon discrimination
+      float mva_pi_mu_;
 
-    /// mva for gamma detection
-    float mva_nothing_gamma_;
+      /// mva for gamma detection
+      float mva_nothing_gamma_;
 
-    /// mva for neutral hadron detection
-    float mva_nothing_nh_;
+      /// mva for neutral hadron detection
+      float mva_nothing_nh_;
 
-    /// mva for neutral hadron - gamma discrimination
-    float mva_gamma_nh_;
+      /// mva for neutral hadron - gamma discrimination
+      float mva_gamma_nh_;
 
-    /// DNN for electron PFid: isolated signal
-    float dnn_e_sigIsolated_;
+      /// DNN for electron PFid: isolated signal
+      float dnn_e_sigIsolated_;
 
-    /// DNN for electron PFid: non-isolated signal
-    float dnn_e_sigNonIsolated_;
+      /// DNN for electron PFid: non-isolated signal
+      float dnn_e_sigNonIsolated_;
 
-    /// DNN for electron PFid: non-isolated bkg
-    float dnn_e_bkgNonIsolated_;
+      /// DNN for electron PFid: non-isolated bkg
+      float dnn_e_bkgNonIsolated_;
 
-    /// DNN for electron PFid: tau bkg
-    float dnn_e_bkgTau_;
+      /// DNN for electron PFid: tau bkg
+      float dnn_e_bkgTau_;
 
-    /// DNN for electron PFid: photon bkg
-    float dnn_e_bkgPhoton_;
+      /// DNN for electron PFid: photon bkg
+      float dnn_e_bkgPhoton_;
 
-    // DNN for gamma PFid
-    float dnn_gamma_;
+      // DNN for gamma PFid
+      float dnn_gamma_;
 
-    /// position at ECAL entrance, from the PFRecTrack
-    math::XYZPointF positionAtECALEntrance_;
+      /// position at ECAL entrance, from the PFRecTrack
+      math::XYZPointF positionAtECALEntrance_;
 
-    //more efficiently stored refs
-    void storeRefInfo(unsigned int iMask,
-                      unsigned int iBit,
-                      bool iIsValid,
-                      const edm::RefCore& iCore,
-                      size_t iKey,
-                      const edm::EDProductGetter*);
-    bool getRefInfo(
-        unsigned int iMask, unsigned int iBit, edm::ProductID& oProdID, size_t& oIndex, size_t& aIndex) const;
+      //more efficiently stored refs
+      void storeRefInfo(unsigned int iMask,
+                        unsigned int iBit,
+                        bool iIsValid,
+                        const edm::RefCore& iCore,
+                        size_t iKey,
+                        const edm::EDProductGetter*);
+      bool getRefInfo(
+          unsigned int iMask, unsigned int iBit, edm::ProductID& oProdID, size_t& oIndex, size_t& aIndex) const;
 
-    const edm::EDProductGetter* getter_;  //transient
-    unsigned short storedRefsBitPattern_;
-    std::vector<unsigned long long> refsInfo_;
-    std::vector<const void*> refsCollectionCache_;
+      const edm::EDProductGetter* getter_;  //transient
+      unsigned short storedRefsBitPattern_;
+      std::vector<unsigned long long> refsInfo_;
+      std::vector<const void*> refsCollectionCache_;
 
-    /// timing information (valid if timeError_ >= 0)
-    float time_;
-    /// timing information uncertainty (<0 if timing not available)
-    float timeError_;
+      /// timing information (valid if timeError_ >= 0)
+      float time_;
+      /// timing information uncertainty (<0 if timing not available)
+      float timeError_;
 
-    std::array<float, 7> hcalDepthEnergyFractions_;
-  };
+      std::array<float, 7> hcalDepthEnergyFractions_;
+    };
 
+    /// get default PFBlockRef component
+    /// as: pfcand->get<PFBlockRef>();
+    /*   GET_DEFAULT_CANDIDATE_COMPONENT( PFCandidate, PFBlockRef, block ); */
+
+    /// get int component
+    /// as: pfcand->get<int, PFParticleIdTag>();
+
+    std::ostream& operator<<(std::ostream& out, const PFCandidate& c);
+
+  }  // namespace io_v1
+  using PFCandidate = io_v1::PFCandidate;
   /// particle ID component tag
   struct PFParticleIdTag {};
-
-  /// get default PFBlockRef component
-  /// as: pfcand->get<PFBlockRef>();
-  /*   GET_DEFAULT_CANDIDATE_COMPONENT( PFCandidate, PFBlockRef, block ); */
-
-  /// get int component
-  /// as: pfcand->get<int, PFParticleIdTag>();
   GET_CANDIDATE_COMPONENT(PFCandidate, PFCandidate::ParticleType, particleId, PFParticleIdTag);
-
-  std::ostream& operator<<(std::ostream& out, const PFCandidate& c);
-
 }  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h
+++ b/DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h
@@ -9,8 +9,10 @@
 #include "DataFormats/Common/interface/FwdPtr.h"
 
 namespace reco {
-  class PFCandidate;
-
+  namespace io_v1 {
+    class PFCandidate;
+  }
+  using PFCandidate = io_v1::PFCandidate;
   /// collection of PFCandidates
   typedef std::vector<reco::PFCandidate> PFCandidateCollection;
 

--- a/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
+++ b/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
@@ -312,7 +312,7 @@ void PFCandidate::setFlag(Flags theFlag, bool value) {
 
 bool PFCandidate::flag(Flags theFlag) const { return (flags_ >> theFlag) & 1; }
 
-ostream& reco::operator<<(ostream& out, const PFCandidate& c) {
+ostream& reco::io_v1::operator<<(ostream& out, const PFCandidate& c) {
   if (!out)
     return out;
 

--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -1,69 +1,53 @@
 <lcgdict>
 
-   <class name="reco::PFCandidate" ClassVersion="20">
-    <version ClassVersion="20" checksum="2748489940"/>
-    <version ClassVersion="19" checksum="2990582232"/>
-    <version ClassVersion="18" checksum="910857761"/>
-    <version ClassVersion="17" checksum="3126170233"/>
-    <version ClassVersion="16" checksum="3060382005"/>
-    <version ClassVersion="15" checksum="1136968957"/>
-    <version ClassVersion="10" checksum="536762407"/>
-    <version ClassVersion="11" checksum="2503588164"/>
-    <version ClassVersion="12" checksum="2782366916"/>
-    <version ClassVersion="13" checksum="3911979988"/>
-    <version ClassVersion="14" checksum="3379420193"/>
+   <class name="reco::io_v1::PFCandidate" ClassVersion="3">
+    <version ClassVersion="3" checksum="3624191462"/>
      <field name="elementsInBlocks_" transient="true"/>
      <field name="getter_" transient="true"/>
      <field name="refsCollectionCache_" transient="true"/>
    </class>
-  <ioread sourceClass = "reco::PFCandidate" version="[1-]" targetClass="reco::PFCandidate" source="" target="getter_">
+  <ioread sourceClass = "reco::io_v1::PFCandidate" version="[1-]" targetClass="reco::io_v1::PFCandidate" source="" target="getter_">
     <![CDATA[edm::EDProductGetter::assignEDProductGetter(getter_); ]]>
   </ioread>
-  <ioread sourceClass = "reco::PFCandidate" version="[1-]" targetClass="reco::PFCandidate" source="" target="elementsInBlocks_">
+  <ioread sourceClass = "reco::io_v1::PFCandidate" version="[1-]" targetClass="reco::io_v1::PFCandidate" source="" target="elementsInBlocks_">
     <![CDATA[elementsInBlocks_ = nullptr; ]]>
   </ioread>
-  <ioread sourceClass = "reco::PFCandidate" version="[1-]" targetClass="reco::PFCandidate" source="std::vector<unsigned long long> refsInfo_" target="refsCollectionCache_">
+  <ioread sourceClass = "reco::io_v1::PFCandidate" version="[1-]" targetClass="reco::io_v1::PFCandidate" source="std::vector<unsigned long long> refsInfo_" target="refsCollectionCache_">
     <![CDATA[refsCollectionCache_.clear();refsCollectionCache_.resize(onfile.refsInfo_.size(),0); ]]>
   </ioread>
 
    <class name="edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> >">
      <field name="m_data" transient="true"/>
   </class>
-  <class name="std::vector<reco::PFCandidate>"/>
-  <class name="edm::Wrapper<reco::PFCandidate>"/>
-  <class name="edm::Wrapper<std::vector<reco::PFCandidate> >"/>
+  <class name="std::vector<reco::io_v1::PFCandidate>"/>
+  <class name="edm::Wrapper<reco::io_v1::PFCandidate>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::PFCandidate> >"/>
   <class name="reco::PFCandidateRef"/>
   <class name="reco::PFCandidateRefProd"/>
   <class name="reco::PFCandidateRefVector"/>
-  <class name="reco::PFCandidate::ElementInBlock"/>
-  <class name="reco::PFCandidate::ElementsInBlocks"/>
-  <class name="edm::reftobase::Holder<reco::Candidate, reco::PFCandidateRef>"/>
+  <class name="reco::io_v1::PFCandidate::ElementInBlock"/>
+  <class name="reco::io_v1::PFCandidate::ElementsInBlocks"/>
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::PFCandidateRef>"/>
   <class name="edm::reftobase::RefHolder<reco::PFCandidateRef>"/>
   <class name="reco::PFCandidatePtr"/>
   <class name="edm::AtomicPtrCache<reco::PFCandidatePtr>"/>
   <class name="std::vector<reco::PFCandidatePtr>"/>
-  <class name="edm::Wrapper<edm::ValueMap<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > >"/>
-  <class name="edm::ValueMap<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > >"/>
-  <class name="std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > >"/>
-  <class name="std::vector<std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > >"/>
-  <class name="edm::Wrapper<edm::ValueMap<std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > > >"/>
-  <class name="edm::ValueMap<std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > >"/>
-  <class name="edm::Wrapper<edm::ValueMap<edm::Ptr<reco::PFCandidate> > >"/>
-  <class name="edm::ValueMap<edm::Ptr<std::vector<reco::PFCandidate> > >"/>
-  <class name="std::vector<edm::Ptr<std::vector<reco::PFCandidate> > >"/>
-  <class name="edm::ValueMap<edm::Ptr<reco::PFCandidate> >"/>
+  <class name="edm::Wrapper<edm::ValueMap<edm::Ref<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate> > > >"/>
+  <class name="edm::ValueMap<edm::Ref<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate> > >"/>
+  <class name="std::vector<edm::Ref<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate> > >"/>
+  <class name="std::vector<std::vector<edm::Ref<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate> > > >"/>
+  <class name="edm::Wrapper<edm::ValueMap<std::vector<edm::Ref<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate> > > > >"/>
+  <class name="edm::ValueMap<std::vector<edm::Ref<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate> > > >"/>
+  <class name="edm::Wrapper<edm::ValueMap<edm::Ptr<reco::io_v1::PFCandidate> > >"/>
+  <class name="edm::ValueMap<edm::Ptr<std::vector<reco::io_v1::PFCandidate> > >"/>
+  <class name="std::vector<edm::Ptr<std::vector<reco::io_v1::PFCandidate> > >"/>
+  <class name="edm::ValueMap<edm::Ptr<reco::io_v1::PFCandidate> >"/>
   <class name="edm::reftobase::RefVectorHolder<reco::PFCandidateRefVector >"/>
-  <class name="edm::PtrVector<reco::PFCandidate> "/>
-  <class name="edm::Wrapper<edm::PtrVector<reco::PFCandidate> >"/>
+  <class name="edm::PtrVector<reco::io_v1::PFCandidate> "/>
+  <class name="edm::Wrapper<edm::PtrVector<reco::io_v1::PFCandidate> >"/>
 
-  <class name="reco::IsolatedPFCandidate"  ClassVersion="16">
-   <version ClassVersion="16" checksum="2274533749"/>
-   <version ClassVersion="15" checksum="3042264953"/>
-   <version ClassVersion="14" checksum="207328514"/>
-   <version ClassVersion="13" checksum="1855164250"/>
-   <version ClassVersion="12" checksum="2650360086"/>
-   <version ClassVersion="11" checksum="696008414"/>
-   <version ClassVersion="10" checksum="1426765407"/>
+  <class name="reco::IsolatedPFCandidate"  ClassVersion="3">
+   <version ClassVersion="3" checksum="1014378071"/>
   </class>
   <class name="std::vector<reco::IsolatedPFCandidate>"/>
   <class name="edm::Wrapper<std::vector<reco::IsolatedPFCandidate> >"/>
@@ -72,14 +56,8 @@
   <class name="reco::IsolatedPFCandidateRefVector"/>
   <class name="reco::IsolatedPFCandidatePtr"/>
 
-  <class name="reco::PileUpPFCandidate"  ClassVersion="16">
-   <version ClassVersion="16" checksum="3331568330"/>
-   <version ClassVersion="15" checksum="953549166"/>
-   <version ClassVersion="14" checksum="4065938015"/>
-   <version ClassVersion="13" checksum="1734488695"/>
-   <version ClassVersion="12" checksum="2377890195"/>
-   <version ClassVersion="11" checksum="1422984859"/>
-   <version ClassVersion="10" checksum="1986419188"/>
+  <class name="reco::PileUpPFCandidate"  ClassVersion="3">
+   <version ClassVersion="3" checksum="4065313068"/>
   </class>
   <class name="std::vector<reco::PileUpPFCandidate>"/>
   <class name="edm::Wrapper<std::vector<reco::PileUpPFCandidate> >"/>
@@ -89,7 +67,7 @@
   <class name="reco::PileUpPFCandidatePtr"/>
 
   <class name="reco::PFCandidateFwdRef"/>
-  <class name="edm::reftobase::Holder<reco::Candidate, reco::PFCandidateFwdRef>"/>
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::PFCandidateFwdRef>"/>
   <class name="edm::reftobase::RefHolder<reco::PFCandidateFwdRef>"/>
   <class name="reco::PFCandidateFwdPtr"/>
   <class name="std::vector<reco::PFCandidateFwdRef>"/>
@@ -97,7 +75,7 @@
   <class name="edm::Wrapper<std::vector<reco::PFCandidateFwdPtr> >"/>
 
   <class name="reco::PFCandidateElectronExtra" ClassVersion="3">
-   <version ClassVersion="3" checksum="450244063"/>
+   <version ClassVersion="3" checksum="356094023"/>
 <!-- 
   <field name="mvaVariables_" transient="true"/>
 -->
@@ -109,7 +87,7 @@
   <class name="reco::PFCandidateElectronExtraRefVector"/>
 
   <class name="reco::PFCandidatePhotonExtra" ClassVersion="3">
-   <version ClassVersion="3" checksum="2283262343"/>
+   <version ClassVersion="3" checksum="2361815551"/>
   </class>
   <class name="std::vector<reco::PFCandidatePhotonExtra>"/>
   <class name="edm::Wrapper<std::vector<reco::PFCandidatePhotonExtra> >"/>
@@ -135,34 +113,34 @@
   <class name="edm::Wrapper<edm::Association<reco::PFCandidateCollection> >" />
 
   
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::Vertex> >,edm::RefProd<std::vector<reco::PFCandidate> > >" />  
-  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> >,float> > >" />
-  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> >,float> > > > " />
-  <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Vertex>,std::vector<reco::PFCandidate>,float,unsigned int> >" >
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::io_v1::Vertex> >,edm::RefProd<std::vector<reco::io_v1::PFCandidate> > >" />  
+  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate> >,float> > >" />
+  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate> >,float> > > > " />
+  <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::io_v1::Vertex>,std::vector<reco::io_v1::PFCandidate>,float,unsigned int> >" >
     <field name="transientMap_" transient="true"/>
   </class>
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Vertex>,std::vector<reco::PFCandidate>,float,unsigned int> > >" >
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::io_v1::Vertex>,std::vector<reco::io_v1::PFCandidate>,float,unsigned int> > >" >
     <field name="transientMap_" transient="true"/>
   </class>
-  <class name="std::vector<std::pair<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> >,float> >" />							
-  <class name="std::pair<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> >,float>" />	
-  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> >,int> > >" />
-  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> >,int> > > > " />
-  <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Vertex>,std::vector<reco::PFCandidate>,int,unsigned int> >" >
+  <class name="std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate> >,float> >" />							
+  <class name="std::pair<edm::Ref<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate> >,float>" />	
+  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate> >,int> > >" />
+  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate> >,int> > > > " />
+  <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::io_v1::Vertex>,std::vector<reco::io_v1::PFCandidate>,int,unsigned int> >" >
     <field name="transientMap_" transient="true"/>
   </class>
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Vertex>,std::vector<reco::PFCandidate>,int,unsigned int> > >" />
-  <class name="std::vector<std::pair<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> >,int> >" />							
-  <class name="std::pair<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> >,int>" />
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::io_v1::Vertex>,std::vector<reco::io_v1::PFCandidate>,int,unsigned int> > >" />
+  <class name="std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate> >,int> >" />							
+  <class name="std::pair<edm::Ref<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate> >,int>" />
 										
 										
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::PFCandidate> >,edm::RefProd<std::vector<reco::Vertex> > >" />  
-  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> >,std::vector<std::pair<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,int> > >" />
-  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> >,std::vector<std::pair<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,int> > > > " />
-  <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::PFCandidate>,std::vector<reco::Vertex>,int,unsigned int> >" >
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::io_v1::PFCandidate> >,edm::RefProd<std::vector<reco::io_v1::Vertex> > >" />  
+  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate> >,std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex> >,int> > >" />
+  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFCandidate>,reco::io_v1::PFCandidate> >,std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex> >,int> > > > " />
+  <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::io_v1::PFCandidate>,std::vector<reco::io_v1::Vertex>,int,unsigned int> >" >
     <field name="transientMap_" transient="true"/>
   </class>
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::PFCandidate>,std::vector<reco::Vertex>,int,unsigned int> > >" />
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::io_v1::PFCandidate>,std::vector<reco::io_v1::Vertex>,int,unsigned int> > >" />
 
 </lcgdict>
  

--- a/DataFormats/ParticleFlowReco/interface/HGCalMultiCluster.h
+++ b/DataFormats/ParticleFlowReco/interface/HGCalMultiCluster.h
@@ -9,29 +9,32 @@
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 
 namespace reco {
-  class HGCalMultiCluster : public reco::PFCluster {
-  public:
-    typedef edm::PtrVector<reco::BasicCluster>::const_iterator component_iterator;
-    typedef edm::PtrVector<reco::BasicCluster> ClusterCollection;
+  namespace io_v1 {
+    class HGCalMultiCluster : public reco::PFCluster {
+    public:
+      typedef edm::PtrVector<reco::BasicCluster>::const_iterator component_iterator;
+      typedef edm::PtrVector<reco::BasicCluster> ClusterCollection;
 
-    HGCalMultiCluster() : PFCluster() { this->setLayer(PFLayer::HGCAL); }
+      HGCalMultiCluster() : PFCluster() { this->setLayer(PFLayer::HGCAL); }
 
-    HGCalMultiCluster(double energy, double x, double y, double z, ClusterCollection& thecls);
+      HGCalMultiCluster(double energy, double x, double y, double z, ClusterCollection& thecls);
 
-    void push_back(const edm::Ptr<reco::BasicCluster>& b) { myclusters.push_back(b); }
+      void push_back(const edm::Ptr<reco::BasicCluster>& b) { myclusters.push_back(b); }
 
-    const edm::PtrVector<reco::BasicCluster>& clusters() const { return myclusters; }
+      const edm::PtrVector<reco::BasicCluster>& clusters() const { return myclusters; }
 
-    unsigned int size() const { return myclusters.size(); }
-    component_iterator begin() const { return myclusters.begin(); }
-    component_iterator end() const { return myclusters.end(); }
+      unsigned int size() const { return myclusters.size(); }
+      component_iterator begin() const { return myclusters.begin(); }
+      component_iterator end() const { return myclusters.end(); }
 
-    bool operator>(const HGCalMultiCluster& rhs) const { return (energy() > rhs.energy()); }
+      bool operator>(const HGCalMultiCluster& rhs) const { return (energy() > rhs.energy()); }
 
-  private:
-    edm::PtrVector<reco::BasicCluster> myclusters;
-  };
+    private:
+      edm::PtrVector<reco::BasicCluster> myclusters;
+    };
 
+  }  // namespace io_v1
+  using HGCalMultiCluster = io_v1::HGCalMultiCluster;
   typedef std::vector<HGCalMultiCluster> HGCalMultiClusterCollection;
 }  // namespace reco
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFBlock.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlock.h
@@ -12,9 +12,10 @@
 #include "DataFormats/Common/interface/OwnVector.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  /// \brief Block of elements
-  /*!
+    /// \brief Block of elements
+    /*!
     \author Colin Bernet
     \date January 2006
 
@@ -23,86 +24,88 @@ namespace reco {
     - a set of links between these elements
   */
 
-  class PFBlock {
-  public:
-    struct Link {
-      Link() : distance(-1), test(0) {}
-      Link(float d, char t) : distance(d), test(t) {}
-      float distance;
-      char test;
+    class PFBlock {
+    public:
+      struct Link {
+        Link() : distance(-1), test(0) {}
+        Link(float d, char t) : distance(d), test(t) {}
+        float distance;
+        char test;
+      };
+
+      typedef edm::OwnVector<reco::PFBlockElement>::const_iterator IE;
+      /*     typedef std::vector< reco::PFBlockLink >::const_iterator IL; */
+
+      // typedef std::vector< std::vector<double> > LinkData;
+      typedef std::map<unsigned int, Link> LinkData;
+
+      enum LinkTest { LINKTEST_RECHIT, LINKTEST_NLINKTEST, LINKTEST_ALL };
+
+      PFBlock() {}
+      // PFBlock(const PFBlock& other);
+
+      /// add an element to the current PFBlock
+      /// the block will keep a copy.
+      void addElement(reco::PFBlockElement* element);
+
+      void bookLinkData();
+
+      /// makes the correspondance between a 2d element matrix and
+      /// the 1D vector which is the most compact way to store the matrix
+      bool matrix2vector(unsigned i, unsigned j, unsigned& index) const;
+
+      /// set a link between elements of indices i1 and i2, of "distance" dist
+      /// the link is set in the linkData vector provided as an argument.
+      /// As indicated by the 'const' statement, 'this' is not modified.
+      void setLink(unsigned i1, unsigned i2, double dist, LinkData& linkData, LinkTest test = LINKTEST_RECHIT) const;
+
+      /// lock an element ( unlink it from the others )
+      /// Colin: this function is misleading
+      /// void lock(unsigned i, LinkData& linkData ) const;
+
+      /// fills a map with the elements associated to element i.
+      /// elements are sorted by increasing distance.
+      /// if specified, only the elements of type "type" will be considered
+      /// if specified, only the link calculated from a certain "test" will
+      /// be considered: distance test, etc..
+      void associatedElements(unsigned i,
+                              const LinkData& linkData,
+                              std::multimap<double, unsigned>& sortedAssociates,
+                              reco::PFBlockElement::Type type = PFBlockElement::NONE,
+                              LinkTest test = LINKTEST_RECHIT) const;
+
+      /// \return distance of link
+      double dist(unsigned ie1, unsigned ie2, const LinkData& linkData, LinkTest test) const {
+        return dist(ie1, ie2, linkData);
+      }
+
+      /// \return distance of link
+      double dist(unsigned ie1, unsigned ie2, const LinkData& linkData) const;
+
+      /// \return elements
+      const edm::OwnVector<reco::PFBlockElement>& elements() const { return elements_; }
+
+      /// \return link data
+      const LinkData& linkData() const { return linkData_; }
+
+      /// \return link data
+      LinkData& linkData() { return linkData_; }
+
+    private:
+      /// \return size of linkData_, calculated from the number of elements
+      unsigned linkDataSize() const;
+
+      /// link data (permanent)
+      LinkData linkData_;
+
+      /// all elements
+      edm::OwnVector<reco::PFBlockElement> elements_;
     };
 
-    typedef edm::OwnVector<reco::PFBlockElement>::const_iterator IE;
-    /*     typedef std::vector< reco::PFBlockLink >::const_iterator IL; */
+    std::ostream& operator<<(std::ostream& out, const PFBlock& co);
 
-    // typedef std::vector< std::vector<double> > LinkData;
-    typedef std::map<unsigned int, Link> LinkData;
-
-    enum LinkTest { LINKTEST_RECHIT, LINKTEST_NLINKTEST, LINKTEST_ALL };
-
-    PFBlock() {}
-    // PFBlock(const PFBlock& other);
-
-    /// add an element to the current PFBlock
-    /// the block will keep a copy.
-    void addElement(reco::PFBlockElement* element);
-
-    void bookLinkData();
-
-    /// makes the correspondance between a 2d element matrix and
-    /// the 1D vector which is the most compact way to store the matrix
-    bool matrix2vector(unsigned i, unsigned j, unsigned& index) const;
-
-    /// set a link between elements of indices i1 and i2, of "distance" dist
-    /// the link is set in the linkData vector provided as an argument.
-    /// As indicated by the 'const' statement, 'this' is not modified.
-    void setLink(unsigned i1, unsigned i2, double dist, LinkData& linkData, LinkTest test = LINKTEST_RECHIT) const;
-
-    /// lock an element ( unlink it from the others )
-    /// Colin: this function is misleading
-    /// void lock(unsigned i, LinkData& linkData ) const;
-
-    /// fills a map with the elements associated to element i.
-    /// elements are sorted by increasing distance.
-    /// if specified, only the elements of type "type" will be considered
-    /// if specified, only the link calculated from a certain "test" will
-    /// be considered: distance test, etc..
-    void associatedElements(unsigned i,
-                            const LinkData& linkData,
-                            std::multimap<double, unsigned>& sortedAssociates,
-                            reco::PFBlockElement::Type type = PFBlockElement::NONE,
-                            LinkTest test = LINKTEST_RECHIT) const;
-
-    /// \return distance of link
-    double dist(unsigned ie1, unsigned ie2, const LinkData& linkData, LinkTest test) const {
-      return dist(ie1, ie2, linkData);
-    }
-
-    /// \return distance of link
-    double dist(unsigned ie1, unsigned ie2, const LinkData& linkData) const;
-
-    /// \return elements
-    const edm::OwnVector<reco::PFBlockElement>& elements() const { return elements_; }
-
-    /// \return link data
-    const LinkData& linkData() const { return linkData_; }
-
-    /// \return link data
-    LinkData& linkData() { return linkData_; }
-
-  private:
-    /// \return size of linkData_, calculated from the number of elements
-    unsigned linkDataSize() const;
-
-    /// link data (permanent)
-    LinkData linkData_;
-
-    /// all elements
-    edm::OwnVector<reco::PFBlockElement> elements_;
-  };
-
-  std::ostream& operator<<(std::ostream& out, const PFBlock& co);
-
+  }  // namespace io_v1
+  using PFBlock = io_v1::PFBlock;
 }  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFBlockFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockFwd.h
@@ -7,7 +7,10 @@
 /* #include "DataFormats/Common/interface/RefProd.h" */
 
 namespace reco {
-  class PFBlock;
+  namespace io_v1 {
+    class PFBlock;
+  }
+  using PFBlock = io_v1::PFBlock;
 
   /// collection of PFBlock objects
   typedef std::vector<PFBlock> PFBlockCollection;

--- a/DataFormats/ParticleFlowReco/interface/PFCluster.h
+++ b/DataFormats/ParticleFlowReco/interface/PFCluster.h
@@ -18,8 +18,9 @@
 class PFClusterAlgo;
 
 namespace reco {
+  namespace io_v1 {
 
-  /**\class PFCluster
+    /**\class PFCluster
      \brief Particle flow cluster, see clustering algorithm in PFClusterAlgo
      
      A particle flow cluster is defined by its energy and position, which are 
@@ -39,129 +40,131 @@ namespace reco {
      \author Colin Bernet
      \date   July 2006
   */
-  class PFCluster : public CaloCluster {
-  public:
-    typedef std::vector<std::pair<CaloClusterPtr::key_type, edm::Ptr<PFCluster>>> EEtoPSAssociation;
-    // Next typedef uses double in ROOT 6 rather than Double32_t due to a bug in ROOT 5,
-    // which otherwise would make ROOT5 files unreadable in ROOT6.  This does not increase
-    // the size on disk, because due to the bug, double was actually stored on disk in ROOT 5.
-    typedef ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double>> REPPoint;
+    class PFCluster : public CaloCluster {
+    public:
+      typedef std::vector<std::pair<CaloClusterPtr::key_type, edm::Ptr<PFCluster>>> EEtoPSAssociation;
+      // Next typedef uses double in ROOT 6 rather than Double32_t due to a bug in ROOT 5,
+      // which otherwise would make ROOT5 files unreadable in ROOT6.  This does not increase
+      // the size on disk, because due to the bug, double was actually stored on disk in ROOT 5.
+      typedef ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double>> REPPoint;
 
-    PFCluster() : CaloCluster(CaloCluster::particleFlow), time_(-99.0), layer_(PFLayer::NONE) {}
+      PFCluster() : CaloCluster(CaloCluster::particleFlow), time_(-99.0), layer_(PFLayer::NONE) {}
 
-    /// constructor
-    PFCluster(PFLayer::Layer layer, double energy, double x, double y, double z);
+      /// constructor
+      PFCluster(PFLayer::Layer layer, double energy, double x, double y, double z);
 
-    /// resets clusters parameters
-    void reset();
+      /// resets clusters parameters
+      void reset();
 
-    /// reset only hits and fractions
-    void resetHitsAndFractions();
+      /// reset only hits and fractions
+      void resetHitsAndFractions();
 
-    /// add a given fraction of the rechit
-    void addRecHitFraction(const reco::PFRecHitFraction& frac);
+      /// add a given fraction of the rechit
+      void addRecHitFraction(const reco::PFRecHitFraction& frac);
 
-    /// vector of rechit fractions
-    const std::vector<reco::PFRecHitFraction>& recHitFractions() const { return rechits_; }
+      /// vector of rechit fractions
+      const std::vector<reco::PFRecHitFraction>& recHitFractions() const { return rechits_; }
 
-    /// set layer
-    void setLayer(PFLayer::Layer layer);
+      /// set layer
+      void setLayer(PFLayer::Layer layer);
 
-    /// cluster layer, see PFLayer.h in this directory
-    PFLayer::Layer layer() const;
+      /// cluster layer, see PFLayer.h in this directory
+      PFLayer::Layer layer() const;
 
-    /// cluster energy
-    double energy() const { return energy_; }
+      /// cluster energy
+      double energy() const { return energy_; }
 
-    /// \return cluster time
-    float time() const { return time_; }
-    /// \return the timing uncertainty
-    float timeError() const { return timeError_; }
+      /// \return cluster time
+      float time() const { return time_; }
+      /// \return the timing uncertainty
+      float timeError() const { return timeError_; }
 
-    /// cluster depth
-    double depth() const { return depth_; }
+      /// cluster depth
+      double depth() const { return depth_; }
 
-    void setTime(float time, float timeError = 0) {
-      time_ = time;
-      timeError_ = timeError;
-    }
-    void setTimeError(float timeError) { timeError_ = timeError; }
-    void setDepth(double depth) { depth_ = depth; }
+      void setTime(float time, float timeError = 0) {
+        time_ = time;
+        timeError_ = timeError;
+      }
+      void setTimeError(float timeError) { timeError_ = timeError; }
+      void setDepth(double depth) { depth_ = depth; }
 
-    /// cluster position: rho, eta, phi
-    const REPPoint& positionREP() const { return posrep_; }
+      /// cluster position: rho, eta, phi
+      const REPPoint& positionREP() const { return posrep_; }
 
-    /// computes posrep_ once and for all
-    void calculatePositionREP() { posrep_.SetCoordinates(position_.Rho(), position_.Eta(), position_.Phi()); }
+      /// computes posrep_ once and for all
+      void calculatePositionREP() { posrep_.SetCoordinates(position_.Rho(), position_.Eta(), position_.Phi()); }
 
-    /// \todo move to PFClusterTools
-    static double getDepthCorrection(double energy, bool isBelowPS = false, bool isHadron = false);
+      /// \todo move to PFClusterTools
+      static double getDepthCorrection(double energy, bool isBelowPS = false, bool isHadron = false);
 
-    /// some classes to make this fit into a template footprint
-    /// for RecoPFClusterRefCandidate so we can make jets and MET
-    /// out of PFClusters.
+      /// some classes to make this fit into a template footprint
+      /// for RecoPFClusterRefCandidate so we can make jets and MET
+      /// out of PFClusters.
 
-    /// dummy charge
-    double charge() const { return 0; }
+      /// dummy charge
+      double charge() const { return 0; }
 
-    /// transverse momentum, massless approximation
-    double pt() const { return (energy() * sin(position_.theta())); }
+      /// transverse momentum, massless approximation
+      double pt() const { return (energy() * sin(position_.theta())); }
 
-    /// angle
-    double theta() const { return position_.theta(); }
+      /// angle
+      double theta() const { return position_.theta(); }
 
-    /// dummy vertex access
-    math::XYZPoint const& vertex() const { return dummyVtx_; }
-    double vx() const { return vertex().x(); }
-    double vy() const { return vertex().y(); }
-    double vz() const { return vertex().z(); }
+      /// dummy vertex access
+      math::XYZPoint const& vertex() const { return dummyVtx_; }
+      double vx() const { return vertex().x(); }
+      double vy() const { return vertex().y(); }
+      double vz() const { return vertex().z(); }
 
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
-    template <typename pruner>
-    void pruneUsing(pruner prune) {
-      // remove_if+erase algo applied to both vectors...
-      auto iter = std::find_if_not(rechits_.begin(), rechits_.end(), prune);
-      if (iter == rechits_.end())
-        return;
-      auto first = iter - rechits_.begin();
-      for (auto i = first; ++i < int(rechits_.size());) {
-        if (prune(rechits_[i])) {
-          rechits_[first] = std::move(rechits_[i]);
-          hitsAndFractions_[first] = std::move(hitsAndFractions_[i]);
-          ++first;
+      template <typename pruner>
+      void pruneUsing(pruner prune) {
+        // remove_if+erase algo applied to both vectors...
+        auto iter = std::find_if_not(rechits_.begin(), rechits_.end(), prune);
+        if (iter == rechits_.end())
+          return;
+        auto first = iter - rechits_.begin();
+        for (auto i = first; ++i < int(rechits_.size());) {
+          if (prune(rechits_[i])) {
+            rechits_[first] = std::move(rechits_[i]);
+            hitsAndFractions_[first] = std::move(hitsAndFractions_[i]);
+            ++first;
+          }
         }
+        rechits_.erase(rechits_.begin() + first, rechits_.end());
+        hitsAndFractions_.erase(hitsAndFractions_.begin() + first, hitsAndFractions_.end());
       }
-      rechits_.erase(rechits_.begin() + first, rechits_.end());
-      hitsAndFractions_.erase(hitsAndFractions_.begin() + first, hitsAndFractions_.end());
-    }
 #endif
 
-  private:
-    /// vector of rechit fractions (transient)
-    std::vector<reco::PFRecHitFraction> rechits_;
+    private:
+      /// vector of rechit fractions (transient)
+      std::vector<reco::PFRecHitFraction> rechits_;
 
-    /// cluster position: rho, eta, phi (transient)
-    REPPoint posrep_;
+      /// cluster position: rho, eta, phi (transient)
+      REPPoint posrep_;
 
-    /// Michalis: add timing and depth information
-    float time_;
-    float timeError_{0};
-    double depth_{0};
+      /// Michalis: add timing and depth information
+      float time_;
+      float timeError_{0};
+      double depth_{0};
 
-    /// transient layer
-    PFLayer::Layer layer_;
+      /// transient layer
+      PFLayer::Layer layer_;
 
-    /// depth corrections
-    static const constexpr double depthCorA_ = 0.89;
-    static const constexpr double depthCorB_ = 7.3;
-    static const constexpr double depthCorAp_ = 0.89;
-    static const constexpr double depthCorBp_ = 4.0;
+      /// depth corrections
+      static const constexpr double depthCorA_ = 0.89;
+      static const constexpr double depthCorB_ = 7.3;
+      static const constexpr double depthCorAp_ = 0.89;
+      static const constexpr double depthCorBp_ = 4.0;
 
-    static const math::XYZPoint dummyVtx_;
-  };
+      static const math::XYZPoint dummyVtx_;
+    };
 
-  std::ostream& operator<<(std::ostream& out, const PFCluster& cluster);
+    std::ostream& operator<<(std::ostream& out, const PFCluster& cluster);
 
+  }  // namespace io_v1
+  using PFCluster = io_v1::PFCluster;
 }  // namespace reco
 
 #endif  // DataFormats_ParticleFlowReco_PFCluster_h

--- a/DataFormats/ParticleFlowReco/interface/PFClusterFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/PFClusterFwd.h
@@ -6,7 +6,10 @@
 #include "DataFormats/Common/interface/RefProd.h"
 
 namespace reco {
-  class PFCluster;
+  namespace io_v1 {
+    class PFCluster;
+  }
+  using PFCluster = io_v1::PFCluster;
 
   /// collection of PFCluster objects
   typedef std::vector<PFCluster> PFClusterCollection;

--- a/DataFormats/ParticleFlowReco/interface/PFConversion.h
+++ b/DataFormats/ParticleFlowReco/interface/PFConversion.h
@@ -9,8 +9,6 @@
 #include <iostream>
 #include <vector>
 
-class Conversion;
-
 namespace reco {
 
   /**\class PFConversion

--- a/DataFormats/ParticleFlowReco/interface/PFDisplacedVertex.h
+++ b/DataFormats/ParticleFlowReco/interface/PFDisplacedVertex.h
@@ -10,9 +10,10 @@
 #include <iostream>
 
 namespace reco {
+  namespace io_v1 {
 
-  /// \brief Block of elements
-  /*!
+    /// \brief Block of elements
+    /*!
     \author Maxime Gouzevitch
     \date November 2009
 
@@ -20,247 +21,251 @@ namespace reco {
     tracks's hit-vertex distances, tracks types and the expected vertex type.
   */
 
-  class PFDisplacedVertex : public Vertex {
-  public:
-    /// Information on the distance between track's hits and the Vertex
-    typedef std::pair<unsigned int, unsigned int> PFTrackHitInfo;
-    typedef std::pair<PFTrackHitInfo, PFTrackHitInfo> PFTrackHitFullInfo;
+    class PFDisplacedVertex : public Vertex {
+    public:
+      /// Information on the distance between track's hits and the Vertex
+      typedef std::pair<unsigned int, unsigned int> PFTrackHitInfo;
+      typedef std::pair<PFTrackHitInfo, PFTrackHitInfo> PFTrackHitFullInfo;
 
-    /// Mass hypothesis enum
-    enum M_Hypo { M_CUSTOM, M_MASSLESS, M_PION, M_KAON, M_LAMBDA };
+      /// Mass hypothesis enum
+      enum M_Hypo { M_CUSTOM, M_MASSLESS, M_PION, M_KAON, M_LAMBDA };
 
-    /// Classification of tracks according to the position with respect
-    /// to the Vertex. A Merged track is a track which has at least
-    /// two hits before and two hits after the vertex. It may come from
-    /// a primary track merged with a low quality secondary track.
-    enum VertexTrackType { T_NOT_FROM_VERTEX, T_TO_VERTEX, T_FROM_VERTEX, T_MERGED };
+      /// Classification of tracks according to the position with respect
+      /// to the Vertex. A Merged track is a track which has at least
+      /// two hits before and two hits after the vertex. It may come from
+      /// a primary track merged with a low quality secondary track.
+      enum VertexTrackType { T_NOT_FROM_VERTEX, T_TO_VERTEX, T_FROM_VERTEX, T_MERGED };
 
-    /// Classification of vertex according to different parameters such as the
-    /// Number of tracks, the invariant mass etc...
-    enum VertexType {
-      ANY = 0,
-      FAKE = 1,
-      LOOPER = 2,
-      NUCL = 10,
-      NUCL_LOOSE = 11,
-      NUCL_KINK = 12,
-      CONVERSION = 20,
-      CONVERSION_LOOSE = 21,
-      CONVERTED_BREMM = 22,
-      K0_DECAY = 30,
-      LAMBDA_DECAY = 31,
-      LAMBDABAR_DECAY = 32,
-      KPLUS_DECAY = 40,
-      KMINUS_DECAY = 41,
-      KPLUS_DECAY_LOOSE = 42,
-      KMINUS_DECAY_LOOSE = 43,
-      BSM_VERTEX = 100
-    };
+      /// Classification of vertex according to different parameters such as the
+      /// Number of tracks, the invariant mass etc...
+      enum VertexType {
+        ANY = 0,
+        FAKE = 1,
+        LOOPER = 2,
+        NUCL = 10,
+        NUCL_LOOSE = 11,
+        NUCL_KINK = 12,
+        CONVERSION = 20,
+        CONVERSION_LOOSE = 21,
+        CONVERTED_BREMM = 22,
+        K0_DECAY = 30,
+        LAMBDA_DECAY = 31,
+        LAMBDABAR_DECAY = 32,
+        KPLUS_DECAY = 40,
+        KMINUS_DECAY = 41,
+        KPLUS_DECAY_LOOSE = 42,
+        KMINUS_DECAY_LOOSE = 43,
+        BSM_VERTEX = 100
+      };
 
-    /// Default constructor
-    PFDisplacedVertex();
+      /// Default constructor
+      PFDisplacedVertex();
 
-    /// Constructor from the reco::Vertex
-    PFDisplacedVertex(reco::Vertex&);
+      /// Constructor from the reco::Vertex
+      PFDisplacedVertex(reco::Vertex&);
 
-    /// Add a new track to the vertex
-    void addElement(const TrackBaseRef& r,
-                    const Track& refTrack,
-                    const PFTrackHitFullInfo& hitInfo,
-                    VertexTrackType trackType = T_NOT_FROM_VERTEX,
-                    float w = 1.0);
+      /// Add a new track to the vertex
+      void addElement(const TrackBaseRef& r,
+                      const Track& refTrack,
+                      const PFTrackHitFullInfo& hitInfo,
+                      VertexTrackType trackType = T_NOT_FROM_VERTEX,
+                      float w = 1.0);
 
-    /// Clean the tracks collection and all the associated collections
-    void cleanTracks();
+      /// Clean the tracks collection and all the associated collections
+      void cleanTracks();
 
-    /// Set the type of this vertex
-    void setVertexType(VertexType vertexType) { vertexType_ = vertexType; }
+      /// Set the type of this vertex
+      void setVertexType(VertexType vertexType) { vertexType_ = vertexType; }
 
-    /// Estimate the direction of the vertex. This function produced a unitary vector.
-    /// It is calculated the axis linking the primary vertex of the event pvtx to this vertex
-    void setPrimaryDirection(const math::XYZPoint& pvtx);
+      /// Estimate the direction of the vertex. This function produced a unitary vector.
+      /// It is calculated the axis linking the primary vertex of the event pvtx to this vertex
+      void setPrimaryDirection(const math::XYZPoint& pvtx);
 
-    /// Get the type of this vertex
-    VertexType vertexType() { return vertexType_; }
+      /// Get the type of this vertex
+      VertexType vertexType() { return vertexType_; }
 
-    const std::vector<PFTrackHitFullInfo> trackHitFullInfos() const { return trackHitFullInfos_; }
+      const std::vector<PFTrackHitFullInfo> trackHitFullInfos() const { return trackHitFullInfos_; }
 
-    const std::vector<VertexTrackType> trackTypes() const { return trackTypes_; }
+      const std::vector<VertexTrackType> trackTypes() const { return trackTypes_; }
 
-    /// -------- Provide useful information -------- ///
+      /// -------- Provide useful information -------- ///
 
-    /// If a primary track was identified
-    const bool isTherePrimaryTracks() const { return isThereKindTracks(T_TO_VERTEX); }
+      /// If a primary track was identified
+      const bool isTherePrimaryTracks() const { return isThereKindTracks(T_TO_VERTEX); }
 
-    /// If a merged track was identified
-    const bool isThereMergedTracks() const { return isThereKindTracks(T_MERGED); }
+      /// If a merged track was identified
+      const bool isThereMergedTracks() const { return isThereKindTracks(T_MERGED); }
 
-    /// If a secondary track was identified
-    const bool isThereSecondaryTracks() const { return isThereKindTracks(T_FROM_VERTEX); }
+      /// If a secondary track was identified
+      const bool isThereSecondaryTracks() const { return isThereKindTracks(T_FROM_VERTEX); }
 
-    /// If there is a track which was not identified
-    const bool isThereNotFromVertexTracks() const { return isThereKindTracks(T_NOT_FROM_VERTEX); }
+      /// If there is a track which was not identified
+      const bool isThereNotFromVertexTracks() const { return isThereKindTracks(T_NOT_FROM_VERTEX); }
 
-    /// Is a primary track was identified
-    const bool isPrimaryTrack(const reco::TrackBaseRef& originalTrack) const {
-      size_t itrk = trackPosition(originalTrack);
-      return isTrack(itrk, T_TO_VERTEX);
-    }
+      /// Is a primary track was identified
+      const bool isPrimaryTrack(const reco::TrackBaseRef& originalTrack) const {
+        size_t itrk = trackPosition(originalTrack);
+        return isTrack(itrk, T_TO_VERTEX);
+      }
 
-    /// Is a secondary track was identified
-    const bool isSecondaryTrack(const reco::TrackBaseRef& originalTrack) const {
-      size_t itrk = trackPosition(originalTrack);
-      return isTrack(itrk, T_FROM_VERTEX);
-    }
+      /// Is a secondary track was identified
+      const bool isSecondaryTrack(const reco::TrackBaseRef& originalTrack) const {
+        size_t itrk = trackPosition(originalTrack);
+        return isTrack(itrk, T_FROM_VERTEX);
+      }
 
-    /// Is a secondary track was identified
-    const bool isMergedTrack(const reco::TrackBaseRef& originalTrack) const {
-      size_t itrk = trackPosition(originalTrack);
-      return isTrack(itrk, T_MERGED);
-    }
+      /// Is a secondary track was identified
+      const bool isMergedTrack(const reco::TrackBaseRef& originalTrack) const {
+        size_t itrk = trackPosition(originalTrack);
+        return isTrack(itrk, T_MERGED);
+      }
 
-    const PFTrackHitFullInfo trackHitFullInfo(const reco::TrackBaseRef& originalTrack) const {
-      size_t itrk = trackPosition(originalTrack);
-      return trackHitFullInfos_[itrk];
-    }
+      const PFTrackHitFullInfo trackHitFullInfo(const reco::TrackBaseRef& originalTrack) const {
+        size_t itrk = trackPosition(originalTrack);
+        return trackHitFullInfos_[itrk];
+      }
 
-    /// Is primary or merged track
-    const bool isIncomingTrack(const reco::TrackBaseRef& originalTrack) const {
-      size_t itrk = trackPosition(originalTrack);
-      return isTrack(itrk, T_MERGED) || isTrack(itrk, T_TO_VERTEX);
-    }
+      /// Is primary or merged track
+      const bool isIncomingTrack(const reco::TrackBaseRef& originalTrack) const {
+        size_t itrk = trackPosition(originalTrack);
+        return isTrack(itrk, T_MERGED) || isTrack(itrk, T_TO_VERTEX);
+      }
 
-    /// Is secondary track
-    const bool isOutgoingTrack(const reco::TrackBaseRef& originalTrack) const {
-      size_t itrk = trackPosition(originalTrack);
-      return isTrack(itrk, T_FROM_VERTEX);
-    }
+      /// Is secondary track
+      const bool isOutgoingTrack(const reco::TrackBaseRef& originalTrack) const {
+        size_t itrk = trackPosition(originalTrack);
+        return isTrack(itrk, T_FROM_VERTEX);
+      }
 
-    /// Number of primary tracks was identified
-    const int nPrimaryTracks() const { return nKindTracks(T_TO_VERTEX); }
+      /// Number of primary tracks was identified
+      const int nPrimaryTracks() const { return nKindTracks(T_TO_VERTEX); }
 
-    /// Number of merged tracks was identified
-    const int nMergedTracks() const { return nKindTracks(T_MERGED); }
+      /// Number of merged tracks was identified
+      const int nMergedTracks() const { return nKindTracks(T_MERGED); }
 
-    /// Number of secondary tracks was identified
-    const int nSecondaryTracks() const { return nKindTracks(T_FROM_VERTEX); }
+      /// Number of secondary tracks was identified
+      const int nSecondaryTracks() const { return nKindTracks(T_FROM_VERTEX); }
 
-    /// Number of tracks which was not identified
-    const int nNotFromVertexTracks() const { return nKindTracks(T_NOT_FROM_VERTEX); }
+      /// Number of tracks which was not identified
+      const int nNotFromVertexTracks() const { return nKindTracks(T_NOT_FROM_VERTEX); }
 
-    /// Number of tracks
-    const int nTracks() const { return trackTypes_.size(); }
+      /// Number of tracks
+      const int nTracks() const { return trackTypes_.size(); }
 
-    //    const reco::VertexTrackType vertexTrackType(reco::TrackBaseRef tkRef) const;
+      //    const reco::VertexTrackType vertexTrackType(reco::TrackBaseRef tkRef) const;
 
-    /// Momentum of secondary tracks calculated with a mass hypothesis. Some of those
-    /// hypothesis are default: "PI" , "KAON", "LAMBDA", "MASSLESS", "CUSTOM"
-    /// the value of custom shall be then provided in mass variable
-    const math::XYZTLorentzVector secondaryMomentum(std::string massHypo = "PI",
+      /// Momentum of secondary tracks calculated with a mass hypothesis. Some of those
+      /// hypothesis are default: "PI" , "KAON", "LAMBDA", "MASSLESS", "CUSTOM"
+      /// the value of custom shall be then provided in mass variable
+      const math::XYZTLorentzVector secondaryMomentum(std::string massHypo = "PI",
+                                                      bool useRefitted = true,
+                                                      double mass = 0.0) const {
+        return momentum(massHypo, T_FROM_VERTEX, useRefitted, mass);
+      }
+
+      /// Momentum of primary or merged track calculated with a mass hypothesis.
+      const math::XYZTLorentzVector primaryMomentum(std::string massHypo = "PI",
                                                     bool useRefitted = true,
                                                     double mass = 0.0) const {
-      return momentum(massHypo, T_FROM_VERTEX, useRefitted, mass);
-    }
+        return momentum(massHypo, T_TO_VERTEX, useRefitted, mass);
+      }
 
-    /// Momentum of primary or merged track calculated with a mass hypothesis.
-    const math::XYZTLorentzVector primaryMomentum(std::string massHypo = "PI",
-                                                  bool useRefitted = true,
-                                                  double mass = 0.0) const {
-      return momentum(massHypo, T_TO_VERTEX, useRefitted, mass);
-    }
+      /// Momentum of secondary tracks calculated with a mass hypothesis. Some of those
+      /// hypothesis are default: "PI" , "KAON", "LAMBDA", "MASSLESS", "CUSTOM"
+      /// the value of custom shall be then provided in mass variable
+      const math::XYZTLorentzVector secondaryMomentum(M_Hypo massHypo,
+                                                      bool useRefitted = true,
+                                                      double mass = 0.0) const {
+        return momentum(massHypo, T_FROM_VERTEX, useRefitted, mass);
+      }
 
-    /// Momentum of secondary tracks calculated with a mass hypothesis. Some of those
-    /// hypothesis are default: "PI" , "KAON", "LAMBDA", "MASSLESS", "CUSTOM"
-    /// the value of custom shall be then provided in mass variable
-    const math::XYZTLorentzVector secondaryMomentum(M_Hypo massHypo, bool useRefitted = true, double mass = 0.0) const {
-      return momentum(massHypo, T_FROM_VERTEX, useRefitted, mass);
-    }
+      /// Momentum of primary or merged track calculated with a mass hypothesis.
+      const math::XYZTLorentzVector primaryMomentum(M_Hypo massHypo, bool useRefitted = true, double mass = 0.0) const {
+        return momentum(massHypo, T_TO_VERTEX, useRefitted, mass);
+      }
 
-    /// Momentum of primary or merged track calculated with a mass hypothesis.
-    const math::XYZTLorentzVector primaryMomentum(M_Hypo massHypo, bool useRefitted = true, double mass = 0.0) const {
-      return momentum(massHypo, T_TO_VERTEX, useRefitted, mass);
-    }
+      void calcKinematics() {
+        defaultPrimaryMomentum_ = momentum("PI", T_TO_VERTEX, false, 0.0);
+        defaultSecondaryMomentum_ = momentum("PI", T_FROM_VERTEX, true, 0.0);
+      }
 
-    void calcKinematics() {
-      defaultPrimaryMomentum_ = momentum("PI", T_TO_VERTEX, false, 0.0);
-      defaultSecondaryMomentum_ = momentum("PI", T_FROM_VERTEX, true, 0.0);
-    }
+      const double secondaryPt() const { return defaultPrimaryMomentum_.Pt(); }
 
-    const double secondaryPt() const { return defaultPrimaryMomentum_.Pt(); }
+      /// Momentum of primary or merged track calculated with a mass hypothesis.
+      const double primaryPt() const { return defaultSecondaryMomentum_.Pt(); }
 
-    /// Momentum of primary or merged track calculated with a mass hypothesis.
-    const double primaryPt() const { return defaultSecondaryMomentum_.Pt(); }
+      /// Total Charge
+      const int totalCharge() const;
 
-    /// Total Charge
-    const int totalCharge() const;
+      /// Angle PrimaryVertex-DisplacedVertex (or primary track if there is)
+      /// And secondary momentum
+      const double angle_io() const;
 
-    /// Angle PrimaryVertex-DisplacedVertex (or primary track if there is)
-    /// And secondary momentum
-    const double angle_io() const;
+      /// Primary Direction
+      const math::XYZVector primaryDirection() const;
 
-    /// Primary Direction
-    const math::XYZVector primaryDirection() const;
+      bool isFake() const { return vertexType_ == FAKE; }
+      bool isLooper() const { return vertexType_ == LOOPER; }
+      bool isNucl() const { return vertexType_ == NUCL; }
+      bool isNucl_Loose() const { return vertexType_ == NUCL_LOOSE; }
+      bool isNucl_Kink() const { return vertexType_ == NUCL_KINK; }
+      bool isConv() const { return vertexType_ == CONVERSION; }
+      bool isConv_Loose() const { return vertexType_ == CONVERSION_LOOSE; }
+      bool isConvertedBremm() const { return vertexType_ == CONVERTED_BREMM; }
+      bool isK0() const { return vertexType_ == K0_DECAY; }
+      bool isLambda() const { return vertexType_ == LAMBDA_DECAY; }
+      bool isLambdaBar() const { return vertexType_ == LAMBDABAR_DECAY; }
+      bool isKplus() const { return vertexType_ == KPLUS_DECAY; }
+      bool isKminus() const { return vertexType_ == KMINUS_DECAY; }
+      bool isKplus_Loose() const { return vertexType_ == KPLUS_DECAY_LOOSE; }
+      bool isKminus_Loose() const { return vertexType_ == KMINUS_DECAY_LOOSE; }
+      bool isBSM() const { return vertexType_ == BSM_VERTEX; }
 
-    bool isFake() const { return vertexType_ == FAKE; }
-    bool isLooper() const { return vertexType_ == LOOPER; }
-    bool isNucl() const { return vertexType_ == NUCL; }
-    bool isNucl_Loose() const { return vertexType_ == NUCL_LOOSE; }
-    bool isNucl_Kink() const { return vertexType_ == NUCL_KINK; }
-    bool isConv() const { return vertexType_ == CONVERSION; }
-    bool isConv_Loose() const { return vertexType_ == CONVERSION_LOOSE; }
-    bool isConvertedBremm() const { return vertexType_ == CONVERTED_BREMM; }
-    bool isK0() const { return vertexType_ == K0_DECAY; }
-    bool isLambda() const { return vertexType_ == LAMBDA_DECAY; }
-    bool isLambdaBar() const { return vertexType_ == LAMBDABAR_DECAY; }
-    bool isKplus() const { return vertexType_ == KPLUS_DECAY; }
-    bool isKminus() const { return vertexType_ == KMINUS_DECAY; }
-    bool isKplus_Loose() const { return vertexType_ == KPLUS_DECAY_LOOSE; }
-    bool isKminus_Loose() const { return vertexType_ == KMINUS_DECAY_LOOSE; }
-    bool isBSM() const { return vertexType_ == BSM_VERTEX; }
+      std::string nameVertexType() const;
 
-    std::string nameVertexType() const;
+      /// cout function
+      void Dump(std::ostream& out = std::cout) const;
 
-    /// cout function
-    void Dump(std::ostream& out = std::cout) const;
+    private:
+      /// --------- TOOLS -------------- ///
 
-  private:
-    /// --------- TOOLS -------------- ///
+      /// Common tool used to know if there are tracks of a given Kind
+      const bool isThereKindTracks(VertexTrackType) const;
 
-    /// Common tool used to know if there are tracks of a given Kind
-    const bool isThereKindTracks(VertexTrackType) const;
+      /// Common tool used to get the number of tracks of a given Kind
+      const int nKindTracks(VertexTrackType) const;
 
-    /// Common tool used to get the number of tracks of a given Kind
-    const int nKindTracks(VertexTrackType) const;
+      /// Common tool to calculate the momentum vector of tracks with a given Kind
+      const math::XYZTLorentzVector momentum(std::string, VertexTrackType, bool, double mass) const;
 
-    /// Common tool to calculate the momentum vector of tracks with a given Kind
-    const math::XYZTLorentzVector momentum(std::string, VertexTrackType, bool, double mass) const;
+      /// Common tool to calculate the momentum vector of tracks with a given Kind
+      const math::XYZTLorentzVector momentum(M_Hypo massHypo, VertexTrackType, bool, double mass) const;
 
-    /// Common tool to calculate the momentum vector of tracks with a given Kind
-    const math::XYZTLorentzVector momentum(M_Hypo massHypo, VertexTrackType, bool, double mass) const;
+      /// Get the mass with a given hypothesis
+      const double getMass2(M_Hypo, double) const;
 
-    /// Get the mass with a given hypothesis
-    const double getMass2(M_Hypo, double) const;
+      const size_t trackPosition(const reco::TrackBaseRef& originalTrack) const;
 
-    const size_t trackPosition(const reco::TrackBaseRef& originalTrack) const;
+      const bool isTrack(size_t itrk, VertexTrackType T) const { return trackTypes_[itrk] == T; }
 
-    const bool isTrack(size_t itrk, VertexTrackType T) const { return trackTypes_[itrk] == T; }
+      /// -------- MEMBERS -------- ///
 
-    /// -------- MEMBERS -------- ///
+      /// This vertex type
+      VertexType vertexType_;
 
-    /// This vertex type
-    VertexType vertexType_;
+      /// Types of the tracks associated to the vertex
+      std::vector<VertexTrackType> trackTypes_;
 
-    /// Types of the tracks associated to the vertex
-    std::vector<VertexTrackType> trackTypes_;
+      /// Information on the distance between track's hits and the Vertex
+      std::vector<PFTrackHitFullInfo> trackHitFullInfos_;
 
-    /// Information on the distance between track's hits and the Vertex
-    std::vector<PFTrackHitFullInfo> trackHitFullInfos_;
+      math::XYZVector primaryDirection_;
 
-    math::XYZVector primaryDirection_;
-
-    math::XYZTLorentzVector defaultPrimaryMomentum_;
-    math::XYZTLorentzVector defaultSecondaryMomentum_;
-  };
+      math::XYZTLorentzVector defaultPrimaryMomentum_;
+      math::XYZTLorentzVector defaultSecondaryMomentum_;
+    };
+  }  // namespace io_v1
+  using PFDisplacedVertex = io_v1::PFDisplacedVertex;
 }  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFDisplacedVertexFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/PFDisplacedVertexFwd.h
@@ -7,7 +7,10 @@
 /* #include "DataFormats/Common/interface/RefProd.h" */
 
 namespace reco {
-  class PFDisplacedVertex;
+  namespace io_v1 {
+    class PFDisplacedVertex;
+  }
+  using PFDisplacedVertex = io_v1::PFDisplacedVertex;
 
   /// collection of PFDisplacedVertex objects
   typedef std::vector<PFDisplacedVertex> PFDisplacedVertexCollection;

--- a/DataFormats/ParticleFlowReco/interface/PFRecHit.h
+++ b/DataFormats/ParticleFlowReco/interface/PFRecHit.h
@@ -20,8 +20,9 @@
 #include "Geometry/CaloGeometry/interface/CaloCellGeometryMayOwnPtr.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  /**\class PFRecHit
+    /**\class PFRecHit
      \brief Particle flow rechit (rechit + geometry and topology information). See clustering algorithm in PFClusterAlgo
           
      \author Colin Bernet
@@ -29,143 +30,148 @@ namespace reco {
 
      Feb 2014 [Michalis: 8 years later!Modifying the class to be able to generalize the neighbours for 3D calorimeters ]
   */
-  class PFRecHit {
-  public:
-    using PositionType = GlobalPoint::BasicVectorType;
-    using REPPoint = RhoEtaPhi;
-    using RepCorners = CaloCellGeometry::RepCorners;
-    using REPPointVector = RepCorners;
-    using CornersVec = CaloCellGeometry::CornersVec;
+    class PFRecHit {
+    public:
+      using PositionType = GlobalPoint::BasicVectorType;
+      using REPPoint = RhoEtaPhi;
+      using RepCorners = CaloCellGeometry::RepCorners;
+      using REPPointVector = RepCorners;
+      using CornersVec = CaloCellGeometry::CornersVec;
 
-    struct Neighbours {
-      using Pointer = unsigned int const*;
-      Neighbours() {}
-      Neighbours(Pointer ib, unsigned int n) : b(ib), e(ib + n) {}
-      Pointer b, e;
-      Pointer begin() const { return b; }
-      Pointer end() const { return e; }
-      unsigned int size() const { return e - b; }
+      struct Neighbours {
+        using Pointer = unsigned int const*;
+        Neighbours() {}
+        Neighbours(Pointer ib, unsigned int n) : b(ib), e(ib + n) {}
+        Pointer b, e;
+        Pointer begin() const { return b; }
+        Pointer end() const { return e; }
+        unsigned int size() const { return e - b; }
+      };
+
+      enum { NONE = 0 };
+      /// default constructor. Sets energy and position to zero
+      PFRecHit() {}
+
+      PFRecHit(CaloCellGeometryMayOwnPtr caloCell,
+               unsigned int detId,
+               PFLayer::Layer layer,
+               float energy,
+               uint32_t flags = 0)
+          : caloCell_(std::move(caloCell)), detId_(detId), layer_(layer), energy_(energy), flags_(flags) {}
+
+      /// copy
+      PFRecHit(const PFRecHit& other) = default;
+      PFRecHit(PFRecHit&& other) = default;
+      PFRecHit& operator=(const PFRecHit& other) = default;
+      PFRecHit& operator=(PFRecHit&& other) = default;
+
+      /// destructor
+      ~PFRecHit() = default;
+
+      void setEnergy(float energy) { energy_ = energy; }
+
+      void addNeighbour(short x, short y, short z, unsigned int);
+      unsigned int getNeighbour(short x, short y, short z) const;
+      void setTime(double time) { time_ = time; }
+      void setDepth(int depth) { depth_ = depth; }
+      void clearNeighbours() {
+        neighbours_.clear();
+        neighbourInfos_.clear();
+        neighbours4_ = neighbours8_ = 0;
+      }
+
+      Neighbours neighbours4() const { return buildNeighbours(neighbours4_); }
+      Neighbours neighbours8() const { return buildNeighbours(neighbours8_); }
+
+      Neighbours neighbours() const { return buildNeighbours(neighbours_.size()); }
+
+      const std::vector<unsigned short>& neighbourInfos() { return neighbourInfos_; }
+
+      /// calo cell
+      CaloCellGeometry const& caloCell() const { return *(caloCell_.get()); }
+      bool hasCaloCell() const { return (caloCell_ != nullptr); }
+
+      /// rechit detId
+      unsigned detId() const { return detId_; }
+
+      /// rechit layer
+      PFLayer::Layer layer() const { return layer_; }
+
+      /// rechit energy
+      float energy() const { return energy_; }
+
+      /// timing for cleaned hits
+      float time() const { return time_; }
+
+      /// depth for segemntation
+      int depth() const { return depth_; }
+
+      /// rechit momentum transverse to the beam, squared.
+      double pt2() const { return energy_ * energy_ * (position().perp2() / position().mag2()); }
+
+      // Detector-dependent status flag
+      uint32_t flags() const { return flags_; }
+
+      //
+      void setFlags(uint32_t flags) { flags_ = flags; }
+
+      /// rechit cell centre x, y, z
+      PositionType const& position() const { return caloCell().getPosition().basicVector(); }
+
+      RhoEtaPhi const& positionREP() const { return caloCell().repPos(); }
+
+      /// rechit corners
+      CornersVec const& getCornersXYZ() const { return caloCell().getCorners(); }
+
+      RepCorners const& getCornersREP() const { return caloCell().getCornersREP(); }
+
+      /// comparison >= operator
+      bool operator>=(const PFRecHit& rhs) const { return (energy_ >= rhs.energy_); }
+
+      /// comparison > operator
+      bool operator>(const PFRecHit& rhs) const { return (energy_ > rhs.energy_); }
+
+      /// comparison <= operator
+      bool operator<=(const PFRecHit& rhs) const { return (energy_ <= rhs.energy_); }
+
+      /// comparison < operator
+      bool operator<(const PFRecHit& rhs) const { return (energy_ < rhs.energy_); }
+
+    private:
+      Neighbours buildNeighbours(unsigned int n) const { return Neighbours(neighbours_.data(), n); }
+
+      /// cell geometry
+      CaloCellGeometryMayOwnPtr caloCell_;
+
+      ///cell detid
+      unsigned int detId_ = 0;
+
+      /// rechit layer
+      PFLayer::Layer layer_ = PFLayer::NONE;
+
+      /// rechit energy
+      float energy_ = 0;
+
+      /// time
+      float time_ = -1;
+
+      /// depth
+      int depth_ = 0;
+
+      /// indices to existing neighbours (1 common side)
+      std::vector<unsigned int> neighbours_;
+      std::vector<unsigned short> neighbourInfos_;
+
+      //Caching the neighbours4/8 per request of Lindsey
+      unsigned int neighbours4_ = 0;
+      unsigned int neighbours8_ = 0;
+
+      // Detector-dependent hit status flag
+      uint32_t flags_ = 0;
     };
 
-    enum { NONE = 0 };
-    /// default constructor. Sets energy and position to zero
-    PFRecHit() {}
-
-    PFRecHit(
-        CaloCellGeometryMayOwnPtr caloCell, unsigned int detId, PFLayer::Layer layer, float energy, uint32_t flags = 0)
-        : caloCell_(std::move(caloCell)), detId_(detId), layer_(layer), energy_(energy), flags_(flags) {}
-
-    /// copy
-    PFRecHit(const PFRecHit& other) = default;
-    PFRecHit(PFRecHit&& other) = default;
-    PFRecHit& operator=(const PFRecHit& other) = default;
-    PFRecHit& operator=(PFRecHit&& other) = default;
-
-    /// destructor
-    ~PFRecHit() = default;
-
-    void setEnergy(float energy) { energy_ = energy; }
-
-    void addNeighbour(short x, short y, short z, unsigned int);
-    unsigned int getNeighbour(short x, short y, short z) const;
-    void setTime(double time) { time_ = time; }
-    void setDepth(int depth) { depth_ = depth; }
-    void clearNeighbours() {
-      neighbours_.clear();
-      neighbourInfos_.clear();
-      neighbours4_ = neighbours8_ = 0;
-    }
-
-    Neighbours neighbours4() const { return buildNeighbours(neighbours4_); }
-    Neighbours neighbours8() const { return buildNeighbours(neighbours8_); }
-
-    Neighbours neighbours() const { return buildNeighbours(neighbours_.size()); }
-
-    const std::vector<unsigned short>& neighbourInfos() { return neighbourInfos_; }
-
-    /// calo cell
-    CaloCellGeometry const& caloCell() const { return *(caloCell_.get()); }
-    bool hasCaloCell() const { return (caloCell_ != nullptr); }
-
-    /// rechit detId
-    unsigned detId() const { return detId_; }
-
-    /// rechit layer
-    PFLayer::Layer layer() const { return layer_; }
-
-    /// rechit energy
-    float energy() const { return energy_; }
-
-    /// timing for cleaned hits
-    float time() const { return time_; }
-
-    /// depth for segemntation
-    int depth() const { return depth_; }
-
-    /// rechit momentum transverse to the beam, squared.
-    double pt2() const { return energy_ * energy_ * (position().perp2() / position().mag2()); }
-
-    // Detector-dependent status flag
-    uint32_t flags() const { return flags_; }
-
-    //
-    void setFlags(uint32_t flags) { flags_ = flags; }
-
-    /// rechit cell centre x, y, z
-    PositionType const& position() const { return caloCell().getPosition().basicVector(); }
-
-    RhoEtaPhi const& positionREP() const { return caloCell().repPos(); }
-
-    /// rechit corners
-    CornersVec const& getCornersXYZ() const { return caloCell().getCorners(); }
-
-    RepCorners const& getCornersREP() const { return caloCell().getCornersREP(); }
-
-    /// comparison >= operator
-    bool operator>=(const PFRecHit& rhs) const { return (energy_ >= rhs.energy_); }
-
-    /// comparison > operator
-    bool operator>(const PFRecHit& rhs) const { return (energy_ > rhs.energy_); }
-
-    /// comparison <= operator
-    bool operator<=(const PFRecHit& rhs) const { return (energy_ <= rhs.energy_); }
-
-    /// comparison < operator
-    bool operator<(const PFRecHit& rhs) const { return (energy_ < rhs.energy_); }
-
-  private:
-    Neighbours buildNeighbours(unsigned int n) const { return Neighbours(neighbours_.data(), n); }
-
-    /// cell geometry
-    CaloCellGeometryMayOwnPtr caloCell_;
-
-    ///cell detid
-    unsigned int detId_ = 0;
-
-    /// rechit layer
-    PFLayer::Layer layer_ = PFLayer::NONE;
-
-    /// rechit energy
-    float energy_ = 0;
-
-    /// time
-    float time_ = -1;
-
-    /// depth
-    int depth_ = 0;
-
-    /// indices to existing neighbours (1 common side)
-    std::vector<unsigned int> neighbours_;
-    std::vector<unsigned short> neighbourInfos_;
-
-    //Caching the neighbours4/8 per request of Lindsey
-    unsigned int neighbours4_ = 0;
-    unsigned int neighbours8_ = 0;
-
-    // Detector-dependent hit status flag
-    uint32_t flags_ = 0;
-  };
-
+  }  // namespace io_v1
+  using PFRecHit = io_v1::PFRecHit;
 }  // namespace reco
 std::ostream& operator<<(std::ostream& out, const reco::PFRecHit& hit);
 

--- a/DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h
@@ -6,7 +6,10 @@
 #include "DataFormats/Common/interface/RefProd.h"
 
 namespace reco {
-  class PFRecHit;
+  namespace io_v1 {
+    class PFRecHit;
+  }
+  using PFRecHit = io_v1::PFRecHit;
 
   /// collection of PFRecHit objects
   typedef std::vector<PFRecHit> PFRecHitCollection;

--- a/DataFormats/ParticleFlowReco/interface/PreId.h
+++ b/DataFormats/ParticleFlowReco/interface/PreId.h
@@ -10,114 +10,117 @@
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
 
 namespace reco {
-  class PreId {
-  public:
-    enum MatchingType { NONE = 0, ECALMATCH = 1, ESMATCH = 2, TRACKFILTERING = 3, MVA = 4, FINAL = 10 };
+  namespace io_v1 {
+    class PreId {
+    public:
+      enum MatchingType { NONE = 0, ECALMATCH = 1, ESMATCH = 2, TRACKFILTERING = 3, MVA = 4, FINAL = 10 };
 
-  public:
-    PreId(unsigned nselection = 1)
-        : trackRef_(reco::TrackRef()),
-          clusterRef_(reco::PFClusterRef()),
-          matchingEop_(-999.),
-          EcalPos_(math::XYZPoint()),
-          meanShower_(math::XYZPoint()),
-          gsfChi2_(-999.),
-          dpt_(0.),
-          chi2Ratio_(0.) {
-      matching_.resize(nselection, false);
-      mva_.resize(nselection, -999.);
-      geomMatching_.resize(5, -999.);
-    }
-    void setTrack(reco::TrackRef trackref) { trackRef_ = trackref; }
-
-    void setECALMatchingProperties(PFClusterRef clusterRef,
-                                   const math::XYZPoint &ecalpos,
-                                   const math::XYZPoint &meanShower,
-                                   float deta,
-                                   float dphi,
-                                   float chieta,
-                                   float chiphi,
-                                   float chi2,
-                                   float eop) {
-      clusterRef_ = clusterRef;
-      EcalPos_ = ecalpos;
-      meanShower_ = meanShower;
-      geomMatching_[0] = deta;
-      geomMatching_[1] = dphi;
-      geomMatching_[2] = chieta;
-      geomMatching_[3] = chiphi;
-      geomMatching_[4] = chi2;
-      matchingEop_ = eop;
-    }
-
-    void setTrackProperties(float newchi2, float chi2ratio, float dpt) {
-      gsfChi2_ = newchi2;
-      chi2Ratio_ = chi2ratio;
-      dpt_ = dpt;
-    }
-
-    void setFinalDecision(bool accepted, unsigned n = 0) { setMatching(FINAL, accepted, n); }
-    void setECALMatching(bool accepted, unsigned n = 0) { setMatching(ECALMATCH, accepted, n); }
-    void setESMatching(bool accepted, unsigned n = 0) { setMatching(ESMATCH, accepted, n); }
-    void setTrackFiltering(bool accepted, unsigned n = 0) { setMatching(TRACKFILTERING, accepted, n); }
-    void setMVA(bool accepted, float mva, unsigned n = 0) {
-      setMatching(MVA, accepted, n);
-      if (n < mva_.size())
-        mva_[n] = mva;
-    }
-
-    void setMatching(MatchingType type, bool result, unsigned n = 0);
-    bool matching(MatchingType type, unsigned n = 0) const {
-      if (n < matching_.size()) {
-        return matching_[n] & (1 << type);
+    public:
+      PreId(unsigned nselection = 1)
+          : trackRef_(reco::TrackRef()),
+            clusterRef_(reco::PFClusterRef()),
+            matchingEop_(-999.),
+            EcalPos_(math::XYZPoint()),
+            meanShower_(math::XYZPoint()),
+            gsfChi2_(-999.),
+            dpt_(0.),
+            chi2Ratio_(0.) {
+        matching_.resize(nselection, false);
+        mva_.resize(nselection, -999.);
+        geomMatching_.resize(5, -999.);
       }
-      return false;
-    }
+      void setTrack(reco::TrackRef trackref) { trackRef_ = trackref; }
 
-    /// Access methods
-    inline const std::vector<float> &geomMatching() const { return geomMatching_; }
-    inline float eopMatch() const { return matchingEop_; }
-    inline float pt() const { return trackRef_->pt(); }
-    inline float eta() const { return trackRef_->eta(); }
-    inline float kfChi2() const { return trackRef_->normalizedChi2(); }
-    inline float kfNHits() const { return trackRef_->found(); }
+      void setECALMatchingProperties(PFClusterRef clusterRef,
+                                     const math::XYZPoint &ecalpos,
+                                     const math::XYZPoint &meanShower,
+                                     float deta,
+                                     float dphi,
+                                     float chieta,
+                                     float chiphi,
+                                     float chi2,
+                                     float eop) {
+        clusterRef_ = clusterRef;
+        EcalPos_ = ecalpos;
+        meanShower_ = meanShower;
+        geomMatching_[0] = deta;
+        geomMatching_[1] = dphi;
+        geomMatching_[2] = chieta;
+        geomMatching_[3] = chiphi;
+        geomMatching_[4] = chi2;
+        matchingEop_ = eop;
+      }
 
-    const math::XYZPoint &ecalPos() const { return EcalPos_; }
-    const math::XYZPoint &meanShower() const { return meanShower_; }
+      void setTrackProperties(float newchi2, float chi2ratio, float dpt) {
+        gsfChi2_ = newchi2;
+        chi2Ratio_ = chi2ratio;
+        dpt_ = dpt;
+      }
 
-    inline float chi2Ratio() const { return chi2Ratio_; }
-    inline float gsfChi2() const { return gsfChi2_; }
+      void setFinalDecision(bool accepted, unsigned n = 0) { setMatching(FINAL, accepted, n); }
+      void setECALMatching(bool accepted, unsigned n = 0) { setMatching(ECALMATCH, accepted, n); }
+      void setESMatching(bool accepted, unsigned n = 0) { setMatching(ESMATCH, accepted, n); }
+      void setTrackFiltering(bool accepted, unsigned n = 0) { setMatching(TRACKFILTERING, accepted, n); }
+      void setMVA(bool accepted, float mva, unsigned n = 0) {
+        setMatching(MVA, accepted, n);
+        if (n < mva_.size())
+          mva_[n] = mva;
+      }
 
-    inline bool ecalMatching(unsigned n = 0) const { return matching(ECALMATCH, n); }
-    inline bool esMatching(unsigned n = 0) const { return matching(ESMATCH, n); }
-    inline bool trackFiltered(unsigned n = 0) const { return matching(TRACKFILTERING, n); }
-    inline bool mvaSelected(unsigned n = 0) const { return matching(MVA, n); }
-    inline bool preIded(unsigned n = 0) const { return matching(FINAL, n); }
+      void setMatching(MatchingType type, bool result, unsigned n = 0);
+      bool matching(MatchingType type, unsigned n = 0) const {
+        if (n < matching_.size()) {
+          return matching_[n] & (1 << type);
+        }
+        return false;
+      }
 
-    float mva(unsigned n = 0) const;
-    inline float dpt() const { return dpt_; }
-    reco::TrackRef trackRef() const { return trackRef_; }
-    PFClusterRef clusterRef() const { return clusterRef_; }
+      /// Access methods
+      inline const std::vector<float> &geomMatching() const { return geomMatching_; }
+      inline float eopMatch() const { return matchingEop_; }
+      inline float pt() const { return trackRef_->pt(); }
+      inline float eta() const { return trackRef_->eta(); }
+      inline float kfChi2() const { return trackRef_->normalizedChi2(); }
+      inline float kfNHits() const { return trackRef_->found(); }
 
-  private:
-    reco::TrackRef trackRef_;
-    PFClusterRef clusterRef_;
+      const math::XYZPoint &ecalPos() const { return EcalPos_; }
+      const math::XYZPoint &meanShower() const { return meanShower_; }
 
-    std::vector<float> geomMatching_;
-    float matchingEop_;
-    math::XYZPoint EcalPos_;
-    math::XYZPoint meanShower_;
+      inline float chi2Ratio() const { return chi2Ratio_; }
+      inline float gsfChi2() const { return gsfChi2_; }
 
-    float gsfChi2_;
-    float dpt_;
-    float chi2Ratio_;
-    std::vector<float> mva_;
+      inline bool ecalMatching(unsigned n = 0) const { return matching(ECALMATCH, n); }
+      inline bool esMatching(unsigned n = 0) const { return matching(ESMATCH, n); }
+      inline bool trackFiltered(unsigned n = 0) const { return matching(TRACKFILTERING, n); }
+      inline bool mvaSelected(unsigned n = 0) const { return matching(MVA, n); }
+      inline bool preIded(unsigned n = 0) const { return matching(FINAL, n); }
 
-    //    bool goodpreid_;
-    //    bool TkId_;
-    //    bool EcalMatching_;
-    //    bool PSMatching_;
-    std::vector<int> matching_;
-  };
+      float mva(unsigned n = 0) const;
+      inline float dpt() const { return dpt_; }
+      reco::TrackRef trackRef() const { return trackRef_; }
+      PFClusterRef clusterRef() const { return clusterRef_; }
+
+    private:
+      reco::TrackRef trackRef_;
+      PFClusterRef clusterRef_;
+
+      std::vector<float> geomMatching_;
+      float matchingEop_;
+      math::XYZPoint EcalPos_;
+      math::XYZPoint meanShower_;
+
+      float gsfChi2_;
+      float dpt_;
+      float chi2Ratio_;
+      std::vector<float> mva_;
+
+      //    bool goodpreid_;
+      //    bool TkId_;
+      //    bool EcalMatching_;
+      //    bool PSMatching_;
+      std::vector<int> matching_;
+    };
+  }  // namespace io_v1
+  using PreId = io_v1::PreId;
 }  // namespace reco
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PreIdFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/PreIdFwd.h
@@ -3,7 +3,10 @@
 #include <vector>
 #include "DataFormats/Common/interface/Ref.h"
 namespace reco {
-  class PreId;
+  namespace io_v1 {
+    class PreId;
+  }
+  using PreId = io_v1::PreId;
   typedef std::vector<reco::PreId> PreIdCollection;
   typedef edm::Ref<reco::PreIdCollection> PreIdRef;
 }  // namespace reco

--- a/DataFormats/ParticleFlowReco/src/PFBlock.cc
+++ b/DataFormats/ParticleFlowReco/src/PFBlock.cc
@@ -132,7 +132,7 @@ double PFBlock::dist(unsigned ie1, unsigned ie2, const LinkData& linkData) const
   return Dist;
 }
 
-ostream& reco::operator<<(ostream& out, const reco::PFBlock& block) {
+ostream& reco::io_v1::operator<<(ostream& out, const reco::PFBlock& block) {
   if (!out)
     return out;
   const edm::OwnVector<reco::PFBlockElement>& elements = block.elements();

--- a/DataFormats/ParticleFlowReco/src/PFCluster.cc
+++ b/DataFormats/ParticleFlowReco/src/PFCluster.cc
@@ -4,6 +4,7 @@
 
 using namespace std;
 using namespace reco;
+using namespace reco::io_v1;
 
 const math::XYZPoint PFCluster::dummyVtx_(0, 0, 0);
 
@@ -60,7 +61,7 @@ PFLayer::Layer PFCluster::layer() const {
   return PFLayer::fromCaloID(caloID());
 }
 
-std::ostream& reco::operator<<(std::ostream& out, const PFCluster& cluster) {
+std::ostream& reco::io_v1::operator<<(std::ostream& out, const PFCluster& cluster) {
   if (!out)
     return out;
 

--- a/DataFormats/ParticleFlowReco/src/classes_def_1.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_1.xml
@@ -12,8 +12,8 @@
   <class name="edm::RefVector<std::vector<reco::PFNuclearInteraction>, reco::PFNuclearInteraction, edm::refhelper::FindUsingAdvance<std::vector<reco::PFNuclearInteraction>, reco::PFNuclearInteraction> >" />
 
 
-  <class name="reco::PFDisplacedTrackerVertex"  ClassVersion="10">
-   <version ClassVersion="10" checksum="2059737151"/>
+  <class name="reco::PFDisplacedTrackerVertex"  ClassVersion="3">
+   <version ClassVersion="3" checksum="707455687"/>
   </class>
   <class name="std::vector<reco::PFDisplacedTrackerVertex>" />
   <class name="edm::Wrapper<std::vector<reco::PFDisplacedTrackerVertex> >" />
@@ -21,8 +21,8 @@
   <class name="edm::RefProd<std::vector<reco::PFDisplacedTrackerVertex> >" />
   <class name="edm::RefVector<std::vector<reco::PFDisplacedTrackerVertex>, reco::PFDisplacedTrackerVertex, edm::refhelper::FindUsingAdvance<std::vector<reco::PFDisplacedTrackerVertex>, reco::PFDisplacedTrackerVertex> >" />
 
-  <class name="reco::PFConversion" ClassVersion="10">
-   <version ClassVersion="10" checksum="2417207933"/>
+  <class name="reco::PFConversion" ClassVersion="3">
+   <version ClassVersion="3" checksum="3014028333"/>
   </class>
   <class name="std::vector<reco::PFConversion>"/>
   <class name="edm::Wrapper<std::vector<reco::PFConversion> >"/>
@@ -32,14 +32,14 @@
   <class name="std::vector<edm::Ref<std::vector<reco::PFRecTrack>,reco::PFRecTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::PFRecTrack>,reco::PFRecTrack> > >"/>
 
  <class name="reco::PFV0"  ClassVersion="3">
-  <version ClassVersion="3" checksum="1009242484"/>
+  <version ClassVersion="3" checksum="2269809524"/>
  </class>
   <class name="std::vector<reco::PFV0>" />
   <class name="edm::Wrapper<std::vector<reco::PFV0> >" />
   <class name="edm::Ref<std::vector<reco::PFV0>, reco::PFV0, edm::refhelper::FindUsingAdvance<std::vector<reco::PFV0>, reco::PFV0> >" />
   <class name="edm::RefProd<std::vector<reco::PFV0> >" />
   <class name="edm::RefVector<std::vector<reco::PFV0>, reco::PFV0, edm::refhelper::FindUsingAdvance<std::vector<reco::PFV0>, reco::PFV0> >" />
-<class name="edm::Ref<std::vector<reco::VertexCompositeCandidate>,reco::VertexCompositeCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::VertexCompositeCandidate>,reco::VertexCompositeCandidate> >" />
+<class name="edm::Ref<std::vector<reco::io_v1::VertexCompositeCandidate>,reco::io_v1::VertexCompositeCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::VertexCompositeCandidate>,reco::io_v1::VertexCompositeCandidate> >" />
 
 
   <class name="reco::ConvBremSeed" ClassVersion="12">

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -1,77 +1,54 @@
 <lcgdict>
 <selection>
 
-  <class name="reco::PFCluster" ClassVersion="17">
-   <version ClassVersion="17" checksum="3021111509"/>
-   <version ClassVersion="16" checksum="1786894710"/>
-   <version ClassVersion="15" checksum="1837961152"/>
-   <version ClassVersion="14" checksum="3610074122"/>
-   <version ClassVersion="13" checksum="1305770681"/>
-   <version ClassVersion="12" checksum="1218979136"/>
-   <version ClassVersion="11" checksum="1793013291"/>
-   <version ClassVersion="10" checksum="1793013291"/>
+  <class name="reco::io_v1::PFCluster" ClassVersion="3">
+   <version ClassVersion="3" checksum="3548902471"/>
     <field name="posrep_" transient="true"/>
     <field name="layer_" transient="true"/> 
   </class>
-  <class name="std::vector<reco::PFCluster>"/>
-  <class name="edm::Wrapper<std::vector<reco::PFCluster> >"/>
+  <class name="std::vector<reco::io_v1::PFCluster>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::PFCluster> >"/>
 
-  <class name="reco::HGCalMultiCluster" ClassVersion="3">
-    <version ClassVersion="3" checksum="1942695459"/>
+  <class name="reco::io_v1::HGCalMultiCluster" ClassVersion="3">
+    <version ClassVersion="3" checksum="121905775"/>
   </class>
-  <class name="std::vector<reco::HGCalMultiCluster>"/>
-  <class name="edm::RefProd<vector<reco::HGCalMultiCluster> >" />
-  <class name="edm::Wrapper<std::vector<reco::HGCalMultiCluster> >"/>  
+  <class name="std::vector<reco::io_v1::HGCalMultiCluster>"/>
+  <class name="edm::RefProd<vector<reco::io_v1::HGCalMultiCluster> >" />
+  <class name="edm::Wrapper<std::vector<reco::io_v1::HGCalMultiCluster> >"/>  
 
-  <class name="std::pair<edm::Ptr<reco::CaloCluster>::key_type,edm::Ptr<reco::PFCluster> >"/>
-  <class name="reco::PFCluster::EEtoPSAssociation"/>
-  <class name="edm::Wrapper<reco::PFCluster::EEtoPSAssociation>"/>
+  <class name="std::pair<edm::Ptr<reco::io_v1::CaloCluster>::key_type,edm::Ptr<reco::io_v1::PFCluster> >"/>
+  <class name="reco::io_v1::PFCluster::EEtoPSAssociation"/>
+  <class name="edm::Wrapper<reco::io_v1::PFCluster::EEtoPSAssociation>"/>
 
   <class name="PFLayer" ClassVersion="10">
    <version ClassVersion="10" checksum="85611"/>
   </class>
   <enum name="PFLayer::Layer"/> 
-  <class name="reco::PFRecHitFraction" ClassVersion="10">
-   <version ClassVersion="10" checksum="3960206"/>
+  <class name="reco::PFRecHitFraction" ClassVersion="3">
+   <version ClassVersion="3" checksum="1054932742"/>
   </class>
   <class name="std::vector<reco::PFRecHitFraction>"/>
 
-  <class name="reco::RecoPFClusterRefCandidate"  ClassVersion="12">
-   <version ClassVersion="12" checksum="4214927259"/>
-   <version ClassVersion="11" checksum="3462309765"/>
-   <version ClassVersion="10" checksum="3428152128"/>
+  <class name="reco::RecoPFClusterRefCandidate"  ClassVersion="3">
+   <version ClassVersion="3" checksum="3961848295"/>
   </class>
 
 
-  <class name="reco::PFRecHit" ClassVersion="19"> 
-   <version ClassVersion="19" checksum="3022044895"/> 
-   <version ClassVersion="18" checksum="3122773923"/>
-   <version ClassVersion="17" checksum="2606786437"/>
-   <version ClassVersion="10" checksum="1807687081"/>
-   <version ClassVersion="11" checksum="3727193351"/>
-   <version ClassVersion="12" checksum="207373238"/>
-   <version ClassVersion="13" checksum="2553278843"/>
-   <version ClassVersion="14" checksum="3941705446"/>
-   <version ClassVersion="15" checksum="730472518"/>
-   <version ClassVersion="16" checksum="2707878893"/>
-   <ioread sourceClass = "reco::PFRecHit" version="[1-10]" targetClass="reco::PFRecHit" source="std::vector<unsigned> neighbours4_; std::vector<unsigned> neighbours8_;" target="">
-    <![CDATA[]]>
-   </ioread>
-
+  <class name="reco::io_v1::PFRecHit" ClassVersion="3"> 
+   <version ClassVersion="3" checksum="2405400969"/> 
    <field name="caloCell_" transient="true"/>
    <field name="neighbours_" transient="true"/>
    <field name="neighbours_info" transient="true"/>
    <field name="neighbours4_" transient="true"/>
    <field name="neighbours8_" transient="true"/>
-
   </class>
 
 
-  <class name="std::vector<reco::PFRecHit>"/>
-  <class name="edm::Wrapper<std::vector<reco::PFRecHit> >"/>
-  <class name="edm::Ref< std::vector<reco::PFRecHit>, reco::PFRecHit, edm::refhelper::FindUsingAdvance<std::vector<reco::PFRecHit>,reco::PFRecHit>  >"/>
+  <class name="std::vector<reco::io_v1::PFRecHit>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::PFRecHit> >"/>
+  <class name="edm::Ref< std::vector<reco::io_v1::PFRecHit>, reco::io_v1::PFRecHit, edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFRecHit>,reco::io_v1::PFRecHit>  >"/>
 
-  <class name="edm::RefVector<std::vector<reco::PFRecHit>,reco::PFRecHit,edm::refhelper::FindUsingAdvance<std::vector<reco::PFRecHit>,reco::PFRecHit> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::PFRecHit>,reco::io_v1::PFRecHit,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFRecHit>,reco::io_v1::PFRecHit> >"/>
 
   
 
@@ -97,7 +74,7 @@
   <class name="std::vector<reco::PFTrajectoryPoint>"/>
   <class name="edm::Wrapper<std::vector<reco::PFTrajectoryPoint> >"/>
 
-  <class name="edm::RefVector<std::vector<reco::PFBlock>,reco::PFBlock,edm::refhelper::FindUsingAdvance<std::vector<reco::PFBlock>,reco::PFBlock> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::PFBlock>,reco::io_v1::PFBlock,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFBlock>,reco::io_v1::PFBlock> >"/>
   <class name="reco::PFRecTrack" ClassVersion="3">
    <version ClassVersion="3" checksum="3356916753"/>
   </class>
@@ -105,7 +82,7 @@
   <class name="edm::Wrapper<std::vector<reco::PFRecTrack> >"/>
 
   <class name="reco::GsfPFRecTrack" ClassVersion="3">
-   <version ClassVersion="3" checksum="997076017"/>
+   <version ClassVersion="3" checksum="2950231625"/>
   </class>
   <class name="std::vector<reco::GsfPFRecTrack>"/>
   <class name="edm::Wrapper<std::vector<reco::GsfPFRecTrack> >"/>
@@ -145,29 +122,19 @@
   <class name="edm::Wrapper<edm::OwnVector<reco::PFBlockElement, edm::ClonePolicy<reco::PFBlockElement> > >" />
 
   <class name="reco::PFBlockElementTrack" ClassVersion="3">
-   <version ClassVersion="3" checksum="764868352"/>
+   <version ClassVersion="3" checksum="972442600"/>
   </class>
 
-  <class name="reco::PFBlockElementGsfTrack" ClassVersion="15">
-   <version ClassVersion="15" checksum="233050648"/>
-   <version ClassVersion="14" checksum="3921871079"/>
-   <version ClassVersion="13" checksum="2453155267"/>
-   <version ClassVersion="12" checksum="1521047275"/>
-   <version ClassVersion="11" checksum="1367777435"/>
-   <version ClassVersion="10" checksum="549349370"/>
+  <class name="reco::PFBlockElementGsfTrack" ClassVersion="3">
+   <version ClassVersion="3" checksum="874706272"/>
 <!-- removed by Florian. It useful to have this Ref (especially for a reprocessing)
    Florian
     <field name="GsftrackRefPF_" transient="true"/> // Daniele
 -->
   </class>
 
-  <class name="reco::PFBlockElementBrem" ClassVersion="15">
-   <version ClassVersion="15" checksum="2963077707"/>
-   <version ClassVersion="14" checksum="3702597792"/>
-   <version ClassVersion="13" checksum="157699540"/>
-   <version ClassVersion="12" checksum="112730380"/>
-   <version ClassVersion="11" checksum="2362699420"/>
-   <version ClassVersion="10" checksum="2231967579"/>
+  <class name="reco::PFBlockElementBrem" ClassVersion="3">
+   <version ClassVersion="3" checksum="4159933843"/>
 <!-- removed by Florian. It useful to have this Ref (especially for a reprocessing)
    Florian
     <field name="BremtrackRefPF_" transient="true"/> // Daniele
@@ -175,27 +142,21 @@
   </class>
 
 
-  <class name="reco::PFBlockElementCluster" ClassVersion="16">
-   <version ClassVersion="16" checksum="4263698413"/>
-   <version ClassVersion="15" checksum="3252388"/>
-   <version ClassVersion="14" checksum="407383072"/>
-   <version ClassVersion="13" checksum="775826696"/>
-   <version ClassVersion="12" checksum="1263691576"/>
-   <version ClassVersion="10" checksum="2503385411"/>
-   <version ClassVersion="11" checksum="2936163017"/>
+  <class name="reco::PFBlockElementCluster" ClassVersion="3">
+   <version ClassVersion="3" checksum="1113199285"/>
   </class>
 
-  <class name="std::map<unsigned int,reco::PFBlock::Link>"/>
-  <class name="reco::PFBlock::Link" ClassVersion="10">
-   <version ClassVersion="10" checksum="3119379929"/>
+  <class name="std::map<unsigned int,reco::io_v1::PFBlock::Link>"/>
+  <class name="reco::io_v1::PFBlock::Link" ClassVersion="3">
+   <version ClassVersion="3" checksum="3388044151"/>
   </class>
-  <class name="reco::PFBlock" ClassVersion="10">
-   <version ClassVersion="10" checksum="2213575983"/>
+  <class name="reco::io_v1::PFBlock" ClassVersion="3">
+   <version ClassVersion="3" checksum="2904310273"/>
   </class>
 
-  <class name="std::vector<reco::PFBlock>"/>
-  <class name="edm::Wrapper<std::vector<reco::PFBlock> >"/>
-  <class name="edm::Ref< std::vector<reco::PFBlock>, reco::PFBlock, edm::refhelper::FindUsingAdvance<std::vector<reco::PFBlock>,reco::PFBlock> >"/>
+  <class name="std::vector<reco::io_v1::PFBlock>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::PFBlock> >"/>
+  <class name="edm::Ref< std::vector<reco::io_v1::PFBlock>, reco::io_v1::PFBlock, edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFBlock>,reco::io_v1::PFBlock> >"/>
   <class name="edm::Ref<std::vector<reco::PFRecTrack>,reco::PFRecTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::PFRecTrack>,reco::PFRecTrack> >"/>
   <class name="edm::RefVector<std::vector<reco::PFRecTrack>,reco::PFRecTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::PFRecTrack>,reco::PFRecTrack> >"/>
 
@@ -203,7 +164,10 @@
   <class name="edm::RefVector<std::vector<reco::GsfPFRecTrack>,reco::GsfPFRecTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfPFRecTrack>,reco::GsfPFRecTrack> >"/>
   <class name="std::vector<edm::Ref<std::vector<reco::GsfPFRecTrack>,reco::GsfPFRecTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfPFRecTrack>,reco::GsfPFRecTrack> > >"/>
 
-  <class name="edm::Ref<std::vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCluster>,reco::PFCluster> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::PFCluster>,reco::io_v1::PFCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFCluster>,reco::io_v1::PFCluster> >"/>
+  <class name="edm::Ptr<reco::io_v1::PFCluster>" />
+  <class name="std::vector<edm::Ptr<reco::io_v1::PFCluster> >" />
+  <class name="edm::RefProd<std::vector<reco::io_v1::PFCluster>>"/>
 
 
   <class name="pftools::ParticleFiltrationDecision" ClassVersion="11">
@@ -228,38 +192,32 @@
   <class name="edm::Wrapper<std::vector<reco::PFDisplacedVertexCandidate> >"/>
   <class name="edm::Ref< std::vector<reco::PFDisplacedVertexCandidate>, reco::PFDisplacedVertexCandidate, edm::refhelper::FindUsingAdvance<std::vector<reco::PFDisplacedVertexCandidate>,reco::PFDisplacedVertexCandidate> >"/>
 
-  <class name="reco::PFDisplacedVertex" ClassVersion="3">
-   <version ClassVersion="3" checksum="2807110114"/>
+  <class name="reco::io_v1::PFDisplacedVertex" ClassVersion="3">
+   <version ClassVersion="3" checksum="2554700204"/>
   </class>
 
-  <class name="std::vector<reco::PFDisplacedVertex>"/>
-  <class name="edm::Wrapper<std::vector<reco::PFDisplacedVertex> >"/>
-  <class name="edm::Ref< std::vector<reco::PFDisplacedVertex>, reco::PFDisplacedVertex, edm::refhelper::FindUsingAdvance<std::vector<reco::PFDisplacedVertex>,reco::PFDisplacedVertex> >"/>
+  <class name="std::vector<reco::io_v1::PFDisplacedVertex>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::PFDisplacedVertex> >"/>
+  <class name="edm::Ref< std::vector<reco::io_v1::PFDisplacedVertex>, reco::io_v1::PFDisplacedVertex, edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFDisplacedVertex>,reco::io_v1::PFDisplacedVertex> >"/>
 
-  <class name="std::vector<reco::PFDisplacedVertex::VertexTrackType>"/>
+  <class name="std::vector<reco::io_v1::PFDisplacedVertex::VertexTrackType>"/>
 
   <class name="std::vector<std::pair<std::pair<unsigned int,unsigned int>,std::pair<unsigned int,unsigned int> > >"/>
 
   <class name="std::pair<std::pair<unsigned int,unsigned int>,std::pair<unsigned int,unsigned int> >"/>
 
-  <class name="reco::PreId" ClassVersion="3">
-   <version ClassVersion="3" checksum="2607778601"/>
+  <class name="reco::io_v1::PreId" ClassVersion="3">
+   <version ClassVersion="3" checksum="4038806563"/>
   </class>
-  <class name="std::vector<reco::PreId>"/>
-  <class name="edm::Wrapper<std::vector<reco::PreId> >"/>
+  <class name="std::vector<reco::io_v1::PreId>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::PreId> >"/>
   <class name="edm::ValueMap<reco::PreIdRef>"/>
   <class name="std::vector<reco::PreIdRef>"/>
   <class name="edm::Wrapper<edm::ValueMap<reco::PreIdRef> >"/>
-  <class name="edm::Ref<std::vector<reco::PreId>,reco::PreId,edm::refhelper::FindUsingAdvance<std::vector<reco::PreId>,reco::PreId> >" />
+  <class name="edm::Ref<std::vector<reco::io_v1::PreId>,reco::io_v1::PreId,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PreId>,reco::io_v1::PreId> >" />
 
-  <class name="reco::PFBlockElementSuperCluster" ClassVersion="16">
-   <version ClassVersion="16" checksum="4220702137"/>
-   <version ClassVersion="15" checksum="1074027768"/>
-   <version ClassVersion="14" checksum="285242772"/>
-   <version ClassVersion="13" checksum="3749373244"/>
-   <version ClassVersion="12" checksum="1656578540"/>
-   <version ClassVersion="10" checksum="456156271"/>
-   <version ClassVersion="11" checksum="3584097231"/>
+  <class name="reco::PFBlockElementSuperCluster" ClassVersion="3">
+   <version ClassVersion="3" checksum="322190993"/>
   </class>
   <class name="std::vector<reco::PFBlockElementSuperCluster>"/>
   <class name="edm::Wrapper<std::vector<reco::PFBlockElementSuperCluster> >"/>
@@ -276,9 +234,9 @@
   <class name="edm::RefProd<std::vector<reco::RecoPFClusterRefCandidate> >"/>
   <class name="edm::RefVector<std::vector<reco::RecoPFClusterRefCandidate>,reco::RecoPFClusterRefCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoPFClusterRefCandidate>,reco::RecoPFClusterRefCandidate> >"/>
 
-  <class name="edm::reftobase::Holder<reco::Candidate, reco::RecoPFClusterRefCandidateRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::RecoPFClusterRefCandidateRef>" />
   <class name="edm::reftobase::RefHolder<reco::RecoPFClusterRefCandidateRef>" />
-  <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::RecoPFClusterRefCandidateRefVector>" />
+  <class name="edm::reftobase::VectorHolder<reco::io_v1::Candidate, reco::RecoPFClusterRefCandidateRefVector>" />
   <class name="edm::reftobase::RefVectorHolder<reco::RecoPFClusterRefCandidateRefVector>" />
 
   <class name="edm::Wrapper<edm::RefVector<std::vector<reco::RecoPFClusterRefCandidate>,reco::RecoPFClusterRefCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoPFClusterRefCandidate>,reco::RecoPFClusterRefCandidate> > >" />

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -1,46 +1,34 @@
 <lcgdict>
  <selection>
   <!-- PAT Base Templates -->
-  <class name="pat::PATObject<reco::GsfElectron>" />
-  <class name="pat::PATObject<reco::Muon>" />
+  <class name="pat::PATObject<reco::io_v1::GsfElectron>" />
+  <class name="pat::PATObject<reco::io_v1::Muon>" />
   <class name="pat::PATObject<reco::BaseTau>" />
-  <class name="pat::PATObject<reco::Photon>" />
-  <class name="pat::PATObject<reco::Jet>" />
-  <class name="pat::PATObject<reco::MET>" />
+  <class name="pat::PATObject<reco::io_v1::Photon>" />
+  <class name="pat::PATObject<reco::io_v1::Jet>" />
+  <class name="pat::PATObject<reco::io_v1::MET>" />
   <class name="pat::PATObject<reco::LeafCandidate>" />
-  <class name="pat::PATObject<reco::CompositeCandidate>" />
-  <class name="pat::PATObject<reco::PFCandidate>" />
+  <class name="pat::PATObject<reco::io_v1::CompositeCandidate>" />
+  <class name="pat::PATObject<reco::io_v1::PFCandidate>" />
   <class name="pat::PATObject<reco::RecoCandidate>" />
-  <class name="pat::Lepton<reco::GsfElectron>" />
-  <class name="pat::Lepton<reco::Muon>" />
+  <class name="pat::Lepton<reco::io_v1::GsfElectron>" />
+  <class name="pat::Lepton<reco::io_v1::Muon>" />
   <class name="pat::Lepton<reco::BaseTau>" />
 
   <!-- PAT Objects, and embedded data  -->
   <class name="pat::Electron"  ClassVersion="3">
-   <version ClassVersion="3" checksum="2417779180"/>
+   <version ClassVersion="3" checksum="3647282676"/>
    <field name="superClusterRelinked_" transient="true"/>
-   <version ClassVersion="26" checksum="2045819644"/>
-   <version ClassVersion="25" checksum="1488101799"/>
-   <version ClassVersion="24" checksum="2646043873"/>
-   <version ClassVersion="23" checksum="434577157"/>
-   <version ClassVersion="22" checksum="4113394532"/>
-   <version ClassVersion="21" checksum="366535823"/>
-   <version ClassVersion="20" checksum="4220542719"/>
-   <version ClassVersion="19" checksum="839477640"/>
-   <version ClassVersion="18" checksum="191995725"/>
-   <version ClassVersion="17" checksum="1230088720"/>
-   <version ClassVersion="15" checksum="990589145"/>
-   <version ClassVersion="10" checksum="1662079993"/>
   </class>
   <ioread sourceClass="pat::Electron" targetClass="pat::Electron" version="[1-]" source="" target="superClusterRelinked_">
     <![CDATA[superClusterRelinked_.reset();]]>
   </ioread>
   <class name="pat::Muon"  ClassVersion="3">
-   <version ClassVersion="3" checksum="4185602613"/>
+   <version ClassVersion="3" checksum="1254301627"/>
   </class>
 
   <class name="pat::Tau"  ClassVersion="3">
-   <version ClassVersion="3" checksum="1081551115"/>
+   <version ClassVersion="3" checksum="116344369"/>
    <field name="isolationTracksTransientRefVector_" transient="true"/>
    <field name="signalTracksTransientRefVector_" transient="true"/>
    <field name="signalPFCandsTransientPtrs_" transient="true"/>
@@ -53,10 +41,8 @@
    <field name="isolationPFGammaCandsTransientPtrs_" transient="true"/>
   </class>
 
-  <class name="pat::IsolatedTrack" ClassVersion="5">
-   <version ClassVersion="5" checksum="139818330"/>
-   <version ClassVersion="4" checksum="71166093"/>
-   <version ClassVersion="3" checksum="550880582"/>
+  <class name="pat::IsolatedTrack" ClassVersion="3">
+   <version ClassVersion="3" checksum="655235006"/>
   </class>
 
   <class name="pat::PFIsolation" ClassVersion="3">
@@ -94,81 +80,25 @@
   <![CDATA[isolationPFGammaCandsTransientPtrs_.reset();]]>
   </ioread>
   <class name="pat::tau::TauPFSpecific"  ClassVersion="3">
-   <version ClassVersion="3" checksum="2664182121"/>
+   <version ClassVersion="3" checksum="4003299421"/>
   </class>
   <class name="std::vector<pat::tau::TauPFSpecific>" />
 
-  <class name="pat::tau::TauPFEssential" ClassVersion="14">
-    <version ClassVersion="14" checksum="524735083" /> 
-    <version ClassVersion="13" checksum="1052833547" />
-    <version ClassVersion="12" checksum="3865233356" /> 
-    <version ClassVersion="11" checksum="1193752112" />
-    <version ClassVersion="10" checksum="1628501942" />
+  <class name="pat::tau::TauPFEssential" ClassVersion="3">
+    <version ClassVersion="3" checksum="904488891" /> 
   </class>
-  <ioread sourceClass="pat::tau::TauPFEssential" targetClass="pat::tau::TauPFEssential" version="[-10]" source="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > p4Jet_" target="p4Jet_">
-          <![CDATA[ p4Jet_ = ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> >(onfile.p4Jet_); ]]>
-  </ioread>
-  <ioread sourceClass="pat::tau::TauPFEssential" targetClass="pat::tau::TauPFEssential" version="[-10]" source="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > p4CorrJet_" target="p4CorrJet_">
-          <![CDATA[ p4CorrJet_ = ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> >(onfile.p4CorrJet_); ]]>
-  </ioread>
-  <ioread sourceClass="pat::tau::TauPFEssential" targetClass="pat::tau::TauPFEssential" version="[-10]" source="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag> dxy_PCA_" target="dxy_PCA_">
-          <![CDATA[ dxy_PCA_ = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag>(onfile.dxy_PCA_); ]]>
-  </ioread>
-  <ioread sourceClass="pat::tau::TauPFEssential" targetClass="pat::tau::TauPFEssential" version="[-10]" source="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag> pvPos_" target="pvPos_">
-          <![CDATA[ pvPos_ = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag>(onfile.pvPos_); ]]>
-  </ioread>
-  <ioread sourceClass="pat::tau::TauPFEssential" targetClass="pat::tau::TauPFEssential" version="[-10]" source="ROOT::Math::SMatrix<double,3,3,ROOT::Math::MatRepSym<double,3> > pvCov_" target="pvCov_">
-    <![CDATA[
-       // matrices must be copied by hand
-       for (unsigned int i = 0; i < 3; ++i) { for (unsigned int j = 0; j < 3; ++j) {
-            pvCov_(i,j) = onfile.pvCov_(i,j);
-       }}
-    ]]>
-  </ioread>
-  <ioread sourceClass="pat::tau::TauPFEssential" targetClass="pat::tau::TauPFEssential" version="[-10]" source="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag> flightLength_" target="flightLength_">
-          <![CDATA[ flightLength_ = ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag>(onfile.flightLength_); ]]>
-  </ioread>
-  <ioread sourceClass="pat::tau::TauPFEssential" targetClass="pat::tau::TauPFEssential" version="[-10]" source="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag> svPos_" target="svPos_">
-          <![CDATA[ svPos_ = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag>(onfile.svPos_); ]]>
-  </ioread>
-  <ioread sourceClass="pat::tau::TauPFEssential" targetClass="pat::tau::TauPFEssential" version="[-10]" source="ROOT::Math::SMatrix<double,3,3,ROOT::Math::MatRepSym<double,3> > svCov_" target="svCov_">
-    <![CDATA[
-       // matrices must be copied by hand
-       for (unsigned int i = 0; i < 3; ++i) { for (unsigned int j = 0; j < 3; ++j) {
-            svCov_(i,j) = onfile.svCov_(i,j);
-       }}
-    ]]>
-  </ioread>
 
   <class name="std::vector<pat::tau::TauPFEssential>" />
-  <class name="pat::Photon"  ClassVersion="22">
-   <version ClassVersion="22" checksum="1415449268"/>
-   <version ClassVersion="21" checksum="3263223164"/>
-   <version ClassVersion="20" checksum="1579185367"/>
-   <version ClassVersion="19" checksum="4285818507"/>
-   <version ClassVersion="18" checksum="1413598928"/>
-   <version ClassVersion="17" checksum="2394457997"/>
+  <class name="pat::Photon"  ClassVersion="3">
+   <version ClassVersion="3" checksum="334335458"/>
    <field name="superClusterRelinked_" transient="true"/>
-   <version ClassVersion="16" checksum="344001813"/>
-   <version ClassVersion="15" checksum="3096238365"/>
-   <version ClassVersion="14" checksum="2817723713"/>
-   <version ClassVersion="13" checksum="3948496360"/>
-   <version ClassVersion="12" checksum="2518470540"/>
-   <version ClassVersion="11" checksum="3277818926"/>
-   <version ClassVersion="10" checksum="865744757"/>
   </class>
   <ioread sourceClass="pat::Photon" targetClass="pat::Photon" version="[1-]" source="" target="superClusterRelinked_">
     <![CDATA[superClusterRelinked_.reset();]]>
   </ioread>
-  <ioread sourceClass="pat::Photon"  targetClass="pat::Photon" version="[-20]" target="" source="float ecalPFClusIso_;float hcalPFClusIso_">
-    <![CDATA[reco::Photon::PflowIsolationVariables pfIsoVar = newObj->getPflowIsolationVariables();
-             pfIsoVar.sumEcalClusterEt = onfile.ecalPFClusIso_;
-             pfIsoVar.sumHcalClusterEt = onfile.hcalPFClusIso_;
-             newObj->setPflowIsolationVariables(pfIsoVar);]]>
-  </ioread>
 
   <class name="pat::Jet"  ClassVersion="3">
-   <version ClassVersion="3" checksum="1924074509"/>
+   <version ClassVersion="3" checksum="306401941"/>
    <field name="daughtersTemp_" transient="true"/>
    <field name="caloTowersTemp_" transient="true"/>
    <field name="pfCandidatesTemp_" transient="true"/>
@@ -182,16 +112,9 @@
   <ioread sourceClass = "pat::Jet" version="[1-]" targetClass="pat::Jet" source="" target="daughtersTemp_">
     <![CDATA[daughtersTemp_.reset();]]>
   </ioread>
-  <class name="pat::MET"  ClassVersion="17">
-    <version ClassVersion="17" checksum="1526897576"/>
-    <version ClassVersion="16" checksum="2416242778"/>
+  <class name="pat::MET"  ClassVersion="3">
+    <version ClassVersion="3" checksum="1773211734"/>
     <field name="corMap_" transient="true"/>
-   <version ClassVersion="15" checksum="428901429"/>
-   <version ClassVersion="14" checksum="1795935545"/>
-   <version ClassVersion="13" checksum="2368359386"/>
-   <version ClassVersion="12" checksum="1474251442"/>
-   <version ClassVersion="11" checksum="1829185007"/>
-   <version ClassVersion="10" checksum="1136648776"/>
   </class>
   <class name="pat::MET::PackedMETUncertainty" ClassVersion="11">
     <version ClassVersion="11" checksum="3523936012"/>
@@ -200,37 +123,23 @@
   <class name="pat::MET::Vector2"  transient="true" />
 
   <class name="std::vector<pat::MET::PackedMETUncertainty>" />
-  <class name="pat::MHT"  ClassVersion="12">
-   <version ClassVersion="12" checksum="965016657"/>
-   <version ClassVersion="11" checksum="2562213081"/>
-   <version ClassVersion="10" checksum="2696169357"/>
+  <class name="pat::MHT"  ClassVersion="3">
+   <version ClassVersion="3" checksum="1121416267"/>
   </class>
-  <class name="pat::Particle"  ClassVersion="12">
-   <version ClassVersion="12" checksum="1268816645"/>
-   <version ClassVersion="11" checksum="2960540813"/>
-   <version ClassVersion="10" checksum="1421351288"/>
+  <class name="pat::Particle"  ClassVersion="3">
+   <version ClassVersion="3" checksum="735620471"/>
   </class>
-  <class name="pat::CompositeCandidate"  ClassVersion="12">
-   <version ClassVersion="12" checksum="2489375362"/>
-   <version ClassVersion="11" checksum="3492108938"/>
-   <version ClassVersion="10" checksum="417284221"/>
+  <class name="pat::CompositeCandidate"  ClassVersion="3">
+   <version ClassVersion="3" checksum="2856590720"/>
   </class>
-  <class name="pat::PFParticle"  ClassVersion="16">
-   <version ClassVersion="16" checksum="4057492004"/>
-   <version ClassVersion="15" checksum="1485536104"/>
-   <version ClassVersion="14" checksum="2795911745"/>
-   <version ClassVersion="13" checksum="223824921"/>
-   <version ClassVersion="12" checksum="4118931093"/>
-   <version ClassVersion="11" checksum="2923110109"/>
-   <version ClassVersion="10" checksum="2240381542"/>
+  <class name="pat::PFParticle"  ClassVersion="3">
+   <version ClassVersion="3" checksum="1471957762"/>
   </class>
   <class name="pat::GenericParticle"  ClassVersion="3">
-   <version ClassVersion="3" checksum="581922746"/>
+   <version ClassVersion="3" checksum="776020708"/>
   </class>
-  <class name="pat::Hemisphere"  ClassVersion="12">
-   <version ClassVersion="12" checksum="1827958121"/>
-   <version ClassVersion="11" checksum="1034779649"/>
-   <version ClassVersion="10" checksum="2908192056"/>
+  <class name="pat::Hemisphere"  ClassVersion="3">
+   <version ClassVersion="3" checksum="3728411613"/>
   </class>
   <class name="pat::Conversion"  ClassVersion="11">
    <version ClassVersion="11" checksum="1239840459"/>
@@ -238,33 +147,8 @@
   <class name="pat::PackedCandidate::PackedCovariance" ClassVersion="3">
    <version ClassVersion="3" checksum="3320406063"/>
   </class>
-  <class name="pat::PackedCandidate" ClassVersion="35">
-   <version ClassVersion="35" checksum="2065846728"/>
-   <version ClassVersion="34" checksum="3953181632"/>
-   <version ClassVersion="33" checksum="1092680546"/>
-   <version ClassVersion="32" checksum="926869123"/>
-   <version ClassVersion="31" checksum="1248040002"/>
-   <version ClassVersion="30" checksum="3338823671"/>
-   <version ClassVersion="29" checksum="649303924"/>
-   <version ClassVersion="28" checksum="1956349111"/>
-    <version ClassVersion="27" checksum="2418936168"/>
-    <version ClassVersion="26" checksum="2986327792"/>
-    <version ClassVersion="25" checksum="3654469025"/>
-    <version ClassVersion="24" checksum="663492232"/>
-    <version ClassVersion="23" checksum="559934341"/>
-    <version ClassVersion="22" checksum="691064527"/>
-    <version ClassVersion="21" checksum="1075665714"/>
-    <version ClassVersion="20" checksum="2078702780"/>
-    <version ClassVersion="19" checksum="359155190"/>
-    <version ClassVersion="18" checksum="4275117305"/>
-    <version ClassVersion="17" checksum="1257500115"/>
-    <version ClassVersion="16" checksum="3261782486"/>
-    <version ClassVersion="15" checksum="2118306102"/>
-    <version ClassVersion="14" checksum="1075333340"/>
-    <version ClassVersion="13" checksum="981046949"/>
-    <version ClassVersion="12" checksum="981046949"/>
-    <version ClassVersion="11" checksum="3135186025"/>
-    <version ClassVersion="10" checksum="572957881"/>
+  <class name="pat::PackedCandidate" ClassVersion="3">
+   <version ClassVersion="3" checksum="3982189188"/>
     <field name="p4_" transient="true" />
     <field name="p4c_" transient="true" />
     <field name="vertex_" transient="true" />
@@ -298,59 +182,13 @@
     <![CDATA[delete m_.exchange(nullptr);
     ]]>
   </ioread>
-  <ioread sourceClass="pat::PackedCandidate" source="uint16_t packedCovarianceDxyDxy_; uint16_t packedCovarianceDxyDz_; uint16_t packedCovarianceDzDz_;   int8_t packedCovarianceDlambdaDz_; int8_t packedCovarianceDphiDxy_;  int8_t packedCovarianceDptDpt_; int8_t packedCovarianceDetaDeta_;  int8_t packedCovarianceDphiDphi_ " version="[-28]" targetClass="pat::PackedCandidate"
-   target="packedCovariance_" embed="false" >
-   <![CDATA[
-            packedCovariance_.dxydxy = onfile.packedCovarianceDxyDxy_;
-            packedCovariance_.dxydz = onfile.packedCovarianceDxyDz_;
-	    packedCovariance_.dzdz = onfile.packedCovarianceDzDz_;
-	    packedCovariance_.dlambdadz = onfile.packedCovarianceDlambdaDz_;
-	    packedCovariance_.dphidxy = onfile.packedCovarianceDphiDxy_;
-            packedCovariance_.dptdpt = onfile.packedCovarianceDptDpt_;
-            packedCovariance_.detadeta = onfile.packedCovarianceDetaDeta_;
-            packedCovariance_.dphidphi = onfile.packedCovarianceDphiDphi_;
-   ]]>
-   </ioread>
-  <ioread sourceClass="pat::PackedCandidate" source="int8_t packedPuppiweight_" version="[-32]" targetClass="pat::PackedCandidate"
-   target="packedPuppiweight_" include="DataFormats/Math/interface/liblogintpack.h">
-   <![CDATA[
-            packedPuppiweight_ = std::numeric_limits<uint8_t>::max()*(logintpack::unpack8logClosed(onfile.packedPuppiweight_,-2,0,64)/2. + 0.5);
-   ]]>
-   </ioread>
-  <ioread sourceClass="pat::PackedCandidate" source="int8_t packedPuppiweightNoLepDiff_; int8_t packedPuppiweight_" version="[-32]" targetClass="pat::PackedCandidate"
-   target="packedPuppiweightNoLepDiff_" include="DataFormats/Math/interface/liblogintpack.h">
-   <![CDATA[
-            packedPuppiweightNoLepDiff_ = std::numeric_limits<int8_t>::max()*(logintpack::unpack8logClosed(onfile.packedPuppiweightNoLepDiff_+onfile.packedPuppiweight_,-2,0,64)/2. - logintpack::unpack8logClosed(onfile.packedPuppiweight_,-2,0,64)/2.);
-   ]]>
-   </ioread>
-  <ioread sourceClass="pat::PackedCandidate" source="int8_t hcalFraction_; int pdgId_" version="[-33]" targetClass="pat::PackedCandidate" target="rawHcalFraction_,hcalFraction_,pdgId_">
-   <![CDATA[
-      int absPdgId = abs(onfile.pdgId_);
-      if (absPdgId == 211 || absPdgId == 11 || absPdgId == 13) {
-        rawHcalFraction_ = onfile.hcalFraction_;
-        hcalFraction_ = 0;
-      } else {
-        hcalFraction_ = onfile.hcalFraction_;
-      }
-      pdgId_ = onfile.pdgId_;
-   ]]>
-   </ioread>
 
 
-  <class name="pat::PackedGenParticle" ClassVersion="12">
-    <version ClassVersion="12" checksum="2626711017"/>
-    <version ClassVersion="11" checksum="25552245"/>
-    <version ClassVersion="10" checksum="389883266"/>
+  <class name="pat::PackedGenParticle" ClassVersion="3">
+    <version ClassVersion="3" checksum="126922139"/>
     <field name="p4_" transient="true" />
     <field name="p4c_" transient="true" />
   </class>
-  <ioread sourceClass="pat::PackedGenParticle" source="int16_t packedEta_;int16_t packedPt_;int16_t packedM_;" version="[-10]" checksum="[389883266]" targetClass="pat::PackedGenParticle"
-  	 target="packedY_" embed="false" include="DataFormats/PatCandidates/interface/ioread_packedgen.h" >
-	<![CDATA[
-	packedY_ = convertPackedEtaToPackedY(onfile.packedPt_,onfile.packedEta_,onfile.packedM_);
-	]]>
-   </ioread>
-
   <ioread sourceClass="pat::PackedGenParticle"  version="[1-]" targetClass="pat::PackedGenParticle" source="" target="p4_">
     <![CDATA[delete p4_.exchange(nullptr);
     ]]>
@@ -496,17 +334,17 @@
 
   <!-- RefToBase<Candidate> from PATObjects -->
     <!-- With direct Holder -->
-  <class name="edm::reftobase::Holder<reco::Candidate, pat::ElectronRef>" />
-  <class name="edm::reftobase::Holder<reco::Candidate, pat::MuonRef>" />
-  <class name="edm::reftobase::Holder<reco::Candidate, pat::TauRef>" />
-  <class name="edm::reftobase::Holder<reco::Candidate, pat::PhotonRef>" />
-  <class name="edm::reftobase::Holder<reco::Candidate, pat::JetRef>" />
-  <class name="edm::reftobase::Holder<reco::Candidate, pat::METRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, pat::ElectronRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, pat::MuonRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, pat::TauRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, pat::PhotonRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, pat::JetRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, pat::METRef>" />
 <!-- no reftobase needed for pat::MHT as it is filled from PAT objects -->
-  <class name="edm::reftobase::Holder<reco::Candidate, pat::ParticleRef>" />
-  <class name="edm::reftobase::Holder<reco::Candidate, pat::CompositeCandidateRef>" />
-  <class name="edm::reftobase::Holder<reco::Candidate, pat::PFParticleRef>" />
-  <class name="edm::reftobase::Holder<reco::Candidate, pat::GenericParticleRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, pat::ParticleRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, pat::CompositeCandidateRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, pat::PFParticleRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, pat::GenericParticleRef>" />
     <!-- With indirect holder (RefHolder) -->
   <class name="edm::reftobase::RefHolder<pat::ElectronRef>" />
   <class name="edm::reftobase::RefHolder<pat::MuonRef>" />
@@ -523,7 +361,7 @@
 
  <!-- RefToBaseVector<Candidate> from PATObjetcs  -->
   <class name="edm::reftobase::RefVectorHolder<pat::CompositeCandidateRefVector>" />
-  <class name="edm::reftobase::VectorHolder<reco::Candidate, pat::CompositeCandidateRefVector>" />
+  <class name="edm::reftobase::VectorHolder<reco::io_v1::Candidate, pat::CompositeCandidateRefVector>" />
 
   <class name="edm::RefProd<pat::PackedCandidateCollection>" />
   <class name="edm::Association<pat::PackedCandidateCollection>" />

--- a/DataFormats/PatCandidates/src/classes_def_other.xml
+++ b/DataFormats/PatCandidates/src/classes_def_other.xml
@@ -24,22 +24,22 @@
   <class name="edm::Wrapper<StringMap>" />
 
   <class name="pat::VertexAssociation"  ClassVersion="3">
-   <version ClassVersion="3" checksum="3351303165"/>
+   <version ClassVersion="3" checksum="21244477"/>
   </class>
   <class name="std::vector<pat::VertexAssociation>" />
   <class name="edm::ValueMap<pat::VertexAssociation>" />
   <class name="edm::Wrapper<edm::ValueMap<pat::VertexAssociation> >" />
 
-  <class name="pat::EventHypothesis"  ClassVersion="10">
-   <version ClassVersion="10" checksum="1415498305"/>
+  <class name="pat::EventHypothesis"  ClassVersion="3">
+   <version ClassVersion="3" checksum="3601051829"/>
   </class>
   <class name="std::vector<pat::EventHypothesis>" />
 
   <class name="edm::Wrapper<std::vector<pat::EventHypothesis> >" />
 
   <enum name ="pat::IsolationKeys" />
-  <class name="std::pair<pat::IsolationKeys,reco::IsoDeposit>" />
-  <class name="std::vector<std::pair<pat::IsolationKeys,reco::IsoDeposit> >" />
+  <class name="std::pair<pat::IsolationKeys,reco::io_v1::IsoDeposit>" />
+  <class name="std::vector<std::pair<pat::IsolationKeys,reco::io_v1::IsoDeposit> >" />
 
   <class name="pat::LookupTableRecord"  ClassVersion="10">
    <version ClassVersion="10" checksum="3701346054"/>

--- a/DataFormats/PatCandidates/src/classes_def_trigger.xml
+++ b/DataFormats/PatCandidates/src/classes_def_trigger.xml
@@ -1,10 +1,8 @@
 <lcgdict>
  <selection>
 
-  <class name="pat::TriggerObject"  ClassVersion="12">
-   <version ClassVersion="12" checksum="2628734905"/>
-   <version ClassVersion="11" checksum="2574350865"/>
-   <version ClassVersion="10" checksum="2299474032"/>
+  <class name="pat::TriggerObject"  ClassVersion="3">
+   <version ClassVersion="3" checksum="2359969177"/>
   </class>
   <class name="std::vector&lt;pat::TriggerObject&gt;" />
   <class name="std::vector&lt;pat::TriggerObject&gt;::const_iterator" />
@@ -17,7 +15,7 @@
   <class name="pat::TriggerObjectRefVector" />
   <class name="pat::TriggerObjectRefVectorIterator" />
   <class name="edm::Association&lt;std::vector&lt;pat::TriggerObject&gt; &gt;" />
-  <class name="edm::reftobase::Holder&lt;reco::Candidate,pat::TriggerObjectRef&gt;" />
+  <class name="edm::reftobase::Holder&lt;reco::io_v1::Candidate,pat::TriggerObjectRef&gt;" />
   <class name="edm::reftobase::RefHolder&lt;pat::TriggerObjectRef&gt;" />
   <class name="edm::Wrapper&lt;edm::Association&lt;std::vector&lt;pat::TriggerObject&gt; &gt; &gt;" />
   <class name="edm::RefProd&lt;edm::Association&lt;std::vector&lt;pat::TriggerObject&gt; &gt; &gt;" />
@@ -26,12 +24,8 @@
   <class name="std::map&lt;std::string, edm::RefProd&lt;edm::Association&lt;std::vector&lt;pat::TriggerObject&gt; &gt; &gt; &gt;::const_iterator" />
   <class name="edm::Wrapper&lt;std::map&lt;std::string, edm::RefProd&lt;edm::Association&lt;std::vector&lt;pat::TriggerObject&gt; &gt; &gt; &gt; &gt;" />
 
-  <class name="pat::TriggerObjectStandAlone"  ClassVersion="14">
-   <version ClassVersion="14" checksum="2704342787"/>
-   <version ClassVersion="13" checksum="54935316"/>
-   <version ClassVersion="12" checksum="2923001116"/>
-   <version ClassVersion="10" checksum="3478292234"/>
-   <version ClassVersion="11" checksum="167266363"/>
+  <class name="pat::TriggerObjectStandAlone"  ClassVersion="3">
+   <version ClassVersion="3" checksum="3324775075"/>
   </class>
   <class name="std::vector&lt;pat::TriggerObjectStandAlone&gt;" />
   <class name="std::vector&lt;pat::TriggerObjectStandAlone&gt;::const_iterator" />
@@ -42,7 +36,7 @@
   <class name="pat::TriggerObjectStandAloneRefVector" />
   <class name="pat::TriggerObjectStandAloneRefVectorIterator" />
   <class name="edm::Association&lt;std::vector&lt;pat::TriggerObjectStandAlone&gt; &gt;" />
-  <class name="edm::reftobase::Holder&lt;reco::Candidate,pat::TriggerObjectStandAloneRef&gt;" />
+  <class name="edm::reftobase::Holder&lt;reco::io_v1::Candidate,pat::TriggerObjectStandAloneRef&gt;" />
   <class name="edm::reftobase::RefHolder&lt;pat::TriggerObjectStandAloneRef&gt;" />
   <class name="edm::Wrapper&lt;edm::Association&lt;std::vector&lt;pat::TriggerObjectStandAlone&gt; &gt; &gt;" />
 

--- a/DataFormats/PatCandidates/src/classes_def_user.xml
+++ b/DataFormats/PatCandidates/src/classes_def_user.xml
@@ -38,9 +38,9 @@
 <class name="pat::UserHolder<Vector3DBase<float,GlobalTag> >" />
 <class name="pat::UserHolder<bool>" />
 <class name="pat::UserHolder<edm::Ref<vector<pat::CompositeCandidate>,pat::CompositeCandidate,edm::refhelper::FindUsingAdvance<vector<pat::CompositeCandidate>,pat::CompositeCandidate> > >" />
-<class name="pat::UserHolder<edm::Ref<vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<vector<reco::Vertex>,reco::Vertex> > >" />
+<class name="pat::UserHolder<edm::Ref<vector<reco::io_v1::Vertex>,reco::io_v1::Vertex,edm::refhelper::FindUsingAdvance<vector<reco::io_v1::Vertex>,reco::io_v1::Vertex> > >" />
 <class name="pat::UserHolder<reco::Track>" />
-<class name="pat::UserHolder<reco::Vertex>" />
+<class name="pat::UserHolder<reco::io_v1::Vertex>" />
 <class name="pat::UserHolder<edm::Ptr<pat::PackedCandidate> >" />
 <class name="pat::UserHolder<vector<unsigned int> >" />
 

--- a/DataFormats/ProtonReco/interface/ForwardProton.h
+++ b/DataFormats/ProtonReco/interface/ForwardProton.h
@@ -16,157 +16,160 @@
 #include "DataFormats/CTPPSReco/interface/CTPPSLocalTrackLiteFwd.h"
 
 namespace reco {
-  class ForwardProton {
-  public:
-    /// parameter dimension
-    enum { dimension = 5 };
-    /// indices to the covariance matrix
-    enum struct Index { xi, th_x, vtx_x, th_y, vtx_y, num_indices = dimension };
-    /// dimension-parameter covariance matrix
-    typedef math::ErrorF<dimension>::type CovarianceMatrix;
-    /// spatial vector
-    typedef math::XYZVectorF Vector;
-    /// point in the space
-    typedef math::XYZPointF Point;
-    /// type of reconstruction applied for this track
-    enum class ReconstructionMethod { invalid = -1, singleRP, multiRP };
+  namespace io_v1 {
+    class ForwardProton {
+    public:
+      /// parameter dimension
+      enum { dimension = 5 };
+      /// indices to the covariance matrix
+      enum struct Index { xi, th_x, vtx_x, th_y, vtx_y, num_indices = dimension };
+      /// dimension-parameter covariance matrix
+      typedef math::ErrorF<dimension>::type CovarianceMatrix;
+      /// spatial vector
+      typedef math::XYZVectorF Vector;
+      /// point in the space
+      typedef math::XYZPointF Point;
+      /// type of reconstruction applied for this track
+      enum class ReconstructionMethod { invalid = -1, singleRP, multiRP };
 
-  public:
-    /// default constructor
-    ForwardProton();
-    /// constructor from refit parameters, fitted vertex and momentum, and longitudinal fractional momentum loss
-    ForwardProton(double chi2,
-                  double ndof,
-                  const Point& vtx,
-                  const Vector& momentum,
-                  float xi,
-                  const CovarianceMatrix& cov,
-                  ReconstructionMethod method,
-                  const CTPPSLocalTrackLiteRefVector& local_tracks,
-                  bool valid,
-                  const float time = 0.,
-                  const float time_err = 0.);
+    public:
+      /// default constructor
+      ForwardProton();
+      /// constructor from refit parameters, fitted vertex and momentum, and longitudinal fractional momentum loss
+      ForwardProton(double chi2,
+                    double ndof,
+                    const Point& vtx,
+                    const Vector& momentum,
+                    float xi,
+                    const CovarianceMatrix& cov,
+                    ReconstructionMethod method,
+                    const CTPPSLocalTrackLiteRefVector& local_tracks,
+                    bool valid,
+                    const float time = 0.,
+                    const float time_err = 0.);
 
-    /// fitted vertex position
-    const Point& vertex() const { return vertex_; }
-    /// fitted vertex horizontal position
-    float vx() const { return vertex_.x(); }
-    /// fitted vertex vertical position
-    float vy() const { return vertex_.y(); }
-    /// vertex longitudinal position (conventionally set to 0)
-    float vz() const { return vertex_.z(); }
-    /// fitted track direction
-    const Vector& momentum() const { return momentum_; }
-    /// scalar norm of fitted track momentum
-    float p() const { return momentum_.r(); }
-    /// scalar fitted track transverse momentum
-    float pt() const { return momentum_.rho(); }
-    /// fitted track momentum horizontal component
-    float px() const { return momentum_.x(); }
-    /// fitted track momentum vertical component
-    float py() const { return momentum_.y(); }
-    /// fitted track momentum longitudinal component
-    float pz() const { return momentum_.z(); }
+      /// fitted vertex position
+      const Point& vertex() const { return vertex_; }
+      /// fitted vertex horizontal position
+      float vx() const { return vertex_.x(); }
+      /// fitted vertex vertical position
+      float vy() const { return vertex_.y(); }
+      /// vertex longitudinal position (conventionally set to 0)
+      float vz() const { return vertex_.z(); }
+      /// fitted track direction
+      const Vector& momentum() const { return momentum_; }
+      /// scalar norm of fitted track momentum
+      float p() const { return momentum_.r(); }
+      /// scalar fitted track transverse momentum
+      float pt() const { return momentum_.rho(); }
+      /// fitted track momentum horizontal component
+      float px() const { return momentum_.x(); }
+      /// fitted track momentum vertical component
+      float py() const { return momentum_.y(); }
+      /// fitted track momentum longitudinal component
+      float pz() const { return momentum_.z(); }
 
-    /// chi-squared of the fit
-    float chi2() const { return chi2_; }
-    /// number of degrees of freedom for the track fit
-    unsigned int ndof() const { return ndof_; }
-    /// chi-squared divided by ndof (or chi-squared * 1e6 if ndof is zero)
-    float normalizedChi2() const { return (ndof_ != 0) ? chi2_ / ndof_ : chi2_ * 1.e6; }
+      /// chi-squared of the fit
+      float chi2() const { return chi2_; }
+      /// number of degrees of freedom for the track fit
+      unsigned int ndof() const { return ndof_; }
+      /// chi-squared divided by ndof (or chi-squared * 1e6 if ndof is zero)
+      float normalizedChi2() const { return (ndof_ != 0) ? chi2_ / ndof_ : chi2_ * 1.e6; }
 
-    /// longitudinal fractional momentum loss
-    float xi() const { return xi_; }
-    /// vertical scattering angle, in rad
-    float thetaX() const { return px() / p(); }
-    /// horizontal scattering angle, in rad
-    float thetaY() const { return py() / p(); }
+      /// longitudinal fractional momentum loss
+      float xi() const { return xi_; }
+      /// vertical scattering angle, in rad
+      float thetaX() const { return px() / p(); }
+      /// horizontal scattering angle, in rad
+      float thetaY() const { return py() / p(); }
 
-    // vertex position can be obtained via TrackBase::vx() and vy() functions
+      // vertex position can be obtained via TrackBase::vx() and vy() functions
 
-    /// return the uncertainty on a given component
-    double error(Index i) const { return sqrt(covariance_((unsigned int)i, (unsigned int)i)); }
+      /// return the uncertainty on a given component
+      double error(Index i) const { return sqrt(covariance_((unsigned int)i, (unsigned int)i)); }
 
-    /// uncertainty on longitudinal fractional momentum loss
-    float xiError() const { return error(Index::xi); }
-    /// uncertainty on fitted momentum horizontal angle opening
-    float thetaXError() const { return error(Index::th_x); }
-    /// uncertainty on fitted momentum vertical angle opening
-    float thetaYError() const { return error(Index::th_y); }
-    /// uncertainty on fitted vertex horizontal position
-    float vxError() const { return error(Index::vtx_x); }
-    /// uncertainty on fitted vertex vertical position
-    float vyError() const { return error(Index::vtx_y); }
+      /// uncertainty on longitudinal fractional momentum loss
+      float xiError() const { return error(Index::xi); }
+      /// uncertainty on fitted momentum horizontal angle opening
+      float thetaXError() const { return error(Index::th_x); }
+      /// uncertainty on fitted momentum vertical angle opening
+      float thetaYError() const { return error(Index::th_y); }
+      /// uncertainty on fitted vertex horizontal position
+      float vxError() const { return error(Index::vtx_x); }
+      /// uncertainty on fitted vertex vertical position
+      float vyError() const { return error(Index::vtx_y); }
 
-    /// proton mass in GeV
-    static float mass() { return mass_; }
+      /// proton mass in GeV
+      static float mass() { return mass_; }
 
-    /// compute the squared four-momentum transfer from incident and scattered momenta, and angular information
-    static float calculateT(double beam_mom, double proton_mom, double theta);
+      /// compute the squared four-momentum transfer from incident and scattered momenta, and angular information
+      static float calculateT(double beam_mom, double proton_mom, double theta);
 
-    /// four-momentum transfer squared, in GeV^2
-    float t() const;
+      /// four-momentum transfer squared, in GeV^2
+      float t() const;
 
-    /// time of proton arrival at forward stations
-    float time() const { return time_; }
-    void setTime(float time) { time_ = time; }
+      /// time of proton arrival at forward stations
+      float time() const { return time_; }
+      void setTime(float time) { time_ = time; }
 
-    /// uncertainty on time of proton arrival at forward stations
-    float timeError() const { return time_err_; }
-    void setTimeError(float time_err) { time_err_ = time_err; }
+      /// uncertainty on time of proton arrival at forward stations
+      float timeError() const { return time_err_; }
+      void setTimeError(float time_err) { time_err_ = time_err; }
 
-    /// set the flag for the fit validity
-    void setValidFit(bool valid = true) { valid_fit_ = valid; }
-    /// flag for the fit validity
-    bool validFit() const { return valid_fit_; }
+      /// set the flag for the fit validity
+      void setValidFit(bool valid = true) { valid_fit_ = valid; }
+      /// flag for the fit validity
+      bool validFit() const { return valid_fit_; }
 
-    /// set the reconstruction method for this track
-    void setMethod(const ReconstructionMethod& method) { method_ = method; }
-    /// reconstruction method for this track
-    ReconstructionMethod method() const { return method_; }
+      /// set the reconstruction method for this track
+      void setMethod(const ReconstructionMethod& method) { method_ = method; }
+      /// reconstruction method for this track
+      ReconstructionMethod method() const { return method_; }
 
-    /// store the list of RP tracks that contributed to this global track
-    void setContributingLocalTracks(const CTPPSLocalTrackLiteRefVector& v) { contributing_local_tracks_ = v; }
-    /// list of RP tracks that contributed to this global track
-    const CTPPSLocalTrackLiteRefVector& contributingLocalTracks() const { return contributing_local_tracks_; }
+      /// store the list of RP tracks that contributed to this global track
+      void setContributingLocalTracks(const CTPPSLocalTrackLiteRefVector& v) { contributing_local_tracks_ = v; }
+      /// list of RP tracks that contributed to this global track
+      const CTPPSLocalTrackLiteRefVector& contributingLocalTracks() const { return contributing_local_tracks_; }
 
-    /// LHC sector
-    enum class LHCSector { invalid = -1, sector45, sector56 };
-    LHCSector lhcSector() const {
-      if (pz() < 0.)
-        return LHCSector::sector56;
-      if (pz() > 0.)
-        return LHCSector::sector45;
-      return LHCSector::invalid;
-    }
+      /// LHC sector
+      enum class LHCSector { invalid = -1, sector45, sector56 };
+      LHCSector lhcSector() const {
+        if (pz() < 0.)
+          return LHCSector::sector56;
+        if (pz() > 0.)
+          return LHCSector::sector45;
+        return LHCSector::invalid;
+      }
 
-  private:
-    static constexpr float mass_ = 0.938272046;        ///< proton mass, GeV
-    static constexpr float massSquared_ = 0.88035443;  ///< proton mass squared, GeV^2
+    private:
+      static constexpr float mass_ = 0.938272046;        ///< proton mass, GeV
+      static constexpr float massSquared_ = 0.88035443;  ///< proton mass squared, GeV^2
 
-    /// reconstructed vertex position at z/s = 0
-    Point vertex_;
-    /// reconstructed momentum vector
-    Vector momentum_;
-    /// reconstructed time at forward detectors
-    float time_;
-    /// uncertainty on reconstructed time at forward detectors
-    float time_err_;
-    /// fractional momentum loss (positive for diffractive protons)
-    float xi_;
-    /// 5x5 covariance matrix
-    CovarianceMatrix covariance_;
-    /// chi-squared
-    float chi2_;
-    /// number of degrees of freedom
-    unsigned int ndof_;
-    /// fit validity flag
-    bool valid_fit_;
-    /// type of reconstruction applied
-    ReconstructionMethod method_;
-    /// collection of references to tracks contributing to this object definition
-    CTPPSLocalTrackLiteRefVector contributing_local_tracks_;
-  };
+      /// reconstructed vertex position at z/s = 0
+      Point vertex_;
+      /// reconstructed momentum vector
+      Vector momentum_;
+      /// reconstructed time at forward detectors
+      float time_;
+      /// uncertainty on reconstructed time at forward detectors
+      float time_err_;
+      /// fractional momentum loss (positive for diffractive protons)
+      float xi_;
+      /// 5x5 covariance matrix
+      CovarianceMatrix covariance_;
+      /// chi-squared
+      float chi2_;
+      /// number of degrees of freedom
+      unsigned int ndof_;
+      /// fit validity flag
+      bool valid_fit_;
+      /// type of reconstruction applied
+      ReconstructionMethod method_;
+      /// collection of references to tracks contributing to this object definition
+      CTPPSLocalTrackLiteRefVector contributing_local_tracks_;
+    };
+  }  // namespace io_v1
+  using ForwardProton = io_v1::ForwardProton;
 }  // namespace reco
 
 #endif

--- a/DataFormats/ProtonReco/interface/ForwardProtonFwd.h
+++ b/DataFormats/ProtonReco/interface/ForwardProtonFwd.h
@@ -17,7 +17,10 @@
 #include <vector>
 
 namespace reco {
-  class ForwardProton;
+  namespace io_v1 {
+    class ForwardProton;
+  }
+  using ForwardProton = io_v1::ForwardProton;
   /// Collection of ForwardProton objects
   typedef std::vector<ForwardProton> ForwardProtonCollection;
   /// Persistent reference to a ForwardProton

--- a/DataFormats/ProtonReco/src/classes_def.xml
+++ b/DataFormats/ProtonReco/src/classes_def.xml
@@ -1,10 +1,10 @@
 <lcgdict>
-  <class name="reco::ForwardProton" ClassVersion="3">
-    <version ClassVersion="3" checksum="897616683"/>
+  <class name="reco::io_v1::ForwardProton" ClassVersion="3">
+    <version ClassVersion="3" checksum="2994769763"/>
   </class>
-  <class name="std::vector<reco::ForwardProton>"/>
-  <class name="edm::Wrapper<std::vector<reco::ForwardProton> >"/>
-  <class name="edm::RefProd<std::vector<reco::ForwardProton> >"/>
-  <class name="edm::Ref<std::vector<reco::ForwardProton>,reco::ForwardProton,edm::refhelper::FindUsingAdvance<std::vector<reco::ForwardProton>,reco::ForwardProton> >"/>
-  <class name="edm::RefVector<std::vector<reco::ForwardProton>,reco::ForwardProton,edm::refhelper::FindUsingAdvance<std::vector<reco::ForwardProton>,reco::ForwardProton> >"/>
+  <class name="std::vector<reco::io_v1::ForwardProton>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::ForwardProton> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::ForwardProton> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::ForwardProton>,reco::io_v1::ForwardProton,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::ForwardProton>,reco::io_v1::ForwardProton> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::ForwardProton>,reco::io_v1::ForwardProton,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::ForwardProton>,reco::io_v1::ForwardProton> >"/>
 </lcgdict>

--- a/DataFormats/RecoCandidate/interface/IsoDepositFwd.h
+++ b/DataFormats/RecoCandidate/interface/IsoDepositFwd.h
@@ -6,7 +6,10 @@
 #define HAVE_COMMON_ISODEPOSITMAP 1
 
 namespace reco {
-  class IsoDeposit;
+  namespace io_v1 {
+    class IsoDeposit;
+  }
+  using IsoDeposit = io_v1::IsoDeposit;
 
   //! keep it only as a part of ValueMap
   typedef edm::ValueMap<reco::IsoDeposit> IsoDepositMap;

--- a/DataFormats/RecoCandidate/interface/RecoChargedCandidate.h
+++ b/DataFormats/RecoCandidate/interface/RecoChargedCandidate.h
@@ -11,35 +11,38 @@
 #include "DataFormats/RecoCandidate/interface/RecoCandidate.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  class RecoChargedCandidate : public RecoCandidate {
-  public:
-    /// default constructor
-    RecoChargedCandidate() : RecoCandidate() {}
-    /// constructor from values
-    RecoChargedCandidate(
-        Charge q, const LorentzVector& p4, const Point& vtx = Point(0, 0, 0), int pdgId = 0, int status = 0)
-        : RecoCandidate(q, p4, vtx, pdgId, status) {}
-    /// constructor from values
-    RecoChargedCandidate(
-        Charge q, const PolarLorentzVector& p4, const Point& vtx = Point(0, 0, 0), int pdgId = 0, int status = 0)
-        : RecoCandidate(q, p4, vtx, pdgId, status) {}
-    /// destructor
-    ~RecoChargedCandidate() override;
-    /// returns a clone of the candidate
-    RecoChargedCandidate* clone() const override;
-    /// set reference to track
-    void setTrack(const reco::TrackRef& r) { track_ = r; }
-    /// reference to a track
-    reco::TrackRef track() const override;
+    class RecoChargedCandidate : public RecoCandidate {
+    public:
+      /// default constructor
+      RecoChargedCandidate() : RecoCandidate() {}
+      /// constructor from values
+      RecoChargedCandidate(
+          Charge q, const LorentzVector& p4, const Point& vtx = Point(0, 0, 0), int pdgId = 0, int status = 0)
+          : RecoCandidate(q, p4, vtx, pdgId, status) {}
+      /// constructor from values
+      RecoChargedCandidate(
+          Charge q, const PolarLorentzVector& p4, const Point& vtx = Point(0, 0, 0), int pdgId = 0, int status = 0)
+          : RecoCandidate(q, p4, vtx, pdgId, status) {}
+      /// destructor
+      ~RecoChargedCandidate() override;
+      /// returns a clone of the candidate
+      RecoChargedCandidate* clone() const override;
+      /// set reference to track
+      void setTrack(const reco::TrackRef& r) { track_ = r; }
+      /// reference to a track
+      reco::TrackRef track() const override;
 
-  private:
-    /// check overlap with another candidate
-    bool overlap(const Candidate&) const override;
-    /// reference to a track
-    reco::TrackRef track_;
-  };
+    private:
+      /// check overlap with another candidate
+      bool overlap(const Candidate&) const override;
+      /// reference to a track
+      reco::TrackRef track_;
+    };
 
+  }  // namespace io_v1
+  using RecoChargedCandidate = io_v1::RecoChargedCandidate;
 }  // namespace reco
 
 #endif

--- a/DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h
+++ b/DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h
@@ -6,7 +6,10 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 namespace reco {
-  class RecoChargedCandidate;
+  namespace io_v1 {
+    class RecoChargedCandidate;
+  }
+  using RecoChargedCandidate = io_v1::RecoChargedCandidate;
 
   /// collectin of RecoChargedCandidate objects
   typedef std::vector<RecoChargedCandidate> RecoChargedCandidateCollection;

--- a/DataFormats/RecoCandidate/interface/RecoChargedRefCandidate.h
+++ b/DataFormats/RecoCandidate/interface/RecoChargedRefCandidate.h
@@ -9,42 +9,46 @@ namespace reco {
 
   typedef LeafRefCandidateT RecoChargedRefCandidateBase;
 
-  class RecoChargedRefCandidate : public LeafRefCandidateT {
-  public:
-    RecoChargedRefCandidate() {}
-    RecoChargedRefCandidate(TrackRef ref, float m) : LeafRefCandidateT(ref, m) {}
+  namespace io_v1 {
 
-    ~RecoChargedRefCandidate() override {}
+    class RecoChargedRefCandidate : public LeafRefCandidateT {
+    public:
+      RecoChargedRefCandidate() {}
+      RecoChargedRefCandidate(TrackRef ref, float m) : LeafRefCandidateT(ref, m) {}
 
-    RecoChargedRefCandidate* clone() const override { return new RecoChargedRefCandidate(*this); }
+      ~RecoChargedRefCandidate() override {}
 
-    reco::TrackRef track() const { return getRef<reco::TrackRef>(); }
-    // return a pointer to the best track, if available.
-    // otherwise, return a null pointer
-    const reco::Track* bestTrack() const override {
-      if (track().isNonnull() && track().isAvailable())
-        return &(*track());
-      else
-        return nullptr;
-    }
+      RecoChargedRefCandidate* clone() const override { return new RecoChargedRefCandidate(*this); }
 
-    /// uncertainty on dz
-    float dzError() const override {
-      const Track* tr = bestTrack();
-      if (tr != nullptr)
-        return tr->dzError();
-      else
-        return 0;
-    }
-    /// uncertainty on dxy
-    float dxyError() const override {
-      const Track* tr = bestTrack();
-      if (tr != nullptr)
-        return tr->dxyError();
-      else
-        return 0;
-    }
-  };
+      reco::TrackRef track() const { return getRef<reco::TrackRef>(); }
+      // return a pointer to the best track, if available.
+      // otherwise, return a null pointer
+      const reco::Track* bestTrack() const override {
+        if (track().isNonnull() && track().isAvailable())
+          return &(*track());
+        else
+          return nullptr;
+      }
+
+      /// uncertainty on dz
+      float dzError() const override {
+        const Track* tr = bestTrack();
+        if (tr != nullptr)
+          return tr->dzError();
+        else
+          return 0;
+      }
+      /// uncertainty on dxy
+      float dxyError() const override {
+        const Track* tr = bestTrack();
+        if (tr != nullptr)
+          return tr->dxyError();
+        else
+          return 0;
+      }
+    };
+  }  // namespace io_v1
+  using RecoChargedRefCandidate = io_v1::RecoChargedRefCandidate;
 }  // namespace reco
 
 #endif

--- a/DataFormats/RecoCandidate/interface/RecoEcalCandidate.h
+++ b/DataFormats/RecoCandidate/interface/RecoEcalCandidate.h
@@ -11,35 +11,38 @@
 #include "DataFormats/RecoCandidate/interface/RecoCandidate.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  class RecoEcalCandidate : public RecoCandidate {
-  public:
-    /// default constructor
-    RecoEcalCandidate() : RecoCandidate() {}
-    /// constructor from values
-    RecoEcalCandidate(
-        Charge q, const LorentzVector& p4, const Point& vtx = Point(0, 0, 0), int pdgId = 0, int status = 0)
-        : RecoCandidate(q, p4, vtx, pdgId, status) {}
-    /// constructor from values
-    RecoEcalCandidate(
-        Charge q, const PolarLorentzVector& p4, const Point& vtx = Point(0, 0, 0), int pdgId = 0, int status = 0)
-        : RecoCandidate(q, p4, vtx, pdgId, status) {}
-    /// destructor
-    ~RecoEcalCandidate() override;
-    /// returns a clone of the candidate
-    RecoEcalCandidate* clone() const override;
-    /// set reference to superCluster
-    void setSuperCluster(const reco::SuperClusterRef& r) { superCluster_ = r; }
-    /// reference to a superCluster
-    reco::SuperClusterRef superCluster() const override;
+    class RecoEcalCandidate : public RecoCandidate {
+    public:
+      /// default constructor
+      RecoEcalCandidate() : RecoCandidate() {}
+      /// constructor from values
+      RecoEcalCandidate(
+          Charge q, const LorentzVector& p4, const Point& vtx = Point(0, 0, 0), int pdgId = 0, int status = 0)
+          : RecoCandidate(q, p4, vtx, pdgId, status) {}
+      /// constructor from values
+      RecoEcalCandidate(
+          Charge q, const PolarLorentzVector& p4, const Point& vtx = Point(0, 0, 0), int pdgId = 0, int status = 0)
+          : RecoCandidate(q, p4, vtx, pdgId, status) {}
+      /// destructor
+      ~RecoEcalCandidate() override;
+      /// returns a clone of the candidate
+      RecoEcalCandidate* clone() const override;
+      /// set reference to superCluster
+      void setSuperCluster(const reco::SuperClusterRef& r) { superCluster_ = r; }
+      /// reference to a superCluster
+      reco::SuperClusterRef superCluster() const override;
 
-  private:
-    /// check overlap with another candidate
-    bool overlap(const Candidate&) const override;
-    /// reference to a superCluster
-    reco::SuperClusterRef superCluster_;
-  };
+    private:
+      /// check overlap with another candidate
+      bool overlap(const Candidate&) const override;
+      /// reference to a superCluster
+      reco::SuperClusterRef superCluster_;
+    };
 
+  }  // namespace io_v1
+  using RecoEcalCandidate = io_v1::RecoEcalCandidate;
 }  // namespace reco
 
 #endif

--- a/DataFormats/RecoCandidate/interface/RecoEcalCandidateFwd.h
+++ b/DataFormats/RecoCandidate/interface/RecoEcalCandidateFwd.h
@@ -6,7 +6,10 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 namespace reco {
-  class RecoEcalCandidate;
+  namespace io_v1 {
+    class RecoEcalCandidate;
+  }
+  using RecoEcalCandidate = io_v1::RecoEcalCandidate;
 
   /// collectin of RecoEcalCandidate objects
   typedef std::vector<RecoEcalCandidate> RecoEcalCandidateCollection;

--- a/DataFormats/RecoCandidate/src/classes_def.xml
+++ b/DataFormats/RecoCandidate/src/classes_def.xml
@@ -1,33 +1,22 @@
 <lcgdict>
   <selection>
-  <class name="reco::RecoCandidate"  ClassVersion="12">
-   <version ClassVersion="12" checksum="3838151746"/>
-   <version ClassVersion="11" checksum="1478341962"/>
-   <version ClassVersion="10" checksum="1183963017"/>
+  <class name="reco::RecoCandidate"  ClassVersion="3">
+   <version ClassVersion="3" checksum="4047077766"/>
   </class>
-  <class name="reco::RecoChargedCandidate"  ClassVersion="3">
-   <version ClassVersion="3" checksum="3697403153"/>
+  <class name="reco::io_v1::RecoChargedCandidate"  ClassVersion="3">
+   <version ClassVersion="3" checksum="2583659187"/>
   </class>
-  <class name="reco::RecoChargedRefCandidate"  ClassVersion="12">
-   <version ClassVersion="12" checksum="2499408251"/>
-    <version ClassVersion="11" checksum="27158565"/>
-    <version ClassVersion="10" checksum="2155624976"/>
+  <class name="reco::io_v1::RecoChargedRefCandidate"  ClassVersion="3">
+   <version ClassVersion="3" checksum="2706310913"/>
   </class>
-  <class name="reco::RecoEcalCandidate"  ClassVersion="12">
-   <version ClassVersion="12" checksum="2643748274"/>
-   <version ClassVersion="11" checksum="1100355146"/>
-   <version ClassVersion="10" checksum="3531165310"/>
+  <class name="reco::io_v1::RecoEcalCandidate"  ClassVersion="3">
+   <version ClassVersion="3" checksum="2351437140"/>
   </class>
-  <class name="reco::RecoCaloTowerCandidate" ClassVersion="12">
-   <version ClassVersion="12" checksum="4228136352"/>
-   <version ClassVersion="11" checksum="2294254376"/>
-   <version ClassVersion="10" checksum="4182970126"/>
+  <class name="reco::RecoCaloTowerCandidate" ClassVersion="3">
+   <version ClassVersion="3" checksum="583643428"/>
   </class>
-  <class name="reco::CaloRecHitCandidate" ClassVersion="13">
-   <version ClassVersion="13" checksum="1653614292"/>
-   <version ClassVersion="12" checksum="878375709"/>
-   <version ClassVersion="11" checksum="85197237"/>
-   <version ClassVersion="10" checksum="1441861764"/>
+  <class name="reco::CaloRecHitCandidate" ClassVersion="3">
+   <version ClassVersion="3" checksum="1842643264"/>
   </class>
 
   <class name="reco::FitQuality"  ClassVersion="11">
@@ -40,112 +29,114 @@
     <!-- <field name="fixed_" transient="true"/> -->
   </class>
 
-  <class name="std::vector<reco::RecoChargedCandidate>"/>
-  <class name="edm::Wrapper<std::vector<reco::RecoChargedCandidate> >"/>
-  <class name="edm::Ref<std::vector<reco::RecoChargedCandidate>,reco::RecoChargedCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoChargedCandidate>,reco::RecoChargedCandidate> >"/>
-  <class name="edm::RefProd<std::vector<reco::RecoChargedCandidate> >"/>
-  <class name="edm::RefVector<std::vector<reco::RecoChargedCandidate>,reco::RecoChargedCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoChargedCandidate>,reco::RecoChargedCandidate> >"/>
+  <class name="std::vector<reco::io_v1::RecoChargedCandidate>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::RecoChargedCandidate> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::RecoChargedCandidate>,reco::io_v1::RecoChargedCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoChargedCandidate>,reco::io_v1::RecoChargedCandidate> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::RecoChargedCandidate> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::RecoChargedCandidate>,reco::io_v1::RecoChargedCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoChargedCandidate>,reco::io_v1::RecoChargedCandidate> >"/>
+  <class name="std::vector<edm::Ref<std::vector<reco::io_v1::RecoChargedCandidate>,reco::io_v1::RecoChargedCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoChargedCandidate>,reco::io_v1::RecoChargedCandidate> > >"/>
 
-  <class name="std::vector<reco::RecoChargedRefCandidate>"/>
-  <class name="edm::Wrapper<std::vector<reco::RecoChargedRefCandidate> >"/>
-  <class name="edm::Ref<std::vector<reco::RecoChargedRefCandidate>,reco::RecoChargedRefCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoChargedRefCandidate>,reco::RecoChargedRefCandidate> >"/>
-  <class name="edm::RefProd<std::vector<reco::RecoChargedRefCandidate> >"/>
-  <class name="edm::RefVector<std::vector<reco::RecoChargedRefCandidate>,reco::RecoChargedRefCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoChargedRefCandidate>,reco::RecoChargedRefCandidate> >"/>
+  <class name="std::vector<reco::io_v1::RecoChargedRefCandidate>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::RecoChargedRefCandidate> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::RecoChargedRefCandidate>,reco::io_v1::RecoChargedRefCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoChargedRefCandidate>,reco::io_v1::RecoChargedRefCandidate> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::RecoChargedRefCandidate> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::RecoChargedRefCandidate>,reco::io_v1::RecoChargedRefCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoChargedRefCandidate>,reco::io_v1::RecoChargedRefCandidate> >"/>
 
-  <class name="edm::AssociationMap<edm::OneToValue<std::vector<reco::RecoChargedCandidate>, float, unsigned int> >">
+  <class name="edm::AssociationMap<edm::OneToValue<std::vector<reco::io_v1::RecoChargedCandidate>, float, unsigned int> >">
       <field name="transientMap_" transient="true" />
   </class>
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<std::vector<reco::RecoChargedCandidate>, float, unsigned int> > >" />
-  <class name="edm::helpers::Key<edm::RefProd<std::vector<reco::RecoChargedCandidate> > >" />
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<std::vector<reco::io_v1::RecoChargedCandidate>, float, unsigned int> > >" />
+  <class name="edm::helpers::Key<edm::RefProd<std::vector<reco::io_v1::RecoChargedCandidate> > >" />
 
-  <class name="std::vector<reco::RecoEcalCandidate>"/>
-  <class name="edm::Wrapper<std::vector<reco::RecoEcalCandidate> >"/>
+  <class name="std::vector<reco::io_v1::RecoEcalCandidate>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::RecoEcalCandidate> >"/>
 
-  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::RecoEcalCandidate> > >"/>
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::io_v1::RecoEcalCandidate> > >"/>
 
-  <class name="edm::Ref<std::vector<reco::RecoEcalCandidate>,reco::RecoEcalCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoEcalCandidate>,reco::RecoEcalCandidate> >"/>
-  <class name="edm::RefProd<std::vector<reco::RecoEcalCandidate> >"/>
-  <class name="edm::RefVector<std::vector<reco::RecoEcalCandidate>,reco::RecoEcalCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoEcalCandidate>,reco::RecoEcalCandidate> >"/>
- <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::RecoEcalCandidate>,reco::RecoEcalCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoEcalCandidate>,reco::RecoEcalCandidate> > >" />
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::RecoChargedCandidate>,reco::RecoChargedCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoChargedCandidate>,reco::RecoChargedCandidate> > >" />
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::RecoChargedRefCandidate>,reco::RecoChargedRefCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoChargedRefCandidate>,reco::RecoChargedRefCandidate> > >" />
+  <class name="edm::Ref<std::vector<reco::io_v1::RecoEcalCandidate>,reco::io_v1::RecoEcalCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoEcalCandidate>,reco::io_v1::RecoEcalCandidate> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::RecoEcalCandidate> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::RecoEcalCandidate>,reco::io_v1::RecoEcalCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoEcalCandidate>,reco::io_v1::RecoEcalCandidate> >"/>
+ <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<reco::io_v1::RecoEcalCandidate>,reco::io_v1::RecoEcalCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoEcalCandidate>,reco::io_v1::RecoEcalCandidate> > >" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<reco::io_v1::RecoChargedCandidate>,reco::io_v1::RecoChargedCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoChargedCandidate>,reco::io_v1::RecoChargedCandidate> > >" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<reco::io_v1::RecoChargedRefCandidate>,reco::io_v1::RecoChargedRefCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoChargedRefCandidate>,reco::io_v1::RecoChargedRefCandidate> > >" />
+  <class name="std::vector<edm::Ref<std::vector<reco::io_v1::RecoEcalCandidate>,reco::io_v1::RecoEcalCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoEcalCandidate>,reco::io_v1::RecoEcalCandidate> > >"/>
 
-  <class name="edm::AssociationMap<edm::OneToValue<std::vector<reco::RecoEcalCandidate>, float, unsigned int> >">
+  <class name="edm::AssociationMap<edm::OneToValue<std::vector<reco::io_v1::RecoEcalCandidate>, float, unsigned int> >">
     <field name="transientMap_" transient="true" />
   </class>
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<std::vector<reco::RecoEcalCandidate>, float, unsigned int> > >" />
-  <class name="edm::helpers::Key<edm::RefProd<std::vector<reco::RecoEcalCandidate> > >" />
-  <class name="edm::AssociationMap<edm::OneToOne<std::vector<reco::Track>,edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,unsigned int> >">
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<std::vector<reco::io_v1::RecoEcalCandidate>, float, unsigned int> > >" />
+  <class name="edm::helpers::Key<edm::RefProd<std::vector<reco::io_v1::RecoEcalCandidate> > >" />
+  <class name="edm::AssociationMap<edm::OneToOne<std::vector<reco::Track>,edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,unsigned int> >">
      <field name="transientMap_" transient="true" />
   </class>
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::Track> >,edm::RefProd<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> > > >" />
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<std::vector<reco::Track>,edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,unsigned int> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::Track> >,edm::RefProd<edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> > > >" />
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<std::vector<reco::Track>,edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,unsigned int> > >" />
 
-  <class name="edm::ValueMap<reco::IsoDeposit>" />
+  <class name="edm::ValueMap<reco::io_v1::IsoDeposit>" />
   <class name="edm::ValueMap<reco::FitQuality>" />
   <!-- <class pattern="edm::Wrapper<edm::ValueMap<*>" /> -->
-<class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<vector<reco::Track>,edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,unsigned int> > >" />
-<class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<vector<reco::RecoChargedCandidate>,float,unsigned int> > >" />
-<class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<vector<reco::RecoEcalCandidate>,float,unsigned int> > >" />
+<class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<vector<reco::Track>,edm::OwnVector<reco::io_v1::Candidate,edm::ClonePolicy<reco::io_v1::Candidate> >,unsigned int> > >" />
+<class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<vector<reco::io_v1::RecoChargedCandidate>,float,unsigned int> > >" />
+<class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<vector<reco::io_v1::RecoEcalCandidate>,float,unsigned int> > >" />
 <class name="edm::Wrapper<edm::OwnVector<reco::RecoCandidate,edm::ClonePolicy<reco::RecoCandidate> > >" />
   <!-- <class pattern="edm::Wrapper<edm::AssociationMap<*>" /> -->
 <class name="edm::Wrapper<edm::ValueMap<reco::FitQuality> >" />
-<class name="edm::Wrapper<edm::ValueMap<reco::IsoDeposit> >" />
+<class name="edm::Wrapper<edm::ValueMap<reco::io_v1::IsoDeposit> >" />
  
-  <class name="edm::reftobase::Holder<reco::Candidate, reco::RecoChargedCandidateRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::RecoChargedCandidateRef>" />
   <class name="edm::reftobase::RefHolder<reco::RecoChargedCandidateRef>" />
-  <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::RecoChargedCandidateRefVector>" />
+  <class name="edm::reftobase::VectorHolder<reco::io_v1::Candidate, reco::RecoChargedCandidateRefVector>" />
   <class name="edm::reftobase::RefVectorHolder<reco::RecoChargedCandidateRefVector>" />
 
-  <class name="edm::reftobase::Holder<reco::Candidate, reco::RecoChargedRefCandidateRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::RecoChargedRefCandidateRef>" />
   <class name="edm::reftobase::RefHolder<reco::RecoChargedRefCandidateRef>" />
-  <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::RecoChargedRefCandidateRefVector>" />
+  <class name="edm::reftobase::VectorHolder<reco::io_v1::Candidate, reco::RecoChargedRefCandidateRefVector>" />
   <class name="edm::reftobase::RefVectorHolder<reco::RecoChargedRefCandidateRefVector>" />
 
-  <class name="edm::reftobase::Holder<reco::Candidate, reco::RecoStandAloneMuonCandidateRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::RecoStandAloneMuonCandidateRef>" />
   <class name="edm::reftobase::RefHolder<reco::RecoStandAloneMuonCandidateRef>" />
-  <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::RecoStandAloneMuonCandidateRefVector>" />
+  <class name="edm::reftobase::VectorHolder<reco::io_v1::Candidate, reco::RecoStandAloneMuonCandidateRefVector>" />
   <class name="edm::reftobase::RefVectorHolder<reco::RecoStandAloneMuonCandidateRefVector>" />
 
-  <class name="edm::reftobase::Holder<reco::Candidate, reco::RecoEcalCandidateRef>" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, reco::RecoEcalCandidateRef>" />
   <class name="edm::reftobase::RefHolder<reco::RecoEcalCandidateRef>" />
-  <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::RecoEcalCandidateRefVector>" />
+  <class name="edm::reftobase::VectorHolder<reco::io_v1::Candidate, reco::RecoEcalCandidateRefVector>" />
   <class name="edm::reftobase::RefVectorHolder<reco::RecoEcalCandidateRefVector>" />
 
-  <class name="reco::IsoDeposit" ClassVersion="10">
-   <version ClassVersion="10" checksum="2477314412"/>
+  <class name="reco::io_v1::IsoDeposit" ClassVersion="3">
+   <version ClassVersion="3" checksum="2520868128"/>
   </class>
-  <class name="reco::IsoDeposit::const_iterator" ClassVersion="10">
-   <version ClassVersion="10" checksum="3505639118"/>
+  <class name="reco::io_v1::IsoDeposit::const_iterator" ClassVersion="3">
+   <version ClassVersion="3" checksum="1988268972"/>
       <field name="parent_" transient="true" />
       <field name="it_" transient="true" />
       <field name="cache_" transient="true" />
       <field name="cacheReady_" transient="true" />
   </class>
-  <class name="std::vector<reco::IsoDeposit>"/>
-  <class name="std::vector<reco::IsoDeposit>::const_iterator"/>
+  <class name="std::vector<reco::io_v1::IsoDeposit>"/>
+  <class name="std::vector<reco::io_v1::IsoDeposit>::const_iterator"/>
 
-  <class name="reco::isodeposit::Direction" ClassVersion="10">
+  <class name="reco::io_v1::IsoDeposit::Direction" ClassVersion="10">
    <version ClassVersion="10" checksum="2412209684"/>
   </class>
-  <class name="reco::isodeposit::Direction::Distance" ClassVersion="10">
+  <class name="reco::io_v1::IsoDeposit::Direction::Distance" ClassVersion="10">
    <version ClassVersion="10" checksum="2603689691"/>
   </class>
-  <class name="reco::IsoDeposit::Veto" ClassVersion="10">
-   <version ClassVersion="10" checksum="4098085496"/>
+  <class name="reco::io_v1::IsoDeposit::Veto" ClassVersion="3">
+   <version ClassVersion="3" checksum="4179939266"/>
   </class>
-  <class name="std::multimap<reco::isodeposit::Direction::Distance,float>"/>
+  <class name="std::multimap<reco::io_v1::IsoDeposit::Direction::Distance,float>"/>
 
-  <class name="edm::ValueMap<reco::IsoDeposit>::const_iterator">
+  <class name="edm::ValueMap<reco::io_v1::IsoDeposit>::const_iterator">
     <field name="values_" transient="true"/>
     <field name="i_" transient="true"/>
     <field name="end_" transient="true"/>
   </class>
   <class name="edm::Wrapper<reco::IsoDepositMap>"/>
   
-  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::RecoChargedCandidate>,reco::RecoChargedCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoChargedCandidate>,reco::RecoChargedCandidate> > >" />
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::io_v1::RecoChargedCandidate>,reco::io_v1::RecoChargedCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoChargedCandidate>,reco::io_v1::RecoChargedCandidate> > >" />
 
-  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::RecoChargedRefCandidate>,reco::RecoChargedRefCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoChargedRefCandidate>,reco::RecoChargedRefCandidate> > >" />
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::io_v1::RecoChargedRefCandidate>,reco::io_v1::RecoChargedRefCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoChargedRefCandidate>,reco::io_v1::RecoChargedRefCandidate> > >" />
 
   <class name="std::vector<reco::RecoCandidate*>"/>
   <class name="edm::OwnVector<reco::RecoCandidate, edm::ClonePolicy<reco::RecoCandidate> >"/>

--- a/DataFormats/TauReco/interface/PFTau.h
+++ b/DataFormats/TauReco/interface/PFTau.h
@@ -32,285 +32,288 @@ namespace reco {
 }  // namespace reco
 
 namespace reco {
+  namespace io_v1 {
 
-  class PFTau : public BaseTau {
-  public:
-    enum hadronicDecayMode {
-      kNull = -1,
-      kOneProng0PiZero,
-      kOneProng1PiZero,
-      kOneProng2PiZero,
-      kOneProng3PiZero,
-      kOneProngNPiZero,
-      kTwoProng0PiZero,
-      kTwoProng1PiZero,
-      kTwoProng2PiZero,
-      kTwoProng3PiZero,
-      kTwoProngNPiZero,
-      kThreeProng0PiZero,
-      kThreeProng1PiZero,
-      kThreeProng2PiZero,
-      kThreeProng3PiZero,
-      kThreeProngNPiZero,
-      kRareDecayMode
+    class PFTau : public BaseTau {
+    public:
+      enum hadronicDecayMode {
+        kNull = -1,
+        kOneProng0PiZero,
+        kOneProng1PiZero,
+        kOneProng2PiZero,
+        kOneProng3PiZero,
+        kOneProngNPiZero,
+        kTwoProng0PiZero,
+        kTwoProng1PiZero,
+        kTwoProng2PiZero,
+        kTwoProng3PiZero,
+        kTwoProngNPiZero,
+        kThreeProng0PiZero,
+        kThreeProng1PiZero,
+        kThreeProng2PiZero,
+        kThreeProng3PiZero,
+        kThreeProngNPiZero,
+        kRareDecayMode
+      };
+
+      PFTau();
+      PFTau(Charge q, const LorentzVector&, const Point& = Point(0, 0, 0));
+      ~PFTau() override {}
+      PFTau* clone() const override;
+
+      const JetBaseRef& jetRef() const;
+      void setjetRef(const JetBaseRef&);
+
+      // functions to access the PFTauTagInfoRef used by HLT
+      const PFTauTagInfoRef& pfTauTagInfoRef() const;
+      void setpfTauTagInfoRef(const PFTauTagInfoRef);
+
+      PFRecoTauChargedHadronRef leadTauChargedHadronCandidate() const;
+      const CandidatePtr& leadChargedHadrCand() const;
+      const CandidatePtr& leadNeutralCand() const;
+      //Can be either the charged or the neutral one
+      const CandidatePtr& leadCand() const;
+
+      void setleadChargedHadrCand(const CandidatePtr&);
+      void setleadNeutralCand(const CandidatePtr&);
+      void setleadCand(const CandidatePtr&);
+
+      /// Signed transverse impact parameter significance of the Track
+      /// associated to the leading charged PFCandidate
+      float leadPFChargedHadrCandsignedSipt() const;
+      void setleadPFChargedHadrCandsignedSipt(const float&);
+
+      /// Candidates in signal region
+      const std::vector<reco::CandidatePtr>& signalCands() const;
+      void setsignalCands(const std::vector<reco::CandidatePtr>&);
+
+      /// Charged hadrons in signal region
+      const std::vector<reco::CandidatePtr>& signalChargedHadrCands() const;
+      void setsignalChargedHadrCands(const std::vector<reco::CandidatePtr>&);
+
+      /// Neutral hadrons in signal region
+      const std::vector<reco::CandidatePtr>& signalNeutrHadrCands() const;
+      void setsignalNeutrHadrCands(const std::vector<reco::CandidatePtr>&);
+
+      /// Gamma candidates in signal region
+      const std::vector<reco::CandidatePtr>& signalGammaCands() const;
+      void setsignalGammaCands(const std::vector<reco::CandidatePtr>&);
+
+      /// Candidates in isolation region
+      const std::vector<reco::CandidatePtr>& isolationCands() const;
+      void setisolationCands(const std::vector<reco::CandidatePtr>&);
+
+      /// Charged candidates in isolation region
+      const std::vector<reco::CandidatePtr>& isolationChargedHadrCands() const;
+      void setisolationChargedHadrCands(const std::vector<reco::CandidatePtr>&);
+
+      //// Neutral hadrons in isolation region
+      const std::vector<reco::CandidatePtr>& isolationNeutrHadrCands() const;
+      void setisolationNeutrHadrCands(const std::vector<reco::CandidatePtr>&);
+
+      /// Gamma candidates in isolation region
+      const std::vector<reco::CandidatePtr>& isolationGammaCands() const;
+      void setisolationGammaCands(const std::vector<reco::CandidatePtr>&);
+
+      /// Getters for different PFCandidates for PFTaus made from PFCandidates
+      const PFCandidatePtr leadPFChargedHadrCand() const;
+      const PFCandidatePtr leadPFNeutralCand() const;
+      const PFCandidatePtr leadPFCand() const;
+      const std::vector<reco::PFCandidatePtr>& signalPFCands() const;
+      const std::vector<reco::PFCandidatePtr>& signalPFChargedHadrCands() const;
+      const std::vector<reco::PFCandidatePtr>& signalPFNeutrHadrCands() const;
+      const std::vector<reco::PFCandidatePtr>& signalPFGammaCands() const;
+      const std::vector<reco::PFCandidatePtr>& isolationPFCands() const;
+      const std::vector<reco::PFCandidatePtr>& isolationPFChargedHadrCands() const;
+      const std::vector<reco::PFCandidatePtr>& isolationPFNeutrHadrCands() const;
+      const std::vector<reco::PFCandidatePtr>& isolationPFGammaCands() const;
+
+      /// Sum of charged hadron candidate PT in isolation cone; returns NaN
+      /// if isolation region is undefined.
+      float isolationPFChargedHadrCandsPtSum() const;
+      void setisolationPFChargedHadrCandsPtSum(const float&);
+
+      /// Sum of gamma candidate PT in isolation cone; returns NaN
+      /// if isolation region is undefined.
+      float isolationPFGammaCandsEtSum() const;
+      void setisolationPFGammaCandsEtSum(const float&);
+
+      /// Et of the highest Et HCAL PFCluster
+      float maximumHCALPFClusterEt() const;
+      void setmaximumHCALPFClusterEt(const float&);
+
+      /// Retrieve the association of signal region gamma candidates into candidate PiZeros
+      const std::vector<RecoTauPiZero>& signalPiZeroCandidates() const;
+      void setsignalPiZeroCandidates(std::vector<RecoTauPiZero>);
+      void setSignalPiZeroCandidatesRefs(RecoTauPiZeroRefVector);
+
+      /// Retrieve the association of isolation region gamma candidates into candidate PiZeros
+      const std::vector<RecoTauPiZero>& isolationPiZeroCandidates() const;
+      void setisolationPiZeroCandidates(std::vector<RecoTauPiZero>);
+      void setIsolationPiZeroCandidatesRefs(RecoTauPiZeroRefVector);
+
+      /// Retrieve the association of signal region PF candidates into candidate PFRecoTauChargedHadrons
+      const std::vector<PFRecoTauChargedHadron>& signalTauChargedHadronCandidates() const;
+      void setSignalTauChargedHadronCandidates(std::vector<PFRecoTauChargedHadron>);
+      void setSignalTauChargedHadronCandidatesRefs(PFRecoTauChargedHadronRefVector);
+
+      /// Retrieve the association of isolation region PF candidates into candidate PFRecoTauChargedHadron
+      const std::vector<PFRecoTauChargedHadron>& isolationTauChargedHadronCandidates() const;
+      void setIsolationTauChargedHadronCandidates(std::vector<PFRecoTauChargedHadron>);
+      void setIsolationTauChargedHadronCandidatesRefs(PFRecoTauChargedHadronRefVector);
+
+      /// Retrieve the identified hadronic decay mode according to the number of
+      /// charged and piZero candidates in the signal cone
+      hadronicDecayMode decayMode() const;
+      void setDecayMode(const hadronicDecayMode&);
+
+      /// Effect of eta and phi correction of strip on mass of tau candidate
+      float bendCorrMass() const { return bendCorrMass_; }
+      void setBendCorrMass(float bendCorrMass) { bendCorrMass_ = bendCorrMass; }
+
+      /// Size of signal cone
+      double signalConeSize() const { return signalConeSize_; }
+      void setSignalConeSize(double signalConeSize) { signalConeSize_ = signalConeSize; }
+
+      //Electron rejection
+      float emFraction() const;        // Ecal/Hcal Cluster Energy
+      float hcalTotOverPLead() const;  // total Hcal Cluster E / leadPFChargedHadron P
+      float hcalMaxOverPLead() const;  // max. Hcal Cluster E / leadPFChargedHadron P
+      // Hcal Cluster E in R<0.184 around Ecal impact point of leading track / leadPFChargedHadron P
+      float hcal3x3OverPLead() const;
+      float ecalStripSumEOverPLead() const;       // Simple BremsRecovery Sum E / leadPFChargedHadron P
+      float bremsRecoveryEOverPLead() const;      // BremsRecovery Sum E / leadPFChargedHadron P
+      reco::TrackRef electronPreIDTrack() const;  // Ref to KF track from Electron PreID
+      float electronPreIDOutput() const;          // BDT output from Electron PreID
+      bool electronPreIDDecision() const;         // Decision from Electron PreID
+
+      void setemFraction(const float&);
+      void sethcalTotOverPLead(const float&);
+      void sethcalMaxOverPLead(const float&);
+      void sethcal3x3OverPLead(const float&);
+      void setecalStripSumEOverPLead(const float&);
+      void setbremsRecoveryEOverPLead(const float&);
+      void setelectronPreIDTrack(const reco::TrackRef&);
+      void setelectronPreIDOutput(const float&);
+      void setelectronPreIDDecision(const bool&);
+
+      // For Muon Rejection
+      bool hasMuonReference() const;  // check if muon ref exists
+      float caloComp() const;
+      float segComp() const;
+      bool muonDecision() const;
+      void setCaloComp(const float&);
+      void setSegComp(const float&);
+      void setMuonDecision(const bool&);
+
+      /// return the number of source Candidates
+      /// ( the candidates used to construct this Candidate)
+      /// in the case of taus, there is only one source candidate,
+      /// which is the corresponding PFJet
+      size_type numberOfSourceCandidatePtrs() const override { return 1; }
+
+      /// return a RefToBase to the source Candidates
+      /// ( the candidates used to construct this Candidate)
+      CandidatePtr sourceCandidatePtr(size_type i) const override;
+
+      /// prints information on this PFTau
+      void dump(std::ostream& out = std::cout) const;
+
+    private:
+      friend class tau::RecoTauConstructor;
+      friend class tau::PFRecoTauEnergyAlgorithmPlugin;
+
+      //These are used by the friends
+      std::vector<RecoTauPiZero>& signalPiZeroCandidatesRestricted();
+      std::vector<RecoTauPiZero>& isolationPiZeroCandidatesRestricted();
+      std::vector<PFRecoTauChargedHadron>& signalTauChargedHadronCandidatesRestricted();
+      std::vector<PFRecoTauChargedHadron>& isolationTauChargedHadronCandidatesRestricted();
+
+      // check overlap with another candidate
+      bool overlap(const Candidate&) const override;
+
+      bool muonDecision_;
+      bool electronPreIDDecision_;
+
+      // SIP
+      float leadPFChargedHadrCandsignedSipt_;
+      // Isolation variables
+      float isolationPFChargedHadrCandsPtSum_;
+      float isolationPFGammaCandsEtSum_;
+      float maximumHCALPFClusterEt_;
+
+      // Electron rejection variables
+      float emFraction_;
+      float hcalTotOverPLead_;
+      float hcalMaxOverPLead_;
+      float hcal3x3OverPLead_;
+      float ecalStripSumEOverPLead_;
+      float bremsRecoveryEOverPLead_;
+      float electronPreIDOutput_;
+
+      // Muon rejection variables
+      float caloComp_;
+      float segComp_;
+
+      hadronicDecayMode decayMode_;
+
+      float bendCorrMass_;
+
+      float signalConeSize_;
+
+      reco::JetBaseRef jetRef_;
+      PFTauTagInfoRef PFTauTagInfoRef_;
+      reco::CandidatePtr leadChargedHadrCand_;
+      reco::CandidatePtr leadNeutralCand_;
+      reco::CandidatePtr leadCand_;
+      reco::TrackRef electronPreIDTrack_;
+
+      // Signal candidates
+      std::vector<reco::CandidatePtr> selectedSignalCands_;
+      std::vector<reco::CandidatePtr> selectedSignalChargedHadrCands_;
+      std::vector<reco::CandidatePtr> selectedSignalNeutrHadrCands_;
+      std::vector<reco::CandidatePtr> selectedSignalGammaCands_;
+
+      // Isolation candidates
+      std::vector<reco::CandidatePtr> selectedIsolationCands_;
+      std::vector<reco::CandidatePtr> selectedIsolationChargedHadrCands_;
+      std::vector<reco::CandidatePtr> selectedIsolationNeutrHadrCands_;
+      std::vector<reco::CandidatePtr> selectedIsolationGammaCands_;
+
+      // Transient caches for PFCandidate-based accessors
+      edm::AtomicPtrCache<reco::PFCandidatePtr> leadPFChargedHadrCand_;
+      edm::AtomicPtrCache<reco::PFCandidatePtr> leadPFNeutralCand_;
+      edm::AtomicPtrCache<reco::PFCandidatePtr> leadPFCand_;
+
+      edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr>> selectedTransientSignalPFCands_;
+      edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr>> selectedTransientSignalPFChargedHadrCands_;
+      edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr>> selectedTransientSignalPFNeutrHadrCands_;
+      edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr>> selectedTransientSignalPFGammaCands_;
+
+      edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr>> selectedTransientIsolationPFCands_;
+      edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr>> selectedTransientIsolationPFChargedHadrCands_;
+      edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr>> selectedTransientIsolationPFNeutrHadrCands_;
+      edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr>> selectedTransientIsolationPFGammaCands_;
+
+      RecoTauPiZeroRefVector signalPiZeroCandidatesRefs_;
+      RecoTauPiZeroRefVector isolationPiZeroCandidatesRefs_;
+
+      PFRecoTauChargedHadronRefVector signalTauChargedHadronCandidatesRefs_;
+      PFRecoTauChargedHadronRefVector isolationTauChargedHadronCandidatesRefs_;
+
+      // Association of gamma candidates into PiZeros (transient)
+      edm::AtomicPtrCache<std::vector<reco::RecoTauPiZero>> signalPiZeroCandidates_;
+      edm::AtomicPtrCache<std::vector<reco::RecoTauPiZero>> isolationPiZeroCandidates_;
+
+      // Association of PF candidates into PFRecoTauChargedHadrons (transient)
+      edm::AtomicPtrCache<std::vector<reco::PFRecoTauChargedHadron>> signalTauChargedHadronCandidates_;
+      edm::AtomicPtrCache<std::vector<reco::PFRecoTauChargedHadron>> isolationTauChargedHadronCandidates_;
     };
 
-    PFTau();
-    PFTau(Charge q, const LorentzVector&, const Point& = Point(0, 0, 0));
-    ~PFTau() override {}
-    PFTau* clone() const override;
+    std::ostream& operator<<(std::ostream& out, const PFTau& c);
 
-    const JetBaseRef& jetRef() const;
-    void setjetRef(const JetBaseRef&);
-
-    // functions to access the PFTauTagInfoRef used by HLT
-    const PFTauTagInfoRef& pfTauTagInfoRef() const;
-    void setpfTauTagInfoRef(const PFTauTagInfoRef);
-
-    PFRecoTauChargedHadronRef leadTauChargedHadronCandidate() const;
-    const CandidatePtr& leadChargedHadrCand() const;
-    const CandidatePtr& leadNeutralCand() const;
-    //Can be either the charged or the neutral one
-    const CandidatePtr& leadCand() const;
-
-    void setleadChargedHadrCand(const CandidatePtr&);
-    void setleadNeutralCand(const CandidatePtr&);
-    void setleadCand(const CandidatePtr&);
-
-    /// Signed transverse impact parameter significance of the Track
-    /// associated to the leading charged PFCandidate
-    float leadPFChargedHadrCandsignedSipt() const;
-    void setleadPFChargedHadrCandsignedSipt(const float&);
-
-    /// Candidates in signal region
-    const std::vector<reco::CandidatePtr>& signalCands() const;
-    void setsignalCands(const std::vector<reco::CandidatePtr>&);
-
-    /// Charged hadrons in signal region
-    const std::vector<reco::CandidatePtr>& signalChargedHadrCands() const;
-    void setsignalChargedHadrCands(const std::vector<reco::CandidatePtr>&);
-
-    /// Neutral hadrons in signal region
-    const std::vector<reco::CandidatePtr>& signalNeutrHadrCands() const;
-    void setsignalNeutrHadrCands(const std::vector<reco::CandidatePtr>&);
-
-    /// Gamma candidates in signal region
-    const std::vector<reco::CandidatePtr>& signalGammaCands() const;
-    void setsignalGammaCands(const std::vector<reco::CandidatePtr>&);
-
-    /// Candidates in isolation region
-    const std::vector<reco::CandidatePtr>& isolationCands() const;
-    void setisolationCands(const std::vector<reco::CandidatePtr>&);
-
-    /// Charged candidates in isolation region
-    const std::vector<reco::CandidatePtr>& isolationChargedHadrCands() const;
-    void setisolationChargedHadrCands(const std::vector<reco::CandidatePtr>&);
-
-    //// Neutral hadrons in isolation region
-    const std::vector<reco::CandidatePtr>& isolationNeutrHadrCands() const;
-    void setisolationNeutrHadrCands(const std::vector<reco::CandidatePtr>&);
-
-    /// Gamma candidates in isolation region
-    const std::vector<reco::CandidatePtr>& isolationGammaCands() const;
-    void setisolationGammaCands(const std::vector<reco::CandidatePtr>&);
-
-    /// Getters for different PFCandidates for PFTaus made from PFCandidates
-    const PFCandidatePtr leadPFChargedHadrCand() const;
-    const PFCandidatePtr leadPFNeutralCand() const;
-    const PFCandidatePtr leadPFCand() const;
-    const std::vector<reco::PFCandidatePtr>& signalPFCands() const;
-    const std::vector<reco::PFCandidatePtr>& signalPFChargedHadrCands() const;
-    const std::vector<reco::PFCandidatePtr>& signalPFNeutrHadrCands() const;
-    const std::vector<reco::PFCandidatePtr>& signalPFGammaCands() const;
-    const std::vector<reco::PFCandidatePtr>& isolationPFCands() const;
-    const std::vector<reco::PFCandidatePtr>& isolationPFChargedHadrCands() const;
-    const std::vector<reco::PFCandidatePtr>& isolationPFNeutrHadrCands() const;
-    const std::vector<reco::PFCandidatePtr>& isolationPFGammaCands() const;
-
-    /// Sum of charged hadron candidate PT in isolation cone; returns NaN
-    /// if isolation region is undefined.
-    float isolationPFChargedHadrCandsPtSum() const;
-    void setisolationPFChargedHadrCandsPtSum(const float&);
-
-    /// Sum of gamma candidate PT in isolation cone; returns NaN
-    /// if isolation region is undefined.
-    float isolationPFGammaCandsEtSum() const;
-    void setisolationPFGammaCandsEtSum(const float&);
-
-    /// Et of the highest Et HCAL PFCluster
-    float maximumHCALPFClusterEt() const;
-    void setmaximumHCALPFClusterEt(const float&);
-
-    /// Retrieve the association of signal region gamma candidates into candidate PiZeros
-    const std::vector<RecoTauPiZero>& signalPiZeroCandidates() const;
-    void setsignalPiZeroCandidates(std::vector<RecoTauPiZero>);
-    void setSignalPiZeroCandidatesRefs(RecoTauPiZeroRefVector);
-
-    /// Retrieve the association of isolation region gamma candidates into candidate PiZeros
-    const std::vector<RecoTauPiZero>& isolationPiZeroCandidates() const;
-    void setisolationPiZeroCandidates(std::vector<RecoTauPiZero>);
-    void setIsolationPiZeroCandidatesRefs(RecoTauPiZeroRefVector);
-
-    /// Retrieve the association of signal region PF candidates into candidate PFRecoTauChargedHadrons
-    const std::vector<PFRecoTauChargedHadron>& signalTauChargedHadronCandidates() const;
-    void setSignalTauChargedHadronCandidates(std::vector<PFRecoTauChargedHadron>);
-    void setSignalTauChargedHadronCandidatesRefs(PFRecoTauChargedHadronRefVector);
-
-    /// Retrieve the association of isolation region PF candidates into candidate PFRecoTauChargedHadron
-    const std::vector<PFRecoTauChargedHadron>& isolationTauChargedHadronCandidates() const;
-    void setIsolationTauChargedHadronCandidates(std::vector<PFRecoTauChargedHadron>);
-    void setIsolationTauChargedHadronCandidatesRefs(PFRecoTauChargedHadronRefVector);
-
-    /// Retrieve the identified hadronic decay mode according to the number of
-    /// charged and piZero candidates in the signal cone
-    hadronicDecayMode decayMode() const;
-    void setDecayMode(const hadronicDecayMode&);
-
-    /// Effect of eta and phi correction of strip on mass of tau candidate
-    float bendCorrMass() const { return bendCorrMass_; }
-    void setBendCorrMass(float bendCorrMass) { bendCorrMass_ = bendCorrMass; }
-
-    /// Size of signal cone
-    double signalConeSize() const { return signalConeSize_; }
-    void setSignalConeSize(double signalConeSize) { signalConeSize_ = signalConeSize; }
-
-    //Electron rejection
-    float emFraction() const;        // Ecal/Hcal Cluster Energy
-    float hcalTotOverPLead() const;  // total Hcal Cluster E / leadPFChargedHadron P
-    float hcalMaxOverPLead() const;  // max. Hcal Cluster E / leadPFChargedHadron P
-    // Hcal Cluster E in R<0.184 around Ecal impact point of leading track / leadPFChargedHadron P
-    float hcal3x3OverPLead() const;
-    float ecalStripSumEOverPLead() const;       // Simple BremsRecovery Sum E / leadPFChargedHadron P
-    float bremsRecoveryEOverPLead() const;      // BremsRecovery Sum E / leadPFChargedHadron P
-    reco::TrackRef electronPreIDTrack() const;  // Ref to KF track from Electron PreID
-    float electronPreIDOutput() const;          // BDT output from Electron PreID
-    bool electronPreIDDecision() const;         // Decision from Electron PreID
-
-    void setemFraction(const float&);
-    void sethcalTotOverPLead(const float&);
-    void sethcalMaxOverPLead(const float&);
-    void sethcal3x3OverPLead(const float&);
-    void setecalStripSumEOverPLead(const float&);
-    void setbremsRecoveryEOverPLead(const float&);
-    void setelectronPreIDTrack(const reco::TrackRef&);
-    void setelectronPreIDOutput(const float&);
-    void setelectronPreIDDecision(const bool&);
-
-    // For Muon Rejection
-    bool hasMuonReference() const;  // check if muon ref exists
-    float caloComp() const;
-    float segComp() const;
-    bool muonDecision() const;
-    void setCaloComp(const float&);
-    void setSegComp(const float&);
-    void setMuonDecision(const bool&);
-
-    /// return the number of source Candidates
-    /// ( the candidates used to construct this Candidate)
-    /// in the case of taus, there is only one source candidate,
-    /// which is the corresponding PFJet
-    size_type numberOfSourceCandidatePtrs() const override { return 1; }
-
-    /// return a RefToBase to the source Candidates
-    /// ( the candidates used to construct this Candidate)
-    CandidatePtr sourceCandidatePtr(size_type i) const override;
-
-    /// prints information on this PFTau
-    void dump(std::ostream& out = std::cout) const;
-
-  private:
-    friend class tau::RecoTauConstructor;
-    friend class tau::PFRecoTauEnergyAlgorithmPlugin;
-
-    //These are used by the friends
-    std::vector<RecoTauPiZero>& signalPiZeroCandidatesRestricted();
-    std::vector<RecoTauPiZero>& isolationPiZeroCandidatesRestricted();
-    std::vector<PFRecoTauChargedHadron>& signalTauChargedHadronCandidatesRestricted();
-    std::vector<PFRecoTauChargedHadron>& isolationTauChargedHadronCandidatesRestricted();
-
-    // check overlap with another candidate
-    bool overlap(const Candidate&) const override;
-
-    bool muonDecision_;
-    bool electronPreIDDecision_;
-
-    // SIP
-    float leadPFChargedHadrCandsignedSipt_;
-    // Isolation variables
-    float isolationPFChargedHadrCandsPtSum_;
-    float isolationPFGammaCandsEtSum_;
-    float maximumHCALPFClusterEt_;
-
-    // Electron rejection variables
-    float emFraction_;
-    float hcalTotOverPLead_;
-    float hcalMaxOverPLead_;
-    float hcal3x3OverPLead_;
-    float ecalStripSumEOverPLead_;
-    float bremsRecoveryEOverPLead_;
-    float electronPreIDOutput_;
-
-    // Muon rejection variables
-    float caloComp_;
-    float segComp_;
-
-    hadronicDecayMode decayMode_;
-
-    float bendCorrMass_;
-
-    float signalConeSize_;
-
-    reco::JetBaseRef jetRef_;
-    PFTauTagInfoRef PFTauTagInfoRef_;
-    reco::CandidatePtr leadChargedHadrCand_;
-    reco::CandidatePtr leadNeutralCand_;
-    reco::CandidatePtr leadCand_;
-    reco::TrackRef electronPreIDTrack_;
-
-    // Signal candidates
-    std::vector<reco::CandidatePtr> selectedSignalCands_;
-    std::vector<reco::CandidatePtr> selectedSignalChargedHadrCands_;
-    std::vector<reco::CandidatePtr> selectedSignalNeutrHadrCands_;
-    std::vector<reco::CandidatePtr> selectedSignalGammaCands_;
-
-    // Isolation candidates
-    std::vector<reco::CandidatePtr> selectedIsolationCands_;
-    std::vector<reco::CandidatePtr> selectedIsolationChargedHadrCands_;
-    std::vector<reco::CandidatePtr> selectedIsolationNeutrHadrCands_;
-    std::vector<reco::CandidatePtr> selectedIsolationGammaCands_;
-
-    // Transient caches for PFCandidate-based accessors
-    edm::AtomicPtrCache<reco::PFCandidatePtr> leadPFChargedHadrCand_;
-    edm::AtomicPtrCache<reco::PFCandidatePtr> leadPFNeutralCand_;
-    edm::AtomicPtrCache<reco::PFCandidatePtr> leadPFCand_;
-
-    edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr>> selectedTransientSignalPFCands_;
-    edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr>> selectedTransientSignalPFChargedHadrCands_;
-    edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr>> selectedTransientSignalPFNeutrHadrCands_;
-    edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr>> selectedTransientSignalPFGammaCands_;
-
-    edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr>> selectedTransientIsolationPFCands_;
-    edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr>> selectedTransientIsolationPFChargedHadrCands_;
-    edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr>> selectedTransientIsolationPFNeutrHadrCands_;
-    edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr>> selectedTransientIsolationPFGammaCands_;
-
-    RecoTauPiZeroRefVector signalPiZeroCandidatesRefs_;
-    RecoTauPiZeroRefVector isolationPiZeroCandidatesRefs_;
-
-    PFRecoTauChargedHadronRefVector signalTauChargedHadronCandidatesRefs_;
-    PFRecoTauChargedHadronRefVector isolationTauChargedHadronCandidatesRefs_;
-
-    // Association of gamma candidates into PiZeros (transient)
-    edm::AtomicPtrCache<std::vector<reco::RecoTauPiZero>> signalPiZeroCandidates_;
-    edm::AtomicPtrCache<std::vector<reco::RecoTauPiZero>> isolationPiZeroCandidates_;
-
-    // Association of PF candidates into PFRecoTauChargedHadrons (transient)
-    edm::AtomicPtrCache<std::vector<reco::PFRecoTauChargedHadron>> signalTauChargedHadronCandidates_;
-    edm::AtomicPtrCache<std::vector<reco::PFRecoTauChargedHadron>> isolationTauChargedHadronCandidates_;
-  };
-
-  std::ostream& operator<<(std::ostream& out, const PFTau& c);
-
+  }  // namespace io_v1
+  using PFTau = io_v1::PFTau;
 }  // end namespace reco
 
 #endif

--- a/DataFormats/TauReco/interface/PFTauDiscriminator.h
+++ b/DataFormats/TauReco/interface/PFTauDiscriminator.h
@@ -9,14 +9,17 @@
 namespace reco {
   typedef edm::AssociationVector<PFTauRefProd, std::vector<float> > PFTauDiscriminatorBase;
 
-  class PFTauDiscriminator : public PFTauDiscriminatorBase {
-  public:
-    PFTauDiscriminator() : PFTauDiscriminatorBase() {}
+  namespace io_v1 {
+    class PFTauDiscriminator : public PFTauDiscriminatorBase {
+    public:
+      PFTauDiscriminator() : PFTauDiscriminatorBase() {}
 
-    PFTauDiscriminator(const reco::PFTauRefProd &ref) : PFTauDiscriminatorBase(ref) {}
+      PFTauDiscriminator(const reco::PFTauRefProd &ref) : PFTauDiscriminatorBase(ref) {}
 
-    PFTauDiscriminator(const PFTauDiscriminatorBase &v) : PFTauDiscriminatorBase(v) {}
-  };
+      PFTauDiscriminator(const PFTauDiscriminatorBase &v) : PFTauDiscriminatorBase(v) {}
+    };
+  }  // namespace io_v1
+  using PFTauDiscriminator = io_v1::PFTauDiscriminator;
 
   typedef PFTauDiscriminator::value_type PFTauDiscriminatorVT;
   typedef edm::Ref<PFTauDiscriminator> PFTauDiscriminatorRef;

--- a/DataFormats/TauReco/interface/PFTauFwd.h
+++ b/DataFormats/TauReco/interface/PFTauFwd.h
@@ -6,7 +6,10 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 namespace reco {
-  class PFTau;
+  namespace io_v1 {
+    class PFTau;
+  }
+  using PFTau = io_v1::PFTau;
   /// collection of PFTau objects
   typedef std::vector<PFTau> PFTauCollection;
   /// presistent reference to a PFTau

--- a/DataFormats/TauReco/interface/PFTauTransverseImpactParameter.h
+++ b/DataFormats/TauReco/interface/PFTauTransverseImpactParameter.h
@@ -21,64 +21,67 @@
 #include "TVector3.h"
 
 namespace reco {
-  class PFTauTransverseImpactParameter {
-    enum { dimension = 3 };
-    enum { covarianceSize = dimension * (dimension + 1) / 2 };
+  namespace io_v1 {
+    class PFTauTransverseImpactParameter {
+      enum { dimension = 3 };
+      enum { covarianceSize = dimension * (dimension + 1) / 2 };
 
-  public:
-    typedef math::Error<dimension>::type CovMatrix;
-    typedef math::XYZPoint Point;
-    typedef math::XYZVector Vector;
+    public:
+      typedef math::Error<dimension>::type CovMatrix;
+      typedef math::XYZPoint Point;
+      typedef math::XYZVector Vector;
 
-    PFTauTransverseImpactParameter() {}
-    /// constructor from values
-    PFTauTransverseImpactParameter(const Point&, double, double, const Point&, double, double, const VertexRef&);
-    PFTauTransverseImpactParameter(const Point&,
-                                   double,
-                                   double,
-                                   const Point&,
-                                   double,
-                                   double,
-                                   const VertexRef&,
-                                   const Point&,
-                                   double,
-                                   const VertexRef&);
+      PFTauTransverseImpactParameter() {}
+      /// constructor from values
+      PFTauTransverseImpactParameter(const Point&, double, double, const Point&, double, double, const VertexRef&);
+      PFTauTransverseImpactParameter(const Point&,
+                                     double,
+                                     double,
+                                     const Point&,
+                                     double,
+                                     double,
+                                     const VertexRef&,
+                                     const Point&,
+                                     double,
+                                     const VertexRef&);
 
-    virtual ~PFTauTransverseImpactParameter() {}
-    PFTauTransverseImpactParameter* clone() const;
+      virtual ~PFTauTransverseImpactParameter() {}
+      PFTauTransverseImpactParameter* clone() const;
 
-    const Point& dxy_PCA() const { return pca_; }
-    double dxy() const { return dxy_; }
-    double dxy_error() const { return dxy_error_; }
-    double dxy_Sig() const { return (dxy_error_ != 0) ? (dxy_ / dxy_error_) : 0.; }
-    const Point& ip3d_PCA() const { return pca3d_; }
-    double ip3d() const { return ip3d_; }
-    double ip3d_error() const { return ip3d_error_; }
-    double ip3d_Sig() const { return (ip3d_error_ != 0) ? (ip3d_ / ip3d_error_) : 0.; }
-    const VertexRef& primaryVertex() const { return PV_; }
-    Point primaryVertexPos() const;
-    CovMatrix primaryVertexCov() const;
-    bool hasSecondaryVertex() const { return hasSV_; }
-    const Vector& flightLength() const;
-    double flightLengthSig() const;
-    CovMatrix flightLengthCov() const;
-    const VertexRef& secondaryVertex() const { return SV_; }
-    Point secondaryVertexPos() const;
-    CovMatrix secondaryVertexCov() const;
+      const Point& dxy_PCA() const { return pca_; }
+      double dxy() const { return dxy_; }
+      double dxy_error() const { return dxy_error_; }
+      double dxy_Sig() const { return (dxy_error_ != 0) ? (dxy_ / dxy_error_) : 0.; }
+      const Point& ip3d_PCA() const { return pca3d_; }
+      double ip3d() const { return ip3d_; }
+      double ip3d_error() const { return ip3d_error_; }
+      double ip3d_Sig() const { return (ip3d_error_ != 0) ? (ip3d_ / ip3d_error_) : 0.; }
+      const VertexRef& primaryVertex() const { return PV_; }
+      Point primaryVertexPos() const;
+      CovMatrix primaryVertexCov() const;
+      bool hasSecondaryVertex() const { return hasSV_; }
+      const Vector& flightLength() const;
+      double flightLengthSig() const;
+      CovMatrix flightLengthCov() const;
+      const VertexRef& secondaryVertex() const { return SV_; }
+      Point secondaryVertexPos() const;
+      CovMatrix secondaryVertexCov() const;
 
-  private:
-    Point pca_;
-    double dxy_{0};
-    double dxy_error_{0};
-    Point pca3d_;
-    double ip3d_{0};
-    double ip3d_error_{0};
-    VertexRef PV_;
-    bool hasSV_{false};
-    Vector FlightLength_;
-    double FlightLengthSig_{0};
-    VertexRef SV_;
-  };
+    private:
+      Point pca_;
+      double dxy_{0};
+      double dxy_error_{0};
+      Point pca3d_;
+      double ip3d_{0};
+      double ip3d_error_{0};
+      VertexRef PV_;
+      bool hasSV_{false};
+      Vector FlightLength_;
+      double FlightLengthSig_{0};
+      VertexRef SV_;
+    };
+  }  // namespace io_v1
+  using PFTauTransverseImpactParameter = io_v1::PFTauTransverseImpactParameter;
 }  // namespace reco
 
 #endif

--- a/DataFormats/TauReco/interface/PFTauTransverseImpactParameterFwd.h
+++ b/DataFormats/TauReco/interface/PFTauTransverseImpactParameterFwd.h
@@ -6,7 +6,10 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 namespace reco {
-  class PFTauTransverseImpactParameter;
+  namespace io_v1 {
+    class PFTauTransverseImpactParameter;
+  }
+  using PFTauTransverseImpactParameter = io_v1::PFTauTransverseImpactParameter;
   /// collection of PFTauTransverseImpactParameter objects
   typedef std::vector<reco::PFTauTransverseImpactParameter> PFTauTransverseImpactParameterCollection;
   /// presistent reference to a PFTauTransverseImpactParameter

--- a/DataFormats/TauReco/interface/RecoTauPiZero.h
+++ b/DataFormats/TauReco/interface/RecoTauPiZero.h
@@ -4,96 +4,99 @@
 #include "DataFormats/Candidate/interface/CompositePtrCandidate.h"
 
 namespace reco {
-  class RecoTauPiZero : public CompositePtrCandidate {
-  public:
-    enum PiZeroAlgorithm {
-      // Algorithm where each photon becomes a pi zero
-      kUndefined = 0,
-      kTrivial = 1,
-      kCombinatoric = 2,
-      kStrips = 3
+  namespace io_v1 {
+    class RecoTauPiZero : public CompositePtrCandidate {
+    public:
+      enum PiZeroAlgorithm {
+        // Algorithm where each photon becomes a pi zero
+        kUndefined = 0,
+        kTrivial = 1,
+        kCombinatoric = 2,
+        kStrips = 3
+      };
+
+      RecoTauPiZero() : CompositePtrCandidate(), algoName_(kUndefined), bendCorrEta_(0.), bendCorrPhi_(0.) {
+        this->setPdgId(111);
+      }
+
+      RecoTauPiZero(PiZeroAlgorithm algoName)
+          : CompositePtrCandidate(), algoName_(algoName), bendCorrEta_(0.), bendCorrPhi_(0.) {
+        this->setPdgId(111);
+      }
+
+      /// constructor from values
+      RecoTauPiZero(Charge q,
+                    const LorentzVector& p4,
+                    const Point& vtx = Point(0, 0, 0),
+                    int pdgId = 111,
+                    int status = 0,
+                    bool integerCharge = true,
+                    PiZeroAlgorithm algoName = kUndefined)
+          : CompositePtrCandidate(q, p4, vtx, pdgId, status, integerCharge),
+            algoName_(algoName),
+            bendCorrEta_(0.),
+            bendCorrPhi_(0.) {}
+
+      /// constructor from values
+      RecoTauPiZero(Charge q,
+                    const PolarLorentzVector& p4,
+                    const Point& vtx = Point(0, 0, 0),
+                    int pdgId = 111,
+                    int status = 0,
+                    bool integerCharge = true,
+                    PiZeroAlgorithm algoName = kUndefined)
+          : CompositePtrCandidate(q, p4, vtx, pdgId, status, integerCharge),
+            algoName_(algoName),
+            bendCorrEta_(0.),
+            bendCorrPhi_(0.) {}
+
+      /// constructor from a Candidate
+      explicit RecoTauPiZero(const Candidate& p, PiZeroAlgorithm algoName = kUndefined)
+          : CompositePtrCandidate(p), algoName_(algoName), bendCorrEta_(0.), bendCorrPhi_(0.) {
+        this->setPdgId(111);
+      }
+
+      /// destructor
+      ~RecoTauPiZero() override {}
+
+      /// Number of PFGamma constituents
+      size_t numberOfGammas() const;
+
+      /// Number of electron constituents
+      size_t numberOfElectrons() const;
+
+      /// Maximum DeltaPhi between a constituent and the four vector
+      double maxDeltaPhi() const;
+
+      /// Maxmum DeltaEta between a constituent and the four vector
+      double maxDeltaEta() const;
+
+      /// Algorithm that built this piZero
+      PiZeroAlgorithm algo() const;
+
+      /// Check whether a given algo produced this pi zero
+      bool algoIs(PiZeroAlgorithm algo) const;
+
+      /// Size of correction to account for spread of photon energy in eta and phi
+      /// in case charged pions make nuclear interactions or photons convert within the tracking detector
+      float bendCorrEta() const { return bendCorrEta_; }
+      float bendCorrPhi() const { return bendCorrPhi_; }
+      void setBendCorrEta(float bendCorrEta) { bendCorrEta_ = bendCorrEta; }
+      void setBendCorrPhi(float bendCorrPhi) { bendCorrPhi_ = bendCorrPhi; }
+
+      void print(std::ostream& out = std::cout) const;
+
+    private:
+      PiZeroAlgorithm algoName_;
+
+      float bendCorrEta_;
+      float bendCorrPhi_;
     };
 
-    RecoTauPiZero() : CompositePtrCandidate(), algoName_(kUndefined), bendCorrEta_(0.), bendCorrPhi_(0.) {
-      this->setPdgId(111);
-    }
+    std::ostream& operator<<(std::ostream& out, const RecoTauPiZero& c);
 
-    RecoTauPiZero(PiZeroAlgorithm algoName)
-        : CompositePtrCandidate(), algoName_(algoName), bendCorrEta_(0.), bendCorrPhi_(0.) {
-      this->setPdgId(111);
-    }
-
-    /// constructor from values
-    RecoTauPiZero(Charge q,
-                  const LorentzVector& p4,
-                  const Point& vtx = Point(0, 0, 0),
-                  int pdgId = 111,
-                  int status = 0,
-                  bool integerCharge = true,
-                  PiZeroAlgorithm algoName = kUndefined)
-        : CompositePtrCandidate(q, p4, vtx, pdgId, status, integerCharge),
-          algoName_(algoName),
-          bendCorrEta_(0.),
-          bendCorrPhi_(0.) {}
-
-    /// constructor from values
-    RecoTauPiZero(Charge q,
-                  const PolarLorentzVector& p4,
-                  const Point& vtx = Point(0, 0, 0),
-                  int pdgId = 111,
-                  int status = 0,
-                  bool integerCharge = true,
-                  PiZeroAlgorithm algoName = kUndefined)
-        : CompositePtrCandidate(q, p4, vtx, pdgId, status, integerCharge),
-          algoName_(algoName),
-          bendCorrEta_(0.),
-          bendCorrPhi_(0.) {}
-
-    /// constructor from a Candidate
-    explicit RecoTauPiZero(const Candidate& p, PiZeroAlgorithm algoName = kUndefined)
-        : CompositePtrCandidate(p), algoName_(algoName), bendCorrEta_(0.), bendCorrPhi_(0.) {
-      this->setPdgId(111);
-    }
-
-    /// destructor
-    ~RecoTauPiZero() override {}
-
-    /// Number of PFGamma constituents
-    size_t numberOfGammas() const;
-
-    /// Number of electron constituents
-    size_t numberOfElectrons() const;
-
-    /// Maximum DeltaPhi between a constituent and the four vector
-    double maxDeltaPhi() const;
-
-    /// Maxmum DeltaEta between a constituent and the four vector
-    double maxDeltaEta() const;
-
-    /// Algorithm that built this piZero
-    PiZeroAlgorithm algo() const;
-
-    /// Check whether a given algo produced this pi zero
-    bool algoIs(PiZeroAlgorithm algo) const;
-
-    /// Size of correction to account for spread of photon energy in eta and phi
-    /// in case charged pions make nuclear interactions or photons convert within the tracking detector
-    float bendCorrEta() const { return bendCorrEta_; }
-    float bendCorrPhi() const { return bendCorrPhi_; }
-    void setBendCorrEta(float bendCorrEta) { bendCorrEta_ = bendCorrEta; }
-    void setBendCorrPhi(float bendCorrPhi) { bendCorrPhi_ = bendCorrPhi; }
-
-    void print(std::ostream& out = std::cout) const;
-
-  private:
-    PiZeroAlgorithm algoName_;
-
-    float bendCorrEta_;
-    float bendCorrPhi_;
-  };
-
-  std::ostream& operator<<(std::ostream& out, const RecoTauPiZero& c);
-
+  }  // namespace io_v1
+  using RecoTauPiZero = io_v1::RecoTauPiZero;
 }  // namespace reco
 
 #endif

--- a/DataFormats/TauReco/interface/RecoTauPiZeroFwd.h
+++ b/DataFormats/TauReco/interface/RecoTauPiZeroFwd.h
@@ -6,7 +6,10 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 namespace reco {
-  class RecoTauPiZero;
+  namespace io_v1 {
+    class RecoTauPiZero;
+  }
+  using RecoTauPiZero = io_v1::RecoTauPiZero;
   /// collection of RecoTauPiZero objects
   typedef std::vector<RecoTauPiZero> RecoTauPiZeroCollection;
   /// presistent reference to a RecoTauPiZero

--- a/DataFormats/TauReco/src/RecoTauPiZero.cc
+++ b/DataFormats/TauReco/src/RecoTauPiZero.cc
@@ -3,91 +3,93 @@
 #include "DataFormats/Math/interface/deltaPhi.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  size_t RecoTauPiZero::numberOfGammas() const {
-    size_t nGammas = 0;
-    size_t nDaughters = numberOfDaughters();
-    for (size_t i = 0; i < nDaughters; ++i) {
-      if (daughter(i)->pdgId() == 22)
-        ++nGammas;
+    size_t RecoTauPiZero::numberOfGammas() const {
+      size_t nGammas = 0;
+      size_t nDaughters = numberOfDaughters();
+      for (size_t i = 0; i < nDaughters; ++i) {
+        if (daughter(i)->pdgId() == 22)
+          ++nGammas;
+      }
+      return nGammas;
     }
-    return nGammas;
-  }
 
-  size_t RecoTauPiZero::numberOfElectrons() const {
-    size_t nElectrons = 0;
-    size_t nDaughters = numberOfDaughters();
-    for (size_t i = 0; i < nDaughters; ++i) {
-      if (std::abs(daughter(i)->pdgId()) == 11)
-        ++nElectrons;
+    size_t RecoTauPiZero::numberOfElectrons() const {
+      size_t nElectrons = 0;
+      size_t nDaughters = numberOfDaughters();
+      for (size_t i = 0; i < nDaughters; ++i) {
+        if (std::abs(daughter(i)->pdgId()) == 11)
+          ++nElectrons;
+      }
+      return nElectrons;
     }
-    return nElectrons;
-  }
 
-  double RecoTauPiZero::maxDeltaPhi() const {
-    double maxDPhi = 0;
-    size_t nDaughters = numberOfDaughters();
-    for (size_t i = 0; i < nDaughters; ++i) {
-      double dPhi = std::fabs(deltaPhi(*this, *daughter(i)));
-      if (dPhi > maxDPhi)
-        maxDPhi = dPhi;
+    double RecoTauPiZero::maxDeltaPhi() const {
+      double maxDPhi = 0;
+      size_t nDaughters = numberOfDaughters();
+      for (size_t i = 0; i < nDaughters; ++i) {
+        double dPhi = std::fabs(deltaPhi(*this, *daughter(i)));
+        if (dPhi > maxDPhi)
+          maxDPhi = dPhi;
+      }
+      return maxDPhi;
     }
-    return maxDPhi;
-  }
 
-  double RecoTauPiZero::maxDeltaEta() const {
-    double maxDEta = 0;
-    size_t nDaughters = numberOfDaughters();
-    for (size_t i = 0; i < nDaughters; ++i) {
-      double dEta = std::fabs(eta() - daughter(i)->eta());
-      if (dEta > maxDEta)
-        maxDEta = dEta;
+    double RecoTauPiZero::maxDeltaEta() const {
+      double maxDEta = 0;
+      size_t nDaughters = numberOfDaughters();
+      for (size_t i = 0; i < nDaughters; ++i) {
+        double dEta = std::fabs(eta() - daughter(i)->eta());
+        if (dEta > maxDEta)
+          maxDEta = dEta;
+      }
+      return maxDEta;
     }
-    return maxDEta;
-  }
 
-  RecoTauPiZero::PiZeroAlgorithm RecoTauPiZero::algo() const { return algoName_; }
+    RecoTauPiZero::PiZeroAlgorithm RecoTauPiZero::algo() const { return algoName_; }
 
-  bool RecoTauPiZero::algoIs(RecoTauPiZero::PiZeroAlgorithm algo) const { return (algoName_ == algo); }
+    bool RecoTauPiZero::algoIs(RecoTauPiZero::PiZeroAlgorithm algo) const { return (algoName_ == algo); }
 
-  namespace {
-    std::string getPFCandidateType(reco::PFCandidate::ParticleType pfCandidateType) {
-      if (pfCandidateType == reco::PFCandidate::X)
-        return "undefined";
-      else if (pfCandidateType == reco::PFCandidate::h)
-        return "PFChargedHadron";
-      else if (pfCandidateType == reco::PFCandidate::e)
-        return "PFElectron";
-      else if (pfCandidateType == reco::PFCandidate::mu)
-        return "PFMuon";
-      else if (pfCandidateType == reco::PFCandidate::gamma)
-        return "PFGamma";
-      else if (pfCandidateType == reco::PFCandidate::h0)
-        return "PFNeutralHadron";
-      else if (pfCandidateType == reco::PFCandidate::h_HF)
-        return "HF_had";
-      else if (pfCandidateType == reco::PFCandidate::egamma_HF)
-        return "HF_em";
-      else
-        assert(0);
+    namespace {
+      std::string getPFCandidateType(reco::PFCandidate::ParticleType pfCandidateType) {
+        if (pfCandidateType == reco::PFCandidate::X)
+          return "undefined";
+        else if (pfCandidateType == reco::PFCandidate::h)
+          return "PFChargedHadron";
+        else if (pfCandidateType == reco::PFCandidate::e)
+          return "PFElectron";
+        else if (pfCandidateType == reco::PFCandidate::mu)
+          return "PFMuon";
+        else if (pfCandidateType == reco::PFCandidate::gamma)
+          return "PFGamma";
+        else if (pfCandidateType == reco::PFCandidate::h0)
+          return "PFNeutralHadron";
+        else if (pfCandidateType == reco::PFCandidate::h_HF)
+          return "HF_had";
+        else if (pfCandidateType == reco::PFCandidate::egamma_HF)
+          return "HF_em";
+        else
+          assert(0);
+      }
+    }  // namespace
+
+    void RecoTauPiZero::print(std::ostream& stream) const {
+      std::cout << "Pt = " << this->pt() << ", eta = " << this->eta() << ", phi = " << this->phi() << std::endl;
+      size_t numDaughters = this->numberOfDaughters();
+      for (size_t iDaughter = 0; iDaughter < numDaughters; ++iDaughter) {
+        const reco::PFCandidate* daughter = dynamic_cast<const reco::PFCandidate*>(this->daughterPtr(iDaughter).get());
+        std::cout << " daughter #" << iDaughter << " (" << getPFCandidateType(daughter->particleId()) << "):"
+                  << " Pt = " << daughter->pt() << ", eta = " << daughter->eta() << ", phi = " << daughter->phi()
+                  << std::endl;
+      }
     }
-  }  // namespace
 
-  void RecoTauPiZero::print(std::ostream& stream) const {
-    std::cout << "Pt = " << this->pt() << ", eta = " << this->eta() << ", phi = " << this->phi() << std::endl;
-    size_t numDaughters = this->numberOfDaughters();
-    for (size_t iDaughter = 0; iDaughter < numDaughters; ++iDaughter) {
-      const reco::PFCandidate* daughter = dynamic_cast<const reco::PFCandidate*>(this->daughterPtr(iDaughter).get());
-      std::cout << " daughter #" << iDaughter << " (" << getPFCandidateType(daughter->particleId()) << "):"
-                << " Pt = " << daughter->pt() << ", eta = " << daughter->eta() << ", phi = " << daughter->phi()
-                << std::endl;
-    }
-  }
-
-  std::ostream& operator<<(std::ostream& out, const reco::RecoTauPiZero& piZero) {
-    if (!out)
+    std::ostream& operator<<(std::ostream& out, const reco::RecoTauPiZero& piZero) {
+      if (!out)
+        return out;
+      piZero.print(out);
       return out;
-    piZero.print(out);
-    return out;
-  }
+    }
+  }  // namespace io_v1
 }  // namespace reco

--- a/DataFormats/TauReco/src/classes_def_1.xml
+++ b/DataFormats/TauReco/src/classes_def_1.xml
@@ -19,99 +19,23 @@
   <class name="edm::RefVector<std::vector<reco::BaseTauTagInfo>,reco::BaseTauTagInfo,edm::refhelper::FindUsingAdvance<std::vector<reco::BaseTauTagInfo>,reco::BaseTauTagInfo> >"/>
   
   <class name="reco::PFTauTagInfo" ClassVersion="3">
-   <version ClassVersion="3" checksum="1535484060"/>
+   <version ClassVersion="3" checksum="285981860"/>
   </class>
   <class name="std::vector<reco::PFTauTagInfo>"/>
   <class name="edm::Wrapper<std::vector<reco::PFTauTagInfo> >"/>
   <class name="edm::Ref<std::vector<reco::PFTauTagInfo>,reco::PFTauTagInfo,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTagInfo>,reco::PFTauTagInfo> >"/>
   <class name="edm::RefProd<std::vector<reco::PFTauTagInfo> >"/>
   <class name="edm::RefVector<std::vector<reco::PFTauTagInfo>,reco::PFTauTagInfo,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTagInfo>,reco::PFTauTagInfo> >"/>
-
-<!-- Adding ioread rules for backwards compatibility -->
-
-<ioread sourceClass="reco::PFTauTagInfo" version="[-12]" 
-  source="edm::Ref<vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<vector<reco::PFJet>,reco::PFJet> > PFJetRef_;" 
-  targetClass="reco::PFTauTagInfo" target="PFJetRef_" include="DataFormats/JetReco/interface/PFJet.h">
-    <![CDATA[PFJetRef_ = reco::JetBaseRef(onfile.PFJetRef_);]]>
-  </ioread>
-
-<ioread sourceClass="reco::PFTauTagInfo" version="[11-12]" 
-  source="std::vector<edm::Ptr<reco::PFCandidate> > PFChargedHadrCands_;" 
-  targetClass="reco::PFTauTagInfo" target="PFChargedHadrCands_">
-    <![CDATA[
-    PFChargedHadrCands_.reserve(onfile.PFChargedHadrCands_.size());
-    for (const auto& cand : onfile.PFChargedHadrCands_)
-      PFChargedHadrCands_.push_back(edm::Ptr<reco::Candidate>(cand));]]>
-  </ioread>
-
-<ioread sourceClass="reco::PFTauTagInfo" version="[11-12]" 
-  source="std::vector<edm::Ptr<reco::PFCandidate> > PFNeutrHadrCands_;" 
-  targetClass="reco::PFTauTagInfo" target="PFNeutrHadrCands_">
-    <![CDATA[
-    PFNeutrHadrCands_.reserve(onfile.PFNeutrHadrCands_.size());
-    for (const auto& cand : onfile.PFNeutrHadrCands_)
-      PFNeutrHadrCands_.push_back(edm::Ptr<reco::Candidate>(cand));]]>
-  </ioread>
-
-<ioread sourceClass="reco::PFTauTagInfo" version="[11-12]" 
-  source="std::vector<edm::Ptr<reco::PFCandidate> > PFGammaCands_;" 
-  targetClass="reco::PFTauTagInfo" target="PFGammaCands_">
-    <![CDATA[
-    PFGammaCands_.reserve(onfile.PFGammaCands_.size());
-    for (const auto& cand : onfile.PFGammaCands_)
-      PFGammaCands_.push_back(edm::Ptr<reco::Candidate>(cand));]]>
-  </ioread>
-
-<ioread sourceClass="reco::PFTauTagInfo" version="[-10]"
-source="reco::PFCandidateRefVector PFChargedHadrCands_;"
- targetClass="reco::PFTauTagInfo"
-target="PFChargedHadrCands_"
-include="DataFormats/Common/interface/RefToPtr.h">
-    <![CDATA[
-   PFChargedHadrCands_.reserve(onfile.PFChargedHadrCands_.size());
-for(auto const& ref : onfile.PFChargedHadrCands_) { 
-   PFChargedHadrCands_.push_back(edm::refToPtr(ref));
-}
-]]>
-</ioread>
-
-<ioread sourceClass="reco::PFTauTagInfo" version="[-10]"
-source="reco::PFCandidateRefVector PFNeutrHadrCands_;"
- targetClass="reco::PFTauTagInfo"
-target="PFNeutrHadrCands_"
-include="DataFormats/Common/interface/RefToPtr.h">
-    <![CDATA[
-   PFNeutrHadrCands_.reserve(onfile.PFNeutrHadrCands_.size());
-for(auto const& ref : onfile.PFNeutrHadrCands_) { 
-   PFNeutrHadrCands_.push_back(edm::refToPtr(ref));
-}
-]]>
-</ioread>
-
-<ioread sourceClass="reco::PFTauTagInfo" version="[-10]"
-source="reco::PFCandidateRefVector PFGammaCands_;"
- targetClass="reco::PFTauTagInfo"
-target="PFGammaCands_"
-include="DataFormats/Common/interface/RefToPtr.h">
-    <![CDATA[
-   PFGammaCands_.reserve(onfile.PFGammaCands_.size());
-for(auto const& ref : onfile.PFGammaCands_) { 
-   PFGammaCands_.push_back(edm::refToPtr(ref));
-}
-]]>
-</ioread>
-
-
   
   <class name="reco::BaseTau" ClassVersion="3">
-   <version ClassVersion="3" checksum="1151169052"/>
+   <version ClassVersion="3" checksum="2297856736"/>
   </class>
   <class name="std::vector<reco::BaseTau>"/>
   <class name="edm::Wrapper<std::vector<reco::BaseTau> >"/>
   <class name="edm::Ref<std::vector<reco::BaseTau>,reco::BaseTau,edm::refhelper::FindUsingAdvance<std::vector<reco::BaseTau>,reco::BaseTau> >"/>
   <class name="edm::RefProd<std::vector<reco::BaseTau> >"/>
   <class name="edm::RefVector<std::vector<reco::BaseTau>,reco::BaseTau,edm::refhelper::FindUsingAdvance<std::vector<reco::BaseTau>,reco::BaseTau> >"/>
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::BaseTau>,reco::BaseTau,edm::refhelper::FindUsingAdvance<std::vector<reco::BaseTau>,reco::BaseTau> > >" />
+  <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<reco::BaseTau>,reco::BaseTau,edm::refhelper::FindUsingAdvance<std::vector<reco::BaseTau>,reco::BaseTau> > >" />
   
 
 </lcgdict>

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -1,7 +1,7 @@
 <lcgdict>
   
-  <class name="reco::PFTau" ClassVersion="3">
-   <version ClassVersion="3" checksum="3358760451"/>
+  <class name="reco::io_v1::PFTau" ClassVersion="3">
+   <version ClassVersion="3" checksum="3700826437"/>
      <field name="leadPFChargedHadrCand_" transient="true"/>
      <field name="leadPFNeutralCand_" transient="true"/>
      <field name="leadPFCand_" transient="true"/>
@@ -19,26 +19,28 @@
      <field name="isolationTauChargedHadronCandidates_" transient="true"/>
   </class>
 
-  <class name="std::vector<reco::PFTau>"/>
-  <class name="edm::Wrapper<std::vector<reco::PFTau> >"/>
-  <class name="edm::Ref<std::vector<reco::PFTau>,reco::PFTau,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTau>,reco::PFTau> >"/>
-  <class name="edm::RefProd<std::vector<reco::PFTau> >"/>
-  <class name="edm::RefVector<std::vector<reco::PFTau>,reco::PFTau,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTau>,reco::PFTau> >"/>
-          <class name="edm::Wrapper<edm::RefVector<std::vector<reco::PFTau>,reco::PFTau,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTau>,reco::PFTau> > >"/>
-  <class name="edm::reftobase::Holder<reco::BaseTau, edm::Ref<std::vector<reco::PFTau>,reco::PFTau,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTau>,reco::PFTau> > >" />
+  <class name="std::vector<reco::io_v1::PFTau>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::PFTau> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::PFTau>,reco::io_v1::PFTau,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFTau>,reco::io_v1::PFTau> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::PFTau> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::PFTau>,reco::io_v1::PFTau,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFTau>,reco::io_v1::PFTau> >"/>
+          <class name="edm::Wrapper<edm::RefVector<std::vector<reco::io_v1::PFTau>,reco::io_v1::PFTau,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFTau>,reco::io_v1::PFTau> > >"/>
+  <class name="edm::reftobase::Holder<reco::BaseTau, edm::Ref<std::vector<reco::io_v1::PFTau>,reco::io_v1::PFTau,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFTau>,reco::io_v1::PFTau> > >" />
+  <class name="std::vector<edm::Ref<std::vector<reco::io_v1::PFTau>,reco::io_v1::PFTau,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFTau>,reco::io_v1::PFTau> > >"/>
 
-  <class name="edm::RefToBaseProd<reco::PFTau>" >
+
+  <class name="edm::RefToBaseProd<reco::io_v1::PFTau>" >
      <!-- <field name="view_" transient="true" /> -->
   </class>
-  <class name="edm::reftobase::BaseHolder<reco::PFTau>" />
-  <class name="edm::reftobase::IndirectHolder<reco::PFTau>" />
-  <class name="edm::reftobase::BaseVectorHolder<reco::PFTau>"/>
-  <class name="edm::reftobase::Holder<reco::PFTau, reco::PFTauRef>" />
+  <class name="edm::reftobase::BaseHolder<reco::io_v1::PFTau>" />
+  <class name="edm::reftobase::IndirectHolder<reco::io_v1::PFTau>" />
+  <class name="edm::reftobase::BaseVectorHolder<reco::io_v1::PFTau>"/>
+  <class name="edm::reftobase::Holder<reco::io_v1::PFTau, reco::PFTauRef>" />
   <class name="edm::reftobase::RefHolder<reco::PFTauRef>" />
 
 
-<ioread sourceClass = "reco::PFTau" version="[1-]"
- targetClass="reco::PFTau"
+<ioread sourceClass = "reco::io_v1::PFTau" version="[1-]"
+ targetClass="reco::io_v1::PFTau"
 source = ""
 target="leadPFChargedHadrCand_,leadPFNeutralCand_,leadPFCand_,selectedTransientSignalPFCands_,selectedTransientSignalPFChargedHadrCands_,selectedTransientSignalPFNeutrHadrCands_,selectedTransientSignalPFGammaCands_,selectedTransientIsolationPFCands_,selectedTransientIsolationPFChargedHadrCands_,selectedTransientIsolationPFNeutrHadrCands_,selectedTransientIsolationPFGammaCands_">
 <![CDATA[
@@ -57,8 +59,8 @@ selectedTransientIsolationPFGammaCands_.reset();
 </ioread>
 
 
-<ioread sourceClass = "reco::PFTau" version="[1-]" 
- targetClass="reco::PFTau" 
+<ioread sourceClass = "reco::io_v1::PFTau" version="[1-]" 
+ targetClass="reco::io_v1::PFTau" 
 source = "" 
 target="signalPiZeroCandidates_">
 <![CDATA[
@@ -66,8 +68,8 @@ signalPiZeroCandidates_.reset();
 ]]>
 </ioread>
               
-<ioread sourceClass = "reco::PFTau" version="[1-]" 
- targetClass="reco::PFTau" 
+<ioread sourceClass = "reco::io_v1::PFTau" version="[1-]" 
+ targetClass="reco::io_v1::PFTau" 
 source = "" 
 target="isolationPiZeroCandidates_">
 <![CDATA[
@@ -76,16 +78,16 @@ isolationPiZeroCandidates_.reset();
 </ioread>
 
 
-<ioread sourceClass = "reco::PFTau" version="[1-]"
- targetClass="reco::PFTau" 
+<ioread sourceClass = "reco::io_v1::PFTau" version="[1-]"
+ targetClass="reco::io_v1::PFTau" 
 source = "" 
 target="signalTauChargedHadronCandidates_">
 <![CDATA[signalTauChargedHadronCandidates_.reset();
 ]]>                                    
 </ioread>
                                       
-<ioread sourceClass = "reco::PFTau" version="[1-]"
- targetClass="reco::PFTau" 
+<ioread sourceClass = "reco::io_v1::PFTau" version="[1-]"
+ targetClass="reco::io_v1::PFTau" 
 source = "" 
 target="isolationTauChargedHadronCandidates_">                                          
 <![CDATA[
@@ -96,42 +98,34 @@ isolationTauChargedHadronCandidates_.reset();
 
 
 
-  <class name="reco::PFTauDecayMode" ClassVersion="13">
-   <version ClassVersion="13" checksum="3507751092"/>
-   <version ClassVersion="12" checksum="2043565930"/>
-   <version ClassVersion="11" checksum="3414615810"/>
-   <version ClassVersion="10" checksum="2108215737"/>
+  <class name="reco::PFTauDecayMode" ClassVersion="3">
+   <version ClassVersion="3" checksum="3878283080"/>
   </class>
   <class name="std::vector<reco::PFTauDecayMode>"/>
   <class name="edm::Wrapper<std::vector<reco::PFTauDecayMode> >"/>
   <class name="edm::Ref<std::vector<reco::PFTauDecayMode>,reco::PFTauDecayMode,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauDecayMode>,reco::PFTauDecayMode> >"/>
   <class name="edm::RefProd<std::vector<reco::PFTauDecayMode> >"/>
   <class name="edm::RefVector<std::vector<reco::PFTauDecayMode>,reco::PFTauDecayMode,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauDecayMode>,reco::PFTauDecayMode> >"/>
-  <class name="edm::reftobase::Holder<reco::CompositeCandidate, edm::Ref<std::vector<reco::PFTauDecayMode>,reco::PFTauDecayMode,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauDecayMode>,reco::PFTauDecayMode> > >" />
+  <class name="edm::reftobase::Holder<reco::io_v1::CompositeCandidate, edm::Ref<std::vector<reco::PFTauDecayMode>,reco::PFTauDecayMode,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauDecayMode>,reco::PFTauDecayMode> > >" />
   <class name="edm::Association<std::vector<reco::PFTauDecayMode> >"/>
-  <class name="edm::Association<std::vector<reco::PFTau> >"/>
+  <class name="edm::Association<std::vector<reco::io_v1::PFTau> >"/>
   <class name="edm::Wrapper<edm::Association<std::vector<reco::PFTauDecayMode> > >"/>
-  <class name="edm::Wrapper<edm::Association<std::vector<reco::PFTau> > >"/>
+  <class name="edm::Wrapper<edm::Association<std::vector<reco::io_v1::PFTau> > >"/>
 
-  <class name="reco::RecoTauPiZero" ClassVersion="14">
-   <version ClassVersion="15" checksum="4070597512"/>
-   <version ClassVersion="14" checksum="3535311745"/>
-   <version ClassVersion="13" checksum="3687187514"/>
-   <version ClassVersion="12" checksum="453348937"/>
-   <version ClassVersion="11" checksum="2458276705"/>
-   <version ClassVersion="10" checksum="465425628"/>
+  <class name="reco::io_v1::RecoTauPiZero" ClassVersion="3">
+   <version ClassVersion="3" checksum="444545959"/>
   </class>
-  <class name="std::vector<reco::RecoTauPiZero>"/>
-  <class name="edm::AtomicPtrCache<std::vector<reco::RecoTauPiZero> >"/>
-     <class name="std::vector<std::vector<reco::RecoTauPiZero> >"/>
-  <class name="edm::Wrapper<std::vector<reco::RecoTauPiZero> >"/>
-  <class name="edm::Ref<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero> >"/>
-  <class name="edm::RefProd<std::vector<reco::RecoTauPiZero> >"/>
-  <class name="edm::RefVector<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero> >"/>
-  <class name="edm::reftobase::Holder<reco::CompositePtrCandidate, edm::Ref<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero> > >" />
+  <class name="std::vector<reco::io_v1::RecoTauPiZero>"/>
+  <class name="edm::AtomicPtrCache<std::vector<reco::io_v1::RecoTauPiZero> >"/>
+     <class name="std::vector<std::vector<reco::io_v1::RecoTauPiZero> >"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::RecoTauPiZero> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::RecoTauPiZero>,reco::io_v1::RecoTauPiZero,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoTauPiZero>,reco::io_v1::RecoTauPiZero> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::RecoTauPiZero> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::RecoTauPiZero>,reco::io_v1::RecoTauPiZero,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoTauPiZero>,reco::io_v1::RecoTauPiZero> >"/>
+  <class name="edm::reftobase::Holder<reco::CompositePtrCandidate, edm::Ref<std::vector<reco::io_v1::RecoTauPiZero>,reco::io_v1::RecoTauPiZero,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoTauPiZero>,reco::io_v1::RecoTauPiZero> > >" />
 
   <class name="reco::PFRecoTauChargedHadron" ClassVersion="3">
-   <version ClassVersion="3" checksum="2202387059"/>
+   <version ClassVersion="3" checksum="98882705"/>
   </class>
   <class name="std::vector<reco::PFRecoTauChargedHadron>"/>
   <class name="edm::AtomicPtrCache<std::vector<reco::PFRecoTauChargedHadron> >"/>

--- a/DataFormats/TauReco/src/classes_def_3.xml
+++ b/DataFormats/TauReco/src/classes_def_3.xml
@@ -3,9 +3,8 @@
   <class name="reco::PFTauDiscriminatorByIsolationBase">
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="reco::PFTauDiscriminatorByIsolation" ClassVersion="11">
-   <version ClassVersion="10" checksum="1187112623"/>
-   <version ClassVersion="11" checksum="443644863"/>
+  <class name="reco::PFTauDiscriminatorByIsolation" ClassVersion="3">
+   <version ClassVersion="3" checksum="1555020723"/>
     <!-- <field name="transientVector_" transient="true"/> -->
   </class>
   <class name="reco::PFTauDiscriminatorByIsolationRef"/>
@@ -23,15 +22,14 @@
     <field name="transientVector_" transient="true"/>
   </class>
 
-  <class name="reco::PFTauDiscriminator" ClassVersion="11">
-   <version ClassVersion="10" checksum="4019319043"/>
-   <version ClassVersion="11" checksum="3738212815"/>
+  <class name="reco::io_v1::PFTauDiscriminator" ClassVersion="3">
+   <version ClassVersion="3" checksum="2313516099"/>
     <!-- <field name="transientVector_" transient="true"/> -->
   </class>
   <class name="reco::PFTauDiscriminatorRef"/>
   <class name="reco::PFTauDiscriminatorRefProd"/>
   <class name="reco::PFTauDiscriminatorRefVector"/>
-  <class name="edm::Wrapper<reco::PFTauDiscriminator>"/>
+  <class name="edm::Wrapper<reco::io_v1::PFTauDiscriminator>"/>
 
   <class name="reco::SingleTauDiscriminatorContainer" ClassVersion="3">
     <version ClassVersion="3" checksum="2968610760"/>
@@ -44,10 +42,8 @@
     <field name="transientVector_" transient="true"/>
   </class>
 
-  <class name="reco::JetPiZeroAssociation" ClassVersion="12">
-   <version ClassVersion="10" checksum="3488813045"/>
-   <version ClassVersion="11" checksum="2107652063"/>
-   <version ClassVersion="12" checksum="2981210128"/>
+  <class name="reco::JetPiZeroAssociation" ClassVersion="3">
+   <version ClassVersion="3" checksum="92158174"/>
     <field name="transientVector_" transient="true"/>
   </class>
   <class name="reco::JetPiZeroAssociationRef"/>
@@ -55,20 +51,18 @@
   <class name="reco::JetPiZeroAssociationRefVector"/>
   <class name="edm::Wrapper<reco::JetPiZeroAssociation>"/>
 
-  <class name="std::pair<reco::PFJetRef, std::vector<reco::RecoTauPiZero> >"/>
-  <class name="std::vector<std::pair<reco::PFJetRef, std::vector<reco::RecoTauPiZero> > >" />
+  <class name="std::pair<reco::PFJetRef, std::vector<reco::io_v1::RecoTauPiZero> >"/>
+  <class name="std::vector<std::pair<reco::PFJetRef, std::vector<reco::io_v1::RecoTauPiZero> > >" />
 
-  <class name="std::pair<reco::JetBaseRef, std::vector<reco::RecoTauPiZero> >"/>
-  <class name="std::vector<std::pair<reco::JetBaseRef, std::vector<reco::RecoTauPiZero> > >" />
+  <class name="std::pair<reco::JetBaseRef, std::vector<reco::io_v1::RecoTauPiZero> >"/>
+  <class name="std::vector<std::pair<reco::JetBaseRef, std::vector<reco::io_v1::RecoTauPiZero> > >" />
 
   <class name="reco::PFJetChargedHadronAssociationBase">
     <field name="transientVector_" transient="true"/>
   </class>
 
-  <class name="reco::PFJetChargedHadronAssociation" ClassVersion="12">
-   <version ClassVersion="10" checksum="3498827707"/>
-   <version ClassVersion="11" checksum="269001295"/>
-   <version ClassVersion="12" checksum="1002363278"/>
+  <class name="reco::PFJetChargedHadronAssociation" ClassVersion="3">
+   <version ClassVersion="3" checksum="2811520304"/>
     <field name="transientVector_" transient="true"/>
   </class>
   <class name="reco::PFJetChargedHadronAssociationRef"/>
@@ -93,18 +87,18 @@
   <class name="std::pair<reco::PFTauRef, reco::PFTauDecayMode>"/>
   <class name="std::vector<std::pair<reco::PFTauRef, reco::PFTauDecayMode> >" />
 
-  <class name="reco::PFTauTransverseImpactParameter" ClassVersion="2">
-   <version ClassVersion="2" checksum="2154806108"/>
+  <class name="reco::io_v1::PFTauTransverseImpactParameter" ClassVersion="3">
+   <version ClassVersion="3" checksum="3979630662"/>
   </class>
 
-  <class name="std::vector<reco::PFTauTransverseImpactParameter>"/>
-  <class name="edm::Wrapper<std::vector<reco::PFTauTransverseImpactParameter> >"/>
-  <class name="edm::Ref<std::vector<reco::PFTauTransverseImpactParameter>,reco::PFTauTransverseImpactParameter,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTransverseImpactParameter>,reco::PFTauTransverseImpactParameter> >"/>
-  <class name="edm::RefProd<std::vector<reco::PFTauTransverseImpactParameter> >"/>
-  <class name="edm::RefVector<std::vector<reco::PFTauTransverseImpactParameter>,reco::PFTauTransverseImpactParameter,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTransverseImpactParameter>,reco::PFTauTransverseImpactParameter> >"/>
-  <class name="edm::reftobase::Holder<reco::PFTauTransverseImpactParameter, edm::Ref<std::vector<reco::PFTauTransverseImpactParameter>,reco::PFTauTransverseImpactParameter,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTransverseImpactParameter>,reco::PFTauTransverseImpactParameter> > >" />
-  <class name="edm::Association<std::vector<reco::PFTauTransverseImpactParameter> >"/>
-  <class name="edm::Wrapper<edm::Association<std::vector<reco::PFTauTransverseImpactParameter> > >"/>
+  <class name="std::vector<reco::io_v1::PFTauTransverseImpactParameter>"/>
+  <class name="edm::Wrapper<std::vector<reco::io_v1::PFTauTransverseImpactParameter> >"/>
+  <class name="edm::Ref<std::vector<reco::io_v1::PFTauTransverseImpactParameter>,reco::io_v1::PFTauTransverseImpactParameter,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFTauTransverseImpactParameter>,reco::io_v1::PFTauTransverseImpactParameter> >"/>
+  <class name="edm::RefProd<std::vector<reco::io_v1::PFTauTransverseImpactParameter> >"/>
+  <class name="edm::RefVector<std::vector<reco::io_v1::PFTauTransverseImpactParameter>,reco::io_v1::PFTauTransverseImpactParameter,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFTauTransverseImpactParameter>,reco::io_v1::PFTauTransverseImpactParameter> >"/>
+  <class name="edm::reftobase::Holder<reco::io_v1::PFTauTransverseImpactParameter, edm::Ref<std::vector<reco::io_v1::PFTauTransverseImpactParameter>,reco::io_v1::PFTauTransverseImpactParameter,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PFTauTransverseImpactParameter>,reco::io_v1::PFTauTransverseImpactParameter> > >" />
+  <class name="edm::Association<std::vector<reco::io_v1::PFTauTransverseImpactParameter> >"/>
+  <class name="edm::Wrapper<edm::Association<std::vector<reco::io_v1::PFTauTransverseImpactParameter> > >"/>
 
   <class name="std::vector<reco::PFTauTransverseImpactParameterCollection>"/>
   <class name="edm::Wrapper<std::vector<reco::PFTauTransverseImpactParameterCollection> >"/>

--- a/DataFormats/TauReco/src/classes_def_hlt.xml
+++ b/DataFormats/TauReco/src/classes_def_hlt.xml
@@ -13,13 +13,13 @@
   <class name="edm::Ptr<reco::BaseTau>" />
   <class name="edm::PtrVector<reco::BaseTau>" />
 
-  <class name="edm::Ptr<reco::PFTau>" />
-  <class name="std::vector<edm::Ptr<reco::PFTau> >" />
-  <class name="edm::Wrapper<std::vector<edm::Ptr<reco::PFTau> > >" />
+  <class name="edm::Ptr<reco::io_v1::PFTau>" />
+  <class name="std::vector<edm::Ptr<reco::io_v1::PFTau> >" />
+  <class name="edm::Wrapper<std::vector<edm::Ptr<reco::io_v1::PFTau> > >" />
 
-  <class name="edm::FwdPtr<reco::PFTau>" />
-  <class name="std::vector<edm::FwdPtr<reco::PFTau> >" />
-  <class name="edm::Wrapper<std::vector<edm::FwdPtr<reco::PFTau> > >" />
+  <class name="edm::FwdPtr<reco::io_v1::PFTau>" />
+  <class name="std::vector<edm::FwdPtr<reco::io_v1::PFTau> >" />
+  <class name="edm::Wrapper<std::vector<edm::FwdPtr<reco::io_v1::PFTau> > >" />
 
   <class name="edm::FwdPtr<reco::BaseTau>" />
   <class name="std::vector<edm::FwdPtr<reco::BaseTau> >" />

--- a/DataFormats/TrackReco/interface/DeDxData.h
+++ b/DataFormats/TrackReco/interface/DeDxData.h
@@ -4,28 +4,32 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  class DeDxData {
-  public:
-    DeDxData();
-    DeDxData(float val, int nsat, unsigned int num);
-    DeDxData(float val, float er, int sat, unsigned int num);
-    virtual ~DeDxData();
-    float dEdx() const;
-    float dEdxError() const;
-    int numberOfSaturatedMeasurements() const;
-    unsigned int numberOfMeasurements() const;
+    class DeDxData {
+    public:
+      DeDxData();
+      DeDxData(float val, int nsat, unsigned int num);
+      DeDxData(float val, float er, int sat, unsigned int num);
+      virtual ~DeDxData();
+      float dEdx() const;
+      float dEdxError() const;
+      int numberOfSaturatedMeasurements() const;
+      unsigned int numberOfMeasurements() const;
 
-  private:
-    float value_;
-    float error_;
-    unsigned int numberOfMeasurements_;
-    int numberOfSatMeasurements_;
-  };
+    private:
+      float value_;
+      float error_;
+      unsigned int numberOfMeasurements_;
+      int numberOfSatMeasurements_;
+    };
+
+  }  // namespace io_v1
+  using DeDxData = io_v1::DeDxData;
 
   //Association Track -> float estimator
-  typedef std::vector<reco::DeDxData> DeDxDataCollection;
-  typedef edm::ValueMap<reco::DeDxData> DeDxDataValueMap;
+  typedef std::vector<DeDxData> DeDxDataCollection;
+  typedef edm::ValueMap<DeDxData> DeDxDataValueMap;
 
   // //Association Track -> float estimator
   //typedef  edm::AssociationVector<reco::TrackRefProd,std::vector<DeDxData> >  DeDxDataCollection;

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -416,9 +416,8 @@
   </class>
   <class name="std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,std::vector<reco::DeDxHit> >" />
      <!--   <class name="reco::DeDxDataCollection"/> -->
-     <class name="reco::DeDxData" ClassVersion="11">
-      <version ClassVersion="11" checksum="30657010"/>
-      <version ClassVersion="10" checksum="204721063"/>
+     <class name="reco::io_v1::DeDxData" ClassVersion="3">
+      <version ClassVersion="3" checksum="3791549648"/>
      </class>
      <class name="reco::DeDxDataCollection"/>
      <class name="reco::DeDxDataValueMap"/>
@@ -484,23 +483,21 @@
     <class name="edm::Association<std::vector<reco::io_v1::TrackExtra>>"/>
     <class name="edm::Wrapper<edm::Association<std::vector<reco::io_v1::TrackExtra>>>"/>
 
-   <class name="reco::DeDxHitInfo::DeDxHitInfoContainer" ClassVersion="3">
-    <version ClassVersion="2" checksum="3964047764"/>
-    <version ClassVersion="3" checksum="4148946944"/>
+   <class name="reco::io_v1::DeDxHitInfo::DeDxHitInfoContainer" ClassVersion="3">
+    <version ClassVersion="3" checksum="3147335498"/>
    </class>
-   <class name="reco::DeDxHitInfo::DeDxHitInfoContainerCollection"/>
+   <class name="reco::io_v1::DeDxHitInfo::DeDxHitInfoContainerCollection"/>
 
 
-   <class name="reco::DeDxHitInfo" ClassVersion="3">
-    <version ClassVersion="3" checksum="2577777556"/>
-    <version ClassVersion="2" checksum="3000986250"/>
+   <class name="reco::io_v1::DeDxHitInfo" ClassVersion="3">
+    <version ClassVersion="3" checksum="4266756504"/>
    </class>
    <class name="reco::DeDxHitInfoCollection"/>
    <class name="reco::DeDxHitInfoRef"/>
    <class name="reco::DeDxHitInfoRefProd"/>
    <class name="reco::DeDxHitInfoRefVector"/>
    <class name="reco::DeDxHitInfoAss"/>
-   <class name="edm::Wrapper<reco::DeDxHitInfo>"/>
+   <class name="edm::Wrapper<reco::io_v1::DeDxHitInfo>"/>
    <class name="edm::Wrapper<reco::DeDxHitInfoCollection>"/>
    <class name="edm::Wrapper<reco::DeDxHitInfoAss>"/>
 

--- a/DataFormats/V0Candidate/src/classes_def.xml
+++ b/DataFormats/V0Candidate/src/classes_def.xml
@@ -1,9 +1,7 @@
 <lcgdict>
 <selection>
-  <class name="reco::V0Candidate" ClassVersion="12">
-   <version ClassVersion="12" checksum="3594667806"/>
-   <version ClassVersion="11" checksum="3236778854"/>
-   <version ClassVersion="10" checksum="1361748283"/>
+  <class name="reco::V0Candidate" ClassVersion="3">
+   <version ClassVersion="3" checksum="717642420"/>
   </class>
   <class name="std::vector<reco::V0Candidate>" />
   <class name="edm::Wrapper<std::vector<reco::V0Candidate> >" />

--- a/DataFormats/VertexReco/interface/Vertex.h
+++ b/DataFormats/VertexReco/interface/Vertex.h
@@ -29,211 +29,214 @@
 #include "DataFormats/Math/interface/LorentzVector.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  class Vertex {
-  public:
-    /// The iteratator for the vector<TrackRef>
-    typedef std::vector<TrackBaseRef>::const_iterator trackRef_iterator;
-    /// point in the space
-    typedef math::XYZPoint Point;
-    /// error matrix dimension
-    constexpr static int dimension = 3;
-    constexpr static int dimension4D = 4;
-    /// covariance error matrix (3x3)
-    typedef math::Error<dimension>::type Error;
-    /// covariance error matrix (3x3)
-    typedef math::Error<dimension>::type CovarianceMatrix;
-    /// covariance error matrix (4x4)
-    typedef math::Error<dimension4D>::type Error4D;
-    /// covariance error matrix (4x4)
-    typedef math::Error<dimension4D>::type CovarianceMatrix4D;
-    /// matix size
-    constexpr static int size = dimension * (dimension + 1) / 2, size4D = (dimension4D) * (dimension4D + 1) / 2;
-    /// index type
-    typedef unsigned int index;
-    /// default constructor - The vertex will not be valid. Position, error,
-    /// chi2, ndof will have random entries, and the vectors of tracks will be empty
-    /// Use the isValid method to check that your vertex is valid.
-    Vertex() : chi2_(0.0), ndof_(0), position_(0., 0., 0.), time_(0.) {
-      validity_ = false;
-      for (int i = 0; i < size4D; ++i)
-        covariance_[i] = 0.;
-    }
-    /// Constructor for a fake vertex.
-    Vertex(const Point &, const Error &);
-    /// Constructor for a fake vertex. 4D
-    Vertex(const Point &, const Error4D &, double);
-    /// constructor for a valid vertex, with all data
-    Vertex(const Point &, const Error &, double chi2, double ndof, size_t size);
-    /// constructor for a valid vertex, with all data 4D
-    Vertex(const Point &, const Error4D &, double time, double chi2, double ndof, size_t size);
-    /// Tells whether the vertex is valid.
-    bool isValid() const { return validity_; }
-    /// Tells whether a Vertex is fake, i.e. not a vertex made out of a proper
-    /// fit with tracks.
-    /// For a primary vertex, it could simply be the beam line.
-    bool isFake() const { return (chi2_ == 0 && ndof_ == 0 && tracks_.empty()); }
-    /// reserve space for the tracks
-    void reserve(int size, bool refitAsWell = false) {
-      tracks_.reserve(size);
-      if (refitAsWell)
-        refittedTracks_.reserve(size);
-      weights_.reserve(size);
-    }
-    /// add a reference to a Track
-    template <typename Ref>
-    void add(Ref const &r, float w = 1.0) {
-      tracks_.emplace_back(r);
-      weights_.emplace_back(w * 255.f);
-    }
-    /// add the original a Track(reference) and the smoothed Track
-    void add(const TrackBaseRef &r, const Track &refTrack, float w = 1.0);
-    void removeTracks();
-
-    ///returns the weight with which a Track has contributed to the vertex-fit.
-    template <typename TREF>
-    float trackWeight(const TREF &r) const {
-      int i = 0;
-      for (auto const &t : tracks_) {
-        if ((r.id() == t.id()) && (t.key() == r.key()))
-          return weights_[i] / 255.f;
-        ++i;
+    class Vertex {
+    public:
+      /// The iteratator for the vector<TrackRef>
+      typedef std::vector<TrackBaseRef>::const_iterator trackRef_iterator;
+      /// point in the space
+      typedef math::XYZPoint Point;
+      /// error matrix dimension
+      constexpr static int dimension = 3;
+      constexpr static int dimension4D = 4;
+      /// covariance error matrix (3x3)
+      typedef math::Error<dimension>::type Error;
+      /// covariance error matrix (3x3)
+      typedef math::Error<dimension>::type CovarianceMatrix;
+      /// covariance error matrix (4x4)
+      typedef math::Error<dimension4D>::type Error4D;
+      /// covariance error matrix (4x4)
+      typedef math::Error<dimension4D>::type CovarianceMatrix4D;
+      /// matix size
+      constexpr static int size = dimension * (dimension + 1) / 2, size4D = (dimension4D) * (dimension4D + 1) / 2;
+      /// index type
+      typedef unsigned int index;
+      /// default constructor - The vertex will not be valid. Position, error,
+      /// chi2, ndof will have random entries, and the vectors of tracks will be empty
+      /// Use the isValid method to check that your vertex is valid.
+      Vertex() : chi2_(0.0), ndof_(0), position_(0., 0., 0.), time_(0.) {
+        validity_ = false;
+        for (int i = 0; i < size4D; ++i)
+          covariance_[i] = 0.;
       }
-      return 0;
-    }
-    // track collections
-    auto const &tracks() const { return tracks_; }
-    /// first iterator over tracks
-    trackRef_iterator tracks_begin() const { return tracks_.begin(); }
-    /// last iterator over tracks
-    trackRef_iterator tracks_end() const { return tracks_.end(); }
-    /// number of tracks
-    size_t tracksSize() const { return tracks_.size(); }
-    /// python friendly track getting
-    const TrackBaseRef &trackRefAt(size_t idx) const { return tracks_[idx]; }
-    /// chi-squares
-    double chi2() const { return chi2_; }
-    /** Number of degrees of freedom
+      /// Constructor for a fake vertex.
+      Vertex(const Point &, const Error &);
+      /// Constructor for a fake vertex. 4D
+      Vertex(const Point &, const Error4D &, double);
+      /// constructor for a valid vertex, with all data
+      Vertex(const Point &, const Error &, double chi2, double ndof, size_t size);
+      /// constructor for a valid vertex, with all data 4D
+      Vertex(const Point &, const Error4D &, double time, double chi2, double ndof, size_t size);
+      /// Tells whether the vertex is valid.
+      bool isValid() const { return validity_; }
+      /// Tells whether a Vertex is fake, i.e. not a vertex made out of a proper
+      /// fit with tracks.
+      /// For a primary vertex, it could simply be the beam line.
+      bool isFake() const { return (chi2_ == 0 && ndof_ == 0 && tracks_.empty()); }
+      /// reserve space for the tracks
+      void reserve(int size, bool refitAsWell = false) {
+        tracks_.reserve(size);
+        if (refitAsWell)
+          refittedTracks_.reserve(size);
+        weights_.reserve(size);
+      }
+      /// add a reference to a Track
+      template <typename Ref>
+      void add(Ref const &r, float w = 1.0) {
+        tracks_.emplace_back(r);
+        weights_.emplace_back(w * 255.f);
+      }
+      /// add the original a Track(reference) and the smoothed Track
+      void add(const TrackBaseRef &r, const Track &refTrack, float w = 1.0);
+      void removeTracks();
+
+      ///returns the weight with which a Track has contributed to the vertex-fit.
+      template <typename TREF>
+      float trackWeight(const TREF &r) const {
+        int i = 0;
+        for (auto const &t : tracks_) {
+          if ((r.id() == t.id()) && (t.key() == r.key()))
+            return weights_[i] / 255.f;
+          ++i;
+        }
+        return 0;
+      }
+      // track collections
+      auto const &tracks() const { return tracks_; }
+      /// first iterator over tracks
+      trackRef_iterator tracks_begin() const { return tracks_.begin(); }
+      /// last iterator over tracks
+      trackRef_iterator tracks_end() const { return tracks_.end(); }
+      /// number of tracks
+      size_t tracksSize() const { return tracks_.size(); }
+      /// python friendly track getting
+      const TrackBaseRef &trackRefAt(size_t idx) const { return tracks_[idx]; }
+      /// chi-squares
+      double chi2() const { return chi2_; }
+      /** Number of degrees of freedom
      *  Meant to be Double32_t for soft-assignment fitters: 
      *  tracks may contribute to the vertex with fractional weights.
      *  The ndof is then = to the sum of the track weights.
      *  see e.g. CMS NOTE-2006/032, CMS NOTE-2004/002
      */
-    double ndof() const { return ndof_; }
-    /// chi-squared divided by n.d.o.f.
-    double normalizedChi2() const { return ndof_ != 0 ? chi2_ / ndof_ : chi2_ * 1e6; }
-    /// position
-    const Point &position() const { return position_; }
-    /// x coordinate
-    double x() const { return position_.X(); }
-    /// y coordinate
-    double y() const { return position_.Y(); }
-    /// z coordinate
-    double z() const { return position_.Z(); }
-    /// t coordinate
-    double t() const { return time_; }
-    /// error on x
-    double xError() const { return sqrt(covariance(0, 0)); }
-    /// error on y
-    double yError() const { return sqrt(covariance(1, 1)); }
-    /// error on z
-    double zError() const { return sqrt(covariance(2, 2)); }
-    /// error on t
-    double tError() const { return sqrt(covariance(3, 3)); }
-    /// (i, j)-th element of error matrix, i, j = 0, ... 2
-    // Note that:
-    //   double error( int i, int j ) const
-    // is OBSOLETE, use covariance(i, j)
-    double covariance(int i, int j) const { return covariance_[idx(i, j)]; }
-    /// return SMatrix
-    CovarianceMatrix covariance() const {
-      Error m;
-      fill(m);
-      return m;
-    }
-    /// return SMatrix 4D
-    CovarianceMatrix4D covariance4D() const {
-      Error4D m;
-      fill(m);
-      return m;
-    }
+      double ndof() const { return ndof_; }
+      /// chi-squared divided by n.d.o.f.
+      double normalizedChi2() const { return ndof_ != 0 ? chi2_ / ndof_ : chi2_ * 1e6; }
+      /// position
+      const Point &position() const { return position_; }
+      /// x coordinate
+      double x() const { return position_.X(); }
+      /// y coordinate
+      double y() const { return position_.Y(); }
+      /// z coordinate
+      double z() const { return position_.Z(); }
+      /// t coordinate
+      double t() const { return time_; }
+      /// error on x
+      double xError() const { return sqrt(covariance(0, 0)); }
+      /// error on y
+      double yError() const { return sqrt(covariance(1, 1)); }
+      /// error on z
+      double zError() const { return sqrt(covariance(2, 2)); }
+      /// error on t
+      double tError() const { return sqrt(covariance(3, 3)); }
+      /// (i, j)-th element of error matrix, i, j = 0, ... 2
+      // Note that:
+      //   double error( int i, int j ) const
+      // is OBSOLETE, use covariance(i, j)
+      double covariance(int i, int j) const { return covariance_[idx(i, j)]; }
+      /// return SMatrix
+      CovarianceMatrix covariance() const {
+        Error m;
+        fill(m);
+        return m;
+      }
+      /// return SMatrix 4D
+      CovarianceMatrix4D covariance4D() const {
+        Error4D m;
+        fill(m);
+        return m;
+      }
 
-    /// return SMatrix
-    Error error() const {
-      Error m;
-      fill(m);
-      return m;
-    }
-    /// return SMatrix
-    Error4D error4D() const {
-      Error4D m;
-      fill(m);
-      return m;
-    }
+      /// return SMatrix
+      Error error() const {
+        Error m;
+        fill(m);
+        return m;
+      }
+      /// return SMatrix
+      Error4D error4D() const {
+        Error4D m;
+        fill(m);
+        return m;
+      }
 
-    /// fill SMatrix
-    void fill(CovarianceMatrix &v) const;
-    /// 4D version
-    void fill(CovarianceMatrix4D &v) const;
+      /// fill SMatrix
+      void fill(CovarianceMatrix &v) const;
+      /// 4D version
+      void fill(CovarianceMatrix4D &v) const;
 
-    /// Checks whether refitted tracks are stored.
-    bool hasRefittedTracks() const { return !refittedTracks_.empty(); }
+      /// Checks whether refitted tracks are stored.
+      bool hasRefittedTracks() const { return !refittedTracks_.empty(); }
 
-    /// Returns the original track which corresponds to a particular refitted Track
-    /// Throws an exception if now refitted tracks are stored ot the track is not found in the list
-    TrackBaseRef originalTrack(const Track &refTrack) const;
+      /// Returns the original track which corresponds to a particular refitted Track
+      /// Throws an exception if now refitted tracks are stored ot the track is not found in the list
+      TrackBaseRef originalTrack(const Track &refTrack) const;
 
-    /// Returns the refitted track which corresponds to a particular original Track
-    /// Throws an exception if now refitted tracks are stored ot the track is not found in the list
-    Track refittedTrack(const TrackBaseRef &track) const;
+      /// Returns the refitted track which corresponds to a particular original Track
+      /// Throws an exception if now refitted tracks are stored ot the track is not found in the list
+      Track refittedTrack(const TrackBaseRef &track) const;
 
-    /// Returns the refitted track which corresponds to a particular original Track
-    /// Throws an exception if now refitted tracks are stored ot the track is not found in the list
-    Track refittedTrack(const TrackRef &track) const;
+      /// Returns the refitted track which corresponds to a particular original Track
+      /// Throws an exception if now refitted tracks are stored ot the track is not found in the list
+      Track refittedTrack(const TrackRef &track) const;
 
-    /// Returns the container of refitted tracks
-    const std::vector<Track> &refittedTracks() const { return refittedTracks_; }
+      /// Returns the container of refitted tracks
+      const std::vector<Track> &refittedTracks() const { return refittedTracks_; }
 
-    /// Returns the four momentum of the sum of the tracks, assuming the given mass for the decay products
-    math::XYZTLorentzVectorD p4(float mass = 0.13957018, float minWeight = 0.5) const;
+      /// Returns the four momentum of the sum of the tracks, assuming the given mass for the decay products
+      math::XYZTLorentzVectorD p4(float mass = 0.13957018, float minWeight = 0.5) const;
 
-    /// Returns the number of tracks in the vertex with weight above minWeight
-    unsigned int nTracks(float minWeight = 0.5) const;
+      /// Returns the number of tracks in the vertex with weight above minWeight
+      unsigned int nTracks(float minWeight = 0.5) const;
 
-    class TrackEqual {
-    public:
-      TrackEqual(const Track &t) : track_(t) {}
-      bool operator()(const Track &t) const { return t.pt() == track_.pt(); }
+      class TrackEqual {
+      public:
+        TrackEqual(const Track &t) : track_(t) {}
+        bool operator()(const Track &t) const { return t.pt() == track_.pt(); }
+
+      private:
+        const Track &track_;
+      };
 
     private:
-      const Track &track_;
+      /// chi-sqared
+      float chi2_;
+      /// number of degrees of freedom
+      float ndof_;
+      /// position
+      Point position_;
+      /// covariance matrix (4x4) as vector
+      float covariance_[size4D];
+      /// reference to tracks
+      std::vector<TrackBaseRef> tracks_;
+      /// The vector of refitted tracks
+      std::vector<Track> refittedTracks_;
+      std::vector<uint8_t> weights_;
+      /// tells wether the vertex is really valid.
+      bool validity_;
+      double time_;
+
+      /// position index
+      index idx(index i, index j) const {
+        int a = (i <= j ? i : j), b = (i <= j ? j : i);
+        return b * (b + 1) / 2 + a;
+      }
     };
 
-  private:
-    /// chi-sqared
-    float chi2_;
-    /// number of degrees of freedom
-    float ndof_;
-    /// position
-    Point position_;
-    /// covariance matrix (4x4) as vector
-    float covariance_[size4D];
-    /// reference to tracks
-    std::vector<TrackBaseRef> tracks_;
-    /// The vector of refitted tracks
-    std::vector<Track> refittedTracks_;
-    std::vector<uint8_t> weights_;
-    /// tells wether the vertex is really valid.
-    bool validity_;
-    double time_;
-
-    /// position index
-    index idx(index i, index j) const {
-      int a = (i <= j ? i : j), b = (i <= j ? j : i);
-      return b * (b + 1) / 2 + a;
-    }
-  };
-
+  }  // namespace io_v1
+  using Vertex = io_v1::Vertex;
 }  // namespace reco
 
 #endif

--- a/DataFormats/VertexReco/interface/VertexFwd.h
+++ b/DataFormats/VertexReco/interface/VertexFwd.h
@@ -6,7 +6,10 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 namespace reco {
-  class Vertex;
+  namespace io_v1 {
+    class Vertex;
+  }
+  using Vertex = io_v1::Vertex;
   /// collection of Vertex objects
   typedef std::vector<Vertex> VertexCollection;
   /// persistent reference to a Vertex

--- a/DataFormats/VertexReco/src/classes_def.xml
+++ b/DataFormats/VertexReco/src/classes_def.xml
@@ -1,15 +1,15 @@
 <lcgdict>
-  <class name="reco::Vertex"  ClassVersion="3">
-   <version ClassVersion="3" checksum="1003958319"/>
+  <class name="reco::io_v1::Vertex"  ClassVersion="3">
+   <version ClassVersion="3" checksum="314752797"/>
   </class>
-  <class name="std::vector<reco::Vertex>" />
-  <class name="edm::Wrapper<std::vector<reco::Vertex> >" />
-  <class name="edm::Ref<std::vector<reco::Vertex>, reco::Vertex, edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>, reco::Vertex> >" />
-  <class name="edm::RefProd<std::vector<reco::Vertex> >" />
-  <class name="edm::RefVector<std::vector<reco::Vertex>, reco::Vertex, edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>, reco::Vertex> >" />
+  <class name="std::vector<reco::io_v1::Vertex>" />
+  <class name="edm::Wrapper<std::vector<reco::io_v1::Vertex> >" />
+  <class name="edm::Ref<std::vector<reco::io_v1::Vertex>, reco::io_v1::Vertex, edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Vertex>, reco::io_v1::Vertex> >" />
+  <class name="edm::RefProd<std::vector<reco::io_v1::Vertex> >" />
+  <class name="edm::RefVector<std::vector<reco::io_v1::Vertex>, reco::io_v1::Vertex, edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Vertex>, reco::io_v1::Vertex> >" />
 
-  <class name="reco::NuclearInteraction"  ClassVersion="10">
-   <version ClassVersion="10" checksum="4040521424"/>
+  <class name="reco::NuclearInteraction"  ClassVersion="3">
+   <version ClassVersion="3" checksum="957163416"/>
   </class>
   <class name="std::vector<reco::NuclearInteraction>" />
   <class name="edm::Wrapper<std::vector<reco::NuclearInteraction> >" />
@@ -17,35 +17,35 @@
   <class name="edm::RefProd<std::vector<reco::NuclearInteraction> >" />
   <class name="edm::RefVector<std::vector<reco::NuclearInteraction>, reco::NuclearInteraction, edm::refhelper::FindUsingAdvance<std::vector<reco::NuclearInteraction>, reco::NuclearInteraction> >" />
 
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::Vertex> >,edm::RefProd<std::vector<reco::io_v1::Track> > >" />  
-  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,float> > >" />
-  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,float> > > >" />
-  <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Vertex>,std::vector<reco::io_v1::Track>,float,unsigned int> >" >
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::io_v1::Vertex> >,edm::RefProd<std::vector<reco::io_v1::Track> > >" />  
+  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,float> > >" />
+  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,float> > > >" />
+  <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::io_v1::Vertex>,std::vector<reco::io_v1::Track>,float,unsigned int> >" >
     <field name="transientMap_" transient="true"/>
   </class>
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Vertex>,std::vector<reco::io_v1::Track>,float,unsigned int> > >" />
-  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,int> > >" />
-  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,int> > > >" />
-  <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Vertex>,std::vector<reco::io_v1::Track>,int,unsigned int> >" >
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::io_v1::Vertex>,std::vector<reco::io_v1::Track>,float,unsigned int> > >" />
+  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,int> > >" />
+  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,int> > > >" />
+  <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::io_v1::Vertex>,std::vector<reco::io_v1::Track>,int,unsigned int> >" >
     <field name="transientMap_" transient="true"/>
   </class>
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Vertex>,std::vector<reco::io_v1::Track>,int,unsigned int> > >" >
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::io_v1::Vertex>,std::vector<reco::io_v1::Track>,int,unsigned int> > >" >
     <field name="transientMap_" transient="true"/>
   </class>
 
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::io_v1::Track> >,edm::RefProd<std::vector<reco::Vertex> > >" />  
-  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,std::vector<std::pair<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,int> > >" />
-  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,std::vector<std::pair<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,int> > > >" />
-  <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::io_v1::Track>,std::vector<reco::Vertex>,int,unsigned int> >" >
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::io_v1::Track> >,edm::RefProd<std::vector<reco::io_v1::Vertex> > >" />  
+  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex> >,int> > >" />
+  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::io_v1::Track>,reco::io_v1::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Track>,reco::io_v1::Track> >,std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex> >,int> > > >" />
+  <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::io_v1::Track>,std::vector<reco::io_v1::Vertex>,int,unsigned int> >" >
     <field name="transientMap_" transient="true"/>
   </class>
-<!--      <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::io_v1::Track>,std::vector<reco::Vertex>,int,unsigned int> > >" /> -->
+<!--      <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::io_v1::Track>,std::vector<reco::io_v1::Vertex>,int,unsigned int> > >" /> -->
 
 
- <class name="edm::Association<std::vector<reco::Vertex> >"/>
- <class name="edm::Wrapper<edm::Association<std::vector<reco::Vertex> > >"/>
-  <class name="std::vector<std::pair<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,int> >" />
-  <class name="std::pair<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,int>" />
+ <class name="edm::Association<std::vector<reco::io_v1::Vertex> >"/>
+ <class name="edm::Wrapper<edm::Association<std::vector<reco::io_v1::Vertex> > >"/>
+  <class name="std::vector<std::pair<edm::Ref<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex> >,int> >" />
+  <class name="std::pair<edm::Ref<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Vertex>,reco::io_v1::Vertex> >,int>" />
 
   <class name="TrackTimeLifeInfo" />
   <class name="std::vector<TrackTimeLifeInfo>"/>

--- a/PhysicsTools/SelectorUtils/src/classes_def.xml
+++ b/PhysicsTools/SelectorUtils/src/classes_def.xml
@@ -9,9 +9,9 @@
   <class name="MuonVPlusJetsIDSelectionFunctor"/>
   <class name="PVSelector"/>
   <class name="RunLumiSelector"/>
-  <class name="VersionedSelector<edm::Ptr<reco::Photon>>"/>
+  <class name="VersionedSelector<edm::Ptr<reco::io_v1::Photon>>"/>
   <class name="VersionedSelector<edm::Ptr<pat::Photon>>"/>
-  <class name="VersionedSelector<edm::Ptr<reco::Muon>>"/>
-  <class name="VersionedSelector<edm::Ptr<reco::GsfElectron>>"/>
+  <class name="VersionedSelector<edm::Ptr<reco::io_v1::Muon>>"/>
+  <class name="VersionedSelector<edm::Ptr<reco::io_v1::GsfElectron>>"/>
   <class name="VersionedSelector<edm::Ptr<pat::Electron>>"/>
 </lcgdict>

--- a/SimDataFormats/Associations/src/classes_def.xml
+++ b/SimDataFormats/Associations/src/classes_def.xml
@@ -58,11 +58,11 @@
   <class name="std::vector<ticl::AssociationElement<std::pair<ticl::SharedEnergyType, float> > >"/>
   <class name="std::vector<std::vector<ticl::AssociationElement<std::pair<ticl::SharedEnergyType, float> > > >"/>
   
-  <class name="std::pair<edm::RefProd<std::vector<reco::CaloCluster> >,edm::RefProd<std::vector<ticl::Trackster> > >"/>
+  <class name="std::pair<edm::RefProd<std::vector<reco::io_v1::CaloCluster> >,edm::RefProd<std::vector<ticl::Trackster> > >"/>
 
   <!-- For one-to-many map with FractionType -->
-  <class name="ticl::AssociationMap<ticl::mapWithFraction, std::vector<reco::CaloCluster>, std::vector<ticl::Trackster> >"/>
-  <class name="edm::Wrapper<ticl::AssociationMap<ticl::mapWithFraction, std::vector<reco::CaloCluster>, std::vector<ticl::Trackster> > >"/>
+  <class name="ticl::AssociationMap<ticl::mapWithFraction, std::vector<reco::io_v1::CaloCluster>, std::vector<ticl::Trackster> >"/>
+  <class name="edm::Wrapper<ticl::AssociationMap<ticl::mapWithFraction, std::vector<reco::io_v1::CaloCluster>, std::vector<ticl::Trackster> > >"/>
   <class name="ticl::AssociationMap<ticl::mapWithFraction, void, void >"/>
   <class name="edm::Wrapper<ticl::AssociationMap<ticl::mapWithFraction, void, void > >"/>
   <!-- For one-to-many map with FractionType and Score -->
@@ -77,8 +77,8 @@
   <class name="edm::Wrapper<ticl::AssociationMap<ticl::oneToOneMapWithFraction, void, void > >"/>
 
   <!-- For one-to-many map with SharedEnergyType -->
-  <class name="ticl::AssociationMap<ticl::mapWithSharedEnergy, std::vector<reco::CaloCluster>, std::vector<ticl::Trackster> >"/>
-  <class name="edm::Wrapper<ticl::AssociationMap<ticl::mapWithSharedEnergy, std::vector<reco::CaloCluster>, std::vector<ticl::Trackster> > >"/>
+  <class name="ticl::AssociationMap<ticl::mapWithSharedEnergy, std::vector<reco::io_v1::CaloCluster>, std::vector<ticl::Trackster> >"/>
+  <class name="edm::Wrapper<ticl::AssociationMap<ticl::mapWithSharedEnergy, std::vector<reco::io_v1::CaloCluster>, std::vector<ticl::Trackster> > >"/>
   <class name="ticl::AssociationMap<ticl::mapWithSharedEnergy, void, void >"/>
   <class name="edm::Wrapper<ticl::AssociationMap<ticl::mapWithSharedEnergy, void, void > >"/>
 
@@ -119,8 +119,8 @@
   <class name="edm::Wrapper<ticl::RecoToSimCollectionT<reco::CaloClusterCollection>>" />
   <class name="edm::Wrapper<ticl::RecoToSimCollectionT<reco::PFClusterCollection>>" />
 
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<CaloParticle> >,edm::RefProd<vector<reco::CaloCluster> > >" />
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::CaloCluster> >,edm::RefProd<vector<CaloParticle> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<CaloParticle> >,edm::RefProd<vector<reco::io_v1::CaloCluster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::io_v1::CaloCluster> >,edm::RefProd<vector<CaloParticle> > >" />
   <class name="map<unsigned int,vector<pair<unsigned int,pair<float,float> > > >" />
   <class name="vector<pair<unsigned int,pair<float,float> > >" />
 
@@ -155,8 +155,8 @@
   </class>
   <class name="edm::Wrapper<ticl::RecoToSimCollectionTracksters>" />
 
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<SimCluster> >,edm::RefProd<vector<reco::CaloCluster> > >" />
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::CaloCluster> >,edm::RefProd<vector<SimCluster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<SimCluster> >,edm::RefProd<vector<reco::io_v1::CaloCluster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::io_v1::CaloCluster> >,edm::RefProd<vector<SimCluster> > >" />
 
   <class name="edm::Wrapper<reco::SimToRecoCollection>" />
   <class name="edm::Wrapper<reco::RecoToSimCollection>" />
@@ -168,40 +168,39 @@
    <field name="transientMap_" transient="true"/>
   </class>
 
-  <class name="edm::RefProd<std::vector<reco::PFCluster>>"/>
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<SimCluster> >,edm::RefProd<vector<reco::PFCluster> > >" />
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::PFCluster> >,edm::RefProd<vector<SimCluster> > >" />
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<CaloParticle> >,edm::RefProd<vector<reco::PFCluster> > >" />
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::PFCluster> >,edm::RefProd<vector<CaloParticle> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<SimCluster> >,edm::RefProd<vector<reco::io_v1::PFCluster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::io_v1::PFCluster> >,edm::RefProd<vector<SimCluster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<CaloParticle> >,edm::RefProd<vector<reco::io_v1::PFCluster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::io_v1::PFCluster> >,edm::RefProd<vector<CaloParticle> > >" />
 
   <class name="edm::AssociationMap<edm::OneToManyWithQualityGeneric<
-               std::vector<SimCluster>, std::vector<reco::PFCluster>, std::pair<float,float>, unsigned int,
-               edm ::RefProd<std::vector<SimCluster>>, edm::RefProd<std::vector<reco::PFCluster>>,
-               edm::Ref<std::vector<SimCluster>>, edm::Ref<std::vector<reco::PFCluster>>
+               std::vector<SimCluster>, std::vector<reco::io_v1::PFCluster>, std::pair<float,float>, unsigned int,
+               edm ::RefProd<std::vector<SimCluster>>, edm::RefProd<std::vector<reco::io_v1::PFCluster>>,
+               edm::Ref<std::vector<SimCluster>>, edm::Ref<std::vector<reco::io_v1::PFCluster>>
 			   >>">
 		 <field name="transientMap_" transient="true"/>
   </class>
   
   <class name="edm::AssociationMap<edm::OneToManyWithQualityGeneric<
-               std::vector<reco::PFCluster>, std::vector<SimCluster>, float, unsigned int,
-               edm::RefProd<std::vector<reco::PFCluster>>, edm::RefProd<std::vector<SimCluster>>,
-               edm::Ref<std::vector<reco::PFCluster>>, edm::Ref<std::vector<SimCluster>>
+               std::vector<reco::io_v1::PFCluster>, std::vector<SimCluster>, float, unsigned int,
+               edm::RefProd<std::vector<reco::io_v1::PFCluster>>, edm::RefProd<std::vector<SimCluster>>,
+               edm::Ref<std::vector<reco::io_v1::PFCluster>>, edm::Ref<std::vector<SimCluster>>
 			   >>" >
 		 <field name="transientMap_" transient="true"/>
   </class>
   
   <class name="edm::AssociationMap<edm::OneToManyWithQualityGeneric<
-               std::vector<CaloParticle>, std::vector<reco::PFCluster>, std::pair<float,float>, unsigned int,
-               edm::RefProd<std::vector<CaloParticle>>, edm::RefProd<std::vector<reco::PFCluster>>,
-               edm::Ref<std::vector<CaloParticle>>, edm::Ref<std::vector<reco::PFCluster>>
+               std::vector<CaloParticle>, std::vector<reco::io_v1::PFCluster>, std::pair<float,float>, unsigned int,
+               edm::RefProd<std::vector<CaloParticle>>, edm::RefProd<std::vector<reco::io_v1::PFCluster>>,
+               edm::Ref<std::vector<CaloParticle>>, edm::Ref<std::vector<reco::io_v1::PFCluster>>
 			   >>" >
 		 <field name="transientMap_" transient="true"/>
   </class>
 
   <class name="edm::AssociationMap<edm::OneToManyWithQualityGeneric<
-               std::vector<reco::PFCluster>, std::vector<CaloParticle>, float, unsigned int,
-               edm::RefProd<std::vector<reco::PFCluster>>, edm::RefProd<std::vector<CaloParticle>>,
-               edm::Ref<std::vector<reco::PFCluster>>, edm::Ref<std::vector<CaloParticle>>
+               std::vector<reco::io_v1::PFCluster>, std::vector<CaloParticle>, float, unsigned int,
+               edm::RefProd<std::vector<reco::io_v1::PFCluster>>, edm::RefProd<std::vector<CaloParticle>>,
+               edm::Ref<std::vector<reco::io_v1::PFCluster>>, edm::Ref<std::vector<CaloParticle>>
 			   >>" >
 		 <field name="transientMap_" transient="true"/>
   </class>
@@ -222,8 +221,8 @@
   </class>
   <class name="edm::Wrapper<hgcal::RecoToSimCollectionWithMultiClusters>" />
 
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<CaloParticle> >,edm::RefProd<vector<reco::HGCalMultiCluster> > >" />
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::HGCalMultiCluster> >,edm::RefProd<vector<CaloParticle> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<CaloParticle> >,edm::RefProd<vector<reco::io_v1::HGCalMultiCluster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::io_v1::HGCalMultiCluster> >,edm::RefProd<vector<CaloParticle> > >" />
 
 
   <class name="ticl::SimToRecoCollectionSimTracksters" >
@@ -247,8 +246,8 @@
   </class>
   <class name="edm::Wrapper<ticl::RecoToSimTracksterCollection>" />
 
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::CaloCluster> >,edm::RefProd<vector<ticl::Trackster> > >" />
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<ticl::Trackster> >,edm::RefProd<vector<reco::CaloCluster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::io_v1::CaloCluster> >,edm::RefProd<vector<ticl::Trackster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<ticl::Trackster> >,edm::RefProd<vector<reco::io_v1::CaloCluster> > >" />
 
 
   <class name="TTTrackTruthPair<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >" />

--- a/SimDataFormats/CaloAnalysis/src/classes_def.xml
+++ b/SimDataFormats/CaloAnalysis/src/classes_def.xml
@@ -1,7 +1,6 @@
 <lcgdict>
-   <class name="CaloParticle"  ClassVersion="5">
-    <version ClassVersion="5" checksum="2074797506"/>
-   <version ClassVersion="4" checksum="1423471036"/>
+   <class name="CaloParticle"  ClassVersion="3">
+    <version ClassVersion="3" checksum="3832020818"/>
   </class>
   <class name="CaloParticleCollection"/>
   <class name="edm::Wrapper<CaloParticleCollection>"/>
@@ -18,12 +17,8 @@
   <class name="MtdCaloParticleRefProd"/>
   <class name="MtdCaloParticleContainer"/>
 
-  <class name="SimCluster"  ClassVersion="7">
-   <version ClassVersion="7" checksum="3868743425"/>
-   <version ClassVersion="6" checksum="1198608638"/>
-   <version ClassVersion="5" checksum="3963576369"/>
-   <version ClassVersion="4" checksum="3868743425"/>
-   <version ClassVersion="3" checksum="1773780587"/>
+  <class name="SimCluster"  ClassVersion="3">
+   <version ClassVersion="3" checksum="2937120977"/>
   </class>
   <class name="SimClusterCollection"/>
   <class name="edm::Wrapper<SimClusterCollection>"/>
@@ -34,11 +29,8 @@
 
   <class name="std::pair<edm::RefProd<std::vector<SimCluster> >, edm::RefProd<std::vector<CaloParticle> > >"/>
 
-  <class name="MtdSimCluster" ClassVersion="6">
-    <version ClassVersion="6" checksum="3803328692"/>
-    <version ClassVersion="5" checksum="3108339619"/>
-    <version ClassVersion="4" checksum="3803328692"/>
-    <version ClassVersion="3" checksum="1001786642"/>
+  <class name="MtdSimCluster" ClassVersion="3">
+    <version ClassVersion="3" checksum="348726692"/>
   </class>
   <class name="MtdSimClusterCollection"/>
   <class name="edm::Wrapper<MtdSimClusterCollection>"/>

--- a/SimDataFormats/HiGenData/src/classes_def.xml
+++ b/SimDataFormats/HiGenData/src/classes_def.xml
@@ -1,6 +1,6 @@
 <lcgdict>
- <class name="edm::GenHIEvent" ClassVersion="10">
-  <version ClassVersion="10" checksum="1192921172"/>
+ <class name="edm::GenHIEvent" ClassVersion="3">
+  <version ClassVersion="3" checksum="1558760564"/>
  </class>
  <class name="edm::Wrapper<edm::GenHIEvent>"/>
 </lcgdict>

--- a/SimDataFormats/TrackingAnalysis/src/classes_def.xml
+++ b/SimDataFormats/TrackingAnalysis/src/classes_def.xml
@@ -10,9 +10,8 @@
   <class name="TrackingVertexRefVector" />
   <class name="edm::RefProd<std::vector<TrackingVertex> >" />
 
-  <class name="TrackingParticle" ClassVersion="11">
-   <version ClassVersion="11" checksum="2086515162"/>
-   <version ClassVersion="10" checksum="2835241548"/>
+  <class name="TrackingParticle" ClassVersion="3">
+   <version ClassVersion="3" checksum="3602175482"/>
   </class>
   <class name="std::vector<TrackingParticle>" />
   <class name="edm::Wrapper<std::vector<TrackingParticle> >" />

--- a/TrackingTools/GsfTracking/src/classes_def.xml
+++ b/TrackingTools/GsfTracking/src/classes_def.xml
@@ -1,5 +1,5 @@
 <lcgdict>
-  <class name="edm::AssociationMap<edm::OneToOne<std::vector<Trajectory>, std::vector<reco::GsfTrack>, unsigned short > >" >
+  <class name="edm::AssociationMap<edm::OneToOne<std::vector<Trajectory>, std::vector<reco::io_v1::GsfTrack>, unsigned short > >" >
     <field name="transientMap_" transient="true" />
   </class>
   <class name="edm::AssociationMap<edm::OneToOne<reco::GsfTrackCollection, std::vector<MomentumConstraint>, unsigned int> >" >
@@ -8,16 +8,16 @@
   <class name="edm::AssociationMap<edm::OneToOne<reco::GsfTrackCollection, std::vector<VertexConstraint>, unsigned int> >" >
     <field name="transientMap_" transient="true" />
   </class>
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<std::vector<Trajectory>, std::vector<reco::GsfTrack>, unsigned short > > >" />
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<std::vector<Trajectory>, std::vector<reco::io_v1::GsfTrack>, unsigned short > > >" />
 
   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<reco::GsfTrackCollection, std::vector<MomentumConstraint>, unsigned int> > >" />
 
   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<reco::GsfTrackCollection, std::vector<VertexConstraint>, unsigned int> > >" />
 
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<Trajectory> >, edm::RefProd<std::vector<reco::GsfTrack> > >"/>
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::GsfTrack> >, edm::RefProd<std::vector<MomentumConstraint> > >"/>
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::GsfTrack> >, edm::RefProd<std::vector<VertexConstraint> > >"/>
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<Trajectory> >, edm::RefProd<std::vector<reco::io_v1::GsfTrack> > >"/>
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::io_v1::GsfTrack> >, edm::RefProd<std::vector<MomentumConstraint> > >"/>
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::io_v1::GsfTrack> >, edm::RefProd<std::vector<VertexConstraint> > >"/>
 
-  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<Trajectory>, Trajectory, edm::refhelper::FindUsingAdvance<std::vector<Trajectory>, Trajectory> >, edm::Ref<std::vector<reco::GsfTrack>, reco::GsfTrack, edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrack>, reco::GsfTrack> > >" />
+  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<Trajectory>, Trajectory, edm::refhelper::FindUsingAdvance<std::vector<Trajectory>, Trajectory> >, edm::Ref<std::vector<reco::io_v1::GsfTrack>, reco::io_v1::GsfTrack, edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::GsfTrack>, reco::io_v1::GsfTrack> > >" />
 
 </lcgdict>


### PR DESCRIPTION
#### PR description:

- classes in reco:: namespace which are stored in common data formats were moved to reco::io_v1 namespace
- Forward references to those classes were handled via includes of a FWD file.
- class versions were reset to 3

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/1810