### PR TITLE
[EVO] Disable CalibTracker tests which read old files

### DIFF
--- a/CalibTracker/SiStripCommon/test/BuildFile.xml
+++ b/CalibTracker/SiStripCommon/test/BuildFile.xml
@@ -1,5 +1,5 @@
-<test name="testCalibTrackerSiStripCommonOneByOne" command="run_tests.sh"/>
-<test name="testCalibTrackerSiStripCommonAll" command="test_all.sh"/>
+<!-- <test name="testCalibTrackerSiStripCommonOneByOne" command="run_tests.sh"/> COMMENT: reads old format file -->
+<!-- <test name="testCalibTrackerSiStripCommonAll" command="test_all.sh"/> COMMENT: reads old format file -->
 
 <use name="CalibTracker/SiStripCommon"/>
 <library file="*.cc" name="CalibTrackerSiStripCommonTest">

--- a/CalibTracker/SiStripHitEfficiency/test/BuildFile.xml
+++ b/CalibTracker/SiStripHitEfficiency/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="testSiStripHitEfficiency" command="test_SiStripHitEfficiency.sh"/>
+<!-- <test name="testSiStripHitEfficiency" command="test_SiStripHitEfficiency.sh"/> COMMENT: reads old format file -->

--- a/CalibTracker/SiStripHitResolution/test/BuildFile.xml
+++ b/CalibTracker/SiStripHitResolution/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="testSiStripHitResolution" command="test_SiStripHitResolution.sh"/>
+<!-- <test name="testSiStripHitResolution" command="test_SiStripHitResolution.sh"/> COMMENT: reads old format file -->


### PR DESCRIPTION
#### PR description:

Disabled tests which required reading files holding classes with old names.

#### PR validation:

All tests are disabled so nothing runs in local build area.

resolves https://github.com/cms-sw/framework-team/issues/1824