### PR TITLE
Include cpuinfo_riscv.h on RISCV64 arch

### DIFF
--- a/FWCore/Services/test/test_catch2_cpu_features.cc
+++ b/FWCore/Services/test/test_catch2_cpu_features.cc
@@ -12,6 +12,8 @@
 #include "cpu_features/cpuinfo_aarch64.h"
 #elif defined(CPU_FEATURES_ARCH_PPC)
 #include "cpu_features/cpuinfo_ppc.h"
+#elif defined(CPU_FEATURES_ARCH_RISCV)
+#include "cpu_features/cpuinfo_riscv.h"
 #endif
 
 TEST_CASE("Test cpu_features library", "[cpu_features]") {


### PR DESCRIPTION
This should fix the riscv64 build error [a].

[a]
```
src/FWCore/Services/test/test_catch2_cpu_features.cc: In function 'void CATCH2_INTERNAL_TEST_0()':
  [src/FWCore/Services/test/test_catch2_cpu_features.cc:18](https://github.com/cms-sw/cmssw/blob/CMSSW_16_1_X_2026-02-21-1100/FWCore/Services/test/test_catch2_cpu_features.cc#L18):19: error: 'cpu_features' is not a namespace-name
    18 |   using namespace cpu_features;
```