### PR TITLE
Move CUDA Alpaka backends under cuda-gcc-support

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/test/BuildFile.xml
+++ b/RecoParticleFlow/PFClusterProducer/test/BuildFile.xml
@@ -29,19 +29,6 @@
   <flags ALPAKA_BACKENDS="1"/>
 </bin>
 
-<bin name="ShowerShapeTest_cooperative" file="alpaka/ShowerShapeTest.dev.cc">
-  <use name="alpaka"/>
-  <use name="eigen"/>
-  <use name="HeterogeneousCore/AlpakaInterface"/>
-  <use name="FWCore/Utilities"/>
-  <use name="DataFormats/SoATemplate"/>
-  <use name="DataFormats/Portable"/>
-  <use name="RecoParticleFlow/PFClusterProducer"/>
-  <flags CPPFLAGS="-DSHOWER_SHAPE_COOPERATIVE"/>
-  <flags ALPAKA_BACKENDS="cuda"/>
-</bin>
-
-
 <bin file="alpaka/ConstructLinksTest.dev.cc">
   <use name="alpaka"/>
   <use name="eigen"/>
@@ -86,15 +73,28 @@
   <flags ALPAKA_BACKENDS="1"/>
 </bin>
 
-<bin name="EpilogueTest_cooperative" file="alpaka/EpilogueTest.dev.cc">
-  <use name="alpaka"/>
-  <use name="eigen"/>
-  <use name="HeterogeneousCore/AlpakaInterface"/>
-  <use name="FWCore/Utilities"/>
-  <use name="DataFormats/SoATemplate"/>
-  <use name="DataFormats/Portable"/>
-  <use name="RecoParticleFlow/PFClusterProducer"/>
-  <flags CPPFLAGS="-DEPILOGUE_COOPERATIVE"/>
-  <flags ALPAKA_BACKENDS="cuda"/>
-</bin>
+<iftool name="cuda-gcc-support">
+ <bin name="EpilogueTest_cooperative" file="alpaka/EpilogueTest.dev.cc">
+   <use name="alpaka"/>
+   <use name="eigen"/>
+   <use name="HeterogeneousCore/AlpakaInterface"/>
+   <use name="FWCore/Utilities"/>
+   <use name="DataFormats/SoATemplate"/>
+   <use name="DataFormats/Portable"/>
+   <use name="RecoParticleFlow/PFClusterProducer"/>
+   <flags CPPFLAGS="-DEPILOGUE_COOPERATIVE"/>
+   <flags ALPAKA_BACKENDS="cuda"/>
+ </bin>
 
+ <bin name="ShowerShapeTest_cooperative" file="alpaka/ShowerShapeTest.dev.cc">
+   <use name="alpaka"/>
+   <use name="eigen"/>
+   <use name="HeterogeneousCore/AlpakaInterface"/>
+   <use name="FWCore/Utilities"/>
+   <use name="DataFormats/SoATemplate"/>
+   <use name="DataFormats/Portable"/>
+   <use name="RecoParticleFlow/PFClusterProducer"/>
+   <flags CPPFLAGS="-DSHOWER_SHAPE_COOPERATIVE"/>
+   <flags ALPAKA_BACKENDS="cuda"/>
+ </bin>
+</iftool>


### PR DESCRIPTION
Put "ALPAKA_BACKENDS=cuda" inside iftool block to fix build errors in `<el9/el10-amd64-gcc15>` IBs

Fixes Build Errors introduced after https://github.com/cms-sw/cmssw/pull/48248
