### PR TITLE
fix `GenericTriggerEventFlag` parameters for stage2 L1T in `DQMOffline/JetMET`

### DIFF
--- a/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
@@ -18,7 +18,7 @@ jetDQMAnalyzerAk4CaloUncleaned = DQMEDAnalyzer('JetAnalyzer',
     #
     #
     highPtJetTrigger = cms.PSet(
-        andOr         = cms.bool( False ),
+        andOr          = cms.bool( False ),
         dbLabel        = cms.string("JetMETDQMTrigger"),
         hltInputTag    = cms.InputTag( "TriggerResults::HLT" ),
         hltPaths       = cms.vstring( 'HLT_PFJet450_v*'), 
@@ -26,7 +26,7 @@ jetDQMAnalyzerAk4CaloUncleaned = DQMEDAnalyzer('JetAnalyzer',
         errorReplyHlt  = cms.bool( False ),
     ),
     lowPtJetTrigger = cms.PSet(
-        andOr         = cms.bool( False ),
+        andOr          = cms.bool( False ),
         dbLabel        = cms.string("JetMETDQMTrigger"),
         hltInputTag    = cms.InputTag( "TriggerResults::HLT" ),
         hltPaths       = cms.vstring( 'HLT_PFJet80_v*'), 
@@ -90,7 +90,15 @@ jetDQMAnalyzerAk4CaloUncleaned = DQMEDAnalyzer('JetAnalyzer',
 ## change the default to stage2 for all current eras
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 stage2L1Trigger.toModify(jetDQMAnalyzerAk4CaloUncleaned,
-                         stage2L1 = True)
+                         stage2L1 = True,
+                         highPtJetTrigger = dict(stage2 = cms.bool(True),
+                                                 l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
+                                                 l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
+                                                 ReadPrescalesFromFile = cms.bool(False)),
+                         lowPtJetTrigger = dict(stage2 = cms.bool(True),
+                                                l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
+                                                l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
+                                                ReadPrescalesFromFile = cms.bool(False)))
 
 jetDQMAnalyzerAk4CaloCleaned=jetDQMAnalyzerAk4CaloUncleaned.clone(
     JetCleaningFlag   = True,
@@ -235,6 +243,17 @@ jetDQMAnalyzerAk4ScoutingUncleaned = jetDQMAnalyzerAk4CaloUncleaned.clone(
       alwaysPass = cms.untracked.bool(False)
     )
 )
+
+stage2L1Trigger.toModify(jetDQMAnalyzerAk4ScoutingUncleaned,
+                         stage2L1 = True,
+                         highPtJetTrigger = dict(stage2 = cms.bool(True),
+                                                 l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
+                                                 l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
+                                                 ReadPrescalesFromFile = cms.bool(False)),
+                         lowPtJetTrigger = dict(stage2 = cms.bool(True),
+                                                l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
+                                                l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
+                                                ReadPrescalesFromFile = cms.bool(False)))
 
 jetDQMAnalyzerAk4ScoutingCleaned = jetDQMAnalyzerAk4ScoutingUncleaned.clone(
     JetCleaningFlag = True
@@ -381,4 +400,3 @@ jetDQMMatchAkPu5CaloAkPu5PF = DQMEDAnalyzer('JetAnalyzer_HeavyIons_matching',
                                              recoDelRMatch = cms.double(0.2),
                                              recoJetEtaCut = cms.double(2.0)
 )
-


### PR DESCRIPTION
#### PR description:

Title say it all. Addresses https://github.com/cms-sw/cmssw/pull/50285#issuecomment-3996586454 by modifying the `highPtJetTrigger` and `lowPtJetTrigger` `PSet`-s in order to comply with the `stage2L1Trigger` modifier.

#### PR validation:

`scram b runtests_TestDQMOnlineClient-scouting_dqm_sourceclient` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A