### PR TITLE
Multiple improvements to `HeterogeneousCore/MPICore`

### DIFF
--- a/HeterogeneousCore/MPICore/interface/api.h
+++ b/HeterogeneousCore/MPICore/interface/api.h
@@ -96,7 +96,7 @@ public:
     }
   }
 
-  // receive and object of type T, and deserialize it using its ROOT dictionary
+  // receive an object of type T, and deserialize it using its ROOT dictionary
   template <typename T>
   void receiveProduct(int instance, T& product) {
     if constexpr (std::is_fundamental_v<T>) {
@@ -131,7 +131,7 @@ private:
   void edmToBuffer_(EDM_MPI_LuminosityBlockAuxiliary_t& buffer, edm::LuminosityBlockAuxiliary const& aux);
   void edmToBuffer_(EDM_MPI_EventAuxiliary_t& buffer, edm::EventAuxiliary const& aux);
 
-  // dwserialize an EDM object from a simplified representation transmitted as an MPI message
+  // deserialize an EDM object from a simplified representation transmitted as an MPI message
   void edmFromBuffer_(EDM_MPI_RunAuxiliary_t const& buffer, edm::RunAuxiliary& aux);
   void edmFromBuffer_(EDM_MPI_LuminosityBlockAuxiliary_t const& buffer, edm::LuminosityBlockAuxiliary& aux);
   void edmFromBuffer_(EDM_MPI_EventAuxiliary_t const& buffer, edm::EventAuxiliary& aux);

--- a/HeterogeneousCore/MPICore/interface/messages.h
+++ b/HeterogeneousCore/MPICore/interface/messages.h
@@ -7,7 +7,7 @@
 // MPI headers
 #include <mpi.h>
 
-/* register the MPI message types forthe EDM communication
+/* register the MPI message types for the EDM communication
  */
 void EDM_MPI_build_types();
 

--- a/HeterogeneousCore/MPICore/interface/metadata.h
+++ b/HeterogeneousCore/MPICore/interface/metadata.h
@@ -21,18 +21,26 @@ enum ProductFlags : uint8_t {
   HasTrivialCopy = 1 << 2,
 };
 
+struct MetadataHeader {
+  int16_t productCount = 0;
+  uint8_t productFlags = 0;
+  int32_t serializedBufferSize = 0;
+};
+
+static_assert(sizeof(MetadataHeader) == 8, "Wrong MPI MetadataHeader size - expected to be 8 bytes.");
+
 struct ProductMetadata {
   enum class Kind : uint8_t { Missing = 0, Serialized = 1, TrivialCopy = 2 };
 
   Kind kind;
-  size_t sizeMeta = 0;
+  uint64_t sizeMeta = 0;
   const uint8_t* trivialCopyOffset = nullptr;  // Only valid if kind == TrivialCopy
 };
 
 class ProductMetadataBuilder {
 public:
   ProductMetadataBuilder();
-  explicit ProductMetadataBuilder(size_t productCount);
+  explicit ProductMetadataBuilder(int16_t productCount);
   ~ProductMetadataBuilder();
 
   // No copy
@@ -47,7 +55,7 @@ public:
   void reserve(size_t bytes);
 
   // set or reset number of products. will fail if not set called before sending
-  void setProductCount(size_t prod_num) { productCount_ = prod_num; }
+  void setProductCount(int16_t prod_num) { header_.productCount = prod_num; }
   void setHeader();
 
   // Sender API
@@ -67,11 +75,11 @@ public:
   // Please make sure that ProductMetadataBuilder lives longer than returned ProductMetadata
   ProductMetadata getNext();
 
-  int64_t productCount() const { return productCount_; }
-  int64_t serializedBufferSize() const { return serializedBufferSize_; }
-  bool hasMissing() const { return productFlags_ & HasMissing; }
-  bool hasSerialized() const { return productFlags_ & HasSerialized; }
-  bool hasTrivialCopy() const { return productFlags_ & HasTrivialCopy; }
+  int16_t productCount() const { return header_.productCount; }
+  int32_t serializedBufferSize() const { return header_.serializedBufferSize; }
+  bool hasMissing() const { return header_.productFlags & HasMissing; }
+  bool hasSerialized() const { return header_.productFlags & HasSerialized; }
+  bool hasTrivialCopy() const { return header_.productFlags & HasTrivialCopy; }
 
   void debugPrintMetadataSummary() const;
 
@@ -80,11 +88,9 @@ private:
   size_t capacity_;
   size_t size_;
   size_t readOffset_;
-  const size_t headerSize_ = 13;         // fixed header that stores global info (count, flags, serialized size)
   const size_t maxMetadataSize_ = 1024;  // default size for buffer initialization. Must fit any metadata
-  int serializedBufferSize_ = 0;
-  uint8_t productFlags_ = 0;
-  int64_t productCount_ = 0;
+  MetadataHeader header_;
+  static constexpr size_t headerSize_ = sizeof(header_);
 
   void resizeBuffer(size_t newCap);
   void ensureCapacity(size_t needed);

--- a/HeterogeneousCore/MPICore/interface/metadata.h
+++ b/HeterogeneousCore/MPICore/interface/metadata.h
@@ -80,8 +80,8 @@ private:
   size_t capacity_;
   size_t size_;
   size_t readOffset_;
-  const size_t headerSize_ = 13;  // header is always present in the metadata object do describe products in general
-  const size_t maxMetadataSize_ = 1024;  // default size for buffer initialization. must fit any metadata
+  const size_t headerSize_ = 13;         // fixed header that stores global info (count, flags, serialized size)
+  const size_t maxMetadataSize_ = 1024;  // default size for buffer initialization. Must fit any metadata
   int serializedBufferSize_ = 0;
   uint8_t productFlags_ = 0;
   int64_t productCount_ = 0;

--- a/HeterogeneousCore/MPICore/plugins/MPIReceiver.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPIReceiver.cc
@@ -112,7 +112,7 @@ public:
       else if (product_meta.kind == ProductMetadata::Kind::Serialized) {
         std::unique_ptr<edm::WrapperBase> wrapper(
             reinterpret_cast<edm::WrapperBase*>(entry.wrappedType.getClass()->New()));
-        assert(static_cast<int64_t>(serialized_buffer->Length() + product_meta.sizeMeta) <=
+        assert(static_cast<int32_t>(serialized_buffer->Length() + product_meta.sizeMeta) <=
                    received_meta_->serializedBufferSize() &&
                "serialized data buffer is shorter than expected");
         entry.wrappedType.getClass()->Streamer(wrapper.get(), *serialized_buffer);

--- a/HeterogeneousCore/MPICore/plugins/MPIReceiver.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPIReceiver.cc
@@ -63,7 +63,7 @@ public:
   void acquire(edm::Event const& event, edm::EventSetup const&, edm::WaitingTaskWithArenaHolder holder) final {
     const MPIToken& token = event.get(upstream_);
 
-    //also try unique or optional
+    // also try unique or optional
     received_meta_ = std::make_shared<ProductMetadataBuilder>();
 
     edm::Service<edm::Async> as;
@@ -114,7 +114,6 @@ public:
         std::unique_ptr<edm::WrapperBase> wrapper(
             reinterpret_cast<edm::WrapperBase*>(entry.wrappedType.getClass()->New()));
         auto productBuffer = TBufferFile(TBuffer::kRead, product_meta.sizeMeta);
-        // assert(!wrapper->hasTrivialCopyTraits() && "mismatch between expected and actual metadata type");
         assert(buffer_offset < serialized_buffer->BufferSize() && "serialized data buffer is shorter than expected");
         productBuffer.SetBuffer(serialized_buffer->Buffer() + buffer_offset, product_meta.sizeMeta, false);
         buffer_offset += product_meta.sizeMeta;
@@ -124,7 +123,6 @@ public:
       }
 
       else if (product_meta.kind == ProductMetadata::Kind::TrivialCopy) {
-        // assert(wrapper->hasTrivialCopyTraits() && "mismatch between expected and actual metadata type");
         std::unique_ptr<ngt::SerialiserBase> serialiser =
             ngt::SerialiserFactory::get()->tryToCreate(entry.type.typeInfo().name());
         if (not serialiser) {
@@ -134,7 +132,6 @@ public:
         ngt::AnyBuffer buffer = writer->uninitialized_parameters();  // constructs buffer with typeid
         assert(buffer.size_bytes() == product_meta.sizeMeta);
         std::memcpy(buffer.data(), product_meta.trivialCopyOffset, product_meta.sizeMeta);
-        // why both of these methods are called initialize? I find this rather confusing
         writer->initialize(buffer);
         token.channel()->receiveInitializedTrivialCopy(instance_, *writer);
         writer->finalize();
@@ -167,12 +164,12 @@ public:
         ->setComment(
             "MPI communication channel. Can be an \"MPIController\", \"MPISource\", \"MPISender\" or \"MPIReceiver\". "
             "Passing an \"MPIController\" or \"MPISource\" only identifies the pair of local and remote application "
-            "that communicate. Passing an \"MPISender\" or \"MPIReceiver\" in addition in addition imposes a "
-            "scheduling dependency.");
+            "that communicate. Passing an \"MPISender\" or \"MPIReceiver\" in addition imposes a scheduling "
+            "dependency.");
     desc.addVPSet("products", product, {})
         ->setComment("Products to be received by a separate CMSSW job and produced into the event.");
     desc.add<int32_t>("instance", 0)
-        ->setComment("A value between 1 and 255 used to identify a matching pair of \"MPISender\"/\"MPIRecevier\".");
+        ->setComment("A value between 1 and 255 used to identify a matching pair of \"MPISender\"/\"MPIReceiver\".");
 
     descriptions.addWithDefaultLabel(desc);
   }

--- a/HeterogeneousCore/MPICore/plugins/MPIReceiver.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPIReceiver.cc
@@ -87,7 +87,6 @@ public:
       return;
     }
 
-    int buffer_offset = 0;
     std::unique_ptr<TBufferFile> serialized_buffer;
     if (received_meta_->hasSerialized()) {
       serialized_buffer = token.channel()->receiveSerializedBuffer(instance_, received_meta_->serializedBufferSize());
@@ -95,7 +94,7 @@ public:
       {
         edm::LogSystem msg("MPISender");
         msg << "Received serialised product:\n";
-        for (int i = 0; i < serialized_buffer->Length(); ++i) {
+        for (int i = 0; i < received_meta_->serializedBufferSize(); ++i) {
           msg << "0x" << std::hex << std::setw(2) << std::setfill('0')
               << (unsigned int)(unsigned char)serialized_buffer->Buffer()[i] << (i % 16 == 15 ? '\n' : ' ');
         }
@@ -113,11 +112,10 @@ public:
       else if (product_meta.kind == ProductMetadata::Kind::Serialized) {
         std::unique_ptr<edm::WrapperBase> wrapper(
             reinterpret_cast<edm::WrapperBase*>(entry.wrappedType.getClass()->New()));
-        auto productBuffer = TBufferFile(TBuffer::kRead, product_meta.sizeMeta);
-        assert(buffer_offset < serialized_buffer->BufferSize() && "serialized data buffer is shorter than expected");
-        productBuffer.SetBuffer(serialized_buffer->Buffer() + buffer_offset, product_meta.sizeMeta, false);
-        buffer_offset += product_meta.sizeMeta;
-        entry.wrappedType.getClass()->Streamer(wrapper.get(), productBuffer);
+        assert(static_cast<int64_t>(serialized_buffer->Length() + product_meta.sizeMeta) <=
+                   received_meta_->serializedBufferSize() &&
+               "serialized data buffer is shorter than expected");
+        entry.wrappedType.getClass()->Streamer(wrapper.get(), *serialized_buffer);
         // put the data into the Event
         event.put(entry.token, std::move(wrapper));
       }
@@ -141,7 +139,7 @@ public:
     }
 
     if (received_meta_->hasSerialized()) {
-      assert(buffer_offset == received_meta_->serializedBufferSize() &&
+      assert(serialized_buffer->Length() == received_meta_->serializedBufferSize() &&
              "serialized data buffer is not equal to the expected length");
     }
 

--- a/HeterogeneousCore/MPICore/plugins/MPISender.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPISender.cc
@@ -103,11 +103,10 @@ public:
 
   void acquire(edm::Event const& event, edm::EventSetup const&, edm::WaitingTaskWithArenaHolder holder) final {
     const MPIToken& token = event.get(upstream_);
-    // we need 1 byte for type, 8 bytes for size, and at least 8 bytes for MemoryCopyTraits Properties buffer
-    auto meta = std::make_shared<ProductMetadataBuilder>(products_.size() * 24);
+    // pass the number of products to estimate the right size for the metadata buffer
+    auto meta = std::make_shared<ProductMetadataBuilder>(products_.size());
     size_t index = 0;
     buffer_->Reset();
-    meta->setProductCount(products_.size());
     has_serialized_ = false;
     is_active_ = true;
 

--- a/HeterogeneousCore/MPICore/plugins/MPISender.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPISender.cc
@@ -104,18 +104,14 @@ public:
 
   void acquire(edm::Event const& event, edm::EventSetup const&, edm::WaitingTaskWithArenaHolder holder) final {
     const MPIToken& token = event.get(upstream_);
-    // we need 1 byte for type, 8 bytes for size and at least 8 bytes for trivial copy parameters buffer
+    // we need 1 byte for type, 8 bytes for size, and at least 8 bytes for MemoryCopyTraits Properties buffer
     auto meta = std::make_shared<ProductMetadataBuilder>(products_.size() * 24);
     size_t index = 0;
-    // this seems to work fine, but does this vector indeed persist between acquire() and produce()?
-    // serializedBuffers_.clear();
     buffer_->Reset();
     buffer_offset_ = 0;
     meta->setProductCount(products_.size());
     has_serialized_ = false;
     is_active_ = true;
-
-    // estimate buffer size in the constructor
 
     for (auto const& entry : products_) {
       // Get the product
@@ -218,15 +214,15 @@ public:
         ->setComment(
             "MPI communication channel. Can be an \"MPIController\", \"MPISource\", \"MPISender\" or \"MPIReceiver\". "
             "Passing an \"MPIController\" or \"MPISource\" only identifies the pair of local and remote application "
-            "that communicate. Passing an \"MPISender\" or \"MPIReceiver\" in addition in addition imposes a "
-            "scheduling dependency.");
+            "that communicate. Passing an \"MPISender\" or \"MPIReceiver\" in addition imposes a scheduling "
+            "dependency.");
     desc.add<std::vector<std::string>>("products", {})
         ->setComment(
             "Event products to be consumed and copied over to a separate CMSSW job. Can be a list of module labels, "
             "branch names (similar to an OutputModule's \"keep ...\" statement), or a mix of the two. Wildcards (\"?\" "
             "and \"*\") are allowed in a module label or in each field of a branch name.");
     desc.add<int32_t>("instance", 0)
-        ->setComment("A value between 1 and 255 used to identify a matching pair of \"MPISender\"/\"MPIRecevier\".");
+        ->setComment("A value between 1 and 255 used to identify a matching pair of \"MPISender\"/\"MPIReceiver\".");
 
     descriptions.addWithDefaultLabel(desc);
   }

--- a/HeterogeneousCore/MPICore/src/api.cc
+++ b/HeterogeneousCore/MPICore/src/api.cc
@@ -197,8 +197,6 @@ std::unique_ptr<TBufferFile> MPIChannel::receiveSerializedBuffer(int instance, i
   int receivedCount = 0;
   MPI_Get_count(&status, MPI_BYTE, &receivedCount);
   assert(receivedCount == bufSize && "received serialized buffer size mismatches the size expected from metadata");
-  // set the buffer length
-  buffer->SetBufferOffset(receivedCount);
   return buffer;
 }
 

--- a/HeterogeneousCore/MPICore/src/macros.h
+++ b/HeterogeneousCore/MPICore/src/macros.h
@@ -136,10 +136,10 @@ namespace mpi_traits {
   _Pragma("GCC diagnostic push");                                                                   \
   _Pragma("GCC diagnostic ignored \"-Winvalid-offsetof\"");                                         \
   {                                                                                                 \
-    constexpr int lenghts[] = {_GET_MPI_TYPE_LENGTHS(STRUCT, __VA_ARGS__)};                         \
+    constexpr int lengths[] = {_GET_MPI_TYPE_LENGTHS(STRUCT, __VA_ARGS__)};                         \
     constexpr MPI_Aint displacements[] = {_GET_MPI_TYPE_OFFSETS(STRUCT, __VA_ARGS__)};              \
     const MPI_Datatype types[] = {_GET_MPI_TYPE_TYPEIDS(STRUCT, __VA_ARGS__)};                      \
-    MPI_Type_create_struct(std::size(lenghts), lenghts, displacements, types, &TYPE);               \
+    MPI_Type_create_struct(std::size(lengths), lengths, displacements, types, &TYPE);               \
     MPI_Type_commit(&TYPE);                                                                         \
   }                                                                                                 \
   _Pragma("GCC diagnostic pop")

--- a/HeterogeneousCore/MPICore/src/metadata.cc
+++ b/HeterogeneousCore/MPICore/src/metadata.cc
@@ -83,7 +83,7 @@ std::span<const uint8_t> ProductMetadataBuilder::buffer() const { return {buffer
 void ProductMetadataBuilder::receiveMetadata(int src, int tag, MPI_Comm comm) {
   MPI_Status status;
   MPI_Recv(buffer_, maxMetadataSize_, MPI_BYTE, src, tag, comm, &status);
-  //add error hadling if message too long
+  // add error handling if message is too long
   int receivedBytes = 0;
   MPI_Get_count(&status, MPI_BYTE, &receivedBytes);
   assert(static_cast<size_t>(receivedBytes) >= headerSize_ && "received metadata was less than header size");

--- a/HeterogeneousCore/MPICore/src/metadata.cc
+++ b/HeterogeneousCore/MPICore/src/metadata.cc
@@ -12,9 +12,12 @@ ProductMetadataBuilder::ProductMetadataBuilder() : buffer_(nullptr), capacity_(0
   size_ = headerSize_;
 }
 
-ProductMetadataBuilder::ProductMetadataBuilder(size_t expectedSize)
+ProductMetadataBuilder::ProductMetadataBuilder(int16_t productCount)
     : buffer_(nullptr), capacity_(0), size_(0), readOffset_(0) {
-  reserve(expectedSize + headerSize_);
+  // we need 1 byte for type, 8 bytes for size, and at least 8 bytes for MemoryCopyTraits Properties buffer
+  // on average 24 bytes per product should be enough, but metadata will adapt if the actual contents is larger
+  reserve(productCount * 24 + headerSize_);
+  header_.productCount = static_cast<int16_t>(productCount);
   size_ = headerSize_;
 }
 
@@ -51,27 +54,25 @@ void ProductMetadataBuilder::reserve(size_t bytes) {
 
 void ProductMetadataBuilder::setHeader() {
   assert(size_ >= headerSize_ && "Buffer must reserve space for header");
-  std::memcpy(buffer_, &productCount_, sizeof(int64_t));          // first 8 bytes
-  buffer_[8] = productFlags_;                                     // indicate which products are present
-  std::memcpy(buffer_ + 9, &serializedBufferSize_, sizeof(int));  // size of serialized products
+  std::memcpy(buffer_, &header_, sizeof(header_));
 }
 
 void ProductMetadataBuilder::addMissing() {
-  productFlags_ |= HasMissing;
+  header_.productFlags |= HasMissing;
   append<uint8_t>(static_cast<uint8_t>(ProductMetadata::Kind::Missing));
 }
 
-void ProductMetadataBuilder::addSerialized(size_t size) {
-  productFlags_ |= HasSerialized;
+void ProductMetadataBuilder::addSerialized(uint64_t size) {
+  header_.productFlags |= HasSerialized;
   append<uint8_t>(static_cast<uint8_t>(ProductMetadata::Kind::Serialized));
-  append<size_t>(size);
-  serializedBufferSize_ += size;
+  append<uint64_t>(size);
+  header_.serializedBufferSize += static_cast<int32_t>(size);
 }
 
-void ProductMetadataBuilder::addTrivialCopy(const std::byte* buffer, size_t size) {
-  productFlags_ |= HasTrivialCopy;
+void ProductMetadataBuilder::addTrivialCopy(const std::byte* buffer, uint64_t size) {
+  header_.productFlags |= HasTrivialCopy;
   append<uint8_t>(static_cast<uint8_t>(ProductMetadata::Kind::TrivialCopy));
-  append<size_t>(size);
+  append<uint64_t>(size);
   appendBytes(buffer, size);
 }
 
@@ -83,14 +84,13 @@ std::span<const uint8_t> ProductMetadataBuilder::buffer() const { return {buffer
 void ProductMetadataBuilder::receiveMetadata(int src, int tag, MPI_Comm comm) {
   MPI_Status status;
   MPI_Recv(buffer_, maxMetadataSize_, MPI_BYTE, src, tag, comm, &status);
-  // add error handling if message is too long
+  // add error handling if message is too long (quite unlikely to happen so far)
   int receivedBytes = 0;
   MPI_Get_count(&status, MPI_BYTE, &receivedBytes);
   assert(static_cast<size_t>(receivedBytes) >= headerSize_ && "received metadata was less than header size");
-  productCount_ = consume<int64_t>();
-  productFlags_ = consume<ProductFlags>();
-  serializedBufferSize_ = consume<int>();
+  memcpy(&header_, buffer_, sizeof(header_));
   size_ = receivedBytes;
+  readOffset_ = headerSize_;
 }
 
 ProductMetadata ProductMetadataBuilder::getNext() {
@@ -106,11 +106,11 @@ ProductMetadata ProductMetadataBuilder::getNext() {
       break;
 
     case ProductMetadata::Kind::Serialized:
-      meta.sizeMeta = consume<size_t>();
+      meta.sizeMeta = consume<uint64_t>();
       break;
 
     case ProductMetadata::Kind::TrivialCopy: {
-      size_t blobSize = consume<size_t>();
+      uint64_t blobSize = consume<uint64_t>();
       if (readOffset_ + blobSize > size_) {
         throw std::runtime_error("Metadata buffer too short for trivialCopy data");
       }
@@ -157,31 +157,50 @@ void ProductMetadataBuilder::appendBytes(const std::byte* src, size_t size) {
 }
 
 void ProductMetadataBuilder::debugPrintMetadataSummary() const {
-  if (size_ < headerSize_) {
-    std::cerr << "ERROR: Buffer too small to contain header\n";
+  if (size_ < sizeof(MetadataHeader)) {
+    std::cerr << "ERROR: Buffer too small to contain metadata header\n";
     return;
   }
 
   std::ostringstream out;
-  size_t offset = headerSize_;  // Skip the header
+  size_t offset = 0;
+
+  // --- Read header fields explicitly ---
+  MetadataHeader header;
+  std::memcpy(&header, buffer_, sizeof(MetadataHeader));
+  offset += sizeof(MetadataHeader);
+
+  out << "---- ProductMetadata Debug Summary ----\n";
+  out << "Header:\n";
+  out << "  Product count:           " << header.productCount << "\n";
+  out << "  Serialized buffer size:  " << header.serializedBufferSize << " bytes\n";
+  out << "  Flags:";
+  if (header.productFlags & HasMissing)
+    out << " Missing";
+  if (header.productFlags & HasSerialized)
+    out << " Serialized";
+  if (header.productFlags & HasTrivialCopy)
+    out << " TrivialCopy";
+  out << "\n\n";
+
+  // --- Parse product entries ---
   size_t count = 0;
   size_t numMissing = 0;
   size_t numSerialized = 0;
   size_t numTrivial = 0;
 
-  uint64_t headerCount = 0;
-  std::memcpy(&headerCount, buffer_, sizeof(uint64_t));
-  uint8_t flags = buffer_[sizeof(uint64_t)];
-
-  out << "---- ProductMetadata Debug Summary ----\n";
-  out << "Header:\n";
-  out << "  Product count:  " << headerCount << "\n";
-  out << "  Flags: " << ((flags & HasMissing) ? "Missing " : "") << ((flags & HasSerialized) ? "Serialized " : "")
-      << ((flags & HasTrivialCopy) ? "TrivialCopy " : "") << "\n\n";
-
   while (offset < size_) {
-    uint8_t kindVal = buffer_[offset];
-    auto kind = static_cast<ProductMetadata::Kind>(kindVal);
+    if (count >= static_cast<size_t>(header.productCount)) {
+      out << "WARNING: More metadata entries than header.productCount\n";
+      break;
+    }
+
+    if (offset + sizeof(uint8_t) > size_) {
+      out << "ERROR: Truncated metadata entry\n";
+      break;
+    }
+
+    auto kind = static_cast<ProductMetadata::Kind>(buffer_[offset]);
     offset += sizeof(uint8_t);
     count++;
 
@@ -198,7 +217,7 @@ void ProductMetadataBuilder::debugPrintMetadataSummary() const {
           out << "ERROR: Corrupted serialized metadata\n";
           return;
         }
-        size_t sz;
+        size_t sz = 0;
         std::memcpy(&sz, buffer_ + offset, sizeof(size_t));
         offset += sizeof(size_t);
         numSerialized++;
@@ -208,14 +227,15 @@ void ProductMetadataBuilder::debugPrintMetadataSummary() const {
 
       case ProductMetadata::Kind::TrivialCopy: {
         if (offset + sizeof(size_t) > size_) {
-          out << "ERROR: Corrupted trivial copy metadata\n";
+          out << "ERROR: Corrupted trivial-copy metadata\n";
           return;
         }
-        size_t sz;
+        size_t sz = 0;
         std::memcpy(&sz, buffer_ + offset, sizeof(size_t));
         offset += sizeof(size_t);
+
         if (offset + sz > size_) {
-          out << "ERROR: Trivial copy data overflows buffer\n";
+          out << "ERROR: Trivial-copy data overflows buffer\n";
           return;
         }
         offset += sz;
@@ -225,17 +245,21 @@ void ProductMetadataBuilder::debugPrintMetadataSummary() const {
       }
 
       default:
-        out << "Unknown kind: " << static_cast<int>(kindVal) << "\n";
+        out << "ERROR: Unknown product kind " << static_cast<int>(kind) << "\n";
         return;
     }
   }
 
-  out << "----------------------------------------\n";
+  if (count != static_cast<size_t>(header.productCount)) {
+    out << "\nWARNING: Parsed " << count << " entries, but header says " << header.productCount << "\n";
+  }
+
+  out << "\n----------------------------------------\n";
   out << "Total entries parsed:   " << count << "\n";
   out << "  Missing:              " << numMissing << "\n";
   out << "  Serialized:           " << numSerialized << "\n";
   out << "  TrivialCopy:          " << numTrivial << "\n";
-  out << "Total buffer size:      " << size_ << " bytes\n";
+  out << "Total metadata size:    " << size_ << " bytes\n";
 
   std::cerr << out.str() << std::flush;
 }

--- a/HeterogeneousCore/MPICore/test/BuildFile.xml
+++ b/HeterogeneousCore/MPICore/test/BuildFile.xml
@@ -9,6 +9,8 @@
 
 <test name="testMPIComplexTransfer" command="testMPICommWorld.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/controller_complex_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_complex_cfg.py"/>
 
+<test name="testMPIFilters" command="testMPICommWorld.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/controller_filters_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_filters_cfg.py"/>
+
 <bin name="testSerialisation" file="testSerialisation.cc">
     <use name="root"/>
 </bin>

--- a/HeterogeneousCore/MPICore/test/controller_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_cfg.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("MPIServer")
+process = cms.Process("MPIController")
 
 process.options.numberOfThreads = 4
 process.options.numberOfStreams = 4

--- a/HeterogeneousCore/MPICore/test/controller_complex_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_complex_cfg.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("MPIServer")
+process = cms.Process("MPIController")
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.INFO.limit = 10000000

--- a/HeterogeneousCore/MPICore/test/controller_filters_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_filters_cfg.py
@@ -1,0 +1,115 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("MPIController")
+
+process.options.numberOfThreads = 4
+process.options.numberOfStreams = 4
+# MPIController supports a single concurrent LuminosityBlock
+process.options.numberOfConcurrentLuminosityBlocks = 1
+process.options.numberOfConcurrentRuns = 1
+process.options.wantSummary = False
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1
+
+process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+
+from eventlist_cff import eventlist
+process.source = cms.Source("EmptySourceFromEventIDs",
+    events = cms.untracked(eventlist)
+)
+
+process.maxEvents.input = 30
+
+from HeterogeneousCore.MPICore.modules import MPIController, MPISender, MPIReceiver
+
+process.mpiController = MPIController(
+    mode = 'CommWorld'
+)
+
+# Produce EventID, that will be sent to the Follower
+process.eventIDProducer = cms.EDProducer("edmtest::EventIDProducer")
+
+# Send the EventID to the Follower. The Follower will run a ModuloEventIDFilter
+# and send back the results.
+process.sender = MPISender(
+    upstream = "mpiController",
+    instance = 42,
+    products = [ "edmEventID_eventIDProducer__*" ]
+)
+
+# Receive a PathStateToken back from the Follower. This token will be present if
+# the remore filter passed, and missing otherwise (see follower_filters_cfg.py for
+# details)
+process.receiver = MPIReceiver(
+    upstream = "sender",
+    instance = 99,
+    products = [
+        dict(
+            type = "edm::PathStateToken",
+            label = "remoteCapture"
+        )
+    ]
+)
+
+# The PathStateRelease module below is a filter that will pass if the
+# edm::PathStateToken above is present, and will not pass otherwise.
+from FWCore.Modules.modules import PathStateRelease
+process.remoteRelease = PathStateRelease(
+    state = cms.InputTag("receiver", "remoteCapture")
+)
+
+# The Follower runs "ModuloEventIDFilter" which accepts only events where (event
+# number % `modulo` == 0). This is configured in follower_filters_cfg.py. In order
+# to replicate the remote filtering locally, the same `modulo` value must be used
+# here.
+modulo = 3
+
+# Controller runs the same filter locally
+process.localFilter = cms.EDFilter("ModuloEventIDFilter",
+    modulo = cms.uint32(modulo),
+    offset = cms.uint32(0)
+)
+
+# Local filter path
+process.localFilterPath = cms.Path(
+    process.localFilter        # Apply the eventID filter locally
+)
+
+process.controllerPath = cms.Path(
+    process.mpiController +    # Set up the MPI communication
+    process.eventIDProducer +  # Produce EventID
+    process.sender +           # Send EventID to the Follower
+    process.receiver           # Receive PathStateToken back from the Follower
+)
+
+# Path that will pass (fail) if the remote filter path passed (failed)
+process.remoteFilterPath = cms.Path(
+    process.remoteRelease
+)
+
+
+# Compare local filter path and remote filter path. The outcome of these paths
+# should be the same.
+from FWCore.Modules.modules import PathStatusFilter
+process.compare = PathStatusFilter(
+    logicalExpression = '(localFilterPath and remoteFilterPath) or (not localFilterPath and not remoteFilterPath)'
+)
+
+process.validatePath = cms.Path(
+    process.compare
+)
+
+# Verify that all events passed the comparison
+from FWCore.Framework.modules import SewerModule
+process.require = SewerModule(
+    name = cms.string('require'),
+    shouldPass = process.maxEvents.input.value(),
+    SelectEvents = dict(
+        SelectEvents = 'validatePath'
+    )
+)
+
+process.endpath = cms.EndPath(
+    process.require
+)

--- a/HeterogeneousCore/MPICore/test/controller_soa_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_soa_cfg.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("MPIServer")
+process = cms.Process("MPIController")
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.INFO.limit = 10000000

--- a/HeterogeneousCore/MPICore/test/follower_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_cfg.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("MPIClient")
+process = cms.Process("MPIFollower")
 
 process.options.numberOfThreads = 8
 process.options.numberOfStreams = 8

--- a/HeterogeneousCore/MPICore/test/follower_complex_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_complex_cfg.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("MPIClient")
+process = cms.Process("MPIFollower")
 
 process.options.numberOfThreads = 4
 process.options.numberOfStreams = 4

--- a/HeterogeneousCore/MPICore/test/follower_filters_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_filters_cfg.py
@@ -1,0 +1,64 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("MPIFollower")
+
+process.options.numberOfThreads = 4
+process.options.numberOfStreams = 4
+process.options.numberOfConcurrentLuminosityBlocks = 2
+process.options.numberOfConcurrentRuns = 2
+process.options.wantSummary = False
+
+process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+
+from HeterogeneousCore.MPICore.modules import MPISource, MPIReceiver, MPISender
+
+process.source = MPISource()
+
+process.maxEvents.input = -1
+
+# Receive EventIDs from the Controller
+process.receiver = MPIReceiver(
+    upstream = "source",
+    instance = 42,
+    products = [ dict(
+        type = "edm::EventID",
+        label = ""
+    )]
+)
+
+# Filter that accepts events whose eventID % `modulo` == 0
+modulo = 3
+process.remoteFilter = cms.EDFilter("ModuloEventIDFilter",
+    modulo = cms.uint32(modulo),
+    offset = cms.uint32(0)
+)
+
+# This producer will be scheduled after the filter above, and will produce a
+# `edm::PathStateToken` if the filter passes. If filter does not pass, this module
+# will not run, and MPISender will detect the missing token.
+from FWCore.Modules.modules import PathStateCapture
+process.remoteCapture = PathStateCapture()
+
+# Send back the PathStateToken to the Controller. Filtered-out events will be
+# detected by MPISender because for them, the PathStateToken will be missing. When
+# sending the metadata of such events, the MPISender will set `productCount = -1`
+# to indicate that the event was filtered out.
+process.sender = MPISender(
+    upstream = "receiver",
+    instance = 99,
+    products = [
+        "edmPathStateToken_remoteCapture__*"
+    ]
+)
+
+# Path for the filter (+ the PathStateCapture)
+process.filterPath = cms.Path(
+    process.remoteFilter +     # Apply the filter
+    process.remoteCapture      # Capture path state (if filter passes)
+)
+
+# The MPI modules are put in a different path so that they are always scheduled.
+process.mpiPath = cms.Path(
+    process.receiver +         # Receive original EventIDs from controller
+    process.sender             # Send back PathStateToken
+)

--- a/HeterogeneousCore/MPICore/test/follower_soa_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_soa_cfg.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("MPIClient")
+process = cms.Process("MPIFollower")
 
 process.options.numberOfThreads = 4
 process.options.numberOfStreams = 4


### PR DESCRIPTION
#### PR description:

- Added a test to `MPICore/test` to check the remote filter functionality.
  - The test does the following:
    1. Send some events to a remote process via MPI
    2. In the remote process, an `edm::ModuloEventIDFilter` module filters out all events whose `eventID % 3 != 0`.
    3. Non rejected events are sent back to the local process.
    4. The same `edm::ModuloEventIDFilter` runs in the Controller process, and a `PathStatusFilter` is used to verify that the local and the remote paths produce the same result.
  - The test consists on the following files:
    - `controller_filters_cfg.py` and `follower_filters_cfg.py`, the local and remote configurations respectively

Other than adding the test, this PR introduces the following changes:
- fix several inconsistent types in the metadata messages
- Simplify the metadata handling
- Clarified some comments, fixed various typos

#### PR validation:
- The added test passes