### PR TITLE
PF DQM updates

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -130,12 +130,14 @@ from DQMOffline.RecoB.PrimaryVertexMonitor_cff import *
 from DQM.TrackingMonitor.trackingRecoMaterialAnalyzer_cfi import materialDumperAnalyzer
 from DQMOffline.Muon.muonMonitors_cff import *
 from DQMOffline.JetMET.jetMETDQMOfflineSource_cff import *
+from DQMOffline.ParticleFlow.runBasic_cff import *
 from DQMOffline.EGamma.egammaDQMOffline_cff import *
 from DQMOffline.Trigger.DQMOffline_Trigger_cff import *
 from DQMOffline.RecoB.dqmAnalyzer_cff import *
 from DQM.BeamMonitor.AlcaBeamMonitor_cff import *
 from DQM.Physics.DQMPhysics_cff import *
 from DQM.Physics.heavyFlavorDQMFirstStep_cff import *
+from DQMOffline.ParticleFlow.runBasic_cff import DQMOfflinePFAnalyzer
 
 DQMOfflineVertex = cms.Sequence( pvMonitor )
 
@@ -150,6 +152,8 @@ muonRecoAnalyzer.doMVA =         cms.bool( True )
 muonRecoAnalyzer_miniAOD.doMVA = cms.bool( True )
 
 DQMOfflineJetMET = cms.Sequence( jetMETDQMOfflineSource )
+
+#DQMOfflineParticleFlow = cms.Sequence( jetMETDQMOfflineSource )
 
 DQMOfflineEGamma = cms.Sequence( egammaDQMOffline )
 
@@ -166,6 +170,7 @@ DQMOfflineHeavyFlavor = cms.Sequence( heavyFlavorDQMSource )
 DQMOfflinePrePOG = cms.Sequence( DQMOfflineTracking *
                                  DQMOfflineMUO *
                                  DQMOfflineJetMET *
+                                 #DQMOfflinePFAnalyzer *
                                  DQMOfflineEGamma *
                                  DQMOfflineTrigger *
                                  DQMOfflineScoutingForRelVals *
@@ -255,7 +260,8 @@ DQMOfflineCommon = cms.Sequence( DQMOfflineDCS *
                                  DQMOfflineBeam *
                                  DQMOfflineCASTOR *
                                  DQMOfflinePhysics *
-				 DQMOfflineTAU
+				                 DQMOfflineTAU 
+                                 #* DQMOfflinePFAnalyzer
                                 )
 
 DQMOfflineCommonFakeHLT = cms.Sequence( DQMOfflineCommon )
@@ -313,7 +319,9 @@ from DQM.TrackingMonitor.tracksDQMMiniAOD_cff import *
 from DQMOffline.RecoB.bTagMiniDQM_cff import *
 from DQMOffline.Muon.miniAOD_cff import *
 from DQM.Physics.DQMTopMiniAOD_cff import *
+from DQMOffline.ParticleFlow.runMini_cff import PFAnalyzerMiniAOD 
 
+#DQMOfflineMiniAOD = cms.Sequence(jetMETDQMOfflineRedoProductsMiniAOD*bTagMiniDQMSource*muonMonitors_miniAOD*MuonMiniAOD*DQMOfflinePF*PFAnalyzerMiniAOD)
 DQMOfflineMiniAOD = cms.Sequence(jetMETDQMOfflineRedoProductsMiniAOD*bTagMiniDQMSource*muonMonitors_miniAOD*MuonMiniAOD*DQMOfflinePF)
 DQMOfflineMiniAODBTagOnly = cms.Sequence(bTagMiniDQMSource)
 

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -153,8 +153,6 @@ muonRecoAnalyzer_miniAOD.doMVA = cms.bool( True )
 
 DQMOfflineJetMET = cms.Sequence( jetMETDQMOfflineSource )
 
-#DQMOfflineParticleFlow = cms.Sequence( jetMETDQMOfflineSource )
-
 DQMOfflineEGamma = cms.Sequence( egammaDQMOffline )
 
 DQMOfflineTrigger = cms.Sequence( triggerOfflineDQMSource )
@@ -170,7 +168,7 @@ DQMOfflineHeavyFlavor = cms.Sequence( heavyFlavorDQMSource )
 DQMOfflinePrePOG = cms.Sequence( DQMOfflineTracking *
                                  DQMOfflineMUO *
                                  DQMOfflineJetMET *
-                                 #DQMOfflinePFAnalyzer *
+                                 DQMOfflinePFAnalyzer *
                                  DQMOfflineEGamma *
                                  DQMOfflineTrigger *
                                  DQMOfflineScoutingForRelVals *
@@ -260,8 +258,8 @@ DQMOfflineCommon = cms.Sequence( DQMOfflineDCS *
                                  DQMOfflineBeam *
                                  DQMOfflineCASTOR *
                                  DQMOfflinePhysics *
-				                 DQMOfflineTAU 
-                                 #* DQMOfflinePFAnalyzer
+				                 DQMOfflineTAU *
+                                 DQMOfflinePFAnalyzer
                                 )
 
 DQMOfflineCommonFakeHLT = cms.Sequence( DQMOfflineCommon )
@@ -321,8 +319,7 @@ from DQMOffline.Muon.miniAOD_cff import *
 from DQM.Physics.DQMTopMiniAOD_cff import *
 from DQMOffline.ParticleFlow.runMini_cff import PFAnalyzerMiniAOD 
 
-#DQMOfflineMiniAOD = cms.Sequence(jetMETDQMOfflineRedoProductsMiniAOD*bTagMiniDQMSource*muonMonitors_miniAOD*MuonMiniAOD*DQMOfflinePF*PFAnalyzerMiniAOD)
-DQMOfflineMiniAOD = cms.Sequence(jetMETDQMOfflineRedoProductsMiniAOD*bTagMiniDQMSource*muonMonitors_miniAOD*MuonMiniAOD*DQMOfflinePF)
+DQMOfflineMiniAOD = cms.Sequence(jetMETDQMOfflineRedoProductsMiniAOD*bTagMiniDQMSource*muonMonitors_miniAOD*MuonMiniAOD*DQMOfflinePF*PFAnalyzerMiniAOD)
 DQMOfflineMiniAODBTagOnly = cms.Sequence(bTagMiniDQMSource)
 
 #Post sequences are automatically placed in the EndPath by ConfigBuilder if PAT is run.

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -137,7 +137,6 @@ from DQMOffline.RecoB.dqmAnalyzer_cff import *
 from DQM.BeamMonitor.AlcaBeamMonitor_cff import *
 from DQM.Physics.DQMPhysics_cff import *
 from DQM.Physics.heavyFlavorDQMFirstStep_cff import *
-from DQMOffline.ParticleFlow.runBasic_cff import DQMOfflinePFAnalyzer
 
 DQMOfflineVertex = cms.Sequence( pvMonitor )
 

--- a/DQMOffline/ParticleFlow/plugins/BuildFile.xml
+++ b/DQMOffline/ParticleFlow/plugins/BuildFile.xml
@@ -10,6 +10,7 @@
 <use name="DataFormats/RecoCandidate"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Math"/>
+<use name="fastjet"/>
 <use name="DataFormats/PatCandidates"/>
 <use name="JetMETCorrections/JetCorrector"/>
 <use name="SimDataFormats/GeneratorProducts"/>

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
@@ -67,7 +67,6 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   m_funcMap["puppi"] = getPuppiWeight;
 
 
-
   m_funcMap["HCalE_depth1"] = getHcalEnergy_depth1;
   m_funcMap["HCalE_depth2"] = getHcalEnergy_depth2;
   m_funcMap["HCalE_depth3"] = getHcalEnergy_depth3;

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
@@ -6,7 +6,6 @@
  *
  */
 
-
 #include "DQMOffline/ParticleFlow/plugins/PFAnalyzer.h"
 #include <iostream>
 
@@ -15,7 +14,8 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   m_directory = "ParticleFlow";
   parameters_ = pSet.getParameter<edm::ParameterSet>("pfAnalysis");
   m_isMiniAOD = pSet.getParameter<bool>("isMiniAOD");
-  if(m_isMiniAOD) m_directory = m_directory + "_MiniAOD";
+  if (m_isMiniAOD)
+    m_directory = m_directory + "_MiniAOD";
   m_runNumber = pSet.getParameter<unsigned int>("runNumber");
 
   patPfCandidateCollection_ =
@@ -24,7 +24,6 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
 
   thePfCandidateCollection_ = consumes<CandView>(pSet.getParameter<edm::InputTag>("pfCandidates"));
   pfJetsToken_ = consumes<reco::PFJetCollection>(pSet.getParameter<edm::InputTag>("pfJetCollection"));
-
 
   theTriggerResultsLabel_ = pSet.getParameter<edm::InputTag>("TriggerResultsLabel");
   m_selection = pSet.getParameter<std::string>("eventSelection");
@@ -65,7 +64,6 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   m_funcMap["abseta"] = getAbsEta;
   m_funcMap["phi"] = getPhi;
   m_funcMap["puppi"] = getPuppiWeight;
-
 
   m_funcMap["HCalE_depth1"] = getHcalEnergy_depth1;
   m_funcMap["HCalE_depth2"] = getHcalEnergy_depth2;
@@ -128,14 +126,20 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   m_jetFuncMap["pt"] = getJetPt;
   m_jetFuncMap["chargeFrac"] = getJetChargeFrac;
 
-
-  if(std::find(m_pfNames.begin(), m_pfNames.end(), "chargedHadPFC") != m_pfNames.end()) m_particleTypeName[reco::PFCandidate::ParticleType::h] = "chargedHadPFC";
-  if(std::find(m_pfNames.begin(), m_pfNames.end(), "neutralHadPFC") != m_pfNames.end()) m_particleTypeName[reco::PFCandidate::ParticleType::h] = "neutralHadPFC";
-  if(std::find(m_pfNames.begin(), m_pfNames.end(), "electronPFC") != m_pfNames.end()) m_particleTypeName[reco::PFCandidate::ParticleType::h] = "electronPFC";
-  if(std::find(m_pfNames.begin(), m_pfNames.end(), "muonPFC") != m_pfNames.end()) m_particleTypeName[reco::PFCandidate::ParticleType::h] = "muonPFC";
-  if(std::find(m_pfNames.begin(), m_pfNames.end(), "gammaPFC") != m_pfNames.end()) m_particleTypeName[reco::PFCandidate::ParticleType::h] = "gammaPFC";
-  if(std::find(m_pfNames.begin(), m_pfNames.end(), "hadHFPFC") != m_pfNames.end()) m_particleTypeName[reco::PFCandidate::ParticleType::h] = "hadHFPFC";
-  if(std::find(m_pfNames.begin(), m_pfNames.end(), "emHFPFC") != m_pfNames.end()) m_particleTypeName[reco::PFCandidate::ParticleType::h] = "emHFPFC";
+  if (std::find(m_pfNames.begin(), m_pfNames.end(), "chargedHadPFC") != m_pfNames.end())
+    m_particleTypeName[reco::PFCandidate::ParticleType::h] = "chargedHadPFC";
+  if (std::find(m_pfNames.begin(), m_pfNames.end(), "neutralHadPFC") != m_pfNames.end())
+    m_particleTypeName[reco::PFCandidate::ParticleType::h] = "neutralHadPFC";
+  if (std::find(m_pfNames.begin(), m_pfNames.end(), "electronPFC") != m_pfNames.end())
+    m_particleTypeName[reco::PFCandidate::ParticleType::h] = "electronPFC";
+  if (std::find(m_pfNames.begin(), m_pfNames.end(), "muonPFC") != m_pfNames.end())
+    m_particleTypeName[reco::PFCandidate::ParticleType::h] = "muonPFC";
+  if (std::find(m_pfNames.begin(), m_pfNames.end(), "gammaPFC") != m_pfNames.end())
+    m_particleTypeName[reco::PFCandidate::ParticleType::h] = "gammaPFC";
+  if (std::find(m_pfNames.begin(), m_pfNames.end(), "hadHFPFC") != m_pfNames.end())
+    m_particleTypeName[reco::PFCandidate::ParticleType::h] = "hadHFPFC";
+  if (std::find(m_pfNames.begin(), m_pfNames.end(), "emHFPFC") != m_pfNames.end())
+    m_particleTypeName[reco::PFCandidate::ParticleType::h] = "emHFPFC";
 
   // Convert the cutList strings into real cuts that can be applied
   // The format should be three comma separated values
@@ -218,7 +222,6 @@ PFAnalyzer::~PFAnalyzer() { LogTrace("PFAnalyzer") << "[PFAnalyzer] Saving the h
 
 // ***********************************************************
 void PFAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const&) {
-
   for (unsigned int i = 0; i < m_fullCutList.size(); i++) {
     m_allSuffixes.push_back(getAllSuffixes(m_fullCutList[i], m_binList[i]));
   }
@@ -304,7 +307,8 @@ void PFAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
                                             npvString.c_str());
                 MonitorElement* mHistInJet = ibooker.book1D(
                     histName, Form(";%s;", obsInfo.axisName.c_str()), obsInfo.nBins, obsInfo.binMin, obsInfo.binMax);
-                map_of_MEs.insert(std::pair<std::string, MonitorElement*>(m_directory + "/PFCinJet/" + histName, mHistInJet));
+                map_of_MEs.insert(
+                    std::pair<std::string, MonitorElement*>(m_directory + "/PFCinJet/" + histName, mHistInJet));
               }
             }
           }
@@ -367,7 +371,8 @@ void PFAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
                                         npvString.c_str());
             MonitorElement* mHistInJet =
                 ibooker.book1D(histName, Form(";%s;", axisString.c_str()), nBinsJet, binMinJet, binMaxJet);
-            map_of_MEs.insert(std::pair<std::string, MonitorElement*>(m_directory + "/PFCinJet/" + histName, mHistInJet));
+            map_of_MEs.insert(
+                std::pair<std::string, MonitorElement*>(m_directory + "/PFCinJet/" + histName, mHistInJet));
           }
         }
       }
@@ -398,7 +403,8 @@ void PFAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
                                                             pfInJetInfo.nBins,
                                                             pfInJetInfo.binMin,
                                                             pfInJetInfo.binMax);
-                map_of_MEs.insert(std::pair<std::string, MonitorElement*>(m_directory + "/PFCinJet/" + histName, mHistInJet));
+                map_of_MEs.insert(
+                    std::pair<std::string, MonitorElement*>(m_directory + "/PFCinJet/" + histName, mHistInJet));
               }
             }
           }
@@ -465,7 +471,8 @@ void PFAnalyzer::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup
 
 void PFAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("puppiWeight", edm::InputTag("puppi"))->setComment("The name of the puppi weight in the file");
+  desc.add<edm::InputTag>("puppiWeight", edm::InputTag("puppi"))
+      ->setComment("The name of the puppi weight in the file");
 
   desc.add<unsigned int>("runNumber", 0)->setComment("The run number (0 for no selection on the run)");
   desc.add<bool>("isMiniAOD", true)->setComment("Is the input file in miniAOD format? Alternative would be RECO");
@@ -481,7 +488,11 @@ void PFAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
       ->setComment("Input collection of primary vertices");
 
   edm::ParameterSetDescription pfAnalysisDesc;
-  pfAnalysisDesc.add<std::vector<std::string>>("pfNames", {"allPFC", "neutralHadPFC", "chargedHadPFC", "electronPFC", "muonPFC", "gammaPFC", "hadHFPFC", "emHFPFC"})->setComment("PF candidate types (e.g. allPFC, chargedHadPFC, etc");
+  pfAnalysisDesc
+      .add<std::vector<std::string>>(
+          "pfNames",
+          {"allPFC", "neutralHadPFC", "chargedHadPFC", "electronPFC", "muonPFC", "gammaPFC", "hadHFPFC", "emHFPFC"})
+      ->setComment("PF candidate types (e.g. allPFC, chargedHadPFC, etc");
   pfAnalysisDesc.add<std::vector<std::string>>("observables", std::vector<std::string>())
       ->setComment("List of PF candidate observables to monitor");
   pfAnalysisDesc.add<std::vector<std::string>>("eventObservables", std::vector<std::string>())
@@ -501,7 +512,6 @@ void PFAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
 
   descriptions.addWithDefaultLabel(desc);
 }
-
 
 // How many significant digits do we need to save for the values to be distinct?
 std::string PFAnalyzer::stringWithDecimals(int bin, std::vector<double> bins) {
@@ -688,7 +698,7 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   //Vertex information
   edm::Handle<reco::VertexCollection> vertexHandle;
   iEvent.getByToken(vertexToken_, vertexHandle);
-  if(m_runNumber !=0 && iEvent.run() != m_runNumber){
+  if (m_runNumber != 0 && iEvent.run() != m_runNumber) {
     return;
   }
   //std::cout << iEvent.run() << std::endl;
@@ -750,7 +760,7 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
       //reco::PFCandidatePtr cand =  (reco::PFCandidate*) (recoPfCollection->ptrAt(i));
       reco::PFCandidatePtr cand = (reco::PFCandidatePtr)(recoPfCollection->ptrAt(i));
       //pfCollection.push_back( recoPfCollection->ptrAt(i) );
-      pfCollection.push_back( cand );
+      pfCollection.push_back(cand);
       //pfCollection.push_back(*((*recoPfCollection)[i].ptr()));
     }
     numPFCands = recoPfCollection->size();
@@ -787,7 +797,7 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   if (!puppiWeightToken_.isUninitialized())
     iEvent.getByToken(puppiWeightToken_, puppiWeight);
 
-  if(!puppiWeight.isValid()){
+  if (!puppiWeight.isValid()) {
     edm::LogError("PFAnalyzer") << "invalid collection: Puppi weights \n";
   }
 
@@ -844,8 +854,8 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
         map_of_MEs[m_directory + "/PFCs/allPFC_" + histName]->Fill(val, eventWeight);
 
         if (partType == 0 && m_particleTypeName.find(recoPF.get()->particleId()) != m_particleTypeName.end()) {
-          map_of_MEs[m_directory + "/PFCs/" + m_particleTypeName[recoPF.get()->particleId()] + "_" + histName]->Fill(val,
-                                                                                                         eventWeight);
+          map_of_MEs[m_directory + "/PFCs/" + m_particleTypeName[recoPF.get()->particleId()] + "_" + histName]->Fill(
+              val, eventWeight);
         }
       }
     }
@@ -930,8 +940,9 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
             map_of_MEs[m_directory + "/PFCinJet/allPFC_jetMatched_" + histName]->Fill(
                 m_funcMap[m_observableNames[i]](recoPF, packedCand, cand, partType, puppiWeight), eventWeight);
             if (partType == 0 && m_particleTypeName.find(recoPF.get()->particleId()) != m_particleTypeName.end()) {
-              map_of_MEs[m_directory + "/PFCinJet/" + m_particleTypeName[recoPF.get()->particleId()] + "_jetMatched_" + histName]->Fill(
-                  m_funcMap[m_observableNames[i]](recoPF, packedCand, cand, partType, puppiWeight), eventWeight);
+              map_of_MEs[m_directory + "/PFCinJet/" + m_particleTypeName[recoPF.get()->particleId()] + "_jetMatched_" +
+                         histName]
+                  ->Fill(m_funcMap[m_observableNames[i]](recoPF, packedCand, cand, partType, puppiWeight), eventWeight);
             }
           }
 
@@ -945,8 +956,10 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
                 m_pfInJetFuncMap[m_pfInJetObservableNames[i]](recoPF, packedCand, cand, partType, cjet), eventWeight);
 
             if (partType == 0 && m_particleTypeName.find(recoPF.get()->particleId()) != m_particleTypeName.end()) {
-              map_of_MEs[m_directory + "/PFCinJet/" + m_particleTypeName[recoPF.get()->particleId()] + "_jetMatched_" + histName]->Fill(
-                  m_pfInJetFuncMap[m_pfInJetObservableNames[i]](recoPF, packedCand, cand, partType, cjet), eventWeight);
+              map_of_MEs[m_directory + "/PFCinJet/" + m_particleTypeName[recoPF.get()->particleId()] + "_jetMatched_" +
+                         histName]
+                  ->Fill(m_pfInJetFuncMap[m_pfInJetObservableNames[i]](recoPF, packedCand, cand, partType, cjet),
+                         eventWeight);
             }
           }
         }

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
@@ -241,7 +241,7 @@ void PFAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
     for (unsigned int m = 0; m < m_pfNames.size(); m++) {
       // For each observable, we make a couple histograms based on a few generic categorizations.
       // In all cases, the PFCs that go into these histograms must pass the PFC selection from m_cutList.
-      ibooker.setCurrentFolder(m_directory + "/DQM_PFCs_" + m_pfNames[m].c_str());
+      ibooker.setCurrentFolder(m_directory + "/DQM_PFCs_" + m_pfNames[m]);
       std::string histName =
           Form("%s_%s_%s", m_pfNames[m].c_str(), m_fullCutList2D[i][0].c_str(), m_fullCutList2D[i][1].c_str());
       MonitorElement* mHist =
@@ -282,7 +282,7 @@ void PFAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
           for (unsigned int m = 0; m < m_pfNames.size(); m++) {
             // For each observable, we make a couple histograms based on a few generic categorizations.
             // In all cases, the PFCs that go into these histograms must pass the PFC selection from m_cutList.
-            ibooker.setCurrentFolder(m_directory + "/DQM_PFCs_" + m_pfNames[m].c_str());
+            ibooker.setCurrentFolder(m_directory + "/DQM_PFCs_" + m_pfNames[m]);
             std::string histName = Form("%s_%s%s_%s",
                                         m_pfNames[m].c_str(),
                                         obsInfo.observable.c_str(),
@@ -352,7 +352,7 @@ void PFAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
         m_eventObservableNames.push_back(observableName);
 
       for (unsigned int m = 0; m < m_pfNames.size(); m++) {
-        ibooker.setCurrentFolder(m_directory + "/DQM_PFCs_" + m_pfNames[m].c_str());
+        ibooker.setCurrentFolder(m_directory + "/DQM_PFCs_" + m_pfNames[m]);
         std::string histName = Form("%s_%s_%s", m_pfNames[m].c_str(), observableName.c_str(), npvString.c_str());
         MonitorElement* mHist = ibooker.book1D(histName, Form(";%s;", axisString.c_str()), nBins, binMin, binMax);
         map_of_MEs.insert(std::pair<std::string, MonitorElement*>(m_directory + "/PFCs/" + histName, mHist));
@@ -363,7 +363,7 @@ void PFAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
           for (unsigned int m = 0; m < m_pfNames.size(); m++) {
             // These histograms are for PFCs passing the basic selection, and which are matched to jets
             // that pass the jet selection
-            ibooker.setCurrentFolder(m_directory + "/DQM_PFCs_" + m_pfNames[m].c_str());
+            ibooker.setCurrentFolder(m_directory + "/DQM_PFCs_" + m_pfNames[m]);
             std::string histName = Form("%s_jetMatched_%s_jetCuts%s_%s",
                                         m_pfNames[m].c_str(),
                                         observableName.c_str(),
@@ -389,7 +389,7 @@ void PFAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
           for (unsigned int k = 0; k < m_allJetSuffixes.size(); k++) {
             for (unsigned int p = 0; p < m_allJetSuffixes[k].size(); p++) {
               for (unsigned int m = 0; m < m_pfNames.size(); m++) {
-                ibooker.setCurrentFolder(m_directory + "/DQM_PFCs_" + m_pfNames[m].c_str());
+                ibooker.setCurrentFolder(m_directory + "/DQM_PFCs_" + m_pfNames[m]);
                 // These histograms are for PFCs passing the basic selection, and which are matched to jets
                 // that pass the jet selection
                 std::string histName = Form("%s_jetMatched_%s%s_jetCuts%s_%s",

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
@@ -797,7 +797,6 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   }
 
   if (!m_isMiniAOD) {
-    iEvent.getByToken(puppiWeightToken_, puppiWeight);
     if (!puppiWeightToken_.isUninitialized())
       iEvent.getByToken(puppiWeightToken_, puppiWeight);
 

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
@@ -796,7 +796,7 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     numPFCands = patPfCollection->size();
   }
 
-  if(!m_isMiniAOD){
+  if (!m_isMiniAOD) {
     iEvent.getByToken(puppiWeightToken_, puppiWeight);
     if (!puppiWeightToken_.isUninitialized())
       iEvent.getByToken(puppiWeightToken_, puppiWeight);
@@ -881,14 +881,14 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   map_of_MEs[m_directory + "/Event/NPV"]->Fill(numPV, eventWeight);
   reco::Jet leadJet;
 
-  if(numJets){
-  if (m_isMiniAOD) {
-    leadJet = jets[0];
-  } else {
-    leadJet = *pfJets->begin();
-  }
-  map_of_MEs[m_directory + Form("/JetKinematics/jetPtLead_%s", npvString.c_str())]->Fill(leadJet.pt(), eventWeight);
-  map_of_MEs[m_directory + Form("/JetKinematics/jetEtaLead_%s", npvString.c_str())]->Fill(leadJet.eta(), eventWeight);
+  if (numJets) {
+    if (m_isMiniAOD) {
+      leadJet = jets[0];
+    } else {
+      leadJet = *pfJets->begin();
+    }
+    map_of_MEs[m_directory + Form("/JetKinematics/jetPtLead_%s", npvString.c_str())]->Fill(leadJet.pt(), eventWeight);
+    map_of_MEs[m_directory + Form("/JetKinematics/jetEtaLead_%s", npvString.c_str())]->Fill(leadJet.eta(), eventWeight);
   }
 
   // Make plots of all observables, this time for PF candidates within jets

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
@@ -33,7 +33,6 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
 
   puppiWeightToken_ = consumes<edm::ValueMap<float>>(pSet.getParameter<edm::InputTag>("puppiWeight"));
 
-  //m_pfNames = {"allPFC", "neutralHadPFC", "chargedHadPFC", "electronPFC", "muonPFC", "gammaPFC", "hadHFPFC", "emHFPFC"};
   vertexTag_ = pSet.getParameter<edm::InputTag>("PVCollection");
   vertexToken_ = consumes<std::vector<reco::Vertex>>(edm::InputTag(vertexTag_));
 
@@ -59,11 +58,15 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   // Many of these are quite trivial, but this enables a simple way to include a
   // variety of observables on-the-fly.
   m_funcMap["pt"] = &getPt;
+  m_funcMap["logPt"] = &getLogPt;
   m_funcMap["energy"] = getEnergy;
   m_funcMap["eta"] = getEta;
   m_funcMap["abseta"] = getAbsEta;
   m_funcMap["phi"] = getPhi;
   m_funcMap["puppi"] = getPuppiWeight;
+  m_funcMap["puppiPt"] = getPuppiPt;
+  m_funcMap["logPuppiPt"] = getLogPuppiPt;
+  m_funcMap["puppiEta"] = getPuppiEta;
 
   m_funcMap["HCalE_depth1"] = getHcalEnergy_depth1;
   m_funcMap["HCalE_depth2"] = getHcalEnergy_depth2;
@@ -90,7 +93,6 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   m_funcMap["RelRawHCal_E"] = getRelRawHcalEnergy;
   m_funcMap["RelHO_E"] = getRelHOEnergy;
   m_funcMap["RelRawHO_E"] = getRelRawHOEnergy;
-
 
   m_funcMap["PFHad_calibration"] = getHadCalibration;
   m_funcMap["CellsInBlock"] = getCellsInBlock;
@@ -743,8 +745,6 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   }
   const edm::TriggerNames& triggerNames = iEvent.triggerNames(*triggerResults);
 
-  //edm::Handle<reco::PFCandidateCollection> recoPfCollection;
-  //edm::Handle<std::vector<edm::FwdPtr<reco::PFCandidate>>> recoPfCollection;
   edm::Handle<CandView> recoPfCollection;
 
   edm::Handle<pat::PackedCandidateCollection> patPfCollection;
@@ -763,13 +763,8 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
       return;
     }
     for (unsigned int i = 0; i < recoPfCollection->size(); i++) {
-      //pfCollection.push_back(recoPfCollection->at(i));
-      //reco::PFCandidate* cand =  (reco::PFCandidate*) (recoPfCollection->ptrAt(i).get());
-      //reco::PFCandidatePtr cand =  (reco::PFCandidate*) (recoPfCollection->ptrAt(i));
       reco::PFCandidatePtr cand = (reco::PFCandidatePtr)(recoPfCollection->ptrAt(i));
-      //pfCollection.push_back( recoPfCollection->ptrAt(i) );
       pfCollection.push_back(cand);
-      //pfCollection.push_back(*((*recoPfCollection)[i].ptr()));
     }
     numPFCands = recoPfCollection->size();
 
@@ -947,9 +942,7 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
                                         npvString.c_str());
             map_of_MEs[m_directory + "/PFCinJet/allPFC_jetMatched_" + histName]->Fill(
                 m_funcMap[m_observableNames[i]](recoPF, packedCand, cand, partType, puppiWeight), eventWeight);
-              //std::cout << recoPF.get()->particleId() << "\t" << pfConstits[iConstit]->particleId() << std::endl;;
             if (partType == 0 && m_particleTypeName.find(recoPF.get()->particleId()) != m_particleTypeName.end()) {
-              //std::cout << recoPF.get()->particleId() << "\t" <<  m_particleTypeName[recoPF.get()->particleId()] << std::endl;
               map_of_MEs[m_directory + "/PFCinJet/" + m_particleTypeName[recoPF.get()->particleId()] + "_jetMatched_" +
                          histName]
                   ->Fill(m_funcMap[m_observableNames[i]](recoPF, packedCand, cand, partType, puppiWeight), eventWeight);

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
@@ -796,12 +796,14 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     numPFCands = patPfCollection->size();
   }
 
-  iEvent.getByToken(puppiWeightToken_, puppiWeight);
-  if (!puppiWeightToken_.isUninitialized())
+  if(!m_isMiniAOD){
     iEvent.getByToken(puppiWeightToken_, puppiWeight);
+    if (!puppiWeightToken_.isUninitialized())
+      iEvent.getByToken(puppiWeightToken_, puppiWeight);
 
-  if (!puppiWeight.isValid()) {
-    edm::LogError("PFAnalyzer") << "invalid collection: Puppi weights \n";
+    if (!puppiWeight.isValid()) {
+      edm::LogError("PFAnalyzer") << "invalid collection: Puppi weights \n";
+    }
   }
 
   if (!passesTriggerSelection(jets, triggerResults, triggerNames, m_triggerOptions)) {
@@ -878,13 +880,16 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   // Plots for generic debugging
   map_of_MEs[m_directory + "/Event/NPV"]->Fill(numPV, eventWeight);
   reco::Jet leadJet;
+
+  if(numJets){
   if (m_isMiniAOD) {
-    leadJet = *patJets->begin();
+    leadJet = jets[0];
   } else {
     leadJet = *pfJets->begin();
   }
   map_of_MEs[m_directory + Form("/JetKinematics/jetPtLead_%s", npvString.c_str())]->Fill(leadJet.pt(), eventWeight);
   map_of_MEs[m_directory + Form("/JetKinematics/jetEtaLead_%s", npvString.c_str())]->Fill(leadJet.eta(), eventWeight);
+  }
 
   // Make plots of all observables, this time for PF candidates within jets
   for (unsigned int index = 0; index < numJets; index++) {

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
@@ -120,7 +120,7 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   m_funcMap["trk_ptError"] = getTrackPtError;
   m_funcMap["trk_relPtError"] = getTrackRelPtError;
   m_funcMap["trk_d0"] = getTrackD0;
-  m_funcMap["trk_z0"] = getTrackZ0;
+  m_funcMap["trk_dz"] = getTrackDZ;
   m_funcMap["trk_thetaError"] = getTrackThetaError;
   m_funcMap["trk_etaError"] = getTrackEtaError;
   m_funcMap["trk_phiError"] = getTrackPhiError;

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
@@ -83,7 +83,17 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   m_funcMap["RawHCal_E"] = getRawHcalEnergy;
   m_funcMap["HO_E"] = getHOEnergy;
   m_funcMap["RawHO_E"] = getRawHOEnergy;
+
+  m_funcMap["RelECal_E"] = getRelEcalEnergy;
+  m_funcMap["RelRawECal_E"] = getRelRawEcalEnergy;
+  m_funcMap["RelHCal_E"] = getRelHcalEnergy;
+  m_funcMap["RelRawHCal_E"] = getRelRawHcalEnergy;
+  m_funcMap["RelHO_E"] = getRelHOEnergy;
+  m_funcMap["RelRawHO_E"] = getRelRawHOEnergy;
+
+
   m_funcMap["PFHad_calibration"] = getHadCalibration;
+  m_funcMap["CellsInBlock"] = getCellsInBlock;
 
   m_funcMap["MVAIsolated"] = getMVAIsolated;
   m_funcMap["MVAEPi"] = getMVAEPi;
@@ -99,7 +109,6 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   m_funcMap["DNNEBkgTauIsolated"] = getDNNEBkgTauIsolated;
   m_funcMap["DNNEBkgPhotonIsolated"] = getDNNEBkgPhotonIsolated;
 
-  m_funcMap["hcalE"] = getHCalEnergy;
   m_funcMap["eOverP"] = getEoverP;
   m_funcMap["nTrkInBlock"] = getNTracksInBlock;
 
@@ -129,17 +138,17 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   if (std::find(m_pfNames.begin(), m_pfNames.end(), "chargedHadPFC") != m_pfNames.end())
     m_particleTypeName[reco::PFCandidate::ParticleType::h] = "chargedHadPFC";
   if (std::find(m_pfNames.begin(), m_pfNames.end(), "neutralHadPFC") != m_pfNames.end())
-    m_particleTypeName[reco::PFCandidate::ParticleType::h] = "neutralHadPFC";
+    m_particleTypeName[reco::PFCandidate::ParticleType::h0] = "neutralHadPFC";
   if (std::find(m_pfNames.begin(), m_pfNames.end(), "electronPFC") != m_pfNames.end())
-    m_particleTypeName[reco::PFCandidate::ParticleType::h] = "electronPFC";
+    m_particleTypeName[reco::PFCandidate::ParticleType::e] = "electronPFC";
   if (std::find(m_pfNames.begin(), m_pfNames.end(), "muonPFC") != m_pfNames.end())
-    m_particleTypeName[reco::PFCandidate::ParticleType::h] = "muonPFC";
+    m_particleTypeName[reco::PFCandidate::ParticleType::mu] = "muonPFC";
   if (std::find(m_pfNames.begin(), m_pfNames.end(), "gammaPFC") != m_pfNames.end())
-    m_particleTypeName[reco::PFCandidate::ParticleType::h] = "gammaPFC";
+    m_particleTypeName[reco::PFCandidate::ParticleType::gamma] = "gammaPFC";
   if (std::find(m_pfNames.begin(), m_pfNames.end(), "hadHFPFC") != m_pfNames.end())
-    m_particleTypeName[reco::PFCandidate::ParticleType::h] = "hadHFPFC";
+    m_particleTypeName[reco::PFCandidate::ParticleType::h_HF] = "hadHFPFC";
   if (std::find(m_pfNames.begin(), m_pfNames.end(), "emHFPFC") != m_pfNames.end())
-    m_particleTypeName[reco::PFCandidate::ParticleType::h] = "emHFPFC";
+    m_particleTypeName[reco::PFCandidate::ParticleType::egamma_HF] = "emHFPFC";
 
   // Convert the cutList strings into real cuts that can be applied
   // The format should be three comma separated values
@@ -701,7 +710,6 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   if (m_runNumber != 0 && iEvent.run() != m_runNumber) {
     return;
   }
-  //std::cout << iEvent.run() << std::endl;
 
   if (!vertexHandle.isValid()) {
     LogDebug("") << "PFAnalyzer: Could not find vertex collection" << std::endl;
@@ -939,7 +947,9 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
                                         npvString.c_str());
             map_of_MEs[m_directory + "/PFCinJet/allPFC_jetMatched_" + histName]->Fill(
                 m_funcMap[m_observableNames[i]](recoPF, packedCand, cand, partType, puppiWeight), eventWeight);
+              //std::cout << recoPF.get()->particleId() << "\t" << pfConstits[iConstit]->particleId() << std::endl;;
             if (partType == 0 && m_particleTypeName.find(recoPF.get()->particleId()) != m_particleTypeName.end()) {
+              //std::cout << recoPF.get()->particleId() << "\t" <<  m_particleTypeName[recoPF.get()->particleId()] << std::endl;
               map_of_MEs[m_directory + "/PFCinJet/" + m_particleTypeName[recoPF.get()->particleId()] + "_jetMatched_" +
                          histName]
                   ->Fill(m_funcMap[m_observableNames[i]](recoPF, packedCand, cand, partType, puppiWeight), eventWeight);

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
@@ -136,7 +136,7 @@ private:
     if(partType == 1){
       return packedPart.pt() / jet.pt();
     }
-    if(partType == 1){
+    if(partType == 2){
       return cand->pt() / jet.pt();
     }
     return -1;
@@ -199,83 +199,101 @@ private:
                       const pat::PackedCandidate packedPart,
                       const reco::CandidatePtr cand,
                       int partType, edm::Handle<edm::ValueMap<float>>) {
+    if (partType == 0) {
+      return pfCand.get()->pt();
+    }
     if (partType == 1) {
       return packedPart.pt();
     }
     if (partType == 2) {
       return cand->pt();
     }
-    return pfCand.get()->pt();
+    return -1;
   }
 
   static double getEnergy(const reco::PFCandidatePtr pfCand,
                           const pat::PackedCandidate packedPart,
                           const reco::CandidatePtr cand,
                           int partType, edm::Handle<edm::ValueMap<float>>) {
+    if (partType == 0) {
+      return pfCand.get()->energy();
+    }
     if (partType == 1) {
       return packedPart.energy();
     }
     if (partType == 2){
       return cand->energy();
     }
-    return pfCand.get()->energy();
+    return -1;
   }
   static double getEta(const reco::PFCandidatePtr pfCand,
                        const pat::PackedCandidate packedPart,
                        const reco::CandidatePtr cand,
                        int partType, edm::Handle<edm::ValueMap<float>>) {
+    if (partType == 0) {
+      return pfCand.get()->eta();
+    }
     if (partType == 1) {
       return packedPart.eta();
     }
     if (partType == 2) {
       return cand->eta();
     }
-    return pfCand.get()->eta();
+    return -1;
   }
   static double getAbsEta(const reco::PFCandidatePtr pfCand,
                           const pat::PackedCandidate packedPart,
                           const reco::CandidatePtr cand,
                           int partType, edm::Handle<edm::ValueMap<float>>) {
+    if (partType == 0) {
+      return std::abs(pfCand.get()->eta());
+    }
     if (partType == 1) {
       return std::abs(packedPart.eta());
     }
     if (partType == 2) {
       return std::abs(cand->eta());
     }
-    return std::abs(pfCand.get()->eta());
+    return -1;
   }
   static double getPhi(const reco::PFCandidatePtr pfCand,
                        const pat::PackedCandidate packedPart,
                        const reco::CandidatePtr cand,
                        int partType, edm::Handle<edm::ValueMap<float>>) {
+    if (partType == 0) {
+      return pfCand.get()->phi();
+    }
     if (partType == 1) {
       return packedPart.phi();
     }
     if (partType == 2) {
       return cand->phi();
     }
-    return pfCand.get()->phi();
+    return -1;
   }
 
   static double getHadCalibration(const reco::PFCandidatePtr pfCand,
                                   const pat::PackedCandidate packedPart,
                                   const reco::CandidatePtr cand,
                                   int partType, edm::Handle<edm::ValueMap<float>>) {
-    if (pfCand.get()->rawHcalEnergy() == 0)
-      return -1;
-    return pfCand.get()->hcalEnergy() / pfCand.get()->rawHcalEnergy();
+    if (partType == 0 ){
+      if (pfCand.get()->rawHcalEnergy() == 0)
+        return -1;
+      return pfCand.get()->hcalEnergy() / pfCand.get()->rawHcalEnergy();
+    }
+    return -1;
   }
   static double getPuppiWeight(const reco::PFCandidatePtr pfCand,
                                const pat::PackedCandidate packedPart,
                                const reco::CandidatePtr cand,
                                int partType, edm::Handle<edm::ValueMap<float>> puppiWeight) {
-    if (partType == 1) {
-      return packedPart.puppiWeight();
-    }
     if (partType == 0 ){
       return (*puppiWeight)[pfCand];
     }
-    return 1;
+    if (partType == 1) {
+      return packedPart.puppiWeight();
+    }
+    return -1;
   }
 
   static double getTime(const reco::PFCandidatePtr pfCand,
@@ -295,87 +313,120 @@ private:
                                      const pat::PackedCandidate packedPart,
                                      const reco::CandidatePtr cand,
                                      int partType, edm::Handle<edm::ValueMap<float>>) {
-    return pfCand.get()->hcalDepthEnergyFraction(1);
+    if (partType == 0) {
+      return pfCand.get()->hcalDepthEnergyFraction(1);
+    }
+    return -1;
   }
   static double getHcalEnergy_depth2(const reco::PFCandidatePtr pfCand,
                                      const pat::PackedCandidate packedPart,
                                      const reco::CandidatePtr cand,
                                      int partType, edm::Handle<edm::ValueMap<float>>) {
-    return pfCand.get()->hcalDepthEnergyFraction(2);
+    if (partType == 0) {
+      return pfCand.get()->hcalDepthEnergyFraction(2);
+    }
+    return -1;
   }
   static double getHcalEnergy_depth3(const reco::PFCandidatePtr pfCand,
                                      const pat::PackedCandidate packedPart,
                                      const reco::CandidatePtr cand,
                                      int partType, edm::Handle<edm::ValueMap<float>>) {
-    return pfCand.get()->hcalDepthEnergyFraction(3);
+    if (partType == 0) {
+      return pfCand.get()->hcalDepthEnergyFraction(3);
+    }
+    return -1;
   }
   static double getHcalEnergy_depth4(const reco::PFCandidatePtr pfCand,
                                      const pat::PackedCandidate packedPart,
                                      const reco::CandidatePtr cand,
                                      int partType, edm::Handle<edm::ValueMap<float>>) {
-    return pfCand.get()->hcalDepthEnergyFraction(4);
+    if (partType == 0) {
+      return pfCand.get()->hcalDepthEnergyFraction(4);
+    }
+    return -1;
   }
   static double getHcalEnergy_depth5(const reco::PFCandidatePtr pfCand,
                                      const pat::PackedCandidate packedPart,
                                      const reco::CandidatePtr cand,
                                      int partType, edm::Handle<edm::ValueMap<float>>) {
-    return pfCand.get()->hcalDepthEnergyFraction(5);
+    if (partType == 0) {
+      return pfCand.get()->hcalDepthEnergyFraction(5);
+    }
+    return -1;
   }
   static double getHcalEnergy_depth6(const reco::PFCandidatePtr pfCand,
                                      const pat::PackedCandidate packedPart,
                                      const reco::CandidatePtr cand,
                                      int partType, edm::Handle<edm::ValueMap<float>>) {
-    return pfCand.get()->hcalDepthEnergyFraction(6);
+    if (partType == 0) {
+      return pfCand.get()->hcalDepthEnergyFraction(6);
+    }
+    return -1;
   }
   static double getHcalEnergy_depth7(const reco::PFCandidatePtr pfCand,
                                      const pat::PackedCandidate packedPart,
                                      const reco::CandidatePtr cand,
                                      int partType, edm::Handle<edm::ValueMap<float>>) {
-    return pfCand.get()->hcalDepthEnergyFraction(7);
+    if (partType == 0) {
+      return pfCand.get()->hcalDepthEnergyFraction(7);
+    }
+    return -1;
   }
 
   static double getEcalEnergy(const reco::PFCandidatePtr pfCand,
                               const pat::PackedCandidate packedPart,
                               const reco::CandidatePtr cand,
                               int partType, edm::Handle<edm::ValueMap<float>>) {
+    if (partType == 0) {
+      return pfCand.get()->ecalEnergy();
+    }
     if (partType == 1) {
       return (1.0 - packedPart.hcalFraction()) * packedPart.energy();
     }
-    return pfCand.get()->ecalEnergy();
+    return -1;
   }
   static double getRawEcalEnergy(const reco::PFCandidatePtr pfCand,
                                  const pat::PackedCandidate packedPart,
                                  const reco::CandidatePtr cand,
                                  int partType, edm::Handle<edm::ValueMap<float>>) {
+    if (partType == 0) {
+      return pfCand.get()->rawEcalEnergy();
+    }
     if (partType == 1) {
       return (1.0 - packedPart.rawHcalFraction()) * packedPart.energy();
     }
-    return pfCand.get()->rawEcalEnergy();
+    return -1;
   }
   static double getHcalEnergy(const reco::PFCandidatePtr pfCand,
                               const pat::PackedCandidate packedPart,
                               const reco::CandidatePtr cand,
                               int partType, edm::Handle<edm::ValueMap<float>>) {
+    if (partType == 0) {
+      return pfCand.get()->hcalEnergy();
+    }
     if (partType == 1) {
       return packedPart.hcalFraction() * packedPart.energy();
     }
-    return pfCand.get()->hcalEnergy();
+    return -1;
   }
   static double getRawHcalEnergy(const reco::PFCandidatePtr pfCand,
                                  const pat::PackedCandidate packedPart,
                                  const reco::CandidatePtr cand,
                                  int partType, edm::Handle<edm::ValueMap<float>>) {
+    if (partType == 0) {
+      return pfCand.get()->rawHcalEnergy();
+    }
     if (partType == 1) {
       return packedPart.rawHcalFraction() * packedPart.energy();
     }
-    return pfCand.get()->rawHcalEnergy();
+    return -1;
   }
   static double getHOEnergy(const reco::PFCandidatePtr pfCand,
                             const pat::PackedCandidate packedPart,
                             const reco::CandidatePtr cand,
                             int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     return pfCand.get()->hoEnergy();
   }
@@ -384,7 +435,7 @@ private:
                                const reco::CandidatePtr cand,
                                int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     return pfCand.get()->rawHoEnergy();
   }
@@ -394,7 +445,7 @@ private:
                                const reco::CandidatePtr cand,
                                int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     return pfCand.get()->mva_Isolated();
   }
@@ -403,7 +454,7 @@ private:
                           const reco::CandidatePtr cand,
                           int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     return pfCand.get()->mva_e_pi();
   }
@@ -412,7 +463,7 @@ private:
                           const reco::CandidatePtr cand,
                           int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     return pfCand.get()->mva_e_mu();
   }
@@ -421,7 +472,7 @@ private:
                            const reco::CandidatePtr cand,
                            int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     return pfCand.get()->mva_pi_mu();
   }
@@ -430,7 +481,7 @@ private:
                                    const reco::CandidatePtr cand,
                                    int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     return pfCand.get()->mva_nothing_gamma();
   }
@@ -439,7 +490,7 @@ private:
                                 const reco::CandidatePtr cand,
                                 int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     return pfCand.get()->mva_nothing_nh();
   }
@@ -448,7 +499,7 @@ private:
                               const reco::CandidatePtr cand,
                               int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     return pfCand.get()->mva_gamma_nh();
   }
@@ -458,7 +509,7 @@ private:
                                    const reco::CandidatePtr cand,
                                    int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     return pfCand.get()->dnn_e_sigIsolated();
   }
@@ -467,7 +518,7 @@ private:
                                       const reco::CandidatePtr cand,
                                       int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     return pfCand.get()->dnn_e_sigNonIsolated();
   }
@@ -476,7 +527,7 @@ private:
                                       const reco::CandidatePtr cand,
                                       int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     return pfCand.get()->dnn_e_bkgNonIsolated();
   }
@@ -485,7 +536,7 @@ private:
                                       const reco::CandidatePtr cand,
                                       int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     return pfCand.get()->dnn_e_bkgTau();
   }
@@ -494,7 +545,7 @@ private:
                                          const reco::CandidatePtr cand,
                                          int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     return pfCand.get()->dnn_e_bkgPhoton();
   }
@@ -504,7 +555,7 @@ private:
                              const reco::CandidatePtr cand,
                              int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     return pfCand.get()->ecalEnergy() / pfCand.get()->energy();
   }
@@ -513,7 +564,7 @@ private:
                              const reco::CandidatePtr cand,
                              int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     return pfCand.get()->hcalEnergy() / pfCand.get()->energy();
   }
@@ -522,7 +573,7 @@ private:
                              const reco::CandidatePtr cand,
                              int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     return pfCand.get()->pS1Energy();
   }
@@ -531,7 +582,7 @@ private:
                              const reco::CandidatePtr cand,
                              int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     return pfCand.get()->pS2Energy();
   }
@@ -540,7 +591,7 @@ private:
                             const reco::CandidatePtr cand,
                             int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     return pfCand.get()->pS1Energy() + pfCand.get()->pS2Energy();
   }
@@ -550,11 +601,11 @@ private:
                            const reco::CandidatePtr cand,
                            int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     if (pfCand.get()->trackRef().isNonnull())
       return (pfCand.get()->trackRef())->pt();
-    return 0;
+    return -1;
   }
 
   static double getTrackNStripHits(const reco::PFCandidatePtr pfCand,
@@ -562,7 +613,7 @@ private:
                                    const reco::CandidatePtr cand,
                                    int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     if (pfCand.get()->trackRef().isNonnull())
       return (pfCand.get()->trackRef())->hitPattern().numberOfValidStripHits();
@@ -574,7 +625,7 @@ private:
                                  const reco::CandidatePtr cand,
                                  int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     if (pfCand.get()->trackRef().isNonnull())
       return (pfCand.get()->trackRef())->hitPattern().numberOfValidPixelHits();
@@ -587,7 +638,7 @@ private:
                              const reco::CandidatePtr cand,
                              int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     if (pfCand.get()->trackRef().isNonnull())
       return (pfCand.get()->trackRef())->chi2();
@@ -599,7 +650,7 @@ private:
                                 const reco::CandidatePtr cand,
                                 int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     if (pfCand.get()->trackRef().isNonnull())
       return (pfCand.get()->trackRef())->ptError();
@@ -611,7 +662,7 @@ private:
                                    const reco::CandidatePtr cand,
                                    int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     if (pfCand.get()->trackRef().isNonnull())
       return (pfCand.get()->trackRef())->ptError() / (pfCand->trackRef())->pt();
@@ -623,7 +674,7 @@ private:
                            const reco::CandidatePtr cand,
                            int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     if (pfCand.get()->trackRef().isNonnull())
       return (pfCand.get()->trackRef())->d0();
@@ -635,7 +686,7 @@ private:
                            const reco::CandidatePtr cand,
                            int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     if (pfCand.get()->trackRef().isNonnull())
       return (pfCand.get()->trackRef())->d0();
@@ -647,7 +698,7 @@ private:
                                    const reco::CandidatePtr cand,
                                    int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     if (pfCand.get()->trackRef().isNonnull())
       return (pfCand.get()->trackRef())->thetaError();
@@ -659,7 +710,7 @@ private:
                                  const reco::CandidatePtr cand,
                                  int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     if (pfCand.get()->trackRef().isNonnull())
       return (pfCand.get()->trackRef())->etaError();
@@ -671,7 +722,7 @@ private:
                                  const reco::CandidatePtr cand,
                                  int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     if (pfCand.get()->trackRef().isNonnull())
       return (pfCand.get()->trackRef())->phiError();
@@ -683,7 +734,7 @@ private:
                           const reco::CandidatePtr cand,
                           int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     double energy = 0;
     int maxElement = pfCand.get()->elementsInBlocks().size();
@@ -710,7 +761,7 @@ private:
                               const reco::CandidatePtr cand,
                               int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     double energy = 0;
     int maxElement = pfCand.get()->elementsInBlocks().size();
@@ -737,7 +788,7 @@ private:
                               const reco::CandidatePtr cand,
                               int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     double energy = 0;
     int maxElement = pfCand.get()->elementsInBlocks().size();
@@ -765,7 +816,7 @@ private:
                                   const reco::CandidatePtr cand,
                                   int partType, edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
-      return 0;
+      return -1;
     }
     // We need this function to return a double, even though this is an integer value
     double nTrack = 0;

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
@@ -94,7 +94,7 @@ private:
                const std::vector<reco::PFCandidatePtr> pfCands, reco::PFCandidate::ParticleType pfType, const reco::Jet)>>
       m_jetWideFuncMap;
 
-  std::map<std::string, std::function<double(const reco::PFCandidatePtr, const reco::Jet)>> m_pfInJetFuncMap;
+  std::map<std::string, std::function<double(const reco::PFCandidatePtr, const pat::PackedCandidate, const reco::CandidatePtr, int, const reco::Jet)>> m_pfInJetFuncMap;
   std::map<std::string, std::function<double(const reco::Jet, const std::vector<reco::PFCandidatePtr> pfCands)>>
       m_jetFuncMap;
 
@@ -125,10 +125,21 @@ private:
                         std::vector<std::string> observables,
                         std::vector<std::vector<double>> binnings);
 
-  static double getEnergySpectrum(const reco::PFCandidatePtr pfCand, const reco::Jet jet) {
+
+
+  static double getEnergySpectrum(const reco::PFCandidatePtr pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType, const reco::Jet jet) {
     if (!jet.pt())
       return -1;
-    return pfCand.get()->pt() / jet.pt();
+    if(partType==0){
+      return pfCand.get()->pt() / jet.pt();
+    }
+    if(partType == 1){
+      return packedPart.pt() / jet.pt();
+    }
+    if(partType == 1){
+      return cand->pt() / jet.pt();
+    }
+    return -1;
   }
 
   static double getNPFC(const std::vector<reco::PFCandidatePtr> pfCands, reco::PFCandidate::ParticleType pfType) {
@@ -204,6 +215,9 @@ private:
     if (partType == 1) {
       return packedPart.energy();
     }
+    if (partType == 2){
+      return cand->energy();
+    }
     return pfCand.get()->energy();
   }
   static double getEta(const reco::PFCandidatePtr pfCand,
@@ -271,7 +285,10 @@ private:
     if (partType == 1) {
       return packedPart.time();
     }
-    return pfCand.get()->time();
+    if (partType == 0) {
+      return pfCand.get()->time();
+    }
+    return -1;
   }
 
   static double getHcalEnergy_depth1(const reco::PFCandidatePtr pfCand,
@@ -886,6 +903,7 @@ private:
   // the lowest and highest values for the histogram.
   // The observable name should have an entry in m_funcMap to define how
   // it can be retrieved from a PFCandidate.
+  vstring m_pfNames;
   vstring m_observables;
   vstring m_eventObservables;
   vstring m_pfInJetObservables;
@@ -925,7 +943,7 @@ private:
   // Making this configurable is useful in case you want to look at the core of a jet.
   double m_matchingRadius;
 
-  std::vector<std::string> m_pfNames;
+  //std::vector<std::string> m_pfNames;
 };
 
 struct PFAnalyzer::binInfo {

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
@@ -83,7 +83,11 @@ private:
   // This allows us to construct more complicated observables easily, and have it more configurable
   // in the config file.
   std::map<std::string,
-           std::function<double(const reco::PFCandidatePtr, const pat::PackedCandidate, const reco::CandidatePtr, int, edm::Handle<edm::ValueMap<float>> )>>
+           std::function<double(const reco::PFCandidatePtr,
+                                const pat::PackedCandidate,
+                                const reco::CandidatePtr,
+                                int,
+                                edm::Handle<edm::ValueMap<float>>)>>
       m_funcMap;
   std::map<std::string,
            std::function<double(const std::vector<reco::PFCandidatePtr>, reco::PFCandidate::ParticleType pfType)>>
@@ -94,7 +98,10 @@ private:
                const std::vector<reco::PFCandidatePtr> pfCands, reco::PFCandidate::ParticleType pfType, const reco::Jet)>>
       m_jetWideFuncMap;
 
-  std::map<std::string, std::function<double(const reco::PFCandidatePtr, const pat::PackedCandidate, const reco::CandidatePtr, int, const reco::Jet)>> m_pfInJetFuncMap;
+  std::map<std::string,
+           std::function<double(
+               const reco::PFCandidatePtr, const pat::PackedCandidate, const reco::CandidatePtr, int, const reco::Jet)>>
+      m_pfInJetFuncMap;
   std::map<std::string, std::function<double(const reco::Jet, const std::vector<reco::PFCandidatePtr> pfCands)>>
       m_jetFuncMap;
 
@@ -125,18 +132,20 @@ private:
                         std::vector<std::string> observables,
                         std::vector<std::vector<double>> binnings);
 
-
-
-  static double getEnergySpectrum(const reco::PFCandidatePtr pfCand, const pat::PackedCandidate packedPart, const reco::CandidatePtr cand, int partType, const reco::Jet jet) {
+  static double getEnergySpectrum(const reco::PFCandidatePtr pfCand,
+                                  const pat::PackedCandidate packedPart,
+                                  const reco::CandidatePtr cand,
+                                  int partType,
+                                  const reco::Jet jet) {
     if (!jet.pt())
       return -1;
-    if(partType==0){
+    if (partType == 0) {
       return pfCand.get()->pt() / jet.pt();
     }
-    if(partType == 1){
+    if (partType == 1) {
       return packedPart.pt() / jet.pt();
     }
-    if(partType == 2){
+    if (partType == 2) {
       return cand->pt() / jet.pt();
     }
     return -1;
@@ -198,7 +207,8 @@ private:
   static double getPt(const reco::PFCandidatePtr pfCand,
                       const pat::PackedCandidate packedPart,
                       const reco::CandidatePtr cand,
-                      int partType, edm::Handle<edm::ValueMap<float>>) {
+                      int partType,
+                      edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
       return pfCand.get()->pt();
     }
@@ -214,14 +224,15 @@ private:
   static double getEnergy(const reco::PFCandidatePtr pfCand,
                           const pat::PackedCandidate packedPart,
                           const reco::CandidatePtr cand,
-                          int partType, edm::Handle<edm::ValueMap<float>>) {
+                          int partType,
+                          edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
       return pfCand.get()->energy();
     }
     if (partType == 1) {
       return packedPart.energy();
     }
-    if (partType == 2){
+    if (partType == 2) {
       return cand->energy();
     }
     return -1;
@@ -229,7 +240,8 @@ private:
   static double getEta(const reco::PFCandidatePtr pfCand,
                        const pat::PackedCandidate packedPart,
                        const reco::CandidatePtr cand,
-                       int partType, edm::Handle<edm::ValueMap<float>>) {
+                       int partType,
+                       edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
       return pfCand.get()->eta();
     }
@@ -244,7 +256,8 @@ private:
   static double getAbsEta(const reco::PFCandidatePtr pfCand,
                           const pat::PackedCandidate packedPart,
                           const reco::CandidatePtr cand,
-                          int partType, edm::Handle<edm::ValueMap<float>>) {
+                          int partType,
+                          edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
       return std::abs(pfCand.get()->eta());
     }
@@ -259,7 +272,8 @@ private:
   static double getPhi(const reco::PFCandidatePtr pfCand,
                        const pat::PackedCandidate packedPart,
                        const reco::CandidatePtr cand,
-                       int partType, edm::Handle<edm::ValueMap<float>>) {
+                       int partType,
+                       edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
       return pfCand.get()->phi();
     }
@@ -275,8 +289,9 @@ private:
   static double getHadCalibration(const reco::PFCandidatePtr pfCand,
                                   const pat::PackedCandidate packedPart,
                                   const reco::CandidatePtr cand,
-                                  int partType, edm::Handle<edm::ValueMap<float>>) {
-    if (partType == 0 ){
+                                  int partType,
+                                  edm::Handle<edm::ValueMap<float>>) {
+    if (partType == 0) {
       if (pfCand.get()->rawHcalEnergy() == 0)
         return -1;
       return pfCand.get()->hcalEnergy() / pfCand.get()->rawHcalEnergy();
@@ -286,8 +301,9 @@ private:
   static double getPuppiWeight(const reco::PFCandidatePtr pfCand,
                                const pat::PackedCandidate packedPart,
                                const reco::CandidatePtr cand,
-                               int partType, edm::Handle<edm::ValueMap<float>> puppiWeight) {
-    if (partType == 0 ){
+                               int partType,
+                               edm::Handle<edm::ValueMap<float>> puppiWeight) {
+    if (partType == 0) {
       return (*puppiWeight)[pfCand];
     }
     if (partType == 1) {
@@ -299,7 +315,8 @@ private:
   static double getTime(const reco::PFCandidatePtr pfCand,
                         const pat::PackedCandidate packedPart,
                         const reco::CandidatePtr cand,
-                        int partType, edm::Handle<edm::ValueMap<float>>) {
+                        int partType,
+                        edm::Handle<edm::ValueMap<float>>) {
     if (partType == 1) {
       return packedPart.time();
     }
@@ -312,7 +329,8 @@ private:
   static double getHcalEnergy_depth1(const reco::PFCandidatePtr pfCand,
                                      const pat::PackedCandidate packedPart,
                                      const reco::CandidatePtr cand,
-                                     int partType, edm::Handle<edm::ValueMap<float>>) {
+                                     int partType,
+                                     edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
       return pfCand.get()->hcalDepthEnergyFraction(1);
     }
@@ -321,7 +339,8 @@ private:
   static double getHcalEnergy_depth2(const reco::PFCandidatePtr pfCand,
                                      const pat::PackedCandidate packedPart,
                                      const reco::CandidatePtr cand,
-                                     int partType, edm::Handle<edm::ValueMap<float>>) {
+                                     int partType,
+                                     edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
       return pfCand.get()->hcalDepthEnergyFraction(2);
     }
@@ -330,7 +349,8 @@ private:
   static double getHcalEnergy_depth3(const reco::PFCandidatePtr pfCand,
                                      const pat::PackedCandidate packedPart,
                                      const reco::CandidatePtr cand,
-                                     int partType, edm::Handle<edm::ValueMap<float>>) {
+                                     int partType,
+                                     edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
       return pfCand.get()->hcalDepthEnergyFraction(3);
     }
@@ -339,7 +359,8 @@ private:
   static double getHcalEnergy_depth4(const reco::PFCandidatePtr pfCand,
                                      const pat::PackedCandidate packedPart,
                                      const reco::CandidatePtr cand,
-                                     int partType, edm::Handle<edm::ValueMap<float>>) {
+                                     int partType,
+                                     edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
       return pfCand.get()->hcalDepthEnergyFraction(4);
     }
@@ -348,7 +369,8 @@ private:
   static double getHcalEnergy_depth5(const reco::PFCandidatePtr pfCand,
                                      const pat::PackedCandidate packedPart,
                                      const reco::CandidatePtr cand,
-                                     int partType, edm::Handle<edm::ValueMap<float>>) {
+                                     int partType,
+                                     edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
       return pfCand.get()->hcalDepthEnergyFraction(5);
     }
@@ -357,7 +379,8 @@ private:
   static double getHcalEnergy_depth6(const reco::PFCandidatePtr pfCand,
                                      const pat::PackedCandidate packedPart,
                                      const reco::CandidatePtr cand,
-                                     int partType, edm::Handle<edm::ValueMap<float>>) {
+                                     int partType,
+                                     edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
       return pfCand.get()->hcalDepthEnergyFraction(6);
     }
@@ -366,7 +389,8 @@ private:
   static double getHcalEnergy_depth7(const reco::PFCandidatePtr pfCand,
                                      const pat::PackedCandidate packedPart,
                                      const reco::CandidatePtr cand,
-                                     int partType, edm::Handle<edm::ValueMap<float>>) {
+                                     int partType,
+                                     edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
       return pfCand.get()->hcalDepthEnergyFraction(7);
     }
@@ -376,7 +400,8 @@ private:
   static double getEcalEnergy(const reco::PFCandidatePtr pfCand,
                               const pat::PackedCandidate packedPart,
                               const reco::CandidatePtr cand,
-                              int partType, edm::Handle<edm::ValueMap<float>>) {
+                              int partType,
+                              edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
       return pfCand.get()->ecalEnergy();
     }
@@ -388,7 +413,8 @@ private:
   static double getRawEcalEnergy(const reco::PFCandidatePtr pfCand,
                                  const pat::PackedCandidate packedPart,
                                  const reco::CandidatePtr cand,
-                                 int partType, edm::Handle<edm::ValueMap<float>>) {
+                                 int partType,
+                                 edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
       return pfCand.get()->rawEcalEnergy();
     }
@@ -400,7 +426,8 @@ private:
   static double getHcalEnergy(const reco::PFCandidatePtr pfCand,
                               const pat::PackedCandidate packedPart,
                               const reco::CandidatePtr cand,
-                              int partType, edm::Handle<edm::ValueMap<float>>) {
+                              int partType,
+                              edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
       return pfCand.get()->hcalEnergy();
     }
@@ -412,7 +439,8 @@ private:
   static double getRawHcalEnergy(const reco::PFCandidatePtr pfCand,
                                  const pat::PackedCandidate packedPart,
                                  const reco::CandidatePtr cand,
-                                 int partType, edm::Handle<edm::ValueMap<float>>) {
+                                 int partType,
+                                 edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
       return pfCand.get()->rawHcalEnergy();
     }
@@ -424,7 +452,8 @@ private:
   static double getHOEnergy(const reco::PFCandidatePtr pfCand,
                             const pat::PackedCandidate packedPart,
                             const reco::CandidatePtr cand,
-                            int partType, edm::Handle<edm::ValueMap<float>>) {
+                            int partType,
+                            edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -433,7 +462,8 @@ private:
   static double getRawHOEnergy(const reco::PFCandidatePtr pfCand,
                                const pat::PackedCandidate packedPart,
                                const reco::CandidatePtr cand,
-                               int partType, edm::Handle<edm::ValueMap<float>>) {
+                               int partType,
+                               edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -443,7 +473,8 @@ private:
   static double getMVAIsolated(const reco::PFCandidatePtr pfCand,
                                const pat::PackedCandidate packedPart,
                                const reco::CandidatePtr cand,
-                               int partType, edm::Handle<edm::ValueMap<float>>) {
+                               int partType,
+                               edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -452,7 +483,8 @@ private:
   static double getMVAEPi(const reco::PFCandidatePtr pfCand,
                           const pat::PackedCandidate packedPart,
                           const reco::CandidatePtr cand,
-                          int partType, edm::Handle<edm::ValueMap<float>>) {
+                          int partType,
+                          edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -461,7 +493,8 @@ private:
   static double getMVAEMu(const reco::PFCandidatePtr pfCand,
                           const pat::PackedCandidate packedPart,
                           const reco::CandidatePtr cand,
-                          int partType, edm::Handle<edm::ValueMap<float>>) {
+                          int partType,
+                          edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -470,7 +503,8 @@ private:
   static double getMVAPiMu(const reco::PFCandidatePtr pfCand,
                            const pat::PackedCandidate packedPart,
                            const reco::CandidatePtr cand,
-                           int partType, edm::Handle<edm::ValueMap<float>>) {
+                           int partType,
+                           edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -479,7 +513,8 @@ private:
   static double getMVANothingGamma(const reco::PFCandidatePtr pfCand,
                                    const pat::PackedCandidate packedPart,
                                    const reco::CandidatePtr cand,
-                                   int partType, edm::Handle<edm::ValueMap<float>>) {
+                                   int partType,
+                                   edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -488,7 +523,8 @@ private:
   static double getMVANothingNH(const reco::PFCandidatePtr pfCand,
                                 const pat::PackedCandidate packedPart,
                                 const reco::CandidatePtr cand,
-                                int partType, edm::Handle<edm::ValueMap<float>>) {
+                                int partType,
+                                edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -497,7 +533,8 @@ private:
   static double getMVAGammaNH(const reco::PFCandidatePtr pfCand,
                               const pat::PackedCandidate packedPart,
                               const reco::CandidatePtr cand,
-                              int partType, edm::Handle<edm::ValueMap<float>>) {
+                              int partType,
+                              edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -507,7 +544,8 @@ private:
   static double getDNNESigIsolated(const reco::PFCandidatePtr pfCand,
                                    const pat::PackedCandidate packedPart,
                                    const reco::CandidatePtr cand,
-                                   int partType, edm::Handle<edm::ValueMap<float>>) {
+                                   int partType,
+                                   edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -516,7 +554,8 @@ private:
   static double getDNNESigNonIsolated(const reco::PFCandidatePtr pfCand,
                                       const pat::PackedCandidate packedPart,
                                       const reco::CandidatePtr cand,
-                                      int partType, edm::Handle<edm::ValueMap<float>>) {
+                                      int partType,
+                                      edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -525,7 +564,8 @@ private:
   static double getDNNEBkgNonIsolated(const reco::PFCandidatePtr pfCand,
                                       const pat::PackedCandidate packedPart,
                                       const reco::CandidatePtr cand,
-                                      int partType, edm::Handle<edm::ValueMap<float>>) {
+                                      int partType,
+                                      edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -534,7 +574,8 @@ private:
   static double getDNNEBkgTauIsolated(const reco::PFCandidatePtr pfCand,
                                       const pat::PackedCandidate packedPart,
                                       const reco::CandidatePtr cand,
-                                      int partType, edm::Handle<edm::ValueMap<float>>) {
+                                      int partType,
+                                      edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -543,7 +584,8 @@ private:
   static double getDNNEBkgPhotonIsolated(const reco::PFCandidatePtr pfCand,
                                          const pat::PackedCandidate packedPart,
                                          const reco::CandidatePtr cand,
-                                         int partType, edm::Handle<edm::ValueMap<float>>) {
+                                         int partType,
+                                         edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -553,7 +595,8 @@ private:
   static double getECalEFrac(const reco::PFCandidatePtr pfCand,
                              const pat::PackedCandidate packedPart,
                              const reco::CandidatePtr cand,
-                             int partType, edm::Handle<edm::ValueMap<float>>) {
+                             int partType,
+                             edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -562,7 +605,8 @@ private:
   static double getHCalEFrac(const reco::PFCandidatePtr pfCand,
                              const pat::PackedCandidate packedPart,
                              const reco::CandidatePtr cand,
-                             int partType, edm::Handle<edm::ValueMap<float>>) {
+                             int partType,
+                             edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -571,7 +615,8 @@ private:
   static double getPS1Energy(const reco::PFCandidatePtr pfCand,
                              const pat::PackedCandidate packedPart,
                              const reco::CandidatePtr cand,
-                             int partType, edm::Handle<edm::ValueMap<float>>) {
+                             int partType,
+                             edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -580,7 +625,8 @@ private:
   static double getPS2Energy(const reco::PFCandidatePtr pfCand,
                              const pat::PackedCandidate packedPart,
                              const reco::CandidatePtr cand,
-                             int partType, edm::Handle<edm::ValueMap<float>>) {
+                             int partType,
+                             edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -589,7 +635,8 @@ private:
   static double getPSEnergy(const reco::PFCandidatePtr pfCand,
                             const pat::PackedCandidate packedPart,
                             const reco::CandidatePtr cand,
-                            int partType, edm::Handle<edm::ValueMap<float>>) {
+                            int partType,
+                            edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -599,7 +646,8 @@ private:
   static double getTrackPt(const reco::PFCandidatePtr pfCand,
                            const pat::PackedCandidate packedPart,
                            const reco::CandidatePtr cand,
-                           int partType, edm::Handle<edm::ValueMap<float>>) {
+                           int partType,
+                           edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -611,7 +659,8 @@ private:
   static double getTrackNStripHits(const reco::PFCandidatePtr pfCand,
                                    const pat::PackedCandidate packedPart,
                                    const reco::CandidatePtr cand,
-                                   int partType, edm::Handle<edm::ValueMap<float>>) {
+                                   int partType,
+                                   edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -623,7 +672,8 @@ private:
   static double getTrackNPixHits(const reco::PFCandidatePtr pfCand,
                                  const pat::PackedCandidate packedPart,
                                  const reco::CandidatePtr cand,
-                                 int partType, edm::Handle<edm::ValueMap<float>>) {
+                                 int partType,
+                                 edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -636,7 +686,8 @@ private:
   static double getTrackChi2(const reco::PFCandidatePtr pfCand,
                              const pat::PackedCandidate packedPart,
                              const reco::CandidatePtr cand,
-                             int partType, edm::Handle<edm::ValueMap<float>>) {
+                             int partType,
+                             edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -648,7 +699,8 @@ private:
   static double getTrackPtError(const reco::PFCandidatePtr pfCand,
                                 const pat::PackedCandidate packedPart,
                                 const reco::CandidatePtr cand,
-                                int partType, edm::Handle<edm::ValueMap<float>>) {
+                                int partType,
+                                edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -660,7 +712,8 @@ private:
   static double getTrackRelPtError(const reco::PFCandidatePtr pfCand,
                                    const pat::PackedCandidate packedPart,
                                    const reco::CandidatePtr cand,
-                                   int partType, edm::Handle<edm::ValueMap<float>>) {
+                                   int partType,
+                                   edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -672,7 +725,8 @@ private:
   static double getTrackD0(const reco::PFCandidatePtr pfCand,
                            const pat::PackedCandidate packedPart,
                            const reco::CandidatePtr cand,
-                           int partType, edm::Handle<edm::ValueMap<float>>) {
+                           int partType,
+                           edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -684,7 +738,8 @@ private:
   static double getTrackZ0(const reco::PFCandidatePtr pfCand,
                            const pat::PackedCandidate packedPart,
                            const reco::CandidatePtr cand,
-                           int partType, edm::Handle<edm::ValueMap<float>>) {
+                           int partType,
+                           edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -696,7 +751,8 @@ private:
   static double getTrackThetaError(const reco::PFCandidatePtr pfCand,
                                    const pat::PackedCandidate packedPart,
                                    const reco::CandidatePtr cand,
-                                   int partType, edm::Handle<edm::ValueMap<float>>) {
+                                   int partType,
+                                   edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -708,7 +764,8 @@ private:
   static double getTrackEtaError(const reco::PFCandidatePtr pfCand,
                                  const pat::PackedCandidate packedPart,
                                  const reco::CandidatePtr cand,
-                                 int partType, edm::Handle<edm::ValueMap<float>>) {
+                                 int partType,
+                                 edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -720,7 +777,8 @@ private:
   static double getTrackPhiError(const reco::PFCandidatePtr pfCand,
                                  const pat::PackedCandidate packedPart,
                                  const reco::CandidatePtr cand,
-                                 int partType, edm::Handle<edm::ValueMap<float>>) {
+                                 int partType,
+                                 edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -732,7 +790,8 @@ private:
   static double getEoverP(const reco::PFCandidatePtr pfCand,
                           const pat::PackedCandidate packedPart,
                           const reco::CandidatePtr cand,
-                          int partType, edm::Handle<edm::ValueMap<float>>) {
+                          int partType,
+                          edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -759,7 +818,8 @@ private:
   static double getHCalEnergy(const reco::PFCandidatePtr pfCand,
                               const pat::PackedCandidate packedPart,
                               const reco::CandidatePtr cand,
-                              int partType, edm::Handle<edm::ValueMap<float>>) {
+                              int partType,
+                              edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -786,7 +846,8 @@ private:
   static double getECalEnergy(const reco::PFCandidatePtr pfCand,
                               const pat::PackedCandidate packedPart,
                               const reco::CandidatePtr cand,
-                              int partType, edm::Handle<edm::ValueMap<float>>) {
+                              int partType,
+                              edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -814,7 +875,8 @@ private:
   static double getNTracksInBlock(const reco::PFCandidatePtr pfCand,
                                   const pat::PackedCandidate packedPart,
                                   const reco::CandidatePtr cand,
-                                  int partType, edm::Handle<edm::ValueMap<float>>) {
+                                  int partType,
+                                  edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
@@ -28,8 +28,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Common/interface/TriggerNames.h"
 
-#include "DataFormats/Common/interface/ValueMap.h"
-
 #include "DataFormats/ParticleFlowReco/interface/PFBlockFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
@@ -54,6 +52,7 @@
 
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "fastjet/PseudoJet.hh"
 
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 class PFAnalyzer;
@@ -221,6 +220,24 @@ private:
     return -1;
   }
 
+  // Various functions designed to get information from a PF canddidate
+  static double getLogPt(const reco::PFCandidatePtr pfCand,
+                         const pat::PackedCandidate packedPart,
+                         const reco::CandidatePtr cand,
+                         int partType,
+                         edm::Handle<edm::ValueMap<float>>) {
+    if (partType == 0) {
+      return pfCand.get()->pt() > 0 ? log10(pfCand.get()->pt()) : -10;
+    }
+    if (partType == 1) {
+      return packedPart.pt() > 0 ? log10(packedPart.pt()) : -10;
+    }
+    if (partType == 2) {
+      return cand->pt() > 0 ? log10(cand->pt()) : -10;
+    }
+    return -1;
+  }
+
   static double getEnergy(const reco::PFCandidatePtr pfCand,
                           const pat::PackedCandidate packedPart,
                           const reco::CandidatePtr cand,
@@ -292,7 +309,7 @@ private:
                                   int partType,
                                   edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
-      if (pfCand.get()->rawHcalEnergy() == 0){
+      if (pfCand.get()->rawHcalEnergy() == 0) {
         return -1;
       }
       return pfCand.get()->hcalEnergy() / pfCand.get()->rawHcalEnergy();
@@ -309,6 +326,54 @@ private:
     }
     if (partType == 1) {
       return packedPart.puppiWeight();
+    }
+    return -1;
+  }
+  static double getPuppiPt(const reco::PFCandidatePtr pfCand,
+                           const pat::PackedCandidate packedPart,
+                           const reco::CandidatePtr cand,
+                           int partType,
+                           edm::Handle<edm::ValueMap<float>> puppiWeight) {
+    if (partType == 0) {
+      return (*puppiWeight)[pfCand] * pfCand.get()->pt();
+    }
+    if (partType == 1) {
+      return packedPart.puppiWeight() * packedPart.pt();
+    }
+    return -1;
+  }
+
+  static double getLogPuppiPt(const reco::PFCandidatePtr pfCand,
+                              const pat::PackedCandidate packedPart,
+                              const reco::CandidatePtr cand,
+                              int partType,
+                              edm::Handle<edm::ValueMap<float>> puppiWeight) {
+    if (partType == 0) {
+      return (*puppiWeight)[pfCand] * pfCand.get()->pt() > 0 ? log10((*puppiWeight)[pfCand] * pfCand.get()->pt()) : -10;
+    }
+    if (partType == 1) {
+      return packedPart.puppiWeight() * packedPart.pt() > 0 ? log10(packedPart.puppiWeight() * packedPart.pt()) : -10;
+    }
+    return -1;
+  }
+
+  static double getPuppiEta(const reco::PFCandidatePtr pfCand,
+                            const pat::PackedCandidate packedPart,
+                            const reco::CandidatePtr cand,
+                            int partType,
+                            edm::Handle<edm::ValueMap<float>> puppiWeight) {
+    double weight = (*puppiWeight)[pfCand];
+    if (partType == 0) {
+      fastjet::PseudoJet weightedPF = fastjet::PseudoJet(weight * pfCand.get()->px(),
+                                                         weight * pfCand.get()->py(),
+                                                         weight * pfCand.get()->pz(),
+                                                         weight * pfCand.get()->energy());
+      return weightedPF.eta();
+    }
+    if (partType == 1) {
+      fastjet::PseudoJet weightedPF = fastjet::PseudoJet(
+          weight * packedPart.px(), weight * packedPart.py(), weight * packedPart.pz(), weight * packedPart.energy());
+      return packedPart.puppiWeight() * packedPart.eta();
     }
     return -1;
   }
@@ -471,12 +536,11 @@ private:
     return pfCand.get()->rawHoEnergy();
   }
 
-
   static double getRelEcalEnergy(const reco::PFCandidatePtr pfCand,
-                              const pat::PackedCandidate packedPart,
-                              const reco::CandidatePtr cand,
-                              int partType,
-                              edm::Handle<edm::ValueMap<float>>) {
+                                 const pat::PackedCandidate packedPart,
+                                 const reco::CandidatePtr cand,
+                                 int partType,
+                                 edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
       return pfCand.get()->ecalEnergy() / pfCand.get()->energy();
     }
@@ -486,12 +550,13 @@ private:
     return -1;
   }
   static double getRelRawEcalEnergy(const reco::PFCandidatePtr pfCand,
-                                 const pat::PackedCandidate packedPart,
-                                 const reco::CandidatePtr cand,
-                                 int partType,
-                                 edm::Handle<edm::ValueMap<float>>) {
+                                    const pat::PackedCandidate packedPart,
+                                    const reco::CandidatePtr cand,
+                                    int partType,
+                                    edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
-      return pfCand.get()->rawEcalEnergy() /  (pfCand.get()->rawHoEnergy() + pfCand.get()->rawHcalEnergy() + pfCand.get()->rawEcalEnergy());
+      return pfCand.get()->rawEcalEnergy() /
+             (pfCand.get()->rawHoEnergy() + pfCand.get()->rawHcalEnergy() + pfCand.get()->rawEcalEnergy());
     }
     if (partType == 1) {
       return (1.0 - packedPart.rawHcalFraction()) * packedPart.energy();
@@ -499,10 +564,10 @@ private:
     return -1;
   }
   static double getRelHcalEnergy(const reco::PFCandidatePtr pfCand,
-                              const pat::PackedCandidate packedPart,
-                              const reco::CandidatePtr cand,
-                              int partType,
-                              edm::Handle<edm::ValueMap<float>>) {
+                                 const pat::PackedCandidate packedPart,
+                                 const reco::CandidatePtr cand,
+                                 int partType,
+                                 edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
       return pfCand.get()->hcalEnergy() / pfCand.get()->energy();
     }
@@ -512,12 +577,13 @@ private:
     return -1;
   }
   static double getRelRawHcalEnergy(const reco::PFCandidatePtr pfCand,
-                                 const pat::PackedCandidate packedPart,
-                                 const reco::CandidatePtr cand,
-                                 int partType,
-                                 edm::Handle<edm::ValueMap<float>>) {
+                                    const pat::PackedCandidate packedPart,
+                                    const reco::CandidatePtr cand,
+                                    int partType,
+                                    edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
-      return pfCand.get()->rawHcalEnergy() /  (pfCand.get()->rawHoEnergy() + pfCand.get()->rawHcalEnergy() + pfCand.get()->rawEcalEnergy());
+      return pfCand.get()->rawHcalEnergy() /
+             (pfCand.get()->rawHoEnergy() + pfCand.get()->rawHcalEnergy() + pfCand.get()->rawEcalEnergy());
     }
     if (partType == 1) {
       return packedPart.rawHcalFraction() * packedPart.energy();
@@ -526,16 +592,6 @@ private:
   }
 
   static double getRelHOEnergy(const reco::PFCandidatePtr pfCand,
-                            const pat::PackedCandidate packedPart,
-                            const reco::CandidatePtr cand,
-                            int partType,
-                            edm::Handle<edm::ValueMap<float>>) {
-    if (partType) {
-      return -1;
-    }
-    return pfCand.get()->hoEnergy() / pfCand.get()->energy();
-  }
-  static double getRelRawHOEnergy(const reco::PFCandidatePtr pfCand,
                                const pat::PackedCandidate packedPart,
                                const reco::CandidatePtr cand,
                                int partType,
@@ -543,7 +599,18 @@ private:
     if (partType) {
       return -1;
     }
-    return pfCand.get()->rawHoEnergy() / (pfCand.get()->rawHoEnergy() + pfCand.get()->rawHcalEnergy() + pfCand.get()->rawEcalEnergy());
+    return pfCand.get()->hoEnergy() / pfCand.get()->energy();
+  }
+  static double getRelRawHOEnergy(const reco::PFCandidatePtr pfCand,
+                                  const pat::PackedCandidate packedPart,
+                                  const reco::CandidatePtr cand,
+                                  int partType,
+                                  edm::Handle<edm::ValueMap<float>>) {
+    if (partType) {
+      return -1;
+    }
+    return pfCand.get()->rawHoEnergy() /
+           (pfCand.get()->rawHoEnergy() + pfCand.get()->rawHcalEnergy() + pfCand.get()->rawEcalEnergy());
   }
 
   static double getMVAIsolated(const reco::PFCandidatePtr pfCand,
@@ -975,10 +1042,10 @@ private:
   }
 
   static double getCellsInBlock(const reco::PFCandidatePtr pfCand,
-                                  const pat::PackedCandidate packedPart,
-                                  const reco::CandidatePtr cand,
-                                  int partType,
-                                  edm::Handle<edm::ValueMap<float>>) {
+                                const pat::PackedCandidate packedPart,
+                                const reco::CandidatePtr cand,
+                                int partType,
+                                edm::Handle<edm::ValueMap<float>>) {
     if (partType) {
       return -1;
     }
@@ -992,10 +1059,11 @@ private:
       const edm::OwnVector<reco::PFBlockElement>& elements = blockRef->elements();
       for (unsigned iEle = 0; iEle < elements.size(); iEle++) {
         if (elements[iEle].index() == pfCand.get()->elementsInBlocks()[e].second) {
-          if (elements[iEle].type() == elements[iEle].type() == reco::PFBlockElement::HCAL) {  // Element is HB or HE
+          if (elements[iEle].type() == elements[iEle].type() ||
+              elements[iEle].type() == reco::PFBlockElement::HCAL) {  // Element is HB or HE
             reco::PFClusterRef clusterref = elements[iEle].clusterRef();
-            reco::PFCluster cluster = *clusterref;
-             
+            const reco::PFCluster& cluster = *clusterref;
+
             nTrack += cluster.recHitFractions().size();
           }
         }
@@ -1003,7 +1071,6 @@ private:
     }
     return nTrack;
   }
-
 
   static double getJetPt(const reco::Jet jet, const std::vector<reco::PFCandidatePtr> pfCands) { return jet.pt(); }
   static double getJetChargeFrac(const reco::Jet jet, const std::vector<reco::PFCandidatePtr> pfCands) {
@@ -1076,8 +1143,6 @@ private:
   unsigned int m_runNumber;
 
   typedef edm::View<reco::Candidate> CandView;
-  //edm::EDGetTokenT<reco::PFCandidateCollection> thePfCandidateCollection_;
-  //edm::EDGetTokenT<std::vector<edm::FwdPtr<reco::PFCandidate>>> thePfCandidateCollection_;
   edm::EDGetTokenT<CandView> thePfCandidateCollection_;
 
   edm::EDGetTokenT<pat::PackedCandidateCollection> patPfCandidateCollection_;

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
@@ -373,7 +373,7 @@ private:
     if (partType == 1) {
       fastjet::PseudoJet weightedPF = fastjet::PseudoJet(
           weight * packedPart.px(), weight * packedPart.py(), weight * packedPart.pz(), weight * packedPart.energy());
-      return packedPart.puppiWeight() * packedPart.eta();
+      return weightedPF.eta();
     }
     return -1;
   }
@@ -878,7 +878,7 @@ private:
     return -1;
   }
 
-  static double getTrackZ0(const reco::PFCandidatePtr pfCand,
+  static double getTrackDZ(const reco::PFCandidatePtr pfCand,
                            const pat::PackedCandidate packedPart,
                            const reco::CandidatePtr cand,
                            int partType,
@@ -887,7 +887,7 @@ private:
       return -1;
     }
     if (pfCand.get()->trackRef().isNonnull())
-      return (pfCand.get()->trackRef())->d0();
+      return (pfCand.get()->trackRef())->dz();
     return -1;
   }
 
@@ -1052,15 +1052,13 @@ private:
     // We need this function to return a double, even though this is an integer value
     double nTrack = 0;
     int maxElement = pfCand.get()->elementsInBlocks().size();
-    std::cout << maxElement << std::endl;
     for (int e = 0; e < maxElement; ++e) {
       // Get elements from block
       reco::PFBlockRef blockRef = pfCand.get()->elementsInBlocks()[e].first;
       const edm::OwnVector<reco::PFBlockElement>& elements = blockRef->elements();
       for (unsigned iEle = 0; iEle < elements.size(); iEle++) {
         if (elements[iEle].index() == pfCand.get()->elementsInBlocks()[e].second) {
-          if (elements[iEle].type() == elements[iEle].type() ||
-              elements[iEle].type() == reco::PFBlockElement::HCAL) {  // Element is HB or HE
+          if ( elements[iEle].type() == reco::PFBlockElement::HCAL) {  // Element is HB or HE
             reco::PFClusterRef clusterref = elements[iEle].clusterRef();
             const reco::PFCluster& cluster = *clusterref;
 

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
@@ -1058,7 +1058,7 @@ private:
       const edm::OwnVector<reco::PFBlockElement>& elements = blockRef->elements();
       for (unsigned iEle = 0; iEle < elements.size(); iEle++) {
         if (elements[iEle].index() == pfCand.get()->elementsInBlocks()[e].second) {
-          if ( elements[iEle].type() == reco::PFBlockElement::HCAL) {  // Element is HB or HE
+          if (elements[iEle].type() == reco::PFBlockElement::HCAL) {  // Element is HB or HE
             reco::PFClusterRef clusterref = elements[iEle].clusterRef();
             const reco::PFCluster& cluster = *clusterref;
 

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.h
@@ -292,8 +292,9 @@ private:
                                   int partType,
                                   edm::Handle<edm::ValueMap<float>>) {
     if (partType == 0) {
-      if (pfCand.get()->rawHcalEnergy() == 0)
+      if (pfCand.get()->rawHcalEnergy() == 0){
         return -1;
+      }
       return pfCand.get()->hcalEnergy() / pfCand.get()->rawHcalEnergy();
     }
     return -1;
@@ -468,6 +469,81 @@ private:
       return -1;
     }
     return pfCand.get()->rawHoEnergy();
+  }
+
+
+  static double getRelEcalEnergy(const reco::PFCandidatePtr pfCand,
+                              const pat::PackedCandidate packedPart,
+                              const reco::CandidatePtr cand,
+                              int partType,
+                              edm::Handle<edm::ValueMap<float>>) {
+    if (partType == 0) {
+      return pfCand.get()->ecalEnergy() / pfCand.get()->energy();
+    }
+    if (partType == 1) {
+      return (1.0 - packedPart.hcalFraction()) * packedPart.energy();
+    }
+    return -1;
+  }
+  static double getRelRawEcalEnergy(const reco::PFCandidatePtr pfCand,
+                                 const pat::PackedCandidate packedPart,
+                                 const reco::CandidatePtr cand,
+                                 int partType,
+                                 edm::Handle<edm::ValueMap<float>>) {
+    if (partType == 0) {
+      return pfCand.get()->rawEcalEnergy() /  (pfCand.get()->rawHoEnergy() + pfCand.get()->rawHcalEnergy() + pfCand.get()->rawEcalEnergy());
+    }
+    if (partType == 1) {
+      return (1.0 - packedPart.rawHcalFraction()) * packedPart.energy();
+    }
+    return -1;
+  }
+  static double getRelHcalEnergy(const reco::PFCandidatePtr pfCand,
+                              const pat::PackedCandidate packedPart,
+                              const reco::CandidatePtr cand,
+                              int partType,
+                              edm::Handle<edm::ValueMap<float>>) {
+    if (partType == 0) {
+      return pfCand.get()->hcalEnergy() / pfCand.get()->energy();
+    }
+    if (partType == 1) {
+      return packedPart.hcalFraction() * packedPart.energy();
+    }
+    return -1;
+  }
+  static double getRelRawHcalEnergy(const reco::PFCandidatePtr pfCand,
+                                 const pat::PackedCandidate packedPart,
+                                 const reco::CandidatePtr cand,
+                                 int partType,
+                                 edm::Handle<edm::ValueMap<float>>) {
+    if (partType == 0) {
+      return pfCand.get()->rawHcalEnergy() /  (pfCand.get()->rawHoEnergy() + pfCand.get()->rawHcalEnergy() + pfCand.get()->rawEcalEnergy());
+    }
+    if (partType == 1) {
+      return packedPart.rawHcalFraction() * packedPart.energy();
+    }
+    return -1;
+  }
+
+  static double getRelHOEnergy(const reco::PFCandidatePtr pfCand,
+                            const pat::PackedCandidate packedPart,
+                            const reco::CandidatePtr cand,
+                            int partType,
+                            edm::Handle<edm::ValueMap<float>>) {
+    if (partType) {
+      return -1;
+    }
+    return pfCand.get()->hoEnergy() / pfCand.get()->energy();
+  }
+  static double getRelRawHOEnergy(const reco::PFCandidatePtr pfCand,
+                               const pat::PackedCandidate packedPart,
+                               const reco::CandidatePtr cand,
+                               int partType,
+                               edm::Handle<edm::ValueMap<float>>) {
+    if (partType) {
+      return -1;
+    }
+    return pfCand.get()->rawHoEnergy() / (pfCand.get()->rawHoEnergy() + pfCand.get()->rawHcalEnergy() + pfCand.get()->rawEcalEnergy());
   }
 
   static double getMVAIsolated(const reco::PFCandidatePtr pfCand,
@@ -897,6 +973,37 @@ private:
     }
     return nTrack;
   }
+
+  static double getCellsInBlock(const reco::PFCandidatePtr pfCand,
+                                  const pat::PackedCandidate packedPart,
+                                  const reco::CandidatePtr cand,
+                                  int partType,
+                                  edm::Handle<edm::ValueMap<float>>) {
+    if (partType) {
+      return -1;
+    }
+    // We need this function to return a double, even though this is an integer value
+    double nTrack = 0;
+    int maxElement = pfCand.get()->elementsInBlocks().size();
+    std::cout << maxElement << std::endl;
+    for (int e = 0; e < maxElement; ++e) {
+      // Get elements from block
+      reco::PFBlockRef blockRef = pfCand.get()->elementsInBlocks()[e].first;
+      const edm::OwnVector<reco::PFBlockElement>& elements = blockRef->elements();
+      for (unsigned iEle = 0; iEle < elements.size(); iEle++) {
+        if (elements[iEle].index() == pfCand.get()->elementsInBlocks()[e].second) {
+          if (elements[iEle].type() == elements[iEle].type() == reco::PFBlockElement::HCAL) {  // Element is HB or HE
+            reco::PFClusterRef clusterref = elements[iEle].clusterRef();
+            reco::PFCluster cluster = *clusterref;
+             
+            nTrack += cluster.recHitFractions().size();
+          }
+        }
+      }
+    }
+    return nTrack;
+  }
+
 
   static double getJetPt(const reco::Jet jet, const std::vector<reco::PFCandidatePtr> pfCands) { return jet.pt(); }
   static double getJetChargeFrac(const reco::Jet jet, const std::vector<reco::PFCandidatePtr> pfCands) {

--- a/DQMOffline/ParticleFlow/python/runBasic_cff.py
+++ b/DQMOffline/ParticleFlow/python/runBasic_cff.py
@@ -6,7 +6,6 @@ DQMOfflinePFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
     pfCandidates             = cms.InputTag("particleFlow"),
     pfJetCollection        = cms.InputTag("ak4PFJetsPuppiCorrected"),
     PVCollection             = cms.InputTag("offlinePrimaryVertices"),
-
     TriggerResultsLabel        = cms.InputTag("TriggerResults::HLT"),
     TriggerNames = cms.vstring("HLT_PFJet450"),
     puppiWeight  = cms.InputTag("puppi"),
@@ -108,6 +107,4 @@ DQMOfflinePFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
                                    '[pt;20;50;100;1000]',
                                   ),
     )
-
-
 )

--- a/DQMOffline/ParticleFlow/python/runBasic_cff.py
+++ b/DQMOffline/ParticleFlow/python/runBasic_cff.py
@@ -1,22 +1,33 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+#from DQMOffline.ParticleFlow.pfAnalyzer_cfi import pfAnalyzer
 from DQMOffline.ParticleFlow.pfAnalyzer_cfi import pfAnalyzer
 
-PFAnalyzer = pfAnalyzer.clone( 
-    isMiniAOD = cms.bool(True),
+
+
+PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
     pfCandidates             = cms.InputTag("particleFlow"),
     pfJetCollection        = cms.InputTag("ak4PFJetsPuppiCorrected"),
+    #pfJetCollection        = cms.InputTag("ak4PFJetsPuppi"),
     PVCollection             = cms.InputTag("offlinePrimaryVertices"),
+
     TriggerResultsLabel        = cms.InputTag("TriggerResults::HLT"),
+    #TriggerNames = cms.vstring("HLT_PFJet450", "HLT_PFJet500", "HLT_PFJet550"),
     TriggerNames = cms.vstring("HLT_PFJet450"),
-    #puppiWeight  = cms.InputTag("packedPuppiweight"),
+    puppiWeight  = cms.InputTag("puppi"),
     eventSelection = cms.string("dijet"),
     #eventSelection = cms.string("nocut"),
+    isMiniAOD = cms.bool(False),
+    runNumber = cms.uint32(397954),
+    #runNumber = cms.uint32(397962),
+    #runNumber = cms.uint32(398902),
+    #runNumber = cms.uint32(398903),
+    #runNumber = cms.uint32(0),
 
     pfAnalysis = cms.PSet(
       # Bins of NPV for plots
       #NPVBins = cms.vdouble(0, 25, 45, 100),
-      NPVBins = cms.vdouble(0,100),
+      NPVBins = cms.vdouble(0,200),
 
       # A list of observables for which plots should be made.
       # The format should be a list of semicolon-separated values.
@@ -27,20 +38,20 @@ PFAnalyzer = pfAnalyzer.clone(
       # in order, are the number of bins, the lowest, and the highest values.
       # If any other number is given, this is just a list of bins for the histogram.
       observables     = cms.vstring('pt;p_{T,PFC};50.;0.;350.', 
-                                    'eta;#eta;50;-5;5',
-                                    'phi;#phi;50;-3.14;3.14',
+                                    'eta;#eta;30;-5;5',
+                                    'phi;#phi;30;-3.14;3.14',
                                     'energy;E;50;0;300',
-                                    'puppi;E;50;0;1',
-      #                              'RawHCal_E;Raw E_{hcal};50;0;300', 
-      #                              'HCal_E;E_{hcal};50;0;300', 
-      #                              'PFHad_calibration;E_{Hcal,calib} / E_{Hcal, raw};50;0;4',
-      #                              'HCalE_depth1;HCal E, depth 1;50;0;1',
-      #                              'HCalE_depth2;HCal E, depth 2;50;0;1',
-      #                              'HCalE_depth3;HCal E, depth 3;50;0;1',
-      #                              'HCalE_depth4;HCal E, depth 4;50;0;1',
-      #                              'HCalE_depth5;HCal E, depth 5;50;0;1',
-      #                              'HCalE_depth6;HCal E, depth 6;50;0;1',
-      #                              'HCalE_depth7;HCal E, depth 7;50;0;1',
+                                    'puppi;E;30;0;1',
+                                    #'RawHCal_E;Raw E_{hcal};50;0;300', 
+                                    #'HCal_E;E_{hcal};50;0;300', 
+                                    'PFHad_calibration;E_{Hcal,calib} / E_{Hcal, raw};50;0;4',
+                                    'HCalE_depth1;HCal E, depth 1;50;0;1',
+                                    'HCalE_depth2;HCal E, depth 2;50;0;1',
+                                    'HCalE_depth3;HCal E, depth 3;50;0;1',
+                                    'HCalE_depth4;HCal E, depth 4;50;0;1',
+                                    'HCalE_depth5;HCal E, depth 5;50;0;1',
+                                    'HCalE_depth6;HCal E, depth 6;50;0;1',
+                                    'HCalE_depth7;HCal E, depth 7;50;0;1',
                                    ),
 
       # A list of event- or jet-wide observables for which plots should be made.
@@ -93,7 +104,7 @@ PFAnalyzer = pfAnalyzer.clone(
       cutList     = cms.vstring(
                                 '[pt;1;0;10000]',
                                 #'[pt;0;1;2;4;6;10;20;40;60;100][abseta;0;1.5;2.0;2.5;2.8;2.85;2.9;2.95;3]',
-                                #'[pt;0;2;5;10;20;50;100;1000]',
+                                '[pt;0;2;5;10;20;50;100;1000]',
                                 #'[pt;1;0;10000][abseta;0;1;2;2.5;2.6;2.7;2.8;2.9;3;3.5;4.0;4.5]',
                                 #'[pt;1;0;10000][abseta;0;1;1.5;2;2.5;3;3.5;4.0]',
                                ),
@@ -106,8 +117,10 @@ PFAnalyzer = pfAnalyzer.clone(
       #
       # Just like for cutList, multiple sets of cuts can be applied, using the same formulation.
       jetCutList     = cms.vstring(
-      #                             '[pt;20;30;50;100;200;450;1000]',
+      #                             '[pt;20;30;50;100;1000]',
                                    '[pt;20;10000]',
                                   ),
     )
+
+
 )

--- a/DQMOffline/ParticleFlow/python/runBasic_cff.py
+++ b/DQMOffline/ParticleFlow/python/runBasic_cff.py
@@ -1,33 +1,25 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
-#from DQMOffline.ParticleFlow.pfAnalyzer_cfi import pfAnalyzer
 from DQMOffline.ParticleFlow.pfAnalyzer_cfi import pfAnalyzer
 
-
-
-PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
+DQMOfflinePFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
     pfCandidates             = cms.InputTag("particleFlow"),
     pfJetCollection        = cms.InputTag("ak4PFJetsPuppiCorrected"),
-    #pfJetCollection        = cms.InputTag("ak4PFJetsPuppi"),
     PVCollection             = cms.InputTag("offlinePrimaryVertices"),
 
     TriggerResultsLabel        = cms.InputTag("TriggerResults::HLT"),
-    #TriggerNames = cms.vstring("HLT_PFJet450", "HLT_PFJet500", "HLT_PFJet550"),
     TriggerNames = cms.vstring("HLT_PFJet450"),
     puppiWeight  = cms.InputTag("puppi"),
-    eventSelection = cms.string("dijet"),
-    #eventSelection = cms.string("nocut"),
+    #eventSelection = cms.string("dijet"),
+    eventSelection = cms.string("nocut"),
     isMiniAOD = cms.bool(False),
-    runNumber = cms.uint32(397954),
-    #runNumber = cms.uint32(397962),
-    #runNumber = cms.uint32(398902),
-    #runNumber = cms.uint32(398903),
-    #runNumber = cms.uint32(0),
+    runNumber = cms.uint32(0),
 
     pfAnalysis = cms.PSet(
+      pfNames = cms.vstring("allPFC", "neutralHadPFC", "chargedHadPFC", "electronPFC", "muonPFC", "gammaPFC", "hadHFPFC", "emHFPFC"),
       # Bins of NPV for plots
-      #NPVBins = cms.vdouble(0, 25, 45, 100),
       NPVBins = cms.vdouble(0,200),
+
 
       # A list of observables for which plots should be made.
       # The format should be a list of semicolon-separated values.
@@ -40,18 +32,15 @@ PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
       observables     = cms.vstring('pt;p_{T,PFC};50.;0.;350.', 
                                     'eta;#eta;30;-5;5',
                                     'phi;#phi;30;-3.14;3.14',
-                                    'energy;E;50;0;300',
                                     'puppi;E;30;0;1',
-                                    #'RawHCal_E;Raw E_{hcal};50;0;300', 
-                                    #'HCal_E;E_{hcal};50;0;300', 
-                                    'PFHad_calibration;E_{Hcal,calib} / E_{Hcal, raw};50;0;4',
-                                    'HCalE_depth1;HCal E, depth 1;50;0;1',
-                                    'HCalE_depth2;HCal E, depth 2;50;0;1',
-                                    'HCalE_depth3;HCal E, depth 3;50;0;1',
-                                    'HCalE_depth4;HCal E, depth 4;50;0;1',
-                                    'HCalE_depth5;HCal E, depth 5;50;0;1',
-                                    'HCalE_depth6;HCal E, depth 6;50;0;1',
-                                    'HCalE_depth7;HCal E, depth 7;50;0;1',
+                                    'PFHad_calibration;E_{Hcal,calib} / E_{Hcal, raw};30;0;4',
+                                    'HCalE_depth1;HCal E, depth 1;30;0;1',
+                                    'HCalE_depth2;HCal E, depth 2;30;0;1',
+                                    'HCalE_depth3;HCal E, depth 3;30;0;1',
+                                    'HCalE_depth4;HCal E, depth 4;30;0;1',
+                                    'HCalE_depth5;HCal E, depth 5;30;0;1',
+                                    'HCalE_depth6;HCal E, depth 6;30;0;1',
+                                    'HCalE_depth7;HCal E, depth 7;30;0;1',
                                    ),
 
       # A list of event- or jet-wide observables for which plots should be made.
@@ -65,12 +54,12 @@ PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
       # Since the binning may be very different for events and jets, the first list
       # of bins is for the event histograms, and the second set is for the jets
       eventObservables     = cms.vstring(
-      #                                   'NPFC;N_{PFC};500;0;10000;100;0;100',
+                                         'NPFC;N_{PFC};500;0;10000;100;0;100',
                                         ),
 
 
       pfInJetObservables     = cms.vstring(
-      #                                   'PFSpectrum;E_{PF}/E_{jet};50;0;1',
+                                         'PFSpectrum;E_{PF}/E_{jet};50;0;1',
                                         ),
 
 
@@ -104,9 +93,8 @@ PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
       cutList     = cms.vstring(
                                 '[pt;1;0;10000]',
                                 #'[pt;0;1;2;4;6;10;20;40;60;100][abseta;0;1.5;2.0;2.5;2.8;2.85;2.9;2.95;3]',
-                                '[pt;0;2;5;10;20;50;100;1000]',
-                                #'[pt;1;0;10000][abseta;0;1;2;2.5;2.6;2.7;2.8;2.9;3;3.5;4.0;4.5]',
-                                #'[pt;1;0;10000][abseta;0;1;1.5;2;2.5;3;3.5;4.0]',
+                                '[pt;0;2;10;100]',
+                                '[abseta;0;1;2;2.5;2.7;3;3.5;5.0]',
                                ),
 
       # This is a list of multidimensional cuts on the jets that are applied for the plots.
@@ -117,8 +105,7 @@ PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
       #
       # Just like for cutList, multiple sets of cuts can be applied, using the same formulation.
       jetCutList     = cms.vstring(
-      #                             '[pt;20;30;50;100;1000]',
-                                   '[pt;20;10000]',
+                                   '[pt;20;50;100;1000]',
                                   ),
     )
 

--- a/DQMOffline/ParticleFlow/python/runBasic_cfg.py
+++ b/DQMOffline/ParticleFlow/python/runBasic_cfg.py
@@ -51,11 +51,11 @@ process.ak4PFJetsPuppiCorrected = cms.EDProducer('CorrectedPFJetProducer',
 ###################################################################
 # Data certification GoldenJSON filtering
 ###################################################################
-#goldenJSONPath="/eos/user/c/cmsdqm/www/CAF/certification/Collisions25/Cert_Collisions2025_391658_397294_Golden.json"
-#if goldenJSONPath != "":
-#    import FWCore.PythonUtilities.LumiList as LumiList
-#    process.source.lumisToProcess = LumiList.LumiList(filename = goldenJSONPath).getVLuminosityBlockRange()
-#
+goldenJSONPath="/eos/user/c/cmsdqm/www/CAF/certification/Collisions25/Cert_Collisions2025_391658_397294_Golden.json"
+if goldenJSONPath != "":
+    import FWCore.PythonUtilities.LumiList as LumiList
+    process.source.lumisToProcess = LumiList.LumiList(filename = goldenJSONPath).getVLuminosityBlockRange()
+
 process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
                                      fileName = cms.untracked.string("OUT_step1.root"))
 
@@ -63,7 +63,7 @@ process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
 process.p = cms.Path(
     process.ak4PFPuppiL1FastL2L3ResidualCorrectorChain+
     process.ak4PFJetsPuppiCorrected+
-    process.PFAnalyzer)
+    process.DQMOfflinePFAnalyzer)
 process.DQMoutput_step = cms.EndPath(process.DQMoutput)
 
 

--- a/DQMOffline/ParticleFlow/python/runBasic_cfg.py
+++ b/DQMOffline/ParticleFlow/python/runBasic_cfg.py
@@ -51,11 +51,11 @@ process.ak4PFJetsPuppiCorrected = cms.EDProducer('CorrectedPFJetProducer',
 ###################################################################
 # Data certification GoldenJSON filtering
 ###################################################################
-goldenJSONPath="/eos/user/c/cmsdqm/www/CAF/certification/Collisions25/Cert_Collisions2025_391658_397294_Golden.json"
-if goldenJSONPath != "":
-    import FWCore.PythonUtilities.LumiList as LumiList
-    process.source.lumisToProcess = LumiList.LumiList(filename = goldenJSONPath).getVLuminosityBlockRange()
-
+#goldenJSONPath="/eos/user/c/cmsdqm/www/CAF/certification/Collisions25/Cert_Collisions2025_391658_397294_Golden.json"
+#if goldenJSONPath != "":
+#    import FWCore.PythonUtilities.LumiList as LumiList
+#    process.source.lumisToProcess = LumiList.LumiList(filename = goldenJSONPath).getVLuminosityBlockRange()
+#
 process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
                                      fileName = cms.untracked.string("OUT_step1.root"))
 

--- a/DQMOffline/ParticleFlow/python/runMini_cff.py
+++ b/DQMOffline/ParticleFlow/python/runMini_cff.py
@@ -1,24 +1,29 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+from DQMOffline.ParticleFlow.pfAnalyzer_cfi import pfAnalyzer
 
-PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
+
+PFAnalyzerMiniAOD = DQMEDAnalyzer("PFAnalyzer",
     # For Mini
     pfCandidates             = cms.InputTag("packedPFCandidates"),
     pfJetCollection        = cms.InputTag("slimmedJets"),
+    isMiniAOD = cms.bool(True),
 
     PVCollection             = cms.InputTag("offlinePrimaryVertices"),
 
     TriggerResultsLabel        = cms.InputTag("TriggerResults::HLT"),
     TriggerNames = cms.vstring(""),
-    #eventSelection = cms.string("dijet"),
     eventSelection = cms.string("nocut"),
 
 
 
     pfAnalysis = cms.PSet(
+      # We don't have a detailed breakdown of the PF candidate type for MiniAOD
+      pfNames = cms.vstring("allPFC"),
+
       # Bins of NPV for plots
       #NPVBins = cms.vdouble(0, 25, 45, 100),
-      NPVBins = cms.vdouble(0,100),
+      NPVBins = cms.vdouble(0,200),
 
       # A list of observables for which plots should be made.
       # The format should be a list of semicolon-separated values.
@@ -30,19 +35,7 @@ PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
       # If any other number is given, this is just a list of bins for the histogram.
       observables     = cms.vstring('pt;p_{T,PFC};50.;0.;350.', 
                                     'eta;#eta;50;-5;5',
-                                    'phi;#phi;50;-3.14;3.14',
-                                    'energy;E;50;0;300',
-                                    'puppi;E;50;0;1',
-      #                              'RawHCal_E;Raw E_{hcal};50;0;300', 
-      #                              'HCal_E;E_{hcal};50;0;300', 
-      #                              'PFHad_calibration;E_{Hcal,calib} / E_{Hcal, raw};50;0;4',
-      #                              'HCalE_depth1;HCal E, depth 1;50;0;1',
-      #                              'HCalE_depth2;HCal E, depth 2;50;0;1',
-      #                              'HCalE_depth3;HCal E, depth 3;50;0;1',
-      #                              'HCalE_depth4;HCal E, depth 4;50;0;1',
-      #                              'HCalE_depth5;HCal E, depth 5;50;0;1',
-      #                              'HCalE_depth6;HCal E, depth 6;50;0;1',
-      #                              'HCalE_depth7;HCal E, depth 7;50;0;1',
+                                    'phi;#phi;30;-3.14;3.14',
                                    ),
 
       # A list of event- or jet-wide observables for which plots should be made.
@@ -56,12 +49,12 @@ PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
       # Since the binning may be very different for events and jets, the first list
       # of bins is for the event histograms, and the second set is for the jets
       eventObservables     = cms.vstring(
-      #                                   'NPFC;N_{PFC};500;0;10000;100;0;100',
+                                         'NPFC;N_{PFC};500;0;10000;100;0;100',
                                         ),
 
 
       pfInJetObservables     = cms.vstring(
-      #                                   'PFSpectrum;E_{PF}/E_{jet};50;0;1',
+                                         'PFSpectrum;E_{PF}/E_{jet};50;0;1',
                                         ),
 
 
@@ -94,10 +87,7 @@ PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
      
       cutList     = cms.vstring(
                                 '[pt;1;0;10000]',
-                                #'[pt;0;1;2;4;6;10;20;40;60;100][abseta;0;1.5;2.0;2.5;2.8;2.85;2.9;2.95;3]',
-                                #'[pt;0;2;5;10;20;50;100;1000]',
-                                #'[pt;1;0;10000][abseta;0;1;2;2.5;2.6;2.7;2.8;2.9;3;3.5;4.0;4.5]',
-                                #'[pt;1;0;10000][abseta;0;1;1.5;2;2.5;3;3.5;4.0]',
+                                '[abseta;0;1;2;2.5;2.73;3.5;4.0;4.5]',
                                ),
 
       # This is a list of multidimensional cuts on the jets that are applied for the plots.
@@ -108,8 +98,7 @@ PFAnalyzer = DQMEDAnalyzer("PFAnalyzer",
       #
       # Just like for cutList, multiple sets of cuts can be applied, using the same formulation.
       jetCutList     = cms.vstring(
-      #                             '[pt;20;30;50;100;200;450;1000]',
-                                   '[pt;20;10000]',
+                                   '[pt;20;100;10000]',
                                   ),
     )
 

--- a/DQMOffline/ParticleFlow/python/runMini_cfg.py
+++ b/DQMOffline/ParticleFlow/python/runMini_cfg.py
@@ -16,7 +16,7 @@ process.load("DQMServices.Core.DQM_cfg")
 process.load("DQMServices.Components.DQMEnvironment_cfi")
 
 # my analyzer
-process.load('DQMOffline.ParticleFlow.runMini_cfi')
+process.load('DQMOffline.ParticleFlow.runMini_cff')
 
 
 with open('fileList.log') as f:
@@ -29,7 +29,7 @@ process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
 
 
 process.p = cms.Path(
-    process.PFAnalyzer)
+    process.PFAnalyzerMiniAOD)
 process.DQMoutput_step = cms.EndPath(process.DQMoutput)
 
 


### PR DESCRIPTION
#### PR description:

This PR makes a number of improvements to the PF DQM framework. The main impact of this is to introduce PF DQM plots in the offline DQM results so they are made automatically. I have limited the number of automatic plots that are made.

* I have made the PF framework include the possibility to plot things related to the PUPPI weights
* I have made the framework more robust for MiniAOD (with some more improvements saved for a future PR) by automatically returning -1 for functions that are ill-defined for the mini data format.
* I have changed the configuration files to also include the list of PF types that should be included in the output. This is useful for MiniAOD studies, where we do not have this detailed breakdown.
* I have changed the default plots so that there are fewer plots in the output


#### PR validation:

* I have checked the PUPPI weight plots to confirm that they look reasonable, which have also been shown in a recent PF meeting
* I have checked the output of the DQM file for one test (runTheMatrix.py -l 12834.0), where the plots show up successfully and look reasonable.


