### PR TITLE
[16_0_X] Escape special characters in most JobReport XML elements

### DIFF
--- a/FWCore/MessageLogger/interface/xmlUtils.h
+++ b/FWCore/MessageLogger/interface/xmlUtils.h
@@ -1,0 +1,40 @@
+#ifndef FWCore_MessageLogger_xmlUtils_h
+#define FWCore_MessageLogger_xmlUtils_h
+
+#include "tinyxml2.h"
+
+#include <format>
+#include <ostream>
+#include <string_view>
+
+/**
+ * These are really an implementation detail of JobReport, but are in interface because of tests
+ */
+namespace edm::xml {
+  template <typename T>
+  void addElement(char const* elementName, T&& elementValue, std::string_view suffix, std::ostream& os) {
+    tinyxml2::XMLDocument doc;
+    tinyxml2::XMLPrinter printer(nullptr, true);  // compact mode - no extra whitespace
+
+    const char* cstr;
+    std::string formatted;
+
+    using DecayedT = std::decay_t<T>;
+    if constexpr (std::is_same_v<DecayedT, std::string>) {
+      cstr = elementValue.c_str();
+    } else if constexpr (std::is_same_v<DecayedT, char const*> || std::is_same_v<DecayedT, char*>) {
+      cstr = elementValue;
+    } else {
+      formatted = std::format("{}", elementValue);
+      cstr = formatted.c_str();
+    }
+
+    // Memory of element is managed by doc, so we don't need to delete it
+    auto* element = doc.NewElement(elementName);
+    element->SetText(cstr);
+    element->Accept(&printer);
+    os << printer.CStr() << suffix;
+  }
+}  // namespace edm::xml
+
+#endif

--- a/FWCore/MessageLogger/src/JobReport.cc
+++ b/FWCore/MessageLogger/src/JobReport.cc
@@ -18,6 +18,7 @@
 //
 
 #include "FWCore/MessageLogger/interface/JobReport.h"
+#include "FWCore/MessageLogger/interface/xmlUtils.h"
 #include "FWCore/Utilities/interface/Map.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
@@ -38,21 +39,21 @@ namespace edm {
 
   template <typename S, typename T>
   S& formatFile(T const& f, S& os) {
-    tinyxml2::XMLDocument doc;
     if (f.fileHasBeenClosed) {
       os << "\n<State  Value=\"closed\"/>";
     } else {
       os << "\n<State  Value=\"open\"/>";
     }
-    os << "\n<LFN>" << doc.NewText(f.logicalFileName.c_str())->Value() << "</LFN>";
-    os << "\n<PFN>" << doc.NewText(f.physicalFileName.c_str())->Value() << "</PFN>";
-    os << "\n<Catalog>" << doc.NewText(f.catalog.c_str())->Value() << "</Catalog>";
-    os << "\n<ModuleLabel>" << doc.NewText(f.moduleLabel.c_str())->Value() << "</ModuleLabel>";
-    os << "\n<GUID>" << f.guid << "</GUID>";
-    os << "\n<Branches>";
+    os << "\n";
+    xml::addElement("LFN", f.logicalFileName, "\n", os);
+    xml::addElement("PFN", f.physicalFileName, "\n", os);
+    xml::addElement("Catalog", f.catalog, "\n", os);
+    xml::addElement("ModuleLabel", f.moduleLabel, "\n", os);
+    xml::addElement("GUID", f.guid, "\n", os);
+    os << "<Branches>";
     for (auto const& branch : f.branchNames) {
-      os << "\n  <Branch>" << doc.NewText(branch.c_str())->Value() << "</Branch>";
-      doc.DeleteChildren();
+      os << "\n  ";
+      xml::addElement("Branch", branch, "", os);
     }
     os << "\n</Branches>";
     return os;
@@ -64,23 +65,23 @@ namespace edm {
    */
   template <typename S>
   S& print(S& os, JobReport::InputFile const& f) {
-    tinyxml2::XMLDocument doc;
     os << "\n<InputFile>";
     formatFile(f, os);
-    os << "\n<InputType>" << f.inputType << "</InputType>";
-    os << "\n<InputSourceClass>" << doc.NewText(f.inputSourceClassName.c_str())->Value() << "</InputSourceClass>";
-    os << "\n<EventsRead>" << f.numEventsRead << "</EventsRead>";
+    os << "\n";
+    xml::addElement("InputType", f.inputType, "\n", os);
+    xml::addElement("InputSourceClass", f.inputSourceClassName, "\n", os);
+    xml::addElement("EventsRead", f.numEventsRead, "", os);
     return os;
   }
 
   template <typename S>
   S& print(S& os, JobReport::OutputFile const& f) {
-    tinyxml2::XMLDocument doc;
     formatFile(f, os);
-    os << "\n<OutputModuleClass>" << doc.NewText(f.outputModuleClassName.c_str())->Value() << "</OutputModuleClass>";
-    os << "\n<TotalEvents>" << f.numEventsWritten << "</TotalEvents>\n";
-    os << "\n<DataType>" << doc.NewText(f.dataType.c_str())->Value() << "</DataType>\n";
-    os << "\n<BranchHash>" << doc.NewText(f.branchHash.c_str())->Value() << "</BranchHash>\n";
+    os << "\n";
+    xml::addElement("OutputModuleClass", f.outputModuleClassName, "\n", os);
+    xml::addElement("TotalEvents", f.numEventsWritten, "\n\n", os);
+    xml::addElement("DataType", f.dataType, "\n\n", os);
+    xml::addElement("BranchHash", f.branchHash, "\n", os);
     return os;
   }
 
@@ -193,7 +194,6 @@ namespace edm {
    *
    */
   void JobReport::JobReportImpl::writeOutputFile(JobReport::OutputFile const& f) {
-    tinyxml2::XMLDocument doc;
     if (ost_) {
       *ost_ << "\n<File>";
       *ost_ << f;
@@ -207,23 +207,21 @@ namespace edm {
       *ost_ << "\n<Inputs>";
       for (auto token : f.contributingInputs) {
         JobReport::InputFile inpFile = inputFiles_.at(token);
-        *ost_ << "\n<Input>";
-        *ost_ << "\n  <LFN>" << doc.NewText(inpFile.logicalFileName.c_str())->Value() << "</LFN>";
-        *ost_ << "\n  <PFN>" << doc.NewText(inpFile.physicalFileName.c_str())->Value() << "</PFN>";
-        *ost_ << "\n  <FastCopying>" << findOrDefault(f.fastCopyingInputs, inpFile.physicalFileName)
-              << "</FastCopying>";
-        *ost_ << "\n</Input>";
-        doc.DeleteChildren();
+        *ost_ << "\n<Input>\n  ";
+        xml::addElement("LFN", inpFile.logicalFileName, "\n  ", *ost_);
+        xml::addElement("PFN", inpFile.physicalFileName, "\n  ", *ost_);
+        xml::addElement(
+            "FastCopying", static_cast<int>(findOrDefault(f.fastCopyingInputs, inpFile.physicalFileName)), "\n", *ost_);
+        *ost_ << "</Input>";
       }
       for (auto token : f.contributingInputsSecSource) {
         JobReport::InputFile inpFile = inputFilesSecSource_.at(token);
-        *ost_ << "\n<Input>";
-        *ost_ << "\n  <LFN>" << doc.NewText(inpFile.logicalFileName.c_str())->Value() << "</LFN>";
-        *ost_ << "\n  <PFN>" << doc.NewText(inpFile.physicalFileName.c_str())->Value() << "</PFN>";
-        *ost_ << "\n  <FastCopying>" << findOrDefault(f.fastCopyingInputs, inpFile.physicalFileName)
-              << "</FastCopying>";
-        *ost_ << "\n</Input>";
-        doc.DeleteChildren();
+        *ost_ << "\n<Input>\n  ";
+        xml::addElement("LFN", inpFile.logicalFileName, "\n  ", *ost_);
+        xml::addElement("PFN", inpFile.physicalFileName, "\n  ", *ost_);
+        xml::addElement(
+            "FastCopying", static_cast<int>(findOrDefault(f.fastCopyingInputs, inpFile.physicalFileName)), "\n", *ost_);
+        *ost_ << "</Input>";
       }
       *ost_ << "\n</Inputs>";
       *ost_ << "\n</File>\n";
@@ -756,7 +754,6 @@ namespace edm {
   std::string JobReport::dumpFiles(void) {
     std::ostringstream msg;
 
-    tinyxml2::XMLDocument doc;
     for (auto const& f : impl_->outputFiles_) {
       msg << "\n<File>";
       msg << f;
@@ -766,12 +763,12 @@ namespace edm {
       typedef std::vector<JobReport::Token>::iterator iterator;
       for (auto const& iInput : f.contributingInputs) {
         auto const& inpFile = impl_->inputFiles_[iInput];
-        msg << "\n<Input>";
-        msg << "\n  <LFN>" << doc.NewText(inpFile.logicalFileName.c_str())->Value() << "</LFN>";
-        msg << "\n  <PFN>" << doc.NewText(inpFile.physicalFileName.c_str())->Value() << "</PFN>";
-        msg << "\n  <FastCopying>" << findOrDefault(f.fastCopyingInputs, inpFile.physicalFileName) << "</FastCopying>";
+        msg << "\n<Input>\n  ";
+        xml::addElement("LFN", inpFile.logicalFileName, "\n  ", msg);
+        xml::addElement("PFN", inpFile.physicalFileName, "\n  ", msg);
+        xml::addElement(
+            "FastCopying", static_cast<int>(findOrDefault(f.fastCopyingInputs, inpFile.physicalFileName)), "", msg);
         msg << "\n</Input>";
-        doc.DeleteChildren();
       }
       msg << "\n</Inputs>";
       msg << "\n</File>";

--- a/FWCore/MessageLogger/src/JobReport.cc
+++ b/FWCore/MessageLogger/src/JobReport.cc
@@ -30,6 +30,20 @@
 #include <ostream>
 #include <sstream>
 
+namespace {
+  void addInputElement(edm::JobReport::InputFile const& inpFile,
+                       std::map<std::string, bool> const& fastCopyingInputs,
+                       std::ostream& ost) {
+    ost << "\n<Input>\n  ";
+    edm::xml::addElement("LFN", inpFile.logicalFileName, "\n  ", ost);
+    edm::xml::addElement("PFN", inpFile.physicalFileName, "\n  ", ost);
+    // Casting to int to have 0/1 instead of false/true
+    edm::xml::addElement(
+        "FastCopying", static_cast<int>(edm::findOrDefault(fastCopyingInputs, inpFile.physicalFileName)), "\n", ost);
+    ost << "</Input>";
+  }
+}  // namespace
+
 namespace edm {
   /*
    * Note that output formatting is spattered across these classes
@@ -206,22 +220,10 @@ namespace edm {
 
       *ost_ << "\n<Inputs>";
       for (auto token : f.contributingInputs) {
-        JobReport::InputFile inpFile = inputFiles_.at(token);
-        *ost_ << "\n<Input>\n  ";
-        xml::addElement("LFN", inpFile.logicalFileName, "\n  ", *ost_);
-        xml::addElement("PFN", inpFile.physicalFileName, "\n  ", *ost_);
-        xml::addElement(
-            "FastCopying", static_cast<int>(findOrDefault(f.fastCopyingInputs, inpFile.physicalFileName)), "\n", *ost_);
-        *ost_ << "</Input>";
+        addInputElement(inputFiles_.at(token), f.fastCopyingInputs, *ost_);
       }
       for (auto token : f.contributingInputsSecSource) {
-        JobReport::InputFile inpFile = inputFilesSecSource_.at(token);
-        *ost_ << "\n<Input>\n  ";
-        xml::addElement("LFN", inpFile.logicalFileName, "\n  ", *ost_);
-        xml::addElement("PFN", inpFile.physicalFileName, "\n  ", *ost_);
-        xml::addElement(
-            "FastCopying", static_cast<int>(findOrDefault(f.fastCopyingInputs, inpFile.physicalFileName)), "\n", *ost_);
-        *ost_ << "</Input>";
+        addInputElement(inputFilesSecSource_.at(token), f.fastCopyingInputs, *ost_);
       }
       *ost_ << "\n</Inputs>";
       *ost_ << "\n</File>\n";
@@ -762,13 +764,7 @@ namespace edm {
       msg << "\n<Inputs>";
       typedef std::vector<JobReport::Token>::iterator iterator;
       for (auto const& iInput : f.contributingInputs) {
-        auto const& inpFile = impl_->inputFiles_[iInput];
-        msg << "\n<Input>\n  ";
-        xml::addElement("LFN", inpFile.logicalFileName, "\n  ", msg);
-        xml::addElement("PFN", inpFile.physicalFileName, "\n  ", msg);
-        xml::addElement(
-            "FastCopying", static_cast<int>(findOrDefault(f.fastCopyingInputs, inpFile.physicalFileName)), "", msg);
-        msg << "\n</Input>";
+        addInputElement(impl_->inputFiles_[iInput], f.fastCopyingInputs, msg);
       }
       msg << "\n</Inputs>";
       msg << "\n</File>";

--- a/FWCore/MessageService/test/BuildFile.xml
+++ b/FWCore/MessageService/test/BuildFile.xml
@@ -256,8 +256,13 @@
 <test name="unitTestsGroup_6" command="${value}.sh" foreach="u23,u27,u30,u31,u33"/>
 
 <test name="TestFWCoreMessageServiceJobReport" command="testJobReport.sh"/>
+
 <bin name="makeJobReport" file="makeJobReport.cpp">
   <use name="boost_program_options"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
+  <flags NO_TESTRUN="1"/>
 </bin>
+<test name="testMakeJobReport" command="testMakeJobReport.sh">
+  <flags PRE_TEST="makeJobReport"/>
+</test>

--- a/FWCore/MessageService/test/BuildFile.xml
+++ b/FWCore/MessageService/test/BuildFile.xml
@@ -266,3 +266,8 @@
 <test name="testMakeJobReport" command="testMakeJobReport.sh">
   <flags PRE_TEST="makeJobReport"/>
 </test>
+<bin name="testJobReportXMLUtils" file="testJobReportXMLUtils.cpp">
+  <use name="catch2"/>
+  <use name="tinyxml2"/>
+  <use name="FWCore/MessageLogger" source_only="1"/>
+</bin>

--- a/FWCore/MessageService/test/makeJobReport.cpp
+++ b/FWCore/MessageService/test/makeJobReport.cpp
@@ -7,8 +7,7 @@
 #include "FWCore/MessageLogger/interface/JobReport.h"
 #include "FWCore/Utilities/interface/InputType.h"
 
-void work() {
-  std::cout << "Testing JobReport" << std::endl;
+int work() {
   std::ostringstream ost;
   {
     auto theReport = std::make_unique<edm::JobReport>(&ost);
@@ -18,15 +17,21 @@ void work() {
       inputBranches.push_back("Some_Input_Branch");
     }
 
-    std::size_t inpFile = theReport->inputFileOpened(
-        "InputPFN", "InputLFN", "InputCatalog", "InputType", "InputSource", "InputLabel", "InputGUID", inputBranches);
+    std::size_t inpFile = theReport->inputFileOpened("InputPFN?with&cgi=params",
+                                                     "InputLFN",
+                                                     "InputCatalog",
+                                                     "InputType",
+                                                     "InputSource",
+                                                     "InputLabel",
+                                                     "InputGUID",
+                                                     inputBranches);
 
     std::vector<std::string> outputBranches;
     for (int i = 0; i < 10; i++) {
       outputBranches.push_back("Some_Output_Branch_Probably_From_HLT");
     }
 
-    std::size_t outFile = theReport->outputFileOpened("OutputPFN",
+    std::size_t outFile = theReport->outputFileOpened("OutputPFN?with&cgi=params",
                                                       "OutputLFN",
                                                       "OutputCatalog",
                                                       "OutputModule",
@@ -44,18 +49,17 @@ void work() {
     theReport->inputFileClosed(edm::InputType::Primary, inpFile);
     theReport->outputFileClosed(outFile);
   }
-  std::cout << ost.str() << std::endl;
+  std::string report = ost.str();
+  std::cout << report << std::endl;
+
+  return 0;
 }
 
 int main() {
   int rc = -1;
   try {
-    work();
-
-    rc = 0;
-  }
-
-  catch (...) {
+    rc = work();
+  } catch (...) {
     std::cerr << "Unknown exception caught\n";
     rc = 2;
   }

--- a/FWCore/MessageService/test/testJobReportXMLUtils.cpp
+++ b/FWCore/MessageService/test/testJobReportXMLUtils.cpp
@@ -1,0 +1,38 @@
+#include <catch2/catch_all.hpp>
+
+#include "FWCore/MessageLogger/interface/xmlUtils.h"
+
+#include <sstream>
+
+TEST_CASE("addElement", "[xmlUtils]") {
+  SECTION("string") {
+    std::ostringstream oss;
+    edm::xml::addElement("PFN", "foo/bar", "", oss);
+    REQUIRE(oss.str() == "<PFN>foo/bar</PFN>");
+  }
+
+  SECTION("integer") {
+    std::ostringstream oss;
+    edm::xml::addElement("PFN", 42, "\n", oss);
+    REQUIRE(oss.str() == "<PFN>42</PFN>\n");
+  }
+
+  SECTION("floating point") {
+    std::ostringstream oss;
+    edm::xml::addElement("PFN", 3.14159, "\n", oss);
+    REQUIRE(oss.str() == "<PFN>3.14159</PFN>\n");
+  }
+
+  SECTION("escapes special characters") {
+    SECTION("ampersand") {
+      std::ostringstream oss;
+      edm::xml::addElement("PFN", "file?with&cgi=params", "\n", oss);
+      REQUIRE(oss.str() == "<PFN>file?with&amp;cgi=params</PFN>\n");
+    }
+    SECTION("less and greater than") {
+      std::ostringstream oss;
+      edm::xml::addElement("Message", "file<other>file", "\n", oss);
+      REQUIRE(oss.str() == "<Message>file&lt;other&gt;file</Message>\n");
+    }
+  }
+}

--- a/FWCore/MessageService/test/testMakeJobReport.sh
+++ b/FWCore/MessageService/test/testMakeJobReport.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+function die { echo "Failure $1: status $2" ; it $2 ; }
+
+makeJobReport > jobreport.xml 2>&1 || die "makeJobReport" $?
+
+cat jobreport.xml | ${LOCALTOP}/src/FWCore/MessageService/test/validateXML.py || die "validateXML" $?
+
+diff -u ${LOCALTOP}/src/FWCore/MessageService/test/unit_test_outputs/makeJobReport_expected.xml jobreport.xml || die "diff" $?
+
+exit 0

--- a/FWCore/MessageService/test/unit_test_outputs/makeJobReport_expected.xml
+++ b/FWCore/MessageService/test/unit_test_outputs/makeJobReport_expected.xml
@@ -1,0 +1,68 @@
+<FrameworkJobReport>
+
+<InputFile>
+<State  Value="closed"/>
+<LFN>InputLFN</LFN>
+<PFN>InputPFN?with&amp;cgi=params</PFN>
+<Catalog>InputCatalog</Catalog>
+<ModuleLabel>InputLabel</ModuleLabel>
+<GUID>InputGUID</GUID>
+<Branches>
+  <Branch>Some_Input_Branch</Branch>
+  <Branch>Some_Input_Branch</Branch>
+  <Branch>Some_Input_Branch</Branch>
+  <Branch>Some_Input_Branch</Branch>
+  <Branch>Some_Input_Branch</Branch>
+  <Branch>Some_Input_Branch</Branch>
+  <Branch>Some_Input_Branch</Branch>
+  <Branch>Some_Input_Branch</Branch>
+  <Branch>Some_Input_Branch</Branch>
+  <Branch>Some_Input_Branch</Branch>
+</Branches>
+<InputType>InputType</InputType>
+<InputSourceClass>InputSource</InputSourceClass>
+<EventsRead>1000</EventsRead>
+<Runs>
+</Runs>
+</InputFile>
+
+<File>
+<State  Value="closed"/>
+<LFN>OutputLFN</LFN>
+<PFN>OutputPFN?with&amp;cgi=params</PFN>
+<Catalog>OutputCatalog</Catalog>
+<ModuleLabel>OutputModuleName</ModuleLabel>
+<GUID>OutputGUID</GUID>
+<Branches>
+  <Branch>Some_Output_Branch_Probably_From_HLT</Branch>
+  <Branch>Some_Output_Branch_Probably_From_HLT</Branch>
+  <Branch>Some_Output_Branch_Probably_From_HLT</Branch>
+  <Branch>Some_Output_Branch_Probably_From_HLT</Branch>
+  <Branch>Some_Output_Branch_Probably_From_HLT</Branch>
+  <Branch>Some_Output_Branch_Probably_From_HLT</Branch>
+  <Branch>Some_Output_Branch_Probably_From_HLT</Branch>
+  <Branch>Some_Output_Branch_Probably_From_HLT</Branch>
+  <Branch>Some_Output_Branch_Probably_From_HLT</Branch>
+  <Branch>Some_Output_Branch_Probably_From_HLT</Branch>
+</Branches>
+<OutputModuleClass>OutputModule</OutputModuleClass>
+<TotalEvents>1000</TotalEvents>
+
+<DataType>DataType</DataType>
+
+<BranchHash>OutputBranchesHash</BranchHash>
+
+<Runs>
+</Runs>
+
+<Inputs>
+<Input>
+  <LFN>InputLFN</LFN>
+  <PFN>InputPFN?with&amp;cgi=params</PFN>
+  <FastCopying>0</FastCopying>
+</Input>
+</Inputs>
+</File>
+<!--                                                            -->
+</FrameworkJobReport>
+

--- a/FWCore/MessageService/test/validateXML.py
+++ b/FWCore/MessageService/test/validateXML.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""
+Strict XML validator using Python's xml.etree.ElementTree parser.
+Reads XML from stdin and exits with code 0 if valid, non-zero if invalid.
+"""
+import sys
+import xml.etree.ElementTree as ET
+
+try:
+    xml_content = sys.stdin.read()
+    ET.fromstring(xml_content)
+    sys.exit(0)
+except ET.ParseError as e:
+    print(f"XML validation failed: {e}", file=sys.stderr)
+    print("=" * 80, file=sys.stderr)
+    print("XML content:", file=sys.stderr)
+    print(xml_content, file=sys.stderr)
+    print("=" * 80, file=sys.stderr)
+    sys.exit(1)
+except Exception as e:
+    print(f"Unexpected error during XML validation: {e}", file=sys.stderr)
+    sys.exit(2)


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/50024. From the original PR description
> #50020 reports a parsing problem of framework job report XML in Tier0 when `&` is added to the PFN (this can happen with #49740). Following suggestion [#47555 (comment)](https://github.com/cms-sw/cmssw/issues/47555#issuecomment-2718867578) this PR adds `addElement()` function that uses tinyxml2 to properly escape special characters.

Resolves https://github.com/cms-sw/cmssw/issues/50020
Resolves https://github.com/cms-sw/framework-team/issues/1874

#### PR validation:

None beyond https://github.com/cms-sw/cmssw/pull/50024

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/50024