### PR TITLE
[EVOLUTION_X] Move stored classes in DataFormats/{CSC,GEM}{Digi,RecHit} to io_v1 namespace

### DIFF
--- a/AnalysisDataFormats/SUSYBSMObjects/src/classes_def.xml
+++ b/AnalysisDataFormats/SUSYBSMObjects/src/classes_def.xml
@@ -47,8 +47,8 @@
    <class name="edm::Wrapper<susybsm::HSCPDeDxInfoCollection>"/>
    <class name="edm::Wrapper<susybsm::HSCPDeDxInfoValueMap>"/>
 
-   <class name="susybsm::MuonSegment" ClassVersion="10">
-    <version ClassVersion="10" checksum="3541168201"/>
+   <class name="susybsm::MuonSegment" ClassVersion="3">
+    <version ClassVersion="3" checksum="3201138241"/>
    </class>
    <class name="susybsm::MuonSegmentCollection"/>
    <class name="susybsm::MuonSegmentRef"/>

--- a/DataFormats/CSCDigi/interface/CSCALCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCALCTDigi.h
@@ -14,131 +14,136 @@
 #include <limits>
 #include <vector>
 
-class CSCALCTDigi {
-public:
-  enum class Version { Legacy = 0, Run3 };
+namespace io_v1 {
 
-  typedef std::vector<std::vector<uint16_t>> WireContainer;
+  class CSCALCTDigi {
+  public:
+    enum class Version { Legacy = 0, Run3 };
 
-  /// Constructors
-  CSCALCTDigi(const uint16_t valid,
-              const uint16_t quality,
-              const uint16_t accel,
-              const uint16_t patternb,
-              const uint16_t keywire,
-              const uint16_t bx,
-              const uint16_t trknmb = 0,
-              const uint16_t hmt = 0,
-              const Version version = Version::Legacy);
-  /// default
-  CSCALCTDigi();
+    typedef std::vector<std::vector<uint16_t>> WireContainer;
 
-  /// clear this ALCT
-  void clear();
+    /// Constructors
+    CSCALCTDigi(const uint16_t valid,
+                const uint16_t quality,
+                const uint16_t accel,
+                const uint16_t patternb,
+                const uint16_t keywire,
+                const uint16_t bx,
+                const uint16_t trknmb = 0,
+                const uint16_t hmt = 0,
+                const Version version = Version::Legacy);
+    /// default
+    CSCALCTDigi();
 
-  /// check ALCT validity (1 - valid ALCT)
-  bool isValid() const { return valid_; }
+    /// clear this ALCT
+    void clear();
 
-  /// set valid
-  void setValid(const uint16_t valid) { valid_ = valid; }
+    /// check ALCT validity (1 - valid ALCT)
+    bool isValid() const { return valid_; }
 
-  /// return quality of a pattern
-  uint16_t getQuality() const { return quality_; }
+    /// set valid
+    void setValid(const uint16_t valid) { valid_ = valid; }
 
-  /// set quality
-  void setQuality(const uint16_t quality) { quality_ = quality; }
+    /// return quality of a pattern
+    uint16_t getQuality() const { return quality_; }
 
-  /// return Accelerator bit
-  /// 1-Accelerator pattern, 0-CollisionA or CollisionB pattern
-  uint16_t getAccelerator() const { return accel_; }
+    /// set quality
+    void setQuality(const uint16_t quality) { quality_ = quality; }
 
-  /// set accelerator bit
-  void setAccelerator(const uint16_t accelerator) { accel_ = accelerator; }
+    /// return Accelerator bit
+    /// 1-Accelerator pattern, 0-CollisionA or CollisionB pattern
+    uint16_t getAccelerator() const { return accel_; }
 
-  /// return Collision Pattern B bit
-  /// 1-CollisionB pattern (accel_ = 0),
-  /// 0-CollisionA pattern (accel_ = 0)
-  uint16_t getCollisionB() const { return patternb_; }
+    /// set accelerator bit
+    void setAccelerator(const uint16_t accelerator) { accel_ = accelerator; }
 
-  /// set Collision Pattern B bit
-  void setCollisionB(const uint16_t collision) { patternb_ = collision; }
+    /// return Collision Pattern B bit
+    /// 1-CollisionB pattern (accel_ = 0),
+    /// 0-CollisionA pattern (accel_ = 0)
+    uint16_t getCollisionB() const { return patternb_; }
 
-  /// return key wire group
-  uint16_t getKeyWG() const { return keywire_; }
+    /// set Collision Pattern B bit
+    void setCollisionB(const uint16_t collision) { patternb_ = collision; }
 
-  /// set key wire group
-  void setKeyWG(const uint16_t keyWG) { keywire_ = keyWG; }
+    /// return key wire group
+    uint16_t getKeyWG() const { return keywire_; }
 
-  /// return BX - five low bits of BXN counter tagged by the ALCT
-  uint16_t getBX() const { return bx_; }
+    /// set key wire group
+    void setKeyWG(const uint16_t keyWG) { keywire_ = keyWG; }
 
-  /// set BX
-  void setBX(const uint16_t BX) { bx_ = BX; }
+    /// return BX - five low bits of BXN counter tagged by the ALCT
+    uint16_t getBX() const { return bx_; }
 
-  /// return track number (1,2)
-  uint16_t getTrknmb() const { return trknmb_; }
+    /// set BX
+    void setBX(const uint16_t BX) { bx_ = BX; }
 
-  /// Set track number (1,2) after sorting ALCTs.
-  void setTrknmb(const uint16_t number) { trknmb_ = number; }
+    /// return track number (1,2)
+    uint16_t getTrknmb() const { return trknmb_; }
 
-  /// return 12-bit full BX.
-  uint16_t getFullBX() const { return fullbx_; }
+    /// Set track number (1,2) after sorting ALCTs.
+    void setTrknmb(const uint16_t number) { trknmb_ = number; }
 
-  /// Set 12-bit full BX.
-  void setFullBX(const uint16_t fullbx) { fullbx_ = fullbx; }
+    /// return 12-bit full BX.
+    uint16_t getFullBX() const { return fullbx_; }
 
-  /// return the high multiplicity bits
-  uint16_t getHMT() const;
+    /// Set 12-bit full BX.
+    void setFullBX(const uint16_t fullbx) { fullbx_ = fullbx; }
 
-  /// set the high multiplicity bits
-  void setHMT(const uint16_t hmt);
+    /// return the high multiplicity bits
+    uint16_t getHMT() const;
 
-  /// True if the first ALCT has a larger quality, or if it has the same
-  /// quality but a larger wire group.
-  bool operator>(const CSCALCTDigi&) const;
+    /// set the high multiplicity bits
+    void setHMT(const uint16_t hmt);
 
-  /// True if all members (except the number) of both ALCTs are equal.
-  bool operator==(const CSCALCTDigi&) const;
+    /// True if the first ALCT has a larger quality, or if it has the same
+    /// quality but a larger wire group.
+    bool operator>(const CSCALCTDigi&) const;
 
-  /// True if the preceding one is false.
-  bool operator!=(const CSCALCTDigi&) const;
+    /// True if all members (except the number) of both ALCTs are equal.
+    bool operator==(const CSCALCTDigi&) const;
 
-  /// Print content of digi.
-  void print() const;
+    /// True if the preceding one is false.
+    bool operator!=(const CSCALCTDigi&) const;
 
-  /// set wiregroup number
-  void setWireGroup(uint16_t wiregroup) { keywire_ = wiregroup; }
+    /// Print content of digi.
+    void print() const;
 
-  /// Distinguish Run-1/2 from Run-3
-  bool isRun3() const { return version_ == Version::Run3; }
+    /// set wiregroup number
+    void setWireGroup(uint16_t wiregroup) { keywire_ = wiregroup; }
 
-  void setRun3(const bool isRun3);
+    /// Distinguish Run-1/2 from Run-3
+    bool isRun3() const { return version_ == Version::Run3; }
 
-  // wire hits in this ALCT
-  const WireContainer& getHits() const { return hits_.empty() ? emptyContainer() : hits_; }
+    void setRun3(const bool isRun3);
 
-  void setHits(const WireContainer& hits) { hits_ = hits; }
+    // wire hits in this ALCT
+    const WireContainer& getHits() const { return hits_.empty() ? emptyContainer() : hits_; }
 
-private:
-  static const WireContainer& emptyContainer();
-  uint16_t valid_;
-  uint16_t quality_;
-  uint16_t accel_;
-  uint16_t patternb_;  // not used since 2007
-  uint16_t keywire_;
-  uint16_t bx_;
-  uint16_t trknmb_;
-  uint16_t fullbx_;
-  // In Run-3, CSC trigger data will include the high-multiplicity
-  // bits for a chamber. These bits may indicate the observation of
-  // "exotic" events. This data member was included in a prototype.
-  // Later on, we developed a dedicated object: "CSCShowerDigi<Anode>"
-  uint16_t hmt_;
+    void setHits(const WireContainer& hits) { hits_ = hits; }
 
-  Version version_;
-  // which hits are in this ALCT?
-  WireContainer hits_;
-};
+  private:
+    static const WireContainer& emptyContainer();
+    uint16_t valid_;
+    uint16_t quality_;
+    uint16_t accel_;
+    uint16_t patternb_;  // not used since 2007
+    uint16_t keywire_;
+    uint16_t bx_;
+    uint16_t trknmb_;
+    uint16_t fullbx_;
+    // In Run-3, CSC trigger data will include the high-multiplicity
+    // bits for a chamber. These bits may indicate the observation of
+    // "exotic" events. This data member was included in a prototype.
+    // Later on, we developed a dedicated object: "CSCShowerDigi<Anode>"
+    uint16_t hmt_;
 
-std::ostream& operator<<(std::ostream& o, const CSCALCTDigi& digi);
+    Version version_;
+    // which hits are in this ALCT?
+    WireContainer hits_;
+  };
+
+  std::ostream& operator<<(std::ostream& o, const CSCALCTDigi& digi);
+
+}  // namespace io_v1
+using CSCALCTDigi = io_v1::CSCALCTDigi;
 #endif

--- a/DataFormats/CSCDigi/interface/CSCALCTDigiFwd.h
+++ b/DataFormats/CSCDigi/interface/CSCALCTDigiFwd.h
@@ -1,6 +1,9 @@
 #ifndef DataFormats_CSCDigi_CSCALCTDigiFwd_h
 #define DataFormats_CSCDigi_CSCALCTDigiFwd_h
 
-class CSCALCTDigi;
+namespace io_v1 {
+  class CSCALCTDigi;
+}
+using CSCALCTDigi = io_v1::CSCALCTDigi;
 
 #endif

--- a/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
@@ -14,132 +14,134 @@
 #include <vector>
 #include <limits>
 
-class CSCCLCTDigi {
-public:
-  typedef std::vector<std::vector<uint16_t>> ComparatorContainer;
+namespace io_v1 {
 
-  enum class Version { Legacy = 0, Run3 };
-  // for data vs emulator studies
-  enum CLCTBXMask { kBXDataMask = 0x3 };
+  class CSCCLCTDigi {
+  public:
+    typedef std::vector<std::vector<uint16_t>> ComparatorContainer;
 
-  /// Constructors
-  CSCCLCTDigi(const uint16_t valid,
-              const uint16_t quality,
-              const uint16_t pattern,
-              const uint16_t striptype,
-              const uint16_t bend,
-              const uint16_t strip,
-              const uint16_t cfeb,
-              const uint16_t bx,
-              const uint16_t trknmb = 0,
-              const uint16_t fullbx = 0,
-              const int16_t compCode = -1,
-              const Version version = Version::Legacy,
-              const bool run3_quart_strip_bit = false,
-              const bool run3_eighth_strip_bit = false,
-              const uint16_t run3_pattern = 0,
-              const uint16_t run3_slope = 0);
+    enum class Version { Legacy = 0, Run3 };
+    // for data vs emulator studies
+    enum CLCTBXMask { kBXDataMask = 0x3 };
 
-  /// default (calls clear())
-  CSCCLCTDigi();
+    /// Constructors
+    CSCCLCTDigi(const uint16_t valid,
+                const uint16_t quality,
+                const uint16_t pattern,
+                const uint16_t striptype,
+                const uint16_t bend,
+                const uint16_t strip,
+                const uint16_t cfeb,
+                const uint16_t bx,
+                const uint16_t trknmb = 0,
+                const uint16_t fullbx = 0,
+                const int16_t compCode = -1,
+                const Version version = Version::Legacy,
+                const bool run3_quart_strip_bit = false,
+                const bool run3_eighth_strip_bit = false,
+                const uint16_t run3_pattern = 0,
+                const uint16_t run3_slope = 0);
 
-  /// clear this CLCT
-  void clear();
+    /// default (calls clear())
+    CSCCLCTDigi();
 
-  /// check CLCT validity (1 - valid CLCT)
-  bool isValid() const { return valid_; }
+    /// clear this CLCT
+    void clear();
 
-  /// set valid
-  void setValid(const uint16_t valid) { valid_ = valid; }
+    /// check CLCT validity (1 - valid CLCT)
+    bool isValid() const { return valid_; }
 
-  /// return quality of a pattern (number of layers hit!)
-  uint16_t getQuality() const { return quality_; }
+    /// set valid
+    void setValid(const uint16_t valid) { valid_ = valid; }
 
-  /// set quality
-  void setQuality(const uint16_t quality) { quality_ = quality; }
+    /// return quality of a pattern (number of layers hit!)
+    uint16_t getQuality() const { return quality_; }
 
-  /// return pattern
-  uint16_t getPattern() const { return pattern_; }
+    /// set quality
+    void setQuality(const uint16_t quality) { quality_ = quality; }
 
-  /// set pattern
-  void setPattern(const uint16_t pattern) { pattern_ = pattern; }
+    /// return pattern
+    uint16_t getPattern() const { return pattern_; }
 
-  /// return pattern
-  uint16_t getRun3Pattern() const { return run3_pattern_; }
+    /// set pattern
+    void setPattern(const uint16_t pattern) { pattern_ = pattern; }
 
-  /// set pattern
-  void setRun3Pattern(const uint16_t pattern) { run3_pattern_ = pattern; }
+    /// return pattern
+    uint16_t getRun3Pattern() const { return run3_pattern_; }
 
-  /// return the slope
-  uint16_t getSlope() const { return run3_slope_; }
+    /// set pattern
+    void setRun3Pattern(const uint16_t pattern) { run3_pattern_ = pattern; }
 
-  /// set the slope
-  void setSlope(const uint16_t slope) { run3_slope_ = slope; }
+    /// return the slope
+    uint16_t getSlope() const { return run3_slope_; }
 
-  /// slope in number of half-strips/layer
-  /// negative means left-bending
-  /// positive means right-bending
-  float getFractionalSlope() const;
+    /// set the slope
+    void setSlope(const uint16_t slope) { run3_slope_ = slope; }
 
-  /// return striptype
-  uint16_t getStripType() const { return striptype_; }
+    /// slope in number of half-strips/layer
+    /// negative means left-bending
+    /// positive means right-bending
+    float getFractionalSlope() const;
 
-  /// set stripType
-  void setStripType(const uint16_t stripType) { striptype_ = stripType; }
+    /// return striptype
+    uint16_t getStripType() const { return striptype_; }
 
-  /// return bending
-  /// 0: left-bending (negative delta-strip / delta layer)
-  /// 1: right-bending (positive delta-strip / delta layer)
-  uint16_t getBend() const { return bend_; }
+    /// set stripType
+    void setStripType(const uint16_t stripType) { striptype_ = stripType; }
 
-  /// set bend
-  void setBend(const uint16_t bend) { bend_ = bend; }
+    /// return bending
+    /// 0: left-bending (negative delta-strip / delta layer)
+    /// 1: right-bending (positive delta-strip / delta layer)
+    uint16_t getBend() const { return bend_; }
 
-  /// return halfstrip that goes from 0 to 31 in a (D)CFEB
-  uint16_t getStrip() const { return strip_; }
+    /// set bend
+    void setBend(const uint16_t bend) { bend_ = bend; }
 
-  /// set strip
-  void setStrip(const uint16_t strip) { strip_ = strip; }
+    /// return halfstrip that goes from 0 to 31 in a (D)CFEB
+    uint16_t getStrip() const { return strip_; }
 
-  /// set single quart strip bit
-  void setQuartStripBit(const bool quartStripBit) { run3_quart_strip_bit_ = quartStripBit; }
+    /// set strip
+    void setStrip(const uint16_t strip) { strip_ = strip; }
 
-  /// get single quart strip bit
-  bool getQuartStripBit() const { return run3_quart_strip_bit_; }
+    /// set single quart strip bit
+    void setQuartStripBit(const bool quartStripBit) { run3_quart_strip_bit_ = quartStripBit; }
 
-  /// set single eighth strip bit
-  void setEighthStripBit(const bool eighthStripBit) { run3_eighth_strip_bit_ = eighthStripBit; }
+    /// get single quart strip bit
+    bool getQuartStripBit() const { return run3_quart_strip_bit_; }
 
-  /// get single eighth strip bit
-  bool getEighthStripBit() const { return run3_eighth_strip_bit_; }
+    /// set single eighth strip bit
+    void setEighthStripBit(const bool eighthStripBit) { run3_eighth_strip_bit_ = eighthStripBit; }
 
-  /// return Key CFEB ID
-  uint16_t getCFEB() const { return cfeb_; }
+    /// get single eighth strip bit
+    bool getEighthStripBit() const { return run3_eighth_strip_bit_; }
 
-  /// set Key CFEB ID
-  void setCFEB(const uint16_t cfeb) { cfeb_ = cfeb; }
+    /// return Key CFEB ID
+    uint16_t getCFEB() const { return cfeb_; }
 
-  /// return BX
-  uint16_t getBX() const { return bx_; }
+    /// set Key CFEB ID
+    void setCFEB(const uint16_t cfeb) { cfeb_ = cfeb; }
 
-  /// return 2-bit BX as in data
-  uint16_t getBXData() const { return bx_ & kBXDataMask; }
+    /// return BX
+    uint16_t getBX() const { return bx_; }
 
-  /// set bx
-  void setBX(const uint16_t bx) { bx_ = bx; }
+    /// return 2-bit BX as in data
+    uint16_t getBXData() const { return bx_ & kBXDataMask; }
 
-  /// return track number (1,2)
-  uint16_t getTrknmb() const { return trknmb_; }
+    /// set bx
+    void setBX(const uint16_t bx) { bx_ = bx; }
 
-  /// Convert strip_ and cfeb_ to keyStrip. Each CFEB has up to 16 strips
-  /// (32 halfstrips). There are 5 cfebs.  The "strip_" variable is one
-  /// of 32 halfstrips on the keylayer of a single CFEB, so that
-  /// Halfstrip = (cfeb*32 + strip).
-  /// This function can also return the quartstrip or eighthstrip
-  /// when the comparator code has been set
-  uint16_t getKeyStrip(const uint16_t n = 2) const;
+    /// return track number (1,2)
+    uint16_t getTrknmb() const { return trknmb_; }
 
-  /*
+    /// Convert strip_ and cfeb_ to keyStrip. Each CFEB has up to 16 strips
+    /// (32 halfstrips). There are 5 cfebs.  The "strip_" variable is one
+    /// of 32 halfstrips on the keylayer of a single CFEB, so that
+    /// Halfstrip = (cfeb*32 + strip).
+    /// This function can also return the quartstrip or eighthstrip
+    /// when the comparator code has been set
+    uint16_t getKeyStrip(const uint16_t n = 2) const;
+
+    /*
     Strips are numbered starting from 1 in CMSSW
     Half-strips, quarter-strips and eighth-strips are numbered starting from 0
     The table below shows the correct numbering
@@ -156,86 +158,88 @@ public:
     Note: the CSC geometry also has a strip offset of +/- 0.25 strips. When comparing the
     CLCT/LCT position with the true muon position, take the offset into account!
    */
-  float getFractionalStrip(const uint16_t n = 2) const;
+    float getFractionalStrip(const uint16_t n = 2) const;
 
-  /// Set track number (1,2) after sorting CLCTs.
-  void setTrknmb(const uint16_t number) { trknmb_ = number; }
+    /// Set track number (1,2) after sorting CLCTs.
+    void setTrknmb(const uint16_t number) { trknmb_ = number; }
 
-  /// return 12-bit full BX.
-  uint16_t getFullBX() const { return fullbx_; }
+    /// return 12-bit full BX.
+    uint16_t getFullBX() const { return fullbx_; }
 
-  /// Set 12-bit full BX.
-  void setFullBX(const uint16_t fullbx) { fullbx_ = fullbx; }
+    /// Set 12-bit full BX.
+    void setFullBX(const uint16_t fullbx) { fullbx_ = fullbx; }
 
-  // 12-bit comparator code
-  int16_t getCompCode() const { return (isRun3() ? compCode_ : -1); }
+    // 12-bit comparator code
+    int16_t getCompCode() const { return (isRun3() ? compCode_ : -1); }
 
-  void setCompCode(const int16_t code) { compCode_ = code; }
+    void setCompCode(const int16_t code) { compCode_ = code; }
 
-  // comparator hits in this CLCT
-  const ComparatorContainer& getHits() const { return hits_.empty() ? emptyContainer() : hits_; }
+    // comparator hits in this CLCT
+    const ComparatorContainer& getHits() const { return hits_.empty() ? emptyContainer() : hits_; }
 
-  void setHits(const ComparatorContainer& hits) { hits_ = hits; }
+    void setHits(const ComparatorContainer& hits) { hits_ = hits; }
 
-  /// True if the left-hand side has a larger "quality".  Full definition
-  /// of "quality" depends on quality word itself, pattern type, and strip
-  /// number.
-  bool operator>(const CSCCLCTDigi&) const;
+    /// True if the left-hand side has a larger "quality".  Full definition
+    /// of "quality" depends on quality word itself, pattern type, and strip
+    /// number.
+    bool operator>(const CSCCLCTDigi&) const;
 
-  /// True if the two LCTs have exactly the same members (except the number).
-  bool operator==(const CSCCLCTDigi&) const;
+    /// True if the two LCTs have exactly the same members (except the number).
+    bool operator==(const CSCCLCTDigi&) const;
 
-  /// True if the preceding one is false.
-  bool operator!=(const CSCCLCTDigi&) const;
+    /// True if the preceding one is false.
+    bool operator!=(const CSCCLCTDigi&) const;
 
-  /// Print content of digi.
-  void print() const;
+    /// Print content of digi.
+    void print() const;
 
-  /// Distinguish Run-1/2 from Run-3
-  bool isRun3() const { return version_ == Version::Run3; }
+    /// Distinguish Run-1/2 from Run-3
+    bool isRun3() const { return version_ == Version::Run3; }
 
-  void setRun3(bool isRun3);
+    void setRun3(bool isRun3);
 
-private:
-  static const ComparatorContainer& emptyContainer();
-  uint16_t valid_;
-  uint16_t quality_;
-  // Run-1/2 pattern number.
-  // For Run-3 CLCTs, please use run3_pattern_. For some backward
-  // compatibility the trigger emulator translates run3_pattern_
-  // approximately into pattern_ with a lookup table
-  uint16_t pattern_;
-  uint16_t striptype_;  // not used since mid-2008
-  // Common definition for left/right bending in Run-1, Run-2 and Run-3.
-  // 0: right; 1: left
-  uint16_t bend_;
-  // actually the half-strip number
-  uint16_t strip_;
-  // There are up to 7 (D)CFEBs in a chamber
-  uint16_t cfeb_;
-  uint16_t bx_;
-  uint16_t trknmb_;
-  uint16_t fullbx_;
+  private:
+    static const ComparatorContainer& emptyContainer();
+    uint16_t valid_;
+    uint16_t quality_;
+    // Run-1/2 pattern number.
+    // For Run-3 CLCTs, please use run3_pattern_. For some backward
+    // compatibility the trigger emulator translates run3_pattern_
+    // approximately into pattern_ with a lookup table
+    uint16_t pattern_;
+    uint16_t striptype_;  // not used since mid-2008
+    // Common definition for left/right bending in Run-1, Run-2 and Run-3.
+    // 0: right; 1: left
+    uint16_t bend_;
+    // actually the half-strip number
+    uint16_t strip_;
+    // There are up to 7 (D)CFEBs in a chamber
+    uint16_t cfeb_;
+    uint16_t bx_;
+    uint16_t trknmb_;
+    uint16_t fullbx_;
 
-  // new members in Run-3:
+    // new members in Run-3:
 
-  // 12-bit comparator code
-  // set by default to -1 for Run-1 and Run-2 CLCTs
-  int16_t compCode_;
-  // 1/4-strip bit set by CCLUT (see DN-19-059)
-  bool run3_quart_strip_bit_;
-  // 1/8-strip bit set by CCLUT
-  bool run3_eighth_strip_bit_;
-  // In Run-3, the CLCT digi has 3-bit pattern ID, 0 through 4
-  uint16_t run3_pattern_;
-  // 4-bit bending value. There will be 16 bending values * 2 (left/right)
-  uint16_t run3_slope_;
+    // 12-bit comparator code
+    // set by default to -1 for Run-1 and Run-2 CLCTs
+    int16_t compCode_;
+    // 1/4-strip bit set by CCLUT (see DN-19-059)
+    bool run3_quart_strip_bit_;
+    // 1/8-strip bit set by CCLUT
+    bool run3_eighth_strip_bit_;
+    // In Run-3, the CLCT digi has 3-bit pattern ID, 0 through 4
+    uint16_t run3_pattern_;
+    // 4-bit bending value. There will be 16 bending values * 2 (left/right)
+    uint16_t run3_slope_;
 
-  // which hits are in this CLCT?
-  ComparatorContainer hits_;
-  Version version_;
-};
+    // which hits are in this CLCT?
+    ComparatorContainer hits_;
+    Version version_;
+  };
 
-std::ostream& operator<<(std::ostream& o, const CSCCLCTDigi& digi);
+  std::ostream& operator<<(std::ostream& o, const CSCCLCTDigi& digi);
 
+}  // namespace io_v1
+using CSCCLCTDigi = io_v1::CSCCLCTDigi;
 #endif

--- a/DataFormats/CSCDigi/interface/CSCCLCTDigiFwd.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigiFwd.h
@@ -1,6 +1,9 @@
 #ifndef DataFormats_CSCDigi_CSCCLCTDigiFwd_h
 #define DataFormats_CSCDigi_CSCCLCTDigiFwd_h
 
-class CSCCLCTDigi;
+namespace io_v1 {
+  class CSCCLCTDigi;
+}
+using CSCCLCTDigi = io_v1::CSCCLCTDigi;
 
 #endif

--- a/DataFormats/CSCDigi/interface/CSCCLCTPreTriggerDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTPreTriggerDigi.h
@@ -12,102 +12,106 @@
 #include <cstdint>
 #include <iosfwd>
 
-class CSCCLCTPreTriggerDigi {
-public:
-  /// Constructors
-  CSCCLCTPreTriggerDigi(const int valid,
-                        const int quality,
-                        const int pattern,
-                        const int striptype,
-                        const int bend,
-                        const int strip,
-                        const int cfeb,
-                        const int bx,
-                        const int trknmb = 0,
-                        const int fullbx = 0);
-  /// default
-  CSCCLCTPreTriggerDigi();
+namespace io_v1 {
 
-  /// clear this CLCT
-  void clear();
+  class CSCCLCTPreTriggerDigi {
+  public:
+    /// Constructors
+    CSCCLCTPreTriggerDigi(const int valid,
+                          const int quality,
+                          const int pattern,
+                          const int striptype,
+                          const int bend,
+                          const int strip,
+                          const int cfeb,
+                          const int bx,
+                          const int trknmb = 0,
+                          const int fullbx = 0);
+    /// default
+    CSCCLCTPreTriggerDigi();
 
-  /// check CLCT validity (1 - valid CLCT)
-  bool isValid() const { return valid_; }
+    /// clear this CLCT
+    void clear();
 
-  /// return quality of a pattern (number of layers hit!)
-  int getQuality() const { return quality_; }
+    /// check CLCT validity (1 - valid CLCT)
+    bool isValid() const { return valid_; }
 
-  /// return pattern
-  int getPattern() const { return pattern_; }
+    /// return quality of a pattern (number of layers hit!)
+    int getQuality() const { return quality_; }
 
-  /// return striptype
-  int getStripType() const { return striptype_; }
+    /// return pattern
+    int getPattern() const { return pattern_; }
 
-  /// return bend
-  int getBend() const { return bend_; }
+    /// return striptype
+    int getStripType() const { return striptype_; }
 
-  /// return halfstrip that goes from 0 to 31
-  int getStrip() const { return strip_; }
+    /// return bend
+    int getBend() const { return bend_; }
 
-  /// return Key CFEB ID
-  int getCFEB() const { return cfeb_; }
+    /// return halfstrip that goes from 0 to 31
+    int getStrip() const { return strip_; }
 
-  /// return BX
-  int getBX() const { return bx_; }
+    /// return Key CFEB ID
+    int getCFEB() const { return cfeb_; }
 
-  /// return track number (1,2)
-  int getTrknmb() const { return trknmb_; }
+    /// return BX
+    int getBX() const { return bx_; }
 
-  /// Convert strip_ and cfeb_ to keyStrip. Each CFEB has up to 16 strips
-  /// (32 halfstrips). There are 5 cfebs.  The "strip_" variable is one
-  /// of 32 halfstrips on the keylayer of a single CFEB, so that
-  /// Distrip   = (cfeb*32 + strip)/4.
-  /// Halfstrip = (cfeb*32 + strip).
-  /// Always return halfstrip number since this is what is stored in
-  /// the correlated LCT digi.  For distrip patterns, the convention is
-  /// the same as for persistent strip numbers: low halfstrip of a distrip.
-  /// SV, June 15th, 2006.
-  int getKeyStrip() const {
-    int keyStrip = cfeb_ * 32 + strip_;
-    return keyStrip;
-  }
+    /// return track number (1,2)
+    int getTrknmb() const { return trknmb_; }
 
-  /// Set track number (1,2) after sorting CLCTs.
-  void setTrknmb(const uint16_t number) { trknmb_ = number; }
+    /// Convert strip_ and cfeb_ to keyStrip. Each CFEB has up to 16 strips
+    /// (32 halfstrips). There are 5 cfebs.  The "strip_" variable is one
+    /// of 32 halfstrips on the keylayer of a single CFEB, so that
+    /// Distrip   = (cfeb*32 + strip)/4.
+    /// Halfstrip = (cfeb*32 + strip).
+    /// Always return halfstrip number since this is what is stored in
+    /// the correlated LCT digi.  For distrip patterns, the convention is
+    /// the same as for persistent strip numbers: low halfstrip of a distrip.
+    /// SV, June 15th, 2006.
+    int getKeyStrip() const {
+      int keyStrip = cfeb_ * 32 + strip_;
+      return keyStrip;
+    }
 
-  /// return 12-bit full BX.
-  int getFullBX() const { return fullbx_; }
+    /// Set track number (1,2) after sorting CLCTs.
+    void setTrknmb(const uint16_t number) { trknmb_ = number; }
 
-  /// Set 12-bit full BX.
-  void setFullBX(const uint16_t fullbx) { fullbx_ = fullbx; }
+    /// return 12-bit full BX.
+    int getFullBX() const { return fullbx_; }
 
-  /// True if the left-hand side has a larger "quality".  Full definition
-  /// of "quality" depends on quality word itself, pattern type, and strip
-  /// number.
-  bool operator>(const CSCCLCTPreTriggerDigi&) const;
+    /// Set 12-bit full BX.
+    void setFullBX(const uint16_t fullbx) { fullbx_ = fullbx; }
 
-  /// True if the two LCTs have exactly the same members (except the number).
-  bool operator==(const CSCCLCTPreTriggerDigi&) const;
+    /// True if the left-hand side has a larger "quality".  Full definition
+    /// of "quality" depends on quality word itself, pattern type, and strip
+    /// number.
+    bool operator>(const CSCCLCTPreTriggerDigi&) const;
 
-  /// True if the preceding one is false.
-  bool operator!=(const CSCCLCTPreTriggerDigi&) const;
+    /// True if the two LCTs have exactly the same members (except the number).
+    bool operator==(const CSCCLCTPreTriggerDigi&) const;
 
-  /// Print content of digi.
-  void print() const;
+    /// True if the preceding one is false.
+    bool operator!=(const CSCCLCTPreTriggerDigi&) const;
 
-private:
-  uint16_t valid_;
-  uint16_t quality_;
-  uint16_t pattern_;
-  uint16_t striptype_;  // not used since mid-2008
-  uint16_t bend_;
-  uint16_t strip_;
-  uint16_t cfeb_;
-  uint16_t bx_;
-  uint16_t trknmb_;
-  uint16_t fullbx_;
-};
+    /// Print content of digi.
+    void print() const;
 
-std::ostream& operator<<(std::ostream& o, const CSCCLCTPreTriggerDigi& digi);
+  private:
+    uint16_t valid_;
+    uint16_t quality_;
+    uint16_t pattern_;
+    uint16_t striptype_;  // not used since mid-2008
+    uint16_t bend_;
+    uint16_t strip_;
+    uint16_t cfeb_;
+    uint16_t bx_;
+    uint16_t trknmb_;
+    uint16_t fullbx_;
+  };
 
+  std::ostream& operator<<(std::ostream& o, const CSCCLCTPreTriggerDigi& digi);
+
+}  // namespace io_v1
+using CSCCLCTPreTriggerDigi = io_v1::CSCCLCTPreTriggerDigi;
 #endif

--- a/DataFormats/CSCDigi/interface/CSCComparatorDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCComparatorDigi.h
@@ -13,66 +13,70 @@
 #include <vector>
 #include <cstdint>
 
-class CSCComparatorDigi {
-public:
-  /// Construct from the strip number and the ADC readings.
-  CSCComparatorDigi(int strip, int comparator, int timeBinWord);
-  ///comparator here can be either 0 or 1 for left or right halfstrip of given strip
+namespace io_v1 {
 
-  /// Default construction.
-  CSCComparatorDigi();
+  class CSCComparatorDigi {
+  public:
+    /// Construct from the strip number and the ADC readings.
+    CSCComparatorDigi(int strip, int comparator, int timeBinWord);
+    ///comparator here can be either 0 or 1 for left or right halfstrip of given strip
 
-  /// Digis are equal if they are on the same strip and have same Comparator data
-  bool operator==(const CSCComparatorDigi& digi) const;
+    /// Default construction.
+    CSCComparatorDigi();
 
-  /// sort by time first, then by strip
-  bool operator<(const CSCComparatorDigi& digi) const;
+    /// Digis are equal if they are on the same strip and have same Comparator data
+    bool operator==(const CSCComparatorDigi& digi) const;
 
-  /// Get the distrip number. Counts from 0.
-  int getDiStrip() const;
+    /// sort by time first, then by strip
+    bool operator<(const CSCComparatorDigi& digi) const;
 
-  /// Get the strip number. Counts from 1.
-  int getStrip() const { return strip_; }
+    /// Get the distrip number. Counts from 0.
+    int getDiStrip() const;
 
-  /// Get the CFEB number. Counts from 0.
-  int getCFEB() const;
+    /// Get the strip number. Counts from 1.
+    int getStrip() const { return strip_; }
 
-  /// Get Comparator readings. Can be 0 or 1.
-  int getComparator() const { return comparator_; }
+    /// Get the CFEB number. Counts from 0.
+    int getCFEB() const;
 
-  /// Return the word with each bit corresponding to a time bin
-  int getTimeBinWord() const { return timeBinWord_; }
+    /// Get Comparator readings. Can be 0 or 1.
+    int getComparator() const { return comparator_; }
 
-  /// Return bin number of first time bin which is ON. Counts from 0.
-  int getTimeBin() const;
+    /// Return the word with each bit corresponding to a time bin
+    int getTimeBinWord() const { return timeBinWord_; }
 
-  /// Get the associated halfstrip number for this comparator digi. Counts from 0.
-  int getHalfStrip() const;
+    /// Return bin number of first time bin which is ON. Counts from 0.
+    int getTimeBin() const;
 
-  /// Return the fractional half-strip. Counts from 0.25
-  float getFractionalStrip() const;
+    /// Get the associated halfstrip number for this comparator digi. Counts from 0.
+    int getHalfStrip() const;
 
-  /** Return vector of the bin numbers for which time bins are ON.
+    /// Return the fractional half-strip. Counts from 0.25
+    float getFractionalStrip() const;
+
+    /** Return vector of the bin numbers for which time bins are ON.
    * e.g. if bits 0 and 13 fired, then this vector will contain the values 0 and 13
    */
-  std::vector<int> getTimeBinsOn() const;
+    std::vector<int> getTimeBinsOn() const;
 
-  /// Set the strip number
-  void setStrip(int strip);
+    /// Set the strip number
+    void setStrip(int strip);
 
-  /// Set Comparator data
-  void setComparator(int comparator);
+    /// Set Comparator data
+    void setComparator(int comparator);
 
-  /// Print content of digi
-  void print() const;
+    /// Print content of digi
+    void print() const;
 
-private:
-  uint16_t strip_;
-  uint16_t comparator_;
-  uint16_t timeBinWord_;
-};
+  private:
+    uint16_t strip_;
+    uint16_t comparator_;
+    uint16_t timeBinWord_;
+  };
 
-/// Output operator
-std::ostream& operator<<(std::ostream& o, const CSCComparatorDigi& digi);
+  /// Output operator
+  std::ostream& operator<<(std::ostream& o, const CSCComparatorDigi& digi);
 
+}  // namespace io_v1
+using CSCComparatorDigi = io_v1::CSCComparatorDigi;
 #endif

--- a/DataFormats/CSCDigi/interface/CSCComparatorDigiFwd.h
+++ b/DataFormats/CSCDigi/interface/CSCComparatorDigiFwd.h
@@ -1,6 +1,9 @@
 #ifndef DataFormats_CSCDigi_CSCComparatorDigiFwd_h
 #define DataFormats_CSCDigi_CSCComparatorDigiFwd_h
 
-class CSCComparatorDigi;
+namespace io_v1 {
+  class CSCComparatorDigi;
+}
+using CSCComparatorDigi = io_v1::CSCComparatorDigi;
 
 #endif

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -16,79 +16,81 @@
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigi.h"
 
-class CSCCorrelatedLCTDigi {
-public:
-  enum class Version { Legacy = 0, Run3 };
-  // for data vs emulator studies
-  enum LCTBXMask { kBXDataMask = 0x1 };
+namespace io_v1 {
 
-  /// SIMULATION ONLY ////
-  enum Type {
-    CLCTALCT,      // CLCT-centric
-    ALCTCLCT,      // ALCT-centric
-    ALCTCLCTGEM,   // ALCT-CLCT-1 GEM pad
-    ALCTCLCT2GEM,  // ALCT-CLCT-2 GEM pads in coincidence
-    ALCT2GEM,      // ALCT-2 GEM pads in coincidence
-    CLCT2GEM,      // CLCT-2 GEM pads in coincidence
-    CLCTONLY,      // Missing ALCT
-    ALCTONLY       // Missing CLCT
-  };
+  class CSCCorrelatedLCTDigi {
+  public:
+    enum class Version { Legacy = 0, Run3 };
+    // for data vs emulator studies
+    enum LCTBXMask { kBXDataMask = 0x1 };
 
-  /// Constructors
-  CSCCorrelatedLCTDigi(const uint16_t trknmb,
-                       const uint16_t valid,
-                       const uint16_t quality,
-                       const uint16_t keywire,
-                       const uint16_t strip,
-                       const uint16_t pattern,
-                       const uint16_t bend,
-                       const uint16_t bx,
-                       const uint16_t mpclink = 0,
-                       const uint16_t bx0 = 0,
-                       const uint16_t syncErr = 0,
-                       const uint16_t cscID = 0,
-                       const Version version = Version::Legacy,
-                       const bool run3_quart_strip_bit = false,
-                       const bool run3_eighth_strip_bit = false,
-                       const uint16_t run3_pattern = 0,
-                       const uint16_t run3_slope = 0,
-                       const int type = ALCTCLCT,
-                       const uint16_t gemLayerUsedForSlopeComputation = 0);
+    /// SIMULATION ONLY ////
+    enum Type {
+      CLCTALCT,      // CLCT-centric
+      ALCTCLCT,      // ALCT-centric
+      ALCTCLCTGEM,   // ALCT-CLCT-1 GEM pad
+      ALCTCLCT2GEM,  // ALCT-CLCT-2 GEM pads in coincidence
+      ALCT2GEM,      // ALCT-2 GEM pads in coincidence
+      CLCT2GEM,      // CLCT-2 GEM pads in coincidence
+      CLCTONLY,      // Missing ALCT
+      ALCTONLY       // Missing CLCT
+    };
 
-  /// default (calls clear())
-  CSCCorrelatedLCTDigi();
+    /// Constructors
+    CSCCorrelatedLCTDigi(const uint16_t trknmb,
+                         const uint16_t valid,
+                         const uint16_t quality,
+                         const uint16_t keywire,
+                         const uint16_t strip,
+                         const uint16_t pattern,
+                         const uint16_t bend,
+                         const uint16_t bx,
+                         const uint16_t mpclink = 0,
+                         const uint16_t bx0 = 0,
+                         const uint16_t syncErr = 0,
+                         const uint16_t cscID = 0,
+                         const Version version = Version::Legacy,
+                         const bool run3_quart_strip_bit = false,
+                         const bool run3_eighth_strip_bit = false,
+                         const uint16_t run3_pattern = 0,
+                         const uint16_t run3_slope = 0,
+                         const int type = ALCTCLCT,
+                         const uint16_t gemLayerUsedForSlopeComputation = 0);
 
-  /// clear this LCT
-  void clear();
+    /// default (calls clear())
+    CSCCorrelatedLCTDigi();
 
-  /// return track number
-  uint16_t getTrknmb() const { return trknmb; }
+    /// clear this LCT
+    void clear();
 
-  /// return valid pattern bit
-  bool isValid() const { return valid; }
+    /// return track number
+    uint16_t getTrknmb() const { return trknmb; }
 
-  /// return the Quality
-  uint16_t getQuality() const { return quality; }
+    /// return valid pattern bit
+    bool isValid() const { return valid; }
 
-  /// return the key wire group. counts from 0.
-  uint16_t getKeyWG() const { return keywire; }
+    /// return the Quality
+    uint16_t getQuality() const { return quality; }
 
-  /// return the key halfstrip from 0,159
-  uint16_t getStrip(uint16_t n = 2) const;
+    /// return the key wire group. counts from 0.
+    uint16_t getKeyWG() const { return keywire; }
 
-  /// set single quart strip bit
-  void setQuartStripBit(const bool quartStripBit) { run3_quart_strip_bit_ = quartStripBit; }
+    /// return the key halfstrip from 0,159
+    uint16_t getStrip(uint16_t n = 2) const;
 
-  /// get single quart strip bit
-  bool getQuartStripBit() const { return run3_quart_strip_bit_; }
+    /// set single quart strip bit
+    void setQuartStripBit(const bool quartStripBit) { run3_quart_strip_bit_ = quartStripBit; }
 
-  /// set single eighth strip bit
-  void setEighthStripBit(const bool eighthStripBit) { run3_eighth_strip_bit_ = eighthStripBit; }
+    /// get single quart strip bit
+    bool getQuartStripBit() const { return run3_quart_strip_bit_; }
 
-  /// get single eighth strip bit
-  bool getEighthStripBit() const { return run3_eighth_strip_bit_; }
+    /// set single eighth strip bit
+    void setEighthStripBit(const bool eighthStripBit) { run3_eighth_strip_bit_ = eighthStripBit; }
 
-  /*
+    /// get single eighth strip bit
+    bool getEighthStripBit() const { return run3_eighth_strip_bit_; }
+
+    /*
     Strips are numbered starting from 1 in CMSSW
     Half-strips, quarter-strips and eighth-strips are numbered starting from 0
     The table below shows the correct numbering
@@ -105,189 +107,191 @@ public:
     Note: the CSC geometry also has a strip offset of +/- 0.25 strips. When comparing the
     CLCT/LCT position with the true muon position, take the offset into account!
    */
-  float getFractionalStrip(uint16_t n = 2) const;
+    float getFractionalStrip(uint16_t n = 2) const;
 
-  /// return the Run-2 pattern ID
-  uint16_t getPattern() const { return pattern; }
+    /// return the Run-2 pattern ID
+    uint16_t getPattern() const { return pattern; }
 
-  /// return the Run-3 pattern ID
-  uint16_t getRun3Pattern() const { return run3_pattern_; }
+    /// return the Run-3 pattern ID
+    uint16_t getRun3Pattern() const { return run3_pattern_; }
 
-  /// return the slope
-  uint16_t getSlope() const { return run3_slope_; }
+    /// return the slope
+    uint16_t getSlope() const { return run3_slope_; }
 
-  /// slope in number of half-strips/layer
-  /// negative means left-bending
-  /// positive means right-bending
-  float getFractionalSlope() const;
+    /// slope in number of half-strips/layer
+    /// negative means left-bending
+    /// positive means right-bending
+    float getFractionalSlope() const;
 
-  /// return left/right bending
-  /// 0: left-bending (negative delta-strip / delta layer)
-  /// 1: right-bending (positive delta-strip / delta layer)
-  uint16_t getBend() const { return bend; }
+    /// return left/right bending
+    /// 0: left-bending (negative delta-strip / delta layer)
+    /// 1: right-bending (positive delta-strip / delta layer)
+    uint16_t getBend() const { return bend; }
 
-  /// return BX
-  uint16_t getBX() const { return bx; }
+    /// return BX
+    uint16_t getBX() const { return bx; }
 
-  /// return 1-bit BX as in data
-  uint16_t getBXData() const { return bx & kBXDataMask; }
+    /// return 1-bit BX as in data
+    uint16_t getBXData() const { return bx & kBXDataMask; }
 
-  /// return CLCT pattern number (in use again Feb 2011)
-  /// This function should not be used for Run-3
-  uint16_t getCLCTPattern() const;
+    /// return CLCT pattern number (in use again Feb 2011)
+    /// This function should not be used for Run-3
+    uint16_t getCLCTPattern() const;
 
-  /// return strip type (obsolete since mid-2008)
-  uint16_t getStripType() const { return ((pattern & 0x8) >> 3); }
+    /// return strip type (obsolete since mid-2008)
+    uint16_t getStripType() const { return ((pattern & 0x8) >> 3); }
 
-  /// return MPC link number, 0 means not sorted, 1-3 give MPC sorting rank
-  uint16_t getMPCLink() const { return mpclink; }
+    /// return MPC link number, 0 means not sorted, 1-3 give MPC sorting rank
+    uint16_t getMPCLink() const { return mpclink; }
 
-  uint16_t getCSCID() const { return cscID; }
-  uint16_t getBX0() const { return bx0; }
-  uint16_t getSyncErr() const { return syncErr; }
+    uint16_t getCSCID() const { return cscID; }
+    uint16_t getBX0() const { return bx0; }
+    uint16_t getSyncErr() const { return syncErr; }
 
-  /// Run-3 introduces high-multiplicity bits for CSCs.
-  /// The allocation is different for ME1/1 and non-ME1/1
-  /// chambers. Both LCTs in a chamber are needed for the complete
-  /// high-multiplicity trigger information
-  uint16_t getHMT() const;
+    /// Run-3 introduces high-multiplicity bits for CSCs.
+    /// The allocation is different for ME1/1 and non-ME1/1
+    /// chambers. Both LCTs in a chamber are needed for the complete
+    /// high-multiplicity trigger information
+    uint16_t getHMT() const;
 
-  /// Set track number (1,2) after sorting LCTs.
-  void setTrknmb(const uint16_t number) { trknmb = number; }
+    /// Set track number (1,2) after sorting LCTs.
+    void setTrknmb(const uint16_t number) { trknmb = number; }
 
-  /// Set mpc link number after MPC sorting
-  void setMPCLink(const uint16_t& link) { mpclink = link; }
+    /// Set mpc link number after MPC sorting
+    void setMPCLink(const uint16_t& link) { mpclink = link; }
 
-  /// Print content of correlated LCT digi
-  void print() const;
+    /// Print content of correlated LCT digi
+    void print() const;
 
-  ///Comparison
-  bool operator==(const CSCCorrelatedLCTDigi&) const;
-  bool operator!=(const CSCCorrelatedLCTDigi& rhs) const { return !(this->operator==(rhs)); }
+    ///Comparison
+    bool operator==(const CSCCorrelatedLCTDigi&) const;
+    bool operator!=(const CSCCorrelatedLCTDigi& rhs) const { return !(this->operator==(rhs)); }
 
-  /// set wiregroup number
-  void setWireGroup(const uint16_t wiregroup) { keywire = wiregroup; }
+    /// set wiregroup number
+    void setWireGroup(const uint16_t wiregroup) { keywire = wiregroup; }
 
-  /// set quality code
-  void setQuality(const uint16_t q) { quality = q; }
+    /// set quality code
+    void setQuality(const uint16_t q) { quality = q; }
 
-  /// set valid
-  void setValid(const uint16_t v) { valid = v; }
+    /// set valid
+    void setValid(const uint16_t v) { valid = v; }
 
-  /// set strip
-  void setStrip(const uint16_t s) { strip = s; }
+    /// set strip
+    void setStrip(const uint16_t s) { strip = s; }
 
-  /// set pattern
-  void setPattern(const uint16_t p) { pattern = p; }
+    /// set pattern
+    void setPattern(const uint16_t p) { pattern = p; }
 
-  /// set Run-3 pattern
-  void setRun3Pattern(const uint16_t pattern) { run3_pattern_ = pattern; }
+    /// set Run-3 pattern
+    void setRun3Pattern(const uint16_t pattern) { run3_pattern_ = pattern; }
 
-  /// set the slope
-  void setSlope(const uint16_t slope) { run3_slope_ = slope; }
+    /// set the slope
+    void setSlope(const uint16_t slope) { run3_slope_ = slope; }
 
-  /// set bend
-  void setBend(const uint16_t b) { bend = b; }
+    /// set bend
+    void setBend(const uint16_t b) { bend = b; }
 
-  /// set bx
-  void setBX(const uint16_t b) { bx = b; }
+    /// set bx
+    void setBX(const uint16_t b) { bx = b; }
 
-  /// set bx0
-  void setBX0(const uint16_t b) { bx0 = b; }
+    /// set bx0
+    void setBX0(const uint16_t b) { bx0 = b; }
 
-  /// set syncErr
-  void setSyncErr(const uint16_t s) { syncErr = s; }
+    /// set syncErr
+    void setSyncErr(const uint16_t s) { syncErr = s; }
 
-  /// set cscID
-  void setCSCID(const uint16_t c) { cscID = c; }
+    /// set cscID
+    void setCSCID(const uint16_t c) { cscID = c; }
 
-  /// set high-multiplicity bits
-  void setHMT(const uint16_t h);
+    /// set high-multiplicity bits
+    void setHMT(const uint16_t h);
 
-  /// Distinguish Run-1/2 from Run-3
-  bool isRun3() const { return version_ == Version::Run3; }
+    /// Distinguish Run-1/2 from Run-3
+    bool isRun3() const { return version_ == Version::Run3; }
 
-  void setRun3(const bool isRun3);
+    void setRun3(const bool isRun3);
 
-  int getType() const { return type_; }
+    int getType() const { return type_; }
 
-  void setType(int type) { type_ = type; }
+    void setType(int type) { type_ = type; }
 
-  uint16_t getGemLayerUsedForSlopeComputation() const { return gemLayerUsedForSlopeComputation_; }
-  void setGemLayerUsedForSlopeComputation(uint16_t layer) { gemLayerUsedForSlopeComputation_ = layer; }
+    uint16_t getGemLayerUsedForSlopeComputation() const { return gemLayerUsedForSlopeComputation_; }
+    void setGemLayerUsedForSlopeComputation(uint16_t layer) { gemLayerUsedForSlopeComputation_ = layer; }
 
-  void setALCT(const CSCALCTDigi& alct) { alct_ = alct; }
-  void setCLCT(const CSCCLCTDigi& clct) { clct_ = clct; }
-  void setGEM1(const GEMPadDigi& gem) { gem1_ = gem; }
-  void setGEM2(const GEMPadDigi& gem) { gem2_ = gem; }
-  const CSCALCTDigi& getALCT() const { return alct_; }
-  const CSCCLCTDigi& getCLCT() const { return clct_; }
-  const GEMPadDigi& getGEM1() const { return gem1_; }
-  const GEMPadDigi& getGEM2() const { return gem2_; }
+    void setALCT(const CSCALCTDigi& alct) { alct_ = alct; }
+    void setCLCT(const CSCCLCTDigi& clct) { clct_ = clct; }
+    void setGEM1(const GEMPadDigi& gem) { gem1_ = gem; }
+    void setGEM2(const GEMPadDigi& gem) { gem2_ = gem; }
+    const CSCALCTDigi& getALCT() const { return alct_; }
+    const CSCCLCTDigi& getCLCT() const { return clct_; }
+    const GEMPadDigi& getGEM1() const { return gem1_; }
+    const GEMPadDigi& getGEM2() const { return gem2_; }
 
-private:
-  // Note: The Run-3 data format is substantially different than the
-  // Run-1/2 data format. Some explanation is provided below. For
-  // more information, please check "DN-20-016".
+  private:
+    // Note: The Run-3 data format is substantially different than the
+    // Run-1/2 data format. Some explanation is provided below. For
+    // more information, please check "DN-20-016".
 
-  // Run-1, Run-2 and Run-3 trknmb is either 1 or 2.
-  uint16_t trknmb;
-  // In Run-3, the valid will be encoded as a quality
-  // value "000" or "00".
-  uint16_t valid;
-  // In Run-3, the LCT quality number will be 2 or 3 bits
-  // For ME1/1 chambers: 3 bits
-  // For non-ME1/1 chambers: 2 bits
-  uint16_t quality;
-  // 7-bit key wire
-  uint16_t keywire;
-  // actually the 8-bit half-strip number
-  uint16_t strip;
-  // Run-1/2 pattern number.
-  // For Run-3 CLCTs, please use run3_pattern_. For some backward
-  // compatibility the trigger emulator translates run3_pattern_
-  // approximately into pattern_ with a lookup table
-  uint16_t pattern;
-  // Common definition for left/right bending in Run-1, Run-2 and Run-3.
-  // 0: right; 1: left
-  uint16_t bend;
-  uint16_t bx;
-  uint16_t mpclink;
-  uint16_t bx0;
-  // The synchronization bit is actually not used by MPC or EMTF
-  uint16_t syncErr;
-  // 4-bit CSC chamber identifier
-  uint16_t cscID;
+    // Run-1, Run-2 and Run-3 trknmb is either 1 or 2.
+    uint16_t trknmb;
+    // In Run-3, the valid will be encoded as a quality
+    // value "000" or "00".
+    uint16_t valid;
+    // In Run-3, the LCT quality number will be 2 or 3 bits
+    // For ME1/1 chambers: 3 bits
+    // For non-ME1/1 chambers: 2 bits
+    uint16_t quality;
+    // 7-bit key wire
+    uint16_t keywire;
+    // actually the 8-bit half-strip number
+    uint16_t strip;
+    // Run-1/2 pattern number.
+    // For Run-3 CLCTs, please use run3_pattern_. For some backward
+    // compatibility the trigger emulator translates run3_pattern_
+    // approximately into pattern_ with a lookup table
+    uint16_t pattern;
+    // Common definition for left/right bending in Run-1, Run-2 and Run-3.
+    // 0: right; 1: left
+    uint16_t bend;
+    uint16_t bx;
+    uint16_t mpclink;
+    uint16_t bx0;
+    // The synchronization bit is actually not used by MPC or EMTF
+    uint16_t syncErr;
+    // 4-bit CSC chamber identifier
+    uint16_t cscID;
 
-  // new members in Run-3:
+    // new members in Run-3:
 
-  // In Run-3, CSC trigger data will include the high-multiplicity
-  // bits for a chamber. These bits may indicate the observation of
-  // "exotic" events. This data member was included in a prototype.
-  // Later on, we developed a dedicated object: "CSCShowerDigi"
-  uint16_t hmt;
-  // 1/4-strip bit set by CCLUT (see DN-19-059)
-  bool run3_quart_strip_bit_;
-  // 1/8-strip bit set by CCLUT
-  bool run3_eighth_strip_bit_;
-  // In Run-3, the CLCT digi has 3-bit pattern ID, 0 through 4
-  uint16_t run3_pattern_;
-  // 4-bit bending value. There will be 16 bending values * 2 (left/right)
-  uint16_t run3_slope_;
-  // In Run-3, the GEM information is included in the LCT data format. The "gemLayerUsedForSlopeComputation_" indicates what GEM layer was used to compute the slope.
-  uint16_t gemLayerUsedForSlopeComputation_;
+    // In Run-3, CSC trigger data will include the high-multiplicity
+    // bits for a chamber. These bits may indicate the observation of
+    // "exotic" events. This data member was included in a prototype.
+    // Later on, we developed a dedicated object: "CSCShowerDigi"
+    uint16_t hmt;
+    // 1/4-strip bit set by CCLUT (see DN-19-059)
+    bool run3_quart_strip_bit_;
+    // 1/8-strip bit set by CCLUT
+    bool run3_eighth_strip_bit_;
+    // In Run-3, the CLCT digi has 3-bit pattern ID, 0 through 4
+    uint16_t run3_pattern_;
+    // 4-bit bending value. There will be 16 bending values * 2 (left/right)
+    uint16_t run3_slope_;
+    // In Run-3, the GEM information is included in the LCT data format. The "gemLayerUsedForSlopeComputation_" indicates what GEM layer was used to compute the slope.
+    uint16_t gemLayerUsedForSlopeComputation_;
 
-  /// SIMULATION ONLY ////
-  int type_;
+    /// SIMULATION ONLY ////
+    int type_;
 
-  CSCALCTDigi alct_;
-  CSCCLCTDigi clct_;
-  GEMPadDigi gem1_;
-  GEMPadDigi gem2_;
+    CSCALCTDigi alct_;
+    CSCCLCTDigi clct_;
+    GEMPadDigi gem1_;
+    GEMPadDigi gem2_;
 
-  Version version_;
-};
+    Version version_;
+  };
 
-std::ostream& operator<<(std::ostream& o, const CSCCorrelatedLCTDigi& digi);
+  std::ostream& operator<<(std::ostream& o, const CSCCorrelatedLCTDigi& digi);
 
+}  // namespace io_v1
+using CSCCorrelatedLCTDigi = io_v1::CSCCorrelatedLCTDigi;
 #endif

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiFwd.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiFwd.h
@@ -1,6 +1,9 @@
 #ifndef DataFormats_CSCDigi_CSCCorrelatedLCTDigiFwd_h
 #define DataFormats_CSCDigi_CSCCorrelatedLCTDigiFwd_h
 
-class CSCCorrelatedLCTDigi;
+namespace io_v1 {
+  class CSCCorrelatedLCTDigi;
+}
+using CSCCorrelatedLCTDigi = io_v1::CSCCorrelatedLCTDigi;
 
 #endif

--- a/DataFormats/CSCDigi/interface/CSCDCCFormatStatusDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCDCCFormatStatusDigi.h
@@ -157,48 +157,50 @@ std::set<TKey> getKeysList(const std::map<TKey, TVal>& m) {
  * @class CSCDCCFormatStatusDigi
  * @brief CSC Format Status Object
  */
-class CSCDCCFormatStatusDigi {
-private:
-  /**
+namespace io_v1 {
+
+  class CSCDCCFormatStatusDigi {
+  private:
+    /**
    * Internal mask storage variables and containers.
    */
 
-  /** DCC Examiner mask used */
-  ExaminerMaskType fDCC_MASK;
+    /** DCC Examiner mask used */
+    ExaminerMaskType fDCC_MASK;
 
-  /** CSC Examiner mask used */
-  ExaminerMaskType fCSC_MASK;
+    /** CSC Examiner mask used */
+    ExaminerMaskType fCSC_MASK;
 
-  /** FED/DCC Id */
-  DCCIdType DCCId;
+    /** FED/DCC Id */
+    DCCIdType DCCId;
 
-  /** DCC Level summary errors */
-  ExaminerStatusType fDDU_SUMMARY_ERRORS;
+    /** DCC Level summary errors */
+    ExaminerStatusType fDDU_SUMMARY_ERRORS;
 
-  std::map<DDUIdType, ExaminerStatusType> mDDU_ERRORS;
-  std::map<CSCIdType, ExaminerStatusType> mCSC_ERRORS;
-  std::map<CSCIdType, ExaminerStatusType> mCSC_PAYLOADS;
-  std::map<CSCIdType, ExaminerStatusType> mCSC_STATUS;
+    std::map<DDUIdType, ExaminerStatusType> mDDU_ERRORS;
+    std::map<CSCIdType, ExaminerStatusType> mCSC_ERRORS;
+    std::map<CSCIdType, ExaminerStatusType> mCSC_PAYLOADS;
+    std::map<CSCIdType, ExaminerStatusType> mCSC_STATUS;
 
-protected:
-  /// Make CSCIdType from Crate and DMB IDs
-  CSCIdType makeCSCId(const uint16_t crateId, const uint16_t dmbId) const {
-    return ((CSCIdType(crateId & 0xFF) << 4) | (dmbId & 0xF));
-  }
+  protected:
+    /// Make CSCIdType from Crate and DMB IDs
+    CSCIdType makeCSCId(const uint16_t crateId, const uint16_t dmbId) const {
+      return ((CSCIdType(crateId & 0xFF) << 4) | (dmbId & 0xF));
+    }
 
-  /// Init internal data stuctures
-  void init() {
-    fDDU_SUMMARY_ERRORS = 0;
-    fCSC_MASK = 0;
-    fDCC_MASK = 0;
-    mDDU_ERRORS.clear();
-    mCSC_ERRORS.clear();
-    mCSC_PAYLOADS.clear();
-    mCSC_STATUS.clear();
-  }
+    /// Init internal data stuctures
+    void init() {
+      fDDU_SUMMARY_ERRORS = 0;
+      fCSC_MASK = 0;
+      fDCC_MASK = 0;
+      mDDU_ERRORS.clear();
+      mCSC_ERRORS.clear();
+      mCSC_PAYLOADS.clear();
+      mCSC_STATUS.clear();
+    }
 
-public:
-  /**
+  public:
+    /**
    * @brief  Constructor
    * @param  fDCC_MASK_ DCC Examiner mask used (for information purposes).
    * @param  fCSC_MASK_ Examiner mask per chamber
@@ -208,85 +210,85 @@ public:
    * @param  mCSC_PAYLOADS_ List of payloads per CSC
    * @param  mCSC_STATUS_ List of statuses per CSC
    */
-  CSCDCCFormatStatusDigi(const DCCIdType DCCId_,
-                         const ExaminerMaskType fDCC_MASK_,
-                         const ExaminerMaskType fCSC_MASK_,
-                         const ExaminerStatusType fDDU_SUMMARY_ERRORS_,
-                         const std::map<DDUIdType, ExaminerStatusType>& mDDU_ERRORS_,
-                         const std::map<CSCIdType, ExaminerStatusType>& mCSC_ERRORS_,
-                         const std::map<CSCIdType, ExaminerStatusType>& mCSC_PAYLOADS_,
-                         const std::map<CSCIdType, ExaminerStatusType>& mCSC_STATUS_)
-      : DCCId(DCCId_) {
-    init();
-    setDCCExaminerInfo(
-        fDCC_MASK_, fCSC_MASK_, fDDU_SUMMARY_ERRORS_, mDDU_ERRORS_, mCSC_ERRORS_, mCSC_PAYLOADS_, mCSC_STATUS_);
-  }
+    CSCDCCFormatStatusDigi(const DCCIdType DCCId_,
+                           const ExaminerMaskType fDCC_MASK_,
+                           const ExaminerMaskType fCSC_MASK_,
+                           const ExaminerStatusType fDDU_SUMMARY_ERRORS_,
+                           const std::map<DDUIdType, ExaminerStatusType>& mDDU_ERRORS_,
+                           const std::map<CSCIdType, ExaminerStatusType>& mCSC_ERRORS_,
+                           const std::map<CSCIdType, ExaminerStatusType>& mCSC_PAYLOADS_,
+                           const std::map<CSCIdType, ExaminerStatusType>& mCSC_STATUS_)
+        : DCCId(DCCId_) {
+      init();
+      setDCCExaminerInfo(
+          fDCC_MASK_, fCSC_MASK_, fDDU_SUMMARY_ERRORS_, mDDU_ERRORS_, mCSC_ERRORS_, mCSC_PAYLOADS_, mCSC_STATUS_);
+    }
 
-  CSCDCCFormatStatusDigi(const DCCIdType DCCId_) : DCCId(DCCId_) { init(); }
+    CSCDCCFormatStatusDigi(const DCCIdType DCCId_) : DCCId(DCCId_) { init(); }
 
-  /// Default constructor.
-  CSCDCCFormatStatusDigi() : DCCId(0) { init(); }
+    /// Default constructor.
+    CSCDCCFormatStatusDigi() : DCCId(0) { init(); }
 
-  /// Fill internal data structures using Examiner object
-  void setDCCExaminerInfo(const ExaminerMaskType fDCC_MASK_,
-                          const ExaminerMaskType fCSC_MASK_,
-                          const ExaminerStatusType fDDU_SUMMARY_ERRORS_,
-                          const std::map<DDUIdType, ExaminerStatusType>& mDDU_ERRORS_,
-                          const std::map<CSCIdType, ExaminerStatusType>& mCSC_ERRORS_,
-                          const std::map<CSCIdType, ExaminerStatusType>& mCSC_PAYLOADS_,
-                          const std::map<CSCIdType, ExaminerStatusType>& mCSC_STATUS_);
+    /// Fill internal data structures using Examiner object
+    void setDCCExaminerInfo(const ExaminerMaskType fDCC_MASK_,
+                            const ExaminerMaskType fCSC_MASK_,
+                            const ExaminerStatusType fDDU_SUMMARY_ERRORS_,
+                            const std::map<DDUIdType, ExaminerStatusType>& mDDU_ERRORS_,
+                            const std::map<CSCIdType, ExaminerStatusType>& mCSC_ERRORS_,
+                            const std::map<CSCIdType, ExaminerStatusType>& mCSC_PAYLOADS_,
+                            const std::map<CSCIdType, ExaminerStatusType>& mCSC_STATUS_);
 
 #ifdef DEBUG
-  /**
+    /**
    * Manipulate internal data structures for debug purposes
    */
-  void setDCCId(DCCIdType id) { DCCId = id; }
-  void setDCCMask(ExaminerMaskType mask) { fDCC_MASK = mask; }
-  void setCSCMask(ExaminerMaskType mask) { fCSC_MASK = mask; }
-  void setDDUSummaryErrors(ExaminerStatusType status) { fDDU_SUMMARY_ERRORS = status; }
-  void setDDUErrors(DDUIdType DDUId, ExaminerStatusType status) {
-    std::map<DDUIdType, ExaminerStatusType>::const_iterator item = mDDU_ERRORS.find(DDUId);
-    if (item != mDDU_ERRORS.end())
-      mDDU_ERRORS[DDUId] = status;
-    else
-      mDDU_ERRORS.insert(std::make_pair(DDUId, status));
-  }
-  void setCSCErrors(CSCIdType CSCId, ExaminerStatusType status) {
-    std::map<CSCIdType, ExaminerStatusType>::const_iterator item = mCSC_ERRORS.find(CSCId);
-    if (item != mCSC_ERRORS.end())
-      mCSC_ERRORS[CSCId] = status;
-    else
-      mCSC_ERRORS.insert(std::make_pair(CSCId, status));
-  }
-  void setCSCPayload(CSCIdType CSCId, ExaminerStatusType status) {
-    std::map<CSCIdType, ExaminerStatusType>::const_iterator item = mCSC_PAYLOADS.find(CSCId);
-    if (item != mCSC_PAYLOADS.end())
-      mCSC_PAYLOADS[CSCId] = status;
-    else
-      mCSC_PAYLOADS.insert(std::make_pair(CSCId, status));
-  }
-  void setCSCStatus(CSCIdType CSCId, ExaminerStatusType status) {
-    std::map<CSCIdType, ExaminerStatusType>::const_iterator item = mCSC_STATUS.find(CSCId);
-    if (item != mCSC_STATUS.end())
-      mCSC_STATUS[CSCId] = status;
-    else
-      mCSC_STATUS.insert(std::make_pair(CSCId, status));
-  }
+    void setDCCId(DCCIdType id) { DCCId = id; }
+    void setDCCMask(ExaminerMaskType mask) { fDCC_MASK = mask; }
+    void setCSCMask(ExaminerMaskType mask) { fCSC_MASK = mask; }
+    void setDDUSummaryErrors(ExaminerStatusType status) { fDDU_SUMMARY_ERRORS = status; }
+    void setDDUErrors(DDUIdType DDUId, ExaminerStatusType status) {
+      std::map<DDUIdType, ExaminerStatusType>::const_iterator item = mDDU_ERRORS.find(DDUId);
+      if (item != mDDU_ERRORS.end())
+        mDDU_ERRORS[DDUId] = status;
+      else
+        mDDU_ERRORS.insert(std::make_pair(DDUId, status));
+    }
+    void setCSCErrors(CSCIdType CSCId, ExaminerStatusType status) {
+      std::map<CSCIdType, ExaminerStatusType>::const_iterator item = mCSC_ERRORS.find(CSCId);
+      if (item != mCSC_ERRORS.end())
+        mCSC_ERRORS[CSCId] = status;
+      else
+        mCSC_ERRORS.insert(std::make_pair(CSCId, status));
+    }
+    void setCSCPayload(CSCIdType CSCId, ExaminerStatusType status) {
+      std::map<CSCIdType, ExaminerStatusType>::const_iterator item = mCSC_PAYLOADS.find(CSCId);
+      if (item != mCSC_PAYLOADS.end())
+        mCSC_PAYLOADS[CSCId] = status;
+      else
+        mCSC_PAYLOADS.insert(std::make_pair(CSCId, status));
+    }
+    void setCSCStatus(CSCIdType CSCId, ExaminerStatusType status) {
+      std::map<CSCIdType, ExaminerStatusType>::const_iterator item = mCSC_STATUS.find(CSCId);
+      if (item != mCSC_STATUS.end())
+        mCSC_STATUS[CSCId] = status;
+      else
+        mCSC_STATUS.insert(std::make_pair(CSCId, status));
+    }
 
 #endif
 
-  /**
+    /**
    * Get lists of DDUs and CSCs 
    * Loop iterators for CSCs
    */
 
-  std::set<DDUIdType> getListOfDDUs() const { return getKeysList(mDDU_ERRORS); }
+    std::set<DDUIdType> getListOfDDUs() const { return getKeysList(mDDU_ERRORS); }
 
-  std::set<CSCIdType> getListOfCSCs() const { return getKeysList(mCSC_PAYLOADS); }
+    std::set<CSCIdType> getListOfCSCs() const { return getKeysList(mCSC_PAYLOADS); }
 
-  std::set<CSCIdType> getListOfCSCsWithErrors() const { return getKeysList(mCSC_ERRORS); }
+    std::set<CSCIdType> getListOfCSCsWithErrors() const { return getKeysList(mCSC_ERRORS); }
 
-  /**
+    /**
    * @brief  CSC with error iteration procedure.  
    * Usage:
    *   unsigned int i = 0;
@@ -299,136 +301,142 @@ public:
    * @return true if CSC id found and returned, false - otherwise
    */
 
-  bool nextCSCWithError(uint32_t& iterator, CSCIdType& CSCId) const { return nextInMap(iterator, CSCId, mCSC_ERRORS); }
+    bool nextCSCWithError(uint32_t& iterator, CSCIdType& CSCId) const {
+      return nextInMap(iterator, CSCId, mCSC_ERRORS);
+    }
 
-  /**
+    /**
    * @brief  CSC with status iteration procedure.  
    * @see    bool nextCSCWithError(uint32_t&, CSCIdType&) const
    * @param  iterator Integer iterator (incremented automatically)
    * @param  CSCId CSC id to return
    * @return true if CSC id found and returned, false - otherwise
    */
-  bool nextCSCWithStatus(uint32_t& iterator, CSCIdType& CSCId) const { return nextInMap(iterator, CSCId, mCSC_STATUS); }
+    bool nextCSCWithStatus(uint32_t& iterator, CSCIdType& CSCId) const {
+      return nextInMap(iterator, CSCId, mCSC_STATUS);
+    }
 
-  /**
+    /**
    * @brief  CSC with payload iteration procedure.  
    * @see    bool nextCSCWithError(uint32_t&, CSCIdType&) const
    * @param  iterator Integer iterator (incremented automatically)
    * @param  CSCId CSC id to return
    * @return true if CSC id found and returned, false - otherwise
    */
-  bool nextCSCWithPayload(uint32_t& iterator, CSCIdType& CSCId) const {
-    return nextInMap(iterator, CSCId, mCSC_PAYLOADS);
-  }
+    bool nextCSCWithPayload(uint32_t& iterator, CSCIdType& CSCId) const {
+      return nextInMap(iterator, CSCId, mCSC_PAYLOADS);
+    }
 
-  /**
+    /**
    * Getters for complete mask by using internal identifiers.
    * Mostly to be used by examiner and old/current code.
    */
 
-  /**
+    /**
    * Return DCC/DDU level Error Status
    */
 
-  ExaminerStatusType getDDUSummaryErrors() const { return fDDU_SUMMARY_ERRORS; }
+    ExaminerStatusType getDDUSummaryErrors() const { return fDDU_SUMMARY_ERRORS; }
 
-  ExaminerStatusType getDDUErrors(const DDUIdType DDUId) const {
-    std::map<DDUIdType, ExaminerStatusType>::const_iterator item = mDDU_ERRORS.find(DDUId);
-    if (item != mDDU_ERRORS.end())
-      return item->second;
-    else
-      return 0;
-  }
+    ExaminerStatusType getDDUErrors(const DDUIdType DDUId) const {
+      std::map<DDUIdType, ExaminerStatusType>::const_iterator item = mDDU_ERRORS.find(DDUId);
+      if (item != mDDU_ERRORS.end())
+        return item->second;
+      else
+        return 0;
+    }
 
-  ExaminerStatusType getCSCErrors(const CSCIdType CSCId) const {
-    std::map<CSCIdType, ExaminerStatusType>::const_iterator item = mCSC_ERRORS.find(CSCId);
-    if (item != mCSC_ERRORS.end())
-      return item->second;
-    else
-      return 0;
-  }
+    ExaminerStatusType getCSCErrors(const CSCIdType CSCId) const {
+      std::map<CSCIdType, ExaminerStatusType>::const_iterator item = mCSC_ERRORS.find(CSCId);
+      if (item != mCSC_ERRORS.end())
+        return item->second;
+      else
+        return 0;
+    }
 
-  ExaminerStatusType getCSCErrors(const uint16_t crateId, const uint16_t dmbId) const {
-    return getCSCErrors(makeCSCId(crateId, dmbId));
-  }
+    ExaminerStatusType getCSCErrors(const uint16_t crateId, const uint16_t dmbId) const {
+      return getCSCErrors(makeCSCId(crateId, dmbId));
+    }
 
-  ExaminerStatusType getCSCPayload(const CSCIdType CSCId) const {
-    std::map<CSCIdType, ExaminerStatusType>::const_iterator item = mCSC_PAYLOADS.find(CSCId);
-    if (item != mCSC_PAYLOADS.end())
-      return item->second;
-    else
-      return 0;
-  }
+    ExaminerStatusType getCSCPayload(const CSCIdType CSCId) const {
+      std::map<CSCIdType, ExaminerStatusType>::const_iterator item = mCSC_PAYLOADS.find(CSCId);
+      if (item != mCSC_PAYLOADS.end())
+        return item->second;
+      else
+        return 0;
+    }
 
-  ExaminerStatusType getCSCPayload(const uint16_t crateId, const uint16_t dmbId) const {
-    return getCSCPayload(makeCSCId(crateId, dmbId));
-  }
+    ExaminerStatusType getCSCPayload(const uint16_t crateId, const uint16_t dmbId) const {
+      return getCSCPayload(makeCSCId(crateId, dmbId));
+    }
 
-  ExaminerStatusType getCSCStatus(const CSCIdType CSCId) const {
-    std::map<CSCIdType, ExaminerStatusType>::const_iterator item = mCSC_STATUS.find(CSCId);
-    if (item != mCSC_STATUS.end())
-      return item->second;
-    else
-      return 0;
-  }
+    ExaminerStatusType getCSCStatus(const CSCIdType CSCId) const {
+      std::map<CSCIdType, ExaminerStatusType>::const_iterator item = mCSC_STATUS.find(CSCId);
+      if (item != mCSC_STATUS.end())
+        return item->second;
+      else
+        return 0;
+    }
 
-  ExaminerStatusType getCSCStatus(const uint16_t crateId, const uint16_t dmbId) const {
-    return getCSCStatus(makeCSCId(crateId, dmbId));
-  }
+    ExaminerStatusType getCSCStatus(const uint16_t crateId, const uint16_t dmbId) const {
+      return getCSCStatus(makeCSCId(crateId, dmbId));
+    }
 
-  /* 
+    /* 
    * Return FED/DCC Id
    */
-  DCCIdType getDCCId() const { return DCCId; }
+    DCCIdType getDCCId() const { return DCCId; }
 
-  /**
+    /**
    * Return DCC/DDU level Errors Mask 
    */
-  ExaminerMaskType getDCCMask() const { return fDCC_MASK; }
+    ExaminerMaskType getDCCMask() const { return fDCC_MASK; }
 
-  /**
+    /**
    * Return CSC level Errors Mask 
    */
-  ExaminerMaskType getCSCMask() const { return fCSC_MASK; }
+    ExaminerMaskType getCSCMask() const { return fCSC_MASK; }
 
-  /**
+    /**
    * Flag Getters for individual named masks.
    */
 
-  bool getDDUSummaryFlag(const FormatErrorFlag flag) const {
-    return ((fDDU_SUMMARY_ERRORS & ExaminerStatusType(0x1 << flag)) != 0);
-  }
-  bool getDDUErrorFlag(const DDUIdType DDUId, const FormatErrorFlag flag) const {
-    return ((getDDUErrors(DDUId) & ExaminerStatusType(0x1 << flag)) != 0);
-  }
+    bool getDDUSummaryFlag(const FormatErrorFlag flag) const {
+      return ((fDDU_SUMMARY_ERRORS & ExaminerStatusType(0x1 << flag)) != 0);
+    }
+    bool getDDUErrorFlag(const DDUIdType DDUId, const FormatErrorFlag flag) const {
+      return ((getDDUErrors(DDUId) & ExaminerStatusType(0x1 << flag)) != 0);
+    }
 
-  bool getCSCErrorFlag(const CSCIdType CSCId, const FormatErrorFlag flag) const {
-    return ((getCSCErrors(CSCId) & ExaminerStatusType(0x1 << flag)) != 0);
-  }
+    bool getCSCErrorFlag(const CSCIdType CSCId, const FormatErrorFlag flag) const {
+      return ((getCSCErrors(CSCId) & ExaminerStatusType(0x1 << flag)) != 0);
+    }
 
-  bool getCSCErrorFlag(const uint16_t crateId, const uint16_t dmbId, const FormatErrorFlag flag) const {
-    return ((getCSCErrors(crateId, dmbId) & ExaminerStatusType(0x1 << flag)) != 0);
-  }
+    bool getCSCErrorFlag(const uint16_t crateId, const uint16_t dmbId, const FormatErrorFlag flag) const {
+      return ((getCSCErrors(crateId, dmbId) & ExaminerStatusType(0x1 << flag)) != 0);
+    }
 
-  bool getCSCPayloadFlag(const CSCIdType CSCId, const CSCPayloadFlag flag) const {
-    return ((getCSCPayload(CSCId) & ExaminerStatusType(0x1 << flag)) != 0);
-  }
+    bool getCSCPayloadFlag(const CSCIdType CSCId, const CSCPayloadFlag flag) const {
+      return ((getCSCPayload(CSCId) & ExaminerStatusType(0x1 << flag)) != 0);
+    }
 
-  bool getCSCPayloadFlag(const uint16_t crateId, const uint16_t dmbId, const CSCPayloadFlag flag) const {
-    return ((getCSCPayload(crateId, dmbId) & ExaminerStatusType(0x1 << flag)) != 0);
-  }
+    bool getCSCPayloadFlag(const uint16_t crateId, const uint16_t dmbId, const CSCPayloadFlag flag) const {
+      return ((getCSCPayload(crateId, dmbId) & ExaminerStatusType(0x1 << flag)) != 0);
+    }
 
-  bool getCSCStatusFlag(const CSCIdType CSCId, const CSCStatusFlag flag) const {
-    return ((getCSCStatus(CSCId) & ExaminerStatusType(0x1 << flag)) != 0);
-  }
+    bool getCSCStatusFlag(const CSCIdType CSCId, const CSCStatusFlag flag) const {
+      return ((getCSCStatus(CSCId) & ExaminerStatusType(0x1 << flag)) != 0);
+    }
 
-  bool getCSCStatusFlag(const uint16_t crateId, const uint16_t dmbId, const CSCStatusFlag flag) const {
-    return ((getCSCStatus(crateId, dmbId) & ExaminerStatusType(0x1 << flag)) != 0);
-  }
+    bool getCSCStatusFlag(const uint16_t crateId, const uint16_t dmbId, const CSCStatusFlag flag) const {
+      return ((getCSCStatus(crateId, dmbId) & ExaminerStatusType(0x1 << flag)) != 0);
+    }
 
-  void print() const;
-};
+    void print() const;
+  };
 
-std::ostream& operator<<(std::ostream& o, const CSCDCCFormatStatusDigi& digi);
+  std::ostream& operator<<(std::ostream& o, const CSCDCCFormatStatusDigi& digi);
 
+}  // namespace io_v1
+using CSCDCCFormatStatusDigi = io_v1::CSCDCCFormatStatusDigi;
 #endif

--- a/DataFormats/CSCDigi/interface/CSCShowerDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCShowerDigi.h
@@ -6,68 +6,73 @@
 #include <limits>
 #include <vector>
 
-class CSCShowerDigi {
-public:
-  // Run-3 definitions as provided in DN-20-033
-  enum Run3Shower { kInvalid = 0, kLoose = 1, kNominal = 2, kTight = 3 };
-  // Shower types. and showers from OTMB/TMB are assigned with kLCTShower
-  enum ShowerType {
-    kInvalidShower = 0,
-    kALCTShower = 1,
-    kCLCTShower = 2,
-    kLCTShower = 3,
-    kEMTFShower = 4,
-    kGMTShower = 5
+namespace io_v1 {
+
+  class CSCShowerDigi {
+  public:
+    // Run-3 definitions as provided in DN-20-033
+    enum Run3Shower { kInvalid = 0, kLoose = 1, kNominal = 2, kTight = 3 };
+    // Shower types. and showers from OTMB/TMB are assigned with kLCTShower
+    enum ShowerType {
+      kInvalidShower = 0,
+      kALCTShower = 1,
+      kCLCTShower = 2,
+      kLCTShower = 3,
+      kEMTFShower = 4,
+      kGMTShower = 5
+    };
+
+    /// Constructors
+    CSCShowerDigi(const uint16_t inTimeBits,
+                  const uint16_t outTimeBits,
+                  const uint16_t cscID,
+                  const uint16_t bx = 0,
+                  const uint16_t showerType = 4,
+                  const uint16_t wireNHits = 0,
+                  const uint16_t compNHits = 0);
+    /// default
+    CSCShowerDigi();
+
+    /// clear this Shower
+    void clear();
+
+    /// data
+    bool isValid() const;
+
+    bool isLooseInTime() const;
+    bool isNominalInTime() const;
+    bool isTightInTime() const;
+    bool isLooseOutOfTime() const;
+    bool isNominalOutOfTime() const;
+    bool isTightOutOfTime() const;
+    bool isValidShowerType() const;
+
+    uint16_t bitsInTime() const { return bitsInTime_; }
+    uint16_t bitsOutOfTime() const { return bitsOutOfTime_; }
+
+    uint16_t getBX() const { return bx_; }
+    uint16_t getCSCID() const { return cscID_; }
+    uint16_t getShowerType() const { return showerType_; }
+    uint16_t getWireNHits() const { return wireNHits_; }
+    uint16_t getComparatorNHits() const { return comparatorNHits_; }
+
+    /// set cscID
+    void setCSCID(const uint16_t c) { cscID_ = c; }
+    void setBX(const uint16_t bx) { bx_ = bx; }
+
+  private:
+    uint16_t bitsInTime_;
+    uint16_t bitsOutOfTime_;
+    // 4-bit CSC chamber identifier
+    uint16_t cscID_;
+    uint16_t bx_;
+    uint16_t showerType_;
+    uint16_t wireNHits_;
+    uint16_t comparatorNHits_;
   };
 
-  /// Constructors
-  CSCShowerDigi(const uint16_t inTimeBits,
-                const uint16_t outTimeBits,
-                const uint16_t cscID,
-                const uint16_t bx = 0,
-                const uint16_t showerType = 4,
-                const uint16_t wireNHits = 0,
-                const uint16_t compNHits = 0);
-  /// default
-  CSCShowerDigi();
+  std::ostream& operator<<(std::ostream& o, const CSCShowerDigi& digi);
 
-  /// clear this Shower
-  void clear();
-
-  /// data
-  bool isValid() const;
-
-  bool isLooseInTime() const;
-  bool isNominalInTime() const;
-  bool isTightInTime() const;
-  bool isLooseOutOfTime() const;
-  bool isNominalOutOfTime() const;
-  bool isTightOutOfTime() const;
-  bool isValidShowerType() const;
-
-  uint16_t bitsInTime() const { return bitsInTime_; }
-  uint16_t bitsOutOfTime() const { return bitsOutOfTime_; }
-
-  uint16_t getBX() const { return bx_; }
-  uint16_t getCSCID() const { return cscID_; }
-  uint16_t getShowerType() const { return showerType_; }
-  uint16_t getWireNHits() const { return wireNHits_; }
-  uint16_t getComparatorNHits() const { return comparatorNHits_; }
-
-  /// set cscID
-  void setCSCID(const uint16_t c) { cscID_ = c; }
-  void setBX(const uint16_t bx) { bx_ = bx; }
-
-private:
-  uint16_t bitsInTime_;
-  uint16_t bitsOutOfTime_;
-  // 4-bit CSC chamber identifier
-  uint16_t cscID_;
-  uint16_t bx_;
-  uint16_t showerType_;
-  uint16_t wireNHits_;
-  uint16_t comparatorNHits_;
-};
-
-std::ostream& operator<<(std::ostream& o, const CSCShowerDigi& digi);
+}  // namespace io_v1
+using CSCShowerDigi = io_v1::CSCShowerDigi;
 #endif

--- a/DataFormats/CSCDigi/interface/CSCStripDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCStripDigi.h
@@ -14,74 +14,78 @@
 #include <iosfwd>
 #include <cstdint>
 
-class CSCStripDigi {
-public:
-  // Construct from the strip number and all the other data members.
-  CSCStripDigi(const int& istrip,
-               const std::vector<int>& vADCCounts,
-               const std::vector<uint16_t>& vADCOverflow,
-               const std::vector<uint16_t>& vOverlap,
-               const std::vector<uint16_t>& vErrorstat)
-      : strip(istrip),
-        ADCCounts(vADCCounts),
-        ADCOverflow(vADCOverflow),
-        OverlappedSample(vOverlap),
-        Errorstat(vErrorstat) {}
+namespace io_v1 {
 
-  // Construct from the strip number and the ADC readings.
-  CSCStripDigi(const int& istrip, const std::vector<int>& vADCCounts)
-      : strip(istrip), ADCCounts(vADCCounts), ADCOverflow(8, 0), OverlappedSample(8, 0), Errorstat(8, 0) {}
+  class CSCStripDigi {
+  public:
+    // Construct from the strip number and all the other data members.
+    CSCStripDigi(const int& istrip,
+                 const std::vector<int>& vADCCounts,
+                 const std::vector<uint16_t>& vADCOverflow,
+                 const std::vector<uint16_t>& vOverlap,
+                 const std::vector<uint16_t>& vErrorstat)
+        : strip(istrip),
+          ADCCounts(vADCCounts),
+          ADCOverflow(vADCOverflow),
+          OverlappedSample(vOverlap),
+          Errorstat(vErrorstat) {}
 
-  CSCStripDigi() : strip(0), ADCCounts(8, 0), ADCOverflow(8, 0), OverlappedSample(8, 0), Errorstat(8, 0) {}
+    // Construct from the strip number and the ADC readings.
+    CSCStripDigi(const int& istrip, const std::vector<int>& vADCCounts)
+        : strip(istrip), ADCCounts(vADCCounts), ADCOverflow(8, 0), OverlappedSample(8, 0), Errorstat(8, 0) {}
 
-  // Digis are equal if they are on the same strip and have same ADC readings
-  bool operator==(const CSCStripDigi& digi) const;
+    CSCStripDigi() : strip(0), ADCCounts(8, 0), ADCOverflow(8, 0), OverlappedSample(8, 0), Errorstat(8, 0) {}
 
-  // Get the strip number. counts from 1.
-  int getStrip() const { return strip; }
+    // Digis are equal if they are on the same strip and have same ADC readings
+    bool operator==(const CSCStripDigi& digi) const;
 
-  /// Get the CFEB number. Counts from 0.
-  int getCFEB() const;
+    // Get the strip number. counts from 1.
+    int getStrip() const { return strip; }
 
-  /// Get ADC readings
-  std::vector<int> const& getADCCounts() const { return ADCCounts; }
+    /// Get the CFEB number. Counts from 0.
+    int getCFEB() const;
 
-  /// Get L1APhase from OverlappedSample (9th bit)
-  std::vector<int> getL1APhase() const {
-    std::vector<int> L1APhaseResult(getOverlappedSample().size());
-    for (int i = 0; i < (int)getOverlappedSample().size(); i++)
-      L1APhaseResult[i] = (getOverlappedSample()[i] >> 8) & 0x1;
-    return L1APhaseResult;
-  }
+    /// Get ADC readings
+    std::vector<int> const& getADCCounts() const { return ADCCounts; }
 
-  int getL1APhase(int i) const { return (getOverlappedSample()[i] >> 8) & 0x1; }
+    /// Get L1APhase from OverlappedSample (9th bit)
+    std::vector<int> getL1APhase() const {
+      std::vector<int> L1APhaseResult(getOverlappedSample().size());
+      for (int i = 0; i < (int)getOverlappedSample().size(); i++)
+        L1APhaseResult[i] = (getOverlappedSample()[i] >> 8) & 0x1;
+      return L1APhaseResult;
+    }
 
-  /// Other getters
-  std::vector<uint16_t> const& getADCOverflow() const { return ADCOverflow; }
-  std::vector<uint16_t> const& getOverlappedSample() const { return OverlappedSample; }
-  std::vector<uint16_t> const& getErrorstat() const { return Errorstat; }
+    int getL1APhase(int i) const { return (getOverlappedSample()[i] >> 8) & 0x1; }
 
-  // Set the strip number
-  void setStrip(int istrip) { strip = istrip; }
+    /// Other getters
+    std::vector<uint16_t> const& getADCOverflow() const { return ADCOverflow; }
+    std::vector<uint16_t> const& getOverlappedSample() const { return OverlappedSample; }
+    std::vector<uint16_t> const& getErrorstat() const { return Errorstat; }
 
-  // Set with a vector of ADC readings
-  void setADCCounts(const std::vector<int>& ADCCounts);
+    // Set the strip number
+    void setStrip(int istrip) { strip = istrip; }
 
-  // Print content of digi
-  void print() const;
+    // Set with a vector of ADC readings
+    void setADCCounts(const std::vector<int>& ADCCounts);
 
-  ///methods for calibrations
-  float pedestal() const { return 0.5f * (ADCCounts[0] + ADCCounts[1]); }
-  float amplitude() const { return ADCCounts[4] - pedestal(); }
+    // Print content of digi
+    void print() const;
 
-private:
-  uint16_t strip;
-  std::vector<int> ADCCounts;
-  std::vector<uint16_t> ADCOverflow;
-  std::vector<uint16_t> OverlappedSample;
-  std::vector<uint16_t> Errorstat;
-};
+    ///methods for calibrations
+    float pedestal() const { return 0.5f * (ADCCounts[0] + ADCCounts[1]); }
+    float amplitude() const { return ADCCounts[4] - pedestal(); }
 
-std::ostream& operator<<(std::ostream& o, const CSCStripDigi& digi);
+  private:
+    uint16_t strip;
+    std::vector<int> ADCCounts;
+    std::vector<uint16_t> ADCOverflow;
+    std::vector<uint16_t> OverlappedSample;
+    std::vector<uint16_t> Errorstat;
+  };
 
+  std::ostream& operator<<(std::ostream& o, const CSCStripDigi& digi);
+
+}  // namespace io_v1
+using CSCStripDigi = io_v1::CSCStripDigi;
 #endif

--- a/DataFormats/CSCDigi/interface/CSCStripDigiFwd.h
+++ b/DataFormats/CSCDigi/interface/CSCStripDigiFwd.h
@@ -1,6 +1,9 @@
 #ifndef DataFormats_CSCDigi_CSCStripDigiFwd_h
 #define DataFormats_CSCDigi_CSCStripDigiFwd_h
 
-class CSCStripDigi;
+namespace io_v1 {
+  class CSCStripDigi;
+}
+using CSCStripDigi = io_v1::CSCStripDigi;
 
 #endif

--- a/DataFormats/CSCDigi/interface/CSCWireDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCWireDigi.h
@@ -11,43 +11,47 @@
 #include <iosfwd>
 #include <cstdint>
 
-class CSCWireDigi {
-public:
-  /// Constructors
+namespace io_v1 {
 
-  CSCWireDigi(int wire, unsigned int tbinb);  /// wiregroup#, tbin bit word
-  CSCWireDigi();                              /// default
+  class CSCWireDigi {
+  public:
+    /// Constructors
 
-  /// return wiregroup number. counts from 1.
-  int getWireGroup() const { return wire_; }
-  /// return BX assigned for the wire group (16 upper bits from the wire group number)
-  int getWireGroupBX() const { return wireBX_; }
-  /// return BX-wiregroup number combined
-  /// (16 upper bits - BX + 16 lower bits - wire group number)
-  int getBXandWireGroup() const { return wireBXandWires_; }
-  /// return the word with time bins bits
-  unsigned int getTimeBinWord() const { return tbinb_; }
-  /// return tbin number, (obsolete, use getTimeBin() instead)
-  int getBeamCrossingTag() const;
-  /// return first tbin ON number
-  int getTimeBin() const;
-  /// return vector of time bins ON
-  std::vector<int> getTimeBinsOn() const;
+    CSCWireDigi(int wire, unsigned int tbinb);  /// wiregroup#, tbin bit word
+    CSCWireDigi();                              /// default
 
-  /// Print content of digi
-  void print() const;
+    /// return wiregroup number. counts from 1.
+    int getWireGroup() const { return wire_; }
+    /// return BX assigned for the wire group (16 upper bits from the wire group number)
+    int getWireGroupBX() const { return wireBX_; }
+    /// return BX-wiregroup number combined
+    /// (16 upper bits - BX + 16 lower bits - wire group number)
+    int getBXandWireGroup() const { return wireBXandWires_; }
+    /// return the word with time bins bits
+    unsigned int getTimeBinWord() const { return tbinb_; }
+    /// return tbin number, (obsolete, use getTimeBin() instead)
+    int getBeamCrossingTag() const;
+    /// return first tbin ON number
+    int getTimeBin() const;
+    /// return vector of time bins ON
+    std::vector<int> getTimeBinsOn() const;
 
-  /// set wiregroup number
-  void setWireGroup(unsigned int wiregroup) { wire_ = wiregroup; }
+    /// Print content of digi
+    void print() const;
 
-private:
-  int wire_;
-  uint32_t tbinb_;
-  /// BX in the wire digis (16 upper bits from the wire group number)
-  int wireBXandWires_;
-  int wireBX_;
-};
+    /// set wiregroup number
+    void setWireGroup(unsigned int wiregroup) { wire_ = wiregroup; }
 
-std::ostream& operator<<(std::ostream& o, const CSCWireDigi& digi);
+  private:
+    int wire_;
+    uint32_t tbinb_;
+    /// BX in the wire digis (16 upper bits from the wire group number)
+    int wireBXandWires_;
+    int wireBX_;
+  };
 
+  std::ostream& operator<<(std::ostream& o, const CSCWireDigi& digi);
+
+}  // namespace io_v1
+using CSCWireDigi = io_v1::CSCWireDigi;
 #endif

--- a/DataFormats/CSCDigi/interface/CSCWireDigiFwd.h
+++ b/DataFormats/CSCDigi/interface/CSCWireDigiFwd.h
@@ -1,6 +1,9 @@
 #ifndef DataFormats_CSCDigi_CSCWireDigiFwd_h
 #define DataFormats_CSCDigi_CSCWireDigiFwd_h
 
-class CSCWireDigi;
+namespace io_v1 {
+  class CSCWireDigi;
+}
+using CSCWireDigi = io_v1::CSCWireDigi;
 
 #endif

--- a/DataFormats/CSCDigi/src/CSCALCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCALCTDigi.cc
@@ -13,128 +13,132 @@
 
 using namespace std;
 
-namespace {
-  enum Pattern_Info { NUM_LAYERS = 6, ALCT_PATTERN_WIDTH = 5 };
+namespace io_v1 {
 
-  CSCALCTDigi::WireContainer makeEmptyContainer() {
-    CSCALCTDigi::WireContainer ret;
-    ret.resize(NUM_LAYERS);
-    for (auto& p : ret) {
-      p.resize(ALCT_PATTERN_WIDTH);
+  namespace {
+    enum Pattern_Info { NUM_LAYERS = 6, ALCT_PATTERN_WIDTH = 5 };
+
+    CSCALCTDigi::WireContainer makeEmptyContainer() {
+      CSCALCTDigi::WireContainer ret;
+      ret.resize(NUM_LAYERS);
+      for (auto& p : ret) {
+        p.resize(ALCT_PATTERN_WIDTH);
+      }
+      return ret;
     }
-    return ret;
+  }  // namespace
+
+  CSCALCTDigi::WireContainer const& CSCALCTDigi::emptyContainer() {
+    static WireContainer const s_container = makeEmptyContainer();
+    return s_container;
   }
-}  // namespace
 
-CSCALCTDigi::WireContainer const& CSCALCTDigi::emptyContainer() {
-  static WireContainer const s_container = makeEmptyContainer();
-  return s_container;
-}
+  /// Constructors
+  CSCALCTDigi::CSCALCTDigi(const uint16_t valid,
+                           const uint16_t quality,
+                           const uint16_t accel,
+                           const uint16_t patternb,
+                           const uint16_t keywire,
+                           const uint16_t bx,
+                           const uint16_t trknmb,
+                           const uint16_t hmt,
+                           const Version version)
+      : valid_(valid),
+        quality_(quality),
+        accel_(accel),
+        patternb_(patternb),
+        keywire_(keywire),
+        bx_(bx),
+        trknmb_(trknmb),
+        fullbx_(0),
+        hmt_(hmt),
+        version_(version) {}
 
-/// Constructors
-CSCALCTDigi::CSCALCTDigi(const uint16_t valid,
-                         const uint16_t quality,
-                         const uint16_t accel,
-                         const uint16_t patternb,
-                         const uint16_t keywire,
-                         const uint16_t bx,
-                         const uint16_t trknmb,
-                         const uint16_t hmt,
-                         const Version version)
-    : valid_(valid),
-      quality_(quality),
-      accel_(accel),
-      patternb_(patternb),
-      keywire_(keywire),
-      bx_(bx),
-      trknmb_(trknmb),
-      fullbx_(0),
-      hmt_(hmt),
-      version_(version) {}
-
-/// Default
-CSCALCTDigi::CSCALCTDigi() {
-  clear();  // set contents to zero
-}
-
-/// Clears this ALCT.
-void CSCALCTDigi::clear() {
-  valid_ = 0;
-  quality_ = 0;
-  accel_ = 0;
-  patternb_ = 0;
-  keywire_ = 0;
-  bx_ = 0;
-  trknmb_ = 0;
-  fullbx_ = 0;
-  hmt_ = 0;
-  hits_.clear();
-  version_ = Version::Legacy;
-}
-
-uint16_t CSCALCTDigi::getHMT() const { return (isRun3() ? hmt_ : std::numeric_limits<uint16_t>::max()); }
-
-void CSCALCTDigi::setHMT(const uint16_t h) { hmt_ = isRun3() ? h : std::numeric_limits<uint16_t>::max(); }
-
-void CSCALCTDigi::setRun3(const bool isRun3) { version_ = isRun3 ? Version::Run3 : Version::Legacy; }
-
-bool CSCALCTDigi::operator>(const CSCALCTDigi& rhs) const {
-  bool returnValue = false;
-
-  // Early ALCTs are always preferred to the ones found at later bx's.
-  if (getBX() < rhs.getBX()) {
-    returnValue = true;
+  /// Default
+  CSCALCTDigi::CSCALCTDigi() {
+    clear();  // set contents to zero
   }
-  if (getBX() != rhs.getBX()) {
+
+  /// Clears this ALCT.
+  void CSCALCTDigi::clear() {
+    valid_ = 0;
+    quality_ = 0;
+    accel_ = 0;
+    patternb_ = 0;
+    keywire_ = 0;
+    bx_ = 0;
+    trknmb_ = 0;
+    fullbx_ = 0;
+    hmt_ = 0;
+    hits_.clear();
+    version_ = Version::Legacy;
+  }
+
+  uint16_t CSCALCTDigi::getHMT() const { return (isRun3() ? hmt_ : std::numeric_limits<uint16_t>::max()); }
+
+  void CSCALCTDigi::setHMT(const uint16_t h) { hmt_ = isRun3() ? h : std::numeric_limits<uint16_t>::max(); }
+
+  void CSCALCTDigi::setRun3(const bool isRun3) { version_ = isRun3 ? Version::Run3 : Version::Legacy; }
+
+  bool CSCALCTDigi::operator>(const CSCALCTDigi& rhs) const {
+    bool returnValue = false;
+
+    // Early ALCTs are always preferred to the ones found at later bx's.
+    if (getBX() < rhs.getBX()) {
+      returnValue = true;
+    }
+    if (getBX() != rhs.getBX()) {
+      return returnValue;
+    }
+
+    // The > operator then checks the quality of ALCTs.
+    // If two qualities are equal, the ALCT furthest from the beam axis
+    // (lowest eta, highest wire group number) is selected.
+    uint16_t quality1 = getQuality();
+    uint16_t quality2 = rhs.getQuality();
+    if (quality1 > quality2) {
+      returnValue = true;
+    } else if (quality1 == quality2 && getKeyWG() > rhs.getKeyWG()) {
+      returnValue = true;
+    }
     return returnValue;
   }
 
-  // The > operator then checks the quality of ALCTs.
-  // If two qualities are equal, the ALCT furthest from the beam axis
-  // (lowest eta, highest wire group number) is selected.
-  uint16_t quality1 = getQuality();
-  uint16_t quality2 = rhs.getQuality();
-  if (quality1 > quality2) {
-    returnValue = true;
-  } else if (quality1 == quality2 && getKeyWG() > rhs.getKeyWG()) {
-    returnValue = true;
+  bool CSCALCTDigi::operator==(const CSCALCTDigi& rhs) const {
+    // Exact equality.
+    bool returnValue = false;
+    if (isValid() == rhs.isValid() && getQuality() == rhs.getQuality() && getAccelerator() == rhs.getAccelerator() &&
+        getCollisionB() == rhs.getCollisionB() && getKeyWG() == rhs.getKeyWG() && getBX() == rhs.getBX()) {
+      returnValue = true;
+    }
+    return returnValue;
   }
-  return returnValue;
-}
 
-bool CSCALCTDigi::operator==(const CSCALCTDigi& rhs) const {
-  // Exact equality.
-  bool returnValue = false;
-  if (isValid() == rhs.isValid() && getQuality() == rhs.getQuality() && getAccelerator() == rhs.getAccelerator() &&
-      getCollisionB() == rhs.getCollisionB() && getKeyWG() == rhs.getKeyWG() && getBX() == rhs.getBX()) {
-    returnValue = true;
+  bool CSCALCTDigi::operator!=(const CSCALCTDigi& rhs) const {
+    // True if == is false.
+    bool returnValue = true;
+    if ((*this) == rhs)
+      returnValue = false;
+    return returnValue;
   }
-  return returnValue;
-}
 
-bool CSCALCTDigi::operator!=(const CSCALCTDigi& rhs) const {
-  // True if == is false.
-  bool returnValue = true;
-  if ((*this) == rhs)
-    returnValue = false;
-  return returnValue;
-}
-
-/// Debug
-void CSCALCTDigi::print() const {
-  if (isValid()) {
-    edm::LogVerbatim("CSCDigi") << "CSC ALCT #" << setw(1) << getTrknmb() << ": Valid = " << setw(1) << isValid()
-                                << " Quality = " << setw(2) << getQuality() << " Accel. = " << setw(1)
-                                << getAccelerator() << " PatternB = " << setw(1) << getCollisionB()
-                                << " Key wire group = " << setw(3) << getKeyWG() << " BX = " << setw(2) << getBX()
-                                << " Full BX = " << std::setw(1) << getFullBX();
-  } else {
-    edm::LogVerbatim("CSCDigi") << "Not a valid Anode LCT.";
+  /// Debug
+  void CSCALCTDigi::print() const {
+    if (isValid()) {
+      edm::LogVerbatim("CSCDigi") << "CSC ALCT #" << setw(1) << getTrknmb() << ": Valid = " << setw(1) << isValid()
+                                  << " Quality = " << setw(2) << getQuality() << " Accel. = " << setw(1)
+                                  << getAccelerator() << " PatternB = " << setw(1) << getCollisionB()
+                                  << " Key wire group = " << setw(3) << getKeyWG() << " BX = " << setw(2) << getBX()
+                                  << " Full BX = " << std::setw(1) << getFullBX();
+    } else {
+      edm::LogVerbatim("CSCDigi") << "Not a valid Anode LCT.";
+    }
   }
-}
 
-std::ostream& operator<<(std::ostream& o, const CSCALCTDigi& digi) {
-  return o << "CSC ALCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " Quality = " << digi.getQuality()
-           << " Accel. = " << digi.getAccelerator() << " PatternB = " << digi.getCollisionB()
-           << " Key wire group = " << digi.getKeyWG() << " BX = " << digi.getBX();
-}
+  std::ostream& operator<<(std::ostream& o, const CSCALCTDigi& digi) {
+    return o << "CSC ALCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " Quality = " << digi.getQuality()
+             << " Accel. = " << digi.getAccelerator() << " PatternB = " << digi.getCollisionB()
+             << " Key wire group = " << digi.getKeyWG() << " BX = " << digi.getBX();
+  }
+
+}  // namespace io_v1

--- a/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
@@ -11,220 +11,224 @@
 #include <iomanip>
 #include <iostream>
 
-enum Pattern_Info { NUM_LAYERS = 6, CLCT_PATTERN_WIDTH = 11 };
+namespace io_v1 {
 
-namespace {
-  CSCCLCTDigi::ComparatorContainer makeEmptyContainer() {
-    CSCCLCTDigi::ComparatorContainer ret;
-    ret.resize(NUM_LAYERS);
-    for (auto& p : ret) {
-      p.resize(CLCT_PATTERN_WIDTH);
+  enum Pattern_Info { NUM_LAYERS = 6, CLCT_PATTERN_WIDTH = 11 };
+
+  namespace {
+    CSCCLCTDigi::ComparatorContainer makeEmptyContainer() {
+      CSCCLCTDigi::ComparatorContainer ret;
+      ret.resize(NUM_LAYERS);
+      for (auto& p : ret) {
+        p.resize(CLCT_PATTERN_WIDTH);
+      }
+      return ret;
     }
-    return ret;
+  }  // namespace
+
+  CSCCLCTDigi::ComparatorContainer const& CSCCLCTDigi::emptyContainer() {
+    static ComparatorContainer const s_container = makeEmptyContainer();
+    return s_container;
   }
-}  // namespace
 
-CSCCLCTDigi::ComparatorContainer const& CSCCLCTDigi::emptyContainer() {
-  static ComparatorContainer const s_container = makeEmptyContainer();
-  return s_container;
-}
+  /// Constructors
+  CSCCLCTDigi::CSCCLCTDigi(const uint16_t valid,
+                           const uint16_t quality,
+                           const uint16_t pattern,
+                           const uint16_t striptype,
+                           const uint16_t bend,
+                           const uint16_t strip,
+                           const uint16_t cfeb,
+                           const uint16_t bx,
+                           const uint16_t trknmb,
+                           const uint16_t fullbx,
+                           const int16_t compCode,
+                           const Version version,
+                           const bool run3_quart_strip_bit,
+                           const bool run3_eighth_strip_bit,
+                           const uint16_t run3_pattern,
+                           const uint16_t run3_slope)
+      : valid_(valid),
+        quality_(quality),
+        pattern_(pattern),
+        striptype_(striptype),
+        bend_(bend),
+        strip_(strip),
+        cfeb_(cfeb),
+        bx_(bx),
+        trknmb_(trknmb),
+        fullbx_(fullbx),
+        compCode_(compCode),
+        run3_quart_strip_bit_(run3_quart_strip_bit),
+        run3_eighth_strip_bit_(run3_eighth_strip_bit),
+        run3_pattern_(run3_pattern),
+        run3_slope_(run3_slope),
+        hits_(),
+        version_(version) {}
 
-/// Constructors
-CSCCLCTDigi::CSCCLCTDigi(const uint16_t valid,
-                         const uint16_t quality,
-                         const uint16_t pattern,
-                         const uint16_t striptype,
-                         const uint16_t bend,
-                         const uint16_t strip,
-                         const uint16_t cfeb,
-                         const uint16_t bx,
-                         const uint16_t trknmb,
-                         const uint16_t fullbx,
-                         const int16_t compCode,
-                         const Version version,
-                         const bool run3_quart_strip_bit,
-                         const bool run3_eighth_strip_bit,
-                         const uint16_t run3_pattern,
-                         const uint16_t run3_slope)
-    : valid_(valid),
-      quality_(quality),
-      pattern_(pattern),
-      striptype_(striptype),
-      bend_(bend),
-      strip_(strip),
-      cfeb_(cfeb),
-      bx_(bx),
-      trknmb_(trknmb),
-      fullbx_(fullbx),
-      compCode_(compCode),
-      run3_quart_strip_bit_(run3_quart_strip_bit),
-      run3_eighth_strip_bit_(run3_eighth_strip_bit),
-      run3_pattern_(run3_pattern),
-      run3_slope_(run3_slope),
-      hits_(),
-      version_(version) {}
-
-/// Default
-CSCCLCTDigi::CSCCLCTDigi() {
-  clear();  // set contents to zero
-}
-
-/// Clears this CLCT.
-void CSCCLCTDigi::clear() {
-  valid_ = 0;
-  quality_ = 0;
-  pattern_ = 0;
-  striptype_ = 0;
-  bend_ = 0;
-  strip_ = 0;
-  cfeb_ = 0;
-  bx_ = 0;
-  trknmb_ = 0;
-  fullbx_ = 0;
-  // Run-3 variables
-  compCode_ = -1;
-  run3_quart_strip_bit_ = false;
-  run3_eighth_strip_bit_ = false;
-  run3_pattern_ = 0;
-  run3_slope_ = 0;
-  version_ = Version::Legacy;
-  hits_.clear();
-}
-
-// slope in number of half-strips/layer
-float CSCCLCTDigi::getFractionalSlope() const {
-  if (isRun3()) {
-    // 4-bit slope
-    float slope[17] = {
-        0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1.0, 1.125, 1.25, 1.375, 1.5, 1.625, 1.75, 2.0, 2.5};
-    return (2 * getBend() - 1) * slope[getSlope()];
-  } else {
-    int slope[11] = {0, 0, -8, 8, -6, 6, -4, 4, -2, 2, 0};
-    return float(slope[getPattern()] / 5.);
+  /// Default
+  CSCCLCTDigi::CSCCLCTDigi() {
+    clear();  // set contents to zero
   }
-}
 
-uint16_t CSCCLCTDigi::getKeyStrip(const uint16_t n) const {
-  // 10-bit case for strip data word
-  if (compCode_ != -1 and n == 8) {
-    return getKeyStrip(4) * 2 + getEighthStripBit();
+  /// Clears this CLCT.
+  void CSCCLCTDigi::clear() {
+    valid_ = 0;
+    quality_ = 0;
+    pattern_ = 0;
+    striptype_ = 0;
+    bend_ = 0;
+    strip_ = 0;
+    cfeb_ = 0;
+    bx_ = 0;
+    trknmb_ = 0;
+    fullbx_ = 0;
+    // Run-3 variables
+    compCode_ = -1;
+    run3_quart_strip_bit_ = false;
+    run3_eighth_strip_bit_ = false;
+    run3_pattern_ = 0;
+    run3_slope_ = 0;
+    version_ = Version::Legacy;
+    hits_.clear();
   }
-  // 9-bit case for strip data word
-  else if (compCode_ != -1 and n == 4) {
-    return getKeyStrip(2) * 2 + getQuartStripBit();
+
+  // slope in number of half-strips/layer
+  float CSCCLCTDigi::getFractionalSlope() const {
+    if (isRun3()) {
+      // 4-bit slope
+      float slope[17] = {
+          0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1.0, 1.125, 1.25, 1.375, 1.5, 1.625, 1.75, 2.0, 2.5};
+      return (2 * getBend() - 1) * slope[getSlope()];
+    } else {
+      int slope[11] = {0, 0, -8, 8, -6, 6, -4, 4, -2, 2, 0};
+      return float(slope[getPattern()] / 5.);
+    }
   }
-  // 8-bit case for strip data word (all other cases)
-  else {
-    return cfeb_ * 32 + getStrip();
+
+  uint16_t CSCCLCTDigi::getKeyStrip(const uint16_t n) const {
+    // 10-bit case for strip data word
+    if (compCode_ != -1 and n == 8) {
+      return getKeyStrip(4) * 2 + getEighthStripBit();
+    }
+    // 9-bit case for strip data word
+    else if (compCode_ != -1 and n == 4) {
+      return getKeyStrip(2) * 2 + getQuartStripBit();
+    }
+    // 8-bit case for strip data word (all other cases)
+    else {
+      return cfeb_ * 32 + getStrip();
+    }
   }
-}
 
-/// return the fractional strip (middle of the strip)
-float CSCCLCTDigi::getFractionalStrip(const uint16_t n) const {
-  if (compCode_ != -1 and n == 8) {
-    return 0.125f * (getKeyStrip(n) + 0.5);
-  } else if (compCode_ != -1 and n == 4) {
-    return 0.25f * (getKeyStrip(n) + 0.5);
-  } else {
-    return 0.5f * (getKeyStrip(n) + 0.5);
+  /// return the fractional strip (middle of the strip)
+  float CSCCLCTDigi::getFractionalStrip(const uint16_t n) const {
+    if (compCode_ != -1 and n == 8) {
+      return 0.125f * (getKeyStrip(n) + 0.5);
+    } else if (compCode_ != -1 and n == 4) {
+      return 0.25f * (getKeyStrip(n) + 0.5);
+    } else {
+      return 0.5f * (getKeyStrip(n) + 0.5);
+    }
   }
-}
 
-void CSCCLCTDigi::setRun3(const bool isRun3) { version_ = isRun3 ? Version::Run3 : Version::Legacy; }
+  void CSCCLCTDigi::setRun3(const bool isRun3) { version_ = isRun3 ? Version::Run3 : Version::Legacy; }
 
-bool CSCCLCTDigi::operator>(const CSCCLCTDigi& rhs) const {
-  // Several versions of CLCT sorting criteria were used before 2008.
-  // They are available in CMSSW versions prior to 3_1_0; here we only keep
-  // the latest one, used in TMB-07 firmware (w/o distrips).
-  bool returnValue = false;
+  bool CSCCLCTDigi::operator>(const CSCCLCTDigi& rhs) const {
+    // Several versions of CLCT sorting criteria were used before 2008.
+    // They are available in CMSSW versions prior to 3_1_0; here we only keep
+    // the latest one, used in TMB-07 firmware (w/o distrips).
+    bool returnValue = false;
 
-  uint16_t quality1 = getQuality();
-  uint16_t quality2 = rhs.getQuality();
+    uint16_t quality1 = getQuality();
+    uint16_t quality2 = rhs.getQuality();
 
-  // Run-3 case
-  if (version_ == Version::Run3) {
-    // Better-quality CLCTs are preferred.
-    // If two qualities are equal, smaller bending is preferred;
-    // left- and right-bend patterns are considered to be of
-    // the same quality. This corresponds to "pattern" being smaller!!!
-    // If both qualities and pattern id's are the same, lower keystrip
-    // is preferred.
-    if ((quality1 > quality2) || (quality1 == quality2 && getPattern() < rhs.getPattern()) ||
-        (quality1 == quality2 && getPattern() == rhs.getPattern() && getKeyStrip() < rhs.getKeyStrip())) {
+    // Run-3 case
+    if (version_ == Version::Run3) {
+      // Better-quality CLCTs are preferred.
+      // If two qualities are equal, smaller bending is preferred;
+      // left- and right-bend patterns are considered to be of
+      // the same quality. This corresponds to "pattern" being smaller!!!
+      // If both qualities and pattern id's are the same, lower keystrip
+      // is preferred.
+      if ((quality1 > quality2) || (quality1 == quality2 && getPattern() < rhs.getPattern()) ||
+          (quality1 == quality2 && getPattern() == rhs.getPattern() && getKeyStrip() < rhs.getKeyStrip())) {
+        returnValue = true;
+      }
+    }
+    // Legacy case:
+    else {
+      // The bend-direction bit pid[0] is ignored (left and right bends have
+      // equal quality).
+      uint16_t pattern1 = getPattern() & 14;
+      uint16_t pattern2 = rhs.getPattern() & 14;
+
+      // Better-quality CLCTs are preferred.
+      // If two qualities are equal, larger pattern id (i.e., straighter pattern)
+      // is preferred; left- and right-bend patterns are considered to be of
+      // the same quality.
+      // If both qualities and pattern id's are the same, lower keystrip
+      // is preferred.
+      if ((quality1 > quality2) || (quality1 == quality2 && pattern1 > pattern2) ||
+          (quality1 == quality2 && pattern1 == pattern2 && getKeyStrip() < rhs.getKeyStrip())) {
+        returnValue = true;
+      }
+    }
+    return returnValue;
+  }
+
+  bool CSCCLCTDigi::operator==(const CSCCLCTDigi& rhs) const {
+    // Exact equality.
+    bool returnValue = false;
+    if (isValid() == rhs.isValid() && getQuality() == rhs.getQuality() && getPattern() == rhs.getPattern() &&
+        getKeyStrip() == rhs.getKeyStrip() && getStripType() == rhs.getStripType() && getBend() == rhs.getBend() &&
+        getBX() == rhs.getBX() && getCompCode() == rhs.getCompCode()) {
       returnValue = true;
     }
+    return returnValue;
   }
-  // Legacy case:
-  else {
-    // The bend-direction bit pid[0] is ignored (left and right bends have
-    // equal quality).
-    uint16_t pattern1 = getPattern() & 14;
-    uint16_t pattern2 = rhs.getPattern() & 14;
 
-    // Better-quality CLCTs are preferred.
-    // If two qualities are equal, larger pattern id (i.e., straighter pattern)
-    // is preferred; left- and right-bend patterns are considered to be of
-    // the same quality.
-    // If both qualities and pattern id's are the same, lower keystrip
-    // is preferred.
-    if ((quality1 > quality2) || (quality1 == quality2 && pattern1 > pattern2) ||
-        (quality1 == quality2 && pattern1 == pattern2 && getKeyStrip() < rhs.getKeyStrip())) {
-      returnValue = true;
+  bool CSCCLCTDigi::operator!=(const CSCCLCTDigi& rhs) const {
+    // True if == is false.
+    bool returnValue = true;
+    if ((*this) == rhs)
+      returnValue = false;
+    return returnValue;
+  }
+
+  /// Debug
+  void CSCCLCTDigi::print() const {
+    if (isValid()) {
+      char stripType = (getStripType() == 0) ? 'D' : 'H';
+      char bend = (getBend() == 0) ? 'L' : 'R';
+
+      edm::LogVerbatim("CSCDigi") << " CSC CLCT #" << std::setw(1) << getTrknmb() << ": Valid = " << std::setw(1)
+                                  << isValid() << " Key Strip = " << std::setw(3) << getKeyStrip()
+                                  << " Strip = " << std::setw(2) << getStrip() << " Quality = " << std::setw(1)
+                                  << getQuality() << " Pattern = " << std::setw(1) << getPattern()
+                                  << " Bend = " << std::setw(1) << bend << " Strip type = " << std::setw(1) << stripType
+                                  << " CFEB ID = " << std::setw(1) << getCFEB() << " BX = " << std::setw(1) << getBX()
+                                  << " Full BX= " << std::setw(1) << getFullBX() << " Comp Code= " << std::setw(1)
+                                  << getCompCode();
+    } else {
+      edm::LogVerbatim("CSCDigi") << "Not a valid Cathode LCT.";
     }
   }
-  return returnValue;
-}
 
-bool CSCCLCTDigi::operator==(const CSCCLCTDigi& rhs) const {
-  // Exact equality.
-  bool returnValue = false;
-  if (isValid() == rhs.isValid() && getQuality() == rhs.getQuality() && getPattern() == rhs.getPattern() &&
-      getKeyStrip() == rhs.getKeyStrip() && getStripType() == rhs.getStripType() && getBend() == rhs.getBend() &&
-      getBX() == rhs.getBX() && getCompCode() == rhs.getCompCode()) {
-    returnValue = true;
+  std::ostream& operator<<(std::ostream& o, const CSCCLCTDigi& digi) {
+    if (digi.isRun3())
+      return o << "CSC CLCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " BX = " << digi.getBX()
+               << " Run-2 Pattern = " << digi.getPattern() << " Run-3 Pattern = " << digi.getRun3Pattern()
+               << " Quality = " << digi.getQuality() << " Comp Code " << digi.getCompCode()
+               << " Bend = " << digi.getBend() << "\n"
+               << " Slope = " << digi.getSlope() << " CFEB = " << digi.getCFEB() << " Strip = " << digi.getStrip()
+               << " KeyHalfStrip = " << digi.getKeyStrip() << " KeyQuartStrip = " << digi.getKeyStrip(4)
+               << " KeyEighthStrip = " << digi.getKeyStrip(8);
+    else
+      return o << "CSC CLCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " BX = " << digi.getBX()
+               << " Pattern = " << digi.getPattern() << " Quality = " << digi.getQuality()
+               << " Bend = " << digi.getBend() << " CFEB = " << digi.getCFEB() << " HalfStrip = " << digi.getStrip()
+               << " KeyHalfStrip = " << digi.getKeyStrip();
   }
-  return returnValue;
-}
 
-bool CSCCLCTDigi::operator!=(const CSCCLCTDigi& rhs) const {
-  // True if == is false.
-  bool returnValue = true;
-  if ((*this) == rhs)
-    returnValue = false;
-  return returnValue;
-}
-
-/// Debug
-void CSCCLCTDigi::print() const {
-  if (isValid()) {
-    char stripType = (getStripType() == 0) ? 'D' : 'H';
-    char bend = (getBend() == 0) ? 'L' : 'R';
-
-    edm::LogVerbatim("CSCDigi") << " CSC CLCT #" << std::setw(1) << getTrknmb() << ": Valid = " << std::setw(1)
-                                << isValid() << " Key Strip = " << std::setw(3) << getKeyStrip()
-                                << " Strip = " << std::setw(2) << getStrip() << " Quality = " << std::setw(1)
-                                << getQuality() << " Pattern = " << std::setw(1) << getPattern()
-                                << " Bend = " << std::setw(1) << bend << " Strip type = " << std::setw(1) << stripType
-                                << " CFEB ID = " << std::setw(1) << getCFEB() << " BX = " << std::setw(1) << getBX()
-                                << " Full BX= " << std::setw(1) << getFullBX() << " Comp Code= " << std::setw(1)
-                                << getCompCode();
-  } else {
-    edm::LogVerbatim("CSCDigi") << "Not a valid Cathode LCT.";
-  }
-}
-
-std::ostream& operator<<(std::ostream& o, const CSCCLCTDigi& digi) {
-  if (digi.isRun3())
-    return o << "CSC CLCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " BX = " << digi.getBX()
-             << " Run-2 Pattern = " << digi.getPattern() << " Run-3 Pattern = " << digi.getRun3Pattern()
-             << " Quality = " << digi.getQuality() << " Comp Code " << digi.getCompCode()
-             << " Bend = " << digi.getBend() << "\n"
-             << " Slope = " << digi.getSlope() << " CFEB = " << digi.getCFEB() << " Strip = " << digi.getStrip()
-             << " KeyHalfStrip = " << digi.getKeyStrip() << " KeyQuartStrip = " << digi.getKeyStrip(4)
-             << " KeyEighthStrip = " << digi.getKeyStrip(8);
-  else
-    return o << "CSC CLCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " BX = " << digi.getBX()
-             << " Pattern = " << digi.getPattern() << " Quality = " << digi.getQuality() << " Bend = " << digi.getBend()
-             << " CFEB = " << digi.getCFEB() << " HalfStrip = " << digi.getStrip()
-             << " KeyHalfStrip = " << digi.getKeyStrip();
-}
+}  // namespace io_v1

--- a/DataFormats/CSCDigi/src/CSCCLCTPreTriggerDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCLCTPreTriggerDigi.cc
@@ -4,122 +4,126 @@
 #include <iomanip>
 #include <iostream>
 
-/// Constructors
-CSCCLCTPreTriggerDigi::CSCCLCTPreTriggerDigi(const int valid,
-                                             const int quality,
-                                             const int pattern,
-                                             const int striptype,
-                                             const int bend,
-                                             const int strip,
-                                             const int cfeb,
-                                             const int bx,
-                                             const int trknmb,
-                                             const int fullbx)
-    : valid_(valid),
-      quality_(quality),
-      pattern_(pattern),
-      striptype_(striptype),
-      bend_(bend),
-      strip_(strip),
-      cfeb_(cfeb),
-      bx_(bx),
-      trknmb_(trknmb),
-      fullbx_(fullbx) {}
+namespace io_v1 {
 
-/// Default
-CSCCLCTPreTriggerDigi::CSCCLCTPreTriggerDigi()
-    : valid_(0),
-      quality_(0),
-      pattern_(0),
-      striptype_(0),
-      bend_(0),
-      strip_(0),
-      cfeb_(0),
-      bx_(0),
-      trknmb_(0),
-      fullbx_(0) {}
+  /// Constructors
+  CSCCLCTPreTriggerDigi::CSCCLCTPreTriggerDigi(const int valid,
+                                               const int quality,
+                                               const int pattern,
+                                               const int striptype,
+                                               const int bend,
+                                               const int strip,
+                                               const int cfeb,
+                                               const int bx,
+                                               const int trknmb,
+                                               const int fullbx)
+      : valid_(valid),
+        quality_(quality),
+        pattern_(pattern),
+        striptype_(striptype),
+        bend_(bend),
+        strip_(strip),
+        cfeb_(cfeb),
+        bx_(bx),
+        trknmb_(trknmb),
+        fullbx_(fullbx) {}
 
-/// Clears this CLCT.
-void CSCCLCTPreTriggerDigi::clear() {
-  valid_ = 0;
-  quality_ = 0;
-  pattern_ = 0;
-  striptype_ = 0;
-  bend_ = 0;
-  strip_ = 0;
-  cfeb_ = 0;
-  bx_ = 0;
-  trknmb_ = 0;
-  fullbx_ = 0;
-}
+  /// Default
+  CSCCLCTPreTriggerDigi::CSCCLCTPreTriggerDigi()
+      : valid_(0),
+        quality_(0),
+        pattern_(0),
+        striptype_(0),
+        bend_(0),
+        strip_(0),
+        cfeb_(0),
+        bx_(0),
+        trknmb_(0),
+        fullbx_(0) {}
 
-bool CSCCLCTPreTriggerDigi::operator>(const CSCCLCTPreTriggerDigi& rhs) const {
-  // Several versions of CLCT sorting criteria were used before 2008.
-  // They are available in CMSSW versions prior to 3_1_0; here we only keep
-  // the latest one, used in TMB-07 firmware (w/o distrips).
-  bool returnValue = false;
-
-  int quality1 = getQuality();
-  int quality2 = rhs.getQuality();
-  // The bend-direction bit pid[0] is ignored (left and right bends have
-  // equal quality).
-  int pattern1 = getPattern() & 14;
-  int pattern2 = rhs.getPattern() & 14;
-
-  // Better-quality CLCTs are preferred.
-  // If two qualities are equal, larger pattern id (i.e., straighter pattern)
-  // is preferred; left- and right-bend patterns are considered to be of
-  // the same quality.
-  // If both qualities and pattern id's are the same, lower keystrip
-  // is preferred.
-  if ((quality1 > quality2) || (quality1 == quality2 && pattern1 > pattern2) ||
-      (quality1 == quality2 && pattern1 == pattern2 && getKeyStrip() < rhs.getKeyStrip())) {
-    returnValue = true;
+  /// Clears this CLCT.
+  void CSCCLCTPreTriggerDigi::clear() {
+    valid_ = 0;
+    quality_ = 0;
+    pattern_ = 0;
+    striptype_ = 0;
+    bend_ = 0;
+    strip_ = 0;
+    cfeb_ = 0;
+    bx_ = 0;
+    trknmb_ = 0;
+    fullbx_ = 0;
   }
 
-  return returnValue;
-}
+  bool CSCCLCTPreTriggerDigi::operator>(const CSCCLCTPreTriggerDigi& rhs) const {
+    // Several versions of CLCT sorting criteria were used before 2008.
+    // They are available in CMSSW versions prior to 3_1_0; here we only keep
+    // the latest one, used in TMB-07 firmware (w/o distrips).
+    bool returnValue = false;
 
-bool CSCCLCTPreTriggerDigi::operator==(const CSCCLCTPreTriggerDigi& rhs) const {
-  // Exact equality.
-  bool returnValue = false;
-  if (isValid() == rhs.isValid() && getQuality() == rhs.getQuality() && getPattern() == rhs.getPattern() &&
-      getKeyStrip() == rhs.getKeyStrip() && getStripType() == rhs.getStripType() && getBend() == getBend() &&
-      getBX() == rhs.getBX()) {
-    returnValue = true;
+    int quality1 = getQuality();
+    int quality2 = rhs.getQuality();
+    // The bend-direction bit pid[0] is ignored (left and right bends have
+    // equal quality).
+    int pattern1 = getPattern() & 14;
+    int pattern2 = rhs.getPattern() & 14;
+
+    // Better-quality CLCTs are preferred.
+    // If two qualities are equal, larger pattern id (i.e., straighter pattern)
+    // is preferred; left- and right-bend patterns are considered to be of
+    // the same quality.
+    // If both qualities and pattern id's are the same, lower keystrip
+    // is preferred.
+    if ((quality1 > quality2) || (quality1 == quality2 && pattern1 > pattern2) ||
+        (quality1 == quality2 && pattern1 == pattern2 && getKeyStrip() < rhs.getKeyStrip())) {
+      returnValue = true;
+    }
+
+    return returnValue;
   }
-  return returnValue;
-}
 
-bool CSCCLCTPreTriggerDigi::operator!=(const CSCCLCTPreTriggerDigi& rhs) const {
-  // True if == is false.
-  bool returnValue = true;
-  if ((*this) == rhs)
-    returnValue = false;
-  return returnValue;
-}
-
-/// Debug
-void CSCCLCTPreTriggerDigi::print() const {
-  if (isValid()) {
-    char stripType = (getStripType() == 0) ? 'D' : 'H';
-    char bend = (getBend() == 0) ? 'L' : 'R';
-
-    edm::LogVerbatim("CSCDigi") << " CSC CLCT #" << std::setw(1) << getTrknmb() << ": Valid = " << std::setw(1)
-                                << isValid() << " Key Strip = " << std::setw(3) << getKeyStrip()
-                                << " Strip = " << std::setw(2) << getStrip() << " Quality = " << std::setw(1)
-                                << getQuality() << " Pattern = " << std::setw(1) << getPattern()
-                                << " Bend = " << std::setw(1) << bend << " Strip type = " << std::setw(1) << stripType
-                                << " CFEB ID = " << std::setw(1) << getCFEB() << " BX = " << std::setw(1) << getBX()
-                                << " Full BX= " << std::setw(1) << getFullBX();
-  } else {
-    edm::LogVerbatim("CSCDigi") << "Not a valid Cathode LCT.";
+  bool CSCCLCTPreTriggerDigi::operator==(const CSCCLCTPreTriggerDigi& rhs) const {
+    // Exact equality.
+    bool returnValue = false;
+    if (isValid() == rhs.isValid() && getQuality() == rhs.getQuality() && getPattern() == rhs.getPattern() &&
+        getKeyStrip() == rhs.getKeyStrip() && getStripType() == rhs.getStripType() && getBend() == getBend() &&
+        getBX() == rhs.getBX()) {
+      returnValue = true;
+    }
+    return returnValue;
   }
-}
 
-std::ostream& operator<<(std::ostream& o, const CSCCLCTPreTriggerDigi& digi) {
-  return o << "CSC CLCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " Quality = " << digi.getQuality()
-           << " Pattern = " << digi.getPattern() << " StripType = " << digi.getStripType()
-           << " Bend = " << digi.getBend() << " Strip = " << digi.getStrip() << " KeyStrip = " << digi.getKeyStrip()
-           << " CFEB = " << digi.getCFEB() << " BX = " << digi.getBX();
-}
+  bool CSCCLCTPreTriggerDigi::operator!=(const CSCCLCTPreTriggerDigi& rhs) const {
+    // True if == is false.
+    bool returnValue = true;
+    if ((*this) == rhs)
+      returnValue = false;
+    return returnValue;
+  }
+
+  /// Debug
+  void CSCCLCTPreTriggerDigi::print() const {
+    if (isValid()) {
+      char stripType = (getStripType() == 0) ? 'D' : 'H';
+      char bend = (getBend() == 0) ? 'L' : 'R';
+
+      edm::LogVerbatim("CSCDigi") << " CSC CLCT #" << std::setw(1) << getTrknmb() << ": Valid = " << std::setw(1)
+                                  << isValid() << " Key Strip = " << std::setw(3) << getKeyStrip()
+                                  << " Strip = " << std::setw(2) << getStrip() << " Quality = " << std::setw(1)
+                                  << getQuality() << " Pattern = " << std::setw(1) << getPattern()
+                                  << " Bend = " << std::setw(1) << bend << " Strip type = " << std::setw(1) << stripType
+                                  << " CFEB ID = " << std::setw(1) << getCFEB() << " BX = " << std::setw(1) << getBX()
+                                  << " Full BX= " << std::setw(1) << getFullBX();
+    } else {
+      edm::LogVerbatim("CSCDigi") << "Not a valid Cathode LCT.";
+    }
+  }
+
+  std::ostream& operator<<(std::ostream& o, const CSCCLCTPreTriggerDigi& digi) {
+    return o << "CSC CLCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " Quality = " << digi.getQuality()
+             << " Pattern = " << digi.getPattern() << " StripType = " << digi.getStripType()
+             << " Bend = " << digi.getBend() << " Strip = " << digi.getStrip() << " KeyStrip = " << digi.getKeyStrip()
+             << " CFEB = " << digi.getCFEB() << " BX = " << digi.getBX();
+  }
+
+}  // namespace io_v1

--- a/DataFormats/CSCDigi/src/CSCComparatorDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCComparatorDigi.cc
@@ -12,107 +12,111 @@
 
 using namespace std;
 
-// Constructors
-CSCComparatorDigi::CSCComparatorDigi(int strip, int comparator, int timeBinWord)
-    : strip_(strip), comparator_(comparator), timeBinWord_(timeBinWord) {}
+namespace io_v1 {
 
-CSCComparatorDigi::CSCComparatorDigi() : strip_(0), comparator_(0), timeBinWord_(0) {}
+  // Constructors
+  CSCComparatorDigi::CSCComparatorDigi(int strip, int comparator, int timeBinWord)
+      : strip_(strip), comparator_(comparator), timeBinWord_(timeBinWord) {}
 
-// Comparison
+  CSCComparatorDigi::CSCComparatorDigi() : strip_(0), comparator_(0), timeBinWord_(0) {}
 
-bool CSCComparatorDigi::operator==(const CSCComparatorDigi& digi) const {
-  if (getStrip() != digi.getStrip())
-    return false;
-  if (getComparator() != digi.getComparator())
-    return false;
-  if (getTimeBinWord() != digi.getTimeBinWord())
-    return false;
-  return true;
-}
+  // Comparison
 
-//@@ If one wanted to order comparator digis how would one want op< to behave?
-// I don't know...
-// I think LHS < RHS only makes sense if
-// i) time(LHS) .eq. time(RHS)
-// AND
-// ii) strip(LHS) .lt. strip(RHS)
-// But I don't see how this can be useful.
-
-bool CSCComparatorDigi::operator<(const CSCComparatorDigi& digi) const {
-  bool result = false;
-  if (getTimeBin() == digi.getTimeBin()) {
-    result = (getStrip() < digi.getStrip());
+  bool CSCComparatorDigi::operator==(const CSCComparatorDigi& digi) const {
+    if (getStrip() != digi.getStrip())
+      return false;
+    if (getComparator() != digi.getComparator())
+      return false;
+    if (getTimeBinWord() != digi.getTimeBinWord())
+      return false;
+    return true;
   }
-  return result;
-}
 
-// Getters
+  //@@ If one wanted to order comparator digis how would one want op< to behave?
+  // I don't know...
+  // I think LHS < RHS only makes sense if
+  // i) time(LHS) .eq. time(RHS)
+  // AND
+  // ii) strip(LHS) .lt. strip(RHS)
+  // But I don't see how this can be useful.
 
-int CSCComparatorDigi::getTimeBin() const {
-  // Find first bin which fired, counting from 0
-  uint16_t tbit = 1;
-  int tbin = -1;
-  for (int i = 0; i < 16; ++i) {
-    if (tbit & timeBinWord_) {
-      tbin = i;
-      break;
+  bool CSCComparatorDigi::operator<(const CSCComparatorDigi& digi) const {
+    bool result = false;
+    if (getTimeBin() == digi.getTimeBin()) {
+      result = (getStrip() < digi.getStrip());
     }
-    tbit = tbit << 1;
+    return result;
   }
-  return tbin;
-}
 
-/// Get the distrip number. Counts from 0.
-// originally defined in EventFilter/CSCRawToDigi/src/CSCComparatorData.cc
-int CSCComparatorDigi::getDiStrip() const { return ((strip_ - 1) % CSCConstants::NUM_STRIPS_PER_CFEB) / 2; }
+  // Getters
 
-/// Get the CFEB number. Counts from 0.
-// originally defined in EventFilter/CSCRawToDigi/src/CSCComparatorData.cc
-int CSCComparatorDigi::getCFEB() const { return (strip_ - 1) / CSCConstants::NUM_STRIPS_PER_CFEB; }
-
-// This definition is consistent with the one used in
-// the function CSCComparatorData::add() in EventFilter/CSCRawToDigi
-// The halfstrip counts from 0!
-int CSCComparatorDigi::getHalfStrip() const { return (getStrip() - 1) * 2 + getComparator(); }
-
-// Return the fractional half-strip
-float CSCComparatorDigi::getFractionalStrip() const { return getStrip() + getComparator() * 0.5f - 0.75f; }
-
-std::vector<int> CSCComparatorDigi::getTimeBinsOn() const {
-  std::vector<int> tbins;
-  uint16_t tbit = timeBinWord_;
-  const uint16_t one = 1;
-  for (int i = 0; i < 16; ++i) {
-    if (tbit & one)
-      tbins.push_back(i);
-    tbit = tbit >> 1;
-    if (tbit == 0)
-      break;  // end already if no more bits set
+  int CSCComparatorDigi::getTimeBin() const {
+    // Find first bin which fired, counting from 0
+    uint16_t tbit = 1;
+    int tbin = -1;
+    for (int i = 0; i < 16; ++i) {
+      if (tbit & timeBinWord_) {
+        tbin = i;
+        break;
+      }
+      tbit = tbit << 1;
+    }
+    return tbin;
   }
-  return tbins;
-}
 
-// Setters
-//@@ No way to set time word?
+  /// Get the distrip number. Counts from 0.
+  // originally defined in EventFilter/CSCRawToDigi/src/CSCComparatorData.cc
+  int CSCComparatorDigi::getDiStrip() const { return ((strip_ - 1) % CSCConstants::NUM_STRIPS_PER_CFEB) / 2; }
 
-void CSCComparatorDigi::setStrip(int strip) { strip_ = strip; }
-void CSCComparatorDigi::setComparator(int comparator) { comparator_ = comparator; }
+  /// Get the CFEB number. Counts from 0.
+  // originally defined in EventFilter/CSCRawToDigi/src/CSCComparatorData.cc
+  int CSCComparatorDigi::getCFEB() const { return (strip_ - 1) / CSCConstants::NUM_STRIPS_PER_CFEB; }
 
-// Output
+  // This definition is consistent with the one used in
+  // the function CSCComparatorData::add() in EventFilter/CSCRawToDigi
+  // The halfstrip counts from 0!
+  int CSCComparatorDigi::getHalfStrip() const { return (getStrip() - 1) * 2 + getComparator(); }
 
-void CSCComparatorDigi::print() const {
-  std::ostringstream ost;
-  ost << "CSCComparatorDigi | strip " << getStrip() << " | comparator " << getComparator() << " | first time bin "
-      << getTimeBin() << " | time bins on ";
-  std::vector<int> tbins = getTimeBinsOn();
-  std::copy(tbins.begin(), tbins.end(), std::ostream_iterator<int>(ost, " "));
-  edm::LogVerbatim("CSCDigi") << ost.str();
-}
+  // Return the fractional half-strip
+  float CSCComparatorDigi::getFractionalStrip() const { return getStrip() + getComparator() * 0.5f - 0.75f; }
 
-std::ostream& operator<<(std::ostream& o, const CSCComparatorDigi& digi) {
-  o << "CSCComparatorDigi Strip:" << digi.getStrip() << ", Comparator: " << digi.getComparator()
-    << ", First Time Bin On: " << digi.getTimeBin() << ", Time Bins On: ";
-  std::vector<int> tbins = digi.getTimeBinsOn();
-  std::copy(tbins.begin(), tbins.end(), std::ostream_iterator<int>(o, " "));
-  return o;
-}
+  std::vector<int> CSCComparatorDigi::getTimeBinsOn() const {
+    std::vector<int> tbins;
+    uint16_t tbit = timeBinWord_;
+    const uint16_t one = 1;
+    for (int i = 0; i < 16; ++i) {
+      if (tbit & one)
+        tbins.push_back(i);
+      tbit = tbit >> 1;
+      if (tbit == 0)
+        break;  // end already if no more bits set
+    }
+    return tbins;
+  }
+
+  // Setters
+  //@@ No way to set time word?
+
+  void CSCComparatorDigi::setStrip(int strip) { strip_ = strip; }
+  void CSCComparatorDigi::setComparator(int comparator) { comparator_ = comparator; }
+
+  // Output
+
+  void CSCComparatorDigi::print() const {
+    std::ostringstream ost;
+    ost << "CSCComparatorDigi | strip " << getStrip() << " | comparator " << getComparator() << " | first time bin "
+        << getTimeBin() << " | time bins on ";
+    std::vector<int> tbins = getTimeBinsOn();
+    std::copy(tbins.begin(), tbins.end(), std::ostream_iterator<int>(ost, " "));
+    edm::LogVerbatim("CSCDigi") << ost.str();
+  }
+
+  std::ostream& operator<<(std::ostream& o, const CSCComparatorDigi& digi) {
+    o << "CSCComparatorDigi Strip:" << digi.getStrip() << ", Comparator: " << digi.getComparator()
+      << ", First Time Bin On: " << digi.getTimeBin() << ", Time Bins On: ";
+    std::vector<int> tbins = digi.getTimeBinsOn();
+    std::copy(tbins.begin(), tbins.end(), std::ostream_iterator<int>(o, " "));
+    return o;
+  }
+
+}  // namespace io_v1

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -10,166 +10,170 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 
-/// Constructors
-CSCCorrelatedLCTDigi::CSCCorrelatedLCTDigi(const uint16_t itrknmb,
-                                           const uint16_t ivalid,
-                                           const uint16_t iquality,
-                                           const uint16_t ikeywire,
-                                           const uint16_t istrip,
-                                           const uint16_t ipattern,
-                                           const uint16_t ibend,
-                                           const uint16_t ibx,
-                                           const uint16_t impclink,
-                                           const uint16_t ibx0,
-                                           const uint16_t isyncErr,
-                                           const uint16_t icscID,
-                                           const Version version,
-                                           const bool run3_quart_strip_bit,
-                                           const bool run3_eighth_strip_bit,
-                                           const uint16_t run3_pattern,
-                                           const uint16_t run3_slope,
-                                           const int type,
-                                           const uint16_t gemLayerUsedForSlopeComputation)
+namespace io_v1 {
 
-    : trknmb(itrknmb),
-      valid(ivalid),
-      quality(iquality),
-      keywire(ikeywire),
-      strip(istrip),
-      pattern(ipattern),
-      bend(ibend),
-      bx(ibx),
-      mpclink(impclink),
-      bx0(ibx0),
-      syncErr(isyncErr),
-      cscID(icscID),
-      hmt(0),
-      run3_quart_strip_bit_(run3_quart_strip_bit),
-      run3_eighth_strip_bit_(run3_eighth_strip_bit),
-      run3_pattern_(run3_pattern),
-      run3_slope_(run3_slope),
-      gemLayerUsedForSlopeComputation_(gemLayerUsedForSlopeComputation),
-      type_(type),
-      version_(version) {}
+  /// Constructors
+  CSCCorrelatedLCTDigi::CSCCorrelatedLCTDigi(const uint16_t itrknmb,
+                                             const uint16_t ivalid,
+                                             const uint16_t iquality,
+                                             const uint16_t ikeywire,
+                                             const uint16_t istrip,
+                                             const uint16_t ipattern,
+                                             const uint16_t ibend,
+                                             const uint16_t ibx,
+                                             const uint16_t impclink,
+                                             const uint16_t ibx0,
+                                             const uint16_t isyncErr,
+                                             const uint16_t icscID,
+                                             const Version version,
+                                             const bool run3_quart_strip_bit,
+                                             const bool run3_eighth_strip_bit,
+                                             const uint16_t run3_pattern,
+                                             const uint16_t run3_slope,
+                                             const int type,
+                                             const uint16_t gemLayerUsedForSlopeComputation)
 
-/// Default
-CSCCorrelatedLCTDigi::CSCCorrelatedLCTDigi() {
-  clear();  // set contents to zero
-}
+      : trknmb(itrknmb),
+        valid(ivalid),
+        quality(iquality),
+        keywire(ikeywire),
+        strip(istrip),
+        pattern(ipattern),
+        bend(ibend),
+        bx(ibx),
+        mpclink(impclink),
+        bx0(ibx0),
+        syncErr(isyncErr),
+        cscID(icscID),
+        hmt(0),
+        run3_quart_strip_bit_(run3_quart_strip_bit),
+        run3_eighth_strip_bit_(run3_eighth_strip_bit),
+        run3_pattern_(run3_pattern),
+        run3_slope_(run3_slope),
+        gemLayerUsedForSlopeComputation_(gemLayerUsedForSlopeComputation),
+        type_(type),
+        version_(version) {}
 
-/// Clears this LCT.
-void CSCCorrelatedLCTDigi::clear() {
-  trknmb = 0;
-  valid = 0;
-  quality = 0;
-  keywire = 0;
-  strip = 0;
-  pattern = 0;
-  bend = 0;
-  bx = 0;
-  mpclink = 0;
-  bx0 = 0;
-  syncErr = 0;
-  cscID = 0;
-  hmt = 0;
-  version_ = Version::Legacy;
-  // Run-3 variables
-  run3_quart_strip_bit_ = false;
-  run3_eighth_strip_bit_ = false;
-  run3_pattern_ = 0;
-  run3_slope_ = 0;
-  // clear the components
-  type_ = 1;
-  gemLayerUsedForSlopeComputation_ = 0;
-  alct_.clear();
-  clct_.clear();
-  gem1_ = GEMPadDigi();
-  gem2_ = GEMPadDigi();
-}
-
-uint16_t CSCCorrelatedLCTDigi::getStrip(const uint16_t n) const {
-  // all 10 bits
-  if (n == 8) {
-    return 2 * getStrip(4) + getEighthStripBit();
+  /// Default
+  CSCCorrelatedLCTDigi::CSCCorrelatedLCTDigi() {
+    clear();  // set contents to zero
   }
-  // lowest 9 bits
-  else if (n == 4) {
-    return 2 * getStrip(2) + getQuartStripBit();
+
+  /// Clears this LCT.
+  void CSCCorrelatedLCTDigi::clear() {
+    trknmb = 0;
+    valid = 0;
+    quality = 0;
+    keywire = 0;
+    strip = 0;
+    pattern = 0;
+    bend = 0;
+    bx = 0;
+    mpclink = 0;
+    bx0 = 0;
+    syncErr = 0;
+    cscID = 0;
+    hmt = 0;
+    version_ = Version::Legacy;
+    // Run-3 variables
+    run3_quart_strip_bit_ = false;
+    run3_eighth_strip_bit_ = false;
+    run3_pattern_ = 0;
+    run3_slope_ = 0;
+    // clear the components
+    type_ = 1;
+    gemLayerUsedForSlopeComputation_ = 0;
+    alct_.clear();
+    clct_.clear();
+    gem1_ = GEMPadDigi();
+    gem2_ = GEMPadDigi();
   }
-  // lowest 8 bits
-  else {
-    return strip;
+
+  uint16_t CSCCorrelatedLCTDigi::getStrip(const uint16_t n) const {
+    // all 10 bits
+    if (n == 8) {
+      return 2 * getStrip(4) + getEighthStripBit();
+    }
+    // lowest 9 bits
+    else if (n == 4) {
+      return 2 * getStrip(2) + getQuartStripBit();
+    }
+    // lowest 8 bits
+    else {
+      return strip;
+    }
   }
-}
 
-// slope in number of half-strips/layer
-float CSCCorrelatedLCTDigi::getFractionalSlope() const {
-  if (isRun3()) {
-    // 4-bit slope
-    float slope[17] = {
-        0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1.0, 1.125, 1.25, 1.375, 1.5, 1.625, 1.75, 2.0, 2.5};
-    return (2 * getBend() - 1) * slope[getSlope()];
-  } else {
-    int slope[11] = {0, 0, -8, 8, -6, 6, -4, 4, -2, 2, 0};
-    return float(slope[getPattern()] / 5.);
+  // slope in number of half-strips/layer
+  float CSCCorrelatedLCTDigi::getFractionalSlope() const {
+    if (isRun3()) {
+      // 4-bit slope
+      float slope[17] = {
+          0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1.0, 1.125, 1.25, 1.375, 1.5, 1.625, 1.75, 2.0, 2.5};
+      return (2 * getBend() - 1) * slope[getSlope()];
+    } else {
+      int slope[11] = {0, 0, -8, 8, -6, 6, -4, 4, -2, 2, 0};
+      return float(slope[getPattern()] / 5.);
+    }
   }
-}
 
-/// return the fractional strip
-float CSCCorrelatedLCTDigi::getFractionalStrip(const uint16_t n) const {
-  if (n == 8) {
-    return 0.125f * (getStrip(n) + 0.5);
-  } else if (n == 4) {
-    return 0.25f * (getStrip(n) + 0.5);
-  } else {
-    return 0.5f * (getStrip(n) + 0.5);
+  /// return the fractional strip
+  float CSCCorrelatedLCTDigi::getFractionalStrip(const uint16_t n) const {
+    if (n == 8) {
+      return 0.125f * (getStrip(n) + 0.5);
+    } else if (n == 4) {
+      return 0.25f * (getStrip(n) + 0.5);
+    } else {
+      return 0.5f * (getStrip(n) + 0.5);
+    }
   }
-}
 
-uint16_t CSCCorrelatedLCTDigi::getCLCTPattern() const {
-  return (isRun3() ? std::numeric_limits<uint16_t>::max() : (pattern & 0xF));
-}
-
-uint16_t CSCCorrelatedLCTDigi::getHMT() const { return (isRun3() ? hmt : std::numeric_limits<uint16_t>::max()); }
-
-void CSCCorrelatedLCTDigi::setHMT(const uint16_t h) { hmt = isRun3() ? h : std::numeric_limits<uint16_t>::max(); }
-
-void CSCCorrelatedLCTDigi::setRun3(const bool isRun3) { version_ = isRun3 ? Version::Run3 : Version::Legacy; }
-
-/// Comparison
-bool CSCCorrelatedLCTDigi::operator==(const CSCCorrelatedLCTDigi& rhs) const {
-  return ((trknmb == rhs.trknmb) && (quality == rhs.quality) && (keywire == rhs.keywire) && (strip == rhs.strip) &&
-          (pattern == rhs.pattern) && (bend == rhs.bend) && (bx == rhs.bx) && (valid == rhs.valid) &&
-          (mpclink == rhs.mpclink));
-}
-
-/// Debug
-void CSCCorrelatedLCTDigi::print() const {
-  if (isValid()) {
-    edm::LogVerbatim("CSCDigi") << "CSC LCT #" << getTrknmb() << ": Valid = " << isValid()
-                                << " Quality = " << getQuality() << " Key Wire = " << getKeyWG()
-                                << " Strip = " << getStrip() << " Pattern = " << getPattern()
-                                << " Bend = " << ((getBend() == 0) ? 'L' : 'R') << " BX = " << getBX()
-                                << " MPC Link = " << getMPCLink() << " Type (SIM) = " << getType();
-  } else {
-    edm::LogVerbatim("CSCDigi") << "Not a valid correlated LCT.";
+  uint16_t CSCCorrelatedLCTDigi::getCLCTPattern() const {
+    return (isRun3() ? std::numeric_limits<uint16_t>::max() : (pattern & 0xF));
   }
-}
 
-std::ostream& operator<<(std::ostream& o, const CSCCorrelatedLCTDigi& digi) {
-  // do not print out CSCID and sync error. They are not used anyway in the firmware, or the emulation
-  if (digi.isRun3())
-    return o << "CSC LCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " BX = " << digi.getBX()
-             << " Run-2 Pattern = " << digi.getPattern() << " Run-3 Pattern = " << digi.getRun3Pattern()
-             << " Quality = " << digi.getQuality() << " Bend = " << digi.getBend() << " Slope = " << digi.getSlope()
-             << "\n"
-             << " KeyHalfStrip = " << digi.getStrip() << " KeyQuartStrip = " << digi.getStrip(4)
-             << " KeyEighthStrip = " << digi.getStrip(8) << " KeyWireGroup = " << digi.getKeyWG()
-             << " Type (SIM) = " << digi.getType() << " MPC Link = " << digi.getMPCLink();
-  else
-    return o << "CSC LCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " BX = " << digi.getBX()
-             << " Pattern = " << digi.getPattern() << " Quality = " << digi.getQuality() << " Bend = " << digi.getBend()
-             << "\n"
-             << " KeyHalfStrip = " << digi.getStrip() << " KeyWireGroup = " << digi.getKeyWG()
-             << " Type (SIM) = " << digi.getType() << " MPC Link = " << digi.getMPCLink();
-}
+  uint16_t CSCCorrelatedLCTDigi::getHMT() const { return (isRun3() ? hmt : std::numeric_limits<uint16_t>::max()); }
+
+  void CSCCorrelatedLCTDigi::setHMT(const uint16_t h) { hmt = isRun3() ? h : std::numeric_limits<uint16_t>::max(); }
+
+  void CSCCorrelatedLCTDigi::setRun3(const bool isRun3) { version_ = isRun3 ? Version::Run3 : Version::Legacy; }
+
+  /// Comparison
+  bool CSCCorrelatedLCTDigi::operator==(const CSCCorrelatedLCTDigi& rhs) const {
+    return ((trknmb == rhs.trknmb) && (quality == rhs.quality) && (keywire == rhs.keywire) && (strip == rhs.strip) &&
+            (pattern == rhs.pattern) && (bend == rhs.bend) && (bx == rhs.bx) && (valid == rhs.valid) &&
+            (mpclink == rhs.mpclink));
+  }
+
+  /// Debug
+  void CSCCorrelatedLCTDigi::print() const {
+    if (isValid()) {
+      edm::LogVerbatim("CSCDigi") << "CSC LCT #" << getTrknmb() << ": Valid = " << isValid()
+                                  << " Quality = " << getQuality() << " Key Wire = " << getKeyWG()
+                                  << " Strip = " << getStrip() << " Pattern = " << getPattern()
+                                  << " Bend = " << ((getBend() == 0) ? 'L' : 'R') << " BX = " << getBX()
+                                  << " MPC Link = " << getMPCLink() << " Type (SIM) = " << getType();
+    } else {
+      edm::LogVerbatim("CSCDigi") << "Not a valid correlated LCT.";
+    }
+  }
+
+  std::ostream& operator<<(std::ostream& o, const CSCCorrelatedLCTDigi& digi) {
+    // do not print out CSCID and sync error. They are not used anyway in the firmware, or the emulation
+    if (digi.isRun3())
+      return o << "CSC LCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " BX = " << digi.getBX()
+               << " Run-2 Pattern = " << digi.getPattern() << " Run-3 Pattern = " << digi.getRun3Pattern()
+               << " Quality = " << digi.getQuality() << " Bend = " << digi.getBend() << " Slope = " << digi.getSlope()
+               << "\n"
+               << " KeyHalfStrip = " << digi.getStrip() << " KeyQuartStrip = " << digi.getStrip(4)
+               << " KeyEighthStrip = " << digi.getStrip(8) << " KeyWireGroup = " << digi.getKeyWG()
+               << " Type (SIM) = " << digi.getType() << " MPC Link = " << digi.getMPCLink();
+    else
+      return o << "CSC LCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " BX = " << digi.getBX()
+               << " Pattern = " << digi.getPattern() << " Quality = " << digi.getQuality()
+               << " Bend = " << digi.getBend() << "\n"
+               << " KeyHalfStrip = " << digi.getStrip() << " KeyWireGroup = " << digi.getKeyWG()
+               << " Type (SIM) = " << digi.getType() << " MPC Link = " << digi.getMPCLink();
+  }
+
+}  // namespace io_v1

--- a/DataFormats/CSCDigi/src/CSCDCCFormatStatusDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCDCCFormatStatusDigi.cc
@@ -22,7 +22,9 @@
 #include <iostream>
 #include <iomanip>
 
-/**
+namespace io_v1 {
+
+  /**
    * @brief  setExaminerInfo 
    * @param  fDCC_MASK_ DCC Examiner mask used (for information purposes).
    * @param  fCSC_MASK_ Examiner mask per chamber
@@ -32,86 +34,89 @@
    * @param  mCSC_PAYLOADS_ List of payloads per CSC
    * @param  mCSC_STATUS_ List of statuses per CSC
    */
-void CSCDCCFormatStatusDigi::setDCCExaminerInfo(const ExaminerMaskType fDCC_MASK_,
-                                                const ExaminerMaskType fCSC_MASK_,
-                                                const ExaminerStatusType fDDU_SUMMARY_ERRORS_,
-                                                const std::map<DDUIdType, ExaminerStatusType>& mDDU_ERRORS_,
-                                                const std::map<CSCIdType, ExaminerStatusType>& mCSC_ERRORS_,
-                                                const std::map<CSCIdType, ExaminerStatusType>& mCSC_PAYLOADS_,
-                                                const std::map<CSCIdType, ExaminerStatusType>& mCSC_STATUS_) {
-  fDCC_MASK = fDCC_MASK_;
-  fCSC_MASK = fCSC_MASK_;
-  fDDU_SUMMARY_ERRORS = fDDU_SUMMARY_ERRORS_;
-  mDDU_ERRORS = mDDU_ERRORS_;
-  mCSC_ERRORS = mCSC_ERRORS_;
-  mCSC_PAYLOADS = mCSC_PAYLOADS_;
-  mCSC_STATUS = mCSC_STATUS_;
-}
-
-/// Debug
-void CSCDCCFormatStatusDigi::print() const {
-  // Keep original code in case I messed up the formatting in some subtle way when switching to MessageLogger
-  //
-  //   std::cout << "CSCDCCFormatStatusDigi: DCC=" << std::dec << getDCCId()
-  //	<< " DCCMask=0x" << std::hex << std::setw(8) << std::setfill('0') << getDCCMask()
-  //	<< " CSCMask=0x" << std::hex << std::setw(8) << std::setfill('0') << getCSCMask()
-  //	<< " DCCErrors=0x" << std::hex << std::setw(8) << std::setfill('0') << getDDUSummaryErrors()
-  //	<< std::dec << "\n";
-  //   std::set<DDUIdType> ddu_list = getListOfDDUs();
-  //   for (std::set<DDUIdType>::iterator itr=ddu_list.begin(); itr != ddu_list.end(); ++itr) {
-  //   	std::cout << "DDU_" << std::dec << ((*itr)&0xFF)
-  //	<< " Errors=0x" << std::hex << std::setw(8) << std::setfill('0') << getDDUErrors(*itr) << "\n";
-  //   }
-  //   std::set<CSCIdType> csc_list = getListOfCSCs();
-  //   for (std::set<CSCIdType>::iterator itr=csc_list.begin(); itr != csc_list.end(); ++itr) {
-  //
-  //        std::cout << "CSC_" << std::dec << (((*itr)>>4)&0xFF) << "_" << ((*itr)&0xF)
-  //		<< " Errors=0x" << std::hex << std::setw(8) << std::setfill('0') << getCSCErrors(*itr)
-  //		<< " Payload=0x" << std::setw(8) << std::setfill('0') << getCSCPayload(*itr)
-  //		<< " Status=0x" << std::setw(8) << std::setfill('0') << getCSCStatus(*itr) << "\n";
-  //   }
-
-  edm::LogVerbatim("CSCDigi") << "CSCDCCFormatStatusDigi: DCC=" << std::dec << getDCCId() << " DCCMask=0x" << std::hex
-                              << std::setw(8) << std::setfill('0') << getDCCMask() << " CSCMask=0x" << std::hex
-                              << std::setw(8) << std::setfill('0') << getCSCMask() << " DCCErrors=0x" << std::hex
-                              << std::setw(8) << std::setfill('0') << getDDUSummaryErrors() << std::dec;
-
-  std::ostringstream ost;
-
-  std::set<DDUIdType> ddu_list = getListOfDDUs();
-  for (std::set<DDUIdType>::iterator itr = ddu_list.begin(); itr != ddu_list.end(); ++itr) {
-    ost << "DDU_" << std::dec << ((*itr) & 0xFF) << " Errors=0x" << std::hex << std::setw(8) << std::setfill('0')
-        << getDDUErrors(*itr);
-    edm::LogVerbatim("CSCDigi") << ost.str();
-    ost.clear();
+  void CSCDCCFormatStatusDigi::setDCCExaminerInfo(const ExaminerMaskType fDCC_MASK_,
+                                                  const ExaminerMaskType fCSC_MASK_,
+                                                  const ExaminerStatusType fDDU_SUMMARY_ERRORS_,
+                                                  const std::map<DDUIdType, ExaminerStatusType>& mDDU_ERRORS_,
+                                                  const std::map<CSCIdType, ExaminerStatusType>& mCSC_ERRORS_,
+                                                  const std::map<CSCIdType, ExaminerStatusType>& mCSC_PAYLOADS_,
+                                                  const std::map<CSCIdType, ExaminerStatusType>& mCSC_STATUS_) {
+    fDCC_MASK = fDCC_MASK_;
+    fCSC_MASK = fCSC_MASK_;
+    fDDU_SUMMARY_ERRORS = fDDU_SUMMARY_ERRORS_;
+    mDDU_ERRORS = mDDU_ERRORS_;
+    mCSC_ERRORS = mCSC_ERRORS_;
+    mCSC_PAYLOADS = mCSC_PAYLOADS_;
+    mCSC_STATUS = mCSC_STATUS_;
   }
 
-  std::set<CSCIdType> csc_list = getListOfCSCs();
-  for (std::set<CSCIdType>::iterator itr = csc_list.begin(); itr != csc_list.end(); ++itr) {
-    ost << "CSC_" << std::dec << (((*itr) >> 4) & 0xFF) << "_" << ((*itr) & 0xF) << " Errors=0x" << std::hex
-        << std::setw(8) << std::setfill('0') << getCSCErrors(*itr) << " Payload=0x" << std::setw(8) << std::setfill('0')
-        << getCSCPayload(*itr) << " Status=0x" << std::setw(8) << std::setfill('0') << getCSCStatus(*itr);
-    edm::LogVerbatim("CSCDigi") << ost.str();
-    ost.clear();
-  }
-}
+  /// Debug
+  void CSCDCCFormatStatusDigi::print() const {
+    // Keep original code in case I messed up the formatting in some subtle way when switching to MessageLogger
+    //
+    //   std::cout << "CSCDCCFormatStatusDigi: DCC=" << std::dec << getDCCId()
+    //	<< " DCCMask=0x" << std::hex << std::setw(8) << std::setfill('0') << getDCCMask()
+    //	<< " CSCMask=0x" << std::hex << std::setw(8) << std::setfill('0') << getCSCMask()
+    //	<< " DCCErrors=0x" << std::hex << std::setw(8) << std::setfill('0') << getDDUSummaryErrors()
+    //	<< std::dec << "\n";
+    //   std::set<DDUIdType> ddu_list = getListOfDDUs();
+    //   for (std::set<DDUIdType>::iterator itr=ddu_list.begin(); itr != ddu_list.end(); ++itr) {
+    //   	std::cout << "DDU_" << std::dec << ((*itr)&0xFF)
+    //	<< " Errors=0x" << std::hex << std::setw(8) << std::setfill('0') << getDDUErrors(*itr) << "\n";
+    //   }
+    //   std::set<CSCIdType> csc_list = getListOfCSCs();
+    //   for (std::set<CSCIdType>::iterator itr=csc_list.begin(); itr != csc_list.end(); ++itr) {
+    //
+    //        std::cout << "CSC_" << std::dec << (((*itr)>>4)&0xFF) << "_" << ((*itr)&0xF)
+    //		<< " Errors=0x" << std::hex << std::setw(8) << std::setfill('0') << getCSCErrors(*itr)
+    //		<< " Payload=0x" << std::setw(8) << std::setfill('0') << getCSCPayload(*itr)
+    //		<< " Status=0x" << std::setw(8) << std::setfill('0') << getCSCStatus(*itr) << "\n";
+    //   }
 
-std::ostream& operator<<(std::ostream& o, const CSCDCCFormatStatusDigi& digi) {
-  o << "CSCDCCFormatStatusDigi: DCC=" << std::dec << digi.getDCCId() << " DCCMask=0x" << std::hex << std::setw(8)
-    << std::setfill('0') << digi.getDCCMask() << " CSCMask=0x" << std::hex << std::setw(8) << std::setfill('0')
-    << digi.getCSCMask() << " DCCErrors=0x" << std::hex << std::setw(8) << std::setfill('0')
-    << digi.getDDUSummaryErrors() << std::dec << "\n";
-  std::set<DDUIdType> ddu_list = digi.getListOfDDUs();
-  for (std::set<DDUIdType>::iterator itr = ddu_list.begin(); itr != ddu_list.end(); ++itr) {
-    o << "DDU_" << std::dec << ((*itr) & 0xFF) << " Errors=0x" << std::hex << std::setw(8) << std::setfill('0')
-      << digi.getDDUErrors(*itr) << "\n";
+    edm::LogVerbatim("CSCDigi") << "CSCDCCFormatStatusDigi: DCC=" << std::dec << getDCCId() << " DCCMask=0x" << std::hex
+                                << std::setw(8) << std::setfill('0') << getDCCMask() << " CSCMask=0x" << std::hex
+                                << std::setw(8) << std::setfill('0') << getCSCMask() << " DCCErrors=0x" << std::hex
+                                << std::setw(8) << std::setfill('0') << getDDUSummaryErrors() << std::dec;
+
+    std::ostringstream ost;
+
+    std::set<DDUIdType> ddu_list = getListOfDDUs();
+    for (std::set<DDUIdType>::iterator itr = ddu_list.begin(); itr != ddu_list.end(); ++itr) {
+      ost << "DDU_" << std::dec << ((*itr) & 0xFF) << " Errors=0x" << std::hex << std::setw(8) << std::setfill('0')
+          << getDDUErrors(*itr);
+      edm::LogVerbatim("CSCDigi") << ost.str();
+      ost.clear();
+    }
+
+    std::set<CSCIdType> csc_list = getListOfCSCs();
+    for (std::set<CSCIdType>::iterator itr = csc_list.begin(); itr != csc_list.end(); ++itr) {
+      ost << "CSC_" << std::dec << (((*itr) >> 4) & 0xFF) << "_" << ((*itr) & 0xF) << " Errors=0x" << std::hex
+          << std::setw(8) << std::setfill('0') << getCSCErrors(*itr) << " Payload=0x" << std::setw(8)
+          << std::setfill('0') << getCSCPayload(*itr) << " Status=0x" << std::setw(8) << std::setfill('0')
+          << getCSCStatus(*itr);
+      edm::LogVerbatim("CSCDigi") << ost.str();
+      ost.clear();
+    }
   }
-  std::set<CSCIdType> csc_list = digi.getListOfCSCs();
-  for (std::set<CSCIdType>::iterator itr = csc_list.begin(); itr != csc_list.end(); ++itr) {
-    o << "CSC_" << std::dec << (((*itr) >> 4) & 0xFF) << "_" << ((*itr) & 0xF) << " Errors=0x" << std::hex
-      << std::setw(8) << std::setfill('0') << digi.getCSCErrors(*itr) << " Payload=0x" << std::setw(8)
-      << std::setfill('0') << digi.getCSCPayload(*itr) << " Status=0x" << std::setw(8) << std::setfill('0')
-      << digi.getCSCStatus(*itr) << "\n";
+
+  std::ostream& operator<<(std::ostream& o, const CSCDCCFormatStatusDigi& digi) {
+    o << "CSCDCCFormatStatusDigi: DCC=" << std::dec << digi.getDCCId() << " DCCMask=0x" << std::hex << std::setw(8)
+      << std::setfill('0') << digi.getDCCMask() << " CSCMask=0x" << std::hex << std::setw(8) << std::setfill('0')
+      << digi.getCSCMask() << " DCCErrors=0x" << std::hex << std::setw(8) << std::setfill('0')
+      << digi.getDDUSummaryErrors() << std::dec << "\n";
+    std::set<DDUIdType> ddu_list = digi.getListOfDDUs();
+    for (std::set<DDUIdType>::iterator itr = ddu_list.begin(); itr != ddu_list.end(); ++itr) {
+      o << "DDU_" << std::dec << ((*itr) & 0xFF) << " Errors=0x" << std::hex << std::setw(8) << std::setfill('0')
+        << digi.getDDUErrors(*itr) << "\n";
+    }
+    std::set<CSCIdType> csc_list = digi.getListOfCSCs();
+    for (std::set<CSCIdType>::iterator itr = csc_list.begin(); itr != csc_list.end(); ++itr) {
+      o << "CSC_" << std::dec << (((*itr) >> 4) & 0xFF) << "_" << ((*itr) & 0xF) << " Errors=0x" << std::hex
+        << std::setw(8) << std::setfill('0') << digi.getCSCErrors(*itr) << " Payload=0x" << std::setw(8)
+        << std::setfill('0') << digi.getCSCPayload(*itr) << " Status=0x" << std::setw(8) << std::setfill('0')
+        << digi.getCSCStatus(*itr) << "\n";
+    }
+    return o;
   }
-  return o;
-}
+
+}  // namespace io_v1

--- a/DataFormats/CSCDigi/src/CSCShowerDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCShowerDigi.cc
@@ -5,87 +5,91 @@
 
 using namespace std;
 
-/// Constructors
-CSCShowerDigi::CSCShowerDigi(const uint16_t bitsInTime,
-                             const uint16_t bitsOutOfTime,
-                             const uint16_t cscID,
-                             const uint16_t bx,
-                             const uint16_t showerType,
-                             const uint16_t wireNHits,
-                             const uint16_t compNHits)
-    : bitsInTime_(bitsInTime),
-      bitsOutOfTime_(bitsOutOfTime),
-      cscID_(cscID),
-      bx_(bx),
-      showerType_(showerType),
-      wireNHits_(wireNHits),
-      comparatorNHits_(compNHits) {}
+namespace io_v1 {
 
-/// Default
-CSCShowerDigi::CSCShowerDigi()
-    : bitsInTime_(0), bitsOutOfTime_(0), cscID_(0), bx_(0), showerType_(0), wireNHits_(0), comparatorNHits_(0) {}
+  /// Constructors
+  CSCShowerDigi::CSCShowerDigi(const uint16_t bitsInTime,
+                               const uint16_t bitsOutOfTime,
+                               const uint16_t cscID,
+                               const uint16_t bx,
+                               const uint16_t showerType,
+                               const uint16_t wireNHits,
+                               const uint16_t compNHits)
+      : bitsInTime_(bitsInTime),
+        bitsOutOfTime_(bitsOutOfTime),
+        cscID_(cscID),
+        bx_(bx),
+        showerType_(showerType),
+        wireNHits_(wireNHits),
+        comparatorNHits_(compNHits) {}
 
-void CSCShowerDigi::clear() {
-  bitsInTime_ = 0;
-  bitsOutOfTime_ = 0;
-  cscID_ = 0;
-  bx_ = 0;
-  showerType_ = 0;
-  wireNHits_ = 0;
-  comparatorNHits_ = 0;
-}
+  /// Default
+  CSCShowerDigi::CSCShowerDigi()
+      : bitsInTime_(0), bitsOutOfTime_(0), cscID_(0), bx_(0), showerType_(0), wireNHits_(0), comparatorNHits_(0) {}
 
-bool CSCShowerDigi::isValid() const {
-  // any loose shower is valid
-  // isLooseOutofTime() is removed as out-of-time shower is not used for Run3
-  return isLooseInTime() and isValidShowerType();
-}
-
-bool CSCShowerDigi::isLooseInTime() const { return bitsInTime() >= kLoose; }
-
-bool CSCShowerDigi::isNominalInTime() const { return bitsInTime() >= kNominal; }
-
-bool CSCShowerDigi::isTightInTime() const { return bitsInTime() >= kTight; }
-
-bool CSCShowerDigi::isLooseOutOfTime() const { return bitsOutOfTime() >= kLoose; }
-
-bool CSCShowerDigi::isNominalOutOfTime() const { return bitsOutOfTime() >= kNominal; }
-
-bool CSCShowerDigi::isTightOutOfTime() const { return bitsOutOfTime() >= kTight; }
-
-bool CSCShowerDigi::isValidShowerType() const { return showerType_ > kInvalidShower; }
-
-std::ostream& operator<<(std::ostream& o, const CSCShowerDigi& digi) {
-  unsigned int showerType = digi.getShowerType();
-  std::string compHitsStr(", comparatorHits ");
-  compHitsStr += std::to_string(digi.getComparatorNHits());
-  std::string wireHitsStr(", wireHits ");
-  wireHitsStr += std::to_string(digi.getWireNHits());
-  std::string showerStr;
-  switch (showerType) {
-    case 0:
-      showerStr = "Invalid ShowerType";
-      break;
-    case 1:
-      showerStr = "AnodeShower";
-      break;
-    case 2:
-      showerStr = "CathodeShower";
-      break;
-    case 3:
-      showerStr = "MatchedShower";
-      break;
-    case 4:
-      showerStr = "EMTFShower";
-      break;
-    case 5:
-      showerStr = "GMTShower";
-      break;
-    default:
-      showerStr = "UnknownShowerType";
+  void CSCShowerDigi::clear() {
+    bitsInTime_ = 0;
+    bitsOutOfTime_ = 0;
+    cscID_ = 0;
+    bx_ = 0;
+    showerType_ = 0;
+    wireNHits_ = 0;
+    comparatorNHits_ = 0;
   }
 
-  return o << showerStr << ": bx " << digi.getBX() << ", in-time bits " << digi.bitsInTime() << ", out-of-time bits "
-           << digi.bitsOutOfTime() << ((showerType == 1 or showerType == 3) ? wireHitsStr : "")
-           << ((showerType == 2 or showerType == 3) ? compHitsStr : "") << ";";
-}
+  bool CSCShowerDigi::isValid() const {
+    // any loose shower is valid
+    // isLooseOutofTime() is removed as out-of-time shower is not used for Run3
+    return isLooseInTime() and isValidShowerType();
+  }
+
+  bool CSCShowerDigi::isLooseInTime() const { return bitsInTime() >= kLoose; }
+
+  bool CSCShowerDigi::isNominalInTime() const { return bitsInTime() >= kNominal; }
+
+  bool CSCShowerDigi::isTightInTime() const { return bitsInTime() >= kTight; }
+
+  bool CSCShowerDigi::isLooseOutOfTime() const { return bitsOutOfTime() >= kLoose; }
+
+  bool CSCShowerDigi::isNominalOutOfTime() const { return bitsOutOfTime() >= kNominal; }
+
+  bool CSCShowerDigi::isTightOutOfTime() const { return bitsOutOfTime() >= kTight; }
+
+  bool CSCShowerDigi::isValidShowerType() const { return showerType_ > kInvalidShower; }
+
+  std::ostream& operator<<(std::ostream& o, const CSCShowerDigi& digi) {
+    unsigned int showerType = digi.getShowerType();
+    std::string compHitsStr(", comparatorHits ");
+    compHitsStr += std::to_string(digi.getComparatorNHits());
+    std::string wireHitsStr(", wireHits ");
+    wireHitsStr += std::to_string(digi.getWireNHits());
+    std::string showerStr;
+    switch (showerType) {
+      case 0:
+        showerStr = "Invalid ShowerType";
+        break;
+      case 1:
+        showerStr = "AnodeShower";
+        break;
+      case 2:
+        showerStr = "CathodeShower";
+        break;
+      case 3:
+        showerStr = "MatchedShower";
+        break;
+      case 4:
+        showerStr = "EMTFShower";
+        break;
+      case 5:
+        showerStr = "GMTShower";
+        break;
+      default:
+        showerStr = "UnknownShowerType";
+    }
+
+    return o << showerStr << ": bx " << digi.getBX() << ", in-time bits " << digi.bitsInTime() << ", out-of-time bits "
+             << digi.bitsOutOfTime() << ((showerType == 1 or showerType == 3) ? wireHitsStr : "")
+             << ((showerType == 2 or showerType == 3) ? compHitsStr : "") << ";";
+  }
+
+}  // namespace io_v1

--- a/DataFormats/CSCDigi/src/CSCStripDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCStripDigi.cc
@@ -9,61 +9,65 @@
 #include <iostream>
 #include <cstdint>
 
-// Comparison
-bool CSCStripDigi::operator==(const CSCStripDigi& digi) const {
-  if (getStrip() != digi.getStrip())
-    return false;
-  if (getADCCounts().size() != digi.getADCCounts().size())
-    return false;
-  if (getADCCounts() != digi.getADCCounts())
-    return false;
-  return true;
-}
+namespace io_v1 {
 
-/// Get the CFEB number. Counts from 0.
-// originally defined in EventFilter/CSCRawToDigi/src/CSCComparatorData.cc
-int CSCStripDigi::getCFEB() const { return (strip - 1) / CSCConstants::NUM_STRIPS_PER_CFEB; }
+  // Comparison
+  bool CSCStripDigi::operator==(const CSCStripDigi& digi) const {
+    if (getStrip() != digi.getStrip())
+      return false;
+    if (getADCCounts().size() != digi.getADCCounts().size())
+      return false;
+    if (getADCCounts() != digi.getADCCounts())
+      return false;
+    return true;
+  }
 
-void CSCStripDigi::setADCCounts(const std::vector<int>& vADCCounts) {
-  bool badVal = false;
-  for (int i = 0; i < (int)vADCCounts.size(); i++) {
-    if (vADCCounts[i] < 1)
-      badVal = true;
-  }
-  if (!badVal) {
-    ADCCounts = vADCCounts;
-  } else {
-    std::vector<int> ZeroCounts(8, 0);
-    ADCCounts = ZeroCounts;
-  }
-}
+  /// Get the CFEB number. Counts from 0.
+  // originally defined in EventFilter/CSCRawToDigi/src/CSCComparatorData.cc
+  int CSCStripDigi::getCFEB() const { return (strip - 1) / CSCConstants::NUM_STRIPS_PER_CFEB; }
 
-// Debug
-void CSCStripDigi::print() const {
-  std::ostringstream ost;
-  ost << "CSCStripDigi | strip " << getStrip() << " | ADCCounts ";
-  for (int i = 0; i < (int)getADCCounts().size(); i++) {
-    ost << getADCCounts()[i] << " ";
+  void CSCStripDigi::setADCCounts(const std::vector<int>& vADCCounts) {
+    bool badVal = false;
+    for (int i = 0; i < (int)vADCCounts.size(); i++) {
+      if (vADCCounts[i] < 1)
+        badVal = true;
+    }
+    if (!badVal) {
+      ADCCounts = vADCCounts;
+    } else {
+      std::vector<int> ZeroCounts(8, 0);
+      ADCCounts = ZeroCounts;
+    }
   }
-  ost << " | Overflow ";
-  for (int i = 0; i < (int)getADCOverflow().size(); i++) {
-    ost << getADCOverflow()[i] << " ";
-  }
-  ost << " | Overlapped ";
-  for (int i = 0; i < (int)getOverlappedSample().size(); i++) {
-    ost << getOverlappedSample()[i] << " ";
-  }
-  ost << " | L1APhase ";
-  for (int i = 0; i < (int)getL1APhase().size(); i++) {
-    ost << getL1APhase()[i] << " ";
-  }
-  edm::LogVerbatim("CSCDigi") << ost.str();
-}
 
-std::ostream& operator<<(std::ostream& o, const CSCStripDigi& digi) {
-  o << " " << digi.getStrip();
-  for (size_t i = 0; i < digi.getADCCounts().size(); ++i) {
-    o << " " << (digi.getADCCounts())[i];
+  // Debug
+  void CSCStripDigi::print() const {
+    std::ostringstream ost;
+    ost << "CSCStripDigi | strip " << getStrip() << " | ADCCounts ";
+    for (int i = 0; i < (int)getADCCounts().size(); i++) {
+      ost << getADCCounts()[i] << " ";
+    }
+    ost << " | Overflow ";
+    for (int i = 0; i < (int)getADCOverflow().size(); i++) {
+      ost << getADCOverflow()[i] << " ";
+    }
+    ost << " | Overlapped ";
+    for (int i = 0; i < (int)getOverlappedSample().size(); i++) {
+      ost << getOverlappedSample()[i] << " ";
+    }
+    ost << " | L1APhase ";
+    for (int i = 0; i < (int)getL1APhase().size(); i++) {
+      ost << getL1APhase()[i] << " ";
+    }
+    edm::LogVerbatim("CSCDigi") << ost.str();
   }
-  return o;
-}
+
+  std::ostream& operator<<(std::ostream& o, const CSCStripDigi& digi) {
+    o << " " << digi.getStrip();
+    for (size_t i = 0; i < digi.getADCCounts().size(); ++i) {
+      o << " " << (digi.getADCCounts())[i];
+    }
+    return o;
+  }
+
+}  // namespace io_v1

--- a/DataFormats/CSCDigi/src/CSCWireDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCWireDigi.cc
@@ -10,72 +10,77 @@
 #include <iterator>
 #include <cstdint>
 
-/// Constructors
+namespace io_v1 {
 
-CSCWireDigi::CSCWireDigi(int wire, unsigned int tbinb) {
-  /// Wire group number in the digi (16 lower bits from the wire group number)
-  wire_ = wire & 0x0000FFFF;
-  tbinb_ = tbinb;
-  /// BX in the wire digis (16 upper bits from the wire group number)
-  wireBX_ = (wire >> 16) & 0x0000FFFF;
-  /// BX wire group combination
-  wireBXandWires_ = wire;
-}
+  /// Constructors
 
-/// Default
-CSCWireDigi::CSCWireDigi() {
-  wire_ = 0;
-  tbinb_ = 0;
-  wireBX_ = 0;
-  wireBXandWires_ = 0;
-}
-
-/// return tbin number (obsolete, use getTimeBin() instead)
-int CSCWireDigi::getBeamCrossingTag() const { return getTimeBin(); }
-/// return first tbin ON number
-int CSCWireDigi::getTimeBin() const {
-  uint32_t tbit = 1;
-  int tbin = -1;
-  for (int i = 0; i < 32; i++) {
-    if (tbit & tbinb_)
-      tbin = i;
-    if (tbin > -1)
-      break;
-    tbit = tbit << 1;
+  CSCWireDigi::CSCWireDigi(int wire, unsigned int tbinb) {
+    /// Wire group number in the digi (16 lower bits from the wire group number)
+    wire_ = wire & 0x0000FFFF;
+    tbinb_ = tbinb;
+    /// BX in the wire digis (16 upper bits from the wire group number)
+    wireBX_ = (wire >> 16) & 0x0000FFFF;
+    /// BX wire group combination
+    wireBXandWires_ = wire;
   }
-  return tbin;
-}
-/// return vector of time bins ON
-std::vector<int> CSCWireDigi::getTimeBinsOn() const {
-  std::vector<int> tbins;
-  uint32_t tbit = tbinb_;
-  uint32_t one = 1;
-  for (int i = 0; i < 32; i++) {
-    if (tbit & one)
-      tbins.push_back(i);
-    tbit = tbit >> 1;
-    if (tbit == 0)
-      break;
+
+  /// Default
+  CSCWireDigi::CSCWireDigi() {
+    wire_ = 0;
+    tbinb_ = 0;
+    wireBX_ = 0;
+    wireBXandWires_ = 0;
   }
-  return tbins;
-}
 
-/// Debug
+  /// return tbin number (obsolete, use getTimeBin() instead)
+  int CSCWireDigi::getBeamCrossingTag() const { return getTimeBin(); }
+  /// return first tbin ON number
+  int CSCWireDigi::getTimeBin() const {
+    uint32_t tbit = 1;
+    int tbin = -1;
+    for (int i = 0; i < 32; i++) {
+      if (tbit & tbinb_)
+        tbin = i;
+      if (tbin > -1)
+        break;
+      tbit = tbit << 1;
+    }
+    return tbin;
+  }
+  /// return vector of time bins ON
+  std::vector<int> CSCWireDigi::getTimeBinsOn() const {
+    std::vector<int> tbins;
+    uint32_t tbit = tbinb_;
+    uint32_t one = 1;
+    for (int i = 0; i < 32; i++) {
+      if (tbit & one)
+        tbins.push_back(i);
+      tbit = tbit >> 1;
+      if (tbit == 0)
+        break;
+    }
+    return tbins;
+  }
 
-void CSCWireDigi::print() const {
-  std::ostringstream ost;
-  ost << "CSCWireDigi | wg " << getWireGroup() << " | "
-      << " BX # " << getWireGroupBX() << " | "
-      << " BX + Wire " << std::hex << getBXandWireGroup() << " | " << std::dec << " First Time Bin On " << getTimeBin()
-      << " | Time Bins On ";
-  std::vector<int> tbins = getTimeBinsOn();
-  std::copy(tbins.begin(), tbins.end(), std::ostream_iterator<int>(ost, " "));
-  edm::LogVerbatim("CSCDigi") << ost.str();
-}
+  /// Debug
 
-std::ostream& operator<<(std::ostream& o, const CSCWireDigi& digi) {
-  o << " CSCWireDigi wg: " << digi.getWireGroup() << ", First Time Bin On: " << digi.getTimeBin() << ", Time Bins On: ";
-  std::vector<int> tbins = digi.getTimeBinsOn();
-  std::copy(tbins.begin(), tbins.end(), std::ostream_iterator<int>(o, " "));
-  return o;
-}
+  void CSCWireDigi::print() const {
+    std::ostringstream ost;
+    ost << "CSCWireDigi | wg " << getWireGroup() << " | "
+        << " BX # " << getWireGroupBX() << " | "
+        << " BX + Wire " << std::hex << getBXandWireGroup() << " | " << std::dec << " First Time Bin On "
+        << getTimeBin() << " | Time Bins On ";
+    std::vector<int> tbins = getTimeBinsOn();
+    std::copy(tbins.begin(), tbins.end(), std::ostream_iterator<int>(ost, " "));
+    edm::LogVerbatim("CSCDigi") << ost.str();
+  }
+
+  std::ostream& operator<<(std::ostream& o, const CSCWireDigi& digi) {
+    o << " CSCWireDigi wg: " << digi.getWireGroup() << ", First Time Bin On: " << digi.getTimeBin()
+      << ", Time Bins On: ";
+    std::vector<int> tbins = digi.getTimeBinsOn();
+    std::copy(tbins.begin(), tbins.end(), std::ostream_iterator<int>(o, " "));
+    return o;
+  }
+
+}  // namespace io_v1

--- a/DataFormats/CSCDigi/src/classes_def.xml
+++ b/DataFormats/CSCDigi/src/classes_def.xml
@@ -1,170 +1,157 @@
 <lcgdict>
-   <class name="CSCWireDigi" ClassVersion="10">
-    <version ClassVersion="10" checksum="2850817593"/>
+   <class name="io_v1::CSCWireDigi" ClassVersion="3">
+    <version ClassVersion="3" checksum="3296971449"/>
    </class>
-   <class name="CSCRPCDigi" ClassVersion="10">
-    <version ClassVersion="10" checksum="133698288"/>
+   <class name="CSCRPCDigi" ClassVersion="3">
+    <version ClassVersion="3" checksum="133698288"/>
    </class>
-   <class name="CSCStripDigi" ClassVersion="10">
-    <version ClassVersion="10" checksum="432407273"/>
+   <class name="io_v1::CSCStripDigi" ClassVersion="3">
+    <version ClassVersion="3" checksum="1269315433"/>
    </class>
-   <class name="CSCComparatorDigi" ClassVersion="10">
-    <version ClassVersion="10" checksum="656608282"/>
+   <class name="io_v1::CSCComparatorDigi" ClassVersion="3">
+    <version ClassVersion="3" checksum="581803418"/>
    </class>
-   <class name="CSCCorrelatedLCTDigi" ClassVersion="14">
-    <version ClassVersion="14" checksum="1183056062"/>
-    <version ClassVersion="13" checksum="537762368"/>
-    <version ClassVersion="12" checksum="1516836035"/>
-    <version ClassVersion="11" checksum="2118578151"/>
-    <version ClassVersion="10" checksum="1301481852"/>
+   <class name="io_v1::CSCCorrelatedLCTDigi" ClassVersion="3">
+    <version ClassVersion="3" checksum="2776087862"/>
    </class>
-   <class name="GEMCSCLCTDigi" ClassVersion="11">
-    <version ClassVersion="11" checksum="56593764"/>
-    <version ClassVersion="10" checksum="967689346"/>
+   <class name="GEMCSCLCTDigi" ClassVersion="3">
+    <version ClassVersion="3" checksum="56593764"/>
    </class>
-   <class name="CSCCLCTDigi" ClassVersion="13">
-    <version ClassVersion="13" checksum="695892295"/>
-    <version ClassVersion="12" checksum="1002733592"/>
-    <version ClassVersion="11" checksum="511203876"/>
-    <version ClassVersion="10" checksum="3910057547"/>
+   <class name="io_v1::CSCCLCTDigi" ClassVersion="3">
+    <version ClassVersion="3" checksum="3978276429"/>
    </class>
-   <ioread sourceClass="CSCCLCTDigi"  targetClass="CSCCLCTDigi" version="[-10]" target="compCode_" source=""> <![CDATA[ compCode_ = -1; ]]> </ioread>
-   <class name="CSCCLCTPreTriggerDigi" ClassVersion="10">
-    <version ClassVersion="10" checksum="1207676078"/>
+   <class name="io_v1::CSCCLCTPreTriggerDigi" ClassVersion="3">
+    <version ClassVersion="3" checksum="983415342"/>
    </class>
-   <class name="CSCALCTDigi" ClassVersion="12">
-     <version ClassVersion="12" checksum="2762007033"/>
-     <version ClassVersion="11" checksum="4162193785"/>
-     <version ClassVersion="10" checksum="817473300"/>
+   <class name="io_v1::CSCALCTDigi" ClassVersion="3">
+     <version ClassVersion="3" checksum="931776359"/>
    </class>
-   <class name="CSCALCTPreTriggerDigi" ClassVersion="10">
-    <version ClassVersion="10" checksum="2925979693"/>
+   <class name="CSCALCTPreTriggerDigi" ClassVersion="3">
+    <version ClassVersion="3" checksum="2925979693"/>
    </class>
-   <class name="CSCShowerDigi" ClassVersion="12">
-    <version ClassVersion="12" checksum="2873709471"/>
-    <version ClassVersion="11" checksum="3092485146"/>
-    <version ClassVersion="10" checksum="3566030124"/>
+   <class name="io_v1::CSCShowerDigi" ClassVersion="3">
+    <version ClassVersion="3" checksum="22018335"/>
    </class>
-   <class name="CSCCFEBStatusDigi" ClassVersion="10">
-    <version ClassVersion="10" checksum="3752412263"/>
+   <class name="CSCCFEBStatusDigi" ClassVersion="3">
+    <version ClassVersion="3" checksum="3752412263"/>
    </class>
-   <class name="CSCTMBStatusDigi" ClassVersion="10">
-    <version ClassVersion="10" checksum="192211156"/>
+   <class name="CSCTMBStatusDigi" ClassVersion="3">
+    <version ClassVersion="3" checksum="192211156"/>
    </class>
-   <class name="CSCDMBStatusDigi" ClassVersion="10">
-    <version ClassVersion="10" checksum="2414593123"/>
+   <class name="CSCDMBStatusDigi" ClassVersion="3">
+    <version ClassVersion="3" checksum="2414593123"/>
    </class>
-   <class name="CSCDCCFormatStatusDigi" ClassVersion="10">
-    <version ClassVersion="10" checksum="734521968"/>
+   <class name="io_v1::CSCDCCFormatStatusDigi" ClassVersion="3">
+    <version ClassVersion="3" checksum="1836835568"/>
    </class>
-   <class name="CSCDDUStatusDigi" ClassVersion="10">
-    <version ClassVersion="10" checksum="3231645748"/>
+   <class name="CSCDDUStatusDigi" ClassVersion="3">
+    <version ClassVersion="3" checksum="3231645748"/>
    </class>
-   <class name="CSCDCCStatusDigi" ClassVersion="10">
-    <version ClassVersion="10" checksum="1612132636"/>
+   <class name="CSCDCCStatusDigi" ClassVersion="3">
+    <version ClassVersion="3" checksum="1612132636"/>
    </class>
-   <class name="CSCALCTStatusDigi" ClassVersion="10">
-    <version ClassVersion="10" checksum="3333415454"/>
+   <class name="CSCALCTStatusDigi" ClassVersion="3">
+    <version ClassVersion="3" checksum="3333415454"/>
    </class>
 
-   <class name="std::vector<CSCWireDigi>"/>
+   <class name="std::vector<io_v1::CSCWireDigi>"/>
    <class name="std::vector<CSCRPCDigi>"/>
-   <class name="std::vector<CSCStripDigi>"/>
-   <class name="std::vector<CSCComparatorDigi>"/>
-   <class name="std::vector<CSCCorrelatedLCTDigi>"/>
+   <class name="std::vector<io_v1::CSCStripDigi>"/>
+   <class name="std::vector<io_v1::CSCComparatorDigi>"/>
+   <class name="std::vector<io_v1::CSCCorrelatedLCTDigi>"/>
    <class name="std::vector<GEMCSCLCTDigi>"/>
-   <class name="std::vector<CSCCLCTDigi>"/>
-   <class name="std::vector<CSCCLCTPreTriggerDigi>"/>
-   <class name="std::vector<CSCALCTDigi>"/>
+   <class name="std::vector<io_v1::CSCCLCTDigi>"/>
+   <class name="std::vector<io_v1::CSCCLCTPreTriggerDigi>"/>
+   <class name="std::vector<io_v1::CSCALCTDigi>"/>
    <class name="std::vector<CSCALCTPreTriggerDigi>"/>
    <class name="std::vector<CSCCFEBStatusDigi>"/>
    <class name="std::vector<CSCTMBStatusDigi>"/>
    <class name="std::vector<CSCDMBStatusDigi>"/>
-   <class name="std::vector<CSCDCCFormatStatusDigi>"/>
+   <class name="std::vector<io_v1::CSCDCCFormatStatusDigi>"/>
    <class name="std::vector<CSCDDUStatusDigi>"/>
    <class name="std::vector<CSCDCCStatusDigi>"/>
    <class name="std::vector<CSCALCTStatusDigi>"/>
-   <class name="std::vector<CSCShowerDigi>"/>
+   <class name="std::vector<io_v1::CSCShowerDigi>"/>
 
-   <class name="std::map<CSCDetId,std::vector<CSCWireDigi> >"/>
+   <class name="std::map<CSCDetId,std::vector<io_v1::CSCWireDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCRPCDigi> >"/>
-   <class name="std::map<CSCDetId,std::vector<CSCStripDigi> >"/>
-   <class name="std::map<CSCDetId,std::vector<CSCComparatorDigi> >"/>
-   <class name="std::map<CSCDetId,std::vector<CSCCorrelatedLCTDigi> >"/>
+   <class name="std::map<CSCDetId,std::vector<io_v1::CSCStripDigi> >"/>
+   <class name="std::map<CSCDetId,std::vector<io_v1::CSCComparatorDigi> >"/>
+   <class name="std::map<CSCDetId,std::vector<io_v1::CSCCorrelatedLCTDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<GEMCSCLCTDigi> >"/>
-   <class name="std::map<CSCDetId,std::vector<CSCCLCTDigi> >"/>
-   <class name="std::map<CSCDetId,std::vector<CSCCLCTPreTriggerDigi> >"/>
-   <class name="std::map<CSCDetId,std::vector<CSCALCTDigi> >"/>
+   <class name="std::map<CSCDetId,std::vector<io_v1::CSCCLCTDigi> >"/>
+   <class name="std::map<CSCDetId,std::vector<io_v1::CSCCLCTPreTriggerDigi> >"/>
+   <class name="std::map<CSCDetId,std::vector<io_v1::CSCALCTDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCALCTPreTriggerDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCCFEBStatusDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCTMBStatusDigi> >"/>
-   <class name="std::map<CSCDetId,std::vector<CSCDCCFormatStatusDigi> >"/>
+   <class name="std::map<CSCDetId,std::vector<io_v1::CSCDCCFormatStatusDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCDMBStatusDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCDDUStatusDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCDCCStatusDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCALCTStatusDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCCLCTPreTrigger> >"/>
-   <class name="std::map<CSCDetId,std::vector<CSCShowerDigi> >"/>
+   <class name="std::map<CSCDetId,std::vector<io_v1::CSCShowerDigi> >"/>
 
-   <class name="std::pair<CSCDetId,std::vector<CSCWireDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<io_v1::CSCWireDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCRPCDigi> >"/>
-   <class name="std::pair<CSCDetId,std::vector<CSCStripDigi> >"/>
-   <class name="std::pair<CSCDetId,std::vector<CSCComparatorDigi> >"/>
-   <class name="std::pair<CSCDetId,std::vector<CSCCorrelatedLCTDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<io_v1::CSCStripDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<io_v1::CSCComparatorDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<io_v1::CSCCorrelatedLCTDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<GEMCSCLCTDigi> >"/>
-   <class name="std::pair<CSCDetId,std::vector<CSCCLCTDigi> >"/>
-   <class name="std::pair<CSCDetId,std::vector<CSCCLCTPreTriggerDigi> >"/>
-   <class name="std::pair<CSCDetId,std::vector<CSCALCTDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<io_v1::CSCCLCTDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<io_v1::CSCCLCTPreTriggerDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<io_v1::CSCALCTDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCALCTPreTriggerDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCCFEBStatusDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCTMBStatusDigi> >"/>
-   <class name="std::pair<CSCDetId,std::vector<CSCDCCFormatStatusDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<io_v1::CSCDCCFormatStatusDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCDMBStatusDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCDDUStatusDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCDCCStatusDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCALCTStatusDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCCLCTPreTrigger> >"/>
-   <class name="std::pair<CSCDetId,std::vector<CSCShowerDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<io_v1::CSCShowerDigi> >"/>
 
 
-   <class name="MuonDigiCollection<CSCDetId,CSCWireDigi>"/>
+   <class name="MuonDigiCollection<CSCDetId,io_v1::CSCWireDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCRPCDigi>"/>
-   <class name="MuonDigiCollection<CSCDetId,CSCStripDigi>"/>
-   <class name="MuonDigiCollection<CSCDetId,CSCComparatorDigi>"/>
-   <class name="MuonDigiCollection<CSCDetId,CSCCorrelatedLCTDigi>"/>
+   <class name="MuonDigiCollection<CSCDetId,io_v1::CSCStripDigi>"/>
+   <class name="MuonDigiCollection<CSCDetId,io_v1::CSCComparatorDigi>"/>
+   <class name="MuonDigiCollection<CSCDetId,io_v1::CSCCorrelatedLCTDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,GEMCSCLCTDigi>"/>
-   <class name="MuonDigiCollection<CSCDetId,CSCCLCTDigi>"/>
-   <class name="MuonDigiCollection<CSCDetId,CSCCLCTPreTriggerDigi>"/>
-   <class name="MuonDigiCollection<CSCDetId,CSCALCTDigi>"/>
+   <class name="MuonDigiCollection<CSCDetId,io_v1::CSCCLCTDigi>"/>
+   <class name="MuonDigiCollection<CSCDetId,io_v1::CSCCLCTPreTriggerDigi>"/>
+   <class name="MuonDigiCollection<CSCDetId,io_v1::CSCALCTDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCALCTPreTriggerDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCCFEBStatusDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCTMBStatusDigi>"/>
-   <class name="MuonDigiCollection<CSCDetId,CSCDCCFormatStatusDigi>"/>
+   <class name="MuonDigiCollection<CSCDetId,io_v1::CSCDCCFormatStatusDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCDMBStatusDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCDCCStatusDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCDDUStatusDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCALCTStatusDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCCLCTPreTrigger>"/>
-   <class name="MuonDigiCollection<CSCDetId,CSCShowerDigi>"/>
+   <class name="MuonDigiCollection<CSCDetId,io_v1::CSCShowerDigi>"/>
 
-   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCWireDigi>>"  splitLevel="0"/>
+   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,io_v1::CSCWireDigi>>"  splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCRPCDigi>>" splitLevel="0"/>
-   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCStripDigi>>"  splitLevel="0"/>
-   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCComparatorDigi>>"  splitLevel="0"/>
-   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCCorrelatedLCTDigi> >" splitLevel="0"/>
+   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,io_v1::CSCStripDigi>>"  splitLevel="0"/>
+   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,io_v1::CSCComparatorDigi>>"  splitLevel="0"/>
+   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,io_v1::CSCCorrelatedLCTDigi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,GEMCSCLCTDigi> >" splitLevel="0"/>
-   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCCLCTDigi> >" splitLevel="0"/>
-   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCCLCTPreTriggerDigi> >" splitLevel="0"/>
-   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCALCTDigi> >" splitLevel="0"/>
+   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,io_v1::CSCCLCTDigi> >" splitLevel="0"/>
+   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,io_v1::CSCCLCTPreTriggerDigi> >" splitLevel="0"/>
+   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,io_v1::CSCALCTDigi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCALCTPreTriggerDigi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCCFEBStatusDigi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCTMBStatusDigi> >" splitLevel="0"/>
-   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCDCCFormatStatusDigi> >" splitLevel="0"/>
+   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,io_v1::CSCDCCFormatStatusDigi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCDMBStatusDigi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCDCCStatusDigi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCDDUStatusDigi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCALCTStatusDigi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCCLCTPreTrigger> >" splitLevel="0"/>
-   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCShowerDigi> >" splitLevel="0"/>
+   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,io_v1::CSCShowerDigi> >" splitLevel="0"/>
 
 </lcgdict>

--- a/DataFormats/CSCRecHit/interface/CSCRecHit2D.h
+++ b/DataFormats/CSCRecHit/interface/CSCRecHit2D.h
@@ -15,131 +15,135 @@
 #include <map>
 #include <iosfwd>
 
-class CSCRecHit2D final : public RecHit2DLocalPos {
-public:
-  typedef std::vector<int> ChannelContainer;
-  typedef edm::RangeMap<int, std::vector<float> > ADCContainer;
+namespace io_v1 {
 
-  enum SharedInputType {
-    all = TrackingRecHit::all,
-    some = TrackingRecHit::some,
-    allWires,
-    someWires,
-    allStrips,
-    someStrips
+  class CSCRecHit2D final : public RecHit2DLocalPos {
+  public:
+    typedef std::vector<int> ChannelContainer;
+    typedef edm::RangeMap<int, std::vector<float> > ADCContainer;
+
+    enum SharedInputType {
+      all = TrackingRecHit::all,
+      some = TrackingRecHit::some,
+      allWires,
+      someWires,
+      allStrips,
+      someStrips
+    };
+
+    static const unsigned int MAXSTRIPS = 3;
+    static const unsigned int MAXTIMEBINS = 4;
+    static const unsigned int N_ADC = MAXSTRIPS * MAXTIMEBINS;
+    CSCRecHit2D();
+
+    CSCRecHit2D(const CSCDetId& id,
+                const LocalPoint& pos,
+                const LocalError& err,
+                const ChannelContainer& channels,
+                const ADCContainer& adcs,
+                const ChannelContainer& wgroups,
+                float tpeak,
+                float posInStrip,
+                float errInStrip,
+                int quality,
+                short int badStrip = 0,
+                short int badWireGroup = 0,
+                int scaledWireTime = 0,
+                float energyDeposit = -995.);
+
+    ~CSCRecHit2D() override;
+
+    /// RecHit2DLocalPos base class interface
+    CSCRecHit2D* clone() const override { return new CSCRecHit2D(*this); }
+    LocalPoint localPosition() const override { return theLocalPosition; }
+    LocalError localPositionError() const override { return theLocalError; }
+    CSCDetId cscDetId() const { return geographicalId(); }
+
+    /// Extracting strip channel numbers comprising the rechit - low
+    int channels(unsigned int i) const { return theStrips_[i]; }
+    unsigned int nStrips() const { return nStrips_; }
+
+    /// Extract the L1A phase bits from the StripChannelContainer - high
+    int channelsl1a(unsigned int i) const { return theL1APhaseBits_[i]; }  /// L1A
+
+    /// Container of wire groups comprising the rechit
+    short int hitWire() const { return hitWire_; }
+    short int wgroupsBX() const { return theWGroupsBX_; }
+
+    unsigned int nWireGroups() const { return nWireGroups_; }
+
+    /// Map of strip ADCs for strips comprising the rechit
+    float adcs(unsigned int strip, unsigned int timebin) const { return theADCs_[strip * MAXTIMEBINS + timebin]; }
+
+    unsigned int nTimeBins() const { return nTimeBins_; }
+
+    /// Fitted peaking time
+    float tpeak() const { return theTpeak; }
+
+    /// The estimated position within the strip
+    float positionWithinStrip() const { return thePositionWithinStrip; };
+
+    /// The uncertainty of the estimated position within the strip
+    float errorWithinStrip() const { return theErrorWithinStrip; };
+
+    /// quality flag of the reconstruction
+    int quality() const { return theQuality; }
+
+    /// flags for involvement of 'bad' channels
+    short int badStrip() const { return theBadStrip; }
+    short int badWireGroup() const { return theBadWireGroup; }
+
+    // Calculated wire time in ns
+    float wireTime() const { return (float)theScaledWireTime / 100.; }
+
+    /// Energy deposited in the layer.  Note:  this value is dE.  In order to
+    /// get the dE/dX, you will need to divide by the path length.
+    /// Specific failure values...
+    /// If the user has chosen not to use the gas gain correction --->  -998.
+    /// If the gas gain correction from the database is a bad value ->  -997.
+    /// If it is an edge strip -------------------------------------->  -996.
+    /// If gas-gain is OK, but the ADC vector is the wrong size  ---->  -999.
+    /// If the user has created the Rechit without the energy deposit>  -995.
+    /// If the user has created the Rechit with no arguments -------->  -994.
+    float energyDepositedInLayer() const { return theEnergyDeposit; }
+
+    /// Returns true if the two TrackingRecHits are using the same input information, false otherwise.  In this case, looks at the geographical ID and channel numbers for strips and wires.
+    bool sharesInput(const TrackingRecHit* other, TrackingRecHit::SharedInputType what) const override;
+
+    /// Returns true if the two TrackingRecHits are using the same input information, false otherwise.  In this case, looks at the geographical ID and channel numbers for strips and wires.
+    bool sharesInput(const TrackingRecHit* other, CSCRecHit2D::SharedInputType what) const;
+
+    /// Returns true if the two CSCRecHits are using the same input information, false otherwise.  In this case, looks at the geographical ID and channel numbers for strips and wires.
+    bool sharesInput(const CSCRecHit2D* otherRecHit, CSCRecHit2D::SharedInputType what) const;
+
+    /// Print the content of the RecHit2D including L1A (for debugging)
+    void print() const;
+
+  private:
+    float theTpeak;
+    float thePositionWithinStrip;
+    float theErrorWithinStrip;
+    float theEnergyDeposit;
+    int theQuality;
+    int theScaledWireTime;
+    short int hitWire_;
+    short int theWGroupsBX_;
+    short int theBadStrip;
+    short int theBadWireGroup;
+
+    unsigned char nStrips_, nWireGroups_, nTimeBins_;
+
+    unsigned char theL1APhaseBits_[MAXSTRIPS];
+    unsigned char theStrips_[MAXSTRIPS];
+    float theADCs_[N_ADC];
+
+    LocalPoint theLocalPosition;
+    LocalError theLocalError;
   };
 
-  static const unsigned int MAXSTRIPS = 3;
-  static const unsigned int MAXTIMEBINS = 4;
-  static const unsigned int N_ADC = MAXSTRIPS * MAXTIMEBINS;
-  CSCRecHit2D();
+  /// Output operator for CSCRecHit2D
+  std::ostream& operator<<(std::ostream& os, const CSCRecHit2D& rh);
 
-  CSCRecHit2D(const CSCDetId& id,
-              const LocalPoint& pos,
-              const LocalError& err,
-              const ChannelContainer& channels,
-              const ADCContainer& adcs,
-              const ChannelContainer& wgroups,
-              float tpeak,
-              float posInStrip,
-              float errInStrip,
-              int quality,
-              short int badStrip = 0,
-              short int badWireGroup = 0,
-              int scaledWireTime = 0,
-              float energyDeposit = -995.);
-
-  ~CSCRecHit2D() override;
-
-  /// RecHit2DLocalPos base class interface
-  CSCRecHit2D* clone() const override { return new CSCRecHit2D(*this); }
-  LocalPoint localPosition() const override { return theLocalPosition; }
-  LocalError localPositionError() const override { return theLocalError; }
-  CSCDetId cscDetId() const { return geographicalId(); }
-
-  /// Extracting strip channel numbers comprising the rechit - low
-  int channels(unsigned int i) const { return theStrips_[i]; }
-  unsigned int nStrips() const { return nStrips_; }
-
-  /// Extract the L1A phase bits from the StripChannelContainer - high
-  int channelsl1a(unsigned int i) const { return theL1APhaseBits_[i]; }  /// L1A
-
-  /// Container of wire groups comprising the rechit
-  short int hitWire() const { return hitWire_; }
-  short int wgroupsBX() const { return theWGroupsBX_; }
-
-  unsigned int nWireGroups() const { return nWireGroups_; }
-
-  /// Map of strip ADCs for strips comprising the rechit
-  float adcs(unsigned int strip, unsigned int timebin) const { return theADCs_[strip * MAXTIMEBINS + timebin]; }
-
-  unsigned int nTimeBins() const { return nTimeBins_; }
-
-  /// Fitted peaking time
-  float tpeak() const { return theTpeak; }
-
-  /// The estimated position within the strip
-  float positionWithinStrip() const { return thePositionWithinStrip; };
-
-  /// The uncertainty of the estimated position within the strip
-  float errorWithinStrip() const { return theErrorWithinStrip; };
-
-  /// quality flag of the reconstruction
-  int quality() const { return theQuality; }
-
-  /// flags for involvement of 'bad' channels
-  short int badStrip() const { return theBadStrip; }
-  short int badWireGroup() const { return theBadWireGroup; }
-
-  // Calculated wire time in ns
-  float wireTime() const { return (float)theScaledWireTime / 100.; }
-
-  /// Energy deposited in the layer.  Note:  this value is dE.  In order to
-  /// get the dE/dX, you will need to divide by the path length.
-  /// Specific failure values...
-  /// If the user has chosen not to use the gas gain correction --->  -998.
-  /// If the gas gain correction from the database is a bad value ->  -997.
-  /// If it is an edge strip -------------------------------------->  -996.
-  /// If gas-gain is OK, but the ADC vector is the wrong size  ---->  -999.
-  /// If the user has created the Rechit without the energy deposit>  -995.
-  /// If the user has created the Rechit with no arguments -------->  -994.
-  float energyDepositedInLayer() const { return theEnergyDeposit; }
-
-  /// Returns true if the two TrackingRecHits are using the same input information, false otherwise.  In this case, looks at the geographical ID and channel numbers for strips and wires.
-  bool sharesInput(const TrackingRecHit* other, TrackingRecHit::SharedInputType what) const override;
-
-  /// Returns true if the two TrackingRecHits are using the same input information, false otherwise.  In this case, looks at the geographical ID and channel numbers for strips and wires.
-  bool sharesInput(const TrackingRecHit* other, CSCRecHit2D::SharedInputType what) const;
-
-  /// Returns true if the two CSCRecHits are using the same input information, false otherwise.  In this case, looks at the geographical ID and channel numbers for strips and wires.
-  bool sharesInput(const CSCRecHit2D* otherRecHit, CSCRecHit2D::SharedInputType what) const;
-
-  /// Print the content of the RecHit2D including L1A (for debugging)
-  void print() const;
-
-private:
-  float theTpeak;
-  float thePositionWithinStrip;
-  float theErrorWithinStrip;
-  float theEnergyDeposit;
-  int theQuality;
-  int theScaledWireTime;
-  short int hitWire_;
-  short int theWGroupsBX_;
-  short int theBadStrip;
-  short int theBadWireGroup;
-
-  unsigned char nStrips_, nWireGroups_, nTimeBins_;
-
-  unsigned char theL1APhaseBits_[MAXSTRIPS];
-  unsigned char theStrips_[MAXSTRIPS];
-  float theADCs_[N_ADC];
-
-  LocalPoint theLocalPosition;
-  LocalError theLocalError;
-};
-
-/// Output operator for CSCRecHit2D
-std::ostream& operator<<(std::ostream& os, const CSCRecHit2D& rh);
-
+}  // namespace io_v1
+using CSCRecHit2D = io_v1::CSCRecHit2D;
 #endif

--- a/DataFormats/CSCRecHit/interface/CSCSegment.h
+++ b/DataFormats/CSCRecHit/interface/CSCSegment.h
@@ -17,87 +17,91 @@
 
 #include <iosfwd>
 
-class CSCSegment final : public RecSegment {
-public:
-  /// Default constructor
-  CSCSegment() : theChi2(0.), aME11a_duplicate(false) {}
+namespace io_v1 {
 
-  /// Constructor
-  CSCSegment(const std::vector<const CSCRecHit2D*>& proto_segment,
-             LocalPoint origin,
-             LocalVector direction,
-             const AlgebraicSymMatrix& errors,
-             double chi2);
+  class CSCSegment final : public RecSegment {
+  public:
+    /// Default constructor
+    CSCSegment() : theChi2(0.), aME11a_duplicate(false) {}
 
-  /// Destructor
-  ~CSCSegment() override;
+    /// Constructor
+    CSCSegment(const std::vector<const CSCRecHit2D*>& proto_segment,
+               LocalPoint origin,
+               LocalVector direction,
+               const AlgebraicSymMatrix& errors,
+               double chi2);
 
-  //--- Base class interface
-  CSCSegment* clone() const override { return new CSCSegment(*this); }
+    /// Destructor
+    ~CSCSegment() override;
 
-  LocalPoint localPosition() const override { return theOrigin; }
-  LocalError localPositionError() const override;
+    //--- Base class interface
+    CSCSegment* clone() const override { return new CSCSegment(*this); }
 
-  LocalVector localDirection() const override { return theLocalDirection; }
-  LocalError localDirectionError() const override;
+    LocalPoint localPosition() const override { return theOrigin; }
+    LocalError localPositionError() const override;
 
-  /// Parameters of the segment, for the track fit in the order (dx/dz, dy/dz, x, y )
-  AlgebraicVector parameters() const override;
+    LocalVector localDirection() const override { return theLocalDirection; }
+    LocalError localDirectionError() const override;
 
-  /// Covariance matrix of parameters()
-  AlgebraicSymMatrix parametersError() const override { return theCovMatrix; }
+    /// Parameters of the segment, for the track fit in the order (dx/dz, dy/dz, x, y )
+    AlgebraicVector parameters() const override;
 
-  /// The projection matrix relates the trajectory state parameters to the segment parameters().
-  AlgebraicMatrix projectionMatrix() const override;
+    /// Covariance matrix of parameters()
+    AlgebraicSymMatrix parametersError() const override { return theCovMatrix; }
 
-  std::vector<const TrackingRecHit*> recHits() const override;
+    /// The projection matrix relates the trajectory state parameters to the segment parameters().
+    AlgebraicMatrix projectionMatrix() const override;
 
-  std::vector<TrackingRecHit*> recHits() override;
+    std::vector<const TrackingRecHit*> recHits() const override;
 
-  double chi2() const override { return theChi2; };
+    std::vector<TrackingRecHit*> recHits() override;
 
-  int dimension() const override { return 4; }
+    double chi2() const override { return theChi2; };
 
-  int degreesOfFreedom() const override { return 2 * nRecHits() - 4; }
+    int dimension() const override { return 4; }
 
-  //--- Extension of the interface
+    int degreesOfFreedom() const override { return 2 * nRecHits() - 4; }
 
-  const std::vector<CSCRecHit2D>& specificRecHits() const { return theCSCRecHits; }
+    //--- Extension of the interface
 
-  int nRecHits() const { return theCSCRecHits.size(); }
+    const std::vector<CSCRecHit2D>& specificRecHits() const { return theCSCRecHits; }
 
-  CSCDetId cscDetId() const { return geographicalId(); }
+    int nRecHits() const { return theCSCRecHits.size(); }
 
-  void setDuplicateSegments(std::vector<CSCSegment*>& duplicates);
+    CSCDetId cscDetId() const { return geographicalId(); }
 
-  bool isME11a_duplicate() const { return (!theDuplicateSegments.empty() ? true : false); }
-  // a copy of the duplicated segments (ME1/1a only)
-  const std::vector<CSCSegment>& duplicateSegments() const { return theDuplicateSegments; }
+    void setDuplicateSegments(std::vector<CSCSegment*>& duplicates);
 
-  bool testSharesAllInSpecificRecHits(const std::vector<CSCRecHit2D>& specificRecHits_1,
-                                      const std::vector<CSCRecHit2D>& specificRecHits_2,
-                                      CSCRecHit2D::SharedInputType) const;
+    bool isME11a_duplicate() const { return (!theDuplicateSegments.empty() ? true : false); }
+    // a copy of the duplicated segments (ME1/1a only)
+    const std::vector<CSCSegment>& duplicateSegments() const { return theDuplicateSegments; }
 
-  //bool sharesRecHits(CSCSegment  & anotherSegment, CSCRecHit2D::SharedInputType);
-  // checks if ALL the rechits share the specific input (allWires, allStrips or all)
-  bool sharesRecHits(const CSCSegment& anotherSegment, CSCRecHit2D::SharedInputType sharesInput) const;
-  // checks if ALL the rechits share SOME wire AND SOME strip input
-  bool sharesRecHits(const CSCSegment& anotherSegment) const;
+    bool testSharesAllInSpecificRecHits(const std::vector<CSCRecHit2D>& specificRecHits_1,
+                                        const std::vector<CSCRecHit2D>& specificRecHits_2,
+                                        CSCRecHit2D::SharedInputType) const;
 
-  float time() const;
+    //bool sharesRecHits(CSCSegment  & anotherSegment, CSCRecHit2D::SharedInputType);
+    // checks if ALL the rechits share the specific input (allWires, allStrips or all)
+    bool sharesRecHits(const CSCSegment& anotherSegment, CSCRecHit2D::SharedInputType sharesInput) const;
+    // checks if ALL the rechits share SOME wire AND SOME strip input
+    bool sharesRecHits(const CSCSegment& anotherSegment) const;
 
-  void print() const;
+    float time() const;
 
-private:
-  std::vector<CSCRecHit2D> theCSCRecHits;
-  LocalPoint theOrigin;             // in chamber frame - the GeomDet local coordinate system
-  LocalVector theLocalDirection;    // in chamber frame - the GeomDet local coordinate system
-  AlgebraicSymMatrix theCovMatrix;  // the covariance matrix
-  double theChi2;
-  bool aME11a_duplicate;
-  std::vector<CSCSegment> theDuplicateSegments;  // ME1/1a only
-};
+    void print() const;
 
-std::ostream& operator<<(std::ostream& os, const CSCSegment& seg);
+  private:
+    std::vector<CSCRecHit2D> theCSCRecHits;
+    LocalPoint theOrigin;             // in chamber frame - the GeomDet local coordinate system
+    LocalVector theLocalDirection;    // in chamber frame - the GeomDet local coordinate system
+    AlgebraicSymMatrix theCovMatrix;  // the covariance matrix
+    double theChi2;
+    bool aME11a_duplicate;
+    std::vector<CSCSegment> theDuplicateSegments;  // ME1/1a only
+  };
 
+  std::ostream& operator<<(std::ostream& os, const CSCSegment& seg);
+
+}  // namespace io_v1
+using CSCSegment = io_v1::CSCSegment;
 #endif  // CSCRecHit_CSCSegment_h

--- a/DataFormats/CSCRecHit/src/CSCRecHit2D.cc
+++ b/DataFormats/CSCRecHit/src/CSCRecHit2D.cc
@@ -1,224 +1,228 @@
 #include <DataFormats/CSCRecHit/interface/CSCRecHit2D.h>
 #include <iostream>
 
-CSCRecHit2D::CSCRecHit2D()
-    : theTpeak(-999.),
-      thePositionWithinStrip(-999.),
-      theErrorWithinStrip(-999.),
-      theEnergyDeposit(-994.),
-      theQuality(0),
-      theScaledWireTime(0),
-      theBadStrip(0),
-      theBadWireGroup(0),
-      nStrips_(0),
-      nWireGroups_(0),
-      nTimeBins_(0),
-      theLocalPosition(0., 0.),
-      theLocalError(0., 0., 0.) {
-  for (unsigned int i = 0; i < MAXSTRIPS; i++)
-    theStrips_[i] = 0;
-  for (unsigned int i = 0; i < MAXSTRIPS; i++)
-    for (unsigned int j = 0; j < MAXTIMEBINS; j++)
-      theADCs_[i * MAXTIMEBINS + j] = 0;
-}
+namespace io_v1 {
 
-CSCRecHit2D::CSCRecHit2D(const CSCDetId& id,
-                         const LocalPoint& pos,
-                         const LocalError& err,
-                         const ChannelContainer& channels,
-                         const ADCContainer& adcs,
-                         const ChannelContainer& wgroups,
-                         float tpeak,
-                         float posInStrip,
-                         float errInStrip,
-                         int quality,
-                         short int badStrip,
-                         short int badWireGroup,
-                         int scaledWireTime,
-                         float energyDeposit)
-    : RecHit2DLocalPos(id),
-      theTpeak(tpeak),
-      thePositionWithinStrip(posInStrip),
-      theErrorWithinStrip(errInStrip),
-      theEnergyDeposit(energyDeposit),
-      theQuality(quality),
-      theScaledWireTime(scaledWireTime),
-      theBadStrip(badStrip),
-      theBadWireGroup(badWireGroup),
-      theLocalPosition(pos),
-      theLocalError(err) {
-  nStrips_ = channels.size();
-  nWireGroups_ = wgroups.size();
-
-  if (nStrips_ > MAXSTRIPS) {
-    std::cout << "CSCRecHit2D: not enough strips in DataFormat! " << unsigned(nStrips_) << std::endl;
-    nStrips_ = MAXSTRIPS;
+  CSCRecHit2D::CSCRecHit2D()
+      : theTpeak(-999.),
+        thePositionWithinStrip(-999.),
+        theErrorWithinStrip(-999.),
+        theEnergyDeposit(-994.),
+        theQuality(0),
+        theScaledWireTime(0),
+        theBadStrip(0),
+        theBadWireGroup(0),
+        nStrips_(0),
+        nWireGroups_(0),
+        nTimeBins_(0),
+        theLocalPosition(0., 0.),
+        theLocalError(0., 0., 0.) {
+    for (unsigned int i = 0; i < MAXSTRIPS; i++)
+      theStrips_[i] = 0;
+    for (unsigned int i = 0; i < MAXSTRIPS; i++)
+      for (unsigned int j = 0; j < MAXTIMEBINS; j++)
+        theADCs_[i * MAXTIMEBINS + j] = 0;
   }
 
-  for (unsigned int i = 0; i < MAXSTRIPS; i++)
-    theStrips_[i] = 0;
-  for (unsigned int i = 0; i < MAXSTRIPS; i++)
-    theL1APhaseBits_[i] = 0;
-  for (unsigned int i = 0; i < MAXSTRIPS; i++)
-    for (unsigned int j = 0; j < MAXTIMEBINS; j++)
-      theADCs_[i * MAXTIMEBINS + j] = 0;
+  CSCRecHit2D::CSCRecHit2D(const CSCDetId& id,
+                           const LocalPoint& pos,
+                           const LocalError& err,
+                           const ChannelContainer& channels,
+                           const ADCContainer& adcs,
+                           const ChannelContainer& wgroups,
+                           float tpeak,
+                           float posInStrip,
+                           float errInStrip,
+                           int quality,
+                           short int badStrip,
+                           short int badWireGroup,
+                           int scaledWireTime,
+                           float energyDeposit)
+      : RecHit2DLocalPos(id),
+        theTpeak(tpeak),
+        thePositionWithinStrip(posInStrip),
+        theErrorWithinStrip(errInStrip),
+        theEnergyDeposit(energyDeposit),
+        theQuality(quality),
+        theScaledWireTime(scaledWireTime),
+        theBadStrip(badStrip),
+        theBadWireGroup(badWireGroup),
+        theLocalPosition(pos),
+        theLocalError(err) {
+    nStrips_ = channels.size();
+    nWireGroups_ = wgroups.size();
 
-  for (unsigned int i = 0; i < nStrips_; i++) {
-    theStrips_[i] = channels[i] & 0x000000FF;
-    theL1APhaseBits_[i] = channels[i] & 0x0000FF00;
-  }
-  if (nWireGroups_ > 0) {
-    //take only the low bits
-    hitWire_ = wgroups[nWireGroups_ / 2] & 0x0000FFFF;
-    theWGroupsBX_ = (wgroups[nWireGroups_ / 2] >> 16) & 0x0000FFFF;
-  } else {
-    hitWire_ = 0;
-    theWGroupsBX_ = 0;
-  }
-  ADCContainer tmp(adcs);  //must be a bug in RangeMap!!!???
-  nTimeBins_ = tmp.size() / nStrips_;
-  unsigned int k = 0;
-  for (unsigned int i = 0; i < nStrips_; i++)
-    for (unsigned int j = 0; j < nTimeBins_; j++) {
-      theADCs_[i * MAXTIMEBINS + j] = tmp[k];
-      k++;
+    if (nStrips_ > MAXSTRIPS) {
+      std::cout << "CSCRecHit2D: not enough strips in DataFormat! " << unsigned(nStrips_) << std::endl;
+      nStrips_ = MAXSTRIPS;
     }
-}
 
-CSCRecHit2D::~CSCRecHit2D() {}
+    for (unsigned int i = 0; i < MAXSTRIPS; i++)
+      theStrips_[i] = 0;
+    for (unsigned int i = 0; i < MAXSTRIPS; i++)
+      theL1APhaseBits_[i] = 0;
+    for (unsigned int i = 0; i < MAXSTRIPS; i++)
+      for (unsigned int j = 0; j < MAXTIMEBINS; j++)
+        theADCs_[i * MAXTIMEBINS + j] = 0;
 
-bool CSCRecHit2D::sharesInput(const TrackingRecHit* other, TrackingRecHit::SharedInputType what) const {
-  // This is to satisfy the base class virtual function
-
-  // @@ Cast the enum (!) But what if the TRH::SIT changes?!
-  CSCRecHit2D::SharedInputType cscWhat = static_cast<CSCRecHit2D::SharedInputType>(what);
-  return sharesInput(other, cscWhat);
-}
-
-bool CSCRecHit2D::sharesInput(const TrackingRecHit* other, CSCRecHit2D::SharedInputType what) const {
-  // Check to see if the TrackingRecHit is actually a CSCRecHit2D.
-  if (other->geographicalId().subdetId() != MuonSubdetId::CSC)
-    return false;
-
-  // Now I can static cast, because the previous guarantees that this is a CSCRecHit2D
-  const CSCRecHit2D* otherRecHit = static_cast<const CSCRecHit2D*>(other);
-
-  return sharesInput(otherRecHit, what);
-}
-
-bool CSCRecHit2D::sharesInput(const CSCRecHit2D* otherRecHit, CSCRecHit2D::SharedInputType what) const {
-  // Check to see if the geographical ID of the two are the same
-  if (geographicalId() != otherRecHit->geographicalId())
-    return false;
-
-  // Trivial cases
-  if (nStrips() == 0 && otherRecHit->nStrips() == 0 && nWireGroups() == 0 && otherRecHit->nWireGroups() == 0)
-    return true;
-  if ((what == allWires || what == someWires) && nWireGroups() == 0 && otherRecHit->nWireGroups() == 0)
-    return true;
-  if ((what == allStrips || what == someStrips) && nStrips() == 0 && otherRecHit->nStrips() == 0)
-    return true;
-
-  // Check to see if the wire containers are the same length
-  if ((what == all || what == allWires) && nWireGroups() != otherRecHit->nWireGroups())
-    return false;
-
-  // Check to see if the strip containers are the same length
-  if ((what == all || what == allStrips) && nStrips() != otherRecHit->nStrips())
-    return false;
-
-  bool foundWire = false;
-  // Check to see if the wires are the same
-  if (what != allStrips && what != someStrips) {
-    //can we do better here?
-    if (hitWire() != otherRecHit->hitWire())
-      return false;
+    for (unsigned int i = 0; i < nStrips_; i++) {
+      theStrips_[i] = channels[i] & 0x000000FF;
+      theL1APhaseBits_[i] = channels[i] & 0x0000FF00;
+    }
+    if (nWireGroups_ > 0) {
+      //take only the low bits
+      hitWire_ = wgroups[nWireGroups_ / 2] & 0x0000FFFF;
+      theWGroupsBX_ = (wgroups[nWireGroups_ / 2] >> 16) & 0x0000FFFF;
+    } else {
+      hitWire_ = 0;
+      theWGroupsBX_ = 0;
+    }
+    ADCContainer tmp(adcs);  //must be a bug in RangeMap!!!???
+    nTimeBins_ = tmp.size() / nStrips_;
+    unsigned int k = 0;
+    for (unsigned int i = 0; i < nStrips_; i++)
+      for (unsigned int j = 0; j < nTimeBins_; j++) {
+        theADCs_[i * MAXTIMEBINS + j] = tmp[k];
+        k++;
+      }
   }
 
-  // Check to see if the wires are the same
-  bool foundStrip = false;
-  if (what != allWires && what != someWires) {
-    for (unsigned int i = 0; i < nStrips(); i++) {
-      bool found = false;
-      for (unsigned int j = 0; j < nStrips(); j++) {
-        //a strip is a channel for all but ME1/1a chambers (where 3 ganged strips are a channel)
-        if (cscDetId().channel(channels(i)) == otherRecHit->cscDetId().channel(otherRecHit->channels(j))) {
-          if (what == some || what == someStrips)
-            return true;
-          else {
-            found = true;
-            foundStrip = true;
-            break;
-          }
-        }
-      }
-      if ((what == all || what == allStrips) && !found)
+  CSCRecHit2D::~CSCRecHit2D() {}
+
+  bool CSCRecHit2D::sharesInput(const TrackingRecHit* other, TrackingRecHit::SharedInputType what) const {
+    // This is to satisfy the base class virtual function
+
+    // @@ Cast the enum (!) But what if the TRH::SIT changes?!
+    CSCRecHit2D::SharedInputType cscWhat = static_cast<CSCRecHit2D::SharedInputType>(what);
+    return sharesInput(other, cscWhat);
+  }
+
+  bool CSCRecHit2D::sharesInput(const TrackingRecHit* other, CSCRecHit2D::SharedInputType what) const {
+    // Check to see if the TrackingRecHit is actually a CSCRecHit2D.
+    if (other->geographicalId().subdetId() != MuonSubdetId::CSC)
+      return false;
+
+    // Now I can static cast, because the previous guarantees that this is a CSCRecHit2D
+    const CSCRecHit2D* otherRecHit = static_cast<const CSCRecHit2D*>(other);
+
+    return sharesInput(otherRecHit, what);
+  }
+
+  bool CSCRecHit2D::sharesInput(const CSCRecHit2D* otherRecHit, CSCRecHit2D::SharedInputType what) const {
+    // Check to see if the geographical ID of the two are the same
+    if (geographicalId() != otherRecHit->geographicalId())
+      return false;
+
+    // Trivial cases
+    if (nStrips() == 0 && otherRecHit->nStrips() == 0 && nWireGroups() == 0 && otherRecHit->nWireGroups() == 0)
+      return true;
+    if ((what == allWires || what == someWires) && nWireGroups() == 0 && otherRecHit->nWireGroups() == 0)
+      return true;
+    if ((what == allStrips || what == someStrips) && nStrips() == 0 && otherRecHit->nStrips() == 0)
+      return true;
+
+    // Check to see if the wire containers are the same length
+    if ((what == all || what == allWires) && nWireGroups() != otherRecHit->nWireGroups())
+      return false;
+
+    // Check to see if the strip containers are the same length
+    if ((what == all || what == allStrips) && nStrips() != otherRecHit->nStrips())
+      return false;
+
+    bool foundWire = false;
+    // Check to see if the wires are the same
+    if (what != allStrips && what != someStrips) {
+      //can we do better here?
+      if (hitWire() != otherRecHit->hitWire())
         return false;
     }
-    if (what == someStrips && !foundStrip)
-      return false;
-  }
 
-  // In case we were looking for "some" and found absolutely nothing.
-  if (!foundWire && !foundStrip)
-    return false;
-
-  // If we made it this far, then:
-  //  1) the detector IDs are the same
-  //  2) the channel containers have the same number of entries
-  //  3) for each entry in my channel container, I can find the same value in the other RecHit's corresponding channel container
-  // I think that means we are the same.
-  return true;
-}
-
-void CSCRecHit2D::print() const {
-  std::cout << "CSCRecHit in CSC Detector: " << cscDetId() << std::endl;
-  std::cout << "  local x = " << localPosition().x() << " +/- " << sqrt(localPositionError().xx())
-            << " y = " << localPosition().y() << " +/- " << sqrt(localPositionError().yy()) << std::endl;
-
-  std::cout << " tpeak " << theTpeak << " psoInStrip " << thePositionWithinStrip << " errorinstrip "
-            << theErrorWithinStrip << " "
-            << " qual " << theQuality << " wiretime " << theScaledWireTime << " tbs " << theBadStrip << " bwg "
-            << theBadWireGroup << std::endl;
-
-  std::cout << "  Channels: ";
-  for (unsigned int i = 0; i < nStrips(); i++) {
-    std::cout << std::dec << channels(i) << " "
-              << " ("
-              << "HEX: " << std::hex << channels(i) << ")"
-              << " ";
-  }
-  std::cout << std::endl;
-
-  /// L1A
-  std::cout << "  L1APhase: ";
-  for (int i = 0; i < (int)nStrips(); i++) {
-    std::cout << "|";
-    for (int k = 0; k < 8; k++) {
-      std::cout << ((channelsl1a(i) >> (15 - k)) & 0x1) << " ";
+    // Check to see if the wires are the same
+    bool foundStrip = false;
+    if (what != allWires && what != someWires) {
+      for (unsigned int i = 0; i < nStrips(); i++) {
+        bool found = false;
+        for (unsigned int j = 0; j < nStrips(); j++) {
+          //a strip is a channel for all but ME1/1a chambers (where 3 ganged strips are a channel)
+          if (cscDetId().channel(channels(i)) == otherRecHit->cscDetId().channel(otherRecHit->channels(j))) {
+            if (what == some || what == someStrips)
+              return true;
+            else {
+              found = true;
+              foundStrip = true;
+              break;
+            }
+          }
+        }
+        if ((what == all || what == allStrips) && !found)
+          return false;
+      }
+      if (what == someStrips && !foundStrip)
+        return false;
     }
-    std::cout << "| ";
-  }
-  std::cout << std::endl;
 
-  std::cout << "nWireGroups " << (int)nWireGroups() << " central wire " << hitWire_ << std::endl;
-}
+    // In case we were looking for "some" and found absolutely nothing.
+    if (!foundWire && !foundStrip)
+      return false;
 
-std::ostream& operator<<(std::ostream& os, const CSCRecHit2D& rh) {
-  os << "CSCRecHit2D: "
-     << "local x: " << rh.localPosition().x() << " +/- " << sqrt(rh.localPositionError().xx())
-     << " y: " << rh.localPosition().y() << " +/- " << sqrt(rh.localPositionError().yy())
-     << " in strip X: " << rh.positionWithinStrip() << " +/- " << rh.errorWithinStrip() << " quality: " << rh.quality()
-     << " tpeak: " << rh.tpeak() << " wireTime: " << rh.wireTime() << std::endl;
-  os << "strips: ";
-  for (size_t iS = 0; iS < rh.nStrips(); ++iS) {
-    os << rh.channels(iS) << "  ";
+    // If we made it this far, then:
+    //  1) the detector IDs are the same
+    //  2) the channel containers have the same number of entries
+    //  3) for each entry in my channel container, I can find the same value in the other RecHit's corresponding channel container
+    // I think that means we are the same.
+    return true;
   }
-  int nwgs = rh.nWireGroups();
-  if (nwgs == 1) {
-    os << "central wire: " << rh.hitWire() << " of " << nwgs << " wiregroup" << std::endl;
-  } else {
-    os << "central wire: " << rh.hitWire() << " of " << nwgs << " wiregroups" << std::endl;
+
+  void CSCRecHit2D::print() const {
+    std::cout << "CSCRecHit in CSC Detector: " << cscDetId() << std::endl;
+    std::cout << "  local x = " << localPosition().x() << " +/- " << sqrt(localPositionError().xx())
+              << " y = " << localPosition().y() << " +/- " << sqrt(localPositionError().yy()) << std::endl;
+
+    std::cout << " tpeak " << theTpeak << " psoInStrip " << thePositionWithinStrip << " errorinstrip "
+              << theErrorWithinStrip << " "
+              << " qual " << theQuality << " wiretime " << theScaledWireTime << " tbs " << theBadStrip << " bwg "
+              << theBadWireGroup << std::endl;
+
+    std::cout << "  Channels: ";
+    for (unsigned int i = 0; i < nStrips(); i++) {
+      std::cout << std::dec << channels(i) << " "
+                << " ("
+                << "HEX: " << std::hex << channels(i) << ")"
+                << " ";
+    }
+    std::cout << std::endl;
+
+    /// L1A
+    std::cout << "  L1APhase: ";
+    for (int i = 0; i < (int)nStrips(); i++) {
+      std::cout << "|";
+      for (int k = 0; k < 8; k++) {
+        std::cout << ((channelsl1a(i) >> (15 - k)) & 0x1) << " ";
+      }
+      std::cout << "| ";
+    }
+    std::cout << std::endl;
+
+    std::cout << "nWireGroups " << (int)nWireGroups() << " central wire " << hitWire_ << std::endl;
   }
-  return os;
-}
+
+  std::ostream& operator<<(std::ostream& os, const CSCRecHit2D& rh) {
+    os << "CSCRecHit2D: "
+       << "local x: " << rh.localPosition().x() << " +/- " << sqrt(rh.localPositionError().xx())
+       << " y: " << rh.localPosition().y() << " +/- " << sqrt(rh.localPositionError().yy())
+       << " in strip X: " << rh.positionWithinStrip() << " +/- " << rh.errorWithinStrip()
+       << " quality: " << rh.quality() << " tpeak: " << rh.tpeak() << " wireTime: " << rh.wireTime() << std::endl;
+    os << "strips: ";
+    for (size_t iS = 0; iS < rh.nStrips(); ++iS) {
+      os << rh.channels(iS) << "  ";
+    }
+    int nwgs = rh.nWireGroups();
+    if (nwgs == 1) {
+      os << "central wire: " << rh.hitWire() << " of " << nwgs << " wiregroup" << std::endl;
+    } else {
+      os << "central wire: " << rh.hitWire() << " of " << nwgs << " wiregroups" << std::endl;
+    }
+    return os;
+  }
+
+}  // namespace io_v1

--- a/DataFormats/CSCRecHit/src/CSCSegment.cc
+++ b/DataFormats/CSCRecHit/src/CSCSegment.cc
@@ -6,187 +6,191 @@
 #include <DataFormats/CSCRecHit/interface/CSCSegment.h>
 #include <iostream>
 
-namespace {
-  // Get CSCDetId from one of the rechits, but then remove the layer part so it's a _chamber_ id
-  inline DetId buildDetId(CSCDetId id) { return CSCDetId(id.endcap(), id.station(), id.ring(), id.chamber(), 0); }
+namespace io_v1 {
 
-}  // namespace
+  namespace {
+    // Get CSCDetId from one of the rechits, but then remove the layer part so it's a _chamber_ id
+    inline DetId buildDetId(CSCDetId id) { return CSCDetId(id.endcap(), id.station(), id.ring(), id.chamber(), 0); }
 
-CSCSegment::CSCSegment(const std::vector<const CSCRecHit2D*>& proto_segment,
-                       LocalPoint origin,
-                       LocalVector direction,
-                       const AlgebraicSymMatrix& errors,
-                       double chi2)
-    : RecSegment(buildDetId(proto_segment.front()->cscDetId())),
-      theOrigin(origin),
-      theLocalDirection(direction),
-      theCovMatrix(errors),
-      theChi2(chi2),
-      aME11a_duplicate(false) {
-  for (unsigned int i = 0; i < proto_segment.size(); ++i)
-    theCSCRecHits.push_back(*proto_segment[i]);
-}
+  }  // namespace
 
-CSCSegment::~CSCSegment() {}
-
-std::vector<const TrackingRecHit*> CSCSegment::recHits() const {
-  std::vector<const TrackingRecHit*> pointersOfRecHits;
-  for (std::vector<CSCRecHit2D>::const_iterator irh = theCSCRecHits.begin(); irh != theCSCRecHits.end(); ++irh) {
-    pointersOfRecHits.push_back(&(*irh));
+  CSCSegment::CSCSegment(const std::vector<const CSCRecHit2D*>& proto_segment,
+                         LocalPoint origin,
+                         LocalVector direction,
+                         const AlgebraicSymMatrix& errors,
+                         double chi2)
+      : RecSegment(buildDetId(proto_segment.front()->cscDetId())),
+        theOrigin(origin),
+        theLocalDirection(direction),
+        theCovMatrix(errors),
+        theChi2(chi2),
+        aME11a_duplicate(false) {
+    for (unsigned int i = 0; i < proto_segment.size(); ++i)
+      theCSCRecHits.push_back(*proto_segment[i]);
   }
-  return pointersOfRecHits;
-}
 
-std::vector<TrackingRecHit*> CSCSegment::recHits() {
-  std::vector<TrackingRecHit*> pointersOfRecHits;
-  for (std::vector<CSCRecHit2D>::iterator irh = theCSCRecHits.begin(); irh != theCSCRecHits.end(); ++irh) {
-    pointersOfRecHits.push_back(&(*irh));
+  CSCSegment::~CSCSegment() {}
+
+  std::vector<const TrackingRecHit*> CSCSegment::recHits() const {
+    std::vector<const TrackingRecHit*> pointersOfRecHits;
+    for (std::vector<CSCRecHit2D>::const_iterator irh = theCSCRecHits.begin(); irh != theCSCRecHits.end(); ++irh) {
+      pointersOfRecHits.push_back(&(*irh));
+    }
+    return pointersOfRecHits;
   }
-  return pointersOfRecHits;
-}
 
-LocalError CSCSegment::localPositionError() const {
-  return LocalError(theCovMatrix[2][2], theCovMatrix[2][3], theCovMatrix[3][3]);
-}
-
-LocalError CSCSegment::localDirectionError() const {
-  return LocalError(theCovMatrix[0][0], theCovMatrix[0][1], theCovMatrix[1][1]);
-}
-
-AlgebraicVector CSCSegment::parameters() const {
-  // For consistency with DT and what we require for the TrackingRecHit interface,
-  // the order of the parameters in the returned vector should be (dx/dz, dy/dz, x, z)
-
-  AlgebraicVector result(4);
-
-  result[0] = theLocalDirection.x() / theLocalDirection.z();
-  result[1] = theLocalDirection.y() / theLocalDirection.z();
-  result[2] = theOrigin.x();
-  result[3] = theOrigin.y();
-
-  return result;
-}
-
-AlgebraicMatrix createStaticMatrix() {
-  AlgebraicMatrix m(4, 5, 0);
-  m[0][1] = 1;
-  m[1][2] = 1;
-  m[2][3] = 1;
-  m[3][4] = 1;
-  return m;
-}
-
-static const AlgebraicMatrix theProjectionMatrix = createStaticMatrix();
-
-AlgebraicMatrix CSCSegment::projectionMatrix() const { return theProjectionMatrix; }
-
-void CSCSegment::setDuplicateSegments(std::vector<CSCSegment*>& duplicates) {
-  theDuplicateSegments.clear();
-  for (unsigned int i = 0; i < duplicates.size(); ++i) {
-    theDuplicateSegments.push_back(*duplicates[i]);
-    //avoid copying duplicates of duplicates of duplicates...
-    theDuplicateSegments.back().theDuplicateSegments.resize(0);
+  std::vector<TrackingRecHit*> CSCSegment::recHits() {
+    std::vector<TrackingRecHit*> pointersOfRecHits;
+    for (std::vector<CSCRecHit2D>::iterator irh = theCSCRecHits.begin(); irh != theCSCRecHits.end(); ++irh) {
+      pointersOfRecHits.push_back(&(*irh));
+    }
+    return pointersOfRecHits;
   }
-}
 
-bool CSCSegment::testSharesAllInSpecificRecHits(const std::vector<CSCRecHit2D>& specificRecHits_1,
-                                                const std::vector<CSCRecHit2D>& specificRecHits_2,
-                                                CSCRecHit2D::SharedInputType sharesInput) const {
-  const std::vector<CSCRecHit2D>* rhContainer_1 = &specificRecHits_1;
-  const std::vector<CSCRecHit2D>* rhContainer_2 = &specificRecHits_2;
-  if (specificRecHits_1.size() > specificRecHits_2.size()) {
-    rhContainer_2 = &specificRecHits_1;
-    rhContainer_1 = &specificRecHits_2;
+  LocalError CSCSegment::localPositionError() const {
+    return LocalError(theCovMatrix[2][2], theCovMatrix[2][3], theCovMatrix[3][3]);
   }
-  //
-  bool shareConditionPassed = true;
-  for (std::vector<CSCRecHit2D>::const_iterator itRH = rhContainer_1->begin(); itRH != rhContainer_1->end(); ++itRH) {
-    const CSCRecHit2D* firstRecHit = &(*itRH);
-    bool sharedHit = false;
-    for (std::vector<CSCRecHit2D>::const_iterator itRH2 = rhContainer_2->begin(); itRH2 != rhContainer_2->end();
-         ++itRH2) {
-      if (itRH2->sharesInput(firstRecHit, sharesInput)) {
-        sharedHit = true;
+
+  LocalError CSCSegment::localDirectionError() const {
+    return LocalError(theCovMatrix[0][0], theCovMatrix[0][1], theCovMatrix[1][1]);
+  }
+
+  AlgebraicVector CSCSegment::parameters() const {
+    // For consistency with DT and what we require for the TrackingRecHit interface,
+    // the order of the parameters in the returned vector should be (dx/dz, dy/dz, x, z)
+
+    AlgebraicVector result(4);
+
+    result[0] = theLocalDirection.x() / theLocalDirection.z();
+    result[1] = theLocalDirection.y() / theLocalDirection.z();
+    result[2] = theOrigin.x();
+    result[3] = theOrigin.y();
+
+    return result;
+  }
+
+  AlgebraicMatrix createStaticMatrix() {
+    AlgebraicMatrix m(4, 5, 0);
+    m[0][1] = 1;
+    m[1][2] = 1;
+    m[2][3] = 1;
+    m[3][4] = 1;
+    return m;
+  }
+
+  static const AlgebraicMatrix theProjectionMatrix = createStaticMatrix();
+
+  AlgebraicMatrix CSCSegment::projectionMatrix() const { return theProjectionMatrix; }
+
+  void CSCSegment::setDuplicateSegments(std::vector<CSCSegment*>& duplicates) {
+    theDuplicateSegments.clear();
+    for (unsigned int i = 0; i < duplicates.size(); ++i) {
+      theDuplicateSegments.push_back(*duplicates[i]);
+      //avoid copying duplicates of duplicates of duplicates...
+      theDuplicateSegments.back().theDuplicateSegments.resize(0);
+    }
+  }
+
+  bool CSCSegment::testSharesAllInSpecificRecHits(const std::vector<CSCRecHit2D>& specificRecHits_1,
+                                                  const std::vector<CSCRecHit2D>& specificRecHits_2,
+                                                  CSCRecHit2D::SharedInputType sharesInput) const {
+    const std::vector<CSCRecHit2D>* rhContainer_1 = &specificRecHits_1;
+    const std::vector<CSCRecHit2D>* rhContainer_2 = &specificRecHits_2;
+    if (specificRecHits_1.size() > specificRecHits_2.size()) {
+      rhContainer_2 = &specificRecHits_1;
+      rhContainer_1 = &specificRecHits_2;
+    }
+    //
+    bool shareConditionPassed = true;
+    for (std::vector<CSCRecHit2D>::const_iterator itRH = rhContainer_1->begin(); itRH != rhContainer_1->end(); ++itRH) {
+      const CSCRecHit2D* firstRecHit = &(*itRH);
+      bool sharedHit = false;
+      for (std::vector<CSCRecHit2D>::const_iterator itRH2 = rhContainer_2->begin(); itRH2 != rhContainer_2->end();
+           ++itRH2) {
+        if (itRH2->sharesInput(firstRecHit, sharesInput)) {
+          sharedHit = true;
+          break;
+        }
+      }
+      if (!sharedHit) {
+        shareConditionPassed = false;
         break;
       }
     }
-    if (!sharedHit) {
-      shareConditionPassed = false;
-      break;
+    return shareConditionPassed;
+  }
+
+  //bool CSCSegment::sharesRecHits(CSCSegment  & anotherSegment, CSCRecHit2D::SharedInputType sharesInput){
+  // 2 tracks through a chamber leave 4 rechits per layer (2 strips x 2 wire groups)
+  // this function finds segments sharing wires or strips (first the rechits by sharesInput() )
+  // there could probably be more complicated cases with partial sharing (but this needs studies)
+  //
+  //return testSharesAllInSpecificRecHits( theCSCRecHits , anotherSegment.specificRecHits(), sharesInput);
+  //}
+
+  bool CSCSegment::sharesRecHits(const CSCSegment& anotherSegment, CSCRecHit2D::SharedInputType sharesInput) const {
+    return testSharesAllInSpecificRecHits(theCSCRecHits, anotherSegment.specificRecHits(), sharesInput);
+  }
+
+  //
+  bool CSCSegment::sharesRecHits(const CSCSegment& anotherSegment) const {
+    if (testSharesAllInSpecificRecHits(theCSCRecHits, anotherSegment.specificRecHits(), CSCRecHit2D::someWires) &&
+        testSharesAllInSpecificRecHits(theCSCRecHits, anotherSegment.specificRecHits(), CSCRecHit2D::someStrips)) {
+      return true;
+    } else {
+      return false;
     }
   }
-  return shareConditionPassed;
-}
+  //
 
-//bool CSCSegment::sharesRecHits(CSCSegment  & anotherSegment, CSCRecHit2D::SharedInputType sharesInput){
-// 2 tracks through a chamber leave 4 rechits per layer (2 strips x 2 wire groups)
-// this function finds segments sharing wires or strips (first the rechits by sharesInput() )
-// there could probably be more complicated cases with partial sharing (but this needs studies)
-//
-//return testSharesAllInSpecificRecHits( theCSCRecHits , anotherSegment.specificRecHits(), sharesInput);
-//}
+  float CSCSegment::time() const {
+    float averageTime = 0;
+    std::vector<float> wireTimes;
+    for (std::vector<CSCRecHit2D>::const_iterator itRH = theCSCRecHits.begin(); itRH != theCSCRecHits.end(); ++itRH) {
+      const CSCRecHit2D* recHit = &(*itRH);
+      averageTime += recHit->tpeak();
+      averageTime += recHit->wireTime();
+      wireTimes.push_back(recHit->wireTime());
+    }
+    averageTime = averageTime / (2 * theCSCRecHits.size());
 
-bool CSCSegment::sharesRecHits(const CSCSegment& anotherSegment, CSCRecHit2D::SharedInputType sharesInput) const {
-  return testSharesAllInSpecificRecHits(theCSCRecHits, anotherSegment.specificRecHits(), sharesInput);
-}
-
-//
-bool CSCSegment::sharesRecHits(const CSCSegment& anotherSegment) const {
-  if (testSharesAllInSpecificRecHits(theCSCRecHits, anotherSegment.specificRecHits(), CSCRecHit2D::someWires) &&
-      testSharesAllInSpecificRecHits(theCSCRecHits, anotherSegment.specificRecHits(), CSCRecHit2D::someStrips)) {
-    return true;
-  } else {
-    return false;
-  }
-}
-//
-
-float CSCSegment::time() const {
-  float averageTime = 0;
-  std::vector<float> wireTimes;
-  for (std::vector<CSCRecHit2D>::const_iterator itRH = theCSCRecHits.begin(); itRH != theCSCRecHits.end(); ++itRH) {
-    const CSCRecHit2D* recHit = &(*itRH);
-    averageTime += recHit->tpeak();
-    averageTime += recHit->wireTime();
-    wireTimes.push_back(recHit->wireTime());
-  }
-  averageTime = averageTime / (2 * theCSCRecHits.size());
-
-  //The wire times have a long tail that has to be pruned.  The strip times (tpeak) are fine
-  bool modified = true;
-  while (modified) {
-    modified = false;
-    double maxDiff = -1;
-    std::vector<float>::iterator maxHit;
-    for (std::vector<float>::iterator itWT = wireTimes.begin(); itWT != wireTimes.end(); ++itWT) {
-      float diff = fabs(*itWT - averageTime);
-      if (diff > maxDiff) {
-        maxDiff = diff;
-        maxHit = itWT;
+    //The wire times have a long tail that has to be pruned.  The strip times (tpeak) are fine
+    bool modified = true;
+    while (modified) {
+      modified = false;
+      double maxDiff = -1;
+      std::vector<float>::iterator maxHit;
+      for (std::vector<float>::iterator itWT = wireTimes.begin(); itWT != wireTimes.end(); ++itWT) {
+        float diff = fabs(*itWT - averageTime);
+        if (diff > maxDiff) {
+          maxDiff = diff;
+          maxHit = itWT;
+        }
+      }
+      if (maxDiff > 26) {
+        int N = theCSCRecHits.size() + wireTimes.size();
+        averageTime = (averageTime * N - (*maxHit)) / (N - 1);
+        wireTimes.erase(maxHit);
+        modified = true;
       }
     }
-    if (maxDiff > 26) {
-      int N = theCSCRecHits.size() + wireTimes.size();
-      averageTime = (averageTime * N - (*maxHit)) / (N - 1);
-      wireTimes.erase(maxHit);
-      modified = true;
-    }
+    return averageTime;
   }
-  return averageTime;
-}
 
-//
-void CSCSegment::print() const { std::cout << *this << std::endl; }
+  //
+  void CSCSegment::print() const { std::cout << *this << std::endl; }
 
-std::ostream& operator<<(std::ostream& os, const CSCSegment& seg) {
-  os << "CSCSegment: local pos = " << seg.localPosition() << " posErr = (" << sqrt(seg.localPositionError().xx()) << ","
-     << sqrt(seg.localPositionError().yy()) << "0,)\n"
-     << "            dir = " << seg.localDirection() << " dirErr = (" << sqrt(seg.localDirectionError().xx()) << ","
-     << sqrt(seg.localDirectionError().yy()) << "0,)\n"
-     << "            chi2/ndf = " << seg.chi2() / double(seg.degreesOfFreedom())
-     << " #rechits = " << seg.specificRecHits().size() << " ME1/1a duplicates : " << seg.duplicateSegments().size();
-  return os;
-}
+  std::ostream& operator<<(std::ostream& os, const CSCSegment& seg) {
+    os << "CSCSegment: local pos = " << seg.localPosition() << " posErr = (" << sqrt(seg.localPositionError().xx())
+       << "," << sqrt(seg.localPositionError().yy()) << "0,)\n"
+       << "            dir = " << seg.localDirection() << " dirErr = (" << sqrt(seg.localDirectionError().xx()) << ","
+       << sqrt(seg.localDirectionError().yy()) << "0,)\n"
+       << "            chi2/ndf = " << seg.chi2() / double(seg.degreesOfFreedom())
+       << " #rechits = " << seg.specificRecHits().size() << " ME1/1a duplicates : " << seg.duplicateSegments().size();
+    return os;
+  }
+
+}  // namespace io_v1
 
 /*
 const CSCChamber* CSCSegment::chamber() const { return theChamber; }

--- a/DataFormats/CSCRecHit/src/classes_def.xml
+++ b/DataFormats/CSCRecHit/src/classes_def.xml
@@ -1,42 +1,37 @@
 <lcgdict>
 <selection>
-  <class name="CSCRecHit2D" ClassVersion="14">
-   <version ClassVersion="14" checksum="1191763325"/>
-   <version ClassVersion="11" checksum="2464154506"/>
-   <version ClassVersion="10" checksum="2273322213"/>
-  <version ClassVersion="12" checksum="4199658304"/>
-  <version ClassVersion="13" checksum="1105334358"/>
+  <class name="io_v1::CSCRecHit2D" ClassVersion="3">
+   <version ClassVersion="3" checksum="703422205"/>
   </class>
-  <class name="std::vector<CSCRecHit2D>"/>
-  <class name="std::vector<CSCRecHit2D*>"/>
+  <class name="std::vector<io_v1::CSCRecHit2D>"/>
+  <class name="std::vector<io_v1::CSCRecHit2D*>"/>
   <class name="std::map<CSCDetId,std::pair<unsigned int,unsigned int> >"/>
   <class name="std::map<CSCDetId,std::pair<unsigned long,unsigned long> >"/>
   <class name="std::pair<CSCDetId,std::pair<unsigned int,unsigned int> >"/>  <!-- Root6 -->
   <class name="std::pair<CSCDetId,std::pair<unsigned long,unsigned long> >"/><!-- Root6 -->
-  <class name="edm::OwnVector<CSCRecHit2D,edm::ClonePolicy<CSCRecHit2D> >"  rntupleStreamerMode="true" />
-  <class name="edm::ClonePolicy<CSCRecHit2D>"/> <!-- Root6 -->
-  <class name="edm::RangeMap<CSCDetId,edm::OwnVector<CSCRecHit2D,edm::ClonePolicy<CSCRecHit2D> >,edm::ClonePolicy<CSCRecHit2D> >"/>
-  <class name="edm::Wrapper<edm::RangeMap<CSCDetId,edm::OwnVector<CSCRecHit2D,edm::ClonePolicy<CSCRecHit2D> >,edm::ClonePolicy<CSCRecHit2D> > >"/>
+  <class name="edm::OwnVector<io_v1::CSCRecHit2D,edm::ClonePolicy<io_v1::CSCRecHit2D> >"  rntupleStreamerMode="true" />
+  <class name="edm::ClonePolicy<io_v1::CSCRecHit2D>"/> <!-- Root6 -->
+  <class name="edm::RangeMap<CSCDetId,edm::OwnVector<io_v1::CSCRecHit2D,edm::ClonePolicy<io_v1::CSCRecHit2D> >,edm::ClonePolicy<io_v1::CSCRecHit2D> >"/>
+  <class name="edm::Wrapper<edm::RangeMap<CSCDetId,edm::OwnVector<io_v1::CSCRecHit2D,edm::ClonePolicy<io_v1::CSCRecHit2D> >,edm::ClonePolicy<io_v1::CSCRecHit2D> > >"/>
 
-  <class name="std::vector<CSCSegment>"/>
-  <class name="std::vector<CSCSegment*>"/>
-  <class name="CSCSegment" ClassVersion="11">
-   <version ClassVersion="11" checksum="160361831"/>
-   <version ClassVersion="10" checksum="3002485899"/>
+  <class name="std::vector<io_v1::CSCSegment>"/>
+  <class name="std::vector<io_v1::CSCSegment*>"/>
+  <class name="io_v1::CSCSegment" ClassVersion="3">
+   <version ClassVersion="3" checksum="985709"/>
   </class>
-  <class name="edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >"  rntupleStreamerMode="true" />
-  <class name="edm::RangeMap<CSCDetId,edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >,edm::ClonePolicy<CSCSegment> >"/>
-  <class name="edm::ClonePolicy<CSCSegment>"/> <!-- Root6 -->
-  <class name="edm::Wrapper<edm::RangeMap<CSCDetId,edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >,edm::ClonePolicy<CSCSegment> > >"/>
+  <class name="edm::OwnVector<io_v1::CSCSegment,edm::ClonePolicy<io_v1::CSCSegment> >"  rntupleStreamerMode="true" />
+  <class name="edm::RangeMap<CSCDetId,edm::OwnVector<io_v1::CSCSegment,edm::ClonePolicy<io_v1::CSCSegment> >,edm::ClonePolicy<io_v1::CSCSegment> >"/>
+  <class name="edm::ClonePolicy<io_v1::CSCSegment>"/> <!-- Root6 -->
+  <class name="edm::Wrapper<edm::RangeMap<CSCDetId,edm::OwnVector<io_v1::CSCSegment,edm::ClonePolicy<io_v1::CSCSegment> >,edm::ClonePolicy<io_v1::CSCSegment> > >"/>
   <class name="CSCSegmentRef"/>
 </selection>
 
 <exclusion>
-  <class name="edm::OwnVector<CSCRecHit2D, edm::ClonePolicy<CSCRecHit2D> >">
+  <class name="edm::OwnVector<io_v1::CSCRecHit2D, edm::ClonePolicy<io_v1::CSCRecHit2D> >">
     <method name="sort"/>
   </class>
 
-  <class name="edm::OwnVector<CSCSegment, edm::ClonePolicy<CSCSegment> >">
+  <class name="edm::OwnVector<io_v1::CSCSegment, edm::ClonePolicy<io_v1::CSCSegment> >">
     <method name="sort"/>
   </class>
 </exclusion>

--- a/DataFormats/GEMDigi/interface/GEMAMC13Status.h
+++ b/DataFormats/GEMDigi/interface/GEMAMC13Status.h
@@ -7,66 +7,71 @@
 #include <bitset>
 #include <ostream>
 
-class GEMAMC13Status {
-public:
-  union Errors {
-    uint8_t codes;
-    struct {
-      uint8_t InValidSize : 1;
-      uint8_t failTrailerCheck : 1;
-      uint8_t failFragmentLength : 1;
-      uint8_t failTrailerMatch : 1;
-      uint8_t moreTrailers : 1;
-      uint8_t crcModified : 1;
-      uint8_t slinkError : 1;
-      uint8_t wrongFedId : 1;
-    };
-  };
-  union Warnings {
-    uint8_t wcodes;
-    struct {
-      uint8_t InValidAMC : 1;  // error for AMC but cant display when not found.
-    };
-  };
+namespace io_v1 {
 
-  GEMAMC13Status() {}
-  GEMAMC13Status(const FEDRawData& fedData) {
-    Errors error{0};
-    if ((fedData.size() / sizeof(uint64_t)) < 5) {
-      error.InValidSize = 1;
-    } else {
-      FEDTrailer trailer(fedData.data() + fedData.size() - FEDTrailer::length);
-      error.failTrailerCheck = !trailer.check();
-      error.failFragmentLength = (trailer.fragmentLength() * sizeof(uint64_t) != fedData.size());
-      error.moreTrailers = trailer.moreTrailers();
-      error.crcModified = trailer.crcModified();
-      error.slinkError = trailer.slinkError();
-      error.wrongFedId = trailer.wrongFedId();
+  class GEMAMC13Status {
+  public:
+    union Errors {
+      uint8_t codes;
+      struct {
+        uint8_t InValidSize : 1;
+        uint8_t failTrailerCheck : 1;
+        uint8_t failFragmentLength : 1;
+        uint8_t failTrailerMatch : 1;
+        uint8_t moreTrailers : 1;
+        uint8_t crcModified : 1;
+        uint8_t slinkError : 1;
+        uint8_t wrongFedId : 1;
+      };
+    };
+    union Warnings {
+      uint8_t wcodes;
+      struct {
+        uint8_t InValidAMC : 1;  // error for AMC but cant display when not found.
+      };
+    };
+
+    GEMAMC13Status() {}
+    GEMAMC13Status(const FEDRawData& fedData) {
+      Errors error{0};
+      if ((fedData.size() / sizeof(uint64_t)) < 5) {
+        error.InValidSize = 1;
+      } else {
+        FEDTrailer trailer(fedData.data() + fedData.size() - FEDTrailer::length);
+        error.failTrailerCheck = !trailer.check();
+        error.failFragmentLength = (trailer.fragmentLength() * sizeof(uint64_t) != fedData.size());
+        error.moreTrailers = trailer.moreTrailers();
+        error.crcModified = trailer.crcModified();
+        error.slinkError = trailer.slinkError();
+        error.wrongFedId = trailer.wrongFedId();
+      }
+      errors_ = error.codes;
+
+      Warnings warn{0};
+      warnings_ = warn.wcodes;
     }
-    errors_ = error.codes;
+    void inValidAMC() {
+      Warnings warn{warnings_};
+      warn.InValidAMC = 1;
+      warnings_ = warn.wcodes;
+    }
 
-    Warnings warn{0};
-    warnings_ = warn.wcodes;
+    bool isBad() const { return errors_ != 0; }
+    uint8_t errors() const { return errors_; }
+    uint8_t warnings() const { return warnings_; }
+
+  private:
+    uint8_t errors_;
+    uint8_t warnings_;
+  };
+
+  inline std::ostream& operator<<(std::ostream& out, const GEMAMC13Status& status) {
+    out << "GEMAMC13Status errors " << std::bitset<8>(status.errors()) << " warnings "
+        << std::bitset<8>(status.warnings());
+    return out;
   }
-  void inValidAMC() {
-    Warnings warn{warnings_};
-    warn.InValidAMC = 1;
-    warnings_ = warn.wcodes;
-  }
 
-  bool isBad() const { return errors_ != 0; }
-  uint8_t errors() const { return errors_; }
-  uint8_t warnings() const { return warnings_; }
-
-private:
-  uint8_t errors_;
-  uint8_t warnings_;
-};
-
-inline std::ostream& operator<<(std::ostream& out, const GEMAMC13Status& status) {
-  out << "GEMAMC13Status errors " << std::bitset<8>(status.errors()) << " warnings "
-      << std::bitset<8>(status.warnings());
-  return out;
-}
+}  // namespace io_v1
+using GEMAMC13Status = io_v1::GEMAMC13Status;
 
 #endif

--- a/DataFormats/GEMDigi/interface/GEMAMCStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMAMCStatus.h
@@ -5,85 +5,90 @@
 #include <bitset>
 #include <ostream>
 
-class GEMAMCStatus {
-public:
-  union Errors {
-    uint16_t ecodes;
-    struct {
-      uint16_t badEC : 1;  // event counter
-      uint16_t badBC : 1;  // bunch crossing
-      uint16_t badOC : 1;  // orbit number
-      uint16_t badRunType : 1;
-      uint16_t badCRC : 1;
-      uint16_t MMCMlocked : 1;
-      uint16_t DAQclocklocked : 1;
-      uint16_t DAQnotReday : 1;
-      uint16_t BC0locked : 1;
-      uint16_t badFEDId : 1;
-      uint16_t L1AFull : 1;
+namespace io_v1 {
+
+  class GEMAMCStatus {
+  public:
+    union Errors {
+      uint16_t ecodes;
+      struct {
+        uint16_t badEC : 1;  // event counter
+        uint16_t badBC : 1;  // bunch crossing
+        uint16_t badOC : 1;  // orbit number
+        uint16_t badRunType : 1;
+        uint16_t badCRC : 1;
+        uint16_t MMCMlocked : 1;
+        uint16_t DAQclocklocked : 1;
+        uint16_t DAQnotReday : 1;
+        uint16_t BC0locked : 1;
+        uint16_t badFEDId : 1;
+        uint16_t L1AFull : 1;
+      };
     };
-  };
-  union Warnings {
-    uint8_t wcodes;
-    struct {
-      uint8_t InValidOH : 1;
-      uint8_t backPressure : 1;
-      uint8_t L1ANearFull : 1;
+    union Warnings {
+      uint8_t wcodes;
+      struct {
+        uint8_t InValidOH : 1;
+        uint8_t backPressure : 1;
+        uint8_t L1ANearFull : 1;
+      };
     };
+
+    GEMAMCStatus() {}
+    GEMAMCStatus(const GEMAMC13* amc13, const GEMAMC& amc) {
+      amcNum_ = amc.amcNum();
+      Errors error{0};
+      error.badEC = (amc13->lv1Id() != amc.lv1Id());
+      // Last BC in AMC13 is different to TCDS, AMC, and VFAT
+      error.badBC = !((amc13->bunchCrossing() == amc.bunchCrossing()) ||
+                      (amc13->bunchCrossing() == 0 && amc.bunchCrossing() == GEMAMC13::lastBC));
+      error.badRunType = amc.runType() != 0x1;
+      // Last OC in AMC13 is different to TCDS, AMC, and VFAT
+      if (amc.formatVer() == 0)
+        error.badOC =
+            !((uint16_t(amc13->orbitNumber()) == amc.orbitNumber()) ||
+              (amc13->bunchCrossing() == 0 && uint16_t(amc.orbitNumber() + 1) == uint16_t(amc13->orbitNumber())));
+      else
+        error.badOC = !((amc13->orbitNumber() == (amc.orbitNumber() + 1)) ||
+                        (amc13->bunchCrossing() == 0 && amc13->orbitNumber() == (amc.orbitNumber() + 2)));
+      error.MMCMlocked = !amc.mmcmLocked();
+      error.DAQclocklocked = !amc.daqClockLocked();
+      error.DAQnotReday = !amc.daqReady();
+      error.BC0locked = !amc.bc0locked();
+      error.badFEDId = (amc13->sourceId() != amc.softSrcId() and amc.formatVer() != 0);
+      error.L1AFull = (amc.l1aF() and amc.formatVer() != 0);
+      errors_ = error.ecodes;
+
+      Warnings warn{0};
+      warn.backPressure = amc.backPressure();
+      warn.L1ANearFull = (amc.l1aNF() and amc.formatVer() != 0);
+      warnings_ = warn.wcodes;
+    }
+
+    void inValidOH() {
+      Warnings warn{warnings_};
+      warn.InValidOH = 1;
+      warnings_ = warn.wcodes;
+    }
+
+    uint8_t amcNumber() const { return amcNum_; };
+    bool isBad() const { return errors_ != 0; }
+    uint16_t errors() const { return errors_; }
+    uint8_t warnings() const { return warnings_; }
+
+  private:
+    uint8_t amcNum_;
+    uint16_t errors_;
+    uint8_t warnings_;
   };
 
-  GEMAMCStatus() {}
-  GEMAMCStatus(const GEMAMC13* amc13, const GEMAMC& amc) {
-    amcNum_ = amc.amcNum();
-    Errors error{0};
-    error.badEC = (amc13->lv1Id() != amc.lv1Id());
-    // Last BC in AMC13 is different to TCDS, AMC, and VFAT
-    error.badBC = !((amc13->bunchCrossing() == amc.bunchCrossing()) ||
-                    (amc13->bunchCrossing() == 0 && amc.bunchCrossing() == GEMAMC13::lastBC));
-    error.badRunType = amc.runType() != 0x1;
-    // Last OC in AMC13 is different to TCDS, AMC, and VFAT
-    if (amc.formatVer() == 0)
-      error.badOC =
-          !((uint16_t(amc13->orbitNumber()) == amc.orbitNumber()) ||
-            (amc13->bunchCrossing() == 0 && uint16_t(amc.orbitNumber() + 1) == uint16_t(amc13->orbitNumber())));
-    else
-      error.badOC = !((amc13->orbitNumber() == (amc.orbitNumber() + 1)) ||
-                      (amc13->bunchCrossing() == 0 && amc13->orbitNumber() == (amc.orbitNumber() + 2)));
-    error.MMCMlocked = !amc.mmcmLocked();
-    error.DAQclocklocked = !amc.daqClockLocked();
-    error.DAQnotReday = !amc.daqReady();
-    error.BC0locked = !amc.bc0locked();
-    error.badFEDId = (amc13->sourceId() != amc.softSrcId() and amc.formatVer() != 0);
-    error.L1AFull = (amc.l1aF() and amc.formatVer() != 0);
-    errors_ = error.ecodes;
-
-    Warnings warn{0};
-    warn.backPressure = amc.backPressure();
-    warn.L1ANearFull = (amc.l1aNF() and amc.formatVer() != 0);
-    warnings_ = warn.wcodes;
+  inline std::ostream& operator<<(std::ostream& out, const GEMAMCStatus& status) {
+    out << "GEMAMCStatus errors " << std::bitset<16>(status.errors()) << " warnings "
+        << std::bitset<8>(status.warnings());
+    return out;
   }
 
-  void inValidOH() {
-    Warnings warn{warnings_};
-    warn.InValidOH = 1;
-    warnings_ = warn.wcodes;
-  }
-
-  uint8_t amcNumber() const { return amcNum_; };
-  bool isBad() const { return errors_ != 0; }
-  uint16_t errors() const { return errors_; }
-  uint8_t warnings() const { return warnings_; }
-
-private:
-  uint8_t amcNum_;
-  uint16_t errors_;
-  uint8_t warnings_;
-};
-
-inline std::ostream& operator<<(std::ostream& out, const GEMAMCStatus& status) {
-  out << "GEMAMCStatus errors " << std::bitset<16>(status.errors()) << " warnings "
-      << std::bitset<8>(status.warnings());
-  return out;
-}
+}  // namespace io_v1
+using GEMAMCStatus = io_v1::GEMAMCStatus;
 
 #endif

--- a/DataFormats/GEMDigi/interface/GEMCoPadDigi.h
+++ b/DataFormats/GEMDigi/interface/GEMCoPadDigi.h
@@ -13,30 +13,35 @@
 #include <cstdint>
 #include <iosfwd>
 
-class GEMCoPadDigi {
-public:
-  explicit GEMCoPadDigi(uint8_t roll, GEMPadDigi pad1, GEMPadDigi pad2);
-  GEMCoPadDigi();
+namespace io_v1 {
 
-  bool operator==(const GEMCoPadDigi& digi) const;
-  bool operator!=(const GEMCoPadDigi& digi) const;
-  bool isValid() const;
+  class GEMCoPadDigi {
+  public:
+    explicit GEMCoPadDigi(uint8_t roll, GEMPadDigi pad1, GEMPadDigi pad2);
+    GEMCoPadDigi();
 
-  int roll() const { return roll_; }
-  int pad(int l) const;
-  int bx(int l) const;
+    bool operator==(const GEMCoPadDigi& digi) const;
+    bool operator!=(const GEMCoPadDigi& digi) const;
+    bool isValid() const;
 
-  GEMPadDigi first() const { return first_; }
-  GEMPadDigi second() const { return second_; }
+    int roll() const { return roll_; }
+    int pad(int l) const;
+    int bx(int l) const;
 
-  void print() const;
+    GEMPadDigi first() const { return first_; }
+    GEMPadDigi second() const { return second_; }
 
-private:
-  uint8_t roll_;
-  GEMPadDigi first_;
-  GEMPadDigi second_;
-};
+    void print() const;
 
-std::ostream& operator<<(std::ostream& o, const GEMCoPadDigi& digi);
+  private:
+    uint8_t roll_;
+    GEMPadDigi first_;
+    GEMPadDigi second_;
+  };
+
+  std::ostream& operator<<(std::ostream& o, const GEMCoPadDigi& digi);
+
+}  // namespace io_v1
+using GEMCoPadDigi = io_v1::GEMCoPadDigi;
 
 #endif

--- a/DataFormats/GEMDigi/interface/GEMDigi.h
+++ b/DataFormats/GEMDigi/interface/GEMDigi.h
@@ -12,27 +12,32 @@
 #include <cstdint>
 #include <iosfwd>
 
-class GEMDigi {
-public:
-  explicit GEMDigi(uint16_t strip, int16_t bx);
-  GEMDigi();
+namespace io_v1 {
 
-  bool operator==(const GEMDigi& digi) const;
-  bool operator!=(const GEMDigi& digi) const;
-  bool operator<(const GEMDigi& digi) const;
-  bool isValid() const;
+  class GEMDigi {
+  public:
+    explicit GEMDigi(uint16_t strip, int16_t bx);
+    GEMDigi();
 
-  // return the strip number. counts from 0.
-  uint16_t strip() const { return strip_; }
-  int16_t bx() const { return bx_; }
+    bool operator==(const GEMDigi& digi) const;
+    bool operator!=(const GEMDigi& digi) const;
+    bool operator<(const GEMDigi& digi) const;
+    bool isValid() const;
 
-  void print() const;
+    // return the strip number. counts from 0.
+    uint16_t strip() const { return strip_; }
+    int16_t bx() const { return bx_; }
 
-private:
-  uint16_t strip_;
-  int16_t bx_;
-};
+    void print() const;
 
-std::ostream& operator<<(std::ostream& o, const GEMDigi& digi);
+  private:
+    uint16_t strip_;
+    int16_t bx_;
+  };
+
+  std::ostream& operator<<(std::ostream& o, const GEMDigi& digi);
+
+}  // namespace io_v1
+using GEMDigi = io_v1::GEMDigi;
 
 #endif

--- a/DataFormats/GEMDigi/interface/GEMOHStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMOHStatus.h
@@ -4,94 +4,100 @@
 #include <bitset>
 #include <ostream>
 
-// GEM OptoHybrid status
-class GEMOHStatus {
-public:
-  union Errors {
-    uint16_t codes;
-    struct {
-      uint16_t EvtF : 1;      // Event FIFO full
-      uint16_t InF : 1;       // Input FIFO full
-      uint16_t L1aF : 1;      // L1A FIFO full
-      uint16_t EvtSzOFW : 1;  // Event size overflow
-      uint16_t Inv : 1;       // Invalid event
-      uint16_t OOScAvV : 1;   // Out of Sync (EC mismatch) AMC vs VFAT
-      uint16_t OOScVvV : 1;   // Out of Sync (EC mismatch) VFAT vs VFAT
-      uint16_t BxmAvV : 1;    // BX mismatch AMC vs VFAT
-      uint16_t BxmVvV : 1;    // 1st bit BX mismatch VFAT vs VFAT
-      uint16_t InUfw : 1;     // Input FIFO underflow
-      uint16_t badVFatCount : 1;
+namespace io_v1 {
+
+  // GEM OptoHybrid status
+  class GEMOHStatus {
+  public:
+    union Errors {
+      uint16_t codes;
+      struct {
+        uint16_t EvtF : 1;      // Event FIFO full
+        uint16_t InF : 1;       // Input FIFO full
+        uint16_t L1aF : 1;      // L1A FIFO full
+        uint16_t EvtSzOFW : 1;  // Event size overflow
+        uint16_t Inv : 1;       // Invalid event
+        uint16_t OOScAvV : 1;   // Out of Sync (EC mismatch) AMC vs VFAT
+        uint16_t OOScVvV : 1;   // Out of Sync (EC mismatch) VFAT vs VFAT
+        uint16_t BxmAvV : 1;    // BX mismatch AMC vs VFAT
+        uint16_t BxmVvV : 1;    // 1st bit BX mismatch VFAT vs VFAT
+        uint16_t InUfw : 1;     // Input FIFO underflow
+        uint16_t badVFatCount : 1;
+      };
     };
-  };
-  union Warnings {
-    uint8_t wcodes;
-    struct {
-      uint8_t EvtNF : 1;   // Event FIFO near full
-      uint8_t InNF : 1;    // Input FIFO near full
-      uint8_t L1aNF : 1;   // L1A FIFO near full
-      uint8_t EvtSzW : 1;  // Event size warning
-      uint8_t InValidVFAT : 1;
-      uint8_t missingVFAT : 1;
+    union Warnings {
+      uint8_t wcodes;
+      struct {
+        uint8_t EvtNF : 1;   // Event FIFO near full
+        uint8_t InNF : 1;    // Input FIFO near full
+        uint8_t L1aNF : 1;   // L1A FIFO near full
+        uint8_t EvtSzW : 1;  // Event size warning
+        uint8_t InValidVFAT : 1;
+        uint8_t missingVFAT : 1;
+      };
     };
+
+    GEMOHStatus() {}
+    GEMOHStatus(const GEMOptoHybrid& oh, int chamberType) : chamberType_(chamberType) {
+      Errors error{0};
+      error.EvtF = oh.evtF();
+      error.InF = oh.inF();
+      error.L1aF = (oh.l1aF() and (oh.version() == 0));
+      error.EvtSzOFW = oh.evtSzOFW();
+      error.Inv = oh.inv();
+      error.OOScAvV = oh.oOScAvV();
+      error.OOScVvV = oh.oOScVvV();
+      error.BxmAvV = oh.bxmAvV();
+      error.BxmVvV = oh.bxmVvV();
+      error.InUfw = oh.inUfw();
+      error.badVFatCount = oh.vfatWordCnt() != oh.vfatWordCntT();
+      errors_ = error.codes;
+
+      Warnings warn{0};
+      existVFATs_ = oh.existVFATs();
+      vfatMask_ = oh.vfatMask();
+      zsMask_ = oh.zsMask();
+      missingVFATs_ = (existVFATs_ ^ 0xffffff) & (vfatMask_ & (zsMask_ ^ 0xffffff));
+      warn.EvtNF = oh.evtNF();
+      warn.InNF = oh.inNF();
+      warn.L1aNF = (oh.l1aNF() and (oh.version() == 0));
+      warn.EvtSzW = oh.evtSzW();
+      warn.missingVFAT = (oh.version() != 0) and (missingVFATs_ != 0);
+      warnings_ = warn.wcodes;
+    }
+
+    void inValidVFAT() {
+      Warnings warn{warnings_};
+      warn.InValidVFAT = 1;
+      warnings_ = warn.wcodes;
+    }
+
+    bool isBad() const { return errors_ != 0; }
+    uint16_t errors() const { return errors_; }
+    uint8_t warnings() const { return warnings_; }
+    uint32_t missingVFATs() const { return missingVFATs_; }
+    uint32_t vfatMask() const { return vfatMask_; }
+    uint32_t zsMask() const { return zsMask_; }
+    uint32_t existVFATs() const { return existVFATs_; }
+    int chamberType() const { return chamberType_; }
+
+  private:
+    int chamberType_;
+    uint16_t errors_;
+    uint8_t warnings_;
+    uint32_t missingVFATs_;
+    uint32_t vfatMask_;
+    uint32_t zsMask_;
+    uint32_t existVFATs_;
   };
 
-  GEMOHStatus() {}
-  GEMOHStatus(const GEMOptoHybrid& oh, int chamberType) : chamberType_(chamberType) {
-    Errors error{0};
-    error.EvtF = oh.evtF();
-    error.InF = oh.inF();
-    error.L1aF = (oh.l1aF() and (oh.version() == 0));
-    error.EvtSzOFW = oh.evtSzOFW();
-    error.Inv = oh.inv();
-    error.OOScAvV = oh.oOScAvV();
-    error.OOScVvV = oh.oOScVvV();
-    error.BxmAvV = oh.bxmAvV();
-    error.BxmVvV = oh.bxmVvV();
-    error.InUfw = oh.inUfw();
-    error.badVFatCount = oh.vfatWordCnt() != oh.vfatWordCntT();
-    errors_ = error.codes;
-
-    Warnings warn{0};
-    existVFATs_ = oh.existVFATs();
-    vfatMask_ = oh.vfatMask();
-    zsMask_ = oh.zsMask();
-    missingVFATs_ = (existVFATs_ ^ 0xffffff) & (vfatMask_ & (zsMask_ ^ 0xffffff));
-    warn.EvtNF = oh.evtNF();
-    warn.InNF = oh.inNF();
-    warn.L1aNF = (oh.l1aNF() and (oh.version() == 0));
-    warn.EvtSzW = oh.evtSzW();
-    warn.missingVFAT = (oh.version() != 0) and (missingVFATs_ != 0);
-    warnings_ = warn.wcodes;
+  inline std::ostream& operator<<(std::ostream& out, const GEMOHStatus& status) {
+    out << "GEMOHStatus errors " << std::bitset<16>(status.errors()) << " warnings "
+        << std::bitset<8>(status.warnings());
+    return out;
   }
 
-  void inValidVFAT() {
-    Warnings warn{warnings_};
-    warn.InValidVFAT = 1;
-    warnings_ = warn.wcodes;
-  }
-
-  bool isBad() const { return errors_ != 0; }
-  uint16_t errors() const { return errors_; }
-  uint8_t warnings() const { return warnings_; }
-  uint32_t missingVFATs() const { return missingVFATs_; }
-  uint32_t vfatMask() const { return vfatMask_; }
-  uint32_t zsMask() const { return zsMask_; }
-  uint32_t existVFATs() const { return existVFATs_; }
-  int chamberType() const { return chamberType_; }
-
-private:
-  int chamberType_;
-  uint16_t errors_;
-  uint8_t warnings_;
-  uint32_t missingVFATs_;
-  uint32_t vfatMask_;
-  uint32_t zsMask_;
-  uint32_t existVFATs_;
-};
-
-inline std::ostream& operator<<(std::ostream& out, const GEMOHStatus& status) {
-  out << "GEMOHStatus errors " << std::bitset<16>(status.errors()) << " warnings " << std::bitset<8>(status.warnings());
-  return out;
-}
+}  // namespace io_v1
+using GEMOHStatus = io_v1::GEMOHStatus;
 
 #endif

--- a/DataFormats/GEMDigi/interface/GEMPadDigi.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigi.h
@@ -14,42 +14,47 @@
 #include <cstdint>
 #include <iosfwd>
 
-class GEMPadDigi {
-public:
-  enum InValid { ME0InValid = 255, GE11InValid = 255, GE21InValid = 511 };
-  // Newer GE2/1 geometries will have 16 eta partitions
-  // instead of the usual 8.
-  enum NumberPartitions { ME0 = 8, GE11 = 8, GE21 = 8, GE21SplitStrip = 16 };
+namespace io_v1 {
 
-  explicit GEMPadDigi(uint16_t pad,
-                      int16_t bx,
-                      enum GEMSubDetId::Station station = GEMSubDetId::Station::GE11,
-                      unsigned nPart = NumberPartitions::GE11);
-  GEMPadDigi();
+  class GEMPadDigi {
+  public:
+    enum InValid { ME0InValid = 255, GE11InValid = 255, GE21InValid = 511 };
+    // Newer GE2/1 geometries will have 16 eta partitions
+    // instead of the usual 8.
+    enum NumberPartitions { ME0 = 8, GE11 = 8, GE21 = 8, GE21SplitStrip = 16 };
 
-  bool operator==(const GEMPadDigi& digi) const;
-  bool operator!=(const GEMPadDigi& digi) const;
-  bool operator<(const GEMPadDigi& digi) const;
-  // only depends on the "InValid" enum so it also
-  // works on unpacked data
-  bool isValid() const;
+    explicit GEMPadDigi(uint16_t pad,
+                        int16_t bx,
+                        enum GEMSubDetId::Station station = GEMSubDetId::Station::GE11,
+                        unsigned nPart = NumberPartitions::GE11);
+    GEMPadDigi();
 
-  // return the pad number. counts from 0.
-  uint16_t pad() const { return pad_; }
-  int16_t bx() const { return bx_; }
-  GEMSubDetId::Station station() const { return station_; }
+    bool operator==(const GEMPadDigi& digi) const;
+    bool operator!=(const GEMPadDigi& digi) const;
+    bool operator<(const GEMPadDigi& digi) const;
+    // only depends on the "InValid" enum so it also
+    // works on unpacked data
+    bool isValid() const;
 
-  unsigned nPartitions() const { return part_; }
-  void print() const;
+    // return the pad number. counts from 0.
+    uint16_t pad() const { return pad_; }
+    int16_t bx() const { return bx_; }
+    GEMSubDetId::Station station() const { return station_; }
 
-private:
-  uint16_t pad_;
-  int16_t bx_;
-  GEMSubDetId::Station station_;
-  // number of eta partitions
-  unsigned part_;
-};
+    unsigned nPartitions() const { return part_; }
+    void print() const;
 
-std::ostream& operator<<(std::ostream& o, const GEMPadDigi& digi);
+  private:
+    uint16_t pad_;
+    int16_t bx_;
+    GEMSubDetId::Station station_;
+    // number of eta partitions
+    unsigned part_;
+  };
+
+  std::ostream& operator<<(std::ostream& o, const GEMPadDigi& digi);
+
+}  // namespace io_v1
+using GEMPadDigi = io_v1::GEMPadDigi;
 
 #endif

--- a/DataFormats/GEMDigi/interface/GEMPadDigiCluster.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigiCluster.h
@@ -16,46 +16,51 @@
 #include <iosfwd>
 #include <vector>
 
-class GEMPadDigiCluster {
-public:
-  enum InValid { GE11InValid = 255, GE21InValid = 511 };
-  // Newer GE2/1 geometries will have 16 eta partitions
-  // instead of the usual 8.
-  enum NumberPartitions { ME0 = 8, GE11 = 8, GE21 = 8, GE21SplitStrip = 16 };
+namespace io_v1 {
 
-  explicit GEMPadDigiCluster(std::vector<uint16_t> pads,
-                             int16_t bx,
-                             enum GEMSubDetId::Station station = GEMSubDetId::Station::GE11,
-                             unsigned nPart = NumberPartitions::GE11);
-  GEMPadDigiCluster();
+  class GEMPadDigiCluster {
+  public:
+    enum InValid { GE11InValid = 255, GE21InValid = 511 };
+    // Newer GE2/1 geometries will have 16 eta partitions
+    // instead of the usual 8.
+    enum NumberPartitions { ME0 = 8, GE11 = 8, GE21 = 8, GE21SplitStrip = 16 };
 
-  bool operator==(const GEMPadDigiCluster& digi) const;
-  bool operator!=(const GEMPadDigiCluster& digi) const;
-  bool operator<(const GEMPadDigiCluster& digi) const;
-  // only depends on the "InValid" enum so it also
-  // works on unpacked data
-  bool isValid() const;
+    explicit GEMPadDigiCluster(std::vector<uint16_t> pads,
+                               int16_t bx,
+                               enum GEMSubDetId::Station station = GEMSubDetId::Station::GE11,
+                               unsigned nPart = NumberPartitions::GE11);
+    GEMPadDigiCluster();
 
-  const std::vector<uint16_t>& pads() const { return v_; }
-  int bx() const { return bx_; }
+    bool operator==(const GEMPadDigiCluster& digi) const;
+    bool operator!=(const GEMPadDigiCluster& digi) const;
+    bool operator<(const GEMPadDigiCluster& digi) const;
+    // only depends on the "InValid" enum so it also
+    // works on unpacked data
+    bool isValid() const;
 
-  GEMSubDetId::Station station() const { return station_; }
+    const std::vector<uint16_t>& pads() const { return v_; }
+    int bx() const { return bx_; }
 
-  unsigned nPartitions() const { return part_; }
-  void print() const;
+    GEMSubDetId::Station station() const { return station_; }
 
-  int alctMatchTime() const { return alctMatchTime_; }
-  void setAlctMatchTime(int matchWin) { alctMatchTime_ = matchWin; }
+    unsigned nPartitions() const { return part_; }
+    void print() const;
 
-private:
-  std::vector<uint16_t> v_;
-  int32_t bx_;
-  int alctMatchTime_ = -1;
-  GEMSubDetId::Station station_;
-  // number of eta partitions
-  unsigned part_;
-};
+    int alctMatchTime() const { return alctMatchTime_; }
+    void setAlctMatchTime(int matchWin) { alctMatchTime_ = matchWin; }
 
-std::ostream& operator<<(std::ostream& o, const GEMPadDigiCluster& digi);
+  private:
+    std::vector<uint16_t> v_;
+    int32_t bx_;
+    int alctMatchTime_ = -1;
+    GEMSubDetId::Station station_;
+    // number of eta partitions
+    unsigned part_;
+  };
+
+  std::ostream& operator<<(std::ostream& o, const GEMPadDigiCluster& digi);
+
+}  // namespace io_v1
+using GEMPadDigiCluster = io_v1::GEMPadDigiCluster;
 
 #endif

--- a/DataFormats/GEMDigi/interface/GEMPadDigiClusterFwd.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigiClusterFwd.h
@@ -1,6 +1,9 @@
 #ifndef DataFormats_GEMDigi_GEMPadDigiClusterFwd_h
 #define DataFormats_GEMDigi_GEMPadDigiClusterFwd_h
 
-class GEMPadDigiCluster;
+namespace io_v1 {
+  class GEMPadDigiCluster;
+}  // namespace io_v1
+using GEMPadDigiCluster = io_v1::GEMPadDigiCluster;
 
 #endif

--- a/DataFormats/GEMDigi/interface/GEMVFATStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMVFATStatus.h
@@ -6,77 +6,83 @@
 #include <bitset>
 #include <ostream>
 
-class GEMVFATStatus {
-public:
-  union Errors {
-    uint8_t codes;
-    struct {
-      uint8_t vc : 1;  // VFAT CRC error
-      uint8_t InValidHeader : 1;
-      uint8_t EC : 1;        // does not match AMC EC
-      uint8_t BC : 1;        // does not match AMC BC
-      uint8_t vfatMask : 1;  // VFAT mask error
-      uint8_t zsMask : 1;    // Zero Suppression mask error
+namespace io_v1 {
+
+  class GEMVFATStatus {
+  public:
+    union Errors {
+      uint8_t codes;
+      struct {
+        uint8_t vc : 1;  // VFAT CRC error
+        uint8_t InValidHeader : 1;
+        uint8_t EC : 1;        // does not match AMC EC
+        uint8_t BC : 1;        // does not match AMC BC
+        uint8_t vfatMask : 1;  // VFAT mask error
+        uint8_t zsMask : 1;    // Zero Suppression mask error
+      };
     };
-  };
-  union Warnings {
-    uint8_t wcodes;
-    struct {
-      uint8_t basicOFW : 1;    // Basic overflow warning
-      uint8_t zeroSupOFW : 1;  // Zero-sup overflow warning
+    union Warnings {
+      uint8_t wcodes;
+      struct {
+        uint8_t basicOFW : 1;    // Basic overflow warning
+        uint8_t zeroSupOFW : 1;  // Zero-sup overflow warning
+      };
     };
-  };
 
-  GEMVFATStatus() {}
-  GEMVFATStatus(const GEMAMC& amc, const GEMOptoHybrid& oh, const GEMVFAT& vfat, int chamberType, bool readMultiBX)
-      : chamberType_(chamberType) {
-    Errors error{0};
-    Warnings warn{0};
+    GEMVFATStatus() {}
+    GEMVFATStatus(const GEMAMC& amc, const GEMOptoHybrid& oh, const GEMVFAT& vfat, int chamberType, bool readMultiBX)
+        : chamberType_(chamberType) {
+      Errors error{0};
+      Warnings warn{0};
 
-    error.EC = vfat.ec() != amc.lv1Idt();
-    if (!readMultiBX)
-      error.BC = vfat.bc() != amc.bunchCrossing();
+      error.EC = vfat.ec() != amc.lv1Idt();
+      if (!readMultiBX)
+        error.BC = vfat.bc() != amc.bunchCrossing();
 
-    if (oh.version() != 0) {
-      error.vfatMask = (oh.vfatMask() >> vfat.vfatId()) ^ 0x1;
-      error.zsMask = (oh.zsMask() >> vfat.vfatId()) & 0x1;
+      if (oh.version() != 0) {
+        error.vfatMask = (oh.vfatMask() >> vfat.vfatId()) ^ 0x1;
+        error.zsMask = (oh.zsMask() >> vfat.vfatId()) & 0x1;
+      }
+
+      if (vfat.version() > 2) {
+        error.vc = vfat.vc();
+        if (vfat.header() == 0x1E)
+          warn.basicOFW = 0;
+        else if (vfat.header() == 0x5E)
+          warn.basicOFW = 1;
+        else if (vfat.header() == 0x1A)
+          warn.zeroSupOFW = 0;
+        else if (vfat.header() == 0x56)
+          warn.zeroSupOFW = 1;
+        else
+          error.InValidHeader = 1;
+      }
+      vfatPosition_ = vfat.vfatId();
+
+      errors_ = error.codes;
+      warnings_ = warn.wcodes;
     }
 
-    if (vfat.version() > 2) {
-      error.vc = vfat.vc();
-      if (vfat.header() == 0x1E)
-        warn.basicOFW = 0;
-      else if (vfat.header() == 0x5E)
-        warn.basicOFW = 1;
-      else if (vfat.header() == 0x1A)
-        warn.zeroSupOFW = 0;
-      else if (vfat.header() == 0x56)
-        warn.zeroSupOFW = 1;
-      else
-        error.InValidHeader = 1;
-    }
-    vfatPosition_ = vfat.vfatId();
+    uint16_t vfatPosition() const { return vfatPosition_; }
+    bool isBad() const { return errors_ != 0; }
+    uint8_t errors() const { return errors_; }
+    uint8_t warnings() const { return warnings_; }
+    int chamberType() const { return chamberType_; }
 
-    errors_ = error.codes;
-    warnings_ = warn.wcodes;
+  private:
+    int chamberType_;
+    uint16_t vfatPosition_;
+    uint8_t errors_;
+    uint8_t warnings_;
+  };
+
+  inline std::ostream& operator<<(std::ostream& out, const GEMVFATStatus& status) {
+    out << "GEMVFATStatus errors " << std::bitset<8>(status.errors()) << " warnings "
+        << std::bitset<8>(status.warnings());
+    return out;
   }
 
-  uint16_t vfatPosition() const { return vfatPosition_; }
-  bool isBad() const { return errors_ != 0; }
-  uint8_t errors() const { return errors_; }
-  uint8_t warnings() const { return warnings_; }
-  int chamberType() const { return chamberType_; }
+}  // namespace io_v1
+using GEMVFATStatus = io_v1::GEMVFATStatus;
 
-private:
-  int chamberType_;
-  uint16_t vfatPosition_;
-  uint8_t errors_;
-  uint8_t warnings_;
-};
-
-inline std::ostream& operator<<(std::ostream& out, const GEMVFATStatus& status) {
-  out << "GEMVFATStatus errors " << std::bitset<8>(status.errors()) << " warnings "
-      << std::bitset<8>(status.warnings());
-  return out;
-}
 #endif

--- a/DataFormats/GEMDigi/src/GEMCoPadDigi.cc
+++ b/DataFormats/GEMDigi/src/GEMCoPadDigi.cc
@@ -1,45 +1,49 @@
 #include "DataFormats/GEMDigi/interface/GEMCoPadDigi.h"
 #include <iostream>
 
-GEMCoPadDigi::GEMCoPadDigi(uint8_t roll, GEMPadDigi f, GEMPadDigi s) : roll_(roll), first_(f), second_(s) {}
+namespace io_v1 {
 
-GEMCoPadDigi::GEMCoPadDigi() : roll_(0), first_(GEMPadDigi()), second_(GEMPadDigi()) {}
+  GEMCoPadDigi::GEMCoPadDigi(uint8_t roll, GEMPadDigi f, GEMPadDigi s) : roll_(roll), first_(f), second_(s) {}
 
-// Comparison
-bool GEMCoPadDigi::operator==(const GEMCoPadDigi& digi) const {
-  return digi.first() == first_ and digi.second() == second_ and digi.roll() == roll_;
-}
+  GEMCoPadDigi::GEMCoPadDigi() : roll_(0), first_(GEMPadDigi()), second_(GEMPadDigi()) {}
 
-// Comparison
-bool GEMCoPadDigi::operator!=(const GEMCoPadDigi& digi) const {
-  return digi.first() != first_ or digi.second() != second_ or digi.roll() != roll_;
-}
+  // Comparison
+  bool GEMCoPadDigi::operator==(const GEMCoPadDigi& digi) const {
+    return digi.first() == first_ and digi.second() == second_ and digi.roll() == roll_;
+  }
 
-bool GEMCoPadDigi::isValid() const { return first_.isValid() and second_.isValid(); }
+  // Comparison
+  bool GEMCoPadDigi::operator!=(const GEMCoPadDigi& digi) const {
+    return digi.first() != first_ or digi.second() != second_ or digi.roll() != roll_;
+  }
 
-int GEMCoPadDigi::pad(int l) const {
-  if (l == 1)
-    return first_.pad();
-  else if (l == 2)
-    return second_.pad();
-  else
-    return -99;  // invalid
-}
+  bool GEMCoPadDigi::isValid() const { return first_.isValid() and second_.isValid(); }
 
-int GEMCoPadDigi::bx(int l) const {
-  if (l == 1)
-    return first_.bx();
-  else if (l == 2)
-    return second_.bx();
-  else
-    return -99;  // invalid
-}
+  int GEMCoPadDigi::pad(int l) const {
+    if (l == 1)
+      return first_.pad();
+    else if (l == 2)
+      return second_.pad();
+    else
+      return -99;  // invalid
+  }
 
-void GEMCoPadDigi::print() const {
-  std::cout << "Roll " << roll_ << ", pad1 " << first_.pad() << " bx1 " << first_.bx() << ", Pad2 " << second_.pad()
-            << " bx2 " << second_.bx() << std::endl;
-}
+  int GEMCoPadDigi::bx(int l) const {
+    if (l == 1)
+      return first_.bx();
+    else if (l == 2)
+      return second_.bx();
+    else
+      return -99;  // invalid
+  }
 
-std::ostream& operator<<(std::ostream& o, const GEMCoPadDigi& digi) {
-  return o << "Roll: " << digi.roll() << " layer1:" << digi.first() << ", layer2:" << digi.second();
-}
+  void GEMCoPadDigi::print() const {
+    std::cout << "Roll " << roll_ << ", pad1 " << first_.pad() << " bx1 " << first_.bx() << ", Pad2 " << second_.pad()
+              << " bx2 " << second_.bx() << std::endl;
+  }
+
+  std::ostream& operator<<(std::ostream& o, const GEMCoPadDigi& digi) {
+    return o << "Roll: " << digi.roll() << " layer1:" << digi.first() << ", layer2:" << digi.second();
+  }
+
+}  // namespace io_v1

--- a/DataFormats/GEMDigi/src/GEMDigi.cc
+++ b/DataFormats/GEMDigi/src/GEMDigi.cc
@@ -1,28 +1,32 @@
 #include "DataFormats/GEMDigi/interface/GEMDigi.h"
 #include <iostream>
 
-GEMDigi::GEMDigi(uint16_t strip, int16_t bx) : strip_(strip), bx_(bx) {}
+namespace io_v1 {
 
-GEMDigi::GEMDigi() : strip_(65535), bx_(-99) {}
+  GEMDigi::GEMDigi(uint16_t strip, int16_t bx) : strip_(strip), bx_(bx) {}
 
-// Comparison
-bool GEMDigi::operator==(const GEMDigi& digi) const { return strip_ == digi.strip() and bx_ == digi.bx(); }
+  GEMDigi::GEMDigi() : strip_(65535), bx_(-99) {}
 
-// Comparison
-bool GEMDigi::operator!=(const GEMDigi& digi) const { return strip_ != digi.strip() or bx_ != digi.bx(); }
+  // Comparison
+  bool GEMDigi::operator==(const GEMDigi& digi) const { return strip_ == digi.strip() and bx_ == digi.bx(); }
 
-///Precedence operator
-bool GEMDigi::operator<(const GEMDigi& digi) const {
-  if (digi.bx() == bx_)
-    return digi.strip() < strip_;
-  else
-    return digi.bx() < bx_;
-}
+  // Comparison
+  bool GEMDigi::operator!=(const GEMDigi& digi) const { return strip_ != digi.strip() or bx_ != digi.bx(); }
 
-bool GEMDigi::isValid() const { return bx_ != -99 and strip_ != 65535; }
+  ///Precedence operator
+  bool GEMDigi::operator<(const GEMDigi& digi) const {
+    if (digi.bx() == bx_)
+      return digi.strip() < strip_;
+    else
+      return digi.bx() < bx_;
+  }
 
-std::ostream& operator<<(std::ostream& o, const GEMDigi& digi) {
-  return o << " GEMDigi strip = " << digi.strip() << " bx = " << digi.bx();
-}
+  bool GEMDigi::isValid() const { return bx_ != -99 and strip_ != 65535; }
 
-void GEMDigi::print() const { std::cout << "Strip " << strip() << " bx " << bx() << std::endl; }
+  std::ostream& operator<<(std::ostream& o, const GEMDigi& digi) {
+    return o << " GEMDigi strip = " << digi.strip() << " bx = " << digi.bx();
+  }
+
+  void GEMDigi::print() const { std::cout << "Strip " << strip() << " bx " << bx() << std::endl; }
+
+}  // namespace io_v1

--- a/DataFormats/GEMDigi/src/GEMPadDigi.cc
+++ b/DataFormats/GEMDigi/src/GEMPadDigi.cc
@@ -1,40 +1,44 @@
 #include "DataFormats/GEMDigi/interface/GEMPadDigi.h"
 #include <iostream>
 
-GEMPadDigi::GEMPadDigi(uint16_t pad, int16_t bx, enum GEMSubDetId::Station station, unsigned nPart)
-    : pad_(pad), bx_(bx), station_(station), part_(nPart) {}
+namespace io_v1 {
 
-GEMPadDigi::GEMPadDigi()
-    : pad_(GE11InValid), bx_(-99), station_(GEMSubDetId::Station::GE11), part_(NumberPartitions::GE11) {}
+  GEMPadDigi::GEMPadDigi(uint16_t pad, int16_t bx, enum GEMSubDetId::Station station, unsigned nPart)
+      : pad_(pad), bx_(bx), station_(station), part_(nPart) {}
 
-// Comparison
-bool GEMPadDigi::operator==(const GEMPadDigi& digi) const {
-  return pad_ == digi.pad() and bx_ == digi.bx() and station_ == digi.station();
-}
+  GEMPadDigi::GEMPadDigi()
+      : pad_(GE11InValid), bx_(-99), station_(GEMSubDetId::Station::GE11), part_(NumberPartitions::GE11) {}
 
-// Comparison
-bool GEMPadDigi::operator!=(const GEMPadDigi& digi) const { return pad_ != digi.pad() or bx_ != digi.bx(); }
-
-///Precedence operator
-bool GEMPadDigi::operator<(const GEMPadDigi& digi) const {
-  if (digi.bx() == bx_)
-    return digi.pad() < pad_;
-  else
-    return digi.bx() < bx_;
-}
-
-bool GEMPadDigi::isValid() const {
-  uint16_t invalid = GE11InValid;
-  if (station_ == GEMSubDetId::Station::ME0) {
-    invalid = ME0InValid;
-  } else if (station_ == GEMSubDetId::Station::GE21) {
-    invalid = GE21InValid;
+  // Comparison
+  bool GEMPadDigi::operator==(const GEMPadDigi& digi) const {
+    return pad_ == digi.pad() and bx_ == digi.bx() and station_ == digi.station();
   }
-  return pad_ != invalid;
-}
 
-std::ostream& operator<<(std::ostream& o, const GEMPadDigi& digi) {
-  return o << " GEMPadDigi Pad = " << digi.pad() << " bx = " << digi.bx();
-}
+  // Comparison
+  bool GEMPadDigi::operator!=(const GEMPadDigi& digi) const { return pad_ != digi.pad() or bx_ != digi.bx(); }
 
-void GEMPadDigi::print() const { std::cout << "Pad " << pad() << " bx " << bx() << std::endl; }
+  ///Precedence operator
+  bool GEMPadDigi::operator<(const GEMPadDigi& digi) const {
+    if (digi.bx() == bx_)
+      return digi.pad() < pad_;
+    else
+      return digi.bx() < bx_;
+  }
+
+  bool GEMPadDigi::isValid() const {
+    uint16_t invalid = GE11InValid;
+    if (station_ == GEMSubDetId::Station::ME0) {
+      invalid = ME0InValid;
+    } else if (station_ == GEMSubDetId::Station::GE21) {
+      invalid = GE21InValid;
+    }
+    return pad_ != invalid;
+  }
+
+  std::ostream& operator<<(std::ostream& o, const GEMPadDigi& digi) {
+    return o << " GEMPadDigi Pad = " << digi.pad() << " bx = " << digi.bx();
+  }
+
+  void GEMPadDigi::print() const { std::cout << "Pad " << pad() << " bx " << bx() << std::endl; }
+
+}  // namespace io_v1

--- a/DataFormats/GEMDigi/src/GEMPadDigiCluster.cc
+++ b/DataFormats/GEMDigi/src/GEMPadDigiCluster.cc
@@ -1,56 +1,60 @@
 #include "DataFormats/GEMDigi/interface/GEMPadDigiCluster.h"
 #include <iostream>
 
-GEMPadDigiCluster::GEMPadDigiCluster(std::vector<uint16_t> pads,
-                                     int16_t bx,
-                                     enum GEMSubDetId::Station station,
-                                     unsigned nPart)
-    : v_(pads), bx_(bx), station_(station), part_(nPart) {}
+namespace io_v1 {
 
-GEMPadDigiCluster::GEMPadDigiCluster()
-    : v_(std::vector<uint16_t>()), bx_(-99), station_(GEMSubDetId::Station::GE11), part_(NumberPartitions::GE11) {}
+  GEMPadDigiCluster::GEMPadDigiCluster(std::vector<uint16_t> pads,
+                                       int16_t bx,
+                                       enum GEMSubDetId::Station station,
+                                       unsigned nPart)
+      : v_(pads), bx_(bx), station_(station), part_(nPart) {}
 
-// Comparison
-bool GEMPadDigiCluster::operator==(const GEMPadDigiCluster& digi) const {
-  return v_ == digi.pads() and bx_ == digi.bx() and station_ == digi.station();
-}
+  GEMPadDigiCluster::GEMPadDigiCluster()
+      : v_(std::vector<uint16_t>()), bx_(-99), station_(GEMSubDetId::Station::GE11), part_(NumberPartitions::GE11) {}
 
-// Comparison
-bool GEMPadDigiCluster::operator!=(const GEMPadDigiCluster& digi) const {
-  return v_ != digi.pads() or bx_ != digi.bx();
-}
-
-///Precedence operator
-bool GEMPadDigiCluster::operator<(const GEMPadDigiCluster& digi) const {
-  if (digi.bx() == bx_)
-    return digi.pads().front() < v_.front();
-  else
-    return digi.bx() < bx_;
-}
-
-bool GEMPadDigiCluster::isValid() const {
-  // empty clusters are always invalid
-  if (v_.empty())
-    return false;
-
-  uint16_t invalid = GE11InValid;
-  if (station_ == GEMSubDetId::Station::GE21) {
-    invalid = GE21InValid;
+  // Comparison
+  bool GEMPadDigiCluster::operator==(const GEMPadDigiCluster& digi) const {
+    return v_ == digi.pads() and bx_ == digi.bx() and station_ == digi.station();
   }
-  return v_[0] != invalid;
-}
 
-std::ostream& operator<<(std::ostream& o, const GEMPadDigiCluster& digi) {
-  o << " bx: " << digi.bx() << " pads: [";
-  for (auto p : digi.pads())
-    o << " " << p;
-  o << "]";
-  return o;
-}
+  // Comparison
+  bool GEMPadDigiCluster::operator!=(const GEMPadDigiCluster& digi) const {
+    return v_ != digi.pads() or bx_ != digi.bx();
+  }
 
-void GEMPadDigiCluster::print() const {
-  std::cout << " bx: " << bx() << " pads: ";
-  for (auto p : pads())
-    std::cout << " " << p;
-  std::cout << std::endl;
-}
+  ///Precedence operator
+  bool GEMPadDigiCluster::operator<(const GEMPadDigiCluster& digi) const {
+    if (digi.bx() == bx_)
+      return digi.pads().front() < v_.front();
+    else
+      return digi.bx() < bx_;
+  }
+
+  bool GEMPadDigiCluster::isValid() const {
+    // empty clusters are always invalid
+    if (v_.empty())
+      return false;
+
+    uint16_t invalid = GE11InValid;
+    if (station_ == GEMSubDetId::Station::GE21) {
+      invalid = GE21InValid;
+    }
+    return v_[0] != invalid;
+  }
+
+  std::ostream& operator<<(std::ostream& o, const GEMPadDigiCluster& digi) {
+    o << " bx: " << digi.bx() << " pads: [";
+    for (auto p : digi.pads())
+      o << " " << p;
+    o << "]";
+    return o;
+  }
+
+  void GEMPadDigiCluster::print() const {
+    std::cout << " bx: " << bx() << " pads: ";
+    for (auto p : pads())
+      std::cout << " " << p;
+    std::cout << std::endl;
+  }
+
+}  // namespace io_v1

--- a/DataFormats/GEMDigi/src/classes_def.xml
+++ b/DataFormats/GEMDigi/src/classes_def.xml
@@ -1,87 +1,76 @@
 <lcgdict>
 
-<class name="GEMDigi" ClassVersion="11">
- <version ClassVersion="10" checksum="2054480652"/>
- <version ClassVersion="11" checksum="1310457745"/>
+<class name="io_v1::GEMDigi" ClassVersion="3">
+ <version ClassVersion="3" checksum="542025745"/>
 </class>
-<class name="std::vector<GEMDigi>"/>
-<class name="std::map<GEMDetId,std::vector<GEMDigi> >"/>
-<class name="std::pair<GEMDetId,std::vector<GEMDigi> >"/>
-<class name="MuonDigiCollection<GEMDetId,GEMDigi>"/>
-<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMDigi> >" splitLevel="0"/>
+<class name="std::vector<io_v1::GEMDigi>"/>
+<class name="std::map<GEMDetId,std::vector<io_v1::GEMDigi> >"/>
+<class name="std::pair<GEMDetId,std::vector<io_v1::GEMDigi> >"/>
+<class name="MuonDigiCollection<GEMDetId,io_v1::GEMDigi>"/>
+<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,io_v1::GEMDigi> >" splitLevel="0"/>
 
-<class name="GEMPadDigi" ClassVersion="14">
- <version ClassVersion="11" checksum="426510066"/>
- <version ClassVersion="12" checksum="3838591655"/>
- <version ClassVersion="13" checksum="2944221332"/>
- <version ClassVersion="14" checksum="1418399352"/>
+<class name="io_v1::GEMPadDigi" ClassVersion="3">
+ <version ClassVersion="3" checksum="2419866616"/>
 </class>
-<class name="std::vector<GEMPadDigi>"/>
-<class name="std::map<GEMDetId,std::vector<GEMPadDigi> >"/>
-<class name="std::pair<GEMDetId,std::vector<GEMPadDigi> >"/>
-<class name="MuonDigiCollection<GEMDetId,GEMPadDigi>"/>
-<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMPadDigi> >" splitLevel="0"/>
+<class name="std::vector<io_v1::GEMPadDigi>"/>
+<class name="std::map<GEMDetId,std::vector<io_v1::GEMPadDigi> >"/>
+<class name="std::pair<GEMDetId,std::vector<io_v1::GEMPadDigi> >"/>
+<class name="MuonDigiCollection<GEMDetId,io_v1::GEMPadDigi>"/>
+<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,io_v1::GEMPadDigi> >" splitLevel="0"/>
 
-<class name="GEMPadDigiCluster" ClassVersion="13">
- <version ClassVersion="10" checksum="2569340006"/>
- <version ClassVersion="11" checksum="3372991553"/>
- <version ClassVersion="12" checksum="533478463"/>
- <version ClassVersion="13" checksum="3488459777"/>
+<class name="io_v1::GEMPadDigiCluster" ClassVersion="3">
+ <version ClassVersion="3" checksum="2338972033"/>
 </class>
-<class name="std::vector<GEMPadDigiCluster>"/>
-<class name="std::map<GEMDetId,std::vector<GEMPadDigiCluster> >"/>
-<class name="std::pair<GEMDetId,std::vector<GEMPadDigiCluster> >"/>
-<class name="MuonDigiCollection<GEMDetId,GEMPadDigiCluster>"/>
-<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMPadDigiCluster> >" splitLevel="0"/>
+<class name="std::vector<io_v1::GEMPadDigiCluster>"/>
+<class name="std::map<GEMDetId,std::vector<io_v1::GEMPadDigiCluster> >"/>
+<class name="std::pair<GEMDetId,std::vector<io_v1::GEMPadDigiCluster> >"/>
+<class name="MuonDigiCollection<GEMDetId,io_v1::GEMPadDigiCluster>"/>
+<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,io_v1::GEMPadDigiCluster> >" splitLevel="0"/>
 
-<class name="GEMCoPadDigi" ClassVersion="12">
- <version ClassVersion="12" checksum="2678638706"/>
+<class name="io_v1::GEMCoPadDigi" ClassVersion="3">
+ <version ClassVersion="3" checksum="88431106"/>
 </class>
-<class name="std::vector<GEMCoPadDigi>"/>
-<class name="std::map<GEMDetId,std::vector<GEMCoPadDigi> >"/>
-<class name="std::pair<GEMDetId,std::vector<GEMCoPadDigi> >"/>
-<class name="MuonDigiCollection<GEMDetId,GEMCoPadDigi>"/>
-<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMCoPadDigi> >" splitLevel="0"/>
+<class name="std::vector<io_v1::GEMCoPadDigi>"/>
+<class name="std::map<GEMDetId,std::vector<io_v1::GEMCoPadDigi> >"/>
+<class name="std::pair<GEMDetId,std::vector<io_v1::GEMCoPadDigi> >"/>
+<class name="MuonDigiCollection<GEMDetId,io_v1::GEMCoPadDigi>"/>
+<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,io_v1::GEMCoPadDigi> >" splitLevel="0"/>
 
-<class name="GEMAMC13Status" ClassVersion="3">
- <version ClassVersion="3" checksum="3469985462"/>
+<class name="io_v1::GEMAMC13Status" ClassVersion="3">
+ <version ClassVersion="3" checksum="540579894"/>
 </class>
-<class name="std::vector<GEMAMC13Status>"/>
-<class name="std::map<uint16_t,std::vector<GEMAMC13Status> >"/>
-<class name="std::pair<uint16_t,std::vector<GEMAMC13Status> >"/>
-<class name="MuonDigiCollection<uint16_t,GEMAMC13Status>"/>
-<class name="edm::Wrapper<MuonDigiCollection<uint16_t,GEMAMC13Status> >" splitLevel="0"/>
+<class name="std::vector<io_v1::GEMAMC13Status>"/>
+<class name="std::map<uint16_t,std::vector<io_v1::GEMAMC13Status> >"/>
+<class name="std::pair<uint16_t,std::vector<io_v1::GEMAMC13Status> >"/>
+<class name="MuonDigiCollection<uint16_t,io_v1::GEMAMC13Status>"/>
+<class name="edm::Wrapper<MuonDigiCollection<uint16_t,io_v1::GEMAMC13Status> >" splitLevel="0"/>
 
-<class name="GEMAMCStatus" ClassVersion="3">
- <version ClassVersion="3" checksum="2120084327"/>
+<class name="io_v1::GEMAMCStatus" ClassVersion="3">
+ <version ClassVersion="3" checksum="1729733607"/>
 </class>
-<class name="std::vector<GEMAMCStatus>"/>
-<class name="std::map<uint16_t,std::vector<GEMAMCStatus> >"/>
-<class name="std::pair<uint16_t,std::vector<GEMAMCStatus> >"/>
-<class name="MuonDigiCollection<uint16_t,GEMAMCStatus>"/>
-<class name="edm::Wrapper<MuonDigiCollection<uint16_t,GEMAMCStatus> >" splitLevel="0"/>
+<class name="std::vector<io_v1::GEMAMCStatus>"/>
+<class name="std::map<uint16_t,std::vector<io_v1::GEMAMCStatus> >"/>
+<class name="std::pair<uint16_t,std::vector<io_v1::GEMAMCStatus> >"/>
+<class name="MuonDigiCollection<uint16_t,io_v1::GEMAMCStatus>"/>
+<class name="edm::Wrapper<MuonDigiCollection<uint16_t,io_v1::GEMAMCStatus> >" splitLevel="0"/>
 
-<class name="GEMOHStatus" ClassVersion="5">
- <version ClassVersion="3" checksum="1715607020"/>
- <version ClassVersion="4" checksum="442197271"/>
- <version ClassVersion="5" checksum="3896553455"/>
+<class name="io_v1::GEMOHStatus" ClassVersion="3">
+ <version ClassVersion="3" checksum="2966637679"/>
 </class>
-<class name="std::vector<GEMOHStatus>"/>
-<class name="std::map<GEMDetId,std::vector<GEMOHStatus> >"/>
-<class name="std::pair<GEMDetId,std::vector<GEMOHStatus> >"/>
-<class name="MuonDigiCollection<GEMDetId,GEMOHStatus>"/>
-<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMOHStatus> >" splitLevel="0"/>
+<class name="std::vector<io_v1::GEMOHStatus>"/>
+<class name="std::map<GEMDetId,std::vector<io_v1::GEMOHStatus> >"/>
+<class name="std::pair<GEMDetId,std::vector<io_v1::GEMOHStatus> >"/>
+<class name="MuonDigiCollection<GEMDetId,io_v1::GEMOHStatus>"/>
+<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,io_v1::GEMOHStatus> >" splitLevel="0"/>
 
-<class name="GEMVFATStatus" ClassVersion="5">
- <version ClassVersion="3" checksum="2994917778"/>
- <version ClassVersion="4" checksum="2298275534"/>
- <version ClassVersion="5" checksum="272057922"/>
+<class name="io_v1::GEMVFATStatus" ClassVersion="3">
+ <version ClassVersion="3" checksum="1061702338"/>
 </class>
-<class name="std::vector<GEMVFATStatus>"/>
-<class name="std::map<GEMDetId,std::vector<GEMVFATStatus> >"/>
-<class name="std::pair<GEMDetId,std::vector<GEMVFATStatus> >"/>
-<class name="MuonDigiCollection<GEMDetId,GEMVFATStatus>"/>
-<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMVFATStatus> >" splitLevel="0"/>
+<class name="std::vector<io_v1::GEMVFATStatus>"/>
+<class name="std::map<GEMDetId,std::vector<io_v1::GEMVFATStatus> >"/>
+<class name="std::pair<GEMDetId,std::vector<io_v1::GEMVFATStatus> >"/>
+<class name="MuonDigiCollection<GEMDetId,io_v1::GEMVFATStatus>"/>
+<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,io_v1::GEMVFATStatus> >" splitLevel="0"/>
 
 <class name="ME0DigiPreReco" ClassVersion="13">
  <version ClassVersion="10" checksum="79088950"/>

--- a/DataFormats/GEMRecHit/interface/GEMCSCSegment.h
+++ b/DataFormats/GEMRecHit/interface/GEMCSCSegment.h
@@ -20,72 +20,77 @@
 
 #include <iosfwd>
 
-class GEMCSCSegment final : public RecSegment {
-public:
-  /// Default constructor
-  GEMCSCSegment() : theChi2(0.) {}
+namespace io_v1 {
 
-  /// Constructor
-  GEMCSCSegment(const CSCSegment* csc_segment,
-                const std::vector<const GEMRecHit*> gem_rhs,
-                LocalPoint origin,
-                LocalVector direction,
-                AlgebraicSymMatrix errors,
-                double chi2);
+  class GEMCSCSegment final : public RecSegment {
+  public:
+    /// Default constructor
+    GEMCSCSegment() : theChi2(0.) {}
 
-  /// Destructor
-  ~GEMCSCSegment() override;
+    /// Constructor
+    GEMCSCSegment(const CSCSegment* csc_segment,
+                  const std::vector<const GEMRecHit*> gem_rhs,
+                  LocalPoint origin,
+                  LocalVector direction,
+                  AlgebraicSymMatrix errors,
+                  double chi2);
 
-  //--- Base class interface
-  GEMCSCSegment* clone() const override { return new GEMCSCSegment(*this); }
+    /// Destructor
+    ~GEMCSCSegment() override;
 
-  LocalPoint localPosition() const override { return theOrigin; }
-  LocalError localPositionError() const override;
+    //--- Base class interface
+    GEMCSCSegment* clone() const override { return new GEMCSCSegment(*this); }
 
-  LocalVector localDirection() const override { return theLocalDirection; }
-  LocalError localDirectionError() const override;
+    LocalPoint localPosition() const override { return theOrigin; }
+    LocalError localPositionError() const override;
 
-  /// Parameters of the segment, for the track fit in the order (dx/dz, dy/dz, x, y )
-  AlgebraicVector parameters() const override;
+    LocalVector localDirection() const override { return theLocalDirection; }
+    LocalError localDirectionError() const override;
 
-  /// Covariance matrix of parameters()
-  AlgebraicSymMatrix parametersError() const override { return theCovMatrix; }
+    /// Parameters of the segment, for the track fit in the order (dx/dz, dy/dz, x, y )
+    AlgebraicVector parameters() const override;
 
-  /// The projection matrix relates the trajectory state parameters to the segment parameters().
-  AlgebraicMatrix projectionMatrix() const override;
+    /// Covariance matrix of parameters()
+    AlgebraicSymMatrix parametersError() const override { return theCovMatrix; }
 
-  double chi2() const override { return theChi2; };
+    /// The projection matrix relates the trajectory state parameters to the segment parameters().
+    AlgebraicMatrix projectionMatrix() const override;
 
-  int dimension() const override { return 4; }
+    double chi2() const override { return theChi2; };
 
-  int degreesOfFreedom() const override { return 2 * nRecHits() - 4; }
+    int dimension() const override { return 4; }
 
-  int nRecHits() const { return (theGEMRecHits.size() + theCSCSegment.specificRecHits().size()); }
+    int degreesOfFreedom() const override { return 2 * nRecHits() - 4; }
 
-  //--- Return the constituents in different ways
-  const CSCSegment cscSegment() const { return theCSCSegment; }
-  const std::vector<GEMRecHit>& gemRecHits() const { return theGEMRecHits; }
-  const std::vector<CSCRecHit2D>& cscRecHits() const { return theCSCSegment.specificRecHits(); }
-  std::vector<const TrackingRecHit*> recHits() const override;
-  std::vector<TrackingRecHit*> recHits() override;
+    int nRecHits() const { return (theGEMRecHits.size() + theCSCSegment.specificRecHits().size()); }
 
-  CSCDetId cscDetId() const { return geographicalId(); }
+    //--- Return the constituents in different ways
+    const CSCSegment cscSegment() const { return theCSCSegment; }
+    const std::vector<GEMRecHit>& gemRecHits() const { return theGEMRecHits; }
+    const std::vector<CSCRecHit2D>& cscRecHits() const { return theCSCSegment.specificRecHits(); }
+    std::vector<const TrackingRecHit*> recHits() const override;
+    std::vector<TrackingRecHit*> recHits() override;
 
-  void print() const;
+    CSCDetId cscDetId() const { return geographicalId(); }
 
-private:
-  std::vector<GEMRecHit> theGEMRecHits;  // store GEM Rechits
-  CSCSegment theCSCSegment;              // store CSC RecHits and store CSC Segment
-                                         // eventually we have to disentangle if later on we decide
-                                         // not to have a one-to-one relationship anymore
-                                         // i.e. if we allow the GEMCSC segment to modify the
-                                         // (selection of the rechits of the) CSC segment
-  LocalPoint theOrigin;                  // in chamber frame - the GeomDet local coordinate system
-  LocalVector theLocalDirection;         // in chamber frame - the GeomDet local coordinate system
-  AlgebraicSymMatrix theCovMatrix;       // the covariance matrix
-  double theChi2;
-};
+    void print() const;
 
-std::ostream& operator<<(std::ostream& os, const GEMCSCSegment& seg);
+  private:
+    std::vector<GEMRecHit> theGEMRecHits;  // store GEM Rechits
+    CSCSegment theCSCSegment;              // store CSC RecHits and store CSC Segment
+                                           // eventually we have to disentangle if later on we decide
+                                           // not to have a one-to-one relationship anymore
+                                           // i.e. if we allow the GEMCSC segment to modify the
+                                           // (selection of the rechits of the) CSC segment
+    LocalPoint theOrigin;                  // in chamber frame - the GeomDet local coordinate system
+    LocalVector theLocalDirection;         // in chamber frame - the GeomDet local coordinate system
+    AlgebraicSymMatrix theCovMatrix;       // the covariance matrix
+    double theChi2;
+  };
+
+  std::ostream& operator<<(std::ostream& os, const GEMCSCSegment& seg);
+
+}  // namespace io_v1
+using GEMCSCSegment = io_v1::GEMCSCSegment;
 
 #endif

--- a/DataFormats/GEMRecHit/interface/GEMRecHit.h
+++ b/DataFormats/GEMRecHit/interface/GEMRecHit.h
@@ -11,78 +11,84 @@
 #include "DataFormats/TrackingRecHit/interface/RecHit2DLocalPos.h"
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
 
-class GEMRecHit : public RecHit2DLocalPos {
-public:
-  GEMRecHit(const GEMDetId& gemId, int bx);
+namespace io_v1 {
 
-  /// Default constructor
-  GEMRecHit();
+  class GEMRecHit : public RecHit2DLocalPos {
+  public:
+    GEMRecHit(const GEMDetId& gemId, int bx);
 
-  /// Constructor from a local position, gemId and digi time.
-  /// The 3-dimensional local error is defined as
-  /// resolution (the cell resolution) for the coordinate being measured
-  /// and 0 for the two other coordinates
-  GEMRecHit(const GEMDetId& gemId, int bx, const LocalPoint& pos);
+    /// Default constructor
+    GEMRecHit();
 
-  /// Constructor from a local position and error, gemId and bx.
-  GEMRecHit(const GEMDetId& gemId, int bx, const LocalPoint& pos, const LocalError& err);
+    /// Constructor from a local position, gemId and digi time.
+    /// The 3-dimensional local error is defined as
+    /// resolution (the cell resolution) for the coordinate being measured
+    /// and 0 for the two other coordinates
+    GEMRecHit(const GEMDetId& gemId, int bx, const LocalPoint& pos);
 
-  /// Constructor from a local position and error, gemId, bx, frist strip of cluster and cluster size.
-  GEMRecHit(const GEMDetId& gemId, int bx, int firstStrip, int clustSize, const LocalPoint& pos, const LocalError& err);
+    /// Constructor from a local position and error, gemId and bx.
+    GEMRecHit(const GEMDetId& gemId, int bx, const LocalPoint& pos, const LocalError& err);
 
-  /// Destructor
-  ~GEMRecHit() override;
+    /// Constructor from a local position and error, gemId, bx, frist strip of cluster and cluster size.
+    GEMRecHit(
+        const GEMDetId& gemId, int bx, int firstStrip, int clustSize, const LocalPoint& pos, const LocalError& err);
 
-  /// Return the 3-dimensional local position
-  LocalPoint localPosition() const override { return theLocalPosition; }
+    /// Destructor
+    ~GEMRecHit() override;
 
-  /// Return the 3-dimensional error on the local position
-  LocalError localPositionError() const override { return theLocalError; }
+    /// Return the 3-dimensional local position
+    LocalPoint localPosition() const override { return theLocalPosition; }
 
-  GEMRecHit* clone() const override;
+    /// Return the 3-dimensional error on the local position
+    LocalError localPositionError() const override { return theLocalError; }
 
-  /// Access to component RecHits.
-  /// No components rechits: it returns a null vector
-  std::vector<const TrackingRecHit*> recHits() const override;
+    GEMRecHit* clone() const override;
 
-  /// Non-const access to component RecHits.
-  /// No components rechits: it returns a null vector
-  std::vector<TrackingRecHit*> recHits() override;
+    /// Access to component RecHits.
+    /// No components rechits: it returns a null vector
+    std::vector<const TrackingRecHit*> recHits() const override;
 
-  /// Set local position
-  void setPosition(LocalPoint pos) { theLocalPosition = pos; }
+    /// Non-const access to component RecHits.
+    /// No components rechits: it returns a null vector
+    std::vector<TrackingRecHit*> recHits() override;
 
-  /// Set local position error
-  void setError(LocalError err) { theLocalError = err; }
+    /// Set local position
+    void setPosition(LocalPoint pos) { theLocalPosition = pos; }
 
-  /// Set the local position and its error
-  void setPositionAndError(LocalPoint pos, LocalError err) {
-    theLocalPosition = pos;
-    theLocalError = err;
-  }
+    /// Set local position error
+    void setError(LocalError err) { theLocalError = err; }
 
-  /// Return the gemId
-  GEMDetId gemId() const { return theGEMId; }
+    /// Set the local position and its error
+    void setPositionAndError(LocalPoint pos, LocalError err) {
+      theLocalPosition = pos;
+      theLocalError = err;
+    }
 
-  int BunchX() const { return theBx; }
+    /// Return the gemId
+    GEMDetId gemId() const { return theGEMId; }
 
-  int firstClusterStrip() const { return theFirstStrip; }
+    int BunchX() const { return theBx; }
 
-  int clusterSize() const { return theClusterSize; }
+    int firstClusterStrip() const { return theFirstStrip; }
 
-  /// Comparison operator, based on the gemId and the digi time
-  bool operator==(const GEMRecHit& hit) const;
+    int clusterSize() const { return theClusterSize; }
 
-private:
-  GEMDetId theGEMId;
-  int theBx;
-  int theFirstStrip;
-  int theClusterSize;
-  // Position and error in the Local Ref. Frame of the GEMLayer
-  LocalPoint theLocalPosition;
-  LocalError theLocalError;
-};
+    /// Comparison operator, based on the gemId and the digi time
+    bool operator==(const GEMRecHit& hit) const;
+
+  private:
+    GEMDetId theGEMId;
+    int theBx;
+    int theFirstStrip;
+    int theClusterSize;
+    // Position and error in the Local Ref. Frame of the GEMLayer
+    LocalPoint theLocalPosition;
+    LocalError theLocalError;
+  };
+
+  std::ostream& operator<<(std::ostream& os, const GEMRecHit& hit);
+
+}  // namespace io_v1
+using GEMRecHit = io_v1::GEMRecHit;
+
 #endif
-
-/// The ostream operator
-std::ostream& operator<<(std::ostream& os, const GEMRecHit& hit);

--- a/DataFormats/GEMRecHit/interface/GEMSegment.h
+++ b/DataFormats/GEMRecHit/interface/GEMSegment.h
@@ -15,88 +15,93 @@
 
 #include <iosfwd>
 
-class GEMSegment final : public RecSegment {
-public:
-  /// Default constructor
-  GEMSegment() : theChi2(0.) {}
+namespace io_v1 {
 
-  /// Constructor
-  GEMSegment(const std::vector<const GEMRecHit*>& proto_segment,
-             const LocalPoint& origin,
-             const LocalVector& direction,
-             const AlgebraicSymMatrix& errors,
-             double chi2);
+  class GEMSegment final : public RecSegment {
+  public:
+    /// Default constructor
+    GEMSegment() : theChi2(0.) {}
 
-  GEMSegment(const std::vector<const GEMRecHit*>& proto_segment,
-             const LocalPoint& origin,
-             const LocalVector& direction,
-             const AlgebraicSymMatrix& errors,
-             double chi2,
-             float bx);
+    /// Constructor
+    GEMSegment(const std::vector<const GEMRecHit*>& proto_segment,
+               const LocalPoint& origin,
+               const LocalVector& direction,
+               const AlgebraicSymMatrix& errors,
+               double chi2);
 
-  GEMSegment(const std::vector<const GEMRecHit*>& proto_segment,
-             const LocalPoint& origin,
-             const LocalVector& direction,
-             const AlgebraicSymMatrix& errors,
-             double chi2,
-             float bx,
-             float deltaPhi);
+    GEMSegment(const std::vector<const GEMRecHit*>& proto_segment,
+               const LocalPoint& origin,
+               const LocalVector& direction,
+               const AlgebraicSymMatrix& errors,
+               double chi2,
+               float bx);
 
-  /// Destructor
-  ~GEMSegment() override;
+    GEMSegment(const std::vector<const GEMRecHit*>& proto_segment,
+               const LocalPoint& origin,
+               const LocalVector& direction,
+               const AlgebraicSymMatrix& errors,
+               double chi2,
+               float bx,
+               float deltaPhi);
 
-  //--- Base class interface
-  GEMSegment* clone() const override { return new GEMSegment(*this); }
+    /// Destructor
+    ~GEMSegment() override;
 
-  LocalPoint localPosition() const override { return theOrigin; }
-  LocalError localPositionError() const override;
+    //--- Base class interface
+    GEMSegment* clone() const override { return new GEMSegment(*this); }
 
-  LocalVector localDirection() const override { return theLocalDirection; }
-  LocalError localDirectionError() const override;
+    LocalPoint localPosition() const override { return theOrigin; }
+    LocalError localPositionError() const override;
 
-  /// Parameters of the segment, for the track fit in the order (dx/dz, dy/dz, x, y )
-  AlgebraicVector parameters() const override;
+    LocalVector localDirection() const override { return theLocalDirection; }
+    LocalError localDirectionError() const override;
 
-  /// Covariance matrix of parameters()
-  AlgebraicSymMatrix parametersError() const override { return theCovMatrix; }
+    /// Parameters of the segment, for the track fit in the order (dx/dz, dy/dz, x, y )
+    AlgebraicVector parameters() const override;
 
-  /// The projection matrix relates the trajectory state parameters to the segment parameters().
-  AlgebraicMatrix projectionMatrix() const override;
+    /// Covariance matrix of parameters()
+    AlgebraicSymMatrix parametersError() const override { return theCovMatrix; }
 
-  std::vector<const TrackingRecHit*> recHits() const override;
+    /// The projection matrix relates the trajectory state parameters to the segment parameters().
+    AlgebraicMatrix projectionMatrix() const override;
 
-  std::vector<TrackingRecHit*> recHits() override;
+    std::vector<const TrackingRecHit*> recHits() const override;
 
-  double chi2() const override { return theChi2; };
+    std::vector<TrackingRecHit*> recHits() override;
 
-  int dimension() const override { return 4; }
+    double chi2() const override { return theChi2; };
 
-  int degreesOfFreedom() const override { return 2 * nRecHits() - 4; }
+    int dimension() const override { return 4; }
 
-  //--- Extension of the interface
+    int degreesOfFreedom() const override { return 2 * nRecHits() - 4; }
 
-  const std::vector<GEMRecHit>& specificRecHits() const { return theGEMRecHits; }
+    //--- Extension of the interface
 
-  int nRecHits() const { return theGEMRecHits.size(); }
+    const std::vector<GEMRecHit>& specificRecHits() const { return theGEMRecHits; }
 
-  GEMDetId gemDetId() const { return geographicalId(); }
+    int nRecHits() const { return theGEMRecHits.size(); }
 
-  float bunchX() const { return theBX; }
+    GEMDetId gemDetId() const { return geographicalId(); }
 
-  float deltaPhi() const { return theDeltaPhi; }
+    float bunchX() const { return theBX; }
 
-  void print() const;
+    float deltaPhi() const { return theDeltaPhi; }
 
-private:
-  std::vector<GEMRecHit> theGEMRecHits;
-  LocalPoint theOrigin;             // in chamber frame - the GeomDet local coordinate system
-  LocalVector theLocalDirection;    // in chamber frame - the GeomDet local coordinate system
-  AlgebraicSymMatrix theCovMatrix;  // the covariance matrix
-  double theChi2;                   // the Chi squared of the segment fit
-  float theBX;                      // the bunch crossing
-  float theDeltaPhi;                // Difference in segment phi position: outer layer - inner lay
-};
+    void print() const;
 
-std::ostream& operator<<(std::ostream& os, const GEMSegment& seg);
+  private:
+    std::vector<GEMRecHit> theGEMRecHits;
+    LocalPoint theOrigin;             // in chamber frame - the GeomDet local coordinate system
+    LocalVector theLocalDirection;    // in chamber frame - the GeomDet local coordinate system
+    AlgebraicSymMatrix theCovMatrix;  // the covariance matrix
+    double theChi2;                   // the Chi squared of the segment fit
+    float theBX;                      // the bunch crossing
+    float theDeltaPhi;                // Difference in segment phi position: outer layer - inner lay
+  };
+
+  std::ostream& operator<<(std::ostream& os, const GEMSegment& seg);
+
+}  // namespace io_v1
+using GEMSegment = io_v1::GEMSegment;
 
 #endif

--- a/DataFormats/GEMRecHit/src/GEMCSCSegment.cc
+++ b/DataFormats/GEMRecHit/src/GEMCSCSegment.cc
@@ -8,112 +8,116 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 
-namespace {
-  // Get CSCDetId from one of the rechits, but then remove the layer part so it's a _chamber_ id
-  inline DetId buildDetId(CSCDetId id) { return CSCDetId(id.endcap(), id.station(), id.ring(), id.chamber(), 0); }
-}  // namespace
+namespace io_v1 {
 
-class ProjectionMatrixDiag {
-  // Aider class to make the return of the projection Matrix thread-safe
-protected:
-  AlgebraicMatrix theProjectionMatrix;
+  namespace {
+    // Get CSCDetId from one of the rechits, but then remove the layer part so it's a _chamber_ id
+    inline DetId buildDetId(CSCDetId id) { return CSCDetId(id.endcap(), id.station(), id.ring(), id.chamber(), 0); }
+  }  // namespace
 
-public:
-  ProjectionMatrixDiag() : theProjectionMatrix(4, 5, 0) {
-    theProjectionMatrix[0][1] = 1;
-    theProjectionMatrix[1][2] = 1;
-    theProjectionMatrix[2][3] = 1;
-    theProjectionMatrix[3][4] = 1;
+  class ProjectionMatrixDiag {
+    // Aider class to make the return of the projection Matrix thread-safe
+  protected:
+    AlgebraicMatrix theProjectionMatrix;
+
+  public:
+    ProjectionMatrixDiag() : theProjectionMatrix(4, 5, 0) {
+      theProjectionMatrix[0][1] = 1;
+      theProjectionMatrix[1][2] = 1;
+      theProjectionMatrix[2][3] = 1;
+      theProjectionMatrix[3][4] = 1;
+    }
+    const AlgebraicMatrix& getMatrix() const { return (theProjectionMatrix); }
+  };
+
+  GEMCSCSegment::GEMCSCSegment(const CSCSegment* csc_segment,
+                               const std::vector<const GEMRecHit*> gem_rhs,
+                               LocalPoint origin,
+                               LocalVector direction,
+                               AlgebraicSymMatrix errors,
+                               double chi2)
+      :
+
+        RecSegment(buildDetId(csc_segment->cscDetId())),
+        theOrigin(origin),
+        theLocalDirection(direction),
+        theCovMatrix(errors),
+        theChi2(chi2) {
+    for (unsigned int i = 0; i < gem_rhs.size(); ++i) {
+      theGEMRecHits.push_back((*gem_rhs[i]));
+    }
+    theCSCSegment = *csc_segment;
+    // LogDebug
+    edm::LogVerbatim("GEMCSCSegment")
+        << "[GEMCSCSegment :: ctor] CSCDetId: " << csc_segment->cscDetId()
+        << " CSC RecHits: " << csc_segment->specificRecHits().size() << " GEM RecHits: " << gem_rhs.size()
+        << "\n"  //  << " Fit chi2: "<<chi2<<" Position: "<<origin<<" Direction: "<<direction
+        << "    CSC Segment Details: \n"
+        << *csc_segment << "\n"
+        << " GEMCSC Segment Details: \n"
+        << *this << "\n"
+        << "[GEMCSCSegment :: ctor] ------------------------------------------------------------";
   }
-  const AlgebraicMatrix& getMatrix() const { return (theProjectionMatrix); }
-};
 
-GEMCSCSegment::GEMCSCSegment(const CSCSegment* csc_segment,
-                             const std::vector<const GEMRecHit*> gem_rhs,
-                             LocalPoint origin,
-                             LocalVector direction,
-                             AlgebraicSymMatrix errors,
-                             double chi2)
-    :
+  GEMCSCSegment::~GEMCSCSegment() {}
 
-      RecSegment(buildDetId(csc_segment->cscDetId())),
-      theOrigin(origin),
-      theLocalDirection(direction),
-      theCovMatrix(errors),
-      theChi2(chi2) {
-  for (unsigned int i = 0; i < gem_rhs.size(); ++i) {
-    theGEMRecHits.push_back((*gem_rhs[i]));
+  std::vector<const TrackingRecHit*> GEMCSCSegment::recHits() const {
+    std::vector<const TrackingRecHit*> pointersOfRecHits;
+    for (std::vector<GEMRecHit>::const_iterator irh = theGEMRecHits.begin(); irh != theGEMRecHits.end(); ++irh) {
+      pointersOfRecHits.push_back(&(*irh));
+    }
+    for (std::vector<CSCRecHit2D>::const_iterator irh = theCSCSegment.specificRecHits().begin();
+         irh != theCSCSegment.specificRecHits().end();
+         ++irh) {
+      pointersOfRecHits.push_back(&(*irh));
+    }
+    return pointersOfRecHits;
   }
-  theCSCSegment = *csc_segment;
-  // LogDebug
-  edm::LogVerbatim("GEMCSCSegment")
-      << "[GEMCSCSegment :: ctor] CSCDetId: " << csc_segment->cscDetId()
-      << " CSC RecHits: " << csc_segment->specificRecHits().size() << " GEM RecHits: " << gem_rhs.size()
-      << "\n"  //  << " Fit chi2: "<<chi2<<" Position: "<<origin<<" Direction: "<<direction
-      << "    CSC Segment Details: \n"
-      << *csc_segment << "\n"
-      << " GEMCSC Segment Details: \n"
-      << *this << "\n"
-      << "[GEMCSCSegment :: ctor] ------------------------------------------------------------";
-}
 
-GEMCSCSegment::~GEMCSCSegment() {}
-
-std::vector<const TrackingRecHit*> GEMCSCSegment::recHits() const {
-  std::vector<const TrackingRecHit*> pointersOfRecHits;
-  for (std::vector<GEMRecHit>::const_iterator irh = theGEMRecHits.begin(); irh != theGEMRecHits.end(); ++irh) {
-    pointersOfRecHits.push_back(&(*irh));
+  std::vector<TrackingRecHit*> GEMCSCSegment::recHits() {
+    std::vector<TrackingRecHit*> pointersOfRecHits;
+    for (std::vector<GEMRecHit>::iterator irh = theGEMRecHits.begin(); irh != theGEMRecHits.end(); ++irh) {
+      pointersOfRecHits.push_back(&(*irh));
+    }
+    return pointersOfRecHits;
   }
-  for (std::vector<CSCRecHit2D>::const_iterator irh = theCSCSegment.specificRecHits().begin();
-       irh != theCSCSegment.specificRecHits().end();
-       ++irh) {
-    pointersOfRecHits.push_back(&(*irh));
+
+  LocalError GEMCSCSegment::localPositionError() const {
+    return LocalError(theCovMatrix[2][2], theCovMatrix[2][3], theCovMatrix[3][3]);
   }
-  return pointersOfRecHits;
-}
 
-std::vector<TrackingRecHit*> GEMCSCSegment::recHits() {
-  std::vector<TrackingRecHit*> pointersOfRecHits;
-  for (std::vector<GEMRecHit>::iterator irh = theGEMRecHits.begin(); irh != theGEMRecHits.end(); ++irh) {
-    pointersOfRecHits.push_back(&(*irh));
+  LocalError GEMCSCSegment::localDirectionError() const {
+    return LocalError(theCovMatrix[0][0], theCovMatrix[0][1], theCovMatrix[1][1]);
   }
-  return pointersOfRecHits;
-}
 
-LocalError GEMCSCSegment::localPositionError() const {
-  return LocalError(theCovMatrix[2][2], theCovMatrix[2][3], theCovMatrix[3][3]);
-}
+  AlgebraicVector GEMCSCSegment::parameters() const {
+    // For consistency with DT, CSC and what we require for the TrackingRecHit interface,
+    // the order of the parameters in the returned vector should be (dx/dz, dy/dz, x, z)
 
-LocalError GEMCSCSegment::localDirectionError() const {
-  return LocalError(theCovMatrix[0][0], theCovMatrix[0][1], theCovMatrix[1][1]);
-}
-
-AlgebraicVector GEMCSCSegment::parameters() const {
-  // For consistency with DT, CSC and what we require for the TrackingRecHit interface,
-  // the order of the parameters in the returned vector should be (dx/dz, dy/dz, x, z)
-
-  AlgebraicVector result(4);
-  if (theLocalDirection.z() != 0) {
-    result[0] = theLocalDirection.x() / theLocalDirection.z();
-    result[1] = theLocalDirection.y() / theLocalDirection.z();
+    AlgebraicVector result(4);
+    if (theLocalDirection.z() != 0) {
+      result[0] = theLocalDirection.x() / theLocalDirection.z();
+      result[1] = theLocalDirection.y() / theLocalDirection.z();
+    }
+    result[2] = theOrigin.x();
+    result[3] = theOrigin.y();
+    return result;
   }
-  result[2] = theOrigin.x();
-  result[3] = theOrigin.y();
-  return result;
-}
 
-AlgebraicMatrix GEMCSCSegment::projectionMatrix() const {
-  static const ProjectionMatrixDiag theProjectionMatrix;
-  return (theProjectionMatrix.getMatrix());
-}
+  AlgebraicMatrix GEMCSCSegment::projectionMatrix() const {
+    static const ProjectionMatrixDiag theProjectionMatrix;
+    return (theProjectionMatrix.getMatrix());
+  }
 
-std::ostream& operator<<(std::ostream& os, const GEMCSCSegment& seg) {
-  os << "GEMCSCSegment: local pos = " << seg.localPosition() << " posErr = (" << sqrt(seg.localPositionError().xx())
-     << "," << sqrt(seg.localPositionError().yy()) << "0,)\n"
-     << "            dir = " << seg.localDirection() << " dirErr = (" << sqrt(seg.localDirectionError().xx()) << ","
-     << sqrt(seg.localDirectionError().yy()) << "0,)\n"
-     << "            chi2/ndf = "
-     << ((seg.degreesOfFreedom() != 0) ? (seg.chi2() / double(seg.degreesOfFreedom())) : 0.0)
-     << " #rechits = " << seg.nRecHits();
-  return os;
-}
+  std::ostream& operator<<(std::ostream& os, const GEMCSCSegment& seg) {
+    os << "GEMCSCSegment: local pos = " << seg.localPosition() << " posErr = (" << sqrt(seg.localPositionError().xx())
+       << "," << sqrt(seg.localPositionError().yy()) << "0,)\n"
+       << "            dir = " << seg.localDirection() << " dirErr = (" << sqrt(seg.localDirectionError().xx()) << ","
+       << sqrt(seg.localDirectionError().yy()) << "0,)\n"
+       << "            chi2/ndf = "
+       << ((seg.degreesOfFreedom() != 0) ? (seg.chi2() / double(seg.degreesOfFreedom())) : 0.0)
+       << " #rechits = " << seg.nRecHits();
+    return os;
+  }
+
+}  // namespace io_v1

--- a/DataFormats/GEMRecHit/src/GEMRecHit.cc
+++ b/DataFormats/GEMRecHit/src/GEMRecHit.cc
@@ -6,77 +6,86 @@
 
 #include "DataFormats/GEMRecHit/interface/GEMRecHit.h"
 
-GEMRecHit::GEMRecHit(const GEMDetId& gemId, int bx)
-    : RecHit2DLocalPos(gemId),
-      theGEMId(gemId),
-      theBx(bx),
-      theFirstStrip(99),
-      theClusterSize(99),
-      theLocalPosition(),
-      theLocalError() {}
+namespace io_v1 {
 
-GEMRecHit::GEMRecHit()
-    : RecHit2DLocalPos(),
-      theGEMId(),
-      theBx(99),
-      theFirstStrip(99),
-      theClusterSize(99),
-      theLocalPosition(),
-      theLocalError() {}
+  GEMRecHit::GEMRecHit(const GEMDetId& gemId, int bx)
+      : RecHit2DLocalPos(gemId),
+        theGEMId(gemId),
+        theBx(bx),
+        theFirstStrip(99),
+        theClusterSize(99),
+        theLocalPosition(),
+        theLocalError() {}
 
-GEMRecHit::GEMRecHit(const GEMDetId& gemId, int bx, const LocalPoint& pos)
-    : RecHit2DLocalPos(gemId), theGEMId(gemId), theBx(bx), theFirstStrip(99), theClusterSize(99), theLocalPosition(pos) {
-  float stripResolution = 3.0;  //cm  this sould be taken from trimmed cluster size times strip size
-                                //    taken out from geometry service i.e. topology
-  theLocalError = LocalError(stripResolution * stripResolution, 0., 0.);  //FIXME: is it really needed?
-}
+  GEMRecHit::GEMRecHit()
+      : RecHit2DLocalPos(),
+        theGEMId(),
+        theBx(99),
+        theFirstStrip(99),
+        theClusterSize(99),
+        theLocalPosition(),
+        theLocalError() {}
 
-// Constructor from a local position and error, wireId and digi time.
-GEMRecHit::GEMRecHit(const GEMDetId& gemId, int bx, const LocalPoint& pos, const LocalError& err)
-    : RecHit2DLocalPos(gemId),
-      theGEMId(gemId),
-      theBx(bx),
-      theFirstStrip(99),
-      theClusterSize(99),
-      theLocalPosition(pos),
-      theLocalError(err) {}
+  GEMRecHit::GEMRecHit(const GEMDetId& gemId, int bx, const LocalPoint& pos)
+      : RecHit2DLocalPos(gemId),
+        theGEMId(gemId),
+        theBx(bx),
+        theFirstStrip(99),
+        theClusterSize(99),
+        theLocalPosition(pos) {
+    float stripResolution = 3.0;  //cm  this sould be taken from trimmed cluster size times strip size
+                                  //    taken out from geometry service i.e. topology
+    theLocalError = LocalError(stripResolution * stripResolution, 0., 0.);  //FIXME: is it really needed?
+  }
 
-// Constructor from a local position and error, wireId, bx and cluster size.
-GEMRecHit::GEMRecHit(
-    const GEMDetId& gemId, int bx, int firstStrip, int clustSize, const LocalPoint& pos, const LocalError& err)
-    : RecHit2DLocalPos(gemId),
-      theGEMId(gemId),
-      theBx(bx),
-      theFirstStrip(firstStrip),
-      theClusterSize(clustSize),
-      theLocalPosition(pos),
-      theLocalError(err) {}
+  // Constructor from a local position and error, wireId and digi time.
+  GEMRecHit::GEMRecHit(const GEMDetId& gemId, int bx, const LocalPoint& pos, const LocalError& err)
+      : RecHit2DLocalPos(gemId),
+        theGEMId(gemId),
+        theBx(bx),
+        theFirstStrip(99),
+        theClusterSize(99),
+        theLocalPosition(pos),
+        theLocalError(err) {}
 
-// Destructor
-GEMRecHit::~GEMRecHit() {}
+  // Constructor from a local position and error, wireId, bx and cluster size.
+  GEMRecHit::GEMRecHit(
+      const GEMDetId& gemId, int bx, int firstStrip, int clustSize, const LocalPoint& pos, const LocalError& err)
+      : RecHit2DLocalPos(gemId),
+        theGEMId(gemId),
+        theBx(bx),
+        theFirstStrip(firstStrip),
+        theClusterSize(clustSize),
+        theLocalPosition(pos),
+        theLocalError(err) {}
 
-GEMRecHit* GEMRecHit::clone() const { return new GEMRecHit(*this); }
+  // Destructor
+  GEMRecHit::~GEMRecHit() {}
 
-// Access to component RecHits.
-// No components rechits: it returns a null vector
-std::vector<const TrackingRecHit*> GEMRecHit::recHits() const {
-  std::vector<const TrackingRecHit*> nullvector;
-  return nullvector;
-}
+  GEMRecHit* GEMRecHit::clone() const { return new GEMRecHit(*this); }
 
-// Non-const access to component RecHits.
-// No components rechits: it returns a null vector
-std::vector<TrackingRecHit*> GEMRecHit::recHits() {
-  std::vector<TrackingRecHit*> nullvector;
-  return nullvector;
-}
+  // Access to component RecHits.
+  // No components rechits: it returns a null vector
+  std::vector<const TrackingRecHit*> GEMRecHit::recHits() const {
+    std::vector<const TrackingRecHit*> nullvector;
+    return nullvector;
+  }
 
-// Comparison operator, based on the wireId and the digi time
-bool GEMRecHit::operator==(const GEMRecHit& hit) const { return this->geographicalId() == hit.geographicalId(); }
+  // Non-const access to component RecHits.
+  // No components rechits: it returns a null vector
+  std::vector<TrackingRecHit*> GEMRecHit::recHits() {
+    std::vector<TrackingRecHit*> nullvector;
+    return nullvector;
+  }
 
-// The ostream operator
-std::ostream& operator<<(std::ostream& os, const GEMRecHit& hit) {
-  os << "pos: " << hit.localPosition().x();
-  os << " +/- " << sqrt(hit.localPositionError().xx());
-  return os;
-}
+  // Comparison operator, based on the wireId and the digi time
+  bool GEMRecHit::operator==(const GEMRecHit& hit) const { return this->geographicalId() == hit.geographicalId(); }
+
+  // The ostream operator
+  std::ostream& operator<<(std::ostream& os, const GEMRecHit& hit) {
+    os << "pos: " << hit.localPosition().x();
+    os << " +/- " << sqrt(hit.localPositionError().xx());
+    return os;
+  }
+
+}  // namespace io_v1

--- a/DataFormats/GEMRecHit/src/GEMSegment.cc
+++ b/DataFormats/GEMRecHit/src/GEMSegment.cc
@@ -6,134 +6,140 @@
 #include "DataFormats/GEMRecHit/interface/GEMSegment.h"
 #include <iostream>
 
-namespace {
-  // create reference GEM Chamber ID for segment
-  inline DetId buildDetId(GEMDetId id) { return GEMDetId(id.superChamberId()); }
-}  // namespace
+namespace io_v1 {
 
-class ProjectionMatrixDiag {
-  // Aider class to make the return of the projection Matrix thread-safe
-protected:
-  AlgebraicMatrix theProjectionMatrix;
+  namespace {
+    // create reference GEM Chamber ID for segment
+    inline DetId buildDetId(GEMDetId id) { return GEMDetId(id.superChamberId()); }
+  }  // namespace
 
-public:
-  ProjectionMatrixDiag() : theProjectionMatrix(4, 5, 0) {
-    theProjectionMatrix[0][1] = 1;
-    theProjectionMatrix[1][2] = 1;
-    theProjectionMatrix[2][3] = 1;
-    theProjectionMatrix[3][4] = 1;
+  class ProjectionMatrixDiag {
+    // Aider class to make the return of the projection Matrix thread-safe
+  protected:
+    AlgebraicMatrix theProjectionMatrix;
+
+  public:
+    ProjectionMatrixDiag() : theProjectionMatrix(4, 5, 0) {
+      theProjectionMatrix[0][1] = 1;
+      theProjectionMatrix[1][2] = 1;
+      theProjectionMatrix[2][3] = 1;
+      theProjectionMatrix[3][4] = 1;
+    }
+    const AlgebraicMatrix& getMatrix() const { return (theProjectionMatrix); }
+  };
+
+  GEMSegment::GEMSegment(const std::vector<const GEMRecHit*>& proto_segment,
+                         const LocalPoint& origin,
+                         const LocalVector& direction,
+                         const AlgebraicSymMatrix& errors,
+                         double chi2)
+      : RecSegment(buildDetId(proto_segment.front()->gemId())),
+        theOrigin(origin),
+        theLocalDirection(direction),
+        theCovMatrix(errors),
+        theChi2(chi2) {
+    theBX = -10.0;
+    theDeltaPhi = -10.0;
+    for (unsigned int i = 0; i < proto_segment.size(); ++i)
+      theGEMRecHits.push_back(*proto_segment[i]);
   }
-  const AlgebraicMatrix& getMatrix() const { return (theProjectionMatrix); }
-};
 
-GEMSegment::GEMSegment(const std::vector<const GEMRecHit*>& proto_segment,
-                       const LocalPoint& origin,
-                       const LocalVector& direction,
-                       const AlgebraicSymMatrix& errors,
-                       double chi2)
-    : RecSegment(buildDetId(proto_segment.front()->gemId())),
-      theOrigin(origin),
-      theLocalDirection(direction),
-      theCovMatrix(errors),
-      theChi2(chi2) {
-  theBX = -10.0;
-  theDeltaPhi = -10.0;
-  for (unsigned int i = 0; i < proto_segment.size(); ++i)
-    theGEMRecHits.push_back(*proto_segment[i]);
-}
-
-GEMSegment::GEMSegment(const std::vector<const GEMRecHit*>& proto_segment,
-                       const LocalPoint& origin,
-                       const LocalVector& direction,
-                       const AlgebraicSymMatrix& errors,
-                       double chi2,
-                       float bx)
-    : RecSegment(buildDetId(proto_segment.front()->gemId())),
-      theOrigin(origin),
-      theLocalDirection(direction),
-      theCovMatrix(errors),
-      theChi2(chi2),
-      theBX(bx) {
-  theDeltaPhi = -10.0;
-  for (unsigned int i = 0; i < proto_segment.size(); ++i)
-    theGEMRecHits.push_back(*proto_segment[i]);
-}
-
-GEMSegment::GEMSegment(const std::vector<const GEMRecHit*>& proto_segment,
-                       const LocalPoint& origin,
-                       const LocalVector& direction,
-                       const AlgebraicSymMatrix& errors,
-                       double chi2,
-                       float bx,
-                       float deltaPhi)
-    : RecSegment(buildDetId(proto_segment.front()->gemId())),
-      theOrigin(origin),
-      theLocalDirection(direction),
-      theCovMatrix(errors),
-      theChi2(chi2),
-      theBX(bx),
-      theDeltaPhi(deltaPhi) {
-  for (unsigned int i = 0; i < proto_segment.size(); ++i)
-    theGEMRecHits.push_back(*proto_segment[i]);
-}
-
-GEMSegment::~GEMSegment() {}
-
-std::vector<const TrackingRecHit*> GEMSegment::recHits() const {
-  std::vector<const TrackingRecHit*> pointersOfRecHits;
-  for (std::vector<GEMRecHit>::const_iterator irh = theGEMRecHits.begin(); irh != theGEMRecHits.end(); ++irh) {
-    pointersOfRecHits.push_back(&(*irh));
+  GEMSegment::GEMSegment(const std::vector<const GEMRecHit*>& proto_segment,
+                         const LocalPoint& origin,
+                         const LocalVector& direction,
+                         const AlgebraicSymMatrix& errors,
+                         double chi2,
+                         float bx)
+      : RecSegment(buildDetId(proto_segment.front()->gemId())),
+        theOrigin(origin),
+        theLocalDirection(direction),
+        theCovMatrix(errors),
+        theChi2(chi2),
+        theBX(bx) {
+    theDeltaPhi = -10.0;
+    for (unsigned int i = 0; i < proto_segment.size(); ++i)
+      theGEMRecHits.push_back(*proto_segment[i]);
   }
-  return pointersOfRecHits;
-}
 
-std::vector<TrackingRecHit*> GEMSegment::recHits() {
-  std::vector<TrackingRecHit*> pointersOfRecHits;
-  for (std::vector<GEMRecHit>::iterator irh = theGEMRecHits.begin(); irh != theGEMRecHits.end(); ++irh) {
-    pointersOfRecHits.push_back(&(*irh));
+  GEMSegment::GEMSegment(const std::vector<const GEMRecHit*>& proto_segment,
+                         const LocalPoint& origin,
+                         const LocalVector& direction,
+                         const AlgebraicSymMatrix& errors,
+                         double chi2,
+                         float bx,
+                         float deltaPhi)
+      : RecSegment(buildDetId(proto_segment.front()->gemId())),
+        theOrigin(origin),
+        theLocalDirection(direction),
+        theCovMatrix(errors),
+        theChi2(chi2),
+        theBX(bx),
+        theDeltaPhi(deltaPhi) {
+    for (unsigned int i = 0; i < proto_segment.size(); ++i)
+      theGEMRecHits.push_back(*proto_segment[i]);
   }
-  return pointersOfRecHits;
-}
 
-LocalError GEMSegment::localPositionError() const {
-  return LocalError(theCovMatrix[2][2], theCovMatrix[2][3], theCovMatrix[3][3]);
-}
+  GEMSegment::~GEMSegment() {}
 
-LocalError GEMSegment::localDirectionError() const {
-  return LocalError(theCovMatrix[0][0], theCovMatrix[0][1], theCovMatrix[1][1]);
-}
-
-AlgebraicVector GEMSegment::parameters() const {
-  // For consistency with DT and CSC  and what we require for the TrackingRecHit interface,
-  // the order of the parameters in the returned vector should be (dx/dz, dy/dz, x, z)
-
-  AlgebraicVector result(4);
-
-  if (theLocalDirection.z() != 0) {
-    result[0] = theLocalDirection.x() / theLocalDirection.z();
-    result[1] = theLocalDirection.y() / theLocalDirection.z();
+  std::vector<const TrackingRecHit*> GEMSegment::recHits() const {
+    std::vector<const TrackingRecHit*> pointersOfRecHits;
+    for (std::vector<GEMRecHit>::const_iterator irh = theGEMRecHits.begin(); irh != theGEMRecHits.end(); ++irh) {
+      pointersOfRecHits.push_back(&(*irh));
+    }
+    return pointersOfRecHits;
   }
-  result[2] = theOrigin.x();
-  result[3] = theOrigin.y();
 
-  return result;
-}
+  std::vector<TrackingRecHit*> GEMSegment::recHits() {
+    std::vector<TrackingRecHit*> pointersOfRecHits;
+    for (std::vector<GEMRecHit>::iterator irh = theGEMRecHits.begin(); irh != theGEMRecHits.end(); ++irh) {
+      pointersOfRecHits.push_back(&(*irh));
+    }
+    return pointersOfRecHits;
+  }
 
-AlgebraicMatrix GEMSegment::projectionMatrix() const {
-  static const ProjectionMatrixDiag theProjectionMatrix;
-  return (theProjectionMatrix.getMatrix());
-}
+  LocalError GEMSegment::localPositionError() const {
+    return LocalError(theCovMatrix[2][2], theCovMatrix[2][3], theCovMatrix[3][3]);
+  }
 
-//
-void GEMSegment::print() const { LogDebug("GEMSegment") << *this; }
+  LocalError GEMSegment::localDirectionError() const {
+    return LocalError(theCovMatrix[0][0], theCovMatrix[0][1], theCovMatrix[1][1]);
+  }
 
-std::ostream& operator<<(std::ostream& os, const GEMSegment& seg) {
-  os << "GEMSegment: local pos = " << seg.localPosition() << " posErr = (" << sqrt(seg.localPositionError().xx()) << ","
-     << sqrt(seg.localPositionError().yy()) << "0,)\n"
-     << "            dir = " << seg.localDirection() << " dirErr = (" << sqrt(seg.localDirectionError().xx()) << ","
-     << sqrt(seg.localDirectionError().yy()) << "0,)\n"
-     << "            chi2/ndf = " << ((seg.degreesOfFreedom() != 0.) ? seg.chi2() / double(seg.degreesOfFreedom()) : 0)
-     << " #rechits = " << seg.specificRecHits().size() << " bx = " << seg.bunchX() << " deltaPhi = " << seg.deltaPhi();
+  AlgebraicVector GEMSegment::parameters() const {
+    // For consistency with DT and CSC  and what we require for the TrackingRecHit interface,
+    // the order of the parameters in the returned vector should be (dx/dz, dy/dz, x, z)
 
-  return os;
-}
+    AlgebraicVector result(4);
+
+    if (theLocalDirection.z() != 0) {
+      result[0] = theLocalDirection.x() / theLocalDirection.z();
+      result[1] = theLocalDirection.y() / theLocalDirection.z();
+    }
+    result[2] = theOrigin.x();
+    result[3] = theOrigin.y();
+
+    return result;
+  }
+
+  AlgebraicMatrix GEMSegment::projectionMatrix() const {
+    static const ProjectionMatrixDiag theProjectionMatrix;
+    return (theProjectionMatrix.getMatrix());
+  }
+
+  //
+  void GEMSegment::print() const { LogDebug("GEMSegment") << *this; }
+
+  std::ostream& operator<<(std::ostream& os, const GEMSegment& seg) {
+    os << "GEMSegment: local pos = " << seg.localPosition() << " posErr = (" << sqrt(seg.localPositionError().xx())
+       << "," << sqrt(seg.localPositionError().yy()) << "0,)\n"
+       << "            dir = " << seg.localDirection() << " dirErr = (" << sqrt(seg.localDirectionError().xx()) << ","
+       << sqrt(seg.localDirectionError().yy()) << "0,)\n"
+       << "            chi2/ndf = "
+       << ((seg.degreesOfFreedom() != 0.) ? seg.chi2() / double(seg.degreesOfFreedom()) : 0)
+       << " #rechits = " << seg.specificRecHits().size() << " bx = " << seg.bunchX()
+       << " deltaPhi = " << seg.deltaPhi();
+
+    return os;
+  }
+
+}  // namespace io_v1

--- a/DataFormats/GEMRecHit/src/classes_def.xml
+++ b/DataFormats/GEMRecHit/src/classes_def.xml
@@ -1,17 +1,16 @@
 <lcgdict>
 <selection>
 
-  <class name="GEMRecHit" splitLevel="0" ClassVersion="11">
-  <version ClassVersion="11" checksum="3146992425"/>
-  <version ClassVersion="10" checksum="3680872192"/>
+  <class name="io_v1::GEMRecHit" splitLevel="0" ClassVersion="3">
+  <version ClassVersion="3" checksum="4164786089"/>
   </class>
-  <class name="std::vector<GEMRecHit>" splitLevel="0"/>
-  <class name="std::vector<GEMRecHit*>" splitLevel="0"/>
+  <class name="std::vector<io_v1::GEMRecHit>" splitLevel="0"/>
+  <class name="std::vector<io_v1::GEMRecHit*>" splitLevel="0"/>
   <class name="std::map<GEMDetId, std::pair<unsigned int, unsigned int> >" splitLevel="0"/>
   <class name="std::map<GEMDetId, std::pair<unsigned long, unsigned long> >" splitLevel="0"/>
-  <class name="edm::OwnVector<GEMRecHit, edm::ClonePolicy<GEMRecHit> >" splitLevel="0"  rntupleStreamerMode="true"/>
-  <class name="edm::RangeMap<GEMDetId, edm::OwnVector<GEMRecHit, edm::ClonePolicy<GEMRecHit> >, edm::ClonePolicy<GEMRecHit> >" splitLevel="0"/>
-  <class name="edm::Wrapper<edm::RangeMap<GEMDetId, edm::OwnVector<GEMRecHit, edm::ClonePolicy<GEMRecHit> >, edm::ClonePolicy<GEMRecHit> > >" splitLevel="0"/>
+  <class name="edm::OwnVector<io_v1::GEMRecHit, edm::ClonePolicy<io_v1::GEMRecHit> >" splitLevel="0"  rntupleStreamerMode="true"/>
+  <class name="edm::RangeMap<GEMDetId, edm::OwnVector<io_v1::GEMRecHit, edm::ClonePolicy<io_v1::GEMRecHit> >, edm::ClonePolicy<io_v1::GEMRecHit> >" splitLevel="0"/>
+  <class name="edm::Wrapper<edm::RangeMap<GEMDetId, edm::OwnVector<io_v1::GEMRecHit, edm::ClonePolicy<io_v1::GEMRecHit> >, edm::ClonePolicy<io_v1::GEMRecHit> > >" splitLevel="0"/>
 
   <class name="ME0RecHit" splitLevel="0" ClassVersion="11">
   <version ClassVersion="11" checksum="3948270793"/>
@@ -25,28 +24,22 @@
   <class name="edm::RangeMap<ME0DetId, edm::OwnVector<ME0RecHit, edm::ClonePolicy<ME0RecHit> >, edm::ClonePolicy<ME0RecHit> >" splitLevel="0"/>
   <class name="edm::Wrapper<edm::RangeMap<ME0DetId, edm::OwnVector<ME0RecHit, edm::ClonePolicy<ME0RecHit> >, edm::ClonePolicy<ME0RecHit> > >" splitLevel="0"/>
 
-  <class name="GEMCSCSegment" splitLevel="0" ClassVersion="12">
-  <version ClassVersion="12" checksum="3885697532"/>
-  <version ClassVersion="11" checksum="2470665576"/>
-  <version ClassVersion="10" checksum="2470665576"/>
+  <class name="io_v1::GEMCSCSegment" splitLevel="0" ClassVersion="3">
+  <version ClassVersion="3" checksum="2523382514"/>
   </class>
-  <class name="std::vector<GEMCSCSegment*>" splitLevel="0"/>
-  <class name="edm::OwnVector<GEMCSCSegment,edm::ClonePolicy<GEMCSCSegment> >" splitLevel="0"  rntupleStreamerMode="true"/>
-  <class name="edm::RangeMap<CSCDetId,edm::OwnVector<GEMCSCSegment,edm::ClonePolicy<GEMCSCSegment> >,edm::ClonePolicy<GEMCSCSegment> >" splitLevel="0"/>
-  <class name="edm::Wrapper<edm::RangeMap<CSCDetId,edm::OwnVector<GEMCSCSegment,edm::ClonePolicy<GEMCSCSegment> >,edm::ClonePolicy<GEMCSCSegment> > >" splitLevel="0"/>
+  <class name="std::vector<io_v1::GEMCSCSegment*>" splitLevel="0"/>
+  <class name="edm::OwnVector<io_v1::GEMCSCSegment,edm::ClonePolicy<io_v1::GEMCSCSegment> >" splitLevel="0"  rntupleStreamerMode="true"/>
+  <class name="edm::RangeMap<CSCDetId,edm::OwnVector<io_v1::GEMCSCSegment,edm::ClonePolicy<io_v1::GEMCSCSegment> >,edm::ClonePolicy<io_v1::GEMCSCSegment> >" splitLevel="0"/>
+  <class name="edm::Wrapper<edm::RangeMap<CSCDetId,edm::OwnVector<io_v1::GEMCSCSegment,edm::ClonePolicy<io_v1::GEMCSCSegment> >,edm::ClonePolicy<io_v1::GEMCSCSegment> > >" splitLevel="0"/>
   <class name="GEMCSCSegmentRef" splitLevel="0"/>
 
-  <class name="GEMSegment" ClassVersion="4">
-  <version ClassVersion="4" checksum="1506093327"/>
-  <version ClassVersion="3" checksum="1513163288"/>
-  <ioread sourceClass="GEMSegment" version="[-3]" targetClass="GEMSegment" source="" target="theDeltaPhi">
-    <![CDATA[ theDeltaPhi = -10.; ]]>
-  </ioread>
+  <class name="io_v1::GEMSegment" ClassVersion="3">
+  <version ClassVersion="3" checksum="883436307"/>
   </class>
-  <class name="std::vector<GEMSegment*>" splitLevel="0"/>
-  <class name="edm::OwnVector<GEMSegment,edm::ClonePolicy<GEMSegment> >" splitLevel="0"  rntupleStreamerMode="true"/>
-  <class name="edm::RangeMap<GEMDetId,edm::OwnVector<GEMSegment,edm::ClonePolicy<GEMSegment> >,edm::ClonePolicy<GEMSegment> >" splitLevel="0"/>
-  <class name="edm::Wrapper<edm::RangeMap<GEMDetId,edm::OwnVector<GEMSegment,edm::ClonePolicy<GEMSegment> >,edm::ClonePolicy<GEMSegment> > >" splitLevel="0"/>
+  <class name="std::vector<io_v1::GEMSegment*>" splitLevel="0"/>
+  <class name="edm::OwnVector<io_v1::GEMSegment,edm::ClonePolicy<io_v1::GEMSegment> >" splitLevel="0"  rntupleStreamerMode="true"/>
+  <class name="edm::RangeMap<GEMDetId,edm::OwnVector<io_v1::GEMSegment,edm::ClonePolicy<io_v1::GEMSegment> >,edm::ClonePolicy<io_v1::GEMSegment> >" splitLevel="0"/>
+  <class name="edm::Wrapper<edm::RangeMap<GEMDetId,edm::OwnVector<io_v1::GEMSegment,edm::ClonePolicy<io_v1::GEMSegment> >,edm::ClonePolicy<io_v1::GEMSegment> > >" splitLevel="0"/>
   <class name="GEMSegmentRef" splitLevel="0"/>
 
   <class name="ME0Segment" ClassVersion="13">
@@ -63,13 +56,13 @@
 
 </selection>
 <exclusion>
-  <class name="edm::OwnVector<GEMRecHit, edm::ClonePolicy<GEMRecHit> >">
+  <class name="edm::OwnVector<io_v1::GEMRecHit, edm::ClonePolicy<io_v1::GEMRecHit> >">
     <method name="sort" splitLevel="0"/>
   </class>
   <class name="edm::OwnVector<ME0RecHit, edm::ClonePolicy<ME0RecHit> >">
     <method name="sort" splitLevel="0"/>
   </class>
-  <class name="edm::OwnVector<GEMCSCSegment, edm::ClonePolicy<GEMCSCSegment> >">
+  <class name="edm::OwnVector<io_v1::GEMCSCSegment, edm::ClonePolicy<io_v1::GEMCSCSegment> >">
     <method name="sort" splitLevel="0"/>
   </class>
   <class name="edm::OwnVector<ME0Segment, edm::ClonePolicy<ME0Segment> >">

--- a/DataFormats/L1CSCTrackFinder/src/classes_def.xml
+++ b/DataFormats/L1CSCTrackFinder/src/classes_def.xml
@@ -13,7 +13,7 @@
    </class>
 
    <class name="csctf::io_v1::TrackStub" ClassVersion="3">
-    <version ClassVersion="3" checksum="1384357088"/>
+    <version ClassVersion="3" checksum="3006204060"/>
      <field name="thePhiBinning" transient="true"/>
      <field name="theEtaBinning" transient="true"/>
    </class>

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -56,9 +56,8 @@ initial version number of a class which has never been stored before.
    <version ClassVersion="11" checksum="541727491"/>
    <version ClassVersion="10" checksum="4050071853"/>
   </class>
-  <class name="reco::MuonSegmentMatch" ClassVersion="11">
-    <version ClassVersion="11" checksum="2861296960"/>
-    <version ClassVersion="10" checksum="754193003"/>    
+  <class name="reco::MuonSegmentMatch" ClassVersion="3">
+    <version ClassVersion="3" checksum="3516388384"/>
   </class>
   <class name="reco::MuonRPCHitMatch" ClassVersion="10">
    <version ClassVersion="10" checksum="4193465224"/>


### PR DESCRIPTION
#### PR description:

This PR moves the stored classes in `DataFormats/{CSC,GEM}{Digi,RecHit}` to `io_v1` namespace in the EVOLUTION_X branch. The class versions are also reset to 3.

Resolves https://github.com/cms-sw/framework-team/issues/1964

#### PR validation:

Code compiles