### PR TITLE
[16.0.X] add reconstructable sim vertices validation for HLT full vertices

### DIFF
--- a/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
+++ b/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
@@ -10,6 +10,7 @@ hltMultiPVanalysis = vertexAnalysis.clone(
     trackAssociatorMap    = "trackingParticleRecoTrackAsssociation",
     vertexAssociator      = "VertexAssociatorByPositionAndTracks"
 )
+
 from Validation.RecoTrack.associators_cff import hltTPClusterProducer, hltTrackAssociatorByHits, tpToHLTpixelTrackAssociation
 from SimTracker.VertexAssociation.VertexAssociatorByPositionAndTracks_cfi import VertexAssociatorByPositionAndTracks as _VertexAssociatorByPositionAndTracks
 vertexAssociatorByPositionAndTracks4pixelTracks = _VertexAssociatorByPositionAndTracks.clone(
@@ -70,6 +71,18 @@ hltPVanalysis = hltMultiPVanalysis.clone(
     )
 )
 
+hltPVanalysisReconstructable = hltMultiPVanalysis.clone(
+    do_generic_sim_plots  = False, # to not produce fill the ones from hltPixelPVanalysisReconstructable twice
+    use_reconstructable_simvertices = True,
+    reco_tracks_for_reconstructable_simvertices = 1, #inclusive, below or equal discard sim vertex.
+    root_folder           = "HLT/Vertexing/ValidationWRTReconstructableSim",
+    trackAssociatorMap    = "tpToHLTpfMuonMergingTrackAssociation",
+    vertexAssociator      = "vertexAssociatorByPositionAndTracks4pfMuonMergingTracks",
+    vertexRecoCollections = (
+        "hltVerticesPFFilter",
+    )
+)
+
 tpToHLTphase2TrackAssociation = tpToHLTpixelTrackAssociation.clone(
     label_tr = "hltGeneralTracks"
 )
@@ -85,6 +98,7 @@ def _modifyFullPVanalysisForPhase2(pvanalysis):
     pvanalysis.vertexAssociator   = "vertexAssociatorByPositionAndTracks4phase2HLTTracks"
 
 phase2_tracker.toModify(hltPVanalysis, _modifyFullPVanalysisForPhase2)
+phase2_tracker.toModify(hltPVanalysisReconstructable, _modifyFullPVanalysisForPhase2)
 
 hltMultiPVAssociations = cms.Task(
     hltOtherTPClusterProducer,
@@ -98,9 +112,8 @@ hltMultiPVAssociations = cms.Task(
     vertexAssociatorByPositionAndTracks4phase2HLTTracks
 )
 
-hltMultiPVValidation = cms.Sequence( 
-    hltPixelPVanalysis
-    + hltPixelPVanalysisReconstructable
-    + hltPVanalysis,
-    hltMultiPVAssociations
-)
+hltMultiPVValidation = cms.Sequence(hltPixelPVanalysis +
+                                    hltPixelPVanalysisReconstructable +
+                                    hltPVanalysis +
+                                    hltPVanalysisReconstructable,
+                                    hltMultiPVAssociations)


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/49900

#### PR description:

Title say it all, this is a follow-up to https://github.com/cms-sw/cmssw/pull/49609.
In that PR we introduced the concept of "reconstructable" sim-vertex, allowing the validation module to optionally focus only on sim vertices that meet reconstruction criteria (≥3 associated tracks).
We extend that validation flavor also to the "full" (offline-like, i.e. DA-driven) vertices.

#### PR validation:

Run the following script:

```bash
#!/bin/bash -ex

cmsDriver.py step2 --step L1P2GT,HLT:NGTScouting,VALIDATION:@hltValidation \
 --procModifier phase2LegacyPixelTracks \
 --conditions auto:phase2_realistic_T33 --processName HLTX \
 --datatier DQMIO --eventcontent DQMIO \
 --geometry ExtendedRun4D110 --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 --era Phase2C17I13M9 \
 --inputCommands='keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT' \
 --filein file:/eos/cms/store/relval/CMSSW_16_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_150X_mcRun4_realistic_v1_STD_Run4D110_PU-v2/2580000/037118f1-472e-4647-88fc-b0211e52df6f.root \
 --fileout file:step2.root -n -1 --nThreads 0

cmsDriver.py step3 -s HARVESTING:@hltValidation --filetype DQM \
 --conditions auto:phase2_realistic_T33 --geometry ExtendedRun4D110 \
 --scenario pp --mc --era Phase2C17I13M9 \
 -n -1 --filein file:step2.root
```

and checked that the output DQM file is sensible.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

https://github.com/cms-sw/cmssw/pull/49900