### PR TITLE
Optimise directory checks in DirManager [16.0.x]

### DIFF
--- a/EventFilter/Utilities/interface/DirManager.h
+++ b/EventFilter/Utilities/interface/DirManager.h
@@ -17,7 +17,7 @@ namespace evf {
     unsigned int findHighestRun();
     std::string findHighestRunDir();
     std::string findRunDir(unsigned int);
-    bool checkDirEmpty(std::string &);
+    bool checkDirEmpty(const std::string &);
 
   private:
     std::string dir_;  // this is the base dir with all runs in it

--- a/EventFilter/Utilities/src/DirManager.cc
+++ b/EventFilter/Utilities/src/DirManager.cc
@@ -61,12 +61,13 @@ namespace evf {
     return retval;
   }
 
-  bool DirManager::checkDirEmpty(std::string &d) {
+  bool DirManager::checkDirEmpty(const std::string &d) {
     int filecount = 0;
     DIR *dir = opendir(d.c_str());
     while (readdir(dir)) {
       filecount++;
     }
+    closedir(dir);
     return (filecount == 0);
   }
 }  // namespace evf

--- a/EventFilter/Utilities/src/DirManager.cc
+++ b/EventFilter/Utilities/src/DirManager.cc
@@ -1,6 +1,9 @@
 #include "EventFilter/Utilities/interface/DirManager.h"
 #include "FWCore/Utilities/interface/Exception.h"
+
 #include <iostream>
+#include <string>
+#include <string_view>
 
 namespace evf {
 
@@ -11,11 +14,11 @@ namespace evf {
     while ((buf = readdir(dir))) {
       if (buf->d_type != DT_DIR and buf->d_type != DT_UNKNOWN)
         continue;
-      std::string dirnameNum = buf->d_name;
-      if (dirnameNum.find("run") != std::string::npos)
-        dirnameNum = dirnameNum.substr(3, std::string::npos);
-      if (atoi(dirnameNum.c_str()) > maxrun) {
-        maxrun = atoi(dirnameNum.c_str());
+      std::string_view dirnameNum = buf->d_name;
+      if (dirnameNum.starts_with("run"))
+        dirnameNum.remove_prefix(3);
+      if (int run = atoi(dirnameNum.data()); run > maxrun) {
+        maxrun = run;
       }
     }
     closedir(dir);
@@ -31,12 +34,12 @@ namespace evf {
     while ((buf = readdir(dir))) {
       if (buf->d_type != DT_DIR and buf->d_type != DT_UNKNOWN)
         continue;
-      std::string dirnameNum = buf->d_name;
-      if (dirnameNum.find("run") != std::string::npos)
-        dirnameNum = dirnameNum.substr(3, std::string::npos);
-      if (atoi(dirnameNum.c_str()) > maxrun) {
+      std::string_view dirnameNum = buf->d_name;
+      if (dirnameNum.starts_with("run"))
+        dirnameNum.remove_prefix(3);
+      if (int run = atoi(dirnameNum.data()); run > maxrun) {
         tmpdir = buf->d_name;
-        maxrun = atoi(dirnameNum.c_str());
+        maxrun = run;
       }
     }
     closedir(dir);
@@ -52,10 +55,10 @@ namespace evf {
     while ((buf = readdir(dir))) {
       if (buf->d_type != DT_DIR and buf->d_type != DT_UNKNOWN)
         continue;
-      std::string dirnameNum = buf->d_name;
-      if (dirnameNum.find("run") != std::string::npos)
-        dirnameNum = dirnameNum.substr(3, std::string::npos);
-      if ((unsigned int)atoi(dirnameNum.c_str()) == run) {
+      std::string_view dirnameNum = buf->d_name;
+      if (dirnameNum.starts_with("run"))
+        dirnameNum.remove_prefix(3);
+      if ((unsigned int)atoi(dirnameNum.data()) == run) {
         tmpdir = buf->d_name;
         break;
       }

--- a/EventFilter/Utilities/src/DirManager.cc
+++ b/EventFilter/Utilities/src/DirManager.cc
@@ -9,6 +9,8 @@ namespace evf {
     struct dirent *buf;
     int maxrun = 0;
     while ((buf = readdir(dir))) {
+      if (buf->d_type != DT_DIR and buf->d_type != DT_UNKNOWN)
+        continue;
       std::string dirnameNum = buf->d_name;
       if (dirnameNum.find("run") != std::string::npos)
         dirnameNum = dirnameNum.substr(3, std::string::npos);
@@ -27,6 +29,8 @@ namespace evf {
     struct dirent *buf;
     int maxrun = 0;
     while ((buf = readdir(dir))) {
+      if (buf->d_type != DT_DIR and buf->d_type != DT_UNKNOWN)
+        continue;
       std::string dirnameNum = buf->d_name;
       if (dirnameNum.find("run") != std::string::npos)
         dirnameNum = dirnameNum.substr(3, std::string::npos);
@@ -46,6 +50,8 @@ namespace evf {
     DIR *dir = opendir(dir_.c_str());
     struct dirent *buf;
     while ((buf = readdir(dir))) {
+      if (buf->d_type != DT_DIR and buf->d_type != DT_UNKNOWN)
+        continue;
       std::string dirnameNum = buf->d_name;
       if (dirnameNum.find("run") != std::string::npos)
         dirnameNum = dirnameNum.substr(3, std::string::npos);


### PR DESCRIPTION
#### PR description:

Optimise the checks in `DirManager`:
  - skip non-directory entries
  - use `string_view` instead of `string` to avoid memory copies
  - cache conversion from string to integer

#### PR validation:

None.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #50184 to 16.0.x.