### PR TITLE
Serialization: treat gcc/clang headers as system to avoid warnings coming from these header

### DIFF
--- a/CondFormats/Serialization/python/condformats_serialization_generate.py
+++ b/CondFormats/Serialization/python/condformats_serialization_generate.py
@@ -401,7 +401,7 @@ def get_default_gcc_search_paths(gcc = 'g++', language = 'c++'):
             if '/lib/gcc/' in path:
                 continue
 
-            paths.append('-I%s' % path)
+            paths.append('-isystem%s' % path)
 
         else:
             if line == '#include <...> search starts here:':


### PR DESCRIPTION
In GCC15 IBs, we get build errors when we use clang to parse c++ standard headers [a]. The [condformats_serialization_generate.py script](https://github.com/cms-sw/cmssw/blob/master/CondFormats/Serialization/python/condformats_serialization_generate.py#L385-L413) passes `-I/gcc/include/paths` to clang. This causes clang to parse gcc standard headers and complain if there are warnings such as signed/unsigned int comparison.

This PR proposes to use `-isystem` for gcc headers which should avoid such errors/warnings. This should fix GCC build errors 

[a]
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/00a168351345ba56094748b560b049a6/opt/cmssw/el9_amd64_gcc15/cms/cmssw/CMSSW_16_1_X_2026-01-29-2300/src/CondFormats/Serialization/python/condformats_serialization_generate.py --output /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/00a168351345ba56094748b560b049a6/opt/cmssw/el9_amd64_gcc15/cms/cmssw/CMSSW_16_1_X_2026-01-29-2300/tmp/el9_amd64_gcc15/src/CondFormats/BTauObjects/src/CondFormatsBTauObjects/serialization/Serialization.cc --package src/CondFormats/BTauObjects/ -- -I/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/00a168351345ba56094748b560b049a6/opt/cmssw/el9_amd64_gcc15/cms/cmssw/CMSSW_16_1_X_2026-01-29-2300/src -DCMS_MICRO_ARCH="x86-64-v3" -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=150201 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DBOOST_MPL_IGNORE_PARENTHESES_WARNING -DCMSSW_GIT_HASH="CMSSW_16_1_X_2026-01-29-2300" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_16_1_X_2026-01-29-2300" -Isrc -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/pcre/8.43-e8d981ef0c4e659020f7412da1f5d32f/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/boost/1.80.0-ca4e3dcb01fa10bceeff71c969b3471f/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/bz2lib/1.0.6-d6b0d90322e2469015e82237698b8105/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/libuuid/2.34-8c96ef19d9d30d7a2ea427dc2df76bd3/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/lcg/root/6.36.07-f49e3dc2e35fc97a7392769e6f8c216c/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/tbb/v2022.3.0-83b40bee6aefdebbd4a7361ad4cc192e/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/xz/5.6.4-c37131f740b73f345f07f4d83cfbb550/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/zlib/1.2.13-a0f5f18f7c5d2ffe296dd1edf0335aee/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/md5/1.0.0-ac47d1fc5e4229cfcaadcc311e56ffb0/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/tinyxml2/6.2.0-167a91690145cc0ef52dd09f2762c1a9/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/00a168351345ba56094748b560b049a6/opt/cmssw/el9_amd64_gcc15/cms/cmssw/CMSSW_16_1_X_2026-01-29-2300/src/CondFormats/BTauObjects/src -O3 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++23 -ftree-vectorize -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -fuse-ld=bfd -march=x86-64-v3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -Wno-unknown-warning-option -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -Wno-tautological-type-limit-compare -Wno-vla-cxx-extension -fsized-deallocation -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS
[2026-01-30 11:28:03,282] ERROR: Diagnostic: [Error] comparison of integers of different signs: 'int' and 'const unsigned int'
[2026-01-30 11:28:03,282] ERROR:    at line 166 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/tr1/exp_integral.tcc
[2026-01-30 11:28:03,282] ERROR: Diagnostic: [Error] comparison of integers of different signs: 'int' and 'unsigned int'
[2026-01-30 11:28:03,283] ERROR:    at line 268 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/tr1/exp_integral.tcc
[2026-01-30 11:28:03,283] ERROR: Diagnostic: [Warning] builtin __has_trivial_constructor is deprecated; use __is_trivially_constructible instead
[2026-01-30 11:28:03,283] ERROR:    at line 317 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/bits/stl_tempbuf.h
[2026-01-30 11:28:03,283] ERROR: Diagnostic: [Warning] inline namespace reopened as a non-inline namespace
[2026-01-30 11:28:03,283] ERROR:    at line 1663 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/bits/locale_facets.h
[2026-01-30 11:28:03,283] ERROR: Diagnostic: [Warning] inline namespace reopened as a non-inline namespace
[2026-01-30 11:28:03,283] ERROR:    at line 384 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/bits/locale_facets_nonio.h
[2026-01-30 11:28:03,283] ERROR: Diagnostic: [Warning] inline namespace reopened as a non-inline namespace
[2026-01-30 11:28:03,283] ERROR:    at line 1054 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/bits/locale_facets_nonio.h
[2026-01-30 11:28:03,283] ERROR: Diagnostic: [Warning] inline namespace reopened as a non-inline namespace
[2026-01-30 11:28:03,283] ERROR:    at line 1492 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/bits/locale_facets_nonio.h
[2026-01-30 11:28:03,283] ERROR: Diagnostic: [Warning] inline namespace reopened as a non-inline namespace
[2026-01-30 11:28:03,283] ERROR:    at line 1831 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/bits/locale_facets_nonio.h
[2026-01-30 11:28:03,283] ERROR: Diagnostic: [Warning] inline namespace reopened as a non-inline namespace
[2026-01-30 11:28:03,283] ERROR:    at line 133 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/bits/locale_facets_nonio.tcc
[2026-01-30 11:28:03,283] ERROR: Diagnostic: [Warning] inline namespace reopened as a non-inline namespace
[2026-01-30 11:28:03,283] ERROR:    at line 256 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/bits/locale_conv.h
[2026-01-30 11:28:03,283] ERROR: Diagnostic: [Warning] '_Scanner' defined as a struct template here but previously declared as a class template; this is valid, but may result in linker errors under the Microsoft C++ ABI
[2026-01-30 11:28:03,283] ERROR:    at line 4444 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/format
[2026-01-30 11:28:03,283] ERROR: Diagnostic: [Warning] 'std::__format::_Sink<char>' has virtual functions but non-virtual destructor
[2026-01-30 11:28:03,283] ERROR:    at line 3117 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/format
[2026-01-30 11:28:03,283] ERROR: Diagnostic: [Warning] 'std::__format::_Buf_sink<char>' has virtual functions but non-virtual destructor
[2026-01-30 11:28:03,283] ERROR:    at line 3268 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/format
[2026-01-30 11:28:03,283] ERROR: Diagnostic: [Warning] 'std::__format::_Sink<wchar_t>' has virtual functions but non-virtual destructor
[2026-01-30 11:28:03,283] ERROR:    at line 3117 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/format
[2026-01-30 11:28:03,283] ERROR: Diagnostic: [Warning] 'std::__format::_Buf_sink<wchar_t>' has virtual functions but non-virtual destructor
[2026-01-30 11:28:03,283] ERROR:    at line 3268 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/format
[2026-01-30 11:28:03,283] ERROR: Diagnostic: [Warning] 'std::__format::_Iter_sink<char, char *>' has virtual functions but non-virtual destructor
[2026-01-30 11:28:03,283] ERROR:    at line 3404 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/format
[2026-01-30 11:28:03,283] ERROR: Diagnostic: [Warning] 'std::__format::_Iter_sink<wchar_t, wchar_t *>' has virtual functions but non-virtual destructor
[2026-01-30 11:28:03,283] ERROR:    at line 3404 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/format
[2026-01-30 11:28:03,284] ERROR: Diagnostic: [Warning] inline namespace reopened as a non-inline namespace
[2026-01-30 11:28:03,284] ERROR:    at line 60 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/sstream
[2026-01-30 11:28:03,284] ERROR: Diagnostic: [Warning] 'std::__format::_Iter_sink<char, std::__format::_Sink_iter<char>>' has virtual functions but non-virtual destructor
[2026-01-30 11:28:03,284] ERROR:    at line 3404 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/format
[2026-01-30 11:28:03,284] ERROR: Diagnostic: [Warning] 'std::__format::_Scanner<char>' has virtual functions but non-virtual destructor
[2026-01-30 11:28:03,284] ERROR:    at line 4444 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/format
[2026-01-30 11:28:03,284] ERROR: Diagnostic: [Warning] 'std::__format::_Formatting_scanner<std::__format::_Sink_iter<char>, char>' has virtual functions but non-virtual destructor
[2026-01-30 11:28:03,284] ERROR:    at line 4567 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/format
[2026-01-30 11:28:03,284] ERROR: Diagnostic: [Warning] 'std::__format::_Iter_sink<wchar_t, std::__format::_Sink_iter<wchar_t>>' has virtual functions but non-virtual destructor
[2026-01-30 11:28:03,284] ERROR:    at line 3404 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/format
[2026-01-30 11:28:03,284] ERROR: Diagnostic: [Warning] 'std::__format::_Scanner<wchar_t>' has virtual functions but non-virtual destructor
[2026-01-30 11:28:03,284] ERROR:    at line 4444 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/format
[2026-01-30 11:28:03,284] ERROR: Diagnostic: [Warning] 'std::__format::_Formatting_scanner<std::__format::_Sink_iter<wchar_t>, wchar_t>' has virtual functions but non-virtual destructor
[2026-01-30 11:28:03,284] ERROR:    at line 4567 in /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-ea076504722538be9017594c0399c68d/include/c++/15.2.1/format
Traceback (most recent call last):
  File "/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/00a168351345ba56094748b560b049a6/opt/cmssw/el9_amd64_gcc15/cms/cmssw/CMSSW_16_1_X_2026-01-29-2300/src/CondFormats/Serialization/python/condformats_serialization_generate.py", line 603, in <module>
    main()
  File "/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/00a168351345ba56094748b560b049a6/opt/cmssw/el9_amd64_gcc15/cms/cmssw/CMSSW_16_1_X_2026-01-29-2300/src/CondFormats/Serialization/python/condformats_serialization_generate.py", line 600, in main
    SerializationCodeGenerator( scramFlags=args[1:] ).generate( opts.output )
  File "/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/00a168351345ba56094748b560b049a6/opt/cmssw/el9_amd64_gcc15/cms/cmssw/CMSSW_16_1_X_2026-01-29-2300/src/CondFormats/Serialization/python/condformats_serialization_generate.py", line 505, in __init__
    raise Exception('Please, resolve all errors before proceeding.')
Exception: Please, resolve all errors before proceeding.

```