### PR TITLE
Fix calculation in VertexDistance3D.cc

### DIFF
--- a/RecoVertex/VertexTools/src/VertexDistance3D.cc
+++ b/RecoVertex/VertexTools/src/VertexDistance3D.cc
@@ -9,7 +9,7 @@ Measurement1D VertexDistance3D::signedDistance(const Vertex& vtx1,
   Measurement1D unsignedDistance = distance(vtx1, vtx2);
   Basic3DVector<float> diff = Basic3DVector<float>(vtx2.position()) - Basic3DVector<float>(vtx1.position());
   //   Basic3DVector<float> (vtx2 - vtx1);
-  if ((momentum.x() * diff.x() + momentum.y() * diff.y() * momentum.z() * diff.z()) < 0)
+  if ((momentum.x() * diff.x() + momentum.y() * diff.y() + momentum.z() * diff.z()) < 0)
     return Measurement1D(-1.0 * unsignedDistance.value(), unsignedDistance.error());
   return unsignedDistance;
 }


### PR DESCRIPTION
#### PR description:

Line 12 in RecoVertex/VertexTools/src/VertexDistance3D.cc, the decision of sign had wrong calculation:  momentum.x() * diff.x() + momentum.y() * diff.y() * momentum.z() * diff.z(). It is supposed to be addition of the components in 3 directions. The multiplication of y and z components was corrected to  momentum.x() * diff.x() + momentum.y() * diff.y() + momentum.z() * diff.z().

#### PR validation:

Build test was successful without error. runTheMatrix had the 190 tests passed and 7 failed.