### PR TITLE
SoA backend cleanup

### DIFF
--- a/DataFormats/HGCalDigi/BuildFile.xml
+++ b/DataFormats/HGCalDigi/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/ForwardDetId"/>
 <use name="DataFormats/DetId"/>
+<use name="DataFormats/SoATemplate"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>
 <use name="eigen"/>
 <flags ALPAKA_BACKENDS="!serial"/>

--- a/DataFormats/Portable/interface/PortableDeviceCollection.h
+++ b/DataFormats/Portable/interface/PortableDeviceCollection.h
@@ -133,26 +133,13 @@ public:
   void deepCopy(TQueue& queue, ConstView const& view) {
     ConstDescriptor desc{view};
     Descriptor desc_{view_};
-    _deepCopy<0>(queue, desc_, desc);
+    portablecollection::deepCopy<0>(queue, desc_, desc);
   }
 
   // Either Layout::size_type for normal layouts or std::array<Layout::size_type, N> for SoABlocks layouts
   auto size() const { return layout_.metadata().size(); }
 
 private:
-  // Helper function implementing the recursive deep copy
-  template <int I, typename TQueue>
-  void _deepCopy(TQueue& queue, Descriptor& dest, ConstDescriptor const& src) {
-    if constexpr (I < ConstDescriptor::num_cols) {
-      assert(std::get<I>(dest.buff).size_bytes() == std::get<I>(src.buff).size_bytes());
-      alpaka::memcpy(
-          queue,
-          alpaka::createView(alpaka::getDev(queue), std::get<I>(dest.buff).data(), std::get<I>(dest.buff).size()),
-          alpaka::createView(alpaka::getDev(queue), std::get<I>(src.buff).data(), std::get<I>(src.buff).size()));
-      _deepCopy<I + 1>(queue, dest, src);
-    }
-  }
-
   // Data members
   std::optional<Buffer> buffer_;  //!
   Layout layout_;                 //

--- a/DataFormats/Portable/interface/PortableHostCollection.h
+++ b/DataFormats/Portable/interface/PortableHostCollection.h
@@ -175,26 +175,13 @@ public:
   void deepCopy(TQueue& queue, ConstView const& view) {
     ConstDescriptor desc{view};
     Descriptor desc_{view_};
-    _deepCopy<0>(queue, desc_, desc);
+    portablecollection::deepCopy<0>(queue, desc_, desc);
   }
 
   // Either Layout::size_type for normal layouts or std::array<Layout::size_type, N> for SoABlocks layouts
   auto size() const { return layout_.metadata().size(); }
 
 private:
-  // Helper function implementing the recursive deep copy
-  template <int I, typename TQueue>
-  void _deepCopy(TQueue& queue, Descriptor& dest, ConstDescriptor const& src) {
-    if constexpr (I < ConstDescriptor::num_cols) {
-      assert(std::get<I>(dest.buff).size_bytes() == std::get<I>(src.buff).size_bytes());
-      alpaka::memcpy(
-          queue,
-          alpaka::createView(alpaka::getDev(queue), std::get<I>(dest.buff).data(), std::get<I>(dest.buff).size()),
-          alpaka::createView(alpaka::getDev(queue), std::get<I>(src.buff).data(), std::get<I>(src.buff).size()));
-      _deepCopy<I + 1>(queue, dest, src);
-    }
-  }
-
   // Data members
   std::optional<Buffer> buffer_;  //!
   Layout layout_;                 //

--- a/DataFormats/SiPixelClusterSoA/BuildFile.xml
+++ b/DataFormats/SiPixelClusterSoA/BuildFile.xml
@@ -2,7 +2,7 @@
 <use name="rootcore"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Portable"/>
-<use name="DataFormats/SoATemplate" source_only="1"/>
+<use name="DataFormats/SoATemplate"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>
 <flags ALPAKA_BACKENDS="!serial"/>
 <export>

--- a/DataFormats/SiPixelDigiSoA/BuildFile.xml
+++ b/DataFormats/SiPixelDigiSoA/BuildFile.xml
@@ -3,7 +3,7 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Portable"/>
 <use name="DataFormats/SiPixelRawData"/>
-<use name="DataFormats/SoATemplate" source_only="1"/>
+<use name="DataFormats/SoATemplate"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>
 <flags ALPAKA_BACKENDS="!serial"/>
 <export>

--- a/DataFormats/SoATemplate/BuildFile.xml
+++ b/DataFormats/SoATemplate/BuildFile.xml
@@ -1,3 +1,6 @@
 <use name="boost_header"/>
 <use name="FWCore/Reflection" source_only="1"/>
 <use name="FWCore/Utilities" source_only="1"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/DataFormats/SoATemplate/src/SoACommon.cc
+++ b/DataFormats/SoATemplate/src/SoACommon.cc
@@ -1,0 +1,12 @@
+#include <format>
+#include <stdexcept>
+
+#include "DataFormats/SoATemplate/interface/SoACommon.h"
+
+namespace cms::soa::detail {
+  [[noreturn]] void throwRuntimeError(const char* message) { throw std::runtime_error(message); }
+
+  [[noreturn]] void throwOutOfRangeError(const char* message, cms::soa::size_type index, cms::soa::size_type range) {
+    throw std::out_of_range(std::format("{}: index {} out of range {}", message, index, range));
+  }
+}  // namespace cms::soa::detail

--- a/DataFormats/SoATemplate/test/BuildFile.xml
+++ b/DataFormats/SoATemplate/test/BuildFile.xml
@@ -77,6 +77,13 @@
   <use name="DataFormats/Portable"/>
 </bin>
 
+<bin file="SoAStreamInternal_t.cc" name="SoAStreamInternal_t">
+  <use name="boost"/>
+  <use name="catch2"/>
+  <use name="eigen"/>
+  <use name="DataFormats/SoATemplate"/>
+</bin>
+
 <!-- This test triggers a bug in ROOT, so it's kept disabled
 <bin file="SoAStreamer_t.cpp" name="SoAStreamer_t">
   <use name="root"/>

--- a/DataFormats/SoATemplate/test/SoAStreamInternal_t.cc
+++ b/DataFormats/SoATemplate/test/SoAStreamInternal_t.cc
@@ -1,0 +1,63 @@
+#include <iostream>
+#include <sstream>
+
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_all.hpp>
+
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+
+GENERATE_SOA_LAYOUT(SoATemplate,
+                    // columns: one value per element
+                    SOA_COLUMN(double, x),
+                    SOA_COLUMN(double, y),
+                    SOA_COLUMN(double, z),
+                    SOA_EIGEN_COLUMN(Eigen::Vector3d, a),
+                    SOA_EIGEN_COLUMN(Eigen::Vector3d, b),
+                    SOA_EIGEN_COLUMN(Eigen::Vector3d, r),
+                    SOA_COLUMN(uint16_t, colour),
+                    SOA_COLUMN(int32_t, value),
+                    SOA_COLUMN(double *, py),
+                    SOA_COLUMN(uint32_t, count),
+                    SOA_COLUMN(uint32_t, anotherCount),
+
+                    // scalars: one value for the whole structure
+                    SOA_SCALAR(const char *, description),
+                    SOA_SCALAR(uint32_t, someNumber));
+
+using SoA = SoATemplate<64, true>;
+
+TEST_CASE("Stream SoA") {
+  const std::size_t slSize = 32;
+  const std::size_t slBufferSize = SoA::computeDataSize(slSize);
+  // memory buffer aligned according to the layout requirements
+  std::unique_ptr<std::byte, decltype(std::free) *> slBuffer{
+      reinterpret_cast<std::byte *>(aligned_alloc(SoA::alignment, slBufferSize)), std::free};
+  // SoA layout
+  SoA soa{slBuffer.get(), slSize};
+
+  std::ostringstream expected;
+  expected << "SoATemplate(32 elements, byte alignement= 64, @" << static_cast<void *>(slBuffer.get()) << "): \n"
+           << "  sizeof(SoATemplate): 176\n"
+           << " Column x at offset 0 has size 256 and padding 0\n"
+           << " Column y at offset 256 has size 256 and padding 0\n"
+           << " Column z at offset 512 has size 256 and padding 0\n"
+           << " Eigen value a at offset 768 has dimension (3 x 1) and per column size 256 and padding 0\n"
+           << " Eigen value b at offset 1536 has dimension (3 x 1) and per column size 256 and padding 0\n"
+           << " Eigen value r at offset 2304 has dimension (3 x 1) and per column size 256 and padding 0\n"
+           << " Column colour at offset 3072 has size 64 and padding 0\n"
+           << " Column value at offset 3136 has size 128 and padding 0\n"
+           << " Column py at offset 3264 has size 256 and padding 0\n"
+           << " Column count at offset 3520 has size 128 and padding 0\n"
+           << " Column anotherCount at offset 3648 has size 128 and padding 0\n"
+           << " Scalar description at offset 3776 has size 8 and padding 56\n"
+           << " Scalar someNumber at offset 3840 has size 4 and padding 60\n"
+           << "Final offset = 3904 computeDataSize(...): 3904\n\n";
+
+  std::ostringstream oss;
+  oss << soa;
+
+  REQUIRE(oss.str() == expected.str());
+}

--- a/DataFormats/TrackSoA/BuildFile.xml
+++ b/DataFormats/TrackSoA/BuildFile.xml
@@ -3,7 +3,7 @@
 <use name="eigen"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Portable"/>
-<use name="DataFormats/SoATemplate" source_only="1"/>
+<use name="DataFormats/SoATemplate"/>
 <use name="DataFormats/TrackerCommon" source_only="1"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>
 <flags ALPAKA_BACKENDS="!serial"/>

--- a/DataFormats/TrackSoA/test/BuildFile.xml
+++ b/DataFormats/TrackSoA/test/BuildFile.xml
@@ -15,6 +15,7 @@
 <library name="testTrackSoA" file="TestWriteHostTrackSoA.cc,TestReadHostTrackSoA.cc,">
   <flags EDM_PLUGIN="1"/>
   <use name="alpaka"/>
+  <use name="DataFormats/SoATemplate"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/Utilities"/>

--- a/DataFormats/TrackingRecHitSoA/BuildFile.xml
+++ b/DataFormats/TrackingRecHitSoA/BuildFile.xml
@@ -3,7 +3,7 @@
 <use name="eigen"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/SiPixelClusterSoA"/>
-<use name="DataFormats/SoATemplate" source_only="1"/>
+<use name="DataFormats/SoATemplate"/>
 <use name="DataFormats/TrackerCommon" source_only="1"/>
 <use name="Geometry/CommonTopologies" source_only="1"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>

--- a/DataFormats/TrackingRecHitSoA/test/BuildFile.xml
+++ b/DataFormats/TrackingRecHitSoA/test/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="eigen"/>
 <bin file="alpaka/Hits_test.cc alpaka/Hits_test.dev.cc" name="Hits_test">
   <use name="alpaka"/>
+  <use name="DataFormats/SoATemplate"/>
   <use name="HeterogeneousCore/AlpakaInterface"/>
   <flags ALPAKA_BACKENDS="1"/>
 </bin>
@@ -8,10 +9,10 @@
 <library name="testHitSoA" file="TestWriteHostHitSoA.cc,TestReadHostHitSoA.cc,">
   <flags EDM_PLUGIN="1"/>
   <use name="alpaka"/>
+  <use name="DataFormats/SoATemplate"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/Utilities"/>
 </library>
 
 <test name="testWriteAndReadHitSoA" command="testWriteAndReadHitSoA.sh" />
-

--- a/DataFormats/VertexSoA/BuildFile.xml
+++ b/DataFormats/VertexSoA/BuildFile.xml
@@ -3,7 +3,7 @@
 <use name="eigen"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Portable"/>
-<use name="DataFormats/SoATemplate" source_only="1"/>
+<use name="DataFormats/SoATemplate"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>
 <flags ALPAKA_BACKENDS="!serial"/>
 <export>

--- a/PhysicsTools/PyTorchAlpaka/interface/TensorCollection.h
+++ b/PhysicsTools/PyTorchAlpaka/interface/TensorCollection.h
@@ -101,13 +101,13 @@ namespace cms::torch::alpakatools {
              std::tuple<TSoAParamsImpl, cms::soa::size_type> column,
              std::tuple<Others, cms::soa::size_type>... others) {
       using DataType = typename TSoAParamsImpl::ScalarType;
-      auto [ptr, stride] = std::get<0>(column).tupleOrPointer();
+      auto ptr = std::get<0>(column).data();
       int n_elems =
           cms::torch::alpakatools::detail::num_elements_per_column(batch_size, SoALayout::alignment, sizeof(DataType));
       assert_location(
           n_elems * TSoAParamsImpl::ValueType::RowsAtCompileTime * TSoAParamsImpl::ValueType::ColsAtCompileTime,
           ptr,
-          std::get<0>(std::get<0>(others).tupleOrPointer())...);
+          std::get<0>(others).data()...);
 
       std::vector<int> tensor_dims;
       if constexpr (TSoAParamsImpl::ValueType::ColsAtCompileTime > 1)
@@ -140,8 +140,8 @@ namespace cms::torch::alpakatools {
       using DataType = typename TSoAParamsImpl::ScalarType;
       int n_elems =
           cms::torch::alpakatools::detail::num_elements_per_column(batch_size, SoALayout::alignment, sizeof(DataType));
-      assert_location(n_elems, std::get<0>(column).tupleOrPointer(), std::get<0>(others).tupleOrPointer()...);
-      auto ptr = std::get<0>(column).tupleOrPointer();
+      assert_location(n_elems, std::get<0>(column).data(), std::get<0>(others).data()...);
+      auto ptr = std::get<0>(column).data();
       emplace_tensor(name, SoALayout::alignment, ptr, batch_size, {1 + sizeof...(Others)});
     }
 
@@ -161,7 +161,7 @@ namespace cms::torch::alpakatools {
     void add(const std::string& name,
              int batch_size,
              std::tuple<cms::soa::SoAParametersImpl<column_t, T>, cms::soa::size_type> column) {
-      auto ptr = std::get<0>(column).tupleOrPointer();
+      auto ptr = std::get<0>(column).data();
       emplace_tensor(name, SoALayout::alignment, ptr, batch_size, {1}, true);
     }
 

--- a/PhysicsTools/PyTorchAlpaka/test/BuildFile.xml
+++ b/PhysicsTools/PyTorchAlpaka/test/BuildFile.xml
@@ -5,6 +5,7 @@
   <use name="eigen"/>
   <use name="pytorch"/>
   <use name="pytorch-cuda" for="alpaka/cuda"/>
+  <use name="DataFormats/SoATemplate"/>
   <use name="HeterogeneousCore/AlpakaInterface"/>
   <use name="PhysicsTools/PyTorchAlpaka"/>
   <!-- Omit ROCM because of copy workaround -> copy private to TensorRegistry -->
@@ -18,6 +19,7 @@
   <use name="eigen"/>
   <use name="pytorch"/>
   <use name="pytorch-cuda" for="alpaka/cuda"/>
+  <use name="DataFormats/SoATemplate"/>
   <use name="HeterogeneousCore/AlpakaInterface"/>
   <use name="PhysicsTools/PyTorch"/>
   <use name="PhysicsTools/PyTorchAlpaka"/>

--- a/RecoTracker/LSTCore/BuildFile.xml
+++ b/RecoTracker/LSTCore/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="root"/>
 <use name="FWCore/MessageLogger"/>
 <use name="DataFormats/Common"/>
+<use name="DataFormats/SoATemplate"/>
 <use name="DataFormats/TrackerRecHit2D"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>
 <flags ALPAKA_BACKENDS="1"/>

--- a/RecoTracker/LSTCore/standalone/bin/lst.cc
+++ b/RecoTracker/LSTCore/standalone/bin/lst.cc
@@ -568,3 +568,13 @@ void run_lst() {
 namespace edm {
   std::string typeDemangle(char const *mangledName) { return boost::core::demangle(mangledName); }
 }  // namespace edm
+
+// Dummy implementation of SoACommon.cc from DataFormats/SoATemplate/src
+// to avoid having to link extra libraries
+namespace cms::soa::detail {
+  [[noreturn]] void throwRuntimeError(const char *message) { throw std::runtime_error(message); }
+
+  [[noreturn]] void throwOutOfRangeError(const char *message, cms::soa::size_type index, cms::soa::size_type range) {
+    throw std::out_of_range(std::format("{}: index {} out of range {}", message, index, range));
+  }
+}  // namespace cms::soa::detail


### PR DESCRIPTION
This PR introduces various cleanups to the SoA backend:

1. Removal of `TupleOrPointerType` in `SoAParametersImpl`. `TupleOrPointerType` is replaced by member functions that return the data address (and the stride in the case of an Eigen Column).
2. Removal of the `checkAlignment` function in `SoAParametersImpl`. The function was mostly code duplication across the four specializations of `SoAParametersImpl`. It is now a free function in the `cms::soa::detail` namespace.
3. `AccumulateColumnByteSizes`  and `computePitch` were essentially code duplication. It is replaced by `ComputePitch` which is a rename of `AccumulateColumnByteSizes` and replaces the function `computePitch` entirely.
4. `printColumn` is implemented as a `PrintColumn` struct now
5. Manual alignment checks are replaced by the `checkAlignment` function
6. Removal of unused `_DECLARE_VIEW_CONSTRUCTION_BYCOLUMN_PARAMETERS` and `_DECLARE_VIEW_MEMBER_INITIALIZERS_BYCOLUMN` macros
7. Removal of a large comment of a dumped SoA in `SoALayout` by a test case that actually dumps an SoA and checks the output string
8. `_deepCopy` was implemented in `PortableDeviceCollection` and `PortableHostCollection` with the exact same functionality. It is not moved to the `portablecollection` namespace and called in both places.


Fyi @felicepantaleo 