### PR TITLE
[FWLite] Avoid dependency on TrackingTools/PatternTools

### DIFF
--- a/DataFormats/EgammaTrackReco/interface/ConversionTrack.h
+++ b/DataFormats/EgammaTrackReco/interface/ConversionTrack.h
@@ -14,7 +14,7 @@
 #define EgammaReco_ConversionTrack_h
 
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "TrackingTools/PatternTools/interface/TrajectoryFwd.h"
+class Trajectory;
 namespace reco {
   class ConversionTrack {
   public:


### PR DESCRIPTION
This is a workaround to fix the FWLITE builds (see https://github.com/cms-sw/cmssw/issues/50210 issue for details). This reverts the `Trajectory` change for `DataFormats/EgammaTrackReco` done in https://github.com/cms-sw/cmssw/pull/50161.

This is a workaround to fix the FWLite build which are failing as `TrackingTools/PatternTools/interface/TrajectoryFwd.h` is not part of [fwlite build set](https://raw.githubusercontent.com/cms-sw/cmsdist/refs/heads/IB/CMSSW_16_1_X/master/fwlite_build_set.file)