### PR TITLE
Put back SiPixel Rechits GPU-vs-CPU validation in online DQM and GPU relvals

### DIFF
--- a/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
@@ -93,7 +93,7 @@ process.siPixelTrackComparisonHarvesterAlpaka.topFolderName = cms.string('SiPixe
 #-------------------------------------
 #  User switches for what to monitor
 #-------------------------------------
-doRecHits  = False
+doRecHits  = True
 doTracks   = True
 doVertices = True
 

--- a/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
@@ -97,11 +97,11 @@ hltHcalGPUComparisonTask = hcalGPUComparisonTask.clone(
 HLTHeterogeneousMonitoringSequence = cms.Sequence(
     hltPfHcalGPUComparisonTask +
     hltSiPixelPhase1CompareDigiErrors +
-    #hltSiPixelPhase1CompareRecHits +   # waiting a resolution of #49349
+    hltSiPixelPhase1CompareRecHits +
     hltSiPixelPhase1CompareTracks +
     hltSiPixelCompareVertices +
     hltEcalMonitorTask +
-    hltHcalGPUComparisonTask    
+    hltHcalGPUComparisonTask
 )
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common


### PR DESCRIPTION
#### PR description:

Title says it all, possible after the merge of #49928 (see  [CMSHLT-3710](https://its.cern.ch/jira/browse/CMSHLT-3710) for more details) in which we have (re-)started to populate the `DQMGPUvsCPU` stream with the `SiPixelRecHits` SoA data-structures, thanks to the resolution of  https://github.com/cms-sw/cmssw/issues/49349 via https://github.com/cms-sw/cmssw/pull/49432

#### PR validation:

`scram b runtests_TestDQMOnlineClient-pixelgpu_dqm_sourceclient` runs fine after the updated.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, it will be backported to `CMSSW_16_0_X` for 2026 data-taking operations.
