### PR TITLE
Add IntrusiveAllocProfiler

### DIFF
--- a/PerfTools/AllocMonitor/README.md
+++ b/PerfTools/AllocMonitor/README.md
@@ -155,11 +155,9 @@ The beginning of the file contains a description of the structure and contents o
 This service is multi-thread safe.
 
 
-### IntrusiveAllocMonitor
+### IntrusiveAllocMonitors
 
-This service registers a monitor when the service is created (after python parsing is finished, but before any modules have been loaded into cmsRun). The user can then start the monitoring in their code as shown in the example below. The monitoring stops, in an RAII fashion, at the end of the scope and the results of the memory operations are printed with the [MessageLogger](../../FWCore/MessageService/Readme.md) with an `IntrusiveAllocMonitor` message category.
-
-Example how to use the `IntrusiveAllocMonitor` in C++ code
+These services register monitors when the service is created (after python parsing is finished, but before any modules have been loaded into cmsRun) that a user can use to instrument their code as shown in the following example
 ```cpp
 #include "FWCore/AbstractServices/interface/IntrusiveMonitorBase.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -175,22 +173,62 @@ void someFunction() {
 }
 
 ```
+The monitoring stops, in an RAII fashion, at the end of the scope, and the results of the memory operations within that code block are reported. Note that the instrumented code is independent of the specific IntrusiveAllocMonitor, that is specified through the python configuration
 
-The message will print
+These services are multi-thread safe, and concurrent measurements can be done in different threads, although in multi-threaded context MessageLogger messages can be dropped so some measurements from these services could be lost. The services are re-entrant, i.e. measurements in nested scopes or function calls can be done within one thread. In case of nested measurements the numbers for the outer scope exclude the numbers of the inner scope. 
+
+Note that if an `std::string` is passed to `startMeasurement()`, the memory allocations from the string formatting will be accounted by a possible outer scope measurements. Therefore it is recommended to use `std::string` overload only when really necessary.
+
+Allocations done in different thread where the `startMeasurement()` is called are not recorded. Measurements started in one thread and ended in different thread are not supported.
+
+
+
+#### IntrusiveAllocMonitor
+
+The `IntrusiveAllocMonitor` records the following quantities that are printed at the end of each measurement with the [MessageLogger](../../FWCore/MessageService/Readme.md) with an `IntrusiveAllocMonitor` message category.
 | Field | Description |
 |-------|-------------|
 | `requested` | Total number of requested bytes |
-| `added ` | Total number of bytes added (can be more than `requested`) |
+| `added` | Total number of bytes added (can be more than `requested`) |
 | `max alloc` | Largest single memory allocation |
 | `peak` | Maximum amount of allocated memory at any given moment |
 | `nAlloc` | Number of memory allocations |
 | `nDealloc` | Number of memory deallocations |
 
-This service is multi-thread safe, and concurrent measurements can be done in different threads. The service is re-entrant, i.e. measurements in nested scopes or function calls can be done within one thread. In case of nested measurements the numbers for the outer scope exclude the numbers of the inner scope. For the inner scope measurement the message will contain the description strings of all outer measurements in a strack-trace-like format.
 
-Note that if an `std::string` is passed to `startMeasurement()`, the memory allocations from the string formatting will be accounted by a possible outer scope measurements. In that case the measurement printout of the outer scope will denote that along with the minimum amount of allocated memory and the number of allocations for the strings, but generally the numbers can not be obtained precisely. Therefore it is recommended to use `std::string` overload only when really necessary.
+In case of nested measurements, the inner scope measurement message will contain the description strings of all outer measurements in a strack-trace-like format.
 
-Allocations done in different thread where the `startMeasurement()` is called are not recorded. Measurements started in one thread and ended in different thread are not supported.
+If an `std::string` is passed to `startMeasurement()`, the measurement printout of the outer scope will denote that along with the minimum amount of allocated memory and the number of allocations for the strings, but generally the numbers can not be obtained precisely.
+
+#### IntrusiveAllocProfiler (C++23)
+
+The `IntrusiveAllocProfiler` records the stack traces of each individual memory allocation and deallocation within the measurement region. At the end of the measurement it reports
+| Name | Description |
+|-------|-------------|
+| `alloc` | Stack traces from all memory allocations. Sorted in decreasing order by `actual` allocated memory. |
+| `dealloc` | Stack traces from all memory deallocations. Sorted in decreasing order by `actual` deallocated memory. |
+| `atMaxAlloc` | Stack traces from such memory allocations that were not deallocated at the moment the `actual` allocated memory reached its maximum value during the measurement. Sorted in decreasing order by `actual` allocated memory. |
+| `added` | Stack traces from such memory allocations that were not deallocated within the same measurement, i.e. that memory is added to the process by the corresponding code block. Roughly corresponds to IgProf's `MEM_LIVE`. Sorted in decreasing order by `actual` allocated memory. |
+| `churn` | Stack traces from such memory allocations that were deallocated within the same measurement. These indicate possible memory churn. The first entry in the stack trace shows the lowest entry that is common in the stack traces of both the allocation and deallocation. Sorted in decreasing order by the number of allocations (`count`) |
+| `churnalloc` | Shows same memory allocations as in the `churn` report, but the stack traces point to the memory allocations. Sorted in decreasing order by the number of allocations (`count`). |
+
+Following quantities are reported for the aggregated stack traces
+| Field | Description |
+|-------|-------------|
+| `count` | Number of allocations/deallocations |
+| `requested` | Requested bytes (not shown for deallocations) |
+| `actual` | Actually allocated/deallocated bytes |
+
+The Service has the following configuration parameters
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `filePattern` | empty | If empty, print the repots with MessageLogger. If non-empty, specifies the pattern for output text files. Must contain at least one `%I` for a file counter, and `%M` for the measurement name. |
+| `statistics` | `False` | If `True`, print internal statistics to the log. |
+
+By default all reports are printed with MessageLogger. With `filePattern` the reports are written into files, with the file names being printed with MessageLogger at the time when each measurment ends. The `edmIntrusiveAllocProfilerFoldStacks.py` script can be used to "fold" the stack traces to a format understood e.g. flamegraph tools such as https://github.com/brendangregg/FlameGraph for one quantity at a time. An example
+```sh
+edmIntrusiveAllocProfilerFoldStacks.py -q actual report.txt | flamegraph.pl > report_flamegraph.svg
+```
 
 ### ThresholdAbortAllocMonitor
 

--- a/PerfTools/AllocMonitor/plugins/BuildFile.xml
+++ b/PerfTools/AllocMonitor/plugins/BuildFile.xml
@@ -4,3 +4,7 @@
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Utilities" source_only="1"/>
 <use name="PerfTools/AllocMonitor"/>
+<!-- Needed by monitors that use std::stacktrace, presently available only in CPP23 builds -->
+<ifrelease name="CPP23">
+  <lib name="stdc++exp"/>
+</ifrelease>

--- a/PerfTools/AllocMonitor/plugins/IntrusiveAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/IntrusiveAllocMonitor.cc
@@ -6,39 +6,25 @@
 #include "PerfTools/AllocMonitor/interface/AllocMonitorBase.h"
 #include "PerfTools/AllocMonitor/interface/AllocMonitorRegistry.h"
 
+#include "MonitorStackNode.h"
 #include "ThreadAllocInfo.h"
 #include "ThreadTracker.h"
 
 namespace {
   using namespace edm::service::moduleAlloc;
 
-  /**
-   * These objects form a linked list of nested uses
-   * IntrusiveAllocMonitor measurements.
-   */
-  class MonitorStackNode {
+  class StackData {
   public:
-    MonitorStackNode(std::string_view name,
-                     bool nameIsString,
-                     ThreadAllocInfo const& previousInfo,
-                     std::unique_ptr<MonitorStackNode> previousNode)
-        : name_(name), previousInfo_(previousInfo), previousNode_(std::move(previousNode)) {
-      if (nameIsString and previousNode_) {
-        auto& n = previousNode_->nestedNameSizes_;
+    StackData(std::string_view name, bool nameIsString, ThreadAllocInfo const& previousInfo, StackData* previousNodeData)
+        : previousInfo_(previousInfo) {
+      if (nameIsString and previousNodeData) {
+        auto& n = previousNodeData->nestedNameSizes_;
         n.sum_ += name.size();
         n.count_ += 1;
       }
     }
-    MonitorStackNode(MonitorStackNode const&) = delete;
-    MonitorStackNode& operator=(MonitorStackNode const&) = delete;
-    MonitorStackNode(MonitorStackNode&&) = delete;
-    MonitorStackNode& operator=(MonitorStackNode&&) = delete;
 
-    ~MonitorStackNode() noexcept = default;
-
-    std::string_view name() const { return name_; }
     ThreadAllocInfo const& previousAllocInfo() const { return previousInfo_; }
-    MonitorStackNode const* previousNode() const { return previousNode_.get(); }
 
     struct NestedNameSizes {
       size_t sum_ = 0;
@@ -46,14 +32,11 @@ namespace {
     };
     NestedNameSizes const& nestedNameSizes() const { return nestedNameSizes_; }
 
-    std::unique_ptr<MonitorStackNode> popPreviousNode() { return std::move(previousNode_); }
-
   private:
-    std::string_view name_;
     NestedNameSizes nestedNameSizes_;
     ThreadAllocInfo previousInfo_;
-    std::unique_ptr<MonitorStackNode> previousNode_;
   };
+  using MonitorStackNode = cms::perftools::allocMon::MonitorStackNode<StackData>;
   std::unique_ptr<MonitorStackNode>& currentMonitorStackNode() {
     static thread_local std::unique_ptr<MonitorStackNode> ptr;
     return ptr;
@@ -65,7 +48,7 @@ namespace {
         : currentNode_(std::move(node)), info_(info) {}
     ~PreviousStateRestoreGuard() noexcept {
       currentMonitorStackNode() = currentNode_->popPreviousNode();
-      info_ = currentNode_->previousAllocInfo();
+      info_ = currentNode_->get().previousAllocInfo();
       assert(not info_.active_);
 
       // deallocate outside of measurement
@@ -90,7 +73,11 @@ namespace {
       // keep the previous measurement deactivated until the guard activates it again in ~PreviousStateRestoreGuard
       t.deactivate();
       // push a node to the top of the MonitorStackNode list
-      auto node = std::make_unique<MonitorStackNode>(name, nameIsString, t, std::move(currentMonitorStackNode()));
+      auto prevNodePtr = currentMonitorStackNode().get();
+      auto node = std::make_unique<MonitorStackNode>(
+          name,
+          std::move(currentMonitorStackNode()),
+          StackData(name, nameIsString, t, prevNodePtr ? &(prevNodePtr->get()) : nullptr));
       currentMonitorStackNode() = std::move(node);
       t.reset();
     }
@@ -176,7 +163,7 @@ public:
         node = node->previousNode();
         ++depth;
       }
-      auto const& nestedNames = guard.currentNode()->nestedNameSizes();
+      auto const& nestedNames = guard.currentNode()->get().nestedNameSizes();
       if (nestedNames.count_ > 0) {
         log.format("\nThis includes at least {} bytes in {} allocations from string names in nested measurements",
                    nestedNames.sum_,

--- a/PerfTools/AllocMonitor/plugins/IntrusiveAllocProfiler.cc
+++ b/PerfTools/AllocMonitor/plugins/IntrusiveAllocProfiler.cc
@@ -55,13 +55,204 @@ namespace {
     std::size_t count_ = 0;
   };
 
+  // Statistics Strategy Pattern
+  class StatisticsStrategy {
+  public:
+    virtual ~StatisticsStrategy() = default;
+
+    // RAII timer for measuring operation durations
+    class ScopedTimer {
+    public:
+      ScopedTimer(std::chrono::duration<double, std::milli>* target) : target_(target) {
+        if (target_) {
+          start_ = std::chrono::steady_clock::now();
+        }
+      }
+      ~ScopedTimer() {
+        if (target_) {
+          *target_ = std::chrono::steady_clock::now() - start_;
+        }
+      }
+
+    private:
+      std::chrono::duration<double, std::milli>* target_;
+      std::chrono::steady_clock::time_point start_;
+    };
+
+    // Combined recording: timing and counting
+    virtual ScopedTimer recordAllocation() = 0;
+    virtual ScopedTimer recordDeallocation() = 0;
+
+    // Allocation printing measurements
+    virtual void recordAllocationsUniqueAggregated(std::size_t value) = 0;
+    virtual ScopedTimer timeAllocationsAggregation() = 0;
+    virtual ScopedTimer timeAllocationsSorting() = 0;
+    virtual ScopedTimer timeAllocationsFormatting() = 0;
+    virtual ScopedTimer timeAllocationsAtMaxActualSorting() = 0;
+    virtual ScopedTimer timeAllocationsAtMaxActualFormatting() = 0;
+    virtual ScopedTimer timeAllocationsAddedFiltering() = 0;
+    virtual ScopedTimer timeAllocationsAddedFormatting() = 0;
+
+    // Deallocation printing measurements
+    virtual void recordDeallocationsUniqueAggregated(std::size_t value) = 0;
+    virtual ScopedTimer timeDeallocationAggregation() = 0;
+    virtual ScopedTimer timeDeallocationsSorting() = 0;
+    virtual ScopedTimer timeDeallocationsFormatting() = 0;
+
+    // Churn printing measurements
+    virtual void recordChurnUniqueAggregated(std::size_t value) = 0;
+    virtual void recordChurnMaxInnerSize(std::size_t value) = 0;
+    virtual ScopedTimer timeChurnAggregation() = 0;
+    virtual ScopedTimer timeChurnSorting() = 0;
+    virtual ScopedTimer timeChurnFormatting() = 0;
+
+    // Final statistics printout (accesses internal member data)
+    virtual void printStatistics(edm::LogSystem& log,
+                                 std::size_t numAllocTraces,
+                                 std::size_t numDeallocTraces) const = 0;
+  };
+
+  // No-op strategy: zero overhead, no measurements
+  class NoOpStatisticsStrategy : public StatisticsStrategy {
+  public:
+    ScopedTimer recordAllocation() override { return ScopedTimer(nullptr); }
+    ScopedTimer recordDeallocation() override { return ScopedTimer(nullptr); }
+
+    void recordAllocationsUniqueAggregated(std::size_t) override {}
+    ScopedTimer timeAllocationsAggregation() override { return ScopedTimer(nullptr); }
+    ScopedTimer timeAllocationsSorting() override { return ScopedTimer(nullptr); }
+    ScopedTimer timeAllocationsFormatting() override { return ScopedTimer(nullptr); }
+    ScopedTimer timeAllocationsAtMaxActualSorting() override { return ScopedTimer(nullptr); }
+    ScopedTimer timeAllocationsAtMaxActualFormatting() override { return ScopedTimer(nullptr); }
+    ScopedTimer timeAllocationsAddedFiltering() override { return ScopedTimer(nullptr); }
+    ScopedTimer timeAllocationsAddedFormatting() override { return ScopedTimer(nullptr); }
+
+    void recordDeallocationsUniqueAggregated(std::size_t) override {}
+    ScopedTimer timeDeallocationAggregation() override { return ScopedTimer(nullptr); }
+    ScopedTimer timeDeallocationsSorting() override { return ScopedTimer(nullptr); }
+    ScopedTimer timeDeallocationsFormatting() override { return ScopedTimer(nullptr); }
+
+    void recordChurnUniqueAggregated(std::size_t) override {}
+    void recordChurnMaxInnerSize(std::size_t) override {}
+    ScopedTimer timeChurnAggregation() override { return ScopedTimer(nullptr); }
+    ScopedTimer timeChurnSorting() override { return ScopedTimer(nullptr); }
+    ScopedTimer timeChurnFormatting() override { return ScopedTimer(nullptr); }
+
+    void printStatistics(edm::LogSystem&, std::size_t, std::size_t) const override {}
+  };
+
+  // Collecting strategy: measures and reports all statistics
+  class CollectingStatisticsStrategy : public StatisticsStrategy {
+  public:
+    ScopedTimer recordAllocation() override {
+      ++numAllocations_;
+      return ScopedTimer(&allocationsTime_);
+    }
+    ScopedTimer recordDeallocation() override {
+      ++numDeallocations_;
+      return ScopedTimer(&deallocationsTime_);
+    }
+
+    void recordAllocationsUniqueAggregated(std::size_t value) override { allocStats_.uniqueAggregated = value; }
+    ScopedTimer timeAllocationsAggregation() override { return ScopedTimer(&allocStats_.t_aggregation); }
+    ScopedTimer timeAllocationsSorting() override { return ScopedTimer(&allocStats_.t_sorting); }
+    ScopedTimer timeAllocationsFormatting() override { return ScopedTimer(&allocStats_.t_format); }
+    ScopedTimer timeAllocationsAtMaxActualSorting() override { return ScopedTimer(&allocStats_.t_atMaxActualSorting); }
+    ScopedTimer timeAllocationsAtMaxActualFormatting() override {
+      return ScopedTimer(&allocStats_.t_atMaxActualFormat);
+    }
+    ScopedTimer timeAllocationsAddedFiltering() override { return ScopedTimer(&allocStats_.t_addedFiltering); }
+    ScopedTimer timeAllocationsAddedFormatting() override { return ScopedTimer(&allocStats_.t_addedFormat); }
+
+    void recordDeallocationsUniqueAggregated(std::size_t value) override { deallocStats_.uniqueAggregated = value; }
+    ScopedTimer timeDeallocationAggregation() override { return ScopedTimer(&deallocStats_.t_aggregation); }
+    ScopedTimer timeDeallocationsSorting() override { return ScopedTimer(&deallocStats_.t_sorting); }
+    ScopedTimer timeDeallocationsFormatting() override { return ScopedTimer(&deallocStats_.t_format); }
+
+    void recordChurnUniqueAggregated(std::size_t value) override { churnStats_.uniqueAggregated = value; }
+    void recordChurnMaxInnerSize(std::size_t value) override {
+      churnStats_.maxInnerSize = std::max(churnStats_.maxInnerSize, value);
+    }
+    ScopedTimer timeChurnAggregation() override { return ScopedTimer(&churnStats_.t_aggregation); }
+    ScopedTimer timeChurnSorting() override { return ScopedTimer(&churnStats_.t_sorting); }
+    ScopedTimer timeChurnFormatting() override { return ScopedTimer(&churnStats_.t_format); }
+
+    void printStatistics(edm::LogSystem& log, std::size_t numAllocTraces, std::size_t numDeallocTraces) const override {
+      log.format("\nStatistics:\nAllocations recorded {} in {}\nDeallocations recorded {} in {}\n",
+                 numAllocations_,
+                 allocationsTime_,
+                 numDeallocations_,
+                 deallocationsTime_);
+      log.format("Allocation traces total {} aggregated {}; aggregation {} sorting {} formatting {}\n",
+                 numAllocTraces,
+                 allocStats_.uniqueAggregated,
+                 allocStats_.t_aggregation,
+                 allocStats_.t_sorting,
+                 allocStats_.t_format);
+      log.format(
+          "AtMaxActual sorting {} formatting {}\n", allocStats_.t_atMaxActualSorting, allocStats_.t_atMaxActualFormat);
+      log.format("Added filtering {} formatting {}\n", allocStats_.t_addedFiltering, allocStats_.t_addedFormat);
+      log.format("Deallocation traces total {} aggregated {}; aggregation {} sorting {} formatting {}\n",
+                 numDeallocTraces,
+                 deallocStats_.uniqueAggregated,
+                 deallocStats_.t_aggregation,
+                 deallocStats_.t_sorting,
+                 deallocStats_.t_format);
+      log.format("Churn aggregated traces {} inner container max size {}; aggregation {} sorting {} formatting {}",
+                 churnStats_.uniqueAggregated,
+                 churnStats_.maxInnerSize,
+                 churnStats_.t_aggregation,
+                 churnStats_.t_sorting,
+                 churnStats_.t_format);
+    }
+
+  private:
+    struct AllocPrintStats {
+      std::chrono::duration<double, std::milli> t_aggregation{};
+      std::chrono::duration<double, std::milli> t_sorting{};
+      std::chrono::duration<double, std::milli> t_format{};
+      std::chrono::duration<double, std::milli> t_atMaxActualSorting{};
+      std::chrono::duration<double, std::milli> t_atMaxActualFormat{};
+      std::chrono::duration<double, std::milli> t_addedFiltering{};
+      std::chrono::duration<double, std::milli> t_addedFormat{};
+      std::size_t uniqueAggregated = 0;
+    };
+
+    struct DeallocPrintStats {
+      std::chrono::duration<double, std::milli> t_aggregation{};
+      std::chrono::duration<double, std::milli> t_sorting{};
+      std::chrono::duration<double, std::milli> t_format{};
+      std::size_t uniqueAggregated = 0;
+    };
+
+    struct ChurnPrintStats {
+      std::chrono::duration<double, std::milli> t_aggregation{};
+      std::chrono::duration<double, std::milli> t_sorting{};
+      std::chrono::duration<double, std::milli> t_format{};
+      std::size_t uniqueAggregated = 0;
+      std::size_t maxInnerSize = 0;
+    };
+
+    std::chrono::duration<double, std::milli> allocationsTime_{};
+    std::chrono::duration<double, std::milli> deallocationsTime_{};
+    std::size_t numAllocations_ = 0;
+    std::size_t numDeallocations_ = 0;
+    AllocPrintStats allocStats_;
+    DeallocPrintStats deallocStats_;
+    ChurnPrintStats churnStats_;
+  };
+
   class StackNodeData;
   using MonitorStackNode = cms::perftools::allocMon::MonitorStackNode<StackNodeData>;
 
   class StackNodeData {
   public:
     StackNodeData(std::stacktrace trace, unsigned int fileCount, std::string filePattern, bool printStatistics)
-        : trace_(std::move(trace)), filePattern_(std::move(filePattern)), printStatistics_(printStatistics) {
+        : trace_(std::move(trace)),
+          filePattern_(std::move(filePattern)),
+          statistics_(printStatistics ? static_cast<std::unique_ptr<StatisticsStrategy>>(
+                                            std::make_unique<CollectingStatisticsStrategy>())
+                                      : std::make_unique<NoOpStatisticsStrategy>()) {
       // Skip first entries that are internals for AllocMonitor if they are in the trace
       // By experience these entries are not always part of the stack trace
       auto it = trace_.cbegin();
@@ -93,7 +284,7 @@ namespace {
     std::stacktrace const& stacktrace() const { return trace_; }
 
     void recordAllocation(std::stacktrace trace, AllocationRecord record, void const* ptr) {
-      auto start = std::chrono::steady_clock::now();
+      auto timer = statistics_->recordAllocation();
 
       UniqueTraceIndex traceIndex;
       auto hash = std::hash<std::stacktrace>()(trace);
@@ -117,22 +308,16 @@ namespace {
         }
         maxActual_ = presentActual_;
       }
-
-      stats_.t_allocations_ += (std::chrono::steady_clock::now() - start);
-      stats_.num_allocations_ += 1;
     }
 
     void recordDeallocation(std::stacktrace trace,
                             DeallocationRecord record,
                             void const* ptr,
                             MonitorStackNode* prevNode) {
-      auto start = std::chrono::steady_clock::now();
+      auto timer = statistics_->recordDeallocation();
 
       auto const deallocIndex = addDeallocation(std::move(trace), record);
       subtractDeallocationFromAllocations(deallocIndex, ptr, prevNode);
-
-      stats_.t_deallocations_ += (std::chrono::steady_clock::now() - start);
-      stats_.num_deallocations_ += 1;
     }
 
     void recordDeallocationFromNestedMeasurement(void const* ptr, MonitorStackNode* prevNode) {
@@ -143,38 +328,11 @@ namespace {
     void print(T&& log, std::string_view measurementName) const {
       log.format(" Reported stack traces are based on\n{}", formatTrace(trace_, startFromEntry_, 0));
 
-      auto const allocStats = printAllocations(log, measurementName);
-      auto const deallocStats = printDeallocations(log, measurementName);
-      auto const churnStats = printChurn(log, measurementName);
+      printAllocations(log, measurementName);
+      printDeallocations(log, measurementName);
+      printChurn(log, measurementName);
 
-      if (printStatistics_) {
-        log.format("\nStatistics:\nAllocations recorded {} in {}\nDeallocations recorded {} in {}\n",
-                   stats_.num_allocations_,
-                   stats_.t_allocations_,
-                   stats_.num_deallocations_,
-                   stats_.t_deallocations_);
-        log.format("Allocation traces total {} aggregated {}; aggregation {} sorting {} formatting {}\n",
-                   uniqueAllocTraces_.size(),
-                   allocStats.uniqueAggregated,
-                   allocStats.t_aggregation,
-                   allocStats.t_sorting,
-                   allocStats.t_format);
-        log.format(
-            "AtMaxActual sorting {} formatting {}\n", allocStats.t_atMaxActualSorting, allocStats.t_atMaxActualFormat);
-        log.format("Added filtering {} formatting {}\n", allocStats.t_addedFiltering, allocStats.t_addedFormat);
-        log.format("Deallocation traces total {} aggregated {}; aggregation {} sorting {} formatting {}\n",
-                   uniqueDeallocTraces_.size(),
-                   deallocStats.uniqueAggregated,
-                   deallocStats.t_aggregation,
-                   deallocStats.t_sorting,
-                   deallocStats.t_format);
-        log.format("Churn aggregated traces {} inner container max size {}; aggregation {} sorting {} formatting {}",
-                   churnStats.uniqueAggregated,
-                   churnStats.maxInnerSize,
-                   churnStats.t_aggregation,
-                   churnStats.t_sorting,
-                   churnStats.t_format);
-      }
+      statistics_->printStatistics(log, uniqueAllocTraces_.size(), uniqueDeallocTraces_.size());
     }
 
   private:
@@ -223,224 +381,203 @@ namespace {
       AllocationRecord total_;
     };
 
-    struct AllocPrintStats {
-      std::chrono::duration<double, std::milli> t_aggregation{};
-      std::chrono::duration<double, std::milli> t_sorting{};
-      std::chrono::duration<double, std::milli> t_format{};
-      std::chrono::duration<double, std::milli> t_atMaxActualSorting{};
-      std::chrono::duration<double, std::milli> t_atMaxActualFormat{};
-      std::chrono::duration<double, std::milli> t_addedFiltering{};
-      std::chrono::duration<double, std::milli> t_addedFormat{};
-      std::size_t uniqueAggregated = 0;
-    };
-
-    struct DeallocPrintStats {
-      std::chrono::duration<double, std::milli> t_aggregation{};
-      std::chrono::duration<double, std::milli> t_sorting{};
-      std::chrono::duration<double, std::milli> t_format{};
-      std::size_t uniqueAggregated = 0;
-    };
-
-    struct ChurnPrintStats {
-      std::chrono::duration<double, std::milli> t_aggregation{};
-      std::chrono::duration<double, std::milli> t_sorting{};
-      std::chrono::duration<double, std::milli> t_format{};
-      std::size_t uniqueAggregated = 0;
-      std::size_t maxInnerSize = 0;
-    };
-
     template <typename T>
-    AllocPrintStats printAllocations(T&& log, std::string_view measurementName) const {
-      AllocPrintStats stats;
+    void printAllocations(T&& log, std::string_view measurementName) const {
       using AggregationMap = std::unordered_map<std::string, AllocationTrace::Records>;
 
-      auto start = std::chrono::steady_clock::now();
       AggregationMap aggregatedAllocs;
-      for (auto const& record : uniqueAllocTraces_) {
-        aggregatedAllocs[formatTrace(record.trace_, 0, stackDepth_ - 1)].add(record.records_);
-      }
-      stats.t_aggregation = (std::chrono::steady_clock::now() - start);
-      stats.uniqueAggregated = aggregatedAllocs.size();
-
-      start = std::chrono::steady_clock::now();
-      auto orderAllocs =
-          makeSortedIterators(aggregatedAllocs, [](auto const& it) { return it->second.total_.actual_; });
-      stats.t_sorting = (std::chrono::steady_clock::now() - start);
-
-      start = std::chrono::steady_clock::now();
-      log.format("\nAll allocations");
-      writeFileOrMessage("alloc", measurementName, log, [&](std::ostream& os) {
-        for (auto const& itTrace : orderAllocs) {
-          auto const& records = itTrace->second;
-          std::print(os,
-                     "count {} requested {} actual {}\n{}",
-                     records.total_.count_,
-                     records.total_.requested_,
-                     records.total_.actual_,
-                     itTrace->first);
+      {
+        auto timer = statistics_->timeAllocationsAggregation();
+        for (auto const& record : uniqueAllocTraces_) {
+          aggregatedAllocs[formatTrace(record.trace_, 0, stackDepth_ - 1)].add(record.records_);
         }
-      });
-      stats.t_format = (std::chrono::steady_clock::now() - start);
+        statistics_->recordAllocationsUniqueAggregated(aggregatedAllocs.size());
+      }
+
+      std::vector<std::unordered_map<std::string, AllocationTrace::Records>::const_iterator> orderAllocs;
+      {
+        auto timer = statistics_->timeAllocationsSorting();
+        orderAllocs = makeSortedIterators(aggregatedAllocs, [](auto const& it) { return it->second.total_.actual_; });
+      }
+
+      {
+        auto timer = statistics_->timeAllocationsFormatting();
+        log.format("\nAll allocations");
+        writeFileOrMessage("alloc", measurementName, log, [&](std::ostream& os) {
+          for (auto const& itTrace : orderAllocs) {
+            auto const& records = itTrace->second;
+            std::print(os,
+                       "count {} requested {} actual {}\n{}",
+                       records.total_.count_,
+                       records.total_.requested_,
+                       records.total_.actual_,
+                       itTrace->first);
+          }
+        });
+      }
 
       // AtMaxActual
-      start = std::chrono::steady_clock::now();
-      std::ranges::sort(orderAllocs, std::greater{}, [](auto const& it) { return it->second.atMaxActual_.actual_; });
-      stats.t_atMaxActualSorting = (std::chrono::steady_clock::now() - start);
+      {
+        auto timer = statistics_->timeAllocationsAtMaxActualSorting();
+        std::ranges::sort(orderAllocs, std::greater{}, [](auto const& it) { return it->second.atMaxActual_.actual_; });
+      }
 
-      start = std::chrono::steady_clock::now();
-      log.format("\nAllocated memory at the max actual moment");
-      writeFileOrMessage("atMaxActual", measurementName, log, [&](std::ostream& os) {
-        for (auto const& itTrace : orderAllocs) {
-          auto const& records = itTrace->second;
-          std::print(os,
-                     "count {} requested {} actual {}\n{}",
-                     records.atMaxActual_.count_,
-                     records.atMaxActual_.requested_,
-                     records.atMaxActual_.actual_,
-                     itTrace->first);
-        }
-      });
-      stats.t_atMaxActualFormat = (std::chrono::steady_clock::now() - start);
+      {
+        auto timer = statistics_->timeAllocationsAtMaxActualFormatting();
+        log.format("\nAllocated memory at the max actual moment");
+        writeFileOrMessage("atMaxActual", measurementName, log, [&](std::ostream& os) {
+          for (auto const& itTrace : orderAllocs) {
+            auto const& records = itTrace->second;
+            std::print(os,
+                       "count {} requested {} actual {}\n{}",
+                       records.atMaxActual_.count_,
+                       records.atMaxActual_.requested_,
+                       records.atMaxActual_.actual_,
+                       itTrace->first);
+          }
+        });
+      }
 
       // Added
-      start = std::chrono::steady_clock::now();
-      std::erase_if(orderAllocs, [](auto const& it) { return it->second.added_.count_ == 0; });
-      std::ranges::sort(orderAllocs, std::greater{}, [](auto const& it) { return it->second.added_.actual_; });
-      stats.t_addedFiltering = (std::chrono::steady_clock::now() - start);
+      {
+        auto timer = statistics_->timeAllocationsAddedFiltering();
+        std::erase_if(orderAllocs, [](auto const& it) { return it->second.added_.count_ == 0; });
+        std::ranges::sort(orderAllocs, std::greater{}, [](auto const& it) { return it->second.added_.actual_; });
+      }
 
-      start = std::chrono::steady_clock::now();
-      log.format("\nAdded memory");
-      writeFileOrMessage("added", measurementName, log, [&](std::ostream& os) {
-        for (auto const& itTrace : orderAllocs) {
-          auto const& records = itTrace->second;
-          std::print(os,
-                     "count {} requested {} actual {}\n{}",
-                     records.added_.count_,
-                     records.added_.requested_,
-                     records.added_.actual_,
-                     itTrace->first);
-          // The keys of aggregatedAllocs are large, so destruct them as soon as possible. The erase() does not invalidate
-          // the iterators to other elements, so it's safe to erase while iterating through orderAllocs.
-          aggregatedAllocs.erase(itTrace);
-        }
-      });
-      stats.t_addedFormat = (std::chrono::steady_clock::now() - start);
-
-      return stats;
+      {
+        auto timer = statistics_->timeAllocationsAddedFormatting();
+        log.format("\nAdded memory");
+        writeFileOrMessage("added", measurementName, log, [&](std::ostream& os) {
+          for (auto const& itTrace : orderAllocs) {
+            auto const& records = itTrace->second;
+            std::print(os,
+                       "count {} requested {} actual {}\n{}",
+                       records.added_.count_,
+                       records.added_.requested_,
+                       records.added_.actual_,
+                       itTrace->first);
+            // The keys of aggregatedAllocs are large, so destruct them as soon as possible. The erase() does not invalidate
+            // the iterators to other elements, so it's safe to erase while iterating through orderAllocs.
+            aggregatedAllocs.erase(itTrace);
+          }
+        });
+      }
     }
 
     template <typename T>
-    DeallocPrintStats printDeallocations(T&& log, std::string_view measurementName) const {
-      DeallocPrintStats stats;
+    void printDeallocations(T&& log, std::string_view measurementName) const {
       using AggregationMap = std::unordered_map<std::string, DeallocationRecord>;
       AggregationMap aggregatedDeallocs;
 
-      auto start = std::chrono::steady_clock::now();
-      for (auto const& record : uniqueDeallocTraces_) {
-        aggregatedDeallocs[formatTrace(record.trace_, 0, stackDepth_ - 1)].add(record.total_);
-      }
-      stats.t_aggregation = (std::chrono::steady_clock::now() - start);
-      stats.uniqueAggregated = aggregatedDeallocs.size();
-
-      start = std::chrono::steady_clock::now();
-      auto orderDeallocs = makeSortedIterators(aggregatedDeallocs, [](auto const& it) { return it->second.actual_; });
-      stats.t_sorting = (std::chrono::steady_clock::now() - start);
-
-      start = std::chrono::steady_clock::now();
-      log.format("\nAll deallocations");
-      writeFileOrMessage("dealloc", measurementName, log, [&](std::ostream& os) {
-        for (auto const& itTrace : orderDeallocs) {
-          auto const& record = itTrace->second;
-          std::print(os, "count {} actual {}\n{}", record.count_, record.actual_, itTrace->first);
-          aggregatedDeallocs.erase(itTrace);
+      {
+        auto timer = statistics_->timeDeallocationAggregation();
+        for (auto const& record : uniqueDeallocTraces_) {
+          aggregatedDeallocs[formatTrace(record.trace_, 0, stackDepth_ - 1)].add(record.total_);
         }
-      });
-      stats.t_format = (std::chrono::steady_clock::now() - start);
+        statistics_->recordDeallocationsUniqueAggregated(aggregatedDeallocs.size());
+      }
 
-      return stats;
+      std::vector<std::unordered_map<std::string, DeallocationRecord>::const_iterator> orderDeallocs;
+      {
+        auto timer = statistics_->timeDeallocationsSorting();
+        orderDeallocs = makeSortedIterators(aggregatedDeallocs, [](auto const& it) { return it->second.actual_; });
+      }
+
+      {
+        auto timer = statistics_->timeDeallocationsFormatting();
+        log.format("\nAll deallocations");
+        writeFileOrMessage("dealloc", measurementName, log, [&](std::ostream& os) {
+          for (auto const& itTrace : orderDeallocs) {
+            auto const& record = itTrace->second;
+            std::print(os, "count {} actual {}\n{}", record.count_, record.actual_, itTrace->first);
+            aggregatedDeallocs.erase(itTrace);
+          }
+        });
+      }
     }
 
     template <typename T>
-    ChurnPrintStats printChurn(T&& log, std::string_view measurementName) const {
-      ChurnPrintStats stats;
+    void printChurn(T&& log, std::string_view measurementName) const {
       using AggregationMap = std::unordered_map<std::string, AllocationRecord>;
       AggregationMap aggregatedChurn;
       AggregationMap aggregatedChurnAllocs;
 
-      auto start = std::chrono::steady_clock::now();
-      auto traceToString = [](auto const& traceEntry) { return traceEntry.description(); };
-      // zip stops at the shorter range, naturally handling churnRecords_ being possibly smaller than uniqueAllocTraces_
-      for (auto const& [allocRecord, churnVec] : std::views::zip(uniqueAllocTraces_, churnRecords_)) {
-        auto const& allocTrace = allocRecord.trace_;
-        // can skip the topmost stackDepth entries because they are the same throughout the measurement
-        // subtract 1 in case the measurement starting function is doing the churn
-        auto const allocTraceStrings = allocTrace | std::views::take(allocTrace.size() - (stackDepth_ - 1)) |
-                                       std::views::transform(traceToString) |
-                                       std::ranges::to<std::vector<std::string>>();
+      {
+        auto timer = statistics_->timeChurnAggregation();
+        auto traceToString = [](auto const& traceEntry) { return traceEntry.description(); };
+        // zip stops at the shorter range, naturally handling churnRecords_ being possibly smaller than uniqueAllocTraces_
+        for (auto const& [allocRecord, churnVec] : std::views::zip(uniqueAllocTraces_, churnRecords_)) {
+          auto const& allocTrace = allocRecord.trace_;
+          // can skip the topmost stackDepth entries because they are the same throughout the measurement
+          // subtract 1 in case the measurement starting function is doing the churn
+          auto const allocTraceStrings = allocTrace | std::views::take(allocTrace.size() - (stackDepth_ - 1)) |
+                                         std::views::transform(traceToString) |
+                                         std::ranges::to<std::vector<std::string>>();
 
-        stats.maxInnerSize = std::max(stats.maxInnerSize, churnVec.size());
-        for (auto const& record : churnVec) {
-          // Stopping to the lowest common stacktrace_entry between allocation and deallocation
-          {
-            auto const& deallocTrace = uniqueDeallocTraces_[record.deallocIndex_].trace_;
-            auto const deallocTraceStrings = deallocTrace | std::views::take(deallocTrace.size() - (stackDepth_ - 1)) |
-                                             std::views::transform(traceToString) |
-                                             std::ranges::to<std::vector<std::string>>();
+          statistics_->recordChurnMaxInnerSize(churnVec.size());
+          for (auto const& record : churnVec) {
+            // Stopping to the lowest common stacktrace_entry between allocation and deallocation
+            {
+              auto const& deallocTrace = uniqueDeallocTraces_[record.deallocIndex_].trace_;
+              auto const deallocTraceStrings =
+                  deallocTrace | std::views::take(deallocTrace.size() - (stackDepth_ - 1)) |
+                  std::views::transform(traceToString) | std::ranges::to<std::vector<std::string>>();
 
-            // iterate from the top (outermost) downward to find where the traces first diverge
-            auto allocEntries = allocTraceStrings | std::views::reverse;
-            auto deallocEntries = deallocTraceStrings | std::views::reverse;
+              // iterate from the top (outermost) downward to find where the traces first diverge
+              auto allocEntries = allocTraceStrings | std::views::reverse;
+              auto deallocEntries = deallocTraceStrings | std::views::reverse;
 
-            auto [it_alloc, it_dealloc] = std::ranges::mismatch(allocEntries, deallocEntries);
-            assert(it_alloc != allocEntries.end() and it_dealloc != deallocEntries.end());
+              auto [it_alloc, it_dealloc] = std::ranges::mismatch(allocEntries, deallocEntries);
+              assert(it_alloc != allocEntries.end() and it_dealloc != deallocEntries.end());
 
-            // Because the comparisons were done with strings, the
-            // it_alloc and it_dealloc should point to different
-            // functions. Go one level up (toward outer frames) to find the common function
-            assert(it_alloc != allocEntries.begin());
-            --it_alloc;
+              // Because the comparisons were done with strings, the
+              // it_alloc and it_dealloc should point to different
+              // functions. Go one level up (toward outer frames) to find the common function
+              assert(it_alloc != allocEntries.begin());
+              --it_alloc;
 
-            auto str_trace = formatTrace(std::ranges::subrange(std::prev(it_alloc.base()), allocTraceStrings.end()));
-            aggregatedChurn[str_trace].add(record.total_);
-          }
-          // Churn allocation stack traces
-          {
-            auto str_trace = formatTrace(allocTraceStrings);
-            aggregatedChurnAllocs[str_trace].add(record.total_);
+              auto str_trace = formatTrace(std::ranges::subrange(std::prev(it_alloc.base()), allocTraceStrings.end()));
+              aggregatedChurn[str_trace].add(record.total_);
+            }
+            // Churn allocation stack traces
+            {
+              auto str_trace = formatTrace(allocTraceStrings);
+              aggregatedChurnAllocs[str_trace].add(record.total_);
+            }
           }
         }
+        statistics_->recordChurnUniqueAggregated(aggregatedChurn.size());
       }
-      stats.t_aggregation = (std::chrono::steady_clock::now() - start);
-      stats.uniqueAggregated = aggregatedChurn.size();
 
-      start = std::chrono::steady_clock::now();
-      auto orderChurn = makeSortedIterators(aggregatedChurn, [](auto const& it) { return it->second.count_; });
-      auto orderChurnAllocs =
-          makeSortedIterators(aggregatedChurnAllocs, [](auto const& it) { return it->second.count_; });
-      stats.t_sorting = (std::chrono::steady_clock::now() - start);
+      std::vector<std::unordered_map<std::string, AllocationRecord>::const_iterator> orderChurn, orderChurnAllocs;
+      {
+        auto timer = statistics_->timeChurnSorting();
+        orderChurn = makeSortedIterators(aggregatedChurn, [](auto const& it) { return it->second.count_; });
+        orderChurnAllocs = makeSortedIterators(aggregatedChurnAllocs, [](auto const& it) { return it->second.count_; });
+      }
 
-      start = std::chrono::steady_clock::now();
-      log.format("\nMemory allocation+deallocation churn");
-      writeFileOrMessage("churn", measurementName, log, [&](std::ostream& os) {
-        for (auto const& it : orderChurn) {
-          auto const& record = it->second;
-          std::print(
-              os, "count {} requested {} actual {}\n{}", record.count_, record.requested_, record.actual_, it->first);
-          aggregatedChurn.erase(it);
-        }
-      });
-      log.format("\nMemory allocation+deallocation churn allocations");
-      writeFileOrMessage("churnalloc", measurementName, log, [&](std::ostream& os) {
-        for (auto const& it : orderChurnAllocs) {
-          auto const& record = it->second;
-          std::print(
-              os, "count {} requested {} actual {}\n{}", record.count_, record.requested_, record.actual_, it->first);
-          aggregatedChurnAllocs.erase(it);
-        }
-      });
-      stats.t_format = (std::chrono::steady_clock::now() - start);
-
-      return stats;
+      {
+        auto timer = statistics_->timeChurnFormatting();
+        log.format("\nMemory allocation+deallocation churn");
+        writeFileOrMessage("churn", measurementName, log, [&](std::ostream& os) {
+          for (auto const& it : orderChurn) {
+            auto const& record = it->second;
+            std::print(
+                os, "count {} requested {} actual {}\n{}", record.count_, record.requested_, record.actual_, it->first);
+            aggregatedChurn.erase(it);
+          }
+        });
+        log.format("\nMemory allocation+deallocation churn allocations");
+        writeFileOrMessage("churnalloc", measurementName, log, [&](std::ostream& os) {
+          for (auto const& it : orderChurnAllocs) {
+            auto const& record = it->second;
+            std::print(
+                os, "count {} requested {} actual {}\n{}", record.count_, record.requested_, record.actual_, it->first);
+            aggregatedChurnAllocs.erase(it);
+          }
+        });
+      }
     }
 
     void subtractDeallocationFromAllocations(std::optional<UniqueTraceIndex> deallocIndex,
@@ -558,7 +695,7 @@ namespace {
     int startFromEntry_ = 0;
     std::size_t stackDepth_ = 0;
     std::string filePattern_;
-    bool printStatistics_;
+    std::unique_ptr<StatisticsStrategy> statistics_;
 
     // Collection of stack traces
     long long presentActual_ = 0;
@@ -574,14 +711,6 @@ namespace {
     // allocating trace would be small enough that a linear search is
     // good enough
     std::vector<std::vector<ChurnRecord>> churnRecords_;
-
-    struct Statistics {
-      std::chrono::duration<double, std::milli> t_allocations_{};
-      std::chrono::duration<double, std::milli> t_deallocations_{};
-      std::size_t num_allocations_ = 0;
-      std::size_t num_deallocations_ = 0;
-    };
-    Statistics stats_;
   };
   std::unique_ptr<MonitorStackNode>& currentMonitorStackNode() {
     static thread_local std::unique_ptr<MonitorStackNode> ptr;

--- a/PerfTools/AllocMonitor/plugins/IntrusiveAllocProfiler.cc
+++ b/PerfTools/AllocMonitor/plugins/IntrusiveAllocProfiler.cc
@@ -1,0 +1,705 @@
+#include <version>
+#if (__cpp_lib_stacktrace >= 202011L) && (__cpp_lib_formatters >= 202302L) && \
+    (__cpp_lib_ranges_enumerate >= 202302L) && (__cpp_lib_print >= 202207L)
+
+#include "FWCore/AbstractServices/interface/IntrusiveMonitorBase.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
+
+#include "PerfTools/AllocMonitor/interface/AllocMonitorBase.h"
+#include "PerfTools/AllocMonitor/interface/AllocMonitorRegistry.h"
+
+#include "MonitorStackNode.h"
+#include "ThreadTracker.h"
+
+#include <boost/algorithm/string.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <fstream>
+#include <ostream>
+#include <print>
+#include <ranges>
+#include <stacktrace>
+#include <unordered_map>
+
+namespace {
+  struct AllocationRecord {
+    void add(AllocationRecord const& o) {
+      requested_ += o.requested_;
+      actual_ += o.actual_;
+      count_ += o.count_;
+    }
+    void subtract(AllocationRecord const& o) {
+      requested_ -= o.requested_;
+      actual_ -= o.actual_;
+      count_ -= o.count_;
+    }
+
+    std::size_t requested_ = 0;
+    std::size_t actual_ = 0;
+    std::size_t count_ = 0;
+  };
+  struct DeallocationRecord {
+    void add(DeallocationRecord const& o) {
+      actual_ += o.actual_;
+      count_ += o.count_;
+    }
+    void subtract(DeallocationRecord const& o) {
+      actual_ -= o.actual_;
+      count_ -= o.count_;
+    }
+
+    std::size_t actual_ = 0;
+    std::size_t count_ = 0;
+  };
+
+  class StackNodeData;
+  using MonitorStackNode = cms::perftools::allocMon::MonitorStackNode<StackNodeData>;
+
+  class StackNodeData {
+  public:
+    StackNodeData(std::stacktrace trace, unsigned int fileCount, std::string filePattern, bool printStatistics)
+        : trace_(std::move(trace)), filePattern_(std::move(filePattern)), printStatistics_(printStatistics) {
+      // Skip first entries that are internals for AllocMonitor if they are in the trace
+      // By experience these entries are not always part of the stack trace
+      auto it = trace_.cbegin();
+      // The startOnThread() is a member of MonitorAdaptor, but with
+      // debug synbols the MonitorAdaptor does not seem to be part of
+      // the symbol name
+      if (it->description().contains("startOnThread")) {
+        ++it;
+        ++startFromEntry_;
+      }
+      if (it->description().contains("IntrusiveAllocProfiler::start")) {
+        ++it;
+        ++startFromEntry_;
+      }
+      if (it->description().contains("edm::IntrusiveMonitorBase::startMonitoring")) {
+        ++it;
+        ++startFromEntry_;
+      }
+      assert(it != trace.cend());
+      stackDepth_ = std::distance(it, trace_.cend());
+
+      if (not filePattern_.empty()) {
+        boost::replace_all(filePattern_, "%I", std::to_string(fileCount));
+      }
+    }
+
+    std::size_t stackDepth() const { return stackDepth_; }
+
+    std::stacktrace const& stacktrace() const { return trace_; }
+
+    void recordAllocation(std::stacktrace trace, AllocationRecord record, void const* ptr) {
+      auto start = std::chrono::steady_clock::now();
+
+      UniqueTraceIndex traceIndex;
+      auto hash = std::hash<std::stacktrace>()(trace);
+      auto found = hashToAllocTraceIndex_.find(hash);
+      if (found != hashToAllocTraceIndex_.end()) {
+        traceIndex = found->second;
+        assert(trace == uniqueAllocTraces_[traceIndex].trace_);
+        uniqueAllocTraces_[traceIndex].recordAllocation(record);
+      } else {
+        // intentionally narrowing
+        traceIndex = static_cast<UniqueTraceIndex>(uniqueAllocTraces_.size());
+        uniqueAllocTraces_.emplace_back(record, std::move(trace));
+        hashToAllocTraceIndex_.emplace(hash, traceIndex);
+      }
+      addressToAllocation_.emplace(ptr, std::tuple{record, traceIndex});
+
+      presentActual_ += record.actual_;
+      if (presentActual_ > maxActual_) {
+        for (auto& trace : uniqueAllocTraces_) {
+          trace.setAtMaxActual();
+        }
+        maxActual_ = presentActual_;
+      }
+
+      stats_.t_allocations_ += (std::chrono::steady_clock::now() - start);
+      stats_.num_allocations_ += 1;
+    }
+
+    void recordDeallocation(std::stacktrace trace,
+                            DeallocationRecord record,
+                            void const* ptr,
+                            MonitorStackNode* prevNode) {
+      auto start = std::chrono::steady_clock::now();
+
+      auto const deallocIndex = addDeallocation(std::move(trace), record);
+      subtractDeallocationFromAllocations(deallocIndex, ptr, prevNode);
+
+      stats_.t_deallocations_ += (std::chrono::steady_clock::now() - start);
+      stats_.num_deallocations_ += 1;
+    }
+
+    void recordDeallocationFromNestedMeasurement(void const* ptr, MonitorStackNode* prevNode) {
+      subtractDeallocationFromAllocations({}, ptr, prevNode);
+    }
+
+    template <typename T>
+    void print(T&& log, std::string_view measurementName) const {
+      log.format(" Reported stack traces are based on\n{}", formatTrace(trace_, startFromEntry_, 0));
+
+      auto const allocStats = printAllocations(log, measurementName);
+      auto const deallocStats = printDeallocations(log, measurementName);
+      auto const churnStats = printChurn(log, measurementName);
+
+      if (printStatistics_) {
+        log.format("\nStatistics:\nAllocations recorded {} in {}\nDeallocations recorded {} in {}\n",
+                   stats_.num_allocations_,
+                   stats_.t_allocations_,
+                   stats_.num_deallocations_,
+                   stats_.t_deallocations_);
+        log.format("Allocation traces total {} aggregated {}; aggregation {} sorting {} formatting {}\n",
+                   uniqueAllocTraces_.size(),
+                   allocStats.uniqueAggregated,
+                   allocStats.t_aggregation,
+                   allocStats.t_sorting,
+                   allocStats.t_format);
+        log.format(
+            "AtMaxActual sorting {} formatting {}\n", allocStats.t_atMaxActualSorting, allocStats.t_atMaxActualFormat);
+        log.format("Added filtering {} formatting {}\n", allocStats.t_addedFiltering, allocStats.t_addedFormat);
+        log.format("Deallocation traces total {} aggregated {}; aggregation {} sorting {} formatting {}\n",
+                   uniqueDeallocTraces_.size(),
+                   deallocStats.uniqueAggregated,
+                   deallocStats.t_aggregation,
+                   deallocStats.t_sorting,
+                   deallocStats.t_format);
+        log.format("Churn aggregated traces {} inner container max size {}; aggregation {} sorting {} formatting {}",
+                   churnStats.uniqueAggregated,
+                   churnStats.maxInnerSize,
+                   churnStats.t_aggregation,
+                   churnStats.t_sorting,
+                   churnStats.t_format);
+      }
+    }
+
+  private:
+    // If we get more than 2^32 different stack traces, we'll have other problems
+    using UniqueTraceIndex = unsigned int;
+    using TraceHashValue = std::size_t;
+
+    struct AllocationTrace {
+      AllocationTrace(AllocationRecord const& o, std::stacktrace trace)
+          : records_{.total_ = o, .added_ = o, .atMaxActual_ = {}}, trace_(trace) {}
+
+      void recordAllocation(AllocationRecord const& o) {
+        records_.total_.add(o);
+        records_.added_.add(o);
+      }
+      void recordDeallocation(AllocationRecord const& o) { records_.added_.subtract(o); }
+
+      void setAtMaxActual() { records_.atMaxActual_ = records_.added_; }
+
+      struct Records {
+        void add(Records const& o) {
+          total_.add(o.total_);
+          added_.add(o.added_);
+          atMaxActual_.add(o.atMaxActual_);
+        }
+        AllocationRecord total_;
+        AllocationRecord added_;
+        AllocationRecord atMaxActual_;
+      };
+      Records records_;
+
+      std::stacktrace trace_;
+    };
+
+    struct DeallocationTrace {
+      DeallocationTrace(DeallocationRecord const& o, std::stacktrace trace) : total_(o), trace_(trace) {}
+
+      void recordDeallocation(DeallocationRecord const& o) { total_.add(o); }
+
+      DeallocationRecord total_;
+      std::stacktrace trace_;
+    };
+
+    struct ChurnRecord {
+      UniqueTraceIndex deallocIndex_;
+      AllocationRecord total_;
+    };
+
+    struct AllocPrintStats {
+      std::chrono::duration<double, std::milli> t_aggregation{};
+      std::chrono::duration<double, std::milli> t_sorting{};
+      std::chrono::duration<double, std::milli> t_format{};
+      std::chrono::duration<double, std::milli> t_atMaxActualSorting{};
+      std::chrono::duration<double, std::milli> t_atMaxActualFormat{};
+      std::chrono::duration<double, std::milli> t_addedFiltering{};
+      std::chrono::duration<double, std::milli> t_addedFormat{};
+      std::size_t uniqueAggregated = 0;
+    };
+
+    struct DeallocPrintStats {
+      std::chrono::duration<double, std::milli> t_aggregation{};
+      std::chrono::duration<double, std::milli> t_sorting{};
+      std::chrono::duration<double, std::milli> t_format{};
+      std::size_t uniqueAggregated = 0;
+    };
+
+    struct ChurnPrintStats {
+      std::chrono::duration<double, std::milli> t_aggregation{};
+      std::chrono::duration<double, std::milli> t_sorting{};
+      std::chrono::duration<double, std::milli> t_format{};
+      std::size_t uniqueAggregated = 0;
+      std::size_t maxInnerSize = 0;
+    };
+
+    template <typename T>
+    AllocPrintStats printAllocations(T&& log, std::string_view measurementName) const {
+      AllocPrintStats stats;
+      using AggregationMap = std::unordered_map<std::string, AllocationTrace::Records>;
+
+      auto start = std::chrono::steady_clock::now();
+      AggregationMap aggregatedAllocs;
+      for (auto const& record : uniqueAllocTraces_) {
+        aggregatedAllocs[formatTrace(record.trace_, 0, stackDepth_ - 1)].add(record.records_);
+      }
+      stats.t_aggregation = (std::chrono::steady_clock::now() - start);
+      stats.uniqueAggregated = aggregatedAllocs.size();
+
+      start = std::chrono::steady_clock::now();
+      auto orderAllocs =
+          makeSortedIterators(aggregatedAllocs, [](auto const& it) { return it->second.total_.actual_; });
+      stats.t_sorting = (std::chrono::steady_clock::now() - start);
+
+      start = std::chrono::steady_clock::now();
+      log.format("\nAll allocations");
+      writeFileOrMessage("alloc", measurementName, log, [&](std::ostream& os) {
+        for (auto const& itTrace : orderAllocs) {
+          auto const& records = itTrace->second;
+          std::print(os,
+                     "count {} requested {} actual {}\n{}",
+                     records.total_.count_,
+                     records.total_.requested_,
+                     records.total_.actual_,
+                     itTrace->first);
+        }
+      });
+      stats.t_format = (std::chrono::steady_clock::now() - start);
+
+      // AtMaxActual
+      start = std::chrono::steady_clock::now();
+      std::ranges::sort(orderAllocs, std::greater{}, [](auto const& it) { return it->second.atMaxActual_.actual_; });
+      stats.t_atMaxActualSorting = (std::chrono::steady_clock::now() - start);
+
+      start = std::chrono::steady_clock::now();
+      log.format("\nAllocated memory at the max actual moment");
+      writeFileOrMessage("atMaxActual", measurementName, log, [&](std::ostream& os) {
+        for (auto const& itTrace : orderAllocs) {
+          auto const& records = itTrace->second;
+          std::print(os,
+                     "count {} requested {} actual {}\n{}",
+                     records.atMaxActual_.count_,
+                     records.atMaxActual_.requested_,
+                     records.atMaxActual_.actual_,
+                     itTrace->first);
+        }
+      });
+      stats.t_atMaxActualFormat = (std::chrono::steady_clock::now() - start);
+
+      // Added
+      start = std::chrono::steady_clock::now();
+      std::erase_if(orderAllocs, [](auto const& it) { return it->second.added_.count_ == 0; });
+      std::ranges::sort(orderAllocs, std::greater{}, [](auto const& it) { return it->second.added_.actual_; });
+      stats.t_addedFiltering = (std::chrono::steady_clock::now() - start);
+
+      start = std::chrono::steady_clock::now();
+      log.format("\nAdded memory");
+      writeFileOrMessage("added", measurementName, log, [&](std::ostream& os) {
+        for (auto const& itTrace : orderAllocs) {
+          auto const& records = itTrace->second;
+          std::print(os,
+                     "count {} requested {} actual {}\n{}",
+                     records.added_.count_,
+                     records.added_.requested_,
+                     records.added_.actual_,
+                     itTrace->first);
+          // The keys of aggregatedAllocs are large, so destruct them as soon as possible. The erase() does not invalidate
+          // the iterators to other elements, so it's safe to erase while iterating through orderAllocs.
+          aggregatedAllocs.erase(itTrace);
+        }
+      });
+      stats.t_addedFormat = (std::chrono::steady_clock::now() - start);
+
+      return stats;
+    }
+
+    template <typename T>
+    DeallocPrintStats printDeallocations(T&& log, std::string_view measurementName) const {
+      DeallocPrintStats stats;
+      using AggregationMap = std::unordered_map<std::string, DeallocationRecord>;
+      AggregationMap aggregatedDeallocs;
+
+      auto start = std::chrono::steady_clock::now();
+      for (auto const& record : uniqueDeallocTraces_) {
+        aggregatedDeallocs[formatTrace(record.trace_, 0, stackDepth_ - 1)].add(record.total_);
+      }
+      stats.t_aggregation = (std::chrono::steady_clock::now() - start);
+      stats.uniqueAggregated = aggregatedDeallocs.size();
+
+      start = std::chrono::steady_clock::now();
+      auto orderDeallocs = makeSortedIterators(aggregatedDeallocs, [](auto const& it) { return it->second.actual_; });
+      stats.t_sorting = (std::chrono::steady_clock::now() - start);
+
+      start = std::chrono::steady_clock::now();
+      log.format("\nAll deallocations");
+      writeFileOrMessage("dealloc", measurementName, log, [&](std::ostream& os) {
+        for (auto const& itTrace : orderDeallocs) {
+          auto const& record = itTrace->second;
+          std::print(os, "count {} actual {}\n{}", record.count_, record.actual_, itTrace->first);
+          aggregatedDeallocs.erase(itTrace);
+        }
+      });
+      stats.t_format = (std::chrono::steady_clock::now() - start);
+
+      return stats;
+    }
+
+    template <typename T>
+    ChurnPrintStats printChurn(T&& log, std::string_view measurementName) const {
+      ChurnPrintStats stats;
+      using AggregationMap = std::unordered_map<std::string, AllocationRecord>;
+      AggregationMap aggregatedChurn;
+      AggregationMap aggregatedChurnAllocs;
+
+      auto start = std::chrono::steady_clock::now();
+      auto traceToString = [](auto const& traceEntry) { return traceEntry.description(); };
+      // zip stops at the shorter range, naturally handling churnRecords_ being possibly smaller than uniqueAllocTraces_
+      for (auto const& [allocRecord, churnVec] : std::views::zip(uniqueAllocTraces_, churnRecords_)) {
+        auto const& allocTrace = allocRecord.trace_;
+        // can skip the topmost stackDepth entries because they are the same throughout the measurement
+        // subtract 1 in case the measurement starting function is doing the churn
+        auto const allocTraceStrings = allocTrace | std::views::take(allocTrace.size() - (stackDepth_ - 1)) |
+                                       std::views::transform(traceToString) |
+                                       std::ranges::to<std::vector<std::string>>();
+
+        stats.maxInnerSize = std::max(stats.maxInnerSize, churnVec.size());
+        for (auto const& record : churnVec) {
+          // Stopping to the lowest common stacktrace_entry between allocation and deallocation
+          {
+            auto const& deallocTrace = uniqueDeallocTraces_[record.deallocIndex_].trace_;
+            auto const deallocTraceStrings = deallocTrace | std::views::take(deallocTrace.size() - (stackDepth_ - 1)) |
+                                             std::views::transform(traceToString) |
+                                             std::ranges::to<std::vector<std::string>>();
+
+            // iterate from the top (outermost) downward to find where the traces first diverge
+            auto allocEntries = allocTraceStrings | std::views::reverse;
+            auto deallocEntries = deallocTraceStrings | std::views::reverse;
+
+            auto [it_alloc, it_dealloc] = std::ranges::mismatch(allocEntries, deallocEntries);
+            assert(it_alloc != allocEntries.end() and it_dealloc != deallocEntries.end());
+
+            // Because the comparisons were done with strings, the
+            // it_alloc and it_dealloc should point to different
+            // functions. Go one level up (toward outer frames) to find the common function
+            assert(it_alloc != allocEntries.begin());
+            --it_alloc;
+
+            auto str_trace = formatTrace(std::ranges::subrange(std::prev(it_alloc.base()), allocTraceStrings.end()));
+            aggregatedChurn[str_trace].add(record.total_);
+          }
+          // Churn allocation stack traces
+          {
+            auto str_trace = formatTrace(allocTraceStrings);
+            aggregatedChurnAllocs[str_trace].add(record.total_);
+          }
+        }
+      }
+      stats.t_aggregation = (std::chrono::steady_clock::now() - start);
+      stats.uniqueAggregated = aggregatedChurn.size();
+
+      start = std::chrono::steady_clock::now();
+      auto orderChurn = makeSortedIterators(aggregatedChurn, [](auto const& it) { return it->second.count_; });
+      auto orderChurnAllocs =
+          makeSortedIterators(aggregatedChurnAllocs, [](auto const& it) { return it->second.count_; });
+      stats.t_sorting = (std::chrono::steady_clock::now() - start);
+
+      start = std::chrono::steady_clock::now();
+      log.format("\nMemory allocation+deallocation churn");
+      writeFileOrMessage("churn", measurementName, log, [&](std::ostream& os) {
+        for (auto const& it : orderChurn) {
+          auto const& record = it->second;
+          std::print(
+              os, "count {} requested {} actual {}\n{}", record.count_, record.requested_, record.actual_, it->first);
+          aggregatedChurn.erase(it);
+        }
+      });
+      log.format("\nMemory allocation+deallocation churn allocations");
+      writeFileOrMessage("churnalloc", measurementName, log, [&](std::ostream& os) {
+        for (auto const& it : orderChurnAllocs) {
+          auto const& record = it->second;
+          std::print(
+              os, "count {} requested {} actual {}\n{}", record.count_, record.requested_, record.actual_, it->first);
+          aggregatedChurnAllocs.erase(it);
+        }
+      });
+      stats.t_format = (std::chrono::steady_clock::now() - start);
+
+      return stats;
+    }
+
+    void subtractDeallocationFromAllocations(std::optional<UniqueTraceIndex> deallocIndex,
+                                             void const* ptr,
+                                             MonitorStackNode* prevNode) {
+      auto found = addressToAllocation_.find(ptr);
+      if (found == addressToAllocation_.end()) {
+        // The memory was allocated before the measurement region
+        // If there is an earlier node in the stack, try to subtract it from there
+        if (prevNode) {
+          prevNode->get().recordDeallocationFromNestedMeasurement(ptr, prevNode->previousNode());
+        }
+        // If there is no earlier node in the stack, ignore the deallocation
+        return;
+      }
+      // subtraction
+      auto const& allocRecord = std::get<AllocationRecord>(found->second);
+      auto const allocIndex = std::get<UniqueTraceIndex>(found->second);
+      uniqueAllocTraces_[allocIndex].recordDeallocation(allocRecord);
+
+      // Account the presentActual on the node where the memory was allocated
+      // This can lead to some possibly weird cases when a nested node deallocates memory
+      presentActual_ -= allocRecord.actual_;
+
+      // churn analysis (only if deallocation is from the same measurement and not from a nested one)
+      if (deallocIndex) {
+        analyzeDeallocationForChurn(*deallocIndex, allocRecord, allocIndex);
+      }
+
+      addressToAllocation_.erase(found);
+    }
+
+    void analyzeDeallocationForChurn(UniqueTraceIndex deallocIndex,
+                                     AllocationRecord const& record,
+                                     UniqueTraceIndex allocIndex) {
+      // allocIndex points to an element in uniqueAllocTraces_ and is thus at most the size of uniqueAllocTraces_
+      if (allocIndex >= churnRecords_.size()) {
+        churnRecords_.resize(uniqueAllocTraces_.size());
+      }
+      auto& churns = churnRecords_[allocIndex];
+      auto found =
+          std::ranges::find_if(churns, [deallocIndex](auto& elem) { return elem.deallocIndex_ == deallocIndex; });
+      if (found == churns.end()) {
+        churns.push_back(ChurnRecord{.deallocIndex_ = deallocIndex, .total_ = record});
+      } else {
+        found->total_.add(record);
+      }
+    }
+
+    UniqueTraceIndex addDeallocation(std::stacktrace trace, DeallocationRecord record) {
+      auto hash = std::hash<std::stacktrace>()(trace);
+      auto found = hashToDeallocTraceIndex_.find(hash);
+      UniqueTraceIndex traceIndex;
+      if (found != hashToDeallocTraceIndex_.end()) {
+        traceIndex = found->second;
+        assert(trace == uniqueDeallocTraces_[traceIndex].trace_);
+        uniqueDeallocTraces_[traceIndex].recordDeallocation(record);
+      } else {
+        traceIndex = uniqueDeallocTraces_.size();
+        uniqueDeallocTraces_.emplace_back(record, std::move(trace));
+        hashToDeallocTraceIndex_.emplace(hash, traceIndex);
+      }
+      return traceIndex;
+    }
+
+    std::string formatTrace(std::stacktrace const& trace, int skipFromBottom, int skipFromTop) const {
+      assert(skipFromBottom < trace.size());
+      assert(skipFromTop < trace.size());
+      assert(skipFromBottom + skipFromTop < trace.size());
+      return formatTrace(std::ranges::subrange(trace.cbegin() + skipFromBottom, trace.cend() - skipFromTop));
+    }
+
+    template <typename T>
+    std::string formatTrace(T&& traceRange) const {
+      std::string ret;
+      for (auto const& [index, entry] : traceRange | std::views::enumerate) {
+        ret += std::format("{:>4}# {} \n", index, entry);
+      }
+      return ret;
+    }
+
+    template <typename T, typename P>
+    auto makeSortedIterators(T const& map, P&& pred) const {
+      std::vector<typename T::const_iterator> ordered;
+      ordered.reserve(map.size());
+      for (auto it = map.begin(); it != map.end(); ++it) {
+        ordered.push_back(it);
+      }
+      std::ranges::sort(ordered, std::greater{}, std::forward<P>(pred));
+      return ordered;
+    }
+
+    template <typename T, typename F>
+    void writeFileOrMessage(std::string_view measurementType,
+                            std::string_view measurementName,
+                            T&& log,
+                            F&& format) const {
+      if (not filePattern_.empty()) {
+        auto fname = filePattern_;
+        boost::replace_all(fname, "%M", measurementType);
+        std::ofstream os(fname);
+        std::print(os, "# {}\n", measurementName);
+        format(os);
+        os.close();
+        log.format(" saved in {}", fname);
+      } else {
+        std::stringstream ss;
+        format(ss);
+        log << "\n" << ss.str();
+      }
+    }
+
+    // About the measurement itself
+    std::stacktrace trace_;
+    int startFromEntry_ = 0;
+    std::size_t stackDepth_ = 0;
+    std::string filePattern_;
+    bool printStatistics_;
+
+    // Collection of stack traces
+    long long presentActual_ = 0;
+    long long maxActual_ = 0;
+    std::vector<AllocationTrace> uniqueAllocTraces_;
+    std::vector<DeallocationTrace> uniqueDeallocTraces_;
+    std::unordered_map<TraceHashValue, UniqueTraceIndex> hashToAllocTraceIndex_;
+    std::unordered_map<TraceHashValue, UniqueTraceIndex> hashToDeallocTraceIndex_;
+    std::unordered_map<void const*, std::tuple<AllocationRecord, UniqueTraceIndex>> addressToAllocation_;
+
+    // Same indexing as in uniqueAllocTraces_
+    // Assuming the number of different deallocation traces per one
+    // allocating trace would be small enough that a linear search is
+    // good enough
+    std::vector<std::vector<ChurnRecord>> churnRecords_;
+
+    struct Statistics {
+      std::chrono::duration<double, std::milli> t_allocations_{};
+      std::chrono::duration<double, std::milli> t_deallocations_{};
+      std::size_t num_allocations_ = 0;
+      std::size_t num_deallocations_ = 0;
+    };
+    Statistics stats_;
+  };
+  std::unique_ptr<MonitorStackNode>& currentMonitorStackNode() {
+    static thread_local std::unique_ptr<MonitorStackNode> ptr;
+    return ptr;
+  }
+
+  std::atomic<unsigned int>& globalFileCounter() {
+    static std::atomic<unsigned int> counter = 0;
+    return counter;
+  }
+
+  bool& threadActiveMonitoring() {
+    using namespace cms::perftools::allocMon;
+    static bool s_active[ThreadTracker::kTotalEntries]{};
+    return s_active[ThreadTracker::instance().thread_index()];
+  }
+
+  class MonitorAdaptor : public cms::perftools::AllocMonitorBase {
+  public:
+    static void startOnThread(std::string_view name, std::string filePattern, bool printStatistics) {
+      threadActiveMonitoring() = false;
+      auto trace = std::stacktrace::current();
+      auto const fileCount = globalFileCounter().fetch_add(1);
+      auto node = std::make_unique<MonitorStackNode>(
+          name,
+          std::move(currentMonitorStackNode()),
+          StackNodeData(std::move(trace), fileCount, std::move(filePattern), printStatistics));
+      {
+        edm::LogSystem log("IntrusiveAllocProfiler");
+        using namespace cms::perftools::allocMon;
+        log.format("Starting tracing for \"{}\".", name);
+      }
+      currentMonitorStackNode() = std::move(node);
+      threadActiveMonitoring() = true;
+    }
+    static void stopOnThread(std::string_view name) {
+      threadActiveMonitoring() = false;
+      using namespace cms::perftools::allocMon;
+      {
+        auto node = std::move(currentMonitorStackNode());
+        edm::LogSystem log("IntrusiveAllocProfiler");
+        log.format("Ending tracing for \"{}\".", name);
+        node->get().print(log, name);
+        currentMonitorStackNode() = node->popPreviousNode();
+      }
+      if (currentMonitorStackNode()) {
+        threadActiveMonitoring() = true;
+      }
+    }
+
+  private:
+    void allocCalled(size_t iRequested, size_t iActual, void const* ptr) final {
+      if (not threadActiveMonitoring()) {
+        return;
+      }
+      // First two entries are in the internals of AllocMonitor
+      constexpr auto skip = 2;
+      currentMonitorStackNode()->get().recordAllocation(
+          std::stacktrace::current(skip),
+          AllocationRecord{.requested_ = iRequested, .actual_ = iActual, .count_ = 1},
+          ptr);
+    }
+    void deallocCalled(size_t iActual, void const* ptr) final {
+      if (not threadActiveMonitoring()) {
+        return;
+      }
+      // First two entries are in the internals of AllocMonitor
+      constexpr auto skip = 2;
+      currentMonitorStackNode()->get().recordDeallocation(std::stacktrace::current(skip),
+                                                          DeallocationRecord{.actual_ = iActual, .count_ = 1},
+                                                          ptr,
+                                                          currentMonitorStackNode()->previousNode());
+    }
+  };
+}  // namespace
+
+class IntrusiveAllocProfiler : public edm::IntrusiveMonitorBase {
+public:
+  IntrusiveAllocProfiler(edm::ParameterSet const& iPSet)
+      : pattern_(iPSet.getUntrackedParameter<std::string>("filePattern")),
+        printStatistics_(iPSet.getUntrackedParameter<bool>("statistics")) {
+    if (not pattern_.empty()) {
+      if (not pattern_.contains("%I")) {
+        throw edm::Exception(edm::errors::Configuration) << "filePattern did not contain '%I'";
+      }
+      if (not pattern_.contains("%M")) {
+        throw edm::Exception(edm::errors::Configuration) << "filePattern did not contain '%M'";
+      }
+    }
+
+    (void)cms::perftools::AllocMonitorRegistry::instance().createAndRegisterMonitor<MonitorAdaptor>();
+  };
+  ~IntrusiveAllocProfiler() noexcept override = default;
+
+  void start(std::string_view name, bool nameIsString) final {
+    MonitorAdaptor::startOnThread(name, pattern_, printStatistics_);
+  }
+  void stop(std::string_view name) noexcept final { MonitorAdaptor::stopOnThread(name); }
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& iDesc) {
+    edm::ParameterSetDescription ps;
+    ps.addUntracked<std::string>("filePattern", "")
+        ->setComment(
+            "Pattern for the file names for the measurement results. Must contain '%I' for the counter of different "
+            "files, and '%M' for the measurement type (that are 'alloc', 'dealloc', 'atMaxAlloc', 'added', 'churn', "
+            "'churnalloc'). If empty (default), results are printed with MessageLogger.");
+    ps.addUntracked<bool>("statistics", false)
+        ->setComment("Whether to print some timing statistics about the memory measurement itself. Default is false.");
+    iDesc.addDefault(ps);
+  }
+
+private:
+  std::string pattern_;
+  bool printStatistics_ = false;
+};
+
+typedef edm::serviceregistry::ParameterSetMaker<edm::IntrusiveMonitorBase, IntrusiveAllocProfiler>
+    IntrusiveAllocProfilerMaker;
+DEFINE_FWK_SERVICE_MAKER(IntrusiveAllocProfiler, IntrusiveAllocProfilerMaker);
+
+#endif  // C++ version checks

--- a/PerfTools/AllocMonitor/plugins/MonitorStackNode.h
+++ b/PerfTools/AllocMonitor/plugins/MonitorStackNode.h
@@ -1,0 +1,39 @@
+#ifndef PerfTools_AllocMonitor_plugins_MonitorStackNode_h
+#define PerfTools_AllocMonitor_plugins_MonitorStackNode_h
+
+#include <memory>
+
+namespace cms::perftools::allocMon {
+  /**
+   * This class template provides a common stack node structure for
+   * IntrusiveAllocMonitors. The stack is presented as a linked list
+   * of nested uses of thean IntrusiveAllocMonitor measurements.
+   */
+  template <typename T>
+  class MonitorStackNode {
+  public:
+    MonitorStackNode(std::string_view name, std::unique_ptr<MonitorStackNode> previousNode, T&& data)
+        : name_(name), previousNode_(std::move(previousNode)), data_(std::move(data)) {}
+
+    MonitorStackNode(MonitorStackNode const&) = delete;
+    MonitorStackNode& operator=(MonitorStackNode const&) = delete;
+    MonitorStackNode(MonitorStackNode&&) = delete;
+    MonitorStackNode& operator=(MonitorStackNode&&) = delete;
+    ~MonitorStackNode() noexcept = default;
+
+    std::string_view name() const { return name_; }
+    MonitorStackNode* previousNode() { return previousNode_.get(); }
+    MonitorStackNode const* previousNode() const { return previousNode_.get(); }
+    std::unique_ptr<MonitorStackNode> popPreviousNode() { return std::move(previousNode_); }
+
+    T& get() { return data_; }
+    T const& get() const { return data_; }
+
+  private:
+    std::string_view name_;
+    std::unique_ptr<MonitorStackNode> previousNode_;
+    T data_;
+  };
+}  // namespace cms::perftools::allocMon
+
+#endif

--- a/PerfTools/AllocMonitor/scripts/edmIntrusiveAllocProfilerFoldStacks.py
+++ b/PerfTools/AllocMonitor/scripts/edmIntrusiveAllocProfilerFoldStacks.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import sys
+
+def parse_quantity_value_line(line):
+    """Parse a line containing quantity-value pairs.
+    Returns an ordered list of (quantity, value) tuples."""
+    tokens = line.split()
+    pairs = []
+    i = 0
+    while i + 1 < len(tokens):
+        try:
+            value = int(tokens[i + 1])
+            pairs.append((tokens[i], value))
+            i += 2
+        except ValueError:
+            i += 1
+    return pairs
+
+def parse_stack_frame_function(line):
+    """Extract the function name from a stack frame line."""
+    stripped = line.lstrip()
+    # Remove frame number prefix (digits followed by '#' and optional whitespace)
+    rest = re.sub(r'^\d+#\s*', '', stripped)
+    # Split on the last ' at ' to separate function name from file:line
+    parts = rest.rsplit(' at ', 1)
+    return parts[0]
+
+def is_stack_frame_line(line):
+    """Return True if the line is a stack frame line."""
+    return bool(re.match(r'\s*\d+#', line))
+
+def main(args):
+    quantity = args.quantity
+    first_quantity_name = None  # first quantity name seen across all records
+    error_occurred = False
+    current_pairs = None
+    current_frames = []
+
+    def emit_record(pairs, frames):
+        nonlocal quantity, first_quantity_name, error_occurred
+
+        if not pairs:
+            return
+
+        # Validate consistent first quantity across records
+        record_first = pairs[0][0]
+        if first_quantity_name is None:
+            first_quantity_name = record_first
+            if quantity is None:
+                quantity = record_first
+        elif record_first != first_quantity_name:
+            print(f'Error: inconsistent first quantity: expected {first_quantity_name!r}, got {record_first!r}',
+                  file=sys.stderr)
+            error_occurred = True
+            return
+
+        qty_dict = dict(pairs)
+        if quantity not in qty_dict:
+            print(f'Error: quantity {quantity!r} not found in record', file=sys.stderr)
+            error_occurred = True
+            return
+
+        value = qty_dict[quantity]
+        reversed_frames = list(reversed(frames))
+        print('; '.join(reversed_frames) + ' ' + str(value))
+
+    with open(args.input) as f:
+        for raw_line in f:
+            line = raw_line.rstrip('\n')
+            stripped = line.strip()
+
+            if not stripped or stripped.startswith('#'):
+                continue
+
+            if is_stack_frame_line(line):
+                if current_pairs is not None:
+                    current_frames.append(parse_stack_frame_function(line))
+            else:
+                # New quantity-value line: emit the previous record first
+                if current_pairs is not None:
+                    emit_record(current_pairs, current_frames)
+                    if error_occurred:
+                        sys.exit(1)
+                current_pairs = parse_quantity_value_line(stripped)
+                current_frames = []
+
+    # Emit the final record
+    if current_pairs is not None:
+        emit_record(current_pairs, current_frames)
+        if error_occurred:
+            sys.exit(1)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Transform output strack trace files from IntrusiveAllocProfiler to format usable e.g. for flame graphs'
+    )
+    parser.add_argument('input', help='Path to the input file to analyze')
+    parser.add_argument('-q', '--quantity', default=None,
+                        help='Name of the quantity to print (default: first quantity in file)')
+    args = parser.parse_args()
+
+    main(args)

--- a/PerfTools/AllocMonitor/test/BuildFile.xml
+++ b/PerfTools/AllocMonitor/test/BuildFile.xml
@@ -33,8 +33,15 @@
     <use name="FWCore/ServiceRegistry"/>
     <use name="PerfTools/AllocMonitor"/>
     <use name="PerfTools/AllocMonitorPreload"/>
+    <!-- This binary run by the tests below. Without a command-line argument it would fail -->
+    <flags NO_TESTRUN="1"/>
   </bin>
-  <test name="testIntrusiveAllocMonitorOutput" command="testIntrusiveAllocMonitor 2>&amp;1 | ${LOCALTOP}/src/PerfTools/AllocMonitor/test/verifyIntrusiveAllocMonitor.py">
+  <test name="testIntrusiveAllocMonitorOutput" command="testIntrusiveAllocMonitor IntrusiveAllocMonitor 2>&amp;1 | ${LOCALTOP}/src/PerfTools/AllocMonitor/test/verifyIntrusiveAllocMonitor.py">
     <flags PRE_TEST="testIntrusiveAllocMonitor"/>
   </test>
+  <ifrelease name="CPP23">
+    <test name="testIntrusiveAllocProfilerOutput" command="testIntrusiveAllocMonitor IntrusiveAllocProfiler 2>&amp;1 | ${LOCALTOP}/src/PerfTools/AllocMonitor/test/verifyIntrusiveAllocProfiler.py">
+      <flags PRE_TEST="testIntrusiveAllocMonitor"/>
+    </test>
+  </ifrelease>
 </ifrelease>

--- a/PerfTools/AllocMonitor/test/test_intrusiveAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/test/test_intrusiveAllocMonitor.cc
@@ -9,8 +9,18 @@
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 
 #include <cassert>
+#include <format>
 #include <memory>
+#include <string_view>
 #include <vector>
+
+[[gnu::noinline]] std::vector<int> nestedChurn() {
+  std::vector<int> vec;
+  for (int i = 0; i < 10000; ++i) {
+    vec.push_back(i * 3 - 5);
+  }
+  return vec;
+}
 
 int* nested() {
   edm::Service<edm::IntrusiveMonitorBase> imb;
@@ -25,14 +35,20 @@ std::atomic<int*> ptr2 = nullptr;
 std::atomic<int*> ptr3 = nullptr;
 std::atomic<int*> ptr4 = nullptr;
 
-int main() {
+int main(int argc, char** argv) {
   edmplugin::PluginManager::configure(edmplugin::standard::config());
 
-  std::string const config = R"_(
+  if (argc < 2) {
+    edm::LogProblem("Test").format("Need one argument for the intrusive monitor name");
+    return 1;
+  }
+
+  std::string const config = std::format(R"_(
 import FWCore.ParameterSet.Config as cms
 process = cms.Process('Test')
-process.add_(cms.Service('IntrusiveAllocMonitor'))
-)_";
+process.add_(cms.Service('{}'))
+)_",
+                                         argv[1]);
   std::unique_ptr<edm::ParameterSet> params;
   edm::makeParameterSets(config, params);
   auto token = edm::ServiceToken(edm::ServiceRegistry::createServicesFromConfig(std::move(params)));
@@ -137,6 +153,20 @@ process.add_(cms.Service('IntrusiveAllocMonitor'))
       delete ptr3.load();
       delete ptr2.load();
       delete ptr1.load();
+    }
+    edm::LogPrint("Test").format("Sum {}", sum);
+  }
+  edm::LogPrint("Test").format("====================");
+
+  edm::LogPrint("Test").format("Test nested churning");
+  {
+    int sum = 0;
+    {
+      auto guard = imb->startMonitoring("Nested churning");
+      auto vec = nestedChurn();
+      for (int a : vec) {
+        sum += a;
+      }
     }
     edm::LogPrint("Test").format("Sum {}", sum);
   }

--- a/PerfTools/AllocMonitor/test/verifyIntrusiveAllocMonitor.py
+++ b/PerfTools/AllocMonitor/test/verifyIntrusiveAllocMonitor.py
@@ -376,14 +376,55 @@ def verify_nested_with_string_messages(test_case):
     if test_case['sum'] != 433:
         raise ValueError(f"nested with string messages: expected sum 433, got {test_case['sum']}")
 
+def verify_nested_churning(test_case):
+    """Verify conditions for 'nested churning' test case."""
+    name = test_case['name']
+    if name != 'nested churning':
+        raise ValueError(f"Expected 'nested churning', got '{name}'")
+
+    messages = test_case['messages']
+    if len(messages) != 1:
+        raise ValueError(f"nested churning: expected 1 message, got {len(messages)}")
+
+    msg = messages[0]
+
+    # Check labels
+    expected_labels = ['Nested churning']
+    if msg['labels'] != expected_labels:
+        raise ValueError(f"nested churning: expected labels {expected_labels}, got {msg['labels']}")
+
+    # added is 0: vec is destroyed before the guard (reverse declaration order), so all
+    # memory allocated during the scope is also freed within the scope
+    if msg['added'] != 0:
+        raise ValueError(f"nested churning: added must be 0, got {msg['added']}")
+
+    # nAlloc equals nDealloc
+    if msg['nAlloc'] != msg['nDealloc']:
+        raise ValueError(f"nested churning: nAlloc ({msg['nAlloc']}) must equal nDealloc ({msg['nDealloc']})")
+
+    # nAlloc is larger than 1 (multiple reallocations during push_back)
+    if msg['nAlloc'] <= 1:
+        raise ValueError(f"nested churning: nAlloc must be > 1, got {msg['nAlloc']}")
+
+    # peak and max_alloc are larger than 0
+    if msg['peak'] <= 0:
+        raise ValueError(f"nested churning: peak must be > 0, got {msg['peak']}")
+    if msg['max_alloc'] <= 0:
+        raise ValueError(f"nested churning: max alloc must be > 0, got {msg['max_alloc']}")
+
+    # Verify sum
+    if test_case['sum'] != 149935000:
+        raise ValueError(f"nested churning: expected sum 149935000, got {test_case['sum']}")
+
+
 def main():
     """Main function to parse and verify IntrusiveAllocMonitor output."""
     try:
         test_cases = read_test_cases()
 
-        # Check that we have exactly 5 test cases
-        if len(test_cases) != 5:
-            raise ValueError(f"Expected exactly 5 test cases, got {len(test_cases)}")
+        # Check that we have exactly 6 test cases
+        if len(test_cases) != 6:
+            raise ValueError(f"Expected exactly 6 test cases, got {len(test_cases)}")
 
         # Verify each test case
         verify_vector_fill(test_cases[0])
@@ -391,6 +432,7 @@ def main():
         verify_nested_empty_outer(test_cases[2])
         verify_nested_allocation(test_cases[3])
         verify_nested_with_string_messages(test_cases[4])
+        verify_nested_churning(test_cases[5])
 
         # All checks passed, exit silently with code 0
         sys.exit(0)

--- a/PerfTools/AllocMonitor/test/verifyIntrusiveAllocProfiler.py
+++ b/PerfTools/AllocMonitor/test/verifyIntrusiveAllocProfiler.py
@@ -1,0 +1,649 @@
+#!/usr/bin/env python3
+
+import sys
+import re
+
+# Section header strings as they appear in the output
+SECTION_KEYS = {
+    'All allocations': 'alloc',
+    'Allocated memory at the max actual moment': 'atMaxActual',
+    'Added memory': 'added',
+    'All deallocations': 'dealloc',
+    'Memory allocation+deallocation churn': 'churn',
+    'Memory allocation+deallocation churn allocations': 'churnalloc',
+}
+
+
+def _parse_alloc_record_line(stripped):
+    """Parse 'count C requested R actual A' → dict, or None."""
+    m = re.match(r'^count\s+(\d+)\s+requested\s+(\d+)\s+actual\s+(\d+)', stripped)
+    if m:
+        return {'count': int(m.group(1)), 'requested': int(m.group(2)),
+                'actual': int(m.group(3)), 'trace': ''}
+    return None
+
+
+def _parse_dealloc_record_line(stripped):
+    """Parse 'count C actual A' → dict, or None."""
+    m = re.match(r'^count\s+(\d+)\s+actual\s+(\d+)', stripped)
+    if m:
+        return {'count': int(m.group(1)), 'actual': int(m.group(2)), 'trace': ''}
+    return None
+
+
+def totals(records, kind='alloc'):
+    """Return summed count/requested/actual over a list of records."""
+    if not records:
+        t = {'count': 0, 'actual': 0}
+        if kind != 'dealloc':
+            t['requested'] = 0
+        return t
+    t = {
+        'count': sum(r['count'] for r in records),
+        'actual': sum(r['actual'] for r in records),
+    }
+    if kind != 'dealloc':
+        t['requested'] = sum(r['requested'] for r in records)
+    return t
+
+
+def parse_trace_message(lines):
+    """Parse one %MSG block (the raw lines between %MSG-s and %MSG).
+
+    Returns a dict with keys: name, alloc, atMaxActual, added, dealloc, churn, churnalloc.
+    Each section value is a list of record dicts.
+    Returns None for 'Starting tracing' blocks.
+    """
+    # Handle line-wrapping by joining stripped non-empty lines for name extraction
+    joined = ' '.join(l.strip() for l in lines if l.strip())
+
+    if 'Ending tracing for' not in joined:
+        return None  # 'Starting tracing' message – skip
+
+    name_m = re.search(r'Ending tracing for "([^"]+)"', joined)
+    if not name_m:
+        return None
+    name = name_m.group(1)
+
+    result = {'name': name, 'alloc': [], 'atMaxActual': [], 'added': [], 'dealloc': [], 'churn': [], 'churnalloc': []}
+    current_section = None
+    current_record = None
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Section header?
+        if stripped in SECTION_KEYS:
+            if current_record is not None:
+                result[current_section].append(current_record)
+                current_record = None
+            current_section = SECTION_KEYS[stripped]
+            continue
+
+        if current_section is None:
+            continue  # lines before first section header (stack trace preamble etc.)
+
+        # Blank line ends the current record
+        if not stripped:
+            if current_record is not None:
+                result[current_section].append(current_record)
+                current_record = None
+            continue
+
+        # Try to start a new record
+        if current_section in ('alloc', 'atMaxActual', 'added', 'churn', 'churnalloc'):
+            rec = _parse_alloc_record_line(stripped)
+            if rec is not None:
+                if current_record is not None:
+                    result[current_section].append(current_record)
+                current_record = rec
+                continue
+        elif current_section == 'dealloc':
+            rec = _parse_dealloc_record_line(stripped)
+            if rec is not None:
+                if current_record is not None:
+                    result[current_section].append(current_record)
+                current_record = rec
+                continue
+
+        # Stack trace line – append to current record's trace string
+        if current_record is not None:
+            current_record['trace'] += stripped + '\n'
+
+    # Flush final record
+    if current_record is not None and current_section is not None:
+        result[current_section].append(current_record)
+
+    return result
+
+
+def read_test_cases():
+    """Read stdin and extract test cases with their IntrusiveAllocProfiler messages."""
+    test_cases = []
+    current = None
+    collecting_msg = False
+    msg_lines = []
+
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+
+        # Start of a new test case
+        if line.startswith('Test '):
+            current = {'name': line[5:], 'messages': [], 'sum': None}
+            collecting_msg = False
+            msg_lines = []
+            continue
+
+        if current is None:
+            continue
+
+        # End of a test case
+        if line.startswith('===='):
+            if current is not None:
+                test_cases.append(current)
+            current = None
+            continue
+
+        # Start of a %MSG block
+        if line.startswith('%MSG-s IntrusiveAllocProfiler:'):
+            collecting_msg = True
+            msg_lines = []
+            continue
+
+        # End of a %MSG block
+        if line == '%MSG' and collecting_msg:
+            collecting_msg = False
+            msg = parse_trace_message(msg_lines)
+            if msg is not None:
+                current['messages'].append(msg)
+            msg_lines = []
+            continue
+
+        if collecting_msg:
+            msg_lines.append(raw_line)
+            continue
+
+        if line.startswith('Sum '):
+            current['sum'] = int(line[4:])
+
+    if current is not None:
+        test_cases.append(current)
+
+    return test_cases
+
+
+# ---------------------------------------------------------------------------
+# Per-test verifiers
+# ---------------------------------------------------------------------------
+
+def verify_vector_fill(test_case):
+    """Verify the 'vector fill' test case."""
+    name = test_case['name']
+    if name != 'vector fill':
+        raise ValueError(f"Expected test 'vector fill', got '{name}'")
+
+    messages = test_case['messages']
+    if len(messages) != 1:
+        raise ValueError(f"vector fill: expected 1 message, got {len(messages)}")
+
+    msg = messages[0]
+    if msg['name'] != 'Vector fill':
+        raise ValueError(f"vector fill: expected message name 'Vector fill', got '{msg['name']}'")
+
+    alloc_t = totals(msg['alloc'])
+    added_t = totals(msg['added'])
+    dealloc_t = totals(msg['dealloc'], 'dealloc')
+
+    # Multiple allocations due to vector growth, one live buffer at end
+    if alloc_t['count'] <= 1:
+        raise ValueError(f"vector fill: alloc count must be > 1 (vector reallocates), got {alloc_t['count']}")
+
+    # Exactly one allocation is still live (the final buffer)
+    if added_t['count'] != 1:
+        raise ValueError(f"vector fill: added count must be 1, got {added_t['count']}")
+
+    # All intermediate buffers were freed: dealloc = alloc - added
+    expected_dealloc = alloc_t['count'] - added_t['count']
+    if dealloc_t['count'] != expected_dealloc:
+        raise ValueError(f"vector fill: dealloc count must be {expected_dealloc}, got {dealloc_t['count']}")
+
+    # Churn: repeated alloc+free of growing buffers
+    if not msg['churn']:
+        raise ValueError("vector fill: churn section must be non-empty")
+
+    # churnalloc totals match churn totals (same alloc+dealloc pairs, different grouping)
+    churn_t = totals(msg['churn'])
+    churnalloc_t = totals(msg['churnalloc'])
+    if churnalloc_t['count'] != churn_t['count']:
+        raise ValueError(f"vector fill: churnalloc count ({churnalloc_t['count']}) must equal churn count ({churn_t['count']})")
+    if churnalloc_t['actual'] != churn_t['actual']:
+        raise ValueError(f"vector fill: churnalloc actual ({churnalloc_t['actual']}) must equal churn actual ({churn_t['actual']})")
+
+    # At peak, two buffers are simultaneously live (old + new during realloc)
+    atMaxActual_t = totals(msg['atMaxActual'])
+    if atMaxActual_t['count'] != 2:
+        raise ValueError(f"vector fill: atMaxActual count must be 2 (two buffers live at realloc peak), got {atMaxActual_t['count']}")
+
+    if test_case['sum'] != 99980000:
+        raise ValueError(f"vector fill: expected sum 99980000, got {test_case['sum']}")
+
+
+def verify_vector_fill_again(test_case):
+    """Verify the 'vector fill again' test case."""
+    name = test_case['name']
+    if name != 'vector fill again':
+        raise ValueError(f"Expected test 'vector fill again', got '{name}'")
+
+    messages = test_case['messages']
+    if len(messages) != 1:
+        raise ValueError(f"vector fill again: expected 1 message, got {len(messages)}")
+
+    msg = messages[0]
+    if msg['name'] != 'Vector fill again':
+        raise ValueError(f"vector fill again: expected message name 'Vector fill again', got '{msg['name']}'")
+
+    if not msg['alloc']:
+        raise ValueError("vector fill again: alloc section must be non-empty")
+
+    added_t = totals(msg['added'])
+    if added_t['count'] < 1:
+        raise ValueError(f"vector fill again: added count must be >= 1, got {added_t['count']}")
+
+    # Only one allocation in this scope (new buffer); atMaxActual count equals alloc count
+    alloc_t = totals(msg['alloc'])
+    atMaxActual_t = totals(msg['atMaxActual'])
+    if atMaxActual_t['count'] != alloc_t['count']:
+        raise ValueError(f"vector fill again: atMaxActual count ({atMaxActual_t['count']}) must equal alloc count ({alloc_t['count']})")
+
+    # No churn: the freed buffer was allocated in a previous measurement
+    if msg['churnalloc']:
+        raise ValueError("vector fill again: churnalloc section must be empty (no intra-measurement alloc+free)")
+
+    if test_case['sum'] != 199960000:
+        raise ValueError(f"vector fill again: expected sum 199960000, got {test_case['sum']}")
+
+
+def verify_nested_empty_outer(test_case):
+    """Verify the 'nested allocation with empty outer' test case."""
+    name = test_case['name']
+    if name != 'nested allocation with empty outer':
+        raise ValueError(f"Expected test 'nested allocation with empty outer', got '{name}'")
+
+    messages = test_case['messages']
+    if len(messages) != 2:
+        raise ValueError(f"nested allocation with empty outer: expected 2 messages, got {len(messages)}")
+
+    inner_msg = messages[0]
+    outer_msg = messages[1]
+
+    if inner_msg['name'] != 'inner unique_ptr':
+        raise ValueError(f"nested allocation with empty outer: inner message name must be 'inner unique_ptr', got '{inner_msg['name']}'")
+    if outer_msg['name'] != 'Nested allocation empty outer':
+        raise ValueError(f"nested allocation with empty outer: outer message name must be 'Nested allocation empty outer', got '{outer_msg['name']}'")
+
+    # Inner: one allocation (new int(42)), still alive at inner measurement end
+    inner_alloc_t = totals(inner_msg['alloc'])
+    inner_added_t = totals(inner_msg['added'])
+
+    if inner_alloc_t['count'] != 1:
+        raise ValueError(f"nested allocation with empty outer (inner): alloc count must be 1, got {inner_alloc_t['count']}")
+    if inner_alloc_t['requested'] != 4:
+        raise ValueError(f"nested allocation with empty outer (inner): alloc requested must be 4, got {inner_alloc_t['requested']}")
+    if inner_added_t['count'] != 1:
+        raise ValueError(f"nested allocation with empty outer (inner): added count must be 1, got {inner_added_t['count']}")
+    if inner_added_t['requested'] != 4:
+        raise ValueError(f"nested allocation with empty outer (inner): added requested must be 4, got {inner_added_t['requested']}")
+    if inner_msg['dealloc']:
+        raise ValueError(f"nested allocation with empty outer (inner): dealloc section must be empty")
+    if inner_msg['churn']:
+        raise ValueError(f"nested allocation with empty outer (inner): churn section must be empty")
+
+    # Single int allocation, live the whole inner scope: atMaxActual equals alloc
+    inner_atMaxActual_t = totals(inner_msg['atMaxActual'])
+    if inner_atMaxActual_t['count'] != inner_alloc_t['count']:
+        raise ValueError(f"nested allocation with empty outer (inner): atMaxActual count ({inner_atMaxActual_t['count']}) must equal alloc count ({inner_alloc_t['count']})")
+    if inner_msg['churnalloc']:
+        raise ValueError("nested allocation with empty outer (inner): churnalloc section must be empty")
+
+    # Outer: no allocations of its own; the one deallocation is the inner allocation freed here
+    if outer_msg['alloc']:
+        raise ValueError("nested allocation with empty outer (outer): alloc section must be empty")
+    if outer_msg['added']:
+        raise ValueError("nested allocation with empty outer (outer): added section must be empty")
+
+    outer_dealloc_t = totals(outer_msg['dealloc'], 'dealloc')
+    if outer_dealloc_t['count'] != 1:
+        raise ValueError(f"nested allocation with empty outer (outer): dealloc count must be 1, got {outer_dealloc_t['count']}")
+
+    # The same allocation size flows from inner alloc to outer dealloc
+    if inner_alloc_t['actual'] != outer_dealloc_t['actual']:
+        raise ValueError(
+            f"nested allocation with empty outer: inner alloc actual ({inner_alloc_t['actual']}) "
+            f"must equal outer dealloc actual ({outer_dealloc_t['actual']})"
+        )
+
+    if outer_msg['churn']:
+        raise ValueError("nested allocation with empty outer (outer): churn section must be empty")
+    if outer_msg['atMaxActual']:
+        raise ValueError("nested allocation with empty outer (outer): atMaxActual section must be empty")
+    if outer_msg['churnalloc']:
+        raise ValueError("nested allocation with empty outer (outer): churnalloc section must be empty")
+
+    if test_case['sum'] != 42:
+        raise ValueError(f"nested allocation with empty outer: expected sum 42, got {test_case['sum']}")
+
+
+def verify_nested_allocation(test_case):
+    """Verify the 'nested allocation' test case."""
+    name = test_case['name']
+    if name != 'nested allocation':
+        raise ValueError(f"Expected test 'nested allocation', got '{name}'")
+
+    messages = test_case['messages']
+    if len(messages) != 2:
+        raise ValueError(f"nested allocation: expected 2 messages, got {len(messages)}")
+
+    inner_msg = messages[0]
+    outer_msg = messages[1]
+
+    if inner_msg['name'] != 'inner unique_ptr':
+        raise ValueError(f"nested allocation (inner): expected name 'inner unique_ptr', got '{inner_msg['name']}'")
+    if outer_msg['name'] != 'Nested allocation outer unique_ptr':
+        raise ValueError(f"nested allocation (outer): expected name 'Nested allocation outer unique_ptr', got '{outer_msg['name']}'")
+
+    # Inner: one allocation (new int(42)), alive at inner measurement end
+    inner_alloc_t = totals(inner_msg['alloc'])
+    inner_added_t = totals(inner_msg['added'])
+
+    if inner_alloc_t['count'] != 1:
+        raise ValueError(f"nested allocation (inner): alloc count must be 1, got {inner_alloc_t['count']}")
+    if inner_alloc_t['requested'] != 4:
+        raise ValueError(f"nested allocation (inner): alloc requested must be 4, got {inner_alloc_t['requested']}")
+    if inner_added_t['count'] != 1:
+        raise ValueError(f"nested allocation (inner): added count must be 1, got {inner_added_t['count']}")
+    if inner_msg['dealloc']:
+        raise ValueError("nested allocation (inner): dealloc section must be empty")
+    if inner_msg['churn']:
+        raise ValueError("nested allocation (inner): churn section must be empty")
+
+    # Single int allocation, live for the whole inner scope: atMaxActual equals alloc
+    inner_atMaxActual_t = totals(inner_msg['atMaxActual'])
+    if inner_atMaxActual_t['count'] != inner_alloc_t['count']:
+        raise ValueError(f"nested allocation (inner): atMaxActual count ({inner_atMaxActual_t['count']}) must equal alloc count ({inner_alloc_t['count']})")
+    if inner_msg['churnalloc']:
+        raise ValueError("nested allocation (inner): churnalloc section must be empty")
+
+    # Outer: allocates ptr1, added is empty (both ptr1 and ptr2 freed by end of measurement),
+    # dealloc has ptr1 (freed in outer) + ptr2 (attributed from inner), churn has ptr1 (alloc+free in outer)
+    outer_alloc_t = totals(outer_msg['alloc'])
+    outer_added_t = totals(outer_msg['added'])
+    outer_dealloc_t = totals(outer_msg['dealloc'], 'dealloc')
+    outer_churn_t = totals(outer_msg['churn'])
+
+    if outer_alloc_t['count'] < 1:
+        raise ValueError(f"nested allocation (outer): alloc count must be >= 1, got {outer_alloc_t['count']}")
+    if outer_alloc_t['requested'] != 4:
+        raise ValueError(f"nested allocation (outer): alloc requested must be 4 (ptr1), got {outer_alloc_t['requested']}")
+
+    if outer_added_t['count'] != 0:
+        raise ValueError(f"nested allocation (outer): added must be empty (all freed), got count {outer_added_t['count']}")
+
+    # dealloc count = outer alloc + inner alloc (ptr2 attributed up)
+    expected_dealloc = outer_alloc_t['count'] + inner_alloc_t['count']
+    if outer_dealloc_t['count'] != expected_dealloc:
+        raise ValueError(f"nested allocation (outer): dealloc count must be {expected_dealloc}, got {outer_dealloc_t['count']}")
+
+    # churn count = outer alloc count (ptr1 was allocated and freed within this measurement)
+    if outer_churn_t['count'] != outer_alloc_t['count']:
+        raise ValueError(f"nested allocation (outer): churn count must equal outer alloc count ({outer_alloc_t['count']}), got {outer_churn_t['count']}")
+
+    # ptr1 (only outer alloc) was live for the full outer scope: atMaxActual count equals alloc count
+    outer_atMaxActual_t = totals(outer_msg['atMaxActual'])
+    if outer_atMaxActual_t['count'] != outer_alloc_t['count']:
+        raise ValueError(f"nested allocation (outer): atMaxActual count ({outer_atMaxActual_t['count']}) must equal alloc count ({outer_alloc_t['count']})")
+
+    # churnalloc totals match churn totals
+    outer_churnalloc_t = totals(outer_msg['churnalloc'])
+    if outer_churnalloc_t['count'] != outer_churn_t['count']:
+        raise ValueError(f"nested allocation (outer): churnalloc count ({outer_churnalloc_t['count']}) must equal churn count ({outer_churn_t['count']})")
+    if outer_churnalloc_t['actual'] != outer_churn_t['actual']:
+        raise ValueError(f"nested allocation (outer): churnalloc actual ({outer_churnalloc_t['actual']}) must equal churn actual ({outer_churn_t['actual']})")
+
+    if test_case['sum'] != 84:
+        raise ValueError(f"nested allocation: expected sum 84, got {test_case['sum']}")
+
+
+def verify_nested_with_string_messages(test_case):
+    """Verify the 'nested with string messages' test case."""
+    name = test_case['name']
+    if name != 'nested with string messages':
+        raise ValueError(f"Expected test 'nested with string messages', got '{name}'")
+
+    messages = test_case['messages']
+    if len(messages) != 5:
+        raise ValueError(f"nested with string messages: expected 5 messages, got {len(messages)}")
+
+    def verify_simple_inner(msg, expected_name, msg_id):
+        """Verify an inner measurement that allocates a single int and keeps it alive."""
+        if msg['name'] != expected_name:
+            raise ValueError(f"nested with string messages (msg {msg_id}): expected name '{expected_name}', got '{msg['name']}'")
+
+        alloc_t = totals(msg['alloc'])
+        added_t = totals(msg['added'])
+
+        if alloc_t['count'] != 1:
+            raise ValueError(f"nested with string messages (msg {msg_id}): alloc count must be 1, got {alloc_t['count']}")
+        if alloc_t['requested'] != 4:
+            raise ValueError(f"nested with string messages (msg {msg_id}): alloc requested must be 4, got {alloc_t['requested']}")
+        if added_t['count'] != 1:
+            raise ValueError(f"nested with string messages (msg {msg_id}): added count must be 1, got {added_t['count']}")
+        if added_t['requested'] != 4:
+            raise ValueError(f"nested with string messages (msg {msg_id}): added requested must be 4, got {added_t['requested']}")
+        if msg['dealloc']:
+            raise ValueError(f"nested with string messages (msg {msg_id}): dealloc section must be empty")
+        if msg['churn']:
+            raise ValueError(f"nested with string messages (msg {msg_id}): churn section must be empty")
+
+        # Single int allocation: atMaxActual equals alloc, no churnalloc
+        atMaxActual_t = totals(msg['atMaxActual'])
+        if atMaxActual_t['count'] != 1:
+            raise ValueError(f"nested with string messages (msg {msg_id}): atMaxActual count must be 1, got {atMaxActual_t['count']}")
+        if atMaxActual_t['requested'] != 4:
+            raise ValueError(f"nested with string messages (msg {msg_id}): atMaxActual requested must be 4, got {atMaxActual_t['requested']}")
+        if msg['churnalloc']:
+            raise ValueError(f"nested with string messages (msg {msg_id}): churnalloc section must be empty")
+
+    # Messages 0-2: simple inner measurements (ptr2, ptr3, ptr4)
+    verify_simple_inner(messages[0], 'inner unique_ptr', 0)
+    verify_simple_inner(messages[1], 'another inner unique_ptr', 1)
+    verify_simple_inner(messages[2], 'inner unique_ptr', 2)
+
+    # Message 3: 'inner empty' – allocates a string for the sub-measurement name,
+    # that string is then freed in the same scope. ptr4 is freed in the outer scope.
+    inner_empty = messages[3]
+    if inner_empty['name'] != 'inner empty':
+        raise ValueError(f"nested with string messages (msg 3): expected name 'inner empty', got '{inner_empty['name']}'")
+
+    if not inner_empty['alloc']:
+        raise ValueError("nested with string messages (msg 3): alloc section must be non-empty (string allocation)")
+
+    inner_empty_alloc_t = totals(inner_empty['alloc'])
+    inner_empty_dealloc_t = totals(inner_empty['dealloc'], 'dealloc')
+
+    if inner_empty['added']:
+        raise ValueError("nested with string messages (msg 3): added section must be empty")
+
+    if not inner_empty['dealloc']:
+        raise ValueError("nested with string messages (msg 3): dealloc section must be non-empty")
+
+    # All allocations observed in 'inner empty' were also deallocated within it
+    if inner_empty_alloc_t['count'] != inner_empty_dealloc_t['count']:
+        raise ValueError(
+            f"nested with string messages (msg 3): alloc count ({inner_empty_alloc_t['count']}) "
+            f"must equal dealloc count ({inner_empty_dealloc_t['count']})"
+        )
+
+    if not inner_empty['churn']:
+        raise ValueError("nested with string messages (msg 3): churn section must be non-empty")
+
+    # churnalloc totals match churn totals
+    inner_empty_churn_t = totals(inner_empty['churn'])
+    inner_empty_churnalloc_t = totals(inner_empty['churnalloc'])
+    if inner_empty_churnalloc_t['count'] != inner_empty_churn_t['count']:
+        raise ValueError(
+            f"nested with string messages (msg 3): churnalloc count ({inner_empty_churnalloc_t['count']}) "
+            f"must equal churn count ({inner_empty_churn_t['count']})"
+        )
+    if inner_empty_churnalloc_t['actual'] != inner_empty_churn_t['actual']:
+        raise ValueError(
+            f"nested with string messages (msg 3): churnalloc actual ({inner_empty_churnalloc_t['actual']}) "
+            f"must equal churn actual ({inner_empty_churn_t['actual']})"
+        )
+
+    # One allocation (string name): atMaxActual count equals alloc count
+    inner_empty_atMaxActual_t = totals(inner_empty['atMaxActual'])
+    if inner_empty_atMaxActual_t['count'] != inner_empty_alloc_t['count']:
+        raise ValueError(
+            f"nested with string messages (msg 3): atMaxActual count ({inner_empty_atMaxActual_t['count']}) "
+            f"must equal alloc count ({inner_empty_alloc_t['count']})"
+        )
+
+    # Message 4: outer measurement – ptr1 was allocated here; all 4 ptrs are freed here
+    outer_msg = messages[4]
+    if outer_msg['name'] != 'Nested allocation with string messages outer unique_ptr':
+        raise ValueError(
+            f"nested with string messages (msg 4): expected name "
+            f"'Nested allocation with string messages outer unique_ptr', got '{outer_msg['name']}'"
+        )
+
+    if not outer_msg['alloc']:
+        raise ValueError("nested with string messages (msg 4): alloc section must be non-empty")
+
+    if outer_msg['added']:
+        raise ValueError("nested with string messages (msg 4): added section must be empty (all ptrs freed)")
+
+    outer_dealloc_t = totals(outer_msg['dealloc'], 'dealloc')
+    if outer_dealloc_t['count'] < 4:
+        raise ValueError(
+            f"nested with string messages (msg 4): dealloc count must be >= 4 (four ptrs freed), "
+            f"got {outer_dealloc_t['count']}"
+        )
+
+    if not outer_msg['churn']:
+        raise ValueError("nested with string messages (msg 4): churn section must be non-empty")
+
+    # churnalloc totals match churn totals
+    outer_alloc_t = totals(outer_msg['alloc'])
+    outer_churn_t = totals(outer_msg['churn'])
+    outer_churnalloc_t = totals(outer_msg['churnalloc'])
+    if outer_churnalloc_t['count'] != outer_churn_t['count']:
+        raise ValueError(
+            f"nested with string messages (msg 4): churnalloc count ({outer_churnalloc_t['count']}) "
+            f"must equal churn count ({outer_churn_t['count']})"
+        )
+    if outer_churnalloc_t['actual'] != outer_churn_t['actual']:
+        raise ValueError(
+            f"nested with string messages (msg 4): churnalloc actual ({outer_churnalloc_t['actual']}) "
+            f"must equal churn actual ({outer_churn_t['actual']})"
+        )
+
+    # atMaxActual is non-empty and within alloc count
+    if not outer_msg['atMaxActual']:
+        raise ValueError("nested with string messages (msg 4): atMaxActual section must be non-empty")
+    outer_atMaxActual_t = totals(outer_msg['atMaxActual'])
+    if outer_atMaxActual_t['count'] > outer_alloc_t['count']:
+        raise ValueError(
+            f"nested with string messages (msg 4): atMaxActual count ({outer_atMaxActual_t['count']}) "
+            f"must be <= alloc count ({outer_alloc_t['count']})"
+        )
+
+    if test_case['sum'] != 433:
+        raise ValueError(f"nested with string messages: expected sum 433, got {test_case['sum']}")
+
+
+def verify_nested_churning(test_case):
+    """Verify the 'nested churning' test case."""
+    name = test_case['name']
+    if name != 'nested churning':
+        raise ValueError(f"Expected test 'nested churning', got '{name}'")
+
+    messages = test_case['messages']
+    if len(messages) != 1:
+        raise ValueError(f"nested churning: expected 1 message, got {len(messages)}")
+
+    msg = messages[0]
+    if msg['name'] != 'Nested churning':
+        raise ValueError(f"nested churning: expected message name 'Nested churning', got '{msg['name']}'")
+
+    alloc_t = totals(msg['alloc'])
+    dealloc_t = totals(msg['dealloc'], 'dealloc')
+
+    # vec is destroyed before the guard (reverse declaration order), so all
+    # memory is freed within the scope: added must be empty
+    if msg['added']:
+        raise ValueError("nested churning: added section must be empty (vec freed before guard)")
+
+    # Multiple allocations due to vector growth
+    if alloc_t['count'] <= 1:
+        raise ValueError(f"nested churning: alloc count must be > 1 (vector reallocates), got {alloc_t['count']}")
+
+    # All allocations were freed: dealloc count equals alloc count
+    if dealloc_t['count'] != alloc_t['count']:
+        raise ValueError(
+            f"nested churning: dealloc count ({dealloc_t['count']}) must equal "
+            f"alloc count ({alloc_t['count']})"
+        )
+
+    # Churn section must be non-empty (intermediate buffers allocated and freed)
+    if not msg['churn']:
+        raise ValueError("nested churning: churn section must be non-empty")
+
+    # churnalloc totals match churn totals
+    churn_t = totals(msg['churn'])
+    churnalloc_t = totals(msg['churnalloc'])
+    if churnalloc_t['count'] != churn_t['count']:
+        raise ValueError(f"nested churning: churnalloc count ({churnalloc_t['count']}) must equal churn count ({churn_t['count']})")
+    if churnalloc_t['actual'] != churn_t['actual']:
+        raise ValueError(f"nested churning: churnalloc actual ({churnalloc_t['actual']}) must equal churn actual ({churn_t['actual']})")
+
+    # nestedChurn() must appear in at least one churn stack trace
+    if not any('nestedChurn' in r['trace'] for r in msg['churn']):
+        raise ValueError("nested churning: 'nestedChurn' must appear in at least one churn stack trace")
+
+    # nestedChurn() must appear in at least one churnalloc stack trace
+    if not any('nestedChurn' in r['trace'] for r in msg['churnalloc']):
+        raise ValueError("nested churning: 'nestedChurn' must appear in at least one churnalloc stack trace")
+
+    # At peak, two buffers are simultaneously live (old + new during realloc)
+    atMaxActual_t = totals(msg['atMaxActual'])
+    if atMaxActual_t['count'] != 2:
+        raise ValueError(f"nested churning: atMaxActual count must be 2 (two buffers live at realloc peak), got {atMaxActual_t['count']}")
+
+    if test_case['sum'] != 149935000:
+        raise ValueError(f"nested churning: expected sum 149935000, got {test_case['sum']}")
+
+
+def main():
+    """Main: parse and verify IntrusiveAllocProfiler output from stdin."""
+    try:
+        test_cases = read_test_cases()
+
+        if len(test_cases) != 6:
+            raise ValueError(f"Expected exactly 6 test cases, got {len(test_cases)}")
+
+        verify_vector_fill(test_cases[0])
+        verify_vector_fill_again(test_cases[1])
+        verify_nested_empty_outer(test_cases[2])
+        verify_nested_allocation(test_cases[3])
+        verify_nested_with_string_messages(test_cases[4])
+        verify_nested_churning(test_cases[5])
+
+        sys.exit(0)
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
#### PR description:

This PR adds ~~`IntrusiveTraceAllocMonitor`~~ `IntrusiveAllocProfiler` that differs from the existing `IntrusiveAllocMonitor` by providing stack traces of allocations and deallocations (and some analyses based on those stack traces). See the updated README for more details.

It uses the C++23 `std::stacktrace` for the stack traces, and is thus presently limited to CPP23 builds. The code is made to build only in CPP23 IB with `ifrelease` and `#ifdef`.

This tool was already useful in an investigation that led to https://github.com/cms-sw/cmssw/pull/50270.

Resolves https://github.com/cms-sw/framework-team/issues/1957

#### PR validation:

Added unit test passes in CPP23 build.