### PR TITLE
Use Fwd.h files for classes which are stored [part 1]

### DIFF
--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h
@@ -25,7 +25,6 @@ class AlignableMuon;
 class AlignableExtras;
 class AlignmentParameterStore;
 class IntegratedCalibrationBase;
-class Trajectory;
 // These data formats cannot be forward declared since they are typedef's,
 // so include the headers that define the typedef's
 // (no need to include in dependencies in BuildFile):
@@ -38,6 +37,7 @@ class Trajectory;
 #include "DataFormats/Alignment/interface/AliClusterValueMapFwd.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/BeamSpot/interface/BeamSpotFwd.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 

--- a/Alignment/CommonAlignmentAlgorithm/interface/IntegratedCalibrationBase.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/IntegratedCalibrationBase.h
@@ -20,6 +20,7 @@
  */
 
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 
 #include <vector>
 #include <utility>
@@ -30,7 +31,6 @@ class AlignableMuon;
 class AlignableExtras;
 
 class TrajectoryStateOnSurface;
-class TrackingRecHit;
 
 namespace edm {
   class EventSetup;

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentCSCBeamHaloSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentCSCBeamHaloSelector.h
@@ -4,14 +4,13 @@
 #include <vector>
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 namespace edm {
   class Event;
   class ParameterSet;
 }  // namespace edm
-
-class TrackingRecHit;
 
 class AlignmentCSCBeamHaloSelector {
 public:

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentCSCOverlapSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentCSCOverlapSelector.h
@@ -4,13 +4,12 @@
 #include <vector>
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 
 namespace edm {
   class Event;
   class ParameterSet;
 }  // namespace edm
-
-class TrackingRecHit;
 
 class AlignmentCSCOverlapSelector {
 public:

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentCSCTrackSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentCSCTrackSelector.h
@@ -4,14 +4,13 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include <vector>
 
 namespace edm {
   class Event;
   class ParameterSet;
 }  // namespace edm
-
-class TrackingRecHit;
 
 class AlignmentCSCTrackSelector {
 public:

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentTrackSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentTrackSelector.h
@@ -6,6 +6,7 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -19,7 +20,6 @@ namespace edm {
   class ParameterSet;
 }  // namespace edm
 
-class TrackingRecHit;
 class SiStripRecHit1D;
 class SiStripRecHit2D;
 

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentTracksFromVertexCompositeCandidateSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentTracksFromVertexCompositeCandidateSelector.h
@@ -5,6 +5,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/Candidate/interface/VertexCompositeCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include <vector>
@@ -13,8 +14,6 @@ namespace edm {
   class Event;
   class ParameterSet;
 }  // namespace edm
-
-class TrackingRecHit;
 
 class AlignmentTrackFromVertexCompositeCandidateSelector {
 public:

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentTracksFromVertexSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentTracksFromVertexSelector.h
@@ -4,6 +4,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -15,8 +16,6 @@ namespace edm {
   class Event;
   class ParameterSet;
 }  // namespace edm
-
-class TrackingRecHit;
 
 class AlignmentTrackFromVertexSelector {
 public:

--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeMonitor.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeMonitor.h
@@ -18,6 +18,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 
 #include <vector>
 #include <array>
@@ -29,7 +30,6 @@
 class TH1;
 class TH2;
 class TDirectory;
-class Trajectory;
 
 class TrackerTopology;
 

--- a/Alignment/OfflineValidation/interface/TrackerValidationVariables.h
+++ b/Alignment/OfflineValidation/interface/TrackerValidationVariables.h
@@ -9,8 +9,7 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
-
-class Trajectory;
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 
 namespace edm {
   class ConsumesCollector;

--- a/Alignment/TrackerAlignment/interface/TrackerAlignableId.h
+++ b/Alignment/TrackerAlignment/interface/TrackerAlignableId.h
@@ -15,8 +15,8 @@
 ///  (last update by $Author: cklae $)
 
 #include <utility>
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 
-class DetId;
 class TrackerTopology;
 
 class TrackerAlignableId {

--- a/Alignment/TrackerAlignment/interface/TrackerAlignmentLevelBuilder.h
+++ b/Alignment/TrackerAlignment/interface/TrackerAlignmentLevelBuilder.h
@@ -16,8 +16,8 @@
 #include "Alignment/CommonAlignment/interface/AlignmentLevel.h"
 #include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/TrackerAlignment/interface/TrackerNameSpace.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 
-class DetId;
 class TrackerTopology;
 class TrackerGeometry;
 

--- a/CalibMuon/DTCalibration/interface/DTRecHitSegmentResidual.h
+++ b/CalibMuon/DTCalibration/interface/DTRecHitSegmentResidual.h
@@ -5,8 +5,9 @@
  *  \author A. Vilela Pereira
  */
 
+#include "DataFormats/DTRecHit/interface/DTRecSegment4DFwd.h"
+
 class DTGeometry;
-class DTRecSegment4D;
 class DTRecHit1D;
 
 class DTRecHitSegmentResidual {

--- a/CalibMuon/DTCalibration/interface/DTSegmentSelector.h
+++ b/CalibMuon/DTCalibration/interface/DTSegmentSelector.h
@@ -14,12 +14,12 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/DTRecHit/interface/DTRecSegment4DFwd.h"
 #include "CondFormats/DataRecord/interface/DTStatusFlagRcd.h"
 #include "CondFormats/DTObjects/interface/DTStatusFlag.h"
 
 #include <vector>
 
-class DTRecSegment4D;
 class DTRecHit1D;
 class DTStatusFlag;
 

--- a/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.h
+++ b/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.h
@@ -26,13 +26,13 @@
 #include "DetectorDescription/DDCMS/interface/DDCompactView.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/MuonNumbering/interface/MuonGeometryConstants.h"
+#include "DataFormats/MuonDetId/interface/DTLayerIdFwd.h"
 
 //#include <pair>
 #include <map>
 
 class DTT0;
 class DTT0Rcd;
-class DTLayerId;
 
 class DTFakeT0ESProducer : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:

--- a/CalibMuon/DTCalibration/plugins/DTGeometryParserFromDDD.h
+++ b/CalibMuon/DTCalibration/plugins/DTGeometryParserFromDDD.h
@@ -13,10 +13,9 @@
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 #include "Geometry/MuonNumbering/interface/MuonGeometryConstants.h"
 #include "Geometry/MuonNumbering/interface/DTNumberingScheme.h"
+#include "DataFormats/MuonDetId/interface/DTLayerIdFwd.h"
 
 #include <map>
-
-class DTLayerId;
 
 class DTGeometryParserFromDDD {
 public:

--- a/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.h
@@ -15,6 +15,8 @@
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
 #include "DataFormats/DTDigi/interface/DTDigiCollection.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
+#include "DataFormats/MuonDetId/interface/DTLayerIdFwd.h"
 
 #include <string>
 #include <vector>
@@ -22,9 +24,7 @@
 #include <ctime>
 
 class DTGeometry;
-class DTChamberId;
 class DTSuperLayerId;
-class DTLayerId;
 class DTWireId;
 class DTTtrig;
 class TFile;

--- a/CalibMuon/DTCalibration/plugins/DTResidualCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTResidualCalibration.h
@@ -15,6 +15,7 @@
 #include "CalibMuon/DTCalibration/interface/DTSegmentSelector.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
+#include "DataFormats/MuonDetId/interface/DTLayerIdFwd.h"
 
 #include <string>
 #include <vector>
@@ -25,7 +26,6 @@ class TH1F;
 class TH2F;
 class DTGeometry;
 class DTSuperLayerId;
-class DTLayerId;
 
 class DTResidualCalibration : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:

--- a/CalibMuon/DTCalibration/plugins/DTTPAnalyzer.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTPAnalyzer.cc
@@ -8,13 +8,13 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/DTDigi/interface/DTDigiCollection.h"
+#include "DataFormats/MuonDetId/interface/DTLayerIdFwd.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 #include <string>
 #include <map>
 
 //class DTT0;
-class DTLayerId;
 class DTWireId;
 class DTGeometry;
 class DTTTrigBaseSync;

--- a/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.h
@@ -11,6 +11,7 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "CalibMuon/DTCalibration/interface/DTSegmentSelector.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
@@ -23,7 +24,6 @@ namespace edm {
   class EventSetup;
 }  // namespace edm
 
-class DTChamberId;
 class DTTtrig;
 class TFile;
 class TH1F;

--- a/CalibMuon/DTCalibration/plugins/DTVDriftSegmentCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftSegmentCalibration.h
@@ -12,12 +12,12 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "CalibMuon/DTCalibration/interface/DTSegmentSelector.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
 
 #include <map>
 
-class DTChamberId;
 class TFile;
 class TH1F;
 class TH2F;

--- a/CalibMuon/RPCCalibration/interface/RPCCalibSetUp.h
+++ b/CalibMuon/RPCCalibration/interface/RPCCalibSetUp.h
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/MuonDetId/interface/RPCDetIdFwd.h"
 //#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include <cstdlib>
 #include <cstring>
@@ -17,7 +18,6 @@
 
 class RPCDigitizer;
 class RPCGeometry;
-class RPCDetId;
 
 class RPCCalibSetUp {
 public:

--- a/CalibTracker/SiStripHitEfficiency/interface/TrajectoryAtInvalidHit.h
+++ b/CalibTracker/SiStripHitEfficiency/interface/TrajectoryAtInvalidHit.h
@@ -9,11 +9,11 @@
 #include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementError.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementVector.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "TrackingTools/GeomPropagators/interface/AnalyticalPropagator.h"
 
 class Topology;
-class TrackingRecHit;
 class StripTopology;
 class PixelTopology;
 class TrackerTopology;

--- a/Calibration/TkAlCaRecoProducers/interface/CalibrationTrackSelector.h
+++ b/Calibration/TkAlCaRecoProducers/interface/CalibrationTrackSelector.h
@@ -6,6 +6,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -14,8 +15,6 @@ namespace edm {
   class Event;
   class ParameterSet;
 }  // namespace edm
-
-class TrackingRecHit;
 
 class CalibrationTrackSelector {
 public:

--- a/Calibration/Tools/interface/EcalRingCalibrationTools.h
+++ b/Calibration/Tools/interface/EcalRingCalibrationTools.h
@@ -15,9 +15,9 @@
 #include <atomic>
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 
-class DetId;
 class CaloGeometry;
 
 class EcalRingCalibrationTools {

--- a/CommonTools/UtilAlgos/interface/DetIdSelector.h
+++ b/CommonTools/UtilAlgos/interface/DetIdSelector.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-class DetId;
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 namespace edm {
   class ParameterSet;
 }

--- a/CondFormats/Alignment/interface/DetectorGlobalPosition.h
+++ b/CondFormats/Alignment/interface/DetectorGlobalPosition.h
@@ -6,9 +6,10 @@
 /// return the entry corresponding to this detector id
 ///
 
+#include "DataFormats/DetId/interface/DetIdFwd.h"
+
 class Alignments;
 class AlignTransform;
-class DetId;
 
 namespace align {
   const AlignTransform &DetectorGlobalPosition(const Alignments &allGlobals, const DetId &id);

--- a/CondFormats/CSCObjects/interface/CSCChamberMap.h
+++ b/CondFormats/CSCObjects/interface/CSCChamberMap.h
@@ -4,9 +4,8 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include "CondFormats/CSCObjects/interface/CSCMapItem.h"
+#include "DataFormats/MuonDetId/interface/CSCDetIdFwd.h"
 #include <map>
-
-class CSCDetId;
 
 class CSCChamberMap {
 public:

--- a/CondFormats/DTObjects/interface/DTHVStatus.h
+++ b/CondFormats/DTObjects/interface/DTHVStatus.h
@@ -19,10 +19,10 @@
 //------------------------------------
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include "FWCore/Utilities/interface/ConstRespectingPtr.h"
+#include "DataFormats/MuonDetId/interface/DTLayerIdFwd.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
 
 class DTWireId;
-class DTLayerId;
-class DTChamberId;
 
 //---------------
 // C++ Headers --

--- a/CondFormats/DTObjects/interface/DTLVStatus.h
+++ b/CondFormats/DTObjects/interface/DTLVStatus.h
@@ -18,8 +18,7 @@
 //------------------------------------
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include "FWCore/Utilities/interface/ConstRespectingPtr.h"
-
-class DTChamberId;
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
 
 //---------------
 // C++ Headers --

--- a/CondFormats/EcalCorrections/interface/EcalGlobalShowerContainmentCorrectionsVsEta.h
+++ b/CondFormats/EcalCorrections/interface/EcalGlobalShowerContainmentCorrectionsVsEta.h
@@ -31,7 +31,7 @@
 #include <algorithm>
 #include <map>
 
-class DetId;
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 
 class EcalGlobalShowerContainmentCorrectionsVsEta {
 public:

--- a/CondTools/DT/interface/DTHVHandler.h
+++ b/CondTools/DT/interface/DTHVHandler.h
@@ -18,8 +18,9 @@
 //------------------------------------
 // Collaborating Class Declarations --
 //------------------------------------
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
+
 class DTHVStatus;
-class DTChamberId;
 //class DTLayerId;
 class DTWireId;
 //class DTGeometry;

--- a/CondTools/DT/interface/DTPosNeg.h
+++ b/CondTools/DT/interface/DTPosNeg.h
@@ -18,7 +18,7 @@
 //------------------------------------
 // Collaborating Class Declarations --
 //------------------------------------
-class DTChamberId;
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
 
 //---------------
 // C++ Headers --

--- a/CondTools/RPC/interface/RPCDBSimSetUp.h
+++ b/CondTools/RPC/interface/RPCDBSimSetUp.h
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/MuonDetId/interface/RPCDetIdFwd.h"
 #include <map>
 #include <vector>
 #include <fstream>
@@ -16,7 +17,6 @@
 
 class RPCDigitizer;
 class RPCGeometry;
-class RPCDetId;
 
 class RPCDBSimSetUp {
 public:

--- a/DPGAnalysis/SiStripTools/interface/SiStripTKNumbers.h
+++ b/DPGAnalysis/SiStripTools/interface/SiStripTKNumbers.h
@@ -3,7 +3,7 @@
 
 #include <map>
 
-class DetId;
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 
 class SiStripTKNumbers {
 public:

--- a/DPGAnalysis/Skims/src/RPCRecHitFilter.h
+++ b/DPGAnalysis/Skims/src/RPCRecHitFilter.h
@@ -36,6 +36,7 @@
 #include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 #include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 #include "TrackingTools/DetLayers/interface/DetLayer.h"
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
@@ -48,8 +49,6 @@
 #include "TFile.h"
 #include "TTree.h"
 
-class RPCDetId;
-class Trajectory;
 class Propagator;
 class GeomDet;
 class TrajectoryStateOnSurface;

--- a/DQM/DTMonitorClient/src/DTChamberEfficiencyClient.h
+++ b/DQM/DTMonitorClient/src/DTChamberEfficiencyClient.h
@@ -27,6 +27,9 @@
 
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
+#include "DataFormats/MuonDetId/interface/DTLayerIdFwd.h"
+
 #include <memory>
 #include <iostream>
 #include <fstream>
@@ -35,8 +38,6 @@
 #include <map>
 
 class DTGeometry;
-class DTChamberId;
-class DTLayerId;
 
 class DTChamberEfficiencyClient : public DQMEDHarvester {
 public:

--- a/DQM/DTMonitorClient/src/DTChamberEfficiencyTest.h
+++ b/DQM/DTMonitorClient/src/DTChamberEfficiencyTest.h
@@ -27,6 +27,9 @@
 
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
+#include "DataFormats/MuonDetId/interface/DTLayerIdFwd.h"
+
 #include <memory>
 #include <iostream>
 #include <fstream>
@@ -35,9 +38,7 @@
 #include <map>
 
 class DTGeometry;
-class DTChamberId;
 class DTSuperLayerId;
-class DTLayerId;
 
 class DTChamberEfficiencyTest : public DQMEDHarvester {
 public:

--- a/DQM/DTMonitorClient/src/DTEfficiencyTest.h
+++ b/DQM/DTMonitorClient/src/DTEfficiencyTest.h
@@ -25,6 +25,9 @@
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
+#include "DataFormats/MuonDetId/interface/DTLayerIdFwd.h"
+
 #include <memory>
 #include <iostream>
 #include <fstream>
@@ -33,9 +36,7 @@
 #include <map>
 
 class DTGeometry;
-class DTChamberId;
 class DTSuperLayerId;
-class DTLayerId;
 
 class DTEfficiencyTest : public DQMEDHarvester {
 public:

--- a/DQM/DTMonitorClient/src/DTLocalTriggerBaseTest.h
+++ b/DQM/DTMonitorClient/src/DTLocalTriggerBaseTest.h
@@ -26,10 +26,11 @@
 
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
+
 #include <string>
 #include <map>
 
-class DTChamberId;
 class DTGeometry;
 class TH1F;
 class TH2F;

--- a/DQM/DTMonitorClient/src/DTNoiseAnalysisTest.h
+++ b/DQM/DTMonitorClient/src/DTNoiseAnalysisTest.h
@@ -17,13 +17,13 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
 
 #include <iostream>
 #include <string>
 #include <map>
 
 class DTGeometry;
-class DTChamberId;
 class DTSuperLayerId;
 
 class DTNoiseAnalysisTest : public DQMEDHarvester {

--- a/DQM/DTMonitorClient/src/DTOccupancyTest.h
+++ b/DQM/DTMonitorClient/src/DTOccupancyTest.h
@@ -18,6 +18,7 @@
 #include "DataFormats/MuonDetId/interface/DTLayerId.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
 
 #include "TH2F.h"
 
@@ -26,7 +27,6 @@
 #include <map>
 
 class DTGeometry;
-class DTChamberId;
 
 #include "TFile.h"
 #include "TNtuple.h"

--- a/DQM/DTMonitorClient/src/DTResolutionTest.h
+++ b/DQM/DTMonitorClient/src/DTResolutionTest.h
@@ -26,6 +26,8 @@
 
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
+
 #include <memory>
 #include <iostream>
 #include <fstream>
@@ -34,7 +36,6 @@
 #include <map>
 
 class DTGeometry;
-class DTChamberId;
 class DTSuperLayerId;
 
 class DTResolutionTest : public DQMEDHarvester {

--- a/DQM/DTMonitorClient/src/DTRunConditionVarClient.h
+++ b/DQM/DTMonitorClient/src/DTRunConditionVarClient.h
@@ -34,6 +34,9 @@
 
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
+#include "DataFormats/MuonDetId/interface/DTLayerIdFwd.h"
+
 #include <memory>
 #include <iostream>
 #include <fstream>
@@ -42,8 +45,6 @@
 #include <map>
 
 class DTGeometry;
-class DTChamberId;
-class DTLayerId;
 class DTMtime;
 class DTRecoConditions;
 

--- a/DQM/DTMonitorClient/src/DTSegmentAnalysisTest.h
+++ b/DQM/DTMonitorClient/src/DTSegmentAnalysisTest.h
@@ -24,6 +24,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
 
 #include <memory>
 #include <iostream>
@@ -33,7 +34,6 @@
 #include <map>
 
 class DTGeometry;
-class DTChamberId;
 class DTSuperLayerId;
 
 class DTSegmentAnalysisTest : public DQMEDHarvester {

--- a/DQM/DTMonitorModule/interface/DTDigiTask.h
+++ b/DQM/DTMonitorModule/interface/DTDigiTask.h
@@ -30,6 +30,8 @@
 #include "DataFormats/LTCDigi/interface/LTCDigi.h"
 #include "DataFormats/DTDigi/interface/DTDigi.h"
 #include "DataFormats/DTDigi/interface/DTDigiCollection.h"
+#include "DataFormats/MuonDetId/interface/DTLayerIdFwd.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
 
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -43,8 +45,6 @@
 
 class DTGeometry;
 class DTSuperLayerId;
-class DTLayerId;
-class DTChamberId;
 class DTTtrig;
 class DTT0;
 

--- a/DQM/DTMonitorModule/interface/DTTrigGeomUtils.h
+++ b/DQM/DTMonitorModule/interface/DTTrigGeomUtils.h
@@ -10,12 +10,12 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/GeometryVector/interface/Pi.h"
+#include "DataFormats/DTRecHit/interface/DTRecSegment4DFwd.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
 
 #include <cmath>
 
 class DTGeometry;
-class DTRecSegment4D;
-class DTChamberId;
 class L1MuDTChambPhDigi;
 
 class DTTrigGeomUtils {

--- a/DQM/DTMonitorModule/src/DTChamberEfficiency.h
+++ b/DQM/DTMonitorModule/src/DTChamberEfficiency.h
@@ -30,6 +30,7 @@
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
 #include "RecoMuon/MeasurementDet/interface/MuonDetLayerMeasurements.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 
 #include <string>
 #include <vector>
@@ -43,7 +44,6 @@ class MuonServiceProxy;
 
 class FreeTrajectoryState;
 class DetLayer;
-class DetId;
 class NavigationSchool;
 
 class DTChamberEfficiency : public DQMEDAnalyzer {

--- a/DQM/DTMonitorModule/src/DTLocalTriggerBaseTask.h
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerBaseTask.h
@@ -27,6 +27,8 @@
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambPhContainer.h"
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambThContainer.h"
 #include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhContainer.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
+#include "DataFormats/DTRecHit/interface/DTRecSegment4DFwd.h"
 
 #include <vector>
 #include <string>
@@ -34,8 +36,6 @@
 
 class DTGeometry;
 class DTTrigGeomUtils;
-class DTChamberId;
-class DTRecSegment4D;
 class L1MuDTChambPhDigi;
 class L1MuDTChambThDigi;
 class L1Phase2MuDTPhDigi;

--- a/DQM/DTMonitorModule/src/DTLocalTriggerLutTask.h
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerLutTask.h
@@ -23,6 +23,7 @@
 
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambPhContainer.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 #include <vector>
@@ -32,7 +33,6 @@
 
 class DTGeometry;
 class DTTrigGeomUtils;
-class DTChamberId;
 class L1MuDTChambPhDigi;
 
 typedef std::array<std::array<std::array<int, 13>, 5>, 6> DTArr3int;

--- a/DQM/DTMonitorModule/src/DTLocalTriggerSynchTask.h
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerSynchTask.h
@@ -23,6 +23,8 @@
 
 #include "DataFormats/DTDigi/interface/DTLocalTriggerCollection.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
+#include "DataFormats/DTRecHit/interface/DTRecSegment4DFwd.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 // DT trigger
@@ -34,8 +36,6 @@
 #include <map>
 
 class DTGeometry;
-class DTChamberId;
-class DTRecSegment4D;
 class DTTTrigBaseSync;
 class DTLocalTrigger;
 class L1MuDTChambPhDigi;

--- a/DQM/DTMonitorModule/src/DTLocalTriggerTask.h
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerTask.h
@@ -27,6 +27,8 @@
 #include "DataFormats/LTCDigi/interface/LTCDigi.h"
 #include "DataFormats/DTDigi/interface/DTLocalTriggerCollection.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
+#include "DataFormats/DTRecHit/interface/DTRecSegment4DFwd.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 #include <vector>
@@ -35,8 +37,6 @@
 
 class DTGeometry;
 class DTTrigGeomUtils;
-class DTChamberId;
-class DTRecSegment4D;
 class DTLocalTrigger;
 class L1MuDTChambPhDigi;
 class L1MuDTChambThDigi;

--- a/DQM/DTMonitorModule/src/DTRunConditionVar.h
+++ b/DQM/DTMonitorModule/src/DTRunConditionVar.h
@@ -21,6 +21,7 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment4D.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -42,7 +43,6 @@
 
 class DTGeometry;
 class DetLayer;
-class DetId;
 
 class DTRunConditionVar : public DQMEDAnalyzer {
 public:

--- a/DQM/DTMonitorModule/src/DTTriggerEfficiencyTask.h
+++ b/DQM/DTMonitorModule/src/DTTriggerEfficiencyTask.h
@@ -28,6 +28,7 @@
 #include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTReadoutCollection.h"
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambPhContainer.h"
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambThContainer.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 
@@ -36,7 +37,6 @@
 #include <map>
 
 class DTGeometry;
-class DTChamberId;
 class DTTrigGeomUtils;
 
 class DTTriggerEfficiencyTask : public DQMEDAnalyzer {

--- a/DQM/EcalCommon/interface/MESetBinningUtils.h
+++ b/DQM/EcalCommon/interface/MESetBinningUtils.h
@@ -3,11 +3,11 @@
 
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
+#include "DataFormats/EcalDetId/interface/EcalElectronicsIdFwd.h"
 
 #include <string>
 
-class DetId;
-class EcalElectronicsId;
 namespace edm {
   class ParameterSet;
   class ParameterSetDescription;

--- a/DQM/EcalMonitorClient/interface/DQWorkerClient.h
+++ b/DQM/EcalMonitorClient/interface/DQWorkerClient.h
@@ -5,8 +5,8 @@
 
 #include "DQM/EcalCommon/interface/DQWorker.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 
-class DetId;
 namespace edm {
   class ConsumesCollector;
 }  // namespace edm

--- a/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayTLA.h
+++ b/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayTLA.h
@@ -13,10 +13,11 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedFwd.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
+
 class TrackerGeometry;
-class TrackingRecHit;
-class TrajectorySeed;
-class Trajectory;
 
 class SiStripFineDelayTLA {
 public:

--- a/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayTOF.h
+++ b/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayTOF.h
@@ -1,12 +1,8 @@
 #ifndef CalibTracker_SiSitripLorentzAngle_SiStripFineDelayTOF_h
 #define CalibTracker_SiSitripLorentzAngle_SiStripFineDelayTOF_h
 
-namespace reco {
-  class Track;
-}
-
-class TrackingRecHit;
-
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 class SiStripFineDelayTOF {
 public:
   static double timeOfFlight(bool cosmics, bool field, double* trackParameters, double* hit, double* phit, bool onDisk);

--- a/DQM/SiStripMonitorCluster/interface/SiStripMonitorCluster.h
+++ b/DQM/SiStripMonitorCluster/interface/SiStripMonitorCluster.h
@@ -26,6 +26,7 @@
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelClusterFwd.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "CalibTracker/SiStripCommon/interface/TkDetMap.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
@@ -38,7 +39,6 @@
 #include "CalibTracker/Records/interface/SiStripQualityRcd.h"
 
 class SiStripCluster;
-class SiPixelCluster;
 class EventWithHistory;
 class APVCyclePhaseCollection;
 class SiStripDCSStatus;

--- a/DQMOffline/CalibMuon/interface/DTnoiseDBValidation.h
+++ b/DQMOffline/CalibMuon/interface/DTnoiseDBValidation.h
@@ -17,13 +17,13 @@
 #include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 #include "CondFormats/DataRecord/interface/DTStatusFlagRcd.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
 
 #include <map>
 #include <string>
 #include <vector>
 
 class DTGeometry;
-class DTChamberId;
 class DTStatusFlag;
 class TFile;
 

--- a/DQMOffline/EGamma/plugins/PhotonAnalyzer.h
+++ b/DQMOffline/EGamma/plugins/PhotonAnalyzer.h
@@ -61,6 +61,8 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
+#include "SimDataFormats/Vertex/interface/SimVertexFwd.h"
+#include "SimDataFormats/Track/interface/SimTrackFwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -91,8 +93,6 @@ class TH1F;
 class TH2F;
 class TProfile;
 class TTree;
-class SimVertex;
-class SimTrack;
 
 class PhotonAnalyzer : public DQMEDAnalyzer {
 public:

--- a/DQMOffline/EGamma/plugins/PiZeroAnalyzer.h
+++ b/DQMOffline/EGamma/plugins/PiZeroAnalyzer.h
@@ -40,6 +40,8 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
+#include "SimDataFormats/Vertex/interface/SimVertexFwd.h"
+#include "SimDataFormats/Track/interface/SimTrackFwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -69,8 +71,6 @@ class TH1F;
 class TH2F;
 class TProfile;
 class TTree;
-class SimVertex;
-class SimTrack;
 
 class PiZeroAnalyzer : public DQMEDAnalyzer {
 public:

--- a/DQMOffline/JetMET/interface/ECALRecHitAnalyzer.h
+++ b/DQMOffline/JetMET/interface/ECALRecHitAnalyzer.h
@@ -63,7 +63,6 @@
 #include <TFile.h>
 #include <TMath.h>
 
-class DetId;
 //class HcalTopology;
 class CaloGeometry;
 class CaloSubdetectorGeometry;

--- a/DQMOffline/Muon/interface/MuonSeedsAnalyzer.h
+++ b/DQMOffline/Muon/interface/MuonSeedsAnalyzer.h
@@ -23,7 +23,6 @@
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 
 class TrajectoryStateOnSurface;
-class TrajectorySeed;
 class MuonServiceProxy;
 
 class MuonSeedsAnalyzer : public DQMEDAnalyzer {

--- a/DataFormats/CSCDigi/interface/CSCALCTDigiFwd.h
+++ b/DataFormats/CSCDigi/interface/CSCALCTDigiFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_CSCDigi_CSCALCTDigiFwd_h
+#define DataFormats_CSCDigi_CSCALCTDigiFwd_h
+
+class CSCALCTDigi;
+
+#endif

--- a/DataFormats/CSCDigi/interface/CSCCLCTDigiFwd.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigiFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_CSCDigi_CSCCLCTDigiFwd_h
+#define DataFormats_CSCDigi_CSCCLCTDigiFwd_h
+
+class CSCCLCTDigi;
+
+#endif

--- a/DataFormats/CSCDigi/interface/CSCComparatorDigiFwd.h
+++ b/DataFormats/CSCDigi/interface/CSCComparatorDigiFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_CSCDigi_CSCComparatorDigiFwd_h
+#define DataFormats_CSCDigi_CSCComparatorDigiFwd_h
+
+class CSCComparatorDigi;
+
+#endif

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiFwd.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_CSCDigi_CSCCorrelatedLCTDigiFwd_h
+#define DataFormats_CSCDigi_CSCCorrelatedLCTDigiFwd_h
+
+class CSCCorrelatedLCTDigi;
+
+#endif

--- a/DataFormats/CSCDigi/interface/CSCStripDigiFwd.h
+++ b/DataFormats/CSCDigi/interface/CSCStripDigiFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_CSCDigi_CSCStripDigiFwd_h
+#define DataFormats_CSCDigi_CSCStripDigiFwd_h
+
+class CSCStripDigi;
+
+#endif

--- a/DataFormats/CSCDigi/interface/CSCWireDigiFwd.h
+++ b/DataFormats/CSCDigi/interface/CSCWireDigiFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_CSCDigi_CSCWireDigiFwd_h
+#define DataFormats_CSCDigi_CSCWireDigiFwd_h
+
+class CSCWireDigi;
+
+#endif

--- a/DataFormats/CSCRecHit/interface/CSCSegment.h
+++ b/DataFormats/CSCRecHit/interface/CSCSegment.h
@@ -13,10 +13,9 @@
 
 #include <DataFormats/TrackingRecHit/interface/RecSegment.h>
 #include <DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h>
+#include <DataFormats/MuonDetId/interface/CSCDetIdFwd.h>
 
 #include <iosfwd>
-
-class CSCDetId;
 
 class CSCSegment final : public RecSegment {
 public:

--- a/DataFormats/CaloTowers/interface/CaloTowerFwd.h
+++ b/DataFormats/CaloTowers/interface/CaloTowerFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_CaloTowers_CaloTowerFwd_h
+#define DataFormats_CaloTowers_CaloTowerFwd_h
+
+class CaloTower;
+
+#endif

--- a/DataFormats/DTDigi/interface/DTDigiFwd.h
+++ b/DataFormats/DTDigi/interface/DTDigiFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_DTDigi_DTDigiFwd_h
+#define DataFormats_DTDigi_DTDigiFwd_h
+
+class DTDigi;
+
+#endif

--- a/DataFormats/DTRecHit/interface/DTRecHit1DPair.h
+++ b/DataFormats/DTRecHit/interface/DTRecHit1DPair.h
@@ -16,12 +16,12 @@
  */
 
 #include "DataFormats/DTRecHit/interface/DTRecHit1D.h"
+#include "DataFormats/DTDigi/interface/DTDigiFwd.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 
 #include <utility>
 
 class DTLayer;
-class DTDigi;
 
 class DTRecHit1DPair : public RecHit1D {
 public:

--- a/DataFormats/DTRecHit/interface/DTRecSegment4DFwd.h
+++ b/DataFormats/DTRecHit/interface/DTRecSegment4DFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_DTRecHit_DTRecSegment4DFwd_h
+#define DataFormats_DTRecHit_DTRecSegment4DFwd_h
+
+class DTRecSegment4D;
+
+#endif

--- a/DataFormats/DetId/interface/DetIdFwd.h
+++ b/DataFormats/DetId/interface/DetIdFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_DetId_DetIdFwd_h
+#define DataFormats_DetId_DetIdFwd_h
+
+class DetId;
+
+#endif

--- a/DataFormats/EcalDetId/interface/EcalElectronicsIdFwd.h
+++ b/DataFormats/EcalDetId/interface/EcalElectronicsIdFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_EcalDetId_EcalElectronicsIdFwd_h
+#define DataFormats_EcalDetId_EcalElectronicsIdFwd_h
+
+class EcalElectronicsId;
+
+#endif

--- a/DataFormats/EcalRecHit/interface/EcalRecHitFwd.h
+++ b/DataFormats/EcalRecHit/interface/EcalRecHitFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_EcalRecHit_EcalRecHitFwd_h
+#define DataFormats_EcalRecHit_EcalRecHitFwd_h
+
+class EcalRecHit;
+
+#endif

--- a/DataFormats/EgammaTrackReco/interface/ConversionTrack.h
+++ b/DataFormats/EgammaTrackReco/interface/ConversionTrack.h
@@ -14,7 +14,7 @@
 #define EgammaReco_ConversionTrack_h
 
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
-class Trajectory;
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 namespace reco {
   class ConversionTrack {
   public:

--- a/DataFormats/GEMDigi/interface/GEMPadDigiClusterFwd.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigiClusterFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_GEMDigi_GEMPadDigiClusterFwd_h
+#define DataFormats_GEMDigi_GEMPadDigiClusterFwd_h
+
+class GEMPadDigiCluster;
+
+#endif

--- a/DataFormats/GEMRecHit/interface/GEMCSCSegment.h
+++ b/DataFormats/GEMRecHit/interface/GEMCSCSegment.h
@@ -16,10 +16,9 @@
 #include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
 #include "DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h"
 #include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
+#include "DataFormats/MuonDetId/interface/CSCDetIdFwd.h"
 
 #include <iosfwd>
-
-class CSCDetId;
 
 class GEMCSCSegment final : public RecSegment {
 public:

--- a/DataFormats/GEMRecHit/interface/GEMSegment.h
+++ b/DataFormats/GEMRecHit/interface/GEMSegment.h
@@ -11,10 +11,9 @@
 
 #include "DataFormats/TrackingRecHit/interface/RecSegment.h"
 #include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
+#include "DataFormats/MuonDetId/interface/GEMDetIdFwd.h"
 
 #include <iosfwd>
-
-class GEMDetId;
 
 class GEMSegment final : public RecSegment {
 public:

--- a/DataFormats/HcalRecHit/interface/HBHERecHitFwd.h
+++ b/DataFormats/HcalRecHit/interface/HBHERecHitFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_HcalRecHit_HBHERecHitFwd_h
+#define DataFormats_HcalRecHit_HBHERecHitFwd_h
+
+class HBHERecHit;
+
+#endif

--- a/DataFormats/L1DTTrackFinder/interface/L1MuDTChambThContainerFwd.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1MuDTChambThContainerFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_L1DTTrackFinder_L1MuDTChambThContainerFwd_h
+#define DataFormats_L1DTTrackFinder_L1MuDTChambThContainerFwd_h
+
+class L1MuDTChambThContainer;
+
+#endif

--- a/DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTCandFwd.h
+++ b/DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTCandFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_L1GlobalMuonTrigger_L1MuGMTCandFwd_h
+#define DataFormats_L1GlobalMuonTrigger_L1MuGMTCandFwd_h
+
+class L1MuGMTCand;
+
+#endif

--- a/DataFormats/MuonDetId/interface/CSCDetId.h
+++ b/DataFormats/MuonDetId/interface/CSCDetId.h
@@ -19,10 +19,6 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 
-class CSCDetId;
-
-std::ostream& operator<<(std::ostream& os, const CSCDetId& id);
-
 class CSCDetId : public DetId {
 public:
   /// Default constructor; fills the common part in the base
@@ -319,5 +315,7 @@ private:
     START_ENDCAP = START_STATION + BITS_STATION
   };
 };
+
+std::ostream& operator<<(std::ostream& os, const CSCDetId& id);
 
 #endif

--- a/DataFormats/MuonDetId/interface/CSCDetIdFwd.h
+++ b/DataFormats/MuonDetId/interface/CSCDetIdFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_MuonDetId_CSCDetIdFwd_h
+#define DataFormats_MuonDetId_CSCDetIdFwd_h
+
+class CSCDetId;
+
+#endif

--- a/DataFormats/MuonDetId/interface/CSCTriggerNumbering.h
+++ b/DataFormats/MuonDetId/interface/CSCTriggerNumbering.h
@@ -10,7 +10,7 @@
  * \warning EVERY INDEX COUNTS FROM ONE
  */
 
-class CSCDetId;
+#include "DataFormats/MuonDetId/interface/CSCDetIdFwd.h"
 
 class CSCTriggerNumbering {
 public:

--- a/DataFormats/MuonDetId/interface/DTChamberIdFwd.h
+++ b/DataFormats/MuonDetId/interface/DTChamberIdFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_MuonDetId_DTChamberIdFwd_h
+#define DataFormats_MuonDetId_DTChamberIdFwd_h
+
+class DTChamberId;
+
+#endif

--- a/DataFormats/MuonDetId/interface/DTLayerIdFwd.h
+++ b/DataFormats/MuonDetId/interface/DTLayerIdFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_MuonDetId_DTLayerIdFwd_h
+#define DataFormats_MuonDetId_DTLayerIdFwd_h
+
+class DTLayerId;
+
+#endif

--- a/DataFormats/MuonDetId/interface/GEMDetIdFwd.h
+++ b/DataFormats/MuonDetId/interface/GEMDetIdFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_MuonDetId_GEMDetIdFwd_h
+#define DataFormats_MuonDetId_GEMDetIdFwd_h
+
+class GEMDetId;
+
+#endif

--- a/DataFormats/MuonDetId/interface/RPCDetIdFwd.h
+++ b/DataFormats/MuonDetId/interface/RPCDetIdFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_MuonDetId_RPCDetIdFwd_h
+#define DataFormats_MuonDetId_RPCDetIdFwd_h
+
+class RPCDetId;
+
+#endif

--- a/DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigiFwd.h
+++ b/DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigiFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_Phase2TrackerDigi_Phase2TrackerDigiFwd_h
+#define DataFormats_Phase2TrackerDigi_Phase2TrackerDigiFwd_h
+
+class Phase2TrackerDigi;
+
+#endif

--- a/DataFormats/RPCDigi/interface/RPCDigiFwd.h
+++ b/DataFormats/RPCDigi/interface/RPCDigiFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_RPCDigi_RPCDigiFwd_h
+#define DataFormats_RPCDigi_RPCDigiFwd_h
+
+class RPCDigi;
+
+#endif

--- a/DataFormats/RPCRecHit/interface/RPCRecHitFwd.h
+++ b/DataFormats/RPCRecHit/interface/RPCRecHitFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_RPCRecHit_RPCRecHitFwd_h
+#define DataFormats_RPCRecHit_RPCRecHitFwd_h
+
+class RPCRecHit;
+
+#endif

--- a/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
+++ b/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
@@ -23,7 +23,7 @@
 #include <cassert>
 #include <limits>
 
-class PixelDigi;
+#include "DataFormats/SiPixelDigi/interface/PixelDigiFwd.h"
 
 class SiPixelCluster {
 public:

--- a/DataFormats/SiPixelCluster/interface/SiPixelClusterFwd.h
+++ b/DataFormats/SiPixelCluster/interface/SiPixelClusterFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_SiPixelCluster_SiPixelClusterFwd_h
+#define DataFormats_SiPixelCluster_SiPixelClusterFwd_h
+
+class SiPixelCluster;
+
+#endif

--- a/DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h
+++ b/DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h
@@ -8,8 +8,7 @@
 #include "DataFormats/SiPixelDetId/interface/PixelModuleName.h"
 #include <string>
 #include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
-
-class DetId;
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 
 class PixelBarrelNameUpgrade : public PixelModuleName {
 public:

--- a/DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h
+++ b/DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h
@@ -10,8 +10,7 @@
 #include <string>
 #include <iostream>
 #include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
-
-class DetId;
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 
 class PixelEndcapNameUpgrade : public PixelModuleName {
 public:

--- a/DataFormats/SiPixelDigi/interface/PixelDigiFwd.h
+++ b/DataFormats/SiPixelDigi/interface/PixelDigiFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_SiPixelDigi_PixelDigiFwd_h
+#define DataFormats_SiPixelDigi_PixelDigiFwd_h
+
+class PixelDigi;
+
+#endif

--- a/DataFormats/TrackerCommon/interface/PixelBarrelName.h
+++ b/DataFormats/TrackerCommon/interface/PixelBarrelName.h
@@ -7,10 +7,10 @@
 
 #include "DataFormats/SiPixelDetId/interface/PixelModuleName.h"
 #include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 
 #include <string>
 
-class DetId;
 class TrackerTopology;
 
 class PixelBarrelName : public PixelModuleName {

--- a/DataFormats/TrackerCommon/interface/PixelEndcapName.h
+++ b/DataFormats/TrackerCommon/interface/PixelEndcapName.h
@@ -6,11 +6,11 @@
  */
 #include "DataFormats/SiPixelDetId/interface/PixelModuleName.h"
 #include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 
 #include <string>
 #include <iostream>
 
-class DetId;
 class TrackerTopology;
 
 class PixelEndcapName : public PixelModuleName {

--- a/DataFormats/TrackingRecHit/interface/KfComponentsHolder.h
+++ b/DataFormats/TrackingRecHit/interface/KfComponentsHolder.h
@@ -3,10 +3,9 @@
 
 #include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
 #include "DataFormats/Math/interface/ProjectMatrix.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include <cstdint>
 #include <cassert>
-
-class TrackingRecHit;
 
 // #define Debug_KfComponentsHolder
 

--- a/DataFormats/TrajectorySeed/interface/TrajectorySeedFwd.h
+++ b/DataFormats/TrajectorySeed/interface/TrajectorySeedFwd.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_TrajectorySeed_TrajectorySeedFwd_h
+#define DataFormats_TrajectorySeed_TrajectorySeedFwd_h
+
+class TrajectorySeed;
+
+#endif

--- a/EventFilter/CSCRawToDigi/interface/CSCCFEBData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCCFEBData.h
@@ -1,8 +1,9 @@
 #ifndef EventFilter_CSCRawToDigi_CSCCFEBData_h
 #define EventFilter_CSCRawToDigi_CSCCFEBData_h
 
+#include "DataFormats/CSCDigi/interface/CSCStripDigiFwd.h"
+
 class CSCCFEBTimeSlice;
-class CSCStripDigi;
 class CSCCFEBStatusDigi;
 
 #include <vector>

--- a/EventFilter/CSCRawToDigi/interface/CSCEventData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCEventData.h
@@ -4,8 +4,6 @@
 class CSCCFEBData;
 class CSCTMBHeader;
 class CSCComparatorData;
-class CSCWireDigi;
-class CSCStripDigi;
 #include <map>
 #include <vector>
 #ifndef LOCAL_UNPACK
@@ -21,6 +19,8 @@ class CSCStripDigi;
 #include "DataFormats/CSCDigi/interface/CSCRPCDigi.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
+#include "DataFormats/CSCDigi/interface/CSCWireDigiFwd.h"
+#include "DataFormats/CSCDigi/interface/CSCStripDigiFwd.h"
 #include <boost/dynamic_bitset.hpp>
 
 class CSCEventData {

--- a/EventFilter/CSCRawToDigi/interface/CSCGEMData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCGEMData.h
@@ -6,7 +6,7 @@
 #include <atomic>
 #endif
 
-class GEMPadDigiCluster;
+#include "DataFormats/GEMDigi/interface/GEMPadDigiClusterFwd.h"
 
 class CSCGEMData {
 public:

--- a/EventFilter/CSCRawToDigi/plugins/CSCDigiValidator.cc
+++ b/EventFilter/CSCRawToDigi/plugins/CSCDigiValidator.cc
@@ -36,13 +36,14 @@
 
 #include "DataFormats/L1CSCTrackFinder/interface/L1Track.h"
 
-class CSCWireDigi;
-class CSCStripDigi;
-class CSCComparatorDigi;
-class CSCCLCTDigi;
-class CSCALCTDigi;
-class CSCCorrelatedLCTDigi;
-class CSCDetId;
+#include "DataFormats/CSCDigi/interface/CSCWireDigiFwd.h"
+#include "DataFormats/CSCDigi/interface/CSCStripDigiFwd.h"
+#include "DataFormats/CSCDigi/interface/CSCComparatorDigiFwd.h"
+#include "DataFormats/CSCDigi/interface/CSCCLCTDigiFwd.h"
+#include "DataFormats/CSCDigi/interface/CSCALCTDigiFwd.h"
+#include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiFwd.h"
+#include "DataFormats/MuonDetId/interface/CSCDetIdFwd.h"
+
 class CSCChamberMap;
 
 class CSCDigiValidator : public edm::one::EDFilter<> {

--- a/FastSimDataFormats/L1GlobalMuonTrigger/interface/SimpleL1MuGMTCand.h
+++ b/FastSimDataFormats/L1GlobalMuonTrigger/interface/SimpleL1MuGMTCand.h
@@ -5,7 +5,7 @@
 
 #include "DataFormats/Math/interface/LorentzVector.h"
 
-class SimTrack;
+#include "SimDataFormats/Track/interface/SimTrackFwd.h"
 
 namespace HepMC {
   class GenParticle;

--- a/FastSimulation/CaloGeometryTools/interface/BaseCrystal.h
+++ b/FastSimulation/CaloGeometryTools/interface/BaseCrystal.h
@@ -14,8 +14,6 @@
 
 #include <vector>
 
-class DetId;
-
 class BaseCrystal {
 public:
   typedef math::XYZVector XYZVector;

--- a/FastSimulation/CaloGeometryTools/interface/CaloGeometryHelper.h
+++ b/FastSimulation/CaloGeometryTools/interface/CaloGeometryHelper.h
@@ -4,11 +4,11 @@
 #include "FastSimulation/CalorimeterProperties/interface/Calorimeter.h"
 #include "Geometry/CaloTopology/interface/CaloDirection.h"
 #include "FastSimulation/CaloGeometryTools/interface/BaseCrystal.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 
 #include <vector>
 #include <array>
 
-class DetId;
 class Crystal;
 
 namespace edm {

--- a/FastSimulation/CaloGeometryTools/interface/Crystal.h
+++ b/FastSimulation/CaloGeometryTools/interface/Crystal.h
@@ -15,8 +15,6 @@
 
 #include <vector>
 
-class DetId;
-
 class Crystal {
 public:
   typedef math::XYZVector XYZVector;

--- a/FastSimulation/Event/interface/FBaseSimEvent.h
+++ b/FastSimulation/Event/interface/FBaseSimEvent.h
@@ -3,6 +3,8 @@
 
 // Data Formats
 #include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
+#include "SimDataFormats/Track/interface/SimTrackFwd.h"
+#include "SimDataFormats/Vertex/interface/SimVertexFwd.h"
 #include "DataFormats/Math/interface/Point3D.h"
 
 // HepPDT Headers
@@ -25,9 +27,6 @@
 class FSimTrack;
 class FSimVertex;
 class KineParticleFilter;
-
-class SimTrack;
-class SimVertex;
 
 namespace edm {
   class ParameterSet;

--- a/FastSimulation/Muons/plugins/FastTSGFromIOHit.h
+++ b/FastSimulation/Muons/plugins/FastTSGFromIOHit.h
@@ -16,11 +16,11 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimDataFormats/Track/interface/SimTrackFwd.h"
 #include <vector>
 
 class RectangularEtaPhiTrackingRegion;
 class TrackingRegion;
-class SimTrack;
 
 class FastTSGFromIOHit : public TrackerSeedGenerator {
 public:

--- a/FastSimulation/Muons/plugins/FastTSGFromL2Muon.h
+++ b/FastSimulation/Muons/plugins/FastTSGFromL2Muon.h
@@ -6,6 +6,7 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimDataFormats/Track/interface/SimTrackFwd.h"
 
 #include <vector>
 namespace edm {
@@ -17,7 +18,6 @@ namespace edm {
 class MuonServiceProxy;
 class MuonTrackingRegionBuilder;
 class RectangularEtaPhiTrackingRegion;
-class SimTrack;
 
 //
 // generate seeds corresponding to L2 muons

--- a/FastSimulation/Muons/plugins/FastTSGFromPropagation.h
+++ b/FastSimulation/Muons/plugins/FastTSGFromPropagation.h
@@ -24,6 +24,7 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimDataFormats/Track/interface/SimTrackFwd.h"
 
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
@@ -41,7 +42,6 @@ class MeasurementTracker;
 class GeometricSearchTracker;
 class DirectTrackerNavigation;
 struct TrajectoryStateTransform;
-class SimTrack;
 class TrackerGeometry;
 class TrackerTopology;
 class TransientRecHitRecord;

--- a/FastSimulation/Tracking/interface/SeedMatcher.h
+++ b/FastSimulation/Tracking/interface/SeedMatcher.h
@@ -3,12 +3,12 @@
 
 #include "vector"
 #include "DataFormats/TrackerRecHit2D/interface/FastTrackerRecHitCollection.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedFwd.h"
+#include "SimDataFormats/Track/interface/SimTrackFwd.h"
 
-class TrajectorySeed;
 class Propagator;
 class MagneticField;
 class TrajectoryStateOnSurface;
-class SimTrack;
 class TrackerGeometry;
 
 class SeedMatcher {

--- a/Fireworks/Calo/plugins/FWHGTowerSliceSelector.h
+++ b/Fireworks/Calo/plugins/FWHGTowerSliceSelector.h
@@ -21,7 +21,7 @@
 // system include files
 
 // user include files
-class DetId;
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 class TEveCaloDataVec;
 
 #include "Fireworks/Calo/interface/FWFromSliceSelector.h"

--- a/Fireworks/Tracks/interface/TrackUtils.h
+++ b/Fireworks/Tracks/interface/TrackUtils.h
@@ -10,23 +10,22 @@
 #include "TEveVSDStructs.h"
 #include <set>
 
+#include "DataFormats/DetId/interface/DetIdFwd.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelClusterFwd.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
 // forward declarations
-namespace reco {
-  class Track;
-}
 class RecSegment;
 
 class FWEventItem;
 class TEveElement;
 class TEveTrack;
 class TEveTrackPropagator;
-class DetId;
 class FWGeometry;
 class TEveStraightLineSet;
 
-class SiPixelCluster;
 class SiStripCluster;
-class TrackingRecHit;
 
 namespace fireworks {
 

--- a/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromCondDB.h
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromCondDB.h
@@ -21,7 +21,7 @@ class DTGeometry;
 class DTChamber;
 class DTSuperLayer;
 class DTLayer;
-class DetId;
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 #include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
 

--- a/Geometry/GEMGeometryBuilder/interface/GEMGeometryParsFromDD.h
+++ b/Geometry/GEMGeometryBuilder/interface/GEMGeometryParsFromDD.h
@@ -10,6 +10,7 @@
  *
  */
 
+#include "DataFormats/MuonDetId/interface/GEMDetIdFwd.h"
 #include <string>
 #include <vector>
 #include <map>
@@ -23,7 +24,6 @@ namespace cms {  // DD4hep
 }  // namespace cms
 class MuonGeometryConstants;
 class RecoIdealGeometry;
-class GEMDetId;
 
 class GEMGeometryParsFromDD {
 public:

--- a/Geometry/RPCGeometry/interface/RPCGeomServ.h
+++ b/Geometry/RPCGeometry/interface/RPCGeomServ.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-class RPCDetId;
+#include "DataFormats/MuonDetId/interface/RPCDetIdFwd.h"
 class RPCGeomServ {
 public:
   RPCGeomServ(const RPCDetId& id);

--- a/Geometry/RPCGeometryBuilder/interface/RPCGeometryParsFromDD.h
+++ b/Geometry/RPCGeometryBuilder/interface/RPCGeometryParsFromDD.h
@@ -10,6 +10,7 @@
  *
  */
 
+#include "DataFormats/MuonDetId/interface/RPCDetIdFwd.h"
 #include <string>
 #include <map>
 #include <list>
@@ -20,7 +21,6 @@ namespace cms {  // DD4hep
   class DDFilteredView;
   class DDCompactView;
 }  // namespace cms
-class RPCDetId;
 class RPCRoll;
 class MuonGeometryConstants;
 class RecoIdealGeometry;

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromCondDB.h
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromCondDB.h
@@ -9,12 +9,12 @@
  */
 
 #include <CondFormats/GeometryObjects/interface/RecoIdealGeometry.h>
+#include "DataFormats/MuonDetId/interface/RPCDetIdFwd.h"
 #include <string>
 #include <map>
 #include <list>
 
 class RPCGeometry;
-class RPCDetId;
 class RPCRoll;
 
 class RPCGeometryBuilderFromCondDB {

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCALCTCrossCLCT.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCALCTCrossCLCT.h
@@ -22,12 +22,11 @@ this feature into the CSC trigger firmware
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/CSCDigi/interface/CSCALCTDigiFwd.h"
+#include "DataFormats/CSCDigi/interface/CSCCLCTDigiFwd.h"
 
 #include <string>
 #include <array>
-
-class CSCALCTDigi;
-class CSCCLCTDigi;
 
 class CSCALCTCrossCLCT {
 public:

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMatcher.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMatcher.h
@@ -14,12 +14,12 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CondFormats/CSCObjects/interface/CSCL1TPLookupTableME11ILT.h"
 #include "CondFormats/CSCObjects/interface/CSCL1TPLookupTableME21ILT.h"
+#include "DataFormats/CSCDigi/interface/CSCALCTDigiFwd.h"
+#include "DataFormats/CSCDigi/interface/CSCCLCTDigiFwd.h"
 
 #include <string>
 #include <vector>
 
-class CSCALCTDigi;
-class CSCCLCTDigi;
 class GEMInternalCluster;
 
 class CSCGEMMatcher {

--- a/L1Trigger/CSCTriggerPrimitives/interface/ComparatorCodeLUT.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/ComparatorCodeLUT.h
@@ -14,13 +14,12 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/CSCDigi/interface/CSCConstants.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCCLCTDigiFwd.h"
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCPatternBank.h"
 #include "CondFormats/CSCObjects/interface/CSCL1TPLookupTableCCLUT.h"
 
 #include <vector>
 #include <string>
-
-class CSCCLCTDigi;
 
 class ComparatorCodeLUT {
 public:

--- a/L1Trigger/DTBti/interface/DTBtiChip.h
+++ b/L1Trigger/DTBti/interface/DTBtiChip.h
@@ -20,7 +20,6 @@
 class DTBtiHit;
 class DTBtiTrig;
 class DTBtiTrigData;
-class DTDigi;
 
 //----------------------
 // Base Class Headers --
@@ -28,6 +27,7 @@ class DTDigi;
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/MuonDetId/interface/DTBtiId.h"
+#include "DataFormats/DTDigi/interface/DTDigiFwd.h"
 #include "L1Trigger/DTUtilities/interface/DTTrigGeom.h"
 #include "L1TriggerConfig/DTTPGConfig/interface/DTConfig.h"
 #include "L1TriggerConfig/DTTPGConfig/interface/BitArray.h"

--- a/L1Trigger/DTBti/interface/DTBtiHit.h
+++ b/L1Trigger/DTBti/interface/DTBtiHit.h
@@ -22,11 +22,11 @@
 //------------------------------------
 // Collaborating Class Declarations --
 //------------------------------------
-class DTDigi;
 
 //----------------------
 // Base Class Headers --
 //----------------------
+#include "DataFormats/DTDigi/interface/DTDigiFwd.h"
 #include "L1TriggerConfig/DTTPGConfig/interface/DTConfig.h"
 #include "L1TriggerConfig/DTTPGConfig/interface/DTConfigBti.h"
 

--- a/L1Trigger/DTBti/interface/DTBtiTrig.h
+++ b/L1Trigger/DTBti/interface/DTBtiTrig.h
@@ -19,12 +19,12 @@
 //------------------------------------
 // Collaborating Class Declarations --
 //------------------------------------
-class DTDigi;
 class DTBtiChip;
 
 //----------------------
 // Base Class Headers --
 //----------------------
+#include "DataFormats/DTDigi/interface/DTDigiFwd.h"
 #include "L1Trigger/DTUtilities/interface/DTTrigData.h"
 #include "L1Trigger/DTBti/interface/DTBtiTrigData.h"
 

--- a/L1Trigger/DTTrackFinder/src/L1MuDTEtaProcessor.h
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTEtaProcessor.h
@@ -41,7 +41,7 @@
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "L1Trigger/DTTrackFinder/interface/L1MuDTAddressArray.h"
-class L1MuDTChambThContainer;
+#include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambThContainerFwd.h"
 class L1MuDTTrackSegEta;
 class L1MuDTTrackFinder;
 class L1MuDTTrack;

--- a/L1Trigger/GlobalMuonTrigger/src/L1MuGMTEtaProjectionUnit.h
+++ b/L1Trigger/GlobalMuonTrigger/src/L1MuGMTEtaProjectionUnit.h
@@ -38,9 +38,9 @@
 #include "L1Trigger/GlobalMuonTrigger/src/L1MuGMTConfig.h"
 #include "L1Trigger/GlobalMuonTrigger/src/L1MuGMTMatrix.h"
 #include "DataFormats/L1GlobalMuonTrigger/interface/L1MuRegionalCand.h"
+#include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTCandFwd.h"
 
 class L1MuGMTMipIsoAU;
-class L1MuGMTCand;
 
 //              ---------------------
 //              -- Class Interface --

--- a/L1Trigger/GlobalMuonTrigger/src/L1MuGMTMipIsoAU.h
+++ b/L1Trigger/GlobalMuonTrigger/src/L1MuGMTMipIsoAU.h
@@ -38,9 +38,9 @@
 
 #include "L1Trigger/GlobalMuonTrigger/src/L1MuGMTConfig.h"
 #include "DataFormats/L1GlobalMuonTrigger/interface/L1MuRegionalCand.h"
+#include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTCandFwd.h"
 
 class L1MuGlobalMuonTrigger;
-class L1MuGMTCand;
 class L1MuGMTPhiProjectionUnit;
 class L1MuGMTEtaProjectionUnit;
 

--- a/L1Trigger/GlobalMuonTrigger/src/L1MuGMTPhiProjectionUnit.h
+++ b/L1Trigger/GlobalMuonTrigger/src/L1MuGMTPhiProjectionUnit.h
@@ -39,9 +39,9 @@
 #include "L1Trigger/GlobalMuonTrigger/src/L1MuGMTConfig.h"
 #include "L1Trigger/GlobalMuonTrigger/src/L1MuGMTMatrix.h"
 #include "DataFormats/L1GlobalMuonTrigger/interface/L1MuRegionalCand.h"
+#include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTCandFwd.h"
 
 class L1MuGMTMipIsoAU;
-class L1MuGMTCand;
 
 //              ---------------------
 //              -- Class Interface --

--- a/L1Trigger/GlobalTrigger/interface/L1GtMuonCondition.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GtMuonCondition.h
@@ -22,12 +22,11 @@
 // user include files
 //   base classes
 #include "L1Trigger/GlobalTrigger/interface/L1GtConditionEvaluation.h"
+#include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTCandFwd.h"
 
 // forward declarations
 class L1GtCondition;
 class L1GtMuonTemplate;
-
-class L1MuGMTCand;
 
 class L1GlobalTriggerGTL;
 

--- a/L1Trigger/L1TMuon/interface/MuonTriggerPrimitive.h
+++ b/L1Trigger/L1TMuon/interface/MuonTriggerPrimitive.h
@@ -24,29 +24,23 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/L1TMuon/interface/L1TMuonSubsystems.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
+#include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiFwd.h"
+#include "DataFormats/MuonDetId/interface/CSCDetIdFwd.h"
+#include "DataFormats/RPCRecHit/interface/RPCRecHitFwd.h"
+#include "DataFormats/RPCDigi/interface/RPCDigiFwd.h"
+#include "DataFormats/MuonDetId/interface/RPCDetIdFwd.h"
+#include "DataFormats/MuonDetId/interface/GEMDetIdFwd.h"
+#include "DataFormats/GEMDigi/interface/GEMPadDigiClusterFwd.h"
 
 // DT digi types
-class DTChamberId;
 class L1MuDTChambPhDigi;
 class L1MuDTChambThDigi;
-
-// CSC digi types
-class CSCCorrelatedLCTDigi;
-class CSCDetId;
-
-// RPC digi types
-class RPCRecHit;
-class RPCDigi;
-class RPCDetId;
 
 // CPPF digi types
 namespace l1t {
   class CPPFDigi;
 }
-
-// GEM digi types
-class GEMPadDigiCluster;
-class GEMDetId;
 
 // ME0 digi types
 class ME0TriggerDigi;

--- a/L1Trigger/L1TMuonOverlap/interface/AngleConverter.h
+++ b/L1Trigger/L1TMuonOverlap/interface/AngleConverter.h
@@ -6,6 +6,11 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
+#include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambThContainerFwd.h"
+#include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiFwd.h"
+#include "DataFormats/RPCDigi/interface/RPCDigiFwd.h"
+#include "DataFormats/MuonDetId/interface/CSCDetIdFwd.h"
+#include "DataFormats/MuonDetId/interface/RPCDetIdFwd.h"
 
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
@@ -17,11 +22,6 @@
 class CSCLayer;
 
 class L1MuDTChambPhDigi;
-class L1MuDTChambThContainer;
-class CSCCorrelatedLCTDigi;
-class RPCDigi;
-class CSCDetId;
-class RPCDetId;
 
 class AngleConverter {
 public:

--- a/L1Trigger/L1TMuonOverlap/interface/OMTFProcessor.h
+++ b/L1Trigger/L1TMuonOverlap/interface/OMTFProcessor.h
@@ -6,11 +6,10 @@
 #include "L1Trigger/L1TMuonOverlap/interface/GoldenPattern.h"
 #include "L1Trigger/L1TMuonOverlap/interface/OMTFResult.h"
 #include "L1Trigger/L1TMuonOverlap/interface/OMTFConfiguration.h"
+#include "SimDataFormats/Track/interface/SimTrackFwd.h"
 
 class L1TMuonOverlapParams;
 class OMTFinput;
-
-class SimTrack;
 
 namespace edm {
   class ParameterSet;

--- a/L1Trigger/L1TMuonOverlap/plugins/OMTFPatternMaker.h
+++ b/L1Trigger/L1TMuonOverlap/plugins/OMTFPatternMaker.h
@@ -18,6 +18,7 @@
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
 #include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimDataFormats/Track/interface/SimTrackFwd.h"
 
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
 
@@ -25,8 +26,6 @@ class OMTFProcessor;
 class OMTFConfiguration;
 class OMTFConfigMaker;
 class OMTFinputMaker;
-
-class SimTrack;
 
 class XMLConfigWriter;
 

--- a/L1Trigger/L1TMuonOverlapPhase1/interface/AngleConverterBase.h
+++ b/L1Trigger/L1TMuonOverlapPhase1/interface/AngleConverterBase.h
@@ -6,6 +6,12 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
+#include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambThContainerFwd.h"
+#include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiFwd.h"
+#include "DataFormats/RPCDigi/interface/RPCDigiFwd.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
+#include "DataFormats/MuonDetId/interface/CSCDetIdFwd.h"
+#include "DataFormats/MuonDetId/interface/RPCDetIdFwd.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 
@@ -22,13 +28,6 @@ class DTGeometry;
 
 class L1MuDTChambPhDigi;
 class L1MuDTChambThDigi;
-class L1MuDTChambThContainer;
-class CSCCorrelatedLCTDigi;
-class RPCDigi;
-
-class DTChamberId;
-class CSCDetId;
-class RPCDetId;
 
 struct EtaValue {
   int eta = 0;

--- a/L1Trigger/L1TMuonOverlapPhase1/interface/Omtf/ProcessorBase.h
+++ b/L1Trigger/L1TMuonOverlapPhase1/interface/Omtf/ProcessorBase.h
@@ -11,11 +11,11 @@
 #include "L1Trigger/L1TMuonOverlapPhase1/interface/Omtf/GoldenPatternBase.h"
 #include "L1Trigger/L1TMuonOverlapPhase1/interface/Omtf/OMTFConfiguration.h"
 #include "L1Trigger/L1TMuonOverlapPhase1/interface/Omtf/OMTFinput.h"
+#include "SimDataFormats/Track/interface/SimTrackFwd.h"
 
 #include <memory>
 
 class L1TMuonOverlapParams;
-class SimTrack;
 
 template <class GoldenPatternType>
 class ProcessorBase {

--- a/L1TriggerConfig/DTTPGConfigProducers/plugins/DTTPGParamsWriter.h
+++ b/L1TriggerConfig/DTTPGConfigProducers/plugins/DTTPGParamsWriter.h
@@ -7,6 +7,7 @@
  */
 
 #include "CondFormats/DTObjects/interface/DTTPGParameters.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include <fstream>
 #include <string>
@@ -16,8 +17,6 @@ namespace edm {
   class Event;
   class EventSetup;
 }  // namespace edm
-
-class DTChamberId;
 
 class DTTPGParamsWriter : public edm::one::EDAnalyzer<> {
 public:

--- a/L1TriggerConfig/DTTPGConfigProducers/src/DTPosNegType.h
+++ b/L1TriggerConfig/DTTPGConfigProducers/src/DTPosNegType.h
@@ -12,11 +12,11 @@
 //----------------------
 // Base Class Headers --
 //----------------------
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
 
 //------------------------------------
 // Collaborating Class Declarations --
 //------------------------------------
-class DTChamberId;
 
 //---------------
 // C++ Headers --

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitUtils.h
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitUtils.h
@@ -16,6 +16,7 @@
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimDataFormats/Track/interface/SimTrackFwd.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "TGraphErrors.h"
 #include "TH2F.h"
@@ -42,7 +43,6 @@ class resolutionFunctionBase;
 class backgroundFunctionBase;
 class BackgroundHandler;
 
-class SimTrack;
 class TString;
 class TTree;
 

--- a/PhysicsTools/PatUtils/interface/CaloIsolationEnergy.h
+++ b/PhysicsTools/PatUtils/interface/CaloIsolationEnergy.h
@@ -20,10 +20,10 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/PatCandidates/interface/MuonFwd.h"
 #include "DataFormats/PatCandidates/interface/ElectronFwd.h"
+#include "DataFormats/CaloTowers/interface/CaloTowerFwd.h"
 
 class MagneticField;
 class TrackToEcalPropagator;
-class CaloTower;
 
 namespace pat {
   class CaloIsolationEnergy {

--- a/PhysicsTools/RecoUtils/interface/CheckHitPattern.h
+++ b/PhysicsTools/RecoUtils/interface/CheckHitPattern.h
@@ -13,10 +13,9 @@
 #include "RecoVertex/VertexPrimitives/interface/VertexState.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "DataFormats/TrackReco/interface/HitPattern.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 #include <utility>
 #include <map>
-
-class DetId;
 
 class TrackerTopology;
 class TrackerGeometry;

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h
@@ -59,7 +59,6 @@
 #include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
 #include "RecoEcal/EgammaCoreTools/interface/EgammaLocalCovParamDefaults.h"
 
-class DetId;
 class CaloTopology;
 class CaloGeometry;
 

--- a/RecoEgamma/EgammaElectronAlgos/interface/TrajSeedMatcher.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/TrajSeedMatcher.h
@@ -28,6 +28,7 @@
 #include "DataFormats/Math/interface/Point3D.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
@@ -49,7 +50,6 @@ namespace edm {
 }  // namespace edm
 
 class FreeTrajectoryState;
-class TrackingRecHit;
 
 class TrajSeedMatcher {
 public:

--- a/RecoEgamma/EgammaPhotonAlgos/interface/ConversionHitChecker.h
+++ b/RecoEgamma/EgammaPhotonAlgos/interface/ConversionHitChecker.h
@@ -27,7 +27,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include <utility>
 
-class Trajectory;
 class ConversionHitChecker {
 public:
   ConversionHitChecker() {}

--- a/RecoJets/JetProducers/interface/JetMatchingTools.h
+++ b/RecoJets/JetProducers/interface/JetMatchingTools.h
@@ -6,22 +6,22 @@
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
+#include "DataFormats/CaloTowers/interface/CaloTowerFwd.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimDataFormats/CaloHit/interface/PCaloHitFwd.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/JetReco/interface/CaloJetFwd.h"
 #include "DataFormats/JetReco/interface/GenJetFwd.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 namespace edm {
   class Event;
 }
 
-class CaloTower;
 class CaloRecHit;
-class DetId;
-class PCaloHit;
 
 class JetMatchingTools {
 public:

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.h
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.h
@@ -5,6 +5,7 @@
 #include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 
 // channel status
@@ -38,7 +39,6 @@ class CaloGeometry;
 class CaloSubdetectorGeometry;
 class CaloTowerConstituentsMap;
 class CaloRecHit;
-class DetId;
 
 /** \class CaloTowersCreationAlgo
   *  

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalCleaningAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalCleaningAlgo.h
@@ -12,9 +12,8 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 #include <vector>
-
-class DetId;
 
 class EcalCleaningAlgo {
 public:

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h
@@ -12,6 +12,8 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EcalRecHit/interface/EcalSeverityLevel.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitFwd.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 #include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
 
 #include <vector>
@@ -26,9 +28,6 @@
      Do not cache the algorithm, or the channel status will not be updated.
      
  */
-
-class EcalRecHit;
-class DetId;
 
 class EcalSeverityLevelAlgo {
 public:

--- a/RecoLocalCalo/HGCalRecAlgos/interface/ClusterTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/ClusterTools.h
@@ -9,6 +9,7 @@
 #include "DataFormats/HGCRecHit/interface/HGCRecHitCollections.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/HGCalMultiCluster.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 #include "DataFormats/Common/interface/MultiSpan.h"
 
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
@@ -19,7 +20,6 @@
 
 class HGCalGeometry;
 class HGCalDDDConstants;
-class DetId;
 
 namespace edm {
   class Event;

--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -12,7 +12,6 @@
 
 class CaloGeometry;
 class CaloSubdetectorGeometry;
-class DetId;
 
 namespace edm {
   class Event;

--- a/RecoLocalCalo/HcalRecAlgos/interface/HBHEIsolatedNoiseAlgos.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HBHEIsolatedNoiseAlgos.h
@@ -31,7 +31,9 @@ Original Author: John Paul Chou (Brown University)
 #include "CondFormats/HcalObjects/interface/HcalFrontEndMap.h"
 #include "Geometry/CaloTopology/interface/CaloTowerConstituentsMap.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "DataFormats/HcalRecHit/interface/HBHERecHitFwd.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitFwd.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/JetReco/interface/TrackExtrapolation.h"
 
@@ -40,8 +42,6 @@ Original Author: John Paul Chou (Brown University)
 #include <map>
 
 // forward declarations
-class HBHERecHit;
-class EcalRecHit;
 class HcalChannelQuality;
 class HcalSeverityLevelComputer;
 class EcalSeverityLevelAlgo;

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalTDCReco.h
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalTDCReco.h
@@ -1,8 +1,8 @@
 #ifndef HcalRecAlgos_HcalTDCReco_h
 #define HcalRecAlgos_HcalTDCReco_h
 
+#include "DataFormats/HcalRecHit/interface/HBHERecHitFwd.h"
 class HcalUpgradeDataFrame;
-class HBHERecHit;
 
 class HcalTDCReco {
 public:

--- a/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.h
+++ b/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.h
@@ -39,6 +39,7 @@
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/MuonDetId/interface/CSCDetIdFwd.h"
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 
@@ -90,7 +91,6 @@ namespace edm {
 
 class TFile;
 class CSCLayer;
-class CSCDetId;
 
 class CSCEfficiency : public edm::one::EDFilter<> {
 public:

--- a/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.h
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.h
@@ -20,6 +20,7 @@
 #include "RecoLocalMuon/CSCRecHitD/src/CSCRecoConditions.h"
 
 #include "DataFormats/CSCDigi/interface/CSCStripDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCStripDigiFwd.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -28,7 +29,6 @@
 #include <array>
 
 class CSCLayer;
-class CSCStripDigi;
 class CSCPedestalChoice;
 
 class CSCHitFromStripOnly {

--- a/RecoLocalMuon/CSCRecHitD/src/CSCHitFromWireOnly.h
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCHitFromWireOnly.h
@@ -21,6 +21,7 @@
 #include <RecoLocalMuon/CSCRecHitD/src/CSCWireHit.h>
 
 #include <DataFormats/CSCDigi/interface/CSCWireDigiCollection.h>
+#include "DataFormats/MuonDetId/interface/CSCDetIdFwd.h"
 
 #include <RecoLocalMuon/CSCRecHitD/src/CSCRecoConditions.h>
 
@@ -31,7 +32,6 @@
 
 class CSCLayer;
 class CSCLayerGeometry;
-class CSCDetId;
 
 class CSCHitFromWireOnly {
 public:

--- a/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.h
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.h
@@ -17,10 +17,10 @@
 #include <RecoLocalMuon/CSCRecHitD/src/CSCFindPeakTime.h>
 
 #include <DataFormats/CSCRecHit/interface/CSCRecHit2D.h>
+#include "DataFormats/MuonDetId/interface/CSCDetIdFwd.h"
 
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
 
-class CSCDetId;
 class CSCLayer;
 class CSCChamberSpecs;
 class CSCLayerGeometry;

--- a/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDBuilder.h
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDBuilder.h
@@ -24,12 +24,12 @@
 #include <DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h>
 #include <DataFormats/CSCDigi/interface/CSCStripDigiCollection.h>
 #include <DataFormats/CSCDigi/interface/CSCWireDigiCollection.h>
+#include <DataFormats/MuonDetId/interface/CSCDetIdFwd.h>
 
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
 
 class CSCLayer;
 class CSCGeometry;
-class CSCDetId;
 class CSCHitFromStripOnly;
 class CSCHitFromWireOnly;
 class CSCMake2DRecHit;

--- a/RecoLocalMuon/DTRecHit/interface/DTRecHitBaseAlgo.h
+++ b/RecoLocalMuon/DTRecHit/interface/DTRecHitBaseAlgo.h
@@ -13,12 +13,12 @@
 #include "DataFormats/GeometrySurface/interface/LocalError.h"
 
 #include "DataFormats/DTDigi/interface/DTDigiCollection.h"
+#include "DataFormats/DTDigi/interface/DTDigiFwd.h"
 #include "DataFormats/DTRecHit/interface/DTRecHit1DPair.h"
 #include "DataFormats/Common/interface/OwnVector.h"
+#include "DataFormats/MuonDetId/interface/DTLayerIdFwd.h"
 
-class DTDigi;
 class DTLayer;
-class DTLayerId;
 class DTTTrigBaseSync;
 
 namespace edm {

--- a/RecoLocalMuon/DTRecHit/test/DTRecHitReader.h
+++ b/RecoLocalMuon/DTRecHit/test/DTRecHitReader.h
@@ -12,6 +12,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitFwd.h"
 
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 
@@ -27,7 +28,6 @@ namespace edm {
   class EventSetup;
 }  // namespace edm
 
-class PSimHit;
 class TFile;
 class DTLayer;
 class DTWireId;

--- a/RecoLocalMuon/DTSegment/src/DTRecSegment4DBaseAlgo.h
+++ b/RecoLocalMuon/DTSegment/src/DTRecSegment4DBaseAlgo.h
@@ -17,10 +17,9 @@ namespace edm {
 #include "DataFormats/DTRecHit/interface/DTRecSegment4D.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment2DCollection.h"
 #include "DataFormats/DTRecHit/interface/DTRecHitCollection.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
 
 #include "DataFormats/Common/interface/Handle.h"
-
-class DTChamberId;
 
 // C++ Headers
 #include <vector>

--- a/RecoLocalMuon/DTSegment/src/DTSegmentUpdator.h
+++ b/RecoLocalMuon/DTSegment/src/DTSegmentUpdator.h
@@ -19,6 +19,7 @@
 
 #include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/DTRecHit/interface/DTRecSegment4DFwd.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -30,7 +31,6 @@
 /* Collaborating Class Declarations */
 class DTSegmentCand;
 class DTRecSegment2D;
-class DTRecSegment4D;
 class DTLinearFit;
 class DTRecHitBaseAlgo;
 class DTChamberRecSegment2D;

--- a/RecoLocalMuon/DTSegment/test/DTAnalyzerDetailed.h
+++ b/RecoLocalMuon/DTSegment/test/DTAnalyzerDetailed.h
@@ -23,12 +23,12 @@ namespace edm {
 
 /* Collaborating Class Declarations */
 #include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/MuonDetId/interface/DTLayerIdFwd.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
 class TFile;
 class TH1F;
 class TH2F;
-class DTLayerId;
 class DTSuperLayerId;
-class DTChamberId;
 class DTTTrigBaseSync;
 class MuonGeometryRecord;
 class DTGeometry;

--- a/RecoLocalMuon/DTSegment/test/DTEffAnalyzer.h
+++ b/RecoLocalMuon/DTSegment/test/DTEffAnalyzer.h
@@ -27,9 +27,9 @@ namespace edm {
 class TFile;
 class TH1F;
 class TH2F;
-class DTLayerId;
 class DTSuperLayerId;
-class DTChamberId;
+#include "DataFormats/MuonDetId/interface/DTLayerIdFwd.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"

--- a/RecoLocalMuon/DTSegment/test/DTSegAnalyzer.h
+++ b/RecoLocalMuon/DTSegment/test/DTSegAnalyzer.h
@@ -23,12 +23,12 @@ namespace edm {
 
 /* Collaborating Class Declarations */
 #include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/MuonDetId/interface/DTLayerIdFwd.h"
+#include "DataFormats/MuonDetId/interface/DTChamberIdFwd.h"
 class TFile;
 class TH1F;
 class TH2F;
-class DTLayerId;
 class DTSuperLayerId;
-class DTChamberId;
 class DTTTrigBaseSync;
 class DTGeometry;
 class MuonGeometryRecord;

--- a/RecoLocalMuon/GEMRecHit/interface/GEMRecHitBaseAlgo.h
+++ b/RecoLocalMuon/GEMRecHit/interface/GEMRecHitBaseAlgo.h
@@ -13,6 +13,7 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
 #include "DataFormats/GEMRecHit/interface/GEMRecHit.h"
+#include "DataFormats/MuonDetId/interface/GEMDetIdFwd.h"
 #include "DataFormats/Common/interface/OwnVector.h"
 
 #include "RecoLocalMuon/GEMRecHit/interface/GEMEtaPartitionMask.h"
@@ -20,7 +21,6 @@
 
 class GEMCluster;
 class GEMEtaPartition;
-class GEMDetId;
 
 namespace edm {
   class ParameterSet;

--- a/RecoLocalMuon/RPCRecHit/plugins/RPCRecHitBaseAlgo.h
+++ b/RecoLocalMuon/RPCRecHit/plugins/RPCRecHitBaseAlgo.h
@@ -13,6 +13,7 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
+#include "DataFormats/MuonDetId/interface/RPCDetIdFwd.h"
 #include "DataFormats/Common/interface/OwnVector.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -20,7 +21,6 @@
 
 class RPCCluster;
 class RPCRoll;
-class RPCDetId;
 
 namespace edm {
   class EventSetup;

--- a/RecoLocalMuon/RPCRecHit/test/RPCRecHitReader.h
+++ b/RecoLocalMuon/RPCRecHit/test/RPCRecHitReader.h
@@ -15,6 +15,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
+#include "DataFormats/RPCRecHit/interface/RPCRecHitFwd.h"
 
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"
@@ -34,7 +35,6 @@ class TFile;
 class TH1F;
 class TH2F;
 
-class RPCRecHit;
 class RPCGeometry;
 class MuonGeometryRecord;
 

--- a/RecoLuminosity/LumiProducer/test/analysis/plugins/PCCNTupler.h
+++ b/RecoLuminosity/LumiProducer/test/analysis/plugins/PCCNTupler.h
@@ -18,6 +18,7 @@
 #include <map>
 
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
@@ -39,7 +40,6 @@ class TObject;
 class TTree;
 class TH1D;
 class TFile;
-class DetId;
 
 class PCCNTupler : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchLuminosityBlocks> {
 public:

--- a/RecoMET/METAlgorithms/interface/CaloSpecificAlgo.h
+++ b/RecoMET/METAlgorithms/interface/CaloSpecificAlgo.h
@@ -27,10 +27,10 @@
 #include "DataFormats/METReco/interface/CommonMETData.h"
 #include "DataFormats/METReco/interface/SpecificCaloMETData.h"
 #include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/CaloTowers/interface/CaloTowerFwd.h"
 
 #include <vector>
 
-class CaloTower;
 struct SpecificCaloMETData;
 
 //____________________________________________________________________________||

--- a/RecoMuon/CosmicMuonProducer/interface/CosmicMuonSmoother.h
+++ b/RecoMuon/CosmicMuonProducer/interface/CosmicMuonSmoother.h
@@ -27,7 +27,6 @@ namespace edm {
   class EventSetup;
 }  // namespace edm
 
-class Trajectory;
 class TrajectoryMeasurement;
 
 typedef MuonTransientTrackingRecHit::MuonRecHitContainer MuonRecHitContainer;

--- a/RecoMuon/CosmicMuonProducer/interface/CosmicMuonTrajectoryBuilder.h
+++ b/RecoMuon/CosmicMuonProducer/interface/CosmicMuonTrajectoryBuilder.h
@@ -14,6 +14,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "TrackingTools/DetLayers/interface/DetLayer.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 #include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 #include "RecoMuon/MeasurementDet/interface/MuonDetLayerMeasurements.h"
 #include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h"
@@ -29,7 +30,6 @@ namespace edm {
   class EventSetup;
 }  // namespace edm
 
-class Trajectory;
 class TrajectoryMeasurement;
 class CosmicMuonUtilities;
 class DirectMuonNavigation;

--- a/RecoMuon/CosmicMuonProducer/interface/CosmicMuonUtilities.h
+++ b/RecoMuon/CosmicMuonProducer/interface/CosmicMuonUtilities.h
@@ -10,6 +10,7 @@
 #include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 
 class Propagator;
 
@@ -19,7 +20,6 @@ namespace edm {
   class EventSetup;
 }  // namespace edm
 
-class Trajectory;
 class TrajectoryMeasurement;
 
 typedef MuonTransientTrackingRecHit::MuonRecHitContainer MuonRecHitContainer;

--- a/RecoMuon/CosmicMuonProducer/interface/GlobalCosmicMuonTrajectoryBuilder.h
+++ b/RecoMuon/CosmicMuonProducer/interface/GlobalCosmicMuonTrajectoryBuilder.h
@@ -21,6 +21,7 @@
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "RecoMuon/CosmicMuonProducer/interface/CosmicMuonSmoother.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 #include "RecoMuon/GlobalTrackingTools/interface/GlobalMuonTrackMatcher.h"
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 
@@ -30,7 +31,6 @@ namespace edm {
   class EventSetup;
 }  // namespace edm
 
-class Trajectory;
 class TrajectoryMeasurement;
 class CosmicMuonUtilities;
 

--- a/RecoMuon/GlobalTrackFinder/interface/GlobalMuonTrajectoryBuilder.h
+++ b/RecoMuon/GlobalTrackFinder/interface/GlobalMuonTrajectoryBuilder.h
@@ -23,7 +23,6 @@ namespace edm {
 }  // namespace edm
 
 class MuonServiceProxy;
-class Trajectory;
 
 class GlobalMuonTrajectoryBuilder : public GlobalTrajectoryBuilderBase {
 public:

--- a/RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h
+++ b/RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h
@@ -23,6 +23,7 @@
 #include "RecoMuon/TrackingTools/interface/MuonTrajectoryBuilder.h"
 #include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h"
 #include "TrackingTools/TrackRefitter/interface/TrackTransformer.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 #include "DataFormats/DTRecHit/interface/DTRecHitCollection.h"
 #include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
 #include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
@@ -42,7 +43,6 @@ class TrackerTopology;
 
 class MuonDetLayerMeasurements;
 class MuonServiceProxy;
-class Trajectory;
 
 class TrajectoryFitter;
 class TrajectoryFitterRecord;

--- a/RecoMuon/GlobalTrackingTools/interface/GlobalMuonTrackMatcher.h
+++ b/RecoMuon/GlobalTrackingTools/interface/GlobalMuonTrackMatcher.h
@@ -23,10 +23,10 @@
  */
 
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 
 class TrajectoryStateOnSurface;
 class MuonServiceProxy;
-class Trajectory;
 
 namespace edm {
   class ParameterSet;

--- a/RecoMuon/L2MuonSeedGenerator/plugins/L2MuonSeedGenerator.h
+++ b/RecoMuon/L2MuonSeedGenerator/plugins/L2MuonSeedGenerator.h
@@ -25,6 +25,7 @@
 #include "DataFormats/MuonSeed/interface/L2MuonTrajectorySeed.h"
 #include "DataFormats/MuonSeed/interface/L2MuonTrajectorySeedCollection.h"
 #include "DataFormats/TrajectoryState/interface/PTrajectoryStateOnDet.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedFwd.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTExtendedCand.h"
@@ -42,7 +43,6 @@
 
 class MuonServiceProxy;
 class MeasurementEstimator;
-class TrajectorySeed;
 class TrajectoryStateOnSurface;
 
 namespace edm {

--- a/RecoMuon/L2MuonSeedGenerator/plugins/L2MuonSeedGeneratorFromL1T.h
+++ b/RecoMuon/L2MuonSeedGenerator/plugins/L2MuonSeedGeneratorFromL1T.h
@@ -27,6 +27,7 @@
 #include "DataFormats/MuonSeed/interface/L2MuonTrajectorySeed.h"
 #include "DataFormats/MuonSeed/interface/L2MuonTrajectorySeedCollection.h"
 #include "DataFormats/TrajectoryState/interface/PTrajectoryStateOnDet.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedFwd.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -40,7 +41,6 @@
 
 class MuonServiceProxy;
 class MeasurementEstimator;
-class TrajectorySeed;
 class TrajectoryStateOnSurface;
 
 namespace edm {

--- a/RecoMuon/L3TrackFinder/interface/L3MuonTrajectoryBuilder.h
+++ b/RecoMuon/L3TrackFinder/interface/L3MuonTrajectoryBuilder.h
@@ -13,6 +13,7 @@
 #include "RecoMuon/GlobalTrackingTools/interface/GlobalTrajectoryBuilderBase.h"
 #include "TrackingTools/PatternTools/interface/TrajectoryBuilder.h"
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 #include "TrackingTools/DetLayers/interface/NavigationSchool.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -31,7 +32,6 @@ namespace edm {
 }  // namespace edm
 
 class MuonServiceProxy;
-class Trajectory;
 class TrajectoryCleaner;
 
 class L3MuonTrajectoryBuilder : public GlobalTrajectoryBuilderBase {

--- a/RecoMuon/MuonIdentification/interface/MuonShowerInformationFiller.h
+++ b/RecoMuon/MuonIdentification/interface/MuonShowerInformationFiller.h
@@ -49,7 +49,6 @@ namespace reco {
 }  // namespace reco
 
 class MuonServiceProxy;
-class Trajectory;
 class Cylinder;
 class Disk;
 class BarrelDetLayer;

--- a/RecoMuon/MuonIdentification/plugins/MuonReducedTrackExtraProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonReducedTrackExtraProducer.h
@@ -13,9 +13,9 @@
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelClusterFwd.h"
 #include "DataFormats/Common/interface/Association.h"
 
-class SiPixelCluster;
 class SiStripCluster;
 
 class MuonReducedTrackExtraProducer : public edm::stream::EDProducer<> {

--- a/RecoMuon/MuonSeedGenerator/interface/SETFilter.h
+++ b/RecoMuon/MuonSeedGenerator/interface/SETFilter.h
@@ -38,7 +38,6 @@ struct SeedCandidate {
 };
 
 class DetLayer;
-class Trajectory;
 //class MuonServiceProxy;
 class TrajectoryFitter;
 

--- a/RecoMuon/MuonSeedGenerator/plugins/SETMuonSeedProducer.h
+++ b/RecoMuon/MuonSeedGenerator/plugins/SETMuonSeedProducer.h
@@ -21,8 +21,8 @@
 #include "RecoMuon/MuonSeedGenerator/interface/SETPatternRecognition.h"
 #include "RecoMuon/MuonSeedGenerator/interface/SETSeedFinder.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedFwd.h"
 
-class TrajectorySeed;
 class STAFilter;
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"

--- a/RecoMuon/MuonSeedGenerator/test/MCSeedGenerator/MCMuonSeedGenerator.h
+++ b/RecoMuon/MuonSeedGenerator/test/MCSeedGenerator/MCMuonSeedGenerator.h
@@ -15,12 +15,12 @@
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 #include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedFwd.h"
+#include "SimDataFormats/Track/interface/SimTrackFwd.h"
+#include "SimDataFormats/Vertex/interface/SimVertexFwd.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 
 class MuonServiceProxy;
-class TrajectorySeed;
-class SimTrack;
-class SimVertex;
 
 namespace edm {
   class ParameterSet;

--- a/RecoMuon/MuonSeedGenerator/test/MuonSeedPTAnalysis/MuonSeedParametrization.h
+++ b/RecoMuon/MuonSeedGenerator/test/MuonSeedPTAnalysis/MuonSeedParametrization.h
@@ -17,6 +17,7 @@
 
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 #include <DataFormats/MuonDetId/interface/DTChamberId.h>
+#include "DataFormats/MuonDetId/interface/DTLayerIdFwd.h"
 #include <DataFormats/CSCRecHit/interface/CSCRecHit2D.h>
 #include <DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h>
 #include <DataFormats/CSCRecHit/interface/CSCSegment.h>
@@ -62,10 +63,7 @@ namespace edm {
 //class PSimHit;
 class TFile;
 class CSCLayer;
-class CSCDetId;
-class DTLayerId;
 class DTSuperLayerId;
-class DTChamberId;
 class SegSelector;
 class MuonSeedParaFillHisto;
 class MuonSeeddPhiScale;

--- a/RecoMuon/MuonSeedGenerator/test/MuonSeedPTAnalysis/MuonSeedValidator.h
+++ b/RecoMuon/MuonSeedGenerator/test/MuonSeedPTAnalysis/MuonSeedValidator.h
@@ -17,6 +17,7 @@
 
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 #include <DataFormats/MuonDetId/interface/DTChamberId.h>
+#include "DataFormats/MuonDetId/interface/DTLayerIdFwd.h"
 #include <DataFormats/CSCRecHit/interface/CSCRecHit2D.h>
 #include <DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h>
 #include <DataFormats/CSCRecHit/interface/CSCSegment.h>
@@ -65,10 +66,7 @@ namespace edm {
 //class PSimHit;
 class TFile;
 class CSCLayer;
-class CSCDetId;
-class DTLayerId;
 class DTSuperLayerId;
-class DTChamberId;
 class SegSelector;
 //class MuonSeedBuilder;
 

--- a/RecoMuon/MuonSeedGenerator/test/MuonSeedPTAnalysis/SegSelector.h
+++ b/RecoMuon/MuonSeedGenerator/test/MuonSeedPTAnalysis/SegSelector.h
@@ -12,6 +12,7 @@
 
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 #include <DataFormats/MuonDetId/interface/DTChamberId.h>
+#include "DataFormats/MuonDetId/interface/DTLayerIdFwd.h"
 #include <DataFormats/CSCRecHit/interface/CSCRecHit2D.h>
 #include <DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h>
 #include <DataFormats/CSCRecHit/interface/CSCSegment.h>
@@ -47,10 +48,7 @@
 
 //class PSimHit;
 class CSCLayer;
-class CSCDetId;
-class DTLayerId;
 class DTSuperLayerId;
-class DTChamberId;
 
 // Sim_CSCSegments products
 struct SimSegment {

--- a/RecoMuon/StandAloneTrackFinder/interface/StandAloneMuonFilter.h
+++ b/RecoMuon/StandAloneTrackFinder/interface/StandAloneMuonFilter.h
@@ -14,6 +14,7 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 #include "TrackingTools/DetLayers/interface/NavigationDirection.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 #include "DataFormats/TrajectorySeed/interface/PropagationDirection.h"
 
 #include "RecoMuon/TrackingTools/interface/MuonBestMeasurementFinder.h"
@@ -22,7 +23,6 @@
 class Propagator;
 class DetLayer;
 class MuonTrajectoryUpdator;
-class Trajectory;
 class MuonDetLayerMeasurements;
 class MeasurementEstimator;
 class MuonServiceProxy;

--- a/RecoMuon/StandAloneTrackFinder/interface/StandAloneMuonRefitter.h
+++ b/RecoMuon/StandAloneTrackFinder/interface/StandAloneMuonRefitter.h
@@ -19,7 +19,6 @@ namespace edm {
 }  // namespace edm
 class MuonServiceProxy;
 class TrajectoryFitter;
-class Trajectory;
 
 class StandAloneMuonRefitter {
 public:

--- a/RecoMuon/StandAloneTrackFinder/interface/StandAloneTrajectoryBuilder.h
+++ b/RecoMuon/StandAloneTrackFinder/interface/StandAloneTrajectoryBuilder.h
@@ -12,7 +12,8 @@
 #include "RecoMuon/TrackingTools/interface/RecoMuonEnumerators.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
-class TrajectorySeed;
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedFwd.h"
+
 class StandAloneMuonFilter;
 class StandAloneMuonBackwardFilter;
 class StandAloneMuonRefitter;

--- a/RecoMuon/TrackerSeedGenerator/interface/L1MuonPixelTrackFitter.h
+++ b/RecoMuon/TrackerSeedGenerator/interface/L1MuonPixelTrackFitter.h
@@ -8,6 +8,8 @@
 #include "DataFormats/GeometryVector/interface/Point3DBase.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
+#include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTCandFwd.h"
 
 #include <vector>
 
@@ -16,8 +18,6 @@ namespace reco {
 }
 
 class TrackingRegion;
-class TrackingRecHit;
-class L1MuGMTCand;
 class PixelRecoLineRZ;
 class SeedingHitSet;
 class MagneticField;

--- a/RecoMuon/TrackerSeedGenerator/interface/L1MuonRegionProducer.h
+++ b/RecoMuon/TrackerSeedGenerator/interface/L1MuonRegionProducer.h
@@ -4,11 +4,11 @@
 #include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTCandFwd.h"
 #include <vector>
 #include <memory>
 
 class TrackingRegion;
-class L1MuGMTCand;
 class MagneticField;
 class IdealMagneticFieldRecord;
 class MultipleScatteringParametrisationMaker;

--- a/RecoMuon/TrackerSeedGenerator/interface/TrackerSeedGenerator.h
+++ b/RecoMuon/TrackerSeedGenerator/interface/TrackerSeedGenerator.h
@@ -8,8 +8,8 @@
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 
-class Trajectory;
 class TrackingRegion;
 class MuonServiceProxy;
 class TrackerTopology;

--- a/RecoMuon/TrackingTools/interface/DirectMuonTrajectoryBuilder.h
+++ b/RecoMuon/TrackingTools/interface/DirectMuonTrajectoryBuilder.h
@@ -10,11 +10,11 @@
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "RecoMuon/TrackingTools/interface/MuonCandidate.h"
 #include "RecoMuon/TrackingTools/interface/MuonTrajectoryBuilder.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedFwd.h"
 #include <vector>
 
 class MuonServiceProxy;
 class SeedTransformer;
-class TrajectorySeed;
 
 namespace edm {
   class ParameterSet;

--- a/RecoMuon/TrackingTools/interface/MuonPatternRecoDumper.h
+++ b/RecoMuon/TrackingTools/interface/MuonPatternRecoDumper.h
@@ -8,12 +8,12 @@
  *  \author R. Bellan - INFN Torino <riccardo.bellan@cern.ch>
  */
 
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 #include <string>
 
 class DetLayer;
 class FreeTrajectoryState;
 class TrajectoryStateOnSurface;
-class DetId;
 
 class MuonPatternRecoDumper {
 public:

--- a/RecoMuon/TrackingTools/interface/MuonTrackLoader.h
+++ b/RecoMuon/TrackingTools/interface/MuonTrackLoader.h
@@ -25,6 +25,7 @@
 
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
 #include "TrackingTools/TrackFitters/interface/TrajectoryFitter.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 
 namespace edm {
   class Event;
@@ -32,7 +33,6 @@ namespace edm {
   class ParameterSet;
 }  // namespace edm
 
-class Trajectory;
 class Propagator;
 class MuonServiceProxy;
 class MuonUpdatorAtVertex;

--- a/RecoMuon/TrackingTools/interface/MuonTrajectoryBuilder.h
+++ b/RecoMuon/TrackingTools/interface/MuonTrajectoryBuilder.h
@@ -9,14 +9,13 @@
 
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedFwd.h"
 #include "RecoMuon/TrackingTools/interface/MuonCandidate.h"
 #include <vector>
 
 namespace edm {
   class Event;
 }
-
-class TrajectorySeed;
 
 class MuonTrajectoryBuilder {
 public:

--- a/RecoMuon/TrackingTools/interface/MuonTrajectoryUpdator.h
+++ b/RecoMuon/TrackingTools/interface/MuonTrajectoryUpdator.h
@@ -16,13 +16,13 @@
 
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 #include "TrackingTools/DetLayers/interface/NavigationDirection.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 
 #include <functional>
 
 class Propagator;
 class MeasurementEstimator;
 class TrajectoryMeasurement;
-class Trajectory;
 class TrajectoryStateOnSurface;
 class TrajectoryStateUpdator;
 class DetLayer;

--- a/RecoParticleFlow/PFProducer/plugins/PFElectronTranslator.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFElectronTranslator.cc
@@ -19,8 +19,8 @@
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 #include "CondFormats/EcalObjects/interface/EcalMustacheSCParameters.h"
 #include "CondFormats/DataRecord/interface/EcalMustacheSCParametersRcd.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 
-class DetId;
 namespace edm {
   class EventSetup;
 }  // namespace edm

--- a/RecoParticleFlow/PFTracking/interface/PFCheckHitPattern.h
+++ b/RecoParticleFlow/PFTracking/interface/PFCheckHitPattern.h
@@ -11,13 +11,12 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 #include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 #define DEBUG_CHECKHITPATTERN
-
-class DetId;
 
 /// \brief PFCheckHitPatter
 /*!

--- a/RecoParticleFlow/PFTracking/interface/PFTrackTransformer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFTrackTransformer.h
@@ -16,6 +16,7 @@
 #include "DataFormats/Math/interface/Vector3D.h"
 #include "TrackingTools/GsfTools/interface/MultiTrajectoryStateTransform.h"
 #include "TrackingTools/GsfTools/interface/MultiTrajectoryStateMode.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 
 /// \brief Abstract
 /*!
@@ -30,7 +31,6 @@
  Evaluate the surface corresponding to the maximum shower
 */
 
-class Trajectory;
 class PFTrackTransformer {
 public:
   PFTrackTransformer(const math::XYZVector&);

--- a/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
@@ -3,6 +3,8 @@
 
 #include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
 #include "TrackingTools/PatternTools/interface/TrajectoryBuilder.h"
+#include "TrackingTools/PatternTools/interface/TempTrajectory.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -11,7 +13,6 @@
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
 
 #include <cassert>
-#include "TrackingTools/PatternTools/interface/TempTrajectory.h"
 
 class CkfDebugger;
 class Chi2MeasurementEstimatorBase;
@@ -31,7 +32,6 @@ class TrajectoryStateOnSurface;
 class TrajectoryFitter;
 class TransientRecHitRecord;
 class TransientTrackingRecHitBuilder;
-class Trajectory;
 class TempTrajectory;
 class TrajectoryFilter;
 class TrackingRegion;

--- a/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
@@ -6,7 +6,6 @@
 class Propagator;
 class TrajectoryStateUpdator;
 class MeasurementEstimator;
-class TrajectorySeed;
 class TrajectoryStateOnSurface;
 class TrajectoryFilter;
 

--- a/RecoTracker/CkfPattern/interface/TransientInitialStateEstimator.h
+++ b/RecoTracker/CkfPattern/interface/TransientInitialStateEstimator.h
@@ -5,13 +5,13 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h"
 
 #include <utility>
 
 class Propagator;
 class GeomDet;
-class Trajectory;
 class TrackingComponentsRecord;
 namespace edm {
   class EventSetup;

--- a/RecoTracker/CkfPattern/plugins/TrajectorySegmentBuilder.h
+++ b/RecoTracker/CkfPattern/plugins/TrajectorySegmentBuilder.h
@@ -7,6 +7,7 @@
 //B.M.#include "TrackingTools/GeomPropagators/interface/AnalyticalPropagator.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTracker.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 #include "TrackingTools/MeasurementDet/interface/LayerMeasurements.h"
@@ -16,7 +17,6 @@
 
 class TrajectoryStateUpdator;
 class MeasurementEstimator;
-class Trajectory;
 class TrajectoryMeasurement;
 class TrajectoryMeasurementGroup;
 class FreeTrajectoryState;

--- a/RecoTracker/DebugTools/plugins/CkfDebugger.h
+++ b/RecoTracker/DebugTools/plugins/CkfDebugger.h
@@ -20,6 +20,7 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
 #include "TrackingTools/PatternTools/interface/MeasurementExtractor.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
@@ -29,9 +30,7 @@
 #include <TH1F.h>
 #include <TH2F.h>
 
-class Trajectory;
 class TrajectoryMeasurement;
-class PSimHit;
 class MeasurementTrackerEvent;
 class TrajectoryStateOnSurface;
 class MagneticField;

--- a/RecoTracker/DebugTools/plugins/FTSFromSimHitFactory.h
+++ b/RecoTracker/DebugTools/plugins/FTSFromSimHitFactory.h
@@ -2,8 +2,8 @@
 #define FTSFromSimHitFactory_H
 
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitFwd.h"
 
-class PSimHit;
 class GeomDet;
 class MagneticField;
 

--- a/RecoTracker/MeasurementDet/plugins/RecHitPropagator.h
+++ b/RecoTracker/MeasurementDet/plugins/RecHitPropagator.h
@@ -2,8 +2,8 @@
 #define RecHitPropagator_H
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 
-class TrackingRecHit;
 class MagneticField;
 class Plane;
 

--- a/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.h
@@ -9,8 +9,8 @@
 #include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 #include "RecoTracker/MeasurementDet/src/TkMeasurementDetSet.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 
-class TrackingRecHit;
 class LocalTrajectoryParameters;
 
 class dso_hidden TkPhase2OTMeasurementDet final : public MeasurementDet {

--- a/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.h
@@ -10,8 +10,8 @@
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 #include "RecoTracker/MeasurementDet/src/TkMeasurementDetSet.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 
-class TrackingRecHit;
 class LocalTrajectoryParameters;
 
 class dso_hidden TkPixelMeasurementDet final : public MeasurementDet {

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.h
@@ -9,6 +9,7 @@
 #include "RecoLocalTracker/SiStripRecHitConverter/interface/StripCPE.h"
 
 #include "DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "DataFormats/SiStripCluster/interface/SiStripClusterCollection.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
@@ -24,8 +25,6 @@
 #include "RecoTracker/MeasurementDet/interface/ClusterFilterPayload.h"
 
 #include <tuple>
-
-class TrackingRecHit;
 
 class TkStripMeasurementDet;
 

--- a/RecoTracker/MkFit/interface/MkFitClusterIndexToHit.h
+++ b/RecoTracker/MkFit/interface/MkFitClusterIndexToHit.h
@@ -3,7 +3,7 @@
 
 #include <vector>
 
-class TrackingRecHit;
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 
 class MkFitClusterIndexToHit {
 public:

--- a/RecoTracker/NuclearSeedGenerator/interface/NuclearSeedsEDProducer.h
+++ b/RecoTracker/NuclearSeedGenerator/interface/NuclearSeedsEDProducer.h
@@ -36,12 +36,12 @@
 
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "RecoTracker/NuclearSeedGenerator/interface/TrajectoryToSeedMap.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 
 namespace reco {
   class TransientTrack;
 }
 
-class Trajectory;
 class Chi2MeasurementEstimatorBase;
 class CkfComponentsRecord;
 class NavigationSchoolRecord;

--- a/RecoTracker/PixelLowPtUtilities/interface/ClusterShape.h
+++ b/RecoTracker/PixelLowPtUtilities/interface/ClusterShape.h
@@ -7,7 +7,6 @@
 #include <vector>
 
 class PixelGeomDetUnit;
-class SiPixelCluster;
 class SiPixelRecHit;
 class ClusterData;
 

--- a/RecoTracker/PixelLowPtUtilities/interface/ClusterShapeTrackFilter.h
+++ b/RecoTracker/PixelLowPtUtilities/interface/ClusterShapeTrackFilter.h
@@ -11,10 +11,11 @@ typedef Vector2DBase<float, GlobalTag> Global2DVector;
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
+
 #include <vector>
 
 class TrackerGeometry;
-class TrackingRecHit;
 class ClusterShapeHitFilter;
 class TrackerTopology;
 class SiPixelClusterShapeCache;

--- a/RecoTracker/PixelLowPtUtilities/interface/HitInfo.h
+++ b/RecoTracker/PixelLowPtUtilities/interface/HitInfo.h
@@ -1,9 +1,9 @@
 #ifndef RecoTracker_PixelLowPtUtilities_HitInfo_h
 #define RecoTracker_PixelLowPtUtilities_HitInfo_h
 
-class DetId;
-class TrackingRecHit;
-class PSimHit;
+#include "DataFormats/DetId/interface/DetIdFwd.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitFwd.h"
 
 #include <vector>
 #include <string>

--- a/RecoTracker/PixelLowPtUtilities/interface/ThirdHitPrediction.h
+++ b/RecoTracker/PixelLowPtUtilities/interface/ThirdHitPrediction.h
@@ -18,9 +18,10 @@ typedef Vector2DBase<float, GlobalTag> Global2DVector;
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
+
 class DetLayer;
 class OrderedHitPair;
-class TrackingRecHit;
 
 class MagneticField;
 class TransientTrackingRecHitBuilder;

--- a/RecoTracker/PixelLowPtUtilities/interface/TripletFilter.h
+++ b/RecoTracker/PixelLowPtUtilities/interface/TripletFilter.h
@@ -3,10 +3,10 @@
 
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 
 #include <vector>
 
-class TrackingRecHit;
 class ClusterShapeHitFilter;
 class TrackerTopology;
 class SiPixelClusterShapeCache;

--- a/RecoTracker/PixelTrackFitting/interface/KFBasedPixelFitter.h
+++ b/RecoTracker/PixelTrackFitting/interface/KFBasedPixelFitter.h
@@ -13,7 +13,7 @@ class TransientTrackingRecHitBuilder;
 class TrackerGeometry;
 class MagneticField;
 class TrackingRegion;
-class TrackingRecHit;
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 class Propagator;
 
 class KFBasedPixelFitter : public PixelFitterBase {

--- a/RecoTracker/PixelTrackFitting/interface/PixelFitterBase.h
+++ b/RecoTracker/PixelTrackFitting/interface/PixelFitterBase.h
@@ -2,12 +2,12 @@
 #define RecoTracker_PixelTrackFitting_PixelFitterBase_h
 
 #include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 
 #include <vector>
 #include <memory>
 
 class TrackingRegion;
-class TrackingRecHit;
 
 class PixelFitterBase {
 public:

--- a/RecoTracker/PixelTrackFitting/interface/PixelTrackBuilder.h
+++ b/RecoTracker/PixelTrackFitting/interface/PixelTrackBuilder.h
@@ -6,7 +6,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1D.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
-class TrackingRecHit;
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 class MagneticField;
 class FreeTrajectoryState;
 

--- a/RecoTracker/PixelTrackFitting/interface/PixelTrackFilterBase.h
+++ b/RecoTracker/PixelTrackFitting/interface/PixelTrackFilterBase.h
@@ -1,15 +1,14 @@
 #ifndef RecoTracker_PixelTrackFitting_PixelTrackFilterBase_h
 #define RecoTracker_PixelTrackFitting_PixelTrackFilterBase_h
 
-namespace reco {
-  class Track;
-}
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
 namespace edm {
   class Event;
   class EventSetup;
   class ConsumesCollector;
 }  // namespace edm
-class TrackingRecHit;
 
 #include <vector>
 

--- a/RecoTracker/SiTrackerMRHTools/interface/MultiRecHitCollector.h
+++ b/RecoTracker/SiTrackerMRHTools/interface/MultiRecHitCollector.h
@@ -2,9 +2,9 @@
 #define SiTrackerMRHTools_MultiRecHitCollector_h
 
 #include "RecoTracker/MeasurementDet/interface/MeasurementTracker.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 #include <vector>
 
-class Trajectory;
 class TrajectoryMeasurement;
 
 class MultiRecHitCollector {

--- a/RecoTracker/SiTrackerMRHTools/interface/SiTrackerMultiRecHitUpdator.h
+++ b/RecoTracker/SiTrackerMRHTools/interface/SiTrackerMultiRecHitUpdator.h
@@ -10,6 +10,7 @@
 #define SiTrackerMultiRecHitUpdator_h
 
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h"
@@ -19,7 +20,6 @@
 
 class SiTrackerMultiRecHit;
 class TrajectoryStateOnSurface;
-class TrackingRecHit;
 class TransientTrackingRecHitBuilder;
 class LocalError;
 class TrackingRecHitPropagator;

--- a/RecoTracker/TkSeedingLayers/interface/SeedComparitor.h
+++ b/RecoTracker/TkSeedingLayers/interface/SeedComparitor.h
@@ -9,8 +9,8 @@
  */
 
 #include "SeedingHitSet.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedFwd.h"
 
-class TrajectorySeed;
 class TrackingRegion;
 class TrajectoryStateOnSurface;
 class FastHelix;

--- a/RecoTracker/TrackProducer/interface/AlgoProductTraits.h
+++ b/RecoTracker/TrackProducer/interface/AlgoProductTraits.h
@@ -2,9 +2,9 @@
 #define RecoTrackerTrackProducerAlgoProductTraits_H
 
 #include "DataFormats/TrajectorySeed/interface/PropagationDirection.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 #include "DataFormats/Common/interface/View.h"
 #include <vector>
-class Trajectory;
 
 template <class T>
 class AlgoProductTraits {

--- a/RecoTracker/TrackProducer/interface/DAFTrackProducerAlgorithm.h
+++ b/RecoTracker/TrackProducer/interface/DAFTrackProducerAlgorithm.h
@@ -18,13 +18,13 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 
 class MagneticField;
 class TrackingGeometry;
 class TrajAnnealing;
 class TrajectoryFitter;
-class Trajectory;
 class TrajectoryStateOnSurface;
 class TransientTrackingRecHitBuilder;
 class MultiRecHitCollector;

--- a/RecoTracker/TrackProducer/interface/KfTrackProducerBase.h
+++ b/RecoTracker/TrackProducer/interface/KfTrackProducerBase.h
@@ -11,7 +11,7 @@
 
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 
-class Trajectory;
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 
 class KfTrackProducerBase : public TrackProducerBase<reco::Track> {
 public:

--- a/RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.h
+++ b/RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.h
@@ -20,13 +20,13 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
 #include "TrackingTools/PatternTools/interface/TrackConstraintAssociation.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 #include "TrackingTools/TrackFitters/interface/TrajectoryFitter.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 
 class MagneticField;
 class TrackingGeometry;
 class Propagator;
-class Trajectory;
 class TrajectoryStateOnSurface;
 
 struct FitterCloner {

--- a/RecoTracker/TrackProducer/src/TrajectoryToResiduals.h
+++ b/RecoTracker/TrackProducer/src/TrajectoryToResiduals.h
@@ -3,7 +3,7 @@
 
 #include "DataFormats/TrackReco/interface/TrackResiduals.h"
 
-class Trajectory;
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 reco::TrackResiduals trajectoryToResiduals(const Trajectory &);
 
 #endif

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloVSimParameterMap.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloVSimParameterMap.h
@@ -1,7 +1,8 @@
 #ifndef CaloSimAlgos_CaloVSimParameterMap_h
 #define CaloSimAlgos_CaloVSimParameterMap_h
 
-class DetId;
+#include "DataFormats/DetId/interface/DetIdFwd.h"
+
 class CaloSimParameters;
 
 class CaloVSimParameterMap {

--- a/SimCalorimetry/EcalSimAlgos/interface/EcalCoder.h
+++ b/SimCalorimetry/EcalSimAlgos/interface/EcalCoder.h
@@ -7,12 +7,12 @@
 #include "CondFormats/EcalObjects/interface/EcalIntercalibConstantsMC.h"
 #include "CondFormats/EcalObjects/interface/EcalGainRatios.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EcalCorrelatedNoiseMatrix.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 
 template <typename M>
 class CorrelatedNoisifier;
 class EcalMGPASample;
 class EcalDataFrame;
-class DetId;
 
 #include <vector>
 

--- a/SimCalorimetry/EcalSimAlgos/interface/EcalLiteDTUCoder.h
+++ b/SimCalorimetry/EcalSimAlgos/interface/EcalLiteDTUCoder.h
@@ -7,12 +7,12 @@
 #include "CondFormats/EcalObjects/interface/EcalCATIAGainRatios.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EcalCorrelatedNoiseMatrix.h"
 #include "DataFormats/EcalDigi/interface/EcalConstants.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 
 template <typename M>
 class CorrelatedNoisifier;
 class EcalLiteDTUSample;
 class EcalDataFrame_Ph2;
-class DetId;
 class EcalLiteDTUPed;
 
 #include <vector>

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizer.h
@@ -23,7 +23,6 @@
 #include <memory>
 #include <tuple>
 
-class PCaloHit;
 class PileUpEventPrincipal;
 
 class HGCDigitizer {

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalShapes.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalShapes.h
@@ -10,10 +10,10 @@
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalShape.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/ZDCShape.h"
 #include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 #include <vector>
 #include <map>
 class CaloVShape;
-class DetId;
 
 class HcalShapes : public CaloShapes {
 public:

--- a/SimDataFormats/CaloAnalysis/interface/CaloParticle.h
+++ b/SimDataFormats/CaloAnalysis/interface/CaloParticle.h
@@ -10,7 +10,6 @@
 #include "SimDataFormats/Track/interface/SimTrack.h"
 #include <vector>
 
-class SimTrack;
 class EncodedEventId;
 
 class CaloParticle {

--- a/SimDataFormats/CaloAnalysis/interface/MtdCaloParticle.h
+++ b/SimDataFormats/CaloAnalysis/interface/MtdCaloParticle.h
@@ -4,10 +4,10 @@
 #include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
 #include "SimDataFormats/CaloAnalysis/interface/MtdSimClusterFwd.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
+#include "SimDataFormats/Track/interface/SimTrackFwd.h"
 
 #include <vector>
 
-class SimTrack;
 class EncodedEventId;
 
 class MtdCaloParticle : public CaloParticle {

--- a/SimDataFormats/CaloAnalysis/interface/SimCluster.h
+++ b/SimDataFormats/CaloAnalysis/interface/SimCluster.h
@@ -17,7 +17,6 @@
 //
 // Forward declarations
 //
-class SimTrack;
 class EncodedEventId;
 
 /** @brief Monte Carlo truth information used for tracking validation.

--- a/SimDataFormats/CaloHit/interface/PCaloHitFwd.h
+++ b/SimDataFormats/CaloHit/interface/PCaloHitFwd.h
@@ -1,0 +1,6 @@
+#ifndef SimDataFormats_CaloHit_PCaloHitFwd_h
+#define SimDataFormats_CaloHit_PCaloHitFwd_h
+
+class PCaloHit;
+
+#endif

--- a/SimDataFormats/Track/interface/SimTrackFwd.h
+++ b/SimDataFormats/Track/interface/SimTrackFwd.h
@@ -1,0 +1,6 @@
+#ifndef SimDataFormats_Track_SimTrackFwd_h
+#define SimDataFormats_Track_SimTrackFwd_h
+
+class SimTrack;
+
+#endif

--- a/SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLinkFwd.h
+++ b/SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLinkFwd.h
@@ -1,0 +1,6 @@
+#ifndef SimDataFormats_TrackerDigiSimLink_PixelDigiSimLinkFwd_h
+#define SimDataFormats_TrackerDigiSimLink_PixelDigiSimLinkFwd_h
+
+class PixelDigiSimLink;
+
+#endif

--- a/SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h
+++ b/SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h
@@ -7,13 +7,13 @@
 #include "DataFormats/Math/interface/Vector3D.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexFwd.h"
+#include "SimDataFormats/Track/interface/SimTrackFwd.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 
 //
 // Forward declarations
 //
-class TrackingVertex;
-class SimTrack;
 class EncodedEventId;
 
 /** @brief Monte Carlo truth information used for tracking validation.

--- a/SimDataFormats/TrackingAnalysis/interface/TrackingVertexFwd.h
+++ b/SimDataFormats/TrackingAnalysis/interface/TrackingVertexFwd.h
@@ -1,0 +1,6 @@
+#ifndef SimDataFormats_TrackingAnalysis_TrackingVertexFwd_h
+#define SimDataFormats_TrackingAnalysis_TrackingVertexFwd_h
+
+class TrackingVertex;
+
+#endif

--- a/SimDataFormats/TrackingHit/interface/PSimHitFwd.h
+++ b/SimDataFormats/TrackingHit/interface/PSimHitFwd.h
@@ -1,0 +1,6 @@
+#ifndef SimDataFormats_TrackingHit_PSimHitFwd_h
+#define SimDataFormats_TrackingHit_PSimHitFwd_h
+
+class PSimHit;
+
+#endif

--- a/SimDataFormats/Vertex/interface/SimVertexFwd.h
+++ b/SimDataFormats/Vertex/interface/SimVertexFwd.h
@@ -1,0 +1,6 @@
+#ifndef SimDataFormats_Vertex_SimVertexFwd_h
+#define SimDataFormats_Vertex_SimVertexFwd_h
+
+class SimVertex;
+
+#endif

--- a/SimGeneral/MixingModule/plugins/MixingWorker.h
+++ b/SimGeneral/MixingModule/plugins/MixingWorker.h
@@ -22,6 +22,8 @@
 #include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
 #include "SimDataFormats/CrossingFrame/interface/PCrossingFrame.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "SimDataFormats/Track/interface/SimTrackFwd.h"
+#include "SimDataFormats/Vertex/interface/SimVertexFwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include <memory>
@@ -30,8 +32,6 @@
 #include <typeinfo>
 #include "MixingWorkerBase.h"
 
-class SimTrack;
-class SimVertex;
 namespace edm {
   template <class T>
   class MixingWorker : public MixingWorkerBase {

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.h
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.h
@@ -7,13 +7,13 @@
 #include "FWCore/Framework/interface/ProducesCollector.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitFwd.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 #include "SimTracker/Common/interface/TrackingParticleSelector.h"
 #include <memory>  // required for std::unique_ptr
 
 // Forward declarations
 class PileUpEventPrincipal;
-class PSimHit;
 
 /** @brief Replacement for TrackingTruthProducer in the new pileup mixing setup.
  *

--- a/SimMuon/CSCDigitizer/src/CSCBaseElectronicsSim.h
+++ b/SimMuon/CSCDigitizer/src/CSCBaseElectronicsSim.h
@@ -19,6 +19,8 @@
 #include <vector>
 
 #include "DataFormats/Common/interface/DetSet.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitFwd.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
 
 // declarations
@@ -27,8 +29,6 @@ class CSCChamberSpecs;
 class CSCDetectorHit;
 class CSCLayerGeometry;
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
-class DetId;
-class PSimHit;
 
 namespace CLHEP {
   class HepRandomEngine;

--- a/SimMuon/CSCDigitizer/src/CSCDetectorHit.h
+++ b/SimMuon/CSCDigitizer/src/CSCDetectorHit.h
@@ -11,7 +11,7 @@
  */
 
 #include <iosfwd>
-class PSimHit;
+#include "SimDataFormats/TrackingHit/interface/PSimHitFwd.h"
 
 class CSCDetectorHit {
 public:

--- a/SimMuon/CSCDigitizer/src/CSCDriftSim.h
+++ b/SimMuon/CSCDigitizer/src/CSCDriftSim.h
@@ -20,8 +20,8 @@
 #include <vector>
 class CSCLayer;
 class CSCDetectorHit;
-class PSimHit;
 class MagneticField;
+#include "SimDataFormats/TrackingHit/interface/PSimHitFwd.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 

--- a/SimMuon/CSCDigitizer/src/CSCStripElectronicsSim.h
+++ b/SimMuon/CSCDigitizer/src/CSCStripElectronicsSim.h
@@ -10,11 +10,11 @@
 
 #include "DataFormats/CSCDigi/interface/CSCComparatorDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCStripDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCComparatorDigiFwd.h"
 #include "SimMuon/CSCDigitizer/src/CSCBaseElectronicsSim.h"
 #include "SimMuon/CSCDigitizer/src/CSCStripAmpResponse.h"
 
 class CSCDetectorHit;
-class CSCComparatorDigi;
 class CSCCrosstalkGenerator;
 class CSCStripConditions;
 #include <list>

--- a/SimMuon/CSCDigitizer/src/CSCWireElectronicsSim.h
+++ b/SimMuon/CSCDigitizer/src/CSCWireElectronicsSim.h
@@ -9,12 +9,12 @@
  */
 
 #include "DataFormats/CSCDigi/interface/CSCWireDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCWireDigiFwd.h"
 #include "SimMuon/CSCDigitizer/src/CSCBaseElectronicsSim.h"
 
 // declarations
 class CSCLayer;
 class CSCDetectorHit;
-class CSCWireDigi;
 class CSCAnalogSignal;
 
 class CSCWireElectronicsSim : public CSCBaseElectronicsSim {

--- a/SimMuon/DTDigitizer/src/DTDigitizer.h
+++ b/SimMuon/DTDigitizer/src/DTDigitizer.h
@@ -37,7 +37,6 @@ namespace CLHEP {
 }
 
 class DTLayer;
-class PSimHit;
 class DTWireType;
 class DTBaseDigiSync;
 class DTTopology;

--- a/SimMuon/DTDigitizer/test/DTDigiAnalyzer.h
+++ b/SimMuon/DTDigitizer/test/DTDigiAnalyzer.h
@@ -20,7 +20,6 @@
 
 class TH1F;
 class TFile;
-class PSimHit;
 // class DTMCStatistics;
 // class DTMuonDigiStatistics;
 // class DTHitsAnalysis;

--- a/SimMuon/GEMDigitizer/interface/GEMDigiModel.h
+++ b/SimMuon/GEMDigitizer/interface/GEMDigiModel.h
@@ -15,6 +15,7 @@
 #include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
 #include "DataFormats/Common/interface/DetSet.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitFwd.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
 #include "SimDataFormats/GEMDigiSimLink/interface/GEMDigiSimLink.h"
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
@@ -26,7 +27,6 @@ namespace CLHEP {
   class HepRandomEngine;
 }
 
-class PSimHit;
 class GEMEtaPartition;
 class GEMGeometry;
 

--- a/SimMuon/GEMDigitizer/interface/GEMDigiModule.h
+++ b/SimMuon/GEMDigitizer/interface/GEMDigiModule.h
@@ -15,6 +15,7 @@
 #include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
 #include "DataFormats/Common/interface/DetSet.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitFwd.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
 #include "SimDataFormats/GEMDigiSimLink/interface/GEMDigiSimLink.h"
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
@@ -30,7 +31,6 @@ namespace CLHEP {
 class GEMDigiModel;
 class GEMEtaPartition;
 class GEMGeometry;
-class PSimHit;
 
 class GEMDigiModule {
 public:

--- a/SimMuon/GEMDigitizer/interface/ME0DigiModel.h
+++ b/SimMuon/GEMDigitizer/interface/ME0DigiModel.h
@@ -14,6 +14,7 @@
 #include "DataFormats/GEMDigi/interface/ME0DigiCollection.h"
 #include "DataFormats/Common/interface/DetSet.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitFwd.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
 #include "SimDataFormats/GEMDigiSimLink/interface/ME0DigiSimLink.h"
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
@@ -27,7 +28,6 @@ namespace CLHEP {
 
 class ME0EtaPartition;
 class ME0Geometry;
-class PSimHit;
 
 class ME0DigiModel {
 public:

--- a/SimMuon/GEMDigitizer/interface/ME0DigiPreRecoModel.h
+++ b/SimMuon/GEMDigitizer/interface/ME0DigiPreRecoModel.h
@@ -12,6 +12,7 @@
 #include "DataFormats/GEMDigi/interface/ME0DigiPreRecoCollection.h"
 #include "DataFormats/Common/interface/DetSet.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitFwd.h"
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 
 #include <map>
@@ -23,7 +24,6 @@ namespace CLHEP {
 
 class ME0EtaPartition;
 class ME0Geometry;
-class PSimHit;
 
 class ME0DigiPreRecoModel {
 public:

--- a/SimMuon/RPCDigitizer/src/RPCSim.h
+++ b/SimMuon/RPCDigitizer/src/RPCSim.h
@@ -16,12 +16,12 @@
 
 #include "DataFormats/Common/interface/DetSet.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitFwd.h"
 #include "SimDataFormats/RPCDigiSimLink/interface/RPCDigiSimLink.h"
 
 class RPCRoll;
 class RPCGeometry;
 class RPCSimSetUp;
-class PSimHit;
 
 namespace CLHEP {
   class HepRandomEngine;

--- a/SimMuon/RPCDigitizer/src/RPCSimSetUp.h
+++ b/SimMuon/RPCDigitizer/src/RPCSimSetUp.h
@@ -9,6 +9,7 @@
 #include "CondFormats/DataRecord/interface/RPCStripNoisesRcd.h"
 #include "CondFormats/RPCObjects/interface/RPCClusterSize.h"
 #include "CondFormats/DataRecord/interface/RPCClusterSizeRcd.h"
+#include "DataFormats/MuonDetId/interface/RPCDetIdFwd.h"
 
 #include <map>
 #include <vector>
@@ -22,7 +23,6 @@
 
 class RPCDigitizer;
 class RPCGeometry;
-class RPCDetId;
 
 class RPCSimSetUp {
 public:

--- a/SimMuon/RPCDigitizer/src/RPCSynchronizer.h
+++ b/SimMuon/RPCDigitizer/src/RPCSynchronizer.h
@@ -19,9 +19,9 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitFwd.h"
 #include <set>
 
-class PSimHit;
 class RPCSimSetUp;
 
 namespace edm {

--- a/SimPPS/PPSPixelDigiProducer/plugins/PPSPixelDigiAnalyzer.cc
+++ b/SimPPS/PPSPixelDigiProducer/plugins/PPSPixelDigiAnalyzer.cc
@@ -40,8 +40,6 @@
 using namespace edm;
 using namespace std;
 
-class PSimHit;
-
 namespace edm {
   class ParameterSet;
   class Event;

--- a/SimPPS/RPDigiProducer/plugins/RPDisplacementGenerator.h
+++ b/SimPPS/RPDigiProducer/plugins/RPDisplacementGenerator.h
@@ -3,10 +3,9 @@
 
 #include "SimPPS/RPDigiProducer/interface/RPSimTypes.h"
 #include "DataFormats/CTPPSDetId/interface/TotemRPDetId.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitFwd.h"
 #include <Math/Rotation3D.h>
 #include <map>
-
-class PSimHit;
 
 /**
  * \ingroup TotemDigiProduction

--- a/SimTracker/Common/interface/SiPixelChargeReweightingAlgorithm.h
+++ b/SimTracker/Common/interface/SiPixelChargeReweightingAlgorithm.h
@@ -24,6 +24,7 @@
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -41,10 +42,7 @@
 #include "SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h"
 
 // forward declarations
-class DetId;
 class GaussianTailNoiseGenerator;
-class PixelDigi;
-class PixelDigiSimLink;
 class PixelGeomDetUnit;
 class SiG4UniversalFluctuation;
 

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
@@ -26,6 +26,7 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 #include "SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerFwd.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitFwd.h"
 
 // Forward declaration
 namespace CLHEP {
@@ -43,7 +44,6 @@ namespace edm {
 
 class MagneticField;
 class PileUpEventPrincipal;
-class PSimHit;
 class Phase2TrackerDigitizerAlgorithm;
 class TrackerDigiGeometryRecord;
 

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
@@ -12,6 +12,7 @@
 #include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
 #include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 
 #include "SimTracker/Common/interface/DigitizerUtility.h"
 #include "SimTracker/Common/interface/SiPixelChargeReweightingAlgorithm.h"
@@ -30,7 +31,6 @@ namespace CLHEP {
   class RandFlat;
 }  // namespace CLHEP
 
-class DetId;
 class GaussianTailNoiseGenerator;
 class SiG4UniversalFluctuation;
 class SiPixelGainCalibrationOfflineSimService;

--- a/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.h
+++ b/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.h
@@ -29,6 +29,7 @@
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitFwd.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "DataFormats/DetId/interface/DetId.h"
@@ -47,7 +48,6 @@
 
 //class MonitorElement;
 class GeomDet;
-class PSimHit;
 class PixelGeomDetUnit;
 
 class PixelTestBeamValidation : public DQMEDAnalyzer {

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
@@ -28,11 +28,11 @@
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitFwd.h"
 
 class MagneticField;
 class PileUpEventPrincipal;
 class PixelGeomDetUnit;
-class PSimHit;
 class SiPixelDigitizerAlgorithm;
 class TrackerGeometry;
 

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
@@ -13,6 +13,7 @@
 #include "SimTracker/SiPixelDigitizer/plugins/PixelDigiAddTempInfo.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/PixelSimHitExtraInfo.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/PixelSimHitExtraInfoLite.h"
+#include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLinkFwd.h"
 #include "DataFormats/Math/interface/approx_exp.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupMixingContent.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
@@ -20,6 +21,8 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "CondFormats/SiPixelTransient/interface/SiPixelTemplate2D.h"
 #include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
+#include "DataFormats/SiPixelDigi/interface/PixelDigiFwd.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
 #include "CalibTracker/Records/interface/SiPixelFEDChannelContainerESProducerRcd.h"
 #include "CondFormats/DataRecord/interface/SiPixelQualityRcd.h"
 #include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
@@ -39,10 +42,7 @@ namespace CLHEP {
   class HepRandomEngine;
 }
 
-class DetId;
 class GaussianTailNoiseGenerator;
-class PixelDigi;
-class PixelDigiSimLink;
 class PixelGeomDetUnit;
 class SiG4UniversalFluctuation;
 class SiPixelFedCablingMap;

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
@@ -20,6 +20,7 @@
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupMixingContent.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitFwd.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 
 class TrackerTopology;
@@ -40,7 +41,6 @@ namespace edm {
 
 class MagneticField;
 class PileUpEventPrincipal;
-class PSimHit;
 class SiStripDigitizerAlgorithm;
 class StripGeomDetUnit;
 class TrackerGeometry;

--- a/TrackingTools/DetLayers/interface/MeasurementEstimator.h
+++ b/TrackingTools/DetLayers/interface/MeasurementEstimator.h
@@ -3,12 +3,12 @@
 
 #include "DataFormats/GeometryVector/interface/Vector2DBase.h"
 #include "DataFormats/GeometryVector/interface/LocalTag.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include <limits>
 
 class Plane;
 class TrajectoryStateOnSurface;
 class Surface;
-class TrackingRecHit;
 
 /** The MeasurementEstimator defines the compatibility of a 
  *  TrajectoryStateOnSurface and a RecHit, and of a 

--- a/TrackingTools/GsfTracking/interface/GsfMultiStateUpdator.h
+++ b/TrackingTools/GsfTracking/interface/GsfMultiStateUpdator.h
@@ -2,9 +2,9 @@
 #define _GSFMULTISTATEUPDATOR_H_
 
 #include "TrackingTools/PatternTools/interface/TrajectoryStateUpdator.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 
 class TrajectoryStateOnSurface;
-class TrackingRecHit;
 
 /** Class which updates a Gaussian mixture trajectory state 
  *  with the information from a

--- a/TrackingTools/PatternTools/interface/TrajectoryBuilder.h
+++ b/TrackingTools/PatternTools/interface/TrajectoryBuilder.h
@@ -3,10 +3,9 @@
 
 #include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedFwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-class TrajectorySeed;
 
 /** The component of track reconstruction that, strating from a seed,
  *  reconstructs all possible trajectories.

--- a/TrackingTools/PatternTools/interface/TrajectoryFwd.h
+++ b/TrackingTools/PatternTools/interface/TrajectoryFwd.h
@@ -1,0 +1,6 @@
+#ifndef TrackingTools_PatternTools_TrajectoryFwd_h
+#define TrackingTools_PatternTools_TrajectoryFwd_h
+
+class Trajectory;
+
+#endif

--- a/TrackingTools/PatternTools/interface/TrajectoryStateUpdator.h
+++ b/TrackingTools/PatternTools/interface/TrajectoryStateUpdator.h
@@ -2,8 +2,7 @@
 #define _TRACKER_UPDATOR_H_
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
-
-class TrackingRecHit;
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 
 /** The TrajectoryState updator is a basic track fititng component 
  *  that combines the information from a measurement

--- a/TrackingTools/TrackFitters/interface/TrajectoryFitter.h
+++ b/TrackingTools/TrackFitters/interface/TrajectoryFitter.h
@@ -3,10 +3,10 @@
 
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedFwd.h"
 
 #include <memory>
 
-class TrajectorySeed;
 class TrajectoryStateOnSurface;
 class TkCloner;
 

--- a/TrackingTools/TrackRefitter/interface/SeedTransformer.h
+++ b/TrackingTools/TrackRefitter/interface/SeedTransformer.h
@@ -12,6 +12,8 @@
 // Base class header
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "TrackingTools/TrackFitters/interface/TrajectoryFitter.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedFwd.h"
 
 #include <vector>
 
@@ -20,8 +22,6 @@ namespace edm {
   class EventSetup;
   class ConsumesCollector;
 }  // namespace edm
-class Trajectory;
-class TrajectorySeed;
 class TrajectoryStateOnSurface;
 class GlobalTrackingGeometry;
 class MagneticField;

--- a/TrackingTools/TrackRefitter/interface/TrackTransformer.h
+++ b/TrackingTools/TrackRefitter/interface/TrackTransformer.h
@@ -24,6 +24,7 @@
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
 
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
@@ -36,7 +37,6 @@ class TrajectoryFitter;
 class TrajectorySmoother;
 class Propagator;
 class TransientTrackingRecHitBuilder;
-class Trajectory;
 class GlobalTrackingGeometryRecord;
 class IdealMagneticFieldRecord;
 class TrajectoryFitterRecord;

--- a/TrackingTools/TrackRefitter/interface/TrackTransformerBase.h
+++ b/TrackingTools/TrackRefitter/interface/TrackTransformerBase.h
@@ -8,8 +8,8 @@
  */
 
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 
-class Trajectory;
 namespace edm {
   class EventSetup;
 }

--- a/TrackingTools/TrackRefitter/interface/TrackTransformerForCosmicMuons.h
+++ b/TrackingTools/TrackRefitter/interface/TrackTransformerForCosmicMuons.h
@@ -34,6 +34,7 @@
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "TrackingTools/TrackFitters/interface/TrajectoryFitter.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 
 namespace edm {
   class ParameterSet;
@@ -47,7 +48,6 @@ class TrajectoryFitter;
 class TrajectorySmoother;
 class Propagator;
 class TransientTrackingRecHitBuilder;
-class Trajectory;
 
 class TrackTransformerForCosmicMuons : public TrackTransformerBase {
 public:

--- a/TrackingTools/TrackRefitter/interface/TrackTransformerForGlobalCosmicMuons.h
+++ b/TrackingTools/TrackRefitter/interface/TrackTransformerForGlobalCosmicMuons.h
@@ -26,6 +26,7 @@
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "TrackingTools/TrackFitters/interface/TrajectoryFitter.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
 
 namespace edm {
   class ParameterSet;
@@ -39,7 +40,6 @@ class TrajectoryFitter;
 class TrajectorySmoother;
 class Propagator;
 class TransientTrackingRecHitBuilder;
-class Trajectory;
 class TrackerTopology;
 
 class TrackTransformerForGlobalCosmicMuons : public TrackTransformerBase {

--- a/TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h
@@ -9,7 +9,6 @@ namespace edm {
   class ConsumesCollector;
 }  // namespace edm
 
-class Trajectory;
 class TempTrajectory;
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/Validation/DTRecHits/interface/DTHitQualityUtils.h
+++ b/Validation/DTRecHits/interface/DTHitQualityUtils.h
@@ -14,11 +14,11 @@
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitFwd.h"
 
 #include <atomic>
 #include <map>
 
-class PSimHit;
 class DTGeometry;
 
 namespace DTHitQualityUtils {

--- a/Validation/DTRecHits/plugins/DTRecHitQuality.h
+++ b/Validation/DTRecHits/plugins/DTRecHitQuality.h
@@ -27,6 +27,7 @@
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitFwd.h"
 
 namespace edm {
   class ParameterSet;
@@ -34,7 +35,6 @@ namespace edm {
   class EventSetup;
 }  // namespace edm
 
-class PSimHit;
 class DTLayer;
 class DTWireId;
 class DTGeometry;

--- a/Validation/MuonDTDigis/src/MuonDTDigis.h
+++ b/Validation/MuonDTDigis/src/MuonDTDigis.h
@@ -36,7 +36,6 @@
 
 class TH1F;
 class TFile;
-class PSimHit;
 class hDigis;
 
 namespace edm {

--- a/Validation/RecoEgamma/plugins/ElectronConversionRejectionValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronConversionRejectionValidator.h
@@ -11,6 +11,8 @@
 #include "DataFormats/BeamSpot/interface/BeamSpotFwd.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "DataFormats/EgammaCandidates/interface/ConversionFwd.h"
+#include "SimDataFormats/Vertex/interface/SimVertexFwd.h"
+#include "SimDataFormats/Track/interface/SimTrackFwd.h"
 //
 //DQM services
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
@@ -27,8 +29,6 @@ class TH1F;
 class TH2F;
 class TProfile;
 class TTree;
-class SimVertex;
-class SimTrack;
 /** \class ElectronConversionRejectionValidator
  **
  **

--- a/Validation/RecoEgamma/plugins/PhotonValidator.h
+++ b/Validation/RecoEgamma/plugins/PhotonValidator.h
@@ -53,8 +53,6 @@ class TH1F;
 class TH2F;
 class TProfile;
 class TTree;
-class SimVertex;
-class SimTrack;
 
 class PhotonValidator : public DQMOneEDAnalyzer<> {
 public:

--- a/Validation/RecoEgamma/plugins/PhotonValidatorMiniAOD.h
+++ b/Validation/RecoEgamma/plugins/PhotonValidatorMiniAOD.h
@@ -12,6 +12,8 @@
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
+#include "SimDataFormats/Vertex/interface/SimVertexFwd.h"
+#include "SimDataFormats/Track/interface/SimTrackFwd.h"
 //
 //DQM services
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -39,8 +41,6 @@ class TH1F;
 class TH2F;
 class TProfile;
 class TTree;
-class SimVertex;
-class SimTrack;
 
 class PhotonValidatorMiniAOD : public DQMEDAnalyzer {
 public:

--- a/Validation/RecoEgamma/plugins/TkConvValidator.h
+++ b/Validation/RecoEgamma/plugins/TkConvValidator.h
@@ -18,6 +18,8 @@
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 #include "DataFormats/JetReco/interface/GenJetCollection.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
+#include "SimDataFormats/Vertex/interface/SimVertexFwd.h"
+#include "SimDataFormats/Track/interface/SimTrackFwd.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
@@ -38,8 +40,6 @@ class TH1F;
 class TH2F;
 class TProfile;
 class TTree;
-class SimVertex;
-class SimTrack;
 /** \class TkConvValidator
  **
  **

--- a/Validation/RecoMuon/src/HTrack.h
+++ b/Validation/RecoMuon/src/HTrack.h
@@ -1,7 +1,7 @@
+#include "SimDataFormats/Track/interface/SimTrackFwd.h"
 class HTrackVariables;
 class HResolution;
 class TFile;
-class SimTrack;
 class TrajectoryStateOnSurface;
 class FreeTrajectoryState;
 

--- a/Validation/RecoMuon/src/MuonSeedTrack.h
+++ b/Validation/RecoMuon/src/MuonSeedTrack.h
@@ -26,6 +26,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedFwd.h"
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -37,7 +38,6 @@ namespace reco {
 }
 
 class MuonServiceProxy;
-class TrajectorySeed;
 class MuonUpdatorAtVertex;
 //
 // class decleration

--- a/Validation/RecoMuon/src/MuonTrackAnalyzer.h
+++ b/Validation/RecoMuon/src/MuonTrackAnalyzer.h
@@ -19,6 +19,7 @@
 
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
@@ -44,7 +45,6 @@ class TrajectoryStateOnSurface;
 class FreeTrajectoryState;
 class MuonServiceProxy;
 class MuonPatternRecoDumper;
-class TrajectorySeed;
 class MuonUpdatorAtVertex;
 
 class MuonTrackAnalyzer : public DQMEDAnalyzer {

--- a/Validation/SiTrackerPhase2V/plugins/Phase2TrackerValidateDigi.h
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2TrackerValidateDigi.h
@@ -7,23 +7,23 @@
 #include "FWCore/Framework/interface/Event.h"
 
 #include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiPixelDigi/interface/PixelDigiFwd.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimDataFormats/Track/interface/SimTrackFwd.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLinkFwd.h"
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
+#include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigiFwd.h"
+class TrackerGeometry;
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
 // DQM Histograming
-class PixelDigiSimLink;
-class SimTrack;
 class SimHit;
 class TrackerTopology;
-class PixelDigi;
-class Phase2TrackerDigi;
-class TrackerGeometry;
 class TrackerDigiGeometryRecord;
 class TrackerTopologyRcd;
 class Phase2TrackerValidateDigi : public DQMEDAnalyzer {

--- a/Validation/TrackerDigis/plugins/SiPixelDigiValid.h
+++ b/Validation/TrackerDigis/plugins/SiPixelDigiValid.h
@@ -7,6 +7,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 #include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
+#include "DataFormats/SiPixelDigi/interface/PixelDigiFwd.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
 #include <string>
@@ -15,7 +16,6 @@ namespace edm {
   template <class T>
   class DetSetVector;
 }
-class PixelDigi;
 
 class SiPixelDigiValid : public DQMEDAnalyzer {
 public:

--- a/Validation/TrackerRecHits/interface/SiPixelRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiPixelRecHitsValid.h
@@ -16,11 +16,11 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "DataFormats/DetId/interface/DetIdFwd.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitFwd.h"
 
 #include <string>
 
-class DetId;
-class PSimHit;
 class PixelGeomDetUnit;
 class SiPixelRecHit;
 class TrackerTopology;


### PR DESCRIPTION
#### PR description:

- Created Fwd.h files for a group of the classes which are stored (or are template arguments for data that is stored).
- Replaced forward references for those classes with the new Fwd.h files.

This is part of the work being done for the EVOLUTION branch. This will be the largest one time PR for this campaign. These files were all committed together as all the files which were doing forward referencing only need to be changed in this PR and not later ones which are related to different data products. I.e. this set of added Fwd.h files only require editing the other files once.

#### PR validation:

Code compiles. Cross checked that no further forward references exist for these classes in CMSSW.

resolves https://github.com/cms-sw/framework-team/issues/1926