### PR TITLE
[16.0.X] `conddblib`: add an option `onlinepro` to `officialdbs` to point to `FrontierProd` servlet

### DIFF
--- a/CondCore/Utilities/python/conddblib.py
+++ b/CondCore/Utilities/python/conddblib.py
@@ -494,6 +494,7 @@ def make_url(database='pro',read_only = True):
     officialdbs = { 
         # frontier 
         'pro' :         ('frontier','PromptProd',             { 'R': schema_name }, ),
+        'onlinepro' :   ('frontier','FrontierProd',           { 'R': schema_name }, ),
         'arc' :         ('frontier','FrontierArc',            { 'R': schema_name }, ),
         'int' :         ('frontier','FrontierInt',            { 'R': schema_name }, ),
         'dev' :         ('frontier','FrontierPrep',           { 'R': schema_name }, ),


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/50180

#### PR description:

Title say is all, otherwise `conddb list ...` doesn't work in the P5 network (not sure why we need to use the Tier0 Frontier servlet for this service)

#### PR validation:

On e.g. `devfu-c2b03-44-01`:

```
$ conddb list EcalPedestals_NGTDemonstrator
[2026-02-18 22:07:12,882] INFO: Connecting to pro [frontier://PromptProd/cms_conditions]
/data/cmssw/el8_amd64_gcc13/external/py3-sqlalchemy/1.3.24-17fe1f9904f20d3dec1c52d6c4325157/lib/python3.9/site-packages/sqlalchemy/engine/default.py:408: SAWarning: Exception attempting to detect unicode returns: ProgrammingError("(frontier.ProgrammingError) Error while fetching data: (-8, b'[frontier.c:1136]: No more proxies. Last error was: Request 8 on chan 1 failed at Wed Feb 18 22:07:12 2026: -8 [fn-htclient.c:444]: server error (HTTP/1.1 404 Not Found) proxy=localhost[[::1]:3128] server=localhost')")
  util.warn(
/data/cmssw/el8_amd64_gcc13/external/py3-sqlalchemy/1.3.24-17fe1f9904f20d3dec1c52d6c4325157/lib/python3.9/site-packages/sqlalchemy/engine/default.py:408: SAWarning: Exception attempting to detect unicode returns: ProgrammingError("(frontier.ProgrammingError) Error while fetching data: (-8, b'[frontier.c:1136]: No more proxies. Last error was: Request 16 on chan 1 failed at Wed Feb 18 22:07:12 2026: -8 [fn-htclient.c:444]: server error (HTTP/1.1 404 Not Found) proxy=localhost[[::1]:3128] server=localhost')")
  util.warn(
/data/cmssw/el8_amd64_gcc13/external/py3-sqlalchemy/1.3.24-17fe1f9904f20d3dec1c52d6c4325157/lib/python3.9/site-packages/sqlalchemy/engine/default.py:408: SAWarning: Exception attempting to detect unicode returns: ProgrammingError("(frontier.ProgrammingError) Error while fetching data: (-8, b'[frontier.c:1136]: No more proxies. Last error was: Request 24 on chan 1 failed at Wed Feb 18 22:07:12 2026: -8 [fn-htclient.c:444]: server error (HTTP/1.1 404 Not Found) proxy=localhost[[::1]:3128] server=localhost')")
  util.warn(
[2026-02-18 22:07:12,942] ERROR: (frontier.ProgrammingError) Error while fetching data: (-8, b'[frontier.c:1136]: No more proxies. Last error was: Request 32 on chan 1 failed at Wed Feb 18 22:07:12 2026: -8 [fn-htclient.c:444]: server error (HTTP/1.1 404 Not Found) proxy=localhost[[::1]:3128] server=localhost')
[SQL: b'SELECT table_name FROM all_tables WHERE table_name = :name AND owner = :schema_name']
[parameters: {b'name': 'TAG', b'schema_name': 'CMS_CONDITIONS'}]
(Background on this error at: http://sqlalche.me/e/13/f405)
```
but

```
$ conddb --db onlinepro list EcalPedestals_NGTDemonstrator
[2026-02-18 22:07:34,543] INFO: Connecting to onlinepro [frontier://FrontierProd/cms_conditions]
[2026-02-18 22:07:34,612] INFO: Listing with a limit of 500 IOVs, starting from the highest since. If you need to see more, please increase the limit of returned results.
Since: Run   Insertion Time       Payload                                   Object Type                             
-----------  -------------------  ----------------------------------------  -------------------------------------   
390000       2025-10-24 08:40:18  77ba0f6609705b43091699e56d66ff3e4e4c9ba6  EcalCondObjectContainer<EcalPedestal>   
390131       2025-10-24 08:40:18  745f6fd6561e0a2f357f4056a2fbe56d29f7d02b  EcalCondObjectContainer<EcalPedestal>   
390733       2025-10-24 08:40:18  41e9d4df664f3254fa13d633eee39795b015ee1d  EcalCondObjectContainer<EcalPedestal>   
390939       2025-10-24 08:40:18  db16c45a42dadd1cf2ce45b20e8916544520ed44  EcalCondObjectContainer<EcalPedestal>   
...
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:


plain backport of https://github.com/cms-sw/cmssw/pull/50180 to the 2026 data-taking release.