### PR TITLE
[GCC15] (CORE-DQM) Fix uninitialized warning in MEtoEDMFormat (DataFormats/Histograms)

### DIFF
--- a/DataFormats/Histograms/interface/MEtoEDMFormat.h
+++ b/DataFormats/Histograms/interface/MEtoEDMFormat.h
@@ -53,7 +53,7 @@ public:
   typedef std::vector<MEtoEDMObject> MEtoEdmObjectVector;
 
   void putMEtoEdmObject(const std::string &name, const T &object) {
-    typename MEtoEdmObjectVector::value_type temp;
+    typename MEtoEdmObjectVector::value_type temp{};
     MEtoEdmObject.push_back(temp);
     MEtoEdmObject.back().name = name;
     MEtoEdmObject.back().object = object;


### PR DESCRIPTION
- Initialize MEtoEDMObject to fix GCC15 uninitialized warning
`- typename MEtoEdmObjectVector::value_type temp;`
`+ typename MEtoEdmObjectVector::value_type temp{};`
[log](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc15/CMSSW_16_1_X_2026-02-03-1100/DataFormats/Histograms)