### PR TITLE
Phase2-hgx365V1 Add a few more debug statements for the most recent version of DDHGCalSilicon used for loading the HGCal geometry of full silicon layers

### DIFF
--- a/Geometry/HGCalCommonData/plugins/DDHGCalSiliconRotatedCassette.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalSiliconRotatedCassette.cc
@@ -401,7 +401,6 @@ void DDHGCalSiliconRotatedCassette::constructLayers(const DDLogicalPart& module,
           unsigned int num = (-layerSense_[ly] <= waferTypes_) ? passiveAbsorb_.size() : passiveCool_.size();
           if (num > 0)
             positionPassiveNew(glog, i, -layerSense_[ly], cpv);
-          //          positionPassiveNew(glog, (copy - firstLayer_), -layerSense_[ly], cpv);
         } else {
           positionPassive(glog, (copy - firstLayer_), -layerSense_[ly], cpv);
         }
@@ -668,7 +667,7 @@ void DDHGCalSiliconRotatedCassette::positionPassiveNew(const DDLogicalPart& glog
                                                        int absType,
                                                        DDCompactView& cpv) {
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: positionPassiveNew is called";
+  edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: positionPassiveNew is called for layer " << layer << " absType " << absType << " cassettes_ " << cassettes_ << " number of layers " << layers_.size();
   int kount(0);
 #endif
   bool type = (absType <= waferTypes_);

--- a/Geometry/HGCalCommonData/plugins/DDHGCalSiliconRotatedCassette.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalSiliconRotatedCassette.cc
@@ -667,7 +667,9 @@ void DDHGCalSiliconRotatedCassette::positionPassiveNew(const DDLogicalPart& glog
                                                        int absType,
                                                        DDCompactView& cpv) {
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: positionPassiveNew is called for layer " << layer << " absType " << absType << " cassettes_ " << cassettes_ << " number of layers " << layers_.size();
+  edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: positionPassiveNew is called for layer " << layer
+                                << " absType " << absType << " cassettes_ " << cassettes_ << " number of layers "
+                                << layers_.size();
   int kount(0);
 #endif
   bool type = (absType <= waferTypes_);

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalSiliconRotatedCassette.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalSiliconRotatedCassette.cc
@@ -308,7 +308,6 @@ struct HGCalSiliconRotatedCassette {
             unsigned int num = (-layerSense_[ly] <= waferTypes_) ? passiveAbsorb_.size() : passiveCool_.size();
             if (num > 0)
               positionPassiveNew(ctxt, e, glog, i, -layerSense_[ly]);
-            //            positionPassiveNew(ctxt, e, glog, (copy - firstLayer_), -layerSense_[ly]);
           } else {
             positionPassive(ctxt, e, glog, (copy - firstLayer_), -layerSense_[ly]);
           }
@@ -576,7 +575,7 @@ struct HGCalSiliconRotatedCassette {
   void positionPassiveNew(cms::DDParsingContext& ctxt, xml_h e, const dd4hep::Volume& glog, int layer, int absType) {
     cms::DDNamespace ns(ctxt, e, true);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: positionPassiveNew is called";
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: positionPassiveNew is called for layer " << layer << " absType " << absType << " cassettes_ " << cassettes_ << " number of layers " << layers_.size();
     int kount(0);
 #endif
     bool type = (absType <= waferTypes_);

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalSiliconRotatedCassette.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalSiliconRotatedCassette.cc
@@ -575,7 +575,9 @@ struct HGCalSiliconRotatedCassette {
   void positionPassiveNew(cms::DDParsingContext& ctxt, xml_h e, const dd4hep::Volume& glog, int layer, int absType) {
     cms::DDNamespace ns(ctxt, e, true);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: positionPassiveNew is called for layer " << layer << " absType " << absType << " cassettes_ " << cassettes_ << " number of layers " << layers_.size();
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: positionPassiveNew is called for layer " << layer
+                                  << " absType " << absType << " cassettes_ " << cassettes_ << " number of layers "
+                                  << layers_.size();
     int kount(0);
 #endif
     bool type = (absType <= waferTypes_);


### PR DESCRIPTION
#### PR description:

Add a few more debug statements for the most recent version of DDHGCalSilicon used for loading the HGCal geometry of full silicon layers

#### PR validation:

Tested for the V19 geometry

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special