### PR TITLE
enable ROOT's batch mode in `test-btvNano-check` unit test

### DIFF
--- a/PhysicsTools/NanoAOD/test/test-btvNano.py
+++ b/PhysicsTools/NanoAOD/test/test-btvNano.py
@@ -1,6 +1,7 @@
 #!/bin/env python3
-
 import ROOT
+
+ROOT.gROOT.SetBatch(ROOT.kTRUE)
 
 f = ROOT.TFile.Open("btvNanoMC_NANO.root")
 t = f.Get("Events")


### PR DESCRIPTION
#### PR description:

The unit test `test-btvNano-check` in `PhysicsTools/NanoAOD` briefly displays a `TCanvas` when executed (and the `TCanvas` quickly disappears once the execution of the unit test finishes).

This is not really useful, maybe unintended, and it can slow down the execution of the unit test unnecessarily.

This PR enables ROOT's "batch mode" in said unit test, avoiding any attempt at displaying extra graphics.

#### PR validation:

The unit test `test-btvNano-check` passes.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A
