### PR TITLE
Add Reco2Sim association map to NGTScouting NanoAOD

### DIFF
--- a/HLTrigger/NGTScouting/python/hltTracksters_cfi.py
+++ b/HLTrigger/NGTScouting/python/hltTracksters_cfi.py
@@ -78,7 +78,7 @@ for iterLabel in hltTiclIterLabels:
     tracksterTableProducers.append(globals()[label])
     for iterLabelSim in hltSimTrackstersLabels:
         CP_SC_label = "CP" if "CP" in iterLabelSim else "SC"
-        trackstersAssociationOneToManyTable = cms.EDProducer(
+        trackstersAssociationOneToManyS2RTable = cms.EDProducer(
             "TracksterTracksterEnergyScoreFlatTableProducer",
             src=cms.InputTag(
                 f"hltAllTrackstersToSimTrackstersAssociationsByHits:{iterLabelSim}To{iterLabel}"
@@ -92,7 +92,7 @@ for iterLabel in hltTiclIterLabels:
                         f"Sim{CP_SC_label}2{iterLabel}ByHitsLinks"),
                     doc=cms.string("Association links."),
                     useCount=cms.bool(True),
-                    useOffset=cms.bool(False),
+                    useOffset=cms.bool(True),
                     variables=cms.PSet(
                         index=Var("index", "uint",
                                   doc="Index of the associated Trackster."),
@@ -101,13 +101,45 @@ for iterLabel in hltTiclIterLabels:
                             "float",
                             doc="Shared energy with associated Trackster.",
                         ),
-                        score=Var("score", "float", doc="Association score."),
+                        score=Var("score", "float", doc="Sim2Reco Association score."),
                     ),
                 )
             ),
         )
         labelAssociation = f"{iterLabelSim}To{iterLabel}AssociationTableProducer"
-        globals()[labelAssociation] = trackstersAssociationOneToManyTable.clone()
+        globals()[labelAssociation] = trackstersAssociationOneToManyS2RTable.clone()
+        hltTrackstersAssociationOneToManyTableProducers.append(
+            globals()[labelAssociation])
+
+        trackstersAssociationOneToManyR2STable = cms.EDProducer(
+            "TracksterTracksterEnergyScoreFlatTableProducer",
+            src=cms.InputTag(
+                f"hltAllTrackstersToSimTrackstersAssociationsByHits:{iterLabel}To{iterLabelSim}"
+            ),
+            name=cms.string(f"Reco{iterLabel}2Sim{CP_SC_label}ByHits"),
+            doc=cms.string(
+                f"Association between {iterLabel} and SimTracksters, by hits."),
+            collectionVariables=cms.PSet(
+                links=cms.PSet(
+                    name=cms.string(f"Reco{iterLabel}2Sim{CP_SC_label}ByHitsLinks"),
+                    doc=cms.string("Association links."),
+                    useCount=cms.bool(True),
+                    useOffset=cms.bool(False),
+                    variables=cms.PSet(
+                        index=Var("index", "uint",
+                                  doc="Index of the associated SimTrackster."),
+                        sharedEnergy=Var(
+                            "sharedEnergy",
+                            "float",
+                            doc="Shared energy with associated SimTrackster.",
+                        ),
+                        score=Var("score", "float", doc="Reco2Sim Association score."),
+                    ),
+                )
+            ),
+        )
+        labelAssociation = f"{iterLabel}To{iterLabelSim}AssociationTableProducer"
+        globals()[labelAssociation] = trackstersAssociationOneToManyR2STable.clone()
         hltTrackstersAssociationOneToManyTableProducers.append(
             globals()[labelAssociation])
 

--- a/HLTrigger/NGTScouting/test/readNano.py
+++ b/HLTrigger/NGTScouting/test/readNano.py
@@ -96,12 +96,12 @@ def main():
             try:  # Offset pattern
                 offset = 0
                 for obj_idx in range(event.nSimCP2hltTiclCandidateByHits - 1):
-                    next_offset = event.SimSC2hltTiclCandidateByHits_oSimSC2hltTiclCandidateByHitsLinks[
+                    next_offset = event.SimCP2hltTiclCandidateByHits_oSimCP2hltTiclCandidateByHitsLinks[
                         obj_idx + 1
                     ]
-                    elements = event.SimCP2hltTiclTrackstersCLUE3DHighByHitsLinks_index[offset:next_offset]
-                    scores = event.SimCP2hltTiclTrackstersCLUE3DHighByHitsLinks_score[offset:next_offset]
-                    sharedEnergy = event.SimCP2hltTiclTrackstersCLUE3DHighByHitsLinks_sharedEnergy[
+                    elements = event.SimCP2hltTiclCandidateByHitsLinks_index[offset:next_offset]
+                    scores = event.SimCP2hltTiclCandidateByHitsLinks_score[offset:next_offset]
+                    sharedEnergy = event.SimCP2hltTiclCandidateByHitsLinks_sharedEnergy[
                         offset:next_offset
                     ]
                     if len(elements) > 0:
@@ -134,6 +134,39 @@ def main():
                     sharedEnergy = event.SimCP2hltTiclCandidateByHitsLinks_sharedEnergy[
                         offset : offset + count
                     ]
+                    if len(elements) > 0:
+                        print("Count ", obj_idx, elements, scores, sharedEnergy)
+                    offset += count
+            except AttributeError as e:
+                print(f"An AttributeError occurred (Count): {e}")
+
+
+            #Reco2Sim
+            
+            try:  # Offset pattern
+                offset = 0
+                for obj_idx in range(event.nRecohltTiclCandidate2SimCPByHits - 1):
+                    next_offset = event.RecohltTiclCandidate2SimCPByHits_oSimCP2hltTiclCandidateByHitsLinks[
+                        obj_idx + 1
+                    ]
+                    elements = event.RecohltTiclCandidate2SimCPByHitsLinks_index[offset:next_offset]
+                    scores = event.RecohltTiclCandidate2SimCPByHitsLinks_score[offset:next_offset]
+                    sharedEnergy = event.RecohltTiclCandidate2SimCPByHitsLinks_sharedEnergy[
+                        offset:next_offset
+                    ]
+                    if len(elements) > 0:
+                        print("Offset ", obj_idx, elements, scores, sharedEnergy)
+                    offset = next_offset
+            except AttributeError as e:
+                print(f"An AttributeError occurred (Offset): {e}")
+
+            try:  # Count pattern
+                offset = 0
+                for obj_idx in range(event.nRecohltTiclCandidate2SimCPByHits):
+                    count = event.RecohltTiclCandidate2SimCPByHits_nRecohltTiclCandidate2SimCPByHitsLinks[obj_idx]
+                    elements = event.RecohltTiclCandidate2SimCPByHitsLinks_index[offset : offset + count]
+                    scores = event.RecohltTiclCandidate2SimCPByHitsLinks_score[offset : offset + count]
+                    sharedEnergy = event.RecohltTiclCandidate2SimCPByHitsLinks_sharedEnergy[offset : offset + count]
                     if len(elements) > 0:
                         print("Count ", obj_idx, elements, scores, sharedEnergy)
                     offset += count


### PR DESCRIPTION
Title says it all.

Additional fix to the `readNano.py` example that was using inconsistent branches.

Should be tested with a .773 workflow (for example 34434.773) 