### PR TITLE
LST: Adding GenJets to LST with indexing

### DIFF
--- a/RecoTracker/LSTCore/standalone/bin/lst.cc
+++ b/RecoTracker/LSTCore/standalone/bin/lst.cc
@@ -311,8 +311,8 @@ int main(int argc, char **argv) {
   ana.t4dnn_branches = result["t4dnn"].as<bool>() || result["allobj"].as<bool>();
 
   //_______________________________________________________________________________
-  // --jet
-  ana.jet_branches = result["jet"].as<bool>() || result["allobj"].as<bool>();
+  // --jet (Not triggered by allobj since most files don't have jet info)
+  ana.jet_branches = result["jet"].as<bool>();
 
   //_______________________________________________________________________________
   // --sim

--- a/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
@@ -48,6 +48,9 @@ void fillOutputBranches(LSTEvent* event) {
 
   unsigned int n_accepted_simtrk = setSimTrackContainerBranches(event);
 
+  if (ana.jet_branches)
+    setGenJetBranches(event);
+
   if (ana.occ_branches)
     setOccupancyBranches(event);
 
@@ -192,12 +195,13 @@ void createT4DNNBranches() {
 
 //________________________________________________________________________________________________________________________________
 void createJetBranches() {
-  ana.tx->createBranch<std::vector<float>>("sim_deltaEta");
-  ana.tx->createBranch<std::vector<float>>("sim_deltaPhi");
-  ana.tx->createBranch<std::vector<float>>("sim_deltaR");
-  ana.tx->createBranch<std::vector<float>>("sim_jet_eta");
-  ana.tx->createBranch<std::vector<float>>("sim_jet_phi");
-  ana.tx->createBranch<std::vector<float>>("sim_jet_pt");
+  ana.tx->createBranch<std::vector<float>>("sim_genjet_deltaEta");
+  ana.tx->createBranch<std::vector<float>>("sim_genjet_deltaPhi");
+  ana.tx->createBranch<std::vector<float>>("sim_genjet_deltaR");
+  ana.tx->createBranch<std::vector<int>>("sim_genjet_idx");
+  ana.tx->createBranch<std::vector<float>>("genjet_eta");
+  ana.tx->createBranch<std::vector<float>>("genjet_phi");
+  ana.tx->createBranch<std::vector<float>>("genjet_pt");
 }
 
 //________________________________________________________________________________________________________________________________
@@ -617,6 +621,27 @@ void createOccupancyBranches() {
 }
 
 //________________________________________________________________________________________________________________________________
+void setGenJetBranches(LSTEvent* event) {
+  //--------------------------------------------
+  //
+  //
+  // Gen Jets
+  //
+  //
+  //--------------------------------------------
+
+  auto const& trk_genjet_eta = trk.getVF("genjet_eta");
+  auto const& trk_genjet_phi = trk.getVF("genjet_phi");
+  auto const& trk_genjet_pt = trk.getVF("genjet_pt");
+
+  for (unsigned int ijet = 0; ijet < trk_genjet_pt.size(); ++ijet) {
+    ana.tx->pushbackToBranch<float>("genjet_eta", trk_genjet_eta[ijet]);
+    ana.tx->pushbackToBranch<float>("genjet_phi", trk_genjet_phi[ijet]);
+    ana.tx->pushbackToBranch<float>("genjet_pt", trk_genjet_pt[ijet]);
+  }
+}
+
+//________________________________________________________________________________________________________________________________
 unsigned int setSimTrackContainerBranches(LSTEvent* event) {
   //--------------------------------------------
   //
@@ -669,19 +694,15 @@ unsigned int setSimTrackContainerBranches(LSTEvent* event) {
     // Now we have a list of "accepted" tracks (no condition on vtx_z/perp, nor pt, eta etc are applied yet)
 
     if (ana.jet_branches) {
-      auto const& trk_sim_deltaEta = trk.getVF("sim_deltaEta");
-      auto const& trk_sim_deltaPhi = trk.getVF("sim_deltaPhi");
-      auto const& trk_sim_deltaR = trk.getVF("sim_deltaR");
-      auto const& trk_sim_jet_eta = trk.getVF("sim_jet_eta");
-      auto const& trk_sim_jet_phi = trk.getVF("sim_jet_phi");
-      auto const& trk_sim_jet_pt = trk.getVF("sim_jet_pt");
+      auto const& trk_sim_genjet_deltaEta = trk.getVF("sim_genjet_deltaEta");
+      auto const& trk_sim_genjet_deltaPhi = trk.getVF("sim_genjet_deltaPhi");
+      auto const& trk_sim_genjet_deltaR = trk.getVF("sim_genjet_deltaR");
+      auto const& trk_sim_genjet_idx = trk.getVI("sim_genjet_idx");
 
-      ana.tx->pushbackToBranch<float>("sim_deltaEta", trk_sim_deltaEta[isimtrk]);
-      ana.tx->pushbackToBranch<float>("sim_deltaPhi", trk_sim_deltaPhi[isimtrk]);
-      ana.tx->pushbackToBranch<float>("sim_deltaR", trk_sim_deltaR[isimtrk]);
-      ana.tx->pushbackToBranch<float>("sim_jet_eta", trk_sim_jet_eta[isimtrk]);
-      ana.tx->pushbackToBranch<float>("sim_jet_phi", trk_sim_jet_phi[isimtrk]);
-      ana.tx->pushbackToBranch<float>("sim_jet_pt", trk_sim_jet_pt[isimtrk]);
+      ana.tx->pushbackToBranch<float>("sim_genjet_deltaEta", trk_sim_genjet_deltaEta[isimtrk]);
+      ana.tx->pushbackToBranch<float>("sim_genjet_deltaPhi", trk_sim_genjet_deltaPhi[isimtrk]);
+      ana.tx->pushbackToBranch<float>("sim_genjet_deltaR", trk_sim_genjet_deltaR[isimtrk]);
+      ana.tx->pushbackToBranch<int>("sim_genjet_idx", trk_sim_genjet_idx[isimtrk]);
     }
 
     // Fill the branch with simulated tracks.

--- a/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.h
+++ b/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.h
@@ -33,6 +33,7 @@ void createOccupancyBranches();
 
 void fillOutputBranches(LSTEvent* event);
 void setOccupancyBranches(LSTEvent* event);
+void setGenJetBranches(LSTEvent* event);
 unsigned int setSimTrackContainerBranches(LSTEvent* event);
 void setTrackCandidateBranches(LSTEvent* event,
                                unsigned int n_accepted_tracks,

--- a/RecoTracker/LSTCore/standalone/efficiency/bin/lst_timing
+++ b/RecoTracker/LSTCore/standalone/efficiency/bin/lst_timing
@@ -146,8 +146,8 @@ if [ -z "${SPECIFICGPUVERSION}" ] || [[ "${SPECIFICGPUVERSION}" == "explicit" ]]
 fi
 
 echo "Total Timing Summary"
-grep -h "Time for map " timing_temp.txt | cut -d " " -f 6 | awk '{ SUM += $1} END { print "Average time for map loading =",SUM/5,"ms" }' # 5 is the number of stream values run
-grep -h "Time for input " timing_temp.txt | cut -d " " -f 6 | awk '{ SUM += $1} END { print "Average time for input loading =",SUM/5,"ms" }' # 5 is the number of stream values run
-grep -h "Time for event " timing_temp.txt | cut -d " " -f 6 | awk '{ SUM += $1} END { print "Average time for lst::Event creation =",SUM/21,"ms"}' # 5 is the number of total streams run (1+2+4+6+8)
+grep -ah "Time for map " timing_temp.txt | cut -d " " -f 6 | awk '{ SUM += $1} END { print "Average time for map loading =",SUM/5,"ms" }' # 5 is the number of stream values run
+grep -ah "Time for input " timing_temp.txt | cut -d " " -f 6 | awk '{ SUM += $1} END { print "Average time for input loading =",SUM/5,"ms" }' # 5 is the number of stream values run
+grep -ah "Time for event " timing_temp.txt | cut -d " " -f 6 | awk '{ SUM += $1} END { print "Average time for lst::Event creation =",SUM/21,"ms"}' # 5 is the number of total streams run (1+2+4+6+8)
 echo "   Evt    Hits       MD       LS      T3       T5       pLS       T4       pT5      pT3      TC       Reset    Event     Short             Rate"
-grep -hr "avg " timing_temp.txt # space is needed to not get certain bad lines 
+grep -ah "avg " timing_temp.txt

--- a/RecoTracker/LSTCore/standalone/efficiency/python/lst_plot_performance.py
+++ b/RecoTracker/LSTCore/standalone/efficiency/python/lst_plot_performance.py
@@ -9,7 +9,7 @@ from math import sqrt
 
 sel_choices = ["base", "loweta", "xtr", "vtr", "none"]
 metric_choices = ["eff", "fakerate", "duplrate", "fakeorduplrate", "avgOTlen"]
-variable_choices = ["pt", "ptmtv", "ptlow", "eta", "phi", "dxy", "dz", "vxy", "deltaEta", "deltaPhi", "deltaR", "jet_eta", "jet_phi", "jet_pt"]
+variable_choices = ["pt", "ptmtv", "ptlow", "eta", "phi", "dxy", "dz", "vxy", "deltaEta", "deltaPhi", "deltaR", "genJetEta", "genJetPhi", "genJetPt"]
 objecttype_choices = ["TC", "pT5", "T5", "pT3", "pLS", "T4", "pT5_lower", "pT3_lower", "T5_lower", "pLS_lower"]
 #lowerObjectType = ["pT5_lower", "pT3_lower", "T5_lower"]
 
@@ -478,11 +478,11 @@ def set_label(eff, output_name, raw_number):
         title = "#phi diffs"
     elif "_deltaR" in output_name:
         title = "#Delta R"
-    elif "_jet_eta" in output_name:
+    elif "_genJetEta" in output_name:
         title = "jet #eta"
-    elif "_jet_phi" in output_name:
+    elif "_genJetPhi" in output_name:
         title = "jet #phi"
-    elif "_jet_pt" in output_name:
+    elif "_genJetPt" in output_name:
         title = "jet pT"
     elif "_dz" in output_name:
         title = "z [cm]"
@@ -735,7 +735,11 @@ def plot_standard_performance_plots(args):
             "fakeorduplrate": ["pt", "ptlow", "ptmtv", "eta", "phi"],
             "avgOTlen": ["eta"],
             }
-    if (args.jet_branches): variables["eff"] = ["pt", "ptlow", "ptmtv", "eta", "phi", "dxy", "dz", "vxy", "deltaEta", "deltaPhi", "deltaR", "jet_eta", "jet_phi", "jet_pt"]
+    if (args.jet_branches): 
+        variables["eff"] = ["pt", "ptlow", "ptmtv", "eta", "phi", "dxy", "dz", "vxy", "deltaEta", "deltaPhi", "deltaR", "genJetEta", "genJetPhi", "genJetPt"]
+        variables["duplrate"] = ["pt", "ptlow", "ptmtv", "eta", "phi", "deltaR"]
+        variables["fakerate"] = ["pt", "ptlow", "ptmtv", "eta", "phi", "deltaR"]
+        variables["fakeorduplrate"] = ["pt", "ptlow", "ptmtv", "eta", "phi", "deltaR"]
     sels = {
             "eff": ["base", "loweta"],
             "fakerate": ["none"],
@@ -757,9 +761,9 @@ def plot_standard_performance_plots(args):
         xcoarses["deltaEta"] = [False, True]
         xcoarses["deltaPhi"] = [False, True]
         xcoarses["deltaR"] = [False, True]
-        xcoarses["jet_eta"] = [False, True]
-        xcoarses["jet_phi"] = [False, True]
-        xcoarses["jet_pt"] = [False, True]
+        xcoarses["genJetEta"] = [False, True]
+        xcoarses["genJetPhi"] = [False, True]
+        xcoarses["genJetPt"] = [False, True]
 
     types = objecttype_choices
     breakdowns = {

--- a/RecoTracker/LSTCore/standalone/efficiency/src/performance.cc
+++ b/RecoTracker/LSTCore/standalone/efficiency/src/performance.cc
@@ -725,52 +725,20 @@ void bookEfficiencySet(SimTrackSetDefinition& effset) {
     return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_deltaR");
   });
 
-  // Lines for jet_eta
-  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_jet_eta");
-  ana.histograms.addVecHistogram(category_name + "_ef_denom_jet_eta", 180, -4.5, 4.5, [&, category_name]() {
-    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_jet_eta");
+  // Lines for genJetPt
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_genJetPt");
+  ana.histograms.addVecHistogram(category_name + "_ef_denom_genJetPt", 50, 1000, 3000, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_genJetPt");
   });
 
-  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_jet_eta");
-  ana.histograms.addVecHistogram(category_name + "_ef_numer_jet_eta", 180, -4.5, 4.5, [&, category_name]() {
-    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_jet_eta");
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_genJetPt");
+  ana.histograms.addVecHistogram(category_name + "_ef_numer_genJetPt", 50, 1000, 3000, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_genJetPt");
   });
 
-  ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_jet_eta");
-  ana.histograms.addVecHistogram(category_name + "_ie_numer_jet_eta", 180, -4.5, 4.5, [&, category_name]() {
-    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_jet_eta");
-  });
-
-  // Lines for jet_phi
-  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_jet_phi");
-  ana.histograms.addVecHistogram(category_name + "_ef_denom_jet_phi", 180, -4.5, 4.5, [&, category_name]() {
-    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_jet_phi");
-  });
-
-  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_jet_phi");
-  ana.histograms.addVecHistogram(category_name + "_ef_numer_jet_phi", 180, -4.5, 4.5, [&, category_name]() {
-    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_jet_phi");
-  });
-
-  ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_jet_phi");
-  ana.histograms.addVecHistogram(category_name + "_ie_numer_jet_phi", 180, -4.5, 4.5, [&, category_name]() {
-    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_jet_phi");
-  });
-
-  // Lines for jet_pt
-  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_jet_pt");
-  ana.histograms.addVecHistogram(category_name + "_ef_denom_jet_pt", 50, 50, 1000, [&, category_name]() {
-    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_jet_pt");
-  });
-
-  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_jet_pt");
-  ana.histograms.addVecHistogram(category_name + "_ef_numer_jet_pt", 50, 50, 1000, [&, category_name]() {
-    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_jet_pt");
-  });
-
-  ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_jet_pt");
-  ana.histograms.addVecHistogram(category_name + "_ie_numer_jet_pt", 50, 50, 1000, [&, category_name]() {
-    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_jet_pt");
+  ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_genJetPt");
+  ana.histograms.addVecHistogram(category_name + "_ie_numer_genJetPt", 50, 1000, 3000, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_genJetPt");
   });
 
   // Moving the standard pT code up here for convenience
@@ -901,11 +869,13 @@ void bookDuplicateRateSet(RecoTrackSetDefinition& DRset) {
   ana.tx.createBranch<std::vector<float>>(category_name + "_dr_denom_pt");
   ana.tx.createBranch<std::vector<float>>(category_name + "_dr_denom_eta");
   ana.tx.createBranch<std::vector<float>>(category_name + "_dr_denom_phi");
+  ana.tx.createBranch<std::vector<float>>(category_name + "_dr_denom_deltaR");
 
   // Numerator tracks' quantities
   ana.tx.createBranch<std::vector<float>>(category_name + "_dr_numer_pt");
   ana.tx.createBranch<std::vector<float>>(category_name + "_dr_numer_eta");
   ana.tx.createBranch<std::vector<float>>(category_name + "_dr_numer_phi");
+  ana.tx.createBranch<std::vector<float>>(category_name + "_dr_numer_deltaR");
 
   // Histogram utility object that is used to define the histograms
   ana.histograms.addVecHistogram(category_name + "_dr_denom_pt", getPtBounds(0), [&, category_name]() {
@@ -923,6 +893,9 @@ void bookDuplicateRateSet(RecoTrackSetDefinition& DRset) {
   ana.histograms.addVecHistogram(category_name + "_dr_denom_phi", 180, -M_PI, M_PI, [&, category_name]() {
     return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_dr_denom_phi");
   });
+  ana.histograms.addVecHistogram(category_name + "_dr_denom_deltaR", 50, 0, 0.1, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_dr_denom_deltaR");
+  });
   ana.histograms.addVecHistogram(category_name + "_dr_numer_pt", getPtBounds(0), [&, category_name]() {
     return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_dr_numer_pt");
   });
@@ -937,6 +910,9 @@ void bookDuplicateRateSet(RecoTrackSetDefinition& DRset) {
   });
   ana.histograms.addVecHistogram(category_name + "_dr_numer_phi", 180, -M_PI, M_PI, [&, category_name]() {
     return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_dr_numer_phi");
+  });
+  ana.histograms.addVecHistogram(category_name + "_dr_numer_deltaR", 50, 0, 0.1, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_dr_numer_deltaR");
   });
 }
 
@@ -955,11 +931,13 @@ void bookFakeOrDuplicateRateSet(RecoTrackSetDefinition& FDRset) {
   ana.tx.createBranch<std::vector<float>>(category_name + "_fdr_denom_pt");
   ana.tx.createBranch<std::vector<float>>(category_name + "_fdr_denom_eta");
   ana.tx.createBranch<std::vector<float>>(category_name + "_fdr_denom_phi");
+  ana.tx.createBranch<std::vector<float>>(category_name + "_fdr_denom_deltaR");
 
   // Numerator tracks' quantities
   ana.tx.createBranch<std::vector<float>>(category_name + "_fdr_numer_pt");
   ana.tx.createBranch<std::vector<float>>(category_name + "_fdr_numer_eta");
   ana.tx.createBranch<std::vector<float>>(category_name + "_fdr_numer_phi");
+  ana.tx.createBranch<std::vector<float>>(category_name + "_fdr_numer_deltaR");
 
   // Histogram utility object that is used to define the histograms
   ana.histograms.addVecHistogram(category_name + "_fdr_denom_pt", getPtBounds(0), [&, category_name]() {
@@ -977,6 +955,9 @@ void bookFakeOrDuplicateRateSet(RecoTrackSetDefinition& FDRset) {
   ana.histograms.addVecHistogram(category_name + "_fdr_denom_phi", 180, -M_PI, M_PI, [&, category_name]() {
     return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fdr_denom_phi");
   });
+  ana.histograms.addVecHistogram(category_name + "_fdr_denom_deltaR", 50, 0, 0.1, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fdr_denom_deltaR");
+  });
   ana.histograms.addVecHistogram(category_name + "_fdr_numer_pt", getPtBounds(0), [&, category_name]() {
     return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fdr_numer_pt");
   });
@@ -991,6 +972,9 @@ void bookFakeOrDuplicateRateSet(RecoTrackSetDefinition& FDRset) {
   });
   ana.histograms.addVecHistogram(category_name + "_fdr_numer_phi", 180, -M_PI, M_PI, [&, category_name]() {
     return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fdr_numer_phi");
+  });
+  ana.histograms.addVecHistogram(category_name + "_fdr_numer_deltaR", 50, 0, 0.1, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fdr_numer_deltaR");
   });
 }
 
@@ -1009,11 +993,13 @@ void bookFakeRateSet(RecoTrackSetDefinition& FRset) {
   ana.tx.createBranch<std::vector<float>>(category_name + "_fr_denom_pt");
   ana.tx.createBranch<std::vector<float>>(category_name + "_fr_denom_eta");
   ana.tx.createBranch<std::vector<float>>(category_name + "_fr_denom_phi");
+  ana.tx.createBranch<std::vector<float>>(category_name + "_fr_denom_deltaR");
 
   // Numerator tracks' quantities
   ana.tx.createBranch<std::vector<float>>(category_name + "_fr_numer_pt");
   ana.tx.createBranch<std::vector<float>>(category_name + "_fr_numer_eta");
   ana.tx.createBranch<std::vector<float>>(category_name + "_fr_numer_phi");
+  ana.tx.createBranch<std::vector<float>>(category_name + "_fr_numer_deltaR");
 
   // Histogram utility object that is used to define the histograms
   ana.histograms.addVecHistogram(category_name + "_fr_denom_pt", getPtBounds(0), [&, category_name]() {
@@ -1027,6 +1013,12 @@ void bookFakeRateSet(RecoTrackSetDefinition& FRset) {
   });
   ana.histograms.addVecHistogram(category_name + "_fr_denom_eta", 180, -4.5, 4.5, [&, category_name]() {
     return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fr_denom_eta");
+  });
+  ana.histograms.addVecHistogram(category_name + "_fr_denom_phi", 180, -M_PI, M_PI, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fr_denom_phi");
+  });
+  ana.histograms.addVecHistogram(category_name + "_fr_denom_deltaR", 50, 0, 0.1, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fr_denom_deltaR");
   });
   ana.histograms.addVecHistogram(category_name + "_fr_numer_phi", 180, -M_PI, M_PI, [&, category_name]() {
     return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fr_numer_phi");
@@ -1043,8 +1035,8 @@ void bookFakeRateSet(RecoTrackSetDefinition& FRset) {
   ana.histograms.addVecHistogram(category_name + "_fr_numer_eta", 180, -4.5, 4.5, [&, category_name]() {
     return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fr_numer_eta");
   });
-  ana.histograms.addVecHistogram(category_name + "_fr_denom_phi", 180, -M_PI, M_PI, [&, category_name]() {
-    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fr_denom_phi");
+  ana.histograms.addVecHistogram(category_name + "_fr_numer_deltaR", 50, 0, 0.1, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fr_numer_deltaR");
   });
 }
 
@@ -1053,6 +1045,32 @@ void bookFakeRateSet(RecoTrackSetDefinition& FRset) {
 // ---------------------------------------------------------=============================================-------------------------------------------------------------------
 // ---------------------------------------------------------=============================================-------------------------------------------------------------------
 // ---------------------------------------------------------=============================================-------------------------------------------------------------------
+
+float dRClosestJet(float eta,
+                   float phi,
+                   std::vector<float> const& genJetPt,
+                   std::vector<float> const& genJetEta,
+                   std::vector<float> const& genJetPhi) {
+  float dEtaj = 999;
+  float dPhij = 999;
+  float dRj2 = 999;
+  float dRTemp2 = 999;
+  float genJetPtj;
+  float genJetEtaj;
+  for (unsigned int ijet = 0; ijet < genJetPhi.size(); ++ijet) {
+    genJetPtj = genJetPt[ijet];
+    genJetEtaj = genJetEta[ijet];
+    if (genJetPtj > 1000 && (genJetEtaj < 2.5 && genJetEtaj > -2.5)) {
+      dEtaj = eta - genJetEtaj;
+      dPhij = std::acos(std::cos(phi - genJetPhi[ijet]));
+      dRj2 = std::pow(dEtaj, 2) + std::pow(dPhij, 2);
+      if (dRj2 < dRTemp2) {
+        dRTemp2 = dRj2;
+      }
+    }
+  }
+  return std::sqrt(dRTemp2);
+}
 
 //__________________________________________________________________________________________________________________________________________________________________________
 void fillEfficiencySets(std::vector<SimTrackSetDefinition>& effsets) {
@@ -1068,33 +1086,37 @@ void fillEfficiencySets(std::vector<SimTrackSetDefinition>& effsets) {
   std::vector<float> const& vtx_z = lstEff.getVF("sim_vz");
 
   if (ana.jet_branches) {
-    std::vector<float> const& deltaEta = lstEff.getVF("sim_deltaEta");
-    std::vector<float> const& deltaPhi = lstEff.getVF("sim_deltaPhi");
-    std::vector<float> const& deltaR = lstEff.getVF("sim_deltaR");
-    std::vector<float> const& jet_eta = lstEff.getVF("sim_jet_eta");
-    std::vector<float> const& jet_phi = lstEff.getVF("sim_jet_phi");
-    std::vector<float> const& jet_pt = lstEff.getVF("sim_jet_pt");
+    std::vector<float> const& deltaEta = lstEff.getVF("sim_genjet_deltaEta");
+    std::vector<float> const& deltaPhi = lstEff.getVF("sim_genjet_deltaPhi");
+    std::vector<float> const& deltaR = lstEff.getVF("sim_genjet_deltaR");
+    std::vector<int> const& genJetIdx = lstEff.getVI("sim_genjet_idx");
+    std::vector<float> const& genJetPt = lstEff.getVF("genjet_pt");
+    std::vector<float> const& genJetEta = lstEff.getVF("genjet_eta");
+    float genJetPt_isimtrk = 0;
+    float genJetEta_isimtrk = 0;
 
     for (auto& effset : effsets) {
       for (unsigned int isimtrk = 0; isimtrk < lstEff.getVF("sim_pt").size(); ++isimtrk) {
-        fillEfficiencySet(isimtrk,
-                          effset,
-                          pt.at(isimtrk),
-                          eta.at(isimtrk),
-                          dz.at(isimtrk),
-                          dxy.at(isimtrk),
-                          phi.at(isimtrk),
-                          pdgidtrk.at(isimtrk),
-                          q.at(isimtrk),
-                          vtx_x.at(isimtrk),
-                          vtx_y.at(isimtrk),
-                          vtx_z.at(isimtrk),
-                          deltaEta.at(isimtrk),
-                          deltaPhi.at(isimtrk),
-                          deltaR.at(isimtrk),
-                          jet_eta.at(isimtrk),
-                          jet_phi.at(isimtrk),
-                          jet_pt.at(isimtrk));
+        genJetPt_isimtrk = genJetPt.at(genJetIdx.at(isimtrk));
+        genJetEta_isimtrk = genJetEta.at(genJetIdx.at(isimtrk));
+        if (genJetPt_isimtrk > 1000 && (genJetEta_isimtrk < 2.5 && genJetEta_isimtrk > -2.5)) {
+          fillEfficiencySet(isimtrk,
+                            effset,
+                            pt.at(isimtrk),
+                            eta.at(isimtrk),
+                            dz.at(isimtrk),
+                            dxy.at(isimtrk),
+                            phi.at(isimtrk),
+                            pdgidtrk.at(isimtrk),
+                            q.at(isimtrk),
+                            vtx_x.at(isimtrk),
+                            vtx_y.at(isimtrk),
+                            vtx_z.at(isimtrk),
+                            deltaEta.at(isimtrk),
+                            deltaPhi.at(isimtrk),
+                            deltaR.at(isimtrk),
+                            genJetPt_isimtrk);
+        }
       }
     }
   } else {
@@ -1133,9 +1155,7 @@ void fillEfficiencySet(int isimtrk,
                        float deltaEta,
                        float deltaPhi,
                        float deltaR,
-                       float jet_eta,
-                       float jet_phi,
-                       float jet_pt) {
+                       float genJetPt) {
   //=========================================================
   // NOTE: The following is not applied as the LSTNtuple no longer writes this.
   // const int &bunch = lstEff.getVI("sim_bunchCrossing")[isimtrk];
@@ -1173,103 +1193,87 @@ void fillEfficiencySet(int isimtrk,
   const float vtx_z_thresh = 30;
   const float vtx_perp_thresh = 2.5;
 
-  if (pt > 0 && jet_eta < 140 && jet_eta > -140 && (jet_eta > -999 && deltaEta > -999)) {
-    // N minus eta cut
-    if (pt > ana.pt_cut and std::abs(vtx_z) < vtx_z_thresh and std::abs(vtx_perp) < vtx_perp_thresh) {
-      // vs. eta plot
-      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_eta", eta);
-      if (pass)
-        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_eta", eta);
-      else
-        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_eta", eta);
+  // N minus eta cut
+  if (pt > ana.pt_cut and std::abs(vtx_z) < vtx_z_thresh and std::abs(vtx_perp) < vtx_perp_thresh) {
+    // vs. eta plot
+    ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_eta", eta);
+    if (pass)
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_eta", eta);
+    else
+      ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_eta", eta);
+  }
+
+  // N minus pt cut
+  if (std::abs(eta) < ana.eta_cut and std::abs(vtx_z) < vtx_z_thresh and std::abs(vtx_perp) < vtx_perp_thresh) {
+    // vs. pt plot
+    ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_pt", pt);
+    if (pass)
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_pt", pt);
+    else
+      ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_pt", pt);
+  }
+
+  // N minus dxy cut
+  if (std::abs(eta) < ana.eta_cut and pt > ana.pt_cut and std::abs(vtx_z) < vtx_z_thresh) {
+    // vs. dxy plot
+    ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_dxy", dxy);
+    ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_vxy", vtx_perp);
+    if (pass) {
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_dxy", dxy);
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_vxy", vtx_perp);
+    } else {
+      ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_dxy", dxy);
+      ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_vxy", vtx_perp);
     }
+  }
 
-    // N minus pt cut
-    if (std::abs(eta) < ana.eta_cut and std::abs(vtx_z) < vtx_z_thresh and std::abs(vtx_perp) < vtx_perp_thresh) {
-      // vs. pt plot
-      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_pt", pt);
-      if (pass)
-        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_pt", pt);
-      else
-        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_pt", pt);
-    }
+  // N minus dz cut
+  if (std::abs(eta) < ana.eta_cut and pt > ana.pt_cut and std::abs(vtx_perp) < vtx_perp_thresh) {
+    // vs. dz plot
+    ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_dz", dz);
+    if (pass)
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_dz", dz);
+    else
+      ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_dz", dz);
+  }
 
-    // N minus dxy cut
-    if (std::abs(eta) < ana.eta_cut and pt > ana.pt_cut and std::abs(vtx_z) < vtx_z_thresh) {
-      // vs. dxy plot
-      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_dxy", dxy);
-      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_vxy", vtx_perp);
-      if (pass) {
-        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_dxy", dxy);
-        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_vxy", vtx_perp);
-      } else {
-        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_dxy", dxy);
-        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_vxy", vtx_perp);
-      }
-    }
+  // All phase-space cuts
+  if (std::abs(eta) < ana.eta_cut and pt > ana.pt_cut and std::abs(vtx_z) < vtx_z_thresh and
+      std::abs(vtx_perp) < vtx_perp_thresh) {
+    // vs. Phi plot
+    ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_phi", phi);
+    if (pass)
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_phi", phi);
+    else
+      ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_phi", phi);
 
-    // N minus dz cut
-    if (std::abs(eta) < ana.eta_cut and pt > ana.pt_cut and std::abs(vtx_perp) < vtx_perp_thresh) {
-      // vs. dz plot
-      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_dz", dz);
-      if (pass)
-        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_dz", dz);
-      else
-        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_dz", dz);
-    }
+    // vs. deltaEta plot
+    ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_deltaEta", deltaEta);
+    if (pass)
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_deltaEta", deltaEta);
+    else
+      ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_deltaEta", deltaEta);
 
-    // All phase-space cuts
-    if (std::abs(eta) < ana.eta_cut and pt > ana.pt_cut and std::abs(vtx_z) < vtx_z_thresh and
-        std::abs(vtx_perp) < vtx_perp_thresh) {
-      // vs. Phi plot
-      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_phi", phi);
-      if (pass)
-        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_phi", phi);
-      else
-        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_phi", phi);
+    // vs. deltaPhi plot
+    ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_deltaPhi", deltaPhi);
+    if (pass)
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_deltaPhi", deltaPhi);
+    else
+      ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_deltaPhi", deltaPhi);
 
-      // vs. deltaEta plot
-      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_deltaEta", deltaEta);
-      if (pass)
-        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_deltaEta", deltaEta);
-      else
-        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_deltaEta", deltaEta);
+    // vs. deltaR plot
+    ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_deltaR", deltaR);
+    if (pass)
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_deltaR", deltaR);
+    else
+      ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_deltaR", deltaR);
 
-      // vs. deltaPhi plot
-      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_deltaPhi", deltaPhi);
-      if (pass)
-        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_deltaPhi", deltaPhi);
-      else
-        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_deltaPhi", deltaPhi);
-
-      // vs. deltaR plot
-      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_deltaR", deltaR);
-      if (pass)
-        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_deltaR", deltaR);
-      else
-        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_deltaR", deltaR);
-
-      // vs. jet_eta plot
-      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_jet_eta", jet_eta);
-      if (pass)
-        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_jet_eta", jet_eta);
-      else
-        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_jet_eta", jet_eta);
-
-      // vs. jet_phi plot
-      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_jet_phi", jet_phi);
-      if (pass)
-        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_jet_phi", jet_phi);
-      else
-        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_jet_phi", jet_phi);
-
-      // vs. jet_pt plot
-      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_jet_pt", jet_pt);
-      if (pass)
-        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_jet_pt", jet_pt);
-      else
-        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_jet_pt", jet_pt);
-    }
+    // vs. genJetPt plot
+    ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_genJetPt", genJetPt);
+    if (pass)
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_genJetPt", genJetPt);
+    else
+      ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_genJetPt", genJetPt);
   }
 }
 
@@ -1414,6 +1418,18 @@ void fillFakeRateSet(int itc, RecoTrackSetDefinition& FRset, float pt, float eta
     if (pass)
       ana.tx.pushbackToBranch<float>(category_name + "_fr_numer_phi", phi);
   }
+  if (ana.jet_branches) {
+    std::vector<float> genJetPt = lstEff.getVF("genjet_pt");
+    std::vector<float> genJetEta = lstEff.getVF("genjet_eta");
+    std::vector<float> genJetPhi = lstEff.getVF("genjet_phi");
+
+    float dRTemp = dRClosestJet(eta, phi, genJetPt, genJetEta, genJetPhi);
+
+    ana.tx.pushbackToBranch<float>(category_name + "_fr_denom_deltaR", dRTemp);
+    if (pass) {
+      ana.tx.pushbackToBranch<float>(category_name + "_fr_numer_deltaR", dRTemp);
+    }
+  }
 }
 
 //__________________________________________________________________________________________________________________________________________________________________________
@@ -1452,6 +1468,18 @@ void fillDuplicateRateSet(int itc, RecoTrackSetDefinition& DRset, float pt, floa
     if (pass)
       ana.tx.pushbackToBranch<float>(category_name + "_dr_numer_phi", phi);
   }
+  if (ana.jet_branches) {
+    std::vector<float> genJetPt = lstEff.getVF("genjet_pt");
+    std::vector<float> genJetEta = lstEff.getVF("genjet_eta");
+    std::vector<float> genJetPhi = lstEff.getVF("genjet_phi");
+
+    float dRTemp = dRClosestJet(eta, phi, genJetPt, genJetEta, genJetPhi);
+
+    ana.tx.pushbackToBranch<float>(category_name + "_dr_denom_deltaR", dRTemp);
+    if (pass) {
+      ana.tx.pushbackToBranch<float>(category_name + "_dr_numer_deltaR", dRTemp);
+    }
+  }
 }
 
 //__________________________________________________________________________________________________________________________________________________________________________
@@ -1489,5 +1517,17 @@ void fillFakeOrDuplicateRateSet(int itc, RecoTrackSetDefinition& FDRset, float p
     ana.tx.pushbackToBranch<float>(category_name + "_fdr_denom_phi", phi);
     if (pass)
       ana.tx.pushbackToBranch<float>(category_name + "_fdr_numer_phi", phi);
+  }
+  if (ana.jet_branches) {
+    std::vector<float> genJetPt = lstEff.getVF("genjet_pt");
+    std::vector<float> genJetEta = lstEff.getVF("genjet_eta");
+    std::vector<float> genJetPhi = lstEff.getVF("genjet_phi");
+
+    float dRTemp = dRClosestJet(eta, phi, genJetPt, genJetEta, genJetPhi);
+
+    ana.tx.pushbackToBranch<float>(category_name + "_fdr_denom_deltaR", dRTemp);
+    if (pass) {
+      ana.tx.pushbackToBranch<float>(category_name + "_fdr_numer_deltaR", dRTemp);
+    }
   }
 }

--- a/RecoTracker/LSTCore/standalone/efficiency/src/performance.cc
+++ b/RecoTracker/LSTCore/standalone/efficiency/src/performance.cc
@@ -1051,25 +1051,17 @@ float dRClosestJet(float eta,
                    std::vector<float> const& genJetPt,
                    std::vector<float> const& genJetEta,
                    std::vector<float> const& genJetPhi) {
-  float dEtaj = 999;
-  float dPhij = 999;
-  float dRj2 = 999;
-  float dRTemp2 = 999;
-  float genJetPtj;
-  float genJetEtaj;
-  for (unsigned int ijet = 0; ijet < genJetPhi.size(); ++ijet) {
-    genJetPtj = genJetPt[ijet];
-    genJetEtaj = genJetEta[ijet];
-    if (genJetPtj > 1000 && (genJetEtaj < 2.5 && genJetEtaj > -2.5)) {
-      dEtaj = eta - genJetEtaj;
-      dPhij = std::acos(std::cos(phi - genJetPhi[ijet]));
-      dRj2 = std::pow(dEtaj, 2) + std::pow(dPhij, 2);
-      if (dRj2 < dRTemp2) {
-        dRTemp2 = dRj2;
-      }
+  float best_dR2 = 999;
+  for (size_t i = 0; i < genJetPhi.size(); ++i) {
+    if (genJetPt[i] > 1000.f && std::abs(genJetEta[i]) < 2.5f) {
+      auto dPhi = std::abs(phi - genJetPhi[i]);
+      if (dPhi > float(M_PI))
+        dPhi -= float(2 * M_PI);
+      const float dR2 = std::pow(eta - genJetEta[i], 2) + std::pow(dPhi, 2);
+      best_dR2 = std::min(best_dR2, dR2);
     }
   }
-  return std::sqrt(dRTemp2);
+  return std::sqrt(best_dR2);
 }
 
 //__________________________________________________________________________________________________________________________________________________________________________
@@ -1099,7 +1091,7 @@ void fillEfficiencySets(std::vector<SimTrackSetDefinition>& effsets) {
       for (unsigned int isimtrk = 0; isimtrk < lstEff.getVF("sim_pt").size(); ++isimtrk) {
         genJetPt_isimtrk = genJetPt.at(genJetIdx.at(isimtrk));
         genJetEta_isimtrk = genJetEta.at(genJetIdx.at(isimtrk));
-        if (genJetPt_isimtrk > 1000 && (genJetEta_isimtrk < 2.5 && genJetEta_isimtrk > -2.5)) {
+        if (genJetPt_isimtrk > 1000 && std::abs(genJetEta_isimtrk) < 2.5) {
           fillEfficiencySet(isimtrk,
                             effset,
                             pt.at(isimtrk),

--- a/RecoTracker/LSTCore/standalone/efficiency/src/performance.h
+++ b/RecoTracker/LSTCore/standalone/efficiency/src/performance.h
@@ -34,9 +34,7 @@ void fillEfficiencySet(int isimtrk,
                        float deltaEta,
                        float deltaPhi,
                        float deltaR,
-                       float jet_eta,
-                       float jet_phi,
-                       float jet_pt);
+                       float genJetPt);
 void fillEfficiencySet(int isimtrk,
                        SimTrackSetDefinition& effset,
                        float pt,

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -93,6 +93,12 @@
 
 #include "RecoTracker/FinalTrackSelectors/interface/getBestVertex.h"
 
+// GenJet headers
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
+#include "DataFormats/JetReco/interface/GenJet.h"
+#include "DataFormats/JetReco/interface/GenJetCollection.h"
+
 #include <set>
 #include <map>
 #include <unordered_set>
@@ -628,6 +634,8 @@ private:
   void fillTrackingVertices(const TrackingVertexRefVector& trackingVertices,
                             const TrackingParticleRefKeyToIndex& tpKeyToIndex);
 
+  void fillGenJets(const edm::Event& iEvent, const TrackingParticleRefVector& tpCollection);
+
   struct SimHitData {
     std::vector<int> matchingSimHit;
     std::vector<float> chargeFraction;
@@ -704,6 +712,8 @@ private:
 
   HistoryBase tracer_;
   ParametersDefinerForTP parametersDefiner_;
+
+  const edm::EDGetTokenT<reco::GenJetCollection> tok_jets_;
 
   TTree* t;
 
@@ -1415,6 +1425,18 @@ private:
   std::vector<std::vector<int>> simvtx_sourceSimIdx;    // second index runs through source TrackingParticles
   std::vector<std::vector<int>> simvtx_daughterSimIdx;  // second index runs through daughter TrackingParticles
   std::vector<int> simpv_idx;
+  std::vector<float> sim_genjet_deltaEta;  // distance to closest GenJet
+  std::vector<float> sim_genjet_deltaPhi;
+  std::vector<float> sim_genjet_deltaR;
+  std::vector<int> sim_genjet_idx;  // index of GenJet for each Sim track
+
+  ////////////////////
+  // GenJets
+  std::vector<float> genjet_pt;
+  std::vector<float> genjet_eta;
+  std::vector<float> genjet_phi;
+  std::vector<float> genjet_invisible_energy;
+  std::vector<float> genjet_auxiliary_energy;
 };
 
 //
@@ -1473,7 +1495,8 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       keepEleSimHits_(iConfig.getUntrackedParameter<bool>("keepEleSimHits")),
       saveSimHitsP3_(iConfig.getUntrackedParameter<bool>("saveSimHitsP3")),
       simHitBySignificance_(iConfig.getUntrackedParameter<bool>("simHitBySignificance")),
-      parametersDefiner_(iConfig.getUntrackedParameter<edm::InputTag>("beamSpot"), consumesCollector()) {
+      parametersDefiner_(iConfig.getUntrackedParameter<edm::InputTag>("beamSpot"), consumesCollector()),
+      tok_jets_(consumes<reco::GenJetCollection>(iConfig.getParameter<edm::InputTag>("jetSource"))) {
   if (includeSeeds_) {
     seedTokens_ =
         edm::vector_transform(iConfig.getUntrackedParameter<std::vector<edm::InputTag>>("seedTracks"),
@@ -2050,8 +2073,19 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
   t->Branch("simvtx_z", &simvtx_z);
   t->Branch("simvtx_sourceSimIdx", &simvtx_sourceSimIdx);
   t->Branch("simvtx_daughterSimIdx", &simvtx_daughterSimIdx);
+  t->Branch("sim_genjet_deltaEta", &sim_genjet_deltaEta);
+  t->Branch("sim_genjet_deltaPhi", &sim_genjet_deltaPhi);
+  t->Branch("sim_genjet_deltaR", &sim_genjet_deltaR);
 
   t->Branch("simpv_idx", &simpv_idx);
+
+  // GenJets
+  t->Branch("genjet_pt", &genjet_pt);
+  t->Branch("genjet_eta", &genjet_eta);
+  t->Branch("genjet_phi", &genjet_phi);
+  t->Branch("genjet_invisible_energy", &genjet_invisible_energy);
+  t->Branch("genjet_auxiliary_energy", &genjet_auxiliary_energy);
+  t->Branch("sim_genjet_idx", &sim_genjet_idx);
 
   //t->Branch("" , &);
 }
@@ -2462,6 +2496,17 @@ void TrackingNtuple::clearVariables() {
   simvtx_sourceSimIdx.clear();
   simvtx_daughterSimIdx.clear();
   simpv_idx.clear();
+  sim_genjet_deltaEta.clear();
+  sim_genjet_deltaPhi.clear();
+  sim_genjet_deltaR.clear();
+  sim_genjet_idx.clear();
+
+  // GenJets
+  genjet_pt.clear();
+  genjet_eta.clear();
+  genjet_phi.clear();
+  genjet_invisible_energy.clear();
+  genjet_auxiliary_energy.clear();
 }
 
 // ------------ method called for each event  ------------
@@ -2735,7 +2780,50 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   // tracking vertices
   fillTrackingVertices(tvRefs, tpKeyToIndex);
 
+  // GenJets
+  fillGenJets(iEvent, tpCollection);
+
   t->Fill();
+}
+
+void TrackingNtuple::fillGenJets(const edm::Event& iEvent, const TrackingParticleRefVector& tpCollection) {
+  auto const& genJets = iEvent.get(tok_jets_);
+  for (auto const& jet : genJets) {
+    genjet_pt.push_back(jet.pt());
+    genjet_eta.push_back(jet.eta());
+    genjet_phi.push_back(jet.phi());
+    genjet_invisible_energy.push_back(jet.invisibleEnergy());
+    genjet_auxiliary_energy.push_back(jet.auxiliaryEnergy());
+  }
+  for (const TrackingParticleRef& tp : tpCollection) {
+    float sim_eta = tp->eta();
+    float sim_phi = tp->phi();
+    float dEtaj = 999;
+    float dPhij = 999;
+    float dRj2 = 999;
+    float dEtaTemp = 999;
+    float dPhiTemp = 999;
+    float dRTemp2 = 999;
+    int jet_idx = 999;
+    int counter = 0;
+
+    for (auto const& jet : genJets) {
+      dEtaj = sim_eta - jet.eta();
+      dPhij = reco::deltaPhi(sim_phi, jet.phi());
+      dRj2 = std::pow(dEtaj, 2) + std::pow(dPhij, 2);
+      if (dRj2 < dRTemp2) {
+        dEtaTemp = dEtaj;
+        dPhiTemp = dPhij;
+        dRTemp2 = dRj2;
+        jet_idx = counter;
+      }
+      counter = counter + 1;
+    }
+    sim_genjet_deltaEta.push_back(dEtaTemp);
+    sim_genjet_deltaPhi.push_back(dPhiTemp);
+    sim_genjet_deltaR.push_back(std::sqrt(dRTemp2));
+    sim_genjet_idx.push_back(jet_idx);
+  }
 }
 
 void TrackingNtuple::fillBeamSpot(const reco::BeamSpot& bs) {
@@ -4721,6 +4809,7 @@ void TrackingNtuple::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.addUntracked<bool>("keepEleSimHits", false);
   desc.addUntracked<bool>("saveSimHitsP3", false);
   desc.addUntracked<bool>("simHitBySignificance", false);
+  desc.add<edm::InputTag>("jetSource", edm::InputTag("ak4GenJets"));
   descriptions.add("trackingNtuple", desc);
 }
 


### PR DESCRIPTION
TrackingNtuple.cc has been modified so that when the trackingNtuple.root file is produced with cmsDriver.py, it includes branches corresponding to GenJets. These branches are:

- genjet_pt
- genjet_eta
- genjet_phi
- genjet_invisible_energy
- genjet_auxiliary_energy
- sim_genjet_idx

The last one is an index that allows each sim track to be matched with the jet it is closest to (minimizes ΔR). This replaces the post-processing described in #48674 , which added branches corresponding to ΔR and the jets after trackingNtuple.root was produced. The branches sim_genjet_deltaR, sim_genjet_deltaEta, and sim_genjet_deltaPhi are now also included in trackingNtuple.root.

This allows the efficiency, fake rate, and duplicate rate to plotted against ΔR. I also included a limit such that only tracks corresponding to GenJets with pT > 1000 GeV are considered.

<img width="488" height="385" alt="image" src="https://github.com/user-attachments/assets/45cb3bed-5aa3-4239-ad74-13f95487d8f2" />

None of these changes should impact the rest of LST. The code looking at the jet branches can be enabled/disabled using the -J flag.

Here are some example plots for 100 events from the file /RelValQCD_Pt_1800_2400_14/CMSSW_16_0_0_pre1-150X_mcRun4_realistic_v1_STD_RegeneratedGS_Run4D110_noPU-v1/GEN-SIM-DIGI-RAW, including only tracks with GenJet pT > 1000 GeV:

<img width="522" height="354" alt="image" src="https://github.com/user-attachments/assets/cad5f160-a13e-44e9-af91-df9e145d7438" />
<img width="522" height="354" alt="image" src="https://github.com/user-attachments/assets/f1a96e4b-df8f-4447-8976-540ee508c4c5" />
<img width="522" height="354" alt="image" src="https://github.com/user-attachments/assets/a7a44ede-eebc-4ef8-9446-84926ed12194" />
<img width="522" height="354" alt="image" src="https://github.com/user-attachments/assets/08e4ef0e-bb34-4128-92cc-7e98bf9a207b" />

