### PR TITLE
Add half ROC mask bitset per ECON-D

### DIFF
--- a/CondFormats/HGCalObjects/interface/HGCalConfiguration.h
+++ b/CondFormats/HGCalObjects/interface/HGCalConfiguration.h
@@ -17,6 +17,7 @@ struct HGCalROCConfig {
 struct HGCalECONDConfig {
   //std::string typecode;
   uint32_t headerMarker;  // begin of event marker/identifier for ECON-D
+  uint16_t enabledErx;
   std::vector<HGCalROCConfig> rocs;
   COND_SERIALIZABLE;
 };

--- a/CondFormats/HGCalObjects/src/HGCalMappingModuleIndexer.cc
+++ b/CondFormats/HGCalObjects/src/HGCalMappingModuleIndexer.cc
@@ -127,8 +127,7 @@ void HGCalMappingModuleIndexer::finalize() {
       uint32_t internalData_offset = globalTypesNWords_[type_val] * typeCounters[type_val];
       fedit.chDataOffsets_[i] = baseData_offset + internalData_offset;
 
-      //enabled erx flags
-      //FIXME: assume all eRx are enabled now
+      //enabled erx flags: by default all available are enabled - configuration may override
       fedit.enabledErx_[i] = (0b1 << globalTypesNErx_[type_val]) - 0b1;
       typeCounters[type_val]++;
     }

--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
@@ -286,8 +286,8 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
         continue;
       }
 
-      // parse ECON-D body(eRx subpackets)
-      const auto enabledErx = fedReadoutSequence.enabledErx_[globalECONDIdx];
+      // parse ECON-D body(eRx subpackets)      
+      const auto enabledErx = fedConfig.econds[globalECONDIdx].enabledErx;
       const auto erxMax = moduleIndexer.globalTypesNErx()[fedReadoutSequence.readoutTypes_[globalECONDIdx]];
       const bool pass_through_mode = (econd_headers[0] >> ECOND_FRAME::BITP_POS) & 0b1;
 
@@ -299,6 +299,7 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
         for (uint32_t erxIdx = 0; erxIdx < erxMax; erxIdx++) {
           // check if the eRx is enabled
           if ((enabledErx >> erxIdx & 1) == 0) {
+	    LogDebug("[HGCalUnpacker]") << "Skipping eRx=" << erxIdx << " for ECON-D "<< globalECONDIdx << " @ FED=" << fedReadoutSequence.id;
             continue;
           }
           LogDebug("[HGCalUnpacker]") << "fedId = " << fedId << ", captureblockIdx = " << captureblockIdx
@@ -368,6 +369,7 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
         for (uint32_t erxIdx = 0; erxIdx < erxMax; erxIdx++) {
           // check if the eRx is enabled
           if ((enabledErx >> erxIdx & 1) == 0) {
+	    LogDebug("[HGCalUnpacker]") << "Skipping eRx=" << erxIdx << " for ECON-D "<< globalECONDIdx << " @ FED=" << fedReadoutSequence.id;
             continue;
           }
           LogDebug("[HGCalUnpacker]") << "fedId = " << fedId << ", captureblockIdx = " << captureblockIdx
@@ -446,7 +448,8 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
         edm::LogWarning("[HGCalUnpacker]")
             << "Mismatch between unpacked and expected ECON-D #" << (int)globalECONDIdx << " payload length\n"
             << "  unpacked payload length=" << iword + 1 << "\n"
-            << "  expected payload length=" << econd_payload_length;
+            << "  expected payload length=" << econd_payload_length
+	    << " enabledErx=" << enabledErx << " erxMax=" << erxMax;
         return (0x1 << hgcaldigi::FEDUnpackingFlags::ECONDPayloadLengthMismatch) |
                (hasActiveCBFlags << hgcaldigi::FEDUnpackingFlags::ActiveCaptureBlockFlags);
       }

--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
@@ -286,7 +286,7 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
         continue;
       }
 
-      // parse ECON-D body(eRx subpackets)      
+      // parse ECON-D body(eRx subpackets)
       const auto enabledErx = fedConfig.econds[globalECONDIdx].enabledErx;
       const auto erxMax = moduleIndexer.globalTypesNErx()[fedReadoutSequence.readoutTypes_[globalECONDIdx]];
       const bool pass_through_mode = (econd_headers[0] >> ECOND_FRAME::BITP_POS) & 0b1;
@@ -299,7 +299,8 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
         for (uint32_t erxIdx = 0; erxIdx < erxMax; erxIdx++) {
           // check if the eRx is enabled
           if ((enabledErx >> erxIdx & 1) == 0) {
-	    LogDebug("[HGCalUnpacker]") << "Skipping eRx=" << erxIdx << " for ECON-D "<< globalECONDIdx << " @ FED=" << fedReadoutSequence.id;
+            LogDebug("[HGCalUnpacker]") << "Skipping eRx=" << erxIdx << " for ECON-D " << globalECONDIdx
+                                        << " @ FED=" << fedReadoutSequence.id;
             continue;
           }
           LogDebug("[HGCalUnpacker]") << "fedId = " << fedId << ", captureblockIdx = " << captureblockIdx
@@ -369,7 +370,8 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
         for (uint32_t erxIdx = 0; erxIdx < erxMax; erxIdx++) {
           // check if the eRx is enabled
           if ((enabledErx >> erxIdx & 1) == 0) {
-	    LogDebug("[HGCalUnpacker]") << "Skipping eRx=" << erxIdx << " for ECON-D "<< globalECONDIdx << " @ FED=" << fedReadoutSequence.id;
+            LogDebug("[HGCalUnpacker]") << "Skipping eRx=" << erxIdx << " for ECON-D " << globalECONDIdx
+                                        << " @ FED=" << fedReadoutSequence.id;
             continue;
           }
           LogDebug("[HGCalUnpacker]") << "fedId = " << fedId << ", captureblockIdx = " << captureblockIdx
@@ -448,8 +450,8 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
         edm::LogWarning("[HGCalUnpacker]")
             << "Mismatch between unpacked and expected ECON-D #" << (int)globalECONDIdx << " payload length\n"
             << "  unpacked payload length=" << iword + 1 << "\n"
-            << "  expected payload length=" << econd_payload_length
-	    << " enabledErx=" << enabledErx << " erxMax=" << erxMax;
+            << "  expected payload length=" << econd_payload_length << " enabledErx=" << enabledErx
+            << " erxMax=" << erxMax;
         return (0x1 << hgcaldigi::FEDUnpackingFlags::ECONDPayloadLengthMismatch) |
                (hasActiveCBFlags << hgcaldigi::FEDUnpackingFlags::ActiveCaptureBlockFlags);
       }

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/HGCalConfigurationESProducer.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/HGCalConfigurationESProducer.cc
@@ -144,14 +144,14 @@ public:
               << ")!";
         mod.rocs.resize(nrocs);
 
-	//by default are enabled except if configured otherwise
-	mod.enabledErx = (0b1 << nrocs) - 0b1;
-	if( mod_config_data[modkey].count("enabledErx")>0 ) {
-	  mod.enabledErx = gethex(mod_config_data[modkey]["enabledErx"],-1);
-	  edm::LogWarning("HGCalConfigurationESProducer") << "Overwritting default eRx enabled mask with 0x" <<
-	    std::hex << mod.enabledErx << std::dec << " for " << typecode;
-	}
-       
+        //by default are enabled except if configured otherwise
+        mod.enabledErx = (0b1 << nrocs) - 0b1;
+        if (mod_config_data[modkey].count("enabledErx") > 0) {
+          mod.enabledErx = gethex(mod_config_data[modkey]["enabledErx"], -1);
+          edm::LogWarning("HGCalConfigurationESProducer") << "Overwritting default eRx enabled mask with 0x" << std::hex
+                                                          << mod.enabledErx << std::dec << " for " << typecode;
+        }
+
         // fill eRX (half-ROC) configuration
         for (uint32_t iroc = 0; iroc < nrocs; iroc++) {
           ntot_rocs++;

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/HGCalConfigurationESProducer.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/HGCalConfigurationESProducer.cc
@@ -144,6 +144,14 @@ public:
               << ")!";
         mod.rocs.resize(nrocs);
 
+	//by default are enabled except if configured otherwise
+	mod.enabledErx = (0b1 << nrocs) - 0b1;
+	if( mod_config_data[modkey].count("enabledErx")>0 ) {
+	  mod.enabledErx = gethex(mod_config_data[modkey]["enabledErx"],-1);
+	  edm::LogWarning("HGCalConfigurationESProducer") << "Overwritting default eRx enabled mask with 0x" <<
+	    std::hex << mod.enabledErx << std::dec << " for " << typecode;
+	}
+       
         // fill eRX (half-ROC) configuration
         for (uint32_t iroc = 0; iroc < nrocs; iroc++) {
           ntot_rocs++;


### PR DESCRIPTION
#### PR description:

For HGCAL we have relied so far that each module will have the maximum number of half-ROCs enabled, as expected from counting of chips. However in some specific cases one needs to mask some of them which are disabled by default. 
This PR introduces the necessary change in the CondFormats to do so. The HGCalUnpacker is also changed such that it uses the mask bitset from the Configuration CondFormat instead of taking it from the baseline module mapper.


#### PR validation:

This was validated with data from layer 26 where the first modules which need this (so-called ML-5) were tested for the first time. The inspection of a `fixed_adc` run looks reasonable

<img width="600" alt="Layer 26 <ADC>" src="https://github.com/user-attachments/assets/bb152264-88a1-4fe4-9933-33e63168ff80" />



@IzaakWN @yulunmiao @cramonal @adavidzh