### PR TITLE
L1S: fixes to the `ScoutingJetProducer` plugin (eta/phi values, sorting of outputs)

### DIFF
--- a/L1TriggerScouting/OnlineProcessing/plugins/BuildFile.xml
+++ b/L1TriggerScouting/OnlineProcessing/plugins/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="DataFormats/L1Trigger"/>
 <use name="DataFormats/Math"/>
 <use name="FWCore/Framework"/>
+<use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
 <use name="L1TriggerScouting/Utilities"/>

--- a/L1TriggerScouting/OnlineProcessing/plugins/ScoutingJetProducer.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/ScoutingJetProducer.cc
@@ -106,9 +106,10 @@ void ScoutingJetProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::
     for (const auto& incJet : incJets) {
       int nConst = incJet.has_constituents() ? incJet.constituents().size() : 0;
       float area = incJet.has_area() ? incJet.area() : -1.0f;
+      // use phi_std(), instead of phi(), in order to have angles in the range (-pi,pi]
       bufferThisBX.emplace_back(MiniFloatConverter::reduceMantissaToNbitsRounding(incJet.Et(), mantissaPrecision_),
                                 MiniFloatConverter::reduceMantissaToNbitsRounding(incJet.eta(), mantissaPrecision_),
-                                MiniFloatConverter::reduceMantissaToNbitsRounding(incJet.phi(), mantissaPrecision_),
+                                MiniFloatConverter::reduceMantissaToNbitsRounding(incJet.phi_std(), mantissaPrecision_),
                                 MiniFloatConverter::reduceMantissaToNbitsRounding(incJet.m(), mantissaPrecision_),
                                 nConst,
                                 MiniFloatConverter::reduceMantissaToNbitsRounding(area, mantissaPrecision_));

--- a/L1TriggerScouting/Utilities/interface/conversion.h
+++ b/L1TriggerScouting/Utilities/interface/conversion.h
@@ -2,7 +2,7 @@
 #define L1TriggerScouting_Utilities_conversion_h
 
 #include "L1TriggerScouting/Utilities/interface/scales.h"
-#include <cmath>
+#include <cstdint>
 
 namespace l1ScoutingRun3 {
 
@@ -34,10 +34,20 @@ namespace l1ScoutingRun3 {
 
   namespace calol1 {
 
-    inline float fEt(int hwEt) { return scales::et_scale * hwEt; };
-    inline float fEta(int hwEta) { return scales::eta_scale * hwEta; };
-    inline float fPhi(int hwPhi) { return _setPhiRange(scales::phi_scale * hwPhi); };
+    inline float fEt(int16_t hwEt) { return scales::et_scale * hwEt; };
 
+    inline constexpr int16_t kHwEtaAbsMin = 1;
+    inline constexpr int16_t kHwEtaAbsMax = 41;
+    inline constexpr int16_t kHwEtaAbsHFFirst = 29;
+
+    bool validHwEta(int16_t hwEta);
+    float fEta(int16_t hwEta);
+
+    inline constexpr int16_t kHwPhiMin = 1;
+    inline constexpr int16_t kHwPhiMax = 72;
+
+    bool validHwPhi(int16_t hwPhi);
+    float fPhi(int16_t hwPhi);
   }  // namespace calol1
 
 }  // namespace l1ScoutingRun3

--- a/L1TriggerScouting/Utilities/interface/scales.h
+++ b/L1TriggerScouting/Utilities/interface/scales.h
@@ -1,7 +1,6 @@
 #ifndef L1TriggerScouting_Utilities_scales_h
 #define L1TriggerScouting_Utilities_scales_h
 
-#include <cstdint>
 #include <cmath>
 
 namespace l1ScoutingRun3 {
@@ -28,9 +27,7 @@ namespace l1ScoutingRun3 {
 
   namespace calol1 {
     struct scales {
-      static constexpr float phi_scale = 0.0870;
-      static constexpr float eta_scale = 0.0870;
-      static constexpr float et_scale = 0.5;
+      static constexpr float et_scale = 0.5f;
     };
   }  // namespace calol1
 

--- a/L1TriggerScouting/Utilities/src/conversion.cc
+++ b/L1TriggerScouting/Utilities/src/conversion.cc
@@ -1,0 +1,47 @@
+#include <algorithm>
+#include <cmath>
+
+#include "L1TriggerScouting/Utilities/interface/conversion.h"
+
+bool l1ScoutingRun3::calol1::validHwEta(int16_t hwEta) {
+  auto const hwEtaAbs = std::abs(hwEta);
+  return (hwEtaAbs >= kHwEtaAbsMin and hwEtaAbs <= kHwEtaAbsMax and hwEtaAbs != kHwEtaAbsHFFirst);
+}
+
+float l1ScoutingRun3::calol1::fEta(int16_t hwEta) {
+  //
+  // The array kTowerEtas in this function holds the average (midpoint) of
+  // the pseudorapidity boundaries of the calorimeter towers used in the level-1 trigger.
+  // These values are based on those listed in CMS NOTE 2005/016 (Table 1),
+  // and used in the function l1t::CaloTools::towerEta() implemented in
+  //   L1Trigger/L1TCalorimeter/src/CaloTools.cc
+  //
+  // Note: the midpoint of tower 28 in this function is based on the pseudorapidity boundaries
+  // given in CMS NOTE 2005/016 for that tower (i.e. 2.650 < |eta| < 3.000),
+  // while in l1t::CaloTools::towerEta() the outer edge of tower 28
+  // corresponds to the start of the first HF tower (i.e. 2.650 < |eta| < 2.853).
+  //
+  // Three non-physical values are used in kTowerEtas at indices 0, 29, and 42.
+  // These correspond to |ieta| values that L1T calorimeter towers are never supposed to have
+  // (with 42 corresponding to any |ieta| value higher than 41).
+  //
+  static constexpr float kTowerEtas[kHwEtaAbsMax + 2] = {
+      9999.0f, 0.0435f, 0.1305f, 0.2175f, 0.3045f, 0.3915f, 0.4785f, 0.5655f, 0.6525f, 0.7395f, 0.8265f,
+      0.9135f, 1.0005f, 1.0875f, 1.1745f, 1.2615f, 1.3485f, 1.4355f, 1.5225f, 1.6095f, 1.6965f, 1.7850f,
+      1.8800f, 1.9865f, 2.1075f, 2.2470f, 2.4110f, 2.5750f, 2.8250f, 9998.0f, 2.9960f, 3.2265f, 3.4015f,
+      3.5765f, 3.7515f, 3.9260f, 4.1020f, 4.2770f, 4.4505f, 4.6270f, 4.8025f, 5.0400f, 9997.0f};
+
+  uint8_t const hwEtaAbs = std::min(kHwEtaAbsMax + 1, std::abs(hwEta));
+  return (hwEta < 0) ? -kTowerEtas[hwEtaAbs] : kTowerEtas[hwEtaAbs];
+}
+
+bool l1ScoutingRun3::calol1::validHwPhi(int16_t hwPhi) { return (hwPhi >= kHwPhiMin and hwPhi <= kHwPhiMax); }
+
+float l1ScoutingRun3::calol1::fPhi(int16_t hwPhi) {
+  //
+  // Based on the implementation of l1t::CaloTools::towerPhi() in
+  //  L1Trigger/L1TCalorimeter/src/CaloTools.cc
+  //
+  float const phi = (2 * hwPhi - 1) * M_PI / kHwPhiMax;
+  return (phi > M_PI) ? (phi - 2.f * M_PI) : phi;
+}


### PR DESCRIPTION
#### PR description:

This PR contains a few fixes to the `ScoutingJetProducer` plugin introduced in #48093 for L1-Scouting.
 - Fix for the conversion of the CaloTowers' (ieta, iphi) integer values to (eta, phi) physical values.
 - Fix to have the $\phi$ value of the output jets in the range $(-\pi,\pi]$, instead of $[0, 2\pi)$.
 - Removed the configuration parameter `debug` because unused, and added `LogTrace` calls for debugging purposes.
 - Added the sorting of the final output products, and removed the intermediate sorting of `fastjet`'s outputs (this guarantees that the plugin's output products are ordered based on their final $E_{T}$ values).

Each one of these 4 changes corresponds to a commit in this PR, and some more info is included in the commit messages.

#### PR validation:

Checked the outputs of the `ScoutingJetProducer` plugin with a custom-made config.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

`CMSSW_16_0_X`

Fixes to be backported to the production cycle for 2026 pp data-taking (in case this plugin is used in L1-Scouting workflows).
