### PR TITLE
Adapting changes from CMSHLT-3712 for the NGT DQM client

### DIFF
--- a/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
@@ -21,7 +21,7 @@ else:
   from DQM.Integration.config.inputsource_cfi import options
 
   if not options.inputFiles:
-      process.source.streamLabel = "streamLocalTestDataScouting"
+      process.source.streamLabel = "streamDQMTestDataScouting"
 
 # for testing in lxplus
 #process.load("DQM.Integration.config.fileinputsource_cfi")

--- a/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
@@ -31,6 +31,11 @@ else:
 #    input = cms.untracked.int32(100)
 #)
 
+# import beamspot
+from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer as _onlineBeamSpotProducer
+process.hltOnlineBeamSpot = _onlineBeamSpotProducer.clone()
+
+
 process.load("DQM.Integration.config.environment_cfi")
 
 process.dqmEnv.subSystemFolder = 'NGT'
@@ -52,11 +57,13 @@ process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 ### for pp collisions
 process.load("DQM.HLTEvF.ScoutingCollectionMonitor_cfi")
 process.scoutingCollectionMonitor.topfoldername = "NGT/ScoutingCollections"
-process.scoutingCollectionMonitor.onlyScouting = True
+process.scoutingCollectionMonitor.onlyScouting = False
+process.scoutingCollectionMonitor.onlineMetaDataDigis = "hltOnlineMetaDataDigis"
+process.scoutingCollectionMonitor.rho = ["hltScoutingPFPacker", "rho"]
 process.dqmcommon = cms.Sequence(process.dqmEnv
                                * process.dqmSaver)#*process.dqmSaverPB)
 
-process.p = cms.Path(process.dqmcommon * process.scoutingCollectionMonitor)
+process.p = cms.Path(process.dqmcommon * process.hltOnlineBeamSpot * process.scoutingCollectionMonitor)
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *


### PR DESCRIPTION
#### PR description:

This PR accommodates for the changes in menu introduced through [CMSHLT-3712](https://its.cern.ch/jira/browse/CMSHLT-3712) , renaming the path `LocalTestDataScouting` to `streamDQMTestDataScouting`. We also adapted the ngt client to include the beamspot and MetaDataDigis.

We also removed the `onlyScouting` condition everywhere as we now do save the online lumi metadata so it is no longer needed.

#### PR validation:

This PR was developed in `CMSSW_16_1_X_2026-01-20-2300`, using the packages `DQM/Integration` and `DQM/HLTEvF`.

We validated by creating streamer files in `398183` for the ngt-client and then running the following test:

```
cmsRun DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py runInputDir=DQM-Integration runNumber=398183 scanOnce=True
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport but is backported to `16_0_X` in https://github.com/cms-sw/cmssw/pull/49941.

---

cc: @mmusich 
