### PR TITLE
Use signed integer for "present actual"  and "max actual" in AllocMonitors

### DIFF
--- a/PerfTools/AllocMonitor/plugins/EventProcessingAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/EventProcessingAllocMonitor.cc
@@ -66,15 +66,12 @@ namespace {
         return;
       }
       nDeallocations_.fetch_add(1, std::memory_order_acq_rel);
-      auto present = presentActual_.load(std::memory_order_acquire);
-      if (present >= iActual) {
-        presentActual_.fetch_sub(iActual, std::memory_order_acq_rel);
-      }
+      presentActual_.fetch_sub(iActual, std::memory_order_acq_rel);
     }
 
     std::atomic<size_t> requested_ = 0;
-    std::atomic<size_t> presentActual_ = 0;
-    std::atomic<size_t> maxActual_ = 0;
+    std::atomic<long long> presentActual_ = 0;
+    std::atomic<long long> maxActual_ = 0;
     std::atomic<size_t> nAllocations_ = 0;
     std::atomic<size_t> nDeallocations_ = 0;
 

--- a/PerfTools/AllocMonitor/plugins/PeriodicAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/PeriodicAllocMonitor.cc
@@ -74,15 +74,12 @@ namespace {
       if (0 == iActual)
         return;
       nDeallocations_.fetch_add(1, std::memory_order_acq_rel);
-      auto present = presentActual_.load(std::memory_order_acquire);
-      if (present >= iActual) {
-        presentActual_.fetch_sub(iActual, std::memory_order_acq_rel);
-      }
+      presentActual_.fetch_sub(iActual, std::memory_order_acq_rel);
     }
 
     std::atomic<size_t> requested_ = 0;
-    std::atomic<size_t> presentActual_ = 0;
-    std::atomic<size_t> maxActual_ = 0;
+    std::atomic<long long> presentActual_ = 0;
+    std::atomic<long long> maxActual_ = 0;
     std::atomic<size_t> nAllocations_ = 0;
     std::atomic<size_t> nDeallocations_ = 0;
     std::atomic<size_t> maxSingleRequested_ = 0;

--- a/PerfTools/AllocMonitor/plugins/SimpleAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/SimpleAllocMonitor.cc
@@ -39,10 +39,7 @@ namespace {
     }
     void deallocCalled(size_t iActual, void const*) final {
       nDeallocations_.fetch_add(1, std::memory_order_acq_rel);
-      auto present = presentActual_.load(std::memory_order_acquire);
-      if (present >= iActual) {
-        presentActual_.fetch_sub(iActual, std::memory_order_acq_rel);
-      }
+      presentActual_.fetch_sub(iActual, std::memory_order_acq_rel);
     }
 
     void performanceReport() const {
@@ -61,8 +58,8 @@ namespace {
 
   private:
     std::atomic<size_t> requested_ = 0;
-    std::atomic<size_t> presentActual_ = 0;
-    std::atomic<size_t> maxActual_ = 0;
+    std::atomic<long long> presentActual_ = 0;
+    std::atomic<long long> maxActual_ = 0;
     std::atomic<size_t> nAllocations_ = 0;
     std::atomic<size_t> nDeallocations_ = 0;
   };

--- a/PerfTools/MaxMemoryPreload/src/preload.cc
+++ b/PerfTools/MaxMemoryPreload/src/preload.cc
@@ -65,10 +65,7 @@ namespace {
         return;
 
       nDeallocations_.fetch_add(1, std::memory_order_acq_rel);
-      auto present = presentActual_.load(std::memory_order_acquire);
-      if (present >= iActual) {
-        presentActual_.fetch_sub(iActual, std::memory_order_acq_rel);
-      }
+      presentActual_.fetch_sub(iActual, std::memory_order_acq_rel);
     }
 
     void performanceReport() const {
@@ -86,8 +83,8 @@ namespace {
 
   private:
     std::atomic<size_t> requested_ = 0;
-    std::atomic<size_t> presentActual_ = 0;
-    std::atomic<size_t> maxActual_ = 0;
+    std::atomic<long long> presentActual_ = 0;
+    std::atomic<long long> maxActual_ = 0;
     std::atomic<size_t> nAllocations_ = 0;
     std::atomic<size_t> nDeallocations_ = 0;
   };


### PR DESCRIPTION
#### PR description:

This PR addresses the concern in https://github.com/cms-sw/cmssw/pull/49950#discussion_r2733464757 by making the "present actual" and "max actual" counters signed integers. The AllocMonitors doing per-thread accounting did that for "present actual" already
https://github.com/cms-sw/cmssw/blob/5b4897d1e7dddc68550a09ff9f1d49a991e2eee2/PerfTools/AllocMonitor/plugins/ThreadAllocInfo.h#L30-L32

In principle the "max actual" could have been kept as unsigned, but it is being compared to "present actual" and I felt things would be simplest to understand if it would be changed accordingly.

Resolves https://github.com/cms-sw/framework-team/issues/1848

#### PR validation:

Code compiles