### PR TITLE
[Scouting DQM] Filter-by-filter monitoring for Scouting-EGM DQM

### DIFF
--- a/HLTriggerOffline/Scouting/plugins/PatElectronTagProbeAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/PatElectronTagProbeAnalyzer.cc
@@ -202,7 +202,8 @@ PatElectronTagProbeAnalyzer::PatElectronTagProbeAnalyzer(const edm::ParameterSet
   l1GtUtils_ = std::make_shared<l1t::L1TGlobalUtil>(iConfig, consumesCollector(), l1t::UseEventSetupIn::RunAndEvent);
   l1Seeds_ = iConfig.getParameter<std::vector<std::string>>("L1Seeds");
   for (const auto& pset : vtriggerConfig_) {
-    vtriggerSet_.push_back({pset.getParameter<std::string>("pathName"), pset.getParameter<std::vector<std::string>>("filters")});
+    vtriggerSet_.push_back(
+        {pset.getParameter<std::string>("pathName"), pset.getParameter<std::vector<std::string>>("filters")});
   }
 }
 
@@ -251,7 +252,7 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
 
   std::vector<kTriggerSetResult> vtriggerSetResults;
   vtriggerSetResults.reserve(vtriggerSet_.size());
-  for(const auto& config : vtriggerSet_) {
+  for (const auto& config : vtriggerSet_) {
     vtriggerSetResults.push_back({config.pathName, config.filters, false, {}});
   }
 
@@ -261,9 +262,9 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
       TString TrigPath = triggerNames.triggerName(i_Trig);
       for (auto& result : vtriggerSetResults) {
         if (!result.passTrigger) {
-           if (TrigPath.Index(result.pathName) >= 0) {
-             result.passTrigger = true;
-           }
+          if (TrigPath.Index(result.pathName) >= 0) {
+            result.passTrigger = true;
+          }
         }
       }
 
@@ -277,16 +278,15 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
 
   // Trigger Object Matching
   for (pat::TriggerObjectStandAlone obj : *triggerObjects) {
-      obj.unpackNamesAndLabels(iEvent, *triggerResults);
-      for (auto& result : vtriggerSetResults) {
-          for (const auto& filterName : result.filters) {
-              if (obj.hasFilterLabel(filterName)) {
-                  result.filterObjects[filterName].push_back(obj);
-              }
-          }
+    obj.unpackNamesAndLabels(iEvent, *triggerResults);
+    for (auto& result : vtriggerSetResults) {
+      for (const auto& filterName : result.filters) {
+        if (obj.hasFilterLabel(filterName)) {
+          result.filterObjects[filterName].push_back(obj);
+        }
       }
+    }
   }
-  
 
   // L1 Object Matching
   size_t numberOfl1Filters = l1filterToMatch_.size();
@@ -551,51 +551,52 @@ void PatElectronTagProbeAnalyzer::fillHistograms_resonance(const kProbeKinematic
     histos.hPtvsInvMass_Barrel->Fill(el.pt(), inv_mass);
 
     if (pass_baseDST) {
-      auto*  selected_histos = (pt_order == 0) ? &histos.leading_electron : 
-                              (pt_order == 1) ? &histos.subleading_electron : nullptr;
+      auto* selected_histos = (pt_order == 0)   ? &histos.leading_electron
+                              : (pt_order == 1) ? &histos.subleading_electron
+                                                : nullptr;
       if (selected_histos) {
-          selected_histos->hPt_Barrel_passBaseDST->Fill(el.pt());
-          selected_histos->hEta_passBaseDST->Fill(el.eta());
-          int filter_idx_counter = 0; // Keeps track of flattened filter histogram index
-          for (size_t i = 0; i < triggerset_result.size(); i++) {
-              const auto& res = triggerset_result[i];
-              // Pass Trigger Path
-              if (res.passTrigger) {
-                  selected_histos->hPt_Barrel_passDST[i]->Fill(el.pt());
-                  selected_histos->hEta_passDST[i]->Fill(el.eta());
-              }
-              // Pass Filter Objects
-              for (const auto& filterName : res.filters) {
-                  bool passObj = false;
-                  // Check if we have objects for this filter
-                  auto it = res.filterObjects.find(filterName);
-                  if (it != res.filterObjects.end()) {
-                      if (patElectron_passHLT(el, it->second)) {
-                          passObj = true;
-                      }
-                  }
-                  if (passObj) {
-                      selected_histos->hPt_Barrel_fireTrigObj[filter_idx_counter]->Fill(el.pt());
-                      selected_histos->hEta_fireTrigObj[filter_idx_counter]->Fill(el.eta());
-                  }
-
-                  filter_idx_counter++;
-              }
+        selected_histos->hPt_Barrel_passBaseDST->Fill(el.pt());
+        selected_histos->hEta_passBaseDST->Fill(el.eta());
+        int filter_idx_counter = 0;  // Keeps track of flattened filter histogram index
+        for (size_t i = 0; i < triggerset_result.size(); i++) {
+          const auto& res = triggerset_result[i];
+          // Pass Trigger Path
+          if (res.passTrigger) {
+            selected_histos->hPt_Barrel_passDST[i]->Fill(el.pt());
+            selected_histos->hEta_passDST[i]->Fill(el.eta());
           }
-
-          for (unsigned int il1seed = 0; il1seed < l1Seeds_.size(); il1seed++) {
-              if (l1_result[il1seed]) {
-                  unsigned int ifilter = 0;
-                  while ((ifilter < l1filterIndex_.size()) && (il1seed >= l1filterIndex_[ifilter]))
-                      ifilter++;
-                  if (!(patElectron_passHLT(el, l1_legObjects[ifilter])))
-                      continue;
-                  // check if electron fire the l1 seed leg
-                  selected_histos->hPt_Barrel_fireL1[il1seed]->Fill(el.pt());
-                  selected_histos->hEta_fireL1[il1seed]->Fill(el.eta());
+          // Pass Filter Objects
+          for (const auto& filterName : res.filters) {
+            bool passObj = false;
+            // Check if we have objects for this filter
+            auto it = res.filterObjects.find(filterName);
+            if (it != res.filterObjects.end()) {
+              if (patElectron_passHLT(el, it->second)) {
+                passObj = true;
               }
+            }
+            if (passObj) {
+              selected_histos->hPt_Barrel_fireTrigObj[filter_idx_counter]->Fill(el.pt());
+              selected_histos->hEta_fireTrigObj[filter_idx_counter]->Fill(el.eta());
+            }
+
+            filter_idx_counter++;
           }
-      } 
+        }
+
+        for (unsigned int il1seed = 0; il1seed < l1Seeds_.size(); il1seed++) {
+          if (l1_result[il1seed]) {
+            unsigned int ifilter = 0;
+            while ((ifilter < l1filterIndex_.size()) && (il1seed >= l1filterIndex_[ifilter]))
+              ifilter++;
+            if (!(patElectron_passHLT(el, l1_legObjects[ifilter])))
+              continue;
+            // check if electron fire the l1 seed leg
+            selected_histos->hPt_Barrel_fireL1[il1seed]->Fill(el.pt());
+            selected_histos->hEta_fireL1[il1seed]->Fill(el.eta());
+          }
+        }
+      }
     }
   } else {
     histos.hPt_Endcap->Fill(el.pt());
@@ -613,52 +614,53 @@ void PatElectronTagProbeAnalyzer::fillHistograms_resonance(const kProbeKinematic
     histos.hPtvsInvMass_Endcap->Fill(el.pt(), inv_mass);
 
     if (pass_baseDST) {
-        auto* selected_histos = (pt_order == 0) ? &histos.leading_electron :
-                                (pt_order == 1) ? &histos.subleading_electron : nullptr;
-        if (selected_histos){
-            selected_histos->hPt_Endcap_passBaseDST->Fill(el.pt());
-            selected_histos->hEta_passBaseDST->Fill(el.eta());
+      auto* selected_histos = (pt_order == 0)   ? &histos.leading_electron
+                              : (pt_order == 1) ? &histos.subleading_electron
+                                                : nullptr;
+      if (selected_histos) {
+        selected_histos->hPt_Endcap_passBaseDST->Fill(el.pt());
+        selected_histos->hEta_passBaseDST->Fill(el.eta());
 
-            int filter_idx_counter = 0; // Keeps track of flattened filter histogram index
-            for (size_t i = 0; i < triggerset_result.size(); i++) {
-                const auto& res = triggerset_result[i];
-                // Pass Trigger Path
-                if (res.passTrigger) {
-                    selected_histos->hPt_Endcap_passDST[i]->Fill(el.pt());
-                    selected_histos->hEta_passDST[i]->Fill(el.eta());
-                }
-                // Pass Filter Objects
-                for (const auto& filterName : res.filters) {
-                    bool passObj = false;
-                    // Check if we have objects for this filter
-                    auto it = res.filterObjects.find(filterName);
-                    if (it != res.filterObjects.end()) {
-                        if (patElectron_passHLT(el, it->second)) {
-                            passObj = true;
-                        }
-                    }
-                    if (passObj) {
-                        selected_histos->hPt_Endcap_fireTrigObj[filter_idx_counter]->Fill(el.pt());
-                        selected_histos->hEta_fireTrigObj[filter_idx_counter]->Fill(el.eta());
-                    }
-
-                    filter_idx_counter++;
-                }
+        int filter_idx_counter = 0;  // Keeps track of flattened filter histogram index
+        for (size_t i = 0; i < triggerset_result.size(); i++) {
+          const auto& res = triggerset_result[i];
+          // Pass Trigger Path
+          if (res.passTrigger) {
+            selected_histos->hPt_Endcap_passDST[i]->Fill(el.pt());
+            selected_histos->hEta_passDST[i]->Fill(el.eta());
+          }
+          // Pass Filter Objects
+          for (const auto& filterName : res.filters) {
+            bool passObj = false;
+            // Check if we have objects for this filter
+            auto it = res.filterObjects.find(filterName);
+            if (it != res.filterObjects.end()) {
+              if (patElectron_passHLT(el, it->second)) {
+                passObj = true;
+              }
+            }
+            if (passObj) {
+              selected_histos->hPt_Endcap_fireTrigObj[filter_idx_counter]->Fill(el.pt());
+              selected_histos->hEta_fireTrigObj[filter_idx_counter]->Fill(el.eta());
             }
 
-            for (unsigned int il1seed = 0; il1seed < l1Seeds_.size(); il1seed++) {
-                if (l1_result[il1seed]) {
-                    unsigned int ifilter = 0;
-                    while ((ifilter < l1filterIndex_.size()) && (il1seed >= l1filterIndex_[ifilter]))
-                        ifilter++;
-                    if (!(patElectron_passHLT(el, l1_legObjects[ifilter])))
-                        continue;
-                    // check if electron fire the l1 seed leg
-                    selected_histos->hPt_Endcap_fireL1[il1seed]->Fill(el.pt());
-                    selected_histos->hEta_fireL1[il1seed]->Fill(el.eta());
-                }
-            }
+            filter_idx_counter++;
+          }
         }
+
+        for (unsigned int il1seed = 0; il1seed < l1Seeds_.size(); il1seed++) {
+          if (l1_result[il1seed]) {
+            unsigned int ifilter = 0;
+            while ((ifilter < l1filterIndex_.size()) && (il1seed >= l1filterIndex_[ifilter]))
+              ifilter++;
+            if (!(patElectron_passHLT(el, l1_legObjects[ifilter])))
+              continue;
+            // check if electron fire the l1 seed leg
+            selected_histos->hPt_Endcap_fireL1[il1seed]->Fill(el.pt());
+            selected_histos->hEta_fireL1[il1seed]->Fill(el.eta());
+          }
+        }
+      }
     }
   }
 }
@@ -707,53 +709,54 @@ void PatElectronTagProbeAnalyzer::fillHistograms_resonance_sct(const kProbeKinem
     }
 
     if (pass_baseDST) {
-
-      auto*  selected_histos = (pt_order == 0) ? &histos.leading_electron : 
-                              (pt_order == 1) ? &histos.subleading_electron : nullptr;
+      auto* selected_histos = (pt_order == 0)   ? &histos.leading_electron
+                              : (pt_order == 1) ? &histos.subleading_electron
+                                                : nullptr;
       if (selected_histos) {
-          selected_histos->hPt_Barrel_passBaseDST->Fill(el.pt());
-          selected_histos->hEta_passBaseDST->Fill(el.eta());
-          int filter_idx_counter = 0; // Keeps track of flattened filter histogram index
-          for (size_t i = 0; i < triggerset_result.size(); i++) {
-              const auto& res = triggerset_result[i];
-              // Pass Trigger Path
-              if (res.passTrigger) {
-                  selected_histos->hPt_Barrel_passDST[i]->Fill(el.pt());
-                  selected_histos->hEta_passDST[i]->Fill(el.eta());
-              }
-              // Pass Filter Objects
-              for (const auto& filterName : res.filters) {
-                  bool passObj = false;
-                  // Check if we have objects for this filter
-                  auto it = res.filterObjects.find(filterName);
-                  if (it != res.filterObjects.end()) {
-                      if (scoutingElectron_passHLT(el.trketaMode()[gsfTrackIndex], el.trkphiMode()[gsfTrackIndex], it->second)) {
-                          passObj = true;
-                      }
-                  }
-                  if (passObj) {
-                      selected_histos->hPt_Barrel_fireTrigObj[filter_idx_counter]->Fill(el.pt());
-                      selected_histos->hEta_fireTrigObj[filter_idx_counter]->Fill(el.eta());
-                  }
-
-                  filter_idx_counter++;
-              }
+        selected_histos->hPt_Barrel_passBaseDST->Fill(el.pt());
+        selected_histos->hEta_passBaseDST->Fill(el.eta());
+        int filter_idx_counter = 0;  // Keeps track of flattened filter histogram index
+        for (size_t i = 0; i < triggerset_result.size(); i++) {
+          const auto& res = triggerset_result[i];
+          // Pass Trigger Path
+          if (res.passTrigger) {
+            selected_histos->hPt_Barrel_passDST[i]->Fill(el.pt());
+            selected_histos->hEta_passDST[i]->Fill(el.eta());
           }
-
-          for (unsigned int il1seed = 0; il1seed < l1Seeds_.size(); il1seed++) {
-              if (l1_result[il1seed]) {
-                  unsigned int ifilter = 0;
-                  while ((ifilter < l1filterIndex_.size()) && (il1seed >= l1filterIndex_[ifilter]))
-                      ifilter++;
-                  if (!(scoutingElectron_passHLT(
-                      el.trketaMode()[gsfTrackIndex], el.trkphiMode()[gsfTrackIndex], l1_legObjects[ifilter])))
-                  continue;
-                  // check if electron fire the l1 seed leg
-                  selected_histos->hPt_Barrel_fireL1[il1seed]->Fill(el.pt());
-                  selected_histos->hEta_fireL1[il1seed]->Fill(el.eta());
+          // Pass Filter Objects
+          for (const auto& filterName : res.filters) {
+            bool passObj = false;
+            // Check if we have objects for this filter
+            auto it = res.filterObjects.find(filterName);
+            if (it != res.filterObjects.end()) {
+              if (scoutingElectron_passHLT(
+                      el.trketaMode()[gsfTrackIndex], el.trkphiMode()[gsfTrackIndex], it->second)) {
+                passObj = true;
               }
+            }
+            if (passObj) {
+              selected_histos->hPt_Barrel_fireTrigObj[filter_idx_counter]->Fill(el.pt());
+              selected_histos->hEta_fireTrigObj[filter_idx_counter]->Fill(el.eta());
+            }
+
+            filter_idx_counter++;
           }
-      } 
+        }
+
+        for (unsigned int il1seed = 0; il1seed < l1Seeds_.size(); il1seed++) {
+          if (l1_result[il1seed]) {
+            unsigned int ifilter = 0;
+            while ((ifilter < l1filterIndex_.size()) && (il1seed >= l1filterIndex_[ifilter]))
+              ifilter++;
+            if (!(scoutingElectron_passHLT(
+                    el.trketaMode()[gsfTrackIndex], el.trkphiMode()[gsfTrackIndex], l1_legObjects[ifilter])))
+              continue;
+            // check if electron fire the l1 seed leg
+            selected_histos->hPt_Barrel_fireL1[il1seed]->Fill(el.pt());
+            selected_histos->hEta_fireL1[il1seed]->Fill(el.eta());
+          }
+        }
+      }
     }
   } else {
     histos.hPt_Endcap->Fill(el.pt());
@@ -785,52 +788,54 @@ void PatElectronTagProbeAnalyzer::fillHistograms_resonance_sct(const kProbeKinem
     }
 
     if (pass_baseDST) {
-      auto*  selected_histos = (pt_order == 0) ? &histos.leading_electron : 
-                              (pt_order == 1) ? &histos.subleading_electron : nullptr;
+      auto* selected_histos = (pt_order == 0)   ? &histos.leading_electron
+                              : (pt_order == 1) ? &histos.subleading_electron
+                                                : nullptr;
       if (selected_histos) {
-          selected_histos->hPt_Endcap_passBaseDST->Fill(el.pt());
-          selected_histos->hEta_passBaseDST->Fill(el.eta());
-          int filter_idx_counter = 0; // Keeps track of flattened filter histogram index
-          for (size_t i = 0; i < triggerset_result.size(); i++) {
-              const auto& res = triggerset_result[i];
-              // Pass Trigger Path
-              if (res.passTrigger) {
-                  selected_histos->hPt_Endcap_passDST[i]->Fill(el.pt());
-                  selected_histos->hEta_passDST[i]->Fill(el.eta());
-              }
-              // Pass Filter Objects
-              for (const auto& filterName : res.filters) {
-                  bool passObj = false;
-                  // Check if we have objects for this filter
-                  auto it = res.filterObjects.find(filterName);
-                  if (it != res.filterObjects.end()) {
-                      if (scoutingElectron_passHLT(el.trketaMode()[gsfTrackIndex], el.trkphiMode()[gsfTrackIndex], it->second)) {
-                          passObj = true;
-                      }
-                  }
-                  if (passObj) {
-                      selected_histos->hPt_Endcap_fireTrigObj[filter_idx_counter]->Fill(el.pt());
-                      selected_histos->hEta_fireTrigObj[filter_idx_counter]->Fill(el.eta());
-                  }
-
-                  filter_idx_counter++;
-              }
+        selected_histos->hPt_Endcap_passBaseDST->Fill(el.pt());
+        selected_histos->hEta_passBaseDST->Fill(el.eta());
+        int filter_idx_counter = 0;  // Keeps track of flattened filter histogram index
+        for (size_t i = 0; i < triggerset_result.size(); i++) {
+          const auto& res = triggerset_result[i];
+          // Pass Trigger Path
+          if (res.passTrigger) {
+            selected_histos->hPt_Endcap_passDST[i]->Fill(el.pt());
+            selected_histos->hEta_passDST[i]->Fill(el.eta());
           }
-
-          for (unsigned int il1seed = 0; il1seed < l1Seeds_.size(); il1seed++) {
-              if (l1_result[il1seed]) {
-                  unsigned int ifilter = 0;
-                  while ((ifilter < l1filterIndex_.size()) && (il1seed >= l1filterIndex_[ifilter]))
-                      ifilter++;
-                  if (!(scoutingElectron_passHLT(
-                      el.trketaMode()[gsfTrackIndex], el.trkphiMode()[gsfTrackIndex], l1_legObjects[ifilter])))
-                  continue;
-                  // check if electron fire the l1 seed leg
-                  selected_histos->hPt_Endcap_fireL1[il1seed]->Fill(el.pt());
-                  selected_histos->hEta_fireL1[il1seed]->Fill(el.eta());
+          // Pass Filter Objects
+          for (const auto& filterName : res.filters) {
+            bool passObj = false;
+            // Check if we have objects for this filter
+            auto it = res.filterObjects.find(filterName);
+            if (it != res.filterObjects.end()) {
+              if (scoutingElectron_passHLT(
+                      el.trketaMode()[gsfTrackIndex], el.trkphiMode()[gsfTrackIndex], it->second)) {
+                passObj = true;
               }
+            }
+            if (passObj) {
+              selected_histos->hPt_Endcap_fireTrigObj[filter_idx_counter]->Fill(el.pt());
+              selected_histos->hEta_fireTrigObj[filter_idx_counter]->Fill(el.eta());
+            }
+
+            filter_idx_counter++;
           }
-      } 
+        }
+
+        for (unsigned int il1seed = 0; il1seed < l1Seeds_.size(); il1seed++) {
+          if (l1_result[il1seed]) {
+            unsigned int ifilter = 0;
+            while ((ifilter < l1filterIndex_.size()) && (il1seed >= l1filterIndex_[ifilter]))
+              ifilter++;
+            if (!(scoutingElectron_passHLT(
+                    el.trketaMode()[gsfTrackIndex], el.trkphiMode()[gsfTrackIndex], l1_legObjects[ifilter])))
+              continue;
+            // check if electron fire the l1 seed leg
+            selected_histos->hPt_Endcap_fireL1[il1seed]->Fill(el.pt());
+            selected_histos->hEta_fireL1[il1seed]->Fill(el.eta());
+          }
+        }
+      }
     }
   }
 }
@@ -950,70 +955,54 @@ void PatElectronTagProbeAnalyzer::bookHistograms_resonance(DQMStore::IBooker& ib
   histos.subleading_electron.hEta_passBaseDST =
       ibook.book1D(name + "_subleading_Eta_passBaseDST", name + "_subleading_Eta_passBaseDST", 20, -5.0, 5.0);
 
-
   for (const auto& config : vtriggerSet_) {
-      std::string cleaned_vt = config.pathName;
-      cleaned_vt.erase(std::remove(cleaned_vt.begin(), cleaned_vt.end(), '*'), cleaned_vt.end());
+    std::string cleaned_vt = config.pathName;
+    cleaned_vt.erase(std::remove(cleaned_vt.begin(), cleaned_vt.end(), '*'), cleaned_vt.end());
 
-      // =======================================================
-      // Pass DST
-      // =======================================================
-      // -- Leading Electron --
+    // =======================================================
+    // Pass DST
+    // =======================================================
+    // -- Leading Electron --
 
-      histos.leading_electron.hPt_Barrel_passDST.push_back(ibook.book1D(
-            name + "_leading_Pt_Barrel_pass" + cleaned_vt,
-            name + "_leading_Pt_Barrel_pass" + cleaned_vt, 40, 0, 200));
-      histos.leading_electron.hPt_Endcap_passDST.push_back(ibook.book1D(
-            name + "_leading_Pt_Endcap_pass" + cleaned_vt,
-            name + "_leading_Pt_Endcap_pass" + cleaned_vt, 40, 0, 200));
-      histos.leading_electron.hEta_passDST.push_back(ibook.book1D(
-            name + "_leading_Eta_pass" + cleaned_vt,
-            name + "_leading_Eta_pass" + cleaned_vt, 20, -5.0, 5.0));
+    histos.leading_electron.hPt_Barrel_passDST.push_back(ibook.book1D(
+        name + "_leading_Pt_Barrel_pass" + cleaned_vt, name + "_leading_Pt_Barrel_pass" + cleaned_vt, 40, 0, 200));
+    histos.leading_electron.hPt_Endcap_passDST.push_back(ibook.book1D(
+        name + "_leading_Pt_Endcap_pass" + cleaned_vt, name + "_leading_Pt_Endcap_pass" + cleaned_vt, 40, 0, 200));
+    histos.leading_electron.hEta_passDST.push_back(
+        ibook.book1D(name + "_leading_Eta_pass" + cleaned_vt, name + "_leading_Eta_pass" + cleaned_vt, 20, -5.0, 5.0));
 
-      // -- SubLeading Electron --
-      histos.subleading_electron.hPt_Barrel_passDST.push_back(ibook.book1D(
-            name + "_subleading_Pt_Barrel_pass" + cleaned_vt, 
-            name + "_subleading_Pt_Barrel_pass" + cleaned_vt, 40, 0, 200));
-      histos.subleading_electron.hPt_Endcap_passDST.push_back(ibook.book1D(
-            name + "_subleading_Pt_Endcap_pass" + cleaned_vt, 
-            name + "_subleading_Pt_Endcap_pass" + cleaned_vt, 40, 0, 200));
-      histos.subleading_electron.hEta_passDST.push_back(ibook.book1D(
-            name + "_subleading_Eta_pass" + cleaned_vt, 
-            name + "_subleading_Eta_pass" + cleaned_vt, 20, -5.0, 5.0));
+    // -- SubLeading Electron --
+    histos.subleading_electron.hPt_Barrel_passDST.push_back(ibook.book1D(
+        name + "_subleading_Pt_Barrel_pass" + cleaned_vt, name + "_subleading_Pt_Barrel_pass" + cleaned_vt, 40, 0, 200));
+    histos.subleading_electron.hPt_Endcap_passDST.push_back(ibook.book1D(
+        name + "_subleading_Pt_Endcap_pass" + cleaned_vt, name + "_subleading_Pt_Endcap_pass" + cleaned_vt, 40, 0, 200));
+    histos.subleading_electron.hEta_passDST.push_back(ibook.book1D(
+        name + "_subleading_Eta_pass" + cleaned_vt, name + "_subleading_Eta_pass" + cleaned_vt, 20, -5.0, 5.0));
 
-      // -----------------------------------------------------
-      // B. Book Fire TrigObj Histograms (Per Filter)
-      // -----------------------------------------------------
-      // These vectors will grow larger than the passDST vectors!
-      for (const auto& filterName : config.filters) {
+    // -----------------------------------------------------
+    // B. Book Fire TrigObj Histograms (Per Filter)
+    // -----------------------------------------------------
+    // These vectors will grow larger than the passDST vectors!
+    for (const auto& filterName : config.filters) {
+      // Create a unique name: Path + Filter
+      std::string suffix = cleaned_vt + "_" + filterName;
 
-        // Create a unique name: Path + Filter
-        std::string suffix = cleaned_vt + "_" + filterName;
+      // Leading
+      histos.leading_electron.hPt_Barrel_fireTrigObj.push_back(ibook.book1D(
+          name + "_leading_Pt_Barrel_pass" + suffix, name + "_leading_Pt_Barrel_pass" + suffix, 40, 0, 200));
+      histos.leading_electron.hPt_Endcap_fireTrigObj.push_back(ibook.book1D(
+          name + "_leading_Pt_Endcap_pass" + suffix, name + "_leading_Pt_Endcap_pass" + suffix, 40, 0, 200));
+      histos.leading_electron.hEta_fireTrigObj.push_back(
+          ibook.book1D(name + "_leading_Eta_pass" + suffix, name + "_leading_Eta_pass" + suffix, 20, -5.0, 5.0));
 
-        // Leading
-        histos.leading_electron.hPt_Barrel_fireTrigObj.push_back(ibook.book1D(
-            name + "_leading_Pt_Barrel_pass" + suffix,
-            name + "_leading_Pt_Barrel_pass" + suffix, 40, 0, 200));
-        histos.leading_electron.hPt_Endcap_fireTrigObj.push_back(ibook.book1D(
-            name + "_leading_Pt_Endcap_pass" + suffix,
-            name + "_leading_Pt_Endcap_pass" + suffix, 40, 0, 200));
-        histos.leading_electron.hEta_fireTrigObj.push_back(ibook.book1D(
-            name + "_leading_Eta_pass" + suffix,
-            name + "_leading_Eta_pass" + suffix, 20, -5.0, 5.0));
-
-        // SubLeading
-        histos.subleading_electron.hPt_Barrel_fireTrigObj.push_back(ibook.book1D(
-            name + "_subleading_Pt_Barrel_pass" + suffix,
-            name + "_subleading_Pt_Barrel_pass" + suffix, 40, 0, 200));
-        histos.subleading_electron.hPt_Endcap_fireTrigObj.push_back(ibook.book1D(
-            name + "_subleading_Pt_Endcap_pass" + suffix,
-            name + "_subleading_Pt_Endcap_pass" + suffix, 40, 0, 200));
-        histos.subleading_electron.hEta_fireTrigObj.push_back(ibook.book1D(
-            name + "_subleading_Eta_pass" + suffix,
-            name + "_subleading_Eta_pass" + suffix, 20, -5.0, 5.0));
+      // SubLeading
+      histos.subleading_electron.hPt_Barrel_fireTrigObj.push_back(ibook.book1D(
+          name + "_subleading_Pt_Barrel_pass" + suffix, name + "_subleading_Pt_Barrel_pass" + suffix, 40, 0, 200));
+      histos.subleading_electron.hPt_Endcap_fireTrigObj.push_back(ibook.book1D(
+          name + "_subleading_Pt_Endcap_pass" + suffix, name + "_subleading_Pt_Endcap_pass" + suffix, 40, 0, 200));
+      histos.subleading_electron.hEta_fireTrigObj.push_back(
+          ibook.book1D(name + "_subleading_Eta_pass" + suffix, name + "_subleading_Eta_pass" + suffix, 20, -5.0, 5.0));
     }
-
-
   }
 
   for (auto const& l1seed : l1Seeds_) {

--- a/HLTriggerOffline/Scouting/plugins/PatElectronTagProbeAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/PatElectronTagProbeAnalyzer.cc
@@ -31,6 +31,18 @@
 //  Class declaration  //
 /////////////////////////
 
+struct kTriggerSet {
+  std::string pathName;
+  std::vector<std::string> filters;
+};
+
+struct kTriggerSetResult {
+  std::string pathName;
+  std::vector<std::string> filters;
+  bool passTrigger;
+  std::map<std::string, trigger::TriggerObjectCollection> filterObjects;
+};
+
 struct kProbeFilterHistos {
   dqm::reco::MonitorElement* hPt_Barrel_passBaseDST;
   dqm::reco::MonitorElement* hPt_Endcap_passBaseDST;
@@ -126,8 +138,7 @@ private:
 
   void fillHistograms_resonance(const kProbeKinematicHistos& histos,
                                 const pat::Electron& el,
-                                const std::vector<bool> trigger_result,
-                                const trigger::TriggerObjectCollection* legObjects,
+                                const std::vector<kTriggerSetResult>& trigger_set_result,
                                 const trigger::TriggerObjectCollection* l1_legObjects,
                                 const std::vector<bool> l1_result,
                                 const bool pass_baseDST,
@@ -137,8 +148,7 @@ private:
   void fillHistograms_resonance_sct(const kProbeKinematicHistos& histos,
                                     const Run3ScoutingElectron& el,
                                     const int gsfTrackIndex,
-                                    const std::vector<bool> trigger_result,
-                                    const trigger::TriggerObjectCollection* legObjects,
+                                    const std::vector<kTriggerSetResult>& trigger_set_result,
                                     const trigger::TriggerObjectCollection* l1_legObjects,
                                     const std::vector<bool> l1_result,
                                     const bool pass_baseDST,
@@ -155,10 +165,11 @@ private:
   const std::string outputInternalPath_;
 
   const std::vector<std::string> vBaseTriggerSelection_;
-  const std::vector<std::string> vtriggerSelection_;
-  const std::vector<std::string> filterToMatch_;
+  const std::vector<edm::ParameterSet> vtriggerConfig_;
   const std::vector<std::string> l1filterToMatch_;
   const std::vector<unsigned int> l1filterIndex_;
+
+  std::vector<kTriggerSet> vtriggerSet_;
 
   edm::EDGetToken algToken_;
   std::shared_ptr<l1t::L1TGlobalUtil> l1GtUtils_;
@@ -176,8 +187,7 @@ using namespace ROOT;
 PatElectronTagProbeAnalyzer::PatElectronTagProbeAnalyzer(const edm::ParameterSet& iConfig)
     : outputInternalPath_(iConfig.getParameter<std::string>("OutputInternalPath")),
       vBaseTriggerSelection_{iConfig.getParameter<std::vector<std::string>>("BaseTriggerSelection")},
-      vtriggerSelection_{iConfig.getParameter<std::vector<std::string>>("triggerSelection")},
-      filterToMatch_{iConfig.getParameter<std::vector<std::string>>("finalfilterSelection")},
+      vtriggerConfig_{iConfig.getParameter<std::vector<edm::ParameterSet>>("triggerConfigs")},
       l1filterToMatch_{iConfig.getParameter<std::vector<std::string>>("l1filterSelection")},
       l1filterIndex_{iConfig.getParameter<std::vector<unsigned int>>("l1filterSelectionIndex")},
       algToken_{consumes<BXVector<GlobalAlgBlk>>(iConfig.getParameter<edm::InputTag>("AlgInputTag"))},
@@ -191,6 +201,9 @@ PatElectronTagProbeAnalyzer::PatElectronTagProbeAnalyzer(const edm::ParameterSet
       eleIdMapTightToken_(consumes<edm::ValueMap<bool>>(iConfig.getParameter<edm::InputTag>("eleIdMapTight"))) {
   l1GtUtils_ = std::make_shared<l1t::L1TGlobalUtil>(iConfig, consumesCollector(), l1t::UseEventSetupIn::RunAndEvent);
   l1Seeds_ = iConfig.getParameter<std::vector<std::string>>("L1Seeds");
+  for (const auto& pset : vtriggerConfig_) {
+    vtriggerSet_.push_back({pset.getParameter<std::string>("pathName"), pset.getParameter<std::vector<std::string>>("filters")});
+  }
 }
 
 void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
@@ -232,16 +245,25 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
     edm::LogWarning("ScoutingEGammaCollectionMonitoring") << "Trgger Results not found.";
     return;
   }
+
   int nTriggers = triggerResults->size();
-  std::vector<bool> vtrigger_result(vtriggerSelection_.size(), false);
-  bool passBaseDST = false;
   const edm::TriggerNames& triggerNames = iEvent.triggerNames(*triggerResults);
+
+  std::vector<kTriggerSetResult> vtriggerSetResults;
+  vtriggerSetResults.reserve(vtriggerSet_.size());
+  for(const auto& config : vtriggerSet_) {
+    vtriggerSetResults.push_back({config.pathName, config.filters, false, {}});
+  }
+
+  bool passBaseDST = false;
   for (int i_Trig = 0; i_Trig < nTriggers; i_Trig++) {
     if (triggerResults.product()->accept(i_Trig)) {
       TString TrigPath = triggerNames.triggerName(i_Trig);
-      for (unsigned int i_selectTrig = 0; i_selectTrig < vtriggerSelection_.size(); i_selectTrig++) {
-        if (TrigPath.Index(vtriggerSelection_.at(i_selectTrig)) >= 0) {
-          vtrigger_result[i_selectTrig] = true;
+      for (auto& result : vtriggerSetResults) {
+        if (!result.passTrigger) {
+           if (TrigPath.Index(result.pathName) >= 0) {
+             result.passTrigger = true;
+           }
         }
       }
 
@@ -254,17 +276,17 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
   }
 
   // Trigger Object Matching
-  size_t numberOfFilters = filterToMatch_.size();
-  trigger::TriggerObjectCollection* legObjects = new trigger::TriggerObjectCollection[numberOfFilters];
-  for (size_t iteFilter = 0; iteFilter < filterToMatch_.size(); iteFilter++) {
-    std::string filterTag = filterToMatch_.at(iteFilter);
-    for (pat::TriggerObjectStandAlone obj : *triggerObjects) {
+  for (pat::TriggerObjectStandAlone obj : *triggerObjects) {
       obj.unpackNamesAndLabels(iEvent, *triggerResults);
-      if (obj.hasFilterLabel(filterTag)) {
-        legObjects[iteFilter].push_back(obj);
+      for (auto& result : vtriggerSetResults) {
+          for (const auto& filterName : result.filters) {
+              if (obj.hasFilterLabel(filterName)) {
+                  result.filterObjects[filterName].push_back(obj);
+              }
+          }
       }
-    }
   }
+  
 
   // L1 Object Matching
   size_t numberOfl1Filters = l1filterToMatch_.size();
@@ -355,8 +377,7 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
       if ((TandP_Z_minMass < invMass) && (invMass < TandP_Z_maxMass)) {
         fillHistograms_resonance(histos.patElectron.resonanceZ,
                                  pat_el_second,
-                                 vtrigger_result,
-                                 legObjects,
+                                 vtriggerSetResults,
                                  l1_legObjects,
                                  l1_result,
                                  passBaseDST,
@@ -364,8 +385,7 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
                                  second_pat_pt_order);
         fillHistograms_resonance(histos.patElectron.resonanceAll,
                                  pat_el_second,
-                                 vtrigger_result,
-                                 legObjects,
+                                 vtriggerSetResults,
                                  l1_legObjects,
                                  l1_result,
                                  passBaseDST,
@@ -377,8 +397,7 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
       if ((TandP_jpsi_minMass < invMass) && (invMass < TandP_jpsi_maxMass)) {
         fillHistograms_resonance(histos.patElectron.resonanceJ,
                                  pat_el_second,
-                                 vtrigger_result,
-                                 legObjects,
+                                 vtriggerSetResults,
                                  l1_legObjects,
                                  l1_result,
                                  passBaseDST,
@@ -386,8 +405,7 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
                                  second_pat_pt_order);  // J/Psi mass: 3.3 +/- 0.2 GeV
         fillHistograms_resonance(histos.patElectron.resonanceAll,
                                  pat_el_second,
-                                 vtrigger_result,
-                                 legObjects,
+                                 vtriggerSetResults,
                                  l1_legObjects,
                                  l1_result,
                                  passBaseDST,
@@ -399,8 +417,7 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
       if ((TandP_ups_minMass < invMass) && (invMass < TandP_ups_maxMass)) {
         fillHistograms_resonance(histos.patElectron.resonanceY,
                                  pat_el_second,
-                                 vtrigger_result,
-                                 legObjects,
+                                 vtriggerSetResults,
                                  l1_legObjects,
                                  l1_result,
                                  passBaseDST,
@@ -408,8 +425,7 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
                                  second_pat_pt_order);  // Y mass: 9.8 +/- 0.4 GeV & 10.6 +/- 1 GeV
         fillHistograms_resonance(histos.patElectron.resonanceAll,
                                  pat_el_second,
-                                 vtrigger_result,
-                                 legObjects,
+                                 vtriggerSetResults,
                                  l1_legObjects,
                                  l1_result,
                                  passBaseDST,
@@ -446,8 +462,7 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
         fillHistograms_resonance_sct(histos.sctElectron.resonanceZ,
                                      sct_el_second,
                                      gsfTrackIndex,
-                                     vtrigger_result,
-                                     legObjects,
+                                     vtriggerSetResults,
                                      l1_legObjects,
                                      l1_result,
                                      passBaseDST,
@@ -456,8 +471,7 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
         fillHistograms_resonance_sct(histos.sctElectron.resonanceAll,
                                      sct_el_second,
                                      gsfTrackIndex,
-                                     vtrigger_result,
-                                     legObjects,
+                                     vtriggerSetResults,
                                      l1_legObjects,
                                      l1_result,
                                      passBaseDST,
@@ -468,8 +482,7 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
         fillHistograms_resonance_sct(histos.sctElectron.resonanceJ,
                                      sct_el_second,
                                      gsfTrackIndex,
-                                     vtrigger_result,
-                                     legObjects,
+                                     vtriggerSetResults,
                                      l1_legObjects,
                                      l1_result,
                                      passBaseDST,
@@ -478,8 +491,7 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
         fillHistograms_resonance_sct(histos.sctElectron.resonanceAll,
                                      sct_el_second,
                                      gsfTrackIndex,
-                                     vtrigger_result,
-                                     legObjects,
+                                     vtriggerSetResults,
                                      l1_legObjects,
                                      l1_result,
                                      passBaseDST,
@@ -490,8 +502,7 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
         fillHistograms_resonance_sct(histos.sctElectron.resonanceY,
                                      sct_el_second,
                                      gsfTrackIndex,
-                                     vtrigger_result,
-                                     legObjects,
+                                     vtriggerSetResults,
                                      l1_legObjects,
                                      l1_result,
                                      passBaseDST,
@@ -500,8 +511,7 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
         fillHistograms_resonance_sct(histos.sctElectron.resonanceAll,
                                      sct_el_second,
                                      gsfTrackIndex,
-                                     vtrigger_result,
-                                     legObjects,
+                                     vtriggerSetResults,
                                      l1_legObjects,
                                      l1_result,
                                      passBaseDST,
@@ -514,8 +524,7 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
 
 void PatElectronTagProbeAnalyzer::fillHistograms_resonance(const kProbeKinematicHistos& histos,
                                                            const pat::Electron& el,
-                                                           const std::vector<bool> trigger_result,
-                                                           const trigger::TriggerObjectCollection* legObjects,
+                                                           const std::vector<kTriggerSetResult>& triggerset_result,
                                                            const trigger::TriggerObjectCollection* l1_legObjects,
                                                            const std::vector<bool> l1_result,
                                                            const bool pass_baseDST,
@@ -542,58 +551,51 @@ void PatElectronTagProbeAnalyzer::fillHistograms_resonance(const kProbeKinematic
     histos.hPtvsInvMass_Barrel->Fill(el.pt(), inv_mass);
 
     if (pass_baseDST) {
-      if (pt_order == 0) {
-        histos.leading_electron.hPt_Barrel_passBaseDST->Fill(el.pt());
-        histos.leading_electron.hEta_passBaseDST->Fill(el.eta());
-        for (unsigned int iTrig = 0; iTrig < vtriggerSelection_.size(); iTrig++) {
-          if (trigger_result[iTrig]) {
-            histos.leading_electron.hPt_Barrel_passDST[iTrig]->Fill(el.pt());
-            histos.leading_electron.hEta_passDST[iTrig]->Fill(el.eta());
-          }
-          if (patElectron_passHLT(el, legObjects[iTrig])) {
-            histos.leading_electron.hPt_Barrel_fireTrigObj[iTrig]->Fill(el.pt());
-            histos.leading_electron.hEta_fireTrigObj[iTrig]->Fill(el.eta());
-          }
-        }
+      auto*  selected_histos = (pt_order == 0) ? &histos.leading_electron : 
+                              (pt_order == 1) ? &histos.subleading_electron : nullptr;
+      if (selected_histos) {
+          selected_histos->hPt_Barrel_passBaseDST->Fill(el.pt());
+          selected_histos->hEta_passBaseDST->Fill(el.eta());
+          int filter_idx_counter = 0; // Keeps track of flattened filter histogram index
+          for (size_t i = 0; i < triggerset_result.size(); i++) {
+              const auto& res = triggerset_result[i];
+              // Pass Trigger Path
+              if (res.passTrigger) {
+                  selected_histos->hPt_Barrel_passDST[i]->Fill(el.pt());
+                  selected_histos->hEta_passDST[i]->Fill(el.eta());
+              }
+              // Pass Filter Objects
+              for (const auto& filterName : res.filters) {
+                  bool passObj = false;
+                  // Check if we have objects for this filter
+                  auto it = res.filterObjects.find(filterName);
+                  if (it != res.filterObjects.end()) {
+                      if (patElectron_passHLT(el, it->second)) {
+                          passObj = true;
+                      }
+                  }
+                  if (passObj) {
+                      selected_histos->hPt_Barrel_fireTrigObj[filter_idx_counter]->Fill(el.pt());
+                      selected_histos->hEta_fireTrigObj[filter_idx_counter]->Fill(el.eta());
+                  }
 
-        for (unsigned int il1seed = 0; il1seed < l1Seeds_.size(); il1seed++) {
-          if (l1_result[il1seed]) {
-            unsigned int ifilter = 0;
-            while ((ifilter < l1filterIndex_.size()) && (il1seed >= l1filterIndex_[ifilter]))
-              ifilter++;
-            if (!(patElectron_passHLT(el, l1_legObjects[ifilter])))
-              continue;
-            // check if electron fire the l1 seed leg
-            histos.leading_electron.hPt_Barrel_fireL1[il1seed]->Fill(el.pt());
-            histos.leading_electron.hEta_fireL1[il1seed]->Fill(el.eta());
+                  filter_idx_counter++;
+              }
           }
-        }
-      } else if (pt_order == 1) {
-        histos.subleading_electron.hPt_Barrel_passBaseDST->Fill(el.pt());
-        histos.subleading_electron.hEta_passBaseDST->Fill(el.eta());
-        for (unsigned int iTrig = 0; iTrig < vtriggerSelection_.size(); iTrig++) {
-          if (trigger_result[iTrig]) {
-            histos.subleading_electron.hPt_Barrel_passDST[iTrig]->Fill(el.pt());
-            histos.subleading_electron.hEta_passDST[iTrig]->Fill(el.eta());
-          }
-          if (patElectron_passHLT(el, legObjects[iTrig])) {
-            histos.subleading_electron.hPt_Barrel_fireTrigObj[iTrig]->Fill(el.pt());
-            histos.subleading_electron.hEta_fireTrigObj[iTrig]->Fill(el.eta());
-          }
-        }
 
-        for (unsigned int il1seed = 0; il1seed < l1Seeds_.size(); il1seed++) {
-          if (l1_result[il1seed]) {
-            unsigned int ifilter = 0;
-            while ((ifilter < l1filterIndex_.size()) && (il1seed >= l1filterIndex_[ifilter]))
-              ifilter++;
-            if (!(patElectron_passHLT(el, l1_legObjects[ifilter])))
-              continue;
-            histos.subleading_electron.hPt_Barrel_fireL1[il1seed]->Fill(el.pt());
-            histos.subleading_electron.hEta_fireL1[il1seed]->Fill(el.eta());
+          for (unsigned int il1seed = 0; il1seed < l1Seeds_.size(); il1seed++) {
+              if (l1_result[il1seed]) {
+                  unsigned int ifilter = 0;
+                  while ((ifilter < l1filterIndex_.size()) && (il1seed >= l1filterIndex_[ifilter]))
+                      ifilter++;
+                  if (!(patElectron_passHLT(el, l1_legObjects[ifilter])))
+                      continue;
+                  // check if electron fire the l1 seed leg
+                  selected_histos->hPt_Barrel_fireL1[il1seed]->Fill(el.pt());
+                  selected_histos->hEta_fireL1[il1seed]->Fill(el.eta());
+              }
           }
-        }
-      }
+      } 
     }
   } else {
     histos.hPt_Endcap->Fill(el.pt());
@@ -611,57 +613,52 @@ void PatElectronTagProbeAnalyzer::fillHistograms_resonance(const kProbeKinematic
     histos.hPtvsInvMass_Endcap->Fill(el.pt(), inv_mass);
 
     if (pass_baseDST) {
-      if (pt_order == 0) {
-        histos.leading_electron.hPt_Endcap_passBaseDST->Fill(el.pt());
-        histos.leading_electron.hEta_passBaseDST->Fill(el.eta());
-        for (unsigned int iTrig = 0; iTrig < vtriggerSelection_.size(); iTrig++) {
-          if (trigger_result[iTrig]) {
-            histos.leading_electron.hPt_Endcap_passDST[iTrig]->Fill(el.pt());
-            histos.leading_electron.hEta_passDST[iTrig]->Fill(el.eta());
-          }
-          if (patElectron_passHLT(el, legObjects[iTrig])) {
-            histos.leading_electron.hPt_Endcap_fireTrigObj[iTrig]->Fill(el.pt());
-            histos.leading_electron.hEta_fireTrigObj[iTrig]->Fill(el.eta());
-          }
-        }
+        auto* selected_histos = (pt_order == 0) ? &histos.leading_electron :
+                                (pt_order == 1) ? &histos.subleading_electron : nullptr;
+        if (selected_histos){
+            selected_histos->hPt_Endcap_passBaseDST->Fill(el.pt());
+            selected_histos->hEta_passBaseDST->Fill(el.eta());
 
-        for (unsigned int il1seed = 0; il1seed < l1Seeds_.size(); il1seed++) {
-          if (l1_result[il1seed]) {
-            unsigned int ifilter = 0;
-            while ((ifilter < l1filterIndex_.size()) && (il1seed >= l1filterIndex_[ifilter]))
-              ifilter++;
-            if (!(patElectron_passHLT(el, l1_legObjects[ifilter])))
-              continue;
-            histos.leading_electron.hPt_Endcap_fireL1[il1seed]->Fill(el.pt());
-            histos.leading_electron.hEta_fireL1[il1seed]->Fill(el.eta());
-          }
-        }
-      } else if (pt_order == 1) {
-        histos.subleading_electron.hPt_Endcap_passBaseDST->Fill(el.pt());
-        histos.subleading_electron.hEta_passBaseDST->Fill(el.eta());
-        for (unsigned int iTrig = 0; iTrig < vtriggerSelection_.size(); iTrig++) {
-          if (trigger_result[iTrig]) {
-            histos.subleading_electron.hPt_Endcap_passDST[iTrig]->Fill(el.pt());
-            histos.subleading_electron.hEta_passDST[iTrig]->Fill(el.eta());
-          }
-          if (patElectron_passHLT(el, legObjects[iTrig])) {
-            histos.subleading_electron.hPt_Endcap_fireTrigObj[iTrig]->Fill(el.pt());
-            histos.subleading_electron.hEta_fireTrigObj[iTrig]->Fill(el.eta());
-          }
-        }
+            int filter_idx_counter = 0; // Keeps track of flattened filter histogram index
+            for (size_t i = 0; i < triggerset_result.size(); i++) {
+                const auto& res = triggerset_result[i];
+                // Pass Trigger Path
+                if (res.passTrigger) {
+                    selected_histos->hPt_Endcap_passDST[i]->Fill(el.pt());
+                    selected_histos->hEta_passDST[i]->Fill(el.eta());
+                }
+                // Pass Filter Objects
+                for (const auto& filterName : res.filters) {
+                    bool passObj = false;
+                    // Check if we have objects for this filter
+                    auto it = res.filterObjects.find(filterName);
+                    if (it != res.filterObjects.end()) {
+                        if (patElectron_passHLT(el, it->second)) {
+                            passObj = true;
+                        }
+                    }
+                    if (passObj) {
+                        selected_histos->hPt_Endcap_fireTrigObj[filter_idx_counter]->Fill(el.pt());
+                        selected_histos->hEta_fireTrigObj[filter_idx_counter]->Fill(el.eta());
+                    }
 
-        for (unsigned int il1seed = 0; il1seed < l1Seeds_.size(); il1seed++) {
-          if (l1_result[il1seed]) {
-            unsigned int ifilter = 0;
-            while ((ifilter < l1filterIndex_.size()) && (il1seed >= l1filterIndex_[ifilter]))
-              ifilter++;
-            if (!(patElectron_passHLT(el, l1_legObjects[ifilter])))
-              continue;
-            histos.subleading_electron.hPt_Endcap_fireL1[il1seed]->Fill(el.pt());
-            histos.subleading_electron.hEta_fireL1[il1seed]->Fill(el.eta());
-          }
+                    filter_idx_counter++;
+                }
+            }
+
+            for (unsigned int il1seed = 0; il1seed < l1Seeds_.size(); il1seed++) {
+                if (l1_result[il1seed]) {
+                    unsigned int ifilter = 0;
+                    while ((ifilter < l1filterIndex_.size()) && (il1seed >= l1filterIndex_[ifilter]))
+                        ifilter++;
+                    if (!(patElectron_passHLT(el, l1_legObjects[ifilter])))
+                        continue;
+                    // check if electron fire the l1 seed leg
+                    selected_histos->hPt_Endcap_fireL1[il1seed]->Fill(el.pt());
+                    selected_histos->hEta_fireL1[il1seed]->Fill(el.eta());
+                }
+            }
         }
-      }
     }
   }
 }
@@ -669,8 +666,7 @@ void PatElectronTagProbeAnalyzer::fillHistograms_resonance(const kProbeKinematic
 void PatElectronTagProbeAnalyzer::fillHistograms_resonance_sct(const kProbeKinematicHistos& histos,
                                                                const Run3ScoutingElectron& el,
                                                                const int gsfTrackIndex,
-                                                               const std::vector<bool> trigger_result,
-                                                               const trigger::TriggerObjectCollection* legObjects,
+                                                               const std::vector<kTriggerSetResult>& triggerset_result,
                                                                const trigger::TriggerObjectCollection* l1_legObjects,
                                                                const std::vector<bool> l1_result,
                                                                const bool pass_baseDST,
@@ -711,65 +707,53 @@ void PatElectronTagProbeAnalyzer::fillHistograms_resonance_sct(const kProbeKinem
     }
 
     if (pass_baseDST) {
-      if (pt_order == 0) {
-        histos.leading_electron.hPt_Barrel_passBaseDST->Fill(el.pt());
-        histos.leading_electron.hEta_passBaseDST->Fill(el.eta());
 
-        for (unsigned int iTrig = 0; iTrig < vtriggerSelection_.size(); iTrig++) {
-          if (trigger_result[iTrig]) {
-            histos.leading_electron.hPt_Barrel_passDST[iTrig]->Fill(el.pt());
-            histos.leading_electron.hEta_passDST[iTrig]->Fill(el.eta());
-          }
-          if (scoutingElectron_passHLT(
-                  el.trketaMode()[gsfTrackIndex], el.trkphiMode()[gsfTrackIndex], legObjects[iTrig])) {
-            histos.leading_electron.hPt_Barrel_fireTrigObj[iTrig]->Fill(el.pt());
-            histos.leading_electron.hEta_fireTrigObj[iTrig]->Fill(el.eta());
-          }
-        }
+      auto*  selected_histos = (pt_order == 0) ? &histos.leading_electron : 
+                              (pt_order == 1) ? &histos.subleading_electron : nullptr;
+      if (selected_histos) {
+          selected_histos->hPt_Barrel_passBaseDST->Fill(el.pt());
+          selected_histos->hEta_passBaseDST->Fill(el.eta());
+          int filter_idx_counter = 0; // Keeps track of flattened filter histogram index
+          for (size_t i = 0; i < triggerset_result.size(); i++) {
+              const auto& res = triggerset_result[i];
+              // Pass Trigger Path
+              if (res.passTrigger) {
+                  selected_histos->hPt_Barrel_passDST[i]->Fill(el.pt());
+                  selected_histos->hEta_passDST[i]->Fill(el.eta());
+              }
+              // Pass Filter Objects
+              for (const auto& filterName : res.filters) {
+                  bool passObj = false;
+                  // Check if we have objects for this filter
+                  auto it = res.filterObjects.find(filterName);
+                  if (it != res.filterObjects.end()) {
+                      if (scoutingElectron_passHLT(el.trketaMode()[gsfTrackIndex], el.trkphiMode()[gsfTrackIndex], it->second)) {
+                          passObj = true;
+                      }
+                  }
+                  if (passObj) {
+                      selected_histos->hPt_Barrel_fireTrigObj[filter_idx_counter]->Fill(el.pt());
+                      selected_histos->hEta_fireTrigObj[filter_idx_counter]->Fill(el.eta());
+                  }
 
-        for (unsigned int il1seed = 0; il1seed < l1Seeds_.size(); il1seed++) {
-          if (l1_result[il1seed]) {
-            unsigned int ifilter = 0;
-            while ((ifilter < l1filterIndex_.size()) && (il1seed >= l1filterIndex_[ifilter]))
-              ifilter++;
-            if (!(scoutingElectron_passHLT(
-                    el.trketaMode()[gsfTrackIndex], el.trkphiMode()[gsfTrackIndex], l1_legObjects[ifilter])))
-              continue;
-
-            histos.leading_electron.hPt_Barrel_fireL1[il1seed]->Fill(el.pt());
-            histos.leading_electron.hEta_fireL1[il1seed]->Fill(el.eta());
+                  filter_idx_counter++;
+              }
           }
-        }
-      } else if (pt_order == 1) {
-        histos.subleading_electron.hPt_Barrel_passBaseDST->Fill(el.pt());
-        histos.subleading_electron.hEta_passBaseDST->Fill(el.eta());
 
-        for (unsigned int iTrig = 0; iTrig < vtriggerSelection_.size(); iTrig++) {
-          if (trigger_result[iTrig]) {
-            histos.subleading_electron.hPt_Barrel_passDST[iTrig]->Fill(el.pt());
-            histos.subleading_electron.hEta_passDST[iTrig]->Fill(el.eta());
+          for (unsigned int il1seed = 0; il1seed < l1Seeds_.size(); il1seed++) {
+              if (l1_result[il1seed]) {
+                  unsigned int ifilter = 0;
+                  while ((ifilter < l1filterIndex_.size()) && (il1seed >= l1filterIndex_[ifilter]))
+                      ifilter++;
+                  if (!(scoutingElectron_passHLT(
+                      el.trketaMode()[gsfTrackIndex], el.trkphiMode()[gsfTrackIndex], l1_legObjects[ifilter])))
+                  continue;
+                  // check if electron fire the l1 seed leg
+                  selected_histos->hPt_Barrel_fireL1[il1seed]->Fill(el.pt());
+                  selected_histos->hEta_fireL1[il1seed]->Fill(el.eta());
+              }
           }
-          if (scoutingElectron_passHLT(
-                  el.trketaMode()[gsfTrackIndex], el.trkphiMode()[gsfTrackIndex], legObjects[iTrig])) {
-            histos.subleading_electron.hPt_Barrel_fireTrigObj[iTrig]->Fill(el.pt());
-            histos.subleading_electron.hEta_fireTrigObj[iTrig]->Fill(el.eta());
-          }
-        }
-
-        for (unsigned int il1seed = 0; il1seed < l1Seeds_.size(); il1seed++) {
-          if (l1_result[il1seed]) {
-            unsigned int ifilter = 0;
-            while ((ifilter < l1filterIndex_.size()) && (il1seed >= l1filterIndex_[ifilter]))
-              ifilter++;
-            if (!(scoutingElectron_passHLT(
-                    el.trketaMode()[gsfTrackIndex], el.trkphiMode()[gsfTrackIndex], l1_legObjects[ifilter])))
-              continue;
-
-            histos.subleading_electron.hPt_Barrel_fireL1[il1seed]->Fill(el.pt());
-            histos.subleading_electron.hEta_fireL1[il1seed]->Fill(el.eta());
-          }
-        }
-      }
+      } 
     }
   } else {
     histos.hPt_Endcap->Fill(el.pt());
@@ -801,65 +785,52 @@ void PatElectronTagProbeAnalyzer::fillHistograms_resonance_sct(const kProbeKinem
     }
 
     if (pass_baseDST) {
-      if (pt_order == 0) {
-        histos.leading_electron.hPt_Endcap_passBaseDST->Fill(el.pt());
-        histos.leading_electron.hEta_passBaseDST->Fill(el.eta());
+      auto*  selected_histos = (pt_order == 0) ? &histos.leading_electron : 
+                              (pt_order == 1) ? &histos.subleading_electron : nullptr;
+      if (selected_histos) {
+          selected_histos->hPt_Endcap_passBaseDST->Fill(el.pt());
+          selected_histos->hEta_passBaseDST->Fill(el.eta());
+          int filter_idx_counter = 0; // Keeps track of flattened filter histogram index
+          for (size_t i = 0; i < triggerset_result.size(); i++) {
+              const auto& res = triggerset_result[i];
+              // Pass Trigger Path
+              if (res.passTrigger) {
+                  selected_histos->hPt_Endcap_passDST[i]->Fill(el.pt());
+                  selected_histos->hEta_passDST[i]->Fill(el.eta());
+              }
+              // Pass Filter Objects
+              for (const auto& filterName : res.filters) {
+                  bool passObj = false;
+                  // Check if we have objects for this filter
+                  auto it = res.filterObjects.find(filterName);
+                  if (it != res.filterObjects.end()) {
+                      if (scoutingElectron_passHLT(el.trketaMode()[gsfTrackIndex], el.trkphiMode()[gsfTrackIndex], it->second)) {
+                          passObj = true;
+                      }
+                  }
+                  if (passObj) {
+                      selected_histos->hPt_Endcap_fireTrigObj[filter_idx_counter]->Fill(el.pt());
+                      selected_histos->hEta_fireTrigObj[filter_idx_counter]->Fill(el.eta());
+                  }
 
-        for (unsigned int iTrig = 0; iTrig < vtriggerSelection_.size(); iTrig++) {
-          if (trigger_result[iTrig]) {
-            histos.leading_electron.hPt_Endcap_passDST[iTrig]->Fill(el.pt());
-            histos.leading_electron.hEta_passDST[iTrig]->Fill(el.eta());
+                  filter_idx_counter++;
+              }
           }
-          if (scoutingElectron_passHLT(
-                  el.trketaMode()[gsfTrackIndex], el.trkphiMode()[gsfTrackIndex], legObjects[iTrig])) {
-            histos.leading_electron.hPt_Endcap_fireTrigObj[iTrig]->Fill(el.pt());
-            histos.leading_electron.hEta_fireTrigObj[iTrig]->Fill(el.eta());
-          }
-        }
 
-        for (unsigned int il1seed = 0; il1seed < l1Seeds_.size(); il1seed++) {
-          if (l1_result[il1seed]) {
-            unsigned int ifilter = 0;
-            while ((ifilter < l1filterIndex_.size()) && (il1seed >= l1filterIndex_[ifilter]))
-              ifilter++;
-            if (!(scoutingElectron_passHLT(
-                    el.trketaMode()[gsfTrackIndex], el.trkphiMode()[gsfTrackIndex], l1_legObjects[ifilter])))
-              continue;
-
-            histos.leading_electron.hPt_Endcap_fireL1[il1seed]->Fill(el.pt());
-            histos.leading_electron.hEta_fireL1[il1seed]->Fill(el.eta());
+          for (unsigned int il1seed = 0; il1seed < l1Seeds_.size(); il1seed++) {
+              if (l1_result[il1seed]) {
+                  unsigned int ifilter = 0;
+                  while ((ifilter < l1filterIndex_.size()) && (il1seed >= l1filterIndex_[ifilter]))
+                      ifilter++;
+                  if (!(scoutingElectron_passHLT(
+                      el.trketaMode()[gsfTrackIndex], el.trkphiMode()[gsfTrackIndex], l1_legObjects[ifilter])))
+                  continue;
+                  // check if electron fire the l1 seed leg
+                  selected_histos->hPt_Endcap_fireL1[il1seed]->Fill(el.pt());
+                  selected_histos->hEta_fireL1[il1seed]->Fill(el.eta());
+              }
           }
-        }
-      } else if (pt_order == 1) {
-        histos.subleading_electron.hPt_Endcap_passBaseDST->Fill(el.pt());
-        histos.subleading_electron.hEta_passBaseDST->Fill(el.eta());
-
-        for (unsigned int iTrig = 0; iTrig < vtriggerSelection_.size(); iTrig++) {
-          if (trigger_result[iTrig]) {
-            histos.subleading_electron.hPt_Endcap_passDST[iTrig]->Fill(el.pt());
-            histos.subleading_electron.hEta_passDST[iTrig]->Fill(el.eta());
-          }
-          if (scoutingElectron_passHLT(
-                  el.trketaMode()[gsfTrackIndex], el.trkphiMode()[gsfTrackIndex], legObjects[iTrig])) {
-            histos.subleading_electron.hPt_Endcap_fireTrigObj[iTrig]->Fill(el.pt());
-            histos.subleading_electron.hEta_fireTrigObj[iTrig]->Fill(el.eta());
-          }
-        }
-
-        for (unsigned int il1seed = 0; il1seed < l1Seeds_.size(); il1seed++) {
-          if (l1_result[il1seed]) {
-            unsigned int ifilter = 0;
-            while ((ifilter < l1filterIndex_.size()) && (il1seed >= l1filterIndex_[ifilter]))
-              ifilter++;
-            if (!(scoutingElectron_passHLT(
-                    el.trketaMode()[gsfTrackIndex], el.trkphiMode()[gsfTrackIndex], l1_legObjects[ifilter])))
-              continue;
-
-            histos.subleading_electron.hPt_Endcap_fireL1[il1seed]->Fill(el.pt());
-            histos.subleading_electron.hEta_fireL1[il1seed]->Fill(el.eta());
-          }
-        }
-      }
+      } 
     }
   }
 }
@@ -979,63 +950,70 @@ void PatElectronTagProbeAnalyzer::bookHistograms_resonance(DQMStore::IBooker& ib
   histos.subleading_electron.hEta_passBaseDST =
       ibook.book1D(name + "_subleading_Eta_passBaseDST", name + "_subleading_Eta_passBaseDST", 20, -5.0, 5.0);
 
-  for (auto const& vt : vtriggerSelection_) {
-    std::string cleaned_vt = vt;
-    cleaned_vt.erase(std::remove(cleaned_vt.begin(), cleaned_vt.end(), '*'), cleaned_vt.end());
 
-    // Leading Electron
-    histos.leading_electron.hPt_Barrel_passDST.push_back(ibook.book1D(
-        name + "_leading_Pt_Barrel_pass" + cleaned_vt, name + "_leading_Pt_Barrel_pass" + cleaned_vt, 40, 0, 200));
-    histos.leading_electron.hPt_Endcap_passDST.push_back(ibook.book1D(
-        name + "_leading_Pt_Endcap_pass" + cleaned_vt, name + "_leading_Pt_Endcap_pass" + cleaned_vt, 40, 0, 200));
-    histos.leading_electron.hEta_passDST.push_back(
-        ibook.book1D(name + "_leading_Eta_pass" + cleaned_vt, name + "_leading_Eta_pass" + cleaned_vt, 20, -5.0, 5.0));
+  for (const auto& config : vtriggerSet_) {
+      std::string cleaned_vt = config.pathName;
+      cleaned_vt.erase(std::remove(cleaned_vt.begin(), cleaned_vt.end(), '*'), cleaned_vt.end());
 
-    histos.leading_electron.hPt_Barrel_fireTrigObj.push_back(
-        ibook.book1D(name + "_leading_Pt_Barrel_pass" + cleaned_vt + "_fireTrigObj",
-                     name + "_leading_Pt_Barrel_pass" + cleaned_vt + "_fireTrigObj",
-                     40,
-                     0,
-                     200));
-    histos.leading_electron.hPt_Endcap_fireTrigObj.push_back(
-        ibook.book1D(name + "_leading_Pt_Endcap_pass" + cleaned_vt + "_fireTrigObj",
-                     name + "_leading_Pt_Endcap_pass" + cleaned_vt + "_fireTrigObj",
-                     40,
-                     0,
-                     200));
-    histos.leading_electron.hEta_fireTrigObj.push_back(
-        ibook.book1D(name + "_leading_Eta_pass" + cleaned_vt + "_fireTrigObj",
-                     name + "_leading_Eta_pass" + cleaned_vt + "_fireTrigObj",
-                     20,
-                     -5.0,
-                     5.0));
+      // =======================================================
+      // Pass DST
+      // =======================================================
+      // -- Leading Electron --
 
-    // SubLeading Electron
-    histos.subleading_electron.hPt_Barrel_passDST.push_back(ibook.book1D(
-        name + "_subleading_Pt_Barrel_pass" + cleaned_vt, name + "_subleading_Pt_Barrel_pass" + cleaned_vt, 40, 0, 200));
-    histos.subleading_electron.hPt_Endcap_passDST.push_back(ibook.book1D(
-        name + "_subleading_Pt_Endcap_pass" + cleaned_vt, name + "_subleading_Pt_Endcap_pass" + cleaned_vt, 40, 0, 200));
-    histos.subleading_electron.hEta_passDST.push_back(ibook.book1D(
-        name + "_subleading_Eta_pass" + cleaned_vt, name + "_subleading_Eta_pass" + cleaned_vt, 20, -5.0, 5.0));
+      histos.leading_electron.hPt_Barrel_passDST.push_back(ibook.book1D(
+            name + "_leading_Pt_Barrel_pass" + cleaned_vt,
+            name + "_leading_Pt_Barrel_pass" + cleaned_vt, 40, 0, 200));
+      histos.leading_electron.hPt_Endcap_passDST.push_back(ibook.book1D(
+            name + "_leading_Pt_Endcap_pass" + cleaned_vt,
+            name + "_leading_Pt_Endcap_pass" + cleaned_vt, 40, 0, 200));
+      histos.leading_electron.hEta_passDST.push_back(ibook.book1D(
+            name + "_leading_Eta_pass" + cleaned_vt,
+            name + "_leading_Eta_pass" + cleaned_vt, 20, -5.0, 5.0));
 
-    histos.subleading_electron.hPt_Barrel_fireTrigObj.push_back(
-        ibook.book1D(name + "_subleading_Pt_Barrel_pass" + cleaned_vt + "_fireTrigObj",
-                     name + "_subleading_Pt_Barrel_pass" + cleaned_vt + "_fireTrigObj",
-                     40,
-                     0,
-                     200));
-    histos.subleading_electron.hPt_Endcap_fireTrigObj.push_back(
-        ibook.book1D(name + "_subleading_Pt_Endcap_pass" + cleaned_vt + "_fireTrigObj",
-                     name + "_subleading_Pt_Endcap_pass" + cleaned_vt + "_fireTrigObj",
-                     40,
-                     0,
-                     200));
-    histos.subleading_electron.hEta_fireTrigObj.push_back(
-        ibook.book1D(name + "_subleading_Eta_pass" + cleaned_vt + "_fireTrigObj",
-                     name + "_subleading_Eta_pass" + cleaned_vt + "_fireTrigObj",
-                     20,
-                     -5.0,
-                     5.0));
+      // -- SubLeading Electron --
+      histos.subleading_electron.hPt_Barrel_passDST.push_back(ibook.book1D(
+            name + "_subleading_Pt_Barrel_pass" + cleaned_vt, 
+            name + "_subleading_Pt_Barrel_pass" + cleaned_vt, 40, 0, 200));
+      histos.subleading_electron.hPt_Endcap_passDST.push_back(ibook.book1D(
+            name + "_subleading_Pt_Endcap_pass" + cleaned_vt, 
+            name + "_subleading_Pt_Endcap_pass" + cleaned_vt, 40, 0, 200));
+      histos.subleading_electron.hEta_passDST.push_back(ibook.book1D(
+            name + "_subleading_Eta_pass" + cleaned_vt, 
+            name + "_subleading_Eta_pass" + cleaned_vt, 20, -5.0, 5.0));
+
+      // -----------------------------------------------------
+      // B. Book Fire TrigObj Histograms (Per Filter)
+      // -----------------------------------------------------
+      // These vectors will grow larger than the passDST vectors!
+      for (const auto& filterName : config.filters) {
+
+        // Create a unique name: Path + Filter
+        std::string suffix = cleaned_vt + "_" + filterName;
+
+        // Leading
+        histos.leading_electron.hPt_Barrel_fireTrigObj.push_back(ibook.book1D(
+            name + "_leading_Pt_Barrel_pass" + suffix,
+            name + "_leading_Pt_Barrel_pass" + suffix, 40, 0, 200));
+        histos.leading_electron.hPt_Endcap_fireTrigObj.push_back(ibook.book1D(
+            name + "_leading_Pt_Endcap_pass" + suffix,
+            name + "_leading_Pt_Endcap_pass" + suffix, 40, 0, 200));
+        histos.leading_electron.hEta_fireTrigObj.push_back(ibook.book1D(
+            name + "_leading_Eta_pass" + suffix,
+            name + "_leading_Eta_pass" + suffix, 20, -5.0, 5.0));
+
+        // SubLeading
+        histos.subleading_electron.hPt_Barrel_fireTrigObj.push_back(ibook.book1D(
+            name + "_subleading_Pt_Barrel_pass" + suffix,
+            name + "_subleading_Pt_Barrel_pass" + suffix, 40, 0, 200));
+        histos.subleading_electron.hPt_Endcap_fireTrigObj.push_back(ibook.book1D(
+            name + "_subleading_Pt_Endcap_pass" + suffix,
+            name + "_subleading_Pt_Endcap_pass" + suffix, 40, 0, 200));
+        histos.subleading_electron.hEta_fireTrigObj.push_back(ibook.book1D(
+            name + "_subleading_Eta_pass" + suffix,
+            name + "_subleading_Eta_pass" + suffix, 20, -5.0, 5.0));
+    }
+
+
   }
 
   for (auto const& l1seed : l1Seeds_) {
@@ -1061,10 +1039,12 @@ void PatElectronTagProbeAnalyzer::bookHistograms_resonance(DQMStore::IBooker& ib
 
 void PatElectronTagProbeAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
+  edm::ParameterSetDescription triggerConfigDesc;
+  triggerConfigDesc.add<std::string>("pathName", "");
+  triggerConfigDesc.add<std::vector<std::string>>("filters", {});
   desc.add<std::string>("OutputInternalPath", "MY_FOLDER");
   desc.add<std::vector<std::string>>("BaseTriggerSelection", {});
-  desc.add<std::vector<std::string>>("triggerSelection", {});
-  desc.add<std::vector<std::string>>("finalfilterSelection", {});
+  desc.addVPSet("triggerConfigs", triggerConfigDesc, {});
   desc.add<std::vector<std::string>>("l1filterSelection", {});
   desc.add<std::vector<unsigned int>>("l1filterSelectionIndex", {});
   desc.add<edm::InputTag>("AlgInputTag", edm::InputTag("gtStage2Digis"));

--- a/HLTriggerOffline/Scouting/plugins/ScoutingDQMUtils.h
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingDQMUtils.h
@@ -22,28 +22,28 @@ namespace scoutingDQMUtils {
   inline const bool scoutingElectronID(const Run3ScoutingElectron& el) {
     bool isEB = (std::abs(el.eta()) < scoutingDQMUtils::ELE_etaEB);
     if (isEB) {
-      if (el.sigmaIetaIeta() > 0.015)
+      if (el.sigmaIetaIeta() > 0.0146)
         return false;
       if (el.hOverE() > 0.2)
         return false;
-      if (std::abs(el.dEtaIn()) > 0.008)
+      if (std::abs(el.ooEMOop()) > 0.0641) 
         return false;
-      if (std::abs(el.dPhiIn()) > 0.06)
+      if (std::abs(el.dEtaIn()) > 0.0087)
         return false;
-      if (el.ecalIso() / el.pt() > 0.25)
+      if (std::abs(el.dPhiIn()) > 0.2653)
         return false;
       return true;
 
     } else {
-      if (el.sigmaIetaIeta() > 0.045)
+      if (el.sigmaIetaIeta() > 0.0305)
         return false;
       if (el.hOverE() > 0.2)
         return false;
-      if (std::abs(el.dEtaIn()) > 0.012)
+      if (std::abs(el.dEtaIn()) > 1.5994)
         return false;
-      if (std::abs(el.dPhiIn()) > 0.06)
+      if (std::abs(el.dPhiIn()) > 0.2728)
         return false;
-      if (el.ecalIso() / el.pt() > 0.1)
+      if (std::abs(el.ooEMOop()) > 0.0681)
         return false;
       return true;
     }

--- a/HLTriggerOffline/Scouting/plugins/ScoutingDQMUtils.h
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingDQMUtils.h
@@ -26,7 +26,7 @@ namespace scoutingDQMUtils {
         return false;
       if (el.hOverE() > 0.2)
         return false;
-      if (std::abs(el.ooEMOop()) > 0.0641) 
+      if (std::abs(el.ooEMOop()) > 0.0641)
         return false;
       if (std::abs(el.dEtaIn()) > 0.0087)
         return false;

--- a/HLTriggerOffline/Scouting/plugins/ScoutingEGammaCollectionMonitoring.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingEGammaCollectionMonitoring.cc
@@ -359,9 +359,9 @@ void ScoutingEGammaCollectionMonitoring::bookHistograms(DQMStore::IBooker& ibook
       ibook.book1D("patElectron_subleading_Phi", "patElectron_subleading_Phi", 660, -3.3, 3.3);
 
   // Inv Mass PAT Electron Summary
-  histos.patElectron.h1InvMass12 = ibook.book1D("patElectron_E1E2_invMass", "patElectron_E1E2_invMass", 400, 0., 200.);
+  histos.patElectron.h1InvMass12 = ibook.book1D("patElectron_E1E2_invMass", "patElectron_E1E2_invMass", 2000, 0., 200.);
   histos.patElectron.h1InvMassID =
-      ibook.book1D("patElectron_appliedID_invMass", "patElectron_appliedID_invMass", 400, 0., 200.);
+      ibook.book1D("patElectron_appliedID_invMass", "patElectron_appliedID_invMass", 2000, 0., 200.);
   // Scouting electron summary
   histos.sctElectron.h1N = ibook.book1D("all_sctElectron_electrons_N", "all_sctElectron_electrons_N", 20, 0., 20.);
   histos.sctElectron.electrons.h1Pt =
@@ -386,15 +386,15 @@ void ScoutingEGammaCollectionMonitoring::bookHistograms(DQMStore::IBooker& ibook
   histos.sctElectron.electron2.h1Phi =
       ibook.book1D("sctElectron_subleading_Phi", "sctElectron_subleading_Phi", 660, -3.3, 3.3);
 
-  histos.sctElectron.h1InvMass12 = ibook.book1D("sctElectron_E1E2_invMass", "sctElectron_E1E2_invMass", 400, 0., 200.);
+  histos.sctElectron.h1InvMass12 = ibook.book1D("sctElectron_E1E2_invMass", "sctElectron_E1E2_invMass", 2000, 0., 200.);
   histos.sctElectron.h1InvMassID =
-      ibook.book1D("sctElectron_appliedID_invMass", "sctElectron_appliedID_invMass", 400, 0., 200.);
+      ibook.book1D("sctElectron_appliedID_invMass", "sctElectron_appliedID_invMass", 2000, 0., 200.);
   histos.sctElectron.h1InvMassIDEBEB =
-      ibook.book1D("sctElectron_EBEB_appliedID_invMass", "sctElectron_EBEB_appliedID_invMass", 400, 0., 200.);
+      ibook.book1D("sctElectron_EBEB_appliedID_invMass", "sctElectron_EBEB_appliedID_invMass", 2000, 0., 200.);
   histos.sctElectron.h1InvMassIDEBEE =
-      ibook.book1D("sctElectron_EBEE_appliedID_invMass", "sctElectron_EBEE_appliedID_invMass", 400, 0., 200.);
+      ibook.book1D("sctElectron_EBEE_appliedID_invMass", "sctElectron_EBEE_appliedID_invMass", 2000, 0., 200.);
   histos.sctElectron.h1InvMassIDEEEE =
-      ibook.book1D("sctElectron_EEEE_appliedID_invMass", "sctElectron_EEEE_appliedID_invMass", 400, 0., 200.);
+      ibook.book1D("sctElectron_EEEE_appliedID_invMass", "sctElectron_EEEE_appliedID_invMass", 2000, 0., 200.);
 
   for (auto const& vt : vtriggerSelection_) {
     std::string cleaned_vt = vt;
@@ -406,33 +406,33 @@ void ScoutingEGammaCollectionMonitoring::bookHistograms(DQMStore::IBooker& ibook
     std::vector<dqm::reco::MonitorElement*> h_EEEE_passDST;
 
     h_passDST.push_back(ibook.book1D(
-        "sctElectron_appliedID_invMass_pass_" + cleaned_vt, ";Invariant mass (GeV); Electrons", 400, 0., 200));
+        "sctElectron_appliedID_invMass_pass_" + cleaned_vt, ";Invariant mass (GeV); Electrons", 2000, 0., 200));
     h_EBEB_passDST.push_back(ibook.book1D(
-        "sctElectron_EBEB_appliedID_invMass_pass_" + cleaned_vt, ";Invariant mass (GeV); Electrons", 400, 0., 200));
+        "sctElectron_EBEB_appliedID_invMass_pass_" + cleaned_vt, ";Invariant mass (GeV); Electrons", 2000, 0., 200));
     h_EBEE_passDST.push_back(ibook.book1D(
-        "sctElectron_EBEE_appliedID_invMass_pass_" + cleaned_vt, ";Invariant mass (GeV); Electrons", 400, 0., 200));
+        "sctElectron_EBEE_appliedID_invMass_pass_" + cleaned_vt, ";Invariant mass (GeV); Electrons", 2000, 0., 200));
     h_EEEE_passDST.push_back(ibook.book1D(
-        "sctElectron_EEEE_appliedID_invMass_pass_" + cleaned_vt, ";Invariant mass (GeV); Electrons", 400, 0., 200));
+        "sctElectron_EEEE_appliedID_invMass_pass_" + cleaned_vt, ";Invariant mass (GeV); Electrons", 2000, 0., 200));
 
     for (auto const& l1seed : l1Seeds_) {
       h_passDST.push_back(ibook.book1D("sctElectron_appliedID_invMass_pass_" + cleaned_vt + "_and_" + l1seed,
                                        ";Invariant mass (GeV); Electrons",
-                                       400,
+                                       2000,
                                        0.,
                                        200));
       h_EBEB_passDST.push_back(ibook.book1D("sctElectron_EBEB_appliedID_invMass_pass_" + cleaned_vt + "_and_" + l1seed,
                                             ";Invariant mass (GeV); Electrons",
-                                            400,
+                                            2000,
                                             0.,
                                             200));
       h_EBEE_passDST.push_back(ibook.book1D("sctElectron_EBEE_appliedID_invMass_pass_" + cleaned_vt + "_and_" + l1seed,
                                             ";Invariant mass (GeV); Electrons",
-                                            400,
+                                            2000,
                                             0.,
                                             200));
       h_EEEE_passDST.push_back(ibook.book1D("sctElectron_EEEE_appliedID_invMass_pass_" + cleaned_vt + "_and_" + l1seed,
                                             ";Invariant mass (GeV); Electrons",
-                                            400,
+                                            2000,
                                             0.,
                                             200));
     }

--- a/HLTriggerOffline/Scouting/python/PatElectronTagProbeAnalyzer_cfi.py
+++ b/HLTriggerOffline/Scouting/python/PatElectronTagProbeAnalyzer_cfi.py
@@ -39,12 +39,32 @@ SinglePhotonL1 = [
   'L1_SingleIsoEG34er2p5'
 ]
 
+triggerConfigs = cms.VPSet(
+    cms.PSet(
+        pathName = cms.string("DST_PFScouting_DoubleEG_v"),
+        filters  = cms.vstring("hltEGL1DoubleIsoEG11Filter", 
+                               "hltDoubleEG11CaloIdLEt11Filter",
+                               "hltDoubleEG11CaloIdLClusterShapeFilter",
+                               "hltDoubleEG11CaloIdLHEFilter")
+    ),
+    cms.PSet(
+        pathName = cms.string("DST_PFScouting_SinglePhotonEB_v"),
+        filters  = cms.vstring("hltEGL1SingleEGOrFilter",
+                               "hltEG30EBTightIDTightIsoEtFilter",
+                               "hltEG30EBTightIDTightIsoClusterShapeFilter",
+                               "hltEG30EBTightIDTightIsoHEFilter",
+                               "hltEG30EBTightIDTightIsoR9Filter",
+                               "hltEG30EBTightIDTightIsotEcalIsoFilter",
+                               "hltEG30EBTightIDTightIsoHcalIsoFilter",
+                               "hltEG30EBTightIDTightIsoTrackIsoFilter"),
+    )
+)
+
 PatElectronTagProbeAnalysis = DQMEDAnalyzer('PatElectronTagProbeAnalyzer',
 
     OutputInternalPath = cms.string('/HLT/ScoutingOffline/EGamma/TnP/Tag_PatElectron'),
     BaseTriggerSelection = cms.vstring(["DST_PFScouting_ZeroBias_v", "DST_PFScouting_SingleMuon_v", "DST_PFScouting_DoubleMuon_v", "DST_PFScouting_JetHT_v"]),
-    triggerSelection = cms.vstring(["DST_PFScouting_DoubleEG_v", "DST_PFScouting_SinglePhotonEB_v"]),
-    finalfilterSelection = cms.vstring(["hltDoubleEG11CaloIdLHEFilter", "hltEG30EBTightIDTightIsoTrackIsoFilter"]), # Must align with triggerSelection
+    triggerConfigs   = triggerConfigs,
     l1filterSelection  = cms.vstring(["hltL1sDSTRun3DoubleEGPFScoutingPixelTracking", "hltL1sSingleEGor"]),
     l1filterSelectionIndex = cms.vuint32([len(DoubleEGL1), len(DoubleEGL1) + len(SinglePhotonL1)]),
     AlgInputTag        = cms.InputTag("gtStage2Digis"),


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

This PR targets to integrate new functions for 2026 Scouting DQM in order to provide filter-by-filter efficiency monitoring and the ability to monitor J/Psi reconstruction for EGM objects. The plan has been raised in the [2025 Annual Trigger Review](https://indico.cern.ch/event/1597088/contributions/6738695/attachments/3167217/5629246/2025-10-31_2026TriggerReview_HLTScouting.pdf) and discussed in recent scouting round tables.


#### Description of the current change

- Filter-by-filter efficiency monitoring, mainly to provide the hint for origins of observed efficiency difference.
- Update scouting ID, basically removed the isolation cut + some minor optimization of the variables (based on the study of scouting cutbased ID reported in [EGM meeting](https://indico.cern.ch/event/1610914/contributions/6788708/attachments/3178779/5653835/ScoutingElectron%20Cutbased%20ID.pdf)). This change is needed to monitor the J/Psi reconstruction.
- The changes should affect both Online and Offline DQM stream.



#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

This PR has been prepared from `CMSSW_16_1_0_pre1`

```
cmsrel CMSSW_16_1_0_pre1
cd CMSSW_16_1_0_pre1/src
cmsenv
git cms-init
git cms-addpkg HLTriggerOffline/Scouting/
scram b && scram b code-checks && scram b code-format && scram b
```

Check the code dependcy
```
git cms-checkdeps -a -A
>> Checking HLTriggerOffline/Scouting CMSSW_16_1_0_pre1
   x HLTriggerOffline/Scouting/plugins/PatElectronTagProbeAnalyzer.cc
   x HLTriggerOffline/Scouting/plugins/ScoutingDQMUtils.h
   x HLTriggerOffline/Scouting/plugins/ScoutingEGammaCollectionMonitoring.cc
   x HLTriggerOffline/Scouting/python/PatElectronTagProbeAnalyzer_cfi.py
```
And

```bash
# 2500.3307 ScoutingPFRun3_Run2025C_HLTSCOUT_150X+scoutingNANO_data15.0
# 2500.3308 ScoutingPFMonitor_Run2025C_MINIAOD_150X+scoutingNANO_monitor_data15.0
runTheMatrix.py -l 2500.3307 # all pass
runTheMatrix.py -l 2500.3308 # all pass
```

This PR is further tested on `/ScoutingPFMonitor/Run2025G-PromptReco-v1/MINIAOD` with the check of target observables in [Scouting meeting EGM round table report (06 Feb 2026) ](https://indico.cern.ch/event/1631078/contributions/6865937/subcontributions/593382/attachments/3215144/5727561/2026ScoutingDQMUpgradePlan.pdf).


#### Backport plan:
This is targeted to be backported to 16.0.X for 2026 data taking operations.

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->


<!-- Please delete the text above after you verified all points of the checklist  -->

[c.c. @silviodonato @patinkaew ]