### PR TITLE
Adding 2026 pp and HI scenarios

### DIFF
--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_2026.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_2026.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""
+_ppEra_Run3_2026_
+Scenario supporting proton collisions for 2026
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_2026_cff import Run3_2026
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run3_2026(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.eras=Run3_2026
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2026' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2026' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2026' ]
+    """
+    _ppEra_Run3_2026_
+    Implement configuration building for data processing for proton
+    collision data taking for Run3_2026
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_2026_UPC.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_2026_UPC.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""
+_ppEra_Run3_2026_UPC_
+Scenario supporting UPC collisions for 2026
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_2026_UPC_cff import Run3_2026_UPC
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run3_2026_UPC(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.isRepacked=True
+        self.eras=Run3_2026_UPC
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2026_UPC' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2026_UPC' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2026_UPC' ]
+    """
+    _ppEra_Run3_2026_UPC_
+    Implement configuration building for data processing for proton
+    collision data taking for Run3_2026
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_2026.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_2026.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+_ppEra_Run3_pp_on_PbPb_2026_
+
+Scenario supporting heavy ions collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_pp_on_PbPb_2026_cff import Run3_pp_on_PbPb_2026
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run3_pp_on_PbPb_2026(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.isRepacked=True
+        self.eras=Run3_pp_on_PbPb_2026
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_2026' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_2026' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_2026' ]
+    """
+    _ppEra_Run3_pp_on_PbPb_2026_
+
+    Implement configuration building for data processing for pp-like processing of HI
+    collision data taking for Run3
+
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2026.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2026.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+_ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2026_
+
+Scenario supporting heavy ions collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+from Configuration.Eras.Era_Run3_pp_on_PbPb_approxSiStripClusters_2026_cff import Run3_pp_on_PbPb_approxSiStripClusters_2026
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2026(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.isRepacked=True
+        self.eras=Run3_pp_on_PbPb_approxSiStripClusters_2026
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters_2026' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters_2026' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters_2026' ]
+
+    """
+    _ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2026_
+
+    Implement configuration building for data processing for pp-like processing of HI
+    collision data taking for Run3 with approxSiStripClusters (rawprime format)
+
+    """

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -99,6 +99,11 @@ def customisePostEra_Run3_2025(process):
     customisePostEra_Run3_2024(process)
     return process
 
+def customisePostEra_Run3_2026(process):
+    #start with a repeat of 2025
+    customisePostEra_Run3_2025(process)
+    return process
+
 def customisePostEra_Run3_express_trackingOnly(process):
     #start with a repeat of 2018
     customisePostEra_Run2_2018_express_trackingOnly(process)
@@ -155,6 +160,18 @@ def customisePostEra_Run3_2025_UPC(process):
 
 def customisePostEra_Run3_2025_OXY(process):
     customisePostEra_Run3_2025(process)
+    return process
+
+def customisePostEra_Run3_pp_on_PbPb_2026(process):
+    customisePostEra_Run3_2026(process)
+    return process
+
+def customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters_2026(process):
+    customisePostEra_Run3_pp_on_PbPb_2026(process)
+    return process
+
+def customisePostEra_Run3_2026_UPC(process):
+    customisePostEra_Run3_2026(process)
     return process
 
 ##############################################################################

--- a/Configuration/DataProcessing/test/run_CfgTest_4.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest_4.sh
@@ -3,7 +3,7 @@
 # Test suite for miniaod from prompt
 
 # Pass in name and status
-declare -a arr=("ppEra_Run3_2025" "ppEra_Run3_2026")
+declare -a arr=("ppEra_Run3_2025" "ppEra_Run3_2026" "ppEra_Run3_2026_UPC" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2026" "ppEra_Run3_pp_on_PbPb_2026")
 for scenario in "${arr[@]}"
 do
     rm -rf RunPromptRecoCfg.pkl

--- a/Configuration/DataProcessing/test/run_CfgTest_4.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest_4.sh
@@ -3,7 +3,7 @@
 # Test suite for miniaod from prompt
 
 # Pass in name and status
-declare -a arr=("ppEra_Run3_2025")
+declare -a arr=("ppEra_Run3_2025" "ppEra_Run3_2026")
 for scenario in "${arr[@]}"
 do
     rm -rf RunPromptRecoCfg.pkl


### PR DESCRIPTION
#### PR description:

Adding `ppEra_Run3_2026.py` and `ppEra_Run3_pp_on_PbPb_2026.py` scenarios using 2025 templates. 
2026 Era is alredy present in https://github.com/cms-sw/cmssw/tree/master/Configuration/Eras/python

#### PR validation:

none

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, will be backported to CMSSW_16_0_X for 2026 data-taking operations.
