### PR TITLE
Better handling of initializing DescriptionCloner

### DIFF
--- a/FWCore/ParameterSet/interface/DescriptionCloner.h
+++ b/FWCore/ParameterSet/interface/DescriptionCloner.h
@@ -4,7 +4,9 @@
 
 #include <string_view>
 #include <variant>
+#include <optional>
 #include <memory>
+#include <vector>
 
 namespace edm {
   class DescriptionCloner {
@@ -36,7 +38,7 @@ namespace edm {
     struct WhichEntry {
       std::string label;
       std::variant<std::vector<WhichEntry>, std::shared_ptr<EntryTypeBase>> entry;
-      bool isTracked;
+      std::optional<bool> isTracked;
     };
 
     template <typename T>

--- a/FWCore/ParameterSet/src/DescriptionCloner.cc
+++ b/FWCore/ParameterSet/src/DescriptionCloner.cc
@@ -93,14 +93,14 @@ namespace edm {
           //this is a PSet
           auto const& subEntry = std::get<std::vector<DescriptionCloner::WhichEntry>>(whichEntry.entry);
           ParameterSetDescription subDesc = createDifferenceFromEntries(subEntry);
-          if (whichEntry.isTracked) {
+          if (whichEntry.isTracked.value()) {
             diffDesc.add(whichEntry.label, subDesc);
           } else {
             diffDesc.addUntracked(whichEntry.label, subDesc);
           }
         } else if (std::holds_alternative<std::shared_ptr<DescriptionCloner::EntryTypeBase>>(whichEntry.entry)) {
           auto const& entryPtr = std::get<std::shared_ptr<DescriptionCloner::EntryTypeBase>>(whichEntry.entry);
-          entryPtr->addTo(diffDesc, whichEntry.label, whichEntry.isTracked);
+          entryPtr->addTo(diffDesc, whichEntry.label, whichEntry.isTracked.value());
         }
       }
       return diffDesc;

--- a/FWCore/ParameterSet/test/test_catch2_DescriptionCloner.cc
+++ b/FWCore/ParameterSet/test/test_catch2_DescriptionCloner.cc
@@ -7,7 +7,7 @@
 #include "catch2/catch_all.hpp"
 #include <string>
 
-TEST_CASE("DescriptionCloner") {
+TEST_CASE("DescriptionCloner", "[DescriptionCloner]") {
   SECTION("basic usage") {
     edm::DescriptionCloner cloner;
     cloner.set("level1.level2.intParam", 42);


### PR DESCRIPTION
#### PR description:

Explicitly check that trackiness is properly set.

This is meant to avoid/track-down the UBSAN error
[5537 FWCore/ParameterSet/interface/DescriptionCloner.h:36:12: runtime error: load of value 65, which is not a valid value for type 'bool'](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ubsan_logs/CMSSW_16_1_X_2026-03-06-2300/logs/c2/c2dd8bc7e37399c5ee4fae048475adde/log)
#### PR validation:

Code compiles. Framework unit tests pass.