### PR TITLE
Fix `seed` column in LayerCluster SoA 

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersSoAAlgoWrapper.dev.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersSoAAlgoWrapper.dev.cc
@@ -28,7 +28,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         alpaka::atomicAdd(acc, &outputs[clIdx].energy(), input_rechits_soa[i].energy());
         alpaka::atomicAdd(acc, &outputs[clIdx].cells(), 1);
         if (input_clusters_soa[i].isSeed() == 1) {
-          outputs[clIdx].seed() = input_rechits_soa[i].detid();
+          outputs[clIdx].seed() = i;
         }
       }
     }


### PR DESCRIPTION
Currently the `seed` column in the LayerCluster SoA is set using the rechit detID, causing problems as the SoA column is defined as `int` while the detID is an `unsigned int`. However, the original idea was to use the `seed` column to store the seed rechit index and not the detID

@felicepantaleo @rovere 