### PR TITLE
Memory Improvements for LST

### DIFF
--- a/RecoTracker/LSTCore/interface/MiniDoubletsSoA.h
+++ b/RecoTracker/LSTCore/interface/MiniDoubletsSoA.h
@@ -14,11 +14,6 @@ namespace lst {
                       SOA_COLUMN(float, dphichanges),
                       SOA_COLUMN(float, dzs),
                       SOA_COLUMN(float, dphis),
-                      SOA_COLUMN(float, shiftedXs),
-                      SOA_COLUMN(float, shiftedYs),
-                      SOA_COLUMN(float, shiftedZs),
-                      SOA_COLUMN(float, noShiftedDphis),
-                      SOA_COLUMN(float, noShiftedDphiChanges),
                       SOA_COLUMN(float, anchorX),
                       SOA_COLUMN(float, anchorY),
                       SOA_COLUMN(float, anchorZ),
@@ -34,6 +29,7 @@ namespace lst {
                       SOA_COLUMN(float, outerX),
                       SOA_COLUMN(float, outerY),
                       SOA_COLUMN(float, outerZ),
+#ifdef CUT_VALUE_DEBUG
                       SOA_COLUMN(float, outerRt),
                       SOA_COLUMN(float, outerPhi),
                       SOA_COLUMN(float, outerEta),
@@ -41,6 +37,12 @@ namespace lst {
                       SOA_COLUMN(float, outerHighEdgeY),
                       SOA_COLUMN(float, outerLowEdgeX),
                       SOA_COLUMN(float, outerLowEdgeY),
+                      SOA_COLUMN(float, shiftedXs),
+                      SOA_COLUMN(float, shiftedYs),
+                      SOA_COLUMN(float, shiftedZs),
+                      SOA_COLUMN(float, noShiftedDphis),
+                      SOA_COLUMN(float, noShiftedDphiChanges),
+#endif
                       SOA_COLUMN(unsigned int, connectedMax))
 
   GENERATE_SOA_LAYOUT(MiniDoubletsOccupancySoALayout,

--- a/RecoTracker/LSTCore/interface/PixelQuintupletsSoA.h
+++ b/RecoTracker/LSTCore/interface/PixelQuintupletsSoA.h
@@ -14,10 +14,12 @@ namespace lst {
                       SOA_COLUMN(Params_pT5::ArrayU16xLayers, lowerModuleIndices),  // lower module index (OT part)
                       SOA_COLUMN(Params_pT5::ArrayU8xLayers, logicalLayers),        // layer ID
                       SOA_COLUMN(Params_pT5::ArrayUxHits, hitIndices),              // hit indices
-                      SOA_COLUMN(float, rPhiChiSquared),                            // chi2 from pLS to T5
-                      SOA_COLUMN(float, rPhiChiSquaredInwards),                     // chi2 from T5 to pLS
+                      SOA_COLUMN(FPX, pixelRadius),                                 // pLS pt converted
+#ifdef CUT_VALUE_DEBUG
+                      SOA_COLUMN(float, rPhiChiSquared),         // chi2 from pLS to T5
+                      SOA_COLUMN(float, rPhiChiSquaredInwards),  // chi2 from T5 to pLS
                       SOA_COLUMN(float, rzChiSquared),
-                      SOA_COLUMN(FPX, pixelRadius),       // pLS pt converted
+#endif
                       SOA_COLUMN(FPX, quintupletRadius),  // T5 circle
                       SOA_COLUMN(FPX, eta),
                       SOA_COLUMN(FPX, phi),

--- a/RecoTracker/LSTCore/interface/PixelTripletsSoA.h
+++ b/RecoTracker/LSTCore/interface/PixelTripletsSoA.h
@@ -14,14 +14,16 @@ namespace lst {
                       SOA_COLUMN(Params_pT3::ArrayU16xLayers, lowerModuleIndices),  // lower module index (OT part)
                       SOA_COLUMN(Params_pT3::ArrayU8xLayers, logicalLayers),        // layer ID
                       SOA_COLUMN(Params_pT3::ArrayUxHits, hitIndices),              // hit indices
-                      SOA_COLUMN(float, rPhiChiSquared),                            // chi2 from pLS to T3
-                      SOA_COLUMN(float, rPhiChiSquaredInwards),                     // chi2 from T3 to pLS
-                      SOA_COLUMN(float, rzChiSquared),
-                      SOA_COLUMN(FPX, pixelRadius),  // pLS pt converted
-                      SOA_COLUMN(FPX, pixelRadiusError),
-                      SOA_COLUMN(FPX, tripletRadius),  // T3 circle
-                      SOA_COLUMN(FPX, pt),
+                      SOA_COLUMN(FPX, pixelRadius),                                 // pLS pt converted
+                      SOA_COLUMN(FPX, tripletRadius),                               // T3 circle
                       SOA_COLUMN(FPX, eta),
+#ifdef CUT_VALUE_DEBUG
+                      SOA_COLUMN(float, rPhiChiSquared),         // chi2 from pLS to T3
+                      SOA_COLUMN(float, rPhiChiSquaredInwards),  // chi2 from T3 to pLS
+                      SOA_COLUMN(float, rzChiSquared),
+                      SOA_COLUMN(FPX, pixelRadiusError),
+                      SOA_COLUMN(FPX, pt),
+#endif
                       SOA_COLUMN(FPX, phi),
                       SOA_COLUMN(FPX, eta_pix),  // eta from pLS
                       SOA_COLUMN(FPX, phi_pix),  // phi from pLS

--- a/RecoTracker/LSTCore/interface/QuadrupletsSoA.h
+++ b/RecoTracker/LSTCore/interface/QuadrupletsSoA.h
@@ -16,26 +16,28 @@ namespace lst {
                       SOA_COLUMN(Params_T4::ArrayU16xLayers, lowerModuleIndices),  // lower module index in each layer
                       SOA_COLUMN(Params_T4::ArrayU8xLayers, logicalLayers),        // layer ID
                       SOA_COLUMN(Params_T4::ArrayUxHits, hitIndices),              // hit indices
-                      SOA_COLUMN(FPX, innerRadius),                                // inner triplet circle radius
-                      SOA_COLUMN(FPX, outerRadius),                                // outer triplet radius
-                      SOA_COLUMN(FPX, pt),
                       SOA_COLUMN(FPX, eta),
                       SOA_COLUMN(FPX, phi),
-                      SOA_COLUMN(FPX, score_rphisum),  // r-phi based score
-                      SOA_COLUMN(char, isDup),         // duplicate flag
-                      SOA_COLUMN(bool, partOfTC),
+                      SOA_COLUMN(char, isDup),  // duplicate flag
                       SOA_COLUMN(float, regressionRadius),
-                      SOA_COLUMN(float, nonAnchorRegressionRadius),
                       SOA_COLUMN(float, regressionCenterX),
                       SOA_COLUMN(float, regressionCenterY),
-                      SOA_COLUMN(float, rzChiSquared),  // r-z only chi2
                       SOA_COLUMN(float, chiSquared),
                       SOA_COLUMN(float, nonAnchorChiSquared),
-                      SOA_COLUMN(float, promptScore),
                       SOA_COLUMN(float, displacedScore),
                       SOA_COLUMN(float, fakeScore),
+                      SOA_COLUMN(FPX, innerRadius),  // inner triplet circle radius
+                      SOA_COLUMN(FPX, outerRadius),  // outer triplet radius
+                      SOA_COLUMN(FPX, pt),
+#ifdef CUT_VALUE_DEBUG
+                      SOA_COLUMN(FPX, score_rphisum),  // r-phi based score
+                      SOA_COLUMN(float, nonAnchorRegressionRadius),
+                      SOA_COLUMN(float, rzChiSquared),  // r-z only chi2
+                      SOA_COLUMN(float, promptScore),
                       SOA_COLUMN(int, layer),
-                      SOA_COLUMN(float, dBeta));
+                      SOA_COLUMN(float, dBeta),
+#endif
+                      SOA_COLUMN(bool, partOfTC));
 
   using QuadrupletsSoA = QuadrupletsSoALayout<>;
   using Quadruplets = QuadrupletsSoA::View;

--- a/RecoTracker/LSTCore/interface/QuintupletsSoA.h
+++ b/RecoTracker/LSTCore/interface/QuintupletsSoA.h
@@ -17,25 +17,27 @@ namespace lst {
                       SOA_COLUMN(Params_T5::ArrayU8xLayers, logicalLayers),        // layer ID
                       SOA_COLUMN(Params_T5::ArrayUxHits, hitIndices),              // hit indices
                       SOA_COLUMN(Params_T5::ArrayFxEmbed, t5Embed),                // t5 embedding vector
-                      SOA_COLUMN(FPX, innerRadius),                                // inner triplet circle radius
-                      SOA_COLUMN(FPX, bridgeRadius),                               // "middle"/bridge triplet radius
-                      SOA_COLUMN(FPX, outerRadius),                                // outer triplet radius
-                      SOA_COLUMN(FPX, pt),
                       SOA_COLUMN(FPX, eta),
                       SOA_COLUMN(FPX, phi),
                       SOA_COLUMN(FPX, score_rphisum),  // r-phi based score
                       SOA_COLUMN(char, isDup),         // duplicate flag
                       SOA_COLUMN(bool, tightCutFlag),  // tight pass to be a TC
-                      SOA_COLUMN(bool, partOfPT5),
                       SOA_COLUMN(float, regressionRadius),
                       SOA_COLUMN(float, regressionCenterX),
                       SOA_COLUMN(float, regressionCenterY),
+                      SOA_COLUMN(float, dnnScore),
+                      SOA_COLUMN(FPX, innerRadius),   // inner triplet circle radius
+                      SOA_COLUMN(FPX, bridgeRadius),  // "middle"/bridge triplet radius
+                      SOA_COLUMN(FPX, outerRadius),   // outer triplet radius
+                      SOA_COLUMN(FPX, pt),
+#ifdef CUT_VALUE_DEBUG
                       SOA_COLUMN(float, rzChiSquared),  // r-z only chi2
                       SOA_COLUMN(float, chiSquared),
                       SOA_COLUMN(float, nonAnchorChiSquared),
-                      SOA_COLUMN(float, dnnScore),
                       SOA_COLUMN(float, dBeta1),
-                      SOA_COLUMN(float, dBeta2));
+                      SOA_COLUMN(float, dBeta2),
+#endif
+                      SOA_COLUMN(bool, partOfPT5));
 
   using QuintupletsSoA = QuintupletsSoALayout<>;
   using Quintuplets = QuintupletsSoA::View;

--- a/RecoTracker/LSTCore/interface/SegmentsSoA.h
+++ b/RecoTracker/LSTCore/interface/SegmentsSoA.h
@@ -10,13 +10,13 @@
 namespace lst {
 
   GENERATE_SOA_LAYOUT(SegmentsSoALayout,
-                      SOA_COLUMN(FPX, dPhis),
-                      SOA_COLUMN(FPX, dPhiMins),
-                      SOA_COLUMN(FPX, dPhiMaxs),
                       SOA_COLUMN(FPX, dPhiChanges),
                       SOA_COLUMN(FPX, dPhiChangeMins),
                       SOA_COLUMN(FPX, dPhiChangeMaxs),
 #ifdef CUT_VALUE_DEBUG
+                      SOA_COLUMN(FPX, dPhis),
+                      SOA_COLUMN(FPX, dPhiMins),
+                      SOA_COLUMN(FPX, dPhiMaxs),
                       SOA_COLUMN(FPX, zHis),
                       SOA_COLUMN(FPX, zLos),
                       SOA_COLUMN(FPX, rtHis),

--- a/RecoTracker/LSTCore/interface/TrackCandidatesSoA.h
+++ b/RecoTracker/LSTCore/interface/TrackCandidatesSoA.h
@@ -16,13 +16,15 @@ namespace lst {
                       SOA_SCALAR(unsigned int, nTrackCandidates))
 
   GENERATE_SOA_LAYOUT(TrackCandidatesExtendedSoALayout,
-                      SOA_COLUMN(unsigned int, directObjectIndices),  // direct indices to each type containers
                       SOA_COLUMN(ArrayUx2, objectIndices),            // tracklet and  triplet indices
+                      SOA_COLUMN(unsigned int, directObjectIndices),  // direct indices to each type containers
                       SOA_COLUMN(Params_TC::ArrayU8xLayers, logicalLayers),
                       SOA_COLUMN(Params_TC::ArrayU16xLayers, lowerModuleIndices),
+#ifdef CUT_VALUE_DEBUG
                       SOA_COLUMN(FPX, centerX),
                       SOA_COLUMN(FPX, centerY),
                       SOA_COLUMN(FPX, radius),
+#endif
                       SOA_SCALAR(unsigned int, nTrackCandidatespT3),
                       SOA_SCALAR(unsigned int, nTrackCandidatespT5),
                       SOA_SCALAR(unsigned int, nTrackCandidatespLS),

--- a/RecoTracker/LSTCore/src/alpaka/LST.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LST.cc
@@ -2,6 +2,8 @@
 
 #include "LSTEvent.h"
 
+#include <format>
+
 using namespace ALPAKA_ACCELERATOR_NAMESPACE::lst;
 
 #include "Math/Vector3D.h"
@@ -132,6 +134,7 @@ void LST::run(Queue& queue,
     printf("        # of pLS TrackCandidates produced: %d\n", event.getNumberOfPLSTrackCandidates());
     printf("        # of T5 TrackCandidates produced: %d\n", event.getNumberOfT5TrackCandidates());
     printf("        # of T4 TrackCandidates produced: %d\n", event.getNumberOfT4TrackCandidates());
+    lstWarning(std::format("[MEM] Total: {:.1f} MB", event.getMemoryAllocatedMB()));
   }
 
   trackCandidatesBaseDC_ = event.releaseTrackCandidatesBaseDeviceCollection();

--- a/RecoTracker/LSTCore/src/alpaka/LSTEvent.h
+++ b/RecoTracker/LSTCore/src/alpaka/LSTEvent.h
@@ -96,7 +96,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     ModulesDeviceCollection const& modules_;
     PixelMap const& pixelMapping_;
     EndcapGeometryDevDeviceCollection const& endcapGeometry_;
-    bool addObjects_;
+    bool objectsStatistics_ = false;
+    double memoryAllocatedMB_ = 0;
 
   public:
     // Constructor used for CMSSW integration. Uses an external queue.
@@ -112,7 +113,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           modules_(*deviceESData->modules),
           pixelMapping_(*deviceESData->pixelMapping),
           endcapGeometry_(*deviceESData->endcapGeometry),
-          addObjects_(verbose) {
+          objectsStatistics_(verbose) {
       if (ptCut < 0.6f) {
         throw std::invalid_argument("Minimum pT cut must be at least 0.6 GeV. Provided value: " +
                                     std::to_string(ptCut));
@@ -176,6 +177,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     unsigned int getNumberOfQuadruplets();
     unsigned int getNumberOfQuadrupletsByLayerBarrel(unsigned int layer);
     unsigned int getNumberOfQuadrupletsByLayerEndcap(unsigned int layer);
+
+    double getMemoryAllocatedMB() const { return memoryAllocatedMB_; }
 
     // sync adds alpaka::wait at the end of filling a buffer during lazy fill
     // (has no effect on repeated calls)

--- a/RecoTracker/LSTCore/src/alpaka/MiniDoublet.h
+++ b/RecoTracker/LSTCore/src/alpaka/MiniDoublet.h
@@ -53,12 +53,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     mds.dphichanges()[idx] = dPhiChange;
     mds.dphis()[idx] = dPhi;
     mds.dzs()[idx] = dz;
+#ifdef CUT_VALUE_DEBUG
     mds.shiftedXs()[idx] = shiftedX;
     mds.shiftedYs()[idx] = shiftedY;
     mds.shiftedZs()[idx] = shiftedZ;
 
     mds.noShiftedDphis()[idx] = noShiftedDphi;
     mds.noShiftedDphiChanges()[idx] = noShiftedDPhiChange;
+#endif
 
     mds.anchorX()[idx] = hitsBase.xs()[anchorHitIndex];
     mds.anchorY()[idx] = hitsBase.ys()[anchorHitIndex];
@@ -76,6 +78,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     mds.outerX()[idx] = hitsBase.xs()[outerHitIndex];
     mds.outerY()[idx] = hitsBase.ys()[outerHitIndex];
     mds.outerZ()[idx] = hitsBase.zs()[outerHitIndex];
+#ifdef CUT_VALUE_DEBUG
     mds.outerRt()[idx] = hitsExtended.rts()[outerHitIndex];
     mds.outerPhi()[idx] = hitsExtended.phis()[outerHitIndex];
     mds.outerEta()[idx] = hitsExtended.etas()[outerHitIndex];
@@ -83,6 +86,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     mds.outerHighEdgeY()[idx] = hitsExtended.highEdgeYs()[outerHitIndex];
     mds.outerLowEdgeX()[idx] = hitsExtended.lowEdgeXs()[outerHitIndex];
     mds.outerLowEdgeY()[idx] = hitsExtended.lowEdgeYs()[outerHitIndex];
+#endif
   }
 
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool isTighterTiltedModules(ModulesConst modules, uint16_t moduleIndex) {

--- a/RecoTracker/LSTCore/src/alpaka/PixelQuintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/PixelQuintuplet.h
@@ -81,9 +81,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     pixelQuintuplets.hitIndices()[pixelQuintupletIndex][12] = quintuplets.hitIndices()[t5Index][8];
     pixelQuintuplets.hitIndices()[pixelQuintupletIndex][13] = quintuplets.hitIndices()[t5Index][9];
 
+#ifdef CUT_VALUE_DEBUG
     pixelQuintuplets.rzChiSquared()[pixelQuintupletIndex] = rzChiSquared;
     pixelQuintuplets.rPhiChiSquared()[pixelQuintupletIndex] = rPhiChiSquared;
     pixelQuintuplets.rPhiChiSquaredInwards()[pixelQuintupletIndex] = rPhiChiSquaredInwards;
+#endif
   }
 
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool passPT5RZChiSquaredCuts(ModulesConst modules,

--- a/RecoTracker/LSTCore/src/alpaka/PixelTriplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/PixelTriplet.h
@@ -74,9 +74,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     pixelTriplets.pixelSegmentIndices()[pixelTripletIndex] = pixelSegmentIndex;
     pixelTriplets.tripletIndices()[pixelTripletIndex] = tripletIndex;
     pixelTriplets.pixelRadius()[pixelTripletIndex] = __F2H(pixelRadius);
-    pixelTriplets.pixelRadiusError()[pixelTripletIndex] = __F2H(pixelRadiusError);
     pixelTriplets.tripletRadius()[pixelTripletIndex] = __F2H(tripletRadius);
+#ifdef CUT_VALUE_DEBUG
+    pixelTriplets.pixelRadiusError()[pixelTripletIndex] = __F2H(pixelRadiusError);
     pixelTriplets.pt()[pixelTripletIndex] = __F2H(pt);
+#endif
     pixelTriplets.eta()[pixelTripletIndex] = __F2H(eta);
     pixelTriplets.phi()[pixelTripletIndex] = __F2H(phi);
     pixelTriplets.eta_pix()[pixelTripletIndex] = __F2H(eta_pix);
@@ -112,9 +114,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     pixelTriplets.hitIndices()[pixelTripletIndex][7] = triplets.hitIndices()[tripletIndex][3];
     pixelTriplets.hitIndices()[pixelTripletIndex][8] = triplets.hitIndices()[tripletIndex][4];
     pixelTriplets.hitIndices()[pixelTripletIndex][9] = triplets.hitIndices()[tripletIndex][5];
+#ifdef CUT_VALUE_DEBUG
     pixelTriplets.rPhiChiSquared()[pixelTripletIndex] = rPhiChiSquared;
     pixelTriplets.rPhiChiSquaredInwards()[pixelTripletIndex] = rPhiChiSquaredInwards;
     pixelTriplets.rzChiSquared()[pixelTripletIndex] = rzChiSquared;
+#endif
   }
 
   template <alpaka::concepts::Acc TAcc>

--- a/RecoTracker/LSTCore/src/alpaka/Quadruplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quadruplet.h
@@ -53,14 +53,16 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     quadruplets.lowerModuleIndices()[quadrupletIndex][1] = lowerModule2;
     quadruplets.lowerModuleIndices()[quadrupletIndex][2] = lowerModule3;
     quadruplets.lowerModuleIndices()[quadrupletIndex][3] = lowerModule4;
+    quadruplets.eta()[quadrupletIndex] = __F2H(eta);
+    quadruplets.phi()[quadrupletIndex] = __F2H(phi);
+    quadruplets.isDup()[quadrupletIndex] = 0;
     quadruplets.innerRadius()[quadrupletIndex] = __F2H(innerRadius);
     quadruplets.outerRadius()[quadrupletIndex] = __F2H(outerRadius);
     quadruplets.pt()[quadrupletIndex] = __F2H(pt);
-    quadruplets.eta()[quadrupletIndex] = __F2H(eta);
-    quadruplets.phi()[quadrupletIndex] = __F2H(phi);
+#ifdef CUT_VALUE_DEBUG
     quadruplets.score_rphisum()[quadrupletIndex] = __F2H(scores);
     quadruplets.layer()[quadrupletIndex] = layer;
-    quadruplets.isDup()[quadrupletIndex] = 0;
+#endif
     quadruplets.logicalLayers()[quadrupletIndex][0] = triplets.logicalLayers()[innerTripletIndex][0];
     quadruplets.logicalLayers()[quadrupletIndex][1] = triplets.logicalLayers()[innerTripletIndex][1];
     quadruplets.logicalLayers()[quadrupletIndex][2] = triplets.logicalLayers()[innerTripletIndex][2];
@@ -75,14 +77,16 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     quadruplets.hitIndices()[quadrupletIndex][6] = triplets.hitIndices()[outerTripletIndex][4];
     quadruplets.hitIndices()[quadrupletIndex][7] = triplets.hitIndices()[outerTripletIndex][5];
 
-    quadruplets.rzChiSquared()[quadrupletIndex] = rzChiSquared;
-    quadruplets.dBeta()[quadrupletIndex] = dBeta;
-    quadruplets.promptScore()[quadrupletIndex] = promptScore;
     quadruplets.displacedScore()[quadrupletIndex] = displacedScore;
     quadruplets.fakeScore()[quadrupletIndex] = fakeScore;
 
     quadruplets.regressionRadius()[quadrupletIndex] = regressionRadius;
+#ifdef CUT_VALUE_DEBUG
+    quadruplets.rzChiSquared()[quadrupletIndex] = rzChiSquared;
+    quadruplets.dBeta()[quadrupletIndex] = dBeta;
+    quadruplets.promptScore()[quadrupletIndex] = promptScore;
     quadruplets.nonAnchorRegressionRadius()[quadrupletIndex] = nonAnchorRegressionRadius;
+#endif
     quadruplets.regressionCenterX()[quadrupletIndex] = regressionCenterX;
     quadruplets.regressionCenterY()[quadrupletIndex] = regressionCenterY;
   };

--- a/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
@@ -84,11 +84,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     quintuplets.hitIndices()[quintupletIndex][8] = triplets.hitIndices()[outerTripletIndex][4];
     quintuplets.hitIndices()[quintupletIndex][9] = triplets.hitIndices()[outerTripletIndex][5];
     quintuplets.bridgeRadius()[quintupletIndex] = bridgeRadius;
+#ifdef CUT_VALUE_DEBUG
     quintuplets.rzChiSquared()[quintupletIndex] = rzChiSquared;
     quintuplets.chiSquared()[quintupletIndex] = rPhiChiSquared;
     quintuplets.nonAnchorChiSquared()[quintupletIndex] = nonAnchorChiSquared;
     quintuplets.dBeta1()[quintupletIndex] = dBeta1;
     quintuplets.dBeta2()[quintupletIndex] = dBeta2;
+#endif
     quintuplets.dnnScore()[quintupletIndex] = dnnScore;
 
     CMS_UNROLL_LOOP

--- a/RecoTracker/LSTCore/src/alpaka/Segment.h
+++ b/RecoTracker/LSTCore/src/alpaka/Segment.h
@@ -186,13 +186,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                          uint16_t outerLowerModuleIndex,
                                                          unsigned int innerMDAnchorHitIndex,
                                                          unsigned int outerMDAnchorHitIndex,
-                                                         float dPhi,
-                                                         float dPhiMin,
-                                                         float dPhiMax,
                                                          float dPhiChange,
                                                          float dPhiChangeMin,
                                                          float dPhiChangeMax,
 #ifdef CUT_VALUE_DEBUG
+                                                         float dPhi,
+                                                         float dPhiMin,
+                                                         float dPhiMax,
                                                          float zHi,
                                                          float zLo,
                                                          float rtHi,
@@ -209,10 +209,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     segments.innerMiniDoubletAnchorHitIndices()[idx] = innerMDAnchorHitIndex;
     segments.outerMiniDoubletAnchorHitIndices()[idx] = outerMDAnchorHitIndex;
 
+    segments.dPhiChanges()[idx] = __F2H(dPhiChange);
+#ifdef CUT_VALUE_DEBUG
     segments.dPhis()[idx] = __F2H(dPhi);
     segments.dPhiMins()[idx] = __F2H(dPhiMin);
     segments.dPhiMaxs()[idx] = __F2H(dPhiMax);
-    segments.dPhiChanges()[idx] = __F2H(dPhiChange);
+#endif
     segments.dPhiChangeMins()[idx] = __F2H(dPhiChangeMin);
     segments.dPhiChangeMaxs()[idx] = __F2H(dPhiChangeMax);
 
@@ -771,13 +773,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                    outerLowerModuleIndex,
                                    innerMiniDoubletAnchorHitIndex,
                                    outerMiniDoubletAnchorHitIndex,
-                                   dPhi,
-                                   dPhiMin,
-                                   dPhiMax,
                                    dPhiChange,
                                    dPhiChangeMin,
                                    dPhiChangeMax,
 #ifdef CUT_VALUE_DEBUG
+                                   dPhi,
+                                   dPhiMin,
+                                   dPhiMax,
                                    zHi,
                                    zLo,
                                    rtHi,

--- a/RecoTracker/LSTCore/standalone/code/core/trkCore.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/trkCore.cc
@@ -320,6 +320,8 @@ float runTrackCandidate(LSTEvent* event, bool no_pls_dupclean, bool tc_pls_tripl
     std::cout << "# of T5 TrackCandidates produced: " << event->getNumberOfT5TrackCandidates() << std::endl;
   if (ana.verbose >= 2)
     std::cout << "# of T4 TrackCandidates produced: " << event->getNumberOfT4TrackCandidates() << std::endl;
+  if (ana.verbose >= 2)
+    printf("[MEM] Total: %.1f MB\n", event->getMemoryAllocatedMB());
 
   return tc_elapsed;
 }

--- a/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
@@ -172,7 +172,9 @@ void createT4DNNBranches() {
   ana.tx->createBranch<std::vector<float>>("t4_t3_promptScore2");
   ana.tx->createBranch<std::vector<float>>("t4_t3_displacedScore2");
   ana.tx->createBranch<std::vector<float>>("t4_regressionRadius");
+#ifdef CUT_VALUE_DEBUG
   ana.tx->createBranch<std::vector<float>>("t4_nonAnchorRegressionRadius");
+#endif
 
   // Hit-specific branches
   std::vector<std::string> hitIndices = {"0", "1", "2", "3", "4", "5"};
@@ -451,13 +453,17 @@ void createQuadrupletBranches() {
   ana.tx->createBranch<std::vector<float>>("t4_eta");
   ana.tx->createBranch<std::vector<float>>("t4_phi");
   ana.tx->createBranch<std::vector<int>>("t4_isDup");
+#ifdef CUT_VALUE_DEBUG
   ana.tx->createBranch<std::vector<float>>("t4_rzChiSquared");
+#endif
   ana.tx->createBranch<std::vector<float>>("t4_pMatched");
   ana.tx->createBranch<std::vector<float>>("t4_sim_vxy");
   ana.tx->createBranch<std::vector<float>>("t4_sim_vz");
   ana.tx->createBranch<std::vector<std::vector<int>>>("t4_matched_simIdx");
+#ifdef CUT_VALUE_DEBUG
   ana.tx->createBranch<std::vector<float>>("t4_score_rphisum");
   ana.tx->createBranch<std::vector<float>>("t4_promptScore");
+#endif
   ana.tx->createBranch<std::vector<float>>("t4_displacedScore");
   ana.tx->createBranch<std::vector<float>>("t4_fakeScore");
 
@@ -569,11 +575,13 @@ void createPixelTripletBranches() {
   ana.tx->createBranch<std::vector<std::vector<float>>>("pT3_simIdxAllFrac");
   // pT3 DNN branches below.
   ana.tx->createBranch<std::vector<float>>("pT3_pixelRadius");
-  ana.tx->createBranch<std::vector<float>>("pT3_pixelRadiusError");
   ana.tx->createBranch<std::vector<float>>("pT3_tripletRadius");
+#ifdef CUT_VALUE_DEBUG
+  ana.tx->createBranch<std::vector<float>>("pT3_pixelRadiusError");
   ana.tx->createBranch<std::vector<float>>("pT3_rPhiChiSquared");
   ana.tx->createBranch<std::vector<float>>("pT3_rPhiChiSquaredInwards");
   ana.tx->createBranch<std::vector<float>>("pT3_rzChiSquared");
+#endif
   ana.tx->createBranch<std::vector<int>>("pT3_moduleType_binary");
   ana.tx->createBranch<std::vector<float>>("pT3_pLS_pMatched");
 }
@@ -1435,9 +1443,11 @@ std::map<unsigned int, unsigned int> setQuadrupletBranches(LSTEvent* event,
       ana.tx->pushbackToBranch<float>("t4_innerRadius", __H2F(quadruplets.innerRadius()[t4Idx]));
       ana.tx->pushbackToBranch<float>("t4_outerRadius", __H2F(quadruplets.outerRadius()[t4Idx]));
       ana.tx->pushbackToBranch<float>("t4_pMatched", percent_matched);
+#ifdef CUT_VALUE_DEBUG
       ana.tx->pushbackToBranch<float>("t4_score_rphisum", __H2F(quadruplets.score_rphisum()[t4Idx]));
       ana.tx->pushbackToBranch<float>("t4_rzChiSquared", quadruplets.rzChiSquared()[t4Idx]);
       ana.tx->pushbackToBranch<float>("t4_promptScore", quadruplets.promptScore()[t4Idx]);
+#endif
       ana.tx->pushbackToBranch<float>("t4_displacedScore", quadruplets.displacedScore()[t4Idx]);
       ana.tx->pushbackToBranch<float>("t4_fakeScore", quadruplets.fakeScore()[t4Idx]);
 
@@ -1937,13 +1947,15 @@ std::map<unsigned int, unsigned int> setPixelTripletBranches(LSTEvent* event,
     // pT3 DNN branches below.
 
     float pixelRadius = pixelTriplets.pixelRadius()[ipT3];
-    float pixelRadiusError = pixelTriplets.pixelRadiusError()[ipT3];
     float tripletRadius = pixelTriplets.tripletRadius()[ipT3];
     float phi_t3 = pixelTriplets.phi()[ipT3];       // from the T3
     float phi_pix = pixelTriplets.phi_pix()[ipT3];  // from the pLS
+#ifdef CUT_VALUE_DEBUG
+    float pixelRadiusError = pixelTriplets.pixelRadiusError()[ipT3];
     float rPhiChiSquared = pixelTriplets.rPhiChiSquared()[ipT3];
     float rPhiChiSquaredInwards = pixelTriplets.rPhiChiSquaredInwards()[ipT3];
     float rzChiSquared = pixelTriplets.rzChiSquared()[ipT3];
+#endif
     float eta_t3 = pixelTriplets.eta()[ipT3];
     float eta_pix = pixelTriplets.eta_pix()[ipT3];  // eta from pLS
 
@@ -1997,12 +2009,14 @@ std::map<unsigned int, unsigned int> setPixelTripletBranches(LSTEvent* event,
     ana.tx->pushbackToBranch<float>("pT3_t3_phi", phi_t3);
     ana.tx->pushbackToBranch<float>("pT3_t3_pMatched", t3_percent_matched);
     ana.tx->pushbackToBranch<float>("pT3_pLS_pMatched", pLS_percent_matched);
+    ana.tx->pushbackToBranch<float>("pT3_pixelRadius", pixelRadius);
+    ana.tx->pushbackToBranch<float>("pT3_tripletRadius", tripletRadius);
+#ifdef CUT_VALUE_DEBUG
     ana.tx->pushbackToBranch<float>("pT3_rPhiChiSquared", rPhiChiSquared);
     ana.tx->pushbackToBranch<float>("pT3_rPhiChiSquaredInwards", rPhiChiSquaredInwards);
     ana.tx->pushbackToBranch<float>("pT3_rzChiSquared", rzChiSquared);
-    ana.tx->pushbackToBranch<float>("pT3_pixelRadius", pixelRadius);
     ana.tx->pushbackToBranch<float>("pT3_pixelRadiusError", pixelRadiusError);
-    ana.tx->pushbackToBranch<float>("pT3_tripletRadius", tripletRadius);
+#endif
     ana.tx->pushbackToBranch<int>("pT3_moduleType_binary", module_type_binary);
 
     // end of pT3 DNN branches.
@@ -2825,7 +2839,9 @@ void setT4DNNBranches(LSTEvent* event) {
       ana.tx->pushbackToBranch<float>("t4_t3_displacedScore2", tripletsSoA.displacedScore()[t3sIdx[1]]);
 
       ana.tx->pushbackToBranch<float>("t4_regressionRadius", quadruplets.regressionRadius()[t4Idx]);
+#ifdef CUT_VALUE_DEBUG
       ana.tx->pushbackToBranch<float>("t4_nonAnchorRegressionRadius", quadruplets.nonAnchorRegressionRadius()[t4Idx]);
+#endif
 
       if (t4s_used_in_tc.find(t4Idx) != t4s_used_in_tc.end()) {
         ana.tx->pushbackToBranch<int>("t4_partOfTC", 1);
@@ -2970,11 +2986,11 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
   //
   //       *
   //       |\
-    //       | \
-    //       |1 \
-    //       |   \
-    //       |  * \
-    //       |
+  //       | \
+  //       |1 \
+  //       |   \
+  //       |  * \
+  //       |
   //       |
   //       |
   //       |
@@ -3010,10 +3026,10 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
   //
   //       *
   //       |\
-    //       | \
-    //       |1 \
-    //       |   \
-    //       |  * X   (* here are "two" MDs but really just one)
+  //       | \
+  //       |1 \
+  //       |   \
+  //       |  * X   (* here are "two" MDs but really just one)
   //       |   /
   //       |2 /
   //       | /


### PR DESCRIPTION
This PR reduces device memory allocation in LST up to 70% on average by dynamically sizing buffers based on event content rather than fixed upper limits. Track candidate buffers are sized by a new `CountSurvivingTCs` kernel, replacing hardcoded caps. Pixel module buffers are likewise allocated to their actual input sizes. Also, unused SoA fields are put behind a compile-time flag to reduce per-element buffer sizes. Lastly, an extra cut is included in one of the existing sizing kernels to reduce the buffer size for T3s in LST. Timing and physics performance are unchanged on both CPU and GPU backends.

This table is an average over 10 events.
<img width="700" alt="Screenshot 2026-02-15 at 1 46 36 PM" src="https://github.com/user-attachments/assets/30da2099-1fb3-4823-8f21-1113571626c0" />

c.c. @slava77 