### PR TITLE
MTD digitization: update for SiPM saturation + time walk corrections for BTL

### DIFF
--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/BTLUncalibRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/BTLUncalibRecHitAlgo.cc
@@ -15,6 +15,7 @@ public:
         npeToADC_(conf.getParameter<std::vector<double>>("npeToADC")),
         npePerMeV_(conf.getParameter<double>("npePerMeV")),
         invADCPerMeV_(1. / (npeToADC_[1] * npePerMeV_)),
+        npeSaturationCorr_(conf.getParameter<std::vector<double>>("npeSaturationCorrection")),
         tdc_to_ns_(conf.getParameter<double>("tdcLSB_ns")),
         timeError_(conf.getParameter<std::string>("timeResolutionInNs")),
         timeWalkCorr_(conf.getParameter<std::string>("timeWalkCorrection")) {}
@@ -35,6 +36,7 @@ private:
   const std::vector<double> npeToADC_;
   const double npePerMeV_;
   const double invADCPerMeV_;
+  const std::vector<double> npeSaturationCorr_;
   const double tdc_to_ns_;
   const reco::FormulaEvaluator timeError_;
   const reco::FormulaEvaluator timeWalkCorr_;
@@ -57,14 +59,17 @@ FTLUncalibratedRecHit BTLUncalibRecHitAlgo::makeRecHit(const BTLDataFrame& dataF
 
   // --- Reconstruct amplitude and time of the crystal's right channel
   if (sampleRight.data() > 0) {
-    // Correct the time of the right SiPM for the time-walk
-    amplitude.first = double(sampleRight.data());
-    time.first = double(sampleRight.toa()) -
-                 timeWalkCorr_.evaluate(std::array<double, 1>{{amplitude.first}}, std::array<double, 1>{{0.0}});
-
     // Convert ADC counts to MeV and TDC counts to ns
-    amplitude.first = (double(sampleRight.data()) - npeToADC_[0]) * invADCPerMeV_;
-    time.first *= tdc_to_ns_;
+    amplitude.first = (double(sampleRight.data()) - npeToADC_[0]) / npeToADC_[1];
+    time.first = double(sampleRight.toa()) * tdc_to_ns_;
+
+    // Correction for SiPM saturation (just invert the function used to model this effect in BTLElectronicsSim)
+    float d = npeSaturationCorr_[1] * npeSaturationCorr_[1] + 4. * npeSaturationCorr_[0] * amplitude.first;
+    amplitude.first = (-npeSaturationCorr_[1] + sqrt(d)) / (2. * (npeSaturationCorr_[0]));
+    amplitude.first /= npePerMeV_;
+
+    // Correct the time of the right SiPM for the time-walk
+    time.first -= timeWalkCorr_.evaluate(std::array<double, 1>{{amplitude.first}}, std::array<double, 1>{{0.0}});
 
     flag |= 0x1;
     nHits += 1.;
@@ -72,14 +77,17 @@ FTLUncalibratedRecHit BTLUncalibRecHitAlgo::makeRecHit(const BTLDataFrame& dataF
 
   // --- Reconstruct amplitude and time of the crystal's left channel
   if (sampleLeft.data() > 0) {
-    // Correct the time of the left SiPM for the time-walk
-    amplitude.second = double(sampleLeft.data());
-    time.second = double(sampleLeft.toa()) -
-                  timeWalkCorr_.evaluate(std::array<double, 1>{{amplitude.second}}, std::array<double, 1>{{0.0}});
-
     // Convert ADC counts to MeV and TDC counts to ns
-    amplitude.second = (double(sampleLeft.data()) - npeToADC_[0]) * invADCPerMeV_;
-    time.second *= tdc_to_ns_;
+    amplitude.second = (double(sampleLeft.data()) - npeToADC_[0]) / npeToADC_[1];
+    time.second = double(sampleLeft.toa()) * tdc_to_ns_;
+
+    // Correction for SiPM saturation (just invert the function used to model this effect in BTLElectronicsSim)
+    float d = npeSaturationCorr_[1] * npeSaturationCorr_[1] + 4. * npeSaturationCorr_[0] * amplitude.second;
+    amplitude.second = (-npeSaturationCorr_[1] + sqrt(d)) / (2. * (npeSaturationCorr_[0]));
+    amplitude.second /= npePerMeV_;
+
+    // Correct the time of the left SiPM for the time-walk
+    time.second -= timeWalkCorr_.evaluate(std::array<double, 1>{{amplitude.second}}, std::array<double, 1>{{0.0}});
 
     flag |= (0x1 << 1);
     nHits += 1.;

--- a/RecoLocalFastTime/FTLRecProducers/python/mtdUncalibratedRecHits_cfi.py
+++ b/RecoLocalFastTime/FTLRecProducers/python/mtdUncalibratedRecHits_cfi.py
@@ -7,9 +7,10 @@ _barrelAlgo = cms.PSet(
     invLightSpeedLYSO = mtdDigitizer.barrelDigitizer.DeviceSimulation.LightCollectionSlope, # [ns/cm]
     npeToADC = mtdDigitizer.barrelDigitizer.ElectronicsSimulation.PulseQParam, # Npe to ADC counts conversion
     npePerMeV = mtdDigitizer.barrelDigitizer.DeviceSimulation.LightOutput, # [Npe/MeV]
+    npeSaturationCorrection = mtdDigitizer.barrelDigitizer.ElectronicsSimulation.SiPMSaturationParam, # effective Npe to true Npe conversion (SiPM saturation)
     tdcLSB_ns = cms.double(0.020), # [ns]
     timeResolutionInNs = cms.string("0.0593858*pow(x,-1.02826)+0.0156719"), # [ns]
-    timeWalkCorrection = cms.string("1.9e6/0.020*pow(9.389e5/0.0348*(x+22.5),-0.663)-7.5e-4*x-3.5e-3") # linear ad hoc correction for bias from global delay removal
+    timeWalkCorrection = cms.string("1.16946*pow(x,-0.671018)+0.0443454") # [ns]
 )
 
 _endcapAlgo = cms.PSet(

--- a/SLHCUpgradeSimulations/Configuration/python/aging.py
+++ b/SLHCUpgradeSimulations/Configuration/python/aging.py
@@ -262,7 +262,9 @@ def ageMTD(process,lumi):
             "time_over_thr1": [1.3e9, 9.58676, -2.51351e-10, 5.98501e-18, -3.326821e-27, -7.61576e-10, 13.21],
             "slew_rate": [1.3e9, -0.8, 8.7e-9, 11.1],
             "pulse_q": [-43.5, 0.0793],
-            "hit_time_res": "0.143789*pow(x,-1.09324)+0.0166063"
+            "hit_time_res": "0.143789*pow(x,-1.09324)+0.0166063",
+            "sipm_saturation": [-9.80E-06, 1.007],
+            "time_walk_corr":"2.40863*pow(x,-0.583148)+0.0545682"
         },
         3000: {
             "light_output": 1004.,
@@ -277,7 +279,9 @@ def ageMTD(process,lumi):
             "time_over_thr1": [1.3e9, 9.58676, -2.51351e-10, 5.98501e-18, -3.326821e-27, -7.61576e-10, 13.21],
             "slew_rate": [1.3e9, -0.8, 8.7e-9, 11.1],
             "pulse_q": [-34.3, 0.085],
-            "hit_time_res": "0.2567*pow(x,-1.10973)+0.0165099"
+            "hit_time_res": "0.2567*pow(x,-1.10973)+0.0165099",
+            "sipm_saturation": [-1.04E-05, 1.008],
+            "time_walk_corr":"3.42178*pow(x,-0.57758)+0.0448797"
         },
     }
 
@@ -286,7 +290,7 @@ def ageMTD(process,lumi):
             process.mix.digitizers.fastTimingLayer.barrelDigitizer.DeviceSimulation.LightOutput = cms.double(mtd_parameters[lumi]["light_output"])
             process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.LightOutput = cms.double(mtd_parameters[lumi]["light_output"])
             process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.PulseT2Threshold = cms.double(mtd_parameters[lumi]["pulse_t2_threshold"])
-            process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.PulseEThrershold = cms.double(mtd_parameters[lumi]["pulse_e_threshold"])
+            process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.PulseEThreshold = cms.double(mtd_parameters[lumi]["pulse_e_threshold"])
             process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.DarkCountRate  = cms.double(mtd_parameters[lumi]["dark_count_rate"])
             process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.SiPMGain = cms.double(mtd_parameters[lumi]["sipm_gain"])
             process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.PulseTbranchAParam = cms.vdouble(mtd_parameters[lumi]["pulse_tbranch_a"])
@@ -296,12 +300,13 @@ def ageMTD(process,lumi):
             process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.TimeOverThr1Param = cms.vdouble(mtd_parameters[lumi]["time_over_thr1"])
             process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.SlewRateParam = cms.vdouble(mtd_parameters[lumi]["slew_rate"])
             process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.PulseQParam = cms.vdouble(mtd_parameters[lumi]["pulse_q"])
+            process.mix.digitizers.fastTimingLayer.barrelDigitizer.ElectronicsSimulation.SiPMSaturationParam = cms.vdouble(mtd_parameters[lumi]["sipm_saturation"])
         # --- This is for the workflows with premixing:
         if hasattr(process,'mixData') and hasattr(process.mixData,'workers') and hasattr(process.mixData.workers,'mtdBarrel'):
             process.mixData.workers.mtdBarrel.DeviceSimulation.LightOutput = cms.double(mtd_parameters[lumi]["light_output"])
             process.mixData.workers.mtdBarrel.ElectronicsSimulation.LightOutput = cms.double(mtd_parameters[lumi]["light_output"])
             process.mixData.workers.mtdBarrel.ElectronicsSimulation.PulseT2Threshold = cms.double(mtd_parameters[lumi]["pulse_t2_threshold"])
-            process.mixData.workers.mtdBarrel.ElectronicsSimulation.PulseEThrershold = cms.double(mtd_parameters[lumi]["pulse_e_threshold"])
+            process.mixData.workers.mtdBarrel.ElectronicsSimulation.PulseEThreshold = cms.double(mtd_parameters[lumi]["pulse_e_threshold"])
             process.mixData.workers.mtdBarrel.ElectronicsSimulation.DarkCountRate  = cms.double(mtd_parameters[lumi]["dark_count_rate"])
             process.mixData.workers.mtdBarrel.ElectronicsSimulation.SiPMGain = cms.double(mtd_parameters[lumi]["sipm_gain"])
             process.mixData.workers.mtdBarrel.ElectronicsSimulation.PulseTbranchAParam = cms.vdouble(mtd_parameters[lumi]["pulse_tbranch_a"])
@@ -311,20 +316,13 @@ def ageMTD(process,lumi):
             process.mixData.workers.mtdBarrel.ElectronicsSimulation.TimeOverThr1Param = cms.vdouble(mtd_parameters[lumi]["time_over_thr1"])
             process.mixData.workers.mtdBarrel.ElectronicsSimulation.SlewRateParam = cms.vdouble(mtd_parameters[lumi]["slew_rate"])
             process.mixData.workers.mtdBarrel.ElectronicsSimulation.PulseQParam = cms.vdouble(mtd_parameters[lumi]["pulse_q"])
+            process.mixData.workers.mtdBarrel.ElectronicsSimulation.SiPMSaturationParam = cms.vdouble(mtd_parameters[lumi]["sipm_saturation"])
         # --- This is for the uncalibrated RecHit reconstruction:
         if hasattr(process,'mtdUncalibratedRecHits') and hasattr(process.mtdUncalibratedRecHits,'barrel'):
             process.mtdUncalibratedRecHits.barrel.npePerMeV = cms.double(mtd_parameters[lumi]["light_output"])
             process.mtdUncalibratedRecHits.barrel.npeToADC = cms.vdouble(mtd_parameters[lumi]["pulse_q"])
             process.mtdUncalibratedRecHits.barrel.timeResolutionInNs = cms.string(mtd_parameters[lumi]["hit_time_res"])
-            process.mtdUncalibratedRecHits.barrel.timeWalkCorrection = cms.string(
-                "{}/{}*pow({}/{}*(x-{}),{})".format( mtd_parameters[lumi]["time_at_thr1rise"][0],
-                                                     0.020, # [ns], TDC LSB
-                                                     mtd_parameters[lumi]["sipm_gain"],
-                                                     mtd_parameters[lumi]["pulse_q"][1],
-                                                     mtd_parameters[lumi]["pulse_q"][0],
-                                                     mtd_parameters[lumi]["time_at_thr1rise"][1]
-                )
-            )
+            process.mtdUncalibratedRecHits.barrel.timeWalkCorrection = cms.string(mtd_parameters[lumi]["time_walk_corr"])
 
     return process
 

--- a/SimFastTiming/FastTimingCommon/interface/BTLElectronicsSim.h
+++ b/SimFastTiming/FastTimingCommon/interface/BTLElectronicsSim.h
@@ -62,6 +62,8 @@ private:
 
   float pulse_qRes(const float& npe) const;
 
+  float effective_npe(const float& npe) const;
+
   static constexpr float sqrt2_ = 1.41421356f;
 
   static constexpr float tofhirClock_ = 6.25f;  // [ns]
@@ -104,6 +106,7 @@ private:
   const float sinPhi_;
   const float scintillatorDecayTimeInv_;
   const float sigmaConst2_;
+  const std::vector<double> paramSiPMSaturation_;
 
   const bool debug_;
 };

--- a/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
+++ b/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
@@ -23,7 +23,7 @@ _barrel_MTDDigitizer = cms.PSet(
         _common_BTLparameters,
         SigmaLCEpositionSlope     = cms.double(0.002),  # [1/cm] sigma of the LCE variation vs longitudinal position shift
         PulseT2Threshold          = cms.double(8.764),  # [uA] T2 threshold
-        PulseEThrershold          = cms.double(20.32),  # [uA] energy threshold (it corresponds to 1 MeV)
+        PulseEThreshold           = cms.double(20.32),  # [uA] energy threshold (it corresponds to 1 MeV)
         ChannelRearmMode          = cms.uint32(2),      # 0: the channel rearming is switched off
                                                         # 1: the channel is rearmed after the end-of-event signal
                                                         # 2: the channel is rearmed after ChannelRearmNClocks cycles of the TOFHiR clock
@@ -50,6 +50,7 @@ _barrel_MTDDigitizer = cms.PSet(
 
         PulseQParam               = cms.vdouble(-22.5, 0.0348), # pulse amplitude in ADC counts vs Npe
         PulseQResParam            = cms.vdouble(51., -0.88),    # relative amplitude resolution vs Npe
+        SiPMSaturationParam       = cms.vdouble(-8.54e-06, 1.034) # parametrization to account for SiPM saturation
         )
 
 

--- a/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
@@ -15,7 +15,7 @@ BTLElectronicsSim::BTLElectronicsSim(const edm::ParameterSet& pset, edm::Consume
       lcepositionSlope_(pset.getParameter<double>("LCEpositionSlope")),
       sigmaLCEpositionSlope_(pset.getParameter<double>("SigmaLCEpositionSlope")),
       pulseT2Threshold_(pset.getParameter<double>("PulseT2Threshold")),
-      pulseEThreshold_(pset.getParameter<double>("PulseEThrershold")),
+      pulseEThreshold_(pset.getParameter<double>("PulseEThreshold")),
       channelRearmMode_(pset.getParameter<uint32_t>("ChannelRearmMode")),
       channelRearmNClocks_(pset.getParameter<double>("ChannelRearmNClocks")),
       t1Delay_(pset.getParameter<double>("T1Delay")),
@@ -43,6 +43,7 @@ BTLElectronicsSim::BTLElectronicsSim(const edm::ParameterSet& pset, edm::Consume
       sinPhi_(0.5 * corrCoeff_ / cosPhi_),
       scintillatorDecayTimeInv_(1. / scintillatorDecayTime_),
       sigmaConst2_(sigmaTDC_ * sigmaTDC_ + sigmaClockGlobal_ * sigmaClockGlobal_),
+      paramSiPMSaturation_(pset.getParameter<std::vector<double>>("SiPMSaturationParam")),
 #ifdef EDM_ML_DEBUG
       debug_(true) {
 #else
@@ -131,18 +132,18 @@ void BTLElectronicsSim::run(const mtd::MTDSimHitDataAccumulator& input,
       // ================================================================================
 
       // --- Skip the hit if its amplitude is below the T2 threshold
-      if (pulse_tbranch_uA(npe[iside]) < pulseT2Threshold_) {
+      if (pulse_tbranch_uA(effective_npe(npe[iside])) < pulseT2Threshold_) {
         continue;
       }
 
       // --- Skip the hit if its amplitude is below the energy threshold
-      if (pulse_ebranch_uA(npe[iside]) < pulseEThreshold_) {
+      if (pulse_ebranch_uA(effective_npe(npe[iside])) < pulseEThreshold_) {
         continue;
       }
 
       // --- Add the T1 and T2 threshold crossing times on the pulse rising edge to the SimHit time
-      float finalToA1 = (it->second).hit_info[1 + 2 * iside][iBX] + time_at_Thr1Rise(npe[iside]);
-      float finalToA2 = (it->second).hit_info[1 + 2 * iside][iBX] + time_at_Thr2Rise(npe[iside]);
+      float finalToA1 = (it->second).hit_info[1 + 2 * iside][iBX] + time_at_Thr1Rise(effective_npe(npe[iside]));
+      float finalToA2 = (it->second).hit_info[1 + 2 * iside][iBX] + time_at_Thr2Rise(effective_npe(npe[iside]));
 
       // --- Loop over the earlier OOT hits in the current bar to determine the channel
       //     rearming time and estimate the photon flux arriving at the in-time BX
@@ -159,16 +160,17 @@ void BTLElectronicsSim::run(const mtd::MTDSimHitDataAccumulator& input,
 
         // Calculate the channel rearming time for this hit (the hit is skipped if it
         // doesn't pass the T2 threshold or an earlier hit is holding the channel)
-        float time_at_T1_oot = time_at_Thr1Rise(hit_npe_oot);
+        float time_at_T1_oot = time_at_Thr1Rise(effective_npe(hit_npe_oot));
 
-        if (channelRearmMode_ && pulse_tbranch_uA(hit_npe_oot) > pulseT2Threshold_ &&
+        if (channelRearmMode_ && pulse_tbranch_uA(effective_npe(hit_npe_oot)) > pulseT2Threshold_ &&
             hit_time_oot + time_at_T1_oot > channelRearmingTime) {
-          channelRearmingTime = rearming_time(hit_time_oot + time_at_T1_oot, hit_npe_oot);
+          channelRearmingTime = rearming_time(hit_time_oot + time_at_T1_oot, effective_npe(hit_npe_oot));
         }
 
         // Rate of photons from earlier OOT hits in the current BTL cell
         if (smearTimeForOOTtails_) {
-          rate_oot += hit_npe_oot * exp(hit_time_oot * scintillatorDecayTimeInv_) * scintillatorDecayTimeInv_;
+          rate_oot += hit_npe_oot * exp(hit_time_oot * scintillatorDecayTimeInv_) *
+                      scintillatorDecayTimeInv_;  /// ?? which Npe?
         }
 
       }  // ibx loop
@@ -180,7 +182,8 @@ void BTLElectronicsSim::run(const mtd::MTDSimHitDataAccumulator& input,
 
       // --- Uncertainty due to photons from earlier OOT hits in the current BTL cell
       if (smearTimeForOOTtails_ && rate_oot > 0.) {
-        float sigma_oot = sqrt(rate_oot * scintillatorRiseTime_) * scintillatorDecayTime_ / npe[iside];
+        float sigma_oot =
+            sqrt(rate_oot * scintillatorRiseTime_) * scintillatorDecayTime_ / npe[iside];  // which npe ????
         float smearing_oot = CLHEP::RandGaussQ::shoot(hre, 0., sigma_oot);
         finalToA1 += smearing_oot;
         finalToA2 += smearing_oot;
@@ -224,12 +227,12 @@ void BTLElectronicsSim::run(const mtd::MTDSimHitDataAccumulator& input,
       // ================================================================================
 
       // --- Get the pulse amplitude in ADC counts
-      float amp = pulse_q(npe[iside]);
+      float amp = pulse_q(effective_npe(npe[iside]));
 
       // --- Get the average uncertainty on the pulse amplitude (here the unsmeared
       //     value of Npe is used, because the parameterization of the relative
       //     amplitude resolution already includes the photostatistics fluctuation)
-      float sigma_amp = amp * pulse_qRes((it->second).hit_info[2 * iside][iBX]);
+      float sigma_amp = amp * pulse_qRes(effective_npe((it->second).hit_info[2 * iside][iBX]));
 
       charge_adc[iside] = CLHEP::RandGaussQ::shoot(hre, amp, sigma_amp);
 
@@ -385,4 +388,8 @@ float BTLElectronicsSim::pulse_q(const float& npe) const { return paramPulseQ_[0
 
 float BTLElectronicsSim::pulse_qRes(const float& npe) const {
   return paramPulseQRes_[0] * std::pow(npe, paramPulseQRes_[1]);
+}
+
+float BTLElectronicsSim::effective_npe(const float& npe) const {
+  return paramSiPMSaturation_[0] * npe * npe + paramSiPMSaturation_[1] * npe;
 }


### PR DESCRIPTION
#### PR description:
This PR updates the digitization of the BTL detector to include the effect of SiPM saturation.
The simple model used to account for the SiPM saturation effect is described in Section 3.1 of [DN-2025/013](https://cms.cern.ch/iCMS/user/noteinfo?cmsnoteid=CMS%20DN-2025/013) and was presented in the [BTL general meeting of 28/01/2026](https://indico.cern.ch/event/1641055/#59-update-experimental-input-t).
The time walk corrections used in the local reconstruction have been updated accordingly, thanks to @casarsa.

#### PR validation:
The code compiles and was tested successfully on TTbar 34424.0 workflow.