### PR TITLE
Speed up RNTupleTempSource by caching more RNTupleViews

### DIFF
--- a/FWIO/RNTupleTempInput/src/RootFile.cc
+++ b/FWIO/RNTupleTempInput/src/RootFile.cc
@@ -186,6 +186,8 @@ namespace edm::rntuple_temp {
                                             ? eventTree_.view(poolNames::eventToProcessBlockIndexesBranchName())
                                             : std::optional<ROOT::RNTupleView<void>>()),
         productProvenanceView_(eventTree_.view(BranchTypeToProductProvenanceBranchName(eventTree_.branchType()))),
+        eventSelectionIDsView_(eventTree_.view(poolNames::eventSelectionsBranchName())),
+        branchListIndexesView_(eventTree_.view(poolNames::branchListIndexesBranchName())),
         productDependencies_(new ProductDependencies),
         duplicateChecker_(crossFileInfo.duplicateChecker),
         provenanceReaderMaker_(),
@@ -1102,22 +1104,17 @@ namespace edm::rntuple_temp {
     // We could consider doing delayed reading, but because we have to
     // store this History object in a different tree than the event
     // data tree, this is too hard to do in this first version.
-    if (fileFormatVersion().eventHistoryBranch()) {
-      assert(false);
-    } else if (fileFormatVersion().eventHistoryTree()) {
-      assert(false);
-      // for backward compatibility.
-    } else if (fileFormatVersion().noMetaDataTrees()) {
-      // Current format
-      auto eventSelectionIDsView = eventTree_.view(poolNames::eventSelectionsBranchName());
-      assert(eventSelectionIDsView.has_value());
-      eventSelectionIDsView->BindRawPtr(&eventSelectionIDs);
-      eventTree_.fillEntry(*eventSelectionIDsView);
-      auto branchListIndexesView = eventTree_.view(poolNames::branchListIndexesBranchName());
-      assert(branchListIndexesView.has_value());
-      branchListIndexesView->BindRawPtr(&branchListIndexes);
-      eventTree_.fillEntry(*branchListIndexesView);
-    }
+    assert(not fileFormatVersion().eventHistoryBranch());
+    assert(not fileFormatVersion().eventHistoryTree());
+    // Current format
+    assert(fileFormatVersion().noMetaDataTrees());
+    assert(eventSelectionIDsView_.has_value());
+    assert(branchListIndexesView_.has_value());
+    eventSelectionIDsView_->BindRawPtr(&eventSelectionIDs);
+    eventTree_.fillEntry(*eventSelectionIDsView_);
+    branchListIndexesView_->BindRawPtr(&branchListIndexes);
+    eventTree_.fillEntry(*branchListIndexesView_);
+
     if (daqProvenanceHelper_) {
       evtAux.setProcessHistoryID(daqProvenanceHelper_->mapProcessHistoryID(evtAux.processHistoryID()));
     }

--- a/FWIO/RNTupleTempInput/src/RootFile.h
+++ b/FWIO/RNTupleTempInput/src/RootFile.h
@@ -306,6 +306,8 @@ namespace edm {
       EventToProcessBlockIndexes eventToProcessBlockIndexes_;
       std::optional<ROOT::RNTupleView<void>> eventToProcessBlockIndexesView_;
       std::optional<ROOT::RNTupleView<void>> productProvenanceView_;
+      std::optional<ROOT::RNTupleView<void>> eventSelectionIDsView_;
+      std::optional<ROOT::RNTupleView<void>> branchListIndexesView_;
       edm::propagate_const<std::shared_ptr<ProductDependencies>> productDependencies_;
       edm::propagate_const<std::shared_ptr<DuplicateChecker>> duplicateChecker_;
       edm::propagate_const<std::unique_ptr<MakeProvenanceReader>> provenanceReaderMaker_;

--- a/FWIO/RNTupleTempInput/src/RootFile.h
+++ b/FWIO/RNTupleTempInput/src/RootFile.h
@@ -305,6 +305,7 @@ namespace edm {
       std::map<std::string, std::string> newBranchToOldBranch_;
       EventToProcessBlockIndexes eventToProcessBlockIndexes_;
       std::optional<ROOT::RNTupleView<void>> eventToProcessBlockIndexesView_;
+      std::optional<ROOT::RNTupleView<void>> productProvenanceView_;
       edm::propagate_const<std::shared_ptr<ProductDependencies>> productDependencies_;
       edm::propagate_const<std::shared_ptr<DuplicateChecker>> duplicateChecker_;
       edm::propagate_const<std::unique_ptr<MakeProvenanceReader>> provenanceReaderMaker_;

--- a/FWIO/RNTupleTempInput/src/RootRNTuple.h
+++ b/FWIO/RNTupleTempInput/src/RootRNTuple.h
@@ -167,8 +167,8 @@ namespace edm::rntuple_temp {
     void fillEntry(ROOT::RNTupleView<void>& view) { getEntry(view, entryNumber_); }
     void fillEntry(ROOT::RNTupleView<void>& view, EntryNumber entryNumber) { getEntry(view, entryNumber); }
 
-    void fillEntry(ROOT::DescriptorId_t id, EntryNumber entryNumber, void* iData) {
-      auto view = reader_->GetView(id, iData);
+    void fillEntry(ROOT::RNTupleView<void>& view, EntryNumber entryNumber, void* iData) {
+      view.BindRawPtr(iData);
       getEntry(view, entryNumber);
     }
 


### PR DESCRIPTION
#### PR description:

Following https://github.com/cms-sw/cmssw/pull/49902 this PR caches the RNTupleViews for the provenance and for the event history fields. The repetitive creation of these RNTupleViews was pointed by VTune profile in https://github.com/cms-sw/cmssw/issues/48400#issuecomment-3787359750.

Resolves https://github.com/cms-sw/cmssw/issues/48400
Resolves https://github.com/cms-sw/framework-team/issues/1818

#### PR validation:

Step3 of workflow 139.005 completes in ~5 minutes on 1 thread. VTune profile did not show further obvious RNTuple-related bottlenecks.