### PR TITLE
[NGT] add `hltESPMkFit` to `NGTScouting` menu

### DIFF
--- a/HLTrigger/Configuration/python/HLT_NGTScouting_cff.py
+++ b/HLTrigger/Configuration/python/HLT_NGTScouting_cff.py
@@ -98,7 +98,7 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPSiPixelCabling
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPSiPixelGainCalibrationForHLTSoA_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPModulesDevLST_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPTTRHBuilderWithoutRefit_cfi")
-
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPMkFit_cfi")
 
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/DST_PFScouting_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLTAnalyzerEndpath_cfi")


### PR DESCRIPTION
#### PR description:

Title says it all, needed to run the new tracking baseline in the NGT scouting menu. This part was missed in https://github.com/cms-sw/cmssw/pull/49231.

#### PR validation:

Will use the bot.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
