### PR TITLE
Update MiniAOD conversions in Run3 UPC era

### DIFF
--- a/HeavyFlavorAnalysis/Onia2MuMu/interface/OniaPhotonConversionProducer.h
+++ b/HeavyFlavorAnalysis/Onia2MuMu/interface/OniaPhotonConversionProducer.h
@@ -74,6 +74,7 @@ private:
 
   std::string convSelectionCuts_;
   std::unique_ptr<StringCutObjectSelector<reco::Conversion>> convSelection_;
+  bool addExtraInfo_;
 };
 
 #endif

--- a/HeavyFlavorAnalysis/Onia2MuMu/python/OniaPhotonConversionProducer_cfi.py
+++ b/HeavyFlavorAnalysis/Onia2MuMu/python/OniaPhotonConversionProducer_cfi.py
@@ -31,9 +31,13 @@ PhotonCandidates = cms.EDProducer('OniaPhotonConversionProducer',
     pi0SmallWindow   = cms.vdouble(pi0_small_min, pi0_small_max),
     pi0LargeWindow   = cms.vdouble(pi0_large_min, pi0_large_max),
     TkMinNumOfDOF = cms.uint32(conv_min_dof),
+    addExtraInfo = cms.bool(False),
     wantHighpurity = cms.bool(conv_high_purity),
     vertexChi2ProbCut = cms.double(0.0005),
     trackchi2Cut = cms.double(10),
     minDistanceOfApproachMinCut = cms.double(-0.25),
     minDistanceOfApproachMaxCut = cms.double(1.00)
     )
+
+from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
+run3_upc.toModify(PhotonCandidates, convQuality = [''], wantCompatibleInnerHits = False, addExtraInfo = True)


### PR DESCRIPTION
#### PR description:

This PR updates the conversions stored in MiniAOD created with the Run 3 UPC era to be used for 2026 PbPb data taking.

#### PR validation:

Tested with relvals 143.901,144.901,180.0.180.1,181.0,181.1,182.0,182.1,183.0,183.1

@mandrenguyen 