### PR TITLE
Added omit ability to DescriptionCloner

### DIFF
--- a/FWCore/ParameterSet/interface/DescriptionCloner.h
+++ b/FWCore/ParameterSet/interface/DescriptionCloner.h
@@ -29,7 +29,6 @@ namespace edm {
       }
       T defaultValue;
     };
-
     /** The vector<WhichEntry> in `entry` is used to represent a PSet with that label and trackiness. The values in
      * that vector represent the parameters within that PSet. The EntryTypeBase is used to represent the actual 
      * parameter to be modified which has that label and trackiness.
@@ -44,6 +43,14 @@ namespace edm {
     void set(std::string_view fullPathName, T const& value) {
       insert(fullPathName, std::make_shared<EntryType<T>>(value));
     }
+    /** Omit is used to indicate that a parameter should be removed from the generated cfi file.
+     *  This is needed in cases where the default description has parameters with defaults that one does
+     *  not want to be included in the generated cfi file for a particular configuration.
+     *  Using omit does not affect the validation of the configuration. The parameter will still be allowed 
+     *  in the configuration and it will still be validated if it is present. It just will not be included in
+     *  the generated cfi file.
+     */
+    void omit(std::string_view fullPathName);
 
     //Should only be called by ConfigurationDescriptions
     void determineTrackinessFromDefaultDescription(const ParameterSetDescription& defaultDesc);

--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -301,6 +301,9 @@ class _Parameterizable(object):
 
         items = d.items() if isinstance(d, dict) else d.parameters_().items()
         for k,v in items:
+            if v is None:
+                delattr(self, k)
+            else:
                 setattr(self, k, v)
 
 

--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -880,6 +880,9 @@ if __name__ == "__main__":
             a.update_(__PSet(a=__TestType(5)))
             self.assertEqual(a.a.value(), 5)
             self.assertRaises(TypeError, lambda: a.update_(dict(c=6)))
+            self.assertTrue(hasattr(a, "a"))
+            a.update_(dict(a=None))
+            self.assertFalse(hasattr(a, "a"))
 
         def testCopy(self):
             class __Test(_TypedParameterizable):

--- a/FWCore/ParameterSet/src/DescriptionCloner.cc
+++ b/FWCore/ParameterSet/src/DescriptionCloner.cc
@@ -109,7 +109,7 @@ namespace edm {
     class NoneDescriptionNode : public edm::ParameterDescriptionNode {
     public:
       explicit NoneDescriptionNode(std::string iLabel) : label_(std::move(iLabel)) {}
-      ~NoneDescriptionNode() final = default;
+      ~NoneDescriptionNode() = default;
 
       ParameterDescriptionNode* clone() const final { return new NoneDescriptionNode(label_); }
 

--- a/FWCore/ParameterSet/src/DescriptionCloner.cc
+++ b/FWCore/ParameterSet/src/DescriptionCloner.cc
@@ -105,10 +105,81 @@ namespace edm {
       }
       return diffDesc;
     }
+
+    class NoneDescriptionNode : public edm::ParameterDescriptionNode {
+    public:
+      explicit NoneDescriptionNode(std::string iLabel) : label_(std::move(iLabel)) {}
+      ~NoneDescriptionNode() final = default;
+
+      ParameterDescriptionNode* clone() const final { return new NoneDescriptionNode(label_); }
+
+    private:
+      std::string label_;
+      void checkAndGetLabelsAndTypes_(std::set<std::string>& usedLabels,
+                                      std::set<ParameterTypes>& parameterTypes,
+                                      std::set<ParameterTypes>& wildcardTypes) const final {}
+
+      void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, Modifier modifier) const final {
+        //do nothing, this node is used to indicate that a parameter should be omitted from the generated cfi file
+      }
+
+      void writeCfi_(std::ostream& os,
+                     Modifier modifier,
+                     bool& startWithComma,
+                     int indentation,
+                     CfiOptions&,
+                     bool& wroteSomething) const final {
+        wroteSomething = true;
+        if (startWithComma)
+          os << ",";
+        startWithComma = true;
+        os << "\n";
+        printSpaces(os, indentation);
+
+        os << label_ << " = None";
+      }
+
+      void print_(std::ostream& os, Modifier /*modifier*/, bool /*writeToCfi*/, edm::DocFormatHelper& dfh) const final {
+        if (dfh.pass() == 0) {
+          dfh.setAtLeast1(label_.size());
+        } else {
+          if (dfh.brief()) {
+            std::ios::fmtflags oldFlags = os.flags();
+
+            dfh.indent(os);
+            os << std::left << std::setw(dfh.column1()) << label_ << " omitted\n";
+            os.flags(oldFlags);
+          } else {
+            dfh.indent(os);
+            os << label_ << "\n";
+            dfh.indent2(os);
+            os << "This parameter is omitted from the generated cfi file.\n";
+          }
+        }
+      }
+
+      cfi::Trackiness trackiness_(std::string_view path) const final { return cfi::Trackiness::kNotAllowed; }
+
+      bool exists_(ParameterSet const& pset) const final { return false; }
+
+      bool partiallyExists_(ParameterSet const& pset) const final { return false; }
+
+      int howManyXORSubNodesExist_(ParameterSet const& pset) const final { return 0; }
+    };
+    struct EntryTypeOmit : public edm::DescriptionCloner::EntryTypeBase {
+      void addTo(edm::ParameterSetDescription& iDesc, std::string_view iLabel, bool isTracked) const final {
+        iDesc.addNode(std::make_unique<NoneDescriptionNode>(std::string(iLabel)));
+      }
+    };
+
   }  // namespace
 
   void DescriptionCloner::insert(std::string_view fullPathName, std::shared_ptr<EntryTypeBase> entry) {
     insertInto(fullPathName, std::move(entry), entries_);
+  }
+
+  void DescriptionCloner::omit(std::string_view fullPathName) {
+    insert(fullPathName, std::make_shared<EntryTypeOmit>());
   }
 
   ParameterSetDescription DescriptionCloner::createDifference() const { return createDifferenceFromEntries(entries_); }

--- a/FWCore/ParameterSet/src/DescriptionCloner.cc
+++ b/FWCore/ParameterSet/src/DescriptionCloner.cc
@@ -109,7 +109,7 @@ namespace edm {
     class NoneDescriptionNode : public edm::ParameterDescriptionNode {
     public:
       explicit NoneDescriptionNode(std::string iLabel) : label_(std::move(iLabel)) {}
-      ~NoneDescriptionNode() = default;
+      ~NoneDescriptionNode() override = default;
 
       ParameterDescriptionNode* clone() const final { return new NoneDescriptionNode(label_); }
 

--- a/FWCore/ParameterSet/test/test_catch2_DescriptionCloner.cc
+++ b/FWCore/ParameterSet/test/test_catch2_DescriptionCloner.cc
@@ -169,4 +169,28 @@ TEST_CASE("DescriptionCloner") {
 
     REQUIRE_THROWS_AS(cloner.createDifference(), edm::Exception);
   }
+  SECTION("omit") {
+    edm::DescriptionCloner cloner;
+    cloner.set("param1", 42);
+    cloner.omit("param2");
+
+    edm::ParameterSetDescription defaultDesc;
+    defaultDesc.add<int>("param1", 0);
+    defaultDesc.add<int>("param2", 100);
+
+    cloner.determineTrackinessFromDefaultDescription(defaultDesc);
+
+    auto diffDesc = cloner.createDifference();
+
+    edm::ParameterSet ps;
+    diffDesc.validate(ps);
+
+    REQUIRE(ps.getParameter<int>("param1") == 42);
+    REQUIRE(ps.exists("param2") == false);
+
+    std::ostringstream s;
+    edm::cfi::CfiOptions options = edm::cfi::Untyped{edm::cfi::Paths{}};
+    diffDesc.writeCfi(s, false, 0, options);
+    REQUIRE(s.str() == "\nparam1 = 42,\nparam2 = None\n");
+  }
 }

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescaler.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescaler.cc
@@ -75,6 +75,7 @@ namespace {
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/DescriptionCloner.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "CondFormats/DataRecord/interface/L1TGlobalPrescalesVetosRcd.h"
@@ -358,19 +359,16 @@ void L1TGlobalPrescaler::fillDescriptions(edm::ConfigurationDescriptions& descri
             // if mode is "applyColumnValues", "applyColumnRatios" or "forceColumnValues", read the target column
             "applyColumnValues" >> l1tPrescaleColumn or "applyColumnRatios" >> l1tPrescaleColumn or
             "forceColumnValues" >> l1tPrescaleColumn);
-    descriptions.addDefault(desc);
     descriptions.add("l1tGlobalPrescaler", desc);
   }
 
   // applyColumnRatios example
   {
-    edm::ParameterSetDescription desc;
-    desc.addNode(l1tResults);
-    desc.add<std::string>("mode", "applyColumnRatios")
-        ->setComment(
-            "apply prescales equal to ratio between the values corresponsing to the given column index, and the ones "
-            "read from the EventSetup");
-    desc.addNode(l1tPrescaleColumn);
+    edm::DescriptionCloner desc;
+    desc.set<std::string>("mode", "applyColumnRatios");
+    desc.set<uint32_t>("l1tPrescaleColumn", 0);
+    //the default adds l1tPrescales to the cfi, but we need to remove that for this config
+    desc.omit("l1tPrescales");
     descriptions.add("l1tGlobalPrescalerTargetColumn", desc);
   }
 }

--- a/RecoBTag/ONNXRuntime/plugins/DeepDoubleXONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/DeepDoubleXONNXJetTagsProducer.cc
@@ -7,6 +7,7 @@
 #include "FWCore/Framework/interface/makeRefToBaseProdFrom.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/DescriptionCloner.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 
 #include "DataFormats/BTauReco/interface/JetTag.h"
@@ -113,26 +114,34 @@ void DeepDoubleXONNXJetTagsProducer::fillDescriptions(edm::ConfigurationDescript
   using PDPSD = edm::ParameterDescription<std::vector<std::string>>;
   using PDCases = edm::ParameterDescriptionCases<std::string>;
   using PDVersion = edm::ParameterDescription<std::string>;
+  const std::vector<std::string> kCvL_flav_name{"probQCD", "probHcc"};
+  const FIP kCvL_model_path{"RecoBTag/Combined/data/DeepDoubleX/94X/V01/DDC.onnx"};
+  const std::vector<std::string> kCvB_flav_name{"probHbb", "probHcc"};
+  const FIP kCvB_model_path{"RecoBTag/Combined/data/DeepDoubleX/94X/V01/DDCvB.onnx"};
   auto flavorCases = [&]() {
     return "BvL" >> (PDPSD("flav_names", std::vector<std::string>{"probQCD", "probHbb"}, true) and
                      PDFIP("model_path", FIP("RecoBTag/Combined/data/DeepDoubleX/94X/V01/DDB.onnx"), true)) or
-           "CvL" >> (PDPSD("flav_names", std::vector<std::string>{"probQCD", "probHcc"}, true) and
-                     PDFIP("model_path", FIP("RecoBTag/Combined/data/DeepDoubleX/94X/V01/DDC.onnx"), true)) or
-           "CvB" >> (PDPSD("flav_names", std::vector<std::string>{"probHbb", "probHcc"}, true) and
-                     PDFIP("model_path", FIP("RecoBTag/Combined/data/DeepDoubleX/94X/V01/DDCvB.onnx"), true));
+           "CvL" >> (PDPSD("flav_names", kCvL_flav_name, true) and PDFIP("model_path", kCvL_model_path, true)) or
+           "CvB" >> (PDPSD("flav_names", kCvB_flav_name, true) and PDFIP("model_path", kCvB_model_path, true));
   };
   auto descBvL(desc);
   descBvL.ifValue(edm::ParameterDescription<std::string>("flavor", "BvL", true), flavorCases());
-  descriptions.addDefault(descBvL);
   descriptions.add("pfDeepDoubleBvLJetTags", descBvL);
 
-  auto descCvL(desc);
-  descCvL.ifValue(edm::ParameterDescription<std::string>("flavor", "CvL", true), flavorCases());
-  descriptions.add("pfDeepDoubleCvLJetTags", descCvL);
-
-  auto descCvB(desc);
-  descCvB.ifValue(edm::ParameterDescription<std::string>("flavor", "CvB", true), flavorCases());
-  descriptions.add("pfDeepDoubleCvBJetTags", descCvB);
+  {
+    edm::DescriptionCloner clone;
+    clone.set<std::string>("flavor", "CvL");
+    clone.set<std::vector<std::string>>("flav_names", kCvL_flav_name);
+    clone.set<edm::FileInPath>("model_path", kCvL_model_path);
+    descriptions.add("pfDeepDoubleCvLJetTags", clone);
+  }
+  {
+    edm::DescriptionCloner clone;
+    clone.set<std::string>("flavor", "CvB");
+    clone.set<std::vector<std::string>>("flav_names", kCvB_flav_name);
+    clone.set<edm::FileInPath>("model_path", kCvB_model_path);
+    descriptions.add("pfDeepDoubleCvBJetTags", clone);
+  }
 }
 
 std::unique_ptr<ONNXRuntime> DeepDoubleXONNXJetTagsProducer::initializeGlobalCache(const edm::ParameterSet& iConfig) {


### PR DESCRIPTION
#### PR description:

- Added the ability to have a parameter with a default in the default configuration _omitted_ in the alternate cfi file.
- Apply DescriptionCloner to modules which use `ifValue`.

#### PR validation:

Code compiles. Checked that the generated cfi files remain the same. Tested that loading the module into cmsRun using one of the generated cfi worked properly.

resolves https://github.com/cms-sw/framework-team/issues/1910
resolves https://github.com/cms-sw/framework-team/issues/1912