### PR TITLE
Update of the GTs in autoCond with the new 2026 L1T Menu Tag L1Menu_Collisions2026_v1_1_0_xml

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -110,11 +110,11 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2025 detector for Heavy Ion
     'phase1_2025_realistic_hi'     :    '151X_mcRun3_2025_realistic_HI_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2026
-    'phase1_2026_design'           :    '160X_mcRun3_2026_design_v1',
+    'phase1_2026_design'           :    '160X_mcRun3_2026_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2026
-    'phase1_2026_realistic'        :    '160X_mcRun3_2026_realistic_v5',
+    'phase1_2026_realistic'        :    '160X_mcRun3_2026_realistic_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2026, Strip tracker in DECO mode
-    'phase1_2026_cosmics'          :    '160X_mcRun3_2026cosmics_realistic_deco_v1',
+    'phase1_2026_cosmics'          :    '160X_mcRun3_2026cosmics_realistic_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2026 detector for Heavy Ion
     'phase1_2026_realistic_hi'     :    '151X_mcRun3_2025_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for Phase2

--- a/Configuration/AlCa/python/autoCondModifiers.py
+++ b/Configuration/AlCa/python/autoCondModifiers.py
@@ -115,7 +115,7 @@ def autoCondRelValForRun3(autoCond):
 
     GlobalTagRelValForRun3 = {}
     L1GtTriggerMenuForRelValForRun3 =    ','.join( ['L1Menu_Collisions2015_25nsStage1_v5' , "L1GtTriggerMenuRcd",             connectionString, "", "2023-01-28 12:00:00.000"] )
-    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2026_v1_0_0_xml'    , "L1TUtmTriggerMenuRcd",           connectionString, "", "2026-02-04 14:35:13.000"] )
+    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2026_v1_1_0_xml'    , "L1TUtmTriggerMenuRcd",           connectionString, "", "2026-03-12 11:22:42.000"] )
 
     for key,val in autoCond.items():
         if 'run3_data' in key or 'run3_hlt' in key :


### PR DESCRIPTION

#### PR description:

Update of the GTs in autoCond with the new 2026 L1T Menu Tag L1Menu_Collisions2026_v1_1_0_xml, as requested in https://cms-talk.web.cern.ch/t/gt-mc-data-relval-update-of-the-gt-with-the-new-2026-l1t-menu-tag-l1menu-collisions2026-v1-1-0-xml/142934

The new MC GTs are the following:
- [160X_mcRun3_2026_realistic_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/160X_mcRun3_2026_realistic_v6)
- [160X_mcRun3_2026_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/160X_mcRun3_2026_design_v2)
- [160X_mcRun3_2026cosmics_realistic_deco_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/160X_mcRun3_2026cosmics_realistic_deco_v2)

Their differences with respect to their previous versions in autoCond are simply:
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/160X_mcRun3_2026_realistic_v5/160X_mcRun3_2026_realistic_v6
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/160X_mcRun3_2026_design_v1/160X_mcRun3_2026_design_v2
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/160X_mcRun3_2026cosmics_realistic_deco_v2/160X_mcRun3_2026cosmics_realistic_deco_v1

#### PR validation:

Rely on bot tests

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

It will be backported in CMSSW_16_0_X (and also to CMSSW_16_1_X, if the master has already moved to CMSSW_16_2_X by the time this PR is merged)
