### PR TITLE
[EVO] Disable HLTrigger tests which read old files

### DIFF
--- a/HLTrigger/Configuration/test/BuildFile.xml
+++ b/HLTrigger/Configuration/test/BuildFile.xml
@@ -1,5 +1,5 @@
 <!-- test access to EDM files used in HLT-AddOnTests and HLT-Validation tests -->
-<test name="testAccessToEDMInputsOfHLTTests" command="testAccessToEDMInputsOfHLTTests.sh"/>
+<!-- <test name="testAccessToEDMInputsOfHLTTests" command="testAccessToEDMInputsOfHLTTests.sh"/> COMMENT: reads old format files -->
 
 <!-- test script hltPrintMenuVersions
      enabled only for the x86-64 architecture, because the python module cx_Oracle

--- a/HLTrigger/HLTcore/test/BuildFile.xml
+++ b/HLTrigger/HLTcore/test/BuildFile.xml
@@ -11,7 +11,7 @@
 </bin>
 
 <!-- test the HLTPrescaleExample plugin -->
-<test name="testHLTPrescaleExample" command="testHLTPrescaleExample.sh"/>
+<!-- <test name="testHLTPrescaleExample" command="testHLTPrescaleExample.sh"/> COMMENT: reads old format file -->
 
 <!-- test EDAnalyzers using TriggerEvent and TriggerEventWithRefs -->
-<test name="testTriggerEventAnalyzers" command="testTriggerEventAnalyzers.sh"/>
+<!-- <test name="testTriggerEventAnalyzers" command="testTriggerEventAnalyzers.sh"/> COMMENT: reads old format file -->

--- a/HLTrigger/NGTScouting/test/BuildFile.xml
+++ b/HLTrigger/NGTScouting/test/BuildFile.xml
@@ -1,4 +1,4 @@
 <environment>
-  <test name="testProduceNanoHLT" command="testNanohltDQM.sh unitTest"/>
+  <!-- <test name="testProduceNanoHLT" command="testNanohltDQM.sh unitTest"/> COMMENT: reads old format file -->
 </environment>
 


### PR DESCRIPTION
#### PR description:

- The tests read files which contain data products where the type name now includes a version namespace.

#### PR validation:

All remaining tests in the packages pass.

resolves https://github.com/cms-sw/framework-team/issues/1825