### PR TITLE
Add various missing dictionaries

### DIFF
--- a/DataFormats/EgammaReco/src/classes_def.xml
+++ b/DataFormats/EgammaReco/src/classes_def.xml
@@ -134,6 +134,7 @@
   </class>
   <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::BasicCluster> >, edm::RefProd<std::vector<reco::ClusterShape> > >"/>
 
+  <class name="edm::OneToOne<std::vector<reco::SuperCluster>, std::vector<reco::HFEMClusterShape>, unsigned int >"/>
   <class name="edm::AssociationMap<edm::OneToOne<std::vector<reco::SuperCluster>, std::vector<reco::HFEMClusterShape>, unsigned int > >">
     <field name="transientMap_" transient="true" />
   </class>

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -58,6 +58,7 @@ initial version number of a class which has never been stored before.
   <class name="reco::HcalMuonRecHit" ClassVersion="3">
    <version ClassVersion="3" checksum="2031556424"/>
   </class>
+  <class name="std::vector<reco::HcalMuonRecHit>"/>
   <class name="reco::MuonChamberMatch" ClassVersion="14">
    <version ClassVersion="14" checksum="3579435038"/>
    <version ClassVersion="13" checksum="2674954213"/>

--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -32,6 +32,7 @@
   <class name="std::vector<reco::PFCandidate>"/>
   <class name="edm::Wrapper<reco::PFCandidate>"/>
   <class name="edm::Wrapper<std::vector<reco::PFCandidate> >"/>
+  <class name="edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate>"/>
   <class name="reco::PFCandidateRef"/>
   <class name="reco::PFCandidateRefProd"/>
   <class name="reco::PFCandidateRefVector"/>

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -213,6 +213,7 @@
 
   <class name="std::vector<reco::PFBlock>"/>
   <class name="edm::Wrapper<std::vector<reco::PFBlock> >"/>
+  <class name="edm::refhelper::FindUsingAdvance<std::vector<reco::PFBlock>,reco::PFBlock>"/>
   <class name="edm::Ref< std::vector<reco::PFBlock>, reco::PFBlock, edm::refhelper::FindUsingAdvance<std::vector<reco::PFBlock>,reco::PFBlock> >"/>
   <class name="edm::Ref<std::vector<reco::PFRecTrack>,reco::PFRecTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::PFRecTrack>,reco::PFRecTrack> >"/>
   <class name="edm::RefVector<std::vector<reco::PFRecTrack>,reco::PFRecTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::PFRecTrack>,reco::PFRecTrack> >"/>

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -37,6 +37,7 @@
   <class name="edm::RefVector<std::vector<reco::PFTau>,reco::PFTau,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTau>,reco::PFTau> >"/>
           <class name="edm::Wrapper<edm::RefVector<std::vector<reco::PFTau>,reco::PFTau,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTau>,reco::PFTau> > >"/>
   <class name="edm::reftobase::Holder<reco::BaseTau, edm::Ref<std::vector<reco::PFTau>,reco::PFTau,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTau>,reco::PFTau> > >" />
+  <class name="edm::refhelper::FindUsingAdvance<std::vector<reco::PFTau>,reco::PFTau>"/>
 
   <class name="edm::RefToBaseProd<reco::PFTau>" >
      <!-- <field name="view_" transient="true" /> -->

--- a/DataFormats/TauReco/src/classes_def_3.xml
+++ b/DataFormats/TauReco/src/classes_def_3.xml
@@ -103,6 +103,7 @@
   <class name="edm::RefProd<std::vector<reco::PFTauTransverseImpactParameter> >"/>
   <class name="edm::RefVector<std::vector<reco::PFTauTransverseImpactParameter>,reco::PFTauTransverseImpactParameter,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTransverseImpactParameter>,reco::PFTauTransverseImpactParameter> >"/>
   <class name="edm::reftobase::Holder<reco::PFTauTransverseImpactParameter, edm::Ref<std::vector<reco::PFTauTransverseImpactParameter>,reco::PFTauTransverseImpactParameter,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTransverseImpactParameter>,reco::PFTauTransverseImpactParameter> > >" />
+  <class name="edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTransverseImpactParameter>,reco::PFTauTransverseImpactParameter>"/>
   <class name="edm::Association<std::vector<reco::PFTauTransverseImpactParameter> >"/>
   <class name="edm::Wrapper<edm::Association<std::vector<reco::PFTauTransverseImpactParameter> > >"/>
 
@@ -142,6 +143,7 @@
   <class name="edm::Association<std::vector<std::vector<reco::VertexRef> > >"/>
   <class name="edm::Wrapper<edm::Association<std::vector<std::vector<reco::VertexRef> > > >"/>
 
+  <class name="std::vector<edm::Ref<std::vector<reco::PFTauTransverseImpactParameter>,reco::PFTauTransverseImpactParameter,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTransverseImpactParameter>,reco::PFTauTransverseImpactParameter> > >"/>
   <class name="reco::PFTauTIPAssociation">
     <field name="transientVector_" transient="true"/>
   </class>

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -397,6 +397,7 @@
  
   <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::Track> >,edm::RefProd<std::vector<reco::Track> > >" />
 
+  <class name="edm::OneToOne<std::vector<reco::Track>,std::vector<reco::Track>,unsigned int>"/>
   <class name="edm::AssociationMap<edm::OneToOne<std::vector<reco::Track>,std::vector<reco::Track>,unsigned int> >">
     <field name="transientMap_" transient="true" />
   </class>


### PR DESCRIPTION
#### PR description:

This PR adds dictionaries for types that I saw ROOT triggering header parsing for in https://github.com/cms-sw/cmssw/issues/49966

Resolves https://github.com/cms-sw/cmssw/issues/49966
Resolves https://github.com/cms-sw/framework-team/issues/1852

#### PR validation:

Running an AODSIM copy job through `cmsTraceFunction ExecAutoParse` no longer reports auto-parsing for these types.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
