### PR TITLE
[NGT] Miscellaneous improvements to `DQM/SiPixelHeterogeneous` towards Phase-2 

### DIFF
--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareRecHitsSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareRecHitsSoA.cc
@@ -1,3 +1,13 @@
+// -*- C++ -*-
+// Package:    DQM/SiPixelHeterogeneous
+// Class:      SiPixelCompareRecHitsSoA
+//
+/**\class SiPixelCompareRecHitsSoA SiPixelCompareRecHitsSoA.cc
+*/
+//
+// Author: Suvankar Roy Chowdhury
+//
+
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareTracksSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareTracksSoA.cc
@@ -1,5 +1,5 @@
 // -*- C++ -*-
-// Package:    SiPixelCompareTracksSoA
+// Package:    DQM/SiPixelHetrogeneous
 // Class:      SiPixelCompareTracksSoA
 //
 /**\class SiPixelCompareTracksSoA SiPixelCompareTracksSoA.cc
@@ -8,25 +8,26 @@
 // Author: Suvankar Roy Chowdhury
 //
 
-// for string manipulations
+// system includes
 #include <algorithm>
 #include <fmt/printf.h>
-#include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/Math/interface/deltaR.h"
-#include "DataFormats/Math/interface/deltaPhi.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-// DQM Histograming
-#include "DQMServices/Core/interface/MonitorElement.h"
+
+// user includes
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
-// DataFormats
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+#include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/TrackSoA/interface/TracksHost.h"
 #include "DataFormats/TrackSoA/interface/alpaka/TrackUtilities.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 
 namespace {
   // same logic used for the MTV:
@@ -275,7 +276,7 @@ void SiPixelCompareTracksSoA::analyzeSeparate(U tokenRef, V tokenTar, const edm:
 //
 
 void SiPixelCompareTracksSoA::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  // The default use case is to use vertices from Alpaka reconstructed on CPU and GPU;
+  // The default use case is to use tracks from Alpaka reconstructed on CPU and GPU;
   // The function is left templated if any other cases need to be added
   analyzeSeparate(tokenSoATrackReference_, tokenSoATrackTarget_, iEvent);
 }
@@ -366,7 +367,6 @@ void SiPixelCompareTracksSoA::bookHistograms(DQMStore::IBooker& iBook,
 }
 
 void SiPixelCompareTracksSoA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  // monitorpixelTrackSoA
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("pixelTrackReferenceSoA", edm::InputTag("pixelTracksAlpakaSerial"));
   desc.add<edm::InputTag>("pixelTrackTargetSoA", edm::InputTag("pixelTracksAlpaka"));
@@ -377,6 +377,5 @@ void SiPixelCompareTracksSoA::fillDescriptions(edm::ConfigurationDescriptions& d
   descriptions.addWithDefaultLabel(desc);
 }
 
-// Duplicates to keep them alive for the HLT menu to migrate to the new modules
+#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SiPixelCompareTracksSoA);
-

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareVerticesSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareVerticesSoA.cc
@@ -1,5 +1,5 @@
 // -*- C++ -*-
-// Package:    SiPixelCompareVerticesSoA
+// Package:    DQM/SiPixelHeterogeneous
 // Class:      SiPixelCompareVerticesSoA
 //
 /**\class SiPixelCompareVerticesSoA SiPixelCompareVerticesSoA.cc
@@ -187,7 +187,6 @@ void SiPixelCompareVerticesSoA::bookHistograms(DQMStore::IBooker& ibooker,
 }
 
 void SiPixelCompareVerticesSoA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  // monitorpixelVertexSoA
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("pixelVertexReferenceSoA", edm::InputTag("pixelVerticesAlpakaSerial"));
   desc.add<edm::InputTag>("pixelVertexTargetSoA", edm::InputTag("pixelVerticesAlpaka"));

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorRecHitsSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorRecHitsSoA.cc
@@ -44,6 +44,11 @@ private:
   const std::string topFolderName_;
   const TrackerGeometry* tkGeom_ = nullptr;
   const TrackerTopology* tTopo_ = nullptr;
+
+  bool isPhase2_;
+  static constexpr double kInnerDiskRange = 20.0;
+  static constexpr double kOuterDiskRange = 27.5;
+
   MonitorElement* hnHits;
   MonitorElement* hBFposZP;
   MonitorElement* hBFposZR;
@@ -75,6 +80,9 @@ SiPixelMonitorRecHitsSoA::SiPixelMonitorRecHitsSoA(const edm::ParameterSet& iCon
 
 void SiPixelMonitorRecHitsSoA::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
   tkGeom_ = &iSetup.getData(geomToken_);
+  if ((tkGeom_->isThere(GeomDetEnumerators::P2PXB)) || (tkGeom_->isThere(GeomDetEnumerators::P2PXEC))) {
+    isPhase2_ = true;
+  }
   tTopo_ = &iSetup.getData(topoToken_);
 }
 
@@ -163,7 +171,8 @@ void SiPixelMonitorRecHitsSoA::bookHistograms(DQMStore::IBooker& iBook,
   for(int is=0;is<2;is++){
     int sign=is==0? -1:1;
     for(unsigned int id=0;id<tkGeom_->numberOfLayers(PixelSubdetector::PixelEndcap);id++){
-      const double range = (id > 8) ? 27.5 : 20.0;  // Phase-2 TEPX disks larger
+      // Phase-2 TEPX disks larger
+      const double range = (id > 7) ? kOuterDiskRange : kInnerDiskRange;
       hFposXYD[is][id] = iBook.book2D(Form("recHitsFDisk%+dPosXY",id*sign+sign), Form("RecHits position Endcaps Disk%+d;X;Y",id*sign+sign), 200, -range, range, 200, -range, range);
       hFchargeD[is][id] = iBook.book1D(Form("recHitsFDisk%+dCharge",id*sign+sign), Form("RecHits Charge Endcaps Disk%+d;Charge;#events",id*sign+sign), 250, 0, 100000);
       hFsizexD[is][id] = iBook.book1D(Form("recHitsFDisk%+dSizex",id*sign+sign), Form("RecHits SizeX Endcaps Disk%+d;SizeX;#events",id*sign+sign), 50, 0, 50);

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorRecHitsSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorRecHitsSoA.cc
@@ -163,7 +163,8 @@ void SiPixelMonitorRecHitsSoA::bookHistograms(DQMStore::IBooker& iBook,
   for(int is=0;is<2;is++){
     int sign=is==0? -1:1;
     for(unsigned int id=0;id<tkGeom_->numberOfLayers(PixelSubdetector::PixelEndcap);id++){
-      hFposXYD[is][id] = iBook.book2D(Form("recHitsFDisk%+dPosXY",id*sign+sign), Form("RecHits position Endcaps Disk%+d;X;Y",id*sign+sign), 200, -20, 20, 200,-20,20);
+      const double range = (id > 8) ? 27.5 : 20.0;  // Phase-2 TEPX disks larger
+      hFposXYD[is][id] = iBook.book2D(Form("recHitsFDisk%+dPosXY",id*sign+sign), Form("RecHits position Endcaps Disk%+d;X;Y",id*sign+sign), 200, -range, range, 200, -range, range);
       hFchargeD[is][id] = iBook.book1D(Form("recHitsFDisk%+dCharge",id*sign+sign), Form("RecHits Charge Endcaps Disk%+d;Charge;#events",id*sign+sign), 250, 0, 100000);
       hFsizexD[is][id] = iBook.book1D(Form("recHitsFDisk%+dSizex",id*sign+sign), Form("RecHits SizeX Endcaps Disk%+d;SizeX;#events",id*sign+sign), 50, 0, 50);
       hFsizeyD[is][id] = iBook.book1D(Form("recHitsFDisk%+dSizey",id*sign+sign), Form("RecHits SizeY Endcaps Disk%+d;SizeY;#events",id*sign+sign), 50, 0, 50);

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorRecHitsSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorRecHitsSoA.cc
@@ -1,6 +1,16 @@
-#include "DQMServices/Core/interface/MonitorElement.h"
+// -*- C++ -*-
+// Package:    DQM/SiPixelHeterogeneous
+// Class:      SiPixelMonitorTrackSoA
+//
+/**\class SiPixelMonitorRecHitsSoA SiPixelMonitorRecHitsSoA.cc
+*/
+//
+// Author: Suvankar Roy Chowdhury
+//
+
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
 #include "DataFormats/Math/interface/approx_atan2.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
@@ -8,9 +18,9 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
@@ -57,28 +67,16 @@ private:
   MonitorElement* hFsizeyD[2][12];
 };
 
-//
-// constructors
-//
-
 SiPixelMonitorRecHitsSoA::SiPixelMonitorRecHitsSoA(const edm::ParameterSet& iConfig)
     : geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
       topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()),
       tokenSoAHits_(consumes(iConfig.getParameter<edm::InputTag>("pixelHitsSrc"))),
       topFolderName_(iConfig.getParameter<std::string>("TopFolderName")) {}
 
-//
-// Begin Run
-//
-
 void SiPixelMonitorRecHitsSoA::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
   tkGeom_ = &iSetup.getData(geomToken_);
   tTopo_ = &iSetup.getData(topoToken_);
 }
-
-//
-// -- Analyze
-//
 
 void SiPixelMonitorRecHitsSoA::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   const auto& rhsoaHandle = iEvent.getHandle(tokenSoAHits_);
@@ -132,16 +130,11 @@ void SiPixelMonitorRecHitsSoA::analyze(const edm::Event& iEvent, const edm::Even
   }
 }
 
-//
-// -- Book Histograms
-//
-
 void SiPixelMonitorRecHitsSoA::bookHistograms(DQMStore::IBooker& iBook,
                                               edm::Run const& iRun,
                                               edm::EventSetup const& iSetup) {
   iBook.cd();
   iBook.setCurrentFolder(topFolderName_);
-
   // clang-format off
   //Global
   hnHits = iBook.book1D("nHits", "RecHits per event;RecHits;#events", 200, 0, 5000);
@@ -176,10 +169,10 @@ void SiPixelMonitorRecHitsSoA::bookHistograms(DQMStore::IBooker& iBook,
       hFsizeyD[is][id] = iBook.book1D(Form("recHitsFDisk%+dSizey",id*sign+sign), Form("RecHits SizeY Endcaps Disk%+d;SizeY;#events",id*sign+sign), 50, 0, 50);
     }
   }
+  // clang-format on
 }
 
 void SiPixelMonitorRecHitsSoA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  // monitorpixelRecHitsSoA
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("pixelHitsSrc", edm::InputTag("siPixelRecHitsPreSplittingAlpaka"));
   desc.add<std::string>("TopFolderName", "SiPixelHeterogeneous/PixelRecHitsAlpaka");
@@ -188,4 +181,3 @@ void SiPixelMonitorRecHitsSoA::fillDescriptions(edm::ConfigurationDescriptions& 
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SiPixelMonitorRecHitsSoA);
-

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoA.cc
@@ -44,36 +44,45 @@ private:
   const edm::EDGetTokenT<PixelTrackHeterogeneous> tokenSoATrack_;
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
   const std::string topFolderName_;
-  const bool useQualityCut_;
-  const pixelTrack::Quality minQuality_;
+
+  std::vector<std::string> qualityDefinitions_;
   const TrackerGeometry* tkGeom_ = nullptr;
   bool isPhase2_;
-  MonitorElement* hnTracks;
-  MonitorElement* hnLooseAndAboveTracks;
-  MonitorElement* hnHits;
-  MonitorElement* hnHitsVsPhi;
-  MonitorElement* hnHitsVsEta;
-  MonitorElement* hnLayers;
-  MonitorElement* hnLayersVsPhi;
-  MonitorElement* hnLayersVsEta;
-  MonitorElement* hchi2;
-  MonitorElement* hChi2VsPhi;
-  MonitorElement* hChi2VsEta;
-  MonitorElement* hpt;
-  MonitorElement* hCurvature;
-  MonitorElement* heta;
-  MonitorElement* hphi;
-  MonitorElement* hz;
-  MonitorElement* htip;
+
+  // Global histogram for the quality distribution of ALL tracks
   MonitorElement* hquality;
+
+  // Struct to hold histograms for a specific quality level
+  struct QualityHistograms {
+    pixelTrack::Quality minQuality;
+    std::string qualityName;
+
+    MonitorElement* hnTracks;
+    MonitorElement* hnHits;
+    MonitorElement* hnHitsVsPhi;
+    MonitorElement* hnHitsVsEta;
+    MonitorElement* hnLayers;
+    MonitorElement* hnLayersVsPhi;
+    MonitorElement* hnLayersVsEta;
+    MonitorElement* hchi2;
+    MonitorElement* hChi2VsPhi;
+    MonitorElement* hChi2VsEta;
+    MonitorElement* hpt;
+    MonitorElement* hCurvature;
+    MonitorElement* heta;
+    MonitorElement* hphi;
+    MonitorElement* hz;
+    MonitorElement* htip;
+  };
+
+  std::vector<QualityHistograms> histograms_;
 };
 
 SiPixelMonitorTrackSoA::SiPixelMonitorTrackSoA(const edm::ParameterSet& iConfig)
     : tokenSoATrack_{consumes<PixelTrackHeterogeneous>(iConfig.getParameter<edm::InputTag>("pixelTrackSrc"))},
       geomToken_{esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()},
       topFolderName_{iConfig.getParameter<std::string>("topFolderName")},
-      useQualityCut_{iConfig.getParameter<bool>("useQualityCut")},
-      minQuality_{pixelTrack::qualityByName(iConfig.getParameter<std::string>("minQuality"))},
+      qualityDefinitions_{iConfig.getParameter<std::vector<std::string>>("qualityDefinitions")},
       isPhase2_{false} {}
 
 void SiPixelMonitorTrackSoA::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
@@ -93,8 +102,9 @@ void SiPixelMonitorTrackSoA::analyze(const edm::Event& iEvent, const edm::EventS
   auto const& tsoa = *tsoaHandle.product();
   auto maxTracks = tsoa.view().tracks().metadata().size();
   auto const quality = tsoa.view().tracks().quality();
-  int32_t nTracks = 0;
-  int32_t nLooseAndAboveTracks = 0;
+
+  // Initialize counters for this event for each configured quality level
+  std::vector<int32_t> nTracksPerQuality(histograms_.size(), 0);
 
   for (int32_t it = 0; it < maxTracks; ++it) {
     auto nHits = reco::nHits(tsoa.const_view().tracks(), it);
@@ -105,42 +115,52 @@ void SiPixelMonitorTrackSoA::analyze(const edm::Event& iEvent, const edm::EventS
     if (!(pt > 0.))
       continue;
 
-    // fill the quality for all tracks
+    // fill the global quality for all tracks
     pixelTrack::Quality qual = quality[it];
     hquality->Fill(int(qual));
-    nTracks++;
 
-    if (useQualityCut_ && quality[it] < minQuality_)
-      continue;
+    // Loop over the configured histogram sets
+    for (size_t i = 0; i < histograms_.size(); ++i) {
+      auto& histSet = histograms_[i];
 
-    // fill parameters only for quality >= loose
-    auto track = tsoa.view().tracks()[it];
-    float chi2 = track.chi2();
-    float phi = track.state()(0);  //TODO: put these numbers in enum
-    float zip = track.state()(4);
-    float eta = track.eta();
-    float tip = track.state()(1);
-    auto charge = reco::charge(tsoa.view().tracks(), it);
+      // Check if track meets this specific quality requirement
+      if (qual < histSet.minQuality)
+        continue;
 
-    hchi2->Fill(chi2);
-    hChi2VsPhi->Fill(phi, chi2);
-    hChi2VsEta->Fill(eta, chi2);
-    hnHits->Fill(nHits);
-    hnLayers->Fill(nLayers);
-    hnHitsVsPhi->Fill(phi, nHits);
-    hnHitsVsEta->Fill(eta, nHits);
-    hnLayersVsPhi->Fill(phi, nLayers);
-    hnLayersVsEta->Fill(eta, nLayers);
-    hpt->Fill(pt);
-    hCurvature->Fill(charge / pt);
-    heta->Fill(eta);
-    hphi->Fill(phi);
-    hz->Fill(zip);
-    htip->Fill(tip);
-    nLooseAndAboveTracks++;
+      nTracksPerQuality[i]++;
+
+      // Retrieve track parameters
+      auto track = tsoa.view().tracks()[it];
+      float chi2 = track.chi2();
+      float phi = track.state()(0);
+      float zip = track.state()(4);
+      float eta = track.eta();
+      float tip = track.state()(1);
+      auto charge = reco::charge(tsoa.view().tracks(), it);
+
+      // Fill histograms for this quality set
+      histSet.hchi2->Fill(chi2);
+      histSet.hChi2VsPhi->Fill(phi, chi2);
+      histSet.hChi2VsEta->Fill(eta, chi2);
+      histSet.hnHits->Fill(nHits);
+      histSet.hnLayers->Fill(nLayers);
+      histSet.hnHitsVsPhi->Fill(phi, nHits);
+      histSet.hnHitsVsEta->Fill(eta, nHits);
+      histSet.hnLayersVsPhi->Fill(phi, nLayers);
+      histSet.hnLayersVsEta->Fill(eta, nLayers);
+      histSet.hpt->Fill(pt);
+      histSet.hCurvature->Fill(charge / pt);
+      histSet.heta->Fill(eta);
+      histSet.hphi->Fill(phi);
+      histSet.hz->Fill(zip);
+      histSet.htip->Fill(tip);
+    }
   }
-  hnTracks->Fill(nTracks);
-  hnLooseAndAboveTracks->Fill(nLooseAndAboveTracks);
+
+  // Fill event-level counts
+  for (size_t i = 0; i < histograms_.size(); ++i) {
+    histograms_[i].hnTracks->Fill(nTracksPerQuality[i]);
+  }
 }
 
 void SiPixelMonitorTrackSoA::bookHistograms(DQMStore::IBooker& iBook,
@@ -149,44 +169,94 @@ void SiPixelMonitorTrackSoA::bookHistograms(DQMStore::IBooker& iBook,
   iBook.cd();
   iBook.setCurrentFolder(topFolderName_);
 
-  // clang-format off
-  std::string toRep = "Number of tracks";
-  hnTracks = iBook.book1D("nTracks", fmt::format(";{} per event;#events",toRep), 1001, -0.5, 2001.5);
-  hnLooseAndAboveTracks = iBook.book1D("nLooseAndAboveTracks", fmt::format(";{} (quality #geq loose) per event;#events",toRep), 1001, -0.5, 2001.5);
-
-  // N.B.: we need to book explicitly profiles with the option "" (default) in order to get the error on the mean
-  // (see https://root.cern.ch/doc/master/classTProfile.html), otherwise the default in DQMServices/Core/interface/DQMStore.h
-  // uses the option "s" (i.e. standard deviation on all y values)
-
-  const double etaMax = isPhase2_ ? 4.1 : 3.;
-
-  toRep = "Number of all RecHits per track (quality #geq loose)";
-  hnHits = iBook.book1D("nRecHits", fmt::format(";{};#tracks",toRep), 15, -0.5, 14.5);
-  hnHitsVsPhi = iBook.bookProfile("nHitsPerTrackVsPhi", fmt::format("{} vs track #phi;Track #phi [rad];{}",toRep,toRep), 30, -M_PI, M_PI,0., 15., "");
-  hnHitsVsEta = iBook.bookProfile("nHitsPerTrackVsEta", fmt::format("{} vs track #eta;Track #eta;{}",toRep,toRep), 30, -etaMax, etaMax, 0., 15., "");
-
-  toRep = "Number of all layers per track (quality #geq loose)";
-  hnLayers = iBook.book1D("nLayers", fmt::format(";{};#tracks",toRep), 15, -0.5, 14.5);
-  hnLayersVsPhi = iBook.bookProfile("nLayersPerTrackVsPhi", fmt::format("{} vs track #phi;Track #phi [rad];{}",toRep,toRep), 30, -M_PI, M_PI,0., 15., "");
-  hnLayersVsEta = iBook.bookProfile("nLayersPerTrackVsEta", fmt::format("{} vs track #eta;Track #eta;{}",toRep,toRep), 30, -etaMax, etaMax, 0., 15., "");
-
-  toRep = "Track (quality #geq loose) #chi^{2}/ndof";
-  hchi2 = iBook.book1D("nChi2ndof", fmt::format(";{};#tracks",toRep), 40, 0., 20.);
-  hChi2VsPhi = iBook.bookProfile("nChi2ndofVsPhi", fmt::format("{} vs track #phi;Track #phi [rad];{}",toRep,toRep), 30, -M_PI, M_PI, 0., 20., "");
-  hChi2VsEta = iBook.bookProfile("nChi2ndofVsEta", fmt::format("{} vs track #eta;Track #eta;{}",toRep,toRep), 30, -etaMax, etaMax, 0., 20., "");
-  // clang-format on
-
-  hpt = iBook.book1D("pt", ";Track (quality #geq loose) p_{T} [GeV];#tracks", 200, 0., 200.);
-  hCurvature = iBook.book1D("curvature", ";Track (quality #geq loose) q/p_{T} [GeV^{-1}];#tracks", 100, -3., 3.);
-  heta = iBook.book1D("eta", ";Track (quality #geq loose) #eta;#tracks", 30, -etaMax, etaMax);
-  hphi = iBook.book1D("phi", ";Track (quality #geq loose) #phi [rad];#tracks", 30, -M_PI, M_PI);
-  hz = iBook.book1D("z", ";Track (quality #geq loose) z [cm];#tracks", 30, -30., 30.);
-  htip = iBook.book1D("tip", ";Track (quality #geq loose) TIP [cm];#tracks", 100, -0.5, 0.5);
+  // Global Quality Histogram
   hquality = iBook.book1D("quality", ";Track Quality;#tracks", 7, -0.5, 6.5);
   uint i = 1;
   for (const auto& q : pixelTrack::qualityName) {
     hquality->setBinLabel(i, q.data(), 1);
     i++;
+  }
+
+  // Loop over user defined qualities
+  for (const auto& qName : qualityDefinitions_) {
+    QualityHistograms histSet;
+    histSet.qualityName = qName;
+    histSet.minQuality = pixelTrack::qualityByName(qName);
+
+    // Create a sub-folder for this quality to avoid name clashes
+    iBook.setCurrentFolder(topFolderName_ + "/" + qName);
+
+    std::string toRep = fmt::format("Number of tracks (quality #geq {})", qName);
+    histSet.hnTracks = iBook.book1D("nTracks", fmt::format(";{} per event;#events", toRep), 1001, -0.5, 2001.5);
+
+    // N.B.: we need to book explicitly profiles with the option "" (default) in order to get the error on the mean
+    // (see https://root.cern.ch/doc/master/classTProfile.html), otherwise the default in DQMServices/Core/interface/DQMStore.h
+    // uses the option "s" (i.e. standard deviation on all y values)
+
+    const double etaMax = isPhase2_ ? 4.1 : 3.;
+
+    toRep = fmt::format("Number of all RecHits per track (quality #geq {})", qName);
+    histSet.hnHits = iBook.book1D("nRecHits", fmt::format(";{};#tracks", toRep), 15, -0.5, 14.5);
+    histSet.hnHitsVsPhi = iBook.bookProfile("nHitsPerTrackVsPhi",
+                                            fmt::format("{} vs track #phi [rad];Track #phi [rad];{}", toRep, toRep),
+                                            30,
+                                            -M_PI,
+                                            M_PI,
+                                            0.,
+                                            15.,
+                                            "");
+    histSet.hnHitsVsEta = iBook.bookProfile("nHitsPerTrackVsEta",
+                                            fmt::format("{} vs track #eta;Track #eta;{}", toRep, toRep),
+                                            30,
+                                            -etaMax,
+                                            etaMax,
+                                            0.,
+                                            15.,
+                                            "");
+
+    toRep = fmt::format("Number of all layers per track (quality #geq {})", qName);
+    histSet.hnLayers = iBook.book1D("nLayers", fmt::format(";{};#tracks", toRep), 15, -0.5, 14.5);
+    histSet.hnLayersVsPhi = iBook.bookProfile("nLayersPerTrackVsPhi",
+                                              fmt::format("{} vs track #phi [rad];Track #phi [rad];{}", toRep, toRep),
+                                              30,
+                                              -M_PI,
+                                              M_PI,
+                                              0.,
+                                              15.,
+                                              "");
+    histSet.hnLayersVsEta = iBook.bookProfile("nLayersPerTrackVsEta",
+                                              fmt::format("{} vs track #eta;Track #eta;{}", toRep, toRep),
+                                              30,
+                                              -etaMax,
+                                              etaMax,
+                                              0.,
+                                              15.,
+                                              "");
+
+    toRep = fmt::format("Track (quality #geq {}) #chi^{{2}}/ndof", qName);
+    histSet.hchi2 = iBook.book1D("nChi2ndof", fmt::format(";{};#tracks", toRep), 40, 0., 20.);
+    histSet.hChi2VsPhi = iBook.bookProfile("nChi2ndofVsPhi",
+                                           fmt::format("{} vs track #phi [rad];Track #phi [rad];{}", toRep, toRep),
+                                           30,
+                                           -M_PI,
+                                           M_PI,
+                                           0.,
+                                           20.,
+                                           "");
+    histSet.hChi2VsEta = iBook.bookProfile(
+        "nChi2ndofVsEta", fmt::format("{} vs track #eta;Track #eta;{}", toRep, toRep), 30, -etaMax, etaMax, 0., 20., "");
+
+    // Standard kinematic plots
+    std::string label = fmt::format("Track (quality #geq {})", qName);
+    histSet.hpt = iBook.book1D("pt", fmt::format(";{} p_{{T}} [GeV];#tracks", label), 200, 0., 200.);
+    histSet.hCurvature =
+        iBook.book1D("curvature", fmt::format(";{} q/p_{{T}} [GeV^{{-1}}];#tracks", label), 100, -3., 3.);
+    histSet.heta = iBook.book1D("eta", fmt::format(";{} #eta;#tracks", label), 30, -etaMax, etaMax);
+    histSet.hphi = iBook.book1D("phi", fmt::format(";{} #phi [rad];#tracks", label), 30, -M_PI, M_PI);
+    histSet.hz = iBook.book1D("z", fmt::format(";{} z [cm];#tracks", label), 30, -30., 30.);
+    histSet.htip = iBook.book1D("tip", fmt::format(";{} TIP [cm];#tracks", label), 100, -0.5, 0.5);
+
+    histograms_.push_back(histSet);
   }
 }
 
@@ -194,8 +264,8 @@ void SiPixelMonitorTrackSoA::fillDescriptions(edm::ConfigurationDescriptions& de
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("pixelTrackSrc", edm::InputTag("pixelTracksAlpaka"));
   desc.add<std::string>("topFolderName", "SiPixelHeterogeneous/PixelTrackAlpaka");
-  desc.add<bool>("useQualityCut", true);
-  desc.add<std::string>("minQuality", "loose");
+  // Default configuration now accepts a list.
+  desc.add<std::vector<std::string>>("qualityDefinitions", {"loose", "highPurity"});
   descriptions.addWithDefaultLabel(desc);
 }
 

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoA.cc
@@ -139,20 +139,25 @@ void SiPixelMonitorTrackSoA::bookHistograms(DQMStore::IBooker& iBook,
   hnTracks = iBook.book1D("nTracks", fmt::format(";{} per event;#events",toRep), 1001, -0.5, 2001.5);
   hnLooseAndAboveTracks = iBook.book1D("nLooseAndAboveTracks", fmt::format(";{} (quality #geq loose) per event;#events",toRep), 1001, -0.5, 2001.5);
 
+
+  // N.B.: we need to book explicitly profiles with the option "" (default) in order to get the error on the mean
+  // (see https://root.cern.ch/doc/master/classTProfile.html), otherwise the default in DQMServices/Core/interface/DQMStore.h
+  // uses the option "s" (i.e. standard deviation on all y values)
+
   toRep = "Number of all RecHits per track (quality #geq loose)";
   hnHits = iBook.book1D("nRecHits", fmt::format(";{};#tracks",toRep), 15, -0.5, 14.5);
-  hnHitsVsPhi = iBook.bookProfile("nHitsPerTrackVsPhi", fmt::format("{} vs track #phi;Track #phi;{}",toRep,toRep), 30, -M_PI, M_PI,0., 15.);
-  hnHitsVsEta = iBook.bookProfile("nHitsPerTrackVsEta", fmt::format("{} vs track #eta;Track #eta;{}",toRep,toRep), 30, -3., 3., 0., 15.);
+  hnHitsVsPhi = iBook.bookProfile("nHitsPerTrackVsPhi", fmt::format("{} vs track #phi;Track #phi;{}",toRep,toRep), 30, -M_PI, M_PI,0., 15., "");
+  hnHitsVsEta = iBook.bookProfile("nHitsPerTrackVsEta", fmt::format("{} vs track #eta;Track #eta;{}",toRep,toRep), 30, -3., 3., 0., 15., "");
 
   toRep = "Number of all layers per track (quality #geq loose)";
   hnLayers = iBook.book1D("nLayers", fmt::format(";{};#tracks",toRep), 15, -0.5, 14.5);
-  hnLayersVsPhi = iBook.bookProfile("nLayersPerTrackVsPhi", fmt::format("{} vs track #phi;Track #phi;{}",toRep,toRep), 30, -M_PI, M_PI,0., 15.);
-  hnLayersVsEta = iBook.bookProfile("nLayersPerTrackVsEta", fmt::format("{} vs track #eta;Track #eta;{}",toRep,toRep), 30, -3., 3., 0., 15.);
+  hnLayersVsPhi = iBook.bookProfile("nLayersPerTrackVsPhi", fmt::format("{} vs track #phi;Track #phi;{}",toRep,toRep), 30, -M_PI, M_PI,0., 15., "");
+  hnLayersVsEta = iBook.bookProfile("nLayersPerTrackVsEta", fmt::format("{} vs track #eta;Track #eta;{}",toRep,toRep), 30, -3., 3., 0., 15., "");
 
   toRep = "Track (quality #geq loose) #chi^{2}/ndof";
   hchi2 = iBook.book1D("nChi2ndof", fmt::format(";{};#tracks",toRep), 40, 0., 20.);
-  hChi2VsPhi = iBook.bookProfile("nChi2ndofVsPhi", fmt::format("{} vs track #phi;Track #phi;{}",toRep,toRep), 30, -M_PI, M_PI, 0., 20.);
-  hChi2VsEta = iBook.bookProfile("nChi2ndofVsEta", fmt::format("{} vs track #eta;Track #eta;{}",toRep,toRep), 30, -3., 3., 0., 20.);
+  hChi2VsPhi = iBook.bookProfile("nChi2ndofVsPhi", fmt::format("{} vs track #phi;Track #phi;{}",toRep,toRep), 30, -M_PI, M_PI, 0., 20., "");
+  hChi2VsEta = iBook.bookProfile("nChi2ndofVsEta", fmt::format("{} vs track #eta;Track #eta;{}",toRep,toRep), 30, -3., 3., 0., 20., "");
   // clang-format on
 
   hpt = iBook.book1D("pt", ";Track (quality #geq loose) p_{T} [GeV];#tracks", 200, 0., 200.);

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoA.cc
@@ -158,28 +158,28 @@ void SiPixelMonitorTrackSoA::bookHistograms(DQMStore::IBooker& iBook,
   // (see https://root.cern.ch/doc/master/classTProfile.html), otherwise the default in DQMServices/Core/interface/DQMStore.h
   // uses the option "s" (i.e. standard deviation on all y values)
 
-  const double etaMax = isPhase2_ ? 4. : 3.;
+  const double etaMax = isPhase2_ ? 4.1 : 3.;
 
   toRep = "Number of all RecHits per track (quality #geq loose)";
   hnHits = iBook.book1D("nRecHits", fmt::format(";{};#tracks",toRep), 15, -0.5, 14.5);
-  hnHitsVsPhi = iBook.bookProfile("nHitsPerTrackVsPhi", fmt::format("{} vs track #phi;Track #phi;{}",toRep,toRep), 30, -M_PI, M_PI,0., 15., "");
+  hnHitsVsPhi = iBook.bookProfile("nHitsPerTrackVsPhi", fmt::format("{} vs track #phi;Track #phi [rad];{}",toRep,toRep), 30, -M_PI, M_PI,0., 15., "");
   hnHitsVsEta = iBook.bookProfile("nHitsPerTrackVsEta", fmt::format("{} vs track #eta;Track #eta;{}",toRep,toRep), 30, -etaMax, etaMax, 0., 15., "");
 
   toRep = "Number of all layers per track (quality #geq loose)";
   hnLayers = iBook.book1D("nLayers", fmt::format(";{};#tracks",toRep), 15, -0.5, 14.5);
-  hnLayersVsPhi = iBook.bookProfile("nLayersPerTrackVsPhi", fmt::format("{} vs track #phi;Track #phi;{}",toRep,toRep), 30, -M_PI, M_PI,0., 15., "");
+  hnLayersVsPhi = iBook.bookProfile("nLayersPerTrackVsPhi", fmt::format("{} vs track #phi;Track #phi [rad];{}",toRep,toRep), 30, -M_PI, M_PI,0., 15., "");
   hnLayersVsEta = iBook.bookProfile("nLayersPerTrackVsEta", fmt::format("{} vs track #eta;Track #eta;{}",toRep,toRep), 30, -etaMax, etaMax, 0., 15., "");
 
   toRep = "Track (quality #geq loose) #chi^{2}/ndof";
   hchi2 = iBook.book1D("nChi2ndof", fmt::format(";{};#tracks",toRep), 40, 0., 20.);
-  hChi2VsPhi = iBook.bookProfile("nChi2ndofVsPhi", fmt::format("{} vs track #phi;Track #phi;{}",toRep,toRep), 30, -M_PI, M_PI, 0., 20., "");
+  hChi2VsPhi = iBook.bookProfile("nChi2ndofVsPhi", fmt::format("{} vs track #phi;Track #phi [rad];{}",toRep,toRep), 30, -M_PI, M_PI, 0., 20., "");
   hChi2VsEta = iBook.bookProfile("nChi2ndofVsEta", fmt::format("{} vs track #eta;Track #eta;{}",toRep,toRep), 30, -etaMax, etaMax, 0., 20., "");
   // clang-format on
 
   hpt = iBook.book1D("pt", ";Track (quality #geq loose) p_{T} [GeV];#tracks", 200, 0., 200.);
   hCurvature = iBook.book1D("curvature", ";Track (quality #geq loose) q/p_{T} [GeV^{-1}];#tracks", 100, -3., 3.);
   heta = iBook.book1D("eta", ";Track (quality #geq loose) #eta;#tracks", 30, -etaMax, etaMax);
-  hphi = iBook.book1D("phi", ";Track (quality #geq loose) #phi;#tracks", 30, -M_PI, M_PI);
+  hphi = iBook.book1D("phi", ";Track (quality #geq loose) #phi [rad];#tracks", 30, -M_PI, M_PI);
   hz = iBook.book1D("z", ";Track (quality #geq loose) z [cm];#tracks", 30, -30., 30.);
   htip = iBook.book1D("tip", ";Track (quality #geq loose) TIP [cm];#tracks", 100, -0.5, 0.5);
   hquality = iBook.book1D("quality", ";Track Quality;#tracks", 7, -0.5, 6.5);

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorVertexSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorVertexSoA.cc
@@ -100,13 +100,13 @@ void SiPixelMonitorVertexSoA::bookHistograms(DQMStore::IBooker& ibooker,
                                              edm::EventSetup const& iSetup) {
   ibooker.cd();
   ibooker.setCurrentFolder(topFolderName_);
-  hnVertex = ibooker.book1D("nVertex", ";# of Vertices;#entries", 101, -0.5, 100.5);
-  hx = ibooker.book1D("vx", ";Vertex x;#entries", 50, -1.5, 1.5);
-  hy = ibooker.book1D("vy", ";Vertex y;#entries", 50, -1.5, 1.5);
-  hz = ibooker.book1D("vz", ";Vertex z;#entries", 50, -12.5, 12.5);
+  hnVertex = ibooker.book1D("nVertex", ";# of Vertices;#entries", 201, -0.5, 200.5);
+  hx = ibooker.book1D("vx", ";Vertex x [cm];#entries", 51, -1.5, 1.5);
+  hy = ibooker.book1D("vy", ";Vertex y [cm];#entries", 51, -1.5, 1.5);
+  hz = ibooker.book1D("vz", ";Vertex z [cm];#entries", 50, -12.5, 12.5);
   hchi2 = ibooker.book1D("chi2", ";Vertex chi-squared;#entries", 40, 0., 20.);
   hchi2oNdof = ibooker.book1D("chi2oNdof", ";Vertex chi-squared/Ndof;#entries", 40, 0., 20.);
-  hptv2 = ibooker.book1D("ptsq", ";Vertex #sum (p_{T})^{2};#entries", 200, 0., 200.);
+  hptv2 = ibooker.book1D("ptsq", ";Vertex #sum (p_{T})^{2} [GeV^{2}];#entries", 200, 0., 200.);
   hntrks = ibooker.book1D("ntrk", ";#tracks associated;#entries", 100, -0.5, 99.5);
 }
 

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorVertexSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorVertexSoA.cc
@@ -1,28 +1,28 @@
 // -*- C++ -*-
-///bookLayer
-// Package:    SiPixelMonitorVertexSoA
+// Package:    DQM/SiPixelHeterogeneous
 // Class:      SiPixelMonitorVertexSoA
 //
 /**\class SiPixelMonitorVertexSoA SiPixelMonitorVertexSoA.cc
 */
+
 //
 // Author: Suvankar Roy Chowdhury
 //
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "DataFormats/Common/interface/Handle.h"
-// DQM Histograming
-#include "DQMServices/Core/interface/MonitorElement.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "DataFormats/VertexSoA/interface/ZVertexHost.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/VertexSoA/interface/ZVertexHost.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 
 class SiPixelMonitorVertexSoA : public DQMEDAnalyzer {
 public:
@@ -47,18 +47,11 @@ private:
   MonitorElement* hntrks;
 };
 
-//
-// constructors
-//
-
 SiPixelMonitorVertexSoA::SiPixelMonitorVertexSoA(const edm::ParameterSet& iConfig)
     : tokenSoAVertex_(consumes<reco::ZVertexHost>(iConfig.getParameter<edm::InputTag>("pixelVertexSrc"))),
       tokenBeamSpot_(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpotSrc"))),
       topFolderName_(iConfig.getParameter<std::string>("topFolderName")) {}
 
-//
-// -- Analyze
-//
 void SiPixelMonitorVertexSoA::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   const auto& vsoaHandle = iEvent.getHandle(tokenSoAVertex_);
   if (!vsoaHandle.isValid()) {
@@ -102,13 +95,9 @@ void SiPixelMonitorVertexSoA::analyze(const edm::Event& iEvent, const edm::Event
   hnVertex->Fill(nVertices);
 }
 
-//
-// -- Book Histograms
-//
 void SiPixelMonitorVertexSoA::bookHistograms(DQMStore::IBooker& ibooker,
                                              edm::Run const& iRun,
                                              edm::EventSetup const& iSetup) {
-  //std::string top_folder = ""//
   ibooker.cd();
   ibooker.setCurrentFolder(topFolderName_);
   hnVertex = ibooker.book1D("nVertex", ";# of Vertices;#entries", 101, -0.5, 100.5);
@@ -122,7 +111,6 @@ void SiPixelMonitorVertexSoA::bookHistograms(DQMStore::IBooker& ibooker,
 }
 
 void SiPixelMonitorVertexSoA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  // monitorpixelVertexSoA
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("pixelVertexSrc", edm::InputTag("pixelVerticesAlpaka"));
   desc.add<edm::InputTag>("beamSpotSrc", edm::InputTag("offlineBeamSpot"));
@@ -130,4 +118,5 @@ void SiPixelMonitorVertexSoA::fillDescriptions(edm::ConfigurationDescriptions& d
   descriptions.addWithDefaultLabel(desc);
 }
 
+#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SiPixelMonitorVertexSoA);

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorVertexSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorVertexSoA.cc
@@ -36,7 +36,7 @@ public:
 private:
   const edm::EDGetTokenT<reco::ZVertexHost> tokenSoAVertex_;
   const edm::EDGetTokenT<reco::BeamSpot> tokenBeamSpot_;
-  std::string topFolderName_;
+  const std::string topFolderName_;
   MonitorElement* hnVertex;
   MonitorElement* hx;
   MonitorElement* hy;
@@ -101,9 +101,9 @@ void SiPixelMonitorVertexSoA::bookHistograms(DQMStore::IBooker& ibooker,
   ibooker.cd();
   ibooker.setCurrentFolder(topFolderName_);
   hnVertex = ibooker.book1D("nVertex", ";# of Vertices;#entries", 101, -0.5, 100.5);
-  hx = ibooker.book1D("vx", ";Vertex x;#entries", 10, -5., 5.);
-  hy = ibooker.book1D("vy", ";Vertex y;#entries", 10, -5., 5.);
-  hz = ibooker.book1D("vz", ";Vertex z;#entries", 30, -30., 30);
+  hx = ibooker.book1D("vx", ";Vertex x;#entries", 50, -1.5, 1.5);
+  hy = ibooker.book1D("vy", ";Vertex y;#entries", 50, -1.5, 1.5);
+  hz = ibooker.book1D("vz", ";Vertex z;#entries", 50, -12.5, 12.5);
   hchi2 = ibooker.book1D("chi2", ";Vertex chi-squared;#entries", 40, 0., 20.);
   hchi2oNdof = ibooker.book1D("chi2oNdof", ";Vertex chi-squared/Ndof;#entries", 40, 0., 20.);
   hptv2 = ibooker.book1D("ptsq", ";Vertex #sum (p_{T})^{2};#entries", 200, 0., 200.);


### PR DESCRIPTION
#### PR description:

The goal of this PR is to start preparing the modules in `DQM/SiPixelHeterogeneous` in order to better support phase-2 pixel tracking as well as the CA extension.
The acceptance of the monitored tracks and recHits is changed to better reflect the Phase-2 tracker geometry and for pixel tracks it is now possible to monitor different quality bits.
To allow the 2025 GRun V1.3 frozen menu which still directly employs these modules a customization function is introduced.

#### PR validation:

Run successfully the following workflows:
- `runTheMatrix.py --what gpu -l 34634.402 --ibeos`
- `runTheMatrix.py --what gpu -l 34634.4021 --ibeos`
- `cd HLTrigger/Configuration/test; ./runAll.csh frozen`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, not to be backported.