### PR TITLE
Make prefetching configurable and default to disabled in RepeatingCachedRootSource

### DIFF
--- a/IOPool/Input/src/RepeatingCachedRootSource.cc
+++ b/IOPool/Input/src/RepeatingCachedRootSource.cc
@@ -137,7 +137,8 @@ namespace edm {
                                            std::shared_ptr<InputFile> filePtr,
                                            std::shared_ptr<EventSkipperByID> skipper,
                                            std::shared_ptr<DuplicateChecker> duplicateChecker,
-                                           std::vector<std::shared_ptr<IndexIntoFile>>& indexesIntoFiles);
+                                           std::vector<std::shared_ptr<IndexIntoFile>>& indexesIntoFiles,
+                                           bool enablePrefetching);
 
     RootServiceChecker rootServiceChecker_;
     ProductSelectorRules selectorRules_;
@@ -198,6 +199,7 @@ RepeatingCachedRootSource::RepeatingCachedRootSource(ParameterSet const& pset, I
   auto const& physicalFileName = catalog.fileCatalogItems().front().fileNames().front();
   auto const nEventsToSkip = pset.getUntrackedParameter<unsigned int>("skipEvents");
   std::shared_ptr<EventSkipperByID> skipper(EventSkipperByID::create(pset).release());
+  auto const enablePrefetching = pset.getUntrackedParameter<bool>("enablePrefetching");
 
   auto duplicateChecker = std::make_shared<DuplicateChecker>(pset);
 
@@ -205,8 +207,14 @@ RepeatingCachedRootSource::RepeatingCachedRootSource(ParameterSet const& pset, I
 
   auto input =
       std::make_shared<InputFile>(physicalFileName.c_str(), "  Initiating request to open file ", InputType::Primary);
-  rootFile_ = makeRootFile(
-      logicalFileName, physicalFileName, 0 != nEventsToSkip, input, skipper, duplicateChecker, indexesIntoFiles);
+  rootFile_ = makeRootFile(logicalFileName,
+                           physicalFileName,
+                           0 != nEventsToSkip,
+                           input,
+                           skipper,
+                           duplicateChecker,
+                           indexesIntoFiles,
+                           enablePrefetching);
   rootFile_->reportOpened("repeating");
 
   std::vector<std::string> processOrder;
@@ -294,6 +302,10 @@ void RepeatingCachedRootSource::fillDescriptions(ConfigurationDescriptions& desc
   desc.addUntracked<unsigned int>("repeatNEvents", 10U)
       ->setComment("Number of events to read from file and then repeat in sequence.");
   desc.addUntracked<unsigned int>("skipEvents", 0);
+  desc.addUntracked<bool>("enablePrefetching", false)
+      ->setComment(
+          "Theoretically prefetching should make the initial read more efficient. However, we have experienced "
+          "problems with that. See issue #49215 for more details.");
   ProductSelectorRules::fillDescription(desc, "inputCommands");
   InputSource::fillDescription(desc);
 
@@ -311,38 +323,39 @@ std::unique_ptr<RootFile> RepeatingCachedRootSource::makeRootFile(
     std::shared_ptr<InputFile> filePtr,
     std::shared_ptr<EventSkipperByID> skipper,
     std::shared_ptr<DuplicateChecker> duplicateChecker,
-    std::vector<std::shared_ptr<IndexIntoFile>>& indexesIntoFiles) {
-  return std::make_unique<RootFile>(
-      RootFile::FileOptions{.fileName = pName,
-                            .logicalFileName = logicalFileName,
-                            .filePtr = filePtr,
-                            .bypassVersionCheck = false,
-                            .enforceGUIDInFileName = false},
-      InputType::Primary,
-      RootFile::ProcessingOptions{.eventSkipperByID = skipper,
-                                  .skipAnyEvents = isSkipping,
-                                  .remainingEvents = remainingEvents(),
-                                  .remainingLumis = remainingLuminosityBlocks(),
-                                  .processingMode = processingMode(),
-                                  .noRunLumiSort = false,
-                                  .noEventSort = true,
-                                  .usingGoToEvent = false},
-      RootFile::TTreeOptions{
-          .treeCacheSize = roottree::defaultCacheSize, .treeMaxVirtualSize = -1, .enablePrefetching = true},
-      RootFile::ProductChoices{.productSelectorRules = selectorRules_,
-                               .associationsFromSecondary = nullptr,
-                               .dropDescendantsOfDroppedProducts = false,
-                               .labelRawDataLikeMC = true},
-      RootFile::CrossFileInfo{.runHelper = runHelper_.get(),
-                              .branchIDListHelper = branchIDListHelper(),
-                              .processBlockHelper = processBlockHelper().get(),
-                              .thinnedAssociationsHelper = thinnedAssociationsHelper(),
-                              .duplicateChecker = duplicateChecker,
-                              .indexesIntoFiles = indexesIntoFiles,
-                              .currentIndexIntoFile = 0},
-      1,
-      processHistoryRegistryForUpdate(),
-      orderedProcessHistoryIDs_);
+    std::vector<std::shared_ptr<IndexIntoFile>>& indexesIntoFiles,
+    bool enablePrefetching) {
+  return std::make_unique<RootFile>(RootFile::FileOptions{.fileName = pName,
+                                                          .logicalFileName = logicalFileName,
+                                                          .filePtr = filePtr,
+                                                          .bypassVersionCheck = false,
+                                                          .enforceGUIDInFileName = false},
+                                    InputType::Primary,
+                                    RootFile::ProcessingOptions{.eventSkipperByID = skipper,
+                                                                .skipAnyEvents = isSkipping,
+                                                                .remainingEvents = remainingEvents(),
+                                                                .remainingLumis = remainingLuminosityBlocks(),
+                                                                .processingMode = processingMode(),
+                                                                .noRunLumiSort = false,
+                                                                .noEventSort = true,
+                                                                .usingGoToEvent = false},
+                                    RootFile::TTreeOptions{.treeCacheSize = roottree::defaultCacheSize,
+                                                           .treeMaxVirtualSize = -1,
+                                                           .enablePrefetching = enablePrefetching},
+                                    RootFile::ProductChoices{.productSelectorRules = selectorRules_,
+                                                             .associationsFromSecondary = nullptr,
+                                                             .dropDescendantsOfDroppedProducts = false,
+                                                             .labelRawDataLikeMC = true},
+                                    RootFile::CrossFileInfo{.runHelper = runHelper_.get(),
+                                                            .branchIDListHelper = branchIDListHelper(),
+                                                            .processBlockHelper = processBlockHelper().get(),
+                                                            .thinnedAssociationsHelper = thinnedAssociationsHelper(),
+                                                            .duplicateChecker = duplicateChecker,
+                                                            .indexesIntoFiles = indexesIntoFiles,
+                                                            .currentIndexIntoFile = 0},
+                                    1,
+                                    processHistoryRegistryForUpdate(),
+                                    orderedProcessHistoryIDs_);
 }
 
 std::shared_ptr<WrapperBase> RepeatingCachedRootSource::getProduct(unsigned int iStreamIndex,


### PR DESCRIPTION
#### PR description:

I experienced again read errors like in https://github.com/cms-sw/cmssw/issues/49215 with MiniAODSIM file and `RepeatingCachedRootSource`. The `RepeatingCachedRootSource` did not provide a way to disable prefetching, so this PR adds such an option. Given the problems I've experienced, we decided to make the default to disable the prefetching.

Resolves https://github.com/cms-sw/framework-team/issues/1985

#### PR validation:

With these changes I was able to use the MiniAODSIM file with `RepeathingCachedRootSource` in a private test.