### PR TITLE
Updates to the offline CPU vs. GPU workflows for LST

### DIFF
--- a/Configuration/ProcessModifiers/python/alpakaValidationLST_cff.py
+++ b/Configuration/ProcessModifiers/python/alpakaValidationLST_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier performs the host/device validation for the LST algorithm
+alpakaValidationLST = cms.Modifier()

--- a/Configuration/ProcessModifiers/python/alpakaValidation_cff.py
+++ b/Configuration/ProcessModifiers/python/alpakaValidation_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.ProcessModifiers.alpaka_cff import *
 from Configuration.ProcessModifiers.alpakaValidationEcal_cff import *
+from Configuration.ProcessModifiers.alpakaValidationLST_cff import *
 from Configuration.ProcessModifiers.alpakaValidationPixel_cff import *
 
 # This modifier chain is for turning on DQM modules used for alpaka device/host validation
@@ -9,5 +10,6 @@ from Configuration.ProcessModifiers.alpakaValidationPixel_cff import *
 alpakaValidation =  cms.ModifierChain(
     alpaka,
     alpakaValidationEcal,
+    alpakaValidationLST,
     alpakaValidationPixel
 )

--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -51,8 +51,9 @@ The offsets currently in use are:
 * 0.7: trackingMkFit modifier
 * 0.701: DisplacedRegionalStep tracking iteration for Run-3
 * 0.702: trackingMkFit modifier for Phase-2 (initialStep only)
-* 0.703: LST tracking (Phase-2 only), initialStep+HighPtTripletStep only, on CPU
-* 0.704: LST tracking (Phase-2 only), initialStep+HighPtTripletStep only, on GPU (if available)
+* 0.711: LST tracking (Phase-2 only), initialStep+HighPtTripletStep only, on CPU
+* 0.712: LST tracking (Phase-2 only), initialStep+HighPtTripletStep only, on GPU (if available)
+* 0.713: LST tracking (Phase-2 only), initialStep+HighPtTripletStep only, on GPU (if available), CPU vs. GPU
 * 0.75: HLT phase-2 timing menu
 * 0.7501: HLT phase-2 tracking-only menu
 * 0.751: HLT phase-2 timing menu Alpaka variant

--- a/Configuration/PyReleaseValidation/python/relval_Run4.py
+++ b/Configuration/PyReleaseValidation/python/relval_Run4.py
@@ -36,7 +36,7 @@ numWFIB.extend([prefixDet+34.702]) #mkFit tracking (initialStep)
 numWFIB.extend([prefixDet+34.5])   #pixelTrackingOnly
 numWFIB.extend([prefixDet+34.9])   #vector hits
 numWFIB.extend([prefixDet+34.402]) #Alpaka local reconstruction offloaded on device (GPU if available)
-numWFIB.extend([prefixDet+34.703]) #LST tracking on CPU (initialStep+HighPtTripletStep only)
+numWFIB.extend([prefixDet+34.711]) #LST tracking on CPU (initialStep+HighPtTripletStep only)
 numWFIB.extend([prefixDet+34.21])  #prodlike
 numWFIB.extend([prefixDet+96.0])   #CloseByPGun CE_E_Front_120um
 numWFIB.extend([prefixDet+100.0])  #CloseByPGun CE_H_Coarse_Scint
@@ -50,7 +50,7 @@ numWFIB.extend([prefixDet+234.999])  #premixing combined stage1+stage2 ttbar+PU5
 numWFIB.extend([prefixDet+234.21])   #prodlike PU
 numWFIB.extend([prefixDet+234.9921]) #prodlike premix stage1+stage2
 numWFIB.extend([prefixDet+234.114])  #PU, with 10% OT inefficiency
-numWFIB.extend([prefixDet+234.703])  #LST tracking on CPU (initialStep+HighPtTripletStep only)
+numWFIB.extend([prefixDet+234.711])  #LST tracking on CPU (initialStep+HighPtTripletStep only)
 
 # Phase-2 HLT tests
 numWFIB.extend([prefixDet+34.7501])# HLTTrackingOnly75e33

--- a/Configuration/PyReleaseValidation/python/relval_gpu.py
+++ b/Configuration/PyReleaseValidation/python/relval_gpu.py
@@ -81,13 +81,13 @@ numWFIB = [
            prefixDet+34.402, prefixDet+34.4021, prefixDet+34.403, prefixDet+34.404, prefixDet+34.406,
            prefixDet+34.612,
            prefixDet+61.402,
-           prefixDet+34.704,
+           prefixDet+34.712, prefixDet+34.713,
            prefixDet+34.751,
            prefixDet+61.751,
 
            # Run4, Alpaka-based PU
            prefixDet+234.402, prefixDet+234.4021, prefixDet+234.403, prefixDet+234.404,
-           prefixDet+234.704,
+           prefixDet+234.712, prefixDet+234.713,
            prefixDet+234.751,
         ]
 

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -525,7 +525,7 @@ upgradeWFs['lstOnCPUIters01TrackingOnly'] = UpgradeWorkflow_lstOnCPUIters01Track
         'HARVESTGlobal',
     ],
     suffix = '_lstOnCPUIters01TrackingOnly',
-    offset = 0.703,
+    offset = 0.711,
 )
 upgradeWFs['lstOnCPUIters01TrackingOnly'].step3 = upgradeWFs['trackingOnly'].step3 | {
     '--procModifiers': 'trackingIters01,trackingLST',
@@ -554,10 +554,20 @@ upgradeWFs['lstOnGPUIters01TrackingOnly'] = UpgradeWorkflow_lstOnGPUIters01Track
         'HARVESTGlobal',
     ],
     suffix = '_lstOnGPUIters01TrackingOnly',
-    offset = 0.704,
+    offset = 0.712,
 )
 upgradeWFs['lstOnGPUIters01TrackingOnly'].step3 = upgradeWFs['trackingOnly'].step3 | {
     '--procModifiers': 'trackingIters01,trackingLST',
+}
+
+# LST on GPU (if available), initialStep+highPtTripletStep-only tracking-only, CPU vs. GPU comparison
+class UpgradeWorkflow_lstOnGPUIters01TrackingOnlyAlpakaValidationLST(UpgradeWorkflow_lstOnGPUIters01TrackingOnly):
+    pass
+upgradeWFs['lstOnGPUIters01TrackingOnlyAlpakaValidationLST'] = deepcopy(upgradeWFs['lstOnGPUIters01TrackingOnly'])
+upgradeWFs['lstOnGPUIters01TrackingOnlyAlpakaValidationLST'].suffix = '_lstOnGPUIters01TrackingOnlyAlpakaValidationLST'
+upgradeWFs['lstOnGPUIters01TrackingOnlyAlpakaValidationLST'].offset = 0.713
+upgradeWFs['lstOnGPUIters01TrackingOnlyAlpakaValidationLST'].step3 = upgradeWFs['trackingOnly'].step3 | {
+    '--procModifiers': 'alpakaValidationLST,trackingIters01,trackingLST',
 }
 
 #DeepCore seeding for JetCore iteration workflow

--- a/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_cff.py
@@ -98,8 +98,9 @@ highPtTripletStepTrackToTrackSerialSyncAnalyzer = _t2t.clone(
 trackToTrackCPUAnalyzer = cms.Sequence()
 _trackToTrackCPUAnalyzer_trackingLST = cms.Sequence(highPtTripletStepTrackToTrackSerialSyncAnalyzer)
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
+from Configuration.ProcessModifiers.alpakaValidationLST_cff import alpakaValidationLST
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
-(trackingPhase2PU140 & trackingLST).toReplaceWith(trackToTrackCPUAnalyzer, _trackToTrackCPUAnalyzer_trackingLST)
+(trackingPhase2PU140 & alpakaValidationLST & trackingLST).toReplaceWith(trackToTrackCPUAnalyzer, _trackToTrackCPUAnalyzer_trackingLST)
 
 
 TrackingOfflineDQMClient = cms.Sequence(trackingQTester*trackingOfflineAnalyser*trackingEffFromHitPattern*voMonitoringClientSequence*primaryVertexResolutionClient*TrackEffClient*foldedMapClientSeq*trackToTrackCPUAnalyzer)

--- a/DQM/TrackingMonitorSource/python/trackToTrackCPU_cff.py
+++ b/DQM/TrackingMonitorSource/python/trackToTrackCPU_cff.py
@@ -17,5 +17,6 @@ _trackToTrackCPUTask_trackingLST = cms.Sequence(HighPtTripletStepTaskSerialSync)
 _trackToTrackCPUTask_trackingLST += highPtTripletStepTrackToTrackSerialSync
 
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
+from Configuration.ProcessModifiers.alpakaValidationLST_cff import alpakaValidationLST
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
-(trackingPhase2PU140 & trackingLST).toReplaceWith(trackToTrackCPUSequence, _trackToTrackCPUTask_trackingLST)
+(trackingPhase2PU140 & alpakaValidationLST & trackingLST).toReplaceWith(trackToTrackCPUSequence, _trackToTrackCPUTask_trackingLST)

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -433,25 +433,26 @@ _HighPtTripletStepTask_LST.add(siPhase2RecHits, lstInitialStepSeedTracks, lstHig
                                lstProducerTask, highPtTripletStepLSTpTracks, highPtTripletStepLSTT4T5Tracks, highPtTripletStepSelectorLSTT4T5)
 (trackingPhase2PU140 & trackingLST).toReplaceWith(HighPtTripletStepTask, _HighPtTripletStepTask_LST)
 
+from Configuration.ProcessModifiers.alpakaValidationLST_cff import alpakaValidationLST
 from HeterogeneousCore.AlpakaCore.functions import makeSerialClone
 lstInputProducerSerialSync = makeSerialClone(lstInputProducer)
 lstProducerSerialSync = makeSerialClone(lstProducer, lstInput = "lstInputProducerSerialSync")
 
 highPtTripletStepTrackCandidatesSerialSync = highPtTripletStepTrackCandidates.clone()
-(trackingPhase2PU140 & trackingLST).toModify(highPtTripletStepTrackCandidatesSerialSync,
+(trackingPhase2PU140 & alpakaValidationLST & trackingLST).toModify(highPtTripletStepTrackCandidatesSerialSync,
     lstOutput = "lstProducerSerialSync",
     lstInput = "lstInputProducerSerialSync",
     lstPixelSeeds = "lstInputProducerSerialSync"
 )
 highPtTripletStepLSTpTracksSerialSync = highPtTripletStepLSTpTracks.clone(
-    src    = 'highPtTripletStepTrackCandidatesSerialSync:pTCsLST')
+    src = 'highPtTripletStepTrackCandidatesSerialSync:pTCsLST')
 highPtTripletStepLSTT4T5TracksSerialSync = highPtTripletStepLSTT4T5Tracks.clone(
-    src    = 'highPtTripletStepTrackCandidatesSerialSync:t4t5TCsLST')
+    src = 'highPtTripletStepTrackCandidatesSerialSync:t4t5TCsLST')
 highPtTripletStepSelectorSerialSync = highPtTripletStepSelector.clone()
-(trackingPhase2PU140 & trackingLST).toModify(highPtTripletStepSelectorSerialSync, src = "highPtTripletStepLSTpTracksSerialSync" )
+(trackingPhase2PU140 & alpakaValidationLST & trackingLST).toModify(highPtTripletStepSelectorSerialSync, src = "highPtTripletStepLSTpTracksSerialSync" )
 highPtTripletStepSelectorLSTT4T5SerialSync = highPtTripletStepSelectorLSTT4T5.clone(src = "highPtTripletStepLSTT4T5TracksSerialSync")
 highPtTripletStepTracksSerialSync = highPtTripletStepTracks.clone()
-(trackingPhase2PU140 & trackingLST).toModify(highPtTripletStepTracksSerialSync,
+(trackingPhase2PU140 & alpakaValidationLST & trackingLST).toModify(highPtTripletStepTracksSerialSync,
     TrackProducers     = ['highPtTripletStepLSTpTracksSerialSync',
                           'highPtTripletStepLSTT4T5TracksSerialSync'],
     selectedTrackQuals = ['highPtTripletStepSelectorSerialSync:highPtTripletStep',
@@ -465,7 +466,7 @@ _HighPtTripletStepTask_LSTSerialSync.add(siPhase2RecHits, lstInitialStepSeedTrac
                                          highPtTripletStepTracksSerialSync
 )
 HighPtTripletStepTaskSerialSync = cms.Task()
-(trackingPhase2PU140 & trackingLST).toReplaceWith(HighPtTripletStepTaskSerialSync, _HighPtTripletStepTask_LSTSerialSync)
+(trackingPhase2PU140 & alpakaValidationLST & trackingLST).toReplaceWith(HighPtTripletStepTaskSerialSync, _HighPtTripletStepTask_LSTSerialSync)
 
 # fast tracking mask producer 
 from FastSimulation.Tracking.FastTrackerRecHitMaskProducer_cfi import maskProducerFromClusterRemover

--- a/RecoTracker/LSTCore/standalone/README.md
+++ b/RecoTracker/LSTCore/standalone/README.md
@@ -154,25 +154,19 @@ Follow the instructions in the ["Setting up LST within CMSSW" section](#setting-
 
 ## Run the LST reconstruction in CMSSW (read to the end, before running)
 
-Two complete workflows have been implemented within CMSSW to run a two-iteration, tracking-only reconstruction with LST:
- - 24834.703 (CPU)
- - 24834.704 (GPU)
+A two-iteration, tracking-only offline workflow with PU, running LST (on GPU if available, otherwise on CPU), 34634.712, has been implemented within CMSSW. More LST workflows can be found in https://github.com/cms-sw/cmssw/tree/master/Configuration/PyReleaseValidation.
 
-We will use the second one in the example below. To get the commands of this workflow, one can run:
+To get the commands for the workflow mentioned above, one can run:
 
-    runTheMatrix.py -w upgrade -n -e -l 24834.704
-
-For convenience, the workflow has been run for 100 events and the output is stored here:
-
-    /data2/segmentlinking/step2_29834.1_100Events.root
+    runTheMatrix.py -w upgrade -n -e -l 34634.712
 
 The input files in each step may need to be properly adjusted to match the ones produced by the previous step/provided externally, hence it is better to run the commands with the `--no_exec` option included.
 
 Running the configuration file with `cmsRun`, the output file will have a name starting with `DQM`. The name is the same every time this step runs,
-so it is good practice to rename the file, e.g. to `step4_24834.704.root`.
+so it is good practice to rename the file, e.g. to `step4_34634.712.root`.
 The MTV plots can be produced with the command:
 
-    makeTrackValidationPlots.py --extended step4_24834.704.root
+    makeTrackValidationPlots.py --extended step4_34634.712.root
 
 Comparison plots can be made by including multiple ROOT files as arguments.
 


### PR DESCRIPTION
This PR applies the additional CPU reconstruction (`SerialSync`) and CPU vs. GPU comparison plots for the LST implementation in the Phase 2 offline reconstruction through a new procModifier, `alpakaValidationLST`. The new modifier is also included in the `alpakaValidation` modifier chain.

With the introduction of the alpakaValidationLST modifier, the offline workflow testing LST on CPU vs. LST on GPU can be made explicit. The code is changed so that the heterogeneous workflow `0.712` (previously `0.704`) runs the offline reconstruction without any additional CPU reconstruction, while a new workflow, `0.713`, runs the comparison. Workflow `0.703` has also been renamed to `0.711`. The workflow numbering changes are made so that the offline LST workflows follow the numbering conventions for Alpaka workflows, following https://github.com/cms-sw/cmssw/pull/49832#discussion_r2694322784.

The PR has been validated by running workflows `0.711`, `0.712` and `0.713` locally. They finished successfully, with the anticipated content in the DQM file.

This PR includes the offline part of #49832 and it supersedes it. It requires and is required by cms-sw/cms-bot#2663.