### PR TITLE
Require that addDefault is called in case of multiple ParameterSetDescriptions used in fillDescriptions

### DIFF
--- a/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+/// -*- C++ -*-
 //
 // Package:    DetectorDescription/DDDetectorESProducer
 // Class:      DDDetectorESProducer
@@ -99,6 +99,7 @@ void DDDetectorESProducer::fillDescriptions(ConfigurationDescriptions& descripti
   desc.add<string>("rootDDName", "cms:OCMS");
   desc.add<string>("label", "");
   desc.add<bool>("fromDB", false);
+  descriptions.addDefault(desc);
   descriptions.add("DDDetectorESProducer", desc);
 
   edm::ParameterSetDescription descDB;

--- a/FWCore/Integration/plugins/ProducerWithPSetDesc.cc
+++ b/FWCore/Integration/plugins/ProducerWithPSetDesc.cc
@@ -1140,7 +1140,12 @@ namespace edmtest {
     }
   }  // namespace
   void ProducerWithPSetDesc::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    descriptions.addDefault(description(2));
+
+    // ------------------------------------------
+
     auto iDesc = description(2147483647);
+
     // ------------------------------------------
 
     descriptions.add("testProducerWithPsetDesc", iDesc);
@@ -1209,10 +1214,6 @@ namespace edmtest {
 
     iDesc1.add("noDefaultPset2", noDefaultPset2);
     descriptions.add("testLabel1", iDesc1);
-
-    // ------------------------------------------
-
-    descriptions.addDefault(description(2));
 
     // ------------------------------------------
 

--- a/FWCore/ParameterSet/src/ConfigurationDescriptions.cc
+++ b/FWCore/ParameterSet/src/ConfigurationDescriptions.cc
@@ -74,6 +74,10 @@ namespace edm {
       }
     }
 
+    if (!descriptions_.empty() && defaultDescDefined_ == false) {
+      throw edm::Exception(edm::errors::LogicError,
+                           "If more than one ParameterSetDescription added, must first do addDefault\n");
+    }
     // To minimize the number of copies involved create an empty description first
     // and push it into the vector.  Then perform the copy.
     std::pair<std::string, ParameterSetDescription> pairWithEmptyDescription;

--- a/FWCore/ParameterSet/src/ConfigurationDescriptions.cc
+++ b/FWCore/ParameterSet/src/ConfigurationDescriptions.cc
@@ -75,8 +75,9 @@ namespace edm {
     }
 
     if (!descriptions_.empty() && defaultDescDefined_ == false) {
-      throw edm::Exception(edm::errors::LogicError,
-                           "If more than one ParameterSetDescription added, must first do addDefault\n");
+      throw edm::Exception(
+          edm::errors::LogicError,
+          "More than one ParameterSetDescription was added, one of them must be added with addDefault()\n");
     }
     // To minimize the number of copies involved create an empty description first
     // and push it into the vector.  Then perform the copy.

--- a/Geometry/MTDGeometryBuilder/plugins/MTDDigiGeometryESModule.cc
+++ b/Geometry/MTDGeometryBuilder/plugins/MTDDigiGeometryESModule.cc
@@ -88,6 +88,7 @@ void MTDDigiGeometryESModule::fillDescriptions(edm::ConfigurationDescriptions& d
   descDB.add<bool>("fromDDD", false);
   descDB.add<bool>("applyAlignment", true);
   descDB.add<std::string>("alignmentsLabel", "");
+  descriptions.addDefault(descDB);
   descriptions.add("mtdGeometryDB", descDB);
 
   edm::ParameterSetDescription desc;

--- a/Geometry/MTDNumberingBuilder/plugins/MTDGeometricTimingDetESModule.cc
+++ b/Geometry/MTDNumberingBuilder/plugins/MTDGeometricTimingDetESModule.cc
@@ -53,6 +53,7 @@ void MTDGeometricTimingDetESModule::fillDescriptions(edm::ConfigurationDescripti
   edm::ParameterSetDescription descDB;
   descDB.add<bool>("fromDDD", false);
   descDB.add<bool>("fromDD4hep", false);
+  descriptions.addDefault(descDB);
   descriptions.add("mtdNumberingGeometryDB", descDB);
 
   edm::ParameterSetDescription desc;

--- a/Geometry/TrackerGeometryBuilder/plugins/TrackerDigiGeometryESModule.cc
+++ b/Geometry/TrackerGeometryBuilder/plugins/TrackerDigiGeometryESModule.cc
@@ -94,6 +94,7 @@ void TrackerDigiGeometryESModule::fillDescriptions(edm::ConfigurationDescription
   descDB.add<bool>("fromDDD", false);
   descDB.add<bool>("applyAlignment", true);
   descDB.add<std::string>("alignmentsLabel", "");
+  descriptions.addDefault(descDB);
   descriptions.add("trackerGeometryDB", descDB);
 
   edm::ParameterSetDescription desc;

--- a/Geometry/TrackerNumberingBuilder/plugins/TrackerGeometricDetESModule.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/TrackerGeometricDetESModule.cc
@@ -53,6 +53,7 @@ void TrackerGeometricDetESModule::fillDescriptions(edm::ConfigurationDescription
   edm::ParameterSetDescription descDB;
   descDB.add<bool>("fromDDD", false);
   descDB.add<bool>("fromDD4hep", false);
+  descriptions.addDefault(descDB);
   descriptions.add("trackerNumberingGeometryDB", descDB);
 
   edm::ParameterSetDescription desc;

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescaler.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescaler.cc
@@ -358,6 +358,7 @@ void L1TGlobalPrescaler::fillDescriptions(edm::ConfigurationDescriptions& descri
             // if mode is "applyColumnValues", "applyColumnRatios" or "forceColumnValues", read the target column
             "applyColumnValues" >> l1tPrescaleColumn or "applyColumnRatios" >> l1tPrescaleColumn or
             "forceColumnValues" >> l1tPrescaleColumn);
+    descriptions.addDefault(desc);
     descriptions.add("l1tGlobalPrescaler", desc);
   }
 

--- a/RecoBTag/ONNXRuntime/plugins/DeepDoubleXONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/DeepDoubleXONNXJetTagsProducer.cc
@@ -123,6 +123,7 @@ void DeepDoubleXONNXJetTagsProducer::fillDescriptions(edm::ConfigurationDescript
   };
   auto descBvL(desc);
   descBvL.ifValue(edm::ParameterDescription<std::string>("flavor", "BvL", true), flavorCases());
+  descriptions.addDefault(descBvL);
   descriptions.add("pfDeepDoubleBvLJetTags", descBvL);
 
   auto descCvL(desc);

--- a/RecoLocalCalo/HcalRecProducers/src/HcalSimpleReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalSimpleReconstructor.cc
@@ -128,6 +128,7 @@ void HcalSimpleReconstructor::fillDescriptions(edm::ConfigurationDescriptions& d
   descHO.add<bool>("dropZSmarkedPassed", true);
   descHO.add<bool>("correctForPhaseContainment", true);
   descHO.add<int>("firstSample", 4);
+  descriptions.addDefault(descHO);
   descriptions.add("hosimplereco", descHO);
 
   // hfreco

--- a/RecoMET/METFilters/plugins/BadParticleFilter.cc
+++ b/RecoMET/METFilters/plugins/BadParticleFilter.cc
@@ -233,6 +233,7 @@ void BadParticleFilter::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.add<double>("maxDR", 0.001);
   desc.add<edm::InputTag>("muons", edm::InputTag("muons"));
   desc.add<double>("minPtDiffRel", 0.0);
+  descriptions.addDefault(desc);
   descriptions.add("BadPFMuonFilter", desc);
   descriptions.addWithDefaultLabel(desc);
 }

--- a/RecoMET/METProducers/src/PFMETProducer.cc
+++ b/RecoMET/METProducers/src/PFMETProducer.cc
@@ -148,6 +148,7 @@ namespace cms {
     edm::ParameterSetDescription desc2 = desc;
     desc1.add<bool>("applyWeight", false);
     desc1.add<edm::InputTag>("srcWeights", edm::InputTag(""));
+    descriptions.addDefault(desc1);
     descriptions.add("pfMet", desc1);
     desc2.add<bool>("applyWeight", true);
     desc2.add<edm::InputTag>("srcWeights", edm::InputTag("puppiNoLep"));

--- a/RecoMuon/GlobalTrackingTools/src/MuonTrackingRegionBuilder.cc
+++ b/RecoMuon/GlobalTrackingTools/src/MuonTrackingRegionBuilder.cc
@@ -269,6 +269,7 @@ void MuonTrackingRegionBuilder::fillDescriptions(edm::ConfigurationDescriptions&
   {
     edm::ParameterSetDescription desc;
     fillDescriptionsOffline(desc);
+    descriptions.addDefault(desc);
     descriptions.add("MuonTrackingRegionBuilder", desc);
   }
   {

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauTagInfoProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauTagInfoProducer.cc
@@ -132,6 +132,7 @@ void PFRecoTauTagInfoProducer::fillDescriptions(edm::ConfigurationDescriptions& 
     desc.add<double>("smearedPVsigmaZ", 0.005);
     desc.add<double>("ChargedHadrCand_tkPVmaxDZ", 0.2);
     desc.add<double>("tkmaxipt", 0.03);
+    descriptions.addDefault(desc);
     descriptions.add("pfRecoTauTagInfoProducerInsideOut", desc);
   }
   {

--- a/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegionProducerFromBeamSpot.h
+++ b/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegionProducerFromBeamSpot.h
@@ -58,6 +58,7 @@ public:
       edm::ParameterSetDescription descRegion;
       descRegion.add<edm::ParameterSetDescription>("RegionPSet", desc);
 
+      descriptions.addDefault(descRegion);
       descriptions.add("globalTrackingRegionFromBeamSpot", descRegion);
     }
 


### PR DESCRIPTION
#### PR description:

- enforce that an explicit default is chosen in case where multiple options are present.

#### PR validation:

Code compiles. No changes are expected in behavior.

resolves https://github.com/cms-sw/framework-team/issues/1843