### PR TITLE
Cleanup CUDACore dependency from PFClusterProducer/plugin

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/BuildFile.xml
+++ b/RecoParticleFlow/PFClusterProducer/plugins/BuildFile.xml
@@ -16,7 +16,6 @@
   <use name="Geometry/CaloGeometry"/>
   <use name="Geometry/CaloTopology"/>
   <use name="Geometry/Records"/>
-  <use name="HeterogeneousCore/CUDACore"/>
   <use name="RecoLocalCalo/HGCalRecProducers"/>
   <use name="RecoParticleFlow/PFClusterProducer"/>
   <flags EDM_PLUGIN="1"/>
@@ -56,7 +55,6 @@
   <use name="Geometry/Records"/>
   <use name="HeterogeneousCore/AlpakaCore"/>
   <use name="HeterogeneousCore/AlpakaInterface"/>
-  <use name="HeterogeneousCore/CUDACore"/>
   <use name="RecoParticleFlow/PFClusterProducer"/>
   <use name="RecoParticleFlow/PFRecHitProducer"/>
   <flags ALPAKA_BACKENDS="1"/>


### PR DESCRIPTION
https://github.com/cms-sw/cmssw/pull/49891 removed the legacy cuda framework and `HeterogeneousCore/CUDACore` does not generate any public shared library. This PR removes the `HeterogeneousCore/CUDACore dependency from  `RecoParticleFlow/PFClusterProducer/plugins`. 

This should fix the scram's warning
```
****WARNING: Invalid tool HeterogeneousCore/CUDACore. Please fix src/RecoParticleFlow/PFClusterProducer/plugins/BuildFile.xml file.
```