### PR TITLE
Alpaka  multi-block optimization for MD PF clusterizer

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/Common.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/Common.h
@@ -1,0 +1,28 @@
+#ifndef PFClusterProducer_interface_Common_h
+#define PFClusterProducer_interface_Common_h
+
+#include <cstdint>
+
+namespace cms::alpakaintrinsics {
+  namespace warp {
+
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+    using warp_mask_t = std::uint32_t;  // 32-bit masks on NVIDIA
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+    using warp_mask_t = std::uint64_t;  // 64-bit masks on AMD (!)
+#endif
+
+#else
+    using warp_mask_t = std::uint32_t;  // for host (no-op)
+#endif
+
+  }  // namespace warp
+}  // namespace cms::alpakaintrinsics
+
+struct ccSeed {
+  uint32_t value;
+  uint32_t key;
+};
+
+#endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFMultiDepthClusteringCCLabelsSoA.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFMultiDepthClusteringCCLabelsSoA.h
@@ -9,6 +9,7 @@ namespace reco {
   GENERATE_SOA_LAYOUT(PFMultiDepthClusteringCCLabelsSoALayout,
                       SOA_COLUMN(int, mdpf_topoId),
                       SOA_COLUMN(int, workl),
+                      SOA_SCALAR(int, ncomponents),
                       SOA_SCALAR(int, topH),
                       SOA_SCALAR(int, posH),
                       SOA_SCALAR(int, topL),

--- a/RecoParticleFlow/PFClusterProducer/interface/PFMultiDepthECLCCEpilogueArgsHostCollection.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFMultiDepthECLCCEpilogueArgsHostCollection.h
@@ -1,0 +1,11 @@
+#ifndef RecoParticleFlow_PFClusterProducer_interface_PFMultiDepthECLCCEpilogueArgsHostCollection_h
+#define RecoParticleFlow_PFClusterProducer_interface_PFMultiDepthECLCCEpilogueArgsHostCollection_h
+
+#include "RecoParticleFlow/PFClusterProducer/interface/PFMultiDepthECLCCEpilogueArgsSoA.h"
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+
+namespace reco {
+  using PFMultiDepthECLCCEpilogueArgsHostCollection = PortableHostCollection<PFMultiDepthECLCCEpilogueArgsSoA>;
+}
+
+#endif  // RecoParticleFlow_PFClusterProducer_interface_PFMultiDepthECLCCEpilogueArgsHostCollection_h

--- a/RecoParticleFlow/PFClusterProducer/interface/PFMultiDepthECLCCEpilogueArgsSoA.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFMultiDepthECLCCEpilogueArgsSoA.h
@@ -1,0 +1,22 @@
+#ifndef RecoParticleFlow_PFClusterProducer_interface_PFMultiDepthECLCCEpilogueArgsSoA_h
+#define RecoParticleFlow_PFClusterProducer_interface_PFMultiDepthECLCCEpilogueArgsSoA_h
+
+#include "DataFormats/SoATemplate/interface/SoACommon.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+
+namespace reco {
+
+  GENERATE_SOA_LAYOUT(PFMultiDepthECLCCEpilogueArgsSoALayout,
+                      SOA_COLUMN(uint32_t, ccRHFOffset),
+                      SOA_COLUMN(uint32_t, ccRHFSize),
+                      SOA_COLUMN(uint32_t, rootMap),
+                      SOA_COLUMN(uint32_t, rootLocalMap),
+                      SOA_COLUMN(uint32_t, blockRHFOffset),
+                      SOA_COLUMN(uint64_t, ccEnergySeed),
+                      SOA_SCALAR(int, blockCount),
+                      SOA_SCALAR(int, size))
+
+  using PFMultiDepthECLCCEpilogueArgsSoA = PFMultiDepthECLCCEpilogueArgsSoALayout<>;
+}  // namespace reco
+
+#endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFMultiDepthECLCCPrologueArgsHostCollection.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFMultiDepthECLCCPrologueArgsHostCollection.h
@@ -1,0 +1,11 @@
+#ifndef RecoParticleFlow_PFClusterProducer_interface_PFMultiDepthECLCCPrologueArgsHostCollection_h
+#define RecoParticleFlow_PFClusterProducer_interface_PFMultiDepthECLCCPrologueArgsHostCollection_h
+
+#include "RecoParticleFlow/PFClusterProducer/interface/PFMultiDepthECLCCPrologueArgsSoA.h"
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+
+namespace reco {
+  using PFMultiDepthECLCCPrologueArgsHostCollection = PortableHostCollection<PFMultiDepthECLCCPrologueArgsSoA>;
+}
+
+#endif  // RecoParticleFlow_PFClusterProducer_interface_PFMultiDepthECLCCPrologueArgsHostCollection_h

--- a/RecoParticleFlow/PFClusterProducer/interface/PFMultiDepthECLCCPrologueArgsSoA.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFMultiDepthECLCCPrologueArgsSoA.h
@@ -1,0 +1,20 @@
+#ifndef RecoParticleFlow_PFClusterProducer_interface_PFMultiDepthECLCCPrologueArgsSoA_h
+#define RecoParticleFlow_PFClusterProducer_interface_PFMultiDepthECLCCPrologueArgsSoA_h
+
+#include "DataFormats/SoATemplate/interface/SoACommon.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+
+namespace reco {
+
+  GENERATE_SOA_LAYOUT(PFMultiDepthECLCCPrologueArgsSoALayout,
+                      SOA_COLUMN(uint32_t, ccOffset),
+                      SOA_COLUMN(uint32_t, ccLocalOffset),
+                      SOA_COLUMN(uint32_t, ccSize),
+                      SOA_COLUMN(uint32_t, blockInternCCSize),
+                      SOA_SCALAR(int, blockCount),
+                      SOA_SCALAR(int, size))
+
+  using PFMultiDepthECLCCPrologueArgsSoA = PFMultiDepthECLCCPrologueArgsSoALayout<>;
+}  // namespace reco
+
+#endif

--- a/RecoParticleFlow/PFClusterProducer/interface/alpaka/PFMultiDepthECLCCEpilogueArgsDeviceCollection.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/alpaka/PFMultiDepthECLCCEpilogueArgsDeviceCollection.h
@@ -1,0 +1,14 @@
+#ifndef RecoParticleFlow_PFRecHitProducer_interface_alpaka_PFMultiDepthECLCCEpilogueArgsDeviceCollection_h
+#define RecoParticleFlow_PFRecHitProducer_interface_alpaka_PFMultiDepthECLCCEpilogueArgsDeviceCollection_h
+
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+#include "RecoParticleFlow/PFClusterProducer/interface/PFMultiDepthECLCCEpilogueArgsSoA.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::reco {
+
+  using PFMultiDepthECLCCEpilogueArgsDeviceCollection = PortableCollection<::reco::PFMultiDepthECLCCEpilogueArgsSoA>;
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::reco
+
+#endif

--- a/RecoParticleFlow/PFClusterProducer/interface/alpaka/PFMultiDepthECLCCPrologueArgsDeviceCollection.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/alpaka/PFMultiDepthECLCCPrologueArgsDeviceCollection.h
@@ -1,0 +1,14 @@
+#ifndef RecoParticleFlow_PFRecHitProducer_interface_alpaka_PFMultiDepthECLCCPrologueArgsDeviceCollection_h
+#define RecoParticleFlow_PFRecHitProducer_interface_alpaka_PFMultiDepthECLCCPrologueArgsDeviceCollection_h
+
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+#include "RecoParticleFlow/PFClusterProducer/interface/PFMultiDepthECLCCPrologueArgsSoA.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::reco {
+
+  using PFMultiDepthECLCCPrologueArgsDeviceCollection = PortableCollection<::reco::PFMultiDepthECLCCPrologueArgsSoA>;
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::reco
+
+#endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterWarpIntrinsics.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterWarpIntrinsics.h
@@ -2,23 +2,13 @@
 #define PFClusterProducer_plugins_alpaka_PFMultiDepthClusterWarpIntrinsics_h
 
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/Common.h"
 
 #include <type_traits>
 #include <concepts>
 
 namespace cms::alpakaintrinsics {
   namespace warp {
-
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-    using warp_mask_t = std::uint32_t;  // 32-bit masks on NVIDIA
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-    using warp_mask_t = std::uint64_t;  // 64-bit masks on AMD (!)
-#endif
-
-#else
-    using warp_mask_t = std::uint32_t;  // for host (no-op)
-#endif
 
 #ifdef __HIP_DEVICE_COMPILE__
 
@@ -171,7 +161,7 @@ namespace cms::alpakaintrinsics {
  * @param val  Per-lane value to be compared across the warp.
  *
  * @return A warp mask with bits set for lanes (enabled in 'mask') whose
- *         'val' equals the calling lane’s value.
+ *         'val' equals the calling lane's value.
  */
     template <alpaka::concepts::Acc TAcc, typename T>
       requires std::is_arithmetic_v<T>

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterizer.dev.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterizer.dev.cc
@@ -12,6 +12,14 @@
 #include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterECLCC.h"
 #include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCEpilogue.h"
 
+#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFMultiDepthECLCCPrologueArgsDeviceCollection.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFMultiDepthECLCCEpilogueArgsDeviceCollection.h"
+
+#include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCPrologueMultiBlock.h"
+
+#include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCEpilogueMultiBlock.h"
+#include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCFinalizeEpilogue.h"
+
 /**
  * @file PFMultiDepthClusterizer.dev.cc
  * @brief Alpaka-based particle flow multi-depth clustering using Alpaka.
@@ -53,10 +61,16 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::eclcc {
                   const reco::PFRecHitDeviceCollection& pfRecHit,
                   const PFMultiDepthClusterParams* params,
                   const unsigned int nClusters) {
+    constexpr bool enable_multiblock_prologue = !std::is_same_v<Device, alpaka::DevCpu>;
+    constexpr bool enable_multiblock_epilogue = !std::is_same_v<Device, alpaka::DevCpu>;
+
     const unsigned int wExtend = alpaka::getPreferredWarpSize(alpaka::getDev(queue));
-    const unsigned int maxThreadsPerBlock = nClusters <= 768 ? 768 : 256;
-    const unsigned int threadsPerBlock = std::min(static_cast<alpaka_common::Idx>(maxThreadsPerBlock),
-                                                  ::cms::alpakatools::round_up_by(nClusters, wExtend));
+
+    // for ROCm/CUDA backend should be a multiple of the warp size which can be 32 or 64
+    const unsigned int threadsPerBlock =
+        std::is_same_v<Device, alpaka::DevCpu>
+            ? nClusters
+            : (nClusters > 768 ? 256 : ::cms::alpakatools::round_up_by(nClusters, wExtend));
 
     const unsigned int blocks = ::cms::alpakatools::divide_up_by(nClusters, threadsPerBlock);
 
@@ -77,38 +91,106 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::eclcc {
                         mdpfCCLabels.view(),
                         mdpfClusteringVars.view(),
                         params);
-    // ECL-CC prologue:
-    if (threadsPerBlock <= 256) {
-      constexpr unsigned int max_w_items = 8;
-      if (blocks == 1) {
+
+    const bool do_opt_prologue = enable_multiblock_prologue && (blocks > 1);
+
+    if (do_opt_prologue) {
+      reco::PFMultiDepthECLCCPrologueArgsDeviceCollection prologueArgs{queue, static_cast<int>(nClusters)};
+
+      prologueArgs.zeroInitialise(queue);
+
+      alpaka::exec<Acc1D>(queue,
+                          ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                          ECLCCComputeExternNeighsKernel{},
+                          prologueArgs.view(),
+                          mdpfCCLabels.view());
+
+      if (threadsPerBlock <= 256) {
+        constexpr unsigned int max_w_items = 8;
         alpaka::exec<Acc1D>(queue,
                             ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
-                            ECLCCPrologueKernel<max_w_items>{},
+                            ECLCCPrologueComputeOffsetsKernel<max_w_items>{},
+                            prologueArgs.view(),
+                            mdpfCCLabels.view());
+
+        alpaka::exec<Acc1D>(queue,
+                            ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                            ECLCCFinalizePrologueKernel<max_w_items>{},
+                            mdpfClusteringEdgeVars.view(),
+                            prologueArgs.view(),
+                            mdpfCCLabels.view());
+      } else if (threadsPerBlock <= 512) {
+        constexpr unsigned int max_w_items = 16;
+        alpaka::exec<Acc1D>(queue,
+                            ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                            ECLCCPrologueComputeOffsetsKernel<max_w_items>{},
+                            prologueArgs.view(),
+                            mdpfCCLabels.view());
+
+        alpaka::exec<Acc1D>(queue,
+                            ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                            ECLCCFinalizePrologueKernel<max_w_items>{},
+                            mdpfClusteringEdgeVars.view(),
+                            prologueArgs.view(),
+                            mdpfCCLabels.view());
+
+      } else {
+        constexpr unsigned int max_w_items = 32;
+        alpaka::exec<Acc1D>(queue,
+                            ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                            ECLCCPrologueComputeOffsetsKernel<max_w_items>{},
+                            prologueArgs.view(),
+                            mdpfCCLabels.view());
+
+        alpaka::exec<Acc1D>(queue,
+                            ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                            ECLCCFinalizePrologueKernel<max_w_items>{},
+                            mdpfClusteringEdgeVars.view(),
+                            prologueArgs.view(),
+                            mdpfCCLabels.view());
+      }
+
+      alpaka::exec<Acc1D>(queue,
+                          ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                          ECLCCLoadCrossBlockNeighKernel{},
+                          mdpfClusteringEdgeVars.view(),
+                          prologueArgs.view(),
+                          mdpfCCLabels.view());
+
+    } else {
+      if constexpr (std::is_same_v<Device, alpaka::DevCpu>) {
+        alpaka::exec<Acc1D>(queue,
+                            ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                            ECLCCPrologueNaiveKernel{},
                             mdpfClusteringEdgeVars.view(),
                             mdpfCCLabels.view());
       } else {
-        constexpr bool multi_block = true;
-        alpaka::exec<Acc1D>(queue,
-                            ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
-                            ECLCCPrologueKernel<max_w_items, multi_block>{},
-                            mdpfClusteringEdgeVars.view(),
-                            mdpfCCLabels.view());
+        // ECL-CC prologue:
+        if (threadsPerBlock <= 256) {
+          constexpr unsigned int max_w_items = 8;
+          alpaka::exec<Acc1D>(queue,
+                              ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                              ECLCCPrologueKernel<max_w_items>{},
+                              mdpfClusteringEdgeVars.view(),
+                              mdpfCCLabels.view());
+        } else if (threadsPerBlock <= 512) {
+          constexpr unsigned int max_w_items = 16;
+          alpaka::exec<Acc1D>(queue,
+                              ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                              ECLCCPrologueKernel<max_w_items>{},
+                              mdpfClusteringEdgeVars.view(),
+                              mdpfCCLabels.view());
+        } else {
+          constexpr unsigned int max_w_items = 32;
+          alpaka::exec<Acc1D>(queue,
+                              ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                              ECLCCPrologueKernel<max_w_items>{},
+                              mdpfClusteringEdgeVars.view(),
+                              mdpfCCLabels.view());
+        }
       }
-    } else if (threadsPerBlock <= 512) {
-      constexpr unsigned int max_w_items = 16;
-      alpaka::exec<Acc1D>(queue,
-                          ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
-                          ECLCCPrologueKernel<max_w_items>{},
-                          mdpfClusteringEdgeVars.view(),
-                          mdpfCCLabels.view());
-    } else {
-      constexpr unsigned int max_w_items = 32;
-      alpaka::exec<Acc1D>(queue,
-                          ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
-                          ECLCCPrologueKernel<max_w_items>{},
-                          mdpfClusteringEdgeVars.view(),
-                          mdpfCCLabels.view());
     }
+
     // Launch ECL-CC algorithm:
     // ECL-CC init stage:
     alpaka::exec<Acc1D>(queue,
@@ -141,13 +223,93 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::eclcc {
                         ECLCCFlattenKernel{},
                         mdpfCCLabels.view());
 
-    // ECL-CC epilogue:
-    if (threadsPerBlock <= 256) {
-      constexpr unsigned int max_w_items = 8;
-      if (blocks == 1) {
+    const bool do_opt_epilogue = enable_multiblock_epilogue && (blocks > 1);
+
+    if (do_opt_epilogue) {
+      reco::PFMultiDepthECLCCEpilogueArgsDeviceCollection epilogueArgs{queue, static_cast<int>(nClusters)};
+
+      epilogueArgs.zeroInitialise(queue);
+
+      alpaka::exec<Acc1D>(queue,
+                          ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                          ECLCCEpilogueRecHitFracOffsetsKernel{},
+                          epilogueArgs.view(),
+                          mdpfCCLabels.view(),
+                          pfCluster.view());
+      if (threadsPerBlock <= 256) {
+        constexpr unsigned int max_w_items = 8;
         alpaka::exec<Acc1D>(queue,
                             ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
-                            ECLCCEpilogueKernel<max_w_items>{},
+                            ECLCCEpilogueCCOffsetsKernel<max_w_items>{},
+                            outPFCluster.view(),
+                            epilogueArgs.view(),
+                            mdpfCCLabels.view(),
+                            pfCluster.view());
+
+        alpaka::exec<Acc1D>(queue,
+                            ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                            ECLCCFinalizeEpilogueKernel<max_w_items>{},
+                            outPFCluster.view(),
+                            outPFRecHitFracs.view(),
+                            epilogueArgs.view(),
+                            mdpfCCLabels.view(),
+                            pfCluster.view(),
+                            pfRecHitFracs.view(),
+                            pfRecHit.view());
+
+      } else if (threadsPerBlock <= 256) {
+        constexpr unsigned int max_w_items = 16;
+        alpaka::exec<Acc1D>(queue,
+                            ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                            ECLCCEpilogueCCOffsetsKernel<max_w_items>{},
+                            outPFCluster.view(),
+                            epilogueArgs.view(),
+                            mdpfCCLabels.view(),
+                            pfCluster.view());
+
+        alpaka::exec<Acc1D>(queue,
+                            ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                            ECLCCFinalizeEpilogueKernel<max_w_items>{},
+                            outPFCluster.view(),
+                            outPFRecHitFracs.view(),
+                            epilogueArgs.view(),
+                            mdpfCCLabels.view(),
+                            pfCluster.view(),
+                            pfRecHitFracs.view(),
+                            pfRecHit.view());
+      } else {
+        constexpr unsigned int max_w_items = 32;
+        alpaka::exec<Acc1D>(queue,
+                            ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                            ECLCCEpilogueCCOffsetsKernel<max_w_items>{},
+                            outPFCluster.view(),
+                            epilogueArgs.view(),
+                            mdpfCCLabels.view(),
+                            pfCluster.view());
+
+        alpaka::exec<Acc1D>(queue,
+                            ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                            ECLCCFinalizeEpilogueKernel<max_w_items>{},
+                            outPFCluster.view(),
+                            outPFRecHitFracs.view(),
+                            epilogueArgs.view(),
+                            mdpfCCLabels.view(),
+                            pfCluster.view(),
+                            pfRecHitFracs.view(),
+                            pfRecHit.view());
+      }
+
+      alpaka::exec<Acc1D>(queue,
+                          ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                          ECLCCLoadSeedsKernel{},
+                          outPFCluster.view(),
+                          epilogueArgs.view());
+
+    } else {
+      if constexpr (std::is_same_v<Device, alpaka::DevCpu>) {
+        alpaka::exec<Acc1D>(queue,
+                            ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                            ECLCCEpilogueNaiveKernel{},
                             outPFCluster.view(),
                             outPFRecHitFracs.view(),
                             mdpfCCLabels.view(),
@@ -155,40 +317,44 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::eclcc {
                             pfRecHitFracs.view(),
                             pfRecHit.view());
       } else {
-        constexpr bool multi_block = true;
         constexpr bool cooperative_work = true;
-        alpaka::exec<Acc1D>(queue,
-                            ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
-                            ECLCCEpilogueKernel<max_w_items, cooperative_work, multi_block>{},
-                            outPFCluster.view(),
-                            outPFRecHitFracs.view(),
-                            mdpfCCLabels.view(),
-                            pfCluster.view(),
-                            pfRecHitFracs.view(),
-                            pfRecHit.view());
+        // ECL-CC epilogue:
+        if (threadsPerBlock <= 256) {
+          constexpr unsigned int max_w_items = 8;
+          alpaka::exec<Acc1D>(queue,
+                              ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                              ECLCCEpilogueKernel<max_w_items, cooperative_work>{},
+                              outPFCluster.view(),
+                              outPFRecHitFracs.view(),
+                              mdpfCCLabels.view(),
+                              pfCluster.view(),
+                              pfRecHitFracs.view(),
+                              pfRecHit.view());
+
+        } else if (threadsPerBlock <= 512) {
+          constexpr unsigned int max_w_items = 16;
+          alpaka::exec<Acc1D>(queue,
+                              ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                              ECLCCEpilogueKernel<max_w_items, cooperative_work>{},
+                              outPFCluster.view(),
+                              outPFRecHitFracs.view(),
+                              mdpfCCLabels.view(),
+                              pfCluster.view(),
+                              pfRecHitFracs.view(),
+                              pfRecHit.view());
+        } else {
+          constexpr unsigned int max_w_items = 32;
+          alpaka::exec<Acc1D>(queue,
+                              ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
+                              ECLCCEpilogueKernel<max_w_items, cooperative_work>{},
+                              outPFCluster.view(),
+                              outPFRecHitFracs.view(),
+                              mdpfCCLabels.view(),
+                              pfCluster.view(),
+                              pfRecHitFracs.view(),
+                              pfRecHit.view());
+        }
       }
-    } else if (threadsPerBlock <= 512) {
-      constexpr unsigned int max_w_items = 16;
-      alpaka::exec<Acc1D>(queue,
-                          ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
-                          ECLCCEpilogueKernel<max_w_items>{},
-                          outPFCluster.view(),
-                          outPFRecHitFracs.view(),
-                          mdpfCCLabels.view(),
-                          pfCluster.view(),
-                          pfRecHitFracs.view(),
-                          pfRecHit.view());
-    } else {
-      constexpr unsigned int max_w_items = 32;
-      alpaka::exec<Acc1D>(queue,
-                          ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
-                          ECLCCEpilogueKernel<max_w_items>{},
-                          outPFCluster.view(),
-                          outPFRecHitFracs.view(),
-                          mdpfCCLabels.view(),
-                          pfCluster.view(),
-                          pfRecHitFracs.view(),
-                          pfRecHit.view());
     }
   }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterizerHelper.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterizerHelper.h
@@ -58,15 +58,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
  *
  * @param mask Input mask.
  * @param mask Input lane index in the warp
- * @param w_extent (Sub)warp size
  * 
  * @return True if active, otherwise false.
  */
-  ALPAKA_FN_ACC constexpr inline bool is_work_lane(const warp::warp_mask_t work_mask,
-                                                   const unsigned int lane_idx,
-                                                   const unsigned extent) {
-    if (lane_idx >= extent)
-      return false;
+  ALPAKA_FN_ACC constexpr inline bool is_work_lane(const warp::warp_mask_t work_mask, const unsigned int lane_idx) {
     return ((work_mask >> lane_idx) & 1);
   }
 
@@ -92,6 +87,40 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     const auto pos = alpaka::ffs(acc, static_cast<signed_warp_mask_t>(mask));
     return static_cast<warp::warp_mask_t>(pos - 1);
+  }
+
+  /**
+ * @brief Returns true if a given lane is represented in the least significant bit in a mask.
+ *
+ * @tparam TAcc Alpaka accelerator type.
+ * 
+ * @param acc   Alpaka accelerator instance.
+ * @param mask  Input mask.
+ * @param lane_idx Current thread's lane index.
+ * 
+ * @return True if lane_idx is the least significant bit in a mask, otherwise faulse .
+ */
+  template <alpaka::concepts::Acc TAcc>
+  ALPAKA_FN_ACC ALPAKA_FN_INLINE bool is_ls1b_idx(const warp::warp_mask_t mask, const unsigned int lane_idx) {
+    if (mask == 0)
+      return false;
+
+    if constexpr (std::is_same_v<alpaka::Dev<TAcc>, alpaka::DevCpu>)
+      return true;
+
+    const warp::warp_mask_t lane_mask = get_lane_mask(lane_idx);
+
+    // First check wether the lane is represented at all, otherwise check the trivial case:
+    if ((mask & lane_mask) == 0)
+      return false;
+    else if (lane_idx == 0)
+      return true;
+
+    constexpr unsigned int w_extent = get_warp_size<TAcc>();
+
+    const warp::warp_mask_t inverted_mask = mask << (w_extent - lane_idx);
+
+    return (inverted_mask == 0);
   }
 
   /**
@@ -257,7 +286,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       return mask == 0 ? 0 : in;
 
     // Non-active lanes should skip the reduction:
-    if (is_work_lane(mask, lane_idx, w_extent) == false)
+    if (is_work_lane(mask, lane_idx) == false)
       return in;
 
     unsigned int nActiveLanes = alpaka::popcount(acc, mask);  // count number of active lanes
@@ -320,7 +349,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       return all == false ? 0 : (mask == 0 ? 0 : val);
 
     // Non-active lanes should skip the reduction:
-    if (is_work_lane(mask, lane_idx, w_extent) == false)
+    if (is_work_lane(mask, lane_idx) == false)
       return 0;
 
     // count number of active lanes

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthConstructLinks.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthConstructLinks.h
@@ -24,7 +24,7 @@
  * (i.e. ECL-CC algorithm).
  *
  * Execution model:
- * - Warp-tiling over (source tile × destination lane) pairs.
+ * - Warp-tiling over (source tile x destination lane) pairs.
  * - Candidate filtering: depth > 0 and (eta, phi) within nSigma cuts.
  * - Multi-stage warp pruning using masked collectives (ballot/shuffle/reduction).
  *
@@ -41,7 +41,12 @@
 
 // We perform full warp computation for old NVIDIA and AMD microarchitectures
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && (__CUDA_ARCH__ < 800) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-#define FULL_WARP_COMPUTE
+/*
+* For pre-Ampere CUDA architectures the operations must be done for all lanes in the whole warp.
+*/
+constexpr bool full_warp_compute = true;
+#else
+constexpr bool full_warp_compute = false;
 #endif
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
@@ -257,11 +262,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   reco::PFMultiDepthClusteringCCLabelsDeviceCollection::View mdpfClusteringCCLabels,
                                   const reco::PFMultiDepthClusteringVarsDeviceCollection::ConstView mdpfClusteringVars,
                                   const PFMultiDepthClusterParams* nSigma) const {
-#ifdef FULL_WARP_COMPUTE
-      constexpr bool full_warp_compute = true;
-#else
-      constexpr bool full_warp_compute = false;
-#endif
       constexpr unsigned int w_extent = get_warp_size<Acc1D>();
 
       const unsigned int nClusters = mdpfClusteringVars.size();
@@ -271,12 +271,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       const double nSigmaEta = nSigma->nSigmaEta;
       const double nSigmaPhi = nSigma->nSigmaPhi;
-#ifndef FULL_WARP_COMPUTE
-      constexpr PFMDLinkParamKind param_kinds[3] = {
-          PFMDLinkParamKind::DZ, PFMDLinkParamKind::DR, PFMDLinkParamKind::ENERGY};
-#endif
+
       if (::cms::alpakatools::once_per_grid(acc)) {
         mdpfClusteringCCLabels.size() = nClusters;
+        mdpfClusteringCCLabels.ncomponents() = 0;
       }
 
       for (auto group : ::cms::alpakatools::uniform_groups(acc)) {
@@ -290,15 +288,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           if (idx.global < nClusters) {
             mdpfClusteringCCLabels[idx.global].workl() = 0;
           }
-/*
-* For pre-Ampere CUDA architectures the operations must be done for all lanes in the whole warp.
-*/
-// Active-lane mask for this warp iteration:
-// every warp collective must use a mask that covers all participating lanes;
-// we additionally OR-in the destination lane to keep it active for result updates.
-#ifndef FULL_WARP_COMPUTE
-          const warp::warp_mask_t init_active_lanes_mask = alpaka::warp::ballot(acc, idx.global < nClusters);
-#endif
+
+          // Active-lane mask for this warp iteration:
+          // every warp collective must use a mask that covers all participating lanes;
+          // we additionally OR-in the destination lane to keep it active for result updates.
+          const warp::warp_mask_t init_active_lanes_mask =
+              alpaka::warp::ballot(acc, full_warp_compute || (idx.global < nClusters));
+
           // From this point all warp-level collectives must be accompanied with init_active_lanes_mask (or any derived from it) mask:
           // for example, new_mask = warp::ballot_mask(acc, old_mask, predicate) will generate a new mask that selects a subset of lanes from old_mask
           // Link parameters (by default store its own global index):
@@ -340,104 +336,79 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             for (unsigned int dst_lane_idx = 0; dst_lane_idx < w_extent; dst_lane_idx++) {
               // 1. We need to keep the target cluster lane with dst_lane_idx reserved from divergence
               const warp::warp_mask_t dst_lane_mask = get_lane_mask(dst_lane_idx);
-#ifndef FULL_WARP_COMPUTE
+
               const warp::warp_mask_t active_lanes_mask = init_active_lanes_mask | dst_lane_mask;
-#endif
+
               const bool is_owner_lane = is_owner_tile && (dst_lane_idx == lane_idx);
               // 2. Broadcast values from dst_lane_idx, this will give us warp-local source cluster depth:
-#ifndef FULL_WARP_COMPUTE
               const float dst_depth =
                   warp::shfl_mask(acc, active_lanes_mask, dst_cl_params.depth(), dst_lane_idx, w_extent);
-#else
-              const float dst_depth = alpaka::warp::shfl(acc, dst_cl_params.depth(), dst_lane_idx);
-#endif
+
               // 3. Do not link at the same layer and only link inside out:
               //    Note that if lane_idx == iter_lane_id and is_proper_tile == true, then dz == 0 and the lane is filtered
               //   (but will be not excluded from active lanes)
               const auto dz = (static_cast<int>(dst_depth) - static_cast<int>(src_cl_params.depth()));
               // 4. Select lanes that contain valid candidates, i.e., all lanes for which dz > 0,
               //    excluding lane_idx = iter_lane_id and is_proper_tile = true
-#ifndef FULL_WARP_COMPUTE
               warp::warp_mask_t leftover_lanes_mask = warp::ballot_mask(acc, active_lanes_mask, dz > 0);
-#else
-              warp::warp_mask_t leftover_lanes_mask = alpaka::warp::ballot(acc, dz > 0);
-#endif
+
               // 5. If the warp is 'empty' (no valid lanes), start the next iteration
               //    if no threads detected then coninue, no warp synchronization at the point
-              //warp::syncWarpThreads_mask(acc, valid_candidates_mask || dst_lane_mask);
               // Note that lane with id equal to dst_lane_idx must be always active, since it's responsible for storing
               // result.
               // 6. Skip if there are no active lanes in the leftover lanes mask (all lanes are filtered and must skip);
               if (leftover_lanes_mask == 0)
                 continue;
               // From here on, only lanes in (leftover_lanes_mask | dst_lane_mask) are allowed to call masked collectives.
-#ifndef FULL_WARP_COMPUTE
-              if (is_work_lane(leftover_lanes_mask | dst_lane_mask, lane_idx, w_extent) == false)
+
+              auto updated_active_lanes_mask =
+                  full_warp_compute ? init_active_lanes_mask : leftover_lanes_mask | dst_lane_mask;
+
+              if (is_work_lane(updated_active_lanes_mask, lane_idx) == false)
                 continue;
 
-              const float dst_eta = warp::shfl_mask(
-                  acc, leftover_lanes_mask | dst_lane_mask, dst_cl_params.eta(), dst_lane_idx, w_extent);
-              const double dst_etaRMS2 = warp::shfl_mask(
-                  acc, leftover_lanes_mask | dst_lane_mask, dst_cl_params.etaRMS2(), dst_lane_idx, w_extent);
+              const bool is_valid_lane = (is_owner_lane == false) && is_work_lane(leftover_lanes_mask, lane_idx);
+
+              const float dst_eta =
+                  warp::shfl_mask(acc, updated_active_lanes_mask, dst_cl_params.eta(), dst_lane_idx, w_extent);
+              const double dst_etaRMS2 =
+                  warp::shfl_mask(acc, updated_active_lanes_mask, dst_cl_params.etaRMS2(), dst_lane_idx, w_extent);
 
               const auto tmp1 = src_cl_params.eta() - dst_eta;
-              const auto deta = tmp1 * tmp1 / (src_cl_params.etaRMS2() + dst_etaRMS2);
+              const auto deta = is_valid_lane ? tmp1 * tmp1 / (src_cl_params.etaRMS2() + dst_etaRMS2) : 0;
 
-              const float dst_phi = warp::shfl_mask(
-                  acc, leftover_lanes_mask | dst_lane_mask, dst_cl_params.phi(), dst_lane_idx, w_extent);
-              const double dst_phiRMS2 = warp::shfl_mask(
-                  acc, leftover_lanes_mask | dst_lane_mask, dst_cl_params.phiRMS2(), dst_lane_idx, w_extent);
+              const float dst_phi =
+                  warp::shfl_mask(acc, updated_active_lanes_mask, dst_cl_params.phi(), dst_lane_idx, w_extent);
 
-              const auto tmp2 = ::cms::alpakatools::deltaPhi(acc, src_cl_params.phi(), dst_phi);
-              const auto dphi = tmp2 * tmp2 / (src_cl_params.phiRMS2() + dst_phiRMS2);
-#else
-              const float dst_eta = alpaka::warp::shfl(acc, dst_cl_params.eta(), dst_lane_idx);
-              const double dst_etaRMS2 = alpaka::warp::shfl(acc, dst_cl_params.etaRMS2(), dst_lane_idx);
+              const double dst_phiRMS2 =
+                  warp::shfl_mask(acc, updated_active_lanes_mask, dst_cl_params.phiRMS2(), dst_lane_idx, w_extent);
 
-              const auto tmp1 = src_cl_params.eta() - dst_eta;
-              const auto deta = is_work_lane(leftover_lanes_mask | dst_lane_mask, lane_idx, w_extent)
-                                    ? tmp1 * tmp1 / (src_cl_params.etaRMS2() + dst_etaRMS2)
-                                    : 0;
+              const auto tmp2 = is_valid_lane ? ::cms::alpakatools::deltaPhi(acc, src_cl_params.phi(), dst_phi) : 0;
 
-              const float dst_phi = alpaka::warp::shfl(acc, dst_cl_params.phi(), dst_lane_idx);
-              const double dst_phiRMS2 = alpaka::warp::shfl(acc, dst_cl_params.phiRMS2(), dst_lane_idx);
+              const auto dphi = is_valid_lane ? tmp2 * tmp2 / (src_cl_params.phiRMS2() + dst_phiRMS2) : 0;
 
-              const auto tmp2 = is_work_lane(leftover_lanes_mask | dst_lane_mask, lane_idx, w_extent)
-                                    ? ::cms::alpakatools::deltaPhi(acc, src_cl_params.phi(), dst_phi)
-                                    : 0;
-              const auto dphi = is_work_lane(leftover_lanes_mask | dst_lane_mask, lane_idx, w_extent)
-                                    ? tmp2 * tmp2 / (src_cl_params.phiRMS2() + dst_phiRMS2)
-                                    : 0;
-#endif
-              const bool is_valid_lane =
-                  (is_owner_lane == false) && is_work_lane(leftover_lanes_mask, lane_idx, w_extent);
-#ifndef FULL_WARP_COMPUTE
-              warp::warp_mask_t next_leftover_lanes_mask = warp::ballot_mask(
-                  acc,
-                  leftover_lanes_mask | dst_lane_mask,
-                  (deta < nSigmaEta && dphi < nSigmaPhi) && is_valid_lane);  //update valid candidate mask
-#else
               const bool pred = is_valid_lane && (deta < nSigmaEta && dphi < nSigmaPhi);
-              warp::warp_mask_t next_leftover_lanes_mask =
-                  alpaka::warp::ballot(acc, pred);  //update valid candidate mask
-#endif
+
+              warp::warp_mask_t next_leftover_lanes_mask = warp::ballot_mask(acc,
+                                                                             updated_active_lanes_mask,
+                                                                             pred);  //update valid candidate mask
 
               if (next_leftover_lanes_mask == 0)
                 continue;
 
               leftover_lanes_mask = next_leftover_lanes_mask | dst_lane_mask;
-#ifndef FULL_WARP_COMPUTE
-              if (is_work_lane(leftover_lanes_mask, lane_idx, w_extent) == false)
+
+              updated_active_lanes_mask = full_warp_compute ? init_active_lanes_mask : leftover_lanes_mask;
+
+              if (is_work_lane(updated_active_lanes_mask, lane_idx) == false)
                 continue;
 
               const float dst_energy =
-                  warp::shfl_mask(acc, leftover_lanes_mask, dst_cl_params.energy(), dst_lane_idx, w_extent);
-#else
-              const float dst_energy = alpaka::warp::shfl(acc, dst_cl_params.energy(), dst_lane_idx);
-#endif
+                  warp::shfl_mask(acc, updated_active_lanes_mask, dst_cl_params.energy(), dst_lane_idx, w_extent);
+
               // 7. Now start inter-warp pruning:
               // 7.1 Create warp-local link params (with the latest leftover lane mask);
-              const bool is_non_owner_lane = is_work_lane(next_leftover_lanes_mask, lane_idx, w_extent);
+              const bool is_non_owner_lane = is_work_lane(next_leftover_lanes_mask, lane_idx);
 
               auto candidate_link_params =
                   is_non_owner_lane
@@ -469,26 +440,28 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                   }
                 }
                 continue;
-              }
-#ifndef FULL_WARP_COMPUTE
-              for (unsigned int k = 0; k < 3; k++) {
-                next_leftover_lanes_mask = prune_link(acc,
-                                                      leftover_lanes_mask,
-                                                      selected_link_params,
-                                                      candidate_link_params,
-                                                      lane_idx,
-                                                      dst_lane_idx,
-                                                      param_kinds[k],
-                                                      is_owner_tile);
-                if (next_leftover_lanes_mask == 0)
-                  break;
+              } else {
+                constexpr PFMDLinkParamKind param_kinds[3] = {
+                    PFMDLinkParamKind::DZ, PFMDLinkParamKind::DR, PFMDLinkParamKind::ENERGY};
 
-                if (is_work_lane(next_leftover_lanes_mask | dst_lane_mask, lane_idx, w_extent) == false)
-                  break;  // exit loop for filtered lanes only
-                // Reset filtered link mask:
-                leftover_lanes_mask = next_leftover_lanes_mask;
+                for (unsigned int k = 0; k < 3; k++) {
+                  next_leftover_lanes_mask = prune_link(acc,
+                                                        leftover_lanes_mask,
+                                                        selected_link_params,
+                                                        candidate_link_params,
+                                                        lane_idx,
+                                                        dst_lane_idx,
+                                                        param_kinds[k],
+                                                        is_owner_tile);
+                  if (next_leftover_lanes_mask == 0)
+                    break;
+
+                  if (is_work_lane(next_leftover_lanes_mask | dst_lane_mask, lane_idx) == false)
+                    break;  // exit loop for filtered lanes only
+                  // Reset filtered link mask:
+                  leftover_lanes_mask = next_leftover_lanes_mask;
+                }
               }
-#endif
             }  //end dst lane id
           }  //end all (full!) tiles
           // Store linked cluster id (or self index, if isolated)

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCEpilogue.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCEpilogue.h
@@ -1,6 +1,8 @@
 #ifndef PFClusterProducer_plugins_alpaka_PFMultiDepthECLCCEpilogue_h
 #define PFClusterProducer_plugins_alpaka_PFMultiDepthECLCCEpilogue_h
 
+#include <limits>
+
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/VecArray.h"
@@ -39,8 +41,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
  * connected-component labels computed by the ECL clustering stage. Supports
  * optional cooperative warp-level processing.
  *
- * @tparam max_w_items     Maximum number of items processed per warp.
- * @tparam is_cooperative Enable cooperative warp-level processing if true.
+ * @tparam max_w_items     Maximum number of items processed per warp (ROCm/CUDA backend)
+ * @tparam is_cooperative Enable cooperative warp-level processing if true (ROCm/CUDA backend)
  * 
  * @param acc                 Alpaka accelerator object.
  * @param outPFCluster        Output PF cluster device collection.
@@ -51,7 +53,84 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
  * @param pfRecHit            Input PF rec hit device collection.
  */
 
-  template <unsigned int max_w_items = 32, bool is_cooperative = false, bool multi_block = false>
+  class ECLCCEpilogueNaiveKernel {
+  public:
+    ALPAKA_FN_ACC void operator()(
+        Acc1D const& acc,
+        reco::PFClusterDeviceCollection::View outPFCluster,
+        reco::PFRecHitFractionDeviceCollection::View outPFRecHitFracs,
+        const reco::PFMultiDepthClusteringCCLabelsDeviceCollection::ConstView pfClusteringCCLabels,
+        const reco::PFClusterDeviceCollection::ConstView pfCluster,
+        const reco::PFRecHitFractionDeviceCollection::ConstView pfRecHitFracs,
+        const reco::PFRecHitDeviceCollection::ConstView pfRecHit) const {
+      const unsigned int nVertices = pfClusteringCCLabels.size();
+
+      if (::cms::alpakatools::once_per_grid(acc)) {
+        unsigned int ccrhfrac_idx = 0;
+        unsigned int cc_idx = 0;
+
+        for (unsigned int vtx_idx = 0; vtx_idx < nVertices; vtx_idx++) {
+          const unsigned int rep_idx = pfClusteringCCLabels[vtx_idx].mdpf_topoId();
+          const bool is_representative = rep_idx == vtx_idx;
+
+          if (is_representative == false)
+            continue;
+
+          outPFCluster[cc_idx].depth() = pfCluster[rep_idx].depth();
+          outPFCluster[cc_idx].topoId() = cc_idx;
+          outPFCluster[cc_idx].energy() = pfCluster[rep_idx].energy();
+          outPFCluster[cc_idx].x() = pfCluster[rep_idx].x();
+          outPFCluster[cc_idx].y() = pfCluster[rep_idx].y();
+          outPFCluster[cc_idx].z() = pfCluster[rep_idx].z();
+          outPFCluster[cc_idx].topoRHCount() = pfCluster[rep_idx].topoRHCount();
+
+          int cc_seed = pfCluster[rep_idx].seedRHIdx();
+          float cc_energy = pfRecHit[cc_seed].energy();
+
+          outPFCluster[cc_idx].rhfracOffset() = ccrhfrac_idx;
+
+          for (unsigned int iter_idx = 0; iter_idx < nVertices; iter_idx++) {
+            const unsigned int comp_id = pfClusteringCCLabels[iter_idx].mdpf_topoId();
+
+            if (comp_id != rep_idx)
+              continue;
+            const int seed = pfCluster[iter_idx].seedRHIdx();
+            const float energy = pfRecHit[seed].energy();
+
+            const unsigned int rhf_begin = pfCluster[iter_idx].rhfracOffset();
+            const unsigned int rhf_end = rhf_begin + pfCluster[iter_idx].rhfracSize();
+
+            for (unsigned int src_rhfrac_idx = rhf_begin; src_rhfrac_idx < rhf_end; src_rhfrac_idx++) {
+              const unsigned int dst_rhfrac_idx = ccrhfrac_idx;
+
+              outPFRecHitFracs[dst_rhfrac_idx].frac() = pfRecHitFracs[src_rhfrac_idx].frac();
+              outPFRecHitFracs[dst_rhfrac_idx].pfrhIdx() = pfRecHitFracs[src_rhfrac_idx].pfrhIdx();
+              outPFRecHitFracs[dst_rhfrac_idx].pfcIdx() = cc_idx;
+
+              ccrhfrac_idx += 1;
+            }
+
+            if (energy > cc_energy) {
+              cc_energy = energy;
+              cc_seed = seed;
+            }
+          }  // iter_idx
+
+          outPFCluster[cc_idx].rhfracSize() = ccrhfrac_idx - outPFCluster[cc_idx].rhfracOffset();
+          outPFCluster[cc_idx].seedRHIdx() = cc_seed;
+
+          cc_idx += 1;  //nComponents
+        }  // vtx_idx
+
+        outPFCluster.nTopos() = cc_idx;
+        outPFCluster.nSeeds() = cc_idx;
+        outPFCluster.nRHFracs() = pfCluster.nRHFracs();
+        outPFCluster.size() = cc_idx;
+      }
+    }
+  };
+
+  template <unsigned int max_w_items = 32, bool is_cooperative = false>
   class ECLCCEpilogueKernel {
   public:
     ALPAKA_FN_ACC void operator()(
@@ -68,586 +147,487 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       const unsigned int nVertices = pfClusteringCCLabels.size();
 
-      if constexpr (std::is_same_v<Device, alpaka::DevCpu> ||
-                    std::is_same_v<alpaka::AccToTag<Acc1D>, alpaka::TagGpuHipRt> || multi_block) {
-        if (::cms::alpakatools::once_per_grid(acc)) {
-          unsigned int ccrhfrac_idx = 0;
-          unsigned int cc_idx = 0;
+      // component offsets
+      auto& subcc_offsets(alpaka::declareSharedVar<uint32_t[w_extent], __COUNTER__>(acc));
+      // isolate root flag : 0 - an isolated root vertex, 1 - a non-isolated root vertex
+      auto& vertex_mask(alpaka::declareSharedVar<warp::warp_mask_t[max_w_items], __COUNTER__>(acc));
 
-          for (unsigned int vtx_idx = 0; vtx_idx < nVertices; vtx_idx++) {
-            const unsigned int rep_idx = pfClusteringCCLabels[vtx_idx].mdpf_topoId();
-            const bool is_representative = rep_idx == vtx_idx;
+      auto& common_buf1(alpaka::declareSharedVar<uint32_t[max_w_items * w_extent], __COUNTER__>(acc));
+      auto& common_buf2(alpaka::declareSharedVar<uint32_t[max_w_items * w_extent], __COUNTER__>(acc));
+      auto& common_buf3(alpaka::declareSharedVar<uint32_t[max_w_items * w_extent], __COUNTER__>(acc));
 
-            if (is_representative == false)
-              continue;
+      auto& cc_energy_seed(alpaka::declareSharedVar<uint64_t[max_w_items * w_extent], __COUNTER__>(acc));
 
-            outPFCluster[cc_idx].depth() = pfCluster[rep_idx].depth();
-            outPFCluster[cc_idx].topoId() = cc_idx;
-            outPFCluster[cc_idx].energy() = pfCluster[rep_idx].energy();
-            outPFCluster[cc_idx].x() = pfCluster[rep_idx].x();
-            outPFCluster[cc_idx].y() = pfCluster[rep_idx].y();
-            outPFCluster[cc_idx].z() = pfCluster[rep_idx].z();
-            outPFCluster[cc_idx].topoRHCount() = pfCluster[rep_idx].topoRHCount();
+      //block-local number of components
+      unsigned int& localNComponents = alpaka::declareSharedVar<uint32_t, __COUNTER__>(acc);
 
-            int cc_seed = pfCluster[rep_idx].seedRHIdx();
-            float cc_energy = pfRecHit[cc_seed].energy();
+      for (auto group : ::cms::alpakatools::uniform_groups(acc)) {
+        if (group > 0)
+          continue;
 
-            outPFCluster[cc_idx].rhfracOffset() = ccrhfrac_idx;
-
-            for (unsigned int iter_idx = 0; iter_idx < nVertices; iter_idx++) {
-              const unsigned int comp_id = pfClusteringCCLabels[iter_idx].mdpf_topoId();
-
-              if (comp_id != rep_idx)
-                continue;
-
-              const int seed = pfCluster[iter_idx].seedRHIdx();
-              const float energy = pfRecHit[seed].energy();
-
-              const unsigned int rhf_begin = pfCluster[iter_idx].rhfracOffset();
-              const unsigned int rhf_end = rhf_begin + pfCluster[iter_idx].rhfracSize();
-
-              for (unsigned int src_rhfrac_idx = rhf_begin; src_rhfrac_idx < rhf_end; src_rhfrac_idx++) {
-                const unsigned int dst_rhfrac_idx = ccrhfrac_idx;
-
-                outPFRecHitFracs[dst_rhfrac_idx].frac() = pfRecHitFracs[src_rhfrac_idx].frac();
-                outPFRecHitFracs[dst_rhfrac_idx].pfrhIdx() = pfRecHitFracs[src_rhfrac_idx].pfrhIdx();
-                outPFRecHitFracs[dst_rhfrac_idx].pfcIdx() = cc_idx;
-
-                ccrhfrac_idx += 1;
-              }
-
-              if (energy > cc_energy) {
-                cc_energy = energy;
-                cc_seed = seed;
-              }
-            }  // iter_idx
-
-            outPFCluster[cc_idx].rhfracSize() = ccrhfrac_idx - outPFCluster[cc_idx].rhfracOffset();
-            outPFCluster[cc_idx].seedRHIdx() = cc_seed;
-
-            cc_idx += 1;  //nComponents
-          }  // vtx_idx
-
-          outPFCluster.nTopos() = cc_idx;
-          outPFCluster.nSeeds() = cc_idx;
-          outPFCluster.size() = cc_idx;
+        if (::cms::alpakatools::once_per_block(acc)) {
+          localNComponents = 0;
         }
-        return;
-      } else {
-        //representative vertex index for a component.
-        auto& cc_roots(alpaka::declareSharedVar<unsigned int[max_w_items * w_extent + 1], __COUNTER__>(acc));
-        // max energy (bit-cast) per component, cc_energies stores float energies bit-cast to uint for atomicMax():
-        auto& cc_energies(alpaka::declareSharedVar<unsigned int[max_w_items * w_extent], __COUNTER__>(acc));
-        // selected seed per component:
-        auto& cc_seeds(alpaka::declareSharedVar<unsigned int[max_w_items * w_extent], __COUNTER__>(acc));
-        // total rhfrac count per component (compact indexing).
-        auto& cc_rhf_sizes(alpaka::declareSharedVar<unsigned int[max_w_items * w_extent + 1], __COUNTER__>(acc));
-        // Maps vertex root -> compact component id (cc_idx); also uses [nVertices] as component counter.
-        auto& component_map(alpaka::declareSharedVar<unsigned int[max_w_items * w_extent + 1], __COUNTER__>(acc));
-        // component size accumulated at root index
-        auto& connected_comp_sizes(
-            alpaka::declareSharedVar<unsigned int[max_w_items * w_extent + 1], __COUNTER__>(acc));
 
-        auto& subcc_offsets(alpaka::declareSharedVar<unsigned int[max_w_items], __COUNTER__>(acc));
-        auto& isolated_roots(alpaka::declareSharedVar<unsigned int[max_w_items], __COUNTER__>(acc));
-
-        auto& common_buf(alpaka::declareSharedVar<unsigned int[max_w_items * w_extent + 1], __COUNTER__>(acc));
-
-        //total rhfrac count per component (accumulated at root).
-        auto& connected_comp_rhf_sizes = common_buf;
-
-        unsigned int rep_idx = nVertices;
         unsigned int vertex_idx = nVertices;
 
-        unsigned int connected_comp_rhf_offsets = 0;
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
 
-        int vertex_seed = 0;
-        unsigned int vertex_energy = 0;
+          common_buf1[idx.local] = nVertices;
+          common_buf2[idx.local] = 0;
+          common_buf3[idx.local] = 0;
 
-        for (auto group : ::cms::alpakatools::uniform_groups(acc)) {
-          if (::cms::alpakatools::once_per_block(acc)) {
-            component_map[nVertices] = 0;
+          cc_energy_seed[idx.local] = 0;
+
+          if (idx.local < max_w_items) {
+            subcc_offsets[idx.local] = 0;
+            vertex_mask[idx.local] = active_lanes_mask;  //needed for AND operation
           }
 
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(
-                   acc, group, ::cms::alpakatools::round_up_by(nVertices, w_extent))) {
-            connected_comp_sizes[idx.local] = 0;
-            connected_comp_rhf_sizes[idx.local] = 0;
+          vertex_idx = idx.local;
+        }
 
-            cc_energies[idx.local] = 0;
-            cc_seeds[idx.local] = 0;
+        const unsigned int rep_idx = vertex_idx < nVertices ? pfClusteringCCLabels[vertex_idx].mdpf_topoId() : 0;
 
-            if (idx.local < max_w_items)
-              subcc_offsets[idx.local] = 0;
+        const bool is_representative = vertex_idx < nVertices ? vertex_idx == rep_idx : false;
 
-            if (idx.local >= nVertices)
-              continue;
+        alpaka::syncBlockThreads(acc);
 
-            vertex_idx = idx.local;
+        //Maps vertex root -> compact component id (cc_idx); also uses [nVertices] as component counter:
+        auto& component_map = common_buf1;
+        auto& cc_idx_cache = common_buf3;
 
-            rep_idx = pfClusteringCCLabels[vertex_idx].mdpf_topoId();
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+          const unsigned int lane_idx = idx.local % w_extent;
 
-            vertex_seed = pfCluster[vertex_idx].seedRHIdx();
+          const warp::warp_mask_t rep_mask = warp::ballot_mask(acc, active_lanes_mask, is_representative);
+
+          if (is_representative == false)
+            continue;
+
+          const unsigned int low_rep_idx = get_ls1b_idx(acc, rep_mask);
+
+          unsigned int local_topo_offset = 0;
+
+          if (lane_idx == low_rep_idx) {
+            const unsigned int local_n_topo = alpaka::popcount(acc, rep_mask);
+
+            local_topo_offset = alpaka::atomicAdd(acc, &localNComponents, local_n_topo, alpaka::hierarchy::Threads{});
           }
+          warp::syncWarpThreads_mask(acc, rep_mask);
 
-          alpaka::syncBlockThreads(acc);
+          const unsigned int cc_idx_stub = warp::shfl_mask(acc, rep_mask, local_topo_offset, low_rep_idx, w_extent);
+          const unsigned int cc_idx = cc_idx_stub + get_logical_lane_idx(acc, rep_mask, lane_idx);
 
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(
-                   acc, group, ::cms::alpakatools::round_up_by(nVertices, w_extent))) {
-            const warp::warp_mask_t active_lanes_mask = alpaka::warp::ballot(acc, idx.local < nVertices);
-            if (idx.local >= nVertices)
-              continue;
+          cc_idx_cache[cc_idx] = rep_idx;
+          component_map[vertex_idx] = cc_idx;
+        }
+        alpaka::syncBlockThreads(acc);
 
-            const unsigned int lane_idx = idx.local % w_extent;
+        const unsigned int nComponents = localNComponents;
+        const unsigned int rep_cc_idx = vertex_idx < nVertices ? component_map[rep_idx] : nVertices;
 
-            const bool is_representative = vertex_idx == rep_idx;
+        // Store nComponents in the global buffer (per block):
+        if (::cms::alpakatools::once_per_block(acc)) {
+          outPFCluster.nTopos() = nComponents;
+          outPFCluster.nSeeds() = nComponents;
+          outPFCluster.nRHFracs() = pfCluster.nRHFracs();
+          outPFCluster.size() = nComponents;
+        }
 
-            const warp::warp_mask_t rep_mask = warp::ballot_mask(acc, active_lanes_mask, is_representative);
+        // Store relevant data (per thread):
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nComponents)) {
+          const unsigned int topo_idx = idx.local;
+          const unsigned int root_idx = cc_idx_cache[topo_idx];
 
-            if (is_work_lane(rep_mask, lane_idx, w_extent) == false)
-              continue;
+          outPFCluster[topo_idx].depth() = pfCluster[root_idx].depth();
+          outPFCluster[topo_idx].topoId() = topo_idx;
+          outPFCluster[topo_idx].energy() = pfCluster[root_idx].energy();
+          outPFCluster[topo_idx].x() = pfCluster[root_idx].x();
+          outPFCluster[topo_idx].y() = pfCluster[root_idx].y();
+          outPFCluster[topo_idx].z() = pfCluster[root_idx].z();
+          outPFCluster[topo_idx].topoRHCount() = pfCluster[root_idx].topoRHCount();
+          // reset buffer 3:
+          common_buf3[topo_idx] = 0;
+        }
+        // total rhfrac count per component (accumulated at root).
+        auto& connected_comp_rhf_sizes = common_buf2;
 
-            const unsigned int low_rep_idx = get_ls1b_idx(acc, rep_mask);
+        unsigned int cc_rhf_relative_offset = 0;
 
-            unsigned int local_topo_offset = 0;
+        const unsigned int rhf_begin = vertex_idx < nVertices ? pfCluster[vertex_idx].rhfracOffset() : 0;
+        const unsigned int rhf_size = vertex_idx < nVertices ? pfCluster[vertex_idx].rhfracSize() : 0;
 
-            if (lane_idx == low_rep_idx) {
-              const unsigned int local_n_topo = alpaka::popcount(acc, rep_mask);
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
 
-              local_topo_offset =
-                  alpaka::atomicAdd(acc, &component_map[nVertices], local_n_topo, alpaka::hierarchy::Threads{});
-            }
-            warp::syncWarpThreads_mask(acc, rep_mask);
+          const unsigned int lane_idx = idx.local % w_extent;
+          const warp::warp_mask_t rep_lane_mask = get_lane_mask(rep_idx % w_extent);
 
-            const unsigned int cc_idx_stub = warp::shfl_mask(acc, rep_mask, local_topo_offset, low_rep_idx, w_extent);
-            const unsigned int cc_idx = cc_idx_stub + get_logical_lane_idx(acc, rep_mask, lane_idx);
+          const warp::warp_mask_t subcomp_mask = warp::match_any_mask(acc, active_lanes_mask, rep_idx);
 
-            cc_roots[cc_idx] = rep_idx;
-            component_map[vertex_idx] = cc_idx;
-          }
-          alpaka::syncBlockThreads(acc);
+          const unsigned int local_subcomponent_rep_idx = get_ls1b_idx(acc, subcomp_mask);
 
-          const unsigned int nComponents = component_map[nVertices];
+          bool update_iso_root_lane = false;
 
-          // Store nComponents in the global buffer (per block):
-          if (::cms::alpakatools::once_per_block(acc)) {
-            outPFCluster.nTopos() = nComponents;
-            outPFCluster.nSeeds() = nComponents;
-            outPFCluster.size() = nComponents;
-          }
+          unsigned int which_warp_idx = std::numeric_limits<unsigned int>::max();
 
-          // Store relevant data (per thread):
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nComponents)) {
-            const unsigned int topo_idx = idx.local;
-            const unsigned int root_idx = cc_roots[topo_idx];
-
-            outPFCluster[topo_idx].depth() = pfCluster[root_idx].depth();
-            outPFCluster[topo_idx].topoId() = topo_idx;
-            outPFCluster[topo_idx].energy() = pfCluster[root_idx].energy();
-            outPFCluster[topo_idx].x() = pfCluster[root_idx].x();
-            outPFCluster[topo_idx].y() = pfCluster[root_idx].y();
-            outPFCluster[topo_idx].z() = pfCluster[root_idx].z();
-            outPFCluster[topo_idx].topoRHCount() = pfCluster[root_idx].topoRHCount();
-          }
-
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(
-                   acc, group, ::cms::alpakatools::round_up_by(nVertices, w_extent))) {
-            const warp::warp_mask_t active_lanes_mask = alpaka::warp::ballot(acc, idx.local < nVertices);
-            // Skip inactive lanes:
-            if (idx.local >= nVertices)
-              continue;
-
-            const unsigned int lane_idx = idx.local % w_extent;
-
-            const warp::warp_mask_t subcomp_mask = warp::match_any_mask(acc, active_lanes_mask, rep_idx);
-            const unsigned int local_subcomponent_rep_idx = get_ls1b_idx(acc, subcomp_mask);
-
-            if (lane_idx == local_subcomponent_rep_idx) {
-              const unsigned int subcomp_size = alpaka::popcount(acc, subcomp_mask);
-
-              alpaka::atomicAdd(acc, &connected_comp_sizes[rep_idx], subcomp_size, alpaka::hierarchy::Threads{});
-            }
-            // Load rhfrac sizes (to compute offsets for rechit fractions):
-            const unsigned int rhf_size = pfCluster[vertex_idx].rhfracSize();
-
-            unsigned int subcomp_rhf_offset = warp_sparse_exclusive_sum(acc, subcomp_mask, rhf_size, lane_idx);
-
-            unsigned int relative_rhf_offset_stub = 0;
-
-            if (lane_idx == local_subcomponent_rep_idx) {
-              // Remark: exclusive sum returns total number of elements
-              // (i.e., subcomponent rhf size) for the lowest lane idx in the mask.
-              relative_rhf_offset_stub = alpaka::atomicAdd(
-                  acc, &connected_comp_rhf_sizes[rep_idx], subcomp_rhf_offset, alpaka::hierarchy::Threads{});
-              subcomp_rhf_offset = 0;  // we need to reset local offset for local rep lane.
-            }
-
-            const unsigned int relative_rhf_offset =
-                warp::shfl_mask(acc, subcomp_mask, relative_rhf_offset_stub, local_subcomponent_rep_idx, w_extent);
-
-            connected_comp_rhf_offsets = relative_rhf_offset + subcomp_rhf_offset;  // store relative offsets
-          }
-
-          alpaka::syncBlockThreads(acc);
-
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(
-                   acc, group, ::cms::alpakatools::round_up_by(nVertices, w_extent))) {
-            const warp::warp_mask_t active_lanes_mask = alpaka::warp::ballot(acc, idx.local < nVertices);
-
-            if (idx.local >= nVertices)
-              continue;
-
-            if (idx.local == 0) {
-              cc_roots[nVertices] = nComponents;  // hold its size
-            }
-
-            const unsigned int lane_idx = idx.local % w_extent;
-
-            const bool is_representative = vertex_idx == rep_idx;
-
-            const warp::warp_mask_t rep_mask = warp::ballot_mask(acc, active_lanes_mask, is_representative);
-
-            const unsigned int connected_comp_rhf_size = is_representative ? connected_comp_rhf_sizes[rep_idx] : 0;
-
-            if (is_work_lane(rep_mask, lane_idx, w_extent)) {
-              const unsigned int cc_idx = component_map[vertex_idx];
-              cc_rhf_sizes[cc_idx] = connected_comp_rhf_size;
+          if (lane_idx == local_subcomponent_rep_idx) {
+            const unsigned int subcomp_size = alpaka::popcount(acc, subcomp_mask);
+            if ((subcomp_size > 1) || (subcomp_size == 1 && !is_representative)) {
+              update_iso_root_lane = true;
+              which_warp_idx = rep_idx / w_extent;
             }
           }
 
-          alpaka::syncBlockThreads(acc);
+          const warp::warp_mask_t iso_root_lanes = warp::ballot_mask(acc, active_lanes_mask, update_iso_root_lane);
 
-          auto& cc_rhf_offsets = common_buf;
+          const warp::warp_mask_t iso_root_lanes_subgroup =
+              warp::match_any_mask(acc, active_lanes_mask, which_warp_idx);
 
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(
-                   acc, group, ::cms::alpakatools::round_up_by(nComponents, w_extent))) {
-            const warp::warp_mask_t active_lanes_mask = alpaka::warp::ballot(acc, idx.local < nComponents);
+          if (is_work_lane(iso_root_lanes, lane_idx)) {
+            // Construct correct rep mask:
+            auto orFn = [] ALPAKA_FN_ACC(const warp::warp_mask_t m1, const warp::warp_mask_t m2) -> warp::warp_mask_t {
+              return m1 | m2;
+            };
 
-            if (idx.local >= nComponents)
-              continue;
+            warp::warp_mask_t selected_iso_root_mask =
+                warp_sparse_reduce(acc, iso_root_lanes_subgroup, lane_idx, rep_lane_mask, orFn);
 
-            const unsigned int warp_idx = idx.local / w_extent;
-            const unsigned int lane_idx = idx.local % w_extent;
+            if (is_ls1b_idx<Acc1D>(iso_root_lanes_subgroup, lane_idx)) {
+              // Temporary WAR (general form of De Morgan's law):
+              const warp::warp_mask_t nonisolated_vertex_lanes = ~selected_iso_root_mask;
 
-            const unsigned int cc_rhf_size = cc_rhf_sizes[idx.local];  //topo_id = idx.local
-
-            const unsigned int cc_rhf_offset = warp_sparse_exclusive_sum(acc, active_lanes_mask, cc_rhf_size, lane_idx);
-            cc_rhf_offsets[idx.local] = lane_idx == 0 ? 0 : cc_rhf_offset;
-
-            if (lane_idx == 0)
-              subcc_offsets[warp_idx] = cc_rhf_offset;
-          }
-          alpaka::syncBlockThreads(acc);
-
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, w_extent)) {
-            const unsigned int cc_rhf_size = subcc_offsets[idx.local];
-
-            const unsigned int cc_rhf_global_offset = warp_exclusive_sum(acc, cc_rhf_size, idx.local);
-
-            subcc_offsets[idx.local] = cc_rhf_global_offset;
-          }
-
-          alpaka::syncBlockThreads(acc);
-
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nComponents)) {
-            const unsigned int warp_idx = idx.local / w_extent;
-
-            const unsigned int cc_rhf_global_offset = warp_idx == 0 ? 0 : subcc_offsets[warp_idx];
-
-            if (warp_idx > 0) {
-              cc_rhf_offsets[idx.local] += cc_rhf_global_offset;
-            }
-          }
-          alpaka::syncBlockThreads(acc);
-
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(
-                   acc, group, ::cms::alpakatools::round_up_by(nVertices, w_extent))) {
-            const warp::warp_mask_t active_lanes_mask = alpaka::warp::ballot(acc, idx.local < nVertices);
-
-            if (idx.local >= nVertices)
-              continue;
-
-            const unsigned int lane_idx = idx.local % w_extent;
-            const unsigned int warp_idx = idx.local / w_extent;
-
-            const unsigned int cc_idx = component_map[rep_idx];
-
-            const unsigned int rhf_begin = pfCluster[idx.local].rhfracOffset();
-            const unsigned int rhf_end = rhf_begin + pfCluster[vertex_idx].rhfracSize();
-
-            const bool is_root = (vertex_idx == rep_idx);
-
-            const unsigned int comp_size = is_root ? connected_comp_sizes[vertex_idx] : 0;
-
-            const bool is_isolated_root = is_root && (comp_size == 1);
-
-            const warp::warp_mask_t iso_root_mask = warp::ballot_mask(acc, active_lanes_mask, is_isolated_root);
-
-            if (lane_idx == 0)
-              isolated_roots[warp_idx] = iso_root_mask;
-
-            unsigned int dst_rhf_offset = connected_comp_rhf_offsets + cc_rhf_offsets[cc_idx];
-
-            const float energy = is_isolated_root == false ? pfRecHit[vertex_seed].energy() : 0.f;
-
-            // Cooperative mode: each "master" lane (iter_lane_idx) owns a PFRecHitFraction span
-            // [pfrhf_offset, pfrhf_offset + pfrhf_size). If that span is longer than 1, we recruit a
-            // subgroup of currently "free" lanes to help process the span in parallel.
-            //
-            // Mask conventions in this scope:
-            // - active_lanes_mask : lanes corresponding to in-range clusters (plus any forced lanes).
-            // - free_lanes_mask   : lanes currently available to be assigned as cooperative workers
-            //                       (subset of active_lanes_mask).
-            //                       if a swap_lanes_mask (see below) is a non-empty set, then free lanes mask
-            //                       also includes lanes for later swap operation
-            // - swap_lanes_mask   : lanes that currently hold state and must be preserved to be swapped out to some free lanes.
-            if constexpr (is_cooperative) {
-              const unsigned int eff_w_extent = alpaka::popcount(acc, active_lanes_mask);
-
-              unsigned int src_rhf_offset = rhf_begin;
-              unsigned int rhf_size = rhf_end - rhf_begin;
-              // Define iteration parameters:
-              unsigned int iter_lane_idx = 0;
-
-              while (iter_lane_idx < eff_w_extent) {
-                // Identify lanes whose remaining PFRecHitFraction work is exactly one element.
-                // These lanes cannot benefit from recruiting cooperative helpers and are handled by a fast path.
-                // Note: pfrhf_size may have been reduced in a previous iteration due to leftover handling.
-                const warp::warp_mask_t single_worklane_mask = warp::ballot_mask(acc, active_lanes_mask, rhf_size == 1);
-
-                // Create temporary per-iteration masks for cooperative scheduling:
-                // -- how many vacant lanes in the warp, i.e., lanes available to become cooperators in this iteration ('free_lanes_mask')
-                // -- how many reserved lanes in the warp ('swap_lanes_mask'); note that free_lanes_mask must also include reserved lanes
-                warp::warp_mask_t free_lanes_mask = active_lanes_mask;
-                warp::warp_mask_t swap_lanes_mask = static_cast<warp::warp_mask_t>(0);
-
-                unsigned int swap_lane_idx{w_extent};  //assigned to some default value (it's outside of the warp range)
-                unsigned int swap_lanes_num{0};        //no lanes in the warp keep iter lane idx for swap operation
-
-                unsigned int proc_lane_idx{w_extent};
-                unsigned int proc_dst_rhf_offset{dst_rhf_offset};
-                unsigned int proc_src_rhf_offset{src_rhf_offset};
-
-                bool update_params = true;
-
-                warp::syncWarpThreads_mask(acc, active_lanes_mask);
-
-                while (update_params) {
-                  const warp::warp_mask_t iter_lane_mask = get_lane_mask(iter_lane_idx);
-
-                  const bool is_master_lane = iter_lane_idx == lane_idx;
-                  // first we need to check whether the current iter lane itself is vacant.
-                  if ((free_lanes_mask & iter_lane_mask) == 0) {
-                    // The current iteration lane is not free: it currently holds state that must be preserved.
-                    // Mark it as reserved-for-swap; later we move its state into an actually free lane.
-                    swap_lanes_mask = swap_lanes_mask | iter_lane_mask;
-                    ++swap_lanes_num;  //how many lanes are reserved for swap
-
-                    if (is_master_lane && iter_lane_idx != proc_lane_idx)
-                      swap_lane_idx = proc_lane_idx;
-                  } else {
-                    // update the free mask (erase master-lane bit):
-                    free_lanes_mask &= ~iter_lane_mask;
-                  }
-                  // 'iter_lane_idx' is warp-uniform; thus all lanes agree on which lane is the current master.
-                  // Check whether the current lane has exactly one element of work remaining.
-                  const bool is_single_work_lane = is_work_lane(single_worklane_mask, iter_lane_idx, w_extent);
-                  // Available cooperative subgroup capacity: free lanes minus those reserved to preserve state (swap lanes).
-                  // Note: the name 'subgroup' is used here because it does not take into account iterative (master) lane itself.
-                  const unsigned int free_subgroup_size =
-                      static_cast<std::uint32_t>(alpaka::popcount(acc, free_lanes_mask)) - swap_lanes_num;
-
-                  if (is_single_work_lane) {
-                    if (is_master_lane) {
-                      proc_lane_idx = iter_lane_idx;
-                      proc_dst_rhf_offset = dst_rhf_offset;
-                      proc_src_rhf_offset = src_rhf_offset;
-                    }
-                    iter_lane_idx += 1;
-                    update_params =
-                        iter_lane_idx < eff_w_extent &&
-                        (static_cast<std::uint32_t>(alpaka::popcount(acc, free_lanes_mask)) > swap_lanes_num);
-                    continue;
-                  }
-
-                  const unsigned int proc_rhf_size =
-                      is_master_lane ? (rhf_size - 1) : 0;  //exclude master lane itself..
-                  // Broadcast worksize (all active lanes):
-                  const unsigned int iter_rhf_size =
-                      warp::shfl_mask(acc, active_lanes_mask, proc_rhf_size, iter_lane_idx, w_extent);
-
-                  const unsigned int coop_subgroup_size = alpaka::math::min(acc, iter_rhf_size, free_subgroup_size);
-
-                  // Check which lane can cooperate in the work:
-                  // -- it must be vacant (corresponding bit in 'free_lanes_mask' must be set)
-                  // -- among free lanes, it must be within the first 'coop_subgroup_size' positions
-                  //    (using logical indexing over free_lanes_mask)
-                  // -- vacant lanes must not be reserved for swapping operation (which is already taking into account in 'coop_subgroup_size')
-                  const bool is_coop_subgroup_lane =
-                      is_work_lane(free_lanes_mask, lane_idx, w_extent)
-                          ? (get_logical_lane_idx(acc, free_lanes_mask, lane_idx) < coop_subgroup_size)
-                          : false;
-                  // Cooperative subgroup lanes are drawn from free_lanes_mask; by construction this excludes the master lane
-                  // (because the master lane was already removed from free_lanes_mask earlier).
-                  const warp::warp_mask_t coop_subgroup_mask = warp::ballot_mask(
-                      acc, active_lanes_mask, is_coop_subgroup_lane);  //Note: it excludes master lane.
-                  // Erase corresponding bits in 'free_lanes_mask'
-                  free_lanes_mask &= ~coop_subgroup_mask;
-                  // Update parameters only for cooperative subgroup lanes (and the master lane)
-                  // if 'true' - do broadcast of iter. lane index and corresponding rechit offset from source (current iterative) lane:
-                  if (is_coop_subgroup_lane || is_master_lane)
-                    proc_lane_idx = warp::shfl_mask(
-                        acc, coop_subgroup_mask | iter_lane_mask, iter_lane_idx, iter_lane_idx, w_extent);
-
-                  // Now we need to check whether we need to increment iteration lane index.
-                  // Check if worksize less or equal subgroup size, if 'true', increment iter lane index for the next rec hit fraction array:
-                  if (iter_rhf_size <= free_subgroup_size) {
-                    iter_lane_idx += 1;
-                    // if 'false', we  have to update a leftover work for the current master lane (will continue in the next iteration):
-                  } else if (is_master_lane) {
-                    // update rechit fraction offset for the next iteration
-                    proc_dst_rhf_offset = dst_rhf_offset;
-                    dst_rhf_offset +=
-                        coop_subgroup_size + 1;  //we need to take into account the master lane itself (hence "+1" here)
-                    proc_src_rhf_offset = src_rhf_offset;
-                    src_rhf_offset +=
-                        coop_subgroup_size + 1;  //we need to take into account the master lane itself (hence "+1" here)
-                    // compute remaining work size (that is a leftover rec hit fraction size)
-                    rhf_size = iter_rhf_size - coop_subgroup_size;
-                  }
-                  update_params = (iter_lane_idx < eff_w_extent) &&
-                                  (static_cast<std::uint32_t>(alpaka::popcount(acc, free_lanes_mask)) > swap_lanes_num);
-                }
-                // Now we need to swap cached values to vacant lanes:
-                if (is_work_lane(free_lanes_mask | swap_lanes_mask, lane_idx, w_extent)) {
-                  const unsigned int src_log_lane_idx = is_work_lane(free_lanes_mask, lane_idx, w_extent)
-                                                            ? get_logical_lane_idx(acc, free_lanes_mask, lane_idx)
-                                                            : w_extent;
-                  const unsigned int src_phys_lane_idx =
-                      src_log_lane_idx < swap_lanes_num ? get_physical_lane_idx(acc, swap_lanes_mask, src_log_lane_idx)
-                                                        : lane_idx;
-
-                  const unsigned int tmp_proc_lane_idx = warp::shfl_mask(
-                      acc, free_lanes_mask | swap_lanes_mask, swap_lane_idx, src_phys_lane_idx, w_extent);
-
-                  if (is_work_lane(free_lanes_mask, lane_idx, w_extent) && src_log_lane_idx < swap_lanes_num)
-                    proc_lane_idx = tmp_proc_lane_idx;
-                }
-
-                const warp::warp_mask_t nonvacant_lanes_mask =
-                    warp::ballot_mask(acc, active_lanes_mask, proc_lane_idx != w_extent);
-
-                if (is_work_lane(nonvacant_lanes_mask, lane_idx, w_extent) == false)
-                  continue;
-
-                const warp::warp_mask_t coop_group_mask =
-                    warp::match_any_mask(acc, nonvacant_lanes_mask, proc_lane_idx);
-
-                const float proc_cc_idx = warp::shfl_mask(acc, coop_group_mask, cc_idx, proc_lane_idx, w_extent);
-
-                const unsigned int coop_dst_rhf_offset =
-                    warp::shfl_mask(acc, coop_group_mask, proc_dst_rhf_offset, proc_lane_idx, w_extent);
-                const unsigned int coop_src_rhf_offset =
-                    warp::shfl_mask(acc, coop_group_mask, proc_src_rhf_offset, proc_lane_idx, w_extent);
-
-                const auto log_lane_idx = get_logical_lane_idx(acc, coop_group_mask, lane_idx);
-                const int dst_rhfrac_idx = log_lane_idx + coop_dst_rhf_offset;
-                const int src_rhfrac_idx = log_lane_idx + coop_src_rhf_offset;
-
-                outPFRecHitFracs[dst_rhfrac_idx].frac() = pfRecHitFracs[src_rhfrac_idx].frac();
-                outPFRecHitFracs[dst_rhfrac_idx].pfrhIdx() = pfRecHitFracs[src_rhfrac_idx].pfrhIdx();
-                outPFRecHitFracs[dst_rhfrac_idx].pfcIdx() = proc_cc_idx;
-              }
-            } else {
-              unsigned int dst_rhfrac_idx = dst_rhf_offset;
-              for (unsigned int src_rhfrac_idx = rhf_begin; src_rhfrac_idx < rhf_end; src_rhfrac_idx++) {
-                outPFRecHitFracs[dst_rhfrac_idx].frac() = pfRecHitFracs[src_rhfrac_idx].frac();
-                outPFRecHitFracs[dst_rhfrac_idx].pfrhIdx() = pfRecHitFracs[src_rhfrac_idx].pfrhIdx();
-                outPFRecHitFracs[dst_rhfrac_idx].pfcIdx() = cc_idx;
-                ++dst_rhfrac_idx;
-              }
-            }
-
-            auto compFn = [] ALPAKA_FN_ACC(const float a, const float b) -> float { return a > b ? a : b; };
-
-            const warp::warp_mask_t updated_active_lanes_mask =
-                warp::ballot_mask(acc, active_lanes_mask, is_isolated_root == false);
-
-            if (is_isolated_root)
-              continue;
-
-            const warp::warp_mask_t subcomponent_mask = warp::match_any_mask(acc, updated_active_lanes_mask, rep_idx);
-
-            const unsigned int low_local_rep_idx = get_ls1b_idx(acc, subcomponent_mask);
-
-            const float max_energy = warp_sparse_reduce(acc, subcomponent_mask, lane_idx, energy, compFn);
-            // Equality on energy is intentional: max_energy is selected from lane values via shuffles/reduction,
-            // so it is bitwise-equal to at least one participating lane's energy.
-            const warp::warp_mask_t max_energy_lanes_mask =
-                warp::ballot_mask(acc, subcomponent_mask, max_energy == energy);
-
-            const unsigned int max_energy_lane_idx = alpaka::ffs(acc, static_cast<int>(max_energy_lanes_mask)) - 1;
-
-            //need to store seed:
-            const auto seed_max = warp::shfl_mask(acc, subcomponent_mask, vertex_seed, max_energy_lane_idx, w_extent);
-            const auto energy_max = warp::shfl_mask(acc, subcomponent_mask, max_energy, max_energy_lane_idx, w_extent);
-
-            warp::syncWarpThreads_mask(acc, updated_active_lanes_mask);
-            // Energies are assumed non-negative; bit-cast uint ordering matches float ordering for atomicMax.
-            if (lane_idx == low_local_rep_idx) {
-              unsigned int x = std::bit_cast<unsigned int>(energy_max);
-              alpaka::atomicMax(acc, &cc_energies[cc_idx], x);
-              vertex_seed = seed_max;
-              vertex_energy = x;
+              alpaka::atomicAnd(
+                  acc, &vertex_mask[which_warp_idx], nonisolated_vertex_lanes, alpaka::hierarchy::Threads{});
             }
           }
 
-          alpaka::syncBlockThreads(acc);
+          unsigned int subcomp_rhf_offset = warp_sparse_exclusive_sum(acc, subcomp_mask, rhf_size, lane_idx);
 
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(
-                   acc, group, ::cms::alpakatools::round_up_by(nVertices, w_extent))) {
-            const warp::warp_mask_t active_lanes_mask = alpaka::warp::ballot(acc, idx.local < nVertices);
-            if (idx.local >= nVertices)
-              continue;
+          unsigned int relative_rhf_offset_stub = 0;
 
-            const unsigned int lane_idx = idx.local % w_extent;
-            const unsigned int warp_idx = idx.local / w_extent;
-
-            const warp::warp_mask_t iso_root_mask = isolated_roots[warp_idx];
-
-            const unsigned int cc_idx = component_map[rep_idx];
-
-            const bool is_isolated_root = is_work_lane(iso_root_mask, lane_idx, w_extent);
-
-            const warp::warp_mask_t updated_active_lanes_mask =
-                warp::ballot_mask(acc, active_lanes_mask, is_isolated_root == false);
-
-            if (is_isolated_root) {
-              cc_seeds[cc_idx] = vertex_seed;
-              continue;
-            }
-
-            const warp::warp_mask_t subcomponent_mask = warp::match_any_mask(acc, updated_active_lanes_mask, rep_idx);
-            const unsigned int low_local_rep_idx = get_ls1b_idx(acc, subcomponent_mask);
-
-            if (lane_idx == low_local_rep_idx) {
-              const unsigned int max_energy = cc_energies[cc_idx];
-              // We have only one vertex that holds max energy, so no race condition here:
-              if (vertex_energy == max_energy)
-                cc_seeds[cc_idx] = vertex_seed;
-            }
+          if (lane_idx == local_subcomponent_rep_idx) {
+            // Remark: exclusive sum returns total number of elements
+            // (i.e., subcomponent rhf size) for the lowest lane idx in the mask.
+            relative_rhf_offset_stub = alpaka::atomicAdd(
+                acc, &connected_comp_rhf_sizes[rep_idx], subcomp_rhf_offset, alpaka::hierarchy::Threads{});
+            subcomp_rhf_offset = 0;  // we need to reset local offset for local rep lane.
           }
-          alpaka::syncBlockThreads(acc);
 
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nComponents)) {
-            const unsigned int topo_idx = idx.local;
+          const unsigned int relative_rhf_offset =
+              warp::shfl_mask(acc, subcomp_mask, relative_rhf_offset_stub, local_subcomponent_rep_idx, w_extent);
+          cc_rhf_relative_offset = relative_rhf_offset + subcomp_rhf_offset;  // store relative offsets
+        }
 
-            outPFCluster[topo_idx].rhfracOffset() = cc_rhf_offsets[topo_idx];
-            outPFCluster[topo_idx].rhfracSize() = cc_rhf_sizes[topo_idx];
-            outPFCluster[topo_idx].seedRHIdx() = cc_seeds[topo_idx];
+        alpaka::syncBlockThreads(acc);
+
+        // total rhfrac count per component (compact indexing).
+        auto& cc_rhf_sizes = common_buf3;
+
+        // Reset buffer 1:
+        if (vertex_idx < max_w_items * w_extent)
+          common_buf1[vertex_idx] = 0;
+
+        if (is_representative) {
+          cc_rhf_sizes[rep_cc_idx] = connected_comp_rhf_sizes[rep_idx];
+        }
+
+        alpaka::syncBlockThreads(acc);
+
+        unsigned int cc_rhf_offset = 0;
+
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nComponents)) {
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+
+          const unsigned int warp_idx = idx.local / w_extent;
+          const unsigned int lane_idx = idx.local % w_extent;
+
+          const unsigned int cc_rhf_size = cc_rhf_sizes[idx.local];  //topo_id = idx.local
+          // Store rhf sizes in memory:
+          outPFCluster[idx.local].rhfracSize() = cc_rhf_size;
+
+          // compute warp-local rhf offsets:
+          cc_rhf_offset = warp_sparse_exclusive_sum(acc, active_lanes_mask, cc_rhf_size, lane_idx);
+
+          if (lane_idx == 0) {
+            subcc_offsets[warp_idx] = cc_rhf_offset;
+            cc_rhf_offset = 0;
           }
         }
-      }  //end of solo-block branch
+        alpaka::syncBlockThreads(acc);
+
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, w_extent)) {
+          const unsigned int cc_rhf_size = subcc_offsets[idx.local];
+
+          const unsigned int cc_rhf_global_offset = warp_exclusive_sum(acc, cc_rhf_size, idx.local);
+
+          subcc_offsets[idx.local] = cc_rhf_global_offset;
+        }
+
+        alpaka::syncBlockThreads(acc);
+
+        auto& cc_rhf_offsets = common_buf2;
+
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nComponents)) {
+          const unsigned int warp_idx = idx.local / w_extent;
+
+          const unsigned int cc_rhf_global_offset = warp_idx == 0 ? 0 : subcc_offsets[warp_idx];
+
+          if (warp_idx > 0)
+            cc_rhf_offset += cc_rhf_global_offset;
+
+          cc_rhf_offsets[idx.local] = cc_rhf_offset;
+        }
+        alpaka::syncBlockThreads(acc);
+
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nComponents)) {
+          outPFCluster[idx.local].rhfracOffset() = cc_rhf_offset;
+        }
+
+        unsigned int vertex_seed = vertex_idx < nVertices ? pfCluster[vertex_idx].seedRHIdx() : 0;
+
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+
+          const unsigned int lane_idx = idx.local % w_extent;
+
+          const unsigned int rhf_end = rhf_begin + rhf_size;
+
+          unsigned int dst_rhf_offset = cc_rhf_relative_offset + cc_rhf_offsets[rep_cc_idx];
+
+          // Cooperative mode: each "master" lane (iter_lane_idx) owns a PFRecHitFraction span
+          // [pfrhf_offset, pfrhf_offset + pfrhf_size). If that span is longer than 1, we recruit a
+          // subgroup of currently "free" lanes to help process the span in parallel.
+          //
+          // Mask conventions in this scope:
+          // - active_lanes_mask : lanes corresponding to in-range clusters (plus any forced lanes).
+          // - free_lanes_mask   : lanes currently available to be assigned as cooperative workers
+          //                       (subset of active_lanes_mask).
+          //                       if a swap_lanes_mask (see below) is a non-empty set, then free lanes mask
+          //                       also includes lanes for later swap operation
+          // - swap_lanes_mask   : lanes that currently hold state and must be preserved to be swapped out to some free lanes.
+          if constexpr (is_cooperative) {
+            const unsigned int eff_w_extent = alpaka::popcount(acc, active_lanes_mask);
+
+            unsigned int src_rhf_offset = rhf_begin;
+            unsigned int rhf_size = rhf_end - rhf_begin;
+            // Define iteration parameters:
+            unsigned int iter_lane_idx = 0;
+
+            while (iter_lane_idx < eff_w_extent) {
+              // Identify lanes whose remaining PFRecHitFraction work is exactly one element.
+              // These lanes cannot benefit from recruiting cooperative helpers and are handled by a fast path.
+              // Note: pfrhf_size may have been reduced in a previous iteration due to leftover handling.
+              const warp::warp_mask_t single_worklane_mask = warp::ballot_mask(acc, active_lanes_mask, rhf_size == 1);
+
+              // Create temporary per-iteration masks for cooperative scheduling:
+              // -- how many vacant lanes in the warp, i.e., lanes available to become cooperators in this iteration ('free_lanes_mask')
+              // -- how many reserved lanes in the warp ('swap_lanes_mask'); note that free_lanes_mask must also include reserved lanes
+              warp::warp_mask_t free_lanes_mask = active_lanes_mask;
+              warp::warp_mask_t swap_lanes_mask = static_cast<warp::warp_mask_t>(0);
+
+              unsigned int swap_lane_idx{w_extent};  //assigned to some default value (it's outside of the warp range)
+              unsigned int swap_lanes_num{0};        //no lanes in the warp keep iter lane idx for swap operation
+
+              unsigned int proc_lane_idx{w_extent};
+              unsigned int proc_dst_rhf_offset{dst_rhf_offset};
+              unsigned int proc_src_rhf_offset{src_rhf_offset};
+
+              bool update_params = true;
+
+              warp::syncWarpThreads_mask(acc, active_lanes_mask);
+
+              while (update_params) {
+                const warp::warp_mask_t iter_lane_mask = get_lane_mask(iter_lane_idx);
+
+                const bool is_master_lane = iter_lane_idx == lane_idx;
+                // first we need to check whether the current iter lane itself is vacant.
+                if ((free_lanes_mask & iter_lane_mask) == 0) {
+                  // The current iteration lane is not free: it currently holds state that must be preserved.
+                  // Mark it as reserved-for-swap; later we move its state into an actually free lane.
+                  swap_lanes_mask = swap_lanes_mask | iter_lane_mask;
+                  ++swap_lanes_num;  //how many lanes are reserved for swap
+
+                  if (is_master_lane && iter_lane_idx != proc_lane_idx)
+                    swap_lane_idx = proc_lane_idx;
+                } else {
+                  // update the free mask (erase master-lane bit):
+                  free_lanes_mask &= ~iter_lane_mask;
+                }
+                // 'iter_lane_idx' is warp-uniform; thus all lanes agree on which lane is the current master.
+                // Check whether the current lane has exactly one element of work remaining.
+                const bool is_single_work_lane = is_work_lane(single_worklane_mask, iter_lane_idx);
+                // Available cooperative subgroup capacity: free lanes minus those reserved to preserve state (swap lanes).
+                // Note: the name 'subgroup' is used here because it does not take into account iterative (master) lane itself.
+                const unsigned int free_subgroup_size =
+                    static_cast<std::uint32_t>(alpaka::popcount(acc, free_lanes_mask)) - swap_lanes_num;
+
+                if (is_single_work_lane) {
+                  if (is_master_lane) {
+                    proc_lane_idx = iter_lane_idx;
+                    proc_dst_rhf_offset = dst_rhf_offset;
+                    proc_src_rhf_offset = src_rhf_offset;
+                  }
+                  iter_lane_idx += 1;
+                  update_params = iter_lane_idx < eff_w_extent &&
+                                  (static_cast<std::uint32_t>(alpaka::popcount(acc, free_lanes_mask)) > swap_lanes_num);
+                  continue;
+                }
+
+                const unsigned int proc_rhf_size = is_master_lane ? (rhf_size - 1) : 0;  //exclude master lane itself..
+                // Broadcast worksize (all active lanes):
+                const unsigned int iter_rhf_size =
+                    warp::shfl_mask(acc, active_lanes_mask, proc_rhf_size, iter_lane_idx, w_extent);
+
+                const unsigned int coop_subgroup_size = alpaka::math::min(acc, iter_rhf_size, free_subgroup_size);
+
+                // Check which lane can cooperate in the work:
+                // -- it must be vacant (corresponding bit in 'free_lanes_mask' must be set)
+                // -- among free lanes, it must be within the first 'coop_subgroup_size' positions
+                //    (using logical indexing over free_lanes_mask)
+                // -- vacant lanes must not be reserved for swapping operation (which is already taking into account in 'coop_subgroup_size')
+                const bool is_coop_subgroup_lane =
+                    is_work_lane(free_lanes_mask, lane_idx)
+                        ? (get_logical_lane_idx(acc, free_lanes_mask, lane_idx) < coop_subgroup_size)
+                        : false;
+                // Cooperative subgroup lanes are drawn from free_lanes_mask; by construction this excludes the master lane
+                // (because the master lane was already removed from free_lanes_mask earlier).
+                const warp::warp_mask_t coop_subgroup_mask =
+                    warp::ballot_mask(acc, active_lanes_mask, is_coop_subgroup_lane);  //Note: it excludes master lane.
+                // Erase corresponding bits in 'free_lanes_mask'
+                free_lanes_mask &= ~coop_subgroup_mask;
+                // Update parameters only for cooperative subgroup lanes (and the master lane)
+                // if 'true' - do broadcast of iter. lane index and corresponding rechit offset from source (current iterative) lane:
+                if (is_coop_subgroup_lane || is_master_lane)
+                  proc_lane_idx =
+                      warp::shfl_mask(acc, coop_subgroup_mask | iter_lane_mask, iter_lane_idx, iter_lane_idx, w_extent);
+
+                // Now we need to check whether we need to increment iteration lane index.
+                // Check if worksize less or equal subgroup size, if 'true', increment iter lane index for the next rec hit fraction array:
+                if (iter_rhf_size <= free_subgroup_size) {
+                  iter_lane_idx += 1;
+                  // if 'false', we  have to update a leftover work for the current master lane (will continue in the next iteration):
+                } else if (is_master_lane) {
+                  // update rechit fraction offset for the next iteration
+                  proc_dst_rhf_offset = dst_rhf_offset;
+                  dst_rhf_offset +=
+                      coop_subgroup_size + 1;  //we need to take into account the master lane itself (hence "+1" here)
+                  proc_src_rhf_offset = src_rhf_offset;
+                  src_rhf_offset +=
+                      coop_subgroup_size + 1;  //we need to take into account the master lane itself (hence "+1" here)
+                  // compute remaining work size (that is a leftover rec hit fraction size)
+                  rhf_size = iter_rhf_size - coop_subgroup_size;
+                }
+                update_params = (iter_lane_idx < eff_w_extent) &&
+                                (static_cast<std::uint32_t>(alpaka::popcount(acc, free_lanes_mask)) > swap_lanes_num);
+              }
+              // Now we need to swap cached values to vacant lanes:
+              if (is_work_lane(free_lanes_mask | swap_lanes_mask, lane_idx)) {
+                const unsigned int src_log_lane_idx = is_work_lane(free_lanes_mask, lane_idx)
+                                                          ? get_logical_lane_idx(acc, free_lanes_mask, lane_idx)
+                                                          : w_extent;
+                const unsigned int src_phys_lane_idx =
+                    src_log_lane_idx < swap_lanes_num ? get_physical_lane_idx(acc, swap_lanes_mask, src_log_lane_idx)
+                                                      : lane_idx;
+
+                const unsigned int tmp_proc_lane_idx =
+                    warp::shfl_mask(acc, free_lanes_mask | swap_lanes_mask, swap_lane_idx, src_phys_lane_idx, w_extent);
+
+                if (is_work_lane(free_lanes_mask, lane_idx) && src_log_lane_idx < swap_lanes_num)
+                  proc_lane_idx = tmp_proc_lane_idx;
+              }
+
+              const warp::warp_mask_t nonvacant_lanes_mask =
+                  warp::ballot_mask(acc, active_lanes_mask, proc_lane_idx != w_extent);
+
+              if (is_work_lane(nonvacant_lanes_mask, lane_idx) == false)
+                continue;
+
+              const warp::warp_mask_t coop_group_mask = warp::match_any_mask(acc, nonvacant_lanes_mask, proc_lane_idx);
+
+              const float proc_cc_idx = warp::shfl_mask(acc, coop_group_mask, rep_cc_idx, proc_lane_idx, w_extent);
+
+              const unsigned int coop_dst_rhf_offset =
+                  warp::shfl_mask(acc, coop_group_mask, proc_dst_rhf_offset, proc_lane_idx, w_extent);
+              const unsigned int coop_src_rhf_offset =
+                  warp::shfl_mask(acc, coop_group_mask, proc_src_rhf_offset, proc_lane_idx, w_extent);
+
+              const auto log_lane_idx = get_logical_lane_idx(acc, coop_group_mask, lane_idx);
+              const int dst_rhfrac_idx = log_lane_idx + coop_dst_rhf_offset;
+              const int src_rhfrac_idx = log_lane_idx + coop_src_rhf_offset;
+
+              outPFRecHitFracs[dst_rhfrac_idx].frac() = pfRecHitFracs[src_rhfrac_idx].frac();
+              outPFRecHitFracs[dst_rhfrac_idx].pfrhIdx() = pfRecHitFracs[src_rhfrac_idx].pfrhIdx();
+              outPFRecHitFracs[dst_rhfrac_idx].pfcIdx() = proc_cc_idx;
+            }
+          } else {
+            unsigned int dst_rhfrac_idx = dst_rhf_offset;
+            for (unsigned int src_rhfrac_idx = rhf_begin; src_rhfrac_idx < rhf_end; src_rhfrac_idx++) {
+              outPFRecHitFracs[dst_rhfrac_idx].frac() = pfRecHitFracs[src_rhfrac_idx].frac();
+              outPFRecHitFracs[dst_rhfrac_idx].pfrhIdx() = pfRecHitFracs[src_rhfrac_idx].pfrhIdx();
+              outPFRecHitFracs[dst_rhfrac_idx].pfcIdx() = rep_cc_idx;
+              ++dst_rhfrac_idx;
+            }
+          }
+        }
+
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const unsigned int warp_idx = idx.local / w_extent;
+          const unsigned int lane_idx = idx.local % w_extent;
+
+          if (is_representative) {
+            const warp::warp_mask_t lane_mask = get_lane_mask(lane_idx);
+            const warp::warp_mask_t non_isolated_vertices = vertex_mask[warp_idx];
+            const bool is_isolated_root = ((lane_mask & non_isolated_vertices));
+
+            if (is_isolated_root) {
+              cc_energy_seed[rep_cc_idx] = static_cast<uint64_t>(vertex_seed);
+              continue;
+            }
+          }
+
+          const warp::warp_mask_t updated_active_lanes_mask = alpaka::warp::activemask(acc);
+
+          const float energy = pfRecHit[vertex_seed].energy();
+
+          const warp::warp_mask_t subcomponent_mask = warp::match_any_mask(acc, updated_active_lanes_mask, rep_idx);
+
+          auto compFn = [] ALPAKA_FN_ACC(const float a, const float b) -> float { return a > b ? a : b; };
+
+          const float max_energy = warp_sparse_reduce(acc, subcomponent_mask, lane_idx, energy, compFn);
+          // Equality on energy is intentional: max_energy is selected from lane values via shuffles/reduction,
+          // so it is bitwise-equal to at least one participating lane's energy.
+          const warp::warp_mask_t max_energy_lanes_mask =
+              warp::ballot_mask(acc, subcomponent_mask, max_energy == energy);
+
+          const unsigned int max_energy_lane_idx = alpaka::ffs(acc, static_cast<int>(max_energy_lanes_mask)) - 1;
+
+          //need to store seed:
+          const auto seed_max = warp::shfl_mask(acc, subcomponent_mask, vertex_seed, max_energy_lane_idx, w_extent);
+          const auto energy_max = warp::shfl_mask(acc, subcomponent_mask, max_energy, max_energy_lane_idx, w_extent);
+
+          // Energies are assumed non-negative; bit-cast uint ordering matches float ordering for atomicMax.
+          if (is_ls1b_idx<Acc1D>(subcomponent_mask, lane_idx)) {
+            uint32_t e_uint = std::bit_cast<unsigned int>(energy_max);
+            uint64_t x = (static_cast<uint64_t>(e_uint) << 32) | static_cast<uint64_t>(seed_max);
+            alpaka::atomicMax(acc, &cc_energy_seed[rep_cc_idx], x);
+          }
+        }
+
+        alpaka::syncBlockThreads(acc);
+
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nComponents)) {
+          const unsigned int topo_idx = idx.local;
+          // Retrieve relevant seed :
+          uint64_t energy_seed_packed = cc_energy_seed[topo_idx];
+          uint32_t seed_to_store = static_cast<uint32_t>(energy_seed_packed & 0xFFFFFFFF);
+
+          outPFCluster[topo_idx].seedRHIdx() = seed_to_store;
+        }
+      }
     }
   };
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCEpilogue.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCEpilogue.h
@@ -150,7 +150,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       // component offsets
       auto& subcc_offsets(alpaka::declareSharedVar<uint32_t[w_extent], __COUNTER__>(acc));
       // isolate root flag : 0 - an isolated root vertex, 1 - a non-isolated root vertex
-      auto& vertex_mask(alpaka::declareSharedVar<warp::warp_mask_t[max_w_items], __COUNTER__>(acc));
+      auto& vertex_mask(alpaka::declareSharedVar<warp::warp_mask_t[w_extent], __COUNTER__>(acc));
 
       auto& common_buf1(alpaka::declareSharedVar<uint32_t[max_w_items * w_extent], __COUNTER__>(acc));
       auto& common_buf2(alpaka::declareSharedVar<uint32_t[max_w_items * w_extent], __COUNTER__>(acc));
@@ -180,7 +180,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
           cc_energy_seed[idx.local] = 0;
 
-          if (idx.local < max_w_items) {
+          if (idx.local < w_extent) {
             subcc_offsets[idx.local] = 0;
             vertex_mask[idx.local] = active_lanes_mask;  //needed for AND operation
           }
@@ -270,41 +270,41 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
           const unsigned int local_subcomponent_rep_idx = get_ls1b_idx(acc, subcomp_mask);
 
-          bool update_iso_root_lane = false;
+          if constexpr (std::is_same_v<alpaka::AccToTag<Acc1D>, alpaka::TagGpuCudaRt>) {
+            bool update_iso_root_lane = false;
 
-          unsigned int which_warp_idx = std::numeric_limits<unsigned int>::max();
+            unsigned int which_warp_idx = std::numeric_limits<unsigned int>::max();
 
-          if (lane_idx == local_subcomponent_rep_idx) {
-            const unsigned int subcomp_size = alpaka::popcount(acc, subcomp_mask);
-            if ((subcomp_size > 1) || (subcomp_size == 1 && !is_representative)) {
-              update_iso_root_lane = true;
-              which_warp_idx = rep_idx / w_extent;
+            if (lane_idx == local_subcomponent_rep_idx) {
+              const unsigned int subcomp_size = alpaka::popcount(acc, subcomp_mask);
+              if ((subcomp_size > 1) || (subcomp_size == 1 && !is_representative)) {
+                update_iso_root_lane = true;
+                which_warp_idx = rep_idx / w_extent;
+              }
+            }
+
+            const warp::warp_mask_t iso_root_lanes = warp::ballot_mask(acc, active_lanes_mask, update_iso_root_lane);
+
+            const warp::warp_mask_t iso_root_lanes_subgroup =
+                warp::match_any_mask(acc, active_lanes_mask, which_warp_idx);
+
+            if (is_work_lane(iso_root_lanes, lane_idx)) {
+              // Construct correct rep mask:
+              auto orFn = [] ALPAKA_FN_ACC(const warp::warp_mask_t m1,
+                                           const warp::warp_mask_t m2) -> warp::warp_mask_t { return m1 | m2; };
+
+              warp::warp_mask_t selected_iso_root_mask =
+                  warp_sparse_reduce(acc, iso_root_lanes_subgroup, lane_idx, rep_lane_mask, orFn);
+
+              if (is_ls1b_idx<Acc1D>(iso_root_lanes_subgroup, lane_idx)) {
+                // Temporary WAR (general form of De Morgan's law):
+                const warp::warp_mask_t nonisolated_vertex_lanes = ~selected_iso_root_mask;
+
+                alpaka::atomicAnd(
+                    acc, &vertex_mask[which_warp_idx], nonisolated_vertex_lanes, alpaka::hierarchy::Threads{});
+              }
             }
           }
-
-          const warp::warp_mask_t iso_root_lanes = warp::ballot_mask(acc, active_lanes_mask, update_iso_root_lane);
-
-          const warp::warp_mask_t iso_root_lanes_subgroup =
-              warp::match_any_mask(acc, active_lanes_mask, which_warp_idx);
-
-          if (is_work_lane(iso_root_lanes, lane_idx)) {
-            // Construct correct rep mask:
-            auto orFn = [] ALPAKA_FN_ACC(const warp::warp_mask_t m1, const warp::warp_mask_t m2) -> warp::warp_mask_t {
-              return m1 | m2;
-            };
-
-            warp::warp_mask_t selected_iso_root_mask =
-                warp_sparse_reduce(acc, iso_root_lanes_subgroup, lane_idx, rep_lane_mask, orFn);
-
-            if (is_ls1b_idx<Acc1D>(iso_root_lanes_subgroup, lane_idx)) {
-              // Temporary WAR (general form of De Morgan's law):
-              const warp::warp_mask_t nonisolated_vertex_lanes = ~selected_iso_root_mask;
-
-              alpaka::atomicAnd(
-                  acc, &vertex_mask[which_warp_idx], nonisolated_vertex_lanes, alpaka::hierarchy::Threads{});
-            }
-          }
-
           unsigned int subcomp_rhf_offset = warp_sparse_exclusive_sum(acc, subcomp_mask, rhf_size, lane_idx);
 
           unsigned int relative_rhf_offset_stub = 0;
@@ -360,9 +360,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         alpaka::syncBlockThreads(acc);
 
         for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, w_extent)) {
+          if (idx.local >= (nComponents + w_extent) / w_extent)
+            continue;
+
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+
           const unsigned int cc_rhf_size = subcc_offsets[idx.local];
 
-          const unsigned int cc_rhf_global_offset = warp_exclusive_sum(acc, cc_rhf_size, idx.local);
+          const unsigned int cc_rhf_global_offset =
+              warp_sparse_exclusive_sum(acc, active_lanes_mask, cc_rhf_size, idx.local);
 
           subcc_offsets[idx.local] = cc_rhf_global_offset;
         }
@@ -574,45 +580,39 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           }
         }
 
+        auto compFn = [] ALPAKA_FN_ACC(const float a, const float b) -> float { return a > b ? a : b; };
+
         for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
           const unsigned int warp_idx = idx.local / w_extent;
           const unsigned int lane_idx = idx.local % w_extent;
 
-          if (is_representative) {
-            const warp::warp_mask_t lane_mask = get_lane_mask(lane_idx);
-            const warp::warp_mask_t non_isolated_vertices = vertex_mask[warp_idx];
-            const bool is_isolated_root = ((lane_mask & non_isolated_vertices));
+          if constexpr (std::is_same_v<alpaka::AccToTag<Acc1D>, alpaka::TagGpuCudaRt>) {
+            if (is_representative) {
+              const warp::warp_mask_t lane_mask = get_lane_mask(lane_idx);
+              const warp::warp_mask_t non_isolated_vertices = vertex_mask[warp_idx];
+              const bool is_isolated_root = ((lane_mask & non_isolated_vertices));
 
-            if (is_isolated_root) {
-              cc_energy_seed[rep_cc_idx] = static_cast<uint64_t>(vertex_seed);
-              continue;
+              if (is_isolated_root) {
+                cc_energy_seed[rep_cc_idx] = static_cast<uint64_t>(vertex_seed);
+                continue;
+              }
             }
           }
 
-          const warp::warp_mask_t updated_active_lanes_mask = alpaka::warp::activemask(acc);
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
 
           const float energy = pfRecHit[vertex_seed].energy();
 
-          const warp::warp_mask_t subcomponent_mask = warp::match_any_mask(acc, updated_active_lanes_mask, rep_idx);
+          const warp::warp_mask_t subcomponent_mask = warp::match_any_mask(acc, active_lanes_mask, rep_idx);
 
-          auto compFn = [] ALPAKA_FN_ACC(const float a, const float b) -> float { return a > b ? a : b; };
-
+          // WARNING: warp_sparse_reduce broadcasts the reduced value to all lanes by default.
+          // If this behavior changes in the future, make sure that the value is propagated to all
+          // lanes in the submask!
           const float max_energy = warp_sparse_reduce(acc, subcomponent_mask, lane_idx, energy, compFn);
-          // Equality on energy is intentional: max_energy is selected from lane values via shuffles/reduction,
-          // so it is bitwise-equal to at least one participating lane's energy.
-          const warp::warp_mask_t max_energy_lanes_mask =
-              warp::ballot_mask(acc, subcomponent_mask, max_energy == energy);
 
-          const unsigned int max_energy_lane_idx = alpaka::ffs(acc, static_cast<int>(max_energy_lanes_mask)) - 1;
-
-          //need to store seed:
-          const auto seed_max = warp::shfl_mask(acc, subcomponent_mask, vertex_seed, max_energy_lane_idx, w_extent);
-          const auto energy_max = warp::shfl_mask(acc, subcomponent_mask, max_energy, max_energy_lane_idx, w_extent);
-
-          // Energies are assumed non-negative; bit-cast uint ordering matches float ordering for atomicMax.
-          if (is_ls1b_idx<Acc1D>(subcomponent_mask, lane_idx)) {
-            uint32_t e_uint = std::bit_cast<unsigned int>(energy_max);
-            uint64_t x = (static_cast<uint64_t>(e_uint) << 32) | static_cast<uint64_t>(seed_max);
+          if (max_energy == energy) {
+            uint32_t e_uint = std::bit_cast<unsigned int>(max_energy);
+            uint64_t x = (static_cast<uint64_t>(e_uint) << 32) | static_cast<uint64_t>(vertex_seed);
             alpaka::atomicMax(acc, &cc_energy_seed[rep_cc_idx], x);
           }
         }

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCEpilogueMultiBlock.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCEpilogueMultiBlock.h
@@ -1,0 +1,382 @@
+#ifndef PFClusterProducer_plugins_alpaka_PFMultiDepthECLCCEpilogueMultiBlock_h
+#define PFClusterProducer_plugins_alpaka_PFMultiDepthECLCCEpilogueMultiBlock_h
+
+#include <limits>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/VecArray.h"
+
+#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFMultiDepthClusteringCCLabelsDeviceCollection.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFMultiDepthECLCCEpilogueArgsDeviceCollection.h"
+
+#include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitDeviceCollection.h"
+#include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitFractionDeviceCollection.h"
+#include "DataFormats/ParticleFlowReco/interface/alpaka/PFClusterDeviceCollection.h"
+
+#include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterWarpIntrinsics.h"
+#include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterizerHelper.h"
+
+/**
+ * @file PFMultiDepthECLCCEpilogue.h
+ * @brief Warp-based postprocessing kernel for multi-depth particle flow clustering (ECL-CC Epilogue).
+ *
+ * This header defines and implements an Alpaka GPU kernel that finalizes the clustering of
+ * particle flow clusters after connected components (ECL-CC) detection.
+ *
+ * The kernel performs:
+ * - Consolidation of connected component membership for each cluster.
+ * - Assignment of component energy sums based on rechit fractions.
+ * - Remapping of cluster indices to component indices.
+ */
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  using namespace ::cms::alpakatools;
+  using namespace ::cms::alpakaintrinsics;
+
+  class ECLCCEpilogueRecHitFracOffsetsKernel {
+  public:
+    ALPAKA_FN_ACC void operator()(
+        Acc1D const& acc,
+        reco::PFMultiDepthECLCCEpilogueArgsDeviceCollection::View args,
+        const reco::PFMultiDepthClusteringCCLabelsDeviceCollection::ConstView pfClusteringCCLabels,
+        const reco::PFClusterDeviceCollection::ConstView pfCluster) const {
+      constexpr unsigned int w_extent = get_warp_size<Acc1D>();
+
+      const unsigned int nVertices = pfClusteringCCLabels.size();
+
+      for (auto group : ::cms::alpakatools::uniform_groups(acc)) {
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+
+          const unsigned int vertex_idx = idx.global;
+          const unsigned int rep_idx = pfClusteringCCLabels[vertex_idx].mdpf_topoId();
+
+          // Load rhfrac sizes (to compute offsets for rechit fractions):
+          const unsigned int rhf_size = pfCluster[vertex_idx].rhfracSize();
+
+          const unsigned int lane_idx = idx.local % w_extent;
+
+          const warp::warp_mask_t subcomp_mask = warp::match_any_mask(acc, active_lanes_mask, rep_idx);
+
+          const unsigned int subcomp_rep_idx = get_ls1b_idx(acc, subcomp_mask);
+
+          unsigned int subcomp_rhf_offset = warp_sparse_exclusive_sum(acc, subcomp_mask, rhf_size, lane_idx);
+
+          unsigned int relative_rhf_offset_stub = 0;
+
+          if (lane_idx == subcomp_rep_idx) {
+            // Remark: exclusive sum returns total number of elements
+            // (i.e., subcomponent rhf size) for the lowest lane idx in the mask.
+            relative_rhf_offset_stub =
+                alpaka::atomicAdd(acc, &args[rep_idx].ccRHFSize(), subcomp_rhf_offset, alpaka::hierarchy::Blocks{});
+            subcomp_rhf_offset = 0;  // we need to reset local offset for local rep lane.
+          }
+
+          const unsigned int relative_rhf_offset =
+              warp::shfl_mask(acc, subcomp_mask, relative_rhf_offset_stub, subcomp_rep_idx, w_extent);
+          //connected comp rhf offsets for all vertices:
+          args[vertex_idx].ccRHFOffset() = relative_rhf_offset + subcomp_rhf_offset;  // store relative offsets
+        }
+      }
+    }
+  };
+
+  /**
+ * @brief Alpaka kernel finalizing PF clusters after ECL-CC clustering.
+ *
+ * Produces the final PF cluster and rec hit fraction collections using the
+ * connected-component labels computed by the ECL clustering stage. Supports
+ * optional cooperative warp-level processing.
+ *
+ * @tparam max_w_items     Maximum number of items processed per warp.
+ * @tparam is_cooperative Enable cooperative warp-level processing if true.
+ * 
+ * @param acc                 Alpaka accelerator object.
+ * @param outPFCluster        Output PF cluster device collection.
+ * @param outPFRecHitFracs    Output PF rec hit fraction device collection.
+ * @param pfClusteringCCLabels Input view of connected-component labels.
+ * @param pfCluster           Input PF cluster device collection.
+ * @param pfRecHitFracs       Input PF rec hit fraction device collection.
+ * @param pfRecHit            Input PF rec hit device collection.
+ */
+
+  template <unsigned int max_w_items = 32>
+  class ECLCCEpilogueCCOffsetsKernel {
+  public:
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
+                                  reco::PFClusterDeviceCollection::View outPFCluster,
+                                  reco::PFMultiDepthECLCCEpilogueArgsDeviceCollection::View args,
+                                  reco::PFMultiDepthClusteringCCLabelsDeviceCollection::View pfClusteringCCLabels,
+                                  const reco::PFClusterDeviceCollection::ConstView pfCluster) const {
+      constexpr unsigned int w_extent = get_warp_size<Acc1D>();
+
+      static_assert(max_w_items <= 32, "ECLCCEpilogueKernel: number of warps per block is unsupported.");
+
+      const unsigned int nVertices = pfClusteringCCLabels.size();
+
+      const unsigned int blockDim = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u];
+
+      const unsigned int gridDim = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc)[0u];
+      const unsigned int nBlocks = alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[0u];
+
+      // component offsets
+      auto& subcc_offsets(alpaka::declareSharedVar<unsigned int[w_extent], __COUNTER__>(acc));
+
+      auto& common_buf1(alpaka::declareSharedVar<unsigned int[max_w_items * w_extent], __COUNTER__>(acc));
+      auto& common_buf2(alpaka::declareSharedVar<unsigned int[max_w_items * w_extent], __COUNTER__>(acc));
+
+      //block-local number of components
+      unsigned int& localNComponents = alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
+      unsigned int& isLastBlockDone = alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
+      unsigned int& topo_block_offset = alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
+
+      for (auto group : ::cms::alpakatools::uniform_groups(acc)) {
+        if (::cms::alpakatools::once_per_block(acc)) {
+          localNComponents = 0;
+          isLastBlockDone = 0;
+          topo_block_offset = 0;
+        }
+
+        unsigned int vertex_idx = nVertices;
+
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          if (idx.local < w_extent) {
+            subcc_offsets[idx.local] = 0;
+          }
+          vertex_idx = idx.global;
+        }
+
+        const unsigned int rep_idx = vertex_idx < nVertices ? pfClusteringCCLabels[vertex_idx].mdpf_topoId() : gridDim;
+
+        const bool is_representative = vertex_idx < nVertices ? vertex_idx == rep_idx : false;
+
+        auto& block_local_component_map = common_buf1;
+        auto& block_local_cc_idx_record = common_buf2;
+
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+          const unsigned int lane_idx = idx.local % w_extent;
+
+          const warp::warp_mask_t rep_mask = warp::ballot_mask(acc, active_lanes_mask, is_representative);
+
+          if (is_representative == false) {
+            continue;
+          }
+
+          const unsigned int low_rep_idx = get_ls1b_idx(acc, rep_mask);
+
+          unsigned int local_topo_offset = 0;
+
+          if (lane_idx == low_rep_idx) {
+            const unsigned int local_n_topo = alpaka::popcount(acc, rep_mask);
+
+            local_topo_offset = alpaka::atomicAdd(acc, &localNComponents, local_n_topo, alpaka::hierarchy::Threads{});
+          }
+
+          const unsigned int cc_idx_stub = warp::shfl_mask(acc, rep_mask, local_topo_offset, low_rep_idx, w_extent);
+          const unsigned int cc_idx = cc_idx_stub + get_logical_lane_idx(acc, rep_mask, lane_idx);
+
+          block_local_cc_idx_record[cc_idx] = rep_idx;
+          block_local_component_map[idx.local] = cc_idx;
+        }
+        alpaka::syncBlockThreads(acc);
+
+        const unsigned int nBlockLocalComponents = localNComponents;
+
+        if (::cms::alpakatools::once_per_block(acc)) {
+          topo_block_offset = alpaka::atomicAdd(acc,
+                                                &pfClusteringCCLabels.ncomponents(),
+                                                static_cast<int>(nBlockLocalComponents),
+                                                alpaka::hierarchy::Blocks{});
+
+          alpaka::mem_fence(acc, alpaka::memory_scope::Device{});
+        }
+
+        alpaka::syncBlockThreads(acc);
+        // block/group uniform branch (mandatary for all threads in the block):
+        if (nBlockLocalComponents != 0) {
+          unsigned int global_topo_idx = nVertices;
+
+          // Store relevant data (per thread):
+          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+            if (idx.local >= nBlockLocalComponents)
+              continue;
+            const unsigned int root_idx = block_local_cc_idx_record[idx.local];  //collection of rep indices
+            global_topo_idx = idx.local + topo_block_offset;
+
+            outPFCluster[global_topo_idx].depth() = pfCluster[root_idx].depth();
+            outPFCluster[global_topo_idx].topoId() = global_topo_idx;
+            outPFCluster[global_topo_idx].energy() = pfCluster[root_idx].energy();
+            outPFCluster[global_topo_idx].x() = pfCluster[root_idx].x();
+            outPFCluster[global_topo_idx].y() = pfCluster[root_idx].y();
+            outPFCluster[global_topo_idx].z() = pfCluster[root_idx].z();
+            outPFCluster[global_topo_idx].topoRHCount() = pfCluster[root_idx].topoRHCount();
+            // note that root idx is within the block range:
+            args[root_idx].rootMap() = global_topo_idx;
+            // now we can reset common_buf2 buffer (block_local_cc_idx_record):
+            common_buf2[idx.local] = 0;
+          }
+
+          alpaka::syncBlockThreads(acc);
+
+          // total rhfrac count per component (compact indexing).
+          auto& cc_rhf_sizes = common_buf2;
+
+          if (is_representative) {  // rep_cc_idx in the range [0,nBlockLocalComponents)
+            const unsigned int rep_cc_idx = block_local_component_map[rep_idx % blockDim];
+            args[rep_idx].rootLocalMap() = rep_cc_idx;
+            cc_rhf_sizes[rep_cc_idx] = args[rep_idx].ccRHFSize();
+          }
+
+          alpaka::syncBlockThreads(acc);
+
+          unsigned int cc_rhf_offset = 0;
+
+          // Compute block-local rhf offsets:
+          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+            if (idx.local >= nBlockLocalComponents)
+              continue;
+            const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+
+            const unsigned int warp_idx = idx.local / w_extent;
+            const unsigned int lane_idx = idx.local % w_extent;
+
+            const unsigned int cc_rhf_size = cc_rhf_sizes[idx.local];
+            // Store rhf sizes in memory:
+            outPFCluster[global_topo_idx].rhfracSize() = cc_rhf_size;
+
+            cc_rhf_offset = warp_sparse_exclusive_sum(
+                acc, active_lanes_mask, cc_rhf_size, lane_idx);  //warp local rhf offsets, lane zero contains NNZ
+
+            if (lane_idx == 0) {
+              subcc_offsets[warp_idx] = cc_rhf_offset;  //store warp-local nnz
+              cc_rhf_offset = 0;
+            }
+          }
+          alpaka::syncBlockThreads(acc);
+
+          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+            if (nBlockLocalComponents == 1 || idx.local > max_w_items)
+              continue;
+
+            const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+
+            const unsigned int cc_warp_nnz = subcc_offsets[idx.local];  //load nnz per warp
+
+            const unsigned int cc_rhf_global_offset =
+                warp_sparse_exclusive_sum(acc, active_lanes_mask, cc_warp_nnz, idx.local);
+
+            subcc_offsets[idx.local] = cc_rhf_global_offset;  //subcc_offsets[0] contains block nnz
+          }
+
+          alpaka::syncBlockThreads(acc);
+
+          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+            if (idx.local >= nBlockLocalComponents)
+              continue;
+            const unsigned int warp_idx = idx.local / w_extent;
+
+            const unsigned int cc_rhf_block_offset = warp_idx > 0 || idx.local == 0 ? subcc_offsets[warp_idx] : 0;
+
+            cc_rhf_offset += cc_rhf_block_offset;
+
+            args[idx.global].blockRHFOffset() = cc_rhf_offset;  //idx.local = 0 has block nnz
+          }
+        }  // end of nBlockLocalComponents branch
+
+        alpaka::mem_fence(acc, alpaka::memory_scope::Device{});
+
+        if (::cms::alpakatools::once_per_block(acc)) {
+          const unsigned int whichBlockDone =
+              alpaka::atomicAdd(acc, &args.blockCount(), +1, alpaka::hierarchy::Blocks{});
+
+          alpaka::mem_fence(acc, alpaka::memory_scope::Device{});
+
+          if (whichBlockDone == (nBlocks - 1)) {
+            isLastBlockDone = 1;
+          }
+        }
+
+        alpaka::syncBlockThreads(acc);
+
+        if (isLastBlockDone) {
+          if (::cms::alpakatools::once_per_block(acc)) {
+            const unsigned int totNComponents = pfClusteringCCLabels.ncomponents();
+
+            outPFCluster.nTopos() = totNComponents;
+            outPFCluster.nSeeds() = totNComponents;
+            outPFCluster.nRHFracs() = pfCluster.nRHFracs();
+            outPFCluster.size() = totNComponents;
+          }
+
+          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+            common_buf2[idx.local] = 0;
+          }
+          alpaka::syncBlockThreads(acc);
+
+          auto& reduce_buf = common_buf2;
+          //warning nBlocks must be <= blockDim
+          unsigned int block_offset = 0;
+
+          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, gridDim)) {
+            if (idx.local >= nBlocks)
+              continue;
+
+            const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+
+            const unsigned int warp_idx = idx.local / w_extent;
+            const unsigned int lane_idx = idx.local % w_extent;
+
+            const unsigned int load_idx = idx.local * blockDim;
+
+            const unsigned int block_rhf_size = args[load_idx].blockRHFOffset();
+
+            block_offset = warp_sparse_exclusive_sum(acc, active_lanes_mask, block_rhf_size, lane_idx);
+
+            if (lane_idx == 0) {
+              reduce_buf[warp_idx] = block_offset;  //store warp-local nnz
+              block_offset = 0;
+            }
+          }
+
+          alpaka::syncBlockThreads(acc);
+
+          if (nBlocks >= w_extent) {
+            for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, gridDim)) {
+              if (idx.local >= w_extent)
+                continue;
+
+              const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+
+              const unsigned int tmp = reduce_buf[idx.local];  //load nnz per warp
+
+              const unsigned int global_offset = warp_sparse_exclusive_sum(acc, active_lanes_mask, tmp, idx.local);
+
+              reduce_buf[idx.local] = global_offset;  //reduce_buf[0] contains total nnz
+            }
+          }
+          alpaka::syncBlockThreads(acc);
+
+          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, gridDim)) {
+            if (idx.local >= nBlocks)
+              continue;
+            const unsigned int warp_idx = idx.local / w_extent;
+
+            const unsigned int shift = warp_idx > 0 ? reduce_buf[warp_idx] : 0;
+
+            block_offset += shift;
+
+            // now re-use buffer for the offsets:
+            const unsigned int load_idx = idx.local * blockDim;
+
+            args[load_idx].blockRHFOffset() = block_offset;
+          }
+        }
+      }
+    }
+  };
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCFinalizeEpilogue.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCFinalizeEpilogue.h
@@ -1,0 +1,383 @@
+#ifndef PFClusterProducer_plugins_alpaka_PFMultiDepthECLCCFinalizeEpilogue_h
+#define PFClusterProducer_plugins_alpaka_PFMultiDepthECLCCFinalizeEpilogue_h
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/VecArray.h"
+
+#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFMultiDepthClusteringCCLabelsDeviceCollection.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFMultiDepthECLCCEpilogueArgsDeviceCollection.h"
+
+#include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitDeviceCollection.h"
+#include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitFractionDeviceCollection.h"
+#include "DataFormats/ParticleFlowReco/interface/alpaka/PFClusterDeviceCollection.h"
+
+#include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterWarpIntrinsics.h"
+#include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterizerHelper.h"
+
+/**
+ * @file PFMultiDepthECLCCEpilogue.h
+ * @brief Warp-based postprocessing kernel for multi-depth particle flow clustering (ECL-CC Epilogue).
+ *
+ * This header defines and implements an Alpaka GPU kernel that finalizes the clustering of
+ * particle flow clusters after connected components (ECL-CC) detection.
+ *
+ * The kernel performs:
+ * - Consolidation of connected component membership for each cluster.
+ * - Assignment of component energy sums based on rechit fractions.
+ * - Remapping of cluster indices to component indices.
+ */
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  using namespace ::cms::alpakatools;
+  using namespace ::cms::alpakaintrinsics;
+
+  /**
+ * @brief Alpaka kernel finalizing PF clusters after ECL-CC clustering.
+ *
+ * Produces the final PF cluster and rec hit fraction collections using the
+ * connected-component labels computed by the ECL clustering stage. Supports
+ * optional cooperative warp-level processing.
+ *
+ * @tparam max_w_items     Maximum number of items processed per warp.
+ * @tparam is_cooperative Enable cooperative warp-level processing if true.
+ * 
+ * @param acc                 Alpaka accelerator object.
+ * @param outPFCluster        Output PF cluster device collection.
+ * @param outPFRecHitFracs    Output PF rec hit fraction device collection.
+ * @param pfClusteringCCLabels Input view of connected-component labels.
+ * @param pfCluster           Input PF cluster device collection.
+ * @param pfRecHitFracs       Input PF rec hit fraction device collection.
+ * @param pfRecHit            Input PF rec hit device collection.
+ */
+
+  template <unsigned int max_w_items = 32, bool is_cooperative = false>
+  class ECLCCFinalizeEpilogueKernel {
+  public:
+    ALPAKA_FN_ACC void operator()(
+        Acc1D const& acc,
+        reco::PFClusterDeviceCollection::View outPFCluster,
+        reco::PFRecHitFractionDeviceCollection::View outPFRecHitFracs,
+        reco::PFMultiDepthECLCCEpilogueArgsDeviceCollection::View args,
+        const reco::PFMultiDepthClusteringCCLabelsDeviceCollection::ConstView pfClusteringCCLabels,
+        const reco::PFClusterDeviceCollection::ConstView pfCluster,
+        const reco::PFRecHitFractionDeviceCollection::ConstView pfRecHitFracs,
+        const reco::PFRecHitDeviceCollection::ConstView pfRecHit) const {
+      constexpr unsigned int w_extent = get_warp_size<Acc1D>();
+
+      static_assert(max_w_items <= 32, "ECLCCEpilogueKernel: number of warps per block is unsupported.");
+
+      const unsigned int nVertices = pfClusteringCCLabels.size();
+
+      const unsigned int blockDim = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u];
+
+      auto& cc_energy_seed(alpaka::declareSharedVar<uint64_t[max_w_items * w_extent], __COUNTER__>(acc));
+
+      //block-local number of components
+      unsigned int& nComponents = alpaka::declareSharedVar<uint32_t, __COUNTER__>(acc);
+      unsigned int& blockRHFShift = alpaka::declareSharedVar<uint32_t, __COUNTER__>(acc);
+
+      for (auto group : ::cms::alpakatools::uniform_groups(acc)) {
+        if (::cms::alpakatools::once_per_block(acc)) {
+          nComponents = outPFCluster.nSeeds();
+          blockRHFShift = args[group * blockDim].blockRHFOffset();
+        }
+
+        unsigned int vertex_idx = nVertices;
+
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          cc_energy_seed[idx.local] = 0;
+          vertex_idx = idx.global;
+        }
+        alpaka::syncBlockThreads(acc);
+
+        const unsigned int rep_idx = vertex_idx < nVertices ? pfClusteringCCLabels[vertex_idx].mdpf_topoId() : 0;
+
+        const bool is_representative = vertex_idx < nVertices ? vertex_idx == rep_idx : false;
+
+        const unsigned int global_topo_idx = vertex_idx < nVertices ? args[rep_idx].rootMap() : nVertices;
+        const unsigned int rep_cc_idx = vertex_idx < nVertices ? args[rep_idx].rootLocalMap() : nVertices;
+
+        const unsigned int rhf_begin = vertex_idx < nVertices ? pfCluster[vertex_idx].rhfracOffset() : 0;
+        const unsigned int rhf_size = vertex_idx < nVertices ? pfCluster[vertex_idx].rhfracSize() : 0;
+
+        unsigned int vertex_seed = vertex_idx < nVertices ? pfCluster[vertex_idx].seedRHIdx() : 0;
+
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+
+          const unsigned int rep_group_idx = rep_idx / blockDim;
+          const unsigned int shift =
+              rep_group_idx == group ? blockRHFShift : args[rep_group_idx * blockDim].blockRHFOffset();
+
+          const unsigned int cc_rhf_global_offset =
+              rep_cc_idx > 0 ? args[rep_group_idx * blockDim + rep_cc_idx].blockRHFOffset() + shift : shift;
+
+          if (is_representative)
+            outPFCluster[global_topo_idx].rhfracOffset() = cc_rhf_global_offset;
+
+          const unsigned int cc_rhf_relative_offset = args[vertex_idx].ccRHFOffset();
+
+          const unsigned int lane_idx = idx.local % w_extent;
+
+          const unsigned int rhf_end = rhf_begin + rhf_size;
+
+          unsigned int dst_rhf_offset = cc_rhf_relative_offset + cc_rhf_global_offset;
+
+          // Cooperative mode: each "master" lane (iter_lane_idx) owns a PFRecHitFraction span
+          // [pfrhf_offset, pfrhf_offset + pfrhf_size). If that span is longer than 1, we recruit a
+          // subgroup of currently "free" lanes to help process the span in parallel.
+          //
+          // Mask conventions in this scope:
+          // - active_lanes_mask : lanes corresponding to in-range clusters (plus any forced lanes).
+          // - free_lanes_mask   : lanes currently available to be assigned as cooperative workers
+          //                       (subset of active_lanes_mask).
+          //                       if a swap_lanes_mask (see below) is a non-empty set, then free lanes mask
+          //                       also includes lanes for later swap operation
+          // - swap_lanes_mask   : lanes that currently hold state and must be preserved to be swapped out to some free lanes.
+          if constexpr (is_cooperative) {
+            const unsigned int eff_w_extent = alpaka::popcount(acc, active_lanes_mask);
+
+            unsigned int src_rhf_offset = rhf_begin;
+            unsigned int rhf_size = rhf_end - rhf_begin;
+            // Define iteration parameters:
+            unsigned int iter_lane_idx = 0;
+
+            while (iter_lane_idx < eff_w_extent) {
+              // Identify lanes whose remaining PFRecHitFraction work is exactly one element.
+              // These lanes cannot benefit from recruiting cooperative helpers and are handled by a fast path.
+              // Note: pfrhf_size may have been reduced in a previous iteration due to leftover handling.
+              const warp::warp_mask_t single_worklane_mask = warp::ballot_mask(acc, active_lanes_mask, rhf_size == 1);
+
+              // Create temporary per-iteration masks for cooperative scheduling:
+              // -- how many vacant lanes in the warp, i.e., lanes available to become cooperators in this iteration ('free_lanes_mask')
+              // -- how many reserved lanes in the warp ('swap_lanes_mask'); note that free_lanes_mask must also include reserved lanes
+              warp::warp_mask_t free_lanes_mask = active_lanes_mask;
+              warp::warp_mask_t swap_lanes_mask = static_cast<warp::warp_mask_t>(0);
+
+              unsigned int swap_lane_idx{w_extent};  //assigned to some default value (it's outside of the warp range)
+              unsigned int swap_lanes_num{0};        //no lanes in the warp keep iter lane idx for swap operation
+
+              unsigned int proc_lane_idx{w_extent};
+              unsigned int proc_dst_rhf_offset{dst_rhf_offset};
+              unsigned int proc_src_rhf_offset{src_rhf_offset};
+
+              bool update_params = true;
+
+              warp::syncWarpThreads_mask(acc, active_lanes_mask);
+
+              while (update_params) {
+                const warp::warp_mask_t iter_lane_mask = get_lane_mask(iter_lane_idx);
+
+                const bool is_master_lane = iter_lane_idx == lane_idx;
+                // first we need to check whether the current iter lane itself is vacant.
+                if ((free_lanes_mask & iter_lane_mask) == 0) {
+                  // The current iteration lane is not free: it currently holds state that must be preserved.
+                  // Mark it as reserved-for-swap; later we move its state into an actually free lane.
+                  swap_lanes_mask = swap_lanes_mask | iter_lane_mask;
+                  ++swap_lanes_num;  //how many lanes are reserved for swap
+
+                  if (is_master_lane && iter_lane_idx != proc_lane_idx)
+                    swap_lane_idx = proc_lane_idx;
+                } else {
+                  // update the free mask (erase master-lane bit):
+                  free_lanes_mask &= ~iter_lane_mask;
+                }
+                // 'iter_lane_idx' is warp-uniform; thus all lanes agree on which lane is the current master.
+                // Check whether the current lane has exactly one element of work remaining.
+                const bool is_single_work_lane = is_work_lane(single_worklane_mask, iter_lane_idx);
+                // Available cooperative subgroup capacity: free lanes minus those reserved to preserve state (swap lanes).
+                // Note: the name 'subgroup' is used here because it does not take into account iterative (master) lane itself.
+                const unsigned int free_subgroup_size =
+                    static_cast<std::uint32_t>(alpaka::popcount(acc, free_lanes_mask)) - swap_lanes_num;
+
+                if (is_single_work_lane) {
+                  if (is_master_lane) {
+                    proc_lane_idx = iter_lane_idx;
+                    proc_dst_rhf_offset = dst_rhf_offset;
+                    proc_src_rhf_offset = src_rhf_offset;
+                  }
+                  iter_lane_idx += 1;
+                  update_params = iter_lane_idx < eff_w_extent &&
+                                  (static_cast<std::uint32_t>(alpaka::popcount(acc, free_lanes_mask)) > swap_lanes_num);
+                  continue;
+                }
+
+                const unsigned int proc_rhf_size = is_master_lane ? (rhf_size - 1) : 0;  //exclude master lane itself..
+                // Broadcast worksize (all active lanes):
+                const unsigned int iter_rhf_size =
+                    warp::shfl_mask(acc, active_lanes_mask, proc_rhf_size, iter_lane_idx, w_extent);
+
+                const unsigned int coop_subgroup_size = alpaka::math::min(acc, iter_rhf_size, free_subgroup_size);
+
+                // Check which lane can cooperate in the work:
+                // -- it must be vacant (corresponding bit in 'free_lanes_mask' must be set)
+                // -- among free lanes, it must be within the first 'coop_subgroup_size' positions
+                //    (using logical indexing over free_lanes_mask)
+                // -- vacant lanes must not be reserved for swapping operation (which is already taking into account in 'coop_subgroup_size')
+                const bool is_coop_subgroup_lane =
+                    is_work_lane(free_lanes_mask, lane_idx)
+                        ? (get_logical_lane_idx(acc, free_lanes_mask, lane_idx) < coop_subgroup_size)
+                        : false;
+                // Cooperative subgroup lanes are drawn from free_lanes_mask; by construction this excludes the master lane
+                // (because the master lane was already removed from free_lanes_mask earlier).
+                const warp::warp_mask_t coop_subgroup_mask =
+                    warp::ballot_mask(acc, active_lanes_mask, is_coop_subgroup_lane);  //Note: it excludes master lane.
+                // Erase corresponding bits in 'free_lanes_mask'
+                free_lanes_mask &= ~coop_subgroup_mask;
+                // Update parameters only for cooperative subgroup lanes (and the master lane)
+                // if 'true' - do broadcast of iter. lane index and corresponding rechit offset from source (current iterative) lane:
+                if (is_coop_subgroup_lane || is_master_lane)
+                  proc_lane_idx =
+                      warp::shfl_mask(acc, coop_subgroup_mask | iter_lane_mask, iter_lane_idx, iter_lane_idx, w_extent);
+
+                // Now we need to check whether we need to increment iteration lane index.
+                // Check if worksize less or equal subgroup size, if 'true', increment iter lane index for the next rec hit fraction array:
+                if (iter_rhf_size <= free_subgroup_size) {
+                  iter_lane_idx += 1;
+                  // if 'false', we  have to update a leftover work for the current master lane (will continue in the next iteration):
+                } else if (is_master_lane) {
+                  // update rechit fraction offset for the next iteration
+                  proc_dst_rhf_offset = dst_rhf_offset;
+                  dst_rhf_offset +=
+                      coop_subgroup_size + 1;  //we need to take into account the master lane itself (hence "+1" here)
+                  proc_src_rhf_offset = src_rhf_offset;
+                  src_rhf_offset +=
+                      coop_subgroup_size + 1;  //we need to take into account the master lane itself (hence "+1" here)
+                  // compute remaining work size (that is a leftover rec hit fraction size)
+                  rhf_size = iter_rhf_size - coop_subgroup_size;
+                }
+                update_params = (iter_lane_idx < eff_w_extent) &&
+                                (static_cast<std::uint32_t>(alpaka::popcount(acc, free_lanes_mask)) > swap_lanes_num);
+              }
+              // Now we need to swap cached values to vacant lanes:
+              if (is_work_lane(free_lanes_mask | swap_lanes_mask, lane_idx)) {
+                const unsigned int src_log_lane_idx = is_work_lane(free_lanes_mask, lane_idx)
+                                                          ? get_logical_lane_idx(acc, free_lanes_mask, lane_idx)
+                                                          : w_extent;
+                const unsigned int src_phys_lane_idx =
+                    src_log_lane_idx < swap_lanes_num ? get_physical_lane_idx(acc, swap_lanes_mask, src_log_lane_idx)
+                                                      : lane_idx;
+
+                const unsigned int tmp_proc_lane_idx =
+                    warp::shfl_mask(acc, free_lanes_mask | swap_lanes_mask, swap_lane_idx, src_phys_lane_idx, w_extent);
+
+                if (is_work_lane(free_lanes_mask, lane_idx) && src_log_lane_idx < swap_lanes_num)
+                  proc_lane_idx = tmp_proc_lane_idx;
+              }
+
+              const warp::warp_mask_t nonvacant_lanes_mask =
+                  warp::ballot_mask(acc, active_lanes_mask, proc_lane_idx != w_extent);
+
+              if (is_work_lane(nonvacant_lanes_mask, lane_idx) == false)
+                continue;
+
+              const warp::warp_mask_t coop_group_mask = warp::match_any_mask(acc, nonvacant_lanes_mask, proc_lane_idx);
+
+              const float proc_cc_idx = warp::shfl_mask(acc, coop_group_mask, global_topo_idx, proc_lane_idx, w_extent);
+
+              const unsigned int coop_dst_rhf_offset =
+                  warp::shfl_mask(acc, coop_group_mask, proc_dst_rhf_offset, proc_lane_idx, w_extent);
+              const unsigned int coop_src_rhf_offset =
+                  warp::shfl_mask(acc, coop_group_mask, proc_src_rhf_offset, proc_lane_idx, w_extent);
+
+              const auto log_lane_idx = get_logical_lane_idx(acc, coop_group_mask, lane_idx);
+              const int dst_rhfrac_idx = log_lane_idx + coop_dst_rhf_offset;
+              const int src_rhfrac_idx = log_lane_idx + coop_src_rhf_offset;
+
+              outPFRecHitFracs[dst_rhfrac_idx].frac() = pfRecHitFracs[src_rhfrac_idx].frac();
+              outPFRecHitFracs[dst_rhfrac_idx].pfrhIdx() = pfRecHitFracs[src_rhfrac_idx].pfrhIdx();
+              outPFRecHitFracs[dst_rhfrac_idx].pfcIdx() = proc_cc_idx;
+            }
+          } else {
+            unsigned int dst_rhfrac_idx = dst_rhf_offset;
+            for (unsigned int src_rhfrac_idx = rhf_begin; src_rhfrac_idx < rhf_end; src_rhfrac_idx++) {
+              outPFRecHitFracs[dst_rhfrac_idx].frac() = pfRecHitFracs[src_rhfrac_idx].frac();
+              outPFRecHitFracs[dst_rhfrac_idx].pfrhIdx() = pfRecHitFracs[src_rhfrac_idx].pfrhIdx();
+              outPFRecHitFracs[dst_rhfrac_idx].pfcIdx() = global_topo_idx;
+              ++dst_rhfrac_idx;
+            }
+          }
+        }
+
+        const bool is_block_local_represantative = (group * blockDim <= rep_idx) && (rep_idx < (group + 1) * blockDim);
+
+        auto compFn = [] ALPAKA_FN_ACC(const float a, const float b) -> float { return a > b ? a : b; };
+
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          if (is_block_local_represantative == false) {
+            continue;
+          }
+
+          const warp::warp_mask_t rep_mask = alpaka::warp::activemask(acc);
+
+          const unsigned int lane_idx = idx.local % w_extent;
+
+          const float energy = pfRecHit[vertex_seed].energy();
+
+          const warp::warp_mask_t subcomponent_mask = warp::match_any_mask(acc, rep_mask, rep_idx);
+
+          // WARNING: warp_sparse_reduce broadcasts the reduced value to all lanes by default.
+          // If this behavior changes in the future, make sure that the value is propagated to all
+          // lanes in the submask!
+          const float max_energy = warp_sparse_reduce(acc, subcomponent_mask, lane_idx, energy, compFn);
+
+          if (max_energy == energy) {
+            uint32_t e_uint = std::bit_cast<unsigned int>(max_energy);
+            uint64_t x = (static_cast<uint64_t>(e_uint) << 32) | static_cast<uint64_t>(vertex_seed);
+            alpaka::atomicMax(acc, &cc_energy_seed[rep_cc_idx], x);
+          }
+        }
+
+        alpaka::syncBlockThreads(acc);
+
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          // Note that representatives are always block-local
+          uint64_t energy_seed = is_representative ? cc_energy_seed[rep_cc_idx] : 0;
+
+          if (is_block_local_represantative == false) {
+            const unsigned int lane_idx = idx.local % w_extent;
+
+            const warp::warp_mask_t active_lane_mask = alpaka::warp::activemask(acc);
+
+            const warp::warp_mask_t subcomponent_mask = warp::match_any_mask(acc, active_lane_mask, rep_idx);
+
+            const float energy = pfRecHit[vertex_seed].energy();
+            // WARNING: warp_sparse_reduce broadcasts the reduced value to all lanes by default.
+            // If this behavior changes in the future, make sure that the value is propagated to all
+            // lanes in the submask!
+            const float max_energy = warp_sparse_reduce(acc, subcomponent_mask, lane_idx, energy, compFn);
+
+            if (max_energy == energy) {
+              uint32_t e_uint = std::bit_cast<unsigned int>(max_energy);
+              energy_seed = (static_cast<uint64_t>(e_uint) << 32) | static_cast<uint64_t>(vertex_seed);
+            }
+          }
+          // Energies are assumed non-negative; bit-cast uint ordering matches float ordering for atomicMax.
+          if (energy_seed != 0) {
+            alpaka::atomicMax(acc, &args[global_topo_idx].ccEnergySeed(), energy_seed);
+          }
+        }
+      }
+    }
+  };
+
+  class ECLCCLoadSeedsKernel {
+  public:
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
+                                  reco::PFClusterDeviceCollection::View outPFCluster,
+                                  reco::PFMultiDepthECLCCEpilogueArgsDeviceCollection::View args) const {
+      const unsigned int nComponents = outPFCluster.nSeeds();
+
+      for (auto global_topo_idx : ::cms::alpakatools::uniform_elements(acc, nComponents)) {
+        uint64_t energy_seed_packed = args[global_topo_idx].ccEnergySeed();
+        uint32_t seed_to_store = static_cast<uint32_t>(energy_seed_packed & 0xFFFFFFFF);
+
+        outPFCluster[global_topo_idx].seedRHIdx() = seed_to_store;
+      }
+    }
+  };
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCPrologue.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCPrologue.h
@@ -83,8 +83,42 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
  * @param pfClusteringEdgeVars Output view for per-edge clustering variables.
  * @param pfClusteringCCLabels Input view of connected-component labels.
  */
+  class ECLCCPrologueNaiveKernel {
+  public:
+    ALPAKA_FN_ACC void operator()(
+        Acc1D const& acc,
+        reco::PFMultiDepthClusteringEdgeVarsDeviceCollection::View pfClusteringEdgeVars,
+        const reco::PFMultiDepthClusteringCCLabelsDeviceCollection::ConstView pfClusteringCCLabels) const {
+      const unsigned int nVertices = pfClusteringCCLabels.size();
 
-  template <unsigned int max_w_items = 32, bool multi_block = false>
+      if (::cms::alpakatools::once_per_grid(acc)) {
+        unsigned int store_idx = 0;
+
+        for (unsigned int dst_idx = 0; dst_idx < nVertices; dst_idx++) {
+          pfClusteringEdgeVars[dst_idx].mdpf_adjacencyIndex() = store_idx;
+
+          const unsigned int base_neigh_idx = pfClusteringCCLabels[dst_idx].mdpf_topoId();
+
+          if (dst_idx != base_neigh_idx)
+            pfClusteringEdgeVars[store_idx++].mdpf_adjacencyList() = base_neigh_idx;
+
+          for (unsigned int iter_idx = 0; iter_idx < nVertices; iter_idx++) {
+            if (iter_idx == dst_idx)
+              continue;
+
+            const unsigned int neigh_idx = pfClusteringCCLabels[iter_idx].mdpf_topoId();
+
+            if (neigh_idx == dst_idx)
+              pfClusteringEdgeVars[store_idx++].mdpf_adjacencyList() = iter_idx;
+          }
+        }
+        pfClusteringEdgeVars[nVertices].mdpf_adjacencyIndex() = store_idx;
+      }
+      return;
+    }
+  };
+
+  template <unsigned int max_w_items = 32>
   class ECLCCPrologueKernel {
   public:
     ALPAKA_FN_ACC void operator()(
@@ -97,7 +131,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       const unsigned int nVertices = pfClusteringCCLabels.size();
 
       if constexpr (std::is_same_v<Device, alpaka::DevCpu> ||
-                    std::is_same_v<alpaka::AccToTag<Acc1D>, alpaka::TagGpuHipRt> || multi_block) {
+                    std::is_same_v<alpaka::AccToTag<Acc1D>, alpaka::TagGpuHipRt>) {
         if (::cms::alpakatools::once_per_grid(acc)) {
           unsigned int store_idx = 0;
 
@@ -126,58 +160,49 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         const unsigned int blockDim = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u];
 
         const unsigned int w_items = alpaka::math::min(acc, (blockDim + (w_extent - 1)) / w_extent, max_w_items);
-
-        // nlist_offsets plays two roles:
+        // warp_local_nlist and blck_local_nlist plays two roles:
         // -- neighbor count per vertex during counting,
         // -- CSR begin-offset per vertex after prefix sums.
-        auto& nlist_offsets(alpaka::declareSharedVar<unsigned int[max_w_items * w_extent], __COUNTER__>(acc));
+        auto& warp_local_nlist(alpaka::declareSharedVar<unsigned int[max_w_items * w_extent], __COUNTER__>(acc));
+        auto& blck_local_nlist(alpaka::declareSharedVar<unsigned int[max_w_items * w_extent], __COUNTER__>(acc));
 
         // Temporary CSR storage: adjacency_list[0..tot_nnz) built in shared and then copied to global.
         // Note: adjacency_list capacity is 2*nVertices (worst-case assumption for this graph model).
         auto& adjacency_list(alpaka::declareSharedVar<unsigned int[2 * max_w_items * w_extent], __COUNTER__>(acc));
 
-        auto& adjacency_idx(alpaka::declareSharedVar<unsigned int[max_w_items * w_extent], __COUNTER__>(acc));
-
         // Per-warp total offsets used for coarse-grained scan across warps.
-        auto& subdomain_offsets(alpaka::declareSharedVar<unsigned int[max_w_items + 1], __COUNTER__>(acc));
+        auto& subdomain_offsets(alpaka::declareSharedVar<unsigned int[w_extent], __COUNTER__>(acc));
 
-        unsigned int dst_vertex_idx = 0;
-        unsigned int src_vertex_idx = 0;  //base (local base) neigbor index
+        unsigned int dst_vertex_idx = nVertices;
+        unsigned int src_vertex_idx = nVertices;
 
-        for (auto group : ::cms::alpakatools::uniform_groups(acc)) {  //loop over thread blocks
+        for (auto group : ::cms::alpakatools::uniform_groups(acc)) {
+          if (group > 0)
+            continue;
           // This kernel is intended to run with a single block for the full graph.
           // (If multi-block support is needed, the CSR construction could be made block-partition aware.)
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(
-                   acc, group, ::cms::alpakatools::round_up_by(nVertices, w_extent))) {
-            if (idx.global >= nVertices) {
-              nlist_offsets[idx.local] = 0;
-              adjacency_idx[idx.local] = 0;
-              continue;
-            }
+          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
             dst_vertex_idx = idx.global;
 
             src_vertex_idx = pfClusteringCCLabels[dst_vertex_idx].mdpf_topoId();
 
             // Init offset array with zero if locally isolated (self-connected) otherwise 1:
-            nlist_offsets[idx.local] = dst_vertex_idx == src_vertex_idx ? 0 : 1;
+            warp_local_nlist[idx.local] = dst_vertex_idx == src_vertex_idx ? 0 : 1;
+            blck_local_nlist[idx.local] = 0;
 
-            adjacency_idx[idx.local] = dst_vertex_idx == src_vertex_idx ? 0 : 1;
-
-            if (idx.local <= max_w_items)
+            if (idx.local < max_w_items) {
               subdomain_offsets[idx.local] = 0;
+            }
           }
+
           alpaka::syncBlockThreads(acc);
           // Next, identify:
           //  - inner (intra-warp) neighbors: vertices within the same warp that share the same base_neighbor
           //  - outer (inter-warp) neighbors: vertices in other warps that point to a base_neighbor in this warp
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(
-                   acc, group, ::cms::alpakatools::round_up_by(nVertices, w_extent))) {
-            const warp::warp_mask_t active_lanes_mask = alpaka::warp::ballot(acc, idx.local < nVertices);
-            // Skip inactive lanes, from this point all warp-level operations must be done with active_lanes_mask
+          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+            const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+            // from this point all warp-level operations must be done with active_lanes_mask
             // or derived mask
-            if (idx.global >= nVertices)
-              continue;
-
             const unsigned int warp_idx = idx.local / w_extent;
             const unsigned int lane_idx = idx.local % w_extent;
             // Lane self-mask (bit corresponding to this lane).
@@ -198,11 +223,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             const bool is_warp_local_src_idx =
                 (src_vertex_idx >= warp_low_boundary && src_vertex_idx < warp_high_boundary);
             // Assign warp lane index to each source vertex, for example, in the toy model vertex 7 is assign to lane 3 (as it can be seen)
-            const int warp_local_src_vertex_lane_idx =
-                is_warp_local_src_idx ? static_cast<int>(src_vertex_idx % w_extent) : -1;
+            const unsigned int warp_local_src_vertex_lane_idx =
+                is_warp_local_src_idx ? src_vertex_idx % w_extent : w_extent;
             // and make corresponding lane mask:
-            const warp::warp_mask_t warp_local_src_vertex_lane_mask =
-                is_warp_local_src_idx ? get_lane_mask(warp_local_src_vertex_lane_idx) : 0;
+            const warp::warp_mask_t warp_local_src_vertex_lane_mask = get_lane_mask(warp_local_src_vertex_lane_idx);
             // We need to exclude all self-connections, like vertices 5 and 7 in the toy model
             // WARNING: neigh_num counts only directed neighbors. For vertex 7 neigh_num = 0 while it does have a neighbor via directed
             // edge (2,7)
@@ -229,7 +253,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                                                      : control_mask);
             // Exclude self-links (v -> v): they are sentinels for isolated vertices and must not appear as edges.
             if (is_self_connected)
-              control_mask = control_mask ^ lane_mask;  // clear representative's own bit
+              control_mask &= ~lane_mask;  // clear representative's own bit
             // Only the representative writes the group mask.
             // For warp-local sources we store the group under the 'source vertex index' so that the source vertex
             // can later account for inbound edges from same-warp destinations.
@@ -238,48 +262,46 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             if (lane_idx == rep_lane_idx) {
               const unsigned int neigh_num = alpaka::popcount(acc, control_mask);
               if (is_warp_local_src_idx) {  //i.e, src_vertex_idx is warp-local.
-                adjacency_idx[src_vertex_idx] += neigh_num;
+                warp_local_nlist[src_vertex_idx] += neigh_num;
+              } else {
+                alpaka::atomicAdd(acc, &blck_local_nlist[src_vertex_idx], neigh_num, alpaka::hierarchy::Threads{});
               }
-              alpaka::atomicAdd(acc, &nlist_offsets[src_vertex_idx], neigh_num, alpaka::hierarchy::Threads{});
             }
           }
 
           alpaka::syncBlockThreads(acc);
 
           unsigned int cached_local_warp_offset = 0;
-
           // For the second stage, we compute local offsets for each lane (vertex) in the warp:
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(
-                   acc, group, ::cms::alpakatools::round_up_by(nVertices, w_extent))) {
+          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+            const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+
             const auto warp_idx = idx.local / w_extent;
             const auto lane_idx = idx.local % w_extent;
 
-            const unsigned int nnz = nlist_offsets[idx.local];  //note that nnz = 0 for idx.local >= nVertices
+            const unsigned int nnz = warp_local_nlist[idx.local] +
+                                     blck_local_nlist[idx.local];  //note that nnz = 0 for idx.local >= nVertices
 
             //WARNING: unlike a standard exclusive scan, where lane 0 gets 0 (that carries no useful information),
             //         our lane 0 stores total nnz:
             // - lanes 1..(w_extent-1) receive the exclusive prefix sum (CSR offsets within the warp),
             // - lane 0 receives the total sum over the warp (used as the per-warp NNZ aggregate).
-            const auto local_warp_offset = warp_exclusive_sum(acc, nnz, lane_idx);
-            // First, store total warp-local nnz into shared mem buffer for the lane id = 0:
+            // Store total local offsets into the private register (but lane 0 gets total nnz):
+            cached_local_warp_offset = warp_sparse_exclusive_sum(acc, active_lanes_mask, nnz, lane_idx);
+            // Store total warp-local nnz into shared mem buffer for the lane id = 0:
             // local_warp_offset is the per-lane CSR offset within the warp (custom exclusive prefix sum of nnz).
-            if (lane_idx == 0)
-              subdomain_offsets[warp_idx] = local_warp_offset;
-            // Second, store total local offsets into the private register:
-            cached_local_warp_offset = lane_idx > 0 ? local_warp_offset : 0;
+            if (lane_idx == 0) {
+              subdomain_offsets[warp_idx] = cached_local_warp_offset;
+              // reset local offsets:
+              cached_local_warp_offset = 0;
+            }
           }
 
           alpaka::syncBlockThreads(acc);
 
-          // Construct coarse-grained offset (offsets for each warp):
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(
-                   acc, group, ::cms::alpakatools::round_up_by(nVertices, w_extent))) {
-            const auto warp_idx = idx.local / w_extent;
-
-            if (warp_idx != 0)
-              continue;
-            // Create the full warp mask (all lanes will vote):
-            const auto lane_idx = idx.local % w_extent;
+          // Constract coarse-grained offset (offsets for each warp):
+          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, w_extent)) {
+            const auto lane_idx = idx.local;
 
             const auto local_warp_nnz = lane_idx < w_items ? subdomain_offsets[lane_idx] : 0;
 
@@ -291,17 +313,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
           alpaka::syncBlockThreads(acc);
 
-          unsigned block_nnz = 0;
+          const unsigned int block_nnz = subdomain_offsets[0];
 
           // Now we assemble global offsets for each vertex:
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(
-                   acc, group, ::cms::alpakatools::round_up_by(nVertices, w_extent))) {
-            const warp::warp_mask_t active_lanes_mask = alpaka::warp::ballot(acc, idx.global < nVertices);
-
-            if (idx.global >= nVertices)
-              continue;
-
-            block_nnz = subdomain_offsets[0];
+          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+            const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
 
             const unsigned int warp_idx = idx.local / w_extent;
             const unsigned int lane_idx = idx.local % w_extent;
@@ -310,22 +326,19 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             // Broadcast warp offset from lane 0 (for warp 0 it's just 0):
             const unsigned shift = warp_idx != 0 ? subdomain_offsets[warp_idx] : 0;
 
-            const unsigned block_offset = lane_offset + shift;
+            unsigned int block_offset = lane_offset + shift;
 
             // Store final offsets in shared memory:
-            adjacency_idx[idx.local] += block_offset;
+            warp_local_nlist[idx.local] += block_offset;
 
             // Identify warp-local domain range:
             const unsigned int warp_low_boundary = (warp_idx + 0) * w_extent + group * blockDim;
             const unsigned int warp_high_boundary = (warp_idx + 1) * w_extent + group * blockDim;
 
-            // Store block-level offsets in the  buffer:
             pfClusteringEdgeVars[dst_vertex_idx].mdpf_adjacencyIndex() = block_offset;
 
-            unsigned int block_adjacency_pos = block_offset;
-
             if (src_vertex_idx != dst_vertex_idx)  // exclude self connection
-              adjacency_list[block_adjacency_pos++] = src_vertex_idx;
+              adjacency_list[block_offset++] = src_vertex_idx;
 
             const bool is_warp_local_src_vertex_idx =
                 (src_vertex_idx >= warp_low_boundary && src_vertex_idx < warp_high_boundary);
@@ -335,15 +348,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
             // NOTE: the source lane does not know about warp_local_neigh_mask!
             const unsigned int src_block_adjacency_pos =
-                warp::shfl_mask(acc, active_lanes_mask, block_adjacency_pos, warp_local_src_vertex_lane_idx, w_extent);
+                warp::shfl_mask(acc, active_lanes_mask, block_offset, warp_local_src_vertex_lane_idx, w_extent);
             // (exclude self-connection):
             const warp::warp_mask_t coop_mask = warp::ballot_mask(
                 acc, active_lanes_mask, is_warp_local_src_vertex_idx && src_vertex_idx != dst_vertex_idx);
 
-            if (is_work_lane(coop_mask, lane_idx, w_extent)) {
+            if (is_work_lane(coop_mask, lane_idx)) {
               const warp::warp_mask_t warp_local_neigh_mask = warp::match_any_mask(acc, coop_mask, src_vertex_idx);
 
-              if (is_work_lane(warp_local_neigh_mask, lane_idx, w_extent)) {
+              if (is_work_lane(warp_local_neigh_mask, lane_idx)) {
                 const unsigned int logical_lane_idx = get_logical_lane_idx(acc, warp_local_neigh_mask, lane_idx);
 
                 adjacency_list[src_block_adjacency_pos + logical_lane_idx] = dst_vertex_idx;
@@ -352,21 +365,17 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           }
           alpaka::syncBlockThreads(acc);
 
-          // Store tot_nnz in the global buffer:
+          // Store tot_nnz in the global buffer (for single-block exec):
           if (::cms::alpakatools::once_per_block(acc)) {
             pfClusteringEdgeVars[nVertices].mdpf_adjacencyIndex() = block_nnz;
           }
 
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(
-                   acc, group, ::cms::alpakatools::round_up_by(nVertices, w_extent))) {
-            const warp::warp_mask_t active_lanes_mask = alpaka::warp::ballot(acc, idx.global < nVertices);
-
-            if (idx.global >= nVertices)
-              continue;
+          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+            const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
 
             const unsigned int warp_idx = idx.local / w_extent;
             const unsigned int lane_idx = idx.local % w_extent;
-            //
+
             const unsigned int warp_low_boundary = (warp_idx + 0) * w_extent + group * blockDim;
             const unsigned int warp_high_boundary = (warp_idx + 1) * w_extent + group * blockDim;
 
@@ -379,19 +388,16 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             // Compute neighebor mask (internal or external):
             const warp::warp_mask_t totneighs_mask = warp::match_any_mask(acc, active_lanes_mask, src_vertex_idx);
             // Filter out internal neighbors (and clear non-representative lane bits):
-            if (is_work_lane(outer_totneighs_mask, lane_idx, w_extent)) {
+            if (is_work_lane(outer_totneighs_mask, lane_idx)) {
               const warp::warp_mask_t outer_neigh_mask = totneighs_mask & outer_totneighs_mask;
 
               const unsigned int rep_lane_idx = get_ls1b_idx(acc, outer_neigh_mask);
 
               const unsigned int nnz = static_cast<unsigned int>(alpaka::popcount(acc, outer_neigh_mask));
 
-              const unsigned int block_local_src_vertex_idx = src_vertex_idx;
-
               const unsigned int block_adjacency_pos =
                   rep_lane_idx == lane_idx
-                      ? alpaka::atomicAdd(
-                            acc, &adjacency_idx[block_local_src_vertex_idx], nnz, alpaka::hierarchy::Threads{})
+                      ? alpaka::atomicAdd(acc, &warp_local_nlist[src_vertex_idx], nnz, alpaka::hierarchy::Threads{})
                       : 2 * nVertices;
 
               const unsigned int src_adjacency_pos =
@@ -406,12 +412,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           alpaka::syncBlockThreads(acc);
 
           for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
-            for (unsigned int i = idx.local; i < block_nnz; i += nVertices) {
-              pfClusteringEdgeVars[i].mdpf_adjacencyList() = adjacency_list[i];
+            for (unsigned int j = idx.local; j < block_nnz; j += nVertices) {
+              pfClusteringEdgeVars[j].mdpf_adjacencyList() = adjacency_list[j];
             }
           }
-        }  //groups
-      }  // end of solo-block branch
+        }
+      }
     }
   };
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCPrologueMultiBlock.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCPrologueMultiBlock.h
@@ -1,0 +1,770 @@
+#ifndef PFClusterProducer_plugins_alpaka_PFMultiDepthECLCCPrologueMultiBlock_h
+#define PFClusterProducer_plugins_alpaka_PFMultiDepthECLCCPrologueMultiBlock_h
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/VecArray.h"
+
+#include "HeterogeneousCore/AlpakaMath/interface/deltaPhi.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFMultiDepthClusteringEdgeVarsDeviceCollection.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFMultiDepthClusteringCCLabelsDeviceCollection.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFMultiDepthECLCCPrologueArgsDeviceCollection.h"
+
+#include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterWarpIntrinsics.h"
+#include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterizerHelper.h"
+
+/**
+ * @brief Warp-based construction of adjacency graph for multi-depth particle flow clusters.
+ *
+ * This header defines and implements an Alpaka kernel that builds the local neighbor structure
+ * (adjacency lists) between particle flow clusters in preparation for 
+ * connected components labeling algorithm (ECL-CC).
+ * 
+ * The kernel operates entirely at warp level, detecting both intra-warp and inter-warp neighbors
+ * using masked ballot and shuffle operations. It produces a compressed sparse row (CSR) representation
+ * of the cluster adjacency graph, suitable for efficient graph-based clustering algorithms.
+ * 
+ * Steps:
+ * - Detect warp-local neighbors using ballots and match-any masks.
+ * - Detect external (inter-warp) neighbors and handle them with atomic operations.
+ * - Assemble per-warp and global prefix sums to build adjacency list offsets.
+ * - Populate flattened adjacency list and offset arrays.
+ * - Write adjacency structure into the device-side `PFMultiDepthClusteringEdgeVarsDeviceCollection`.
+ *
+ * - Warp-masked operations are used consistently to ensure efficiency and avoid divergence.
+ * - Shared memory is used heavily for local neighbor data caching.
+ * - Only a single thread group (`group == 0`) is active during execution.
+ * - The output CSR structure (offsets + adjacency list) is used in subsequent ECL-CC graph processing.
+ *
+ * Additional notes:
+ * - Shared memory consumption is proportional to the number of clusters and maximum warp size.
+ *   Ensure device shared memory is sufficient for the intended cluster sizes.
+ */
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  using namespace ::cms::alpakatools;
+  using namespace ::cms::alpakaintrinsics;
+
+  class ECLCCComputeExternNeighsKernel {
+  public:
+    ALPAKA_FN_ACC void operator()(
+        Acc1D const& acc,
+        reco::PFMultiDepthECLCCPrologueArgsDeviceCollection::View args,
+        const reco::PFMultiDepthClusteringCCLabelsDeviceCollection::ConstView pfClusteringCCLabels) const {
+      const unsigned int nVertices = pfClusteringCCLabels.size();
+
+      const unsigned int blockDim = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u];
+      const unsigned int w_extent = alpaka::warp::getSize(acc);
+
+      if (::cms::alpakatools::once_per_grid(acc)) {
+        args.blockCount() = 0;
+      }
+
+      for (auto group : ::cms::alpakatools::uniform_groups(acc)) {  //loop over thread blocks
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+
+          const unsigned int lane_idx = idx.local % w_extent;
+
+          const unsigned int src_vertex_idx = pfClusteringCCLabels[idx.global].mdpf_topoId();
+          const warp::warp_mask_t blk_nonlocal_mask =
+              warp::ballot_mask(acc,
+                                active_lanes_mask,
+                                (src_vertex_idx < group * blockDim) || (src_vertex_idx >= (group + 1) * blockDim));
+          // Note : from this point, a vertex cannot be self-connected.
+          if (is_work_lane(blk_nonlocal_mask, lane_idx) == false)
+            continue;
+
+          const warp::warp_mask_t control_mask = warp::match_any_mask(acc, blk_nonlocal_mask, src_vertex_idx);
+
+          if (is_ls1b_idx<Acc1D>(control_mask, lane_idx)) {
+            const unsigned int extern_neigh_num = alpaka::popcount(acc, control_mask);
+            alpaka::atomicAdd(acc, &args[src_vertex_idx].ccSize(), extern_neigh_num, alpaka::hierarchy::Blocks{});
+          }
+        }
+      }
+    }
+  };
+
+  /**
+ * @class ECLCCPrologueKernel
+ * @brief Kernel for constructing the initial adjacency graph for ECL-CC clustering.
+ * 
+ * @tparam max_w_items Maximum number of warp-sized tiles processed by a single block,
+ *                     Controls shared memory footprint and parallelism 
+ *                     (currently default to 32, and must be <= 32).
+ * The ECLCCPrologueKernel builds the compressed sparse row (CSR) representation
+ * of the connectivity graph between particle flow clusters.
+ * 
+ * It operates at warp level, detecting both intra-warp and inter-warp
+ * neighbors based on precomputed cluster links (e.g., from geometric matching).
+ * 
+ * The adjacency information is stored into the `PFMultiDepthClusteringEdgeVarsDeviceCollection`,
+ * and consists of:
+ * - `mdpf_adjacencyList()`: Flat array of neighbor indices.
+ * - `mdpf_adjacencyIndex()`: CSR-style offset array per cluster.
+ * 
+ * The resulting adjacency graph is used as input for graph-based connected
+ * components labeling (ECL-CC).
+ *
+ * @algorithm
+ * - Neighbor detection using ballot, match_any_mask, mask manipulation.
+ * - Warp-local prefix sum (exclusive sum) for offset computations.
+ * - Intra-warp and inter-warp neighbor management.
+ * - Atomic updates for global neighbor list in external connections.
+ * 
+ * - Only thread group `group == 0` processes the graph (single block), but this can be
+ *   extended for true multi-block excution. 
+ * - Shared memory scratch buffers are extensively used for intermediate neighbor masks.
+ * 
+ * - The algorithm assumes that each destination vertex is connected to just a single source vertex, 
+ * - Same source can be linked to one or many destination vertices, or isolated. 
+ * 
+ * @param acc                  Alpaka accelerator instance.
+ * @param pfClusteringEdgeVars Output view for per-edge clustering variables.
+ * @param pfClusteringCCLabels Input view of connected-component labels.
+ */
+
+  template <unsigned int max_w_items = 32>
+  class ECLCCPrologueComputeOffsetsKernel {
+  public:
+    ALPAKA_FN_ACC void operator()(
+        Acc1D const& acc,
+        reco::PFMultiDepthECLCCPrologueArgsDeviceCollection::View args,
+        const reco::PFMultiDepthClusteringCCLabelsDeviceCollection::ConstView pfClusteringCCLabels) const {
+      constexpr unsigned int w_extent = get_warp_size<Acc1D>();
+      static_assert(max_w_items <= 32, "ECLCCPrologueKernel: number of warps per block is unsupported.");
+
+      const unsigned int nVertices = pfClusteringCCLabels.size();
+
+      const unsigned int blockDim = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u];
+      const unsigned int nBlocks = alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[0u];
+
+      const unsigned int w_items = alpaka::math::min(acc, (blockDim + (w_extent - 1)) / w_extent, max_w_items);
+
+      // warp_local_nlist and block_local_nlist plays two roles:
+      // -- neighbor count per vertex during counting,
+      // -- CSR begin-offset per vertex after prefix sums.
+      auto& warp_local_nlist(alpaka::declareSharedVar<unsigned int[max_w_items * w_extent], __COUNTER__>(acc));
+      auto& block_local_nlist(alpaka::declareSharedVar<unsigned int[max_w_items * w_extent], __COUNTER__>(acc));
+
+      // Per-warp total offsets used for coarse-grained scan across warps.
+      auto& subdomain_offsets(alpaka::declareSharedVar<unsigned int[w_extent], __COUNTER__>(acc));
+
+      unsigned int& isLastBlockDone = alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
+
+      unsigned int dst_vertex_idx = nVertices;
+      unsigned int src_vertex_idx = nVertices;
+
+      for (auto group : ::cms::alpakatools::uniform_groups(acc)) {  //loop over thread blocks
+        // This kernel is intended to run with a single block for the full graph.
+        // (If multi-block support is needed, the CSR construction could be made block-partition aware.)
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          dst_vertex_idx = idx.global;
+
+          src_vertex_idx = pfClusteringCCLabels[dst_vertex_idx].mdpf_topoId();
+
+          // Init offset array with zero if locally isolated (self-connected) otherwise 1:
+          warp_local_nlist[idx.local] = dst_vertex_idx == src_vertex_idx ? 0 : 1;
+          block_local_nlist[idx.local] = 0;
+
+          if (idx.local < max_w_items) {
+            subdomain_offsets[idx.local] = 0;
+          }
+        }
+
+        alpaka::syncBlockThreads(acc);
+        // Next, identify:
+        //  - inner (intra-warp) neighbors: vertices within the same warp that share the same base_neighbor
+        //  - outer (inter-warp) neighbors: vertices in other warps that point to a base_neighbor in this warp
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+          // from this point all warp-level operations must be done with active_lanes_mask
+          // or derived mask
+          const unsigned int warp_idx = idx.local / w_extent;
+          const unsigned int lane_idx = idx.local % w_extent;
+          // Lane self-mask (bit corresponding to this lane).
+          const warp::warp_mask_t lane_mask = get_lane_mask(lane_idx);
+          // Identify warp-local domain range:
+          const unsigned int warp_low_boundary = (warp_idx + 0) * w_extent + group * blockDim;
+          const unsigned int warp_high_boundary = (warp_idx + 1) * w_extent + group * blockDim;
+
+          const bool is_warp_local_src_idx =
+              (src_vertex_idx >= warp_low_boundary && src_vertex_idx < warp_high_boundary);
+          const unsigned int warp_local_src_vertex_lane_idx =
+              is_warp_local_src_idx ? src_vertex_idx % w_extent : w_extent;
+
+          const warp::warp_mask_t warp_local_src_vertex_lane_mask = get_lane_mask(warp_local_src_vertex_lane_idx);
+          const bool is_self_connected = (src_vertex_idx == dst_vertex_idx);  //!!!
+
+          warp::warp_mask_t control_mask = warp::match_any_mask(acc, active_lanes_mask, src_vertex_idx);
+
+          const unsigned int rep_lane_idx = get_ls1b_idx(
+              acc,
+              ((control_mask & warp_local_src_vertex_lane_mask) != 0) ? warp_local_src_vertex_lane_mask : control_mask);
+          // Exclude self-links (v -> v): they are sentinels for isolated vertices and must not appear as edges.
+          if (is_self_connected)
+            control_mask &= ~lane_mask;  // clear representative's own bit
+
+          if (lane_idx == rep_lane_idx) {
+            const unsigned int neigh_num = alpaka::popcount(acc, control_mask);
+            const unsigned int block_local_src_vertex_idx = src_vertex_idx % blockDim;
+            if (is_warp_local_src_idx) {  //no race condition here:
+              warp_local_nlist[block_local_src_vertex_idx] += neigh_num;
+            } else if ((src_vertex_idx >= group * blockDim) && (src_vertex_idx < (group + 1) * blockDim)) {
+              alpaka::atomicAdd(
+                  acc, &block_local_nlist[block_local_src_vertex_idx], neigh_num, alpaka::hierarchy::Threads{});
+            }
+          }
+        }
+        alpaka::syncBlockThreads(acc);
+
+        const unsigned int block_external_nnz = (dst_vertex_idx < nVertices) ? args[dst_vertex_idx].ccSize() : 0;
+
+        unsigned int cached_warp_local_offset = 0;
+
+        // For the second stage, we compute local offsets for each lane (vertex) in the warp:
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+
+          const auto warp_idx = idx.local / w_extent;
+          const auto lane_idx = idx.local % w_extent;
+
+          const unsigned int block_internal_nnz = warp_local_nlist[idx.local] + block_local_nlist[idx.local];
+
+          args[idx.global].blockInternCCSize() = block_internal_nnz;
+
+          //WARNING: unlike a standard exclusive scan, where lane 0 gets 0 (that carries no useful information),
+          //         our lane 0 stores total nnz:
+          // - lanes 1..(w_extent-1) receive the exclusive prefix sum (CSR offsets within the warp),
+          // - lane 0 receives the total sum over the warp (used as the per-warp NNZ aggregate).
+          // Store total local offsets into the private register (but lane 0 gets total nnz):
+          cached_warp_local_offset = warp_sparse_exclusive_sum(acc, active_lanes_mask, block_internal_nnz, lane_idx);
+          // Store total warp-local nnz into shared mem buffer for the lane id = 0:
+          // local_warp_offset is the per-lane CSR offset within the warp (custom exclusive prefix sum of nnz).
+          if (lane_idx == 0) {
+            subdomain_offsets[warp_idx] = cached_warp_local_offset;
+            // reset local offsets:
+            cached_warp_local_offset = 0;
+          }
+        }
+        alpaka::syncBlockThreads(acc);
+
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const auto lane_idx = idx.local % w_extent;
+          if (lane_idx >= w_items)
+            continue;
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+
+          const auto nnz = subdomain_offsets[lane_idx];
+
+          const auto cross_warp_offset = warp_sparse_exclusive_sum(acc, active_lanes_mask, nnz, lane_idx);
+
+          subdomain_offsets[lane_idx] = cross_warp_offset;  //NOTE: lane 0 get total (block) nnz
+        }
+        alpaka::syncBlockThreads(acc);
+
+        int store_offset = 0;
+
+        // Now we assemble global offsets for each vertex:
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const unsigned int warp_idx = idx.local / w_extent;
+
+          // Broadcast warp offset from lane 0 (for warp 0 it's just 0):
+          cached_warp_local_offset += (warp_idx != 0 ? subdomain_offsets[warp_idx] : 0);
+
+          store_offset = idx.local == 0 ? subdomain_offsets[0] : cached_warp_local_offset;
+
+          args[dst_vertex_idx].ccLocalOffset() = store_offset;
+        }
+        alpaka::syncBlockThreads(acc);
+
+        // Now repeat for the block-external neighbors:
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          if (idx.local < w_extent)
+            subdomain_offsets[idx.local] = 0;
+        }
+        alpaka::syncBlockThreads(acc);
+
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+          const auto warp_idx = idx.local / w_extent;
+          const auto lane_idx = idx.local % w_extent;
+
+          cached_warp_local_offset = warp_sparse_exclusive_sum(acc, active_lanes_mask, block_external_nnz, lane_idx);
+
+          if (lane_idx == 0) {
+            subdomain_offsets[warp_idx] = cached_warp_local_offset;
+            // reset local offsets:
+            cached_warp_local_offset = 0;
+          }
+        }
+        alpaka::syncBlockThreads(acc);
+
+        // Constract coarse-grained offset (offsets for each warp):
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, w_extent)) {
+          const auto lane_idx = idx.local % w_extent;
+          if (lane_idx >= w_items)
+            continue;
+
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+
+          const auto nnz = subdomain_offsets[lane_idx];
+
+          const auto cross_warp_offset = warp_sparse_exclusive_sum(acc, active_lanes_mask, nnz, lane_idx);
+
+          subdomain_offsets[lane_idx] = cross_warp_offset;  //NOTE: lane 0 get total (block) nnz
+        }
+        alpaka::syncBlockThreads(acc);
+
+        // Now we assemble global offsets for each vertex:
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const unsigned int warp_idx = idx.local / w_extent;
+
+          // Broadcast warp offset from lane 0 (for warp 0 it's just 0):
+          cached_warp_local_offset += (warp_idx != 0 ? subdomain_offsets[warp_idx] : 0);
+
+          store_offset += idx.local == 0 ? subdomain_offsets[0] : cached_warp_local_offset;
+
+          args[dst_vertex_idx].ccOffset() = store_offset;  // contains total block neigh number for idx.local = 0
+        }
+        alpaka::syncBlockThreads(acc);
+        // Store tot_nnz in the global buffer (for single-block exec):
+        if (::cms::alpakatools::once_per_block(acc)) {
+          const unsigned int whichBlockDone =
+              alpaka::atomicAdd(acc, &args.blockCount(), +1, alpaka::hierarchy::Blocks{});
+
+          alpaka::mem_fence(acc, alpaka::memory_scope::Device{});
+
+          isLastBlockDone = whichBlockDone == (nBlocks - 1) ? 1 : 0;
+        }
+
+        alpaka::syncBlockThreads(acc);
+
+        if (isLastBlockDone == 1) {
+          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+            // Create the full warp mask (all lanes will vote):
+            const auto lane_idx = idx.local % w_extent;
+
+            if (lane_idx >= nBlocks)
+              continue;
+
+            const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+
+            const auto load_idx = lane_idx * blockDim;
+
+            const auto global_nnz = args[load_idx].ccOffset();
+
+            const auto global_offset = warp_sparse_exclusive_sum(acc, active_lanes_mask, global_nnz, lane_idx);
+
+            args[load_idx].ccOffset() = lane_idx > 0 ? global_offset : 0;
+
+            if (lane_idx == 0)
+              args.size() = global_offset;
+          }
+        }
+      }
+    }
+  };
+
+  template <unsigned int max_w_items = 32, bool is_cooperative = true>
+  class ECLCCFinalizePrologueKernel {
+  public:
+    ALPAKA_FN_ACC void operator()(
+        Acc1D const& acc,
+        reco::PFMultiDepthClusteringEdgeVarsDeviceCollection::View pfClusteringEdgeVars,
+        reco::PFMultiDepthECLCCPrologueArgsDeviceCollection::View args,
+        const reco::PFMultiDepthClusteringCCLabelsDeviceCollection::ConstView pfClusteringCCLabels) const {
+      constexpr unsigned int w_extent = get_warp_size<Acc1D>();
+      static_assert(max_w_items <= 32, "ECLCCPrologueKernel: number of warps per block is unsupported.");
+
+      const unsigned int nVertices = pfClusteringCCLabels.size();
+
+      const unsigned int blockDim = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u];
+
+      if (::cms::alpakatools::once_per_grid(acc)) {
+        pfClusteringEdgeVars[nVertices].mdpf_adjacencyIndex() = args.size();
+      }
+
+      auto& adjacency_pos(alpaka::declareSharedVar<unsigned int[max_w_items * w_extent], __COUNTER__>(acc));
+
+      // Temporary CSR storage: adjacency_list[0..tot_nnz) built in shared and then copied to global.
+      // Note: adjacency_list capacity is 2*nVertices (worst-case assumption for this graph model).
+      auto& adjacency_list(alpaka::declareSharedVar<unsigned int[2 * max_w_items * w_extent], __COUNTER__>(acc));
+
+      unsigned int& base = alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
+
+      unsigned int dst_vertex_idx = nVertices;
+      unsigned int src_vertex_idx = nVertices;
+
+      for (auto group : ::cms::alpakatools::uniform_groups(acc)) {  //loop over thread blocks
+        // This kernel is intended to run with a single block for the full graph.
+        // (If multi-block support is needed, the CSR construction could be made block-partition aware.)
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          dst_vertex_idx = idx.global;
+          src_vertex_idx = pfClusteringCCLabels[dst_vertex_idx].mdpf_topoId();
+
+          adjacency_list[idx.local] = 0;
+          adjacency_pos[idx.local] = 0;
+        }
+
+        const bool is_self_connected = dst_vertex_idx < nVertices ? (dst_vertex_idx == src_vertex_idx) : false;
+
+        if (::cms::alpakatools::once_per_block(acc)) {
+          base = group > 0 ? args[group * blockDim].ccOffset() : 0;
+        }
+
+        alpaka::syncBlockThreads(acc);
+
+        const unsigned int local_offset = dst_vertex_idx < nVertices ? args[dst_vertex_idx].ccLocalOffset() : 0;
+
+        unsigned int offset = 0;
+
+        // Now we assemble global offsets for each vertex:
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+
+          offset = idx.local > 0 ? args[dst_vertex_idx].ccOffset() + base : base;
+
+          args[dst_vertex_idx].ccOffset() = offset;
+
+          pfClusteringEdgeVars[dst_vertex_idx].mdpf_adjacencyIndex() = offset;
+
+          const unsigned int warp_idx = idx.local / w_extent;
+          const unsigned int lane_idx = idx.local % w_extent;
+
+          unsigned int current_offset = idx.local > 0 ? local_offset : 0;
+
+          // Identify warp-local domain range:
+          const unsigned int warp_low_boundary = (warp_idx + 0) * w_extent + group * blockDim;
+          const unsigned int warp_high_boundary = (warp_idx + 1) * w_extent + group * blockDim;
+
+          const bool is_warp_local_src_vertex_idx =
+              (src_vertex_idx >= warp_low_boundary && src_vertex_idx < warp_high_boundary);
+
+          if (is_self_connected == false) {  // exclude self connection
+            adjacency_list[current_offset++] = src_vertex_idx;
+          }
+
+          // Store offsets in shared memory:
+          adjacency_pos[idx.local] =
+              current_offset;  //not that is current_offset is schifted by 1 for non-self connected nodes
+
+          warp::syncWarpThreads_mask(acc, active_lanes_mask);
+
+          const unsigned int warp_local_src_vertex_lane_idx =
+              is_warp_local_src_vertex_idx ? src_vertex_idx % w_extent : lane_idx;
+
+          // NOTE: the source lane does not know about warp_local_neigh_mask!
+          const unsigned int src_block_adjacency_pos =
+              warp::shfl_mask(acc, active_lanes_mask, current_offset, warp_local_src_vertex_lane_idx, w_extent);
+          // (exclude self-connection):
+          const warp::warp_mask_t coop_mask =
+              warp::ballot_mask(acc, active_lanes_mask, is_warp_local_src_vertex_idx && !is_self_connected);
+
+          if (is_work_lane(coop_mask, lane_idx)) {
+            const warp::warp_mask_t warp_local_neigh_mask = warp::match_any_mask(acc, coop_mask, src_vertex_idx);
+
+            if (is_work_lane(warp_local_neigh_mask, lane_idx)) {
+              const unsigned int logical_lane_idx = get_logical_lane_idx(acc, warp_local_neigh_mask, lane_idx);
+
+              adjacency_list[src_block_adjacency_pos + logical_lane_idx] = dst_vertex_idx;
+              // no race condition since src_vertex_idx % blockDim is a warp-local index:
+              if (logical_lane_idx == 0)
+                adjacency_pos[src_vertex_idx % blockDim] +=
+                    static_cast<unsigned int>(alpaka::popcount(acc, warp_local_neigh_mask));
+            }
+          }
+        }
+        alpaka::syncBlockThreads(acc);
+
+        const unsigned int block_internal_nnz =
+            dst_vertex_idx < nVertices ? args[dst_vertex_idx].blockInternCCSize() : 0;
+
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+
+          const unsigned int warp_idx = idx.local / w_extent;
+          const unsigned int lane_idx = idx.local % w_extent;
+
+          const unsigned int warp_low_boundary = (warp_idx + 0) * w_extent + group * blockDim;
+          const unsigned int warp_high_boundary = (warp_idx + 1) * w_extent + group * blockDim;
+
+          const bool is_nonlocal_src_vertex_idx =
+              (src_vertex_idx < warp_low_boundary || src_vertex_idx >= warp_high_boundary);
+
+          const bool is_block_local_src_vertex_idx =
+              (src_vertex_idx >= group * blockDim) && (src_vertex_idx < (group + 1) * blockDim);
+
+          // Detect all lanes that have external (inter-warp) neighbors
+          const warp::warp_mask_t outer_totneighs_mask =
+              warp::ballot_mask(acc, active_lanes_mask, is_nonlocal_src_vertex_idx && is_block_local_src_vertex_idx);
+          // Compute neighebor mask (internal or external):
+          const warp::warp_mask_t totneighs_mask = warp::match_any_mask(acc, active_lanes_mask, src_vertex_idx);
+          // Filter out internal neighbors (and clear non-representative lane bits):
+          if (is_work_lane(outer_totneighs_mask, lane_idx)) {
+            const warp::warp_mask_t outer_neigh_mask = totneighs_mask & outer_totneighs_mask;
+
+            const unsigned int rep_lane_idx = get_ls1b_idx(acc, outer_neigh_mask);
+
+            const unsigned int nnz = static_cast<unsigned int>(alpaka::popcount(acc, outer_neigh_mask));
+
+            const unsigned int block_local_src_vertex_idx = src_vertex_idx % blockDim;
+
+            const unsigned int block_adjacency_pos =
+                rep_lane_idx == lane_idx
+                    ? alpaka::atomicAdd(
+                          acc, &adjacency_pos[block_local_src_vertex_idx], nnz, alpaka::hierarchy::Threads{})
+                    : 2 * nVertices;
+
+            const unsigned int src_adjacency_pos =
+                warp::shfl_mask(acc, outer_totneighs_mask, block_adjacency_pos, rep_lane_idx, w_extent);
+
+            const unsigned int logical_lane_idx = get_logical_lane_idx(acc, outer_neigh_mask, lane_idx);
+
+            adjacency_list[src_adjacency_pos + logical_lane_idx] = dst_vertex_idx;
+          }
+        }
+        alpaka::syncBlockThreads(acc);
+
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+
+          if constexpr (is_cooperative) {
+            const unsigned int eff_w_extent = alpaka::popcount(acc, active_lanes_mask);
+
+            const unsigned int lane_idx = idx.local % w_extent;
+
+            unsigned int intern_nnz = block_internal_nnz;
+            // Define iteration parameters:
+            unsigned int iter_lane_idx = 0;
+
+            unsigned int dst_offset = offset;
+            unsigned int src_offset = idx.local > 0 ? local_offset : 0;
+
+            const warp::warp_mask_t nonvoid_lanes_mask = warp::ballot_mask(acc, active_lanes_mask, intern_nnz > 0);
+
+            while (iter_lane_idx < eff_w_extent) {
+              // Identify lanes whose remaining PFRecHitFraction work is exactly one element.
+              // These lanes cannot benefit from recruiting cooperative helpers and are handled by a fast path.
+              // Note: pfrhf_size may have been reduced in a previous iteration due to leftover handling.
+              const warp::warp_mask_t single_worklane_mask = warp::ballot_mask(acc, active_lanes_mask, intern_nnz == 1);
+
+              // Create temporary per-iteration masks for cooperative scheduling:
+              // -- how many vacant lanes in the warp, i.e., lanes available to become cooperators in this iteration ('free_lanes_mask')
+              // -- how many reserved lanes in the warp ('swap_lanes_mask'); note that free_lanes_mask must also include reserved lanes
+              warp::warp_mask_t free_lanes_mask = active_lanes_mask;
+              warp::warp_mask_t swap_lanes_mask = static_cast<warp::warp_mask_t>(0);
+
+              unsigned int swap_lane_idx{w_extent};  //assigned to some default value (it's outside of the warp range)
+              unsigned int swap_lanes_num{0};        //no lanes in the warp keep iter lane idx for swap operation
+
+              unsigned int proc_lane_idx{w_extent};
+              unsigned int proc_dst_offset{dst_offset};
+              unsigned int proc_src_offset{src_offset};
+
+              bool update_params = true;
+
+              warp::syncWarpThreads_mask(acc, active_lanes_mask);
+
+              while (update_params) {
+                if (is_work_lane(nonvoid_lanes_mask, iter_lane_idx) == false) {
+                  iter_lane_idx += 1;
+                  update_params = iter_lane_idx < eff_w_extent;
+                  continue;
+                }
+                const warp::warp_mask_t iter_lane_mask = get_lane_mask(iter_lane_idx);
+
+                const bool is_master_lane = iter_lane_idx == lane_idx;
+                // first we need to check whether the current iter lane itself is vacant.
+                if ((free_lanes_mask & iter_lane_mask) == 0) {
+                  // The current iteration lane is not free: it currently holds state that must be preserved.
+                  // Mark it as reserved-for-swap; later we move its state into an actually free lane.
+                  swap_lanes_mask = swap_lanes_mask | iter_lane_mask;
+                  ++swap_lanes_num;  //how many lanes are reserved for swap
+
+                  if (is_master_lane && iter_lane_idx != proc_lane_idx)
+                    swap_lane_idx = proc_lane_idx;
+                } else {
+                  // update the free mask (erase master-lane bit):
+                  free_lanes_mask &= ~iter_lane_mask;
+                }
+                // 'iter_lane_idx' is warp-uniform; thus all lanes agree on which lane is the current master.
+                // Check whether the current lane has exactly one element of work remaining.
+                const bool is_single_work_lane = is_work_lane(single_worklane_mask, iter_lane_idx);
+                // Available cooperative subgroup capacity: free lanes minus those reserved to preserve state (swap lanes).
+                // Note: the name 'subgroup' is used here because it does not take into account iterative (master) lane itself.
+                const unsigned int free_subgroup_size =
+                    static_cast<std::uint32_t>(alpaka::popcount(acc, free_lanes_mask)) - swap_lanes_num;
+
+                if (is_single_work_lane) {
+                  if (is_master_lane) {
+                    proc_lane_idx = iter_lane_idx;
+                    proc_dst_offset = dst_offset;
+                    proc_src_offset = src_offset;
+                  }
+                  iter_lane_idx += 1;
+                  update_params = iter_lane_idx < eff_w_extent &&
+                                  (static_cast<std::uint32_t>(alpaka::popcount(acc, free_lanes_mask)) > swap_lanes_num);
+                  continue;
+                }
+
+                const unsigned int proc_intern_nnz =
+                    is_master_lane ? (intern_nnz - 1) : 0;  //exclude master lane itself..
+                // Broadcast worksize (all active lanes):
+                const unsigned int iter_intern_nnz =
+                    warp::shfl_mask(acc, active_lanes_mask, proc_intern_nnz, iter_lane_idx, w_extent);
+
+                const unsigned int coop_subgroup_size = alpaka::math::min(acc, iter_intern_nnz, free_subgroup_size);
+
+                // Check which lane can cooperate in the work:
+                // -- it must be vacant (corresponding bit in 'free_lanes_mask' must be set)
+                // -- among free lanes, it must be within the first 'coop_subgroup_size' positions
+                //    (using logical indexing over free_lanes_mask)
+                // -- vacant lanes must not be reserved for swapping operation (which is already taking into account in 'coop_subgroup_size')
+                const bool is_coop_subgroup_lane =
+                    is_work_lane(free_lanes_mask, lane_idx)
+                        ? (get_logical_lane_idx(acc, free_lanes_mask, lane_idx) < coop_subgroup_size)
+                        : false;
+                // Cooperative subgroup lanes are drawn from free_lanes_mask; by construction this excludes the master lane
+                // (because the master lane was already removed from free_lanes_mask earlier).
+                const warp::warp_mask_t coop_subgroup_mask =
+                    warp::ballot_mask(acc, active_lanes_mask, is_coop_subgroup_lane);  //Note: it excludes master lane.
+                // Erase corresponding bits in 'free_lanes_mask'
+                free_lanes_mask &= ~coop_subgroup_mask;
+                // Update parameters only for cooperative subgroup lanes (and the master lane)
+                // if 'true' - do broadcast of iter. lane index and corresponding rechit offset from source (current iterative) lane:
+                if (is_coop_subgroup_lane || is_master_lane)
+                  proc_lane_idx =
+                      warp::shfl_mask(acc, coop_subgroup_mask | iter_lane_mask, iter_lane_idx, iter_lane_idx, w_extent);
+
+                // Now we need to check whether we need to increment iteration lane index.
+                // Check if worksize less or equal subgroup size, if 'true', increment iter lane index for the next rec hit fraction array:
+                if (iter_intern_nnz <= free_subgroup_size) {
+                  iter_lane_idx += 1;
+                  // if 'false', we  have to update a leftover work for the current master lane (will continue in the next iteration):
+                } else if (is_master_lane) {
+                  // update rechit fraction offset for the next iteration
+                  proc_dst_offset = dst_offset;
+                  dst_offset +=
+                      coop_subgroup_size + 1;  //we need to take into account the master lane itself (hence "+1" here)
+                  proc_src_offset = src_offset;
+                  src_offset +=
+                      coop_subgroup_size + 1;  //we need to take into account the master lane itself (hence "+1" here)
+                  // compute remaining work size (that is a leftover rec hit fraction size)
+                  intern_nnz = iter_intern_nnz - coop_subgroup_size;
+                }
+                update_params = (iter_lane_idx < eff_w_extent) &&
+                                (static_cast<std::uint32_t>(alpaka::popcount(acc, free_lanes_mask)) > swap_lanes_num);
+              }
+              // Now we need to swap cached values to vacant lanes:
+              if (is_work_lane(free_lanes_mask | swap_lanes_mask, lane_idx)) {
+                const unsigned int src_log_lane_idx = is_work_lane(free_lanes_mask, lane_idx)
+                                                          ? get_logical_lane_idx(acc, free_lanes_mask, lane_idx)
+                                                          : w_extent;
+                const unsigned int src_phys_lane_idx =
+                    src_log_lane_idx < swap_lanes_num ? get_physical_lane_idx(acc, swap_lanes_mask, src_log_lane_idx)
+                                                      : lane_idx;
+
+                const unsigned int tmp_proc_lane_idx =
+                    warp::shfl_mask(acc, free_lanes_mask | swap_lanes_mask, swap_lane_idx, src_phys_lane_idx, w_extent);
+
+                if (is_work_lane(free_lanes_mask, lane_idx) && src_log_lane_idx < swap_lanes_num)
+                  proc_lane_idx = tmp_proc_lane_idx;
+              }
+
+              const warp::warp_mask_t nonvacant_lanes_mask =
+                  warp::ballot_mask(acc, active_lanes_mask, proc_lane_idx != w_extent);
+
+              if (is_work_lane(nonvacant_lanes_mask, lane_idx) == false)
+                continue;
+
+              const warp::warp_mask_t coop_group_mask = warp::match_any_mask(acc, nonvacant_lanes_mask, proc_lane_idx);
+
+              const unsigned int coop_dst_offset =
+                  warp::shfl_mask(acc, coop_group_mask, proc_dst_offset, proc_lane_idx, w_extent);
+              const unsigned int coop_src_offset =
+                  warp::shfl_mask(acc, coop_group_mask, proc_src_offset, proc_lane_idx, w_extent);
+
+              const auto log_lane_idx = get_logical_lane_idx(acc, coop_group_mask, lane_idx);
+              const int dst_idx = log_lane_idx + coop_dst_offset;
+              const int src_idx = log_lane_idx + coop_src_offset;
+
+              pfClusteringEdgeVars[dst_idx].mdpf_adjacencyList() = adjacency_list[src_idx];
+            }
+          } else {
+            const unsigned int local_shift = idx.local > 0 ? local_offset : 0;
+            for (unsigned int j = 0; j < block_internal_nnz; j++) {
+              pfClusteringEdgeVars[offset + j].mdpf_adjacencyList() = adjacency_list[j + local_shift];
+            }
+          }
+        }
+      }
+    }
+  };
+
+  class ECLCCLoadCrossBlockNeighKernel {
+  public:
+    ALPAKA_FN_ACC void operator()(
+        Acc1D const& acc,
+        reco::PFMultiDepthClusteringEdgeVarsDeviceCollection::View pfClusteringEdgeVars,
+        reco::PFMultiDepthECLCCPrologueArgsDeviceCollection::View args,
+        const reco::PFMultiDepthClusteringCCLabelsDeviceCollection::ConstView pfClusteringCCLabels) const {
+      const unsigned int nVertices = pfClusteringCCLabels.size();
+
+      const unsigned int blockDim = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u];
+      const unsigned int w_extent = alpaka::warp::getSize(acc);
+
+      for (auto group : ::cms::alpakatools::uniform_groups(acc)) {  //loop over thread blocks
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+
+          const unsigned int lane_idx = idx.local % w_extent;
+
+          const unsigned int src_vertex_idx = pfClusteringCCLabels[idx.global].mdpf_topoId();
+          const unsigned int dst_vertex_idx = idx.global;
+
+          const bool is_non_block_local_src_vertex_idx =
+              (src_vertex_idx < group * blockDim) || (src_vertex_idx >= (group + 1) * blockDim);
+
+          // Detect all lanes that have external (inter-warp) neighbors
+          const warp::warp_mask_t outer_totneighs_mask =
+              warp::ballot_mask(acc, active_lanes_mask, is_non_block_local_src_vertex_idx);
+
+          // Compute neighebor mask (internal or external):
+          const warp::warp_mask_t totneighs_mask = warp::match_any_mask(acc, active_lanes_mask, src_vertex_idx);
+
+          // Filter out internal neighbors (and clear non-representative lane bits):
+          if (is_work_lane(outer_totneighs_mask, lane_idx)) {
+            const warp::warp_mask_t outer_neigh_mask = totneighs_mask & outer_totneighs_mask;
+
+            const unsigned int rep_lane_idx = get_ls1b_idx(acc, outer_neigh_mask);
+
+            const unsigned int nnz_to_load = static_cast<unsigned int>(alpaka::popcount(acc, outer_neigh_mask));
+
+            const unsigned int block_internal_nnz =
+                rep_lane_idx == lane_idx ? args[src_vertex_idx].blockInternCCSize() : 0;
+
+            const unsigned int global_adj_pos =
+                rep_lane_idx == lane_idx
+                    ? block_internal_nnz +
+                          alpaka::atomicAdd(
+                              acc, &args[src_vertex_idx].ccOffset(), nnz_to_load, alpaka::hierarchy::Blocks{})
+                    : 2 * nVertices;
+
+            const unsigned int src_adjacency_pos =
+                warp::shfl_mask(acc, outer_totneighs_mask, global_adj_pos, rep_lane_idx, w_extent);
+
+            const unsigned int logical_lane_idx = get_logical_lane_idx(acc, outer_neigh_mask, lane_idx);
+
+            pfClusteringEdgeVars[src_adjacency_pos + logical_lane_idx].mdpf_adjacencyList() = dst_vertex_idx;
+          }
+        }
+      }
+    }
+  };
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthShowerShape.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthShowerShape.h
@@ -123,12 +123,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   template <bool is_cooperative = false>
   class ShowerShapeKernel {
   public:
+    using reduce_t = double;
+    using compute_t = double;
+
     ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   reco::PFMultiDepthClusteringVarsDeviceCollection::View mdpfClusteringVars,
                                   const reco::PFClusterDeviceCollection::ConstView pfClusters,
                                   const reco::PFRecHitFractionDeviceCollection::ConstView pfRecHitFracs,
                                   const reco::PFRecHitDeviceCollection::ConstView pfRecHit,
-                                  const float rms2_threshold = 0.1) const {
+                                  const float rms2_threshold = 0.1f) const {
       const unsigned int nClusters = pfClusters.nSeeds();
 
       if (::cms::alpakatools::once_per_grid(acc)) {
@@ -138,267 +141,163 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       const unsigned int w_extent = alpaka::warp::getSize(acc);
 
       for (auto group : ::cms::alpakatools::uniform_groups(acc)) {  //loop over thread blocks
-        for (auto idx : ::cms::alpakatools::uniform_group_elements(
-                 acc, group, ::cms::alpakatools::round_up_by(nClusters, w_extent))) {
-          const warp::warp_mask_t active_lanes_mask = alpaka::warp::ballot(acc, idx.global < nClusters);
 
-          const unsigned int lane_idx = idx.local % w_extent;
+        reduce_t accum_etaSum_div_en{0.};
+        reduce_t accum_phiSum_div_en{0.};
 
-          const unsigned int eff_w_extent = alpaka::popcount(acc, active_lanes_mask);
-          // Skip inactive lanes:
-          if (idx.global >= nClusters)
-            continue;
-          const int i = idx.global;
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nClusters)) {
+          const float pfc_energy = pfClusters[idx.global].energy();
 
-          const auto pfc_energy = pfClusters[i].energy();
+          mdpfClusteringVars[idx.global].depth() = pfClusters[idx.global].depth();
+          mdpfClusteringVars[idx.global].energy() = pfc_energy;
 
-          mdpfClusteringVars[i].depth() = pfClusters[i].depth();
-          mdpfClusteringVars[i].energy() = pfc_energy;
-
-          const double x_c = pfClusters[i].x();
-          const double y_c = pfClusters[i].y();
-          const double z_c = pfClusters[i].z();
+          const compute_t x_c = pfClusters[idx.global].x();
+          const compute_t y_c = pfClusters[idx.global].y();
+          const compute_t z_c = pfClusters[idx.global].z();
 
           const float eta_c = static_cast<float>(cms::alpakamath::eta(acc, x_c, y_c, z_c));
           const float phi_c = static_cast<float>(::cms::alpakatools::phi(acc, x_c, y_c));
 
-          mdpfClusteringVars[i].eta() = eta_c;
-          mdpfClusteringVars[i].phi() = phi_c;
+          mdpfClusteringVars[idx.global].eta() = eta_c;
+          mdpfClusteringVars[idx.global].phi() = phi_c;
 
-          int pfrhf_offset = pfClusters[i].rhfracOffset();
-          int pfrhf_size = pfClusters[i].rhfracSize();
+          int pfrhf_offset = pfClusters[idx.global].rhfracOffset();
+          int pfrhf_size = pfClusters[idx.global].rhfracSize();
 
-          auto addFn = [] ALPAKA_FN_ACC(double a, double b) -> double { return a + b; };
+          reduce_t iter_accum_etaSum{0};
+          reduce_t iter_accum_phiSum{0};
 
-          // Cooperative mode: each "master" lane (iter_lane_idx) owns a PFRecHitFraction span
-          // [pfrhf_offset, pfrhf_offset + pfrhf_size). If that span is longer than 1, we recruit a
-          // subgroup of currently "free" lanes to help process the span in parallel.
-          //
-          // Mask conventions in this scope:
-          // - active_lanes_mask : lanes corresponding to in-range clusters (plus any forced lanes).
-          // - free_lanes_mask   : lanes currently available to be assigned as cooperative workers
-          //                       (subset of active_lanes_mask).
-          //                       if a swap_lanes_mask (see below) is a non-empty set, then free lanes mask
-          //                       also includes lanes for later swap operation
-          // - swap_lanes_mask   : lanes that currently hold state and must be preserved to be swapped out to some free lanes.
-          if constexpr (is_cooperative) {
-            // Define iteration parameters:
-            unsigned int iter_lane_idx = 0;
+          constexpr int pfrhf_size_threshold = 32;
 
-            double iter_accum_etaSum{0};
-            double iter_accum_phiSum{0};
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
 
-            bool keep_accum = false;
+          const warp::warp_mask_t high_occup_lanes_mask =
+              is_cooperative ? warp::ballot_mask(acc, active_lanes_mask, pfrhf_size > pfrhf_size_threshold) : 0;
 
-            while (iter_lane_idx < eff_w_extent) {
-              // Identify lanes whose remaining PFRecHitFraction work is exactly one element.
-              // These lanes cannot benefit from recruiting cooperative helpers and are handled by a fast path.
-              // Note: pfrhf_size may have been reduced in a previous iteration due to leftover handling.
-              const warp::warp_mask_t single_worklane_mask = warp::ballot_mask(acc, active_lanes_mask, pfrhf_size == 1);
+          const unsigned int lane_idx = idx.local % w_extent;
 
-              // Create temporary per-iteration masks for cooperative scheduling:
-              // -- how many vacant lanes in the warp, i.e., lanes available to become cooperators in this iteration ('free_lanes_mask')
-              // -- how many reserved lanes in the warp ('swap_lanes_mask'); note that free_lanes_mask must also include reserved lanes
-              warp::warp_mask_t free_lanes_mask = active_lanes_mask;
-              warp::warp_mask_t swap_lanes_mask = static_cast<warp::warp_mask_t>(0);
-
-              unsigned int swap_lane_idx{
-                  w_extent};  //assigned to some default value (note that it's outside of the warp range)
-              unsigned int swap_lanes_num{0};  //no lanes in the warp keep iter lane idx for swap operation
-
-              unsigned int proc_lane_idx{w_extent};
-              unsigned int proc_pfrhf_offset{static_cast<unsigned int>(pfrhf_offset)};
-
-              bool update_params = true;
-
-              bool load_flag = false;
-              // Ensure masks and per-lane state updates from previous iteration are visible before scheduling.
-              warp::syncWarpThreads_mask(acc, active_lanes_mask);
-
-              while (update_params) {
-                const warp::warp_mask_t iter_lane_mask = get_lane_mask(iter_lane_idx);
-
-                const bool is_master_lane = iter_lane_idx == lane_idx;
-                // first we need to check whether the current iter lane itself is vacant.
-                if ((free_lanes_mask & iter_lane_mask) == 0) {
-                  // The current iteration lane is not free: it currently holds state that must be preserved.
-                  // Mark it as reserved-for-swap; later we move its state into an actually free lane.
-                  swap_lanes_mask = swap_lanes_mask | iter_lane_mask;
-                  ++swap_lanes_num;  // number of lanes reserved for swap in this iteration
-
-                  if (is_master_lane && iter_lane_idx != proc_lane_idx)
-                    swap_lane_idx = proc_lane_idx;
-                } else {
-                  // update the free mask (erase master-lane bit):
-                  free_lanes_mask &= ~iter_lane_mask;
-                }
-                // 'iter_lane_idx' is warp-uniform; thus all lanes agree on which lane is the current master.
-                // Check whether the current lane has exactly one element of work remaining.
-                const bool is_single_work_lane = is_work_lane(single_worklane_mask, iter_lane_idx, w_extent);
-                // Available cooperative subgroup capacity: free lanes minus those reserved to preserve state (swap lanes).
-                // Note: the name 'subgroup' is used here because it does not take into account iterative (master) lane itself.
-                const unsigned int free_subgroup_size = alpaka::popcount(acc, free_lanes_mask) - swap_lanes_num;
-
-                if (is_single_work_lane) {
-                  if (is_master_lane) {
-                    proc_lane_idx = iter_lane_idx;
-                    proc_pfrhf_offset = pfrhf_offset;
-                    load_flag = true;
-                  }
-                  iter_lane_idx += 1;
-                  update_params = iter_lane_idx < eff_w_extent &&
-                                  (static_cast<std::uint32_t>(alpaka::popcount(acc, free_lanes_mask)) > swap_lanes_num);
-                  continue;
-                }
-
-                const unsigned int proc_pfrhf_size =
-                    is_master_lane ? (pfrhf_size - 1) : 0;  //exclude master lane itself..
-                // Broadcast worksize (all active lanes):
-                const unsigned int iter_pfrhf_size =
-                    warp::shfl_mask(acc, active_lanes_mask, proc_pfrhf_size, iter_lane_idx, w_extent);
-
-                const unsigned int coop_subgroup_size = alpaka::math::min(acc, iter_pfrhf_size, free_subgroup_size);
-
-                // Check which lane can cooperate in the work:
-                // -- it must be vacant (corresponding bit in 'free_lanes_mask' must be set)
-                // -- among free lanes, it must be within the first 'coop_subgroup_size' positions
-                //    (using logical indexing over free_lanes_mask)
-                // -- vacant lanes must not be reserved for swapping operation (which is already taking into account in 'coop_subgroup_size')
-                const bool is_coop_subgroup_lane =
-                    is_work_lane(free_lanes_mask, lane_idx, w_extent)
-                        ? (get_logical_lane_idx(acc, free_lanes_mask, lane_idx) < coop_subgroup_size)
-                        : false;
-                // Cooperative subgroup lanes are drawn from free_lanes_mask; by construction this excludes the master lane
-                // (because the master lane was already removed from free_lanes_mask earlier).
-                const warp::warp_mask_t coop_subgroup_mask =
-                    warp::ballot_mask(acc, active_lanes_mask, is_coop_subgroup_lane);
-                // Erase corresponding bits in 'free_lanes_mask'
-                free_lanes_mask &= ~coop_subgroup_mask;
-                // Update parameters only for cooperative subgroup lanes (and the master lane):
-                // Broadcast from the current master lane (iter_lane_idx): which lane owns the work and its current offset.
-                // Only the cooperative subgroup lanes and the master lane participate in these shuffles
-                if (is_coop_subgroup_lane || is_master_lane)
-                  proc_lane_idx =
-                      warp::shfl_mask(acc, coop_subgroup_mask | iter_lane_mask, iter_lane_idx, iter_lane_idx, w_extent);
-
-                // Now we need to check whether we need to increment iteration lane index.
-                // Check if worksize less or equal subgroup size, if 'true', increment iter lane index for the next rec hit fraction array:
-                if (iter_pfrhf_size <= free_subgroup_size) {
-                  iter_lane_idx += 1;
-                  if (is_master_lane)
-                    load_flag = true;  //master lane must store its values in the global arrays later
-                } else if (is_master_lane) {
-                  // Otherwise, the master lane has more work than available helpers; keep a leftover tail.
-                  // We advance pfrhf_offset by (coop helpers + master) and reduce pfrhf_size accordingly.
-                  keep_accum = true;
-                  // update rechit fraction offset for the next iteration
-                  proc_pfrhf_offset = pfrhf_offset;
-                  pfrhf_offset += coop_subgroup_size + 1;  // +1 accounts for the master lane processing one element
-                  // compute remaining work size (that is a leftover rec hit fraction size)
-                  pfrhf_size = iter_pfrhf_size - coop_subgroup_size;
-                }
-                // Continue scheduling while we have remaining iter lanes and enough free capacity
-                // to eventually place swap lanes
-                update_params = (iter_lane_idx < eff_w_extent) &&
-                                (static_cast<std::uint32_t>(alpaka::popcount(acc, free_lanes_mask)) > swap_lanes_num);
-              }
-
-              // Now we need to swap cached values to vacant lanes:
-              if (is_work_lane(free_lanes_mask | swap_lanes_mask, lane_idx, w_extent)) {
-                const unsigned int src_log_lane_idx = is_work_lane(free_lanes_mask, lane_idx, w_extent)
-                                                          ? get_logical_lane_idx(acc, free_lanes_mask, lane_idx)
-                                                          : w_extent;
-                const unsigned int src_phys_lane_idx =
-                    src_log_lane_idx < swap_lanes_num ? get_physical_lane_idx(acc, swap_lanes_mask, src_log_lane_idx)
-                                                      : lane_idx;
-
-                const unsigned int tmp_proc_lane_idx =
-                    warp::shfl_mask(acc, free_lanes_mask | swap_lanes_mask, swap_lane_idx, src_phys_lane_idx, w_extent);
-
-                if (is_work_lane(free_lanes_mask, lane_idx, w_extent) && src_log_lane_idx < swap_lanes_num)
-                  proc_lane_idx = tmp_proc_lane_idx;
-              }
-
-              const warp::warp_mask_t nonvacant_lanes_mask =
-                  warp::ballot_mask(acc, active_lanes_mask, proc_lane_idx != w_extent);
-
-              if (is_work_lane(nonvacant_lanes_mask, lane_idx, w_extent) == false)
-                continue;
-
-              const warp::warp_mask_t coop_group_mask = warp::match_any_mask(acc, nonvacant_lanes_mask, proc_lane_idx);
-
-              const float proc_eta_c = warp::shfl_mask(acc, coop_group_mask, eta_c, proc_lane_idx, w_extent);
-              const float proc_phi_c = warp::shfl_mask(acc, coop_group_mask, phi_c, proc_lane_idx, w_extent);
-              const float proc_pfc_energy = warp::shfl_mask(acc, coop_group_mask, pfc_energy, proc_lane_idx, w_extent);
-
-              const unsigned int coop_pfrhf_offset =
-                  warp::shfl_mask(acc, coop_group_mask, proc_pfrhf_offset, proc_lane_idx, w_extent);
-
-              const int pfrhfrac_idx = get_logical_lane_idx(acc, coop_group_mask, lane_idx) + coop_pfrhf_offset;
-
+          if (!is_cooperative || is_work_lane(high_occup_lanes_mask, lane_idx) == false) {
+            for (int pfrhfrac_idx = pfrhf_offset; pfrhfrac_idx < (pfrhf_offset + pfrhf_size); pfrhfrac_idx++) {
               const int pfrh_idx = pfRecHitFracs[pfrhfrac_idx].pfrhIdx();
-              const float frac_energy = pfRecHitFracs[pfrhfrac_idx].frac() * pfRecHit[pfrh_idx].energy();
+              const float fracXenergy = pfRecHitFracs[pfrhfrac_idx].frac() * pfRecHit[pfrh_idx].energy();
 
-              const double x_rh = pfRecHit[pfrh_idx].x();
-              const double y_rh = pfRecHit[pfrh_idx].y();
-              const double z_rh = pfRecHit[pfrh_idx].z();
+              const compute_t x_rh = pfRecHit[pfrh_idx].x();
+              const compute_t y_rh = pfRecHit[pfrh_idx].y();
+              const compute_t z_rh = pfRecHit[pfrh_idx].z();
 
               const float eta_rh = static_cast<float>(cms::alpakamath::eta(acc, x_rh, y_rh, z_rh));
               const float phi_rh = static_cast<float>(::cms::alpakatools::phi(acc, x_rh, y_rh));
 
-              const double etaSum_ = static_cast<double>(frac_energy * alpaka::math::abs(acc, eta_rh - proc_eta_c));
-              const double phiSum_ = static_cast<double>(
-                  frac_energy * alpaka::math::abs(acc, ::cms::alpakatools::deltaPhi(acc, phi_rh, proc_phi_c)));
+              auto etaSum_tmp = fracXenergy * alpaka::math::abs(acc, eta_rh - eta_c);
+              auto phiSum_tmp = fracXenergy * alpaka::math::abs(acc, ::cms::alpakatools::deltaPhi(acc, phi_rh, phi_c));
+
+              iter_accum_etaSum += etaSum_tmp;
+              iter_accum_phiSum += phiSum_tmp;
+            }
+
+            accum_etaSum_div_en = iter_accum_etaSum / pfc_energy;
+            accum_phiSum_div_en = iter_accum_phiSum / pfc_energy;
+          }
+
+          if constexpr (!is_cooperative)  //uniform condition for all lanes
+            continue;
+
+          const unsigned int eff_w_extent = alpaka::popcount(acc, high_occup_lanes_mask);
+
+          auto addFn = [] ALPAKA_FN_ACC(reduce_t a, reduce_t b) -> reduce_t { return a + b; };
+
+          // Define iteration parameters:
+          unsigned int iter_lane_idx = 0;
+
+          float iter_eta_c{0};
+          float iter_phi_c{0};
+          float iter_pfc_energy{0};
+
+          bool update_iter_params = true;
+
+          while (iter_lane_idx < eff_w_extent) {
+            warp::syncWarpThreads_mask(acc, active_lanes_mask);
+
+            const unsigned int src_lane_idx = get_physical_lane_idx(acc, high_occup_lanes_mask, iter_lane_idx);
+
+            const unsigned int iter_pfrhf_size =
+                warp::shfl_mask(acc, active_lanes_mask, pfrhf_size, src_lane_idx, w_extent);  // exclude the source lane
+
+            const bool is_src_in_range = (src_lane_idx < iter_pfrhf_size);
+
+            const bool is_coop_lane = lane_idx == src_lane_idx || (is_src_in_range && lane_idx < iter_pfrhf_size) ||
+                                      (!is_src_in_range && lane_idx < (iter_pfrhf_size - 1));
+
+            const unsigned int coop_group_mask = warp::ballot_mask(acc, active_lanes_mask, is_coop_lane);
+
+            if (is_work_lane(coop_group_mask, lane_idx)) {
+              if (update_iter_params) {
+                iter_eta_c = warp::shfl_mask(acc, coop_group_mask, eta_c, src_lane_idx, w_extent);
+                iter_phi_c = warp::shfl_mask(acc, coop_group_mask, phi_c, src_lane_idx, w_extent);
+                iter_pfc_energy = warp::shfl_mask(acc, coop_group_mask, pfc_energy, src_lane_idx, w_extent);
+
+                iter_accum_etaSum = 0;
+                iter_accum_phiSum = 0;
+
+                update_iter_params = false;
+              }
+
+              const unsigned int iter_pfrhf_offset_stub =
+                  warp::shfl_mask(acc, coop_group_mask, pfrhf_offset, src_lane_idx, w_extent);
+
+              const unsigned int stride =
+                  (lane_idx != src_lane_idx || is_src_in_range) ? lane_idx : (iter_pfrhf_size - 1);
+
+              const unsigned int pfrhfrac_idx = iter_pfrhf_offset_stub + stride;
+
+              const int pfrh_idx = pfRecHitFracs[pfrhfrac_idx].pfrhIdx();
+              const float fracXenergy = pfRecHitFracs[pfrhfrac_idx].frac() * pfRecHit[pfrh_idx].energy();
+
+              const compute_t x_rh = pfRecHit[pfrh_idx].x();
+              const compute_t y_rh = pfRecHit[pfrh_idx].y();
+              const compute_t z_rh = pfRecHit[pfrh_idx].z();
+
+              const float eta_rh = static_cast<float>(cms::alpakamath::eta(acc, x_rh, y_rh, z_rh));
+              const float phi_rh = static_cast<float>(::cms::alpakatools::phi(acc, x_rh, y_rh));
+
+              const reduce_t etaSum_ = static_cast<reduce_t>(fracXenergy * alpaka::math::abs(acc, eta_rh - iter_eta_c));
+              const reduce_t phiSum_ = static_cast<reduce_t>(
+                  fracXenergy * alpaka::math::abs(acc, ::cms::alpakatools::deltaPhi(acc, phi_rh, iter_phi_c)));
 
               iter_accum_etaSum += warp_sparse_reduce(acc, coop_group_mask, lane_idx, etaSum_, addFn);
               iter_accum_phiSum += warp_sparse_reduce(acc, coop_group_mask, lane_idx, phiSum_, addFn);
 
-              if (load_flag) {
-                const double etaRMS2_ = alpaka::math::max(acc, iter_accum_etaSum / proc_pfc_energy, rms2_threshold);
-                mdpfClusteringVars[i].etaRMS2() = etaRMS2_ * etaRMS2_;
+              const unsigned int coop_group_size = alpaka::popcount(acc, coop_group_mask);
 
-                const double phiRMS2_ = alpaka::math::max(acc, iter_accum_phiSum / proc_pfc_energy, rms2_threshold);
-                mdpfClusteringVars[i].phiRMS2() = phiRMS2_ * phiRMS2_;
+              if (iter_pfrhf_size == coop_group_size) {  //done for this iteration
+                if (src_lane_idx == lane_idx) {
+                  accum_etaSum_div_en = iter_accum_etaSum / iter_pfc_energy;
+                  accum_phiSum_div_en = iter_accum_phiSum / iter_pfc_energy;
+                }
+                iter_lane_idx += 1;
+                update_iter_params = true;
+              } else {
+                if (src_lane_idx == lane_idx) {
+                  pfrhf_size -= coop_group_size;
+                  pfrhf_offset += coop_group_size;
+                }
               }
-
-              if (keep_accum == false) {
-                iter_accum_etaSum = 0.;
-                iter_accum_phiSum = 0.;
-              }
-
-              keep_accum = false;
-            }  // end while
-          } else {  //non cooperative work
-            double accum_etaSum = 0.;
-            double accum_phiSum = 0.;
-
-            for (int pfrhfrac_idx = pfrhf_offset; pfrhfrac_idx < (pfrhf_offset + pfrhf_size); pfrhfrac_idx++) {
-              const int pfrh_idx = pfRecHitFracs[pfrhfrac_idx].pfrhIdx();
-              const float frac = pfRecHitFracs[pfrhfrac_idx].frac();
-              const float energy = pfRecHit[pfrh_idx].energy();
-
-              const double x_rh = pfRecHit[pfrh_idx].x();
-              const double y_rh = pfRecHit[pfrh_idx].y();
-              const double z_rh = pfRecHit[pfrh_idx].z();
-
-              const float eta_rh = static_cast<float>(cms::alpakamath::eta(acc, x_rh, y_rh, z_rh));
-              const float phi_rh = static_cast<float>(::cms::alpakatools::phi(acc, x_rh, y_rh));
-
-              auto etaSum_tmp = (frac * energy) * alpaka::math::abs(acc, eta_rh - eta_c);
-              auto phiSum_tmp =
-                  (frac * energy) * alpaka::math::abs(acc, ::cms::alpakatools::deltaPhi(acc, phi_rh, phi_c));
-
-              accum_etaSum += etaSum_tmp;
-              accum_phiSum += phiSum_tmp;
+            } else {
+              iter_lane_idx += 1;
+              update_iter_params = true;
             }
+          }  //end of while
+        }  //end uniform_groups_elements
 
-            const double etaRMS2_ = alpaka::math::max(acc, accum_etaSum / pfc_energy, rms2_threshold);
-            mdpfClusteringVars[i].etaRMS2() = etaRMS2_ * etaRMS2_;
+        alpaka::syncBlockThreads(acc);
 
-            const double phiRMS2_ = alpaka::math::max(acc, accum_phiSum / pfc_energy, rms2_threshold);
-            mdpfClusteringVars[i].phiRMS2() = phiRMS2_ * phiRMS2_;
-          }
-        }  //end uniform_groups
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nClusters)) {
+          const reduce_t etaRMS2_ = alpaka::math::max(acc, accum_etaSum_div_en, rms2_threshold);
+          const reduce_t phiRMS2_ = alpaka::math::max(acc, accum_phiSum_div_en, rms2_threshold);
+
+          mdpfClusteringVars[idx.global].etaRMS2() = etaRMS2_ * etaRMS2_;
+          mdpfClusteringVars[idx.global].phiRMS2() = phiRMS2_ * phiRMS2_;
+        }
       }
     }
   };

--- a/RecoParticleFlow/PFClusterProducer/test/BuildFile.xml
+++ b/RecoParticleFlow/PFClusterProducer/test/BuildFile.xml
@@ -40,7 +40,7 @@
   <flags ALPAKA_BACKENDS="1"/>
 </bin>
 
-<bin file="alpaka/PrologueTest.dev.cc">
+<bin name="PrologueTest"  file="alpaka/PrologueTest.dev.cc">
   <use name="alpaka"/>
   <use name="eigen"/>
   <use name="HeterogeneousCore/AlpakaInterface"/>
@@ -49,6 +49,18 @@
   <use name="DataFormats/Portable"/>
   <use name="RecoParticleFlow/PFClusterProducer"/>
   <flags ALPAKA_BACKENDS="1"/>
+</bin>
+
+<bin name="PrologueTest_multiblock"  file="alpaka/PrologueTest.dev.cc">
+  <use name="alpaka"/>
+  <use name="eigen"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="FWCore/Utilities"/>
+  <use name="DataFormats/SoATemplate"/>
+  <use name="DataFormats/Portable"/>
+  <use name="RecoParticleFlow/PFClusterProducer"/>
+  <flags CPPFLAGS="-DEPILOGUE_MULTIBLOCK"/>
+  <flags ALPAKA_BACKENDS="cuda rocm"/>
 </bin>
 
 <bin file="alpaka/ECLCCTest.dev.cc">
@@ -73,6 +85,18 @@
   <flags ALPAKA_BACKENDS="1"/>
 </bin>
 
+<bin name="EpilogueTest_multiblock_noncooperative"  file="alpaka/EpilogueTest.dev.cc">
+  <use name="alpaka"/>
+  <use name="eigen"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="FWCore/Utilities"/>
+  <use name="DataFormats/SoATemplate"/>
+  <use name="DataFormats/Portable"/>
+  <use name="RecoParticleFlow/PFClusterProducer"/>
+  <flags CPPFLAGS="-DEPILOGUE_MULTIBLOCK"/>
+  <flags ALPAKA_BACKENDS="cuda rocm"/>
+</bin>
+
 <iftool name="cuda-gcc-support">
  <bin name="EpilogueTest_cooperative" file="alpaka/EpilogueTest.dev.cc">
    <use name="alpaka"/>
@@ -83,6 +107,18 @@
    <use name="DataFormats/Portable"/>
    <use name="RecoParticleFlow/PFClusterProducer"/>
    <flags CPPFLAGS="-DEPILOGUE_COOPERATIVE"/>
+   <flags ALPAKA_BACKENDS="cuda"/>
+ </bin>
+
+  <bin name="EpilogueTest_multiblock_cooperative" file="alpaka/EpilogueTest.dev.cc">
+   <use name="alpaka"/>
+   <use name="eigen"/>
+   <use name="HeterogeneousCore/AlpakaInterface"/>
+   <use name="FWCore/Utilities"/>
+   <use name="DataFormats/SoATemplate"/>
+   <use name="DataFormats/Portable"/>
+   <use name="RecoParticleFlow/PFClusterProducer"/>
+   <flags CPPFLAGS="-DEPILOGUE_COOPERATIVE -DEPILOGUE_MULTIBLOCK"/>
    <flags ALPAKA_BACKENDS="cuda"/>
  </bin>
 

--- a/RecoParticleFlow/PFClusterProducer/test/alpaka/ConstructLinksTest.dev.cc
+++ b/RecoParticleFlow/PFClusterProducer/test/alpaka/ConstructLinksTest.dev.cc
@@ -58,11 +58,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                  reco::PFMultiDepthClusteringCCLabelsDeviceCollection& mdpfCCLabels,
                                  const reco::PFMultiDepthClusteringVarsDeviceCollection& mdpfClusteringVars,
                                  const PFMultiDepthClusterParams* nSigma) const {
-#ifdef __CUDACC__
-    uint32_t items = 160;
-#else
-    uint32_t items = 192;
-#endif
+    uint32_t items = std::is_same_v<Device, alpaka::DevCpu> ? 1 : 64;
 
     auto n = static_cast<uint32_t>(mdpfClusteringVars->metadata().size());
     uint32_t groups = cms::alpakatools::divide_up_by(n, items);

--- a/RecoParticleFlow/PFClusterProducer/test/alpaka/EpilogueTest.dev.cc
+++ b/RecoParticleFlow/PFClusterProducer/test/alpaka/EpilogueTest.dev.cc
@@ -2,58 +2,50 @@
 #include <vector>
 #include <cmath>
 #include <algorithm>
-
 #include <Eigen/Core>
 #include <Eigen/Dense>
-
 #include <iostream>
 #include <cstdlib>
-
 #include <alpaka/alpaka.hpp>
-
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
-
-#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
-#include "FWCore/Utilities/interface/stringize.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
-
-#include "DataFormats/SoATemplate/interface/SoACommon.h"
-#include "DataFormats/SoATemplate/interface/SoALayout.h"
-
-#include "DataFormats/Portable/interface/PortableHostCollection.h"
-#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
-
-#include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterizerHelper.h"
-#include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCEpilogue.h"
-
+#include "DataFormats/Math/interface/deltaPhi.h"
 #include "DataFormats/ParticleFlowReco/interface/PFClusterHostCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/alpaka/PFClusterDeviceCollection.h"
-
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitHostCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitDeviceCollection.h"
-
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFractionHostCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitFractionDeviceCollection.h"
-
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFLayer.h"
-
-#include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
-
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
-
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "DataFormats/SoATemplate/interface/SoACommon.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "FWCore/Utilities/interface/stringize.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometryMayOwnPtr.h"
-#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
-
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+#include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterizerHelper.h"
+#include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCEpilogue.h"
+#include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCEpilogueMultiBlock.h"
+#include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCFinalizeEpilogue.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/PFMultiDepthClusteringCCLabelsHostCollection.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFMultiDepthECLCCEpilogueArgsDeviceCollection.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/PFMultiDepthECLCCEpilogueArgsHostCollection.h"
 
-#include "DataFormats/Math/interface/deltaPhi.h"
+#ifdef EPILOGUE_MULTIBLOCK
+static constexpr bool multiblock = true;
+#else
+static constexpr bool multiblock = false;
+#endif
 
 #ifdef EPILOGUE_COOPERATIVE
 static constexpr bool cooperative = true;
@@ -147,7 +139,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     void apply(Queue &queue,
                reco::PFClusterDeviceCollection &outPFCluster,
                reco::PFRecHitFractionDeviceCollection &outPFRecHitFracs,
-               const reco::PFMultiDepthClusteringCCLabelsDeviceCollection &mdpfClusteringVars,
+               reco::PFMultiDepthClusteringCCLabelsDeviceCollection &mdpfClusteringVars,
                const reco::PFClusterDeviceCollection &pfClusters,
                const reco::PFRecHitFractionDeviceCollection &pfRecHitFracs,
                const reco::PFRecHitDeviceCollection &pfRecHit) const;
@@ -156,11 +148,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   void EpilogueTest::apply(Queue &queue,
                            reco::PFClusterDeviceCollection &outPFCluster,
                            reco::PFRecHitFractionDeviceCollection &outPFRecHitFracs,
-                           const reco::PFMultiDepthClusteringCCLabelsDeviceCollection &mdpfClusteringVars,
+                           reco::PFMultiDepthClusteringCCLabelsDeviceCollection &mdpfClusteringVars,
                            const reco::PFClusterDeviceCollection &pfClusters,
                            const reco::PFRecHitFractionDeviceCollection &pfRecHitFracs,
                            const reco::PFRecHitDeviceCollection &pfRecHit) const {
-    uint32_t items = 160;
+    uint32_t items = std::is_same_v<Device, alpaka::DevCpu> ? 1 : (multiblock ? 128 : 512);
 
     auto n = static_cast<uint32_t>(mdpfClusteringVars->metadata().size());
     uint32_t groups = cms::alpakatools::divide_up_by(n, items);
@@ -174,15 +166,72 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     auto workDiv = cms::alpakatools::make_workdiv<Acc1D>(groups, items);
 
-    alpaka::exec<Acc1D>(queue,
-                        workDiv,
-                        ECLCCEpilogueKernel<32, cooperative>{},
-                        outPFCluster.view(),
-                        outPFRecHitFracs.view(),
-                        mdpfClusteringVars.view(),
-                        pfClusters.view(),
-                        pfRecHitFracs.view(),
-                        pfRecHit.view());
+    if constexpr (multiblock) {
+      if constexpr (cooperative) {
+        printf("Running multiblock epilogue in cooperative mode.\n");
+      } else {
+        printf("Running multiblock epilogue in noncooperative mode.\n");
+      }
+      reco::PFMultiDepthECLCCEpilogueArgsDeviceCollection devClusteringEpilogueArgs{queue, n};
+
+      devClusteringEpilogueArgs.zeroInitialise(queue);
+
+      alpaka::exec<Acc1D>(queue,
+                          workDiv,
+                          ECLCCEpilogueRecHitFracOffsetsKernel{},
+                          devClusteringEpilogueArgs.view(),
+                          mdpfClusteringVars.view(),
+                          pfClusters.view());
+
+      alpaka::exec<Acc1D>(queue,
+                          workDiv,
+                          ECLCCEpilogueCCOffsetsKernel{},
+                          outPFCluster.view(),
+                          devClusteringEpilogueArgs.view(),
+                          mdpfClusteringVars.view(),
+                          pfClusters.view());
+
+      alpaka::exec<Acc1D>(queue,
+                          workDiv,
+                          ECLCCFinalizeEpilogueKernel<32, cooperative>{},
+                          outPFCluster.view(),
+                          outPFRecHitFracs.view(),
+                          devClusteringEpilogueArgs.view(),
+                          mdpfClusteringVars.view(),
+                          pfClusters.view(),
+                          pfRecHitFracs.view(),
+                          pfRecHit.view());
+
+      alpaka::exec<Acc1D>(
+          queue, workDiv, ECLCCLoadSeedsKernel{}, outPFCluster.view(), devClusteringEpilogueArgs.view());
+    } else {
+      if constexpr (cooperative) {
+        printf("Running legacy epilogue in cooperative mode.\n");
+      } else {
+        printf("Running legacy epilogue in noncooperative mode.\n");
+      }
+      if constexpr (std::is_same_v<Device, alpaka::DevCpu>) {
+        alpaka::exec<Acc1D>(queue,
+                            workDiv,
+                            ECLCCEpilogueNaiveKernel{},
+                            outPFCluster.view(),
+                            outPFRecHitFracs.view(),
+                            mdpfClusteringVars.view(),
+                            pfClusters.view(),
+                            pfRecHitFracs.view(),
+                            pfRecHit.view());
+      } else {
+        alpaka::exec<Acc1D>(queue,
+                            workDiv,
+                            ECLCCEpilogueKernel<32, cooperative>{},
+                            outPFCluster.view(),
+                            outPFRecHitFracs.view(),
+                            mdpfClusteringVars.view(),
+                            pfClusters.view(),
+                            pfRecHitFracs.view(),
+                            pfRecHit.view());
+      }
+    }
 
     alpaka::wait(queue);
   }
@@ -458,6 +507,7 @@ void load(::reco::PFClusterHostCollection &hostClusters,
     hClusters[i].y() = cpos.y();
     hClusters[i].z() = cpos.z();
     hClusters[i].topoRHCount() = 0;  //?
+    //printf("\n CLUSTER :: %u %u %f %u \n", recHitOffset, recHitFracSize, cluster.energy(), seedIdx[i]  );
   }
 }
 
@@ -469,7 +519,7 @@ void create_cc_list(::reco::PFMultiDepthClusteringCCLabelsHostCollection &hostCl
   const int low_cc_roots_num = 2;  //zero and the next (after zero) cc roots
   const int cc_roots_num = static_cast<int>(cc_roots.size());
 
-  std::mt19937 rng(std::random_device{}());
+  std::mt19937 rng(12435);
 
   std::bernoulli_distribution pick_next_to_zero_cc_root(0.5);
   std::bernoulli_distribution pick_zero_cc_root_cond(0.1 / 0.5);
@@ -506,7 +556,8 @@ void create_cc_list(::reco::PFMultiDepthClusteringCCLabelsHostCollection &hostCl
   }
 }
 
-int checkEpilogue(const ::reco::PFClusterHostCollection &outHostClusters,
+int checkEpilogue(Queue &queue,
+                  const ::reco::PFClusterHostCollection &outHostClusters,
                   const ::reco::PFRecHitFractionHostCollection &outHostRecHitsFracs,
                   const ::reco::PFClusterHostCollection &inHostClusters,
                   const ::reco::PFRecHitHostCollection &recHits,
@@ -521,8 +572,75 @@ int checkEpilogue(const ::reco::PFClusterHostCollection &outHostClusters,
   auto recHitsView = recHits.view();
 
   const int inClustersNum = inHostClustersView.size();
+  const unsigned int nVertices = hostClusteringVarsView.size();
 
   int nerrors = 0;
+
+  const unsigned int nComponents = static_cast<unsigned int>(cc_roots.size());
+  const unsigned int nFracs = outHostClustersView.nRHFracs();
+
+  ::reco::PFClusterHostCollection outCheckHostClusters{queue, nComponents};
+  ::reco::PFRecHitFractionHostCollection outCheckHostRecHitFracs{queue, nFracs};
+
+  auto outPFCluster = outCheckHostClusters.view();
+  auto outPFRecHitFracs = outCheckHostRecHitFracs.view();
+
+  outPFCluster.nTopos() = nComponents;
+  outPFCluster.nSeeds() = nComponents;
+  outPFCluster.nRHFracs() = inHostClustersView.nRHFracs();
+  outPFCluster.size() = nComponents;
+
+  unsigned int ccrhfrac_idx = 0;
+  unsigned int cc_idx = 0;
+
+  for (auto &rep_idx : cc_roots) {
+    outPFCluster[cc_idx].depth() = inHostClustersView[rep_idx].depth();
+    outPFCluster[cc_idx].topoId() = cc_idx;
+    outPFCluster[cc_idx].energy() = inHostClustersView[rep_idx].energy();
+    outPFCluster[cc_idx].x() = inHostClustersView[rep_idx].x();
+    outPFCluster[cc_idx].y() = inHostClustersView[rep_idx].y();
+    outPFCluster[cc_idx].z() = inHostClustersView[rep_idx].z();
+    outPFCluster[cc_idx].topoRHCount() = inHostClustersView[rep_idx].topoRHCount();
+
+    // Setup rechitfracs:
+    int cc_seed = inHostClustersView[rep_idx].seedRHIdx();
+    float cc_energy = recHitsView[cc_seed].energy();
+
+    outPFCluster[cc_idx].rhfracOffset() = ccrhfrac_idx;
+
+    for (unsigned int iter_idx = 0; iter_idx < nVertices; iter_idx++) {
+      const unsigned int comp_id = hostClusteringVarsView[iter_idx].mdpf_topoId();
+
+      if (comp_id != static_cast<unsigned int>(rep_idx))
+        continue;
+
+      const int seed = inHostClustersView[iter_idx].seedRHIdx();
+      const float energy = recHitsView[seed].energy();
+
+      const unsigned int rhf_begin = inHostClustersView[iter_idx].rhfracOffset();
+      const unsigned int rhf_end = rhf_begin + inHostClustersView[iter_idx].rhfracSize();
+
+      for (unsigned int src_rhfrac_idx = rhf_begin; src_rhfrac_idx < rhf_end; src_rhfrac_idx++) {
+        const unsigned int dst_rhfrac_idx = ccrhfrac_idx;
+
+        outPFRecHitFracs[dst_rhfrac_idx].frac() = inHostRecHitsFracsView[src_rhfrac_idx].frac();
+        outPFRecHitFracs[dst_rhfrac_idx].pfrhIdx() = inHostRecHitsFracsView[src_rhfrac_idx].pfrhIdx();
+        outPFRecHitFracs[dst_rhfrac_idx].pfcIdx() = cc_idx;
+
+        ccrhfrac_idx += 1;
+      }
+      //
+      if (energy > cc_energy) {
+        cc_energy = energy;
+        cc_seed = seed;
+      }
+    }  // iter_idx
+
+    outPFCluster[cc_idx].rhfracSize() = ccrhfrac_idx - outPFCluster[cc_idx].rhfracOffset();
+    outPFCluster[cc_idx].seedRHIdx() = cc_seed;
+
+    cc_idx += 1;
+  }
 
   for (auto &cc_root : cc_roots) {
     printf("\n\n>>>>> Process cc root %d\n", cc_root);
@@ -570,6 +688,7 @@ int checkEpilogue(const ::reco::PFClusterHostCollection &outHostClusters,
     const auto recFracOffset = outHostClustersView[i].rhfracOffset();
     const auto recFracSize = outHostClustersView[i].rhfracSize();
     const auto clidx = outHostRecHitsFracsView[recFracOffset].pfcIdx();
+
     const auto seed = outHostClustersView[i].seedRHIdx();
     const auto energy = recHitsView[seed].energy();
     printf("OUT cluster RHF offset %d RHF size %d  idx %d seed %d energy %f\n",
@@ -578,6 +697,59 @@ int checkEpilogue(const ::reco::PFClusterHostCollection &outHostClusters,
            clidx,
            seed,
            energy);
+  }
+
+  for (int i = 0; i < outClustersNum; i++) {
+    const auto recFracOffset = outHostClustersView[i].rhfracOffset();
+    const auto recFracSize = outHostClustersView[i].rhfracSize();
+    const auto clidx = outHostRecHitsFracsView[recFracOffset].pfcIdx();
+    const auto seed = outHostClustersView[i].seedRHIdx();
+
+    bool match = false;
+    unsigned int found_idx = nComponents;
+    int nmatch = 0;
+    for (int j = 0; j < static_cast<int>(nComponents); j++) {
+      const auto test_seed = outPFCluster[j].seedRHIdx();
+
+      if (test_seed == seed) {
+        const auto test_recFracSize = outPFCluster[j].rhfracSize();
+        const auto test_recFracOffset = outPFCluster[j].rhfracOffset();
+        const auto test_clidx = outPFRecHitFracs[test_recFracOffset].pfcIdx();
+        match = (test_recFracSize == recFracSize) && (test_clidx == j);
+        if (match) {
+          found_idx = test_clidx;
+          nmatch += 1;
+        }
+      }
+    }
+
+    if (nmatch == 0) {
+      printf("ERROR: did not find test cluster (alpaka cluster id %u) !\n", clidx);
+    } else if (nmatch > 1) {
+      printf("ERROR: found multiple clusters (alpaka cluster id %u) !\n", clidx);
+    }
+
+    const int recFracOffset4check = outPFCluster[found_idx].rhfracOffset();
+    const int recFracSize4check = outPFCluster[found_idx].rhfracSize();
+
+    for (int r = 0; r < recFracSize; r++) {
+      const int recHitidx = outHostRecHitsFracsView[recFracOffset + r].pfrhIdx();
+      const float frac = outHostRecHitsFracsView[recFracOffset + r].frac();
+      bool found = false;
+
+      for (int j = 0; j < recFracSize4check; j++) {
+        const int recHitidx4check = outPFRecHitFracs[recFracOffset4check + j].pfrhIdx();
+        const float frac4check = outPFRecHitFracs[recFracOffset4check + j].frac();
+
+        if (recHitidx == recHitidx4check && (fabs(frac - frac4check) < 1e-6))
+          found = true;
+      }
+
+      if (!found) {
+        printf("ERROR: could not find rechit idx %u for cluster %u, size %u\n", recHitidx, i, recFracSize4check);
+        exit(-1);
+      }
+    }
   }
 
   return nerrors;
@@ -595,9 +767,9 @@ int main() {
     exit(EXIT_FAILURE);
   }
 
-  const int nClusters = 145;
-  const int maxHitsPerCluster = 67;
-  const int minHitsPerCluster = 23;
+  const int nClusters = multiblock ? 1200 : 500;
+  const int maxHitsPerCluster = multiblock ? 8 : 23;
+  const int minHitsPerCluster = 1;
 
   ::reco::PFClusterCollection clusters;
   clusters.reserve(nClusters);
@@ -615,9 +787,14 @@ int main() {
   const int nHits = sizes.first;
   const int nFracs = sizes.second;
 
-  std::vector<int> cc_roots = {0, 1, 5, 9, 33, 38, 101};
+  std::vector<int> cc_roots = {0, 1, 5, 9, 33, 38, 101, 113, 313, 331};
 
   const int cc_num = static_cast<int>(cc_roots.size());
+
+  if (cc_roots.back() > nClusters) {
+    std::cerr << "Incorrect cc list." << std::endl;
+    exit(-1);
+  }
 
   // run the test on each device
   for (auto const &device : devices) {
@@ -648,6 +825,7 @@ int main() {
     outHClusters.size() = cc_num;
 
     hClusteringVars.size() = nClusters;
+    hClusteringVars.ncomponents() = 0;
 
     load(hostClusters, hostRecHits, hostRecHitFracs, clusters, hits, rhfracs, seedIdx);
 
@@ -656,8 +834,14 @@ int main() {
     launch_epilogue_test(
         queue, outHostClusters, outHostRecHitFracs, hostClusteringVars, hostClusters, hostRecHits, hostRecHitFracs);
 
-    auto nerrs = checkEpilogue(
-        outHostClusters, outHostRecHitFracs, hostClusters, hostRecHits, hostRecHitFracs, hostClusteringVars, cc_roots);
+    auto nerrs = checkEpilogue(queue,
+                               outHostClusters,
+                               outHostRecHitFracs,
+                               hostClusters,
+                               hostRecHits,
+                               hostRecHitFracs,
+                               hostClusteringVars,
+                               cc_roots);
 
     if (nerrs != 0) {
       std::cerr << nerrs << " errors detected, exiting." << std::endl;

--- a/RecoParticleFlow/PFClusterProducer/test/alpaka/PrologueTest.dev.cc
+++ b/RecoParticleFlow/PFClusterProducer/test/alpaka/PrologueTest.dev.cc
@@ -2,44 +2,34 @@
 #include <vector>
 #include <cmath>
 #include <algorithm>
-
 #include <iostream>
 #include <cstdlib>
-
 #include <Eigen/Core>
 #include <Eigen/Dense>
-
 #include <alpaka/alpaka.hpp>
-
-#include "DataFormats/HcalDetId/interface/HcalDetId.h"
-#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
-
+#include "DataFormats/SoATemplate/interface/SoACommon.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "DataFormats/ParticleFlowReco/interface/PFClusterHostCollection.h"
+#include "FWCore/Utilities/interface/stringize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
-#include "FWCore/Utilities/interface/stringize.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
-
-#include "DataFormats/SoATemplate/interface/SoACommon.h"
-#include "DataFormats/SoATemplate/interface/SoALayout.h"
-
-#include "DataFormats/Portable/interface/PortableHostCollection.h"
-#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
-
 #include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterizerHelper.h"
 #include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCPrologue.h"
-
-#include "DataFormats/ParticleFlowReco/interface/PFClusterHostCollection.h"
-#include "DataFormats/ParticleFlowReco/interface/alpaka/PFClusterDeviceCollection.h"
-
-#include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
-#include "DataFormats/ParticleFlowReco/interface/PFLayer.h"
-
-#include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
-
+#include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCPrologueMultiBlock.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/PFMultiDepthClusteringCCLabelsHostCollection.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/PFMultiDepthClusteringEdgeVarsHostCollection.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFMultiDepthECLCCPrologueArgsDeviceCollection.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/PFMultiDepthECLCCPrologueArgsHostCollection.h"
+
+#ifdef PROLOGUE_MULTIBLOCK
+static constexpr bool multiblock = true;
+#else
+static constexpr bool multiblock = false;
+#endif
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
@@ -53,7 +43,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   void PrologueTest::apply(Queue &queue,
                            reco::PFMultiDepthClusteringEdgeVarsDeviceCollection &pfClusteringEdgeVars,
                            const reco::PFMultiDepthClusteringCCLabelsDeviceCollection &mdpfClusteringVars) const {
-    uint32_t items = 160;
+    uint32_t items = std::is_same_v<Device, alpaka::DevCpu> ? 1 : (multiblock ? 64 : 160);
 
     auto n = static_cast<uint32_t>(mdpfClusteringVars->metadata().size());
     uint32_t groups = cms::alpakatools::divide_up_by(n, items);
@@ -66,8 +56,42 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     }
 
     auto workDiv = cms::alpakatools::make_workdiv<Acc1D>(groups, items);
+    if constexpr (multiblock) {
+      reco::PFMultiDepthECLCCPrologueArgsDeviceCollection devClusteringPrologueArgs{queue, n};
 
-    alpaka::exec<Acc1D>(queue, workDiv, ECLCCPrologueKernel{}, pfClusteringEdgeVars.view(), mdpfClusteringVars.view());
+      devClusteringPrologueArgs.zeroInitialise(queue);
+
+      alpaka::exec<Acc1D>(
+          queue, workDiv, ECLCCComputeExternNeighsKernel{}, devClusteringPrologueArgs.view(), mdpfClusteringVars.view());
+
+      alpaka::exec<Acc1D>(queue,
+                          workDiv,
+                          ECLCCPrologueComputeOffsetsKernel{},
+                          devClusteringPrologueArgs.view(),
+                          mdpfClusteringVars.view());
+
+      alpaka::exec<Acc1D>(queue,
+                          workDiv,
+                          ECLCCFinalizePrologueKernel{},
+                          pfClusteringEdgeVars.view(),
+                          devClusteringPrologueArgs.view(),
+                          mdpfClusteringVars.view());
+
+      alpaka::exec<Acc1D>(queue,
+                          workDiv,
+                          ECLCCLoadCrossBlockNeighKernel{},
+                          pfClusteringEdgeVars.view(),
+                          devClusteringPrologueArgs.view(),
+                          mdpfClusteringVars.view());
+    } else {
+      if constexpr (std::is_same_v<Device, alpaka::DevCpu>) {
+        alpaka::exec<Acc1D>(
+            queue, workDiv, ECLCCPrologueNaiveKernel{}, pfClusteringEdgeVars.view(), mdpfClusteringVars.view());
+      } else {
+        alpaka::exec<Acc1D>(
+            queue, workDiv, ECLCCPrologueKernel{}, pfClusteringEdgeVars.view(), mdpfClusteringVars.view());
+      }
+    }
 
     alpaka::wait(queue);
   }
@@ -173,19 +197,34 @@ int checkPrologue(const ::reco::PFMultiDepthClusteringEdgeVarsHostCollection &ho
     }
     std::cout << "]   ";
 
+    std::vector<std::pair<int, int>> broken_idx;
+    broken_idx.reserve(end - begin);
+
+    int loc_nerrors = 0;
+
     std::cout << "\t\t Alpaka [";
     for (int j = begin; j < end; j++) {
       const int idx = hClusteringEdgeVars[j].mdpf_adjacencyList();
       const bool is_found = std::binary_search(adj[i].begin(), adj[i].end(), idx);
 
       if (is_found == false) {
-        nerrors += 1;
-        std::cout << "mismatch detected for vertex " << i << ", index  " << idx << std::endl;
+        loc_nerrors += 1;
+        broken_idx.push_back(std::make_pair(idx, j));
+        std::cout << "? ";
+      } else {
+        std::cout << hClusteringEdgeVars[j].mdpf_adjacencyList() << " ";
       }
-
-      std::cout << hClusteringEdgeVars[j].mdpf_adjacencyList() << " ";
     }
     std::cout << "]\n";
+
+    if (loc_nerrors > 0) {
+      nerrors += loc_nerrors;
+      std::cout << "\nError: mismatch detected for vertex : " << i;
+      for (auto &ii : broken_idx) {
+        std::cout << ", index " << ii.first << ", at address " << ii.second;
+      }
+      std::cout << "\n\n";
+    }
   }
 
   return nerrors;
@@ -203,7 +242,7 @@ int main() {
     exit(EXIT_FAILURE);
   }
 
-  const int nClusters = 145;
+  const int nClusters = multiblock ? 1200 : 145;
 
   std::vector<int> roots = {0, 3, 7, 11, 19, 29, 37, 41, 71, 83, 97, 101, 137};
 

--- a/RecoParticleFlow/PFClusterProducer/test/alpaka/ShowerShapeTest.dev.cc
+++ b/RecoParticleFlow/PFClusterProducer/test/alpaka/ShowerShapeTest.dev.cc
@@ -2,58 +2,43 @@
 #include <vector>
 #include <cmath>
 #include <algorithm>
-
 #include <iostream>
 #include <cstdlib>
-
 #include <Eigen/Core>
 #include <Eigen/Dense>
-
 #include <alpaka/alpaka.hpp>
-
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
-
-#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
-#include "FWCore/Utilities/interface/stringize.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
-
-#include "DataFormats/SoATemplate/interface/SoACommon.h"
-#include "DataFormats/SoATemplate/interface/SoALayout.h"
-
-#include "DataFormats/Portable/interface/PortableHostCollection.h"
-#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
-
-#include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterizerHelper.h"
-#include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthShowerShape.h"
-
+#include "DataFormats/Math/interface/deltaPhi.h"
 #include "DataFormats/ParticleFlowReco/interface/PFClusterHostCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/alpaka/PFClusterDeviceCollection.h"
-
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitHostCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitDeviceCollection.h"
-
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFractionHostCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitFractionDeviceCollection.h"
-
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFLayer.h"
-
-#include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
-
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
-
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "DataFormats/SoATemplate/interface/SoACommon.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "FWCore/Utilities/interface/stringize.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometryMayOwnPtr.h"
-#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
-
+#include "FWCore/Utilities/interface/stringize.h"
+#include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloCellGeometryMayOwnPtr.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+#include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterizerHelper.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/PFMultiDepthClusteringVarsHostCollection.h"
-
-#include "DataFormats/Math/interface/deltaPhi.h"
+#include "RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthShowerShape.h"
 
 #ifdef SHOWER_SHAPE_COOPERATIVE
 static constexpr bool cooperative = true;
@@ -155,7 +140,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                               const reco::PFClusterDeviceCollection& pfClusters,
                               const reco::PFRecHitFractionDeviceCollection& pfRecHitFracs,
                               const reco::PFRecHitDeviceCollection& pfRecHit) const {
-    uint32_t items = 160;
+    uint32_t items = std::is_same_v<Device, alpaka::DevCpu> ? 1 : 64;
 
     auto n = static_cast<uint32_t>(pfClusters->metadata().size());
     uint32_t groups = ::cms::alpakatools::divide_up_by(n, items);
@@ -505,6 +490,7 @@ int main() {
   }
 
   const int nClusters = 145;
+
   const int maxHitsPerCluster = 67;
   const int minHitsPerCluster = 23;
 


### PR DESCRIPTION
This PR is a follow-up contribution to the Alpaka multi-depth PF clusterizer. It introduces optimized multiblock implementations for the pre- and post-processing kernels of the ECLCC algorithm, and includes several additional kernel optimizations.
Main changes: 
-- multi-block support for ECLCC pre/post processing
-- designed to support large cluster collections where current version is inefficient.
-- improved memory access pattern in the shower shape computation kernel, enabling coalesced writes.
-- reduced shared memory usage in the single-block prologue and epilogue kernels.
Multiblock support required extending the corresponding source files with additional helper kernels and utilities.
The previous implementation assumed primarily single-block execution, which limits scalability for larger cluster collections for Prologue/Epilogue kernels. The multi-block implementations improve scalability while keeping the single-block path efficient.

Resolves https://github.com/cms-sw/framework-team/issues/1924
