### PR TITLE
Re-enable `*.999` in PR tests

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -138,8 +138,7 @@ if __name__ == '__main__':
             # Phase2
             prefixDet+34.0,    # RelValTTbar_14TeV                     phase2_realistic_T35        ExtendedRun4D121         (Phase-2 baseline)
             prefixDet+34.911,  # TTbar_14TeV_TuneCP5                   phase2_realistic_T35        DD4hepExtendedRun4D121   DD4Hep (HLLHC14TeV BeamSpot)
-            # TODO: Temporarily disabled until new MinBias files get produced. See https://github.com/cms-sw/cmssw/issues/49795
-            #prefixDet+234.999, # RelValTTbar_14TeV (PREMIX)            phase2_realistic_T35        ExtendedRun4D121         AVE_50_BX_25ns_m3p3
+            prefixDet+234.999, # RelValTTbar_14TeV (PREMIX)            phase2_realistic_T35        ExtendedRun4D121         AVE_50_BX_25ns_m3p3
             prefixDet+96.0,    # RelValCloseByPGun_CE_E_Front_120um    phase2_realistic_T35        ExtendedRun4D121
             prefixDet+100.0,   # RelValCloseByPGun_CE_H_Coarse_Scint   phase2_realistic_T35        ExtendedRun4D121
             #23234.0,   # Need new workflow with HFNose


### PR DESCRIPTION
Following the discussion at https://github.com/cms-sw/cmssw/issues/49795 and the solution in https://github.com/cms-sw/cmssw/pull/50062, we can revert `*.999` workflows in the PR testing.