### PR TITLE
Use CreateBareEntry in RNTupleOutputModule

### DIFF
--- a/FWIO/RNTupleTempOutput/src/RootOutputRNTuple.cc
+++ b/FWIO/RNTupleTempOutput/src/RootOutputRNTuple.cc
@@ -129,7 +129,7 @@ namespace edm {
     options.SetUseBufferedWrite(config.useBufferedWrite);
     options.SetUseDirectIO(config.useDirectIO);
     writer_ = ROOT::RNTupleWriter::Append(std::move(model_), name_, *filePtr_, options);
-    entry_ = writer_->CreateEntry();
+    entry_ = writer_->GetModel().CreateBareEntry();
   }
 
   namespace {


### PR DESCRIPTION
#### PR description:

Avoid creating temporary edm::Wrappers when the REntry is created.

#### PR validation:

Code compiles. Framework unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/1930