### PR TITLE
Fix ODR violation in L1Trigger/L1TCalorimeter

### DIFF
--- a/L1Trigger/L1TCalorimeter/interface/AccumulatingSort.h
+++ b/L1Trigger/L1TCalorimeter/interface/AccumulatingSort.h
@@ -2,7 +2,7 @@
 #include <list>
 #include <cstdint>
 
-template <typename T>
+template <typename T, typename Greater>
 class AccumulatingSort {
 private:
   std::vector<std::list<T> > mSortArrays;
@@ -13,16 +13,16 @@ private:
     aTail.clear();
 
     bool lAccInserted(false);
-
-    for (typename std::list<T>::const_iterator lIt(aInput.begin()); lIt != aInput.end(); ++lIt) {
+    const Greater g;
+    for (auto const& l : aInput) {
       if (!lAccInserted and
-          !(*lIt >
-            aAcc))  // Accumulator greater than or equal to new entry and not previously inserted -> Reinsert accumulator
+          !g(l,
+             aAcc))  // Accumulator greater than or equal to new entry and not previously inserted -> Reinsert accumulator
       {
         aTail.push_back(aAcc);
         lAccInserted = true;
       }
-      aTail.push_back(*lIt);
+      aTail.push_back(l);
     }
 
     aAcc = *aTail.begin();

--- a/L1Trigger/L1TCalorimeter/interface/BitonicSort.h
+++ b/L1Trigger/L1TCalorimeter/interface/BitonicSort.h
@@ -7,58 +7,51 @@
 enum sort_direction { up, down };
 
 // DECLARE!
-template <typename T>
-void BitonicSort(sort_direction aDir,
-                 typename std::vector<T>::iterator& aDataStart,
-                 typename std::vector<T>::iterator& aDataEnd);
-template <typename T>
-void BitonicMerge(sort_direction aDir,
-                  typename std::vector<T>::iterator& aDataStart,
-                  typename std::vector<T>::iterator& aDataEnd);
+template <typename T, typename Greater, typename Itr>
+void BitonicSort(sort_direction aDir, Itr aDataStart, Itr aDataEnd);
+template <typename T, typename Greater, typename Itr>
+void BitonicMerge(sort_direction aDir, Itr aDataStart, Itr aDataEnd);
 //DEFINE!
 
 //SORT
-template <typename T>
-void BitonicSort(sort_direction aDir,
-                 typename std::vector<T>::iterator& aDataStart,
-                 typename std::vector<T>::iterator& aDataEnd) {
+template <typename T, typename Greater, typename Itr>
+void BitonicSort(sort_direction aDir, Itr aDataStart, Itr aDataEnd) {
   uint32_t lSize(aDataEnd - aDataStart);
   if (lSize > 1) {
-    typename std::vector<T>::iterator lMidpoint(aDataStart + (lSize >> 1));
+    Itr lMidpoint(aDataStart + (lSize >> 1));
     if (aDir == down) {
-      BitonicSort<T>(up, aDataStart, lMidpoint);
-      BitonicSort<T>(down, lMidpoint, aDataEnd);
+      BitonicSort<T, Greater>(up, aDataStart, lMidpoint);
+      BitonicSort<T, Greater>(down, lMidpoint, aDataEnd);
     } else {
-      BitonicSort<T>(down, aDataStart, lMidpoint);
-      BitonicSort<T>(up, lMidpoint, aDataEnd);
+      BitonicSort<T, Greater>(down, aDataStart, lMidpoint);
+      BitonicSort<T, Greater>(up, lMidpoint, aDataEnd);
     }
-    BitonicMerge<T>(aDir, aDataStart, aDataEnd);
+    BitonicMerge<T, Greater>(aDir, aDataStart, aDataEnd);
   }
 }
 
 //MERGE
-template <typename T>
-void BitonicMerge(sort_direction aDir,
-                  typename std::vector<T>::iterator& aDataStart,
-                  typename std::vector<T>::iterator& aDataEnd) {
+template <typename T, typename Greater, typename Itr>
+void BitonicMerge(sort_direction aDir, Itr aDataStart, Itr aDataEnd) {
   uint32_t lSize(aDataEnd - aDataStart);
   if (lSize > 1) {
     uint32_t lPower2(1);
     while (lPower2 < lSize)
       lPower2 <<= 1;
 
-    typename std::vector<T>::iterator lMidpoint(aDataStart + (lPower2 >> 1));
-    typename std::vector<T>::iterator lFirst(aDataStart);
-    typename std::vector<T>::iterator lSecond(lMidpoint);
+    Itr lMidpoint(aDataStart + (lPower2 >> 1));
+    Itr lFirst(aDataStart);
+    Itr lSecond(lMidpoint);
 
+    const Greater g;
     for (; lSecond != aDataEnd; ++lFirst, ++lSecond) {
-      if (((*lFirst) > (*lSecond)) == (aDir == up)) {
+      if (g((*lFirst), (*lSecond)) == (aDir == up)) {
         std::swap(*lFirst, *lSecond);
       }
     }
 
-    BitonicMerge<T>(aDir, aDataStart, lMidpoint);
-    BitonicMerge<T>(aDir, lMidpoint, aDataEnd);
+    BitonicMerge<T, Greater>(aDir, aDataStart, lMidpoint);
+    BitonicMerge<T, Greater>(aDir, lMidpoint, aDataEnd);
   }
 }
 

--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloLayer2Comp.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloLayer2Comp.cc
@@ -37,11 +37,12 @@
 #include "L1Trigger/L1TCalorimeter/interface/BitonicSort.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 
-namespace l1t {
-  bool operator>(const l1t::Jet &a, l1t::Jet &b) { return a.hwPt() > b.hwPt(); }
-  bool operator>(const l1t::EGamma &a, l1t::EGamma &b) { return a.hwPt() > b.hwPt(); }
-  bool operator>(const l1t::Tau &a, l1t::Tau &b) { return a.hwPt() > b.hwPt(); }
-}  // namespace l1t
+namespace {
+  template <typename T>
+  struct Greater {
+    constexpr bool operator()(const T &a, const T &b) const noexcept { return a.hwPt() > b.hwPt(); }
+  };
+}  // namespace
 
 /**
  * Short class description.
@@ -669,8 +670,8 @@ bool L1TStage2CaloLayer2Comp::compareSums(const edm::Handle<l1t::EtSumBxCollecti
 void L1TStage2CaloLayer2Comp::accuSort(std::vector<l1t::Jet> *jets) {
   math::PtEtaPhiMLorentzVector emptyP4;
   l1t::Jet tempJet(emptyP4, 0, 0, 0, 0);
-  std::vector<std::vector<l1t::Jet> > jetEtaPos(41, std::vector<l1t::Jet>(18, tempJet));
-  std::vector<std::vector<l1t::Jet> > jetEtaNeg(41, std::vector<l1t::Jet>(18, tempJet));
+  std::vector<std::vector<l1t::Jet>> jetEtaPos(41, std::vector<l1t::Jet>(18, tempJet));
+  std::vector<std::vector<l1t::Jet>> jetEtaNeg(41, std::vector<l1t::Jet>(18, tempJet));
 
   for (unsigned int iJet = 0; iJet < jets->size(); iJet++) {
     if (jets->at(iJet).hwEta() > 0)
@@ -679,8 +680,8 @@ void L1TStage2CaloLayer2Comp::accuSort(std::vector<l1t::Jet> *jets) {
       jetEtaNeg.at(-(jets->at(iJet).hwEta() + 1)).at((jets->at(iJet).hwPhi() - 1) / 4) = jets->at(iJet);
   }
 
-  AccumulatingSort<l1t::Jet> etaPosSorter(7);
-  AccumulatingSort<l1t::Jet> etaNegSorter(7);
+  AccumulatingSort<l1t::Jet, Greater<l1t::Jet>> etaPosSorter(7);
+  AccumulatingSort<l1t::Jet, Greater<l1t::Jet>> etaNegSorter(7);
   std::vector<l1t::Jet> accumEtaPos;
   std::vector<l1t::Jet> accumEtaNeg;
 
@@ -689,13 +690,13 @@ void L1TStage2CaloLayer2Comp::accuSort(std::vector<l1t::Jet> *jets) {
     std::vector<l1t::Jet>::iterator start_, end_;
     start_ = jetEtaPos.at(ieta).begin();
     end_ = jetEtaPos.at(ieta).end();
-    BitonicSort<l1t::Jet>(down, start_, end_);
+    BitonicSort<l1t::Jet, Greater<l1t::Jet>>(down, start_, end_);
     etaPosSorter.Merge(jetEtaPos.at(ieta), accumEtaPos);
 
     // eta -
     start_ = jetEtaNeg.at(ieta).begin();
     end_ = jetEtaNeg.at(ieta).end();
-    BitonicSort<l1t::Jet>(down, start_, end_);
+    BitonicSort<l1t::Jet, Greater<l1t::Jet>>(down, start_, end_);
     etaNegSorter.Merge(jetEtaNeg.at(ieta), accumEtaNeg);
   }
 
@@ -729,8 +730,8 @@ void L1TStage2CaloLayer2Comp::accuSort(std::vector<l1t::Jet> *jets) {
 void L1TStage2CaloLayer2Comp::accuSort(std::vector<l1t::EGamma> *egs) {
   math::PtEtaPhiMLorentzVector emptyP4;
   l1t::EGamma tempEGamma(emptyP4, 0, 0, 0, 0);
-  std::vector<std::vector<l1t::EGamma> > jetEtaPos(41, std::vector<l1t::EGamma>(18, tempEGamma));
-  std::vector<std::vector<l1t::EGamma> > jetEtaNeg(41, std::vector<l1t::EGamma>(18, tempEGamma));
+  std::vector<std::vector<l1t::EGamma>> jetEtaPos(41, std::vector<l1t::EGamma>(18, tempEGamma));
+  std::vector<std::vector<l1t::EGamma>> jetEtaNeg(41, std::vector<l1t::EGamma>(18, tempEGamma));
 
   for (unsigned int iEGamma = 0; iEGamma < egs->size(); iEGamma++) {
     if (egs->at(iEGamma).hwEta() > 0)
@@ -739,8 +740,8 @@ void L1TStage2CaloLayer2Comp::accuSort(std::vector<l1t::EGamma> *egs) {
       jetEtaNeg.at(-(egs->at(iEGamma).hwEta() + 1)).at((egs->at(iEGamma).hwPhi() - 1) / 4) = egs->at(iEGamma);
   }
 
-  AccumulatingSort<l1t::EGamma> etaPosSorter(7);
-  AccumulatingSort<l1t::EGamma> etaNegSorter(7);
+  AccumulatingSort<l1t::EGamma, Greater<l1t::EGamma>> etaPosSorter(7);
+  AccumulatingSort<l1t::EGamma, Greater<l1t::EGamma>> etaNegSorter(7);
   std::vector<l1t::EGamma> accumEtaPos;
   std::vector<l1t::EGamma> accumEtaNeg;
 
@@ -749,13 +750,13 @@ void L1TStage2CaloLayer2Comp::accuSort(std::vector<l1t::EGamma> *egs) {
     std::vector<l1t::EGamma>::iterator start_, end_;
     start_ = jetEtaPos.at(ieta).begin();
     end_ = jetEtaPos.at(ieta).end();
-    BitonicSort<l1t::EGamma>(down, start_, end_);
+    BitonicSort<l1t::EGamma, Greater<l1t::EGamma>>(down, start_, end_);
     etaPosSorter.Merge(jetEtaPos.at(ieta), accumEtaPos);
 
     // eta -
     start_ = jetEtaNeg.at(ieta).begin();
     end_ = jetEtaNeg.at(ieta).end();
-    BitonicSort<l1t::EGamma>(down, start_, end_);
+    BitonicSort<l1t::EGamma, Greater<l1t::EGamma>>(down, start_, end_);
     etaNegSorter.Merge(jetEtaNeg.at(ieta), accumEtaNeg);
   }
 
@@ -789,8 +790,8 @@ void L1TStage2CaloLayer2Comp::accuSort(std::vector<l1t::EGamma> *egs) {
 void L1TStage2CaloLayer2Comp::accuSort(std::vector<l1t::Tau> *taus) {
   math::PtEtaPhiMLorentzVector emptyP4;
   l1t::Tau tempTau(emptyP4, 0, 0, 0, 0);
-  std::vector<std::vector<l1t::Tau> > jetEtaPos(41, std::vector<l1t::Tau>(18, tempTau));
-  std::vector<std::vector<l1t::Tau> > jetEtaNeg(41, std::vector<l1t::Tau>(18, tempTau));
+  std::vector<std::vector<l1t::Tau>> jetEtaPos(41, std::vector<l1t::Tau>(18, tempTau));
+  std::vector<std::vector<l1t::Tau>> jetEtaNeg(41, std::vector<l1t::Tau>(18, tempTau));
 
   for (unsigned int iTau = 0; iTau < taus->size(); iTau++) {
     if (taus->at(iTau).hwEta() > 0)
@@ -799,8 +800,8 @@ void L1TStage2CaloLayer2Comp::accuSort(std::vector<l1t::Tau> *taus) {
       jetEtaNeg.at(-(taus->at(iTau).hwEta() + 1)).at((taus->at(iTau).hwPhi() - 1) / 4) = taus->at(iTau);
   }
 
-  AccumulatingSort<l1t::Tau> etaPosSorter(7);
-  AccumulatingSort<l1t::Tau> etaNegSorter(7);
+  AccumulatingSort<l1t::Tau, Greater<l1t::Tau>> etaPosSorter(7);
+  AccumulatingSort<l1t::Tau, Greater<l1t::Tau>> etaNegSorter(7);
   std::vector<l1t::Tau> accumEtaPos;
   std::vector<l1t::Tau> accumEtaNeg;
 
@@ -809,13 +810,13 @@ void L1TStage2CaloLayer2Comp::accuSort(std::vector<l1t::Tau> *taus) {
     std::vector<l1t::Tau>::iterator start_, end_;
     start_ = jetEtaPos.at(ieta).begin();
     end_ = jetEtaPos.at(ieta).end();
-    BitonicSort<l1t::Tau>(down, start_, end_);
+    BitonicSort<l1t::Tau, Greater<l1t::Tau>>(down, start_, end_);
     etaPosSorter.Merge(jetEtaPos.at(ieta), accumEtaPos);
 
     // eta -
     start_ = jetEtaNeg.at(ieta).begin();
     end_ = jetEtaNeg.at(ieta).end();
-    BitonicSort<l1t::Tau>(down, start_, end_);
+    BitonicSort<l1t::Tau, Greater<l1t::Tau>>(down, start_, end_);
     etaNegSorter.Merge(jetEtaNeg.at(ieta), accumEtaNeg);
   }
 

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxEGAlgoFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxEGAlgoFirmwareImp1.cc
@@ -14,20 +14,22 @@
 #include <algorithm>
 #include "L1Trigger/L1TCalorimeter/interface/BitonicSort.h"
 
-namespace l1t {
-  inline bool operator>(l1t::EGamma& a, l1t::EGamma& b) {
-    if (a.pt() == b.pt()) {
-      if (a.hwPhi() == b.hwPhi()) {
-        return a.hwEta() > b.hwEta();
-      } else {
-        return a.hwPhi() > b.hwPhi();
-      }
+namespace {
+  struct Greater {
+    inline bool operator()(l1t::EGamma& a, l1t::EGamma& b) const {
+      if (a.pt() == b.pt()) {
+        if (a.hwPhi() == b.hwPhi()) {
+          return a.hwEta() > b.hwEta();
+        } else {
+          return a.hwPhi() > b.hwPhi();
+        }
 
-    } else {
-      return a.pt() > b.pt();
+      } else {
+        return a.pt() > b.pt();
+      }
     }
-  }
-}  // namespace l1t
+  };
+}  // namespace
 
 l1t::Stage2Layer2DemuxEGAlgoFirmwareImp1::Stage2Layer2DemuxEGAlgoFirmwareImp1(CaloParamsHelper const* params)
     : params_(params) {}
@@ -97,5 +99,5 @@ void l1t::Stage2Layer2DemuxEGAlgoFirmwareImp1::processEvent(const std::vector<l1
   //sorting with descending pT
   std::vector<l1t::EGamma>::iterator start_ = outputEGammas.begin();
   std::vector<l1t::EGamma>::iterator end_ = outputEGammas.end();
-  BitonicSort<l1t::EGamma>(down, start_, end_);
+  BitonicSort<l1t::EGamma, Greater>(down, start_, end_);
 }

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxJetAlgoFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxJetAlgoFirmwareImp1.cc
@@ -14,13 +14,17 @@
 #include <vector>
 #include <algorithm>
 
-inline bool operator>(l1t::Jet& a, l1t::Jet& b) {
-  if (a.hwPt() > b.hwPt()) {
-    return true;
-  } else {
-    return false;
-  }
-}
+namespace {
+  struct Greater {
+    inline bool operator()(l1t::Jet& a, l1t::Jet& b) const noexcept {
+      if (a.hwPt() > b.hwPt()) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+  };
+}  // namespace
 
 #include "L1Trigger/L1TCalorimeter/interface/BitonicSort.h"
 
@@ -38,7 +42,7 @@ void l1t::Stage2Layer2DemuxJetAlgoFirmwareImp1::processEvent(const std::vector<l
   //    std::cout << "MP : " << jet.hwPt() << ", " << jet.hwEta() << ", " << jet.hwPhi() << ", " << CaloTools::towerEta(jet.hwEta()) << ", " << CaloTools::towerPhi(jet.hwEta(),jet.hwPhi()) << std::endl;
   //  }
 
-  BitonicSort<l1t::Jet>(down, start, end);
+  BitonicSort<l1t::Jet, Greater>(down, start, end);
 
   // convert eta to GT coordinates
   for (auto& jet : outputJets) {

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxTauAlgoFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxTauAlgoFirmwareImp1.cc
@@ -14,20 +14,22 @@
 #include <algorithm>
 #include "L1Trigger/L1TCalorimeter/interface/BitonicSort.h"
 
-namespace l1t {
-  inline bool operator>(l1t::Tau& a, l1t::Tau& b) {
-    if (a.pt() == b.pt()) {
-      if (a.hwPhi() == b.hwPhi()) {
-        return a.hwEta() > b.hwEta();
-      } else {
-        return a.hwPhi() > b.hwPhi();
-      }
+namespace {
+  struct Greater {
+    inline bool operator()(l1t::Tau& a, l1t::Tau& b) const noexcept {
+      if (a.pt() == b.pt()) {
+        if (a.hwPhi() == b.hwPhi()) {
+          return a.hwEta() > b.hwEta();
+        } else {
+          return a.hwPhi() > b.hwPhi();
+        }
 
-    } else {
-      return a.pt() > b.pt();
+      } else {
+        return a.pt() > b.pt();
+      }
     }
-  }
-}  // namespace l1t
+  };
+}  // namespace
 
 l1t::Stage2Layer2DemuxTauAlgoFirmwareImp1::Stage2Layer2DemuxTauAlgoFirmwareImp1(CaloParamsHelper const* params)
     : params_(params) {}
@@ -97,5 +99,5 @@ void l1t::Stage2Layer2DemuxTauAlgoFirmwareImp1::processEvent(const std::vector<l
   //sorting with descending pT
   std::vector<l1t::Tau>::iterator start_ = outputTaus.begin();
   std::vector<l1t::Tau>::iterator end_ = outputTaus.end();
-  BitonicSort<l1t::Tau>(down, start_, end_);
+  BitonicSort<l1t::Tau, Greater>(down, start_, end_);
 }

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2EGammaAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2EGammaAlgorithmFirmwareImp1.cc
@@ -13,9 +13,11 @@
 #include "L1Trigger/L1TCalorimeter/interface/BitonicSort.h"
 #include "L1Trigger/L1TCalorimeter/interface/AccumulatingSort.h"
 
-namespace l1t {
-  bool operator>(const l1t::EGamma& a, const l1t::EGamma& b) { return a.pt() > b.pt(); }
-}  // namespace l1t
+namespace {
+  struct Greater {
+    bool operator()(const l1t::EGamma& a, const l1t::EGamma& b) const noexcept { return a.pt() > b.pt(); }
+  };
+}  // namespace
 
 /*****************************************************************/
 l1t::Stage2Layer2EGammaAlgorithmFirmwareImp1::Stage2Layer2EGammaAlgorithmFirmwareImp1(CaloParamsHelper const* params)
@@ -272,8 +274,8 @@ void l1t::Stage2Layer2EGammaAlgorithmFirmwareImp1::processEvent(const std::vecto
       egEtaNeg.at(-(egammas_raw.at(iEG).hwEta() + 1)).at((72 - egammas_raw.at(iEG).hwPhi()) / 4) = egammas_raw.at(iEG);
   }
 
-  AccumulatingSort<l1t::EGamma> etaPosSorter(6);
-  AccumulatingSort<l1t::EGamma> etaNegSorter(6);
+  AccumulatingSort<l1t::EGamma, Greater> etaPosSorter(6);
+  AccumulatingSort<l1t::EGamma, Greater> etaNegSorter(6);
   std::vector<l1t::EGamma> accumEtaPos;
   std::vector<l1t::EGamma> accumEtaNeg;
 
@@ -282,13 +284,13 @@ void l1t::Stage2Layer2EGammaAlgorithmFirmwareImp1::processEvent(const std::vecto
     std::vector<l1t::EGamma>::iterator start_, end_;
     start_ = egEtaPos.at(ieta).begin();
     end_ = egEtaPos.at(ieta).end();
-    BitonicSort<l1t::EGamma>(down, start_, end_);
+    BitonicSort<l1t::EGamma, Greater>(down, start_, end_);
     etaPosSorter.Merge(egEtaPos.at(ieta), accumEtaPos);
 
     // eta -
     start_ = egEtaNeg.at(ieta).begin();
     end_ = egEtaNeg.at(ieta).end();
-    BitonicSort<l1t::EGamma>(down, start_, end_);
+    BitonicSort<l1t::EGamma, Greater>(down, start_, end_);
     etaNegSorter.Merge(egEtaNeg.at(ieta), accumEtaNeg);
   }
 

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetAlgorithmFirmwareImp1.cc
@@ -18,9 +18,11 @@
 #include <algorithm>
 #include <cmath>
 
-namespace l1t {
-  bool operator>(const l1t::Jet& a, const l1t::Jet& b) { return a.hwPt() > b.hwPt(); }
-}  // namespace l1t
+namespace {
+  struct Greater {
+    bool operator()(const l1t::Jet& a, const l1t::Jet& b) const noexcept { return a.hwPt() > b.hwPt(); }
+  };
+}  // namespace
 
 // jet mask, needs to be configurable at some point
 // just a square for now
@@ -264,7 +266,7 @@ void l1t::Stage2Layer2JetAlgorithmFirmwareImp1::create(const std::vector<l1t::Ca
         // sort these jets and keep top 6
         auto start_ = jetsRing.begin();
         auto end_ = jetsRing.end();
-        BitonicSort<l1t::Jet>(down, start_, end_);
+        BitonicSort<l1t::Jet, Greater>(down, start_, end_);
         if (jetsRing.size() > 6)
           jetsRing.resize(6);
 
@@ -289,8 +291,8 @@ void l1t::Stage2Layer2JetAlgorithmFirmwareImp1::accuSort(std::vector<l1t::Jet>& 
       jetEtaNeg.at(-(jets.at(iJet).hwEta() + 1)).at((72 - jets.at(iJet).hwPhi()) / 4) = jets.at(iJet);
   }
 
-  AccumulatingSort<l1t::Jet> etaPosSorter(7);
-  AccumulatingSort<l1t::Jet> etaNegSorter(7);
+  AccumulatingSort<l1t::Jet, Greater> etaPosSorter(7);
+  AccumulatingSort<l1t::Jet, Greater> etaNegSorter(7);
   std::vector<l1t::Jet> accumEtaPos;
   std::vector<l1t::Jet> accumEtaNeg;
 
@@ -299,13 +301,13 @@ void l1t::Stage2Layer2JetAlgorithmFirmwareImp1::accuSort(std::vector<l1t::Jet>& 
     std::vector<l1t::Jet>::iterator start_, end_;
     start_ = jetEtaPos.at(ieta).begin();
     end_ = jetEtaPos.at(ieta).end();
-    BitonicSort<l1t::Jet>(down, start_, end_);
+    BitonicSort<l1t::Jet, Greater>(down, start_, end_);
     etaPosSorter.Merge(jetEtaPos.at(ieta), accumEtaPos);
 
     // eta -
     start_ = jetEtaNeg.at(ieta).begin();
     end_ = jetEtaNeg.at(ieta).end();
-    BitonicSort<l1t::Jet>(down, start_, end_);
+    BitonicSort<l1t::Jet, Greater>(down, start_, end_);
     etaNegSorter.Merge(jetEtaNeg.at(ieta), accumEtaNeg);
   }
 

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2TauAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2TauAlgorithmFirmwareImp1.cc
@@ -11,9 +11,11 @@
 #include "L1Trigger/L1TCalorimeter/interface/BitonicSort.h"
 #include "L1Trigger/L1TCalorimeter/interface/AccumulatingSort.h"
 
-namespace l1t {
-  bool operator>(const l1t::Tau& a, const l1t::Tau& b) { return a.pt() > b.pt(); }
-}  // namespace l1t
+namespace {
+  struct Greater {
+    bool operator()(const l1t::Tau& a, const l1t::Tau& b) const noexcept { return a.pt() > b.pt(); }
+  };
+}  // namespace
 
 l1t::Stage2Layer2TauAlgorithmFirmwareImp1::Stage2Layer2TauAlgorithmFirmwareImp1(CaloParamsHelper const* params)
     : params_(params) {
@@ -435,8 +437,8 @@ void l1t::Stage2Layer2TauAlgorithmFirmwareImp1::dosorting(std::vector<l1t::Tau>&
       tauEtaNeg.at(-(taus.at(iTau).hwEta() + 1)).at((72 - taus.at(iTau).hwPhi()) / 4) = taus.at(iTau);
   }
 
-  AccumulatingSort<l1t::Tau> etaPosSorter(6);
-  AccumulatingSort<l1t::Tau> etaNegSorter(6);
+  AccumulatingSort<l1t::Tau, Greater> etaPosSorter(6);
+  AccumulatingSort<l1t::Tau, Greater> etaNegSorter(6);
   std::vector<l1t::Tau> accumEtaPos;
   std::vector<l1t::Tau> accumEtaNeg;
 
@@ -445,13 +447,13 @@ void l1t::Stage2Layer2TauAlgorithmFirmwareImp1::dosorting(std::vector<l1t::Tau>&
     std::vector<l1t::Tau>::iterator start_, end_;
     start_ = tauEtaPos.at(ieta).begin();
     end_ = tauEtaPos.at(ieta).end();
-    BitonicSort<l1t::Tau>(down, start_, end_);
+    BitonicSort<l1t::Tau, Greater>(down, start_, end_);
     etaPosSorter.Merge(tauEtaPos.at(ieta), accumEtaPos);
 
     // eta -
     start_ = tauEtaNeg.at(ieta).begin();
     end_ = tauEtaNeg.at(ieta).end();
-    BitonicSort<l1t::Tau>(down, start_, end_);
+    BitonicSort<l1t::Tau, Greater>(down, start_, end_);
     etaNegSorter.Merge(tauEtaNeg.at(ieta), accumEtaNeg);
   }
 

--- a/L1Trigger/L1TCalorimeter/test/BuildFile.xml
+++ b/L1Trigger/L1TCalorimeter/test/BuildFile.xml
@@ -1,0 +1,3 @@
+<bin file="test_catch2*.cc" name="testL1TriggerL1TCalorimeter">
+  <use name="catch2"/>
+</bin>

--- a/L1Trigger/L1TCalorimeter/test/test_catch2_accumulatingsort.cc
+++ b/L1Trigger/L1TCalorimeter/test/test_catch2_accumulatingsort.cc
@@ -1,0 +1,98 @@
+#include "L1Trigger/L1TCalorimeter/interface/AccumulatingSort.h"
+
+#include "catch2/catch_all.hpp"
+
+TEST_CASE("AccumulatingSort", "[AccumulatingSort]") {
+  SECTION("empty out") {
+    SECTION("ascending") {
+      std::vector<int> v = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+      std::vector<int> out;
+      const std::vector<int> answer = {1, 2, 3};
+      AccumulatingSort<int, std::greater<int>> s(3);
+      s.Merge(v, out);
+      CHECK(answer == out);
+    }
+    SECTION("descending") {
+      std::vector<int> v = {9, 8, 7, 6, 5, 4, 3, 2, 1};
+      std::vector<int> out;
+      AccumulatingSort<int, std::greater<int>> s(3);
+      s.Merge(v, out);
+      const std::vector<int> answer = {9, 8, 7};
+      CHECK(answer == out);
+    }
+    SECTION("random") {
+      std::vector<int> v = {7, 3, 9, 4, 6, 5, 1, 2, 8};
+      std::vector<int> out;
+      AccumulatingSort<int, std::greater<int>> s(3);
+      s.Merge(v, out);
+      const std::vector<int> answer = {7, 3, 9};
+      CHECK(answer == out);
+    }
+    SECTION("duplicates ascending") {
+      std::vector<int> v = {1, 2, 2, 2, 3, 4, 5, 6, 7, 8, 9};
+      std::vector<int> out;
+      const std::vector<int> answer = {1, 2, 2};
+      AccumulatingSort<int, std::greater<int>> s(3);
+      s.Merge(v, out);
+      CHECK(answer == out);
+    }
+    SECTION("duplicates descending") {
+      std::vector<int> v = {9, 8, 8, 8, 7, 6, 5, 4, 3, 2, 1};
+      std::vector<int> out;
+      AccumulatingSort<int, std::greater<int>> s(3);
+      s.Merge(v, out);
+      const std::vector<int> answer = {9, 8, 8};
+      CHECK(answer == out);
+    }
+    SECTION("mixed") {
+      std::vector<int> v = {3, 4, 5, 1, 2, 0, 8, 9};
+      std::vector<int> out;
+      AccumulatingSort<int, std::greater<int>> s(6);
+      s.Merge(v, out);
+      const std::vector<int> answer = {3, 4, 5, 1, 2, 0};
+      CHECK(answer == out);
+    }
+  }
+  SECTION("out with entries") {
+    SECTION("out larger") {
+      std::vector<int> v = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+      std::vector<int> out = {10, 11, 12, 13};
+      AccumulatingSort<int, std::greater<int>> s(out.size());
+      s.Merge(v, out);
+      const std::vector<int> answer = {10, 11, 12, 13};
+      CHECK(answer == out);
+    }
+    SECTION("in larger") {
+      std::vector<int> v = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+      std::vector<int> out = {-10, -11, -12, -13};
+      AccumulatingSort<int, std::greater<int>> s(out.size());
+      s.Merge(v, out);
+      const std::vector<int> answer = {1, 2, 3, 4};
+      CHECK(answer == out);
+    }
+    SECTION("mixture") {
+      std::vector<int> v = {1, 4, 8, 9, 12};
+      std::vector<int> out = {0, 5, 6, 10};
+      AccumulatingSort<int, std::greater<int>> s(out.size());
+      s.Merge(v, out);
+      const std::vector<int> answer = {1, 5, 6, 10};
+      CHECK(answer == out);
+    }
+    SECTION("interleaved") {
+      std::vector<int> v = {1, 3, 5, 7, 9};
+      std::vector<int> out = {2, 4, 6, 8};
+      AccumulatingSort<int, std::greater<int>> s(out.size());
+      s.Merge(v, out);
+      const std::vector<int> answer = {2, 4, 6, 8};
+      CHECK(answer == out);
+    }
+    SECTION("interleaved") {
+      std::vector<int> v = {2, 4, 6, 8, 10};
+      std::vector<int> out = {1, 2, 3, 4};
+      AccumulatingSort<int, std::greater<int>> s(out.size());
+      s.Merge(v, out);
+      const std::vector<int> answer = {2, 4, 6, 8};
+      CHECK(answer == out);
+    }
+  }
+}

--- a/L1Trigger/L1TCalorimeter/test/test_catch2_bitonicsort.cc
+++ b/L1Trigger/L1TCalorimeter/test/test_catch2_bitonicsort.cc
@@ -1,0 +1,22 @@
+#include "L1Trigger/L1TCalorimeter/interface/BitonicSort.h"
+
+#include "catch2/catch_all.hpp"
+
+#include <vector>
+
+TEST_CASE("BitonicSort", "[BitonicSort]") {
+  std::vector<int> v = {6, 4, 8, 1, 12};
+
+  SECTION("up") {
+    std::vector<int> answer = v;
+    std::sort(answer.begin(), answer.end(), std::less<>());
+    BitonicSort<int, std::greater<int>>(up, v.begin(), v.end());
+    CHECK(v == answer);
+  }
+  SECTION("down") {
+    std::vector<int> answer = v;
+    std::sort(answer.begin(), answer.end(), std::greater<>());
+    BitonicSort<int, std::greater<int>>(down, v.begin(), v.end());
+    CHECK(v == answer);
+  }
+}


### PR DESCRIPTION
#### PR description:

- Multiple different implementations for the same operator< were used in the package. The problematic templated code was changed to take the operator as one of the parameters.
- To avoid this problem in the future, all operators for a class should be declared in the package containing the class.

#### PR validation:

Code compiles. New unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/1897