### PR TITLE
Detect AMD GPUs in the ResourceInformation service

### DIFF
--- a/FWCore/AbstractServices/interface/ResourceInformation.h
+++ b/FWCore/AbstractServices/interface/ResourceInformation.h
@@ -31,6 +31,7 @@ namespace edm {
     virtual std::vector<std::string> const& gpuModels() const = 0;
 
     virtual bool hasGpuNvidia() const = 0;
+    virtual bool hasGpuAMD() const = 0;
 
     virtual std::string const& nvidiaDriverVersion() const = 0;
     virtual int cudaDriverVersion() const = 0;
@@ -45,8 +46,11 @@ namespace edm {
     virtual void setGPUModels(std::vector<std::string> const&) = 0;
 
     virtual void setNvidiaDriverVersion(std::string const&) = 0;
+    virtual void setAMDDriverVersion(std::string const&) = 0;
     virtual void setCudaDriverVersion(int) = 0;
     virtual void setCudaRuntimeVersion(int) = 0;
+    virtual void setRocmDriverVersion(int) = 0;
+    virtual void setRocmRuntimeVersion(int) = 0;
 
     virtual void setCpuModelsFormatted(std::string const&) = 0;
     virtual void setCpuAverageSpeed(double) = 0;

--- a/FWCore/Services/plugins/ResourceInformationService.cc
+++ b/FWCore/Services/plugins/ResourceInformationService.cc
@@ -38,6 +38,7 @@ namespace edm {
       std::vector<std::string> const& gpuModels() const final;
 
       bool hasGpuNvidia() const final;
+      bool hasGpuAMD() const final;
 
       std::string const& nvidiaDriverVersion() const final;
       int cudaDriverVersion() const final;
@@ -52,8 +53,11 @@ namespace edm {
       void setGPUModels(std::vector<std::string> const&) final;
 
       void setNvidiaDriverVersion(std::string const&) final;
+      void setAMDDriverVersion(std::string const&) final;
       void setCudaDriverVersion(int) final;
       void setCudaRuntimeVersion(int) final;
+      void setRocmDriverVersion(int) final;
+      void setRocmRuntimeVersion(int) final;
 
       void setCpuModelsFormatted(std::string const&) final;
       void setCpuAverageSpeed(double) final;
@@ -68,13 +72,19 @@ namespace edm {
       std::vector<std::string> gpuModels_;
 
       std::string nvidiaDriverVersion_;
+      std::string amdDriverVersion_;
+
       int cudaDriverVersion_ = 0;
       int cudaRuntimeVersion_ = 0;
+
+      int rocmDriverVersion_ = 0;
+      int rocmRuntimeVersion_ = 0;
 
       std::string cpuModelsFormatted_;
       double cpuAverageSpeed_ = 0;
 
       bool hasGpuNvidia_ = false;
+      bool hasGpuAMD_ = false;
       bool locked_ = false;
       bool verbose_;
     };
@@ -114,6 +124,7 @@ namespace edm {
     std::vector<std::string> const& ResourceInformationService::gpuModels() const { return gpuModels_; }
 
     bool ResourceInformationService::hasGpuNvidia() const { return hasGpuNvidia_; }
+    bool ResourceInformationService::hasGpuAMD() const { return hasGpuAMD_; }
 
     std::string const& ResourceInformationService::nvidiaDriverVersion() const { return nvidiaDriverVersion_; }
 
@@ -148,6 +159,12 @@ namespace edm {
       hasGpuNvidia_ = true;
     }
 
+    void ResourceInformationService::setAMDDriverVersion(std::string const& val) {
+      throwIfLocked();
+      amdDriverVersion_ = val;
+      hasGpuAMD_ = true;
+    }
+
     void ResourceInformationService::setCudaDriverVersion(int val) {
       throwIfLocked();
       cudaDriverVersion_ = val;
@@ -168,6 +185,18 @@ namespace edm {
     void ResourceInformationService::setCpuAverageSpeed(double val) {
       throwIfLocked();
       cpuAverageSpeed_ = val;
+    }
+
+    void ResourceInformationService::setRocmDriverVersion(int val) {
+      throwIfLocked();
+      rocmDriverVersion_ = val;
+      hasGpuAMD_ = true;
+    }
+
+    void ResourceInformationService::setRocmRuntimeVersion(int val) {
+      throwIfLocked();
+      rocmRuntimeVersion_ = val;
+      hasGpuAMD_ = true;
     }
 
     void ResourceInformationService::throwIfLocked() const {

--- a/HeterogeneousCore/ROCmServices/plugins/ROCmService.cc
+++ b/HeterogeneousCore/ROCmServices/plugins/ROCmService.cc
@@ -286,12 +286,9 @@ ROCmService::ROCmService(edm::ParameterSet const& config) : verbose_(config.getU
   if (resourceInformationService.isAvailable()) {
     std::vector<std::string> modelsV(models.begin(), models.end());
     resourceInformationService->setGPUModels(modelsV);
-    /*
-    std::string nvidiaDriverVersion{systemDriverVersion};
-    resourceInformationService->setNvidiaDriverVersion(nvidiaDriverVersion);
-    resourceInformationService->setCudaDriverVersion(driverVersion);
-    resourceInformationService->setCudaRuntimeVersion(runtimeVersion);
-    */
+    resourceInformationService->setRocmDriverVersion(driverVersion);
+    resourceInformationService->setRocmRuntimeVersion(runtimeVersion);
+    resourceInformationService->setAMDDriverVersion(systemDriverVersion);
   }
 
   if (verbose_) {


### PR DESCRIPTION
This PR extends the GPU resource detection in the framework by adding support for AMD GPUs. It introduces a hasGpuAMD() query to the resource information service, following the same pattern used for NVIDIA GPU detection. This allows modules to determine whether AMD GPU resources are available at runtime.
This work originated while investigating the possibility of running the MLPF model on GPUs. During that check, we found that the framework already provides a mechanism to detect NVIDIA GPU availability through the resource information service, but there was no equivalent way to detect AMD GPU resources. This PR adds that capability so that modules can query AMD GPU availability in a consistent way.
Looking ahead, this may also be useful if support for running ONNX models on AMD GPUs becomes available in the future.

Tagging @fwyzard 