### PR TITLE
[EVOLUTION_X] Move `CrossingFramePlaybackInfoNew` and `PileupSummaryInfo` to io_v1 namespace

### DIFF
--- a/SimDataFormats/CrossingFrame/interface/CrossingFramePlaybackInfoNew.h
+++ b/SimDataFormats/CrossingFrame/interface/CrossingFramePlaybackInfoNew.h
@@ -19,43 +19,49 @@
 #include <vector>
 #include <utility>
 
-class CrossingFramePlaybackInfoNew {
-public:
-  // con- and destructors
+namespace io_v1 {
 
-  CrossingFramePlaybackInfoNew() {}
-  CrossingFramePlaybackInfoNew(int minBunch, int maxBunch, unsigned int maxNbSources);
+  class CrossingFramePlaybackInfoNew {
+  public:
+    // con- and destructors
 
-  ~CrossingFramePlaybackInfoNew() {}
+    CrossingFramePlaybackInfoNew() {}
+    CrossingFramePlaybackInfoNew(int minBunch, int maxBunch, unsigned int maxNbSources);
 
-  typedef std::vector<edm::SecondaryEventIDAndFileInfo>::iterator iterator;
-  typedef std::pair<iterator, iterator> range;
+    ~CrossingFramePlaybackInfoNew() {}
 
-  // setter
-  void setInfo(std::vector<edm::SecondaryEventIDAndFileInfo>& eventInfo, std::vector<size_t>& sizes) {
-    sizes_.swap(sizes);
-    eventInfo_.swap(eventInfo);
-  }
+    typedef std::vector<edm::SecondaryEventIDAndFileInfo>::iterator iterator;
+    typedef std::pair<iterator, iterator> range;
 
-  // getters
-  std::vector<edm::SecondaryEventIDAndFileInfo>::const_iterator getEventId(size_t offset) const {
-    std::vector<edm::SecondaryEventIDAndFileInfo>::const_iterator iter = eventInfo_.begin();
-    std::advance(iter, offset);
-    return iter;
-  }
+    // setter
+    void setInfo(std::vector<edm::SecondaryEventIDAndFileInfo>& eventInfo, std::vector<size_t>& sizes) {
+      sizes_.swap(sizes);
+      eventInfo_.swap(eventInfo);
+    }
 
-  size_t getNumberOfEvents(int bunchIdx, size_t sourceNumber) const {
-    return sizes_[((bunchIdx - minBunch_) * maxNbSources_) + sourceNumber];
-  }
+    // getters
+    std::vector<edm::SecondaryEventIDAndFileInfo>::const_iterator getEventId(size_t offset) const {
+      std::vector<edm::SecondaryEventIDAndFileInfo>::const_iterator iter = eventInfo_.begin();
+      std::advance(iter, offset);
+      return iter;
+    }
 
-  //private:
+    size_t getNumberOfEvents(int bunchIdx, size_t sourceNumber) const {
+      return sizes_[((bunchIdx - minBunch_) * maxNbSources_) + sourceNumber];
+    }
 
-  // we need the same info for each bunchcrossing
-  unsigned int maxNbSources_;
-  int nBcrossings_;
-  std::vector<size_t> sizes_;
-  std::vector<edm::SecondaryEventIDAndFileInfo> eventInfo_;
-  int minBunch_;
-};
+    //private:
+
+    // we need the same info for each bunchcrossing
+    unsigned int maxNbSources_;
+    int nBcrossings_;
+    std::vector<size_t> sizes_;
+    std::vector<edm::SecondaryEventIDAndFileInfo> eventInfo_;
+    int minBunch_;
+  };
+
+}  // namespace io_v1
+
+using CrossingFramePlaybackInfoNew = io_v1::CrossingFramePlaybackInfoNew;
 
 #endif

--- a/SimDataFormats/CrossingFrame/interface/CrossingFramePlaybackInfoNewFwd.h
+++ b/SimDataFormats/CrossingFrame/interface/CrossingFramePlaybackInfoNewFwd.h
@@ -1,6 +1,10 @@
 #ifndef SimDataFormats_CrossingFrame_CrossingFramePlaybackInfoNewFwd_h
 #define SimDataFormats_CrossingFrame_CrossingFramePlaybackInfoNewFwd_h
 
-class CrossingFramePlaybackInfoNew;
+namespace io_v1 {
+  class CrossingFramePlaybackInfoNew;
+}  // namespace io_v1
+
+using CrossingFramePlaybackInfoNew = io_v1::CrossingFramePlaybackInfoNew;
 
 #endif

--- a/SimDataFormats/CrossingFrame/src/CrossingFramePlaybackInfoNew.cc
+++ b/SimDataFormats/CrossingFrame/src/CrossingFramePlaybackInfoNew.cc
@@ -1,9 +1,13 @@
 #include "SimDataFormats/CrossingFrame/interface/CrossingFramePlaybackInfoNew.h"
 #include <utility>
 
-CrossingFramePlaybackInfoNew::CrossingFramePlaybackInfoNew(int minBunch, int maxBunch, unsigned int maxNbSources)
-    : maxNbSources_(maxNbSources),
-      nBcrossings_(maxBunch - minBunch + 1),
-      sizes_(maxNbSources_ * nBcrossings_, 0U),
-      eventInfo_(),
-      minBunch_(minBunch) {}
+namespace io_v1 {
+
+  CrossingFramePlaybackInfoNew::CrossingFramePlaybackInfoNew(int minBunch, int maxBunch, unsigned int maxNbSources)
+      : maxNbSources_(maxNbSources),
+        nBcrossings_(maxBunch - minBunch + 1),
+        sizes_(maxNbSources_ * nBcrossings_, 0U),
+        eventInfo_(),
+        minBunch_(minBunch) {}
+
+}  // namespace io_v1

--- a/SimDataFormats/CrossingFrame/src/classes_def.xml
+++ b/SimDataFormats/CrossingFrame/src/classes_def.xml
@@ -1,11 +1,11 @@
 <lcgdict>
   <!-- persistent="false" qualifier for non-wrappers is deprecated. Will be removed when no longer needed.-->
   <class name="CrossingFrame<PSimHit>" persistent="false"/>
-  <class name="CrossingFramePlaybackInfoNew" ClassVersion="10">
-   <version ClassVersion="10" checksum="1434967133"/>
+  <class name="io_v1::CrossingFramePlaybackInfoNew" ClassVersion="3">
+   <version ClassVersion="3" checksum="505051357"/>
   </class>
-  <class name="CrossingFramePlaybackInfoExtended" ClassVersion="10">
-   <version ClassVersion="10" checksum="3172490198"/>
+  <class name="CrossingFramePlaybackInfoExtended" ClassVersion="3">
+   <version ClassVersion="3" checksum="3172490198"/>
   </class>
   <class name="CrossingFrame<PCaloHit>" persistent="false"/>
   <class name="CrossingFrame<SimTrack>" persistent="false"/>
@@ -21,7 +21,7 @@
   <class name="edm::Wrapper<PCrossingFrame<PCaloHit> >"/>
   <class name="edm::Wrapper<PCrossingFrame<PSimHit> >"/>
   <class name="edm::Wrapper<PCrossingFrame<edm::HepMCProduct> >"/>
-  <class name="edm::Wrapper<CrossingFramePlaybackInfoNew>"/>
+  <class name="edm::Wrapper<io_v1::CrossingFramePlaybackInfoNew>"/>
   <class name="edm::Wrapper<CrossingFramePlaybackInfoExtended>"/>
   <class name="edm::Wrapper<CrossingFrame<SimTrack> >" persistent="false"/>
   <class name="edm::Wrapper<CrossingFrame<SimVertex> >" persistent="false"/>

--- a/SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h
+++ b/SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h
@@ -19,80 +19,86 @@ Usage: purely descriptive
 #include <vector>
 #include <string>
 
-class PileupSummaryInfo {
-public:
-  PileupSummaryInfo() {}
+namespace io_v1 {
 
-  PileupSummaryInfo(const int num_PU_vertices,
-                    const std::vector<float>& zpositions,
-                    const std::vector<float>& times,  // may be empty
-                    const std::vector<float>& sumpT_lowpT,
-                    const std::vector<float>& sumpT_highpT,
-                    const std::vector<int>& ntrks_lowpT,
-                    const std::vector<int>& ntrks_highpT);
+  class PileupSummaryInfo {
+  public:
+    PileupSummaryInfo() {}
 
-  PileupSummaryInfo(const int num_PU_vertices,
-                    const std::vector<float>& zpositions,
-                    const std::vector<float>& times,  // may be empty
-                    const std::vector<float>& sumpT_lowpT,
-                    const std::vector<float>& sumpT_highpT,
-                    const std::vector<int>& ntrks_lowpT,
-                    const std::vector<int>& ntrks_highpT,
-                    int bunchCrossing);
+    PileupSummaryInfo(const int num_PU_vertices,
+                      const std::vector<float>& zpositions,
+                      const std::vector<float>& times,  // may be empty
+                      const std::vector<float>& sumpT_lowpT,
+                      const std::vector<float>& sumpT_highpT,
+                      const std::vector<int>& ntrks_lowpT,
+                      const std::vector<int>& ntrks_highpT);
 
-  PileupSummaryInfo(const int num_PU_vertices,
-                    const std::vector<float>& zpositions,
-                    const std::vector<float>& times,  // may be empty
-                    const std::vector<float>& sumpT_lowpT,
-                    const std::vector<float>& sumpT_highpT,
-                    const std::vector<int>& ntrks_lowpT,
-                    const std::vector<int>& ntrks_highpT,
-                    const std::vector<edm::EventID>& eventInfo,
-                    const std::vector<float>& pT_hats,
-                    int bunchCrossing,
-                    float TrueNumInteractions,
-                    int bunchSpacing);
+    PileupSummaryInfo(const int num_PU_vertices,
+                      const std::vector<float>& zpositions,
+                      const std::vector<float>& times,  // may be empty
+                      const std::vector<float>& sumpT_lowpT,
+                      const std::vector<float>& sumpT_highpT,
+                      const std::vector<int>& ntrks_lowpT,
+                      const std::vector<int>& ntrks_highpT,
+                      int bunchCrossing);
 
-  PileupSummaryInfo(const int num_PU_vertices,
-                    const std::vector<float>& instLumi,
-                    const std::vector<edm::EventID>& eventInfo);
+    PileupSummaryInfo(const int num_PU_vertices,
+                      const std::vector<float>& zpositions,
+                      const std::vector<float>& times,  // may be empty
+                      const std::vector<float>& sumpT_lowpT,
+                      const std::vector<float>& sumpT_highpT,
+                      const std::vector<int>& ntrks_lowpT,
+                      const std::vector<int>& ntrks_highpT,
+                      const std::vector<edm::EventID>& eventInfo,
+                      const std::vector<float>& pT_hats,
+                      int bunchCrossing,
+                      float TrueNumInteractions,
+                      int bunchSpacing);
 
-  ~PileupSummaryInfo();
+    PileupSummaryInfo(const int num_PU_vertices,
+                      const std::vector<float>& instLumi,
+                      const std::vector<edm::EventID>& eventInfo);
 
-  const int getPU_NumInteractions() const { return num_PU_vertices_; }
-  const std::vector<float>& getPU_zpositions() const { return zpositions_; }
-  bool has_times() const { return !times_.empty(); }
-  const std::vector<float>& getPU_times() const { return times_; }
-  const std::vector<float>& getPU_sumpT_lowpT() const { return sumpT_lowpT_; }
-  const std::vector<float>& getPU_sumpT_highpT() const { return sumpT_highpT_; }
-  const std::vector<int>& getPU_ntrks_lowpT() const { return ntrks_lowpT_; }
-  const std::vector<int>& getPU_ntrks_highpT() const { return ntrks_highpT_; }
-  const std::vector<float>& getPU_instLumi() const { return instLumi_; }
-  const std::vector<edm::EventID>& getPU_EventID() const { return eventInfo_; }
-  const std::vector<float>& getPU_pT_hats() const { return pT_hats_; }
-  const int getBunchCrossing() const { return bunchCrossing_; }
-  const int getBunchSpacing() const { return bunchSpacing_; }
-  const float getTrueNumInteractions() const { return TrueNumInteractions_; }
+    ~PileupSummaryInfo();
 
-private:
-  // for "standard" pileup: we have MC Truth information for these
+    const int getPU_NumInteractions() const { return num_PU_vertices_; }
+    const std::vector<float>& getPU_zpositions() const { return zpositions_; }
+    bool has_times() const { return !times_.empty(); }
+    const std::vector<float>& getPU_times() const { return times_; }
+    const std::vector<float>& getPU_sumpT_lowpT() const { return sumpT_lowpT_; }
+    const std::vector<float>& getPU_sumpT_highpT() const { return sumpT_highpT_; }
+    const std::vector<int>& getPU_ntrks_lowpT() const { return ntrks_lowpT_; }
+    const std::vector<int>& getPU_ntrks_highpT() const { return ntrks_highpT_; }
+    const std::vector<float>& getPU_instLumi() const { return instLumi_; }
+    const std::vector<edm::EventID>& getPU_EventID() const { return eventInfo_; }
+    const std::vector<float>& getPU_pT_hats() const { return pT_hats_; }
+    const int getBunchCrossing() const { return bunchCrossing_; }
+    const int getBunchSpacing() const { return bunchSpacing_; }
+    const float getTrueNumInteractions() const { return TrueNumInteractions_; }
 
-  int num_PU_vertices_;
-  std::vector<float> zpositions_;
-  std::vector<float> times_;
-  std::vector<float> sumpT_lowpT_;
-  std::vector<float> sumpT_highpT_;
-  std::vector<int> ntrks_lowpT_;
-  std::vector<int> ntrks_highpT_;
-  std::vector<edm::EventID> eventInfo_;
-  std::vector<float> pT_hats_;
-  int bunchCrossing_;
-  int bunchSpacing_;
-  float TrueNumInteractions_;
+  private:
+    // for "standard" pileup: we have MC Truth information for these
 
-  // for DataMixer pileup, we only have raw information:
+    int num_PU_vertices_;
+    std::vector<float> zpositions_;
+    std::vector<float> times_;
+    std::vector<float> sumpT_lowpT_;
+    std::vector<float> sumpT_highpT_;
+    std::vector<int> ntrks_lowpT_;
+    std::vector<int> ntrks_highpT_;
+    std::vector<edm::EventID> eventInfo_;
+    std::vector<float> pT_hats_;
+    int bunchCrossing_;
+    int bunchSpacing_;
+    float TrueNumInteractions_;
 
-  std::vector<float> instLumi_;
-};
+    // for DataMixer pileup, we only have raw information:
+
+    std::vector<float> instLumi_;
+  };
+
+}  // namespace io_v1
+
+using PileupSummaryInfo = io_v1::PileupSummaryInfo;
 
 #endif

--- a/SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfoFwd.h
+++ b/SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfoFwd.h
@@ -1,6 +1,10 @@
 #ifndef SimDataFormats_PileupSummaryInfo_PileupSummaryInfoFwd_h
 #define SimDataFormats_PileupSummaryInfo_PileupSummaryInfoFwd_h
 
-class PileupSummaryInfo;
+namespace io_v1 {
+  class PileupSummaryInfo;
+}  // namespace io_v1
+
+using PileupSummaryInfo = io_v1::PileupSummaryInfo;
 
 #endif

--- a/SimDataFormats/PileupSummaryInfo/src/PileupSummaryInfo.cc
+++ b/SimDataFormats/PileupSummaryInfo/src/PileupSummaryInfo.cc
@@ -12,66 +12,70 @@
 
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 
-PileupSummaryInfo::PileupSummaryInfo(const int num_PU_vertices,
-                                     const std::vector<float>& zpositions,
-                                     const std::vector<float>& times,
-                                     const std::vector<float>& sumpT_lowpT,
-                                     const std::vector<float>& sumpT_highpT,
-                                     const std::vector<int>& ntrks_lowpT,
-                                     const std::vector<int>& ntrks_highpT)
-    : num_PU_vertices_(num_PU_vertices),
-      zpositions_(zpositions),
-      times_(times),
-      sumpT_lowpT_(sumpT_lowpT),
-      sumpT_highpT_(sumpT_highpT),
-      ntrks_lowpT_(ntrks_lowpT),
-      ntrks_highpT_(ntrks_highpT) {}
+namespace io_v1 {
 
-PileupSummaryInfo::PileupSummaryInfo(const int num_PU_vertices,
-                                     const std::vector<float>& zpositions,
-                                     const std::vector<float>& times,
-                                     const std::vector<float>& sumpT_lowpT,
-                                     const std::vector<float>& sumpT_highpT,
-                                     const std::vector<int>& ntrks_lowpT,
-                                     const std::vector<int>& ntrks_highpT,
-                                     int bunchCrossing)
-    : num_PU_vertices_(num_PU_vertices),
-      zpositions_(zpositions),
-      times_(times),
-      sumpT_lowpT_(sumpT_lowpT),
-      sumpT_highpT_(sumpT_highpT),
-      ntrks_lowpT_(ntrks_lowpT),
-      ntrks_highpT_(ntrks_highpT),
-      bunchCrossing_(bunchCrossing) {}
+  PileupSummaryInfo::PileupSummaryInfo(const int num_PU_vertices,
+                                       const std::vector<float>& zpositions,
+                                       const std::vector<float>& times,
+                                       const std::vector<float>& sumpT_lowpT,
+                                       const std::vector<float>& sumpT_highpT,
+                                       const std::vector<int>& ntrks_lowpT,
+                                       const std::vector<int>& ntrks_highpT)
+      : num_PU_vertices_(num_PU_vertices),
+        zpositions_(zpositions),
+        times_(times),
+        sumpT_lowpT_(sumpT_lowpT),
+        sumpT_highpT_(sumpT_highpT),
+        ntrks_lowpT_(ntrks_lowpT),
+        ntrks_highpT_(ntrks_highpT) {}
 
-PileupSummaryInfo::PileupSummaryInfo(const int num_PU_vertices,
-                                     const std::vector<float>& zpositions,
-                                     const std::vector<float>& times,
-                                     const std::vector<float>& sumpT_lowpT,
-                                     const std::vector<float>& sumpT_highpT,
-                                     const std::vector<int>& ntrks_lowpT,
-                                     const std::vector<int>& ntrks_highpT,
-                                     const std::vector<edm::EventID>& eventInfo,
-                                     const std::vector<float>& pThats,
-                                     int bunchCrossing,
-                                     float TrueNumInteractions,
-                                     int bunchSpacing)
-    : num_PU_vertices_(num_PU_vertices),
-      zpositions_(zpositions),
-      times_(times),
-      sumpT_lowpT_(sumpT_lowpT),
-      sumpT_highpT_(sumpT_highpT),
-      ntrks_lowpT_(ntrks_lowpT),
-      ntrks_highpT_(ntrks_highpT),
-      eventInfo_(eventInfo),
-      pT_hats_(pThats),
-      bunchCrossing_(bunchCrossing),
-      bunchSpacing_(bunchSpacing),
-      TrueNumInteractions_(TrueNumInteractions) {}
+  PileupSummaryInfo::PileupSummaryInfo(const int num_PU_vertices,
+                                       const std::vector<float>& zpositions,
+                                       const std::vector<float>& times,
+                                       const std::vector<float>& sumpT_lowpT,
+                                       const std::vector<float>& sumpT_highpT,
+                                       const std::vector<int>& ntrks_lowpT,
+                                       const std::vector<int>& ntrks_highpT,
+                                       int bunchCrossing)
+      : num_PU_vertices_(num_PU_vertices),
+        zpositions_(zpositions),
+        times_(times),
+        sumpT_lowpT_(sumpT_lowpT),
+        sumpT_highpT_(sumpT_highpT),
+        ntrks_lowpT_(ntrks_lowpT),
+        ntrks_highpT_(ntrks_highpT),
+        bunchCrossing_(bunchCrossing) {}
 
-PileupSummaryInfo::PileupSummaryInfo(const int num_PU_vertices,
-                                     const std::vector<float>& instLumi,
-                                     const std::vector<edm::EventID>& eventInfo)
-    : num_PU_vertices_(num_PU_vertices), eventInfo_(eventInfo), instLumi_(instLumi) {}
+  PileupSummaryInfo::PileupSummaryInfo(const int num_PU_vertices,
+                                       const std::vector<float>& zpositions,
+                                       const std::vector<float>& times,
+                                       const std::vector<float>& sumpT_lowpT,
+                                       const std::vector<float>& sumpT_highpT,
+                                       const std::vector<int>& ntrks_lowpT,
+                                       const std::vector<int>& ntrks_highpT,
+                                       const std::vector<edm::EventID>& eventInfo,
+                                       const std::vector<float>& pThats,
+                                       int bunchCrossing,
+                                       float TrueNumInteractions,
+                                       int bunchSpacing)
+      : num_PU_vertices_(num_PU_vertices),
+        zpositions_(zpositions),
+        times_(times),
+        sumpT_lowpT_(sumpT_lowpT),
+        sumpT_highpT_(sumpT_highpT),
+        ntrks_lowpT_(ntrks_lowpT),
+        ntrks_highpT_(ntrks_highpT),
+        eventInfo_(eventInfo),
+        pT_hats_(pThats),
+        bunchCrossing_(bunchCrossing),
+        bunchSpacing_(bunchSpacing),
+        TrueNumInteractions_(TrueNumInteractions) {}
 
-PileupSummaryInfo::~PileupSummaryInfo() {}
+  PileupSummaryInfo::PileupSummaryInfo(const int num_PU_vertices,
+                                       const std::vector<float>& instLumi,
+                                       const std::vector<edm::EventID>& eventInfo)
+      : num_PU_vertices_(num_PU_vertices), eventInfo_(eventInfo), instLumi_(instLumi) {}
+
+  PileupSummaryInfo::~PileupSummaryInfo() {}
+
+}  // namespace io_v1

--- a/SimDataFormats/PileupSummaryInfo/src/classes_def.xml
+++ b/SimDataFormats/PileupSummaryInfo/src/classes_def.xml
@@ -1,22 +1,18 @@
 <lcgdict>
-  <class name="PileupSummaryInfo" ClassVersion="13">
-   <version ClassVersion="13" checksum="1980628569"/>
-   <version ClassVersion="12" checksum="231481749"/>
-   <version ClassVersion="11" checksum="1526417022"/>
+  <class name="io_v1::PileupSummaryInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="612161497"/>
   </class>
-  <class name="std::vector<PileupSummaryInfo>"/>  
-  <class name="edm::Wrapper<PileupSummaryInfo>"/>
-  <class name="edm::Wrapper<std::vector<PileupSummaryInfo> >"/>
-  <class name="PileupMixingContent" ClassVersion="12">
-   <version ClassVersion="11" checksum="468037571"/>
-   <version ClassVersion="12" checksum="624720677"/>
+  <class name="std::vector<io_v1::PileupSummaryInfo>"/>
+  <class name="edm::Wrapper<io_v1::PileupSummaryInfo>"/>
+  <class name="edm::Wrapper<std::vector<io_v1::PileupSummaryInfo> >"/>
+  <class name="PileupMixingContent" ClassVersion="3">
+   <version ClassVersion="3" checksum="624720677"/>
   </class>
   <class name="std::vector<PileupMixingContent>"/>  
   <class name="edm::Wrapper<PileupMixingContent>"/>
   <class name="edm::Wrapper<std::vector<PileupMixingContent> >"/>
-  <class name="PileupVertexContent" ClassVersion="4">
-   <version ClassVersion="4" checksum="1959165237"/>
-   <version ClassVersion="3" checksum="3263569137"/>
+  <class name="PileupVertexContent" ClassVersion="3">
+   <version ClassVersion="3" checksum="1959165237"/>
   </class>
   <class name="std::vector<PileupVertexContent>"/>  
   <class name="edm::Wrapper<PileupVertexContent>"/>


### PR DESCRIPTION
#### PR description:

Part of the EVOLUTION_X work.

Resolves https://github.com/cms-sw/framework-team/issues/2025

#### PR validation:

Code compiles