### PR TITLE
add a customization function for modules renamed in #49936, still used in the 2025 frozen HLT menu

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -198,6 +198,38 @@ def customizeHLTfor49436(process):
 
     return process
 
+def customizeHLTfor49936(process):
+    """
+    Update Pixel comparison and monitoring modules to comply with the
+    SoA-based plugin migration introduced in PR #49936.
+
+    Existing HLT menus use legacy plugin types (e.g.
+    SiPixelPhase1CompareRecHits); this customization updates the C++
+    plugin type in place while preserving:
+      - module labels
+      - parameters
+      - path and task scheduling
+    """
+
+    from HLTrigger.Configuration.common import producers_by_type
+
+    type_map = {
+        "SiPixelPhase1CompareRecHits": "SiPixelCompareRecHitsSoA",
+        "SiPixelPhase1CompareTracks": "SiPixelCompareTracksSoA",
+        "SiPixelCompareVertices": "SiPixelCompareVerticesSoA",
+
+        "SiPixelPhase1MonitorRecHitsSoAAlpaka": "SiPixelMonitorRecHitsSoA",
+        "SiPixelPhase1MonitorTrackSoAAlpaka": "SiPixelMonitorTrackSoA",
+        "SiPixelMonitorVertexSoAAlpaka": "SiPixelMonitorVertexSoA",
+    }
+
+    for old_type, new_type in type_map.items():
+        for module in producers_by_type(process, old_type):
+            module._TypedParameterizable__type = new_type
+
+    return process
+
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -206,5 +238,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     # process = customiseFor12718(process)
 
     # process = customizeHLTfor49436(process)
+
+    process = customizeHLTfor49936(process)
 
     return process


### PR DESCRIPTION
#### PR description:

PR #49936 changed the names of a few modules that used to be included in the 2025 frozen menu.
In PRs    
  * https://github.com/cms-sw/cmssw/pull/49747 (16.1.X)
  * https://github.com/cms-sw/cmssw/pull/49766 (16.0.X)
  
we changed the default HLT menu run in 2025 relvals to be the `Fake` one, thus the problem is not caught in IB relvals.
Also the IB TSG tests are not running the frozen menu, but only the development tables:

https://github.com/cms-sw/cmssw/blob/79a3459af5f470014daf33615829579a5e602f73/HLTrigger/Configuration/test/runOne.csh#L16-L17

thus also not seen in IB TSG tests.

@Martin-Grunewald noticed in private tests that this breaks the running of the full batter of TSG tests.

#### PR validation:

With the updated branch, I run `./runAll.csh frozen`
Obtaining:

```
2026-01-28 Wed 14:38:26
Starting ./runOne.csh MC frozen

14:38:26 cmsRun RelVal_DigiL1Raw_2025v13_MC.py >& RelVal_DigiL1Raw_2025v13_MC.log
141.766u 5.752s 3:04.97 79.7%	0+0k 1664+278376io 3473pf+0w
14:41:31 exit status: 0

14:41:31 cmsRun OnLine_HLT_2025v13.py realData=False globalTag=@ inputFiles=@ >& OnLine_HLT_2025v13_MC.log
92.176u 18.553s 1:43.90 106.5%	0+0k 57200+1699984io 671pf+0w
14:43:15 exit status: 0

14:43:15 cmsRun RelVal_HLT_2025v13_MC.py >& RelVal_HLT_2025v13_MC.log
79.815u 14.079s 1:18.01 120.3%	0+0k 176360+779832io 0pf+0w
14:44:33 exit status: 0

14:44:33 cmsRun RelVal_HLT2_2025v13_MC.py >& RelVal_HLT2_2025v13_MC.log
65.159u 13.013s 1:02.14 125.7%	0+0k 16+93272io 0pf+0w
14:45:35 exit status: 0

14:45:35 cmsRun RelVal_HLT_Reco_2025v13_MC.py >& RelVal_HLT_Reco_2025v13_MC.log
73.305u 13.287s 1:24.19 102.8%	0+0k 59080+89808io 8pf+0w
14:46:59 exit status: 0

14:46:59 cmsRun RelVal_DigiL1RawHLT_2025v13_MC.py >& RelVal_DigiL1RawHLT_2025v13_MC.log
186.994u 15.847s 3:50.23 88.0%	0+0k 4120+908256io 1682pf+0w
14:50:49 exit status: 0

14:50:50 cmsRun RelVal_RECO_2025v13_MC.py >& RelVal_RECO_2025v13_MC.log
248.826u 22.660s 3:06.58 145.5%	0+0k 444560+301544io 1815pf+0w
14:53:56 exit status: 0

Finished ./runOne.csh MC frozen
2026-01-28 Wed 14:53:56
888.638u 103.979s 16:08.02 102.5%	0+0k 743312+4151072io 7652pf+0w

2026-01-28 Wed 14:38:25
Starting ./runOne.csh DATA frozen

14:38:25 cmsRun RelVal_L1RePack_2025v13_DATA.py >& RelVal_L1RePack_2025v13_DATA.log
60.657u 5.375s 0:52.85 124.9%	0+0k 88+356112io 4355pf+0w
14:39:18 exit status: 0

14:39:18 cmsRun OnLine_HLT_2025v13.py realData=True globalTag=@ inputFiles=@ >& OnLine_HLT_2025v13_DATA.log
209.690u 28.237s 2:40.91 147.8%	0+0k 193832+10505624io 1347pf+0w
14:41:59 exit status: 0

14:41:59 cmsRun RelVal_HLT_2025v13_DATA.py >& RelVal_HLT_2025v13_DATA.log
139.021u 16.734s 1:36.33 161.6%	0+0k 331408+1840160io 50pf+0w
14:43:36 exit status: 0

14:43:36 cmsRun RelVal_HLT2_2025v13_DATA.py >& RelVal_HLT2_2025v13_DATA.log
147.872u 17.510s 1:26.75 190.6%	0+0k 16+413496io 0pf+0w
14:45:03 exit status: 0

14:45:03 cmsRun RelVal_HLT_Reco_2025v13_DATA.py >& RelVal_HLT_Reco_2025v13_DATA.log
168.733u 18.006s 1:43.03 181.2%	0+0k 201064+408432io 303pf+0w
14:46:46 exit status: 0

14:46:46 cmsRun RelVal_RECO_2025v13_DATA.py >& RelVal_RECO_2025v13_DATA.log
902.930u 44.743s 6:20.64 248.9%	0+0k 638656+766672io 1198pf+0w
14:53:06 exit status: 0

Finished ./runOne.csh DATA frozen
2026-01-28 Wed 14:53:06

Resulting log files:
-rw-r--r--. 1 musich zh 25599363 Jan 28 14:41 OnLine_HLT_2025v13_DATA.log
-rw-r--r--. 1 musich zh 25630477 Jan 28 14:43 OnLine_HLT_2025v13_MC.log
-rw-r--r--. 1 musich zh 23207793 Jan 28 14:50 RelVal_DigiL1RawHLT_2025v13_MC.log
-rw-r--r--. 1 musich zh    77814 Jan 28 14:41 RelVal_DigiL1Raw_2025v13_MC.log
-rw-r--r--. 1 musich zh 23168564 Jan 28 14:45 RelVal_HLT2_2025v13_DATA.log
-rw-r--r--. 1 musich zh 23194915 Jan 28 14:45 RelVal_HLT2_2025v13_MC.log
-rw-r--r--. 1 musich zh 23168613 Jan 28 14:43 RelVal_HLT_2025v13_DATA.log
-rw-r--r--. 1 musich zh 23192630 Jan 28 14:44 RelVal_HLT_2025v13_MC.log
-rw-r--r--. 1 musich zh 23174509 Jan 28 14:46 RelVal_HLT_Reco_2025v13_DATA.log
-rw-r--r--. 1 musich zh 23199246 Jan 28 14:46 RelVal_HLT_Reco_2025v13_MC.log
-rw-r--r--. 1 musich zh    71873 Jan 28 14:39 RelVal_L1RePack_2025v13_DATA.log
-rw-r--r--. 1 musich zh   569833 Jan 28 14:53 RelVal_RECO_2025v13_DATA.log
-rw-r--r--. 1 musich zh   657939 Jan 28 14:53 RelVal_RECO_2025v13_MC.log

2026-01-28 Wed 14:53:56

```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:


