### PR TITLE
Enable RPD reconstruction for 2025 and 2026 heavy-ion data

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2025_UPC_OXY_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_UPC_OXY_cff.py
@@ -2,5 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_2025_UPC_cff import Run3_2025_UPC
 from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
+from Configuration.ProcessModifiers.rpdReco_cff import rpdReco
 
-Run3_2025_UPC_OXY = cms.ModifierChain(Run3_2025_UPC, run3_oxygen)
+Run3_2025_UPC_OXY = cms.ModifierChain(Run3_2025_UPC.copyAndExclude([rpdReco]), run3_oxygen)

--- a/Configuration/Eras/python/Era_Run3_2025_UPC_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_UPC_cff.py
@@ -2,9 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
 from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
+from Configuration.ProcessModifiers.rpdReco_cff import rpdReco
 from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
 from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 from Configuration.Eras.Modifier_run3_upc_2025_cff import run3_upc_2025
 
-Run3_2025_UPC = cms.ModifierChain(Run3_2025, egamma_lowPt_exclusive, highBetaStar, dedx_lfit, run3_upc, run3_upc_2025)
+Run3_2025_UPC = cms.ModifierChain(Run3_2025, egamma_lowPt_exclusive, rpdReco, highBetaStar, dedx_lfit, run3_upc, run3_upc_2025)

--- a/Configuration/Eras/python/Era_Run3_2026_UPC_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2026_UPC_cff.py
@@ -2,9 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_2026_cff import Run3_2026
 from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
+from Configuration.ProcessModifiers.rpdReco_cff import rpdReco
 from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
 from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 from Configuration.Eras.Modifier_run3_upc_2026_cff import run3_upc_2026
 
-Run3_2026_UPC = cms.ModifierChain(Run3_2026, egamma_lowPt_exclusive, highBetaStar, dedx_lfit, run3_upc, run3_upc_2026)
+Run3_2026_UPC = cms.ModifierChain(Run3_2026, egamma_lowPt_exclusive, rpdReco, highBetaStar, dedx_lfit, run3_upc, run3_upc_2026)

--- a/Configuration/Eras/python/Era_Run3_pp_on_PbPb_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_pp_on_PbPb_2025_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+from Configuration.ProcessModifiers.rpdReco_cff import rpdReco
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_2025_cff import pp_on_PbPb_run3_2025
 from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit

--- a/Configuration/Eras/python/Era_Run3_pp_on_PbPb_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_pp_on_PbPb_2025_cff.py
@@ -7,4 +7,4 @@ from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_2025_cff import pp_on_PbPb_run3_2025
 from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
 
-Run3_pp_on_PbPb_2025 = cms.ModifierChain(Run3_2025, dedx_lfit, pp_on_AA, pp_on_PbPb_run3, pp_on_PbPb_run3_2025)
+Run3_pp_on_PbPb_2025 = cms.ModifierChain(Run3_2025, dedx_lfit, pp_on_AA, rpdReco, pp_on_PbPb_run3, pp_on_PbPb_run3_2025)

--- a/Configuration/Eras/python/Era_Run3_pp_on_PbPb_2026_cff.py
+++ b/Configuration/Eras/python/Era_Run3_pp_on_PbPb_2026_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_2026_cff import Run3_2026
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+from Configuration.ProcessModifiers.rpdReco_cff import rpdReco
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_2026_cff import pp_on_PbPb_run3_2026
 from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit

--- a/Configuration/Eras/python/Era_Run3_pp_on_PbPb_2026_cff.py
+++ b/Configuration/Eras/python/Era_Run3_pp_on_PbPb_2026_cff.py
@@ -7,4 +7,4 @@ from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_2026_cff import pp_on_PbPb_run3_2026
 from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
 
-Run3_pp_on_PbPb_2026 = cms.ModifierChain(Run3_2026, dedx_lfit, pp_on_AA, pp_on_PbPb_run3, pp_on_PbPb_run3_2026)
+Run3_pp_on_PbPb_2026 = cms.ModifierChain(Run3_2026, dedx_lfit, pp_on_AA, rpdReco, pp_on_PbPb_run3, pp_on_PbPb_run3_2026)

--- a/Configuration/ProcessModifiers/python/rpdReco_cff.py
+++ b/Configuration/ProcessModifiers/python/rpdReco_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+rpdReco =  cms.Modifier()

--- a/RecoLocalCalo/HcalRecProducers/plugins/ZdcHitReconstructor_Run3.cc
+++ b/RecoLocalCalo/HcalRecProducers/plugins/ZdcHitReconstructor_Run3.cc
@@ -231,7 +231,7 @@ void ZdcHitReconstructor_Run3::fillDescriptions(edm::ConfigurationDescriptions& 
     psd0.add<int>("maxADCvalue", 255);
     desc.add<edm::ParameterSetDescription>("saturationParameters", psd0);
   }
-  descriptions.add("zdcrecoRun3", desc);
+  descriptions.add("zdcRecoRun3", desc);
   // or use the following to generate the label from the module's C++ type
   //descriptions.addWithDefaultLabel(desc);
 }

--- a/RecoLocalCalo/HcalRecProducers/plugins/ZdcHitReconstructor_Run3.cc
+++ b/RecoLocalCalo/HcalRecProducers/plugins/ZdcHitReconstructor_Run3.cc
@@ -177,7 +177,7 @@ void ZdcHitReconstructor_Run3::fillDescriptions(edm::ConfigurationDescriptions& 
   desc.add<edm::InputTag>("digiLabelQIE10ZDC", edm::InputTag("hcalDigis", "ZDC"));
   desc.add<std::string>("Subdetector", "ZDC");
   desc.add<bool>("dropZSmarkedPassed", true);
-  desc.add<bool>("skipRPD", true);
+  desc.add<bool>("skipRPD", false);
   desc.add<int>("recoMethod", 1);
   desc.add<int>("correctionMethodEM", 1);
   desc.add<int>("correctionMethodHAD", 1);

--- a/RecoLocalCalo/HcalRecProducers/plugins/ZdcHitReconstructor_Run3.cc
+++ b/RecoLocalCalo/HcalRecProducers/plugins/ZdcHitReconstructor_Run3.cc
@@ -177,7 +177,7 @@ void ZdcHitReconstructor_Run3::fillDescriptions(edm::ConfigurationDescriptions& 
   desc.add<edm::InputTag>("digiLabelQIE10ZDC", edm::InputTag("hcalDigis", "ZDC"));
   desc.add<std::string>("Subdetector", "ZDC");
   desc.add<bool>("dropZSmarkedPassed", true);
-  desc.add<bool>("skipRPD", false);
+  desc.add<bool>("skipRPD", true);
   desc.add<int>("recoMethod", 1);
   desc.add<int>("correctionMethodEM", 1);
   desc.add<int>("correctionMethodHAD", 1);

--- a/RecoLocalCalo/HcalRecProducers/python/zdcrecoRun3_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/zdcrecoRun3_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+import RecoLocalCalo.HcalRecProducers.zdcRecoRun3_cfi
+# clone (new) zdcrecoRun3  from imtermediate zdcRecoRun3
+zdcrecoRun3 = RecoLocalCalo.HcalRecProducers.zdcRecoRun3_cfi.zdcRecoRun3.clone()
+# apply modifier(s)
+from Configuration.ProcessModifiers.rpdReco_cff  import rpdReco
+rpdReco.toModify(zdcrecoRun3, skipRPD = False) 


### PR DESCRIPTION
#### PR description:

This PR enables RPD reconstruction by default. Now safe due to incorporation and validation of the RPD geometry into the GT (see here: https://its.cern.ch/jira/browse/CMSALCA-348). 

#### PR validation:

RPD reconstruction is run at foresting step for HIN, not included in central streams. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not necessary for past data-taking. Useful to have for the future - no backport needed. 

Tagging HIN Colleagues: @mandrenguyen 
Tagging HCAL colleagues: @abdoulline @akhukhun 