### PR TITLE
[NOT TO BE MERGED] Revert JetCorrectorParameter and SiPixelQuality tags in 2026 MC GT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -112,7 +112,8 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2026
     'phase1_2026_design'           :    '160X_mcRun3_2026_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2026
-    'phase1_2026_realistic'        :    '160X_mcRun3_2026_realistic_v1',
+    # (Candidate for test: revert JetCorrection and SiPixel tags)
+    'phase1_2026_realistic'        :    '160X_mcRun3_2026_realistic_Candidate_2026_02_13_14_00_30',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2026, Strip tracker in DECO mode
     'phase1_2026_cosmics'          :    '160X_mcRun3_2026cosmics_realistic_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2026 detector for Heavy Ion


### PR DESCRIPTION

#### PR description:

A Candidate GT was created to revert JetCorrectorParameter and SiPixelQuality tags in 2026 realistic MC GT:
- [160X_mcRun3_2026_realistic_Candidate_2026_02_13_14_00_30](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/160X_mcRun3_2026_realistic_Candidate_2026_02_13_14_00_30)

Difference with respect to 160X_mcRun3_2026_realistic_v1 (currently in master cmssw) is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/160X_mcRun3_2026_realistic_v1/160X_mcRun3_2026_realistic_Candidate_2026_02_13_14_00_30)

This PR was requested by @makortel in https://github.com/cms-sw/cmssw/pull/50106#issuecomment-3891330614 in order to use it as a testbed for profiling PR test infrastructure changes that (I hope) would allow to see which module(s) end up more memory

NOT TO BE MERGED