### PR TITLE
Phase-2 CRACK DQM: Crack overview and edit crack ranges

### DIFF
--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
@@ -260,7 +260,7 @@ void Phase2OTMonitorCluster::bookHistograms(DQMStore::IBooker& ibooker,
       }
     }
     crackOverview_->getTH2Poly()->SetStats(false);
-    crackOverview_->setOption("z");
+    crackOverview_->setOption("z0");
 
   } else
     crackOverview_ = nullptr;

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
@@ -183,6 +183,9 @@ void Phase2OTMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventS
       if (mType == TrackerGeometry::ModuleType::Ph2SS) {
         if (detId.subdetId() == SiStripSubdetector::TOB) {
           unsigned int module = tTopo_->module(rawid);
+          // CRACK is viewed from behind, so to align plots with what is seen in real life, modules are flipped
+          if (crackOverview_)
+            module = std::abs(int(module - 13));
           //If column is on the bottom of the sensor, *-1 to distinguish it from top
           int topOrBottomColumn = (tTopo_->isLower(rawid) ? (clusterItr.column() + 1) * -1 : (clusterItr.column() + 1));
           if (module < local_mes.PositionOfClusters_2S.size() && local_mes.PositionOfClusters_2S[module]) {
@@ -195,7 +198,7 @@ void Phase2OTMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventS
             local_mes.PositionOfClusters_2SLadder[ladder]->Fill(signedModule, topOrBottomColumn);
           }
           if (crackOverview_)
-            crackOverview_->Fill(module, tTopo_->getOTLayerNumber(rawid) - 0.05 + (module % 2 * 0.1));
+            crackOverview_->Fill(module, tTopo_->getOTLayerNumber(rawid) + 0.05 - (module % 2 * 0.1));
         }
       }
     }
@@ -251,7 +254,7 @@ void Phase2OTMonitorCluster::bookHistograms(DQMStore::IBooker& ibooker,
       double yOffset = 0;
       for (int layer = 1; layer < 7; layer++) {
         for (int module = 1; module < 13; module++) {
-          if (module % 2 == 0)
+          if (module % 2 == 1)
             yOffset = -0.1;
           else
             yOffset = 0;

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
@@ -403,7 +403,7 @@ void Phase2OTMonitorCluster::fillDescriptions(edm::ConfigurationDescriptions& de
     psd0.add<std::string>("name", "Crack_Overview");
     psd0.add<std::string>("title", "Crack_Overview_clusters;Module;Layer");
     psd0.add<double>("xmin", 0.0);
-    psd0.add<bool>("switch", true);
+    psd0.add<bool>("switch", false);
     psd0.add<double>("xmax", 13.0);
     psd0.add<double>("ymin", 0.0);
     psd0.add<double>("ymax", 7.5);

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
@@ -403,7 +403,7 @@ void Phase2OTMonitorCluster::fillDescriptions(edm::ConfigurationDescriptions& de
     psd0.add<std::string>("name", "Crack_Overview");
     psd0.add<std::string>("title", "Crack_Overview_clusters;Module;Layer");
     psd0.add<double>("xmin", 0.0);
-    psd0.add<bool>("switch", false);
+    psd0.add<bool>("switch", true);
     psd0.add<double>("xmax", 13.0);
     psd0.add<double>("ymin", 0.0);
     psd0.add<double>("ymax", 7.5);

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
@@ -388,7 +388,7 @@ void Phase2OTMonitorCluster::fillDescriptions(edm::ConfigurationDescriptions& de
   {
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "NumberOfClusters");
-    psd0.add<std::string>("title", ";Number of clusters per event;");
+    psd0.add<std::string>("title", "Number_Of_Clusters;Number of clusters per event;");
     psd0.add<double>("xmin", 0.0);
     psd0.add<bool>("switch", true);
     psd0.add<double>("xmax", 350000.0);
@@ -473,7 +473,7 @@ void Phase2OTMonitorCluster::fillDescriptions(edm::ConfigurationDescriptions& de
   {
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "NumberOfClusters_Layer_P");
-    psd0.add<std::string>("title", ";Number of clusters per event (macro pixel sensor);");
+    psd0.add<std::string>("title", "Number_Of_Clusters_P_Layer;Number of clusters per event (macro pixel sensor);");
     psd0.add<double>("xmin", 0.0);
     psd0.add<double>("xmax", 28000.0);
     psd0.add<int>("NxBins", 150);
@@ -483,7 +483,7 @@ void Phase2OTMonitorCluster::fillDescriptions(edm::ConfigurationDescriptions& de
   {
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "NumberOfClusters_Layer_S");
-    psd0.add<std::string>("title", ";Number of clusters per event (strip sensor);");
+    psd0.add<std::string>("title", "Number_Of_Clusters_S_Layer;Number of clusters per event (strip sensor);");
     psd0.add<double>("xmin", 0.0);
     psd0.add<double>("xmax", 28000.0);
     psd0.add<int>("NxBins", 150);
@@ -493,7 +493,7 @@ void Phase2OTMonitorCluster::fillDescriptions(edm::ConfigurationDescriptions& de
   {
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Cluster_Size_P");
-    psd0.add<std::string>("title", ";Cluster size (macro pixel sensor);");
+    psd0.add<std::string>("title", "Cluster_Size_P;Cluster size (macro pixel sensor);");
     psd0.add<double>("xmin", -0.5);
     psd0.add<double>("xmax", 30.5);
     psd0.add<int>("NxBins", 31);
@@ -503,7 +503,7 @@ void Phase2OTMonitorCluster::fillDescriptions(edm::ConfigurationDescriptions& de
   {
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Cluster_Size_S");
-    psd0.add<std::string>("title", ";Cluster size (strip sensor);");
+    psd0.add<std::string>("title", "Cluster_Size_S;Cluster size (strip sensor);");
     psd0.add<double>("xmin", -0.5);
     psd0.add<double>("xmax", 30.5);
     psd0.add<int>("NxBins", 31);

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc
@@ -599,7 +599,7 @@ void Phase2OTMonitorTTStub::fillDescriptions(edm::ConfigurationDescriptions &des
     psd0.add<std::string>("name", "Crack_Overview_Stubs");
     psd0.add<std::string>("title", "Crack_Overview_stubs;Module;Layer");
     psd0.add<double>("xmin", 0.0);
-    psd0.add<bool>("switch", false);
+    psd0.add<bool>("switch", true);
     psd0.add<double>("xmax", 13.0);
     psd0.add<double>("ymin", 0.0);
     psd0.add<double>("ymax", 7.5);

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc
@@ -284,7 +284,7 @@ void Phase2OTMonitorTTStub::bookHistograms(DQMStore::IBooker &iBooker, edm::Run 
       }
     }
     CrackOverview->getTH2Poly()->SetStats(false);
-    CrackOverview->setOption("z");
+    CrackOverview->setOption("z0");
 
   } else
     CrackOverview = nullptr;

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc
@@ -154,6 +154,11 @@ void Phase2OTMonitorTTStub::analyze(const edm::Event &iEvent, const edm::EventSe
       double rawBend = tempStubRef->rawBend();
       double bendOffset = tempStubRef->bendOffset();
 
+      // Get module
+      unsigned int module = tTopo_->module(detIdStub);
+      // CRACK is viewed from behind, so to align plots with what is seen in real life, modules are flipped
+      if (CrackOverview)
+        module = std::abs(int(module - 13));
       /// Define position stub by position inner cluster
       MeasurementPoint mp = (tempStubRef->clusterRef(0))->findAverageLocalCoordinates();
       const GeomDet *theGeomDet = tkGeom_->idToDet(detIdStub);
@@ -167,8 +172,7 @@ void Phase2OTMonitorTTStub::analyze(const edm::Event &iEvent, const edm::EventSe
       Stub_bendBE->Fill(tempStubRef->bendBE());
       Stub_isPS->Fill(tempStubRef->moduleTypePS());
       if (CrackOverview)
-        CrackOverview->Fill(tTopo_->module(detIdStub),
-                            tTopo_->getOTLayerNumber(detIdStub) - 0.05 + (tTopo_->module(detIdStub) % 2 * 0.1));
+        CrackOverview->Fill(module, tTopo_->getOTLayerNumber(detIdStub) + 0.05 - (module % 2 * 0.1));
 
       if (detIdStub.subdetId() == static_cast<int>(StripSubdetector::TOB)) {  // Phase 2 Outer Tracker Barrel
         Stub_Barrel->Fill(tTopo_->layer(detIdStub));
@@ -275,7 +279,7 @@ void Phase2OTMonitorTTStub::bookHistograms(DQMStore::IBooker &iBooker, edm::Run 
       double yOffset = 0;
       for (int layer = 1; layer < 7; layer++) {
         for (int module = 1; module < 13; module++) {
-          if (module % 2 == 0)
+          if (module % 2 == 1)
             yOffset = -0.1;
           else
             yOffset = 0;

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc
@@ -61,6 +61,7 @@ public:
   MonitorElement *Stub_Endcap_Fw_XY = nullptr;  // TTStub Forward Endcap y vs. x
   MonitorElement *Stub_Endcap_Bw_XY = nullptr;  // TTStub Backward Endcap y vs. x
   MonitorElement *Stub_RZ = nullptr;            // TTStub #rho vs. z
+  MonitorElement *CrackOverview = nullptr;      // Cosmic rack: TTStub layer vs module
 
   // Number of stubs
   MonitorElement *Stub_Barrel = nullptr;                                                   // TTStub per layer
@@ -165,6 +166,9 @@ void Phase2OTMonitorTTStub::analyze(const edm::Event &iEvent, const edm::EventSe
       Stub_bendFE->Fill(tempStubRef->bendFE());
       Stub_bendBE->Fill(tempStubRef->bendBE());
       Stub_isPS->Fill(tempStubRef->moduleTypePS());
+      if (CrackOverview)
+        CrackOverview->Fill(tTopo_->module(detIdStub),
+                            tTopo_->getOTLayerNumber(detIdStub) - 0.05 + (tTopo_->module(detIdStub) % 2 * 0.1));
 
       if (detIdStub.subdetId() == static_cast<int>(StripSubdetector::TOB)) {  // Phase 2 Outer Tracker Barrel
         Stub_Barrel->Fill(tTopo_->layer(detIdStub));
@@ -257,6 +261,33 @@ void Phase2OTMonitorTTStub::bookHistograms(DQMStore::IBooker &iBooker, edm::Run 
                            psTTStub_RZ.getParameter<double>("ymax"));
   Stub_RZ->setAxisTitle("L1 Stub position z [cm]", 1);
   Stub_RZ->setAxisTitle("L1 Stub position #rho [cm]", 2);
+
+  // CRACK ONLY: module vs layer
+  edm::ParameterSet Parameters = conf_.getParameter<edm::ParameterSet>("CrackOverview");
+  if (Parameters.getParameter<bool>("switch")) {
+    CrackOverview = iBooker.book2DPoly(Parameters.getParameter<std::string>("name"),
+                                       Parameters.getParameter<std::string>("title"),
+                                       Parameters.getParameter<double>("xmin"),
+                                       Parameters.getParameter<double>("xmax"),
+                                       Parameters.getParameter<double>("ymin"),
+                                       Parameters.getParameter<double>("ymax"));
+    if (CrackOverview->getTH2Poly()->GetNumberOfBins() == 0) {
+      double yOffset = 0;
+      for (int layer = 1; layer < 7; layer++) {
+        for (int module = 1; module < 13; module++) {
+          if (module % 2 == 0)
+            yOffset = -0.1;
+          else
+            yOffset = 0;
+          CrackOverview->addBin(module - 0.7, layer + yOffset, module + 0.7, layer + yOffset + 0.1);
+        }
+      }
+    }
+    CrackOverview->getTH2Poly()->SetStats(false);
+    CrackOverview->setOption("z");
+
+  } else
+    CrackOverview = nullptr;
 
   iBooker.setCurrentFolder(topFolderName_ + "/Stubs");
   // TTStub eta
@@ -558,6 +589,17 @@ void Phase2OTMonitorTTStub::fillDescriptions(edm::ConfigurationDescriptions &des
     psd0.add<double>("ymax", 120);
     psd0.add<double>("ymin", 0);
     desc.add<edm::ParameterSetDescription>("TH2TTStub_RZ", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Crack_Overview_Stubs");
+    psd0.add<std::string>("title", "Crack_Overview_stubs;Module;Layer");
+    psd0.add<double>("xmin", 0.0);
+    psd0.add<bool>("switch", false);
+    psd0.add<double>("xmax", 13.0);
+    psd0.add<double>("ymin", 0.0);
+    psd0.add<double>("ymax", 7.5);
+    desc.add<edm::ParameterSetDescription>("CrackOverview", psd0);
   }
   {
     edm::ParameterSetDescription psd0;

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc
@@ -599,7 +599,7 @@ void Phase2OTMonitorTTStub::fillDescriptions(edm::ConfigurationDescriptions &des
     psd0.add<std::string>("name", "Crack_Overview_Stubs");
     psd0.add<std::string>("title", "Crack_Overview_stubs;Module;Layer");
     psd0.add<double>("xmin", 0.0);
-    psd0.add<bool>("switch", true);
+    psd0.add<bool>("switch", false);
     psd0.add<double>("xmax", 13.0);
     psd0.add<double>("ymin", 0.0);
     psd0.add<double>("ymax", 7.5);

--- a/DQM/SiTrackerPhase2/plugins/Phase2TrackerMonitorDigi.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2TrackerMonitorDigi.cc
@@ -488,7 +488,6 @@ void Phase2TrackerMonitorDigi::bookHistograms(DQMStore::IBooker& ibooker,
   } else
     RZOccupancyMap = nullptr;
 
-
   Parameters = config_.getParameter<edm::ParameterSet>("CrackOverview");
   if (Parameters.getParameter<bool>("switch")) {
     CrackOverview = ibooker.book2DPoly(Parameters.getParameter<std::string>("name"),
@@ -510,7 +509,7 @@ void Phase2TrackerMonitorDigi::bookHistograms(DQMStore::IBooker& ibooker,
       }
     }
     CrackOverview->getTH2Poly()->SetStats(false);
-    CrackOverview->setOption("z");
+    CrackOverview->setOption("z0");
 
   } else
     CrackOverview = nullptr;

--- a/DQM/SiTrackerPhase2/plugins/Phase2TrackerMonitorDigi.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2TrackerMonitorDigi.cc
@@ -303,6 +303,10 @@ void Phase2TrackerMonitorDigi::fillOTDigiHistos(const edm::Handle<edm::DetSetVec
     const GeomDet* geomDet = tkGeom_->idToDet(detId);
 
     const Phase2TrackerGeomDetUnit* tkDetUnit = dynamic_cast<const Phase2TrackerGeomDetUnit*>(gDetUnit);
+    int module = tTopo_->module(detId);
+    // CRACK is viewed from behind, so to align plots with what is seen in real life, modules are flipped
+    if (CrackOverview)
+      module = std::abs(int(module - 13));
     int nRows = tkDetUnit->specificTopology().nrows();
     int nColumns = tkDetUnit->specificTopology().ncolumns();
     if (nRows * nColumns == 0)
@@ -335,7 +339,7 @@ void Phase2TrackerMonitorDigi::fillOTDigiHistos(const edm::Handle<edm::DetSetVec
       if (nColumns <= 2 && local_mes.PositionOfDigisS)
         local_mes.PositionOfDigisS->Fill(row + 1, col + 1);
       if (CrackOverview)
-        CrackOverview->Fill(tTopo_->module(rawid), layer - 0.05 + (tTopo_->module(rawid) % 2 * 0.1));
+        CrackOverview->Fill(module, layer + 0.05 - (module % 2 * 0.1));
 
       if (clsFlag_) {
         if (row_last == -1 || abs(row - row_last) != 1 || col != col_last) {
@@ -500,7 +504,7 @@ void Phase2TrackerMonitorDigi::bookHistograms(DQMStore::IBooker& ibooker,
       double yOffset = 0;
       for (int layer = 1; layer < 7; layer++) {
         for (int module = 1; module < 13; module++) {
-          if (module % 2 == 0)
+          if (module % 2 == 1)
             yOffset = -0.1;
           else
             yOffset = 0;

--- a/DQM/SiTrackerPhase2/plugins/Phase2TrackerMonitorDigi.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2TrackerMonitorDigi.cc
@@ -91,6 +91,7 @@ public:
   MonitorElement* RZPositionMap{nullptr};
   MonitorElement* XYOccupancyMap{nullptr};
   MonitorElement* RZOccupancyMap{nullptr};
+  MonitorElement* CrackOverview{nullptr};
 
 private:
   void bookLayerHistos(DQMStore::IBooker& ibooker, unsigned int det_id);
@@ -333,6 +334,8 @@ void Phase2TrackerMonitorDigi::fillOTDigiHistos(const edm::Handle<edm::DetSetVec
         local_mes.PositionOfDigisP->Fill(row + 1, col + 1);
       if (nColumns <= 2 && local_mes.PositionOfDigisS)
         local_mes.PositionOfDigisS->Fill(row + 1, col + 1);
+      if (CrackOverview)
+        CrackOverview->Fill(tTopo_->module(rawid), layer - 0.05 + (tTopo_->module(rawid) % 2 * 0.1));
 
       if (clsFlag_) {
         if (row_last == -1 || abs(row - row_last) != 1 || col != col_last) {
@@ -484,6 +487,33 @@ void Phase2TrackerMonitorDigi::bookHistograms(DQMStore::IBooker& ibooker,
     RZOccupancyMap->setAxisTitle("Digi position #rho [cm]", 2);
   } else
     RZOccupancyMap = nullptr;
+
+
+  Parameters = config_.getParameter<edm::ParameterSet>("CrackOverview");
+  if (Parameters.getParameter<bool>("switch")) {
+    CrackOverview = ibooker.book2DPoly(Parameters.getParameter<std::string>("name"),
+                                       Parameters.getParameter<std::string>("title"),
+                                       Parameters.getParameter<double>("xmin"),
+                                       Parameters.getParameter<double>("xmax"),
+                                       Parameters.getParameter<double>("ymin"),
+                                       Parameters.getParameter<double>("ymax"));
+    if (CrackOverview->getTH2Poly()->GetNumberOfBins() == 0) {
+      double yOffset = 0;
+      for (int layer = 1; layer < 7; layer++) {
+        for (int module = 1; module < 13; module++) {
+          if (module % 2 == 0)
+            yOffset = -0.1;
+          else
+            yOffset = 0;
+          CrackOverview->addBin(module - 0.7, layer + yOffset, module + 0.7, layer + yOffset + 0.1);
+        }
+      }
+    }
+    CrackOverview->getTH2Poly()->SetStats(false);
+    CrackOverview->setOption("z");
+
+  } else
+    CrackOverview = nullptr;
 }
 //
 // -- Book Layer Histograms

--- a/DQM/SiTrackerPhase2/python/Phase2CRackDQMFirstStep_cff.py
+++ b/DQM/SiTrackerPhase2/python/Phase2CRackDQMFirstStep_cff.py
@@ -4,13 +4,13 @@ from DQM.SiTrackerPhase2.Phase2CRackMonitorCluster_cff import *
 from DQM.SiTrackerPhase2.Phase2OTMonitorVectorHits_cff import *
 #L1 
 from DQM.SiTrackerPhase2.Phase2OTMonitorTTTrack_cfi import *
-from DQM.SiTrackerPhase2.Phase2OTMonitorTTStub_cfi import *
+from DQM.SiTrackerPhase2.Phase2CRackMonitorTTStub_cff import *
 from DQM.SiTrackerPhase2.Phase2OTMonitorTTCluster_cfi import *
 
 trackerphase2DQMSource = cms.Sequence(  CRACKDigiMon
                                        + clusterMonitorCRACK
                                        + Phase2OTMonitorTTCluster
-                                       + Phase2OTMonitorTTStub
+                                       + TTStubMonitorCRACK
                                        + Phase2OTMonitorTTTrack
 )
 

--- a/DQM/SiTrackerPhase2/python/Phase2CRackDQMFirstStep_cff.py
+++ b/DQM/SiTrackerPhase2/python/Phase2CRackDQMFirstStep_cff.py
@@ -7,7 +7,7 @@ from DQM.SiTrackerPhase2.Phase2OTMonitorTTTrack_cfi import *
 from DQM.SiTrackerPhase2.Phase2OTMonitorTTStub_cfi import *
 from DQM.SiTrackerPhase2.Phase2OTMonitorTTCluster_cfi import *
 
-trackerphase2DQMSource = cms.Sequence(  otDigiMon
+trackerphase2DQMSource = cms.Sequence(  CRACKDigiMon
                                        + clusterMonitorCRACK
                                        + Phase2OTMonitorTTCluster
                                        + Phase2OTMonitorTTStub

--- a/DQM/SiTrackerPhase2/python/Phase2CRackMonitorCluster_cff.py
+++ b/DQM/SiTrackerPhase2/python/Phase2CRackMonitorCluster_cff.py
@@ -24,7 +24,17 @@ clusterMonitorCRACK = _Phase2OTMonitorCluster.clone(
         ymin = cms.double(-2.5),
         ymax = cms.double(2.5),
         switch = cms.bool(True)
+    ),
+    CrackOverview = _Phase2OTMonitorCluster.CrackOverview.clone(
+    name = cms.string('Crack_Overview_clusters'),
+    title = cms.string('Crack_Overview_clusters;Module;Layer'),
+    xmin = cms.double(0.0),
+    xmax = cms.double(13.0),
+    ymin = cms.double(0.0),
+    ymax = cms.double(7.5),
+    switch = cms.bool(True)
     )
+
     #TopFolderName = cms.string('TrackerPhase2OTCluster'),
     #clusterSrc = cms.InputTag('siPhase2Clusters'),
     #mightGet = cms.optional.untracked.vstring

--- a/DQM/SiTrackerPhase2/python/Phase2CRackMonitorCluster_cff.py
+++ b/DQM/SiTrackerPhase2/python/Phase2CRackMonitorCluster_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from DQM.SiTrackerPhase2.Phase2OTMonitorCluster_cfi import Phase2OTMonitorCluster as _Phase2OTMonitorCluster
 
 clusterMonitorCRACK = _Phase2OTMonitorCluster.clone(
+    # Histograms that are usually set to switch = False in full tracker
     PositionOfClusters_2S = _Phase2OTMonitorCluster.PositionOfClusters_2S.clone(
         name = cms.string('PositionOfClusters_2S_module'),
         title = cms.string('PositionsOfClusters_2S_module;Strip;Half-module;'),
@@ -14,6 +15,16 @@ clusterMonitorCRACK = _Phase2OTMonitorCluster.clone(
         ymax = cms.double(2.5),
         switch = cms.bool(True)
     ),
+    CrackOverview = _Phase2OTMonitorCluster.CrackOverview.clone(
+        name = cms.string('Crack_Overview_clusters'),
+        title = cms.string('Crack_Overview_clusters;Module;Layer'),
+        xmin = cms.double(0.0),
+        xmax = cms.double(13.0),
+        ymin = cms.double(0.0),
+        ymax = cms.double(7.5),
+        switch = cms.bool(True)
+    ),
+    # Changes to x/y ranges for CRACK readability
     PositionOfClusters_2SLadder = _Phase2OTMonitorCluster.PositionOfClusters_2SLadder.clone(
         name = cms.string('PositionOfClusters_2S_Ladder'),
         title = cms.string('PositionsOfClusters_2S_Ladder;Module;Half-module;'),
@@ -25,16 +36,26 @@ clusterMonitorCRACK = _Phase2OTMonitorCluster.clone(
         ymax = cms.double(2.5),
         switch = cms.bool(True)
     ),
-    CrackOverview = _Phase2OTMonitorCluster.CrackOverview.clone(
-    name = cms.string('Crack_Overview_clusters'),
-    title = cms.string('Crack_Overview_clusters;Module;Layer'),
-    xmin = cms.double(0.0),
-    xmax = cms.double(13.0),
-    ymin = cms.double(0.0),
-    ymax = cms.double(7.5),
-    switch = cms.bool(True)
+    GlobalPositionXY_S = _Phase2OTMonitorCluster.GlobalPositionXY_S.clone(
+        xmin = cms.double(-7.0),
+        xmax = cms.double(7.0),
+        ymin = cms.double(-10.0),
+        ymax = cms.double(50.0)
+    ),
+    GlobalPositionRZ_S = _Phase2OTMonitorCluster.GlobalPositionRZ_S.clone(
+        xmin = cms.double(-70.0),
+        xmax = cms.double(70.0),
+        ymin = cms.double(0.0),
+        ymax = cms.double(60.0)
+    ),
+    GlobalNClusters = _Phase2OTMonitorCluster.GlobalNClusters.clone(
+        xmax = cms.double(50.0),
+        NxBins = cms.int32(50)
+    ),
+    NClustersLayer_S = _Phase2OTMonitorCluster.NClustersLayer_S.clone(
+        xmax = cms.double(50.0),
+        NxBins = cms.int32(50)
     )
-
     #TopFolderName = cms.string('TrackerPhase2OTCluster'),
     #clusterSrc = cms.InputTag('siPhase2Clusters'),
     #mightGet = cms.optional.untracked.vstring

--- a/DQM/SiTrackerPhase2/python/Phase2CRackMonitorTTStub_cff.py
+++ b/DQM/SiTrackerPhase2/python/Phase2CRackMonitorTTStub_cff.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQM.SiTrackerPhase2.Phase2OTMonitorTTStub_cfi import Phase2OTMonitorTTStub as _Phase2OTMonitorTTStub
+
+TTStubMonitorCRACK = _Phase2OTMonitorTTStub.clone(
+    # Histograms that are usually set to switch = False in full tracker
+    CrackOverview = _Phase2OTMonitorTTStub.CrackOverview.clone(
+        name = cms.string('Crack_Overview_stubs'),
+        title = cms.string('Crack_Overview_stubs;Module;Layer'),
+        xmin = cms.double(0.0),
+        xmax = cms.double(13.0),
+        ymin = cms.double(0.0),
+        ymax = cms.double(7.5),
+        switch = cms.bool(True)
+    ),
+    # Changes to x/y ranges for CRACK readability
+    TH2TTStub_Position = _Phase2OTMonitorTTStub.TH2TTStub_Position.clone(
+        xmin = cms.double(-7.0),
+        xmax = cms.double(7.0),
+        ymin = cms.double(-10.0),
+        ymax = cms.double(50.0)
+    ),
+    TH2TTStub_RZ = _Phase2OTMonitorTTStub.TH2TTStub_RZ.clone(
+        xmin = cms.double(-70.0),
+        xmax = cms.double(70.0),
+        ymin = cms.double(-0.0),
+        ymax = cms.double(60.0)
+    )
+
+    #TopFolderName = cms.string('TrackerPhase2OTCluster'),
+    #clusterSrc = cms.InputTag('siPhase2Clusters'),
+    #mightGet = cms.optional.untracked.vstring
+)

--- a/DQM/SiTrackerPhase2/python/Phase2TrackerMonitorDigi_cff.py
+++ b/DQM/SiTrackerPhase2/python/Phase2TrackerMonitorDigi_cff.py
@@ -76,13 +76,6 @@ otDigiMon = digiMon.clone(
         ymin = 0.,
         ymax = 125.,
         switch = True
-    ),
-    CrackOverview = digiMon.CrackOverview.clone(
-        xmin = 0,
-        xmax = 13.5,
-        ymin = 0,
-        ymax = 7.5,
-        switch = True
     )
 )
 CRACKDigiMon = digiMon.clone(

--- a/DQM/SiTrackerPhase2/python/Phase2TrackerMonitorDigi_cff.py
+++ b/DQM/SiTrackerPhase2/python/Phase2TrackerMonitorDigi_cff.py
@@ -76,6 +76,13 @@ otDigiMon = digiMon.clone(
         ymin = 0.,
         ymax = 125.,
         switch = True
+    ),
+    CrackOverview = digiMon.CrackOverview.clone(
+        xmin = 0,
+        xmax = 13.5,
+        ymin = 0,
+        ymax = 7.5,
+        switch = True
     )
 )
 CRACKDigiMon = digiMon.clone(

--- a/DQM/SiTrackerPhase2/python/Phase2TrackerMonitorDigi_cff.py
+++ b/DQM/SiTrackerPhase2/python/Phase2TrackerMonitorDigi_cff.py
@@ -78,3 +78,37 @@ otDigiMon = digiMon.clone(
         switch = True
     )
 )
+CRACKDigiMon = digiMon.clone(
+    PixelPlotFillingFlag = False,
+    StandAloneClusteriserFlag = False,
+    TopFolderName = "TrackerPhase2OTDigi",
+    CrackOverview = digiMon.CrackOverview.clone(
+        xmin = 0,
+        xmax = 13.5,
+        ymin = 0,
+        ymax = 7.5,
+        switch = True
+    ),
+    XYPositionMapH = digiMon.XYPositionMapH.clone(
+        Nxbins = 250,
+        xmin = -7,
+        xmax = 7,
+        Nybins = 250,
+        ymin = -10,
+        ymax = 50,
+        switch = True
+    ),
+    RZPositionMapH = digiMon.RZPositionMapH.clone(
+        Nxbins = 600,
+        xmin = -70.,
+        xmax = 70.,
+        Nybins = 250,
+        ymin = 0.,
+        ymax = 60.,
+        switch = True
+    ),
+    TotalNumberOfDigisPerLayerH = digiMon.TotalNumberOfDigisPerLayerH.clone(
+        xmax = 100
+    )
+)
+

--- a/DQM/SiTrackerPhase2/python/Phase2TrackerMonitorDigi_cfi.py
+++ b/DQM/SiTrackerPhase2/python/Phase2TrackerMonitorDigi_cfi.py
@@ -149,6 +149,15 @@ digiMon = DQMEDAnalyzer('Phase2TrackerMonitorDigi',
                             ymin   = cms.double(0.),
                             ymax   = cms.double(125.),
                             switch = cms.bool(True)
+                        ),
+                        CrackOverview = cms.PSet(
+                            name = cms.string('Crack_Overview_digis'),
+                            title = cms.string('Crack_Overview_digis;Module;Layer'),
+                            xmin   = cms.double(0),
+                            xmax   = cms.double(13.5),
+                            ymin   = cms.double(0),
+                            ymax   = cms.double(7.5),
+                            switch = cms.bool(False)
                         )
                     )
 

--- a/DQM/SiTrackerPhase2/test/dqmstep_phase2c-rack_cfg.py
+++ b/DQM/SiTrackerPhase2/test/dqmstep_phase2c-rack_cfg.py
@@ -93,6 +93,7 @@ process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
 # Additional output definition
 
 # Other statements
+process.trackerGeometry.applyAlignment = False
 process.mix.playback = True
 process.mix.digitizers = cms.PSet()
 for a in process.aliases: delattr(process, a)

--- a/DQM/SiTrackerPhase2/test/harvestingstep_phase2c-rack_cfg.py
+++ b/DQM/SiTrackerPhase2/test/harvestingstep_phase2c-rack_cfg.py
@@ -78,6 +78,7 @@ process.configurationMetadata = cms.untracked.PSet(
 # Additional output definition
 
 # Other statements
+process.trackerGeometry.applyAlignment = False
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T35', '')
 


### PR DESCRIPTION
#### PR description:

- Added an overview histogram to the CRACK DQM. 
- Changed the ranges of some existing histograms to better suit the expected range of CRACK values. 
- "Flipped" module related histograms to match the real-life CRACK.
In the TIF, the CRACK is viewed from the back. In this PR, when the CRACK DQM sequence is run, the existing module numbers are flipped (12 becomes 1, 11 becomes 2 ... 1 becomes 12) so that DQM histograms match what is seen in real life (i.e module on the leftmost side of a plot corresponds to leftmost module in real CRACK). By using few events in the DQM sequence, I have checked that the module numbers are internally consistent between plots.

CRACK Overview:
<img width="1507" height="872" alt="image" src="https://github.com/user-attachments/assets/8105bea9-9dd0-4489-8579-0f0c50b0753c" />


#### PR validation:

- Compared existing full-tracker DQM output to this branch -> no change
- Checked that all module numbers have been correctly changed for CRACK by using a small dataset with few muons

Example:
<img width="1507" height="872" alt="image" src="https://github.com/user-attachments/assets/4f5301cf-4c6c-4823-ba6d-cabc821cad06" />

CRACK overview: 4 clusters seen in Layer 4 module 10

<img width="1532" height="869" alt="image" src="https://github.com/user-attachments/assets/68add5e8-0bf3-4095-8a88-31cf212aae67" />

Layer 4 ladder breakdown: 4 clusters seen in module 10, all modules match

<img width="1532" height="869" alt="image" src="https://github.com/user-attachments/assets/0b93fbf0-2634-43e6-8c97-dae6c13bd20e" />

Layer 4 module 10 breakdown: 4 total clusters