### PR TITLE
Make `JetAnalyzer` independent of the Phase0 L1Trigger legacy code

### DIFF
--- a/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
@@ -59,13 +59,6 @@ process.load("DQM.HLTEvF.ScoutingElectronMonitoring_cff")
 process.load("DQM.HLTEvF.ScoutingRechitMonitoring_cff")
 process.load("DQM.HLTEvF.ScoutingDileptonMonitor_cfi")
 process.load("DQM.HLTEvF.ScoutingPi0Monitor_cfi")
-## Run-1 L1TGT required by ScoutingJetMonitoring https://github.com/cms-sw/cmssw/blob/master/DQMOffline/JetMET/src/JetAnalyzer.cc#L2603-L2611
-process.GlobalTag.toGet.append(
- cms.PSet(
- record = cms.string("L1GtTriggerMenuRcd"),
- tag = cms.string('L1GtTriggerMenu_CRAFT09_hlt'),
- )
-)
 
 process.p = cms.Path(process.dqmcommon *
                      process.hltOnlineBeamSpot *

--- a/DQMOffline/JetMET/interface/JetAnalyzer.h
+++ b/DQMOffline/JetMET/interface/JetAnalyzer.h
@@ -71,6 +71,9 @@
 #include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"
 #include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
 
+#include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
+#include "CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h"
+
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include <map>
 #include <string>
@@ -151,7 +154,10 @@ private:
 
   edm::InputTag inputJetIDValueMap;
   edm::EDGetTokenT<edm::ValueMap<reco::JetID>> jetID_ValueMapToken_;
+
+  bool isL1Tstage2_;
   edm::ESGetToken<L1GtTriggerMenu, L1GtTriggerMenuRcd> l1gtTrigMenuToken_;
+  edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> lutmTrigMenuToken_;
 
   //Cleaning parameters
   edm::ParameterSet cleaningParameters_;

--- a/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
@@ -83,8 +83,14 @@ jetDQMAnalyzerAk4CaloUncleaned = DQMEDAnalyzer('JetAnalyzer',
       DetectorTypes = cms.untracked.string("ecal:hbhe:hf"),
       #DebugOn = cms.untracked.bool(True),
       alwaysPass = cms.untracked.bool(False)
-    )
+    ),
+    stage2L1 = cms.bool(False) # by default use legacy L1T code
 )
+
+## change the default to stage2 for all current eras
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toModify(jetDQMAnalyzerAk4CaloUncleaned,
+                         stage2L1 = True)
 
 jetDQMAnalyzerAk4CaloCleaned=jetDQMAnalyzerAk4CaloUncleaned.clone(
     JetCleaningFlag   = True,


### PR DESCRIPTION
fixes https://github.com/cms-sw/cmssw/issues/48413

#### PR description:

The goal of this PR is make `JetAnalyzer` independent of the Phase0 L1 legacy code as reported in issue https://github.com/cms-sw/cmssw/issues/48413.
JME DQM is still relying on the Stage-0/1 L1T code (2015) to check if the event was in a bunch crossing or not (ie. if BPTX+ AND BPTX- fired).
This has two effects:
   * the record of the 2015 L1 GT (L1GtTriggerMenu) is missing in the recent global tag --> this gives a crash unless you force the addition of the missing record.
   * the behavior of this filter might be wrong.

This PR introduces a switch boolean `stage2L1` which makes `JetAnalyzer` fall back to the usage of the Stage2 L1T menu `L1TUtmTriggerMenu` (which is activated via the `stage2L1Trigger` modifier) and use that to check if the event is in a bunch crossing or not.
The lines in `DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py` introduced at https://github.com/cms-sw/cmssw/pull/48398 to provide the phase0 record are removed.

#### PR validation:

* `scram b runtests_TestDQMOnlineClient-scouting_dqm_sourceclient` runs;
* `runTheMatrix.py -l  run3` runs.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, to be backported to CMSSW_16_0_X for 2026 data-taking operations.