### PR TITLE
Minor Tweaks for HCAL MAHI Debugger

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/test/MahiDebugger.cc
+++ b/RecoLocalCalo/HcalRecAlgos/test/MahiDebugger.cc
@@ -129,9 +129,9 @@ private:
   edm::Service<TFileService> FileService;
   TTree* outTree;
 
-  int run;
-  int evt;
-  int ls;
+  uint32_t run;
+  uint64_t evt;
+  uint32_t ls;
 
   int nBxTrain;
 
@@ -314,9 +314,9 @@ float MahiDebugger::hbminusCorrectionFactor(const HcalDetId& cell,
 void MahiDebugger::beginJob() {
   outTree = FileService->make<TTree>("HcalTree", "HcalTree");
 
-  outTree->Branch("run", &run, "run/I");
-  outTree->Branch("evt", &evt, "evt/I");
-  outTree->Branch("ls", &ls, "ls/I");
+  outTree->Branch("run", &run, "run/i");
+  outTree->Branch("evt", &evt, "evt/l");
+  outTree->Branch("ls", &ls, "ls/i");
   outTree->Branch("nBxTrain", &nBxTrain, "nBxTrain/I");
 
   outTree->Branch("ieta", &ieta, "ieta/I");
@@ -365,7 +365,7 @@ void MahiDebugger::fillDescriptions(edm::ConfigurationDescriptions& descriptions
   desc.add<bool>("dynamicPed");
   desc.add<bool>("calculateArrivalTime");
   desc.add<int>("timeAlgo");
-  desc.add<double>("thEnergeticPulse");
+  desc.add<double>("thEnergeticPulses");
   desc.add<double>("ts4Thresh");
   desc.add<double>("chiSqSwitch");
   desc.add<bool>("applyTimeSlew");


### PR DESCRIPTION
#### PR description:

A few spot-changes for the HBHE local reconstruction (MAHI) algorithm debugging test. Most importantly is fixing a typo in the `fillDescription` for the `double` `thEnergeticPulses` (_pulses_ plural not singular).

#### PR validation:

This debugger is not part of any main workflows to my knowledge. In any case, running it independently with these changes, I find that no exception is thrown for missing parameter `thEnergeticPulse` (no *s*).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, no need for a backport.
