### PR TITLE
Updated CSC LCT data format

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -53,8 +53,7 @@ public:
                        const uint16_t run3_pattern = 0,
                        const uint16_t run3_slope = 0,
                        const int type = ALCTCLCT,
-                       const bool has_gem_layer1_hits = false,
-                       const bool has_gem_layer2_hits = false);
+                       const uint16_t gemLayerUsedForSlopeComputation = 0);
 
   /// default (calls clear())
   CSCCorrelatedLCTDigi();
@@ -214,10 +213,8 @@ public:
 
   void setType(int type) { type_ = type; }
 
-  bool hasGEMLayer1Hist() const { return has_gem_layer1_hits_; }
-  bool hasGEMLayer2Hist() const { return has_gem_layer2_hits_; }
-  void setHasGEMLayer1Hits(bool has_hits) { has_gem_layer1_hits_ = has_hits; }
-  void setHasGEMLayer2Hits(bool has_hits) { has_gem_layer2_hits_ = has_hits; }
+  uint16_t getGemLayerUsedForSlopeComputation() const { return gemLayerUsedForSlopeComputation_; }
+  void setGemLayerUsedForSlopeComputation(uint16_t layer) { gemLayerUsedForSlopeComputation_ = layer; }
 
   void setALCT(const CSCALCTDigi& alct) { alct_ = alct; }
   void setCLCT(const CSCCLCTDigi& clct) { clct_ = clct; }
@@ -277,8 +274,8 @@ private:
   uint16_t run3_pattern_;
   // 4-bit bending value. There will be 16 bending values * 2 (left/right)
   uint16_t run3_slope_;
-  // In Run-3, the GEM information is included in the LCT data format. The "gem_layerN_" indicates whatever GEM layer N have hits in coincidence with the CSC primitives.
-  bool has_gem_layer1_hits_, has_gem_layer2_hits_;
+  // In Run-3, the GEM information is included in the LCT data format. The "gemLayerUsedForSlopeComputation_" indicates what GEM layer was used to compute the slope.
+  uint16_t gemLayerUsedForSlopeComputation_;
 
   /// SIMULATION ONLY ////
   int type_;

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -53,8 +53,8 @@ public:
                        const uint16_t run3_pattern = 0,
                        const uint16_t run3_slope = 0,
                        const int type = ALCTCLCT,
-                       const bool has_gem_layer1_hits=false,
-                       const bool has_gem_layer2_hits=false);
+                       const bool has_gem_layer1_hits = false,
+                       const bool has_gem_layer2_hits = false);
 
   /// default (calls clear())
   CSCCorrelatedLCTDigi();

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -52,7 +52,9 @@ public:
                        const bool run3_eighth_strip_bit = false,
                        const uint16_t run3_pattern = 0,
                        const uint16_t run3_slope = 0,
-                       const int type = ALCTCLCT);
+                       const int type = ALCTCLCT,
+                       const bool has_gem_layer1_hits=false,
+                       const bool has_gem_layer2_hits=false);
 
   /// default (calls clear())
   CSCCorrelatedLCTDigi();
@@ -212,6 +214,11 @@ public:
 
   void setType(int type) { type_ = type; }
 
+  bool hasGEMLayer1Hist() const { return has_gem_layer1_hits_; }
+  bool hasGEMLayer2Hist() const { return has_gem_layer2_hits_; }
+  void setHasGEMLayer1Hits(bool has_hits) { has_gem_layer1_hits_ = has_hits; }
+  void setHasGEMLayer2Hits(bool has_hits) { has_gem_layer2_hits_ = has_hits; }
+
   void setALCT(const CSCALCTDigi& alct) { alct_ = alct; }
   void setCLCT(const CSCCLCTDigi& clct) { clct_ = clct; }
   void setGEM1(const GEMPadDigi& gem) { gem1_ = gem; }
@@ -270,6 +277,8 @@ private:
   uint16_t run3_pattern_;
   // 4-bit bending value. There will be 16 bending values * 2 (left/right)
   uint16_t run3_slope_;
+  // In Run-3, the GEM information is included in the LCT data format. The "gem_layerN_" indicates whatever GEM layer N have hits in coincidence with the CSC primitives.
+  bool has_gem_layer1_hits_, has_gem_layer2_hits_;
 
   /// SIMULATION ONLY ////
   int type_;

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -29,8 +29,7 @@ CSCCorrelatedLCTDigi::CSCCorrelatedLCTDigi(const uint16_t itrknmb,
                                            const uint16_t run3_pattern,
                                            const uint16_t run3_slope,
                                            const int type,
-                                           const bool has_gem_layer1_hits,
-                                           const bool has_gem_layer2_hits)
+                                           const uint16_t gemLayerUsedForSlopeComputation)
 
     : trknmb(itrknmb),
       valid(ivalid),
@@ -49,8 +48,7 @@ CSCCorrelatedLCTDigi::CSCCorrelatedLCTDigi(const uint16_t itrknmb,
       run3_eighth_strip_bit_(run3_eighth_strip_bit),
       run3_pattern_(run3_pattern),
       run3_slope_(run3_slope),
-      has_gem_layer1_hits_(has_gem_layer1_hits),
-      has_gem_layer2_hits_(has_gem_layer2_hits),
+      gemLayerUsedForSlopeComputation_(gemLayerUsedForSlopeComputation),
       type_(type),
       version_(version) {}
 
@@ -82,8 +80,7 @@ void CSCCorrelatedLCTDigi::clear() {
   run3_slope_ = 0;
   // clear the components
   type_ = 1;
-  has_gem_layer1_hits_ = false;
-  has_gem_layer2_hits_ = false;
+  gemLayerUsedForSlopeComputation_ = 0;
   alct_.clear();
   clct_.clear();
   gem1_ = GEMPadDigi();

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -28,7 +28,10 @@ CSCCorrelatedLCTDigi::CSCCorrelatedLCTDigi(const uint16_t itrknmb,
                                            const bool run3_eighth_strip_bit,
                                            const uint16_t run3_pattern,
                                            const uint16_t run3_slope,
-                                           const int type)
+                                           const int type,
+                                           const bool has_gem_layer1_hits,
+                                           const bool has_gem_layer2_hits)
+
     : trknmb(itrknmb),
       valid(ivalid),
       quality(iquality),
@@ -46,6 +49,8 @@ CSCCorrelatedLCTDigi::CSCCorrelatedLCTDigi(const uint16_t itrknmb,
       run3_eighth_strip_bit_(run3_eighth_strip_bit),
       run3_pattern_(run3_pattern),
       run3_slope_(run3_slope),
+      has_gem_layer1_hits_(has_gem_layer1_hits),
+      has_gem_layer2_hits_(has_gem_layer2_hits),
       type_(type),
       version_(version) {}
 
@@ -77,6 +82,8 @@ void CSCCorrelatedLCTDigi::clear() {
   run3_slope_ = 0;
   // clear the components
   type_ = 1;
+  has_gem_layer1_hits_ = false;
+  has_gem_layer2_hits_ = false;
   alct_.clear();
   clct_.clear();
   gem1_ = GEMPadDigi();

--- a/DataFormats/CSCDigi/src/classes_def.xml
+++ b/DataFormats/CSCDigi/src/classes_def.xml
@@ -12,7 +12,7 @@
     <version ClassVersion="10" checksum="656608282"/>
    </class>
    <class name="CSCCorrelatedLCTDigi" ClassVersion="14">
-    <version ClassVersion="14" checksum="2032395639"/>
+    <version ClassVersion="14" checksum="1183056062"/>
     <version ClassVersion="13" checksum="537762368"/>
     <version ClassVersion="12" checksum="1516836035"/>
     <version ClassVersion="11" checksum="2118578151"/>

--- a/DataFormats/CSCDigi/src/classes_def.xml
+++ b/DataFormats/CSCDigi/src/classes_def.xml
@@ -11,7 +11,8 @@
    <class name="CSCComparatorDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="656608282"/>
    </class>
-   <class name="CSCCorrelatedLCTDigi" ClassVersion="13">
+   <class name="CSCCorrelatedLCTDigi" ClassVersion="14">
+    <version ClassVersion="14" checksum="2032395639"/>
     <version ClassVersion="13" checksum="537762368"/>
     <version ClassVersion="12" checksum="1516836035"/>
     <version ClassVersion="11" checksum="2118578151"/>

--- a/DataFormats/L1CSCTrackFinder/src/classes_def.xml
+++ b/DataFormats/L1CSCTrackFinder/src/classes_def.xml
@@ -13,7 +13,8 @@
     <version ClassVersion="10" checksum="3445513287"/>
    </class>
 
-   <class name="csctf::TrackStub" ClassVersion="14">
+   <class name="csctf::TrackStub" ClassVersion="15">
+    <version ClassVersion="15" checksum="3460118063"/>
     <version ClassVersion="14" checksum="3081088872"/>
     <version ClassVersion="13" checksum="1877810363"/>
     <version ClassVersion="12" checksum="1100843423"/>

--- a/DataFormats/L1CSCTrackFinder/src/classes_def.xml
+++ b/DataFormats/L1CSCTrackFinder/src/classes_def.xml
@@ -14,7 +14,7 @@
    </class>
 
    <class name="csctf::TrackStub" ClassVersion="15">
-    <version ClassVersion="15" checksum="3460118063"/>
+    <version ClassVersion="15" checksum="3242335238"/>
     <version ClassVersion="14" checksum="3081088872"/>
     <version ClassVersion="13" checksum="1877810363"/>
     <version ClassVersion="12" checksum="1100843423"/>


### PR DESCRIPTION
#### PR description:

Updated CSC LCTDigi data format: added flags for GEM layers matching. The changes are in line with the new proposed OTMB LCT data format discussed [here](https://indico.cern.ch/event/1491198/#sc-3-6-gem-csc-bending-angle-o). The changes to unpacker are planned as a separate PR.

#### PR validation:

No changes to the standard CMSSW workflows are expected. Only the CSCCorrelatedLCTDigi data format is modified to support future changes.

The following basic tests are run locally:
```
scram b runtests use-ibeos
runTheMatrix.py -l limited -i all --ibeos
```