### PR TITLE
Future proof HLT's defaultModuleLabel

### DIFF
--- a/HLTrigger/HLTcore/interface/defaultModuleLabel.h
+++ b/HLTrigger/HLTcore/interface/defaultModuleLabel.h
@@ -1,8 +1,9 @@
-#ifndef defaultModuleLabel_h
-#define defaultModuleLabel_h
+#ifndef HLTrigger_HLTcore_defaultModuleLabel_h
+#define HLTrigger_HLTcore_defaultModuleLabel_h
 
 // C++ headers
 #include <string>
+#include <regex>
 
 // boost headers
 #include <boost/version.hpp>
@@ -20,6 +21,14 @@ std::string defaultModuleLabel() {
 #else
   std::string name = boost::core::demangle(typeid(T).name());
 #endif
+
+  {
+    //Data products have version names which are meant to mostly
+    // be hidden. Need to remove them if the class type references
+    // a data product as a template argument.
+    const std::regex vNamespace("io_v[0-9]::");
+    name = std::regex_replace(name, vNamespace, "");
+  }
 
   // expected size of the label
   unsigned int size = 0;

--- a/HLTrigger/HLTcore/test/BuildFile.xml
+++ b/HLTrigger/HLTcore/test/BuildFile.xml
@@ -10,6 +10,11 @@
   <use name="catch2"/>
 </bin>
 
+<bin file="test_catch2_defaultModuleLabel.cc" name="testHLTriggerHLTcoreDefaultModuleLabelCatch2">
+  <use name="HLTrigger/HLTcore"/>
+  <use name="catch2"/>
+</bin>
+
 <!-- test the HLTPrescaleExample plugin -->
 <test name="testHLTPrescaleExample" command="testHLTPrescaleExample.sh"/>
 

--- a/HLTrigger/HLTcore/test/test_catch2_defaultModuleLabel.cc
+++ b/HLTrigger/HLTcore/test/test_catch2_defaultModuleLabel.cc
@@ -1,0 +1,61 @@
+#include "HLTrigger/HLTcore/interface/defaultModuleLabel.h"
+
+#include "catch2/catch_all.hpp"
+
+class Bar {};
+class MultiWordName {};
+class SHOUTING {};
+class ABCDef {};
+template <typename T>
+class Templated {};
+
+namespace for_testing {
+  class Foo {};
+  template <typename T>
+  class Templated2 {};
+}  // namespace for_testing
+
+namespace io_v1 {
+  class Fii {};
+}  // namespace io_v1
+
+using Fii = io_v1::Fii;
+
+namespace reco {
+  namespace io_v8 {
+    class Fii {};
+  }  // namespace io_v8
+  using Fii = io_v8::Fii;
+}  // namespace reco
+
+TEST_CASE("Test defaultModuleLabel", "[defaultModuleLabel]") {
+  SECTION("no namespace") {
+    CHECK(defaultModuleLabel<Bar>() == "bar");
+    CHECK(defaultModuleLabel<MultiWordName>() == "multiWordName");
+    CHECK(defaultModuleLabel<SHOUTING>() == "shouting");
+    CHECK(defaultModuleLabel<ABCDef>() == "abcDef");
+    SECTION("templated") {
+      CHECK(defaultModuleLabel<Templated<Bar>>() == "templatedBar");
+      CHECK(defaultModuleLabel<Templated<MultiWordName>>() == "templatedMultiWordName");
+      CHECK(defaultModuleLabel<Templated<SHOUTING>>() == "templatedSHOUTING");
+      CHECK(defaultModuleLabel<Templated<ABCDef>>() == "templatedABCDef");
+    }
+  }
+  SECTION("with namespace") {
+    CHECK(defaultModuleLabel<for_testing::Foo>() == "forTestingFoo");
+    SECTION("templated") {
+      CHECK(defaultModuleLabel<for_testing::Templated2<Bar>>() == "forTestingTemplated2Bar");
+      CHECK(defaultModuleLabel<for_testing::Templated2<MultiWordName>>() == "forTestingTemplated2MultiWordName");
+      CHECK(defaultModuleLabel<for_testing::Templated2<SHOUTING>>() == "forTestingTemplated2SHOUTING");
+      CHECK(defaultModuleLabel<for_testing::Templated2<ABCDef>>() == "forTestingTemplated2ABCDef");
+    }
+  }
+  SECTION("with version namespace") {
+    CHECK(defaultModuleLabel<Fii>() == "fii");
+    CHECK(defaultModuleLabel<reco::Fii>() == "recoFii");
+    SECTION("templated") {
+      CHECK(defaultModuleLabel<for_testing::Templated2<Fii>>() == "forTestingTemplated2Fii");
+      CHECK(defaultModuleLabel<for_testing::Templated2<reco::Fii>>() == "forTestingTemplated2RecoFii");
+    }
+  }
+}


### PR DESCRIPTION
#### PR description:

- Need to remove version namespace in data product names in the case where the template type used by defaultModuleLabel is itself a template where the template argument is a data product class name.
- Added unit test for defaultModuleLabel function.

This PR is needed for the EVOLUTION_X branch, but doing it in master will help avoid possible merge conflicts in the future if there are changes made later in master.
#### PR validation:

New unit test passes.

resolves https://github.com/cms-sw/framework-team/issues/1811