### PR TITLE
LST: Improved handling of CA pixel tracks with OT extension, distinguish IT from OT hits

### DIFF
--- a/RecoTracker/LSTCore/interface/Common.h
+++ b/RecoTracker/LSTCore/interface/Common.h
@@ -20,6 +20,10 @@ namespace lst {
   // Named types for LST objects
   enum LSTObjType : int8_t { T5 = 4, pT3 = 5, pT5 = 7, pLS = 8, T4 = 9 };
 
+  enum class HitType : int { Pixel = 0, Invalid = 3, Phase2OT = 4 };  // as in TrackingNtuple.cc
+
+  constexpr unsigned int kPixelModuleId = 1;
+
   constexpr unsigned int max_blocks = 80;
   constexpr unsigned int max_connected_modules = 40;
 

--- a/RecoTracker/LSTCore/interface/LSTInputSoA.h
+++ b/RecoTracker/LSTCore/interface/LSTInputSoA.h
@@ -19,12 +19,11 @@ namespace lst {
                       SOA_COLUMN(float, zs),
                       SOA_COLUMN(unsigned int, idxs),
                       SOA_COLUMN(unsigned int, detid),
-                      SOA_COLUMN(uint16_t, clustsize)
+                      SOA_COLUMN(uint16_t, clustsize),
 #ifndef LST_STANDALONE
-                          ,
-                      SOA_COLUMN(TrackingRecHit const*, hits)
+                      SOA_COLUMN(TrackingRecHit const*, hits),
 #endif
-  )
+                      SOA_SCALAR(unsigned int, nHitsOT))
 
   GENERATE_SOA_LAYOUT(PixelSeedsSoALayout,
                       SOA_COLUMN(Params_pLS::ArrayUxHits, hitIndices),

--- a/RecoTracker/LSTCore/interface/LSTPrepareInput.h
+++ b/RecoTracker/LSTCore/interface/LSTPrepareInput.h
@@ -36,6 +36,7 @@ namespace lst {
                                              std::vector<float> const& see_stateTrajGlbPz,
                                              std::vector<int> const& see_q,
                                              std::vector<std::vector<int>> const& see_hitIdx,
+                                             std::vector<std::vector<int>> const& see_hitType,
                                              std::vector<unsigned int> const& see_algo,
                                              std::vector<unsigned int> const& ph2_detId,
                                              std::vector<uint16_t> const& ph2_clustSize,
@@ -156,18 +157,19 @@ namespace lst {
         trkX.push_back(r3LH.x());
         trkY.push_back(r3LH.y());
         trkZ.push_back(r3LH.z());
-        hitId.push_back(1);
-        hitId.push_back(1);
-        hitId.push_back(1);
-        hitClustSize.push_back(1);
-        hitClustSize.push_back(1);
-        hitClustSize.push_back(1);
+        auto const& hTypes = see_hitType[iSeed];
+        auto constexpr intPixel = static_cast<int>(HitType::Pixel);
+        auto const& hIdxs = see_hitIdx[iSeed];
+        for (int iSH = 0; iSH < 3; iSH++) {
+          hitId.push_back(hTypes[iSH] == intPixel ? kPixelModuleId : ph2_detId[hIdxs[iSH]]);
+          hitClustSize.push_back(hTypes[iSH] == intPixel ? 1 : ph2_clustSize[hIdxs[iSH]]);
+        }
         if (see_hitIdx[iSeed].size() > 3) {
           trkX.push_back(r3LH.x());
           trkY.push_back(see_dxy[iSeed]);
           trkZ.push_back(see_dz[iSeed]);
-          hitId.push_back(1);
-          hitClustSize.push_back(1);
+          hitId.push_back(hTypes[3] == intPixel ? kPixelModuleId : ph2_detId[hIdxs[3]]);
+          hitClustSize.push_back(hTypes[3] == intPixel ? 1 : ph2_clustSize[hIdxs[3]]);
         }
         px_vec.push_back(px);
         py_vec.push_back(py);
@@ -216,6 +218,7 @@ namespace lst {
     LSTInputHostCollection lstInputHC(queue, nHitsIT + nHitsOT, nPixelSeeds);
 
     auto hits = lstInputHC.view().hits();
+    hits.nHitsOT() = nHitsOT;
     std::memcpy(hits.xs().data(), ph2_x.data(), nHitsOT * sizeof(float));
     std::memcpy(hits.ys().data(), ph2_y.data(), nHitsOT * sizeof(float));
     std::memcpy(hits.zs().data(), ph2_z.data(), nHitsOT * sizeof(float));

--- a/RecoTracker/LSTCore/src/alpaka/PixelTriplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/PixelTriplet.h
@@ -23,14 +23,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                                 SegmentsConst segments,
                                                                 PixelSeedsConst pixelSeeds,
                                                                 uint16_t pixelModuleIndex,
-                                                                uint16_t outerInnerLowerModuleIndex,
-                                                                uint16_t outerOuterLowerModuleIndex,
-                                                                unsigned int innerSegmentIndex,
-                                                                unsigned int outerSegmentIndex,
-                                                                unsigned int firstMDIndex,
-                                                                unsigned int secondMDIndex,
-                                                                unsigned int thirdMDIndex,
-                                                                unsigned int fourthMDIndex,
+                                                                uint16_t segmentInnerModuleIndex,
+                                                                uint16_t segmentOuterModuleIndex,
+                                                                unsigned int pLSIndex,
+                                                                unsigned int segmentIndex,
+                                                                unsigned int pLSMD0Index,
+                                                                unsigned int pLSMD1Index,
+                                                                unsigned int segmentMD0Index,
+                                                                unsigned int segmentMD1Index,
                                                                 const float ptCut);
   template <alpaka::concepts::Acc TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runTripletDefaultAlgoPPEE(TAcc const& acc,
@@ -40,14 +40,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                                 SegmentsConst segments,
                                                                 PixelSeedsConst pixelSeeds,
                                                                 uint16_t pixelModuleIndex,
-                                                                uint16_t outerInnerLowerModuleIndex,
-                                                                uint16_t outerOuterLowerModuleIndex,
-                                                                unsigned int innerSegmentIndex,
-                                                                unsigned int outerSegmentIndex,
-                                                                unsigned int firstMDIndex,
-                                                                unsigned int secondMDIndex,
-                                                                unsigned int thirdMDIndex,
-                                                                unsigned int fourthMDIndex,
+                                                                uint16_t segmentInnerModuleIndex,
+                                                                uint16_t segmentOuterModuleIndex,
+                                                                unsigned int pLSIndex,
+                                                                unsigned int segmentIndex,
+                                                                unsigned int pLSMD0Index,
+                                                                unsigned int pLSMD1Index,
+                                                                unsigned int segmentMD0Index,
+                                                                unsigned int segmentMD1Index,
                                                                 const float ptCut);
 
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void addPixelTripletToMemory(MiniDoubletsConst mds,
@@ -848,43 +848,40 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                                 SegmentsConst segments,
                                                                 PixelSeedsConst pixelSeeds,
                                                                 uint16_t pixelModuleIndex,
-                                                                uint16_t outerInnerLowerModuleIndex,
-                                                                uint16_t outerOuterLowerModuleIndex,
-                                                                unsigned int innerSegmentIndex,
-                                                                unsigned int outerSegmentIndex,
-                                                                unsigned int firstMDIndex,
-                                                                unsigned int secondMDIndex,
-                                                                unsigned int thirdMDIndex,
-                                                                unsigned int fourthMDIndex,
+                                                                uint16_t segmentInnerModuleIndex,
+                                                                uint16_t segmentOuterModuleIndex,
+                                                                unsigned int pLSIndex,
+                                                                unsigned int segmentIndex,
+                                                                unsigned int pLSMD0Index,
+                                                                unsigned int pLSMD1Index,
+                                                                unsigned int segmentMD0Index,
+                                                                unsigned int segmentMD1Index,
                                                                 const float ptCut) {
     float dPhi, betaIn, betaOut, pt_beta, zLo, zHi, zLoPointed, zHiPointed, dPhiCut, betaOutCut;
 
-    bool isPS_OutLo = (modules.moduleType()[outerInnerLowerModuleIndex] == PS);
+    bool isPS_OutLo = (modules.moduleType()[segmentInnerModuleIndex] == PS);
 
-    float rt_InLo = mds.anchorRt()[firstMDIndex];
-    float rt_InUp = mds.anchorRt()[secondMDIndex];
-    float rt_OutLo = mds.anchorRt()[thirdMDIndex];
-    float rt_OutUp = mds.anchorRt()[fourthMDIndex];
+    float rt_InLo = mds.anchorRt()[pLSMD0Index];
+    float rt_InUp = mds.anchorRt()[pLSMD1Index];
+    float rt_OutLo = mds.anchorRt()[segmentMD0Index];
+    float rt_OutUp = mds.anchorRt()[segmentMD1Index];
 
-    float z_InUp = mds.anchorZ()[secondMDIndex];
-    float z_OutLo = mds.anchorZ()[thirdMDIndex];
+    float z_InUp = mds.anchorZ()[pLSMD1Index];
+    float z_OutLo = mds.anchorZ()[segmentMD0Index];
 
-    float x_InLo = mds.anchorX()[firstMDIndex];
-    float x_InUp = mds.anchorX()[secondMDIndex];
-    float x_OutLo = mds.anchorX()[thirdMDIndex];
-    float x_OutUp = mds.anchorX()[fourthMDIndex];
+    float x_InLo = mds.anchorX()[pLSMD0Index];
+    float x_InUp = mds.anchorX()[pLSMD1Index];
+    float x_OutLo = mds.anchorX()[segmentMD0Index];
+    float x_OutUp = mds.anchorX()[segmentMD1Index];
 
-    float y_InLo = mds.anchorY()[firstMDIndex];
-    float y_InUp = mds.anchorY()[secondMDIndex];
-    float y_OutLo = mds.anchorY()[thirdMDIndex];
-    float y_OutUp = mds.anchorY()[fourthMDIndex];
+    float y_InLo = mds.anchorY()[pLSMD0Index];
+    float y_InUp = mds.anchorY()[pLSMD1Index];
+    float y_OutLo = mds.anchorY()[segmentMD0Index];
+    float y_OutUp = mds.anchorY()[segmentMD1Index];
 
     float rt_InOut = rt_InUp;
 
-    if (alpaka::math::abs(acc, cms::alpakatools::deltaPhi(acc, x_InUp, y_InUp, x_OutLo, y_OutLo)) > kPi / 2.f)
-      return false;
-
-    unsigned int pixelSegmentArrayIndex = innerSegmentIndex - ranges.segmentModuleIndices()[pixelModuleIndex];
+    unsigned int pixelSegmentArrayIndex = pLSIndex - ranges.segmentModuleIndices()[pixelModuleIndex];
     float ptIn = pixelSeeds.ptIn()[pixelSegmentArrayIndex];
     float ptSLo = ptIn;
     float px = pixelSeeds.px()[pixelSegmentArrayIndex];
@@ -962,11 +959,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
     //lots of array accesses below this...
 
-    float alpha_InLo = __H2F(segments.dPhiChanges()[innerSegmentIndex]);
-    float alpha_OutLo = __H2F(segments.dPhiChanges()[outerSegmentIndex]);
+    float alpha_InLo = __H2F(segments.dPhiChanges()[pLSIndex]);
+    float alpha_OutLo = __H2F(segments.dPhiChanges()[segmentIndex]);
 
-    bool isEC_lastLayer = modules.subdets()[outerOuterLowerModuleIndex] == Endcap and
-                          modules.moduleType()[outerOuterLowerModuleIndex] == TwoS;
+    bool isEC_lastLayer =
+        modules.subdets()[segmentOuterModuleIndex] == Endcap and modules.moduleType()[segmentOuterModuleIndex] == TwoS;
 
     float alpha_OutUp, alpha_OutUp_highEdge, alpha_OutUp_lowEdge;
     alpha_OutUp = cms::alpakatools::deltaPhi(acc, x_OutUp, y_OutUp, x_OutUp - x_OutLo, y_OutUp - y_OutLo);
@@ -994,29 +991,29 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
     if (isEC_lastLayer) {
       alpha_OutUp_highEdge = cms::alpakatools::deltaPhi(acc,
-                                                        mds.anchorHighEdgeX()[fourthMDIndex],
-                                                        mds.anchorHighEdgeY()[fourthMDIndex],
-                                                        mds.anchorHighEdgeX()[fourthMDIndex] - x_OutLo,
-                                                        mds.anchorHighEdgeY()[fourthMDIndex] - y_OutLo);
+                                                        mds.anchorHighEdgeX()[segmentMD1Index],
+                                                        mds.anchorHighEdgeY()[segmentMD1Index],
+                                                        mds.anchorHighEdgeX()[segmentMD1Index] - x_OutLo,
+                                                        mds.anchorHighEdgeY()[segmentMD1Index] - y_OutLo);
       alpha_OutUp_lowEdge = cms::alpakatools::deltaPhi(acc,
-                                                       mds.anchorLowEdgeX()[fourthMDIndex],
-                                                       mds.anchorLowEdgeY()[fourthMDIndex],
-                                                       mds.anchorLowEdgeX()[fourthMDIndex] - x_OutLo,
-                                                       mds.anchorLowEdgeY()[fourthMDIndex] - y_OutLo);
+                                                       mds.anchorLowEdgeX()[segmentMD1Index],
+                                                       mds.anchorLowEdgeY()[segmentMD1Index],
+                                                       mds.anchorLowEdgeX()[segmentMD1Index] - x_OutLo,
+                                                       mds.anchorLowEdgeY()[segmentMD1Index] - y_OutLo);
 
-      tl_axis_highEdge_x = mds.anchorHighEdgeX()[fourthMDIndex] - x_InUp;
-      tl_axis_highEdge_y = mds.anchorHighEdgeY()[fourthMDIndex] - y_InUp;
-      tl_axis_lowEdge_x = mds.anchorLowEdgeX()[fourthMDIndex] - x_InUp;
-      tl_axis_lowEdge_y = mds.anchorLowEdgeY()[fourthMDIndex] - y_InUp;
+      tl_axis_highEdge_x = mds.anchorHighEdgeX()[segmentMD1Index] - x_InUp;
+      tl_axis_highEdge_y = mds.anchorHighEdgeY()[segmentMD1Index] - y_InUp;
+      tl_axis_lowEdge_x = mds.anchorLowEdgeX()[segmentMD1Index] - x_InUp;
+      tl_axis_lowEdge_y = mds.anchorLowEdgeY()[segmentMD1Index] - y_InUp;
 
       betaOutRHmin = -alpha_OutUp_highEdge + cms::alpakatools::deltaPhi(acc,
-                                                                        mds.anchorHighEdgeX()[fourthMDIndex],
-                                                                        mds.anchorHighEdgeY()[fourthMDIndex],
+                                                                        mds.anchorHighEdgeX()[segmentMD1Index],
+                                                                        mds.anchorHighEdgeY()[segmentMD1Index],
                                                                         tl_axis_highEdge_x,
                                                                         tl_axis_highEdge_y);
       betaOutRHmax = -alpha_OutUp_lowEdge + cms::alpakatools::deltaPhi(acc,
-                                                                       mds.anchorLowEdgeX()[fourthMDIndex],
-                                                                       mds.anchorLowEdgeY()[fourthMDIndex],
+                                                                       mds.anchorLowEdgeX()[segmentMD1Index],
+                                                                       mds.anchorLowEdgeY()[segmentMD1Index],
                                                                        tl_axis_lowEdge_x,
                                                                        tl_axis_lowEdge_y);
     }
@@ -1071,13 +1068,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
     float dBetaROut = 0;
     if (isEC_lastLayer) {
-      dBetaROut = (alpaka::math::sqrt(acc,
-                                      mds.anchorHighEdgeX()[fourthMDIndex] * mds.anchorHighEdgeX()[fourthMDIndex] +
-                                          mds.anchorHighEdgeY()[fourthMDIndex] * mds.anchorHighEdgeY()[fourthMDIndex]) -
-                   alpaka::math::sqrt(acc,
-                                      mds.anchorLowEdgeX()[fourthMDIndex] * mds.anchorLowEdgeX()[fourthMDIndex] +
-                                          mds.anchorLowEdgeY()[fourthMDIndex] * mds.anchorLowEdgeY()[fourthMDIndex])) *
-                  sinDPhi / drt_tl_axis;
+      dBetaROut =
+          (alpaka::math::sqrt(acc,
+                              mds.anchorHighEdgeX()[segmentMD1Index] * mds.anchorHighEdgeX()[segmentMD1Index] +
+                                  mds.anchorHighEdgeY()[segmentMD1Index] * mds.anchorHighEdgeY()[segmentMD1Index]) -
+           alpaka::math::sqrt(acc,
+                              mds.anchorLowEdgeX()[segmentMD1Index] * mds.anchorLowEdgeX()[segmentMD1Index] +
+                                  mds.anchorLowEdgeY()[segmentMD1Index] * mds.anchorLowEdgeY()[segmentMD1Index])) *
+          sinDPhi / drt_tl_axis;
     }
 
     const float dBetaROut2 = dBetaROut * dBetaROut;
@@ -1107,41 +1105,41 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                                 SegmentsConst segments,
                                                                 PixelSeedsConst pixelSeeds,
                                                                 uint16_t pixelModuleIndex,
-                                                                uint16_t outerInnerLowerModuleIndex,
-                                                                uint16_t outerOuterLowerModuleIndex,
-                                                                unsigned int innerSegmentIndex,
-                                                                unsigned int outerSegmentIndex,
-                                                                unsigned int firstMDIndex,
-                                                                unsigned int secondMDIndex,
-                                                                unsigned int thirdMDIndex,
-                                                                unsigned int fourthMDIndex,
+                                                                uint16_t segmentInnerModuleIndex,
+                                                                uint16_t segmentOuterModuleIndex,
+                                                                unsigned int pLSIndex,
+                                                                unsigned int segmentIndex,
+                                                                unsigned int pLSMD0Index,
+                                                                unsigned int pLSMD1Index,
+                                                                unsigned int segmentMD0Index,
+                                                                unsigned int segmentMD1Index,
                                                                 const float ptCut) {
     float dPhi, betaIn, betaOut, pt_beta, rtLo, rtHi, dPhiCut, betaOutCut;
 
-    bool isPS_OutLo = (modules.moduleType()[outerInnerLowerModuleIndex] == PS);
+    bool isPS_OutLo = (modules.moduleType()[segmentInnerModuleIndex] == PS);
 
-    float z_InUp = mds.anchorZ()[secondMDIndex];
-    float z_OutLo = mds.anchorZ()[thirdMDIndex];
+    float z_InUp = mds.anchorZ()[pLSMD1Index];
+    float z_OutLo = mds.anchorZ()[segmentMD0Index];
 
     if (z_InUp * z_OutLo <= 0)
       return false;
 
-    float rt_InLo = mds.anchorRt()[firstMDIndex];
-    float rt_InUp = mds.anchorRt()[secondMDIndex];
-    float rt_OutLo = mds.anchorRt()[thirdMDIndex];
-    float rt_OutUp = mds.anchorRt()[fourthMDIndex];
+    float rt_InLo = mds.anchorRt()[pLSMD0Index];
+    float rt_InUp = mds.anchorRt()[pLSMD1Index];
+    float rt_OutLo = mds.anchorRt()[segmentMD0Index];
+    float rt_OutUp = mds.anchorRt()[segmentMD1Index];
 
-    float x_InLo = mds.anchorX()[firstMDIndex];
-    float x_InUp = mds.anchorX()[secondMDIndex];
-    float x_OutLo = mds.anchorX()[thirdMDIndex];
-    float x_OutUp = mds.anchorX()[fourthMDIndex];
+    float x_InLo = mds.anchorX()[pLSMD0Index];
+    float x_InUp = mds.anchorX()[pLSMD1Index];
+    float x_OutLo = mds.anchorX()[segmentMD0Index];
+    float x_OutUp = mds.anchorX()[segmentMD1Index];
 
-    float y_InLo = mds.anchorY()[firstMDIndex];
-    float y_InUp = mds.anchorY()[secondMDIndex];
-    float y_OutLo = mds.anchorY()[thirdMDIndex];
-    float y_OutUp = mds.anchorY()[fourthMDIndex];
+    float y_InLo = mds.anchorY()[pLSMD0Index];
+    float y_InUp = mds.anchorY()[pLSMD1Index];
+    float y_OutLo = mds.anchorY()[segmentMD0Index];
+    float y_OutUp = mds.anchorY()[segmentMD1Index];
 
-    unsigned int pixelSegmentArrayIndex = innerSegmentIndex - ranges.segmentModuleIndices()[pixelModuleIndex];
+    unsigned int pixelSegmentArrayIndex = pLSIndex - ranges.segmentModuleIndices()[pixelModuleIndex];
 
     float ptIn = pixelSeeds.ptIn()[pixelSegmentArrayIndex];
     float ptSLo = ptIn;
@@ -1162,7 +1160,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     const float dzDrtScale = alpaka::math::tan(acc, slope) / slope;  //FIXME: need approximate value
 
     const float dLum = alpaka::math::copysign(acc, kDeltaZLum, z_InUp);
-    bool isOutSgInnerMDPS = modules.moduleType()[outerInnerLowerModuleIndex] == PS;
+    bool isOutSgInnerMDPS = modules.moduleType()[segmentInnerModuleIndex] == PS;
 
     const float rtGeom1 = isOutSgInnerMDPS
                               ? kPixelPSZpitch
@@ -1225,11 +1223,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     if (alpaka::math::abs(acc, dPhi) > dPhiCut)
       return false;
 
-    float alpha_InLo = __H2F(segments.dPhiChanges()[innerSegmentIndex]);
-    float alpha_OutLo = __H2F(segments.dPhiChanges()[outerSegmentIndex]);
+    float alpha_InLo = __H2F(segments.dPhiChanges()[pLSIndex]);
+    float alpha_OutLo = __H2F(segments.dPhiChanges()[segmentIndex]);
 
-    bool isEC_lastLayer = modules.subdets()[outerOuterLowerModuleIndex] == Endcap and
-                          modules.moduleType()[outerOuterLowerModuleIndex] == TwoS;
+    bool isEC_lastLayer =
+        modules.subdets()[segmentOuterModuleIndex] == Endcap and modules.moduleType()[segmentOuterModuleIndex] == TwoS;
 
     float alpha_OutUp, alpha_OutUp_highEdge, alpha_OutUp_lowEdge;
 
@@ -1256,29 +1254,29 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
     if (isEC_lastLayer) {
       alpha_OutUp_highEdge = cms::alpakatools::deltaPhi(acc,
-                                                        mds.anchorHighEdgeX()[fourthMDIndex],
-                                                        mds.anchorHighEdgeY()[fourthMDIndex],
-                                                        mds.anchorHighEdgeX()[fourthMDIndex] - x_OutLo,
-                                                        mds.anchorHighEdgeY()[fourthMDIndex] - y_OutLo);
+                                                        mds.anchorHighEdgeX()[segmentMD1Index],
+                                                        mds.anchorHighEdgeY()[segmentMD1Index],
+                                                        mds.anchorHighEdgeX()[segmentMD1Index] - x_OutLo,
+                                                        mds.anchorHighEdgeY()[segmentMD1Index] - y_OutLo);
       alpha_OutUp_lowEdge = cms::alpakatools::deltaPhi(acc,
-                                                       mds.anchorLowEdgeX()[fourthMDIndex],
-                                                       mds.anchorLowEdgeY()[fourthMDIndex],
-                                                       mds.anchorLowEdgeX()[fourthMDIndex] - x_OutLo,
-                                                       mds.anchorLowEdgeY()[fourthMDIndex] - y_OutLo);
+                                                       mds.anchorLowEdgeX()[segmentMD1Index],
+                                                       mds.anchorLowEdgeY()[segmentMD1Index],
+                                                       mds.anchorLowEdgeX()[segmentMD1Index] - x_OutLo,
+                                                       mds.anchorLowEdgeY()[segmentMD1Index] - y_OutLo);
 
-      tl_axis_highEdge_x = mds.anchorHighEdgeX()[fourthMDIndex] - x_InUp;
-      tl_axis_highEdge_y = mds.anchorHighEdgeY()[fourthMDIndex] - y_InUp;
-      tl_axis_lowEdge_x = mds.anchorLowEdgeX()[fourthMDIndex] - x_InUp;
-      tl_axis_lowEdge_y = mds.anchorLowEdgeY()[fourthMDIndex] - y_InUp;
+      tl_axis_highEdge_x = mds.anchorHighEdgeX()[segmentMD1Index] - x_InUp;
+      tl_axis_highEdge_y = mds.anchorHighEdgeY()[segmentMD1Index] - y_InUp;
+      tl_axis_lowEdge_x = mds.anchorLowEdgeX()[segmentMD1Index] - x_InUp;
+      tl_axis_lowEdge_y = mds.anchorLowEdgeY()[segmentMD1Index] - y_InUp;
 
       betaOutRHmin = -alpha_OutUp_highEdge + cms::alpakatools::deltaPhi(acc,
-                                                                        mds.anchorHighEdgeX()[fourthMDIndex],
-                                                                        mds.anchorHighEdgeY()[fourthMDIndex],
+                                                                        mds.anchorHighEdgeX()[segmentMD1Index],
+                                                                        mds.anchorHighEdgeY()[segmentMD1Index],
                                                                         tl_axis_highEdge_x,
                                                                         tl_axis_highEdge_y);
       betaOutRHmax = -alpha_OutUp_lowEdge + cms::alpakatools::deltaPhi(acc,
-                                                                       mds.anchorLowEdgeX()[fourthMDIndex],
-                                                                       mds.anchorLowEdgeY()[fourthMDIndex],
+                                                                       mds.anchorLowEdgeX()[segmentMD1Index],
+                                                                       mds.anchorLowEdgeY()[segmentMD1Index],
                                                                        tl_axis_lowEdge_x,
                                                                        tl_axis_lowEdge_y);
     }
@@ -1332,13 +1330,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
     float dBetaROut = 0;
     if (isEC_lastLayer) {
-      dBetaROut = (alpaka::math::sqrt(acc,
-                                      mds.anchorHighEdgeX()[fourthMDIndex] * mds.anchorHighEdgeX()[fourthMDIndex] +
-                                          mds.anchorHighEdgeY()[fourthMDIndex] * mds.anchorHighEdgeY()[fourthMDIndex]) -
-                   alpaka::math::sqrt(acc,
-                                      mds.anchorLowEdgeX()[fourthMDIndex] * mds.anchorLowEdgeX()[fourthMDIndex] +
-                                          mds.anchorLowEdgeY()[fourthMDIndex] * mds.anchorLowEdgeY()[fourthMDIndex])) *
-                  sinDPhi / drt_tl_axis;
+      dBetaROut =
+          (alpaka::math::sqrt(acc,
+                              mds.anchorHighEdgeX()[segmentMD1Index] * mds.anchorHighEdgeX()[segmentMD1Index] +
+                                  mds.anchorHighEdgeY()[segmentMD1Index] * mds.anchorHighEdgeY()[segmentMD1Index]) -
+           alpaka::math::sqrt(acc,
+                              mds.anchorLowEdgeX()[segmentMD1Index] * mds.anchorLowEdgeX()[segmentMD1Index] +
+                                  mds.anchorLowEdgeY()[segmentMD1Index] * mds.anchorLowEdgeY()[segmentMD1Index])) *
+          sinDPhi / drt_tl_axis;
     }
 
     const float dBetaROut2 = dBetaROut * dBetaROut;

--- a/RecoTracker/LSTCore/standalone/bin/lst.cc
+++ b/RecoTracker/LSTCore/standalone/bin/lst.cc
@@ -417,6 +417,7 @@ void run_lst() {
                                    trk.getVF("see_stateTrajGlbPz"),
                                    trk.getVI("see_q"),
                                    trk.getVVI("see_hitIdx"),
+                                   trk.getVVI("see_hitType"),
                                    trk.getVU("see_algo"),
                                    trk.getVU("ph2_detId"),
                                    trk_ph2_clustSize,

--- a/RecoTracker/LSTCore/standalone/code/core/AccessHelper.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/AccessHelper.cc
@@ -7,17 +7,17 @@ using namespace ALPAKA_ACCELERATOR_NAMESPACE::lst;
 // ===============
 
 //____________________________________________________________________________________________
-std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> convertHitsToHitIdxsAndHitTypes(
+std::tuple<std::vector<unsigned int>, std::vector<HitType>> convertHitsToHitIdxsAndHitTypes(
     LSTEvent* event, std::vector<unsigned int> hits) {
   auto hitsBase = event->getInput<HitsBaseSoA>();
   std::vector<unsigned int> hitidxs;
-  std::vector<unsigned int> hittypes;
+  std::vector<HitType> hittypes;
   for (auto& hit : hits) {
     hitidxs.push_back(hitsBase.idxs()[hit]);
-    if (hitsBase.detid()[hit] == 1)
-      hittypes.push_back(0);
+    if (hitsBase.detid()[hit] == kPixelModuleId)
+      hittypes.push_back(HitType::Pixel);
     else
-      hittypes.push_back(4);
+      hittypes.push_back(HitType::Phase2OT);
   }
   return std::make_tuple(hitidxs, hittypes);
 }
@@ -27,7 +27,7 @@ std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> convertHitsToHi
 // ===============
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> getPixelHitsFrompLS(LSTEvent* event, unsigned int pLS) {
+std::vector<unsigned int> getHitsFrompLS(LSTEvent* event, unsigned int pLS) {
   SegmentsConst segments = event->getSegments<SegmentsSoA>();
   MiniDoubletsConst miniDoublets = event->getMiniDoublets<MiniDoubletsSoA>();
   auto ranges = event->getRanges();
@@ -46,26 +46,31 @@ std::vector<unsigned int> getPixelHitsFrompLS(LSTEvent* event, unsigned int pLS)
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> getPixelHitIdxsFrompLS(LSTEvent* event, unsigned int pLS) {
+std::vector<unsigned int> getHitIdxsFrompLS(LSTEvent* event, unsigned int pLS) {
   auto hitsBase = event->getInput<HitsBaseSoA>();
-  std::vector<unsigned int> hits = getPixelHitsFrompLS(event, pLS);
+  std::vector<unsigned int> hits = getHitsFrompLS(event, pLS);
   std::vector<unsigned int> hitidxs;
+  hitidxs.reserve(hits.size());
   for (auto& hit : hits)
     hitidxs.push_back(hitsBase.idxs()[hit]);
   return hitidxs;
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> getPixelHitTypesFrompLS(LSTEvent* event, unsigned int pLS) {
-  std::vector<unsigned int> hits = getPixelHitsFrompLS(event, pLS);
-  std::vector<unsigned int> hittypes(hits.size(), 0);
+std::vector<HitType> getHitTypesFrompLS(LSTEvent* event, unsigned int pLS) {
+  std::vector<unsigned int> hits = getHitsFrompLS(event, pLS);
+  std::vector<HitType> hittypes;
+  hittypes.reserve(hits.size());
+  auto hitsBase = event->getInput<HitsBaseSoA>();
+  for (auto& hit : hits)
+    hittypes.push_back(hitsBase.detid()[hit] == kPixelModuleId ? HitType::Pixel : HitType::Phase2OT);
   return hittypes;
 }
 
 //____________________________________________________________________________________________
-std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHitTypesFrompLS(LSTEvent* event,
-                                                                                              unsigned pLS) {
-  return convertHitsToHitIdxsAndHitTypes(event, getPixelHitsFrompLS(event, pLS));
+std::tuple<std::vector<unsigned int>, std::vector<HitType>> getHitIdxsAndHitTypesFrompLS(LSTEvent* event,
+                                                                                         unsigned pLS) {
+  return convertHitsToHitIdxsAndHitTypes(event, getHitsFrompLS(event, pLS));
 }
 
 // ==============
@@ -81,8 +86,7 @@ std::vector<unsigned int> getHitsFromMD(LSTEvent* event, unsigned int MD) {
 }
 
 //____________________________________________________________________________________________
-std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHitTypesFromMD(LSTEvent* event,
-                                                                                             unsigned MD) {
+std::tuple<std::vector<unsigned int>, std::vector<HitType>> getHitIdxsAndHitTypesFromMD(LSTEvent* event, unsigned MD) {
   return convertHitsToHitIdxsAndHitTypes(event, getHitsFromMD(event, MD));
 }
 
@@ -107,8 +111,7 @@ std::vector<unsigned int> getHitsFromLS(LSTEvent* event, unsigned int LS) {
 }
 
 //____________________________________________________________________________________________
-std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHitTypesFromLS(LSTEvent* event,
-                                                                                             unsigned LS) {
+std::tuple<std::vector<unsigned int>, std::vector<HitType>> getHitIdxsAndHitTypesFromLS(LSTEvent* event, unsigned LS) {
   return convertHitsToHitIdxsAndHitTypes(event, getHitsFromLS(event, LS));
 }
 
@@ -142,8 +145,7 @@ std::vector<unsigned int> getHitsFromT3(LSTEvent* event, unsigned int T3) {
 }
 
 //____________________________________________________________________________________________
-std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHitTypesFromT3(LSTEvent* event,
-                                                                                             unsigned T3) {
+std::tuple<std::vector<unsigned int>, std::vector<HitType>> getHitIdxsAndHitTypesFromT3(LSTEvent* event, unsigned T3) {
   return convertHitsToHitIdxsAndHitTypes(event, getHitsFromT3(event, T3));
 }
 
@@ -206,14 +208,12 @@ std::vector<unsigned int> getModuleIdxsFromT4(LSTEvent* event, unsigned int T4) 
   return module_idxs;
 }
 //____________________________________________________________________________________________
-std::vector<unsigned int> getHitTypesFromT4(LSTEvent* event, unsigned int T4) {
-  return {4, 4, 4, 4, 4, 4, 4, 4};
-  ;
+std::vector<HitType> getHitTypesFromT4(LSTEvent* event, unsigned int T4) {
+  return {Params_T4::kHits, HitType::Phase2OT};
 }
 
 //____________________________________________________________________________________________
-std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHitTypesFromT4(LSTEvent* event,
-                                                                                             unsigned T4) {
+std::tuple<std::vector<unsigned int>, std::vector<HitType>> getHitIdxsAndHitTypesFromT4(LSTEvent* event, unsigned T4) {
   return convertHitsToHitIdxsAndHitTypes(event, getHitsFromT4(event, T4));
 }
 
@@ -290,14 +290,17 @@ std::vector<unsigned int> getModuleIdxsFromT3(LSTEvent* event, unsigned int T3) 
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> getHitTypesFromT5(LSTEvent* event, unsigned int T5) { return {4, 4, 4, 4, 4, 4, 4, 4, 4, 4}; }
+std::vector<HitType> getHitTypesFromT5(LSTEvent* event, unsigned int T5) {
+  return {Params_T5::kHits, HitType::Phase2OT};
+}
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> getHitTypesFromT3(LSTEvent* event, unsigned int T5) { return {4, 4, 4, 4, 4, 4}; }
+std::vector<HitType> getHitTypesFromT3(LSTEvent* event, unsigned int T5) {
+  return {Params_T3::kHits, HitType::Phase2OT};
+}
 
 //____________________________________________________________________________________________
-std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHitTypesFromT5(LSTEvent* event,
-                                                                                             unsigned T5) {
+std::tuple<std::vector<unsigned int>, std::vector<HitType>> getHitIdxsAndHitTypesFromT5(LSTEvent* event, unsigned T5) {
   return convertHitsToHitIdxsAndHitTypes(event, getHitsFromT5(event, T5));
 }
 
@@ -306,7 +309,7 @@ std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHi
 // ===============
 
 //____________________________________________________________________________________________
-unsigned int getPixelLSFrompT3(LSTEvent* event, unsigned int pT3) {
+unsigned int getpLSFrompT3(LSTEvent* event, unsigned int pT3) {
   auto const pixelTriplets = event->getPixelTriplets();
   auto ranges = event->getRanges();
   auto modulesEvt = event->getModules<ModulesSoA>();
@@ -333,25 +336,26 @@ std::vector<unsigned int> getMDsFrompT3(LSTEvent* event, unsigned int pT3) {
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> getOuterTrackerHitsFrompT3(LSTEvent* event, unsigned int pT3) {
+std::vector<unsigned int> getT3HitsFrompT3(LSTEvent* event, unsigned int pT3) {
   unsigned int T3 = getT3FrompT3(event, pT3);
   return getHitsFromT3(event, T3);
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> getPixelHitsFrompT3(LSTEvent* event, unsigned int pT3) {
-  unsigned int pLS = getPixelLSFrompT3(event, pT3);
-  return getPixelHitsFrompLS(event, pLS);
+std::vector<unsigned int> getpLSHitsFrompT3(LSTEvent* event, unsigned int pT3) {
+  unsigned int pLS = getpLSFrompT3(event, pT3);
+  return getHitsFrompLS(event, pLS);
 }
 
 //____________________________________________________________________________________________
 std::vector<unsigned int> getHitsFrompT3(LSTEvent* event, unsigned int pT3) {
-  unsigned int pLS = getPixelLSFrompT3(event, pT3);
-  unsigned int T3 = getT3FrompT3(event, pT3);
-  std::vector<unsigned int> pixelHits = getPixelHitsFrompLS(event, pLS);
-  std::vector<unsigned int> outerTrackerHits = getHitsFromT3(event, T3);
-  pixelHits.insert(pixelHits.end(), outerTrackerHits.begin(), outerTrackerHits.end());
-  return pixelHits;
+  auto const& allHits = event->getPixelTriplets().hitIndices()[pT3];
+  std::vector<unsigned int> hits;
+  hits.reserve(allHits.size());
+  for (auto const hit : allHits)
+    if (hits.empty() || hits.back() != hit)  // should eventually check all and type
+      hits.emplace_back(hit);
+  return hits;
 }
 
 //____________________________________________________________________________________________
@@ -365,7 +369,7 @@ std::vector<unsigned int> getHitIdxsFrompT3(LSTEvent* event, unsigned int pT3) {
 }
 //____________________________________________________________________________________________
 std::vector<unsigned int> getModuleIdxsFrompT3(LSTEvent* event, unsigned int pT3) {
-  std::vector<unsigned int> hits = getOuterTrackerHitsFrompT3(event, pT3);
+  std::vector<unsigned int> hits = getT3HitsFrompT3(event, pT3);
   std::vector<unsigned int> module_idxs;
   auto hitsEvt = event->getHits<HitsExtendedSoA>();
   for (auto& hitIdx : hits) {
@@ -374,19 +378,16 @@ std::vector<unsigned int> getModuleIdxsFrompT3(LSTEvent* event, unsigned int pT3
   return module_idxs;
 }
 //____________________________________________________________________________________________
-std::vector<unsigned int> getHitTypesFrompT3(LSTEvent* event, unsigned int pT3) {
-  unsigned int pLS = getPixelLSFrompT3(event, pT3);
-  std::vector<unsigned int> pixelHits = getPixelHitsFrompLS(event, pLS);
-  // pixel Hits list will be either 3 or 4 and depending on it return accordingly
-  if (pixelHits.size() == 3)
-    return {0, 0, 0, 4, 4, 4, 4, 4, 4};
-  else
-    return {0, 0, 0, 0, 4, 4, 4, 4, 4, 4};
+std::vector<HitType> getHitTypesFrompT3(LSTEvent* event, unsigned int pT3) {
+  unsigned int pLS = getpLSFrompT3(event, pT3);
+  auto hitTypes = getHitTypesFrompLS(event, pLS);
+  hitTypes.insert(hitTypes.end(), Params_T3::kHits, HitType::Phase2OT);
+  return hitTypes;
 }
 
 //____________________________________________________________________________________________
-std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHitTypesFrompT3(LSTEvent* event,
-                                                                                              unsigned pT3) {
+std::tuple<std::vector<unsigned int>, std::vector<HitType>> getHitIdxsAndHitTypesFrompT3(LSTEvent* event,
+                                                                                         unsigned pT3) {
   return convertHitsToHitIdxsAndHitTypes(event, getHitsFrompT3(event, pT3));
 }
 
@@ -395,7 +396,7 @@ std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHi
 // ===============
 
 //____________________________________________________________________________________________
-unsigned int getPixelLSFrompT5(LSTEvent* event, unsigned int pT5) {
+unsigned int getpLSFrompT5(LSTEvent* event, unsigned int pT5) {
   auto const pixelQuintuplets = event->getPixelQuintuplets();
   auto ranges = event->getRanges();
   auto modulesEvt = event->getModules<ModulesSoA>();
@@ -428,25 +429,26 @@ std::vector<unsigned int> getMDsFrompT5(LSTEvent* event, unsigned int pT5) {
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> getOuterTrackerHitsFrompT5(LSTEvent* event, unsigned int pT5) {
+std::vector<unsigned int> getT5HitsFrompT5(LSTEvent* event, unsigned int pT5) {
   unsigned int T5 = getT5FrompT5(event, pT5);
   return getHitsFromT5(event, T5);
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> getPixelHitsFrompT5(LSTEvent* event, unsigned int pT5) {
-  unsigned int pLS = getPixelLSFrompT5(event, pT5);
-  return getPixelHitsFrompLS(event, pLS);
+std::vector<unsigned int> getpLSHitsFrompT5(LSTEvent* event, unsigned int pT5) {
+  unsigned int pLS = getpLSFrompT5(event, pT5);
+  return getHitsFrompLS(event, pLS);
 }
 
 //____________________________________________________________________________________________
 std::vector<unsigned int> getHitsFrompT5(LSTEvent* event, unsigned int pT5) {
-  unsigned int pLS = getPixelLSFrompT5(event, pT5);
-  unsigned int T5 = getT5FrompT5(event, pT5);
-  std::vector<unsigned int> pixelHits = getPixelHitsFrompLS(event, pLS);
-  std::vector<unsigned int> outerTrackerHits = getHitsFromT5(event, T5);
-  pixelHits.insert(pixelHits.end(), outerTrackerHits.begin(), outerTrackerHits.end());
-  return pixelHits;
+  auto const& allHits = event->getPixelQuintuplets().hitIndices()[pT5];
+  std::vector<unsigned int> hits;
+  hits.reserve(allHits.size());
+  for (auto const hit : allHits)
+    if (hits.empty() || hits.back() != hit)  // should eventually check all and type
+      hits.emplace_back(hit);
+  return hits;
 }
 
 //____________________________________________________________________________________________
@@ -461,7 +463,7 @@ std::vector<unsigned int> getHitIdxsFrompT5(LSTEvent* event, unsigned int pT5) {
 
 //____________________________________________________________________________________________
 std::vector<unsigned int> getModuleIdxsFrompT5(LSTEvent* event, unsigned int pT5) {
-  std::vector<unsigned int> hits = getOuterTrackerHitsFrompT5(event, pT5);
+  std::vector<unsigned int> hits = getT5HitsFrompT5(event, pT5);
   std::vector<unsigned int> module_idxs;
   auto hitsEvt = event->getHits<HitsExtendedSoA>();
   for (auto& hitIdx : hits) {
@@ -471,19 +473,16 @@ std::vector<unsigned int> getModuleIdxsFrompT5(LSTEvent* event, unsigned int pT5
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> getHitTypesFrompT5(LSTEvent* event, unsigned int pT5) {
-  unsigned int pLS = getPixelLSFrompT5(event, pT5);
-  std::vector<unsigned int> pixelHits = getPixelHitsFrompLS(event, pLS);
-  // pixel Hits list will be either 3 or 4 and depending on it return accordingly
-  if (pixelHits.size() == 3)
-    return {0, 0, 0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
-  else
-    return {0, 0, 0, 0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
+std::vector<HitType> getHitTypesFrompT5(LSTEvent* event, unsigned int pT5) {
+  unsigned int pLS = getpLSFrompT5(event, pT5);
+  auto hitTypes = getHitTypesFrompLS(event, pLS);
+  hitTypes.insert(hitTypes.end(), Params_T5::kHits, HitType::Phase2OT);
+  return hitTypes;
 }
 
 //____________________________________________________________________________________________
-std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHitTypesFrompT5(LSTEvent* event,
-                                                                                              unsigned pT5) {
+std::tuple<std::vector<unsigned int>, std::vector<HitType>> getHitIdxsAndHitTypesFrompT5(LSTEvent* event,
+                                                                                         unsigned pT5) {
   return convertHitsToHitIdxsAndHitTypes(event, getHitsFrompT5(event, pT5));
 }
 
@@ -518,8 +517,8 @@ std::vector<unsigned int> getLSsFromTC(LSTEvent* event, unsigned int iTC) {
 }
 
 //____________________________________________________________________________________________
-std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHitTypesFromTC(LSTEvent* event,
-                                                                                             unsigned iTC) {
+std::tuple<std::vector<unsigned int>, std::vector<HitType>> getUnderlyingHitIdxsAndHitTypesFromTC(LSTEvent* event,
+                                                                                                  unsigned iTC) {
   // Get the type of the track candidate
   auto const& trackCandidatesBase = event->getTrackCandidatesBase();
   auto const& trackCandidatesExtended = event->getTrackCandidatesExtended();
@@ -544,15 +543,15 @@ std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHi
   }
 }
 
-std::pair<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndTypesFromTC(LSTEvent* event,
-                                                                                         unsigned int tc_idx) {
+std::pair<std::vector<unsigned int>, std::vector<HitType>> getHitIdxsAndHitTypesFromTC(LSTEvent* event,
+                                                                                       unsigned int tc_idx) {
   auto const& base = event->getTrackCandidatesBase();
   auto const& ext = event->getTrackCandidatesExtended();
   auto const& hitsBase = event->getInput<HitsBaseSoA>();
 
   std::vector<unsigned int> hitIdx;
   hitIdx.reserve(Params_TC::kHits);
-  std::vector<unsigned int> hitType;
+  std::vector<HitType> hitType;
   hitType.reserve(Params_TC::kHits);
 
   for (int layerSlot = 0; layerSlot < Params_TC::kLayers; ++layerSlot) {
@@ -566,10 +565,10 @@ std::pair<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndTyp
         continue;
 
       // Get the GLOBAL ntuple indices
-      const unsigned int hitGlobal = hitsBase.idxs()[hitLocal];
+      const auto hitGlobal = hitsBase.idxs()[hitLocal];
 
-      // Determine the type from the hit's detid (1 = pixel, otherwise OT)
-      const unsigned int type = (hitsBase.detid()[hitLocal] == 1) ? 0u : 4u;
+      // Determine the type from the hit's detid
+      const auto type = (hitsBase.detid()[hitLocal] == kPixelModuleId) ? HitType::Pixel : HitType::Phase2OT;
 
       // Push the GLOBAL index and type
       hitIdx.push_back(hitGlobal);

--- a/RecoTracker/LSTCore/standalone/code/core/AccessHelper.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/AccessHelper.cc
@@ -514,6 +514,7 @@ std::vector<unsigned int> getLSsFromTC(LSTEvent* event, unsigned int iTC) {
       return getLSsFromT4(event, objidx);
       break;
   }
+  throw std::logic_error("Unsupported type " + std::to_string(type));
 }
 
 //____________________________________________________________________________________________
@@ -541,6 +542,7 @@ std::tuple<std::vector<unsigned int>, std::vector<HitType>> getUnderlyingHitIdxs
       return getHitIdxsAndHitTypesFromT4(event, objidx);
       break;
   }
+  throw std::logic_error("Unsupported type " + std::to_string(type));
 }
 
 std::pair<std::vector<unsigned int>, std::vector<HitType>> getHitIdxsAndHitTypesFromTC(LSTEvent* event,

--- a/RecoTracker/LSTCore/standalone/code/core/AccessHelper.h
+++ b/RecoTracker/LSTCore/standalone/code/core/AccessHelper.h
@@ -8,34 +8,34 @@
 using LSTEvent = ALPAKA_ACCELERATOR_NAMESPACE::lst::LSTEvent;
 
 // ----* Hit *----
-std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> convertHitsToHitIdxsAndHitTypes(
+std::tuple<std::vector<unsigned int>, std::vector<lst::HitType>> convertHitsToHitIdxsAndHitTypes(
     LSTEvent* event, std::vector<unsigned int> hits);
 
 // ----* pLS *----
-std::vector<unsigned int> getPixelHitsFrompLS(LSTEvent* event, unsigned int pLS);
-std::vector<unsigned int> getPixelHitIdxsFrompLS(LSTEvent* event, unsigned int pLS);
-std::vector<unsigned int> getPixelHitTypesFrompLS(LSTEvent* event, unsigned int pLS);
-std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHitTypesFrompLS(LSTEvent* event,
+std::vector<unsigned int> getHitsFrompLS(LSTEvent* event, unsigned int pLS);
+std::vector<unsigned int> getHitIdxsFrompLS(LSTEvent* event, unsigned int pLS);
+std::vector<lst::HitType> getHitTypesFrompLS(LSTEvent* event, unsigned int pLS);
+std::tuple<std::vector<unsigned int>, std::vector<lst::HitType>> getHitIdxsAndHitTypesFrompLS(LSTEvent* event,
                                                                                               unsigned pLS);
 
 // ----* MD *----
 std::vector<unsigned int> getHitsFromMD(LSTEvent* event, unsigned int MD);
-std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHitTypesFromMD(LSTEvent* event,
+std::tuple<std::vector<unsigned int>, std::vector<lst::HitType>> getHitIdxsAndHitTypesFromMD(LSTEvent* event,
                                                                                              unsigned MD);
 
 // ----* LS *----
 std::vector<unsigned int> getMDsFromLS(LSTEvent* event, unsigned int LS);
 std::vector<unsigned int> getHitsFromLS(LSTEvent* event, unsigned int LS);
-std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHitTypesFromLS(LSTEvent* event,
+std::tuple<std::vector<unsigned int>, std::vector<lst::HitType>> getHitIdxsAndHitTypesFromLS(LSTEvent* event,
                                                                                              unsigned LS);
 
 // ----* T3 *----
 std::vector<unsigned int> getLSsFromT3(LSTEvent* event, unsigned int T3);
 std::vector<unsigned int> getMDsFromT3(LSTEvent* event, unsigned int T3);
 std::vector<unsigned int> getHitsFromT3(LSTEvent* event, unsigned int T3);
-std::vector<unsigned int> getHitTypesFromT3(LSTEvent* event, unsigned int T3);
+std::vector<lst::HitType> getHitTypesFromT3(LSTEvent* event, unsigned int T3);
 std::vector<unsigned int> getModuleIdxsFromT3(LSTEvent* event, unsigned int T3);
-std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHitTypesFromT3(LSTEvent* event,
+std::tuple<std::vector<unsigned int>, std::vector<lst::HitType>> getHitIdxsAndHitTypesFromT3(LSTEvent* event,
                                                                                              unsigned T3);
 
 // ----* T4 *----
@@ -44,9 +44,9 @@ std::vector<unsigned int> getLSsFromT4(LSTEvent* event, unsigned int T4);
 std::vector<unsigned int> getMDsFromT4(LSTEvent* event, unsigned int T4);
 std::vector<unsigned int> getHitsFromT4(LSTEvent* event, unsigned int T4);
 std::vector<unsigned int> getHitIdxsFromT4(LSTEvent* event, unsigned int T4);
-std::vector<unsigned int> getHitTypesFromT4(LSTEvent* event, unsigned int T4);
+std::vector<lst::HitType> getHitTypesFromT4(LSTEvent* event, unsigned int T4);
 std::vector<unsigned int> getModuleIdxsFromT4(LSTEvent* event, unsigned int T4);
-std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHitTypesFromT4(LSTEvent* event,
+std::tuple<std::vector<unsigned int>, std::vector<lst::HitType>> getHitIdxsAndHitTypesFromT4(LSTEvent* event,
                                                                                              unsigned T4);
 
 // ----* T5 *----
@@ -55,46 +55,46 @@ std::vector<unsigned int> getLSsFromT5(LSTEvent* event, unsigned int T5);
 std::vector<unsigned int> getMDsFromT5(LSTEvent* event, unsigned int T5);
 std::vector<unsigned int> getHitsFromT5(LSTEvent* event, unsigned int T5);
 std::vector<unsigned int> getHitIdxsFromT5(LSTEvent* event, unsigned int T5);
-std::vector<unsigned int> getHitTypesFromT5(LSTEvent* event, unsigned int T5);
+std::vector<lst::HitType> getHitTypesFromT5(LSTEvent* event, unsigned int T5);
 std::vector<unsigned int> getModuleIdxsFromT5(LSTEvent* event, unsigned int T5);
-std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHitTypesFromT5(LSTEvent* event,
+std::tuple<std::vector<unsigned int>, std::vector<lst::HitType>> getHitIdxsAndHitTypesFromT5(LSTEvent* event,
                                                                                              unsigned T5);
 
 // ----* pT3 *----
-unsigned int getPixelLSFrompT3(LSTEvent* event, unsigned int pT3);
+unsigned int getpLSFrompT3(LSTEvent* event, unsigned int pT3);
 unsigned int getT3FrompT3(LSTEvent* event, unsigned int pT3);
 std::vector<unsigned int> getLSsFrompT3(LSTEvent* event, unsigned int pT3);
 std::vector<unsigned int> getMDsFrompT3(LSTEvent* event, unsigned int pT3);
-std::vector<unsigned int> getOuterTrackerHitsFrompT3(LSTEvent* event, unsigned int pT3);
-std::vector<unsigned int> getPixelHitsFrompT3(LSTEvent* event, unsigned int pT3);
+std::vector<unsigned int> getT3HitsFrompT3(LSTEvent* event, unsigned int pT3);
+std::vector<unsigned int> getpLSHitsFrompT3(LSTEvent* event, unsigned int pT3);
 std::vector<unsigned int> getHitsFrompT3(LSTEvent* event, unsigned int pT3);
 std::vector<unsigned int> getHitIdxsFrompT3(LSTEvent* event, unsigned int pT3);
-std::vector<unsigned int> getHitTypesFrompT3(LSTEvent* event, unsigned int pT3);
+std::vector<lst::HitType> getHitTypesFrompT3(LSTEvent* event, unsigned int pT3);
 std::vector<unsigned int> getModuleIdxsFrompT3(LSTEvent* event, unsigned int pT3);
-std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHitTypesFrompT3(LSTEvent* event,
+std::tuple<std::vector<unsigned int>, std::vector<lst::HitType>> getHitIdxsAndHitTypesFrompT3(LSTEvent* event,
                                                                                               unsigned pT3);
 
 // ----* pT5 *----
-unsigned int getPixelLSFrompT5(LSTEvent* event, unsigned int pT5);
+unsigned int getpLSFrompT5(LSTEvent* event, unsigned int pT5);
 unsigned int getT5FrompT5(LSTEvent* event, unsigned int pT5);
 std::vector<unsigned int> getT3sFrompT5(LSTEvent* event, unsigned int pT5);
 std::vector<unsigned int> getLSsFrompT5(LSTEvent* event, unsigned int pT5);
 std::vector<unsigned int> getMDsFrompT5(LSTEvent* event, unsigned int pT5);
-std::vector<unsigned int> getOuterTrackerHitsFrompT5(LSTEvent* event, unsigned int pT5);
-std::vector<unsigned int> getPixelHitsFrompT5(LSTEvent* event, unsigned int pT5);
+std::vector<unsigned int> getT5HitsFrompT5(LSTEvent* event, unsigned int pT5);
+std::vector<unsigned int> getpLSHitsFrompT5(LSTEvent* event, unsigned int pT5);
 std::vector<unsigned int> getHitsFrompT5(LSTEvent* event, unsigned int pT5);
 std::vector<unsigned int> getHitIdxsFrompT5(LSTEvent* event, unsigned int pT5);
-std::vector<unsigned int> getHitTypesFrompT5(LSTEvent* event, unsigned int pT5);
+std::vector<lst::HitType> getHitTypesFrompT5(LSTEvent* event, unsigned int pT5);
 std::vector<unsigned int> getModuleIdxsFrompT5(LSTEvent* event, unsigned int pT5);
-std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHitTypesFrompT5(LSTEvent* event,
+std::tuple<std::vector<unsigned int>, std::vector<lst::HitType>> getHitIdxsAndHitTypesFrompT5(LSTEvent* event,
                                                                                               unsigned pT5);
 
 // ----* TC *----
 std::vector<unsigned int> getLSsFromTC(LSTEvent* event, unsigned int TC);
 std::vector<unsigned int> getHitsFromTC(LSTEvent* event, unsigned int TC);
-std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHitTypesFromTC(LSTEvent* event,
-                                                                                             unsigned int TC);
-std::pair<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndTypesFromTC(LSTEvent* event,
-                                                                                         unsigned int tc_idx);
+std::tuple<std::vector<unsigned int>, std::vector<lst::HitType>> getUnderlyingHitIdxsAndHitTypesFromTC(LSTEvent* event,
+                                                                                                       unsigned int TC);
+std::pair<std::vector<unsigned int>, std::vector<lst::HitType>> getHitIdxsAndHitTypesFromTC(LSTEvent* event,
+                                                                                            unsigned int tc_idx);
 
 #endif

--- a/RecoTracker/LSTCore/standalone/code/core/trkCore.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/trkCore.cc
@@ -1,4 +1,5 @@
 #include "trkCore.h"
+#include <tuple>
 
 //___________________________________________________________________________________________________________________________________________________________________________________________
 bool goodEvent() {
@@ -333,25 +334,23 @@ float runTrackCandidate(LSTEvent* event, bool no_pls_dupclean, bool tc_pls_tripl
 //  ---------------------------------- =========================================== ----------------------------------------------
 
 //___________________________________________________________________________________________________________________________________________________________________________________________
-std::vector<int> matchedSimTrkIdxs(std::vector<unsigned int> hitidxs,
-                                   std::vector<unsigned int> hittypes,
+std::vector<int> matchedSimTrkIdxs(std::vector<unsigned int> const& hitidxs,
+                                   std::vector<lst::HitType> const& hittypes,
                                    std::vector<int> const& trk_simhit_simTrkIdx,
                                    std::vector<std::vector<int>> const& trk_ph2_simHitIdx,
                                    std::vector<std::vector<int>> const& trk_pix_simHitIdx,
                                    bool verbose,
                                    float matchfrac,
                                    float* pmatched) {
-  std::vector<int> matched_idxs;
-  std::vector<float> matched_idx_fracs;
-  std::tie(matched_idxs, matched_idx_fracs) = matchedSimTrkIdxsAndFracs(
+  auto [matched_idxs, dummy] = matchedSimTrkIdxsAndFracs(
       hitidxs, hittypes, trk_simhit_simTrkIdx, trk_ph2_simHitIdx, trk_pix_simHitIdx, verbose, matchfrac, pmatched);
   return matched_idxs;
 }
 
 //___________________________________________________________________________________________________________________________________________________________________________________________
 std::tuple<std::vector<int>, std::vector<float>> matchedSimTrkIdxsAndFracs(
-    std::vector<unsigned int> hitidxs,
-    std::vector<unsigned int> hittypes,
+    std::vector<unsigned int> const& hitidxs,
+    std::vector<lst::HitType> const& hittypes,
     std::vector<int> const& trk_simhit_simTrkIdx,
     std::vector<std::vector<int>> const& trk_ph2_simHitIdx,
     std::vector<std::vector<int>> const& trk_pix_simHitIdx,
@@ -364,7 +363,7 @@ std::tuple<std::vector<int>, std::vector<float>> matchedSimTrkIdxsAndFracs(
     std::cout << "hittypes.size(): " << hittypes.size() << std::endl;
   }
 
-  std::vector<std::pair<unsigned int, unsigned int>> to_check_duplicate;
+  std::vector<std::pair<unsigned int, lst::HitType>> to_check_duplicate;
   for (size_t i = 0; i < hitidxs.size(); ++i) {
     auto hitidx = hitidxs[i];
     auto hittype = hittypes[i];
@@ -389,12 +388,13 @@ std::tuple<std::vector<int>, std::vector<float>> matchedSimTrkIdxsAndFracs(
     auto&& [hitidx, hittype] = ihitdata;
 
     if (verbose) {
-      std::cout << " hitidx: " << hitidx << " hittype: " << hittype << std::endl;
+      std::cout << " hitidx: " << hitidx << " hittype: " << static_cast<int>(hittype) << std::endl;
     }
 
     std::vector<int> simtrk_idxs_per_hit;
 
-    const std::vector<std::vector<int>>* simHitIdxs = hittype == 4 ? &trk_ph2_simHitIdx : &trk_pix_simHitIdx;
+    const std::vector<std::vector<int>>* simHitIdxs =
+        hittype == lst::HitType::Phase2OT ? &trk_ph2_simHitIdx : &trk_pix_simHitIdx;
 
     if (verbose) {
       std::cout << " trk_ph2_simHitIdx.size(): " << trk_ph2_simHitIdx.size() << std::endl;
@@ -403,17 +403,17 @@ std::tuple<std::vector<int>, std::vector<float>> matchedSimTrkIdxsAndFracs(
 
     if (static_cast<const unsigned int>((*simHitIdxs).size()) <= hitidx) {
       std::cout << "ERROR" << std::endl;
-      std::cout << " hittype: " << hittype << std::endl;
+      std::cout << " hittype: " << static_cast<int>(hittype) << std::endl;
       std::cout << " trk_pix_simHitIdx.size(): " << trk_pix_simHitIdx.size() << std::endl;
       std::cout << " trk_ph2_simHitIdx.size(): " << trk_ph2_simHitIdx.size() << std::endl;
-      std::cout << (*simHitIdxs).size() << " " << hittype << std::endl;
-      std::cout << hitidx << " " << hittype << std::endl;
+      std::cout << (*simHitIdxs).size() << " " << static_cast<int>(hittype) << std::endl;
+      std::cout << hitidx << " " << static_cast<int>(hittype) << std::endl;
     }
 
     for (auto& simhit_idx : (*simHitIdxs).at(hitidx)) {
       if (static_cast<const int>(trk_simhit_simTrkIdx.size()) <= simhit_idx) {
-        std::cout << (*simHitIdxs).size() << " " << hittype << std::endl;
-        std::cout << hitidx << " " << hittype << std::endl;
+        std::cout << (*simHitIdxs).size() << " " << static_cast<int>(hittype) << std::endl;
+        std::cout << hitidx << " " << static_cast<int>(hittype) << std::endl;
         std::cout << trk_simhit_simTrkIdx.size() << " " << simhit_idx << std::endl;
       }
       int simtrk_idx = trk_simhit_simTrkIdx[simhit_idx];
@@ -588,7 +588,7 @@ int getDenomSimTrkType(int isimtrk,
 }
 
 //__________________________________________________________________________________________
-int getDenomSimTrkType(std::vector<int> simidxs,
+int getDenomSimTrkType(std::vector<int> const& simidxs,
                        std::vector<int> const& trk_sim_q,
                        std::vector<float> const& trk_sim_pt,
                        std::vector<float> const& trk_sim_eta,

--- a/RecoTracker/LSTCore/standalone/code/core/trkCore.h
+++ b/RecoTracker/LSTCore/standalone/code/core/trkCore.h
@@ -33,8 +33,8 @@ float runpT3(LSTEvent* event);
 
 // --------------------- ======================== ---------------------
 
-std::vector<int> matchedSimTrkIdxs(std::vector<unsigned int> hitidxs,
-                                   std::vector<unsigned int> hittypes,
+std::vector<int> matchedSimTrkIdxs(std::vector<unsigned int> const& hitidxs,
+                                   std::vector<lst::HitType> const& hittypes,
                                    std::vector<int> const& trk_simhit_simTrkIdx,
                                    std::vector<std::vector<int>> const& trk_ph2_simHitIdx,
                                    std::vector<std::vector<int>> const& trk_pix_simHitIdx,
@@ -42,8 +42,8 @@ std::vector<int> matchedSimTrkIdxs(std::vector<unsigned int> hitidxs,
                                    float matchfrac = 0.75,
                                    float* pmatched = nullptr);
 std::tuple<std::vector<int>, std::vector<float>> matchedSimTrkIdxsAndFracs(
-    std::vector<unsigned int> hitidxs,
-    std::vector<unsigned int> hittypes,
+    std::vector<unsigned int> const& hitidxs,
+    std::vector<lst::HitType> const& hittypes,
     std::vector<int> const& trk_simhit_simTrkIdx,
     std::vector<std::vector<int>> const& trk_ph2_simHitIdx,
     std::vector<std::vector<int>> const& trk_pix_simHitIdx,
@@ -60,7 +60,7 @@ int getDenomSimTrkType(int isimtrk,
                        std::vector<float> const& trk_simvtx_x,
                        std::vector<float> const& trk_simvtx_y,
                        std::vector<float> const& trk_simvtx_z);
-int getDenomSimTrkType(std::vector<int> simidxs,
+int getDenomSimTrkType(std::vector<int> const& simidxs,
                        std::vector<int> const& trk_sim_q,
                        std::vector<float> const& trk_sim_pt,
                        std::vector<float> const& trk_sim_eta,

--- a/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
@@ -1802,9 +1802,10 @@ std::map<unsigned int, unsigned int> setPixelLineSegmentBranches(
     ana.tx->pushbackToBranch<int>("pLS_charge", pixelSeeds.charge()[ipLS]);
     ana.tx->pushbackToBranch<float>("pLS_deltaPhi", pixelSeeds.deltaPhi()[ipLS]);
     ana.tx->pushbackToBranch<int>("pLS_nhit", hit_idx.size());
-    for (size_t ihit = 0; ihit < trk_see_hitIdx[ipLS].size() && ihit < lst::Params_pLS::kHits; ++ihit) {
-      int hitidx = trk_see_hitIdx[ipLS][ihit];
-      bool isPixel = static_cast<HitType>(trk_see_hitType[ipLS][ihit]) == HitType::Pixel;
+    unsigned int seedIdx = pixelSeeds.seedIdx()[ipLS];
+    for (size_t ihit = 0; ihit < trk_see_hitIdx[seedIdx].size() && ihit < lst::Params_pLS::kHits; ++ihit) {
+      int hitidx = trk_see_hitIdx[seedIdx][ihit];
+      bool isPixel = static_cast<HitType>(trk_see_hitType[seedIdx][ihit]) == HitType::Pixel;
       auto const& x = isPixel ? trk_pix_x[hitidx] : trk_ph2_x[hitidx];
       auto const& y = isPixel ? trk_pix_y[hitidx] : trk_ph2_y[hitidx];
       auto const& z = isPixel ? trk_pix_z[hitidx] : trk_ph2_z[hitidx];
@@ -1812,7 +1813,7 @@ std::map<unsigned int, unsigned int> setPixelLineSegmentBranches(
       ana.tx->pushbackToBranch<float>(TString::Format("pLS_hit%zu_y", ihit), y);
       ana.tx->pushbackToBranch<float>(TString::Format("pLS_hit%zu_z", ihit), z);
     }
-    if (trk_see_hitIdx[ipLS].size() == 3) {
+    if (trk_see_hitIdx[seedIdx].size() == 3) {
       ana.tx->pushbackToBranch<float>("pLS_hit3_x", -999);
       ana.tx->pushbackToBranch<float>("pLS_hit3_y", -999);
       ana.tx->pushbackToBranch<float>("pLS_hit3_z", -999);

--- a/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
@@ -2,6 +2,7 @@
 #include "Circle.h"
 
 #include "write_lst_ntuple.h"
+#include <tuple>
 
 using namespace ALPAKA_ACCELERATOR_NAMESPACE::lst;
 
@@ -939,13 +940,10 @@ std::map<unsigned int, unsigned int> setMiniDoubletBranches(LSTEvent* event,
       md_idx_map[mdIdx] = md_idx;
 
       // Access the list of hits in the mini-doublets (there are only two in this case)
-      std::vector<unsigned int> hit_idx, hit_type;
-      std::tie(hit_idx, hit_type) = getHitIdxsAndHitTypesFromMD(event, mdIdx);
+      auto [hit_idx, hit_type] = getHitIdxsAndHitTypesFromMD(event, mdIdx);
 
       // And then compute matching between simtrack and the mini-doublets
-      std::vector<int> simidx;
-      std::vector<float> simidxfrac;
-      std::tie(simidx, simidxfrac) =
+      auto [simidx, simidxfrac] =
           matchedSimTrkIdxsAndFracs(hit_idx, hit_type, trk_simhit_simTrkIdx, trk_ph2_simHitIdx, trk_pix_simHitIdx);
 
       // Obtain the lower and upper hit information to compute some basic property of the mini-doublets
@@ -1122,13 +1120,10 @@ std::map<unsigned int, unsigned int> setLineSegmentBranches(LSTEvent* event,
       ls_idx_map[lsIdx] = ls_idx;
 
       // Access the list of hits in the objects (there are only two in this case)
-      std::vector<unsigned int> hit_idx, hit_type;
-      std::tie(hit_idx, hit_type) = getHitIdxsAndHitTypesFromLS(event, lsIdx);
+      auto [hit_idx, hit_type] = getHitIdxsAndHitTypesFromLS(event, lsIdx);
 
       // And then compute matching between simtrack and the objects
-      std::vector<int> simidx;
-      std::vector<float> simidxfrac;
-      std::tie(simidx, simidxfrac) =
+      auto [simidx, simidxfrac] =
           matchedSimTrkIdxsAndFracs(hit_idx, hit_type, trk_simhit_simTrkIdx, trk_ph2_simHitIdx, trk_pix_simHitIdx);
       std::vector<unsigned int> mdIdxs = getMDsFromLS(event, lsIdx);
 
@@ -1289,11 +1284,8 @@ std::map<unsigned int, unsigned int> setTripletBranches(LSTEvent* event,
     for (unsigned int iT3 = 0; iT3 < tripletOccupancies.nTriplets()[idx]; iT3++) {
       unsigned int t3Idx = ranges.tripletModuleIndices()[idx] + iT3;
       t3_idx_map[t3Idx] = t3_idx;
-      std::vector<unsigned int> hit_idx, hit_type;
-      std::tie(hit_idx, hit_type) = getHitIdxsAndHitTypesFromT3(event, t3Idx);
-      std::vector<int> simidx;
-      std::vector<float> simidxfrac;
-      std::tie(simidx, simidxfrac) =
+      auto [hit_idx, hit_type] = getHitIdxsAndHitTypesFromT3(event, t3Idx);
+      auto [simidx, simidxfrac] =
           matchedSimTrkIdxsAndFracs(hit_idx, hit_type, trk_simhit_simTrkIdx, trk_ph2_simHitIdx, trk_pix_simHitIdx);
       std::vector<unsigned int> lsIdxs = getLSsFromT3(event, t3Idx);
       if (ana.ls_branches) {
@@ -1419,19 +1411,16 @@ std::map<unsigned int, unsigned int> setQuadrupletBranches(LSTEvent* event,
     for (unsigned int iT4 = 0; iT4 < quadrupletOccupancies.nQuadruplets()[idx]; iT4++) {
       unsigned int t4Idx = ranges.quadrupletModuleIndices()[idx] + iT4;
       t4_idx_map[t4Idx] = t4_idx;
-      std::vector<unsigned int> hit_idx, hit_type;
-      std::tie(hit_idx, hit_type) = getHitIdxsAndHitTypesFromT4(event, t4Idx);
-      std::vector<int> simidx;
-      std::vector<float> simidxfrac;
+      auto [hit_idx, hit_type] = getHitIdxsAndHitTypesFromT4(event, t4Idx);
       float percent_matched;
-      std::tie(simidx, simidxfrac) = matchedSimTrkIdxsAndFracs(hit_idx,
-                                                               hit_type,
-                                                               trk_simhit_simTrkIdx,
-                                                               trk_ph2_simHitIdx,
-                                                               trk_pix_simHitIdx,
-                                                               false,
-                                                               matchfrac,
-                                                               &percent_matched);
+      auto [simidx, simidxfrac] = matchedSimTrkIdxsAndFracs(hit_idx,
+                                                            hit_type,
+                                                            trk_simhit_simTrkIdx,
+                                                            trk_ph2_simHitIdx,
+                                                            trk_pix_simHitIdx,
+                                                            false,
+                                                            matchfrac,
+                                                            &percent_matched);
       std::vector<unsigned int> t3Idxs = getT3sFromT4(event, t4Idx);
 
       float pt = __H2F(quadruplets.pt()[t4Idx]);
@@ -1588,19 +1577,16 @@ std::map<unsigned int, unsigned int> setQuintupletBranches(LSTEvent* event,
     for (unsigned int iT5 = 0; iT5 < quintupletOccupancies.nQuintuplets()[idx]; iT5++) {
       unsigned int t5Idx = ranges.quintupletModuleIndices()[idx] + iT5;
       t5_idx_map[t5Idx] = t5_idx;
-      std::vector<unsigned int> hit_idx, hit_type;
-      std::tie(hit_idx, hit_type) = getHitIdxsAndHitTypesFromT5(event, t5Idx);
-      std::vector<int> simidx;
-      std::vector<float> simidxfrac;
+      auto [hit_idx, hit_type] = getHitIdxsAndHitTypesFromT5(event, t5Idx);
       float percent_matched;
-      std::tie(simidx, simidxfrac) = matchedSimTrkIdxsAndFracs(hit_idx,
-                                                               hit_type,
-                                                               trk_simhit_simTrkIdx,
-                                                               trk_ph2_simHitIdx,
-                                                               trk_pix_simHitIdx,
-                                                               false,
-                                                               matchfrac,
-                                                               &percent_matched);
+      auto [simidx, simidxfrac] = matchedSimTrkIdxsAndFracs(hit_idx,
+                                                            hit_type,
+                                                            trk_simhit_simTrkIdx,
+                                                            trk_ph2_simHitIdx,
+                                                            trk_pix_simHitIdx,
+                                                            false,
+                                                            matchfrac,
+                                                            &percent_matched);
       std::vector<unsigned int> t3Idxs = getT3sFromT5(event, t5Idx);
       if (ana.t3_branches) {
         ana.tx->pushbackToBranch<int>("t5_t3Idx0", t3_idx_map.at(t3Idxs[0]));
@@ -1749,11 +1735,8 @@ std::map<unsigned int, unsigned int> setPixelLineSegmentBranches(LSTEvent* event
   for (unsigned int ipLS = 0; ipLS < n_pls; ipLS++) {
     unsigned int plsIdx = pls_range_start + ipLS;
     pls_idx_map[plsIdx] = pls_idx;
-    std::vector<unsigned int> hit_idx, hit_type;
-    std::tie(hit_idx, hit_type) = getHitIdxsAndHitTypesFrompLS(event, ipLS);
-    std::vector<int> simidx;
-    std::vector<float> simidxfrac;
-    std::tie(simidx, simidxfrac) =
+    auto [hit_idx, hit_type] = getHitIdxsAndHitTypesFrompLS(event, ipLS);
+    auto [simidx, simidxfrac] =
         matchedSimTrkIdxsAndFracs(hit_idx, hit_type, trk_simhit_simTrkIdx, trk_ph2_simHitIdx, trk_pix_simHitIdx);
     ana.tx->pushbackToBranch<float>("pLS_pt", pixelSeeds.ptIn()[ipLS]);
     ana.tx->pushbackToBranch<float>("pLS_ptErr", pixelSeeds.ptErr()[ipLS]);
@@ -1770,7 +1753,7 @@ std::map<unsigned int, unsigned int> setPixelLineSegmentBranches(LSTEvent* event
     ana.tx->pushbackToBranch<int>("pLS_charge", pixelSeeds.charge()[ipLS]);
     ana.tx->pushbackToBranch<float>("pLS_deltaPhi", pixelSeeds.deltaPhi()[ipLS]);
     ana.tx->pushbackToBranch<int>("pLS_nhit", hit_idx.size());
-    for (size_t ihit = 0; ihit < trk_see_hitIdx[ipLS].size(); ++ihit) {
+    for (size_t ihit = 0; ihit < trk_see_hitIdx[ipLS].size() && ihit < lst::Params_pLS::kHits; ++ihit) {
       int hitidx = trk_see_hitIdx[ipLS][ihit];
       int hittype = trk_see_hitType[ipLS][ihit];
       auto const& x = trk_pix_x[hitidx];
@@ -1886,14 +1869,11 @@ std::map<unsigned int, unsigned int> setPixelTripletBranches(LSTEvent* event,
   for (unsigned int ipT3 = 0; ipT3 < nPixelTriplets; ipT3++) {
     unsigned int pt3Idx = ipT3;
     pt3_idx_map[pt3Idx] = pt3_idx;
-    std::vector<unsigned int> hit_idx, hit_type;
-    std::tie(hit_idx, hit_type) = getHitIdxsAndHitTypesFrompT3(event, ipT3);
-    std::vector<int> simidx;
-    std::vector<float> simidxfrac;
-    std::tie(simidx, simidxfrac) =
+    auto [hit_idx, hit_type] = getHitIdxsAndHitTypesFrompT3(event, ipT3);
+    auto [simidx, simidxfrac] =
         matchedSimTrkIdxsAndFracs(hit_idx, hit_type, trk_simhit_simTrkIdx, trk_ph2_simHitIdx, trk_pix_simHitIdx);
     // // Computing line segment pt estimate (assuming beam spot is at zero)
-    unsigned int ipLS = getPixelLSFrompT3(event, ipT3);
+    unsigned int ipLS = getpLSFrompT3(event, ipT3);
     float pt = pixelSeeds.ptIn()[ipLS];
     float eta = pixelSeeds.eta()[ipLS];
     float phi = pixelSeeds.phi()[ipLS];
@@ -1959,13 +1939,13 @@ std::map<unsigned int, unsigned int> setPixelTripletBranches(LSTEvent* event,
     float eta_t3 = pixelTriplets.eta()[ipT3];
     float eta_pix = pixelTriplets.eta_pix()[ipT3];  // eta from pLS
 
-    unsigned int pLSIndex = getPixelLSFrompT3(event, ipT3);
+    unsigned int pLSIndex = getpLSFrompT3(event, ipT3);
     unsigned int T3Index = getT3FrompT3(event, ipT3);
 
-    std::vector<unsigned int> pls_hit_idx = getPixelHitIdxsFrompLS(event, pLSIndex);
-    std::vector<unsigned int> pls_hit_type = getPixelHitTypesFrompLS(event, pLSIndex);
-    std::vector<unsigned int> t3_hit_idx = getHitsFromT3(event, T3Index);
-    std::vector<unsigned int> t3_hit_type = getHitTypesFromT3(event, T3Index);
+    auto pls_hit_idx = getHitIdxsFrompLS(event, pLSIndex);
+    auto pls_hit_type = getHitTypesFrompLS(event, pLSIndex);
+    auto t3_hit_idx = getHitsFromT3(event, T3Index);
+    auto t3_hit_type = getHitTypesFromT3(event, T3Index);
 
     // The anchor hits of the T3 are at indices 0, 2, and 4
     unsigned int anchor_hit_1_full_idx = t3_hit_idx[0];
@@ -2095,15 +2075,12 @@ std::map<unsigned int, unsigned int> setPixelQuintupletBranches(LSTEvent* event,
   for (unsigned int ipT5 = 0; ipT5 < nPixelQuintuplets; ipT5++) {
     unsigned int pt5Idx = ipT5;
     pt5_idx_map[pt5Idx] = pt5_idx;
-    std::vector<unsigned int> hit_idx, hit_type;
-    std::tie(hit_idx, hit_type) = getHitIdxsAndHitTypesFrompT5(event, ipT5);
-    std::vector<int> simidx;
-    std::vector<float> simidxfrac;
-    std::tie(simidx, simidxfrac) =
+    auto [hit_idx, hit_type] = getHitIdxsAndHitTypesFrompT5(event, ipT5);
+    auto [simidx, simidxfrac] =
         matchedSimTrkIdxsAndFracs(hit_idx, hit_type, trk_simhit_simTrkIdx, trk_ph2_simHitIdx, trk_pix_simHitIdx);
     // // Computing line segment pt estimate (assuming beam spot is at zero)
     unsigned int T5Index = getT5FrompT5(event, ipT5);
-    unsigned int ipLS = getPixelLSFrompT5(event, ipT5);
+    unsigned int ipLS = getpLSFrompT5(event, ipT5);
     float pt = (__H2F(quintuplets.innerRadius()[T5Index]) * k2Rinv1GeVf * 2 + pixelSeeds.ptIn()[ipLS]) / 2;
     float eta = pixelSeeds.eta()[ipLS];
     float phi = pixelSeeds.phi()[ipLS];
@@ -2236,23 +2213,18 @@ void setTrackCandidateBranches(LSTEvent* event,
   // Looping over each track candidate
   for (unsigned int tc_idx = 0; tc_idx < nTrackCandidates; tc_idx++) {
     // Compute reco quantities of track candidate based on final object
-    int type, isFake;
-    float pt, eta, phi;
-    std::vector<int> simidx;        // list of all the matched sim idx
-    std::vector<float> simidxfrac;  // list of match fraction for each matched sim idx
-
     // The following function reads off and computes the matched sim track indices
     float percent_matched;
-    std::tie(type, pt, eta, phi, isFake, simidx, simidxfrac) = parseTrackCandidateAllMatch(event,
-                                                                                           tc_idx,
-                                                                                           trk_ph2_x,
-                                                                                           trk_ph2_y,
-                                                                                           trk_ph2_z,
-                                                                                           trk_simhit_simTrkIdx,
-                                                                                           trk_ph2_simHitIdx,
-                                                                                           trk_pix_simHitIdx,
-                                                                                           percent_matched,
-                                                                                           matchfrac);
+    auto [type, pt, eta, phi, isFake, simidx, simidxfrac] = parseTrackCandidateAllMatch(event,
+                                                                                        tc_idx,
+                                                                                        trk_ph2_x,
+                                                                                        trk_ph2_y,
+                                                                                        trk_ph2_z,
+                                                                                        trk_simhit_simTrkIdx,
+                                                                                        trk_ph2_simHitIdx,
+                                                                                        trk_pix_simHitIdx,
+                                                                                        percent_matched,
+                                                                                        matchfrac);
 
     int nPixHits = 0, nOtHits = 0, nLayers = 0;
     for (int layerSlot = 0; layerSlot < Params_TC::kLayers; ++layerSlot) {
@@ -2529,7 +2501,7 @@ void fillT3DNNBranches(LSTEvent* event, unsigned int iT3) {
   auto const& hitsExtended = event->getHits<HitsExtendedSoA>();
   auto const& modules = event->getModules<ModulesSoA>();
 
-  std::vector<unsigned int> hitIdx = getHitsFromT3(event, iT3);
+  auto hitIdx = getHitsFromT3(event, iT3);
   std::vector<lst_math::Hit> hitObjects;
 
   for (int i = 0; i < hitIdx.size(); ++i) {
@@ -2566,7 +2538,7 @@ void fillT5DNNBranches(LSTEvent* event, unsigned int iT3) {
   auto hitsExtended = event->getHits<HitsExtendedSoA>();
   auto modules = event->getModules<ModulesSoA>();
 
-  std::vector<unsigned int> hitIdx = getHitsFromT3(event, iT3);
+  auto hitIdx = getHitsFromT3(event, iT3);
   std::vector<lst_math::Hit> hitObjects(hitIdx.size());
 
   auto const& trk_ph2_subdet = trk.getVUS("ph2_subdet");
@@ -2670,9 +2642,9 @@ void setT3DNNBranches(LSTEvent* event, float matchfrac) {
       unsigned int tripletIndex = ranges.tripletModuleIndices()[lowerModuleIdx] + idx;
 
       // Get hit indices and types
-      std::vector<unsigned int> hit_idx = getHitsFromT3(event, tripletIndex);
-      std::vector<unsigned int> hit_type = getHitTypesFromT3(event, tripletIndex);
-      std::vector<unsigned int> module_idx = getModuleIdxsFromT3(event, tripletIndex);
+      auto hit_idx = getHitsFromT3(event, tripletIndex);
+      auto hit_type = getHitTypesFromT3(event, tripletIndex);
+      auto module_idx = getModuleIdxsFromT3(event, tripletIndex);
 
       // Calculate layer binary representation
       int layer_binary = 0;
@@ -2765,7 +2737,7 @@ void setT5DNNBranches(LSTEvent* event) {
   for (unsigned int idx = 0; idx < modules.nLowerModules(); ++idx) {
     for (unsigned int jdx = 0; jdx < quintuplets.nQuintuplets()[idx]; ++jdx) {
       unsigned int t5Idx = ranges.quintupletModuleIndices()[idx] + jdx;
-      std::vector<unsigned int> t3sIdx = getT3sFromT5(event, t5Idx);
+      auto t3sIdx = getT3sFromT5(event, t5Idx);
 
       ana.tx->pushbackToBranch<int>("t5_t3_idx0", t3_index_map[t3sIdx[0]]);
       ana.tx->pushbackToBranch<int>("t5_t3_idx1", t3_index_map[t3sIdx[1]]);
@@ -2871,7 +2843,8 @@ std::tuple<int, float, float, float, int, std::vector<int>> parseTrackCandidate(
 
   // Compute pt eta phi and hit indices that will be used to figure out whether the TC matched
   float pt, eta, phi;
-  std::vector<unsigned int> hit_idx, hit_type;
+  std::vector<unsigned int> hit_idx;
+  std::vector<HitType> hit_type;
   switch (type) {
     case LSTObjType::pT5:
       std::tie(pt, eta, phi, hit_idx, hit_type) = parsepT5(event, idx);
@@ -2891,7 +2864,7 @@ std::tuple<int, float, float, float, int, std::vector<int>> parseTrackCandidate(
   }
 
   if (type == LSTObjType::T5 || type == LSTObjType::pT5) {
-    std::tie(hit_idx, hit_type) = getHitIdxsAndTypesFromTC(event, idx);
+    std::tie(hit_idx, hit_type) = getHitIdxsAndHitTypesFromTC(event, idx);
   }
 
   // Perform matching
@@ -2920,7 +2893,8 @@ std::tuple<int, float, float, float, int, std::vector<int>, std::vector<float>> 
 
   // Compute pt eta phi and hit indices that will be used to figure out whether the TC matched
   float pt, eta, phi;
-  std::vector<unsigned int> hit_idx, hit_type;
+  std::vector<unsigned int> hit_idx;
+  std::vector<HitType> hit_type;
   switch (type) {
     case LSTObjType::pT5:
       std::tie(pt, eta, phi, hit_idx, hit_type) = parsepT5(event, idx);
@@ -2940,13 +2914,11 @@ std::tuple<int, float, float, float, int, std::vector<int>, std::vector<float>> 
   }
 
   if (type == LSTObjType::T5 || type == LSTObjType::pT5) {
-    std::tie(hit_idx, hit_type) = getHitIdxsAndTypesFromTC(event, idx);
+    std::tie(hit_idx, hit_type) = getHitIdxsAndHitTypesFromTC(event, idx);
   }
 
   // Perform matching
-  std::vector<int> simidx;
-  std::vector<float> simidxfrac;
-  std::tie(simidx, simidxfrac) = matchedSimTrkIdxsAndFracs(
+  auto [simidx, simidxfrac] = matchedSimTrkIdxsAndFracs(
       hit_idx, hit_type, trk_simhit_simTrkIdx, trk_ph2_simHitIdx, trk_pix_simHitIdx, false, matchfrac, &percent_matched);
   int isFake = simidx.size() == 0;
 
@@ -2954,8 +2926,8 @@ std::tuple<int, float, float, float, int, std::vector<int>, std::vector<float>> 
 }
 
 //________________________________________________________________________________________________________________________________
-std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned int>> parsepT5(LSTEvent* event,
-                                                                                               unsigned int idx) {
+std::tuple<float, float, float, std::vector<unsigned int>, std::vector<HitType>> parsepT5(LSTEvent* event,
+                                                                                          unsigned int idx) {
   // Get relevant information
   auto const trackCandidatesExtended = event->getTrackCandidatesExtended();
   auto const quintuplets = event->getQuintuplets<QuintupletsSoA>();
@@ -2971,7 +2943,7 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
   //                oo -- oo -- oo               first T3 of the T5
   //                            oo -- oo -- oo   second T3 of the T5
   unsigned int pT5 = trackCandidatesExtended.directObjectIndices()[idx];
-  unsigned int pLS = getPixelLSFrompT5(event, pT5);
+  unsigned int pLS = getpLSFrompT5(event, pT5);
   unsigned int T5Index = getT5FrompT5(event, pT5);
 
   //=================================================================================
@@ -3059,15 +3031,15 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
   const float pt = (pt_T5 + pt_pLS) / 2;
 
   // Form the hit idx/type std::vector
-  std::vector<unsigned int> hit_idx = getHitIdxsFrompT5(event, pT5);
-  std::vector<unsigned int> hit_type = getHitTypesFrompT5(event, pT5);
+  auto hit_idx = getHitIdxsFrompT5(event, pT5);
+  auto hit_type = getHitTypesFrompT5(event, pT5);
 
   return {pt, eta_pLS, phi_pLS, hit_idx, hit_type};
 }
 
 //________________________________________________________________________________________________________________________________
-std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned int>> parsepT3(LSTEvent* event,
-                                                                                               unsigned int idx) {
+std::tuple<float, float, float, std::vector<unsigned int>, std::vector<HitType>> parsepT3(LSTEvent* event,
+                                                                                          unsigned int idx) {
   // Get relevant information
   auto const trackCandidatesExtended = event->getTrackCandidatesExtended();
   auto const triplets = event->getTriplets<TripletsSoA>();
@@ -3081,7 +3053,7 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
   // pLS            01    23    45               (anchor hit of a minidoublet is always the first of the pair)
   // ****           oo -- oo -- oo               pT3
   unsigned int pT3 = trackCandidatesExtended.directObjectIndices()[idx];
-  unsigned int pLS = getPixelLSFrompT3(event, pT3);
+  unsigned int pLS = getpLSFrompT3(event, pT3);
   unsigned int T3 = getT3FrompT3(event, pT3);
 
   // pixel pt
@@ -3094,14 +3066,14 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
   const float pt = (pt_pLS + pt_T3) / 2;
 
   // Form the hit idx/type std::vector
-  std::vector<unsigned int> hit_idx = getHitIdxsFrompT3(event, pT3);
-  std::vector<unsigned int> hit_type = getHitTypesFrompT3(event, pT3);
+  auto hit_idx = getHitIdxsFrompT3(event, pT3);
+  auto hit_type = getHitTypesFrompT3(event, pT3);
 
   return {pt, eta_pLS, phi_pLS, hit_idx, hit_type};
 }
 
 //________________________________________________________________________________________________________________________________
-std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned int>> parseT5(
+std::tuple<float, float, float, std::vector<unsigned int>, std::vector<HitType>> parseT5(
     LSTEvent* event,
     unsigned int idx,
     std::vector<float> const& trk_ph2_x,
@@ -3110,7 +3082,7 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
   auto const trackCandidatesExtended = event->getTrackCandidatesExtended();
   auto const quintuplets = event->getQuintuplets<QuintupletsSoA>();
   unsigned int T5 = trackCandidatesExtended.directObjectIndices()[idx];
-  std::vector<unsigned int> hits = getHitsFromT5(event, T5);
+  auto hits = getHitsFromT5(event, T5);
 
   //
   // pictorial representation of a T5
@@ -3132,14 +3104,14 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
   const float phi = hitA.phi();
   const float eta = hitB.eta();
 
-  std::vector<unsigned int> hit_idx = getHitIdxsFromT5(event, T5);
-  std::vector<unsigned int> hit_type = getHitTypesFromT5(event, T5);
+  auto hit_idx = getHitIdxsFromT5(event, T5);
+  auto hit_type = getHitTypesFromT5(event, T5);
 
   return {pt, eta, phi, hit_idx, hit_type};
 }
 
 //________________________________________________________________________________________________________________________________
-std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned int>> parseT4(
+std::tuple<float, float, float, std::vector<unsigned int>, std::vector<HitType>> parseT4(
     LSTEvent* event,
     unsigned int idx,
     std::vector<float> const& trk_ph2_x,
@@ -3170,15 +3142,15 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
   const float phi = hitA.phi();
   const float eta = hitB.eta();
 
-  std::vector<unsigned int> hit_idx = getHitIdxsFromT4(event, t4);
-  std::vector<unsigned int> hit_type = getHitTypesFromT4(event, t4);
+  auto hit_idx = getHitIdxsFromT4(event, t4);
+  auto hit_type = getHitTypesFromT4(event, t4);
 
   return {pt, eta, phi, hit_idx, hit_type};
 }
 
 //________________________________________________________________________________________________________________________________
-std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned int>> parsepLS(LSTEvent* event,
-                                                                                               unsigned int idx) {
+std::tuple<float, float, float, std::vector<unsigned int>, std::vector<HitType>> parsepLS(LSTEvent* event,
+                                                                                          unsigned int idx) {
   auto const& trackCandidatesExtended = event->getTrackCandidatesExtended();
   auto pixelSeeds = event->getInput<PixelSeedsSoA>();
 
@@ -3191,8 +3163,8 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
   float phi = pixelSeeds.phi()[pLS];
 
   // Getting hit indices and types
-  std::vector<unsigned int> hit_idx = getPixelHitIdxsFrompLS(event, pLS);
-  std::vector<unsigned int> hit_type = getPixelHitTypesFrompLS(event, pLS);
+  auto hit_idx = getHitIdxsFrompLS(event, pLS);
+  auto hit_type = getHitTypesFrompLS(event, pLS);
 
   return {pt, eta, phi, hit_idx, hit_type};
 }

--- a/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
@@ -354,6 +354,9 @@ void createMiniDoubletBranches() {
   //
   //  The container will hold per entry a mini-doublet built by LST in the event.
   //
+#ifdef CUT_VALUE_DEBUG
+  ana.tx->createBranch<std::vector<int>>("md_rawIdx");  // raw index in the SoA
+#endif
   ana.tx->createBranch<std::vector<bool>>("md_isPLS");
   ana.tx->createBranch<std::vector<float>>("md_pt");   // pt (computed based on delta phi change)
   ana.tx->createBranch<std::vector<float>>("md_eta");  // eta (computed based on anchor hit's eta)
@@ -389,6 +392,9 @@ void createLineSegmentBranches() {
   //
   //  The container will hold per entry a line-segment built by LST in the event.
   //
+#ifdef CUT_VALUE_DEBUG
+  ana.tx->createBranch<std::vector<int>>("ls_rawIdx");  // raw index in the SoA
+#endif
   ana.tx->createBranch<std::vector<bool>>("ls_isPLS");
   // pt (computed based on radius of the circle formed by three points: (origin), (anchor hit 1), (anchor hit 2))
   ana.tx->createBranch<std::vector<float>>("ls_pt");
@@ -425,6 +431,9 @@ void createTripletBranches() {
   //
   //  The container will hold per entry a triplets built by LST in the event.
   //
+#ifdef CUT_VALUE_DEBUG
+  ana.tx->createBranch<std::vector<int>>("t3_rawIdx");  // raw index in the SoA
+#endif
   // pt (computed based on radius of the circle formed by three points: anchor hit 1, 2, 3
   ana.tx->createBranch<std::vector<float>>("t3_pt");
   ana.tx->createBranch<std::vector<float>>("t3_eta");        // eta (computed based on last anchor hit's eta)
@@ -484,6 +493,9 @@ void createQuintupletBranches() {
   //
   //  The container will hold per entry a quintuplet built by LST in the event.
   //
+#ifdef CUT_VALUE_DEBUG
+  ana.tx->createBranch<std::vector<int>>("t5_rawIdx");  // raw index in the SoA
+#endif
   // pt (computed based on average of the 4 circles formed by, (1, 2, 3), (2, 3, 4), (3, 4, 5), (1, 3, 5)
   ana.tx->createBranch<std::vector<std::vector<float>>>("t5_embed");
   ana.tx->createBranch<std::vector<float>>("t5_dnnScore");
@@ -513,6 +525,9 @@ void createPixelLineSegmentBranches() {
   //
   //  The container will hold per entry a pixel line segment (built by an external algo, e.g. patatrack) accepted by LST in the event.
   //
+#ifdef CUT_VALUE_DEBUG
+  ana.tx->createBranch<std::vector<int>>("pLS_rawIdx");  // raw index in the SoA
+#endif
   ana.tx->createBranch<std::vector<int>>("pLS_lsIdx");  // LS-format part
   // pt (taken from pt of the 3-vector from see_stateTrajGlbPx/Py/Pz)
   ana.tx->createBranch<std::vector<float>>("pLS_pt");
@@ -559,6 +574,9 @@ void createPixelTripletBranches() {
   //
   //  The container will hold per entry a pT3 built by LST in the event.
   //
+#ifdef CUT_VALUE_DEBUG
+  ana.tx->createBranch<std::vector<int>>("pT3_rawIdx");  // raw index in the SoA
+#endif
   ana.tx->createBranch<std::vector<int>>("sim_pT3_matched");
   ana.tx->createBranch<std::vector<float>>("pT3_score");
   ana.tx->createBranch<std::vector<float>>("pT3_pt");         // pt (taken from the pLS)
@@ -597,6 +615,9 @@ void createPixelQuintupletBranches() {
   //
   //  The container will hold per entry a pT5 built by LST in the event.
   //
+#ifdef CUT_VALUE_DEBUG
+  ana.tx->createBranch<std::vector<int>>("pT5_rawIdx");  // raw index in the SoA
+#endif
   ana.tx->createBranch<std::vector<float>>("pT5_pt");         // pt (taken from the pLS)
   ana.tx->createBranch<std::vector<float>>("pT5_eta");        // eta (taken from the pLS)
   ana.tx->createBranch<std::vector<float>>("pT5_phi");        // phi (taken from the pLS)
@@ -986,6 +1007,9 @@ std::map<unsigned int, unsigned int> setMiniDoubletBranches(LSTEvent* event,
       int isPS = isPLS ? 0 : (is_endcap ? (layer <= 2 ? ring <= 10 : ring <= 7) : layer <= 3);
 
       // Write out the ntuple
+#ifdef CUT_VALUE_DEBUG
+      ana.tx->pushbackToBranch<int>("md_rawIdx", mdIdx);
+#endif
       ana.tx->pushbackToBranch<bool>("md_isPLS", isPLS);
       ana.tx->pushbackToBranch<float>("md_pt", pt);
       ana.tx->pushbackToBranch<float>("md_eta", eta);
@@ -1160,6 +1184,9 @@ std::map<unsigned int, unsigned int> setLineSegmentBranches(LSTEvent* event,
 #endif
 
       // Write out the ntuple
+#ifdef CUT_VALUE_DEBUG
+      ana.tx->pushbackToBranch<int>("ls_rawIdx", lsIdx);
+#endif
       ana.tx->pushbackToBranch<bool>("ls_isPLS", isPLS);
       ana.tx->pushbackToBranch<float>("ls_pt", pt);
       ana.tx->pushbackToBranch<float>("ls_eta", eta);
@@ -1290,6 +1317,9 @@ std::map<unsigned int, unsigned int> setTripletBranches(LSTEvent* event,
   for (unsigned int idx = 0; idx < nRanges; ++idx) {
     for (unsigned int iT3 = 0; iT3 < tripletOccupancies.nTriplets()[idx]; iT3++) {
       unsigned int t3Idx = ranges.tripletModuleIndices()[idx] + iT3;
+#ifdef CUT_VALUE_DEBUG
+      ana.tx->pushbackToBranch<int>("t3_rawIdx", t3Idx);
+#endif
       t3_idx_map[t3Idx] = t3_idx;
       auto [hit_idx, hit_type] = getHitIdxsAndHitTypesFromT3(event, t3Idx);
       auto [simidx, simidxfrac] =
@@ -1582,6 +1612,9 @@ std::map<unsigned int, unsigned int> setQuintupletBranches(LSTEvent* event,
   for (unsigned int idx = 0; idx < nRanges; ++idx) {
     for (unsigned int iT5 = 0; iT5 < quintupletOccupancies.nQuintuplets()[idx]; iT5++) {
       unsigned int t5Idx = ranges.quintupletModuleIndices()[idx] + iT5;
+#ifdef CUT_VALUE_DEBUG
+      ana.tx->pushbackToBranch<int>("t5_rawIdx", t5Idx);
+#endif
       t5_idx_map[t5Idx] = t5_idx;
       auto [hit_idx, hit_type] = getHitIdxsAndHitTypesFromT5(event, t5Idx);
       float percent_matched;
@@ -1744,6 +1777,9 @@ std::map<unsigned int, unsigned int> setPixelLineSegmentBranches(
   unsigned int n_pls = segmentsOccupancy.nSegments()[pixelModule];
   unsigned int pls_range_start = ranges.segmentModuleIndices()[pixelModule];
   for (unsigned int ipLS = 0; ipLS < n_pls; ipLS++) {
+#ifdef CUT_VALUE_DEBUG
+    ana.tx->pushbackToBranch<int>("pLS_rawIdx", ipLS);
+#endif
     unsigned int plsIdx = pls_range_start + ipLS;
     pls_idx_map[plsIdx] = pls_idx;
     auto [hit_idx, hit_type] = getHitIdxsAndHitTypesFrompLS(event, ipLS);
@@ -1881,6 +1917,9 @@ std::map<unsigned int, unsigned int> setPixelTripletBranches(LSTEvent* event,
   unsigned int nPixelTriplets = pixelTriplets.nPixelTriplets();
   for (unsigned int ipT3 = 0; ipT3 < nPixelTriplets; ipT3++) {
     unsigned int pt3Idx = ipT3;
+#ifdef CUT_VALUE_DEBUG
+    ana.tx->pushbackToBranch<int>("pT3_rawIdx", ipT3);
+#endif
     pt3_idx_map[pt3Idx] = pt3_idx;
     auto [hit_idx, hit_type] = getHitIdxsAndHitTypesFrompT3(event, ipT3);
     auto [simidx, simidxfrac] =
@@ -2087,6 +2126,9 @@ std::map<unsigned int, unsigned int> setPixelQuintupletBranches(LSTEvent* event,
   unsigned int nPixelQuintuplets = pixelQuintuplets.nPixelQuintuplets();
   for (unsigned int ipT5 = 0; ipT5 < nPixelQuintuplets; ipT5++) {
     unsigned int pt5Idx = ipT5;
+#ifdef CUT_VALUE_DEBUG
+    ana.tx->pushbackToBranch<int>("pT5_rawIdx", ipT5);
+#endif
     pt5_idx_map[pt5Idx] = pt5_idx;
     auto [hit_idx, hit_type] = getHitIdxsAndHitTypesFrompT5(event, ipT5);
     auto [simidx, simidxfrac] =

--- a/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.h
+++ b/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.h
@@ -104,23 +104,23 @@ std::tuple<int, float, float, float, int, std::vector<int>, std::vector<float>> 
     std::vector<std::vector<int>> const& trk_pix_simHitIdx,
     float& percent_matched,
     float matchfrac = 0.75);
-std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned int>> parsepT5(LSTEvent* event,
+std::tuple<float, float, float, std::vector<unsigned int>, std::vector<lst::HitType>> parsepT5(LSTEvent* event,
                                                                                                unsigned int);
-std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned int>> parsepT3(LSTEvent* event,
+std::tuple<float, float, float, std::vector<unsigned int>, std::vector<lst::HitType>> parsepT3(LSTEvent* event,
                                                                                                unsigned int);
-std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned int>> parseT5(
+std::tuple<float, float, float, std::vector<unsigned int>, std::vector<lst::HitType>> parseT5(
     LSTEvent* event,
     unsigned int,
     std::vector<float> const& trk_ph2_x,
     std::vector<float> const& trk_ph2_y,
     std::vector<float> const& trk_ph2_z);
-std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned int>> parseT4(
+std::tuple<float, float, float, std::vector<unsigned int>, std::vector<lst::HitType>> parseT4(
     LSTEvent* event,
     unsigned int,
     std::vector<float> const& trk_ph2_x,
     std::vector<float> const& trk_ph2_y,
     std::vector<float> const& trk_ph2_z);
-std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned int>> parsepLS(LSTEvent* event,
+std::tuple<float, float, float, std::vector<unsigned int>, std::vector<lst::HitType>> parsepLS(LSTEvent* event,
                                                                                                unsigned int);
 
 // Print multiplicities

--- a/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.h
+++ b/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.h
@@ -64,7 +64,8 @@ std::map<unsigned int, unsigned int> setQuintupletBranches(LSTEvent* event,
                                                            std::map<unsigned int, unsigned int> const& t3_idx_map);
 std::map<unsigned int, unsigned int> setPixelLineSegmentBranches(LSTEvent* event,
                                                                  unsigned int n_accepted_simtrk,
-                                                                 float matchfrac);
+                                                                 float matchfrac,
+                                                                 std::map<unsigned int, unsigned int> const& ls_idx_map);
 std::map<unsigned int, unsigned int> setPixelTripletBranches(LSTEvent* event,
                                                              unsigned int n_accepted_simtrk,
                                                              float matchfrac,


### PR DESCRIPTION
Hit provenance updates
- add hitType for pLS (pixel track/seed) hits to distinguish IT from OT
- fill the (pLS) hit-on-track part of the hits SoA with the first (4 or 3 a before) but now distinguishing types and appropriate index back to the OT hits in the SoA if the pLS hit is OT
- introduce/use `lst::HitType` in the code including the validation parts
- in LSTOD (standalone LST ntuple): 
    - add `_rawIdx` branches (for `CUT_VALUE_DEBUG` to more easily find an index of objects for debugging)
    - add `_isPLS` branches for MD and LS to disambiguate cases that came from pLS
    - fill `pLS_hit%zu_[xyz]` branches with IT or OT hits as appropriate
        - additionally, a bugfix in the use of the index to the pixel/seed track in the tracking ntuple, which differs from the internal LST index

later PR(s) are expected to resolve the inefficiency in the selections arising from fully including the OT hits (these are currently bypassed with `hltInitialStepSeeds.removeOTRechits = True`). A mostly technical commit improving the naming of variables in the `PixelTriplet.h` file is also included in this PR.