### PR TITLE
[16.0.X] HLT Scouting DQM: add HB/HE separation, energy-threshold and energy-time plots for scouting rechits

### DIFF
--- a/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
+++ b/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
@@ -1512,10 +1512,10 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
                      500.0);
 
     ebRecHits_time_hist[i] = ibook.book1D("ebRechits_time" + sfx,
-                                          "Time of EB RecHits (" + lbl + "); Energy of EB recHits (ps); Entries",
-                                          100,
-                                          0.0,
-                                          1000.0);
+                                          "Time of EB RecHits (" + lbl + "); Energy of EB recHits (ns); Entries",
+                                          200,
+                                          -100.,
+                                          100.0);
     eeRecHitsNumber_hist[i] = ibook.book1D(
         "eeRechitsN" + sfx, "Number of EE RecHits (" + lbl + "); number of EE recHits; Entries", 100, 0.0, 1000.0);
     eeRecHits_energy_hist[i] =
@@ -1524,8 +1524,11 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
                      100,
                      0.0,
                      1000.0);
-    eeRecHits_time_hist[i] = ibook.book1D(
-        "eeRechits_time" + sfx, "Time of EE RecHits (" + lbl + "); Time of EE recHits (ps); Entries", 100, 0.0, 1000.0);
+    eeRecHits_time_hist[i] = ibook.book1D("eeRechits_time" + sfx,
+                                          "Time of EE RecHits (" + lbl + "); Time of EE recHits (ns); Entries",
+                                          200,
+                                          -100.0,
+                                          100.0);
 
     ebRecHitsEtaPhiMap[i] = ibook.book2D("ebRecHitsEtaPhitMap" + sfx,
                                          "Occupancy map of EB rechits (" + lbl + ");ieta;iphi;Entries",
@@ -1602,14 +1605,15 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
         ibook.book1D(name + "Rechits_time",
                      "Time of " + subdet + " RecHits; Time of " + subdet + " recHits (ns); RecHits",
                      100,
-                     0.0,
+                     0.,
                      30.0);
 
+    // Energy > 5 GeV histograms
     hbheRecHits_time_egt5_hist[i] =
         ibook.book1D(name + "StiffRechits_time",
                      "Time of " + subdet + " RecHits (E > 5 GeV); Time of stiff " + subdet + " recHits (ns); RecHits",
                      100,
-                     0.0,
+                     0.,
                      30.0);
   }
 

--- a/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
+++ b/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
@@ -17,10 +17,11 @@ It is based on the preexisting work of the scouting group and can be found at gi
 //
 
 // system include files
-#include <TLorentzVector.h>
+#include <algorithm>
 #include <cmath>
 #include <memory>
 #include <vector>
+#include <TLorentzVector.h>
 
 // user include files
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
@@ -431,9 +432,13 @@ private:
   dqm::reco::MonitorElement* eeRecHits_time_hist[2];
   dqm::reco::MonitorElement* eePlusRecHitsXYMap[2];
   dqm::reco::MonitorElement* eeMinusRecHitsXYMap[2];
-  dqm::reco::MonitorElement* hbheRecHitsNumber_hist;
-  dqm::reco::MonitorElement* hbheRecHits_energy_hist;
-  dqm::reco::MonitorElement* hbheRecHits_time_hist;
+
+  // three MEs (HBHE, HB, HE)
+  dqm::reco::MonitorElement* hbheRecHitsNumber_hist[3];
+  dqm::reco::MonitorElement* hbheRecHits_energy_hist[3];
+  dqm::reco::MonitorElement* hbheRecHits_time_hist[3];
+
+  // separate maps for each subdetector
   dqm::reco::MonitorElement* hbheRecHitsEtaPhiMap;
   dqm::reco::MonitorElement* hbRecHitsEtaPhiMap;
   dqm::reco::MonitorElement* heRecHitsEtaPhiMap;
@@ -959,23 +964,37 @@ void ScoutingCollectionMonitor::analyze(const edm::Event& iEvent, const edm::Eve
                      eeRecHits_time_hist);
   }
 
+  // counter of rechits
+  size_t nHBRechits{0};
+  size_t nHERechits{0};
+
   // process the HBHE rechits
   edm::Handle<Run3ScoutingHBHERecHitCollection> hbheRecHitsH;
   if (!hbheRecHitsToken_.isUninitialized() &&
       getValidHandle(iEvent, hbheRecHitsToken_, hbheRecHitsH, "pfRecHitsHBHE")) {
-    hbheRecHitsNumber_hist->Fill(hbheRecHitsH->size());
+    hbheRecHitsNumber_hist[0]->Fill(hbheRecHitsH->size());
     for (const auto& hbheRecHit : *hbheRecHitsH) {
-      hbheRecHits_energy_hist->Fill(hbheRecHit.energy());
-      hbheRecHits_time_hist->Fill(hbheRecHit.time());
+      hbheRecHits_energy_hist[0]->Fill(hbheRecHit.energy());
+      hbheRecHits_time_hist[0]->Fill(hbheRecHit.time());
       HcalDetId hcalid(hbheRecHit.detId());
       hbheRecHitsEtaPhiMap->Fill(hcalid.ieta(), hcalid.iphi());
       const auto& subdet = hcalid.subdetId();
       if (subdet == 1) {  // HB
+        nHBRechits++;
         hbRecHitsEtaPhiMap->Fill(hcalid.ieta(), hcalid.iphi());
+        hbheRecHits_energy_hist[1]->Fill(hbheRecHit.energy());
+        hbheRecHits_time_hist[1]->Fill(hbheRecHit.time());
       } else {  // HE
+        nHERechits++;
         heRecHitsEtaPhiMap->Fill(hcalid.ieta(), hcalid.iphi());
+        hbheRecHits_energy_hist[2]->Fill(hbheRecHit.energy());
+        hbheRecHits_time_hist[2]->Fill(hbheRecHit.time());
       }
     }
+    // check that rechits size is the same
+    assert(hbheRecHitsH->size() == (nHBRechits + nHERechits));
+    hbheRecHitsNumber_hist[1]->Fill(nHBRechits);
+    hbheRecHitsNumber_hist[2]->Fill(nHERechits);
   }
 }
 
@@ -1526,13 +1545,40 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   }
 
   ibook.setCurrentFolder(topfoldername_ + "/CaloRecHitsAll");
-  hbheRecHitsNumber_hist =
-      ibook.book1D("hbheRechitsN", "number of hbhe RecHits; Number of HBHE recHits; Entries", 100, 0.0, 2000.0);
-  hbheRecHits_energy_hist = ibook.book1D(
-      "hbheRechits_energy", "Energy spectrum of hbhe RecHits; Energy of HBHE recHits (GeV); Entries", 100, 0.0, 200.0);
 
-  hbheRecHits_time_hist =
-      ibook.book1D("hbheRechits time", "Time of HBHE RecHits; Time of HBHE recHits (ns); Entries", 100, 0.0, 30.0);
+  const std::array<std::string, 3> subdets = {{"HBHE", "HB", "HE"}};
+
+  // helper lambda
+  auto toLower = [](std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+    return s;
+  };
+
+  for (int i = 0; i < 3; ++i) {
+    const std::string& subdet = subdets[i];
+    std::string name = toLower(subdet);
+
+    hbheRecHitsNumber_hist[i] =
+        ibook.book1D(name + "RechitsN",
+                     "number of " + subdet + " RecHits; Number of " + subdet + " recHits; Entries",
+                     100,
+                     0.0,
+                     2000.0);
+
+    hbheRecHits_energy_hist[i] =
+        ibook.book1D(name + "Rechits_energy",
+                     "Energy spectrum of " + subdet + " RecHits; Energy of " + subdet + " recHits (GeV); Entries",
+                     100,
+                     0.0,
+                     200.0);
+
+    hbheRecHits_time_hist[i] =
+        ibook.book1D(name + "Rechits_time",
+                     "Time of " + subdet + " RecHits; Time of " + subdet + " recHits (ns); Entries",
+                     100,
+                     0.0,
+                     30.0);
+  }
 
   hbheRecHitsEtaPhiMap = ibook.book2D(
       "hbheRecHitsEtaPhitMap", "Occupancy map of HBHE rechits;ieta;iphi;Entries", 61, -30.5, 30.5, 74, -0.5, 73.5);

--- a/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
+++ b/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
@@ -437,6 +437,8 @@ private:
   dqm::reco::MonitorElement* hbheRecHitsNumber_hist[3];
   dqm::reco::MonitorElement* hbheRecHits_energy_hist[3];
   dqm::reco::MonitorElement* hbheRecHits_time_hist[3];
+  dqm::reco::MonitorElement* hbheRecHits_energy_egt5_hist[3];
+  dqm::reco::MonitorElement* hbheRecHits_time_egt5_hist[3];
 
   // separate maps for each subdetector
   dqm::reco::MonitorElement* hbheRecHitsEtaPhiMap;
@@ -974,8 +976,15 @@ void ScoutingCollectionMonitor::analyze(const edm::Event& iEvent, const edm::Eve
       getValidHandle(iEvent, hbheRecHitsToken_, hbheRecHitsH, "pfRecHitsHBHE")) {
     hbheRecHitsNumber_hist[0]->Fill(hbheRecHitsH->size());
     for (const auto& hbheRecHit : *hbheRecHitsH) {
+      const bool isStiffRecHit = (hbheRecHit.energy() > 5);
+
       hbheRecHits_energy_hist[0]->Fill(hbheRecHit.energy());
       hbheRecHits_time_hist[0]->Fill(hbheRecHit.time());
+      if (isStiffRecHit) {
+        hbheRecHits_energy_egt5_hist[0]->Fill(hbheRecHit.energy());
+        hbheRecHits_time_egt5_hist[0]->Fill(hbheRecHit.time());
+      }
+
       HcalDetId hcalid(hbheRecHit.detId());
       hbheRecHitsEtaPhiMap->Fill(hcalid.ieta(), hcalid.iphi());
       const auto& subdet = hcalid.subdetId();
@@ -984,11 +993,19 @@ void ScoutingCollectionMonitor::analyze(const edm::Event& iEvent, const edm::Eve
         hbRecHitsEtaPhiMap->Fill(hcalid.ieta(), hcalid.iphi());
         hbheRecHits_energy_hist[1]->Fill(hbheRecHit.energy());
         hbheRecHits_time_hist[1]->Fill(hbheRecHit.time());
+        if (isStiffRecHit) {
+          hbheRecHits_energy_egt5_hist[1]->Fill(hbheRecHit.energy());
+          hbheRecHits_time_egt5_hist[1]->Fill(hbheRecHit.time());
+        }
       } else {  // HE
         nHERechits++;
         heRecHitsEtaPhiMap->Fill(hcalid.ieta(), hcalid.iphi());
         hbheRecHits_energy_hist[2]->Fill(hbheRecHit.energy());
         hbheRecHits_time_hist[2]->Fill(hbheRecHit.time());
+        if (isStiffRecHit) {
+          hbheRecHits_energy_egt5_hist[2]->Fill(hbheRecHit.energy());
+          hbheRecHits_time_egt5_hist[2]->Fill(hbheRecHit.time());
+        }
       }
     }
     // check that rechits size is the same
@@ -1572,9 +1589,24 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
                      0.0,
                      200.0);
 
+    // Energy > 5 GeV histograms
+    hbheRecHits_energy_egt5_hist[i] =
+        ibook.book1D(name + "Rechits_energy_Egt5",
+                     "Energy spectrum of " + subdet + " RecHits (E > 5 GeV); Energy (GeV); Entries",
+                     100,
+                     0.0,
+                     30.0);
+
     hbheRecHits_time_hist[i] =
         ibook.book1D(name + "Rechits_time",
                      "Time of " + subdet + " RecHits; Time of " + subdet + " recHits (ns); Entries",
+                     100,
+                     0.0,
+                     30.0);
+
+    hbheRecHits_time_egt5_hist[i] =
+        ibook.book1D(name + "Rechits_time_Egt5",
+                     "Time of " + subdet + " RecHits; Time of " + subdet + " recHits (E > 5 GeV) (ns); Entries",
                      100,
                      0.0,
                      30.0);

--- a/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
+++ b/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
@@ -1563,6 +1563,7 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
 
   ibook.setCurrentFolder(topfoldername_ + "/CaloRecHitsAll");
 
+  // now do HCAL
   const std::array<std::string, 3> subdets = {{"HBHE", "HB", "HE"}};
 
   // helper lambda
@@ -1577,51 +1578,51 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
 
     hbheRecHitsNumber_hist[i] =
         ibook.book1D(name + "RechitsN",
-                     "number of " + subdet + " RecHits; Number of " + subdet + " recHits; Entries",
+                     "number of " + subdet + " RecHits; Number of " + subdet + " recHits; RecHits",
                      100,
                      0.0,
                      2000.0);
 
     hbheRecHits_energy_hist[i] =
         ibook.book1D(name + "Rechits_energy",
-                     "Energy spectrum of " + subdet + " RecHits; Energy of " + subdet + " recHits (GeV); Entries",
+                     "Energy spectrum of " + subdet + " RecHits; Energy of " + subdet + " recHits (GeV); RecHits",
                      100,
                      0.0,
                      200.0);
 
     // Energy > 5 GeV histograms
-    hbheRecHits_energy_egt5_hist[i] =
-        ibook.book1D(name + "Rechits_energy_Egt5",
-                     "Energy spectrum of " + subdet + " RecHits (E > 5 GeV); Energy (GeV); Entries",
-                     100,
-                     0.0,
-                     30.0);
+    hbheRecHits_energy_egt5_hist[i] = ibook.book1D(
+        name + "StiffRechits_energy",
+        "Energy spectrum of " + subdet + " RecHits  (E > 5 GeV);Energy of stiff " + subdet + " recHits (GeV); RecHits",
+        100,
+        0.0,
+        30.0);
 
     hbheRecHits_time_hist[i] =
         ibook.book1D(name + "Rechits_time",
-                     "Time of " + subdet + " RecHits; Time of " + subdet + " recHits (ns); Entries",
+                     "Time of " + subdet + " RecHits; Time of " + subdet + " recHits (ns); RecHits",
                      100,
                      0.0,
                      30.0);
 
     hbheRecHits_time_egt5_hist[i] =
-        ibook.book1D(name + "Rechits_time_Egt5",
-                     "Time of " + subdet + " RecHits; Time of " + subdet + " recHits (E > 5 GeV) (ns); Entries",
+        ibook.book1D(name + "StiffRechits_time",
+                     "Time of " + subdet + " RecHits (E > 5 GeV); Time of stiff " + subdet + " recHits (ns); RecHits",
                      100,
                      0.0,
                      30.0);
   }
 
   hbheRecHitsEtaPhiMap = ibook.book2D(
-      "hbheRecHitsEtaPhitMap", "Occupancy map of HBHE rechits;ieta;iphi;Entries", 61, -30.5, 30.5, 74, -0.5, 73.5);
+      "hbheRecHitsEtaPhitMap", "Occupancy map of HBHE rechits;ieta;iphi;RecHits", 61, -30.5, 30.5, 74, -0.5, 73.5);
   hbheRecHitsEtaPhiMap->setOption("colz");
 
   hbRecHitsEtaPhiMap = ibook.book2D(
-      "hbRecHitsEtaPhitMap", "Occupancy map of HB rechits;ieta;iphi;Entries", 83, -41.5, 41.5, 72, 0.5, 72.5);
+      "hbRecHitsEtaPhitMap", "Occupancy map of HB rechits;ieta;iphi;RecHits", 83, -41.5, 41.5, 72, 0.5, 72.5);
   hbRecHitsEtaPhiMap->setOption("colz");
 
   heRecHitsEtaPhiMap = ibook.book2D(
-      "heRecHitsEtaPhitMap", "Occupancy map of HE rechits;ieta;iphi;Entries", 83, -41.5, 41.5, 72, 0.5, 72.5);
+      "heRecHitsEtaPhitMap", "Occupancy map of HE rechits;ieta;iphi;RecHits", 83, -41.5, 41.5, 72, 0.5, 72.5);
   heRecHitsEtaPhiMap->setOption("colz");
 }
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/HLTriggerOffline/Scouting/plugins/ScoutingRecHitAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingRecHitAnalyzer.cc
@@ -180,18 +180,18 @@ void ScoutingRecHitAnalyzer<RecHitType>::bookHistograms(DQMStore::IBooker& ibook
       energy_time_histograms_.push_back(
           ibooker.book2D("energy_time", "Energy (GeV);Time (ps);Entries", 100, 0., 20., 100, 0., 1000.));
       ieta_iphi_histograms_.push_back(
-          ibooker.book2D("ieta_iphi", "i#eta;i#phi;Entries", 171, -85.5, 85.5, 360, 0.5, 360.5));
+          ibooker.book2D("ieta_iphi", ";i#eta;i#phi;Entries", 171, -85.5, 85.5, 360, 0.5, 360.5));
       eta_phi_histograms_.push_back(
-          ibooker.book2D("eta_phi", "#eta;#phi;Entries", 170, -85 * kDegToRad, 85 * kDegToRad, 360, -M_PI, M_PI));
+          ibooker.book2D("eta_phi", ";#eta;#phi;Entries", 170, -85 * kDegToRad, 85 * kDegToRad, 360, -M_PI, M_PI));
       ieta_iphi_energy_profiles_.push_back(ibooker.bookProfile2D(
-          "ieta_iphi_energy", "i#eta;i#phi;mean Energy", 171, -85.5, 85.5, 360, 0.5, 360.5, 0, 20));
+          "ieta_iphi_energy", ";i#eta;i#phi;mean Energy", 171, -85.5, 85.5, 360, 0.5, 360.5, 0, 20));
       eta_phi_energy_profiles_.push_back(ibooker.bookProfile2D(
-          "eta_phi_energy", "#eta;#phi;mean Energy", 170, -85 * kDegToRad, 85 * kDegToRad, 360, -M_PI, M_PI, 0, 20));
+          "eta_phi_energy", ";#eta;#phi;mean Energy", 170, -85 * kDegToRad, 85 * kDegToRad, 360, -M_PI, M_PI, 0, 20));
 
       ieta_iphi_time_profiles_.push_back(
-          ibooker.bookProfile2D("ieta_iphi_time", "i#eta;i#phi;mean Time", 171, -85.5, 85.5, 360, 0.5, 360.5, 0, 20));
+          ibooker.bookProfile2D("ieta_iphi_time", ";i#eta;i#phi;mean Time", 171, -85.5, 85.5, 360, 0.5, 360.5, 0, 20));
       eta_phi_time_profiles_.push_back(ibooker.bookProfile2D(
-          "eta_phi_time", "#eta;#phi;mean Time", 170, -85 * kDegToRad, 85 * kDegToRad, 360, -M_PI, M_PI, 0, 20));
+          "eta_phi_time", ";#eta;#phi;mean Time", 170, -85 * kDegToRad, 85 * kDegToRad, 360, -M_PI, M_PI, 0, 20));
 
     } else if constexpr (std::is_same<RecHitType, Run3ScoutingHBHERecHit>()) {
       std::vector<double> eta_edges(59);
@@ -221,35 +221,35 @@ void ScoutingRecHitAnalyzer<RecHitType>::bookHistograms(DQMStore::IBooker& ibook
       energy_histograms_.push_back(ibooker.book1D("energy", "Energy (GeV);Events", 100, 0., 20.));
       time_histograms_.push_back(ibooker.book1D("time", "Time (ns);Events", 100, 0., 30.));
       energy_time_histograms_.push_back(
-          ibooker.book2D("energy_time", "Energy (GeV);Time (ns);Entries", 100., 0., 20., 100., 0., 30.));
+          ibooker.book2D("energy_time", ";Energy (GeV);Time (ns);Entries", 100., 0., 50., 100., 0., 50.));
 
       ieta_iphi_histograms_.push_back(
-          ibooker.book2D("ieta_iphi", "i#eta;i#phi;Entries", 59, -29.5, 29.5, 72, 0.5, 72.5));
+          ibooker.book2D("ieta_iphi", ";i#eta;i#phi;Entries", 59, -29.5, 29.5, 72, 0.5, 72.5));
       ieta_iphi_energy_profiles_.push_back(
-          ibooker.bookProfile2D("ieta_iphi_energy", "i#eta;i#phi;mean Energy", 59, -29.5, 29.5, 72, 0.5, 72.5, 0, 20));
+          ibooker.bookProfile2D("ieta_iphi_energy", ";i#eta;i#phi;mean Energy", 59, -29.5, 29.5, 72, 0.5, 72.5, 0, 20));
 
       ieta_iphi_time_profiles_.push_back(
-          ibooker.bookProfile2D("ieta_iphi_time", "i#eta;i#phi;mean Time", 59, -29.5, 29.5, 72, 0.5, 72.5, 0, 20));
+          ibooker.bookProfile2D("ieta_iphi_time", ";i#eta;i#phi;mean Time", 59, -29.5, 29.5, 72, 0.5, 72.5, 0, 20));
 
       // demote edges from double to float
       std::vector<float> eta_edges_f(eta_edges.begin(), eta_edges.end());
       std::vector<float> phi_edges_f(phi_edges.begin(), phi_edges.end());
       eta_phi_histograms_.push_back(ibooker.book2D("eta_phi",
-                                                   "#eta;#phi;Entries",
+                                                   ";#eta;#phi;Entries",
                                                    eta_edges_f.size() - 1,
                                                    eta_edges_f.data(),
                                                    phi_edges_f.size() - 1,
                                                    phi_edges_f.data()));
 
       eta_phi_energy_profiles_.push_back(ibooker.bookProfile2D("eta_phi_energy",
-                                                               "#eta;#phi;mean Energy",
+                                                               ";#eta;#phi;mean Energy",
                                                                eta_edges.size() - 1,
                                                                eta_edges.data(),
                                                                phi_edges.size() - 1,
                                                                phi_edges.data()));
 
       eta_phi_time_profiles_.push_back(ibooker.bookProfile2D("eta_phi_time",
-                                                             "#eta;#phi;mean Time",
+                                                             ";#eta;#phi;mean Time",
                                                              eta_edges.size() - 1,
                                                              eta_edges.data(),
                                                              phi_edges.size() - 1,

--- a/HLTriggerOffline/Scouting/plugins/ScoutingRecHitAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingRecHitAnalyzer.cc
@@ -174,24 +174,52 @@ void ScoutingRecHitAnalyzer<RecHitType>::bookHistograms(DQMStore::IBooker& ibook
   for (auto const& trigger_name : trigger_names_) {
     ibooker.setCurrentFolder(topFolderName_ + "/" + trigger_name);
     if constexpr (std::is_same<RecHitType, Run3ScoutingEBRecHit>()) {
-      number_histograms_.push_back(ibooker.book1D("number", "Number;Events", 100, 0., 1000.));
-      energy_histograms_.push_back(ibooker.book1D("energy", "Energy (GeV);Events", 100, 0., 20.));
-      time_histograms_.push_back(ibooker.book1D("time", "Time (ps);Events", 100, 0., 1000.));
-      energy_time_histograms_.push_back(
-          ibooker.book2D("energy_time", "Energy (GeV);Time (ps);Entries", 100, 0., 20., 100, 0., 1000.));
-      ieta_iphi_histograms_.push_back(
-          ibooker.book2D("ieta_iphi", ";i#eta;i#phi;Entries", 171, -85.5, 85.5, 360, 0.5, 360.5));
-      eta_phi_histograms_.push_back(
-          ibooker.book2D("eta_phi", ";#eta;#phi;Entries", 170, -85 * kDegToRad, 85 * kDegToRad, 360, -M_PI, M_PI));
-      ieta_iphi_energy_profiles_.push_back(ibooker.bookProfile2D(
-          "ieta_iphi_energy", ";i#eta;i#phi;mean Energy", 171, -85.5, 85.5, 360, 0.5, 360.5, 0, 20));
-      eta_phi_energy_profiles_.push_back(ibooker.bookProfile2D(
-          "eta_phi_energy", ";#eta;#phi;mean Energy", 170, -85 * kDegToRad, 85 * kDegToRad, 360, -M_PI, M_PI, 0, 20));
+      // 1D histograms
+      number_histograms_.push_back(ibooker.book1D("number", "Number or RecHits;RecHits Number;Events", 100, 0., 1000.));
+      energy_histograms_.push_back(
+          ibooker.book1D("energy", "Energy of RecHits;RecHit Energy (GeV);RecHits", 100, 0., 20.));
+      time_histograms_.push_back(ibooker.book1D("time", "Time of RecHits;RecHit Time (ns);RecHits", 200, -100., 100.));
 
-      ieta_iphi_time_profiles_.push_back(
-          ibooker.bookProfile2D("ieta_iphi_time", ";i#eta;i#phi;mean Time", 171, -85.5, 85.5, 360, 0.5, 360.5, 0, 20));
-      eta_phi_time_profiles_.push_back(ibooker.bookProfile2D(
-          "eta_phi_time", ";#eta;#phi;mean Time", 170, -85 * kDegToRad, 85 * kDegToRad, 360, -M_PI, M_PI, 0, 20));
+      // 2D histograms
+      energy_time_histograms_.push_back(ibooker.book2D(
+          "energy_time", "RecHit Time vs Energy;Energy (GeV);Time (ns);Entries", 100, 0., 20., 100, -100., 100.));
+      ieta_iphi_histograms_.push_back(
+          ibooker.book2D("ieta_iphi", "RecHit i#phi vs i#eta;i#eta;i#phi;Entries", 171, -85.5, 85.5, 360, 0.5, 360.5));
+      eta_phi_histograms_.push_back(ibooker.book2D("eta_phi",
+                                                   "RecHit #phi vs #eta;#eta;#phi (rad);Entries",
+                                                   170,
+                                                   -85 * kDegToRad,
+                                                   85 * kDegToRad,
+                                                   360,
+                                                   -M_PI,
+                                                   M_PI));
+
+      // 2D profiles
+      ieta_iphi_energy_profiles_.push_back(ibooker.bookProfile2D(
+          "ieta_iphi_energy", "mean RecHit Energy;i#eta;i#phi;mean Energy", 171, -85.5, 85.5, 360, 0.5, 360.5, 0, 20));
+      eta_phi_energy_profiles_.push_back(ibooker.bookProfile2D("eta_phi_energy",
+                                                               "mean RecHit Energy;#eta;#phi (rad);mean Energy",
+                                                               170,
+                                                               -85 * kDegToRad,
+                                                               85 * kDegToRad,
+                                                               360,
+                                                               -M_PI,
+                                                               M_PI,
+                                                               0,
+                                                               20));
+
+      ieta_iphi_time_profiles_.push_back(ibooker.bookProfile2D(
+          "ieta_iphi_time", "Mean RecHit time;i#eta;i#phi;mean Time", 171, -85.5, 85.5, 360, 0.5, 360.5, 0, 20));
+      eta_phi_time_profiles_.push_back(ibooker.bookProfile2D("eta_phi_time",
+                                                             "Mean RecHit time;#eta;#phi (rad);mean Time",
+                                                             170,
+                                                             -85 * kDegToRad,
+                                                             85 * kDegToRad,
+                                                             360,
+                                                             -M_PI,
+                                                             M_PI,
+                                                             0,
+                                                             20));
 
     } else if constexpr (std::is_same<RecHitType, Run3ScoutingHBHERecHit>()) {
       std::vector<double> eta_edges(59);
@@ -217,39 +245,45 @@ void ScoutingRecHitAnalyzer<RecHitType>::bookHistograms(DQMStore::IBooker& ibook
         return phiMin + i * dphi;
       });
 
-      number_histograms_.push_back(ibooker.book1D("number", "Number;Events", 100, 0., 2000.));
-      energy_histograms_.push_back(ibooker.book1D("energy", "Energy (GeV);Events", 100, 0., 20.));
-      time_histograms_.push_back(ibooker.book1D("time", "Time (ns);Events", 100, 0., 30.));
-      energy_time_histograms_.push_back(
-          ibooker.book2D("energy_time", ";Energy (GeV);Time (ns);Entries", 100., 0., 50., 100., 0., 50.));
+      // 1D histograms
+      number_histograms_.push_back(ibooker.book1D("number", "Number of RecHits;RecHits Number;Events", 100, 0., 2000.));
+      energy_histograms_.push_back(
+          ibooker.book1D("energy", "Energy of RecHits;RecHit Energy (GeV);RecHits", 100, 0., 20.));
+      time_histograms_.push_back(ibooker.book1D("time", "Time of RecHits;RecHit Time (ns);RecHits", 100, 0., 30.));
+
+      // 2D histograms
+      energy_time_histograms_.push_back(ibooker.book2D(
+          "energy_time", "RecHit Time vs Energy;Energy (GeV);Time (ns);Entries", 100., 0., 50., 100., 0, 30.));
 
       ieta_iphi_histograms_.push_back(
-          ibooker.book2D("ieta_iphi", ";i#eta;i#phi;Entries", 59, -29.5, 29.5, 72, 0.5, 72.5));
-      ieta_iphi_energy_profiles_.push_back(
-          ibooker.bookProfile2D("ieta_iphi_energy", ";i#eta;i#phi;mean Energy", 59, -29.5, 29.5, 72, 0.5, 72.5, 0, 20));
+          ibooker.book2D("ieta_iphi", "RecHit i#phi vs i#eta;i#eta;i#phi;Entries", 59, -29.5, 29.5, 72, 0.5, 72.5));
 
-      ieta_iphi_time_profiles_.push_back(
-          ibooker.bookProfile2D("ieta_iphi_time", ";i#eta;i#phi;mean Time", 59, -29.5, 29.5, 72, 0.5, 72.5, 0, 20));
+      // 2D profiles
+      ieta_iphi_energy_profiles_.push_back(ibooker.bookProfile2D(
+          "ieta_iphi_energy", "mean RecHit Energy;i#eta;i#phi;mean Energy", 59, -29.5, 29.5, 72, 0.5, 72.5, 0, 100.));
+
+      ieta_iphi_time_profiles_.push_back(ibooker.bookProfile2D(
+          "ieta_iphi_time", "mean RecHit time;i#eta;i#phi;mean Time", 59, -29.5, 29.5, 72, 0.5, 72.5, 0, 30.));
 
       // demote edges from double to float
       std::vector<float> eta_edges_f(eta_edges.begin(), eta_edges.end());
       std::vector<float> phi_edges_f(phi_edges.begin(), phi_edges.end());
       eta_phi_histograms_.push_back(ibooker.book2D("eta_phi",
-                                                   ";#eta;#phi;Entries",
+                                                   "RecHit #phi vs #eta;#eta;#phi (rad);Entries",
                                                    eta_edges_f.size() - 1,
                                                    eta_edges_f.data(),
                                                    phi_edges_f.size() - 1,
                                                    phi_edges_f.data()));
 
       eta_phi_energy_profiles_.push_back(ibooker.bookProfile2D("eta_phi_energy",
-                                                               ";#eta;#phi;mean Energy",
+                                                               "mean RecHit Energy;#eta;#phi (rad);mean Energy",
                                                                eta_edges.size() - 1,
                                                                eta_edges.data(),
                                                                phi_edges.size() - 1,
                                                                phi_edges.data()));
 
       eta_phi_time_profiles_.push_back(ibooker.bookProfile2D("eta_phi_time",
-                                                             ";#eta;#phi;mean Time",
+                                                             "mean RecHit Time;#eta;#phi (rad);mean Time",
                                                              eta_edges.size() - 1,
                                                              eta_edges.data(),
                                                              phi_edges.size() - 1,

--- a/HLTriggerOffline/Scouting/plugins/ScoutingRecHitAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingRecHitAnalyzer.cc
@@ -104,6 +104,7 @@ protected:
   std::vector<MonitorElement*> time_histograms_;
   std::vector<MonitorElement*> ieta_iphi_histograms_;
   std::vector<MonitorElement*> eta_phi_histograms_;
+  std::vector<MonitorElement*> energy_time_histograms_;
   std::vector<MonitorElement*> ieta_iphi_energy_profiles_;
   std::vector<MonitorElement*> eta_phi_energy_profiles_;
   std::vector<MonitorElement*> ieta_iphi_time_profiles_;
@@ -176,6 +177,8 @@ void ScoutingRecHitAnalyzer<RecHitType>::bookHistograms(DQMStore::IBooker& ibook
       number_histograms_.push_back(ibooker.book1D("number", "Number;Events", 100, 0., 1000.));
       energy_histograms_.push_back(ibooker.book1D("energy", "Energy (GeV);Events", 100, 0., 20.));
       time_histograms_.push_back(ibooker.book1D("time", "Time (ps);Events", 100, 0., 1000.));
+      energy_time_histograms_.push_back(
+          ibooker.book2D("energy_time", "Energy (GeV);Time (ps);Entries", 100, 0., 20., 100, 0., 1000.));
       ieta_iphi_histograms_.push_back(
           ibooker.book2D("ieta_iphi", "i#eta;i#phi;Entries", 171, -85.5, 85.5, 360, 0.5, 360.5));
       eta_phi_histograms_.push_back(
@@ -217,6 +220,9 @@ void ScoutingRecHitAnalyzer<RecHitType>::bookHistograms(DQMStore::IBooker& ibook
       number_histograms_.push_back(ibooker.book1D("number", "Number;Events", 100, 0., 2000.));
       energy_histograms_.push_back(ibooker.book1D("energy", "Energy (GeV);Events", 100, 0., 20.));
       time_histograms_.push_back(ibooker.book1D("time", "Time (ns);Events", 100, 0., 30.));
+      energy_time_histograms_.push_back(
+          ibooker.book2D("energy_time", "Energy (GeV);Time (ns);Entries", 100., 0., 20., 100., 0., 30.));
+
       ieta_iphi_histograms_.push_back(
           ibooker.book2D("ieta_iphi", "i#eta;i#phi;Entries", 59, -29.5, 29.5, 72, 0.5, 72.5));
       ieta_iphi_energy_profiles_.push_back(
@@ -295,6 +301,7 @@ void ScoutingRecHitAnalyzer<RecHitType>::analyze(const edm::Event& iEvent, const
       time_histograms_[0]->Fill(time);
       ieta_iphi_histograms_[0]->Fill(ieta, iphi);
       eta_phi_histograms_[0]->Fill(eta, phi);
+      energy_time_histograms_[0]->Fill(energy, time);
       ieta_iphi_energy_profiles_[0]->Fill(ieta, iphi, energy);
       eta_phi_energy_profiles_[0]->Fill(eta, phi, energy);
       ieta_iphi_time_profiles_[0]->Fill(ieta, iphi, time);
@@ -317,6 +324,7 @@ void ScoutingRecHitAnalyzer<RecHitType>::analyze(const edm::Event& iEvent, const
           time_histograms_[itrigger]->Fill(time);
           ieta_iphi_histograms_[itrigger]->Fill(ieta, iphi);
           eta_phi_histograms_[itrigger]->Fill(eta, phi);
+          energy_time_histograms_[itrigger]->Fill(energy, time);
           ieta_iphi_energy_profiles_[itrigger]->Fill(ieta, iphi, energy);
           eta_phi_energy_profiles_[itrigger]->Fill(eta, phi, energy);
           ieta_iphi_time_profiles_[itrigger]->Fill(ieta, iphi, time);


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/50257

#### PR description:

This PR improves scouting calorimeter rechit DQM in `DQM/HLTEvF` and `HLTriggerOffline/Scouting`.
It packages the various comments received while reviewing what is available in the discussion at [CMSHLT-3743](https://its.cern.ch/jira/browse/CMSHLT-3743). 

Changes include:

- Split HBHE monitoring into HBHE (inclusive), HB, and HE.
- Added per-subdetector histograms for number of rechits, energy, and time.
- Added energy and time histograms for E > 5 GeV (“stiff” rechits).
- Added Energy vs Time 2D histograms.
- Updated EB/EE timing histograms (units in ns, range set to [-100, 100]).
- Improved axis labels and histogram consistency.
- Minor code cleanup and refactoring.

No changes to event content or reconstruction; DQM-only update.

#### PR validation:

Run successfully the following command:

```bash
#!/bin/bash -ex                                                                                                                                                                                             

LOCALPATH='/eos/cms/store/data/Run2025G/EphemeralHLTPhysics0/RAW/v1/000/398/183/00000/'
echo "Input source: |${LOCALPATH}|"
LOCALFILES=$(ls -1 ${LOCALPATH})
ALL_FILES=""
for f in ${LOCALFILES[@]}; do
    ALL_FILES+="file:${LOCALPATH}/${f},"
done

# Remove the last character                                                                                                                                                                                 
ALL_FILES="${ALL_FILES%?}"
echo "Discovered files: $ALL_FILES"

cmsDriver.py step2 -s L1REPACK:uGT,HLT:GRun,DQM:hltScoutingMonitoringRecHits+hltScoutingCollectionMonitor \
             --conditions 160X_dataRun3_HLT_v1 \
             --custom_conditions "L1Menu_Collisions2026_v1_0_0_xml,L1TUtmTriggerMenuRcd,frontier://FrontierProd/CMS_CONDITIONS" \
             --datatier DQMIO \
             -n 1000 \
             --eventcontent DQMIO \
             --geometry DB:Extended \
             --era Run3_2025 \
             --filein file:$ALL_FILES \
             --fileout file:step2.root \
             --nThreads 24 \
             --process HLTX \
             --python_filename hlt.py \
             --inputCommands='keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT' \
             --no_exec

cat <<@EOF >> hlt.py
process.scoutingCollectionMonitor.onlineMetaDataDigis = "hltOnlineMetaDataDigis"
process.L1BitsScouting.src="hltGtStage2Digis"
@EOF

cmsRun hlt.py >& hlt.log

cmsDriver.py step3 -s HARVESTING:@standardDQM \
             --conditions 160X_dataRun3_HLT_v1 \
             --data \
             --geometry DB:Extended \
             --scenario pp \
             --filetype DQM \
             --era Run3_2025 \
             -n 1000 \
             --filein file:step2.root \
             --fileout file:step3.root \
             --no_exec

cmsRun step3_HARVESTING.py >& harvesting.log
```
The output DQM file is available [here](https://cernbox.cern.ch/s/2C2jAfq3m1bmtg8).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/50257 for 2026 data-taking operations.