### PR TITLE
make `edm::Wrapper` of GsfTracking types not defined in `DataFormats` non persistable

### DIFF
--- a/TrackingTools/GsfTracking/src/classes_def.xml
+++ b/TrackingTools/GsfTracking/src/classes_def.xml
@@ -8,11 +8,14 @@
   <class name="edm::AssociationMap<edm::OneToOne<reco::GsfTrackCollection, std::vector<VertexConstraint>, unsigned int> >" >
     <field name="transientMap_" transient="true" />
   </class>
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<std::vector<Trajectory>, std::vector<reco::GsfTrack>, unsigned short > > >" />
 
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<reco::GsfTrackCollection, std::vector<MomentumConstraint>, unsigned int> > >" />
+  <!-- As per issue https://github.com/cms-sw/cmssw/issues/50165 -->
+  <!-- The following dictionaries are defined outside of DataFormats, thus -->
+  <!-- they need to be non-persistent -->
 
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<reco::GsfTrackCollection, std::vector<VertexConstraint>, unsigned int> > >" />
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<std::vector<Trajectory>, std::vector<reco::GsfTrack>, unsigned short > > >" persistent="false"/>
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<reco::GsfTrackCollection,std::vector<MomentumConstraint>, unsigned int> > >" persistent="false" />
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<reco::GsfTrackCollection, std::vector<VertexConstraint>, unsigned int> > >" persistent="false"/>
 
   <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<Trajectory> >, edm::RefProd<std::vector<reco::GsfTrack> > >"/>
   <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::GsfTrack> >, edm::RefProd<std::vector<MomentumConstraint> > >"/>


### PR DESCRIPTION
#### PR description:

As per suggestion at https://github.com/cms-sw/cmssw/issues/50165#issuecomment-3916846784

#### PR validation:

`runTheMatrix.py -l ph2_hlt` technically runs (haven't checked the impact on validation yet, let's do that via bot testing)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, not to be backorted (?)
