### PR TITLE
Add `PresentThesholdAbortAllocMonitor`

### DIFF
--- a/PerfTools/AllocMonitor/README.md
+++ b/PerfTools/AllocMonitor/README.md
@@ -176,3 +176,12 @@ This service registers a monitor when the service is created and will abort the 
 - `skipCount` : the number of times allocations have satisfied the `minThreshold` to `maxThreshold` range before the next time will trigger an abort. A value of `0` will trigger the first time the range is met.
 
 This service is multi-thread safe although it may not yield consistent results if multiple threads reach the criteria at the same time. Using `skipCount` concurrently will likely make the inconsistency worse.
+
+### PresentThresholdAbortAllocMonitor
+
+This service registers a monitor when the service is created and will abort the job (which will normally trigger a stack trace) if the actual presently allocated memory would grow above a threshold for a specified number of times. The service accepts the following parameters
+
+- `threshold` : the number of bytes the actual presently allocated memory must reach before an abort might be triggered.
+- `skipCount` : the number of times the `threshold` condition is crossed  before the next time will trigger an abort. A value of `0` will trigger the first time the `threshold` is met.
+
+This service is multi-thread safe although it may not yield consistent results if multiple threads reach the criteria at the same time. Using `skipCount` concurrently will likely make the inconsistency worse.

--- a/PerfTools/AllocMonitor/plugins/PresentThresholdAbortAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/PresentThresholdAbortAllocMonitor.cc
@@ -1,0 +1,72 @@
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+
+#include "PerfTools/AllocMonitor/interface/AllocMonitorBase.h"
+#include "PerfTools/AllocMonitor/interface/AllocMonitorRegistry.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include <atomic>
+#include <iostream>
+#include <format>
+
+namespace {
+  class MonitorAdaptor : public cms::perftools::AllocMonitorBase {
+  public:
+    MonitorAdaptor(unsigned int skip, size_t threshold) : m_skip{skip}, m_threshold{threshold} {}
+
+  private:
+    void allocCalled(size_t iRequested, size_t iActual, void const*) final {
+      // returns previous value
+      auto const before = m_presentActual.fetch_add(iActual, std::memory_order_acq_rel);
+      auto const after = before + iActual;
+      if (before < m_threshold and after >= m_threshold) {
+        auto v = ++m_count;
+        if (v > m_skip) {
+          std::cout << std::format(
+                           "abort threshold reached count: {} request: {} presentActual: {}", v, iRequested, after)
+                    << std::endl;
+          abort();
+        }
+      }
+    }
+
+    void deallocCalled(size_t iActual, void const*) final {
+      if (0 == iActual)
+        return;
+      auto const present = m_presentActual.load(std::memory_order_acquire);
+      if (present >= iActual) {
+        m_presentActual.fetch_sub(iActual, std::memory_order_acq_rel);
+      }
+    }
+
+    unsigned int m_skip;
+    size_t m_threshold;
+    std::atomic<unsigned int> m_count = 0;
+    std::atomic<size_t> m_presentActual = 0;
+  };
+}  // namespace
+
+class PresentThresholdAbortAllocMonitor {
+public:
+  PresentThresholdAbortAllocMonitor(edm::ParameterSet const& iPSet) {
+    (void)cms::perftools::AllocMonitorRegistry::instance().createAndRegisterMonitor<MonitorAdaptor>(
+        iPSet.getUntrackedParameter<unsigned int>("skipCount"),
+        iPSet.getUntrackedParameter<unsigned long long>("threshold"));
+  };
+  static void fillDescriptions(edm::ConfigurationDescriptions& iConfig) {
+    edm::ParameterSetDescription desc;
+    desc.addUntracked<unsigned int>("skipCount", 0)
+        ->setComment(
+            "Number of times the present allocated memory crossing the thresholdmust be met before doing an abort. A "
+            "value of 0 will happen the first "
+            "time.");
+    desc.addUntracked<unsigned long long>("threshold")
+        ->setComment("Present allocated memory going over this limit triggers the abort. The units are bytes.");
+    iConfig.addDefault(desc);
+  }
+};
+
+typedef edm::serviceregistry::ParameterSetMaker<PresentThresholdAbortAllocMonitor>
+    PresentThresholdAbortAllocMonitorMaker;
+DEFINE_FWK_SERVICE_MAKER(PresentThresholdAbortAllocMonitor, PresentThresholdAbortAllocMonitorMaker);


### PR DESCRIPTION
#### PR description:

This PR adds `PresentThesholdAbortAllocMonitor` that aborts when the actual presently allocated memory goes over a configurable threshold.

Resolves https://github.com/cms-sw/framework-team/issues/1847

#### PR validation:

Used successfully to investigate https://github.com/cms-sw/cmssw/issues/49949