### PR TITLE
Add per-PFCand plots to nanoDQM

### DIFF
--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -268,7 +268,15 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
             )
         ),
         PFCand = cms.PSet(
-            sels = cms.PSet(),
+            sels = cms.PSet(
+                    ChargedHadron = cms.string('abs(pdgId) == 211'),
+                    NeutralHadron = cms.string('pdgId == 130'),
+                    Photon = cms.string('pdgId == 22'),
+                    Electron = cms.string('abs(pdgId) == 11'),
+                    Muon = cms.string('abs(pdgId) == 13'),
+                    HFHadron = cms.string('pdgId == 1'),
+                    HFEM = cms.string('pdgId == 2')
+                ),
             plots = cms.VPSet(
                 Count1D('_size', 10, 0, 100, 'PF candidates'),
                 Plot1D('pt', 'pt', 20,  0, 50, 'Puppi-weighted pt'),


### PR DESCRIPTION
This is the master version of PR #49803 

PR description:
Updating NanoDQM PFCand plots to include separate plots for each PFCand type for validation of NanoAOD. As proposed in recent PF group meeting [link](https://indico.cern.ch/event/1607501/contributions/6788489/attachments/3187526/5671839/PF%20validation%20report%20and%20plan.pdf).

PR validation:
Ran on TTbar, QCD, ZEE RelVals, also performed code-checks and code-format.

@laurenhay @hatakeyamak @ahinzmann @stahlleiton



