### PR TITLE
Use std::launder in SoATuple

### DIFF
--- a/FWCore/Utilities/interface/SoATuple.h
+++ b/FWCore/Utilities/interface/SoATuple.h
@@ -162,7 +162,7 @@ namespace edm {
         unsigned int iIndex) const {
       typedef typename soahelper::AlignmentHelper<typename std::tuple_element<I, std::tuple<Args...>>::type>::Type
           ReturnType;
-      return *(static_cast<ReturnType const*>(m_values[I]) + iIndex);
+      return *(std::launder(static_cast<ReturnType const*>(m_values[I])) + iIndex);
     }
 
     /** Returns the beginning of the container holding all Ith data elements*/
@@ -171,7 +171,7 @@ namespace edm {
         const {
       typedef soahelper::AlignmentHelper<typename std::tuple_element<I, std::tuple<Args...>>::type> Helper;
       typedef typename Helper::Type ReturnType;
-      return std::assume_aligned<Helper::kAlignment>(static_cast<ReturnType const*>(m_values[I]));
+      return std::assume_aligned<Helper::kAlignment>(std::launder(static_cast<ReturnType const*>(m_values[I])));
     }
     /** Returns the end of the container holding all Ith data elements*/
     template <unsigned int I>
@@ -179,7 +179,7 @@ namespace edm {
         const {
       typedef typename soahelper::AlignmentHelper<typename std::tuple_element<I, std::tuple<Args...>>::type>::Type
           ReturnType;
-      return static_cast<ReturnType const*>(m_values[I]) + m_size;
+      return std::launder(static_cast<ReturnType const*>(m_values[I])) + m_size;
     }
 
     // ---------- member functions ---------------------------
@@ -222,7 +222,7 @@ namespace edm {
         unsigned int iIndex) {
       typedef typename soahelper::AlignmentHelper<typename std::tuple_element<I, std::tuple<Args...>>::type>::Type
           ReturnType;
-      return *(static_cast<ReturnType*>(m_values[I]) + iIndex);
+      return *(std::launder(static_cast<ReturnType*>(m_values[I]) + iIndex));
     }
 
     /** Returns the beginning of the container holding all Ith data elements*/
@@ -230,18 +230,14 @@ namespace edm {
     typename soahelper::AlignmentHelper<typename std::tuple_element<I, std::tuple<Args...>>::type>::Type* begin() {
       typedef soahelper::AlignmentHelper<typename std::tuple_element<I, std::tuple<Args...>>::type> Helper;
       typedef typename Helper::Type ReturnType;
-#if GCC_PREREQUISITE(4, 7, 0)
-      return static_cast<ReturnType*>(__builtin_assume_aligned(m_values[I], Helper::kAlignment));
-#else
-      return static_cast<ReturnType*>(m_values[I]);
-#endif
+      return std::assume_aligned<Helper::kAlignment>(std::launder(static_cast<ReturnType*>(m_values[I])));
     }
     /** Returns the end of the container holding all Ith data elements*/
     template <unsigned int I>
     typename soahelper::AlignmentHelper<typename std::tuple_element<I, std::tuple<Args...>>::type>::Type* end() {
       typedef typename soahelper::AlignmentHelper<typename std::tuple_element<I, std::tuple<Args...>>::type>::Type
           ReturnType;
-      return static_cast<ReturnType*>(m_values[I]) + m_size;
+      return std::launder(static_cast<ReturnType*>(m_values[I])) + m_size;
     }
 
     void swap(SoATuple<Args...>& iOther) {

--- a/FWCore/Utilities/interface/SoATupleHelper.h
+++ b/FWCore/Utilities/interface/SoATupleHelper.h
@@ -119,9 +119,10 @@ namespace edm {
       auto do_move = [&]<typename T>(T const*, auto I) {
         using Type = typename AlignmentHelper<T>::Type;
         constexpr unsigned int boundary = AlignmentHelper<T>::kAlignment;
-        Type* newStart = reinterpret_cast<Type*>(iNewMemory + usedSoFar + padding_needed(usedSoFar, boundary));
+        Type* newStart =
+            std::launder(reinterpret_cast<Type*>(iNewMemory + usedSoFar + padding_needed(usedSoFar, boundary)));
         void** oldStart = oToSet + I;
-        Type* oldValues = static_cast<Type*>(*oldStart);
+        Type* oldValues = std::launder(static_cast<Type*>(*oldStart));
         if (oldValues != nullptr) {
           auto ptr = newStart;
           for (auto it = oldValues; it != oldValues + iSize; ++it, ++ptr) {
@@ -150,9 +151,10 @@ namespace edm {
       auto do_copy = [&]<typename T>(T const*, auto I) {
         using Type = typename AlignmentHelper<T>::Type;
         constexpr unsigned int boundary = AlignmentHelper<T>::kAlignment;
-        Type* newStart = reinterpret_cast<Type*>(iNewMemory + usedSoFar + padding_needed(usedSoFar, boundary));
+        Type* newStart =
+            std::launder(reinterpret_cast<Type*>(iNewMemory + usedSoFar + padding_needed(usedSoFar, boundary)));
         void* const* oldStart = iFrom + I;
-        Type* oldValues = static_cast<Type*>(*oldStart);
+        Type* oldValues = std::launder(static_cast<Type*>(*oldStart));
         if (oldValues != nullptr) {
           auto ptr = newStart;
           for (auto it = oldValues; it != oldValues + iSize; ++it, ++ptr) {
@@ -192,7 +194,7 @@ namespace edm {
     void SoATupleHelper<Args...>::push_back(void** iToSet, size_t iSize, std::tuple<Args...> const& iValues) {
       auto do_placement = [&]<typename T>(auto Index, T const*) {
         using Type = typename AlignmentHelper<T>::Type;
-        new (static_cast<Type*>(*(iToSet + Index)) + iSize) Type(std::get<Index>(iValues));
+        new (std::launder(static_cast<Type*>(*(iToSet + Index))) + iSize) Type(std::get<Index>(iValues));
       };
       //The use of index_sequence gives an index for each type in Args...
       [&]<std::size_t... Is>(std::index_sequence<Is...>) {
@@ -206,7 +208,7 @@ namespace edm {
     void SoATupleHelper<Args...>::emplace_back(void** iToSet, size_t iSize, FArgs... iValues) {
       auto do_placement = [&]<typename T>(auto Index, T const*) {
         using Type = typename AlignmentHelper<T>::Type;
-        new (static_cast<Type*>(*(iToSet + Index)) + iSize)
+        new (std::launder(static_cast<Type*>(*(iToSet + Index))) + iSize)
             Type(arg_puller<0, Index, Type const&, FArgs...>::pull(std::forward<FArgs>(iValues)...));
       };
       //The use of index_sequence gives an index for each type in Args...
@@ -221,7 +223,7 @@ namespace edm {
       auto do_destroy = [&]<typename T>(std::size_t I, T const*) {
         void** start = iToSet + I;
         using Type = typename AlignmentHelper<T>::Type;
-        Type* values = static_cast<Type*>(*start);
+        Type* values = std::launder(static_cast<Type*>(*start));
 
         for (auto it = values; it != values + iSize; ++it) {
           it->~Type();


### PR DESCRIPTION
#### PR description:

Since C++17 one is required to call `std::launder` in the case where the allocation of space was done using a type that is not the one then used for placement new.

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/2038