### PR TITLE
trackingNtuple fix: use seed charge from the original seed state

### DIFF
--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -3618,6 +3618,8 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       see_stateTrajGlbPx.push_back(stateGlobal.momentum().x());
       see_stateTrajGlbPy.push_back(stateGlobal.momentum().y());
       see_stateTrajGlbPz.push_back(stateGlobal.momentum().z());
+      if (charge == 0)  // replace with seed state if the  track failed
+        see_q.back() = stateGlobal.charge();
       if (addSeedCurvCov_) {
         auto const& stateCcov = tsos.curvilinearError().matrix();
         std::vector<float> cov(15);


### PR DESCRIPTION
`see_q` is needed to define the track seed state parameters at the last hit (used in the mkFit standalone setup and other studies).
Before this PR, this value was taken from a track-to-seed conversion (made by `TrackFromSeedProducer`), which occasionally fails for seeds with large outer track hit radius.
In case of a failure we get charge of zero, which is not good.
Here, in case of that conversion failure the value is picked up directly from the seed state.

Ultimately, the code/math in `TwoTrackMinimumDistanceHelixLine` needs to be improved to reduce the rate of failed conversions in `TrackFromSeedProducer`; for this I created #50121


