### PR TITLE
[GCC15]: (alca-db) Fix build warnings in CalibTracker/SiStripQuality …

### DIFF
--- a/CalibTracker/SiStripQuality/src/SiStripHotStripAlgorithmFromClusterOccupancy.cc
+++ b/CalibTracker/SiStripQuality/src/SiStripHotStripAlgorithmFromClusterOccupancy.cc
@@ -266,7 +266,7 @@ void SiStripHotStripAlgorithmFromClusterOccupancy::iterativeSearch(pHisto& histo
   evaluatePoissonian(vPoissonProbs, meanVal);
 
   // Find median occupancy, taking into account only good strips
-  unsigned int goodstripentries[128];
+  unsigned int goodstripentries[128] = {};
   int nGoodStrips = 0;
   for (size_t i = ibinStart; i < ibinStop; ++i) {
     if (ishot[(apv * 128) + i - 1] == 0) {

--- a/CondCore/SiPixelPlugins/plugins/SiPixelDynamicInefficiency_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelDynamicInefficiency_PayloadInspector.cc
@@ -73,7 +73,7 @@ namespace {
       const std::map<uint32_t, double>& PixelGeomFactorsDBIn = payload->getPixelGeomFactors();
 
       // first fill
-      for (const auto db_factor : PixelGeomFactorsDBIn) {
+      for (const auto& db_factor : PixelGeomFactorsDBIn) {
         int subid = DetId(db_factor.first).subdetId();
         int shift = (subid == static_cast<int>(PixelSubdetector::PixelBarrel)) ? BPixRocIdShift : FPixRocIdShift;
         unsigned int rocMask = rocIdMaskBits << shift;


### PR DESCRIPTION
- Initialize local array in SiStripHotStripAlgorithmFromClusterOccupancy to avoid
  uninitialized use flagged by GCC 15.
`- unsigned int goodstripentries[128];`
`+ unsigned int goodstripentries[128] = {};`
[logs](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc15/CMSSW_16_1_X_2026-02-03-1100/CalibTracker/SiStripQuality)

- Use const reference in range-based loop in SiPixelDynamicInefficiency_PayloadInspector
  to avoid unnecessary copies.
  `- for (const auto db_factor : PixelGeomFactorsDBIn) {
    // use db_factor
}`
`+ for (const auto& db_factor : PixelGeomFactorsDBIn) {
    // use db_factor
}`
[logs](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc15/CMSSW_16_1_X_2026-02-03-1100/CondCore/SiPixelPlugins)