### PR TITLE
PerfTools/AllocMonitor: ModuleEventAllocMonitor add the option to skip module by label. 

### DIFF
--- a/PerfTools/AllocMonitor/README.md
+++ b/PerfTools/AllocMonitor/README.md
@@ -110,6 +110,7 @@ list of module names, and  an optional number of initial events to skip are spec
 service in the configuration. The parameters are
 - `filename`: name of file to which to write reports
 - `moduleNames`: list of modules which should have their information added to the file. An empty list specifies all modules should be included.
+- `skippedModuleNames`: list of module which should have their information skipped. 
 - `nEventsToSkip`: the number of initial events that must be processed before reporting happens.
 
 The beginning of the file contains a description of the structure and contents of the file.

--- a/PerfTools/AllocMonitor/plugins/ModuleEventAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/ModuleEventAllocMonitor.cc
@@ -257,7 +257,7 @@ public:
           std::sort(moduleIDs_.begin(), moduleIDs_.end());
         } else {
           s << "# Skipping module" << description.moduleLabel() << " " << description.moduleName() << " "
-              << description.id() << " # skipped\n";
+            << description.id() << " # skipped\n";
         }
         file->write(s.str());
       });

--- a/PerfTools/AllocMonitor/plugins/ModuleEventAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/ModuleEventAllocMonitor.cc
@@ -252,8 +252,7 @@ public:
           file->write(s.str());
         }
       });
-    }
-    else if (not skippedModuleNames_.empty()) {
+    } else if (not skippedModuleNames_.empty()) {
       iAR.watchPreModuleConstruction([this, file](auto const& description) {
         auto found = std::find(skippedModuleNames_.begin(), skippedModuleNames_.end(), description.moduleLabel());
         if (found == skippedModuleNames_.end()) {
@@ -265,8 +264,8 @@ public:
           file->write(s.str());
         } else {
           std::stringstream s;
-          s << "# Skipping module " << description.moduleLabel() << " " << description.moduleName() << " " << description.id()
-            << " # skipped\n";
+          s << "# Skipping module" << description.moduleLabel() << " " << description.moduleName() << " "
+            << description.id() << " # skipped\n";
           file->write(s.str());
         }
       });
@@ -434,9 +433,8 @@ public:
         ->setComment(
             "Module labels for modules which should have their allocations monitored. If empty all modules will be "
             "monitored.");
-     ps.addUntracked<std::vector<std::string>>("skippedModuleNames", std::vector<std::string>())
-        ->setComment(
-            "Module labels for modules which should have their allocations ignored.");
+    ps.addUntracked<std::vector<std::string>>("skippedModuleNames", std::vector<std::string>())
+        ->setComment("Module labels for modules which should have their allocations ignored.");
     ps.addUntracked<unsigned int>("nEventsToSkip", 0)
         ->setComment(
             "Number of events to skip before turning on monitoring. If used in a multi-threaded application, "

--- a/PerfTools/AllocMonitor/plugins/ModuleEventAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/ModuleEventAllocMonitor.cc
@@ -247,7 +247,7 @@ public:
           shouldKeep = std::ranges::find(moduleNames_, description.moduleLabel()) != moduleNames_.end();
         }
         if (not skippedModuleNames_.empty()) {
-          shouldKeep = std::ranges::find(skippedModuleNames_, description.moduleLabel()) != skippedModuleNames_.end();
+          shouldKeep = std::ranges::find(skippedModuleNames_, description.moduleLabel()) == skippedModuleNames_.end();
         }
         std::stringstream s;
         if (shouldKeep) {

--- a/PerfTools/AllocMonitor/plugins/ModuleEventAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/ModuleEventAllocMonitor.cc
@@ -267,6 +267,8 @@ public:
         auto found = std::find(skippedModuleNames_.begin(), skippedModuleNames_.end(), description.moduleLabel());
         if (found != skippedModuleNames_.end()) {
           moduleIDs_.erase(moduleIDs_.begin() + moduleIndex(description.id()));
+          nModules_ = moduleIDs_.size();
+          std::sort(moduleIDs_.begin(), moduleIDs_.end());
           std::stringstream s;
           s << "# Skipping module " << description.moduleLabel() << " " << description.moduleName() << " "
             << description.id() << "\n";

--- a/PerfTools/AllocMonitor/plugins/ModuleEventAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/ModuleEventAllocMonitor.cc
@@ -210,7 +210,7 @@ class ModuleEventAllocMonitor {
 public:
   ModuleEventAllocMonitor(edm::ParameterSet const& iPS, edm::ActivityRegistry& iAR)
       : moduleNames_(iPS.getUntrackedParameter<std::vector<std::string>>("moduleNames")),
-        skippedNames_(iPS.getUntrackedParameter<std::vector<std::string>>("skippedModuleNames")),
+        skippedModuleNames_(iPS.getUntrackedParameter<std::vector<std::string>>("skippedModuleNames")),
         nEventsToSkip_(iPS.getUntrackedParameter<unsigned int>("nEventsToSkip")),
         filter_(&moduleIDs_) {
     (void)cms::perftools::AllocMonitorRegistry::instance().createAndRegisterMonitor<MonitorAdaptor>();
@@ -262,10 +262,10 @@ public:
         file->write(s.str());
       });
     }
-    if (not skippedNames_.empty()) {
+    if (not skippedModuleNames_.empty()) {
       iAR.watchPreModuleConstruction([this, file](auto const& description) {
-        auto found = std::find(skippedNames_.begin(), skippedNames_.end(), description.moduleLabel());
-        if (found != skippedNames_.end()) {
+        auto found = std::find(skippedModuleNames_.begin(), skippedModuleNames_.end(), description.moduleLabel());
+        if (found != skippedModuleNames_.end()) {
           moduleIDs_.erase(moduleIDs_.begin() + moduleIndex(description.id()));
           std::stringstream s;
           s << "# Skipping module " << description.moduleLabel() << " " << description.moduleName() << " "
@@ -456,7 +456,7 @@ private:
   std::vector<std::atomic<unsigned int>> streamNFinishedModules_;
   std::vector<std::atomic<unsigned int>> streamSync_;
   std::vector<std::string> moduleNames_;
-  std::vector<std::string> skippedNames_;
+  std::vector<std::string> skippedModuleNames_;
   std::vector<int> moduleIDs_;
   unsigned int nStreams_ = 0;
   unsigned int nModules_ = 0;

--- a/PerfTools/AllocMonitor/plugins/ModuleEventAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/ModuleEventAllocMonitor.cc
@@ -265,7 +265,7 @@ public:
           file->write(s.str());
         } else {
           std::stringstream s;
-          s << "# Skipping module" << description.moduleLabel() << " " << description.moduleName() << " " << description.id()
+          s << "# Skipping module " << description.moduleLabel() << " " << description.moduleName() << " " << description.id()
             << " # skipped\n";
           file->write(s.str());
         }

--- a/PerfTools/AllocMonitor/plugins/ModuleEventAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/ModuleEventAllocMonitor.cc
@@ -252,6 +252,20 @@ public:
           file->write(s.str());
         }
       });
+    }
+    else if (not skippedModuleNames_.empty()) {
+      iAR.watchPreModuleConstruction([this, file](auto const& description) {
+        auto found = std::find(skippedModuleNames_.begin(), skippedModuleNames_.end(), description.moduleLabel());
+        if (found == skippedModuleNames_.end()) {
+          moduleIDs_.push_back(description.id());
+          nModules_ = moduleIDs_.size();
+          std::sort(moduleIDs_.begin(), moduleIDs_.end());
+          std::stringstream s;
+          s << "# Skipping module " << description.moduleLabel() << " " << description.moduleName() << " "
+            << description.id() << "\n";
+          file->write(s.str());
+        }
+      });
     } else {
       iAR.watchPreModuleConstruction([this, file](auto const& description) {
         if (description.id() + 1 > nModules_) {
@@ -262,20 +276,7 @@ public:
         file->write(s.str());
       });
     }
-    if (not skippedModuleNames_.empty()) {
-      iAR.watchPreModuleConstruction([this, file](auto const& description) {
-        auto found = std::find(skippedModuleNames_.begin(), skippedModuleNames_.end(), description.moduleLabel());
-        if (found != skippedModuleNames_.end()) {
-          moduleIDs_.erase(moduleIDs_.begin() + moduleIndex(description.id()));
-          nModules_ = moduleIDs_.size();
-          std::sort(moduleIDs_.begin(), moduleIDs_.end());
-          std::stringstream s;
-          s << "# Skipping module " << description.moduleLabel() << " " << description.moduleName() << " "
-            << description.id() << "\n";
-          file->write(s.str());
-        }
-      });
-    }
+
     if (nEventsToSkip_ > 0) {
       iAR.watchPreSourceEvent([this](auto) {
         ++nEventsStarted_;

--- a/PerfTools/AllocMonitor/plugins/ModuleEventAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/ModuleEventAllocMonitor.cc
@@ -261,8 +261,12 @@ public:
           nModules_ = moduleIDs_.size();
           std::sort(moduleIDs_.begin(), moduleIDs_.end());
           std::stringstream s;
-          s << "# Skipping module " << description.moduleLabel() << " " << description.moduleName() << " "
-            << description.id() << "\n";
+          s << "@ " << description.moduleLabel() << " " << description.moduleName() << " " << description.id() << "\n";
+          file->write(s.str());
+        } else {
+          std::stringstream s;
+          s << "# Skipping module" << description.moduleLabel() << " " << description.moduleName() << " " << description.id()
+            << " # skipped\n";
           file->write(s.str());
         }
       });

--- a/PerfTools/AllocMonitor/plugins/ModuleEventAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/ModuleEventAllocMonitor.cc
@@ -427,6 +427,9 @@ public:
         ->setComment(
             "Module labels for modules which should have their allocations monitored. If empty all modules will be "
             "monitored.");
+     ps.addUntracked<std::vector<std::string>>("skippedModuleNames", std::vector<std::string>())
+        ->setComment(
+            "Module labels for modules which should have their allocations ignored.");
     ps.addUntracked<unsigned int>("nEventsToSkip", 0)
         ->setComment(
             "Number of events to skip before turning on monitoring. If used in a multi-threaded application, "

--- a/PerfTools/AllocMonitor/python/ModuleEventAllocMonitor.py
+++ b/PerfTools/AllocMonitor/python/ModuleEventAllocMonitor.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+def customise(process):
+    process.ModuleEventAllocMonitor = cms.Service("ModuleEventAllocMonitor",
+                                   fileName=cms.untracked.string("moduleEventAllocMonitor.log")
+                                   )
+    return(process)

--- a/PerfTools/AllocMonitor/python/ModuleEventAllocMonitor.py
+++ b/PerfTools/AllocMonitor/python/ModuleEventAllocMonitor.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 def customise(process):
     process.ModuleEventAllocMonitor = cms.Service("ModuleEventAllocMonitor",
                                    fileName=cms.untracked.string("moduleEventAllocMonitor.log"),
-                                   skippedModuleNames=cms.untracked.vstring(['mix']),
+                                   skippedModuleNames=cms.untracked.vstring(["mix"]),
                                    )
     return(process)

--- a/PerfTools/AllocMonitor/python/ModuleEventAllocMonitor.py
+++ b/PerfTools/AllocMonitor/python/ModuleEventAllocMonitor.py
@@ -2,5 +2,6 @@ import FWCore.ParameterSet.Config as cms
 def customise(process):
     process.ModuleEventAllocMonitor = cms.Service("ModuleEventAllocMonitor",
                                    fileName=cms.untracked.string("moduleEventAllocMonitor.log"),
+                                   skippedModuleNames=cms.untracked.vstring('mix',),
                                    )
     return(process)

--- a/PerfTools/AllocMonitor/python/ModuleEventAllocMonitor.py
+++ b/PerfTools/AllocMonitor/python/ModuleEventAllocMonitor.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 def customise(process):
     process.ModuleEventAllocMonitor = cms.Service("ModuleEventAllocMonitor",
                                    fileName=cms.untracked.string("moduleEventAllocMonitor.log"),
-                                   skippedModuleNames=cms.untracked.vstring('mix',),
+                                   skippedModuleNames=cms.untracked.vstring(['mix']),
                                    )
     return(process)

--- a/PerfTools/AllocMonitor/python/ModuleEventAllocMonitor.py
+++ b/PerfTools/AllocMonitor/python/ModuleEventAllocMonitor.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 def customise(process):
     process.ModuleEventAllocMonitor = cms.Service("ModuleEventAllocMonitor",
-                                   fileName=cms.untracked.string("moduleEventAllocMonitor.log")
+                                   fileName=cms.untracked.string("moduleEventAllocMonitor.log"),
                                    )
     return(process)

--- a/PerfTools/AllocMonitor/scripts/edmModuleEventAllocMonitorAnalyze.py
+++ b/PerfTools/AllocMonitor/scripts/edmModuleEventAllocMonitorAnalyze.py
@@ -245,7 +245,7 @@ if __name__=="__main__":
     if args.retained:
         printReport(reportModuleRetainingMemory(fileParser, args.eventData, args.csv), args.eventData, "average retained", "retained each event", args.maxColumn)
     if args.product:
-        printReport(reportModuleDataProductMemory(fileParser, args.eventData), args.eventData, "average data products size", "data products size each event", args.maxColumn)
+        printReport(reportModuleDataProductMemory(fileParser, args.eventData, args.csv), args.eventData, "average data products size", "data products size each event", args.maxColumn)
     if args.tempSize:
         printReport(reportModuleTemporary(fileParser, args.eventData, args.csv), args.eventData, "average temporary allocation size", "temporary allocation size each event", args.maxColumn)
     if args.nTemp:


### PR DESCRIPTION
Tested locally that "mix" module can be skipped in step2 which shortens the amount of time needed to obtain the module event allocat monitor log.