### PR TITLE
Set `rntupleStreamerMode` attribute for all remaining `PortableHost*` data products

### DIFF
--- a/DataFormats/BeamSpot/src/classes_def.xml
+++ b/DataFormats/BeamSpot/src/classes_def.xml
@@ -5,7 +5,7 @@
   </class>
   <class name="edm::Wrapper<reco::BeamSpot>"/>
 
-  <class name="BeamSpotHost"/>
+  <class name="BeamSpotHost" rntupleStreamerMode="true"/>
   <!-- BeamSpotHost::Product must be listed before the aliased-to type -->
   <!-- TODO: we should find a better way than replicating the class versions and checksums -->
   <class name="BeamSpotHost::Product" ClassVersion="3">

--- a/DataFormats/EcalDigi/src/classes_def.xml
+++ b/DataFormats/EcalDigi/src/classes_def.xml
@@ -152,9 +152,7 @@
    <class name="EcalDigiHostCollection::Layout"/>
    <class name="EcalDigiSoA"/>
    <class name="EcalDigiSoA::View"/>
-   <class name="EcalDigiHostCollection" ClassVersion="3">
-     <version ClassVersion="3" checksum="9207964"/>
-   </class>
+   <class name="EcalDigiHostCollection" rntupleStreamerMode="true"/>
    <class name="edm::Wrapper<EcalDigiHostCollection>" splitLevel="0"/>
 
    <class name="EcalDataArrayPhase2"/>
@@ -162,8 +160,6 @@
    <class name="EcalDigiPhase2HostCollection::Layout"/>
    <class name="EcalDigiPhase2SoA"/>
    <class name="EcalDigiPhase2SoA::View"/>
-   <class name="EcalDigiPhase2HostCollection" ClassVersion="3">
-     <version ClassVersion="3" checksum="2567280384"/>
-   </class>
+   <class name="EcalDigiPhase2HostCollection" rntupleStreamerMode="true"/>
    <class name="edm::Wrapper<EcalDigiPhase2HostCollection>" splitLevel="0"/>
 </lcgdict>

--- a/DataFormats/EcalRecHit/src/classes_def.xml
+++ b/DataFormats/EcalRecHit/src/classes_def.xml
@@ -39,7 +39,7 @@
   <class name="edm::Wrapper<edm::DetSetVector<EcalRecHit> >"/>
   <class name="edm::Wrapper<std::vector<std::vector<edm::DetSet<EcalRecHit> > > >"/>
 
-  <class name="EcalUncalibratedRecHitHostCollection"/>
+  <class name="EcalUncalibratedRecHitHostCollection" rntupleStreamerMode="true"/>
   <!-- EcalUncalibratedRecHitHostCollection::Layout must be listed before the aliased-to type -->
   <class name="EcalUncalibratedRecHitHostCollection::Layout"/>
   <class name="EcalOotAmpArray"/>
@@ -47,7 +47,7 @@
   <class name="EcalUncalibratedRecHitSoA::View"/>
   <class name="edm::Wrapper<EcalUncalibratedRecHitHostCollection>" splitLevel="0"/>
 
-  <class name="EcalRecHitHostCollection"/>
+  <class name="EcalRecHitHostCollection" rntupleStreamerMode="true"/>
   <!-- EcalRecHitHostCollection::Layout must be listed before the aliased-to type -->
   <class name="EcalRecHitHostCollection::Layout"/>
   <class name="EcalRecHitSoA"/>

--- a/DataFormats/HGCalReco/src/classes_def.xml
+++ b/DataFormats/HGCalReco/src/classes_def.xml
@@ -76,14 +76,14 @@
   <class name="edm::Wrapper<TICLCandidate>" />
   <class name="edm::Wrapper<std::vector<TICLCandidate> >" />
 
-  <class name="MtdHostCollection"/>
+  <class name="MtdHostCollection" rntupleStreamerMode="true"/>
   <!-- MtdHostCollection::Layout must be listed before the aliased-to type -->
   <class name="MtdHostCollection::Layout"/>
   <class name="MtdSoA"/>
   <class name="MtdSoA::View"/>
   <class name="edm::Wrapper<MtdHostCollection>" splitLevel="0"/>
 
-  <class name="HGCalSoARecHitsHostCollection"/>
+  <class name="HGCalSoARecHitsHostCollection" rntupleStreamerMode="true"/>
   <!-- HGCalSoARecHitsHostCollection::Layout must be listed before the aliased-to type -->
   <class name="HGCalSoARecHitsHostCollection::Layout"/>
   <class name="HGCalSoARecHits"/>

--- a/DataFormats/HcalDigi/src/classes_def.xml
+++ b/DataFormats/HcalDigi/src/classes_def.xml
@@ -115,14 +115,14 @@
    <class name="edm::Wrapper<HcalUMNioDigi>" splitLevel="0"/>
 
 
-  <class name="hcal::Phase1DigiHostCollection"/>
+  <class name="hcal::Phase1DigiHostCollection" rntupleStreamerMode="true"/>
   <!-- hcal::Phase1DigiHostCollection::Layout must be listed before the aliased-to type -->
   <class name="hcal::Phase1DigiHostCollection::Layout"/>
   <class name="hcal::HcalPhase1DigiSoA"/>
   <class name="hcal::HcalPhase1DigiSoA::View"/>
   <class name="edm::Wrapper<hcal::Phase1DigiHostCollection>" splitLevel="0"/>
 
-  <class name="hcal::Phase0DigiHostCollection"/> 
+  <class name="hcal::Phase0DigiHostCollection" rntupleStreamerMode="true"/> 
   <!-- hcal::Phase0DigiHostCollection::Layout must be listed before the aliased-to type -->
   <class name="hcal::Phase0DigiHostCollection::Layout"/>
   <class name="hcal::HcalPhase0DigiSoA"/>

--- a/DataFormats/HcalRecHit/src/classes_def.xml
+++ b/DataFormats/HcalRecHit/src/classes_def.xml
@@ -120,7 +120,7 @@
   <class name="edm::reftobase::Holder<CaloRecHit,edm::Ref<edm::SortedCollection<HORecHit,edm::StrictWeakOrdering<HORecHit> >,HORecHit,edm::refhelper::FindUsingAdvance<edm::SortedCollection<HORecHit,edm::StrictWeakOrdering<HORecHit> >,HORecHit> > >" />
   <class name="edm::reftobase::Holder<CaloRecHit,edm::Ref<edm::SortedCollection<HBHERecHit,edm::StrictWeakOrdering<HBHERecHit> >,HBHERecHit,edm::refhelper::FindUsingAdvance<edm::SortedCollection<HBHERecHit,edm::StrictWeakOrdering<HBHERecHit> >,HBHERecHit> > >" />
 
-  <class name="hcal::RecHitHostCollection" />
+  <class name="hcal::RecHitHostCollection" rntupleStreamerMode="true"/>
   <!-- hcal::RecHitHostCollection::Layout must be listed before the aliased-to type -->
   <class name="hcal::RecHitHostCollection::Layout" />
   <class name="hcal::HcalRecHitSoA"/>

--- a/DataFormats/ParticleFlowReco/src/classes_serial_def.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_serial_def.xml
@@ -1,26 +1,26 @@
 <lcgdict>
-  <class name="reco::CaloRecHitHostCollection"/>
+  <class name="reco::CaloRecHitHostCollection" rntupleStreamerMode="true"/>
   <!-- reco::CaloRecHitHostCollection::Layout must be listed before the aliased-to type -->
   <class name="reco::CaloRecHitHostCollection::Layout"/>
   <class name="reco::CaloRecHitSoA"/>
   <class name="reco::CaloRecHitSoA::View"/>
   <class name="edm::Wrapper<reco::CaloRecHitHostCollection>" splitLevel="0"/>
 
-  <class name="reco::PFRecHitHostCollection"/>
+  <class name="reco::PFRecHitHostCollection" rntupleStreamerMode="true"/>
   <!-- reco::PFRecHitHostCollection::Layout must be listed before the aliased-to type -->
   <class name="reco::PFRecHitHostCollection::Layout"/>
   <class name="reco::PFRecHitSoA"/>
   <class name="reco::PFRecHitSoA::View"/>
   <class name="edm::Wrapper<reco::PFRecHitHostCollection>" splitLevel="0"/>
 
-  <class name="reco::PFClusterHostCollection"/>
+  <class name="reco::PFClusterHostCollection" rntupleStreamerMode="true"/>
   <!-- reco::PFClusterHostCollection::Layout must be listed before the aliased-to type -->
   <class name="reco::PFClusterHostCollection::Layout"/>
   <class name="reco::PFClusterSoA"/>
   <class name="reco::PFClusterSoA::View"/>
   <class name="edm::Wrapper<reco::PFClusterHostCollection>" splitLevel="0"/>
 
-  <class name="reco::PFRecHitFractionHostCollection"/>
+  <class name="reco::PFRecHitFractionHostCollection" rntupleStreamerMode="true"/>
   <!-- reco::PFRecHitFractionHostCollection::Layout must be listed before the aliased-to type -->
   <class name="reco::PFRecHitFractionHostCollection::Layout"/>
   <class name="reco::PFRecHitFractionSoA"/>

--- a/DataFormats/Portable/README.md
+++ b/DataFormats/Portable/README.md
@@ -36,6 +36,8 @@ SET_PORTABLEHOSTOBJECT_READ_RULES(portabletest::TestHostObject);
 ```
 **Note:** The dictionary for `portabletest::TestHostObject::Product` (using the same type alias as in the registration macro above) must be placed in the `classes_def.xml` file before the type that `Product` aliases.
 
+**Note:** The dictionary for `portabletest::TestHostObject` in `classes_def.xml` needs `rntupleStreamerMode="true"` attribute in order to be storable with RNTuple.
+
 
 `PortableHostObject<T>` objects can also be read back in "bare ROOT" mode, without any dictionaries.
 They have no implicit or explicit references to alpaka (neither as part of the class signature nor as part of its name).
@@ -96,6 +98,8 @@ one would create the file `classes.cc` with the content:
 SET_PORTABLEHOSTCOLLECTION_READ_RULES(portabletest::TestHostCollection);
 ```
 **Note:** The dictionary for `portabletest::TestHostCollection::Layout` (using the same type alias as in the registration macro above) must be placed in the `classes_def.xml` file before the type that `Layout` aliases.
+
+**Note:** The dictionary for `portabletest::TestHostCollection` in `classes_def.xml` needs `rntupleStreamerMode="true"` attribute in order to be storable with RNTuple.
 
 
 `PortableHostCollection<T>` collections can also be read back in "bare ROOT" mode, without any dictionaries.

--- a/DataFormats/Portable/scripts/portableHostCollectionHints
+++ b/DataFormats/Portable/scripts/portableHostCollectionHints
@@ -13,7 +13,7 @@ for i in range(len(layouts)):
 print("In <module>/src/classes_def.xml (with necessary includes in <module>/src/classes.h):\n")
 print("<lcgdict>")
 print("  <!-- Collection declaration for dictionary -->")
-print("  <class name=\"%s\"/>"% collectionName)
+print("  <class name=\"%s\" rntupleStreamerMode=\"true\"/>"% collectionName)
 print("  <!-- %s::Layout must be listed before the aliased-to type -->"% collectionName)
 print("  <class name=\"%s::Layout\"/>"% collectionName)
 print()

--- a/DataFormats/PortableTestObjects/src/classes_def.xml
+++ b/DataFormats/PortableTestObjects/src/classes_def.xml
@@ -1,20 +1,20 @@
 <lcgdict>
-  <class name="portabletest::TestHostCollection"/>
+  <class name="portabletest::TestHostCollection" rntupleStreamerMode="true"/>
   <!-- portabletest::TestHostCollection::Layout alias must be listed before the aliased-to type -->
   <class name="portabletest::TestHostCollection::Layout"/>
   <class name="edm::Wrapper<portabletest::TestHostCollection>" splitLevel="0"/>
 
-  <class name="portabletest::TestHostCollection2"/>
+  <class name="portabletest::TestHostCollection2" rntupleStreamerMode="true"/>
   <!-- portabletest::TestHostCollection2::Layout alias must be listed before the aliased-to type -->
   <class name="portabletest::TestHostCollection2::Layout"/>
   <class name="edm::Wrapper<portabletest::TestHostCollection2>" splitLevel="0"/>
 
-  <class name="portabletest::TestHostCollection3"/>
+  <class name="portabletest::TestHostCollection3" rntupleStreamerMode="true"/>
   <!-- portabletest::TestHostCollection3::Layout alias must be listed before the aliased-to type -->
   <class name="portabletest::TestHostCollection3::Layout"/>
   <class name="edm::Wrapper<portabletest::TestHostCollection3>" splitLevel="0"/>
 
-  <class name="portabletest::TestHostObject"/>
+  <class name="portabletest::TestHostObject" rntupleStreamerMode="true"/>
   <!-- portabletest::TestHostObject::Product alias must be listed before the aliased-to type -->
   <!-- TODO: we should find a better way than replicating the class versions and checksums -->
   <class name="portabletest::TestHostObject::Product" ClassVersion="3">
@@ -35,7 +35,7 @@
   <class name="edm::Wrapper<portabletest::TestProductWithPtr<alpaka_common::DevHost>>" persistent="false"/>
 
   <!-- Torch SoAs and Collections -->
-  <class name="portabletest::ParticleHostCollection"/>
+  <class name="portabletest::ParticleHostCollection" rntupleStreamerMode="true"/>
   <!-- portabletest::ParticleHostCollection::Layout must be listed before the aliased-to type -->
   <class name="portabletest::ParticleHostCollection::Layout"/>
   <class name="portabletest::ParticleSoA"/>
@@ -43,7 +43,7 @@
   <class name="portabletest::ParticleSoA::ConstView"/>
   <class name="edm::Wrapper<portabletest::ParticleHostCollection>" splitLevel="0"/>
 
-  <class name="portabletest::SimpleNetHostCollection"/>
+  <class name="portabletest::SimpleNetHostCollection" rntupleStreamerMode="true"/>
   <!-- portabletest::SimpleNetHostCollection::Layout must be listed before the aliased-to type -->
   <class name="portabletest::SimpleNetHostCollection::Layout"/>
   <class name="portabletest::SimpleNetSoA"/>
@@ -51,7 +51,7 @@
   <class name="portabletest::SimpleNetSoA::ConstView"/>
   <class name="edm::Wrapper<portabletest::SimpleNetHostCollection>" splitLevel="0"/>
 
-  <class name="portabletest::MultiHeadNetHostCollection"/>
+  <class name="portabletest::MultiHeadNetHostCollection" rntupleStreamerMode="true"/>
   <!-- portabletest::MultiHeadNetHostCollection::Layout must be listed before the aliased-to type -->
   <class name="portabletest::MultiHeadNetHostCollection::Layout"/>
   <class name="portabletest::MultiHeadNetSoA"/>
@@ -59,7 +59,7 @@
   <class name="portabletest::MultiHeadNetSoA::ConstView"/>
   <class name="edm::Wrapper<portabletest::MultiHeadNetHostCollection>" splitLevel="0"/>
 
-  <class name="portabletest::ImageHostCollection"/>
+  <class name="portabletest::ImageHostCollection" rntupleStreamerMode="true"/>
   <!-- portabletest::ImageHostCollection::Layout must be listed before the aliased-to type -->
   <class name="portabletest::ImageHostCollection::Layout"/>
   <class name="portabletest::ImageSoA"/>
@@ -67,7 +67,7 @@
   <class name="portabletest::ImageSoA::ConstView"/>
   <class name="edm::Wrapper<portabletest::ImageHostCollection>" splitLevel="0"/>
 
-  <class name="portabletest::LogitsHostCollection"/>
+  <class name="portabletest::LogitsHostCollection" rntupleStreamerMode="true"/>
   <!-- portabletest::LogitsHostCollection::Layout must be listed before the aliased-to type -->
   <class name="portabletest::LogitsHostCollection::Layout"/>
   <class name="portabletest::LogitsSoA"/>
@@ -75,7 +75,7 @@
   <class name="portabletest::LogitsSoA::ConstView"/>
   <class name="edm::Wrapper<portabletest::LogitsHostCollection>" splitLevel="0"/>
 
-  <class name="portabletest::MaskHostCollection"/>
+  <class name="portabletest::MaskHostCollection" rntupleStreamerMode="true"/>
   <!-- portabletest::MaskHostCollection::Layout must be listed before the aliased-to type -->
   <class name="portabletest::MaskHostCollection::Layout"/>
   <class name="portabletest::MaskSoA"/>

--- a/DataFormats/SiPixelClusterSoA/src/classes_def.xml
+++ b/DataFormats/SiPixelClusterSoA/src/classes_def.xml
@@ -1,5 +1,5 @@
 <lcgdict>
-  <class name="PortableHostCollection<SiPixelClustersSoA>"/>
+  <class name="PortableHostCollection<SiPixelClustersSoA>" rntupleStreamerMode="true"/>
   <!-- PortableHostCollection<SiPixelClustersSoA>::Layout must be listed before the aliased-to type -->
   <class name="PortableHostCollection<SiPixelClustersSoA>::Layout"/>
   <class name="SiPixelClustersSoA"/>

--- a/DataFormats/SiPixelDigiSoA/src/classes_def.xml
+++ b/DataFormats/SiPixelDigiSoA/src/classes_def.xml
@@ -1,5 +1,5 @@
 <lcgdict>
-  <class name="PortableHostCollection<SiPixelDigisSoA>"/>
+  <class name="PortableHostCollection<SiPixelDigisSoA>" rntupleStreamerMode="true"/>
   <!-- PortableHostCollection<SiPixelDigisSoA>::Layout must be listed before the aliased-to type -->
   <class name="PortableHostCollection<SiPixelDigisSoA>::Layout"/>
   <class name="SiPixelDigisSoA"/>
@@ -7,7 +7,7 @@
   <class name="SiPixelDigisHost"/>
   <class name="edm::Wrapper<SiPixelDigisHost>" splitLevel="0"/>
 
-  <class name="PortableHostCollection<SiPixelDigiErrorsSoA>"/>
+  <class name="PortableHostCollection<SiPixelDigiErrorsSoA>" rntupleStreamerMode="true"/>
   <!-- PortableHostCollection<SiPixelDigiErrorsSoA>::Layout must be listed before the aliased-to type -->
   <class name="PortableHostCollection<SiPixelDigiErrorsSoA>::Layout"/>
   <class name="SiPixelDigiErrorsSoA"/>

--- a/DataFormats/SiStripClusterSoA/src/classes_def.xml
+++ b/DataFormats/SiStripClusterSoA/src/classes_def.xml
@@ -2,6 +2,6 @@
   <!-- ::Layout alias must be listed before the aliased-to type -->
   <class name="sistrip::SiStripClusterHost::Layout"/>
   <class name="sistrip::SiStripClusterSoALayout<128,false>"/>
-  <class name="sistrip::SiStripClusterHost"/>
+  <class name="sistrip::SiStripClusterHost" rntupleStreamerMode="true"/>
   <class name="edm::Wrapper<sistrip::SiStripClusterHost>" splitLevel="0"/>
 </lcgdict>

--- a/DataFormats/SiStripDigiSoA/src/classes_def.xml
+++ b/DataFormats/SiStripDigiSoA/src/classes_def.xml
@@ -2,6 +2,6 @@
   <!-- ::Layout alias must be listed before the aliased-to type -->
   <class name="sistrip::SiStripDigiHost::Layout"/>
   <class name="sistrip::SiStripDigiSoALayout<128,false>"/>
-  <class name="sistrip::SiStripDigiHost"/>
+  <class name="sistrip::SiStripDigiHost" rntupleStreamerMode="true"/>
   <class name="edm::Wrapper<sistrip::SiStripDigiHost>" splitLevel="0"/>
 </lcgdict>


### PR DESCRIPTION
#### PR description:

Workflow 77.0 was failing in RNTuple RelVal tests in a way similar to https://github.com/cms-sw/cmssw/issues/49090 .

This PR adds the `rntupleStreamerMode="true"` attribute in `classes_def.xml` for all remaining `PortableHostCollection` and `PortableHostProduct` data products (so that they can be stored in RNTuple files without discovering them one at a time). the documentation in `DataFormats/Portable` is also updated

Resolves https://github.com/cms-sw/framework-team/issues/1799


#### PR validation:

Workflow 77.0 succeeds with `runTheMatrix.py --use-rntuple`.