### PR TITLE
[EVO] Disable tests in Reco* sub-system which read old files

### DIFF
--- a/RecoBTag/FeatureTools/test/BuildFile.xml
+++ b/RecoBTag/FeatureTools/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="testRecoBTagInfoWithUnsubJets" command="cmsRun ${LOCALTOP}/src/RecoBTag/FeatureTools/test/u0_cfg.py"/>
+<!-- <test name="testRecoBTagInfoWithUnsubJets" command="cmsRun ${LOCALTOP}/src/RecoBTag/FeatureTools/test/u0_cfg.py"/> COMMENT: read old format file -->

--- a/RecoEcal/EgammaClusterProducers/test/BuildFile.xml
+++ b/RecoEcal/EgammaClusterProducers/test/BuildFile.xml
@@ -9,4 +9,4 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<test name="DRNTest" command="runtests.sh"/>
+<!-- <test name="DRNTest" command="runtests.sh"/> COMMENT: reads old format file -->

--- a/RecoEgamma/ElectronIdentification/test/BuildFile.xml
+++ b/RecoEgamma/ElectronIdentification/test/BuildFile.xml
@@ -8,4 +8,4 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<test name="runtestRecoEgammaElectronIdentification" command="runtests.sh"/>
+<!-- <test name="runtestRecoEgammaElectronIdentification" command="runtests.sh"/> COMMENT: reads old format file -->

--- a/RecoEgamma/PhotonIdentification/test/BuildFile.xml
+++ b/RecoEgamma/PhotonIdentification/test/BuildFile.xml
@@ -5,4 +5,4 @@
   <use name="RecoEgamma/PhotonIdentification"/>
 </bin>
 
-<test name="runtestRecoEgammaPhotonIdentification" command="runtests.sh"/>
+<!-- <test name="runtestRecoEgammaPhotonIdentification" command="runtests.sh"/> COMMENT: reads old format file -->

--- a/RecoMET/METProducers/test/BuildFile.xml
+++ b/RecoMET/METProducers/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="testRecoMETMETProducers" command="runtests.sh"/>
+<!-- <test name="testRecoMETMETProducers" command="runtests.sh"/> COMMENT: reads old format file -->

--- a/RecoPPS/Local/test/BuildFile.xml
+++ b/RecoPPS/Local/test/BuildFile.xml
@@ -1,3 +1,3 @@
 <test name="RecoPPSLocalNewT2" command="testNT2.sh"/>
-<test name="PPSReconstructionDefault" command="global_reco_PPS_test.sh"/>
+<!-- <test name="PPSReconstructionDefault" command="global_reco_PPS_test.sh"/> COMMENT: reads old format file -->
 <test name="PPSReconstructionStrips" command="global_reco_PPS_test_strips.sh"/>

--- a/RecoTauTag/RecoTau/test/BuildFile.xml
+++ b/RecoTauTag/RecoTau/test/BuildFile.xml
@@ -29,4 +29,4 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<test name="runtestRecoTauTagRecoTau" command="runtests.sh"/>
+<!-- <test name="runtestRecoTauTagRecoTau" command="runtests.sh"/> COMMENT: reads old format file -->

--- a/RecoTracker/TrackProducer/test/BuildFile.xml
+++ b/RecoTracker/TrackProducer/test/BuildFile.xml
@@ -30,4 +30,4 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<test name="testMuonTrackRefitting" command="testMuonTrackRefitting.sh"/>
+<!-- <test name="testMuonTrackRefitting" command="testMuonTrackRefitting.sh"/> COMMENT: reads old format file -->

--- a/RecoVertex/BeamSpotProducer/test/BuildFile.xml
+++ b/RecoVertex/BeamSpotProducer/test/BuildFile.xml
@@ -11,7 +11,7 @@
 
 <test name="testReadWriteBSFromDB" command="testReadWriteBSFromDB.sh"/>
 
-<test name="testBeamSpotCompatibilityEventData" command="testBeamSpotCompatibility.sh"/>
+<!-- <test name="testBeamSpotCompatibilityEventData" command="testBeamSpotCompatibility.sh"/> COMMENT: reads old format file -->
 
 <bin file="testBeamSpotAnalyzer.cc">
   <use name="FWCore/TestProcessor"/>


### PR DESCRIPTION
#### PR description:

The files contain data products which had their names change to include a versioning namespace.

#### PR validation:

The remaining tests in the packages pass.

resolves https://github.com/cms-sw/framework-team/issues/1830