### PR TITLE
Improve the use of MPI communicators [16.0.x]

### DIFF
--- a/HeterogeneousCore/MPICore/BuildFile.xml
+++ b/HeterogeneousCore/MPICore/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="fmt"/>
 <use name="mpi"/>
 <use name="DataFormats/Common"/>
 <use name="FWCore/Framework"/>

--- a/HeterogeneousCore/MPICore/interface/api.h
+++ b/HeterogeneousCore/MPICore/interface/api.h
@@ -25,12 +25,46 @@
 class MPIChannel {
 public:
   MPIChannel() = default;
-  MPIChannel(MPI_Comm comm, int destination) : comm_(comm), dest_(destination) {}
+  MPIChannel(MPI_Comm comm, int destination) : comm_(comm), dest_(destination), sync_(false) {}
+
+  MPIChannel(MPIChannel const& other) : comm_(other.comm_), dest_(other.dest_), sync_(false) {}
+
+  MPIChannel& operator=(MPIChannel const& other) {
+    comm_ = other.comm_;
+    dest_ = other.dest_;
+    sync_ = false;
+    return *this;
+  }
+
+  MPIChannel(MPIChannel&& other) : comm_(other.comm_), dest_(other.dest_), sync_(other.sync_) { other.sync_ = false; }
+
+  MPIChannel& operator=(MPIChannel&& other) {
+    comm_ = other.comm_;
+    dest_ = other.dest_;
+    sync_ = other.sync_;
+    other.sync_ = false;
+    return *this;
+  }
+
+  ~MPIChannel() {
+    // make sure both endpoints have completed processing the event(s) that were transmitted
+    if (sync_) {
+      MPI_Barrier(comm_);
+    }
+  }
 
   // build a new MPIChannel that uses a duplicate of the underlying communicator and the same destination
+  // Note: this is a blocking collective operation.
   MPIChannel duplicate() const;
 
+  std::unique_ptr<MPIChannel> syncChannel() const {
+    auto channel = std::make_unique<MPIChannel>(*this);
+    channel->sync_ = true;
+    return channel;
+  }
+
   // close the underlying communicator and reset the MPIChannel to an invalid state
+  // Note: this is a blocking collective operation.
   void reset();
 
   // announce that a client has just connected
@@ -62,18 +96,11 @@ public:
   }
 
   // signal a new event, and transmit the EventAuxiliary
-  void sendEvent(edm::EventAuxiliary const& aux) { sendEventAuxiliary_(aux); }
-
-  /*
-  // start processing a new event, and receive the EventAuxiliary
-  MPI_Status receiveEvent(edm::EventAuxiliary& aux, int source) {
-    return receiveEventAuxiliary_(aux, source, EDM_MPI_ProcessEvent);
-  }
-  */
+  void sendEvent(edm::EventAuxiliary const& aux, unsigned int sid) { sendEventAuxiliary_(aux, sid); }
 
   // start processing a new event, and receive the EventAuxiliary
-  MPI_Status receiveEvent(edm::EventAuxiliary& aux, MPI_Message& message) {
-    return receiveEventAuxiliary_(aux, message);
+  MPI_Status receiveEvent(edm::EventAuxiliary& aux, unsigned int& sid, MPI_Message& message) {
+    return receiveEventAuxiliary_(aux, sid, message);
   }
 
   void sendMetadata(int instance, std::shared_ptr<ProductMetadataBuilder> meta);
@@ -129,12 +156,12 @@ private:
   // serialize an EDM object to a simplified representation that can be transmitted as an MPI message
   void edmToBuffer_(EDM_MPI_RunAuxiliary_t& buffer, edm::RunAuxiliary const& aux);
   void edmToBuffer_(EDM_MPI_LuminosityBlockAuxiliary_t& buffer, edm::LuminosityBlockAuxiliary const& aux);
-  void edmToBuffer_(EDM_MPI_EventAuxiliary_t& buffer, edm::EventAuxiliary const& aux);
+  void edmToBuffer_(EDM_MPI_EventAuxiliary_t& buffer, edm::EventAuxiliary const& aux, unsigned int sid);
 
   // deserialize an EDM object from a simplified representation transmitted as an MPI message
   void edmFromBuffer_(EDM_MPI_RunAuxiliary_t const& buffer, edm::RunAuxiliary& aux);
   void edmFromBuffer_(EDM_MPI_LuminosityBlockAuxiliary_t const& buffer, edm::LuminosityBlockAuxiliary& aux);
-  void edmFromBuffer_(EDM_MPI_EventAuxiliary_t const& buffer, edm::EventAuxiliary& aux);
+  void edmFromBuffer_(EDM_MPI_EventAuxiliary_t const& buffer, edm::EventAuxiliary& aux, unsigned int& sid);
 
   // fill and send an EDM_MPI_Empty_t buffer
   void sendEmpty_(int tag);
@@ -146,11 +173,11 @@ private:
   void sendLuminosityBlockAuxiliary_(int tag, edm::LuminosityBlockAuxiliary const& aux);
 
   // fill and send an EDM_MPI_EventAuxiliary_t buffer
-  void sendEventAuxiliary_(edm::EventAuxiliary const& aux);
+  void sendEventAuxiliary_(edm::EventAuxiliary const& aux, unsigned int sid);
 
   // receive an EDM_MPI_EventAuxiliary_t buffer and populate an edm::EventAuxiliary
-  MPI_Status receiveEventAuxiliary_(edm::EventAuxiliary& aux, int source, int tag);
-  MPI_Status receiveEventAuxiliary_(edm::EventAuxiliary& aux, MPI_Message& message);
+  MPI_Status receiveEventAuxiliary_(edm::EventAuxiliary& aux, unsigned int& sid, int source, int tag);
+  MPI_Status receiveEventAuxiliary_(edm::EventAuxiliary& aux, unsigned int& sid, MPI_Message& message);
 
   // this is what is used for sending when product is of raw fundamental type
   template <typename T>
@@ -172,11 +199,14 @@ private:
     MPI_Mrecv(&product, size, MPI_BYTE, &message, MPI_STATUS_IGNORE);
   }
 
-  // MPI intercommunicator
+  // MPI communicator
   MPI_Comm comm_ = MPI_COMM_NULL;
 
-  // MPI destination
+  // MPI remote rank
   int dest_ = MPI_UNDEFINED;
+
+  // whether the MPI channel should use a barrier to synchronise both endpoints when it's being destructed
+  bool sync_;
 };
 
 #endif  // HeterogeneousCore_MPICore_interface_api_h

--- a/HeterogeneousCore/MPICore/interface/messages.h
+++ b/HeterogeneousCore/MPICore/interface/messages.h
@@ -102,6 +102,7 @@ struct EDM_MPI_EventAuxiliary_t : public EDM_MPI_Header_t {
   uint32_t run;               // edm::RunNumber_t
   uint32_t lumi;              // edm::LuminosityBlockNumber_t
   uint32_t event;             // edm::EventNumber_t
+  uint32_t streamId;          // edm::StreamID
 };
 
 // corresponding MPI type

--- a/HeterogeneousCore/MPICore/plugins/MPIController.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPIController.cc
@@ -1,14 +1,14 @@
 // C++ headers
-#include <iostream>
-#include <memory>
+#include <array>
+#include <optional>
+#include <string>
 #include <vector>
+
+// fmt library
+#include <fmt/ranges.h>
 
 // MPI headers
 #include <mpi.h>
-
-// ROOT headers
-#include <TBufferFile.h>
-#include <TClass.h>
 
 // CMSSW headers
 #include "DataFormats/Provenance/interface/BranchKey.h"
@@ -35,16 +35,11 @@
 
 /* MPIController class
  *
- * This module runs inside a CMSSW job (the "controller") and connects to an "MPISource" in a separate CMSSW job (the "follower").
- * The follower is informed of all transitions seen by the controller, and can replicate them in its own process.
- *
- * Current limitations:
- *   - support a single "follower"
- *
- * Future work:
- *   - support multiple "followers"
+ * This module runs inside a CMSSW job (the "controller") and connects to one or more "MPISource" in one or more CMSSW jobs (the "followers").
+ * Each follower is informed of all transitions seen by the controller, and can replicate them in its own process.
  */
 
+// TODO: change to an edm::global module
 class MPIController : public edm::one::EDProducer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   explicit MPIController(edm::ParameterSet const& config);
@@ -76,8 +71,8 @@ private:
   }
 
   MPI_Comm comm_ = MPI_COMM_NULL;
-  MPIChannel channel_;
-  std::vector<std::shared_ptr<MPIChannel>> channels_;
+  std::vector<MPIChannel> channels_;
+  std::vector<std::optional<MPIChannel>> streams_;
   edm::EDPutTokenT<MPIToken> token_;
   Mode mode_;
 };
@@ -105,40 +100,52 @@ MPIController::MPIController(edm::ParameterSet const& config)
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
     // Determine the rank of the other process.
-    int remote = config.getUntrackedParameter<int>("remoteRank");
-    if (remote == -1) {
+    auto followers = config.getUntrackedParameter<std::vector<int32_t>>("followers");
+    if (followers.empty()) {
       // When there are only two proccesses, we can assume the ranks to be 0 and 1,
       // and we can infer the other process rank from our own.
       if (size == 2) {
-        remote = 1 - rank;
+        followers = {1 - rank};
       } else {
         throw edm::Exception(edm::errors::Configuration)
-            << "Setting the remote rank to -1 is valid only where there are exactly two processes.";
+            << "An empty list of remote processes is valid only where there are exactly two processes.";
       }
     }
-    if (remote < 0 or remote >= size) {
+    if (followers.size() >= static_cast<size_t>(size)) {
       throw edm::Exception(edm::errors::Configuration)
-          << "The rank of the remote process (" << remote << ") is invalid. Valid ranks are 0 to " << size - 1 << ".";
+          << "The number of remote processes is invalid. Please specify at most " << size - 1 << "remote processes.";
     }
-    if (size == 2) {
-      edm::LogAbsolute("MPI") << "MPIController and the remote process have ranks " << rank << ", " << remote
-                              << " in MPI_COMM_WORLD.";
-      comm_ = MPI_COMM_WORLD;
-    } else {
-      // Create a new communicator that spans only this process and the one with the given remote rank.
-      int ranks[2] = {rank, remote};
+    std::vector<int32_t> invalid;
+    for (int follower : followers) {
+      if (follower < 0 or follower >= size) {
+        invalid.push_back(follower);
+      }
+    }
+    if (invalid.size() == 1) {
+      throw edm::Exception(edm::errors::Configuration)
+          << fmt::format("The remote process {} is invalid. Valid ranks are 0 to {}.", invalid.front(), size - 1);
+    } else if (invalid.size() > 1) {
+      throw edm::Exception(edm::errors::Configuration) << fmt::format(
+          "The remote processes {} are invalid. Valid ranks are 0 to {}.", fmt::join(invalid, ", "), size - 1);
+    }
+
+    for (int follower : followers) {
+      // Create a new communicator that spans only this process and one of its followers.
+      std::array<int, 2> ranks = {rank, follower};
       MPI_Group world_group, comm_group;
       MPI_Comm_group(MPI_COMM_WORLD, &world_group);
-      MPI_Group_incl(world_group, 2, ranks, &comm_group);
-      MPI_Comm_create_group(MPI_COMM_WORLD, comm_group, 0, &comm_);
+      MPI_Group_incl(world_group, ranks.size(), ranks.data(), &comm_group);
+      // Note: module construction is serialised, so we can leave the tag set to 0.
+      MPI_Comm comm = MPI_COMM_NULL;
+      MPI_Comm_create_group(MPI_COMM_WORLD, comm_group, 0, &comm);
       MPI_Group_free(&world_group);
       MPI_Group_free(&comm_group);
-      edm::LogAbsolute("MPI") << "MPIController and the remote process have ranks " << rank << ", " << remote
+      edm::LogAbsolute("MPI") << "The controller and follower processes have ranks " << rank << ", " << follower
                               << " in MPI_COMM_WORLD, mapped to ranks 0, 1 in their private communicator.";
-      // The remote process always has rank 1 in the new communicator.
-      remote = 1;
+      // The follower process always has rank 1 in the new communicator.
+      follower = 1;
+      channels_.emplace_back(comm, follower);
     }
-    channel_ = MPIChannel(comm_, remote);
   } else if (mode_ == kIntercommunicator) {
     // Use an intercommunicator to let two groups of processes communicate with each other.
     // The current implementation supports only two processes: one controller and one source.
@@ -166,7 +173,7 @@ MPIController::MPIController(edm::ParameterSet const& config)
           << "The current implementation supports only two processes: one controller and one source.";
     }
     edm::LogAbsolute("MPI") << "Client connected to " << size << (size == 1 ? " server" : " servers");
-    channel_ = MPIChannel(comm_, 0);
+    channels_ = {MPIChannel(comm_, 0)};
   } else {
     // Invalid mode.
     throw edm::Exception(edm::errors::Configuration)
@@ -175,6 +182,12 @@ MPIController::MPIController(edm::ParameterSet const& config)
 }
 
 MPIController::~MPIController() {
+  // Disconnect the per-stream communicators.
+  for (auto& stream : streams_) {
+    // TODO move this to end stream
+    stream->reset();
+  }
+
   // Close the intercommunicator.
   if (mode_ == kIntercommunicator) {
     MPI_Comm_disconnect(&comm_);
@@ -183,7 +196,9 @@ MPIController::~MPIController() {
 
 void MPIController::beginJob() {
   // signal the connection
-  channel_.sendConnect();
+  for (auto& channel : channels_) {
+    channel.sendConnect();
+  }
 
   /* is there a way to access all known process histories ?
   edm::ProcessHistoryRegistry const& registry = * edm::ProcessHistoryRegistry::instance();
@@ -196,7 +211,9 @@ void MPIController::beginJob() {
 
 void MPIController::endJob() {
   // signal the disconnection
-  channel_.sendDisconnect();
+  for (auto& channel : channels_) {
+    channel.sendDisconnect();
+  }
 }
 
 void MPIController::beginRun(edm::Run const& run, edm::EventSetup const& setup) {
@@ -205,7 +222,10 @@ void MPIController::beginRun(edm::Run const& run, edm::EventSetup const& setup) 
    * Ideally the ProcessHistoryID stored in the run.runAuxiliary() should be the correct one, and
    * we could simply do
 
-  channel_.sendBeginRun(run.runAuxiliary());
+  for (auto& channel: channels_) {
+    channel.sendBeginRun(run.runAuxiliary());
+    channel.sendProduct(0, run.processHistory());
+  }
 
    * Instead, it looks like the ProcessHistoryID stored in the run.runAuxiliary() is that of the
    * _parent_ process.
@@ -214,10 +234,12 @@ void MPIController::beginRun(edm::Run const& run, edm::EventSetup const& setup) 
    */
   auto aux = run.runAuxiliary();
   aux.setProcessHistoryID(run.processHistory().id());
-  channel_.sendBeginRun(aux);
+  for (auto& channel : channels_) {
+    channel.sendBeginRun(aux);
 
-  // transmit the ProcessHistory
-  channel_.sendProduct(0, run.processHistory());
+    // transmit the ProcessHistory
+    channel.sendProduct(0, run.processHistory());
+  }
 }
 
 void MPIController::endRun(edm::Run const& run, edm::EventSetup const& setup) {
@@ -226,7 +248,9 @@ void MPIController::endRun(edm::Run const& run, edm::EventSetup const& setup) {
    * Ideally the ProcessHistoryID stored in the run.runAuxiliary() should be the correct one, and
    * we could simply do
 
-  channel_.sendEndRun(run.runAuxiliary());
+  for (auto& channel: channels_) {
+    channel.sendEndRun(run.runAuxiliary());
+  }
 
    * Instead, it looks like the ProcessHistoryID stored in the run.runAuxiliary() is that of the
    * _parent_ process.
@@ -235,7 +259,9 @@ void MPIController::endRun(edm::Run const& run, edm::EventSetup const& setup) {
    */
   auto aux = run.runAuxiliary();
   aux.setProcessHistoryID(run.processHistory().id());
-  channel_.sendEndRun(aux);
+  for (auto& channel : channels_) {
+    channel.sendEndRun(aux);
+  }
 }
 
 void MPIController::beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& setup) {
@@ -244,7 +270,9 @@ void MPIController::beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::
    * Ideally the ProcessHistoryID stored in the lumi.luminosityBlockAuxiliary() should be the
    * correct one, and we could simply do
 
-  channel_.sendBeginLuminosityBlock(lumi.luminosityBlockAuxiliary());
+  for (auto& channel: channels_) {
+    channel.sendBeginLuminosityBlock(lumi.luminosityBlockAuxiliary());
+  }
 
    * Instead, it looks like the ProcessHistoryID stored in the lumi.luminosityBlockAuxiliary() is
    * that of the _parent_ process.
@@ -253,7 +281,9 @@ void MPIController::beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::
    */
   auto aux = lumi.luminosityBlockAuxiliary();
   aux.setProcessHistoryID(lumi.processHistory().id());
-  channel_.sendBeginLuminosityBlock(aux);
+  for (auto& channel : channels_) {
+    channel.sendBeginLuminosityBlock(aux);
+  }
 }
 
 void MPIController::endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& setup) {
@@ -262,7 +292,9 @@ void MPIController::endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::Ev
    * Ideally the ProcessHistoryID stored in the lumi.luminosityBlockAuxiliary() should be the
    * correct one, and we could simply do
 
-  channel_.sendEndLuminosityBlock(lumi.luminosityBlockAuxiliary());
+  for (auto& channel: channels_) {
+    channel.sendEndLuminosityBlock(lumi.luminosityBlockAuxiliary());
+  }
 
    * Instead, it looks like the ProcessHistoryID stored in the lumi.luminosityBlockAuxiliary() is
    * that of the _parent_ process.
@@ -271,7 +303,9 @@ void MPIController::endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::Ev
    */
   auto aux = lumi.luminosityBlockAuxiliary();
   aux.setProcessHistoryID(lumi.processHistory().id());
-  channel_.sendEndLuminosityBlock(aux);
+  for (auto& channel : channels_) {
+    channel.sendEndLuminosityBlock(aux);
+  }
 }
 
 void MPIController::produce(edm::Event& event, edm::EventSetup const& setup) {
@@ -290,23 +324,23 @@ void MPIController::produce(edm::Event& event, edm::EventSetup const& setup) {
     log << "\nprocessGUID " << edm::Guid(event.eventAuxiliary().processGUID(), true).toString();
   }
 
+  // use the channel associated to the framework stream
+  unsigned int sid = event.streamID().value();
+
   // signal a new event, and transmit the EventAuxiliary
-  channel_.sendEvent(event.eventAuxiliary(), event.streamID().value());
+  auto& channel = channels_[sid % channels_.size()];
+  channel.sendEvent(event.eventAuxiliary(), event.streamID().value());
 
   // keep a duplicate of the MPIChannel for each framework stream
-  unsigned int sid = event.streamID().value();
-  if (sid >= channels_.size()) {
-    channels_.resize(sid + 1);
+  if (sid >= streams_.size()) {
+    streams_.resize(sid + 1);
   }
-  if (not channels_[sid]) {
+  if (not streams_[sid]) {
     // TODO move this to begin stream
-    channels_[sid] = std::shared_ptr<MPIChannel>(new MPIChannel(channel_.duplicate()), [](MPIChannel* ptr) {
-      ptr->reset();
-      delete ptr;
-    });
+    streams_[sid] = channel.duplicate();
   }
   // create a new channel object reusing the same communicator that will synchronise at the end pf the event
-  event.emplace(token_, channels_[sid]->syncChannel());
+  event.emplace(token_, streams_[sid]->syncChannel());
 }
 
 void MPIController::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -318,13 +352,15 @@ void MPIController::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.ifValue(
           edm::ParameterDescription<std::string>("mode", "CommWorld", false),
           ModeDescription[kCommWorld] >>
-                  edm::ParameterDescription<int>(
-                      "remoteRank",
-                      -1,
+                  edm::ParameterDescription<std::vector<int32_t>>(
+                      "followers",
+                      {},
                       false,
-                      edm::Comment(
-                          "Rank of the remote process. When there are only two processes, pass -1 to autodetect the "
-                          "rank of the remote process based on the rank of the current process.")) or
+                      edm::Comment("Ranks of the remote \"follower\" processes.\n"
+                                   "When there are two or more follower processes, framework streams are associated to "
+                                   "each follower in a round-robin fashion.\n"
+                                   "When there is only one remote process, pass an empty list to autodetect its rank "
+                                   "based on the rank of the current process.")) or
               ModeDescription[kIntercommunicator] >> edm::ParameterDescription<std::string>("name", "server", false))
       ->setComment(
           "Valid modes are CommWorld (use MPI_COMM_WORLD) and Intercommunicator (use an MPI name server to setup an "

--- a/HeterogeneousCore/MPICore/plugins/MPIController.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPIController.cc
@@ -86,32 +86,59 @@ MPIController::MPIController(edm::ParameterSet const& config)
     : token_(produces<MPIToken>()),
       mode_(parseMode(config.getUntrackedParameter<std::string>("mode")))  //
 {
-  // make sure that MPI is initialised
+  // Make sure that MPI is initialised.
   MPIService::required();
 
-  // make sure the EDM MPI types are available
+  // Make sure the EDM MPI types are available.
   EDM_MPI_build_types();
 
   if (mode_ == kCommWorld) {
     // All processes are in MPI_COMM_WORLD.
-    // The current implementation supports only two processes: one controller and one source.
     edm::LogAbsolute("MPI") << "MPIController in " << ModeDescription[mode_] << " mode.";
 
-    // Check how many processes are there in MPI_COMM_WORLD
+    // Check how many processes are there in MPI_COMM_WORLD.
     int size;
     MPI_Comm_size(MPI_COMM_WORLD, &size);
-    if (size != 2) {
-      throw edm::Exception(edm::errors::Configuration)
-          << "The current implementation supports only two processes: one controller and one source.";
-    }
 
-    // Check the rank of this process, and determine the rank of the other process.
+    // Check the rank of this process.
     int rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    edm::LogAbsolute("MPI") << "MPIController has rank " << rank << " in MPI_COMM_WORLD.";
-    int other_rank = 1 - rank;
-    comm_ = MPI_COMM_WORLD;
-    channel_ = MPIChannel(comm_, other_rank);
+
+    // Determine the rank of the other process.
+    int remote = config.getUntrackedParameter<int>("remoteRank");
+    if (remote == -1) {
+      // When there are only two proccesses, we can assume the ranks to be 0 and 1,
+      // and we can infer the other process rank from our own.
+      if (size == 2) {
+        remote = 1 - rank;
+      } else {
+        throw edm::Exception(edm::errors::Configuration)
+            << "Setting the remote rank to -1 is valid only where there are exactly two processes.";
+      }
+    }
+    if (remote < 0 or remote >= size) {
+      throw edm::Exception(edm::errors::Configuration)
+          << "The rank of the remote process (" << remote << ") is invalid. Valid ranks are 0 to " << size - 1 << ".";
+    }
+    if (size == 2) {
+      edm::LogAbsolute("MPI") << "MPIController and the remote process have ranks " << rank << ", " << remote
+                              << " in MPI_COMM_WORLD.";
+      comm_ = MPI_COMM_WORLD;
+    } else {
+      // Create a new communicator that spans only this process and the one with the given remote rank.
+      int ranks[2] = {rank, remote};
+      MPI_Group world_group, comm_group;
+      MPI_Comm_group(MPI_COMM_WORLD, &world_group);
+      MPI_Group_incl(world_group, 2, ranks, &comm_group);
+      MPI_Comm_create_group(MPI_COMM_WORLD, comm_group, 0, &comm_);
+      MPI_Group_free(&world_group);
+      MPI_Group_free(&comm_group);
+      edm::LogAbsolute("MPI") << "MPIController and the remote process have ranks " << rank << ", " << remote
+                              << " in MPI_COMM_WORLD, mapped to ranks 0, 1 in their private communicator.";
+      // The remote process always has rank 1 in the new communicator.
+      remote = 1;
+    }
+    channel_ = MPIChannel(comm_, remote);
   } else if (mode_ == kIntercommunicator) {
     // Use an intercommunicator to let two groups of processes communicate with each other.
     // The current implementation supports only two processes: one controller and one source.
@@ -290,7 +317,14 @@ void MPIController::fillDescriptions(edm::ConfigurationDescriptions& description
   edm::ParameterSetDescription desc;
   desc.ifValue(
           edm::ParameterDescription<std::string>("mode", "CommWorld", false),
-          ModeDescription[kCommWorld] >> edm::EmptyGroupDescription() or
+          ModeDescription[kCommWorld] >>
+                  edm::ParameterDescription<int>(
+                      "remoteRank",
+                      -1,
+                      false,
+                      edm::Comment(
+                          "Rank of the remote process. When there are only two processes, pass -1 to autodetect the "
+                          "rank of the remote process based on the rank of the current process.")) or
               ModeDescription[kIntercommunicator] >> edm::ParameterDescription<std::string>("name", "server", false))
       ->setComment(
           "Valid modes are CommWorld (use MPI_COMM_WORLD) and Intercommunicator (use an MPI name server to setup an "

--- a/HeterogeneousCore/MPICore/plugins/MPIController.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPIController.cc
@@ -1,7 +1,7 @@
 // C++ headers
 #include <iostream>
 #include <memory>
-#include <sstream>
+#include <vector>
 
 // MPI headers
 #include <mpi.h>
@@ -77,6 +77,7 @@ private:
 
   MPI_Comm comm_ = MPI_COMM_NULL;
   MPIChannel channel_;
+  std::vector<std::shared_ptr<MPIChannel>> channels_;
   edm::EDPutTokenT<MPIToken> token_;
   Mode mode_;
 };
@@ -263,14 +264,22 @@ void MPIController::produce(edm::Event& event, edm::EventSetup const& setup) {
   }
 
   // signal a new event, and transmit the EventAuxiliary
-  channel_.sendEvent(event.eventAuxiliary());
+  channel_.sendEvent(event.eventAuxiliary(), event.streamID().value());
 
-  // duplicate the MPIChannel and put the copy into the Event
-  std::shared_ptr<MPIChannel> link(new MPIChannel(channel_.duplicate()), [](MPIChannel* ptr) {
-    ptr->reset();
-    delete ptr;
-  });
-  event.emplace(token_, std::move(link));
+  // keep a duplicate of the MPIChannel for each framework stream
+  unsigned int sid = event.streamID().value();
+  if (sid >= channels_.size()) {
+    channels_.resize(sid + 1);
+  }
+  if (not channels_[sid]) {
+    // TODO move this to begin stream
+    channels_[sid] = std::shared_ptr<MPIChannel>(new MPIChannel(channel_.duplicate()), [](MPIChannel* ptr) {
+      ptr->reset();
+      delete ptr;
+    });
+  }
+  // create a new channel object reusing the same communicator that will synchronise at the end pf the event
+  event.emplace(token_, channels_[sid]->syncChannel());
 }
 
 void MPIController::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HeterogeneousCore/MPICore/plugins/MPISource.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPISource.cc
@@ -2,6 +2,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 // MPI headers
 #include <mpi.h>
@@ -35,6 +36,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescriptionFiller.h"
 #include "FWCore/Sources/interface/ProducerSourceBase.h"
 #include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/StreamID.h"
 #include "HeterogeneousCore/MPICore/interface/api.h"
 #include "HeterogeneousCore/MPICore/interface/conversion.h"
 #include "HeterogeneousCore/MPICore/interface/messages.h"
@@ -68,10 +70,14 @@ private:
   char port_[MPI_MAX_PORT_NAME];
   MPI_Comm comm_ = MPI_COMM_NULL;
   MPIChannel channel_;
+  std::vector<std::shared_ptr<MPIChannel>> channels_;
   edm::EDPutTokenT<MPIToken> token_;
   Mode mode_;
 
   edm::ProcessHistory history_;
+
+  // temporary value used to pass information from setRunAndEventInfo() to produce()
+  unsigned int controller_sid_ = edm::StreamID::invalidStreamID();
 };
 
 MPISource::MPISource(edm::ParameterSet const& config, edm::InputSourceDescription const& desc)
@@ -276,7 +282,27 @@ bool MPISource::setRunAndEventInfo(edm::EventID& event,
       case EDM_MPI_ProcessEvent: {
         // receive the EventAuxiliary
         edm::EventAuxiliary aux;
-        status = channel_.receiveEvent(aux, message);
+        unsigned int sid;
+        status = channel_.receiveEvent(aux, sid, message);
+
+        // keep a duplicate of the MPIChannel for each controller's framework stream
+        if (sid >= channels_.size()) {
+          channels_.resize(sid + 1);
+        }
+        if (not channels_[sid]) {
+          // TODO move this to begin stream
+          channels_[sid] = std::shared_ptr<MPIChannel>(new MPIChannel(channel_.duplicate()), [](MPIChannel* ptr) {
+            ptr->reset();
+            delete ptr;
+          });
+        }
+
+        // store the controller's framework stream to reuse it in produce()
+        controller_sid_ = sid;
+        if (controller_sid_ == edm::StreamID::invalidStreamID()) {
+          throw cms::Exception("InvalidValue")
+              << "The MPISource has received an EDM_MPI_ProcessEvent with invalid stream id.";
+        }
 
         // extract the rank of the other process (currently unused)
         int source = status.MPI_SOURCE;
@@ -302,12 +328,9 @@ bool MPISource::setRunAndEventInfo(edm::EventID& event,
 }
 
 void MPISource::produce(edm::Event& event) {
-  // duplicate the MPIChannel and put the copy into the Event
-  std::shared_ptr<MPIChannel> channel(new MPIChannel(channel_.duplicate()), [](MPIChannel* ptr) {
-    ptr->reset();
-    delete ptr;
-  });
-  event.emplace(token_, std::move(channel));
+  // create a new channel object reusing the same communicator that will synchronise at the end pf the event
+  event.emplace(token_, channels_[controller_sid_]->syncChannel());
+  controller_sid_ = edm::StreamID::invalidStreamID();
 }
 
 void MPISource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HeterogeneousCore/MPICore/plugins/MPISource.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPISource.cc
@@ -88,8 +88,7 @@ MPISource::MPISource(edm::ParameterSet const& config, edm::InputSourceDescriptio
       token_(produces<MPIToken>()),
       mode_(parseMode(config.getUntrackedParameter<std::string>("mode")))  //
 {
-  // make sure that MPI is initialised
-
+  // Make sure that MPI is initialised.
   MPIService::required();
 
   // Make sure the EDM MPI types are available.
@@ -97,24 +96,51 @@ MPISource::MPISource(edm::ParameterSet const& config, edm::InputSourceDescriptio
 
   if (mode_ == kCommWorld) {
     // All processes are in MPI_COMM_WORLD.
-    // The current implementation supports only two processes: one controller and one source.
     edm::LogAbsolute("MPI") << "MPISource in " << ModeDescription[mode_] << " mode.";
 
     // Check how many processes are there in MPI_COMM_WORLD
     int size;
     MPI_Comm_size(MPI_COMM_WORLD, &size);
-    if (size != 2) {
-      throw edm::Exception(edm::errors::Configuration)
-          << "The current implementation supports only two processes: one controller and one source.";
-    }
 
-    // Check the rank of this process, and determine the rank of the other process.
+    // Check the rank of this process.
     int rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    edm::LogAbsolute("MPI") << "MPISource has rank " << rank << " in MPI_COMM_WORLD.";
-    int other_rank = 1 - rank;
-    comm_ = MPI_COMM_WORLD;
-    channel_ = MPIChannel(comm_, other_rank);
+
+    // Determine the rank of the other process.
+    int remote = config.getUntrackedParameter<int>("remoteRank");
+    if (remote == -1) {
+      // When there are only two proccesses, we can assume the ranks to be 0 and 1,
+      // and we can infer the other process rank from our own.
+      if (size == 2) {
+        remote = 1 - rank;
+      } else {
+        throw edm::Exception(edm::errors::Configuration)
+            << "Setting the remote rank to -1 is valid only where there are exactly two processes.";
+      }
+    }
+    if (remote < 0 or remote >= size) {
+      throw edm::Exception(edm::errors::Configuration)
+          << "The rank of the remote process (" << remote << ") is invalid. Valid ranks are 0 to " << size - 1 << ".";
+    }
+    if (size == 2) {
+      edm::LogAbsolute("MPI") << "The remote process and MPISource have ranks " << remote << ", " << rank
+                              << " in MPI_COMM_WORLD.";
+      comm_ = MPI_COMM_WORLD;
+    } else {
+      // Create a new communicator that spans only this process and the one with the given remote rank.
+      int ranks[2] = {remote, rank};
+      MPI_Group world_group, comm_group;
+      MPI_Comm_group(MPI_COMM_WORLD, &world_group);
+      MPI_Group_incl(world_group, 2, ranks, &comm_group);
+      MPI_Comm_create_group(MPI_COMM_WORLD, comm_group, 0, &comm_);
+      MPI_Group_free(&world_group);
+      MPI_Group_free(&comm_group);
+      edm::LogAbsolute("MPI") << "The remote process and MPISource have ranks " << remote << ", " << rank
+                              << " in MPI_COMM_WORLD, mapped to ranks 0, 1 in their private communicator.";
+      // The remote process always has rank 0 in the new communicator.
+      remote = 0;
+    }
+    channel_ = MPIChannel(comm_, remote);
   } else if (mode_ == kIntercommunicator) {
     // Use an intercommunicator to let two groups of processes communicate with each other.
     // The current implementation supports only two processes: one controller and one source.
@@ -342,7 +368,14 @@ void MPISource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ProducerSourceBase::fillDescription(desc);
   desc.ifValue(
           edm::ParameterDescription<std::string>("mode", "CommWorld", false),
-          ModeDescription[kCommWorld] >> edm::EmptyGroupDescription() or
+          ModeDescription[kCommWorld] >>
+                  edm::ParameterDescription<int>(
+                      "remoteRank",
+                      -1,
+                      false,
+                      edm::Comment(
+                          "Rank of the remote process. When there are only two processes, pass -1 to autodetect the "
+                          "rank of the remote process based on the rank of the current process.")) or
               ModeDescription[kIntercommunicator] >> edm::ParameterDescription<std::string>("name", "server", false))
       ->setComment(
           "Valid modes are CommWorld (use MPI_COMM_WORLD) and Intercommunicator (use an MPI name server to setup an "

--- a/HeterogeneousCore/MPICore/plugins/MPISource.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPISource.cc
@@ -1,16 +1,11 @@
 // C++ headers
-#include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 // MPI headers
 #include <mpi.h>
-
-// ROOT headers
-#include <TBuffer.h>
-#include <TBufferFile.h>
-#include <TClass.h>
 
 // CMSSW headers
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
@@ -70,7 +65,7 @@ private:
   char port_[MPI_MAX_PORT_NAME];
   MPI_Comm comm_ = MPI_COMM_NULL;
   MPIChannel channel_;
-  std::vector<std::shared_ptr<MPIChannel>> channels_;
+  std::vector<std::optional<MPIChannel>> streams_;
   edm::EDPutTokenT<MPIToken> token_;
   Mode mode_;
 
@@ -107,7 +102,7 @@ MPISource::MPISource(edm::ParameterSet const& config, edm::InputSourceDescriptio
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
     // Determine the rank of the other process.
-    int remote = config.getUntrackedParameter<int>("remoteRank");
+    int remote = config.getUntrackedParameter<int>("controller");
     if (remote == -1) {
       // When there are only two proccesses, we can assume the ranks to be 0 and 1,
       // and we can infer the other process rank from our own.
@@ -122,24 +117,19 @@ MPISource::MPISource(edm::ParameterSet const& config, edm::InputSourceDescriptio
       throw edm::Exception(edm::errors::Configuration)
           << "The rank of the remote process (" << remote << ") is invalid. Valid ranks are 0 to " << size - 1 << ".";
     }
-    if (size == 2) {
-      edm::LogAbsolute("MPI") << "The remote process and MPISource have ranks " << remote << ", " << rank
-                              << " in MPI_COMM_WORLD.";
-      comm_ = MPI_COMM_WORLD;
-    } else {
-      // Create a new communicator that spans only this process and the one with the given remote rank.
-      int ranks[2] = {remote, rank};
-      MPI_Group world_group, comm_group;
-      MPI_Comm_group(MPI_COMM_WORLD, &world_group);
-      MPI_Group_incl(world_group, 2, ranks, &comm_group);
-      MPI_Comm_create_group(MPI_COMM_WORLD, comm_group, 0, &comm_);
-      MPI_Group_free(&world_group);
-      MPI_Group_free(&comm_group);
-      edm::LogAbsolute("MPI") << "The remote process and MPISource have ranks " << remote << ", " << rank
-                              << " in MPI_COMM_WORLD, mapped to ranks 0, 1 in their private communicator.";
-      // The remote process always has rank 0 in the new communicator.
-      remote = 0;
-    }
+
+    // Create a new communicator that spans only this process and the one with the given remote rank.
+    int ranks[2] = {remote, rank};
+    MPI_Group world_group, comm_group;
+    MPI_Comm_group(MPI_COMM_WORLD, &world_group);
+    MPI_Group_incl(world_group, 2, ranks, &comm_group);
+    MPI_Comm_create_group(MPI_COMM_WORLD, comm_group, 0, &comm_);
+    MPI_Group_free(&world_group);
+    MPI_Group_free(&comm_group);
+    edm::LogAbsolute("MPI") << "The remote process and MPISource have ranks " << remote << ", " << rank
+                            << " in MPI_COMM_WORLD, mapped to ranks 0, 1 in their private communicator.";
+    // The remote process always has rank 0 in the new communicator.
+    remote = 0;
     channel_ = MPIChannel(comm_, remote);
   } else if (mode_ == kIntercommunicator) {
     // Use an intercommunicator to let two groups of processes communicate with each other.
@@ -185,6 +175,14 @@ MPISource::MPISource(edm::ParameterSet const& config, edm::InputSourceDescriptio
 }
 
 MPISource::~MPISource() {
+  // Disconnect the per-stream communicators.
+  for (auto& stream : streams_) {
+    // TODO move this to end stream
+    if (stream) {
+      stream->reset();
+    }
+  }
+
   if (mode_ == kIntercommunicator) {
     // Close the intercommunicator.
     MPI_Comm_disconnect(&comm_);
@@ -310,25 +308,22 @@ bool MPISource::setRunAndEventInfo(edm::EventID& event,
         edm::EventAuxiliary aux;
         unsigned int sid;
         status = channel_.receiveEvent(aux, sid, message);
+        if (sid == edm::StreamID::invalidStreamID()) {
+          throw cms::Exception("InvalidValue")
+              << "The MPISource has received an EDM_MPI_ProcessEvent with invalid stream id.";
+        }
 
         // keep a duplicate of the MPIChannel for each controller's framework stream
-        if (sid >= channels_.size()) {
-          channels_.resize(sid + 1);
+        if (sid >= streams_.size()) {
+          streams_.resize(sid + 1);
         }
-        if (not channels_[sid]) {
+        if (not streams_[sid]) {
           // TODO move this to begin stream
-          channels_[sid] = std::shared_ptr<MPIChannel>(new MPIChannel(channel_.duplicate()), [](MPIChannel* ptr) {
-            ptr->reset();
-            delete ptr;
-          });
+          streams_[sid] = channel_.duplicate();
         }
 
         // store the controller's framework stream to reuse it in produce()
         controller_sid_ = sid;
-        if (controller_sid_ == edm::StreamID::invalidStreamID()) {
-          throw cms::Exception("InvalidValue")
-              << "The MPISource has received an EDM_MPI_ProcessEvent with invalid stream id.";
-        }
 
         // extract the rank of the other process (currently unused)
         int source = status.MPI_SOURCE;
@@ -355,7 +350,7 @@ bool MPISource::setRunAndEventInfo(edm::EventID& event,
 
 void MPISource::produce(edm::Event& event) {
   // create a new channel object reusing the same communicator that will synchronise at the end pf the event
-  event.emplace(token_, channels_[controller_sid_]->syncChannel());
+  event.emplace(token_, streams_[controller_sid_]->syncChannel());
   controller_sid_ = edm::StreamID::invalidStreamID();
 }
 
@@ -370,12 +365,12 @@ void MPISource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
           edm::ParameterDescription<std::string>("mode", "CommWorld", false),
           ModeDescription[kCommWorld] >>
                   edm::ParameterDescription<int>(
-                      "remoteRank",
+                      "controller",
                       -1,
                       false,
-                      edm::Comment(
-                          "Rank of the remote process. When there are only two processes, pass -1 to autodetect the "
-                          "rank of the remote process based on the rank of the current process.")) or
+                      edm::Comment("Rank of the remote \"controller\" process.\n"
+                                   "When there are only two processes, pass -1 to autodetect the rank of the remote "
+                                   "process based on the rank of the current process.")) or
               ModeDescription[kIntercommunicator] >> edm::ParameterDescription<std::string>("name", "server", false))
       ->setComment(
           "Valid modes are CommWorld (use MPI_COMM_WORLD) and Intercommunicator (use an MPI name server to setup an "

--- a/HeterogeneousCore/MPICore/src/api.cc
+++ b/HeterogeneousCore/MPICore/src/api.cc
@@ -37,6 +37,7 @@ namespace {
 
 // build a new MPIChannel that uses a duplicate of the underlying communicator and the same destination
 MPIChannel MPIChannel::duplicate() const {
+  // This is a blocking collective operation.
   MPI_Comm newcomm;
   MPI_Comm_dup(comm_, &newcomm);
   return MPIChannel(newcomm, dest_);
@@ -44,6 +45,7 @@ MPIChannel MPIChannel::duplicate() const {
 
 // close the underlying communicator and reset the MPIChannel to an invalid state
 void MPIChannel::reset() {
+  // This is a blocking collective operation.
   MPI_Comm_disconnect(&comm_);
   dest_ = MPI_UNDEFINED;
 }
@@ -81,7 +83,7 @@ void MPIChannel::edmToBuffer_(EDM_MPI_LuminosityBlockAuxiliary_t& buffer, edm::L
 }
 
 // fill an edm::EventAuxiliary object from an EDM_MPI_EventAuxiliary buffer
-void MPIChannel::edmFromBuffer_(EDM_MPI_EventAuxiliary_t const& buffer, edm::EventAuxiliary& aux) {
+void MPIChannel::edmFromBuffer_(EDM_MPI_EventAuxiliary_t const& buffer, edm::EventAuxiliary& aux, unsigned int& sid) {
   aux = edm::EventAuxiliary({buffer.run, buffer.lumi, buffer.event},
                             std::string(buffer.processGuid, std::size(buffer.processGuid)),
                             edm::Timestamp(buffer.time),
@@ -92,10 +94,11 @@ void MPIChannel::edmFromBuffer_(EDM_MPI_EventAuxiliary_t const& buffer, edm::Eve
                             buffer.orbitNumber);
   aux.setProcessHistoryID(
       edm::ProcessHistoryID(std::string(buffer.processHistoryID, std::size(buffer.processHistoryID))));
+  sid = buffer.streamId;
 }
 
 // fill an EDM_MPI_EventAuxiliary buffer from an edm::EventAuxiliary object
-void MPIChannel::edmToBuffer_(EDM_MPI_EventAuxiliary_t& buffer, edm::EventAuxiliary const& aux) {
+void MPIChannel::edmToBuffer_(EDM_MPI_EventAuxiliary_t& buffer, edm::EventAuxiliary const& aux, unsigned int sid) {
   copy_and_fill(buffer.processHistoryID, aux.processHistoryID().compactForm());
   copy_and_fill(buffer.processGuid, aux.processGUID());
   buffer.time = aux.time().value();
@@ -107,6 +110,7 @@ void MPIChannel::edmToBuffer_(EDM_MPI_EventAuxiliary_t& buffer, edm::EventAuxili
   buffer.run = aux.id().run();
   buffer.lumi = aux.id().luminosityBlock();
   buffer.event = aux.id().event();
+  buffer.streamId = sid;
 }
 
 // fill and send an EDM_MPI_Empty_t buffer
@@ -133,33 +137,33 @@ void MPIChannel::sendLuminosityBlockAuxiliary_(int tag, edm::LuminosityBlockAuxi
 }
 
 // fill and send an EDM_MPI_EventAuxiliary_t buffer
-void MPIChannel::sendEventAuxiliary_(edm::EventAuxiliary const& aux) {
+void MPIChannel::sendEventAuxiliary_(edm::EventAuxiliary const& aux, unsigned int sid) {
   EDM_MPI_EventAuxiliary_t buffer;
   buffer.messageTag = EDM_MPI_ProcessEvent;
-  edmToBuffer_(buffer, aux);
+  edmToBuffer_(buffer, aux, sid);
   MPI_Send(&buffer, 1, EDM_MPI_EventAuxiliary, dest_, EDM_MPI_ProcessEvent, comm_);
 }
 
 /*
 // receive an EDM_MPI_EventAuxiliary_t buffer and populate an edm::EventAuxiliary
-MPI_Status MPIChannel::receiveEventAuxiliary_(edm::EventAuxiliary& aux, int source, int tag) {
+MPI_Status MPIChannel::receiveEventAuxiliary_(edm::EventAuxiliary& aux, unsigned int& sid, int source, int tag) {
   MPI_Status status;
   EDM_MPI_EventAuxiliary_t buffer;
   MPI_Recv(&buffer, 1, EDM_MPI_EventAuxiliary, source, tag, comm_, &status);
-  edmFromBuffer_(buffer, aux);
+  edmFromBuffer_(buffer, aux, sid);
   return status;
 }
 */
 
 // receive an EDM_MPI_EventAuxiliary_t buffer and populate an edm::EventAuxiliary
-MPI_Status MPIChannel::receiveEventAuxiliary_(edm::EventAuxiliary& aux, MPI_Message& message) {
+MPI_Status MPIChannel::receiveEventAuxiliary_(edm::EventAuxiliary& aux, unsigned int& sid, MPI_Message& message) {
   MPI_Status status = {};
   EDM_MPI_EventAuxiliary_t buffer;
 #ifdef EDM_ML_DEBUG
   memset(&buffer, 0x00, sizeof(buffer));
 #endif
   status.MPI_ERROR = MPI_Mrecv(&buffer, 1, EDM_MPI_EventAuxiliary, &message, &status);
-  edmFromBuffer_(buffer, aux);
+  edmFromBuffer_(buffer, aux, sid);
   return status;
 }
 

--- a/HeterogeneousCore/MPICore/src/messages.cc
+++ b/HeterogeneousCore/MPICore/src/messages.cc
@@ -59,7 +59,8 @@ void EDM_MPI_build_types_() {
                    storeNumber,               // LHC fill number ?
                    run,                       // edm::RunNumber_t
                    lumi,                      // edm::LuminosityBlockNumber_t
-                   event);                    // edm::EventNumber_t
+                   event,                     // edm::EventNumber_t
+                   streamId);                 // edm::StreamID
 
   EDM_MPI_MessageType[EDM_MPI_Connect] = EDM_MPI_Empty;                                  //
   EDM_MPI_MessageType[EDM_MPI_Disconnect] = EDM_MPI_Empty;                               //

--- a/HeterogeneousCore/MPICore/test/BuildFile.xml
+++ b/HeterogeneousCore/MPICore/test/BuildFile.xml
@@ -3,16 +3,36 @@
     <flags TEST_RUNNER_CMD="mpirun -np 4 testMPI -s 1000 -r 12345 -n 10"/>
 </bin>
 
-<test name="testMPIEventId" command="testMPICommWorld.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/controller_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_cfg.py"/>
-
-<test name="testMPISoATransfer" command="testMPICommWorld.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/controller_soa_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_soa_cfg.py"/>
-
-<test name="testMPIComplexTransfer" command="testMPICommWorld.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/controller_complex_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_complex_cfg.py"/>
-
-<test name="testMPIFilters" command="testMPICommWorld.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/controller_filters_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_filters_cfg.py"/>
-
-<test name="testMPIAutosplitter" command="testAutomaticSplitter.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/scripts/edmMpiSplitConfig ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/configutration_for_automatic_splitter.py"/>
-
 <bin name="testSerialisation" file="testSerialisation.cc">
     <use name="root"/>
 </bin>
+
+<test
+  name="testMPIEventId"
+  command="testMPICommWorld.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/controller_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_cfg.py"
+/>
+
+<test
+  name="testMPIMultiEventId"
+  command="testMPICommWorld.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/controller_multi_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_multi1_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_multi2_cfg.py"
+/>
+
+<test
+  name="testMPISoATransfer"
+  command="testMPICommWorld.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/controller_soa_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_soa_cfg.py"
+/>
+
+<test
+  name="testMPIComplexTransfer"
+  command="testMPICommWorld.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/controller_complex_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_complex_cfg.py"
+/>
+
+<test
+  name="testMPIFilters"
+  command="testMPICommWorld.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/controller_filters_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_filters_cfg.py"
+/>
+
+<test
+  name="testMPIAutosplitter"
+  command="testAutomaticSplitter.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/scripts/edmMpiSplitConfig ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/configutration_for_automatic_splitter.py"
+/>

--- a/HeterogeneousCore/MPICore/test/BuildFile.xml
+++ b/HeterogeneousCore/MPICore/test/BuildFile.xml
@@ -18,6 +18,16 @@
 />
 
 <test
+  name="testMPIRoundRobinEventId"
+  command="testMPICommWorld.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/controller_rr_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_cfg.py"
+/>
+
+<test
+  name="testMPIRoundRobinMultiEventId"
+  command="testMPICommWorld.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/controller_multi_rr_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_multi1_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_multi1_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_multi2_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_multi2_cfg.py"
+/>
+
+<test
   name="testMPISoATransfer"
   command="testMPICommWorld.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/controller_soa_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_soa_cfg.py"
 />

--- a/HeterogeneousCore/MPICore/test/controller_multi_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_multi_cfg.py
@@ -1,0 +1,104 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("MPIController")
+
+process.options.numberOfThreads = 4
+process.options.numberOfStreams = 4
+# MPIController supports a single concurrent LuminosityBlock
+process.options.numberOfConcurrentLuminosityBlocks = 1
+process.options.numberOfConcurrentRuns = 1
+process.options.wantSummary = False
+
+process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+
+from eventlist_cff import eventlist
+process.source = cms.Source("EmptySourceFromEventIDs",
+    events = cms.untracked(eventlist)
+)
+
+process.maxEvents.input = 100
+
+from HeterogeneousCore.MPICore.modules import *
+
+process.ids = cms.EDProducer("edmtest::EventIDProducer")
+
+process.initialcheck = cms.EDAnalyzer("edmtest::EventIDValidator",
+    source = cms.untracked.InputTag('ids')
+)
+
+# Interface with the first remote process
+
+process.mpiController1 = MPIController(
+    mode = 'CommWorld',
+    remoteRank = 1
+)
+
+process.sender1 = MPISender(
+    upstream = "mpiController1",
+    instance = 11,
+    products = [ "edmEventID_ids__*" ]
+)
+
+process.othersender1 = MPISender(
+    upstream = "mpiController1",
+    instance = 12,
+    products = [ "edmEventID_ids__*" ]
+)
+
+process.receiver1 = MPIReceiver(
+    upstream = "othersender1",   # guarantees that this module will only run after "othersender1" has run
+    instance = 13,
+    products = [ dict(
+        type = "edm::EventID",
+        label = ""
+    )]
+)
+
+process.finalcheck1 = cms.EDAnalyzer("edmtest::EventIDValidator",
+    source = cms.untracked.InputTag('receiver1')
+)
+
+process.path1 = cms.Path(
+    process.mpiController1 +
+    process.ids +
+    process.initialcheck +
+    process.sender1 +
+    process.othersender1 +
+    process.receiver1 +
+    process.finalcheck1
+)
+
+# Interface with the second remote process
+
+process.mpiController2 = MPIController(
+    mode = 'CommWorld',
+    remoteRank = 2
+)
+
+process.sender2 = MPISender(
+    upstream = "mpiController2",
+    instance = 21,
+    products = [ "edmEventID_ids__*" ]
+)
+
+process.receiver2 = MPIReceiver(
+    upstream = "sender2",   # guarantees that this module will only run after "sender2" has run
+    instance = 22,
+    products = [ dict(
+        type = "edm::EventID",
+        label = ""
+    )]
+)
+
+process.finalcheck2 = cms.EDAnalyzer("edmtest::EventIDValidator",
+    source = cms.untracked.InputTag('receiver2')
+)
+
+process.path2 = cms.Path(
+    process.mpiController2 +
+    process.ids +
+    process.initialcheck +
+    process.sender2 +
+    process.receiver2 +
+    process.finalcheck2
+)

--- a/HeterogeneousCore/MPICore/test/controller_multi_rr_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_multi_rr_cfg.py
@@ -30,7 +30,7 @@ process.initialcheck = cms.EDAnalyzer("edmtest::EventIDValidator",
 
 process.mpiController1 = MPIController(
     mode = 'CommWorld',
-    followers = [ 1 ]
+    followers = [ 1, 2 ]
 )
 
 process.sender1 = MPISender(
@@ -72,7 +72,7 @@ process.path1 = cms.Path(
 
 process.mpiController2 = MPIController(
     mode = 'CommWorld',
-    followers = [ 2 ]
+    followers = [ 3, 4 ]
 )
 
 process.sender2 = MPISender(

--- a/HeterogeneousCore/MPICore/test/controller_rr_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_rr_cfg.py
@@ -1,0 +1,59 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("MPIController")
+
+process.options.numberOfThreads = 4
+process.options.numberOfStreams = 4
+# MPIController supports a single concurrent LuminosityBlock
+process.options.numberOfConcurrentLuminosityBlocks = 1
+process.options.numberOfConcurrentRuns = 1
+process.options.wantSummary = False
+
+process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+
+from eventlist_cff import eventlist
+process.source = cms.Source("EmptySourceFromEventIDs",
+    events = cms.untracked(eventlist)
+)
+
+process.maxEvents.input = 100
+
+from HeterogeneousCore.MPICore.modules import *
+
+process.mpiController = MPIController(
+    mode = 'CommWorld',
+    followers = [ 1, 2 ]
+)
+
+process.ids = cms.EDProducer("edmtest::EventIDProducer")
+
+process.initialcheck = cms.EDAnalyzer("edmtest::EventIDValidator",
+    source = cms.untracked.InputTag('ids')
+)
+
+process.sender = MPISender(
+    upstream = "mpiController",
+    instance = 42,
+    products = [ "edmEventID_ids__*" ]
+)
+
+process.othersender = MPISender(
+    upstream = "mpiController",
+    instance = 19,
+    products = [ "edmEventID_ids__*" ]
+)
+
+process.receiver = MPIReceiver(
+    upstream = "othersender",   # guarantees that this module will only run after "othersender" has run
+    instance = 99,
+    products = [ dict(
+        type = "edm::EventID",
+        label = ""
+    )]
+)
+
+process.finalcheck = cms.EDAnalyzer("edmtest::EventIDValidator",
+    source = cms.untracked.InputTag('receiver')
+)
+
+process.path = cms.Path(process.mpiController + process.ids + process.initialcheck + process.sender + process.othersender + process.receiver + process.finalcheck)

--- a/HeterogeneousCore/MPICore/test/follower_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_cfg.py
@@ -12,7 +12,10 @@ process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
 
 from HeterogeneousCore.MPICore.modules import *
 
-process.source = MPISource()
+process.source = MPISource(
+    mode = 'CommWorld',
+    controller = 0
+)
 
 process.maxEvents.input = -1
 

--- a/HeterogeneousCore/MPICore/test/follower_multi1_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_multi1_cfg.py
@@ -1,0 +1,54 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("MPIFollower")
+
+process.options.numberOfThreads = 8
+process.options.numberOfStreams = 8
+process.options.numberOfConcurrentLuminosityBlocks = 2
+process.options.numberOfConcurrentRuns = 2
+process.options.wantSummary = False
+
+process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+
+from HeterogeneousCore.MPICore.modules import *
+
+process.source = MPISource(
+    mode = 'CommWorld',
+    remoteRank = 0
+)
+
+process.maxEvents.input = -1
+
+# very verbose
+#from HeterogeneousCore.MPICore.mpiReporter_cfi import mpiReporter as mpiReporter_
+#process.reporter = mpiReporter_.clone()
+
+process.receiver = MPIReceiver(
+    upstream = "source",
+    instance = 11,
+    products = [ dict(
+        type = "edm::EventID",
+        label = ""
+    )]
+)
+
+process.otherreceiver = MPIReceiver(
+    upstream = "source",
+    instance = 12,
+    products = [ dict(
+        type = "edm::EventID",
+        label = ""
+    )]
+)
+
+process.sender = MPISender(
+    upstream = "otherreceiver", # guarantees that this module will only run after otherreceiver has run
+    instance = 13,
+    products = [ "edmEventID_otherreceiver__*" ]
+)
+
+process.analyzer = cms.EDAnalyzer("edmtest::EventIDValidator",
+    source = cms.untracked.InputTag("receiver")
+)
+
+process.path = cms.Path(process.receiver + process.analyzer + process.otherreceiver + process.sender)

--- a/HeterogeneousCore/MPICore/test/follower_multi1_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_multi1_cfg.py
@@ -14,7 +14,7 @@ from HeterogeneousCore.MPICore.modules import *
 
 process.source = MPISource(
     mode = 'CommWorld',
-    remoteRank = 0
+    controller = 0
 )
 
 process.maxEvents.input = -1

--- a/HeterogeneousCore/MPICore/test/follower_multi2_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_multi2_cfg.py
@@ -1,0 +1,45 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("MPIFollower")
+
+process.options.numberOfThreads = 8
+process.options.numberOfStreams = 8
+process.options.numberOfConcurrentLuminosityBlocks = 2
+process.options.numberOfConcurrentRuns = 2
+process.options.wantSummary = False
+
+process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+
+from HeterogeneousCore.MPICore.modules import *
+
+process.source = MPISource(
+    mode = 'CommWorld',
+    remoteRank = 0
+)
+
+process.maxEvents.input = -1
+
+# very verbose
+#from HeterogeneousCore.MPICore.mpiReporter_cfi import mpiReporter as mpiReporter_
+#process.reporter = mpiReporter_.clone()
+
+process.receiver = MPIReceiver(
+    upstream = "source",
+    instance = 21,
+    products = [ dict(
+        type = "edm::EventID",
+        label = ""
+    )]
+)
+
+process.sender = MPISender(
+    upstream = "receiver", # guarantees that this module will only run after receiver has run
+    instance = 22,
+    products = [ "edmEventID_receiver__*" ]
+)
+
+process.analyzer = cms.EDAnalyzer("edmtest::EventIDValidator",
+    source = cms.untracked.InputTag("receiver")
+)
+
+process.path = cms.Path(process.receiver + process.analyzer + process.sender)

--- a/HeterogeneousCore/MPICore/test/follower_multi2_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_multi2_cfg.py
@@ -14,7 +14,7 @@ from HeterogeneousCore.MPICore.modules import *
 
 process.source = MPISource(
     mode = 'CommWorld',
-    remoteRank = 0
+    controller = 0
 )
 
 process.maxEvents.input = -1

--- a/HeterogeneousCore/MPICore/test/testMPICommWorld.sh
+++ b/HeterogeneousCore/MPICore/test/testMPICommWorld.sh
@@ -1,17 +1,43 @@
 #! /bin/bash
 
 # Shell script for testing CMSSW over MPI.
-CONTROLLER=$(realpath $1)
-FOLLOWER=$(realpath $2)
+
+function usage() {
+  echo "usage:"
+  echo "  $(basename $0) config.py [config.py ...]"
+  echo
+}
 
 # Make sure the CMSSW environment has been loaded.
 if [ -z "$CMSSW_BASE" ]; then
   eval `scram runtime -sh`
 fi
 
+if [ $# == 0 ]; then
+  usage
+  echo "$(basename $0): error: please specify at least one argument."
+  exit 1
+fi
+
+# Check that the arguments exist, and convert them to absolute paths.
+CONFIGS=()
+for CFG in "$@"; do
+  if ! [ -f "$CFG" ]; then
+    echo "$(basename $0): error: invalid argument '$CFG'"
+    exit 1
+  fi
+  CONFIGS+=($(realpath "$CFG"))
+done
+
 # The CM pml leads to silent communication failures on some machines.
 # Until this is understood and fixed, keep it disabled.
 export OMPI_MCA_pml='^cm'
 
-# Launch the controller and follower processes
-mpirun -n 1 cmsRun ${CONTROLLER} : -n 1 cmsRun ${FOLLOWER}
+# Build the mpirun command line
+CMD="-n 1 cmsRun ${CONFIGS[0]}" 
+for CFG in "${CONFIGS[@]:1}"; do
+    CMD+=" : -n 1 cmsRun ${CFG}"
+done
+
+# Launch the cmsRun processes
+mpirun $CMD


### PR DESCRIPTION
#### PR description:

This remove some of the synchronisation points between local and remote processes, resulting in a 4% speed-up for an empty remote process:
  - reference: 105.5 ± 1.2 ev/s
  - with this: 109.7 ± 0.5 ev/s (**+4%**)

The speed-up is consistent when offloading part of the reconstruction to a separate job running _on the same cores_:
  - reference: 81.3 ± 0.5 ev/s
  - with this: 86.3 ± 0.2 ev/s (**+6%**)
 
Implement support for multiple "follower" remote processes:
  - send different parts of the event processing to separate remote processes
  - send events to different remote processes in round-robin fashion
  - both at the same time

and add unit tests for these features.

#### PR validation:

MPI unit tests pass.

#### Backport status:

Backport of #50461 to 16.0.x for online NGT tests.