### PR TITLE
[EVO] Moved CLASS_VERSION for templated classes in DataFormats/Common

### DIFF
--- a/DataFormats/Common/interface/Association.h
+++ b/DataFormats/Common/interface/Association.h
@@ -87,7 +87,7 @@ namespace edm {
     using base::id_offset_vector;
 
     //Used by ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(3)
 
   private:
     refprod_type ref_;

--- a/DataFormats/Common/interface/AssociationMap.h
+++ b/DataFormats/Common/interface/AssociationMap.h
@@ -242,7 +242,7 @@ namespace edm {
     };
 
     //Used by ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(3)
 
   private:
     /// reference set

--- a/DataFormats/Common/interface/AssociationVector.h
+++ b/DataFormats/Common/interface/AssociationVector.h
@@ -109,7 +109,7 @@ namespace edm {
     const_iterator end() const { return transientVector().end(); }
 
     //Used by ROOT storage
-    CMS_CLASS_VERSION(11)
+    CMS_CLASS_VERSION(3)
 
   private:
     enum CacheState { kUnset, kFilling, kSet };

--- a/DataFormats/Common/interface/BaseHolder.h
+++ b/DataFormats/Common/interface/BaseHolder.h
@@ -62,7 +62,7 @@ namespace edm {
       virtual bool isTransient() const = 0;
 
       //Used by ROOT storage
-      CMS_CLASS_VERSION(10)
+      CMS_CLASS_VERSION(3)
 
     protected:
       // We want the following called only by derived classes.

--- a/DataFormats/Common/interface/ContainerMask.h
+++ b/DataFormats/Common/interface/ContainerMask.h
@@ -59,7 +59,7 @@ namespace edm {
     void swap(ContainerMask<T>& iOther);
 
     //Used by ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(3)
 
   private:
     //ContainerMask(const ContainerMask&); // stop default

--- a/DataFormats/Common/interface/DetSet.h
+++ b/DataFormats/Common/interface/DetSet.h
@@ -74,7 +74,7 @@ namespace edm {
     det_id_type detId() const { return id; }
 
     //Used by ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(3)
 
     det_id_type id;
     collection_type data;

--- a/DataFormats/Common/interface/DetSetRefVector.h
+++ b/DataFormats/Common/interface/DetSetRefVector.h
@@ -185,7 +185,7 @@ namespace edm {
     //void post_insert();
 
     //Needed for ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(3)
 
   private:
     collection_type sets_;

--- a/DataFormats/Common/interface/DetSetVector.h
+++ b/DataFormats/Common/interface/DetSetVector.h
@@ -227,7 +227,7 @@ namespace edm {
     void fillView(ProductID const& id, std::vector<void const*>& pointers, FillViewHelperVector& helpers) const;
 
     //Used by ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(3)
 
   private:
     collection_type _sets;

--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -577,7 +577,7 @@ namespace edmNew {
     DataContainer const& data() const { return m_data; }
 
     //Used by ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(3)
 
   private:
     //for testing

--- a/DataFormats/Common/interface/FwdPtr.h
+++ b/DataFormats/Common/interface/FwdPtr.h
@@ -117,7 +117,7 @@ namespace edm {
     Ptr<value_type> const& backPtr() const { return backPtr_; }
 
     //Used by ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(3)
 
   private:
     Ptr<value_type> ptr_;

--- a/DataFormats/Common/interface/FwdRef.h
+++ b/DataFormats/Common/interface/FwdRef.h
@@ -197,7 +197,7 @@ namespace edm {
     bool isTransient() const { return ref_.isTransient(); }
 
     //Used by ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(3)
 
   private:
     Ref<C, T, F> ref_;

--- a/DataFormats/Common/interface/Holder.h
+++ b/DataFormats/Common/interface/Holder.h
@@ -42,7 +42,7 @@ namespace edm {
       bool isTransient() const override { return ref_.isTransient(); }
 
       //Used by ROOT storage
-      CMS_CLASS_VERSION(10)
+      CMS_CLASS_VERSION(3)
 
     private:
       REF ref_;

--- a/DataFormats/Common/interface/IndirectHolder.h
+++ b/DataFormats/Common/interface/IndirectHolder.h
@@ -54,7 +54,7 @@ namespace edm {
       bool isTransient() const override { return helper_->isTransient(); }
 
       //Used by ROOT storage
-      CMS_CLASS_VERSION(10)
+      CMS_CLASS_VERSION(3)
 
     private:
       friend class RefToBase<T>;

--- a/DataFormats/Common/interface/IndirectVectorHolder.h
+++ b/DataFormats/Common/interface/IndirectVectorHolder.h
@@ -50,7 +50,7 @@ namespace edm {
       bool isAvailable() const override { return helper_->isAvailable(); }
 
       //Used by ROOT storage
-      CMS_CLASS_VERSION(10)
+      CMS_CLASS_VERSION(3)
 
     private:
       typedef typename base_type::const_iterator_imp const_iterator_imp;

--- a/DataFormats/Common/interface/MultiAssociation.h
+++ b/DataFormats/Common/interface/MultiAssociation.h
@@ -292,7 +292,7 @@ namespace edm {
     }
 
     //Used by ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(3)
 
   private:
     typedef helper::IndexRangeAssociation Indices;

--- a/DataFormats/Common/interface/OwnVector.h
+++ b/DataFormats/Common/interface/OwnVector.h
@@ -217,7 +217,7 @@ namespace edm {
                        std::vector<void const*>& ptrs) const;
 
     //Used by ROOT storage
-    CMS_CLASS_VERSION(11)
+    CMS_CLASS_VERSION(3)
 
   private:
     void destroy() noexcept;

--- a/DataFormats/Common/interface/Ptr.h
+++ b/DataFormats/Common/interface/Ptr.h
@@ -174,7 +174,7 @@ namespace edm {
     void const* product() const { return nullptr; }
 
     //Used by ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(3)
 
   private:
     template <typename C>

--- a/DataFormats/Common/interface/PtrVector.h
+++ b/DataFormats/Common/interface/PtrVector.h
@@ -174,7 +174,7 @@ namespace edm {
     void fillView(std::vector<void const*>& pointers, FillViewHelperVector& helpers) const;
 
     //Used by ROOT storage
-    CMS_CLASS_VERSION(8)
+    CMS_CLASS_VERSION(3)
 
   private:
     //PtrVector const& operator=(PtrVector const&); // stop default

--- a/DataFormats/Common/interface/RangeMap.h
+++ b/DataFormats/Common/interface/RangeMap.h
@@ -195,7 +195,7 @@ namespace edm {
     void swap(RangeMap<ID, C, P>& other);
 
     //Used by ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(3)
 
   private:
     /// stored collection

--- a/DataFormats/Common/interface/Ref.h
+++ b/DataFormats/Common/interface/Ref.h
@@ -261,7 +261,7 @@ namespace edm {
     RefCore const& refCore() const { return product_; }
 
     //Used by ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(3)
     //  private:
     // Constructor from member of RefVector
     Ref(RefCore const& iRefCore, key_type const& iKey) : product_(iRefCore), index_(iKey) {}
@@ -410,7 +410,7 @@ namespace edm {
     RefCore const& refCore() const { return product_.toRefCore(); }
 
     //Used by ROOT storage
-    CMS_CLASS_VERSION(11)
+    CMS_CLASS_VERSION(3)
     //  private:
     // Constructor from member of RefVector
     Ref(RefCore const& iRefCore, key_type const& iKey) : product_(iRefCore, iKey) {}

--- a/DataFormats/Common/interface/RefHolder_.h
+++ b/DataFormats/Common/interface/RefHolder_.h
@@ -39,7 +39,7 @@ namespace edm {
       bool isTransient() const override { return ref_.isTransient(); }
 
       //Needed for ROOT storage
-      CMS_CLASS_VERSION(10)
+      CMS_CLASS_VERSION(3)
     private:
       void const* pointerToType(std::type_info const& iToType) const override;
       REF ref_;

--- a/DataFormats/Common/interface/RefProd.h
+++ b/DataFormats/Common/interface/RefProd.h
@@ -144,7 +144,7 @@ namespace edm {
     void swap(RefProd<C>&);
 
     //Needed for ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(3)
 
   private:
     // Compile time check that the argument is a C* or C const*

--- a/DataFormats/Common/interface/RefToBase.h
+++ b/DataFormats/Common/interface/RefToBase.h
@@ -128,7 +128,7 @@ namespace edm {
     bool isTransient() const { return holder_ ? holder_->isTransient() : false; }
 
     //Needed for ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(3)
   private:
     value_type const* getPtrImpl() const;
     reftobase::BaseHolder<value_type>* holder_;

--- a/DataFormats/Common/interface/RefToBaseProd.h
+++ b/DataFormats/Common/interface/RefToBaseProd.h
@@ -89,7 +89,7 @@ namespace edm {
     void swap(RefToBaseProd<T>&);
 
     //Needed for ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(3)
   private:
     //NOTE: Access to RefCore should be private since we modify the use of productPtr
     RefCore const& refCore() const { return product_; }

--- a/DataFormats/Common/interface/RefToBaseVector.h
+++ b/DataFormats/Common/interface/RefToBaseVector.h
@@ -73,7 +73,7 @@ namespace edm {
     bool isAvailable() const { return holder_->isAvailable(); }
 
     //Needed for ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(3)
 
   private:
     holder_type* holder_;

--- a/DataFormats/Common/interface/RefVector.h
+++ b/DataFormats/Common/interface/RefVector.h
@@ -150,7 +150,7 @@ namespace edm {
     void fillView(ProductID const& id, std::vector<void const*>& pointers, FillViewHelperVector& helpers) const;
 
     //Needed for ROOT storage
-    CMS_CLASS_VERSION(13)
+    CMS_CLASS_VERSION(3)
 
   private:
     contents_type refVector_;

--- a/DataFormats/Common/interface/RefVectorBase.h
+++ b/DataFormats/Common/interface/RefVectorBase.h
@@ -122,7 +122,7 @@ namespace edm {
     }
 
     //Needed for ROOT storage
-    CMS_CLASS_VERSION(13)
+    CMS_CLASS_VERSION(3)
 
   private:
     std::vector<void const*> const& memberPointers() const { return memberPointersHolder_.memberPointers(); }

--- a/DataFormats/Common/interface/RefVectorHolder.h
+++ b/DataFormats/Common/interface/RefVectorHolder.h
@@ -32,7 +32,7 @@ namespace edm {
       size_t keyForIndex(size_t idx) const override;
 
       //Needed for ROOT storage
-      CMS_CLASS_VERSION(10)
+      CMS_CLASS_VERSION(3)
 
     private:
       typedef typename RefVectorHolderBase::const_iterator_imp const_iterator_imp;

--- a/DataFormats/Common/interface/SortedCollection.h
+++ b/DataFormats/Common/interface/SortedCollection.h
@@ -162,7 +162,7 @@ namespace edm {
                        std::vector<void const*>& ptrs) const;
 
     //Used by ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(3)
 
   private:
     typedef std::vector<T> collection_type;

--- a/DataFormats/Common/interface/ValueMap.h
+++ b/DataFormats/Common/interface/ValueMap.h
@@ -229,7 +229,7 @@ namespace edm {
     const_reference_type get(size_t idx) const { return values_[idx]; }
 
     //Used by ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(3)
 
   protected:
     container values_;

--- a/DataFormats/Common/interface/VectorHolder.h
+++ b/DataFormats/Common/interface/VectorHolder.h
@@ -77,7 +77,7 @@ namespace edm {
       bool isAvailable() const override { return refVector_.isAvailable(); }
 
       //Used by ROOT storage
-      CMS_CLASS_VERSION(10)
+      CMS_CLASS_VERSION(3)
 
     private:
       typedef typename base_type::const_iterator_imp const_iterator_imp;


### PR DESCRIPTION
#### PR description:

All versions are now reset to 3.


#### PR validation:

Code compiles. Running a simple failing IB RelVal now passes.

resolves https://github.com/cms-sw/framework-team/issues/1838