### PR TITLE
Implement heterogeneous Association Map based on SoA blocks

### DIFF
--- a/DataFormats/SoATemplate/README.md
+++ b/DataFormats/SoATemplate/README.md
@@ -88,6 +88,11 @@ buffers of different sizes. The alignment is ensured to be the same for every bl
 mirroring the structure of the underlying structs. The blocks are built via composition and access to individual layouts 
 and views is provided by name.
 
+`SoABlocks` also have the possibility of generating methods for the `View` and `ConstView` classes using the macros `SOA_VIEW_METHODS`
+and `SOA_CONST_VIEW_METHODS`. Like the macros for the element methods, this can also be called only once, and if more methods
+have to be generated, they must be listed inside the same macro call. Since these methods can be called from the device,
+they must be prefixed with the `SOA_HOST_DEVICE` macro and, when possible, with the `constexpr` keyword.
+
 TODOs:
 - Add introspection utilities to print the structure and layout of a `SoABlocks` instance.
 - Implement support for heterogeneous `deepCopy()` operations between different but compatible `SoABlocks` configurations.
@@ -203,6 +208,43 @@ GENERATE_SOA_LAYOUT(SoATemplate,
 using SoA = SoATemplate<>;
 using SoAView = SoA::View;
 using SoAConstView = SoA::ConstView;
+```
+
+as well as methods that operate on the View:
+
+```C++
+GENERATE_SOA_LAYOUT(PositionLayout,
+                    SOA_COLUMN(float, x),
+                    SOA_COLUMN(float, y),
+                    SOA_COLUMN(float, z))
+
+GENERATE_SOA_LAYOUT(VelocityLayout,
+                    SOA_COLUMN(float, vx),
+                    SOA_COLUMN(float, vy),
+                    SOA_COLUMN(float, vz))
+
+GENERATE_SOA_BLOCKS(PointsLayout,
+                    SOA_BLOCK(position, PositionLayout),
+                    SOA_BLOCK(velocity, VelocityLayout),
+                    SOA_VIEW_METHODS(
+                        SOA_HOST_DEVICE void update_position(uint32_t i, float time) {
+                            auto pos = this->position()[i];
+                            auto vel = this->velocity()[i];
+                            pos.x() += vel.vx() * time;
+                            pos.y() += vel.vy() * time;
+                            pos.z() += vel.vz() * time;
+                        }
+                    ),
+                    SOA_CONST_VIEW_METHODS(
+                        SOA_HOST_DEVICE auto distance2(uint32_t i, uint32_t j) const {
+                            auto pi = this->position()[i];
+                            auto pj = this->position()[j];
+                            return (pi.x() - pj.x()) * (pi.x() - pj.x()) + 
+                                   (pi.y() - pj.y()) * (pi.y() - pj.y()) + 
+                                   (pi.z() - pj.z()) * (pi.z() - pj.z());
+                        }
+                    )
+)
 ```
 
 The buffer of the proper size is allocated, and the layout is populated with:

--- a/DataFormats/SoATemplate/README.md
+++ b/DataFormats/SoATemplate/README.md
@@ -101,6 +101,11 @@ In addition to those fully parametrized templates, two further levels of paramet
 mirroring the structure of the underlying structs. The blocks are built via composition, 
 and access to individual layouts and views is provided by name.
 
+`SoABlocks` also have the possibility of generating methods for the `View` and `ConstView` classes using the macros `SOA_VIEW_METHODS`
+and `SOA_CONST_VIEW_METHODS`. Like the macros for the element methods, this can also be called only once, and if more methods
+have to be generated, they must be listed inside the same macro call. Since these methods can be called from the device,
+they must be prefixed with the `SOA_HOST_DEVICE` macro and, when possible, with the `constexpr` keyword.
+
 TODOs:
 - Add introspection utilities to print the structure and layout of a `SoABlocks` instance.
 
@@ -232,6 +237,43 @@ GENERATE_SOA_LAYOUT(SoATemplate,
 using SoA = SoATemplate<>;
 using SoAView = SoA::View;
 using SoAConstView = SoA::ConstView;
+```
+
+as well as methods that operate on the View:
+
+```C++
+GENERATE_SOA_LAYOUT(PositionLayout,
+                    SOA_COLUMN(float, x),
+                    SOA_COLUMN(float, y),
+                    SOA_COLUMN(float, z))
+
+GENERATE_SOA_LAYOUT(VelocityLayout,
+                    SOA_COLUMN(float, vx),
+                    SOA_COLUMN(float, vy),
+                    SOA_COLUMN(float, vz))
+
+GENERATE_SOA_BLOCKS(PointsLayout,
+                    SOA_BLOCK(position, PositionLayout),
+                    SOA_BLOCK(velocity, VelocityLayout),
+                    SOA_VIEW_METHODS(
+                        SOA_HOST_DEVICE void update_position(uint32_t i, float time) {
+                            auto pos = this->position()[i];
+                            auto vel = this->velocity()[i];
+                            pos.x() += vel.vx() * time;
+                            pos.y() += vel.vy() * time;
+                            pos.z() += vel.vz() * time;
+                        }
+                    ),
+                    SOA_CONST_VIEW_METHODS(
+                        SOA_HOST_DEVICE auto distance2(uint32_t i, uint32_t j) const {
+                            auto pi = this->position()[i];
+                            auto pj = this->position()[j];
+                            return (pi.x() - pj.x()) * (pi.x() - pj.x()) + 
+                                   (pi.y() - pj.y()) * (pi.y() - pj.y()) + 
+                                   (pi.z() - pj.z()) * (pi.z() - pj.z());
+                        }
+                    )
+)
 ```
 
 The buffer of the proper size is allocated, and the layout is populated with:

--- a/DataFormats/SoATemplate/interface/SoABlocks.h
+++ b/DataFormats/SoATemplate/interface/SoABlocks.h
@@ -399,6 +399,7 @@
                                                                                                                        \
       /* Accessors for the const views for each block */                                                               \
       _ITERATE_ON_ALL(_DECLARE_ACCESSORS_CONST_VIEW_BLOCKS, ~, __VA_ARGS__)                                            \
+      ENUM_IF_VALID(_ITERATE_ON_ALL(GENERATE_CONST_VIEW_METHODS, ~, __VA_ARGS__))                                      \
                                                                                                                        \
       private:                                                                                                         \
         _ITERATE_ON_ALL(_DECLARE_MEMBERS_CONST_VIEW_BLOCKS, ~, __VA_ARGS__)                                            \
@@ -481,6 +482,8 @@
                                                                                                                        \
       /* Accessors for the views for each block */                                                                     \
       _ITERATE_ON_ALL(_DECLARE_ACCESSORS_VIEW_BLOCKS, ~, __VA_ARGS__)                                                  \
+      /*ENUM_IF_VALID(_ITERATE_ON_ALL(GENERATE_CONST_VIEW_METHODS, ~, __VA_ARGS__))*/                                  \
+      ENUM_IF_VALID(_ITERATE_ON_ALL(GENERATE_VIEW_METHODS, ~, __VA_ARGS__))                                            \
                                                                                                                        \
        /* Data members inherited from the ConstView */                                                                 \
     };                                                                                                                 \

--- a/DataFormats/SoATemplate/interface/SoABlocks.h
+++ b/DataFormats/SoATemplate/interface/SoABlocks.h
@@ -482,7 +482,6 @@
                                                                                                                        \
       /* Accessors for the views for each block */                                                                     \
       _ITERATE_ON_ALL(_DECLARE_ACCESSORS_VIEW_BLOCKS, ~, __VA_ARGS__)                                                  \
-      /*ENUM_IF_VALID(_ITERATE_ON_ALL(GENERATE_CONST_VIEW_METHODS, ~, __VA_ARGS__))*/                                  \
       ENUM_IF_VALID(_ITERATE_ON_ALL(GENERATE_VIEW_METHODS, ~, __VA_ARGS__))                                            \
                                                                                                                        \
        /* Data members inherited from the ConstView */                                                                 \

--- a/DataFormats/SoATemplate/interface/SoABlocks.h
+++ b/DataFormats/SoATemplate/interface/SoABlocks.h
@@ -466,6 +466,7 @@
                                                                                                                        \
       /* Accessors for the const views for each block */                                                               \
       _ITERATE_ON_ALL(_DECLARE_ACCESSORS_CONST_VIEW_BLOCKS, ~, __VA_ARGS__)                                            \
+      ENUM_IF_VALID(_ITERATE_ON_ALL(GENERATE_CONST_VIEW_METHODS, ~, __VA_ARGS__))                                      \
                                                                                                                        \
       private:                                                                                                         \
         _ITERATE_ON_ALL(_DECLARE_MEMBERS_CONST_VIEW_BLOCKS, ~, __VA_ARGS__)                                            \
@@ -548,6 +549,8 @@
                                                                                                                        \
       /* Accessors for the views for each block */                                                                     \
       _ITERATE_ON_ALL(_DECLARE_ACCESSORS_VIEW_BLOCKS, ~, __VA_ARGS__)                                                  \
+      /*ENUM_IF_VALID(_ITERATE_ON_ALL(GENERATE_CONST_VIEW_METHODS, ~, __VA_ARGS__))*/                                  \
+      ENUM_IF_VALID(_ITERATE_ON_ALL(GENERATE_VIEW_METHODS, ~, __VA_ARGS__))                                            \
                                                                                                                        \
        /* Data members inherited from the ConstView */                                                                 \
     };                                                                                                                 \

--- a/DataFormats/SoATemplate/interface/SoABlocks.h
+++ b/DataFormats/SoATemplate/interface/SoABlocks.h
@@ -549,7 +549,6 @@
                                                                                                                        \
       /* Accessors for the views for each block */                                                                     \
       _ITERATE_ON_ALL(_DECLARE_ACCESSORS_VIEW_BLOCKS, ~, __VA_ARGS__)                                                  \
-      /*ENUM_IF_VALID(_ITERATE_ON_ALL(GENERATE_CONST_VIEW_METHODS, ~, __VA_ARGS__))*/                                  \
       ENUM_IF_VALID(_ITERATE_ON_ALL(GENERATE_VIEW_METHODS, ~, __VA_ARGS__))                                            \
                                                                                                                        \
        /* Data members inherited from the ConstView */                                                                 \

--- a/DataFormats/SoATemplate/test/SoACustomizedMethods_t.cc
+++ b/DataFormats/SoATemplate/test/SoACustomizedMethods_t.cc
@@ -30,7 +30,7 @@ TEST_CASE("SoACustomizedMethods") {
   }
   view.detectorType() = 42;
 
-  SECTION("ConstView methods") {
+  SECTION("ConstElement methods") {
     // arrays of norms
     std::array<float, elems> position_norms;
     std::array<double, elems> velocity_norms;
@@ -46,7 +46,7 @@ TEST_CASE("SoACustomizedMethods") {
     }
   }
 
-  SECTION("View methods") {
+  SECTION("Element methods") {
     // array of times
     std::array<double, elems> times;
 
@@ -70,5 +70,34 @@ TEST_CASE("SoACustomizedMethods") {
       REQUIRE_THAT(view[i].square_norm_position(), Catch::Matchers::WithinAbs(1.f, 1.e-6));
       REQUIRE_THAT(view[i].square_norm_velocity(), Catch::Matchers::WithinAbs(1., 1.e-9));
     }
+  }
+
+  const auto points_sizes = std::array<cms::soa::size_type, 2>{{2, 2}};
+  const std::size_t blocksBufferSize = Points::computeDataSize(points_sizes);
+
+  std::unique_ptr<std::byte, decltype(std::free) *> points_buffer{
+      reinterpret_cast<std::byte *>(aligned_alloc(Points::alignment, blocksBufferSize)), std::free};
+
+  Points points(points_buffer.get(), points_sizes);
+  PointsView points_view{points};
+  PointsConstView points_const_view{points};
+  points_view.position()[0].x() = 2.f;
+  points_view.position()[0].y() = 4.f;
+  points_view.position()[0].z() = 3.f;
+  points_view.position()[1].x() = 1.f;
+  points_view.position()[1].y() = 1.f;
+  points_view.position()[1].z() = 1.f;
+
+  SECTION("View methods") { REQUIRE(points_const_view.distance2(0, 1) == 14.f); }
+
+  SECTION("ConstView methods") {
+    points_view.velocity()[0].vx() = 1.f;
+    points_view.velocity()[0].vy() = 3.f;
+    points_view.velocity()[0].vz() = 5.f;
+    const auto time = .5f;
+    points_view.update_position(0, time);
+    REQUIRE(points_view.position()[0].x() == 2.5f);
+    REQUIRE(points_view.position()[0].y() == 5.5f);
+    REQUIRE(points_view.position()[0].z() == 5.5f);
   }
 }

--- a/DataFormats/SoATemplate/test/SoACustomizedMethods_t.cu
+++ b/DataFormats/SoATemplate/test/SoACustomizedMethods_t.cu
@@ -24,6 +24,15 @@ __global__ void checkNormalise(SoAView soaView, double* checkTimesFunction) {
   soaView[i].normalise();
 }
 
+__global__ void checkPointsDistance(PointsConstView view, bool* result) { *result &= (view.distance2(0, 1) == 14.f); }
+
+__global__ void checkPointsPositionUpdate(PointsView view, float time, bool* result) {
+  view.update_position(0, time);
+  *result &= (view.position()[0].x() == 2.5f);
+  *result &= (view.position()[0].y() == 5.5f);
+  *result &= (view.position()[0].z() == 5.5f);
+}
+
 TEST_CASE("SoACustomizedMethods CUDA", "[SoACustomizedMethods][cuda]") {
   // common number of elements for the SoAs
   const std::size_t elems = 10;
@@ -69,7 +78,7 @@ TEST_CASE("SoACustomizedMethods CUDA", "[SoACustomizedMethods][cuda]") {
   // Host → Device copy
   CUDA_CHECK(cudaMemcpy(d_buf, h_buf, bufferSize, cudaMemcpyHostToDevice));
 
-  SECTION("ConstView methods CUDA") {
+  SECTION("ConstElement methods CUDA") {
     calculateNorm<<<(elems + 255) / 256, 256>>>(d_Constview, d_position_norms, d_velocity_norms);
 
     CUDA_CHECK(cudaMemcpy(h_position_norms.data(), d_position_norms, elems * sizeof(float), cudaMemcpyDeviceToHost));
@@ -88,7 +97,7 @@ TEST_CASE("SoACustomizedMethods CUDA", "[SoACustomizedMethods][cuda]") {
     }
   }
 
-  SECTION("View methods CUDA") {
+  SECTION("Element methods CUDA") {
     std::array<double, elems> times;
 
     // Check for the correctness of the time() function
@@ -116,10 +125,55 @@ TEST_CASE("SoACustomizedMethods CUDA", "[SoACustomizedMethods][cuda]") {
     }
   }
 
+  const auto points_sizes = std::array<cms::soa::size_type, 2>{{2, 2}};
+  const std::size_t blocksBufferSize = Points::computeDataSize(points_sizes);
+
+  std::byte* points_buffer_host = nullptr;
+  CUDA_CHECK(cudaMallocHost(&points_buffer_host, blocksBufferSize));
+
+  Points h_points(points_buffer_host, points_sizes);
+  PointsView h_points_view{h_points};
+  h_points_view.position()[0].x() = 2.f;
+  h_points_view.position()[0].y() = 4.f;
+  h_points_view.position()[0].z() = 3.f;
+  h_points_view.position()[1].x() = 1.f;
+  h_points_view.position()[1].y() = 1.f;
+  h_points_view.position()[1].z() = 1.f;
+  h_points_view.velocity()[0].vx() = 1.f;
+  h_points_view.velocity()[0].vy() = 3.f;
+  h_points_view.velocity()[0].vz() = 5.f;
+
+  std::byte* points_buffer_device = nullptr;
+  CUDA_CHECK(cudaMalloc(&points_buffer_device, blocksBufferSize));
+
+  Points d_points(points_buffer_device, points_sizes);
+  PointsView d_points_view{d_points};
+  PointsConstView d_points_const_view{d_points};
+
+  CUDA_CHECK(cudaMemcpy(points_buffer_device, points_buffer_host, blocksBufferSize, cudaMemcpyHostToDevice));
+
+  bool* d_result = nullptr;
+  CUDA_CHECK(cudaMalloc(&d_result, sizeof(bool)));
+  CUDA_CHECK(cudaMemset(d_result, 1, sizeof(bool)));
+
+  SECTION("View methods") { checkPointsDistance<<<1, 1>>>(d_points_const_view, d_result); }
+
+  SECTION("ConstView methods") {
+    const auto time = .5f;
+    checkPointsPositionUpdate<<<1, 1>>>(d_points_view, time, d_result);
+  }
+
+  bool h_result;
+  CUDA_CHECK(cudaMemcpy(&h_result, d_result, sizeof(bool), cudaMemcpyDeviceToHost));
+  REQUIRE(h_result);
+
   // ===== cleanup =====
   CUDA_CHECK(cudaFree(d_position_norms));
   CUDA_CHECK(cudaFree(d_velocity_norms));
   CUDA_CHECK(cudaFree(d_times));
   CUDA_CHECK(cudaFree(d_buf));
+  CUDA_CHECK(cudaFree(points_buffer_device));
+  CUDA_CHECK(cudaFree(d_result));
   CUDA_CHECK(cudaFreeHost(h_buf));
+  CUDA_CHECK(cudaFreeHost(points_buffer_host));
 }

--- a/DataFormats/SoATemplate/test/SoACustomizedMethods_t.hip.cc
+++ b/DataFormats/SoATemplate/test/SoACustomizedMethods_t.hip.cc
@@ -26,6 +26,15 @@ __global__ void checkNormalise(SoAView soaView, double* checkTimesFunction) {
   soaView[i].normalise();
 }
 
+__global__ void checkPointsDistance(PointsConstView view, bool* result) { *result &= (view.distance2(0, 1) == 14.f); }
+
+__global__ void checkPointsPositionUpdate(PointsView view, float time, bool* result) {
+  view.update_position(0, time);
+  *result &= (view.position()[0].x() == 2.5f);
+  *result &= (view.position()[0].y() == 5.5f);
+  *result &= (view.position()[0].z() == 5.5f);
+}
+
 TEST_CASE("SoACustomizedMethods hip", "[SoACustomizedMethods][hip]") {
   // common number of elements for the SoAs
   const std::size_t elems = 10;
@@ -71,7 +80,7 @@ TEST_CASE("SoACustomizedMethods hip", "[SoACustomizedMethods][hip]") {
   // Host → Device copy
   HIP_CHECK(hipMemcpy(d_buf, h_buf, bufferSize, hipMemcpyHostToDevice));
 
-  SECTION("ConstView methods HIP") {
+  SECTION("ConstElement methods HIP") {
     calculateNorm<<<(elems + 255) / 256, 256>>>(d_Constview, d_position_norms, d_velocity_norms);
 
     HIP_CHECK(hipMemcpy(h_position_norms.data(), d_position_norms, elems * sizeof(float), hipMemcpyDeviceToHost));
@@ -90,7 +99,7 @@ TEST_CASE("SoACustomizedMethods hip", "[SoACustomizedMethods][hip]") {
     }
   }
 
-  SECTION("View methods HIP") {
+  SECTION("Element methods HIP") {
     std::array<double, elems> times;
 
     // Check for the correctness of the time() function
@@ -118,10 +127,55 @@ TEST_CASE("SoACustomizedMethods hip", "[SoACustomizedMethods][hip]") {
     }
   }
 
+  const auto points_sizes = std::array<cms::soa::size_type, 2>{{2, 2}};
+  const std::size_t blocksBufferSize = Points::computeDataSize(points_sizes);
+
+  std::byte* points_buffer_host = nullptr;
+  HIP_CHECK(hipHostMalloc(&points_buffer_host, blocksBufferSize));
+
+  Points h_points(points_buffer_host, points_sizes);
+  PointsView h_points_view{h_points};
+  h_points_view.position()[0].x() = 2.f;
+  h_points_view.position()[0].y() = 4.f;
+  h_points_view.position()[0].z() = 3.f;
+  h_points_view.position()[1].x() = 1.f;
+  h_points_view.position()[1].y() = 1.f;
+  h_points_view.position()[1].z() = 1.f;
+  h_points_view.velocity()[0].vx() = 1.f;
+  h_points_view.velocity()[0].vy() = 3.f;
+  h_points_view.velocity()[0].vz() = 5.f;
+
+  std::byte* points_buffer_device = nullptr;
+  HIP_CHECK(hipMalloc(&points_buffer_device, blocksBufferSize));
+
+  Points d_points(points_buffer_device, points_sizes);
+  PointsView d_points_view{d_points};
+  PointsConstView d_points_const_view{d_points};
+
+  HIP_CHECK(hipMemcpy(points_buffer_device, points_buffer_host, blocksBufferSize, hipMemcpyHostToDevice));
+
+  bool* d_result = nullptr;
+  HIP_CHECK(hipMalloc(&d_result, sizeof(bool)));
+  HIP_CHECK(hipMemset(d_result, 1, sizeof(bool)));
+
+  SECTION("View methods") { checkPointsDistance<<<1, 1>>>(d_points_const_view, d_result); }
+
+  SECTION("ConstView methods") {
+    const auto time = .5f;
+    checkPointsPositionUpdate<<<1, 1>>>(d_points_view, time, d_result);
+  }
+
+  bool h_result;
+  HIP_CHECK(hipMemcpy(&h_result, d_result, sizeof(bool), hipMemcpyDeviceToHost));
+  REQUIRE(h_result);
+
   // ===== cleanup =====
   HIP_CHECK(hipFree(d_position_norms));
   HIP_CHECK(hipFree(d_velocity_norms));
   HIP_CHECK(hipFree(d_times));
   HIP_CHECK(hipFree(d_buf));
+  HIP_CHECK(hipFree(points_buffer_device));
+  HIP_CHECK(hipFree(d_result));
   HIP_CHECK(hipFreeHost(h_buf));
+  HIP_CHECK(hipFreeHost(points_buffer_host));
 }

--- a/DataFormats/SoATemplate/test/SoADefinition_CustomizedMethods.h
+++ b/DataFormats/SoATemplate/test/SoADefinition_CustomizedMethods.h
@@ -1,6 +1,7 @@
 #include <cmath>
 
 #include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "DataFormats/SoATemplate/interface/SoABlocks.h"
 
 GENERATE_SOA_LAYOUT(SoATemplate,
                     SOA_COLUMN(float, x),
@@ -18,21 +19,21 @@ GENERATE_SOA_LAYOUT(SoATemplate,
                             x() /= norm_position;
                             y() /= norm_position;
                             z() /= norm_position;
-                          };
+                          }
                           double norm_velocity = square_norm_velocity();
                           if (norm_velocity > 0.0f) {
                             v_x() /= norm_velocity;
                             v_y() /= norm_velocity;
                             v_z() /= norm_velocity;
-                          };
+                          }
                         }),
 
                     SOA_CONST_ELEMENT_METHODS(
                         SOA_HOST_DEVICE float square_norm_position()
-                            const { return sqrt(x() * x() + y() * y() + z() * z()); };
+                            const { return sqrt(x() * x() + y() * y() + z() * z()); }
 
                         SOA_HOST_DEVICE double square_norm_velocity()
-                            const { return sqrt(v_x() * v_x() + v_y() * v_y() + v_z() * v_z()); };
+                            const { return sqrt(v_x() * v_x() + v_y() * v_y() + v_z() * v_z()); }
 
                         template <typename T1, typename T2>
                         SOA_HOST_DEVICE static auto time(T1 pos, T2 vel) {
@@ -46,3 +47,42 @@ GENERATE_SOA_LAYOUT(SoATemplate,
 using SoA = SoATemplate<>;
 using SoAView = SoA::View;
 using SoAConstView = SoA::ConstView;
+
+// clang-format off
+GENERATE_SOA_LAYOUT(PositionLayout,
+                    SOA_COLUMN(float, x),
+                    SOA_COLUMN(float, y),
+                    SOA_COLUMN(float, z))
+
+GENERATE_SOA_LAYOUT(VelocityLayout,
+                    SOA_COLUMN(float, vx),
+                    SOA_COLUMN(float, vy),
+                    SOA_COLUMN(float, vz))
+
+GENERATE_SOA_BLOCKS(PointsLayout,
+                    SOA_BLOCK(position, PositionLayout),
+                    SOA_BLOCK(velocity, VelocityLayout),
+                    SOA_VIEW_METHODS(
+                        SOA_HOST_DEVICE void update_position(uint32_t i, float time) {
+                            auto pos = this->position()[i];
+                            auto vel = this->velocity()[i];
+                            pos.x() += vel.vx() * time;
+                            pos.y() += vel.vy() * time;
+                            pos.z() += vel.vz() * time;
+                        }
+                    ),
+                    SOA_CONST_VIEW_METHODS(
+                        SOA_HOST_DEVICE auto distance2(uint32_t i, uint32_t j) const {
+                            auto pi = this->position()[i];
+                            auto pj = this->position()[j];
+                            return (pi.x() - pj.x()) * (pi.x() - pj.x()) + 
+                                   (pi.y() - pj.y()) * (pi.y() - pj.y()) + 
+                                   (pi.z() - pj.z()) * (pi.z() - pj.z());
+                        }
+                    )
+)
+// clang-format on
+
+using Points = PointsLayout<>;
+using PointsView = Points::View;
+using PointsConstView = Points::ConstView;

--- a/DataFormats/TICL/BuildFile.xml
+++ b/DataFormats/TICL/BuildFile.xml
@@ -1,0 +1,3 @@
+<use name="alpaka"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<use name="DataFormats/SoATemplate"/>

--- a/DataFormats/TICL/README.md
+++ b/DataFormats/TICL/README.md
@@ -1,0 +1,93 @@
+# `ticl::AssociationMap`
+
+`ticl::AssociationMap` is an heterogeneous GPU-friendly associator that maps integral `keys` to values, which mush be `trivially copyable`.
+The map is designed using `SoABlocks` so it can be stored in a `PortableCollection` and allocated like a normal SoA.
+
+Internally it uses a CSR-like (compressed sparse row) layout:
+
+- an **offsets** block holding `nkeys + 1` prefix-sum offsets (`keys_offsets`)
+- a **content** block holding the `nvalues` values themselves (`values`)
+
+Defined in `interface/AssociationMap.h`.
+
+## Template parameters
+
+```cpp
+template <std::integral TKey = uint32_t, ticl::concepts::trivially_copyable TMapped = uint32_t>
+```
+
+- `TKey`: an integral type used as the key (must be usable as an index, i.e. `0 <= key < nkeys`).
+- `TMapped`: any trivially-copyable type stored as the associated value.
+
+Both `TKey` and `TMapped` default to `uint32_t`.
+
+## Construction
+
+```cpp
+#include "DataFormats/Portable/interface/PortableCollection.h"
+#include "DataFormats/TICL/interface/AssociationMap.h"
+
+const uint32_t nkeys = 2;
+const uint32_t nvalues = 100;
+PortableCollection<Device, ticl::AssociationMap<>> map(queue, nkeys, nvalues);
+```
+
+## Filling the map
+
+Filling is done with `ticl::associator::fill`, declared in `interface/FillAssociator.h`.
+The fill happens all in one go, so all the data to save inside the map should be available
+when calling `fill`.
+
+```cpp
+#include "DataFormats/TICL/interface/FillAssociator.h"
+
+// keys[i] and values[i] are the key/value of the i-th (key, value) pair to insert
+ticl::associator::fill<Acc1D>(queue, map.view(), keys_span, values_span);
+```
+
+- `keys` and `values` are `std::span<const TKey>` / `std::span<const TMapped>` and must have the same size.
+- Every entry in `keys` must satisfy `0 <= key < map.keys()`.
+- `keys.size() == values.size()` must be `<= nvalues` (the capacity passed at construction).
+- `fill` computes, per key, how many values map to it, turns those counts into prefix-sum
+  offsets (via a multi-block prefix scan), stores them in the `offsets` block, and scatters each value into its key's slice of the `content` block.
+- The relative order of values within a single key's bucket is **not guaranteed** to match the input order, since the scatter happens in parallel across threads.
+- `fill` can be called with a shorter span than the map's capacity (a "partial fill"); any keys/values beyond `keys.size()`/`values.size()` are simply not part of the fill.
+
+## Reading the map (host and device)
+
+The accessors are methods of the View/ConstView and are marked `SOA_HOST_DEVICE`, so they can be called both from the host and the device:
+
+```cpp
+auto view = map.view();        // or map.const_view() for read-only access
+
+view.keys();                   // number of keys (nkeys)
+view.size();                   // total capacity / number of stored values (nvalues)
+view.count(key);               // number of values associated to `key`
+view.contains(key);            // true if count(key) > 0
+view[key];                     // std::span<TMapped> (or std::span<const TMapped> on a
+                               // ConstView) with the values associated to `key`
+```
+
+Example, inside an alpaka kernel:
+
+```cpp
+ALPAKA_FN_ACC void operator()(const Acc1D& acc, ticl::AssociationMapView<> map, ...) const {
+  for (auto key : alpaka::uniformElements(acc, map.keys())) {
+    if (!map.contains(key))
+      continue;
+    for (auto value : map[key]) {
+      // ...
+    }
+  }
+}
+```
+
+### Note
+For querying the size of the map prefer the `keys` and `size` view methods rather than the native SoA's `metadata().size()`.
+
+## Relevant files
+
+- `interface/AssociationMap.h` — the SoA layout and the `View`/`ConstView` accessors (`operator[]`, `count`, `contains`, `keys`, `size`).
+- `interface/FillAssociator.h` — public entry point `ticl::associator::fill`.
+- `interface/detail/FillAssociator.h` — the kernels used to fill the map (counting, prefix-sum, scatter).
+- `test/alpaka/TestAssociationMap.dev.cc` — usage examples covering construction, filling (full and partial), deep copy, and access from both host and device code.

--- a/DataFormats/TICL/interface/AssociationMap.h
+++ b/DataFormats/TICL/interface/AssociationMap.h
@@ -1,0 +1,82 @@
+
+#ifndef DataFormats_TICL_interface_AssociationMap_h
+#define DataFormats_TICL_interface_AssociationMap_h
+
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "DataFormats/SoATemplate/interface/SoABlocks.h"
+#include <concepts>
+#include <cstdint>
+#include <type_traits>
+
+namespace ticl {
+
+  namespace concepts {
+
+    template <typename T>
+    concept trivially_copyable = std::is_trivially_copyable_v<T>;
+
+  }
+
+  // clang-format off
+  template <std::integral TKey, concepts::trivially_copyable TMapped>
+  struct AssociationMapLayout {
+    GENERATE_SOA_LAYOUT(ContentBuffersLayout, SOA_COLUMN(TMapped, values))
+    GENERATE_SOA_LAYOUT(OffsetBufferLayout, SOA_COLUMN(TKey, keys_offsets))
+    
+    template <CMS_SOA_BYTE_SIZE_TYPE ALIGNMENT = cms::soa::CacheLineSize::defaultSize,
+              bool ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::relaxed>
+    class OffsetsLayout final : public OffsetBufferLayout<ALIGNMENT, ALIGNMENT_ENFORCEMENT> {
+      using Parent = OffsetBufferLayout<ALIGNMENT, ALIGNMENT_ENFORCEMENT>;
+
+    public:
+      OffsetsLayout() : Parent() {}
+      OffsetsLayout(std::byte* mem, cms::soa::size_type elements) : Parent(mem, elements + 1) {}
+
+      static constexpr auto computeDataSize(std::size_t size) {
+        return Parent::computeDataSize(size + 1);
+      }
+    };
+
+    GENERATE_SOA_BLOCKS(Layout,
+                        SOA_BLOCK(content, ContentBuffersLayout),
+                        SOA_BLOCK(offsets, OffsetsLayout),
+                        SOA_VIEW_METHODS(
+							constexpr SOA_HOST_DEVICE auto operator[](TKey key) {
+							  const auto offset = this->offsets()[key].keys_offsets();
+							  const auto size = this->count(key);
+							  return std::span<TMapped>{this->content().values().data() + offset, static_cast<std::size_t>(size)};
+							}
+						),
+                        SOA_CONST_VIEW_METHODS(
+							constexpr SOA_HOST_DEVICE auto operator[](TKey key) const {
+                const auto offset = this->offsets()[key].keys_offsets();
+							  const auto size = this->count(key);
+							  return std::span<const TMapped>{this->content().values().data() + offset, static_cast<std::size_t>(size)};
+							}
+							constexpr SOA_HOST_DEVICE auto contains(TKey key) const {
+                return this->count(key) > 0;
+							}
+							constexpr SOA_HOST_DEVICE auto count(TKey key) const {
+                return this->offsets()[key + 1].keys_offsets() - this->offsets()[key].keys_offsets();
+							}
+							constexpr SOA_HOST_DEVICE auto keys() const {
+                return this->offsets().metadata().size() - 1;
+							}
+							constexpr SOA_HOST_DEVICE auto size() const {
+                return this->content().metadata().size();
+							}
+						)
+    )
+  };
+  // clang-format on
+
+  template <std::integral TKey = uint32_t, concepts::trivially_copyable TMapped = uint32_t>
+  using AssociationMap = typename AssociationMapLayout<TMapped, TKey>::template Layout<>;
+  template <std::integral TKey = uint32_t, concepts::trivially_copyable TMapped = uint32_t>
+  using AssociationMapView = typename AssociationMap<TMapped, TKey>::View;
+  template <std::integral TKey = uint32_t, concepts::trivially_copyable TMapped = uint32_t>
+  using AssociationMapConstView = typename AssociationMap<TMapped, TKey>::ConstView;
+
+}  // namespace ticl
+
+#endif

--- a/DataFormats/TICL/interface/AssociationMap.h
+++ b/DataFormats/TICL/interface/AssociationMap.h
@@ -71,11 +71,11 @@ namespace ticl {
   // clang-format on
 
   template <std::integral TKey = uint32_t, concepts::trivially_copyable TMapped = uint32_t>
-  using AssociationMap = typename AssociationMapLayout<TMapped, TKey>::template Layout<>;
+  using AssociationMap = typename AssociationMapLayout<TKey, TMapped>::template Layout<>;
   template <std::integral TKey = uint32_t, concepts::trivially_copyable TMapped = uint32_t>
-  using AssociationMapView = typename AssociationMap<TMapped, TKey>::View;
+  using AssociationMapView = typename AssociationMap<TKey, TMapped>::View;
   template <std::integral TKey = uint32_t, concepts::trivially_copyable TMapped = uint32_t>
-  using AssociationMapConstView = typename AssociationMap<TMapped, TKey>::ConstView;
+  using AssociationMapConstView = typename AssociationMap<TKey, TMapped>::ConstView;
 
 }  // namespace ticl
 

--- a/DataFormats/TICL/interface/AssociationMap.h
+++ b/DataFormats/TICL/interface/AssociationMap.h
@@ -1,0 +1,82 @@
+
+#ifndef DataFormats_TICL_interface_AssociationMap_h
+#define DataFormats_TICL_interface_AssociationMap_h
+
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "DataFormats/SoATemplate/interface/SoABlocks.h"
+#include <concepts>
+#include <cstdint>
+#include <type_traits>
+
+namespace ticl {
+
+  namespace concepts {
+
+    template <typename T>
+    concept trivially_copyable = std::is_trivially_copyable_v<T>;
+
+  }
+
+  // clang-format off
+  template <std::integral TKey, concepts::trivially_copyable TMapped>
+  struct AssociationMapLayout {
+    GENERATE_SOA_LAYOUT(ContentBuffersLayout, SOA_COLUMN(TMapped, values))
+    GENERATE_SOA_LAYOUT(OffsetBufferLayout, SOA_COLUMN(TKey, keys_offsets))
+    
+    template <CMS_SOA_BYTE_SIZE_TYPE ALIGNMENT = cms::soa::CacheLineSize::defaultSize,
+              bool ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::relaxed>
+    class OffsetsLayout final : public OffsetBufferLayout<ALIGNMENT, ALIGNMENT_ENFORCEMENT> {
+      using Parent = OffsetBufferLayout<ALIGNMENT, ALIGNMENT_ENFORCEMENT>;
+
+    public:
+      OffsetsLayout() : Parent() {}
+      OffsetsLayout(std::byte* mem, cms::soa::size_type elements) : Parent(mem, elements + 1) {}
+
+      static constexpr auto computeDataSize(std::size_t size) {
+        return Parent::computeDataSize(size + 1);
+      }
+    };
+
+    GENERATE_SOA_BLOCKS(Layout,
+                        SOA_BLOCK(offsets, OffsetsLayout),
+                        SOA_BLOCK(content, ContentBuffersLayout),
+                        SOA_VIEW_METHODS(
+                          constexpr SOA_HOST_DEVICE auto operator[](TKey key) {
+                            const auto offset = this->offsets()[key].keys_offsets();
+                            const auto size = this->count(key);
+                            return std::span<TMapped>{this->content().values().data() + offset, static_cast<std::size_t>(size)};
+                          }
+                        ),
+                        SOA_CONST_VIEW_METHODS(
+                          constexpr SOA_HOST_DEVICE auto operator[](TKey key) const {
+                            const auto offset = this->offsets()[key].keys_offsets();
+                            const auto size = this->count(key);
+                            return std::span<const TMapped>{this->content().values().data() + offset, static_cast<std::size_t>(size)};
+                          }
+                          constexpr SOA_HOST_DEVICE auto contains(TKey key) const {
+                            return this->count(key) > 0;
+                          }
+                          constexpr SOA_HOST_DEVICE auto count(TKey key) const {
+                            return this->offsets()[key + 1].keys_offsets() - this->offsets()[key].keys_offsets();
+                          }
+                          constexpr SOA_HOST_DEVICE auto keys() const {
+                            return this->offsets().metadata().size() - 1;
+                          }
+                          constexpr SOA_HOST_DEVICE auto size() const {
+                            return this->content().metadata().size();
+                          }
+                        )
+    )
+  };
+  // clang-format on
+
+  template <std::integral TKey = uint32_t, concepts::trivially_copyable TMapped = uint32_t>
+  using AssociationMap = typename AssociationMapLayout<TMapped, TKey>::template Layout<>;
+  template <std::integral TKey = uint32_t, concepts::trivially_copyable TMapped = uint32_t>
+  using AssociationMapView = typename AssociationMap<TMapped, TKey>::View;
+  template <std::integral TKey = uint32_t, concepts::trivially_copyable TMapped = uint32_t>
+  using AssociationMapConstView = typename AssociationMap<TMapped, TKey>::ConstView;
+
+}  // namespace ticl
+
+#endif

--- a/DataFormats/TICL/interface/FillAssociator.h
+++ b/DataFormats/TICL/interface/FillAssociator.h
@@ -12,7 +12,7 @@ namespace ticl::associator {
   template <alpaka::concepts::Acc TAcc, typename TQueue, std::integral TKey, concepts::trivially_copyable TMapped>
     requires alpaka::isQueue<TQueue>
   ALPAKA_FN_HOST auto fill(TQueue& queue,
-                           ticl::AssociationMapView<TMapped, TKey>& map,
+                           ticl::AssociationMapView<TKey, TMapped>& map,
                            std::span<const TKey> keys,
                            std::span<const TMapped> values) {
     detail::fill<TAcc>(queue, map, keys, values);

--- a/DataFormats/TICL/interface/FillAssociator.h
+++ b/DataFormats/TICL/interface/FillAssociator.h
@@ -1,0 +1,23 @@
+
+#ifndef DataFormats_TICL_interface_FillAssociator_h
+#define DataFormats_TICL_interface_FillAssociator_h
+
+#include "DataFormats/TICL/interface/AssociationMap.h"
+#include "DataFormats/TICL/interface/detail/FillAssociator.h"
+#include <alpaka/alpaka.hpp>
+#include <span>
+
+namespace ticl::associator {
+
+  template <alpaka::concepts::Acc TAcc, typename TQueue, std::integral TKey, concepts::trivially_copyable TMapped>
+    requires alpaka::isQueue<TQueue>
+  ALPAKA_FN_HOST auto fill(TQueue& queue,
+                           ticl::AssociationMapView<TMapped, TKey>& map,
+                           std::span<const TKey> keys,
+                           std::span<const TMapped> values) {
+    detail::fill<TAcc>(queue, map, keys, values);
+  }
+
+}  // namespace ticl::associator
+
+#endif

--- a/DataFormats/TICL/interface/detail/FillAssociator.h
+++ b/DataFormats/TICL/interface/detail/FillAssociator.h
@@ -25,7 +25,7 @@ namespace ticl::associator::detail {
   struct KernelFillAssociator {
     template <alpaka::concepts::Acc TAcc, std::integral TKey, concepts::trivially_copyable TMapped>
     ALPAKA_FN_ACC void operator()(const TAcc& acc,
-                                  ticl::AssociationMapView<TMapped, TKey> view,
+                                  ticl::AssociationMapView<TKey, TMapped> view,
                                   std::span<const TKey> keys,
                                   std::span<const TMapped> values,
                                   TKey* temp_offsets) const {
@@ -40,7 +40,7 @@ namespace ticl::associator::detail {
   template <alpaka::concepts::Acc TAcc, typename TQueue, std::integral TKey, concepts::trivially_copyable TMapped>
     requires alpaka::isQueue<TQueue>
   ALPAKA_FN_HOST auto fill(TQueue& queue,
-                           ticl::AssociationMapView<TMapped, TKey>& map,
+                           ticl::AssociationMapView<TKey, TMapped>& map,
                            std::span<const TKey> keys,
                            std::span<const TMapped> values) {
     using namespace ::cms::alpakatools;

--- a/DataFormats/TICL/interface/detail/FillAssociator.h
+++ b/DataFormats/TICL/interface/detail/FillAssociator.h
@@ -1,0 +1,88 @@
+
+#ifndef DataFormats_TICL_interface_detail_FillAssociator_h
+#define DataFormats_TICL_interface_detail_FillAssociator_h
+
+#include "DataFormats/TICL/interface/AssociationMap.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/prefixScan.h"
+#include <alpaka/alpaka.hpp>
+#include <concepts>
+#include <span>
+
+namespace ticl::associator::detail {
+
+  struct KernelComputeAssociationSizes {
+    template <alpaka::concepts::Acc TAcc, std::integral TKey>
+    ALPAKA_FN_ACC void operator()(const TAcc& acc,
+                                  std::span<const TKey> keys,
+                                  TKey* keys_counts,
+                                  std::size_t size) const {
+      for (auto i : alpaka::uniformElements(acc, size)) {
+        alpaka::atomicAdd(acc, &keys_counts[keys[i]], TKey{1});
+      }
+    }
+  };
+
+  struct KernelFillAssociator {
+    template <alpaka::concepts::Acc TAcc, std::integral TKey, concepts::trivially_copyable TMapped>
+    ALPAKA_FN_ACC void operator()(const TAcc& acc,
+                                  ticl::AssociationMapView<TMapped, TKey> view,
+                                  std::span<const TKey> keys,
+                                  std::span<const TMapped> values,
+                                  TKey* temp_offsets) const {
+      for (auto i : alpaka::uniformElements(acc, values.size())) {
+        const auto key = keys[i];
+        const auto offset = alpaka::atomicAdd(acc, &temp_offsets[key], TKey{1});
+        view.content().values()[offset] = values[i];
+      }
+    }
+  };
+
+  template <alpaka::concepts::Acc TAcc, typename TQueue, std::integral TKey, concepts::trivially_copyable TMapped>
+    requires alpaka::isQueue<TQueue>
+  ALPAKA_FN_HOST auto fill(TQueue& queue,
+                           ticl::AssociationMapView<TMapped, TKey>& map,
+                           std::span<const TKey> keys,
+                           std::span<const TMapped> values) {
+    using namespace ::cms::alpakatools;
+
+    const auto nkeys = map.keys();
+    const auto nvalues = map.content().metadata().size();
+
+    assert(keys.size() == values.size());
+    assert(static_cast<cms::soa::size_type>(values.size()) <= nvalues);
+
+    const auto blocksize = 1024u;
+    const auto gridsize = divide_up_by(keys.size(), blocksize);
+    const auto workdiv = make_workdiv<TAcc>(gridsize, blocksize);
+    auto keys_counts = make_device_buffer<TKey[]>(queue, nkeys);
+    alpaka::memset(queue, keys_counts, 0);
+    alpaka::exec<TAcc>(queue, workdiv, KernelComputeAssociationSizes{}, keys, keys_counts.data(), keys.size());
+
+    // prepare for prefix scan
+    auto block_counter = make_device_buffer<int32_t>(queue);
+    alpaka::memset(queue, block_counter, 0);
+    auto temp_offsets = make_device_buffer<TKey[]>(queue, nkeys + 1);
+    alpaka::memset(queue, temp_offsets, 0);
+    const auto blocksize_multiblockscan = 1024;
+    auto gridsize_multiblockscan = divide_up_by(nkeys, blocksize_multiblockscan);
+    const auto workdiv_multiblockscan = make_workdiv<TAcc>(gridsize_multiblockscan, blocksize_multiblockscan);
+    auto warp_size = alpaka::getPreferredWarpSize(alpaka::getDev(queue));
+    alpaka::exec<TAcc>(queue,
+                       workdiv_multiblockscan,
+                       multiBlockPrefixScan<TKey>{},
+                       keys_counts.data(),
+                       temp_offsets.data() + 1,
+                       nkeys,
+                       gridsize_multiblockscan,
+                       block_counter.data(),
+                       warp_size);
+
+    alpaka::memcpy(queue,
+                   make_device_view(queue, map.offsets().keys_offsets().data(), nkeys + 1),
+                   make_device_view(queue, temp_offsets.data(), nkeys + 1));
+    alpaka::exec<TAcc>(queue, workdiv, KernelFillAssociator{}, map, keys, values, temp_offsets.data());
+  }
+
+}  // namespace ticl::associator::detail
+
+#endif

--- a/DataFormats/TICL/interface/detail/FillAssociator.h
+++ b/DataFormats/TICL/interface/detail/FillAssociator.h
@@ -1,0 +1,85 @@
+
+#ifndef DataFormats_TICL_interface_detail_FillAssociator_h
+#define DataFormats_TICL_interface_detail_FillAssociator_h
+
+#include "DataFormats/TICL/interface/AssociationMap.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/prefixScan.h"
+#include <alpaka/alpaka.hpp>
+#include <concepts>
+#include <span>
+
+namespace ticl::associator::detail {
+
+  struct KernelComputeAssociationSizes {
+    template <alpaka::concepts::Acc TAcc, std::integral TKey>
+    ALPAKA_FN_ACC void operator()(const TAcc& acc,
+                                  std::span<const TKey> keys,
+                                  TKey* keys_counts,
+                                  std::size_t size) const {
+      for (auto i : alpaka::uniformElements(acc, size)) {
+        alpaka::atomicAdd(acc, &keys_counts[keys[i]], TKey{1});
+      }
+    }
+  };
+
+  struct KernelFillAssociator {
+    template <alpaka::concepts::Acc TAcc, std::integral TKey, concepts::trivially_copyable TMapped>
+    ALPAKA_FN_ACC void operator()(const TAcc& acc,
+                                  ticl::AssociationMapView<TMapped, TKey> view,
+                                  std::span<const TKey> keys,
+                                  std::span<const TMapped> values,
+                                  TKey* temp_offsets) const {
+      for (auto i : alpaka::uniformElements(acc, values.size())) {
+        const auto key = keys[i];
+        const auto offset = alpaka::atomicAdd(acc, &temp_offsets[key], TKey{1});
+        view.content().values()[offset] = values[i];
+      }
+    }
+  };
+
+  template <alpaka::concepts::Acc TAcc, typename TQueue, std::integral TKey, concepts::trivially_copyable TMapped>
+    requires alpaka::isQueue<TQueue>
+  ALPAKA_FN_HOST auto fill(TQueue& queue,
+                           ticl::AssociationMapView<TMapped, TKey>& map,
+                           std::span<const TKey> keys,
+                           std::span<const TMapped> values) {
+    using namespace ::cms::alpakatools;
+
+    const auto nkeys = map.metadata().size()[1];
+    const auto nvalues = map.metadata().size()[0];
+
+    const auto blocksize = 1024u;
+    const auto gridsize = divide_up_by(keys.size(), blocksize);
+    const auto workdiv = make_workdiv<TAcc>(gridsize, blocksize);
+    auto keys_counts = make_device_buffer<TKey[]>(queue, nkeys);
+    alpaka::memset(queue, keys_counts, 0);
+    alpaka::exec<TAcc>(queue, workdiv, KernelComputeAssociationSizes{}, keys, keys_counts.data(), nvalues);
+
+    // prepare for prefix scan
+    auto block_counter = make_device_buffer<int32_t>(queue);
+    alpaka::memset(queue, block_counter, 0);
+    auto temp_offsets = make_device_buffer<TKey[]>(queue, nkeys + 1);
+    alpaka::memset(queue, temp_offsets, 0);
+    const auto blocksize_multiblockscan = 1024;
+    auto gridsize_multiblockscan = divide_up_by(nkeys, blocksize_multiblockscan);
+    const auto workdiv_multiblockscan = make_workdiv<TAcc>(gridsize_multiblockscan, blocksize_multiblockscan);
+    auto warp_size = alpaka::getPreferredWarpSize(alpaka::getDev(queue));
+    alpaka::exec<TAcc>(queue,
+                       workdiv_multiblockscan,
+                       multiBlockPrefixScan<TKey>{},
+                       keys_counts.data(),
+                       temp_offsets.data() + 1,
+                       nkeys,
+                       gridsize_multiblockscan,
+                       block_counter.data(),
+                       warp_size);
+
+    alpaka::memcpy(queue,
+                   make_device_view(queue, map.offsets().keys_offsets().data(), nkeys + 1),
+                   make_device_view(queue, temp_offsets.data(), nkeys + 1));
+    alpaka::exec<TAcc>(queue, workdiv, KernelFillAssociator{}, map, keys, values, temp_offsets.data());
+  }
+
+}  // namespace ticl::associator::detail
+
+#endif

--- a/DataFormats/TICL/test/BuildFile.xml
+++ b/DataFormats/TICL/test/BuildFile.xml
@@ -1,0 +1,7 @@
+<bin name="TestAssociationMap" file="alpaka/*.dev.cc">
+  <use name="catch2"/>
+  <use name="DataFormats/Portable"/>
+  <use name="DataFormats/TICL"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <flags ALPAKA_BACKENDS="1"/>
+</bin>

--- a/DataFormats/TICL/test/alpaka/TestAssociationMap.dev.cc
+++ b/DataFormats/TICL/test/alpaka/TestAssociationMap.dev.cc
@@ -1,0 +1,141 @@
+
+#include "DataFormats/Portable/interface/PortableCollection.h"
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/TICL/interface/AssociationMap.h"
+#include "DataFormats/TICL/interface/FillAssociator.h"
+
+#include <alpaka/alpaka.hpp>
+#include <ranges>
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_all.hpp>
+
+using namespace ALPAKA_ACCELERATOR_NAMESPACE;
+
+namespace {
+  template <typename TKey, typename TMapped>
+  struct TestKernel {
+    ALPAKA_FN_ACC void operator()(const Acc1D& acc, ticl::AssociationMapView<TKey, TMapped> map, bool* result) const {
+      for (auto idx : alpaka::uniformElements(acc, map.size() / 2)) {
+        *result &= (map[0][idx] % 2 != 0);
+        *result &= (map[1][idx] % 2 == 0);
+      }
+      *result &= (map.count(0) == 50);
+      *result &= (map.count(1) == 50);
+      *result &= map.contains(0);
+      *result &= map.contains(1);
+      *result &= (map.keys() == 2);
+    }
+  };
+}  // namespace
+
+TEST_CASE("Construct and fill an association map") {
+  const auto& devices = cms::alpakatools::devices<Platform>();
+
+  SECTION("Test default map") {
+    for (const auto& device : devices) {
+      Queue queue(device);
+
+      const auto nkeys = 2u;
+      const auto nvalues = 100u;
+      PortableCollection<Device, ticl::AssociationMap<>> map(queue, nvalues, nkeys);
+      auto host_values = cms::alpakatools::make_host_buffer<uint32_t[]>(queue, nvalues);
+      auto host_associations = cms::alpakatools::make_host_buffer<uint32_t[]>(queue, nvalues);
+      std::ranges::copy(std::views::iota(0u, nvalues), host_values.data());
+      for (auto i : std::views::iota(0u, nvalues))
+        host_associations[i] = (i % 2 == 0);
+      auto device_values = cms::alpakatools::make_device_buffer<uint32_t[]>(queue, nvalues);
+      auto device_associations = cms::alpakatools::make_device_buffer<uint32_t[]>(queue, nvalues);
+      alpaka::memcpy(queue, device_values, host_values);
+      alpaka::memcpy(queue, device_associations, host_associations);
+      ticl::associator::fill<Acc1D>(queue,
+                                    map.view(),
+                                    std::span<const uint32_t>{device_associations.data(), nvalues},
+                                    std::span<const uint32_t>{device_values.data(), nvalues});
+      auto offsets = cms::alpakatools::make_host_buffer<uint32_t[]>(queue, nkeys + 1);
+      auto values = cms::alpakatools::make_host_buffer<uint32_t[]>(queue, nvalues);
+      alpaka::memcpy(queue,
+                     offsets,
+                     cms::alpakatools::make_device_view(queue, map.view().offsets().keys_offsets().data(), nkeys + 1));
+      alpaka::memcpy(
+          queue, values, cms::alpakatools::make_device_view(queue, map.view().content().values().data(), nvalues));
+
+      auto device_result = cms::alpakatools::make_device_buffer<bool>(queue);
+      alpaka::memset(queue, device_result, 1);
+      const auto blocksize = 1024u;
+      const auto gridsize = cms::alpakatools::divide_up_by(nvalues, blocksize);
+      auto work_division = cms::alpakatools::make_workdiv<Acc1D>(gridsize, blocksize);
+      alpaka::exec<Acc1D>(queue, work_division, TestKernel<uint32_t, uint32_t>{}, map.view(), device_result.data());
+      auto host_result = cms::alpakatools::make_host_buffer<bool>(queue);
+      alpaka::memcpy(queue, host_result, device_result);
+      alpaka::wait(queue);
+
+      CHECK(*host_result);
+
+      // check content back on CPU
+      CHECK(offsets[0] == 0);
+      CHECK(offsets[1] == 50);
+      CHECK(offsets[2] == 100);
+      for (auto i = 0u; i < nvalues; ++i) {
+        if (i < nvalues / 2) {
+          CHECK(values[i] % 2 != 0);
+        } else {
+          CHECK(values[i] % 2 == 0);
+        }
+      }
+    }
+  }
+  SECTION("Test map with specialized templates") {
+    for (const auto& device : devices) {
+      Queue queue(device);
+
+      const auto nkeys = 2;
+      const auto nvalues = 100;
+      PortableCollection<Device, ticl::AssociationMap<int, int>> map(queue, nvalues, nkeys);
+      auto host_values = cms::alpakatools::make_host_buffer<int[]>(queue, nvalues);
+      auto host_associations = cms::alpakatools::make_host_buffer<int[]>(queue, nvalues);
+      std::ranges::copy(std::views::iota(0, nvalues), host_values.data());
+      for (auto i : std::views::iota(0, nvalues))
+        host_associations[i] = (i % 2 == 0);
+      auto device_values = cms::alpakatools::make_device_buffer<int[]>(queue, nvalues);
+      auto device_associations = cms::alpakatools::make_device_buffer<int[]>(queue, nvalues);
+      alpaka::memcpy(queue, device_values, host_values);
+      alpaka::memcpy(queue, device_associations, host_associations);
+      ticl::associator::fill<Acc1D>(queue,
+                                    map.view(),
+                                    std::span<const int>{device_associations.data(), static_cast<std::size_t>(nvalues)},
+                                    std::span<const int>{device_values.data(), static_cast<std::size_t>(nvalues)});
+      auto offsets = cms::alpakatools::make_host_buffer<int[]>(queue, nkeys + 1);
+      auto values = cms::alpakatools::make_host_buffer<int[]>(queue, nvalues);
+      alpaka::memcpy(queue,
+                     offsets,
+                     cms::alpakatools::make_device_view(queue, map.view().offsets().keys_offsets().data(), nkeys + 1));
+      alpaka::memcpy(
+          queue, values, cms::alpakatools::make_device_view(queue, map.view().content().values().data(), nvalues));
+
+      auto device_result = cms::alpakatools::make_device_buffer<bool>(queue);
+      alpaka::memset(queue, device_result, 1);
+      const auto blocksize = 1024u;
+      const auto gridsize = cms::alpakatools::divide_up_by(nvalues, blocksize);
+      auto work_division = cms::alpakatools::make_workdiv<Acc1D>(gridsize, blocksize);
+      alpaka::exec<Acc1D>(queue, work_division, TestKernel<int, int>{}, map.view(), device_result.data());
+      auto host_result = cms::alpakatools::make_host_buffer<bool>(queue);
+      alpaka::memcpy(queue, host_result, device_result);
+      alpaka::wait(queue);
+
+      CHECK(*host_result);
+
+      // check content back on CPU
+      CHECK(offsets[0] == 0);
+      CHECK(offsets[1] == 50);
+      CHECK(offsets[2] == 100);
+      for (auto i = 0u; i < nvalues; ++i) {
+        if (i < nvalues / 2) {
+          CHECK(values[i] % 2 != 0);
+        } else {
+          CHECK(values[i] % 2 == 0);
+        }
+      }
+    }
+  }
+}

--- a/DataFormats/TICL/test/alpaka/TestAssociationMap.dev.cc
+++ b/DataFormats/TICL/test/alpaka/TestAssociationMap.dev.cc
@@ -1,0 +1,280 @@
+#include "DataFormats/Portable/interface/PortableCollection.h"
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/TICL/interface/AssociationMap.h"
+#include "DataFormats/TICL/interface/FillAssociator.h"
+
+#include <alpaka/alpaka.hpp>
+#include <ranges>
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_all.hpp>
+
+using namespace ALPAKA_ACCELERATOR_NAMESPACE;
+
+namespace {
+  template <typename TKey, typename TMapped>
+  struct TestKernel {
+    ALPAKA_FN_ACC void operator()(const Acc1D& acc, ticl::AssociationMapView<TKey, TMapped> map, bool* result) const {
+      for (auto idx : alpaka::uniformElements(acc, map.size() / 2)) {
+        *result &= (map[0][idx] % 2 != 0);
+        *result &= (map[1][idx] % 2 == 0);
+      }
+      *result &= (map.count(0) == 50);
+      *result &= (map.count(1) == 50);
+      *result &= map.contains(0);
+      *result &= map.contains(1);
+      *result &= (map.keys() == 2);
+    }
+  };
+}  // namespace
+
+TEST_CASE("Construct and fill an association map") {
+  const auto& devices = cms::alpakatools::devices<Platform>();
+
+  SECTION("Test default map") {
+    for (const auto& device : devices) {
+      Queue queue(device);
+
+      const auto nkeys = 2u;
+      const auto nvalues = 100u;
+      PortableCollection<Device, ticl::AssociationMap<>> map(queue, nkeys, nvalues);
+      auto host_values = cms::alpakatools::make_host_buffer<uint32_t[]>(queue, nvalues);
+      auto host_associations = cms::alpakatools::make_host_buffer<uint32_t[]>(queue, nvalues);
+      std::ranges::copy(std::views::iota(0u, nvalues), host_values.data());
+      for (auto i : std::views::iota(0u, nvalues))
+        host_associations[i] = (i % 2 == 0);
+      auto device_values = cms::alpakatools::make_device_buffer<uint32_t[]>(queue, nvalues);
+      auto device_associations = cms::alpakatools::make_device_buffer<uint32_t[]>(queue, nvalues);
+      alpaka::memcpy(queue, device_values, host_values);
+      alpaka::memcpy(queue, device_associations, host_associations);
+      ticl::associator::fill<Acc1D>(
+          queue, map.view(), std::span<const uint32_t>{device_associations}, std::span<const uint32_t>{device_values});
+      auto offsets = cms::alpakatools::make_host_buffer<uint32_t[]>(queue, map.view().offsets().keys_offsets().size());
+      auto values = cms::alpakatools::make_host_buffer<uint32_t[]>(queue, nvalues);
+      alpaka::memcpy(queue, offsets, cms::alpakatools::make_device_view(queue, map.view().offsets().keys_offsets()));
+      alpaka::memcpy(queue, values, cms::alpakatools::make_device_view(queue, map.view().content().values()));
+
+      auto device_result = cms::alpakatools::make_device_buffer<bool>(queue);
+      alpaka::memset(queue, device_result, 1);
+      const auto blocksize = 1024u;
+      const auto gridsize = cms::alpakatools::divide_up_by(nvalues, blocksize);
+      auto work_division = cms::alpakatools::make_workdiv<Acc1D>(gridsize, blocksize);
+      alpaka::exec<Acc1D>(queue, work_division, TestKernel<uint32_t, uint32_t>{}, map.view(), device_result.data());
+      auto host_result = cms::alpakatools::make_host_buffer<bool>(queue);
+      alpaka::memcpy(queue, host_result, device_result);
+      alpaka::wait(queue);
+
+      CHECK(*host_result);
+
+      // check content back on CPU
+      CHECK(offsets[0] == 0);
+      CHECK(offsets[1] == 50);
+      CHECK(offsets[2] == 100);
+      for (auto i = 0u; i < nvalues; ++i) {
+        if (i < nvalues / 2) {
+          CHECK(values[i] % 2 != 0);
+        } else {
+          CHECK(values[i] % 2 == 0);
+        }
+      }
+      SECTION("Test partially filled map") {
+        PortableCollection<Device, ticl::AssociationMap<>> partial_map(queue, nkeys, nvalues);
+        auto partial_map_view = partial_map.view();
+        ticl::associator::fill<Acc1D>(queue,
+                                      partial_map_view,
+                                      std::span<const uint32_t>{device_associations.data(), nvalues / 2},
+                                      std::span<const uint32_t>{device_values.data(), nvalues / 2});
+        auto partial_offsets =
+            cms::alpakatools::make_host_buffer<uint32_t[]>(queue, partial_map.view().offsets().keys_offsets().size());
+        auto partial_values = cms::alpakatools::make_host_buffer<uint32_t[]>(queue, nvalues / 2);
+        alpaka::memcpy(queue,
+                       partial_offsets,
+                       cms::alpakatools::make_device_view(queue, partial_map.view().offsets().keys_offsets()));
+        alpaka::memcpy(queue,
+                       partial_values,
+                       cms::alpakatools::make_device_view(queue, partial_map.view().content().values(), nvalues / 2));
+        alpaka::wait(queue);
+
+        CHECK(partial_offsets[0] == 0);
+        CHECK(partial_offsets[1] == nvalues / 4);
+        CHECK(partial_offsets[2] == nvalues / 2);
+        for (auto i = 0u; i < nvalues / 2; ++i) {
+          if (i < nvalues / 4) {
+            CHECK(partial_values[i] % 2 != 0);
+          } else {
+            CHECK(partial_values[i] % 2 == 0);
+          }
+        }
+      }
+      SECTION("Test deep copy") {
+        PortableCollection<Device, ticl::AssociationMap<>> new_map(queue, nkeys, nvalues);
+        new_map.deepCopy(queue, map.const_view());
+
+        alpaka::memset(queue, offsets, 0x0);
+        alpaka::memset(queue, values, 0x0);
+        alpaka::memcpy(
+            queue, offsets, cms::alpakatools::make_device_view(queue, new_map.view().offsets().keys_offsets()));
+        alpaka::memcpy(queue, values, cms::alpakatools::make_device_view(queue, new_map.view().content().values()));
+        alpaka::wait(queue);
+
+        CHECK(offsets[0] == 0);
+        CHECK(offsets[1] == 50);
+        CHECK(offsets[2] == 100);
+        for (auto i = 0u; i < nvalues; ++i) {
+          if (i < nvalues / 2) {
+            CHECK(values[i] % 2 != 0);
+          } else {
+            CHECK(values[i] % 2 == 0);
+          }
+        }
+      }
+    }
+  }
+  SECTION("Test map with specialized templates") {
+    for (const auto& device : devices) {
+      Queue queue(device);
+
+      const auto nkeys = 2;
+      const auto nvalues = 100;
+      PortableCollection<Device, ticl::AssociationMap<int, int>> map(queue, nkeys, nvalues);
+      auto host_values = cms::alpakatools::make_host_buffer<int[]>(queue, nvalues);
+      auto host_associations = cms::alpakatools::make_host_buffer<int[]>(queue, nvalues);
+      std::ranges::copy(std::views::iota(0, nvalues), host_values.data());
+      for (auto i : std::views::iota(0, nvalues))
+        host_associations[i] = (i % 2 == 0);
+      auto device_values = cms::alpakatools::make_device_buffer<int[]>(queue, nvalues);
+      auto device_associations = cms::alpakatools::make_device_buffer<int[]>(queue, nvalues);
+      alpaka::memcpy(queue, device_values, host_values);
+      alpaka::memcpy(queue, device_associations, host_associations);
+      ticl::associator::fill<Acc1D>(queue,
+                                    map.view(),
+                                    std::span<const int>{device_associations.data(), static_cast<std::size_t>(nvalues)},
+                                    std::span<const int>{device_values.data(), static_cast<std::size_t>(nvalues)});
+      auto offsets = cms::alpakatools::make_host_buffer<int[]>(queue, map.view().offsets().keys_offsets().size());
+      auto values = cms::alpakatools::make_host_buffer<int[]>(queue, nvalues);
+      alpaka::memcpy(queue, offsets, cms::alpakatools::make_device_view(queue, map.view().offsets().keys_offsets()));
+      alpaka::memcpy(queue, values, cms::alpakatools::make_device_view(queue, map.view().content().values()));
+
+      auto device_result = cms::alpakatools::make_device_buffer<bool>(queue);
+      alpaka::memset(queue, device_result, 1);
+      const auto blocksize = 1024u;
+      const auto gridsize = cms::alpakatools::divide_up_by(nvalues, blocksize);
+      auto work_division = cms::alpakatools::make_workdiv<Acc1D>(gridsize, blocksize);
+      alpaka::exec<Acc1D>(queue, work_division, TestKernel<int, int>{}, map.view(), device_result.data());
+      auto host_result = cms::alpakatools::make_host_buffer<bool>(queue);
+      alpaka::memcpy(queue, host_result, device_result);
+      alpaka::wait(queue);
+
+      CHECK(*host_result);
+
+      // check content back on CPU
+      CHECK(offsets[0] == 0);
+      CHECK(offsets[1] == 50);
+      CHECK(offsets[2] == 100);
+      for (auto i = 0u; i < nvalues; ++i) {
+        if (i < nvalues / 2) {
+          CHECK(values[i] % 2 != 0);
+        } else {
+          CHECK(values[i] % 2 == 0);
+        }
+      }
+      SECTION("Test deep copy") {
+        PortableCollection<Device, ticl::AssociationMap<int, int>> new_map(queue, nkeys, nvalues);
+        new_map.deepCopy(queue, map.const_view());
+
+        alpaka::memset(queue, offsets, 0x0);
+        alpaka::memset(queue, values, 0x0);
+        alpaka::memcpy(
+            queue, offsets, cms::alpakatools::make_device_view(queue, new_map.view().offsets().keys_offsets()));
+        alpaka::memcpy(queue, values, cms::alpakatools::make_device_view(queue, new_map.view().content().values()));
+        alpaka::wait(queue);
+
+        CHECK(offsets[0] == 0);
+        CHECK(offsets[1] == 50);
+        CHECK(offsets[2] == 100);
+        for (auto i = 0u; i < nvalues; ++i) {
+          if (i < nvalues / 2) {
+            CHECK(values[i] % 2 != 0);
+          } else {
+            CHECK(values[i] % 2 == 0);
+          }
+        }
+      }
+    }
+  }
+}
+
+TEST_CASE("Test different numbers of keys") {
+  const auto& devices = cms::alpakatools::devices<Platform>();
+
+  SECTION("Test map with keys close to alignments") {
+    for (const auto& device : devices) {
+      Queue queue(device);
+
+      const auto nvalues = 100u;
+      auto host_values = cms::alpakatools::make_host_buffer<uint32_t[]>(queue, nvalues);
+      std::ranges::copy(std::views::iota(0u, nvalues), host_values.data());
+
+      const auto nkeys1 = 30;
+      const auto nkeys2 = 31;
+      const auto nkeys3 = 32;
+      auto host_associations1 = cms::alpakatools::make_host_buffer<uint32_t[]>(queue, nvalues);
+      auto host_associations2 = cms::alpakatools::make_host_buffer<uint32_t[]>(queue, nvalues);
+      auto host_associations3 = cms::alpakatools::make_host_buffer<uint32_t[]>(queue, nvalues);
+      for (auto i : std::views::iota(0u, nvalues)) {
+        host_associations1[i] = (i < static_cast<unsigned>(nkeys1)) ? i : nkeys1 - 1;
+        host_associations2[i] = (i < static_cast<unsigned>(nkeys2)) ? i : nkeys2 - 1;
+        host_associations3[i] = (i < static_cast<unsigned>(nkeys3)) ? i : nkeys3 - 1;
+      }
+      auto device_values = cms::alpakatools::make_device_buffer<uint32_t[]>(queue, nvalues);
+      auto device_associations1 = cms::alpakatools::make_device_buffer<uint32_t[]>(queue, nvalues);
+      auto device_associations2 = cms::alpakatools::make_device_buffer<uint32_t[]>(queue, nvalues);
+      auto device_associations3 = cms::alpakatools::make_device_buffer<uint32_t[]>(queue, nvalues);
+      alpaka::memcpy(queue, device_values, host_values);
+      alpaka::memcpy(queue, device_associations1, host_associations1);
+      alpaka::memcpy(queue, device_associations2, host_associations2);
+      alpaka::memcpy(queue, device_associations3, host_associations3);
+
+      PortableCollection<Device, ticl::AssociationMap<>> map1(queue, nkeys1, nvalues);
+      PortableCollection<Device, ticl::AssociationMap<>> map2(queue, nkeys2, nvalues);
+      PortableCollection<Device, ticl::AssociationMap<>> map3(queue, nkeys3, nvalues);
+      ticl::associator::fill<Acc1D>(queue,
+                                    map1.view(),
+                                    std::span<const uint32_t>{device_associations1},
+                                    std::span<const uint32_t>{device_values});
+      ticl::associator::fill<Acc1D>(queue,
+                                    map2.view(),
+                                    std::span<const uint32_t>{device_associations2},
+                                    std::span<const uint32_t>{device_values});
+      ticl::associator::fill<Acc1D>(queue,
+                                    map3.view(),
+                                    std::span<const uint32_t>{device_associations3},
+                                    std::span<const uint32_t>{device_values});
+
+      // every key below `nkeys - 1` gets exactly the single value equal to its own index;
+      // all the overflow values (i >= nkeys - 1) are collected, in order, under the last key
+      auto checkMap = [&](auto& map, int nkeys) {
+        auto offsets =
+            cms::alpakatools::make_host_buffer<uint32_t[]>(queue, map.view().offsets().keys_offsets().size());
+        auto values = cms::alpakatools::make_host_buffer<uint32_t[]>(queue, nvalues);
+        alpaka::memcpy(queue, offsets, cms::alpakatools::make_device_view(queue, map.view().offsets().keys_offsets()));
+        alpaka::memcpy(queue, values, cms::alpakatools::make_device_view(queue, map.view().content().values()));
+        alpaka::wait(queue);
+
+        const auto last_key = static_cast<uint32_t>(nkeys - 1);
+        CHECK(offsets[0] == 0);
+        for (auto k = 0u; k < last_key; ++k) {
+          CHECK(offsets[k + 1] - offsets[k] == 1);
+          CHECK(values[offsets[k]] == k);
+        }
+        CHECK(offsets[nkeys] == nvalues);
+        for (auto i = last_key; i < nvalues; ++i) {
+          CHECK(values[offsets[last_key] + (i - last_key)] >= last_key);
+        }
+      };
+      checkMap(map1, nkeys1);
+      checkMap(map2, nkeys2);
+      checkMap(map3, nkeys3);
+    }
+  }
+}


### PR DESCRIPTION
#### PR description:

This PR implements an association map based on SoA blocks. In order to provide the accessors to the map's properties and content, the PR also enables the definition of SoA view methods.

#### PR validation:

The PR includes a test of the construction and fill of the map and checks the correctness of the content and the accessor methods.

FYI @felicepantaleo 
