### PR TITLE
Drop explicit dependency on stdc++fs which is now part of stdc++ since GCC8/c++17

### DIFF
--- a/Alignment/OfflineValidation/interface/PrepareDMRTrends.h
+++ b/Alignment/OfflineValidation/interface/PrepareDMRTrends.h
@@ -8,7 +8,6 @@
 #include <map>
 #include <iomanip>
 #include <fstream>
-#include <experimental/filesystem>
 #include "TPad.h"
 #include "TCanvas.h"
 #include "TGraph.h"

--- a/Alignment/OfflineValidation/src/PrepareDMRTrends.cc
+++ b/Alignment/OfflineValidation/src/PrepareDMRTrends.cc
@@ -1,7 +1,8 @@
 #include "Alignment/OfflineValidation/interface/PrepareDMRTrends.h"
+#include <filesystem>
 
 using namespace std;
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 namespace pt = boost::property_tree;
 
 PrepareDMRTrends::PrepareDMRTrends(const char *outputFileName, pt::ptree &json) : outputFileName_(outputFileName) {

--- a/Calibration/EcalCalibAlgos/BuildFile.xml
+++ b/Calibration/EcalCalibAlgos/BuildFile.xml
@@ -21,7 +21,6 @@
 <use name="SimDataFormats/GeneratorProducts"/>
 <use name="DQMServices/Core"/>
 <use name="CondCore/DBOutputService"/>
-<use name="stdcxx-fs"/>
 <export>
   <lib name="1"/>
 </export>

--- a/CondCore/CondDB/BuildFile.xml
+++ b/CondCore/CondDB/BuildFile.xml
@@ -9,7 +9,6 @@
 <use name="CoralKernel"/>
 <use name="CoralBase"/>
 <use name="RelationalAccess"/>
-<use name="stdcxx-fs"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DQM/PixelLumi/plugins/BuildFile.xml
+++ b/DQM/PixelLumi/plugins/BuildFile.xml
@@ -12,7 +12,6 @@
 <use name="Geometry/CommonTopologies"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
-<use name="stdcxx-fs"/>
 <library name="DQMPLumDQMPlugins" file="*.cc">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/DQMServices/FileIO/plugins/BuildFile.xml
+++ b/DQMServices/FileIO/plugins/BuildFile.xml
@@ -5,7 +5,6 @@
 <use name="FWCore/Utilities"/>
 <use name="EventFilter/Utilities"/>
 <use name="Utilities/OpenSSL"/>
-<use name="stdcxx-fs"/>
 <use name="boost"/>
 <use name="boost_iostreams"/>
 <library file="*.cc" name="DQMServicesFileIOPlugins">

--- a/DQMServices/StreamerIO/plugins/BuildFile.xml
+++ b/DQMServices/StreamerIO/plugins/BuildFile.xml
@@ -11,7 +11,6 @@
 <use name="FWCore/Utilities"/>
 <use name="IOPool/Output"/>
 <use name="IOPool/Streamer"/>
-<use name="stdcxx-fs"/>
 <use name="boost_regex"/>
 <library file="*.cc" name="DQMServicesStreamerIOPlugins">
   <flags EDM_PLUGIN="1"/>

--- a/DQMServices/StreamerIO/test/BuildFile.xml
+++ b/DQMServices/StreamerIO/test/BuildFile.xml
@@ -2,7 +2,6 @@
 <use name="IOPool/Streamer"/>
 <use name="EventFilter/Utilities"/>
 <use name="DQMServices/Components"/>
-<use name="stdcxx-fs"/>
 <use name="fmt"/>
 <library file="*.cc" name="DQMServicesStreamerIOTestPlugins">
   <flags EDM_PLUGIN="1"/>

--- a/DataFormats/OnlineMetaData/test/BuildFile.xml
+++ b/DataFormats/OnlineMetaData/test/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="cppunit"/>
 <use name="DataFormats/FEDRawData"/>
 <use name="DataFormats/OnlineMetaData"/>
-<use name="stdcxx-fs"/>
 <bin name="testDataFormatsOnlineMetaData" file="testRunner.cpp,onlineMetaDataRecord_t.cpp">
 </bin>

--- a/EventFilter/Utilities/BuildFile.xml
+++ b/EventFilter/Utilities/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="curl"/>
-<use name="stdcxx-fs"/>
 <use name="tbb"/>
 <use name="fmt"/>
 <use name="DataFormats/FEDRawData"/>

--- a/EventFilter/Utilities/plugins/BuildFile.xml
+++ b/EventFilter/Utilities/plugins/BuildFile.xml
@@ -11,6 +11,5 @@
   <use name="CLHEP"/>
   <use name="boost"/>
   <use name="root"/>
-  <use name="stdcxx-fs"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/FWCore/PluginManager/BuildFile.xml
+++ b/FWCore/PluginManager/BuildFile.xml
@@ -2,7 +2,6 @@
 <use name="tbb"/>
 <use name="rootcling"/>
 <use name="FWCore/Utilities"/>
-<use name="stdcxx-fs"/>
 <export>
   <lib name="1"/>
 </export>

--- a/FWCore/Utilities/BuildFile.xml
+++ b/FWCore/Utilities/BuildFile.xml
@@ -2,7 +2,6 @@
 <use name="libuuid"/>
 <use name="tbb"/>
 <use name="md5"/>
-<use name="stdcxx-fs"/>
 <export>
   <lib name="1"/>
 </export>

--- a/GeneratorInterface/LHEInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/LHEInterface/plugins/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="stdcxx-fs"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>

--- a/IOPool/Common/bin/BuildFile.xml
+++ b/IOPool/Common/bin/BuildFile.xml
@@ -31,5 +31,4 @@
   <use name="FWStorage/Services"/>
   <use name="FWCore/Catalog"/>
   <use name="FWCore/ParameterSet"/>
-  <use name="stdcxx-fs"/>
 </bin>

--- a/IORawData/CaloPatterns/BuildFile.xml
+++ b/IORawData/CaloPatterns/BuildFile.xml
@@ -7,5 +7,4 @@
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/HcalObjects"/>
 <use name="root"/>
-<use name="stdcxx-fs"/>
 <flags EDM_PLUGIN="1"/>

--- a/L1TriggerConfig/L1GtConfigProducers/BuildFile.xml
+++ b/L1TriggerConfig/L1GtConfigProducers/BuildFile.xml
@@ -7,5 +7,4 @@
 <use name="HLTrigger/HLTcore"/>
 <use name="Utilities/Xerces"/>
 <use name="xerces-c"/>
-<use name="stdcxx-fs"/>
 <flags EDM_PLUGIN="1"/>

--- a/RecoLuminosity/LumiProducer/BuildFile.xml
+++ b/RecoLuminosity/LumiProducer/BuildFile.xml
@@ -4,7 +4,6 @@
 <use name="CoralBase"/>
 <use name="RelationalAccess"/>
 <use name="FWCore/Utilities"/>
-<use name="stdcxx-fs"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoLuminosity/LumiProducer/plugins/BuildFile.xml
+++ b/RecoLuminosity/LumiProducer/plugins/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="FWCore/Framework"/>
-<use name="stdcxx-fs"/>
 <library file="Module.cc" name="LumiServicesPlugins">
   <use name="RecoLuminosity/LumiProducer"/>
   <flags EDM_PLUGIN="1"/>


### PR DESCRIPTION
This PR proposes to drop the explicit `stdc++fs` dependency as since GCC8 with c++17 it is part of stdc++ itself. Just having `#include <filesystem>` is enough for build/link.