### PR TITLE
fix faulty default of `sigmaZ` in `VertexAssociatorByPositionAndTracksProducer`, use fake cut only for HLT [16.0.X]

### DIFF
--- a/SimTracker/VertexAssociation/plugins/VertexAssociatorByPositionAndTracksProducer.cc
+++ b/SimTracker/VertexAssociation/plugins/VertexAssociatorByPositionAndTracksProducer.cc
@@ -64,7 +64,7 @@ void VertexAssociatorByPositionAndTracksProducer::fillDescriptions(edm::Configur
 
   // Matching conditions
   desc.add<double>("absZ", 0.1);
-  desc.add<double>("sigmaZ", std::numeric_limits<double>::max());
+  desc.add<double>("sigmaZ", 3.0);
   desc.add<double>("maxRecoZ", 1000.0);
   desc.add<double>("absT", -1.0);
   desc.add<double>("sigmaT", -1.0);

--- a/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
+++ b/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
@@ -17,7 +17,9 @@ vertexAssociatorByPositionAndTracks4pixelTracks = _VertexAssociatorByPositionAnd
     trackAssociation = "tpToHLTpixelTrackAssociation",
     sharedTrackFraction = -1, # requires optimization
     weightMethod = "dzError",
+    sigmaZ = 10e6
 )
+
 hltOtherTPClusterProducer = hltTPClusterProducer.clone(
     stripClusterOtherSrc = "hltSiStripRawToClustersFacilityOnDemand"
 )
@@ -90,6 +92,7 @@ vertexAssociatorByPositionAndTracks4phase2HLTTracks = _VertexAssociatorByPositio
     trackAssociation = "tpToHLTphase2TrackAssociation",
     sharedTrackFraction = 0.5, # requires optimization
     weightMethod = "dzError",
+    sigmaZ = 10e6
 )
 
 def _modifyFullPVanalysisForPhase2(pvanalysis):


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/50107

#### PR description:

PR https://github.com/cms-sw/cmssw/pull/49609 inadvertently introduced a bug in the vertexing validation suite.
In that PR we introduced new SIM<->RECO vertexing association methods that do not rely on the spatial proximity normalized by the vertexing error (`zdiff / recoVertex.zError() < sigmaZ_`) as this is very reliant on the actual estimation of the z position error. To that effect, the value of the significance cut was changed from the default 3. to ~ infinity in the `fillDescriptions` of `VertexAssociatorByPositionAndTracksProducer`. This makes sense **only** if the association method (variable `weightMethod`) is not `"none"` (which is the current default for the offline validation). In case one wants to use the "old" default the `sigmaZ` cut needs to be in place. 
The issue was spotted in the offline `CMSSW_16_0_0_pre4` validation: https://cern.ch/krpwx

To fix the issue we revert the `sigmaZ` cut to 3 and we change it explicitly only when needed (i.e. when `weightMethod` is equal to `dzError`)

#### PR validation:

I run in `CMSSW_16_1_X_2026-02-09-2300` with / and without this branch and big difference is seen e.g. in the vertex merge rate:

| Current release | This PR |
| ------------- | ------------- |
| <img width="957" height="1009" alt="image" src="https://github.com/user-attachments/assets/aa0f191d-37a0-449b-8c9e-4b4f0efa70d7" /> | <img width="1122" height="1009" alt="image" src="https://github.com/user-attachments/assets/4906234b-c96f-407d-b364-35881733aa5b" /> |

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport to CMSSW_16_0_X of #50107 for 2026 data-taking purposes.
