### PR TITLE
Extend the `HeterogeneousCore/TrivialSerialisation` mechanism to device products

### DIFF
--- a/DataFormats/EcalDigi/plugins/BuildFile.xml
+++ b/DataFormats/EcalDigi/plugins/BuildFile.xml
@@ -3,3 +3,11 @@
   <use name="HeterogeneousCore/TrivialSerialisation"/>
   <flags EDM_PLUGIN="1"/>
 </library>
+<library file="alpaka/TrivialSerialisation.cc" name="DataFormatsEcalDigiTrivialSerialisationPortable">
+  <use name="DataFormats/AlpakaCommon"/>
+  <use name="DataFormats/EcalDigi"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="HeterogeneousCore/TrivialSerialisation"/>
+  <flags ALPAKA_BACKENDS="1"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/DataFormats/EcalDigi/plugins/alpaka/TrivialSerialisation.cc
+++ b/DataFormats/EcalDigi/plugins/alpaka/TrivialSerialisation.cc
@@ -1,0 +1,5 @@
+#include "DataFormats/EcalDigi/interface/alpaka/EcalDigiDeviceCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserFactoryDevice.h"
+
+DEFINE_TRIVIAL_SERIALISER_PLUGIN_DEVICE(EcalDigiDeviceCollection);

--- a/DataFormats/EcalRecHit/plugins/BuildFile.xml
+++ b/DataFormats/EcalRecHit/plugins/BuildFile.xml
@@ -3,3 +3,11 @@
   <use name="HeterogeneousCore/TrivialSerialisation"/>
   <flags EDM_PLUGIN="1"/>
 </library>
+<library file="alpaka/TrivialSerialisation.cc" name="DataFormatsEcalRecHitTrivialSerialisationPortable">
+  <use name="DataFormats/AlpakaCommon"/>
+  <use name="DataFormats/EcalRecHit"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="HeterogeneousCore/TrivialSerialisation"/>
+  <flags ALPAKA_BACKENDS="1"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/DataFormats/EcalRecHit/plugins/alpaka/TrivialSerialisation.cc
+++ b/DataFormats/EcalRecHit/plugins/alpaka/TrivialSerialisation.cc
@@ -1,0 +1,5 @@
+#include "DataFormats/EcalRecHit/interface/alpaka/EcalUncalibratedRecHitDeviceCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserFactoryDevice.h"
+
+DEFINE_TRIVIAL_SERIALISER_PLUGIN_DEVICE(EcalUncalibratedRecHitDeviceCollection);

--- a/DataFormats/HcalRecHit/plugins/BuildFile.xml
+++ b/DataFormats/HcalRecHit/plugins/BuildFile.xml
@@ -3,3 +3,13 @@
   <use name="HeterogeneousCore/TrivialSerialisation"/>
   <flags EDM_PLUGIN="1"/>
 </library>
+
+<library file="alpaka/TrivialSerialisation.cc" name="DataFormatsHcalRecHitTrivialSerialisationPortable">
+  <use name="DataFormats/AlpakaCommon"/>
+  <use name="DataFormats/HcalRecHit"/>
+  <use name="DataFormats/Portable"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="HeterogeneousCore/TrivialSerialisation"/>
+  <flags ALPAKA_BACKENDS="1"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/DataFormats/HcalRecHit/plugins/alpaka/TrivialSerialisation.cc
+++ b/DataFormats/HcalRecHit/plugins/alpaka/TrivialSerialisation.cc
@@ -1,0 +1,5 @@
+#include "DataFormats/HcalRecHit/interface/alpaka/HcalRecHitDeviceCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserFactoryDevice.h"
+
+DEFINE_TRIVIAL_SERIALISER_PLUGIN_DEVICE(hcal::RecHitDeviceCollection);

--- a/DataFormats/ParticleFlowReco/plugins/BuildFile.xml
+++ b/DataFormats/ParticleFlowReco/plugins/BuildFile.xml
@@ -3,3 +3,12 @@
   <use name="HeterogeneousCore/TrivialSerialisation"/>
   <flags EDM_PLUGIN="1"/>
 </library>
+
+<library file="alpaka/TrivialSerialisation.cc" name="DataFormatsParticleFlowRecoTrivialSerialisationPortable">
+  <use name="DataFormats/AlpakaCommon"/>
+  <use name="DataFormats/ParticleFlowReco"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="HeterogeneousCore/TrivialSerialisation"/>
+  <flags ALPAKA_BACKENDS="1"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/DataFormats/ParticleFlowReco/plugins/alpaka/TrivialSerialisation.cc
+++ b/DataFormats/ParticleFlowReco/plugins/alpaka/TrivialSerialisation.cc
@@ -1,0 +1,11 @@
+#include <Eigen/Core>
+
+#include "DataFormats/ParticleFlowReco/interface/alpaka/PFClusterDeviceCollection.h"
+#include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitDeviceCollection.h"
+#include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitFractionDeviceCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserFactoryDevice.h"
+
+DEFINE_TRIVIAL_SERIALISER_PLUGIN_DEVICE(reco::PFRecHitDeviceCollection);
+DEFINE_TRIVIAL_SERIALISER_PLUGIN_DEVICE(reco::PFClusterDeviceCollection);
+DEFINE_TRIVIAL_SERIALISER_PLUGIN_DEVICE(reco::PFRecHitFractionDeviceCollection);

--- a/DataFormats/Portable/interface/PortableDeviceCollection.h
+++ b/DataFormats/Portable/interface/PortableDeviceCollection.h
@@ -12,6 +12,7 @@
 
 #include "DataFormats/Common/interface/Uninitialized.h"
 #include "DataFormats/Portable/interface/PortableCollectionCommon.h"
+#include "DataFormats/TrivialSerialisation/interface/MemoryCopyTraits.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 
@@ -145,5 +146,40 @@ private:
   Layout layout_;                 //
   View view_;                     //!
 };
+
+namespace ngt {
+
+  // Specialize MemoryCopyTraits for PortableDeviceCollection
+  template <typename T, typename TDev>
+  struct MemoryCopyTraits<PortableDeviceCollection<T, TDev>> {
+    using value_type = PortableDeviceCollection<T, TDev>;
+
+    // Properties are the collection size: T::size_type, or std::array<T::size_type, N> for SoABlocks.
+    using Properties = decltype(std::declval<value_type>()->metadata().size());
+
+    static Properties properties(value_type const& object) { return object->metadata().size(); }
+
+    template <typename TQueue>
+    static void initialize(TQueue& queue, value_type& object, Properties const& size)
+      requires(alpaka::isQueue<TQueue>)
+    {
+      // Replace the default-constructed empty object with one where the buffer
+      // has been allocated in global device memory
+      object = value_type(queue, size);
+    }
+
+    static std::vector<std::span<std::byte>> regions(value_type& object) {
+      std::byte* address = reinterpret_cast<std::byte*>(object.buffer().data());
+      size_t size = alpaka::getExtentProduct(object.buffer());
+      return {{address, size}};
+    }
+
+    static std::vector<std::span<const std::byte>> regions(value_type const& object) {
+      const std::byte* address = reinterpret_cast<const std::byte*>(object.buffer().data());
+      size_t size = alpaka::getExtentProduct(object.buffer());
+      return {{address, size}};
+    }
+  };
+}  // namespace ngt
 
 #endif  // DataFormats_Portable_interface_PortableDeviceCollection_h

--- a/DataFormats/Portable/interface/PortableDeviceObject.h
+++ b/DataFormats/Portable/interface/PortableDeviceObject.h
@@ -8,6 +8,7 @@
 #include <alpaka/alpaka.hpp>
 
 #include "DataFormats/Common/interface/Uninitialized.h"
+#include "DataFormats/TrivialSerialisation/interface/MemoryCopyTraits.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 
@@ -79,5 +80,29 @@ public:
 private:
   std::optional<Buffer> buffer_;
 };
+
+namespace ngt {
+
+  // Specialize MemoryCopyTraits for PortableDeviceObject
+  template <typename TDev, typename T>
+  struct MemoryCopyTraits<PortableDeviceObject<TDev, T>> {
+    template <typename TQueue>
+      requires(alpaka::isQueue<TQueue>)
+    static void initialize(TQueue& queue, PortableDeviceObject<TDev, T>& object) {
+      // Replace the default-constructed empty object with one where the
+      // buffer has been allocated in global device memory
+      object = PortableDeviceObject<TDev, T>(queue);
+    }
+
+    static std::vector<std::span<std::byte>> regions(PortableDeviceObject<TDev, T>& object) {
+      return {{reinterpret_cast<std::byte*>(object.data()), sizeof(T)}};
+    }
+
+    static std::vector<std::span<const std::byte>> regions(PortableDeviceObject<TDev, T> const& object) {
+      return {{reinterpret_cast<std::byte const*>(object.data()), sizeof(T)}};
+    }
+  };
+
+}  // namespace ngt
 
 #endif  // DataFormats_Portable_interface_PortableDeviceObject_h

--- a/DataFormats/Portable/interface/PortableHostCollection.h
+++ b/DataFormats/Portable/interface/PortableHostCollection.h
@@ -200,8 +200,17 @@ namespace ngt {
     // The properties needed to initialize a new PrortableHostCollection are just its size.
     static Properties properties(value_type const& object) { return object->metadata().size(); }
 
-    // Replace the default-constructed empty object with one where the buffer has been allocated in pageable system memory.
+    template <typename TQueue>
+      requires(alpaka::isQueue<TQueue>)
+    static void initialize(TQueue& queue, value_type& object, Properties const& size) {
+      // Replace the default-constructed empty object with one where the buffer
+      // has been allocated in pinned host memory.
+      object = value_type(queue, size);
+    }
+
     static void initialize(value_type& object, Properties const& size) {
+      // Replace the default-constructed empty object with one where the buffer
+      // has been allocated in pageable host memory.
       object = value_type(cms::alpakatools::host(), size);
     }
 

--- a/DataFormats/Portable/interface/PortableHostObject.h
+++ b/DataFormats/Portable/interface/PortableHostObject.h
@@ -121,11 +121,21 @@ namespace ngt {
 
   template <typename T>
   struct MemoryCopyTraits<PortableHostObject<T>> {
-    // This specialisation requires a initialize() method, but does not need to pass any parameters to it.
+    // This specialisation requires an initialize() method, but does not need to
+    // pass any parameters to it.
     using Properties = void;
 
+    template <typename TQueue>
+      requires(alpaka::isQueue<TQueue>)
+    static void initialize(TQueue& queue, PortableHostObject<T>& object) {
+      // Replace the default-constructed empty object with one where the buffer
+      // has been allocated in pinned host memory
+      object = PortableHostObject<T>(queue);
+    }
+
     static void initialize(PortableHostObject<T>& object) {
-      // Replace the default-constructed empty object with one where the buffer has been allocated in pageable system memory.
+      // Replace the default-constructed empty object with one where the buffer
+      // has been allocated in pageable host memory.
       object = PortableHostObject<T>(cms::alpakatools::host());
     }
 

--- a/DataFormats/PortableTestObjects/plugins/BuildFile.xml
+++ b/DataFormats/PortableTestObjects/plugins/BuildFile.xml
@@ -3,3 +3,12 @@
   <use name="HeterogeneousCore/TrivialSerialisation"/>
   <flags EDM_PLUGIN="1"/>
 </library>
+
+<library file="alpaka/*.cc" name="DataFormatsPortableTestObjectsPluginsAlpaka">
+  <use name="DataFormats/AlpakaCommon"/>
+  <use name="DataFormats/PortableTestObjects"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="HeterogeneousCore/TrivialSerialisation"/>
+  <flags ALPAKA_BACKENDS="1"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/DataFormats/PortableTestObjects/plugins/alpaka/TrivialSerialisation.cc
+++ b/DataFormats/PortableTestObjects/plugins/alpaka/TrivialSerialisation.cc
@@ -1,0 +1,9 @@
+#include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"
+#include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceObject.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserFactoryDevice.h"
+
+DEFINE_TRIVIAL_SERIALISER_PLUGIN_DEVICE(portabletest::TestDeviceCollection);
+DEFINE_TRIVIAL_SERIALISER_PLUGIN_DEVICE(portabletest::TestDeviceCollection2);
+DEFINE_TRIVIAL_SERIALISER_PLUGIN_DEVICE(portabletest::TestDeviceCollection3);
+DEFINE_TRIVIAL_SERIALISER_PLUGIN_DEVICE(portabletest::TestDeviceObject);

--- a/DataFormats/TrackSoA/plugins/BuildFile.xml
+++ b/DataFormats/TrackSoA/plugins/BuildFile.xml
@@ -3,3 +3,11 @@
   <use name="HeterogeneousCore/TrivialSerialisation"/>
   <flags EDM_PLUGIN="1"/>
 </library>
+<library file="alpaka/TrivialSerialisation.cc" name="DataFormatsTrackSoATrivialSerialisationPortable">
+  <use name="DataFormats/AlpakaCommon"/>
+  <use name="DataFormats/TrackSoA"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="HeterogeneousCore/TrivialSerialisation"/>
+  <flags ALPAKA_BACKENDS="1"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/DataFormats/TrackSoA/plugins/alpaka/TrivialSerialisation.cc
+++ b/DataFormats/TrackSoA/plugins/alpaka/TrivialSerialisation.cc
@@ -1,0 +1,5 @@
+#include "DataFormats/TrackSoA/interface/alpaka/TracksSoACollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserFactoryDevice.h"
+
+DEFINE_TRIVIAL_SERIALISER_PLUGIN_DEVICE(reco::TracksSoACollection);

--- a/DataFormats/TrivialSerialisation/interface/MemoryCopyTraits.h
+++ b/DataFormats/TrivialSerialisation/interface/MemoryCopyTraits.h
@@ -54,36 +54,38 @@ namespace ngt {
 
   // Checks if the properties method is defined
   template <typename T>
-  concept HasTrivialCopyProperties = requires(T const& object) { MemoryCopyTraits<T>::properties(object); };
+  concept HasTrivialCopyProperties = requires(T const& object) { ngt::MemoryCopyTraits<T>::properties(object); };
 
   // Get the return type of properties(...), if it exists.
   template <typename T>
-    requires HasTrivialCopyProperties<T>
-  using TrivialCopyProperties = decltype(MemoryCopyTraits<T>::properties(std::declval<T const&>()));
+    requires ngt::HasTrivialCopyProperties<T>
+  using TrivialCopyProperties = decltype(ngt::MemoryCopyTraits<T>::properties(std::declval<T const&>()));
 
   // Checks if the declaration of initialize(...) is consistent with the presence or absence of properties.
   template <typename T>
   concept HasValidInitialize =
       // does not have properties(...) and initialize(object) takes a single argument, or
-      (not HasTrivialCopyProperties<T> and requires(T& object) { MemoryCopyTraits<T>::initialize(object); }) or
+      (not ngt::HasTrivialCopyProperties<T> and
+       requires(T& object) { ngt::MemoryCopyTraits<T>::initialize(object); }) or
       // does have properties(...) and initialize(object, props) takes two arguments
-      (HasTrivialCopyProperties<T> and
-       requires(T& object, TrivialCopyProperties<T> props) { MemoryCopyTraits<T>::initialize(object, props); });
+      (ngt::HasTrivialCopyProperties<T> and requires(T& object, ngt::TrivialCopyProperties<T> props) {
+        ngt::MemoryCopyTraits<T>::initialize(object, props);
+      });
 
   // Checks for const and non const memory regions
   template <typename T>
   concept HasRegions = requires(T& object, T const& const_object) {
-    MemoryCopyTraits<T>::regions(object);
-    MemoryCopyTraits<T>::regions(const_object);
+    ngt::MemoryCopyTraits<T>::regions(object);
+    ngt::MemoryCopyTraits<T>::regions(const_object);
   };
 
   // Checks if there is a valid specialisation of MemoryCopyTraits for a type T
   template <typename T>
   concept HasMemoryCopyTraits =
       // Has memory regions declared and
-      (HasRegions<T>) and
+      (ngt::HasRegions<T>) and
       // has either no initialize(...) or a valid one
-      (not requires { &MemoryCopyTraits<T>::initialize; } or HasValidInitialize<T>);
+      (not requires { &ngt::MemoryCopyTraits<T>::initialize; } or ngt::HasValidInitialize<T>);
 
   // Checks if finalize(...) is defined
   template <typename T>

--- a/DataFormats/TrivialSerialisation/test/BuildFile.xml
+++ b/DataFormats/TrivialSerialisation/test/BuildFile.xml
@@ -2,3 +2,16 @@
   <use name="catch2"/>
   <use name="DataFormats/TrivialSerialisation"/>
 </bin>
+
+
+<bin name="TestDataFormatsTrivialSerialisationPortable" file="alpaka/test_catch2_*.cc,alpaka/test_catch2_*.dev.cc">
+  <use name="alpaka"/>
+  <use name="catch2"/>
+  <use name="Eigen"/>
+  <use name="DataFormats/Common"/>
+  <use name="DataFormats/Portable"/>
+  <use name="DataFormats/PortableTestObjects"/>
+  <use name="DataFormats/TrivialSerialisation"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <flags ALPAKA_BACKENDS="1"/>
+</bin>

--- a/DataFormats/TrivialSerialisation/test/alpaka/test_catch2_MemoryCopyTraitsPortable.dev.cc
+++ b/DataFormats/TrivialSerialisation/test/alpaka/test_catch2_MemoryCopyTraitsPortable.dev.cc
@@ -1,0 +1,363 @@
+#include <cstring>
+#include <utility>
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_all.hpp>
+
+#include <Eigen/Dense>
+
+#include "DataFormats/Portable/interface/PortableCollection.h"
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/Portable/interface/PortableHostObject.h"
+#include "DataFormats/PortableTestObjects/interface/TestSoA.h"
+#include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"
+#include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceObject.h"
+#include "DataFormats/TrivialSerialisation/interface/MemoryCopyTraits.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+using namespace ALPAKA_ACCELERATOR_NAMESPACE;
+namespace alpaka_portable_test = ALPAKA_ACCELERATOR_NAMESPACE::portabletest;
+
+/*
+ * Catch2 tests for MemoryCopyTraits specializations of portable types.
+ *
+ * This test verifies that:
+ * - PortableHostCollection has valid MemoryCopyTraits with Properties and initialize()
+ * - PortableHostObject has valid MemoryCopyTraits with initialize() but no Properties
+ * - PortableDeviceCollection has valid MemoryCopyTraits with Properties and initialize()
+ * - PortableDeviceObject has valid MemoryCopyTraits with initialize() but no Properties
+ * - Multi-block collections (SoABlocks2, SoABlocks3) have valid MemoryCopyTraits
+ *
+ * It also tests that data can be correctly copied using the MemoryCopyTraits interface
+ * for both host and device portable types.
+ */
+
+TEST_CASE("Test MemoryCopyTraits with portable types", "[MemoryCopyTraits][Portable]") {
+  auto const& devices = cms::alpakatools::devices<Platform>();
+  if (devices.empty()) {
+    FAIL("No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend");
+  }
+
+  SECTION("PortableHostCollection checks") {
+    using HostCollectionType = PortableHostCollection<alpaka_portable_test::TestSoALayout<128, false>>;
+
+    // PortableHostCollection should have MemoryCopyTraits
+    static_assert(::ngt::HasMemoryCopyTraits<HostCollectionType>);
+    // It should have Properties (the size)
+    static_assert(::ngt::HasTrivialCopyProperties<HostCollectionType>);
+    // It should have a valid initialize()
+    static_assert(::ngt::HasValidInitialize<HostCollectionType>);
+    // It should have regions
+    static_assert(::ngt::HasRegions<HostCollectionType>);
+  }
+
+  SECTION("PortableHostObject checks") {
+    using HostObjectType = PortableHostObject<alpaka_portable_test::TestStruct>;
+
+    // PortableHostObject should have MemoryCopyTraits
+    static_assert(::ngt::HasMemoryCopyTraits<HostObjectType>);
+    // It should not have Properties
+    static_assert(not ::ngt::HasTrivialCopyProperties<HostObjectType>);
+    // It should have regions
+    static_assert(::ngt::HasRegions<HostObjectType>);
+  }
+
+  SECTION("PortableDeviceCollection checks") {
+    using DeviceCollectionType = alpaka_portable_test::TestDeviceCollection;
+
+    // PortableDeviceCollection should have MemoryCopyTraits
+    static_assert(::ngt::HasMemoryCopyTraits<DeviceCollectionType>);
+    // It should have Properties (the size)
+    static_assert(::ngt::HasTrivialCopyProperties<DeviceCollectionType>);
+    // It should have regions
+    static_assert(::ngt::HasRegions<DeviceCollectionType>);
+  }
+
+  SECTION("PortableDeviceObject checks") {
+    using DeviceObjectType = alpaka_portable_test::TestDeviceObject;
+
+    // PortableDeviceObject should have MemoryCopyTraits
+    static_assert(::ngt::HasMemoryCopyTraits<DeviceObjectType>);
+    // It should not have Properties
+    static_assert(not ::ngt::HasTrivialCopyProperties<DeviceObjectType>);
+    // It should have regions
+    static_assert(::ngt::HasRegions<DeviceObjectType>);
+  }
+
+  SECTION("Multi-block PortableHostCollection checks") {
+    // SoABlocks2
+    using HostCollection2Type = PortableHostCollection<alpaka_portable_test::TestSoABlocks2>;
+    static_assert(::ngt::HasMemoryCopyTraits<HostCollection2Type>);
+    static_assert(::ngt::HasTrivialCopyProperties<HostCollection2Type>);
+    static_assert(::ngt::HasRegions<HostCollection2Type>);
+
+    // SoABlocks3
+    using HostCollection3Type = PortableHostCollection<alpaka_portable_test::TestSoABlocks3>;
+    static_assert(::ngt::HasMemoryCopyTraits<HostCollection3Type>);
+    static_assert(::ngt::HasTrivialCopyProperties<HostCollection3Type>);
+    static_assert(::ngt::HasRegions<HostCollection3Type>);
+  }
+
+  SECTION("Multi-block PortableDeviceCollection checks") {
+    using DeviceCollection2Type = alpaka_portable_test::TestDeviceCollection2;
+    static_assert(::ngt::HasMemoryCopyTraits<DeviceCollection2Type>);
+    static_assert(::ngt::HasTrivialCopyProperties<DeviceCollection2Type>);
+    static_assert(::ngt::HasRegions<DeviceCollection2Type>);
+
+    using DeviceCollection3Type = alpaka_portable_test::TestDeviceCollection3;
+    static_assert(::ngt::HasMemoryCopyTraits<DeviceCollection3Type>);
+    static_assert(::ngt::HasTrivialCopyProperties<DeviceCollection3Type>);
+    static_assert(::ngt::HasRegions<DeviceCollection3Type>);
+  }
+
+  SECTION("PortableHostCollection copy via MemoryCopyTraits") {
+    using HostCollectionType = PortableHostCollection<alpaka_portable_test::TestSoALayout<128, false>>;
+    const int size = 10;
+
+    for (auto const& device : devices) {
+      Queue queue(device);
+
+      // Create a source collection and fill it with data
+      HostCollectionType source(queue, size);
+      source.view().r() = 3.14;
+      for (int i = 0; i < size; i++) {
+        source.view()[i].x() = i * 10.0 + 1;
+        source.view()[i].y() = i * 10.0 + 2;
+        source.view()[i].z() = i * 10.0 + 3;
+        source.view()[i].id() = i;
+        source.view()[i].flags() = std::array<short, 4>{
+            {static_cast<short>(i), static_cast<short>(i + 1), static_cast<short>(i + 2), static_cast<short>(i + 3)}};
+        source.view()[i].m = Eigen::Matrix<double, 3, 6>::Identity() * i;
+      }
+
+      // Get properties from source
+      auto props = ::ngt::MemoryCopyTraits<HostCollectionType>::properties(source);
+      REQUIRE(props == size);
+
+      // Create a clone and initialize it
+      HostCollectionType clone(edm::kUninitialized);
+      ::ngt::MemoryCopyTraits<HostCollectionType>::initialize(clone, props);
+
+      // Get regions and copy
+      auto sources_regions = ::ngt::MemoryCopyTraits<HostCollectionType>::regions(std::as_const(source));
+      auto targets_regions = ::ngt::MemoryCopyTraits<HostCollectionType>::regions(clone);
+
+      REQUIRE(sources_regions.size() == targets_regions.size());
+      REQUIRE(sources_regions.size() == 1);
+      REQUIRE(sources_regions[0].size_bytes() == targets_regions[0].size_bytes());
+
+      std::memcpy(targets_regions[0].data(), sources_regions[0].data(), sources_regions[0].size_bytes());
+
+      // Verify clone
+      REQUIRE(clone.const_view().r() == source.const_view().r());
+      for (int i = 0; i < size; i++) {
+        REQUIRE(clone.const_view()[i].x() == source.const_view()[i].x());
+        REQUIRE(clone.const_view()[i].y() == source.const_view()[i].y());
+        REQUIRE(clone.const_view()[i].z() == source.const_view()[i].z());
+        REQUIRE(clone.const_view()[i].id() == source.const_view()[i].id());
+        REQUIRE(clone.const_view()[i].flags() == source.const_view()[i].flags());
+        REQUIRE(clone.const_view()[i].m() == source.const_view()[i].m());
+      }
+    }
+  }
+
+  SECTION("PortableHostObject copy via MemoryCopyTraits") {
+    using HostObjectType = PortableHostObject<alpaka_portable_test::TestStruct>;
+
+    for (auto const& device : devices) {
+      Queue queue(device);
+
+      // Create source object
+      HostObjectType source(cms::alpakatools::host());
+      source->x = 5.0;
+      source->y = 12.0;
+      source->z = 13.0;
+      source->id = 42;
+
+      // Create an uninitialized clone
+      HostObjectType clone(edm::kUninitialized);
+      ::ngt::MemoryCopyTraits<HostObjectType>::initialize(clone);
+
+      // Get regions and copy
+      auto sources_regions = ::ngt::MemoryCopyTraits<HostObjectType>::regions(std::as_const(source));
+      auto targets_regions = ::ngt::MemoryCopyTraits<HostObjectType>::regions(clone);
+
+      REQUIRE(sources_regions.size() == targets_regions.size());
+      REQUIRE(sources_regions.size() == 1);
+      REQUIRE(sources_regions[0].size_bytes() == sizeof(alpaka_portable_test::TestStruct));
+      REQUIRE(targets_regions[0].size_bytes() == sizeof(alpaka_portable_test::TestStruct));
+
+      std::memcpy(targets_regions[0].data(), sources_regions[0].data(), sources_regions[0].size_bytes());
+
+      // Verify clone
+      REQUIRE(clone->x == 5.0);
+      REQUIRE(clone->y == 12.0);
+      REQUIRE(clone->z == 13.0);
+      REQUIRE(clone->id == 42);
+    }
+  }
+
+  SECTION("PortableDeviceCollection copy via MemoryCopyTraits") {
+    using DeviceCollectionType = alpaka_portable_test::TestDeviceCollection;
+    using HostCollectionType = PortableHostCollection<alpaka_portable_test::TestSoALayout<128, false>>;
+    const int size = 10;
+
+    for (auto const& device : devices) {
+      Queue queue(device);
+
+      // Create a reference host collection with known data
+      HostCollectionType refHost(queue, size);
+      refHost.view().r() = 2.71;
+      for (int i = 0; i < size; i++) {
+        refHost.view()[i].x() = i * 100.0;
+        refHost.view()[i].y() = i * 200.0;
+        refHost.view()[i].z() = i * 300.0;
+        refHost.view()[i].id() = i + 100;
+        refHost.view()[i].flags() = std::array<short, 4>{
+            {static_cast<short>(i), static_cast<short>(i + 1), static_cast<short>(i + 2), static_cast<short>(i + 3)}};
+        refHost.view()[i].m = Eigen::Matrix<double, 3, 6>::Identity() * i;
+      }
+
+      // Create a device collection and copy the reference data to it
+      DeviceCollectionType source(queue, size);
+      alpaka::memcpy(queue, source.buffer(), refHost.buffer());
+      alpaka::wait(queue);
+
+      // Get properties
+      auto props = ::ngt::MemoryCopyTraits<DeviceCollectionType>::properties(source);
+      REQUIRE(props == size);
+
+      // Create a clone on device
+      DeviceCollectionType clone(edm::kUninitialized);
+      ::ngt::MemoryCopyTraits<DeviceCollectionType>::initialize(queue, clone, props);
+
+      // Get regions and copy (device-to-device via alpaka)
+      auto sources_regions = ::ngt::MemoryCopyTraits<DeviceCollectionType>::regions(std::as_const(source));
+      auto targets_regions = ::ngt::MemoryCopyTraits<DeviceCollectionType>::regions(clone);
+
+      REQUIRE(sources_regions.size() == targets_regions.size());
+      for (size_t i = 0; i < sources_regions.size(); ++i) {
+        REQUIRE(sources_regions[i].size_bytes() == targets_regions[i].size_bytes());
+        auto src_view = alpaka::createView(device, sources_regions[i].data(), sources_regions[i].size_bytes());
+        auto trg_view = alpaka::createView(device, targets_regions[i].data(), targets_regions[i].size_bytes());
+        alpaka::memcpy(queue, trg_view, src_view);
+      }
+      alpaka::wait(queue);
+
+      // Copy the clone back to host to verify
+      HostCollectionType verifyHost(queue, size);
+      alpaka::memcpy(queue, verifyHost.buffer(), clone.buffer());
+      alpaka::wait(queue);
+
+      REQUIRE(verifyHost.const_view().r() == refHost.const_view().r());
+      for (int i = 0; i < size; i++) {
+        REQUIRE(verifyHost.const_view()[i].x() == refHost.const_view()[i].x());
+        REQUIRE(verifyHost.const_view()[i].y() == refHost.const_view()[i].y());
+        REQUIRE(verifyHost.const_view()[i].z() == refHost.const_view()[i].z());
+        REQUIRE(verifyHost.const_view()[i].id() == refHost.const_view()[i].id());
+        REQUIRE(verifyHost.const_view()[i].flags() == refHost.const_view()[i].flags());
+      }
+    }
+  }
+
+  SECTION("PortableDeviceObject copy via MemoryCopyTraits") {
+    using DeviceObjectType = alpaka_portable_test::TestDeviceObject;
+
+    for (auto const& device : devices) {
+      Queue queue(device);
+
+      // Create source object on host, copy to device
+      PortableHostObject<alpaka_portable_test::TestStruct> hostSource(queue);
+      hostSource->x = 1.0;
+      hostSource->y = 2.0;
+      hostSource->z = 3.0;
+      hostSource->id = 99;
+
+      DeviceObjectType source(queue);
+      alpaka::memcpy(queue, source.buffer(), hostSource.buffer());
+      alpaka::wait(queue);
+
+      // Create an uninitialized clone
+      DeviceObjectType clone(edm::kUninitialized);
+      ::ngt::MemoryCopyTraits<DeviceObjectType>::initialize(queue, clone);
+
+      // Get regions and copy
+      auto sources_regions = ::ngt::MemoryCopyTraits<DeviceObjectType>::regions(std::as_const(source));
+      auto targets_regions = ::ngt::MemoryCopyTraits<DeviceObjectType>::regions(clone);
+
+      REQUIRE(sources_regions.size() == 1);
+      REQUIRE(targets_regions.size() == 1);
+      REQUIRE(sources_regions[0].size_bytes() == sizeof(alpaka_portable_test::TestStruct));
+
+      auto src_view = alpaka::createView(device, sources_regions[0].data(), sources_regions[0].size_bytes());
+      auto trg_view = alpaka::createView(device, targets_regions[0].data(), targets_regions[0].size_bytes());
+      alpaka::memcpy(queue, trg_view, src_view);
+      alpaka::wait(queue);
+
+      // Copy clone back to host and verify
+      PortableHostObject<alpaka_portable_test::TestStruct> hostClone(queue);
+      alpaka::memcpy(queue, hostClone.buffer(), clone.buffer());
+      alpaka::wait(queue);
+
+      REQUIRE(hostClone->x == 1.0);
+      REQUIRE(hostClone->y == 2.0);
+      REQUIRE(hostClone->z == 3.0);
+      REQUIRE(hostClone->id == 99);
+    }
+  }
+
+  SECTION("Multi-block PortableHostCollection copy via MemoryCopyTraits") {
+    using HostCollection2Type = PortableHostCollection<alpaka_portable_test::TestSoABlocks2>;
+    const int size1 = 8;
+    const int size2 = 12;
+
+    for (auto const& device : devices) {
+      Queue queue(device);
+
+      // Create source with two blocks
+      HostCollection2Type source(queue, size1, size2);
+      source.view().first().r() = 1.23;
+      source.view().second().r2() = 4.56;
+      for (int i = 0; i < size1; i++) {
+        source.view().first()[i].x() = i * 1.0;
+        source.view().first()[i].id() = i;
+      }
+      for (int i = 0; i < size2; i++) {
+        source.view().second()[i].x2() = i * 2.0;
+        source.view().second()[i].id2() = i + 100;
+      }
+
+      // Get properties
+      auto props = ::ngt::MemoryCopyTraits<HostCollection2Type>::properties(source);
+      REQUIRE(props[0] == size1);
+      REQUIRE(props[1] == size2);
+
+      // Create clone and initialize
+      HostCollection2Type clone(edm::kUninitialized);
+      ::ngt::MemoryCopyTraits<HostCollection2Type>::initialize(clone, props);
+
+      // Copy regions
+      auto sources_regions = ::ngt::MemoryCopyTraits<HostCollection2Type>::regions(std::as_const(source));
+      auto targets_regions = ::ngt::MemoryCopyTraits<HostCollection2Type>::regions(clone);
+
+      REQUIRE(sources_regions.size() == targets_regions.size());
+      for (size_t i = 0; i < sources_regions.size(); ++i) {
+        REQUIRE(sources_regions[i].size_bytes() == targets_regions[i].size_bytes());
+        std::memcpy(targets_regions[i].data(), sources_regions[i].data(), sources_regions[i].size_bytes());
+      }
+
+      // Verify
+      REQUIRE(clone.const_view().first().r() == 1.23);
+      REQUIRE(clone.const_view().second().r2() == 4.56);
+      for (int i = 0; i < size1; i++) {
+        REQUIRE(clone.const_view().first()[i].x() == i * 1.0);
+        REQUIRE(clone.const_view().first()[i].id() == i);
+      }
+      for (int i = 0; i < size2; i++) {
+        REQUIRE(clone.const_view().second()[i].x2() == i * 2.0);
+        REQUIRE(clone.const_view().second()[i].id2() == i + 100);
+      }
+    }
+  }
+}

--- a/DataFormats/VertexSoA/plugins/BuildFile.xml
+++ b/DataFormats/VertexSoA/plugins/BuildFile.xml
@@ -3,3 +3,12 @@
   <use name="HeterogeneousCore/TrivialSerialisation"/>
   <flags EDM_PLUGIN="1"/>
 </library>
+<library file="alpaka/TrivialSerialisation.cc" name="DataFormatsVertexSoATrivialSerialisationPortable">
+  <use name="DataFormats/AlpakaCommon"/>
+  <use name="DataFormats/Portable"/>
+  <use name="DataFormats/VertexSoA"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="HeterogeneousCore/TrivialSerialisation"/>
+  <flags ALPAKA_BACKENDS="1"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/DataFormats/VertexSoA/plugins/alpaka/TrivialSerialisation.cc
+++ b/DataFormats/VertexSoA/plugins/alpaka/TrivialSerialisation.cc
@@ -1,0 +1,5 @@
+#include "DataFormats/VertexSoA/interface/alpaka/ZVertexSoACollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserFactoryDevice.h"
+
+DEFINE_TRIVIAL_SERIALISER_PLUGIN_DEVICE(reco::ZVertexSoACollection);

--- a/HeterogeneousCore/TrivialSerialisation/BuildFile.xml
+++ b/HeterogeneousCore/TrivialSerialisation/BuildFile.xml
@@ -1,7 +1,11 @@
+<use name="alpaka"/>
+<use name="DataFormats/AlpakaCommon"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/TrivialSerialisation"/>
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/Utilities"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<flags ALPAKA_BACKENDS="1"/>
 <export>
   <lib name="1"/>
 </export>

--- a/HeterogeneousCore/TrivialSerialisation/interface/Common.h
+++ b/HeterogeneousCore/TrivialSerialisation/interface/Common.h
@@ -1,0 +1,51 @@
+#ifndef HeterogeneousCore_TrivialSerialisation_interface_Common_h
+#define HeterogeneousCore_TrivialSerialisation_interface_Common_h
+
+#include <cstddef>
+#include <span>
+#include <vector>
+
+#include "DataFormats/TrivialSerialisation/interface/MemoryCopyTraits.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/AnyBuffer.h"
+
+namespace ngt {
+
+  // Helper functions used by both the alpaka and non-alpaka variants of the
+  // Reader and Writer.
+
+  // Return the TrivialCopyProperties for an object, wrapped in an AnyBuffer.
+  // Returns an empty AnyBuffer if MemoryCopyTraits<T> has no properties().
+  template <typename T>
+  ngt::AnyBuffer get_properties(T const& obj) {
+    if constexpr (not ngt::HasTrivialCopyProperties<T>) {
+      return {};
+    } else {
+      return ngt::AnyBuffer(ngt::MemoryCopyTraits<T>::properties(obj));
+    }
+  }
+
+  // Return the memory regions of an object (mutable)
+  template <typename T>
+  std::vector<std::span<std::byte>> get_regions(T& obj) {
+    static_assert(ngt::HasRegions<T>);
+    return ngt::MemoryCopyTraits<T>::regions(obj);
+  }
+
+  // Return the memory regions of an object (const)
+  template <typename T>
+  std::vector<std::span<const std::byte>> get_regions(T const& obj) {
+    static_assert(ngt::HasRegions<T>);
+    return ngt::MemoryCopyTraits<T>::regions(obj);
+  }
+
+  // Call finalize() on an object, if MemoryCopyTraits<T> provides it
+  template <typename T>
+  void do_finalize(T& obj) {
+    if constexpr (ngt::HasTrivialCopyFinalize<T>) {
+      ngt::MemoryCopyTraits<T>::finalize(obj);
+    }
+  }
+
+}  // namespace ngt
+
+#endif  // HeterogeneousCore_TrivialSerialisation_interface_Common_h

--- a/HeterogeneousCore/TrivialSerialisation/interface/ReaderBase.h
+++ b/HeterogeneousCore/TrivialSerialisation/interface/ReaderBase.h
@@ -1,5 +1,5 @@
-#ifndef TrivialSerialisation_Common_interface_ReaderBase_h
-#define TrivialSerialisation_Common_interface_ReaderBase_h
+#ifndef HeterogeneousCore_TrivialSerialisation_interface_ReaderBase_h
+#define HeterogeneousCore_TrivialSerialisation_interface_ReaderBase_h
 
 #include <cstddef>
 #include <span>
@@ -10,6 +10,7 @@
 
 namespace ngt {
 
+  // Base class for reading the memory regions and properties of a serialised product.
   class ReaderBase {
   public:
     ReaderBase(const edm::WrapperBase* ptr) : ptr_(ptr) {}
@@ -25,4 +26,4 @@ namespace ngt {
 
 }  // namespace ngt
 
-#endif  // TrivialSerialisation_Common_interface_ReaderBase_h
+#endif  // HeterogeneousCore_TrivialSerialisation_interface_ReaderBase_h

--- a/HeterogeneousCore/TrivialSerialisation/interface/Serialiser.h
+++ b/HeterogeneousCore/TrivialSerialisation/interface/Serialiser.h
@@ -1,5 +1,5 @@
-#ifndef TrivialSerialisation_Common_interface_Serialiser_h
-#define TrivialSerialisation_Common_interface_Serialiser_h
+#ifndef HeterogeneousCore_TrivialSerialisation_interface_Serialiser_h
+#define HeterogeneousCore_TrivialSerialisation_interface_Serialiser_h
 
 #include <memory>
 
@@ -13,6 +13,7 @@
 
 namespace ngt {
 
+  // Concrete Serialiser for host products.  T is the bare product type (not wrapped).
   template <typename T>
   class Serialiser : public SerialiserBase {
   public:
@@ -26,4 +27,4 @@ namespace ngt {
 
 }  // namespace ngt
 
-#endif  // TrivialSerialisation_Common_interface_Serialiser_h
+#endif  // HeterogeneousCore_TrivialSerialisation_interface_Serialiser_h

--- a/HeterogeneousCore/TrivialSerialisation/interface/SerialiserBase.h
+++ b/HeterogeneousCore/TrivialSerialisation/interface/SerialiserBase.h
@@ -1,5 +1,5 @@
-#ifndef TrivialSerialisation_Common_interface_SerialiserBase_h
-#define TrivialSerialisation_Common_interface_SerialiserBase_h
+#ifndef HeterogeneousCore_TrivialSerialisation_interface_SerialiserBase_h
+#define HeterogeneousCore_TrivialSerialisation_interface_SerialiserBase_h
 
 #include <memory>
 
@@ -8,6 +8,8 @@
 #include "HeterogeneousCore/TrivialSerialisation/interface/WriterBase.h"
 
 namespace ngt {
+
+  // Abstract factory interface for creating Readers and Writers for host products.
   class SerialiserBase {
   public:
     virtual std::unique_ptr<WriterBase> writer() = 0;
@@ -17,4 +19,4 @@ namespace ngt {
   };
 }  // namespace ngt
 
-#endif  // TrivialSerialisation_Common_interface_SerialiserBase_h
+#endif  // HeterogeneousCore_TrivialSerialisation_interface_SerialiserBase_h

--- a/HeterogeneousCore/TrivialSerialisation/interface/SerialiserFactory.h
+++ b/HeterogeneousCore/TrivialSerialisation/interface/SerialiserFactory.h
@@ -1,16 +1,23 @@
-#ifndef TrivialSerialisation_src_SerialiserFactory_h
-#define TrivialSerialisation_src_SerialiserFactory_h
+#ifndef HeterogeneousCore_TrivialSerialisation_interface_SerialiserFactory_h
+#define HeterogeneousCore_TrivialSerialisation_interface_SerialiserFactory_h
 
-#include "HeterogeneousCore/TrivialSerialisation/interface/SerialiserBase.h"
-#include "HeterogeneousCore/TrivialSerialisation/interface/Serialiser.h"
 #include "FWCore/PluginManager/interface/PluginFactory.h"
+#include "FWCore/Utilities/interface/stringize.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/Serialiser.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/SerialiserBase.h"
 
 namespace ngt {
+  // Plugin factory for host-product Serialisers, keyed by typeid name.
   using SerialiserFactory = edmplugin::PluginFactory<SerialiserBase*()>;
-}
+}  // namespace ngt
 
-// Helper macro to define Serialiser plugins
-#define DEFINE_TRIVIAL_SERIALISER_PLUGIN(TYPE) \
-  DEFINE_EDM_PLUGIN(ngt::SerialiserFactory, ngt::Serialiser<TYPE>, typeid(TYPE).name())
+// Register a Serialiser plugin for a host product type.
+//
+// The plugin is registered under both the mangled typeid name and
+// EDM_STRINGIZE(TYPE). EDM_STRINGIZE(TYPE) is more human-readable, and thus
+// more suitable for Python configuration files.
+#define DEFINE_TRIVIAL_SERIALISER_PLUGIN(TYPE)                                           \
+  DEFINE_EDM_PLUGIN(ngt::SerialiserFactory, ngt::Serialiser<TYPE>, typeid(TYPE).name()); \
+  DEFINE_EDM_PLUGIN2(ngt::SerialiserFactory, ngt::Serialiser<TYPE>, EDM_STRINGIZE(TYPE))
 
-#endif  // TrivialSerialisation_src_SerialiserFactory_h
+#endif  // HeterogeneousCore_TrivialSerialisation_interface_SerialiserFactory_h

--- a/HeterogeneousCore/TrivialSerialisation/interface/Writer.h
+++ b/HeterogeneousCore/TrivialSerialisation/interface/Writer.h
@@ -1,5 +1,5 @@
-#ifndef TrivialSerialisation_Common_interface_Writer_h
-#define TrivialSerialisation_Common_interface_Writer_h
+#ifndef HeterogeneousCore_TrivialSerialisation_interface_Writer_h
+#define HeterogeneousCore_TrivialSerialisation_interface_Writer_h
 
 #include <cstddef>
 #include <span>
@@ -8,10 +8,12 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/TrivialSerialisation/interface/MemoryCopyTraits.h"
 #include "HeterogeneousCore/TrivialSerialisation/interface/AnyBuffer.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/Common.h"
 #include "HeterogeneousCore/TrivialSerialisation/interface/WriterBase.h"
 
 namespace ngt {
 
+  // Writer for host products: creates a Wrapper<T> and exposes its memory regions for writing.
   template <typename T>
   class Writer : public WriterBase {
     static_assert(ngt::HasMemoryCopyTraits<T>, "No specialization of MemoryCopyTraits found for type T");
@@ -28,39 +30,24 @@ namespace ngt {
       }
     }
 
-    ngt::AnyBuffer uninitialized_parameters() const override {
-      if constexpr (not ngt::HasTrivialCopyProperties<T>) {
-        // if ngt::MemoryCopyTraits<T>::properties(...) is not declared, do not call it.
-        return {};
-      } else {
-        // if ngt::MemoryCopyTraits<T>::properties(...) is declared, call it and wrap the result in an ngt::AnyBuffer
-        return ngt::AnyBuffer(ngt::MemoryCopyTraits<T>::properties(object()));
-      }
-    }
+    ngt::AnyBuffer uninitialized_parameters() const override { return ngt::get_properties<T>(object()); }
 
     void initialize(ngt::AnyBuffer const& args) override {
       if constexpr (not ngt::HasValidInitialize<T>) {
-        // If there is no valid initialize(), this shouldn't be present.
+        // if MemoryCopyTraits<T> has no valid initialize(), then the object must be
+        // default-constructible, and thus there is nothing to initialize. Just check
+        // that properties are not present, as they are not needed.
         static_assert(not ngt::HasTrivialCopyProperties<T>);
       } else if constexpr (not ngt::HasTrivialCopyProperties<T>) {
-        // If T has no TrivialCopyProperties, call initialize() without any additional arguments.
         ngt::MemoryCopyTraits<T>::initialize(object());
       } else {
-        // If T has TrivialCopyProperties, cast args to Properties and pass it as an additional argument to initialize().
         ngt::MemoryCopyTraits<T>::initialize(object(), args.cast_to<ngt::TrivialCopyProperties<T>>());
       }
     }
 
-    std::vector<std::span<std::byte>> regions() override {
-      static_assert(ngt::HasRegions<T>);
-      return ngt::MemoryCopyTraits<T>::regions(object());
-    }
+    std::vector<std::span<std::byte>> regions() override { return ngt::get_regions<T>(object()); }
 
-    void finalize() override {
-      if constexpr (ngt::HasTrivialCopyFinalize<T>) {
-        ngt::MemoryCopyTraits<T>::finalize(object());
-      }
-    }
+    void finalize() override { ngt::do_finalize<T>(object()); }
 
   private:
     const T& object() const { return static_cast<const WrapperType*>(ptr_.get())->bareProduct(); }
@@ -70,4 +57,4 @@ namespace ngt {
 
 }  // namespace ngt
 
-#endif  // TrivialSerialisation_Common_interface_Writer_h
+#endif  // HeterogeneousCore_TrivialSerialisation_interface_Writer_h

--- a/HeterogeneousCore/TrivialSerialisation/interface/WriterBase.h
+++ b/HeterogeneousCore/TrivialSerialisation/interface/WriterBase.h
@@ -1,5 +1,5 @@
-#ifndef TrivialSerialisation_Common_interface_WriterBase_h
-#define TrivialSerialisation_Common_interface_WriterBase_h
+#ifndef HeterogeneousCore_TrivialSerialisation_interface_WriterBase_h
+#define HeterogeneousCore_TrivialSerialisation_interface_WriterBase_h
 
 #include <cstddef>
 #include <span>
@@ -10,6 +10,7 @@
 
 namespace ngt {
 
+  // Base class for creating a new product and exposing its memory regions for writing.
   class WriterBase {
   public:
     WriterBase() = default;
@@ -28,4 +29,4 @@ namespace ngt {
 
 }  // namespace ngt
 
-#endif  // TrivialSerialisation_Common_interface_WriterBase_h
+#endif  // HeterogeneousCore_TrivialSerialisation_interface_WriterBase_h

--- a/HeterogeneousCore/TrivialSerialisation/interface/alpaka/Reader.h
+++ b/HeterogeneousCore/TrivialSerialisation/interface/alpaka/Reader.h
@@ -1,0 +1,41 @@
+#ifndef HeterogeneousCore_TrivialSerialisation_interface_alpaka_Reader_h
+#define HeterogeneousCore_TrivialSerialisation_interface_alpaka_Reader_h
+
+#include <cstddef>
+#include <span>
+#include <vector>
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/TrivialSerialisation/interface/MemoryCopyTraits.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/AnyBuffer.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/Common.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/ReaderBase.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt {
+
+  // Reader for device products.
+  template <typename T>
+  class Reader : public ::ngt::ReaderBase {
+    static_assert(::ngt::HasMemoryCopyTraits<T>, "No specialization of MemoryCopyTraits found for type T");
+
+  public:
+    using WrapperType = edm::Wrapper<T>;
+
+    // Constructor from Wrapper<T>
+    explicit Reader(WrapperType const& wrapper) : ::ngt::ReaderBase(&wrapper), productPtr_(&wrapper.bareProduct()) {}
+
+    // Constructor from T const& directly.
+    explicit Reader(T const& product) : ::ngt::ReaderBase(nullptr), productPtr_(&product) {}
+
+    ::ngt::AnyBuffer parameters() const override { return ::ngt::get_properties<T>(*productPtr_); }
+
+    std::vector<std::span<const std::byte>> regions() const override { return ::ngt::get_regions<T>(*productPtr_); }
+
+  private:
+    T const* productPtr_;
+  };
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt
+
+#endif  // HeterogeneousCore_TrivialSerialisation_interface_alpaka_Reader_h

--- a/HeterogeneousCore/TrivialSerialisation/interface/alpaka/ReaderBase.h
+++ b/HeterogeneousCore/TrivialSerialisation/interface/alpaka/ReaderBase.h
@@ -1,0 +1,14 @@
+#ifndef HeterogeneousCore_TrivialSerialisation_interface_alpaka_ReaderBase_h
+#define HeterogeneousCore_TrivialSerialisation_interface_alpaka_ReaderBase_h
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/ReaderBase.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt {
+
+  // The alpaka ReaderBase is the same as the host one.
+  using ReaderBase = ::ngt::ReaderBase;
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt
+
+#endif  // HeterogeneousCore_TrivialSerialisation_interface_alpaka_ReaderBase_h

--- a/HeterogeneousCore/TrivialSerialisation/interface/alpaka/Serialiser.h
+++ b/HeterogeneousCore/TrivialSerialisation/interface/alpaka/Serialiser.h
@@ -1,0 +1,41 @@
+#ifndef HeterogeneousCore_TrivialSerialisation_interface_alpaka_Serialiser_h
+#define HeterogeneousCore_TrivialSerialisation_interface_alpaka_Serialiser_h
+
+#include <memory>
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Common/interface/WrapperBase.h"
+#include "DataFormats/AlpakaCommon/interface/alpaka/DeviceProductType.h"
+#include "DataFormats/AlpakaCommon/interface/alpaka/EDMetadata.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/alpaka/Reader.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserBase.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/alpaka/Writer.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt {
+
+  // Concrete Serialiser for device products.
+  // T is the inner product type (e.g. PortableDeviceCollection<...>).
+  template <typename T>
+  class Serialiser : public SerialiserBase {
+  public:
+    using WrapperType = edm::Wrapper<detail::DeviceProductType<T>>;
+
+    std::unique_ptr<WriterBase> writer() override { return std::make_unique<Writer<T>>(); }
+
+    std::unique_ptr<const ReaderBase> reader(edm::WrapperBase const& wrapper,
+                                             EDMetadata& metadata,
+                                             bool tryReuseQueue) override {
+      WrapperType const& w = dynamic_cast<WrapperType const&>(wrapper);
+      if constexpr (detail::useProductDirectly) {
+        return std::make_unique<Reader<T>>(w.bareProduct());
+      } else {
+        return std::make_unique<Reader<T>>(
+            w.bareProduct().template getSynchronized<EDMetadata>(metadata, tryReuseQueue));
+      }
+    }
+  };
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt
+
+#endif  // HeterogeneousCore_TrivialSerialisation_interface_alpaka_Serialiser_h

--- a/HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserBase.h
+++ b/HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserBase.h
@@ -1,0 +1,26 @@
+#ifndef HeterogeneousCore_TrivialSerialisation_interface_alpaka_SerialiserBase_h
+#define HeterogeneousCore_TrivialSerialisation_interface_alpaka_SerialiserBase_h
+
+#include <memory>
+
+#include "DataFormats/Common/interface/WrapperBase.h"
+#include "DataFormats/AlpakaCommon/interface/alpaka/EDMetadata.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/alpaka/ReaderBase.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/alpaka/WriterBase.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt {
+
+  // Abstract interface for creating Readers and Writers for device products.
+  class SerialiserBase {
+  public:
+    virtual std::unique_ptr<WriterBase> writer() = 0;
+    virtual std::unique_ptr<const ReaderBase> reader(const edm::WrapperBase& wrapper,
+                                                     EDMetadata& metadata,
+                                                     bool tryReuseQueue) = 0;
+
+    virtual ~SerialiserBase() = default;
+  };
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt
+
+#endif  // HeterogeneousCore_TrivialSerialisation_interface_alpaka_SerialiserBase_h

--- a/HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserFactoryDevice.h
+++ b/HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserFactoryDevice.h
@@ -1,0 +1,30 @@
+#ifndef HeterogeneousCore_TrivialSerialisation_interface_alpaka_SerialiserFactoryDevice_h
+#define HeterogeneousCore_TrivialSerialisation_interface_alpaka_SerialiserFactoryDevice_h
+
+#include "DataFormats/Common/interface/DeviceProduct.h"
+#include "FWCore/PluginManager/interface/PluginFactory.h"
+#include "FWCore/Utilities/interface/stringize.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/alpaka/Serialiser.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserBase.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt {
+  using SerialiserFactoryDevice = edmplugin::PluginFactory<SerialiserBase*()>;
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt
+
+// Helper macro to define Serialiser plugins.
+//
+// TYPE is the inner product type (e.g. PortableDeviceCollection<...>), not
+// wrapped in DeviceProduct, and without ALPAKA_ACCELERATOR_NAMESPACE:: attached
+// to it (it is attached here). The plugin is registered under both the mangled
+// typeid name and EDM_STRINGIZE(TYPE). EDM_STRINGIZE(TYPE) is more
+// human-readable, and thus more suitable for Python configuration files.
+#define DEFINE_TRIVIAL_SERIALISER_PLUGIN_DEVICE(TYPE)                                                   \
+  DEFINE_EDM_PLUGIN(ALPAKA_ACCELERATOR_NAMESPACE::ngt::SerialiserFactoryDevice,                         \
+                    ALPAKA_ACCELERATOR_NAMESPACE::ngt::Serialiser<ALPAKA_ACCELERATOR_NAMESPACE::TYPE>,  \
+                    typeid(edm::DeviceProduct<ALPAKA_ACCELERATOR_NAMESPACE::TYPE>).name());             \
+  DEFINE_EDM_PLUGIN2(ALPAKA_ACCELERATOR_NAMESPACE::ngt::SerialiserFactoryDevice,                        \
+                     ALPAKA_ACCELERATOR_NAMESPACE::ngt::Serialiser<ALPAKA_ACCELERATOR_NAMESPACE::TYPE>, \
+                     EDM_STRINGIZE(TYPE))
+
+#endif  // HeterogeneousCore_TrivialSerialisation_interface_alpaka_SerialiserFactoryDevice_h

--- a/HeterogeneousCore/TrivialSerialisation/interface/alpaka/Writer.h
+++ b/HeterogeneousCore/TrivialSerialisation/interface/alpaka/Writer.h
@@ -1,0 +1,84 @@
+#ifndef HeterogeneousCore_TrivialSerialisation_interface_alpaka_Writer_h
+#define HeterogeneousCore_TrivialSerialisation_interface_alpaka_Writer_h
+
+#include <cstddef>
+#include <memory>
+#include <span>
+#include <vector>
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/TrivialSerialisation/interface/MemoryCopyTraits.h"
+#include "DataFormats/AlpakaCommon/interface/alpaka/DeviceProductType.h"
+#include "DataFormats/AlpakaCommon/interface/alpaka/EDMetadata.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/AnyBuffer.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/Common.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/alpaka/WriterBase.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt {
+
+  // Writer for device products.
+  // T is the inner product type (e.g. PortableDeviceCollection<...>)
+  template <typename T>
+  class Writer : public WriterBase {
+    static_assert(::ngt::HasMemoryCopyTraits<T>, "No specialization of MemoryCopyTraits found for type T");
+
+  public:
+    using WrapperType = edm::Wrapper<detail::DeviceProductType<T>>;
+
+    Writer() : WriterBase(), data_{construct_()} {}
+
+    ::ngt::AnyBuffer uninitialized_parameters() const override { return ::ngt::get_properties<T>(object()); }
+
+    void initialize(Queue& queue, ::ngt::AnyBuffer const& args) override {
+      using Traits = ::ngt::MemoryCopyTraits<T>;
+      if constexpr (::ngt::HasTrivialCopyProperties<T>) {
+        // properties are required to initialize an object of type T
+        using Props = ::ngt::TrivialCopyProperties<T>;
+        static_assert(
+            requires(T& o, Queue& q, Props p) { Traits::initialize(q, o, p); },
+            "MemoryCopyTraits<T> has properties but no initialize(Queue&, T&, Properties const&)");
+        Traits::initialize(queue, object(), args.cast_to<Props>());
+      } else {
+        // No properties are required to initialize an object of type T
+        static_assert(
+            requires(T& o, Queue& q) { Traits::initialize(q, o); },
+            "MemoryCopyTraits<T> has no properties but no initialize(Queue&, T&)");
+        Traits::initialize(queue, object());
+      }
+    }
+
+    std::vector<std::span<std::byte>> regions() override { return ::ngt::get_regions<T>(object()); }
+
+    void finalize() override { ::ngt::do_finalize<T>(object()); }
+
+    std::unique_ptr<edm::WrapperBase> get(std::shared_ptr<EDMetadata> metadata) override {
+      if constexpr (detail::useProductDirectly) {
+        return std::make_unique<WrapperType>(edm::WrapperBase::Emplace{}, std::move(data_));
+      } else {
+        // metadata is needed to construct edm::DeviceProduct<T>
+        return std::make_unique<WrapperType>(edm::WrapperBase::Emplace{}, std::move(metadata), std::move(data_));
+      }
+    }
+
+    // Extract the product T directly by move.
+    T takeProduct() { return std::move(data_); }
+
+  private:
+    static T construct_() {
+      if constexpr (requires { T(); }) {
+        return T{};
+      } else {
+        return T{edm::kUninitialized};
+      }
+    }
+
+    T const& object() const { return data_; }
+    T& object() { return data_; }
+
+    T data_;
+  };
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt
+
+#endif  // HeterogeneousCore_TrivialSerialisation_interface_alpaka_Writer_h

--- a/HeterogeneousCore/TrivialSerialisation/interface/alpaka/WriterBase.h
+++ b/HeterogeneousCore/TrivialSerialisation/interface/alpaka/WriterBase.h
@@ -1,0 +1,32 @@
+#ifndef HeterogeneousCore_TrivialSerialisation_interface_alpaka_WriterBase_h
+#define HeterogeneousCore_TrivialSerialisation_interface_alpaka_WriterBase_h
+
+#include <cstddef>
+#include <memory>
+#include <span>
+#include <vector>
+
+#include "DataFormats/Common/interface/WrapperBase.h"
+#include "DataFormats/AlpakaCommon/interface/alpaka/EDMetadata.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/AnyBuffer.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt {
+
+  // Base class for creating a new device product and exposing its memory regions for writing
+  class WriterBase {
+  public:
+    WriterBase() = default;
+    virtual ~WriterBase() = default;
+
+    virtual void initialize(Queue& queue, ::ngt::AnyBuffer const& args) = 0;
+    virtual ::ngt::AnyBuffer uninitialized_parameters() const = 0;
+    virtual std::vector<std::span<std::byte>> regions() = 0;
+    virtual void finalize() = 0;
+
+    virtual std::unique_ptr<edm::WrapperBase> get(std::shared_ptr<EDMetadata> metadata) = 0;
+  };
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt
+
+#endif  // HeterogeneousCore_TrivialSerialisation_interface_alpaka_WriterBase_h

--- a/HeterogeneousCore/TrivialSerialisation/src/alpaka/SerialiserFactoryDevice.cc
+++ b/HeterogeneousCore/TrivialSerialisation/src/alpaka/SerialiserFactoryDevice.cc
@@ -1,0 +1,4 @@
+#include "HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserFactoryDevice.h"
+
+EDM_REGISTER_PLUGINFACTORY(ALPAKA_ACCELERATOR_NAMESPACE::ngt::SerialiserFactoryDevice,
+                           "SerialiserFactoryDevice " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE));

--- a/HeterogeneousCore/TrivialSerialisation/test/BuildFile.xml
+++ b/HeterogeneousCore/TrivialSerialisation/test/BuildFile.xml
@@ -8,3 +8,19 @@
 
 <test name="TestHeterogeneousCoreTrivialSerialisationGenericCloner" command="cmsRun ${LOCALTOP}/src/HeterogeneousCore/TrivialSerialisation/test/testGenericCloner_cfg.py"/>
 <test name="TestHeterogeneousCoreTrivialSerialisationGenericClonerHost" command="cmsRun ${LOCALTOP}/src/HeterogeneousCore/TrivialSerialisation/test/testGenericClonerHost_cfg.py"/>
+<test name="TestHeterogeneousCoreTrivialSerialisationGenericClonerPortable" command="cmsRun ${LOCALTOP}/src/HeterogeneousCore/TrivialSerialisation/test/testGenericClonerPortable_cfg.py"/>
+
+<bin name="TestHeterogeneousCoreTrivialSerialisationPortable" file="alpaka/test_catch2_*.cc,alpaka/test_catch2_*.dev.cc">
+  <use name="alpaka"/>
+  <use name="catch2"/>
+  <use name="DataFormats/AlpakaCommon"/>
+  <use name="DataFormats/Common"/>
+  <use name="DataFormats/Portable"/>
+  <use name="DataFormats/PortableTestObjects"/>
+  <use name="DataFormats/TrivialSerialisation"/>
+  <use name="Eigen"/>
+  <use name="FWCore/PluginManager"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="HeterogeneousCore/TrivialSerialisation"/>
+  <flags ALPAKA_BACKENDS="1"/>
+</bin>

--- a/HeterogeneousCore/TrivialSerialisation/test/alpaka/test_catch2_main.cc
+++ b/HeterogeneousCore/TrivialSerialisation/test/alpaka/test_catch2_main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_all.hpp>

--- a/HeterogeneousCore/TrivialSerialisation/test/alpaka/test_catch2_portableCollectionsSerialiserPluginFactory.dev.cc
+++ b/HeterogeneousCore/TrivialSerialisation/test/alpaka/test_catch2_portableCollectionsSerialiserPluginFactory.dev.cc
@@ -1,0 +1,340 @@
+#include <alpaka/alpaka.hpp>
+#include <catch2/catch_all.hpp>
+#include <Eigen/Dense>
+
+#include "DataFormats/Common/interface/DeviceProduct.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Portable/interface/PortableCollection.h"
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/Portable/interface/PortableHostObject.h"
+#include "DataFormats/PortableTestObjects/interface/TestSoA.h"
+#include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"
+#include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceObject.h"
+#include "DataFormats/TrivialSerialisation/interface/MemoryCopyTraits.h"
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "DataFormats/AlpakaCommon/interface/alpaka/EDMetadata.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserFactoryDevice.h"
+
+using namespace ALPAKA_ACCELERATOR_NAMESPACE;
+namespace alpaka_portable_test = ALPAKA_ACCELERATOR_NAMESPACE::portabletest;
+namespace alpaka_ngt = ALPAKA_ACCELERATOR_NAMESPACE::ngt;
+
+/*
+ * This test demonstrates a way to use the TrivialSerialisation mechanism to copy
+ * portable types (PortableCollections, PortableObjects, and multi-block
+ * collections) of which only the runtime type information is known.
+ *
+ * For each type, the test performs the following steps:
+ * - Create a portable type and initialize it with some data, wrapped in
+ *   DeviceProductType.
+ * - Wrap it in edm::Wrapper and cast to WrapperBase* to hide the concrete type.
+ * - Use the SerialiserFactory plugin to obtain a type-erased reader and writer.
+ * - Copy the memory regions from the reader into the writer.
+ * - Retrieve the cloned product and verify its contents match the original.
+ *
+ * Tested types: single-block PortableCollection, PortableObject, 2-block and
+ * 3-block PortableCollections.
+ */
+
+namespace test {
+
+  // helper to create a dummy EDMetadata object for the purpose of these tests.
+  std::shared_ptr<EDMetadata> makeMetadata(Device const& device) {
+    if constexpr (detail::useProductDirectly) {
+      return std::make_shared<EDMetadata>(std::make_shared<Queue>(device));
+    } else {
+      return std::make_shared<EDMetadata>(std::make_shared<Queue>(device), std::make_shared<Event>(device));
+    }
+  }
+
+  // helper to wrap a product in edm::Wrapper<detail::DeviceProductType<T>>.
+  template <typename T>
+  edm::Wrapper<detail::DeviceProductType<T>> wrapProduct(T&& product, std::shared_ptr<EDMetadata> metadata) {
+    if constexpr (detail::useProductDirectly) {
+      return edm::Wrapper<detail::DeviceProductType<T>>(edm::WrapperBase::Emplace{}, std::move(product));
+    } else {
+      // asynchronous backends, edm::DeviceProduct<T>'s constructor takes a
+      // metadata object
+      return edm::Wrapper<detail::DeviceProductType<T>>(
+          edm::WrapperBase::Emplace{}, std::move(metadata), std::move(product));
+    }
+  }
+
+  // helper to unwrap a product of type "T" from an
+  // edm::Wrapper<detail::DeviceProductType<T>>
+  template <typename WrapperType>
+  auto const& extractProductFromEdmWrapper(WrapperType const& wrapper, EDMetadata& metadata) {
+    if constexpr (detail::useProductDirectly) {
+      // synchronous backends, WrapperType is edm::Wrapper<T>
+      return wrapper.bareProduct();
+    } else {
+      // asynchronous backends, WrapperType is edm::Wrapper<edm::DeviceProduct<T>>
+      return wrapper.bareProduct().template getSynchronized<EDMetadata>(metadata, true);
+    }
+  }
+}  // namespace test
+
+TEST_CASE("Test MemoryCopyTraits", "[MemoryCopyTraits]") {
+  if (not edmplugin::PluginManager::isAvailable())
+    edmplugin::PluginManager::configure(edmplugin::standard::config());
+
+  auto const& devices = cms::alpakatools::devices<Platform>();
+  if (devices.empty()) {
+    FAIL("No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend");
+  }
+
+  SECTION("PortableCollection<Device, ALPAKA_ACCELERATOR_NAMESPACE::portabletest::TestSoALayout<128, false>>") {
+    using PortableCollectionType = ::PortableCollection<Device, alpaka_portable_test::TestSoALayout<128, false>>;
+    using DeviceProductType = detail::DeviceProductType<PortableCollectionType>;
+    using PortableHostCollectionType = PortableHostCollection<alpaka_portable_test::TestSoALayout<128, false>>;
+    const int size = 10;
+
+    for (auto const& device : devices) {
+      std::cout << "Running on " << alpaka::getName(device) << std::endl;
+      Queue queue(device);
+
+      // Create a PortableHostCollection, to be used as a reference for the checks
+      PortableHostCollectionType refHostCollection(queue, size);
+
+      // Initialize it with some data
+      refHostCollection.view().r() = 3.14;
+      for (int i = 0; i < size; i++) {
+        refHostCollection.view()[i].x() = i * size + 1;
+        refHostCollection.view()[i].y() = i * size + 2;
+        refHostCollection.view()[i].z() = i * size + 3;
+        refHostCollection.view()[i].id() = i;
+        refHostCollection.view()[i].flags() = std::array<short, 4>{
+            {static_cast<short>(i), static_cast<short>(i + 1), static_cast<short>(i + 2), static_cast<short>(i + 3)}};
+        refHostCollection.view()[i].m = Eigen::Matrix<double, 3, 6>::Identity() * i;
+      }
+
+      // Function to validate a PortableCollection whose contents should be
+      // identical to the reference Host collection above
+      auto checkPortableCollection = [&queue, &refHostCollection](PortableCollectionType const& col) {
+        // Since PortableCollection might be a device collection, copy first its
+        // data into an auxiliary PortableHostCollection
+        PortableHostCollectionType auxPortableHostCollection(queue, size);
+        alpaka::memcpy(queue, auxPortableHostCollection.buffer(), col.buffer());
+        alpaka::wait(queue);
+
+        REQUIRE(auxPortableHostCollection.const_view().r() == refHostCollection.const_view().r());
+        for (int i = 0; i < size; i++) {
+          REQUIRE(auxPortableHostCollection.const_view()[i].x() == refHostCollection.const_view()[i].x());
+          REQUIRE(auxPortableHostCollection.const_view()[i].y() == refHostCollection.const_view()[i].y());
+          REQUIRE(auxPortableHostCollection.const_view()[i].z() == refHostCollection.const_view()[i].z());
+          REQUIRE(auxPortableHostCollection.const_view()[i].id() == refHostCollection.const_view()[i].id());
+          REQUIRE(auxPortableHostCollection.const_view()[i].flags() == refHostCollection.const_view()[i].flags());
+          REQUIRE(auxPortableHostCollection.const_view()[i].m() == refHostCollection.const_view()[i].m());
+        }
+      };
+
+      // Create a PortableCollection
+      PortableCollectionType sourceCollection(queue, size);
+
+      // Copy the reference host collection into this newly created one
+      alpaka::memcpy(queue, sourceCollection.buffer(), refHostCollection.buffer());
+
+      // Check that the collection has been successfully initialized.
+      checkPortableCollection(sourceCollection);
+
+      // Wrap it in edm::Wrapper
+      auto metadata = test::makeMetadata(device);
+      auto wrapper_original = test::wrapProduct<PortableCollectionType>(std::move(sourceCollection), metadata);
+
+      // Now cast the wrapper to edm::WrapperBase, hiding the underlying collection type
+      edm::WrapperBase const* wb_original = static_cast<const edm::WrapperBase*>(&wrapper_original);
+
+      // Check that a specialization of MemoryCopyTraits exists for this type
+      static_assert(::ngt::HasMemoryCopyTraits<PortableCollectionType>);
+
+      // Get the Serialiser plugin for this type
+      std::string typeName = typeid(edm::DeviceProduct<PortableCollectionType>).name();
+      std::unique_ptr<alpaka_ngt::SerialiserBase> serialiserSource{
+          alpaka_ngt::SerialiserFactoryDevice::get()->create(typeName)};
+
+      // Create a "reader" and a "writer", then clone via memory regions
+      auto reader = serialiserSource->reader(*wb_original, *metadata, true);
+      auto writer = serialiserSource->writer();
+
+      writer->initialize(queue, reader->parameters());
+
+      // Get memory regions
+      auto targets = writer->regions();
+      auto sources = reader->regions();
+
+      // Check that reader and writer have the same number of memory regions. In
+      // the case of a PortableCollection this should be equal to one.
+      REQUIRE(sources.size() == targets.size());
+
+      // copy each region from the source to the clone
+      for (size_t i = 0; i < sources.size(); ++i) {
+        REQUIRE(sources[i].data() != nullptr);
+        REQUIRE(targets[i].data() != nullptr);
+        REQUIRE(targets[i].size_bytes() == sources[i].size_bytes());
+
+        auto src_view = alpaka::createView(device, sources[i].data(), sources[i].size_bytes());
+        auto trg_view = alpaka::createView(device, targets[i].data(), targets[i].size_bytes());
+
+        alpaka::memcpy(queue, trg_view, src_view);
+      }
+
+      // Retrieve the cloned product back from its type-erased form, and verify its contents
+      std::unique_ptr<edm::WrapperBase> clonebase = writer->get(metadata);
+      edm::Wrapper<DeviceProductType>* cloneptr = dynamic_cast<edm::Wrapper<DeviceProductType>*>(clonebase.get());
+      checkPortableCollection(test::extractProductFromEdmWrapper(*cloneptr, *metadata));
+    }
+  }
+
+  SECTION("DeviceProduct<PortableDeviceObject>") {
+    using DeviceObjectType = alpaka_portable_test::TestDeviceObject;
+    using DeviceProductType = detail::DeviceProductType<DeviceObjectType>;
+    const alpaka_portable_test::TestStruct testData{5.0, 12.0, 13.0, 42};
+
+    for (auto const& device : devices) {
+      std::cout << "Running DeviceObject test on " << alpaka::getName(device) << std::endl;
+      Queue queue(device);
+
+      // Create a reference host object with known data
+      PortableHostObject<alpaka_portable_test::TestStruct> hostSource(queue);
+      hostSource->x = testData.x;
+      hostSource->y = testData.y;
+      hostSource->z = testData.z;
+      hostSource->id = testData.id;
+
+      // Create a DeviceObject, copy the reference host object into it,
+      DeviceObjectType sourceObject(queue);
+      alpaka::memcpy(queue, sourceObject.buffer(), hostSource.buffer());
+
+      // Wrap it in the WrapperBase (type-erased)
+      auto metadata = test::makeMetadata(device);
+      auto wrapper = test::wrapProduct<DeviceObjectType>(std::move(sourceObject), metadata);
+      edm::WrapperBase const* wb = static_cast<const edm::WrapperBase*>(&wrapper);
+
+      // Get the serialiser plugin
+      std::string typeName = typeid(edm::DeviceProduct<DeviceObjectType>).name();
+      std::unique_ptr<alpaka_ngt::SerialiserBase> serialiser{
+          alpaka_ngt::SerialiserFactoryDevice::get()->create(typeName)};
+      REQUIRE(serialiser);
+
+      // Read and write
+      auto reader = serialiser->reader(*wb, *metadata, true);
+      auto writer = serialiser->writer();
+
+      writer->initialize(queue, reader->parameters());
+
+      auto targets = writer->regions();
+      auto sources = reader->regions();
+      REQUIRE(sources.size() == targets.size());
+
+      for (size_t i = 0; i < sources.size(); ++i) {
+        REQUIRE(sources[i].size_bytes() == targets[i].size_bytes());
+        auto src_view = alpaka::createView(device, sources[i].data(), sources[i].size_bytes());
+        auto trg_view = alpaka::createView(device, targets[i].data(), targets[i].size_bytes());
+        alpaka::memcpy(queue, trg_view, src_view);
+      }
+
+      // Get the collection back from its wrapped form
+      std::unique_ptr<edm::WrapperBase> clonebase = writer->get(metadata);
+      auto* cloneptr = dynamic_cast<edm::Wrapper<DeviceProductType>*>(clonebase.get());
+      REQUIRE(cloneptr);
+
+      // Copy back to host to check
+      PortableHostObject<alpaka_portable_test::TestStruct> hostClone(queue);
+      alpaka::memcpy(queue, hostClone.buffer(), test::extractProductFromEdmWrapper(*cloneptr, *metadata).buffer());
+      alpaka::wait(queue);
+
+      REQUIRE(hostClone->x == testData.x);
+      REQUIRE(hostClone->y == testData.y);
+      REQUIRE(hostClone->z == testData.z);
+      REQUIRE(hostClone->id == testData.id);
+    }
+  }
+
+  SECTION("DeviceProduct<PortableDeviceCollection2>") {
+    using DeviceCollection2Type = alpaka_portable_test::TestDeviceCollection2;
+    using DeviceProductType = detail::DeviceProductType<DeviceCollection2Type>;
+    using HostCollection2Type = PortableHostCollection<alpaka_portable_test::TestSoABlocks2>;
+    const int size1 = 7;
+    const int size2 = 11;
+
+    for (auto const& device : devices) {
+      std::cout << "Running DeviceCollection2 test on " << alpaka::getName(device) << std::endl;
+      Queue queue(device);
+
+      // Create reference data on host
+      HostCollection2Type refHost(queue, size1, size2);
+      refHost.view().first().r() = 1.11;
+      refHost.view().second().r2() = 2.22;
+      for (int i = 0; i < size1; i++) {
+        refHost.view().first()[i].x() = i * 10.0;
+        refHost.view().first()[i].y() = 0.0;
+        refHost.view().first()[i].z() = 0.0;
+        refHost.view().first()[i].id() = i;
+        refHost.view().first()[i].flags() = std::array<short, 4>{{0, 0, 0, 0}};
+        refHost.view().first()[i].m = Eigen::Matrix<double, 3, 6>::Zero();
+      }
+      for (int i = 0; i < size2; i++) {
+        refHost.view().second()[i].x2() = i * 20.0;
+        refHost.view().second()[i].y2() = 0.0;
+        refHost.view().second()[i].z2() = 0.0;
+        refHost.view().second()[i].id2() = i + 100;
+        refHost.view().second()[i].m2 = Eigen::Matrix<double, 3, 6>::Zero();
+      }
+
+      // Create DeviceCollection2, fill it, and wrap in DeviceProduct
+      DeviceCollection2Type sourceCollection(queue, size1, size2);
+      alpaka::memcpy(queue, sourceCollection.buffer(), refHost.buffer());
+
+      // Wrap it and cast to WrapperBase
+      auto metadata = test::makeMetadata(device);
+      auto wrapper = test::wrapProduct<DeviceCollection2Type>(std::move(sourceCollection), metadata);
+      edm::WrapperBase const* wb = static_cast<const edm::WrapperBase*>(&wrapper);
+
+      // Get the serialiser plugin
+      std::string typeName = typeid(edm::DeviceProduct<DeviceCollection2Type>).name();
+      std::unique_ptr<alpaka_ngt::SerialiserBase> serialiser{
+          alpaka_ngt::SerialiserFactoryDevice::get()->create(typeName)};
+      REQUIRE(serialiser);
+
+      // Read and write
+      auto reader = serialiser->reader(*wb, *metadata, true);
+      auto writer = serialiser->writer();
+
+      writer->initialize(queue, reader->parameters());
+
+      auto targets = writer->regions();
+      auto sources_r = reader->regions();
+      REQUIRE(sources_r.size() == targets.size());
+
+      for (size_t i = 0; i < sources_r.size(); ++i) {
+        REQUIRE(sources_r[i].size_bytes() == targets[i].size_bytes());
+        auto src_view = alpaka::createView(device, sources_r[i].data(), sources_r[i].size_bytes());
+        auto trg_view = alpaka::createView(device, targets[i].data(), targets[i].size_bytes());
+        alpaka::memcpy(queue, trg_view, src_view);
+      }
+
+      // Get the clone
+      std::unique_ptr<edm::WrapperBase> clonebase = writer->get(metadata);
+      auto* cloneptr = dynamic_cast<edm::Wrapper<DeviceProductType>*>(clonebase.get());
+      REQUIRE(cloneptr);
+
+      // Copy back to host and check
+      HostCollection2Type verifyHost(queue, size1, size2);
+      alpaka::memcpy(queue, verifyHost.buffer(), test::extractProductFromEdmWrapper(*cloneptr, *metadata).buffer());
+      alpaka::wait(queue);
+
+      REQUIRE(verifyHost.const_view().first().r() == 1.11);
+      REQUIRE(verifyHost.const_view().second().r2() == 2.22);
+      for (int i = 0; i < size1; i++) {
+        REQUIRE(verifyHost.const_view().first()[i].x() == i * 10.0);
+        REQUIRE(verifyHost.const_view().first()[i].id() == i);
+      }
+      for (int i = 0; i < size2; i++) {
+        REQUIRE(verifyHost.const_view().second()[i].x2() == i * 20.0);
+        REQUIRE(verifyHost.const_view().second()[i].id2() == i + 100);
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### PR description:

This adds support for device products to the serialisation mechanism under `HeterogeneousCore/TrivialSerialisation`.

It implements an alpaka Plugin Factory under `HeterogeneousCore/TrivialSerialisation/interface/alpaka/` similar to the existing host one. Some of the features of this new Plugin Factory are:

- There is one factory per backend. This is to prevent the "multiple definitions of plugin X found in different files" error when two `.so` files define the same plugin from the same factory, for separate backends. The factory registration is as follows:
```cpp
EDM_REGISTER_PLUGINFACTORY(ALPAKA_ACCELERATOR_NAMESPACE::ngt::SerialiserFactoryPortable,
                           "SerialiserFactoryPortable@" EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE));
```

- Plugins for device collections are registered via the `DEFINE_TRIVIAL_SERIALISER_PLUGIN_DEVICE(TYPE)` macro, where `TYPE` is the inner product type (e.g. PortableDeviceCollection<...>), not wrapped in DeviceProduct. The plugins are registered under both the mangled typeid name and EDM_STRINGIZE(TYPE). EDM_STRINGIZE(TYPE) is more human-readable, and thus more suitable for Python configuration files.
  
For example, a plugin might be registered as follows:
```cpp
DEFINE_TRIVIAL_SERIALISER_PLUGIN_DEVICE(hcal::RecHitDeviceCollection);
```
and then referred to from a configuration:
```python
    products = cms.VPSet(
    cms.PSet(
        type = cms.string("hcal::RecHitDeviceCollection"),
        ...
```

This feature is also added to the existing non-alpaka serialiser plugin factory.

This PR also adds plugin definitions for various types in DataFormats.

#### PR validation:

The following tests are included in the PR:

- `DataFormats/TrivialSerialisation/test/alpaka/test_catch2_MemoryCopyTraitsPortable.dev.cc`
- `HeterogeneousCore/TrivialSerialisation/test/alpaka/test_catch2_portableCollectionsSerialiserPluginFactory.dev.cc`

A description of the tests are included at the top of each file.
All tests pass.