### PR TITLE
Speed up reading `*Auxiliary` fields in RNTupleTempSource

### DIFF
--- a/FWIO/RNTupleTempInput/src/RootFile.cc
+++ b/FWIO/RNTupleTempInput/src/RootFile.cc
@@ -57,9 +57,6 @@
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 
 //used for backward compatibility
-#include "DataFormats/Provenance/interface/EventAux.h"
-#include "DataFormats/Provenance/interface/LuminosityBlockAux.h"
-#include "DataFormats/Provenance/interface/RunAux.h"
 #include "FWCore/ParameterSet/interface/ParameterSetConverter.h"
 
 #include "Rtypes.h"
@@ -1064,16 +1061,8 @@ namespace edm::rntuple_temp {
       // Already read.
       return eventAuxCache_;
     }
-    if (fileFormatVersion().newAuxiliary()) {
-      EventAuxiliary* pEvAux = &eventAuxCache_;
-      eventTree_.fillAux<EventAuxiliary>(pEvAux);
-    } else {
-      // for backward compatibility.
-      EventAux eventAux;
-      EventAux* pEvAux = &eventAux;
-      eventTree_.fillAux<EventAux>(pEvAux);
-      conversion(eventAux, eventAuxCache_);
-    }
+    EventAuxiliary* pEvAux = &eventAuxCache_;
+    eventTree_.fillAux<EventAuxiliary>(pEvAux);
     lastEventEntryNumberRead_ = eventTree_.entryNumber();
     return eventAuxCache_;
   }
@@ -1139,15 +1128,8 @@ namespace edm::rntuple_temp {
 
   std::shared_ptr<LuminosityBlockAuxiliary> RootFile::fillLumiAuxiliary() {
     auto lumiAuxiliary = std::make_shared<LuminosityBlockAuxiliary>();
-    if (fileFormatVersion().newAuxiliary()) {
-      LuminosityBlockAuxiliary* pLumiAux = lumiAuxiliary.get();
-      lumiTree_.fillAux<LuminosityBlockAuxiliary>(pLumiAux);
-    } else {
-      LuminosityBlockAux lumiAux;
-      LuminosityBlockAux* pLumiAux = &lumiAux;
-      lumiTree_.fillAux<LuminosityBlockAux>(pLumiAux);
-      conversion(lumiAux, *lumiAuxiliary);
-    }
+    LuminosityBlockAuxiliary* pLumiAux = lumiAuxiliary.get();
+    lumiTree_.fillAux<LuminosityBlockAuxiliary>(pLumiAux);
     if (daqProvenanceHelper_) {
       lumiAuxiliary->setProcessHistoryID(daqProvenanceHelper_->mapProcessHistoryID(lumiAuxiliary->processHistoryID()));
     }
@@ -1159,15 +1141,8 @@ namespace edm::rntuple_temp {
 
   std::shared_ptr<RunAuxiliary> RootFile::fillRunAuxiliary() {
     auto runAuxiliary = std::make_shared<RunAuxiliary>();
-    if (fileFormatVersion().newAuxiliary()) {
-      RunAuxiliary* pRunAux = runAuxiliary.get();
-      runTree_.fillAux<RunAuxiliary>(pRunAux);
-    } else {
-      RunAux runAux;
-      RunAux* pRunAux = &runAux;
-      runTree_.fillAux<RunAux>(pRunAux);
-      conversion(runAux, *runAuxiliary);
-    }
+    RunAuxiliary* pRunAux = runAuxiliary.get();
+    runTree_.fillAux<RunAuxiliary>(pRunAux);
     if (daqProvenanceHelper_) {
       runAuxiliary->setProcessHistoryID(daqProvenanceHelper_->mapProcessHistoryID(runAuxiliary->processHistoryID()));
     }

--- a/FWIO/RNTupleTempInput/src/RootRNTuple.h
+++ b/FWIO/RNTupleTempInput/src/RootRNTuple.h
@@ -10,6 +10,9 @@ RootRNTuple.h // used by ROOT input sources
 #include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/IndexIntoFile.h"
+#include "DataFormats/Provenance/interface/EventAuxiliary.h"
+#include "DataFormats/Provenance/interface/LuminosityBlockAuxiliary.h"
+#include "DataFormats/Provenance/interface/RunAuxiliary.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistryfwd.h"
 #include "FWCore/Utilities/interface/BranchType.h"
@@ -25,6 +28,7 @@ RootRNTuple.h // used by ROOT input sources
 #include <vector>
 #include <unordered_set>
 #include <unordered_map>
+#include <variant>
 
 #include "ROOT/RNTuple.hxx"
 #include "ROOT/RNTupleReader.hxx"
@@ -141,7 +145,11 @@ namespace edm::rntuple_temp {
     template <typename T>
     void fillAux(T*& pAux) {
       try {
-        auto view = reader_->GetView(auxDesc_, pAux);
+        if (std::holds_alternative<std::monostate>(auxView_)) {
+          auxView_ = reader_->GetView(auxDesc_, pAux);
+        }
+        auto& view = std::get<ROOT::RNTupleView<T>>(auxView_);
+        view.BindRawPtr(pAux);
         view(entryNumber_);
       } catch (cms::Exception const& e) {
         throw Exception(errors::FileReadError, "", e);
@@ -201,6 +209,11 @@ namespace edm::rntuple_temp {
     unsigned long treeAutoFlush_ = 0;
     bool promptRead_;
     std::unique_ptr<RootDelayedReaderBase> rootDelayedReader_;
+    std::variant<std::monostate,
+                 ROOT::RNTupleView<edm::EventAuxiliary>,
+                 ROOT::RNTupleView<edm::LuminosityBlockAuxiliary>,
+                 ROOT::RNTupleView<edm::RunAuxiliary>>
+        auxView_;
   };
 }  // namespace edm::rntuple_temp
 #endif


### PR DESCRIPTION
#### PR description:

In the context of https://github.com/cms-sw/cmssw/issues/48400 (but not as full resolution) this PR speeds up the initial reading of the `*Auxiliary` fields. With the input file in #48400 that had 2.5M tiny events, the initial read of `EventAuxiliary` went from 6.6 hours to ~1 second.

Resolves https://github.com/cms-sw/framework-team/issues/1785

#### PR validation:

Workflow 139.005 step3 starts much faster.