### PR TITLE
provide defaults to `fillDescriptions` parameters for `RecoLocalTracker/SiStripClusterizer` alpaka plugins

### DIFF
--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClustersToLegacy.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClustersToLegacy.cc
@@ -26,7 +26,7 @@ namespace sistrip {
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
-      desc.add<edm::InputTag>("source");
+      desc.add<edm::InputTag>("source", edm::InputTag("hltSiStripRawToClustersFacilityAlpaka"));
       descriptions.addWithDefaultLabel(desc);
     }
 

--- a/RecoLocalTracker/SiStripClusterizer/plugins/alpaka/SiStripClusterizerConditionsESProducerAlpaka.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/alpaka/SiStripClusterizerConditionsESProducerAlpaka.cc
@@ -59,8 +59,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::sistrip {
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
-      desc.add<edm::ESInputTag>("QualityLabel");
-      desc.add<edm::ESInputTag>("Label");
+      desc.add<edm::ESInputTag>("QualityLabel", edm::ESInputTag(""));
+      desc.add<edm::ESInputTag>("Label", edm::ESInputTag(""));
       descriptions.addWithDefaultLabel(desc);
     }
 


### PR DESCRIPTION
#### PR description:

TItle says it all. Otherwise, when trying to parse these module in confDB it might make it fail in weird ways.
This step is recommended in rule 6.14 [link](https://cms-sw.github.io/cms_coding_rules.html) and needed for modules used at HLT.
Analogous to https://github.com/cms-sw/cmssw/pull/47575.

#### PR validation:

`cmssw` compiles.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, will be backported to CMSSW_16_0_X for 2026 data-taking.

Cc: @pietroGru @Martin-Grunewald 