### PR TITLE
Fix CopyToDevice of TrackingRecHitsSoACollection

### DIFF
--- a/DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitsSoACollection.h
+++ b/DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitsSoACollection.h
@@ -67,10 +67,7 @@ namespace cms::alpakatools {
       reco::TrackingRecHitDevice<TDevice> deviceData(queue, nHits, hostData.nModules());
 
       if (nHits == 0) {
-        std::memset(
-            deviceData.buffer().data(),
-            0,
-            alpaka::getExtentProduct(deviceData.buffer()) * sizeof(alpaka::Elem<reco::TrackingRecHitHost::Buffer>));
+        deviceData.zeroInitialise(queue);
         return deviceData;
       }
 


### PR DESCRIPTION
#### PR description:

This PR fixes the `CopyToDevice` function of the `TrackingRecHitsSoACollection`. Previously, the special case of zero hits ran into a segmentation fault because the used `std::memset` function does not work on the device. 

#### PR validation:

I tested the HLT Phase-2 on single muon events, including the CA extension which uses the only module (`Phase2OTRecHitsSoAConverter`) that actually performs this copy. After the fix it runs perfectly fine on an H100 GPU.

I also tested a nutrino gun workflow on the same H100 GPU that was breaking before using the following command:

```python
runTheMatrix.py -w upgrade -l 34461.402
```

It actually still breaks but at a later point in the HLT reconstruction. The segmentation fault from before is gone.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport.
