### PR TITLE
Phase2-hgx365O Make V18 also using cog as the default - thus removing the error report in the  ID test

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
+++ b/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
@@ -186,6 +186,7 @@ public:
   inline bool v16OrLess() const { return (mode_ < HGCalGeometryMode::Hexagon8Cassette); }
   inline bool v17OrLess() const { return (mode_ < HGCalGeometryMode::Hexagon8CalibCell); }
   inline bool v18OrLess() const { return (mode_ < HGCalGeometryMode::Hexagon8FineCell); }
+  inline bool v18OrMore() const { return (mode_ >= HGCalGeometryMode::Hexagon8CalibCell); }
   inline unsigned int volumes() const { return hgpar_->moduleLayR_.size(); }
   inline bool waferExist(int layer, int waferU, int waferV) const { return hgpar_->waferExist(layer, waferU, waferV); }
   int waferFromCopy(int copy) const;

--- a/Geometry/HGCalGeometry/src/HGCalGeometry.cc
+++ b/Geometry/HGCalGeometry/src/HGCalGeometry.cc
@@ -207,7 +207,7 @@ GlobalPoint HGCalGeometry::getPosition(const DetId& detid) const { return getPos
 
 GlobalPoint HGCalGeometry::getPosition(const DetId& detid, int overRideDebug) const {
   bool debug = ((overRideDebug % 10) > 0);
-  bool cog = m_topology.dddConstants().waferHexagon8Fine() ? true : false;
+  bool cog = m_topology.dddConstants().v18OrMore() ? true : false;
   if (((overRideDebug / 10) % 10) > 0) {
     if (cog)
       cog = false;


### PR DESCRIPTION
#### PR description:

Make V18 also using cog as the default - thus removing the error report in the  ID test

#### PR validation:

Tested using the scripts in Geometry/HGCalGeometry/test

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special