### PR TITLE
Make `processFromFile` behave like `cmsRun`

### DIFF
--- a/FWCore/ParameterSet/python/processFromFile.py
+++ b/FWCore/ParameterSet/python/processFromFile.py
@@ -1,8 +1,13 @@
+import os
 import sys
 import types
 from importlib.machinery import SourceFileLoader
 
 def processFromFile(filename:str, args=None):
+    # make processFromFile behave like cmsRun
+    sys.path.insert(0, os.path.dirname(os.path.abspath(filename)))
+
+    # pass any optional arguments to the file being loaded
     old_sys_argv = None
     if args is not None:
         old_sys_argv = sys.argv[:]
@@ -13,7 +18,11 @@ def processFromFile(filename:str, args=None):
     loader.exec_module(mod)
     process = mod.process
 
+    # restore the original arguments
     if old_sys_argv is not None:
         sys.argv = old_sys_argv
+
+    # restore the original environment
+    sys.path.pop(0)
 
     return process

--- a/FWCore/ParameterSet/scripts/edmConfigDump
+++ b/FWCore/ParameterSet/scripts/edmConfigDump
@@ -1,12 +1,8 @@
 #! /usr/bin/env python3
 
 import sys
-import os 
 import argparse
 from FWCore.ParameterSet.processFromFile import processFromFile
-
-# make the behaviour of 'cmsRun file.py' and 'edmConfigDump file.py' more consistent
-sys.path.append(os.getcwd())
 
 parser = argparse.ArgumentParser(description="Expand python configuration")
 parser.add_argument("filename",

--- a/FWCore/ParameterSet/scripts/edmConfigSplit
+++ b/FWCore/ParameterSet/scripts/edmConfigSplit
@@ -31,9 +31,6 @@ parser.add_argument('-s', '--subdirectories',
 
 args = parser.parse_args()
 
-# make the behaviour of 'cmsRun file.py' and 'edmConfigSplit file.py' more consistent
-sys.path.append(os.getcwd())
-
 process = processFromFile(args.file, args.configArgs)
 
 options = PrintOptions()


### PR DESCRIPTION
#### PR description:

`cmsRun` handles correctly configuration files that import files in the local directory, even if launched from a different directory.

For example, having:
```bash
$ ls workdir/
hlt.py
hlt_2025v13_160v5.py
reduced_hlt.py
run398183_cff.py
```
where `reduced_hlt.py` imports `hlt.py` which imports `hlt_2025v13_160v5.py` and `run398183_cff.py`, `cmsRun` works:
```bash
$ cmsRun workdir/reduced_hlt.py 
%MSG-i ThreadStreamSetup:  (NoModuleName) 26-Feb-2026 14:49:33 CET pre-events
setting # threads 32
setting # streams 24
%MSG
...
```
while `edmConfigDump` does not:
```bash
$ $CMSSW_RELEASE_BASE/bin/el8_amd64_gcc13/edmConfigDump workdir/reduced_hlt.py 
Traceback (most recent call last):
  File "/data/cmssw/el8_amd64_gcc13/cms/cmssw/CMSSW_16_0_1/bin/el8_amd64_gcc13/edmConfigDump", line 24, in <module>
    cmsProcess = processFromFile(options.filename, options.configArgs)
  File "/data/user/fwyzard/CMSSW_16_0_1/src/FWCore/ParameterSet/python/processFromFile.py", line 13, in processFromFile
    loader.exec_module(mod)
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "workdir/reduced_hlt.py", line 3, in <module>
    from hlt import process
ModuleNotFoundError: No module named 'hlt'
```

With these changes it now works:
```bash
$ edmConfigDump workdir/reduced_hlt.py
import FWCore.ParameterSet.Config as cms
from HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka import ProcessAcceleratorAlpaka
from HeterogeneousCore.CUDACore.ProcessAcceleratorCUDA import ProcessAcceleratorCUDA
from HeterogeneousCore.ROCmCore.ProcessAcceleratorROCm import ProcessAcceleratorROCm

process = cms.Process("HLT")

...
```

#### PR validation:

See the description.