### PR TITLE
Introducing Dilepton and π0 HLT Scouting DQM  + fixes to the `ScoutingCollectionMonitor` and `ScoutingRechitMonitoring` labels [16_0_X]

### DIFF
--- a/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
+++ b/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
@@ -187,14 +187,13 @@ private:
   dqm::reco::MonitorElement* PF_vertex_n13_hist;
   dqm::reco::MonitorElement* PF_vertex_1_hist;
   dqm::reco::MonitorElement* PF_vertex_2_hist;
+
+  // the following variables make sense only if there is a Track
+
   dqm::reco::MonitorElement* PF_normchi2_211_hist;
   dqm::reco::MonitorElement* PF_normchi2_n211_hist;
-  dqm::reco::MonitorElement* PF_normchi2_130_hist;
-  dqm::reco::MonitorElement* PF_normchi2_22_hist;
   dqm::reco::MonitorElement* PF_normchi2_13_hist;
   dqm::reco::MonitorElement* PF_normchi2_n13_hist;
-  dqm::reco::MonitorElement* PF_normchi2_1_hist;
-  dqm::reco::MonitorElement* PF_normchi2_2_hist;
 
   dqm::reco::MonitorElement* PF_dz_211_hist;
   dqm::reco::MonitorElement* PF_dz_n211_hist;
@@ -590,7 +589,6 @@ void ScoutingCollectionMonitor::analyze(const edm::Event& iEvent, const edm::Eve
         PF_eta_130_hist->Fill(cand.eta());
         PF_phi_130_hist->Fill(cand.phi());
         PF_vertex_130_hist->Fill(cand.vertex());
-        PF_normchi2_130_hist->Fill(cand.normchi2());
         break;
 
       case 22:
@@ -598,7 +596,6 @@ void ScoutingCollectionMonitor::analyze(const edm::Event& iEvent, const edm::Eve
         PF_eta_22_hist->Fill(cand.eta());
         PF_phi_22_hist->Fill(cand.phi());
         PF_vertex_22_hist->Fill(cand.vertex());
-        PF_normchi2_22_hist->Fill(cand.normchi2());
         break;
 
       case 13:
@@ -636,7 +633,6 @@ void ScoutingCollectionMonitor::analyze(const edm::Event& iEvent, const edm::Eve
         PF_eta_1_hist->Fill(cand.eta());
         PF_phi_1_hist->Fill(cand.phi());
         PF_vertex_1_hist->Fill(cand.vertex());
-        PF_normchi2_1_hist->Fill(cand.normchi2());
         break;
 
       case 2:
@@ -644,7 +640,6 @@ void ScoutingCollectionMonitor::analyze(const edm::Event& iEvent, const edm::Eve
         PF_eta_2_hist->Fill(cand.eta());
         PF_phi_2_hist->Fill(cand.phi());
         PF_vertex_2_hist->Fill(cand.vertex());
-        PF_normchi2_2_hist->Fill(cand.normchi2());
         break;
     }
   }
@@ -1015,87 +1010,101 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   }
 
   ibook.setCurrentFolder(topfoldername_ + "/PFcand");
-  PF_pT_211_hist = ibook.book1DD("pT_211", "PF h^{+}  pT (GeV);p_{T} [GeV];Entries", 100, 0.0, 13.0);
-  PF_pT_n211_hist = ibook.book1DD("pT_n211", "PF h^{-} pT (GeV);p_{T} [GeV];Entries", 100, 0.0, 14.0);
-  PF_pT_130_hist = ibook.book1DD("pT_130", "PF h^{0} pT (GeV);p_{T} [GeV];Entries", 100, 0.0, 20.0);
-  PF_pT_22_hist = ibook.book1DD("pT_22", "PF #gamma pT (GeV);p_{T} [GeV];Entries", 100, 0.0, 18.0);
-  PF_pT_13_hist = ibook.book1DD("pT_13", "PF #mu^{+} pT (GeV);p_{T} [GeV];Entries", 100, 0.0, 80.0);
-  PF_pT_n13_hist = ibook.book1DD("pT_n13", "PF #mu^{-} pT (GeV);p_{T} [GeV];Entries", 100, 0.0, 80.0);
-  PF_pT_2_hist = ibook.book1DD("pT_2", "PF HF h (GeV);pT [GeV];Entries", 100, 0.0, 4.5);
-  PF_pT_1_hist = ibook.book1DD("pT_1", "PF HF e/#gamma pT (GeV);p_{T} [GeV];Entries", 100, 0.0, 6.0);
+  PF_pT_211_hist = ibook.book1DD("pT_posHad", "PF h^{+}  pT (GeV);p_{T} [GeV];Entries", 100, 0.0, 13.0);
+  PF_pT_n211_hist = ibook.book1DD("pT_negHad", "PF h^{-} pT (GeV);p_{T} [GeV];Entries", 100, 0.0, 14.0);
+  PF_pT_130_hist = ibook.book1DD("pT_neuHad", "PF h^{0} pT (GeV);p_{T} [GeV];Entries", 100, 0.0, 20.0);
+  PF_pT_22_hist = ibook.book1DD("pT_gamma", "PF #gamma pT (GeV);p_{T} [GeV];Entries", 100, 0.0, 18.0);
+  PF_pT_13_hist = ibook.book1DD("pT_mu_plus", "PF #mu^{+} pT (GeV);p_{T} [GeV];Entries", 100, 0.0, 80.0);
+  PF_pT_n13_hist = ibook.book1DD("pT_mu_minus", "PF #mu^{-} pT (GeV);p_{T} [GeV];Entries", 100, 0.0, 80.0);
+  PF_pT_2_hist = ibook.book1DD("pT_HF_had", "PF HF h (GeV);pT [GeV];Entries", 100, 0.0, 4.5);
+  PF_pT_1_hist = ibook.book1DD("pT_HF_eg", "PF HF e/#gamma pT (GeV);p_{T} [GeV];Entries", 100, 0.0, 6.0);
 
-  PF_eta_211_hist = ibook.book1DD("eta_211", "PF h^{+} #eta;#eta;Entries", 100, -5.0, 5.0);
-  PF_eta_n211_hist = ibook.book1DD("eta_n211", "PF h^{-} #eta;#eta;Entries", 100, -5.0, 5.0);
-  PF_eta_130_hist = ibook.book1DD("eta_130", "PF h^{0} #eta;#eta;Entries", 100, -5.0, 5.0);
-  PF_eta_22_hist = ibook.book1DD("eta_22", "PF #gamma #eta;#eta;Entries", 100, -5.0, 5.0);
-  PF_eta_13_hist = ibook.book1DD("eta_13", "PF #mu^{+} #eta;#eta;Entries", 100, -5.0, 5.0);
-  PF_eta_n13_hist = ibook.book1DD("eta_n13", "PF #mu^{-} #eta;#eta;Entries", 100, -5.0, 5.0);
-  PF_eta_1_hist = ibook.book1DD("eta_2", "PF HF h #eta;#eta;Entries", 100, -5.0, 5.0);
-  PF_eta_2_hist = ibook.book1DD("eta_1", "PF HF e/#gamma #eta;#eta;Entries", 100, -5.0, 5.0);
+  PF_eta_211_hist = ibook.book1DD("eta_posHad", "PF h^{+} #eta;#eta;Entries", 100, -5.0, 5.0);
+  PF_eta_n211_hist = ibook.book1DD("eta_negHad", "PF h^{-} #eta;#eta;Entries", 100, -5.0, 5.0);
+  PF_eta_130_hist = ibook.book1DD("eta_neuHad", "PF h^{0} #eta;#eta;Entries", 100, -5.0, 5.0);
+  PF_eta_22_hist = ibook.book1DD("eta_gamma", "PF #gamma #eta;#eta;Entries", 100, -5.0, 5.0);
+  PF_eta_13_hist = ibook.book1DD("eta_mu_plus", "PF #mu^{+} #eta;#eta;Entries", 100, -5.0, 5.0);
+  PF_eta_n13_hist = ibook.book1DD("eta_mu_minus", "PF #mu^{-} #eta;#eta;Entries", 100, -5.0, 5.0);
+  PF_eta_1_hist = ibook.book1DD("eta_HF_had", "PF HF h #eta;#eta;Entries", 100, -5.0, 5.0);
+  PF_eta_2_hist = ibook.book1DD("eta_HF_eg", "PF HF e/#gamma #eta;#eta;Entries", 100, -5.0, 5.0);
 
-  PF_phi_211_hist = ibook.book1DD("phi_211", "PF h^{+} #phi;#phi;Entries", 100, -3.2, 3.2);
-  PF_phi_n211_hist = ibook.book1DD("phi_n211", "PF h^{-} #phi;#phi;Entries", 100, -3.2, 3.2);
-  PF_phi_130_hist = ibook.book1DD("phi_130", "PF h^{0} #phi;#phi;Entries", 100, -3.2, 3.2);
-  PF_phi_22_hist = ibook.book1DD("phi_22", "PF #gamma #phi;#phi;Entries", 100, -3.2, 3.2);
-  PF_phi_13_hist = ibook.book1DD("phi_13", "PF #mu^{+} #phi;#phi;Entries", 100, -3.2, 3.2);
-  PF_phi_n13_hist = ibook.book1DD("phi_n13", "PF #mu^{-} #phi;#phi;Entries", 100, -3.2, 3.2);
-  PF_phi_1_hist = ibook.book1DD("phi_2", "PF HF h #phi;#phi;Entries", 100, -3.2, 3.2);
-  PF_phi_2_hist = ibook.book1DD("phi_1", "PF HF e/#gamma #phi;#phi;Entries", 100, -3.2, 3.2);
+  PF_phi_211_hist = ibook.book1DD("phi_posHad", "PF h^{+} #phi;#phi;Entries", 100, -3.2, 3.2);
+  PF_phi_n211_hist = ibook.book1DD("phi_negHad", "PF h^{-} #phi;#phi;Entries", 100, -3.2, 3.2);
+  PF_phi_130_hist = ibook.book1DD("phi_neuHad", "PF h^{0} #phi;#phi;Entries", 100, -3.2, 3.2);
+  PF_phi_22_hist = ibook.book1DD("phi_gamma", "PF #gamma #phi;#phi;Entries", 100, -3.2, 3.2);
+  PF_phi_13_hist = ibook.book1DD("phi_mu_plus", "PF #mu^{+} #phi;#phi;Entries", 100, -3.2, 3.2);
+  PF_phi_n13_hist = ibook.book1DD("phi_mu_minus", "PF #mu^{-} #phi;#phi;Entries", 100, -3.2, 3.2);
+  PF_phi_1_hist = ibook.book1DD("phi_HF_had", "PF HF h #phi;#phi;Entries", 100, -3.2, 3.2);
+  PF_phi_2_hist = ibook.book1DD("phi_HF_eg", "PF HF e/#gamma #phi;#phi;Entries", 100, -3.2, 3.2);
 
-  PF_vertex_211_hist = ibook.book1DD("vertex_211", "PF h^{+} Vertex;Vertex;Entries", 100, -10.0, 15.0);
-  PF_vertex_n211_hist = ibook.book1DD("vertex_n211", "PF h^{-} Vertex;Vertex;Entries", 100, -10.0, 15.0);
-  PF_vertex_130_hist = ibook.book1DD("vertex_130", "PF h^{0} Vertex;Vertex;Entries", 100, -10.0, 10.0);
-  PF_vertex_22_hist = ibook.book1DD("vertex_22", "PF #gamma Vertex;Vertex;Entries", 100, -10.0, 10.0);
-  PF_vertex_13_hist = ibook.book1DD("vertex_13", "PF #mu^{+} Vertex;Vertex;Entries", 100, -10.0, 15.0);
-  PF_vertex_n13_hist = ibook.book1DD("vertex_n13", "PF #mu^{-} Vertex;Vertex;Entries", 100, -10.0, 15.0);
-  PF_vertex_1_hist = ibook.book1DD("vertex_1", "PF HF h Vertex;Vertex;Entries", 100, -10.0, 10.0);
-  PF_vertex_2_hist = ibook.book1DD("vertex_2", "PF HF e/#gamma Vertex;Vertex;Entries", 100, -10.0, 10.0);
+  PF_vertex_211_hist =
+      ibook.book1DD("vertexIndex_posHad", "PF h^{+} Vertex Index ;Vertex index;Entries", 17, -1.5, 15.5);
+  PF_vertex_n211_hist =
+      ibook.book1DD("vertexIndex_negHad", "PF h^{-} Vertex Index;Vertex index;Entries", 17, -1.5, 15.5);
+  PF_vertex_130_hist =
+      ibook.book1DD("vertexIndex_neuHad", "PF h^{0} Vertex Index;Vertex index;Entries", 17, -1.5, 15.5);
+  PF_vertex_22_hist = ibook.book1DD("vertexIndex_gamma", "PF #gamma Vertex Index;Vertex index;Entries", 17, -1.5, 15.5);
+  PF_vertex_13_hist =
+      ibook.book1DD("vertexIndex_mu_plus", "PF #mu^{+} Vertex Index;Vertex index;Entries", 17, -1.5, 15.5);
+  PF_vertex_n13_hist =
+      ibook.book1DD("vertexIndex_mu_minus", "PF #mu^{-} Vertex Index;Vertex index;Entries", 17, -1.5, 15.5);
+  PF_vertex_1_hist = ibook.book1DD("vertexIndex_HF_eg", "PF HF h Vertex Index;Vertex index;Entries", 17, -1.5, 15.5);
+  PF_vertex_2_hist =
+      ibook.book1DD("vertexIndex_HF_had", "PF HF e/#gamma Vertex Index;Vertex index;Entries", 17, -1.5, 15.5);
 
-  PF_normchi2_211_hist = ibook.book1DD("normchi2_211", "PF h^{+} Norm #chi^2;Norm #chi^2;Entries", 100, 0.0, 10.0);
-  PF_normchi2_n211_hist = ibook.book1DD("normchi2_n211", "PF h^{-} Norm #chi^2;Norm #chi^2;Entries", 100, 0.0, 10.0);
-  PF_normchi2_130_hist = ibook.book1DD("normchi2_130", "PF h^{0} Norm #chi^2;Norm #chi^2;Entries", 100, 0.0, 100.0);
-  PF_normchi2_22_hist = ibook.book1DD("normchi2_22", "PF #gamma Norm #chi^2;Norm #chi^2;Entries", 100, 0.0, 100.0);
-  PF_normchi2_13_hist = ibook.book1DD("normchi2_13", "PF #mu^{+} Norm #chi^2;Norm #chi^2;Entries", 100, 0.0, 10.0);
-  PF_normchi2_n13_hist = ibook.book1DD("normchi2_n13", "PF #mu^{-} Norm #chi^2;Norm #chi^2;Entries", 100, 0.0, 10.0);
-  PF_normchi2_1_hist = ibook.book1DD("normchi2_1", "PF HF h Norm #chi^2;Norm #chi^2;Entries", 100, 0.0, 100.0);
-  PF_normchi2_2_hist = ibook.book1DD("normchi2_2", "PF HF e/#gamma Norm #chi^2;Norm #chi^2;Entries", 100, 0.0, 100.0);
+  // the following variables make sense only if there is a Track
 
-  PF_dz_211_hist = ibook.book1DD("dz_211", "PF h^{+} dz (cm);dz (cm);Entries", 100, -1.0, 1.0);
-  PF_dz_n211_hist = ibook.book1DD("dz_n211", "PF h^{-} dz (cm);dz (cm);Entries", 100, -1.0, 1.0);
-  PF_dz_13_hist = ibook.book1DD("dz_13", "PF #mu^{+} dz (cm);dz (cm);Entries", 100, -1.0, 1.0);
-  PF_dz_n13_hist = ibook.book1DD("dz_n13", "PF #mu^{-} dz (cm);dz (cm);Entries", 100, -1.0, 1.0);
+  PF_normchi2_211_hist =
+      ibook.book1DD("normchi2_posHad", "PF h^{+} Norm #chi^{2};Norm #chi^{2};Entries", 100, 0.0, 10.0);
+  PF_normchi2_n211_hist =
+      ibook.book1DD("normchi2_negHad", "PF h^{-} Norm #chi^{2};Norm #chi^{2};Entries", 100, 0.0, 10.0);
+  PF_normchi2_13_hist =
+      ibook.book1DD("normchi2_mu_plus", "PF #mu^{+} Norm #chi^{2};Norm #chi^{2};Entries", 100, 0.0, 10.0);
+  PF_normchi2_n13_hist =
+      ibook.book1DD("normchi2_mu_minus", "PF #mu^{-} Norm #chi^{2};Norm #chi^{2};Entries", 100, 0.0, 10.0);
 
-  PF_dxy_211_hist = ibook.book1DD("dxy_211", "PF h^{+} dxy (cm);dxy (cm);Entries", 100, -0.5, 0.5);
-  PF_dxy_n211_hist = ibook.book1DD("dxy_n211", "PF h^{-} dxy (cm);dxy (cm);Entries", 100, -0.5, 0.5);
-  PF_dxy_13_hist = ibook.book1DD("dxy_13", "PF #mu^{+} dxy (cm);dxy (cm);Entries", 100, -0.5, 0.5);
-  PF_dxy_n13_hist = ibook.book1DD("dxy_n13", "PF #mu^{-} dxy (cm);dxy (cm);Entries", 100, -0.5, 0.5);
+  PF_dz_211_hist = ibook.book1DD("dz_posHad", "PF h^{+} dz (cm);dz (cm);Entries", 100, -1.0, 1.0);
+  PF_dz_n211_hist = ibook.book1DD("dz_negHad", "PF h^{-} dz (cm);dz (cm);Entries", 100, -1.0, 1.0);
+  PF_dz_13_hist = ibook.book1DD("dz_mu_plus", "PF #mu^{+} dz (cm);dz (cm);Entries", 100, -1.0, 1.0);
+  PF_dz_n13_hist = ibook.book1DD("dz_mu_minus", "PF #mu^{-} dz (cm);dz (cm);Entries", 100, -1.0, 1.0);
 
-  PF_dzsig_211_hist = ibook.book1DD("dzsig_211", "PF h^{+} dzsig;dzsig;Entries", 100, 0.0, 10.0);
-  PF_dzsig_n211_hist = ibook.book1DD("dzsig_n211", "PF h^{-} dzsig;dzsig;Entries", 100, 0.0, 10.0);
-  PF_dzsig_13_hist = ibook.book1DD("dzsig_13", "PF #mu^{+} dzsig;dzsig;Entries", 100, 0.0, 10.0);
-  PF_dzsig_n13_hist = ibook.book1DD("dzsig_n13", "PF #mu^{-} dzsig;dzsig;Entries", 100, 0.0, 10.0);
+  PF_dxy_211_hist = ibook.book1DD("dxy_posHad", "PF h^{+} dxy (cm);dxy (cm);Entries", 100, -0.5, 0.5);
+  PF_dxy_n211_hist = ibook.book1DD("dxy_negHad", "PF h^{-} dxy (cm);dxy (cm);Entries", 100, -0.5, 0.5);
+  PF_dxy_13_hist = ibook.book1DD("dxy_mu_plus", "PF #mu^{+} dxy (cm);dxy (cm);Entries", 100, -0.5, 0.5);
+  PF_dxy_n13_hist = ibook.book1DD("dxy_mu_minus", "PF #mu^{-} dxy (cm);dxy (cm);Entries", 100, -0.5, 0.5);
 
-  PF_dxysig_211_hist = ibook.book1DD("dxysig_211", "PF h^{+} dxysig;dxysig;Entries", 100, 0.0, 10.0);
-  PF_dxysig_n211_hist = ibook.book1DD("dxysig_n211", "PF h^{-} dxysig;dxysig;Entries", 100, 0.0, 10.0);
-  PF_dxysig_13_hist = ibook.book1DD("dxysig_13", "PF #mu^{+} dxysig;dxysig;Entries", 100, 0.0, 10.0);
-  PF_dxysig_n13_hist = ibook.book1DD("dxysig_n13", "PF #mu^{-} dxysig;dxysig;Entries", 100, 0.0, 10.0);
+  PF_dzsig_211_hist = ibook.book1DD("dzsig_posHad", "PF h^{+} dzsig;dzsig;Entries", 100, 0.0, 10.0);
+  PF_dzsig_n211_hist = ibook.book1DD("dzsig_negHad", "PF h^{-} dzsig;dzsig;Entries", 100, 0.0, 10.0);
+  PF_dzsig_13_hist = ibook.book1DD("dzsig_mu_plus", "PF #mu^{+} dzsig;dzsig;Entries", 100, 0.0, 10.0);
+  PF_dzsig_n13_hist = ibook.book1DD("dzsig_mu_minus", "PF #mu^{-} dzsig;dzsig;Entries", 100, 0.0, 10.0);
 
-  PF_trk_pt_211_hist = ibook.book1DD("trk_pt_211", "PF h^{+} Track pT (GeV);Track p_{T} (GeV);Entries", 100, 0.0, 10.0);
+  PF_dxysig_211_hist = ibook.book1DD("dxysig_posHad", "PF h^{+} dxysig;dxysig;Entries", 100, 0.0, 10.0);
+  PF_dxysig_n211_hist = ibook.book1DD("dxysig_negHad", "PF h^{-} dxysig;dxysig;Entries", 100, 0.0, 10.0);
+  PF_dxysig_13_hist = ibook.book1DD("dxysig_mu_plus", "PF #mu^{+} dxysig;dxysig;Entries", 100, 0.0, 10.0);
+  PF_dxysig_n13_hist = ibook.book1DD("dxysig_mu_minus", "PF #mu^{-} dxysig;dxysig;Entries", 100, 0.0, 10.0);
+
+  // These variables are actually the difference between the PF candidate reconstructed kinematics and it's bestTrack ones.
+  // This behaviour is governed by the "relativeTrackVars" parameter of HLTScoutingPFProducer
+  // see https://github.com/cms-sw/cmssw/blob/master/HLTrigger/JetMET/plugins/HLTScoutingPFProducer.cc#L177-L185no
+
+  PF_trk_pt_211_hist =
+      ibook.book1DD("trk_pt_posHad", "PF h^{+} Track pT (GeV);Track p_{T} (GeV);Entries", 100, -1., 1.);
   PF_trk_pt_n211_hist =
-      ibook.book1DD("trk_pt_n211", "PF h^{-} Track pT (GeV);Track p_{T} (GeV);Entries", 100, 0.0, 10.0);
-  PF_trk_pt_13_hist = ibook.book1DD("trk_pt_13", "PF #mu^{+} Track pT (GeV);Track p_{T} (GeV);Entries", 100, 0.0, 10.0);
+      ibook.book1DD("trk_pt_negHad", "PF h^{-} Track pT (GeV);Track p_{T} (GeV);Entries", 100, -1., 1.);
+  PF_trk_pt_13_hist =
+      ibook.book1DD("trk_pt_mu_plus", "PF #mu^{+} Track pT (GeV);Track p_{T} (GeV);Entries", 100, -1., 1.);
   PF_trk_pt_n13_hist =
-      ibook.book1DD("trk_pt_n13", "PF #mu^{-} Track pT (GeV);Track p_{T} (GeV);Entries", 100, 0.0, 10.0);
+      ibook.book1DD("trk_pt_mu_minus", "PF #mu^{-} Track pT (GeV);Track p_{T} (GeV);Entries", 100, -1., 1.);
 
-  PF_trk_eta_211_hist = ibook.book1DD("trk_eta_211", "PF h^{+} Track #eta;Track #eta;Entries", 100, -3.0, 3.0);
-  PF_trk_eta_n211_hist = ibook.book1DD("trk_eta_n211", "PF h^{-} Track #eta;Track #eta;Entries", 100, -3.0, 3.0);
-  PF_trk_eta_13_hist = ibook.book1DD("trk_eta_13", "PF #mu^{+} Track #eta;Track #eta;Entries", 100, -3.0, 3.0);
-  PF_trk_eta_n13_hist = ibook.book1DD("trk_eta_n13", "PF #mu^{-} Track #eta;Track #eta;Entries", 100, -3.0, 3.0);
+  PF_trk_eta_211_hist = ibook.book1DD("trk_eta_posHad", "PF h^{+} Track #eta;Track #eta;Entries", 100, -0.1, 0.1);
+  PF_trk_eta_n211_hist = ibook.book1DD("trk_eta_negHad", "PF h^{-} Track #eta;Track #eta;Entries", 100, -0.1, 0.1);
+  PF_trk_eta_13_hist = ibook.book1DD("trk_eta_mu_plus", "PF #mu^{+} Track #eta;Track #eta;Entries", 100, -0.1, 0.1);
+  PF_trk_eta_n13_hist = ibook.book1DD("trk_eta_mu_minus", "PF #mu^{-} Track #eta;Track #eta;Entries", 100, -0.1, 0.1);
 
-  PF_trk_phi_211_hist = ibook.book1DD("trk_phi_211", "PF h^{+} Track #phi;Track #phi;Entries", 100, -3.2, 3.2);
-  PF_trk_phi_n211_hist = ibook.book1DD("trk_phi_n211", "PF h^{-} Track #phi;Track #phi;Entries", 100, -3.2, 3.2);
-  PF_trk_phi_13_hist = ibook.book1DD("trk_phi_13", "PF #mu^{+} Track #phi;Track #phi;Entries", 100, -3.2, 3.2);
-  PF_trk_phi_n13_hist = ibook.book1DD("trk_phi_n13", "PF #mu^{-} Track #phi;Track #phi;Entries", 100, -3.2, 3.2);
+  PF_trk_phi_211_hist = ibook.book1DD("trk_phi_posHad", "PF h^{+} Track #phi;Track #phi;Entries", 100, -0.1, 0.1);
+  PF_trk_phi_n211_hist = ibook.book1DD("trk_phi_negHad", "PF h^{-} Track #phi;Track #phi;Entries", 100, -0.1, 0.1);
+  PF_trk_phi_13_hist = ibook.book1DD("trk_phi_mu_plus", "PF #mu^{+} Track #phi;Track #phi;Entries", 100, -0.1, 0.1);
+  PF_trk_phi_n13_hist = ibook.book1DD("trk_phi_mu_minus", "PF #mu^{-} Track #phi;Track #phi;Entries", 100, -0.1, 0.1);
 
   ibook.setCurrentFolder(topfoldername_ + "/Photon");
   pt_pho_hist = ibook.book1DD("pt_pho", "Photon pT; p_{T} (GeV); Entries", 100, 0.0, 100.0);

--- a/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
+++ b/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
@@ -1001,7 +1001,7 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
 
   rho_hist = ibook.book1D("rho", "#rho; #rho; Entries", 100, 0.0, 60.0);
   pfMetPhi_hist = ibook.book1D("pfMetPhi", "pf MET #phi; #phi ;Entries", 100, -3.14, 3.14);
-  pfMetPt_hist = ibook.book1D("pfMetPt", "pf MET pT;p_{T} [GeV];Entries", 100, 0.0, 250.0);
+  pfMetPt_hist = ibook.book1D("pfMetPt", "pf MET p_{T};p_{T} [GeV];Entries", 100, 0.0, 250.0);
 
   if (!onlyScouting_) {
     PVvsPU_hist =
@@ -1010,14 +1010,14 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   }
 
   ibook.setCurrentFolder(topfoldername_ + "/PFcand");
-  PF_pT_211_hist = ibook.book1DD("pT_posHad", "PF h^{+}  pT (GeV);p_{T} [GeV];Entries", 100, 0.0, 13.0);
-  PF_pT_n211_hist = ibook.book1DD("pT_negHad", "PF h^{-} pT (GeV);p_{T} [GeV];Entries", 100, 0.0, 14.0);
-  PF_pT_130_hist = ibook.book1DD("pT_neuHad", "PF h^{0} pT (GeV);p_{T} [GeV];Entries", 100, 0.0, 20.0);
-  PF_pT_22_hist = ibook.book1DD("pT_gamma", "PF #gamma pT (GeV);p_{T} [GeV];Entries", 100, 0.0, 18.0);
-  PF_pT_13_hist = ibook.book1DD("pT_mu_plus", "PF #mu^{+} pT (GeV);p_{T} [GeV];Entries", 100, 0.0, 80.0);
-  PF_pT_n13_hist = ibook.book1DD("pT_mu_minus", "PF #mu^{-} pT (GeV);p_{T} [GeV];Entries", 100, 0.0, 80.0);
-  PF_pT_2_hist = ibook.book1DD("pT_HF_had", "PF HF h (GeV);pT [GeV];Entries", 100, 0.0, 4.5);
-  PF_pT_1_hist = ibook.book1DD("pT_HF_eg", "PF HF e/#gamma pT (GeV);p_{T} [GeV];Entries", 100, 0.0, 6.0);
+  PF_pT_211_hist = ibook.book1DD("pT_posHad", "PF h^{+}  p_{T} (GeV);p_{T} [GeV];Entries", 100, 0.0, 13.0);
+  PF_pT_n211_hist = ibook.book1DD("pT_negHad", "PF h^{-} p_{T} (GeV);p_{T} [GeV];Entries", 100, 0.0, 14.0);
+  PF_pT_130_hist = ibook.book1DD("pT_neuHad", "PF h^{0} p_{T} (GeV);p_{T} [GeV];Entries", 100, 0.0, 20.0);
+  PF_pT_22_hist = ibook.book1DD("pT_gamma", "PF #gamma p_{T} (GeV);p_{T} [GeV];Entries", 100, 0.0, 18.0);
+  PF_pT_13_hist = ibook.book1DD("pT_mu_plus", "PF #mu^{+} p_{T} (GeV);p_{T} [GeV];Entries", 100, 0.0, 80.0);
+  PF_pT_n13_hist = ibook.book1DD("pT_mu_minus", "PF #mu^{-} p_{T} (GeV);p_{T} [GeV];Entries", 100, 0.0, 80.0);
+  PF_pT_2_hist = ibook.book1DD("pT_HF_had", "PF HF h (GeV);p_{T} [GeV];Entries", 100, 0.0, 4.5);
+  PF_pT_1_hist = ibook.book1DD("pT_HF_eg", "PF HF e/#gamma p_{T} (GeV);p_{T} [GeV];Entries", 100, 0.0, 6.0);
 
   PF_eta_211_hist = ibook.book1DD("eta_posHad", "PF h^{+} #eta;#eta;Entries", 100, -5.0, 5.0);
   PF_eta_n211_hist = ibook.book1DD("eta_negHad", "PF h^{-} #eta;#eta;Entries", 100, -5.0, 5.0);
@@ -1063,51 +1063,89 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   PF_normchi2_n13_hist =
       ibook.book1DD("normchi2_mu_minus", "PF #mu^{-} Norm #chi^{2};Norm #chi^{2};Entries", 100, 0.0, 10.0);
 
-  PF_dz_211_hist = ibook.book1DD("dz_posHad", "PF h^{+} dz (cm);dz (cm);Entries", 100, -1.0, 1.0);
-  PF_dz_n211_hist = ibook.book1DD("dz_negHad", "PF h^{-} dz (cm);dz (cm);Entries", 100, -1.0, 1.0);
-  PF_dz_13_hist = ibook.book1DD("dz_mu_plus", "PF #mu^{+} dz (cm);dz (cm);Entries", 100, -1.0, 1.0);
-  PF_dz_n13_hist = ibook.book1DD("dz_mu_minus", "PF #mu^{-} dz (cm);dz (cm);Entries", 100, -1.0, 1.0);
+  PF_dz_211_hist = ibook.book1DD("dz_posHad", "PF h^{+} d_{z} (cm);d_{z} (cm);Entries", 100, -1.0, 1.0);
+  PF_dz_n211_hist = ibook.book1DD("dz_negHad", "PF h^{-} d_{z} (cm);d_{z} (cm);Entries", 100, -1.0, 1.0);
+  PF_dz_13_hist = ibook.book1DD("dz_mu_plus", "PF #mu^{+} d_{z} (cm);d_{z} (cm);Entries", 100, -1.0, 1.0);
+  PF_dz_n13_hist = ibook.book1DD("dz_mu_minus", "PF #mu^{-} d_{z} (cm);d_{z} (cm);Entries", 100, -1.0, 1.0);
 
-  PF_dxy_211_hist = ibook.book1DD("dxy_posHad", "PF h^{+} dxy (cm);dxy (cm);Entries", 100, -0.5, 0.5);
-  PF_dxy_n211_hist = ibook.book1DD("dxy_negHad", "PF h^{-} dxy (cm);dxy (cm);Entries", 100, -0.5, 0.5);
-  PF_dxy_13_hist = ibook.book1DD("dxy_mu_plus", "PF #mu^{+} dxy (cm);dxy (cm);Entries", 100, -0.5, 0.5);
-  PF_dxy_n13_hist = ibook.book1DD("dxy_mu_minus", "PF #mu^{-} dxy (cm);dxy (cm);Entries", 100, -0.5, 0.5);
+  PF_dxy_211_hist = ibook.book1DD("dxy_posHad", "PF h^{+} d_{xy} (cm);d_{xy} (cm);Entries", 100, -0.5, 0.5);
+  PF_dxy_n211_hist = ibook.book1DD("dxy_negHad", "PF h^{-} d_{xy} (cm);d_{xy} (cm);Entries", 100, -0.5, 0.5);
+  PF_dxy_13_hist = ibook.book1DD("dxy_mu_plus", "PF #mu^{+} d_{xy} (cm);d_{xy} (cm);Entries", 100, -0.5, 0.5);
+  PF_dxy_n13_hist = ibook.book1DD("dxy_mu_minus", "PF #mu^{-} d_{xy} (cm);d_{xy} (cm);Entries", 100, -0.5, 0.5);
 
-  PF_dzsig_211_hist = ibook.book1DD("dzsig_posHad", "PF h^{+} dzsig;dzsig;Entries", 100, 0.0, 10.0);
-  PF_dzsig_n211_hist = ibook.book1DD("dzsig_negHad", "PF h^{-} dzsig;dzsig;Entries", 100, 0.0, 10.0);
-  PF_dzsig_13_hist = ibook.book1DD("dzsig_mu_plus", "PF #mu^{+} dzsig;dzsig;Entries", 100, 0.0, 10.0);
-  PF_dzsig_n13_hist = ibook.book1DD("dzsig_mu_minus", "PF #mu^{-} dzsig;dzsig;Entries", 100, 0.0, 10.0);
+  PF_dzsig_211_hist =
+      ibook.book1DD("dzsig_posHad", "PF h^{+} d_{z} Signficance;d_{z}/#sigma_{dz};Entries", 100, 0.0, 10.0);
+  PF_dzsig_n211_hist =
+      ibook.book1DD("dzsig_negHad", "PF h^{-} d_{z} Signficance;d_{z}/#sigma_{dz};Entries", 100, 0.0, 10.0);
+  PF_dzsig_13_hist =
+      ibook.book1DD("dzsig_mu_plus", "PF #mu^{+} d_{z} Signficance;d_{z}/#sigma_{dz};Entries", 100, 0.0, 10.0);
+  PF_dzsig_n13_hist =
+      ibook.book1DD("dzsig_mu_minus", "PF #mu^{-} d_{z} Signficance;d_{z}/#sigma_{dz};Entries", 100, 0.0, 10.0);
 
-  PF_dxysig_211_hist = ibook.book1DD("dxysig_posHad", "PF h^{+} dxysig;dxysig;Entries", 100, 0.0, 10.0);
-  PF_dxysig_n211_hist = ibook.book1DD("dxysig_negHad", "PF h^{-} dxysig;dxysig;Entries", 100, 0.0, 10.0);
-  PF_dxysig_13_hist = ibook.book1DD("dxysig_mu_plus", "PF #mu^{+} dxysig;dxysig;Entries", 100, 0.0, 10.0);
-  PF_dxysig_n13_hist = ibook.book1DD("dxysig_mu_minus", "PF #mu^{-} dxysig;dxysig;Entries", 100, 0.0, 10.0);
+  PF_dxysig_211_hist =
+      ibook.book1DD("dxysig_posHad", "PF h^{+} d_{xy} Significance;d_{xy}/#sigma_{dxy};Entries", 100, 0.0, 10.0);
+  PF_dxysig_n211_hist =
+      ibook.book1DD("dxysig_negHad", "PF h^{-} d_{xy} Significance;d_{xy}/#sigma_{dxy};Entries", 100, 0.0, 10.0);
+  PF_dxysig_13_hist =
+      ibook.book1DD("dxysig_mu_plus", "PF #mu^{+} d_{xy} Significance;d_{xy}/#sigma_{dxy};Entries", 100, 0.0, 10.0);
+  PF_dxysig_n13_hist =
+      ibook.book1DD("dxysig_mu_minus", "PF #mu^{-} d_{xy} Significance;d_{xy}/#sigma_{dxy};Entries", 100, 0.0, 10.0);
 
   // These variables are actually the difference between the PF candidate reconstructed kinematics and it's bestTrack ones.
   // This behaviour is governed by the "relativeTrackVars" parameter of HLTScoutingPFProducer
   // see https://github.com/cms-sw/cmssw/blob/master/HLTrigger/JetMET/plugins/HLTScoutingPFProducer.cc#L177-L185no
 
   PF_trk_pt_211_hist =
-      ibook.book1DD("trk_pt_posHad", "PF h^{+} Track pT (GeV);Track p_{T} (GeV);Entries", 100, -1., 1.);
+      ibook.book1DD("trk_pt_posHad",
+                    "PF h^{+} #Delta p_{T}(Track - Cand) (GeV);#Delta p_{T}(Track - Cand) (GeV);Entries",
+                    100,
+                    -0.01,
+                    0.01);
   PF_trk_pt_n211_hist =
-      ibook.book1DD("trk_pt_negHad", "PF h^{-} Track pT (GeV);Track p_{T} (GeV);Entries", 100, -1., 1.);
+      ibook.book1DD("trk_pt_negHad",
+                    "PF h^{-} #Delta p_{T}(Track - Cand) (GeV);#Delta p_{T}(Track - Cand) (GeV);Entries",
+                    100,
+                    -0.01,
+                    0.01);
   PF_trk_pt_13_hist =
-      ibook.book1DD("trk_pt_mu_plus", "PF #mu^{+} Track pT (GeV);Track p_{T} (GeV);Entries", 100, -1., 1.);
+      ibook.book1DD("trk_pt_mu_plus",
+                    "PF #mu^{+} #Delta p_{T}(Track - Cand) (GeV);#Delta p_{T}(Track - Cand) (GeV);Entries",
+                    100,
+                    -0.01,
+                    0.01);
   PF_trk_pt_n13_hist =
-      ibook.book1DD("trk_pt_mu_minus", "PF #mu^{-} Track pT (GeV);Track p_{T} (GeV);Entries", 100, -1., 1.);
+      ibook.book1DD("trk_pt_mu_minus",
+                    "PF #mu^{-} #Delta p_{T}(Track - Cand) (GeV);#Delta p_{T}(Track - Cand) (GeV);Entries",
+                    100,
+                    -0.01,
+                    0.01);
 
-  PF_trk_eta_211_hist = ibook.book1DD("trk_eta_posHad", "PF h^{+} Track #eta;Track #eta;Entries", 100, -0.1, 0.1);
-  PF_trk_eta_n211_hist = ibook.book1DD("trk_eta_negHad", "PF h^{-} Track #eta;Track #eta;Entries", 100, -0.1, 0.1);
-  PF_trk_eta_13_hist = ibook.book1DD("trk_eta_mu_plus", "PF #mu^{+} Track #eta;Track #eta;Entries", 100, -0.1, 0.1);
-  PF_trk_eta_n13_hist = ibook.book1DD("trk_eta_mu_minus", "PF #mu^{-} Track #eta;Track #eta;Entries", 100, -0.1, 0.1);
+  PF_trk_eta_211_hist = ibook.book1DD(
+      "trk_eta_posHad", "PF h^{+} #Delta #eta(Track - Cand);#Delta #eta(Track - Cand);Entries", 100, -0.01, 0.01);
+  PF_trk_eta_n211_hist = ibook.book1DD(
+      "trk_eta_negHad", "PF h^{-} #Delta #eta(Track - Cand);#Delta #eta(Track - Cand);Entries", 100, -0.01, 0.01);
+  PF_trk_eta_13_hist = ibook.book1DD(
+      "trk_eta_mu_plus", "PF #mu^{+} #Delta #eta(Track - Cand);#Delta #eta(Track - Cand);Entries", 100, -0.01, 0.01);
+  PF_trk_eta_n13_hist = ibook.book1DD(
+      "trk_eta_mu_minus", "PF #mu^{-} #Delta #eta(Track - Cand);#Delta #eta(Track - Cand);Entries", 100, -0.01, 0.01);
 
-  PF_trk_phi_211_hist = ibook.book1DD("trk_phi_posHad", "PF h^{+} Track #phi;Track #phi;Entries", 100, -0.1, 0.1);
-  PF_trk_phi_n211_hist = ibook.book1DD("trk_phi_negHad", "PF h^{-} Track #phi;Track #phi;Entries", 100, -0.1, 0.1);
-  PF_trk_phi_13_hist = ibook.book1DD("trk_phi_mu_plus", "PF #mu^{+} Track #phi;Track #phi;Entries", 100, -0.1, 0.1);
-  PF_trk_phi_n13_hist = ibook.book1DD("trk_phi_mu_minus", "PF #mu^{-} Track #phi;Track #phi;Entries", 100, -0.1, 0.1);
+  PF_trk_phi_211_hist = ibook.book1DD(
+      "trk_phi_posHad", "PF h^{+} #Delta #phi(Track - Cand);#Delta #phi(Track - Cand) [rad];Entries", 100, -0.01, 0.01);
+  PF_trk_phi_n211_hist = ibook.book1DD(
+      "trk_phi_negHad", "PF h^{-} #Delta #phi(Track - Cand);#Delta #phi(Track - Cand) [rad];Entries", 100, -0.01, 0.01);
+  PF_trk_phi_13_hist = ibook.book1DD("trk_phi_mu_plus",
+                                     "PF #mu^{+} #Delta #phi(Track - Cand);#Delta #phi(Track - Cand) [rad];Entries",
+                                     100,
+                                     -0.01,
+                                     0.01);
+  PF_trk_phi_n13_hist = ibook.book1DD("trk_phi_mu_minus",
+                                      "PF #mu^{-} #Delta #phi(Track - Cand);#Delta #phi(Track - Cand) [rad];Entries",
+                                      100,
+                                      -0.01,
+                                      0.01);
 
   ibook.setCurrentFolder(topfoldername_ + "/Photon");
-  pt_pho_hist = ibook.book1DD("pt_pho", "Photon pT; p_{T} (GeV); Entries", 100, 0.0, 100.0);
+  pt_pho_hist = ibook.book1DD("pt_pho", "Photon p_{T}; p_{T} (GeV); Entries", 100, 0.0, 100.0);
   eta_pho_hist = ibook.book1DD("eta_pho", "photon #eta; #eta; Entries", 100, -2.7, 2.7);
   phi_pho_hist = ibook.book1DD("phi_pho", "Photon #phi; #phi (rad); Entries", 100, -3.14, 3.14);
   rawEnergy_pho_hist = ibook.book1DD("rawEnergy_pho", "Raw Energy Photon; Energy (GeV); Entries", 100, 0.0, 250.0);
@@ -1126,7 +1164,7 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   sMaj_pho_hist = ibook.book1DD("sMaj_pho", "sMaj Photon; sMaj; Entries", 100, 0.0, 3);
 
   ibook.setCurrentFolder(topfoldername_ + "/Electron");
-  pt_ele_hist = ibook.book1DD("pt_ele", "Electron pT; p_{T} (GeV); Entries", 100, 0.0, 100.0);
+  pt_ele_hist = ibook.book1DD("pt_ele", "Electron p_{T}; p_{T} (GeV); Entries", 100, 0.0, 100.0);
   eta_ele_hist = ibook.book1DD("eta_ele", "Electron #eta; #eta; Entries", 100, -2.7, 2.7);
   phi_ele_hist = ibook.book1DD("phi_ele", "Electron #phi; #phi (rad); Entries", 100, -3.14, 3.14);
   rawEnergy_ele_hist = ibook.book1DD("rawEnergy_ele", "Raw Energy Electron; Energy (GeV); Entries", 100, 0.0, 250.0);
@@ -1159,7 +1197,7 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
     const std::string& sfx = suffixes[i];
     const std::string& lbl = muonLabels[i];
 
-    pt_mu_hist[i] = ibook.book1DD("pt_mu" + sfx, "Muon pT (" + lbl + "); p_{T} (GeV); Entries", 100, 0.0, 200.0);
+    pt_mu_hist[i] = ibook.book1DD("pt_mu" + sfx, "Muon p_{T} (" + lbl + "); p_{T} (GeV); Entries", 100, 0.0, 200.0);
     eta_mu_hist[i] = ibook.book1DD("eta_mu" + sfx, "Muon #eta (" + lbl + "); #eta; Entries", 100, -2.7, 2.7);
     phi_mu_hist[i] = ibook.book1DD("phi_mu" + sfx, "Muon #phi (" + lbl + "); #phi (rad); Entries", 100, -3.14, 3.14);
     type_mu_hist[i] = ibook.book1DD("type_mu" + sfx, "Muon Type (" + lbl + "); Type; Entries", 10, 0, 10);
@@ -1227,22 +1265,22 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
     trk_ndof_mu_hist[i] =
         ibook.book1DD("trk_ndof_mu" + sfx, "Muon Tracker Ndof (" + lbl + "); Ndof; Entries", 100, 0, 100);
     trk_dxy_mu_hist[i] =
-        ibook.book1DD("trk_dxy_mu" + sfx, "Muon Tracker dxy (" + lbl + "); dxy (cm); Entries", 100, -0.5, 0.5);
+        ibook.book1DD("trk_dxy_mu" + sfx, "Muon Tracker d_{xy} (" + lbl + "); d_{xy} (cm); Entries", 100, -0.5, 0.5);
     trk_dz_mu_hist[i] =
-        ibook.book1DD("trk_dz_mu" + sfx, "Muon Tracker dz (" + lbl + "); dz (cm); Entries", 100, -20.0, 20.0);
+        ibook.book1DD("trk_dz_mu" + sfx, "Muon Tracker d_{z} (" + lbl + "); d_{z} (cm); Entries", 100, -20.0, 20.0);
     trk_qoverp_mu_hist[i] = ibook.book1DD("trk_qoverp_mu" + sfx, "Muon q/p (" + lbl + "); q/p; Entries", 100, -1, 1);
     trk_lambda_mu_hist[i] =
         ibook.book1DD("trk_lambda_mu" + sfx, "Muon Lambda (" + lbl + "); #lambda; Entries", 100, -2, 2);
     trk_pt_mu_hist[i] =
-        ibook.book1DD("trk_pt_mu" + sfx, "Muon Tracker pT (" + lbl + "); p_{T} (GeV); Entries", 100, 0.0, 200.0);
+        ibook.book1DD("trk_pt_mu" + sfx, "Muon Tracker p_{T} (" + lbl + "); p_{T} (GeV); Entries", 100, 0.0, 200.0);
     trk_phi_mu_hist[i] =
         ibook.book1DD("trk_phi_mu" + sfx, "Muon Tracker #phi (" + lbl + "); #phi (rad); Entries", 100, -3.14, 3.14);
     trk_eta_mu_hist[i] =
         ibook.book1DD("trk_eta_mu" + sfx, "Muon Tracker #eta (" + lbl + "); #eta; Entries", 100, -2.7, 2.7);
-    trk_dxyError_mu_hist[i] =
-        ibook.book1DD("trk_dxyError_mu" + sfx, "Muon dxy Error (" + lbl + "); dxy Error (cm); Entries", 100, 0.0, 0.05);
-    trk_dzError_mu_hist[i] =
-        ibook.book1DD("trk_dzError_mu" + sfx, "Muon dz Error (" + lbl + "); dz Error (cm); Entries", 100, 0.0, 0.05);
+    trk_dxyError_mu_hist[i] = ibook.book1DD(
+        "trk_dxyError_mu" + sfx, "Muon d_{xy} Error (" + lbl + "); d_{xy} Error (cm); Entries", 100, 0.0, 0.05);
+    trk_dzError_mu_hist[i] = ibook.book1DD(
+        "trk_dzError_mu" + sfx, "Muon d_{z} Error (" + lbl + "); d_{z} Error (cm); Entries", 100, 0.0, 0.05);
     trk_qoverpError_mu_hist[i] =
         ibook.book1DD("trk_qoverpError_mu" + sfx, "Muon q/p Error (" + lbl + "); q/p Error; Entries", 100, 0.0, 0.01);
     trk_lambdaError_mu_hist[i] = ibook.book1DD(
@@ -1262,8 +1300,11 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
                                                   100,
                                                   -0.001,
                                                   0.001);
-    trk_qoverp_dxy_cov_mu_hist[i] = ibook.book1DD(
-        "trk_qoverp_dxy_cov_mu" + sfx, "Muon q/p-dxy Covariance (" + lbl + "); Covariance; Entries", 100, -0.001, 0.001);
+    trk_qoverp_dxy_cov_mu_hist[i] = ibook.book1DD("trk_qoverp_dxy_cov_mu" + sfx,
+                                                  "Muon q/p-d_{xy} Covariance (" + lbl + "); Covariance; Entries",
+                                                  100,
+                                                  -0.001,
+                                                  0.001);
     trk_qoverp_dsz_cov_mu_hist[i] = ibook.book1DD(
         "trk_qoverp_dsz_cov_mu" + sfx, "Muon q/p-dsz Covariance (" + lbl + "); Covariance; Entries", 100, -0.001, 0.001);
     trk_lambda_phi_cov_mu_hist[i] = ibook.book1DD("trk_lambda_phi_cov_mu" + sfx,
@@ -1272,7 +1313,7 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
                                                   -0.001,
                                                   0.001);
     trk_lambda_dxy_cov_mu_hist[i] = ibook.book1DD("trk_lambda_dxy_cov_mu" + sfx,
-                                                  "Muon Lambda-dxy Covariance (" + lbl + "); Covariance; Entries",
+                                                  "Muon Lambda-d_{xy} Covariance (" + lbl + "); Covariance; Entries",
                                                   100,
                                                   -0.001,
                                                   0.001);
@@ -1282,11 +1323,11 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
                                                   -0.001,
                                                   0.001);
     trk_phi_dxy_cov_mu_hist[i] = ibook.book1DD(
-        "trk_phi_dxy_cov_mu" + sfx, "Muon Phi-dxy Covariance (" + lbl + "); Covariance; Entries", 100, -0.001, 0.001);
+        "trk_phi_dxy_cov_mu" + sfx, "Muon Phi-d_{xy} Covariance (" + lbl + "); Covariance; Entries", 100, -0.001, 0.001);
     trk_phi_dsz_cov_mu_hist[i] = ibook.book1DD(
         "trk_phi_dsz_cov_mu" + sfx, "Muon Phi-dsz Covariance (" + lbl + "); Covariance; Entries", 100, -0.001, 0.001);
     trk_dxy_dsz_cov_mu_hist[i] = ibook.book1DD(
-        "trk_dxy_dsz_cov_mu" + sfx, "Muon dxy-dsz Covariance (" + lbl + "); Covariance; Entries", 100, -0.001, 0.001);
+        "trk_dxy_dsz_cov_mu" + sfx, "Muon d_{xy}-dsz Covariance (" + lbl + "); Covariance; Entries", 100, -0.001, 0.001);
     trk_vx_mu_hist[i] =
         ibook.book1DD("trk_vx_mu" + sfx, "Muon Tracker Vertex X (" + lbl + "); x (cm); Entries", 100, -0.5, 0.5);
     trk_vy_mu_hist[i] =
@@ -1296,7 +1337,7 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   }
 
   ibook.setCurrentFolder(topfoldername_ + "/PFJet");
-  pt_pfj_hist = ibook.book1DD("pt_pfj", "PF Jet pT; p_{T} (GeV); Entries", 100, 0.0, 150.0);
+  pt_pfj_hist = ibook.book1DD("pt_pfj", "PF Jet p_{T}; p_{T} (GeV); Entries", 100, 0.0, 150.0);
   eta_pfj_hist = ibook.book1DD("eta_pfj", "PF Jet #eta; #eta; Entries", 100, -5.0, 5.0);
   phi_pfj_hist = ibook.book1DD("phi_pfj", "PF Jet #phi; #phi (rad); Entries", 100, -3.14, 3.14);
   m_pfj_hist = ibook.book1DD("m_pfj", "PF Jet Mass; Mass (GeV); Entries", 100, 0.0, 40.0);
@@ -1382,22 +1423,22 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   }
 
   ibook.setCurrentFolder(topfoldername_ + "/Tracking");
-  tk_pt_tk_hist = ibook.book1DD("tk_pt_tk", "Track pT; p_{T} (GeV); Entries", 100, 0.0, 30.0);
+  tk_pt_tk_hist = ibook.book1DD("tk_pt_tk", "Track p_{T}; p_{T} (GeV); Entries", 100, 0.0, 30.0);
   tk_eta_tk_hist = ibook.book1DD("tk_eta_tk", "Track #eta; #eta; Entries", 100, -2.7, 2.7);
   tk_phi_tk_hist = ibook.book1DD("tk_phi_tk", "Track #phi; #phi (rad); Entries", 100, -3.14, 3.14);
   tk_chi2_tk_hist = ibook.book1DD("tk_chi2_tk", "Track #chi^{2}; #chi^{2}; Entries", 100, 0.0, 50.0);
   tk_ndof_tk_hist = ibook.book1DD("tk_ndof_tk", "Track Ndof; Ndof; Entries", 100, 0, 10);
   tk_charge_tk_hist = ibook.book1DD("tk_charge_tk", "Track Charge; Charge; Entries", 3, -1, 2);
-  tk_dxy_tk_hist = ibook.book1DD("tk_dxy_tk", "Track dxy; dxy (cm); Entries", 100, -0.5, 0.5);
-  tk_dz_tk_hist = ibook.book1DD("tk_dz_tk", "Track dz; dz (cm); Entries", 100, -20.0, 20.0);
+  tk_dxy_tk_hist = ibook.book1DD("tk_dxy_tk", "Track d_{xy}; d_{xy} (cm); Entries", 100, -0.5, 0.5);
+  tk_dz_tk_hist = ibook.book1DD("tk_dz_tk", "Track d_{z}; d_{z} (cm); Entries", 100, -20.0, 20.0);
   tk_nValidPixelHits_tk_hist = ibook.book1DD("tk_nValidPixelHits_tk", "Valid Pixel Hits; Hits; Entries", 20, 0, 20);
   tk_nTrackerLayersWithMeasurement_tk_hist = ibook.book1DD(
       "tk_nTrackerLayersWithMeasurement_tk", "Tracker Layers with Measurement; Layers; Entries", 20, 0, 20);
   tk_nValidStripHits_tk_hist = ibook.book1DD("tk_nValidStripHits_tk", "Valid Strip Hits; Hits; Entries", 50, 0, 50);
   tk_qoverp_tk_hist = ibook.book1DD("tk_qoverp_tk", "q/p; q/p; Entries", 100, -1.0, 1.0);
   tk_lambda_tk_hist = ibook.book1DD("tk_lambda_tk", "Lambda; #lambda; Entries", 100, -2, 2);
-  tk_dxy_Error_tk_hist = ibook.book1DD("tk_dxy_Error_tk", "dxy Error; dxy Error (cm); Entries", 100, 0.0, 0.05);
-  tk_dz_Error_tk_hist = ibook.book1DD("tk_dz_Error_tk", "dz Error; dz Error (cm); Entries", 100, 0.0, 0.05);
+  tk_dxy_Error_tk_hist = ibook.book1DD("tk_dxy_Error_tk", "d_{xy} Error; d_{xy} Error (cm); Entries", 100, 0.0, 0.05);
+  tk_dz_Error_tk_hist = ibook.book1DD("tk_dz_Error_tk", "d_{z} Error; d_{z} Error (cm); Entries", 100, 0.0, 0.05);
   tk_qoverp_Error_tk_hist = ibook.book1DD("tk_qoverp_Error_tk", "q/p Error; q/p Error; Entries", 100, 0.0, 0.05);
   tk_lambda_Error_tk_hist = ibook.book1DD("tk_lambda_Error_tk", "Lambda Error; #lambda Error; Entries", 100, 0.0, 0.1);
   tk_phi_Error_tk_hist = ibook.book1DD("tk_phi_Error_tk", "Phi Error; #phi Error (rad); Entries", 100, 0.0, 0.01);
@@ -1409,10 +1450,11 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   tk_vz_tk_hist = ibook.book1DD("tk_vz_tk", "Tracker Vertex Z; z (cm); Entries", 100, -20.0, 20.0);
   tk_chi2_ndof_tk_hist = ibook.book1DD("tk_chi2_ndof_tk", "Reduced #chi^{2}; #chi^{2}/NDOF; Entries", 100, 0, 50);
   tk_chi2_prob_hist = ibook.book1DD("tk_chi2_prob_hist", "p(#chi^{2}, NDOF); p(#chi^{2}, NDOF); Entries", 100, 0, 1);
-  tk_PV_dz_hist = ibook.book1DD("tk_PV_dz", "Track dz w.r.t. PV; Track dz w.r.t. PV; Entries", 100, -0.35, 0.35);
-  tk_PV_dxy_hist = ibook.book1DD("tk_PV_dxy", "Track dxy w.r.t. PV; Track dxy w.r.t. PV; Entries", 100, -0.15, 0.15);
-  tk_BS_dxy_hist = ibook.book1D("tk_BS_dxy", "Track dxy w.r.t. BeamSpot;dxy_{BS} (cm);Entries", 100, -0.5, 0.5);
-  tk_BS_dz_hist = ibook.book1D("tk_BS_dz", "Track dz w.r.t. BeamSpot;dz_{BS} (cm);Entries", 100, -20.0, 20.0);
+  tk_PV_dz_hist = ibook.book1DD("tk_PV_dz", "Track d_{z} w.r.t. PV; Track d_{z} w.r.t. PV; Entries", 100, -0.35, 0.35);
+  tk_PV_dxy_hist =
+      ibook.book1DD("tk_PV_dxy", "Track d_{xy} w.r.t. PV; Track d_{xy} w.r.t. PV; Entries", 100, -0.15, 0.15);
+  tk_BS_dxy_hist = ibook.book1D("tk_BS_dxy", "Track d_{xy} w.r.t. BeamSpot;dxy_{BS} (cm);Entries", 100, -0.5, 0.5);
+  tk_BS_dz_hist = ibook.book1D("tk_BS_dz", "Track d_{z} w.r.t. BeamSpot;dz_{BS} (cm);Entries", 100, -20.0, 20.0);
 
   // book the calo rechits histograms
   const std::array<std::string, 2> caloLabels = {{"Accepted", "Rejected"}};

--- a/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
+++ b/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
@@ -1406,8 +1406,8 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   tk_BS_dz_hist = ibook.book1D("tk_BS_dz", "Track dz w.r.t. BeamSpot;dz_{BS} (cm);Entries", 100, -20.0, 20.0);
 
   // book the calo rechits histograms
-  const std::array<std::string, 2> caloLabels = {{"All", "Cleaned"}};
-  const std::array<std::string, 2> caloSuffixes = {{"", "_clean"}};
+  const std::array<std::string, 2> caloLabels = {{"Accepted", "Rejected"}};
+  const std::array<std::string, 2> caloSuffixes = {{"", "_bad"}};
   for (int i = 0; i < 2; ++i) {
     ibook.setCurrentFolder(topfoldername_ + "/CaloRecHits" + caloLabels[i]);
 

--- a/DQM/HLTEvF/python/ScoutingDileptonMonitor_cfi.py
+++ b/DQM/HLTEvF/python/ScoutingDileptonMonitor_cfi.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+from HLTriggerOffline.Scouting.HLTScoutingDileptonMonitor_cfi import ScoutingDileptonMonitor as _ScoutingDileptonMonitor
+ScoutingDileptonMonitorOnline = _ScoutingDileptonMonitor.clone(OutputInternalPath = cms.string('HLT/ScoutingOnline/DiLepton'))

--- a/DQM/HLTEvF/python/ScoutingPi0Monitor_cfi.py
+++ b/DQM/HLTEvF/python/ScoutingPi0Monitor_cfi.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+from HLTriggerOffline.Scouting.HLTScoutingPi0Monitor_cfi import ScoutingPi0Monitor  as _ScoutingPi0Monitor
+ScoutingPi0MonitorOnline = _ScoutingPi0Monitor.clone(OutputInternalPath = cms.string('HLT/ScoutingOnline/PiZero'))

--- a/DQM/HLTEvF/python/ScoutingRechitMonitoring_cff.py
+++ b/DQM/HLTEvF/python/ScoutingRechitMonitoring_cff.py
@@ -19,6 +19,11 @@ ScoutingEBRechitAnalyzerOnline = ScoutingEBRechitAnalyzer.clone(
     topFolderName = cms.string('HLT/ScoutingOnline/EBRechits')
 )
 
+ScoutingEBCleanedRechitAnalyzerOnline = ScoutingEBCleanedRechitAnalyzer.clone(
+    L1TriggerResults = cms.InputTag('L1BitsScoutingOnline'),
+    topFolderName = cms.string('HLT/ScoutingOnline/EBCleanedRechits')
+)
+
 ScoutingHBHERechitAnalyzerOnline = ScoutingHBHERechitAnalyzer.clone(
     L1TriggerResults = cms.InputTag('L1BitsScoutingOnline'),
     topFolderName = cms.string('HLT/ScoutingOnline/HBHERechits')
@@ -26,4 +31,5 @@ ScoutingHBHERechitAnalyzerOnline = ScoutingHBHERechitAnalyzer.clone(
 
 ScoutingRecHitsMonitoring = cms.Sequence(L1BitsSequence +
                                          ScoutingEBRechitAnalyzerOnline +
+                                         ScoutingEBCleanedRechitAnalyzerOnline +
                                          ScoutingHBHERechitAnalyzerOnline)

--- a/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
@@ -53,17 +53,24 @@ process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
 #process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
 
-
 ### for pp collisions
 process.load("DQM.HLTEvF.ScoutingCollectionMonitor_cfi")
-process.scoutingCollectionMonitor.topfoldername = "NGT/ScoutingCollections"
+process.scoutingCollectionMonitor.topfoldername = "NGT/ScoutingOnline/ScoutingCollections"
 process.scoutingCollectionMonitor.onlyScouting = False
 process.scoutingCollectionMonitor.onlineMetaDataDigis = "hltOnlineMetaDataDigis"
 process.scoutingCollectionMonitor.rho = ["hltScoutingPFPacker", "rho"]
+
+process.load("DQM.HLTEvF.ScoutingDileptonMonitor_cfi")
+process.ScoutingDileptonMonitorOnline.OutputInternalPath = "NGT/ScoutingOnline/DiLepton"
+
 process.dqmcommon = cms.Sequence(process.dqmEnv
                                * process.dqmSaver)#*process.dqmSaverPB)
 
-process.p = cms.Path(process.dqmcommon * process.hltOnlineBeamSpot * process.scoutingCollectionMonitor)
+process.p = cms.Path(process.dqmcommon *
+                     process.hltOnlineBeamSpot *
+                     process.scoutingCollectionMonitor *
+                     process.ScoutingDileptonMonitorOnline
+                     )
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *

--- a/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
@@ -63,14 +63,23 @@ process.scoutingCollectionMonitor.rho = ["hltScoutingPFPacker", "rho"]
 process.load("DQM.HLTEvF.ScoutingDileptonMonitor_cfi")
 process.ScoutingDileptonMonitorOnline.OutputInternalPath = "NGT/ScoutingOnline/DiLepton"
 
+process.load("DQM.HLTEvF.ScoutingPi0Monitor_cfi")
+process.ScoutingPi0MonitorOnline.OutputInternalPath = "NGT/ScoutingOnline/PiZero"
+process.ScoutingPi0MonitorOnline.maxEta = 2.5
+process.ScoutingPi0MonitorOnline.minPt = 1.5
+process.ScoutingPi0MonitorOnline.maxMass = 1.
+process.ScoutingPi0MonitorOnline.isolationPtRatio = 0.8
+process.ScoutingPi0MonitorOnline.asymmetryCut = 0.85
+process.ScoutingPi0MonitorOnline.pairMaxDr = 0.1
+
 process.dqmcommon = cms.Sequence(process.dqmEnv
                                * process.dqmSaver)#*process.dqmSaverPB)
 
 process.p = cms.Path(process.dqmcommon *
                      process.hltOnlineBeamSpot *
                      process.scoutingCollectionMonitor *
-                     process.ScoutingDileptonMonitorOnline
-                     )
+                     process.ScoutingDileptonMonitorOnline *
+                     process.ScoutingPi0MonitorOnline)
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *

--- a/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
@@ -57,6 +57,7 @@ process.load("DQM.HLTEvF.ScoutingMuonMonitoring_cff")
 process.load("DQM.HLTEvF.ScoutingJetMonitoring_cff")
 process.load("DQM.HLTEvF.ScoutingElectronMonitoring_cff")
 process.load("DQM.HLTEvF.ScoutingRechitMonitoring_cff")
+process.load("HLTriggerOffline.Scouting.HLTScoutingDileptonMonitor_cfi")
 ## Run-1 L1TGT required by ScoutingJetMonitoring https://github.com/cms-sw/cmssw/blob/master/DQMOffline/JetMET/src/JetAnalyzer.cc#L2603-L2611
 process.GlobalTag.toGet.append(
  cms.PSet(
@@ -71,7 +72,9 @@ process.p = cms.Path(process.dqmcommon *
                      process.ScoutingMuonMonitoring *
                      process.ScoutingJetMonitoring *
                      process.ScoutingElectronMonitoring *
-                     process.ScoutingRecHitsMonitoring)
+                     process.ScoutingRecHitsMonitoring *
+                     process.ScoutingDileptonMonitor
+                     )
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *

--- a/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
@@ -57,7 +57,7 @@ process.load("DQM.HLTEvF.ScoutingMuonMonitoring_cff")
 process.load("DQM.HLTEvF.ScoutingJetMonitoring_cff")
 process.load("DQM.HLTEvF.ScoutingElectronMonitoring_cff")
 process.load("DQM.HLTEvF.ScoutingRechitMonitoring_cff")
-process.load("HLTriggerOffline.Scouting.HLTScoutingDileptonMonitor_cfi")
+process.load("DQM.HLTEvF.ScoutingDileptonMonitor_cfi")
 ## Run-1 L1TGT required by ScoutingJetMonitoring https://github.com/cms-sw/cmssw/blob/master/DQMOffline/JetMET/src/JetAnalyzer.cc#L2603-L2611
 process.GlobalTag.toGet.append(
  cms.PSet(
@@ -73,7 +73,7 @@ process.p = cms.Path(process.dqmcommon *
                      process.ScoutingJetMonitoring *
                      process.ScoutingElectronMonitoring *
                      process.ScoutingRecHitsMonitoring *
-                     process.ScoutingDileptonMonitor
+                     process.ScoutingDileptonMonitorOnline
                      )
 
 ### process customizations included here

--- a/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
@@ -58,6 +58,7 @@ process.load("DQM.HLTEvF.ScoutingJetMonitoring_cff")
 process.load("DQM.HLTEvF.ScoutingElectronMonitoring_cff")
 process.load("DQM.HLTEvF.ScoutingRechitMonitoring_cff")
 process.load("DQM.HLTEvF.ScoutingDileptonMonitor_cfi")
+process.load("DQM.HLTEvF.ScoutingPi0Monitor_cfi")
 ## Run-1 L1TGT required by ScoutingJetMonitoring https://github.com/cms-sw/cmssw/blob/master/DQMOffline/JetMET/src/JetAnalyzer.cc#L2603-L2611
 process.GlobalTag.toGet.append(
  cms.PSet(
@@ -73,8 +74,8 @@ process.p = cms.Path(process.dqmcommon *
                      process.ScoutingJetMonitoring *
                      process.ScoutingElectronMonitoring *
                      process.ScoutingRecHitsMonitoring *
-                     process.ScoutingDileptonMonitorOnline
-                     )
+                     process.ScoutingDileptonMonitorOnline *
+                     process.ScoutingPi0MonitorOnline)
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *

--- a/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
+++ b/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
@@ -28,7 +28,7 @@ from HLTriggerOffline.Scouting.ScoutingRecHitAnalyzers_cff import *
 from HLTriggerOffline.Scouting.HLTScoutingDileptonMonitor_cfi import *
 
 ### Pi0 Monitoring
-from HLTriggerOffline.Scouting.HLTScoutingPiMonitor_cfi import *
+from HLTriggerOffline.Scouting.HLTScoutingPi0Monitor_cfi import *
 
 hltScoutingMuonDqmOffline = cms.Sequence(scoutingMonitoringTagProbeMuonNoVtx *
                                          scoutingMonitoringTagProbeMuonVtx *

--- a/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
+++ b/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
@@ -27,6 +27,9 @@ from HLTriggerOffline.Scouting.ScoutingRecHitAnalyzers_cff import *
 ### DiLeptons monitoring
 from HLTriggerOffline.Scouting.HLTScoutingDileptonMonitor_cfi import *
 
+### Pi0 Monitoring
+from HLTriggerOffline.Scouting.HLTScoutingPiMonitor_cfi import *
+
 hltScoutingMuonDqmOffline = cms.Sequence(scoutingMonitoringTagProbeMuonNoVtx *
                                          scoutingMonitoringTagProbeMuonVtx *
                                          scoutingMonitoringTriggerMuon_DoubleMu *
@@ -39,11 +42,13 @@ hltScoutingJetDqmOfflineForRelVals = cms.Sequence(jetMETDQMOfflineSourceScouting
 
 hltScoutingCollectionMonitor = cms.Sequence(scoutingCollectionMonitor)
 hltScoutingDileptonMonitor = cms.Sequence(ScoutingDileptonMonitor)
+hltScoutingPi0Monitor = cms.Sequence(ScoutingPi0Monitor)
 
 hltScoutingDqmOffline = cms.Sequence(hltScoutingMuonDqmOffline +
                                      hltScoutingEGammaDqmOffline +
                                      hltScoutingJetDqmOffline +
                                      hltScoutingDileptonMonitor +
+                                     hltScoutingPi0Monitor +
                                      hltScoutingCollectionMonitor)
 
 ## Add the scouting rechits monitoring (only for 2025, integrated in menu GRun 2025 V1.3)

--- a/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
+++ b/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
@@ -24,6 +24,9 @@ from DQM.HLTEvF.ScoutingCollectionMonitor_cfi import *
 ### RecHits monitoring
 from HLTriggerOffline.Scouting.ScoutingRecHitAnalyzers_cff import *
 
+### DiLeptons monitoring
+from HLTriggerOffline.Scouting.HLTScoutingDileptonMonitor_cfi import *
+
 hltScoutingMuonDqmOffline = cms.Sequence(scoutingMonitoringTagProbeMuonNoVtx *
                                          scoutingMonitoringTagProbeMuonVtx *
                                          scoutingMonitoringTriggerMuon_DoubleMu *
@@ -35,10 +38,12 @@ hltScoutingJetDqmOffline = cms.Sequence(jetMETDQMOfflineSourceScouting)
 hltScoutingJetDqmOfflineForRelVals = cms.Sequence(jetMETDQMOfflineSourceScoutingNoCorrection)
 
 hltScoutingCollectionMonitor = cms.Sequence(scoutingCollectionMonitor)
+hltScoutingDileptonMonitor = cms.Sequence(ScoutingDileptonMonitor)
 
 hltScoutingDqmOffline = cms.Sequence(hltScoutingMuonDqmOffline +
                                      hltScoutingEGammaDqmOffline +
                                      hltScoutingJetDqmOffline +
+                                     hltScoutingDileptonMonitor +
                                      hltScoutingCollectionMonitor)
 
 ## Add the scouting rechits monitoring (only for 2025, integrated in menu GRun 2025 V1.3)

--- a/HLTriggerOffline/Scouting/plugins/ScoutingDQMUtils.h
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingDQMUtils.h
@@ -11,6 +11,7 @@
 namespace scoutingDQMUtils {
 
   // Constants
+  static constexpr double MUON_MASS = 0.105658;      // Muon mass in GeV
   static constexpr double ELECTRON_MASS = 0.000511;  // Electron mass in GeV
   static constexpr double ELE_etaEB = 1.479;         // Eta restriction to barrel (for electrons)
 
@@ -21,11 +22,14 @@ namespace scoutingDQMUtils {
   }
 
   // scouting muons ID
-  inline const bool scoutingMuonID(const Run3ScoutingMuon& mu){
-        if (mu.pt() < 3.0) return false;
-        if (std::abs(mu.eta()) > 2.4) return false;
-        if (mu.normalizedChi2() > 3) return false;
-        return true;
+  inline const bool scoutingMuonID(const Run3ScoutingMuon& mu) {
+    if (mu.pt() < 3.0)
+      return false;
+    if (std::abs(mu.eta()) > 2.4)
+      return false;
+    if (mu.normalizedChi2() > 3)
+      return false;
+    return true;
   }
 
   // scouting electron IB

--- a/HLTriggerOffline/Scouting/plugins/ScoutingDQMUtils.h
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingDQMUtils.h
@@ -4,6 +4,8 @@
 #include <cmath>
 
 #include "DataFormats/Scouting/interface/Run3ScoutingElectron.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingMuon.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
 #include "FWCore/Common/interface/TriggerNames.h"
 
 namespace scoutingDQMUtils {
@@ -16,6 +18,14 @@ namespace scoutingDQMUtils {
   inline double computePtFromEnergyMassEta(double energy, double mass, double eta) {
     double transverseEnergy = std::sqrt(energy * energy - mass * mass);
     return transverseEnergy / std::cosh(eta);
+  }
+
+  // scouting muons ID
+  inline const bool scoutingMuonID(const Run3ScoutingMuon& mu){
+        if (mu.pt() < 3.0) return false;
+        if (std::abs(mu.eta()) > 2.4) return false;
+        if (mu.normalizedChi2() > 3) return false;
+        return true;
   }
 
   // scouting electron IB

--- a/HLTriggerOffline/Scouting/plugins/ScoutingDileptonMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingDileptonMonitor.cc
@@ -1,3 +1,10 @@
+// system includes
+#include <type_traits>
+#include <map>
+#include <string>
+#include <vector>
+
+// user includes
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -8,11 +15,6 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-
-#include <type_traits>
-#include <map>
-#include <string>
-#include <vector>
 
 namespace scouting {
 
@@ -61,6 +63,7 @@ private:
                  bool doEtaSplit);
 
   // ---- configuration ----------------------------------------------------
+  const std::string outputInternalPath_;
   const double massMin_;
   const double massMax_;
   const int massBins_;
@@ -82,7 +85,8 @@ private:
 };
 
 ScoutingDileptonMonitor::ScoutingDileptonMonitor(const edm::ParameterSet& iConfig)
-    : massMin_(iConfig.getParameter<double>("massMin")),
+    : outputInternalPath_{iConfig.getParameter<std::string>("OutputInternalPath")},
+      massMin_(iConfig.getParameter<double>("massMin")),
       massMax_(iConfig.getParameter<double>("massMax")),
       massBins_(iConfig.getParameter<int>("massBins")),
       zMin_(iConfig.getParameter<double>("zMassMin")),
@@ -100,7 +104,7 @@ ScoutingDileptonMonitor::ScoutingDileptonMonitor(const edm::ParameterSet& iConfi
 void ScoutingDileptonMonitor::bookHistograms(DQMStore::IBooker& ibooker,
                                              edm::Run const&,
                                              edm::EventSetup const&) {
-  ibooker.setCurrentFolder("HLT/Scouting/Dilepton");
+  ibooker.setCurrentFolder(outputInternalPath_);
 
   auto bookSet = [&](const std::string& name, MassHistos& h, bool splitEta) {
     h.full = ibooker.book1D(

--- a/HLTriggerOffline/Scouting/plugins/ScoutingDileptonMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingDileptonMonitor.cc
@@ -171,7 +171,7 @@ void ScoutingDileptonMonitor::analyzeCollection(const edm::Event& iEvent,
   edm::LogInfo("ScoutingDileptonMonitor") << "collection size: " << handle->size();
 
   for (const auto& obj : *handle) {
-    if (cut(obj)) {
+    if (!cut(obj)) {
       continue;
     }
     if (useID && !checkScoutingID(obj)) {

--- a/HLTriggerOffline/Scouting/plugins/ScoutingDileptonMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingDileptonMonitor.cc
@@ -50,6 +50,7 @@ private:
   struct MassHistos {
     MonitorElement* full{nullptr};
     MonitorElement* zwin{nullptr};
+    MonitorElement* jpsiwin{nullptr};
     MonitorElement* barrel{nullptr};
     MonitorElement* endcap{nullptr};
   };
@@ -71,8 +72,13 @@ private:
   const double massMin_;
   const double massMax_;
   const int massBins_;
+  
   const double zMin_;
   const double zMax_;
+
+  const double jpsiMin_;
+  const double jpsiMax_;
+
   const double barrelEta_;
 
   // ---- muons ------------------------------------------------------------
@@ -95,8 +101,13 @@ ScoutingDileptonMonitor::ScoutingDileptonMonitor(const edm::ParameterSet& iConfi
       massMin_(iConfig.getParameter<double>("massMin")),
       massMax_(iConfig.getParameter<double>("massMax")),
       massBins_(iConfig.getParameter<int>("massBins")),
+      
       zMin_(iConfig.getParameter<double>("zMassMin")),
       zMax_(iConfig.getParameter<double>("zMassMax")),
+
+      jpsiMin_(iConfig.getParameter<double>("jpsiMassMin")),
+      jpsiMax_(iConfig.getParameter<double>("jpsiMassMax")),
+
       barrelEta_(iConfig.getParameter<double>("barrelEta")),
 
       doMuons_(iConfig.getParameter<bool>("doMuons")),
@@ -115,7 +126,10 @@ void ScoutingDileptonMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Ru
   auto bookSet = [&](const std::string& name, MassHistos& h, bool splitEta) {
     h.full = ibooker.book1D(
         name + "_mass", name + " opposite-charge invariant mass;M [GeV];Events", massBins_, massMin_, massMax_);
+    
     h.zwin = ibooker.book1D(name + "_zMass", name + " Z window;M [GeV];Events", massBins_, zMin_, zMax_);
+
+    h.jpsiwin = ibooker.book1D(name + "_jpsiMass", name + " J/Psi window;M [GeV];Events", massBins_, jpsiMin_, jpsiMax_);
 
     if (splitEta) {
       h.barrel = ibooker.book1D(name + "_barrelMass", name + " barrel;M [GeV];Events", massBins_, massMin_, massMax_);
@@ -205,6 +219,9 @@ void ScoutingDileptonMonitor::fillPairs(const std::vector<const T*>& leptons, Ma
       if (mass > zMin_ && mass < zMax_)
         histos.zwin->Fill(mass);
 
+      if (mass > jpsiMin_ && mass < jpsiMax_)
+        histos.jpsiwin->Fill(mass);
+
       if (doEtaSplit) {
         const bool barrel = std::abs(leptons[i]->eta()) < barrelEta_ && std::abs(leptons[j]->eta()) < barrelEta_;
 
@@ -229,8 +246,13 @@ void ScoutingDileptonMonitor::fillDescriptions(edm::ConfigurationDescriptions& d
   desc.add<int>("massBins", 120);
   desc.add<double>("massMin", 0.0);
   desc.add<double>("massMax", 200.0);
+  
   desc.add<double>("zMassMin", 70.0);
   desc.add<double>("zMassMax", 110.0);
+  
+  desc.add<double>("jpsiMassMin", 2.6);
+  desc.add<double>("jpsiMassMax", 3.5);
+
   desc.add<double>("barrelEta", 1.479);
   desc.add<bool>("muonID", true);
   desc.add<bool>("electronID", true);

--- a/HLTriggerOffline/Scouting/plugins/ScoutingDileptonMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingDileptonMonitor.cc
@@ -1,0 +1,220 @@
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingElectron.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingMuon.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include <type_traits>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace scouting {
+
+  inline int charge(const Run3ScoutingMuon& mu) {
+    return mu.charge();
+  }
+
+  inline int charge(const Run3ScoutingElectron& el) {
+    return el.trkcharge()[0];
+  }
+
+  template <typename T>
+  math::PtEtaPhiMLorentzVector p4(const T& obj, double mass) {
+    return math::PtEtaPhiMLorentzVector(obj.pt(), obj.eta(), obj.phi(), mass);
+  }
+}
+
+class ScoutingDileptonMonitor : public DQMEDAnalyzer {
+public:
+  explicit ScoutingDileptonMonitor(const edm::ParameterSet&);
+  ~ScoutingDileptonMonitor() override = default;
+
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
+
+private:
+  // ---- internal structs -------------------------------------------------
+  struct MassHistos {
+    MonitorElement* full{nullptr};
+    MonitorElement* zwin{nullptr};
+    MonitorElement* barrel{nullptr};
+    MonitorElement* endcap{nullptr};
+  };
+
+  // ---- helpers ----------------------------------------------------------
+  template <typename T>
+  void analyzeCollection(const edm::Event&,
+                         const edm::EDGetTokenT<std::vector<T>>&,
+                         const StringCutObjectSelector<T>&,
+                         MassHistos&,
+                         bool doEtaSplit);
+
+  template <typename T>
+  void fillPairs(const std::vector<const T*>&,
+                 MassHistos&,
+                 bool doEtaSplit);
+
+  // ---- configuration ----------------------------------------------------
+  const double massMin_;
+  const double massMax_;
+  const int massBins_;
+  const double zMin_;
+  const double zMax_;
+  const double barrelEta_;
+
+  // ---- muons ------------------------------------------------------------
+  const bool doMuons_;
+  const edm::EDGetTokenT<std::vector<Run3ScoutingMuon>> muonToken_;
+  const StringCutObjectSelector<Run3ScoutingMuon> muonCut_;
+  MassHistos muonHistos_;
+
+  // ---- electrons --------------------------------------------------------
+  const bool doElectrons_;
+  const edm::EDGetTokenT<std::vector<Run3ScoutingElectron>> electronToken_;
+  const StringCutObjectSelector<Run3ScoutingElectron> electronCut_;
+  MassHistos electronHistos_;
+};
+
+ScoutingDileptonMonitor::ScoutingDileptonMonitor(const edm::ParameterSet& iConfig)
+    : massMin_(iConfig.getParameter<double>("massMin")),
+      massMax_(iConfig.getParameter<double>("massMax")),
+      massBins_(iConfig.getParameter<int>("massBins")),
+      zMin_(iConfig.getParameter<double>("zMassMin")),
+      zMax_(iConfig.getParameter<double>("zMassMax")),
+      barrelEta_(iConfig.getParameter<double>("barrelEta")),
+
+      doMuons_(iConfig.getParameter<bool>("doMuons")),
+      muonToken_(consumes<std::vector<Run3ScoutingMuon>>(iConfig.getParameter<edm::InputTag>("muons"))),
+      muonCut_(iConfig.getParameter<std::string>("muonCut")),
+
+      doElectrons_(iConfig.getParameter<bool>("doElectrons")),
+      electronToken_(consumes<std::vector<Run3ScoutingElectron>>(iConfig.getParameter<edm::InputTag>("electrons"))),
+      electronCut_(iConfig.getParameter<std::string>("electronCut")) {}
+
+void ScoutingDileptonMonitor::bookHistograms(DQMStore::IBooker& ibooker,
+                                             edm::Run const&,
+                                             edm::EventSetup const&) {
+  ibooker.setCurrentFolder("HLT/Scouting/Dilepton");
+
+  auto bookSet = [&](const std::string& name, MassHistos& h, bool splitEta) {
+    h.full = ibooker.book1D(
+        name + "_mass",
+        name + " opposite-charge invariant mass;M [GeV];Events",
+        massBins_, massMin_, massMax_);
+
+    h.zwin = ibooker.book1D(
+        name + "_zMass",
+        name + " Z window;M [GeV];Events",
+        massBins_, zMin_, zMax_);
+
+    if (splitEta) {
+      h.barrel = ibooker.book1D(
+          name + "_barrelMass",
+          name + " barrel;M [GeV];Events",
+          massBins_, massMin_, massMax_);
+
+      h.endcap = ibooker.book1D(
+          name + "_endcapMass",
+          name + " endcap;M [GeV];Events",
+          massBins_, massMin_, massMax_);
+    }
+  };
+
+  if (doMuons_)
+    bookSet("muons", muonHistos_, false);
+
+  if (doElectrons_)
+    bookSet("electrons", electronHistos_, true);
+}
+
+void ScoutingDileptonMonitor::analyze(edm::Event const& iEvent,
+                                      edm::EventSetup const&) {
+  if (doMuons_) {
+    analyzeCollection(iEvent, muonToken_, muonCut_, muonHistos_, false);
+  }
+
+  if (doElectrons_) {
+    analyzeCollection(iEvent, electronToken_, electronCut_, electronHistos_, true);
+  }
+}
+
+// ------------------------------------------------------------------------
+
+template <typename T>
+void ScoutingDileptonMonitor::analyzeCollection(
+    const edm::Event& iEvent,
+    const edm::EDGetTokenT<std::vector<T>>& token,
+    const StringCutObjectSelector<T>& cut,
+    MassHistos& histos,
+    bool doEtaSplit) {
+
+  edm::Handle<std::vector<T>> handle;
+  iEvent.getByToken(token, handle);
+  if (!handle.isValid())
+    return;
+
+  std::vector<const T*> selected;
+  selected.reserve(handle->size());
+
+  for (const auto& obj : *handle) {
+    if (cut(obj))
+      selected.push_back(&obj);
+  }
+
+  fillPairs(selected, histos, doEtaSplit);
+}
+
+template <typename T>
+void ScoutingDileptonMonitor::fillPairs(
+    const std::vector<const T*>& leptons,
+    MassHistos& histos,
+    bool doEtaSplit) {
+
+  constexpr double muMass = 0.105658;
+  constexpr double elMass = 0.000511;
+
+  const double massHypothesis =
+      std::is_same_v<T, Run3ScoutingMuon> ? muMass : elMass;
+
+  const size_t n = leptons.size();
+  for (size_t i = 0; i < n; ++i) {
+    for (size_t j = i + 1; j < n; ++j) {
+
+      if (scouting::charge(*leptons[i]) *
+              scouting::charge(*leptons[j]) >= 0)
+        continue;
+
+      const auto p4 =
+          scouting::p4(*leptons[i], massHypothesis) +
+          scouting::p4(*leptons[j], massHypothesis);
+
+      const double mass = p4.mass();
+
+      histos.full->Fill(mass);
+
+      if (mass > zMin_ && mass < zMax_)
+        histos.zwin->Fill(mass);
+
+      if (doEtaSplit) {
+        const bool barrel =
+            std::abs(leptons[i]->eta()) < barrelEta_ &&
+            std::abs(leptons[j]->eta()) < barrelEta_;
+
+        if (barrel)
+          histos.barrel->Fill(mass);
+        else
+          histos.endcap->Fill(mass);
+      }
+    }
+  }
+}
+
+
+
+DEFINE_FWK_MODULE(ScoutingDileptonMonitor);

--- a/HLTriggerOffline/Scouting/plugins/ScoutingDileptonMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingDileptonMonitor.cc
@@ -18,19 +18,15 @@
 
 namespace scouting {
 
-  inline int charge(const Run3ScoutingMuon& mu) {
-    return mu.charge();
-  }
+  inline int charge(const Run3ScoutingMuon& mu) { return mu.charge(); }
 
-  inline int charge(const Run3ScoutingElectron& el) {
-    return el.trkcharge()[0];
-  }
+  inline int charge(const Run3ScoutingElectron& el) { return el.trkcharge()[0]; }
 
   template <typename T>
   math::PtEtaPhiMLorentzVector p4(const T& obj, double mass) {
     return math::PtEtaPhiMLorentzVector(obj.pt(), obj.eta(), obj.phi(), mass);
   }
-}
+}  // namespace scouting
 
 class ScoutingDileptonMonitor : public DQMEDAnalyzer {
 public:
@@ -58,9 +54,7 @@ private:
                          bool doEtaSplit);
 
   template <typename T>
-  void fillPairs(const std::vector<const T*>&,
-                 MassHistos&,
-                 bool doEtaSplit);
+  void fillPairs(const std::vector<const T*>&, MassHistos&, bool doEtaSplit);
 
   // ---- configuration ----------------------------------------------------
   const std::string outputInternalPath_;
@@ -101,32 +95,19 @@ ScoutingDileptonMonitor::ScoutingDileptonMonitor(const edm::ParameterSet& iConfi
       electronToken_(consumes<std::vector<Run3ScoutingElectron>>(iConfig.getParameter<edm::InputTag>("electrons"))),
       electronCut_(iConfig.getParameter<std::string>("electronCut")) {}
 
-void ScoutingDileptonMonitor::bookHistograms(DQMStore::IBooker& ibooker,
-                                             edm::Run const&,
-                                             edm::EventSetup const&) {
+void ScoutingDileptonMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) {
   ibooker.setCurrentFolder(outputInternalPath_);
 
   auto bookSet = [&](const std::string& name, MassHistos& h, bool splitEta) {
     h.full = ibooker.book1D(
-        name + "_mass",
-        name + " opposite-charge invariant mass;M [GeV];Events",
-        massBins_, massMin_, massMax_);
+        name + "_mass", name + " opposite-charge invariant mass;M [GeV];Events", massBins_, massMin_, massMax_);
 
-    h.zwin = ibooker.book1D(
-        name + "_zMass",
-        name + " Z window;M [GeV];Events",
-        massBins_, zMin_, zMax_);
+    h.zwin = ibooker.book1D(name + "_zMass", name + " Z window;M [GeV];Events", massBins_, zMin_, zMax_);
 
     if (splitEta) {
-      h.barrel = ibooker.book1D(
-          name + "_barrelMass",
-          name + " barrel;M [GeV];Events",
-          massBins_, massMin_, massMax_);
+      h.barrel = ibooker.book1D(name + "_barrelMass", name + " barrel;M [GeV];Events", massBins_, massMin_, massMax_);
 
-      h.endcap = ibooker.book1D(
-          name + "_endcapMass",
-          name + " endcap;M [GeV];Events",
-          massBins_, massMin_, massMax_);
+      h.endcap = ibooker.book1D(name + "_endcapMass", name + " endcap;M [GeV];Events", massBins_, massMin_, massMax_);
     }
   };
 
@@ -137,8 +118,7 @@ void ScoutingDileptonMonitor::bookHistograms(DQMStore::IBooker& ibooker,
     bookSet("electrons", electronHistos_, true);
 }
 
-void ScoutingDileptonMonitor::analyze(edm::Event const& iEvent,
-                                      edm::EventSetup const&) {
+void ScoutingDileptonMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const&) {
   if (doMuons_) {
     analyzeCollection(iEvent, muonToken_, muonCut_, muonHistos_, false);
   }
@@ -151,13 +131,11 @@ void ScoutingDileptonMonitor::analyze(edm::Event const& iEvent,
 // ------------------------------------------------------------------------
 
 template <typename T>
-void ScoutingDileptonMonitor::analyzeCollection(
-    const edm::Event& iEvent,
-    const edm::EDGetTokenT<std::vector<T>>& token,
-    const StringCutObjectSelector<T>& cut,
-    MassHistos& histos,
-    bool doEtaSplit) {
-
+void ScoutingDileptonMonitor::analyzeCollection(const edm::Event& iEvent,
+                                                const edm::EDGetTokenT<std::vector<T>>& token,
+                                                const StringCutObjectSelector<T>& cut,
+                                                MassHistos& histos,
+                                                bool doEtaSplit) {
   edm::Handle<std::vector<T>> handle;
   iEvent.getByToken(token, handle);
   if (!handle.isValid())
@@ -175,28 +153,19 @@ void ScoutingDileptonMonitor::analyzeCollection(
 }
 
 template <typename T>
-void ScoutingDileptonMonitor::fillPairs(
-    const std::vector<const T*>& leptons,
-    MassHistos& histos,
-    bool doEtaSplit) {
-
+void ScoutingDileptonMonitor::fillPairs(const std::vector<const T*>& leptons, MassHistos& histos, bool doEtaSplit) {
   constexpr double muMass = 0.105658;
   constexpr double elMass = 0.000511;
 
-  const double massHypothesis =
-      std::is_same_v<T, Run3ScoutingMuon> ? muMass : elMass;
+  const double massHypothesis = std::is_same_v<T, Run3ScoutingMuon> ? muMass : elMass;
 
   const size_t n = leptons.size();
   for (size_t i = 0; i < n; ++i) {
     for (size_t j = i + 1; j < n; ++j) {
-
-      if (scouting::charge(*leptons[i]) *
-              scouting::charge(*leptons[j]) >= 0)
+      if (scouting::charge(*leptons[i]) * scouting::charge(*leptons[j]) >= 0)
         continue;
 
-      const auto p4 =
-          scouting::p4(*leptons[i], massHypothesis) +
-          scouting::p4(*leptons[j], massHypothesis);
+      const auto p4 = scouting::p4(*leptons[i], massHypothesis) + scouting::p4(*leptons[j], massHypothesis);
 
       const double mass = p4.mass();
 
@@ -206,9 +175,7 @@ void ScoutingDileptonMonitor::fillPairs(
         histos.zwin->Fill(mass);
 
       if (doEtaSplit) {
-        const bool barrel =
-            std::abs(leptons[i]->eta()) < barrelEta_ &&
-            std::abs(leptons[j]->eta()) < barrelEta_;
+        const bool barrel = std::abs(leptons[i]->eta()) < barrelEta_ && std::abs(leptons[j]->eta()) < barrelEta_;
 
         if (barrel)
           histos.barrel->Fill(mass);
@@ -218,7 +185,5 @@ void ScoutingDileptonMonitor::fillPairs(
     }
   }
 }
-
-
 
 DEFINE_FWK_MODULE(ScoutingDileptonMonitor);

--- a/HLTriggerOffline/Scouting/plugins/ScoutingDileptonMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingDileptonMonitor.cc
@@ -13,30 +13,23 @@
 #include "DataFormats/Scouting/interface/Run3ScoutingMuon.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "ScoutingDQMUtils.h"
 
-
 namespace {
-  bool checkScoutingID(const Run3ScoutingMuon& obj){
-  	return scoutingDQMUtils::scoutingMuonID(obj);
-  }
+  bool checkScoutingID(const Run3ScoutingMuon& obj) { return scoutingDQMUtils::scoutingMuonID(obj); }
 
-  bool checkScoutingID(const Run3ScoutingElectron& obj){
-	return scoutingDQMUtils::scoutingElectronID(obj);
-  } 
-
-}
+  bool checkScoutingID(const Run3ScoutingElectron& obj) { return scoutingDQMUtils::scoutingElectronID(obj); }
+}  // namespace
 
 namespace scouting {
-
   inline int charge(const Run3ScoutingMuon& mu) { return mu.charge(); }
-
   inline int charge(const Run3ScoutingElectron& el) { return el.trkcharge()[0]; }
 
- 
   template <typename T>
   math::PtEtaPhiMLorentzVector p4(const T& obj, double mass) {
     return math::PtEtaPhiMLorentzVector(obj.pt(), obj.eta(), obj.phi(), mass);
@@ -47,6 +40,7 @@ class ScoutingDileptonMonitor : public DQMEDAnalyzer {
 public:
   explicit ScoutingDileptonMonitor(const edm::ParameterSet&);
   ~ScoutingDileptonMonitor() override = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(edm::Event const&, edm::EventSetup const&) override;
@@ -67,7 +61,7 @@ private:
                          const StringCutObjectSelector<T>&,
                          MassHistos&,
                          bool doEtaSplit,
-			 bool useID);
+                         bool useID);
 
   template <typename T>
   void fillPairs(const std::vector<const T*>&, MassHistos&, bool doEtaSplit);
@@ -108,15 +102,12 @@ ScoutingDileptonMonitor::ScoutingDileptonMonitor(const edm::ParameterSet& iConfi
       doMuons_(iConfig.getParameter<bool>("doMuons")),
       muonToken_(consumes<std::vector<Run3ScoutingMuon>>(iConfig.getParameter<edm::InputTag>("muons"))),
       muonCut_(iConfig.getParameter<std::string>("muonCut")),
-      //muonID_(iConfig.getParameter<bool>("muonID") ? iConfig.getParameter<bool>("muonID") : true),
       muonID_(iConfig.getParameter<bool>("muonID")),
 
       doElectrons_(iConfig.getParameter<bool>("doElectrons")),
       electronToken_(consumes<std::vector<Run3ScoutingElectron>>(iConfig.getParameter<edm::InputTag>("electrons"))),
       electronCut_(iConfig.getParameter<std::string>("electronCut")),
-      // electronID_(iConfig.getParameter<bool>("electronID") ? iConfig.getParameter<bool>("electronID") : true) {}
       electronID_(iConfig.getParameter<bool>("electronID")) {}
-
 
 void ScoutingDileptonMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) {
   ibooker.setCurrentFolder(outputInternalPath_);
@@ -141,13 +132,14 @@ void ScoutingDileptonMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Ru
 
 void ScoutingDileptonMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const&) {
   if (doMuons_) {
-    std::cout << "doing muons: " << std::endl;
-    std::cout << "\n" << "MUON ID ::: " << muonID_ << "\n" << std::endl;
+    edm::LogInfo("ScoutingDileptonMonitor") << "doing muons: ";
+    edm::LogInfo("ScoutingDileptonMonitor") << "\n"
+                                            << "MUON ID ::: " << muonID_;
     analyzeCollection(iEvent, muonToken_, muonCut_, muonHistos_, false, muonID_);
   }
 
   if (doElectrons_) {
-    std::cout << "doing electrons: " << std::endl;
+    edm::LogInfo("ScoutingDileptonMonitor") << "doing electrons: ";
     analyzeCollection(iEvent, electronToken_, electronCut_, electronHistos_, true, electronID_);
   }
 }
@@ -160,32 +152,31 @@ void ScoutingDileptonMonitor::analyzeCollection(const edm::Event& iEvent,
                                                 const StringCutObjectSelector<T>& cut,
                                                 MassHistos& histos,
                                                 bool doEtaSplit,
-						bool useID) {
-  std::cout << "IN ANALYZE COLLECTION" << std::endl;
-  
+                                                bool useID) {
+  edm::LogInfo("ScoutingDileptonMonitor") << "IN ANALYZE COLLECTION";
+
   edm::Handle<std::vector<T>> handle;
   iEvent.getByToken(token, handle);
-  
-  if (!handle.isValid()){
-    std::cout << "Invalid Handle!" << std::endl;;
+
+  if (!handle.isValid()) {
+    edm::LogWarning("ScoutingDileptonMonitor") << "Invalid Handle!";
     return;
   } else {
-    std::cout << "Valid Handle!" << std::endl;;
+    edm::LogInfo("ScoutingDileptonMonitor") << "Valid Handle!";
   }
 
   std::vector<const T*> selected;
   selected.reserve(handle->size());
 
-  std::cout << "collection size: " << handle->size() << std::endl;
-
-  
+  edm::LogInfo("ScoutingDileptonMonitor") << "collection size: " << handle->size();
 
   for (const auto& obj : *handle) {
-    //if (cut(obj))
-    
-    if (useID && !checkScoutingID(obj)) continue;
-    
-
+    if (cut(obj)) {
+      continue;
+    }
+    if (useID && !checkScoutingID(obj)) {
+      continue;
+    }
     selected.push_back(&obj);
   }
 
@@ -194,15 +185,12 @@ void ScoutingDileptonMonitor::analyzeCollection(const edm::Event& iEvent,
 
 template <typename T>
 void ScoutingDileptonMonitor::fillPairs(const std::vector<const T*>& leptons, MassHistos& histos, bool doEtaSplit) {
-  constexpr double muMass = 0.105658;
-  constexpr double elMass = 0.000511;
-
-  const double massHypothesis = std::is_same_v<T, Run3ScoutingMuon> ? muMass : elMass;
+  const double massHypothesis =
+      std::is_same_v<T, Run3ScoutingMuon> ? scoutingDQMUtils::MUON_MASS : scoutingDQMUtils::ELECTRON_MASS;
 
   const size_t n = leptons.size();
+  edm::LogInfo("ScoutingDileptonMonitor") << "lepton size: " << n;
 
-  std::cout << "lepton size: " << n <<std::endl;
-  
   for (size_t i = 0; i < n; ++i) {
     for (size_t j = i + 1; j < n; ++j) {
       if (scouting::charge(*leptons[i]) * scouting::charge(*leptons[j]) >= 0)
@@ -227,6 +215,26 @@ void ScoutingDileptonMonitor::fillPairs(const std::vector<const T*>& leptons, Ma
       }
     }
   }
+}
+
+void ScoutingDileptonMonitor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("OutputInternalPath", "HLT/ScoutingOffline/DiLepton");
+  desc.add<edm::InputTag>("muons", edm::InputTag("hltScoutingMuonPackerVtx"));
+  desc.add<edm::InputTag>("electrons", edm::InputTag("hltScoutingEgammaPacker"));
+  desc.add<bool>("doMuons", true);
+  desc.add<bool>("doElectrons", true);
+  desc.add<std::string>("muonCut", "");
+  desc.add<std::string>("electronCut", "");
+  desc.add<int>("massBins", 120);
+  desc.add<double>("massMin", 0.0);
+  desc.add<double>("massMax", 200.0);
+  desc.add<double>("zMassMin", 70.0);
+  desc.add<double>("zMassMax", 110.0);
+  desc.add<double>("barrelEta", 1.479);
+  desc.add<bool>("muonID", true);
+  desc.add<bool>("electronID", true);
+  descriptions.addWithDefaultLabel(desc);
 }
 
 DEFINE_FWK_MODULE(ScoutingDileptonMonitor);

--- a/HLTriggerOffline/Scouting/plugins/ScoutingPi0Analyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingPi0Analyzer.cc
@@ -1,0 +1,367 @@
+// system includes
+#include <vector>
+#include <cmath>
+#include <algorithm>
+
+// user includes
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingParticle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+class ScoutingPi0Analyzer : public DQMEDAnalyzer {
+  // Helper struct to hold all histograms for a single collection (Scouting or Packed)
+  struct Pi0Histograms {
+    // Kinematics: Input Photons (before selection)
+    MonitorElement* h_input_pt;
+    MonitorElement* h_input_eta;
+    MonitorElement* h_input_phi;
+
+    // Kinematics: Selected Photons (after isolation)
+    MonitorElement* h_sel_pt;
+    MonitorElement* h_sel_eta;
+    MonitorElement* h_sel_phi;
+
+    // Cut Variables: Isolation
+    MonitorElement* h_iso_maxPtRatio;  // Max (Pt_hadron / Pt_photon) in cone
+    MonitorElement* h_iso_minDr;       // Min dR to hadron
+
+    // Cut Variables: Pairs
+    MonitorElement* h_pair_pt;    // Pair Pt
+    MonitorElement* h_pair_asym;  // Energy Asymmetry
+    MonitorElement* h_pair_dr;    // Delta R between photons
+
+    // Selected photons plots
+    MonitorElement* h_selpair_mass;        // Final Invariant Mass
+    MonitorElement* h_selpair_pt;          // Final candidate pT
+    MonitorElement* h_selpair_leadPt;      // Final candidate leading pT
+    MonitorElement* h_selpair_subleadPt;   // Final candidate sub-lead pT
+    MonitorElement* h_selpair_leadEta;     // Final candidate leading eta
+    MonitorElement* h_selpair_subleadEta;  // Final candidate sub-lead eta
+  };
+
+public:
+  explicit ScoutingPi0Analyzer(const edm::ParameterSet&);
+  ~ScoutingPi0Analyzer() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  // Helper to book a set of histograms
+  void bookHistSet(DQMStore::IBooker& ibook, Pi0Histograms& hists, const std::string& suffix);
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  // Templated analysis function to handle both Scouting and PAT types
+  template <typename T>
+  void analyzeCollection(const edm::Handle<std::vector<T>>& handle, MonitorElement* hist);
+
+  // Tokens
+  const edm::EDGetTokenT<std::vector<Run3ScoutingParticle>> scoutingToken_;
+
+  // Configuration parameters
+  const std::string outputInternalPath_;
+  const double minPt_;
+  const double maxEta_;
+  const double isolationConeSq_;
+  const double isolationPtRatio_;
+  const double pairMaxDrSq_;
+  const double asymmetryCut_;
+  const double pairMinPt_;
+  const double maxMass_;
+
+  // Histograms
+  Pi0Histograms h_scouting;
+  MonitorElement* h_mass_scouting;
+};
+
+ScoutingPi0Analyzer::ScoutingPi0Analyzer(const edm::ParameterSet& iConfig)
+    : scoutingToken_(
+          consumes<std::vector<Run3ScoutingParticle>>(iConfig.getParameter<edm::InputTag>("scoutingCollection"))),
+      outputInternalPath_{iConfig.getParameter<std::string>("OutputInternalPath")},
+      minPt_(iConfig.getParameter<double>("minPt")),
+      maxEta_(iConfig.getParameter<double>("maxEta")),
+      isolationConeSq_(std::pow(iConfig.getParameter<double>("isolationCone"), 2)),
+      isolationPtRatio_(iConfig.getParameter<double>("isolationPtRatio")),
+      pairMaxDrSq_(std::pow(iConfig.getParameter<double>("pairMaxDr"), 2)),
+      asymmetryCut_(iConfig.getParameter<double>("asymmetryCut")),
+      pairMinPt_(iConfig.getParameter<double>("pairMinPt")),
+      maxMass_(iConfig.getParameter<double>("maxMass")) {}
+
+void ScoutingPi0Analyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("scoutingCollection", edm::InputTag("hltScoutingPFPacker"));
+  desc.add<std::string>("OutputInternalPath", "HLT/ScoutingOffline/PiZero");
+  desc.add<double>("minPt", 1.5)->setComment("minimum pT of input photons");
+  desc.add<double>("maxEta", 2.5)->setComment("maximum eta of input photons");
+  desc.add<double>("isolationCone", 0.2)->setComment("isolation cone radius");  // will be squared internally
+  desc.add<double>("isolationPtRatio", 0.8)->setComment("charged hadron isolation ratio");
+  desc.add<double>("pairMaxDr", 0.1)->setComment("maximum DeltaR between photons");  // will be squared internally
+  desc.add<double>("asymmetryCut", 0.85)->setComment("Energy asymmetry cut value");
+  desc.add<double>("pairMinPt", 2.0)->setComment("mimimum pT of the di-photon");
+  desc.add<double>("maxMass", 1.)->setComment("maximum invariant mass accepted");
+  descriptions.addWithDefaultLabel(desc);
+}
+
+void ScoutingPi0Analyzer::bookHistSet(DQMStore::IBooker& ibook, Pi0Histograms& h, const std::string& suffix) {
+  // Input Kinematics
+  h.h_input_pt = ibook.book1D(("h_input_pt_" + suffix).c_str(),
+                              ("Input Photon p_{T} (" + suffix + ")#gamma ;p_{T} [GeV];Entries").c_str(),
+                              50,
+                              0,
+                              20);
+  h.h_input_eta = ibook.book1D(("h_input_eta_" + suffix).c_str(),
+                               ("Input Photon #eta (" + suffix + ")#gamma ;#eta;Entries").c_str(),
+                               60,
+                               -3.0,
+                               3.0);
+  h.h_input_phi = ibook.book1D(("h_input_phi_" + suffix).c_str(),
+                               ("Input Photon #phi (" + suffix + ");#gamma #phi;Entries").c_str(),
+                               64,
+                               -3.2,
+                               3.2);
+
+  // Selected Kinematics
+  h.h_sel_pt = ibook.book1D(("h_sel_pt_" + suffix).c_str(),
+                            ("Selected Photon p_{T} (" + suffix + ");#gamma p_{T} [GeV];Entries").c_str(),
+                            50,
+                            0,
+                            20);
+  h.h_sel_eta = ibook.book1D(("h_sel_eta_" + suffix).c_str(),
+                             ("Selected Photon #eta (" + suffix + ");#gamma #eta;Entries").c_str(),
+                             60,
+                             -3.0,
+                             3.0);
+  h.h_sel_phi = ibook.book1D(("h_sel_phi_" + suffix).c_str(),
+                             ("Selected Photon #phi (" + suffix + ");#gamma #phi;Entries").c_str(),
+                             64,
+                             -3.2,
+                             3.2);
+
+  // Cut Variables: Isolation
+  h.h_iso_maxPtRatio = ibook.book1D(("h_iso_maxPtRatio_" + suffix).c_str(),
+                                    ("Max Hadron p_{T} / Photon p_{T} in Cone (" + suffix + ");Ratio;Entries").c_str(),
+                                    50,
+                                    0,
+                                    2.0);
+  h.h_iso_minDr = ibook.book1D(("h_iso_minDr_" + suffix).c_str(),
+                               ("Min #Delta R #gamma to Hadron (" + suffix + ");#Delta R(#gamma,had);Entries").c_str(),
+                               50,
+                               0,
+                               0.5);
+
+  // Cut Variables: Pairs
+  h.h_pair_pt = ibook.book1D(("h_pair_pt_" + suffix).c_str(),
+                             ("Diphoton p_{T} (" + suffix + ");#gamma#gamma p_{T} [GeV];Entries").c_str(),
+                             50,
+                             0,
+                             50);
+  h.h_pair_asym = ibook.book1D(
+      ("h_pair_asym_" + suffix).c_str(),
+      ("Diphoton Energy Asymmetry (" + suffix + ");|E_{#gamma 1}-E_{#gamma 2}|/(E_{#gamma 1}+E_{#gamma 2});Entries")
+          .c_str(),
+      50,
+      0,
+      1.0);
+  h.h_pair_dr = ibook.book1D(("h_pair_dr_" + suffix).c_str(),
+                             ("Diphoton #Delta R (" + suffix + ");#Delta R(#gamma,#gamma);Entries").c_str(),
+                             50,
+                             0,
+                             1.0);
+
+  // Selected final di-photons plots
+  h.h_selpair_mass = ibook.book1D(("h_mass_" + suffix).c_str(),
+                                  ("Diphoton Invariant Mass (" + suffix + ");M_{#gamma#gamma} [GeV];Entries").c_str(),
+                                  100,
+                                  0,
+                                  1.0);
+
+  h.h_selpair_pt = ibook.book1D(("h_selpair_pt_" + suffix).c_str(),
+                                ("Selected Diphoton p_{T} (" + suffix + ");#gamma#gamma p_{T} [GeV];Entries").c_str(),
+                                50,
+                                0,
+                                50);
+
+  // Selected final photons kinematics
+  h.h_selpair_leadPt =
+      ibook.book1D(("h_selpair_leadPt_" + suffix).c_str(),
+                   ("Leading Photon p_{T} (" + suffix + ");leading #gamma p_{T} [GeV];Entries").c_str(),
+                   50,
+                   0,
+                   50);
+  h.h_selpair_leadEta = ibook.book1D(("h_selpair_leadEta_" + suffix).c_str(),
+                                     ("Leading Photon #eta (" + suffix + ");leading #gamma #eta;Entries").c_str(),
+                                     60,
+                                     -3.0,
+                                     3.0);
+
+  h.h_selpair_subleadPt =
+      ibook.book1D(("h_selpair_subleadPt_" + suffix).c_str(),
+                   ("Subleading Photon p_{T} (" + suffix + ");subleading #gamma p_{T} [GeV];Entries").c_str(),
+                   50,
+                   0,
+                   50);
+  h.h_selpair_subleadEta =
+      ibook.book1D(("h_selpair_subleadEta_" + suffix).c_str(),
+                   ("Subleading Photon #eta (" + suffix + ");subleading #gamma #eta;Entries").c_str(),
+                   60,
+                   -3.0,
+                   3.0);
+}
+
+void ScoutingPi0Analyzer::bookHistograms(DQMStore::IBooker& ibook, edm::Run const&, edm::EventSetup const&) {
+  ibook.setCurrentFolder(outputInternalPath_);
+
+  // Scouting Histogram
+  h_mass_scouting =
+      ibook.book1D("h_mass_scouting", "Diphoton Mass (Scouting);Invariant Mass [GeV];Entries", 100, 0.0, maxMass_);
+
+  bookHistSet(ibook, h_scouting, "Scouting");
+}
+
+void ScoutingPi0Analyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // 1. Analyze Scouting Particles
+  edm::Handle<std::vector<Run3ScoutingParticle>> scoutingHandle;
+  iEvent.getByToken(scoutingToken_, scoutingHandle);
+  if (scoutingHandle.isValid()) {
+    analyzeCollection(scoutingHandle, h_mass_scouting);
+  }
+}
+
+template <typename T>
+void ScoutingPi0Analyzer::analyzeCollection(const edm::Handle<std::vector<T>>& handle, MonitorElement* hist) {
+  std::vector<const T*> photons;
+  std::vector<const T*> hadrons;
+  photons.reserve(handle->size());
+  hadrons.reserve(handle->size());
+
+  // 1. Selection and Categorization
+  for (const auto& cand : *handle) {
+    if (cand.pt() < minPt_)
+      continue;
+    if (std::abs(cand.eta()) > maxEta_)
+      continue;
+
+    int pdgId = std::abs(cand.pdgId());
+
+    if (pdgId == 22) {  // Photon
+      photons.push_back(&cand);
+
+      // Diagnostic: Input Kinematics
+      h_scouting.h_input_pt->Fill(cand.pt());
+      h_scouting.h_input_eta->Fill(cand.eta());
+      h_scouting.h_input_phi->Fill(cand.phi());
+
+    } else if (pdgId == 211 || pdgId == 130 || pdgId == 321 || pdgId == 2212) {  // Hadrons
+      hadrons.push_back(&cand);
+    }
+  }
+
+  // 2. Isolation Logic
+  std::vector<const T*> good_photons;
+  good_photons.reserve(photons.size());
+
+  for (const auto* g : photons) {
+    bool is_isolated = true;
+    double max_pt_ratio = -1.0;
+    double min_dr = 999.0;
+
+    for (const auto* h : hadrons) {
+      double dr2 = reco::deltaR2(*g, *h);
+      double dr = std::sqrt(dr2);
+
+      // Track closest hadron for diagnostics
+      if (dr < min_dr)
+        min_dr = dr;
+
+      // Isolation Check
+      if (dr2 < isolationConeSq_) {
+        double ratio = h->pt() / g->pt();
+        if (ratio > max_pt_ratio)
+          max_pt_ratio = ratio;  // Track worst ratio
+
+        if (ratio > isolationPtRatio_) {
+          is_isolated = false;
+          // Note: We don't break here so we can find the true max_pt_ratio for plotting
+        }
+      }
+    }
+
+    // Diagnostic: Isolation variables (N-1 style not fully possible without loop overhead,
+    // but we plot the "worst offender" variables)
+    if (max_pt_ratio >= 0)
+      h_scouting.h_iso_maxPtRatio->Fill(max_pt_ratio);
+    if (min_dr < 999)
+      h_scouting.h_iso_minDr->Fill(min_dr);
+
+    if (is_isolated) {
+      good_photons.push_back(g);
+      // Diagnostic: Selected Kinematics
+      h_scouting.h_sel_pt->Fill(g->pt());
+      h_scouting.h_sel_eta->Fill(g->eta());
+      h_scouting.h_sel_phi->Fill(g->phi());
+    }
+  }
+
+  // 3. Combinatorics
+  // Logic from script: limit to 30 good photons to prevent combinatorial explosion
+  size_t n_good = std::min(good_photons.size(), size_t(100));
+
+  for (size_t i = 0; i < n_good; ++i) {
+    const auto* g1 = good_photons[i];
+
+    for (size_t j = i + 1; j < n_good; ++j) {
+      const auto* g2 = good_photons[j];
+
+      // Manual p4 reconstruction to match script's "mass=0" assumption for photons
+      // (Run3ScoutingParticle has mass, but we treat it as photon here)
+      math::PtEtaPhiMLorentzVector p4_1(g1->pt(), g1->eta(), g1->phi(), 0.0);
+      math::PtEtaPhiMLorentzVector p4_2(g2->pt(), g2->eta(), g2->phi(), 0.0);
+
+      auto p4_gg = p4_1 + p4_2;
+
+      double E1 = p4_1.energy();
+      double E2 = p4_2.energy();
+      double asym = std::abs(E1 - E2) / (E1 + E2);
+      double dr_gg = reco::deltaR(*g1, *g2);
+
+      // Diagnostic: Fill variables before pair cuts
+      h_scouting.h_pair_pt->Fill(p4_gg.pt());
+      h_scouting.h_pair_asym->Fill(asym);
+      h_scouting.h_pair_dr->Fill(dr_gg);
+
+      // Cuts
+      if (p4_gg.pt() < pairMinPt_)
+        continue;
+      if (asym > asymmetryCut_)
+        continue;
+      if (dr_gg * dr_gg > pairMaxDrSq_)
+        continue;  // Note: script used 0.5^2
+      if (p4_gg.mass() > maxMass_)
+        continue;
+
+      h_scouting.h_selpair_mass->Fill(p4_gg.mass());
+      h_scouting.h_selpair_pt->Fill(p4_gg.pt());
+
+      const auto& lead_p4 = (p4_1.pt() > p4_2.pt()) ? p4_1 : p4_2;
+      const auto& sub_p4 = (p4_1.pt() > p4_2.pt()) ? p4_2 : p4_1;
+
+      h_scouting.h_selpair_leadPt->Fill(lead_p4.pt());
+      h_scouting.h_selpair_subleadPt->Fill(sub_p4.pt());
+
+      h_scouting.h_selpair_leadEta->Fill(lead_p4.eta());
+      h_scouting.h_selpair_subleadEta->Fill(sub_p4.eta());
+
+      // Fill Histogram
+      hist->Fill(p4_gg.mass());
+    }
+  }
+}
+
+DEFINE_FWK_MODULE(ScoutingPi0Analyzer);

--- a/HLTriggerOffline/Scouting/python/HLTScoutingDileptonMonitor_cfi.py
+++ b/HLTriggerOffline/Scouting/python/HLTScoutingDileptonMonitor_cfi.py
@@ -14,5 +14,8 @@ ScoutingDileptonMonitor = DQMEDAnalyzer("ScoutingDileptonMonitor",
                                         massMax  = cms.double(200.0),                                            
                                         zMassMin = cms.double(70.0),
                                         zMassMax = cms.double(110.0),                                            
-                                        barrelEta = cms.double(1.479)
+                                        barrelEta = cms.double(1.479),
+
+                                        muonID = cms.bool(True),
+                                        electronID = cms.bool(True)
                                         )

--- a/HLTriggerOffline/Scouting/python/HLTScoutingDileptonMonitor_cfi.py
+++ b/HLTriggerOffline/Scouting/python/HLTScoutingDileptonMonitor_cfi.py
@@ -4,8 +4,10 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 ScoutingDileptonMonitor = DQMEDAnalyzer("ScoutingDileptonMonitor",
                                         OutputInternalPath = cms.string('HLT/ScoutingOffline/DiLepton'), #Output of the root file
                                         muons     = cms.InputTag("hltScoutingMuonPackerVtx"),
+                                        muonsNoVtx  = cms.InputTag("hltScoutingMuonPackerNoVtx"),
                                         electrons = cms.InputTag("hltScoutingEgammaPacker"),
                                         doMuons     = cms.bool(True),
+                                        doMuonsNoVtx  = cms.bool(True),
                                         doElectrons = cms.bool(True),
                                         muonCut     = cms.string(""), #cms.string("pt > 3 && abs(eta) < 2.4"),
                                         electronCut = cms.string(""), #cms.string("pt > 3 && abs(eta) < 2.5"),

--- a/HLTriggerOffline/Scouting/python/HLTScoutingDileptonMonitor_cfi.py
+++ b/HLTriggerOffline/Scouting/python/HLTScoutingDileptonMonitor_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
 ScoutingDileptonMonitor = DQMEDAnalyzer("ScoutingDileptonMonitor",
+                                        OutputInternalPath = cms.string('HLT/ScoutingOffline/DiLepton'), #Output of the root file
                                         muons     = cms.InputTag("hltScoutingMuonPacker"),
                                         electrons = cms.InputTag("hltScoutingElectronPacker"),
                                         doMuons     = cms.bool(True),

--- a/HLTriggerOffline/Scouting/python/HLTScoutingDileptonMonitor_cfi.py
+++ b/HLTriggerOffline/Scouting/python/HLTScoutingDileptonMonitor_cfi.py
@@ -6,16 +6,14 @@ ScoutingDileptonMonitor = DQMEDAnalyzer("ScoutingDileptonMonitor",
                                         muons     = cms.InputTag("hltScoutingMuonPackerVtx"),
                                         electrons = cms.InputTag("hltScoutingEgammaPacker"),
                                         doMuons     = cms.bool(True),
-                                        doElectrons = cms.bool(True),                                            
-                                        muonCut     = cms.string("pt > 3 && abs(eta) < 2.4"),
-                                        electronCut = cms.string("pt > 3 && abs(eta) < 2.5"),                           
+                                        doElectrons = cms.bool(True),
+                                        muonCut     = cms.string(""), #cms.string("pt > 3 && abs(eta) < 2.4"),
+                                        electronCut = cms.string(""), #cms.string("pt > 3 && abs(eta) < 2.5"),
                                         massBins = cms.int32(120),
                                         massMin  = cms.double(0.0),
-                                        massMax  = cms.double(200.0),                                            
+                                        massMax  = cms.double(200.0),
                                         zMassMin = cms.double(70.0),
-                                        zMassMax = cms.double(110.0),                                            
+                                        zMassMax = cms.double(110.0),
                                         barrelEta = cms.double(1.479),
-
                                         muonID = cms.bool(True),
-                                        electronID = cms.bool(True)
-                                        )
+                                        electronID = cms.bool(True))

--- a/HLTriggerOffline/Scouting/python/HLTScoutingDileptonMonitor_cfi.py
+++ b/HLTriggerOffline/Scouting/python/HLTScoutingDileptonMonitor_cfi.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+
+ScoutingDileptonMonitor = DQMEDAnalyzer("ScoutingDileptonMonitor",
+                                        muons     = cms.InputTag("hltScoutingMuonPacker"),
+                                        electrons = cms.InputTag("hltScoutingElectronPacker"),
+                                        doMuons     = cms.bool(True),
+                                        doElectrons = cms.bool(True),                                            
+                                        muonCut     = cms.string("pt > 5 && abs(eta) < 2.4"),
+                                        electronCut = cms.string("pt > 7 && abs(eta) < 2.5"),                           
+                                        massBins = cms.int32(120),
+                                        massMin  = cms.double(0.0),
+                                        massMax  = cms.double(200.0),                                            
+                                        zMassMin = cms.double(70.0),
+                                        zMassMax = cms.double(110.0),                                            
+                                        barrelEta = cms.double(1.479)
+                                        )

--- a/HLTriggerOffline/Scouting/python/HLTScoutingDileptonMonitor_cfi.py
+++ b/HLTriggerOffline/Scouting/python/HLTScoutingDileptonMonitor_cfi.py
@@ -3,12 +3,12 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
 ScoutingDileptonMonitor = DQMEDAnalyzer("ScoutingDileptonMonitor",
                                         OutputInternalPath = cms.string('HLT/ScoutingOffline/DiLepton'), #Output of the root file
-                                        muons     = cms.InputTag("hltScoutingMuonPacker"),
-                                        electrons = cms.InputTag("hltScoutingElectronPacker"),
+                                        muons     = cms.InputTag("hltScoutingMuonPackerVtx"),
+                                        electrons = cms.InputTag("hltScoutingEgammaPacker"),
                                         doMuons     = cms.bool(True),
                                         doElectrons = cms.bool(True),                                            
-                                        muonCut     = cms.string("pt > 5 && abs(eta) < 2.4"),
-                                        electronCut = cms.string("pt > 7 && abs(eta) < 2.5"),                           
+                                        muonCut     = cms.string("pt > 3 && abs(eta) < 2.4"),
+                                        electronCut = cms.string("pt > 3 && abs(eta) < 2.5"),                           
                                         massBins = cms.int32(120),
                                         massMin  = cms.double(0.0),
                                         massMax  = cms.double(200.0),                                            

--- a/HLTriggerOffline/Scouting/python/HLTScoutingPi0Monitor_cfi.py
+++ b/HLTriggerOffline/Scouting/python/HLTScoutingPi0Monitor_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+
+ScoutingPi0Monitor = DQMEDAnalyzer("ScoutingPi0Analyzer",
+                                   scoutingCollection = cms.InputTag('hltScoutingPFPacker'),
+                                   minPt = cms.double(1.5),
+                                   maxEta = cms.double(2.5),
+                                   isolationCone = cms.double(0.2),
+                                   isolationPtRatio = cms.double(0.8),
+                                   pairMaxDr = cms.double(0.1),
+                                   asymmetryCut = cms.double(0.85),
+                                   pairMinPt = cms.double(2),
+                                   maxMass = cms.double(1.))
+

--- a/HLTriggerOffline/Scouting/python/ScoutingRecHitAnalyzers_cff.py
+++ b/HLTriggerOffline/Scouting/python/ScoutingRecHitAnalyzers_cff.py
@@ -15,6 +15,10 @@ ScoutingEBRechitAnalyzer = DQMEDAnalyzer('ScoutingEBRecHitAnalyzer',
                                              )
                                          ))
 
+ScoutingEBCleanedRechitAnalyzer = ScoutingEBRechitAnalyzer.clone(
+                                         src = cms.InputTag ("hltScoutingRecHitPacker", "EBCleaned"),
+                                         topFolderName = cms.string('HLT/ScoutingOffline/EBCleanedRechits'))
+
 ScoutingHBHERechitAnalyzer = DQMEDAnalyzer('ScoutingHBHERecHitAnalyzer',
                                            src = cms.InputTag("hltScoutingRecHitPacker", "HBHE"),
                                            L1TriggerResults = cms.InputTag('L1BitsScouting'),
@@ -37,4 +41,5 @@ L1BitsScouting = _l1bits.clone(src="gtStage2Digis")
 
 hltScoutingMonitoringRecHits = cms.Sequence(L1BitsScouting +
                                             ScoutingEBRechitAnalyzer +
+                                            ScoutingEBCleanedRechitAnalyzer +
                                             ScoutingHBHERechitAnalyzer)


### PR DESCRIPTION
Verbatim backport of https://github.com/cms-sw/cmssw/pull/50176

#### PR description:

This PR introduces two new DQMEDAnalyzer modules, `ScoutingDileptonMonitor` and `ScoutingPi0Analyzer`, and performs a label cleanup in the existing `ScoutingCollectionMonitor` and `ScoutingRechitMonitoring`.

`ScoutingDileptonMonitor`: monitors the full invariant mass spectrum for both dielectrons and dimuons. It utilizes `hltScoutingMuonPackerVtx` and `hltScoutingMuonPackerNoVtx` for muons, and `hltScoutingEgammaPacker` for electrons. We require leptons to have opposite charges and satisfy specific electron and muon ID requirements (also introduced in this PR). The analyzer includes a barrel/endcap split for electrons and provides dedicated "zoom" views for the Z and J/ψ resonance windows.

`ScoutingPi0Analyzer`: monitors the π0→γγ decay. It implements a reduction to the combinatorial background, producing a diphoton invariant mass spectrum in the expected signal range.

`ScoutingCollectionMonitor` updates: histogram titles and labels have been updated for better readability, concretely replacing PDG IDs with the names of the particle.

`ScoutingRechitMonitoring` updates: following discussions in the HLT Scouting meeting, we have updated the labelling of RecHit monitoring. The previous "All" and "Cleaned" labels were misleading and have been renamed to "Accepted" and "Rejected" for better clarity.


#### PR validation:

This PR was validated as follows:
```
cmsrel CMSSW_16_0_X_2026-02-17-2300
cd CMSSW_16_0_X_2026-02-17-2300/src 
cmsenv
git cms-addpkg DQM/HLTEvF DQM/Integration DQMOffline/HLTScouting HLTriggerOffline/Scouting
scram b -j
scram b code-format && scram b code-checks
scram b -j 
```

The workflow was tested with:
```
runTheMatrix.py -l  145.415 -t 4 -j 8 
```
and
```
cmsRun DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py inputFiles=/eos/cms/store/group/tsg-phase2/user/jprendi/NERD25/MoreStats/EGammas/HLT/HLT_run_398858_job6_Scouting.root
```

Running `git cms-checkdeps -a -A` shows further dependencies to DQMOffline/Configuration`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is is the backport of https://github.com/cms-sw/cmssw/pull/50176 .

<!-- Please delete the text above after you verified all points of the checklist  -->
