### PR TITLE
Phase-2: add number of L1 Tracks Validation histogram and minor changes

### DIFF
--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
@@ -185,8 +185,8 @@ void Phase2OTMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventS
           }
         }
         if (tTopo_->getOTLayerNumber(rawid) < 100) {
-          if (local_mes.PositionOfClusters_2SLadder[module] != nullptr) {
-            unsigned int ladder = tTopo_->tobRod(rawid);
+		unsigned int ladder = tTopo_->tobRod(rawid);
+          if (local_mes.PositionOfClusters_2SLadder[ladder] != nullptr) {
             //Change the module nums from 1 - 24 to -12 - 12 so that ladder 'before' the collision point is negative
             local_mes.PositionOfClusters_2SLadder[ladder]->Fill((module < 13 ? module - 13 : module - 12),
                                                                 topOrBottomColumn);

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
@@ -185,7 +185,7 @@ void Phase2OTMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventS
           }
         }
         if (tTopo_->getOTLayerNumber(rawid) < 100) {
-		unsigned int ladder = tTopo_->tobRod(rawid);
+          unsigned int ladder = tTopo_->tobRod(rawid);
           if (local_mes.PositionOfClusters_2SLadder[ladder] != nullptr) {
             //Change the module nums from 1 - 24 to -12 - 12 so that ladder 'before' the collision point is negative
             local_mes.PositionOfClusters_2SLadder[ladder]->Fill((module < 13 ? module - 13 : module - 12),

--- a/Validation/SiTrackerPhase2V/interface/Phase2ITValidateRecHitBase.h
+++ b/Validation/SiTrackerPhase2V/interface/Phase2ITValidateRecHitBase.h
@@ -44,7 +44,7 @@ public:
   ~Phase2ITValidateRecHitBase() override;
   void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
   void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
-  static void fillPSetDescription(edm::ParameterSetDescription& desc);
+  static void fillPSetDescription(edm::ParameterSetDescription& desc, bool tracking);
 
 protected:
   void bookLayerHistos(DQMStore::IBooker& ibooker, unsigned int det_id, std::string& subdir);

--- a/Validation/SiTrackerPhase2V/interface/Phase2OTValidateRecHitBase.h
+++ b/Validation/SiTrackerPhase2V/interface/Phase2OTValidateRecHitBase.h
@@ -53,7 +53,7 @@ public:
                           std::map<std::string, unsigned int>& nrechitLayerMapP_primary,
                           std::map<std::string, unsigned int>& nrechitLayerMapS_primary);
 
-  static void fillPSetDescription(edm::ParameterSetDescription& desc);
+  static void fillPSetDescription(edm::ParameterSetDescription& desc, bool tracking);
   void bookLayerHistos(DQMStore::IBooker& ibooker, unsigned int det_id, std::string& subdir);
 
 protected:

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateCluster.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateCluster.cc
@@ -378,30 +378,30 @@ void Phase2ITValidateCluster::fillDescriptions(edm::ConfigurationDescriptions& d
   {
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Pixel");
-    psd0.add<std::string>("title", "#Delta Phi pixel sensor;phi");
-    psd0.add<double>("xmin", -0.1);
+    psd0.add<std::string>("title", "#Delta Phi pixel;phi");
+    psd0.add<double>("xmin", -0.005);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 0.1);
+    psd0.add<double>("xmax", 0.005);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel", psd0);
   }
   {
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Pixel_Barrel");
-    psd0.add<std::string>("title", "#Delta Phi pixel sensor Barrel;phi");
-    psd0.add<double>("xmin", -0.1);
+    psd0.add<std::string>("title", "#Delta Phi pixel Barrel;phi");
+    psd0.add<double>("xmin", -0.005);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 0.1);
+    psd0.add<double>("xmax", 0.005);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel_Barrel", psd0);
   }
   {
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Pixel_Endcaps");
-    psd0.add<std::string>("title", "#Delta Phi pixel sensor Endcaps;phi");
-    psd0.add<double>("xmin", -0.1);
+    psd0.add<std::string>("title", "#Delta Phi pixel Endcaps;phi");
+    psd0.add<double>("xmin", -0.005);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 0.1);
+    psd0.add<double>("xmax", 0.005);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel_Endcap", psd0);
   }

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateRecHit.cc
@@ -168,7 +168,7 @@ void Phase2ITValidateRecHit::fillDescriptions(edm::ConfigurationDescriptions& de
   edm::ParameterSetDescription desc;
 
   // call the base fillPsetDescription for the plots bookings
-  Phase2ITValidateRecHitBase::fillPSetDescription(desc);
+  Phase2ITValidateRecHitBase::fillPSetDescription(desc, false);
 
   //to be used in TrackerHitAssociator
   desc.add<bool>("associatePixel", true);

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateTrackingRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateTrackingRecHit.cc
@@ -184,7 +184,7 @@ void Phase2ITValidateTrackingRecHit::fillDescriptions(edm::ConfigurationDescript
   edm::ParameterSetDescription desc;
 
   // call the base fillPsetDescription for the plots bookings
-  Phase2ITValidateRecHitBase::fillPSetDescription(desc);
+  Phase2ITValidateRecHitBase::fillPSetDescription(desc, true);
 
   //to be used in TrackerHitAssociator
   desc.add<bool>("associatePixel", true);

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateCluster.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateCluster.cc
@@ -441,9 +441,9 @@ void Phase2OTValidateCluster::fillDescriptions(edm::ConfigurationDescriptions& d
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Pixel");
     psd0.add<std::string>("title", "#Delta Phi " + mptag + ";phi");
-    psd0.add<double>("xmin", -0.1);
+    psd0.add<double>("xmin", -0.01);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 0.1);
+    psd0.add<double>("xmax", 0.01);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel", psd0);
   }
@@ -451,9 +451,9 @@ void Phase2OTValidateCluster::fillDescriptions(edm::ConfigurationDescriptions& d
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Pixel_Barrel");
     psd0.add<std::string>("title", "#Delta Phi " + mptag + " Barrel;phi");
-    psd0.add<double>("xmin", -0.1);
+    psd0.add<double>("xmin", -0.01);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 0.1);
+    psd0.add<double>("xmax", 0.01);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel_Barrel", psd0);
   }
@@ -461,9 +461,9 @@ void Phase2OTValidateCluster::fillDescriptions(edm::ConfigurationDescriptions& d
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Pixel_Endcaps");
     psd0.add<std::string>("title", "#Delta Phi " + mptag + " Endcaps;phi");
-    psd0.add<double>("xmin", -0.1);
+    psd0.add<double>("xmin", -0.01);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 0.1);
+    psd0.add<double>("xmax", 0.01);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel_Endcap", psd0);
   }
@@ -513,9 +513,9 @@ void Phase2OTValidateCluster::fillDescriptions(edm::ConfigurationDescriptions& d
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Strip");
     psd0.add<std::string>("title", "#Delta Phi " + striptag + ";phi");
-    psd0.add<double>("xmin", -0.1);
+    psd0.add<double>("xmin", -0.01);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 0.1);
+    psd0.add<double>("xmax", 0.01);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Strip", psd0);
   }
@@ -523,9 +523,9 @@ void Phase2OTValidateCluster::fillDescriptions(edm::ConfigurationDescriptions& d
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Strip_Barrel");
     psd0.add<std::string>("title", "#Delta Phi " + striptag + " Barrel;phi");
-    psd0.add<double>("xmin", -0.1);
+    psd0.add<double>("xmin", -0.01);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 0.1);
+    psd0.add<double>("xmax", 0.01);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Strip_Barrel", psd0);
   }
@@ -533,9 +533,9 @@ void Phase2OTValidateCluster::fillDescriptions(edm::ConfigurationDescriptions& d
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Strip_Endcaps");
     psd0.add<std::string>("title", "#Delta Phi " + striptag + " Endcaps;phi");
-    psd0.add<double>("xmin", -0.1);
+    psd0.add<double>("xmin", -0.01);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 0.1);
+    psd0.add<double>("xmax", 0.01);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Strip_Endcap", psd0);
   }

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateRecHit.cc
@@ -188,7 +188,7 @@ void Phase2OTValidateRecHit::fillOTHistos(const edm::Event& iEvent,
 void Phase2OTValidateRecHit::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   // call the base fillPsetDescription for the plots bookings
-  Phase2OTValidateRecHitBase::fillPSetDescription(desc);
+  Phase2OTValidateRecHitBase::fillPSetDescription(desc, false);
 
   //for macro-pixel sensors
   ///////

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTrackingRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTrackingRecHit.cc
@@ -204,7 +204,7 @@ void Phase2OTValidateTrackingRecHit::fillOTHistos(const edm::Event& iEvent,
 void Phase2OTValidateTrackingRecHit::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   // call the base fillPsetDescription for the plots bookings
-  Phase2OTValidateRecHitBase::fillPSetDescription(desc);
+  Phase2OTValidateRecHitBase::fillPSetDescription(desc, true);
 
   //for macro-pixel sensors
   ///////

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTracks.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTracks.cc
@@ -686,10 +686,10 @@ void Phase2OTValidateTracks::bookHistograms(DQMStore::IBooker &iBooker,
 
   HistoName = "n_trackParts";
   n_trackParts = iBooker.book1D(HistoName,
-		  HistoName,
-		  n_trackParticles.getParameter<int32_t>("Nbinsx"),
-		  n_trackParticles.getParameter<double>("xmin"),
-		  n_trackParticles.getParameter<double>("xmax"));
+                                HistoName,
+                                n_trackParticles.getParameter<int32_t>("Nbinsx"),
+                                n_trackParticles.getParameter<double>("xmin"),
+                                n_trackParticles.getParameter<double>("xmax"));
   n_trackParts->setAxisTitle("# track particles per event", 1);
 
   // 1D plots for nominal collection efficiency

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTracks.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTracks.cc
@@ -80,6 +80,8 @@ public:
   MonitorElement *trackParts_Eta = nullptr;
   MonitorElement *trackParts_Phi = nullptr;
   MonitorElement *trackParts_Pt = nullptr;
+  MonitorElement *n_trackParts = nullptr;
+  unsigned int nTrackParts = 0;
 
   // pT and eta for efficiency plots
   MonitorElement *tp_pt = nullptr;             // denominator
@@ -540,6 +542,7 @@ void Phase2OTValidateTracks::analyze(const edm::Event &iEvent, const edm::EventS
       trackParts_Pt->Fill(tmp_tp_pt);
       trackParts_Eta->Fill(tmp_tp_eta);
       trackParts_Phi->Fill(tmp_tp_phi);
+      nTrackParts++;
     }
 
     // if (TP_select_eventid == 0 && tmp_eventid != 0)
@@ -620,6 +623,8 @@ void Phase2OTValidateTracks::analyze(const edm::Event &iEvent, const edm::EventS
                              iEvent);  // Regular L1 Tracks
     }
   }  // end loop over tracking particles
+  n_trackParts->Fill(nTrackParts);
+  nTrackParts = 0;
 }  // end of method
 
 // ------------ method called once each job just before starting event loop
@@ -644,6 +649,7 @@ void Phase2OTValidateTracks::bookHistograms(DQMStore::IBooker &iBooker,
   edm::ParameterSet psRes_z0 = conf_.getParameter<edm::ParameterSet>("TH1Res_z0");
   edm::ParameterSet psRes_d0 = conf_.getParameter<edm::ParameterSet>("TH1Res_d0");
   edm::ParameterSet psRes_displaced_d0 = conf_.getParameter<edm::ParameterSet>("TH1Resdisplaced_d0");
+  edm::ParameterSet n_trackParticles = conf_.getParameter<edm::ParameterSet>("n_trackParticles");
   // Histogram setup and definitions
   std::string HistoName;
   iBooker.setCurrentFolder(topFolderName_ + "/trackParticles");
@@ -677,6 +683,14 @@ void Phase2OTValidateTracks::bookHistograms(DQMStore::IBooker &iBooker,
                                   psTrackParts_Phi.getParameter<double>("xmax"));
   trackParts_Phi->setAxisTitle("#phi", 1);
   trackParts_Phi->setAxisTitle("# tracking particles", 2);
+
+  HistoName = "n_trackParts";
+  n_trackParts = iBooker.book1D(HistoName,
+		  HistoName,
+		  n_trackParticles.getParameter<int32_t>("Nbinsx"),
+		  n_trackParticles.getParameter<double>("xmin"),
+		  n_trackParticles.getParameter<double>("xmax"));
+  n_trackParts->setAxisTitle("# track particles per event", 1);
 
   // 1D plots for nominal collection efficiency
   iBooker.setCurrentFolder(topFolderName_ + "/Nominal_L1TF/EfficiencyIngredients");
@@ -1432,6 +1446,13 @@ void Phase2OTValidateTracks::fillDescriptions(edm::ConfigurationDescriptions &de
     psd0.add<double>("xmax", 2.0);
     psd0.add<double>("xmin", -2.0);
     desc.add<edm::ParameterSetDescription>("TH1Resdisplaced_d0", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 100);
+    psd0.add<double>("xmax", 600.0);
+    psd0.add<double>("xmin", 0.0);
+    desc.add<edm::ParameterSetDescription>("n_trackParticles", psd0);
   }
   desc.add<std::string>("TopFolderName", "TrackerPhase2OTL1TrackV");
   desc.add<edm::InputTag>("trackingParticleToken", edm::InputTag("mix", "MergedTrackTruth"));

--- a/Validation/SiTrackerPhase2V/src/Phase2ITValidateRecHitBase.cc
+++ b/Validation/SiTrackerPhase2V/src/Phase2ITValidateRecHitBase.cc
@@ -194,9 +194,11 @@ void Phase2ITValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
   // TrackingRecHits have a larger range of delta phi values
   // The ranges are changed so validators can see the difference
   double delta_phi_range;
-  if (tracking) delta_phi_range = 0.5;
-  else delta_phi_range = 0.005;
-  
+  if (tracking)
+    delta_phi_range = 0.5;
+  else
+    delta_phi_range = 0.005;
+
   edm::ParameterSetDescription psd0;
   psd0.add<std::string>("name", "Delta_X");
   psd0.add<std::string>("title", "Delta_X;RecHit resolution X coordinate [#mum]");

--- a/Validation/SiTrackerPhase2V/src/Phase2ITValidateRecHitBase.cc
+++ b/Validation/SiTrackerPhase2V/src/Phase2ITValidateRecHitBase.cc
@@ -190,7 +190,13 @@ void Phase2ITValidateRecHitBase::fillRechitHistos(const PSimHit* simhitClosest,
   }
 }
 
-void Phase2ITValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescription& desc) {
+void Phase2ITValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescription& desc, bool tracking) {
+  // TrackingRecHits have a larger range of delta phi values
+  // The ranges are changed so validators can see the difference
+  double delta_phi_range;
+  if (tracking) delta_phi_range = 0.5;
+  else delta_phi_range = 0.005;
+  
   edm::ParameterSetDescription psd0;
   psd0.add<std::string>("name", "Delta_X");
   psd0.add<std::string>("title", "Delta_X;RecHit resolution X coordinate [#mum]");
@@ -407,28 +413,28 @@ void Phase2ITValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
 
   edm::ParameterSetDescription psd18;
   psd18.add<std::string>("name", "Delta_phi");
-  psd18.add<std::string>("title", "Delta Phi macro pixel sensor;phi;");
+  psd18.add<std::string>("title", "Delta Phi pixel;phi;");
   psd18.add<int>("NxBins", 100);
   psd18.add<bool>("switch", true);
-  psd18.add<double>("xmax", 0.5);
-  psd18.add<double>("xmin", -0.5);
+  psd18.add<double>("xmax", delta_phi_range);
+  psd18.add<double>("xmin", -delta_phi_range);
   desc.add<edm::ParameterSetDescription>("Delta_Phi", psd18);
 
   edm::ParameterSetDescription psd18b;
   psd18b.add<std::string>("name", "Delta_Phi_Pixel_Barrel");
-  psd18b.add<std::string>("title", "Delta Phi macro pixel sensor barrel;phi;");
+  psd18b.add<std::string>("title", "Delta Phi pixel barrel;phi;");
   psd18b.add<int>("NxBins", 100);
   psd18b.add<bool>("switch", true);
-  psd18b.add<double>("xmax", 0.5);
-  psd18b.add<double>("xmin", -0.5);
+  psd18b.add<double>("xmax", delta_phi_range);
+  psd18b.add<double>("xmin", -delta_phi_range);
   desc.add<edm::ParameterSetDescription>("Delta_Phi_barrel", psd18b);
 
   edm::ParameterSetDescription psd18e;
   psd18e.add<std::string>("name", "Delta_Phi_Pixel_Endcaps");
-  psd18e.add<std::string>("title", "Delta Phi macro pixel sensor endcaps;phi;");
+  psd18e.add<std::string>("title", "Delta Phi pixel endcaps;phi;");
   psd18e.add<int>("NxBins", 100);
   psd18e.add<bool>("switch", true);
-  psd18e.add<double>("xmax", 0.5);
-  psd18e.add<double>("xmin", -0.5);
+  psd18e.add<double>("xmax", delta_phi_range);
+  psd18e.add<double>("xmin", -delta_phi_range);
   desc.add<edm::ParameterSetDescription>("Delta_Phi_endcaps", psd18e);
 }

--- a/Validation/SiTrackerPhase2V/src/Phase2OTValidateRecHitBase.cc
+++ b/Validation/SiTrackerPhase2V/src/Phase2OTValidateRecHitBase.cc
@@ -353,8 +353,10 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
   // TrackingRecHits have a larger range of delta phi values than RecHits
   // The ranges are changed so validators can see the difference
   double delta_phi_range;
-  if (tracking) delta_phi_range = 0.5;
-  else delta_phi_range = 0.005;
+  if (tracking)
+    delta_phi_range = 0.5;
+  else
+    delta_phi_range = 0.005;
 
   //for macro-pixel sensors
   std::string mptag = "macro-pixel sensor";

--- a/Validation/SiTrackerPhase2V/src/Phase2OTValidateRecHitBase.cc
+++ b/Validation/SiTrackerPhase2V/src/Phase2OTValidateRecHitBase.cc
@@ -348,8 +348,14 @@ void Phase2OTValidateRecHitBase::bookLayerHistos(DQMStore::IBooker& ibooker, uns
   }
 }
 
-void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescription& desc) {
+void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescription& desc, bool tracking) {
   // rechitValidOT
+  // TrackingRecHits have a larger range of delta phi values than RecHits
+  // The ranges are changed so validators can see the difference
+  double delta_phi_range;
+  if (tracking) delta_phi_range = 0.5;
+  else delta_phi_range = 0.005;
+
   //for macro-pixel sensors
   std::string mptag = "macro-pixel sensor";
   std::string striptag = "strip sensor";
@@ -594,9 +600,9 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Pixel");
     psd0.add<std::string>("title", "#Delta Phi " + mptag + ";phi");
-    psd0.add<double>("xmin", -0.5);
+    psd0.add<double>("xmin", -delta_phi_range);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 0.5);
+    psd0.add<double>("xmax", delta_phi_range);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel", psd0);
   }
@@ -604,9 +610,9 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Pixel_Barrel");
     psd0.add<std::string>("title", "#Delta Phi " + mptag + " Barrel;phi");
-    psd0.add<double>("xmin", -0.5);
+    psd0.add<double>("xmin", -delta_phi_range);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 0.5);
+    psd0.add<double>("xmax", delta_phi_range);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel_Barrel", psd0);
   }
@@ -614,9 +620,9 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Pixel_Endcaps");
     psd0.add<std::string>("title", "#Delta Phi " + mptag + " Endcaps;phi");
-    psd0.add<double>("xmin", -0.5);
+    psd0.add<double>("xmin", -delta_phi_range);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 0.5);
+    psd0.add<double>("xmax", delta_phi_range);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Pixel_Endcaps", psd0);
   }
@@ -872,9 +878,9 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Strip");
     psd0.add<std::string>("title", "#Delta Phi " + striptag + ";phi");
-    psd0.add<double>("xmin", -0.5);
+    psd0.add<double>("xmin", -delta_phi_range);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 0.5);
+    psd0.add<double>("xmax", delta_phi_range);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Strip", psd0);
   }
@@ -882,9 +888,9 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Strip_Barrel");
     psd0.add<std::string>("title", "#Delta Phi " + striptag + " Barrel;phi");
-    psd0.add<double>("xmin", -0.5);
+    psd0.add<double>("xmin", -delta_phi_range);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 0.5);
+    psd0.add<double>("xmax", delta_phi_range);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Strip_Barrel", psd0);
   }
@@ -892,9 +898,9 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Phi_Strip_Endcaps");
     psd0.add<std::string>("title", "#Delta Phi " + striptag + " Endcaps;phi");
-    psd0.add<double>("xmin", -0.5);
+    psd0.add<double>("xmin", -delta_phi_range);
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 0.5);
+    psd0.add<double>("xmax", delta_phi_range);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Phi_Strip_Endcaps", psd0);
   }


### PR DESCRIPTION
#### PR description:
Add a plot of number of L1Track particles per event:
<img width="1375" height="636" alt="image" src="https://github.com/user-attachments/assets/9b35f63d-5bed-4565-8253-3873e38b18e7" />

Also fixed an error in P2-DQM OTClusters, where the module number would be used instead of the ladder number to check monitorelements are not null. In the full tracker geometry this still produced the correct number of histograms, but in any geom where there are fewer ladders than modules per layer (i.e. the C-Rack) the histograms would not fill properly.

#### Validation Changes
Following feedback, some histogram titles and ranges have been changed. 
Existing histogram -> new histogram
#### ITCluster
<img width="2725" height="717" alt="itCluster_Pix_Barrel" src="https://github.com/user-attachments/assets/a638983d-0f91-4ad9-b138-46c212683f97" />
<img width="2750" height="723" alt="itCluster_Pix_Endcap" src="https://github.com/user-attachments/assets/8c0734f3-07a0-404d-b222-5b8feff3b6cf" />

#### ITRecHit
<img width="2750" height="719" alt="itRecHit_pix_barrel" src="https://github.com/user-attachments/assets/338d2a0e-20d2-4217-8d98-34579737b614" />
<img width="2750" height="721" alt="itRecHit_pix_endcap" src="https://github.com/user-attachments/assets/5b4f3308-5ac2-47ca-b940-58f17d4bde54" />

#### ITTrackingRecHit
<img width="2750" height="719" alt="itTrackingRecHit_pix_barrel" src="https://github.com/user-attachments/assets/3cc2f9fe-425d-4c54-9eb9-dbac5b0488bc" />
<img width="2750" height="720" alt="itTrackingRecHit_pix_endcap" src="https://github.com/user-attachments/assets/b7ff3aa8-2b2b-475a-978d-6518baf6995e" />

#### OTCluster
<img width="2750" height="716" alt="otCluster_pix_barrel" src="https://github.com/user-attachments/assets/0deee164-ed3b-427b-99d5-0c99dc9fcf68" />
<img width="2750" height="724" alt="otCluster_pix_endcap" src="https://github.com/user-attachments/assets/4ee110a8-a13b-4e54-b42f-e430b34fd42d" />
<img width="2750" height="724" alt="otCluster_strip_barrel" src="https://github.com/user-attachments/assets/1ebb4abb-fc0e-449d-9826-e9f243f84bac" />
<img width="2750" height="718" alt="otCluster_strip_endcap" src="https://github.com/user-attachments/assets/36f6967f-99d2-4aca-ac7a-453e42704861" />

#### OTRecHit
<img width="2750" height="721" alt="otRecHit_pix_barrel" src="https://github.com/user-attachments/assets/25c9878d-49d3-4553-87e4-ff160e9b4666" />
<img width="2750" height="714" alt="otRecHit_pix_endcap" src="https://github.com/user-attachments/assets/95670bf4-639b-440b-a512-a00ab266f17b" />
<img width="2750" height="722" alt="otRecHit_strip_barrel" src="https://github.com/user-attachments/assets/43f28223-327a-4a6e-8c99-be0a9b334197" />
<img width="2750" height="717" alt="otRecHit_strip_endcap" src="https://github.com/user-attachments/assets/9f0ed3aa-4bc6-469c-b7e0-3455ab879ed1" />

#### OTTrackingRecHit
<img width="2750" height="722" alt="otTrackingRecHit_pix_barrel" src="https://github.com/user-attachments/assets/d746f4b0-7003-4b9e-89a4-710969c379fc" />
<img width="2750" height="722" alt="otTrackingRecHit_pix_endcaps" src="https://github.com/user-attachments/assets/a878bcf0-735a-4162-8ab8-6e84263ac2f1" />
<img width="2750" height="722" alt="otTrackingRecHit_strip_barrel" src="https://github.com/user-attachments/assets/eb8eb972-75bf-46c7-90f1-342aa4990bc2" />
<img width="2750" height="722" alt="otTrackingRecHit_strip_endcap" src="https://github.com/user-attachments/assets/c3770ca5-62b9-4d46-a71c-73ce9d00b239" />









