### PR TITLE
[MkFit]  MkFit final fit calibration and minor adjustments 

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTracks_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTracks_cfi.py
@@ -20,23 +20,52 @@ hltInitialStepTracks = cms.EDProducer("TrackProducer",
 
 
 _hltInitialStepTracksMkFitFit = cms.EDProducer("MkFitOutputTrackConverter",
-    measurementTrackerEvent = cms.InputTag("hltMeasurementTrackerEvent"),
-    mightGet = cms.optional.untracked.vstring,
     mkFitEventOfHits = cms.InputTag("hltMkFitEventOfHits"),
     mkFitPixelHits = cms.InputTag("hltMkFitSiPixelHits"),
-    mkFitSeeds = cms.InputTag("hltInitialStepMkFitSeeds"),
     mkFitStripHits = cms.InputTag("hltMkFitSiPhase2Hits"),
-    propagatorAlong = cms.ESInputTag("","PropagatorWithMaterial"),
-    propagatorOpposite = cms.ESInputTag("","PropagatorWithMaterialOpposite"),
+    mkFitSeeds = cms.InputTag("hltInitialStepMkFitSeeds"),
+    src = cms.InputTag("hltInitialStepTrackCandidatesMkFitFit"),
+    seeds = cms.InputTag("hltInitialStepTrajectorySeedsLST"),
+    ttrhBuilder = cms.ESInputTag('', 'WithTrackAngle'),
+    propagatorAlong = cms.ESInputTag('', 'PropagatorWithMaterial'),
+    propagatorOpposite = cms.ESInputTag('', 'PropagatorWithMaterialOpposite'),
     qualityMaxInvPt = cms.double(100),
-    qualityMaxPosErr = cms.double(100),
+    qualityMinTheta = cms.double(0.01),
     qualityMaxR = cms.double(120),
     qualityMaxZ = cms.double(280),
-    qualityMinTheta = cms.double(0.01),
+    qualityMaxPosErr = cms.double(100),
     qualitySignPt = cms.bool(True),
-    seeds = cms.InputTag("hltInitialStepTrajectorySeedsLST"),
-    src = cms.InputTag("hltInitialStepTrackCandidatesMkFitFit"),
-    ttrhBuilder = cms.ESInputTag("","WithTrackAngle")
+    calibrate = cms.bool(True),
+    calibBinCenter = cms.vdouble(
+      0.1704,
+      0.6028,
+      1.0188,
+      1.2898,
+      1.439,
+      1.4908,
+      1.55
+    ),
+    calibBinCoeff = cms.vdouble(
+      1,
+      1.0004,
+      1.00014,
+      1.0027,
+      1.0029,
+      1.0009,
+      0.9999
+    ),
+    calibBinOffset = cms.vdouble(
+      0.0016,
+      0.0032,
+      0.0033,
+      0.0045,
+      0.0005,
+      0.0012,
+      0.0003
+    ),
+    NavigationSchool = cms.ESInputTag('', 'SimpleNavigationSchool'),
+    measurementTrackerEvent = cms.InputTag("hltMeasurementTrackerEvent"),
+    mightGet = cms.optional.untracked.vstring
 )
 
 from Configuration.ProcessModifiers.trackingMkFitFit_cff import trackingMkFitFit

--- a/RecoTracker/MkFit/plugins/MkFitOutputTrackConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputTrackConverter.cc
@@ -135,6 +135,11 @@ private:
   const float qualityMaxPosErrSq_;
   const bool qualitySignPt_;
 
+  const bool calibrate_;
+  std::vector<double> calibBinCenter_;
+  std::vector<double> calibBinCoeff_;
+  std::vector<double> calibBinOffset_;
+
   const edm::EDGetTokenT<MeasurementTrackerEvent> measurementTrackerEventToken_;
   const edm::ESGetToken<NavigationSchool, NavigationSchoolRecord> navToken_;
 
@@ -165,6 +170,10 @@ MkFitOutputTrackConverter::MkFitOutputTrackConverter(edm::ParameterSet const& iC
       qualityMaxZ_{float(iConfig.getParameter<double>("qualityMaxZ"))},
       qualityMaxPosErrSq_{float(pow(iConfig.getParameter<double>("qualityMaxPosErr"), 2))},
       qualitySignPt_{iConfig.getParameter<bool>("qualitySignPt")},
+      calibrate_{iConfig.getParameter<bool>("calibrate")},
+      calibBinCenter_{iConfig.getParameter<std::vector<double>>("calibBinCenter")},
+      calibBinCoeff_{iConfig.getParameter<std::vector<double>>("calibBinCoeff")},
+      calibBinOffset_{iConfig.getParameter<std::vector<double>>("calibBinOffset")},
       measurementTrackerEventToken_{consumes(iConfig.getParameter<edm::InputTag>("measurementTrackerEvent"))},
       navToken_{esConsumes(iConfig.getParameter<edm::ESInputTag>("NavigationSchool"))},
       algo_{reco::TrackBase::algoByName(
@@ -194,6 +203,14 @@ void MkFitOutputTrackConverter::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<double>("qualityMaxZ", 280)->setComment("max(|Z|) for the state position for converted tracks");
   desc.add<double>("qualityMaxPosErr", 100)->setComment("max position error for converted tracks");
   desc.add<bool>("qualitySignPt", true)->setComment("check sign of 1/pt for converted tracks");
+
+  desc.add<bool>("calibrate", true)->setComment("true if mkFit fit pT calibration is needed");
+  desc.add<std::vector<double>>("calibBinCenter", {0.1704, 0.6028, 1.0188, 1.2898, 1.4390, 1.4908, 1.5500})
+      ->setComment("calibration bin center (in |theta|)");
+  desc.add<std::vector<double>>("calibBinCoeff", {1.0000, 1.0004, 1.00014, 1.0027, 1.0029, 1.0009, 0.9999})
+      ->setComment("calibration coeff for bin");
+  desc.add<std::vector<double>>("calibBinOffset", {0.0016, 0.0032, 0.0033, 0.0045, 0.0005, 0.0012, 0.0003})
+      ->setComment("calibration offset for bin");
 
   desc.add<edm::ESInputTag>("NavigationSchool", edm::ESInputTag{"", "SimpleNavigationSchool"});
   desc.add<edm::InputTag>("measurementTrackerEvent", edm::InputTag("MeasurementTrackerEvent"));
@@ -524,10 +541,11 @@ void MkFitOutputTrackConverter::convertCandidates(const MkFitOutputWrapper& mkFi
     auto p = stateAtPCA.momentum();
 
     float factor = 1.f;
-    //if calibrate == true
-    const float abstheta = std::fabs(tsosState.globalMomentum().theta() - 1.570796);
-    const float pt = tsosState.globalMomentum().perp();
-    factor = ptcorr(abstheta, pt) / pt;
+    if (calibrate_) {
+      const float abstheta = std::fabs(tsosState.globalMomentum().theta() - 1.570796);
+      const float pt = tsosState.globalMomentum().perp();
+      factor = ptcorr(abstheta, pt);
+    }
 
     math::XYZPoint pos(v0.x(), v0.y(), v0.z());
     math::XYZVector mom(p.x() * factor, p.y() * factor, p.z() * factor);  //can I just multiply p??
@@ -625,35 +643,28 @@ std::pair<TrajectoryStateOnSurface, const GeomDet*> MkFitOutputTrackConverter::c
 }
 
 float MkFitOutputTrackConverter::ptcorr(const float abstheta, float pt) const {
-  // Representative x positions (bin centers)
-  static const int N = 7;
-  static const float xk[N] = {0.1704, 0.6028, 1.0188, 1.2898, 1.4390, 1.4908, 1.5500};
+  const int N = calibBinCenter_.size();
 
-  // Intercepts a(x)
-  static const float a[N] = {0.0016, 0.0032, 0.0033, 0.0045, 0.0005, 0.0012, 0.0003};
+  if (abstheta <= calibBinCenter_[0])
+    return calibBinOffset_[0] / pt + calibBinCoeff_[0];  // pt_new=a+b*pt, return pt_new/pt
+  if (abstheta >= calibBinCenter_[N - 1])
+    return calibBinOffset_[N - 1] / pt + calibBinCoeff_[N - 1];  // pt_new=a+b*pt, return pt_new/pt
 
-  // Slopes b(x)
-  static const float b[N] = {1.0000, 1.0004, 1.00014, 1.0027, 1.0029, 1.0009, 0.9999};
+  // interpolation
+  // a_interp = a_1 + (a_2-a_1)/(x_2-x_1) * (x-x1)
 
-  // Clamp x to range
-  if (abstheta <= xk[0])
-    return a[0] + b[0] * pt;
-  if (abstheta >= xk[N - 1])
-    return a[N - 1] + b[N - 1] * pt;
-
-  // Find interval
   for (int i = 0; i < N - 1; ++i) {
-    if (abstheta >= xk[i] && abstheta < xk[i + 1]) {
-      float t = (abstheta - xk[i]) / (xk[i + 1] - xk[i]);
-      float a_interp = a[i] + t * (a[i + 1] - a[i]);
-      float b_interp = b[i] + t * (b[i + 1] - b[i]);
+    if (abstheta >= calibBinCenter_[i] && abstheta < calibBinCenter_[i + 1]) {
+      float t = (abstheta - calibBinCenter_[i]) / (calibBinCenter_[i + 1] - calibBinCenter_[i]);
+      float offset_interp = calibBinOffset_[i] + t * (calibBinOffset_[i + 1] - calibBinOffset_[i]);
+      float coeff_interp = calibBinCoeff_[i] + t * (calibBinCoeff_[i + 1] - calibBinCoeff_[i]);
 
-      return a_interp + b_interp * pt;
+      return offset_interp / pt + coeff_interp;  // pt_new=a+b*pt, return pt_new/pt
     }
   }
 
   // Should never reach here
-  return pt;
+  return 1.f;
 }
 
 DEFINE_FWK_MODULE(MkFitOutputTrackConverter);

--- a/RecoTracker/MkFitCore/src/MkFitter.cc
+++ b/RecoTracker/MkFitCore/src/MkFitter.cc
@@ -137,7 +137,7 @@ namespace mkfit {
       std::vector<std::pair<float, float>> r2z;
       std::vector<int> indices;
 
-      float minR2 = 1700000;
+      float minR2 = std::numeric_limits<float>::max();
       float z_minR = 0;
 
       int local_m = m_CurHit[i];
@@ -177,7 +177,10 @@ namespace mkfit {
       for (int i = 0; i < (int)r2z.size(); i++) {
         float r2 = r2z[i].first > 0 ? r2z[i].first : -r2z[i].first;
         float z = r2z[i].second - z_minR;
-        //        std::cout << "SORTING by 3dR" << "R2 " << r2z[i].first << " z " << r2z[i].second << " z0 " << z_minR << " check "<< -r2 - z*z <<std::endl;
+#ifdef DEBUG_FIT
+        std::cout << "SORTING by 3dR" << "R2 " << r2z[i].first << " z " << r2z[i].second << " z0 " << z_minR
+                  << " check " << -r2 - z * z << std::endl;
+#endif
         index_RorZ[-r2 - z * z].push_back(indices[i]);
       }
       for (const auto &iRZ : index_RorZ)  //one segment
@@ -192,9 +195,6 @@ namespace mkfit {
         for (auto ii : sorted_indices) {
           std::cout << " indices ssii " << ii << std::endl;
         }
-        //         for (int i = 0; i < (int)indices.size(); i++) {
-        //           std::cout << "R2 " << r2z[i].first << " z " << r2z[i].second << " z0 " << z0 << std::endl;
-        //         }
       }
 #ifdef DEBUG_FIT
       std::cout << " check_size " << (indices.size() == sorted_indices.size()) << std::endl;

--- a/RecoTracker/MkFitCore/src/PropagationMPlexCommon.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlexCommon.cc
@@ -102,7 +102,7 @@ namespace mkfit {
       const float p = pt / sT;
       const float pz = p * cT;
       const float p2 = p * p;
-      constexpr float mpi = 0.140;       // m=140 MeV, pion
+      constexpr float mpi = 0.105;       // m=140 MeV, pion, m=105, muon is used in CKF
       constexpr float mpi2 = mpi * mpi;  // m=140 MeV, pion
       const float beta2 = p2 / (p2 + mpi2);
       const float beta = std::sqrt(beta2);

--- a/RecoTracker/MkFitCore/src/PropagationMPlexCommon.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlexCommon.cc
@@ -143,13 +143,17 @@ namespace mkfit {
       constexpr float me = 0.0005;            // m=0.5 MeV, electron
       const float wmax = 2.f * me * beta2 * gamma2 / (1.f + 2.f * gamma * me / mpi + me * me / (mpi * mpi));
       constexpr float I = 16.0e-9 * 10.75;
-      const float deltahalf =
-          vdt::fast_logf(28.816e-9f * std::sqrt(2.33f * 0.498f) / I) + vdt::fast_logf(beta * gamma) - 0.5f;
-      const float dEdx =
-          beta < 1.f ? (2.f * (hitsXi.constAt(n, 0, 0) * invCos *
-                               (0.5f * vdt::fast_logf(2.f * me * beta2 * gamma2 * wmax / (I * I)) - beta2 - deltahalf) /
-                               beta2))
-                     : 0.f;  //protect against infs and nans
+      const float deltahalf = vdt::fast_logf(28.816e-9f * std::sqrt(2.33f * 0.498f) / I) - 0.5f;
+      // true formula below, but simplifying log(beta*gamma)
+      // vdt::fast_logf(28.816e-9f * std::sqrt(2.33f * 0.498f) / I) + vdt::fast_logf(beta * gamma) - 0.5f;
+
+      const float dEdx = beta < 1.f
+                             ? (2.f * (hitsXi.constAt(n, 0, 0) * invCos *
+                                       (0.5f * vdt::fast_logf(2.f * me * wmax / (I * I)) - beta2 - deltahalf) / beta2))
+                             : 0.f;  //protect against infs and nans
+      // true formula below, but simplifying 0.5*log(beta2*gamma2)
+      // (2.f * (hitsXi.constAt(n, 0, 0) * invCos * (0.5f * vdt::fast_logf(2.f * me * beta2 * gamma2 * wmax / (I * I)) - beta2 - deltahalf) / beta2))
+
       // dEdx = dEdx*2.;//xi in cmssw is defined with an extra factor 0.5 with respect to formula 27.1 in pdg
       //std::cout << "dEdx=" << dEdx << " delta=" << deltahalf << " wmax=" << wmax << " Xi=" << hitsXi.constAt(n,0,0) << std::endl;
       const float dP = propSign.constAt(n, 0, 0) * dEdx / beta;

--- a/RecoTracker/MkFitCore/src/PropagationMPlexCommon.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlexCommon.cc
@@ -102,7 +102,7 @@ namespace mkfit {
       const float p = pt / sT;
       const float pz = p * cT;
       const float p2 = p * p;
-      constexpr float mpi = 0.105;       // m=140 MeV, pion, m=105, muon is used in CKF
+      constexpr float mpi = 0.140;       // m=140 MeV, pion
       constexpr float mpi2 = mpi * mpi;  // m=140 MeV, pion
       const float beta2 = p2 / (p2 + mpi2);
       const float beta = std::sqrt(beta2);


### PR DESCRIPTION
#### PR description:

This PR is making some improvements to the MkFit final fit

In particular the following minor changes are applied based on the comparison with the CKF fit

1. Sorting of the layers by the 3d radius (instead of $R$ or $z$ for barrel and endcap) 
      3d radius  $= \sqrt{ x^2 + y^2 + (z-z_0)^2 }$ for each hit position, where $z_0$ is the $z$ of the hit with minimum $x^2+y^2$
2. Material counted twice for overlap hits 
3. No material for first hit backward and forward 
4. ~~Material model using the muon mass~~  removed in final version

these changes, while minor have slightly positive effect on the $p_T$ bias of the final fit.

____________________________________________

**Furthermore, given that we are not able to pinpoint the cause of the $p_T$ bias (yet), we decided to calibrate the final $p_T$ based on simulation**

The calibration is made using single pion tracks generated at a given $p_T$. We calibrate as a function of $p_T$ in 7 $\eta$ bins $([0.0, 0.35],  [0.35, 1.0],  [1.0, 1.6],  [1.6, 2.5],   [2.5, 3.0],   [3.0, 3.5],   [3.5, 4.0])$.

The generated pT of the pions used in the calibration are $1, 1.1, 1.2, 3, 10, 30$ GeV. We use a linear model where $p_T^{gen} = a \times p_T + b$, so that the calibration will give $p_T^{calib} = a \times p_T + b$.

The calibration is applied in MkFitOutputTrackConverter, i.e. after the fit, right before exporting the track to the CMSSW format and is fully configurable, so the numbers can be changed as needed.

____________________________________________

#### PR validation:

The PR is validated under CMSSW_16_1_0_pre2 using TTbar RelVal samples with Phase-2 realistic conditions and PU

**Physics performance in HLT with legacy seeding**

The calibration clearly improves the $p_T$ bias as shown in the InitialStepTracks (before selections) in the pull and $p_T$ bias vs $\eta$ and $p_T$. Compare red (mkFit Fit pre PR) to black (mkFit Fit post PR). The bias is now much more reasonable and almost closing with the blue (CKF). 

<img width="213" height="258" alt="image" src="https://github.com/user-attachments/assets/01d976ff-bb40-4c82-b311-3c3e8b5d5103" />
<img width="213" height="258" alt="image" src="https://github.com/user-attachments/assets/14fa0e1f-48cb-4b63-bf63-f0b55083d9d9" />
<img width="213" height="258" alt="image" src="https://github.com/user-attachments/assets/3ddd1a9d-0e41-4f5e-aaf8-79aeaa98e49f" />

Other distribution are consistent with the pre PR ones (full MTV validation [here](https://uaf-10.t2.ucsd.edu/~legianni/mkFitFit-debug-2026/PR-plots/compareMKFit_legacySeeding))

**Physics performance in HLT with LST seeding (workflows .7571 and .7572)**

A compatible closure is observed in the configuration with LST seeding ([MTV validation](https://uaf-10.t2.ucsd.edu/~legianni/mkFitFit-debug-2026/PR-plots/compareMKFit_newBaselineSeeding)) for the hltGeneral collection

<img width="213" height="258" alt="image" src="https://github.com/user-attachments/assets/a2ab9726-9f73-4077-9f42-f24cfeb528c2" />
<img width="213" height="258" alt="image" src="https://github.com/user-attachments/assets/c561d8ca-86a6-4693-a069-98b12f7a43b9" />
<img width="213" height="258" alt="image" src="https://github.com/user-attachments/assets/659b89df-2220-45ad-bc24-cbc1fb7dc8ec" />

**Timing cross check**

The PR doesn't affect the timing of the final fit, see eg. this measurement with legacy seeding

[Pre-PR](https://uaf-10.t2.ucsd.edu/~legianni/mkFitFit-debug-2026/PR-plots/web/piechart.php?colours=default&data_name=data&dataset=Phase2Timing_resources_PrePRMKFIT1&groups=hlt&local=false&resource=time_real&show_labels=true&show_animations=true&threshold=0)

MkFitFitProducer 26.6 ms
MkFitOutputTrackConverter 25.6 ms

[Post-PR](https://uaf-10.t2.ucsd.edu/~legianni/mkFitFit-debug-2026/PR-plots/web/piechart.php?colours=default&data_name=data&dataset=Phase2Timing_resources_PostPRMKFIT1&groups=hlt&local=false&resource=time_real&show_labels=true&show_animations=true&threshold=0)

MkFitFitProducer 26.1 ms
MkFitOutputTrackConverter 25.9 ms
