### PR TITLE
Minor update for 2026 PbPb UPC era

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectrons_cfi.py
@@ -72,8 +72,9 @@ _lowPtRegressionModifierUPC = regressionModifier103XLowPtPho.clone(
 )
 from Configuration.Eras.Modifier_run3_upc_2023_cff import run3_upc_2023
 from Configuration.Eras.Modifier_run3_upc_2025_cff import run3_upc_2025
+from Configuration.Eras.Modifier_run3_upc_2026_cff import run3_upc_2026
 from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
-(egamma_lowPt_exclusive & (run3_upc_2023 | run3_upc_2025)).toReplaceWith(lowPtRegressionModifier,_lowPtRegressionModifierUPC)
+(egamma_lowPt_exclusive & (run3_upc_2023 | run3_upc_2025 | run3_upc_2026)).toReplaceWith(lowPtRegressionModifier,_lowPtRegressionModifierUPC)
 
 from RecoEgamma.EgammaElectronProducers.lowPtGsfElectronFinalizer_cfi import lowPtGsfElectronFinalizer
 lowPtGsfElectrons = lowPtGsfElectronFinalizer.clone(

--- a/RecoTracker/DeDx/python/dedxEstimators_cff.py
+++ b/RecoTracker/DeDx/python/dedxEstimators_cff.py
@@ -94,6 +94,8 @@ run3_common.toModify(dedxHitInfo,
 dedxAllHitInfo = dedxHitInfo.clone(minTrackPt = 0)
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 run3_upc.toModify(dedxHitInfo, lowPtTracksPrescalePass = 50, lowPtTracksPrescaleFail = 50, minTrackPtPrescale = 0, usePixelForPrescales = True, storeMomentumAtHit = True)
+from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
+(run3_upc & ~run3_oxygen).toModify(dedxHitInfo, lowPtTracksPrescalePass = 4, lowPtTracksPrescaleFail = 4)
 
 from RecoTracker.DeDx.dedxHitCalibrator_cfi import dedxHitCalibrator as _dedxHitCalibrator
 from SimGeneral.MixingModule.SiStripSimParameters_cfi import SiStripSimBlock as _SiStripSimBlock


### PR DESCRIPTION
#### PR description:

This PR updates the UPC era for the 2026 PbPb data taking by changing to the run3 upc electron regression and decreasing the prescale used for dEdx hit information.

#### PR validation:

Tested with relvals 143.901,144.901,180.0.180.1,181.0,181.1,182.0,182.1,183.0,183.1

@mandrenguyen 