### PR TITLE
Revert "Fix seed column in LayerCluster SoA"

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersSoAAlgoWrapper.dev.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersSoAAlgoWrapper.dev.cc
@@ -28,7 +28,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         alpaka::atomicAdd(acc, &outputs[clIdx].energy(), input_rechits_soa[i].energy());
         alpaka::atomicAdd(acc, &outputs[clIdx].cells(), 1);
         if (input_clusters_soa[i].isSeed() == 1) {
-          outputs[clIdx].seed() = i;
+          outputs[clIdx].seed() = input_rechits_soa[i].detid();
         }
       }
     }


### PR DESCRIPTION
This PR reverts #50017 causing crashes in IB due to wrong usage of the `seed` column. 
See #50051 