### PR TITLE
Update HLTPixelThrustFilter to consider saturated pixels

### DIFF
--- a/HLTrigger/special/plugins/HLTPixelThrustFilter.cc
+++ b/HLTrigger/special/plugins/HLTPixelThrustFilter.cc
@@ -64,23 +64,28 @@ bool HLTPixelThrustFilter::filter(edm::StreamID, edm::Event& event, edm::EventSe
   auto const& clusters = event.get(inputToken_);
   auto const& trackerGeo = iSetup.getData(trackerGeometryRcdToken_);
 
-  size_t nSatPixels(0);
+  size_t nPixels(0), nSatPixels(0);
+  for (auto const& dsv : clusters)
+    for (auto const& cluster : dsv) {
+      nPixels += 1;
+      nSatPixels += cluster.isSaturated();
+    }
+  if (nPixels < min_nPixels_ || nSatPixels < min_nSatPixels_)
+    return false;
+
   std::vector<reco::LeafCandidate> vec;
-  vec.reserve(clusters.size() * 1000);
-  for (auto DSViter = clusters.begin(); DSViter != clusters.end(); DSViter++) {
-    auto const& pgdu = static_cast<const PixelGeomDetUnit*>(trackerGeo.idToDetUnit(DSViter->detId()));
-    for (auto const& cluster : *DSViter) {
-      if (cluster.isSaturated())
-        nSatPixels += 1;
-      else if (useOnlySaturatedPixels_)
+  vec.reserve(nPixels);
+  for (auto const& dsv : clusters) {
+    auto const& pgdu = static_cast<const PixelGeomDetUnit*>(trackerGeo.idToDetUnit(dsv.detId()));
+    for (auto const& cluster : dsv) {
+      if (useOnlySaturatedPixels_ && not cluster.isSaturated())
         continue;
       auto const& pos = pgdu->surface().toGlobal(pgdu->specificTopology().localPosition({cluster.x(), cluster.y()}));
-      auto const mag = std::sqrt(pos.x() * pos.x() + pos.y() * pos.y());
-      if (mag > 0)
+      if (auto mag = pos.perp())
         vec.emplace_back(0, reco::Particle::LorentzVector(pos.x() / mag, pos.y() / mag, 0, 0));
     }
   }
-  if (vec.size() < min_nPixels_ || nSatPixels < min_nSatPixels_)
+  if (vec.size() < min_nPixels_)
     return false;
   auto const thrust = Thrust(vec.begin(), vec.end()).thrust();
 

--- a/HLTrigger/special/plugins/HLTPixelThrustFilter.cc
+++ b/HLTrigger/special/plugins/HLTPixelThrustFilter.cc
@@ -26,7 +26,8 @@ private:
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeometryRcdToken_;
   const edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > inputToken_;
   const bool useOnlySaturatedPixels_;
-  const unsigned int min_nPixels_, min_nSatPixels_;
+  const unsigned int min_nPixels_, max_nPixels_;
+  const unsigned int min_nSatPixels_, max_nSatPixels_;
   const double min_thrust_;  // minimum thrust
   const double max_thrust_;  // maximum thrust
 };
@@ -40,7 +41,9 @@ HLTPixelThrustFilter::HLTPixelThrustFilter(const edm::ParameterSet& config)
       inputToken_(consumes<edmNew::DetSetVector<SiPixelCluster> >(config.getParameter<edm::InputTag>("inputTag"))),
       useOnlySaturatedPixels_(config.getParameter<bool>("useOnlySaturatedPixels")),
       min_nPixels_(config.getParameter<unsigned int>("minNPixels")),
+      max_nPixels_(config.getParameter<unsigned int>("maxNPixels")),
       min_nSatPixels_(config.getParameter<unsigned int>("minNSaturatedPixels")),
+      max_nSatPixels_(config.getParameter<unsigned int>("maxNSaturatedPixels")),
       min_thrust_(config.getParameter<double>("minThrust")),
       max_thrust_(config.getParameter<double>("maxThrust")) {}
 
@@ -49,7 +52,9 @@ void HLTPixelThrustFilter::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.add<edm::InputTag>("inputTag", edm::InputTag("hltSiPixelClusters"));
   desc.add<bool>("useOnlySaturatedPixels", false);
   desc.add<unsigned int>("minNPixels", 2);
+  desc.add<unsigned int>("maxNPixels", 0);
   desc.add<unsigned int>("minNSaturatedPixels", 0);
+  desc.add<unsigned int>("maxNSaturatedPixels", 0);
   desc.add<double>("minThrust", 0);
   desc.add<double>("maxThrust", 0);
   descriptions.add("hltPixelThrustFilter", desc);
@@ -71,6 +76,8 @@ bool HLTPixelThrustFilter::filter(edm::StreamID, edm::Event& event, edm::EventSe
       nSatPixels += cluster.isSaturated();
     }
   if (nPixels < min_nPixels_ || nSatPixels < min_nSatPixels_)
+    return false;
+  if ((max_nPixels_ > 0 && nPixels > max_nPixels_) || (max_nSatPixels_ > 0 && nSatPixels > max_nSatPixels_))
     return false;
 
   std::vector<reco::LeafCandidate> vec;

--- a/HLTrigger/special/plugins/HLTPixelThrustFilter.cc
+++ b/HLTrigger/special/plugins/HLTPixelThrustFilter.cc
@@ -25,6 +25,8 @@ public:
 private:
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeometryRcdToken_;
   const edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > inputToken_;
+  const bool useOnlySaturatedPixels_;
+  const unsigned int min_nPixels_, min_nSatPixels_;
   const double min_thrust_;  // minimum thrust
   const double max_thrust_;  // maximum thrust
 };
@@ -36,12 +38,18 @@ private:
 HLTPixelThrustFilter::HLTPixelThrustFilter(const edm::ParameterSet& config)
     : trackerGeometryRcdToken_(esConsumes()),
       inputToken_(consumes<edmNew::DetSetVector<SiPixelCluster> >(config.getParameter<edm::InputTag>("inputTag"))),
+      useOnlySaturatedPixels_(config.getParameter<bool>("useOnlySaturatedPixels")),
+      min_nPixels_(config.getParameter<unsigned int>("minNPixels")),
+      min_nSatPixels_(config.getParameter<unsigned int>("minNSaturatedPixels")),
       min_thrust_(config.getParameter<double>("minThrust")),
       max_thrust_(config.getParameter<double>("maxThrust")) {}
 
 void HLTPixelThrustFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("inputTag", edm::InputTag("hltSiPixelClusters"));
+  desc.add<bool>("useOnlySaturatedPixels", false);
+  desc.add<unsigned int>("minNPixels", 2);
+  desc.add<unsigned int>("minNSaturatedPixels", 0);
   desc.add<double>("minThrust", 0);
   desc.add<double>("maxThrust", 0);
   descriptions.add("hltPixelThrustFilter", desc);
@@ -56,15 +64,24 @@ bool HLTPixelThrustFilter::filter(edm::StreamID, edm::Event& event, edm::EventSe
   auto const& clusters = event.get(inputToken_);
   auto const& trackerGeo = iSetup.getData(trackerGeometryRcdToken_);
 
+  size_t nSatPixels(0);
   std::vector<reco::LeafCandidate> vec;
+  vec.reserve(clusters.size() * 1000);
   for (auto DSViter = clusters.begin(); DSViter != clusters.end(); DSViter++) {
     auto const& pgdu = static_cast<const PixelGeomDetUnit*>(trackerGeo.idToDetUnit(DSViter->detId()));
     for (auto const& cluster : *DSViter) {
+      if (cluster.isSaturated())
+        nSatPixels += 1;
+      else if (useOnlySaturatedPixels_)
+        continue;
       auto const& pos = pgdu->surface().toGlobal(pgdu->specificTopology().localPosition({cluster.x(), cluster.y()}));
       auto const mag = std::sqrt(pos.x() * pos.x() + pos.y() * pos.y());
-      vec.emplace_back(0, reco::Particle::LorentzVector(pos.x() / mag, pos.y() / mag, 0, 0));
+      if (mag > 0)
+        vec.emplace_back(0, reco::Particle::LorentzVector(pos.x() / mag, pos.y() / mag, 0, 0));
     }
   }
+  if (vec.size() < min_nPixels_ || nSatPixels < min_nSatPixels_)
+    return false;
   auto const thrust = Thrust(vec.begin(), vec.end()).thrust();
 
   bool accept = (thrust >= min_thrust_);

--- a/PhysicsTools/CandUtils/BuildFile.xml
+++ b/PhysicsTools/CandUtils/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="DataFormats/Candidate"/>
 <use name="roothistmatrix"/>
+<use name="vdt_headers"/>
 <export>
   <lib name="1"/>
 </export>

--- a/PhysicsTools/CandUtils/interface/Thrust.h
+++ b/PhysicsTools/CandUtils/interface/Thrust.h
@@ -33,20 +33,23 @@
  */
 #include "DataFormats/Math/interface/Vector3D.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
+#include <vdt/vdtMath.h>
 #include <vector>
 
 class Thrust {
 public:
   /// spatial vector
   typedef math::XYZVector Vector;
+  static constexpr double PI = M_PI, PI2 = 2. * PI, PI_2 = PI / 2., PI_4 = PI / 4.;
   /// constructor from first and last iterators
   template <typename const_iterator>
   Thrust(const_iterator begin, const_iterator end) : thrust_(0), axis_(0, 0, 0), pSum_(0), n_(end - begin), p_(n_) {
     if (n_ == 0)
       return;
     std::vector<const reco::Candidate *> cands;
+    cands.reserve(n_);
     for (const_iterator i = begin; i != end; ++i) {
-      cands.push_back(&*i);
+      cands.emplace_back(&*i);
     }
     init(cands);
   }


### PR DESCRIPTION
#### PR description:

This PR updates the HLTPixelThrustFilter module, which filters on the transverse thrust value of pixel clusters, to allow the option to also compute the transverse thrust considering only saturated pixel clusters or to cut on the number of pixel clusters.

This HLT filter is only used so far in the HIon menu to search for low-mass magnetic monopoles in ultra-peripheral PbPb collisions, which apart from leading to large values of transverse thrust are also expected to be highly ionizing and tend to saturate the pixel clusters. As such, adding the option to select on saturated clusters can help to further reduce the contributions from beam background, which in 2025 PbPb data taking ended up been much larger than in previous years.

#### PR validation:

Tested with relvals 141.201,141.202,142.201,142.202,143.201,143.202,144.201,144.202,180.0.180.1,181.0,181.1,182.0,182.1,183.0,183.1 

@mandrenguyen @flodamas @vince502