### PR TITLE
JME updates for Jet monitoring for DQMOffline (CMSSW_16_1)

### DIFF
--- a/DQMOffline/Trigger/plugins/ZGammaplusJetsPostProcessor.cc
+++ b/DQMOffline/Trigger/plugins/ZGammaplusJetsPostProcessor.cc
@@ -1,0 +1,133 @@
+#include "ZGammaplusJetsPostProcessor.h"
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include <cmath>
+#include <cstring>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+
+ZGammaplusJetsPostProcessor::ZGammaplusJetsPostProcessor(const edm::ParameterSet &pset) {
+  subDir_ = pset.getUntrackedParameter<std::string>("subDir");
+  isMuonTrgigger_ = pset.getUntrackedParameter<std::string>("IsMuonTrigger", "");
+  isPhotonTrgigger_ = pset.getUntrackedParameter<std::string>("IsPhotonTrigger", "");
+}
+
+void ZGammaplusJetsPostProcessor::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
+  bool isMuonDir = false;
+  bool isPhotonDir = false;
+
+  TPRegexp patternMuon(isMuonTrgigger_);
+  TPRegexp patternPhoton(isPhotonTrgigger_);
+
+  // go to the directory to be processed
+  if (igetter.dirExists(subDir_))
+    ibooker.cd(subDir_);
+  else {
+    edm::LogWarning("ZGammaplusJetsPostProcessor: ") << "Directory " << subDir_ << " not found, skip";
+    return;
+  }
+
+  std::vector<std::string> subdirectories = igetter.getSubdirs();
+  for (std::vector<std::string>::iterator dir = subdirectories.begin(); dir != subdirectories.end(); dir++) {
+    ibooker.cd(*dir);
+
+    isMuonDir = false;
+    isPhotonDir = false;
+
+    if (TString(*dir).Contains(patternMuon))
+      isMuonDir = true;
+    if (TString(*dir).Contains(patternPhoton))
+      isPhotonDir = true;
+
+    if (isMuonDir) {
+      // Direct balance vs Z Pt
+      histos_(ibooker, igetter, "DirectBalanceVsZPt_numerator", "meanDBvsZPt", "Z Pt", "mean Direct Balance vs Z Pt");
+    }
+
+    if (isPhotonDir) {
+      // Direct balance vs Photon Pt
+      histos_(ibooker,
+              igetter,
+              "DirectBalanceVsPhotonPt_numerator",
+              "meanDBvsPhotonPt",
+              "Photon Pt",
+              "mean Direct Balance vs Photon Pt");
+    }
+
+    ibooker.goUp();
+  }
+}
+
+TH1F *ZGammaplusJetsPostProcessor::histos_(DQMStore::IBooker &ibooker,
+                                           DQMStore::IGetter &igetter,
+                                           const std::string &DBName,
+                                           const std::string &outName,
+                                           const std::string &label,
+                                           const std::string &title) {
+  TH2F *h_DirectBalance = getHistogram(ibooker, igetter, ibooker.pwd() + "/" + DBName);
+
+  if (h_DirectBalance == nullptr)
+    edm::LogWarning("ZGammaplusJetsPostProcessor")
+        << "DirectBalance histogram " << ibooker.pwd() + "/" + DBName << " does not exist";
+
+  // Check if histograms actually exist
+  if (!h_DirectBalance)
+    return nullptr;
+
+  int DB_nbins = h_DirectBalance->GetXaxis()->GetNbins();
+
+  float bins[DB_nbins + 1];
+  for (int i = 0; i <= (h_DirectBalance->GetXaxis()->GetNbins()) + 1; i++) {
+    double xlow = h_DirectBalance->GetXaxis()->GetBinLowEdge(i);
+    bins[i] = xlow;
+  }
+
+  MonitorElement *meanDBvsRefPt = ibooker.book1D(outName, title, DB_nbins + 1, bins);
+
+  TH1F *pr = meanDBvsRefPt->getTH1F();
+
+  // Enable the approximation
+  TProfile::Approximate(kTRUE);
+  TProfile *hp = h_DirectBalance->ProfileX("_pfx", 1, -1, "");  //"" --> error of the mean of all y values
+
+  pr->SetTitle(TString::Format("%s (Profile X)", h_DirectBalance->GetTitle()));
+  pr->GetXaxis()->SetTitle(label.c_str());
+  pr->GetYaxis()->SetRangeUser(-3.99, 5.99);
+  pr->SetYTitle("<mean Direct Balance>");
+  pr->SetOption("PE");
+  pr->SetLineColor(2);
+  pr->SetLineWidth(2);
+  pr->SetMarkerStyle(20);
+  pr->SetMarkerSize(0.8);
+  pr->SetStats(kTRUE);
+
+  for (int i = 1; i <= hp->GetNbinsX() + 1; i++) {
+    pr->SetBinContent(i + 1, hp->GetBinContent(i));
+    if (hp->GetBinError(i) != 0.)
+      pr->SetBinError(i + 1, hp->GetBinError(i));
+  }
+
+  return pr;
+}
+
+TH2F *ZGammaplusJetsPostProcessor::getHistogram(DQMStore::IBooker &ibooker,
+                                                DQMStore::IGetter &igetter,
+                                                const std::string &histoPath) {
+  ibooker.pwd();
+  MonitorElement *monElement = igetter.get(histoPath);
+  if (monElement != nullptr) {
+    if (monElement->getTH2F()->GetEntries() == 0) {
+      return nullptr;
+    } else {
+      return monElement->getTH2F();
+    }
+  } else {
+    return nullptr;
+  }
+}
+
+DEFINE_FWK_MODULE(ZGammaplusJetsPostProcessor);

--- a/DQMOffline/Trigger/plugins/ZGammaplusJetsPostProcessor.h
+++ b/DQMOffline/Trigger/plugins/ZGammaplusJetsPostProcessor.h
@@ -1,0 +1,23 @@
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+
+#include "TPRegexp.h"
+
+class ZGammaplusJetsPostProcessor : public DQMEDHarvester {
+public:
+  ZGammaplusJetsPostProcessor(const edm::ParameterSet &pset);
+  ~ZGammaplusJetsPostProcessor() override {}
+
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;  // performed in the endJob
+  TH1F *histos_(DQMStore::IBooker &ibooker,
+                DQMStore::IGetter &igetter,
+                const std::string &DBName,
+                const std::string &outName,
+                const std::string &label,
+                const std::string &title);
+
+private:
+  std::string subDir_, isMuonTrgigger_, isPhotonTrgigger_;
+
+  TH2F *getHistogram(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter, const std::string &histoPath);
+};

--- a/DQMOffline/Trigger/python/DQMOffline_HLT_Client_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_HLT_Client_cff.py
@@ -28,6 +28,7 @@ from DQMOffline.Trigger.BTaggingMonitoring_Client_cff import *
 from DQMOffline.Trigger.BPHMonitoring_Client_cff import *
 from DQMOffline.Trigger.JetMETPromptMonitoring_Client_cff import *
 from DQMOffline.Trigger.DiJetMonitor_Client_cff import *
+from DQMOffline.Trigger.ZGammaplusJetsPostProcessor_cff import *
 from DQMOffline.Trigger.BTagAndProbeMonitoring_Client_cff import *
 
 from DQMOffline.Trigger.ParticleNetJetTag_Client_cff import *
@@ -58,6 +59,7 @@ hltOfflineDQMClient = cms.Sequence(
   * bphClient
   * JetMetPromClient
   * dijetClient
+  * ZGammaPostProc
   * BTagAndProbeClient
   * particleNetClientHLT
 )

--- a/DQMOffline/Trigger/python/JetMETPromptMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/JetMETPromptMonitoring_Client_cff.py
@@ -5,59 +5,45 @@ pfjetEfficiency = DQMEDHarvester("DQMGenericClient",
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
-        "effic_pfjetpT          'Jet pT turnON;            PFJet(pT) [GeV]; efficiency'     pfjetpT_numerator          pfjetpT_denominator",
-        "effic_pfjetpT_pTThresh 'Jet pT turnON;            PFJet(pT) [GeV]; efficiency'     pfjetpT_pTThresh_numerator pfjetpT_pTThresh_denominator",
-        "effic_pfjetphi       'Jet efficiency vs #phi; PF Jet #phi [rad]; efficiency' pfjetphi_numerator       pfjetphi_denominator",
-        "effic_pfjeteta       'Jet efficiency vs #eta; PF Jet #eta; efficiency' pfjeteta_numerator       pfjeteta_denominator",
+        "effic_pfpuppijetpT          'Jet pT turnON;            PFPuppi Jet(pT) [GeV]; efficiency'     pfpuppijetpT_numerator          pfpuppijetpT_denominator",
+        "effic_pfpuppijetpT_pTThresh 'Jet pT turnON;            PFPuppi Jet(pT) [GeV]; efficiency'     pfpuppijetpT_pTThresh_numerator pfpuppijetpT_pTThresh_denominator",
+        "effic_pfpuppijetphi       'Jet efficiency vs #phi; PFPuppi Jet #phi [rad]; efficiency' pfpuppijetphi_numerator       pfpuppijetphi_denominator",
+        "effic_pfpuppijeteta       'Jet efficiency vs #eta; PFPuppi Jet #eta; efficiency' pfpuppijeteta_numerator       pfpuppijeteta_denominator",
         ## HB
-        "effic_pfjetpT_HB          'Jet pT turnON (HB);            PFJet(pT) [GeV]; efficiency'     pfjetpT_HB_numerator          pfjetpT_HB_denominator",
-        "effic_pfjetpT_HB_pTThresh 'Jet pT turnON (HB);            PFJet(pT) [GeV]; efficiency'     pfjetpT_pTThresh_HB_numerator pfjetpT_pTThresh_HB_denominator",
-        "effic_pfjetphi_HB       'Jet efficiency vs #phi (HB); PF Jet #phi [rad]; efficiency' pfjetphi_HB_numerator       pfjetphi_HB_denominator",
-        "effic_pfjeteta_HB       'Jet efficiency vs #eta (HB); PF Jet #eta; efficiency' pfjeteta_HB_numerator       pfjeteta_HB_denominator",
+        "effic_pfpuppijetpT_HB          'Jet pT turnON (HB);            PFPuppi Jet(pT) [GeV]; efficiency'     pfpuppijetpT_HB_numerator          pfpuppijetpT_HB_denominator",
+        "effic_pfpuppijetpT_HB_pTThresh 'Jet pT turnON (HB);            PFPuppi Jet(pT) [GeV]; efficiency'     pfpuppijetpT_pTThresh_HB_numerator pfpuppijetpT_pTThresh_HB_denominator",
+        "effic_pfpuppijetphi_HB       'Jet efficiency vs #phi (HB); PFPuppi Jet #phi [rad]; efficiency' pfpuppijetphi_HB_numerator       pfpuppijetphi_HB_denominator",
+        "effic_pfpuppijeteta_HB       'Jet efficiency vs #eta (HB); PFPuppi Jet #eta; efficiency' pfpuppijeteta_HB_numerator       pfpuppijeteta_HB_denominator",
         ## HE
-        "effic_pfjetpT_HE          'Jet pT turnON (HE);            PFJet(pT) [GeV]; efficiency'     pfjetpT_HE_numerator          pfjetpT_HE_denominator",
-        "effic_pfjetpT_HE_pTThresh 'Jet pT turnON (HE);            PFJet(pT) [GeV]; efficiency'     pfjetpT_pTThresh_HE_numerator pfjetpT_pTThresh_HE_denominator",
-        "effic_pfjetphi_HE       'Jet efficiency vs #phi (HE); PF Jet #phi [rad]; efficiency' pfjetphi_HE_numerator       pfjetphi_HE_denominator",
-        "effic_pfjeteta_HE       'Jet efficiency vs #eta (HE); PF Jet #eta; efficiency' pfjeteta_HE_numerator       pfjeteta_HE_denominator",
+        "effic_pfpuppijetpT_HE          'Jet pT turnON (HE);            PFPuppi Jet(pT) [GeV]; efficiency'     pfpuppijetpT_HE_numerator          pfpuppijetpT_HE_denominator",
+        "effic_pfpuppijetpT_HE_pTThresh 'Jet pT turnON (HE);            PFPuppi Jet(pT) [GeV]; efficiency'     pfpuppijetpT_pTThresh_HE_numerator pfpuppijetpT_pTThresh_HE_denominator",
+        "effic_pfpuppijetphi_HE       'Jet efficiency vs #phi (HE); PFPuppi Jet #phi [rad]; efficiency' pfpuppijetphi_HE_numerator       pfpuppijetphi_HE_denominator",
+        "effic_pfpuppijeteta_HE       'Jet efficiency vs #eta (HE); PFPuppi Jet #eta; efficiency' pfpuppijeteta_HE_numerator       pfpuppijeteta_HE_denominator",
          ## HE_p
-        "effic_pfjetpT_HE_p          'Jet pT turnON (HEP);            PFJet(pT) [GeV]; efficiency'     pfjetpT_HE_p_numerator          pfjetpT_HE_p_denominator",
-        "effic_pfjetpT_HE_p_pTThresh 'Jet pT turnON (HEP);            PFJet(pT) [GeV]; efficiency'     pfjetpT_pTThresh_HE_p_numerator pfjetpT_pTThresh_HE_p_denominator",
-        "effic_pfjetphi_HE_p       'Jet efficiency vs #phi (HEP); PF Jet #phi [rad]; efficiency' pfjetphi_HE_p_numerator       pfjetphi_HE_p_denominator",
-        "effic_pfjeteta_HE_p       'Jet efficiency vs #eta (HEP); PF Jet #eta; efficiency' pfjeteta_HE_p_numerator       pfjeteta_HE_p_denominator",
+        "effic_pfpuppijetpT_HE_p          'Jet pT turnON (HEP);            PFPuppi Jet(pT) [GeV]; efficiency'     pfpuppijetpT_HE_p_numerator          pfpuppijetpT_HE_p_denominator",
+        "effic_pfpuppijetpT_HE_p_pTThresh 'Jet pT turnON (HEP);            PFPuppi Jet(pT) [GeV]; efficiency'     pfpuppijetpT_pTThresh_HE_p_numerator pfpuppijetpT_pTThresh_HE_p_denominator",
         ## HE_m
-        "effic_pfjetpT_HE_m          'Jet pT turnON (HEM);            PFJet(pT) [GeV]; efficiency'     pfjetpT_HE_m_numerator          pfjetpT_HE_m_denominator",
-        "effic_pfjetpT_HE_m_pTThresh 'Jet pT turnON (HEM);            PFJet(pT) [GeV]; efficiency'     pfjetpT_pTThresh_HE_m_numerator pfjetpT_pTThresh_HE_m_denominator",
-        "effic_pfjetphi_HE_m       'Jet efficiency vs #phi (HEM); PF Jet #phi [rad]; efficiency' pfjetphi_HE_m_numerator       pfjetphi_HE_m_denominator",
-        "effic_pfjeteta_HE_m       'Jet efficiency vs #eta (HEM); PF Jet #eta; efficiency' pfjeteta_HE_m_numerator       pfjeteta_HE_m_denominator",            
+        "effic_pfpuppijetpT_HE_m          'Jet pT turnON (HEM);            PFPuppi Jet(pT) [GeV]; efficiency'     pfpuppijetpT_HE_m_numerator          pfpuppijetpT_HE_m_denominator",
+        "effic_pfpuppijetpT_HE_m_pTThresh 'Jet pT turnON (HEM);            PFPuppi Jet(pT) [GeV]; efficiency'     pfpuppijetpT_pTThresh_HE_m_numerator pfpuppijetpT_pTThresh_HE_m_denominator", 
         ## HF
-        "effic_pfjetpT_HF          'Jet pT turnON (HF);            PFJet(pT) [GeV]; efficiency'     pfjetpT_HF_numerator          pfjetpT_HF_denominator",
-        "effic_pfjetpT_HF_pTThresh 'Jet pT turnON (HF);            PFJet(pT) [GeV]; efficiency'     pfjetpT_pTThresh_HF_numerator pfjetpT_pTThresh_HF_denominator",
-        "effic_pfjetphi_HF       'Jet efficiency vs #phi (HF); PF Jet #phi [rad]; efficiency' pfjetphi_HF_numerator       pfjetphi_HF_denominator",
-        "effic_pfjeteta_HF       'Jet efficiency vs #eta (HF); PF Jet #eta; efficiency' pfjeteta_HF_numerator       pfjeteta_HF_denominator",
+        "effic_pfpuppijetpT_HF          'Jet pT turnON (HF);            PFPuppi Jet(pT) [GeV]; efficiency'     pfpuppijetpT_HF_numerator          pfpuppijetpT_HF_denominator",
+        "effic_pfpuppijetpT_HF_pTThresh 'Jet pT turnON (HF);            PFPuppi Jet(pT) [GeV]; efficiency'     pfpuppijetpT_pTThresh_HF_numerator pfpuppijetpT_pTThresh_HF_denominator",
+        "effic_pfpuppijetphi_HF       'Jet efficiency vs #phi (HF); PFPuppi Jet #phi [rad]; efficiency' pfpuppijetphi_HF_numerator       pfpuppijetphi_HF_denominator",
+        "effic_pfpuppijeteta_HF       'Jet efficiency vs #eta (HF); PFPuppi Jet #eta; efficiency' pfpuppijeteta_HF_numerator       pfpuppijeteta_HF_denominator",
         ## 2D Eff
-        "effic_pfjetEtaVsPhi       'Jet efficiency vs #eta and #phi; PF Jet #eta; #phi' pfjetEtaVsPhi_numerator       pfjetEtaVsPhi_denominator",
-        "effic_pfjetEtaVsPhi_HB    'Jet efficiency vs #eta and #phi(HB); PF Jet #eta; #phi' pfjetEtaVsPhi_HB_numerator       pfjetEtaVsPhi_HB_denominator",
-        "effic_pfjetEtaVsPhi_HE    'Jet efficiency vs #eta and #phi(HE); PF Jet #eta; #phi' pfjetEtaVsPhi_HE_numerator       pfjetEtaVsPhi_HE_denominator",
-        "effic_pfjetEtaVsPhi_HF    'Jet efficiency vs #eta and #phi(HF); PF Jet #eta; #phi' pfjetEtaVsPhi_HF_numerator       pfjetEtaVsPhi_HF_denominator",
-
-        "effic_pfjetEtaVsPhi_HE_p 'Jet efficiency vs #eta and #phi(HE_p); PF Jet #eta; #phi' pfjetEtaVsPhi_HE_p_numerator       pfjetEtaVsPhi_HE_p_denominator",
-        "effic_pfjetEtaVsPhi_HE_m 'Jet efficiency vs #eta and #phi(HE_m); PF Jet #eta; #phi' pfjetEtaVsPhi_HE_m_numerator       pfjetEtaVsPhi_HE_m_denominator",
+        "effic_pfpuppijetEtaVsPhi       'Jet efficiency vs #eta and #phi; PFPuppi Jet #eta; #phi' pfpuppijetEtaVsPhi_numerator       pfpuppijetEtaVsPhi_denominator",
+        #"effic_pfpuppijetEtaVsPhi_HB    'Jet efficiency vs #eta and #phi(HB); PFPuppi Jet #eta; #phi' pfpuppijetEtaVsPhi_HB_numerator       pfpuppijetEtaVsPhi_HB_denominator",
+        #"effic_pfpuppijetEtaVsPhi_HE    'Jet efficiency vs #eta and #phi(HE); PFPuppi Jet #eta; #phi' pfpuppijetEtaVsPhi_HE_numerator       pfpuppijetEtaVsPhi_HE_denominator",
+        #"effic_pfpuppijetEtaVsPhi_HF    'Jet efficiency vs #eta and #phi(HF); PFPuppi Jet #eta; #phi' pfpuppijetEtaVsPhi_HF_numerator       pfpuppijetEtaVsPhi_HF_denominator",
          
-        "effic_pfjetEtaVspT        'Jet efficiency #eta vs Pt;     PF Jet #eta; Pt' pfjetEtaVspT_numerator          pfjetEtaVspT_denominator",
-        "effic_pfjetEtaVspT_HB     'Jet efficiency #eta vs Pt(HB); PF Jet #eta; Pt' pfjetEtaVspT_HB_numerator       pfjetEtaVspT_HB_denominator",
-        "effic_pfjetEtaVspT_HE     'Jet efficiency #eta vs Pt(HE); PF Jet #eta; Pt' pfjetEtaVspT_HE_numerator       pfjetEtaVspT_HE_denominator",
-        "effic_pfjetEtaVspT_HF     'Jet efficiency #eta vs Pt(HF); PF Jet #eta; Pt' pfjetEtaVspT_HF_numerator       pfjetEtaVspT_HF_denominator",
+        "effic_pfpuppijetEtaVspT        'Jet efficiency #eta vs Pt;     PFPuppi Jet #eta; Pt' pfpuppijetEtaVspT_numerator          pfpuppijetEtaVspT_denominator",
+        #"effic_pfpuppijetEtaVspT_HB     'Jet efficiency #eta vs Pt(HB); PFPuppi Jet #eta; Pt' pfpuppijetEtaVspT_HB_numerator       pfpuppijetEtaVspT_HB_denominator",
+        #"effic_pfpuppijetEtaVspT_HE     'Jet efficiency #eta vs Pt(HE); PFPuppi Jet #eta; Pt' pfpuppijetEtaVspT_HE_numerator       pfpuppijetEtaVspT_HE_denominator",
+        #"effic_pfpuppijetEtaVspT_HF     'Jet efficiency #eta vs Pt(HF); PFPuppi Jet #eta; Pt' pfpuppijetEtaVspT_HF_numerator       pfpuppijetEtaVspT_HF_denominator",
 
-        "effic_pfjetEtaVspT_HE_p   'Jet efficiency #eta vs Pt(HE_p); PF Jet #eta; Pt' pfjetEtaVspT_HE_p_numerator       pfjetEtaVspT_HE_p_denominator",
-        "effic_pfjetEtaVspT_HE_m   'Jet efficiency #eta vs Pt(HE_m); PF Jet #eta; Pt' pfjetEtaVspT_HE_m_numerator       pfjetEtaVspT_HE_m_denominator"
     ),
     efficiencyProfile = cms.untracked.vstring(
-        "effic_pfjetpT_vs_LS 'JET efficiency vs LS; LS; PF JET efficiency' pfjetpTVsLS_numerator pfjetpTVsLS_denominator",
-#        "effic_pfjetpT_HBvs_LS 'JET efficiency vs LS; LS; PF JET efficiency' pfjetpTVsLS_HB_numerator pfjetpTVsLS_HB_denominator",
-#        "effic_pfjetpT_HEvs_LS 'JET efficiency vs LS; LS; PF JET efficiency' pfjetpTVsLS_HE_numerator pfjetpTVsLS_HE_denominator",
-#        "effic_pfjetpT_HFvs_LS 'JET efficiency vs LS; LS; PF JET efficiency' pfjetpTVsLS_HF_numerator pfjetpTVsLS_HF_denominator",
-#        "effic_pfjetpT_HE_mvs_LS 'JET efficiency vs LS; LS; PF JET efficiency' pfjetpTVsLS_HE_m_numerator pfjetpTVsLS_HE_m_denominator",
-#        "effic_pfjetpT_HE_pvs_LS 'JET efficiency vs LS; LS; PF JET efficiency' pfjetpTVsLS_HE_p_numerator pfjetpTVsLS_HE_p_denominator",
+        "effic_pfpuppijetpT_vs_LS 'JET efficiency vs LS; LS; PF JET efficiency' pfpuppijetpTVsLS_numerator pfpuppijetpTVsLS_denominator",
     ),
   
 )
@@ -84,13 +70,9 @@ calojetEfficiency = DQMEDHarvester("DQMGenericClient",
 
         "effic_calojetpT_HE_p          'Jet pT turnON (HEP);            CaloJet(pT) [GeV]; efficiency'     calojetpT_HE_p_numerator          calojetpT_HE_p_denominator",
         "effic_calojetpT_HE_p_pTThresh 'Jet pT turnON (HEP);            CaloJet(pT) [GeV]; efficiency'     calojetpT_pTThresh_HE_p_numerator calojetpT_pTThresh_HE_P_denominator",
-        "effic_calojetphi_HE_p       'Jet efficiency vs #phi (HEP); Calo Jet #phi [rad]; efficiency' calojetphi_HE_p_numerator       calojetphi_HE_p_denominator",
-        "effic_calojeteta_HE_p       'Jet efficiency vs #eta (HEP); Calo Jet #eta; efficiency' calojeteta_HE_p_numerator       calojeteta_HE_p_denominator",
 
         "effic_calojetpT_HE_m          'Jet pT turnON (HEM);            CaloJet(pT) [GeV]; efficiency'     calojetpT_HE_m_numerator          calojetpT_HE_m_denominator",
         "effic_calojetpT_HE_m_pTThresh 'Jet pT turnON (HEM);            CaloJet(pT) [GeV]; efficiency'     calojetpT_pTThresh_HE_m_numerator calojetpT_pTThresh_HE_m_denominator",
-        "effic_calojetphi_HE_m       'Jet efficiency vs #phi (HEM); Calo Jet #phi [rad]; efficiency' calojetphi_HE_m_numerator       calojetphi_HE_m_denominator",
-        "effic_calojeteta_HE_m       'Jet efficiency vs #eta (HEM); Calo Jet #eta; efficiency' calojeteta_HE_m_numerator       calojeteta_HE_m_denominator",
 
         "effic_calojetpT_HF          'Jet pT turnON;            CaloJet(pT) [GeV]; efficiency'     calojetpT_HF_numerator          calojetpT_HF_denominator",
         "effic_calojetpT_HF_pTThresh 'Jet pT turnON;            CaloJet(pT) [GeV]; efficiency'     calojetpT_pTThresh_HF_numerator calojetpT_pTThresh_HF_denominator",
@@ -99,36 +81,109 @@ calojetEfficiency = DQMEDHarvester("DQMGenericClient",
 
         ## 2D Eff
         "effic_calojetEtaVsPhi       'Jet efficiency vs #eta and #phi;      Calo Jet #eta; #phi' calojetEtaVsPhi_numerator          calojetEtaVsPhi_denominator",
-        "effic_calojetEtaVsPhi_HB    'Jet efficiency vs #eta and #phi(HB);  Calo Jet #eta; #phi' calojetEtaVsPhi_HB_numerator       calojetEtaVsPhi_HB_denominator",
-        "effic_calojetEtaVsPhi_HE    'Jet efficiency vs #eta and #phi(HE);  Calo Jet #eta; #phi' calojetEtaVsPhi_HE_numerator       calojetEtaVsPhi_HE_denominator",
-        "effic_calojetEtaVsPhi_HF    'Jet efficiency vs #eta and #phi(HF);  Calo Jet #eta; #phi' calojetEtaVsPhi_HF_numerator       calojetEtaVsPhi_HF_denominator",
-        "effic_calojetEtaVsPhi_HE_p 'Jet efficiency vs #eta and #phi(HE_p); Calo Jet #eta; #phi' calojetEtaVsPhi_HE_p_numerator     calojetEtaVsPhi_HE_p_denominator",
-        "effic_calojetEtaVsPhi_HE_m 'Jet efficiency vs #eta and #phi(HE_m); Calo Jet #eta; #phi' calojetEtaVsPhi_HE_m_numerator     calojetEtaVsPhi_HE_m_denominator",
+        #"effic_calojetEtaVsPhi_HB    'Jet efficiency vs #eta and #phi(HB);  Calo Jet #eta; #phi' calojetEtaVsPhi_HB_numerator       calojetEtaVsPhi_HB_denominator",
+        #"effic_calojetEtaVsPhi_HE    'Jet efficiency vs #eta and #phi(HE);  Calo Jet #eta; #phi' calojetEtaVsPhi_HE_numerator       calojetEtaVsPhi_HE_denominator",
+        #"effic_calojetEtaVsPhi_HF    'Jet efficiency vs #eta and #phi(HF);  Calo Jet #eta; #phi' calojetEtaVsPhi_HF_numerator       calojetEtaVsPhi_HF_denominator",
         
         "effic_calojetEtaVspT        'Jet efficiency #eta vs Pt;        Calo Jet #eta; Pt' calojetEtaVspT_numerator          calojetEtaVspT_denominator",
-        "effic_calojetEtaVspT_HB     'Jet efficiency #eta vs Pt(HB);    Calo Jet #eta; Pt' calojetEtaVspT_HB_numerator       calojetEtaVspT_HB_denominator",
-        "effic_calojetEtaVspT_HE     'Jet efficiency #eta vs Pt(HE);    Calo Jet #eta; Pt' calojetEtaVspT_HE_numerator       calojetEtaVspT_HE_denominator",
-        "effic_calojetEtaVspT_HF     'Jet efficiency #eta vs Pt(HF);    Calo Jet #eta; Pt' calojetEtaVspT_HF_numerator       calojetEtaVspT_HF_denominator",
-
-        "effic_calojetEtaVspT_HE_p   'Jet efficiency #eta vs Pt(HE_p);  Calo Jet #eta; Pt' calojetEtaVspT_HE_p_numerator     calojetEtaVspT_HE_p_denominator",
-        "effic_calojetEtaVspT_HE_m   'Jet efficiency #eta vs Pt(HE_m);  Calo Jet #eta; Pt' calojetEtaVspT_HE_m_numerator     calojetEtaVspT_HE_m_denominator"
-
+        #"effic_calojetEtaVspT_HB     'Jet efficiency #eta vs Pt(HB);    Calo Jet #eta; Pt' calojetEtaVspT_HB_numerator       calojetEtaVspT_HB_denominator",
+        #"effic_calojetEtaVspT_HE     'Jet efficiency #eta vs Pt(HE);    Calo Jet #eta; Pt' calojetEtaVspT_HE_numerator       calojetEtaVspT_HE_denominator",
+        #"effic_calojetEtaVspT_HF     'Jet efficiency #eta vs Pt(HF);    Calo Jet #eta; Pt' calojetEtaVspT_HF_numerator       calojetEtaVspT_HF_denominator",
     ),
     efficiencyProfile = cms.untracked.vstring(
         "effic_calojetpT_vs_LS 'JET efficiency vs LS; LS; Calo Jet efficiency' calojetpTVsLS_numerator calojetpTVsLS_denominator",
-#        "effic_calojetpT_vs_LS 'JET efficiency vs LS; LS; Calo JET efficiency' calojetpTVsLS_numerator calojetpTVsLS_denominator",
-#        "effic_calojetpT_HBvs_LS 'JET efficiency vs LS; LS; Calo JET efficiency' calojetpTVsLS_HB_numerator calojetpTVsLS_HB_denominator",
-#        "effic_calojetpT_HEvs_LS 'JET efficiency vs LS; LS; Calo JET efficiency' calojetpTVsLS_HE_numerator calojetpTVsLS_HE_denominator",
-#        "effic_calojetpT_HFvs_LS 'JET efficiency vs LS; LS; Calo JET efficiency' calojetpTVsLS_HF_numerator calojetpTVsLS_HF_denominator",
-#        "effic_calojetpT_HE_mvs_LS 'JET efficiency vs LS; LS; Calo JET efficiency' calojetpTVsLS_HE_m_numerator calojetpTVsLS_HE_m_denominator",
-#        "effic_calojetpT_HE_pvs_LS 'JET efficiency vs LS; LS; Calo JET efficiency' calojetpTVsLS_HE_p_numerator calojetpTVsLS_HE_p_denominator",
     ),
   
 )
 
+GammaJetsEfficiency = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/JME/ZGammaPlusJets*"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_HLTJetPt40           'HLT Jet (cut=40GeV) efficiency vs HLT Photon Pt [GeV];             HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over40_numerator           PhotonpT_numerator",
+        "effic_HLTJetPt40_HB        'HLT Jet (cut=40GeV) efficiency [HB] vs HLT Photon Pt [GeV];        HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over40_HB_numerator        PhotonpT_HB_numerator",
+        "effic_HLTJetPt40_HEInner   'HLT Jet (cut=40GeV) efficiency [HEInner] vs HLT Photon Pt [GeV];   HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over40_HEInner_numerator   PhotonpT_HEInner_numerator",
+        "effic_HLTJetPt40_HEOuter   'HLT Jet (cut=40GeV) efficiency [HEOuter] vs HLT Photon Pt [GeV];   HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over40_HEOuter_numerator   PhotonpT_HEOuter_numerator",
 
+        "effic_HLTJetPt60           'HLT Jet (cut=60GeV) efficiency vs HLT Photon Pt [GeV];             HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over60_numerator           PhotonpT_numerator",
+        "effic_HLTJetPt60_HB        'HLT Jet (cut=60GeV) efficiency [HB] vs HLT Photon Pt [GeV];        HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over60_HB_numerator        PhotonpT_HB_numerator",
+        "effic_HLTJetPt60_HEInner   'HLT Jet (cut=60GeV) efficiency [HEInner] vs HLT Photon Pt [GeV];   HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over60_HEInner_numerator   PhotonpT_HEInner_numerator",
+        "effic_HLTJetPt60_HEOuter   'HLT Jet (cut=60GeV) efficiency [HEOuter] vs HLT Photon Pt [GeV];   HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over60_HEOuter_numerator   PhotonpT_HEOuter_numerator",
+
+        "effic_HLTJetPt80           'HLT Jet (cut=80GeV) efficiency vs HLT Photon Pt [GeV];             HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over80_numerator           PhotonpT_numerator",
+        "effic_HLTJetPt80_HB        'HLT Jet (cut=80GeV) efficiency [HB] vs HLT Photon Pt [GeV];        HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over80_HB_numerator        PhotonpT_HB_numerator",
+        "effic_HLTJetPt80_HEInner   'HLT Jet (cut=80GeV) efficiency [HEInner] vs HLT Photon Pt [GeV];   HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over80_HEInner_numerator   PhotonpT_HEInner_numerator",
+        "effic_HLTJetPt80_HEOuter   'HLT Jet (cut=80GeV) efficiency [HEOuter] vs HLT Photon Pt [GeV];   HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over80_HEOuter_numerator   PhotonpT_HEOuter_numerator",
+
+        "effic_HLTJetPt110          'HLT Jet (cut=110GeV) efficiency vs HLT Photon Pt [GeV];            HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over110_numerator          PhotonpT_numerator",
+        "effic_HLTJetPt110_HB       'HLT Jet (cut=110GeV) efficiency [HB] vs HLT Photon Pt [GeV];       HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over110_HB_numerator       PhotonpT_HB_numerator",
+        "effic_HLTJetPt110_HEInner  'HLT Jet (cut=110GeV) efficiency [HEInner] vs HLT Photon Pt [GeV];  HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over110_HEInner_numerator  PhotonpT_HEInner_numerator",
+        "effic_HLTJetPt110_HEOuter  'HLT Jet (cut=110GeV) efficiency [HEOuter] vs HLT Photon Pt [GeV];  HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over110_HEOuter_numerator  PhotonpT_HEOuter_numerator",
+        
+        "effic_HLTJetPt140          'HLT Jet (cut=140GeV) efficiency vs HLT Photon Pt [GeV];            HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over140_numerator          PhotonpT_numerator",
+        "effic_HLTJetPt140_HB       'HLT Jet (cut=140GeV) efficiency [HB] vs HLT Photon Pt [GeV];       HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over140_HB_numerator       PhotonpT_HB_numerator",
+        "effic_HLTJetPt140_HEInner  'HLT Jet (cut=140GeV) efficiency [HEInner] vs HLT Photon Pt [GeV];  HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over140_HEInner_numerator  PhotonpT_HEInner_numerator",
+        "effic_HLTJetPt140_HEOuter  'HLT Jet (cut=140GeV) efficiency [HEOuter] vs HLT Photon Pt [GeV];  HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over140_HEOuter_numerator  PhotonpT_HEOuter_numerator",
+
+        "effic_HLTJetPt200          'HLT Jet (cut=200GeV) efficiency vs HLT Photon Pt [GeV];            HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over200_numerator          PhotonpT_numerator",
+        "effic_HLTJetPt200_HB       'HLT Jet (cut=200GeV) efficiency [HB] vs HLT Photon Pt [GeV];       HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over200_HB_numerator       PhotonpT_HB_numerator",
+        "effic_HLTJetPt200_HEInner  'HLT Jet (cut=200GeV) efficiency [HEInner] vs HLT Photon Pt [GeV];  HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over200_HEInner_numerator  PhotonpT_HEInner_numerator",
+        "effic_HLTJetPt200_HEOuter  'HLT Jet (cut=200GeV) efficiency [HEOuter] vs HLT Photon Pt [GeV];  HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over200_HEOuter_numerator  PhotonpT_HEOuter_numerator",
+
+        "effic_HLTJetPt320          'HLT Jet (cut=320GeV) efficiency vs HLT Photon Pt [GeV];            HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over320_numerator          PhotonpT_numerator",
+        "effic_HLTJetPt320_HB       'HLT Jet (cut=320GeV) efficiency [HB] vs HLT Photon Pt [GeV];       HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over320_HB_numerator       PhotonpT_HB_numerator",
+        "effic_HLTJetPt320_HEInner  'HLT Jet (cut=320GeV) efficiency [HEInner] vs HLT Photon Pt [GeV];  HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over320_HEInner_numerator  PhotonpT_HEInner_numerator",
+        "effic_HLTJetPt320_HEOuter  'HLT Jet (cut=320GeV) efficiency [HEOuter] vs HLT Photon Pt [GeV];  HLT Photon (pT) [GeV]; efficiency'  PhotonpT_for_JetpT_over320_HEOuter_numerator  PhotonpT_HEOuter_numerator",
+        ),
+    )
+ZJetsEfficiency = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/JME/ZGammaPlusJets*"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_HLTJetPt40           'HLT Jet (cut=40GeV) efficiency vs HLT Z Pt [GeV];             HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over40_numerator           ZpT_numerator",
+        "effic_HLTJetPt40_HB        'HLT Jet (cut=40GeV) efficiency [HB] vs HLT Z Pt [GeV];        HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over40_HB_numerator        ZpT_HB_numerator",
+        "effic_HLTJetPt40_HEInner   'HLT Jet (cut=40GeV) efficiency [HEInner] vs HLT Z Pt [GeV];   HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over40_HEInner_numerator   ZpT_HEInner_numerator",
+        "effic_HLTJetPt40_HEOuter   'HLT Jet (cut=40GeV) efficiency [HEOuter] vs HLT Z Pt [GeV];   HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over40_HEOuter_numerator   ZpT_HEOuter_numerator",
+
+        "effic_HLTJetPt60           'HLT Jet (cut=60GeV) efficiency vs HLT Z Pt [GeV];             HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over60_numerator           ZpT_numerator",
+        "effic_HLTJetPt60_HB        'HLT Jet (cut=60GeV) efficiency [HB] vs HLT Z Pt [GeV];        HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over60_HB_numerator        ZpT_HB_numerator",
+        "effic_HLTJetPt60_HEInner   'HLT Jet (cut=60GeV) efficiency [HEInner] vs HLT Z Pt [GeV];   HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over60_HEInner_numerator   ZpT_HEInner_numerator",
+        "effic_HLTJetPt60_HEOuter   'HLT Jet (cut=60GeV) efficiency [HEOuter] vs HLT Z Pt [GeV];   HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over60_HEOuter_numerator   ZpT_HEOuter_numerator",
+
+        "effic_HLTJetPt80           'HLT Jet (cut=80GeV) efficiency vs HLT Z Pt [GeV];             HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over80_numerator           ZpT_numerator",
+        "effic_HLTJetPt80_HB        'HLT Jet (cut=80GeV) efficiency [HB] vs HLT Z Pt [GeV];        HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over80_HB_numerator        ZpT_HB_numerator",
+        "effic_HLTJetPt80_HEInner   'HLT Jet (cut=80GeV) efficiency [HEInner] vs HLT Z Pt [GeV];   HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over80_HEInner_numerator   ZpT_HEInner_numerator",
+        "effic_HLTJetPt80_HEOuter   'HLT Jet (cut=80GeV) efficiency [HEOuter] vs HLT Z Pt [GeV];   HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over80_HEOuter_numerator   ZpT_HEOuter_numerator",
+        
+        "effic_HLTJetPt110          'HLT Jet (cut=110GeV) efficiency vs HLT Z Pt [GeV];            HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over110_numerator          ZpT_numerator",
+        "effic_HLTJetPt110_HB       'HLT Jet (cut=110GeV) efficiency [HB] vs HLT Z Pt [GeV];       HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over110_HB_numerator       ZpT_HB_numerator",
+        "effic_HLTJetPt110_HEInner  'HLT Jet (cut=110GeV) efficiency [HEInner] vs HLT Z Pt [GeV];  HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over110_HEInner_numerator  ZpT_HEInner_numerator",
+        "effic_HLTJetPt110_HEOuter  'HLT Jet (cut=110GeV) efficiency [HEOuter] vs HLT Z Pt [GeV];  HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over110_HEOuter_numerator  ZpT_HEOuter_numerator",
+        
+        "effic_HLTJetPt140          'HLT Jet (cut=140GeV) efficiency vs HLT Z Pt [GeV];            HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over140_numerator          ZpT_numerator",
+        "effic_HLTJetPt140_HB       'HLT Jet (cut=140GeV) efficiency [HB] vs HLT Z Pt [GeV];       HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over140_HB_numerator       ZpT_HB_numerator",
+        "effic_HLTJetPt140_HEInner  'HLT Jet (cut=140GeV) efficiency [HEInner] vs HLT Z Pt [GeV];  HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over140_HEInner_numerator  ZpT_HEInner_numerator",
+        "effic_HLTJetPt140_HEOuter  'HLT Jet (cut=140GeV) efficiency [HEOuter] vs HLT Z Pt [GeV];  HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over140_HEOuter_numerator  ZpT_HEOuter_numerator",
+
+        "effic_HLTJetPt200          'HLT Jet (cut=200GeV) efficiency vs HLT Z Pt [GeV];            HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over200_numerator          ZpT_numerator",
+        "effic_HLTJetPt200_HB       'HLT Jet (cut=200GeV) efficiency [HB] vs HLT Z Pt [GeV];       HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over200_HB_numerator       ZpT_HB_numerator",
+        "effic_HLTJetPt200_HEInner  'HLT Jet (cut=200GeV) efficiency [HEInner] vs HLT Z Pt [GeV];  HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over200_HEInner_numerator  ZpT_HEInner_numerator",
+        "effic_HLTJetPt200_HEOuter  'HLT Jet (cut=200GeV) efficiency [HEOuter] vs HLT Z Pt [GeV];  HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over200_HEOuter_numerator  ZpT_HEOuter_numerator",
+
+        "effic_HLTJetPt320          'HLT Jet (cut=320GeV) efficiency vs HLT Z Pt [GeV];            HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over320_numerator          ZpT_numerator",
+        "effic_HLTJetPt320_HB       'HLT Jet (cut=320GeV) efficiency [HB] vs HLT Z Pt [GeV];       HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over320_HB_numerator       ZpT_HB_numerator",
+        "effic_HLTJetPt320_HEInner  'HLT Jet (cut=320GeV) efficiency [HEInner] vs HLT Z Pt [GeV];  HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over320_HEInner_numerator  ZpT_HEInner_numerator",
+        "effic_HLTJetPt320_HEOuter  'HLT Jet (cut=320GeV) efficiency [HEOuter] vs HLT Z Pt [GeV];  HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over320_HEOuter_numerator  ZpT_HEOuter_numerator",
+        ),
+    )
+
+#-----------------------------
 
 JetMetPromClient = cms.Sequence(
     pfjetEfficiency
     *calojetEfficiency
+    *GammaJetsEfficiency
+    *ZJetsEfficiency
 )

--- a/DQMOffline/Trigger/python/JetMonitor_cff.py
+++ b/DQMOffline/Trigger/python/JetMonitor_cff.py
@@ -1,11 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.JetMonitor_cfi import hltJetMETmonitoring
+from JetMETCorrections.Configuration.JetCorrectors_cff import *
+from DQMOffline.Trigger.ZGammaplusJetsMonitor_cff import *
 
 ### HLT_PFJet Triggers ###
 # HLT_PFJet450
 PFJet450_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4/PF/HLT_PFJet450/',
+    corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  112 ,
                 xmin  =   0.,
@@ -17,6 +22,9 @@ PFJet450_Prommonitoring = hltJetMETmonitoring.clone(
 # HLT_PFJet40
 PFJet40_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4/PF/HLT_PFJet40/',
+    corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  50 ,
                 xmin  =  0.,
@@ -27,6 +35,9 @@ PFJet40_Prommonitoring = hltJetMETmonitoring.clone(
 # HLT_PFJet60
 PFJet60_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4/PF/HLT_PFJet60/',
+    corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  75 ,
                 xmin  =  0.,
@@ -38,6 +49,9 @@ PFJet60_Prommonitoring = hltJetMETmonitoring.clone(
 # HLT_PFJet80
 PFJet80_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4/PF/HLT_PFJet80/',
+    corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  100,
                 xmin  =  0.,
@@ -48,6 +62,9 @@ PFJet80_Prommonitoring = hltJetMETmonitoring.clone(
 # HLT_PFJet140
 PFJet140_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4/PF/HLT_PFJet140/',
+    corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  70 ,
                 xmin  =  0.,
@@ -58,6 +75,9 @@ PFJet140_Prommonitoring = hltJetMETmonitoring.clone(
 # HLT_PFJet200
 PFJet200_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4/PF/HLT_PFJet200/',
+    corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  50 ,
                 xmin  =   0.,
@@ -69,6 +89,9 @@ PFJet200_Prommonitoring = hltJetMETmonitoring.clone(
 # HLT_PFJet260
 PFJet260_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4/PF/HLT_PFJet260/',
+    corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins = 65,
                 xmin  = 0.,
@@ -80,6 +103,9 @@ PFJet260_Prommonitoring = hltJetMETmonitoring.clone(
 # HLT_PFJet320
 PFJet320_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4/PF/HLT_PFJet320/',
+    corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins = 80 ,
                 xmin  =  0.,
@@ -91,17 +117,22 @@ PFJet320_Prommonitoring = hltJetMETmonitoring.clone(
 # HLT_PFJet400
 PFJet400_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4/PF/HLT_PFJet400/',
+    corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins = 100 ,
                 xmin  =  0.,
                 xmax  =  1000.)),
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJet400_v*"])
-
 )
 
 # HLT_PFJet500
 PFJet500_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4/PF/HLT_PFJet500/',
+    corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  125,
                 xmin  =  0.,
@@ -114,6 +145,9 @@ PFJet500_Prommonitoring = hltJetMETmonitoring.clone(
 # HLT_PFJetFwd450
 PFJetFwd450_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd450/',
+    corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  112 ,
                 xmin  =  0.,
@@ -124,6 +158,9 @@ PFJetFwd450_Prommonitoring = hltJetMETmonitoring.clone(
 # HLT_PFJetFwd40
 PFJetFwd40_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd40/',
+    corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  50 ,
                 xmin  =   0.,
@@ -135,6 +172,9 @@ PFJetFwd40_Prommonitoring = hltJetMETmonitoring.clone(
 # HLT_PFJetFwd60
 PFJetFwd60_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd60/',
+    corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  75 ,
                 xmin  =   0.,
@@ -146,6 +186,9 @@ PFJetFwd60_Prommonitoring = hltJetMETmonitoring.clone(
 # HLT_PFJetFwd80
 PFJetFwd80_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd80/',
+    corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  100,
                 xmin  =   0.,
@@ -157,6 +200,9 @@ PFJetFwd80_Prommonitoring = hltJetMETmonitoring.clone(
 # HLT_PFJetFwd140
 PFJetFwd140_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd140/',
+    corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  70 ,
                 xmin  =   0.,
@@ -168,6 +214,9 @@ PFJetFwd140_Prommonitoring = hltJetMETmonitoring.clone(
 # HLT_PFJetFwd200
 PFJetFwd200_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd200/',
+    corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins = 50 ,
                 xmin  =   0.,
@@ -179,6 +228,9 @@ PFJetFwd200_Prommonitoring = hltJetMETmonitoring.clone(
 # HLT_PFJetFwd260
 PFJetFwd260_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd260/',
+    corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins = 65 ,
                 xmin  =  0.,
@@ -190,6 +242,9 @@ PFJetFwd260_Prommonitoring = hltJetMETmonitoring.clone(
 # HLT_PFJetFwd320
 PFJetFwd320_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd320/',
+    corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins = 80 ,
                 xmin  =  0.,
@@ -201,6 +256,9 @@ PFJetFwd320_Prommonitoring = hltJetMETmonitoring.clone(
 # HLT_PFJetFwd400
 PFJetFwd400_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd400/',
+    corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins = 100 ,
                 xmin  =  0.,
@@ -212,6 +270,9 @@ PFJetFwd400_Prommonitoring = hltJetMETmonitoring.clone(
 # HLT_PFJetFwd500
 PFJetFwd500_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd500/',
+    corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins = 125,
                 xmin  =   0.,
@@ -225,6 +286,10 @@ PFJetFwd500_Prommonitoring = hltJetMETmonitoring.clone(
 AK8PFJet40_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK8/PF/HLT_AK8PFJet40/',
     jetSrc = "ak8PFJetsPuppi",
+    corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
+    dr2cut = 0.64,
     histoPSet =dict(jetPtThrPSet = dict(
                 nbins =  50 ,
                 xmin  =   0.,
@@ -240,8 +305,12 @@ AK8PFJet40_Prommonitoring = hltJetMETmonitoring.clone(
 AK8PFJet60_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK8/PF/HLT_AK8PFJet60/',
     jetSrc = "ak8PFJetsPuppi",
-    ispfjettrg = True,
+    corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
+    ispfjettrg = True,  # flag for the trigger path 
     iscalojettrg = False,
+    ispuppijet = True,  # flag for offline collection and histonaming
+    enableFullMonitoring = False,
+    dr2cut = 0.64,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  75 ,
                 xmin  =  0.,
@@ -254,8 +323,12 @@ AK8PFJet60_Prommonitoring = hltJetMETmonitoring.clone(
 AK8PFJet80_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK8/PF/HLT_AK8PFJet80/',
     jetSrc = "ak8PFJetsPuppi",
+    corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
     ispfjettrg = True,
     iscalojettrg = False,
+    ispuppijet = True,
+    enableFullMonitoring = False,
+    dr2cut = 0.64,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  100 ,
                 xmin  =   0.,
@@ -268,8 +341,12 @@ AK8PFJet80_Prommonitoring = hltJetMETmonitoring.clone(
 AK8PFJet140_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK8/PF/HLT_AK8PFJet140/',
     jetSrc = "ak8PFJetsPuppi",
+    corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
     ispfjettrg = True,
     iscalojettrg = False,
+    ispuppijet = True,
+    enableFullMonitoring = False,
+    dr2cut = 0.64,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  70 ,
                 xmin  =   0.,
@@ -282,8 +359,12 @@ AK8PFJet140_Prommonitoring = hltJetMETmonitoring.clone(
 AK8PFJet200_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK8/PF/HLT_AK8PFJet200/',
     jetSrc = "ak8PFJetsPuppi",
+    corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
     ispfjettrg = True,
     iscalojettrg = False,
+    ispuppijet = True,
+    enableFullMonitoring = False,
+    dr2cut = 0.64,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  50,
                 xmin  =  0.,
@@ -296,8 +377,12 @@ AK8PFJet200_Prommonitoring = hltJetMETmonitoring.clone(
 AK8PFJet260_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK8/PF/HLT_AK8PFJet260/',
     jetSrc = "ak8PFJetsPuppi",
+    corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
     ispfjettrg = True,
     iscalojettrg = False,
+    ispuppijet = True,
+    enableFullMonitoring = False,
+    dr2cut = 0.64,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  65 ,
                 xmin  =   0.,
@@ -310,8 +395,12 @@ AK8PFJet260_Prommonitoring = hltJetMETmonitoring.clone(
 AK8PFJet320_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK8/PF/HLT_AK8PFJet320/',
     jetSrc = "ak8PFJetsPuppi",
+    corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
     ispfjettrg = True,
     iscalojettrg = False,
+    ispuppijet = True,
+    enableFullMonitoring = False,
+    dr2cut = 0.64,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  80 ,
                 xmin  =  0.,
@@ -324,8 +413,12 @@ AK8PFJet320_Prommonitoring = hltJetMETmonitoring.clone(
 AK8PFJet400_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK8/PF/HLT_AK8PFJet400/',
     jetSrc = "ak8PFJetsPuppi",
+    corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
     ispfjettrg = True,
     iscalojettrg = False,
+    ispuppijet = True,
+    enableFullMonitoring = False,
+    dr2cut = 0.64,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  100 ,
                 xmin  =  0.,
@@ -338,8 +431,12 @@ AK8PFJet400_Prommonitoring = hltJetMETmonitoring.clone(
 AK8PFJet450_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK8/PF/HLT_AK8PFJet450/',
     jetSrc = "ak8PFJetsPuppi",
+    corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
     ispfjettrg = True,
     iscalojettrg = False,
+    ispuppijet = True,
+    enableFullMonitoring = False,
+    dr2cut = 0.64,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  112 ,
                 xmin  =   0.,
@@ -352,8 +449,12 @@ AK8PFJet450_Prommonitoring = hltJetMETmonitoring.clone(
 AK8PFJet500_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK8/PF/HLT_AK8PFJet500/',
     jetSrc = "ak8PFJetsPuppi",
+    corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
     ispfjettrg = True,
     iscalojettrg = False,
+    ispuppijet = True,
+    enableFullMonitoring = False,
+    dr2cut = 0.64,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  125,
                 xmin  =  0.,
@@ -367,8 +468,12 @@ AK8PFJet500_Prommonitoring = hltJetMETmonitoring.clone(
 AK8PFJetFwd40_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd40/',
     jetSrc = "ak8PFJetsPuppi",
+    corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
     ispfjettrg = True,
     iscalojettrg = False,
+    ispuppijet = True,
+    enableFullMonitoring = False,
+    dr2cut = 0.64,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  50 ,
                 xmin  =  0.,
@@ -381,8 +486,12 @@ AK8PFJetFwd40_Prommonitoring = hltJetMETmonitoring.clone(
 AK8PFJetFwd60_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd60/',
     jetSrc = "ak8PFJetsPuppi",
+    corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
     ispfjettrg = True,
     iscalojettrg = False,
+    ispuppijet = True,
+    enableFullMonitoring = False,
+    dr2cut = 0.64,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  75 ,
                 xmin  =   0.,
@@ -395,8 +504,12 @@ AK8PFJetFwd60_Prommonitoring = hltJetMETmonitoring.clone(
 AK8PFJetFwd80_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd80/',
     jetSrc = "ak8PFJetsPuppi",
+    corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
     ispfjettrg = True,
     iscalojettrg = False,
+    ispuppijet = True,
+    enableFullMonitoring = False,
+    dr2cut = 0.64,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  100 ,
                 xmin  =   0.,
@@ -409,8 +522,12 @@ AK8PFJetFwd80_Prommonitoring = hltJetMETmonitoring.clone(
 AK8PFJetFwd140_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd140/',
     jetSrc = "ak8PFJetsPuppi",
+    corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
     ispfjettrg = True,
     iscalojettrg = False,
+    ispuppijet = True,
+    enableFullMonitoring = False,
+    dr2cut = 0.64,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  70 ,
                 xmin  =   0.,
@@ -423,8 +540,12 @@ AK8PFJetFwd140_Prommonitoring = hltJetMETmonitoring.clone(
 AK8PFJetFwd200_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd200/',
     jetSrc = "ak8PFJetsPuppi",
+    corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
     ispfjettrg = True,
     iscalojettrg = False,
+    ispuppijet = True,
+    enableFullMonitoring = False,
+    dr2cut = 0.64,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  50 ,
                 xmin  =   0.,
@@ -437,8 +558,12 @@ AK8PFJetFwd200_Prommonitoring = hltJetMETmonitoring.clone(
 AK8PFJetFwd260_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd260/',
     jetSrc = "ak8PFJetsPuppi",
+    corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
     ispfjettrg = True,
     iscalojettrg = False,
+    ispuppijet = True,
+    enableFullMonitoring = False,
+    dr2cut = 0.64,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  65 ,
                 xmin  =   0.,
@@ -451,8 +576,12 @@ AK8PFJetFwd260_Prommonitoring = hltJetMETmonitoring.clone(
 AK8PFJetFwd320_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd320/',
     jetSrc = "ak8PFJetsPuppi",
+    corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
     ispfjettrg = True,
     iscalojettrg = False,
+    ispuppijet = True,
+    enableFullMonitoring = False,
+    dr2cut = 0.64,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  80 ,
                 xmin  =  0.,
@@ -465,8 +594,12 @@ AK8PFJetFwd320_Prommonitoring = hltJetMETmonitoring.clone(
 AK8PFJetFwd400_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd400/',
     jetSrc = "ak8PFJetsPuppi",
+    corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
     ispfjettrg = True,
     iscalojettrg = False,
+    ispuppijet = True,
+    enableFullMonitoring = False,
+    dr2cut = 0.64,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  100 ,
                 xmin  =   0.,
@@ -478,8 +611,12 @@ AK8PFJetFwd400_Prommonitoring = hltJetMETmonitoring.clone(
 AK8PFJetFwd450_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd450/',
     jetSrc = "ak8PFJetsPuppi",
+    corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
     ispfjettrg = True,
     iscalojettrg = False,
+    ispuppijet = True,
+    enableFullMonitoring = False,
+    dr2cut = 0.64,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =   112 ,
                 xmin  =  0.,
@@ -492,8 +629,12 @@ AK8PFJetFwd450_Prommonitoring = hltJetMETmonitoring.clone(
 AK8PFJetFwd500_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd500/',
     jetSrc = "ak8PFJetsPuppi",
+    corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
     ispfjettrg = True,
     iscalojettrg = False,
+    ispuppijet = True,
+    enableFullMonitoring = False,
+    dr2cut = 0.64,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  125,
                 xmin  =   0.,
@@ -506,18 +647,76 @@ AK8PFJetFwd500_Prommonitoring = hltJetMETmonitoring.clone(
 CaloJet500_NoJetID_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4/Calo/HLT_CaloJet500_NoJetID/',
     jetSrc = "ak4CaloJets",
+    corrector = "ak4CaloL1FastL2L3ResidualCorrector",
     ispfjettrg = False,
     iscalojettrg = True,
+    ispuppijet = False,
+    enableFullMonitoring = False,
     histoPSet = dict(jetPtThrPSet = dict(
                 nbins =  125,
                 xmin  =   0.,
                 xmax  = 1250)),
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_CaloJet500_NoJetID_v*"])
 )
+# configure 3 unprescaled triggers to monitor them using orthogonal method with muon dataset
+# ----------------------------------------------------------------------------------------
+# HLT_PFJetFwd500
+PFJet500_Orthogonal_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/MuonOrthogonal/HLT_PFJet500/',
+    corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = True,
+    dr2cut = 0.16,
+    nmuons = 1,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins = 125,
+                xmin  =   0.,
+                xmax  = 1250)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJet500_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_IsoMu24_v*"])
+)
+# HLT_AK8PFJet500
+AK8PFJet500_Orthogonal_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/MuonOrthogonal/HLT_AK8PFJet500/',
+    jetSrc = "ak8PFJetsPuppi",
+    corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
+    ispuppijet = True,
+    enableFullMonitoring = False,
+    ispfjettrg = True,
+    iscalojettrg = False,
+    dr2cut = 0.64,
+    nmuons = 1,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  125,
+                xmin  =  0.,
+                xmax  = 1250)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet500_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_IsoMu24_v*"])
+)
+# HLT_CaloJet500_NoJetID
+CaloJet500_NoJetID_Orthogonal_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/MuonOrthogonal/HLT_CaloJet500_NoJetID/',
+    jetSrc = "ak4CaloJets",
+    corrector = "ak4CaloL1FastL2L3ResidualCorrector",
+    ispuppijet = False,
+    enableFullMonitoring = True,
+    ispfjettrg = False,
+    iscalojettrg = True,
+    dr2cut = 0.16,
+    nmuons = 1,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  125,
+                xmin  =   0.,
+                xmax  = 1250)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_CaloJet500_NoJetID_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_IsoMu24_v*"])
+)
 
 
-HLTJetmonitoring = cms.Sequence(
-    PFJet40_Prommonitoring    
+HLTJetmonitoring = cms.Sequence(    
+    ak4PFPuppiL1FastL2L3ResidualCorrectorChain
+    *PFJet500_Orthogonal_Prommonitoring
+    *PFJet40_Prommonitoring    
     *PFJet60_Prommonitoring    
     *PFJet80_Prommonitoring    
     *PFJet140_Prommonitoring    
@@ -537,6 +736,8 @@ HLTJetmonitoring = cms.Sequence(
     *PFJetFwd400_Prommonitoring    
     *PFJetFwd450_Prommonitoring
     *PFJetFwd500_Prommonitoring
+    *ak8PFPuppiL1FastL2L3ResidualCorrectorChain
+    *AK8PFJet500_Orthogonal_Prommonitoring
     *AK8PFJet450_Prommonitoring
     *AK8PFJet40_Prommonitoring    
     *AK8PFJet60_Prommonitoring    
@@ -557,5 +758,7 @@ HLTJetmonitoring = cms.Sequence(
     *AK8PFJetFwd320_Prommonitoring    
     *AK8PFJetFwd400_Prommonitoring    
     *AK8PFJetFwd500_Prommonitoring 
+    *ak4CaloL1FastL2L3ResidualCorrectorChain
     *CaloJet500_NoJetID_Prommonitoring
+    *CaloJet500_NoJetID_Orthogonal_Prommonitoring
 )

--- a/DQMOffline/Trigger/python/JetMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/JetMonitor_cfi.py
@@ -19,8 +19,8 @@ hltJetMETmonitoring = jetMonitoring.clone(
                 xmin  = 0.,
                 xmax  = 900),
     ),
-    jetSrc = 'ak4PFJets', # ak4PFJets, ak4PFJetsCHS
-    ptcut = 20.,
+    jetSrc = 'ak4PFJetsPuppi', 
+    ptcut = 30.,
     ispfjettrg = True, # is PFJet Trigger ?
     iscalojettrg = False, # is CaloJet Trigger ?
 
@@ -29,7 +29,7 @@ hltJetMETmonitoring = jetMonitoring.clone(
         dbLabel       = "JetMETDQMTrigger", # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !
         andOrHlt      = True, # True:=OR; False:=AND
         hltInputTag   =  "TriggerResults::HLT",
-        hltPaths      = ["HLT_PFJet450_v*"], # HLT_ZeroBias_v*
+        hltPaths      = ["HLT_PFJet450_v*"], 
         errorReplyHlt = False,
         verbosityLevel = 1),
 
@@ -40,7 +40,8 @@ hltJetMETmonitoring = jetMonitoring.clone(
         dcsPartitions = [ 24, 25, 26, 27, 28, 29], # 24-27: strip, 28-29: pixel, we should add all other detectors !
         andOrDcs      = False,
         errorReplyDcs =  True,
-        verbosityLevel = 1)
+        verbosityLevel = 1,
+        hltPaths      = []) 
 )
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger

--- a/DQMOffline/Trigger/python/ZGammaplusJetsMonitor_cff.py
+++ b/DQMOffline/Trigger/python/ZGammaplusJetsMonitor_cff.py
@@ -3,13 +3,27 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.ZGammaplusJetsMonitor_cfi import hltZJetsmonitoring
 from JetMETCorrections.Configuration.JetCorrectors_cff import *
 
+## ========================================================================================= ##
+ak8PFPuppiL1FastjetCorrector = ak4PFPuppiL1FastjetCorrector.clone()
+ak8PFPuppiL2RelativeCorrector = ak4PFPuppiL2RelativeCorrector.clone(algorithm = 'AK8PFPuppi')
+ak8PFPuppiL3AbsoluteCorrector =ak4PFPuppiL3AbsoluteCorrector.clone(algorithm = 'AK8PFPuppi')
+ak8PFPuppiResidualCorrector = ak4PFPuppiResidualCorrector.clone(algorithm = 'AK8PFPuppi')
+ak8PFPuppiL1FastL2L3ResidualCorrector = cms.EDProducer(
+       'ChainedJetCorrectorProducer',
+       correctors = cms.VInputTag('ak8PFPuppiL1FastjetCorrector','ak8PFPuppiL2RelativeCorrector', 'ak8PFPuppiL3AbsoluteCorrector', 'ak8PFPuppiResidualCorrector')
+       )
+ak8PFPuppiL1FastL2L3ResidualCorrectorTask = cms.Task(
+	ak8PFPuppiL1FastjetCorrector, ak8PFPuppiL2RelativeCorrector, ak8PFPuppiL3AbsoluteCorrector, ak8PFPuppiResidualCorrector, ak8PFPuppiL1FastL2L3ResidualCorrector)
+ak8PFPuppiL1FastL2L3ResidualCorrectorChain = cms.Sequence(ak8PFPuppiL1FastL2L3ResidualCorrectorTask)
+## ========================================================================================= ##
+
 #---- define trigger paths and module paths ---#
 ZJet_monitoring = hltZJetsmonitoring.clone(
         FolderName = 'HLT/JME/ZGammaPlusJets/DimuonPFJet30',
         PathName = 'HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_PFJet30_v',
         ModuleName = 'hltDiMuon178Mass8Filtered',
         jets      = "ak4PFJetsPuppi",
-        corrector = "ak4PFPuppiL1FastL2L3Corrector",
+        corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
         # hlt muons       
         muonpt = 20.,
         muoneta = 2.3,
@@ -22,43 +36,235 @@ ZJet_monitoring = hltZJetsmonitoring.clone(
         DeltaPhi = 2.7,
         # offline jet cut
         OfflineCut = 20.0,
-        isMuonPath = True
+        isMuonPath = True,
+        # dr for matching
+        dr2cut = 0.16
 )
+
+ZAK8Jet_monitoring = hltZJetsmonitoring.clone(
+        FolderName = 'HLT/JME/ZGammaPlusJets/DimuonAK8PFJet30',
+        PathName = 'HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_AK8PFJet30_v',
+        ModuleName = 'hltDiMuon178Mass8Filtered',
+        jets      = "ak8PFJetsPuppi",
+        corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
+        # hlt muons       
+        muonpt = 20.,
+        muoneta = 2.3,
+        # hlt Z cut
+        Z_Dmass = 20.,
+        Z_pt = 30.,
+        # hlt jet
+        ptcut = 30.,
+        # back to back cut (between hlt Z and hlt jet)
+        DeltaPhi = 2.7,
+        # offline jet cut
+        OfflineCut = 20.0,
+        isMuonPath = True,
+        # dr for matching
+        dr2cut = 0.64
+)
+
+
+ZCaloJet_monitoring = hltZJetsmonitoring.clone(
+        FolderName = 'HLT/JME/ZGammaPlusJets/DimuonCaloJet30',
+        PathName = 'HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_CaloJet30_v',
+        ModuleName = 'hltDiMuon178Mass8Filtered',
+        jets      = "ak4CaloJets",
+        corrector = "ak4CaloL1FastL2L3ResidualCorrector",
+        # hlt muons
+        muonpt = 20.,
+        muoneta = 2.3,
+        # hlt Z cut
+        Z_Dmass = 20.,
+        Z_pt = 30.,
+        # hlt jet
+        ptcut = 30.,
+        # back to back cut (between hlt Z and hlt jet)
+        DeltaPhi = 2.7,
+        # offline jet cut
+        OfflineCut = 20.0,
+        isMuonPath = True,
+        # dr for matching
+        dr2cut = 0.16
+)
+
+ZAK8CaloJet_monitoring = hltZJetsmonitoring.clone(
+        FolderName = 'HLT/JME/ZGammaPlusJets/DimuonAK8CaloJet30',
+        PathName = 'HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_AK8CaloJet30_v',
+        ModuleName = 'hltDiMuon178Mass8Filtered',
+        jets      = "ak8PFJetsPuppi",
+        corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
+        # hlt muons
+        muonpt = 20.,
+        muoneta = 2.3,
+        # hlt Z cut
+        Z_Dmass = 20.,
+        Z_pt = 30.,
+        # hlt jet
+        ptcut = 30.,
+        # back to back cut (between hlt Z and hlt jet)
+        DeltaPhi = 2.7,
+        # offline jet cut
+        OfflineCut = 20.0,
+        isMuonPath = True,
+        # dr for matching
+        dr2cut = 0.64
+)
+
 
 Photon50Jet_monitoring = hltZJetsmonitoring.clone(
         FolderName = 'HLT/JME/ZGammaPlusJets/Photon50PFJet30',
         PathName = 'HLT_Photon50EB_TightID_TightIso_PFJet30_v',
         ModuleName = 'hltEG50EBTightIDTightIsoTrackIsoFilter',
         jets      = "ak4PFJetsPuppi",
-        corrector = "ak4PFPuppiL1FastL2L3Corrector",
+        corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
         # hlt jet
         ptcut = 30.,
         # back to back cut (between hlt photon and hlt jet)
         DeltaPhi = 2.7,
         # offline jet cut
         OfflineCut = 20.0,
-        isMuonPath = False
+        isMuonPath = False,
+        # dr for matching
+        dr2cut = 0.16
 )
+
+Photon50AK8Jet_monitoring = hltZJetsmonitoring.clone(
+        FolderName = 'HLT/JME/ZGammaPlusJets/Photon50AK8PFJet30',
+        PathName = 'HLT_Photon50EB_TightID_TightIso_AK8PFJet30_v',
+        ModuleName = 'hltEG50EBTightIDTightIsoTrackIsoFilter',
+        jets      = "ak8PFJetsPuppi",
+        corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
+        # hlt jet
+        ptcut = 30.,
+        # back to back cut (between hlt photon and hlt jet)
+        DeltaPhi = 2.7,
+        # offline jet cut
+        OfflineCut = 20.0,
+        isMuonPath = False,
+        # dr for matching
+        dr2cut = 0.64
+)
+
+Photon50CaloJet_monitoring = hltZJetsmonitoring.clone(
+        FolderName = 'HLT/JME/ZGammaPlusJets/Photon50CaloJet30',
+        PathName = 'HLT_Photon50EB_TightID_TightIso_CaloJet30_v',
+        ModuleName = 'hltEG50EBTightIDTightIsoTrackIsoFilter',
+        jets      = "ak4CaloJets",
+        corrector = "ak4CaloL1FastL2L3ResidualCorrector",
+        # hlt jet
+        ptcut = 30.,
+        # back to back cut (between hlt photon and hlt jet)
+        DeltaPhi = 2.7,
+        # offline jet cut
+        OfflineCut = 20.0,
+        isMuonPath = False,
+        # dr for matching
+        dr2cut = 0.16
+)
+
+Photon50AK8CaloJet_monitoring = hltZJetsmonitoring.clone(
+        FolderName = 'HLT/JME/ZGammaPlusJets/Photon50AK8CaloJet30',
+        PathName = 'HLT_Photon50EB_TightID_TightIso_AK8CaloJet30_v',
+        ModuleName = 'hltEG50EBTightIDTightIsoTrackIsoFilter',
+        jets      = "ak8PFJetsPuppi",
+        corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
+        # hlt jet
+        ptcut = 30.,
+        # back to back cut (between hlt photon and hlt jet)
+        DeltaPhi = 2.7,
+        # offline jet cut
+        OfflineCut = 20.0,
+        isMuonPath = False,
+        # dr for matching
+        dr2cut = 0.64
+)
+
 
 Photon110Jet_monitoring = hltZJetsmonitoring.clone(
         FolderName = 'HLT/JME/ZGammaPlusJets/Photon110PFJet30',
         PathName = 'HLT_Photon110EB_TightID_TightIso_PFJet30_v',
         ModuleName = 'hltEG110EBTightIDTightIsoTrackIsoFilter',
         jets      = "ak4PFJetsPuppi",
-        corrector = "ak4PFPuppiL1FastL2L3Corrector",
+        corrector = "ak4PFPuppiL1FastL2L3ResidualCorrector",
         # hlt jet
         ptcut = 30.,
         # back to back cut (between hlt photon and hlt jet)
         DeltaPhi = 2.7,
         # offline jet cut
         OfflineCut = 20.0,
-        isMuonPath = False
+        isMuonPath = False,
+        # dr for matching
+        dr2cut = 0.16
+)
+
+Photon110AK8Jet_monitoring = hltZJetsmonitoring.clone(
+        FolderName = 'HLT/JME/ZGammaPlusJets/Photon110AK8PFJet30',
+        PathName = 'HLT_Photon110EB_TightID_TightIso_AK8PFJet30_v',
+        ModuleName = 'hltEG110EBTightIDTightIsoTrackIsoFilter',
+        jets      = "ak8PFJetsPuppi",
+        corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
+        # hlt jet
+        ptcut = 30.,
+        # back to back cut (between hlt photon and hlt jet)
+        DeltaPhi = 2.7,
+        # offline jet cut
+        OfflineCut = 20.0,
+        isMuonPath = False,
+        # dr for matching
+        dr2cut = 0.64
+)
+
+Photon110CaloJet_monitoring = hltZJetsmonitoring.clone(
+        FolderName = 'HLT/JME/ZGammaPlusJets/Photon110CaloJet30',
+        PathName = 'HLT_Photon110EB_TightID_TightIso_CaloJet30_v',
+        ModuleName = 'hltEG110EBTightIDTightIsoTrackIsoFilter',
+        jets      = "ak4CaloJets",
+        corrector = "ak4CaloL1FastL2L3ResidualCorrector",
+        # hlt jet
+        ptcut = 30.,
+        # back to back cut (between hlt photon and hlt jet)
+        DeltaPhi = 2.7,
+        # offline jet cut
+        OfflineCut = 20.0,
+        isMuonPath = False,
+        # dr for matching
+        dr2cut = 0.16
+)
+
+Photon110AK8CaloJet_monitoring = hltZJetsmonitoring.clone(
+        FolderName = 'HLT/JME/ZGammaPlusJets/Photon110Ak8CaloJet30',
+        PathName = 'HLT_Photon110EB_TightID_TightIso_AK8CaloJet30_v',
+        ModuleName = 'hltEG110EBTightIDTightIsoTrackIsoFilter',
+        jets      = "ak8PFJetsPuppi",
+        corrector = "ak8PFPuppiL1FastL2L3ResidualCorrector",
+        # hlt jet
+        ptcut = 30.,
+        # back to back cut (between hlt photon and hlt jet)
+        DeltaPhi = 2.7,
+        # offline jet cut
+        OfflineCut = 20.0,
+        isMuonPath = False,
+        # dr for matching
+        dr2cut = 0.64
 )
 
 
+
 HLTZGammaJetmonitoring = cms.Sequence(
-    ak4PFPuppiL1FastL2L3CorrectorChain
+    ak4PFPuppiL1FastL2L3ResidualCorrectorChain
+    + ak8PFPuppiL1FastL2L3ResidualCorrectorChain
+    + ak4CaloL1FastL2L3ResidualCorrectorChain
     + ZJet_monitoring
+    + ZAK8Jet_monitoring
+    + ZCaloJet_monitoring
+    + ZAK8CaloJet_monitoring
     + Photon50Jet_monitoring
+    + Photon50AK8Jet_monitoring
+    + Photon50CaloJet_monitoring
+    + Photon50AK8CaloJet_monitoring
     + Photon110Jet_monitoring
+    + Photon110AK8Jet_monitoring
+    + Photon110CaloJet_monitoring
+    + Photon110AK8CaloJet_monitoring
     )

--- a/DQMOffline/Trigger/python/ZGammaplusJetsPostProcessor_cff.py
+++ b/DQMOffline/Trigger/python/ZGammaplusJetsPostProcessor_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+
+ZGammaPostProc = DQMEDHarvester("ZGammaplusJetsPostProcessor",
+     subDir = cms.untracked.string("HLT/JME/ZGammaPlusJets"),
+     IsMuonTrigger = cms.untracked.string("Dimuon+(AK8*|CaloJet|PFJet)[0-9]+"),
+     IsPhotonTrigger = cms.untracked.string("Photon([0-9])+(AK8*|CaloJet|PFJet)[0-9]+")
+)


### PR DESCRIPTION
#### PR description:

This PR target to update JME Offline DQM for the monitoring of Jets, using codes for JetMonitor for offline objects and also ZGammaplusJets for hlt objects. 

The updates include corrections on the fly, cleaning of jet collections, moving from PF to Puppi collections, post processing and other basic selections. These all have been presented, discussed and approved in JME trigger meetings with @blehtela , @cghuh ,  @theochatzis and @nurfikri89 and @mcremone . A brief description and validation plots can be found [02_12_2025](https://indico.cern.ch/event/1614225/contributions/6802357/attachments/3183751/5664168/DQM%20-%20EPR%20end%20of%20year.pdf) & [20_10_2025](https://indico.cern.ch/event/1602314/contributions/6751430/attachments/3157448/5608832/JMEtrigger_DQMUpdate_20102025.pdf)

#### PR validation:

The changes were tested using Data from 2025. 
Besides the code was tested using the instructions that are included in the [link](https://cms-sw.github.io/PRWorkflow.html) . 
Running runTheMatrix.py -l limited -i all --ibeos the results are:
40 35 34 29 20 1 1 1 1 1 1 tests passed, 12 4 0 0 0 0 0 0 0 0 0 failed

12 with DASERROR and
4 failed with exception in log file: An exception of category 'FallbackFileOpenError' 
which are not fixed after I updated credentials and repeat the proccess, and are not related fails with the updates.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is intended for the master branch. 
Since, it is for monitoring of 2026 data it may should be backported in CMSSW_16_0_X.

