### PR TITLE
Removed gradients computation by default for PyTorch inference

### DIFF
--- a/PhysicsTools/PyTorch/interface/Model.h
+++ b/PhysicsTools/PyTorch/interface/Model.h
@@ -27,7 +27,11 @@ namespace cms::torch {
     }
 
     // Forward pass (inference) of model, returns torch::IValue (multi output support). Match native torchlib interface.
-    ::torch::IValue forward(std::vector<::torch::IValue> &inputs) { return model_.forward(inputs); }
+    ::torch::IValue forward(std::vector<::torch::IValue> &inputs) {
+      // Disabling autograd
+      ::torch::NoGradGuard no_grad_guard;
+      return model_.forward(inputs);
+    }
 
     // Get model current device information.
     ::torch::Device device() const { return device_; }


### PR DESCRIPTION
#### PR description:
The PR adds a standard pytorch RAAI ([docs](https://docs.pytorch.org/cppdocs/api/typedef_namespacetorch_1abf2c764801b507b6a105664a2406a410.html)) which disables the gradient tracking in the current thread for PyTorch model inference. 

The statement is added in the central CMSSW PyTorch interface and works both for direct PyTorch inference and PyTorch-Alpaka models.

#### PR effects
No side effects expected. Expected memory requirements reduction. 