### PR TITLE
Fixed Uninitialized warnings for RecoTracker in ASAN IBs

### DIFF
--- a/RecoTracker/LSTCore/src/alpaka/Quadruplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quadruplet.h
@@ -254,20 +254,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
       error2 = moduleTypei == 0 ? kPixelPSZpitch * kPixelPSZpitch : kStrip2SZpitch * kStrip2SZpitch;
 
       //check the tilted module, side: PosZ, NegZ, Center(for not tilted)
-      float drdz;
-      short side, subdets;
-      if (i == 2) {
-        drdz = alpaka::math::abs(acc, modules.drdzs()[lowerModuleIndex2]);
-        side = modules.sides()[lowerModuleIndex2];
-        subdets = modules.subdets()[lowerModuleIndex2];
-      }
-      if (i == 3) {
-        drdz = alpaka::math::abs(acc, modules.drdzs()[lowerModuleIndex3]);
-        side = modules.sides()[lowerModuleIndex3];
-        subdets = modules.subdets()[lowerModuleIndex3];
-      }
-      const bool isEndcapOrCenter = (subdets == lst::Endcap) or (side == lst::Center);
       if (i == 2 || i == 3) {
+        uint16_t moduleIndex = (i == 2) ? lowerModuleIndex2 : lowerModuleIndex3;
+        float drdz = alpaka::math::abs(acc, modules.drdzs()[moduleIndex]);
+        short side = modules.sides()[moduleIndex];
+        short subdets = modules.subdets()[moduleIndex];
+        const bool isEndcapOrCenter = (subdets == lst::Endcap) or (side == lst::Center);
         residual = (layeri <= 6 && ((side == Center) or (drdz < 1))) ? diffz : diffr;
         float projection_missing2 = 1.f;
         if (drdz < 1)


### PR DESCRIPTION
There are few uninitialized warnings in ASAN IBs this PR addresses that
```BASH
[src/RecoTracker/LSTCore/src/alpaka/Quadruplet.h:269](https://github.com/cms-sw/cmssw/blob/CMSSW_16_1_ASAN_X_2026-02-23-2300/RecoTracker/LSTCore/src/alpaka/Quadruplet.h#L269):71: warning: 'side' may be used uninitialized [-Wmaybe-uninitialized]
   269 |       const bool isEndcapOrCenter = (subdets == lst::Endcap) or (side == lst::Center);
[src/RecoTracker/LSTCore/src/alpaka/Quadruplet.h:269:46: warning: 'subdets' may be used uninitialized [-Wmaybe-uninitialized]
   269 |       const bool isEndcapOrCenter = (subdets == lst::Endcap) or (side == lst::Center);
[src/RecoTracker/LSTCore/src/alpaka/Quadruplet.h:271:54: warning: 'drdz' may be used uninitialized [-Wmaybe-uninitialized]
   271 |         residual = (layeri <= 6 && ((side == Center) or (drdz < 1))) ? diffz : diffr;
```