### PR TITLE
L1TrackJetClustering and other fixes for gcc15 crashes

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/GEMClusterProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMClusterProcessor.cc
@@ -64,7 +64,7 @@ std::vector<GEMInternalCluster> GEMClusterProcessor::getClusters(int bx, Cluster
 
   for (const auto& cl : clusters_) {
     // valid single clusters with the right BX
-    if (cl.bx() == bx and cl.isValid()) {
+    if (cl.isValid() and cl.bx() == bx) {
       // ignore the coincidence clusters
       if (option == SingleClusters and cl.isCoincidence())
         continue;

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetClustering.h
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetClustering.h
@@ -277,7 +277,8 @@ namespace l1ttrackjet {
         clusters[m].pTtot += clusters[m + 1].pTtot;
         clusters[m].ntracks += clusters[m + 1].ntracks;    // total ntrk
         clusters[m].nxtracks += clusters[m + 1].nxtracks;  // total ndisp
-        clusters[m].trackidx.insert(clusters[m].trackidx.end(), clusters[m + 1].trackidx.begin(), clusters[m + 1].trackidx.end());
+        clusters[m].trackidx.insert(
+            clusters[m].trackidx.end(), clusters[m + 1].trackidx.begin(), clusters[m + 1].trackidx.end());
 
         // remove the merged cluster - all the others must be closer to 0
         clusters.erase(clusters.begin() + m + 1);

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetClustering.h
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetClustering.h
@@ -277,14 +277,10 @@ namespace l1ttrackjet {
         clusters[m].pTtot += clusters[m + 1].pTtot;
         clusters[m].ntracks += clusters[m + 1].ntracks;    // total ntrk
         clusters[m].nxtracks += clusters[m + 1].nxtracks;  // total ndisp
-        for (unsigned int itrk = 0; itrk < clusters[m + 1].trackidx.size(); itrk++)
-          clusters[m].trackidx.push_back(clusters[m + 1].trackidx[itrk]);
+        clusters[m].trackidx.insert(clusters[m].trackidx.end(), clusters[m + 1].trackidx.begin(), clusters[m + 1].trackidx.end());
 
-        // if remove the merged cluster - all the others must be closer to 0
-        for (int m1 = m + 1; m1 < nclust - 1; ++m1)
-          clusters[m1] = clusters[m1 + 1];
-
-        clusters.erase(clusters.begin() + nclust);
+        // remove the merged cluster - all the others must be closer to 0
+        clusters.erase(clusters.begin() + m + 1);
         nclust--;
       }  // end if for cluster merging
     }  // end for (m) loop

--- a/L1Trigger/TrackFindingTMTT/src/Stub.cc
+++ b/L1Trigger/TrackFindingTMTT/src/Stub.cc
@@ -41,6 +41,7 @@ namespace tmtt {
         bend_(bend),
         iphi_(iphi),
         alpha_(alpha),
+        assocTP_(nullptr),
         digitalStub_(std::make_unique<DigitalStub>(settings, r, phi, z, iPhiSec)),
         layerId_(layerId),
         layerIdReduced_(TrackerModule::calcLayerIdReduced(layerId)),


### PR DESCRIPTION
#### PR description:

Fixes three issues related to gcc15 relvals in issue #50162

- Fixes what is essentially an off by one error in L1TrackJetClustering.  This is nearly the same issue as #50170 only somewhat simpler.
- Fixes an uninitialized variable use in L1Trigger/CSCTriggerPrimitives by reordering a conditional to test the always initialized value first
- Fixes an uninitialized variable use in L1Trigger/TrackFindingTMTT, where a pointer was being dereferenced without being initialized

#### PR validation:

Compiles, appears to fix the relevant crashes and valgrind memcheck warnings.  No performance impacts expected.

Resolves https://github.com/cms-sw/framework-team/issues/1944
Resolves https://github.com/cms-sw/framework-team/issues/1945
Resolves https://github.com/cms-sw/framework-team/issues/1947
