### PR TITLE
[GCC15] (simulation) Initialize EcalTBEventHeader to fix GCC15 warning

### DIFF
--- a/TBDataFormats/EcalTBObjects/interface/EcalTBEventHeader.h
+++ b/TBDataFormats/EcalTBObjects/interface/EcalTBEventHeader.h
@@ -13,7 +13,7 @@
 
 class EcalTBEventHeader {
 public:
-  EcalTBEventHeader() {}
+  EcalTBEventHeader() = default;
 
   ~EcalTBEventHeader() {}
 


### PR DESCRIPTION
- Initialize EcalTBEventHeader ( warning: 'MEM <const vector(4) int> [(int *)_10 + 12B]' may be used uninitialized)
`- EcalTBEventHeader() {}`
`+ EcalTBEventHeader() = default;`
[log](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc15/CMSSW_16_1_X_2026-02-05-2300/SimG4CMS/EcalTestBeam)