### PR TITLE
Update autoCond with first 2026 MC GT and L1T menu

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -109,15 +109,12 @@ autoCond = {
     'phase1_2025_cosmics'          :    '150X_mcRun3_2025cosmics_realistic_deco_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2025 detector for Heavy Ion
     'phase1_2025_realistic_hi'     :    '151X_mcRun3_2025_realistic_HI_v2',
-    
-    ###########################################################################################
-    ###### The following are just copies of 2025 for the moment. To be updated.
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2026
-    'phase1_2026_design'           :    '150X_mcRun3_2025_design_v4',
+    'phase1_2026_design'           :    '160X_mcRun3_2026_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2026
-    'phase1_2026_realistic'        :    '151X_mcRun3_2025_realistic_v4',
+    'phase1_2026_realistic'        :    '160X_mcRun3_2026_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2026, Strip tracker in DECO mode
-    'phase1_2026_cosmics'          :    '150X_mcRun3_2025cosmics_realistic_deco_v4',
+    'phase1_2026_cosmics'          :    '160X_mcRun3_2026cosmics_realistic_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2026 detector for Heavy Ion
     'phase1_2026_realistic_hi'     :    '151X_mcRun3_2025_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for Phase2

--- a/Configuration/AlCa/python/autoCondModifiers.py
+++ b/Configuration/AlCa/python/autoCondModifiers.py
@@ -115,7 +115,7 @@ def autoCondRelValForRun3(autoCond):
 
     GlobalTagRelValForRun3 = {}
     L1GtTriggerMenuForRelValForRun3 =    ','.join( ['L1Menu_Collisions2015_25nsStage1_v5' , "L1GtTriggerMenuRcd",             connectionString, "", "2023-01-28 12:00:00.000"] )
-    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2025_v1_3_0_xml'    , "L1TUtmTriggerMenuRcd",           connectionString, "", "2025-07-24 05:13:35.000"] )
+    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2026_v1_0_0_xml'    , "L1TUtmTriggerMenuRcd",           connectionString, "", "2026-02-04 14:35:13.000"] )
 
     for key,val in autoCond.items():
         if 'run3_data' in key or 'run3_hlt' in key :


### PR DESCRIPTION
#### PR description:

`phase1_2026_realistic`, `phase1_2026_design` and `phase1_2026_cosmics`  GT in autoCond has been updated with the first 2026 mc GT extracted from the corresponding 160X queues:
- [160X_mcRun3_2026_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/160X_mcRun3_2026_realistic_v1)
- [160X_mcRun3_2026_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/160X_mcRun3_2026_design_v1)
- [160X_mcRun3_2026cosmics_realistic_deco_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/160X_mcRun3_2026cosmics_realistic_deco_v1)

The design and cosmics GTs only differ from the previous ones in autoCond by the L1T menu, as discussed in [cmsTalk](https://cms-talk.web.cern.ch/t/data-relval-update-of-the-relvals-with-the-new-2026-l1t-menu-tag-l1menu-collisions2026-v1-0-0-xml/141911):
- [diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/160X_mcRun3_2026_design_v1/150X_mcRun3_2025_design_v4) between previous 150X_mcRun3_2025_design_v4 and previous 160X_mcRun3_2026_design_v1
- [diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/160X_mcRun3_2026cosmics_realistic_deco_v1/150X_mcRun3_2025cosmics_realistic_deco_v4) between  previous 150X_mcRun3_2025cosmics_realistic_deco_v4 and current 160X_mcRun3_2026cosmics_realistic_deco_v1

In addition to that first L1T menu for 2026 ([cmsTalk](https://cms-talk.web.cern.ch/t/data-relval-update-of-the-relvals-with-the-new-2026-l1t-menu-tag-l1menu-collisions2026-v1-0-0-xml/141911)), the new 2026 realistic GT, [160X_mcRun3_2026_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/160X_mcRun3_2026_realistic_v1) contains all the conditions listed for the Winter26 MC campaign in [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-winter26-mc-global-tag/140278) up to 150X_mcRun3_2026_realistic_v4:
- [diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/160X_mcRun3_2026_realistic_v1/151X_mcRun3_2025_realistic_v4) between previous 151X_mcRun3_2025_realistic_v4 and  current 160X_mcRun3_2026_realistic_v1 (42 tags updated overall)


#### PR validation:

Rely on the PR tests

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

It will be backported to CMSSW_16_0_X