### PR TITLE
[16_0_X] Fix reco::ParticleState read rule

### DIFF
--- a/DataFormats/Candidate/src/classes_def.xml
+++ b/DataFormats/Candidate/src/classes_def.xml
@@ -7,7 +7,7 @@
    <field name="p4Cartesian_" transient="true" />
   </class>
   <!--The 'int pdgId_' is a workaround for ROOT bug which affects iorules for split classes-->
-  <ioread sourceClass = "reco::ParticleState" version="[1-]" targetClass="reco::ParticleState" source="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> > p4Polar_;int pdgId_" target="p4Cartesian_">
+  <ioread sourceClass = "reco::ParticleState" version="[1-]" targetClass="reco::ParticleState" source="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<Double32_t> > p4Polar_;int pdgId_" target="p4Cartesian_">
    <![CDATA[newObj->setCartesian();]]>
   </ioread>
 


### PR DESCRIPTION
#### PR description:

This PR fixes the type in the `sourceClass` of the read rule to be the same as in `field` attributes above. Apparently this is needed now, at least this change allowed the test job in https://github.com/cms-sw/cmssw/issues/50349#issuecomment-4029461964 to succeed.

Resolves https://github.com/cms-sw/cmssw/issues/50349
Resolves https://github.com/cms-sw/framework-team/issues/2018

#### PR validation:

Reproducer in https://github.com/cms-sw/cmssw/issues/50349#issuecomment-4029461964 succeeded


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/50361 (well, original development)