### PR TITLE
Throw is ESHandle is not set

### DIFF
--- a/FWCore/Framework/interface/ESHandle.h
+++ b/FWCore/Framework/interface/ESHandle.h
@@ -64,6 +64,7 @@ namespace edm {
       }
       return data_;
     }
+    static void throwIfDataNotAvailable();
 
   private:
     // ---------- member data --------------------------------
@@ -85,7 +86,13 @@ namespace edm {
     // ---------- const member functions ---------------------
     T const* product() const { return static_cast<T const*>(productStorage()); }
     T const* operator->() const { return product(); }
-    T const& operator*() const { return *product(); }
+    T const& operator*() const {
+      auto const* p = product();
+      if (nullptr == p) [[unlikely]] {
+        throwIfDataNotAvailable();
+      }
+      return *p;
+    }
     // ---------- static member functions --------------------
     static constexpr bool transientAccessOnly = false;
 

--- a/FWCore/Framework/src/ESHandle.cc
+++ b/FWCore/Framework/src/ESHandle.cc
@@ -12,4 +12,7 @@ namespace edm {
     }
     return description_;
   }
+  void ESHandleBase::throwIfDataNotAvailable() {
+    throw edm::Exception(edm::errors::InvalidReference, "ESHandle was not set.");
+  }
 }  // namespace edm

--- a/HLTrigger/special/plugins/HLTEcalPhiSymFilter.cc
+++ b/HLTrigger/special/plugins/HLTEcalPhiSymFilter.cc
@@ -104,9 +104,9 @@ bool HLTEcalPhiSymFilter::filter(edm::StreamID, edm::Event& event, const edm::Ev
 
   // Get ChannelStatus from DB
   edm::ESHandle<EcalChannelStatus> csHandle;
+  const EcalChannelStatus* channelStatus = nullptr;
   if (!useRecoFlag_)
-    csHandle = setup.getHandle(ecalChannelStatusRcdToken_);
-  const EcalChannelStatus& channelStatus = *csHandle;
+    channelStatus = &setup.getData(ecalChannelStatusRcdToken_);
 
   // Get iRing-geometry
   auto const& geoHandle = setup.getHandle(caloGeometryRecordToken_);
@@ -165,7 +165,7 @@ bool HLTEcalPhiSymFilter::filter(edm::StreamID, edm::Event& event, const edm::Ev
         }
       }
     } else {
-      statusCode = channelStatus[hitDetId.rawId()].getStatusCode();
+      statusCode = (*channelStatus)[hitDetId.rawId()].getStatusCode();
     }
 
     if (statusCode <= statusThreshold_) {
@@ -208,7 +208,7 @@ bool HLTEcalPhiSymFilter::filter(edm::StreamID, edm::Event& event, const edm::Ev
         }
       }
     } else {
-      statusCode = channelStatus[hitDetId.rawId()].getStatusCode();
+      statusCode = (*channelStatus)[hitDetId.rawId()].getStatusCode();
     }
 
     if (statusCode <= statusThreshold_) {


### PR DESCRIPTION

#### PR description:

Fixes case where operator* is called on a defaultly constructes ESHandle.

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/2007
resolves https://github.com/cms-sw/framework-team/issues/2008