### PR TITLE
Add cluster summary to Run3 UPC MiniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -168,6 +168,7 @@ _upc_extraCommands = [
     'keep recoClusterCompatibility_hiClusterCompatibility_*_*',
     'keep QIE10DataFrameHcalDataFrameContainer_hcalDigis_ZDC_*',
     'keep *_dedxEstimator_*_*',
+    'keep ClusterSummary_clusterSummaryProducer_*_*',
 ]
 
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc


### PR DESCRIPTION
#### PR description:

This PR adds the per event cluster summary information into the Run3 UPC miniAOD.

@mandrenguyen

#### PR validation:

Tested with 180.0,181.0,182.0,183.0

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: