### PR TITLE
Update 2025 and 2026 MC Gts

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -104,7 +104,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2025
     'phase1_2025_design'           :    '150X_mcRun3_2025_design_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2025
-    'phase1_2025_realistic'        :    '151X_mcRun3_2025_realistic_v4',
+    'phase1_2025_realistic'        :    '151X_mcRun3_2025_realistic_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2025, Strip tracker in DECO mode
     'phase1_2025_cosmics'          :    '150X_mcRun3_2025cosmics_realistic_deco_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2025 detector for Heavy Ion
@@ -112,7 +112,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2026
     'phase1_2026_design'           :    '160X_mcRun3_2026_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2026
-    'phase1_2026_realistic'        :    '160X_mcRun3_2026_realistic_v2',
+    'phase1_2026_realistic'        :    '160X_mcRun3_2026_realistic_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2026, Strip tracker in DECO mode
     'phase1_2026_cosmics'          :    '160X_mcRun3_2026cosmics_realistic_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2026 detector for Heavy Ion


### PR DESCRIPTION
#### PR description:

This PR ports to autoCond the 2025 and 2026 realistic MC GTs after the following updates:
- The 2025 MC GT was synchronized with the updates already integrated in 150X_mcRun3_2025_realistic_v14 and not yet ported to the 151X version of it; moreover, the fixed SiPixelStatus tags are also integrated
- The 2026 MC GT synchronizes the 2025 Geometry with the one already implemented in 151X_mcRun3_2025_realistic (plus a ZDC related addition for the HCal reco geometry already implemented in the current online GTs); moreover, the fixed SiPixelStatus tags are also integrated

To give some more detail:

- 151X_mcRun3_2025_realistic_v5 - Synchronize with 150X_mcRun3_2025_realistic_v14, i.e.:
   - Update JetCorrector parameters:
https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/33
  - Update SiStrip bad channels as in https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/37
  - Update SPixel and Pixel Alignment tags as in https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/38
  - (SiPixelStatus will be synchronized separalely)
- [151X_mcRun3_2025_realistic_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/151X_mcRun3_2025_realistic_v6)
  - Update SiPixelStatusScenario as in https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-winter26-mc-global-tag/140278/18

- 160X_mcRun3_2026_realistic_v3
  - Synchronize the Geometry tags with the 2025 ones already implemented in 151X_mcRun3_2025_realistic as originally described in https://github.com/cms-sw/cmssw/pull/48365
  - Update also the HCal reco geometry with the ZDC as it is implemented since Nov. 2025 in the data taking GTs, see the update of HCALRECO_Geometry_v1_hlt in https://cms-talk.web.cern.ch/t/hlt-prompt-full-track-validation-2025-full-zdc-reconstruction-step-2/135095/8
- [160X_mcRun3_2026_realistic_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/160X_mcRun3_2026_realistic_v5)
  - Update SiPixelStatusScenario as in https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-winter26-mc-global-tag/140278/18

The differences with the GTs previously in confDB follows:
- [Diff between 151X_mcRun3_2025_realistic_v6 and 151X_mcRun3_2025_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/151X_mcRun3_2025_realistic_v4/151X_mcRun3_2025_realistic_v6)
- [Diff between 160X_mcRun3_2026_realistic_v5 and 160X_mcRun3_2026_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/160X_mcRun3_2026_realistic_v2/160X_mcRun3_2026_realistic_v5)


#### PR validation:

Rely on bot tests
All single tags were already tested separately (but good to check all them taken together)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

A backport to CMSSW_16_0_X will be prepared
A partial backport to CMSSW_15_1_X and CMSSW_15_0_X will also be prepared
