### PR TITLE
NanoAOD: add `savePUDensityVars` parameter to `NPUTablesProducer`

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/NPUTablesProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/NPUTablesProducer.cc
@@ -1,22 +1,25 @@
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "DataFormats/NanoAOD/interface/FlatTable.h"
+#include "FWCore/Utilities/interface/Exception.h"
 #include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
-
-#include <vector>
-#include <iostream>
-#include <algorithm>
 
 class NPUTablesProducer : public edm::global::EDProducer<> {
 public:
   NPUTablesProducer(edm::ParameterSet const& params)
-      : npuTag_(consumes<std::vector<PileupSummaryInfo>>(params.getParameter<edm::InputTag>("src"))),
-        pvTag_(consumes<std::vector<reco::Vertex>>(params.getParameter<edm::InputTag>("pvsrc"))),
+      : npuTag_(consumes(params.getParameter<edm::InputTag>("src"))),
+        savePUDensityVars_(params.getParameter<bool>("savePUDensityVars")),
+        pvTag_(savePUDensityVars_ ? consumes<std::vector<reco::Vertex>>(params.getParameter<edm::InputTag>("pvsrc"))
+                                  : edm::EDGetTokenT<std::vector<reco::Vertex>>{}),
         vz_(params.getParameter<std::vector<double>>("zbins")),
         savePtHatMax_(params.getParameter<bool>("savePtHatMax")) {
     produces<nanoaod::FlatTable>();
@@ -27,8 +30,15 @@ public:
   void produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSetup& iSetup) const override {
     auto npuTab = std::make_unique<nanoaod::FlatTable>(1, "Pileup", true);
 
-    const auto& pvProd = iEvent.get(pvTag_);
-    const double refpvz = pvProd.at(0).position().z();
+    double refpvz{0};
+    if (savePUDensityVars_) {
+      auto const& pvProd{iEvent.get(pvTag_)};
+      if (pvProd.empty()) {
+        throw cms::Exception("InvalidInput")
+            << "empty list of reconstructed vertices: z position of PV not available !";
+      }
+      refpvz = pvProd[0].position().z();
+    }
 
     edm::Handle<std::vector<PileupSummaryInfo>> npuInfo;
     if (iEvent.getByToken(npuTag_, npuInfo)) {
@@ -56,20 +66,21 @@ public:
         nt = npuProd[ibx].getTrueNumInteractions();
         npu = npuProd[ibx].getPU_NumInteractions();
 
-        std::vector<float> zpositions;
-        unsigned int nzpositions = npuProd[ibx].getPU_zpositions().size();
-        for (unsigned int j = 0; j < nzpositions; ++j) {
-          zpositions.push_back(npuProd[ibx].getPU_zpositions()[j]);
-          if (std::abs(zpositions.back() - refpvz) < 0.1)
-            pudensity++;  //N_PU/mm
-          auto bin = std::lower_bound(vz_.begin(), vz_.end() - 1, std::abs(zpositions.back()));
-          if (bin != vz_.end() && bin == zbin)
-            gpudensity++;
+        if (savePUDensityVars_) {
+          auto const nzpositions = npuProd[ibx].getPU_zpositions().size();
+          for (unsigned int j = 0; j < nzpositions; ++j) {
+            auto const zpos = npuProd[ibx].getPU_zpositions()[j];
+            if (std::abs(zpos - refpvz) < 0.1)
+              pudensity++;  //N_PU/mm
+            auto bin = std::lower_bound(vz_.begin(), vz_.end() - 1, std::abs(zpos));
+            if (bin != vz_.end() && bin == zbin)
+              gpudensity++;
+          }
+          gpudensity /= (20.0 * (*(zbin) - *(zbin - 1)));
         }
-        gpudensity /= (20.0 * (*(zbin) - *(zbin - 1)));
 
         if (savePtHatMax_) {
-          if (!npuProd[ibx].getPU_pT_hats().empty()) {
+          if (not npuProd[ibx].getPU_pT_hats().empty()) {
             pthatmax = *max_element(npuProd[ibx].getPU_pT_hats().begin(), npuProd[ibx].getPU_pT_hats().end());
           }
         }
@@ -94,8 +105,12 @@ public:
         "the number of pileup interactions that have been added to the event in the current bunch crossing");
     out.addColumnValue<int>("sumEOOT", eoot, "number of early out of time pileup");
     out.addColumnValue<int>("sumLOOT", loot, "number of late out of time pileup");
-    out.addColumnValue<float>("pudensity", pudensity, "PU vertices / mm");
-    out.addColumnValue<float>("gpudensity", gpudensity, "Generator-level PU vertices / mm");
+
+    if (savePUDensityVars_) {
+      out.addColumnValue<float>("pudensity", pudensity, "PU vertices / mm");
+      out.addColumnValue<float>("gpudensity", gpudensity, "Generator-level PU vertices / mm");
+    }
+
     if (savePtHatMax_) {
       out.addColumnValue<float>("pthatmax", pthatmax, "Maximum pt-hat", 10);
     }
@@ -108,17 +123,19 @@ public:
     desc.add<edm::InputTag>("pvsrc", edm::InputTag("offlineSlimmedPrimaryVertices"))->setComment("tag for the PVs");
     desc.add<std::vector<double>>("zbins", {})
         ->setComment("Z bins to compute the generator-level number of PU vertices per mm");
+    desc.add<bool>("savePUDensityVars", true)->setComment("Store quantities related to density in z of PU vertices");
     desc.add<bool>("savePtHatMax", false)->setComment("Store maximum pt-hat of PU");
     descriptions.add("puTable", desc);
   }
 
 protected:
   const edm::EDGetTokenT<std::vector<PileupSummaryInfo>> npuTag_;
-  const edm::EDGetTokenT<std::vector<reco::Vertex>> pvTag_;
 
+  const bool savePUDensityVars_;
+  const edm::EDGetTokenT<std::vector<reco::Vertex>> pvTag_;
   const std::vector<double> vz_;
 
-  bool savePtHatMax_;
+  const bool savePtHatMax_;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/NanoAOD/python/globals_cff.py
+++ b/PhysicsTools/NanoAOD/python/globals_cff.py
@@ -33,6 +33,7 @@ rhoTable = globalVariablesTableProducer.clone(
 
 puTable = cms.EDProducer("NPUTablesProducer",
         src = cms.InputTag("slimmedAddPileupInfo"),
+        savePUDensityVars = cms.bool(True),
         pvsrc = cms.InputTag("offlineSlimmedPrimaryVertices"),
         zbins = cms.vdouble( [0.0,1.7,2.6,3.0,3.5,4.2,5.2,6.0,7.5,9.0,12.0] ),
         savePtHatMax = cms.bool(True),


### PR DESCRIPTION
#### PR description:

This PR adds a new parameter named `savePUDensityVars` to the plugin `NPUTablesProducer` used in the NanoAOD step.

 - The plugin currently requires a collection of reconstructed vertices in order to fill a few variables related to the spatial density of PU interactions.
 - Using `savePUDensityVars=False` provides the possibility of not computing (nor saving) these PU-density values, so that one can still run `NPUTablesProducer` and save variables related to the true/simulated PU (`PileupSummaryInfo`) even in cases where a collection of reconstructed vertices is not available (e.g. "NanoGEN"-type workflows).

The default value of the new parameter is `True`, so the behaviour of all present workflows remains unchanged.

#### PR validation:

Manual checks with non-central wfs.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

TBD (might be useful to backport this to `16_0_X` for future Run-3 MC productions, even if only private ones).
