### PR TITLE
Changes needed for mplhep 1.1.0 as hep.cms.lumitext is removed

### DIFF
--- a/Alignment/OfflineValidation/scripts/plotBeamSpotFromOfflineTag.py
+++ b/Alignment/OfflineValidation/scripts/plotBeamSpotFromOfflineTag.py
@@ -34,9 +34,12 @@ def plot(json_files, labels, output_file, f_ymin, f_ymax):
   
  
     fig, ax = plt.subplots(figsize = (10, 10), dpi = 150)
-    
-    hep.cms.text(f"{CMS_Text}", exp = 'CMS',fontsize = CMS_Text_Size,ax=ax)
-    hep.cms.lumitext(f"{lumitext}", fontsize = CMS_Text_Size,ax=ax)
+
+    if hasattr(hep.cms, "lumitext"): # mplhep 0.4
+        hep.cms.text(f"{CMS_Text}", exp = 'CMS',fontsize = CMS_Text_Size,ax=ax)
+        hep.cms.lumitext(f"{lumitext}", fontsize = CMS_Text_Size,ax=ax)
+    else:                            # mplhep >= 1.0
+        hep.cms.text(text=f" {CMS_Text}", lumi=lumitext, ax=ax, fontsize=CMS_Text_Size)
 
     plt.style.use(hep.style.CMS)
 

--- a/Validation/RecoJets/scripts/makeJetValidationPlots.py
+++ b/Validation/RecoJets/scripts/makeJetValidationPlots.py
@@ -196,8 +196,12 @@ class Plotter:
         self._fig, self._ax = plt.subplots(figsize=(10, 10))
         self.fontsize = fontsize
         
-        hep.cms.text(' Phase-2 Simulation Preliminary', ax=self._ax, fontsize=fontsize)
-        hep.cms.lumitext(label + " | 14 TeV", ax=self._ax, fontsize=fontsize)
+        if hasattr(hep.cms, "lumitext"): # mplhep 0.4
+            hep.cms.text(' Phase-2 Simulation Preliminary', ax=self._ax, fontsize=fontsize)
+            hep.cms.lumitext(label + " | 14 TeV", ax=self._ax, fontsize=fontsize)
+        else:                            # mplhep >= 1.0
+            hep.cms.text(text=' Phase-2 Simulation Preliminary', lumi=label + " | 14 TeV", ax=self._ax, fontsize=fontsize)
+
         if grid_color:
             self._ax.grid(which='major', color=grid_color)
         

--- a/Validation/RecoMET/scripts/makeHLTMETValidationPlots.py
+++ b/Validation/RecoMET/scripts/makeHLTMETValidationPlots.py
@@ -75,8 +75,12 @@ class Plotter:
         self._fig, self._ax = plt.subplots(figsize=(10, 10))
         self.fontsize = fontsize
         
-        hep.cms.text(' Phase-2 Simulation Preliminary', ax=self._ax, fontsize=fontsize)
-        hep.cms.lumitext(label + " | 14 TeV", ax=self._ax, fontsize=fontsize)
+        if hasattr(hep.cms, "lumitext"): # mplhep 0.4
+            hep.cms.text(' Phase-2 Simulation Preliminary', ax=self._ax, fontsize=fontsize)
+            hep.cms.lumitext(label + " | 14 TeV", ax=self._ax, fontsize=fontsize)
+        else:                            # mplhep >= 1.0
+            hep.cms.text(' Phase-2 Simulation Preliminary', lumi=label + " | 14 TeV", ax=self._ax, fontsize=fontsize)
+
         if grid_color:
             self._ax.grid(which='major', color=grid_color)
         


### PR DESCRIPTION
New mplhep version does not have `mplhep.cms.lumitext`. This PR proposes to use `hep.cms.text`  to add both the text and lumi information

Generated pdf files for `BeamSpotPlotting` unit tests are available
- with `mplhep` [0.4.1](https://muzaffar.web.cern.ch/mplhep/0.4.1/)
- with `mplhep` [1.1.0](https://muzaffar.web.cern.ch/mplhep/1.1.0/)