### PR TITLE
add `override` identifier to `CICADATemplate` destructor

### DIFF
--- a/L1Trigger/L1TGlobal/interface/CICADATemplate.h
+++ b/L1Trigger/L1TGlobal/interface/CICADATemplate.h
@@ -1,8 +1,9 @@
 #ifndef L1Trigger_L1TGlobal_CICADATemplate_h
 #define L1Trigger_L1TGlobal_CICADATemplate_h
 
+#include <ostream>
 #include <string>
-#include <iosfwd>
+#include <vector>
 
 #include "L1Trigger/L1TGlobal/interface/GlobalCondition.h"
 
@@ -12,7 +13,7 @@ public:
   CICADATemplate(const std::string&);
   CICADATemplate(const std::string&, const l1t::GtConditionType&);
   CICADATemplate(const CICADATemplate&);
-  ~CICADATemplate() = default;
+  ~CICADATemplate() override = default;
 
   CICADATemplate& operator=(const CICADATemplate&);
 

--- a/L1Trigger/L1TGlobal/src/CICADATemplate.cc
+++ b/L1Trigger/L1TGlobal/src/CICADATemplate.cc
@@ -1,7 +1,6 @@
 #include "L1Trigger/L1TGlobal/interface/CICADATemplate.h"
 
-#include <iostream>
-#include <iomanip>
+#include <ios>
 
 //TODO: Check the actual conditions name: "CondCICADA"
 CICADATemplate::CICADATemplate() : GlobalCondition() { m_condCategory = l1t::CondCICADA; }


### PR DESCRIPTION
#### PR description:

This PR adds the `override` identifier to the destructor of the `CICADATemplate`, fixing the warning (reported below) that `scram build code-checks` currently issues for that class.
```
clang-tidy -export-fixes tmp/el8_amd64_gcc13/code-checks/L1Trigger/L1TGlobal/src/CICADATemplate.cc.yaml -header-filter 'src/.*' src/L1Trigger/L1TGlobal/src/CICADATemplate.cc
369 warnings generated.
src/L1Trigger/L1TGlobal/interface/CICADATemplate.h:16:3: warning: annotate this function with 'override' or (rarely) 'final' [modernize-use-override]
   16 |   ~CICADATemplate() = default;
      |   ^
      |                     override 
Suppressed 368 warnings (368 in non-user code).
```

In addition, this PR corrects the `#include` statements used in `CICADATemplate.{h,cc}`.

Merely technical. No changes expected.

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A
