### PR TITLE
Keep very forward neutrals and nuclear fragments in prunedGenParticle for HI UPC runs [backport to 15.1.X]

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
@@ -51,3 +51,16 @@ prunedGenParticles = cms.EDProducer("GenParticlePruner",
 from Configuration.Eras.Modifier_ppRef_2024_cff import ppRef_2024
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 (pp_on_AA | ppRef_2024).toModify(prunedGenParticles.select, func = lambda list: list.append('keep++ abs(pdgId) == 9920443 || abs(pdgId) == 20443 || abs(pdgId) == 511'))
+
+from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
+def _keep_forward_zdc_fsc_truth(lst):
+    # ZDC/FSC-facing neutrals (signals)
+    lst.append("keep+ abs(pdgId) == 2112 && status == 1 && abs(eta) > 6.0")
+    lst.append("keep+ pdgId == 22        && status == 1 && abs(eta) > 6.0")
+    lst.append("keep+ abs(pdgId) == 130  && status == 1 && abs(eta) > 6.0")
+
+    # Nuclear fragments / ions
+    lst.append("keep+ abs(pdgId) >= 1000000000 && status == 1 && abs(eta) > 6.0")
+
+run3_upc.toModify(prunedGenParticles.select, func=_keep_forward_zdc_fsc_truth)
+

--- a/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
@@ -54,13 +54,11 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 def _keep_forward_zdc_fsc_truth(lst):
-    # ZDC/FSC-facing neutrals (signals)
-    lst.append("keep+ abs(pdgId) == 2112 && status == 1 && abs(eta) > 6.0")
-    lst.append("keep+ pdgId == 22        && status == 1 && abs(eta) > 6.0")
-    lst.append("keep+ abs(pdgId) == 130  && status == 1 && abs(eta) > 6.0")
+    # keep neutrons (stable)
+    lst.append("keep abs(pdgId) == 2112 && status == 1")
 
     # Nuclear fragments / ions
-    lst.append("keep+ abs(pdgId) >= 1000000000 && status == 1 && abs(eta) > 6.0")
+    lst.append("keep+ abs(pdgId) >= 1000000000 && status == 1")
 
 run3_upc.toModify(prunedGenParticles.select, func=_keep_forward_zdc_fsc_truth)
 


### PR DESCRIPTION
#### PR description:

This PR adds additional pruning rules to prunedGenParticles gated by the `run3_upc` modifier used in HI UPC runs:
the following particles are retained in `prunedGenParticles`:

* Neutrons (pdgId = ±2112)
* Nuclear fragments / ions (abs(pdgId) >= 1e9)

The neutral particles are required for ZDC and FSC truth-level studies in Run 3. The change is strictly gated by the `run3_upc` modifier and therefore does not affect standard pp workflows or non-UPC production.

No changes to event content definitions outside the `run3_upc` context are introduced.

#### PR validation:

Validated with `CMSSW_15_1_X`, need to backport to `CMSSW_15_0_X`
