### PR TITLE
limit phase-2 Heavy Ion relval workflow to run on 1 event

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -3369,6 +3369,8 @@ upgradeWFs['SonicTriton'] = UpgradeWorkflow_SonicTriton(
 class UpgradeWorkflow_Phase2_HeavyIon(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         stepDict[stepName][k] = merge([{'--procModifiers': 'phase2_pp_on_AA'}, stepDict[step][k]])
+        # override '-n' setting from PUDataSets in relval_steps.py
+        stepDict[stepName][k] = merge([{'-n':'1'}, stepDict[step][k]])
         if 'GenSim' in step:
             stepDict[stepName][k] = merge([{'--conditions': stepDict[step][k]["--conditions"].replace('_13TeV',''), '-n': 1}, stepDict[stepName][k]])
         elif 'Digi' in step:


### PR DESCRIPTION
#### PR description:

As per https://github.com/cms-sw/cmssw/issues/49728#issuecomment-3714948354

#### PR validation:

`$ runTheMatrix.py -nel 34551.85`

gives:

```
34551.85 Hydjet_Quenched_MinBias_5519GeV_Run4D121_GenSimHLBeamSpot_hi+DigiTrigger_hi_Run4D121+RecoGlobal_hi_Run4D121+HARVESTGlobal_hi_Run4D121+ALCAPhase2_hi_Run4D121 [1]: cmsDriver.py Hydjet_Quenched_MinBias_5519GeV_cfi  -s GEN,SIM -n 1 --conditions auto:phase2_realistic_T35 --beamspot DBrealisticHLLHC --datatier GEN-SIM --eventcontent FEVTDEBUG --geometry ExtendedRun4D121 --era Phase2C22I13M9 --relval 2000,1 
                                           [2]: cmsDriver.py step2  -s DIGI:pdigi_hi,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:@relvalRun4 --conditions auto:phase2_realistic_T35 --datatier GEN-SIM-DIGI-RAW -n 1 --eventcontent FEVTDEBUGHLT --geometry ExtendedRun4D121 --era Phase2C22I13M9 --pileup HiMixNoPU
                                           [3]: cmsDriver.py step3  -s RAW2DIGI,RECO,RECOSIM,PAT,VALIDATION:@phase2Validation+@miniAODValidation,DQM:@phase2+@miniAODDQM --conditions auto:phase2_realistic_T35 --datatier GEN-SIM-RECO,MINIAODSIM,DQMIO -n 1 --eventcontent FEVTDEBUGHLT,MINIAODSIM,DQM --geometry ExtendedRun4D121 --era Phase2C22I13M9
                                           [4]: cmsDriver.py step4  -s HARVESTING:@phase2Validation+@phase2+@miniAODValidation+@miniAODDQM --conditions auto:phase2_realistic_T35 --mc  --geometry ExtendedRun4D121 --scenario pp --filetype DQM --era Phase2C22I13M9 -n 1
                                           [5]: cmsDriver.py step5  -s ALCA:SiPixelCalSingleMuonLoose+SiPixelCalSingleMuonTight+TkAlMuonIsolated+TkAlMinBias+MuAlOverlaps+EcalESAlign+TkAlZMuMu+TkAlDiMuonAndVertex+HcalCalHBHEMuonProducerFilter+TkAlUpsilonMuMu+TkAlJpsiMuMu --conditions auto:phase2_realistic_T35 --datatier ALCARECO -n 1 --eventcontent ALCARECO --geometry ExtendedRun4D121 --era Phase2C22I13M9

1 workflows with 5 steps
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A