### PR TITLE
[GCC15] (DQM) Fix build warnings DQM/SiStripMonitorClient & Validatio…

### DIFF
--- a/DQM/SiStripMonitorClient/plugins/SiStripDcsInfo.cc
+++ b/DQM/SiStripMonitorClient/plugins/SiStripDcsInfo.cc
@@ -344,7 +344,7 @@ void SiStripDcsInfo::addBadModules(DQMStore& dqm_store) {
 
   for (auto const& pr : SubDetMEsMap) {
     auto const& lumiCountBadModules = pr.second.NLumiDetectorIsFaulty;
-    for (auto const [ibad, nBadLumi] : lumiCountBadModules) {
+    for (auto const& [ibad, nBadLumi] : lumiCountBadModules) {
       if (nBadLumi <= MaxAcceptableBadDcsLumi_)
         continue;
       std::string bad_module_folder = mechanical_dir + "/" + pr.second.folder_name +

--- a/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc
+++ b/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc
@@ -129,7 +129,7 @@ private:
       TDirectory *d_top = gDirectory;
 
       gDirectory = d_top->mkdir("h_xi_nTracks");
-      for (const auto& p : m_h_xi_nTracks) {
+      for (const auto &p : m_h_xi_nTracks) {
         char buf[100];
         sprintf(buf, "h_xi_nTracks_%u", p.first);
         p.second->Write(buf);
@@ -340,7 +340,7 @@ private:
       TDirectory *d_top = gDirectory;
 
       gDirectory = d_top->mkdir("h_xi_nTracks");
-      for (const auto& p : m_h_xi_nTracks) {
+      for (const auto &p : m_h_xi_nTracks) {
         char buf[100];
         sprintf(buf, "h_xi_nTracks_%u", p.first);
         p.second->Write(buf);

--- a/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc
+++ b/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc
@@ -129,7 +129,7 @@ private:
       TDirectory *d_top = gDirectory;
 
       gDirectory = d_top->mkdir("h_xi_nTracks");
-      for (const auto p : m_h_xi_nTracks) {
+      for (const auto& p : m_h_xi_nTracks) {
         char buf[100];
         sprintf(buf, "h_xi_nTracks_%u", p.first);
         p.second->Write(buf);
@@ -340,7 +340,7 @@ private:
       TDirectory *d_top = gDirectory;
 
       gDirectory = d_top->mkdir("h_xi_nTracks");
-      for (const auto p : m_h_xi_nTracks) {
+      for (const auto& p : m_h_xi_nTracks) {
         char buf[100];
         sprintf(buf, "h_xi_nTracks_%u", p.first);
         p.second->Write(buf);


### PR DESCRIPTION
 Used const references in range-based for loops to avoid unnecessary copies

- DQM/SiStripMonitorClient/plugins/SiStripDcsInfo.cc
`-    for (auto const [ibad, nBadLumi] : lumiCountBadModules) {`
`+    for (auto const& [ibad, nBadLumi] : lumiCountBadModules) {`
[logs](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc15/CMSSW_16_1_X_2026-02-03-1100/DQM/SiStripMonitorClient)

- Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc
`-      for (const auto p : m_h_xi_nTracks) {`
`+      for (const auto& p : m_h_xi_nTracks) {`
[logs](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc15/CMSSW_16_1_X_2026-02-03-1100/Validation/CTPPS)