### PR TITLE
[EVO] Disable tests in Alignment which read old files

### DIFF
--- a/Alignment/APEEstimation/test/BuildFile.xml
+++ b/Alignment/APEEstimation/test/BuildFile.xml
@@ -1,3 +1,3 @@
 <environment>
-  <test name="ApeTest" command="bash unitTest.sh"/>
+  <!-- <test name="ApeTest" command="bash unitTest.sh"/> COMMENT: reads old format files -->
 </environment>

--- a/Alignment/CommonAlignmentMonitor/test/BuildFile.xml
+++ b/Alignment/CommonAlignmentMonitor/test/BuildFile.xml
@@ -1,3 +1,3 @@
 <environment>
-  <test name="testAlignmentStats" command="testAlignmentStats.sh"/>
+  <!-- <test name="testAlignmentStats" command="testAlignmentStats.sh"/> COMMENT: reads old format file -->
 </environment>

--- a/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
@@ -11,7 +11,7 @@
   <use name="millepede"/>
 </test>
 
-<test name="test_MilleZmm" command="test_mille.sh"/>
+<!-- <test name="test_MilleZmm" command="test_mille.sh"/> COMMENT: reads old format file -->
 <test name="test_PedeCampaign" command="test_pede.sh"/>
 <test name="test_PedeConversion" command="test_pedeConversion.sh">
   <flags PRE_TEST="test_PedeCampaign"/>

--- a/Alignment/OfflineValidation/test/BuildFile.xml
+++ b/Alignment/OfflineValidation/test/BuildFile.xml
@@ -1,73 +1,73 @@
 <environment>
   <test name="validateAlignments" command="testingScripts/validateAlignments.sh"/>
-  <test name="DMRall" command="testingScripts/test_unitDMR.sh">
+  <!-- <test name="DMRall" command="testingScripts/test_unitDMR.sh"> COMMENT: reads old format file
     <flags PRE_TEST="validateAlignments"/>
-  </test>
-  <test name="PVall" command="testingScripts/test_unitPV.sh">
+  </test> -->
+  <!-- <test name="PVall" command="testingScripts/test_unitPV.sh"> COMMENT: reads old format file
     <flags PRE_TEST="validateAlignments"/>
-  </test>
-  <test name="Zmumuall" command="testingScripts/test_unitZmumu.sh">
+  </test> -->
+  <!-- <test name="Zmumuall" command="testingScripts/test_unitZmumu.sh"> COMMENT: reads old format file
     <flags PRE_TEST="validateAlignments"/>
-  </test>
-  <test name="SplitVall" command="testingScripts/test_unitSplitV.sh">
+  </test> -->
+  <!-- <test name="SplitVall" command="testingScripts/test_unitSplitV.sh"> COMMENT: reads old format file
     <flags PRE_TEST="validateAlignments"/>
-  </test>
-  <test name="JetHTall" command="testingScripts/test_unitJetHT.sh">
+  </test> -->
+  <!-- <test name="JetHTall" command="testingScripts/test_unitJetHT.sh"> COMMENT: reads old format file
     <flags PRE_TEST="validateAlignments"/>
-  </test>
+  </test> -->
   <test name="GCPall" command="testingScripts/test_unitGCP.sh">
     <flags PRE_TEST="validateAlignments"/>
   </test>
-  <test name="DiMuonVall" command="testingScripts/test_unitDiMuonV.sh">
+  <!-- <test name="DiMuonVall" command="testingScripts/test_unitDiMuonV.sh"> COMMENT: reads old format file
     <flags PRE_TEST="validateAlignments"/>
-  </test>
+  </test> -->
   <test name="MTSall" command="testingScripts/test_unitMTS.sh">
     <flags PRE_TEST="validateAlignments"/>
   </test>  
   <test name="PixBaryall" command="testingScripts/test_unitPixBary.sh">
     <flags PRE_TEST="validateAlignments"/>
   </test>
-  <test name="Genericall" command="testingScripts/test_unitGeneric.sh">
+  <!-- <test name="Genericall" command="testingScripts/test_unitGeneric.sh"> COMMENT: reads old format file
     <flags PRE_TEST="validateAlignments"/>
-  </test>
-  <test name="PVValidation" command="testingScripts/test_unitPVValidation.sh"/>
+  </test> -->
+  <!-- <test name="PVValidation" command="testingScripts/test_unitPVValidation.sh"/> COMMENT: reads old format file -->
   <bin file="testTrackAnalyzers.cc" name="testTrackAnalysis">
     <use name="FWCore/TestProcessor"/>
     <use name="catch2"/>
   </bin>
-  <test name="PrimaryVertex" command="testingScripts/test_unitPrimaryVertex.sh"/>
-  <bin file="testPVPlotting.cpp" name="testPVPlotting">
+  <!-- <test name="PrimaryVertex" command="testingScripts/test_unitPrimaryVertex.sh"/> COMMENT: reads old format file -->
+  <!-- <bin file="testPVPlotting.cpp" name="testPVPlotting"> COMMENT: dependent test disabled
     <flags PRE_TEST="PrimaryVertex"/>
     <use name="rootmath"/>
     <use name="roothistmatrix"/>
     <use name="rootgraphics"/>
     <use name="Alignment/OfflineValidation"/>
-  </bin>
+  </bin> -->
   <bin file="testTkAlStyle.C" name="testTkAlStyle">
     <use name="rootgraphics"/>
     <use name="Alignment/OfflineValidation"/>
   </bin>
-  <test name="DiMuonVertex" command="testingScripts/test_unitDiMuonVertex.sh"/>
-  <test name="DiElectronVertex" command="testingScripts/test_unitDiElectronVertex.sh"/>
+  <!-- <test name="DiMuonVertex" command="testingScripts/test_unitDiMuonVertex.sh"/> COMMENT: reads old format file -->
+  <!-- <test name="DiElectronVertex" command="testingScripts/test_unitDiElectronVertex.sh"/> COMMENT: reads old format file -->
   <test name="SubmitPVrbr" command="testingScripts/test_unitSubmitPVrbr.sh"/>
   <test name="SubmitPVsplit" command="testingScripts/test_unitSubmitPVsplit.sh"/>
-  <test name="EoP" command="testingScripts/test_unitEoP.sh"/>
-  <bin file="testEoPPlotting.cpp" name="testEoPPlotting">
+  <!-- <test name="EoP" command="testingScripts/test_unitEoP.sh"/> COMMENT: reads old format file -->
+  <!-- <bin file="testEoPPlotting.cpp" name="testEoPPlotting">
     <flags PRE_TEST="EoP"/>
     <use name="rootmath"/>
     <use name="roothistmatrix"/>
     <use name="rootgraphics"/>
     <use name="Alignment/OfflineValidation"/>
-  </bin>
-  <test name="Miscellanea" command="testingScripts/test_unitMiscellanea.sh"/>
-  <test name="ShortTrackValidation" command="testingScripts/test_unitShortTrackValidation.sh"/>
-  <test name="SagittaBiasNtuplizer" command="testingScripts/test_unitSagittaBiasNtuplizer.sh"/>
+  </bin> -->
+  <!-- <test name="Miscellanea" command="testingScripts/test_unitMiscellanea.sh"/> COMMENT: reads old format file -->
+  <!-- <test name="ShortTrackValidation" command="testingScripts/test_unitShortTrackValidation.sh"/> COMMENT: reads old format file -->
+  <!-- <test name="SagittaBiasNtuplizer" command="testingScripts/test_unitSagittaBiasNtuplizer.sh"/> COMMENT: reads old format file -->
   <test name="BeamSpotPlotting" command="testingScripts/test_unitBeamSpotPlotting.sh"/>
-  <bin file="testanalyzeDiMuonBiases.cpp" name="testDiMuonBiasesPlotting">
+  <!-- <bin file="testanalyzeDiMuonBiases.cpp" name="testDiMuonBiasesPlotting"> COMMENT: dependent test disabled
     <flags PRE_TEST="SagittaBiasNtuplizer"/>
     <use name="rootmath"/>
     <use name="roothistmatrix"/>
     <use name="rootgraphics"/>
     <use name="Alignment/OfflineValidation"/>
-  </bin>
+  </bin> -->
 </environment>


### PR DESCRIPTION
#### PR description:
Turn off tests which are failing because classes are now in versioned namespace.

#### PR validation:

Remaining tests in Alignment all passed in local area.

resolves https://github.com/cms-sw/framework-team/issues/1823