### PR TITLE
Fix function input type in the OneToManyAssoc of the alpaka interface

### DIFF
--- a/HeterogeneousCore/AlpakaInterface/interface/HistoContainer.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/HistoContainer.h
@@ -119,19 +119,21 @@ namespace cms::alpakatools {
     }
   }
 
-  template <typename T,      // the type of the discretized input values
-            uint32_t NBINS,  // number of bins
-            int32_t SIZE,    // max number of element. If -1 is initialized at runtime using external storage
+  template <typename T,                         // the type of the discretized input values
+            FlexiStorageBase::size_type NBINS,  // number of bins
+            // max number of element. If cms::alpakatools::kDynamicSize is initialized at runtime using external storage
+            FlexiStorageBase::size_type SIZE,
             uint32_t S = sizeof(T) * 8,  // number of significant bits in T
             typename I = uint32_t,  // type stored in the container (usually an index in a vector of the input values)
-            uint32_t NHISTS = 1     // number of histos stored
+            FlexiStorageBase::size_type NHISTS = 1  // number of histos stored
             >
   class HistoContainer : public OneToManyAssocRandomAccess<I, NHISTS * NBINS + 1, SIZE> {
   public:
     using Base = OneToManyAssocRandomAccess<I, NHISTS * NBINS + 1, SIZE>;
     using View = typename Base::View;
     using Counter = typename Base::Counter;
-    using index_type = typename Base::index_type;
+    using value_type = typename Base::value_type;
+    using size_type = typename Base::size_type;
     using UT = typename std::make_unsigned<T>::type;
 
     static constexpr uint32_t ilog2(uint32_t v) {
@@ -147,13 +149,13 @@ namespace cms::alpakatools {
       return r;
     }
 
+    static constexpr size_type nhists() { return NHISTS; }
+    static constexpr size_type nbins() { return NBINS; }
+    static constexpr size_type totbins() { return NHISTS * NBINS + 1; }
     static constexpr uint32_t sizeT() { return S; }
-    static constexpr int32_t nhists() { return NHISTS; }
-    static constexpr uint32_t nbins() { return NBINS; }
-    static constexpr uint32_t totbins() { return NHISTS * NBINS + 1; }
     static constexpr uint32_t nbits() { return ilog2(NBINS - 1) + 1; }
 
-    static constexpr auto histOff(uint32_t nh) { return NBINS * nh; }
+    static constexpr size_type histOff(size_type nh) { return NBINS * nh; }
 
     static constexpr UT bin(T t) {
       constexpr uint32_t shift = sizeT() - nbits();
@@ -163,14 +165,14 @@ namespace cms::alpakatools {
 
     template <alpaka::concepts::Acc TAcc>
     ALPAKA_FN_ACC ALPAKA_FN_INLINE void count(const TAcc &acc, T t) {
-      uint32_t b = bin(t);
+      size_type b = bin(t);
       ALPAKA_ASSERT_ACC(b < nbins());
       Base::atomicIncrement(acc, this->off[b]);
     }
 
     template <alpaka::concepts::Acc TAcc>
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE void fill(const TAcc &acc, T t, index_type j) {
-      uint32_t b = bin(t);
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE void fill(const TAcc &acc, T t, value_type j) {
+      size_type b = bin(t);
       ALPAKA_ASSERT_ACC(b < nbins());
       auto w = Base::atomicDecrement(acc, this->off[b]);
       ALPAKA_ASSERT_ACC(w > 0);
@@ -178,8 +180,8 @@ namespace cms::alpakatools {
     }
 
     template <alpaka::concepts::Acc TAcc>
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE void count(const TAcc &acc, T t, uint32_t nh) {
-      uint32_t b = bin(t);
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE void count(const TAcc &acc, T t, size_type nh) {
+      size_type b = bin(t);
       ALPAKA_ASSERT_ACC(b < nbins());
       b += histOff(nh);
       ALPAKA_ASSERT_ACC(b < totbins());
@@ -187,8 +189,8 @@ namespace cms::alpakatools {
     }
 
     template <alpaka::concepts::Acc TAcc>
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE void fill(const TAcc &acc, T t, index_type j, uint32_t nh) {
-      uint32_t b = bin(t);
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE void fill(const TAcc &acc, T t, value_type j, size_type nh) {
+      size_type b = bin(t);
       ALPAKA_ASSERT_ACC(b < nbins());
       b += histOff(nh);
       ALPAKA_ASSERT_ACC(b < totbins());

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testHistoContainer.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testHistoContainer.dev.cc
@@ -105,7 +105,7 @@ int go(const DevHost& host, const Device& device, Queue& queue) {
   constexpr uint32_t partSize = N / nParts;
 
   using Hist = HistoContainer<T, 128, N, 8 * sizeof(T), uint32_t, nParts>;
-  using HistR = HistoContainer<T, 128, -1, 8 * sizeof(T), uint32_t, nParts>;
+  using HistR = HistoContainer<T, 128, kDynamicSize, 8 * sizeof(T), uint32_t, nParts>;
   std::cout << "HistoContainer " << (int)(offsetof(Hist, off)) << ' ' << Hist::nbins() << ' ' << Hist::totbins() << ' '
             << Hist{}.capacity() << ' ' << offsetof(Hist, content) - offsetof(Hist, off) << ' '
             << (std::numeric_limits<T>::max() - std::numeric_limits<T>::min()) / Hist::nbins() << std::endl;
@@ -124,10 +124,10 @@ int go(const DevHost& host, const Device& device, Queue& queue) {
   // Run time sized histogram
   auto hr = make_host_buffer<HistR>(queue);
   // Data storage for histogram content (host)
-  auto hd = make_host_buffer<typename HistR::index_type[]>(queue, N);
+  auto hd = make_host_buffer<typename HistR::value_type[]>(queue, N);
   auto hr_d = make_device_buffer<HistR>(queue);
   // Data storage for histogram content (device)
-  auto hd_d = make_device_buffer<typename HistR::index_type[]>(queue, N);
+  auto hd_d = make_device_buffer<typename HistR::value_type[]>(queue, N);
 
   // We iterate the test 5 times.
   for (int it = 0; it < 5; ++it) {
@@ -179,7 +179,7 @@ int go(const DevHost& host, const Device& device, Queue& queue) {
     std::cout << "Calling fillManyFromVector(runtime sized) - " << h->size() << std::endl;
     typename HistR::View hrv_d;
     hrv_d.assoc = hr_d.data();
-    hrv_d.offSize = -1;
+    hrv_d.offSize = kDynamicSize;
     hrv_d.offStorage = nullptr;
     hrv_d.contentSize = N;
     hrv_d.contentStorage = hd_d.data();
@@ -199,7 +199,7 @@ int go(const DevHost& host, const Device& device, Queue& queue) {
     // We cannot update the contents address of the histo container before the copy from device happened
     typename HistR::View hrv;
     hrv.assoc = hr.data();
-    hrv.offSize = -1;
+    hrv.offSize = kDynamicSize;
     hrv.offStorage = nullptr;
     hrv.contentSize = N;
     hrv.contentStorage = hd.data();

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testOneToManyAssoc.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testOneToManyAssoc.dev.cc
@@ -27,13 +27,6 @@ using SmallAssoc = OneToManyAssocSequential<uint16_t, 128, MaxAssocs>;
 using Multiplicity = OneToManyAssocRandomAccess<uint16_t, 8, MaxTk>;
 using TK = std::array<uint16_t, 4>;
 
-namespace {
-  template <typename T>
-  ALPAKA_FN_HOST_ACC typename std::make_signed<T>::type toSigned(T v) {
-    return static_cast<typename std::make_signed<T>::type>(v);
-  }
-}  // namespace
-
 struct countMultiLocal {
   ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                 TK const* __restrict__ tk,
@@ -137,10 +130,10 @@ struct fillBulk {
 struct verifyBulk {
   template <typename Assoc>
   ALPAKA_FN_ACC void operator()(Acc1D const& acc, Assoc const* __restrict__ assoc, AtomicPairCounter const* apc) const {
-    if (::toSigned(apc->get().first) >= Assoc::ctNOnes()) {
+    if (apc->get().first >= Assoc::ctNOnes()) {
       printf("Overflow %d %d\n", apc->get().first, Assoc::ctNOnes());
     }
-    ALPAKA_ASSERT_ACC(toSigned(assoc->size()) < Assoc::ctCapacity());
+    ALPAKA_ASSERT_ACC(assoc->size() < Assoc::ctCapacity());
   }
 };
 

--- a/RecoTracker/PixelSeeding/plugins/alpaka/BrokenLineFit.dev.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/BrokenLineFit.dev.cc
@@ -63,7 +63,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         }
         // get it from the ntuple container (one to one to helix)
         auto tkid = *(tupleMultiplicity->begin(nHitsL) + tuple_idx);
-        ALPAKA_ASSERT_ACC(static_cast<int>(tkid) < foundNtuplets->nOnes());
+        ALPAKA_ASSERT_ACC(tkid < foundNtuplets->nOnes());
 
         ptkids[local_idx] = tkid;
 
@@ -206,7 +206,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           break;
         auto tkid = ptkids[local_idx];
 
-        ALPAKA_ASSERT_ACC(int(tkid) < tupleMultiplicity->capacity());
+        ALPAKA_ASSERT_ACC(tkid < tupleMultiplicity->capacity());
 
         riemannFit::Map3xNd<N> hits(phits + local_idx);
         riemannFit::Map4d fast_fit(pfast_fit + local_idx);

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CACell.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CACell.h
@@ -245,7 +245,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 #ifdef CA_DEBUG
               printf("track n. %d nhits %d with cells: ", it, nh + 1);
 #endif
-              if (it >= 0) {  // if negative is overflow....
+              if (it != cms::alpakatools::kOverflow) {
                 for (auto c : tmpNtuplet) {
 #ifdef CA_DEBUG
                   printf("%d - ", c);

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernels.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernels.h
@@ -111,7 +111,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     // Histograms
 
     using PhiBinner = caStructures::PhiBinnerT<TrackerTraits>;  //the traits here define the number of layer/histograms
-    using PhiBinnerStorageType = typename PhiBinner::index_type;
+    using PhiBinnerStorageType = typename PhiBinner::value_type;
     using PhiBinnerView = typename PhiBinner::View;
 
     using HitToTuple = caStructures::GenericContainer;
@@ -122,7 +122,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     using CellToTrack = caStructures::GenericContainer;
 
     using GenericContainer = caStructures::GenericContainer;
-    using GenericContainerStorage = typename GenericContainer::index_type;
+    using GenericContainerStorage = typename GenericContainer::value_type;
     using GenericContainerView = typename GenericContainer::View;
     using DeviceGenericContainerBuffer = std::optional<cms::alpakatools::device_buffer<Device, GenericContainer>>;
     using DeviceGenericStorageBuffer =
@@ -131,7 +131,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         std::optional<cms::alpakatools::device_buffer<Device, GenericContainerOffsets[]>>;
 
     using SequentialContainer = caStructures::SequentialContainer;
-    using SequentialContainerStorage = typename SequentialContainer::index_type;
+    using SequentialContainerStorage = typename SequentialContainer::value_type;
     using SequentialContainerView = typename SequentialContainer::View;
     using DeviceSequentialContainerBuffer = std::optional<cms::alpakatools::device_buffer<Device, SequentialContainer>>;
     using DeviceSequentialStorageBuffer =

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernelsImpl.h
@@ -1055,8 +1055,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caHitNtupletGeneratorKernels {
                                   TkSoAView tracks_view,
                                   HitContainer const *__restrict__ foundNtuplets,
                                   HitToTuple const *__restrict__ phitToTuple,
-                                  int32_t firstPrint,
-                                  int32_t lastPrint,
+                                  uint32_t firstPrint,
+                                  uint32_t lastPrint,
                                   int iev) const {
       constexpr auto loose = Quality::loose;
 

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAStructures.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAStructures.h
@@ -57,19 +57,25 @@ namespace caStructures {
   using tindex_type = uint32_t;
   using cindex_type = uint32_t;
 
-  using GenericContainer = cms::alpakatools::OneToManyAssocRandomAccess<hindex_type, -1, -1>;
-  using GenericContainerStorage = typename GenericContainer::index_type;
+  using GenericContainer = cms::alpakatools::
+      OneToManyAssocRandomAccess<hindex_type, cms::alpakatools::kDynamicSize, cms::alpakatools::kDynamicSize>;
+  using GenericContainerStorage = typename GenericContainer::value_type;
   using GenericContainerOffsets = typename GenericContainer::Counter;
   using GenericContainerView = typename GenericContainer::View;
 
-  using SequentialContainer = cms::alpakatools::OneToManyAssocSequential<hindex_type, -1, -1>;
-  using SequentialContainerStorage = typename SequentialContainer::index_type;
+  using SequentialContainer = cms::alpakatools::
+      OneToManyAssocSequential<hindex_type, cms::alpakatools::kDynamicSize, cms::alpakatools::kDynamicSize>;
+  using SequentialContainerStorage = typename SequentialContainer::value_type;
   using SequentialContainerOffsets = typename SequentialContainer::Counter;
   using SequentialContainerView = typename SequentialContainer::View;
 
   template <typename TrackerTraits>
-  using PhiBinnerT =
-      cms::alpakatools::HistoContainer<int16_t, 256, -1, 8 * sizeof(int16_t), hindex_type, TrackerTraits::numberOfLayers>;
+  using PhiBinnerT = cms::alpakatools::HistoContainer<int16_t,
+                                                      256,
+                                                      cms::alpakatools::kDynamicSize,
+                                                      8 * sizeof(int16_t),
+                                                      hindex_type,
+                                                      TrackerTraits::numberOfLayers>;
 
   template <typename TrackerTraits>
   using CellNeighborsT =
@@ -100,7 +106,7 @@ namespace caStructures {
   template <typename TrackerTraits>
   using HitToTupleT =
       cms::alpakatools::OneToManyAssocRandomAccess<tindex_type,
-                                                   -1,
+                                                   cms::alpakatools::kDynamicSize,
                                                    TrackerTraits::maxNumberOfTuples *
                                                        TrackerTraits::avgHitsPerTrack>;  // 3.5 should be enough
 

--- a/RecoTracker/PixelSeeding/plugins/alpaka/RiemannFit.dev.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/RiemannFit.dev.cc
@@ -57,7 +57,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
         // get it from the ntuple container (one to one to helix)
         auto tkid = *(tupleMultiplicity->begin(nHits) + tuple_idx);
-        ALPAKA_ASSERT_ACC(static_cast<int>(tkid) < foundNtuplets->nOnes());
+        ALPAKA_ASSERT_ACC(tkid < foundNtuplets->nOnes());
 
         ALPAKA_ASSERT_ACC(foundNtuplets->size(tkid) == nHits);
 

--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksByDensity.h
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksByDensity.h
@@ -72,8 +72,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
         printf("booked hist with %d bins, size %d for %d tracks\n", hist.totbins(), hist.capacity(), nt);
     }
 
-    ALPAKA_ASSERT_ACC(static_cast<int>(nt) <= std::numeric_limits<Hist::index_type>::max());
-    ALPAKA_ASSERT_ACC(static_cast<int>(nt) <= hist.capacity());
+    ALPAKA_ASSERT_ACC(nt <= std::numeric_limits<Hist::value_type>::max());
+    ALPAKA_ASSERT_ACC(nt <= hist.capacity());
     ALPAKA_ASSERT_ACC(eps <= 0.1f);  // see below
 
     // fill hist (bin shall be wider than "eps")

--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksDBSCAN.h
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksDBSCAN.h
@@ -70,8 +70,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
           printf("booked hist with %d bins, size %d for %d tracks\n", hist.nbins(), hist.capacity(), nt);
       }
 
-      ALPAKA_ASSERT_ACC(static_cast<int>(nt) <= std::numeric_limits<Hist::index_type>::max());
-      ALPAKA_ASSERT_ACC(static_cast<int>(nt) <= hist.capacity());
+      ALPAKA_ASSERT_ACC(static_cast<int>(nt) <= std::numeric_limits<Hist::value_type>::max());
+      ALPAKA_ASSERT_ACC(nt <= hist.capacity());
       ALPAKA_ASSERT_ACC(eps <= 0.1f);  // see below
 
       // fill hist (bin shall be wider than "eps")

--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksIterative.h
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksIterative.h
@@ -69,8 +69,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
           printf("booked hist with %d bins, size %d for %d tracks\n", hist.nbins(), hist.capacity(), nt);
       }
 
-      ALPAKA_ASSERT_ACC(static_cast<int>(nt) <= std::numeric_limits<Hist::index_type>::max());
-      ALPAKA_ASSERT_ACC(static_cast<int>(nt) <= hist.capacity());
+      ALPAKA_ASSERT_ACC(static_cast<int>(nt) <= std::numeric_limits<Hist::value_type>::max());
+      ALPAKA_ASSERT_ACC(nt <= hist.capacity());
       ALPAKA_ASSERT_ACC(eps <= 0.1f);  // see below
 
       // fill hist (bin shall be wider than "eps")


### PR DESCRIPTION
#### PR description:

This PR fixes the argument type in two functions of the `OneToManyAssocBase` of the alpaka interface in CMSSW. The purpose of this association is to map from `uint32_t`-type keys ("ones") to a set of associated object of templated type `index_type = I` ("many"). 
However, in two of the functions, the input `b` (which corresponds to a "one") is has the wrong type `I` instead of `uint32_t`.

This bug limits the type `I` of the "many" that can be stored by the association to integer-types as the code of the function does not compile otherwise. As far as I can tell this issue was never discovered since all the applications that are currently in release associate integers to integers.

We are taking this fix as an occasion to harmonize a bit the Key/index type used in the alpaka `FlexiStorage`, `OneToManyAssoc` and `HistoContainer` to use `uint32_t` consistently. 

**Changes in the user interface of these containers:** Before `SIZE == -1` defined a flexible container size that is initialized at runtime using external storage. Now, since `SIZE` is a `uint32_t`, the user is supposed to use `cms::alpakatools::kDynamicSize` instead (see example below). Similarly, the `bulkFill()` function of the `OneToManyAssoc` from now on returns `kOverflow` instead of negative values to indicate overflow. Finally, the former `index_type` was renamed to the more fitting and less misleading `value_type`.

```c++
# example for setting the SIZE to be initialized at runtime time
using GenericContainer = cms::alpakatools::
      OneToManyAssocRandomAccess<hindex_type, cms::alpakatools::kDynamicSize, cms::alpakatools::kDynamicSize>;
```

No changes in the output are expected.

#### PR validation:

For validation, I ran `scram b runtests` in `HeterogeneousCore/AlpakaInterface` to verify the CUDA and serial backends. I also ran the alpaka pixel tracking in HLT Phase-2 (which uses these associations) and checked that the output is identical.

For a validation at larger scale, I think the usual PR tests should be sufficient.
