### PR TITLE
CloseBy smearing for Phase-1.

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -1,5 +1,6 @@
 # import the definition of the steps and input files:
-from  Configuration.PyReleaseValidation.relval_steps import *
+from Configuration.PyReleaseValidation.relval_steps import *
+from .MatrixUtil import Matrix
 
 # here only define the workflows as a combination of the steps defined above:
 workflows = Matrix()

--- a/Configuration/PyReleaseValidation/python/relval_Run4.py
+++ b/Configuration/PyReleaseValidation/python/relval_Run4.py
@@ -1,5 +1,6 @@
 # import the definition of the steps and input files:
-from  Configuration.PyReleaseValidation.relval_steps import *
+from Configuration.PyReleaseValidation.relval_steps import *
+from .MatrixUtil import Matrix
 
 # here only define the workflows as a combination of the steps defined above:
 workflows = Matrix()

--- a/Configuration/PyReleaseValidation/python/relval_cleanedupgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_cleanedupgrade.py
@@ -1,5 +1,6 @@
 # import the definition of the steps and input files:
-from  Configuration.PyReleaseValidation.relval_steps import *
+from Configuration.PyReleaseValidation.relval_steps import *
+from .MatrixUtil import Matrix
 
 # here only define the workflows as a combination of the steps defined above:
 workflows = Matrix()

--- a/Configuration/PyReleaseValidation/python/relval_data_highstats.py
+++ b/Configuration/PyReleaseValidation/python/relval_data_highstats.py
@@ -1,5 +1,6 @@
 # import the definition of the steps and input files:
-from  Configuration.PyReleaseValidation.relval_steps import *
+from Configuration.PyReleaseValidation.relval_steps import *
+from .MatrixUtil import Matrix
 from functools import partial
 
 # here only define the workflows as a combination of the steps defined above:

--- a/Configuration/PyReleaseValidation/python/relval_extendedgen.py
+++ b/Configuration/PyReleaseValidation/python/relval_extendedgen.py
@@ -2,6 +2,7 @@
 #
 # import the definition of the steps and input files:
 from Configuration.PyReleaseValidation.relval_steps import *
+from .MatrixUtil import Matrix
 
 # here only define the workflows as a combination of the steps defined above:
 workflows = Matrix()

--- a/Configuration/PyReleaseValidation/python/relval_ged.py
+++ b/Configuration/PyReleaseValidation/python/relval_ged.py
@@ -1,6 +1,7 @@
 
 # import the definition of the steps and input files:
-from  Configuration.PyReleaseValidation.relval_steps import *
+from Configuration.PyReleaseValidation.relval_steps import *
+from .MatrixUtil import Matrix
 
 # here only define the workflows as a combination of the steps defined above:
 workflows = Matrix()

--- a/Configuration/PyReleaseValidation/python/relval_generator.py
+++ b/Configuration/PyReleaseValidation/python/relval_generator.py
@@ -2,6 +2,7 @@
 #
 # import the definition of the steps and input files:
 from Configuration.PyReleaseValidation.relval_steps import *
+from .MatrixUtil import Matrix
 
 # here only define the workflows as a combination of the steps defined above:
 workflows = Matrix()

--- a/Configuration/PyReleaseValidation/python/relval_gpu.py
+++ b/Configuration/PyReleaseValidation/python/relval_gpu.py
@@ -1,6 +1,7 @@
 
 # import the definition of the steps and input files:
 from  Configuration.PyReleaseValidation.relval_steps import *
+from .MatrixUtil import Matrix
 
 # here only define the workflows as a combination of the steps defined above:
 workflows = Matrix()

--- a/Configuration/PyReleaseValidation/python/relval_highstats.py
+++ b/Configuration/PyReleaseValidation/python/relval_highstats.py
@@ -1,5 +1,6 @@
 # import the definition of the steps and input files:
 from  Configuration.PyReleaseValidation.relval_steps import *
+from .MatrixUtil import Matrix
 
 # here only define the workflows as a combination of the steps defined above:
 workflows = Matrix()

--- a/Configuration/PyReleaseValidation/python/relval_identity.py
+++ b/Configuration/PyReleaseValidation/python/relval_identity.py
@@ -1,6 +1,7 @@
 
 # import the definition of the steps and input files:
 from  Configuration.PyReleaseValidation.relval_steps import *
+from .MatrixUtil import Matrix
 
 # here only define the workflows as a combination of the steps defined above:
 workflows = Matrix()

--- a/Configuration/PyReleaseValidation/python/relval_machine.py
+++ b/Configuration/PyReleaseValidation/python/relval_machine.py
@@ -1,4 +1,4 @@
-from  Configuration.PyReleaseValidation.relval_steps import Matrix, InputInfo, Steps
+from .MatrixUtil import Matrix, InputInfo, Steps
 import os
 import json
 import collections

--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -1,4 +1,5 @@
 from Configuration.PyReleaseValidation.relval_steps import *
+from .MatrixUtil import Matrix
 import math
 
 

--- a/Configuration/PyReleaseValidation/python/relval_pileup.py
+++ b/Configuration/PyReleaseValidation/python/relval_pileup.py
@@ -1,5 +1,6 @@
 # import the definition of the steps and input files:
-from  Configuration.PyReleaseValidation.relval_steps import *
+from Configuration.PyReleaseValidation.relval_steps import *
+from .MatrixUtil import Matrix
 
 # here only define the workflows as a combination of the steps defined above:
 workflows = Matrix()

--- a/Configuration/PyReleaseValidation/python/relval_premix.py
+++ b/Configuration/PyReleaseValidation/python/relval_premix.py
@@ -1,5 +1,6 @@
 # import the definition of the steps and input files:
-from  Configuration.PyReleaseValidation.relval_steps import *
+from Configuration.PyReleaseValidation.relval_steps import *
+from .MatrixUtil import Matrix
 
 # here only define the workflows as a combination of the steps defined above:
 workflows = Matrix()

--- a/Configuration/PyReleaseValidation/python/relval_production.py
+++ b/Configuration/PyReleaseValidation/python/relval_production.py
@@ -1,5 +1,6 @@
 # import the definition of the steps and input files:
-from  Configuration.PyReleaseValidation.relval_steps import *
+from Configuration.PyReleaseValidation.relval_steps import *
+from .MatrixUtil import Matrix
 
 # here only define the workflows as a combination of the steps defined above:
 workflows = Matrix()

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -1,5 +1,6 @@
 # import the definition of the steps and input files:
 from Configuration.PyReleaseValidation.relval_steps import *
+from .MatrixUtil import Matrix
 
 # here only define the workflows as a combination of the steps defined above:
 workflows = Matrix()

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1,8 +1,8 @@
 import sys
-import copy
+from copy import deepcopy
 from functools import partial
 
-from .MatrixUtil import *
+from .MatrixUtil import Steps, merge, remove, Kby, Mby, genvalid, InputInfo, selectedLS, stCond
 
 from Configuration.HLT.autoHLT import autoHLT
 from Configuration.AlCa.autoPCL import autoPCL
@@ -3811,9 +3811,6 @@ steps['RECOHIR10D11']=merge([{'--filein':'file:step2_inREPACKRAW.root',
 #                        '-s':'RECO,HLT:@fake,VALIDATION'},
 #                       steps['RECO']])
 
-#add this line when testing from an input file that is not strictly GEN-SIM
-#addForAll(step3,{'--hltProcess':'DIGI'})
-
 steps['ALCACOSD']={'--conditions':'auto:run1_data',
                    '--datatier':'ALCARECO',
                    '--eventcontent':'ALCARECO',
@@ -4943,7 +4940,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
     
     if beamspot is not None: upgradeStepDict['GenSim'][k]['--beamspot']=beamspot
 
-    upgradeStepDict['GenSimCloseBy'][k] = copy.deepcopy(upgradeStepDict['GenSim'][k])
+    upgradeStepDict['GenSimCloseBy'][k] = deepcopy(upgradeStepDict['GenSim'][k])
     upgradeStepDict['GenSimCloseBy'][k]['--beamspot'] = 'CloseBy'
     
     upgradeStepDict['GenSimHLBeamSpot'][k] = {'-s' : 'GEN,SIM',
@@ -4955,7 +4952,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                               '--geometry' : geom
                                               }
 
-    upgradeStepDict['GenSimHLBeamSpot14'][k] = copy.deepcopy(upgradeStepDict['GenSimHLBeamSpot'][k])
+    upgradeStepDict['GenSimHLBeamSpot14'][k] = deepcopy(upgradeStepDict['GenSimHLBeamSpot'][k])
     upgradeStepDict['GenSimHLBeamSpot14'][k]['--conditions'] = gt
 
     upgradeStepDict['GenSimHLBeamSpotCloseBy'][k] = upgradeStepDict['GenSimCloseBy'][k]
@@ -4980,14 +4977,14 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                   '--geometry' : geom
                                   }
     
-    upgradeStepDict['DigiNoHLT'][k] = copy.deepcopy(upgradeStepDict['Digi'][k])
+    upgradeStepDict['DigiNoHLT'][k] = deepcopy(upgradeStepDict['Digi'][k])
     upgradeStepDict['DigiNoHLT'][k]['-s'] = 'DIGI:pdigi_valid,L1,DIGI2RAW'
     
-    upgradeStepDict['HLTOnly'][k] = copy.deepcopy(upgradeStepDict['Digi'][k])
+    upgradeStepDict['HLTOnly'][k] = deepcopy(upgradeStepDict['Digi'][k])
     upgradeStepDict['HLTOnly'][k]['-s'] = 'HLT:%s'%(hltversion)
 
     # Adding Track trigger step in step2
-    upgradeStepDict['DigiTrigger'][k] = copy.deepcopy(upgradeStepDict['Digi'][k])
+    upgradeStepDict['DigiTrigger'][k] = deepcopy(upgradeStepDict['Digi'][k])
     upgradeStepDict['DigiTrigger'][k]['-s'] = 'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:%s'%(hltversion)
 
     upgradeStepDict['HLTRun3'][k] = {'-s':'HLT:%s'%(hltversion),

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1,4 +1,5 @@
 import sys
+import copy
 from functools import partial
 
 from .MatrixUtil import *
@@ -4931,96 +4932,72 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
     upgradeStepDict['GenHLBeamSpot'][k] = merge([{'--conditions' : gt+'_13TeV'}, upgradeStepDict['Gen'][k]])
     upgradeStepDict['GenHLBeamSpot14'][k] = merge([{}, upgradeStepDict['Gen'][k]])
     
-    upgradeStepDict['GenSim'][k]= {'-s' : 'GEN,SIM',
-                                       '-n' : 10,
-                                       '--conditions' : gt,
-                                       '--beamspot' : 'Realistic25ns13TeVEarly2017Collision',
-                                       '--datatier' : 'GEN-SIM',
-                                       '--eventcontent': 'FEVTDEBUG',
-                                       '--geometry' : geom
-                                       }
+    upgradeStepDict['GenSim'][k] = {'-s' : 'GEN,SIM',
+                                    '-n' : 10,
+                                    '--conditions' : gt,
+                                    '--beamspot' : 'Realistic25ns13TeVEarly2017Collision',
+                                    '--datatier' : 'GEN-SIM',
+                                    '--eventcontent': 'FEVTDEBUG',
+                                    '--geometry' : geom
+                                    }
     
     if beamspot is not None: upgradeStepDict['GenSim'][k]['--beamspot']=beamspot
 
-    upgradeStepDict['GenSimHLBeamSpot'][k]= {'-s' : 'GEN,SIM',
-                                       '-n' : 10,
-                                       '--conditions' : gt+'_13TeV',
-                                       '--beamspot' : 'DBrealisticHLLHC',
-                                       '--datatier' : 'GEN-SIM',
-                                       '--eventcontent': 'FEVTDEBUG',
-                                       '--geometry' : geom
-                                       }
+    upgradeStepDict['GenSimCloseBy'][k] = copy.deepcopy(upgradeStepDict['GenSim'][k])
+    upgradeStepDict['GenSimCloseBy'][k]['--beamspot'] = 'CloseBy'
+    
+    upgradeStepDict['GenSimHLBeamSpot'][k] = {'-s' : 'GEN,SIM',
+                                              '-n' : 10,
+                                              '--conditions' : gt+'_13TeV',
+                                              '--beamspot' : 'DBrealisticHLLHC',
+                                              '--datatier' : 'GEN-SIM',
+                                              '--eventcontent': 'FEVTDEBUG',
+                                              '--geometry' : geom
+                                              }
 
-    upgradeStepDict['GenSimHLBeamSpot14'][k]= {'-s' : 'GEN,SIM',
-                                       '-n' : 10,
-                                       '--conditions' : gt,
-                                       '--beamspot' : 'DBrealisticHLLHC',
-                                       '--datatier' : 'GEN-SIM',
-                                       '--eventcontent': 'FEVTDEBUG',
-                                       '--geometry' : geom
-                                       }
+    upgradeStepDict['GenSimHLBeamSpot14'][k] = copy.deepcopy(upgradeStepDict['GenSimHLBeamSpot'][k])
+    upgradeStepDict['GenSimHLBeamSpot14'][k]['--conditions'] = gt
 
-    upgradeStepDict['GenSimHLBeamSpotCloseBy'][k]= {'-s' : 'GEN,SIM',
-                                       '-n' : 10,
-                                       '--conditions' : gt,
-                                       '--beamspot' : 'CloseBy',
-                                       '--datatier' : 'GEN-SIM',
-                                       '--eventcontent': 'FEVTDEBUG',
-                                       '--geometry' : geom
-                                       }
-
-    upgradeStepDict['Sim'][k]= {'-s' : 'SIM',
-                                       '-n' : 10,
-                                       '--conditions' : gt,
-                                       '--beamspot' : 'Realistic25ns13TeVEarly2017Collision',
-                                       '--datatier' : 'SIM',
-                                       '--eventcontent': 'FEVTDEBUG',
-                                       '--geometry' : geom
-                                       }
+    upgradeStepDict['GenSimHLBeamSpotCloseBy'][k] = upgradeStepDict['GenSimCloseBy'][k]
+    
+    upgradeStepDict['Sim'][k] = {'-s' : 'SIM',
+                                 '-n' : 10,
+                                 '--conditions' : gt,
+                                 '--beamspot' : 'Realistic25ns13TeVEarly2017Collision',
+                                 '--datatier' : 'SIM',
+                                 '--eventcontent': 'FEVTDEBUG',
+                                 '--geometry' : geom
+                                 }
     
     if beamspot is not None: upgradeStepDict['Sim'][k]['--beamspot']=beamspot
     
 
     upgradeStepDict['Digi'][k] = {'-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:%s'%(hltversion),
-                                      '--conditions':gt,
-                                      '--datatier':'GEN-SIM-DIGI-RAW',
-                                      '-n':'10',
-                                      '--eventcontent':'FEVTDEBUGHLT',
-                                      '--geometry' : geom
-                                      }
+                                  '--conditions':gt,
+                                  '--datatier':'GEN-SIM-DIGI-RAW',
+                                  '-n':'10',
+                                  '--eventcontent':'FEVTDEBUGHLT',
+                                  '--geometry' : geom
+                                  }
     
-    upgradeStepDict['DigiNoHLT'][k] = {'-s':'DIGI:pdigi_valid,L1,DIGI2RAW',
-                                      '--conditions':gt,
-                                      '--datatier':'GEN-SIM-DIGI-RAW',
-                                      '-n':'10',
-                                      '--eventcontent':'FEVTDEBUGHLT',
-                                      '--geometry' : geom
-                                      }
+    upgradeStepDict['DigiNoHLT'][k] = copy.deepcopy(upgradeStepDict['Digi'][k])
+    upgradeStepDict['DigiNoHLT'][k]['-s'] = 'DIGI:pdigi_valid,L1,DIGI2RAW'
     
-    upgradeStepDict['HLTOnly'][k] = {'-s':'HLT:%s'%(hltversion),
-                                 '--conditions':gt,
-                                 '--datatier':'GEN-SIM-DIGI-RAW',
-                                 '-n':'10',
-                                 '--eventcontent':'FEVTDEBUGHLT',
-                                 '--geometry' : geom,
-                                 }
+    upgradeStepDict['HLTOnly'][k] = copy.deepcopy(upgradeStepDict['Digi'][k])
+    upgradeStepDict['HLTOnly'][k]['-s'] = 'HLT:%s'%(hltversion)
+
     # Adding Track trigger step in step2
-    upgradeStepDict['DigiTrigger'][k] = {'-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:%s'%(hltversion),
-                                      '--conditions':gt,
-                                      '--datatier':'GEN-SIM-DIGI-RAW',
-                                      '-n':'10',
-                                      '--eventcontent':'FEVTDEBUGHLT',
-                                      '--geometry' : geom
-                                      }
+    upgradeStepDict['DigiTrigger'][k] = copy.deepcopy(upgradeStepDict['Digi'][k])
+    upgradeStepDict['DigiTrigger'][k]['-s'] = 'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:%s'%(hltversion)
 
     upgradeStepDict['HLTRun3'][k] = {'-s':'HLT:%s'%(hltversion),
-                                 '--conditions':gt,
-                                 '--datatier':'GEN-SIM-DIGI-RAW',
-                                 '-n':'10',
-                                 '--eventcontent':'FEVTDEBUGHLT',
-                                 '--geometry' : geom,
-                                 '--outputCommands' : '"drop *_*_*_GEN,drop *_*_*_DIGI2RAW"'
-                                 }
+                                     '--conditions':gt,
+                                     '--datatier':'GEN-SIM-DIGI-RAW',
+                                     '-n':'10',
+                                     '--eventcontent':'FEVTDEBUGHLT',
+                                     '--geometry' : geom,
+                                     '--outputCommands' : '"drop *_*_*_GEN,drop *_*_*_DIGI2RAW"'
+                                     }
 
     upgradeStepDict['HLT75e33'][k] = {'-s':'HLT:@relvalRun4',
                                       '--processName':'HLTX',

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -1,5 +1,6 @@
 # import the definition of the steps and input files:
 from  Configuration.PyReleaseValidation.relval_steps import *
+from .MatrixUtil import Matrix
 
 # here only define the workflows as a combination of the steps defined above:
 workflows = Matrix()

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -40,8 +40,10 @@ for year in upgradeKeys:
                     if 'HLBeamSpot' in step:
                         if '14TeV' in frag:
                             step = 'GenSimHLBeamSpot14'
-                        if 'CloseBy' in frag or 'CE_E' in frag or 'CE_H' in frag:
+                        elif 'CloseBy' in frag or 'CE_E' in frag or 'CE_H' in frag:
                             step = 'GenSimHLBeamSpotCloseBy'
+                    elif 'CloseBy' in frag or 'CE_E' in frag or 'CE_H' in frag:
+                        step = 'GenSimCloseBy'
                     stepMaker = makeStepNameSim
                 elif 'Gen' in step:
                     if 'HLBeamSpot' in step:

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -207,6 +207,7 @@ upgradeWFs['baseline'] = UpgradeWorkflow_baseline(
         'GenHLBeamSpot14',
         'Sim',
         'GenSim',
+        'GenSimCloseBy',
         'GenSimHLBeamSpot',
         'GenSimHLBeamSpot14',
         'GenSimHLBeamSpotCloseBy',

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1,4 +1,4 @@
-from copy import copy, deepcopy
+from copy import deepcopy
 from collections import OrderedDict
 from .MatrixUtil import merge, Kby, Mby, check_dups
 import re


### PR DESCRIPTION
Follows https://github.com/cms-sw/cmssw/pull/49584, which only considered Phase-2 workflows, via `GenSimHLBeamSpotCloseBy`. This PR adds the `GenSimCloseBy` step.
I've avoided some code duplication when most of the options of several steps are identical.

**PR validation:**

Note the `--beamspot CloseBy` option.

+ Phase-2:

```shell
$ runTheMatrix.py -w upgrade -el 34553.0 --show                      
(...)

34553.0 CloseByPGun_Barrel_Front_Run4D121_GenSimHLBeamSpotCloseBy+DigiTrigger_Run4D121+RecoGlobal_Run4D121+HARVESTGlobal_Run4D121+ALCAPhase2_Run4D121 [1]: cmsDriver.py Close
ByPGun_Barrel_Front_cfi  -s GEN,SIM -n 10 --conditions auto:phase2_realistic_T35 --beamspot CloseBy --datatier GEN-SIM --eventcontent FEVTDEBUG --geometry ExtendedRun4D121 -
-era Phase2C22I13M9 --relval 9000,100 
                                           [2]: cmsDriver.py step2  -s DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:@relvalRun4 --conditions auto:phase2_realistic_
T35 --datatier GEN-SIM-DIGI-RAW -n 10 --eventcontent FEVTDEBUGHLT --geometry ExtendedRun4D121 --era Phase2C22I13M9
                                           [3]: cmsDriver.py step3  -s RAW2DIGI,RECO,RECOSIM,PAT,VALIDATION:@phase2Validation+@miniAODValidation,DQM:@phase2+@miniAODDQM --co
nditions auto:phase2_realistic_T35 --datatier GEN-SIM-RECO,MINIAODSIM,DQMIO -n 10 --eventcontent FEVTDEBUGHLT,MINIAODSIM,DQM --geometry ExtendedRun4D121 --era Phase2C22I13M9
                                           [4]: cmsDriver.py step4  -s HARVESTING:@phase2Validation+@phase2+@miniAODValidation+@miniAODDQM --conditions auto:phase2_realistic
_T35 --mc  --geometry ExtendedRun4D121 --scenario pp --filetype DQM --era Phase2C22I13M9 -n 100 
                                           [5]: cmsDriver.py step5  -s ALCA:SiPixelCalSingleMuonLoose+SiPixelCalSingleMuonTight+TkAlMuonIsolated+TkAlMinBias+MuAlOverlaps+Eca
lESAlign+TkAlZMuMu+TkAlDiMuonAndVertex+HcalCalHBHEMuonProducerFilter+TkAlUpsilonMuMu+TkAlJpsiMuMu --conditions auto:phase2_realistic_T35 --datatier ALCARECO -n 10 --eventcon
tent ALCARECO --geometry ExtendedRun4D121 --era Phase2C22I13M9

1 workflows with 5 steps
```

+ Run-3:

```shell
 $ runTheMatrix.py -w upgrade -el 34553.0 --show                      
(...)                                                                                                                   
                                                                                                                                                                             
16953.0 CloseByPGun_Barrel_Front_2025_GenSimCloseBy+Digi_2025+RecoNanoFakeHLT_2025+HARVESTNanoFakeHLT_2025+ALCA_2025 [1]: cmsDriver.py CloseByPGun_Barrel_Front_cfi  -s GEN,SIM -n 10 --conditions auto:phase1_2025_realistic --beamspot CloseBy --datatier GEN-SIM --eventcontent FEVTDEBUG --geometry DB:Extended --era Run3_2025 --relval 9000,100 
                                           [2]: cmsDriver.py step2  -s DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@relval2025 --conditions auto:phase1_2025_realistic --datatier GEN-SIM-DIGI-RAW -n 10 --eventcontent FEVTDEBUGHLT --geometry DB:Extended --era Run3_2025
                                           [3]: cmsDriver.py step3  -s RAW2DIGI,L1Reco,RECO,RECOSIM,PAT,NANO,VALIDATION:@standardValidationNoHLT+@miniAODValidation,DQM:@standardDQMFakeHLT+@miniAODDQM+@nanoAODDQM --conditions auto:phase1_2025_realistic --datatier GEN-SIM-RECO,MINIAODSIM,NANOAODSIM,DQMIO -n 10 --eventcontent RECOSIM,MINIAODSIM,NANOEDMAODSIM,DQM --geometry DB:Extended --era Run3_2025
                                           [4]: cmsDriver.py step4  -s HARVESTING:@standardValidationNoHLT+@standardDQMFakeHLT+@miniAODValidation+@miniAODDQM+@nanoAODDQM --conditions auto:phase1_2025_realistic --mc  --geometry DB:Extended --scenario pp --filetype DQM --era Run3_2025 -n 100 
                                           [5]: cmsDriver.py step5  -s ALCA:SiPixelCalSingleMuonLoose+SiPixelCalSingleMuonTight+TkAlMuonIsolated+TkAlMinBias+MuAlOverlaps+EcalESAlign+TkAlZMuMu+TkAlDiMuonAndVertex+HcalCalHBHEMuonProducerFilter+TkAlUpsilonMuMu+TkAlJpsiMuMu+SiStripCalMinBias --conditions auto:phase1_2025_realistic --datatier ALCARECO -n 10 --eventcontent ALCARECO --geometry DB:Extended --era Run3_2025
```

Both workflows are now using `IOMC.EventVertexGenerators.VtxSmearedCloseBy_cfi`.