### PR TITLE
Adding TnP efficiency on MuonHLT offline DQM

### DIFF
--- a/DQMOffline/Trigger/interface/HLTMuonMatchAndPlot.h
+++ b/DQMOffline/Trigger/interface/HLTMuonMatchAndPlot.h
@@ -75,15 +75,26 @@ public:
   template <class T>
   void fillMapFromPSet(std::map<std::string, T> &, const edm::ParameterSet &, const std::string &);
   template <class T1, class T2>
-  std::vector<size_t> matchByDeltaR(const std::vector<T1> &, const std::vector<T2> &, const double maxDeltaR = NOMATCH);
+  std::vector<size_t> matchByDeltaR(const std::vector<T1> &, const std::vector<T2> &, const double maxDeltaR = NOMATCH, bool isTnPAnalyzer = false);
 
 private:
   // Internal Methods
   void book1D(DQMStore::IBooker &, std::string, const std::string &, std::string);
   void book2D(DQMStore::IBooker &, const std::string &, const std::string &, const std::string &, const std::string &);
-  reco::MuonCollection selectedMuons(const reco::MuonCollection &, const reco::BeamSpot &, bool);
+  reco::MuonCollection selectedMuons(const reco::MuonCollection &, const reco::BeamSpot &, bool, bool);
   trigger::TriggerObjectCollection selectedTriggerObjects(const trigger::TriggerObjectCollection &,
-                                                          const trigger::TriggerEvent &);
+                                                          const trigger::TriggerEvent &) const;
+
+  // Tag and Probe helper functions
+  bool isTagMuon(const reco::Muon& muon, const reco::BeamSpot& beamSpot, const reco::VertexCollection& vertices,
+                 const trigger::TriggerEvent& triggerSummary, const edm::TriggerResults& triggerResults,
+                 const edm::TriggerNames& trigNames) const;
+  bool isProbeMuon(const reco::Muon& muon, const reco::VertexCollection& vertices) const;
+  bool isTightMuonID(const reco::Muon& muon, const reco::VertexCollection& vertices) const;
+  bool isTightPFIsolation(const reco::Muon& muon) const;
+  bool passTriggerMatching(const reco::Muon& muon, const trigger::TriggerEvent& triggerSummary,
+                          const std::string& triggerPath, double deltaRCut = 0.1) const;
+  double calculateInvariantMass(const reco::Muon& muon1, const reco::Muon& muon2) const;
 
   // Input from Configuration File
   std::string hltProcessName_;

--- a/DQMOffline/Trigger/interface/HLTMuonMatchAndPlot.h
+++ b/DQMOffline/Trigger/interface/HLTMuonMatchAndPlot.h
@@ -75,7 +75,10 @@ public:
   template <class T>
   void fillMapFromPSet(std::map<std::string, T> &, const edm::ParameterSet &, const std::string &);
   template <class T1, class T2>
-  std::vector<size_t> matchByDeltaR(const std::vector<T1> &, const std::vector<T2> &, const double maxDeltaR = NOMATCH, bool isTnPAnalyzer = false);
+  std::vector<size_t> matchByDeltaR(const std::vector<T1> &,
+                                    const std::vector<T2> &,
+                                    const double maxDeltaR = NOMATCH,
+                                    bool isTnPAnalyzer = false);
 
 private:
   // Internal Methods
@@ -86,15 +89,20 @@ private:
                                                           const trigger::TriggerEvent &) const;
 
   // Tag and Probe helper functions
-  bool isTagMuon(const reco::Muon& muon, const reco::BeamSpot& beamSpot, const reco::VertexCollection& vertices,
-                 const trigger::TriggerEvent& triggerSummary, const edm::TriggerResults& triggerResults,
-                 const edm::TriggerNames& trigNames) const;
-  bool isProbeMuon(const reco::Muon& muon, const reco::VertexCollection& vertices) const;
-  bool isTightMuonID(const reco::Muon& muon, const reco::VertexCollection& vertices) const;
-  bool isTightPFIsolation(const reco::Muon& muon) const;
-  bool passTriggerMatching(const reco::Muon& muon, const trigger::TriggerEvent& triggerSummary,
-                          const std::string& triggerPath, double deltaRCut = 0.1) const;
-  double calculateInvariantMass(const reco::Muon& muon1, const reco::Muon& muon2) const;
+  bool isTagMuon(const reco::Muon &muon,
+                 const reco::BeamSpot &beamSpot,
+                 const reco::VertexCollection &vertices,
+                 const trigger::TriggerEvent &triggerSummary,
+                 const edm::TriggerResults &triggerResults,
+                 const edm::TriggerNames &trigNames) const;
+  bool isProbeMuon(const reco::Muon &muon, const reco::VertexCollection &vertices) const;
+  bool isTightMuonID(const reco::Muon &muon, const reco::VertexCollection &vertices) const;
+  bool isTightPFIsolation(const reco::Muon &muon) const;
+  bool passTriggerMatching(const reco::Muon &muon,
+                           const trigger::TriggerEvent &triggerSummary,
+                           const std::string &triggerPath,
+                           double deltaRCut = 0.1) const;
+  double calculateInvariantMass(const reco::Muon &muon1, const reco::Muon &muon2) const;
 
   // Input from Configuration File
   std::string hltProcessName_;

--- a/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cff.py
+++ b/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cff.py
@@ -12,22 +12,35 @@ globalMuonParams = cms.PSet(
     hltMinEtaCut  = cms.untracked.double(0.0),
 )
 
+globalAnalyzer = hltMuonOfflineAnalyzer.clone()
+globalAnalyzer.destination = "HLT/Muon/DistributionsGlobal"
+globalAnalyzer.targetParams = globalMuonParams
+#globalAnalyzer.probeParams = cms.PSet()
+
+# ADDED
 globalAnalyzerTnP = hltMuonOfflineAnalyzer.clone()
-globalAnalyzerTnP.destination = "HLT/Muon/DistributionsGlobal"
+globalAnalyzerTnP.destination = "HLT/Muon/DistributionsTnP"
 globalAnalyzerTnP.targetParams = globalMuonParams
-#globalAnalyzerTnP.probeParams = cms.PSet()
+globalAnalyzerTnP.plotCuts.L3DeltaR = cms.untracked.double(0.10)
+globalAnalyzerTnP.hltPathsToCheck = cms.vstring(
+    "HLT_IsoMu24_v",
+    "HLT_Mu50_v",
+    "HLT_CascadeMu100_v",
+    "HLT_HighPtTkMu100_v",
+    "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v",
+)
 
 refPathsList = cms.vstring(
-    "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v",
+    "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v", # alive
     "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v",
-    "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v",
+    "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v", # alive
     "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v",
     "HLT_TkMu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v",
     "HLT_TkMu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v"
     "HLT_Mu18_Mu9_DZ_v",
     "HLT_Mu18_Mu9_v",
     "HLT_Mu18_Mu9_SameSign_DZ_v",
-    "HLT_Mu18_Mu9_SameSign_v"
+    "HLT_Mu18_Mu9_SameSign_v" # alive
     )
 
 globalAnalyzerRef = hltMuonOfflineAnalyzer.clone()
@@ -54,7 +67,8 @@ globalAnalyzerRef19.requiredTriggers = cms.untracked.vstring(
 #globalAnalyzerRef19.probeParams = cms.PSet()
 
 hltMuonOfflineAnalyzers = cms.Sequence(
-    globalAnalyzerTnP  *
+    globalAnalyzer  *
+    globalAnalyzerTnP *
     globalAnalyzerRef  *
     globalAnalyzerRef19
 )
@@ -63,11 +77,11 @@ from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 
-for muAna in [globalAnalyzerTnP.targetParams, 
+for muAna in [globalAnalyzer.targetParams, 
               globalAnalyzerRef.targetParams]:
     for e in [pA_2016, ppRef_2017, pp_on_AA]:
 	    e.toModify(muAna, ptCut_Jpsi = cms.untracked.double( 5.0))
-for muAna in [globalAnalyzerTnP.binParams, 
+for muAna in [globalAnalyzer.binParams, 
               globalAnalyzerRef.binParams]:
     for e in [pA_2016, ppRef_2017, pp_on_AA]:
 	    e.toModify(muAna, ptCoarse = cms.untracked.vdouble(0.,1.,2.,3.,4.,5.,7.,9.,12.,15.,20.,30.,40.))

--- a/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cfi.py
+++ b/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cfi.py
@@ -17,9 +17,9 @@ hltMuonOfflineAnalyzer = DQMEDAnalyzer('HLTMuonOfflineAnalyzer',
       "HLT_IsoMu24_v",
       "HLT_IsoMu27_v",
       "HLT_IsoMu20_v",
-      "HLT_HIL3Mu12_v", #for HI
-      "HLT_HIL3Mu15_v", #for HI
-      "HLT_HIL3Mu20_v", #for HI
+      "HLT_HIL3Mu12_v",
+      "HLT_HIL3Mu15_v",
+      "HLT_HIL3Mu20_v",
       "HLT_CascadeMu100_v",
       "HLT_HighPtTkMu100_v"
     ),
@@ -68,7 +68,7 @@ hltMuonOfflineAnalyzer = DQMEDAnalyzer('HLTMuonOfflineAnalyzer',
         pt = cms.untracked.vdouble(  0.0,   2.0,   4.0, 
                                      6.0,   8.0,  10.0, 
                                     20.0,  30.0,  40.0, 
-                                   100.0, 200.0, 400.0),
+                                   100.0, 200.0, 500.0),
     ),
 
     ## These parameters define which objects are used to fill plots

--- a/DQMOffline/Trigger/python/MuonPostProcessor_cff.py
+++ b/DQMOffline/Trigger/python/MuonPostProcessor_cff.py
@@ -30,6 +30,9 @@ hltMuonEfficiencies = DQMEDHarvester("DQMGenericClient",
                                      
 
     efficiencyProfile = cms.untracked.vstring(
+        #
+        
+        #
         "efficiencyVertex 'Efficiency to Match Reco Muons to Trigger Objects; NVertex^{reco}; N(#mu matched to trigger object) / N(#mu)' efficiencyVertex_numer efficiencyVertex_denom",
         "efficiencyEta 'Efficiency to Match Reco Muons to Trigger Objects; #eta^{reco}; N(#mu matched to trigger object) / N(#mu)' efficiencyEta_numer efficiencyEta_denom",
         "efficiencyPhi 'Efficiency to Match Reco Muons to Trigger Objects; #phi^{reco}; N(#mu matched to trigger object) / N(#mu)' efficiencyPhi_numer efficiencyPhi_denom",
@@ -37,6 +40,8 @@ hltMuonEfficiencies = DQMEDHarvester("DQMGenericClient",
         "efficiencyD0 'Efficiency to Match Reco Muons to Trigger Objects; d0^{reco}; N(#mu matched to trigger object) / N(#mu)' efficiencyD0_numer efficiencyD0_denom",
         "efficiencyZ0 'Efficiency to Match Reco Muons to Trigger Objects; z0^{reco}; N(#mu matched to trigger object) / N(#mu)' efficiencyZ0_numer efficiencyZ0_denom",
         "efficiencyCharge 'Efficiency to Match Reco Muons to Trigger Objects; q^{reco}; N(#mu matched to trigger object) / N(#mu)' efficiencyCharge_numer efficiencyCharge_denom",
+        #
+        #
         "fakerateVertex 'Trigger Fake Rate; NVertex^{trigger}; N(unmatched trigger objects) / N(trigger objects)' fakerateVertex_numer fakerateVertex_denom",
         "fakerateEta 'Trigger Fake Rate; #eta^{trigger}; N(unmatched trigger objects) / N(trigger objects)' fakerateEta_numer fakerateEta_denom",
         "fakeratePhi 'Trigger Fake Rate; #phi^{trigger}; N(unmatched trigger objects) / N(trigger objects)' fakeratePhi_numer fakeratePhi_denom",
@@ -48,7 +53,29 @@ hltMuonEfficiencies = DQMEDHarvester("DQMGenericClient",
         "TPefficiencyVertexZ 'Tag & Probe efficiency; NVertex; N(tt) / N(tp)' massVsVertexZ_numer massVsVertexZ_denom",
                 
     ),
+)
 
+hltMuonEfficienciesTnP = DQMEDHarvester("DQMGenericClient",
+
+    subDirs        = cms.untracked.vstring("HLT/Muon/DistributionsTnP.*"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
+    outputFileName = cms.untracked.string(''),
+    commands       = cms.vstring(),
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(),
+
+    efficiencyProfile = cms.untracked.vstring(
+        # "efficiencyOfflineMuonPt '; p_{T}^{reco}; N(#mu matched to trigger object) / N(#mu)' efficiencyOfflineMuonPt_numer efficiencyOfflineMuonPt_denom",
+        # "efficiencyOfflineMuonEta '; #eta^{reco}; N(#mu matched to trigger object) / N(#mu)' efficiencyOfflineMuonEta_numer efficiencyOfflineMuonEta_denom",
+        # "efficiencyOfflineMuonPhi '; #phi^{reco}; N(#mu matched to trigger object) / N(#mu)' efficiencyOfflineMuonPhi_numer efficiencyOfflineMuonPhi_denom",
+
+        "efficiencyEtaTnP 'Tag & Probe Efficiency; #eta^{reco}; N(#mu matched to trigger object) / N(#mu)' efficiencyEtaTnP_numer efficiencyEtaTnP_denom",
+        "efficiencyPtTnP 'Tag & Probe Efficiency; p_{T}^{reco}; N(#mu matched to trigger object) / N(#mu)' efficiencyPtTnP_numer efficiencyPtTnP_denom",
+        "efficiencyPhiTnP 'Tag & Probe Efficiency; #phi^{reco}; N(#mu matched to trigger object) / N(#mu)' efficiencyPhiTnP_numer efficiencyPhiTnP_denom",
+        "efficiencyNVertexTnP 'Tag & Probe Efficiency; NVertex^{reco}; N(#mu matched to trigger object) / N(#mu)' efficiencyNVertexTnP_numer efficiencyNVertexTnP_denom",
+        "efficiencyZ0TnP 'Tag & Probe Efficiency; z0^{reco}; N(#mu matched to trigger object) / N(#mu)' efficiencyZ0TnP_numer efficiencyZ0TnP_denom",
+        "efficiencyChargeTnP 'Tag & Probe Efficiency; q^{reco}; N(#mu matched to trigger object) / N(#mu)' efficiencyChargeTnP_numer efficiencyChargeTnP_denom",    
+    ),
 )
 
 hltMuonEfficienciesMR =  DQMEDHarvester("DQMGenericClient",
@@ -135,12 +162,8 @@ hltMuonRefEfficienciesMR = DQMEDHarvester("HLTMuonRefMethod",
 
 hltMuonPostVal = cms.Sequence(
     hltMuonEfficiencies*
+    hltMuonEfficienciesTnP*
     hltMuonEfficienciesMR*
     hltMuonRefEfficiencies*
     hltMuonRefEfficienciesMR
 )
-
-
-
-
-

--- a/DQMOffline/Trigger/src/HLTMuonMatchAndPlot.cc
+++ b/DQMOffline/Trigger/src/HLTMuonMatchAndPlot.cc
@@ -85,14 +85,14 @@ HLTMuonMatchAndPlot::HLTMuonMatchAndPlot(const ParameterSet& pset, string hltPat
   }
   delete objArray;
 }
- 
+
 void HLTMuonMatchAndPlot::beginRun(DQMStore::IBooker& iBooker, const edm::Run& iRun, const edm::EventSetup& iSetup) {
   TPRegexp suffixPtCut("Mu[0-9]+$");
 
   string baseDir = destination_;
   if (baseDir[baseDir.size() - 1] != '/')
     baseDir += '/';
-    
+
   string pathSansSuffix = hltPath_;
   if (hltPath_.rfind("_v") < hltPath_.length())
     pathSansSuffix = hltPath_.substr(0, hltPath_.rfind("_v"));
@@ -102,9 +102,9 @@ void HLTMuonMatchAndPlot::beginRun(DQMStore::IBooker& iBooker, const edm::Run& i
   else
     iBooker.setCurrentFolder(baseDir + pathSansSuffix + "/" + moduleLabel_);
 
-   // Form is book1D(name, binningType, title) where 'binningType' is used
-   // to fetch the bin settings from binParams_.
- 
+  // Form is book1D(name, binningType, title) where 'binningType' is used
+  // to fetch the bin settings from binParams_.
+
   // Determine if this is a TnP analyzer instance or Global analyzer instance
   bool isTnPAnalyzer = (destination_.find("DistributionsTnP") != string::npos);
 
@@ -121,7 +121,7 @@ void HLTMuonMatchAndPlot::beginRun(DQMStore::IBooker& iBooker, const edm::Run& i
       book1D(iBooker, "efficiencyTurnOn_" + suffix, "pt", ";p_{T};");
       book1D(iBooker, "efficiencyNVertex_" + suffix, "NVertex", ";NVertex;");
     }
-    
+
     // Book TnP plots only if this IS a TnP analyzer
     if (isTnPAnalyzer) {
       book1D(iBooker, "efficiencyEtaTnP_" + suffix, "etaFine", ";#eta;");
@@ -140,7 +140,7 @@ void HLTMuonMatchAndPlot::beginRun(DQMStore::IBooker& iBooker, const edm::Run& i
     if (!isLastFilter_)
       continue;  //this will be plotted only for the last filter
 
-    // Book Global plots only 
+    // Book Global plots only
     if (!isTnPAnalyzer) {
       book1D(iBooker, "efficiencyCharge_" + suffix, "charge", ";charge;");
       book1D(iBooker, "efficiencyZ0_" + suffix, "z0", ";z0;");
@@ -148,16 +148,15 @@ void HLTMuonMatchAndPlot::beginRun(DQMStore::IBooker& iBooker, const edm::Run& i
     }
   }
 }
- 
+
 void HLTMuonMatchAndPlot::endRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {}
- 
+
 void HLTMuonMatchAndPlot::analyze(Handle<MuonCollection>& allMuons,
-                                   Handle<BeamSpot>& beamSpot,
-                                   Handle<VertexCollection>& vertices,
-                                   Handle<TriggerEvent>& triggerSummary,
-                                   Handle<TriggerResults>& triggerResults,
-                                   const edm::TriggerNames& trigNames) {
- 
+                                  Handle<BeamSpot>& beamSpot,
+                                  Handle<VertexCollection>& vertices,
+                                  Handle<TriggerEvent>& triggerSummary,
+                                  Handle<TriggerResults>& triggerResults,
+                                  const edm::TriggerNames& trigNames) {
   // Determine if this is a TnP analyzer instance
   bool isTnPAnalyzer = (destination_.find("DistributionsTnP") != string::npos);
 
@@ -169,7 +168,7 @@ void HLTMuonMatchAndPlot::analyze(Handle<MuonCollection>& allMuons,
 
     // Find the best trigger object matches for the targetMuons.
     vector<size_t> matches = matchByDeltaR(targetMuons, hltMuons, plotCuts_[triggerLevel_ + "DeltaR"], isTnPAnalyzer);
- 
+
     for (size_t i = 0; i < targetMuons.size(); i++) {
       Muon& muon = targetMuons[i];
 
@@ -204,7 +203,7 @@ void HLTMuonMatchAndPlot::analyze(Handle<MuonCollection>& allMuons,
           }
         }
       }  // finish loop numerator / denominator...
- 
+
       if (!isLastFilter_)
         continue;
       // Fill plots for tag and probe
@@ -285,7 +284,8 @@ void HLTMuonMatchAndPlot::analyze(Handle<MuonCollection>& allMuons,
         continue;
 
       for (size_t j = 0; j < targetMuons.size(); ++j) {
-        if (i == j) continue;
+        if (i == j)
+          continue;
 
         Muon& probeCandidate = targetMuons[j];
 
@@ -303,13 +303,14 @@ void HLTMuonMatchAndPlot::analyze(Handle<MuonCollection>& allMuons,
           continue;
 
         double pTCutProbe = 0.;
-        if (hltPath_.find("Mu50") != string::npos || hltPath_.find("CascadeMu100") != string::npos || hltPath_.find("HighPtTkMu100") != string::npos)
+        if (hltPath_.find("Mu50") != string::npos || hltPath_.find("CascadeMu100") != string::npos ||
+            hltPath_.find("HighPtTkMu100") != string::npos)
           pTCutProbe = 52.;
         else if (hltPath_.find("Mu24") != string::npos)
           pTCutProbe = 26.;
         else if (hltPath_.find("Mu8") != string::npos)
           pTCutProbe = 10.;
-        
+
         // Find track of probe muon to fill the track-based information
         const Track* track = nullptr;
         if (probeCandidate.isTrackerMuon() || probeCandidate.isGlobalMuon())
@@ -323,7 +324,7 @@ void HLTMuonMatchAndPlot::analyze(Handle<MuonCollection>& allMuons,
         if (probeCandidate.pt() > pTCutProbe) {
           hists_["efficiencyEtaTnP_" + denomSuffix]->Fill(probeCandidate.eta());
           hists_["efficiencyPhiTnP_" + denomSuffix]->Fill(probeCandidate.phi());
-          
+
           if (track) {
             hists_["efficiencyChargeTnP_" + denomSuffix]->Fill(probeCandidate.charge());
             hists_["efficiencyNVertexTnP_" + denomSuffix]->Fill(vertices->size());
@@ -332,9 +333,9 @@ void HLTMuonMatchAndPlot::analyze(Handle<MuonCollection>& allMuons,
         }
 
         // Check if probe muon passes HLT
-        if (matches[j] == (size_t)(-1)) 
+        if (matches[j] == (size_t)(-1))
           continue;
-          
+
         // Fill numerator histograms
         std::string numerSuffix = "numer";
         hists_["efficiencyPtTnP_" + numerSuffix]->Fill(probeCandidate.pt());
@@ -352,27 +353,30 @@ void HLTMuonMatchAndPlot::analyze(Handle<MuonCollection>& allMuons,
     }
   }
 }  // End analyze() method.
- 
+
 // Tag and Probe helper function implementations
 bool HLTMuonMatchAndPlot::isTightMuonID(const reco::Muon& muon, const reco::VertexCollection& vertices) const {
-  if (vertices.empty()) return false;
+  if (vertices.empty())
+    return false;
   const reco::Vertex& primaryVertex = vertices.front();
   return muon::isTightMuon(muon, primaryVertex);
 }
- 
+
 bool HLTMuonMatchAndPlot::isTightPFIsolation(const reco::Muon& muon) const {
   // Tight PF isolation
   const double isoCut = 0.15;
   reco::MuonPFIsolation pfIso = muon.pfIsolationR04();
-  double relativeIso = (pfIso.sumChargedHadronPt + 
-                      std::max(0.0, pfIso.sumNeutralHadronEt + pfIso.sumPhotonEt - 0.5 * pfIso.sumPUPt)) / muon.pt();
+  double relativeIso =
+      (pfIso.sumChargedHadronPt + std::max(0.0, pfIso.sumNeutralHadronEt + pfIso.sumPhotonEt - 0.5 * pfIso.sumPUPt)) /
+      muon.pt();
   return relativeIso < isoCut;
 }
 
 // Check if muon passes trigger matching (IsoMu24)
-bool HLTMuonMatchAndPlot::passTriggerMatching(const reco::Muon& muon, const trigger::TriggerEvent& triggerSummary,
-                                              const std::string& triggerPath, double deltaRCut) const {
-
+bool HLTMuonMatchAndPlot::passTriggerMatching(const reco::Muon& muon,
+                                              const trigger::TriggerEvent& triggerSummary,
+                                              const std::string& triggerPath,
+                                              double deltaRCut) const {
   trigger::TriggerObjectCollection allTriggerObjects = triggerSummary.getObjects();
   trigger::TriggerObjectCollection hltMuons;
 
@@ -387,7 +391,7 @@ bool HLTMuonMatchAndPlot::passTriggerMatching(const reco::Muon& muon, const trig
       }
     }
   }
- 
+
   // Check if muon matches any HLT muon object within deltaR cut
   for (const auto& hltMuon : hltMuons) {
     double dR = deltaR(muon.eta(), muon.phi(), hltMuon.eta(), hltMuon.phi());
@@ -395,39 +399,46 @@ bool HLTMuonMatchAndPlot::passTriggerMatching(const reco::Muon& muon, const trig
       return true;
     }
   }
-   
+
   return false;
 }
- 
-bool HLTMuonMatchAndPlot::isTagMuon(const reco::Muon& muon, const reco::BeamSpot& beamSpot, 
-                                  const reco::VertexCollection& vertices,
-                                  const trigger::TriggerEvent& triggerSummary, const edm::TriggerResults& triggerResults,
-                                  const edm::TriggerNames& trigNames) const {
+
+bool HLTMuonMatchAndPlot::isTagMuon(const reco::Muon& muon,
+                                    const reco::BeamSpot& beamSpot,
+                                    const reco::VertexCollection& vertices,
+                                    const trigger::TriggerEvent& triggerSummary,
+                                    const edm::TriggerResults& triggerResults,
+                                    const edm::TriggerNames& trigNames) const {
   // Tag muon selection criteria:
-  if (muon.pt() <= 27.0) return false;
-  if (!isTightMuonID(muon, vertices)) return false;
-  if (!isTightPFIsolation(muon)) return false;
-  if (!passTriggerMatching(muon, triggerSummary, "IsoMu24", 0.1)) return false;
+  if (muon.pt() <= 27.0)
+    return false;
+  if (!isTightMuonID(muon, vertices))
+    return false;
+  if (!isTightPFIsolation(muon))
+    return false;
+  if (!passTriggerMatching(muon, triggerSummary, "IsoMu24", 0.1))
+    return false;
 
-  return true;
- }
- 
-bool HLTMuonMatchAndPlot::isProbeMuon(const reco::Muon& muon, const reco::VertexCollection& vertices) const {
-
-  if (!isTightMuonID(muon, vertices)) return false;
-  
-  if (!isTightPFIsolation(muon)) return false;
-  
   return true;
 }
- 
+
+bool HLTMuonMatchAndPlot::isProbeMuon(const reco::Muon& muon, const reco::VertexCollection& vertices) const {
+  if (!isTightMuonID(muon, vertices))
+    return false;
+
+  if (!isTightPFIsolation(muon))
+    return false;
+
+  return true;
+}
+
 double HLTMuonMatchAndPlot::calculateInvariantMass(const reco::Muon& muon1, const reco::Muon& muon2) const {
-  math::XYZTLorentzVector p4_1 = muon1.p4();
-  math::XYZTLorentzVector p4_2 = muon2.p4();
+  const math::XYZTLorentzVector& p4_1 = muon1.p4();
+  const math::XYZTLorentzVector& p4_2 = muon2.p4();
   math::XYZTLorentzVector p4_total = p4_1 + p4_2;
   return p4_total.mass();
 }
- 
+
 // Method to fill binning parameters from a vector of doubles.
 bool HLTMuonMatchAndPlot::fillEdges(size_t& nBins, float*& edges, const vector<double>& binning) {
   if (binning.size() < 3) {
@@ -478,7 +489,7 @@ void HLTMuonMatchAndPlot::fillMapFromPSet(map<string, T>& m, const ParameterSet&
       m[*iter] = targetPset.getUntrackedParameter<T>(*iter);
   }
 }
- 
+
 // A generic method to find the best deltaR matches from 2 collections.
 template <class T1, class T2>
 vector<size_t> HLTMuonMatchAndPlot::matchByDeltaR(const vector<T1>& collection1,
@@ -520,8 +531,7 @@ vector<size_t> HLTMuonMatchAndPlot::matchByDeltaR(const vector<T1>& collection1,
     }
 
     return result;
-  }
-  else {
+  } else {
     const size_t n1 = collection1.size();
     const size_t n2 = collection2.size();
 
@@ -539,7 +549,6 @@ vector<size_t> HLTMuonMatchAndPlot::matchByDeltaR(const vector<T1>& collection1,
   }
 }
 
- 
 MuonCollection HLTMuonMatchAndPlot::selectedMuons(const MuonCollection& allMuons,
                                                   const BeamSpot& beamSpot,
                                                   bool isTargetMuons,
@@ -566,8 +575,7 @@ MuonCollection HLTMuonMatchAndPlot::selectedMuons(const MuonCollection& allMuons
     }
 
     return reducedMuons;
-  }
-  else {
+  } else {
     MuonCollection reducedMuons;
     double RecoMuonEtaMax = isTargetMuons ? targetMuonEtaMax_ : probeMuonEtaMax_;
     for (auto const& mu : allMuons) {
@@ -578,7 +586,7 @@ MuonCollection HLTMuonMatchAndPlot::selectedMuons(const MuonCollection& allMuons
     return reducedMuons;
   }
 }
- 
+
 TriggerObjectCollection HLTMuonMatchAndPlot::selectedTriggerObjects(const TriggerObjectCollection& triggerObjects,
                                                                     const TriggerEvent& triggerSummary) const {
   InputTag filterTag(moduleLabel_, "", hltProcessName_);
@@ -596,7 +604,7 @@ TriggerObjectCollection HLTMuonMatchAndPlot::selectedTriggerObjects(const Trigge
 
   return selectedObjects;
 }
- 
+
 void HLTMuonMatchAndPlot::book1D(DQMStore::IBooker& iBooker, string name, const string& binningType, string title) {
   /* Properly delete the array of floats that has been allocated on
   * the heap by fillEdges.  Avoid multiple copies and internal ROOT
@@ -615,12 +623,12 @@ void HLTMuonMatchAndPlot::book1D(DQMStore::IBooker& iBooker, string name, const 
     delete[] edges;
   }
 }
- 
+
 void HLTMuonMatchAndPlot::book2D(DQMStore::IBooker& iBooker,
-                                const string& name,
-                                const string& binningTypeX,
-                                const string& binningTypeY,
-                                const string& title) {
+                                 const string& name,
+                                 const string& binningTypeX,
+                                 const string& binningTypeY,
+                                 const string& title) {
   /* Properly delete the arrays of floats that have been allocated on
   * the heap by fillEdges.  Avoid multiple copies and internal ROOT
   * clones by simply creating the histograms directly in the DQMStore
@@ -648,4 +656,3 @@ void HLTMuonMatchAndPlot::book2D(DQMStore::IBooker& iBooker,
     delete[] edgesY;
   }
 }
- 

--- a/DQMOffline/Trigger/src/HLTMuonMatchAndPlot.cc
+++ b/DQMOffline/Trigger/src/HLTMuonMatchAndPlot.cc
@@ -12,6 +12,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Common/interface/TriggerNames.h"
 #include "DataFormats/Candidate/interface/CandMatchMap.h"
+#include "DataFormats/MuonReco/interface/MuonSelectors.h"
+#include "DataFormats/Math/interface/deltaR.h"
 #include <boost/algorithm/string/replace.hpp>
 
 #include <iostream>
@@ -83,13 +85,14 @@ HLTMuonMatchAndPlot::HLTMuonMatchAndPlot(const ParameterSet& pset, string hltPat
   }
   delete objArray;
 }
-
+ 
 void HLTMuonMatchAndPlot::beginRun(DQMStore::IBooker& iBooker, const edm::Run& iRun, const edm::EventSetup& iSetup) {
   TPRegexp suffixPtCut("Mu[0-9]+$");
 
   string baseDir = destination_;
   if (baseDir[baseDir.size() - 1] != '/')
     baseDir += '/';
+    
   string pathSansSuffix = hltPath_;
   if (hltPath_.rfind("_v") < hltPath_.length())
     pathSansSuffix = hltPath_.substr(0, hltPath_.rfind("_v"));
@@ -99,8 +102,11 @@ void HLTMuonMatchAndPlot::beginRun(DQMStore::IBooker& iBooker, const edm::Run& i
   else
     iBooker.setCurrentFolder(baseDir + pathSansSuffix + "/" + moduleLabel_);
 
-  // Form is book1D(name, binningType, title) where 'binningType' is used
-  // to fetch the bin settings from binParams_.
+   // Form is book1D(name, binningType, title) where 'binningType' is used
+   // to fetch the bin settings from binParams_.
+ 
+  // Determine if this is a TnP analyzer instance or Global analyzer instance
+  bool isTnPAnalyzer = (destination_.find("DistributionsTnP") != string::npos);
 
   for (const auto& suffix : EFFICIENCY_SUFFIXES) {
     if (isLastFilter_)
@@ -108,10 +114,23 @@ void HLTMuonMatchAndPlot::beginRun(DQMStore::IBooker& iBooker, const edm::Run& i
     else
       iBooker.setCurrentFolder(baseDir + pathSansSuffix + "/" + moduleLabel_);
 
-    book1D(iBooker, "efficiencyEta_" + suffix, "eta", ";#eta;");
-    book1D(iBooker, "efficiencyPhi_" + suffix, "phi", ";#phi;");
-    book1D(iBooker, "efficiencyTurnOn_" + suffix, "pt", ";p_{T};");
-    book1D(iBooker, "efficiencyNVertex_" + suffix, "NVertex", ";NVertex;");
+    // Book Global plots only
+    if (!isTnPAnalyzer) {
+      book1D(iBooker, "efficiencyEta_" + suffix, "eta", ";#eta;");
+      book1D(iBooker, "efficiencyPhi_" + suffix, "phi", ";#phi;");
+      book1D(iBooker, "efficiencyTurnOn_" + suffix, "pt", ";p_{T};");
+      book1D(iBooker, "efficiencyNVertex_" + suffix, "NVertex", ";NVertex;");
+    }
+    
+    // Book TnP plots only if this IS a TnP analyzer
+    if (isTnPAnalyzer) {
+      book1D(iBooker, "efficiencyEtaTnP_" + suffix, "etaFine", ";#eta;");
+      book1D(iBooker, "efficiencyPtTnP_" + suffix, "pt", ";p_{T};");
+      book1D(iBooker, "efficiencyPhiTnP_" + suffix, "phi", ";#phi;");
+      book1D(iBooker, "efficiencyNVertexTnP_" + suffix, "NVertex", ";NVertex;");
+      book1D(iBooker, "efficiencyChargeTnP_" + suffix, "charge", ";charge;");
+      book1D(iBooker, "efficiencyZ0TnP_" + suffix, "z0", ";z0;");
+    }
 
     if (isLastFilter_)
       iBooker.setCurrentFolder(baseDir + pathSansSuffix);
@@ -121,164 +140,294 @@ void HLTMuonMatchAndPlot::beginRun(DQMStore::IBooker& iBooker, const edm::Run& i
     if (!isLastFilter_)
       continue;  //this will be plotted only for the last filter
 
-    book1D(iBooker, "efficiencyCharge_" + suffix, "charge", ";charge;");
-    book1D(iBooker, "efficiencyZ0_" + suffix, "z0", ";z0;");
-    book1D(iBooker, "efficiency_DZ_Mu_" + suffix, "z0", ";z0;");
+    // Book Global plots only 
+    if (!isTnPAnalyzer) {
+      book1D(iBooker, "efficiencyCharge_" + suffix, "charge", ";charge;");
+      book1D(iBooker, "efficiencyZ0_" + suffix, "z0", ";z0;");
+      book1D(iBooker, "efficiency_DZ_Mu_" + suffix, "z0", ";z0;");
+    }
   }
 }
-
+ 
 void HLTMuonMatchAndPlot::endRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {}
-
+ 
 void HLTMuonMatchAndPlot::analyze(Handle<MuonCollection>& allMuons,
-                                  Handle<BeamSpot>& beamSpot,
-                                  Handle<VertexCollection>& vertices,
-                                  Handle<TriggerEvent>& triggerSummary,
-                                  Handle<TriggerResults>& triggerResults,
-                                  const edm::TriggerNames& trigNames) {
-  /*
-  if(gen != 0) {
-    for(g_part = gen->begin(); g_part != gen->end(); g_part++){
-      if( abs(g_part->pdgId()) ==  13) {
-        if(!( g_part->status() ==1 || (g_part->status() ==2 && abs(g_part->pdgId())==5))) continue;
-        bool GenMomExists  (true);
-        bool GenGrMomExists(true);
-        if( g_part->pt() < 10.0 )  continue;
-        if( fabs(g_part->eta()) > 2.4 ) continue;
-        int gen_id= g_part->pdgId();
-        const GenParticle* gen_lept = &(*g_part);
-        // get mother of gen_lept
-        const GenParticle* gen_mom = static_cast<const GenParticle*> (gen_lept->mother());
-        if(gen_mom==NULL) GenMomExists=false;
-        int m_id=-999;
-        if(GenMomExists) m_id = gen_mom->pdgId();
-        if(m_id != gen_id || !GenMomExists);
-        else{
-          int id= m_id;
-          while(id == gen_id && GenMomExists){
-            gen_mom = static_cast<const GenParticle*> (gen_mom->mother());
-            if(gen_mom==NULL){
-              GenMomExists=false;
+                                   Handle<BeamSpot>& beamSpot,
+                                   Handle<VertexCollection>& vertices,
+                                   Handle<TriggerEvent>& triggerSummary,
+                                   Handle<TriggerResults>& triggerResults,
+                                   const edm::TriggerNames& trigNames) {
+ 
+  // Determine if this is a TnP analyzer instance
+  bool isTnPAnalyzer = (destination_.find("DistributionsTnP") != string::npos);
+
+  if (!isTnPAnalyzer) {
+    // Select objects based on the configuration.
+    MuonCollection targetMuons = selectedMuons(*allMuons, *beamSpot, true, isTnPAnalyzer);
+    TriggerObjectCollection allTriggerObjects = triggerSummary->getObjects();
+    TriggerObjectCollection hltMuons = selectedTriggerObjects(allTriggerObjects, *triggerSummary);
+
+    // Find the best trigger object matches for the targetMuons.
+    vector<size_t> matches = matchByDeltaR(targetMuons, hltMuons, plotCuts_[triggerLevel_ + "DeltaR"], isTnPAnalyzer);
+ 
+    for (size_t i = 0; i < targetMuons.size(); i++) {
+      Muon& muon = targetMuons[i];
+
+      // Fill numerators and denominators for efficiency plots (Global plots only)
+      for (const auto& suffix : EFFICIENCY_SUFFIXES) {
+        // If no match was found, then the numerator plots don't get filled.
+        if (suffix == "numer" && matches[i] >= targetMuons.size())
+          continue;
+
+        if (muon.pt() > cutMinPt_) {
+          hists_["efficiencyEta_" + suffix]->Fill(muon.eta());
+        }
+
+        if (fabs(muon.eta()) < plotCuts_["maxEta"]) {
+          hists_["efficiencyTurnOn_" + suffix]->Fill(muon.pt());
+        }
+
+        if (muon.pt() > cutMinPt_ && fabs(muon.eta()) < plotCuts_["maxEta"]) {
+          const Track* track = nullptr;
+          if (muon.isTrackerMuon())
+            track = &*muon.innerTrack();
+          else if (muon.isStandAloneMuon())
+            track = &*muon.outerTrack();
+          if (track) {
+            hists_["efficiencyNVertex_" + suffix]->Fill(vertices->size());
+            hists_["efficiencyPhi_" + suffix]->Fill(muon.phi());
+
+            if (isLastFilter_) {
+              hists_["efficiencyZ0_" + suffix]->Fill(track->dz(beamSpot->position()));
+              hists_["efficiencyCharge_" + suffix]->Fill(muon.charge());
             }
-            if(GenMomExists) id=gen_mom->pdgId();
           }
         }
-        if(GenMomExists) m_id = gen_mom->pdgId();
-        gen_leptsp.push_back(gen_lept);
-        gen_momsp.push_back(gen_mom);
+      }  // finish loop numerator / denominator...
+ 
+      if (!isLastFilter_)
+        continue;
+      // Fill plots for tag and probe
+      // Muon cannot be a tag because doesn't match an hlt muon
+      if (matches[i] >= targetMuons.size())
+        continue;
+    }  // End loop over targetMuons.
+
+    // fill eff histograms for reference trigger method (Global analyzer only)
+    // Denominator: events passing reference trigger and two target muons
+    // Numerator:   events in the denominator with two target muons
+    // matched to hlt muons
+    if (!isLastFilter_)
+      return;
+
+    // Only fill DZ efficiency for Global analyzer
+    unsigned int numTriggers = trigNames.size();
+
+    int nMatched = 0;
+    for (unsigned long matche : matches) {
+      if (matche < targetMuons.size())
+        nMatched++;
+    }
+
+    string nonDZPath = hltPath_;
+    bool dzPath = false;
+    if (nonDZPath.rfind("_DZ") < nonDZPath.length()) {
+      dzPath = true;
+      nonDZPath = boost::replace_all_copy<string>(nonDZPath, "_DZ", "");
+      nonDZPath = nonDZPath.substr(0, nonDZPath.rfind("_v") + 2);
+    }
+    bool passTriggerDZ = false;
+
+    if (dzPath) {
+      for (unsigned int hltIndex = 0; hltIndex < numTriggers; ++hltIndex) {
+        passTriggerDZ = passTriggerDZ || (trigNames.triggerName(hltIndex).find(nonDZPath) != std::string::npos &&
+                                          triggerResults->wasrun(hltIndex) && triggerResults->accept(hltIndex));
+      }
+    }
+    if (dzPath && targetMuons.size() > 1 && passTriggerDZ) {
+      const Track* track0 = nullptr;
+      const Track* track1 = nullptr;
+      if (targetMuons.at(0).isTrackerMuon())
+        track0 = &*targetMuons.at(0).innerTrack();
+      else if (targetMuons.at(0).isStandAloneMuon())
+        track0 = &*targetMuons.at(0).outerTrack();
+      if (targetMuons.at(1).isTrackerMuon())
+        track1 = &*targetMuons.at(1).innerTrack();
+      else if (targetMuons.at(1).isStandAloneMuon())
+        track1 = &*targetMuons.at(1).outerTrack();
+
+      if (track0 && track1) {
+        hists_["efficiency_DZ_Mu_denom"]->Fill(track0->dz(beamSpot->position()) - track1->dz(beamSpot->position()));
+        if (nMatched > 1) {
+          hists_["efficiency_DZ_Mu_numer"]->Fill(track0->dz(beamSpot->position()) - track1->dz(beamSpot->position()));
+        }
       }
     }
   }
-  std::vector<GenParticle> gen_lepts;
-  for(size_t i = 0; i < gen_leptsp.size(); i++) {
-    gen_lepts.push_back(*gen_leptsp[i]);
-  }
-  */
 
-  // Select objects based on the configuration.
-  MuonCollection targetMuons = selectedMuons(*allMuons, *beamSpot, true);
-  MuonCollection probeMuons = selectedMuons(*allMuons, *beamSpot, false);
-  TriggerObjectCollection allTriggerObjects = triggerSummary->getObjects();
-  TriggerObjectCollection hltMuons = selectedTriggerObjects(allTriggerObjects, *triggerSummary);
-  // Fill plots for HLT muons.
+  // TnP Efficiency Measurement
+  if (isTnPAnalyzer) {
+    // offline muons within eta cut
+    MuonCollection targetMuons = selectedMuons(*allMuons, *beamSpot, true, isTnPAnalyzer);
+    TriggerObjectCollection allTriggerObjects = triggerSummary->getObjects();
+    // collection of selected trigger objects
+    TriggerObjectCollection hltMuons = selectedTriggerObjects(allTriggerObjects, *triggerSummary);
 
-  // Find the best trigger object matches for the targetMuons.
-  vector<size_t> matches = matchByDeltaR(targetMuons, hltMuons, plotCuts_[triggerLevel_ + "DeltaR"]);
+    // Find the best trigger object matches for the targetMuons.
+    vector<size_t> matches = matchByDeltaR(targetMuons, hltMuons, plotCuts_[triggerLevel_ + "DeltaR"], isTnPAnalyzer);
 
-  // Fill plots for matched muons.
-  for (size_t i = 0; i < targetMuons.size(); i++) {
-    Muon& muon = targetMuons[i];
+    // looping over selected offline muons
+    for (size_t i = 0; i < targetMuons.size(); ++i) {
+      Muon& tagCandidate = targetMuons[i];
 
-    // Fill numerators and denominators for efficiency plots.
-    for (const auto& suffix : EFFICIENCY_SUFFIXES) {
-      // If no match was found, then the numerator plots don't get filled.
-      if (suffix == "numer" && matches[i] >= targetMuons.size())
+      // Tag muon selection criteria
+      if (!isTagMuon(tagCandidate, *beamSpot, *vertices, *triggerSummary, *triggerResults, trigNames))
         continue;
 
-      if (muon.pt() > cutMinPt_) {
-        hists_["efficiencyEta_" + suffix]->Fill(muon.eta());
-      }
+      for (size_t j = 0; j < targetMuons.size(); ++j) {
+        if (i == j) continue;
 
-      if (fabs(muon.eta()) < plotCuts_["maxEta"]) {
-        hists_["efficiencyTurnOn_" + suffix]->Fill(muon.pt());
-      }
+        Muon& probeCandidate = targetMuons[j];
 
-      if (muon.pt() > cutMinPt_ && fabs(muon.eta()) < plotCuts_["maxEta"]) {
+        // Probe muon selection criteria
+        if (!isProbeMuon(probeCandidate, *vertices))
+          continue;
+
+        // Requiring oppositly charger tag and probe pair
+        if (tagCandidate.charge() * probeCandidate.charge() > 0)
+          continue;
+
+        // Requiring invariant mass between 81 and 101 GeV
+        double invMass = calculateInvariantMass(tagCandidate, probeCandidate);
+        if (invMass < 81.0 || invMass > 101.0)
+          continue;
+
+        double pTCutProbe = 0.;
+        if (hltPath_.find("Mu50") != string::npos || hltPath_.find("CascadeMu100") != string::npos || hltPath_.find("HighPtTkMu100") != string::npos)
+          pTCutProbe = 52.;
+        else if (hltPath_.find("Mu24") != string::npos)
+          pTCutProbe = 26.;
+        else if (hltPath_.find("Mu8") != string::npos)
+          pTCutProbe = 10.;
+        
+        // Find track of probe muon to fill the track-based information
         const Track* track = nullptr;
-        if (muon.isTrackerMuon())
-          track = &*muon.innerTrack();
-        else if (muon.isStandAloneMuon())
-          track = &*muon.outerTrack();
-        if (track) {
-          hists_["efficiencyNVertex_" + suffix]->Fill(vertices->size());
-          hists_["efficiencyPhi_" + suffix]->Fill(muon.phi());
+        if (probeCandidate.isTrackerMuon() || probeCandidate.isGlobalMuon())
+          track = &*probeCandidate.innerTrack();
+        else if (probeCandidate.isStandAloneMuon())
+          track = &*probeCandidate.outerTrack();
 
-          if (isLastFilter_) {
-            hists_["efficiencyZ0_" + suffix]->Fill(track->dz(beamSpot->position()));
-            hists_["efficiencyCharge_" + suffix]->Fill(muon.charge());
+        // Fill denominator histograms
+        std::string denomSuffix = "denom";
+        hists_["efficiencyPtTnP_" + denomSuffix]->Fill(probeCandidate.pt());
+        if (probeCandidate.pt() > pTCutProbe) {
+          hists_["efficiencyEtaTnP_" + denomSuffix]->Fill(probeCandidate.eta());
+          hists_["efficiencyPhiTnP_" + denomSuffix]->Fill(probeCandidate.phi());
+          
+          if (track) {
+            hists_["efficiencyChargeTnP_" + denomSuffix]->Fill(probeCandidate.charge());
+            hists_["efficiencyNVertexTnP_" + denomSuffix]->Fill(vertices->size());
+            hists_["efficiencyZ0TnP_" + denomSuffix]->Fill(track->dz(beamSpot->position()));
+          }
+        }
+
+        // Check if probe muon passes HLT
+        if (matches[j] == (size_t)(-1)) 
+          continue;
+          
+        // Fill numerator histograms
+        std::string numerSuffix = "numer";
+        hists_["efficiencyPtTnP_" + numerSuffix]->Fill(probeCandidate.pt());
+        if (probeCandidate.pt() > pTCutProbe) {
+          hists_["efficiencyEtaTnP_" + numerSuffix]->Fill(probeCandidate.eta());
+          hists_["efficiencyPhiTnP_" + numerSuffix]->Fill(probeCandidate.phi());
+
+          if (track) {
+            hists_["efficiencyChargeTnP_" + numerSuffix]->Fill(probeCandidate.charge());
+            hists_["efficiencyZ0TnP_" + numerSuffix]->Fill(track->dz(beamSpot->position()));
+            hists_["efficiencyNVertexTnP_" + numerSuffix]->Fill(vertices->size());
           }
         }
       }
-    }  // finish loop numerator / denominator...
-
-    if (!isLastFilter_)
-      continue;
-    // Fill plots for tag and probe
-    // Muon cannot be a tag because doesn't match an hlt muon
-    if (matches[i] >= targetMuons.size())
-      continue;
-  }  // End loop over targetMuons.
-
-  // fill eff histograms for reference trigger method
-  // Denominator: events passing reference trigger and two target muons
-  // Numerator:   events in the denominator with two target muons
-  // matched to hlt muons
-  if (!isLastFilter_)
-    return;
-  unsigned int numTriggers = trigNames.size();
-
-  int nMatched = 0;
-  for (unsigned long matche : matches) {
-    if (matche < targetMuons.size())
-      nMatched++;
-  }
-
-  string nonDZPath = hltPath_;
-  bool dzPath = false;
-  if (nonDZPath.rfind("_DZ") < nonDZPath.length()) {
-    dzPath = true;
-    nonDZPath = boost::replace_all_copy<string>(nonDZPath, "_DZ", "");
-    nonDZPath = nonDZPath.substr(0, nonDZPath.rfind("_v") + 2);
-  }
-  bool passTriggerDZ = false;
-
-  if (dzPath) {
-    for (unsigned int hltIndex = 0; hltIndex < numTriggers; ++hltIndex) {
-      passTriggerDZ = passTriggerDZ || (trigNames.triggerName(hltIndex).find(nonDZPath) != std::string::npos &&
-                                        triggerResults->wasrun(hltIndex) && triggerResults->accept(hltIndex));
     }
   }
-  if (dzPath && targetMuons.size() > 1 && passTriggerDZ) {
-    const Track* track0 = nullptr;
-    const Track* track1 = nullptr;
-    if (targetMuons.at(0).isTrackerMuon())
-      track0 = &*targetMuons.at(0).innerTrack();
-    else if (targetMuons.at(0).isStandAloneMuon())
-      track0 = &*targetMuons.at(0).outerTrack();
-    if (targetMuons.at(1).isTrackerMuon())
-      track1 = &*targetMuons.at(1).innerTrack();
-    else if (targetMuons.at(1).isStandAloneMuon())
-      track1 = &*targetMuons.at(1).outerTrack();
+}  // End analyze() method.
+ 
+// Tag and Probe helper function implementations
+bool HLTMuonMatchAndPlot::isTightMuonID(const reco::Muon& muon, const reco::VertexCollection& vertices) const {
+  if (vertices.empty()) return false;
+  const reco::Vertex& primaryVertex = vertices.front();
+  return muon::isTightMuon(muon, primaryVertex);
+}
+ 
+bool HLTMuonMatchAndPlot::isTightPFIsolation(const reco::Muon& muon) const {
+  // Tight PF isolation
+  const double isoCut = 0.15;
+  reco::MuonPFIsolation pfIso = muon.pfIsolationR04();
+  double relativeIso = (pfIso.sumChargedHadronPt + 
+                      std::max(0.0, pfIso.sumNeutralHadronEt + pfIso.sumPhotonEt - 0.5 * pfIso.sumPUPt)) / muon.pt();
+  return relativeIso < isoCut;
+}
 
-    if (track0 && track1) {
-      hists_["efficiency_DZ_Mu_denom"]->Fill(track0->dz(beamSpot->position()) - track1->dz(beamSpot->position()));
-      if (nMatched > 1) {
-        hists_["efficiency_DZ_Mu_numer"]->Fill(track0->dz(beamSpot->position()) - track1->dz(beamSpot->position()));
+// Check if muon passes trigger matching (IsoMu24)
+bool HLTMuonMatchAndPlot::passTriggerMatching(const reco::Muon& muon, const trigger::TriggerEvent& triggerSummary,
+                                              const std::string& triggerPath, double deltaRCut) const {
+
+  trigger::TriggerObjectCollection allTriggerObjects = triggerSummary.getObjects();
+  trigger::TriggerObjectCollection hltMuons;
+
+  for (size_t i = 0; i < triggerSummary.sizeFilters(); ++i) {
+    std::string filterLabel = triggerSummary.filterTag(i).label();
+    if (filterLabel.find(triggerPath) != std::string::npos) {
+      const trigger::Keys& keys = triggerSummary.filterKeys(i);
+      for (auto key : keys) {
+        if (key < allTriggerObjects.size()) {
+          hltMuons.push_back(allTriggerObjects[key]);
+        }
       }
     }
   }
+ 
+  // Check if muon matches any HLT muon object within deltaR cut
+  for (const auto& hltMuon : hltMuons) {
+    double dR = deltaR(muon.eta(), muon.phi(), hltMuon.eta(), hltMuon.phi());
+    if (dR < deltaRCut) {
+      return true;
+    }
+  }
+   
+  return false;
+}
+ 
+bool HLTMuonMatchAndPlot::isTagMuon(const reco::Muon& muon, const reco::BeamSpot& beamSpot, 
+                                  const reco::VertexCollection& vertices,
+                                  const trigger::TriggerEvent& triggerSummary, const edm::TriggerResults& triggerResults,
+                                  const edm::TriggerNames& trigNames) const {
+  // Tag muon selection criteria:
+  if (muon.pt() <= 27.0) return false;
+  if (!isTightMuonID(muon, vertices)) return false;
+  if (!isTightPFIsolation(muon)) return false;
+  if (!passTriggerMatching(muon, triggerSummary, "IsoMu24", 0.1)) return false;
 
-}  // End analyze() method.
+  return true;
+ }
+ 
+bool HLTMuonMatchAndPlot::isProbeMuon(const reco::Muon& muon, const reco::VertexCollection& vertices) const {
 
+  if (!isTightMuonID(muon, vertices)) return false;
+  
+  if (!isTightPFIsolation(muon)) return false;
+  
+  return true;
+}
+ 
+double HLTMuonMatchAndPlot::calculateInvariantMass(const reco::Muon& muon1, const reco::Muon& muon2) const {
+  math::XYZTLorentzVector p4_1 = muon1.p4();
+  math::XYZTLorentzVector p4_2 = muon2.p4();
+  math::XYZTLorentzVector p4_total = p4_1 + p4_2;
+  return p4_total.mass();
+}
+ 
 // Method to fill binning parameters from a vector of doubles.
 bool HLTMuonMatchAndPlot::fillEdges(size_t& nBins, float*& edges, const vector<double>& binning) {
   if (binning.size() < 3) {
@@ -329,76 +478,109 @@ void HLTMuonMatchAndPlot::fillMapFromPSet(map<string, T>& m, const ParameterSet&
       m[*iter] = targetPset.getUntrackedParameter<T>(*iter);
   }
 }
-
+ 
 // A generic method to find the best deltaR matches from 2 collections.
 template <class T1, class T2>
 vector<size_t> HLTMuonMatchAndPlot::matchByDeltaR(const vector<T1>& collection1,
                                                   const vector<T2>& collection2,
-                                                  const double maxDeltaR) {
-  const size_t n1 = collection1.size();
-  const size_t n2 = collection2.size();
+                                                  const double maxDeltaR,
+                                                  bool isTnPAnalyzer) {
+  if (!isTnPAnalyzer) {
+    const size_t n1 = collection1.size();
+    const size_t n2 = collection2.size();
 
-  vector<size_t> result(n1, -1);
-  vector<vector<double> > deltaRMatrix(n1, vector<double>(n2, NOMATCH));
+    vector<size_t> result(n1, -1);
+    vector<vector<double> > deltaRMatrix(n1, vector<double>(n2, NOMATCH));
 
-  for (size_t i = 0; i < n1; i++)
-    for (size_t j = 0; j < n2; j++) {
-      deltaRMatrix[i][j] = deltaR(collection1[i], collection2[j]);
-    }
-
-  // Run through the matrix n1 times to make sure we've found all matches.
-  for (size_t k = 0; k < n1; k++) {
-    size_t i_min = -1;
-    size_t j_min = -1;
-    double minDeltaR = maxDeltaR;
-    // find the smallest deltaR
     for (size_t i = 0; i < n1; i++)
-      for (size_t j = 0; j < n2; j++)
-        if (deltaRMatrix[i][j] < minDeltaR) {
-          i_min = i;
-          j_min = j;
-          minDeltaR = deltaRMatrix[i][j];
-        }
-    // If a match has been made, save it and make those candidates unavailable.
-    if (minDeltaR < maxDeltaR) {
-      result[i_min] = j_min;
-      deltaRMatrix[i_min] = vector<double>(n2, NOMATCH);
-      for (size_t i = 0; i < n1; i++)
-        deltaRMatrix[i][j_min] = NOMATCH;
-    }
-  }
+      for (size_t j = 0; j < n2; j++) {
+        deltaRMatrix[i][j] = deltaR(collection1[i], collection2[j]);
+      }
 
-  return result;
+    // Run through the matrix n1 times to make sure we've found all matches.
+    for (size_t k = 0; k < n1; k++) {
+      size_t i_min = -1;
+      size_t j_min = -1;
+      double minDeltaR = maxDeltaR;
+      // find the smallest deltaR
+      for (size_t i = 0; i < n1; i++)
+        for (size_t j = 0; j < n2; j++)
+          if (deltaRMatrix[i][j] < minDeltaR) {
+            i_min = i;
+            j_min = j;
+            minDeltaR = deltaRMatrix[i][j];
+          }
+      // If a match has been made, save it and make those candidates unavailable.
+      if (minDeltaR < maxDeltaR) {
+        result[i_min] = j_min;
+        deltaRMatrix[i_min] = vector<double>(n2, NOMATCH);
+        for (size_t i = 0; i < n1; i++)
+          deltaRMatrix[i][j_min] = NOMATCH;
+      }
+    }
+
+    return result;
+  }
+  else {
+    const size_t n1 = collection1.size();
+    const size_t n2 = collection2.size();
+
+    vector<size_t> result(n1, -1);
+
+    for (size_t i = 0; i < n1; i++) {
+      for (size_t j = 0; j < n2; j++) {
+        if (deltaR(collection1[i], collection2[j]) < maxDeltaR) {
+          result[i] = j;
+          break;
+        }
+      }
+    }
+    return result;
+  }
 }
 
+ 
 MuonCollection HLTMuonMatchAndPlot::selectedMuons(const MuonCollection& allMuons,
                                                   const BeamSpot& beamSpot,
-                                                  bool isTargetMuons) {
-  MuonCollection reducedMuons;
-  double RecoMuonEtaMax = isTargetMuons ? targetMuonEtaMax_ : probeMuonEtaMax_;
-  double RecoMuonEtaMin = isTargetMuons ? targetMuonEtaMin_ : probeMuonEtaMin_;
-  bool IsMuonGlb = isTargetMuons ? targetIsMuonGlb_ : probeIsMuonGlb_;
-  double d0Cut = isTargetMuons ? targetD0Cut_ : probeD0Cut_;
-  double z0Cut = isTargetMuons ? targetZ0Cut_ : probeZ0Cut_;
+                                                  bool isTargetMuons,
+                                                  bool isTnPAnalyzer) {
+  if (!isTnPAnalyzer) {
+    MuonCollection reducedMuons;
+    double RecoMuonEtaMax = isTargetMuons ? targetMuonEtaMax_ : probeMuonEtaMax_;
+    double RecoMuonEtaMin = isTargetMuons ? targetMuonEtaMin_ : probeMuonEtaMin_;
+    bool IsMuonGlb = isTargetMuons ? targetIsMuonGlb_ : probeIsMuonGlb_;
+    double d0Cut = isTargetMuons ? targetD0Cut_ : probeD0Cut_;
+    double z0Cut = isTargetMuons ? targetZ0Cut_ : probeZ0Cut_;
 
-  for (auto const& mu : allMuons) {
-    const Track* track = nullptr;
-    if (mu.isTrackerMuon())
-      track = &*mu.innerTrack();
-    else if (mu.isStandAloneMuon())
-      track = &*mu.outerTrack();
-    // minimun ID (requested for cosmics) is being a StandAlone muon
-    bool muID = IsMuonGlb ? mu.isGlobalMuon() : mu.isStandAloneMuon();
-    if (track && muID && abs(mu.eta()) < RecoMuonEtaMax && abs(mu.eta()) >= RecoMuonEtaMin &&
-        fabs(track->dxy(beamSpot.position())) < d0Cut && fabs(track->dz(beamSpot.position())) < z0Cut)
-      reducedMuons.push_back(mu);
+    for (auto const& mu : allMuons) {
+      const Track* track = nullptr;
+      if (mu.isTrackerMuon())
+        track = &*mu.innerTrack();
+      else if (mu.isStandAloneMuon())
+        track = &*mu.outerTrack();
+      // minimun ID (requested for cosmics) is being a StandAlone muon
+      bool muID = IsMuonGlb ? mu.isGlobalMuon() : mu.isStandAloneMuon();
+      if (track && muID && abs(mu.eta()) < RecoMuonEtaMax && abs(mu.eta()) >= RecoMuonEtaMin &&
+          fabs(track->dxy(beamSpot.position())) < d0Cut && fabs(track->dz(beamSpot.position())) < z0Cut)
+        reducedMuons.push_back(mu);
+    }
+
+    return reducedMuons;
   }
+  else {
+    MuonCollection reducedMuons;
+    double RecoMuonEtaMax = isTargetMuons ? targetMuonEtaMax_ : probeMuonEtaMax_;
+    for (auto const& mu : allMuons) {
+      if (fabs(mu.eta()) < RecoMuonEtaMax)
+        reducedMuons.push_back(mu);
+    }
 
-  return reducedMuons;
+    return reducedMuons;
+  }
 }
-
+ 
 TriggerObjectCollection HLTMuonMatchAndPlot::selectedTriggerObjects(const TriggerObjectCollection& triggerObjects,
-                                                                    const TriggerEvent& triggerSummary) {
+                                                                    const TriggerEvent& triggerSummary) const {
   InputTag filterTag(moduleLabel_, "", hltProcessName_);
   size_t filterIndex = triggerSummary.filterIndex(filterTag);
 
@@ -414,13 +596,13 @@ TriggerObjectCollection HLTMuonMatchAndPlot::selectedTriggerObjects(const Trigge
 
   return selectedObjects;
 }
-
+ 
 void HLTMuonMatchAndPlot::book1D(DQMStore::IBooker& iBooker, string name, const string& binningType, string title) {
   /* Properly delete the array of floats that has been allocated on
-   * the heap by fillEdges.  Avoid multiple copies and internal ROOT
-   * clones by simply creating the histograms directly in the DQMStore
-   * using the appropriate book1D method to handle the variable bins
-   * case. */
+  * the heap by fillEdges.  Avoid multiple copies and internal ROOT
+  * clones by simply creating the histograms directly in the DQMStore
+  * using the appropriate book1D method to handle the variable bins
+  * case. */
 
   size_t nBins;
   float* edges = nullptr;
@@ -433,17 +615,17 @@ void HLTMuonMatchAndPlot::book1D(DQMStore::IBooker& iBooker, string name, const 
     delete[] edges;
   }
 }
-
+ 
 void HLTMuonMatchAndPlot::book2D(DQMStore::IBooker& iBooker,
-                                 const string& name,
-                                 const string& binningTypeX,
-                                 const string& binningTypeY,
-                                 const string& title) {
+                                const string& name,
+                                const string& binningTypeX,
+                                const string& binningTypeY,
+                                const string& title) {
   /* Properly delete the arrays of floats that have been allocated on
-   * the heap by fillEdges.  Avoid multiple copies and internal ROOT
-   * clones by simply creating the histograms directly in the DQMStore
-   * using the appropriate book2D method to handle the variable bins
-   * case. */
+  * the heap by fillEdges.  Avoid multiple copies and internal ROOT
+  * clones by simply creating the histograms directly in the DQMStore
+  * using the appropriate book2D method to handle the variable bins
+  * case. */
 
   size_t nBinsX;
   float* edgesX = nullptr;
@@ -466,3 +648,4 @@ void HLTMuonMatchAndPlot::book2D(DQMStore::IBooker& iBooker,
     delete[] edgesY;
   }
 }
+ 


### PR DESCRIPTION
#### PR description:

This PR is for adding tag-and-probe efficiency on Muon HLT offline DQM. 

As reported and discussed on [TSG](https://indico.cern.ch/event/1635530/#sc-1-5-muon-pog) and [MuonPOG](https://indico.cern.ch/event/1638450/#17-hlt-dqm-with-multirun-harve) meeting, original DQM plots are kept unchanged while adding the new plots.

#### PR validation:

In order to validate this PR, below commands are suggested.

```cmsDriver.py step3 -s RAW2DIGI,L1Reco,RECO,PAT,DQM:@standardDQM+@miniAODDQM --conditions 150X_dataRun3_Prompt_v1 -n 30 --datatier DQMIO --data --eventcontent DQM --era Run3_2025 --filein /store/data/Run2025G/Muon0/RAW/v1/000/397/954/00000/11cdedf5-d5ec-46bd-8292-7884460971bb.root```

```cmsDriver.py step4 -s HARVESTING:@standardDQM+@miniAODDQM --conditions 150X_dataRun3_Prompt_v1 --filetype DQM --era Run3_2025 -n -1 --filein file:step3_RAW2DIGI_L1Reco_RECO_PAT_DQM.root```

After running both commands, there is an output named `DQM_V0001_R000397954__Global__CMSSW_X_Y_Z__RECO.root`. By exploring this ROOT file and checking whether plots are saved correctly under `HLT/Run Summary/Muon/DistributionsTnP`, validation could be done.

Following the [PRWorkflow](https://cms-sw.github.io/PRWorkflow.html), tests were done. `scram b runtests use-ibeos` was successfully done and also `runTheMatrix.py -l limited -i all --ibeos` was done without errors.
