### PR TITLE
Make `IntrusiveAllocMonitor` re-entrant

### DIFF
--- a/FWCore/AbstractServices/interface/IntrusiveMonitorBase.h
+++ b/FWCore/AbstractServices/interface/IntrusiveMonitorBase.h
@@ -26,7 +26,7 @@ namespace edm {
     Guard<std::string> startMonitoring(T&& name);
 
   private:
-    virtual void start(std::string_view name) = 0;
+    virtual void start(std::string_view name, bool nameIsString) = 0;
     virtual void stop() noexcept = 0;
   };
 
@@ -34,7 +34,7 @@ namespace edm {
   class IntrusiveMonitorBase::Guard<std::string> {
   public:
     Guard(IntrusiveMonitorBase& mon, std::string name) : monitor_(mon), name_(std::move(name)) {
-      monitor_.start(name_);
+      monitor_.start(name_, true);
     }
     Guard(Guard const&) = delete;
     Guard& operator=(Guard const&) = delete;
@@ -52,7 +52,7 @@ namespace edm {
   template <>
   class IntrusiveMonitorBase::Guard<std::string_view> {
   public:
-    Guard(IntrusiveMonitorBase& mon, std::string_view name) : monitor_(mon) { monitor_.start(name); }
+    Guard(IntrusiveMonitorBase& mon, std::string_view name) : monitor_(mon) { monitor_.start(name, false); }
     Guard(Guard const&) = delete;
     Guard& operator=(Guard const&) = delete;
     Guard(Guard&&) = delete;

--- a/FWCore/AbstractServices/interface/IntrusiveMonitorBase.h
+++ b/FWCore/AbstractServices/interface/IntrusiveMonitorBase.h
@@ -15,65 +15,39 @@ namespace edm {
     virtual ~IntrusiveMonitorBase() noexcept;
 
     template <typename T>
-    class Guard;
+      requires std::is_same_v<T, std::string> or std::is_same_v<T, std::string_view>
+    class Guard {
+    public:
+      Guard(IntrusiveMonitorBase& mon, T name) : monitor_(mon), name_(std::move(name)) {
+        monitor_.start(name_, std::is_same_v<T, std::string>);
+      }
+      Guard(Guard const&) = delete;
+      Guard& operator=(Guard const&) = delete;
+      Guard(Guard&&) = delete;
+      Guard& operator=(Guard&&) = delete;
 
-    Guard<std::string_view> startMonitoring(std::string_view name);
+      ~Guard() noexcept { monitor_.stop(name_); }
+
+    private:
+      IntrusiveMonitorBase& monitor_;
+      // Especially with std::string the name_ must be kept alive until the monitor_.stop() call finishes
+      T name_;
+    };
+
+    auto startMonitoring(std::string_view name) { return Guard<std::string_view>(*this, name); }
 
     // direct std::string&& would be ambiguous for C-string literals
     // without is_rvalue_reference this overload would match for lvalue std::string
     template <typename T>
       requires std::is_same_v<std::remove_cvref_t<T>, std::string> and std::is_rvalue_reference_v<T&&>
-    Guard<std::string> startMonitoring(T&& name);
+    auto startMonitoring(T&& name) {
+      return Guard<std::string>(*this, std::move(name));
+    }
 
   private:
     virtual void start(std::string_view name, bool nameIsString) = 0;
-    virtual void stop() noexcept = 0;
+    virtual void stop(std::string_view name) noexcept = 0;
   };
-
-  template <>
-  class IntrusiveMonitorBase::Guard<std::string> {
-  public:
-    Guard(IntrusiveMonitorBase& mon, std::string name) : monitor_(mon), name_(std::move(name)) {
-      monitor_.start(name_, true);
-    }
-    Guard(Guard const&) = delete;
-    Guard& operator=(Guard const&) = delete;
-    Guard(Guard&&) = delete;
-    Guard& operator=(Guard&&) = delete;
-
-    ~Guard() noexcept { monitor_.stop(); }
-
-  private:
-    IntrusiveMonitorBase& monitor_;
-    // The std::string must be kept alive until the monitor_.stop() call finishes
-    std::string name_;
-  };
-
-  template <>
-  class IntrusiveMonitorBase::Guard<std::string_view> {
-  public:
-    Guard(IntrusiveMonitorBase& mon, std::string_view name) : monitor_(mon) { monitor_.start(name, false); }
-    Guard(Guard const&) = delete;
-    Guard& operator=(Guard const&) = delete;
-    Guard(Guard&&) = delete;
-    Guard& operator=(Guard&&) = delete;
-
-    ~Guard() noexcept { monitor_.stop(); }
-
-  private:
-    IntrusiveMonitorBase& monitor_;
-  };
-
-  inline IntrusiveMonitorBase::Guard<std::string_view> IntrusiveMonitorBase::startMonitoring(std::string_view name) {
-    return Guard<std::string_view>(*this, name);
-  }
-
-  template <typename T>
-    requires std::is_same_v<std::remove_cvref_t<T>, std::string> and std::is_rvalue_reference_v<T&&>
-  IntrusiveMonitorBase::Guard<std::string> IntrusiveMonitorBase::startMonitoring(T&& name) {
-    return Guard<std::string>(*this, std::move(name));
-  }
-
 }  // namespace edm
 
 #endif

--- a/FWCore/AbstractServices/interface/IntrusiveMonitorBase.h
+++ b/FWCore/AbstractServices/interface/IntrusiveMonitorBase.h
@@ -6,6 +6,33 @@
 #include <string_view>
 
 namespace edm {
+  /**
+   * These objects form a linked list of nested uses
+   * IntrusiveMonitors. The objects live in the stack via the Guard
+   * object. The pointers to previous node are non-owning.
+   *
+   * This structure does not allocate memory
+   */
+  class IntrusiveMonitorStackNode {
+  public:
+    IntrusiveMonitorStackNode(std::string_view name, IntrusiveMonitorStackNode const* previous)
+        : name_(name), previous_(previous) {}
+    IntrusiveMonitorStackNode(IntrusiveMonitorStackNode const&) = delete;
+    IntrusiveMonitorStackNode& operator=(IntrusiveMonitorStackNode const&) = delete;
+    IntrusiveMonitorStackNode(IntrusiveMonitorStackNode&&) = delete;
+    IntrusiveMonitorStackNode& operator=(IntrusiveMonitorStackNode&&) = delete;
+
+    static void setNodeInCurrentThread(IntrusiveMonitorStackNode const* node);
+    static IntrusiveMonitorStackNode const* getNodeInCurrentThread();
+
+    std::string_view name() const { return name_; }
+    IntrusiveMonitorStackNode const* previousNode() const { return previous_; }
+
+  private:
+    std::string_view name_;
+    IntrusiveMonitorStackNode const* previous_;
+  };
+
   class IntrusiveMonitorBase {
   public:
     IntrusiveMonitorBase() = default;
@@ -19,18 +46,28 @@ namespace edm {
       requires std::is_same_v<T, std::string> or std::is_same_v<T, std::string_view>
     class Guard {
     public:
-      Guard(IntrusiveMonitorBase& mon, T name) : monitor_(mon), name_(std::move(name)), value_(monitor_.start()) {}
+      Guard(IntrusiveMonitorBase& mon, T name)
+          : monitor_(mon),
+            name_(std::move(name)),
+            value_(monitor_.start()),
+            callStackNode_(name_, IntrusiveMonitorStackNode::getNodeInCurrentThread()) {
+        IntrusiveMonitorStackNode::setNodeInCurrentThread(&callStackNode_);
+      }
       Guard(Guard const&) = delete;
       Guard& operator=(Guard const&) = delete;
       Guard(Guard&&) = delete;
       Guard& operator=(Guard&&) = delete;
 
-      ~Guard() { monitor_.stop(name_, std::move(value_)); }
+      ~Guard() {
+        monitor_.stop(&callStackNode_, std::move(value_));
+        IntrusiveMonitorStackNode::setNodeInCurrentThread(callStackNode_.previousNode());
+      }
 
     private:
       IntrusiveMonitorBase& monitor_;
       T name_;
       std::any value_;
+      IntrusiveMonitorStackNode callStackNode_;
     };
 
     auto startMonitoring(std::string_view name) { return Guard<std::string_view>(*this, name); }
@@ -45,7 +82,7 @@ namespace edm {
 
   private:
     virtual std::any start() = 0;
-    virtual void stop(std::string_view name, std::any) = 0;
+    virtual void stop(IntrusiveMonitorStackNode const* callStack, std::any) = 0;
   };
 }  // namespace edm
 

--- a/FWCore/AbstractServices/interface/IntrusiveMonitorBase.h
+++ b/FWCore/AbstractServices/interface/IntrusiveMonitorBase.h
@@ -12,7 +12,7 @@ namespace edm {
     IntrusiveMonitorBase& operator=(IntrusiveMonitorBase const&) = delete;
     IntrusiveMonitorBase(IntrusiveMonitorBase&&) = delete;
     IntrusiveMonitorBase& operator=(IntrusiveMonitorBase&&) = delete;
-    virtual ~IntrusiveMonitorBase();
+    virtual ~IntrusiveMonitorBase() noexcept;
 
     template <typename T>
     class Guard;
@@ -27,7 +27,7 @@ namespace edm {
 
   private:
     virtual void start(std::string_view name) = 0;
-    virtual void stop() = 0;
+    virtual void stop() noexcept = 0;
   };
 
   template <>
@@ -41,7 +41,7 @@ namespace edm {
     Guard(Guard&&) = delete;
     Guard& operator=(Guard&&) = delete;
 
-    ~Guard() { monitor_.stop(); }
+    ~Guard() noexcept { monitor_.stop(); }
 
   private:
     IntrusiveMonitorBase& monitor_;
@@ -58,7 +58,7 @@ namespace edm {
     Guard(Guard&&) = delete;
     Guard& operator=(Guard&&) = delete;
 
-    ~Guard() { monitor_.stop(); }
+    ~Guard() noexcept { monitor_.stop(); }
 
   private:
     IntrusiveMonitorBase& monitor_;

--- a/FWCore/AbstractServices/interface/IntrusiveMonitorBase.h
+++ b/FWCore/AbstractServices/interface/IntrusiveMonitorBase.h
@@ -1,38 +1,10 @@
 #ifndef FWCore_AbstractServices_IntrusiveMonitorBase_h
 #define FWCore_AbstractServices_IntrusiveMonitorBase_h
 
-#include <any>
 #include <string>
 #include <string_view>
 
 namespace edm {
-  /**
-   * These objects form a linked list of nested uses
-   * IntrusiveMonitors. The objects live in the stack via the Guard
-   * object. The pointers to previous node are non-owning.
-   *
-   * This structure does not allocate memory
-   */
-  class IntrusiveMonitorStackNode {
-  public:
-    IntrusiveMonitorStackNode(std::string_view name, IntrusiveMonitorStackNode const* previous)
-        : name_(name), previous_(previous) {}
-    IntrusiveMonitorStackNode(IntrusiveMonitorStackNode const&) = delete;
-    IntrusiveMonitorStackNode& operator=(IntrusiveMonitorStackNode const&) = delete;
-    IntrusiveMonitorStackNode(IntrusiveMonitorStackNode&&) = delete;
-    IntrusiveMonitorStackNode& operator=(IntrusiveMonitorStackNode&&) = delete;
-
-    static void setNodeInCurrentThread(IntrusiveMonitorStackNode const* node);
-    static IntrusiveMonitorStackNode const* getNodeInCurrentThread();
-
-    std::string_view name() const { return name_; }
-    IntrusiveMonitorStackNode const* previousNode() const { return previous_; }
-
-  private:
-    std::string_view name_;
-    IntrusiveMonitorStackNode const* previous_;
-  };
-
   class IntrusiveMonitorBase {
   public:
     IntrusiveMonitorBase() = default;
@@ -43,47 +15,65 @@ namespace edm {
     virtual ~IntrusiveMonitorBase();
 
     template <typename T>
-      requires std::is_same_v<T, std::string> or std::is_same_v<T, std::string_view>
-    class Guard {
-    public:
-      Guard(IntrusiveMonitorBase& mon, T name)
-          : monitor_(mon),
-            name_(std::move(name)),
-            value_(monitor_.start()),
-            callStackNode_(name_, IntrusiveMonitorStackNode::getNodeInCurrentThread()) {
-        IntrusiveMonitorStackNode::setNodeInCurrentThread(&callStackNode_);
-      }
-      Guard(Guard const&) = delete;
-      Guard& operator=(Guard const&) = delete;
-      Guard(Guard&&) = delete;
-      Guard& operator=(Guard&&) = delete;
+    class Guard;
 
-      ~Guard() {
-        monitor_.stop(&callStackNode_, std::move(value_));
-        IntrusiveMonitorStackNode::setNodeInCurrentThread(callStackNode_.previousNode());
-      }
-
-    private:
-      IntrusiveMonitorBase& monitor_;
-      T name_;
-      std::any value_;
-      IntrusiveMonitorStackNode callStackNode_;
-    };
-
-    auto startMonitoring(std::string_view name) { return Guard<std::string_view>(*this, name); }
+    Guard<std::string_view> startMonitoring(std::string_view name);
 
     // direct std::string&& would be ambiguous for C-string literals
     // without is_rvalue_reference this overload would match for lvalue std::string
     template <typename T>
       requires std::is_same_v<std::remove_cvref_t<T>, std::string> and std::is_rvalue_reference_v<T&&>
-    auto startMonitoring(T&& name) {
-      return Guard<std::string>(*this, std::move(name));
-    }
+    Guard<std::string> startMonitoring(T&& name);
 
   private:
-    virtual std::any start() = 0;
-    virtual void stop(IntrusiveMonitorStackNode const* callStack, std::any) = 0;
+    virtual void start(std::string_view name) = 0;
+    virtual void stop() = 0;
   };
+
+  template <>
+  class IntrusiveMonitorBase::Guard<std::string> {
+  public:
+    Guard(IntrusiveMonitorBase& mon, std::string name) : monitor_(mon), name_(std::move(name)) {
+      monitor_.start(name_);
+    }
+    Guard(Guard const&) = delete;
+    Guard& operator=(Guard const&) = delete;
+    Guard(Guard&&) = delete;
+    Guard& operator=(Guard&&) = delete;
+
+    ~Guard() { monitor_.stop(); }
+
+  private:
+    IntrusiveMonitorBase& monitor_;
+    // The std::string must be kept alive until the monitor_.stop() call finishes
+    std::string name_;
+  };
+
+  template <>
+  class IntrusiveMonitorBase::Guard<std::string_view> {
+  public:
+    Guard(IntrusiveMonitorBase& mon, std::string_view name) : monitor_(mon) { monitor_.start(name); }
+    Guard(Guard const&) = delete;
+    Guard& operator=(Guard const&) = delete;
+    Guard(Guard&&) = delete;
+    Guard& operator=(Guard&&) = delete;
+
+    ~Guard() { monitor_.stop(); }
+
+  private:
+    IntrusiveMonitorBase& monitor_;
+  };
+
+  inline IntrusiveMonitorBase::Guard<std::string_view> IntrusiveMonitorBase::startMonitoring(std::string_view name) {
+    return Guard<std::string_view>(*this, name);
+  }
+
+  template <typename T>
+    requires std::is_same_v<std::remove_cvref_t<T>, std::string> and std::is_rvalue_reference_v<T&&>
+  IntrusiveMonitorBase::Guard<std::string> IntrusiveMonitorBase::startMonitoring(T&& name) {
+    return Guard<std::string>(*this, std::move(name));
+  }
+
 }  // namespace edm
 
 #endif

--- a/FWCore/AbstractServices/src/IntrusiveMonitorBase.cc
+++ b/FWCore/AbstractServices/src/IntrusiveMonitorBase.cc
@@ -1,18 +1,5 @@
 #include "FWCore/AbstractServices/interface/IntrusiveMonitorBase.h"
 
-namespace {
-  edm::IntrusiveMonitorStackNode const*& threadLocalPointer() {
-    static thread_local edm::IntrusiveMonitorStackNode const* ptr = nullptr;
-    return ptr;
-  }
-}  // namespace
-
 namespace edm {
-  void IntrusiveMonitorStackNode::setNodeInCurrentThread(IntrusiveMonitorStackNode const* node) {
-    threadLocalPointer() = node;
-  }
-
-  IntrusiveMonitorStackNode const* IntrusiveMonitorStackNode::getNodeInCurrentThread() { return threadLocalPointer(); }
-
   IntrusiveMonitorBase::~IntrusiveMonitorBase() = default;
 }  // namespace edm

--- a/FWCore/AbstractServices/src/IntrusiveMonitorBase.cc
+++ b/FWCore/AbstractServices/src/IntrusiveMonitorBase.cc
@@ -1,5 +1,18 @@
 #include "FWCore/AbstractServices/interface/IntrusiveMonitorBase.h"
 
+namespace {
+  edm::IntrusiveMonitorStackNode const*& threadLocalPointer() {
+    static thread_local edm::IntrusiveMonitorStackNode const* ptr = nullptr;
+    return ptr;
+  }
+}  // namespace
+
 namespace edm {
+  void IntrusiveMonitorStackNode::setNodeInCurrentThread(IntrusiveMonitorStackNode const* node) {
+    threadLocalPointer() = node;
+  }
+
+  IntrusiveMonitorStackNode const* IntrusiveMonitorStackNode::getNodeInCurrentThread() { return threadLocalPointer(); }
+
   IntrusiveMonitorBase::~IntrusiveMonitorBase() = default;
-}
+}  // namespace edm

--- a/FWCore/AbstractServices/src/IntrusiveMonitorBase.cc
+++ b/FWCore/AbstractServices/src/IntrusiveMonitorBase.cc
@@ -1,5 +1,5 @@
 #include "FWCore/AbstractServices/interface/IntrusiveMonitorBase.h"
 
 namespace edm {
-  IntrusiveMonitorBase::~IntrusiveMonitorBase() = default;
+  IntrusiveMonitorBase::~IntrusiveMonitorBase() noexcept = default;
 }  // namespace edm

--- a/PerfTools/AllocMonitor/README.md
+++ b/PerfTools/AllocMonitor/README.md
@@ -165,7 +165,9 @@ The message will print
 | `nAlloc` | Number of memory allocations |
 | `nDealloc` | Number of memory deallocations |
 
-This service is multi-thread safe, and concurrent measurements can be done in different threads. The service is re-entrant, i.e. measurements in nested scopes or function calls can be done within one thread. In case of nested measurements the numbers for the outer scope exclude the numbers of the inner scope. For the inner scope measurement the message will contain the descriptions of all outer measurements separated by the semicolon (`;`).
+This service is multi-thread safe, and concurrent measurements can be done in different threads. The service is re-entrant, i.e. measurements in nested scopes or function calls can be done within one thread. In case of nested measurements the numbers for the outer scope exclude the numbers of the inner scope. For the inner scope measurement the message will contain the description strings of all outer measurements in a strack-trace-like format.
+
+Note that if an `std::string` is passed to `startMeasurement()`, the memory allocations from the string formatting will be accounted by a possible outer scope measurements. In that case the measurement printout of the outer scope will denote that along with the minimum amount of allocated memory and the number of allocations for the strings, but generally the numbers can not be obtained precisely. Therefore it is recommended to use `std::string` overload only when really necessary.
 
 Allocations done in different thread where the `startMeasurement()` is called are not recorded. Measurements started in one thread and ended in different thread are not supported.
 

--- a/PerfTools/AllocMonitor/README.md
+++ b/PerfTools/AllocMonitor/README.md
@@ -165,7 +165,9 @@ The message will print
 | `nAlloc` | Number of memory allocations |
 | `nDealloc` | Number of memory deallocations |
 
-This service is multi-thread safe, and concurrent measurements can be done in different threads. Nested measurements are not supported (i.e. one thread can be doing only one measurement at a time), and neither are measurements started in one thread and ended in different thread.
+This service is multi-thread safe, and concurrent measurements can be done in different threads. The service is re-entrant, i.e. measurements in nested scopes or function calls can be done within one thread. In case of nested measurements the numbers for the outer scope exclude the numbers of the inner scope. For the inner scope measurement the message will contain the descriptions of all outer measurements separated by the semicolon (`;`).
+
+Allocations done in different thread where the `startMeasurement()` is called are not recorded. Measurements started in one thread and ended in different thread are not supported.
 
 ### ThresholdAbortAllocMonitor
 

--- a/PerfTools/AllocMonitor/plugins/BuildFile.xml
+++ b/PerfTools/AllocMonitor/plugins/BuildFile.xml
@@ -2,4 +2,5 @@
 <use name="FWCore/Concurrency"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ServiceRegistry"/>
+<use name="FWCore/Utilities" source_only="1"/>
 <use name="PerfTools/AllocMonitor"/>

--- a/PerfTools/AllocMonitor/plugins/IntrusiveAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/IntrusiveAllocMonitor.cc
@@ -150,7 +150,7 @@ public:
   ~IntrusiveAllocMonitor() noexcept override = default;
 
   void start(std::string_view name, bool nameIsString) final { MonitorAdaptor::startOnThread(name, nameIsString); }
-  void stop() noexcept final {
+  void stop(std::string_view nameArg) noexcept final {
     // If an exception is thrown here, can't do much more than ignore it
     CMS_SA_ALLOW try {
       auto guard = MonitorAdaptor::stopOnThread();
@@ -166,6 +166,10 @@ public:
                  info.nDeallocations_);
 
       MonitorStackNode const* node = guard.currentNode();
+      if (node != nullptr) {
+        // sanity check
+        assert(nameArg == node->name());
+      }
       int depth = 0;
       while (node != nullptr) {
         log.format("\n[{}] {}", depth, node->name());

--- a/PerfTools/AllocMonitor/plugins/IntrusiveAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/IntrusiveAllocMonitor.cc
@@ -15,11 +15,7 @@ namespace {
     static void startOnThread() { threadAllocInfo().reset(); }
     static ThreadAllocInfo const& stopOnThread() {
       auto& t = threadAllocInfo();
-      if (not t.active_) {
-        t.reset();
-      } else {
-        t.deactivate();
-      }
+      t.deactivate();
       return t;
     }
 

--- a/PerfTools/AllocMonitor/plugins/ThreadAllocInfo.h
+++ b/PerfTools/AllocMonitor/plugins/ThreadAllocInfo.h
@@ -46,6 +46,7 @@ namespace edm::service::moduleAlloc {
       active_ = true;
     }
 
+    void activate() { active_ = true; }
     void deactivate() { active_ = false; }
   };
 }  // namespace edm::service::moduleAlloc

--- a/PerfTools/AllocMonitor/test/BuildFile.xml
+++ b/PerfTools/AllocMonitor/test/BuildFile.xml
@@ -34,7 +34,7 @@
     <use name="PerfTools/AllocMonitor"/>
     <use name="PerfTools/AllocMonitorPreload"/>
   </bin>
-  <test name="testIntrusiveAllocMonitorOutput" command="testIntrusiveAllocMonitor 2>&amp;1 | grep -q 'Vector fill: requested'">
+  <test name="testIntrusiveAllocMonitorOutput" command="testIntrusiveAllocMonitor 2>&amp;1 | ${LOCALTOP}/src/PerfTools/AllocMonitor/test/verifyIntrusiveAllocMonitor.py">
     <flags PRE_TEST="testIntrusiveAllocMonitor"/>
   </test>
 </ifrelease>

--- a/PerfTools/AllocMonitor/test/test_intrusiveAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/test/test_intrusiveAllocMonitor.cc
@@ -9,7 +9,15 @@
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 
 #include <cassert>
+#include <memory>
 #include <vector>
+
+std::unique_ptr<int> nested() {
+  edm::Service<edm::IntrusiveMonitorBase> imb;
+  auto guard = imb->startMonitoring("Nested allocation inner");
+
+  return std::make_unique<int>(42);
+}
 
 int main() {
   edmplugin::PluginManager::configure(edmplugin::standard::config());
@@ -28,9 +36,10 @@ process.add_(cms.Service('IntrusiveAllocMonitor'))
   assert(imb.isAvailable());
 
   std::vector<int> vec;
+  constexpr int N = 10000;
   {
     auto guard = imb->startMonitoring("Vector fill");
-    for (int i = 0; i < 10000; ++i) {
+    for (int i = 0; i < N; ++i) {
       vec.push_back(i * 2 - 1);
     }
 
@@ -43,13 +52,31 @@ process.add_(cms.Service('IntrusiveAllocMonitor'))
   }
   {
     auto guard = imb->startMonitoring(std::string("Vector fill again"));
-    for (int i = 0; i < 10000; ++i) {
+    for (int i = 0; i < N; ++i) {
       vec.push_back(i * 2 - 1);
     }
 
     int sum = 0;
     for (int a : vec) {
       sum += a;
+    }
+
+    edm::LogPrint("Test").format("Sum {}", sum);
+  }
+
+  vec = std::vector<int>();  // clear capacity
+  {
+    int sum = 0;
+    {
+      auto guard = imb->startMonitoring("Nested allocation outer vector fill");
+      for (int i = 0; i < N; ++i) {
+        vec.push_back(i * 2 - 1);
+      }
+
+      auto ptr = nested();
+      for (int a : vec) {
+        sum += a - *ptr;
+      }
     }
 
     edm::LogPrint("Test").format("Sum {}", sum);

--- a/PerfTools/AllocMonitor/test/test_intrusiveAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/test/test_intrusiveAllocMonitor.cc
@@ -14,7 +14,7 @@
 
 std::unique_ptr<int> nested() {
   edm::Service<edm::IntrusiveMonitorBase> imb;
-  auto guard = imb->startMonitoring("Nested allocation inner");
+  auto guard = imb->startMonitoring("inner unique_ptr");
 
   return std::make_unique<int>(42);
 }
@@ -64,19 +64,23 @@ process.add_(cms.Service('IntrusiveAllocMonitor'))
     edm::LogPrint("Test").format("Sum {}", sum);
   }
 
-  vec = std::vector<int>();  // clear capacity
   {
     int sum = 0;
     {
-      auto guard = imb->startMonitoring("Nested allocation outer vector fill");
-      for (int i = 0; i < N; ++i) {
-        vec.push_back(i * 2 - 1);
-      }
+      auto guard = imb->startMonitoring("Nested allocation empty outer");
+      auto ptr2 = nested();
+      sum = *ptr2;
+    }
+    edm::LogPrint("Test").format("Sum {}", sum);
+  }
 
-      auto ptr = nested();
-      for (int a : vec) {
-        sum += a - *ptr;
-      }
+  {
+    int sum = 0;
+    {
+      auto guard = imb->startMonitoring("Nested allocation outer unique_ptr");
+      auto ptr1 = std::make_unique<int>(42);
+      auto ptr2 = nested();
+      sum = *ptr1 + *ptr2;
     }
 
     edm::LogPrint("Test").format("Sum {}", sum);

--- a/PerfTools/AllocMonitor/test/test_intrusiveAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/test/test_intrusiveAllocMonitor.cc
@@ -19,6 +19,12 @@ std::unique_ptr<int> nested() {
   return std::make_unique<int>(42);
 }
 
+// dirty tricks to prevent compiler from optimizing allocations away...
+std::atomic<int*> ptr1 = nullptr;
+std::atomic<int*> ptr2 = nullptr;
+std::atomic<int*> ptr3 = nullptr;
+std::atomic<int*> ptr4 = nullptr;
+
 int main() {
   edmplugin::PluginManager::configure(edmplugin::standard::config());
 
@@ -37,33 +43,43 @@ process.add_(cms.Service('IntrusiveAllocMonitor'))
 
   std::vector<int> vec;
   constexpr int N = 10000;
+  edm::LogPrint("Test").format("Test vector fill");
   {
-    auto guard = imb->startMonitoring("Vector fill");
-    for (int i = 0; i < N; ++i) {
-      vec.push_back(i * 2 - 1);
-    }
-
     int sum = 0;
-    for (int a : vec) {
-      sum += a;
+    {
+      auto guard = imb->startMonitoring("Vector fill");
+      for (int i = 0; i < N; ++i) {
+        vec.push_back(i * 2 - 1);
+      }
+
+      for (int a : vec) {
+        sum += a;
+      }
     }
 
     edm::LogPrint("Test").format("Sum {}", sum);
   }
-  {
-    auto guard = imb->startMonitoring(std::string("Vector fill again"));
-    for (int i = 0; i < N; ++i) {
-      vec.push_back(i * 2 - 1);
-    }
+  edm::LogPrint("Test").format("====================");
 
+  edm::LogPrint("Test").format("Test vector fill again");
+  {
     int sum = 0;
-    for (int a : vec) {
-      sum += a;
+    {
+      auto guard = imb->startMonitoring(std::string("Vector fill again"));
+      for (int i = 0; i < N; ++i) {
+        vec.push_back(i * 2 - 1);
+      }
+
+      for (int a : vec) {
+        sum += a;
+      }
     }
 
     edm::LogPrint("Test").format("Sum {}", sum);
   }
+  edm::LogPrint("Test").format("====================");
 
+  edm::LogPrint("Test").format("Test nested allocation with empty outer");
   {
     int sum = 0;
     {
@@ -73,7 +89,9 @@ process.add_(cms.Service('IntrusiveAllocMonitor'))
     }
     edm::LogPrint("Test").format("Sum {}", sum);
   }
+  edm::LogPrint("Test").format("====================");
 
+  edm::LogPrint("Test").format("Test nested allocation");
   {
     int sum = 0;
     {
@@ -85,6 +103,41 @@ process.add_(cms.Service('IntrusiveAllocMonitor'))
 
     edm::LogPrint("Test").format("Sum {}", sum);
   }
+  edm::LogPrint("Test").format("====================");
+
+  edm::LogPrint("Test").format("Test nested with string messages");
+  {
+    int sum = 0;
+    {
+      auto guard1 = imb->startMonitoring("Nested allocation with string messages outer unique_ptr");
+      ptr1 = new int(42);
+      ptr2 = nullptr;
+      {
+        auto guard2 = imb->startMonitoring(std::string("inner unique_ptr"));
+        ptr2 = new int(67);
+      }
+      ptr3 = nullptr;
+      {
+        auto guard3 = imb->startMonitoring(std::string("another inner unique_ptr"));
+        ptr3 = new int(11);
+      }
+      ptr4 = nullptr;
+      {
+        auto guard4 = imb->startMonitoring(std::string("inner empty"));
+        {
+          auto guard4_1 = imb->startMonitoring(std::string("inner unique_ptr"));
+          ptr4 = new int(313);
+        }
+      }
+      sum = *ptr1 + *ptr2 + *ptr3 + *ptr4;
+      delete ptr4.load();
+      delete ptr3.load();
+      delete ptr2.load();
+      delete ptr1.load();
+    }
+    edm::LogPrint("Test").format("Sum {}", sum);
+  }
+  edm::LogPrint("Test").format("====================");
 
   return 0;
 }

--- a/PerfTools/AllocMonitor/test/verifyIntrusiveAllocMonitor.py
+++ b/PerfTools/AllocMonitor/test/verifyIntrusiveAllocMonitor.py
@@ -6,7 +6,8 @@ import re
 def parse_message(line):
     """Parse a IntrusiveAllocMonitor message line and extract field values."""
     # Pattern: "Name: requested X added Y max alloc Z peak W nAlloc N nDealloc M"
-    pattern = r'^(?P<name>.+):\s+requested\s+(?P<requested>\d+)\s+added\s+(?P<added>\d+)\s+max alloc\s+(?P<max_alloc>\d+)\s+peak\s+(?P<peak>\d+)\s+nAlloc\s+(?P<nAlloc>\d+)\s+nDealloc\s+(?P<nDealloc>\d+)$'
+    # Note: added can be negative
+    pattern = r'^(?P<name>.+):\s+requested\s+(?P<requested>\d+)\s+added\s+(?P<added>-?\d+)\s+max alloc\s+(?P<max_alloc>\d+)\s+peak\s+(?P<peak>\d+)\s+nAlloc\s+(?P<nAlloc>\d+)\s+nDealloc\s+(?P<nDealloc>\d+)$'
     match = re.match(pattern, line.strip())
     if not match:
         raise ValueError(f"Malformed message line: {line}")
@@ -81,63 +82,137 @@ def verify_vector_fill_again(msg, vector_fill_msg):
     if msg['nAlloc'] != msg['nDealloc']:
         raise ValueError(f"Vector fill again: nAlloc ({msg['nAlloc']}) must equal nDealloc ({msg['nDealloc']})")
 
-def verify_nested_inner(msg):
-    """Verify conditions for 'Nested allocation inner' message."""
+def verify_nested_empty_outer_inner(msg):
+    """Verify conditions for 'Nested allocation empty outer;inner unique_ptr' message."""
     name = msg['name']
-    if name != 'Nested allocation inner':
-        raise ValueError(f"Expected 'Nested allocation inner', got '{name}'")
-    
+    if name != 'Nested allocation empty outer;inner unique_ptr':
+        raise ValueError(f"Expected 'Nested allocation empty outer;inner unique_ptr', got '{name}'")
+
     # requested is 4
     if msg['requested'] != 4:
-        raise ValueError(f"Nested allocation inner: requested must be 4, got {msg['requested']}")
-    
+        raise ValueError(f"Nested allocation empty outer;inner unique_ptr: requested must be 4, got {msg['requested']}")
+
     # added and peak are equal
     if msg['added'] != msg['peak']:
-        raise ValueError(f"Nested allocation inner: added ({msg['added']}) must equal peak ({msg['peak']})")
-    
+        raise ValueError(f"Nested allocation empty outer;inner unique_ptr: added ({msg['added']}) must equal peak ({msg['peak']})")
+
     # added is larger or equal to requested
     if msg['added'] < msg['requested']:
-        raise ValueError(f"Nested allocation inner: added ({msg['added']}) must be >= requested ({msg['requested']})")
-    
+        raise ValueError(f"Nested allocation empty outer;inner unique_ptr: added ({msg['added']}) must be >= requested ({msg['requested']})")
+
     # nAlloc is 1 and nDealloc is 0
     if msg['nAlloc'] != 1:
-        raise ValueError(f"Nested allocation inner: nAlloc must be 1, got {msg['nAlloc']}")
+        raise ValueError(f"Nested allocation empty outer;inner unique_ptr: nAlloc must be 1, got {msg['nAlloc']}")
     if msg['nDealloc'] != 0:
-        raise ValueError(f"Nested allocation inner: nDealloc must be 0, got {msg['nDealloc']}")
+        raise ValueError(f"Nested allocation empty outer;inner unique_ptr: nDealloc must be 0, got {msg['nDealloc']}")
 
-def verify_nested_outer(msg, inner_msg):
-    """Verify conditions for 'Nested allocation outer vector fill' message."""
+def verify_nested_empty_outer(msg, inner_msg):
+    """Verify conditions for 'Nested allocation empty outer' message."""
     name = msg['name']
-    if name != 'Nested allocation outer vector fill':
-        raise ValueError(f"Expected 'Nested allocation outer vector fill', got '{name}'")
-    
-    # All fields are larger than 0
-    if not all(msg[field] > 0 for field in ['requested', 'added', 'max_alloc', 'peak', 'nAlloc', 'nDealloc']):
-        raise ValueError(f"Nested allocation outer vector fill: all fields must be > 0, got {msg}")
-    
-    # requested, added, and max alloc are strictly larger than in "Nested allocation inner"
-    if msg['requested'] <= inner_msg['requested']:
-        raise ValueError(f"Nested allocation outer vector fill: requested ({msg['requested']}) must be > inner requested ({inner_msg['requested']})")
-    if msg['added'] <= inner_msg['added']:
-        raise ValueError(f"Nested allocation outer vector fill: added ({msg['added']}) must be > inner added ({inner_msg['added']})")
-    if msg['max_alloc'] <= inner_msg['max_alloc']:
-        raise ValueError(f"Nested allocation outer vector fill: max alloc ({msg['max_alloc']}) must be > inner max alloc ({inner_msg['max_alloc']})")
+    if name != 'Nested allocation empty outer':
+        raise ValueError(f"Expected 'Nested allocation empty outer', got '{name}'")
+
+    # requested is 0
+    if msg['requested'] != 0:
+        raise ValueError(f"Nested allocation empty outer: requested must be 0, got {msg['requested']}")
+
+    # added is negative of inner added
+    if msg['added'] != -inner_msg['added']:
+        raise ValueError(f"Nested allocation empty outer: added ({msg['added']}) must be -{inner_msg['added']}")
+
+    # max alloc is 0
+    if msg['max_alloc'] != 0:
+        raise ValueError(f"Nested allocation empty outer: max alloc must be 0, got {msg['max_alloc']}")
+
+    # peak is 0
+    if msg['peak'] != 0:
+        raise ValueError(f"Nested allocation empty outer: peak must be 0, got {msg['peak']}")
+
+    # nAlloc is 0
+    if msg['nAlloc'] != 0:
+        raise ValueError(f"Nested allocation empty outer: nAlloc must be 0, got {msg['nAlloc']}")
+
+    # nDealloc is 1
+    if msg['nDealloc'] != 1:
+        raise ValueError(f"Nested allocation empty outer: nDealloc must be 1, got {msg['nDealloc']}")
+
+def verify_nested_outer_unique_ptr_inner(msg):
+    """Verify conditions for 'Nested allocation outer unique_ptr;inner unique_ptr' message."""
+    name = msg['name']
+    if name != 'Nested allocation outer unique_ptr;inner unique_ptr':
+        raise ValueError(f"Expected 'Nested allocation outer unique_ptr;inner unique_ptr', got '{name}'")
+
+    # requested is 4
+    if msg['requested'] != 4:
+        raise ValueError(f"Nested allocation outer unique_ptr;inner unique_ptr: requested must be 4, got {msg['requested']}")
+
+    # added and peak are equal
+    if msg['added'] != msg['peak']:
+        raise ValueError(f"Nested allocation outer unique_ptr;inner unique_ptr: added ({msg['added']}) must equal peak ({msg['peak']})")
+
+    # added is larger or equal to requested
+    if msg['added'] < msg['requested']:
+        raise ValueError(f"Nested allocation outer unique_ptr;inner unique_ptr: added ({msg['added']}) must be >= requested ({msg['requested']})")
+
+    # nAlloc is 1 and nDealloc is 0
+    if msg['nAlloc'] != 1:
+        raise ValueError(f"Nested allocation outer unique_ptr;inner unique_ptr: nAlloc must be 1, got {msg['nAlloc']}")
+    if msg['nDealloc'] != 0:
+        raise ValueError(f"Nested allocation outer unique_ptr;inner unique_ptr: nDealloc must be 0, got {msg['nDealloc']}")
+
+def verify_nested_outer_unique_ptr(msg, inner_msg):
+    """Verify conditions for 'Nested allocation outer unique_ptr' message."""
+    name = msg['name']
+    if name != 'Nested allocation outer unique_ptr':
+        raise ValueError(f"Expected 'Nested allocation outer unique_ptr', got '{name}'")
+
+    # requested, max alloc, and peak are larger than 0
+    if msg['requested'] <= 0:
+        raise ValueError(f"Nested allocation outer unique_ptr: requested must be > 0, got {msg['requested']}")
+    if msg['max_alloc'] <= 0:
+        raise ValueError(f"Nested allocation outer unique_ptr: max alloc must be > 0, got {msg['max_alloc']}")
+    if msg['peak'] <= 0:
+        raise ValueError(f"Nested allocation outer unique_ptr: peak must be > 0, got {msg['peak']}")
+
+    # added is negative of inner added
+    if msg['added'] != -inner_msg['added']:
+        raise ValueError(f"Nested allocation outer unique_ptr: added ({msg['added']}) must be -{inner_msg['added']}")
+
+    # requested and max alloc equal to inner
+    if msg['requested'] != inner_msg['requested']:
+        raise ValueError(f"Nested allocation outer unique_ptr: requested ({msg['requested']}) must equal inner requested ({inner_msg['requested']})")
+    if msg['max_alloc'] != inner_msg['max_alloc']:
+        raise ValueError(f"Nested allocation outer unique_ptr: max alloc ({msg['max_alloc']}) must equal inner max alloc ({inner_msg['max_alloc']})")
+
+    # peak equals inner peak
+    if msg['peak'] != inner_msg['peak']:
+        raise ValueError(f"Nested allocation outer unique_ptr: peak ({msg['peak']}) must equal inner peak ({inner_msg['peak']})")
+
+    # nAlloc is 1
+    if msg['nAlloc'] != 1:
+        raise ValueError(f"Nested allocation outer unique_ptr: nAlloc must be 1, got {msg['nAlloc']}")
+
+    # nDealloc is 2
+    if msg['nDealloc'] != 2:
+        raise ValueError(f"Nested allocation outer unique_ptr: nDealloc must be 2, got {msg['nDealloc']}")
 
 def main():
     """Main function to parse and verify IntrusiveAllocMonitor output."""
     try:
         messages = read_messages()
-        
-        # Check that we have exactly 4 messages
-        if len(messages) != 4:
-            raise ValueError(f"Expected exactly 4 messages, got {len(messages)}")
-        
+
+        # Check that we have exactly 6 messages
+        if len(messages) != 6:
+            raise ValueError(f"Expected exactly 6 messages, got {len(messages)}")
+
         # Verify each message
         verify_vector_fill(messages[0])
         verify_vector_fill_again(messages[1], messages[0])
-        verify_nested_inner(messages[2])
-        verify_nested_outer(messages[3], messages[2])
-        
+        verify_nested_empty_outer_inner(messages[2])
+        verify_nested_empty_outer(messages[3], messages[2])
+        verify_nested_outer_unique_ptr_inner(messages[4])
+        verify_nested_outer_unique_ptr(messages[5], messages[4])
+
         # All checks passed, exit silently with code 0
         sys.exit(0)
 

--- a/PerfTools/AllocMonitor/test/verifyIntrusiveAllocMonitor.py
+++ b/PerfTools/AllocMonitor/test/verifyIntrusiveAllocMonitor.py
@@ -3,215 +3,394 @@
 import sys
 import re
 
-def parse_message(line):
-    """Parse a IntrusiveAllocMonitor message line and extract field values."""
-    # Pattern: "Name: requested X added Y max alloc Z peak W nAlloc N nDealloc M"
+def parse_message(lines):
+    """Parse a IntrusiveAllocMonitor message block and extract field values."""
+    # First line: "measured: requested X added Y max alloc Z peak W nAlloc N nDealloc M"
     # Note: added can be negative
-    pattern = r'^(?P<name>.+):\s+requested\s+(?P<requested>\d+)\s+added\s+(?P<added>-?\d+)\s+max alloc\s+(?P<max_alloc>\d+)\s+peak\s+(?P<peak>\d+)\s+nAlloc\s+(?P<nAlloc>\d+)\s+nDealloc\s+(?P<nDealloc>\d+)$'
-    match = re.match(pattern, line.strip())
+    pattern = r'^measured:\s+requested\s+(?P<requested>\d+)\s+added\s+(?P<added>-?\d+)\s+max alloc\s+(?P<max_alloc>\d+)\s+peak\s+(?P<peak>\d+)\s+nAlloc\s+(?P<nAlloc>\d+)\s+nDealloc\s+(?P<nDealloc>\d+)$'
+    match = re.match(pattern, lines[0].strip())
     if not match:
-        raise ValueError(f"Malformed message line: {line}")
+        raise ValueError(f"Malformed message line: {lines[0]}")
 
     data = match.groupdict()
     # Convert numeric fields to integers
     for key in ['requested', 'added', 'max_alloc', 'peak', 'nAlloc', 'nDealloc']:
         data[key] = int(data[key])
+
+    # Parse nested labels from lines like "[0] inner unique_ptr"
+    data['labels'] = []
+    data['stringAdded'] = None
+    data['stringAlloc'] = None
+    for line in lines[1:]:
+        label_match = re.match(r'^\[(\d+)\]\s+(.+)$', line.strip())
+        if label_match:
+            data['labels'].append(label_match.group(2))
+        else:
+            # Parse optional line: "This includes at least X bytes in Y allocations from string names in nested measurements"
+            string_match = re.match(r'^This includes at least (\d+) bytes in (\d+) allocations? from string names in nested measurements$', line.strip())
+            if string_match:
+                data['stringAdded'] = int(string_match.group(1))
+                data['stringAlloc'] = int(string_match.group(2))
+
     return data
 
-def read_messages():
-    """Read stdin and extract IntrusiveAllocMonitor messages."""
-    messages = []
-    lines_iter = iter(sys.stdin)
+def read_test_cases():
+    """Read stdin and extract test cases with their IntrusiveAllocMonitor messages."""
+    test_cases = []
 
-    for line in lines_iter:
-        if line.strip() == '%MSG-s IntrusiveAllocMonitor:':
-            # Next line should be the message
-            try:
-                message_line = next(lines_iter)
-            except StopIteration:
-                raise ValueError("Unexpected end of input after %MSG-s line")
+    for line in sys.stdin:
+        line = line.strip()
 
-            # Next line should be %MSG
-            try:
-                end_marker = next(lines_iter)
-            except StopIteration:
-                raise ValueError("Unexpected end of input, expected %MSG")
+        # Look for test case start
+        if line.startswith('Test '):
+            test_name = line[5:]  # Remove "Test " prefix
+            messages = []
+            sum_value = None
 
-            if end_marker.strip() != '%MSG':
-                raise ValueError("Expected %MSG after message line")
+            # Read until we hit the separator
+            for line in sys.stdin:
+                line_stripped = line.strip()
+                if line_stripped.startswith('===='):
+                    break
 
-            msg = parse_message(message_line)
-            messages.append(msg)
+                if line_stripped == '%MSG-s IntrusiveAllocMonitor:':
+                    # Collect message lines
+                    msg_lines = []
+                    for line in sys.stdin:
+                        if line.strip() == '%MSG':
+                            break
+                        msg_lines.append(line)
 
-    return messages
+                    if msg_lines:
+                        msg = parse_message(msg_lines)
+                        messages.append(msg)
+                elif line_stripped.startswith('Sum '):
+                    sum_value = int(line_stripped[4:])
 
-def verify_vector_fill(msg):
-    """Verify conditions for 'Vector fill' message."""
-    name = msg['name']
-    if name != 'Vector fill':
-        raise ValueError(f"Expected 'Vector fill', got '{name}'")
+            test_cases.append({'name': test_name, 'messages': messages, 'sum': sum_value})
+
+    return test_cases
+
+def verify_vector_fill(test_case):
+    """Verify conditions for 'vector fill' test case."""
+    name = test_case['name']
+    if name != 'vector fill':
+        raise ValueError(f"Expected 'vector fill', got '{name}'")
+
+    messages = test_case['messages']
+    if len(messages) != 1:
+        raise ValueError(f"vector fill: expected 1 message, got {len(messages)}")
+
+    msg = messages[0]
+
+    # Check labels
+    expected_labels = ['Vector fill']
+    if msg['labels'] != expected_labels:
+        raise ValueError(f"vector fill: expected labels {expected_labels}, got {msg['labels']}")
 
     # All fields are larger than 0
     if not all(msg[field] > 0 for field in ['requested', 'added', 'max_alloc', 'peak', 'nAlloc', 'nDealloc']):
-        raise ValueError(f"Vector fill: all fields must be > 0, got {msg}")
+        raise ValueError(f"vector fill: all fields must be > 0, got {msg}")
 
     # added is larger than max alloc
     if msg['added'] <= msg['max_alloc']:
-        raise ValueError(f"Vector fill: added ({msg['added']}) must be > max alloc ({msg['max_alloc']})")
+        raise ValueError(f"vector fill: added ({msg['added']}) must be > max alloc ({msg['max_alloc']})")
 
     # nAlloc is exactly 1 larger than nDealloc
     if msg['nAlloc'] - msg['nDealloc'] != 1:
-        raise ValueError(f"Vector fill: nAlloc - nDealloc must be 1, got {msg['nAlloc']} - {msg['nDealloc']} = {msg['nAlloc'] - msg['nDealloc']}")
+        raise ValueError(f"vector fill: nAlloc - nDealloc must be 1, got {msg['nAlloc']} - {msg['nDealloc']} = {msg['nAlloc'] - msg['nDealloc']}")
 
-def verify_vector_fill_again(msg, vector_fill_msg):
-    """Verify conditions for 'Vector fill again' message."""
-    name = msg['name']
-    if name != 'Vector fill again':
-        raise ValueError(f"Expected 'Vector fill again', got '{name}'")
+    # Verify sum
+    if test_case['sum'] != 99980000:
+        raise ValueError(f"vector fill: expected sum 99980000, got {test_case['sum']}")
+
+def verify_vector_fill_again(test_case, vector_fill_test):
+    """Verify conditions for 'vector fill again' test case."""
+    name = test_case['name']
+    if name != 'vector fill again':
+        raise ValueError(f"Expected 'vector fill again', got '{name}'")
+
+    messages = test_case['messages']
+    if len(messages) != 1:
+        raise ValueError(f"vector fill again: expected 1 message, got {len(messages)}")
+
+    msg = messages[0]
+    vector_fill_msg = vector_fill_test['messages'][0]
+
+    # Check labels
+    expected_labels = ['Vector fill again']
+    if msg['labels'] != expected_labels:
+        raise ValueError(f"vector fill again: expected labels {expected_labels}, got {msg['labels']}")
 
     # All fields are larger than 0
     if not all(msg[field] > 0 for field in ['requested', 'added', 'max_alloc', 'peak', 'nAlloc', 'nDealloc']):
-        raise ValueError(f"Vector fill again: all fields must be > 0, got {msg}")
+        raise ValueError(f"vector fill again: all fields must be > 0, got {msg}")
 
-    # added plus the added from "Vector fill" is larger than max alloc of "Vector fill again"
+    # added plus the added from "vector fill" is larger than max alloc of "vector fill again"
     combined_added = msg['added'] + vector_fill_msg['added']
     if combined_added <= msg['max_alloc']:
-        raise ValueError(f"Vector fill again: combined added ({combined_added}) must be > max alloc ({msg['max_alloc']})")
+        raise ValueError(f"vector fill again: combined added ({combined_added}) must be > max alloc ({msg['max_alloc']})")
 
     # nAlloc and nDealloc are equal
     if msg['nAlloc'] != msg['nDealloc']:
-        raise ValueError(f"Vector fill again: nAlloc ({msg['nAlloc']}) must equal nDealloc ({msg['nDealloc']})")
+        raise ValueError(f"vector fill again: nAlloc ({msg['nAlloc']}) must equal nDealloc ({msg['nDealloc']})")
 
-def verify_nested_empty_outer_inner(msg):
-    """Verify conditions for 'Nested allocation empty outer;inner unique_ptr' message."""
-    name = msg['name']
-    if name != 'Nested allocation empty outer;inner unique_ptr':
-        raise ValueError(f"Expected 'Nested allocation empty outer;inner unique_ptr', got '{name}'")
+    # Verify sum
+    if test_case['sum'] != 199960000:
+        raise ValueError(f"vector fill again: expected sum 199960000, got {test_case['sum']}")
+
+def verify_nested_empty_outer(test_case):
+    """Verify conditions for 'nested allocation with empty outer' test case."""
+    name = test_case['name']
+    if name != 'nested allocation with empty outer':
+        raise ValueError(f"Expected 'nested allocation with empty outer', got '{name}'")
+
+    messages = test_case['messages']
+    if len(messages) != 2:
+        raise ValueError(f"nested allocation with empty outer: expected 2 messages, got {len(messages)}")
+
+    inner_msg = messages[0]
+    outer_msg = messages[1]
+
+    # Verify inner message
+    expected_inner_labels = ['inner unique_ptr', 'Nested allocation empty outer']
+    if inner_msg['labels'] != expected_inner_labels:
+        raise ValueError(f"nested allocation with empty outer (inner): expected labels {expected_inner_labels}, got {inner_msg['labels']}")
 
     # requested is 4
-    if msg['requested'] != 4:
-        raise ValueError(f"Nested allocation empty outer;inner unique_ptr: requested must be 4, got {msg['requested']}")
+    if inner_msg['requested'] != 4:
+        raise ValueError(f"nested allocation with empty outer (inner): requested must be 4, got {inner_msg['requested']}")
 
     # added and peak are equal
-    if msg['added'] != msg['peak']:
-        raise ValueError(f"Nested allocation empty outer;inner unique_ptr: added ({msg['added']}) must equal peak ({msg['peak']})")
+    if inner_msg['added'] != inner_msg['peak']:
+        raise ValueError(f"nested allocation with empty outer (inner): added ({inner_msg['added']}) must equal peak ({inner_msg['peak']})")
 
     # added is larger or equal to requested
-    if msg['added'] < msg['requested']:
-        raise ValueError(f"Nested allocation empty outer;inner unique_ptr: added ({msg['added']}) must be >= requested ({msg['requested']})")
+    if inner_msg['added'] < inner_msg['requested']:
+        raise ValueError(f"nested allocation with empty outer (inner): added ({inner_msg['added']}) must be >= requested ({inner_msg['requested']})")
 
     # nAlloc is 1 and nDealloc is 0
-    if msg['nAlloc'] != 1:
-        raise ValueError(f"Nested allocation empty outer;inner unique_ptr: nAlloc must be 1, got {msg['nAlloc']}")
-    if msg['nDealloc'] != 0:
-        raise ValueError(f"Nested allocation empty outer;inner unique_ptr: nDealloc must be 0, got {msg['nDealloc']}")
+    if inner_msg['nAlloc'] != 1:
+        raise ValueError(f"nested allocation with empty outer (inner): nAlloc must be 1, got {inner_msg['nAlloc']}")
+    if inner_msg['nDealloc'] != 0:
+        raise ValueError(f"nested allocation with empty outer (inner): nDealloc must be 0, got {inner_msg['nDealloc']}")
 
-def verify_nested_empty_outer(msg, inner_msg):
-    """Verify conditions for 'Nested allocation empty outer' message."""
-    name = msg['name']
-    if name != 'Nested allocation empty outer':
-        raise ValueError(f"Expected 'Nested allocation empty outer', got '{name}'")
+    # Verify outer message
+    expected_outer_labels = ['Nested allocation empty outer']
+    if outer_msg['labels'] != expected_outer_labels:
+        raise ValueError(f"nested allocation with empty outer (outer): expected labels {expected_outer_labels}, got {outer_msg['labels']}")
 
     # requested is 0
-    if msg['requested'] != 0:
-        raise ValueError(f"Nested allocation empty outer: requested must be 0, got {msg['requested']}")
+    if outer_msg['requested'] != 0:
+        raise ValueError(f"nested allocation with empty outer (outer): requested must be 0, got {outer_msg['requested']}")
 
     # added is negative of inner added
-    if msg['added'] != -inner_msg['added']:
-        raise ValueError(f"Nested allocation empty outer: added ({msg['added']}) must be -{inner_msg['added']}")
+    if outer_msg['added'] != -inner_msg['added']:
+        raise ValueError(f"nested allocation with empty outer (outer): added ({outer_msg['added']}) must be -{inner_msg['added']}")
 
     # max alloc is 0
-    if msg['max_alloc'] != 0:
-        raise ValueError(f"Nested allocation empty outer: max alloc must be 0, got {msg['max_alloc']}")
+    if outer_msg['max_alloc'] != 0:
+        raise ValueError(f"nested allocation with empty outer (outer): max alloc must be 0, got {outer_msg['max_alloc']}")
 
     # peak is 0
-    if msg['peak'] != 0:
-        raise ValueError(f"Nested allocation empty outer: peak must be 0, got {msg['peak']}")
+    if outer_msg['peak'] != 0:
+        raise ValueError(f"nested allocation with empty outer (outer): peak must be 0, got {outer_msg['peak']}")
 
     # nAlloc is 0
-    if msg['nAlloc'] != 0:
-        raise ValueError(f"Nested allocation empty outer: nAlloc must be 0, got {msg['nAlloc']}")
+    if outer_msg['nAlloc'] != 0:
+        raise ValueError(f"nested allocation with empty outer (outer): nAlloc must be 0, got {outer_msg['nAlloc']}")
 
     # nDealloc is 1
-    if msg['nDealloc'] != 1:
-        raise ValueError(f"Nested allocation empty outer: nDealloc must be 1, got {msg['nDealloc']}")
+    if outer_msg['nDealloc'] != 1:
+        raise ValueError(f"nested allocation with empty outer (outer): nDealloc must be 1, got {outer_msg['nDealloc']}")
 
-def verify_nested_outer_unique_ptr_inner(msg):
-    """Verify conditions for 'Nested allocation outer unique_ptr;inner unique_ptr' message."""
-    name = msg['name']
-    if name != 'Nested allocation outer unique_ptr;inner unique_ptr':
-        raise ValueError(f"Expected 'Nested allocation outer unique_ptr;inner unique_ptr', got '{name}'")
+    # Verify sum
+    if test_case['sum'] != 42:
+        raise ValueError(f"nested allocation with empty outer: expected sum 42, got {test_case['sum']}")
+
+def verify_nested_allocation(test_case):
+    """Verify conditions for 'nested allocation' test case."""
+    name = test_case['name']
+    if name != 'nested allocation':
+        raise ValueError(f"Expected 'nested allocation', got '{name}'")
+
+    messages = test_case['messages']
+    if len(messages) != 2:
+        raise ValueError(f"nested allocation: expected 2 messages, got {len(messages)}")
+
+    inner_msg = messages[0]
+    outer_msg = messages[1]
+
+    # Verify inner message
+    expected_inner_labels = ['inner unique_ptr', 'Nested allocation outer unique_ptr']
+    if inner_msg['labels'] != expected_inner_labels:
+        raise ValueError(f"nested allocation (inner): expected labels {expected_inner_labels}, got {inner_msg['labels']}")
 
     # requested is 4
-    if msg['requested'] != 4:
-        raise ValueError(f"Nested allocation outer unique_ptr;inner unique_ptr: requested must be 4, got {msg['requested']}")
+    if inner_msg['requested'] != 4:
+        raise ValueError(f"nested allocation (inner): requested must be 4, got {inner_msg['requested']}")
 
     # added and peak are equal
-    if msg['added'] != msg['peak']:
-        raise ValueError(f"Nested allocation outer unique_ptr;inner unique_ptr: added ({msg['added']}) must equal peak ({msg['peak']})")
+    if inner_msg['added'] != inner_msg['peak']:
+        raise ValueError(f"nested allocation (inner): added ({inner_msg['added']}) must equal peak ({inner_msg['peak']})")
 
     # added is larger or equal to requested
-    if msg['added'] < msg['requested']:
-        raise ValueError(f"Nested allocation outer unique_ptr;inner unique_ptr: added ({msg['added']}) must be >= requested ({msg['requested']})")
+    if inner_msg['added'] < inner_msg['requested']:
+        raise ValueError(f"nested allocation (inner): added ({inner_msg['added']}) must be >= requested ({inner_msg['requested']})")
 
     # nAlloc is 1 and nDealloc is 0
-    if msg['nAlloc'] != 1:
-        raise ValueError(f"Nested allocation outer unique_ptr;inner unique_ptr: nAlloc must be 1, got {msg['nAlloc']}")
-    if msg['nDealloc'] != 0:
-        raise ValueError(f"Nested allocation outer unique_ptr;inner unique_ptr: nDealloc must be 0, got {msg['nDealloc']}")
+    if inner_msg['nAlloc'] != 1:
+        raise ValueError(f"nested allocation (inner): nAlloc must be 1, got {inner_msg['nAlloc']}")
+    if inner_msg['nDealloc'] != 0:
+        raise ValueError(f"nested allocation (inner): nDealloc must be 0, got {inner_msg['nDealloc']}")
 
-def verify_nested_outer_unique_ptr(msg, inner_msg):
-    """Verify conditions for 'Nested allocation outer unique_ptr' message."""
-    name = msg['name']
-    if name != 'Nested allocation outer unique_ptr':
-        raise ValueError(f"Expected 'Nested allocation outer unique_ptr', got '{name}'")
+    # Verify outer message
+    expected_outer_labels = ['Nested allocation outer unique_ptr']
+    if outer_msg['labels'] != expected_outer_labels:
+        raise ValueError(f"nested allocation (outer): expected labels {expected_outer_labels}, got {outer_msg['labels']}")
 
     # requested, max alloc, and peak are larger than 0
-    if msg['requested'] <= 0:
-        raise ValueError(f"Nested allocation outer unique_ptr: requested must be > 0, got {msg['requested']}")
-    if msg['max_alloc'] <= 0:
-        raise ValueError(f"Nested allocation outer unique_ptr: max alloc must be > 0, got {msg['max_alloc']}")
-    if msg['peak'] <= 0:
-        raise ValueError(f"Nested allocation outer unique_ptr: peak must be > 0, got {msg['peak']}")
+    if outer_msg['requested'] <= 0:
+        raise ValueError(f"nested allocation (outer): requested must be > 0, got {outer_msg['requested']}")
+    if outer_msg['max_alloc'] <= 0:
+        raise ValueError(f"nested allocation (outer): max alloc must be > 0, got {outer_msg['max_alloc']}")
+    if outer_msg['peak'] <= 0:
+        raise ValueError(f"nested allocation (outer): peak must be > 0, got {outer_msg['peak']}")
 
     # added is negative of inner added
-    if msg['added'] != -inner_msg['added']:
-        raise ValueError(f"Nested allocation outer unique_ptr: added ({msg['added']}) must be -{inner_msg['added']}")
+    if outer_msg['added'] != -inner_msg['added']:
+        raise ValueError(f"nested allocation (outer): added ({outer_msg['added']}) must be -{inner_msg['added']}")
 
     # requested and max alloc equal to inner
-    if msg['requested'] != inner_msg['requested']:
-        raise ValueError(f"Nested allocation outer unique_ptr: requested ({msg['requested']}) must equal inner requested ({inner_msg['requested']})")
-    if msg['max_alloc'] != inner_msg['max_alloc']:
-        raise ValueError(f"Nested allocation outer unique_ptr: max alloc ({msg['max_alloc']}) must equal inner max alloc ({inner_msg['max_alloc']})")
+    if outer_msg['requested'] != inner_msg['requested']:
+        raise ValueError(f"nested allocation (outer): requested ({outer_msg['requested']}) must equal inner requested ({inner_msg['requested']})")
+    if outer_msg['max_alloc'] != inner_msg['max_alloc']:
+        raise ValueError(f"nested allocation (outer): max alloc ({outer_msg['max_alloc']}) must equal inner max alloc ({inner_msg['max_alloc']})")
 
     # peak equals inner peak
-    if msg['peak'] != inner_msg['peak']:
-        raise ValueError(f"Nested allocation outer unique_ptr: peak ({msg['peak']}) must equal inner peak ({inner_msg['peak']})")
+    if outer_msg['peak'] != inner_msg['peak']:
+        raise ValueError(f"nested allocation (outer): peak ({outer_msg['peak']}) must equal inner peak ({inner_msg['peak']})")
 
     # nAlloc is 1
-    if msg['nAlloc'] != 1:
-        raise ValueError(f"Nested allocation outer unique_ptr: nAlloc must be 1, got {msg['nAlloc']}")
+    if outer_msg['nAlloc'] != 1:
+        raise ValueError(f"nested allocation (outer): nAlloc must be 1, got {outer_msg['nAlloc']}")
 
     # nDealloc is 2
-    if msg['nDealloc'] != 2:
-        raise ValueError(f"Nested allocation outer unique_ptr: nDealloc must be 2, got {msg['nDealloc']}")
+    if outer_msg['nDealloc'] != 2:
+        raise ValueError(f"nested allocation (outer): nDealloc must be 2, got {outer_msg['nDealloc']}")
+
+    # Verify sum
+    if test_case['sum'] != 84:
+        raise ValueError(f"nested allocation: expected sum 84, got {test_case['sum']}")
+
+def verify_nested_with_string_messages(test_case):
+    """Verify conditions for 'nested with string messages' test case."""
+    def verify_inner_allocation(msg, expected_labels, msg_id):
+        """Verify conditions for an inner allocation message.
+        - requested is 4
+        - added is larger or equal than requested
+        - peak and added are equal
+        - 1 allocation, 0 deallocations
+        """
+        if msg['labels'] != expected_labels:
+            raise ValueError(f"nested with string messages (msg {msg_id}): expected labels {expected_labels}, got {msg['labels']}")
+
+        if msg['requested'] != 4:
+            raise ValueError(f"nested with string messages (msg {msg_id}): requested must be 4, got {msg['requested']}")
+
+        if msg['added'] < msg['requested']:
+            raise ValueError(f"nested with string messages (msg {msg_id}): added ({msg['added']}) must be >= requested ({msg['requested']})")
+
+        if msg['added'] != msg['peak']:
+            raise ValueError(f"nested with string messages (msg {msg_id}): added ({msg['added']}) must equal peak ({msg['peak']})")
+
+        if msg['nAlloc'] != 1:
+            raise ValueError(f"nested with string messages (msg {msg_id}): nAlloc must be 1, got {msg['nAlloc']}")
+        if msg['nDealloc'] != 0:
+            raise ValueError(f"nested with string messages (msg {msg_id}): nDealloc must be 0, got {msg['nDealloc']}")
+
+    name = test_case['name']
+    if name != 'nested with string messages':
+        raise ValueError(f"Expected 'nested with string messages', got '{name}'")
+
+    messages = test_case['messages']
+    if len(messages) != 5:
+        raise ValueError(f"nested with string messages: expected 5 messages, got {len(messages)}")
+
+    # Verify first inner message
+    verify_inner_allocation(
+        messages[0],
+        ['inner unique_ptr', 'Nested allocation with string messages outer unique_ptr'],
+        0
+    )
+
+    # Verify second inner message
+    verify_inner_allocation(
+        messages[1],
+        ['another inner unique_ptr', 'Nested allocation with string messages outer unique_ptr'],
+        1
+    )
+
+    # Verify third inner message
+    verify_inner_allocation(
+        messages[2],
+        ['inner unique_ptr', 'inner empty', 'Nested allocation with string messages outer unique_ptr'],
+        2
+    )
+
+    # Verify fourth message (inner empty)
+    msg3 = messages[3]
+    expected_labels_3 = ['inner empty', 'Nested allocation with string messages outer unique_ptr']
+    if msg3['labels'] != expected_labels_3:
+        raise ValueError(f"nested with string messages (msg 3): expected labels {expected_labels_3}, got {msg3['labels']}")
+
+    if msg3['added'] != 0:
+        raise ValueError(f"nested with string messages (msg 3): added must be 0, got {msg3['added']}")
+
+    if msg3['nAlloc'] != msg3['nDealloc']:
+        raise ValueError(f"nested with string messages (msg 3): nAlloc ({msg3['nAlloc']}) must equal nDealloc ({msg3['nDealloc']})")
+
+    if msg3['stringAlloc'] is not None:
+        if msg3['nAlloc'] < msg3['stringAlloc']:
+            raise ValueError(f"nested with string messages (msg 3): nAlloc ({msg3['nAlloc']}) must be >= stringAlloc ({msg3['stringAlloc']})")
+
+    if msg3['stringAdded'] is not None:
+        if msg3['requested'] < msg3['stringAdded']:
+            raise ValueError(f"nested with string messages (msg 3): requested ({msg3['requested']}) must be >= stringAdded ({msg3['stringAdded']})")
+
+
+    # Verify fifth message (outer)
+    msg4 = messages[4]
+    expected_labels_4 = ['Nested allocation with string messages outer unique_ptr']
+    if msg4['labels'] != expected_labels_4:
+        raise ValueError(f"nested with string messages (msg 4): expected labels {expected_labels_4}, got {msg4['labels']}")
+
+    if msg4['stringAlloc'] is not None:
+        if msg4['stringAlloc'] < 3:
+            raise ValueError(f"nested with string messages (msg 4): stringAlloc must be >= 3, got {msg4['stringAlloc']}")
+
+    if msg4['nDealloc'] - msg4['nAlloc'] != 3:
+        raise ValueError(f"nested with string messages (msg 4): nDealloc - nAlloc must be 3, got {msg4['nDealloc']} - {msg4['nAlloc']} = {msg4['nDealloc'] - msg4['nAlloc']}")
+
+    # Verify sum
+    if test_case['sum'] != 433:
+        raise ValueError(f"nested with string messages: expected sum 433, got {test_case['sum']}")
 
 def main():
     """Main function to parse and verify IntrusiveAllocMonitor output."""
     try:
-        messages = read_messages()
+        test_cases = read_test_cases()
 
-        # Check that we have exactly 6 messages
-        if len(messages) != 6:
-            raise ValueError(f"Expected exactly 6 messages, got {len(messages)}")
+        # Check that we have exactly 5 test cases
+        if len(test_cases) != 5:
+            raise ValueError(f"Expected exactly 5 test cases, got {len(test_cases)}")
 
-        # Verify each message
-        verify_vector_fill(messages[0])
-        verify_vector_fill_again(messages[1], messages[0])
-        verify_nested_empty_outer_inner(messages[2])
-        verify_nested_empty_outer(messages[3], messages[2])
-        verify_nested_outer_unique_ptr_inner(messages[4])
-        verify_nested_outer_unique_ptr(messages[5], messages[4])
+        # Verify each test case
+        verify_vector_fill(test_cases[0])
+        verify_vector_fill_again(test_cases[1], test_cases[0])
+        verify_nested_empty_outer(test_cases[2])
+        verify_nested_allocation(test_cases[3])
+        verify_nested_with_string_messages(test_cases[4])
 
         # All checks passed, exit silently with code 0
         sys.exit(0)

--- a/PerfTools/AllocMonitor/test/verifyIntrusiveAllocMonitor.py
+++ b/PerfTools/AllocMonitor/test/verifyIntrusiveAllocMonitor.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+
+import sys
+import re
+
+def parse_message(line):
+    """Parse a IntrusiveAllocMonitor message line and extract field values."""
+    # Pattern: "Name: requested X added Y max alloc Z peak W nAlloc N nDealloc M"
+    pattern = r'^(?P<name>.+):\s+requested\s+(?P<requested>\d+)\s+added\s+(?P<added>\d+)\s+max alloc\s+(?P<max_alloc>\d+)\s+peak\s+(?P<peak>\d+)\s+nAlloc\s+(?P<nAlloc>\d+)\s+nDealloc\s+(?P<nDealloc>\d+)$'
+    match = re.match(pattern, line.strip())
+    if not match:
+        raise ValueError(f"Malformed message line: {line}")
+
+    data = match.groupdict()
+    # Convert numeric fields to integers
+    for key in ['requested', 'added', 'max_alloc', 'peak', 'nAlloc', 'nDealloc']:
+        data[key] = int(data[key])
+    return data
+
+def read_messages():
+    """Read stdin and extract IntrusiveAllocMonitor messages."""
+    messages = []
+    lines_iter = iter(sys.stdin)
+
+    for line in lines_iter:
+        if line.strip() == '%MSG-s IntrusiveAllocMonitor:':
+            # Next line should be the message
+            try:
+                message_line = next(lines_iter)
+            except StopIteration:
+                raise ValueError("Unexpected end of input after %MSG-s line")
+
+            # Next line should be %MSG
+            try:
+                end_marker = next(lines_iter)
+            except StopIteration:
+                raise ValueError("Unexpected end of input, expected %MSG")
+
+            if end_marker.strip() != '%MSG':
+                raise ValueError("Expected %MSG after message line")
+
+            msg = parse_message(message_line)
+            messages.append(msg)
+
+    return messages
+
+def verify_vector_fill(msg):
+    """Verify conditions for 'Vector fill' message."""
+    name = msg['name']
+    if name != 'Vector fill':
+        raise ValueError(f"Expected 'Vector fill', got '{name}'")
+
+    # All fields are larger than 0
+    if not all(msg[field] > 0 for field in ['requested', 'added', 'max_alloc', 'peak', 'nAlloc', 'nDealloc']):
+        raise ValueError(f"Vector fill: all fields must be > 0, got {msg}")
+
+    # added is larger than max alloc
+    if msg['added'] <= msg['max_alloc']:
+        raise ValueError(f"Vector fill: added ({msg['added']}) must be > max alloc ({msg['max_alloc']})")
+
+    # nAlloc is exactly 1 larger than nDealloc
+    if msg['nAlloc'] - msg['nDealloc'] != 1:
+        raise ValueError(f"Vector fill: nAlloc - nDealloc must be 1, got {msg['nAlloc']} - {msg['nDealloc']} = {msg['nAlloc'] - msg['nDealloc']}")
+
+def verify_vector_fill_again(msg, vector_fill_msg):
+    """Verify conditions for 'Vector fill again' message."""
+    name = msg['name']
+    if name != 'Vector fill again':
+        raise ValueError(f"Expected 'Vector fill again', got '{name}'")
+
+    # All fields are larger than 0
+    if not all(msg[field] > 0 for field in ['requested', 'added', 'max_alloc', 'peak', 'nAlloc', 'nDealloc']):
+        raise ValueError(f"Vector fill again: all fields must be > 0, got {msg}")
+
+    # added plus the added from "Vector fill" is larger than max alloc of "Vector fill again"
+    combined_added = msg['added'] + vector_fill_msg['added']
+    if combined_added <= msg['max_alloc']:
+        raise ValueError(f"Vector fill again: combined added ({combined_added}) must be > max alloc ({msg['max_alloc']})")
+
+    # nAlloc and nDealloc are equal
+    if msg['nAlloc'] != msg['nDealloc']:
+        raise ValueError(f"Vector fill again: nAlloc ({msg['nAlloc']}) must equal nDealloc ({msg['nDealloc']})")
+
+def verify_nested_inner(msg):
+    """Verify conditions for 'Nested allocation inner' message."""
+    name = msg['name']
+    if name != 'Nested allocation inner':
+        raise ValueError(f"Expected 'Nested allocation inner', got '{name}'")
+    
+    # requested is 4
+    if msg['requested'] != 4:
+        raise ValueError(f"Nested allocation inner: requested must be 4, got {msg['requested']}")
+    
+    # added and peak are equal
+    if msg['added'] != msg['peak']:
+        raise ValueError(f"Nested allocation inner: added ({msg['added']}) must equal peak ({msg['peak']})")
+    
+    # added is larger or equal to requested
+    if msg['added'] < msg['requested']:
+        raise ValueError(f"Nested allocation inner: added ({msg['added']}) must be >= requested ({msg['requested']})")
+    
+    # nAlloc is 1 and nDealloc is 0
+    if msg['nAlloc'] != 1:
+        raise ValueError(f"Nested allocation inner: nAlloc must be 1, got {msg['nAlloc']}")
+    if msg['nDealloc'] != 0:
+        raise ValueError(f"Nested allocation inner: nDealloc must be 0, got {msg['nDealloc']}")
+
+def verify_nested_outer(msg, inner_msg):
+    """Verify conditions for 'Nested allocation outer vector fill' message."""
+    name = msg['name']
+    if name != 'Nested allocation outer vector fill':
+        raise ValueError(f"Expected 'Nested allocation outer vector fill', got '{name}'")
+    
+    # All fields are larger than 0
+    if not all(msg[field] > 0 for field in ['requested', 'added', 'max_alloc', 'peak', 'nAlloc', 'nDealloc']):
+        raise ValueError(f"Nested allocation outer vector fill: all fields must be > 0, got {msg}")
+    
+    # requested, added, and max alloc are strictly larger than in "Nested allocation inner"
+    if msg['requested'] <= inner_msg['requested']:
+        raise ValueError(f"Nested allocation outer vector fill: requested ({msg['requested']}) must be > inner requested ({inner_msg['requested']})")
+    if msg['added'] <= inner_msg['added']:
+        raise ValueError(f"Nested allocation outer vector fill: added ({msg['added']}) must be > inner added ({inner_msg['added']})")
+    if msg['max_alloc'] <= inner_msg['max_alloc']:
+        raise ValueError(f"Nested allocation outer vector fill: max alloc ({msg['max_alloc']}) must be > inner max alloc ({inner_msg['max_alloc']})")
+
+def main():
+    """Main function to parse and verify IntrusiveAllocMonitor output."""
+    try:
+        messages = read_messages()
+        
+        # Check that we have exactly 4 messages
+        if len(messages) != 4:
+            raise ValueError(f"Expected exactly 4 messages, got {len(messages)}")
+        
+        # Verify each message
+        verify_vector_fill(messages[0])
+        verify_vector_fill_again(messages[1], messages[0])
+        verify_nested_inner(messages[2])
+        verify_nested_outer(messages[3], messages[2])
+        
+        # All checks passed, exit silently with code 0
+        sys.exit(0)
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
#### PR description:

This PR makes the `IntrusiveAllocMonitor` re-entrant (within one thread). This change allows the `IntrusiveAllocMonitor` measurements to be done in nested scopes such that the counters do not interfere with each other. The counters from the outer measurement scope do not include the numbers from the inner measurement scope.

When the inner scope measurement starts, the state of the counters are stored in the guard object of that scope (as `std::any`), and restored via the guard's destructor. The allocations of the `std::any` and the MessageLogger message are excluded from the measurements (the unit test verifies this behavior now). The message of the inner scope measurement includes the descriptions of all the outer scopes as well, so the measurement stack is clearly visible in the output.

Resolves https://github.com/cms-sw/framework-team/issues/1851

#### PR validation:

Unit test succeeds. Private tests with an RNTuple copy job.