### PR TITLE
Avoid streamer mode in RNTuple for `edm::RefCore` and `edm::RefCoreWithIndex`

### DIFF
--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -8,7 +8,8 @@
   <version ClassVersion="11" checksum="2247759761"/>
   <version ClassVersion="10" checksum="2702412727"/>
  </class>
- <class name="edm::RefCore" ClassVersion="11" rntupleStreamerMode="true">
+ <!-- RefCore has a custom streamer registered, and without explicit false RNTuple would refuse to split RefCore -->
+ <class name="edm::RefCore" ClassVersion="11" rntupleStreamerMode="false">
   <version ClassVersion="10" checksum="641105393"/>
   <version ClassVersion="11" checksum="3425324092"/>
    <field name="cachePtr_" transient = "true"/>
@@ -20,7 +21,7 @@
      edm::refcoreimpl::setCacheIsProductGetter(cachePtr_, getter);
       ]]>
  </ioread>
-  <class name="edm::RefCoreWithIndex" ClassVersion="11" rntupleStreamerMode="true">
+  <class name="edm::RefCoreWithIndex" ClassVersion="11" rntupleStreamerMode="false">
     <version ClassVersion="11" checksum="2602044085"/>
     <field name="cachePtr_" transient = "true"/>
   </class>


### PR DESCRIPTION
#### PR description:

In my recollection once upon a time the streamer mode was used for `edm::RefCore` and `edm::RefCoreWithIndex` in order to run the read rule. Nowadays the read rule should get called regardless of the streamer mode. An explicit value `rntupleStreamerMode="false"` is needed because a custom streamer is registered for them, and just leaving out the `rntupleStreamerModer` attribute would lead to an error message from RNTuple.

Resolves https://github.com/cms-sw/framework-team/issues/1959

#### PR validation:

`FWIO/RNTupleTempInput` unit tests pass. In a copy job reading Run 3 AODSIM
* reading TTree and writing RNTuple the number of memory allocations decreased by 26.6k allocations/event
* reading RNTuple and writing nothing the number of memory allocations decreased by 24.4k allocations/event
* reading RNTuple and writing RNTuple the number of memory allocations decreased by 50.9k allocations/event

Note: After this the AOD files still use streamer mode for `edm::OwnVector` and `edm::RefToBase`. Both use dynamic polymorphism so changing them would be much more complicated (but in the plans to be done). Reducing the number of allocations is now an additional motivation to address them.