### PR TITLE
L1S: fix slow debug calls in `ScCALORawToDigi` and `ScGMTRawToDigi`

### DIFF
--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.cc
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.cc
@@ -1,4 +1,5 @@
 #include "EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 ScCaloRawToDigi::ScCaloRawToDigi(const edm::ParameterSet& iConfig) {
   srcInputTag_ = iConfig.getParameter<edm::InputTag>("srcInputTag");
@@ -218,13 +219,14 @@ void ScCaloRawToDigi::unpackJets(uint32_t* dataBlock, int bx, int nObjets) {
       l1ScoutingRun3::Jet jet(ET, Eta, Phi, Qual);
       orbitBufferJets_[bx].push_back(jet);
       nJetsOrbit_++;
-      if (edm::MessageDrop::instance()->debugEnabled) {
-        std::ostringstream os;
-        os << "Jet " << i << "\n";
-        os << "  Raw: 0x" << std::hex << dataBlock[i] << std::dec << "\n";
-        l1ScoutingRun3::printJet(jet, os);
-        LogDebug("L1Scout") << os.str();
-      }
+
+#ifdef EDM_ML_DEBUG
+      std::ostringstream os;
+      os << "Jet " << i << "\n";
+      os << "  Raw: 0x" << std::hex << dataBlock[i] << std::dec << "\n";
+      l1ScoutingRun3::printJet(jet, os);
+      LogDebug("L1Scout") << os.str();
+#endif
     }
   }  // end link jets unpacking loop
 }
@@ -245,13 +247,13 @@ void ScCaloRawToDigi::unpackEGammas(uint32_t* dataBlock, int bx, int nObjets) {
       orbitBufferEGammas_[bx].push_back(eGamma);
       nEGammasOrbit_++;
 
-      if (edm::MessageDrop::instance()->debugEnabled) {
-        std::ostringstream os;
-        os << "E/g " << i << "\n";
-        os << "  Raw: 0x" << std::hex << dataBlock[i] << std::dec << "\n";
-        l1ScoutingRun3::printEGamma(eGamma, os);
-        LogDebug("L1Scout") << os.str();
-      }
+#ifdef EDM_ML_DEBUG
+      std::ostringstream os;
+      os << "E/g " << i << "\n";
+      os << "  Raw: 0x" << std::hex << dataBlock[i] << std::dec << "\n";
+      l1ScoutingRun3::printEGamma(eGamma, os);
+      LogDebug("L1Scout") << os.str();
+#endif
     }
   }  // end link e/gammas unpacking loop
 }
@@ -272,13 +274,13 @@ void ScCaloRawToDigi::unpackTaus(uint32_t* dataBlock, int bx, int nObjets) {
       orbitBufferTaus_[bx].push_back(tau);
       nTausOrbit_++;
 
-      if (edm::MessageDrop::instance()->debugEnabled) {
-        std::ostringstream os;
-        os << "Tau " << i << "\n";
-        os << "  Raw: 0x" << std::hex << dataBlock[i] << std::dec << "\n";
-        l1ScoutingRun3::printTau(tau, os);
-        LogDebug("L1Scout") << os.str();
-      }
+#ifdef EDM_ML_DEBUG
+      std::ostringstream os;
+      os << "Tau " << i << "\n";
+      os << "  Raw: 0x" << std::hex << dataBlock[i] << std::dec << "\n";
+      l1ScoutingRun3::printTau(tau, os);
+      LogDebug("L1Scout") << os.str();
+#endif
     }
   }  // end link taus unpacking loop
 }
@@ -404,15 +406,15 @@ void ScCaloRawToDigi::unpackEtSums(uint32_t* dataBlock, int bx) {
   orbitBufferEtSums_[bx].push_back(bxSums);
   nEtSumsOrbit_ += 1;
 
-  if (edm::MessageDrop::instance()->debugEnabled) {
-    std::ostringstream os;
-    os << "Raw frames:\n";
-    for (int frame = 0; frame < 6; frame++) {
-      os << "  frame " << frame << ": 0x" << std::hex << dataBlock[frame] << std::dec << "\n";
-      l1ScoutingRun3::printBxSums(bxSums, os);
-    }
-    LogDebug("L1Scout") << os.str();
+#ifdef EDM_ML_DEBUG
+  std::ostringstream os;
+  os << "Raw frames:\n";
+  for (int frame = 0; frame < 6; frame++) {
+    os << "  frame " << frame << ": 0x" << std::hex << dataBlock[frame] << std::dec << "\n";
+    l1ScoutingRun3::printBxSums(bxSums, os);
   }
+  LogDebug("L1Scout") << os.str();
+#endif
 }
 
 void ScCaloRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.h
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.h
@@ -1,5 +1,4 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScGMTRawToDigi.cc
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScGMTRawToDigi.cc
@@ -1,4 +1,5 @@
 #include "EventFilter/L1ScoutingRawToDigi/plugins/ScGMTRawToDigi.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 ScGMTRawToDigi::ScGMTRawToDigi(const edm::ParameterSet& iConfig) {
   srcInputTag = iConfig.getParameter<edm::InputTag>("srcInputTag");
@@ -142,16 +143,15 @@ void ScGMTRawToDigi::unpackOrbit(const unsigned char* buf, size_t len) {
 
       orbitBuffer_[bx].push_back(muon);
 
-      if (edm::MessageDrop::instance()->debugEnabled) {
-        std::ostringstream os;
-        LogDebug("L1Scout") << "--- Muon " << i << " ---\n"
-                            << "  Raw f:     0x" << std::hex << bl->mu[i].f << std::dec << "\n"
-                            << "  Raw s:     0x" << std::hex << bl->mu[i].s << std::dec << "\n"
-                            << "  Raw extra: 0x" << std::hex << bl->mu[i].extra << std::dec << "\n";
-        printMuon(muon, os);
-        LogDebug("L1Scout") << os.str();
-      }
-
+      LogDebug("L1Scout") << "--- Muon " << i << " ---\n"
+                          << "  Raw f:     0x" << std::hex << bl->mu[i].f << std::dec << "\n"
+                          << "  Raw s:     0x" << std::hex << bl->mu[i].s << std::dec << "\n"
+                          << "  Raw extra: 0x" << std::hex << bl->mu[i].extra << std::dec << "\n";
+#ifdef EDM_ML_DEBUG
+      std::ostringstream os;
+      printMuon(muon, os);
+      LogDebug("L1Scout") << os.str();
+#endif
     }  // end of bx
 
   }  // end orbit while loop

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScGMTRawToDigi.h
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScGMTRawToDigi.h
@@ -2,7 +2,6 @@
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 


### PR DESCRIPTION
#### PR description:

Some technical changes to debugging-related calls made during the review of #48093 (https://github.com/cms-sw/cmssw/commit/757444fa56c6171f2cb8554ba1bf7ee7de8118ef) inadvertently made two unpackers of L1-Scouting data (i.e. `ScCALORawToDigi` and `ScGMTRawToDigi`) much slower than they should be. `ScCALORawToDigi`, in particular, became slower by more than a factor of 100. This PR fixes that, by putting these debug-level calls behind the usual `EDM_ML_DEBUG` compilation flag, instead of using `edm::MessageDrop::instance()->debugEnabled`.

#### PR validation:

Checked that, in a simple single-threaded job running on 100 orbits of 2024 L1-Scouting data [*], the time per orbit of an instance of `ScCALORawToDigi` is less than 0.5 ms before #48093, more than 120 ms after #48093, and back to less than 0.5 ms with this PR.

Also checked that
```
USER_CXXFLAGS="-DEDM_ML_DEBUG" scram b
```
compiles without issues after the changes in this PR.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

`CMSSW_16_0_X`

Necessary technical fix to two L1-Scouting unpackers for 2026 data-taking. The bug was introduced in #48093.

---

[*]
Running
```bash
cmsRun test.py -i /eos/user/m/missirol/l1s_data_250216_run379729_stat1E2.root -f
```
where `test.py` corresponds to the config below.
```py
import FWCore.ParameterSet.Config as cms

import argparse
import glob
import os

parser = argparse.ArgumentParser(
    description = 'Config to run the main L1-Scouting modules on EDM files containing'
                  ' raw data from the L1-Scouting FEDs (SDSRawDataCollection)',
    formatter_class = argparse.ArgumentDefaultsHelpFormatter
)

parser.add_argument('-i', '--fileNames', nargs='+', type=str, required=True,
    help='Value of process.source.fileNames')

parser.add_argument('-o', '--outputFileNamePrefix', type=str, default=None,
    help='Prefix of the name of the output files (if not specified, no OutputModule will run)')

parser.add_argument('-n', '--maxEvents', type=int, default=-1,
    help='Value of process.maxEvents.input')

parser.add_argument('--reportEvery', type=int, default=1,
    help='Value of process.MessageLogger.cerr.FwkReport.reportEvery')

parser.add_argument('-t', '--numThreads', type=int, default=1,
    help='Value of process.options.numberOfThreads')

parser.add_argument('-s', '--numStreams', type=int, default=0,
    help='Value of process.options.numberOfStreams')

parser.add_argument('-e', '--eventsToProcess', nargs='+', type=str, default=[],
    help='Value of process.source.eventsToProcess')

parser.add_argument('-f', '--fastTimerService', action='store_true', default=False,
    help='Add an instance of the FastTimerService')

parser.add_argument('--noDuplicateCheck', action='store_true', default=False,
    help='Set process.source.duplicateCheckMode = "noDuplicateCheck"')

parser.add_argument('-d', '--debugModules', nargs='+', type=str, default=[],
    help='Value of Add an instance of the FastTimerService')

args = parser.parse_args()

fileNames = []
for fname in args.fileNames:
    fname_files = glob.glob(fname)
    for fname_file in fname_files:
        fname_file_str = f'file:{fname_file}' if os.path.isfile(fname_file) else fname_file
        fileNames += [fname_file_str]

fileNames = sorted(list(set(fileNames)))

if not fileNames:
    raise SystemExit(f'>>> Fatal Error - found zero input files with a valid name: {args.inputDirName}')

process = cms.Process('TEST')

process.maxEvents.input = args.maxEvents

process.options.numberOfThreads = args.numThreads
process.options.numberOfStreams = args.numStreams
# ShmStreamConsumer requires synchronization at LuminosityBlock boundaries
process.options.numberOfConcurrentLuminosityBlocks = 1

process.MessageLogger.cerr.FwkReport.reportEvery = args.reportEvery

from IOPool.Input.PoolSource import PoolSource
process.source = PoolSource(
    fileNames = fileNames
)

if args.noDuplicateCheck:
    process.source.duplicateCheckMode = 'noDuplicateCheck'

if args.eventsToProcess:
    process.source.eventsToProcess = args.eventsToProcess

import EventFilter.L1ScoutingRawToDigi.ScGMTRawToDigi_cfi
process.l1ScGmtUnpacker = EventFilter.L1ScoutingRawToDigi.ScGMTRawToDigi_cfi.ScGmtUnpacker.clone()

import EventFilter.L1ScoutingRawToDigi.ScCaloRawToDigi_cfi
process.l1ScCaloUnpacker = EventFilter.L1ScoutingRawToDigi.ScCaloRawToDigi_cfi.ScCaloUnpacker.clone()

import EventFilter.L1ScoutingRawToDigi.ScBMTFRawToDigi_cfi
process.l1ScBMTFUnpacker = EventFilter.L1ScoutingRawToDigi.ScBMTFRawToDigi_cfi.ScBMTFUnpacker.clone()

#from EventFilter.L1ScoutingRawToDigi.ScGMTRawToDigi import ScGMTRawToDigi
#process.l1ScGmtUnpacker = ScGMTRawToDigi()
#
#from EventFilter.L1ScoutingRawToDigi.ScCaloRawToDigi import ScCaloRawToDigi
#process.l1ScCaloUnpacker = ScCaloRawToDigi()
#
#from EventFilter.L1ScoutingRawToDigi.ScBMTFRawToDigi import ScBMTFRawToDigi
#process.l1ScBMTFUnpacker = ScBMTFRawToDigi()

#from EventFilter.L1ScoutingRawToDigi.ScCaloTowerRawToDigi import ScCaloTowerRawToDigi
#process.l1ScCaloTowerUnpacker = ScCaloTowerRawToDigi()

#from L1TriggerScouting.OnlineProcessing.ScoutingJetProducer import ScoutingJetProducer
#process.l1ScAK4CaloTowerJets = ScoutingJetProducer(
#    src = 'l1ScCaloTowerUnpacker:CaloTower',
#    akR = 0.4,
#    ptMin = 0.5
#)

process.L1SUnpackingSequence = cms.Sequence(
    process.l1ScGmtUnpacker
  + process.l1ScCaloUnpacker
  + process.l1ScBMTFUnpacker
#  + process.l1ScCaloTowerUnpacker
)

process.L1SReconstructionSequence = cms.Sequence(
#    process.l1ScAK4CaloTowerJets
)

process.L1ScoutingPath = cms.Path(
    process.L1SUnpackingSequence
  + process.L1SReconstructionSequence
)

process.DijetEt30 = cms.EDProducer("JetBxSelector",
    jetsTag          = cms.InputTag("l1ScCaloUnpacker", "Jet"),
    minNJet          = cms.int32(2),
    minJetEt         = cms.vdouble(30, 30),
    maxJetEta        = cms.vdouble(99.9, 99.9)
)

process.HMJetMult4Et20 = cms.EDProducer("JetBxSelector",
    jetsTag          = cms.InputTag("l1ScCaloUnpacker", "Jet"),
    minNJet          = cms.int32(4),
    minJetEt         = cms.vdouble(20, 20, 20, 20),
    maxJetEta        = cms.vdouble(99.9, 99.9, 99.9, 99.9),
)

process.SingleMuPt0BMTF = cms.EDProducer("MuBxSelector",
    muonsTag         = cms.InputTag("l1ScGmtUnpacker",  "Muon"),
    minNMu           = cms.int32(1),
    minMuPt          = cms.vdouble(0.0),
    maxMuEta         = cms.vdouble(99.9),
    minMuTfIndex     = cms.vint32(36),
    maxMuTfIndex     = cms.vint32(71),
    minMuHwQual    = cms.vint32(0),
)

process.DoubleMuPt0Qual8 = cms.EDProducer("MuBxSelector",
    muonsTag         = cms.InputTag("l1ScGmtUnpacker",  "Muon"),
    minNMu           = cms.int32(2),
    minMuPt        = cms.vdouble(0, 0),
    maxMuEta       = cms.vdouble(99.9, 99.9),
    minMuTfIndex     = cms.vint32(0, 0),
    maxMuTfIndex     = cms.vint32(107, 107),
    minMuHwQual      = cms.vint32(8, 8),
)

process.MuTagJetEt30Dr0p4 = cms.EDProducer("MuTagJetBxSelector",
    muonsTag         = cms.InputTag("l1ScGmtUnpacker",  "Muon"),
    jetsTag          = cms.InputTag("l1ScCaloUnpacker", "Jet"),
    minNJet          = cms.int32(1),
    minJetEt         = cms.vdouble(30),
    maxJetEta        = cms.vdouble(99.9),
    minMuPt          = cms.vdouble(0),
    maxMuEta         = cms.vdouble(99.9),
    minMuTfIndex     = cms.vint32(0),
    maxMuTfIndex     = cms.vint32(107),
    minMuHwQual      = cms.vint32(8),
    maxDR            = cms.vdouble(0.4),
)

process.Stubs3BxWindowWheelCond = cms.EDProducer("BMTFStubMultiBxSelector",
    stubsTag         = cms.InputTag("l1ScBMTFUnpacker", "BMTFStub"),
    condition        = cms.string("wheel"),
    bxWindowLength   = cms.uint32(3),
    minNBMTFStub     = cms.uint32(2)
)

process.FinalBxSelector = cms.EDFilter("FinalBxSelector",
    analysisLabels = cms.VInputTag(
        cms.InputTag("DijetEt30", "SelBx"),
        cms.InputTag("SingleMuPt0BMTF", "SelBx"),
        cms.InputTag("DoubleMuPt0Qual8", "SelBx"),
        cms.InputTag("HMJetMult4Et20", "SelBx"),
        cms.InputTag("MuTagJetEt30Dr0p4", "SelBx"),
        cms.InputTag("Stubs3BxWindowWheelCond", "SelBx")
    ),
)

# Final collection producers
process.FinalBxSelectorMuon = cms.EDProducer("MaskOrbitBxScoutingMuon",
    dataTag = cms.InputTag("l1ScGmtUnpacker",  "Muon"),
    selectBxs = cms.InputTag("FinalBxSelector", "SelBx"),
    productLabel = cms.string("Muon")
)

process.FinalBxSelectorJet = cms.EDProducer("MaskOrbitBxScoutingJet",
    dataTag = cms.InputTag("l1ScCaloUnpacker",  "Jet"),
    selectBxs = cms.InputTag("FinalBxSelector", "SelBx"),
    productLabel = cms.string("Jet")
)

process.FinalBxSelectorEGamma = cms.EDProducer("MaskOrbitBxScoutingEGamma",
    dataTag = cms.InputTag("l1ScCaloUnpacker",  "EGamma"),
    selectBxs = cms.InputTag("FinalBxSelector", "SelBx"),
    productLabel = cms.string("EGamma")
)

process.FinalBxSelectorTau = cms.EDProducer("MaskOrbitBxScoutingTau",
    dataTag = cms.InputTag("l1ScCaloUnpacker",  "Tau"),
    selectBxs = cms.InputTag("FinalBxSelector", "SelBx"),
    productLabel = cms.string("Tau")
)

process.FinalBxSelectorBxSums = cms.EDProducer("MaskOrbitBxScoutingBxSums",
    dataTag = cms.InputTag("l1ScCaloUnpacker",  "EtSum"),
    selectBxs = cms.InputTag("FinalBxSelector", "SelBx"),
    productLabel = cms.string("EtSum")
)

process.FinalBxSelectorBMTFStub = cms.EDProducer("MaskOrbitBxScoutingBMTFStub",
    dataTag = cms.InputTag("l1ScBMTFUnpacker",  "BMTFStub"),
    selectBxs = cms.InputTag("FinalBxSelector", "SelBx"),
    productLabel = cms.string("BMTFStub")
)

#process.FinalBxSelectorCaloTower = cms.EDProducer("MaskOrbitBxScoutingCaloTower",
#    dataTag = cms.InputTag("l1ScCaloTowerUnpacker",  "CaloTower"),
#    selectBxs = cms.InputTag("FinalBxSelector", "SelBx"),
#    productLabel = cms.string("CaloTower")
#)

#process.FinalBxSelectorFastJet = cms.EDProducer("MaskOrbitBxScoutingFastJet",
#    dataTag = cms.InputTag("l1ScAK4CaloTowerJets",  "FastJet"),
#    selectBxs = cms.InputTag("FinalBxSelector", "SelBx"),
#    productLabel = cms.string("FastJet")
#)

process.bxSelectors = cms.Sequence(
    process.DijetEt30 +
    process.HMJetMult4Et20 +
    process.SingleMuPt0BMTF +
    process.DoubleMuPt0Qual8 +
    process.MuTagJetEt30Dr0p4 +
    process.Stubs3BxWindowWheelCond
)
process.MaskedCollections = cms.Sequence(
    process.FinalBxSelectorMuon +
    process.FinalBxSelectorJet +
    process.FinalBxSelectorEGamma +
#   process.FinalBxSelectorTau +
    process.FinalBxSelectorBxSums +
    process.FinalBxSelectorBMTFStub
#    process.FinalBxSelectorCaloTower +
#    process.FinalBxSelectorFastJet
)

process.pL1ScoutingSelected = cms.Path(
    process.L1SUnpackingSequence
  + process.bxSelectors
  + process.FinalBxSelector
  + process.MaskedCollections
)

if args.outputFileNamePrefix:
    from IOPool.Output.PoolOutputModule import PoolOutputModule
    process.l1sOutputModule = PoolOutputModule(
        fileName = f'{args.outputFileNamePrefix}_ZeroBias.root',
        outputCommands = [
            'drop *',
            'keep *_l1ScGmtUnpacker_*_*',
            'keep *_l1ScCaloUnpacker_*_*',
            'keep *_l1ScBMTFUnpacker_*_*',
            'keep *_l1ScCaloTowerUnpacker_*_*',
            'keep *_l1ScAK4CaloTowerJets_*_*'
        ]
    )
    process.L1ScoutingOutputEndPath = cms.EndPath(process.l1sOutputModule)

    process.hltOutputL1ScoutingSelection = PoolOutputModule(
        fileName = f'{args.outputFileNamePrefix}_Selection.root',
        SelectEvents = cms.untracked.PSet(
            SelectEvents = cms.vstring("pL1ScoutingSelected")
        ),
        outputCommands = [
            'drop *',
            'keep *_DijetEt30_*_*',
            'keep *_HMJetMult4Et20_*_*',
            'keep *_SingleMuPt0BMTF_*_*',
            'keep *_DoubleMuPt0Qual8_*_*',
            'keep *_MuTagJetEt30Dr0p4_*_*',
            'keep *_Stubs3BxWindowWheelCond_*_*',
            'keep *_FinalBxSelector*_*_*',
        ]
    )
    process.epL1ScoutingSelection = cms.EndPath(process.hltOutputL1ScoutingSelection)

if args.fastTimerService:
    from HLTrigger.Timer.FastTimerService import FastTimerService
    process.FastTimerService = FastTimerService(
        printRunSummary = False,
        enableDQM = False
    )
    process.MessageLogger.FastReport = cms.untracked.PSet()

if args.debugModules:
    process.MessageLogger.cerr.threshold = 'DEBUG'
    process.MessageLogger.debugModules = args.debugModules
```
