### PR TITLE
Adjust TICL track linking to work with (extended) pixel tracks

### DIFF
--- a/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.cc
@@ -379,8 +379,17 @@ void GNNInterpretationAlgo::makeCandidates(const Inputs& input,
   for (unsigned trkId : candidateTrackIds) {
     const auto& tk = tracks[trkId];
     const int side = (tk.eta() > 0);
+    FreeTrajectoryState fts;
 
-    const auto& fts = trajectoryStateTransform::outerFreeState(tk, bFieldProd);
+    // Check whether the outer state is actually valid
+    if (tk.outerOk()) {
+      // Use outer state if available
+      fts = trajectoryStateTransform::outerFreeState(tk, bFieldProd);
+    } else {
+      // Fallback: use PCA (reference point)
+      fts = trajectoryStateTransform::initialFreeState(tk, bFieldProd);
+    }
+
     // to the HGCal front
     const auto tsosFront = prop.propagate(fts, firstDisk_[side]->surface());
     if (tsosFront.isValid()) {

--- a/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
@@ -246,7 +246,17 @@ void GeneralInterpretationAlgo::makeCandidates(const Inputs &input,
   for (auto const i : candidateTrackIds) {
     const auto &tk = tracks[i];
     int iSide = int(tk.eta() > 0);
-    const auto &fts = trajectoryStateTransform::outerFreeState((tk), bFieldProd);
+    FreeTrajectoryState fts;
+
+    // Check whether the outer state is actually valid
+    if (tk.outerOk()) {
+      // Use outer state if available
+      fts = trajectoryStateTransform::outerFreeState(tk, bFieldProd);
+    } else {
+      // Fallback: use PCA (reference point)
+      fts = trajectoryStateTransform::initialFreeState(tk, bFieldProd);
+    }
+
     // to the HGCal front
     const auto &tsos = prop.propagate(fts, firstDisk_[iSide]->surface());
     if (tsos.isValid()) {

--- a/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
+++ b/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
@@ -378,6 +378,15 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
 
   auto getPathLength =
       [&](const reco::Track &track, float zVal) {
+        // Bail out early if inner/outer surfaces are not available
+        if (!track.innerOk() || !track.outerOk()) {
+          if (edm::isDebugEnabled()) {
+            LogDebug("TICLCandidateProducer")
+                << "Not able to use the track to compute the path length. A straight line will be used instead.";
+          }
+          return 0.f;
+        }
+
         const auto &fts_inn = trajectoryStateTransform::innerFreeState(track, bFieldProd);
         const auto &fts_out = trajectoryStateTransform::outerFreeState(track, bFieldProd);
         const auto &surf_inn = trajectoryStateTransform::innerStateOnSurface(track, *trackingGeometry_, bFieldProd);


### PR DESCRIPTION
#### PR description:

While developing HLT reconstruction for the NGT scouting stream which employs (extended) pixel tracks in lieu of full tracks  (this is technically implemented in cmssw by the joint usage of the `ngtScouting`+`phase2CAExtension` modifiers)  we observed a problem in the jet scale in the region covered by HGCal.
This was traced back by the lack of linking of tracksters to tracks. In ticl v4 this is implemented in `RecoHGCal/TICL/plugins/LinkingAlgoByDirectionGeometric.cc` (which is not touched in this PR as it's slated for deletion in https://github.com/cms-sw/cmssw/pull/49932).
More specifically the issue is that pixel tracks extras currently do not implement inner and outer state, which lead to failed track propagation. 
Indeed when checking the efficiency of charged hadrons in the HGCal validation in this configuration, the MonitorElement was found empty.
We propose a simple patch (c62220f8dc68e547804f169ed5bd3ec7fba48640) to use instead the state of the track at the PCA (which instead is currently available for the pixel tracks) when the outer state is not defined.
Additionally in ticlv5 we need an additional patch to handle the computation of the track length for the timing computation. This is dealt with by commit d61292f50c501e3832b976efa67db15d0889dfc0, by simply bailing out the track length computation when the inner / outer states are invalid.
In the long term we foresee to change the Pixel track format to support track states at different surfaces.

#### PR validation:

We re-run with the fix and we do observe non-null charged hadron efficiency in HGcal:

| Before this PR | After this PR |
| ------------- | ------------- |
| <img width="778" height="1007" alt="Screenshot from 2026-02-04 14-00-41" src="https://github.com/user-attachments/assets/8cafddf0-df1d-45f8-ae74-50f37f04978b" /> | <img width="778" height="1007" alt="image" src="https://github.com/user-attachments/assets/6f62c0c8-0b91-4be9-9bf3-386de7a29053" /> |

In addition we checked that the scale using pixel tracks for linking in the endcaps returns to "regular" values:

<img width="1920" height="1513" alt="image" src="https://github.com/user-attachments/assets/048fecca-7a96-402b-a413-e089cb905aee" />

Finally we technically tested that the `runTheMatrix.py -l ph2_hlt` runs without problems

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

Cc: @elenavernazza @rovere
FYI: @felicepantaleo @waredjeb @AuroraPerego 