### PR TITLE
[16.0.X] Miscelleaneous adjustments to HLT Scouting DQM monitor elements

### DIFF
--- a/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
+++ b/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
@@ -1110,22 +1110,22 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   PF_dxy_n13_hist = ibook.book1DD("dxy_mu_minus", "PF #mu^{-} d_{xy} (cm);d_{xy} (cm);Entries", 100, -0.5, 0.5);
 
   PF_dzsig_211_hist =
-      ibook.book1DD("dzsig_posHad", "PF h^{+} d_{z} Signficance;d_{z}/#sigma_{dz};Entries", 100, 0.0, 10.0);
+      ibook.book1DD("dzsig_posHad", "PF h^{+} d_{z} Signficance;d_{z}/#sigma_{dz};Entries", 100, -10.0, 10.0);
   PF_dzsig_n211_hist =
-      ibook.book1DD("dzsig_negHad", "PF h^{-} d_{z} Signficance;d_{z}/#sigma_{dz};Entries", 100, 0.0, 10.0);
+      ibook.book1DD("dzsig_negHad", "PF h^{-} d_{z} Signficance;d_{z}/#sigma_{dz};Entries", 100, -10.0, 10.0);
   PF_dzsig_13_hist =
-      ibook.book1DD("dzsig_mu_plus", "PF #mu^{+} d_{z} Signficance;d_{z}/#sigma_{dz};Entries", 100, 0.0, 10.0);
+      ibook.book1DD("dzsig_mu_plus", "PF #mu^{+} d_{z} Signficance;d_{z}/#sigma_{dz};Entries", 100, -10.0, 10.0);
   PF_dzsig_n13_hist =
-      ibook.book1DD("dzsig_mu_minus", "PF #mu^{-} d_{z} Signficance;d_{z}/#sigma_{dz};Entries", 100, 0.0, 10.0);
+      ibook.book1DD("dzsig_mu_minus", "PF #mu^{-} d_{z} Signficance;d_{z}/#sigma_{dz};Entries", 100, -10.0, 10.0);
 
   PF_dxysig_211_hist =
-      ibook.book1DD("dxysig_posHad", "PF h^{+} d_{xy} Significance;d_{xy}/#sigma_{dxy};Entries", 100, 0.0, 10.0);
+      ibook.book1DD("dxysig_posHad", "PF h^{+} d_{xy} Significance;d_{xy}/#sigma_{dxy};Entries", 100, -10.0, 10.0);
   PF_dxysig_n211_hist =
-      ibook.book1DD("dxysig_negHad", "PF h^{-} d_{xy} Significance;d_{xy}/#sigma_{dxy};Entries", 100, 0.0, 10.0);
+      ibook.book1DD("dxysig_negHad", "PF h^{-} d_{xy} Significance;d_{xy}/#sigma_{dxy};Entries", 100, -10.0, 10.0);
   PF_dxysig_13_hist =
-      ibook.book1DD("dxysig_mu_plus", "PF #mu^{+} d_{xy} Significance;d_{xy}/#sigma_{dxy};Entries", 100, 0.0, 10.0);
+      ibook.book1DD("dxysig_mu_plus", "PF #mu^{+} d_{xy} Significance;d_{xy}/#sigma_{dxy};Entries", 100, -10.0, 10.0);
   PF_dxysig_n13_hist =
-      ibook.book1DD("dxysig_mu_minus", "PF #mu^{-} d_{xy} Significance;d_{xy}/#sigma_{dxy};Entries", 100, 0.0, 10.0);
+      ibook.book1DD("dxysig_mu_minus", "PF #mu^{-} d_{xy} Significance;d_{xy}/#sigma_{dxy};Entries", 100, -10.0, 10.0);
 
   // These variables are actually the difference between the PF candidate reconstructed kinematics and it's bestTrack ones.
   // This behaviour is governed by the "relativeTrackVars" parameter of HLTScoutingPFProducer
@@ -1505,30 +1505,30 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
         "ebRechitsN" + sfx, "Number of EB RecHits (" + lbl + "); number of EB recHits; Entries", 100, 0.0, 1000.0);
 
     ebRecHits_energy_hist[i] =
-        ibook.book1D("ebRechits_energy" + sfx,
-                     "Energy spectrum of EB RecHits (" + lbl + "); Energy of EB recHits (Gev); Entries",
-                     100,
-                     0.0,
-                     500.0);
+        ibook.book1DD("ebRechits_energy" + sfx,
+                      "Energy spectrum of EB RecHits (" + lbl + "); Energy of EB recHits (Gev); Entries",
+                      100,
+                      0.0,
+                      500.0);
 
-    ebRecHits_time_hist[i] = ibook.book1D("ebRechits_time" + sfx,
-                                          "Time of EB RecHits (" + lbl + "); Energy of EB recHits (ns); Entries",
-                                          200,
-                                          -100.,
-                                          100.0);
+    ebRecHits_time_hist[i] = ibook.book1DD("ebRechits_time" + sfx,
+                                           "Time of EB RecHits (" + lbl + "); Energy of EB recHits (ns); Entries",
+                                           200,
+                                           -100.,
+                                           100.0);
     eeRecHitsNumber_hist[i] = ibook.book1D(
         "eeRechitsN" + sfx, "Number of EE RecHits (" + lbl + "); number of EE recHits; Entries", 100, 0.0, 1000.0);
     eeRecHits_energy_hist[i] =
-        ibook.book1D("eeRechits_energy" + sfx,
-                     "Energy spectrum of EE RecHits (" + lbl + "); Energy of EE recHits (GeV); Entries",
-                     100,
-                     0.0,
-                     1000.0);
-    eeRecHits_time_hist[i] = ibook.book1D("eeRechits_time" + sfx,
-                                          "Time of EE RecHits (" + lbl + "); Time of EE recHits (ns); Entries",
-                                          200,
-                                          -100.0,
-                                          100.0);
+        ibook.book1DD("eeRechits_energy" + sfx,
+                      "Energy spectrum of EE RecHits (" + lbl + "); Energy of EE recHits (GeV); Entries",
+                      100,
+                      0.0,
+                      1000.0);
+    eeRecHits_time_hist[i] = ibook.book1DD("eeRechits_time" + sfx,
+                                           "Time of EE RecHits (" + lbl + "); Time of EE recHits (ns); Entries",
+                                           200,
+                                           -100.0,
+                                           100.0);
 
     ebRecHitsEtaPhiMap[i] = ibook.book2D("ebRecHitsEtaPhitMap" + sfx,
                                          "Occupancy map of EB rechits (" + lbl + ");ieta;iphi;Entries",
@@ -1587,11 +1587,11 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
                      2000.0);
 
     hbheRecHits_energy_hist[i] =
-        ibook.book1D(name + "Rechits_energy",
-                     "Energy spectrum of " + subdet + " RecHits; Energy of " + subdet + " recHits (GeV); RecHits",
-                     100,
-                     0.0,
-                     200.0);
+        ibook.book1DD(name + "Rechits_energy",
+                      "Energy spectrum of " + subdet + " RecHits; Energy of " + subdet + " recHits (GeV); RecHits",
+                      100,
+                      0.0,
+                      200.0);
 
     // Energy > 5 GeV histograms
     hbheRecHits_energy_egt5_hist[i] = ibook.book1D(
@@ -1602,11 +1602,11 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
         30.0);
 
     hbheRecHits_time_hist[i] =
-        ibook.book1D(name + "Rechits_time",
-                     "Time of " + subdet + " RecHits; Time of " + subdet + " recHits (ns); RecHits",
-                     100,
-                     0.,
-                     30.0);
+        ibook.book1DD(name + "Rechits_time",
+                      "Time of " + subdet + " RecHits; Time of " + subdet + " recHits (ns); RecHits",
+                      100,
+                      0.,
+                      30.0);
 
     // Energy > 5 GeV histograms
     hbheRecHits_time_egt5_hist[i] =

--- a/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
@@ -32,11 +32,6 @@ else:
 #    input = cms.untracked.int32(100)
 #)
 
-# import beamspot
-from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer as _onlineBeamSpotProducer
-process.hltOnlineBeamSpot = _onlineBeamSpotProducer.clone()
-
-
 process.load("DQM.Integration.config.environment_cfi")
 
 process.dqmEnv.subSystemFolder = 'NGT'
@@ -53,6 +48,10 @@ process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 # Condition for lxplus: change and possibly customise the GT
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
 #process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
+
+# import beamspot
+from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer as _onlineBeamSpotProducer
+process.hltOnlineBeamSpot = _onlineBeamSpotProducer.clone()
 
 ### for pp collisions
 process.load("DQM.HLTEvF.ScoutingCollectionMonitor_cfi")
@@ -73,13 +72,25 @@ process.ScoutingPi0MonitorOnline.isolationPtRatio = 0.8
 process.ScoutingPi0MonitorOnline.asymmetryCut = 0.85
 process.ScoutingPi0MonitorOnline.pairMaxDr = 0.1
 
+# needed by ScoutingMuonPropertiesMonitor
+process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
+process.load("DQM.HLTEvF.ScoutingMuonMonitoring_cff")
+process.ScoutingMuonPropertiesMonitorOnline.OutputInternalPath = "NGT/ScoutingOnline/Muons/Properties"
+
+process.load("DQM.HLTEvF.ScoutingRechitMonitoring_cff")
+process.ScoutingEBRechitAnalyzerOnline.topFolderName  = 'NGT/ScoutingOnline/EBRechits'
+process.ScoutingEBCleanedRechitAnalyzerOnline.topFolderName = 'NGT/ScoutingOnline/EBCleanedRechits'
+process.ScoutingHBHERechitAnalyzerOnline.topFolderName = 'NGT/ScoutingOnline/HBHERechits'
+
 process.dqmcommon = cms.Sequence(process.dqmEnv
                                * process.dqmSaver)#*process.dqmSaverPB)
 
 process.p = cms.Path(process.dqmcommon *
                      process.hltOnlineBeamSpot *
                      process.scoutingCollectionMonitor *
+                     process.ScoutingRecHitsMonitoring *
                      process.ScoutingDileptonMonitorOnline *
+                     process.ScoutingMuonPropertiesMonitorOnline *
                      process.ScoutingPi0MonitorOnline)
 
 ### process customizations included here

--- a/HLTriggerOffline/Scouting/plugins/ScoutingPi0Analyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingPi0Analyzer.cc
@@ -112,104 +112,106 @@ void ScoutingPi0Analyzer::fillDescriptions(edm::ConfigurationDescriptions& descr
 void ScoutingPi0Analyzer::bookHistSet(DQMStore::IBooker& ibook, Pi0Histograms& h, const std::string& suffix) {
   // Input Kinematics
   h.h_input_pt = ibook.book1D(("h_input_pt_" + suffix).c_str(),
-                              ("Input Photon p_{T} (" + suffix + ")#gamma ;p_{T} [GeV];Entries").c_str(),
+                              ("Input Photon p_{T} (" + suffix + ");#gamma p_{T} [GeV];Photons").c_str(),
                               50,
                               0,
                               20);
   h.h_input_eta = ibook.book1D(("h_input_eta_" + suffix).c_str(),
-                               ("Input Photon #eta (" + suffix + ")#gamma ;#eta;Entries").c_str(),
+                               ("Input Photon #eta (" + suffix + ");#gamma #eta;Photons").c_str(),
                                60,
                                -3.0,
                                3.0);
   h.h_input_phi = ibook.book1D(("h_input_phi_" + suffix).c_str(),
-                               ("Input Photon #phi (" + suffix + ");#gamma #phi;Entries").c_str(),
+                               ("Input Photon #phi (" + suffix + ");#gamma #phi [rad];Photons").c_str(),
                                64,
                                -3.2,
                                3.2);
 
   // Selected Kinematics
   h.h_sel_pt = ibook.book1D(("h_sel_pt_" + suffix).c_str(),
-                            ("Selected Photon p_{T} (" + suffix + ");#gamma p_{T} [GeV];Entries").c_str(),
+                            ("Selected Photon p_{T} (" + suffix + ");#gamma p_{T} [GeV];Photons").c_str(),
                             50,
                             0,
                             20);
   h.h_sel_eta = ibook.book1D(("h_sel_eta_" + suffix).c_str(),
-                             ("Selected Photon #eta (" + suffix + ");#gamma #eta;Entries").c_str(),
+                             ("Selected Photon #eta (" + suffix + ");#gamma #eta;Photons").c_str(),
                              60,
                              -3.0,
                              3.0);
   h.h_sel_phi = ibook.book1D(("h_sel_phi_" + suffix).c_str(),
-                             ("Selected Photon #phi (" + suffix + ");#gamma #phi;Entries").c_str(),
+                             ("Selected Photon #phi (" + suffix + ");#gamma #phi [rad];Photons").c_str(),
                              64,
                              -3.2,
                              3.2);
 
   // Cut Variables: Isolation
   h.h_iso_maxPtRatio = ibook.book1D(("h_iso_maxPtRatio_" + suffix).c_str(),
-                                    ("Max Hadron p_{T} / Photon p_{T} in Cone (" + suffix + ");Ratio;Entries").c_str(),
+                                    ("Max Hadron p_{T} / Photon p_{T} in Cone (" + suffix + ");Ratio;Photons").c_str(),
                                     50,
                                     0,
                                     2.0);
   h.h_iso_minDr = ibook.book1D(("h_iso_minDr_" + suffix).c_str(),
-                               ("Min #Delta R #gamma to Hadron (" + suffix + ");#Delta R(#gamma,had);Entries").c_str(),
+                               ("Min #Delta R #gamma to Hadron (" + suffix + ");#Delta R(#gamma,had);Photons").c_str(),
                                50,
                                0,
                                0.5);
 
   // Cut Variables: Pairs
   h.h_pair_pt = ibook.book1D(("h_pair_pt_" + suffix).c_str(),
-                             ("Diphoton p_{T} (" + suffix + ");#gamma#gamma p_{T} [GeV];Entries").c_str(),
+                             ("Diphoton p_{T} (" + suffix + ");#gamma#gamma p_{T} [GeV];Photon Pairs").c_str(),
                              50,
                              0,
                              50);
-  h.h_pair_asym = ibook.book1D(
-      ("h_pair_asym_" + suffix).c_str(),
-      ("Diphoton Energy Asymmetry (" + suffix + ");|E_{#gamma 1}-E_{#gamma 2}|/(E_{#gamma 1}+E_{#gamma 2});Entries")
-          .c_str(),
-      50,
-      0,
-      1.0);
+  h.h_pair_asym = ibook.book1D(("h_pair_asym_" + suffix).c_str(),
+                               ("Diphoton Energy Asymmetry (" + suffix +
+                                ");|E_{#gamma 1}-E_{#gamma 2}|/(E_{#gamma 1}+E_{#gamma 2});Photon Pairs")
+                                   .c_str(),
+                               50,
+                               0,
+                               1.0);
   h.h_pair_dr = ibook.book1D(("h_pair_dr_" + suffix).c_str(),
-                             ("Diphoton #Delta R (" + suffix + ");#Delta R(#gamma,#gamma);Entries").c_str(),
+                             ("Diphoton #Delta R (" + suffix + ");#Delta R(#gamma,#gamma);Photon Pairs").c_str(),
                              50,
                              0,
                              1.0);
 
   // Selected final di-photons plots
-  h.h_selpair_mass = ibook.book1D(("h_mass_" + suffix).c_str(),
-                                  ("Diphoton Invariant Mass (" + suffix + ");M_{#gamma#gamma} [GeV];Entries").c_str(),
-                                  100,
-                                  0,
-                                  1.0);
+  h.h_selpair_mass =
+      ibook.book1D(("h_mass_" + suffix).c_str(),
+                   ("Diphoton Invariant Mass (" + suffix + ");M_{#gamma#gamma} [GeV];Photon Pairs").c_str(),
+                   100,
+                   0,
+                   1.0);
 
-  h.h_selpair_pt = ibook.book1D(("h_selpair_pt_" + suffix).c_str(),
-                                ("Selected Diphoton p_{T} (" + suffix + ");#gamma#gamma p_{T} [GeV];Entries").c_str(),
-                                50,
-                                0,
-                                50);
+  h.h_selpair_pt =
+      ibook.book1D(("h_selpair_pt_" + suffix).c_str(),
+                   ("Selected Diphoton p_{T} (" + suffix + ");#gamma#gamma p_{T} [GeV];Photon Pairs").c_str(),
+                   50,
+                   0,
+                   50);
 
   // Selected final photons kinematics
   h.h_selpair_leadPt =
       ibook.book1D(("h_selpair_leadPt_" + suffix).c_str(),
-                   ("Leading Photon p_{T} (" + suffix + ");leading #gamma p_{T} [GeV];Entries").c_str(),
+                   ("Leading Photon p_{T} (" + suffix + ");leading #gamma p_{T} [GeV];Photon Pairs").c_str(),
                    50,
                    0,
                    50);
   h.h_selpair_leadEta = ibook.book1D(("h_selpair_leadEta_" + suffix).c_str(),
-                                     ("Leading Photon #eta (" + suffix + ");leading #gamma #eta;Entries").c_str(),
+                                     ("Leading Photon #eta (" + suffix + ");leading #gamma #eta;Photons").c_str(),
                                      60,
                                      -3.0,
                                      3.0);
 
   h.h_selpair_subleadPt =
       ibook.book1D(("h_selpair_subleadPt_" + suffix).c_str(),
-                   ("Subleading Photon p_{T} (" + suffix + ");subleading #gamma p_{T} [GeV];Entries").c_str(),
+                   ("Subleading Photon p_{T} (" + suffix + ");subleading #gamma p_{T} [GeV];Photons").c_str(),
                    50,
                    0,
                    50);
   h.h_selpair_subleadEta =
       ibook.book1D(("h_selpair_subleadEta_" + suffix).c_str(),
-                   ("Subleading Photon #eta (" + suffix + ");subleading #gamma #eta;Entries").c_str(),
+                   ("Subleading Photon #eta (" + suffix + ");subleading #gamma #eta;Photons").c_str(),
                    60,
                    -3.0,
                    3.0);

--- a/HLTriggerOffline/Scouting/plugins/ScoutingRecHitAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingRecHitAnalyzer.cc
@@ -170,6 +170,18 @@ template <typename RecHitType>
 void ScoutingRecHitAnalyzer<RecHitType>::bookHistograms(DQMStore::IBooker& ibooker,
                                                         edm::Run const&,
                                                         edm::EventSetup const&) {
+  auto book2D = [&](auto&&... args) {
+    auto h = ibooker.book2D(std::forward<decltype(args)>(args)...);
+    h->setOption("colz");
+    return h;
+  };
+
+  auto bookProfile2D = [&](auto&&... args) {
+    auto h = ibooker.bookProfile2D(std::forward<decltype(args)>(args)...);
+    h->setOption("colz");
+    return h;
+  };
+
   ibooker.setCurrentFolder(topFolderName_);
   for (auto const& trigger_name : trigger_names_) {
     ibooker.setCurrentFolder(topFolderName_ + "/" + trigger_name);
@@ -177,49 +189,49 @@ void ScoutingRecHitAnalyzer<RecHitType>::bookHistograms(DQMStore::IBooker& ibook
       // 1D histograms
       number_histograms_.push_back(ibooker.book1D("number", "Number or RecHits;RecHits Number;Events", 100, 0., 1000.));
       energy_histograms_.push_back(
-          ibooker.book1D("energy", "Energy of RecHits;RecHit Energy (GeV);RecHits", 100, 0., 20.));
-      time_histograms_.push_back(ibooker.book1D("time", "Time of RecHits;RecHit Time (ns);RecHits", 200, -100., 100.));
+          ibooker.book1DD("energy", "Energy of RecHits;RecHit Energy (GeV);RecHits", 100, 0., 20.));
+      time_histograms_.push_back(ibooker.book1DD("time", "Time of RecHits;RecHit Time (ns);RecHits", 200, -100., 100.));
 
       // 2D histograms
-      energy_time_histograms_.push_back(ibooker.book2D(
+      energy_time_histograms_.push_back(book2D(
           "energy_time", "RecHit Time vs Energy;Energy (GeV);Time (ns);Entries", 100, 0., 20., 100, -100., 100.));
       ieta_iphi_histograms_.push_back(
-          ibooker.book2D("ieta_iphi", "RecHit i#phi vs i#eta;i#eta;i#phi;Entries", 171, -85.5, 85.5, 360, 0.5, 360.5));
-      eta_phi_histograms_.push_back(ibooker.book2D("eta_phi",
-                                                   "RecHit #phi vs #eta;#eta;#phi (rad);Entries",
-                                                   170,
-                                                   -85 * kDegToRad,
-                                                   85 * kDegToRad,
-                                                   360,
-                                                   -M_PI,
-                                                   M_PI));
+          book2D("ieta_iphi", "RecHit i#phi vs i#eta;i#eta;i#phi;Entries", 171, -85.5, 85.5, 360, 0.5, 360.5));
+      eta_phi_histograms_.push_back(book2D("eta_phi",
+                                           "RecHit #phi vs #eta;#eta;#phi (rad);Entries",
+                                           170,
+                                           -85 * kDegToRad,
+                                           85 * kDegToRad,
+                                           360,
+                                           -M_PI,
+                                           M_PI));
 
       // 2D profiles
-      ieta_iphi_energy_profiles_.push_back(ibooker.bookProfile2D(
+      ieta_iphi_energy_profiles_.push_back(bookProfile2D(
           "ieta_iphi_energy", "mean RecHit Energy;i#eta;i#phi;mean Energy", 171, -85.5, 85.5, 360, 0.5, 360.5, 0, 20));
-      eta_phi_energy_profiles_.push_back(ibooker.bookProfile2D("eta_phi_energy",
-                                                               "mean RecHit Energy;#eta;#phi (rad);mean Energy",
-                                                               170,
-                                                               -85 * kDegToRad,
-                                                               85 * kDegToRad,
-                                                               360,
-                                                               -M_PI,
-                                                               M_PI,
-                                                               0,
-                                                               20));
+      eta_phi_energy_profiles_.push_back(bookProfile2D("eta_phi_energy",
+                                                       "mean RecHit Energy;#eta;#phi (rad);mean Energy",
+                                                       170,
+                                                       -85 * kDegToRad,
+                                                       85 * kDegToRad,
+                                                       360,
+                                                       -M_PI,
+                                                       M_PI,
+                                                       0,
+                                                       20));
 
-      ieta_iphi_time_profiles_.push_back(ibooker.bookProfile2D(
+      ieta_iphi_time_profiles_.push_back(bookProfile2D(
           "ieta_iphi_time", "Mean RecHit time;i#eta;i#phi;mean Time", 171, -85.5, 85.5, 360, 0.5, 360.5, 0, 20));
-      eta_phi_time_profiles_.push_back(ibooker.bookProfile2D("eta_phi_time",
-                                                             "Mean RecHit time;#eta;#phi (rad);mean Time",
-                                                             170,
-                                                             -85 * kDegToRad,
-                                                             85 * kDegToRad,
-                                                             360,
-                                                             -M_PI,
-                                                             M_PI,
-                                                             0,
-                                                             20));
+      eta_phi_time_profiles_.push_back(bookProfile2D("eta_phi_time",
+                                                     "Mean RecHit time;#eta;#phi (rad);mean Time",
+                                                     170,
+                                                     -85 * kDegToRad,
+                                                     85 * kDegToRad,
+                                                     360,
+                                                     -M_PI,
+                                                     M_PI,
+                                                     0,
+                                                     20));
 
     } else if constexpr (std::is_same<RecHitType, Run3ScoutingHBHERecHit>()) {
       std::vector<double> eta_edges(59);
@@ -248,46 +260,46 @@ void ScoutingRecHitAnalyzer<RecHitType>::bookHistograms(DQMStore::IBooker& ibook
       // 1D histograms
       number_histograms_.push_back(ibooker.book1D("number", "Number of RecHits;RecHits Number;Events", 100, 0., 2000.));
       energy_histograms_.push_back(
-          ibooker.book1D("energy", "Energy of RecHits;RecHit Energy (GeV);RecHits", 100, 0., 20.));
-      time_histograms_.push_back(ibooker.book1D("time", "Time of RecHits;RecHit Time (ns);RecHits", 100, 0., 30.));
+          ibooker.book1DD("energy", "Energy of RecHits;RecHit Energy (GeV);RecHits", 100, 0., 20.));
+      time_histograms_.push_back(ibooker.book1DD("time", "Time of RecHits;RecHit Time (ns);RecHits", 100, 0., 30.));
 
       // 2D histograms
-      energy_time_histograms_.push_back(ibooker.book2D(
-          "energy_time", "RecHit Time vs Energy;Energy (GeV);Time (ns);Entries", 100., 0., 50., 100., 0, 30.));
+      energy_time_histograms_.push_back(
+          book2D("energy_time", "RecHit Time vs Energy;Energy (GeV);Time (ns);Entries", 100., 0., 50., 100., 0, 30.));
 
       ieta_iphi_histograms_.push_back(
-          ibooker.book2D("ieta_iphi", "RecHit i#phi vs i#eta;i#eta;i#phi;Entries", 59, -29.5, 29.5, 72, 0.5, 72.5));
+          book2D("ieta_iphi", "RecHit i#phi vs i#eta;i#eta;i#phi;Entries", 59, -29.5, 29.5, 72, 0.5, 72.5));
 
       // 2D profiles
-      ieta_iphi_energy_profiles_.push_back(ibooker.bookProfile2D(
+      ieta_iphi_energy_profiles_.push_back(bookProfile2D(
           "ieta_iphi_energy", "mean RecHit Energy;i#eta;i#phi;mean Energy", 59, -29.5, 29.5, 72, 0.5, 72.5, 0, 100.));
 
-      ieta_iphi_time_profiles_.push_back(ibooker.bookProfile2D(
+      ieta_iphi_time_profiles_.push_back(bookProfile2D(
           "ieta_iphi_time", "mean RecHit time;i#eta;i#phi;mean Time", 59, -29.5, 29.5, 72, 0.5, 72.5, 0, 30.));
 
       // demote edges from double to float
       std::vector<float> eta_edges_f(eta_edges.begin(), eta_edges.end());
       std::vector<float> phi_edges_f(phi_edges.begin(), phi_edges.end());
-      eta_phi_histograms_.push_back(ibooker.book2D("eta_phi",
-                                                   "RecHit #phi vs #eta;#eta;#phi (rad);Entries",
-                                                   eta_edges_f.size() - 1,
-                                                   eta_edges_f.data(),
-                                                   phi_edges_f.size() - 1,
-                                                   phi_edges_f.data()));
+      eta_phi_histograms_.push_back(book2D("eta_phi",
+                                           "RecHit #phi vs #eta;#eta;#phi (rad);Entries",
+                                           eta_edges_f.size() - 1,
+                                           eta_edges_f.data(),
+                                           phi_edges_f.size() - 1,
+                                           phi_edges_f.data()));
 
-      eta_phi_energy_profiles_.push_back(ibooker.bookProfile2D("eta_phi_energy",
-                                                               "mean RecHit Energy;#eta;#phi (rad);mean Energy",
-                                                               eta_edges.size() - 1,
-                                                               eta_edges.data(),
-                                                               phi_edges.size() - 1,
-                                                               phi_edges.data()));
+      eta_phi_energy_profiles_.push_back(bookProfile2D("eta_phi_energy",
+                                                       "mean RecHit Energy;#eta;#phi (rad);mean Energy",
+                                                       eta_edges.size() - 1,
+                                                       eta_edges.data(),
+                                                       phi_edges.size() - 1,
+                                                       phi_edges.data()));
 
-      eta_phi_time_profiles_.push_back(ibooker.bookProfile2D("eta_phi_time",
-                                                             "mean RecHit Time;#eta;#phi (rad);mean Time",
-                                                             eta_edges.size() - 1,
-                                                             eta_edges.data(),
-                                                             phi_edges.size() - 1,
-                                                             phi_edges.data()));
+      eta_phi_time_profiles_.push_back(bookProfile2D("eta_phi_time",
+                                                     "mean RecHit Time;#eta;#phi (rad);mean Time",
+                                                     eta_edges.size() - 1,
+                                                     eta_edges.data(),
+                                                     phi_edges.size() - 1,
+                                                     phi_edges.data()));
     }
   }
 }


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/50377

#### PR description:

This PR introduces several improvements to the Scouting DQM monitoring used in the NGT online workflow.

Main changes:

- Replace several `book1D` calls with `book1DD` to ensure consistent histogram visibility in the DQM GUI (avoid capping out the number of entries to the maximum float in single precision).
- Extend the range of impact parameter significance histograms (`dzsig_*`,` dxysig_*`) from [0,10] to [-10,10].
- Improve axis labels in `ScoutingPi0Analyzer` for clarity and consistent object counting.
- Add automatic `colz` display option for 2D histograms and profiles in `ScoutingRecHitAnalyzer`.
- Enable additional scouting monitoring modules in `ngt_dqm_sourceclient-live_cfg.py`:
   - `ScoutingRecHitsMonitoring`
   - `ScoutingMuonPropertiesMonitorOnline`

These changes improve online monitoring coverage and visualization for the NGT demonstrator.

#### PR validation:

```bash
scram b runtests_TestDQMOnlineClient-ngt_dqm_sourceclient
scram b runtest_TestDQMOnlineClient-scouting_dqm_sourceclient
```

run fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/50377 for 2026 data-taking.