### PR TITLE
Use `TApplication` in `edmRNTupleTemp{FileUtil,ProvDump,Storage}`

### DIFF
--- a/FWIO/RNTupleTempInput/bin/EdmRNTupleTempFileUtil.cpp
+++ b/FWIO/RNTupleTempInput/bin/EdmRNTupleTempFileUtil.cpp
@@ -28,8 +28,14 @@
 #include "TTree.h"
 #include "ROOT/RNTuple.hxx"
 #include "ROOT/RNTupleReader.hxx"
+#include "TApplication.h"
 
 int main(int argc, char* argv[]) {
+  // TApplication sets up atexit handlers such that header parsing
+  // should not happen there
+  // A simpler solution would be nice
+  TApplication application("edmRNTupleTempFileUtil", nullptr, nullptr);
+
   gErrorIgnoreLevel = kError;
 
   // Add options here

--- a/FWIO/RNTupleTempInput/bin/EdmRNTupleTempProvDump.cc
+++ b/FWIO/RNTupleTempInput/bin/EdmRNTupleTempProvDump.cc
@@ -27,6 +27,7 @@
 
 #include "ROOT/RNTuple.hxx"
 #include "ROOT/RNTupleReader.hxx"
+#include "TApplication.h"
 
 #include "boost/program_options.hpp"
 
@@ -1177,6 +1178,11 @@ static char const* const kDumpPSetIDCommandOpt = "dumpPSetID,i";
 static char const* const kProductIDEntryOpt = "productIDEntry";
 
 int main(int argc, char* argv[]) {
+  // TApplication sets up atexit handlers such that header parsing
+  // should not happen there
+  // A simpler solution would be nice
+  TApplication application("edmRNTupleTempProvDump", nullptr, nullptr);
+
   using namespace boost::program_options;
 
   std::string descString(argv[0]);

--- a/FWIO/RNTupleTempInput/bin/edmRNTupleTempStorage.cc
+++ b/FWIO/RNTupleTempInput/bin/edmRNTupleTempStorage.cc
@@ -1,6 +1,8 @@
 #include "TFile.h"
 #include "ROOT/RNTupleReader.hxx"
 #include "ROOT/RNTuple.hxx"
+#include "TApplication.h"
+
 #include <charconv>
 #include <iostream>
 #include <sstream>
@@ -170,6 +172,11 @@ namespace {
 }  // namespace
 
 int main(int iArgc, char const* iArgv[]) {
+  // TApplication sets up atexit handlers such that header parsing
+  // should not happen there
+  // A simpler solution would be nice
+  TApplication application("edmRNTupleTempStorage", nullptr, nullptr);
+
   // Add options here
 
   boost::program_options::options_description desc("Allowed options");


### PR DESCRIPTION
#### PR description:

This should prevent header parsing at exit() that was observed in conjunction of severe slowdown in using these utilities in PR tests. See discussion in https://github.com/cms-sw/cmssw/issues/49640#issuecomment-3763963238 onwards, specifically https://github.com/cms-sw/cmssw/issues/49640#issuecomment-3791392724 and https://github.com/cms-sw/cmssw/issues/49640#issuecomment-3791519482

Resolves https://github.com/cms-sw/framework-team/issues/1815

#### PR validation:

Checked with `gdb` that `ExecAutoParse` is no longer called after `exit()`.