### PR TITLE
[EVOLUTION_X] Fix destructor definition for RegionalMuonShower

### DIFF
--- a/DataFormats/L1TMuon/src/RegionalMuonShower.cc
+++ b/DataFormats/L1TMuon/src/RegionalMuonShower.cc
@@ -18,7 +18,7 @@ l1t::RegionalMuonShower::RegionalMuonShower(bool oneNominalInTime,
       processor_(0),
       trackFinder_(l1t::tftype::bmtf) {}
 
-l1t::RegionalMuonShower::~RegionalMuonShower() {}
+l1t::io_v1::RegionalMuonShower::~RegionalMuonShower() {}
 
 void l1t::RegionalMuonShower::setTFIdentifiers(int processor, tftype trackFinder) {
   trackFinder_ = trackFinder;

--- a/SimDataFormats/CaloAnalysis/src/classes_def.xml
+++ b/SimDataFormats/CaloAnalysis/src/classes_def.xml
@@ -10,7 +10,7 @@
   <class name="CaloParticleContainer"/>
 
   <class name="MtdCaloParticle" ClassVersion="3">
-    <version ClassVersion="3" checksum="3222440347"/>
+    <version ClassVersion="3" checksum="374264907"/>
   </class>
   <class name="MtdCaloParticleCollection"/>
   <class name="edm::Wrapper<MtdCaloParticleCollection>"/>


### PR DESCRIPTION
#### PR description:

Should fix static analyzer error
```
src/DataFormats/L1TMuon/src/RegionalMuonShower.cc:21:26: error: destructor cannot be declared using a type alias 'RegionalMuonShower' (aka 'l1t::io_v1::RegionalMuonShower') of the class name [-Wdtor-typedef]
   21 | l1t::RegionalMuonShower::~RegionalMuonShower() {}
      |                          ^
1 error generated.
```
that we have seen in many EVOLUTION_X PR tests.

Resolves https://github.com/cms-sw/framework-team/issues/2003

#### PR validation:

None (I checked the pattern in Compiler explorer)
