### PR TITLE
Run3-gex202 Modify the 2026 scripts for geometry creation such that it will create only the standard 2026 geometry

### DIFF
--- a/CondTools/Geometry/test/writehelpers/createExtended2026DD4hepPayloads.sh
+++ b/CondTools/Geometry/test/writehelpers/createExtended2026DD4hepPayloads.sh
@@ -34,23 +34,23 @@ cmsRun geometryExtended2026DD4hep_writer.py --tag=${mytag} || die 'failed geomet
 
 #sed -i '{s/ExtendedGeometry2026/ExtendedGeometry2026ZeroMaterial/g}' geometryExtended2026DD4hep_xmlwriter.py
 #sed -i '{s/\/ge/\/gez/g}' geometryExtended2026DD4hep_xmlwriter.py
-cmsRun geometryExtended2026DD4hep_xmlwriter.py --geom=ExtendedGeometry2026ZeroMaterial --out=gez || die 'failed geometryExtended2026DD4hep_xmlwriter.py ExtendedGeometry2026ZeroMaterial' $?
+#cmsRun geometryExtended2026DD4hep_xmlwriter.py --geom=ExtendedGeometry2026ZeroMaterial --out=gez || die 'failed geometryExtended2026DD4hep_xmlwriter.py ExtendedGeometry2026ZeroMaterial' $?
 
 #sed -i '{s/ExtendedGeometry2026ZeroMaterial/ExtendedGeometry2026FlatMinus05Percent/g}' geometryExtended2026DD4hep_xmlwriter.py
 #sed -i '{s/\/gez/\/geFM05/g}' geometryExtended2026DD4hep_xmlwriter.py
-cmsRun geometryExtended2026DD4hep_xmlwriter.py --geom=ExtendedGeometry2026FlatMinus05Percent --out=geFM05 || die 'failed geometryExtended2026DD4hep_xmlwriter.py ExtendedGeometry2026FlatMinus05Percent' $?
+#cmsRun geometryExtended2026DD4hep_xmlwriter.py --geom=ExtendedGeometry2026FlatMinus05Percent --out=geFM05 || die 'failed geometryExtended2026DD4hep_xmlwriter.py ExtendedGeometry2026FlatMinus05Percent' $?
 
 #sed -i '{s/ExtendedGeometry2026FlatMinus05Percent/ExtendedGeometry2026FlatMinus10Percent/g}' geometryExtended2026DD4hep_xmlwriter.py
 #sed -i '{s/\/geFM05/\/geFM10/g}' geometryExtended2026DD4hep_xmlwriter.py
-cmsRun geometryExtended2026DD4hep_xmlwriter.py --geom=ExtendedGeometry2026FlatMinus10Percent --out=geFM10 || die 'failed geometryExtended2026DD4hep_xmlwriter.py' $?
+#cmsRun geometryExtended2026DD4hep_xmlwriter.py --geom=ExtendedGeometry2026FlatMinus10Percent --out=geFM10 || die 'failed geometryExtended2026DD4hep_xmlwriter.py' $?
 
 #sed -i '{s/ExtendedGeometry2026FlatMinus10Percent/ExtendedGeometry2026FlatPlus05Percent/g}' geometryExtended2026DD4hep_xmlwriter.py
 #sed -i '{s/\/geFM10/\/geFP05/g}' geometryExtended2026DD4hep_xmlwriter.py
-cmsRun geometryExtended2026DD4hep_xmlwriter.py --geom=ExtendedGeometry2026FlatPlus05Percent --out=geFP05 || die 'failed geometryExtended2026DD4hep_xmlwriter.py ExtendedGeometry2026FlatPlus05Percent' $?
+#cmsRun geometryExtended2026DD4hep_xmlwriter.py --geom=ExtendedGeometry2026FlatPlus05Percent --out=geFP05 || die 'failed geometryExtended2026DD4hep_xmlwriter.py ExtendedGeometry2026FlatPlus05Percent' $?
 
 #sed -i '{s/ExtendedGeometry2026FlatPlus05Percent/ExtendedGeometry2026FlatPlus10Percent/g}' geometryExtended2026DD4hep_xmlwriter.py
 #sed -i '{s/\/geFP05/\/geFP10/g}' geometryExtended2026DD4hep_xmlwriter.py
-cmsRun geometryExtended2026DD4hep_xmlwriter.py --geom=ExtendedGeometry2026FlatPlus10Percent --out=geFP10 || die 'failed geometryExtended2026DD4hep_xmlwriter.py' $?
+#cmsRun geometryExtended2026DD4hep_xmlwriter.py --geom=ExtendedGeometry2026FlatPlus10Percent --out=geFP10 || die 'failed geometryExtended2026DD4hep_xmlwriter.py' $?
 
 # Read the one big XML file and output a record to the
 # database with the an identifying tag
@@ -63,23 +63,23 @@ cmsRun geometryExtended2026DD4hep_xmlwriter.py --geom=ExtendedGeometry2026FlatPl
 
 #sed -i '{s/Extended/Extended2026ZeroMaterial/g}' xmlgeometrywriter.py
 #sed -i '{s/\/ge/\/gez/g}' xmlgeometrywriter.py
-cmsRun xmlgeometrywriter.py --tag=${mytag} --out=Extended2026ZeroMaterial --inPre=gez|| die 'failed xmlgeometrywriter.py Extended2026ZeroMaterial' $?
+#cmsRun xmlgeometrywriter.py --tag=${mytag} --out=Extended2026ZeroMaterial --inPre=gez|| die 'failed xmlgeometrywriter.py Extended2026ZeroMaterial' $?
 
 #sed -i '{s/Extended2026ZeroMaterial/Extended2026FlatMinus05Percent/g}' xmlgeometrywriter.py
 #sed -i '{s/\/gez/\/geFM05/g}' xmlgeometrywriter.py
-cmsRun xmlgeometrywriter.py --tag=${mytag} --out=Extended2026FlatMinus05Percent --inPre=geFM05 || die 'failed xmlgeometrywriter.py Extended2026FlatMinus05Percent' $?
+#cmsRun xmlgeometrywriter.py --tag=${mytag} --out=Extended2026FlatMinus05Percent --inPre=geFM05 || die 'failed xmlgeometrywriter.py Extended2026FlatMinus05Percent' $?
 
 #sed -i '{s/Extended2026FlatMinus05Percent/Extended2026FlatMinus10Percent/g}' xmlgeometrywriter.py
 #sed -i '{s/\/geFM05/\/geFM10/g}' xmlgeometrywriter.py
-cmsRun xmlgeometrywriter.py --tag=${mytag} --out=Extended2026FlatMinus10Percent --inPre=geFM10 || die 'failed xmlgeometrywriter.py Extended2026FlatMinus10Percent' $?
+#cmsRun xmlgeometrywriter.py --tag=${mytag} --out=Extended2026FlatMinus10Percent --inPre=geFM10 || die 'failed xmlgeometrywriter.py Extended2026FlatMinus10Percent' $?
 
 #sed -i '{s/Extended2026FlatMinus10Percent/Extended2026FlatPlus05Percent/g}' xmlgeometrywriter.py
 #sed -i '{s/\/geFM10/\/geFP05/g}' xmlgeometrywriter.py
-cmsRun xmlgeometrywriter.py --tag=${mytag} --out=Extended2026FlatPlus05Percent --inPre=geFP05 || die 'failed xmlgeometrywriter.py Extended2026FlatPlus05Percent' $?
+#cmsRun xmlgeometrywriter.py --tag=${mytag} --out=Extended2026FlatPlus05Percent --inPre=geFP05 || die 'failed xmlgeometrywriter.py Extended2026FlatPlus05Percent' $?
 
 #sed -i '{s/Extended2026FlatPlus05Percent/Extended2026FlatPlus10Percent/g}' xmlgeometrywriter.py
 #sed -i '{s/\/geFP05/\/geFP10/g}' xmlgeometrywriter.py
-cmsRun xmlgeometrywriter.py --tag=${mytag} --out=Extended2026FlatPlus10Percent --inPre=geFP10 || die 'failed xmlgeometrywriter.py Extended2026FlatPlus10Percent' $?
+#cmsRun xmlgeometrywriter.py --tag=${mytag} --out=Extended2026FlatPlus10Percent --inPre=geFP10 || die 'failed xmlgeometrywriter.py Extended2026FlatPlus10Percent' $?
 
 # All the database objects were written into one database
 # (myfile.db) in the steps above.  Extract the different

--- a/CondTools/Geometry/test/writehelpers/createExtended2026Payloads.sh
+++ b/CondTools/Geometry/test/writehelpers/createExtended2026Payloads.sh
@@ -34,23 +34,23 @@ cmsRun geometryExtended2026_writer.py --tag=${mytag} || die 'failed geometryExte
 
 #sed -i '{s/Extended2026/Extended2026ZeroMaterial/g}' geometryExtended2026_xmlwriter.py
 #sed -i '{s/\/ge/\/gez/g}' geometryExtended2026_xmlwriter.py
-cmsRun geometryExtended2026_xmlwriter.py --geom=Extended2026ZeroMaterial --out=gez || die 'failed geometryExtended2026_xmlwriter.py Extended2026ZeroMaterial' $?
+#cmsRun geometryExtended2026_xmlwriter.py --geom=Extended2026ZeroMaterial --out=gez || die 'failed geometryExtended2026_xmlwriter.py Extended2026ZeroMaterial' $?
 
 #sed -i '{s/Extended2026ZeroMaterial/Extended2026FlatMinus05Percent/g}' geometryExtended2026_xmlwriter.py
 #sed -i '{s/\/gez/\/geFM05/g}' geometryExtended2026_xmlwriter.py
-cmsRun geometryExtended2026_xmlwriter.py --geom=Extended2026FlatMinus05Percent --out=geFM05 || die 'failed geometryExtended2026_xmlwriter.py Extended2026FlatMinus05Percent' $?
+#cmsRun geometryExtended2026_xmlwriter.py --geom=Extended2026FlatMinus05Percent --out=geFM05 || die 'failed geometryExtended2026_xmlwriter.py Extended2026FlatMinus05Percent' $?
 
 #sed -i '{s/Extended2026FlatMinus05Percent/Extended2026FlatMinus10Percent/g}' geometryExtended2026_xmlwriter.py
 #sed -i '{s/\/geFM05/\/geFM10/g}' geometryExtended2026_xmlwriter.py
-cmsRun geometryExtended2026_xmlwriter.py --geom=Extended2026FlatMinus10Percent --out=geFM10 || die 'failed geometryExtended2026_xmlwriter.py' $?
+#cmsRun geometryExtended2026_xmlwriter.py --geom=Extended2026FlatMinus10Percent --out=geFM10 || die 'failed geometryExtended2026_xmlwriter.py' $?
 
 #sed -i '{s/Extended2026FlatMinus10Percent/Extended2026FlatPlus05Percent/g}' geometryExtended2026_xmlwriter.py
 #sed -i '{s/\/geFM10/\/geFP05/g}' geometryExtended2026_xmlwriter.py
-cmsRun geometryExtended2026_xmlwriter.py --geom=Extended2026FlatPlus05Percent --out=geFP05 || die 'failed geometryExtended2026_xmlwriter.py Extended2026FlatPlus05Percent' $?
+#cmsRun geometryExtended2026_xmlwriter.py --geom=Extended2026FlatPlus05Percent --out=geFP05 || die 'failed geometryExtended2026_xmlwriter.py Extended2026FlatPlus05Percent' $?
 
 #sed -i '{s/Extended2026FlatPlus05Percent/Extended2026FlatPlus10Percent/g}' geometryExtended2026_xmlwriter.py
 #sed -i '{s/\/geFP05/\/geFP10/g}' geometryExtended2026_xmlwriter.py
-cmsRun geometryExtended2026_xmlwriter.py --geom=Extended2026FlatPlus10Percent --out=geFP10 || die 'failed geometryExtended2026_xmlwriter.py' $?
+#cmsRun geometryExtended2026_xmlwriter.py --geom=Extended2026FlatPlus10Percent --out=geFP10 || die 'failed geometryExtended2026_xmlwriter.py' $?
 
 # Read the one big XML file and output a record to the
 # database with the an identifying tag
@@ -63,23 +63,23 @@ cmsRun geometryExtended2026_xmlwriter.py --geom=Extended2026FlatPlus10Percent --
 
 #sed -i '{s/Extended/Extended2026ZeroMaterial/g}' xmlgeometrywriter.py
 #sed -i '{s/\/ge/\/gez/g}' xmlgeometrywriter.py
-cmsRun xmlgeometrywriter.py --tag=${mytag} --out=Extended2026ZeroMaterial --inPre=gez|| die 'failed xmlgeometrywriter.py Extended2026ZeroMaterial' $?
+#cmsRun xmlgeometrywriter.py --tag=${mytag} --out=Extended2026ZeroMaterial --inPre=gez|| die 'failed xmlgeometrywriter.py Extended2026ZeroMaterial' $?
 
 #sed -i '{s/Extended2026ZeroMaterial/Extended2026FlatMinus05Percent/g}' xmlgeometrywriter.py
 #sed -i '{s/\/gez/\/geFM05/g}' xmlgeometrywriter.py
-cmsRun xmlgeometrywriter.py --tag=${mytag} --out=Extended2026FlatMinus05Percent --inPre=geFM05 || die 'failed xmlgeometrywriter.py Extended2026FlatMinus05Percent' $?
+#cmsRun xmlgeometrywriter.py --tag=${mytag} --out=Extended2026FlatMinus05Percent --inPre=geFM05 || die 'failed xmlgeometrywriter.py Extended2026FlatMinus05Percent' $?
 
 #sed -i '{s/Extended2026FlatMinus05Percent/Extended2026FlatMinus10Percent/g}' xmlgeometrywriter.py
 #sed -i '{s/\/geFM05/\/geFM10/g}' xmlgeometrywriter.py
-cmsRun xmlgeometrywriter.py --tag=${mytag} --out=Extended2026FlatMinus10Percent --inPre=geFM10 || die 'failed xmlgeometrywriter.py Extended2026FlatMinus10Percent' $?
+#cmsRun xmlgeometrywriter.py --tag=${mytag} --out=Extended2026FlatMinus10Percent --inPre=geFM10 || die 'failed xmlgeometrywriter.py Extended2026FlatMinus10Percent' $?
 
 #sed -i '{s/Extended2026FlatMinus10Percent/Extended2026FlatPlus05Percent/g}' xmlgeometrywriter.py
 #sed -i '{s/\/geFM10/\/geFP05/g}' xmlgeometrywriter.py
-cmsRun xmlgeometrywriter.py --tag=${mytag} --out=Extended2026FlatPlus05Percent --inPre=geFP05 || die 'failed xmlgeometrywriter.py Extended2026FlatPlus05Percent' $?
+#cmsRun xmlgeometrywriter.py --tag=${mytag} --out=Extended2026FlatPlus05Percent --inPre=geFP05 || die 'failed xmlgeometrywriter.py Extended2026FlatPlus05Percent' $?
 
 #sed -i '{s/Extended2026FlatPlus05Percent/Extended2026FlatPlus10Percent/g}' xmlgeometrywriter.py
 #sed -i '{s/\/geFP05/\/geFP10/g}' xmlgeometrywriter.py
-cmsRun xmlgeometrywriter.py --tag=${mytag} --out=Extended2026FlatPlus10Percent --inPre=geFP10 || die 'failed xmlgeometrywriter.py Extended2026FlatPlus10Percent' $?
+#cmsRun xmlgeometrywriter.py --tag=${mytag} --out=Extended2026FlatPlus10Percent --inPre=geFP10 || die 'failed xmlgeometrywriter.py Extended2026FlatPlus10Percent' $?
 
 # All the database objects were written into one database
 # (myfile.db) in the steps above.  Extract the different

--- a/CondTools/Geometry/test/writehelpers/geometryExtended2026DD4hep_xmlwriter.py
+++ b/CondTools/Geometry/test/writehelpers/geometryExtended2026DD4hep_xmlwriter.py
@@ -4,7 +4,7 @@ import argparse
 import sys
 
 parser = argparse.ArgumentParser(prog=sys.argv[0], description='Generate XML geometry.')
-parser.add_argument("--geom", help="Name of parameter", type=str, default='ExtendedGeometry2026x')
+parser.add_argument("--geom", help="Name of parameter", type=str, default='ExtendedGeometry2026')
 parser.add_argument("--out", help="Prefix for output file", type=str, default='ge')
 
 args = parser.parse_args()

--- a/CondTools/Geometry/test/writehelpers/splitExtended2026Database.sh
+++ b/CondTools/Geometry/test/writehelpers/splitExtended2026Database.sh
@@ -1,11 +1,6 @@
 #!/bin/sh
 
 conddb --yes --db myfile.db copy XMLFILE_Geometry_TagXX_Extended2026_mc --destdb GeometryFileExtended2026.db
-conddb --yes --db myfile.db copy XMLFILE_Geometry_TagXX_Extended2026ZeroMaterial_mc --destdb GeometryFileExtended2026ZeroMaterial.db
-conddb --yes --db myfile.db copy XMLFILE_Geometry_TagXX_Extended2026FlatMinus05Percent_mc --destdb GeometryFileExtended2026FlatMinus05Percent.db
-conddb --yes --db myfile.db copy XMLFILE_Geometry_TagXX_Extended2026FlatMinus10Percent_mc --destdb GeometryFileExtended2026FlatMinus10Percent.db
-conddb --yes --db myfile.db copy XMLFILE_Geometry_TagXX_Extended2026FlatPlus05Percent_mc --destdb GeometryFileExtended2026FlatPlus05Percent.db
-conddb --yes --db myfile.db copy XMLFILE_Geometry_TagXX_Extended2026FlatPlus10Percent_mc --destdb GeometryFileExtended2026FlatPlus10Percent.db
 conddb --yes --db myfile.db copy TKRECO_Geometry_TagXX                  --destdb TKRECO_Geometry.db
 conddb --yes --db myfile.db copy TKParameters_Geometry_TagXX            --destdb TKParameters_Geometry.db
 conddb --yes --db myfile.db copy EBRECO_Geometry_TagXX                  --destdb EBRECO_Geometry.db


### PR DESCRIPTION
#### PR description:

Modify the 2026 scripts for geometry creation such that it will create only the standard 2026 geometry

#### PR validation:

To be used to create the payloads for 2026 Geometry

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special