### PR TITLE
[EVOLUTION_X] Fix destructor definition for pat::Packed{,Gen}Particle

### DIFF
--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -148,7 +148,7 @@ void pat::PackedCandidate::unpackVtx() const {
   }
 }
 
-pat::PackedCandidate::~PackedCandidate() {
+pat::io_v1::PackedCandidate::~PackedCandidate() {
   delete p4_.load();
   delete p4c_.load();
   delete vertex_.load();

--- a/DataFormats/PatCandidates/src/PackedGenParticle.cc
+++ b/DataFormats/PatCandidates/src/PackedGenParticle.cc
@@ -39,7 +39,7 @@ void pat::PackedGenParticle::unpack() const {
   }
 }
 
-pat::PackedGenParticle::~PackedGenParticle() {
+pat::io_v1::PackedGenParticle::~PackedGenParticle() {
   delete p4_.load();
   delete p4c_.load();
 }


### PR DESCRIPTION
#### PR description:

Static analyzer log in https://github.com/cms-sw/cmssw/pull/50370#issuecomment-4063068350 had
```
src/DataFormats/PatCandidates/src/PackedGenParticle.cc:42:25: error: destructor cannot be declared using a type alias 'PackedGenParticle' (aka 'pat::io_v1::PackedGenParticle') of the class name [-Wdtor-typedef]
   42 | pat::PackedGenParticle::~PackedGenParticle() {
      |                         ^
1 error generated.
```

Resolves https://github.com/cms-sw/framework-team/issues/2040

This PR should fix that.

#### PR validation:

None
