### PR TITLE
Optimise the MPI `ProductMetadataBuilder`

### DIFF
--- a/HeterogeneousCore/MPICore/src/api.cc
+++ b/HeterogeneousCore/MPICore/src/api.cc
@@ -165,7 +165,6 @@ MPI_Status MPIChannel::receiveEventAuxiliary_(edm::EventAuxiliary& aux, MPI_Mess
 
 void MPIChannel::sendMetadata(int instance, std::shared_ptr<ProductMetadataBuilder> meta) {
   int tag = EDM_MPI_SendMetadata | instance * EDM_MPI_MessageTagWidth_;
-  meta->setHeader();
   MPI_Ssend(meta->data(), meta->size(), MPI_BYTE, dest_, tag, comm_);
 }
 

--- a/HeterogeneousCore/MPICore/src/metadata.cc
+++ b/HeterogeneousCore/MPICore/src/metadata.cc
@@ -7,21 +7,28 @@
 #include "HeterogeneousCore/MPICore/interface/metadata.h"
 
 ProductMetadataBuilder::ProductMetadataBuilder() : buffer_(nullptr), capacity_(0), size_(0), readOffset_(0) {
-  // reserve at least 13 bytes for header
   reserve(maxMetadataSize_);
-  size_ = headerSize_;
+  size_ = sizeof(MetadataHeader);
+  header().productCount = 0;
+  header().productFlags = 0;
+  header().serializedBufferSize = 0;
 }
 
 ProductMetadataBuilder::ProductMetadataBuilder(int16_t productCount)
     : buffer_(nullptr), capacity_(0), size_(0), readOffset_(0) {
   // we need 1 byte for type, 8 bytes for size, and at least 8 bytes for MemoryCopyTraits Properties buffer
   // on average 24 bytes per product should be enough, but metadata will adapt if the actual contents is larger
-  reserve(productCount * 24 + headerSize_);
-  header_.productCount = static_cast<int16_t>(productCount);
-  size_ = headerSize_;
+  reserve(productCount * 24 + sizeof(MetadataHeader));
+  size_ = sizeof(MetadataHeader);
+  header().productCount = static_cast<int16_t>(productCount);
+  header().productFlags = 0;
+  header().serializedBufferSize = 0;
 }
 
-ProductMetadataBuilder::~ProductMetadataBuilder() { std::free(buffer_); }
+ProductMetadataBuilder::~ProductMetadataBuilder() {
+  // Free the memory buffer.
+  std::free(buffer_);
+}
 
 ProductMetadataBuilder::ProductMetadataBuilder(ProductMetadataBuilder&& other) noexcept
     : buffer_(other.buffer_), capacity_(other.capacity_), size_(other.size_), readOffset_(other.readOffset_) {
@@ -46,40 +53,54 @@ ProductMetadataBuilder& ProductMetadataBuilder::operator=(ProductMetadataBuilder
   return *this;
 }
 
-void ProductMetadataBuilder::reserve(size_t bytes) {
-  if (capacity_ >= bytes)
-    return;
-  resizeBuffer(bytes);
+MetadataHeader& ProductMetadataBuilder::header() {
+  assert(size_ >= sizeof(MetadataHeader) && "Invalid ProductMetadataBuilder, cannot access the MetadataHeader.");
+  return *reinterpret_cast<MetadataHeader*>(buffer_);
 }
 
-void ProductMetadataBuilder::setHeader() {
-  assert(size_ >= headerSize_ && "Buffer must reserve space for header");
-  std::memcpy(buffer_, &header_, sizeof(header_));
+MetadataHeader const& ProductMetadataBuilder::header() const {
+  assert(size_ >= sizeof(MetadataHeader) && "Invalid ProductMetadataBuilder, cannot access the MetadataHeader.");
+  return *reinterpret_cast<const MetadataHeader*>(buffer_);
+}
+
+void ProductMetadataBuilder::reserve(size_t bytes) {
+  // do not shrink the buffer
+  if (capacity_ >= bytes)
+    return;
+
+  // double the capacity until its enough for the requested size
+  size_t newCapacity = capacity_ > 0 ? capacity_ : 64;
+  while (bytes > newCapacity)
+    newCapacity *= 2;
+
+  // reallocate the buffer as needed, and move the contents to the new memory
+  uint8_t* newBuffer = static_cast<uint8_t*>(std::realloc(buffer_, newCapacity));
+  if (newBuffer == nullptr)
+    throw std::bad_alloc();
+
+  // if the reallocation succeded, update the data members
+  buffer_ = newBuffer;
+  capacity_ = newCapacity;
 }
 
 void ProductMetadataBuilder::addMissing() {
-  header_.productFlags |= HasMissing;
+  header().productFlags |= HasMissing;
   append<uint8_t>(static_cast<uint8_t>(ProductMetadata::Kind::Missing));
 }
 
 void ProductMetadataBuilder::addSerialized(uint64_t size) {
-  header_.productFlags |= HasSerialized;
+  header().productFlags |= HasSerialized;
   append<uint8_t>(static_cast<uint8_t>(ProductMetadata::Kind::Serialized));
   append<uint64_t>(size);
-  header_.serializedBufferSize += static_cast<int32_t>(size);
+  header().serializedBufferSize += static_cast<int32_t>(size);
 }
 
 void ProductMetadataBuilder::addTrivialCopy(const std::byte* buffer, uint64_t size) {
-  header_.productFlags |= HasTrivialCopy;
+  header().productFlags |= HasTrivialCopy;
   append<uint8_t>(static_cast<uint8_t>(ProductMetadata::Kind::TrivialCopy));
   append<uint64_t>(size);
   appendBytes(buffer, size);
 }
-
-const uint8_t* ProductMetadataBuilder::data() const { return buffer_; }
-uint8_t* ProductMetadataBuilder::data() { return buffer_; }
-size_t ProductMetadataBuilder::size() const { return size_; }
-std::span<const uint8_t> ProductMetadataBuilder::buffer() const { return {buffer_, size_}; }
 
 void ProductMetadataBuilder::receiveMetadata(int src, int tag, MPI_Comm comm) {
   MPI_Status status;
@@ -87,10 +108,9 @@ void ProductMetadataBuilder::receiveMetadata(int src, int tag, MPI_Comm comm) {
   // add error handling if message is too long (quite unlikely to happen so far)
   int receivedBytes = 0;
   MPI_Get_count(&status, MPI_BYTE, &receivedBytes);
-  assert(static_cast<size_t>(receivedBytes) >= headerSize_ && "received metadata was less than header size");
-  memcpy(&header_, buffer_, sizeof(header_));
+  assert(static_cast<size_t>(receivedBytes) >= sizeof(MetadataHeader) && "received metadata was less than header size");
   size_ = receivedBytes;
-  readOffset_ = headerSize_;
+  readOffset_ = sizeof(MetadataHeader);
 }
 
 ProductMetadata ProductMetadataBuilder::getNext() {
@@ -127,61 +147,44 @@ ProductMetadata ProductMetadataBuilder::getNext() {
   return meta;
 }
 
-void ProductMetadataBuilder::resizeBuffer(size_t newCap) {
-  uint8_t* newBuf = static_cast<uint8_t*>(std::realloc(buffer_, newCap));
-  if (!newBuf)
-    throw std::bad_alloc();
-  buffer_ = newBuf;
-  capacity_ = newCap;
-}
-
-void ProductMetadataBuilder::ensureCapacity(size_t needed) {
-  if (size_ + needed <= capacity_)
-    return;
-
-  size_t newCapacity = capacity_ ? capacity_ : 64;
-  while (size_ + needed > newCapacity)
-    newCapacity *= 2;
-
-  uint8_t* newData = static_cast<uint8_t*>(std::realloc(buffer_, newCapacity));
-  if (!newData)
-    throw std::bad_alloc();
-  buffer_ = newData;
-  capacity_ = newCapacity;
-}
-
 void ProductMetadataBuilder::appendBytes(const std::byte* src, size_t size) {
-  ensureCapacity(size);
+  reserve(size_ + size);
   std::memcpy(buffer_ + size_, src, size);
   size_ += size;
 }
 
-void ProductMetadataBuilder::debugPrintMetadataSummary() const {
+void ProductMetadataBuilder::consumeBytes(std::byte* dst, size_t size) {
+  if (readOffset_ + size > size_)
+    throw std::runtime_error("Buffer underflow");
+  std::memcpy(dst, buffer_ + readOffset_, size);
+  readOffset_ += size;
+}
+
+void ProductMetadataBuilder::debugPrintMetadataSummary() {
   if (size_ < sizeof(MetadataHeader)) {
     std::cerr << "ERROR: Buffer too small to contain metadata header\n";
     return;
   }
 
   std::ostringstream out;
-  size_t offset = 0;
 
-  // --- Read header fields explicitly ---
-  MetadataHeader header;
-  std::memcpy(&header, buffer_, sizeof(MetadataHeader));
-  offset += sizeof(MetadataHeader);
-
+  // --- Read header fields ---
   out << "---- ProductMetadata Debug Summary ----\n";
   out << "Header:\n";
-  out << "  Product count:           " << header.productCount << "\n";
-  out << "  Serialized buffer size:  " << header.serializedBufferSize << " bytes\n";
+  out << "  Product count:           " << header().productCount << "\n";
+  out << "  Serialized buffer size:  " << header().serializedBufferSize << " bytes\n";
   out << "  Flags:";
-  if (header.productFlags & HasMissing)
+  if (hasMissing())
     out << " Missing";
-  if (header.productFlags & HasSerialized)
+  if (hasSerialized())
     out << " Serialized";
-  if (header.productFlags & HasTrivialCopy)
+  if (hasTrivialCopy())
     out << " TrivialCopy";
   out << "\n\n";
+
+  // store the current offset and rewind the buffer
+  size_t offset = readOffset_;
+  readOffset_ = sizeof(MetadataHeader);
 
   // --- Parse product entries ---
   size_t count = 0;
@@ -189,69 +192,36 @@ void ProductMetadataBuilder::debugPrintMetadataSummary() const {
   size_t numSerialized = 0;
   size_t numTrivial = 0;
 
-  while (offset < size_) {
-    if (count >= static_cast<size_t>(header.productCount)) {
-      out << "WARNING: More metadata entries than header.productCount\n";
-      break;
-    }
+  try {
+    while (count < static_cast<size_t>(header().productCount)) {
+      ProductMetadata meta = getNext();
+      ++count;
 
-    if (offset + sizeof(uint8_t) > size_) {
-      out << "ERROR: Truncated metadata entry\n";
-      break;
-    }
+      out << "Product #" << count << ": ";
 
-    auto kind = static_cast<ProductMetadata::Kind>(buffer_[offset]);
-    offset += sizeof(uint8_t);
-    count++;
+      switch (meta.kind) {
+        case ProductMetadata::Kind::Missing:
+          ++numMissing;
+          out << "Missing\n";
+          break;
 
-    out << "Product #" << count << ": ";
+        case ProductMetadata::Kind::Serialized:
+          ++numSerialized;
+          out << "Serialized, size = " << meta.sizeMeta << "\n";
+          break;
 
-    switch (kind) {
-      case ProductMetadata::Kind::Missing:
-        numMissing++;
-        out << "Missing\n";
-        break;
-
-      case ProductMetadata::Kind::Serialized: {
-        if (offset + sizeof(size_t) > size_) {
-          out << "ERROR: Corrupted serialized metadata\n";
-          return;
-        }
-        size_t sz = 0;
-        std::memcpy(&sz, buffer_ + offset, sizeof(size_t));
-        offset += sizeof(size_t);
-        numSerialized++;
-        out << "Serialized, size = " << sz << "\n";
-        break;
+        case ProductMetadata::Kind::TrivialCopy:
+          ++numTrivial;
+          out << "TrivialCopy, size = " << meta.sizeMeta << "\n";
+          break;
       }
-
-      case ProductMetadata::Kind::TrivialCopy: {
-        if (offset + sizeof(size_t) > size_) {
-          out << "ERROR: Corrupted trivial-copy metadata\n";
-          return;
-        }
-        size_t sz = 0;
-        std::memcpy(&sz, buffer_ + offset, sizeof(size_t));
-        offset += sizeof(size_t);
-
-        if (offset + sz > size_) {
-          out << "ERROR: Trivial-copy data overflows buffer\n";
-          return;
-        }
-        offset += sz;
-        numTrivial++;
-        out << "TrivialCopy, size = " << sz << "\n";
-        break;
-      }
-
-      default:
-        out << "ERROR: Unknown product kind " << static_cast<int>(kind) << "\n";
-        return;
     }
+  } catch (const std::exception& e) {
+    out << "\nERROR while parsing metadata: " << e.what() << "\n";
   }
 
-  if (count != static_cast<size_t>(header.productCount)) {
-    out << "\nWARNING: Parsed " << count << " entries, but header says " << header.productCount << "\n";
+  if (count != static_cast<size_t>(header().productCount)) {
+    out << "\nWARNING: Parsed " << count << " entries, but header says " << header().productCount << "\n";
   }
 
   out << "\n----------------------------------------\n";
@@ -262,4 +232,7 @@ void ProductMetadataBuilder::debugPrintMetadataSummary() const {
   out << "Total metadata size:    " << size_ << " bytes\n";
 
   std::cerr << out.str() << std::flush;
+
+  // restore the current offset
+  readOffset_ = offset;
 }


### PR DESCRIPTION
#### PR description:

Reduce the number of local memory copies in `ProductMetadataBuilder`.

#### PR validation:

Unit tests pass.

#### Backport status:

To be backported to 16.0.x.