### PR TITLE
Add class version for MtdCaloParticle and other cleanup

### DIFF
--- a/SimDataFormats/CaloAnalysis/interface/CaloParticle.h
+++ b/SimDataFormats/CaloAnalysis/interface/CaloParticle.h
@@ -7,10 +7,9 @@
 #include "DataFormats/Math/interface/Vector3D.h"
 #include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
+#include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 #include "SimDataFormats/Track/interface/SimTrack.h"
 #include <vector>
-
-class EncodedEventId;
 
 class CaloParticle {
   friend std::ostream &operator<<(std::ostream &s, CaloParticle const &tp);

--- a/SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h
+++ b/SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h
@@ -6,12 +6,12 @@
 #include <vector>
 
 class CaloParticle;
+std::ostream &operator<<(std::ostream &s, CaloParticle const &tp);
+
 typedef std::vector<CaloParticle> CaloParticleCollection;
 typedef edm::Ref<CaloParticleCollection> CaloParticleRef;
 typedef edm::RefVector<CaloParticleCollection> CaloParticleRefVector;
 typedef edm::RefProd<CaloParticleCollection> CaloParticleRefProd;
 typedef edm::RefVector<CaloParticleCollection> CaloParticleContainer;
-
-std::ostream &operator<<(std::ostream &s, CaloParticle const &tp);
 
 #endif

--- a/SimDataFormats/CaloAnalysis/interface/MtdCaloParticle.h
+++ b/SimDataFormats/CaloAnalysis/interface/MtdCaloParticle.h
@@ -3,12 +3,11 @@
 
 #include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
 #include "SimDataFormats/CaloAnalysis/interface/MtdSimClusterFwd.h"
+#include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "SimDataFormats/Track/interface/SimTrackFwd.h"
 
 #include <vector>
-
-class EncodedEventId;
 
 class MtdCaloParticle : public CaloParticle {
   friend std::ostream &operator<<(std::ostream &s, MtdCaloParticle const &tp);

--- a/SimDataFormats/CaloAnalysis/interface/MtdCaloParticleFwd.h
+++ b/SimDataFormats/CaloAnalysis/interface/MtdCaloParticleFwd.h
@@ -6,12 +6,12 @@
 #include <vector>
 
 class MtdCaloParticle;
+std::ostream &operator<<(std::ostream &s, MtdCaloParticle const &tp);
+
 typedef std::vector<MtdCaloParticle> MtdCaloParticleCollection;
 typedef edm::Ref<MtdCaloParticleCollection> MtdCaloParticleRef;
 typedef edm::RefVector<MtdCaloParticleCollection> MtdCaloParticleRefVector;
 typedef edm::RefProd<MtdCaloParticleCollection> MtdCaloParticleRefProd;
 typedef edm::RefVector<MtdCaloParticleCollection> MtdCaloParticleContainer;
-
-std::ostream &operator<<(std::ostream &s, MtdCaloParticle const &tp);
 
 #endif

--- a/SimDataFormats/CaloAnalysis/interface/MtdSimClusterFwd.h
+++ b/SimDataFormats/CaloAnalysis/interface/MtdSimClusterFwd.h
@@ -6,12 +6,12 @@
 #include <vector>
 
 class MtdSimCluster;
+std::ostream &operator<<(std::ostream &s, MtdSimCluster const &tp);
+
 typedef std::vector<MtdSimCluster> MtdSimClusterCollection;
 typedef edm::Ref<MtdSimClusterCollection> MtdSimClusterRef;
 typedef edm::RefVector<MtdSimClusterCollection> MtdSimClusterRefVector;
 typedef edm::RefProd<MtdSimClusterCollection> MtdSimClusterRefProd;
 typedef edm::RefVector<MtdSimClusterCollection> MtdSimClusterContainer;
-
-std::ostream &operator<<(std::ostream &s, MtdSimCluster const &tp);
 
 #endif

--- a/SimDataFormats/CaloAnalysis/interface/MtdSimTracksterFwd.h
+++ b/SimDataFormats/CaloAnalysis/interface/MtdSimTracksterFwd.h
@@ -6,12 +6,12 @@
 #include <vector>
 
 class MtdSimTrackster;
+std::ostream &operator<<(std::ostream &s, MtdSimTrackster const &tp);
+
 typedef std::vector<MtdSimTrackster> MtdSimTracksterCollection;
 typedef edm::Ref<MtdSimTracksterCollection> MtdSimTracksterRef;
 typedef edm::RefVector<MtdSimTracksterCollection> MtdSimTracksterRefVector;
 typedef edm::RefProd<MtdSimTracksterCollection> MtdSimTracksterRefProd;
 typedef edm::RefVector<MtdSimTracksterCollection> MtdSimTracksterContainer;
-
-std::ostream &operator<<(std::ostream &s, MtdSimTrackster const &tp);
 
 #endif

--- a/SimDataFormats/CaloAnalysis/interface/SimCluster.h
+++ b/SimDataFormats/CaloAnalysis/interface/SimCluster.h
@@ -6,6 +6,7 @@
 #include "DataFormats/Math/interface/Point3D.h"
 #include "DataFormats/Math/interface/Vector3D.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
+#include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 #include "SimDataFormats/Track/interface/SimTrack.h"
 #include <vector>
 #include <functional>
@@ -13,11 +14,6 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
-
-//
-// Forward declarations
-//
-class EncodedEventId;
 
 /** @brief Monte Carlo truth information used for tracking validation.
  *

--- a/SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h
+++ b/SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h
@@ -6,12 +6,12 @@
 #include <vector>
 
 class SimCluster;
+std::ostream &operator<<(std::ostream &s, SimCluster const &tp);
+
 typedef std::vector<SimCluster> SimClusterCollection;
 typedef edm::Ref<SimClusterCollection> SimClusterRef;
 typedef edm::RefVector<SimClusterCollection> SimClusterRefVector;
 typedef edm::RefProd<SimClusterCollection> SimClusterRefProd;
 typedef edm::RefVector<SimClusterCollection> SimClusterContainer;
-
-std::ostream &operator<<(std::ostream &s, SimCluster const &tp);
 
 #endif

--- a/SimDataFormats/CaloAnalysis/src/classes_def.xml
+++ b/SimDataFormats/CaloAnalysis/src/classes_def.xml
@@ -10,7 +10,9 @@
   <class name="CaloParticleRefProd"/>
   <class name="CaloParticleContainer"/>
 
-  <class name="MtdCaloParticle"/>
+  <class name="MtdCaloParticle" ClassVersion="3">
+    <version ClassVersion="3" checksum="3222440347"/>
+  </class>
   <class name="MtdCaloParticleCollection"/>
   <class name="edm::Wrapper<MtdCaloParticleCollection>"/>
   <class name="MtdCaloParticleRef"/>

--- a/SimDataFormats/CaloHit/interface/PCaloHit.h
+++ b/SimDataFormats/CaloHit/interface/PCaloHit.h
@@ -3,6 +3,8 @@
 
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 
+#include <iosfwd>
+
 // Persistent Calorimeter hit
 
 class PCaloHit {
@@ -72,7 +74,6 @@ protected:
   EncodedEventId theEventId;
 };
 
-#include <iosfwd>
 std::ostream &operator<<(std::ostream &, const PCaloHit &);
 
 #endif  // _SimDataFormats_SimCaloHit_PCaloHit_h_

--- a/SimDataFormats/DigiSimLinks/interface/DTDigiSimLink.h
+++ b/SimDataFormats/DigiSimLinks/interface/DTDigiSimLink.h
@@ -3,6 +3,9 @@
 
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 
+#include <ostream>
+#include <cstdint>
+
 class DTDigiSimLink {
 public:
   typedef uint32_t ChannelType;
@@ -61,8 +64,6 @@ private:
   EncodedEventId theEventId;
 };
 
-#include <iostream>
-#include <cstdint>
 inline std::ostream& operator<<(std::ostream& o, const DTDigiSimLink& digisimlink) {
   return o << "wire:" << digisimlink.wire() << " digi:" << digisimlink.number() << " time:" << digisimlink.time()
            << " SimTrack:" << digisimlink.SimTrackId() << " eventId:" << digisimlink.eventId().rawId();

--- a/SimDataFormats/Track/interface/SimTrack.h
+++ b/SimDataFormats/Track/interface/SimTrack.h
@@ -6,6 +6,8 @@
 #include "DataFormats/Math/interface/LorentzVector.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
+#include <iosfwd>
+
 class SimTrack : public CoreSimTrack {
 public:
   typedef CoreSimTrack Core;
@@ -88,7 +90,6 @@ private:
   // 00000100 = simTrack crossed the boundary
 };
 
-#include <iosfwd>
 std::ostream& operator<<(std::ostream& o, const SimTrack& t);
 
 #endif

--- a/SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h
+++ b/SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h
@@ -6,15 +6,11 @@
 #include "DataFormats/Math/interface/Point3D.h"
 #include "DataFormats/Math/interface/Vector3D.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
+#include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexFwd.h"
 #include "SimDataFormats/Track/interface/SimTrackFwd.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
-
-//
-// Forward declarations
-//
-class EncodedEventId;
 
 /** @brief Monte Carlo truth information used for tracking validation.
  *

--- a/SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h
+++ b/SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h
@@ -7,13 +7,13 @@
 #include "DataFormats/Common/interface/RefProd.h"
 
 class TrackingParticle;
+std::ostream& operator<<(std::ostream& s, TrackingParticle const& tp);
+
 typedef std::vector<TrackingParticle> TrackingParticleCollection;
 typedef edm::Ptr<TrackingParticle> TrackingParticlePtr;
 typedef edm::Ref<TrackingParticleCollection> TrackingParticleRef;
 typedef edm::RefVector<TrackingParticleCollection> TrackingParticleRefVector;
 typedef edm::RefProd<TrackingParticleCollection> TrackingParticleRefProd;
 typedef edm::RefVector<TrackingParticleCollection> TrackingParticleContainer;
-
-std::ostream& operator<<(std::ostream& s, TrackingParticle const& tp);
 
 #endif

--- a/SimDataFormats/Vertex/interface/SimVertex.h
+++ b/SimDataFormats/Vertex/interface/SimVertex.h
@@ -2,6 +2,8 @@
 #define SimVertex_H
 
 #include "SimDataFormats/Vertex/interface/CoreSimVertex.h"
+#include <iosfwd>
+
 class SimVertex : public CoreSimVertex {
 public:
   typedef CoreSimVertex Core;
@@ -41,7 +43,6 @@ private:
   unsigned int procType;
 };
 
-#include <iosfwd>
 std::ostream& operator<<(std::ostream& o, const SimVertex& v);
 
 #endif


### PR DESCRIPTION
#### PR description:

As a preparatory step for the EVOLUTION_X work in these packages, this PR
* Adds class  version for `MtdCaloParticle`
* Removes `EncodedEventId` forward declarations. They were not useful in practice, because all code that had them used `EncodedEventId` by value (so the full header had to be transitively `#include`d anyway).
* Moving of some code lines (`#include`, declaration of `operator<<()`) such that the future code changes in EVOLUTION_X branch

Resolves https://github.com/cms-sw/framework-team/issues/1984

#### PR validation:

Code compiles in EVOLUTION_X build