### PR TITLE
Drop py3-html5lib unit test

### DIFF
--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -51,7 +51,6 @@
 <test name="import-future" command="python3 -c 'import future'"/>
 <test name="import-concurrent.futures" command="python3 -c 'import concurrent.futures'"/>
 <test name="import-h5py" command="python3 -c 'import h5py'"/>
-<test name="import-html5lib" command="python3 -c 'import html5lib'"/>
 <test name="import-idna" command="python3 -c 'import idna'"/>
 <test name="import-ipykernel" command="python3 -c 'import ipykernel'"/>
 <test name="import-ipython_genutils" command="python3 -c 'import ipython_genutils'"/>


### PR DESCRIPTION
Drop unit tests for testing/importing `html5lib`. It was indirect dependency of few other python packages (`bleach`, `poetry`),  but newer version of these packages do not depend on it.