### PR TITLE
Revert SiPixelQuality conditions in autoCond to the old ones, as requested by TSG

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -112,7 +112,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2026
     'phase1_2026_design'           :    '160X_mcRun3_2026_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2026
-    'phase1_2026_realistic'        :    '160X_mcRun3_2026_realistic_v1',
+    'phase1_2026_realistic'        :    '160X_mcRun3_2026_realistic_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2026, Strip tracker in DECO mode
     'phase1_2026_cosmics'          :    '160X_mcRun3_2026cosmics_realistic_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2026 detector for Heavy Ion


### PR DESCRIPTION
#### PR description:

Following the request made by TSG in https://github.com/cms-sw/cmssw/pull/50124#issuecomment-3898232588 (it was observed that the DigiL1Raw, not HLT, step takes a really long time to complete)  the SiPixelQuality tags have been reverted in the phase1_2026_realistic GT in autoCond. The new GT is :

- [160X_mcRun3_2026_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/160X_mcRun3_2026_realistic_v2)

and its difference with respect to previous _v1 can be inspected [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/160X_mcRun3_2026_realistic_v1/160X_mcRun3_2026_realistic_v2)

The updated GT is also documented in [cmsTalk](https://cms-talk.web.cern.ch/t/data-relval-update-of-the-relvals-with-the-new-2026-l1t-menu-tag-l1menu-collisions2026-v1-0-0-xml/141911/16)


#### PR validation:

The old tags were tested several times in the last days...

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

A backport to CMSSW_16_0_X will be prepared. quite likely by adding this commit to https://github.com/cms-sw/cmssw/pull/50124