### PR TITLE
Add PhaseAllocMonitor

### DIFF
--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -170,6 +170,22 @@ namespace edm {
     }
     AR_WATCH_USING_METHOD_0(watchPostEventSetupModulesConstruction)
 
+    using PreModulesAndSourceConstruction = signalslot::Signal<void()>;
+    /// signal is emitted before the parallel section to construct ED modules and source
+    PreModulesAndSourceConstruction preModulesAndSourceConstructionSignal_;
+    void watchPreModulesAndSourceConstruction(PreModulesAndSourceConstruction::slot_type const& iSlot) {
+      preModulesAndSourceConstructionSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_0(watchPreModulesAndSourceConstruction)
+
+    using PostModulesAndSourceConstruction = signalslot::Signal<void()>;
+    /// signal is emitted after the parallel section to construct ED modules and source
+    PostModulesAndSourceConstruction postModulesAndSourceConstructionSignal_;
+    void watchPostModulesAndSourceConstruction(PostModulesAndSourceConstruction::slot_type const& iSlot) {
+      postModulesAndSourceConstructionSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_0(watchPostModulesAndSourceConstruction)
+
     using PreFinishSchedule = signalslot::Signal<void()>;
     /// signal is emitted before the call to EventSetup::finishSchedule
     PreFinishSchedule preFinishScheduleSignal_;
@@ -420,6 +436,40 @@ namespace edm {
     PostCloseFile postCloseFileSignal_;
     void watchPostCloseFile(PostCloseFile::slot_type const& iSlot) { postCloseFileSignal_.connect_front(iSlot); }
     AR_WATCH_USING_METHOD_1(watchPostCloseFile)
+
+    /// signal is emitted before the framework asks OutputModules to open output files
+    // Note an OutputModule may decide to close and open files by itself, those are not covered by this signal
+    typedef signalslot::Signal<void()> PreOpenOutputFiles;
+    PreOpenOutputFiles preOpenOutputFilesSignal_;
+    void watchPreOpenOutputFiles(PreOpenOutputFiles::slot_type const& iSlot) {
+      preOpenOutputFilesSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_1(watchPreOpenOutputFiles)
+
+    /// signal is emitted after the framework asks OutputModules to open output files
+    typedef signalslot::Signal<void()> PostOpenOutputFiles;
+    PostOpenOutputFiles postOpenOutputFilesSignal_;
+    void watchPostOpenOutputFiles(PostOpenOutputFiles::slot_type const& iSlot) {
+      postOpenOutputFilesSignal_.connect_front(iSlot);
+    }
+    AR_WATCH_USING_METHOD_1(watchPostOpenOutputFiles)
+
+    /// signal is emitted before the framework asks OutputModules to close output files
+    // Note an OutputModule may decide to close and open files by itself, those are not covered by this signal
+    typedef signalslot::Signal<void()> PreCloseOutputFiles;
+    PreCloseOutputFiles preCloseOutputFilesSignal_;
+    void watchPreCloseOutputFiles(PreCloseOutputFiles::slot_type const& iSlot) {
+      preCloseOutputFilesSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_1(watchPreCloseOutputFiles)
+
+    /// signal is emitted after the framework asks OutputModules to close output files
+    typedef signalslot::Signal<void()> PostCloseOutputFiles;
+    PostCloseOutputFiles postCloseOutputFilesSignal_;
+    void watchPostCloseOutputFiles(PostCloseOutputFiles::slot_type const& iSlot) {
+      postCloseOutputFilesSignal_.connect_front(iSlot);
+    }
+    AR_WATCH_USING_METHOD_1(watchPostCloseOutputFiles)
 
     typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PreModuleBeginStream;
     PreModuleBeginStream preModuleBeginStreamSignal_;

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -59,6 +59,8 @@ namespace edm {
     postEventSetupModulesConstructionSignal_.connect(std::cref(iOther.postEventSetupModulesConstructionSignal_));
     preESModuleConstructionSignal_.connect(std::cref(iOther.preESModuleConstructionSignal_));
     postESModuleConstructionSignal_.connect(std::cref(iOther.postESModuleConstructionSignal_));
+    preModulesAndSourceConstructionSignal_.connect(std::cref(iOther.preModulesAndSourceConstructionSignal_));
+    postModulesAndSourceConstructionSignal_.connect(std::cref(iOther.postModulesAndSourceConstructionSignal_));
     preFinishScheduleSignal_.connect(std::cref(iOther.preFinishScheduleSignal_));
     postFinishScheduleSignal_.connect(std::cref(iOther.postFinishScheduleSignal_));
     prePrincipalsCreationSignal_.connect(std::cref(iOther.prePrincipalsCreationSignal_));
@@ -99,6 +101,12 @@ namespace edm {
 
     preCloseFileSignal_.connect(std::cref(iOther.preCloseFileSignal_));
     postCloseFileSignal_.connect(std::cref(iOther.postCloseFileSignal_));
+
+    preOpenOutputFilesSignal_.connect(std::cref(iOther.preOpenOutputFilesSignal_));
+    postOpenOutputFilesSignal_.connect(std::cref(iOther.postOpenOutputFilesSignal_));
+
+    preCloseOutputFilesSignal_.connect(std::cref(iOther.preCloseOutputFilesSignal_));
+    postCloseOutputFilesSignal_.connect(std::cref(iOther.postCloseOutputFilesSignal_));
 
     preSourceConstructionSignal_.connect(std::cref(iOther.preSourceConstructionSignal_));
     postSourceConstructionSignal_.connect(std::cref(iOther.postSourceConstructionSignal_));
@@ -279,6 +287,8 @@ namespace edm {
     copySlotsToFromReverse(postEventSetupModulesConstructionSignal_, iOther.postEventSetupModulesConstructionSignal_);
     copySlotsToFrom(preESModuleConstructionSignal_, iOther.preESModuleConstructionSignal_);
     copySlotsToFromReverse(postESModuleConstructionSignal_, iOther.postESModuleConstructionSignal_);
+    copySlotsToFrom(preModulesAndSourceConstructionSignal_, iOther.preModulesAndSourceConstructionSignal_);
+    copySlotsToFromReverse(postModulesAndSourceConstructionSignal_, iOther.postModulesAndSourceConstructionSignal_);
     copySlotsToFrom(preFinishScheduleSignal_, iOther.preFinishScheduleSignal_);
     copySlotsToFromReverse(postFinishScheduleSignal_, iOther.postFinishScheduleSignal_);
     copySlotsToFrom(prePrincipalsCreationSignal_, iOther.prePrincipalsCreationSignal_);
@@ -322,6 +332,12 @@ namespace edm {
 
     copySlotsToFrom(preCloseFileSignal_, iOther.preCloseFileSignal_);
     copySlotsToFromReverse(postCloseFileSignal_, iOther.postCloseFileSignal_);
+
+    copySlotsToFrom(preOpenOutputFilesSignal_, iOther.preOpenOutputFilesSignal_);
+    copySlotsToFromReverse(postOpenOutputFilesSignal_, iOther.postOpenOutputFilesSignal_);
+
+    copySlotsToFrom(preCloseOutputFilesSignal_, iOther.preCloseOutputFilesSignal_);
+    copySlotsToFromReverse(postCloseOutputFilesSignal_, iOther.postCloseOutputFilesSignal_);
 
     copySlotsToFrom(preBeginStreamSignal_, iOther.preBeginStreamSignal_);
     copySlotsToFromReverse(postBeginStreamSignal_, iOther.postBeginStreamSignal_);

--- a/PerfTools/AllocMonitor/README.md
+++ b/PerfTools/AllocMonitor/README.md
@@ -70,6 +70,26 @@ This service registers a monitor at the end of beginJob (after all modules have 
 
 This service is multi-thread safe. Note that when run multi-threaded the maximum reported value will vary from job to job.
 
+### PhaseAllocMonitor
+
+This service registers a monitor at the end of service construction, and on a predefined set of other signals that correspond to framework's "phases". Each such signal corresponds to a global synchronization point of the framework. This can be useful to understand how memory is being used in different phases of a job. The monitor reports the following quantities measured during the period from the previous signal to the current signal
+
+| Field | Description |
+|-------|-------------|
+| `requested` | Total amount of bytes requested by all allocation calls since the previous signal |
+| `max alloc` | The largest single memory allocation since the previous signal |
+| `presentActual` | The amount of _used_ memory (i.e. actual size) at the time of the signal |
+| `peak` | The maximum amount of _used_ allocated memory that was in use at one time since the previous signal |
+| `added ` | The amount of _used_ memory added by the allocations and deallocations since the previous signal. Can be negative if memory allocated in earlier phases is deleted in the current phase. |
+| `nAlloc` | Number of calls made to allocation functions since the previous signal |
+| `nDealloc` | Number of calls made to deallocation functions since the previous signal |
+
+
+The service has the following configuration parameters:
+- `showSignals`: names of [`ActivityRegistry`](../../FWCore/ServiceRegistry/interface/ActivityRegistry.h) signals to measure. Empty vector (default) shows for all the predefined signals. For a list of possible values see the [code](plugins/PhaseAllocMonitor.cc).
+
+This service is multi-thread safe. Note that when run multi-threaded the maximum reported value will vary from job to job.
+
 ### HistogrammingAllocMonitor
 This service registers a monitor when the service is created (after python parsing is finished but before any modules
 have been loaded into cmsRun) and reports its accumulated information when the service is destroyed (services are the

--- a/PerfTools/AllocMonitor/plugins/PhaseAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/PhaseAllocMonitor.cc
@@ -1,0 +1,168 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+#include "FWCore/Utilities/interface/stringize.h"
+#include "PerfTools/AllocMonitor/interface/AllocMonitorBase.h"
+#include "PerfTools/AllocMonitor/interface/AllocMonitorRegistry.h"
+
+#include <atomic>
+#include <string_view>
+
+namespace {
+  class MonitorAdaptor : public cms::perftools::AllocMonitorBase {
+  public:
+    void activate() { active_ = true; }
+    void deactivate() { active_ = false; }
+
+    void reportAndReset(std::string_view name) {
+      deactivate();
+      auto const requested = requested_.exchange(0, std::memory_order_acq_rel);
+      auto const nAllocations = nAllocations_.exchange(0, std::memory_order_acq_rel);
+      auto const nDeallocations = nDeallocations_.exchange(0, std::memory_order_acq_rel);
+      auto const maxSingleRequested = maxSingleRequested_.exchange(0, std::memory_order_acq_rel);
+
+      // presentActual needs special treatment to find the added
+      auto const presentActual = presentActual_.load(std::memory_order_acquire);
+      auto const previousPresentActual = previousPresentActual_.exchange(presentActual, std::memory_order_acq_rel);
+      auto const added = presentActual - previousPresentActual;
+
+      // use the presentActual as the starting point for the maximum of the next measurement
+      auto const maxActual = maxActual_.exchange(presentActual, std::memory_order_acq_rel);
+
+      edm::LogAbsolute("PhaseAllocMonitor")
+          .format(
+              "PhaseAllocMonitor> {}: requested {} max alloc {} presentActual {} peak {} added {} nAlloc {} nDealloc "
+              "{}",
+              name,
+              requested,
+              maxSingleRequested,
+              presentActual,
+              maxActual,
+              added,
+              nAllocations,
+              nDeallocations);
+
+      activate();
+    }
+
+  private:
+    void allocCalled(size_t iRequested, size_t iActual, void const*) final {
+      if (not active_) {
+        return;
+      }
+
+      nAllocations_.fetch_add(1, std::memory_order_acq_rel);
+      requested_.fetch_add(iRequested, std::memory_order_acq_rel);
+
+      //returns previous value
+      auto a = presentActual_.fetch_add(iActual, std::memory_order_acq_rel);
+      a += iActual;
+
+      auto max = maxActual_.load(std::memory_order_relaxed);
+      while (a > max) {
+        if (maxActual_.compare_exchange_strong(max, a, std::memory_order_acq_rel)) {
+          break;
+        }
+      }
+
+      auto single = maxSingleRequested_.load(std::memory_order_relaxed);
+      while (iRequested > single) {
+        if (maxSingleRequested_.compare_exchange_strong(single, iRequested, std::memory_order_acq_rel)) {
+          break;
+        }
+      }
+    }
+    void deallocCalled(size_t iActual, void const*) final {
+      if (not active_) {
+        return;
+      }
+
+      if (0 == iActual)
+        return;
+      nDeallocations_.fetch_add(1, std::memory_order_acq_rel);
+      presentActual_.fetch_sub(iActual, std::memory_order_acq_rel);
+    }
+
+    std::atomic<bool> active_ = false;
+    std::atomic<size_t> requested_ = 0;
+    std::atomic<long long> previousPresentActual_ = 0;
+    std::atomic<long long> presentActual_ = 0;
+    std::atomic<long long> maxActual_ = 0;
+    std::atomic<size_t> nAllocations_ = 0;
+    std::atomic<size_t> nDeallocations_ = 0;
+    std::atomic<size_t> maxSingleRequested_ = 0;
+  };
+
+}  // namespace
+
+class PhaseAllocMonitor {
+public:
+  PhaseAllocMonitor(edm::ParameterSet const& iPS, edm::ActivityRegistry& iAR) {
+    auto const showSignals = iPS.getUntrackedParameter<std::vector<std::string>>("showSignals");
+    auto adaptor = cms::perftools::AllocMonitorRegistry::instance().createAndRegisterMonitor<MonitorAdaptor>();
+
+    iAR.watchPostServicesConstruction([adaptor]() {
+      adaptor->activate();
+      adaptor->reportAndReset("PostServicesConstruction");
+    });
+
+#define REGISTER(SIGNAL, ...)                                                                              \
+  if (showSignals.empty() or std::ranges::find(showSignals, EDM_STRINGIZE(SIGNAL)) != showSignals.end()) { \
+    iAR.watch##SIGNAL([adaptor](__VA_ARGS__) { adaptor->reportAndReset(EDM_STRINGIZE(SIGNAL)); });         \
+  }
+
+    REGISTER(PreEventSetupModulesConstruction);
+    REGISTER(PostEventSetupModulesConstruction);
+    REGISTER(PreModulesAndSourceConstruction);
+    REGISTER(PostModulesAndSourceConstruction);
+
+    REGISTER(PreFinishSchedule);
+    REGISTER(PostFinishSchedule);
+    REGISTER(PrePrincipalsCreation);
+    REGISTER(PostPrincipalsCreation);
+
+    REGISTER(PreEventSetupConfigurationFinalized);
+    REGISTER(PostEventSetupConfigurationFinalized);
+    REGISTER(PreBeginJob, edm::ProcessContext const&);
+    REGISTER(PostBeginJob);
+
+    // Note that the first {Pre,Post}OpenFile is issued from the
+    // Source construction concurrently to the EDModule construction.
+    // Therefore, in a multithreaded the memory counters from the
+    // first signals might not be reliable. The subsequent signals are
+    // synchronization points for the framework.
+    REGISTER(PreOpenFile, std::string const&);
+    REGISTER(PostOpenFile, std::string const&);
+
+    REGISTER(PreCloseFile, std::string const&);
+    REGISTER(PostCloseFile, std::string const&);
+
+    REGISTER(PreOpenOutputFiles);
+    REGISTER(PostOpenOutputFiles);
+    REGISTER(PreCloseOutputFiles);
+    REGISTER(PostCloseOutputFiles);
+
+    REGISTER(JobFailure);
+    REGISTER(BeginProcessing);
+    REGISTER(EndProcessing);
+
+    REGISTER(PreEndJob);
+    REGISTER(PostEndJob);
+
+#undef REGISTER
+  }
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& iDesc) {
+    edm::ParameterSetDescription ps;
+    ps.addUntracked<std::vector<std::string>>("showSignals", {})
+        ->setComment(
+            "Show measurements for these ActivityRegistry signals. Empty value means show all signals. For the list of "
+            "possible signals see the code.");
+    iDesc.addDefault(ps);
+  }
+};
+
+DEFINE_FWK_SERVICE(PhaseAllocMonitor);


### PR DESCRIPTION
#### PR description:

This PR adds `PhaseAllocMonitor` that monitors the memory allocations within framework's "phases" (synchronization points, or other points where the framework is using only one thread and we already have signals). See the updated README for more details.

This PR also adds signals for
* the beginning and end of "construction of EDModules and Source" parallel section
* the opening and closing of output files when requested by the EventProcessor

This setup has been useful to record the number of memory allocations within the data processing (excluding the file open/close in Source and OutputModules) and outside of the data processing (including the file open/close).

Resolves https://github.com/cms-sw/framework-team/issues/1854

#### PR validation:

Private use in RNTuple studies.