### PR TITLE
Implementation of MTD track extender for muons

### DIFF
--- a/RecoMTD/TrackExtender/BuildFile.xml
+++ b/RecoMTD/TrackExtender/BuildFile.xml
@@ -1,0 +1,13 @@
+<use name="RecoMTD/DetLayers"/>
+<use name="RecoMTD/Records"/>
+<use name="FWCore/Framework"/>
+<use name="clhep"/>
+<use name="TrackingTools/TrackRefitter"/>
+<use name="TrackingTools/Records"/>
+<use name="TrackingTools/TransientTrack"/>
+<use name="TrackingTools/KalmanUpdators"/>
+<use name="MagneticField/Records"/>
+<use name="MagneticField/Engine"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/RecoMTD/TrackExtender/interface/BaseExtenderWithMTD.h
+++ b/RecoMTD/TrackExtender/interface/BaseExtenderWithMTD.h
@@ -1,0 +1,253 @@
+#ifndef RecoMTD_TrackExtender_BaseExtenderWithMTD_h
+#define RecoMTD_TrackExtender_BaseExtenderWithMTD_h
+
+#include <CLHEP/Units/GlobalPhysicalConstants.h>
+
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/Math/interface/GeantUnits.h"
+#include "DataFormats/TrackerRecHit2D/interface/MTDTrackingRecHit.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "RecoMTD/DetLayers/interface/MTDDetLayerGeometry.h"
+#include "RecoMTD/Records/interface/MTDRecoGeometryRecord.h"
+#include "RecoMTD/TransientTrackingRecHit/interface/MTDTransientTrackingRecHitBuilder.h"
+#include "TrackingTools/GeomPropagators/interface/Propagator.h"
+#include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
+#include "TrackingTools/PatternTools/interface/TSCBLBuilderWithPropagator.h"
+#include "TrackingTools/PatternTools/interface/Trajectory.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
+#include "TrackingTools/TrackRefitter/interface/RefitDirection.h"
+
+using namespace std;
+using namespace edm;
+using namespace reco;
+
+namespace mtdtof{
+  constexpr float c_cm_ns = geant_units::operators::convertMmToCm(CLHEP::c_light);  // [mm/ns] -> [cm/ns]
+  constexpr float c_inv = 1.0f / c_cm_ns;
+
+  class MTDHitMatchingInfo{
+    public:
+      MTDHitMatchingInfo();
+
+      bool operator<(const MTDHitMatchingInfo& m2) const;
+      float chi2(float timeWeight = 1.f) const;
+
+      const MTDTrackingRecHit* hit;
+      float estChi2;
+      float timeChi2;
+  };
+
+  class TrackSegments {
+    public:
+      TrackSegments();
+
+      uint32_t addSegment(float tPath, float tMom2, float sigmaMom);
+      float computeTof(float mass_inv2) const;
+      float computeSigmaTof(float mass_inv2);
+      uint32_t size() const;
+      uint32_t removeFirstSegment();
+      std::pair<float, float> getSegmentPathAndMom2(uint32_t iSegment) const;
+
+      uint32_t nSegment_ = 0;
+      std::vector<float> segmentPathOvc_;
+      std::vector<float> segmentMom2_;
+      std::vector<float> segmentSigmaMom_;
+
+      std::vector<float> sigmaTofs_;
+  };
+
+  struct TrackTofPidInfo {
+    float tmtd;
+    float tmtderror;
+    float pathlength;
+
+    float betaerror;
+
+    float dt;
+    float dterror;
+    float dterror2;
+    float dtchi2;
+
+    float dt_best;
+    float dterror_best;
+    float dtchi2_best;
+
+    float gammasq_pi;
+    float beta_pi;
+    float dt_pi;
+    float sigma_dt_pi;
+
+    float gammasq_k;
+    float beta_k;
+    float dt_k;
+    float sigma_dt_k;
+
+    float gammasq_p;
+    float beta_p;
+    float dt_p;
+    float sigma_dt_p;
+
+    float prob_pi;
+    float prob_k;
+    float prob_p;
+  };
+
+  enum class TofCalc { kCost = 1, kSegm = 2, kMixd = 3 };
+  enum class SigmaTofCalc { kCost = 1, kSegm = 2, kMixd = 3 };
+
+  const TrackTofPidInfo computeTrackTofPidInfo(float magp2,
+                                               float length,
+                                               TrackSegments trs,
+                                               float t_mtd,
+                                               float t_mtderr,
+                                               float t_vtx,
+                                               float t_vtx_err,
+                                               bool addPIDError = true,
+                                               TofCalc choice = TofCalc::kCost,
+                                               SigmaTofCalc sigma_choice = SigmaTofCalc::kCost);
+
+  bool getTrajectoryStateClosestToBeamLine(const Trajectory& traj,
+                                           const reco::BeamSpot& bs,
+                                           const Propagator* thePropagator,
+                                           TrajectoryStateClosestToBeamLine& tscbl);
+
+  bool trackPathLength(const Trajectory& traj,
+                       const TrajectoryStateClosestToBeamLine& tscbl,
+                       const Propagator* thePropagator,
+                       float& pathlength,
+                       TrackSegments& trs);
+
+  bool trackPathLength(const Trajectory& traj,
+                       const reco::BeamSpot& bs,
+                       const Propagator* thePropagator,
+                       float& pathlength,
+                       TrackSegments& trs);
+
+  bool cmp_for_detset(const unsigned one, const unsigned two);
+
+  void find_hits_in_dets(const MTDTrackingDetSetVector& hits,
+                         const Trajectory& traj,
+                         const DetLayer* layer,
+                         const TrajectoryStateOnSurface& tsos,
+                         const float pmag2,
+                         const float pathlength0,
+                         const TrackSegments& trs0,
+                         const float vtxTime,
+                         const float vtxTimeError,
+                         bool useVtxConstraint,
+                         const reco::BeamSpot& bs,
+                         const float bsTimeSpread,
+                         const Propagator* prop,
+                         const MeasurementEstimator* estimator,
+                         std::set<MTDHitMatchingInfo>& out);
+}
+
+class BaseExtenderWithMTD {
+
+  public:
+    explicit BaseExtenderWithMTD(const ParameterSet& iConfig);
+    virtual ~BaseExtenderWithMTD();
+
+    std::unique_ptr<MeasurementEstimator> theEstimator;
+
+    typedef typename TrackCollection::value_type TrackType;
+    typedef edm::View<TrackType> InputCollection;
+
+    void setParameters(const TransientTrackingRecHitBuilder* hitbuilder, const GlobalTrackingGeometry* gtg);
+    const TransientTrackingRecHitBuilder* getHitBuilder() const;
+
+    void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+    TransientTrackingRecHit::ConstRecHitContainer tryBTLLayers(const TrajectoryStateOnSurface&,
+                                                               const Trajectory& traj,
+                                                               const float,
+                                                               const float,
+                                                               const mtdtof::TrackSegments&,
+                                                               const MTDTrackingDetSetVector&,
+                                                               const MTDDetLayerGeometry*,
+                                                               const MagneticField* field,
+                                                               const Propagator* prop,
+                                                               const reco::BeamSpot& bs,
+                                                               const float vtxTime,
+                                                               const float vtxTimeError,
+                                                               mtdtof::MTDHitMatchingInfo& bestHit) const;
+
+    TransientTrackingRecHit::ConstRecHitContainer tryETLLayers(const TrajectoryStateOnSurface&,
+                                                              const Trajectory& traj,
+                                                              const float,
+                                                              const float,
+                                                              const mtdtof::TrackSegments&,
+                                                              const MTDTrackingDetSetVector&,
+                                                              const MTDDetLayerGeometry*,
+                                                              const MagneticField* field,
+                                                              const Propagator* prop,
+                                                              const reco::BeamSpot& bs,
+                                                              const float vtxTime,
+                                                              const float vtxTimeError,
+                                                              mtdtof::MTDHitMatchingInfo& bestHit) const;
+
+    virtual void fillMatchingHits(const DetLayer*,
+                                  const TrajectoryStateOnSurface&,
+                                  const Trajectory&,
+                                  const float,
+                                  const float,
+                                  const mtdtof::TrackSegments&,
+                                  const MTDTrackingDetSetVector&,
+                                  const Propagator*,
+                                  const reco::BeamSpot&,
+                                  const float&,
+                                  const float&,
+                                  TransientTrackingRecHit::ConstRecHitContainer&,
+                                  mtdtof::MTDHitMatchingInfo&) const;
+    
+    RefitDirection::GeometricalDirection checkRecHitsOrdering(TransientTrackingRecHit::ConstRecHitContainer const& recHits) const;                          
+
+    reco::Track buildTrack(const reco::TrackRef&,
+                           const Trajectory&,
+                           const Trajectory&,
+                           const reco::BeamSpot&,
+                           const MagneticField* field,
+                           const Propagator* prop,
+                           bool hasMTD,
+                           float& pathLength,
+                           float& tmtdOut,
+                           float& sigmatmtdOut,
+                           GlobalPoint& tmtdPosOut,
+                           float& tofpi,
+                           float& tofk,
+                           float& tofp,
+                           float& sigmatofpi,
+                           float& sigmatofk,
+                           float& sigmatofp) const;
+
+    reco::TrackExtra buildTrackExtra(const Trajectory& trajectory) const;
+    string dumpLayer(const DetLayer* layer) const; 
+
+    const float estMaxChi2_;
+    const float estMaxNSigma_;
+    const float btlChi2Cut_;
+    const float btlTimeChi2Cut_;
+    const float etlChi2Cut_;
+    const float etlTimeChi2Cut_;
+
+    const bool useVertex_;
+    const float dzCut_;
+    const float bsTimeSpread_;
+
+  private:
+
+    const TransientTrackingRecHitBuilder* basehitbuilder_;
+    const GlobalTrackingGeometry* basegtg_;
+
+    static constexpr float trackMaxBtlEta_ = 1.5;
+};
+
+#endif

--- a/RecoMTD/TrackExtender/interface/BaseExtenderWithMTD.h
+++ b/RecoMTD/TrackExtender/interface/BaseExtenderWithMTD.h
@@ -163,8 +163,6 @@ public:
   void setParameters(const TransientTrackingRecHitBuilder* hitbuilder, const GlobalTrackingGeometry* gtg);
   const TransientTrackingRecHitBuilder* getHitBuilder() const;
 
-  void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-
   TransientTrackingRecHit::ConstRecHitContainer tryBTLLayers(const TrajectoryStateOnSurface&,
                                                              const Trajectory& traj,
                                                              const float,

--- a/RecoMTD/TrackExtender/interface/BaseExtenderWithMTD.h
+++ b/RecoMTD/TrackExtender/interface/BaseExtenderWithMTD.h
@@ -29,39 +29,39 @@ using namespace std;
 using namespace edm;
 using namespace reco;
 
-namespace mtdtof{
+namespace mtdtof {
   constexpr float c_cm_ns = geant_units::operators::convertMmToCm(CLHEP::c_light);  // [mm/ns] -> [cm/ns]
   constexpr float c_inv = 1.0f / c_cm_ns;
 
-  class MTDHitMatchingInfo{
-    public:
-      MTDHitMatchingInfo();
+  class MTDHitMatchingInfo {
+  public:
+    MTDHitMatchingInfo();
 
-      bool operator<(const MTDHitMatchingInfo& m2) const;
-      float chi2(float timeWeight = 1.f) const;
+    bool operator<(const MTDHitMatchingInfo& m2) const;
+    float chi2(float timeWeight = 1.f) const;
 
-      const MTDTrackingRecHit* hit;
-      float estChi2;
-      float timeChi2;
+    const MTDTrackingRecHit* hit;
+    float estChi2;
+    float timeChi2;
   };
 
   class TrackSegments {
-    public:
-      TrackSegments();
+  public:
+    TrackSegments();
 
-      uint32_t addSegment(float tPath, float tMom2, float sigmaMom);
-      float computeTof(float mass_inv2) const;
-      float computeSigmaTof(float mass_inv2);
-      uint32_t size() const;
-      uint32_t removeFirstSegment();
-      std::pair<float, float> getSegmentPathAndMom2(uint32_t iSegment) const;
+    uint32_t addSegment(float tPath, float tMom2, float sigmaMom);
+    float computeTof(float mass_inv2) const;
+    float computeSigmaTof(float mass_inv2);
+    uint32_t size() const;
+    uint32_t removeFirstSegment();
+    std::pair<float, float> getSegmentPathAndMom2(uint32_t iSegment) const;
 
-      uint32_t nSegment_ = 0;
-      std::vector<float> segmentPathOvc_;
-      std::vector<float> segmentMom2_;
-      std::vector<float> segmentSigmaMom_;
+    uint32_t nSegment_ = 0;
+    std::vector<float> segmentPathOvc_;
+    std::vector<float> segmentMom2_;
+    std::vector<float> segmentSigmaMom_;
 
-      std::vector<float> sigmaTofs_;
+    std::vector<float> sigmaTofs_;
   };
 
   struct TrackTofPidInfo {
@@ -148,106 +148,105 @@ namespace mtdtof{
                          const Propagator* prop,
                          const MeasurementEstimator* estimator,
                          std::set<MTDHitMatchingInfo>& out);
-}
+}  // namespace mtdtof
 
 class BaseExtenderWithMTD {
+public:
+  explicit BaseExtenderWithMTD(const ParameterSet& iConfig);
+  virtual ~BaseExtenderWithMTD();
 
-  public:
-    explicit BaseExtenderWithMTD(const ParameterSet& iConfig);
-    virtual ~BaseExtenderWithMTD();
+  std::unique_ptr<MeasurementEstimator> theEstimator;
 
-    std::unique_ptr<MeasurementEstimator> theEstimator;
+  typedef typename TrackCollection::value_type TrackType;
+  typedef edm::View<TrackType> InputCollection;
 
-    typedef typename TrackCollection::value_type TrackType;
-    typedef edm::View<TrackType> InputCollection;
+  void setParameters(const TransientTrackingRecHitBuilder* hitbuilder, const GlobalTrackingGeometry* gtg);
+  const TransientTrackingRecHitBuilder* getHitBuilder() const;
 
-    void setParameters(const TransientTrackingRecHitBuilder* hitbuilder, const GlobalTrackingGeometry* gtg);
-    const TransientTrackingRecHitBuilder* getHitBuilder() const;
+  void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-    void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  TransientTrackingRecHit::ConstRecHitContainer tryBTLLayers(const TrajectoryStateOnSurface&,
+                                                             const Trajectory& traj,
+                                                             const float,
+                                                             const float,
+                                                             const mtdtof::TrackSegments&,
+                                                             const MTDTrackingDetSetVector&,
+                                                             const MTDDetLayerGeometry*,
+                                                             const MagneticField* field,
+                                                             const Propagator* prop,
+                                                             const reco::BeamSpot& bs,
+                                                             const float vtxTime,
+                                                             const float vtxTimeError,
+                                                             mtdtof::MTDHitMatchingInfo& bestHit) const;
 
-    TransientTrackingRecHit::ConstRecHitContainer tryBTLLayers(const TrajectoryStateOnSurface&,
-                                                               const Trajectory& traj,
-                                                               const float,
-                                                               const float,
-                                                               const mtdtof::TrackSegments&,
-                                                               const MTDTrackingDetSetVector&,
-                                                               const MTDDetLayerGeometry*,
-                                                               const MagneticField* field,
-                                                               const Propagator* prop,
-                                                               const reco::BeamSpot& bs,
-                                                               const float vtxTime,
-                                                               const float vtxTimeError,
-                                                               mtdtof::MTDHitMatchingInfo& bestHit) const;
+  TransientTrackingRecHit::ConstRecHitContainer tryETLLayers(const TrajectoryStateOnSurface&,
+                                                             const Trajectory& traj,
+                                                             const float,
+                                                             const float,
+                                                             const mtdtof::TrackSegments&,
+                                                             const MTDTrackingDetSetVector&,
+                                                             const MTDDetLayerGeometry*,
+                                                             const MagneticField* field,
+                                                             const Propagator* prop,
+                                                             const reco::BeamSpot& bs,
+                                                             const float vtxTime,
+                                                             const float vtxTimeError,
+                                                             mtdtof::MTDHitMatchingInfo& bestHit) const;
 
-    TransientTrackingRecHit::ConstRecHitContainer tryETLLayers(const TrajectoryStateOnSurface&,
-                                                              const Trajectory& traj,
-                                                              const float,
-                                                              const float,
-                                                              const mtdtof::TrackSegments&,
-                                                              const MTDTrackingDetSetVector&,
-                                                              const MTDDetLayerGeometry*,
-                                                              const MagneticField* field,
-                                                              const Propagator* prop,
-                                                              const reco::BeamSpot& bs,
-                                                              const float vtxTime,
-                                                              const float vtxTimeError,
-                                                              mtdtof::MTDHitMatchingInfo& bestHit) const;
+  virtual void fillMatchingHits(const DetLayer*,
+                                const TrajectoryStateOnSurface&,
+                                const Trajectory&,
+                                const float,
+                                const float,
+                                const mtdtof::TrackSegments&,
+                                const MTDTrackingDetSetVector&,
+                                const Propagator*,
+                                const reco::BeamSpot&,
+                                const float&,
+                                const float&,
+                                TransientTrackingRecHit::ConstRecHitContainer&,
+                                mtdtof::MTDHitMatchingInfo&) const;
 
-    virtual void fillMatchingHits(const DetLayer*,
-                                  const TrajectoryStateOnSurface&,
-                                  const Trajectory&,
-                                  const float,
-                                  const float,
-                                  const mtdtof::TrackSegments&,
-                                  const MTDTrackingDetSetVector&,
-                                  const Propagator*,
-                                  const reco::BeamSpot&,
-                                  const float&,
-                                  const float&,
-                                  TransientTrackingRecHit::ConstRecHitContainer&,
-                                  mtdtof::MTDHitMatchingInfo&) const;
-    
-    RefitDirection::GeometricalDirection checkRecHitsOrdering(TransientTrackingRecHit::ConstRecHitContainer const& recHits) const;                          
+  RefitDirection::GeometricalDirection checkRecHitsOrdering(
+      TransientTrackingRecHit::ConstRecHitContainer const& recHits) const;
 
-    reco::Track buildTrack(const reco::TrackRef&,
-                           const Trajectory&,
-                           const Trajectory&,
-                           const reco::BeamSpot&,
-                           const MagneticField* field,
-                           const Propagator* prop,
-                           bool hasMTD,
-                           float& pathLength,
-                           float& tmtdOut,
-                           float& sigmatmtdOut,
-                           GlobalPoint& tmtdPosOut,
-                           float& tofpi,
-                           float& tofk,
-                           float& tofp,
-                           float& sigmatofpi,
-                           float& sigmatofk,
-                           float& sigmatofp) const;
+  reco::Track buildTrack(const reco::TrackRef&,
+                         const Trajectory&,
+                         const Trajectory&,
+                         const reco::BeamSpot&,
+                         const MagneticField* field,
+                         const Propagator* prop,
+                         bool hasMTD,
+                         float& pathLength,
+                         float& tmtdOut,
+                         float& sigmatmtdOut,
+                         GlobalPoint& tmtdPosOut,
+                         float& tofpi,
+                         float& tofk,
+                         float& tofp,
+                         float& sigmatofpi,
+                         float& sigmatofk,
+                         float& sigmatofp) const;
 
-    reco::TrackExtra buildTrackExtra(const Trajectory& trajectory) const;
-    string dumpLayer(const DetLayer* layer) const; 
+  reco::TrackExtra buildTrackExtra(const Trajectory& trajectory) const;
+  string dumpLayer(const DetLayer* layer) const;
 
-    const float estMaxChi2_;
-    const float estMaxNSigma_;
-    const float btlChi2Cut_;
-    const float btlTimeChi2Cut_;
-    const float etlChi2Cut_;
-    const float etlTimeChi2Cut_;
+  const float estMaxChi2_;
+  const float estMaxNSigma_;
+  const float btlChi2Cut_;
+  const float btlTimeChi2Cut_;
+  const float etlChi2Cut_;
+  const float etlTimeChi2Cut_;
 
-    const bool useVertex_;
-    const float dzCut_;
-    const float bsTimeSpread_;
+  const bool useVertex_;
+  const float dzCut_;
+  const float bsTimeSpread_;
 
-  private:
+private:
+  const TransientTrackingRecHitBuilder* basehitbuilder_;
+  const GlobalTrackingGeometry* basegtg_;
 
-    const TransientTrackingRecHitBuilder* basehitbuilder_;
-    const GlobalTrackingGeometry* basegtg_;
-
-    static constexpr float trackMaxBtlEta_ = 1.5;
+  static constexpr float trackMaxBtlEta_ = 1.5;
 };
 
 #endif

--- a/RecoMTD/TrackExtender/plugins/BuildFile.xml
+++ b/RecoMTD/TrackExtender/plugins/BuildFile.xml
@@ -1,7 +1,8 @@
 <use name="RecoMTD/DetLayers"/>
 <use name="RecoMTD/Records"/>
+<use name="RecoMTD/TrackExtender"/>
 <use name="FWCore/Framework"/>
-<library file="TrackExtenderWithMTD.cc" name="RecoMTDTrackExtenderPlugins">
+<library file="*.cc" name="RecoMTDTrackExtenderPlugins">
   <use name="clhep"/>
   <use name="TrackingTools/TrackRefitter"/>
   <use name="TrackingTools/Records"/>

--- a/RecoMTD/TrackExtender/plugins/MuonExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/MuonExtenderWithMTD.cc
@@ -1,0 +1,1020 @@
+#include <sstream>
+#include <format>
+
+#include "RecoMTD/TrackExtender/plugins/MuonExtenderWithMTD.h"
+
+#include <CLHEP/Units/GlobalPhysicalConstants.h>
+
+#include "DataFormats/ForwardDetId/interface/BTLDetId.h"
+#include "DataFormats/ForwardDetId/interface/ETLDetId.h"
+#include "DataFormats/ForwardDetId/interface/MTDChannelIdentifier.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/Math/interface/GeantUnits.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/Math/interface/Rounding.h"
+#include "DataFormats/TrackerRecHit2D/interface/MTDTrackingRecHit.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+#include "Geometry/CommonTopologies/interface/Topology.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "RecoMTD/DetLayers/interface/MTDDetLayerGeometry.h"
+#include "RecoMTD/DetLayers/interface/MTDTrayBarrelLayer.h"
+#include "RecoMTD/Records/interface/MTDRecoGeometryRecord.h"
+#include "RecoMTD/TransientTrackingRecHit/interface/MTDTransientTrackingRecHitBuilder.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
+#include "RecoMuon/DetLayers/interface/MuonDetLayerGeometry.h"
+#include "RecoMuon/Records/interface/MuonRecoGeometryRecord.h"
+#include "RecoMuon/Navigation/interface/MuonNavigationSchool.h"
+#include "RecoMuon/Navigation/interface/MuonNavigationPrinter.h"
+#include "RecoTracker/TransientTrackingRecHit/interface/Traj2TrackHits.h"
+#include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
+#include "TrackingTools/GeomPropagators/interface/Propagator.h"
+#include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
+#include "TrackingTools/PatternTools/interface/TSCBLBuilderWithPropagator.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+#include "TrackingTools/PatternTools/interface/Trajectory.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "TrackingTools/TrackRefitter/interface/TrackTransformer.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
+#include "TrackingTools/TrackRefitter/interface/RefitDirection.h"
+
+using namespace std;
+using namespace edm;
+using namespace reco;
+using namespace mtdtof;
+
+namespace mtdtof{
+
+  // Asummes 100% muon identification
+  const MuonTofPidInfo computeMuonTofPidInfo(float magp2,
+                                              float length,
+                                              TrackSegments trs,
+                                              float t_mtd,
+                                              float t_mtderr,
+                                              float t_vtx,
+                                              float t_vtx_err,
+                                              bool addPIDError,
+                                              TofCalc choice,
+                                              SigmaTofCalc sigma_choice){
+
+    constexpr float m_mu = 0.10565837f;
+    constexpr float m_mu_inv2 = 1.0f / m_mu / m_mu;
+
+    MuonTofPidInfo tofpid;
+
+    tofpid.tmtd = t_mtd;
+    tofpid.tmtderror = t_mtderr;
+    tofpid.pathlength = length;
+
+    auto deltat = [&](const float mass_inv2, const float betatmp) {
+      float res(1.f);
+      switch (choice) {
+        case TofCalc::kCost:
+          res = tofpid.pathlength / betatmp * c_inv;
+          break;
+        case TofCalc::kSegm:
+          res = trs.computeTof(mass_inv2);
+          break;
+        case TofCalc::kMixd:
+          res = trs.computeTof(mass_inv2) + tofpid.pathlength / betatmp * c_inv;
+          break;
+      }
+      return res;
+    };
+
+    auto sigmadeltat = [&](const float mass_inv2) {
+      float res(1.f);
+      switch (sigma_choice) {
+        case SigmaTofCalc::kCost:
+          // sigma(t) = sigma(p) * |dt/dp| = sigma(p) * DeltaL/c * m^2 / (p^2 * E)
+          res = tofpid.pathlength * c_inv * trs.segmentSigmaMom_[trs.nSegment_ - 1] /
+                (magp2 * sqrt(magp2 + 1 / mass_inv2) * mass_inv2);
+          break;
+        case SigmaTofCalc::kSegm:
+          res = trs.computeSigmaTof(mass_inv2);
+          break;
+        case SigmaTofCalc::kMixd:
+          float res1 = tofpid.pathlength * c_inv * trs.segmentSigmaMom_[trs.nSegment_ - 1] /
+                       (magp2 * sqrt(magp2 + 1 / mass_inv2) * mass_inv2);
+          float res2 = trs.computeSigmaTof(mass_inv2);
+          res = sqrt(res1 * res1 + res2 * res2 + 2 * res1 * res2);
+      }
+
+      return res;
+    };
+
+    tofpid.gammasq_mu = 1.f + magp2 * m_mu_inv2;
+    tofpid.beta_mu = std::sqrt(1.f - 1.f / tofpid.gammasq_mu);
+    tofpid.dt_mu = deltat(m_mu_inv2, tofpid.beta_mu);
+    tofpid.sigma_dt_mu = sigmadeltat(m_mu_inv2);
+
+    tofpid.dt = tofpid.tmtd - tofpid.dt_mu - t_vtx;
+    tofpid.betaerror = 0.f;
+    tofpid.dterror2 = tofpid.tmtderror * tofpid.tmtderror + t_vtx_err * t_vtx_err + tofpid.sigma_dt_mu * tofpid.sigma_dt_mu;
+    tofpid.dterror = sqrt(tofpid.dterror2);
+
+    tofpid.dtchi2 = (tofpid.dt * tofpid.dt) / tofpid.dterror2;
+
+    tofpid.dt_best = tofpid.dt;
+    tofpid.dterror_best = tofpid.dterror;
+    tofpid.dtchi2_best = tofpid.dtchi2;
+
+    return tofpid;
+
+  };
+
+  bool muonPathLength(const Trajectory& traj,
+                       const TrajectoryStateClosestToBeamLine& tscbl,
+                       const Propagator* thePropagator,
+                       float& pathlength,
+                       TrackSegments& trs) {
+    pathlength = 0.f;
+
+    bool validpropagation = true;
+    float oldp = traj.measurements().begin()->updatedState().globalMomentum().mag();
+    float pathlength1 = 0.f;
+    float pathlength2 = 0.f;
+
+    //add pathlength layer by layer
+    for (auto it = traj.measurements().begin(); it != traj.measurements().end() - 1; ++it) {
+    	if (it->recHit()->isValid())
+	      if (it->recHit()->geographicalId().det() == DetId::Muon)
+	        continue;
+      
+      const auto& propresult = thePropagator->propagateWithPath(it->updatedState(), (it + 1)->updatedState().surface());
+      float layerpathlength = std::abs(propresult.second);
+      if (layerpathlength == 0.f) {
+        validpropagation = false;
+      }
+      pathlength1 += layerpathlength;
+
+      // sigma(p) from curvilinear error (on q/p)
+      float sigma_p = sqrt((it + 1)->updatedState().curvilinearError().matrix()(0, 0)) *
+                      (it + 1)->updatedState().globalMomentum().mag2();
+
+      trs.addSegment(layerpathlength, (it + 1)->updatedState().globalMomentum().mag2(), sigma_p);
+
+      LogTrace("MuonExtenderWithMTD") << "TSOS " << std::fixed << std::setw(4) << trs.size() << " R_i " << std::fixed
+                                       << std::setw(14) << it->updatedState().globalPosition().perp() << " z_i "
+                                       << std::fixed << std::setw(14) << it->updatedState().globalPosition().z()
+                                       << " R_e " << std::fixed << std::setw(14)
+                                       << (it + 1)->updatedState().globalPosition().perp() << " z_e " << std::fixed
+                                       << std::setw(14) << (it + 1)->updatedState().globalPosition().z() << " p "
+                                       << std::fixed << std::setw(14) << (it + 1)->updatedState().globalMomentum().mag()
+                                       << " dp " << std::fixed << std::setw(14)
+                                       << (it + 1)->updatedState().globalMomentum().mag() - oldp;
+      oldp = (it + 1)->updatedState().globalMomentum().mag();
+    }
+
+    //add distance from bs to first measurement
+    auto const& tscblPCA = tscbl.trackStateAtPCA();
+    auto const& aSurface = traj.direction() == alongMomentum ? traj.firstMeasurement().updatedState().surface()
+                                                             : traj.lastMeasurement().updatedState().surface();
+    pathlength2 = thePropagator->propagateWithPath(tscblPCA, aSurface).second;
+    if (pathlength2 == 0.f) {
+      validpropagation = false;
+    }
+    pathlength = pathlength1 + pathlength2;
+
+    float sigma_p = sqrt(tscblPCA.curvilinearError().matrix()(0, 0)) * tscblPCA.momentum().mag2();
+
+    trs.addSegment(pathlength2, tscblPCA.momentum().mag2(), sigma_p);
+
+    LogTrace("MuonExtenderWithMTD") << "TSOS " << std::fixed << std::setw(4) << trs.size() << " R_e " << std::fixed
+                                     << std::setw(14) << tscblPCA.position().perp() << " z_e " << std::fixed
+                                     << std::setw(14) << tscblPCA.position().z() << " p " << std::fixed << std::setw(14)
+                                     << tscblPCA.momentum().mag() << " dp " << std::fixed << std::setw(14)
+                                     << tscblPCA.momentum().mag() - oldp << " sigma_p = " << std::fixed << std::setw(14)
+                                     << sigma_p << " sigma_p/p = " << std::fixed << std::setw(14)
+                                     << sigma_p / tscblPCA.momentum().mag() * 100 << " %";
+
+    return validpropagation;
+  };
+
+  bool muonPathLength(const Trajectory& traj,
+                      const reco::BeamSpot& bs,
+                      const Propagator* thePropagator,
+                      float& pathlength,
+                      TrackSegments& trs) {
+    pathlength = 0.f;
+
+    TrajectoryStateClosestToBeamLine tscbl;
+    bool tscbl_status = getTrajectoryStateClosestToBeamLine(traj, bs, thePropagator, tscbl);
+
+    if (!tscbl_status)
+      return false;
+
+    return muonPathLength(traj, tscbl, thePropagator, pathlength, trs);
+  };
+  void find_hits_in_dets_muon(const MTDTrackingDetSetVector& hits,
+                              const Trajectory& traj,
+                              const DetLayer* layer,
+                              const TrajectoryStateOnSurface& tsos,
+                              const float pmag2,
+                              const float pathlength0,
+                              const TrackSegments& trs0,
+                              const float vtxTime,
+                              const float vtxTimeError,
+                              bool useVtxConstraint,
+                              const reco::BeamSpot& bs,
+                              const float bsTimeSpread,
+                              const Propagator* prop,
+                              const MeasurementEstimator* estimator,
+                              std::set<MTDHitMatchingInfo>& out) {
+
+    pair<bool, TrajectoryStateOnSurface> comp = layer->compatible(tsos, *prop, *estimator);
+    if (comp.first) {
+      const vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos, *prop, *estimator);
+      LogTrace("MuonExtenderWithMTD") << "Hit search: Compatible dets " << compDets.size();
+      if (!compDets.empty()) {
+        for (const auto& detWithState : compDets) {
+          auto range = hits.equal_range(detWithState.first->geographicalId(), cmp_for_detset);
+          if (range.first == range.second) {
+            LogTrace("MuonExtenderWithMTD")
+                << "Hit search: no hit in DetId " << detWithState.first->geographicalId().rawId();
+            continue;
+          }
+
+          auto pl = prop->propagateWithPath(tsos, detWithState.second.surface());
+          if (pl.second == 0.) {
+            LogTrace("MuonExtenderWithMTD")
+                << "Hit search: no propagation to DetId " << detWithState.first->geographicalId().rawId();
+            continue;
+          }
+
+          const float t_vtx = useVtxConstraint ? vtxTime : 0.f;
+
+          const float t_vtx_err = useVtxConstraint ? vtxTimeError : bsTimeSpread;
+
+          float lastpmag2 = trs0.getSegmentPathAndMom2(0).second;
+
+          for (auto detitr = range.first; detitr != range.second; ++detitr) {
+            for (const auto& hit : *detitr) {
+              auto est = estimator->estimate(detWithState.second, hit);
+              if (!est.first) {
+                LogTrace("MuonExtenderWithMTD")
+                    << "Hit search: no compatible estimate in DetId " << detWithState.first->geographicalId().rawId()
+                    << " for hit at pos (" << std::fixed << std::setw(14) << hit.globalPosition().x() << ","
+                    << std::fixed << std::setw(14) << hit.globalPosition().y() << "," << std::fixed << std::setw(14)
+                    << hit.globalPosition().z() << ")";
+                continue;
+              }
+
+              LogTrace("MuonExtenderWithMTD")
+                  << "Hit search: spatial compatibility DetId " << detWithState.first->geographicalId().rawId()
+                  << " TSOS dx/dy " << std::fixed << std::setw(14)
+                  << std::sqrt(detWithState.second.localError().positionError().xx()) << " " << std::fixed
+                  << std::setw(14) << std::sqrt(detWithState.second.localError().positionError().yy()) << " hit dx/dy "
+                  << std::fixed << std::setw(14) << std::sqrt(hit.localPositionError().xx()) << " " << std::fixed
+                  << std::setw(14) << std::sqrt(hit.localPositionError().yy()) << " chi2 " << std::fixed
+                  << std::setw(14) << est.second;
+
+              MuonTofPidInfo tof = computeMuonTofPidInfo(lastpmag2,
+                                                          std::abs(pl.second),
+                                                          trs0,
+                                                          hit.time(),
+                                                          hit.timeError(),
+                                                          t_vtx,
+                                                          t_vtx_err,  //put vtx error by hand for the moment
+                                                          false,
+                                                          TofCalc::kMixd,
+                                                          SigmaTofCalc::kMixd);
+              MTDHitMatchingInfo mi;
+              mi.hit = &hit;
+              mi.estChi2 = est.second;
+              mi.timeChi2 = tof.dtchi2_best;  //use the chi2 for the best matching hypothesis
+
+              out.insert(mi);
+            }
+          }
+        }
+      }
+    }
+  };
+} // namespace
+
+// MuonBaseExtenderWithMTD ---------
+
+MuonBaseExtenderWithMTD::MuonBaseExtenderWithMTD(const edm::ParameterSet& iConfig) : BaseExtenderWithMTD(iConfig) {}
+MuonBaseExtenderWithMTD::~MuonBaseExtenderWithMTD() = default;
+
+void MuonBaseExtenderWithMTD::fillMatchingHits(const DetLayer* ilay,
+                                               const TrajectoryStateOnSurface& tsos,
+                                               const Trajectory& traj,
+                                               const float pmag2,
+                                               const float pathlength0,
+                                               const TrackSegments& trs0,
+                                               const MTDTrackingDetSetVector& hits,
+                                               const Propagator* prop,
+                                               const reco::BeamSpot& bs,
+                                               const float& vtxTime,
+                                               const float& vtxTimeError,
+                                               TransientTrackingRecHit::ConstRecHitContainer& output,
+                                               MTDHitMatchingInfo& bestHit) const {
+
+  std::set<MTDHitMatchingInfo> hitsInLayer;
+  bool hitMatched = false;
+
+  using namespace std::placeholders;
+  auto find_hits = std::bind(find_hits_in_dets_muon,
+                             std::cref(hits),
+                             std::cref(traj),
+                             ilay,
+                             std::cref(tsos),
+                             pmag2,
+                             pathlength0,
+                             trs0,
+                             _1,
+                             _2,
+                             _3,
+                             std::cref(bs),
+                             bsTimeSpread_,
+                             prop,
+                             theEstimator.get(),
+                             std::ref(hitsInLayer));
+
+  bool matchVertex = vtxTimeError > 0.f;
+  if (useVertex_ && matchVertex) {
+    find_hits(vtxTime, vtxTimeError, true);
+  } else {
+    find_hits(0, 0, false);
+  }
+
+  float spaceChi2Cut = ilay->isBarrel() ? btlChi2Cut_ : etlChi2Cut_;
+  float timeChi2Cut = ilay->isBarrel() ? btlTimeChi2Cut_ : etlTimeChi2Cut_;
+
+  //just take the first hit because the hits are sorted on their matching quality
+  if (!hitsInLayer.empty()) {
+    //check hits to pass minimum quality matching requirements
+    auto const& firstHit = *hitsInLayer.begin();
+    LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: matching trial 1: estChi2= " << firstHit.estChi2
+                                     << " timeChi2= " << firstHit.timeChi2;
+    if (firstHit.estChi2 < spaceChi2Cut && firstHit.timeChi2 < timeChi2Cut) {
+      hitMatched = true;
+      output.push_back(getHitBuilder()->build(firstHit.hit));
+      if (firstHit < bestHit)
+        bestHit = firstHit;
+    }
+  }
+    
+  if (useVertex_ && matchVertex && !hitMatched) {
+    //try a second search with beamspot hypothesis
+    hitsInLayer.clear();
+    find_hits(0, 0, false);
+    if (!hitsInLayer.empty()) {
+      auto const& firstHit = *hitsInLayer.begin();
+      LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: matching trial 2: estChi2= " << firstHit.estChi2
+                                       << " timeChi2= " << firstHit.timeChi2;
+      if (firstHit.timeChi2 < timeChi2Cut) {
+        if (firstHit.estChi2 < spaceChi2Cut) {
+          hitMatched = true;
+          output.push_back(getHitBuilder()->build(firstHit.hit));
+          if (firstHit < bestHit)
+            bestHit = firstHit;
+        }
+      }
+    }
+  }
+#ifdef EDM_ML_DEBUG
+  if (hitMatched) {
+    LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: matched hit with time: " << bestHit.hit->time()
+                                     << " +/- " << bestHit.hit->timeError();
+  } else {
+    LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: no matched hit";
+  }
+#endif                                                  
+}
+
+reco::Track MuonBaseExtenderWithMTD::buildTrack(const reco::TrackBase::TrackAlgorithm origAlgo,
+                                                const Trajectory& traj,
+                                                const Trajectory& trajWithMtd,
+                                                const reco::BeamSpot& bs,
+                                                const MagneticField* field,
+                                                const Propagator* thePropagator,
+                                                bool hasMTD,
+                                                float& pathLengthOut,
+                                                float& tmtdOut,
+                                                float& sigmatmtdOut,
+                                                GlobalPoint& tmtdPosOut,
+                                                float& tofmu,
+                                                float& sigmatofmu) const {
+  
+  TrajectoryStateClosestToBeamLine tscbl;
+  bool tsbcl_status = getTrajectoryStateClosestToBeamLine(traj, bs, thePropagator, tscbl);
+
+  if (!tsbcl_status)
+    return reco::Track();
+
+  GlobalPoint v = tscbl.trackStateAtPCA().position();
+  math::XYZPoint pos(v.x(), v.y(), v.z());
+  GlobalVector p = tscbl.trackStateAtPCA().momentum();
+  math::XYZVector mom(p.x(), p.y(), p.z());
+
+  int ndof = trajWithMtd.ndof();
+
+  float t0 = 0.f;
+  float covt0t0 = -1.f;
+  pathLengthOut = -1.f;  // if there is no MTD flag the pathlength with -1
+  tmtdOut = 0.f;
+  sigmatmtdOut = -1.f;
+  float betaOut = 0.f;
+  float covbetabeta = -1.f;
+
+  auto routput = [&]() {
+    return reco::Track(trajWithMtd.chiSquared(),
+                       int(ndof),
+                       pos,
+                       mom,
+                       tscbl.trackStateAtPCA().charge(),
+                       tscbl.trackStateAtPCA().curvilinearError(),
+                       origAlgo,
+                       reco::TrackBase::undefQuality,
+                       t0,
+                       betaOut,
+                       covt0t0,
+                       covbetabeta);
+  };
+
+  //compute path length for time backpropagation, using first MTD hit for the momentum
+  if (hasMTD) {
+    float pathlength;
+    TrackSegments trs;
+    bool validpropagation = muonPathLength(trajWithMtd, bs, thePropagator, pathlength, trs);
+    float thit = 0.f;
+    float thiterror = -1.f;
+    GlobalPoint thitpos{0., 0., 0.};
+    bool validmtd = false;
+
+    if (!validpropagation) {
+      return routput();
+    }
+
+    uint32_t ihitcount(0), ietlcount(0);
+    for (auto const& hit : trajWithMtd.measurements()) {
+      if (hit.recHit()->geographicalId().det() == DetId::Forward &&
+          ForwardSubdetector(hit.recHit()->geographicalId().subdetId()) == FastTime) {
+        ihitcount++;
+        if (MTDDetId(hit.recHit()->geographicalId()).mtdSubDetector() == MTDDetId::MTDType::ETL) {
+          ietlcount++;
+        }
+      }
+    }
+
+    LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: selected #hits " << ihitcount << " from ETL "
+                                    << ietlcount;
+
+    // The last measurement is not always the MTD Hit for muons
+    auto ihit1 = trajWithMtd.measurements().cbegin(); 
+    for (auto it = trajWithMtd.measurements().cbegin(); it != trajWithMtd.measurements().cend(); ++it) {
+	    const auto& hit = it->recHit();
+	    if (hit->geographicalId().det() == DetId::Forward && ForwardSubdetector(hit->geographicalId().subdetId()) == FastTime){
+	      ihit1 = it;
+	      break;
+	    }
+    }
+    if (ihitcount == 1) {
+      const MTDTrackingRecHit* mtdhit = static_cast<const MTDTrackingRecHit*>((*ihit1).recHit()->hit());
+      thit = mtdhit->time();
+      thiterror = mtdhit->timeError();
+      thitpos = mtdhit->globalPosition();
+      validmtd = true;
+    } else if (ihitcount == 2 && ietlcount == 2) {
+      std::pair<float, float> lastStep = trs.getSegmentPathAndMom2(0);
+      float etlpathlength = std::abs(lastStep.first * c_cm_ns);
+      //
+      // The information of the two ETL hits is combined and attributed to the innermost hit
+      //
+      if (etlpathlength == 0.f) {
+        validpropagation = false;
+      } else {
+        pathlength -= etlpathlength;
+        trs.removeFirstSegment();
+        const MTDTrackingRecHit* mtdhit1 = static_cast<const MTDTrackingRecHit*>((*ihit1).recHit()->hit());
+        const MTDTrackingRecHit* mtdhit2 = static_cast<const MTDTrackingRecHit*>((*(ihit1 + 1)).recHit()->hit());
+	
+        MuonTofPidInfo tofInfo = computeMuonTofPidInfo(
+							 lastStep.second, etlpathlength, trs, mtdhit1->time(), mtdhit1->timeError(), 0.f, 0.f, true, TofCalc::kCost, SigmaTofCalc::kCost);
+        //
+        // Protect against incompatible times
+        //
+        float err1 = tofInfo.dterror2;
+        float err2 = mtdhit2->timeError() * mtdhit2->timeError();
+        if (cms_rounding::roundIfNear0(err1) == 0.f || cms_rounding::roundIfNear0(err2) == 0.f) {
+          edm::LogError("MuonExtenderWithMTD")
+              << "MTD tracking hits with zero time uncertainty: " << err1 << " " << err2;
+      	}else {
+          if ((tofInfo.dt - mtdhit2->time()) * (tofInfo.dt - mtdhit2->time()) < (err1 + err2) * etlTimeChi2Cut_) {
+            //
+            // Subtract the ETL time of flight from the outermost measurement, and combine it in a weighted average with the innermost
+            // the mass ambiguity related uncertainty on the time of flight is added as an additional uncertainty
+            //
+            err1 = 1.f / err1;
+            err2 = 1.f / err2;
+            thiterror = 1.f / (err1 + err2);
+            thit = (tofInfo.dt * err1 + mtdhit2->time() * err2) * thiterror;
+            thiterror = std::sqrt(thiterror);
+            thitpos = mtdhit2->globalPosition();
+            LogTrace("MuonExtenderWithMTD")
+                << "MuonExtenderWithMTD: p trk = " << p.mag() << " ETL hits times/errors: 1) " << mtdhit1->time()
+                << " +/- " << mtdhit1->timeError() << " , 2) " << mtdhit2->time() << " +/- " << mtdhit2->timeError()
+                << " extrapolated time1: " << tofInfo.dt << " +/- " << tofInfo.dterror << " average = " << thit
+                << " +/- " << thiterror << "\n    hit1 pos: " << mtdhit1->globalPosition()
+                << " hit2 pos: " << mtdhit2->globalPosition() << " etl path length " << etlpathlength << std::endl;
+
+            validmtd = true;
+          } else {
+            // if back extrapolated time of the outermost measurement not compatible with the innermost, keep the one with smallest error
+            if (err1 <= err2) {
+              thit = tofInfo.dt;
+              thiterror = tofInfo.dterror;
+              validmtd = true;
+            } else {
+              thit = mtdhit2->time();
+              thiterror = mtdhit2->timeError();
+              validmtd = true;
+            }
+          }
+        }
+      }
+    } else {
+      edm::LogInfo("MuonExtenderWithMTD")
+          << "MTD hits #" << ihitcount << "ETL hits #" << ietlcount << " anomalous pattern, skipping..."; 
+    }
+
+    if (validmtd && validpropagation) {
+      //here add the PID uncertainty for later use in the 1st step of 4D vtx reconstruction
+
+      MuonTofPidInfo tofInfo = computeMuonTofPidInfo(
+						       p.mag2(), pathlength, trs, thit, thiterror, 0.f, 0.f, true, TofCalc::kSegm, SigmaTofCalc::kCost);
+
+      pathLengthOut = pathlength;  // set path length if we've got a timing hit
+      tmtdOut = thit;
+      sigmatmtdOut = thiterror;
+      tmtdPosOut = thitpos;
+      t0 = tofInfo.dt;
+      covt0t0 = tofInfo.dterror2;
+      betaOut = tofInfo.beta_mu;
+      covbetabeta = tofInfo.betaerror * tofInfo.betaerror;
+      tofmu = tofInfo.dt_mu;
+      sigmatofmu = tofInfo.sigma_dt_mu;
+    }
+  }  
+  return routput();
+}
+
+template <typename T1>
+MuonExtenderWithMTDT<T1>::MuonExtenderWithMTDT(const ParameterSet& iConfig)
+    : muonToken_(consumes<T1>(iConfig.getParameter<edm::InputTag>("muonSrc"))),
+      hitsToken_(consumes<MTDTrackingDetSetVector>(iConfig.getParameter<edm::InputTag>("hitsSrc"))),
+      bsToken_(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpotSrc"))),
+      updateTraj_(iConfig.getParameter<bool>("updateTrackTrajectory")),
+      updateExtra_(iConfig.getParameter<bool>("updateTrackExtra")),
+      updatePattern_(iConfig.getParameter<bool>("updateTrackHitPattern")),
+      mtdRecHitBuilder_(iConfig.getParameter<std::string>("MTDRecHitBuilder")),
+      propagator_(iConfig.getParameter<std::string>("Propagator")),
+      transientTrackBuilder_(iConfig.getParameter<std::string>("TransientTrackBuilder")),
+      useVertex_(iConfig.getParameter<bool>("useVertex")){
+  
+  baseMTDExtender_ = std::make_unique<MuonBaseExtenderWithMTD>(iConfig);
+
+  if (useVertex_) {
+    vtxToken_ = consumes<VertexCollection>(iConfig.getParameter<edm::InputTag>("vtxSrc"));
+  }
+
+  theTransformer = std::make_unique<TrackTransformer>(iConfig.getParameterSet("TrackTransformer"), consumesCollector());
+
+  btlMatchChi2Token_ = produces<edm::ValueMap<float>>("btlMatchChi2");
+  etlMatchChi2Token_ = produces<edm::ValueMap<float>>("etlMatchChi2");
+  btlMatchTimeChi2Token_ = produces<edm::ValueMap<float>>("btlMatchTimeChi2");
+  etlMatchTimeChi2Token_ = produces<edm::ValueMap<float>>("etlMatchTimeChi2");
+  npixBarrelToken_ = produces<edm::ValueMap<int>>("npixBarrel");
+  npixEndcapToken_ = produces<edm::ValueMap<int>>("npixEndcap");
+  outermostHitPositionToken_ = produces<edm::ValueMap<float>>("generalTrackOutermostHitPosition");
+  pOrigTrkToken_ = produces<edm::ValueMap<float>>("generalTrackp");
+  betaOrigTrkToken_ = produces<edm::ValueMap<float>>("generalTrackBeta");
+  t0OrigTrkToken_ = produces<edm::ValueMap<float>>("generalTrackt0");
+  sigmat0OrigTrkToken_ = produces<edm::ValueMap<float>>("generalTracksigmat0");
+  pathLengthOrigTrkToken_ = produces<edm::ValueMap<float>>("generalTrackPathLength");
+  tmtdOrigTrkToken_ = produces<edm::ValueMap<float>>("generalTracktmtd");
+  sigmatmtdOrigTrkToken_ = produces<edm::ValueMap<float>>("generalTracksigmatmtd");
+  tmtdPosOrigTrkToken_ = produces<edm::ValueMap<GlobalPoint>>("generalTrackmtdpos");
+  tofmuOrigTrkToken_ = produces<edm::ValueMap<float>>("generalTrackTofMu");
+  sigmatofmuOrigTrkToken_ = produces<edm::ValueMap<float>>("generalTrackSigmaTofMu");
+  assocOrigTrkToken_ = produces<edm::ValueMap<int>>("generalTrackassoc");
+
+  builderToken_ = esConsumes<TransientTrackBuilder, TransientTrackRecord>(edm::ESInputTag("", transientTrackBuilder_));
+  hitbuilderToken_ =
+      esConsumes<TransientTrackingRecHitBuilder, TransientRecHitRecord>(edm::ESInputTag("", mtdRecHitBuilder_));
+  gtgToken_ = esConsumes<GlobalTrackingGeometry, GlobalTrackingGeometryRecord>();
+  dlgeoToken_ = esConsumes<MTDDetLayerGeometry, MTDRecoGeometryRecord>();
+  magfldToken_ = esConsumes<MagneticField, IdealMagneticFieldRecord>();
+  propToken_ = esConsumes<Propagator, TrackingComponentsRecord>(edm::ESInputTag("", propagator_));
+  ttopoToken_ = esConsumes<TrackerTopology, TrackerTopologyRcd>();
+
+  produces<edm::OwnVector<TrackingRecHit>>();
+  produces<reco::TrackExtraCollection>();
+  produces<TrackCollection>();
+}
+
+template <typename T1>
+template <class H, class T>
+void MuonExtenderWithMTDT<T1>::fillValueMap(edm::Event& iEvent,
+                                                      const H& handle,
+                                                      const std::vector<T>& vec,
+                                                      const edm::EDPutToken& token) const {
+  auto out = std::make_unique<edm::ValueMap<T>>();
+  typename edm::ValueMap<T>::Filler filler(*out);
+  filler.insert(handle, vec.begin(), vec.end());
+  filler.fill();
+  iEvent.put(token, std::move(out));
+}
+
+template <typename T1>
+void MuonExtenderWithMTDT<T1>::produce(edm::Event& ev, const edm::EventSetup& es) {
+
+  //this produces pieces of the track extra
+  Traj2TrackHits t2t;
+
+  theTransformer->setServices(es);
+  TrackingRecHitRefProd hitsRefProd = ev.getRefBeforePut<TrackingRecHitCollection>();
+  reco::TrackExtraRefProd extrasRefProd = ev.getRefBeforePut<reco::TrackExtraCollection>();
+
+  gtg_ = es.getHandle(gtgToken_);
+
+  auto geo = es.getTransientHandle(dlgeoToken_);
+
+  auto magfield = es.getTransientHandle(magfldToken_);
+
+  builder_ = es.getHandle(builderToken_);
+  hitbuilder_ = es.getHandle(hitbuilderToken_);
+
+  baseMTDExtender_->setParameters(&*hitbuilder_, &*gtg_);
+
+  auto propH = es.getTransientHandle(propToken_);
+  const Propagator* prop = propH.product();
+
+  auto httopo = es.getTransientHandle(ttopoToken_);
+  const TrackerTopology& ttopo = *httopo;
+
+  auto output = std::make_unique<TrackCollection>();
+  auto extras = std::make_unique<reco::TrackExtraCollection>();
+  auto outhits = std::make_unique<edm::OwnVector<TrackingRecHit>>();
+
+  std::vector<float> btlMatchChi2;
+  std::vector<float> etlMatchChi2;
+  std::vector<float> btlMatchTimeChi2;
+  std::vector<float> etlMatchTimeChi2;
+  std::vector<int> npixBarrel;
+  std::vector<int> npixEndcap;
+  std::vector<float> outermostHitPosition;
+  std::vector<float> pOrigTrkRaw;
+  std::vector<float> betaOrigTrkRaw;
+  std::vector<float> t0OrigTrkRaw;
+  std::vector<float> sigmat0OrigTrkRaw;
+  std::vector<float> pathLengthsOrigTrkRaw;
+  std::vector<float> tmtdOrigTrkRaw;
+  std::vector<float> sigmatmtdOrigTrkRaw;
+  std::vector<GlobalPoint> tmtdPosOrigTrkRaw;
+  std::vector<float> tofmuOrigTrkRaw;
+  std::vector<float> sigmatofmuOrigTrkRaw;
+  std::vector<int> assocOrigTrkRaw;
+
+  edm::Handle<T1> muons;
+  ev.getByToken(muonToken_, muons);
+
+  //MTD hits DetSet
+  const auto& hits = ev.get(hitsToken_);
+
+  //beam spot
+  const auto& bs = ev.get(bsToken_);
+
+  bool vtxConstraint(false);
+
+  VertexCollection vtxs;
+  if (useVertex_) {
+    vtxs = ev.get(vtxToken_);
+    if (!vtxs.empty()) {
+      vtxConstraint = true;
+    }
+  }
+
+  std::vector<unsigned> track_indices;
+  unsigned imu = 0;
+
+  for (const auto& itmuon: *muons){
+
+    if(!(itmuon.track().isNonnull())) continue; // Require a track to be extrapolated to the MTD
+
+    LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: extrapolating track " << imu
+                                     << " p/pT = " << itmuon.p() << " " << itmuon.pt() << " eta = " << itmuon.eta();
+    LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: sigma_p = "
+                                     << sqrt(itmuon.track()->covariance()(0, 0)) * itmuon.track()->p2()
+                                     << " sigma_p/p = " << sqrt(itmuon.track()->covariance()(0, 0)) * itmuon.track()->p() * 100 << " %";
+
+    float trackVtxTime = 0.f;
+    float trackVtxTimeError = 0.f;
+    if (vtxConstraint) {
+      for (const auto& vtx : vtxs) {
+        for (size_t itrk = 0; itrk < vtx.tracksSize(); itrk++) {
+          if (itmuon.track() == vtx.trackRefAt(itrk).castTo<TrackRef>()) {
+            trackVtxTime = vtx.t();
+            trackVtxTimeError = vtx.tError();
+            break;
+          }
+        }
+      }
+    }
+
+    reco::TransientTrack ttrack(itmuon.track(), magfield.product(), gtg_);
+    auto thits = theTransformer->getTransientRecHits(ttrack);
+    const auto trajVec = theTransformer->transform(ttrack, thits);
+    const Trajectory& trajs = trajVec.front();
+    
+    TransientTrackingRecHit::ConstRecHitContainer mtdthits;
+    MTDHitMatchingInfo mBTL, mETL;
+
+    TrajectoryStateOnSurface tsos = ttrack.outermostMeasurementState(); 
+    
+    if (!trajs.measurements().empty()) {
+	    // Loop over measurements and get the last one in the tracker
+	    auto ordering = baseMTDExtender_->checkRecHitsOrdering(thits);
+	    if (ordering == RefitDirection::insideOut) {
+	      for (auto it = trajs.measurements().rbegin(); it != trajs.measurements().rend(); ++it) {
+          const auto& hit = it->recHit();
+          if (!hit->isValid()) continue;	      
+          if (hit->geographicalId().det() == DetId::Tracker) {
+		        // Got last tracker hit
+		        tsos = it->updatedState(); // this is the outer TSOS in tracker
+	        }else{
+		        continue;	
+          }
+	      }
+	    }else{
+	      for (auto it = trajs.measurements().begin(); it != trajs.measurements().end(); ++it) {
+          const auto& hit = it->recHit();
+          if (!hit->isValid()) continue;		
+          if (hit->geographicalId().det() == DetId::Tracker) {
+            // Got last tracker hit
+            tsos = it->updatedState(); // this is the outer TSOS in tracker
+          }else{
+            continue;
+          }
+        }
+	    }
+	  }
+
+    TrajectoryStateClosestToBeamLine tscbl;
+    bool tscbl_status = getTrajectoryStateClosestToBeamLine(trajs, bs, prop, tscbl);
+
+    if (tscbl_status) {
+      float pmag2 = tscbl.trackStateAtPCA().momentum().mag2();
+      float pathlength0;
+      TrackSegments trs0;
+      muonPathLength(trajs, tscbl, prop, pathlength0, trs0);
+
+      const auto& btlhits = baseMTDExtender_->tryBTLLayers(tsos,
+                                                           trajs,
+                                                           pmag2,
+                                                           pathlength0,
+                                                           trs0,
+                                                           hits,
+                                                           geo.product(),
+                                                           magfield.product(),
+                                                           prop,
+                                                           bs,
+                                                           trackVtxTime,
+                                                           trackVtxTimeError,
+                                                           mBTL);
+      mtdthits.insert(mtdthits.end(), btlhits.begin(), btlhits.end());
+
+      // in the future this should include an intermediate refit before propagating to the ETL
+      // for now it is ok
+      const auto& etlhits = baseMTDExtender_->tryETLLayers(tsos,
+                                                           trajs,
+                                                           pmag2,
+                                                           pathlength0,
+                                                           trs0,
+                                                           hits,
+                                                           geo.product(),
+                                                           magfield.product(),
+                                                           prop,
+                                                           bs,
+                                                           trackVtxTime,
+                                                           trackVtxTimeError,
+                                                           mETL);
+      mtdthits.insert(mtdthits.end(), etlhits.begin(), etlhits.end());
+    }
+#ifdef EDM_ML_DEBUG
+    else {
+      LogTrace("MuonExtenderWithMTD") << "Failing getTrajectoryStateClosestToBeamLine, no search for hits in MTD!";
+    }
+#endif
+
+    // Logic to embed MTD Hits between TRK and Muon hits
+    auto ordering = baseMTDExtender_->checkRecHitsOrdering(thits);
+    TransientTrackingRecHit::ConstRecHitContainer innerthits;
+    TransientTrackingRecHit::ConstRecHitContainer outerthits;
+    if (ordering == RefitDirection::insideOut) {
+      for (auto const& hit : thits) {
+        if (hit->geographicalId().det() == DetId::Tracker){
+          innerthits.push_back(hit);
+        }else if (hit->geographicalId().det() == DetId::Muon){
+          outerthits.push_back(hit);
+        }else{
+          LogTrace("MuonExtenderWithMTD") << "Where is this hit coming from?";	  
+        }
+      }
+      thits = innerthits;
+      thits.insert(thits.end(), mtdthits.begin(), mtdthits.end());
+      thits.insert(thits.end(), outerthits.begin(), outerthits.end());
+    } else {
+      for (auto const& hit : thits) {
+        if (hit->geographicalId().det() == DetId::Tracker){
+          innerthits.push_back(hit);
+        }else if (hit->geographicalId().det() == DetId::Muon){
+          outerthits.push_back(hit);
+        }else{
+          LogTrace("MuonExtenderWithMTD") << "Where is this hit coming from?";
+        }
+	    }
+	    std::reverse(mtdthits.begin(), mtdthits.end());
+      outerthits.insert(outerthits.end(), mtdthits.begin(), mtdthits.end());
+      outerthits.insert(outerthits.end(), innerthits.begin(), innerthits.end());
+	    thits.swap(outerthits);
+    }
+
+    const auto& trajwithmtd = theTransformer->transform(ttrack, thits);
+    float pMap = 0.f, betaMap = 0.f, t0Map = 0.f, sigmat0Map = -1.f, pathLengthMap = -1.f, tmtdMap = 0.f, sigmatmtdMap = -1.f, tofmuMap = 0.f, sigmatofmuMap = -1.f;
+    GlobalPoint tmtdPosMap{0., 0., 0.};
+    int iMap = -1;
+    
+    for (const auto& trj : trajwithmtd) {
+      const auto& thetrj = (updateTraj_ ? trj : trajs);
+      float pathLength = 0.f, tmtd = 0.f, sigmatmtd = -1.f, tofmu = 0.f, sigmatofmu = -1.f;
+      GlobalPoint tmtdPos{0., 0., 0.};
+      LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: refit track " << imu << " p/pT = " << itmuon.track()->p()
+                                       << " " << itmuon.track()->pt() << " eta = " << itmuon.track()->eta();
+      
+      reco::Track result = baseMTDExtender_->buildTrack(itmuon.track()->algo(),
+                                                        thetrj,
+                                                        trj,
+                                                        bs,
+                                                        magfield.product(),
+                                                        prop,
+                                                        !mtdthits.empty(),
+                                                        pathLength,
+                                                        tmtd,
+                                                        sigmatmtd,
+                                                        tmtdPos,
+                                                        tofmu,
+                                                        sigmatofmu);
+      
+      if (result.ndof() >= 0) {
+        /// setup the track extras
+        reco::TrackExtra::TrajParams trajParams;
+        reco::TrackExtra::Chi2sFive chi2s;
+        size_t hitsstart = outhits->size();
+        //t2t(trj, *outhits, trajParams, chi2s);
+        if (updatePattern_) {
+          t2t(trj, *outhits, trajParams, chi2s);  // this fills the output hit collection
+        } else {
+          t2t(thetrj, *outhits, trajParams, chi2s);
+        }
+        size_t hitsend = outhits->size();
+        extras->push_back(baseMTDExtender_->buildTrackExtra(trj));  // always push back the fully built extra, update by setting in track
+        extras->back().setHits(hitsRefProd, hitsstart, hitsend - hitsstart);
+        extras->back().setTrajParams(trajParams, chi2s);
+        //create the track
+        output->push_back(result);
+        btlMatchChi2.push_back(mBTL.hit ? mBTL.estChi2 : -1.f);
+        etlMatchChi2.push_back(mETL.hit ? mETL.estChi2 : -1.f);
+        btlMatchTimeChi2.push_back(mBTL.hit ? mBTL.timeChi2 : -1.f);
+        etlMatchTimeChi2.push_back(mETL.hit ? mETL.timeChi2 : -1.f);
+        pathLengthMap = pathLength;
+        tmtdMap = tmtd;
+        sigmatmtdMap = sigmatmtd;
+        tmtdPosMap = tmtdPos;
+        auto& backtrack = output->back();
+        iMap = output->size() - 1;
+        pMap = backtrack.p();
+        betaMap = backtrack.beta();
+        t0Map = backtrack.t0();
+        sigmat0Map = std::copysign(std::sqrt(std::abs(backtrack.covt0t0())), backtrack.covt0t0());
+        tofmuMap = tofmu;
+        sigmatofmuMap = sigmatofmu;
+        reco::TrackExtraRef extraRef(extrasRefProd, extras->size() - 1);
+        backtrack.setExtra((updateExtra_ ? extraRef : itmuon.track()->extra()));
+        for (unsigned ihit = hitsstart; ihit < hitsend; ++ihit) {
+          backtrack.appendHitPattern((*outhits)[ihit], ttopo);
+        }
+#ifdef EDM_ML_DEBUG
+        LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: hit pattern of refitted track";
+        for (int i = 0; i < backtrack.hitPattern().numberOfAllHits(reco::HitPattern::TRACK_HITS); i++) {
+          backtrack.hitPattern().printHitPattern(reco::HitPattern::TRACK_HITS, i, std::cout);
+        }
+        LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: missing hit pattern of refitted track";
+        for (int i = 0; i < backtrack.hitPattern().numberOfAllHits(reco::HitPattern::MISSING_INNER_HITS); i++) {
+          backtrack.hitPattern().printHitPattern(reco::HitPattern::MISSING_INNER_HITS, i, std::cout);
+        }
+#endif
+        npixBarrel.push_back(backtrack.hitPattern().numberOfValidPixelBarrelHits());
+        npixEndcap.push_back(backtrack.hitPattern().numberOfValidPixelEndcapHits());
+
+        if (mBTL.hit || mETL.hit) {
+          outermostHitPosition.push_back(
+              mBTL.hit ? (float)(*itmuon.track()).outerRadius()
+                       : (float)(*itmuon.track()).outerZ());  // save R of the outermost hit for BTL, z for ETL.
+        } else {
+          outermostHitPosition.push_back(std::abs(itmuon.track()->eta()) < trackMaxBtlEta_ ? (float)(*itmuon.track()).outerRadius()
+                                                                                                 : (float)(*itmuon.track()).outerZ());
+        }
+
+        LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: tmtd " << tmtdMap << " +/- " << sigmatmtdMap
+                                        << " t0 " << t0Map << " +/- " << sigmat0Map << " tof mu " << tofmuMap
+                                        << "+/-" << std::format("{:0.2g}", sigmatofmuMap) << " ("
+                                        << std::format("{:0.2g}", sigmatofmuMap / tofmuMap * 100) << "%) ";
+
+      } else {
+        LogTrace("MuonExtenderWithMTD") << "Error in the MTD track refitting. This should not happen";
+      }
+    }
+
+    pOrigTrkRaw.push_back(pMap);
+    betaOrigTrkRaw.push_back(betaMap);
+    t0OrigTrkRaw.push_back(t0Map);
+    sigmat0OrigTrkRaw.push_back(sigmat0Map);
+    pathLengthsOrigTrkRaw.push_back(pathLengthMap);
+    tmtdOrigTrkRaw.push_back(tmtdMap);
+    sigmatmtdOrigTrkRaw.push_back(sigmatmtdMap);
+    tmtdPosOrigTrkRaw.push_back(tmtdPosMap);
+    tofmuOrigTrkRaw.push_back(tofmuMap);
+    sigmatofmuOrigTrkRaw.push_back(sigmatofmuMap);
+    assocOrigTrkRaw.push_back(iMap);
+
+    if (iMap == -1) {
+      btlMatchChi2.push_back(-1.f);
+      etlMatchChi2.push_back(-1.f);
+      btlMatchTimeChi2.push_back(-1.f);
+      etlMatchTimeChi2.push_back(-1.f);
+      npixBarrel.push_back(-1.f);
+      npixEndcap.push_back(-1.f);
+      outermostHitPosition.push_back(0.);
+    }
+
+    ++imu;
+  }
+  
+  ev.put(std::move(output));
+  ev.put(std::move(extras));
+  ev.put(std::move(outhits));
+
+  fillValueMap(ev, muons, btlMatchChi2, btlMatchChi2Token_);
+  fillValueMap(ev, muons, etlMatchChi2, etlMatchChi2Token_);
+  fillValueMap(ev, muons, btlMatchTimeChi2, btlMatchTimeChi2Token_);
+  fillValueMap(ev, muons, etlMatchTimeChi2, etlMatchTimeChi2Token_);
+  fillValueMap(ev, muons, npixBarrel, npixBarrelToken_);
+  fillValueMap(ev, muons, npixEndcap, npixEndcapToken_);
+  fillValueMap(ev, muons, outermostHitPosition, outermostHitPositionToken_);
+  fillValueMap(ev, muons, pOrigTrkRaw, pOrigTrkToken_);
+  fillValueMap(ev, muons, betaOrigTrkRaw, betaOrigTrkToken_);
+  fillValueMap(ev, muons, t0OrigTrkRaw, t0OrigTrkToken_);
+  fillValueMap(ev, muons, sigmat0OrigTrkRaw, sigmat0OrigTrkToken_);
+  fillValueMap(ev, muons, pathLengthsOrigTrkRaw, pathLengthOrigTrkToken_);
+  fillValueMap(ev, muons, tmtdOrigTrkRaw, tmtdOrigTrkToken_);
+  fillValueMap(ev, muons, sigmatmtdOrigTrkRaw, sigmatmtdOrigTrkToken_);
+  fillValueMap(ev, muons, tmtdPosOrigTrkRaw, tmtdPosOrigTrkToken_);
+  fillValueMap(ev, muons, tofmuOrigTrkRaw, tofmuOrigTrkToken_);
+  fillValueMap(ev, muons, sigmatofmuOrigTrkRaw, sigmatofmuOrigTrkToken_);
+  fillValueMap(ev, muons, assocOrigTrkRaw, assocOrigTrkToken_);
+}
+
+// Define this as a plugin
+#include <FWCore/Framework/interface/MakerMacros.h>
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
+
+typedef MuonExtenderWithMTDT<reco::MuonCollection> MuonExtenderWithMTD;
+typedef MuonExtenderWithMTDT<reco::RecoChargedCandidateCollection> MuonChgCandExtenderWithMTD;
+
+DEFINE_FWK_MODULE(MuonExtenderWithMTD);
+DEFINE_FWK_MODULE(MuonChgCandExtenderWithMTD);

--- a/RecoMTD/TrackExtender/plugins/MuonExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/MuonExtenderWithMTD.cc
@@ -637,6 +637,44 @@ MuonExtenderWithMTDT<T1>::MuonExtenderWithMTDT(const ParameterSet& iConfig)
   produces<TrackCollection>();
 }
 
+template <class T1>
+void MuonExtenderWithMTDT<T1>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc, transDesc;
+  desc.setAllowAnything();
+  desc.add<edm::InputTag>("muonSrc", edm::InputTag("slimmedMuons"));
+  desc.add<edm::InputTag>("hitsSrc", edm::InputTag("mtdTrackingRecHits"));
+  desc.add<edm::InputTag>("beamSpotSrc", edm::InputTag("offlineBeamSpot"));
+  desc.add<edm::InputTag>("vtxSrc", edm::InputTag("offlinePrimaryVertices4D"));
+  desc.add<bool>("updateTrackTrajectory", true);
+  desc.add<bool>("updateTrackExtra", true);
+  desc.add<bool>("updateTrackHitPattern", true);
+  desc.add<std::string>("TransientTrackBuilder", "TransientTrackBuilder");
+  desc.add<std::string>("MTDRecHitBuilder", "MTDRecHitBuilder");
+  desc.add<std::string>("Propagator", "PropagatorWithMaterialForMTD");
+  TrackTransformer::fillPSetDescription(transDesc,
+                                        false,
+                                        "KFFitterForRefitInsideOut",
+                                        "KFSmootherForRefitInsideOut",
+                                        "PropagatorWithMaterialForMTD",
+                                        "alongMomentum",
+                                        true,
+                                        "WithTrackAngle",
+                                        "MuonRecHitBuilder",
+                                        "MTDRecHitBuilder");
+  desc.add<edm::ParameterSetDescription>("TrackTransformer", transDesc);
+  desc.add<double>("estimatorMaxChi2", 500.);
+  desc.add<double>("estimatorMaxNSigma", 10.);
+  desc.add<double>("btlChi2Cut", 50.);
+  desc.add<double>("btlTimeChi2Cut", 10.);
+  desc.add<double>("etlChi2Cut", 50.);
+  desc.add<double>("etlTimeChi2Cut", 10.);
+  desc.add<bool>("useVertex", false);
+  desc.add<double>("dZCut", 0.1);
+  desc.add<double>("bsTimeSpread", 0.2);
+  //descriptions.add("trackExtenderWithMTDBase", desc);
+  descriptions.addDefault(desc);
+}
+
 template <typename T1>
 template <class H, class T>
 void MuonExtenderWithMTDT<T1>::fillValueMap(edm::Event& iEvent,

--- a/RecoMTD/TrackExtender/plugins/MuonExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/MuonExtenderWithMTD.cc
@@ -61,20 +61,19 @@ using namespace edm;
 using namespace reco;
 using namespace mtdtof;
 
-namespace mtdtof{
+namespace mtdtof {
 
   // Asummes 100% muon identification
   const MuonTofPidInfo computeMuonTofPidInfo(float magp2,
-                                              float length,
-                                              TrackSegments trs,
-                                              float t_mtd,
-                                              float t_mtderr,
-                                              float t_vtx,
-                                              float t_vtx_err,
-                                              bool addPIDError,
-                                              TofCalc choice,
-                                              SigmaTofCalc sigma_choice){
-
+                                             float length,
+                                             TrackSegments trs,
+                                             float t_mtd,
+                                             float t_mtderr,
+                                             float t_vtx,
+                                             float t_vtx_err,
+                                             bool addPIDError,
+                                             TofCalc choice,
+                                             SigmaTofCalc sigma_choice) {
     constexpr float m_mu = 0.10565837f;
     constexpr float m_mu_inv2 = 1.0f / m_mu / m_mu;
 
@@ -128,7 +127,8 @@ namespace mtdtof{
 
     tofpid.dt = tofpid.tmtd - tofpid.dt_mu - t_vtx;
     tofpid.betaerror = 0.f;
-    tofpid.dterror2 = tofpid.tmtderror * tofpid.tmtderror + t_vtx_err * t_vtx_err + tofpid.sigma_dt_mu * tofpid.sigma_dt_mu;
+    tofpid.dterror2 =
+        tofpid.tmtderror * tofpid.tmtderror + t_vtx_err * t_vtx_err + tofpid.sigma_dt_mu * tofpid.sigma_dt_mu;
     tofpid.dterror = sqrt(tofpid.dterror2);
 
     tofpid.dtchi2 = (tofpid.dt * tofpid.dt) / tofpid.dterror2;
@@ -138,14 +138,13 @@ namespace mtdtof{
     tofpid.dtchi2_best = tofpid.dtchi2;
 
     return tofpid;
-
   };
 
   bool muonPathLength(const Trajectory& traj,
-                       const TrajectoryStateClosestToBeamLine& tscbl,
-                       const Propagator* thePropagator,
-                       float& pathlength,
-                       TrackSegments& trs) {
+                      const TrajectoryStateClosestToBeamLine& tscbl,
+                      const Propagator* thePropagator,
+                      float& pathlength,
+                      TrackSegments& trs) {
     pathlength = 0.f;
 
     bool validpropagation = true;
@@ -155,10 +154,10 @@ namespace mtdtof{
 
     //add pathlength layer by layer
     for (auto it = traj.measurements().begin(); it != traj.measurements().end() - 1; ++it) {
-    	if (it->recHit()->isValid())
-	      if (it->recHit()->geographicalId().det() == DetId::Muon)
-	        continue;
-      
+      if (it->recHit()->isValid())
+        if (it->recHit()->geographicalId().det() == DetId::Muon)
+          continue;
+
       const auto& propresult = thePropagator->propagateWithPath(it->updatedState(), (it + 1)->updatedState().surface());
       float layerpathlength = std::abs(propresult.second);
       if (layerpathlength == 0.f) {
@@ -173,14 +172,14 @@ namespace mtdtof{
       trs.addSegment(layerpathlength, (it + 1)->updatedState().globalMomentum().mag2(), sigma_p);
 
       LogTrace("MuonExtenderWithMTD") << "TSOS " << std::fixed << std::setw(4) << trs.size() << " R_i " << std::fixed
-                                       << std::setw(14) << it->updatedState().globalPosition().perp() << " z_i "
-                                       << std::fixed << std::setw(14) << it->updatedState().globalPosition().z()
-                                       << " R_e " << std::fixed << std::setw(14)
-                                       << (it + 1)->updatedState().globalPosition().perp() << " z_e " << std::fixed
-                                       << std::setw(14) << (it + 1)->updatedState().globalPosition().z() << " p "
-                                       << std::fixed << std::setw(14) << (it + 1)->updatedState().globalMomentum().mag()
-                                       << " dp " << std::fixed << std::setw(14)
-                                       << (it + 1)->updatedState().globalMomentum().mag() - oldp;
+                                      << std::setw(14) << it->updatedState().globalPosition().perp() << " z_i "
+                                      << std::fixed << std::setw(14) << it->updatedState().globalPosition().z()
+                                      << " R_e " << std::fixed << std::setw(14)
+                                      << (it + 1)->updatedState().globalPosition().perp() << " z_e " << std::fixed
+                                      << std::setw(14) << (it + 1)->updatedState().globalPosition().z() << " p "
+                                      << std::fixed << std::setw(14) << (it + 1)->updatedState().globalMomentum().mag()
+                                      << " dp " << std::fixed << std::setw(14)
+                                      << (it + 1)->updatedState().globalMomentum().mag() - oldp;
       oldp = (it + 1)->updatedState().globalMomentum().mag();
     }
 
@@ -199,12 +198,12 @@ namespace mtdtof{
     trs.addSegment(pathlength2, tscblPCA.momentum().mag2(), sigma_p);
 
     LogTrace("MuonExtenderWithMTD") << "TSOS " << std::fixed << std::setw(4) << trs.size() << " R_e " << std::fixed
-                                     << std::setw(14) << tscblPCA.position().perp() << " z_e " << std::fixed
-                                     << std::setw(14) << tscblPCA.position().z() << " p " << std::fixed << std::setw(14)
-                                     << tscblPCA.momentum().mag() << " dp " << std::fixed << std::setw(14)
-                                     << tscblPCA.momentum().mag() - oldp << " sigma_p = " << std::fixed << std::setw(14)
-                                     << sigma_p << " sigma_p/p = " << std::fixed << std::setw(14)
-                                     << sigma_p / tscblPCA.momentum().mag() * 100 << " %";
+                                    << std::setw(14) << tscblPCA.position().perp() << " z_e " << std::fixed
+                                    << std::setw(14) << tscblPCA.position().z() << " p " << std::fixed << std::setw(14)
+                                    << tscblPCA.momentum().mag() << " dp " << std::fixed << std::setw(14)
+                                    << tscblPCA.momentum().mag() - oldp << " sigma_p = " << std::fixed << std::setw(14)
+                                    << sigma_p << " sigma_p/p = " << std::fixed << std::setw(14)
+                                    << sigma_p / tscblPCA.momentum().mag() * 100 << " %";
 
     return validpropagation;
   };
@@ -239,7 +238,6 @@ namespace mtdtof{
                               const Propagator* prop,
                               const MeasurementEstimator* estimator,
                               std::set<MTDHitMatchingInfo>& out) {
-
     pair<bool, TrajectoryStateOnSurface> comp = layer->compatible(tsos, *prop, *estimator);
     if (comp.first) {
       const vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos, *prop, *estimator);
@@ -288,15 +286,15 @@ namespace mtdtof{
                   << std::setw(14) << est.second;
 
               MuonTofPidInfo tof = computeMuonTofPidInfo(lastpmag2,
-                                                          std::abs(pl.second),
-                                                          trs0,
-                                                          hit.time(),
-                                                          hit.timeError(),
-                                                          t_vtx,
-                                                          t_vtx_err,  //put vtx error by hand for the moment
-                                                          false,
-                                                          TofCalc::kMixd,
-                                                          SigmaTofCalc::kMixd);
+                                                         std::abs(pl.second),
+                                                         trs0,
+                                                         hit.time(),
+                                                         hit.timeError(),
+                                                         t_vtx,
+                                                         t_vtx_err,  //put vtx error by hand for the moment
+                                                         false,
+                                                         TofCalc::kMixd,
+                                                         SigmaTofCalc::kMixd);
               MTDHitMatchingInfo mi;
               mi.hit = &hit;
               mi.estChi2 = est.second;
@@ -309,7 +307,7 @@ namespace mtdtof{
       }
     }
   };
-} // namespace
+}  // namespace mtdtof
 
 // MuonBaseExtenderWithMTD ---------
 
@@ -329,7 +327,6 @@ void MuonBaseExtenderWithMTD::fillMatchingHits(const DetLayer* ilay,
                                                const float& vtxTimeError,
                                                TransientTrackingRecHit::ConstRecHitContainer& output,
                                                MTDHitMatchingInfo& bestHit) const {
-
   std::set<MTDHitMatchingInfo> hitsInLayer;
   bool hitMatched = false;
 
@@ -366,7 +363,7 @@ void MuonBaseExtenderWithMTD::fillMatchingHits(const DetLayer* ilay,
     //check hits to pass minimum quality matching requirements
     auto const& firstHit = *hitsInLayer.begin();
     LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: matching trial 1: estChi2= " << firstHit.estChi2
-                                     << " timeChi2= " << firstHit.timeChi2;
+                                    << " timeChi2= " << firstHit.timeChi2;
     if (firstHit.estChi2 < spaceChi2Cut && firstHit.timeChi2 < timeChi2Cut) {
       hitMatched = true;
       output.push_back(getHitBuilder()->build(firstHit.hit));
@@ -374,7 +371,7 @@ void MuonBaseExtenderWithMTD::fillMatchingHits(const DetLayer* ilay,
         bestHit = firstHit;
     }
   }
-    
+
   if (useVertex_ && matchVertex && !hitMatched) {
     //try a second search with beamspot hypothesis
     hitsInLayer.clear();
@@ -382,7 +379,7 @@ void MuonBaseExtenderWithMTD::fillMatchingHits(const DetLayer* ilay,
     if (!hitsInLayer.empty()) {
       auto const& firstHit = *hitsInLayer.begin();
       LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: matching trial 2: estChi2= " << firstHit.estChi2
-                                       << " timeChi2= " << firstHit.timeChi2;
+                                      << " timeChi2= " << firstHit.timeChi2;
       if (firstHit.timeChi2 < timeChi2Cut) {
         if (firstHit.estChi2 < spaceChi2Cut) {
           hitMatched = true;
@@ -395,12 +392,12 @@ void MuonBaseExtenderWithMTD::fillMatchingHits(const DetLayer* ilay,
   }
 #ifdef EDM_ML_DEBUG
   if (hitMatched) {
-    LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: matched hit with time: " << bestHit.hit->time()
-                                     << " +/- " << bestHit.hit->timeError();
+    LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: matched hit with time: " << bestHit.hit->time() << " +/- "
+                                    << bestHit.hit->timeError();
   } else {
     LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: no matched hit";
   }
-#endif                                                  
+#endif
 }
 
 reco::Track MuonBaseExtenderWithMTD::buildTrack(const reco::TrackBase::TrackAlgorithm origAlgo,
@@ -416,7 +413,6 @@ reco::Track MuonBaseExtenderWithMTD::buildTrack(const reco::TrackBase::TrackAlgo
                                                 GlobalPoint& tmtdPosOut,
                                                 float& tofmu,
                                                 float& sigmatofmu) const {
-  
   TrajectoryStateClosestToBeamLine tscbl;
   bool tsbcl_status = getTrajectoryStateClosestToBeamLine(traj, bs, thePropagator, tscbl);
 
@@ -478,17 +474,17 @@ reco::Track MuonBaseExtenderWithMTD::buildTrack(const reco::TrackBase::TrackAlgo
       }
     }
 
-    LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: selected #hits " << ihitcount << " from ETL "
-                                    << ietlcount;
+    LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: selected #hits " << ihitcount << " from ETL " << ietlcount;
 
     // The last measurement is not always the MTD Hit for muons
-    auto ihit1 = trajWithMtd.measurements().cbegin(); 
+    auto ihit1 = trajWithMtd.measurements().cbegin();
     for (auto it = trajWithMtd.measurements().cbegin(); it != trajWithMtd.measurements().cend(); ++it) {
-	    const auto& hit = it->recHit();
-	    if (hit->geographicalId().det() == DetId::Forward && ForwardSubdetector(hit->geographicalId().subdetId()) == FastTime){
-	      ihit1 = it;
-	      break;
-	    }
+      const auto& hit = it->recHit();
+      if (hit->geographicalId().det() == DetId::Forward &&
+          ForwardSubdetector(hit->geographicalId().subdetId()) == FastTime) {
+        ihit1 = it;
+        break;
+      }
     }
     if (ihitcount == 1) {
       const MTDTrackingRecHit* mtdhit = static_cast<const MTDTrackingRecHit*>((*ihit1).recHit()->hit());
@@ -509,9 +505,17 @@ reco::Track MuonBaseExtenderWithMTD::buildTrack(const reco::TrackBase::TrackAlgo
         trs.removeFirstSegment();
         const MTDTrackingRecHit* mtdhit1 = static_cast<const MTDTrackingRecHit*>((*ihit1).recHit()->hit());
         const MTDTrackingRecHit* mtdhit2 = static_cast<const MTDTrackingRecHit*>((*(ihit1 + 1)).recHit()->hit());
-	
-        MuonTofPidInfo tofInfo = computeMuonTofPidInfo(
-							 lastStep.second, etlpathlength, trs, mtdhit1->time(), mtdhit1->timeError(), 0.f, 0.f, true, TofCalc::kCost, SigmaTofCalc::kCost);
+
+        MuonTofPidInfo tofInfo = computeMuonTofPidInfo(lastStep.second,
+                                                       etlpathlength,
+                                                       trs,
+                                                       mtdhit1->time(),
+                                                       mtdhit1->timeError(),
+                                                       0.f,
+                                                       0.f,
+                                                       true,
+                                                       TofCalc::kCost,
+                                                       SigmaTofCalc::kCost);
         //
         // Protect against incompatible times
         //
@@ -520,7 +524,7 @@ reco::Track MuonBaseExtenderWithMTD::buildTrack(const reco::TrackBase::TrackAlgo
         if (cms_rounding::roundIfNear0(err1) == 0.f || cms_rounding::roundIfNear0(err2) == 0.f) {
           edm::LogError("MuonExtenderWithMTD")
               << "MTD tracking hits with zero time uncertainty: " << err1 << " " << err2;
-      	}else {
+        } else {
           if ((tofInfo.dt - mtdhit2->time()) * (tofInfo.dt - mtdhit2->time()) < (err1 + err2) * etlTimeChi2Cut_) {
             //
             // Subtract the ETL time of flight from the outermost measurement, and combine it in a weighted average with the innermost
@@ -556,14 +560,14 @@ reco::Track MuonBaseExtenderWithMTD::buildTrack(const reco::TrackBase::TrackAlgo
       }
     } else {
       edm::LogInfo("MuonExtenderWithMTD")
-          << "MTD hits #" << ihitcount << "ETL hits #" << ietlcount << " anomalous pattern, skipping..."; 
+          << "MTD hits #" << ihitcount << "ETL hits #" << ietlcount << " anomalous pattern, skipping...";
     }
 
     if (validmtd && validpropagation) {
       //here add the PID uncertainty for later use in the 1st step of 4D vtx reconstruction
 
       MuonTofPidInfo tofInfo = computeMuonTofPidInfo(
-						       p.mag2(), pathlength, trs, thit, thiterror, 0.f, 0.f, true, TofCalc::kSegm, SigmaTofCalc::kCost);
+          p.mag2(), pathlength, trs, thit, thiterror, 0.f, 0.f, true, TofCalc::kSegm, SigmaTofCalc::kCost);
 
       pathLengthOut = pathlength;  // set path length if we've got a timing hit
       tmtdOut = thit;
@@ -576,7 +580,7 @@ reco::Track MuonBaseExtenderWithMTD::buildTrack(const reco::TrackBase::TrackAlgo
       tofmu = tofInfo.dt_mu;
       sigmatofmu = tofInfo.sigma_dt_mu;
     }
-  }  
+  }
   return routput();
 }
 
@@ -591,8 +595,7 @@ MuonExtenderWithMTDT<T1>::MuonExtenderWithMTDT(const ParameterSet& iConfig)
       mtdRecHitBuilder_(iConfig.getParameter<std::string>("MTDRecHitBuilder")),
       propagator_(iConfig.getParameter<std::string>("Propagator")),
       transientTrackBuilder_(iConfig.getParameter<std::string>("TransientTrackBuilder")),
-      useVertex_(iConfig.getParameter<bool>("useVertex")){
-  
+      useVertex_(iConfig.getParameter<bool>("useVertex")) {
   baseMTDExtender_ = std::make_unique<MuonBaseExtenderWithMTD>(iConfig);
 
   if (useVertex_) {
@@ -637,9 +640,9 @@ MuonExtenderWithMTDT<T1>::MuonExtenderWithMTDT(const ParameterSet& iConfig)
 template <typename T1>
 template <class H, class T>
 void MuonExtenderWithMTDT<T1>::fillValueMap(edm::Event& iEvent,
-                                                      const H& handle,
-                                                      const std::vector<T>& vec,
-                                                      const edm::EDPutToken& token) const {
+                                            const H& handle,
+                                            const std::vector<T>& vec,
+                                            const edm::EDPutToken& token) const {
   auto out = std::make_unique<edm::ValueMap<T>>();
   typename edm::ValueMap<T>::Filler filler(*out);
   filler.insert(handle, vec.begin(), vec.end());
@@ -649,7 +652,6 @@ void MuonExtenderWithMTDT<T1>::fillValueMap(edm::Event& iEvent,
 
 template <typename T1>
 void MuonExtenderWithMTDT<T1>::produce(edm::Event& ev, const edm::EventSetup& es) {
-
   //this produces pieces of the track extra
   Traj2TrackHits t2t;
 
@@ -719,15 +721,16 @@ void MuonExtenderWithMTDT<T1>::produce(edm::Event& ev, const edm::EventSetup& es
   std::vector<unsigned> track_indices;
   unsigned imu = 0;
 
-  for (const auto& itmuon: *muons){
+  for (const auto& itmuon : *muons) {
+    if (!(itmuon.track().isNonnull()))
+      continue;  // Require a track to be extrapolated to the MTD
 
-    if(!(itmuon.track().isNonnull())) continue; // Require a track to be extrapolated to the MTD
-
-    LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: extrapolating track " << imu
-                                     << " p/pT = " << itmuon.p() << " " << itmuon.pt() << " eta = " << itmuon.eta();
+    LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: extrapolating track " << imu << " p/pT = " << itmuon.p()
+                                    << " " << itmuon.pt() << " eta = " << itmuon.eta();
     LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: sigma_p = "
-                                     << sqrt(itmuon.track()->covariance()(0, 0)) * itmuon.track()->p2()
-                                     << " sigma_p/p = " << sqrt(itmuon.track()->covariance()(0, 0)) * itmuon.track()->p() * 100 << " %";
+                                    << sqrt(itmuon.track()->covariance()(0, 0)) * itmuon.track()->p2()
+                                    << " sigma_p/p = "
+                                    << sqrt(itmuon.track()->covariance()(0, 0)) * itmuon.track()->p() * 100 << " %";
 
     float trackVtxTime = 0.f;
     float trackVtxTimeError = 0.f;
@@ -747,39 +750,41 @@ void MuonExtenderWithMTDT<T1>::produce(edm::Event& ev, const edm::EventSetup& es
     auto thits = theTransformer->getTransientRecHits(ttrack);
     const auto trajVec = theTransformer->transform(ttrack, thits);
     const Trajectory& trajs = trajVec.front();
-    
+
     TransientTrackingRecHit::ConstRecHitContainer mtdthits;
     MTDHitMatchingInfo mBTL, mETL;
 
-    TrajectoryStateOnSurface tsos = ttrack.outermostMeasurementState(); 
-    
+    TrajectoryStateOnSurface tsos = ttrack.outermostMeasurementState();
+
     if (!trajs.measurements().empty()) {
-	    // Loop over measurements and get the last one in the tracker
-	    auto ordering = baseMTDExtender_->checkRecHitsOrdering(thits);
-	    if (ordering == RefitDirection::insideOut) {
-	      for (auto it = trajs.measurements().rbegin(); it != trajs.measurements().rend(); ++it) {
+      // Loop over measurements and get the last one in the tracker
+      auto ordering = baseMTDExtender_->checkRecHitsOrdering(thits);
+      if (ordering == RefitDirection::insideOut) {
+        for (auto it = trajs.measurements().rbegin(); it != trajs.measurements().rend(); ++it) {
           const auto& hit = it->recHit();
-          if (!hit->isValid()) continue;	      
-          if (hit->geographicalId().det() == DetId::Tracker) {
-		        // Got last tracker hit
-		        tsos = it->updatedState(); // this is the outer TSOS in tracker
-	        }else{
-		        continue;	
-          }
-	      }
-	    }else{
-	      for (auto it = trajs.measurements().begin(); it != trajs.measurements().end(); ++it) {
-          const auto& hit = it->recHit();
-          if (!hit->isValid()) continue;		
+          if (!hit->isValid())
+            continue;
           if (hit->geographicalId().det() == DetId::Tracker) {
             // Got last tracker hit
-            tsos = it->updatedState(); // this is the outer TSOS in tracker
-          }else{
+            tsos = it->updatedState();  // this is the outer TSOS in tracker
+          } else {
             continue;
           }
         }
-	    }
-	  }
+      } else {
+        for (auto it = trajs.measurements().begin(); it != trajs.measurements().end(); ++it) {
+          const auto& hit = it->recHit();
+          if (!hit->isValid())
+            continue;
+          if (hit->geographicalId().det() == DetId::Tracker) {
+            // Got last tracker hit
+            tsos = it->updatedState();  // this is the outer TSOS in tracker
+          } else {
+            continue;
+          }
+        }
+      }
+    }
 
     TrajectoryStateClosestToBeamLine tscbl;
     bool tscbl_status = getTrajectoryStateClosestToBeamLine(trajs, bs, prop, tscbl);
@@ -834,12 +839,12 @@ void MuonExtenderWithMTDT<T1>::produce(edm::Event& ev, const edm::EventSetup& es
     TransientTrackingRecHit::ConstRecHitContainer outerthits;
     if (ordering == RefitDirection::insideOut) {
       for (auto const& hit : thits) {
-        if (hit->geographicalId().det() == DetId::Tracker){
+        if (hit->geographicalId().det() == DetId::Tracker) {
           innerthits.push_back(hit);
-        }else if (hit->geographicalId().det() == DetId::Muon){
+        } else if (hit->geographicalId().det() == DetId::Muon) {
           outerthits.push_back(hit);
-        }else{
-          LogTrace("MuonExtenderWithMTD") << "Where is this hit coming from?";	  
+        } else {
+          LogTrace("MuonExtenderWithMTD") << "Where is this hit coming from?";
         }
       }
       thits = innerthits;
@@ -847,32 +852,33 @@ void MuonExtenderWithMTDT<T1>::produce(edm::Event& ev, const edm::EventSetup& es
       thits.insert(thits.end(), outerthits.begin(), outerthits.end());
     } else {
       for (auto const& hit : thits) {
-        if (hit->geographicalId().det() == DetId::Tracker){
+        if (hit->geographicalId().det() == DetId::Tracker) {
           innerthits.push_back(hit);
-        }else if (hit->geographicalId().det() == DetId::Muon){
+        } else if (hit->geographicalId().det() == DetId::Muon) {
           outerthits.push_back(hit);
-        }else{
+        } else {
           LogTrace("MuonExtenderWithMTD") << "Where is this hit coming from?";
         }
-	    }
-	    std::reverse(mtdthits.begin(), mtdthits.end());
+      }
+      std::reverse(mtdthits.begin(), mtdthits.end());
       outerthits.insert(outerthits.end(), mtdthits.begin(), mtdthits.end());
       outerthits.insert(outerthits.end(), innerthits.begin(), innerthits.end());
-	    thits.swap(outerthits);
+      thits.swap(outerthits);
     }
 
     const auto& trajwithmtd = theTransformer->transform(ttrack, thits);
-    float pMap = 0.f, betaMap = 0.f, t0Map = 0.f, sigmat0Map = -1.f, pathLengthMap = -1.f, tmtdMap = 0.f, sigmatmtdMap = -1.f, tofmuMap = 0.f, sigmatofmuMap = -1.f;
+    float pMap = 0.f, betaMap = 0.f, t0Map = 0.f, sigmat0Map = -1.f, pathLengthMap = -1.f, tmtdMap = 0.f,
+          sigmatmtdMap = -1.f, tofmuMap = 0.f, sigmatofmuMap = -1.f;
     GlobalPoint tmtdPosMap{0., 0., 0.};
     int iMap = -1;
-    
+
     for (const auto& trj : trajwithmtd) {
       const auto& thetrj = (updateTraj_ ? trj : trajs);
       float pathLength = 0.f, tmtd = 0.f, sigmatmtd = -1.f, tofmu = 0.f, sigmatofmu = -1.f;
       GlobalPoint tmtdPos{0., 0., 0.};
       LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: refit track " << imu << " p/pT = " << itmuon.track()->p()
-                                       << " " << itmuon.track()->pt() << " eta = " << itmuon.track()->eta();
-      
+                                      << " " << itmuon.track()->pt() << " eta = " << itmuon.track()->eta();
+
       reco::Track result = baseMTDExtender_->buildTrack(itmuon.track()->algo(),
                                                         thetrj,
                                                         trj,
@@ -886,7 +892,7 @@ void MuonExtenderWithMTDT<T1>::produce(edm::Event& ev, const edm::EventSetup& es
                                                         tmtdPos,
                                                         tofmu,
                                                         sigmatofmu);
-      
+
       if (result.ndof() >= 0) {
         /// setup the track extras
         reco::TrackExtra::TrajParams trajParams;
@@ -899,7 +905,8 @@ void MuonExtenderWithMTDT<T1>::produce(edm::Event& ev, const edm::EventSetup& es
           t2t(thetrj, *outhits, trajParams, chi2s);
         }
         size_t hitsend = outhits->size();
-        extras->push_back(baseMTDExtender_->buildTrackExtra(trj));  // always push back the fully built extra, update by setting in track
+        extras->push_back(baseMTDExtender_->buildTrackExtra(
+            trj));  // always push back the fully built extra, update by setting in track
         extras->back().setHits(hitsRefProd, hitsstart, hitsend - hitsstart);
         extras->back().setTrajParams(trajParams, chi2s);
         //create the track
@@ -943,13 +950,14 @@ void MuonExtenderWithMTDT<T1>::produce(edm::Event& ev, const edm::EventSetup& es
               mBTL.hit ? (float)(*itmuon.track()).outerRadius()
                        : (float)(*itmuon.track()).outerZ());  // save R of the outermost hit for BTL, z for ETL.
         } else {
-          outermostHitPosition.push_back(std::abs(itmuon.track()->eta()) < trackMaxBtlEta_ ? (float)(*itmuon.track()).outerRadius()
-                                                                                                 : (float)(*itmuon.track()).outerZ());
+          outermostHitPosition.push_back(std::abs(itmuon.track()->eta()) < trackMaxBtlEta_
+                                             ? (float)(*itmuon.track()).outerRadius()
+                                             : (float)(*itmuon.track()).outerZ());
         }
 
-        LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: tmtd " << tmtdMap << " +/- " << sigmatmtdMap
-                                        << " t0 " << t0Map << " +/- " << sigmat0Map << " tof mu " << tofmuMap
-                                        << "+/-" << std::format("{:0.2g}", sigmatofmuMap) << " ("
+        LogTrace("MuonExtenderWithMTD") << "MuonExtenderWithMTD: tmtd " << tmtdMap << " +/- " << sigmatmtdMap << " t0 "
+                                        << t0Map << " +/- " << sigmat0Map << " tof mu " << tofmuMap << "+/-"
+                                        << std::format("{:0.2g}", sigmatofmuMap) << " ("
                                         << std::format("{:0.2g}", sigmatofmuMap / tofmuMap * 100) << "%) ";
 
       } else {
@@ -981,7 +989,7 @@ void MuonExtenderWithMTDT<T1>::produce(edm::Event& ev, const edm::EventSetup& es
 
     ++imu;
   }
-  
+
   ev.put(std::move(output));
   ev.put(std::move(extras));
   ev.put(std::move(outhits));

--- a/RecoMTD/TrackExtender/plugins/MuonExtenderWithMTD.h
+++ b/RecoMTD/TrackExtender/plugins/MuonExtenderWithMTD.h
@@ -28,7 +28,7 @@ using namespace edm;
 using namespace reco;
 using namespace mtdtof;
 
-namespace mtdtof{
+namespace mtdtof {
 
   struct MuonTofPidInfo {
     float tmtd;
@@ -49,7 +49,7 @@ namespace mtdtof{
     float gammasq_mu;
     float beta_mu;
     float dt_mu;
-    float sigma_dt_mu;  
+    float sigma_dt_mu;
   };
 
   const MuonTofPidInfo computeMuonTofPidInfo(float magp2,
@@ -73,7 +73,7 @@ namespace mtdtof{
                       const reco::BeamSpot& bs,
                       const Propagator* thePropagator,
                       float& pathlength,
-                      TrackSegments& trs);    
+                      TrackSegments& trs);
 
   void find_hits_in_dets_muon(const MTDTrackingDetSetVector& hits,
                               const Trajectory& traj,
@@ -90,98 +90,98 @@ namespace mtdtof{
                               const Propagator* prop,
                               const MeasurementEstimator* estimator,
                               std::set<MTDHitMatchingInfo>& out);
-}
+}  // namespace mtdtof
 
 class MuonBaseExtenderWithMTD : public BaseExtenderWithMTD {
-  public:
-    explicit MuonBaseExtenderWithMTD(const ParameterSet& iConfig);
-    ~MuonBaseExtenderWithMTD() override;
+public:
+  explicit MuonBaseExtenderWithMTD(const ParameterSet& iConfig);
+  ~MuonBaseExtenderWithMTD() override;
 
-    void fillMatchingHits(const DetLayer*,
-                          const TrajectoryStateOnSurface&,
-                          const Trajectory&,
-                          const float,
-                          const float,
-                          const TrackSegments&,
-                          const MTDTrackingDetSetVector&,
-                          const Propagator*,
-                          const reco::BeamSpot&,
-                          const float&,
-                          const float&,
-                          TransientTrackingRecHit::ConstRecHitContainer&,
-                          MTDHitMatchingInfo&) const override;
+  void fillMatchingHits(const DetLayer*,
+                        const TrajectoryStateOnSurface&,
+                        const Trajectory&,
+                        const float,
+                        const float,
+                        const TrackSegments&,
+                        const MTDTrackingDetSetVector&,
+                        const Propagator*,
+                        const reco::BeamSpot&,
+                        const float&,
+                        const float&,
+                        TransientTrackingRecHit::ConstRecHitContainer&,
+                        MTDHitMatchingInfo&) const override;
 
-    reco::Track buildTrack(const reco::TrackBase::TrackAlgorithm,
-                           const Trajectory&,
-                           const Trajectory&,
-                           const reco::BeamSpot&,
-                           const MagneticField* field,
-                           const Propagator* prop,
-                           bool hasMTD,
-                           float& pathLength,
-                           float& tmtdOut,
-                           float& sigmatmtdOut,
-                           GlobalPoint& tmtdPosOut,
-                           float& tofmu,
-                           float& sigmatofmu) const;
+  reco::Track buildTrack(const reco::TrackBase::TrackAlgorithm,
+                         const Trajectory&,
+                         const Trajectory&,
+                         const reco::BeamSpot&,
+                         const MagneticField* field,
+                         const Propagator* prop,
+                         bool hasMTD,
+                         float& pathLength,
+                         float& tmtdOut,
+                         float& sigmatmtdOut,
+                         GlobalPoint& tmtdPosOut,
+                         float& tofmu,
+                         float& sigmatofmu) const;
 };
 
 template <typename T1>
 class MuonExtenderWithMTDT : public edm::stream::EDProducer<> {
-  public:
-    MuonExtenderWithMTDT(const ParameterSet& pset);
+public:
+  MuonExtenderWithMTDT(const ParameterSet& pset);
 
-    template <class H, class T>
-    void fillValueMap(edm::Event& iEvent, const H& handle, const std::vector<T>& vec, const edm::EDPutToken& token) const;
+  template <class H, class T>
+  void fillValueMap(edm::Event& iEvent, const H& handle, const std::vector<T>& vec, const edm::EDPutToken& token) const;
 
-    void produce(edm::Event& ev, const edm::EventSetup& es) final;
+  void produce(edm::Event& ev, const edm::EventSetup& es) final;
 
-  private:
-    edm::EDPutToken btlMatchChi2Token_;
-    edm::EDPutToken etlMatchChi2Token_;
-    edm::EDPutToken btlMatchTimeChi2Token_;
-    edm::EDPutToken etlMatchTimeChi2Token_;
-    edm::EDPutToken npixBarrelToken_;
-    edm::EDPutToken npixEndcapToken_;
-    edm::EDPutToken outermostHitPositionToken_;
-    edm::EDPutToken pOrigTrkToken_;
-    edm::EDPutToken betaOrigTrkToken_;
-    edm::EDPutToken t0OrigTrkToken_;
-    edm::EDPutToken sigmat0OrigTrkToken_;
-    edm::EDPutToken pathLengthOrigTrkToken_;
-    edm::EDPutToken tmtdOrigTrkToken_;
-    edm::EDPutToken sigmatmtdOrigTrkToken_;
-    edm::EDPutToken tmtdPosOrigTrkToken_;
-    edm::EDPutToken tofmuOrigTrkToken_;
-    edm::EDPutToken sigmatofmuOrigTrkToken_;
-    edm::EDPutToken assocOrigTrkToken_;
+private:
+  edm::EDPutToken btlMatchChi2Token_;
+  edm::EDPutToken etlMatchChi2Token_;
+  edm::EDPutToken btlMatchTimeChi2Token_;
+  edm::EDPutToken etlMatchTimeChi2Token_;
+  edm::EDPutToken npixBarrelToken_;
+  edm::EDPutToken npixEndcapToken_;
+  edm::EDPutToken outermostHitPositionToken_;
+  edm::EDPutToken pOrigTrkToken_;
+  edm::EDPutToken betaOrigTrkToken_;
+  edm::EDPutToken t0OrigTrkToken_;
+  edm::EDPutToken sigmat0OrigTrkToken_;
+  edm::EDPutToken pathLengthOrigTrkToken_;
+  edm::EDPutToken tmtdOrigTrkToken_;
+  edm::EDPutToken sigmatmtdOrigTrkToken_;
+  edm::EDPutToken tmtdPosOrigTrkToken_;
+  edm::EDPutToken tofmuOrigTrkToken_;
+  edm::EDPutToken sigmatofmuOrigTrkToken_;
+  edm::EDPutToken assocOrigTrkToken_;
 
-    edm::EDGetTokenT<T1> muonToken_;
-    edm::EDGetTokenT<MTDTrackingDetSetVector> hitsToken_;
-    edm::EDGetTokenT<reco::BeamSpot> bsToken_;
-    edm::EDGetTokenT<VertexCollection> vtxToken_;
+  edm::EDGetTokenT<T1> muonToken_;
+  edm::EDGetTokenT<MTDTrackingDetSetVector> hitsToken_;
+  edm::EDGetTokenT<reco::BeamSpot> bsToken_;
+  edm::EDGetTokenT<VertexCollection> vtxToken_;
 
-    const bool updateTraj_, updateExtra_, updatePattern_;
-    const std::string mtdRecHitBuilder_, propagator_, transientTrackBuilder_;
+  const bool updateTraj_, updateExtra_, updatePattern_;
+  const std::string mtdRecHitBuilder_, propagator_, transientTrackBuilder_;
 
-    std::unique_ptr<TrackTransformer> theTransformer;
-    edm::ESHandle<TransientTrackBuilder> builder_;
-    edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> builderToken_;
-    edm::ESHandle<TransientTrackingRecHitBuilder> hitbuilder_;
-    edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> hitbuilderToken_;
-    edm::ESHandle<GlobalTrackingGeometry> gtg_;
-    edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> gtgToken_;
+  std::unique_ptr<TrackTransformer> theTransformer;
+  edm::ESHandle<TransientTrackBuilder> builder_;
+  edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> builderToken_;
+  edm::ESHandle<TransientTrackingRecHitBuilder> hitbuilder_;
+  edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> hitbuilderToken_;
+  edm::ESHandle<GlobalTrackingGeometry> gtg_;
+  edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> gtgToken_;
 
-    edm::ESGetToken<MTDDetLayerGeometry, MTDRecoGeometryRecord> dlgeoToken_;
-    edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfldToken_;
-    edm::ESGetToken<Propagator, TrackingComponentsRecord> propToken_;
-    edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
+  edm::ESGetToken<MTDDetLayerGeometry, MTDRecoGeometryRecord> dlgeoToken_;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfldToken_;
+  edm::ESGetToken<Propagator, TrackingComponentsRecord> propToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
 
-    const bool useVertex_;
+  const bool useVertex_;
 
-    static constexpr float trackMaxBtlEta_ = 1.5;
+  static constexpr float trackMaxBtlEta_ = 1.5;
 
-    std::unique_ptr<MuonBaseExtenderWithMTD> baseMTDExtender_;
+  std::unique_ptr<MuonBaseExtenderWithMTD> baseMTDExtender_;
 };
 
 #endif

--- a/RecoMTD/TrackExtender/plugins/MuonExtenderWithMTD.h
+++ b/RecoMTD/TrackExtender/plugins/MuonExtenderWithMTD.h
@@ -95,7 +95,7 @@ namespace mtdtof{
 class MuonBaseExtenderWithMTD : public BaseExtenderWithMTD {
   public:
     explicit MuonBaseExtenderWithMTD(const ParameterSet& iConfig);
-    virtual ~MuonBaseExtenderWithMTD();
+    ~MuonBaseExtenderWithMTD() override;
 
     void fillMatchingHits(const DetLayer*,
                           const TrajectoryStateOnSurface&,

--- a/RecoMTD/TrackExtender/plugins/MuonExtenderWithMTD.h
+++ b/RecoMTD/TrackExtender/plugins/MuonExtenderWithMTD.h
@@ -131,6 +131,8 @@ class MuonExtenderWithMTDT : public edm::stream::EDProducer<> {
 public:
   MuonExtenderWithMTDT(const ParameterSet& pset);
 
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
   template <class H, class T>
   void fillValueMap(edm::Event& iEvent, const H& handle, const std::vector<T>& vec, const edm::EDPutToken& token) const;
 

--- a/RecoMTD/TrackExtender/plugins/MuonExtenderWithMTD.h
+++ b/RecoMTD/TrackExtender/plugins/MuonExtenderWithMTD.h
@@ -1,0 +1,187 @@
+#ifndef RecoMTD_TrackExtender_MuonExtenderWithMTD_h
+#define RecoMTD_TrackExtender_MuonExtenderWithMTD_h
+
+#include <CLHEP/Units/GlobalPhysicalConstants.h>
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
+
+#include "RecoMTD/TrackExtender/interface/BaseExtenderWithMTD.h"
+#include "RecoMTD/TransientTrackingRecHit/interface/MTDTransientTrackingRecHitBuilder.h"
+
+#include "TrackingTools/TrackRefitter/interface/TrackTransformer.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
+
+using namespace std;
+using namespace edm;
+using namespace reco;
+using namespace mtdtof;
+
+namespace mtdtof{
+
+  struct MuonTofPidInfo {
+    float tmtd;
+    float tmtderror;
+    float pathlength;
+
+    float betaerror;
+
+    float dt;
+    float dterror;
+    float dterror2;
+    float dtchi2;
+
+    float dt_best;
+    float dterror_best;
+    float dtchi2_best;
+
+    float gammasq_mu;
+    float beta_mu;
+    float dt_mu;
+    float sigma_dt_mu;  
+  };
+
+  const MuonTofPidInfo computeMuonTofPidInfo(float magp2,
+                                             float length,
+                                             TrackSegments trs,
+                                             float t_mtd,
+                                             float t_mtderr,
+                                             float t_vtx,
+                                             float t_vtx_err,
+                                             bool addPIDError = true,
+                                             TofCalc choice = TofCalc::kCost,
+                                             SigmaTofCalc sigma_choice = SigmaTofCalc::kCost);
+
+  bool muonPathLength(const Trajectory& traj,
+                      const TrajectoryStateClosestToBeamLine& tscbl,
+                      const Propagator* thePropagator,
+                      float& pathlength,
+                      TrackSegments& trs);
+
+  bool muonPathLength(const Trajectory& traj,
+                      const reco::BeamSpot& bs,
+                      const Propagator* thePropagator,
+                      float& pathlength,
+                      TrackSegments& trs);    
+
+  void find_hits_in_dets_muon(const MTDTrackingDetSetVector& hits,
+                              const Trajectory& traj,
+                              const DetLayer* layer,
+                              const TrajectoryStateOnSurface& tsos,
+                              const float pmag2,
+                              const float pathlength0,
+                              const TrackSegments& trs0,
+                              const float vtxTime,
+                              const float vtxTimeError,
+                              bool useVtxConstraint,
+                              const reco::BeamSpot& bs,
+                              const float bsTimeSpread,
+                              const Propagator* prop,
+                              const MeasurementEstimator* estimator,
+                              std::set<MTDHitMatchingInfo>& out);
+}
+
+class MuonBaseExtenderWithMTD : public BaseExtenderWithMTD {
+  public:
+    explicit MuonBaseExtenderWithMTD(const ParameterSet& iConfig);
+    virtual ~MuonBaseExtenderWithMTD();
+
+    void fillMatchingHits(const DetLayer*,
+                          const TrajectoryStateOnSurface&,
+                          const Trajectory&,
+                          const float,
+                          const float,
+                          const TrackSegments&,
+                          const MTDTrackingDetSetVector&,
+                          const Propagator*,
+                          const reco::BeamSpot&,
+                          const float&,
+                          const float&,
+                          TransientTrackingRecHit::ConstRecHitContainer&,
+                          MTDHitMatchingInfo&) const override;
+
+    reco::Track buildTrack(const reco::TrackBase::TrackAlgorithm,
+                           const Trajectory&,
+                           const Trajectory&,
+                           const reco::BeamSpot&,
+                           const MagneticField* field,
+                           const Propagator* prop,
+                           bool hasMTD,
+                           float& pathLength,
+                           float& tmtdOut,
+                           float& sigmatmtdOut,
+                           GlobalPoint& tmtdPosOut,
+                           float& tofmu,
+                           float& sigmatofmu) const;
+};
+
+template <typename T1>
+class MuonExtenderWithMTDT : public edm::stream::EDProducer<> {
+  public:
+    MuonExtenderWithMTDT(const ParameterSet& pset);
+
+    template <class H, class T>
+    void fillValueMap(edm::Event& iEvent, const H& handle, const std::vector<T>& vec, const edm::EDPutToken& token) const;
+
+    void produce(edm::Event& ev, const edm::EventSetup& es) final;
+
+  private:
+    edm::EDPutToken btlMatchChi2Token_;
+    edm::EDPutToken etlMatchChi2Token_;
+    edm::EDPutToken btlMatchTimeChi2Token_;
+    edm::EDPutToken etlMatchTimeChi2Token_;
+    edm::EDPutToken npixBarrelToken_;
+    edm::EDPutToken npixEndcapToken_;
+    edm::EDPutToken outermostHitPositionToken_;
+    edm::EDPutToken pOrigTrkToken_;
+    edm::EDPutToken betaOrigTrkToken_;
+    edm::EDPutToken t0OrigTrkToken_;
+    edm::EDPutToken sigmat0OrigTrkToken_;
+    edm::EDPutToken pathLengthOrigTrkToken_;
+    edm::EDPutToken tmtdOrigTrkToken_;
+    edm::EDPutToken sigmatmtdOrigTrkToken_;
+    edm::EDPutToken tmtdPosOrigTrkToken_;
+    edm::EDPutToken tofmuOrigTrkToken_;
+    edm::EDPutToken sigmatofmuOrigTrkToken_;
+    edm::EDPutToken assocOrigTrkToken_;
+
+    edm::EDGetTokenT<T1> muonToken_;
+    edm::EDGetTokenT<MTDTrackingDetSetVector> hitsToken_;
+    edm::EDGetTokenT<reco::BeamSpot> bsToken_;
+    edm::EDGetTokenT<VertexCollection> vtxToken_;
+
+    const bool updateTraj_, updateExtra_, updatePattern_;
+    const std::string mtdRecHitBuilder_, propagator_, transientTrackBuilder_;
+
+    std::unique_ptr<TrackTransformer> theTransformer;
+    edm::ESHandle<TransientTrackBuilder> builder_;
+    edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> builderToken_;
+    edm::ESHandle<TransientTrackingRecHitBuilder> hitbuilder_;
+    edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> hitbuilderToken_;
+    edm::ESHandle<GlobalTrackingGeometry> gtg_;
+    edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> gtgToken_;
+
+    edm::ESGetToken<MTDDetLayerGeometry, MTDRecoGeometryRecord> dlgeoToken_;
+    edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfldToken_;
+    edm::ESGetToken<Propagator, TrackingComponentsRecord> propToken_;
+    edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
+
+    const bool useVertex_;
+
+    static constexpr float trackMaxBtlEta_ = 1.5;
+
+    std::unique_ptr<MuonBaseExtenderWithMTD> baseMTDExtender_;
+};
+
+#endif

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -1,6 +1,8 @@
 #include <sstream>
 #include <format>
 
+#include "RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.h"
+
 #include <CLHEP/Units/GlobalPhysicalConstants.h>
 
 #include "DataFormats/ForwardDetId/interface/BTLDetId.h"
@@ -44,571 +46,16 @@
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
+#include "TrackingTools/TrackRefitter/interface/RefitDirection.h"
 
 using namespace std;
 using namespace edm;
 using namespace reco;
-
-namespace {
-  constexpr float c_cm_ns = geant_units::operators::convertMmToCm(CLHEP::c_light);  // [mm/ns] -> [cm/ns]
-  constexpr float c_inv = 1.0f / c_cm_ns;
-
-  class MTDHitMatchingInfo {
-  public:
-    MTDHitMatchingInfo() {
-      hit = nullptr;
-      estChi2 = std::numeric_limits<float>::max();
-      timeChi2 = std::numeric_limits<float>::max();
-    }
-
-    //Operator used to sort the hits while performing the matching step at the MTD
-    inline bool operator<(const MTDHitMatchingInfo& m2) const {
-      //only for good matching in time use estChi2, otherwise use mostly time compatibility
-      constexpr float chi2_cut = 10.f;
-      constexpr float low_weight = 3.f;
-      constexpr float high_weight = 8.f;
-      if (timeChi2 < chi2_cut && m2.timeChi2 < chi2_cut)
-        return chi2(low_weight) < m2.chi2(low_weight);
-      else
-        return chi2(high_weight) < m2.chi2(high_weight);
-    }
-
-    inline float chi2(float timeWeight = 1.f) const { return estChi2 + timeWeight * timeChi2; }
-
-    const MTDTrackingRecHit* hit;
-    float estChi2;
-    float timeChi2;
-  };
-
-  class TrackSegments {
-  public:
-    TrackSegments() {
-      sigmaTofs_.reserve(30);  // observed upper limit on nSegments
-    };
-
-    inline uint32_t addSegment(float tPath, float tMom2, float sigmaMom) {
-      segmentPathOvc_.emplace_back(tPath * c_inv);
-      segmentMom2_.emplace_back(tMom2);
-      segmentSigmaMom_.emplace_back(sigmaMom);
-      nSegment_++;
-
-      LogTrace("TrackExtenderWithMTD") << "addSegment # " << nSegment_ << " s = " << tPath
-                                       << " p = " << std::sqrt(tMom2) << " sigma_p = " << sigmaMom
-                                       << " sigma_p/p = " << sigmaMom / std::sqrt(tMom2) * 100 << " %";
-
-      return nSegment_;
-    }
-
-    inline float computeTof(float mass_inv2) const {
-      float tof(0.f);
-      for (uint32_t iSeg = 0; iSeg < nSegment_; iSeg++) {
-        float gammasq = 1.f + segmentMom2_[iSeg] * mass_inv2;
-        float beta = std::sqrt(1.f - 1.f / gammasq);
-        tof += segmentPathOvc_[iSeg] / beta;
-
-        LogTrace("TrackExtenderWithMTD") << " TOF Segment # " << iSeg + 1 << " p = " << std::sqrt(segmentMom2_[iSeg])
-                                         << " tof = " << tof;
-
-#ifdef EDM_ML_DEBUG
-        float sigma_tof = segmentPathOvc_[iSeg] * segmentSigmaMom_[iSeg] /
-                          (segmentMom2_[iSeg] * sqrt(segmentMom2_[iSeg] + 1 / mass_inv2) * mass_inv2);
-
-        LogTrace("TrackExtenderWithMTD") << "TOF Segment # " << iSeg + 1 << std::fixed << std::setw(6)
-                                         << " tof segment = " << segmentPathOvc_[iSeg] / beta << std::scientific
-                                         << "+/- " << sigma_tof << std::fixed
-                                         << "(rel. err. = " << sigma_tof / (segmentPathOvc_[iSeg] / beta) * 100
-                                         << " %)";
-#endif
-      }
-
-      return tof;
-    }
-
-    inline float computeSigmaTof(float mass_inv2) {
-      float sigmatof = 0.;
-
-      // remove previously calculated sigmaTofs
-      sigmaTofs_.clear();
-
-      // compute sigma(tof) on each segment first by propagating sigma(p)
-      // also add diagonal terms to sigmatof
-      float sigma = 0.;
-      for (uint32_t iSeg = 0; iSeg < nSegment_; iSeg++) {
-        sigma = segmentPathOvc_[iSeg] * segmentSigmaMom_[iSeg] /
-                (segmentMom2_[iSeg] * sqrt(segmentMom2_[iSeg] + 1 / mass_inv2) * mass_inv2);
-        sigmaTofs_.push_back(sigma);
-
-        sigmatof += sigma * sigma;
-      }
-
-      // compute sigma on sum of tofs assuming full correlation between segments
-      for (uint32_t iSeg = 0; iSeg < nSegment_; iSeg++) {
-        for (uint32_t jSeg = iSeg + 1; jSeg < nSegment_; jSeg++) {
-          sigmatof += 2 * sigmaTofs_[iSeg] * sigmaTofs_[jSeg];
-        }
-      }
-
-      return sqrt(sigmatof);
-    }
-
-    inline uint32_t size() const { return nSegment_; }
-
-    inline uint32_t removeFirstSegment() {
-      if (nSegment_ > 0) {
-        segmentPathOvc_.erase(segmentPathOvc_.begin());
-        segmentMom2_.erase(segmentMom2_.begin());
-        nSegment_--;
-      }
-      return nSegment_;
-    }
-
-    inline std::pair<float, float> getSegmentPathAndMom2(uint32_t iSegment) const {
-      if (iSegment >= nSegment_) {
-        throw cms::Exception("TrackExtenderWithMTD") << "Requesting non existing track segment #" << iSegment;
-      }
-      return std::make_pair(segmentPathOvc_[iSegment], segmentMom2_[iSegment]);
-    }
-
-    uint32_t nSegment_ = 0;
-    std::vector<float> segmentPathOvc_;
-    std::vector<float> segmentMom2_;
-    std::vector<float> segmentSigmaMom_;
-
-    std::vector<float> sigmaTofs_;
-  };
-
-  struct TrackTofPidInfo {
-    float tmtd;
-    float tmtderror;
-    float pathlength;
-
-    float betaerror;
-
-    float dt;
-    float dterror;
-    float dterror2;
-    float dtchi2;
-
-    float dt_best;
-    float dterror_best;
-    float dtchi2_best;
-
-    float gammasq_pi;
-    float beta_pi;
-    float dt_pi;
-    float sigma_dt_pi;
-
-    float gammasq_k;
-    float beta_k;
-    float dt_k;
-    float sigma_dt_k;
-
-    float gammasq_p;
-    float beta_p;
-    float dt_p;
-    float sigma_dt_p;
-
-    float prob_pi;
-    float prob_k;
-    float prob_p;
-  };
-
-  enum class TofCalc { kCost = 1, kSegm = 2, kMixd = 3 };
-  enum class SigmaTofCalc { kCost = 1, kSegm = 2, kMixd = 3 };
-
-  const TrackTofPidInfo computeTrackTofPidInfo(float magp2,
-                                               float length,
-                                               TrackSegments trs,
-                                               float t_mtd,
-                                               float t_mtderr,
-                                               float t_vtx,
-                                               float t_vtx_err,
-                                               bool addPIDError = true,
-                                               TofCalc choice = TofCalc::kCost,
-                                               SigmaTofCalc sigma_choice = SigmaTofCalc::kCost) {
-    constexpr float m_pi = 0.13957018f;
-    constexpr float m_pi_inv2 = 1.0f / m_pi / m_pi;
-    constexpr float m_k = 0.493677f;
-    constexpr float m_k_inv2 = 1.0f / m_k / m_k;
-    constexpr float m_p = 0.9382720813f;
-    constexpr float m_p_inv2 = 1.0f / m_p / m_p;
-
-    TrackTofPidInfo tofpid;
-
-    tofpid.tmtd = t_mtd;
-    tofpid.tmtderror = t_mtderr;
-    tofpid.pathlength = length;
-
-    auto deltat = [&](const float mass_inv2, const float betatmp) {
-      float res(1.f);
-      switch (choice) {
-        case TofCalc::kCost:
-          res = tofpid.pathlength / betatmp * c_inv;
-          break;
-        case TofCalc::kSegm:
-          res = trs.computeTof(mass_inv2);
-          break;
-        case TofCalc::kMixd:
-          res = trs.computeTof(mass_inv2) + tofpid.pathlength / betatmp * c_inv;
-          break;
-      }
-      return res;
-    };
-
-    auto sigmadeltat = [&](const float mass_inv2) {
-      float res(1.f);
-      switch (sigma_choice) {
-        case SigmaTofCalc::kCost:
-          // sigma(t) = sigma(p) * |dt/dp| = sigma(p) * DeltaL/c * m^2 / (p^2 * E)
-          res = tofpid.pathlength * c_inv * trs.segmentSigmaMom_[trs.nSegment_ - 1] /
-                (magp2 * sqrt(magp2 + 1 / mass_inv2) * mass_inv2);
-          break;
-        case SigmaTofCalc::kSegm:
-          res = trs.computeSigmaTof(mass_inv2);
-          break;
-        case SigmaTofCalc::kMixd:
-          float res1 = tofpid.pathlength * c_inv * trs.segmentSigmaMom_[trs.nSegment_ - 1] /
-                       (magp2 * sqrt(magp2 + 1 / mass_inv2) * mass_inv2);
-          float res2 = trs.computeSigmaTof(mass_inv2);
-          res = sqrt(res1 * res1 + res2 * res2 + 2 * res1 * res2);
-      }
-
-      return res;
-    };
-
-    tofpid.gammasq_pi = 1.f + magp2 * m_pi_inv2;
-    tofpid.beta_pi = std::sqrt(1.f - 1.f / tofpid.gammasq_pi);
-    tofpid.dt_pi = deltat(m_pi_inv2, tofpid.beta_pi);
-    tofpid.sigma_dt_pi = sigmadeltat(m_pi_inv2);
-
-    tofpid.gammasq_k = 1.f + magp2 * m_k_inv2;
-    tofpid.beta_k = std::sqrt(1.f - 1.f / tofpid.gammasq_k);
-    tofpid.dt_k = deltat(m_k_inv2, tofpid.beta_k);
-    tofpid.sigma_dt_k = sigmadeltat(m_k_inv2);
-
-    tofpid.gammasq_p = 1.f + magp2 * m_p_inv2;
-    tofpid.beta_p = std::sqrt(1.f - 1.f / tofpid.gammasq_p);
-    tofpid.dt_p = deltat(m_p_inv2, tofpid.beta_p);
-    tofpid.sigma_dt_p = sigmadeltat(m_p_inv2);
-
-    tofpid.dt = tofpid.tmtd - tofpid.dt_pi - t_vtx;  //assume by default the pi hypothesis
-    tofpid.dterror2 = tofpid.tmtderror * tofpid.tmtderror + t_vtx_err * t_vtx_err;
-    tofpid.betaerror = 0.f;
-    if (addPIDError) {
-      tofpid.dterror2 = tofpid.dterror2 + (tofpid.dt_p - tofpid.dt_pi) * (tofpid.dt_p - tofpid.dt_pi);
-      tofpid.betaerror = tofpid.beta_p - tofpid.beta_pi;
-    } else {
-      // only add sigma(TOF) if not considering mass hp. uncertainty
-      tofpid.dterror2 = tofpid.dterror2 + tofpid.sigma_dt_pi * tofpid.sigma_dt_pi;
-    }
-    tofpid.dterror = sqrt(tofpid.dterror2);
-
-    tofpid.dtchi2 = (tofpid.dt * tofpid.dt) / tofpid.dterror2;
-
-    tofpid.dt_best = tofpid.dt;
-    tofpid.dterror_best = tofpid.dterror;
-    tofpid.dtchi2_best = tofpid.dtchi2;
-
-    tofpid.prob_pi = -1.f;
-    tofpid.prob_k = -1.f;
-    tofpid.prob_p = -1.f;
-
-    if (!addPIDError) {
-      //*TODO* deal with heavier nucleons and/or BSM case here?
-      const float dterror2_wo_sigmatof = tofpid.dterror2 - tofpid.sigma_dt_pi * tofpid.sigma_dt_pi;
-      float chi2_pi = tofpid.dtchi2;
-      float chi2_k = (tofpid.tmtd - tofpid.dt_k - t_vtx) * (tofpid.tmtd - tofpid.dt_k - t_vtx) /
-                     (dterror2_wo_sigmatof + tofpid.sigma_dt_k * tofpid.sigma_dt_k);
-      float chi2_p = (tofpid.tmtd - tofpid.dt_p - t_vtx) * (tofpid.tmtd - tofpid.dt_p - t_vtx) /
-                     (dterror2_wo_sigmatof + tofpid.sigma_dt_p * tofpid.sigma_dt_p);
-
-      float rawprob_pi = exp(-0.5f * chi2_pi);
-      float rawprob_k = exp(-0.5f * chi2_k);
-      float rawprob_p = exp(-0.5f * chi2_p);
-      float normprob = 1.f / (rawprob_pi + rawprob_k + rawprob_p);
-
-      tofpid.prob_pi = rawprob_pi * normprob;
-      tofpid.prob_k = rawprob_k * normprob;
-      tofpid.prob_p = rawprob_p * normprob;
-
-      float prob_heavy = 1.f - tofpid.prob_pi;
-      constexpr float heavy_threshold = 0.75f;
-
-      if (prob_heavy > heavy_threshold) {
-        if (chi2_k < chi2_p) {
-          tofpid.dt_best = (tofpid.tmtd - tofpid.dt_k - t_vtx);
-          tofpid.dtchi2_best = chi2_k;
-        } else {
-          tofpid.dt_best = (tofpid.tmtd - tofpid.dt_p - t_vtx);
-          tofpid.dtchi2_best = chi2_p;
-        }
-      }
-    }
-    return tofpid;
-  }
-
-  bool getTrajectoryStateClosestToBeamLine(const Trajectory& traj,
-                                           const reco::BeamSpot& bs,
-                                           const Propagator* thePropagator,
-                                           TrajectoryStateClosestToBeamLine& tscbl) {
-    // get the state closest to the beamline
-    TrajectoryStateOnSurface stateForProjectionToBeamLineOnSurface =
-        traj.closestMeasurement(GlobalPoint(bs.x0(), bs.y0(), bs.z0())).updatedState();
-
-    if (!stateForProjectionToBeamLineOnSurface.isValid()) {
-      edm::LogError("CannotPropagateToBeamLine") << "the state on the closest measurement isnot valid. skipping track.";
-      return false;
-    }
-
-    const FreeTrajectoryState& stateForProjectionToBeamLine = *stateForProjectionToBeamLineOnSurface.freeState();
-
-    TSCBLBuilderWithPropagator tscblBuilder(*thePropagator);
-    tscbl = tscblBuilder(stateForProjectionToBeamLine, bs);
-
-    return tscbl.isValid();
-  }
-
-  bool trackPathLength(const Trajectory& traj,
-                       const TrajectoryStateClosestToBeamLine& tscbl,
-                       const Propagator* thePropagator,
-                       float& pathlength,
-                       TrackSegments& trs) {
-    pathlength = 0.f;
-
-    bool validpropagation = true;
-    float oldp = traj.measurements().begin()->updatedState().globalMomentum().mag();
-    float pathlength1 = 0.f;
-    float pathlength2 = 0.f;
-
-    //add pathlength layer by layer
-    for (auto it = traj.measurements().begin(); it != traj.measurements().end() - 1; ++it) {
-      const auto& propresult = thePropagator->propagateWithPath(it->updatedState(), (it + 1)->updatedState().surface());
-      float layerpathlength = std::abs(propresult.second);
-      if (layerpathlength == 0.f) {
-        validpropagation = false;
-      }
-      pathlength1 += layerpathlength;
-
-      // sigma(p) from curvilinear error (on q/p)
-      float sigma_p = sqrt((it + 1)->updatedState().curvilinearError().matrix()(0, 0)) *
-                      (it + 1)->updatedState().globalMomentum().mag2();
-
-      trs.addSegment(layerpathlength, (it + 1)->updatedState().globalMomentum().mag2(), sigma_p);
-
-      LogTrace("TrackExtenderWithMTD") << "TSOS " << std::fixed << std::setw(4) << trs.size() << " R_i " << std::fixed
-                                       << std::setw(14) << it->updatedState().globalPosition().perp() << " z_i "
-                                       << std::fixed << std::setw(14) << it->updatedState().globalPosition().z()
-                                       << " R_e " << std::fixed << std::setw(14)
-                                       << (it + 1)->updatedState().globalPosition().perp() << " z_e " << std::fixed
-                                       << std::setw(14) << (it + 1)->updatedState().globalPosition().z() << " p "
-                                       << std::fixed << std::setw(14) << (it + 1)->updatedState().globalMomentum().mag()
-                                       << " dp " << std::fixed << std::setw(14)
-                                       << (it + 1)->updatedState().globalMomentum().mag() - oldp;
-      oldp = (it + 1)->updatedState().globalMomentum().mag();
-    }
-
-    //add distance from bs to first measurement
-    auto const& tscblPCA = tscbl.trackStateAtPCA();
-    auto const& aSurface = traj.direction() == alongMomentum ? traj.firstMeasurement().updatedState().surface()
-                                                             : traj.lastMeasurement().updatedState().surface();
-    pathlength2 = thePropagator->propagateWithPath(tscblPCA, aSurface).second;
-    if (pathlength2 == 0.f) {
-      validpropagation = false;
-    }
-    pathlength = pathlength1 + pathlength2;
-
-    float sigma_p = sqrt(tscblPCA.curvilinearError().matrix()(0, 0)) * tscblPCA.momentum().mag2();
-
-    trs.addSegment(pathlength2, tscblPCA.momentum().mag2(), sigma_p);
-
-    LogTrace("TrackExtenderWithMTD") << "TSOS " << std::fixed << std::setw(4) << trs.size() << " R_e " << std::fixed
-                                     << std::setw(14) << tscblPCA.position().perp() << " z_e " << std::fixed
-                                     << std::setw(14) << tscblPCA.position().z() << " p " << std::fixed << std::setw(14)
-                                     << tscblPCA.momentum().mag() << " dp " << std::fixed << std::setw(14)
-                                     << tscblPCA.momentum().mag() - oldp << " sigma_p = " << std::fixed << std::setw(14)
-                                     << sigma_p << " sigma_p/p = " << std::fixed << std::setw(14)
-                                     << sigma_p / tscblPCA.momentum().mag() * 100 << " %";
-
-    return validpropagation;
-  }
-
-  bool trackPathLength(const Trajectory& traj,
-                       const reco::BeamSpot& bs,
-                       const Propagator* thePropagator,
-                       float& pathlength,
-                       TrackSegments& trs) {
-    pathlength = 0.f;
-
-    TrajectoryStateClosestToBeamLine tscbl;
-    bool tscbl_status = getTrajectoryStateClosestToBeamLine(traj, bs, thePropagator, tscbl);
-
-    if (!tscbl_status)
-      return false;
-
-    return trackPathLength(traj, tscbl, thePropagator, pathlength, trs);
-  }
-
-}  // namespace
-
-template <class TrackCollection>
-class TrackExtenderWithMTDT : public edm::stream::EDProducer<> {
-public:
-  typedef typename TrackCollection::value_type TrackType;
-  typedef edm::View<TrackType> InputCollection;
-
-  TrackExtenderWithMTDT(const ParameterSet& pset);
-
-  template <class H, class T>
-  void fillValueMap(edm::Event& iEvent, const H& handle, const std::vector<T>& vec, const edm::EDPutToken& token) const;
-
-  void produce(edm::Event& ev, const edm::EventSetup& es) final;
-
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-
-  TransientTrackingRecHit::ConstRecHitContainer tryBTLLayers(const TrajectoryStateOnSurface&,
-                                                             const Trajectory& traj,
-                                                             const float,
-                                                             const float,
-                                                             const TrackSegments&,
-                                                             const MTDTrackingDetSetVector&,
-                                                             const MTDDetLayerGeometry*,
-                                                             const MagneticField* field,
-                                                             const Propagator* prop,
-                                                             const reco::BeamSpot& bs,
-                                                             const float vtxTime,
-                                                             const float vtxTimeError,
-                                                             MTDHitMatchingInfo& bestHit) const;
-
-  TransientTrackingRecHit::ConstRecHitContainer tryETLLayers(const TrajectoryStateOnSurface&,
-                                                             const Trajectory& traj,
-                                                             const float,
-                                                             const float,
-                                                             const TrackSegments&,
-                                                             const MTDTrackingDetSetVector&,
-                                                             const MTDDetLayerGeometry*,
-                                                             const MagneticField* field,
-                                                             const Propagator* prop,
-                                                             const reco::BeamSpot& bs,
-                                                             const float vtxTime,
-                                                             const float vtxTimeError,
-                                                             MTDHitMatchingInfo& bestHit) const;
-
-  void fillMatchingHits(const DetLayer*,
-                        const TrajectoryStateOnSurface&,
-                        const Trajectory&,
-                        const float,
-                        const float,
-                        const TrackSegments&,
-                        const MTDTrackingDetSetVector&,
-                        const Propagator*,
-                        const reco::BeamSpot&,
-                        const float&,
-                        const float&,
-                        TransientTrackingRecHit::ConstRecHitContainer&,
-                        MTDHitMatchingInfo&) const;
-
-  RefitDirection::GeometricalDirection checkRecHitsOrdering(
-      TransientTrackingRecHit::ConstRecHitContainer const& recHits) const {
-    if (!recHits.empty()) {
-      GlobalPoint first = gtg_->idToDet(recHits.front()->geographicalId())->position();
-      GlobalPoint last = gtg_->idToDet(recHits.back()->geographicalId())->position();
-
-      // maybe perp2?
-      auto rFirst = first.mag2();
-      auto rLast = last.mag2();
-      if (rFirst < rLast)
-        return RefitDirection::insideOut;
-      if (rFirst > rLast)
-        return RefitDirection::outsideIn;
-    }
-    LogDebug("TrackExtenderWithMTD") << "Impossible to determine the rechits order" << endl;
-    return RefitDirection::undetermined;
-  }
-
-  reco::Track buildTrack(const reco::TrackRef&,
-                         const Trajectory&,
-                         const Trajectory&,
-                         const reco::BeamSpot&,
-                         const MagneticField* field,
-                         const Propagator* prop,
-                         bool hasMTD,
-                         float& pathLength,
-                         float& tmtdOut,
-                         float& sigmatmtdOut,
-                         GlobalPoint& tmtdPosOut,
-                         float& tofpi,
-                         float& tofk,
-                         float& tofp,
-                         float& sigmatofpi,
-                         float& sigmatofk,
-                         float& sigmatofp) const;
-  reco::TrackExtra buildTrackExtra(const Trajectory& trajectory) const;
-
-  string dumpLayer(const DetLayer* layer) const;
-
-private:
-  edm::EDPutToken btlMatchChi2Token_;
-  edm::EDPutToken etlMatchChi2Token_;
-  edm::EDPutToken btlMatchTimeChi2Token_;
-  edm::EDPutToken etlMatchTimeChi2Token_;
-  edm::EDPutToken npixBarrelToken_;
-  edm::EDPutToken npixEndcapToken_;
-  edm::EDPutToken outermostHitPositionToken_;
-  edm::EDPutToken pOrigTrkToken_;
-  edm::EDPutToken betaOrigTrkToken_;
-  edm::EDPutToken t0OrigTrkToken_;
-  edm::EDPutToken sigmat0OrigTrkToken_;
-  edm::EDPutToken pathLengthOrigTrkToken_;
-  edm::EDPutToken tmtdOrigTrkToken_;
-  edm::EDPutToken sigmatmtdOrigTrkToken_;
-  edm::EDPutToken tmtdPosOrigTrkToken_;
-  edm::EDPutToken tofpiOrigTrkToken_;
-  edm::EDPutToken tofkOrigTrkToken_;
-  edm::EDPutToken tofpOrigTrkToken_;
-  edm::EDPutToken sigmatofpiOrigTrkToken_;
-  edm::EDPutToken sigmatofkOrigTrkToken_;
-  edm::EDPutToken sigmatofpOrigTrkToken_;
-  edm::EDPutToken assocOrigTrkToken_;
-
-  edm::EDGetTokenT<InputCollection> tracksToken_;
-  edm::EDGetTokenT<TrajTrackAssociationCollection> trajTrackAToken_;
-  edm::EDGetTokenT<MTDTrackingDetSetVector> hitsToken_;
-  edm::EDGetTokenT<reco::BeamSpot> bsToken_;
-  edm::EDGetTokenT<VertexCollection> vtxToken_;
-
-  const bool updateTraj_, updateExtra_, updatePattern_;
-  const std::string mtdRecHitBuilder_, propagator_, transientTrackBuilder_;
-  std::unique_ptr<MeasurementEstimator> theEstimator;
-  std::unique_ptr<TrackTransformer> theTransformer;
-  edm::ESHandle<TransientTrackBuilder> builder_;
-  edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> builderToken_;
-  edm::ESHandle<TransientTrackingRecHitBuilder> hitbuilder_;
-  edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> hitbuilderToken_;
-  edm::ESHandle<GlobalTrackingGeometry> gtg_;
-  edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> gtgToken_;
-
-  edm::ESGetToken<MTDDetLayerGeometry, MTDRecoGeometryRecord> dlgeoToken_;
-  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfldToken_;
-  edm::ESGetToken<Propagator, TrackingComponentsRecord> propToken_;
-  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
-
-  const float estMaxChi2_;
-  const float estMaxNSigma_;
-  const float btlChi2Cut_;
-  const float btlTimeChi2Cut_;
-  const float etlChi2Cut_;
-  const float etlTimeChi2Cut_;
-
-  const bool useVertex_;
-  const float dzCut_;
-  const float bsTimeSpread_;
-
-  static constexpr float trackMaxBtlEta_ = 1.5;
-};
+using namespace mtdtof;
 
 template <class TrackCollection>
 TrackExtenderWithMTDT<TrackCollection>::TrackExtenderWithMTDT(const ParameterSet& iConfig)
-    : tracksToken_(consumes<InputCollection>(iConfig.getParameter<edm::InputTag>("tracksSrc"))),
+    : tracksToken_(consumes<TrackCollection>(iConfig.getParameter<edm::InputTag>("tracksSrc"))),
       trajTrackAToken_(consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>("trjtrkAssSrc"))),
       hitsToken_(consumes<MTDTrackingDetSetVector>(iConfig.getParameter<edm::InputTag>("hitsSrc"))),
       bsToken_(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpotSrc"))),
@@ -618,20 +65,14 @@ TrackExtenderWithMTDT<TrackCollection>::TrackExtenderWithMTDT(const ParameterSet
       mtdRecHitBuilder_(iConfig.getParameter<std::string>("MTDRecHitBuilder")),
       propagator_(iConfig.getParameter<std::string>("Propagator")),
       transientTrackBuilder_(iConfig.getParameter<std::string>("TransientTrackBuilder")),
-      estMaxChi2_(iConfig.getParameter<double>("estimatorMaxChi2")),
-      estMaxNSigma_(iConfig.getParameter<double>("estimatorMaxNSigma")),
-      btlChi2Cut_(iConfig.getParameter<double>("btlChi2Cut")),
-      btlTimeChi2Cut_(iConfig.getParameter<double>("btlTimeChi2Cut")),
-      etlChi2Cut_(iConfig.getParameter<double>("etlChi2Cut")),
-      etlTimeChi2Cut_(iConfig.getParameter<double>("etlTimeChi2Cut")),
-      useVertex_(iConfig.getParameter<bool>("useVertex")),
-      dzCut_(iConfig.getParameter<double>("dZCut")),
-      bsTimeSpread_(iConfig.getParameter<double>("bsTimeSpread")) {
+      useVertex_(iConfig.getParameter<bool>("useVertex")){
+  
+  baseMTDExtender_ = std::make_unique<BaseExtenderWithMTD>(iConfig);
+
   if (useVertex_) {
     vtxToken_ = consumes<VertexCollection>(iConfig.getParameter<edm::InputTag>("vtxSrc"));
   }
 
-  theEstimator = std::make_unique<Chi2MeasurementEstimator>(estMaxChi2_, estMaxNSigma_);
   theTransformer = std::make_unique<TrackTransformer>(iConfig.getParameterSet("TrackTransformer"), consumesCollector());
 
   btlMatchChi2Token_ = produces<edm::ValueMap<float>>("btlMatchChi2");
@@ -672,43 +113,6 @@ TrackExtenderWithMTDT<TrackCollection>::TrackExtenderWithMTDT(const ParameterSet
 }
 
 template <class TrackCollection>
-void TrackExtenderWithMTDT<TrackCollection>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  edm::ParameterSetDescription desc, transDesc;
-  desc.add<edm::InputTag>("tracksSrc", edm::InputTag("generalTracks"));
-  desc.add<edm::InputTag>("trjtrkAssSrc", edm::InputTag("generalTracks"));
-  desc.add<edm::InputTag>("hitsSrc", edm::InputTag("mtdTrackingRecHits"));
-  desc.add<edm::InputTag>("beamSpotSrc", edm::InputTag("offlineBeamSpot"));
-  desc.add<edm::InputTag>("vtxSrc", edm::InputTag("offlinePrimaryVertices4D"));
-  desc.add<bool>("updateTrackTrajectory", true);
-  desc.add<bool>("updateTrackExtra", true);
-  desc.add<bool>("updateTrackHitPattern", true);
-  desc.add<std::string>("TransientTrackBuilder", "TransientTrackBuilder");
-  desc.add<std::string>("MTDRecHitBuilder", "MTDRecHitBuilder");
-  desc.add<std::string>("Propagator", "PropagatorWithMaterialForMTD");
-  TrackTransformer::fillPSetDescription(transDesc,
-                                        false,
-                                        "KFFitterForRefitInsideOut",
-                                        "KFSmootherForRefitInsideOut",
-                                        "PropagatorWithMaterialForMTD",
-                                        "alongMomentum",
-                                        true,
-                                        "WithTrackAngle",
-                                        "MuonRecHitBuilder",
-                                        "MTDRecHitBuilder");
-  desc.add<edm::ParameterSetDescription>("TrackTransformer", transDesc);
-  desc.add<double>("estimatorMaxChi2", 500.);
-  desc.add<double>("estimatorMaxNSigma", 10.);
-  desc.add<double>("btlChi2Cut", 50.);
-  desc.add<double>("btlTimeChi2Cut", 10.);
-  desc.add<double>("etlChi2Cut", 50.);
-  desc.add<double>("etlTimeChi2Cut", 10.);
-  desc.add<bool>("useVertex", false);
-  desc.add<double>("dZCut", 0.1);
-  desc.add<double>("bsTimeSpread", 0.2);
-  descriptions.add("trackExtenderWithMTDBase", desc);
-}
-
-template <class TrackCollection>
 template <class H, class T>
 void TrackExtenderWithMTDT<TrackCollection>::fillValueMap(edm::Event& iEvent,
                                                           const H& handle,
@@ -738,6 +142,8 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
 
   builder_ = es.getHandle(builderToken_);
   hitbuilder_ = es.getHandle(hitbuilderToken_);
+
+  baseMTDExtender_->setParameters(&*hitbuilder_, &*gtg_);
 
   auto propH = es.getTransientHandle(propToken_);
   const Propagator* prop = propH.product();
@@ -836,36 +242,36 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
         TrackSegments trs0;
         trackPathLength(trajs, tscbl, prop, pathlength0, trs0);
 
-        const auto& btlhits = tryBTLLayers(tsos,
-                                           trajs,
-                                           pmag2,
-                                           pathlength0,
-                                           trs0,
-                                           hits,
-                                           geo.product(),
-                                           magfield.product(),
-                                           prop,
-                                           bs,
-                                           trackVtxTime,
-                                           trackVtxTimeError,
-                                           mBTL);
+        const auto& btlhits = baseMTDExtender_->tryBTLLayers(tsos,
+                                                             trajs,
+                                                             pmag2,
+                                                             pathlength0,
+                                                             trs0,
+                                                             hits,
+                                                             geo.product(),
+                                                             magfield.product(),
+                                                             prop,
+                                                             bs,
+                                                             trackVtxTime,
+                                                             trackVtxTimeError,
+                                                             mBTL);
         mtdthits.insert(mtdthits.end(), btlhits.begin(), btlhits.end());
 
         // in the future this should include an intermediate refit before propagating to the ETL
         // for now it is ok
-        const auto& etlhits = tryETLLayers(tsos,
-                                           trajs,
-                                           pmag2,
-                                           pathlength0,
-                                           trs0,
-                                           hits,
-                                           geo.product(),
-                                           magfield.product(),
-                                           prop,
-                                           bs,
-                                           trackVtxTime,
-                                           trackVtxTimeError,
-                                           mETL);
+        const auto& etlhits = baseMTDExtender_->tryETLLayers(tsos,
+                                                             trajs,
+                                                             pmag2,
+                                                             pathlength0,
+                                                             trs0,
+                                                             hits,
+                                                             geo.product(),
+                                                             magfield.product(),
+                                                             prop,
+                                                             bs,
+                                                             trackVtxTime,
+                                                             trackVtxTimeError,
+                                                             mETL);
         mtdthits.insert(mtdthits.end(), etlhits.begin(), etlhits.end());
       }
 #ifdef EDM_ML_DEBUG
@@ -875,7 +281,7 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
 #endif
     }
 
-    auto ordering = checkRecHitsOrdering(thits);
+    auto ordering = baseMTDExtender_->checkRecHitsOrdering(thits);
     if (ordering == RefitDirection::insideOut) {
       thits.insert(thits.end(), mtdthits.begin(), mtdthits.end());
     } else {
@@ -899,23 +305,23 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
       GlobalPoint tmtdPos{0., 0., 0.};
       LogTrace("TrackExtenderWithMTD") << "TrackExtenderWithMTD: refit track " << itrack << " p/pT = " << track->p()
                                        << " " << track->pt() << " eta = " << track->eta();
-      reco::Track result = buildTrack(track,
-                                      thetrj,
-                                      trj,
-                                      bs,
-                                      magfield.product(),
-                                      prop,
-                                      !trajwithmtd.empty() && !mtdthits.empty(),
-                                      pathLength,
-                                      tmtd,
-                                      sigmatmtd,
-                                      tmtdPos,
-                                      tofpi,
-                                      tofk,
-                                      tofp,
-                                      sigmatofpi,
-                                      sigmatofk,
-                                      sigmatofp);
+      reco::Track result = baseMTDExtender_->buildTrack(track,
+                                                        thetrj,
+                                                        trj,
+                                                        bs,
+                                                        magfield.product(),
+                                                        prop,
+                                                        !trajwithmtd.empty() && !mtdthits.empty(),
+                                                        pathLength,
+                                                        tmtd,
+                                                        sigmatmtd,
+                                                        tmtdPos,
+                                                        tofpi,
+                                                        tofk,
+                                                        tofp,
+                                                        sigmatofpi,
+                                                        sigmatofk,
+                                                        sigmatofp);
       if (result.ndof() >= 0) {
         /// setup the track extras
         reco::TrackExtra::TrajParams trajParams;
@@ -927,7 +333,7 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
           t2t(thetrj, *outhits, trajParams, chi2s);
         }
         size_t hitsend = outhits->size();
-        extras->push_back(buildTrackExtra(trj));  // always push back the fully built extra, update by setting in track
+        extras->push_back(baseMTDExtender_->buildTrackExtra(trj));  // always push back the fully built extra, update by setting in track
         extras->back().setHits(hitsRefProd, hitsstart, hitsend - hitsstart);
         extras->back().setTrajParams(trajParams, chi2s);
         //create the track
@@ -1047,525 +453,6 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
   fillValueMap(ev, tracksH, sigmatofkOrigTrkRaw, sigmatofkOrigTrkToken_);
   fillValueMap(ev, tracksH, sigmatofpOrigTrkRaw, sigmatofpOrigTrkToken_);
   fillValueMap(ev, tracksH, assocOrigTrkRaw, assocOrigTrkToken_);
-}
-
-namespace {
-  bool cmp_for_detset(const unsigned one, const unsigned two) { return one < two; };
-
-  void find_hits_in_dets(const MTDTrackingDetSetVector& hits,
-                         const Trajectory& traj,
-                         const DetLayer* layer,
-                         const TrajectoryStateOnSurface& tsos,
-                         const float pmag2,
-                         const float pathlength0,
-                         const TrackSegments& trs0,
-                         const float vtxTime,
-                         const float vtxTimeError,
-                         bool useVtxConstraint,
-                         const reco::BeamSpot& bs,
-                         const float bsTimeSpread,
-                         const Propagator* prop,
-                         const MeasurementEstimator* estimator,
-                         std::set<MTDHitMatchingInfo>& out) {
-    pair<bool, TrajectoryStateOnSurface> comp = layer->compatible(tsos, *prop, *estimator);
-    if (comp.first) {
-      const vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos, *prop, *estimator);
-      LogTrace("TrackExtenderWithMTD") << "Hit search: Compatible dets " << compDets.size();
-      if (!compDets.empty()) {
-        for (const auto& detWithState : compDets) {
-          auto range = hits.equal_range(detWithState.first->geographicalId(), cmp_for_detset);
-          if (range.first == range.second) {
-            LogTrace("TrackExtenderWithMTD")
-                << "Hit search: no hit in DetId " << detWithState.first->geographicalId().rawId();
-            continue;
-          }
-
-          auto pl = prop->propagateWithPath(tsos, detWithState.second.surface());
-          if (pl.second == 0.) {
-            LogTrace("TrackExtenderWithMTD")
-                << "Hit search: no propagation to DetId " << detWithState.first->geographicalId().rawId();
-            continue;
-          }
-
-          const float t_vtx = useVtxConstraint ? vtxTime : 0.f;
-
-          const float t_vtx_err = useVtxConstraint ? vtxTimeError : bsTimeSpread;
-
-          float lastpmag2 = trs0.getSegmentPathAndMom2(0).second;
-
-          for (auto detitr = range.first; detitr != range.second; ++detitr) {
-            for (const auto& hit : *detitr) {
-              auto est = estimator->estimate(detWithState.second, hit);
-              if (!est.first) {
-                LogTrace("TrackExtenderWithMTD")
-                    << "Hit search: no compatible estimate in DetId " << detWithState.first->geographicalId().rawId()
-                    << " for hit at pos (" << std::fixed << std::setw(14) << hit.globalPosition().x() << ","
-                    << std::fixed << std::setw(14) << hit.globalPosition().y() << "," << std::fixed << std::setw(14)
-                    << hit.globalPosition().z() << ")";
-                continue;
-              }
-
-              LogTrace("TrackExtenderWithMTD")
-                  << "Hit search: spatial compatibility DetId " << detWithState.first->geographicalId().rawId()
-                  << " TSOS dx/dy " << std::fixed << std::setw(14)
-                  << std::sqrt(detWithState.second.localError().positionError().xx()) << " " << std::fixed
-                  << std::setw(14) << std::sqrt(detWithState.second.localError().positionError().yy()) << " hit dx/dy "
-                  << std::fixed << std::setw(14) << std::sqrt(hit.localPositionError().xx()) << " " << std::fixed
-                  << std::setw(14) << std::sqrt(hit.localPositionError().yy()) << " chi2 " << std::fixed
-                  << std::setw(14) << est.second;
-
-              TrackTofPidInfo tof = computeTrackTofPidInfo(lastpmag2,
-                                                           std::abs(pl.second),
-                                                           trs0,
-                                                           hit.time(),
-                                                           hit.timeError(),
-                                                           t_vtx,
-                                                           t_vtx_err,  //put vtx error by hand for the moment
-                                                           false,
-                                                           TofCalc::kMixd,
-                                                           SigmaTofCalc::kMixd);
-              MTDHitMatchingInfo mi;
-              mi.hit = &hit;
-              mi.estChi2 = est.second;
-              mi.timeChi2 = tof.dtchi2_best;  //use the chi2 for the best matching hypothesis
-
-              out.insert(mi);
-            }
-          }
-        }
-      }
-    }
-  }
-}  // namespace
-
-template <class TrackCollection>
-TransientTrackingRecHit::ConstRecHitContainer TrackExtenderWithMTDT<TrackCollection>::tryBTLLayers(
-    const TrajectoryStateOnSurface& tsos,
-    const Trajectory& traj,
-    const float pmag2,
-    const float pathlength0,
-    const TrackSegments& trs0,
-    const MTDTrackingDetSetVector& hits,
-    const MTDDetLayerGeometry* geo,
-    const MagneticField* field,
-    const Propagator* prop,
-    const reco::BeamSpot& bs,
-    const float vtxTime,
-    const float vtxTimeError,
-    MTDHitMatchingInfo& bestHit) const {
-  const vector<const DetLayer*>& layers = geo->allBTLLayers();
-
-  TransientTrackingRecHit::ConstRecHitContainer output;
-  bestHit = MTDHitMatchingInfo();
-  for (const DetLayer* ilay : layers) {
-    LogTrace("TrackExtenderWithMTD") << "Hit search: BTL layer at R= "
-                                     << static_cast<const BarrelDetLayer*>(ilay)->specificSurface().radius();
-
-    fillMatchingHits(
-        ilay, tsos, traj, pmag2, pathlength0, trs0, hits, prop, bs, vtxTime, vtxTimeError, output, bestHit);
-  }
-
-  return output;
-}
-
-template <class TrackCollection>
-TransientTrackingRecHit::ConstRecHitContainer TrackExtenderWithMTDT<TrackCollection>::tryETLLayers(
-    const TrajectoryStateOnSurface& tsos,
-    const Trajectory& traj,
-    const float pmag2,
-    const float pathlength0,
-    const TrackSegments& trs0,
-    const MTDTrackingDetSetVector& hits,
-    const MTDDetLayerGeometry* geo,
-    const MagneticField* field,
-    const Propagator* prop,
-    const reco::BeamSpot& bs,
-    const float vtxTime,
-    const float vtxTimeError,
-    MTDHitMatchingInfo& bestHit) const {
-  const vector<const DetLayer*>& layers = geo->allETLLayers();
-
-  TransientTrackingRecHit::ConstRecHitContainer output;
-  bestHit = MTDHitMatchingInfo();
-  for (const DetLayer* ilay : layers) {
-    const BoundDisk& disk = static_cast<const ForwardDetLayer*>(ilay)->specificSurface();
-    const float diskZ = disk.position().z();
-
-    if (tsos.globalPosition().z() * diskZ < 0)
-      continue;  // only propagate to the disk that's on the same side
-
-    LogTrace("TrackExtenderWithMTD") << "Hit search: ETL disk at Z = " << diskZ;
-
-    fillMatchingHits(
-        ilay, tsos, traj, pmag2, pathlength0, trs0, hits, prop, bs, vtxTime, vtxTimeError, output, bestHit);
-  }
-
-  // the ETL hits order must be from the innermost to the outermost
-
-  if (output.size() == 2) {
-    if (std::abs(output[0]->globalPosition().z()) > std::abs(output[1]->globalPosition().z())) {
-      std::reverse(output.begin(), output.end());
-    }
-  }
-  return output;
-}
-
-template <class TrackCollection>
-void TrackExtenderWithMTDT<TrackCollection>::fillMatchingHits(const DetLayer* ilay,
-                                                              const TrajectoryStateOnSurface& tsos,
-                                                              const Trajectory& traj,
-                                                              const float pmag2,
-                                                              const float pathlength0,
-                                                              const TrackSegments& trs0,
-                                                              const MTDTrackingDetSetVector& hits,
-                                                              const Propagator* prop,
-                                                              const reco::BeamSpot& bs,
-                                                              const float& vtxTime,
-                                                              const float& vtxTimeError,
-                                                              TransientTrackingRecHit::ConstRecHitContainer& output,
-                                                              MTDHitMatchingInfo& bestHit) const {
-  std::set<MTDHitMatchingInfo> hitsInLayer;
-  bool hitMatched = false;
-
-  using namespace std::placeholders;
-  auto find_hits = std::bind(find_hits_in_dets,
-                             std::cref(hits),
-                             std::cref(traj),
-                             ilay,
-                             std::cref(tsos),
-                             pmag2,
-                             pathlength0,
-                             trs0,
-                             _1,
-                             _2,
-                             _3,
-                             std::cref(bs),
-                             bsTimeSpread_,
-                             prop,
-                             theEstimator.get(),
-                             std::ref(hitsInLayer));
-
-  bool matchVertex = vtxTimeError > 0.f;
-  if (useVertex_ && matchVertex) {
-    find_hits(vtxTime, vtxTimeError, true);
-  } else {
-    find_hits(0, 0, false);
-  }
-
-  float spaceChi2Cut = ilay->isBarrel() ? btlChi2Cut_ : etlChi2Cut_;
-  float timeChi2Cut = ilay->isBarrel() ? btlTimeChi2Cut_ : etlTimeChi2Cut_;
-
-  //just take the first hit because the hits are sorted on their matching quality
-  if (!hitsInLayer.empty()) {
-    //check hits to pass minimum quality matching requirements
-    auto const& firstHit = *hitsInLayer.begin();
-    LogTrace("TrackExtenderWithMTD") << "TrackExtenderWithMTD: matching trial 1: estChi2= " << firstHit.estChi2
-                                     << " timeChi2= " << firstHit.timeChi2;
-    if (firstHit.estChi2 < spaceChi2Cut && firstHit.timeChi2 < timeChi2Cut) {
-      hitMatched = true;
-      output.push_back(hitbuilder_->build(firstHit.hit));
-      if (firstHit < bestHit)
-        bestHit = firstHit;
-    }
-  }
-
-  if (useVertex_ && matchVertex && !hitMatched) {
-    //try a second search with beamspot hypothesis
-    hitsInLayer.clear();
-    find_hits(0, 0, false);
-    if (!hitsInLayer.empty()) {
-      auto const& firstHit = *hitsInLayer.begin();
-      LogTrace("TrackExtenderWithMTD") << "TrackExtenderWithMTD: matching trial 2: estChi2= " << firstHit.estChi2
-                                       << " timeChi2= " << firstHit.timeChi2;
-      if (firstHit.timeChi2 < timeChi2Cut) {
-        if (firstHit.estChi2 < spaceChi2Cut) {
-          hitMatched = true;
-          output.push_back(hitbuilder_->build(firstHit.hit));
-          if (firstHit < bestHit)
-            bestHit = firstHit;
-        }
-      }
-    }
-  }
-
-#ifdef EDM_ML_DEBUG
-  if (hitMatched) {
-    LogTrace("TrackExtenderWithMTD") << "TrackExtenderWithMTD: matched hit with time: " << bestHit.hit->time()
-                                     << " +/- " << bestHit.hit->timeError();
-  } else {
-    LogTrace("TrackExtenderWithMTD") << "TrackExtenderWithMTD: no matched hit";
-  }
-#endif
-}
-
-//below is unfortunately ripped from other places but
-//since track producer doesn't know about MTD we have to do this
-template <class TrackCollection>
-reco::Track TrackExtenderWithMTDT<TrackCollection>::buildTrack(const reco::TrackRef& orig,
-                                                               const Trajectory& traj,
-                                                               const Trajectory& trajWithMtd,
-                                                               const reco::BeamSpot& bs,
-                                                               const MagneticField* field,
-                                                               const Propagator* thePropagator,
-                                                               bool hasMTD,
-                                                               float& pathLengthOut,
-                                                               float& tmtdOut,
-                                                               float& sigmatmtdOut,
-                                                               GlobalPoint& tmtdPosOut,
-                                                               float& tofpi,
-                                                               float& tofk,
-                                                               float& tofp,
-                                                               float& sigmatofpi,
-                                                               float& sigmatofk,
-                                                               float& sigmatofp) const {
-  TrajectoryStateClosestToBeamLine tscbl;
-  bool tsbcl_status = getTrajectoryStateClosestToBeamLine(traj, bs, thePropagator, tscbl);
-
-  if (!tsbcl_status)
-    return reco::Track();
-
-  GlobalPoint v = tscbl.trackStateAtPCA().position();
-  math::XYZPoint pos(v.x(), v.y(), v.z());
-  GlobalVector p = tscbl.trackStateAtPCA().momentum();
-  math::XYZVector mom(p.x(), p.y(), p.z());
-
-  int ndof = traj.ndof();
-
-  float t0 = 0.f;
-  float covt0t0 = -1.f;
-  pathLengthOut = -1.f;  // if there is no MTD flag the pathlength with -1
-  tmtdOut = 0.f;
-  sigmatmtdOut = -1.f;
-  float betaOut = 0.f;
-  float covbetabeta = -1.f;
-
-  auto routput = [&]() {
-    return reco::Track(traj.chiSquared(),
-                       int(ndof),
-                       pos,
-                       mom,
-                       tscbl.trackStateAtPCA().charge(),
-                       tscbl.trackStateAtPCA().curvilinearError(),
-                       orig->algo(),
-                       reco::TrackBase::undefQuality,
-                       t0,
-                       betaOut,
-                       covt0t0,
-                       covbetabeta);
-  };
-
-  //compute path length for time backpropagation, using first MTD hit for the momentum
-  if (hasMTD) {
-    float pathlength;
-    TrackSegments trs;
-    bool validpropagation = trackPathLength(trajWithMtd, bs, thePropagator, pathlength, trs);
-    float thit = 0.f;
-    float thiterror = -1.f;
-    GlobalPoint thitpos{0., 0., 0.};
-    bool validmtd = false;
-
-    if (!validpropagation) {
-      return routput();
-    }
-
-    uint32_t ihitcount(0), ietlcount(0);
-    for (auto const& hit : trajWithMtd.measurements()) {
-      if (hit.recHit()->geographicalId().det() == DetId::Forward &&
-          ForwardSubdetector(hit.recHit()->geographicalId().subdetId()) == FastTime) {
-        ihitcount++;
-        if (MTDDetId(hit.recHit()->geographicalId()).mtdSubDetector() == MTDDetId::MTDType::ETL) {
-          ietlcount++;
-        }
-      }
-    }
-
-    LogTrace("TrackExtenderWithMTD") << "TrackExtenderWithMTD: selected #hits " << ihitcount << " from ETL "
-                                     << ietlcount;
-
-    auto ihit1 = trajWithMtd.measurements().cbegin();
-    if (ihitcount == 1) {
-      const MTDTrackingRecHit* mtdhit = static_cast<const MTDTrackingRecHit*>((*ihit1).recHit()->hit());
-      thit = mtdhit->time();
-      thiterror = mtdhit->timeError();
-      thitpos = mtdhit->globalPosition();
-      validmtd = true;
-    } else if (ihitcount == 2 && ietlcount == 2) {
-      std::pair<float, float> lastStep = trs.getSegmentPathAndMom2(0);
-      float etlpathlength = std::abs(lastStep.first * c_cm_ns);
-      //
-      // The information of the two ETL hits is combined and attributed to the innermost hit
-      //
-      if (etlpathlength == 0.f) {
-        validpropagation = false;
-      } else {
-        pathlength -= etlpathlength;
-        trs.removeFirstSegment();
-        const MTDTrackingRecHit* mtdhit1 = static_cast<const MTDTrackingRecHit*>((*ihit1).recHit()->hit());
-        const MTDTrackingRecHit* mtdhit2 = static_cast<const MTDTrackingRecHit*>((*(ihit1 + 1)).recHit()->hit());
-        TrackTofPidInfo tofInfo = computeTrackTofPidInfo(
-            lastStep.second, etlpathlength, trs, mtdhit1->time(), mtdhit1->timeError(), 0.f, 0.f, true, TofCalc::kCost);
-        //
-        // Protect against incompatible times
-        //
-        float err1 = tofInfo.dterror2;
-        float err2 = mtdhit2->timeError() * mtdhit2->timeError();
-        if (cms_rounding::roundIfNear0(err1) == 0.f || cms_rounding::roundIfNear0(err2) == 0.f) {
-          edm::LogError("TrackExtenderWithMTD")
-              << "MTD tracking hits with zero time uncertainty: " << err1 << " " << err2;
-        } else {
-          if ((tofInfo.dt - mtdhit2->time()) * (tofInfo.dt - mtdhit2->time()) < (err1 + err2) * etlTimeChi2Cut_) {
-            //
-            // Subtract the ETL time of flight from the outermost measurement, and combine it in a weighted average with the innermost
-            // the mass ambiguity related uncertainty on the time of flight is added as an additional uncertainty
-            //
-            err1 = 1.f / err1;
-            err2 = 1.f / err2;
-            thiterror = 1.f / (err1 + err2);
-            thit = (tofInfo.dt * err1 + mtdhit2->time() * err2) * thiterror;
-            thiterror = std::sqrt(thiterror);
-            thitpos = mtdhit2->globalPosition();
-            LogTrace("TrackExtenderWithMTD")
-                << "TrackExtenderWithMTD: p trk = " << p.mag() << " ETL hits times/errors: 1) " << mtdhit1->time()
-                << " +/- " << mtdhit1->timeError() << " , 2) " << mtdhit2->time() << " +/- " << mtdhit2->timeError()
-                << " extrapolated time1: " << tofInfo.dt << " +/- " << tofInfo.dterror << " average = " << thit
-                << " +/- " << thiterror << "\n    hit1 pos: " << mtdhit1->globalPosition()
-                << " hit2 pos: " << mtdhit2->globalPosition() << " etl path length " << etlpathlength << std::endl;
-            validmtd = true;
-          } else {
-            // if back extrapolated time of the outermost measurement not compatible with the innermost, keep the one with smallest error
-            if (err1 <= err2) {
-              thit = tofInfo.dt;
-              thiterror = tofInfo.dterror;
-              validmtd = true;
-            } else {
-              thit = mtdhit2->time();
-              thiterror = mtdhit2->timeError();
-              validmtd = true;
-            }
-          }
-        }
-      }
-    } else {
-      edm::LogInfo("TrackExtenderWithMTD")
-          << "MTD hits #" << ihitcount << "ETL hits #" << ietlcount << " anomalous pattern, skipping...";
-    }
-
-    if (validmtd && validpropagation) {
-      //here add the PID uncertainty for later use in the 1st step of 4D vtx reconstruction
-      TrackTofPidInfo tofInfo = computeTrackTofPidInfo(
-          p.mag2(), pathlength, trs, thit, thiterror, 0.f, 0.f, true, TofCalc::kSegm, SigmaTofCalc::kCost);
-
-      pathLengthOut = pathlength;  // set path length if we've got a timing hit
-      tmtdOut = thit;
-      sigmatmtdOut = thiterror;
-      tmtdPosOut = thitpos;
-      t0 = tofInfo.dt;
-      covt0t0 = tofInfo.dterror2;
-      betaOut = tofInfo.beta_pi;
-      covbetabeta = tofInfo.betaerror * tofInfo.betaerror;
-      tofpi = tofInfo.dt_pi;
-      tofk = tofInfo.dt_k;
-      tofp = tofInfo.dt_p;
-      sigmatofpi = tofInfo.sigma_dt_pi;
-      sigmatofk = tofInfo.sigma_dt_k;
-      sigmatofp = tofInfo.sigma_dt_p;
-    }
-  }
-
-  return routput();
-}
-
-template <class TrackCollection>
-reco::TrackExtra TrackExtenderWithMTDT<TrackCollection>::buildTrackExtra(const Trajectory& trajectory) const {
-  static const string metname = "TrackExtenderWithMTD";
-
-  const Trajectory::RecHitContainer transRecHits = trajectory.recHits();
-
-  // put the collection of TrackingRecHit in the event
-
-  // sets the outermost and innermost TSOSs
-  // ToDo: validation for track states with MTD
-  TrajectoryStateOnSurface outerTSOS;
-  TrajectoryStateOnSurface innerTSOS;
-  unsigned int innerId = 0, outerId = 0;
-  TrajectoryMeasurement::ConstRecHitPointer outerRecHit;
-  DetId outerDetId;
-
-  if (trajectory.direction() == alongMomentum) {
-    LogTrace(metname) << "alongMomentum";
-    outerTSOS = trajectory.lastMeasurement().updatedState();
-    innerTSOS = trajectory.firstMeasurement().updatedState();
-    outerId = trajectory.lastMeasurement().recHit()->geographicalId().rawId();
-    innerId = trajectory.firstMeasurement().recHit()->geographicalId().rawId();
-    outerRecHit = trajectory.lastMeasurement().recHit();
-    outerDetId = trajectory.lastMeasurement().recHit()->geographicalId();
-  } else if (trajectory.direction() == oppositeToMomentum) {
-    LogTrace(metname) << "oppositeToMomentum";
-    outerTSOS = trajectory.firstMeasurement().updatedState();
-    innerTSOS = trajectory.lastMeasurement().updatedState();
-    outerId = trajectory.firstMeasurement().recHit()->geographicalId().rawId();
-    innerId = trajectory.lastMeasurement().recHit()->geographicalId().rawId();
-    outerRecHit = trajectory.firstMeasurement().recHit();
-    outerDetId = trajectory.firstMeasurement().recHit()->geographicalId();
-  } else
-    LogError(metname) << "Wrong propagation direction!";
-
-  const GeomDet* outerDet = gtg_->idToDet(outerDetId);
-  GlobalPoint outerTSOSPos = outerTSOS.globalParameters().position();
-  bool inside = outerDet->surface().bounds().inside(outerDet->toLocal(outerTSOSPos));
-
-  GlobalPoint hitPos =
-      (outerRecHit->isValid()) ? outerRecHit->globalPosition() : outerTSOS.globalParameters().position();
-
-  if (!inside) {
-    LogTrace(metname) << "The Global Muon outerMostMeasurementState is not compatible with the recHit detector!"
-                      << " Setting outerMost postition to recHit position if recHit isValid: "
-                      << outerRecHit->isValid();
-    LogTrace(metname) << "From " << outerTSOSPos << " to " << hitPos;
-  }
-
-  //build the TrackExtra
-  GlobalPoint v = (inside) ? outerTSOSPos : hitPos;
-  GlobalVector p = outerTSOS.globalParameters().momentum();
-  math::XYZPoint outpos(v.x(), v.y(), v.z());
-  math::XYZVector outmom(p.x(), p.y(), p.z());
-
-  v = innerTSOS.globalParameters().position();
-  p = innerTSOS.globalParameters().momentum();
-  math::XYZPoint inpos(v.x(), v.y(), v.z());
-  math::XYZVector inmom(p.x(), p.y(), p.z());
-
-  reco::TrackExtra trackExtra(outpos,
-                              outmom,
-                              true,
-                              inpos,
-                              inmom,
-                              true,
-                              outerTSOS.curvilinearError(),
-                              outerId,
-                              innerTSOS.curvilinearError(),
-                              innerId,
-                              trajectory.direction(),
-                              trajectory.seedRef());
-
-  return trackExtra;
-}
-
-template <class TrackCollection>
-string TrackExtenderWithMTDT<TrackCollection>::dumpLayer(const DetLayer* layer) const {
-  stringstream output;
-
-  const BoundSurface* sur = nullptr;
-  const BoundCylinder* bc = nullptr;
-  const BoundDisk* bd = nullptr;
-
-  sur = &(layer->surface());
-  if ((bc = dynamic_cast<const BoundCylinder*>(sur))) {
-    output << "  Cylinder of radius: " << bc->radius() << endl;
-  } else if ((bd = dynamic_cast<const BoundDisk*>(sur))) {
-    output << "  Disk at: " << bd->position().z() << endl;
-  }
-  return output.str();
 }
 
 //define this as a plug-in

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -112,6 +112,43 @@ TrackExtenderWithMTDT<TrackCollection>::TrackExtenderWithMTDT(const ParameterSet
 }
 
 template <class TrackCollection>
+void TrackExtenderWithMTDT<TrackCollection>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc, transDesc;
+  desc.add<edm::InputTag>("tracksSrc", edm::InputTag("generalTracks"));
+  desc.add<edm::InputTag>("trjtrkAssSrc", edm::InputTag("generalTracks"));
+  desc.add<edm::InputTag>("hitsSrc", edm::InputTag("mtdTrackingRecHits"));
+  desc.add<edm::InputTag>("beamSpotSrc", edm::InputTag("offlineBeamSpot"));
+  desc.add<edm::InputTag>("vtxSrc", edm::InputTag("offlinePrimaryVertices4D"));
+  desc.add<bool>("updateTrackTrajectory", true);
+  desc.add<bool>("updateTrackExtra", true);
+  desc.add<bool>("updateTrackHitPattern", true);
+  desc.add<std::string>("TransientTrackBuilder", "TransientTrackBuilder");
+  desc.add<std::string>("MTDRecHitBuilder", "MTDRecHitBuilder");
+  desc.add<std::string>("Propagator", "PropagatorWithMaterialForMTD");
+  TrackTransformer::fillPSetDescription(transDesc,
+                                        false,
+                                        "KFFitterForRefitInsideOut",
+                                        "KFSmootherForRefitInsideOut",
+                                        "PropagatorWithMaterialForMTD",
+                                        "alongMomentum",
+                                        true,
+                                        "WithTrackAngle",
+                                        "MuonRecHitBuilder",
+                                        "MTDRecHitBuilder");
+  desc.add<edm::ParameterSetDescription>("TrackTransformer", transDesc);
+  desc.add<double>("estimatorMaxChi2", 500.);
+  desc.add<double>("estimatorMaxNSigma", 10.);
+  desc.add<double>("btlChi2Cut", 50.);
+  desc.add<double>("btlTimeChi2Cut", 10.);
+  desc.add<double>("etlChi2Cut", 50.);
+  desc.add<double>("etlTimeChi2Cut", 10.);
+  desc.add<bool>("useVertex", false);
+  desc.add<double>("dZCut", 0.1);
+  desc.add<double>("bsTimeSpread", 0.2);
+  descriptions.add("trackExtenderWithMTDBase", desc);
+}
+
+template <class TrackCollection>
 template <class H, class T>
 void TrackExtenderWithMTDT<TrackCollection>::fillValueMap(edm::Event& iEvent,
                                                           const H& handle,

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -65,8 +65,7 @@ TrackExtenderWithMTDT<TrackCollection>::TrackExtenderWithMTDT(const ParameterSet
       mtdRecHitBuilder_(iConfig.getParameter<std::string>("MTDRecHitBuilder")),
       propagator_(iConfig.getParameter<std::string>("Propagator")),
       transientTrackBuilder_(iConfig.getParameter<std::string>("TransientTrackBuilder")),
-      useVertex_(iConfig.getParameter<bool>("useVertex")){
-  
+      useVertex_(iConfig.getParameter<bool>("useVertex")) {
   baseMTDExtender_ = std::make_unique<BaseExtenderWithMTD>(iConfig);
 
   if (useVertex_) {
@@ -333,7 +332,8 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
           t2t(thetrj, *outhits, trajParams, chi2s);
         }
         size_t hitsend = outhits->size();
-        extras->push_back(baseMTDExtender_->buildTrackExtra(trj));  // always push back the fully built extra, update by setting in track
+        extras->push_back(baseMTDExtender_->buildTrackExtra(
+            trj));  // always push back the fully built extra, update by setting in track
         extras->back().setHits(hitsRefProd, hitsstart, hitsend - hitsstart);
         extras->back().setTrajParams(trajParams, chi2s);
         //create the track

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.h
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.h
@@ -25,66 +25,66 @@ using namespace edm;
 using namespace reco;
 
 template <class TrackCollection>
-class TrackExtenderWithMTDT : public edm::stream::EDProducer<>{
-  public:
-    TrackExtenderWithMTDT(const ParameterSet& pset);
+class TrackExtenderWithMTDT : public edm::stream::EDProducer<> {
+public:
+  TrackExtenderWithMTDT(const ParameterSet& pset);
 
-    template <class H, class T>
-    void fillValueMap(edm::Event& iEvent, const H& handle, const std::vector<T>& vec, const edm::EDPutToken& token) const;
+  template <class H, class T>
+  void fillValueMap(edm::Event& iEvent, const H& handle, const std::vector<T>& vec, const edm::EDPutToken& token) const;
 
-    void produce(edm::Event& ev, const edm::EventSetup& es) final;
+  void produce(edm::Event& ev, const edm::EventSetup& es) final;
 
-  private:
-    edm::EDPutToken btlMatchChi2Token_;
-    edm::EDPutToken etlMatchChi2Token_;
-    edm::EDPutToken btlMatchTimeChi2Token_;
-    edm::EDPutToken etlMatchTimeChi2Token_;
-    edm::EDPutToken npixBarrelToken_;
-    edm::EDPutToken npixEndcapToken_;
-    edm::EDPutToken outermostHitPositionToken_;
-    edm::EDPutToken pOrigTrkToken_;
-    edm::EDPutToken betaOrigTrkToken_;
-    edm::EDPutToken t0OrigTrkToken_;
-    edm::EDPutToken sigmat0OrigTrkToken_;
-    edm::EDPutToken pathLengthOrigTrkToken_;
-    edm::EDPutToken tmtdOrigTrkToken_;
-    edm::EDPutToken sigmatmtdOrigTrkToken_;
-    edm::EDPutToken tmtdPosOrigTrkToken_;
-    edm::EDPutToken tofpiOrigTrkToken_;
-    edm::EDPutToken tofkOrigTrkToken_;
-    edm::EDPutToken tofpOrigTrkToken_;
-    edm::EDPutToken sigmatofpiOrigTrkToken_;
-    edm::EDPutToken sigmatofkOrigTrkToken_;
-    edm::EDPutToken sigmatofpOrigTrkToken_;
-    edm::EDPutToken assocOrigTrkToken_;
+private:
+  edm::EDPutToken btlMatchChi2Token_;
+  edm::EDPutToken etlMatchChi2Token_;
+  edm::EDPutToken btlMatchTimeChi2Token_;
+  edm::EDPutToken etlMatchTimeChi2Token_;
+  edm::EDPutToken npixBarrelToken_;
+  edm::EDPutToken npixEndcapToken_;
+  edm::EDPutToken outermostHitPositionToken_;
+  edm::EDPutToken pOrigTrkToken_;
+  edm::EDPutToken betaOrigTrkToken_;
+  edm::EDPutToken t0OrigTrkToken_;
+  edm::EDPutToken sigmat0OrigTrkToken_;
+  edm::EDPutToken pathLengthOrigTrkToken_;
+  edm::EDPutToken tmtdOrigTrkToken_;
+  edm::EDPutToken sigmatmtdOrigTrkToken_;
+  edm::EDPutToken tmtdPosOrigTrkToken_;
+  edm::EDPutToken tofpiOrigTrkToken_;
+  edm::EDPutToken tofkOrigTrkToken_;
+  edm::EDPutToken tofpOrigTrkToken_;
+  edm::EDPutToken sigmatofpiOrigTrkToken_;
+  edm::EDPutToken sigmatofkOrigTrkToken_;
+  edm::EDPutToken sigmatofpOrigTrkToken_;
+  edm::EDPutToken assocOrigTrkToken_;
 
-    edm::EDGetTokenT<TrackCollection> tracksToken_;
-    edm::EDGetTokenT<TrajTrackAssociationCollection> trajTrackAToken_;
-    edm::EDGetTokenT<MTDTrackingDetSetVector> hitsToken_;
-    edm::EDGetTokenT<reco::BeamSpot> bsToken_;
-    edm::EDGetTokenT<VertexCollection> vtxToken_;
+  edm::EDGetTokenT<TrackCollection> tracksToken_;
+  edm::EDGetTokenT<TrajTrackAssociationCollection> trajTrackAToken_;
+  edm::EDGetTokenT<MTDTrackingDetSetVector> hitsToken_;
+  edm::EDGetTokenT<reco::BeamSpot> bsToken_;
+  edm::EDGetTokenT<VertexCollection> vtxToken_;
 
-    const bool updateTraj_, updateExtra_, updatePattern_;
-    const std::string mtdRecHitBuilder_, propagator_, transientTrackBuilder_;
+  const bool updateTraj_, updateExtra_, updatePattern_;
+  const std::string mtdRecHitBuilder_, propagator_, transientTrackBuilder_;
 
-    std::unique_ptr<TrackTransformer> theTransformer;
-    edm::ESHandle<TransientTrackBuilder> builder_;
-    edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> builderToken_;
-    edm::ESHandle<TransientTrackingRecHitBuilder> hitbuilder_;
-    edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> hitbuilderToken_;
-    edm::ESHandle<GlobalTrackingGeometry> gtg_;
-    edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> gtgToken_;
+  std::unique_ptr<TrackTransformer> theTransformer;
+  edm::ESHandle<TransientTrackBuilder> builder_;
+  edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> builderToken_;
+  edm::ESHandle<TransientTrackingRecHitBuilder> hitbuilder_;
+  edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> hitbuilderToken_;
+  edm::ESHandle<GlobalTrackingGeometry> gtg_;
+  edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> gtgToken_;
 
-    edm::ESGetToken<MTDDetLayerGeometry, MTDRecoGeometryRecord> dlgeoToken_;
-    edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfldToken_;
-    edm::ESGetToken<Propagator, TrackingComponentsRecord> propToken_;
-    edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
+  edm::ESGetToken<MTDDetLayerGeometry, MTDRecoGeometryRecord> dlgeoToken_;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfldToken_;
+  edm::ESGetToken<Propagator, TrackingComponentsRecord> propToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
 
-    const bool useVertex_;
+  const bool useVertex_;
 
-    static constexpr float trackMaxBtlEta_ = 1.5;
+  static constexpr float trackMaxBtlEta_ = 1.5;
 
-    std::unique_ptr<BaseExtenderWithMTD> baseMTDExtender_;
+  std::unique_ptr<BaseExtenderWithMTD> baseMTDExtender_;
 };
 
 #endif

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.h
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.h
@@ -29,6 +29,8 @@ class TrackExtenderWithMTDT : public edm::stream::EDProducer<> {
 public:
   TrackExtenderWithMTDT(const ParameterSet& pset);
 
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
   template <class H, class T>
   void fillValueMap(edm::Event& iEvent, const H& handle, const std::vector<T>& vec, const edm::EDPutToken& token) const;
 

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.h
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.h
@@ -1,0 +1,90 @@
+#ifndef RecoMTD_TrackExtender_TrackExtenderWithMTD_h
+#define RecoMTD_TrackExtender_TrackExtenderWithMTD_h
+
+#include <CLHEP/Units/GlobalPhysicalConstants.h>
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+
+#include "RecoMTD/TrackExtender/interface/BaseExtenderWithMTD.h"
+#include "RecoMTD/TransientTrackingRecHit/interface/MTDTransientTrackingRecHitBuilder.h"
+
+#include "TrackingTools/TrackRefitter/interface/TrackTransformer.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
+
+using namespace std;
+using namespace edm;
+using namespace reco;
+
+template <class TrackCollection>
+class TrackExtenderWithMTDT : public edm::stream::EDProducer<>{
+  public:
+    TrackExtenderWithMTDT(const ParameterSet& pset);
+
+    template <class H, class T>
+    void fillValueMap(edm::Event& iEvent, const H& handle, const std::vector<T>& vec, const edm::EDPutToken& token) const;
+
+    void produce(edm::Event& ev, const edm::EventSetup& es) final;
+
+  private:
+    edm::EDPutToken btlMatchChi2Token_;
+    edm::EDPutToken etlMatchChi2Token_;
+    edm::EDPutToken btlMatchTimeChi2Token_;
+    edm::EDPutToken etlMatchTimeChi2Token_;
+    edm::EDPutToken npixBarrelToken_;
+    edm::EDPutToken npixEndcapToken_;
+    edm::EDPutToken outermostHitPositionToken_;
+    edm::EDPutToken pOrigTrkToken_;
+    edm::EDPutToken betaOrigTrkToken_;
+    edm::EDPutToken t0OrigTrkToken_;
+    edm::EDPutToken sigmat0OrigTrkToken_;
+    edm::EDPutToken pathLengthOrigTrkToken_;
+    edm::EDPutToken tmtdOrigTrkToken_;
+    edm::EDPutToken sigmatmtdOrigTrkToken_;
+    edm::EDPutToken tmtdPosOrigTrkToken_;
+    edm::EDPutToken tofpiOrigTrkToken_;
+    edm::EDPutToken tofkOrigTrkToken_;
+    edm::EDPutToken tofpOrigTrkToken_;
+    edm::EDPutToken sigmatofpiOrigTrkToken_;
+    edm::EDPutToken sigmatofkOrigTrkToken_;
+    edm::EDPutToken sigmatofpOrigTrkToken_;
+    edm::EDPutToken assocOrigTrkToken_;
+
+    edm::EDGetTokenT<TrackCollection> tracksToken_;
+    edm::EDGetTokenT<TrajTrackAssociationCollection> trajTrackAToken_;
+    edm::EDGetTokenT<MTDTrackingDetSetVector> hitsToken_;
+    edm::EDGetTokenT<reco::BeamSpot> bsToken_;
+    edm::EDGetTokenT<VertexCollection> vtxToken_;
+
+    const bool updateTraj_, updateExtra_, updatePattern_;
+    const std::string mtdRecHitBuilder_, propagator_, transientTrackBuilder_;
+
+    std::unique_ptr<TrackTransformer> theTransformer;
+    edm::ESHandle<TransientTrackBuilder> builder_;
+    edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> builderToken_;
+    edm::ESHandle<TransientTrackingRecHitBuilder> hitbuilder_;
+    edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> hitbuilderToken_;
+    edm::ESHandle<GlobalTrackingGeometry> gtg_;
+    edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> gtgToken_;
+
+    edm::ESGetToken<MTDDetLayerGeometry, MTDRecoGeometryRecord> dlgeoToken_;
+    edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfldToken_;
+    edm::ESGetToken<Propagator, TrackingComponentsRecord> propToken_;
+    edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
+
+    const bool useVertex_;
+
+    static constexpr float trackMaxBtlEta_ = 1.5;
+
+    std::unique_ptr<BaseExtenderWithMTD> baseMTDExtender_;
+};
+
+#endif

--- a/RecoMTD/TrackExtender/src/BaseExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/src/BaseExtenderWithMTD.cc
@@ -1,0 +1,980 @@
+#include "RecoMTD/TrackExtender/interface/BaseExtenderWithMTD.h"
+
+#include <CLHEP/Units/GlobalPhysicalConstants.h>
+
+#include "DataFormats/ForwardDetId/interface/BTLDetId.h"
+#include "DataFormats/ForwardDetId/interface/ETLDetId.h"
+#include "DataFormats/ForwardDetId/interface/MTDChannelIdentifier.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/Math/interface/GeantUnits.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/Math/interface/Rounding.h"
+#include "DataFormats/TrackerRecHit2D/interface/MTDTrackingRecHit.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+#include "Geometry/CommonTopologies/interface/Topology.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "RecoMTD/DetLayers/interface/MTDDetLayerGeometry.h"
+#include "RecoMTD/DetLayers/interface/MTDTrayBarrelLayer.h"
+#include "RecoMTD/Records/interface/MTDRecoGeometryRecord.h"
+#include "RecoMTD/TransientTrackingRecHit/interface/MTDTransientTrackingRecHitBuilder.h"
+#include "RecoTracker/TransientTrackingRecHit/interface/Traj2TrackHits.h"
+#include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
+#include "TrackingTools/GeomPropagators/interface/Propagator.h"
+#include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
+#include "TrackingTools/PatternTools/interface/TSCBLBuilderWithPropagator.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+#include "TrackingTools/PatternTools/interface/Trajectory.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "TrackingTools/TrackRefitter/interface/TrackTransformer.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
+#include "TrackingTools/TrackRefitter/interface/RefitDirection.h"
+
+using namespace std;
+using namespace edm;
+using namespace reco;
+
+namespace mtdtof{
+  // MTDHitMatchingInfo --------
+  MTDHitMatchingInfo::MTDHitMatchingInfo() {
+      hit = nullptr;
+      estChi2 = std::numeric_limits<float>::max();
+      timeChi2 = std::numeric_limits<float>::max();
+  };
+
+  //Operator used to sort the hits while performing the matching step at the MTD
+  bool MTDHitMatchingInfo::operator<(const MTDHitMatchingInfo& m2) const {
+    //only for good matching in time use estChi2, otherwise use mostly time compatibility
+    constexpr float chi2_cut = 10.f;
+    constexpr float low_weight = 3.f;
+    constexpr float high_weight = 8.f;
+    if (timeChi2 < chi2_cut && m2.timeChi2 < chi2_cut)
+      return chi2(low_weight) < m2.chi2(low_weight);
+    else
+      return chi2(high_weight) < m2.chi2(high_weight);
+  };
+
+  float MTDHitMatchingInfo::chi2(float timeWeight) const { return estChi2 + timeWeight * timeChi2; };
+
+  // TrackSegments --------
+  TrackSegments::TrackSegments() {
+    sigmaTofs_.reserve(30);  // observed upper limit on nSegments
+  };
+
+  uint32_t TrackSegments::addSegment(float tPath, float tMom2, float sigmaMom) {
+    segmentPathOvc_.emplace_back(tPath * c_inv);
+    segmentMom2_.emplace_back(tMom2);
+    segmentSigmaMom_.emplace_back(sigmaMom);
+    nSegment_++;
+
+    LogTrace("BaseExtenderWithMTD") << "addSegment # " << nSegment_ << " s = " << tPath
+                                     << " p = " << std::sqrt(tMom2) << " sigma_p = " << sigmaMom
+                                     << " sigma_p/p = " << sigmaMom / std::sqrt(tMom2) * 100 << " %";
+
+    return nSegment_;
+  };
+
+  float TrackSegments::computeTof(float mass_inv2) const {
+    float tof(0.f);
+    for (uint32_t iSeg = 0; iSeg < nSegment_; iSeg++) {
+      float gammasq = 1.f + segmentMom2_[iSeg] * mass_inv2;
+      float beta = std::sqrt(1.f - 1.f / gammasq);
+      tof += segmentPathOvc_[iSeg] / beta;
+
+      LogTrace("BaseExtenderWithMTD") << " TOF Segment # " << iSeg + 1 << " p = " << std::sqrt(segmentMom2_[iSeg])
+                                       << " tof = " << tof;
+
+#ifdef EDM_ML_DEBUG
+      float sigma_tof = segmentPathOvc_[iSeg] * segmentSigmaMom_[iSeg] /
+                        (segmentMom2_[iSeg] * sqrt(segmentMom2_[iSeg] + 1 / mass_inv2) * mass_inv2);
+
+      LogTrace("BaseExtenderWithMTD") << "TOF Segment # " << iSeg + 1 << std::fixed << std::setw(6)
+                                       << " tof segment = " << segmentPathOvc_[iSeg] / beta << std::scientific
+                                       << "+/- " << sigma_tof << std::fixed
+                                       << "(rel. err. = " << sigma_tof / (segmentPathOvc_[iSeg] / beta) * 100
+                                       << " %)";
+#endif
+    }
+    return tof;
+  };
+
+  float TrackSegments::computeSigmaTof(float mass_inv2) {
+    float sigmatof = 0.;
+
+    // remove previously calculated sigmaTofs
+    sigmaTofs_.clear();
+
+    // compute sigma(tof) on each segment first by propagating sigma(p)
+    // also add diagonal terms to sigmatof
+    float sigma = 0.;
+    for (uint32_t iSeg = 0; iSeg < nSegment_; iSeg++) {
+      sigma = segmentPathOvc_[iSeg] * segmentSigmaMom_[iSeg] /
+              (segmentMom2_[iSeg] * sqrt(segmentMom2_[iSeg] + 1 / mass_inv2) * mass_inv2);
+      sigmaTofs_.push_back(sigma);
+
+      sigmatof += sigma * sigma;
+    }
+
+    // compute sigma on sum of tofs assuming full correlation between segments
+    for (uint32_t iSeg = 0; iSeg < nSegment_; iSeg++) {
+      for (uint32_t jSeg = iSeg + 1; jSeg < nSegment_; jSeg++) {
+        sigmatof += 2 * sigmaTofs_[iSeg] * sigmaTofs_[jSeg];
+      }
+    }
+
+    return sqrt(sigmatof);
+  };
+
+  uint32_t TrackSegments::size() const { return nSegment_; };
+
+  uint32_t TrackSegments::removeFirstSegment() {
+    if (nSegment_ > 0) {
+      segmentPathOvc_.erase(segmentPathOvc_.begin());
+      segmentMom2_.erase(segmentMom2_.begin());
+      nSegment_--;
+    }
+    return nSegment_;
+  };
+
+  std::pair<float, float> TrackSegments::getSegmentPathAndMom2(uint32_t iSegment) const {
+    if (iSegment >= nSegment_) {
+      throw cms::Exception("BaseExtenderWithMTD") << "Requesting non existing track segment #" << iSegment;
+    }
+    return std::make_pair(segmentPathOvc_[iSegment], segmentMom2_[iSegment]);
+  };
+  
+  const TrackTofPidInfo computeTrackTofPidInfo(float magp2,
+                                               float length,
+                                               TrackSegments trs,
+                                               float t_mtd,
+                                               float t_mtderr,
+                                               float t_vtx,
+                                               float t_vtx_err,
+                                               bool addPIDError,
+                                               TofCalc choice,
+                                               SigmaTofCalc sigma_choice) {
+    constexpr float m_pi = 0.13957018f;
+    constexpr float m_pi_inv2 = 1.0f / m_pi / m_pi;
+    constexpr float m_k = 0.493677f;
+    constexpr float m_k_inv2 = 1.0f / m_k / m_k;
+    constexpr float m_p = 0.9382720813f;
+    constexpr float m_p_inv2 = 1.0f / m_p / m_p;
+
+    TrackTofPidInfo tofpid;
+
+    tofpid.tmtd = t_mtd;
+    tofpid.tmtderror = t_mtderr;
+    tofpid.pathlength = length;
+
+    auto deltat = [&](const float mass_inv2, const float betatmp) {
+      float res(1.f);
+      switch (choice) {
+        case TofCalc::kCost:
+          res = tofpid.pathlength / betatmp * c_inv;
+          break;
+        case TofCalc::kSegm:
+          res = trs.computeTof(mass_inv2);
+          break;
+        case TofCalc::kMixd:
+          res = trs.computeTof(mass_inv2) + tofpid.pathlength / betatmp * c_inv;
+          break;
+      }
+      return res;
+    };
+
+    auto sigmadeltat = [&](const float mass_inv2) {
+      float res(1.f);
+      switch (sigma_choice) {
+        case SigmaTofCalc::kCost:
+          // sigma(t) = sigma(p) * |dt/dp| = sigma(p) * DeltaL/c * m^2 / (p^2 * E)
+          res = tofpid.pathlength * c_inv * trs.segmentSigmaMom_[trs.nSegment_ - 1] /
+                (magp2 * sqrt(magp2 + 1 / mass_inv2) * mass_inv2);
+          break;
+        case SigmaTofCalc::kSegm:
+          res = trs.computeSigmaTof(mass_inv2);
+          break;
+        case SigmaTofCalc::kMixd:
+          float res1 = tofpid.pathlength * c_inv * trs.segmentSigmaMom_[trs.nSegment_ - 1] /
+                       (magp2 * sqrt(magp2 + 1 / mass_inv2) * mass_inv2);
+          float res2 = trs.computeSigmaTof(mass_inv2);
+          res = sqrt(res1 * res1 + res2 * res2 + 2 * res1 * res2);
+      }
+
+      return res;
+    };
+
+    tofpid.gammasq_pi = 1.f + magp2 * m_pi_inv2;
+    tofpid.beta_pi = std::sqrt(1.f - 1.f / tofpid.gammasq_pi);
+    tofpid.dt_pi = deltat(m_pi_inv2, tofpid.beta_pi);
+    tofpid.sigma_dt_pi = sigmadeltat(m_pi_inv2);
+
+    tofpid.gammasq_k = 1.f + magp2 * m_k_inv2;
+    tofpid.beta_k = std::sqrt(1.f - 1.f / tofpid.gammasq_k);
+    tofpid.dt_k = deltat(m_k_inv2, tofpid.beta_k);
+    tofpid.sigma_dt_k = sigmadeltat(m_k_inv2);
+
+    tofpid.gammasq_p = 1.f + magp2 * m_p_inv2;
+    tofpid.beta_p = std::sqrt(1.f - 1.f / tofpid.gammasq_p);
+    tofpid.dt_p = deltat(m_p_inv2, tofpid.beta_p);
+    tofpid.sigma_dt_p = sigmadeltat(m_p_inv2);
+
+    tofpid.dt = tofpid.tmtd - tofpid.dt_pi - t_vtx;  //assume by default the pi hypothesis
+    tofpid.dterror2 = tofpid.tmtderror * tofpid.tmtderror + t_vtx_err * t_vtx_err;
+    tofpid.betaerror = 0.f;
+    if (addPIDError) {
+      tofpid.dterror2 = tofpid.dterror2 + (tofpid.dt_p - tofpid.dt_pi) * (tofpid.dt_p - tofpid.dt_pi);
+      tofpid.betaerror = tofpid.beta_p - tofpid.beta_pi;
+    } else {
+      // only add sigma(TOF) if not considering mass hp. uncertainty
+      tofpid.dterror2 = tofpid.dterror2 + tofpid.sigma_dt_pi * tofpid.sigma_dt_pi;
+    }
+    tofpid.dterror = sqrt(tofpid.dterror2);
+
+    tofpid.dtchi2 = (tofpid.dt * tofpid.dt) / tofpid.dterror2;
+
+    tofpid.dt_best = tofpid.dt;
+    tofpid.dterror_best = tofpid.dterror;
+    tofpid.dtchi2_best = tofpid.dtchi2;
+
+    tofpid.prob_pi = -1.f;
+    tofpid.prob_k = -1.f;
+    tofpid.prob_p = -1.f;
+
+    if (!addPIDError) {
+      //*TODO* deal with heavier nucleons and/or BSM case here?
+      const float dterror2_wo_sigmatof = tofpid.dterror2 - tofpid.sigma_dt_pi * tofpid.sigma_dt_pi;
+      float chi2_pi = tofpid.dtchi2;
+      float chi2_k = (tofpid.tmtd - tofpid.dt_k - t_vtx) * (tofpid.tmtd - tofpid.dt_k - t_vtx) /
+                     (dterror2_wo_sigmatof + tofpid.sigma_dt_k * tofpid.sigma_dt_k);
+      float chi2_p = (tofpid.tmtd - tofpid.dt_p - t_vtx) * (tofpid.tmtd - tofpid.dt_p - t_vtx) /
+                     (dterror2_wo_sigmatof + tofpid.sigma_dt_p * tofpid.sigma_dt_p);
+
+      float rawprob_pi = exp(-0.5f * chi2_pi);
+      float rawprob_k = exp(-0.5f * chi2_k);
+      float rawprob_p = exp(-0.5f * chi2_p);
+      float normprob = 1.f / (rawprob_pi + rawprob_k + rawprob_p);
+
+      tofpid.prob_pi = rawprob_pi * normprob;
+      tofpid.prob_k = rawprob_k * normprob;
+      tofpid.prob_p = rawprob_p * normprob;
+
+      float prob_heavy = 1.f - tofpid.prob_pi;
+      constexpr float heavy_threshold = 0.75f;
+
+      if (prob_heavy > heavy_threshold) {
+        if (chi2_k < chi2_p) {
+          tofpid.dt_best = (tofpid.tmtd - tofpid.dt_k - t_vtx);
+          tofpid.dtchi2_best = chi2_k;
+        } else {
+          tofpid.dt_best = (tofpid.tmtd - tofpid.dt_p - t_vtx);
+          tofpid.dtchi2_best = chi2_p;
+        }
+      }
+    }
+    return tofpid;
+  };
+
+  bool getTrajectoryStateClosestToBeamLine(const Trajectory& traj,
+                                           const reco::BeamSpot& bs,
+                                           const Propagator* thePropagator,
+                                           TrajectoryStateClosestToBeamLine& tscbl) {
+    // get the state closest to the beamline
+    TrajectoryStateOnSurface stateForProjectionToBeamLineOnSurface =
+        traj.closestMeasurement(GlobalPoint(bs.x0(), bs.y0(), bs.z0())).updatedState();
+
+    if (!stateForProjectionToBeamLineOnSurface.isValid()) {
+      edm::LogError("CannotPropagateToBeamLine") << "the state on the closest measurement isnot valid. skipping track.";
+      return false;
+    }
+
+    const FreeTrajectoryState& stateForProjectionToBeamLine = *stateForProjectionToBeamLineOnSurface.freeState();
+
+    TSCBLBuilderWithPropagator tscblBuilder(*thePropagator);
+    tscbl = tscblBuilder(stateForProjectionToBeamLine, bs);
+
+    return tscbl.isValid();
+  };
+
+  bool trackPathLength(const Trajectory& traj,
+                       const TrajectoryStateClosestToBeamLine& tscbl,
+                       const Propagator* thePropagator,
+                       float& pathlength,
+                       TrackSegments& trs) {
+    pathlength = 0.f;
+
+    bool validpropagation = true;
+    float oldp = traj.measurements().begin()->updatedState().globalMomentum().mag();
+    float pathlength1 = 0.f;
+    float pathlength2 = 0.f;
+
+    //add pathlength layer by layer
+    for (auto it = traj.measurements().begin(); it != traj.measurements().end() - 1; ++it) {
+      const auto& propresult = thePropagator->propagateWithPath(it->updatedState(), (it + 1)->updatedState().surface());
+      float layerpathlength = std::abs(propresult.second);
+      if (layerpathlength == 0.f) {
+        validpropagation = false;
+      }
+      pathlength1 += layerpathlength;
+
+      // sigma(p) from curvilinear error (on q/p)
+      float sigma_p = sqrt((it + 1)->updatedState().curvilinearError().matrix()(0, 0)) *
+                      (it + 1)->updatedState().globalMomentum().mag2();
+
+      trs.addSegment(layerpathlength, (it + 1)->updatedState().globalMomentum().mag2(), sigma_p);
+
+      LogTrace("BaseExtenderWithMTD") << "TSOS " << std::fixed << std::setw(4) << trs.size() << " R_i " << std::fixed
+                                       << std::setw(14) << it->updatedState().globalPosition().perp() << " z_i "
+                                       << std::fixed << std::setw(14) << it->updatedState().globalPosition().z()
+                                       << " R_e " << std::fixed << std::setw(14)
+                                       << (it + 1)->updatedState().globalPosition().perp() << " z_e " << std::fixed
+                                       << std::setw(14) << (it + 1)->updatedState().globalPosition().z() << " p "
+                                       << std::fixed << std::setw(14) << (it + 1)->updatedState().globalMomentum().mag()
+                                       << " dp " << std::fixed << std::setw(14)
+                                       << (it + 1)->updatedState().globalMomentum().mag() - oldp;
+      oldp = (it + 1)->updatedState().globalMomentum().mag();
+    }
+
+    //add distance from bs to first measurement
+    auto const& tscblPCA = tscbl.trackStateAtPCA();
+    auto const& aSurface = traj.direction() == alongMomentum ? traj.firstMeasurement().updatedState().surface()
+                                                             : traj.lastMeasurement().updatedState().surface();
+    pathlength2 = thePropagator->propagateWithPath(tscblPCA, aSurface).second;
+    if (pathlength2 == 0.f) {
+      validpropagation = false;
+    }
+    pathlength = pathlength1 + pathlength2;
+
+    float sigma_p = sqrt(tscblPCA.curvilinearError().matrix()(0, 0)) * tscblPCA.momentum().mag2();
+
+    trs.addSegment(pathlength2, tscblPCA.momentum().mag2(), sigma_p);
+
+    LogTrace("BaseExtenderWithMTD") << "TSOS " << std::fixed << std::setw(4) << trs.size() << " R_e " << std::fixed
+                                     << std::setw(14) << tscblPCA.position().perp() << " z_e " << std::fixed
+                                     << std::setw(14) << tscblPCA.position().z() << " p " << std::fixed << std::setw(14)
+                                     << tscblPCA.momentum().mag() << " dp " << std::fixed << std::setw(14)
+                                     << tscblPCA.momentum().mag() - oldp << " sigma_p = " << std::fixed << std::setw(14)
+                                     << sigma_p << " sigma_p/p = " << std::fixed << std::setw(14)
+                                     << sigma_p / tscblPCA.momentum().mag() * 100 << " %";
+
+    return validpropagation;
+  };
+
+  bool trackPathLength(const Trajectory& traj,
+                       const reco::BeamSpot& bs,
+                       const Propagator* thePropagator,
+                       float& pathlength,
+                       TrackSegments& trs) {
+    pathlength = 0.f;
+
+    TrajectoryStateClosestToBeamLine tscbl;
+    bool tscbl_status = getTrajectoryStateClosestToBeamLine(traj, bs, thePropagator, tscbl);
+
+    if (!tscbl_status)
+      return false;
+
+    return trackPathLength(traj, tscbl, thePropagator, pathlength, trs);
+  };
+
+  bool cmp_for_detset(const unsigned one, const unsigned two) { return one < two; };
+
+  void find_hits_in_dets(const MTDTrackingDetSetVector& hits,
+                         const Trajectory& traj,
+                         const DetLayer* layer,
+                         const TrajectoryStateOnSurface& tsos,
+                         const float pmag2,
+                         const float pathlength0,
+                         const TrackSegments& trs0,
+                         const float vtxTime,
+                         const float vtxTimeError,
+                         bool useVtxConstraint,
+                         const reco::BeamSpot& bs,
+                         const float bsTimeSpread,
+                         const Propagator* prop,
+                         const MeasurementEstimator* estimator,
+                         std::set<MTDHitMatchingInfo>& out) {
+    pair<bool, TrajectoryStateOnSurface> comp = layer->compatible(tsos, *prop, *estimator);
+    if (comp.first) {
+      const vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos, *prop, *estimator);
+      LogTrace("BaseExtenderWithMTD") << "Hit search: Compatible dets " << compDets.size();
+      if (!compDets.empty()) {
+        for (const auto& detWithState : compDets) {
+          auto range = hits.equal_range(detWithState.first->geographicalId(), cmp_for_detset);
+          if (range.first == range.second) {
+            LogTrace("BaseExtenderWithMTD")
+                << "Hit search: no hit in DetId " << detWithState.first->geographicalId().rawId();
+            continue;
+          }
+
+          auto pl = prop->propagateWithPath(tsos, detWithState.second.surface());
+          if (pl.second == 0.) {
+            LogTrace("BaseExtenderWithMTD")
+                << "Hit search: no propagation to DetId " << detWithState.first->geographicalId().rawId();
+            continue;
+          }
+
+          const float t_vtx = useVtxConstraint ? vtxTime : 0.f;
+
+          const float t_vtx_err = useVtxConstraint ? vtxTimeError : bsTimeSpread;
+
+          float lastpmag2 = trs0.getSegmentPathAndMom2(0).second;
+
+          for (auto detitr = range.first; detitr != range.second; ++detitr) {
+            for (const auto& hit : *detitr) {
+              auto est = estimator->estimate(detWithState.second, hit);
+              if (!est.first) {
+                LogTrace("BaseExtenderWithMTD")
+                    << "Hit search: no compatible estimate in DetId " << detWithState.first->geographicalId().rawId()
+                    << " for hit at pos (" << std::fixed << std::setw(14) << hit.globalPosition().x() << ","
+                    << std::fixed << std::setw(14) << hit.globalPosition().y() << "," << std::fixed << std::setw(14)
+                    << hit.globalPosition().z() << ")";
+                continue;
+              }
+
+              LogTrace("BaseExtenderWithMTD")
+                  << "Hit search: spatial compatibility DetId " << detWithState.first->geographicalId().rawId()
+                  << " TSOS dx/dy " << std::fixed << std::setw(14)
+                  << std::sqrt(detWithState.second.localError().positionError().xx()) << " " << std::fixed
+                  << std::setw(14) << std::sqrt(detWithState.second.localError().positionError().yy()) << " hit dx/dy "
+                  << std::fixed << std::setw(14) << std::sqrt(hit.localPositionError().xx()) << " " << std::fixed
+                  << std::setw(14) << std::sqrt(hit.localPositionError().yy()) << " chi2 " << std::fixed
+                  << std::setw(14) << est.second;
+
+              TrackTofPidInfo tof = computeTrackTofPidInfo(lastpmag2,
+                                                           std::abs(pl.second),
+                                                           trs0,
+                                                           hit.time(),
+                                                           hit.timeError(),
+                                                           t_vtx,
+                                                           t_vtx_err,  //put vtx error by hand for the moment
+                                                           false,
+                                                           TofCalc::kMixd,
+                                                           SigmaTofCalc::kMixd);
+              MTDHitMatchingInfo mi;
+              mi.hit = &hit;
+              mi.estChi2 = est.second;
+              mi.timeChi2 = tof.dtchi2_best;  //use the chi2 for the best matching hypothesis
+
+              out.insert(mi);
+            }
+          }
+        }
+      }
+    }
+  };
+}  // namespace
+
+// BaseExtenderWithMTD ----------
+
+using namespace mtdtof;
+
+BaseExtenderWithMTD::BaseExtenderWithMTD(const ParameterSet& iConfig)
+    : estMaxChi2_(iConfig.getParameter<double>("estimatorMaxChi2")),
+      estMaxNSigma_(iConfig.getParameter<double>("estimatorMaxNSigma")),
+      btlChi2Cut_(iConfig.getParameter<double>("btlChi2Cut")),
+      btlTimeChi2Cut_(iConfig.getParameter<double>("btlTimeChi2Cut")),
+      etlChi2Cut_(iConfig.getParameter<double>("etlChi2Cut")),
+      etlTimeChi2Cut_(iConfig.getParameter<double>("etlTimeChi2Cut")),
+      useVertex_(iConfig.getParameter<bool>("useVertex")),
+      dzCut_(iConfig.getParameter<double>("dZCut")),
+      bsTimeSpread_(iConfig.getParameter<double>("bsTimeSpread")) {
+  theEstimator = std::make_unique<Chi2MeasurementEstimator>(estMaxChi2_, estMaxNSigma_);
+}
+
+BaseExtenderWithMTD::~BaseExtenderWithMTD() = default;
+
+void BaseExtenderWithMTD::setParameters(const TransientTrackingRecHitBuilder* hitbuilder, const GlobalTrackingGeometry* gtg) {
+  basehitbuilder_ = hitbuilder;
+  basegtg_ = gtg;
+}
+
+const TransientTrackingRecHitBuilder* BaseExtenderWithMTD::getHitBuilder() const{
+  return basehitbuilder_;
+}
+
+void BaseExtenderWithMTD::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc, transDesc;
+  desc.add<edm::InputTag>("hitsSrc", edm::InputTag("mtdTrackingRecHits"));
+  desc.add<edm::InputTag>("beamSpotSrc", edm::InputTag("offlineBeamSpot"));
+  desc.add<edm::InputTag>("vtxSrc", edm::InputTag("offlinePrimaryVertices4D"));
+  desc.add<bool>("updateTrackTrajectory", true);
+  desc.add<bool>("updateTrackExtra", true);
+  desc.add<bool>("updateTrackHitPattern", true);
+  desc.add<std::string>("TransientTrackBuilder", "TransientTrackBuilder");
+  desc.add<std::string>("MTDRecHitBuilder", "MTDRecHitBuilder");
+  desc.add<std::string>("Propagator", "PropagatorWithMaterialForMTD");
+  TrackTransformer::fillPSetDescription(transDesc,
+                                        false,
+                                        "KFFitterForRefitInsideOut",
+                                        "KFSmootherForRefitInsideOut",
+                                        "PropagatorWithMaterialForMTD",
+                                        "alongMomentum",
+                                        true,
+                                        "WithTrackAngle",
+                                        "MuonRecHitBuilder",
+                                        "MTDRecHitBuilder");
+  desc.add<edm::ParameterSetDescription>("TrackTransformer", transDesc);
+  desc.add<double>("estimatorMaxChi2", 500.);
+  desc.add<double>("estimatorMaxNSigma", 10.);
+  desc.add<double>("btlChi2Cut", 50.);
+  desc.add<double>("btlTimeChi2Cut", 10.);
+  desc.add<double>("etlChi2Cut", 50.);
+  desc.add<double>("etlTimeChi2Cut", 10.);
+  desc.add<bool>("useVertex", false);
+  desc.add<double>("dZCut", 0.1);
+  desc.add<double>("bsTimeSpread", 0.2);
+  descriptions.add("trackExtenderWithMTDBase", desc);
+}
+
+TransientTrackingRecHit::ConstRecHitContainer BaseExtenderWithMTD::tryBTLLayers(
+    const TrajectoryStateOnSurface& tsos,
+    const Trajectory& traj,
+    const float pmag2,
+    const float pathlength0,
+    const TrackSegments& trs0,
+    const MTDTrackingDetSetVector& hits,
+    const MTDDetLayerGeometry* geo,
+    const MagneticField* field,
+    const Propagator* prop,
+    const reco::BeamSpot& bs,
+    const float vtxTime,
+    const float vtxTimeError,
+    MTDHitMatchingInfo& bestHit) const {
+  const vector<const DetLayer*>& layers = geo->allBTLLayers();
+
+  TransientTrackingRecHit::ConstRecHitContainer output;
+  bestHit = MTDHitMatchingInfo();
+  for (const DetLayer* ilay : layers) {
+    LogTrace("BaseExtenderWithMTD") << "Hit search: BTL layer at R= "
+                                     << static_cast<const BarrelDetLayer*>(ilay)->specificSurface().radius();
+
+    fillMatchingHits(
+        ilay, tsos, traj, pmag2, pathlength0, trs0, hits, prop, bs, vtxTime, vtxTimeError, output, bestHit);
+  }
+
+  return output;
+}
+
+TransientTrackingRecHit::ConstRecHitContainer BaseExtenderWithMTD::tryETLLayers(
+    const TrajectoryStateOnSurface& tsos,
+    const Trajectory& traj,
+    const float pmag2,
+    const float pathlength0,
+    const TrackSegments& trs0,
+    const MTDTrackingDetSetVector& hits,
+    const MTDDetLayerGeometry* geo,
+    const MagneticField* field,
+    const Propagator* prop,
+    const reco::BeamSpot& bs,
+    const float vtxTime,
+    const float vtxTimeError,
+    MTDHitMatchingInfo& bestHit) const {
+  const vector<const DetLayer*>& layers = geo->allETLLayers();
+
+  TransientTrackingRecHit::ConstRecHitContainer output;
+  bestHit = MTDHitMatchingInfo();
+  for (const DetLayer* ilay : layers) {
+    const BoundDisk& disk = static_cast<const ForwardDetLayer*>(ilay)->specificSurface();
+    const float diskZ = disk.position().z();
+
+    if (tsos.globalPosition().z() * diskZ < 0)
+      continue;  // only propagate to the disk that's on the same side
+
+    LogTrace("BaseExtenderWithMTD") << "Hit search: ETL disk at Z = " << diskZ;
+
+    fillMatchingHits(
+        ilay, tsos, traj, pmag2, pathlength0, trs0, hits, prop, bs, vtxTime, vtxTimeError, output, bestHit);
+  }
+
+  // the ETL hits order must be from the innermost to the outermost
+
+  if (output.size() == 2) {
+    if (std::abs(output[0]->globalPosition().z()) > std::abs(output[1]->globalPosition().z())) {
+      std::reverse(output.begin(), output.end());
+    }
+  }
+  return output;
+}
+
+void BaseExtenderWithMTD::fillMatchingHits(const DetLayer* ilay,
+                                           const TrajectoryStateOnSurface& tsos,
+                                           const Trajectory& traj,
+                                           const float pmag2,
+                                           const float pathlength0,
+                                           const TrackSegments& trs0,
+                                           const MTDTrackingDetSetVector& hits,
+                                           const Propagator* prop,
+                                           const reco::BeamSpot& bs,
+                                           const float& vtxTime,
+                                           const float& vtxTimeError,
+                                           TransientTrackingRecHit::ConstRecHitContainer& output,
+                                           MTDHitMatchingInfo& bestHit) const {
+  std::set<MTDHitMatchingInfo> hitsInLayer;
+  bool hitMatched = false;
+
+  using namespace std::placeholders;
+  auto find_hits = std::bind(find_hits_in_dets,
+                             std::cref(hits),
+                             std::cref(traj),
+                             ilay,
+                             std::cref(tsos),
+                             pmag2,
+                             pathlength0,
+                             trs0,
+                             _1,
+                             _2,
+                             _3,
+                             std::cref(bs),
+                             bsTimeSpread_,
+                             prop,
+                             theEstimator.get(),
+                             std::ref(hitsInLayer));
+
+  bool matchVertex = vtxTimeError > 0.f;
+  if (useVertex_ && matchVertex) {
+    find_hits(vtxTime, vtxTimeError, true);
+  } else {
+    find_hits(0, 0, false);
+  }
+
+  float spaceChi2Cut = ilay->isBarrel() ? btlChi2Cut_ : etlChi2Cut_;
+  float timeChi2Cut = ilay->isBarrel() ? btlTimeChi2Cut_ : etlTimeChi2Cut_;
+
+  //just take the first hit because the hits are sorted on their matching quality
+  if (!hitsInLayer.empty()) {
+    //check hits to pass minimum quality matching requirements
+    auto const& firstHit = *hitsInLayer.begin();
+    LogTrace("BaseExtenderWithMTD") << "BaseExtenderWithMTD: matching trial 1: estChi2= " << firstHit.estChi2
+                                     << " timeChi2= " << firstHit.timeChi2;
+    if (firstHit.estChi2 < spaceChi2Cut && firstHit.timeChi2 < timeChi2Cut) {
+      hitMatched = true;
+      output.push_back(basehitbuilder_->build(firstHit.hit));
+      if (firstHit < bestHit)
+        bestHit = firstHit;
+    }
+  }
+
+  if (useVertex_ && matchVertex && !hitMatched) {
+    //try a second search with beamspot hypothesis
+    hitsInLayer.clear();
+    find_hits(0, 0, false);
+    if (!hitsInLayer.empty()) {
+      auto const& firstHit = *hitsInLayer.begin();
+      LogTrace("BaseExtenderWithMTD") << "BaseExtenderWithMTD: matching trial 2: estChi2= " << firstHit.estChi2
+                                       << " timeChi2= " << firstHit.timeChi2;
+      if (firstHit.timeChi2 < timeChi2Cut) {
+        if (firstHit.estChi2 < spaceChi2Cut) {
+          hitMatched = true;
+          output.push_back(basehitbuilder_->build(firstHit.hit));
+          if (firstHit < bestHit)
+            bestHit = firstHit;
+        }
+      }
+    }
+  }
+
+#ifdef EDM_ML_DEBUG
+  if (hitMatched) {
+    LogTrace("BaseExtenderWithMTD") << "BaseExtenderWithMTD: matched hit with time: " << bestHit.hit->time()
+                                     << " +/- " << bestHit.hit->timeError();
+  } else {
+    LogTrace("BaseExtenderWithMTD") << "BaseExtenderWithMTD: no matched hit";
+  }
+#endif
+}
+
+RefitDirection::GeometricalDirection BaseExtenderWithMTD::checkRecHitsOrdering(TransientTrackingRecHit::ConstRecHitContainer const& recHits) const {
+  if (!recHits.empty()) {
+    GlobalPoint first = basegtg_->idToDet(recHits.front()->geographicalId())->position();
+    GlobalPoint last = basegtg_->idToDet(recHits.back()->geographicalId())->position();
+
+    // maybe perp2?
+    auto rFirst = first.mag2();
+    auto rLast = last.mag2();
+    if (rFirst < rLast)
+      return RefitDirection::insideOut;
+    if (rFirst > rLast)
+      return RefitDirection::outsideIn;
+  }
+  LogDebug("BaseExtenderWithMTD") << "Impossible to determine the rechits order" << endl;
+  return RefitDirection::undetermined;
+}
+
+reco::Track BaseExtenderWithMTD::buildTrack(const reco::TrackRef& orig,
+                                            const Trajectory& traj,
+                                            const Trajectory& trajWithMtd,
+                                            const reco::BeamSpot& bs,
+                                            const MagneticField* field,
+                                            const Propagator* thePropagator,
+                                            bool hasMTD,
+                                            float& pathLengthOut,
+                                            float& tmtdOut,
+                                            float& sigmatmtdOut,
+                                            GlobalPoint& tmtdPosOut,
+                                            float& tofpi,
+                                            float& tofk,
+                                            float& tofp,
+                                            float& sigmatofpi,
+                                            float& sigmatofk,
+                                            float& sigmatofp) const {
+  TrajectoryStateClosestToBeamLine tscbl;
+  bool tsbcl_status = getTrajectoryStateClosestToBeamLine(traj, bs, thePropagator, tscbl);
+
+  if (!tsbcl_status)
+    return reco::Track();
+
+  GlobalPoint v = tscbl.trackStateAtPCA().position();
+  math::XYZPoint pos(v.x(), v.y(), v.z());
+  GlobalVector p = tscbl.trackStateAtPCA().momentum();
+  math::XYZVector mom(p.x(), p.y(), p.z());
+
+  int ndof = traj.ndof();
+
+  float t0 = 0.f;
+  float covt0t0 = -1.f;
+  pathLengthOut = -1.f;  // if there is no MTD flag the pathlength with -1
+  tmtdOut = 0.f;
+  sigmatmtdOut = -1.f;
+  float betaOut = 0.f;
+  float covbetabeta = -1.f;
+
+  auto routput = [&]() {
+    return reco::Track(traj.chiSquared(),
+                       int(ndof),
+                       pos,
+                       mom,
+                       tscbl.trackStateAtPCA().charge(),
+                       tscbl.trackStateAtPCA().curvilinearError(),
+                       orig->algo(),
+                       reco::TrackBase::undefQuality,
+                       t0,
+                       betaOut,
+                       covt0t0,
+                       covbetabeta);
+  };
+
+  //compute path length for time backpropagation, using first MTD hit for the momentum
+  if (hasMTD) {
+    float pathlength;
+    TrackSegments trs;
+    bool validpropagation = trackPathLength(trajWithMtd, bs, thePropagator, pathlength, trs);
+    float thit = 0.f;
+    float thiterror = -1.f;
+    GlobalPoint thitpos{0., 0., 0.};
+    bool validmtd = false;
+
+    if (!validpropagation) {
+      return routput();
+    }
+
+    uint32_t ihitcount(0), ietlcount(0);
+    for (auto const& hit : trajWithMtd.measurements()) {
+      if (hit.recHit()->geographicalId().det() == DetId::Forward &&
+          ForwardSubdetector(hit.recHit()->geographicalId().subdetId()) == FastTime) {
+        ihitcount++;
+        if (MTDDetId(hit.recHit()->geographicalId()).mtdSubDetector() == MTDDetId::MTDType::ETL) {
+          ietlcount++;
+        }
+      }
+    }
+
+    LogTrace("BaseExtenderWithMTD") << "BaseExtenderWithMTD: selected #hits " << ihitcount << " from ETL "
+                                     << ietlcount;
+
+    auto ihit1 = trajWithMtd.measurements().cbegin();
+    if (ihitcount == 1) {
+      const MTDTrackingRecHit* mtdhit = static_cast<const MTDTrackingRecHit*>((*ihit1).recHit()->hit());
+      thit = mtdhit->time();
+      thiterror = mtdhit->timeError();
+      thitpos = mtdhit->globalPosition();
+      validmtd = true;
+    } else if (ihitcount == 2 && ietlcount == 2) {
+      std::pair<float, float> lastStep = trs.getSegmentPathAndMom2(0);
+      float etlpathlength = std::abs(lastStep.first * c_cm_ns);
+      //
+      // The information of the two ETL hits is combined and attributed to the innermost hit
+      //
+      if (etlpathlength == 0.f) {
+        validpropagation = false;
+      } else {
+        pathlength -= etlpathlength;
+        trs.removeFirstSegment();
+        const MTDTrackingRecHit* mtdhit1 = static_cast<const MTDTrackingRecHit*>((*ihit1).recHit()->hit());
+        const MTDTrackingRecHit* mtdhit2 = static_cast<const MTDTrackingRecHit*>((*(ihit1 + 1)).recHit()->hit());
+        TrackTofPidInfo tofInfo = computeTrackTofPidInfo(
+            lastStep.second, etlpathlength, trs, mtdhit1->time(), mtdhit1->timeError(), 0.f, 0.f, true, TofCalc::kCost);
+        //
+        // Protect against incompatible times
+        //
+        float err1 = tofInfo.dterror2;
+        float err2 = mtdhit2->timeError() * mtdhit2->timeError();
+        if (cms_rounding::roundIfNear0(err1) == 0.f || cms_rounding::roundIfNear0(err2) == 0.f) {
+          edm::LogError("BaseExtenderWithMTD")
+              << "MTD tracking hits with zero time uncertainty: " << err1 << " " << err2;
+        } else {
+          if ((tofInfo.dt - mtdhit2->time()) * (tofInfo.dt - mtdhit2->time()) < (err1 + err2) * etlTimeChi2Cut_) {
+            //
+            // Subtract the ETL time of flight from the outermost measurement, and combine it in a weighted average with the innermost
+            // the mass ambiguity related uncertainty on the time of flight is added as an additional uncertainty
+            //
+            err1 = 1.f / err1;
+            err2 = 1.f / err2;
+            thiterror = 1.f / (err1 + err2);
+            thit = (tofInfo.dt * err1 + mtdhit2->time() * err2) * thiterror;
+            thiterror = std::sqrt(thiterror);
+            thitpos = mtdhit2->globalPosition();
+            LogTrace("BaseExtenderWithMTD")
+                << "BaseExtenderWithMTD: p trk = " << p.mag() << " ETL hits times/errors: 1) " << mtdhit1->time()
+                << " +/- " << mtdhit1->timeError() << " , 2) " << mtdhit2->time() << " +/- " << mtdhit2->timeError()
+                << " extrapolated time1: " << tofInfo.dt << " +/- " << tofInfo.dterror << " average = " << thit
+                << " +/- " << thiterror << "\n    hit1 pos: " << mtdhit1->globalPosition()
+                << " hit2 pos: " << mtdhit2->globalPosition() << " etl path length " << etlpathlength << std::endl;
+            validmtd = true;
+          } else {
+            // if back extrapolated time of the outermost measurement not compatible with the innermost, keep the one with smallest error
+            if (err1 <= err2) {
+              thit = tofInfo.dt;
+              thiterror = tofInfo.dterror;
+              validmtd = true;
+            } else {
+              thit = mtdhit2->time();
+              thiterror = mtdhit2->timeError();
+              validmtd = true;
+            }
+          }
+        }
+      }
+    } else {
+      edm::LogInfo("BaseExtenderWithMTD")
+          << "MTD hits #" << ihitcount << "ETL hits #" << ietlcount << " anomalous pattern, skipping...";
+    }
+
+    if (validmtd && validpropagation) {
+      //here add the PID uncertainty for later use in the 1st step of 4D vtx reconstruction
+      TrackTofPidInfo tofInfo = computeTrackTofPidInfo(
+          p.mag2(), pathlength, trs, thit, thiterror, 0.f, 0.f, true, TofCalc::kSegm, SigmaTofCalc::kCost);
+
+      pathLengthOut = pathlength;  // set path length if we've got a timing hit
+      tmtdOut = thit;
+      sigmatmtdOut = thiterror;
+      tmtdPosOut = thitpos;
+      t0 = tofInfo.dt;
+      covt0t0 = tofInfo.dterror2;
+      betaOut = tofInfo.beta_pi;
+      covbetabeta = tofInfo.betaerror * tofInfo.betaerror;
+      tofpi = tofInfo.dt_pi;
+      tofk = tofInfo.dt_k;
+      tofp = tofInfo.dt_p;
+      sigmatofpi = tofInfo.sigma_dt_pi;
+      sigmatofk = tofInfo.sigma_dt_k;
+      sigmatofp = tofInfo.sigma_dt_p;
+    }
+  }
+
+  return routput();
+}
+
+reco::TrackExtra BaseExtenderWithMTD::buildTrackExtra(const Trajectory& trajectory) const {
+  static const string metname = "BaseExtenderWithMTD";
+
+  const Trajectory::RecHitContainer transRecHits = trajectory.recHits();
+
+  // put the collection of TrackingRecHit in the event
+
+  // sets the outermost and innermost TSOSs
+  // ToDo: validation for track states with MTD
+  TrajectoryStateOnSurface outerTSOS;
+  TrajectoryStateOnSurface innerTSOS;
+  unsigned int innerId = 0, outerId = 0;
+  TrajectoryMeasurement::ConstRecHitPointer outerRecHit;
+  DetId outerDetId;
+
+  if (trajectory.direction() == alongMomentum) {
+    LogTrace(metname) << "alongMomentum";
+    outerTSOS = trajectory.lastMeasurement().updatedState();
+    innerTSOS = trajectory.firstMeasurement().updatedState();
+    outerId = trajectory.lastMeasurement().recHit()->geographicalId().rawId();
+    innerId = trajectory.firstMeasurement().recHit()->geographicalId().rawId();
+    outerRecHit = trajectory.lastMeasurement().recHit();
+    outerDetId = trajectory.lastMeasurement().recHit()->geographicalId();
+  } else if (trajectory.direction() == oppositeToMomentum) {
+    LogTrace(metname) << "oppositeToMomentum";
+    outerTSOS = trajectory.firstMeasurement().updatedState();
+    innerTSOS = trajectory.lastMeasurement().updatedState();
+    outerId = trajectory.firstMeasurement().recHit()->geographicalId().rawId();
+    innerId = trajectory.lastMeasurement().recHit()->geographicalId().rawId();
+    outerRecHit = trajectory.firstMeasurement().recHit();
+    outerDetId = trajectory.firstMeasurement().recHit()->geographicalId();
+  } else
+    LogError(metname) << "Wrong propagation direction!";
+
+  const GeomDet* outerDet = basegtg_->idToDet(outerDetId);
+  GlobalPoint outerTSOSPos = outerTSOS.globalParameters().position();
+  bool inside = outerDet->surface().bounds().inside(outerDet->toLocal(outerTSOSPos));
+
+  GlobalPoint hitPos =
+      (outerRecHit->isValid()) ? outerRecHit->globalPosition() : outerTSOS.globalParameters().position();
+
+  if (!inside) {
+    LogTrace(metname) << "The Global Muon outerMostMeasurementState is not compatible with the recHit detector!"
+                      << " Setting outerMost postition to recHit position if recHit isValid: "
+                      << outerRecHit->isValid();
+    LogTrace(metname) << "From " << outerTSOSPos << " to " << hitPos;
+  }
+
+  //build the TrackExtra
+  GlobalPoint v = (inside) ? outerTSOSPos : hitPos;
+  GlobalVector p = outerTSOS.globalParameters().momentum();
+  math::XYZPoint outpos(v.x(), v.y(), v.z());
+  math::XYZVector outmom(p.x(), p.y(), p.z());
+
+  v = innerTSOS.globalParameters().position();
+  p = innerTSOS.globalParameters().momentum();
+  math::XYZPoint inpos(v.x(), v.y(), v.z());
+  math::XYZVector inmom(p.x(), p.y(), p.z());
+
+  reco::TrackExtra trackExtra(outpos,
+                              outmom,
+                              true,
+                              inpos,
+                              inmom,
+                              true,
+                              outerTSOS.curvilinearError(),
+                              outerId,
+                              innerTSOS.curvilinearError(),
+                              innerId,
+                              trajectory.direction(),
+                              trajectory.seedRef());
+
+  return trackExtra;
+}
+
+string BaseExtenderWithMTD::dumpLayer(const DetLayer* layer) const {
+  stringstream output;
+
+  const BoundSurface* sur = nullptr;
+  const BoundCylinder* bc = nullptr;
+  const BoundDisk* bd = nullptr;
+
+  sur = &(layer->surface());
+  if ((bc = dynamic_cast<const BoundCylinder*>(sur))) {
+    output << "  Cylinder of radius: " << bc->radius() << endl;
+  } else if ((bd = dynamic_cast<const BoundDisk*>(sur))) {
+    output << "  Disk at: " << bd->position().z() << endl;
+  }
+  return output.str();
+}

--- a/RecoMTD/TrackExtender/src/BaseExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/src/BaseExtenderWithMTD.cc
@@ -504,40 +504,6 @@ void BaseExtenderWithMTD::setParameters(const TransientTrackingRecHitBuilder* hi
 
 const TransientTrackingRecHitBuilder* BaseExtenderWithMTD::getHitBuilder() const { return basehitbuilder_; }
 
-void BaseExtenderWithMTD::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  edm::ParameterSetDescription desc, transDesc;
-  desc.add<edm::InputTag>("hitsSrc", edm::InputTag("mtdTrackingRecHits"));
-  desc.add<edm::InputTag>("beamSpotSrc", edm::InputTag("offlineBeamSpot"));
-  desc.add<edm::InputTag>("vtxSrc", edm::InputTag("offlinePrimaryVertices4D"));
-  desc.add<bool>("updateTrackTrajectory", true);
-  desc.add<bool>("updateTrackExtra", true);
-  desc.add<bool>("updateTrackHitPattern", true);
-  desc.add<std::string>("TransientTrackBuilder", "TransientTrackBuilder");
-  desc.add<std::string>("MTDRecHitBuilder", "MTDRecHitBuilder");
-  desc.add<std::string>("Propagator", "PropagatorWithMaterialForMTD");
-  TrackTransformer::fillPSetDescription(transDesc,
-                                        false,
-                                        "KFFitterForRefitInsideOut",
-                                        "KFSmootherForRefitInsideOut",
-                                        "PropagatorWithMaterialForMTD",
-                                        "alongMomentum",
-                                        true,
-                                        "WithTrackAngle",
-                                        "MuonRecHitBuilder",
-                                        "MTDRecHitBuilder");
-  desc.add<edm::ParameterSetDescription>("TrackTransformer", transDesc);
-  desc.add<double>("estimatorMaxChi2", 500.);
-  desc.add<double>("estimatorMaxNSigma", 10.);
-  desc.add<double>("btlChi2Cut", 50.);
-  desc.add<double>("btlTimeChi2Cut", 10.);
-  desc.add<double>("etlChi2Cut", 50.);
-  desc.add<double>("etlTimeChi2Cut", 10.);
-  desc.add<bool>("useVertex", false);
-  desc.add<double>("dZCut", 0.1);
-  desc.add<double>("bsTimeSpread", 0.2);
-  descriptions.add("trackExtenderWithMTDBase", desc);
-}
-
 TransientTrackingRecHit::ConstRecHitContainer BaseExtenderWithMTD::tryBTLLayers(const TrajectoryStateOnSurface& tsos,
                                                                                 const Trajectory& traj,
                                                                                 const float pmag2,

--- a/RecoMTD/TrackExtender/src/BaseExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/src/BaseExtenderWithMTD.cc
@@ -49,12 +49,12 @@ using namespace std;
 using namespace edm;
 using namespace reco;
 
-namespace mtdtof{
+namespace mtdtof {
   // MTDHitMatchingInfo --------
   MTDHitMatchingInfo::MTDHitMatchingInfo() {
-      hit = nullptr;
-      estChi2 = std::numeric_limits<float>::max();
-      timeChi2 = std::numeric_limits<float>::max();
+    hit = nullptr;
+    estChi2 = std::numeric_limits<float>::max();
+    timeChi2 = std::numeric_limits<float>::max();
   };
 
   //Operator used to sort the hits while performing the matching step at the MTD
@@ -82,9 +82,9 @@ namespace mtdtof{
     segmentSigmaMom_.emplace_back(sigmaMom);
     nSegment_++;
 
-    LogTrace("BaseExtenderWithMTD") << "addSegment # " << nSegment_ << " s = " << tPath
-                                     << " p = " << std::sqrt(tMom2) << " sigma_p = " << sigmaMom
-                                     << " sigma_p/p = " << sigmaMom / std::sqrt(tMom2) * 100 << " %";
+    LogTrace("BaseExtenderWithMTD") << "addSegment # " << nSegment_ << " s = " << tPath << " p = " << std::sqrt(tMom2)
+                                    << " sigma_p = " << sigmaMom << " sigma_p/p = " << sigmaMom / std::sqrt(tMom2) * 100
+                                    << " %";
 
     return nSegment_;
   };
@@ -97,17 +97,16 @@ namespace mtdtof{
       tof += segmentPathOvc_[iSeg] / beta;
 
       LogTrace("BaseExtenderWithMTD") << " TOF Segment # " << iSeg + 1 << " p = " << std::sqrt(segmentMom2_[iSeg])
-                                       << " tof = " << tof;
+                                      << " tof = " << tof;
 
 #ifdef EDM_ML_DEBUG
       float sigma_tof = segmentPathOvc_[iSeg] * segmentSigmaMom_[iSeg] /
                         (segmentMom2_[iSeg] * sqrt(segmentMom2_[iSeg] + 1 / mass_inv2) * mass_inv2);
 
       LogTrace("BaseExtenderWithMTD") << "TOF Segment # " << iSeg + 1 << std::fixed << std::setw(6)
-                                       << " tof segment = " << segmentPathOvc_[iSeg] / beta << std::scientific
-                                       << "+/- " << sigma_tof << std::fixed
-                                       << "(rel. err. = " << sigma_tof / (segmentPathOvc_[iSeg] / beta) * 100
-                                       << " %)";
+                                      << " tof segment = " << segmentPathOvc_[iSeg] / beta << std::scientific << "+/- "
+                                      << sigma_tof << std::fixed
+                                      << "(rel. err. = " << sigma_tof / (segmentPathOvc_[iSeg] / beta) * 100 << " %)";
 #endif
     }
     return tof;
@@ -157,7 +156,7 @@ namespace mtdtof{
     }
     return std::make_pair(segmentPathOvc_[iSegment], segmentMom2_[iSegment]);
   };
-  
+
   const TrackTofPidInfo computeTrackTofPidInfo(float magp2,
                                                float length,
                                                TrackSegments trs,
@@ -338,14 +337,14 @@ namespace mtdtof{
       trs.addSegment(layerpathlength, (it + 1)->updatedState().globalMomentum().mag2(), sigma_p);
 
       LogTrace("BaseExtenderWithMTD") << "TSOS " << std::fixed << std::setw(4) << trs.size() << " R_i " << std::fixed
-                                       << std::setw(14) << it->updatedState().globalPosition().perp() << " z_i "
-                                       << std::fixed << std::setw(14) << it->updatedState().globalPosition().z()
-                                       << " R_e " << std::fixed << std::setw(14)
-                                       << (it + 1)->updatedState().globalPosition().perp() << " z_e " << std::fixed
-                                       << std::setw(14) << (it + 1)->updatedState().globalPosition().z() << " p "
-                                       << std::fixed << std::setw(14) << (it + 1)->updatedState().globalMomentum().mag()
-                                       << " dp " << std::fixed << std::setw(14)
-                                       << (it + 1)->updatedState().globalMomentum().mag() - oldp;
+                                      << std::setw(14) << it->updatedState().globalPosition().perp() << " z_i "
+                                      << std::fixed << std::setw(14) << it->updatedState().globalPosition().z()
+                                      << " R_e " << std::fixed << std::setw(14)
+                                      << (it + 1)->updatedState().globalPosition().perp() << " z_e " << std::fixed
+                                      << std::setw(14) << (it + 1)->updatedState().globalPosition().z() << " p "
+                                      << std::fixed << std::setw(14) << (it + 1)->updatedState().globalMomentum().mag()
+                                      << " dp " << std::fixed << std::setw(14)
+                                      << (it + 1)->updatedState().globalMomentum().mag() - oldp;
       oldp = (it + 1)->updatedState().globalMomentum().mag();
     }
 
@@ -364,12 +363,12 @@ namespace mtdtof{
     trs.addSegment(pathlength2, tscblPCA.momentum().mag2(), sigma_p);
 
     LogTrace("BaseExtenderWithMTD") << "TSOS " << std::fixed << std::setw(4) << trs.size() << " R_e " << std::fixed
-                                     << std::setw(14) << tscblPCA.position().perp() << " z_e " << std::fixed
-                                     << std::setw(14) << tscblPCA.position().z() << " p " << std::fixed << std::setw(14)
-                                     << tscblPCA.momentum().mag() << " dp " << std::fixed << std::setw(14)
-                                     << tscblPCA.momentum().mag() - oldp << " sigma_p = " << std::fixed << std::setw(14)
-                                     << sigma_p << " sigma_p/p = " << std::fixed << std::setw(14)
-                                     << sigma_p / tscblPCA.momentum().mag() * 100 << " %";
+                                    << std::setw(14) << tscblPCA.position().perp() << " z_e " << std::fixed
+                                    << std::setw(14) << tscblPCA.position().z() << " p " << std::fixed << std::setw(14)
+                                    << tscblPCA.momentum().mag() << " dp " << std::fixed << std::setw(14)
+                                    << tscblPCA.momentum().mag() - oldp << " sigma_p = " << std::fixed << std::setw(14)
+                                    << sigma_p << " sigma_p/p = " << std::fixed << std::setw(14)
+                                    << sigma_p / tscblPCA.momentum().mag() * 100 << " %";
 
     return validpropagation;
   };
@@ -476,7 +475,7 @@ namespace mtdtof{
       }
     }
   };
-}  // namespace
+}  // namespace mtdtof
 
 // BaseExtenderWithMTD ----------
 
@@ -497,14 +496,13 @@ BaseExtenderWithMTD::BaseExtenderWithMTD(const ParameterSet& iConfig)
 
 BaseExtenderWithMTD::~BaseExtenderWithMTD() = default;
 
-void BaseExtenderWithMTD::setParameters(const TransientTrackingRecHitBuilder* hitbuilder, const GlobalTrackingGeometry* gtg) {
+void BaseExtenderWithMTD::setParameters(const TransientTrackingRecHitBuilder* hitbuilder,
+                                        const GlobalTrackingGeometry* gtg) {
   basehitbuilder_ = hitbuilder;
   basegtg_ = gtg;
 }
 
-const TransientTrackingRecHitBuilder* BaseExtenderWithMTD::getHitBuilder() const{
-  return basehitbuilder_;
-}
+const TransientTrackingRecHitBuilder* BaseExtenderWithMTD::getHitBuilder() const { return basehitbuilder_; }
 
 void BaseExtenderWithMTD::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc, transDesc;
@@ -540,27 +538,26 @@ void BaseExtenderWithMTD::fillDescriptions(edm::ConfigurationDescriptions& descr
   descriptions.add("trackExtenderWithMTDBase", desc);
 }
 
-TransientTrackingRecHit::ConstRecHitContainer BaseExtenderWithMTD::tryBTLLayers(
-    const TrajectoryStateOnSurface& tsos,
-    const Trajectory& traj,
-    const float pmag2,
-    const float pathlength0,
-    const TrackSegments& trs0,
-    const MTDTrackingDetSetVector& hits,
-    const MTDDetLayerGeometry* geo,
-    const MagneticField* field,
-    const Propagator* prop,
-    const reco::BeamSpot& bs,
-    const float vtxTime,
-    const float vtxTimeError,
-    MTDHitMatchingInfo& bestHit) const {
+TransientTrackingRecHit::ConstRecHitContainer BaseExtenderWithMTD::tryBTLLayers(const TrajectoryStateOnSurface& tsos,
+                                                                                const Trajectory& traj,
+                                                                                const float pmag2,
+                                                                                const float pathlength0,
+                                                                                const TrackSegments& trs0,
+                                                                                const MTDTrackingDetSetVector& hits,
+                                                                                const MTDDetLayerGeometry* geo,
+                                                                                const MagneticField* field,
+                                                                                const Propagator* prop,
+                                                                                const reco::BeamSpot& bs,
+                                                                                const float vtxTime,
+                                                                                const float vtxTimeError,
+                                                                                MTDHitMatchingInfo& bestHit) const {
   const vector<const DetLayer*>& layers = geo->allBTLLayers();
 
   TransientTrackingRecHit::ConstRecHitContainer output;
   bestHit = MTDHitMatchingInfo();
   for (const DetLayer* ilay : layers) {
     LogTrace("BaseExtenderWithMTD") << "Hit search: BTL layer at R= "
-                                     << static_cast<const BarrelDetLayer*>(ilay)->specificSurface().radius();
+                                    << static_cast<const BarrelDetLayer*>(ilay)->specificSurface().radius();
 
     fillMatchingHits(
         ilay, tsos, traj, pmag2, pathlength0, trs0, hits, prop, bs, vtxTime, vtxTimeError, output, bestHit);
@@ -569,20 +566,19 @@ TransientTrackingRecHit::ConstRecHitContainer BaseExtenderWithMTD::tryBTLLayers(
   return output;
 }
 
-TransientTrackingRecHit::ConstRecHitContainer BaseExtenderWithMTD::tryETLLayers(
-    const TrajectoryStateOnSurface& tsos,
-    const Trajectory& traj,
-    const float pmag2,
-    const float pathlength0,
-    const TrackSegments& trs0,
-    const MTDTrackingDetSetVector& hits,
-    const MTDDetLayerGeometry* geo,
-    const MagneticField* field,
-    const Propagator* prop,
-    const reco::BeamSpot& bs,
-    const float vtxTime,
-    const float vtxTimeError,
-    MTDHitMatchingInfo& bestHit) const {
+TransientTrackingRecHit::ConstRecHitContainer BaseExtenderWithMTD::tryETLLayers(const TrajectoryStateOnSurface& tsos,
+                                                                                const Trajectory& traj,
+                                                                                const float pmag2,
+                                                                                const float pathlength0,
+                                                                                const TrackSegments& trs0,
+                                                                                const MTDTrackingDetSetVector& hits,
+                                                                                const MTDDetLayerGeometry* geo,
+                                                                                const MagneticField* field,
+                                                                                const Propagator* prop,
+                                                                                const reco::BeamSpot& bs,
+                                                                                const float vtxTime,
+                                                                                const float vtxTimeError,
+                                                                                MTDHitMatchingInfo& bestHit) const {
   const vector<const DetLayer*>& layers = geo->allETLLayers();
 
   TransientTrackingRecHit::ConstRecHitContainer output;
@@ -659,7 +655,7 @@ void BaseExtenderWithMTD::fillMatchingHits(const DetLayer* ilay,
     //check hits to pass minimum quality matching requirements
     auto const& firstHit = *hitsInLayer.begin();
     LogTrace("BaseExtenderWithMTD") << "BaseExtenderWithMTD: matching trial 1: estChi2= " << firstHit.estChi2
-                                     << " timeChi2= " << firstHit.timeChi2;
+                                    << " timeChi2= " << firstHit.timeChi2;
     if (firstHit.estChi2 < spaceChi2Cut && firstHit.timeChi2 < timeChi2Cut) {
       hitMatched = true;
       output.push_back(basehitbuilder_->build(firstHit.hit));
@@ -675,7 +671,7 @@ void BaseExtenderWithMTD::fillMatchingHits(const DetLayer* ilay,
     if (!hitsInLayer.empty()) {
       auto const& firstHit = *hitsInLayer.begin();
       LogTrace("BaseExtenderWithMTD") << "BaseExtenderWithMTD: matching trial 2: estChi2= " << firstHit.estChi2
-                                       << " timeChi2= " << firstHit.timeChi2;
+                                      << " timeChi2= " << firstHit.timeChi2;
       if (firstHit.timeChi2 < timeChi2Cut) {
         if (firstHit.estChi2 < spaceChi2Cut) {
           hitMatched = true;
@@ -689,15 +685,16 @@ void BaseExtenderWithMTD::fillMatchingHits(const DetLayer* ilay,
 
 #ifdef EDM_ML_DEBUG
   if (hitMatched) {
-    LogTrace("BaseExtenderWithMTD") << "BaseExtenderWithMTD: matched hit with time: " << bestHit.hit->time()
-                                     << " +/- " << bestHit.hit->timeError();
+    LogTrace("BaseExtenderWithMTD") << "BaseExtenderWithMTD: matched hit with time: " << bestHit.hit->time() << " +/- "
+                                    << bestHit.hit->timeError();
   } else {
     LogTrace("BaseExtenderWithMTD") << "BaseExtenderWithMTD: no matched hit";
   }
 #endif
 }
 
-RefitDirection::GeometricalDirection BaseExtenderWithMTD::checkRecHitsOrdering(TransientTrackingRecHit::ConstRecHitContainer const& recHits) const {
+RefitDirection::GeometricalDirection BaseExtenderWithMTD::checkRecHitsOrdering(
+    TransientTrackingRecHit::ConstRecHitContainer const& recHits) const {
   if (!recHits.empty()) {
     GlobalPoint first = basegtg_->idToDet(recHits.front()->geographicalId())->position();
     GlobalPoint last = basegtg_->idToDet(recHits.back()->geographicalId())->position();
@@ -792,8 +789,7 @@ reco::Track BaseExtenderWithMTD::buildTrack(const reco::TrackRef& orig,
       }
     }
 
-    LogTrace("BaseExtenderWithMTD") << "BaseExtenderWithMTD: selected #hits " << ihitcount << " from ETL "
-                                     << ietlcount;
+    LogTrace("BaseExtenderWithMTD") << "BaseExtenderWithMTD: selected #hits " << ihitcount << " from ETL " << ietlcount;
 
     auto ihit1 = trajWithMtd.measurements().cbegin();
     if (ihitcount == 1) {


### PR DESCRIPTION
#### PR description:

This PR intends to introduce the first muon extender with MTD. The pre-existing `TrackExtenderWithMTD` code is reorganized in one base class (`BaseExtenderWithMTD`) that contains all the common code related to the MTD hit objects and functions, and some other common functionalities. Therefore, two EDProducers are created: `TrackExtenderWithMTD` and `MuonExtenderWithMTD`. No change is expected in the `TrackExtenderWithMTD` producer. It's a lightweight version of the old code, since most of it was moved to the base class. The `MuonExtenderWithMTD` contains the needed customizations to run using `reco::Muon` or `reco::RecoChargedCandidate` as input. Currently, the code requires the muon to have a tracker track, which is extended to the MTD in the same way as in the `TrackExtenderWithMTD`.

This effort started within a phase-2 HLT task with the aim of studying the possibility of improving the muon isolation using timing information.

The code is organized as follows. 

Before:

- plugins/TrackExtenderWithMTD.cc


After:

- src/BaseExtenderWithMTD.cc
- interface/BaseExtenderWithMTD.h
- plugins/TrackExtenderWithMTD.cc
- plugins/TrackExtenderWithMTD.h
- plugins/MuonExtenderWithMTD.cc
- plugins/MuonExtenderWithMTD.h

#### PR validation:

A simple validation has been performed to cross-check that the code behaves as expected. Results are linked on [this slides](https://cernbox.cern.ch/s/5jMYQp3l3pByIj9).

Tagging Muon POG conveners: @CeliaFernandez @bonanomi 
Tagging MTD conveners: @fabiocos @martinamalberti 
Tagging other people involved in previous discussions: @24LopezR