### PR TITLE
L1S: fix slow debug calls in `ScCALORawToDigi` and `ScGMTRawToDigi` [`16_0_X`]

### DIFF
--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.cc
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.cc
@@ -1,4 +1,5 @@
 #include "EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 ScCaloRawToDigi::ScCaloRawToDigi(const edm::ParameterSet& iConfig) {
   srcInputTag_ = iConfig.getParameter<edm::InputTag>("srcInputTag");
@@ -218,13 +219,14 @@ void ScCaloRawToDigi::unpackJets(uint32_t* dataBlock, int bx, int nObjets) {
       l1ScoutingRun3::Jet jet(ET, Eta, Phi, Qual);
       orbitBufferJets_[bx].push_back(jet);
       nJetsOrbit_++;
-      if (edm::MessageDrop::instance()->debugEnabled) {
-        std::ostringstream os;
-        os << "Jet " << i << "\n";
-        os << "  Raw: 0x" << std::hex << dataBlock[i] << std::dec << "\n";
-        l1ScoutingRun3::printJet(jet, os);
-        LogDebug("L1Scout") << os.str();
-      }
+
+#ifdef EDM_ML_DEBUG
+      std::ostringstream os;
+      os << "Jet " << i << "\n";
+      os << "  Raw: 0x" << std::hex << dataBlock[i] << std::dec << "\n";
+      l1ScoutingRun3::printJet(jet, os);
+      LogDebug("L1Scout") << os.str();
+#endif
     }
   }  // end link jets unpacking loop
 }
@@ -245,13 +247,13 @@ void ScCaloRawToDigi::unpackEGammas(uint32_t* dataBlock, int bx, int nObjets) {
       orbitBufferEGammas_[bx].push_back(eGamma);
       nEGammasOrbit_++;
 
-      if (edm::MessageDrop::instance()->debugEnabled) {
-        std::ostringstream os;
-        os << "E/g " << i << "\n";
-        os << "  Raw: 0x" << std::hex << dataBlock[i] << std::dec << "\n";
-        l1ScoutingRun3::printEGamma(eGamma, os);
-        LogDebug("L1Scout") << os.str();
-      }
+#ifdef EDM_ML_DEBUG
+      std::ostringstream os;
+      os << "E/g " << i << "\n";
+      os << "  Raw: 0x" << std::hex << dataBlock[i] << std::dec << "\n";
+      l1ScoutingRun3::printEGamma(eGamma, os);
+      LogDebug("L1Scout") << os.str();
+#endif
     }
   }  // end link e/gammas unpacking loop
 }
@@ -272,13 +274,13 @@ void ScCaloRawToDigi::unpackTaus(uint32_t* dataBlock, int bx, int nObjets) {
       orbitBufferTaus_[bx].push_back(tau);
       nTausOrbit_++;
 
-      if (edm::MessageDrop::instance()->debugEnabled) {
-        std::ostringstream os;
-        os << "Tau " << i << "\n";
-        os << "  Raw: 0x" << std::hex << dataBlock[i] << std::dec << "\n";
-        l1ScoutingRun3::printTau(tau, os);
-        LogDebug("L1Scout") << os.str();
-      }
+#ifdef EDM_ML_DEBUG
+      std::ostringstream os;
+      os << "Tau " << i << "\n";
+      os << "  Raw: 0x" << std::hex << dataBlock[i] << std::dec << "\n";
+      l1ScoutingRun3::printTau(tau, os);
+      LogDebug("L1Scout") << os.str();
+#endif
     }
   }  // end link taus unpacking loop
 }
@@ -404,15 +406,15 @@ void ScCaloRawToDigi::unpackEtSums(uint32_t* dataBlock, int bx) {
   orbitBufferEtSums_[bx].push_back(bxSums);
   nEtSumsOrbit_ += 1;
 
-  if (edm::MessageDrop::instance()->debugEnabled) {
-    std::ostringstream os;
-    os << "Raw frames:\n";
-    for (int frame = 0; frame < 6; frame++) {
-      os << "  frame " << frame << ": 0x" << std::hex << dataBlock[frame] << std::dec << "\n";
-      l1ScoutingRun3::printBxSums(bxSums, os);
-    }
-    LogDebug("L1Scout") << os.str();
+#ifdef EDM_ML_DEBUG
+  std::ostringstream os;
+  os << "Raw frames:\n";
+  for (int frame = 0; frame < 6; frame++) {
+    os << "  frame " << frame << ": 0x" << std::hex << dataBlock[frame] << std::dec << "\n";
+    l1ScoutingRun3::printBxSums(bxSums, os);
   }
+  LogDebug("L1Scout") << os.str();
+#endif
 }
 
 void ScCaloRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.h
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.h
@@ -1,5 +1,4 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScGMTRawToDigi.cc
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScGMTRawToDigi.cc
@@ -1,4 +1,5 @@
 #include "EventFilter/L1ScoutingRawToDigi/plugins/ScGMTRawToDigi.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 ScGMTRawToDigi::ScGMTRawToDigi(const edm::ParameterSet& iConfig) {
   srcInputTag = iConfig.getParameter<edm::InputTag>("srcInputTag");
@@ -142,16 +143,15 @@ void ScGMTRawToDigi::unpackOrbit(const unsigned char* buf, size_t len) {
 
       orbitBuffer_[bx].push_back(muon);
 
-      if (edm::MessageDrop::instance()->debugEnabled) {
-        std::ostringstream os;
-        LogDebug("L1Scout") << "--- Muon " << i << " ---\n"
-                            << "  Raw f:     0x" << std::hex << bl->mu[i].f << std::dec << "\n"
-                            << "  Raw s:     0x" << std::hex << bl->mu[i].s << std::dec << "\n"
-                            << "  Raw extra: 0x" << std::hex << bl->mu[i].extra << std::dec << "\n";
-        printMuon(muon, os);
-        LogDebug("L1Scout") << os.str();
-      }
-
+      LogDebug("L1Scout") << "--- Muon " << i << " ---\n"
+                          << "  Raw f:     0x" << std::hex << bl->mu[i].f << std::dec << "\n"
+                          << "  Raw s:     0x" << std::hex << bl->mu[i].s << std::dec << "\n"
+                          << "  Raw extra: 0x" << std::hex << bl->mu[i].extra << std::dec << "\n";
+#ifdef EDM_ML_DEBUG
+      std::ostringstream os;
+      printMuon(muon, os);
+      LogDebug("L1Scout") << os.str();
+#endif
     }  // end of bx
 
   }  // end orbit while loop

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScGMTRawToDigi.h
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScGMTRawToDigi.h
@@ -2,7 +2,6 @@
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 


### PR DESCRIPTION
backport of #50259

#### PR description:

From the description of #50259:

> Some technical changes to debugging-related calls made during the review of #48093 (https://github.com/cms-sw/cmssw/commit/757444fa56c6171f2cb8554ba1bf7ee7de8118ef) inadvertently made two unpackers of L1-Scouting data (i.e. `ScCALORawToDigi` and `ScGMTRawToDigi`) much slower than they should be. `ScCALORawToDigi`, in particular, became slower by more than a factor of 100. This PR fixes that, by putting these debug-level calls behind the usual `EDM_ML_DEBUG` compilation flag, instead of using `edm::MessageDrop::instance()->debugEnabled`.

#### PR validation:

None beyond the checks made for #50259 (see https://github.com/cms-sw/cmssw/pull/50259#issue-3991248059).

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#50259

Necessary technical fix to two L1-Scouting unpackers for 2026 data-taking. The bug was introduced in #50044.
