### PR TITLE
[EVO] Disabled tests in PhysicsTools which read old files

### DIFF
--- a/PhysicsTools/NanoAOD/test/BuildFile.xml
+++ b/PhysicsTools/NanoAOD/test/BuildFile.xml
@@ -4,8 +4,8 @@
   <use name="catch2"/>
 </bin>
 
-<test name="test-btvNano-run" command="test-btvNano.sh"/>
-<test name="test-btvNano-runDY" command="test-btvNanoDY.sh"/>
-<test name="test-btvNano-check" command="test-btvNano.py">
+<!-- <test name="test-btvNano-run" command="test-btvNano.sh"/> COMMENT: reads old format files -->
+<!-- <test name="test-btvNano-runDY" command="test-btvNanoDY.sh"/> COMMENT: reads old format files -->
+<!-- <test name="test-btvNano-check" command="test-btvNano.py"> COMMENT: depends on disabled test 
   <flags PRE_TEST="test-btvNano-run"/>
-</test>
+</test> -->

--- a/PhysicsTools/PatAlgos/test/BuildFile.xml
+++ b/PhysicsTools/PatAlgos/test/BuildFile.xml
@@ -8,4 +8,4 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<test name="runtestPhysicsToolsPatAlgos" command="runtests.sh"/>
+<!-- <test name="runtestPhysicsToolsPatAlgos" command="runtests.sh"/> COMMENT: reads old format files -->

--- a/PhysicsTools/UtilAlgos/test/BuildFile.xml
+++ b/PhysicsTools/UtilAlgos/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="runtestUtilAlgos" command="runtests.sh"/>
+<!-- <test name="runtestUtilAlgos" command="runtests.sh"/> COMMENT: reads old format files -->


### PR DESCRIPTION
#### PR description:

The tests read files containing data products where the names were changed to include versioning namespace

#### PR validation:

Any remaining tests in the packages still pass.

resolves https://github.com/cms-sw/framework-team/issues/1827