### PR TITLE
Update Phase 2 timing configuration

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/test/runHLTTiming.sh
+++ b/HLTrigger/Configuration/python/HLT_75e33/test/runHLTTiming.sh
@@ -8,7 +8,7 @@ set -o pipefail
 
 # Function to check logs for errors
 check_logs_for_errors() {
-    local log_dirs=${1:-"logs/step*/pid*"}  # default path if none passed
+    local log_dirs=${1:-"logs/step*/pid*"} # default path if none passed
     local error_found=0
 
     for f in $log_dirs/stdout $log_dirs/stderr; do
@@ -72,7 +72,13 @@ if [ -e 'Phase2_L1P2GT_HLT.py' ]; then
     if [ ! -d 'patatrack-scripts' ]; then
         git clone https://github.com/cms-patatrack/patatrack-scripts --depth 1
     fi
-    patatrack-scripts/benchmark -j 16 -t 16 -s 16 -e 1000 --no-run-io-benchmark --event-skip 100 --event-resolution 10 -k Phase2Timing_resources.json -- Phase2_L1P2GT_HLT.py
+    patatrack-scripts/benchmark -j 8 -t 16 -s 16 \
+        -e 1000 \
+        --no-input-benchmark \
+        --slot "numa=0-3:mem=0-3" \
+        --event-skip 100 \
+        --event-resolution 10 \
+        -k Phase2Timing_resources.json -- Phase2_L1P2GT_HLT.py
     check_logs_for_errors || exit 1
     mergeResourcesJson.py logs/step*/pid*/Phase2Timing_resources.json >Phase2Timing_resources.json
     if [ -e "$(dirname $0)/augmentResources.py" ]; then
@@ -82,17 +88,23 @@ fi
 
 # run timing menu HLT:75e33_timing (force running on CPU)
 if [ -f Phase2_L1P2GT_HLT.py ]; then
-  cp Phase2_L1P2GT_HLT.py Phase2_L1P2GT_HLT_OnCPU.py
-  echo "process.options.accelerators = ['cpu']" >> Phase2_L1P2GT_HLT_OnCPU.py
+    cp Phase2_L1P2GT_HLT.py Phase2_L1P2GT_HLT_OnCPU.py
+    echo "process.options.accelerators = ['cpu']" >>Phase2_L1P2GT_HLT_OnCPU.py
 else
-  echo "Error: Phase2_L1P2GT_HLT.py not found!"
+    echo "Error: Phase2_L1P2GT_HLT.py not found!"
 fi
 
 if [ -e 'Phase2_L1P2GT_HLT_OnCPU.py' ]; then
     if [ ! -d 'patatrack-scripts' ]; then
         git clone https://github.com/cms-patatrack/patatrack-scripts --depth 1
     fi
-    patatrack-scripts/benchmark -j 16 -t 16 -s 16 -e 1000 --no-run-io-benchmark --event-skip 100 --event-resolution 10 -k Phase2Timing_resources.json -- Phase2_L1P2GT_HLT_OnCPU.py
+    patatrack-scripts/benchmark -j 8 -t 16 -s 16 \
+        -e 1000 \
+        --no-input-benchmark \
+        --slot "numa=0-3:mem=0-3" \
+        --event-skip 100 \
+        --event-resolution 10 \
+        -k Phase2Timing_resources.json -- Phase2_L1P2GT_HLT_OnCPU.py
     check_logs_for_errors || exit 1
     mergeResourcesJson.py logs/step*/pid*/Phase2Timing_resources.json >Phase2Timing_resources_OnCPU.json
 fi
@@ -112,7 +124,13 @@ if [ -e 'NGTScouting_L1P2GT_HLT.py' ]; then
     if [ ! -d 'patatrack-scripts' ]; then
         git clone https://github.com/cms-patatrack/patatrack-scripts --depth 1
     fi
-    patatrack-scripts/benchmark -j 16 -t 16 -s 16 -e 1000 --no-run-io-benchmark --event-skip 100 --event-resolution 10 -k Phase2Timing_resources.json -- NGTScouting_L1P2GT_HLT.py
-    #check_logs_for_errors || exit 1  (commenting check for now, needs a better job division to fit memory budget contraints)
+    patatrack-scripts/benchmark -j 8 -t 16 -s 16 \
+        -e 1000 \
+        --no-input-benchmark \
+        --slot "numa=0-3:mem=0-3" \
+        --event-skip 100 \
+        --event-resolution 10 \
+        -k Phase2Timing_resources.json -- NGTScouting_L1P2GT_HLT.py
+    check_logs_for_errors || exit 1
     mergeResourcesJson.py logs/step*/pid*/Phase2Timing_resources.json >Phase2Timing_resources_NGT.json
 fi


### PR DESCRIPTION
#### PR description:

This PR updates the configuration for Phase 2 timing tests to use a single socket together with two NVIDIA T4 GPUs in order to simulate a possible Run 4 node with a 50/50 split in CPU/GPU compute. The studies and developments follow a lengthy discussion in #50040, offline, and in the [16/02 GPU meeting](https://indico.cern.ch/event/1643732/#3-discussion-on-scheduling-and). As shown in https://github.com/cms-sw/cmssw/pull/50040#issuecomment-3972450121 this configuration should provide good performance both in terms of throughput and timing while still managing to fit the new tracking baseline in the available GPU memory. Further studies are foreseen to assess the benefits of using different input files / source modules and impact on GPU memory coming from other developments.

#### PR validation:

No specific validation for technical change, the bot will hopefully provide baseline numbers for this new configuration.