### PR TITLE
Update `DiagStreamerFile`

### DIFF
--- a/IOPool/Streamer/bin/DiagStreamerFile.cpp
+++ b/IOPool/Streamer/bin/DiagStreamerFile.cpp
@@ -76,6 +76,7 @@ namespace {
   }
   //==========================================================================
   void readfile(std::string filename, std::string outfile) {
+    uint32 num_metadata(0);
     uint32 num_events(0);
     uint32 num_badevents(0);
     uint32 num_baduncompress(0);
@@ -114,6 +115,12 @@ namespace {
 
       while (StreamerInputFile::Next::kEvent == stream_reader.next()) {
         eview = stream_reader.currentRecord();
+        // for now skip the metadata records
+        if (eview->isEventMetaData()) {
+          ++num_metadata;
+          continue;
+        }
+
         ++num_events;
         bool good_event(true);
         if (seenEventMap.find(eview->event()) == seenEventMap.end()) {
@@ -192,7 +199,8 @@ namespace {
 
       std::cout << std::endl
                 << "------------END--------------" << std::endl
-                << "read " << num_events << " events" << std::endl
+                << "read " << num_metadata << " metadata records" << std::endl
+                << "and " << num_events << " events" << std::endl
                 << "and " << num_badevents << " events with bad headers" << std::endl
                 << "and " << num_badchksum << " events with bad check sum" << std::endl
                 << "and " << num_baduncompress << " events with bad uncompress" << std::endl

--- a/IOPool/Streamer/bin/DiagStreamerFile.cpp
+++ b/IOPool/Streamer/bin/DiagStreamerFile.cpp
@@ -29,8 +29,7 @@
 #include "IOPool/Streamer/interface/MsgTools.h"
 #include "IOPool/Streamer/interface/StreamerInputFile.h"
 #include "IOPool/Streamer/interface/StreamerOutputFile.h"
-
-#include "zlib.h"
+#include "IOPool/Streamer/interface/uncompress.h"
 
 #include <iostream>
 #include <map>
@@ -40,7 +39,7 @@ using namespace edm::streamer;
 
 namespace {
   bool compares_bad(EventMsgView const* eview1, EventMsgView const* eview2);
-  bool uncompressBuffer(unsigned char* inputBuffer,
+  bool uncompressBuffer(unsigned char const* inputBuffer,
                         unsigned int inputSize,
                         std::vector<unsigned char>& outputBuffer,
                         unsigned int expectedFullSize);
@@ -264,36 +263,25 @@ namespace {
   //==========================================================================
   bool test_uncompress(EventMsgView const* eview, std::vector<unsigned char>& dest) {
     unsigned long origsize = eview->origDataSize();
-    bool success = false;
     if (origsize != 0 && origsize != 78) {
       // compressed
-      success = uncompressBuffer(
-          const_cast<unsigned char*>((unsigned char const*)eview->eventData()), eview->eventLength(), dest, origsize);
+      return uncompressBuffer(
+          static_cast<unsigned char const*>(eview->eventData()), eview->eventLength(), dest, origsize);
     } else {
       // uncompressed anyway
-      success = true;
+      return false;
     }
-    return success;
   }
 
   //==========================================================================
-  bool uncompressBuffer(unsigned char* inputBuffer,
+  bool uncompressBuffer(unsigned char const* inputBuffer,
                         unsigned int inputSize,
                         std::vector<unsigned char>& outputBuffer,
                         unsigned int expectedFullSize) {
-    unsigned long origSize = expectedFullSize;
-    unsigned long uncompressedSize = expectedFullSize * 1.1;
-    outputBuffer.resize(uncompressedSize);
-    int ret = uncompress(&outputBuffer[0], &uncompressedSize, inputBuffer, inputSize);
-    if (ret == Z_OK) {
-      // check the length against original uncompressed length
-      if (origSize != uncompressedSize) {
-        std::cout << "Problem with uncompress, original size = " << origSize
-                  << " uncompress size = " << uncompressedSize << std::endl;
-        return false;
-      }
-    } else {
-      std::cout << "Problem with uncompress, return value = " << ret << std::endl;
+    try {
+      edm::streamer::uncompress::uncompressBuffer(inputBuffer, inputSize, outputBuffer, expectedFullSize);
+    } catch (cms::Exception& e) {
+      std::cout << "Problem with uncompress: " << e.what() << std::endl;
       return false;
     }
     return true;

--- a/IOPool/Streamer/interface/StreamerInputSource.h
+++ b/IOPool/Streamer/interface/StreamerInputSource.h
@@ -53,41 +53,6 @@ namespace edm::streamer {
 
     static void mergeIntoRegistry(SendJobHeader const& header, ProductRegistry&, bool subsequent);
 
-    /**
-     * Detect if buffer starts with "XZ\0" which means it is compressed in LZMA format
-     */
-    bool isBufferLZMA(unsigned char const* inputBuffer, unsigned int inputSize);
-
-    /**
-     * Detect if buffer starts with "Z\0" which means it is compressed in ZStandard format
-     */
-    bool isBufferZSTD(unsigned char const* inputBuffer, unsigned int inputSize);
-
-    /**
-     * Uncompresses the data in the specified input buffer into the
-     * specified output buffer.  The inputSize should be set to the size
-     * of the compressed data in the inputBuffer.  The expectedFullSize should
-     * be set to the original size of the data (before compression).
-     * Returns the actual size of the uncompressed data.
-     * Errors are reported by throwing exceptions.
-     */
-    static unsigned int uncompressBuffer(unsigned char* inputBuffer,
-                                         unsigned int inputSize,
-                                         std::vector<unsigned char>& outputBuffer,
-                                         unsigned int expectedFullSize);
-
-    static unsigned int uncompressBufferLZMA(unsigned char* inputBuffer,
-                                             unsigned int inputSize,
-                                             std::vector<unsigned char>& outputBuffer,
-                                             unsigned int expectedFullSize,
-                                             bool hasHeader = true);
-
-    static unsigned int uncompressBufferZSTD(unsigned char* inputBuffer,
-                                             unsigned int inputSize,
-                                             std::vector<unsigned char>& outputBuffer,
-                                             unsigned int expectedFullSize,
-                                             bool hasHeader = true);
-
   protected:
     static void declareStreamers(SendDescs const& descs);
     static void buildClassCache(SendDescs const& descs);

--- a/IOPool/Streamer/interface/uncompress.h
+++ b/IOPool/Streamer/interface/uncompress.h
@@ -1,0 +1,27 @@
+#ifndef IOPool_Streamer_uncompress_h
+#define IOPool_Streamer_uncompress_h
+
+#include <vector>
+
+namespace edm::streamer::uncompress {
+  enum class Algo { kZLIB, kZSTD, kLZMA };
+
+  Algo compressionAlgo(unsigned char const* inputBuffer, unsigned int inputSize);
+
+  /**
+     * Uncompresses the data in the specified input buffer into the
+     * specified output buffer.  The inputSize should be set to the size
+     * of the compressed data in the inputBuffer.  The expectedFullSize should
+     * be set to the original size of the data (before compression).
+     * Figures out the compression algorithm from the input content.
+     * Returns the actual size of the uncompressed data.
+     * Errors are reported by throwing exceptions.
+     */
+  unsigned int uncompressBuffer(unsigned char const* inputBuffer,
+                                unsigned int inputSize,
+                                std::vector<unsigned char>& outputBuffer,
+                                unsigned int expectedFullSize,
+                                bool hasHeader = true);
+}  // namespace edm::streamer::uncompress
+
+#endif

--- a/IOPool/Streamer/src/DumpTools.cc
+++ b/IOPool/Streamer/src/DumpTools.cc
@@ -5,13 +5,14 @@
 #include "IOPool/Streamer/interface/DumpTools.h"
 #include "FWCore/Utilities/interface/Digest.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
-#include <iostream>
-#include <iterator>
 #include "DataFormats/Streamer/interface/StreamedProducts.h"
 #include "IOPool/Streamer/interface/ClassFiller.h"
+#include "IOPool/Streamer/interface/uncompress.h"
 
 #include "TBufferFile.h"
 
+#include <iostream>
+#include <iterator>
 #include <memory>
 
 using namespace edm;
@@ -129,6 +130,24 @@ namespace edm::streamer {
   }
 
   void dumpEventHeader(const EventMsgView* eview) {
+    std::string_view algo = "uncompressed";
+    unsigned long origsize = eview->origDataSize();
+    if (origsize != 0 && origsize != 78) {
+      using namespace edm::streamer::uncompress;
+      auto ealgo = compressionAlgo(static_cast<unsigned char const*>(eview->eventData()), eview->eventLength());
+      switch (ealgo) {
+        case Algo::kZLIB:
+          algo = "ZLIB";
+          break;
+        case Algo::kZSTD:
+          algo = "ZSTD";
+          break;
+        case Algo::kLZMA:
+          algo = "LZMA";
+          break;
+      }
+    }
+
     std::cout << "code=" << eview->code() << "\n"
               << "size=" << eview->size() << "\n"
               << "protocolVersion=" << eview->protocolVersion() << "\n"
@@ -137,6 +156,7 @@ namespace edm::streamer {
               << "lumi=" << eview->lumi() << "\n"
               << "origDataSize=" << eview->origDataSize() << "\n"
               << "outModId=0x" << std::hex << eview->outModId() << std::dec << "\n"
+              << "compression=" << algo << "\n"
               << "adler32 chksum= " << eview->adler32_chksum() << "\n"
               << "host name= " << eview->hostName() << "\n"
               << "event length=" << eview->eventLength() << "\n"

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -3,6 +3,7 @@
 #include "IOPool/Streamer/interface/EventMessage.h"
 #include "IOPool/Streamer/interface/InitMessage.h"
 #include "IOPool/Streamer/interface/ClassFiller.h"
+#include "IOPool/Streamer/interface/uncompress.h"
 
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/FileBlock.h"
@@ -15,10 +16,6 @@
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
-
-#include "zlib.h"
-#include "lzma.h"
-#include "zstd.h"
 
 #include "DataFormats/Common/interface/RefCoreStreamer.h"
 #include "FWCore/Utilities/interface/WrappedClassName.h"
@@ -226,21 +223,8 @@ namespace edm::streamer {
     }
     if (origsize != 78 && origsize != 0) {
       // compressed
-      if (isBufferLZMA((unsigned char const*)eventView.eventData(), eventView.eventLength())) {
-        dest_size = uncompressBufferLZMA(const_cast<unsigned char*>((unsigned char const*)eventView.eventData()),
-                                         eventView.eventLength(),
-                                         dest_,
-                                         origsize);
-      } else if (isBufferZSTD((unsigned char const*)eventView.eventData(), eventView.eventLength())) {
-        dest_size = uncompressBufferZSTD(const_cast<unsigned char*>((unsigned char const*)eventView.eventData()),
-                                         eventView.eventLength(),
-                                         dest_,
-                                         origsize);
-      } else
-        dest_size = uncompressBuffer(const_cast<unsigned char*>((unsigned char const*)eventView.eventData()),
-                                     eventView.eventLength(),
-                                     dest_,
-                                     origsize);
+      dest_size = edm::streamer::uncompress::uncompressBuffer(
+          (unsigned char const*)eventView.eventData(), eventView.eventLength(), dest_, origsize);
     } else {  // not compressed
       // we need to copy anyway the buffer as we are using dest in xbuf
       dest_size = eventView.eventLength();
@@ -344,113 +328,6 @@ namespace edm::streamer {
       }
       spitem.clear();
     }
-  }
-
-  /**
-   * Uncompresses the data in the specified input buffer into the
-   * specified output buffer.  The inputSize should be set to the size
-   * of the compressed data in the inputBuffer.  The expectedFullSize should
-   * be set to the original size of the data (before compression).
-   * Returns the actual size of the uncompressed data.
-   * Errors are reported by throwing exceptions.
-   */
-  unsigned int StreamerInputSource::uncompressBuffer(unsigned char* inputBuffer,
-                                                     unsigned int inputSize,
-                                                     std::vector<unsigned char>& outputBuffer,
-                                                     unsigned int expectedFullSize) {
-    unsigned long origSize = expectedFullSize;
-    unsigned long uncompressedSize = expectedFullSize * 1.1;
-    outputBuffer.resize(uncompressedSize);
-    int ret = uncompress(&outputBuffer[0], &uncompressedSize, inputBuffer, inputSize);  // do not need compression level
-    //std::cout << "unCompress Return value: " << ret << " Okay = " << Z_OK << std::endl;
-    if (ret == Z_OK) {
-      // check the length against original uncompressed length
-      if (origSize != uncompressedSize) {
-        // we throw an error and return without event! null pointer
-        throw cms::Exception("StreamDeserialization", "Uncompression error")
-            << "mismatch event lengths should be" << origSize << " got " << uncompressedSize << "\n";
-      }
-    } else {
-      // we throw an error and return without event! null pointer
-      throw cms::Exception("StreamDeserialization", "Uncompression error") << "Error code = " << ret << "\n ";
-    }
-    return (unsigned int)uncompressedSize;
-  }
-
-  bool StreamerInputSource::isBufferLZMA(unsigned char const* inputBuffer, unsigned int inputSize) {
-    if (inputSize >= 4 && !strcmp((const char*)inputBuffer, "XZ"))
-      return true;
-    else
-      return false;
-  }
-
-  unsigned int StreamerInputSource::uncompressBufferLZMA(unsigned char* inputBuffer,
-                                                         unsigned int inputSize,
-                                                         std::vector<unsigned char>& outputBuffer,
-                                                         unsigned int expectedFullSize,
-                                                         bool hasHeader) {
-    unsigned long origSize = expectedFullSize;
-    unsigned long uncompressedSize = expectedFullSize * 1.1;
-    outputBuffer.resize(uncompressedSize);
-
-    lzma_stream stream = LZMA_STREAM_INIT;
-    lzma_ret returnStatus;
-
-    returnStatus = lzma_stream_decoder(&stream, UINT64_MAX, 0U);
-    if (returnStatus != LZMA_OK) {
-      throw cms::Exception("StreamDeserializationLZM", "LZMA stream decoder error")
-          << "Error code = " << returnStatus << "\n ";
-    }
-
-    size_t hdrSize = hasHeader ? 4 : 0;
-    stream.next_in = (const uint8_t*)(inputBuffer + hdrSize);
-    stream.avail_in = (size_t)(inputSize - hdrSize);
-    stream.next_out = (uint8_t*)&outputBuffer[0];
-    stream.avail_out = (size_t)uncompressedSize;
-
-    returnStatus = lzma_code(&stream, LZMA_FINISH);
-    if (returnStatus != LZMA_STREAM_END) {
-      lzma_end(&stream);
-      throw cms::Exception("StreamDeserializationLZM", "LZMA uncompression error")
-          << "Error code = " << returnStatus << "\n ";
-    }
-    lzma_end(&stream);
-
-    uncompressedSize = (unsigned int)stream.total_out;
-
-    if (origSize != uncompressedSize) {
-      // we throw an error and return without event! null pointer
-      throw cms::Exception("StreamDeserialization", "LZMA uncompression error")
-          << "mismatch event lengths should be" << origSize << " got " << uncompressedSize << "\n";
-    }
-
-    return uncompressedSize;
-  }
-
-  bool StreamerInputSource::isBufferZSTD(unsigned char const* inputBuffer, unsigned int inputSize) {
-    if (inputSize >= 4 && !strcmp((const char*)inputBuffer, "ZS"))
-      return true;
-    else
-      return false;
-  }
-
-  unsigned int StreamerInputSource::uncompressBufferZSTD(unsigned char* inputBuffer,
-                                                         unsigned int inputSize,
-                                                         std::vector<unsigned char>& outputBuffer,
-                                                         unsigned int expectedFullSize,
-                                                         bool hasHeader) {
-    unsigned long uncompressedSize = expectedFullSize * 1.1;
-    outputBuffer.resize(uncompressedSize);
-
-    size_t hdrSize = hasHeader ? 4 : 0;
-    size_t ret = ZSTD_decompress(
-        (void*)&(outputBuffer[0]), uncompressedSize, (const void*)(inputBuffer + hdrSize), inputSize - hdrSize);
-
-    if (ZSTD_isError(ret)) {
-      throw cms::Exception("StreamDeserializationZSTD", "ZSTD uncompression error")
-          << "Error core " << ret << ", message:" << ZSTD_getErrorName(ret);
-    }
-    return (unsigned int)ret;
   }
 
   void StreamerInputSource::resetAfterEndRun() {

--- a/IOPool/Streamer/src/uncompress.cc
+++ b/IOPool/Streamer/src/uncompress.cc
@@ -1,0 +1,143 @@
+#include "FWCore/Utilities/interface/Exception.h"
+#include "IOPool/Streamer/interface/uncompress.h"
+
+#include "zlib.h"
+#include "lzma.h"
+#include "zstd.h"
+
+#include <cstring>
+
+namespace {
+  /**
+   * Detect if buffer starts with "XZ\0" which means it is compressed in LZMA format
+   */
+  bool isBufferLZMA(unsigned char const* inputBuffer, unsigned int inputSize) {
+    if (inputSize >= 4 && !strcmp((const char*)inputBuffer, "XZ"))
+      return true;
+    else
+      return false;
+  }
+
+  /**
+   * Detect if buffer starts with "Z\0" which means it is compressed in ZStandard format
+   */
+  bool isBufferZSTD(unsigned char const* inputBuffer, unsigned int inputSize) {
+    if (inputSize >= 4 && !strcmp((const char*)inputBuffer, "ZS"))
+      return true;
+    else
+      return false;
+  }
+
+  unsigned int uncompressBufferZLIB(unsigned char* inputBuffer,
+                                    unsigned int inputSize,
+                                    std::vector<unsigned char>& outputBuffer,
+                                    unsigned int expectedFullSize) {
+    unsigned long origSize = expectedFullSize;
+    unsigned long uncompressedSize = expectedFullSize * 1.1;
+    outputBuffer.resize(uncompressedSize);
+    int ret =
+        ::uncompress(&outputBuffer[0], &uncompressedSize, inputBuffer, inputSize);  // do not need compression level
+    //std::cout << "unCompress Return value: " << ret << " Okay = " << Z_OK << std::endl;
+    if (ret == Z_OK) {
+      // check the length against original uncompressed length
+      if (origSize != uncompressedSize) {
+        // we throw an error and return without event! null pointer
+        throw cms::Exception("StreamDeserialization", "Uncompression error")
+            << "mismatch event lengths should be" << origSize << " got " << uncompressedSize << "\n";
+      }
+    } else {
+      // we throw an error and return without event! null pointer
+      throw cms::Exception("StreamDeserialization", "Uncompression error") << "Error code = " << ret << "\n ";
+    }
+    return (unsigned int)uncompressedSize;
+  }
+
+  unsigned int uncompressBufferLZMA(unsigned char* inputBuffer,
+                                    unsigned int inputSize,
+                                    std::vector<unsigned char>& outputBuffer,
+                                    unsigned int expectedFullSize,
+                                    bool hasHeader) {
+    unsigned long origSize = expectedFullSize;
+    unsigned long uncompressedSize = expectedFullSize * 1.1;
+    outputBuffer.resize(uncompressedSize);
+
+    lzma_stream stream = LZMA_STREAM_INIT;
+    lzma_ret returnStatus;
+
+    returnStatus = lzma_stream_decoder(&stream, UINT64_MAX, 0U);
+    if (returnStatus != LZMA_OK) {
+      throw cms::Exception("StreamDeserializationLZM", "LZMA stream decoder error")
+          << "Error code = " << returnStatus << "\n ";
+    }
+
+    size_t hdrSize = hasHeader ? 4 : 0;
+    stream.next_in = (const uint8_t*)(inputBuffer + hdrSize);
+    stream.avail_in = (size_t)(inputSize - hdrSize);
+    stream.next_out = (uint8_t*)&outputBuffer[0];
+    stream.avail_out = (size_t)uncompressedSize;
+
+    returnStatus = lzma_code(&stream, LZMA_FINISH);
+    if (returnStatus != LZMA_STREAM_END) {
+      lzma_end(&stream);
+      throw cms::Exception("StreamDeserializationLZM", "LZMA uncompression error")
+          << "Error code = " << returnStatus << "\n ";
+    }
+    lzma_end(&stream);
+
+    uncompressedSize = (unsigned int)stream.total_out;
+
+    if (origSize != uncompressedSize) {
+      // we throw an error and return without event! null pointer
+      throw cms::Exception("StreamDeserialization", "LZMA uncompression error")
+          << "mismatch event lengths should be" << origSize << " got " << uncompressedSize << "\n";
+    }
+
+    return uncompressedSize;
+  }
+
+  unsigned int uncompressBufferZSTD(unsigned char* inputBuffer,
+                                    unsigned int inputSize,
+                                    std::vector<unsigned char>& outputBuffer,
+                                    unsigned int expectedFullSize,
+                                    bool hasHeader) {
+    unsigned long uncompressedSize = expectedFullSize * 1.1;
+    outputBuffer.resize(uncompressedSize);
+
+    size_t hdrSize = hasHeader ? 4 : 0;
+    size_t ret = ZSTD_decompress(
+        (void*)&(outputBuffer[0]), uncompressedSize, (const void*)(inputBuffer + hdrSize), inputSize - hdrSize);
+
+    if (ZSTD_isError(ret)) {
+      throw cms::Exception("StreamDeserializationZSTD", "ZSTD uncompression error")
+          << "Error core " << ret << ", message:" << ZSTD_getErrorName(ret);
+    }
+    return (unsigned int)ret;
+  }
+}  // namespace
+
+namespace edm::streamer::uncompress {
+  Algo compressionAlgo(unsigned char const* inputBuffer, unsigned int inputSize) {
+    if (isBufferLZMA(inputBuffer, inputSize)) {
+      return Algo::kLZMA;
+    } else if (isBufferZSTD(inputBuffer, inputSize)) {
+      return Algo::kZSTD;
+    } else {
+      return Algo::kZLIB;
+    }
+  }
+
+  unsigned int uncompressBuffer(unsigned char const* inputBuffer,
+                                unsigned int inputSize,
+                                std::vector<unsigned char>& outputBuffer,
+                                unsigned int expectedFullSize,
+                                bool hasHeader) {
+    if (isBufferLZMA(inputBuffer, inputSize)) {
+      return uncompressBufferLZMA(
+          const_cast<unsigned char*>(inputBuffer), inputSize, outputBuffer, expectedFullSize, hasHeader);
+    } else if (isBufferZSTD(inputBuffer, inputSize)) {
+      return uncompressBufferZSTD(
+          const_cast<unsigned char*>(inputBuffer), inputSize, outputBuffer, expectedFullSize, hasHeader);
+    } else
+      return uncompressBufferZLIB(const_cast<unsigned char*>(inputBuffer), inputSize, outputBuffer, expectedFullSize);
+  }
+}  // namespace edm::streamer::uncompress


### PR DESCRIPTION
#### PR description:

As part of the investigation in https://github.com/cms-sw/cmssw/issues/50349 this PR updates `DiagStreamerFile` utility to
* be able to uncompress ZSTD and LZMA compressions
* handle the metadata records (that were added in https://github.com/cms-sw/cmssw/pull/44892)

Resolves https://github.com/cms-sw/framework-team/issues/2015

#### PR validation:

Running `DiagStreamerFile` privately with the file https://github.com/cms-sw/cmssw/issues/50349#issuecomment-4029461964 works now. `IOPool/Streamer` tests succeed.
