### PR TITLE
Implement saturation flag in pixel cluster

### DIFF
--- a/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
+++ b/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
@@ -92,7 +92,8 @@ public:
                  uint16_t const* ypos,
                  uint16_t xmin,
                  uint16_t ymin,
-                 uint16_t id = invalidClusterId)
+                 uint16_t id = invalidClusterId,
+                 bool isSaturated = false)
       : thePixelOffset(2 * isize), thePixelADC(adcs, adcs + isize), theOriginalClusterId(id) {
     uint16_t maxCol = 0;
     uint16_t maxRow = 0;
@@ -108,6 +109,7 @@ public:
     }
     packRow(xmin, maxRow);
     packCol(ymin, maxCol);
+    isClusterSaturated = isSaturated;
   }
 
   // obsolete (only for regression tests)
@@ -205,6 +207,7 @@ public:
   // the original id (they get sorted)
   auto originalId() const { return theOriginalClusterId; }
   void setOriginalId(uint16_t id) { theOriginalClusterId = id; }
+  bool isSaturated() const { return isClusterSaturated; }
 
 private:
   std::vector<uint8_t> thePixelOffset;
@@ -216,6 +219,7 @@ private:
   uint8_t thePixelColSpan = 0;       // Span pixel index in the y direction (left edge).
 
   uint16_t theOriginalClusterId = invalidClusterId;
+  bool isClusterSaturated = false;
 
   float err_x = -99999.9f;
   float err_y = -99999.9f;

--- a/DataFormats/SiPixelCluster/src/classes_def.xml
+++ b/DataFormats/SiPixelCluster/src/classes_def.xml
@@ -1,9 +1,10 @@
 <lcgdict>
-  <class name="SiPixelCluster" ClassVersion="13">
+  <class name="SiPixelCluster" ClassVersion="14">
    <version ClassVersion="10" checksum="2468063768"/>
    <version ClassVersion="11" checksum="1473312403"/>
    <version ClassVersion="12" checksum="2042538185"/>
    <version ClassVersion="13" checksum="2314992115"/>
+   <version ClassVersion="14" checksum="274013346"/>
    <field name="theOriginalClusterId" transient="true"/>
    <field name="err_x" transient="true"/>
    <field name="err_y" transient="true"/>

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisSoA.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisSoA.h
@@ -10,7 +10,8 @@ GENERATE_SOA_LAYOUT(SiPixelDigisLayout,
                     SOA_COLUMN(uint16_t, adc),
                     SOA_COLUMN(uint16_t, xx),
                     SOA_COLUMN(uint16_t, yy),
-                    SOA_COLUMN(uint16_t, moduleId))
+                    SOA_COLUMN(uint16_t, moduleId),
+                    SOA_COLUMN(uint8_t, rawADC))
 
 using SiPixelDigisSoA = SiPixelDigisLayout<>;
 using SiPixelDigisSoAView = SiPixelDigisSoA::View;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelClusterizerBase.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelClusterizerBase.h
@@ -29,6 +29,7 @@ public:
     uint16_t ymin = 16000;
     unsigned int isize = 0;
     int charge = 0;
+    bool isSaturated = false;
 
     // stack interface (unsafe ok for use below)
     unsigned int curr = 0;
@@ -42,9 +43,10 @@ public:
       isize = 0;
       charge = 0;
       curr = 0;
+      isSaturated = false;
     }
 
-    bool add(SiPixelCluster::PixelPos const& p, uint16_t const iadc) {
+    bool add(SiPixelCluster::PixelPos const& p, uint16_t const iadc, uint8_t const rawADC) {
       if (isize == MAXSIZE)
         return false;
       xmin = std::min<uint16_t>(xmin, p.row());
@@ -53,6 +55,7 @@ public:
       x[isize] = p.row();
       y[isize++] = p.col();
       charge += iadc;
+      isSaturated |= (rawADC == std::numeric_limits<uint8_t>::max());
       return true;
     }
   };

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -134,7 +134,8 @@ bool PixelThresholdClusterizer::setup(const PixelGeomDetUnit* pixDet) {
 //----------------------------------------------------------------------------
 void PixelThresholdClusterizer::clear_buffer(DigiIterator begin, DigiIterator end) {
   for (DigiIterator di = begin; di != end; ++di) {
-    theBuffer.set_adc(di->row(), di->column(), 0);  // reset pixel adc to 0
+    theBuffer.set_adc(di->row(), di->column(), 0);     // reset pixel adc to 0
+    theBuffer.set_rawADC(di->row(), di->column(), 0);  // reset pixel raw ADC to 0
   }
 }
 
@@ -143,7 +144,8 @@ void PixelThresholdClusterizer::clear_buffer(ClusterIterator begin, ClusterItera
     for (int i = 0; i < ci->size(); ++i) {
       const SiPixelCluster::Pixel pixel = ci->pixel(i);
 
-      theBuffer.set_adc(pixel.x, pixel.y, 0);  // reset pixel adc to 0
+      theBuffer.set_adc(pixel.x, pixel.y, 0);     // reset pixel adc to 0
+      theBuffer.set_rawADC(pixel.x, pixel.y, 0);  // reset pixel raw ADC to 0
     }
   }
 }
@@ -235,6 +237,7 @@ void PixelThresholdClusterizer::copy_to_buffer(DigiIterator begin, DigiIterator 
       case 1:
         if (adc >= thePixelThreshold) {
           theBuffer.set_adc(row, col, adc);
+          theBuffer.set_rawADC(row, col, di->adc());
           // VV: add pixel to the fake list. Only when running on digi collection
           if (di->flag() != 0)
             theFakePixels[row * theNumOfCols + col] = true;
@@ -246,6 +249,7 @@ void PixelThresholdClusterizer::copy_to_buffer(DigiIterator begin, DigiIterator 
       // the 2nd occurrence (duplicate pixel: reset the buffer to 0 and remove from the list of seed pixels)
       case 2:
         theBuffer.set_adc(row, col, 0);
+        theBuffer.set_rawADC(row, col, 0);
         auto last = std::remove(theSeeds.begin(), theSeeds.end(), SiPixelCluster::PixelPos(row, col));
         theSeeds.erase(last, theSeeds.end());
         break;
@@ -386,13 +390,14 @@ SiPixelCluster PixelThresholdClusterizer::make_cluster(const SiPixelCluster::Pix
   //       as it is later stored as uint16_t in SiPixelCluster and PixelClusterizerBase/AccretionCluster
   //       (reminder: ADC values here may be expressed in number of electrons)
   seed_adc = std::min(theBuffer(pix.row(), pix.col()), int(std::numeric_limits<uint16_t>::max()));
+  auto const seed_rawADC = theBuffer.rawADC(pix.row(), pix.col());
   theBuffer.set_adc(pix, 1);
   //  }
 
   AccretionCluster acluster, cldata;
-  acluster.add(pix, seed_adc);
+  acluster.add(pix, seed_adc, seed_rawADC);
   if (!theFakePixels[pix.row() * theNumOfCols + pix.col()]) {
-    cldata.add(pix, seed_adc);
+    cldata.add(pix, seed_adc, seed_rawADC);
   }
 
   //Here we search all pixels adjacent to all pixels in the cluster.
@@ -410,11 +415,12 @@ SiPixelCluster PixelThresholdClusterizer::make_cluster(const SiPixelCluster::Pix
         if (theBuffer(r, c) >= thePixelThreshold) {
           SiPixelCluster::PixelPos newpix(r, c);
           auto const newpix_adc = std::min(theBuffer(r, c), int(std::numeric_limits<uint16_t>::max()));
-          if (!acluster.add(newpix, newpix_adc))
+          auto const newpix_rawADC = theBuffer.rawADC(r, c);
+          if (!acluster.add(newpix, newpix_adc, newpix_rawADC))
             goto endClus;
           // VV: no fake pixels in cluster, leads to non-contiguous clusters
           if (!theFakePixels[r * theNumOfCols + c]) {
-            cldata.add(newpix, newpix_adc);
+            cldata.add(newpix, newpix_adc, newpix_rawADC);
           }
           theBuffer.set_adc(newpix, 1);
         }
@@ -447,7 +453,8 @@ SiPixelCluster PixelThresholdClusterizer::make_cluster(const SiPixelCluster::Pix
 
   }  // while accretion
 endClus:
-  SiPixelCluster cluster(cldata.isize, cldata.adc, cldata.x, cldata.y, cldata.xmin, cldata.ymin);
+  constexpr auto i = SiPixelCluster::invalidClusterId;
+  SiPixelCluster cluster(cldata.isize, cldata.adc, cldata.x, cldata.y, cldata.xmin, cldata.ymin, i, cldata.isSaturated);
   //Here we split the cluster, if the flag to do so is set and we have found a dead or noisy pixel.
 
   if (dead_flag && doSplitClusters) {

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelArrayBuffer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelArrayBuffer.h
@@ -32,11 +32,13 @@ public:
   inline int operator()(const SiPixelCluster::PixelPos&) const;
   inline int rows() const { return nrows; }
   inline int columns() const { return ncols; }
+  inline uint8_t rawADC(int row, int col) const { return pixel_rawADC[index(row, col)]; }
 
   inline bool inside(int row, int col) const;
   inline void set_adc(int row, int col, int adc);
   inline void set_adc(const SiPixelCluster::PixelPos&, int adc);
   inline void add_adc(int row, int col, int adc);
+  inline void set_rawADC(int row, int col, uint8_t adc) { pixel_rawADC[index(row, col)] = adc; };
   int size() const { return pixel_vec.size(); }
 
   /// Definition of indexing within the buffer.
@@ -44,15 +46,19 @@ public:
   int index(const SiPixelCluster::PixelPos& pix) const { return index(pix.row(), pix.col()); }
 
 private:
-  std::vector<int> pixel_vec;  // TO DO: any benefit in using shorts instead?
+  uint16_t clamp(int adc) { return std::clamp<int>(adc, 0, std::numeric_limits<uint16_t>::max()); }
+  std::vector<uint16_t> pixel_vec;
+  std::vector<uint8_t> pixel_rawADC;
   int nrows;
   int ncols;
 };
 
-SiPixelArrayBuffer::SiPixelArrayBuffer(int rows, int cols) : pixel_vec(rows * cols, 0), nrows(rows), ncols(cols) {}
+SiPixelArrayBuffer::SiPixelArrayBuffer(int rows, int cols)
+    : pixel_vec(rows * cols, 0), pixel_rawADC(rows * cols, 0), nrows(rows), ncols(cols) {}
 
 void SiPixelArrayBuffer::setSize(int rows, int cols) {
   pixel_vec.resize(rows * cols, 0);
+  pixel_rawADC.resize(rows * cols, 0);
   nrows = rows;
   ncols = cols;
 }
@@ -64,10 +70,13 @@ int SiPixelArrayBuffer::operator()(int row, int col) const { return pixel_vec[in
 int SiPixelArrayBuffer::operator()(const SiPixelCluster::PixelPos& pix) const { return pixel_vec[index(pix)]; }
 
 // unchecked!
-void SiPixelArrayBuffer::set_adc(int row, int col, int adc) { pixel_vec[index(row, col)] = adc; }
+void SiPixelArrayBuffer::set_adc(int row, int col, int adc) { pixel_vec[index(row, col)] = clamp(adc); }
 
-void SiPixelArrayBuffer::set_adc(const SiPixelCluster::PixelPos& pix, int adc) { pixel_vec[index(pix)] = adc; }
+void SiPixelArrayBuffer::set_adc(const SiPixelCluster::PixelPos& pix, int adc) { pixel_vec[index(pix)] = clamp(adc); }
 
-void SiPixelArrayBuffer::add_adc(int row, int col, int adc) { pixel_vec[index(row, col)] += adc; }
+void SiPixelArrayBuffer::add_adc(int row, int col, int adc) {
+  auto& v = pixel_vec[index(row, col)];
+  v = clamp(v + adc);
+}
 
 #endif

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoAAlpaka.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoAAlpaka.cc
@@ -134,7 +134,8 @@ void SiPixelDigisClustersFromSoAAlpaka<TrackerTraits>::produce(edm::StreamID,
             << "Layer/DetId/clusId " << layer << '/' << detId << '/' << ic << " size/charge " << acluster.isize << '/'
             << acluster.charge << "\n";
       // sort by row (x)
-      spc.emplace_back(acluster.isize, acluster.adc, acluster.x, acluster.y, acluster.xmin, acluster.ymin, ic);
+      spc.emplace_back(
+          acluster.isize, acluster.adc, acluster.x, acluster.y, acluster.xmin, acluster.ymin, ic, acluster.isSaturated);
       aclusters[ic].clear();
 #ifdef EDM_ML_DEBUG
       ++totClustersFilled;
@@ -211,7 +212,7 @@ void SiPixelDigisClustersFromSoAAlpaka<TrackerTraits>::produce(edm::StreamID,
 
     if (storeDigis_)
       (*detDigis).data.emplace_back(dig);
-      // fill clusters
+    // fill clusters
 #ifdef EDM_ML_DEBUG
     assert(digisView[i].clus() >= 0);
     assert(digisView[i].clus() < static_cast<int>(TrackerTraits::maxNumClustersPerModules));
@@ -220,7 +221,7 @@ void SiPixelDigisClustersFromSoAAlpaka<TrackerTraits>::produce(edm::StreamID,
     auto row = dig.row();
     auto col = dig.column();
     SiPixelCluster::PixelPos pix(row, col);
-    aclusters[digisView[i].clus()].add(pix, digisView[i].adc());
+    aclusters[digisView[i].clus()].add(pix, digisView[i].adc(), digisView[i].rawADC());
   }
 
   // fill final clusters

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
@@ -231,7 +231,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
                              0,                                      // adc
                              0,                                      // xx
                              0,                                      // yy
-                             ::pixelClustering::invalidModuleId};    // moduleId
+                             ::pixelClustering::invalidModuleId,     // moduleId
+                             0};                                     // rawADC
           }
         }
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
@@ -310,6 +310,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           dvgi.xx() = 0;
           dvgi.yy() = 0;
           dvgi.adc() = 0;
+          dvgi.rawADC() = 0;
 
           // initialise the errors
           err[gIndex].pixelErrors() = SiPixelErrorCompact{0, 0, 0, 0};
@@ -421,6 +422,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           dvgi.xx() = globalPix.row;  // origin shifting by 1 0-159
           dvgi.yy() = globalPix.col;  // origin shifting by 1 0-415
           dvgi.adc() = sipixelconstants::getADC(ww);
+          dvgi.rawADC() = dvgi.adc();
           dvgi.pdigi() = ::pixelDetails::pack(globalPix.row, globalPix.col, dvgi.adc());
           dvgi.moduleId() = detId.moduleId;
           dvgi.rawIdArr() = rawId;


### PR DESCRIPTION
#### PR description:

This PR adds a boolean flag in the pixel cluster data format that indicates when a cluster is saturated, defined as containing at least one pixel with raw ADC equal to 255 (maximum value).

This PR was remade after the previous PR  https://github.com/cms-sw/cmssw/pull/50250 got closed by mistake.

@mmusich @mroguljic @ferencek 

#### PR validation:

Tested locally

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: