### PR TITLE
[16.0.X] Add dummy implementation of edm::typeDemangle for standalone LST

### DIFF
--- a/RecoTracker/LSTCore/standalone/bin/lst.cc
+++ b/RecoTracker/LSTCore/standalone/bin/lst.cc
@@ -3,6 +3,8 @@
 
 #include <typeinfo>
 
+#include <boost/core/demangle.hpp>
+
 using LSTEvent = ALPAKA_ACCELERATOR_NAMESPACE::lst::LSTEvent;
 using LSTInputDeviceCollection = ALPAKA_ACCELERATOR_NAMESPACE::lst::LSTInputDeviceCollection;
 using namespace ::lst;
@@ -569,3 +571,9 @@ void run_lst() {
 
   delete ana.output_tfile;
 }
+
+// Dummy implementation of edm::typeDemangle (without extra replacements)
+// to avoid having to link extra libraries
+namespace edm {
+  std::string typeDemangle(char const *mangledName) { return boost::core::demangle(mangledName); }
+}  // namespace edm


### PR DESCRIPTION
This PR adds a dummy implementation of edm::typeDemangle so that we don't have to link extra libraries when using the standalone version of LST. This is in response to #49953, where the dependency is introduced through PortableCollections.

This is a backport of #49964.