### PR TITLE
Automated configuration splitter for MPI

### DIFF
--- a/HeterogeneousCore/MPICore/README.md
+++ b/HeterogeneousCore/MPICore/README.md
@@ -87,6 +87,32 @@ They also produce a copy of the `MPIToken`, so other modules can consume it to d
 
 An automated test is available in the `test/` directory.
 
+## Automatic configuration splitter
+
+In order to use MPI functionality in CMSSW, you need to create special configurations with MPI modules performing the 
+communication. Therefore we provide ```edmMpiSplitConfig.py``` script which allows to split any given
+python process configuration into 2 parts: local and remote.
+
+The tool takes modules to offload as a command line parameter and analyzes data dependencies between CMSSW modules.
+It generates two derived configuration files: a *local* process config and a *remote* process config.
+
+Modules specified for offloading will be moved to the remote process.
+Any required data products are automatically identified and forwarded
+between processes unless the producing module is explicitly marked as shared.
+
+The example command to offload GPU component of ECAL, HCAL and Pixels would be following:
+
+```
+python3 edmMpiSplitConfig.py hlt.py --remote-modules hltEcalDigisSoA hltEcalUncalibRecHitSoA \
+        hltHcalDigisSoA hltHbheRecoSoA hltParticleFlowRecHitHBHESoA hltParticleFlowClusterHBHESoA \
+        hltSiPixelClustersSoA hltSiPixelRecHitsSoA hltPixelTracksSoA hltPixelVerticesSoA \
+        --duplicate-modules hltHcalDigis hltOnlineBeamSpot   hltOnlineBeamSpotDevice \
+        --output-local local_pixels.py \
+        --output-remote remote_pixels.py
+```
+
+For more information about input parameters of the script you could run ```edmMpiSplitConfig.py -h```.
+
 
 ## Current limitations
 

--- a/HeterogeneousCore/MPICore/plugins/BuildFile.xml
+++ b/HeterogeneousCore/MPICore/plugins/BuildFile.xml
@@ -1,4 +1,5 @@
 <library file="*.cc" name="HeterogeneousCoreMPICorePlugins">
+  <use name="json"/>
   <use name="DataFormats/Provenance"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>

--- a/HeterogeneousCore/MPICore/plugins/DumpProductNames.cc
+++ b/HeterogeneousCore/MPICore/plugins/DumpProductNames.cc
@@ -1,0 +1,59 @@
+#include <fstream>
+#include <vector>
+#include <string>
+
+// JSON headers
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+
+// CMSSW
+#include "DataFormats/Provenance/interface/ProductDescription.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+class DumpProductNames : public edm::global::EDAnalyzer<> {
+public:
+  explicit DumpProductNames(edm::ParameterSet const& pset)
+      : outputFile_(pset.getParameter<std::string>("outputFile")), products_(json::array()) {
+    callWhenNewProductsRegistered([this](edm::ProductDescription const& product) {
+      products_.push_back({{"friendly_type_name", product.friendlyClassName()},
+                           {"module", product.moduleLabel()},
+                           {"product_instance", product.productInstanceName()},
+                           {"process", product.processName()},
+                           {"type", product.unwrappedType().name()},
+                           {"branch", product.branchType()}});
+    });
+  }
+
+  void analyze(edm::StreamID, const edm::Event&, const edm::EventSetup&) const override {}
+
+  void endJob() override {
+    std::ofstream out(outputFile_);
+    out << products_.dump(2);  // pretty-print with indent 2
+  }
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.setComment(
+        "This modul dumps a file with C++ names and some other data about the products in a process."
+        "It produces a json file, which is a list of entries for each product registered by the framweork."
+        " Each entry contains following fields:"
+        "\n - friendly_type_name - friendly type name"
+        "\n - module - name of the module which produces the registered product"
+        "\n - product_instance - if available"
+        "\n - process - name of the process which produces the registered product"
+        "\n - type - C++ type"
+        "\n - branch ");
+    desc.add<std::string>("outputFile", "print_cppnames.json");
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+private:
+  std::string outputFile_;
+  json products_;  // JSON array for product infos
+};
+
+DEFINE_FWK_MODULE(DumpProductNames);

--- a/HeterogeneousCore/MPICore/python/configuration_splitter/cpp_name_getter.py
+++ b/HeterogeneousCore/MPICore/python/configuration_splitter/cpp_name_getter.py
@@ -1,0 +1,99 @@
+import os
+import copy
+import subprocess
+import json
+from collections import defaultdict
+
+import FWCore.ParameterSet.Config as cms
+
+from HeterogeneousCore.MPICore.modules import *
+
+class CPPNameGetter:
+    def __init__(
+        self,
+        original_process,
+        helper_file_dir=".cppnamedir",
+        cfg_name="print_cppnames_cfg.py",
+        json_name="print_cppnames.json",
+        log_name="print_cppnames_debug.log",
+        reuse=False
+    ):
+        os.makedirs(helper_file_dir, exist_ok=True)
+
+        self.cfg_path = os.path.join(helper_file_dir, cfg_name)
+        self.json_path = os.path.join(helper_file_dir, json_name)
+        self.log_name = os.path.join(helper_file_dir, log_name)
+
+        self.reuse = reuse
+
+        if reuse:
+            if not os.path.exists(self.json_path):
+                raise RuntimeError(
+                    f"--cpp-names-exist was specified but JSON file not found: {self.json_path}"
+                )
+            self.process = None
+        else:
+            self.process = copy.deepcopy(original_process)
+
+    def get_cpp_types_of_module_products(self):
+        if self.reuse:
+            return self._read_json()
+
+        self._write_print_cppnames_config()
+        self._run_cmsrun()
+
+        return self._read_json()
+
+    def _write_print_cppnames_config(self):
+
+        self.process.PrintNames = DumpProductNames(
+            outputFile=self.json_path
+        )
+
+        self.process.PrintNamesPath = cms.EndPath(self.process.PrintNames)
+
+        if not hasattr(self.process, "schedule") or self.process.schedule is None:
+            self.process.schedule = cms.Schedule()
+
+        self.process.schedule.append(self.process.PrintNamesPath)
+
+        self.process.maxEvents.input = 0
+        self.process.options.numberOfThreads = 1
+        self.process.options.numberOfStreams = 1
+        self.process.options.numberOfConcurrentLuminosityBlocks = 1
+
+        with open(self.cfg_path, "w") as f:
+            f.write(self.process.dumpPython())
+
+    def _run_cmsrun(self):
+        with open(self.log_name, "w") as log:
+            subprocess.run(
+                ["cmsRun", self.cfg_path],
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                check=False, # Fail later with a nicer message
+            )
+
+    def _read_json(self):
+
+        if not os.path.exists(self.json_path):
+            raise RuntimeError(
+                f"JSON file not produced: {self.json_path}\n"
+                f"Check that DumpProductNames analyzer executed correctly at {self.log_name}"
+            )
+
+        with open(self.json_path) as f:
+            data = json.load(f)
+
+        if not data:
+            raise RuntimeError(
+                f"JSON file '{self.json_path}' is empty.\n"
+                f"Check the analyzer output at {self.log_name}"
+            )
+
+        products = defaultdict(list)
+
+        for entry in data:
+            products[entry["module"]].append(entry)
+
+        return products

--- a/HeterogeneousCore/MPICore/python/configuration_splitter/editor_functions.py
+++ b/HeterogeneousCore/MPICore/python/configuration_splitter/editor_functions.py
@@ -1,0 +1,184 @@
+# This module contains functions to edit local and remote processes
+from typing import Dict, List
+
+import FWCore.ParameterSet.Config as cms
+from HLTrigger.Configuration.common import *
+from HeterogeneousCore.MPICore.modules import *
+
+def add_controller_to_local(process):
+    process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+    process.MPIService.pmix_server_uri = "file:server.uri"
+    process.mpiController = MPIController()
+    # Multiple luminocity blocks are currently unsupported
+    process.options.numberOfConcurrentLuminosityBlocks = 1
+
+
+def clone_module_from_process(dst, src, name):
+    """
+    Clone module 'name' from src Process into dst Process.
+    """
+    if not hasattr(src, name):
+        raise RuntimeError(f"Module {name} not found in source process")
+
+    setattr(dst, name, getattr(src, name).clone())
+
+
+def create_remote_process(local_process, modules_to_run):
+    remote_process = cms.Process("REMOTE")
+    remote_process.load("Configuration.StandardSequences.Accelerators_cff")
+
+    # load the global psets and event setup modules
+    for module in local_process.psets.keys():
+        setattr(remote_process, module, getattr(local_process, module).clone())
+    for module in local_process.es_sources.keys():
+        setattr(remote_process, module, getattr(local_process, module).clone())
+    for module in local_process.es_producers.keys():
+        setattr(remote_process, module, getattr(local_process, module).clone())
+
+    remote_process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+    remote_process.MPIService.pmix_server_uri = "file:server.uri"
+
+    # where do i get this firstRun parameter from?
+    remote_process.source = cms.Source("MPISource")
+    #     firstRun = cms.untracked.uint32(process.Source)
+    # )
+    remote_process.maxEvents.input = -1
+
+    for module in modules_to_run:
+        clone_module_from_process(remote_process, local_process, module)
+    
+    return remote_process
+
+
+# -- functions to add senders and receivers --
+
+def is_device_product(prod):
+    return prod["type"].startswith("edm::DeviceProduct")
+
+def make_sender_patterns(module_name, products):
+    patterns = []
+
+    for p in products:
+        if is_device_product(p):
+            continue
+
+        friendly_type_name = p["friendly_type_name"]
+        label = p["product_instance"]
+
+        patterns.append(f"{friendly_type_name}_{module_name}_{label}_*")
+
+    return patterns
+
+
+def make_receiver_psets(products):
+    psets = []
+
+    for p in products:
+        if is_device_product(p):
+            continue
+
+        psets.append(
+            cms.PSet(
+                type=cms.string(p["type"]),
+                label=cms.string(p["product_instance"])
+            )
+        )
+
+    return cms.VPSet(*psets)
+
+
+def replace_module(process, name, new_module):
+    if hasattr(process, name):
+        delattr(process, name)
+    setattr(process, name, new_module)
+
+
+def get_sender_name(module_name):
+    return f"mpiSender{module_name[0].upper()}{module_name[1:]}"
+
+
+def create_sender(
+    module_name,
+    products,
+    instance,
+    sender_upstream,
+    path_state_capture=None,
+):
+    """
+    Add MPISender for one module.
+    """
+    sender_products = make_sender_patterns(module_name, products)
+
+    if path_state_capture is not None:
+        sender_products.append(f"*_{path_state_capture}__*".replace(" ", ""))
+
+    sender = cms.EDProducer(
+        "MPISender",
+        upstream=cms.InputTag(sender_upstream),
+        instance=cms.int32(instance),
+        products=cms.vstring(*sender_products),
+    )
+
+    return sender
+
+
+def create_receiver(
+    products,
+    instance,
+    receiver_upstream,
+    path_state_capture=False,
+):
+    """
+    MPIReceiver for one module.
+    """
+    receiver_products = make_receiver_psets(products)
+
+    if path_state_capture:
+        receiver_products.append(
+            cms.PSet(
+                type=cms.string("edm::PathStateToken"),
+                label=cms.string(""),
+            )
+        )
+
+    receiver = cms.EDProducer(
+        "MPIReceiver",
+        upstream=cms.InputTag(receiver_upstream),
+        instance=cms.int32(instance),
+        products=cms.VPSet(*receiver_products),
+    )
+
+    return receiver
+
+
+def make_new_path(
+    process,
+    path_name: str,
+    module_names: list[str],
+):
+    """
+    Create a cms.Path from an ordered list of module names
+    and optionally append it to the process schedule.
+    """
+
+    if not module_names:
+        raise ValueError("Offload path must contain at least one module")
+
+    modules = []
+    for name in module_names:
+        if not hasattr(process, name):
+            raise AttributeError(f"Process has no module named '{name}'")
+        modules.append(getattr(process, name))
+
+    # Chain modules with +
+    sequence = modules[0]
+    for mod in modules[1:]:
+        sequence = sequence + mod
+
+    path = cms.Path(sequence)
+    setattr(process, path_name, path)
+
+    if hasattr(process, "schedule") and process.schedule is not None:
+        process.schedule.append(path)
+
+    return path

--- a/HeterogeneousCore/MPICore/python/configuration_splitter/editor_functions.py
+++ b/HeterogeneousCore/MPICore/python/configuration_splitter/editor_functions.py
@@ -80,7 +80,29 @@ def make_receiver_psets(products):
         psets.append(
             cms.PSet(
                 type=cms.string(p["type"]),
-                label=cms.string(p["product_instance"])
+                label=cms.string(p['product_instance'])
+            )
+        )
+
+    return cms.VPSet(*psets)
+
+
+def make_grouped_receiver_psets(products):
+    psets = []
+
+    for p in products:
+        if is_device_product(p):
+            continue
+        
+        if p["product_instance"] == "":
+            label = p["module"]
+        else:
+            label = f"{p['module']}@{p['product_instance']}"
+
+        psets.append(
+            cms.PSet(
+                type=cms.string(p["type"]),
+                label=cms.string(label)
             )
         )
 
@@ -91,10 +113,6 @@ def replace_module(process, name, new_module):
     if hasattr(process, name):
         delattr(process, name)
     setattr(process, name, new_module)
-
-
-def get_sender_name(module_name):
-    return f"mpiSender{module_name[0].upper()}{module_name[1:]}"
 
 
 def create_sender(
@@ -120,6 +138,65 @@ def create_sender(
     )
 
     return sender
+
+
+def create_group_sender(
+    group,
+    all_products,
+    instance,
+    upstream_module,
+    path_state_capture=None,
+):
+    """
+    Add MPISender for multiple modules.
+    """
+    sender_products = []
+    for offloaded_module in group:
+        sender_products.extend(make_sender_patterns(offloaded_module, all_products[offloaded_module]))
+
+    if path_state_capture is not None:
+        sender_products.append(f"*_{path_state_capture}__*".replace(" ", ""))
+
+    sender = cms.EDProducer(
+        "MPISender",
+        upstream=cms.InputTag(upstream_module),
+        instance=cms.int32(instance),
+        products=cms.vstring(*sender_products),
+    )
+
+    return sender
+
+
+def create_group_receiver(
+    group,
+    all_products,
+    instance,
+    receiver_upstream,
+    path_state_capture=False,
+):
+    """
+    MPIReceiver for one module.
+    """
+    receiver_products = []
+    for offloaded_module in group:
+        receiver_products.extend(make_grouped_receiver_psets(all_products[offloaded_module]))
+
+    if path_state_capture:
+        receiver_products.append(
+            cms.PSet(
+                type=cms.string("edm::PathStateToken"),
+                label=cms.string(""),
+            )
+        )
+
+    receiver = cms.EDProducer(
+        "MPIReceiver",
+        upstream=cms.InputTag(receiver_upstream),
+        instance=cms.int32(instance),
+        products=cms.VPSet(*receiver_products),
+    )
+
+    return receiver
 
 
 def create_receiver(
@@ -149,6 +226,42 @@ def create_receiver(
     )
 
     return receiver
+
+
+def create_receiver_alias(receiver_name,
+    products,
+    module_name
+):
+    """
+    Create module aliases for receiver group
+    """
+    psets = []
+
+    for p in products:
+        if is_device_product(p):
+            continue
+        
+        if p["product_instance"] == "":
+            fromProductInstance_string = module_name
+        else:
+            fromProductInstance_string = f"{module_name}@{p['product_instance']}"
+
+        psets.append(
+            cms.PSet(
+                type=cms.string(p["friendly_type_name"]),
+                fromProductInstance=cms.string(fromProductInstance_string),
+                toProductInstance = cms.string(p["product_instance"])
+            )
+        )
+    
+    alias = cms.EDAlias(
+            **{
+                receiver_name: cms.VPSet(*psets)
+            }
+        )
+
+    return alias
+    
 
 
 def make_new_path(

--- a/HeterogeneousCore/MPICore/python/configuration_splitter/module_dependency_analyzer.py
+++ b/HeterogeneousCore/MPICore/python/configuration_splitter/module_dependency_analyzer.py
@@ -1,0 +1,253 @@
+from collections import defaultdict, deque
+from typing import Dict, Set, List
+from itertools import chain
+
+import FWCore.ParameterSet.Config as cms
+
+
+def flatten_all_to_module_set(process, user_args):
+    """
+    This function ensures that if one of the input arguments was path or sequence, 
+    it will be flattened to a module set for input consistency
+    """
+    module_list = set()
+    for name in user_args:
+        if not hasattr(process, name):
+            print(f"[WARN] process has no attribute named '{name}'")
+            continue
+        obj_ = getattr(process, name)
+        if hasattr(obj_, "moduleNames"):
+            print("is sequence")
+            module_list.extend(obj_.moduleNames())
+        else:
+            module_list.add(name)
+    return module_list
+
+
+class ModuleDependencyAnalyzer:
+    def __init__(self, process):
+        self.process = process
+        # cached core structures
+        self.module_inputs: Dict[str, Set[str]] = defaultdict(set)
+        self.producer_to_consumers: Dict[str, Set[str]] = defaultdict(set)
+        self._build_dependency_maps()
+
+    def _build_dependency_maps(self):
+        """
+        Core extraction of dependencies based on input tags (DONE ONCE)
+        """
+        for name in chain(self.process.producers_().keys(), self.process.analyzers_().keys(), \
+                            self.process.outputModules_().keys(), self.process.filters_().keys()):
+            mod = getattr(self.process, name)
+
+            for param in mod.parameters_().values():
+                for tag in self._extract_inputtags(param):
+                    producer = tag.getModuleLabel()
+                    if producer:
+                        self.module_inputs[name].add(producer)
+                        self.producer_to_consumers[producer].add(name)
+
+    def _extract_inputtags(self, value):
+        """
+        Recursively extract cms.InputTag objects from a parameter value.
+        Returns a list of cms.InputTag.
+        """
+        tags = []
+
+        if isinstance(value, cms.InputTag):
+            tags.append(value)
+
+        elif isinstance(value, cms.VInputTag):
+            for elem in value:
+                if isinstance(elem, cms.InputTag):
+                    tags.append(elem)
+                elif isinstance(elem, str):
+                    tags.append(cms.InputTag(elem))
+
+        elif isinstance(value, cms.PSet):
+            for v in value.parameters_().values():
+                tags.extend(self._extract_inputtags(v))
+
+        elif isinstance(value, (list, tuple)):
+            for v in value:
+                tags.extend(self._extract_inputtags(v))
+
+        return tags
+
+    def direct_dependencies(self, modules: Set[str]) -> Set[str]:
+        """
+        Get the modules whose products are needed
+        """
+        deps = set()
+        for m in modules:
+            deps |= self.module_inputs.get(m, set())
+        return deps
+
+    def _consumers_of(self, producer: str) -> Set[str]:
+        """
+        Get the modules which need the products of producer
+        """
+        return self.producer_to_consumers.get(producer, set())
+
+    def _restricted_graph(self, modules: Set[str]) -> Dict[str, Set[str]]:
+        """
+        Restricted dependency graph, reflecting the relationships between the modules to offload
+        """
+        graph = defaultdict(set)
+        for m in modules:
+            graph.setdefault(m, set())
+
+        for consumer in modules:
+            for producer in self.module_inputs.get(consumer, []):
+                if producer in modules:
+                    graph[producer].add(consumer)
+
+        return graph
+    
+    def _connected_groups(self, graph: Dict[str, Set[str]]) -> List[List[str]]:
+        """
+        Return list of weakly connected components.
+        Each component is returned as a list of modules ordered
+        by dependency from root to leaf.
+        """
+
+        # ---- build undirected graph ----
+        undirected = defaultdict(set)
+
+        for src, dsts in graph.items():
+            undirected[src]  # ensure node exists
+            for dst in dsts:
+                undirected[src].add(dst)
+                undirected[dst].add(src)
+
+        seen = set()
+        components = []
+
+        # ---- find weakly connected components ----
+        for node in undirected:
+            if node in seen:
+                continue
+
+            stack = [node]
+            comp = set()
+
+            while stack:
+                n = stack.pop()
+                if n in seen:
+                    continue
+                seen.add(n)
+                comp.add(n)
+                stack.extend(undirected[n] - seen)
+
+            components.append(comp)
+
+        # ---- order each component by dependencies ----
+        ordered_components = []
+
+        for comp in components:
+            # compute in-degree restricted to this component
+            indegree = {n: 0 for n in comp}
+            local_edges = defaultdict(set)
+
+            for src in comp:
+                for dst in graph.get(src, []):
+                    if dst in comp:
+                        local_edges[src].add(dst)
+                        indegree[dst] += 1
+
+            # Kahn's algorithm
+            queue = deque(sorted(n for n in comp if indegree[n] == 0))
+            ordered = []
+
+            while queue:
+                n = queue.popleft()
+                ordered.append(n)
+                for dst in local_edges.get(n, []):
+                    indegree[dst] -= 1
+                    if indegree[dst] == 0:
+                        queue.append(dst)
+
+            # If there is a cycle, append remaining nodes deterministically
+            if len(ordered) < len(comp):
+                remaining = sorted(comp - set(ordered))
+                ordered.extend(remaining)
+
+            ordered_components.append(ordered)
+
+        return ordered_components
+
+    def dependency_groups(self, modules: Set[str]) -> List[List[str]]:
+        """
+        Get dependency groups (ordered)
+        """
+        graph = self._restricted_graph(modules)
+        return self._connected_groups(graph)
+
+    def grouped_external_dependencies(
+        self,
+        groups: List[List[str]],
+    ) -> List[Set[str]]:
+        """
+        Grouped external dependencies
+        """
+
+        grouped = []
+        for group in groups:
+            gset = set(group)
+            deps = set()
+
+            for m in group:
+                for prod in self.module_inputs.get(m, []):
+                    if prod not in gset:
+                        deps.add(prod)
+
+            grouped.append(deps)
+
+        return grouped
+
+    def producer_to_groups(
+        self,
+        grouped_deps: List[Set[str]],
+    ) -> Dict[str, Set[int]]:
+        """
+        Producer → groups map
+        """
+
+        mapping = defaultdict(set)
+        for gi, deps in enumerate(grouped_deps):
+            for prod in deps:
+                mapping[prod].add(gi)
+        return mapping
+
+    def modules_to_send_back_by_group(
+        self,
+        groups: List[List[str]],
+        modules_to_run_on_both: Set[str],
+    ):
+        """
+        Which offloaded modules must send products back, and which are not needed on local
+        """
+        module_to_group = {
+            m: gi for gi, g in enumerate(groups) for m in g
+        }
+
+        result = [[] for _ in groups]
+        unused = []
+
+        for gi, group in enumerate(groups):
+            for produced in group:
+                if produced in modules_to_run_on_both:
+                    continue
+
+                needed = False
+                for consumer in self._consumers_of(produced):
+                    if module_to_group.get(consumer) != gi:
+                        needed = True
+                        break
+
+                if needed:
+                    result[gi].append(produced)
+                else:
+                    unused.append(produced)
+
+        return result, unused

--- a/HeterogeneousCore/MPICore/python/configuration_splitter/path_state_helpers.py
+++ b/HeterogeneousCore/MPICore/python/configuration_splitter/path_state_helpers.py
@@ -8,11 +8,10 @@ from typing import Dict, Set, List
 import FWCore.ParameterSet.Config as cms
 from HLTrigger.Configuration.common import *
 
-def add_activity_filter(process, module_name):
+def add_activity_filter(process, module_name, filter_name):
     filter_object =  cms.EDFilter("PathStateRelease",
             state = cms.InputTag(module_name)
         )
-    filter_name = f"activityFilter{module_name}"
     setattr(process, filter_name, filter_object)
     return filter_name
 
@@ -27,9 +26,6 @@ def insert_path_state_capture_before(
       - create one PathStateCapture EDProducer
       - insert it at position 0 of each passed in sequence
     """
-
-    # unique module name per group
-    capture_name = f"{prefix}{capture_name}"
 
     # create the EDProducer
     setattr(

--- a/HeterogeneousCore/MPICore/python/configuration_splitter/path_state_helpers.py
+++ b/HeterogeneousCore/MPICore/python/configuration_splitter/path_state_helpers.py
@@ -1,0 +1,54 @@
+"""
+functions to add activity filters and path state captures
+"""
+
+from collections import defaultdict, deque
+from typing import Dict, Set, List
+
+import FWCore.ParameterSet.Config as cms
+from HLTrigger.Configuration.common import *
+
+def add_activity_filter(process, module_name):
+    filter_object =  cms.EDFilter("PathStateRelease",
+            state = cms.InputTag(module_name)
+        )
+    filter_name = f"activityFilter{module_name}"
+    setattr(process, filter_name, filter_object)
+    return filter_name
+
+
+def insert_path_state_capture_before(
+    process,
+    first_modules_in_a_group,
+    capture_name,
+    prefix="PathStateCapture",
+):
+    """
+      - create one PathStateCapture EDProducer
+      - insert it at position 0 of each passed in sequence
+    """
+
+    # unique module name per group
+    capture_name = f"{prefix}{capture_name}"
+
+    # create the EDProducer
+    setattr(
+        process,
+        capture_name,
+        cms.EDProducer("PathStateCapture"),
+    )
+
+    capture = getattr(process, capture_name)
+
+    # insert into sequences
+    for module_name in first_modules_in_a_group:
+        if not hasattr(process, module_name):
+            print(f"[WARN] process has no sequence '{module_name}'")
+            continue
+
+        module = getattr(process, module_name)
+
+        # insert at the beginning
+        insert_modules_before(process, module, capture)
+    
+    return capture_name

--- a/HeterogeneousCore/MPICore/scripts/edmMpiSplitConfig
+++ b/HeterogeneousCore/MPICore/scripts/edmMpiSplitConfig
@@ -25,20 +25,20 @@ Required arguments:
         all modules of that sequence will be offloaded
 
 Optional arguments:
-    -ol, --output-local
+    -l, --output-local
         Path to the output configuration for the local process.
         (default: local.py)
 
-    -or, --output-remote
+    -r, --output-remote
         Path to the output configuration for the remote process.
         (default: remote.py)
 
-    --duplicate-modules
+    -d, --duplicate-modules
         List of module labels that must run on both local and remote
         processes. Products from these modules are not transferred
         between processes.
     
-    --reuse-cpp-names
+    -c, --reuse-cpp-names
         False by default. If this script was run before, pass this 
         argument to reuse the generated file with C++ product names
     
@@ -46,14 +46,14 @@ Optional arguments:
         Print debug outputs
 
 Example 1 (offloading GPU part of ECAL and HCAL):
-    python3 edmMpiSplitConfig.py hlt.py --remote-modules hltEcalDigisSoA hltEcalUncalibRecHitSoA \
+    python3 edmMpiSplitConfig hlt.py --remote-modules hltEcalDigisSoA hltEcalUncalibRecHitSoA \
         hltHcalDigisSoA hltHbheRecoSoA hltParticleFlowRecHitHBHESoA hltParticleFlowClusterHBHESoA \
         --duplicate-modules hltHcalDigis \
         --output-local local.py \
         --output-remote remote.py
 
 Example 2 (offloading GPU part of ECAL, HCAL and pixels):
-    python3 edmMpiSplitConfig.py hlt.py --remote-modules hltEcalDigisSoA hltEcalUncalibRecHitSoA \
+    python3 edmMpiSplitConfig hlt.py --remote-modules hltEcalDigisSoA hltEcalUncalibRecHitSoA \
         hltHcalDigisSoA hltHbheRecoSoA hltParticleFlowRecHitHBHESoA hltParticleFlowClusterHBHESoA \
         hltSiPixelClustersSoA hltSiPixelRecHitsSoA hltPixelTracksSoA hltPixelVerticesSoA \
         --duplicate-modules hltHcalDigis hltOnlineBeamSpot   hltOnlineBeamSpotDevice \
@@ -122,38 +122,45 @@ def main():
         " instead of sending their products. Use --duplicate-modules option to specify them.\n"
         "  • Only dependencies expressed via InputTag are analyzed.\n"
         "  • Execution order inside dependency groups is preserved.\n"
-        "  • Use '--' to separate positional argument 'config' from multi-value options.\n"
     ),
-    formatter_class=argparse.RawDescriptionHelpFormatter,
+    formatter_class=argparse.RawTextHelpFormatter,
     )
-    parser.add_argument("config", type=pathlib.Path, help="HLT python config")
     parser.add_argument(
+        "config",
+        metavar="[--] config.py",
+        type=pathlib.Path,
+        help="python configuration file to be split; use '--' to separate the positional argument from multi-value options"
+    )
+    parser.add_argument(
+        "-m",
         "--remote-modules",
         nargs="+",
         default=[],
         help="Modules and/or sequences to offload",
     )
     parser.add_argument(
-        "-ol",
+        "-l",
         "--output-local",
         type=pathlib.Path,
         default=pathlib.Path("local.py"),
         help="Output config path for the local process",
     )
     parser.add_argument(
-        "-or",
+        "-r",
         "--output-remote",
         type=pathlib.Path,
         default=pathlib.Path("remote.py"),
         help="Output config path for the remote process",
     )
     parser.add_argument(
+        "-d",
         "--duplicate-modules",
         nargs="+",
         default=[],
         help="Modules that must run on both local and remote processes",
     )
     parser.add_argument(
+        "-c",
         "--reuse-cpp-names",
         action="store_true",
         help="Assume the file with C++ product names already exists; "
@@ -242,7 +249,8 @@ def main():
     local_sender_by_group = [[] for _ in range(len(groups))]
     for local_dependency, group_indices in producer_to_groups.items():
         first_dependency_in_a_group = [groups[i][0] for i in group_indices]
-        capture_name = insert_path_state_capture_before(local_process, first_modules_in_a_group=first_dependency_in_a_group, capture_name=local_dependency)
+        capture_name = f"activityCaptureBefore{local_dependency.title()}"
+        insert_path_state_capture_before(local_process, first_modules_in_a_group=first_dependency_in_a_group, capture_name=capture_name)
         sender = create_sender(
                 module_name=local_dependency,
                 products=cpp_names_of_the_products[local_dependency],
@@ -250,7 +258,7 @@ def main():
                 sender_upstream="mpiController",
                 path_state_capture = capture_name
             )
-        sender_name = get_sender_name(local_dependency)
+        sender_name = f"mpiSender{local_dependency.title()}"
         setattr(local_process, sender_name, sender)
 
         receiver = create_receiver(
@@ -260,7 +268,8 @@ def main():
                 path_state_capture=True,
             )
         # create filter for the path state
-        filter_name = add_activity_filter(remote_process, local_dependency)
+        filter_name = f"activityFilterAfter{local_dependency.title()}"
+        add_activity_filter(remote_process, local_dependency, filter_name)
         for group_idx in group_indices:
             remote_filters_by_group[group_idx].append(filter_name)
             local_sender_by_group[group_idx].append(sender_name)
@@ -277,7 +286,8 @@ def main():
         # In this approach if there are 2 senders with intersecting groups, it will result in only one group activation sender-receiver pair per group
         if len(group_indices) >= 2:
             for group_idx in group_indices:
-                capture_name = insert_path_state_capture_before(local_process, first_modules_in_a_group=[groups[group_idx][0]], capture_name=f"Group{group_idx}Activation")
+                capture_name=f"activityCaptureBeforeGroup{group_idx}"
+                insert_path_state_capture_before(local_process, first_modules_in_a_group=[groups[group_idx][0]], capture_name=capture_name)
                 sender = create_sender(
                         module_name=local_dependency,
                         products=[],
@@ -285,7 +295,7 @@ def main():
                         sender_upstream="mpiController",
                         path_state_capture = capture_name
                     )
-                sender_name = f"Group{group_idx}ActivationSender"
+                sender_name = f"mpiSenderGroup{group_idx}Activity"
                 setattr(local_process, sender_name, sender)
 
                 receiver = create_receiver(
@@ -294,11 +304,12 @@ def main():
                         receiver_upstream="source",
                         path_state_capture=True,
                     )
-                receiver_name = f"MPIReceiverGroup{group_idx}Activation"
+                receiver_name = f"mpiReceiverGroup{group_idx}Activity"
                 setattr(remote_process, receiver_name, receiver)
 
                 # create filter for the path state
-                filter_name = add_activity_filter(remote_process, receiver_name)
+                filter_name = f"activityFilterBeforeGroup{group_idx}"
+                add_activity_filter(remote_process, receiver_name, filter_name)
                 remote_filters_by_group[group_idx].append(filter_name)
                 local_sender_by_group[group_idx].append(sender_name)
 
@@ -314,52 +325,54 @@ def main():
         if len(group)==0:
             continue
 
-        remote_capture_name = f"PathStateCaptureGroup{group_idx}"
+        remote_capture_name = f"activityCaptureAfterGroup{group_idx}"
         setattr(remote_process, remote_capture_name, cms.EDProducer("PathStateCapture"))
         per_group_remote_captures[group_idx].append(remote_capture_name)
         
+        sender = create_group_sender(
+            group=group,
+            all_products=cpp_names_of_the_products,
+            instance=instance,
+            upstream_module=mpi_path_modules_remote[0],
+            path_state_capture=remote_capture_name,
+        )
+        sender_name = f"mpiSenderGroup{group_idx}"
+        setattr(remote_process, sender_name, sender)
+        
+        if len(local_sender_by_group[group_idx]) != 0:
+            receiver_upstream = local_sender_by_group[group_idx][-1]
+        else:
+            receiver_upstream = "mpiController"
+        
+        receiver = create_group_receiver(
+            group=group,
+            all_products=cpp_names_of_the_products,
+            instance=instance,
+            receiver_upstream=receiver_upstream,
+            path_state_capture=True,
+        )
+        receiver_name = f"mpiReceiverGroup{group_idx}"
+        setattr(local_process, receiver_name, receiver)
+        
+        instance += 1
+        
+        # insert filter on local before the first module which was supposed to run (is it correct?)
+        filter_name = f"activityFilterAfterGroup{group_idx}"
+        add_activity_filter(local_process, receiver_name, filter_name)
+        insert_modules_before(local_process, getattr(local_process, group[0]), getattr(local_process, filter_name))
+        
+        mpi_path_modules_remote.append(sender_name)
+        mpi_path_modules_local.append(receiver_name)
+        
+        
         for i, offloaded_module in enumerate(group):
-            if i == 0:
-                # First sender in the group has to depend on source 
-                sender_upstream=mpi_path_modules_remote[0]
-                # First receiver on local depend on the last sender from group or on local controller
-                if len(local_sender_by_group[group_idx]) != 0:
-                    receiver_upstream = local_sender_by_group[group_idx][-1]
-                else:
-                    receiver_upstream = "mpiController"
-            else:
-                sender_upstream=mpi_path_modules_remote[-1]
-                receiver_upstream=mpi_path_modules_local[-1]
-            
-            sender = create_sender(
-                module_name=offloaded_module,
-                products=cpp_names_of_the_products[offloaded_module],
-                instance=instance,
-                sender_upstream=sender_upstream,
-                path_state_capture = remote_capture_name
-            )
-            sender_name = get_sender_name(offloaded_module)
-            setattr(remote_process, sender_name, sender)
-
-            receiver = create_receiver(
-                products=cpp_names_of_the_products[offloaded_module],
-                instance=instance,
-                receiver_upstream=receiver_upstream,
-                path_state_capture=True,
-            )
-
-            # insert filter on local before the first module which was supposed to run (is it correct?)
-            if i == 0:
-                filter_name = add_activity_filter(local_process, offloaded_module)
-                insert_modules_before(local_process, getattr(local_process, offloaded_module), getattr(local_process, filter_name))
-
             delattr(local_process, offloaded_module)
-            setattr(local_process, offloaded_module, receiver)
+            module_alias = create_receiver_alias(receiver_name=receiver_name,
+                products=cpp_names_of_the_products[offloaded_module],
+                module_name=offloaded_module
+            )
+            setattr(local_process, offloaded_module, module_alias)
 
-
-            instance += 1
-            mpi_path_modules_local.append(offloaded_module)
-            mpi_path_modules_remote.append(sender_name)
     
     # delete offloaded modules whose products are not needed on local from the local process:
     for product in modules_without_local_deps:

--- a/HeterogeneousCore/MPICore/scripts/edmMpiSplitConfig
+++ b/HeterogeneousCore/MPICore/scripts/edmMpiSplitConfig
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+
+"""
+This script splits an HLT configuration into local and remote processes
+by offloading selected modules or sequences.
+
+This tool analyzes data dependencies between CMSSW modules and generates
+two derived configuration files:
+    - a *local* process config
+    - a *remote* process config
+
+Modules specified for offloading will be moved to the remote process.
+Any required data products are automatically identified and forwarded
+between processes unless the producing module is explicitly marked as
+shared.
+
+Positional arguments:
+    config
+        Path to the input HLT Python configuration file.
+
+Required arguments:
+    --remote-modules
+        Modules to be offloaded to the remote process.
+        Sequences can also be passed as a parameter, in which case
+        all modules of that sequence will be offloaded
+
+Optional arguments:
+    -ol, --output-local
+        Path to the output configuration for the local process.
+        (default: local.py)
+
+    -or, --output-remote
+        Path to the output configuration for the remote process.
+        (default: remote.py)
+
+    --duplicate-modules
+        List of module labels that must run on both local and remote
+        processes. Products from these modules are not transferred
+        between processes.
+    
+    --reuse-cpp-names
+        False by default. If this script was run before, pass this 
+        argument to reuse the generated file with C++ product names
+    
+    -v, --verbose
+        Print debug outputs
+
+Example 1 (offloading GPU part of ECAL and HCAL):
+    python3 edmMpiSplitConfig.py hlt.py --remote-modules hltEcalDigisSoA hltEcalUncalibRecHitSoA \
+        hltHcalDigisSoA hltHbheRecoSoA hltParticleFlowRecHitHBHESoA hltParticleFlowClusterHBHESoA \
+        --duplicate-modules hltHcalDigis \
+        --output-local local.py \
+        --output-remote remote.py
+
+Example 2 (offloading GPU part of ECAL, HCAL and pixels):
+    python3 edmMpiSplitConfig.py hlt.py --remote-modules hltEcalDigisSoA hltEcalUncalibRecHitSoA \
+        hltHcalDigisSoA hltHbheRecoSoA hltParticleFlowRecHitHBHESoA hltParticleFlowClusterHBHESoA \
+        hltSiPixelClustersSoA hltSiPixelRecHitsSoA hltPixelTracksSoA hltPixelVerticesSoA \
+        --duplicate-modules hltHcalDigis hltOnlineBeamSpot   hltOnlineBeamSpotDevice \
+        --output-local local_pixels.py \
+        --output-remote remote_pixels.py
+
+
+Notes:
+    - Only data dependencies expressed via InputTag are considered.
+    - Module execution order inside dependency groups is preserved.
+
+Some TBDs:
+    - Now we check all dependencies by input tags. We have to try utilising DependencyGraph. 
+      Modifying the service is mandatory, because current visual graph is to large to be processed
+    - (maybe later?) Do more elegant file dumping
+    - Test if the results and througputs are the same as in manual split
+
+"""
+
+import argparse
+import pathlib
+import os
+import sys
+
+from HeterogeneousCore.MPICore.configuration_splitter.cpp_name_getter import CPPNameGetter
+from HeterogeneousCore.MPICore.configuration_splitter.module_dependency_analyzer import ModuleDependencyAnalyzer, flatten_all_to_module_set
+from HeterogeneousCore.MPICore.configuration_splitter.editor_functions import *
+from HeterogeneousCore.MPICore.configuration_splitter.path_state_helpers import *
+from FWCore.ParameterSet.processFromFile import processFromFile
+
+
+def main():
+    parser = argparse.ArgumentParser(
+    description=(
+        "Split a CMSSW configuration into local and remote processes for MPI execution.\n"
+        "Selected modules (or sequences) are offloaded to a remote process while "
+        "the remaining modules stay in the local process. Data dependencies are "
+        "automatically analyzed and the required products are forwarded between processes."
+    ),
+    epilog=(
+        "Examples:\n"
+        "\n"
+        "Offload ECAL and HCAL GPU reconstruction modules:\n"
+        "  python3 edmMpiSplitConfig.py hlt.py --remote-modules \\\n"
+        "      hltEcalDigisSoA hltEcalUncalibRecHitSoA \\\n"
+        "      hltHcalDigisSoA hltHbheRecoSoA \\\n"
+        "      hltParticleFlowRecHitHBHESoA hltParticleFlowClusterHBHESoA \\\n"
+        "      --duplicate-modules hltHcalDigis \\\n"
+        "      --output-local local.py --output-remote remote.py\n"
+        "\n"
+        "Offload ECAL, HCAL and Pixel GPU reconstruction:\n"
+        "  python3 edmMpiSplitConfig.py hlt.py --remote-modules \\\n"
+        "      hltEcalDigisSoA hltEcalUncalibRecHitSoA \\\n"
+        "      hltHcalDigisSoA hltHbheRecoSoA \\\n"
+        "      hltParticleFlowRecHitHBHESoA hltParticleFlowClusterHBHESoA \\\n"
+        "      hltSiPixelClustersSoA hltSiPixelRecHitsSoA \\\n"
+        "      hltPixelTracksSoA hltPixelVerticesSoA \\\n"
+        "      --duplicate-modules hltHcalDigis hltOnlineBeamSpot hltOnlineBeamSpotDevice\n"
+        "\n"
+        "Notes:\n"
+        "  • To split a configurationm it must be processed with 0 events."
+        " This will cause creating output files and directories (by default in '.cppnamedir' directory).\n"
+        "  • If the splitter was run before, --reuse-cpp-names avoids rerunning cmsRun for products' characteristics."
+        " Passing this option will make the script run much faster, given that needed information already exists.\n"
+        "  • For some modules it might be better to run on both processes"
+        " instead of sending their products. Use --duplicate-modules option to specify them.\n"
+        "  • Only dependencies expressed via InputTag are analyzed.\n"
+        "  • Execution order inside dependency groups is preserved.\n"
+        "  • Use '--' to separate positional argument 'config' from multi-value options.\n"
+    ),
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("config", type=pathlib.Path, help="HLT python config")
+    parser.add_argument(
+        "--remote-modules",
+        nargs="+",
+        default=[],
+        help="Modules and/or sequences to offload",
+    )
+    parser.add_argument(
+        "-ol",
+        "--output-local",
+        type=pathlib.Path,
+        default=pathlib.Path("local.py"),
+        help="Output config path for the local process",
+    )
+    parser.add_argument(
+        "-or",
+        "--output-remote",
+        type=pathlib.Path,
+        default=pathlib.Path("remote.py"),
+        help="Output config path for the remote process",
+    )
+    parser.add_argument(
+        "--duplicate-modules",
+        nargs="+",
+        default=[],
+        help="Modules that must run on both local and remote processes",
+    )
+    parser.add_argument(
+        "--reuse-cpp-names",
+        action="store_true",
+        help="Assume the file with C++ product names already exists; "
+            "do not run cmsRun to regenerate it",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Print execution logs of the splitter",
+    )
+
+    args = parser.parse_args()
+
+    local_process = processFromFile(str(args.config))
+
+    modules_to_offload = flatten_all_to_module_set(local_process, args.remote_modules)
+    modules_to_run_on_both = flatten_all_to_module_set(local_process, args.duplicate_modules)
+    
+    # list of all modules to run on remote
+    modules_to_offload |= modules_to_run_on_both
+
+    analyzer = ModuleDependencyAnalyzer(local_process)
+
+    groups = analyzer.dependency_groups(modules_to_offload)
+    grouped_deps = analyzer.grouped_external_dependencies(groups)
+    producer_to_groups = analyzer.producer_to_groups(grouped_deps)
+
+    if args.verbose:
+        print("Dependency groups: ", groups)
+        print("Grouped depencencies:", grouped_deps )
+        print("Local producers - dependant groups correspondance: ", producer_to_groups)
+
+
+    # get products whose data needs to be sent, excluding modules without local dependencies and modules which should run on both processes
+    modules_to_send, modules_without_local_deps = analyzer.modules_to_send_back_by_group(groups, modules_to_run_on_both)
+
+    if args.verbose:
+        print("Offloaded modues whose products need to be sent: ", modules_to_send)
+        print("Offloaded modules without local dependencies: ", modules_without_local_deps)
+
+
+    # -- get c++ names --
+
+    if args.verbose:
+        if not args.reuse_cpp_names:
+            print("Launching cmsRun to get C++ names of all products in the process...")
+        else:
+            print("Truing to get C++ product names from existing file...")
+
+    cpp_names_getter = CPPNameGetter(local_process, reuse=args.reuse_cpp_names)
+    cpp_names_of_the_products = cpp_names_getter.get_cpp_types_of_module_products()
+
+    if args.verbose:
+        print("Got C++ product names")
+    
+
+    # --- start editing ---
+
+    add_controller_to_local(local_process)
+    remote_process = create_remote_process(local_process, modules_to_offload)
+
+    mpi_path_modules_local = ["mpiController"]
+    mpi_path_modules_remote = []
+
+    instance = 1
+
+    # how to add state captures to the splitter?
+
+    # 1) For the local sender - create path state capture per sender. 
+    # Insert this path state capture before the first module of each needed group.
+    # If multiple groups need these products, create individual path state captures
+    # and add separate senders on top
+    # 
+    # 2) For the remote receiver - add path state product to the list.
+    # Add the general activity filter at the beginning of the group path
+    # and, if needed, separate activity filters for each group
+    #
+    # 3) For the remote sender - add the state capture at the end of the groups path.
+    # Each sender module for this group depens on this state capture
+    #
+    # 4) For the local receiver - before deleting the offloaded module, insert filter for the activity it receives
+
+    # send the data needed by offloaded modules from local to remote
+    remote_filters_by_group = [[] for _ in range(len(groups))]
+    local_sender_by_group = [[] for _ in range(len(groups))]
+    for local_dependency, group_indices in producer_to_groups.items():
+        first_dependency_in_a_group = [groups[i][0] for i in group_indices]
+        capture_name = insert_path_state_capture_before(local_process, first_modules_in_a_group=first_dependency_in_a_group, capture_name=local_dependency)
+        sender = create_sender(
+                module_name=local_dependency,
+                products=cpp_names_of_the_products[local_dependency],
+                instance=instance,
+                sender_upstream="mpiController",
+                path_state_capture = capture_name
+            )
+        sender_name = get_sender_name(local_dependency)
+        setattr(local_process, sender_name, sender)
+
+        receiver = create_receiver(
+                products=cpp_names_of_the_products[local_dependency],
+                instance=instance,
+                receiver_upstream="source",
+                path_state_capture=True,
+            )
+        # create filter for the path state
+        filter_name = add_activity_filter(remote_process, local_dependency)
+        for group_idx in group_indices:
+            remote_filters_by_group[group_idx].append(filter_name)
+            local_sender_by_group[group_idx].append(sender_name)
+        
+        setattr(remote_process, local_dependency, receiver)
+
+        instance += 1
+        mpi_path_modules_local.append(sender_name)
+        mpi_path_modules_remote.append(local_dependency)
+
+        # Handle the case when onle local product is needed by multiple remote groups
+        # For sending from local process - if data is needed by multiple paths, insert additional path state capture and additional sender per group
+        # On remote insert one more receiver for this capture and one more filter in the beginning of the deps group
+        # In this approach if there are 2 senders with intersecting groups, it will result in only one group activation sender-receiver pair per group
+        if len(group_indices) >= 2:
+            for group_idx in group_indices:
+                capture_name = insert_path_state_capture_before(local_process, first_modules_in_a_group=[groups[group_idx][0]], capture_name=f"Group{group_idx}Activation")
+                sender = create_sender(
+                        module_name=local_dependency,
+                        products=[],
+                        instance=instance,
+                        sender_upstream="mpiController",
+                        path_state_capture = capture_name
+                    )
+                sender_name = f"Group{group_idx}ActivationSender"
+                setattr(local_process, sender_name, sender)
+
+                receiver = create_receiver(
+                        products=[],
+                        instance=instance,
+                        receiver_upstream="source",
+                        path_state_capture=True,
+                    )
+                receiver_name = f"MPIReceiverGroup{group_idx}Activation"
+                setattr(remote_process, receiver_name, receiver)
+
+                # create filter for the path state
+                filter_name = add_activity_filter(remote_process, receiver_name)
+                remote_filters_by_group[group_idx].append(filter_name)
+                local_sender_by_group[group_idx].append(sender_name)
+
+                instance += 1
+                mpi_path_modules_local.append(sender_name)
+                mpi_path_modules_remote.append(receiver_name)
+    
+
+    per_group_remote_captures = [[] for _ in range(len(groups))]
+    
+    # send the results from remote to local
+    for group_idx, group in enumerate(modules_to_send):
+        if len(group)==0:
+            continue
+
+        remote_capture_name = f"PathStateCaptureGroup{group_idx}"
+        setattr(remote_process, remote_capture_name, cms.EDProducer("PathStateCapture"))
+        per_group_remote_captures[group_idx].append(remote_capture_name)
+        
+        for i, offloaded_module in enumerate(group):
+            if i == 0:
+                # First sender in the group has to depend on source 
+                sender_upstream=mpi_path_modules_remote[0]
+                # First receiver on local depend on the last sender from group or on local controller
+                if len(local_sender_by_group[group_idx]) != 0:
+                    receiver_upstream = local_sender_by_group[group_idx][-1]
+                else:
+                    receiver_upstream = "mpiController"
+            else:
+                sender_upstream=mpi_path_modules_remote[-1]
+                receiver_upstream=mpi_path_modules_local[-1]
+            
+            sender = create_sender(
+                module_name=offloaded_module,
+                products=cpp_names_of_the_products[offloaded_module],
+                instance=instance,
+                sender_upstream=sender_upstream,
+                path_state_capture = remote_capture_name
+            )
+            sender_name = get_sender_name(offloaded_module)
+            setattr(remote_process, sender_name, sender)
+
+            receiver = create_receiver(
+                products=cpp_names_of_the_products[offloaded_module],
+                instance=instance,
+                receiver_upstream=receiver_upstream,
+                path_state_capture=True,
+            )
+
+            # insert filter on local before the first module which was supposed to run (is it correct?)
+            if i == 0:
+                filter_name = add_activity_filter(local_process, offloaded_module)
+                insert_modules_before(local_process, getattr(local_process, offloaded_module), getattr(local_process, filter_name))
+
+            delattr(local_process, offloaded_module)
+            setattr(local_process, offloaded_module, receiver)
+
+
+            instance += 1
+            mpi_path_modules_local.append(offloaded_module)
+            mpi_path_modules_remote.append(sender_name)
+    
+    # delete offloaded modules whose products are not needed on local from the local process:
+    for product in modules_without_local_deps:
+        delattr(local_process, product)        
+ 
+    # add all needed paths to the processed and schedule them
+
+    make_new_path(local_process, "Offload", mpi_path_modules_local)
+    make_new_path(remote_process, "MPIPath", mpi_path_modules_remote)
+    for i, group in enumerate(groups):
+        make_new_path(remote_process, "RemoteOffloadedSequence"+str(i), remote_filters_by_group[i]+group+per_group_remote_captures[i])
+
+    # dump the 2 processes into files
+
+    args.output_local.parent.mkdir(parents=True, exist_ok=True)
+    args.output_remote.parent.mkdir(parents=True, exist_ok=True)
+
+    args.output_local.write_text(local_process.dumpPython())
+    args.output_remote.write_text(remote_process.dumpPython())
+    print("Success!")
+
+
+if __name__ == "__main__":
+    main()

--- a/HeterogeneousCore/MPICore/test/BuildFile.xml
+++ b/HeterogeneousCore/MPICore/test/BuildFile.xml
@@ -11,6 +11,8 @@
 
 <test name="testMPIFilters" command="testMPICommWorld.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/controller_filters_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_filters_cfg.py"/>
 
+<test name="testMPIAutosplitter" command="testAutomaticSplitter.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/scripts/edmMpiSplitConfig ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/configutration_for_automatic_splitter.py"/>
+
 <bin name="testSerialisation" file="testSerialisation.cc">
     <use name="root"/>
 </bin>

--- a/HeterogeneousCore/MPICore/test/configutration_for_automatic_splitter.py
+++ b/HeterogeneousCore/MPICore/test/configutration_for_automatic_splitter.py
@@ -1,0 +1,135 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("UnsplitTestProcess")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.INFO.limit = 10000000
+
+process.options.numberOfThreads = 4
+process.options.numberOfStreams = 4
+# MPIController supports a single concurrent LuminosityBlock
+process.options.numberOfConcurrentLuminosityBlocks = 1
+process.options.numberOfConcurrentRuns = 1
+process.options.wantSummary = False
+
+process.source = cms.Source("EmptySource")
+process.maxEvents.input = 20
+
+# Phase-1 FED RAW data collection pseudo object
+process.fedRawDataCollectionProducer = cms.EDProducer("TestWriteFEDRawDataCollection",
+    # Test values below are meaningless. We just make sure when we read
+    # we get the same values.
+    FEDData0 = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7),
+    FEDData3 = cms.vuint32(100, 101, 102, 103, 104, 105, 106, 107)
+)
+
+# Phase-2 RAW data buffer pseudo object
+process.rawDataBufferProducer = cms.EDProducer("TestWriteRawDataBuffer",
+    # Test values below are meaningless. We just make sure when we read
+    # we get the same values.
+    dataPattern1 = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
+    dataPattern2 = cms.vuint32(100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115)
+)
+
+# HLT trigger event pseudo object
+process.triggerEventProducer = cms.EDProducer("TestWriteTriggerEvent",
+    # Test values below are meaningless. We just make sure when we read
+    # we get the same values.
+    usedProcessName = cms.string("testName"),
+    collectionTags = cms.vstring('moduleA', 'moduleB', 'moduleC'),
+    collectionKeys = cms.vuint32(11, 21, 31),
+    ids = cms.vint32(1, 3, 5),
+    # stick to values exactly convertible from double to float
+    # to avoid potential rounding issues in the test, because
+    # the configuration only supports double not float and
+    # the data format holds floats.
+    pts = cms.vdouble(11.0, 21.0, 31.0),
+    etas = cms.vdouble(101.0, 102.0, 103.0),
+    phis = cms.vdouble(201.0, 202.0, 203.0),
+    masses = cms.vdouble(301.0, 302.0, 303.0),
+    filterTags = cms.vstring('moduleAA', 'moduleBB'),
+    elementsPerVector = cms.uint32(2),
+    filterIds = cms.vint32(1001, 1002, 1003, 1004),
+    filterKeys = cms.vuint32(2001, 2002, 2003, 2004)
+)
+
+# EDM trigger results pseudo object
+process.triggerResultsProducer = cms.EDProducer("TestWriteTriggerResults",
+    # Test values below are meaningless. We just make sure when we read
+    # we get the same values.
+    parameterSetID = cms.string('8b99d66b6c3865c75e460791f721202d'),
+    # names should normally be empty. Only extremely old data or
+    # has names filled and not empty. If it is not empty, the
+    # ParameterSetID is ignored and left default constructed.
+    names = cms.vstring(),
+    hltStates = cms.vuint32(0, 1, 2, 3),
+    moduleIndexes = cms.vuint32(11, 21, 31, 41)
+)
+
+# Phase-1 FED RAW data collection pseudo object
+process.testReadFEDRawDataCollection = cms.EDAnalyzer("TestReadFEDRawDataCollection",
+    fedRawDataCollectionTag = cms.InputTag("fedRawDataCollectionProducer"),
+    expectedFEDData0 = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7),
+    expectedFEDData3 = cms.vuint32(100, 101, 102, 103, 104, 105, 106, 107)
+)
+
+# Phase-2 RAW data buffer pseudo object
+process.testReadRawDataBuffer = cms.EDAnalyzer("TestReadRawDataBuffer",
+    rawDataBufferTag = cms.InputTag("rawDataBufferProducer"),
+    dataPattern1 = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
+    dataPattern2 = cms.vuint32(100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115)
+)
+
+# HLT trigger event pseudo object
+process.testReadTriggerEvent = cms.EDAnalyzer("TestReadTriggerEvent",
+    expectedUsedProcessName = cms.string("testName"),
+    expectedCollectionTags = cms.vstring('moduleA', 'moduleB', 'moduleC'),
+    expectedCollectionKeys = cms.vuint32(11, 21, 31),
+    expectedIds = cms.vint32(1, 3, 5),
+    # stick to values exactly convertible from double to float
+    # to avoid potential rounding issues in the test, because
+    # the configuration only supports double not float and
+    # the data format holds floats.
+    expectedPts = cms.vdouble(11.0, 21.0, 31.0),
+    expectedEtas = cms.vdouble(101.0, 102.0, 103.0),
+    expectedPhis = cms.vdouble(201.0, 202.0, 203.0),
+    expectedMasses = cms.vdouble(301.0, 302.0, 303.0),
+    expectedFilterTags = cms.vstring('moduleAA', 'moduleBB'),
+    expectedElementsPerVector = cms.uint32(2),
+    expectedFilterIds = cms.vint32(1001, 1002, 1003, 1004),
+    expectedFilterKeys = cms.vuint32(2001, 2002, 2003, 2004),
+    triggerEventTag = cms.InputTag("triggerEventProducer")
+)
+
+# EDM trigger results pseudo object
+process.testReadTriggerResults = cms.EDAnalyzer("TestReadTriggerResults",
+    triggerResultsTag = cms.InputTag("triggerResultsProducer"),
+        expectedParameterSetID = cms.string('8b99d66b6c3865c75e460791f721202d'),
+        expectedNames = cms.vstring(),
+        expectedHLTStates = cms.vuint32(0, 1, 2, 3),
+        expectedModuleIndexes = cms.vuint32(11, 21, 31, 41)
+)
+
+
+process.path1 = cms.Path(
+    process.fedRawDataCollectionProducer +
+    process.testReadFEDRawDataCollection
+)
+
+process.path2 = cms.Path(
+    process.rawDataBufferProducer +
+    process.testReadRawDataBuffer
+)
+
+process.path3 = cms.Path(
+    process.triggerEventProducer +
+    process.testReadTriggerEvent
+)
+
+process.path4 = cms.Path(
+    process.triggerResultsProducer +
+    process.testReadTriggerResults
+)
+
+
+process.schedule = cms.Schedule(*[ process.path1, process.path2, process.path3, process.path4 ])

--- a/HeterogeneousCore/MPICore/test/testAutomaticSplitter.sh
+++ b/HeterogeneousCore/MPICore/test/testAutomaticSplitter.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+# Shell script for testing the automattic config splitter for MPI in CMSSW
+
+SPLITTER=$(realpath "$1")
+WHOLE_CONFIG=$(realpath "$2")
+
+LOCAL_PATH="./autosplit_result/local_test_config.py"
+REMOTE_PATH="./autosplit_result/remote_test_config.py"
+
+python3 "$SPLITTER" "$WHOLE_CONFIG" \
+  --remote-modules triggerEventProducer testReadTriggerResults rawDataBufferProducer testReadFEDRawDataCollection \
+  -ol "$LOCAL_PATH" -or "$REMOTE_PATH"
+
+"$CMSSW_BASE"/src/HeterogeneousCore/MPICore/test/testMPICommWorld.sh "$LOCAL_PATH" "$REMOTE_PATH"

--- a/HeterogeneousCore/MPICore/test/testAutomaticSplitter.sh
+++ b/HeterogeneousCore/MPICore/test/testAutomaticSplitter.sh
@@ -10,6 +10,6 @@ REMOTE_PATH="./autosplit_result/remote_test_config.py"
 
 python3 "$SPLITTER" "$WHOLE_CONFIG" \
   --remote-modules triggerEventProducer testReadTriggerResults rawDataBufferProducer testReadFEDRawDataCollection \
-  -ol "$LOCAL_PATH" -or "$REMOTE_PATH"
+  -l "$LOCAL_PATH" -r "$REMOTE_PATH"
 
 "$CMSSW_BASE"/src/HeterogeneousCore/MPICore/test/testMPICommWorld.sh "$LOCAL_PATH" "$REMOTE_PATH"


### PR DESCRIPTION
#### PR description:

This PR adds a few python modules to HeterogeneousCore/MPICore package, which allow to split a CMSSW python configuration into 2 proccesses: local and remote with a set of specified modules to offload

#### PR validation:

To validate a pr, you can choose a HLT configuration and split it using the `local_remote_splitter.py` script. Then launch via mpi as `mpirun -np 1 cmsRun <remote config name> :  -np 1 cmsRun <local config name>`
