### PR TITLE
[16.0.X] update run number used for `streamDQMGPUvsCPU` based client tests

### DIFF
--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -27,10 +27,10 @@
 <test name="TestDQMOnlineClient-sistrip_dqm_sourceclient" command="runtest.sh sistrip_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-sistrip_approx_dqm_sourceclient" command="runtest.sh sistrip_approx_dqm_sourceclient-live_cfg.py 362321 hi_run"/>
 <test name="TestDQMOnlineClient-onlinebeammonitor_dqm_sourceclient" command="runtest.sh onlinebeammonitor_dqm_sourceclient-live_cfg.py 381594 pp_run"/>
-<test name="TestDQMOnlineClient-ecalgpu_dqm_sourceclient" command="runtest.sh ecalgpu_dqm_sourceclient-live_cfg.py 397813"/>
-<test name="TestDQMOnlineClient-hcalgpu_dqm_sourceclient" command="runtest.sh hcalgpu_dqm_sourceclient-live_cfg.py 397813"/>
-<test name="TestDQMOnlineClient-pixelgpu_dqm_sourceclient" command="runtest.sh pixelgpu_dqm_sourceclient-live_cfg.py 397813"/>
-<test name="TestDQMOnlineClient-pfgpu_dqm_sourceclient" command="runtest.sh pfgpu_dqm_sourceclient-live_cfg.py 397813"/>
+<test name="TestDQMOnlineClient-ecalgpu_dqm_sourceclient" command="runtest.sh ecalgpu_dqm_sourceclient-live_cfg.py 398183"/>
+<test name="TestDQMOnlineClient-hcalgpu_dqm_sourceclient" command="runtest.sh hcalgpu_dqm_sourceclient-live_cfg.py 398183"/>
+<test name="TestDQMOnlineClient-pixelgpu_dqm_sourceclient" command="runtest.sh pixelgpu_dqm_sourceclient-live_cfg.py 398183"/>
+<test name="TestDQMOnlineClient-pfgpu_dqm_sourceclient" command="runtest.sh pfgpu_dqm_sourceclient-live_cfg.py 398183"/>
 <!-- streamDQMCalibration is required -->
 <!-- <test name="TestDQMOnlineClient-ecalcalib_dqm_sourceclient" command="runtest.sh ecalcalib_dqm_sourceclient-live_cfg.py" /> -->
 <!-- streamDQMCalibration is required -->


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/49898

#### PR description:

This in response to https://github.com/cms-sw/cmssw/issues/49892.
Update streamer files to include the change in data-format from https://github.com/cms-sw/cmssw/pull/49882#issuecomment-3794516703. 
Companion of `cms-data` PR https://github.com/cms-data/DQM-Integration/pull/17 (to be tested with https://github.com/cms-sw/cmsdist/pull/10295)

#### PR validation:

See master PR

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verabatim backport of https://github.com/cms-sw/cmssw/pull/49898