### PR TITLE
L1S: add plugins `MaskOrbitBx<l1ScoutingRun3::{CaloTower,FastJet}>` [`16_0_X`]

### DIFF
--- a/L1TriggerScouting/OnlineProcessing/plugins/MaskOrbitBx.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/MaskOrbitBx.cc
@@ -6,6 +6,8 @@
 #include "DataFormats/L1Scouting/interface/L1ScoutingMuon.h"
 #include "DataFormats/L1Scouting/interface/L1ScoutingCalo.h"
 #include "DataFormats/L1Scouting/interface/L1ScoutingBMTFStub.h"
+#include "DataFormats/L1Scouting/interface/L1ScoutingCaloTower.h"
+#include "DataFormats/L1Scouting/interface/L1ScoutingFastJet.h"
 #include "DataFormats/L1Scouting/interface/OrbitCollection.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
@@ -96,6 +98,8 @@ typedef MaskOrbitBx<l1ScoutingRun3::EGamma> MaskOrbitBxScoutingEGamma;
 typedef MaskOrbitBx<l1ScoutingRun3::Tau> MaskOrbitBxScoutingTau;
 typedef MaskOrbitBx<l1ScoutingRun3::BxSums> MaskOrbitBxScoutingBxSums;
 typedef MaskOrbitBx<l1ScoutingRun3::BMTFStub> MaskOrbitBxScoutingBMTFStub;
+typedef MaskOrbitBx<l1ScoutingRun3::CaloTower> MaskOrbitBxScoutingCaloTower;
+typedef MaskOrbitBx<l1ScoutingRun3::FastJet> MaskOrbitBxScoutingFastJet;
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(MaskOrbitBxScoutingMuon);
@@ -104,3 +108,5 @@ DEFINE_FWK_MODULE(MaskOrbitBxScoutingEGamma);
 DEFINE_FWK_MODULE(MaskOrbitBxScoutingTau);
 DEFINE_FWK_MODULE(MaskOrbitBxScoutingBxSums);
 DEFINE_FWK_MODULE(MaskOrbitBxScoutingBMTFStub);
+DEFINE_FWK_MODULE(MaskOrbitBxScoutingCaloTower);
+DEFINE_FWK_MODULE(MaskOrbitBxScoutingFastJet);

--- a/L1TriggerScouting/OnlineProcessing/plugins/MaskOrbitBx.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/MaskOrbitBx.cc
@@ -1,57 +1,48 @@
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/Utilities/interface/EDGetToken.h"
-#include "FWCore/Utilities/interface/EDPutToken.h"
-#include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/Utilities/interface/StreamID.h"
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
-// L1 scouting
 #include "DataFormats/L1Scouting/interface/L1ScoutingMuon.h"
 #include "DataFormats/L1Scouting/interface/L1ScoutingCalo.h"
 #include "DataFormats/L1Scouting/interface/L1ScoutingBMTFStub.h"
 #include "DataFormats/L1Scouting/interface/OrbitCollection.h"
-
-#include <vector>
-#include <set>
-
-using namespace l1ScoutingRun3;
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 template <typename T>
 class MaskOrbitBx : public edm::stream::EDProducer<> {
 public:
   explicit MaskOrbitBx(const edm::ParameterSet&);
-  ~MaskOrbitBx() override {}
+  ~MaskOrbitBx() override = default;
+
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
+  static constexpr int kNBX = 3565;
+
+  // token for scouting data
+  edm::EDGetTokenT<OrbitCollection<T>> const tokenData_;
+
+  // BXs to be kept
+  edm::EDGetTokenT<std::vector<unsigned>> const tokenSelBxs_;
+
+  std::string const productLabel_;
+
   std::vector<std::vector<T>> orbitBuffer_;
-
-  // tokens for scouting data
-  edm::EDGetTokenT<OrbitCollection<T>> tokenData_;
-
-  // BX to be keep
-  edm::EDGetTokenT<std::vector<unsigned>> tokenSelBxs_;
-
-  std::string productLabel_;
-
-  const int NBX = 3565;
 };
 
 template <typename T>
 MaskOrbitBx<T>::MaskOrbitBx(const edm::ParameterSet& iPSet)
-    : tokenData_(consumes<OrbitCollection<T>>(iPSet.getParameter<edm::InputTag>("dataTag"))),
-      tokenSelBxs_(consumes<std::vector<unsigned>>(iPSet.getParameter<edm::InputTag>("selectBxs"))),
+    : tokenData_(consumes(iPSet.getParameter<edm::InputTag>("dataTag"))),
+      tokenSelBxs_(consumes(iPSet.getParameter<edm::InputTag>("selectBxs"))),
       productLabel_(iPSet.getParameter<std::string>("productLabel")) {
   // prepare module buffer
-  orbitBuffer_ = std::vector<std::vector<T>>(NBX);
+  orbitBuffer_ = std::vector<std::vector<T>>(kNBX);
 
   // products
   produces<OrbitCollection<T>>(productLabel_).setBranchAlias(productLabel_ + "OrbitCollection");
@@ -71,28 +62,31 @@ void MaskOrbitBx<T>::produce(edm::Event& iEvent, const edm::EventSetup&) {
   // prepare new collections
   std::unique_ptr<OrbitCollection<T>> selectedObjs(new OrbitCollection<T>);
 
-  int nObjOrbit_ = 0;
+  int nObjOrbit = 0;
 
   // fill collections with objects
-  for (const unsigned& bx : *selBxs) {
-    for (const auto& obj : objCollection->bxIterator(bx)) {
+  for (auto const bx : *selBxs) {
+    auto const& objs = objCollection->bxIterator(bx);
+    orbitBuffer_[bx].reserve(objs.size());
+    for (auto const& obj : objs) {
       orbitBuffer_[bx].push_back(obj);
-      nObjOrbit_++;
+      nObjOrbit++;
     }
   }
 
   // fill orbit collection and clear the Bx buffer vector
-  selectedObjs->fillAndClear(orbitBuffer_, nObjOrbit_);
+  selectedObjs->fillAndClear(orbitBuffer_, nObjOrbit);
 
   // store collections in the event
   iEvent.put(std::move(selectedObjs), productLabel_);
-
-}  // end produce
+}
 
 template <typename T>
 void MaskOrbitBx<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
+  desc.add<edm::InputTag>("dataTag");
+  desc.add<edm::InputTag>("selectBxs");
+  desc.add<std::string>("productLabel");
   descriptions.addDefault(desc);
 }
 
@@ -103,6 +97,7 @@ typedef MaskOrbitBx<l1ScoutingRun3::Tau> MaskOrbitBxScoutingTau;
 typedef MaskOrbitBx<l1ScoutingRun3::BxSums> MaskOrbitBxScoutingBxSums;
 typedef MaskOrbitBx<l1ScoutingRun3::BMTFStub> MaskOrbitBxScoutingBMTFStub;
 
+#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(MaskOrbitBxScoutingMuon);
 DEFINE_FWK_MODULE(MaskOrbitBxScoutingJet);
 DEFINE_FWK_MODULE(MaskOrbitBxScoutingEGamma);


### PR DESCRIPTION
backport of #50247

#### PR description:

From the description of #50247:

> @RoccoA97 noticed that #48093 should have included new instantations of the plugin template `MaskOrbitBx<T>` using the data formats introduced in that PR (i.e. `l1ScoutingRun3::CaloTower` and `l1ScoutingRun3::FastJet`). Having these plugins will make it possible to save those objects for selected BXs in the so-called `L1ScoutingSelection` stream.
> 
> This PR contains 2 commits.
>  - 7c0bb20518c adds the two plugins in question.
>  - 1a2c0bb1552 improves the `fillDescriptions` method of the plugin template (and applies some technical cleanup).

#### PR validation:

None beyond the checks made for #50247.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#50247

Addition of two L1-Scouting plugins for 2026 pp data-taking.
