### PR TITLE
Backport fastsim PUPPI Jet refinement to C14_0_X for NANO-v15

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/JetSorter.cc
+++ b/PhysicsTools/NanoAOD/plugins/JetSorter.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -6,7 +6,11 @@
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
-class JetSorter : public edm::stream::EDProducer<> {
+#include <algorithm>
+#include <string>
+#include <memory>
+
+class JetSorter : public edm::global::EDProducer<> {
 public:
   explicit JetSorter(const edm::ParameterSet &iConfig)
       : srcToken_(consumes<edm::View<pat::Jet>>(iConfig.getParameter<edm::InputTag>("src"))),
@@ -17,7 +21,7 @@ public:
 
   ~JetSorter() override = default;
 
-  void produce(edm::Event &iEvent, const edm::EventSetup &) override {
+  void produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &) const override {
     edm::Handle<edm::View<pat::Jet>> hSrc;
     iEvent.getByToken(srcToken_, hSrc);
 
@@ -28,14 +32,14 @@ public:
       out->push_back(jIn);
     }
 
-    auto key = [&](pat::Jet const &j) -> float {
+    auto key = [this](pat::Jet const &j) -> float {
       if (j.hasUserFloat(userFloatSorter_)) {
         return j.userFloat(userFloatSorter_);
       }
       return static_cast<float>(j.pt());
     };
 
-    std::stable_sort(out->begin(), out->end(), [&](pat::Jet const &a, pat::Jet const &b) {
+    std::stable_sort(out->begin(), out->end(), [this, &key](pat::Jet const &a, pat::Jet const &b) {
       float pa = key(a);
       float pb = key(b);
       return descending_ ? (pa > pb) : (pa < pb);

--- a/PhysicsTools/NanoAOD/plugins/JetSorter.cc
+++ b/PhysicsTools/NanoAOD/plugins/JetSorter.cc
@@ -1,0 +1,53 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+
+class JetSorter : public edm::stream::EDProducer<> {
+public:
+  explicit JetSorter(const edm::ParameterSet &iConfig)
+      : srcToken_(consumes<edm::View<pat::Jet>>(iConfig.getParameter<edm::InputTag>("src"))),
+        userFloatSorter_(iConfig.getParameter<std::string>("userFloatSorter")),
+        descending_(iConfig.getParameter<bool>("descending")) {
+    produces<std::vector<pat::Jet>>();
+  }
+
+  ~JetSorter() override = default;
+
+  void produce(edm::Event &iEvent, const edm::EventSetup &) override {
+    edm::Handle<edm::View<pat::Jet>> hSrc;
+    iEvent.getByToken(srcToken_, hSrc);
+
+    auto out = std::make_unique<std::vector<pat::Jet>>();
+    out->reserve(hSrc->size());
+
+    for (auto const &jIn : *hSrc) {
+      out->push_back(jIn);
+    }
+
+    auto key = [&](pat::Jet const &j) -> float {
+      if (j.hasUserFloat(userFloatSorter_)) {
+        return j.userFloat(userFloatSorter_);
+      }
+      return static_cast<float>(j.pt());
+    };
+
+    std::stable_sort(out->begin(), out->end(), [&](pat::Jet const &a, pat::Jet const &b) {
+      float pa = key(a);
+      float pb = key(b);
+      return descending_ ? (pa > pb) : (pa < pb);
+    });
+
+    iEvent.put(std::move(out));
+  }
+
+private:
+  edm::EDGetTokenT<edm::View<pat::Jet>> srcToken_;
+  std::string userFloatSorter_;
+  bool descending_;
+};
+
+DEFINE_FWK_MODULE(JetSorter);

--- a/PhysicsTools/NanoAOD/plugins/ProcessRefinedJets.cc
+++ b/PhysicsTools/NanoAOD/plugins/ProcessRefinedJets.cc
@@ -55,13 +55,15 @@ public:
       pat::Jet j(jIn);
 
       const double pt_orig = j.pt();
-      const double phi = j.phi();
+      const double phi     = j.phi();
 
       // mask: BvsAll > 0
       const float bvsAll = j.bDiscriminator(maskBtagName_);
-      const bool refine = (bvsAll > 0.f);
+      const bool refine  = (bvsAll > 0.f);
 
-      const double pt_ref = j.hasUserFloat(refinedPtName_) ? static_cast<double>(j.userFloat(refinedPtName_)) : pt_orig;
+      const double pt_ref = j.hasUserFloat(refinedPtName_)
+                                ? static_cast<double>(j.userFloat(refinedPtName_))
+                                : pt_orig;
 
       const double pt_final = refine ? pt_ref : pt_orig;
 
@@ -109,7 +111,7 @@ public:
         m.addUserFloat("phi_unrefined", static_cast<float>(phiOrig));
 
         // stash final values, needed for sorting.
-        m.addUserFloat("pt_final", static_cast<float>(ptFinal));
+        m.addUserFloat("pt_final",  static_cast<float>(ptFinal));
         m.addUserFloat("phi_final", static_cast<float>(phiFinal));
 
         // push back into pat::MET with reco::Candidate::LorentzVector ---

--- a/PhysicsTools/NanoAOD/plugins/ProcessRefinedJets.cc
+++ b/PhysicsTools/NanoAOD/plugins/ProcessRefinedJets.cc
@@ -55,15 +55,13 @@ public:
       pat::Jet j(jIn);
 
       const double pt_orig = j.pt();
-      const double phi     = j.phi();
+      const double phi = j.phi();
 
       // mask: BvsAll > 0
       const float bvsAll = j.bDiscriminator(maskBtagName_);
-      const bool refine  = (bvsAll > 0.f);
+      const bool refine = (bvsAll > 0.f);
 
-      const double pt_ref = j.hasUserFloat(refinedPtName_)
-                                ? static_cast<double>(j.userFloat(refinedPtName_))
-                                : pt_orig;
+      const double pt_ref = j.hasUserFloat(refinedPtName_) ? static_cast<double>(j.userFloat(refinedPtName_)) : pt_orig;
 
       const double pt_final = refine ? pt_ref : pt_orig;
 
@@ -107,11 +105,11 @@ public:
         const double ptFinal = std::sqrt(pxFinal * pxFinal + pyFinal * pyFinal);
         const double phiFinal = std::atan2(pyFinal, pxFinal);
 
-        m.addUserFloat("pt_unrefined",  static_cast<float>(ptOrig));
+        m.addUserFloat("pt_unrefined", static_cast<float>(ptOrig));
         m.addUserFloat("phi_unrefined", static_cast<float>(phiOrig));
 
         // stash final values, needed for sorting.
-        m.addUserFloat("pt_final",  static_cast<float>(ptFinal));
+        m.addUserFloat("pt_final", static_cast<float>(ptFinal));
         m.addUserFloat("phi_final", static_cast<float>(phiFinal));
 
         // push back into pat::MET with reco::Candidate::LorentzVector ---

--- a/PhysicsTools/NanoAOD/plugins/ProcessRefinedJets.cc
+++ b/PhysicsTools/NanoAOD/plugins/ProcessRefinedJets.cc
@@ -1,0 +1,145 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/PatCandidates/interface/MET.h"
+#include "TLorentzVector.h"
+
+#include <cmath>
+
+//This producer was written to embed the final refined FastSim jet pT values
+//so that they can be used as input to the pT-based sorting routine, as well
+//as to implement the Type-1 MET correction based on the refined jets.
+class ProcessRefinedJets : public edm::stream::EDProducer<> {
+public:
+  explicit ProcessRefinedJets(const edm::ParameterSet &iConfig)
+      : jetsToken_(consumes<edm::View<pat::Jet>>(iConfig.getParameter<edm::InputTag>("jets"))),
+        refinedPtName_(iConfig.getParameter<std::string>("refinedPtName")),
+        maskBtagName_(iConfig.getParameter<std::string>("maskBtagName")),
+        ptFinalName_(iConfig.getParameter<std::string>("ptFinalName")),
+        ptUnrefinedName_(iConfig.getParameter<std::string>("ptUnrefinedName")) {
+    // Type-1 MET correction is optional
+    if (iConfig.existsAs<edm::InputTag>("met")) {
+      metToken_ = consumes<edm::View<pat::MET>>(iConfig.getParameter<edm::InputTag>("met"));
+      doMET_ = true;
+    } else {
+      doMET_ = false;
+    }
+
+    produces<std::vector<pat::Jet>>();
+
+    if (doMET_) {
+      // refined MET made available in python
+      produces<std::vector<pat::MET>>("Refined");
+    }
+  }
+
+  ~ProcessRefinedJets() override = default;
+
+  void produce(edm::Event &iEvent, const edm::EventSetup &) override {
+    edm::Handle<edm::View<pat::Jet>> hJets;
+    iEvent.getByToken(jetsToken_, hJets);
+
+    auto outJets = std::make_unique<std::vector<pat::Jet>>();
+    outJets->reserve(hJets->size());
+
+    // Sum over (pt_orig - pt_final) for MET correction
+    double sumDeltaPx = 0.;
+    double sumDeltaPy = 0.;
+
+    for (auto const &jIn : *hJets) {
+      pat::Jet j(jIn);
+
+      const double pt_orig = j.pt();
+      const double phi = j.phi();
+
+      // mask: BvsAll > 0
+      const float bvsAll = j.bDiscriminator(maskBtagName_);
+      const bool refine = (bvsAll > 0.f);
+
+      const double pt_ref = j.hasUserFloat(refinedPtName_) ? static_cast<double>(j.userFloat(refinedPtName_)) : pt_orig;
+
+      const double pt_final = refine ? pt_ref : pt_orig;
+
+      // store unrefined pt if requested
+      if (!ptUnrefinedName_.empty()) {
+        j.addUserFloat(ptUnrefinedName_, static_cast<float>(pt_orig));
+      }
+
+      // store final pt used for Nano, needed for the sorting
+      j.addUserFloat(ptFinalName_, static_cast<float>(pt_final));
+
+      // MET delta: add unrefined jets, subtract final jets
+      // This is equivalent to adding (pt_orig - pt_final) in the jet direction.
+      const double dpt = pt_orig - pt_final;
+      sumDeltaPx += dpt * std::cos(phi);
+      sumDeltaPy += dpt * std::sin(phi);
+
+      outJets->push_back(std::move(j));
+    }
+
+    iEvent.put(std::move(outJets));
+
+    // Optionally correct MET
+    if (doMET_) {
+      edm::Handle<edm::View<pat::MET>> hMET;
+      iEvent.getByToken(metToken_, hMET);
+
+      auto outMET = std::make_unique<std::vector<pat::MET>>();
+      outMET->reserve(hMET->size());
+
+      for (auto const &mIn : *hMET) {
+        pat::MET m(mIn);
+
+        // --- original MET as TLorentzVector ---
+        const double pxOrig = m.px();
+        const double pyOrig = m.py();
+        const double ptOrig = std::sqrt(pxOrig * pxOrig + pyOrig * pyOrig);
+        const double phiOrig = std::atan2(pyOrig, pxOrig);
+
+        TLorentzVector metOrig;
+        metOrig.SetPxPyPzE(pxOrig, pyOrig, 0.0, ptOrig);  // pz=0, E ~ pt (E not really used for MET)
+
+        // Type-1 MET correction for PUPPI MET with refined jets:
+        TLorentzVector delta;
+        const double ptDelta = std::sqrt(sumDeltaPx * sumDeltaPx + sumDeltaPy * sumDeltaPy);
+        delta.SetPxPyPzE(sumDeltaPx, sumDeltaPy, 0.0, ptDelta);
+
+        TLorentzVector metFinal = metOrig + delta;
+
+        const double ptFinal = metFinal.Pt();
+        const double phiFinal = metFinal.Phi();
+
+        // stash unrefined values
+        m.addUserFloat("pt_unrefined", static_cast<float>(ptOrig));
+        m.addUserFloat("phi_unrefined", static_cast<float>(phiOrig));
+
+        // stash final values, needed for sorting.
+        m.addUserFloat("pt_final", static_cast<float>(ptFinal));
+        m.addUserFloat("phi_final", static_cast<float>(phiFinal));
+
+        // push back into pat::MET with reco::Candidate::LorentzVector ---
+        reco::Candidate::LorentzVector p4(metFinal.Px(), metFinal.Py(), 0.0, ptFinal);
+        m.setP4(p4);
+
+        outMET->push_back(std::move(m));
+      }
+      iEvent.put(std::move(outMET), "Refined");
+    }
+  }
+
+private:
+  edm::EDGetTokenT<edm::View<pat::Jet>> jetsToken_;
+  edm::EDGetTokenT<edm::View<pat::MET>> metToken_;
+  bool doMET_;
+
+  std::string refinedPtName_;
+  std::string maskBtagName_;
+  std::string ptFinalName_;
+  std::string ptUnrefinedName_;
+};
+
+DEFINE_FWK_MODULE(ProcessRefinedJets);

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -269,7 +269,7 @@ def nanoAOD_refineFastSim_puppiJet(process):
         batch_eval          = cms.bool(True),
         disableONNXGraphOpt = cms.bool(True),
         src                 = cms.InputTag("updatedJetsPuppi"),  # <<< HERE
-        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/model_fastsimrefine_puppi_31July2025.onnx"),
+        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/model_refinement_regression_31July_long_opset11.onnx"),
         name                = cms.string("puppiJetRefineNN"),
         variables = cms.VPSet(
             cms.PSet(name=cms.string("GenJet_pt"),            expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().pt():pt")),

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -262,55 +262,15 @@ jetPuppiTablesTask = cms.Task(jetPuppiTable)
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 from PhysicsTools.NanoAOD.common_cff import ExtVar
 
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+from PhysicsTools.NanoAOD.common_cff import Var
+
+from PhysicsTools.NanoAOD.common_cff import Var, ExtVar
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+
 def nanoAOD_refineFastSim_puppiJet(process):
-    process.puppiJetRefineNN = cms.EDProducer(
-        "JetBaseMVAValueMapProducer",
-        backend             = cms.string("ONNX"),
-        batch_eval          = cms.bool(True),
-        disableONNXGraphOpt = cms.bool(True),
-        src                 = cms.InputTag("updatedJetsPuppi"),  # <<< HERE
-        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/fastSimPuppiJetRefineNN_31July2025.onnx"),
-        name                = cms.string("puppiJetRefineNN"),
-        variables = cms.VPSet(
-            cms.PSet(name=cms.string("GenJet_pt"),            expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().pt():pt")),
-            cms.PSet(name=cms.string("GenJet_eta"),           expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().eta():eta")),
-            cms.PSet(name=cms.string("Jet_hadronFlavour"),    expr=cms.string("hadronFlavour()")),
-            cms.PSet(name=cms.string("Jet_pt"),               expr=cms.string("pt()")),
-            cms.PSet(name=cms.string("Jet_btagDeepFlavB"),    expr=cms.string("bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')")),
-            cms.PSet(name=cms.string("Jet_btagDeepFlavCvB"),  expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')):-1")),
-            cms.PSet(name=cms.string("Jet_btagDeepFlavCvL"),  expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')):-1")),
-            cms.PSet(name=cms.string("Jet_btagDeepFlavQG"),   expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds'))>0?bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')):-1")),
-            cms.PSet(name=cms.string("Jet_btagUParTAK4B"),    expr=cms.string("bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')")),
-            cms.PSet(name=cms.string("Jet_btagUParTAK4CvB"),  expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'):-1")),
-            cms.PSet(name=cms.string("Jet_btagUParTAK4CvL"),  expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'):-1")),
-            cms.PSet(name=cms.string("Jet_btagUParTAK4QvG"),  expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'):-1")),
-        ),
-        inputTensorName  = cms.string("input"),
-        outputTensorName = cms.string("output"),
-        outputNames      = cms.vstring([
-            "ptrefined","btagDeepFlavBrefined","btagDeepFlavCvBrefined","btagDeepFlavCvLrefined",
-            "btagDeepFlavQGrefined","btagUParTAK4Brefined","btagUParTAK4CvBrefined",
-            "btagUParTAK4CvLrefined","btagUParTAK4QvGrefined"
-        ]),
-        outputFormulas   = cms.vstring([f"at({i})" for i in range(9)]),
-    )
 
-    fastSim.toModify(process.jetPuppiTask, process.jetPuppiTask.add(process.puppiJetRefineNN))
-
-    # 1) now stuff the 9 refined scalars into the existing PATJetUserDataEmbedder
-    fastSim.toModify(process.updatedJetsPuppiWithUserData.userFloats,
-        ptRefined              = cms.InputTag("puppiJetRefineNN","ptrefined"),
-        btagDeepFlavBrefined   = cms.InputTag("puppiJetRefineNN","btagDeepFlavBrefined"),
-        btagDeepFlavCvBrefined = cms.InputTag("puppiJetRefineNN","btagDeepFlavCvBrefined"),
-        btagDeepFlavCvLrefined = cms.InputTag("puppiJetRefineNN","btagDeepFlavCvLrefined"),
-        btagDeepFlavQGrefined  = cms.InputTag("puppiJetRefineNN","btagDeepFlavQGrefined"),
-        btagUParTAK4Brefined   = cms.InputTag("puppiJetRefineNN","btagUParTAK4Brefined"),
-        btagUParTAK4CvBrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4CvBrefined"),
-        btagUParTAK4CvLrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4CvLrefined"),
-        btagUParTAK4QvGrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4QvGrefined"),
-    )
-
-    # 2) backup all 9 originals in the NanoAOD table as *_unrefined
     fastSim.toModify(process.jetPuppiTable.variables,
         pt_unrefined               = process.jetPuppiTable.variables.pt.clone(),
         btagDeepFlavB_unrefined    = process.jetPuppiTable.variables.btagDeepFlavB.clone(),
@@ -322,28 +282,59 @@ def nanoAOD_refineFastSim_puppiJet(process):
         btagUParTAK4CvL_unrefined  = process.jetPuppiTable.variables.btagUParTAK4CvL.clone(),
         btagUParTAK4QvG_unrefined  = process.jetPuppiTable.variables.btagUParTAK4QvG.clone(),
     )
-    # drop them so we can redefine
-    fastSim.toModify(process.jetPuppiTable.variables,
-        pt=None, btagDeepFlavB=None, btagDeepFlavCvB=None,
-        btagDeepFlavCvL=None, btagDeepFlavQG=None,
-        btagUParTAK4B=None, btagUParTAK4CvB=None,
-        btagUParTAK4CvL=None, btagUParTAK4QvG=None,
-    )
-
-    # 3) re‑define each branch with a FastSim‑only mask ternary
-    mask = "(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')>0)"
 
     fastSim.toModify(process.jetPuppiTable.variables,
-        pt              = Var(f"?{mask}?userFloat('ptRefined'):pt()",              float, precision=10, doc="refined pT or original"),
-        btagDeepFlavB   = Var(f"?{mask}?userFloat('btagDeepFlavBrefined'):(bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))", float, precision=10),
-        btagDeepFlavCvB = Var(f"?{mask}?userFloat('btagDeepFlavCvBrefined'):(?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')):-1)", float, precision=10),
-        btagDeepFlavCvL = Var(f"?{mask}?userFloat('btagDeepFlavCvLrefined'):(?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')):-1)", float, precision=10),
-        btagDeepFlavQG  = Var(f"?{mask}?userFloat('btagDeepFlavQGrefined'):(?(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds'))>0?bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')):-1)", float, precision=10),
-        btagUParTAK4B   = Var(f"?{mask}?userFloat('btagUParTAK4Brefined'):(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll'))", float, precision=10),
-        btagUParTAK4CvB = Var(f"?{mask}?userFloat('btagUParTAK4CvBrefined'):(?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'):-1)", float, precision=10),
-        btagUParTAK4CvL = Var(f"?{mask}?userFloat('btagUParTAK4CvLrefined'):(?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'):-1)", float, precision=10),
-        btagUParTAK4QvG = Var(f"?{mask}?userFloat('btagUParTAK4QvGrefined'):(?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'):-1)", float, precision=10),
+        pt=None, btagDeepFlavB=None, btagDeepFlavCvB=None, btagDeepFlavCvL=None, btagDeepFlavQG=None,
+        btagUParTAK4B=None, btagUParTAK4CvB=None, btagUParTAK4CvL=None, btagUParTAK4QvG=None,
     )
+
+    process.puppiJetRefineNN = cms.EDProducer(
+        "JetBaseMVAValueMapProducer",
+        backend             = cms.string("ONNX"),
+        batch_eval          = cms.bool(True),
+        disableONNXGraphOpt = cms.bool(True),
+        src                 = cms.InputTag("linkedObjects","jets"),
+        weightFile          = cms.FileInPath("PhysicsTools/NanoAOD/data/fastSimPuppiJetRefineNN_31July2025.onnx"),
+        name                = cms.string("puppiJetRefineNN"),
+        variables = cms.VPSet(
+            cms.PSet(name=cms.string("GenJet_pt"),           expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().pt():pt")),
+            cms.PSet(name=cms.string("GenJet_eta"),          expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().eta():eta")),
+            cms.PSet(name=cms.string("Jet_hadronFlavour"),   expr=cms.string("hadronFlavour()")),
+            cms.PSet(name=cms.string("Jet_pt"),              expr=cms.string("pt()")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavB"),   expr=cms.string("bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavCvB"), expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')):-1")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavCvL"), expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')):-1")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavQG"),  expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds'))>0?bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')):-1")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4B"),   expr=cms.string("bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4CvB"), expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'):-1")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4CvL"), expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'):-1")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4QvG"), expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'):-1")),
+        ),
+        inputTensorName  = cms.string("input"),
+        outputTensorName = cms.string("output"),
+        outputNames      = cms.vstring(
+            "ptrefined",
+            "btagDeepFlavBrefined","btagDeepFlavCvBrefined","btagDeepFlavCvLrefined","btagDeepFlavQGrefined",
+            "btagUParTAK4Brefined","btagUParTAK4CvBrefined","btagUParTAK4CvLrefined","btagUParTAK4QvGrefined",
+        ),
+        outputFormulas   = cms.vstring("at(0)","at(1)","at(2)","at(3)","at(4)","at(5)","at(6)","at(7)","at(8)"),
+    )
+
+    #publish refined values directly under the plain names (FastSim only) via externalVariables
+    #originals still available as *_unrefined 
+    fastSim.toModify(process.jetPuppiTable.externalVariables,
+        pt              = ExtVar(cms.InputTag("puppiJetRefineNN","ptrefined"),                 float, precision=10, doc="Refined pT (FastSim only)"),
+        btagDeepFlavB   = ExtVar(cms.InputTag("puppiJetRefineNN","btagDeepFlavBrefined"),      float, precision=10, doc="DeepJet b+bb+lepb (refined)"),
+        btagDeepFlavCvB = ExtVar(cms.InputTag("puppiJetRefineNN","btagDeepFlavCvBrefined"),    float, precision=10, doc="DeepJet c vs b+bb+lepb (refined)"),
+        btagDeepFlavCvL = ExtVar(cms.InputTag("puppiJetRefineNN","btagDeepFlavCvLrefined"),    float, precision=10, doc="DeepJet c vs udsg (refined)"),
+        btagDeepFlavQG  = ExtVar(cms.InputTag("puppiJetRefineNN","btagDeepFlavQGrefined"),     float, precision=10, doc="DeepJet g vs uds (refined)"),
+        btagUParTAK4B   = ExtVar(cms.InputTag("puppiJetRefineNN","btagUParTAK4Brefined"),      float, precision=10, doc="UParT BvsAll (refined)"),
+        btagUParTAK4CvB = ExtVar(cms.InputTag("puppiJetRefineNN","btagUParTAK4CvBrefined"),    float, precision=10, doc="UParT CvsB (refined)"),
+        btagUParTAK4CvL = ExtVar(cms.InputTag("puppiJetRefineNN","btagUParTAK4CvLrefined"),    float, precision=10, doc="UParT CvsL (refined)"),
+        btagUParTAK4QvG = ExtVar(cms.InputTag("puppiJetRefineNN","btagUParTAK4QvGrefined"),    float, precision=10, doc="UParT QvsG (refined)"),
+    )
+
+    fastSim.toModify(process.jetPuppiTablesTask, process.jetPuppiTablesTask.add(process.puppiJetRefineNN))
 
     return process
 

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -269,7 +269,7 @@ def nanoAOD_refineFastSim_puppiJet(process):
         batch_eval          = cms.bool(True),
         disableONNXGraphOpt = cms.bool(True),
         src                 = cms.InputTag("updatedJetsPuppi"),  # <<< HERE
-        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/model_fastsimrefine_puppi_31July2025.onnx"),
+        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/fastSimPuppiJetRefineNN_31July2025.onnx"),
         name                = cms.string("puppiJetRefineNN"),
         variables = cms.VPSet(
             cms.PSet(name=cms.string("GenJet_pt"),            expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().pt():pt")),

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -269,7 +269,7 @@ def nanoAOD_refineFastSim_puppiJet(process):
         batch_eval          = cms.bool(True),
         disableONNXGraphOpt = cms.bool(True),
         src                 = cms.InputTag("updatedJetsPuppi"),  # <<< HERE
-        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/model_refinement_regression_31July_long_opset11.onnx"),
+        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/model_fastsimrefine_puppi_31July2025.onnx"),
         name                = cms.string("puppiJetRefineNN"),
         variables = cms.VPSet(
             cms.PSet(name=cms.string("GenJet_pt"),            expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().pt():pt")),

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -269,7 +269,7 @@ def nanoAOD_refineFastSim_puppiJet(process):
         batch_eval          = cms.bool(True),
         disableONNXGraphOpt = cms.bool(True),
         src                 = cms.InputTag("updatedJetsPuppi"),  # <<< HERE
-        weightFile          = cms.FileInPath("model_refinement_regression_20250320_dynamic.onnx"),
+        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/model_fastsimrefine_puppi_31July2025.onnx"),
         name                = cms.string("puppiJetRefineNN"),
         variables = cms.VPSet(
             cms.PSet(name=cms.string("GenJet_pt"),            expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().pt():pt")),

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -260,3 +260,100 @@ jetPuppiTask = cms.Task(jetPuppiCorrFactorsNano,updatedJetsPuppi,jetPuppiUserDat
 
 #after cross linkining
 jetPuppiTablesTask = cms.Task(jetPuppiTable)
+
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+from PhysicsTools.NanoAOD.common_cff import ExtVar
+
+def nanoAOD_refineFastSim_puppiJet(process):
+    process.puppiJetRefineNN = cms.EDProducer(
+        "JetBaseMVAValueMapProducer",
+        backend             = cms.string("ONNX"),
+        batch_eval          = cms.bool(True),
+        disableONNXGraphOpt = cms.bool(True),
+        src                 = cms.InputTag("updatedJetsPuppi"),  # <<< HERE
+        weightFile          = cms.FileInPath("model_refinement_regression_20250320_dynamic.onnx"),
+        name                = cms.string("puppiJetRefineNN"),
+        variables = cms.VPSet(
+            cms.PSet(name=cms.string("GenJet_pt"),            expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().pt():pt")),
+            cms.PSet(name=cms.string("GenJet_eta"),           expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().eta():eta")),
+            cms.PSet(name=cms.string("Jet_hadronFlavour"),    expr=cms.string("hadronFlavour()")),
+            cms.PSet(name=cms.string("Jet_pt"),               expr=cms.string("pt()")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavB"),    expr=cms.string("bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavCvB"),  expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')):-1")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavCvL"),  expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')):-1")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavQG"),   expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds'))>0?bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')):-1")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4B"),    expr=cms.string("bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4CvB"),  expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'):-1")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4CvL"),  expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'):-1")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4QvG"),  expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'):-1")),
+        ),
+        inputTensorName  = cms.string("input"),
+        outputTensorName = cms.string("output"),
+        outputNames      = cms.vstring([
+            "ptrefined","btagDeepFlavBrefined","btagDeepFlavCvBrefined","btagDeepFlavCvLrefined",
+            "btagDeepFlavQGrefined","btagUParTAK4Brefined","btagUParTAK4CvBrefined",
+            "btagUParTAK4CvLrefined","btagUParTAK4QvGrefined"
+        ]),
+        outputFormulas   = cms.vstring([f"at({i})" for i in range(9)]),
+    )
+
+    # schedule it in the jet-building chain
+    fastSim.toModify(process.jetPuppiTask, process.jetPuppiTask.add(process.puppiJetRefineNN))
+
+    #
+    # 1) now stuff those 9 refined scalars into the existing PATJetUserDataEmbedder
+    #
+    fastSim.toModify(process.updatedJetsPuppiWithUserData.userFloats,
+        ptRefined              = cms.InputTag("puppiJetRefineNN","ptrefined"),
+        btagDeepFlavBrefined   = cms.InputTag("puppiJetRefineNN","btagDeepFlavBrefined"),
+        btagDeepFlavCvBrefined = cms.InputTag("puppiJetRefineNN","btagDeepFlavCvBrefined"),
+        btagDeepFlavCvLrefined = cms.InputTag("puppiJetRefineNN","btagDeepFlavCvLrefined"),
+        btagDeepFlavQGrefined  = cms.InputTag("puppiJetRefineNN","btagDeepFlavQGrefined"),
+        btagUParTAK4Brefined   = cms.InputTag("puppiJetRefineNN","btagUParTAK4Brefined"),
+        btagUParTAK4CvBrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4CvBrefined"),
+        btagUParTAK4CvLrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4CvLrefined"),
+        btagUParTAK4QvGrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4QvGrefined"),
+    )
+
+    #
+    # 2) backup all 9 originals in the NanoAOD table as *_unrefined
+    #
+    fastSim.toModify(process.jetPuppiTable.variables,
+        pt_unrefined               = process.jetPuppiTable.variables.pt.clone(),
+        btagDeepFlavB_unrefined    = process.jetPuppiTable.variables.btagDeepFlavB.clone(),
+        btagDeepFlavCvB_unrefined  = process.jetPuppiTable.variables.btagDeepFlavCvB.clone(),
+        btagDeepFlavCvL_unrefined  = process.jetPuppiTable.variables.btagDeepFlavCvL.clone(),
+        btagDeepFlavQG_unrefined   = process.jetPuppiTable.variables.btagDeepFlavQG.clone(),
+        btagUParTAK4B_unrefined    = process.jetPuppiTable.variables.btagUParTAK4B.clone(),
+        btagUParTAK4CvB_unrefined  = process.jetPuppiTable.variables.btagUParTAK4CvB.clone(),
+        btagUParTAK4CvL_unrefined  = process.jetPuppiTable.variables.btagUParTAK4CvL.clone(),
+        btagUParTAK4QvG_unrefined  = process.jetPuppiTable.variables.btagUParTAK4QvG.clone(),
+    )
+    # drop them so we can redefine
+    fastSim.toModify(process.jetPuppiTable.variables,
+        pt=None, btagDeepFlavB=None, btagDeepFlavCvB=None,
+        btagDeepFlavCvL=None, btagDeepFlavQG=None,
+        btagUParTAK4B=None, btagUParTAK4CvB=None,
+        btagUParTAK4CvL=None, btagUParTAK4QvG=None,
+    )
+
+    #
+    # 3) re‑define each branch with a FastSim‑only mask ternary
+    #
+    mask = "(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')>0)"
+
+    fastSim.toModify(process.jetPuppiTable.variables,
+        pt              = Var(f"?{mask}?userFloat('ptRefined'):pt()",              float, precision=10, doc="refined pT or original"),
+        btagDeepFlavB   = Var(f"?{mask}?userFloat('btagDeepFlavBrefined'):(bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))", float, precision=10),
+        btagDeepFlavCvB = Var(f"?{mask}?userFloat('btagDeepFlavCvBrefined'):(?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')):-1)", float, precision=10),
+        btagDeepFlavCvL = Var(f"?{mask}?userFloat('btagDeepFlavCvLrefined'):(?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')):-1)", float, precision=10),
+        btagDeepFlavQG  = Var(f"?{mask}?userFloat('btagDeepFlavQGrefined'):(?(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds'))>0?bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')):-1)", float, precision=10),
+        btagUParTAK4B   = Var(f"?{mask}?userFloat('btagUParTAK4Brefined'):(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll'))", float, precision=10),
+        btagUParTAK4CvB = Var(f"?{mask}?userFloat('btagUParTAK4CvBrefined'):(?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'):-1)", float, precision=10),
+        btagUParTAK4CvL = Var(f"?{mask}?userFloat('btagUParTAK4CvLrefined'):(?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'):-1)", float, precision=10),
+        btagUParTAK4QvG = Var(f"?{mask}?userFloat('btagUParTAK4QvGrefined'):(?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'):-1)", float, precision=10),
+    )
+
+    return process
+
+nanoAOD_refineFastSim_puppiJet = nanoAOD_refineFastSim_puppiJet

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -257,8 +257,6 @@ jetPuppiUserDataTask = cms.Task(tightJetPuppiId, tightJetPuppiIdLepVeto, hfJetPu
 
 #before cross linking
 jetPuppiTask = cms.Task(jetPuppiCorrFactorsNano,updatedJetsPuppi,jetPuppiUserDataTask,updatedJetsPuppiWithUserData,finalJetsPuppi)
-
-#after cross linkining
 jetPuppiTablesTask = cms.Task(jetPuppiTable)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
@@ -297,12 +295,9 @@ def nanoAOD_refineFastSim_puppiJet(process):
         outputFormulas   = cms.vstring([f"at({i})" for i in range(9)]),
     )
 
-    # schedule it in the jet-building chain
     fastSim.toModify(process.jetPuppiTask, process.jetPuppiTask.add(process.puppiJetRefineNN))
 
-    #
-    # 1) now stuff those 9 refined scalars into the existing PATJetUserDataEmbedder
-    #
+    # 1) now stuff the 9 refined scalars into the existing PATJetUserDataEmbedder
     fastSim.toModify(process.updatedJetsPuppiWithUserData.userFloats,
         ptRefined              = cms.InputTag("puppiJetRefineNN","ptrefined"),
         btagDeepFlavBrefined   = cms.InputTag("puppiJetRefineNN","btagDeepFlavBrefined"),
@@ -315,9 +310,7 @@ def nanoAOD_refineFastSim_puppiJet(process):
         btagUParTAK4QvGrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4QvGrefined"),
     )
 
-    #
     # 2) backup all 9 originals in the NanoAOD table as *_unrefined
-    #
     fastSim.toModify(process.jetPuppiTable.variables,
         pt_unrefined               = process.jetPuppiTable.variables.pt.clone(),
         btagDeepFlavB_unrefined    = process.jetPuppiTable.variables.btagDeepFlavB.clone(),
@@ -337,9 +330,7 @@ def nanoAOD_refineFastSim_puppiJet(process):
         btagUParTAK4CvL=None, btagUParTAK4QvG=None,
     )
 
-    #
     # 3) re‑define each branch with a FastSim‑only mask ternary
-    #
     mask = "(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')>0)"
 
     fastSim.toModify(process.jetPuppiTable.variables,

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -261,17 +261,10 @@ jetPuppiTablesTask = cms.Task(jetPuppiTable)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 from PhysicsTools.NanoAOD.common_cff import Var, ExtVar
-<<<<<<< HEAD
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 def nanoAOD_refineFastSim_puppiJet(process):
 
-=======
-
-def nanoAOD_refineFastSim_puppiJet(process):
-
-    # 0. Save originals and clear so we can republish refined versions
->>>>>>> 882bbc46eb0 (implemented refined pT-based sorting of jets in NANO, Type-1 MET correction of the refined jets)
     fastSim.toModify(process.jetPuppiTable.variables,
         pt_unrefined               = process.jetPuppiTable.variables.pt.clone(),
         btagDeepFlavB_unrefined    = process.jetPuppiTable.variables.btagDeepFlavB.clone(),
@@ -289,20 +282,12 @@ def nanoAOD_refineFastSim_puppiJet(process):
         btagUParTAK4B=None, btagUParTAK4CvB=None, btagUParTAK4CvL=None, btagUParTAK4QvG=None,
     )
 
-<<<<<<< HEAD
-=======
-    # 1. Run refinement model and return features
->>>>>>> 882bbc46eb0 (implemented refined pT-based sorting of jets in NANO, Type-1 MET correction of the refined jets)
     process.puppiJetRefineNN = cms.EDProducer(
         "JetBaseMVAValueMapProducer",
         backend             = cms.string("ONNX"),
         batch_eval          = cms.bool(True),
         disableONNXGraphOpt = cms.bool(True),
-<<<<<<< HEAD
         src                 = cms.InputTag("linkedObjects","jets"),
-=======
-        src                 = cms.InputTag("linkedObjects","jets"),  # matches table
->>>>>>> 882bbc46eb0 (implemented refined pT-based sorting of jets in NANO, Type-1 MET correction of the refined jets)
         weightFile          = cms.FileInPath("PhysicsTools/NanoAOD/data/fastSimPuppiJetRefineNN_31July2025.onnx"),
         name                = cms.string("puppiJetRefineNN"),
         variables = cms.VPSet(

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -260,17 +260,18 @@ jetPuppiTask = cms.Task(jetPuppiCorrFactorsNano,updatedJetsPuppi,jetPuppiUserDat
 jetPuppiTablesTask = cms.Task(jetPuppiTable)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-from PhysicsTools.NanoAOD.common_cff import ExtVar
-
-import FWCore.ParameterSet.Config as cms
-from Configuration.Eras.Modifier_fastSim_cff import fastSim
-from PhysicsTools.NanoAOD.common_cff import Var
-
 from PhysicsTools.NanoAOD.common_cff import Var, ExtVar
+<<<<<<< HEAD
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 def nanoAOD_refineFastSim_puppiJet(process):
 
+=======
+
+def nanoAOD_refineFastSim_puppiJet(process):
+
+    # 0. Save originals and clear so we can republish refined versions
+>>>>>>> 882bbc46eb0 (implemented refined pT-based sorting of jets in NANO, Type-1 MET correction of the refined jets)
     fastSim.toModify(process.jetPuppiTable.variables,
         pt_unrefined               = process.jetPuppiTable.variables.pt.clone(),
         btagDeepFlavB_unrefined    = process.jetPuppiTable.variables.btagDeepFlavB.clone(),
@@ -288,12 +289,20 @@ def nanoAOD_refineFastSim_puppiJet(process):
         btagUParTAK4B=None, btagUParTAK4CvB=None, btagUParTAK4CvL=None, btagUParTAK4QvG=None,
     )
 
+<<<<<<< HEAD
+=======
+    # 1. Run refinement model and return features
+>>>>>>> 882bbc46eb0 (implemented refined pT-based sorting of jets in NANO, Type-1 MET correction of the refined jets)
     process.puppiJetRefineNN = cms.EDProducer(
         "JetBaseMVAValueMapProducer",
         backend             = cms.string("ONNX"),
         batch_eval          = cms.bool(True),
         disableONNXGraphOpt = cms.bool(True),
+<<<<<<< HEAD
         src                 = cms.InputTag("linkedObjects","jets"),
+=======
+        src                 = cms.InputTag("linkedObjects","jets"),  # matches table
+>>>>>>> 882bbc46eb0 (implemented refined pT-based sorting of jets in NANO, Type-1 MET correction of the refined jets)
         weightFile          = cms.FileInPath("PhysicsTools/NanoAOD/data/fastSimPuppiJetRefineNN_31July2025.onnx"),
         name                = cms.string("puppiJetRefineNN"),
         variables = cms.VPSet(
@@ -308,15 +317,13 @@ def nanoAOD_refineFastSim_puppiJet(process):
             cms.PSet(name=cms.string("Jet_btagUParTAK4B"),   expr=cms.string("bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')")),
             cms.PSet(name=cms.string("Jet_btagUParTAK4CvB"), expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'):-1")),
             cms.PSet(name=cms.string("Jet_btagUParTAK4CvL"), expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'):-1")),
-            cms.PSet(name=cms.string("Jet_btagUParTAK4QvG"), expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'):-1")),
-        ),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4QvG"), expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'):-1")),),
         inputTensorName  = cms.string("input"),
         outputTensorName = cms.string("output"),
         outputNames      = cms.vstring(
             "ptrefined",
             "btagDeepFlavBrefined","btagDeepFlavCvBrefined","btagDeepFlavCvLrefined","btagDeepFlavQGrefined",
-            "btagUParTAK4Brefined","btagUParTAK4CvBrefined","btagUParTAK4CvLrefined","btagUParTAK4QvGrefined",
-        ),
+            "btagUParTAK4Brefined","btagUParTAK4CvBrefined","btagUParTAK4CvLrefined","btagUParTAK4QvGrefined",),
         outputFormulas   = cms.vstring("at(0)","at(1)","at(2)","at(3)","at(4)","at(5)","at(6)","at(7)","at(8)"),
     )
 

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -289,6 +289,9 @@ def nanoAOD_customizeCommon(process):
     # Add lepton time-life info
     from PhysicsTools.NanoAOD.leptonTimeLifeInfo_common_cff import addTimeLifeInfoBase
     process = addTimeLifeInfoBase(process)
+    
+    process = nanoAOD_refineFastSim_puppiJet(process)
+    process = nanoAOD_refineFastSim_bTagDeepFlav(process)
 
     return process
 


### PR DESCRIPTION
This is a backport of 

https://github.com/cms-sw/cmssw/pull/49429 and https://github.com/cms-sw/cmssw/pull/48587#issuecomment-3151196024 which implements the morphing-based refinement of FastSim jet pT and flavor tagging, and the propagation of the refined jet pT to the PUPPI MET collection. The refined collections override the existing values, but the original values are stored in NANO in an [X]_unrefined branch. This is needed for NANO-v15 FastSim production. 

I note that most likely the complementary PR in cms-data, namely https://github.com/cms-data/PhysicsTools-NanoAOD/pull/20, also needs to be backported to some release, but I'm not sure how that pairing is made. Maybe (hopefully) I'm wrong and it doesn't need to be backported. 
