### PR TITLE
[DQM] Phase-2: Fix module order in 2S_Ladder_layerX histograms

### DIFF
--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
@@ -193,8 +193,11 @@ void Phase2OTMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventS
           }
           unsigned int ladder = tTopo_->tobRod(rawid);
           if (local_mes.PositionOfClusters_2SLadder[ladder] != nullptr) {
-            //Adapt module numbers from 1 to 24 into -12 to +12
-            int signedModule = module <= 12 ? module : -(module - 12);
+            int signedModule = module;
+            // CRACK has numbers 1 to 12 while Tracker has 1 to 24
+            // Adapt module numbers from 1 to 24 into -12 to +12
+            if (!crackOverview_)
+              signedModule = module <= 12 ? module - 13 : module - 12;
             local_mes.PositionOfClusters_2SLadder[ladder]->Fill(signedModule, topOrBottomColumn);
           }
           if (crackOverview_)


### PR DESCRIPTION
A bug was introduced that re-ordered the modules in the PositionOfClusters_2S_LayX_LadY histograms. 
Please excuse the amateur diagrams

**Visual of bug:**

<img width="1263" height="1071" alt="ladders_glitch" src="https://github.com/user-attachments/assets/739b155e-86df-49cd-a31a-a9e8116c07d2" />

**Visual of fix:**

<img width="1262" height="1041" alt="ladders_fix" src="https://github.com/user-attachments/assets/9050ed1b-7f2f-467f-9ca2-3153f2d7f56b" />

#### PR validation:

- Compared fixed histograms to output from version 16_0_1_pre2, before bug was introduced

16_0_1_pre2 (before bug)
<img width="1628" height="894" alt="image" src="https://github.com/user-attachments/assets/2c29a53d-7aea-474b-8ca5-effca341b651" />

16_1_X_2026-02-26-1100 (bug introduced)
<img width="1628" height="894" alt="image" src="https://github.com/user-attachments/assets/e5a83672-57fb-4cd3-bc4d-20944e01dd33" />

New Code (bug fixed)
<img width="1628" height="894" alt="image" src="https://github.com/user-attachments/assets/eb52bb1f-ed53-4a33-b199-379504ffb91f" />

- run CRACK workflow to ensure results are still the same
- Used cout (now removed) to manually check SignedModule variable is behaving as expected