### PR TITLE
Update `defaultDataSets` for `D121` and `D110`

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4855,8 +4855,8 @@ defaultDataSets["2025HLTOnDigi"] = defaultDataSets["2025SimOnGen"] = defaultData
 defaultDataSets["2026HLTOnDigi"] = defaultDataSets["2026SimOnGen"] = defaultDataSets['2026']
 defaultDataSets['2024FS']='CMSSW_13_0_11-130X_mcRun3_2023_realistic_withEarly2023BS_v1_FastSim-v' #To replace with new dataset
 defaultDataSets['2025FS']='CMSSW_13_0_11-130X_mcRun3_2023_realistic_withEarly2023BS_v1_FastSim-v' #To replace with new dataset
-defaultDataSets['Run4D110']='CMSSW_15_1_0_pre5-150X_mcRun4_realistic_v1_STD_RegeneratedGS_Run4D110_noPU-v'
-defaultDataSets['Run4D121']='CMSSW_16_0_0_pre2-150X_mcRun4_realistic_v1_STD_RegeneratedGS_Run4D121_noPU-v'
+defaultDataSets['Run4D110']='CMSSW_16_1_0_pre1-150X_mcRun4_realistic_v1_STD_RegeneratedGS_Run4D110_noPU-v'
+defaultDataSets['Run4D121']='CMSSW_16_1_0_pre1-150X_mcRun4_realistic_v1_STD_RegeneratedGS_Run4D121_noPU-v'
 
 ## HIN
 defaultDataSets['2023HIN']='CCMSSW_14_1_0-PU_140X_mcRun3_2023_realistic_HI_v4_STD_2023HIN_PU-v'


### PR DESCRIPTION
This PR proposes a simple update of the default datasets used for pile-up and as GEN-SIM inputs for `D121` and `D110` workflows. This might help with a few crashes observed due to https://github.com/cms-sw/cmssw/pull/49763 and documented in https://github.com/cms-sw/cmssw/issues/49795. It's not super clear to me. 

I'm opening this just for testing at the moment, since evidence is pointing towards Run4 geometries being "bugged" from https://github.com/cms-sw/cmssw/pull/49763  on. So we wouldn't want bad samples to become the defaults. 