### PR TITLE
[GCC15] (CORE) Fix deprecated user-defined literal syntax for C++23

### DIFF
--- a/FWCore/Framework/src/EventSetupRecordProvider.cc
+++ b/FWCore/Framework/src/EventSetupRecordProvider.cc
@@ -81,7 +81,6 @@ namespace edm {
 
     void EventSetupRecordProvider::setDependentProviders(
         const std::vector<std::shared_ptr<EventSetupRecordProvider>>& iProviders) {
-      using std::placeholders::_1;
       std::shared_ptr<DependentRecordIntervalFinder> newFinder =
           make_shared_noexcept_false<DependentRecordIntervalFinder>(key());
 

--- a/FWCore/Integration/plugins/ViewAnalyzer.cc
+++ b/FWCore/Integration/plugins/ViewAnalyzer.cc
@@ -23,7 +23,6 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 using namespace edm;
-using namespace std::rel_ops;
 
 namespace edmtest {
   class ViewAnalyzer : public edm::global::EDAnalyzer<> {

--- a/FWIO/RNTupleTempInput/src/RootEmbeddedFileSequence.cc
+++ b/FWIO/RNTupleTempInput/src/RootEmbeddedFileSequence.cc
@@ -25,7 +25,7 @@
 
 namespace {
   std::atomic<unsigned int> badFilesSkipped_{0};
-  auto operator"" _uz(unsigned long long i) -> std::size_t { return std::size_t{i}; }  // uz will be in C++23
+  auto operator""_uz(unsigned long long i) -> std::size_t { return std::size_t{i}; }  // uz will be in C++23
 }  // namespace
 
 namespace edm {


### PR DESCRIPTION
- space between quotes and suffix is deprecated in C++23
`- auto operator"" _uz(unsigned long long i) -> std::size_t {
  return std::size_t{i};
}`
`+ auto operator""_uz(unsigned long long i) -> std::size_t {
  return std::size_t{i};
}`
[logs](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc15/CMSSW_16_1_X_2026-02-03-1100/FWIO/RNTupleTempInput)
- Removed unused std::placeholders::_1 in FWCore/Framework
`- using std::placeholders::_1;`
[logs](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc15/CMSSW_16_1_X_2026-02-03-1100/FWCore/Framework)
-  Removed deprecated std::rel_ops usage in FWCore/Integration
`- using namespace std::rel_ops;`
[logs](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc15/CMSSW_16_1_X_2026-02-03-1100/FWCore/Integration)