### PR TITLE
Apply DescriptionCloner to modules generating multiple cfi

### DIFF
--- a/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
@@ -22,6 +22,9 @@
 #include "FWCore/Framework/interface/SourceFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/DescriptionCloner.h"
 #include "FWCore/Concurrency/interface/SharedResourceNames.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CondFormats/Common/interface/FileBlob.h"
@@ -99,13 +102,11 @@ void DDDetectorESProducer::fillDescriptions(ConfigurationDescriptions& descripti
   desc.add<string>("rootDDName", "cms:OCMS");
   desc.add<string>("label", "");
   desc.add<bool>("fromDB", false);
-  descriptions.addDefault(desc);
   descriptions.add("DDDetectorESProducer", desc);
 
-  edm::ParameterSetDescription descDB;
-  descDB.add<string>("rootDDName", "cms:OCMS");
-  descDB.add<string>("label", "Extended");
-  descDB.add<bool>("fromDB", true);
+  edm::DescriptionCloner descDB;
+  descDB.set<string>("label", "Extended");
+  descDB.set<bool>("fromDB", true);
   descriptions.add("DDDetectorESProducerFromDB", descDB);
 }
 

--- a/Geometry/MTDGeometryBuilder/plugins/MTDDigiGeometryESModule.cc
+++ b/Geometry/MTDGeometryBuilder/plugins/MTDDigiGeometryESModule.cc
@@ -26,6 +26,7 @@
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/DescriptionCloner.h"
 
 #include <memory>
 #include <string>
@@ -88,14 +89,10 @@ void MTDDigiGeometryESModule::fillDescriptions(edm::ConfigurationDescriptions& d
   descDB.add<bool>("fromDDD", false);
   descDB.add<bool>("applyAlignment", true);
   descDB.add<std::string>("alignmentsLabel", "");
-  descriptions.addDefault(descDB);
   descriptions.add("mtdGeometryDB", descDB);
 
-  edm::ParameterSetDescription desc;
-  desc.add<std::string>("appendToDataLabel", "");
-  desc.add<bool>("fromDDD", true);
-  desc.add<bool>("applyAlignment", true);
-  desc.add<std::string>("alignmentsLabel", "");
+  edm::DescriptionCloner desc;
+  desc.set<bool>("fromDDD", true);
   descriptions.add("mtdGeometry", desc);
 }
 

--- a/Geometry/MTDNumberingBuilder/plugins/MTDGeometricTimingDetESModule.cc
+++ b/Geometry/MTDNumberingBuilder/plugins/MTDGeometricTimingDetESModule.cc
@@ -12,6 +12,7 @@
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/DescriptionCloner.h"
 
 #include <memory>
 
@@ -53,12 +54,10 @@ void MTDGeometricTimingDetESModule::fillDescriptions(edm::ConfigurationDescripti
   edm::ParameterSetDescription descDB;
   descDB.add<bool>("fromDDD", false);
   descDB.add<bool>("fromDD4hep", false);
-  descriptions.addDefault(descDB);
   descriptions.add("mtdNumberingGeometryDB", descDB);
 
-  edm::ParameterSetDescription desc;
-  desc.add<bool>("fromDDD", true);
-  desc.add<bool>("fromDD4hep", false);
+  edm::DescriptionCloner desc;
+  desc.set<bool>("fromDDD", true);
   descriptions.add("mtdNumberingGeometry", desc);
 }
 

--- a/Geometry/TrackerGeometryBuilder/plugins/TrackerDigiGeometryESModule.cc
+++ b/Geometry/TrackerGeometryBuilder/plugins/TrackerDigiGeometryESModule.cc
@@ -5,6 +5,7 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/DescriptionCloner.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "CondFormats/Alignment/interface/Alignments.h"
 #include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
@@ -94,14 +95,10 @@ void TrackerDigiGeometryESModule::fillDescriptions(edm::ConfigurationDescription
   descDB.add<bool>("fromDDD", false);
   descDB.add<bool>("applyAlignment", true);
   descDB.add<std::string>("alignmentsLabel", "");
-  descriptions.addDefault(descDB);
   descriptions.add("trackerGeometryDB", descDB);
 
-  edm::ParameterSetDescription desc;
-  desc.add<std::string>("appendToDataLabel", "");
-  desc.add<bool>("fromDDD", true);
-  desc.add<bool>("applyAlignment", true);
-  desc.add<std::string>("alignmentsLabel", "");
+  edm::DescriptionCloner desc;
+  desc.set<bool>("fromDDD", true);
   descriptions.add("trackerGeometry", desc);
 }
 

--- a/Geometry/TrackerNumberingBuilder/plugins/TrackerGeometricDetESModule.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/TrackerGeometricDetESModule.cc
@@ -5,6 +5,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/DescriptionCloner.h"
 #include "DetectorDescription/Core/interface/DDCompactView.h"
 #include "DetectorDescription/Core/interface/DDutils.h"
 #include "DetectorDescription/DDCMS/interface/DDCompactView.h"
@@ -53,17 +54,14 @@ void TrackerGeometricDetESModule::fillDescriptions(edm::ConfigurationDescription
   edm::ParameterSetDescription descDB;
   descDB.add<bool>("fromDDD", false);
   descDB.add<bool>("fromDD4hep", false);
-  descriptions.addDefault(descDB);
   descriptions.add("trackerNumberingGeometryDB", descDB);
 
-  edm::ParameterSetDescription desc;
-  desc.add<bool>("fromDDD", true);
-  desc.add<bool>("fromDD4hep", false);
+  edm::DescriptionCloner desc;
+  desc.set<bool>("fromDDD", true);
   descriptions.add("trackerNumberingGeometry", desc);
 
-  edm::ParameterSetDescription descDD4hep;
-  descDD4hep.add<bool>("fromDDD", false);
-  descDD4hep.add<bool>("fromDD4hep", true);
+  edm::DescriptionCloner descDD4hep;
+  descDD4hep.set<bool>("fromDD4hep", true);
   descriptions.add("DD4hep_trackerNumberingGeometry", descDD4hep);
 }
 

--- a/RecoLocalCalo/HcalRecProducers/src/HcalSimpleReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalSimpleReconstructor.cc
@@ -5,6 +5,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/DescriptionCloner.h"
 #include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
 #include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
 #include "CalibFormats/HcalObjects/interface/HcalDbService.h"
@@ -128,19 +129,14 @@ void HcalSimpleReconstructor::fillDescriptions(edm::ConfigurationDescriptions& d
   descHO.add<bool>("dropZSmarkedPassed", true);
   descHO.add<bool>("correctForPhaseContainment", true);
   descHO.add<int>("firstSample", 4);
-  descriptions.addDefault(descHO);
   descriptions.add("hosimplereco", descHO);
 
   // hfreco
-  edm::ParameterSetDescription descHF;
-  descHF.add<double>("correctionPhaseNS", 0.0);
-  descHF.add<edm::InputTag>("digiLabel", edm::InputTag("hcalDigis"));
-  descHF.add<bool>("tsFromDB", true);
-  descHF.add<int>("samplesToAdd", 2);
-  descHF.add<std::string>("Subdetector", "HF");
-  descHF.add<bool>("correctForTimeslew", false);
-  descHF.add<bool>("dropZSmarkedPassed", true);
-  descHF.add<bool>("correctForPhaseContainment", false);
-  descHF.add<int>("firstSample", 4);
+  edm::DescriptionCloner descHF;
+  descHF.set<double>("correctionPhaseNS", 0.0);
+  descHF.set<int>("samplesToAdd", 2);
+  descHF.set<std::string>("Subdetector", "HF");
+  descHF.set<bool>("correctForTimeslew", false);
+  descHF.set<bool>("correctForPhaseContainment", false);
   descriptions.add("hfsimplereco", descHF);
 }

--- a/RecoMET/METFilters/plugins/BadParticleFilter.cc
+++ b/RecoMET/METFilters/plugins/BadParticleFilter.cc
@@ -22,6 +22,7 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/DescriptionCloner.h"
 
 //
 // class declaration
@@ -233,9 +234,9 @@ void BadParticleFilter::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.add<double>("maxDR", 0.001);
   desc.add<edm::InputTag>("muons", edm::InputTag("muons"));
   desc.add<double>("minPtDiffRel", 0.0);
-  descriptions.addDefault(desc);
-  descriptions.add("BadPFMuonFilter", desc);
   descriptions.addWithDefaultLabel(desc);
+  edm::DescriptionCloner clone;
+  descriptions.add("BadPFMuonFilter", clone);
 }
 
 //define this as a plug-in

--- a/RecoMET/METProducers/src/PFMETProducer.cc
+++ b/RecoMET/METProducers/src/PFMETProducer.cc
@@ -9,6 +9,7 @@
 #include "RecoMET/METProducers/interface/PFMETProducer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/EmptyGroupDescription.h"
+#include "FWCore/ParameterSet/interface/DescriptionCloner.h"
 
 //____________________________________________________________________________||
 namespace cms {
@@ -144,15 +145,13 @@ namespace cms {
     edm::ParameterSetDescription params;
     params.setAllowAnything();  // FIXME: This still needs to be defined in METSignficance
     desc.addOptional<edm::ParameterSetDescription>("parameters", params);
-    edm::ParameterSetDescription desc1 = desc;
-    edm::ParameterSetDescription desc2 = desc;
-    desc1.add<bool>("applyWeight", false);
-    desc1.add<edm::InputTag>("srcWeights", edm::InputTag(""));
-    descriptions.addDefault(desc1);
-    descriptions.add("pfMet", desc1);
-    desc2.add<bool>("applyWeight", true);
-    desc2.add<edm::InputTag>("srcWeights", edm::InputTag("puppiNoLep"));
-    descriptions.add("pfMetPuppi", desc2);
+    desc.add<bool>("applyWeight", false);
+    desc.add<edm::InputTag>("srcWeights", edm::InputTag(""));
+    descriptions.add("pfMet", desc);
+    edm::DescriptionCloner clone;
+    clone.set<bool>("applyWeight", true);
+    clone.set<edm::InputTag>("srcWeights", edm::InputTag("puppiNoLep"));
+    descriptions.add("pfMetPuppi", clone);
   }
 
   //____________________________________________________________________________||

--- a/RecoMuon/GlobalTrackingTools/src/MuonTrackingRegionBuilder.cc
+++ b/RecoMuon/GlobalTrackingTools/src/MuonTrackingRegionBuilder.cc
@@ -18,6 +18,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/DescriptionCloner.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "MagneticField/Engine/interface/MagneticField.h"
@@ -265,76 +266,71 @@ std::unique_ptr<RectangularEtaPhiTrackingRegion> MuonTrackingRegionBuilder::regi
   return region;
 }
 
+namespace {
+  const edm::InputTag kHltBeamSpot("hltOnlineBeamSpot");
+  const edm::InputTag kHltVertexCollection("pixelVertices");
+  const edm::InputTag kHltMeasurementTrackerName("hltESPMeasurementTracker");
+  const edm::InputTag kHltInput("hltL2Muons", "UpdatedAtVtx");
+}  // namespace
+
 void MuonTrackingRegionBuilder::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   {
     edm::ParameterSetDescription desc;
     fillDescriptionsOffline(desc);
-    descriptions.addDefault(desc);
     descriptions.add("MuonTrackingRegionBuilder", desc);
   }
   {
-    edm::ParameterSetDescription desc;
-    fillDescriptionsHLT(desc);
+    edm::DescriptionCloner desc;
+    //NOTE: any changes done here need to be done in fillDescriptionsHLT as well
+    desc.set<edm::InputTag>("beamSpot", kHltBeamSpot);
+    desc.set<edm::InputTag>("vertexCollection", kHltVertexCollection);
+    desc.set<edm::InputTag>("MeasurementTrackerName", kHltMeasurementTrackerName);
+    desc.set<edm::InputTag>("input", kHltInput);
     descriptions.add("MuonTrackingRegionBuilderHLT", desc);
   }
   descriptions.setComment(
       "Build a TrackingRegion around a standalone muon. Options to define region around beamspot or primary vertex and "
       "dynamic regions are included.");
 }
+namespace {
+  void fillDescriptionsCommon(edm::ParameterSetDescription& desc) {
+    desc.add<double>("EtaR_UpperLimit_Par1", 0.25);
+    desc.add<double>("DeltaR", 0.2);
+    desc.add<int>("OnDemand", -1);
+    desc.add<double>("Rescale_phi", 3.0);
+    desc.add<bool>("Eta_fixed", false);
+    desc.add<double>("Rescale_eta", 3.0);
+    desc.add<double>("PhiR_UpperLimit_Par2", 0.2);
+    desc.add<double>("Eta_min", 0.05);
+    desc.add<bool>("Phi_fixed", false);
+    desc.add<double>("Phi_min", 0.05);
+    desc.add<double>("PhiR_UpperLimit_Par1", 0.6);
+    desc.add<double>("EtaR_UpperLimit_Par2", 0.15);
+    desc.add<bool>("UseVertex", false);
+    desc.add<double>("Rescale_Dz", 3.0);
+    desc.add<bool>("Pt_fixed", false);
+    desc.add<bool>("Z_fixed", true);
+    desc.add<double>("Pt_min", 1.5);
+    desc.add<double>("DeltaZ", 15.9);
+    desc.add<double>("DeltaEta", 0.2);
+    desc.add<double>("DeltaPhi", 0.2);
+    desc.add<int>("maxRegions", 1);
+    desc.add<bool>("precise", true);
+  }
+}  // namespace
+
 void MuonTrackingRegionBuilder::fillDescriptionsHLT(edm::ParameterSetDescription& desc) {
-  desc.add<double>("EtaR_UpperLimit_Par1", 0.25);
-  desc.add<double>("DeltaR", 0.2);
-  desc.add<edm::InputTag>("beamSpot", edm::InputTag("hltOnlineBeamSpot"));
-  desc.add<int>("OnDemand", -1);
-  desc.add<edm::InputTag>("vertexCollection", edm::InputTag("pixelVertices"));
-  desc.add<double>("Rescale_phi", 3.0);
-  desc.add<bool>("Eta_fixed", false);
-  desc.add<double>("Rescale_eta", 3.0);
-  desc.add<double>("PhiR_UpperLimit_Par2", 0.2);
-  desc.add<double>("Eta_min", 0.05);
-  desc.add<bool>("Phi_fixed", false);
-  desc.add<double>("Phi_min", 0.05);
-  desc.add<double>("PhiR_UpperLimit_Par1", 0.6);
-  desc.add<double>("EtaR_UpperLimit_Par2", 0.15);
-  desc.add<edm::InputTag>("MeasurementTrackerName", edm::InputTag("hltESPMeasurementTracker"));
-  desc.add<bool>("UseVertex", false);
-  desc.add<double>("Rescale_Dz", 3.0);
-  desc.add<bool>("Pt_fixed", false);
-  desc.add<bool>("Z_fixed", true);
-  desc.add<double>("Pt_min", 1.5);
-  desc.add<double>("DeltaZ", 15.9);
-  desc.add<double>("DeltaEta", 0.2);
-  desc.add<double>("DeltaPhi", 0.2);
-  desc.add<int>("maxRegions", 1);
-  desc.add<bool>("precise", true);
-  desc.add<edm::InputTag>("input", edm::InputTag("hltL2Muons", "UpdatedAtVtx"));
+  fillDescriptionsCommon(desc);
+  desc.add<edm::InputTag>("beamSpot", kHltBeamSpot);
+  desc.add<edm::InputTag>("vertexCollection", kHltVertexCollection);
+  desc.add<edm::InputTag>("MeasurementTrackerName", kHltMeasurementTrackerName);
+  desc.add<edm::InputTag>("input", kHltInput);
 }
 
 void MuonTrackingRegionBuilder::fillDescriptionsOffline(edm::ParameterSetDescription& desc) {
-  desc.add<double>("EtaR_UpperLimit_Par1", 0.25);
-  desc.add<double>("DeltaR", 0.2);
+  fillDescriptionsCommon(desc);
   desc.add<edm::InputTag>("beamSpot", edm::InputTag(""));
-  desc.add<int>("OnDemand", -1);
   desc.add<edm::InputTag>("vertexCollection", edm::InputTag(""));
-  desc.add<double>("Rescale_phi", 3.0);
-  desc.add<bool>("Eta_fixed", false);
-  desc.add<double>("Rescale_eta", 3.0);
-  desc.add<double>("PhiR_UpperLimit_Par2", 0.2);
-  desc.add<double>("Eta_min", 0.05);
-  desc.add<bool>("Phi_fixed", false);
-  desc.add<double>("Phi_min", 0.05);
-  desc.add<double>("PhiR_UpperLimit_Par1", 0.6);
-  desc.add<double>("EtaR_UpperLimit_Par2", 0.15);
   desc.add<edm::InputTag>("MeasurementTrackerName", edm::InputTag(""));
-  desc.add<bool>("UseVertex", false);
-  desc.add<double>("Rescale_Dz", 3.0);
-  desc.add<bool>("Pt_fixed", false);
-  desc.add<bool>("Z_fixed", true);
-  desc.add<double>("Pt_min", 1.5);
-  desc.add<double>("DeltaZ", 15.9);
-  desc.add<double>("DeltaEta", 0.2);
-  desc.add<double>("DeltaPhi", 0.2);
-  desc.add<int>("maxRegions", 1);
-  desc.add<bool>("precise", true);
   desc.add<edm::InputTag>("input", edm::InputTag(""));
 }

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauTagInfoProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauTagInfoProducer.cc
@@ -23,6 +23,7 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/DescriptionCloner.h"
 #include "RecoTauTag/RecoTau/interface/PFRecoTauTagInfoAlgorithm.h"
 
 using namespace reco;
@@ -132,34 +133,13 @@ void PFRecoTauTagInfoProducer::fillDescriptions(edm::ConfigurationDescriptions& 
     desc.add<double>("smearedPVsigmaZ", 0.005);
     desc.add<double>("ChargedHadrCand_tkPVmaxDZ", 0.2);
     desc.add<double>("tkmaxipt", 0.03);
-    descriptions.addDefault(desc);
     descriptions.add("pfRecoTauTagInfoProducerInsideOut", desc);
   }
   {
     // pfRecoTauTagInfoProducer
-    edm::ParameterSetDescription desc;
-    desc.add<int>("tkminTrackerHitsn", 3);
-    desc.add<double>("tkminPt", 0.5);
-    desc.add<double>("tkmaxChi2", 100.0);
-    desc.add<double>("ChargedHadrCand_AssociationCone", 0.8);
-    desc.add<int>("ChargedHadrCand_tkminTrackerHitsn", 3);
-    desc.add<double>("ChargedHadrCand_tkmaxChi2", 100.0);
-    desc.add<double>("tkPVmaxDZ", 0.2);
-    desc.add<double>("GammaCand_EcalclusMinEt", 1.0);
-    desc.add<int>("tkminPixelHitsn", 0);
-    desc.add<edm::InputTag>("PVProducer", edm::InputTag("offlinePrimaryVertices"));
-    desc.add<edm::InputTag>("PFCandidateProducer", edm::InputTag("particleFlow"));
-    desc.add<double>("ChargedHadrCand_tkminPt", 0.5);
-    desc.add<double>("ChargedHadrCand_tkmaxipt", 0.03);
-    desc.add<int>("ChargedHadrCand_tkminPixelHitsn", 0);
-    desc.add<bool>("UsePVconstraint", true);
-    desc.add<double>("NeutrHadrCand_HcalclusMinEt", 1.0);
-    desc.add<edm::InputTag>("PFJetTracksAssociatorProducer", edm::InputTag("ak4PFJetTracksAssociatorAtVertex"));
-    desc.add<double>("smearedPVsigmaY", 0.0015);
-    desc.add<double>("smearedPVsigmaX", 0.0015);
-    desc.add<double>("smearedPVsigmaZ", 0.005);
-    desc.add<double>("ChargedHadrCand_tkPVmaxDZ", 0.2);
-    desc.add<double>("tkmaxipt", 0.03);
+    edm::DescriptionCloner desc;
+    desc.set<double>("ChargedHadrCand_AssociationCone", 0.8);
+    desc.set<edm::InputTag>("PFJetTracksAssociatorProducer", edm::InputTag("ak4PFJetTracksAssociatorAtVertex"));
     descriptions.add("pfRecoTauTagInfoProducer", desc);
   }
 }

--- a/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegionProducerFromBeamSpot.h
+++ b/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegionProducerFromBeamSpot.h
@@ -8,6 +8,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/DescriptionCloner.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/Exception.h"
@@ -58,26 +59,15 @@ public:
       edm::ParameterSetDescription descRegion;
       descRegion.add<edm::ParameterSetDescription>("RegionPSet", desc);
 
-      descriptions.addDefault(descRegion);
       descriptions.add("globalTrackingRegionFromBeamSpot", descRegion);
     }
 
     {
-      edm::ParameterSetDescription desc;
+      edm::DescriptionCloner clone;
 
-      desc.add<bool>("precise", true);
-      desc.add<bool>("useMultipleScattering", false);
-      desc.add<double>("nSigmaZ", 0.0);  // this is the default in constructor
-      desc.add<double>("originHalfLength", 21.2);
-      desc.add<double>("originRadius", 0.2);
-      desc.add<double>("ptMin", 0.9);
-      desc.add<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"));
-
-      // Only for backwards-compatibility
-      edm::ParameterSetDescription descRegion;
-      descRegion.add<edm::ParameterSetDescription>("RegionPSet", desc);
-
-      descriptions.add("globalTrackingRegionFromBeamSpotFixedZ", descRegion);
+      clone.set<double>("RegionPSet.nSigmaZ", 0.0);  // this is the default in constructor
+      clone.set<double>("RegionPSet.originHalfLength", 21.2);
+      descriptions.add("globalTrackingRegionFromBeamSpotFixedZ", clone);
     }
   }
 


### PR DESCRIPTION
#### PR description:

This is a move towards only allowing one ParameterSetDescription per module with variations handled by DescriptionCloner.

#### PR validation:

Code compiles. No behavioral changes are expected from this modification.

resolves https://github.com/cms-sw/framework-team/issues/1911