### PR TITLE
Fix: Cluster TrackGenJetAK4 from packedGenParticles and define new Gen-Level Scalars

### DIFF
--- a/PhysicsTools/NanoAOD/python/jetMC_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetMC_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
 from PhysicsTools.NanoAOD.simpleGenJetFlatTableProducer_cfi import simpleGenJetFlatTableProducer
 from PhysicsTools.NanoAOD.simplePATJetFlatTableProducer_cfi import simplePATJetFlatTableProducer
+from PhysicsTools.NanoAOD.globalVariablesTableProducer_cfi import globalVariablesTableProducer
 from PhysicsTools.NanoAOD.jetsAK8_cff import fatJetTable as _fatJetTable
 from PhysicsTools.NanoAOD.jetsAK8_cff import subJetTable as _subJetTable
 from RecoJets.JetProducers.ak4GenJets_cfi import ak4GenJets
@@ -118,8 +119,8 @@ subjetMCTable = simplePATJetFlatTableProducer.clone(
 )
 
 genParticlesForJetsCharged = cms.EDFilter("CandPtrSelector",
-    src = cms.InputTag("prunedGenParticles"),  # or "packedGenParticles" if available
-    cut = cms.string("charge != 0 && pt > 0.3 && status == 1 && abs(pdgId) != 12 && abs(pdgId) != 14 && abs(pdgId) != 16")
+    src = cms.InputTag("packedGenParticles"),
+    cut = cms.string("abs(eta)<2.5 && charge != 0 && pt > 0.5 && status == 1 && abs(pdgId) != 12 && abs(pdgId) != 14 && abs(pdgId) != 16")
 )
 
 ak4GenJetsChargedOnly = ak4GenJets.clone(src = cms.InputTag("genParticlesForJetsCharged"), rParam = cms.double(0.4), jetAlgorithm=cms.string("AntiKt"), doAreaFastjet = False, jetPtMin=1)
@@ -127,6 +128,7 @@ ak4GenJetsChargedOnly = ak4GenJets.clone(src = cms.InputTag("genParticlesForJets
 
 trackGenJetAK4Table = genJetTable.clone(
     src = cms.InputTag("ak4GenJetsChargedOnly"),
+    maxLen = cms.uint32(6),
     cut = cms.string("pt > 1"),
     name = cms.string("TrackGenJetAK4"),
     doc = cms.string("AK4 GenJets made with charged particles only"),
@@ -137,6 +139,23 @@ trackGenJetAK4Table.variables.pt.precision = 10
 trackGenJetAK4Table.variables.eta.precision = 8
 trackGenJetAK4Table.variables.phi.precision = 8
 
-jetMCTaskak4 = cms.Task(jetMCTable,genJetTable,patJetPartonsNano,genJetFlavourTable,genParticlesForJetsCharged,ak4GenJetsChargedOnly,trackGenJetAK4Table)
+# Filtered TrackGenJet collections for HT sums
+trackGenJetsAK4Pt10 = cms.EDFilter("CandPtrSelector", src = cms.InputTag("ak4GenJetsChargedOnly"), cut = cms.string('pt>10'))
+trackGenJetsAK4Pt5 = cms.EDFilter("CandPtrSelector", src = cms.InputTag("ak4GenJetsChargedOnly"), cut = cms.string('pt>5'))
+trackGenJetsAK4Pt2 = cms.EDFilter("CandPtrSelector", src = cms.InputTag("ak4GenJetsChargedOnly"), cut = cms.string('pt>2'))
+
+# Event-level scalar pT sums of TrackGenJets
+trackGenJetSoftActivityTable = globalVariablesTableProducer.clone(
+    variables = cms.PSet(
+        TrackGenJetSoftActivityHT10 = ExtVar( cms.InputTag("trackGenJetsAK4Pt10"), "candidatescalarsum", doc = "scalar sum of TrackGenJetAK4 pt, pt>10" ),
+        TrackGenJetSoftActivityHT5 = ExtVar( cms.InputTag("trackGenJetsAK4Pt5"), "candidatescalarsum", doc = "scalar sum of TrackGenJetAK4 pt, pt>5" ),
+        TrackGenJetSoftActivityHT2 = ExtVar( cms.InputTag("trackGenJetsAK4Pt2"), "candidatescalarsum", doc = "scalar sum of TrackGenJetAK4 pt, pt>2" ),
+        TrackGenJetAK4Njets10 = ExtVar( cms.InputTag("trackGenJetsAK4Pt10"), "candidatesize", doc = "number of TrackGenJetAK4 with pt>10" ),
+        TrackGenJetAK4Njets5 = ExtVar( cms.InputTag("trackGenJetsAK4Pt5"), "candidatesize", doc = "number of TrackGenJetAK4 with pt>5" ),
+        TrackGenJetAK4Njets2 = ExtVar( cms.InputTag("trackGenJetsAK4Pt2"), "candidatesize", doc = "number of TrackGenJetAK4 with pt>2" ),
+    )
+)
+
+jetMCTaskak4 = cms.Task(jetMCTable,genJetTable,patJetPartonsNano,genJetFlavourTable,genParticlesForJetsCharged,ak4GenJetsChargedOnly,trackGenJetAK4Table,trackGenJetsAK4Pt10,trackGenJetsAK4Pt5,trackGenJetsAK4Pt2,trackGenJetSoftActivityTable)
 jetMCTaskak8 = cms.Task(genJetAK8Table,genJetAK8FlavourAssociation,genJetAK8FlavourTable,fatJetMCTable,genSubJetAK8Table,subjetMCTable)
 jetMCTask = jetMCTaskak4.copyAndAdd(jetMCTaskak8)


### PR DESCRIPTION
#### PR description:

This PR fixes the definition of the TrackGenJetAK4 collection, which are now correctly clustered from the `packedGenParticle` collection in the correct $\eta$ region and with a slightly higher $p_T$ threshold on the single particles. We limit the length of this collection to maximum 6 TrackGenJet per event.

We then add 6 new gen-level scalar variables which compute the HT and number of TrackGenJetAK4 with different $p_T$ thresholds (2, 5 and 10 GeV respectively).

These fixes and changes are being made in order to make the TrackGenJet collection a useful input for the production of SoftActivityJet and SoftActivity scalars with FlashSim, as discussed in e.g. https://indico.cern.ch/event/1629400/#179-flashsim-for-hmm-pisa (slide 4)

#### PR validation:
We validated the PR with syntax and naming checks, and we produced the config file with `cmsDriver`, running it through `cmsRun` and double checking the definition of the new variable against the original TrackGenJetAK4 collection.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

As requested after checking with XPOG and PPD,  we are opening the PR against the CMSSW_16_0_X. We made our changes starting from the release CMSSW_16_0_2_patch1

@arizzi (tagged to keep him in the loop)