### PR TITLE
Patch to fix workflow errors from HGCalTypes changes

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalTypes.h
+++ b/Geometry/HGCalCommonData/interface/HGCalTypes.h
@@ -20,12 +20,12 @@ public:
 
   static constexpr int32_t UnknownPosition = -1;
   static constexpr int32_t WaferCenter = 0;
-  static constexpr int32_t WaferCenterB = 1;
-  static constexpr int32_t CornerCenterYp = 2;
-  static constexpr int32_t CornerCenterYm = 3;
-  static constexpr int32_t WaferCenterR = 4;
-  static constexpr int32_t CornerCenterXp = 5;
-  static constexpr int32_t CornerCenterXm = 6;
+  static constexpr int32_t CornerCenterYp = 1;
+  static constexpr int32_t CornerCenterYm = 2;
+  static constexpr int32_t CornerCenterXp = 3;
+  static constexpr int32_t CornerCenterXm = 4;
+  static constexpr int32_t WaferCenterB = 5;
+  static constexpr int32_t WaferCenterR = 6;
 
   static constexpr int32_t WaferTypeUndefined = -1;
   static constexpr int32_t WaferHD120 = 0;

--- a/Geometry/HGCalCommonData/src/HGCalTypes.cc
+++ b/Geometry/HGCalCommonData/src/HGCalTypes.cc
@@ -42,9 +42,9 @@ int32_t HGCalTypes::getUnpackedCell6(int id) { return (id % faccell6_); }
 int32_t HGCalTypes::layerType(int type) {
   static const int32_t layerTypeX[7] = {HGCalTypes::WaferCenter,
                                         HGCalTypes::WaferCenterB,
+                                        HGCalTypes::WaferCenterR,
                                         HGCalTypes::CornerCenterYp,
                                         HGCalTypes::CornerCenterYm,
-                                        HGCalTypes::WaferCenterR,
                                         HGCalTypes::CornerCenterXp,
                                         HGCalTypes::CornerCenterXm};
   return ((type >= 0) && (type < 7)) ? layerTypeX[type] : HGCalTypes::WaferCenter;

--- a/Geometry/HGCalCommonData/src/HGCalTypes.cc
+++ b/Geometry/HGCalCommonData/src/HGCalTypes.cc
@@ -42,9 +42,9 @@ int32_t HGCalTypes::getUnpackedCell6(int id) { return (id % faccell6_); }
 int32_t HGCalTypes::layerType(int type) {
   static const int32_t layerTypeX[7] = {HGCalTypes::WaferCenter,
                                         HGCalTypes::WaferCenterB,
-                                        HGCalTypes::WaferCenterR,
                                         HGCalTypes::CornerCenterYp,
                                         HGCalTypes::CornerCenterYm,
+                                        HGCalTypes::WaferCenterR,
                                         HGCalTypes::CornerCenterXp,
                                         HGCalTypes::CornerCenterXm};
   return ((type >= 0) && (type < 7)) ? layerTypeX[type] : HGCalTypes::WaferCenter;


### PR DESCRIPTION
#### PR description:

Changes in #49763 led to disruption in Phase 2 workflows, as reported in #49795. It was eventually found that the error could occur even in brand-new MC (consuming no old input files), meaning that it must be the result of an actual inconsistency, not just an incompatibility between releases.

I found one bug in #49763 (inadvertent change in the order of the list of constants), which is fixed here. However, this bug did not turn out to be the cause of the workflow errors.

Only reverting the changes in the values of the constants from #49763 fixes the workflows. I still do not know why this is the case. Every usage of these values that I can find compares them to the actual named constants, not raw/hardcoded versions of the values. But there must be some comparison somewhere that does use raw values and therefore becomes inconsistent with the change. For now, all we can do is revert the change. If the new values were in fact correct, they can be restored at a later time once all usage is understood and corrected.

#### PR validation:

Ran on the example failing workflow from https://github.com/cms-sw/cmssw/issues/49795#issuecomment-3837618786. Also ran on a privately produced sample of MC from the same generator fragment that showed the same error. The workflows run successfully with the changes in this PR.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, should not need to be backported because this change was only introduced in 16_1_X.