### PR TITLE
Enable DerivePointerAlignment in clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,3 +16,4 @@ ReflowComments: false
 BinPackArguments: false
 BinPackParameters: false
 InsertNewlineAtEOF: true
+DerivePointerAlignment: true


### PR DESCRIPTION
To avoid a massive code formatting with LLVM21, as proposes in https://github.com/cms-sw/cmssw/pull/49293/changes#diff-1026e0038b722990204a42bed8a6f7c0ec2302aa79e3fad1959d62ba968edfa2R18, this PR suggested to enable DerivePointerAlignment code-format option. This should allow us a minimal code formatting change with new LLVM 21.


Without this change  clang format form LLVM21 will try to format nearly all files. This should go in 23h00 IB so that new LLVM21 only suggest minimal changes (only order of 100 files should be re-formatted with new LLVVM21 and this change)