### PR TITLE
Add fillDescription to PFAnalyzer 

### DIFF
--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
@@ -23,6 +23,8 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Common/interface/TriggerNames.h"
 
@@ -70,6 +72,8 @@ public:
 
   /// Initialize run-based parameters
   void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   struct binInfo;

--- a/DQMOffline/ParticleFlow/python/runBasic_cff.py
+++ b/DQMOffline/ParticleFlow/python/runBasic_cff.py
@@ -1,11 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+from DQMOffline.ParticleFlow.pfAnalyzer_cfi import pfAnalyzer
 
-PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
+PFAnalyzer = pfAnalyzer.clone( 
+    isMiniAOD = cms.bool(True),
     pfCandidates             = cms.InputTag("particleFlow"),
     pfJetCollection        = cms.InputTag("ak4PFJetsPuppiCorrected"),
     PVCollection             = cms.InputTag("offlinePrimaryVertices"),
-
     TriggerResultsLabel        = cms.InputTag("TriggerResults::HLT"),
     TriggerNames = cms.vstring("HLT_PFJet450"),
     #puppiWeight  = cms.InputTag("packedPuppiweight"),
@@ -109,6 +110,4 @@ PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
                                    '[pt;20;10000]',
                                   ),
     )
-
-
 )

--- a/DQMOffline/ParticleFlow/python/runBasic_cfg.py
+++ b/DQMOffline/ParticleFlow/python/runBasic_cfg.py
@@ -19,7 +19,7 @@ process.load("DQMServices.Components.DQMEnvironment_cfi")
 process.load('JetMETCorrections.Configuration.JetCorrectors_cff')
 
 # my analyzer
-process.load('DQMOffline.ParticleFlow.runBasic_cfi')
+process.load('DQMOffline.ParticleFlow.runBasic_cff')
 
 # Setup Global Tag
 from Configuration.AlCa.GlobalTag import GlobalTag
@@ -55,8 +55,6 @@ goldenJSONPath="/eos/user/c/cmsdqm/www/CAF/certification/Collisions25/Cert_Colli
 if goldenJSONPath != "":
     import FWCore.PythonUtilities.LumiList as LumiList
     process.source.lumisToProcess = LumiList.LumiList(filename = goldenJSONPath).getVLuminosityBlockRange()
-
-from DQMOffline.ParticleFlow.runBasic_cfi import *
 
 process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
                                      fileName = cms.untracked.string("OUT_step1.root"))


### PR DESCRIPTION
#### PR description:

This PR adds `fillDescription` to the PFAnalyzer. The usage examples for configuring the module ( `runBasic_cfi`) has been moved to `runBasic_cff` and the corresponding `runBasic_cfg` modified to load the new `cff`. 
The PR adds to the python configuration parameters `isMiniAOD` to tell the module if the input files being processed are in MiniAOD or RECO format. 

Should make the module a bit more flexibile and re-used for Phase-2 studies in a simpler way

@jroloff @jsamudio @stahlleiton @ahinzmann 
