### PR TITLE
Add missing dependencies to SimDataFormats

### DIFF
--- a/L1Trigger/L1TMuonOverlap/BuildFile.xml
+++ b/L1Trigger/L1TMuonOverlap/BuildFile.xml
@@ -13,3 +13,4 @@
 <use name="Geometry/RPCGeometry"/>
 <use name="L1Trigger/CSCTriggerPrimitives"/>
 <use name="L1Trigger/DTUtilities"/>
+<use name="SimDataFormats/Track"/>

--- a/Validation/DTRecHits/BuildFile.xml
+++ b/Validation/DTRecHits/BuildFile.xml
@@ -1,4 +1,8 @@
+<use name="DataFormats/DetId"/>
+<use name="DataFormats/GeometryVector"/>
+<use name="DataFormats/MuonDetId"/>
 <use name="Geometry/DTGeometry"/>
+<use name="SimDataFormats/TrackingHit"/>
 <use name="root"/>
 <export>
   <lib name="1"/>

--- a/Validation/GlobalRecHits/BuildFile.xml
+++ b/Validation/GlobalRecHits/BuildFile.xml
@@ -31,6 +31,7 @@
 <use name="SimDataFormats/CrossingFrame"/>
 <use name="SimDataFormats/CaloHit"/>
 <use name="DQMServices/Core"/>
+<use name="SimDataFormats/TrackingHit"/>
 <use name="SimDataFormats/ValidationFormats"/>
 <use name="Validation/DTRecHits"/>
 <use name="root"/>

--- a/Validation/MuonGEMDigis/plugins/BuildFile.xml
+++ b/Validation/MuonGEMDigis/plugins/BuildFile.xml
@@ -4,6 +4,7 @@
   <use name="Validation/MuonGEMDigis"/>
   <use name="DataFormats/GEMDigi"/>
   <use name="DQMServices/Core"/>
+  <use name="SimDataFormats/TrackingHit"/>
   <use name="HepMC"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/Validation/MuonGEMRecHits/BuildFile.xml
+++ b/Validation/MuonGEMRecHits/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="Geometry/Records"/>
 <use name="Geometry/GEMGeometry"/>
 <use name="SimDataFormats/Track"/>
+<use name="SimDataFormats/TrackingHit"/>
 <use name="SimDataFormats/Vertex"/>
 <use name="rootcore"/>
 <use name="Validation/MuonGEMDigis"/>

--- a/Validation/MuonGEMRecHits/plugins/BuildFile.xml
+++ b/Validation/MuonGEMRecHits/plugins/BuildFile.xml
@@ -2,6 +2,7 @@
   <use name="FWCore/Framework"/>
   <use name="Validation/MuonGEMHits"/>
   <use name="Validation/MuonGEMRecHits"/>
+  <use name="SimDataFormats/TrackingHit"/>
   <use name="HepMC"/>
   <flags EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
#### PR description:

The packages whose `BuildFile.xml`'s are edited make use of code from the packages that are added. I encountered these as build failures when working on changes for EVOLUTION_X.

Resolves https://github.com/cms-sw/framework-team/issues/2000

#### PR validation:

Code compiles in EVOLUTION_X
