### PR TITLE
Update the online GTs in autoCond with some frozen at 2026-02-23

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -31,12 +31,12 @@ autoCond = {
     'run2_data_promptlike_hi'      :    '140X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              :    '140X_dataRun2_HLT_relval_v1',
-    # GlobalTag for Run3 HLT: identical the online GT 150X_dataRun3_HLT_v1 but with snapshot at 2025-06-13 05:00:25 (UTC)
-    'run3_hlt'                     :    '150X_dataRun3_HLT_frozen250613_v1',
-    # GlobalTag for Run3 data relvals (express GT): same as 150X_dataRun3_Express_v1 but with snapshot at 2025-06-13 05:03:22 (UTC)
-    'run3_data_express'            :    '150X_dataRun3_Express_frozen250613_v1',
-    # GlobalTag for Run3 data relvals (prompt GT): same as 150X_dataRun3_Prompt_v1 but with snapshot at 2025-06-13 05:06:05 (UTC)
-    'run3_data_prompt'             :    '150X_dataRun3_Prompt_frozen250613_v1',
+    # GlobalTag for Run3 HLT: identical the online GT 160X_dataRun3_HLT_v1 but with snapshot at 2026-02-23 14:53:19 (UTC)
+    'run3_hlt'                     :    '160X_dataRun3_HLT_frozen260223_v1',
+    # GlobalTag for Run3 data relvals (express GT): same as 160X_dataRun3_Express_v1 but with snapshot at 2026-02-23 14:53:19 (UTC)
+    'run3_data_express'            :    '160X_dataRun3_Express_frozen260223_v1',
+    # GlobalTag for Run3 data relvals (prompt GT): same as 160X_dataRun3_Prompt_v1 but with snapshot at 2026-02-23 14:53:19 (UTC)
+    'run3_data_prompt'             :    '160X_dataRun3_Prompt_frozen260223_v1',
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2025-11-11 14:11:48 (UTC)
     'run3_data'                    :    '150X_dataRun3_v6',
     # GlobalTag for Run3 offline data reprocessing with Prompt GT, currently for 2022FG - snapshot at 2024-05-31 08:53:25 (UTC)


### PR DESCRIPTION
#### PR description:

Replace the online GTs in autoCond with some updated ones, because the current keys in autoCond for the HLT, Express and Prompt workflows are very outdated and the snapshot is set to June 2025 (as pointed out in the [github issue #50220](https://github.com/cms-sw/cmssw/issues/50220#issuecomment-3945045601))

Online GTs for 2026 pp data taking will be:
- 160X_dataRun3_HL T_v1
- 160X_dataRun3_Express_v1
- 160X_dataRun3_Prompt_v1

Therefore, the online GTs in autoCond are set here to those ones, frozen at 2026-02-23 14:53:19

The difference between the baseline 2026 online GTs and the frozen ones is null now, and it will show the additional payloads attached to the current tags as times go by:
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/160X_dataRun3_HLT_frozen260223_v1/160X_dataRun3_HLT_v1
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/160X_dataRun3_Express_frozen260223_v1/160X_dataRun3_Express_v1
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/160X_dataRun3_Prompt_frozen260223_v1/160X_dataRun3_Prompt_v1

For documentation purposes, let me list here also the differences with the frozen online GTs previously in autoCond:

- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/160X_dataRun3_HLT_frozen260223_v1/150X_dataRun3_HLT_frozen250613_v1
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/160X_dataRun3_Express_frozen260223_v1/150X_dataRun3_Express_frozen250613_v1
-  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/160X_dataRun3_Prompt_frozen260223_v1/150X_dataRun3_Prompt_frozen250613_v1

Solves https://github.com/cms-sw/cmssw/issues/50220

#### PR validation:

Rely on bot tests

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

It will get backported to CMSSW_16_0_X