### PR TITLE
[16.0.X] Fix CopyToDevice of TrackingRecHitsSoACollection

### DIFF
--- a/DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitsSoACollection.h
+++ b/DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitsSoACollection.h
@@ -67,10 +67,7 @@ namespace cms::alpakatools {
       reco::TrackingRecHitDevice<TDevice> deviceData(queue, nHits, hostData.nModules());
 
       if (nHits == 0) {
-        std::memset(
-            deviceData.buffer().data(),
-            0,
-            alpaka::getExtentProduct(deviceData.buffer()) * sizeof(alpaka::Elem<reco::TrackingRecHitHost::Buffer>));
+        deviceData.zeroInitialise(queue);
         return deviceData;
       }
 


### PR DESCRIPTION
backport of #50318 

#### PR description:

This PR fixes the `CopyToDevice` function of the `TrackingRecHitsSoACollection`. Previously, the special case of zero hits ran into a segmentation fault because the used std::memset function does not work on the device.

#### PR validation:

Trivial bug fix, tests were performed in the PR for the master branch.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport of #50318 