### PR TITLE
Clean-up `DQM/SiPixelHeterogeneous` plugins

### DIFF
--- a/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
@@ -104,8 +104,8 @@ if process.runType.getRunType() == process.runType.hi_run:
     process.siPixelPhase1MonitorRawDataASerial.src = 'hltSiPixelDigiErrorsPPOnAASerialSync'
     process.siPixelPhase1MonitorRawDataADevice.src = 'hltSiPixelDigiErrorsPPOnAA'
 
-    process.siPixelPhase1CompareDigiErrorsSoAAlpaka.pixelErrorSrcGPU = 'hltSiPixelDigiErrorsPPOnAA'
-    process.siPixelPhase1CompareDigiErrorsSoAAlpaka.pixelErrorSrcCPU = 'hltSiPixelDigiErrorsPPOnAASerialSync'
+    process.siPixelPhase1CompareDigiErrorsSoA.pixelErrorSrcGPU = 'hltSiPixelDigiErrorsPPOnAA'
+    process.siPixelPhase1CompareDigiErrorsSoA.pixelErrorSrcCPU = 'hltSiPixelDigiErrorsPPOnAASerialSync'
 
     process.siPixelRecHitsSoAMonitorSerial.pixelHitsSrc = 'hltSiPixelRecHitsPPOnAASoASerialSync'
     process.siPixelRecHitsSoAMonitorSerial.TopFolderName = 'SiPixelHeterogeneous/PixelRecHitsCPU'
@@ -113,9 +113,9 @@ if process.runType.getRunType() == process.runType.hi_run:
     process.siPixelRecHitsSoAMonitorDevice.pixelHitsSrc = 'hltSiPixelRecHitsPPOnAASoA'
     process.siPixelRecHitsSoAMonitorDevice.TopFolderName = 'SiPixelHeterogeneous/PixelRecHitsGPU'
 
-    process.siPixelPhase1CompareRecHits.pixelHitsReferenceSoA = 'hltSiPixelRecHitsPPOnAASoASerialSync'
-    process.siPixelPhase1CompareRecHits.pixelHitsTargetSoA  = 'hltSiPixelRecHitsPPOnAASoA'
-    process.siPixelPhase1CompareRecHits.topFolderName = 'SiPixelHeterogeneous/PixelRecHitsCompareGPUvsCPU'
+    process.siPixelCompareRecHitsSoA.pixelHitsReferenceSoA = 'hltSiPixelRecHitsPPOnAASoASerialSync'
+    process.siPixelCompareRecHitsSoA.pixelHitsTargetSoA  = 'hltSiPixelRecHitsPPOnAASoA'
+    process.siPixelCompareRecHitsSoA.topFolderName = 'SiPixelHeterogeneous/PixelRecHitsCompareGPUvsCPU'
 
     process.siPixelTrackSoAMonitorSerial.pixelTrackSrc = 'hltPixelTracksPPOnAASoASerialSync'
     process.siPixelTrackSoAMonitorSerial.topFolderName = 'SiPixelHeterogeneous/PixelTrackCPU'
@@ -123,9 +123,9 @@ if process.runType.getRunType() == process.runType.hi_run:
     process.siPixelTrackSoAMonitorDevice.pixelTrackSrc = 'hltPixelTracksPPOnAASoA'
     process.siPixelTrackSoAMonitorDevice.topFolderName = 'SiPixelHeterogeneous/PixelTrackGPU'
 
-    process.siPixelPhase1CompareTracks.pixelTrackReferenceSoA = 'hltPixelTracksPPOnAASoASerialSync'
-    process.siPixelPhase1CompareTracks.pixelTrackTargetSoA = 'hltPixelTracksPPOnAASoA'
-    process.siPixelPhase1CompareTracks.topFolderName = 'SiPixelHeterogeneous/PixelTrackCompareGPUvsCPU'
+    process.siPixelCompareTracksSoA.pixelTrackReferenceSoA = 'hltPixelTracksPPOnAASoASerialSync'
+    process.siPixelCompareTracksSoA.pixelTrackTargetSoA = 'hltPixelTracksPPOnAASoA'
+    process.siPixelCompareTracksSoA.topFolderName = 'SiPixelHeterogeneous/PixelTrackCompareGPUvsCPU'
 
     process.siPixelVertexSoAMonitorSerial.pixelVertexSrc = 'hltPixelVerticesPPOnAASoASerialSync'
     process.siPixelVertexSoAMonitorSerial.beamSpotSrc = 'hltOnlineBeamSpot'
@@ -135,17 +135,17 @@ if process.runType.getRunType() == process.runType.hi_run:
     process.siPixelVertexSoAMonitorDevice.beamSpotSrc = 'hltOnlineBeamSpot'
     process.siPixelVertexSoAMonitorDevice.topFolderName = 'SiPixelHeterogeneous/PixelVertexGPU'
 
-    process.siPixelCompareVertices.pixelVertexReferenceSoA = 'hltPixelVerticesPPOnAASoASerialSync'
-    process.siPixelCompareVertices.pixelVertexTargetSoA = 'hltPixelVerticesPPOnAASoA'
-    process.siPixelCompareVertices.beamSpotSrc = 'hltOnlineBeamSpot'
-    process.siPixelCompareVertices.topFolderName = 'SiPixelHeterogeneous/PixelVertexCompareGPUvsCPU'
+    process.siPixelCompareVerticesSoA.pixelVertexReferenceSoA = 'hltPixelVerticesPPOnAASoASerialSync'
+    process.siPixelCompareVerticesSoA.pixelVertexTargetSoA = 'hltPixelVerticesPPOnAASoA'
+    process.siPixelCompareVerticesSoA.beamSpotSrc = 'hltOnlineBeamSpot'
+    process.siPixelCompareVerticesSoA.topFolderName = 'SiPixelHeterogeneous/PixelVertexCompareGPUvsCPU'
 
 else:
     process.siPixelPhase1MonitorRawDataASerial.src = 'hltSiPixelDigiErrorsSerialSync'
     process.siPixelPhase1MonitorRawDataADevice.src = 'hltSiPixelDigiErrors'
     
-    process.siPixelPhase1CompareDigiErrorsSoAAlpaka.pixelErrorSrcGPU = 'hltSiPixelDigiErrors'
-    process.siPixelPhase1CompareDigiErrorsSoAAlpaka.pixelErrorSrcCPU = 'hltSiPixelDigiErrorsSerialSync'
+    process.siPixelPhase1CompareDigiErrorsSoA.pixelErrorSrcGPU = 'hltSiPixelDigiErrors'
+    process.siPixelPhase1CompareDigiErrorsSoA.pixelErrorSrcCPU = 'hltSiPixelDigiErrorsSerialSync'
     
     process.siPixelRecHitsSoAMonitorSerial.pixelHitsSrc = 'hltSiPixelRecHitsSoASerialSync'
     process.siPixelRecHitsSoAMonitorSerial.TopFolderName = 'SiPixelHeterogeneous/PixelRecHitsCPU'
@@ -153,9 +153,9 @@ else:
     process.siPixelRecHitsSoAMonitorDevice.pixelHitsSrc = 'hltSiPixelRecHitsSoA'
     process.siPixelRecHitsSoAMonitorDevice.TopFolderName = 'SiPixelHeterogeneous/PixelRecHitsGPU'
     
-    process.siPixelPhase1CompareRecHits.pixelHitsReferenceSoA = 'hltSiPixelRecHitsSoASerialSync'
-    process.siPixelPhase1CompareRecHits.pixelHitsTargetSoA  = 'hltSiPixelRecHitsSoA'
-    process.siPixelPhase1CompareRecHits.topFolderName = 'SiPixelHeterogeneous/PixelRecHitsCompareGPUvsCPU'
+    process.siPixelCompareRecHitsSoA.pixelHitsReferenceSoA = 'hltSiPixelRecHitsSoASerialSync'
+    process.siPixelCompareRecHitsSoA.pixelHitsTargetSoA  = 'hltSiPixelRecHitsSoA'
+    process.siPixelCompareRecHitsSoA.topFolderName = 'SiPixelHeterogeneous/PixelRecHitsCompareGPUvsCPU'
     
     process.siPixelTrackSoAMonitorSerial.pixelTrackSrc = 'hltPixelTracksSoASerialSync'
     process.siPixelTrackSoAMonitorSerial.topFolderName = 'SiPixelHeterogeneous/PixelTrackCPU'
@@ -163,9 +163,9 @@ else:
     process.siPixelTrackSoAMonitorDevice.pixelTrackSrc = 'hltPixelTracksSoA'
     process.siPixelTrackSoAMonitorDevice.topFolderName = 'SiPixelHeterogeneous/PixelTrackGPU'
 
-    process.siPixelPhase1CompareTracks.pixelTrackReferenceSoA = 'hltPixelTracksSoASerialSync'
-    process.siPixelPhase1CompareTracks.pixelTrackTargetSoA = 'hltPixelTracksSoA'
-    process.siPixelPhase1CompareTracks.topFolderName = 'SiPixelHeterogeneous/PixelTrackCompareGPUvsCPU'
+    process.siPixelCompareTracksSoA.pixelTrackReferenceSoA = 'hltPixelTracksSoASerialSync'
+    process.siPixelCompareTracksSoA.pixelTrackTargetSoA = 'hltPixelTracksSoA'
+    process.siPixelCompareTracksSoA.topFolderName = 'SiPixelHeterogeneous/PixelTrackCompareGPUvsCPU'
     
     process.siPixelVertexSoAMonitorSerial.pixelVertexSrc = 'hltPixelVerticesSoASerialSync'
     process.siPixelVertexSoAMonitorSerial.beamSpotSrc = 'hltOnlineBeamSpot'
@@ -175,10 +175,10 @@ else:
     process.siPixelVertexSoAMonitorDevice.beamSpotSrc = 'hltOnlineBeamSpot'
     process.siPixelVertexSoAMonitorDevice.topFolderName = 'SiPixelHeterogeneous/PixelVertexGPU'
     
-    process.siPixelCompareVertices.pixelVertexReferenceSoA = 'hltPixelVerticesSoASerialSync'
-    process.siPixelCompareVertices.pixelVertexTargetSoA = 'hltPixelVerticesSoA'
-    process.siPixelCompareVertices.beamSpotSrc = 'hltOnlineBeamSpot'
-    process.siPixelCompareVertices.topFolderName = 'SiPixelHeterogeneous/PixelVertexCompareGPUvsCPU'
+    process.siPixelCompareVerticesSoA.pixelVertexReferenceSoA = 'hltPixelVerticesSoASerialSync'
+    process.siPixelCompareVerticesSoA.pixelVertexTargetSoA = 'hltPixelVerticesSoA'
+    process.siPixelCompareVerticesSoA.beamSpotSrc = 'hltOnlineBeamSpot'
+    process.siPixelCompareVerticesSoA.topFolderName = 'SiPixelHeterogeneous/PixelVertexCompareGPUvsCPU'
     
 #-------------------------------------
 #       Some Debug
@@ -194,22 +194,22 @@ monitoring_modules = []
 # Mandatory pixel digi error modules
 monitoring_modules.append(process.siPixelPhase1MonitorRawDataASerial)
 monitoring_modules.append(process.siPixelPhase1MonitorRawDataADevice)
-monitoring_modules.append(process.siPixelPhase1CompareDigiErrorsSoAAlpaka)
+monitoring_modules.append(process.siPixelPhase1CompareDigiErrorsSoA)
 
 if doRecHits:
     monitoring_modules.append(process.siPixelRecHitsSoAMonitorDevice)
     monitoring_modules.append(process.siPixelRecHitsSoAMonitorSerial)
-    monitoring_modules.append(process.siPixelPhase1CompareRecHits)
+    monitoring_modules.append(process.siPixelCompareRecHitsSoA)
 
 if doTracks:
     monitoring_modules.append(process.siPixelTrackSoAMonitorDevice)
     monitoring_modules.append(process.siPixelTrackSoAMonitorSerial)
-    monitoring_modules.append(process.siPixelPhase1CompareTracks)
+    monitoring_modules.append(process.siPixelCompareTracksSoA)
 
 if doVertices:
     monitoring_modules.append(process.siPixelVertexSoAMonitorDevice)
     monitoring_modules.append(process.siPixelVertexSoAMonitorSerial)
-    monitoring_modules.append(process.siPixelCompareVertices)
+    monitoring_modules.append(process.siPixelCompareVerticesSoA)
 
 # Always add the comparison harvesting sequence as before
 monitoring_modules.append(process.siPixelPhase1RawDataHarvesterSerial)

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareRecHitsSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareRecHitsSoA.cc
@@ -1,5 +1,3 @@
-// TODO: change file name to SiPixelCompareRecHitsSoA.cc when CUDA code is removed
-
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -19,13 +17,12 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
-// TODO: change class name to SiPixelCompareRecHitsSoA when CUDA code is removed
-class SiPixelCompareRecHits : public DQMEDAnalyzer {
+class SiPixelCompareRecHitsSoA : public DQMEDAnalyzer {
 public:
   using HitsSoA = reco::TrackingRecHitHost;
 
-  explicit SiPixelCompareRecHits(const edm::ParameterSet&);
-  ~SiPixelCompareRecHits() override = default;
+  explicit SiPixelCompareRecHitsSoA(const edm::ParameterSet&);
+  ~SiPixelCompareRecHitsSoA() override = default;
   void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
@@ -75,7 +72,7 @@ private:
 // constructors
 //
 
-SiPixelCompareRecHits::SiPixelCompareRecHits(const edm::ParameterSet& iConfig)
+SiPixelCompareRecHitsSoA::SiPixelCompareRecHitsSoA(const edm::ParameterSet& iConfig)
     : geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
       topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()),
       tokenSoAHitsReference_(consumes(iConfig.getParameter<edm::InputTag>("pixelHitsReferenceSoA"))),
@@ -87,19 +84,19 @@ SiPixelCompareRecHits::SiPixelCompareRecHits(const edm::ParameterSet& iConfig)
 // Begin Run
 //
 
-void SiPixelCompareRecHits::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
+void SiPixelCompareRecHitsSoA::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
   tkGeom_ = &iSetup.getData(geomToken_);
   tTopo_ = &iSetup.getData(topoToken_);
 }
 
 template <typename U, typename V>
-void SiPixelCompareRecHits::analyzeSeparate(U tokenRef, V tokenTar, const edm::Event& iEvent) {
+void SiPixelCompareRecHitsSoA::analyzeSeparate(U tokenRef, V tokenTar, const edm::Event& iEvent) {
   const auto& rhsoaHandleRef = iEvent.getHandle(tokenRef);
   const auto& rhsoaHandleTar = iEvent.getHandle(tokenTar);
 
   // Exit early if any handle is invalid
   if (!rhsoaHandleRef || !rhsoaHandleTar) {
-    edm::LogWarning out("SiPixelCompareRecHits");
+    edm::LogWarning out("SiPixelCompareRecHitsSoA");
     if (!rhsoaHandleRef)
       out << "reference rechits not found; ";
     if (!rhsoaHandleTar)
@@ -205,7 +202,7 @@ void SiPixelCompareRecHits::analyzeSeparate(U tokenRef, V tokenTar, const edm::E
 // -- Analyze
 //
 
-void SiPixelCompareRecHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void SiPixelCompareRecHitsSoA::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // The default use case is to use vertices from Alpaka reconstructed on CPU and GPU;
   // The function is left templated if any other cases need to be added
   analyzeSeparate(tokenSoAHitsReference_, tokenSoAHitsTarget_, iEvent);
@@ -215,9 +212,9 @@ void SiPixelCompareRecHits::analyze(const edm::Event& iEvent, const edm::EventSe
 // -- Book Histograms
 //
 
-void SiPixelCompareRecHits::bookHistograms(DQMStore::IBooker& iBook,
-                                           edm::Run const& iRun,
-                                           edm::EventSetup const& iSetup) {
+void SiPixelCompareRecHitsSoA::bookHistograms(DQMStore::IBooker& iBook,
+                                              edm::Run const& iRun,
+                                              edm::EventSetup const& iSetup) {
   iBook.cd();
   iBook.setCurrentFolder(topFolderName_);
 
@@ -258,7 +255,7 @@ void SiPixelCompareRecHits::bookHistograms(DQMStore::IBooker& iBook,
 }
 
 
-void SiPixelCompareRecHits::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void SiPixelCompareRecHitsSoA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // monitorpixelRecHitsSoAAlpaka
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("pixelHitsReferenceSoA", edm::InputTag("siPixelRecHitsPreSplittingAlpakaSerial"));
@@ -268,16 +265,6 @@ void SiPixelCompareRecHits::fillDescriptions(edm::ConfigurationDescriptions& des
   descriptions.addWithDefaultLabel(desc);
 }
 
-using SiPixelCompareRecHits = SiPixelCompareRecHits;
-// keeping the old names to allow a smooth HLT migration
-using SiPixelPhase1CompareRecHits = SiPixelCompareRecHits;
-using SiPixelPhase2CompareRecHits = SiPixelCompareRecHits;
-using SiPixelHIonPhase1CompareRecHits = SiPixelCompareRecHits;
-
 #include "FWCore/Framework/interface/MakerMacros.h"
-// TODO: change module names to SiPixel*CompareRecHitsSoA when CUDA code is removed
-DEFINE_FWK_MODULE(SiPixelCompareRecHits);
-DEFINE_FWK_MODULE(SiPixelPhase1CompareRecHits);
-DEFINE_FWK_MODULE(SiPixelPhase2CompareRecHits);
-DEFINE_FWK_MODULE(SiPixelHIonPhase1CompareRecHits);
+DEFINE_FWK_MODULE(SiPixelCompareRecHitsSoA);
 

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareTracksSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareTracksSoA.cc
@@ -1,10 +1,8 @@
-// TODO: change file name to SiPixelCompareTracksSoA.cc when CUDA code is removed
-
 // -*- C++ -*-
-// Package:    SiPixelCompareTracks
-// Class:      SiPixelCompareTracks
+// Package:    SiPixelCompareTracksSoA
+// Class:      SiPixelCompareTracksSoA
 //
-/**\class SiPixelCompareTracks SiPixelCompareTracks.cc
+/**\class SiPixelCompareTracksSoA SiPixelCompareTracksSoA.cc
 */
 //
 // Author: Suvankar Roy Chowdhury
@@ -68,14 +66,12 @@ namespace {
   }
 }  // namespace
 
-// TODO: change class name to SiPixelCompareTracksSoA when CUDA code is removed
-
-class SiPixelCompareTracks : public DQMEDAnalyzer {
+class SiPixelCompareTracksSoA : public DQMEDAnalyzer {
 public:
   using PixelTrackSoA = reco::TracksHost;
 
-  explicit SiPixelCompareTracks(const edm::ParameterSet&);
-  ~SiPixelCompareTracks() override = default;
+  explicit SiPixelCompareTracksSoA(const edm::ParameterSet&);
+  ~SiPixelCompareTracksSoA() override = default;
   void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
   // analyzeSeparate is templated to accept distinct types of SoAs
@@ -135,7 +131,7 @@ private:
 // constructors
 //
 
-SiPixelCompareTracks::SiPixelCompareTracks(const edm::ParameterSet& iConfig)
+SiPixelCompareTracksSoA::SiPixelCompareTracksSoA(const edm::ParameterSet& iConfig)
     : tokenSoATrackReference_(consumes<PixelTrackSoA>(iConfig.getParameter<edm::InputTag>("pixelTrackReferenceSoA"))),
       tokenSoATrackTarget_(consumes<PixelTrackSoA>(iConfig.getParameter<edm::InputTag>("pixelTrackTargetSoA"))),
       topFolderName_(iConfig.getParameter<std::string>("topFolderName")),
@@ -144,12 +140,12 @@ SiPixelCompareTracks::SiPixelCompareTracks(const edm::ParameterSet& iConfig)
       dr2cut_(iConfig.getParameter<double>("deltaR2cut")) {}
 
 template <typename U, typename V>
-void SiPixelCompareTracks::analyzeSeparate(U tokenRef, V tokenTar, const edm::Event& iEvent) {
+void SiPixelCompareTracksSoA::analyzeSeparate(U tokenRef, V tokenTar, const edm::Event& iEvent) {
   const auto& tsoaHandleRef = iEvent.getHandle(tokenRef);
   const auto& tsoaHandleTar = iEvent.getHandle(tokenTar);
 
   if (not tsoaHandleRef or not tsoaHandleTar) {
-    edm::LogWarning out("SiPixelCompareTracks");
+    edm::LogWarning out("SiPixelCompareTracksSoA");
     if (not tsoaHandleRef) {
       out << "reference tracks not found; ";
     }
@@ -278,7 +274,7 @@ void SiPixelCompareTracks::analyzeSeparate(U tokenRef, V tokenTar, const edm::Ev
 // -- Analyze
 //
 
-void SiPixelCompareTracks::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void SiPixelCompareTracksSoA::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // The default use case is to use vertices from Alpaka reconstructed on CPU and GPU;
   // The function is left templated if any other cases need to be added
   analyzeSeparate(tokenSoATrackReference_, tokenSoATrackTarget_, iEvent);
@@ -288,9 +284,9 @@ void SiPixelCompareTracks::analyze(const edm::Event& iEvent, const edm::EventSet
 // -- Book Histograms
 //
 
-void SiPixelCompareTracks::bookHistograms(DQMStore::IBooker& iBook,
-                                          edm::Run const& iRun,
-                                          edm::EventSetup const& iSetup) {
+void SiPixelCompareTracksSoA::bookHistograms(DQMStore::IBooker& iBook,
+                                             edm::Run const& iRun,
+                                             edm::EventSetup const& iSetup) {
   iBook.cd();
   iBook.setCurrentFolder(topFolderName_);
 
@@ -369,7 +365,7 @@ void SiPixelCompareTracks::bookHistograms(DQMStore::IBooker& iBook,
 
 }
 
-void SiPixelCompareTracks::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void SiPixelCompareTracksSoA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // monitorpixelTrackSoA
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("pixelTrackReferenceSoA", edm::InputTag("pixelTracksAlpakaSerial"));
@@ -381,15 +377,6 @@ void SiPixelCompareTracks::fillDescriptions(edm::ConfigurationDescriptions& desc
   descriptions.addWithDefaultLabel(desc);
 }
 
-// TODO: change module names to SiPixel*CompareTracksSoA when CUDA code is removed
-
-using SiPixelPhase1CompareTracks = SiPixelCompareTracks;
-using SiPixelPhase2CompareTracks = SiPixelCompareTracks;
-using SiPixelHIonPhase1CompareTracks = SiPixelCompareTracks;
-
 // Duplicates to keep them alive for the HLT menu to migrate to the new modules
-DEFINE_FWK_MODULE(SiPixelCompareTracks);
-DEFINE_FWK_MODULE(SiPixelPhase1CompareTracks);
-DEFINE_FWK_MODULE(SiPixelPhase2CompareTracks);
-DEFINE_FWK_MODULE(SiPixelHIonPhase1CompareTracks);
+DEFINE_FWK_MODULE(SiPixelCompareTracksSoA);
 

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareVerticesSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareVerticesSoA.cc
@@ -1,10 +1,8 @@
-// TODO: change file name to SiPixelCompareVerticesSoA.cc when CUDA code is removed
-
 // -*- C++ -*-
-// Package:    SiPixelCompareVertices
-// Class:      SiPixelCompareVertices
+// Package:    SiPixelCompareVerticesSoA
+// Class:      SiPixelCompareVerticesSoA
 //
-/**\class SiPixelCompareVertices SiPixelCompareVertices.cc
+/**\class SiPixelCompareVerticesSoA SiPixelCompareVerticesSoA.cc
 */
 //
 // Author: Suvankar Roy Chowdhury
@@ -23,12 +21,11 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-// TODO: change class name to SiPixelCompareVerticesSoA when CUDA code is removed
-class SiPixelCompareVertices : public DQMEDAnalyzer {
+class SiPixelCompareVerticesSoA : public DQMEDAnalyzer {
 public:
   using IndToEdm = std::vector<uint16_t>;
-  explicit SiPixelCompareVertices(const edm::ParameterSet&);
-  ~SiPixelCompareVertices() override = default;
+  explicit SiPixelCompareVerticesSoA(const edm::ParameterSet&);
+  ~SiPixelCompareVerticesSoA() override = default;
   void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
   // analyzeSeparate is templated to accept distinct types of SoAs
@@ -61,7 +58,7 @@ private:
 // constructors
 //
 
-SiPixelCompareVertices::SiPixelCompareVertices(const edm::ParameterSet& iConfig)
+SiPixelCompareVerticesSoA::SiPixelCompareVerticesSoA(const edm::ParameterSet& iConfig)
     : tokenSoAVertexReferenceSoA_(
           consumes<reco::ZVertexHost>(iConfig.getParameter<edm::InputTag>("pixelVertexReferenceSoA"))),
       tokenSoAVertexTargetSoA_(
@@ -71,12 +68,12 @@ SiPixelCompareVertices::SiPixelCompareVertices(const edm::ParameterSet& iConfig)
       dzCut_(iConfig.getParameter<double>("dzCut")) {}
 
 template <typename U, typename V>
-void SiPixelCompareVertices::analyzeSeparate(U tokenRef, V tokenTar, const edm::Event& iEvent) {
+void SiPixelCompareVerticesSoA::analyzeSeparate(U tokenRef, V tokenTar, const edm::Event& iEvent) {
   const auto& vsoaHandleRef = iEvent.getHandle(tokenRef);
   const auto& vsoaHandleTar = iEvent.getHandle(tokenTar);
 
   if (not vsoaHandleRef or not vsoaHandleTar) {
-    edm::LogWarning out("SiPixelCompareVertices");
+    edm::LogWarning out("SiPixelCompareVerticesSoA");
     if (not vsoaHandleRef) {
       out << "reference vertices not found; ";
     }
@@ -95,7 +92,7 @@ void SiPixelCompareVertices::analyzeSeparate(U tokenRef, V tokenTar, const edm::
   auto bsHandle = iEvent.getHandle(tokenBeamSpot_);
   float x0 = 0., y0 = 0., z0 = 0., dxdz = 0., dydz = 0.;
   if (not bsHandle.isValid()) {
-    edm::LogWarning("SiPixelCompareVertices") << "No beamspot found, returning vertexes with (0,0,Z).";
+    edm::LogWarning("SiPixelCompareVerticesSoA") << "No beamspot found, returning vertexes with (0,0,Z).";
   } else {
     const reco::BeamSpot& bs = *bsHandle;
     x0 = bs.x0();
@@ -158,7 +155,7 @@ void SiPixelCompareVertices::analyzeSeparate(U tokenRef, V tokenTar, const edm::
 //
 // -- Analyze
 //
-void SiPixelCompareVertices::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void SiPixelCompareVerticesSoA::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // The default use case is to use vertices from Alpaka reconstructed on CPU and GPU;
   // The function is left templated if any other cases need to be added
   analyzeSeparate(tokenSoAVertexReferenceSoA_, tokenSoAVertexTargetSoA_, iEvent);
@@ -167,9 +164,9 @@ void SiPixelCompareVertices::analyze(const edm::Event& iEvent, const edm::EventS
 //
 // -- Book Histograms
 //
-void SiPixelCompareVertices::bookHistograms(DQMStore::IBooker& ibooker,
-                                            edm::Run const& iRun,
-                                            edm::EventSetup const& iSetup) {
+void SiPixelCompareVerticesSoA::bookHistograms(DQMStore::IBooker& ibooker,
+                                               edm::Run const& iRun,
+                                               edm::EventSetup const& iSetup) {
   ibooker.cd();
   ibooker.setCurrentFolder(topFolderName_);
 
@@ -189,7 +186,7 @@ void SiPixelCompareVertices::bookHistograms(DQMStore::IBooker& ibooker,
   hzdiff_ = ibooker.book1D("vzdiff", ";Vertex z difference (Reference - Target);#entries", 100, -2.5, 2.5);
 }
 
-void SiPixelCompareVertices::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void SiPixelCompareVerticesSoA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // monitorpixelVertexSoA
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("pixelVertexReferenceSoA", edm::InputTag("pixelVerticesAlpakaSerial"));
@@ -200,5 +197,4 @@ void SiPixelCompareVertices::fillDescriptions(edm::ConfigurationDescriptions& de
   descriptions.addWithDefaultLabel(desc);
 }
 
-// TODO: change module name to SiPixelCompareVerticesSoA when CUDA code is removed
-DEFINE_FWK_MODULE(SiPixelCompareVertices);
+DEFINE_FWK_MODULE(SiPixelCompareVerticesSoA);

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorRecHitsSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorRecHitsSoA.cc
@@ -16,12 +16,12 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
-class SiPixelMonitorRecHitsSoAAlpaka : public DQMEDAnalyzer {
+class SiPixelMonitorRecHitsSoA : public DQMEDAnalyzer {
 public:
   using HitsOnHost = reco::TrackingRecHitHost;
 
-  explicit SiPixelMonitorRecHitsSoAAlpaka(const edm::ParameterSet&);
-  ~SiPixelMonitorRecHitsSoAAlpaka() override = default;
+  explicit SiPixelMonitorRecHitsSoA(const edm::ParameterSet&);
+  ~SiPixelMonitorRecHitsSoA() override = default;
   void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
@@ -61,7 +61,7 @@ private:
 // constructors
 //
 
-SiPixelMonitorRecHitsSoAAlpaka::SiPixelMonitorRecHitsSoAAlpaka(const edm::ParameterSet& iConfig)
+SiPixelMonitorRecHitsSoA::SiPixelMonitorRecHitsSoA(const edm::ParameterSet& iConfig)
     : geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
       topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()),
       tokenSoAHits_(consumes(iConfig.getParameter<edm::InputTag>("pixelHitsSrc"))),
@@ -71,7 +71,7 @@ SiPixelMonitorRecHitsSoAAlpaka::SiPixelMonitorRecHitsSoAAlpaka(const edm::Parame
 // Begin Run
 //
 
-void SiPixelMonitorRecHitsSoAAlpaka::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
+void SiPixelMonitorRecHitsSoA::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
   tkGeom_ = &iSetup.getData(geomToken_);
   tTopo_ = &iSetup.getData(topoToken_);
 }
@@ -80,10 +80,10 @@ void SiPixelMonitorRecHitsSoAAlpaka::dqmBeginRun(const edm::Run& iRun, const edm
 // -- Analyze
 //
 
-void SiPixelMonitorRecHitsSoAAlpaka::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void SiPixelMonitorRecHitsSoA::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   const auto& rhsoaHandle = iEvent.getHandle(tokenSoAHits_);
   if (!rhsoaHandle.isValid()) {
-    edm::LogWarning("SiPixelMonitorRecHitsSoAAlpaka") << "No RecHits SoA found \n returning!";
+    edm::LogWarning("SiPixelMonitorRecHitsSoA") << "No RecHits SoA found \n returning!";
     return;
   }
   auto const& rhsoa = *rhsoaHandle;
@@ -136,9 +136,9 @@ void SiPixelMonitorRecHitsSoAAlpaka::analyze(const edm::Event& iEvent, const edm
 // -- Book Histograms
 //
 
-void SiPixelMonitorRecHitsSoAAlpaka::bookHistograms(DQMStore::IBooker& iBook,
-                                                    edm::Run const& iRun,
-                                                    edm::EventSetup const& iSetup) {
+void SiPixelMonitorRecHitsSoA::bookHistograms(DQMStore::IBooker& iBook,
+                                              edm::Run const& iRun,
+                                              edm::EventSetup const& iSetup) {
   iBook.cd();
   iBook.setCurrentFolder(topFolderName_);
 
@@ -178,7 +178,7 @@ void SiPixelMonitorRecHitsSoAAlpaka::bookHistograms(DQMStore::IBooker& iBook,
   }
 }
 
-void SiPixelMonitorRecHitsSoAAlpaka::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void SiPixelMonitorRecHitsSoA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // monitorpixelRecHitsSoA
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("pixelHitsSrc", edm::InputTag("siPixelRecHitsPreSplittingAlpaka"));
@@ -186,13 +186,6 @@ void SiPixelMonitorRecHitsSoAAlpaka::fillDescriptions(edm::ConfigurationDescript
   descriptions.addWithDefaultLabel(desc);
 }
 
-using SiPixelPhase1MonitorRecHitsSoAAlpaka = SiPixelMonitorRecHitsSoAAlpaka;
-using SiPixelPhase2MonitorRecHitsSoAAlpaka = SiPixelMonitorRecHitsSoAAlpaka;
-using SiPixelHIonPhase1MonitorRecHitsSoAAlpaka = SiPixelMonitorRecHitsSoAAlpaka;
-
 #include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_FWK_MODULE(SiPixelMonitorRecHitsSoAAlpaka);
-DEFINE_FWK_MODULE(SiPixelPhase1MonitorRecHitsSoAAlpaka);
-DEFINE_FWK_MODULE(SiPixelPhase2MonitorRecHitsSoAAlpaka);
-DEFINE_FWK_MODULE(SiPixelHIonPhase1MonitorRecHitsSoAAlpaka);
+DEFINE_FWK_MODULE(SiPixelMonitorRecHitsSoA);
 

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoA.cc
@@ -1,8 +1,8 @@
 // -*- C++ -*-
-// Package:    SiPixelMonitorTrackSoAAlpaka
-// Class:      SiPixelMonitorTrackSoAAlpaka
+// Package:    SiPixelMonitorTrackSoA
+// Class:      SiPixelMonitorTrackSoA
 //
-/**\class SiPixelMonitorTrackSoAAlpaka SiPixelMonitorTrackSoAAlpaka.cc
+/**\class SiPixelMonitorTrackSoA SiPixelMonitorTrackSoA.cc
 */
 //
 // Author: Suvankar Roy Chowdhury
@@ -26,11 +26,11 @@
 #include "DataFormats/TrackSoA/interface/TracksHost.h"
 #include "DataFormats/TrackSoA/interface/alpaka/TrackUtilities.h"
 
-class SiPixelMonitorTrackSoAAlpaka : public DQMEDAnalyzer {
+class SiPixelMonitorTrackSoA : public DQMEDAnalyzer {
 public:
   using PixelTrackHeterogeneous = reco::TracksHost;
-  explicit SiPixelMonitorTrackSoAAlpaka(const edm::ParameterSet&);
-  ~SiPixelMonitorTrackSoAAlpaka() override = default;
+  explicit SiPixelMonitorTrackSoA(const edm::ParameterSet&);
+  ~SiPixelMonitorTrackSoA() override = default;
   void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
@@ -64,7 +64,7 @@ private:
 // constructors
 //
 
-SiPixelMonitorTrackSoAAlpaka::SiPixelMonitorTrackSoAAlpaka(const edm::ParameterSet& iConfig) {
+SiPixelMonitorTrackSoA::SiPixelMonitorTrackSoA(const edm::ParameterSet& iConfig) {
   tokenSoATrack_ = consumes<PixelTrackHeterogeneous>(iConfig.getParameter<edm::InputTag>("pixelTrackSrc"));
   topFolderName_ = iConfig.getParameter<std::string>("topFolderName");  //"SiPixelHeterogeneous/PixelTrackSoA";
   useQualityCut_ = iConfig.getParameter<bool>("useQualityCut");
@@ -75,10 +75,10 @@ SiPixelMonitorTrackSoAAlpaka::SiPixelMonitorTrackSoAAlpaka(const edm::ParameterS
 // -- Analyze
 //
 
-void SiPixelMonitorTrackSoAAlpaka::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void SiPixelMonitorTrackSoA::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   const auto& tsoaHandle = iEvent.getHandle(tokenSoATrack_);
   if (!tsoaHandle.isValid()) {
-    edm::LogWarning("SiPixelMonitorTrackSoAAlpaka") << "No Track SoA found \n returning!" << std::endl;
+    edm::LogWarning("SiPixelMonitorTrackSoA") << "No Track SoA found \n returning!" << std::endl;
     return;
   }
 
@@ -139,9 +139,9 @@ void SiPixelMonitorTrackSoAAlpaka::analyze(const edm::Event& iEvent, const edm::
 // -- Book Histograms
 //
 
-void SiPixelMonitorTrackSoAAlpaka::bookHistograms(DQMStore::IBooker& iBook,
-                                                  edm::Run const& iRun,
-                                                  edm::EventSetup const& iSetup) {
+void SiPixelMonitorTrackSoA::bookHistograms(DQMStore::IBooker& iBook,
+                                            edm::Run const& iRun,
+                                            edm::EventSetup const& iSetup) {
   iBook.cd();
   iBook.setCurrentFolder(topFolderName_);
 
@@ -180,7 +180,7 @@ hChi2VsEta = iBook.bookProfile("nChi2ndofVsEta", fmt::format("{} vs track #eta;T
   }
 }
 
-void SiPixelMonitorTrackSoAAlpaka::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void SiPixelMonitorTrackSoA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // monitorpixelTrackSoA
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("pixelTrackSrc", edm::InputTag("pixelTracksAlpaka"));
@@ -190,12 +190,5 @@ void SiPixelMonitorTrackSoAAlpaka::fillDescriptions(edm::ConfigurationDescriptio
   descriptions.addWithDefaultLabel(desc);
 }
 
-using SiPixelPhase1MonitorTrackSoAAlpaka = SiPixelMonitorTrackSoAAlpaka;
-using SiPixelPhase2MonitorTrackSoAAlpaka = SiPixelMonitorTrackSoAAlpaka;
-using SiPixelHIonPhase1MonitorTrackSoAAlpaka = SiPixelMonitorTrackSoAAlpaka;
-
 // Duplicates to keep them alive for the HLT menu to migrate to the new modules
-DEFINE_FWK_MODULE(SiPixelMonitorTrackSoAAlpaka);
-DEFINE_FWK_MODULE(SiPixelPhase1MonitorTrackSoAAlpaka);
-DEFINE_FWK_MODULE(SiPixelPhase2MonitorTrackSoAAlpaka);
-DEFINE_FWK_MODULE(SiPixelHIonPhase1MonitorTrackSoAAlpaka);
+DEFINE_FWK_MODULE(SiPixelMonitorTrackSoA);

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorVertexSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorVertexSoA.cc
@@ -1,9 +1,9 @@
 // -*- C++ -*-
 ///bookLayer
-// Package:    SiPixelMonitorVertexSoAAlpaka
-// Class:      SiPixelMonitorVertexSoAAlpaka
+// Package:    SiPixelMonitorVertexSoA
+// Class:      SiPixelMonitorVertexSoA
 //
-/**\class SiPixelMonitorVertexSoAAlpaka SiPixelMonitorVertexSoAAlpaka.cc
+/**\class SiPixelMonitorVertexSoA SiPixelMonitorVertexSoA.cc
 */
 //
 // Author: Suvankar Roy Chowdhury
@@ -24,11 +24,11 @@
 #include "DataFormats/VertexSoA/interface/ZVertexHost.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 
-class SiPixelMonitorVertexSoAAlpaka : public DQMEDAnalyzer {
+class SiPixelMonitorVertexSoA : public DQMEDAnalyzer {
 public:
   using IndToEdm = std::vector<uint16_t>;
-  explicit SiPixelMonitorVertexSoAAlpaka(const edm::ParameterSet&);
-  ~SiPixelMonitorVertexSoAAlpaka() override = default;
+  explicit SiPixelMonitorVertexSoA(const edm::ParameterSet&);
+  ~SiPixelMonitorVertexSoA() override = default;
   void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
@@ -51,7 +51,7 @@ private:
 // constructors
 //
 
-SiPixelMonitorVertexSoAAlpaka::SiPixelMonitorVertexSoAAlpaka(const edm::ParameterSet& iConfig)
+SiPixelMonitorVertexSoA::SiPixelMonitorVertexSoA(const edm::ParameterSet& iConfig)
     : tokenSoAVertex_(consumes<reco::ZVertexHost>(iConfig.getParameter<edm::InputTag>("pixelVertexSrc"))),
       tokenBeamSpot_(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpotSrc"))),
       topFolderName_(iConfig.getParameter<std::string>("topFolderName")) {}
@@ -59,10 +59,10 @@ SiPixelMonitorVertexSoAAlpaka::SiPixelMonitorVertexSoAAlpaka(const edm::Paramete
 //
 // -- Analyze
 //
-void SiPixelMonitorVertexSoAAlpaka::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void SiPixelMonitorVertexSoA::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   const auto& vsoaHandle = iEvent.getHandle(tokenSoAVertex_);
   if (!vsoaHandle.isValid()) {
-    edm::LogWarning("SiPixelMonitorVertexSoAAlpaka") << "No Vertex SoA found \n returning!" << std::endl;
+    edm::LogWarning("SiPixelMonitorVertexSoA") << "No Vertex SoA found \n returning!" << std::endl;
     return;
   }
 
@@ -73,7 +73,7 @@ void SiPixelMonitorVertexSoAAlpaka::analyze(const edm::Event& iEvent, const edm:
   auto bsHandle = iEvent.getHandle(tokenBeamSpot_);
   float x0 = 0., y0 = 0., z0 = 0., dxdz = 0., dydz = 0.;
   if (!bsHandle.isValid()) {
-    edm::LogWarning("SiPixelMonitorVertexSoAAlpaka") << "No beamspot found. returning vertexes with (0,0,Z) ";
+    edm::LogWarning("SiPixelMonitorVertexSoA") << "No beamspot found. returning vertexes with (0,0,Z) ";
   } else {
     const reco::BeamSpot& bs = *bsHandle;
     x0 = bs.x0();
@@ -105,9 +105,9 @@ void SiPixelMonitorVertexSoAAlpaka::analyze(const edm::Event& iEvent, const edm:
 //
 // -- Book Histograms
 //
-void SiPixelMonitorVertexSoAAlpaka::bookHistograms(DQMStore::IBooker& ibooker,
-                                                   edm::Run const& iRun,
-                                                   edm::EventSetup const& iSetup) {
+void SiPixelMonitorVertexSoA::bookHistograms(DQMStore::IBooker& ibooker,
+                                             edm::Run const& iRun,
+                                             edm::EventSetup const& iSetup) {
   //std::string top_folder = ""//
   ibooker.cd();
   ibooker.setCurrentFolder(topFolderName_);
@@ -121,7 +121,7 @@ void SiPixelMonitorVertexSoAAlpaka::bookHistograms(DQMStore::IBooker& ibooker,
   hntrks = ibooker.book1D("ntrk", ";#tracks associated;#entries", 100, -0.5, 99.5);
 }
 
-void SiPixelMonitorVertexSoAAlpaka::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void SiPixelMonitorVertexSoA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // monitorpixelVertexSoA
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("pixelVertexSrc", edm::InputTag("pixelVerticesAlpaka"));
@@ -130,4 +130,4 @@ void SiPixelMonitorVertexSoAAlpaka::fillDescriptions(edm::ConfigurationDescripti
   descriptions.addWithDefaultLabel(desc);
 }
 
-DEFINE_FWK_MODULE(SiPixelMonitorVertexSoAAlpaka);
+DEFINE_FWK_MODULE(SiPixelMonitorVertexSoA);

--- a/DQM/SiPixelHeterogeneous/python/SiPixelHeterogenousDQM_FirstStep_cff.py
+++ b/DQM/SiPixelHeterogeneous/python/SiPixelHeterogenousDQM_FirstStep_cff.py
@@ -2,46 +2,25 @@ import copy
 import FWCore.ParameterSet.Config as cms
 # Alpaka Modules
 from Configuration.ProcessModifiers.alpaka_cff import alpaka
-from DQM.SiPixelHeterogeneous.siPixelPhase1MonitorRecHitsSoAAlpaka_cfi import *
-from DQM.SiPixelHeterogeneous.siPixelPhase2MonitorRecHitsSoAAlpaka_cfi import *
-from DQM.SiPixelHeterogeneous.siPixelHIonPhase1MonitorRecHitsSoAAlpaka_cfi import *
-from DQM.SiPixelHeterogeneous.siPixelPhase1MonitorTrackSoAAlpaka_cfi import *
-from DQM.SiPixelHeterogeneous.siPixelPhase2MonitorTrackSoAAlpaka_cfi import *
-from DQM.SiPixelHeterogeneous.siPixelHIonPhase1MonitorTrackSoAAlpaka_cfi import *
-from DQM.SiPixelHeterogeneous.siPixelMonitorVertexSoAAlpaka_cfi import *
+from DQM.SiPixelHeterogeneous.siPixelMonitorRecHitsSoA_cfi import *
+from DQM.SiPixelHeterogeneous.siPixelMonitorTrackSoA_cfi import *
+from DQM.SiPixelHeterogeneous.siPixelMonitorVertexSoA_cfi import *
 
 # Run-3 sequence
 monitorpixelSoASource = cms.Sequence()
 # Run-3 Alpaka sequence 
-monitorpixelSoASourceAlpaka = cms.Sequence(siPixelPhase1MonitorRecHitsSoAAlpaka * siPixelPhase1MonitorTrackSoAAlpaka * siPixelMonitorVertexSoAAlpaka)
+monitorpixelSoASourceAlpaka = cms.Sequence(siPixelMonitorRecHitsSoA * siPixelMonitorTrackSoA * siPixelMonitorVertexSoA)
 alpaka.toReplaceWith(monitorpixelSoASource, monitorpixelSoASourceAlpaka)
-# Phase-2 sequence
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-_monitorpixelSoARecHitsSource = cms.Sequence()
-(phase2_tracker & ~alpaka).toReplaceWith(monitorpixelSoASource, _monitorpixelSoARecHitsSource)
-_monitorpixelSoARecHitsSourceAlpaka = cms.Sequence(siPixelPhase2MonitorRecHitsSoAAlpaka * siPixelPhase2MonitorTrackSoAAlpaka * siPixelMonitorVertexSoAAlpaka)
-(phase2_tracker & alpaka).toReplaceWith(monitorpixelSoASource, _monitorpixelSoARecHitsSourceAlpaka)
 
-# HIon Phase 1 sequence
-from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-
-_monitorpixelSoARecHitsSourceHIon = cms.Sequence()
-(pp_on_AA & ~phase2_tracker).toReplaceWith(monitorpixelSoASource, _monitorpixelSoARecHitsSourceHIon)
-_monitorpixelSoARecHitsSourceHIonAlpaka = cms.Sequence(siPixelHIonPhase1MonitorRecHitsSoAAlpaka * siPixelHIonPhase1MonitorTrackSoAAlpaka * siPixelMonitorVertexSoAAlpaka)
-(pp_on_AA & ~phase2_tracker & alpaka).toReplaceWith(monitorpixelSoASource, _monitorpixelSoARecHitsSourceHIonAlpaka)
-
-#Define the sequence for GPU vs CPU validation
-#This should run:- individual monitor for the 2 collections + comparison module
+# Define the sequence for GPU vs CPU validation
+# This should run:- individual monitor for the 2 collections + comparison module
 from DQM.SiPixelHeterogeneous.siPixelPhase1RawDataErrorComparator_cfi import *
 from DQM.SiPixelPhase1Common.SiPixelPhase1RawData_cfi import *
-#Alpaka
-from DQM.SiPixelHeterogeneous.siPixelPhase1CompareRecHits_cfi import *
-from DQM.SiPixelHeterogeneous.siPixelPhase2CompareRecHits_cfi import *
-from DQM.SiPixelHeterogeneous.siPixelHIonPhase1CompareRecHits_cfi import *
-from DQM.SiPixelHeterogeneous.siPixelPhase1CompareTracks_cfi import *
-from DQM.SiPixelHeterogeneous.siPixelPhase2CompareTracks_cfi import *
-from DQM.SiPixelHeterogeneous.siPixelHIonPhase1CompareTracks_cfi import *
-from DQM.SiPixelHeterogeneous.siPixelCompareVertices_cfi import *
+
+# comparison modules
+from DQM.SiPixelHeterogeneous.siPixelCompareRecHitsSoA_cfi import *
+from DQM.SiPixelHeterogeneous.siPixelCompareTracksSoA_cfi import *
+from DQM.SiPixelHeterogeneous.siPixelCompareVerticesSoA_cfi import *
 
 # digi errors
 SiPixelPhase1RawDataConfForCPU = copy.deepcopy(SiPixelPhase1RawDataConf)
@@ -62,8 +41,6 @@ siPixelPhase1MonitorRawDataAGPU = SiPixelPhase1RawDataAnalyzer.clone(
     histograms  =SiPixelPhase1RawDataConfForGPU
 )
 
-### Alpaka
-
 # digi errors
 SiPixelPhase1RawDataConfForSerial = copy.deepcopy(SiPixelPhase1RawDataConf)
 for pset in SiPixelPhase1RawDataConfForSerial:
@@ -83,81 +60,80 @@ siPixelPhase1MonitorRawDataADevice = SiPixelPhase1RawDataAnalyzer.clone(
     histograms = SiPixelPhase1RawDataConfForDevice
 )
 
-siPixelPhase1CompareDigiErrorsSoAAlpaka = siPixelPhase1RawDataErrorComparator.clone(
+siPixelPhase1CompareDigiErrorsSoA = siPixelPhase1RawDataErrorComparator.clone(
     pixelErrorSrcGPU = cms.InputTag("siPixelDigiErrorsAlpaka"),
     pixelErrorSrcCPU = cms.InputTag("siPixelDigiErrorsAlpakaSerial"),
     topFolderName = cms.string('SiPixelHeterogeneous/PixelErrorCompareGPUvsCPU')
 )
 
 # PixelRecHits: monitor of CPUSerial product (Alpaka backend: 'serial_sync')
-siPixelRecHitsSoAMonitorSerial = siPixelPhase1MonitorRecHitsSoAAlpaka.clone(
+siPixelRecHitsSoAMonitorSerial = siPixelMonitorRecHitsSoA.clone(
     pixelHitsSrc = cms.InputTag( 'siPixelRecHitsPreSplittingAlpakaSerial' ),
     TopFolderName = cms.string( 'SiPixelHeterogeneous/PixelRecHitsSerial' )
 )
 
 # PixelRecHits: monitor of Device product (Alpaka backend: '')
-siPixelRecHitsSoAMonitorDevice = siPixelPhase1MonitorRecHitsSoAAlpaka.clone(
+siPixelRecHitsSoAMonitorDevice = siPixelMonitorRecHitsSoA.clone(
     pixelHitsSrc = cms.InputTag( 'siPixelRecHitsPreSplittingAlpaka' ),
     TopFolderName = cms.string( 'SiPixelHeterogeneous/PixelRecHitsDevice' )
 )
 
 # PixelTracks: monitor of CPUSerial product (Alpaka backend: 'serial_sync')
-siPixelTrackSoAMonitorSerial = siPixelPhase1MonitorTrackSoAAlpaka.clone(
+siPixelTrackSoAMonitorSerial = siPixelMonitorTrackSoA.clone(
     pixelTrackSrc = cms.InputTag('pixelTracksAlpakaSerial'),
     topFolderName = cms.string('SiPixelHeterogeneous/PixelTrackSerial')
 )
 
 # PixelTracks: monitor of CPUSerial product (Alpaka backend: 'serial_sync')
-siPixelTrackSoAMonitorDevice = siPixelPhase1MonitorTrackSoAAlpaka.clone(
+siPixelTrackSoAMonitorDevice = siPixelMonitorTrackSoA.clone(
     pixelTrackSrc = cms.InputTag('pixelTracksAlpaka'),
     topFolderName = cms.string('SiPixelHeterogeneous/PixelTrackDevice')
 )
 
 # PixelVertices: monitor of CPUSerial product (Alpaka backend: 'serial_sync')
-siPixelVertexSoAMonitorSerial = siPixelMonitorVertexSoAAlpaka.clone(
+siPixelVertexSoAMonitorSerial = siPixelMonitorVertexSoA.clone(
     pixelVertexSrc = cms.InputTag("pixelVerticesAlpakaSerial"),
     topFolderName = cms.string('SiPixelHeterogeneous/PixelVertexSerial')
 )
 
-siPixelVertexSoAMonitorDevice = siPixelMonitorVertexSoAAlpaka.clone(
+siPixelVertexSoAMonitorDevice = siPixelMonitorVertexSoA.clone(
     pixelVertexSrc = cms.InputTag("pixelVerticesAlpaka"),
     topFolderName = cms.string('SiPixelHeterogeneous/PixelVertexDevice')
 )
 
-# Run-3 sequence
+# Run-3 sequence ...
 monitorpixelSoACompareSource = cms.Sequence(siPixelPhase1MonitorRawDataACPU *
                                             siPixelPhase1MonitorRawDataAGPU *
                                             siPixelPhase1RawDataErrorComparator)
-# and the Alpaka version
-monitorpixelSoACompareSourceAlpaka = cms.Sequence(
-                                            siPixelPhase1MonitorRawDataASerial *
-                                            siPixelPhase1MonitorRawDataADevice *
-                                            siPixelPhase1CompareDigiErrorsSoAAlpaka *
-                                            siPixelRecHitsSoAMonitorSerial *
-                                            siPixelRecHitsSoAMonitorDevice *
-                                            siPixelPhase1CompareRecHits *
-                                            siPixelTrackSoAMonitorSerial *
-                                            siPixelTrackSoAMonitorDevice *
-                                            siPixelPhase1CompareTracks *
-                                            siPixelVertexSoAMonitorSerial *
-                                            siPixelVertexSoAMonitorDevice *
-                                            siPixelCompareVertices )
+# ... and the Alpaka version
+monitorpixelSoACompareSourceAlpaka = cms.Sequence(siPixelPhase1MonitorRawDataASerial *
+                                                  siPixelPhase1MonitorRawDataADevice *
+                                                  siPixelPhase1CompareDigiErrorsSoA *
+                                                  siPixelRecHitsSoAMonitorSerial *
+                                                  siPixelRecHitsSoAMonitorDevice *
+                                                  siPixelCompareRecHitsSoA *
+                                                  siPixelTrackSoAMonitorSerial *
+                                                  siPixelTrackSoAMonitorDevice *
+                                                  siPixelCompareTracksSoA *
+                                                  siPixelVertexSoAMonitorSerial *
+                                                  siPixelVertexSoAMonitorDevice *
+                                                  siPixelCompareVerticesSoA )
 
 # Phase-2 sequence ...
 _monitorpixelSoACompareSource =  cms.Sequence()
 
-# ...and the Alpaka version
-_monitorpixelSoACompareSourceAlpakaPhase2 = cms.Sequence(                                          
-                                            siPixelRecHitsSoAMonitorSerial *
-                                            siPixelRecHitsSoAMonitorDevice *
-                                            siPixelPhase1CompareRecHits *
-                                            siPixelTrackSoAMonitorSerial *
-                                            siPixelTrackSoAMonitorDevice *
-                                            siPixelPhase1CompareTracks *
-                                            siPixelVertexSoAMonitorSerial *
-                                            siPixelVertexSoAMonitorDevice *
-                                            siPixelCompareVertices )
+# ... and the Alpaka version
+_monitorpixelSoACompareSourceAlpakaPhase2 = cms.Sequence(siPixelRecHitsSoAMonitorSerial *
+                                                         siPixelRecHitsSoAMonitorDevice *
+                                                         siPixelCompareRecHitsSoA *
+                                                         siPixelTrackSoAMonitorSerial *
+                                                         siPixelTrackSoAMonitorDevice *
+                                                         siPixelCompareTracksSoA *
+                                                         siPixelVertexSoAMonitorSerial *
+                                                         siPixelVertexSoAMonitorDevice *
+                                                         siPixelCompareVerticesSoA )
 
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toReplaceWith(monitorpixelSoACompareSource,_monitorpixelSoACompareSource)
 phase2_tracker.toReplaceWith(monitorpixelSoACompareSourceAlpaka,_monitorpixelSoACompareSourceAlpakaPhase2)
 
@@ -166,5 +142,3 @@ gpuValidationPixel.toReplaceWith(monitorpixelSoASource, monitorpixelSoACompareSo
 
 from Configuration.ProcessModifiers.alpakaValidationPixel_cff import alpakaValidationPixel
 (alpakaValidationPixel & ~gpuValidationPixel ).toReplaceWith(monitorpixelSoASource, monitorpixelSoACompareSourceAlpaka)
-
-

--- a/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
@@ -33,19 +33,19 @@ hltSiPixelPhase1CompareDigiErrors = siPixelPhase1RawDataErrorComparator.clone(
     topFolderName = 'HLT/HeterogeneousComparisons/PixelErrors'
 )
 
-hltSiPixelPhase1CompareRecHits = siPixelPhase1CompareRecHits.clone(
+hltSiPixelPhase1CompareRecHits = siPixelCompareRecHitsSoA.clone(
     pixelHitsReferenceSoA = 'hltSiPixelRecHitsSoASerialSync',
     pixelHitsTargetSoA  = 'hltSiPixelRecHitsSoA',
     topFolderName = 'HLT/HeterogeneousComparisons/PixelRecHits'
 )
 
-hltSiPixelPhase1CompareTracks = siPixelPhase1CompareTracks.clone(
+hltSiPixelPhase1CompareTracks = siPixelCompareTracksSoA.clone(
     pixelTrackReferenceSoA = 'hltPixelTracksSoASerialSync',
     pixelTrackTargetSoA = 'hltPixelTracksSoA',
     topFolderName = 'HLT/HeterogeneousComparisons/PixelTracks'
 )
 
-hltSiPixelCompareVertices = siPixelCompareVertices.clone(
+hltSiPixelCompareVertices = siPixelCompareVerticesSoA.clone(
     pixelVertexReferenceSoA = 'hltPixelVerticesSoASerialSync',
     pixelVertexTargetSoA = 'hltPixelVerticesSoA',
     beamSpotSrc = 'hltOnlineBeamSpot',


### PR DESCRIPTION
#### PR description:

With the removal of obsolete CUDA-using modules from `DQM/SiPixelHeterogeneous` at https://github.com/cms-sw/cmssw/pull/49697 and the full removal of DQM plugins in the HLT menu at https://github.com/cms-sw/cmssw/pull/49928 (which simplifies dependencies) we can finally propose the long delay renaming of:

   * `SiPixelCompareRecHits` -> `SiPixelCompareRecHitsSoA`
   * `SiPixelCompareTracks` -> `SiPixelCompareTracksSoA`
   * `SiPixelCompareVertices` -> `SiPixelCompareVerticesSoA`

and of:

  * `SiPixelMonitorRecHitsSoAAlpaka` -> `SiPixelMonitorRecHitsSoA`
  * `SiPixelMonitorTrackSoAAlpaka` -> `SiPixelMonitorTrackSoA`
  * `SiPixelMonitorVertexSoAAlpaka` -> `SiPixelMonitorVertexSoA` 

I profit of this PR to remove all the `TrackerTraits` specialized module declarations.
All sequences are updated to use the new nomenclature. 
Technical, no regressions expected.

#### PR validation:

`runTheMatrix.py -what gpu` runs.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, no backport needed.