### PR TITLE
ECAL GPU vs. CPU validation configuration changes - 160x

### DIFF
--- a/DQM/EcalMonitorTasks/python/EcalMonitorTask_cff.py
+++ b/DQM/EcalMonitorTasks/python/EcalMonitorTask_cff.py
@@ -14,6 +14,10 @@ gpuValidationEcal.toModify(ecalMonitorTask, workerParameters = dict(GpuTask = ec
 alpakaValidationEcal.toModify(ecalGpuTask.params, runGpuTask = True)
 alpakaValidationEcal.toModify(ecalMonitorTask.workers, func = lambda workers: workers.append("GpuTask"))
 alpakaValidationEcal.toModify(ecalMonitorTask, workerParameters = dict(GpuTask = ecalGpuTask))
+alpakaValidationEcal.toModify(ecalDQMCollectionTags, EBCpuDigi = "ecalDigisSerialSync:ebDigis")
+alpakaValidationEcal.toModify(ecalDQMCollectionTags, EECpuDigi = "ecalDigisSerialSync:eeDigis")
+alpakaValidationEcal.toModify(ecalDQMCollectionTags, EBCpuUncalibRecHit = "ecalMultiFitUncalibRecHitSerialSync:EcalUncalibRecHitsEB")
+alpakaValidationEcal.toModify(ecalDQMCollectionTags, EECpuUncalibRecHit = "ecalMultiFitUncalibRecHitSerialSync:EcalUncalibRecHitsEE")
 
 # Skip consuming and running over the EcalRawData collection for all GPU WFs
 # This is to be used as long as the GPU unpacker unpacks a dummy EcalRawData collection

--- a/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
@@ -58,58 +58,28 @@ from DQM.EcalMonitorTasks.EcalMonitorTask_cfi import *
 from DQM.EcalMonitorTasks.ecalGpuTask_cfi import ecalGpuTask as _ecalGpuTask
 
 _hltdir = 'HLT/HeterogeneousComparison/'
+_remove = '%(prefix)sGpuTask/'
 
-hltEcalGpuTask =  _ecalGpuTask.clone(
+def cloneMEsWithPathFix(srcMEs, prefix):
+    clones = {}
+    for name, me in srcMEs.parameters_().items():
+        if hasattr(me, 'path'):
+            old = me.path.value()
+            # remove the unwanted component if present
+            new = old.replace(_remove, '')
+            # prepend the HLT directory if not already there
+            new = prefix + new
+            clones[name] = me.clone(path = new)
+        else:
+            clones[name] = me.clone()
+    return clones
+
+hltEcalGpuTask = _ecalGpuTask.clone(
     params = _ecalGpuTask.params.clone(
         runGpuTask = True,
         enableRecHit = False
     ),
-    MEs = _ecalGpuTask.MEs.clone(
-        DigiCpu = _ecalGpuTask.MEs.DigiCpu.clone(path = _hltdir + '%(subdet)s/Digis/%(prefix)sGT digi nDigis cpu'),
-        DigiCpuAmplitude = _ecalGpuTask.MEs.DigiCpuAmplitude.clone(path = _hltdir + '%(subdet)s/Digis/%(prefix)sGT digi amplitude sample %(sample)s cpu'),
-        DigiGpu = _ecalGpuTask.MEs.DigiGpu.clone(path = _hltdir + '%(subdet)s/Digis/%(prefix)sGT digi nDigis gpu'),
-        DigiGpuAmplitude = _ecalGpuTask.MEs.DigiGpuAmplitude.clone(path = _hltdir + '%(subdet)s/Digis/%(prefix)sGT digi amplitude sample %(sample)s gpu'),
-        DigiGpuCpu = _ecalGpuTask.MEs.DigiGpuCpu.clone(path = _hltdir + '%(subdet)s/Digis/%(prefix)sGT digi nDigis gpu-cpu diff'),
-        DigiGpuCpuAmplitude = _ecalGpuTask.MEs.DigiGpuCpuAmplitude.clone(path = _hltdir + '%(subdet)s/Digis/%(prefix)sGT digi amplitude sample %(sample)s gpu-cpu diff'),
-        Digi2D = _ecalGpuTask.MEs.Digi2D.clone(path = _hltdir + '%(subdet)s/Digis/%(prefix)sGT digi nDigis gpu-cpu map2D'),
-        Digi2DAmplitude = _ecalGpuTask.MEs.Digi2DAmplitude.clone(path = _hltdir + '%(subdet)s/Digis/%(prefix)sGT digi amplitude sample %(sample)s gpu-cpu map2D'),
-        UncalibCpu = _ecalGpuTask.MEs.UncalibCpu.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit nHits cpu'),
-        UncalibCpuAmp = _ecalGpuTask.MEs.UncalibCpuAmp.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit amplitude cpu'),
-        UncalibCpuAmpError = _ecalGpuTask.MEs.UncalibCpuAmpError.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit amplitudeError cpu'),
-        UncalibCpuPedestal = _ecalGpuTask.MEs.UncalibCpuPedestal.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit pedestal cpu'),
-        UncalibCpuJitter = _ecalGpuTask.MEs.UncalibCpuJitter.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit jitter cpu'),
-        UncalibCpuJitterError = _ecalGpuTask.MEs.UncalibCpuJitterError.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit jitterError cpu'),
-        UncalibCpuChi2 = _ecalGpuTask.MEs.UncalibCpuChi2.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit chi2 cpu'),
-        UncalibCpuOOTAmp = _ecalGpuTask.MEs.UncalibCpuOOTAmp.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit OOT amplitude %(OOTAmp)s cpu'),
-        UncalibCpuFlags = _ecalGpuTask.MEs.UncalibCpuFlags.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit flags cpu'),
-        UncalibGpu = _ecalGpuTask.MEs.UncalibGpu.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit nHits gpu'),
-        UncalibGpuAmp = _ecalGpuTask.MEs.UncalibGpuAmp.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit amplitude gpu'),
-        UncalibGpuAmpError = _ecalGpuTask.MEs.UncalibGpuAmpError.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit amplitudeError gpu'),
-        UncalibGpuPedestal = _ecalGpuTask.MEs.UncalibGpuPedestal.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit pedestal gpu'),
-        UncalibGpuJitter = _ecalGpuTask.MEs.UncalibGpuJitter.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit jitter gpu'),
-        UncalibGpuJitterError = _ecalGpuTask.MEs.UncalibGpuJitterError.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit jitterError gpu'),
-        UncalibGpuChi2 = _ecalGpuTask.MEs.UncalibGpuChi2.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit chi2 gpu'),
-        UncalibGpuOOTAmp = _ecalGpuTask.MEs.UncalibGpuOOTAmp.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit OOT amplitude %(OOTAmp)s gpu'),
-        UncalibGpuFlags = _ecalGpuTask.MEs.UncalibGpuFlags.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit flags gpu'),
-        UncalibGpuCpu = _ecalGpuTask.MEs.UncalibGpuCpu.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit nHits gpu-cpu diff'),
-        UncalibGpuCpuAmp = _ecalGpuTask.MEs.UncalibGpuCpuAmp.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit amplitude gpu-cpu diff'),
-        UncalibGpuCpuAmpError = _ecalGpuTask.MEs.UncalibGpuCpuAmpError.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit amplitudeError gpu-cpu diff'),
-        UncalibGpuCpuPedestal = _ecalGpuTask.MEs.UncalibGpuCpuPedestal.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit pedestal gpu-cpu diff'),
-        UncalibGpuCpuJitter = _ecalGpuTask.MEs.UncalibGpuCpuJitter.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit jitter gpu-cpu diff'),
-        UncalibGpuCpuJitterError = _ecalGpuTask.MEs.UncalibGpuCpuJitterError.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit jitterError gpu-cpu diff'),
-        UncalibGpuCpuChi2 = _ecalGpuTask.MEs.UncalibGpuCpuChi2.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit chi2 gpu-cpu diff'),
-        UncalibGpuCpuOOTAmp = _ecalGpuTask.MEs.UncalibGpuCpuOOTAmp.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit OOT amplitude %(OOTAmp)s gpu-cpu diff'),
-        UncalibGpuCpuFlags = _ecalGpuTask.MEs.UncalibGpuCpuFlags.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit flags gpu-cpu diff'),
-        Uncalib2D = _ecalGpuTask.MEs.Uncalib2D.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit nHits gpu-cpu map2D'),
-        Uncalib2DAmp = _ecalGpuTask.MEs.Uncalib2DAmp.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit amplitude gpu-cpu map2D'),
-        Uncalib2DAmpError = _ecalGpuTask.MEs.Uncalib2DAmpError.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit amplitudeError gpu-cpu map2D'),
-        Uncalib2DPedestal = _ecalGpuTask.MEs.Uncalib2DPedestal.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit pedestal gpu-cpu map2D'),
-        Uncalib2DJitter = _ecalGpuTask.MEs.Uncalib2DJitter.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit jitter gpu-cpu map2D'),
-        Uncalib2DJitterError = _ecalGpuTask.MEs.Uncalib2DJitterError.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit jitterError gpu-cpu map2D'),
-        Uncalib2DChi2 = _ecalGpuTask.MEs.Uncalib2DChi2.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit chi2 gpu-cpu map2D'),
-        Uncalib2DOOTAmp = _ecalGpuTask.MEs.Uncalib2DOOTAmp.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit OOT amplitude %(OOTAmp)s gpu-cpu map2D'),
-        Uncalib2DFlags = _ecalGpuTask.MEs.Uncalib2DFlags.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit flags gpu-cpu map2D')
-    )
+    MEs = cloneMEsWithPathFix(_ecalGpuTask.MEs, _hltdir)
 )
 
 hltEcalMonitorTask = ecalMonitorTask.clone(

--- a/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
@@ -57,10 +57,58 @@ hltSiPixelCompareVertices = siPixelCompareVertices.clone(
 from DQM.EcalMonitorTasks.EcalMonitorTask_cfi import *
 from DQM.EcalMonitorTasks.ecalGpuTask_cfi import ecalGpuTask as _ecalGpuTask
 
+_hltdir = 'HLT/HeterogeneousComparison/'
+
 hltEcalGpuTask =  _ecalGpuTask.clone(
     params = _ecalGpuTask.params.clone(
         runGpuTask = True,
         enableRecHit = False
+    ),
+    MEs = _ecalGpuTask.MEs.clone(
+        DigiCpu = _ecalGpuTask.MEs.DigiCpu.clone(path = _hltdir + '%(subdet)s/Digis/%(prefix)sGT digi nDigis cpu'),
+        DigiCpuAmplitude = _ecalGpuTask.MEs.DigiCpuAmplitude.clone(path = _hltdir + '%(subdet)s/Digis/%(prefix)sGT digi amplitude sample %(sample)s cpu'),
+        DigiGpu = _ecalGpuTask.MEs.DigiGpu.clone(path = _hltdir + '%(subdet)s/Digis/%(prefix)sGT digi nDigis gpu'),
+        DigiGpuAmplitude = _ecalGpuTask.MEs.DigiGpuAmplitude.clone(path = _hltdir + '%(subdet)s/Digis/%(prefix)sGT digi amplitude sample %(sample)s gpu'),
+        DigiGpuCpu = _ecalGpuTask.MEs.DigiGpuCpu.clone(path = _hltdir + '%(subdet)s/Digis/%(prefix)sGT digi nDigis gpu-cpu diff'),
+        DigiGpuCpuAmplitude = _ecalGpuTask.MEs.DigiGpuCpuAmplitude.clone(path = _hltdir + '%(subdet)s/Digis/%(prefix)sGT digi amplitude sample %(sample)s gpu-cpu diff'),
+        Digi2D = _ecalGpuTask.MEs.Digi2D.clone(path = _hltdir + '%(subdet)s/Digis/%(prefix)sGT digi nDigis gpu-cpu map2D'),
+        Digi2DAmplitude = _ecalGpuTask.MEs.Digi2DAmplitude.clone(path = _hltdir + '%(subdet)s/Digis/%(prefix)sGT digi amplitude sample %(sample)s gpu-cpu map2D'),
+        UncalibCpu = _ecalGpuTask.MEs.UncalibCpu.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit nHits cpu'),
+        UncalibCpuAmp = _ecalGpuTask.MEs.UncalibCpuAmp.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit amplitude cpu'),
+        UncalibCpuAmpError = _ecalGpuTask.MEs.UncalibCpuAmpError.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit amplitudeError cpu'),
+        UncalibCpuPedestal = _ecalGpuTask.MEs.UncalibCpuPedestal.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit pedestal cpu'),
+        UncalibCpuJitter = _ecalGpuTask.MEs.UncalibCpuJitter.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit jitter cpu'),
+        UncalibCpuJitterError = _ecalGpuTask.MEs.UncalibCpuJitterError.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit jitterError cpu'),
+        UncalibCpuChi2 = _ecalGpuTask.MEs.UncalibCpuChi2.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit chi2 cpu'),
+        UncalibCpuOOTAmp = _ecalGpuTask.MEs.UncalibCpuOOTAmp.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit OOT amplitude %(OOTAmp)s cpu'),
+        UncalibCpuFlags = _ecalGpuTask.MEs.UncalibCpuFlags.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit flags cpu'),
+        UncalibGpu = _ecalGpuTask.MEs.UncalibGpu.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit nHits gpu'),
+        UncalibGpuAmp = _ecalGpuTask.MEs.UncalibGpuAmp.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit amplitude gpu'),
+        UncalibGpuAmpError = _ecalGpuTask.MEs.UncalibGpuAmpError.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit amplitudeError gpu'),
+        UncalibGpuPedestal = _ecalGpuTask.MEs.UncalibGpuPedestal.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit pedestal gpu'),
+        UncalibGpuJitter = _ecalGpuTask.MEs.UncalibGpuJitter.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit jitter gpu'),
+        UncalibGpuJitterError = _ecalGpuTask.MEs.UncalibGpuJitterError.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit jitterError gpu'),
+        UncalibGpuChi2 = _ecalGpuTask.MEs.UncalibGpuChi2.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit chi2 gpu'),
+        UncalibGpuOOTAmp = _ecalGpuTask.MEs.UncalibGpuOOTAmp.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit OOT amplitude %(OOTAmp)s gpu'),
+        UncalibGpuFlags = _ecalGpuTask.MEs.UncalibGpuFlags.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit flags gpu'),
+        UncalibGpuCpu = _ecalGpuTask.MEs.UncalibGpuCpu.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit nHits gpu-cpu diff'),
+        UncalibGpuCpuAmp = _ecalGpuTask.MEs.UncalibGpuCpuAmp.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit amplitude gpu-cpu diff'),
+        UncalibGpuCpuAmpError = _ecalGpuTask.MEs.UncalibGpuCpuAmpError.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit amplitudeError gpu-cpu diff'),
+        UncalibGpuCpuPedestal = _ecalGpuTask.MEs.UncalibGpuCpuPedestal.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit pedestal gpu-cpu diff'),
+        UncalibGpuCpuJitter = _ecalGpuTask.MEs.UncalibGpuCpuJitter.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit jitter gpu-cpu diff'),
+        UncalibGpuCpuJitterError = _ecalGpuTask.MEs.UncalibGpuCpuJitterError.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit jitterError gpu-cpu diff'),
+        UncalibGpuCpuChi2 = _ecalGpuTask.MEs.UncalibGpuCpuChi2.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit chi2 gpu-cpu diff'),
+        UncalibGpuCpuOOTAmp = _ecalGpuTask.MEs.UncalibGpuCpuOOTAmp.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit OOT amplitude %(OOTAmp)s gpu-cpu diff'),
+        UncalibGpuCpuFlags = _ecalGpuTask.MEs.UncalibGpuCpuFlags.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit flags gpu-cpu diff'),
+        Uncalib2D = _ecalGpuTask.MEs.Uncalib2D.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit nHits gpu-cpu map2D'),
+        Uncalib2DAmp = _ecalGpuTask.MEs.Uncalib2DAmp.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit amplitude gpu-cpu map2D'),
+        Uncalib2DAmpError = _ecalGpuTask.MEs.Uncalib2DAmpError.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit amplitudeError gpu-cpu map2D'),
+        Uncalib2DPedestal = _ecalGpuTask.MEs.Uncalib2DPedestal.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit pedestal gpu-cpu map2D'),
+        Uncalib2DJitter = _ecalGpuTask.MEs.Uncalib2DJitter.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit jitter gpu-cpu map2D'),
+        Uncalib2DJitterError = _ecalGpuTask.MEs.Uncalib2DJitterError.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit jitterError gpu-cpu map2D'),
+        Uncalib2DChi2 = _ecalGpuTask.MEs.Uncalib2DChi2.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit chi2 gpu-cpu map2D'),
+        Uncalib2DOOTAmp = _ecalGpuTask.MEs.Uncalib2DOOTAmp.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit OOT amplitude %(OOTAmp)s gpu-cpu map2D'),
+        Uncalib2DFlags = _ecalGpuTask.MEs.Uncalib2DFlags.clone(path = _hltdir + '%(subdet)s/UncalibRecHits/%(prefix)sGT uncalib rec hit flags gpu-cpu map2D')
     )
 )
 

--- a/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/HeterogeneousMonitoring_cff.py
@@ -57,7 +57,7 @@ hltSiPixelCompareVertices = siPixelCompareVertices.clone(
 from DQM.EcalMonitorTasks.EcalMonitorTask_cfi import *
 from DQM.EcalMonitorTasks.ecalGpuTask_cfi import ecalGpuTask as _ecalGpuTask
 
-_hltdir = 'HLT/HeterogeneousComparison/'
+_hltdir = 'HLT/HeterogeneousComparisons/'
 _remove = '%(prefix)sGpuTask/'
 
 def cloneMEsWithPathFix(srcMEs, prefix):

--- a/EventFilter/EcalRawToDigi/python/ecalDigis_cff.py
+++ b/EventFilter/EcalRawToDigi/python/ecalDigis_cff.py
@@ -53,9 +53,21 @@ phase2_ecal_devel.toReplaceWith(ecalDigisTask_alpaka, ecalDigisTask_alpaka.copyA
 
 alpaka.toReplaceWith(ecalDigisTask, ecalDigisTask_alpaka)
 
-# for alpaka validation compare the legacy CPU module with the alpaka module
-from Configuration.ProcessModifiers.alpakaValidationEcal_cff import alpakaValidationEcal
+# for GPU validation compare the legacy CPU module with the alpaka module
+from Configuration.ProcessModifiers.gpuValidationEcal_cff import gpuValidationEcal
 _ecalDigisTaskValidation = ecalDigisTask_alpaka.copy()
 _ecalDigisTaskValidation.add(ecalDigisLegacy)
-alpakaValidationEcal.toReplaceWith(ecalDigisTask, _ecalDigisTaskValidation)
+gpuValidationEcal.toReplaceWith(ecalDigisTask, _ecalDigisTaskValidation)
 
+# for alpaka validation compare alpaka serial with alpaka
+from Configuration.ProcessModifiers.alpakaValidationEcal_cff import alpakaValidationEcal
+from HeterogeneousCore.AlpakaCore.functions import makeSerialClone
+ecalDigisPortableSerialSync = makeSerialClone(ecalDigisPortable)
+ecalDigisSerialSync = _ecalDigisFromPortable.clone(
+    digisInLabelEB = 'ecalDigisPortableSerialSync:ebDigis',
+    digisInLabelEE = 'ecalDigisPortableSerialSync:eeDigis'
+)
+_ecalDigisTaskValidation = ecalDigisTask_alpaka.copy()
+_ecalDigisTaskValidation.add(ecalDigisPortableSerialSync)
+_ecalDigisTaskValidation.add(ecalDigisSerialSync)
+alpakaValidationEcal.toReplaceWith(ecalDigisTask, _ecalDigisTaskValidation)

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cff.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cff.py
@@ -49,7 +49,7 @@ gpuValidationEcal.toReplaceWith(ecalMultiFitUncalibRecHitTask, _ecalMultiFitUnca
 from Configuration.ProcessModifiers.alpakaValidationEcal_cff import alpakaValidationEcal
 from HeterogeneousCore.AlpakaCore.functions import makeSerialClone
 ecalMultiFitUncalibRecHitPortableSerialSync = makeSerialClone(ecalMultiFitUncalibRecHitPortable)
-ecalMultiFitUncalibRecHitSerialSync = ecalMultiFitUncalibRecHit.clone(
+ecalMultiFitUncalibRecHitSerialSync = _ecalUncalibRecHitSoAToLegacy.clone(
     inputCollectionEB = 'ecalMultiFitUncalibRecHitPortableSerialSync:EcalUncalibRecHitsEB',
     inputCollectionEE = 'ecalMultiFitUncalibRecHitPortableSerialSync:EcalUncalibRecHitsEE'
 )

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cff.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cff.py
@@ -39,8 +39,21 @@ alpaka.toReplaceWith(ecalMultiFitUncalibRecHitTask, cms.Task(
   ecalMultiFitUncalibRecHit,
 ))
 
-# for alpaka validation compare the legacy CPU module with the alpaka module
-from Configuration.ProcessModifiers.alpakaValidationEcal_cff import alpakaValidationEcal
+# for GPU validation compare the legacy CPU module with the alpaka module
+from Configuration.ProcessModifiers.gpuValidationEcal_cff import gpuValidationEcal
 _ecalMultiFitUncalibRecHitTaskValidation = ecalMultiFitUncalibRecHitTask.copy()
 _ecalMultiFitUncalibRecHitTaskValidation.add(ecalMultiFitUncalibRecHitLegacy)
+gpuValidationEcal.toReplaceWith(ecalMultiFitUncalibRecHitTask, _ecalMultiFitUncalibRecHitTaskValidation)
+
+# for alpaka validation compare alpaka serial with alpaka
+from Configuration.ProcessModifiers.alpakaValidationEcal_cff import alpakaValidationEcal
+from HeterogeneousCore.AlpakaCore.functions import makeSerialClone
+ecalMultiFitUncalibRecHitPortableSerialSync = makeSerialClone(ecalMultiFitUncalibRecHitPortable)
+ecalMultiFitUncalibRecHitSerialSync = ecalMultiFitUncalibRecHit.clone(
+    inputCollectionEB = 'ecalMultiFitUncalibRecHitPortableSerialSync:EcalUncalibRecHitsEB',
+    inputCollectionEE = 'ecalMultiFitUncalibRecHitPortableSerialSync:EcalUncalibRecHitsEE'
+)
+_ecalMultiFitUncalibRecHitTaskValidation = ecalMultiFitUncalibRecHitTask.copy()
+_ecalMultiFitUncalibRecHitTaskValidation.add(ecalMultiFitUncalibRecHitPortableSerialSync)
+_ecalMultiFitUncalibRecHitTaskValidation.add(ecalMultiFitUncalibRecHitSerialSync)
 alpakaValidationEcal.toReplaceWith(ecalMultiFitUncalibRecHitTask, _ecalMultiFitUncalibRecHitTaskValidation)

--- a/RecoLocalCalo/EcalRecProducers/python/ecalRecHit_cff.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalRecHit_cff.py
@@ -40,10 +40,23 @@ alpaka.toReplaceWith(ecalCalibratedRecHitTask, cms.Task(
   ecalRecHit,
 ))
 
-# for alpaka validation compare the legacy CPU module with the alpaka module
-from Configuration.ProcessModifiers.alpakaValidationEcal_cff import alpakaValidationEcal
+# for gpu validation compare the legacy CPU module with the alpaka module
+from Configuration.ProcessModifiers.gpuValidationEcal_cff import gpuValidationEcal
 _ecalCalibratedRecHitTaskValidation = ecalCalibratedRecHitTask.copy()
 _ecalCalibratedRecHitTaskValidation.add()
+gpuValidationEcal.toReplaceWith(ecalCalibratedRecHitTask, _ecalCalibratedRecHitTaskValidation)
+
+# for alpaka validation compare alpaka serial with alpaka
+from Configuration.ProcessModifiers.alpakaValidationEcal_cff import alpakaValidationEcal
+from HeterogeneousCore.AlpakaCore.functions import makeSerialClone
+ecalRecHitPortableSerialSync = makeSerialClone(ecalRecHitPortable)
+ecalRecHitSerialSync = _ecalRecHitSoAToLegacy.clone(
+    inputCollectionEB = 'ecalRecHitPortableSerialSync:EcalRecHitsEB',
+    inputCollectionEE = 'ecalRecHitPortableSerialSync:EcalRecHitsEE',
+)
+_ecalCalibratedRecHitTaskValidation = ecalCalibratedRecHitTask.copy()
+_ecalCalibratedRecHitTaskValidation.add(ecalRecHitPortableSerialSync)
+_ecalCalibratedRecHitTaskValidation.add(ecalRecHitSerialSync)
 alpakaValidationEcal.toReplaceWith(ecalCalibratedRecHitTask, _ecalCalibratedRecHitTaskValidation)
 
 from Configuration.Eras.Modifier_phase2_ecal_devel_cff import phase2_ecal_devel


### PR DESCRIPTION
#### PR description:

- Place ECAL GPU vs. CPU validation plots for HLT inside the `HLT/HeterogeneousComparison/` DQM directory.
- Make a comparison of Alpaka serial vs. Alpaka instead of legacy vs. Alpaka when the `alpakaValidationEcal` modifier is active. The legacy vs. Alpaka comparison can be activated with the `gpuValidationEcal` modifier instead, which also takes care that the timing algorithms match.

#### PR validation:

Passes 18446.413.

Backport of #49965 to run GPUvsCPU RelVals in 16_0_X.
