### PR TITLE
NanoAOD: remove duplicates of `nanoMetadata` in `cff` fragments

### DIFF
--- a/DPGAnalysis/HcalNanoAOD/python/hcalNano_cff.py
+++ b/DPGAnalysis/HcalNanoAOD/python/hcalNano_cff.py
@@ -1,13 +1,8 @@
 from PhysicsTools.NanoAOD.common_cff import Var,CandVars
+from PhysicsTools.NanoAOD.nano_cff import nanoMetadata
 from DPGAnalysis.HcalNanoAOD.hcalRecHitTable_cff import *
 from DPGAnalysis.HcalNanoAOD.hcalDigiSortedTable_cff import *
 from DPGAnalysis.HcalNanoAOD.hcalDetIdTable_cff import *
-
-nanoMetadata = cms.EDProducer("UniqueStringProducer",
-    strings = cms.PSet(
-        tag = cms.string("untagged"),
-    )
-)
 
 hcalNanoTask = cms.Task(
     nanoMetadata, 

--- a/PhysicsTools/NanoAOD/python/nanogen_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanogen_cff.py
@@ -1,3 +1,4 @@
+from PhysicsTools.NanoAOD.nano_cff import nanoMetadata
 from PhysicsTools.NanoAOD.taus_cff import *
 from PhysicsTools.NanoAOD.jetMC_cff import *
 from PhysicsTools.NanoAOD.globals_cff import genTable,genFilterTable
@@ -9,14 +10,6 @@ from PhysicsTools.NanoAOD.genVertex_cff import *
 from PhysicsTools.NanoAOD.common_cff import Var,CandVars
 from PhysicsTools.NanoAOD.simpleSingletonCandidateFlatTableProducer_cfi import simpleSingletonCandidateFlatTableProducer
 from RecoJets.JetProducers.ak4GenJets_cfi import ak4GenJets
-
-nanoMetadata = cms.EDProducer("UniqueStringProducer",
-    strings = cms.PSet(
-        tag = cms.string("untagged"),
-    )
-)
-
-
 
 nanogenSequence = cms.Sequence(
     nanoMetadata+


### PR DESCRIPTION
#### PR description:

The module `nanoMetadata` is defined (with the same exact definition) in three different `cff` files:

https://github.com/cms-sw/cmssw/blob/a8a0be07cf733c297800282bffcd4749450f88a6/DPGAnalysis/HcalNanoAOD/python/hcalNano_cff.py#L6
https://github.com/cms-sw/cmssw/blob/a8a0be07cf733c297800282bffcd4749450f88a6/PhysicsTools/NanoAOD/python/nano_cff.py#L32
https://github.com/cms-sw/cmssw/blob/a8a0be07cf733c297800282bffcd4749450f88a6/PhysicsTools/NanoAOD/python/nanogen_cff.py#L13

As far as I know, having multiple definitions should be avoided, and it can lead to problems when loading those `cff` fragments together in the same configuration (for example, in this particular case, when attempting to combine different NanoAOD "flavours" in the same job).

This PR removes the extra definitions, taking `nano_cff` as the file that defines `nanoMetadata`, and importing the latter from the former `cff` when needed (following what is done already in some other `cff` fragments in CMSSW).

#### PR validation:

Without this PR, the command in [1] leads to the runtime error in [2]. With this PR, [1] runs without crashing. This was tested in `CMSSW_16_0_0_pre4`, and I would expect the same behaviour in 16_1_X.

[1]
```bash
cmsDriver.py tmp --process TEST --python_filename tmp_cfg.py --fileout file:tmp_out.root \
  --filein /store/mc/Run3Winter25Digi/QCD_Bin-PT-15to7000_Par-PT-flat2022_TuneCP5_13p6TeV_pythia8/GEN-SIM-RAW/FlatPU0to120_142X_mcRun3_2025_realistic_v9-v4/2520000/00491803-ed8e-4011-bfc1-e503706c64f8.root \
  --mc --conditions auto:phase1_2025_realistic --geometry DB:Extended \
  --scenario pp --era Run3_2025 \
  --datatier NANOAOD --eventcontent NANOAOD \
  --nThreads 1 --nStreams 0 \
  -n 10 \
  -s RAW2DIGI,NANO:@GEN+@L1DPG
```

[2]
```bash
RAW2DIGI,NANO:@GEN+@L1DPG,ENDJOB
with DB:
entry /store/mc/Run3Winter25Digi/QCD_Bin-PT-15to7000_Par-PT-flat2022_TuneCP5_13p6TeV_pythia8/GEN-SIM-RAW/FlatPU0to120_142X_mcRun3_2025_realistic_v9-v4/2520000/00491803-ed8e-4011-bfc1-e503706c64f8.root
Step: RAW2DIGI Spec: 
Step: NANO Spec: ['@GEN', '@L1DPG']
in prepare_nano @GEN+@L1DPG
@GEN+@L1DPG
NANO: scheduling: nanogenSequence from PhysicsTools/NanoAOD/nanogen_cff
NANO: scheduling: l1tNanoSequence from DPGAnalysis/L1TNanoAOD/l1tNano_cff
Traceback (most recent call last):
  File "/cvmfs/cms.cern.ch/el8_amd64_gcc13/cms/cmssw/CMSSW_16_0_0_pre4/bin/el8_amd64_gcc13/cmsDriver.py", line 40, in <module>
    run()
  File "/cvmfs/cms.cern.ch/el8_amd64_gcc13/cms/cmssw/CMSSW_16_0_0_pre4/bin/el8_amd64_gcc13/cmsDriver.py", line 16, in run
    configBuilder.prepare()
  File "/cvmfs/cms.cern.ch/el8_amd64_gcc13/cms/cmssw/CMSSW_16_0_0_pre4/src/Configuration/Applications/python/ConfigBuilder.py", line 2349, in prepare
    self.addStandardSequences()
  File "/cvmfs/cms.cern.ch/el8_amd64_gcc13/cms/cmssw/CMSSW_16_0_0_pre4/src/Configuration/Applications/python/ConfigBuilder.py", line 857, in addStandardSequences
    getattr(self,"prepare_"+stepName)(stepSpec = '+'.join(stepSpec))
  File "/cvmfs/cms.cern.ch/el8_amd64_gcc13/cms/cmssw/CMSSW_16_0_0_pre4/src/Configuration/Applications/python/ConfigBuilder.py", line 1878, in prepare_NANO
    self.loadAndRemember(_cff)
  File "/cvmfs/cms.cern.ch/el8_amd64_gcc13/cms/cmssw/CMSSW_16_0_0_pre4/src/Configuration/Applications/python/ConfigBuilder.py", line 365, in loadAndRemember
    self.process.load(includeFile)
  File "/cvmfs/cms.cern.ch/el8_amd64_gcc13/cms/cmssw/CMSSW_16_0_0_pre4/src/FWCore/ParameterSet/python/Config.py", line 711, in load
    self.extend(sys.modules[moduleName])
  File "/cvmfs/cms.cern.ch/el8_amd64_gcc13/cms/cmssw/CMSSW_16_0_0_pre4/src/FWCore/ParameterSet/python/Config.py", line 734, in extend
    self.__setattr__(name,item)
  File "/cvmfs/cms.cern.ch/el8_amd64_gcc13/cms/cmssw/CMSSW_16_0_0_pre4/src/FWCore/ParameterSet/python/Config.py", line 489, in __setattr__
    raise ValueError(msg1+"sequence "+s.label_()+msg2)
ValueError: Trying to override definition of nanoMetadata while it is used by the sequence nanogenSequence
 new object defined in: [...]/CMSSW_16_0_0_pre4/src/PhysicsTools/NanoAOD/python/nano_cff.py
 existing object defined in: [...]/CMSSW_16_0_0_pre4/src/PhysicsTools/NanoAOD/python/nanogen_cff.py
```

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A
