### PR TITLE
Add the an option to disable the `TrivialSerialisation` mechanism in MPI modules

### DIFF
--- a/HeterogeneousCore/MPICore/plugins/MPIReceiver.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPIReceiver.cc
@@ -34,8 +34,8 @@ public:
   MPIReceiver(edm::ParameterSet const& config)
       : upstream_(consumes<MPIToken>(config.getParameter<edm::InputTag>("upstream"))),
         token_(produces<MPIToken>()),
-        instance_(config.getParameter<int32_t>("instance"))  //
-  {
+        instance_(config.getParameter<int32_t>("instance")),
+        enableTrivialSerialisation_(config.getUntrackedParameter<bool>("enableTrivialSerialisation")) {
     // instance 0 is reserved for the MPIController / MPISource pair
     // instance values greater than 255 may not fit in the MPI tag
     if (instance_ < 1 or instance_ > 255) {
@@ -121,6 +121,12 @@ public:
       }
 
       else if (product_meta.kind == ProductMetadata::Kind::TrivialCopy) {
+        if (not enableTrivialSerialisation_) {
+          edm::LogError("MPIReceiver")
+              << "Received a trivially-serialised product, but enableTrivialSerialisation is set to false in this "
+                 "MPIReceiver. Please check that the MPISender and MPIReceiver have consistent settings.";
+          MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+        }
         std::unique_ptr<ngt::SerialiserBase> serialiser =
             ngt::SerialiserFactory::get()->tryToCreate(entry.type.typeInfo().name());
         if (not serialiser) {
@@ -168,6 +174,10 @@ public:
         ->setComment("Products to be received by a separate CMSSW job and produced into the event.");
     desc.add<int32_t>("instance", 0)
         ->setComment("A value between 1 and 255 used to identify a matching pair of \"MPISender\"/\"MPIReceiver\".");
+    desc.addUntracked<bool>("enableTrivialSerialisation", true)
+        ->setComment(
+            "If true (default), use the trivial serialisation mechanism for supported types. If false, always use "
+            "ROOT serialisation for all types. Useful for benchmarking.");
 
     descriptions.addWithDefaultLabel(desc);
   }
@@ -183,8 +193,8 @@ private:
   edm::EDPutTokenT<MPIToken> const token_;  // copy of the MPIToken that may be used to implement an ordering relation
   std::vector<Entry> products_;             // data to be read over the channel and put into the Event
   int32_t const instance_;                  // instance used to identify the source-destination pair
-
   std::shared_ptr<ProductMetadataBuilder> received_meta_;
+  bool enableTrivialSerialisation_ = true;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/HeterogeneousCore/MPICore/plugins/MPISender.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPISender.cc
@@ -44,7 +44,8 @@ public:
         patterns_(edm::productPatterns(config.getParameter<std::vector<std::string>>("products"))),
         instance_(config.getParameter<int32_t>("instance")),
         buffer_(std::make_unique<TBufferFile>(TBuffer::kWrite)),
-        metadata_size_(0) {
+        metadata_size_(0),
+        enableTrivialSerialisation_(config.getUntrackedParameter<bool>("enableTrivialSerialisation")) {
     // instance 0 is reserved for the MPIController / MPISource pair
     // instance values greater than 255 may not fit in the MPI tag
     if (instance_ < 1 or instance_ > 255) {
@@ -124,8 +125,10 @@ public:
 
       if (handle.isValid()) {
         edm::WrapperBase const* wrapper = handle.product();
-        std::unique_ptr<ngt::SerialiserBase> serialiser =
-            ngt::SerialiserFactory::get()->tryToCreate(entry.type.typeInfo().name());
+        std::unique_ptr<ngt::SerialiserBase> serialiser;
+        if (enableTrivialSerialisation_) {
+          serialiser = ngt::SerialiserFactory::get()->tryToCreate(entry.type.typeInfo().name());
+        }
 
         if (serialiser) {
           LogDebug("MPISender") << "Found serializer for type \"" << entry.type.name() << "\" ("
@@ -188,8 +191,10 @@ public:
       edm::WrapperBase const* wrapper = handle.product();
       // we don't send missing products
       if (handle.isValid()) {
-        std::unique_ptr<ngt::SerialiserBase> serialiser =
-            ngt::SerialiserFactory::get()->tryToCreate(entry.type.typeInfo().name());
+        std::unique_ptr<ngt::SerialiserBase> serialiser;
+        if (enableTrivialSerialisation_) {
+          serialiser = ngt::SerialiserFactory::get()->tryToCreate(entry.type.typeInfo().name());
+        }
         if (serialiser) {
           auto reader = serialiser->reader(*wrapper);
           token.channel()->sendTrivialCopyProduct(instance_, *reader);
@@ -220,6 +225,10 @@ public:
             "and \"*\") are allowed in a module label or in each field of a branch name.");
     desc.add<int32_t>("instance", 0)
         ->setComment("A value between 1 and 255 used to identify a matching pair of \"MPISender\"/\"MPIReceiver\".");
+    desc.addUntracked<bool>("enableTrivialSerialisation", true)
+        ->setComment(
+            "If true (default), use the trivial serialisation mechanism for supported types. If false, use "
+            "ROOT serialisation for all types. Intended to be disabled only for benchmarking purposes");
 
     descriptions.addWithDefaultLabel(desc);
   }
@@ -244,6 +253,7 @@ private:
   int32_t const instance_;                         // instance used to identify the source-destination pair
   std::unique_ptr<TBufferFile> buffer_;
   size_t metadata_size_;
+  bool enableTrivialSerialisation_ = true;
   bool has_serialized_ = false;
   bool is_active_ = true;
 };

--- a/HeterogeneousCore/MPICore/test/controller_soa_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_soa_cfg.py
@@ -49,8 +49,24 @@ process.sender = MPISender(
     ]
 )
 
+# Same thing, but this time disabling TrivialSerialisation so all products are
+# serialized through ROOT
+process.senderNoTrivialSerialisation = MPISender(
+    upstream = "sender",
+    instance = 43,
+    enableTrivialSerialisation = False,
+    products = [
+        "portabletestTestStructPortableHostObject_producePortableObjects__*",
+        "128falseportabletestTestSoALayoutPortableHostCollection_producePortableObjects__*",
+        "128falseportabletestSoABlocks2PortableHostCollection_producePortableObjects__*",
+        "128falseportabletestSoABlocks3PortableHostCollection_producePortableObjects__*",
+        "ushort_producePortableObjects_backend_*"
+    ]
+)
+
 process.pathSoA = cms.Path(
     process.mpiController +
     process.producePortableObjects +
-    process.sender
+    process.sender +
+    process.senderNoTrivialSerialisation
 )

--- a/HeterogeneousCore/MPICore/test/follower_soa_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_soa_cfg.py
@@ -14,7 +14,8 @@ process.source = MPISource()
 
 process.maxEvents.input = -1
 
-# receive and validate a portable object, a portable collection, and some portable multi-block collections
+# receive and validate a portable object, a portable collection, and some
+# portable multi-block collections
 process.receiver = MPIReceiver(
     upstream = "source",
     instance = 42,
@@ -50,8 +51,50 @@ process.validatePortableObject = cms.EDAnalyzer("TestAlpakaObjectAnalyzer",
     source = cms.InputTag("receiver")
 )
 
+
+# Same thing, but this time disabling TrivialSerialisation so all products are
+# serialized through ROOT
+process.receiverNoTrivialSerialisation = MPIReceiver(
+    upstream = "receiver",
+    instance = 43,
+    enableTrivialSerialisation = False,
+    products = [
+        dict(
+            type = "PortableHostObject<portabletest::TestStruct>",
+            label = ""
+        ),
+        dict(
+            type = "PortableHostCollection<portabletest::TestSoALayout<128,false> >",
+            label = ""
+        ),
+        dict(
+            type = "PortableHostCollection<portabletest::SoABlocks2<128,false> >",
+            label = ""
+        ),
+        dict(
+            type = "PortableHostCollection<portabletest::SoABlocks3<128,false> >",
+            label = ""
+        ),
+        dict(
+            type = "ushort",
+            label = "backend"
+        )
+    ]
+)
+
+process.validatePortableCollectionsNoTrivialSerialisation = cms.EDAnalyzer("TestAlpakaAnalyzer",
+    source = cms.InputTag("receiverNoTrivialSerialisation")
+)
+
+process.validatePortableObjectNoTrivialSerialisation = cms.EDAnalyzer("TestAlpakaObjectAnalyzer",
+    source = cms.InputTag("receiverNoTrivialSerialisation")
+)
+
 process.pathSoA = cms.Path(
     process.receiver +
     process.validatePortableCollections +
-    process.validatePortableObject
+    process.validatePortableObject +
+    process.receiverNoTrivialSerialisation +
+    process.validatePortableCollectionsNoTrivialSerialisation +
+    process.validatePortableObjectNoTrivialSerialisation
 )

--- a/HeterogeneousCore/MPICore/test/testMPICommWorld.sh
+++ b/HeterogeneousCore/MPICore/test/testMPICommWorld.sh
@@ -13,5 +13,7 @@ fi
 # Until this is understood and fixed, keep it disabled.
 export OMPI_MCA_pml='^cm'
 
-# Launch the controller and follower processes
-mpirun -n 1 cmsRun ${CONTROLLER} : -n 1 cmsRun ${FOLLOWER}
+# Launch the controller and follower processes.
+# The timeout is to prevent indefinite hangs if one side crashes without the
+# other side being aware of it.
+timeout --signal=SIGTERM 120 mpirun -n 1 cmsRun ${CONTROLLER} : -n 1 cmsRun ${FOLLOWER}


### PR DESCRIPTION
#### PR description:

We would like to have an option to toggle the `TrivialSerialisation` mechanism in the MPI modules.
This PR adds the option `enableTrivialSerialisation`, which:
- When set to `True` (default), allows supported types to be trivially serialised through the "TrivialSerialisation" mechanism. Unsupported types still fall back to the ROOT serialisation.
- When set to `False`, all types are _actually serialised_ through ROOT.

This option is mainly useful for easily benchmarking the the `TrivialSerialisation` mechanism with respect to the ROOT serialisation.

A check has been added to the `MPIReceiver`, so that if it has `enableTrivialSerialisation` set to `False` but still receives a trivially-serialised product, it throws an `cms::Exception`. Note that the `MPISender` will hang afterwards. To avoid the tests from hanging (forever?) after this fail, a 120 s timeout has been added to the `mpirun` call in `HeterogeneousCore/MPICore/test/testMPICommWorld.sh`.

#### PR validation:

A Sender / Receiver pair with `enableTrivialSerialisation` set to `False` has been added to the `*_soa_cfg.py` test under `HeterogeneousCore/MPICore/test/`. The test pass.