### PR TITLE
Minor clarification of the --relval cmsDriver option.

### DIFF
--- a/Configuration/Applications/python/Options.py
+++ b/Configuration/Applications/python/Options.py
@@ -67,7 +67,7 @@ parser.add_argument("--filetype",
                   )
 
 parser.add_argument("-n", "--number",
-                    help="The number of events.",
+                    help="The number of events that will be processed.",
                     default=1,
                     type=int,
                     dest="number")
@@ -216,7 +216,7 @@ expertSettings.add_argument("--suffix",
                             dest="suffix")
 
 expertSettings.add_argument("--relval",
-                            help="Set total number of events and events per job.", #this does not get used but get parsed in the command by DataOps
+                            help="Set total number of events and events per job (comma-separated). Only considered if one of the steps is 'DATAMIX'. Ignored in private production; use `--number` to set the number of events to be processed.",
                             default="",
                             dest="relval")
 


### PR DESCRIPTION
Clarifies that `--relval` is ignored in private sample production.
