### PR TITLE
[EVO] Disabled tests in TopEventProducers which read old files

### DIFF
--- a/TopQuarkAnalysis/TopEventProducers/test/BuildFile.xml
+++ b/TopQuarkAnalysis/TopEventProducers/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="runtestTqafTopEventProducers" command="runtests.sh"/>
+<!-- <test name="runtestTqafTopEventProducers" command="runtests.sh"/> COMMENT: reads old format files -->

--- a/TopQuarkAnalysis/TopEventSelection/test/BuildFile.xml
+++ b/TopQuarkAnalysis/TopEventSelection/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="runtestTqafTopEventSelection" command="runtests.sh"/>
+<!-- <test name="runtestTqafTopEventSelection" command="runtests.sh"/> COMMENT: reads old format files -->

--- a/TopQuarkAnalysis/TopHitFit/test/BuildFile.xml
+++ b/TopQuarkAnalysis/TopHitFit/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="runtestTqafTopHitFit" command="runtests.sh"/>
+<!-- <test name="runtestTqafTopHitFit" command="runtests.sh"/> COMMENT: reads old format files -->

--- a/TopQuarkAnalysis/TopJetCombination/test/BuildFile.xml
+++ b/TopQuarkAnalysis/TopJetCombination/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="runtestTqafTopJetCombination" command="runtests.sh"/>
+<!-- <test name="runtestTqafTopJetCombination" command="runtests.sh"/> COMMENT: reads old format files -->

--- a/TopQuarkAnalysis/TopKinFitter/test/BuildFile.xml
+++ b/TopQuarkAnalysis/TopKinFitter/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="runtestTqafTopKinFitter" command="runtests.sh"/>
+<!-- <test name="runtestTqafTopKinFitter" command="runtests.sh"/> COMMENT: reads old format files -->

--- a/TopQuarkAnalysis/TopSkimming/test/BuildFile.xml
+++ b/TopQuarkAnalysis/TopSkimming/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="runtestTqafTopSkimming" command="runtests.sh"/>
+<!-- <test name="runtestTqafTopSkimming" command="runtests.sh"/> COMMENT: reads old format files -->

--- a/TopQuarkAnalysis/TopTools/test/BuildFile.xml
+++ b/TopQuarkAnalysis/TopTools/test/BuildFile.xml
@@ -1,4 +1,4 @@
-<test name="runtestTqafTopTools" command="runtests.sh"/>
+<!-- <test name="runtestTqafTopTools" command="runtests.sh"/> COMMENT: reads old format files -->
 
 <library file="TestGenTtbarCategories.cc">
   <flags EDM_PLUGIN="1"/>


### PR DESCRIPTION
#### PR description:

The old files contain data products where the class names have changed to include a versioned namespace.

#### PR validation:

All tests in the packages have been disabled and in a test area no tests are run.

resolves https://github.com/cms-sw/framework-team/issues/1828