### PR TITLE
Backport FastSim jet refinement+Type-1 MET propagation to CMSSW_15_0_X

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -622,7 +622,6 @@ workflows[135.9] = ['ZMMFS_13',['ZMMFS_13','HARVESTUP15FS','MINIAODMCUP15FS','NA
 workflows[135.11] = ['SMS-T1tttt_mGl-1500_mLSP-100FS_13', ['SMS-T1tttt_mGl-1500_mLSP-100FS_13','HARVESTUP15FS','MINIAODMCUP15FS','NANOUP15FS']]
 workflows[135.12] = ['QCD_Pt_80_120FS_13', ['QCD_Pt_80_120FS_13','HARVESTUP15FS','MINIAODMCUP15FS','NANOUP15FS']]
 workflows[135.13] = ['TTbarFS_13', ['TTbarFS_13_trackingOnlyValidation','HARVESTUP15FS_trackingOnly']]
-workflows[135.14] = ['TTbarFS_13', ['TTbarFS_13','HARVESTUP15FS','MINIAODMCUP15FS','NANOUP15FSrefine']]
 
 ### MinBias fastsim_13 TeV for mixing ###
 workflows[135.8] = ['MinBiasFS_13',['MinBiasFS_13_ForMixing']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4569,7 +4569,6 @@ steps['NANOUP15FS'] = merge([{'--filein':'file:step3.root','--fast':''}, steps['
 steps['NANOUP17FS'] = merge([{'--filein':'file:step3.root','--fast':'','--era':'Run2_2017_FastSim'}, steps['NANOUP17']])
 steps['NANOUP18FS'] = merge([{'--filein':'file:step3.root','--fast':'','--era':'Run2_2018_FastSim'}, steps['NANOUP18']])
 
-steps['NANOUP15FSrefine'] = merge([{'--customise':'PhysicsTools/NanoAOD/jetsAK4_CHS_cff.nanoAOD_refineFastSim_bTagDeepFlav'}, steps['NANOUP15FS']])
 
 steps['HEfail'] = {'--conditions':'auto:phase1_2018_realistic_HEfail',
                    '-n':'10',

--- a/PhysicsTools/NanoAOD/plugins/JetSorter.cc
+++ b/PhysicsTools/NanoAOD/plugins/JetSorter.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -6,7 +6,11 @@
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
-class JetSorter : public edm::stream::EDProducer<> {
+#include <algorithm>
+#include <string>
+#include <memory>
+
+class JetSorter : public edm::global::EDProducer<> {
 public:
   explicit JetSorter(const edm::ParameterSet &iConfig)
       : srcToken_(consumes<edm::View<pat::Jet>>(iConfig.getParameter<edm::InputTag>("src"))),
@@ -17,7 +21,7 @@ public:
 
   ~JetSorter() override = default;
 
-  void produce(edm::Event &iEvent, const edm::EventSetup &) override {
+  void produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &) const override {
     edm::Handle<edm::View<pat::Jet>> hSrc;
     iEvent.getByToken(srcToken_, hSrc);
 
@@ -28,14 +32,14 @@ public:
       out->push_back(jIn);
     }
 
-    auto key = [&](pat::Jet const &j) -> float {
+    auto key = [this](pat::Jet const &j) -> float {
       if (j.hasUserFloat(userFloatSorter_)) {
         return j.userFloat(userFloatSorter_);
       }
       return static_cast<float>(j.pt());
     };
 
-    std::stable_sort(out->begin(), out->end(), [&](pat::Jet const &a, pat::Jet const &b) {
+    std::stable_sort(out->begin(), out->end(), [this, &key](pat::Jet const &a, pat::Jet const &b) {
       float pa = key(a);
       float pb = key(b);
       return descending_ ? (pa > pb) : (pa < pb);

--- a/PhysicsTools/NanoAOD/plugins/JetSorter.cc
+++ b/PhysicsTools/NanoAOD/plugins/JetSorter.cc
@@ -1,0 +1,53 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+
+class JetSorter : public edm::stream::EDProducer<> {
+public:
+  explicit JetSorter(const edm::ParameterSet &iConfig)
+      : srcToken_(consumes<edm::View<pat::Jet>>(iConfig.getParameter<edm::InputTag>("src"))),
+        userFloatSorter_(iConfig.getParameter<std::string>("userFloatSorter")),
+        descending_(iConfig.getParameter<bool>("descending")) {
+    produces<std::vector<pat::Jet>>();
+  }
+
+  ~JetSorter() override = default;
+
+  void produce(edm::Event &iEvent, const edm::EventSetup &) override {
+    edm::Handle<edm::View<pat::Jet>> hSrc;
+    iEvent.getByToken(srcToken_, hSrc);
+
+    auto out = std::make_unique<std::vector<pat::Jet>>();
+    out->reserve(hSrc->size());
+
+    for (auto const &jIn : *hSrc) {
+      out->push_back(jIn);
+    }
+
+    auto key = [&](pat::Jet const &j) -> float {
+      if (j.hasUserFloat(userFloatSorter_)) {
+        return j.userFloat(userFloatSorter_);
+      }
+      return static_cast<float>(j.pt());
+    };
+
+    std::stable_sort(out->begin(), out->end(), [&](pat::Jet const &a, pat::Jet const &b) {
+      float pa = key(a);
+      float pb = key(b);
+      return descending_ ? (pa > pb) : (pa < pb);
+    });
+
+    iEvent.put(std::move(out));
+  }
+
+private:
+  edm::EDGetTokenT<edm::View<pat::Jet>> srcToken_;
+  std::string userFloatSorter_;
+  bool descending_;
+};
+
+DEFINE_FWK_MODULE(JetSorter);

--- a/PhysicsTools/NanoAOD/plugins/ProcessRefinedJets.cc
+++ b/PhysicsTools/NanoAOD/plugins/ProcessRefinedJets.cc
@@ -55,15 +55,13 @@ public:
       pat::Jet j(jIn);
 
       const double pt_orig = j.pt();
-      const double phi     = j.phi();
+      const double phi = j.phi();
 
       // mask: BvsAll > 0
       const float bvsAll = j.bDiscriminator(maskBtagName_);
-      const bool refine  = (bvsAll > 0.f);
+      const bool refine = (bvsAll > 0.f);
 
-      const double pt_ref = j.hasUserFloat(refinedPtName_)
-                                ? static_cast<double>(j.userFloat(refinedPtName_))
-                                : pt_orig;
+      const double pt_ref = j.hasUserFloat(refinedPtName_) ? static_cast<double>(j.userFloat(refinedPtName_)) : pt_orig;
 
       const double pt_final = refine ? pt_ref : pt_orig;
 
@@ -107,11 +105,11 @@ public:
         const double ptFinal = std::sqrt(pxFinal * pxFinal + pyFinal * pyFinal);
         const double phiFinal = std::atan2(pyFinal, pxFinal);
 
-        m.addUserFloat("pt_unrefined",  static_cast<float>(ptOrig));
+        m.addUserFloat("pt_unrefined", static_cast<float>(ptOrig));
         m.addUserFloat("phi_unrefined", static_cast<float>(phiOrig));
 
         // stash final values, needed for sorting.
-        m.addUserFloat("pt_final",  static_cast<float>(ptFinal));
+        m.addUserFloat("pt_final", static_cast<float>(ptFinal));
         m.addUserFloat("phi_final", static_cast<float>(phiFinal));
 
         // push back into pat::MET with reco::Candidate::LorentzVector ---

--- a/PhysicsTools/NanoAOD/plugins/ProcessRefinedJets.cc
+++ b/PhysicsTools/NanoAOD/plugins/ProcessRefinedJets.cc
@@ -1,0 +1,145 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/PatCandidates/interface/MET.h"
+#include "TLorentzVector.h"
+
+#include <cmath>
+
+//This producer was written to embed the final refined FastSim jet pT values
+//so that they can be used as input to the pT-based sorting routine, as well
+//as to implement the Type-1 MET correction based on the refined jets.
+class ProcessRefinedJets : public edm::stream::EDProducer<> {
+public:
+  explicit ProcessRefinedJets(const edm::ParameterSet &iConfig)
+      : jetsToken_(consumes<edm::View<pat::Jet>>(iConfig.getParameter<edm::InputTag>("jets"))),
+        refinedPtName_(iConfig.getParameter<std::string>("refinedPtName")),
+        maskBtagName_(iConfig.getParameter<std::string>("maskBtagName")),
+        ptFinalName_(iConfig.getParameter<std::string>("ptFinalName")),
+        ptUnrefinedName_(iConfig.getParameter<std::string>("ptUnrefinedName")) {
+    // Type-1 MET correction is optional
+    if (iConfig.existsAs<edm::InputTag>("met")) {
+      metToken_ = consumes<edm::View<pat::MET>>(iConfig.getParameter<edm::InputTag>("met"));
+      doMET_ = true;
+    } else {
+      doMET_ = false;
+    }
+
+    produces<std::vector<pat::Jet>>();
+
+    if (doMET_) {
+      // refined MET made available in python
+      produces<std::vector<pat::MET>>("Refined");
+    }
+  }
+
+  ~ProcessRefinedJets() override = default;
+
+  void produce(edm::Event &iEvent, const edm::EventSetup &) override {
+    edm::Handle<edm::View<pat::Jet>> hJets;
+    iEvent.getByToken(jetsToken_, hJets);
+
+    auto outJets = std::make_unique<std::vector<pat::Jet>>();
+    outJets->reserve(hJets->size());
+
+    // Sum over (pt_orig - pt_final) for MET correction
+    double sumDeltaPx = 0.;
+    double sumDeltaPy = 0.;
+
+    for (auto const &jIn : *hJets) {
+      pat::Jet j(jIn);
+
+      const double pt_orig = j.pt();
+      const double phi = j.phi();
+
+      // mask: BvsAll > 0
+      const float bvsAll = j.bDiscriminator(maskBtagName_);
+      const bool refine = (bvsAll > 0.f);
+
+      const double pt_ref = j.hasUserFloat(refinedPtName_) ? static_cast<double>(j.userFloat(refinedPtName_)) : pt_orig;
+
+      const double pt_final = refine ? pt_ref : pt_orig;
+
+      // store unrefined pt if requested
+      if (!ptUnrefinedName_.empty()) {
+        j.addUserFloat(ptUnrefinedName_, static_cast<float>(pt_orig));
+      }
+
+      // store final pt used for Nano, needed for the sorting
+      j.addUserFloat(ptFinalName_, static_cast<float>(pt_final));
+
+      // MET delta: add unrefined jets, subtract final jets
+      // This is equivalent to adding (pt_orig - pt_final) in the jet direction.
+      const double dpt = pt_orig - pt_final;
+      sumDeltaPx += dpt * std::cos(phi);
+      sumDeltaPy += dpt * std::sin(phi);
+
+      outJets->push_back(std::move(j));
+    }
+
+    iEvent.put(std::move(outJets));
+
+    // Optionally correct MET
+    if (doMET_) {
+      edm::Handle<edm::View<pat::MET>> hMET;
+      iEvent.getByToken(metToken_, hMET);
+
+      auto outMET = std::make_unique<std::vector<pat::MET>>();
+      outMET->reserve(hMET->size());
+
+      for (auto const &mIn : *hMET) {
+        pat::MET m(mIn);
+
+        // --- original MET as TLorentzVector ---
+        const double pxOrig = m.px();
+        const double pyOrig = m.py();
+        const double ptOrig = std::sqrt(pxOrig * pxOrig + pyOrig * pyOrig);
+        const double phiOrig = std::atan2(pyOrig, pxOrig);
+
+        TLorentzVector metOrig;
+        metOrig.SetPxPyPzE(pxOrig, pyOrig, 0.0, ptOrig);  // pz=0, E ~ pt (E not really used for MET)
+
+        // Type-1 MET correction for PUPPI MET with refined jets:
+        TLorentzVector delta;
+        const double ptDelta = std::sqrt(sumDeltaPx * sumDeltaPx + sumDeltaPy * sumDeltaPy);
+        delta.SetPxPyPzE(sumDeltaPx, sumDeltaPy, 0.0, ptDelta);
+
+        TLorentzVector metFinal = metOrig + delta;
+
+        const double ptFinal = metFinal.Pt();
+        const double phiFinal = metFinal.Phi();
+
+        // stash unrefined values
+        m.addUserFloat("pt_unrefined", static_cast<float>(ptOrig));
+        m.addUserFloat("phi_unrefined", static_cast<float>(phiOrig));
+
+        // stash final values, needed for sorting.
+        m.addUserFloat("pt_final", static_cast<float>(ptFinal));
+        m.addUserFloat("phi_final", static_cast<float>(phiFinal));
+
+        // push back into pat::MET with reco::Candidate::LorentzVector ---
+        reco::Candidate::LorentzVector p4(metFinal.Px(), metFinal.Py(), 0.0, ptFinal);
+        m.setP4(p4);
+
+        outMET->push_back(std::move(m));
+      }
+      iEvent.put(std::move(outMET), "Refined");
+    }
+  }
+
+private:
+  edm::EDGetTokenT<edm::View<pat::Jet>> jetsToken_;
+  edm::EDGetTokenT<edm::View<pat::MET>> metToken_;
+  bool doMET_;
+
+  std::string refinedPtName_;
+  std::string maskBtagName_;
+  std::string ptFinalName_;
+  std::string ptUnrefinedName_;
+};
+
+DEFINE_FWK_MODULE(ProcessRefinedJets);

--- a/PhysicsTools/NanoAOD/python/jetsAK4_CHS_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_CHS_cff.py
@@ -396,7 +396,11 @@ nanoAOD_addDeepInfoAK4CHS_switch = cms.PSet(
 # ML-based FastSim refinement
 #
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-def nanoAOD_refineFastSim_bTagDeepFlav(process):
+def nanoAOD_refineFastSim_bTagDeepFlav(process, addDeepFlavour):
+
+    # for CHS, only DeepFlav refinement is implemented
+    if not addDeepFlavour:
+        return process
 
     fastSim.toModify( process.jetTable.variables,
       btagDeepFlavBunrefined = process.jetTable.variables.btagDeepFlavB.clone(),

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -224,3 +224,100 @@ jetPuppiTask = cms.Task(jetPuppiCorrFactorsNano,updatedJetsPuppi,jetPuppiUserDat
 
 #after cross linkining
 jetPuppiTablesTask = cms.Task(jetPuppiTable)
+
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+from PhysicsTools.NanoAOD.common_cff import ExtVar
+
+def nanoAOD_refineFastSim_puppiJet(process):
+    process.puppiJetRefineNN = cms.EDProducer(
+        "JetBaseMVAValueMapProducer",
+        backend             = cms.string("ONNX"),
+        batch_eval          = cms.bool(True),
+        disableONNXGraphOpt = cms.bool(True),
+        src                 = cms.InputTag("updatedJetsPuppi"),  # <<< HERE
+        weightFile          = cms.FileInPath("model_refinement_regression_20250320_dynamic.onnx"),
+        name                = cms.string("puppiJetRefineNN"),
+        variables = cms.VPSet(
+            cms.PSet(name=cms.string("GenJet_pt"),            expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().pt():pt")),
+            cms.PSet(name=cms.string("GenJet_eta"),           expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().eta():eta")),
+            cms.PSet(name=cms.string("Jet_hadronFlavour"),    expr=cms.string("hadronFlavour()")),
+            cms.PSet(name=cms.string("Jet_pt"),               expr=cms.string("pt()")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavB"),    expr=cms.string("bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavCvB"),  expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')):-1")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavCvL"),  expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')):-1")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavQG"),   expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds'))>0?bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')):-1")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4B"),    expr=cms.string("bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4CvB"),  expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'):-1")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4CvL"),  expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'):-1")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4QvG"),  expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'):-1")),
+        ),
+        inputTensorName  = cms.string("input"),
+        outputTensorName = cms.string("output"),
+        outputNames      = cms.vstring([
+            "ptrefined","btagDeepFlavBrefined","btagDeepFlavCvBrefined","btagDeepFlavCvLrefined",
+            "btagDeepFlavQGrefined","btagUParTAK4Brefined","btagUParTAK4CvBrefined",
+            "btagUParTAK4CvLrefined","btagUParTAK4QvGrefined"
+        ]),
+        outputFormulas   = cms.vstring([f"at({i})" for i in range(9)]),
+    )
+
+    # schedule it in the jet-building chain
+    fastSim.toModify(process.jetPuppiTask, process.jetPuppiTask.add(process.puppiJetRefineNN))
+
+    #
+    # 1) now stuff those 9 refined scalars into the existing PATJetUserDataEmbedder
+    #
+    fastSim.toModify(process.updatedJetsPuppiWithUserData.userFloats,
+        ptRefined              = cms.InputTag("puppiJetRefineNN","ptrefined"),
+        btagDeepFlavBrefined   = cms.InputTag("puppiJetRefineNN","btagDeepFlavBrefined"),
+        btagDeepFlavCvBrefined = cms.InputTag("puppiJetRefineNN","btagDeepFlavCvBrefined"),
+        btagDeepFlavCvLrefined = cms.InputTag("puppiJetRefineNN","btagDeepFlavCvLrefined"),
+        btagDeepFlavQGrefined  = cms.InputTag("puppiJetRefineNN","btagDeepFlavQGrefined"),
+        btagUParTAK4Brefined   = cms.InputTag("puppiJetRefineNN","btagUParTAK4Brefined"),
+        btagUParTAK4CvBrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4CvBrefined"),
+        btagUParTAK4CvLrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4CvLrefined"),
+        btagUParTAK4QvGrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4QvGrefined"),
+    )
+
+    #
+    # 2) backup all 9 originals in the NanoAOD table as *_unrefined
+    #
+    fastSim.toModify(process.jetPuppiTable.variables,
+        pt_unrefined               = process.jetPuppiTable.variables.pt.clone(),
+        btagDeepFlavB_unrefined    = process.jetPuppiTable.variables.btagDeepFlavB.clone(),
+        btagDeepFlavCvB_unrefined  = process.jetPuppiTable.variables.btagDeepFlavCvB.clone(),
+        btagDeepFlavCvL_unrefined  = process.jetPuppiTable.variables.btagDeepFlavCvL.clone(),
+        btagDeepFlavQG_unrefined   = process.jetPuppiTable.variables.btagDeepFlavQG.clone(),
+        btagUParTAK4B_unrefined    = process.jetPuppiTable.variables.btagUParTAK4B.clone(),
+        btagUParTAK4CvB_unrefined  = process.jetPuppiTable.variables.btagUParTAK4CvB.clone(),
+        btagUParTAK4CvL_unrefined  = process.jetPuppiTable.variables.btagUParTAK4CvL.clone(),
+        btagUParTAK4QvG_unrefined  = process.jetPuppiTable.variables.btagUParTAK4QvG.clone(),
+    )
+    # drop them so we can redefine
+    fastSim.toModify(process.jetPuppiTable.variables,
+        pt=None, btagDeepFlavB=None, btagDeepFlavCvB=None,
+        btagDeepFlavCvL=None, btagDeepFlavQG=None,
+        btagUParTAK4B=None, btagUParTAK4CvB=None,
+        btagUParTAK4CvL=None, btagUParTAK4QvG=None,
+    )
+
+    #
+    # 3) re‑define each branch with a FastSim‑only mask ternary
+    #
+    mask = "(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')>0)"
+
+    fastSim.toModify(process.jetPuppiTable.variables,
+        pt              = Var(f"?{mask}?userFloat('ptRefined'):pt()",              float, precision=10, doc="refined pT or original"),
+        btagDeepFlavB   = Var(f"?{mask}?userFloat('btagDeepFlavBrefined'):(bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))", float, precision=10),
+        btagDeepFlavCvB = Var(f"?{mask}?userFloat('btagDeepFlavCvBrefined'):(?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')):-1)", float, precision=10),
+        btagDeepFlavCvL = Var(f"?{mask}?userFloat('btagDeepFlavCvLrefined'):(?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')):-1)", float, precision=10),
+        btagDeepFlavQG  = Var(f"?{mask}?userFloat('btagDeepFlavQGrefined'):(?(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds'))>0?bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')):-1)", float, precision=10),
+        btagUParTAK4B   = Var(f"?{mask}?userFloat('btagUParTAK4Brefined'):(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll'))", float, precision=10),
+        btagUParTAK4CvB = Var(f"?{mask}?userFloat('btagUParTAK4CvBrefined'):(?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'):-1)", float, precision=10),
+        btagUParTAK4CvL = Var(f"?{mask}?userFloat('btagUParTAK4CvLrefined'):(?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'):-1)", float, precision=10),
+        btagUParTAK4QvG = Var(f"?{mask}?userFloat('btagUParTAK4QvGrefined'):(?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'):-1)", float, precision=10),
+    )
+
+    return process
+
+nanoAOD_refineFastSim_puppiJet = nanoAOD_refineFastSim_puppiJet

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -289,7 +289,8 @@ def nanoAOD_refineFastSim_puppiJet(process):
             btagUParTAK4Brefined   = cms.InputTag("puppiJetRefineNN","btagUParTAK4Brefined"),
             btagUParTAK4CvBrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4CvBrefined"),
             btagUParTAK4CvLrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4CvLrefined"),
-            btagUParTAK4QvGrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4QvGrefined"),)
+            btagUParTAK4QvGrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4QvGrefined"),
+        )
     )
     fastSim.toModify(process.jetPuppiTablesTask, process.jetPuppiTablesTask.add(process.finalJetsPuppiWithRefined))
 

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -222,55 +222,15 @@ jetPuppiTablesTask = cms.Task(jetPuppiTable)
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 from PhysicsTools.NanoAOD.common_cff import ExtVar
 
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+from PhysicsTools.NanoAOD.common_cff import Var
+
+from PhysicsTools.NanoAOD.common_cff import Var, ExtVar
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+
 def nanoAOD_refineFastSim_puppiJet(process):
-    process.puppiJetRefineNN = cms.EDProducer(
-        "JetBaseMVAValueMapProducer",
-        backend             = cms.string("ONNX"),
-        batch_eval          = cms.bool(True),
-        disableONNXGraphOpt = cms.bool(True),
-        src                 = cms.InputTag("updatedJetsPuppi"),  # <<< HERE
-        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/fastSimPuppiJetRefineNN_31July2025.onnx"),
-        name                = cms.string("puppiJetRefineNN"),
-        variables = cms.VPSet(
-            cms.PSet(name=cms.string("GenJet_pt"),            expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().pt():pt")),
-            cms.PSet(name=cms.string("GenJet_eta"),           expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().eta():eta")),
-            cms.PSet(name=cms.string("Jet_hadronFlavour"),    expr=cms.string("hadronFlavour()")),
-            cms.PSet(name=cms.string("Jet_pt"),               expr=cms.string("pt()")),
-            cms.PSet(name=cms.string("Jet_btagDeepFlavB"),    expr=cms.string("bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')")),
-            cms.PSet(name=cms.string("Jet_btagDeepFlavCvB"),  expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')):-1")),
-            cms.PSet(name=cms.string("Jet_btagDeepFlavCvL"),  expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')):-1")),
-            cms.PSet(name=cms.string("Jet_btagDeepFlavQG"),   expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds'))>0?bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')):-1")),
-            cms.PSet(name=cms.string("Jet_btagUParTAK4B"),    expr=cms.string("bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')")),
-            cms.PSet(name=cms.string("Jet_btagUParTAK4CvB"),  expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'):-1")),
-            cms.PSet(name=cms.string("Jet_btagUParTAK4CvL"),  expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'):-1")),
-            cms.PSet(name=cms.string("Jet_btagUParTAK4QvG"),  expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'):-1")),
-        ),
-        inputTensorName  = cms.string("input"),
-        outputTensorName = cms.string("output"),
-        outputNames      = cms.vstring([
-            "ptrefined","btagDeepFlavBrefined","btagDeepFlavCvBrefined","btagDeepFlavCvLrefined",
-            "btagDeepFlavQGrefined","btagUParTAK4Brefined","btagUParTAK4CvBrefined",
-            "btagUParTAK4CvLrefined","btagUParTAK4QvGrefined"
-        ]),
-        outputFormulas   = cms.vstring([f"at({i})" for i in range(9)]),
-    )
 
-    fastSim.toModify(process.jetPuppiTask, process.jetPuppiTask.add(process.puppiJetRefineNN))
-
-    # 1) now stuff the 9 refined scalars into the existing PATJetUserDataEmbedder
-    fastSim.toModify(process.updatedJetsPuppiWithUserData.userFloats,
-        ptRefined              = cms.InputTag("puppiJetRefineNN","ptrefined"),
-        btagDeepFlavBrefined   = cms.InputTag("puppiJetRefineNN","btagDeepFlavBrefined"),
-        btagDeepFlavCvBrefined = cms.InputTag("puppiJetRefineNN","btagDeepFlavCvBrefined"),
-        btagDeepFlavCvLrefined = cms.InputTag("puppiJetRefineNN","btagDeepFlavCvLrefined"),
-        btagDeepFlavQGrefined  = cms.InputTag("puppiJetRefineNN","btagDeepFlavQGrefined"),
-        btagUParTAK4Brefined   = cms.InputTag("puppiJetRefineNN","btagUParTAK4Brefined"),
-        btagUParTAK4CvBrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4CvBrefined"),
-        btagUParTAK4CvLrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4CvLrefined"),
-        btagUParTAK4QvGrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4QvGrefined"),
-    )
-
-    # 2) backup all 9 originals in the NanoAOD table as *_unrefined
     fastSim.toModify(process.jetPuppiTable.variables,
         pt_unrefined               = process.jetPuppiTable.variables.pt.clone(),
         btagDeepFlavB_unrefined    = process.jetPuppiTable.variables.btagDeepFlavB.clone(),
@@ -282,29 +242,63 @@ def nanoAOD_refineFastSim_puppiJet(process):
         btagUParTAK4CvL_unrefined  = process.jetPuppiTable.variables.btagUParTAK4CvL.clone(),
         btagUParTAK4QvG_unrefined  = process.jetPuppiTable.variables.btagUParTAK4QvG.clone(),
     )
-    # drop them so we can redefine
-    fastSim.toModify(process.jetPuppiTable.variables,
-        pt=None, btagDeepFlavB=None, btagDeepFlavCvB=None,
-        btagDeepFlavCvL=None, btagDeepFlavQG=None,
-        btagUParTAK4B=None, btagUParTAK4CvB=None,
-        btagUParTAK4CvL=None, btagUParTAK4QvG=None,
-    )
-
-    # 3) re‑define each branch with a FastSim‑only mask ternary
-    mask = "(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')>0)"
 
     fastSim.toModify(process.jetPuppiTable.variables,
-        pt              = Var(f"?{mask}?userFloat('ptRefined'):pt()",              float, precision=10, doc="refined pT or original"),
-        btagDeepFlavB   = Var(f"?{mask}?userFloat('btagDeepFlavBrefined'):(bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))", float, precision=10),
-        btagDeepFlavCvB = Var(f"?{mask}?userFloat('btagDeepFlavCvBrefined'):(?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')):-1)", float, precision=10),
-        btagDeepFlavCvL = Var(f"?{mask}?userFloat('btagDeepFlavCvLrefined'):(?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')):-1)", float, precision=10),
-        btagDeepFlavQG  = Var(f"?{mask}?userFloat('btagDeepFlavQGrefined'):(?(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds'))>0?bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')):-1)", float, precision=10),
-        btagUParTAK4B   = Var(f"?{mask}?userFloat('btagUParTAK4Brefined'):(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll'))", float, precision=10),
-        btagUParTAK4CvB = Var(f"?{mask}?userFloat('btagUParTAK4CvBrefined'):(?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'):-1)", float, precision=10),
-        btagUParTAK4CvL = Var(f"?{mask}?userFloat('btagUParTAK4CvLrefined'):(?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'):-1)", float, precision=10),
-        btagUParTAK4QvG = Var(f"?{mask}?userFloat('btagUParTAK4QvGrefined'):(?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'):-1)", float, precision=10),
+        pt=None, btagDeepFlavB=None, btagDeepFlavCvB=None, btagDeepFlavCvL=None, btagDeepFlavQG=None,
+        btagUParTAK4B=None, btagUParTAK4CvB=None, btagUParTAK4CvL=None, btagUParTAK4QvG=None,
     )
+
+    process.puppiJetRefineNN = cms.EDProducer(
+        "JetBaseMVAValueMapProducer",
+        backend             = cms.string("ONNX"),
+        batch_eval          = cms.bool(True),
+        disableONNXGraphOpt = cms.bool(True),
+        src                 = cms.InputTag("linkedObjects","jets"),
+        weightFile          = cms.FileInPath("PhysicsTools/NanoAOD/data/fastSimPuppiJetRefineNN_31July2025.onnx"),
+        name                = cms.string("puppiJetRefineNN"),
+        variables = cms.VPSet(
+            cms.PSet(name=cms.string("GenJet_pt"),           expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().pt():pt")),
+            cms.PSet(name=cms.string("GenJet_eta"),          expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().eta():eta")),
+            cms.PSet(name=cms.string("Jet_hadronFlavour"),   expr=cms.string("hadronFlavour()")),
+            cms.PSet(name=cms.string("Jet_pt"),              expr=cms.string("pt()")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavB"),   expr=cms.string("bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavCvB"), expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')):-1")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavCvL"), expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')):-1")),
+            cms.PSet(name=cms.string("Jet_btagDeepFlavQG"),  expr=cms.string("?(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds'))>0?bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')):-1")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4B"),   expr=cms.string("bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4CvB"), expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'):-1")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4CvL"), expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'):-1")),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4QvG"), expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'):-1")),
+        ),
+        inputTensorName  = cms.string("input"),
+        outputTensorName = cms.string("output"),
+        outputNames      = cms.vstring(
+            "ptrefined",
+            "btagDeepFlavBrefined","btagDeepFlavCvBrefined","btagDeepFlavCvLrefined","btagDeepFlavQGrefined",
+            "btagUParTAK4Brefined","btagUParTAK4CvBrefined","btagUParTAK4CvLrefined","btagUParTAK4QvGrefined",
+        ),
+        outputFormulas   = cms.vstring("at(0)","at(1)","at(2)","at(3)","at(4)","at(5)","at(6)","at(7)","at(8)"),
+    )
+
+    #publish refined values directly under the plain names (FastSim only) via externalVariables
+    #originals still available as *_unrefined 
+    fastSim.toModify(process.jetPuppiTable.externalVariables,
+        pt              = ExtVar(cms.InputTag("puppiJetRefineNN","ptrefined"),                 float, precision=10, doc="Refined pT (FastSim only)"),
+        btagDeepFlavB   = ExtVar(cms.InputTag("puppiJetRefineNN","btagDeepFlavBrefined"),      float, precision=10, doc="DeepJet b+bb+lepb (refined)"),
+        btagDeepFlavCvB = ExtVar(cms.InputTag("puppiJetRefineNN","btagDeepFlavCvBrefined"),    float, precision=10, doc="DeepJet c vs b+bb+lepb (refined)"),
+        btagDeepFlavCvL = ExtVar(cms.InputTag("puppiJetRefineNN","btagDeepFlavCvLrefined"),    float, precision=10, doc="DeepJet c vs udsg (refined)"),
+        btagDeepFlavQG  = ExtVar(cms.InputTag("puppiJetRefineNN","btagDeepFlavQGrefined"),     float, precision=10, doc="DeepJet g vs uds (refined)"),
+        btagUParTAK4B   = ExtVar(cms.InputTag("puppiJetRefineNN","btagUParTAK4Brefined"),      float, precision=10, doc="UParT BvsAll (refined)"),
+        btagUParTAK4CvB = ExtVar(cms.InputTag("puppiJetRefineNN","btagUParTAK4CvBrefined"),    float, precision=10, doc="UParT CvsB (refined)"),
+        btagUParTAK4CvL = ExtVar(cms.InputTag("puppiJetRefineNN","btagUParTAK4CvLrefined"),    float, precision=10, doc="UParT CvsL (refined)"),
+        btagUParTAK4QvG = ExtVar(cms.InputTag("puppiJetRefineNN","btagUParTAK4QvGrefined"),    float, precision=10, doc="UParT QvsG (refined)"),
+    )
+
+    fastSim.toModify(process.jetPuppiTablesTask, process.jetPuppiTablesTask.add(process.puppiJetRefineNN))
 
     return process
+
+
+
 
 nanoAOD_refineFastSim_puppiJet = nanoAOD_refineFastSim_puppiJet

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -215,14 +215,8 @@ jetPuppiTable.variables.muonSubtrDeltaEta = Var("userFloat('muonSubtrRawEta') - 
 jetPuppiTable.variables.muonSubtrDeltaPhi = Var("userFloat('muonSubtrRawPhi') - phi()",float,doc="muon-subtracted raw phi - phi",precision=10)
 
 jetPuppiForMETTask =  cms.Task(basicJetsPuppiForMetForT1METNano,corrT1METJetPuppiTable)
-
-#before cross linking
 jetPuppiUserDataTask = cms.Task(hfJetPuppiShowerShapeforNanoAOD)
-
-#before cross linking
 jetPuppiTask = cms.Task(jetPuppiCorrFactorsNano,updatedJetsPuppi,jetPuppiUserDataTask,updatedJetsPuppiWithUserData,finalJetsPuppi)
-
-#after cross linkining
 jetPuppiTablesTask = cms.Task(jetPuppiTable)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
@@ -261,12 +255,9 @@ def nanoAOD_refineFastSim_puppiJet(process):
         outputFormulas   = cms.vstring([f"at({i})" for i in range(9)]),
     )
 
-    # schedule it in the jet-building chain
     fastSim.toModify(process.jetPuppiTask, process.jetPuppiTask.add(process.puppiJetRefineNN))
 
-    #
-    # 1) now stuff those 9 refined scalars into the existing PATJetUserDataEmbedder
-    #
+    # 1) now stuff the 9 refined scalars into the existing PATJetUserDataEmbedder
     fastSim.toModify(process.updatedJetsPuppiWithUserData.userFloats,
         ptRefined              = cms.InputTag("puppiJetRefineNN","ptrefined"),
         btagDeepFlavBrefined   = cms.InputTag("puppiJetRefineNN","btagDeepFlavBrefined"),
@@ -279,9 +270,7 @@ def nanoAOD_refineFastSim_puppiJet(process):
         btagUParTAK4QvGrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4QvGrefined"),
     )
 
-    #
     # 2) backup all 9 originals in the NanoAOD table as *_unrefined
-    #
     fastSim.toModify(process.jetPuppiTable.variables,
         pt_unrefined               = process.jetPuppiTable.variables.pt.clone(),
         btagDeepFlavB_unrefined    = process.jetPuppiTable.variables.btagDeepFlavB.clone(),
@@ -301,9 +290,7 @@ def nanoAOD_refineFastSim_puppiJet(process):
         btagUParTAK4CvL=None, btagUParTAK4QvG=None,
     )
 
-    #
     # 3) re‑define each branch with a FastSim‑only mask ternary
-    #
     mask = "(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')>0)"
 
     fastSim.toModify(process.jetPuppiTable.variables,

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -220,22 +220,11 @@ jetPuppiTask = cms.Task(jetPuppiCorrFactorsNano,updatedJetsPuppi,jetPuppiUserDat
 jetPuppiTablesTask = cms.Task(jetPuppiTable)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-from PhysicsTools.NanoAOD.common_cff import ExtVar
-
-import FWCore.ParameterSet.Config as cms
-from Configuration.Eras.Modifier_fastSim_cff import fastSim
-from PhysicsTools.NanoAOD.common_cff import Var
-
 from PhysicsTools.NanoAOD.common_cff import Var, ExtVar
-from Configuration.Eras.Modifier_fastSim_cff import fastSim
-
-from Configuration.Eras.Modifier_fastSim_cff import fastSim
-from PhysicsTools.NanoAOD.common_cff       import ExtVar, Var
-import FWCore.ParameterSet.Config           as cms
 
 def nanoAOD_refineFastSim_puppiJet(process):
 
-    #save originals and clear so we can republish
+    # 0. Save originals and clear so we can republish refined versions
     fastSim.toModify(process.jetPuppiTable.variables,
         pt_unrefined               = process.jetPuppiTable.variables.pt.clone(),
         btagDeepFlavB_unrefined    = process.jetPuppiTable.variables.btagDeepFlavB.clone(),
@@ -252,13 +241,13 @@ def nanoAOD_refineFastSim_puppiJet(process):
         btagUParTAK4B=None, btagUParTAK4CvB=None, btagUParTAK4CvL=None, btagUParTAK4QvG=None,
     )
 
-    # run refinement model and return features
+    # 1. Run refinement model and return features
     process.puppiJetRefineNN = cms.EDProducer(
         "JetBaseMVAValueMapProducer",
         backend             = cms.string("ONNX"),
         batch_eval          = cms.bool(True),
         disableONNXGraphOpt = cms.bool(True),
-        src                 = cms.InputTag("linkedObjects","jets"),  # <— matches table
+        src                 = cms.InputTag("linkedObjects","jets"),  # matches table
         weightFile          = cms.FileInPath("PhysicsTools/NanoAOD/data/fastSimPuppiJetRefineNN_31July2025.onnx"),
         name                = cms.string("puppiJetRefineNN"),
         variables = cms.VPSet(
@@ -273,25 +262,24 @@ def nanoAOD_refineFastSim_puppiJet(process):
             cms.PSet(name=cms.string("Jet_btagUParTAK4B"),   expr=cms.string("bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')")),
             cms.PSet(name=cms.string("Jet_btagUParTAK4CvB"), expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'):-1")),
             cms.PSet(name=cms.string("Jet_btagUParTAK4CvL"), expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'):-1")),
-            cms.PSet(name=cms.string("Jet_btagUParTAK4QvG"), expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'):-1")),
-        ),
+            cms.PSet(name=cms.string("Jet_btagUParTAK4QvG"), expr=cms.string("?(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')>0)?bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'):-1")),),
         inputTensorName  = cms.string("input"),
         outputTensorName = cms.string("output"),
         outputNames      = cms.vstring(
             "ptrefined",
             "btagDeepFlavBrefined","btagDeepFlavCvBrefined","btagDeepFlavCvLrefined","btagDeepFlavQGrefined",
-            "btagUParTAK4Brefined","btagUParTAK4CvBrefined","btagUParTAK4CvLrefined","btagUParTAK4QvGrefined",
-        ),
+            "btagUParTAK4Brefined","btagUParTAK4CvBrefined","btagUParTAK4CvLrefined","btagUParTAK4QvGrefined",),
         outputFormulas   = cms.vstring("at(0)","at(1)","at(2)","at(3)","at(4)","at(5)","at(6)","at(7)","at(8)"),
     )
     fastSim.toModify(process.jetPuppiTablesTask, process.jetPuppiTablesTask.add(process.puppiJetRefineNN))
 
-    #copy the ONNX ValueMaps onto jets as userFloats
+    # Ensure src is what we expect (redundant but explicit)
     process.puppiJetRefineNN.src = cms.InputTag("linkedObjects","jets")
-    
+
+    # 2. Copy the ONNX ValueMaps onto jets as userFloats
     process.finalJetsPuppiWithRefined = cms.EDProducer(
         "PATJetUserDataEmbedder",
-        src = cms.InputTag("linkedObjects","jets"),  # <— same!
+        src = cms.InputTag("linkedObjects","jets"),
         userFloats = cms.PSet(
             ptrefined              = cms.InputTag("puppiJetRefineNN","ptrefined"),
             btagDeepFlavBrefined   = cms.InputTag("puppiJetRefineNN","btagDeepFlavBrefined"),
@@ -301,29 +289,73 @@ def nanoAOD_refineFastSim_puppiJet(process):
             btagUParTAK4Brefined   = cms.InputTag("puppiJetRefineNN","btagUParTAK4Brefined"),
             btagUParTAK4CvBrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4CvBrefined"),
             btagUParTAK4CvLrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4CvLrefined"),
-            btagUParTAK4QvGrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4QvGrefined"),
-        )
+            btagUParTAK4QvGrefined = cms.InputTag("puppiJetRefineNN","btagUParTAK4QvGrefined"),)
     )
-    process.jetPuppiTable.src = cms.InputTag("finalJetsPuppiWithRefined")
-    
     fastSim.toModify(process.jetPuppiTablesTask, process.jetPuppiTablesTask.add(process.finalJetsPuppiWithRefined))
 
+    # Intermediate src: jets with refined userFloats
     process.jetPuppiTable.src = cms.InputTag("finalJetsPuppiWithRefined")
 
-    #mask jets we shouldn't be refining - Note: the -1 safety in the definitions of the original flavor taggers cannot be implemented in the following, because nested ternaries either crash the parser or confuse the logic and mess up the default values. The max(x,-1) is used as an alternative. 
+    # 3. Apply mask for all refined quantities in Nano (pt + taggers)
+    # Note: we keep all the masking logic here in python.
     _mask = "bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')>0"
+
     fastSim.toModify(process.jetPuppiTable.variables,
-        pt = Var(f"?{_mask}?userFloat('ptrefined'):pt()", float, precision=10),
-        btagDeepFlavB = Var(f"?{_mask}?userFloat('btagDeepFlavBrefined'):(bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))", float, precision=10),
-        btagDeepFlavCvB = Var(f"?{_mask}?userFloat('btagDeepFlavCvBrefined'):max(bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')),-1)", float, precision=10),#max(x,-1) safety because double-ternary not allowed 
-        btagDeepFlavCvL = Var(f"?{_mask}?userFloat('btagDeepFlavCvLrefined'):max(bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')),-1)", float, precision=10),#max(x,-1) safety because double-ternary not allowed 
-        btagDeepFlavQG = Var(f"?{_mask}?userFloat('btagDeepFlavQGrefined'):max(bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')),-1)", float, precision=10),#max(x,-1) safety because double-ternary not allowed 
-        btagUParTAK4B = Var(f"?{_mask}?userFloat('btagUParTAK4Brefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll'),-1)", float, precision=12),
-        btagUParTAK4CvB = Var(f"?{_mask}?userFloat('btagUParTAK4CvBrefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'),-1)", float, precision=12),
-        btagUParTAK4CvL = Var(f"?{_mask}?userFloat('btagUParTAK4CvLrefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'),-1)", float, precision=12),
-        btagUParTAK4QvG = Var(f"?{_mask}?userFloat('btagUParTAK4QvGrefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'),-1)", float, precision=12),        
+        pt = Var("?" + _mask + "?userFloat('ptrefined'):pt()", float, precision=10),
+        btagDeepFlavB = Var("?" + _mask + "?userFloat('btagDeepFlavBrefined'):(bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))", float, precision=10),
+        btagDeepFlavCvB = Var("?" + _mask + "?userFloat('btagDeepFlavCvBrefined'):max(bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')),-1)", float, precision=10),
+        btagDeepFlavCvL = Var("?" + _mask + "?userFloat('btagDeepFlavCvLrefined'):max(bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')),-1)", float, precision=10),
+        btagDeepFlavQG = Var("?" + _mask + "?userFloat('btagDeepFlavQGrefined'):max(bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')),-1)", float, precision=10),
+        btagUParTAK4B = Var("?" + _mask + "?userFloat('btagUParTAK4Brefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll'),-1)", float, precision=12),
+        btagUParTAK4CvB = Var("?" + _mask + "?userFloat('btagUParTAK4CvBrefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'),-1)", float, precision=12),
+        btagUParTAK4CvL = Var("?" + _mask + "?userFloat('btagUParTAK4CvLrefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'),-1)", float, precision=12),
+        btagUParTAK4QvG = Var("?" + _mask + "?userFloat('btagUParTAK4QvGrefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'),-1)", float, precision=12),
     )
+
+    # 4. Build pt_final as a userFloat on jets (mask applied), also do type 1 met correction
+    #    Note for future refinement: The mask definition above is also coded into the producer
+    process.processRefinedJets = cms.EDProducer(
+        "ProcessRefinedJets",  # or "FastSimPuppiRefinedJetProducer" if that is your C++ class name
+        jets            = cms.InputTag("finalJetsPuppiWithRefined"),
+        refinedPtName   = cms.string("ptrefined"),
+        maskBtagName    = cms.string("pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll"),
+        ptFinalName     = cms.string("pt_final"),
+        ptUnrefinedName = cms.string("pt_unrefined"),
+        met             = cms.InputTag("slimmedMETsPuppi"), # MET collection where type-1 refinement corrections 
+    )
+    fastSim.toModify(
+        process.jetPuppiTablesTask,
+        process.jetPuppiTablesTask.add(process.processRefinedJets)
+    )
+
+    #point PuppiMET Nano table to the *refined* MET collection
+    fastSim.toModify(
+        process.puppiMetTable,
+        src = cms.InputTag("processRefinedJets", "Refined"),
+    )
+
+    # And add _unrefined branches from the MET userFloats filled in C++
+    fastSim.toModify(
+        process.puppiMetTable.variables,
+        pt_unrefined  = Var("userFloat('pt_unrefined')",  float, precision=10),
+        phi_unrefined = Var("userFloat('phi_unrefined')", float, precision=10),
+    )
+
+    # 5. Sort jets by pt_final only
+    process.finalJetsPuppiSorted = cms.EDProducer(
+        "JetSorter",
+        src           = cms.InputTag("processRefinedJets"),
+        userFloatSorter = cms.string("pt_final"),
+        descending    = cms.bool(True),
+    )
+    fastSim.toModify(
+        process.jetPuppiTablesTask,
+        process.jetPuppiTablesTask.add(process.finalJetsPuppiSorted)
+    )
+    process.jetPuppiTable.src = cms.InputTag("finalJetsPuppiSorted")
+
     return process
+
 
 # bind for the customise step
 nanoAOD_refineFastSim_puppiJet = nanoAOD_refineFastSim_puppiJet

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -315,13 +315,13 @@ def nanoAOD_refineFastSim_puppiJet(process):
     fastSim.toModify(process.jetPuppiTable.variables,
         pt = Var(f"?{_mask}?userFloat('ptrefined'):pt()", float, precision=10),
         btagDeepFlavB = Var(f"?{_mask}?userFloat('btagDeepFlavBrefined'):(bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))", float, precision=10),
-        btagDeepFlavCvB = Var(f"?{_mask}?userFloat('btagDeepFlavCvBrefined'):bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))", float, precision=10),
-        btagDeepFlavCvL = Var(f"?{_mask}?userFloat('btagDeepFlavCvLrefined'):bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg'))", float, precision=10),
-        btagDeepFlavQG = Var(f"?{_mask}?userFloat('btagDeepFlavQGrefined'):bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds'))", float, precision=10),
-        btagUParTAK4B = Var(f"?{_mask}?userFloat('btagUParTAK4Brefined'):bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')", float, precision=12),
-        btagUParTAK4CvB = Var(f"?{_mask}?userFloat('btagUParTAK4CvBrefined'):bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB')", float, precision=12),
-        btagUParTAK4CvL = Var(f"?{_mask}?userFloat('btagUParTAK4CvLrefined'):bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL')", float, precision=12),
-        btagUParTAK4QvG = Var(f"?{_mask}?userFloat('btagUParTAK4QvGrefined'):bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG')", float, precision=12),        
+        btagDeepFlavCvB = Var(f"?{_mask}?userFloat('btagDeepFlavCvBrefined'):max(bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')),-1)", float, precision=10),#max(x,-1) safety because double-ternary not allowed 
+        btagDeepFlavCvL = Var(f"?{_mask}?userFloat('btagDeepFlavCvLrefined'):max(bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')),-1)", float, precision=10),#max(x,-1) safety because double-ternary not allowed 
+        btagDeepFlavQG = Var(f"?{_mask}?userFloat('btagDeepFlavQGrefined'):max(bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')),-1)", float, precision=10),#max(x,-1) safety because double-ternary not allowed 
+        btagUParTAK4B = Var(f"?{_mask}?userFloat('btagUParTAK4Brefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll'),-1)", float, precision=12),
+        btagUParTAK4CvB = Var(f"?{_mask}?userFloat('btagUParTAK4CvBrefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsB'),-1)", float, precision=12),
+        btagUParTAK4CvL = Var(f"?{_mask}?userFloat('btagUParTAK4CvLrefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:CvsL'),-1)", float, precision=12),
+        btagUParTAK4QvG = Var(f"?{_mask}?userFloat('btagUParTAK4QvGrefined'):max(bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:QvsG'),-1)", float, precision=12),        
     )
     return process
 

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -229,7 +229,7 @@ def nanoAOD_refineFastSim_puppiJet(process):
         batch_eval          = cms.bool(True),
         disableONNXGraphOpt = cms.bool(True),
         src                 = cms.InputTag("updatedJetsPuppi"),  # <<< HERE
-        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/model_refinement_regression_31July_long_opset11.onnx"),
+        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/model_fastsimrefine_puppi_31July2025.onnx"),
         name                = cms.string("puppiJetRefineNN"),
         variables = cms.VPSet(
             cms.PSet(name=cms.string("GenJet_pt"),            expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().pt():pt")),

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -229,7 +229,7 @@ def nanoAOD_refineFastSim_puppiJet(process):
         batch_eval          = cms.bool(True),
         disableONNXGraphOpt = cms.bool(True),
         src                 = cms.InputTag("updatedJetsPuppi"),  # <<< HERE
-        weightFile          = cms.FileInPath("model_refinement_regression_20250320_dynamic.onnx"),
+        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/model_fastsimrefine_puppi_31July2025.onnx"),
         name                = cms.string("puppiJetRefineNN"),
         variables = cms.VPSet(
             cms.PSet(name=cms.string("GenJet_pt"),            expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().pt():pt")),

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -229,7 +229,7 @@ def nanoAOD_refineFastSim_puppiJet(process):
         batch_eval          = cms.bool(True),
         disableONNXGraphOpt = cms.bool(True),
         src                 = cms.InputTag("updatedJetsPuppi"),  # <<< HERE
-        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/model_fastsimrefine_puppi_31July2025.onnx"),
+        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/fastSimPuppiJetRefineNN_31July2025.onnx"),
         name                = cms.string("puppiJetRefineNN"),
         variables = cms.VPSet(
             cms.PSet(name=cms.string("GenJet_pt"),            expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().pt():pt")),

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -310,7 +310,7 @@ def nanoAOD_refineFastSim_puppiJet(process):
 
     process.jetPuppiTable.src = cms.InputTag("finalJetsPuppiWithRefined")
 
-    #mask jets we shouldn't be refining - WARNING: the -1 safety in the definitions of the original flavor taggers cannot be implemented in the following. Multiple nested ternaries either crash the parser or confuse the logic and mess up the default values. 
+    #mask jets we shouldn't be refining - Note: the -1 safety in the definitions of the original flavor taggers cannot be implemented in the following, because nested ternaries either crash the parser or confuse the logic and mess up the default values. The max(x,-1) is used as an alternative. 
     _mask = "bDiscriminator('pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll')>0"
     fastSim.toModify(process.jetPuppiTable.variables,
         pt = Var(f"?{_mask}?userFloat('ptrefined'):pt()", float, precision=10),

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -229,7 +229,7 @@ def nanoAOD_refineFastSim_puppiJet(process):
         batch_eval          = cms.bool(True),
         disableONNXGraphOpt = cms.bool(True),
         src                 = cms.InputTag("updatedJetsPuppi"),  # <<< HERE
-        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/model_fastsimrefine_puppi_31July2025.onnx"),
+        weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/model_refinement_regression_31July_long_opset11.onnx"),
         name                = cms.string("puppiJetRefineNN"),
         variables = cms.VPSet(
             cms.PSet(name=cms.string("GenJet_pt"),            expr=cms.string("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().pt():pt")),

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -352,7 +352,10 @@ def nanoAOD_refineFastSim_puppiJet(process):
         process.jetPuppiTablesTask,
         process.jetPuppiTablesTask.add(process.finalJetsPuppiSorted)
     )
-    process.jetPuppiTable.src = cms.InputTag("finalJetsPuppiSorted")
+    fastSim.toModify(
+        process.jetPuppiTable,
+        src = cms.InputTag("finalJetsPuppiSorted")
+    )
 
     return process
 

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -313,7 +313,7 @@ def nanoAOD_customizeCommon(process):
     process = addTimeLifeInfoBase(process)
     
     process = nanoAOD_refineFastSim_puppiJet(process)
-    process = nanoAOD_refineFastSim_bTagDeepFlav(process)
+    process = nanoAOD_refineFastSim_bTagDeepFlav(process, nanoAOD_addDeepInfoAK4CHS_switch.nanoAOD_addDeepFlavourTag_switch)
 
     return process
 

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -308,10 +308,12 @@ def nanoAOD_customizeCommon(process):
         nanoAOD_boostedTau_switch, idsToAdd=["boostedDeepTauRunIIv2p0"]
     )
     nanoAOD_addBoostedTauIds(process, nanoAOD_boostedTau_switch.idsToAdd.value())
-
-    # Add lepton time-life info
+    
     from PhysicsTools.NanoAOD.leptonTimeLifeInfo_common_cff import addTimeLifeInfoBase
     process = addTimeLifeInfoBase(process)
+    
+    process = nanoAOD_refineFastSim_puppiJet(process)
+    process = nanoAOD_refineFastSim_bTagDeepFlav(process)
 
     return process
 


### PR DESCRIPTION
This PR backports the FastSim AK4 PUPPI jet refinement, e.g., for NANOv15, to CMSSW_15_0_X. It includes the following upstream PRs:

cms-sw/cmssw#48587
-main refinement functionality, replaces DeepJet, UParT branches with refined values and adds backup _unrefined branches for each.
cms-sw/cmssw#49429
-Type-1 MET correction based on the refined jet pT values.
cms-sw/cmssw#49400
-RelVal fixes needed to not break workflows. 

Please note that the original PR (listed above) is accompanied by the corresponding PR for cms-data, which contains the ML model as an ONNX file:

https://github.com/cms-data/PhysicsTools-NanoAOD/pull/20

But the file is not accessible when working in CMSSW_15_0_X, so we need to tweak cms-data. 

