### PR TITLE
[EVOLUTION_X] Move stored products in `SimDataFormats/{Associations,Calo*,Track*,Vertex}` to `io_v1` namespace

### DIFF
--- a/AnalysisDataFormats/TrackInfo/src/classes_def.xml
+++ b/AnalysisDataFormats/TrackInfo/src/classes_def.xml
@@ -24,7 +24,7 @@
   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<std::vector<reco::Track>,std::vector<reco::TrackInfo>,unsigned int> > >" />
 
   <class name="TPtoRecoTrack" ClassVersion="3">
-   <version ClassVersion="3" checksum="2952712808"/>
+   <version ClassVersion="3" checksum="1673086488"/>
   </class>
   <class name="edm::Wrapper<TPtoRecoTrack>"/>
   
@@ -32,7 +32,7 @@
   <class name="edm::Wrapper<std::vector<TPtoRecoTrack> >"/>
 
   <class name="RecoTracktoTP" ClassVersion="3">
-   <version ClassVersion="3" checksum="2837854068"/>
+   <version ClassVersion="3" checksum="3098877748"/>
   </class>
   <class name="edm::Wrapper<RecoTracktoTP>"/>
   

--- a/FastSimDataFormats/NuclearInteractions/src/classes_def.xml
+++ b/FastSimDataFormats/NuclearInteractions/src/classes_def.xml
@@ -20,9 +20,8 @@
   <class name="edm::Wrapper< std::vector<FSimVertexType> >"/>  
   <class name="edm::Ref< std::vector<FSimVertexType>, FSimVertexType, edm::refhelper::FindUsingAdvance< std::vector<FSimVertexType>, FSimVertexType> >"/>
 
-  <class name="FSimDisplacedVertex" ClassVersion="11">
-   <version ClassVersion="11" checksum="2164432722"/>
-   <version ClassVersion="10" checksum="251560649"/>
+  <class name="FSimDisplacedVertex" ClassVersion="3">
+   <version ClassVersion="3" checksum="4095934988"/>
   </class>
   <class name="std::vector<FSimDisplacedVertex>"/>
   <class name="edm::Wrapper< std::vector<FSimDisplacedVertex> >"/>  

--- a/SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociationMap.h
+++ b/SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociationMap.h
@@ -10,48 +10,51 @@
 #include <utility>
 #include <algorithm>
 
-/**
+namespace io_v1 {
+  /**
  * Maps FTLCluserRef to SimLayerClusterRef
  *
  */
-class MtdRecoClusterToSimLayerClusterAssociationMap {
-public:
-  using key_type = FTLClusterRef;
-  using mapped_type = MtdSimLayerClusterRef;
-  using value_type = std::pair<key_type, std::vector<mapped_type>>;
-  using map_type = std::vector<value_type>;
-  using const_iterator = typename map_type::const_iterator;
-  using range = std::pair<const_iterator, const_iterator>;
+  class MtdRecoClusterToSimLayerClusterAssociationMap {
+  public:
+    using key_type = FTLClusterRef;
+    using mapped_type = MtdSimLayerClusterRef;
+    using value_type = std::pair<key_type, std::vector<mapped_type>>;
+    using map_type = std::vector<value_type>;
+    using const_iterator = typename map_type::const_iterator;
+    using range = std::pair<const_iterator, const_iterator>;
 
-  /// Constructor
-  MtdRecoClusterToSimLayerClusterAssociationMap();
-  /// Destructor
-  ~MtdRecoClusterToSimLayerClusterAssociationMap();
+    /// Constructor
+    MtdRecoClusterToSimLayerClusterAssociationMap();
+    /// Destructor
+    ~MtdRecoClusterToSimLayerClusterAssociationMap();
 
-  void emplace_back(const FTLClusterRef& recoClus, std::vector<MtdSimLayerClusterRef>& simClusVect) {
-    map_.emplace_back(recoClus, simClusVect);
-  }
+    void emplace_back(const FTLClusterRef& recoClus, std::vector<MtdSimLayerClusterRef>& simClusVect) {
+      map_.emplace_back(recoClus, simClusVect);
+    }
 
-  void post_insert() { std::sort(map_.begin(), map_.end(), compare); }
+    void post_insert() { std::sort(map_.begin(), map_.end(), compare); }
 
-  bool empty() const { return map_.empty(); }
-  size_t size() const { return map_.size(); }
+    bool empty() const { return map_.empty(); }
+    size_t size() const { return map_.size(); }
 
-  const_iterator begin() const { return map_.begin(); }
-  const_iterator cbegin() const { return map_.cbegin(); }
-  const_iterator end() const { return map_.end(); }
-  const_iterator cend() const { return map_.cend(); }
+    const_iterator begin() const { return map_.begin(); }
+    const_iterator cbegin() const { return map_.cbegin(); }
+    const_iterator end() const { return map_.end(); }
+    const_iterator cend() const { return map_.cend(); }
 
-  range equal_range(const FTLClusterRef& key) const {
-    return std::equal_range(map_.begin(), map_.end(), value_type(key, std::vector<MtdSimLayerClusterRef>()), compare);
-  }
+    range equal_range(const FTLClusterRef& key) const {
+      return std::equal_range(map_.begin(), map_.end(), value_type(key, std::vector<MtdSimLayerClusterRef>()), compare);
+    }
 
-  const map_type& map() const { return map_; }
+    const map_type& map() const { return map_; }
 
-private:
-  static bool compare(const value_type& i, const value_type& j) { return (i.first < j.first); }
+  private:
+    static bool compare(const value_type& i, const value_type& j) { return (i.first < j.first); }
 
-  map_type map_;
-};
+    map_type map_;
+  };
+}  // namespace io_v1
+using MtdRecoClusterToSimLayerClusterAssociationMap = io_v1::MtdRecoClusterToSimLayerClusterAssociationMap;
 
 #endif

--- a/SimDataFormats/Associations/interface/MtdSimLayerClusterToRecoClusterAssociationMap.h
+++ b/SimDataFormats/Associations/interface/MtdSimLayerClusterToRecoClusterAssociationMap.h
@@ -10,61 +10,64 @@
 #include <utility>
 #include <algorithm>
 
-/**
+namespace io_v1 {
+  /**
  * Maps MtdSimLayerCluserRef to FTLClusterRef
  *
  */
-class MtdSimLayerClusterToRecoClusterAssociationMap {
-public:
-  using key_type = MtdSimLayerClusterRef;
-  using mapped_type = FTLClusterRef;
-  using value_type = std::pair<key_type, std::vector<mapped_type>>;
-  using map_type = std::vector<value_type>;
-  using const_iterator = typename map_type::const_iterator;
-  using range = std::pair<const_iterator, const_iterator>;
+  class MtdSimLayerClusterToRecoClusterAssociationMap {
+  public:
+    using key_type = MtdSimLayerClusterRef;
+    using mapped_type = FTLClusterRef;
+    using value_type = std::pair<key_type, std::vector<mapped_type>>;
+    using map_type = std::vector<value_type>;
+    using const_iterator = typename map_type::const_iterator;
+    using range = std::pair<const_iterator, const_iterator>;
 
-  /// Constructor
-  MtdSimLayerClusterToRecoClusterAssociationMap();
-  /// Destructor
-  ~MtdSimLayerClusterToRecoClusterAssociationMap();
+    /// Constructor
+    MtdSimLayerClusterToRecoClusterAssociationMap();
+    /// Destructor
+    ~MtdSimLayerClusterToRecoClusterAssociationMap();
 
-  void emplace_back(const MtdSimLayerClusterRef& simClus, std::vector<FTLClusterRef>& recoClusVect) {
-    map_.emplace_back(simClus, recoClusVect);
-  }
+    void emplace_back(const MtdSimLayerClusterRef& simClus, std::vector<FTLClusterRef>& recoClusVect) {
+      map_.emplace_back(simClus, recoClusVect);
+    }
 
-  void post_insert() { std::sort(map_.begin(), map_.end(), compare); }
+    void post_insert() { std::sort(map_.begin(), map_.end(), compare); }
 
-  bool empty() const { return map_.empty(); }
-  size_t size() const { return map_.size(); }
+    bool empty() const { return map_.empty(); }
+    size_t size() const { return map_.size(); }
 
-  const_iterator begin() const { return map_.begin(); }
-  const_iterator cbegin() const { return map_.cbegin(); }
-  const_iterator end() const { return map_.end(); }
-  const_iterator cend() const { return map_.cend(); }
+    const_iterator begin() const { return map_.begin(); }
+    const_iterator cbegin() const { return map_.cbegin(); }
+    const_iterator end() const { return map_.end(); }
+    const_iterator cend() const { return map_.cend(); }
 
-  range equal_range(const MtdSimLayerClusterRef& key) const {
-    return std::equal_range(map_.begin(), map_.end(), value_type(key, std::vector<FTLClusterRef>()), compare);
-  }
+    range equal_range(const MtdSimLayerClusterRef& key) const {
+      return std::equal_range(map_.begin(), map_.end(), value_type(key, std::vector<FTLClusterRef>()), compare);
+    }
 
-  const map_type& map() const { return map_; }
+    const map_type& map() const { return map_; }
 
-private:
-  static bool compare(const value_type& i, const value_type& j) {
-    const auto& i_hAndE = (i.first)->hits_and_energies();
-    const auto& j_hAndE = (j.first)->hits_and_energies();
+  private:
+    static bool compare(const value_type& i, const value_type& j) {
+      const auto& i_hAndE = (i.first)->hits_and_energies();
+      const auto& j_hAndE = (j.first)->hits_and_energies();
 
-    auto imin = std::min_element(i_hAndE.begin(),
-                                 i_hAndE.end(),
-                                 [](std::pair<uint64_t, float> a, std::pair<uint64_t, float> b) { return a < b; });
+      auto imin = std::min_element(i_hAndE.begin(),
+                                   i_hAndE.end(),
+                                   [](std::pair<uint64_t, float> a, std::pair<uint64_t, float> b) { return a < b; });
 
-    auto jmin = std::min_element(j_hAndE.begin(),
-                                 j_hAndE.end(),
-                                 [](std::pair<uint64_t, float> a, std::pair<uint64_t, float> b) { return a < b; });
+      auto jmin = std::min_element(j_hAndE.begin(),
+                                   j_hAndE.end(),
+                                   [](std::pair<uint64_t, float> a, std::pair<uint64_t, float> b) { return a < b; });
 
-    return (*imin < *jmin);
-  }
+      return (*imin < *jmin);
+    }
 
-  map_type map_;
-};
+    map_type map_;
+  };
+}  // namespace io_v1
+using MtdSimLayerClusterToRecoClusterAssociationMap = io_v1::MtdSimLayerClusterToRecoClusterAssociationMap;
 
 #endif

--- a/SimDataFormats/Associations/src/MtdRecoClusterToSimLayerClusterAssociationMap.cc
+++ b/SimDataFormats/Associations/src/MtdRecoClusterToSimLayerClusterAssociationMap.cc
@@ -1,5 +1,7 @@
 #include "SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociationMap.h"
 
-MtdRecoClusterToSimLayerClusterAssociationMap::MtdRecoClusterToSimLayerClusterAssociationMap() {}
+namespace io_v1 {
+  MtdRecoClusterToSimLayerClusterAssociationMap::MtdRecoClusterToSimLayerClusterAssociationMap() {}
 
-MtdRecoClusterToSimLayerClusterAssociationMap::~MtdRecoClusterToSimLayerClusterAssociationMap() {}
+  MtdRecoClusterToSimLayerClusterAssociationMap::~MtdRecoClusterToSimLayerClusterAssociationMap() {}
+}  // namespace io_v1

--- a/SimDataFormats/Associations/src/MtdSimLayerClusterToRecoClusterAssociationMap.cc
+++ b/SimDataFormats/Associations/src/MtdSimLayerClusterToRecoClusterAssociationMap.cc
@@ -1,5 +1,7 @@
 #include "SimDataFormats/Associations/interface/MtdSimLayerClusterToRecoClusterAssociationMap.h"
 
-MtdSimLayerClusterToRecoClusterAssociationMap::MtdSimLayerClusterToRecoClusterAssociationMap() {}
+namespace io_v1 {
+  MtdSimLayerClusterToRecoClusterAssociationMap::MtdSimLayerClusterToRecoClusterAssociationMap() {}
 
-MtdSimLayerClusterToRecoClusterAssociationMap::~MtdSimLayerClusterToRecoClusterAssociationMap() {}
+  MtdSimLayerClusterToRecoClusterAssociationMap::~MtdSimLayerClusterToRecoClusterAssociationMap() {}
+}  // namespace io_v1

--- a/SimDataFormats/Associations/src/classes_def.xml
+++ b/SimDataFormats/Associations/src/classes_def.xml
@@ -71,8 +71,8 @@
   <class name="ticl::AssociationMap<ticl::mapWithFractionAndScore, void, void >"/>
   <class name="edm::Wrapper<ticl::AssociationMap<ticl::mapWithFractionAndScore, void, void > >"/>
   <!-- For one-to-one map with FractionType -->
-  <class name="ticl::AssociationMap<ticl::oneToOneMapWithFraction, std::vector<SimCluster>, std::vector<CaloParticle> >"/>
-  <class name="edm::Wrapper<ticl::AssociationMap<ticl::oneToOneMapWithFraction, std::vector<SimCluster>, std::vector<CaloParticle> > >"/>
+  <class name="ticl::AssociationMap<ticl::oneToOneMapWithFraction, std::vector<io_v1::SimCluster>, std::vector<io_v1::CaloParticle> >"/>
+  <class name="edm::Wrapper<ticl::AssociationMap<ticl::oneToOneMapWithFraction, std::vector<io_v1::SimCluster>, std::vector<io_v1::CaloParticle> > >"/>
   <class name="ticl::AssociationMap<ticl::oneToOneMapWithFraction, void, void >"/>
   <class name="edm::Wrapper<ticl::AssociationMap<ticl::oneToOneMapWithFraction, void, void > >"/>
 
@@ -89,8 +89,8 @@
   <class name="edm::Wrapper<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore, void, void > >"/>
 
   <!-- For one-to-one map with SharedEnergyType -->
-  <class name="ticl::AssociationMap<ticl::oneToOneMapWithSharedEnergy, std::vector<SimCluster>, std::vector<CaloParticle> >"/>
-  <class name="edm::Wrapper<ticl::AssociationMap<ticl::oneToOneMapWithSharedEnergy, std::vector<SimCluster>, std::vector<CaloParticle> > >"/>
+  <class name="ticl::AssociationMap<ticl::oneToOneMapWithSharedEnergy, std::vector<io_v1::SimCluster>, std::vector<io_v1::CaloParticle> >"/>
+  <class name="edm::Wrapper<ticl::AssociationMap<ticl::oneToOneMapWithSharedEnergy, std::vector<io_v1::SimCluster>, std::vector<io_v1::CaloParticle> > >"/>
   <class name="ticl::AssociationMap<ticl::oneToOneMapWithSharedEnergy, void, void >"/>
   <class name="edm::Wrapper<ticl::AssociationMap<ticl::oneToOneMapWithSharedEnergy, void, void > >"/>
 
@@ -119,8 +119,8 @@
   <class name="edm::Wrapper<ticl::RecoToSimCollectionT<reco::CaloClusterCollection>>" />
   <class name="edm::Wrapper<ticl::RecoToSimCollectionT<reco::PFClusterCollection>>" />
 
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<CaloParticle> >,edm::RefProd<vector<reco::io_v1::CaloCluster> > >" />
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::io_v1::CaloCluster> >,edm::RefProd<vector<CaloParticle> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<io_v1::CaloParticle> >,edm::RefProd<vector<reco::io_v1::CaloCluster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::io_v1::CaloCluster> >,edm::RefProd<vector<io_v1::CaloParticle> > >" />
   <class name="map<unsigned int,vector<pair<unsigned int,pair<float,float> > > >" />
   <class name="vector<pair<unsigned int,pair<float,float> > >" />
 
@@ -142,8 +142,8 @@
   <class name="edm::Wrapper<ticl::RecoToSimCollectionWithSimClustersT<reco::CaloClusterCollection>>" />
   <class name="edm::Wrapper<ticl::RecoToSimCollectionWithSimClustersT<reco::PFClusterCollection>>" />
 
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<SimCluster> >, edm::RefProd<vector<ticl::Trackster> > >" />
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<ticl::Trackster> >, edm::RefProd<vector<SimCluster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<io_v1::SimCluster> >, edm::RefProd<vector<ticl::Trackster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<ticl::Trackster> >, edm::RefProd<vector<io_v1::SimCluster> > >" />
 
 
   <class name="ticl::SimToRecoCollectionTracksters" >
@@ -155,8 +155,8 @@
   </class>
   <class name="edm::Wrapper<ticl::RecoToSimCollectionTracksters>" />
 
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<SimCluster> >,edm::RefProd<vector<reco::io_v1::CaloCluster> > >" />
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::io_v1::CaloCluster> >,edm::RefProd<vector<SimCluster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<io_v1::SimCluster> >,edm::RefProd<vector<reco::io_v1::CaloCluster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::io_v1::CaloCluster> >,edm::RefProd<vector<io_v1::SimCluster> > >" />
 
   <class name="edm::Wrapper<reco::SimToRecoCollection>" />
   <class name="edm::Wrapper<reco::RecoToSimCollection>" />
@@ -168,45 +168,45 @@
    <field name="transientMap_" transient="true"/>
   </class>
 
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<SimCluster> >,edm::RefProd<vector<reco::io_v1::PFCluster> > >" />
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::io_v1::PFCluster> >,edm::RefProd<vector<SimCluster> > >" />
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<CaloParticle> >,edm::RefProd<vector<reco::io_v1::PFCluster> > >" />
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::io_v1::PFCluster> >,edm::RefProd<vector<CaloParticle> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<io_v1::SimCluster> >,edm::RefProd<vector<reco::io_v1::PFCluster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::io_v1::PFCluster> >,edm::RefProd<vector<io_v1::SimCluster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<io_v1::CaloParticle> >,edm::RefProd<vector<reco::io_v1::PFCluster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::io_v1::PFCluster> >,edm::RefProd<vector<io_v1::CaloParticle> > >" />
 
   <class name="edm::AssociationMap<edm::OneToManyWithQualityGeneric<
-               std::vector<SimCluster>, std::vector<reco::io_v1::PFCluster>, std::pair<float,float>, unsigned int,
-               edm ::RefProd<std::vector<SimCluster>>, edm::RefProd<std::vector<reco::io_v1::PFCluster>>,
-               edm::Ref<std::vector<SimCluster>>, edm::Ref<std::vector<reco::io_v1::PFCluster>>
+               std::vector<io_v1::SimCluster>, std::vector<reco::io_v1::PFCluster>, std::pair<float,float>, unsigned int,
+               edm ::RefProd<std::vector<io_v1::SimCluster>>, edm::RefProd<std::vector<reco::io_v1::PFCluster>>,
+               edm::Ref<std::vector<io_v1::SimCluster>>, edm::Ref<std::vector<reco::io_v1::PFCluster>>
 			   >>">
 		 <field name="transientMap_" transient="true"/>
   </class>
   
   <class name="edm::AssociationMap<edm::OneToManyWithQualityGeneric<
-               std::vector<reco::io_v1::PFCluster>, std::vector<SimCluster>, float, unsigned int,
-               edm::RefProd<std::vector<reco::io_v1::PFCluster>>, edm::RefProd<std::vector<SimCluster>>,
-               edm::Ref<std::vector<reco::io_v1::PFCluster>>, edm::Ref<std::vector<SimCluster>>
+               std::vector<reco::io_v1::PFCluster>, std::vector<io_v1::SimCluster>, float, unsigned int,
+               edm::RefProd<std::vector<reco::io_v1::PFCluster>>, edm::RefProd<std::vector<io_v1::SimCluster>>,
+               edm::Ref<std::vector<reco::io_v1::PFCluster>>, edm::Ref<std::vector<io_v1::SimCluster>>
 			   >>" >
 		 <field name="transientMap_" transient="true"/>
   </class>
   
   <class name="edm::AssociationMap<edm::OneToManyWithQualityGeneric<
-               std::vector<CaloParticle>, std::vector<reco::io_v1::PFCluster>, std::pair<float,float>, unsigned int,
-               edm::RefProd<std::vector<CaloParticle>>, edm::RefProd<std::vector<reco::io_v1::PFCluster>>,
-               edm::Ref<std::vector<CaloParticle>>, edm::Ref<std::vector<reco::io_v1::PFCluster>>
+               std::vector<io_v1::CaloParticle>, std::vector<reco::io_v1::PFCluster>, std::pair<float,float>, unsigned int,
+               edm::RefProd<std::vector<io_v1::CaloParticle>>, edm::RefProd<std::vector<reco::io_v1::PFCluster>>,
+               edm::Ref<std::vector<io_v1::CaloParticle>>, edm::Ref<std::vector<reco::io_v1::PFCluster>>
 			   >>" >
 		 <field name="transientMap_" transient="true"/>
   </class>
 
   <class name="edm::AssociationMap<edm::OneToManyWithQualityGeneric<
-               std::vector<reco::io_v1::PFCluster>, std::vector<CaloParticle>, float, unsigned int,
-               edm::RefProd<std::vector<reco::io_v1::PFCluster>>, edm::RefProd<std::vector<CaloParticle>>,
-               edm::Ref<std::vector<reco::io_v1::PFCluster>>, edm::Ref<std::vector<CaloParticle>>
+               std::vector<reco::io_v1::PFCluster>, std::vector<io_v1::CaloParticle>, float, unsigned int,
+               edm::RefProd<std::vector<reco::io_v1::PFCluster>>, edm::RefProd<std::vector<io_v1::CaloParticle>>,
+               edm::Ref<std::vector<reco::io_v1::PFCluster>>, edm::Ref<std::vector<io_v1::CaloParticle>>
 			   >>" >
 		 <field name="transientMap_" transient="true"/>
   </class>
 		
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQualityGeneric<edm::View<reco::Track>,vector<TrackingParticle>,double,unsigned int,edm::RefToBaseProd<reco::Track>,edm::RefProd<vector<TrackingParticle> >,edm::RefToBase<reco::Track>,edm::Ref<vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<vector<TrackingParticle>,TrackingParticle> > > > >" />
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQualityGeneric<vector<TrackingParticle>,edm::View<reco::Track>,double,unsigned int,edm::RefProd<vector<TrackingParticle> >,edm::RefToBaseProd<reco::Track>,edm::Ref<vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<vector<TrackingParticle>,TrackingParticle> >,edm::RefToBase<reco::Track> > > >" />
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQualityGeneric<edm::View<reco::Track>,vector<io_v1::TrackingParticle>,double,unsigned int,edm::RefToBaseProd<reco::Track>,edm::RefProd<vector<io_v1::TrackingParticle> >,edm::RefToBase<reco::Track>,edm::Ref<vector<io_v1::TrackingParticle>,io_v1::TrackingParticle,edm::refhelper::FindUsingAdvance<vector<io_v1::TrackingParticle>,io_v1::TrackingParticle> > > > >" />
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQualityGeneric<vector<io_v1::TrackingParticle>,edm::View<reco::Track>,double,unsigned int,edm::RefProd<vector<io_v1::TrackingParticle> >,edm::RefToBaseProd<reco::Track>,edm::Ref<vector<io_v1::TrackingParticle>,io_v1::TrackingParticle,edm::refhelper::FindUsingAdvance<vector<io_v1::TrackingParticle>,io_v1::TrackingParticle> >,edm::RefToBase<reco::Track> > > >" />
 
   <class name="std::pair<TrackingParticleRef, TrackPSimHitRef>"/>
   <class name="std::vector<std::pair<TrackingParticleRef, TrackPSimHitRef> >"/>
@@ -221,8 +221,8 @@
   </class>
   <class name="edm::Wrapper<hgcal::RecoToSimCollectionWithMultiClusters>" />
 
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<CaloParticle> >,edm::RefProd<vector<reco::io_v1::HGCalMultiCluster> > >" />
-  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::io_v1::HGCalMultiCluster> >,edm::RefProd<vector<CaloParticle> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<io_v1::CaloParticle> >,edm::RefProd<vector<reco::io_v1::HGCalMultiCluster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::io_v1::HGCalMultiCluster> >,edm::RefProd<vector<io_v1::CaloParticle> > >" />
 
 
   <class name="ticl::SimToRecoCollectionSimTracksters" >
@@ -260,15 +260,15 @@
   
   <class name="std::pair<FTLClusterRef, std::vector<MtdSimLayerClusterRef> >" />
   <class name="std::vector<std::pair<FTLClusterRef, std::vector<MtdSimLayerClusterRef> > >" />
-  <class name="MtdRecoClusterToSimLayerClusterAssociationMap" ClassVersion="3">
-    <version ClassVersion="3" checksum="1411787573"/>
+  <class name="io_v1::MtdRecoClusterToSimLayerClusterAssociationMap" ClassVersion="3">
+    <version ClassVersion="3" checksum="595750821"/>
   </class>
-  <class name="edm::Wrapper<MtdRecoClusterToSimLayerClusterAssociationMap>" />
+  <class name="edm::Wrapper<io_v1::MtdRecoClusterToSimLayerClusterAssociationMap>" />
   <class name="std::pair<MtdSimLayerClusterRef, std::vector<FTLClusterRef> >" />
   <class name="std::vector<std::pair<MtdSimLayerClusterRef, std::vector<FTLClusterRef> > >" />
-  <class name="MtdSimLayerClusterToRecoClusterAssociationMap" ClassVersion="3">
-    <version ClassVersion="3" checksum="3331727647"/>
-  </class><class name="edm::Wrapper<MtdSimLayerClusterToRecoClusterAssociationMap>" />
+  <class name="io_v1::MtdSimLayerClusterToRecoClusterAssociationMap" ClassVersion="3">
+    <version ClassVersion="3" checksum="630371151"/>
+  </class><class name="edm::Wrapper<io_v1::MtdSimLayerClusterToRecoClusterAssociationMap>" />
   <class name="reco::MtdRecoClusterToSimLayerClusterAssociator" persistent="false"/>
   <class name="edm::Wrapper<reco::MtdRecoClusterToSimLayerClusterAssociator>" persistent="false"/>
 
@@ -288,8 +288,8 @@
    <field name="transientMap_" transient="true"/>
   </class>
 
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<MtdSimLayerCluster> >, edm::RefProd<std::vector<TrackingParticle> > >" />
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<TrackingParticle> >, edm::RefProd<std::vector<MtdSimLayerCluster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<io_v1::MtdSimLayerCluster> >, edm::RefProd<std::vector<io_v1::TrackingParticle> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<io_v1::TrackingParticle> >, edm::RefProd<std::vector<io_v1::MtdSimLayerCluster> > >" />
 
 
   <class name="edm::RefProd<TTClusterAssociationMap<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
@@ -306,17 +306,17 @@
 
   <class name="edm::Wrapper<TTTrackAssociationMap<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
   
-  <class name="std::map<edm::Ref<edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, std::vector<edm::Ptr<TrackingParticle>, std::allocator<edm::Ptr<TrackingParticle> > >,std::less<edm::Ref<edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector> >, std::allocator<std::pair<const edm::Ref<edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, std::vector<edm::Ptr<TrackingParticle>,std::allocator<edm::Ptr<TrackingParticle> > > > > >" />
+  <class name="std::map<edm::Ref<edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, std::vector<edm::Ptr<io_v1::TrackingParticle>, std::allocator<edm::Ptr<io_v1::TrackingParticle> > >,std::less<edm::Ref<edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector> >, std::allocator<std::pair<const edm::Ref<edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, std::vector<edm::Ptr<io_v1::TrackingParticle>,std::allocator<edm::Ptr<io_v1::TrackingParticle> > > > > >" />
 
-  <class name="std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ref<edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, std::allocator<edm::Ref<edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector> > >, std::less<edm::Ptr<TrackingParticle> >, std::allocator<std::pair<const edm::Ptr<TrackingParticle>, std::vector<edm::Ref<edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, std::allocator<edm::Ref<edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector> > > > > >" />
+  <class name="std::map<edm::Ptr<io_v1::TrackingParticle>, std::vector<edm::Ref<edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, std::allocator<edm::Ref<edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector> > >, std::less<edm::Ptr<io_v1::TrackingParticle> >, std::allocator<std::pair<const edm::Ptr<io_v1::TrackingParticle>, std::vector<edm::Ref<edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, std::allocator<edm::Ref<edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector> > > > > >" />
 
-  <class name="std::map<edm::Ref<edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, edm::Ptr<TrackingParticle>, std::less<edm::Ref<edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector> >, std::allocator<std::pair<const edm::Ref<edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, edm::Ptr<TrackingParticle> > > >" />
+  <class name="std::map<edm::Ref<edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, edm::Ptr<io_v1::TrackingParticle>, std::less<edm::Ref<edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector> >, std::allocator<std::pair<const edm::Ref<edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, edm::Ptr<io_v1::TrackingParticle> > > >" />
 
-  <class name="std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ref<edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, std::allocator<edm::Ref<edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector> > >, std::less<edm::Ptr<TrackingParticle> >, std::allocator<std::pair<const edm::Ptr<TrackingParticle>, std::vector<edm::Ref<edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, std::allocator<edm::Ref<edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector> > > > > >" />
+  <class name="std::map<edm::Ptr<io_v1::TrackingParticle>, std::vector<edm::Ref<edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, std::allocator<edm::Ref<edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector> > >, std::less<edm::Ptr<io_v1::TrackingParticle> >, std::allocator<std::pair<const edm::Ptr<io_v1::TrackingParticle>, std::vector<edm::Ref<edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, std::allocator<edm::Ref<edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector> > > > > >" />
 
-  <class name="std::map<edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, edm::Ptr<TrackingParticle>, std::less<edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > > >, std::allocator<std::pair<const edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, edm::Ptr<TrackingParticle> > > >" />
+  <class name="std::map<edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, edm::Ptr<io_v1::TrackingParticle>, std::less<edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > > >, std::allocator<std::pair<const edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, edm::Ptr<io_v1::TrackingParticle> > > >" />
 
-  <class name="std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, std::allocator<edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > > > >, std::less<edm::Ptr<TrackingParticle> >, std::allocator<std::pair<const edm::Ptr<TrackingParticle>, std::vector<edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, std::allocator<edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > > > > > > >" />
+  <class name="std::map<edm::Ptr<io_v1::TrackingParticle>, std::vector<edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, std::allocator<edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > > > >, std::less<edm::Ptr<io_v1::TrackingParticle> >, std::allocator<std::pair<const edm::Ptr<io_v1::TrackingParticle>, std::vector<edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, std::allocator<edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > > > > > > >" />
 
   <class name="TTClusterAssociationMap<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >" />
 
@@ -324,20 +324,20 @@
 
   <class name="TTTrackAssociationMap<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >" />
 
-  <class name="std::pair<const edm::Ref<edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, std::vector<edm::Ptr<TrackingParticle>, std::allocator<edm::Ptr<TrackingParticle> > > >" />
+  <class name="std::pair<const edm::Ref<edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, std::vector<edm::Ptr<io_v1::TrackingParticle>, std::allocator<edm::Ptr<io_v1::TrackingParticle> > > >" />
 
-  <class name="std::pair<const edm::Ptr<TrackingParticle>, std::vector<edm::Ref<edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, std::allocator<edm::Ref<edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector> > > >" />
+  <class name="std::pair<const edm::Ptr<io_v1::TrackingParticle>, std::vector<edm::Ref<edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, std::allocator<edm::Ref<edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector> > > >" />
 
-  <class name="std::pair<const edm::Ref<edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, edm::Ptr<TrackingParticle> >" />
+  <class name="std::pair<const edm::Ref<edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, edm::Ptr<io_v1::TrackingParticle> >" />
 
 
-  <class name="std::pair<const edm::Ptr<TrackingParticle>, std::vector<edm::Ref<edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, std::allocator<edm::Ref<edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector> > > >" />
+  <class name="std::pair<const edm::Ptr<io_v1::TrackingParticle>, std::vector<edm::Ref<edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector>, std::allocator<edm::Ref<edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >, edmNew::DetSetVector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >::FindForDetSetVector> > > >" />
 
-  <class name="std::pair< edm::Ptr< TTTrack< edm::Ref< edm::DetSetVector< Phase2TrackerDigi >, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector< Phase2TrackerDigi > > > >, edm::Ptr< TrackingParticle > >" />
-  <class name="std::pair< edm::Ptr< TrackingParticle >, vector< edm::Ptr< TTTrack< edm::Ref< edm::DetSetVector< Phase2TrackerDigi >, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector< Phase2TrackerDigi > > > >, allocator< edm::Ptr< TTTrack< edm::Ref< edm::DetSetVector< Phase2TrackerDigi >, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector< Phase2TrackerDigi > > > > > > >" />
+  <class name="std::pair< edm::Ptr< TTTrack< edm::Ref< edm::DetSetVector< Phase2TrackerDigi >, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector< Phase2TrackerDigi > > > >, edm::Ptr<io_v1::TrackingParticle > >" />
+  <class name="std::pair< edm::Ptr< io_v1::TrackingParticle >, vector< edm::Ptr< TTTrack< edm::Ref< edm::DetSetVector< Phase2TrackerDigi >, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector< Phase2TrackerDigi > > > >, allocator< edm::Ptr< TTTrack< edm::Ref< edm::DetSetVector< Phase2TrackerDigi >, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector< Phase2TrackerDigi > > > > > > >" />
 
-  <class name="std::pair<const edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, edm::Ptr<TrackingParticle> >" />
+  <class name="std::pair<const edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, edm::Ptr<io_v1::TrackingParticle> >" />
   
-  <class name="std::pair<const edm::Ptr<TrackingParticle>, std::vector<edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, std::allocator<edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > > > > >" />
+  <class name="std::pair<const edm::Ptr<io_v1::TrackingParticle>, std::vector<edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >, std::allocator<edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > > > > >" />
 
 </lcgdict>

--- a/SimDataFormats/CaloAnalysis/interface/CaloParticle.h
+++ b/SimDataFormats/CaloAnalysis/interface/CaloParticle.h
@@ -11,206 +11,209 @@
 #include "SimDataFormats/Track/interface/SimTrack.h"
 #include <vector>
 
-class CaloParticle {
-  friend std::ostream &operator<<(std::ostream &s, CaloParticle const &tp);
+namespace io_v1 {
+  class CaloParticle {
+    friend std::ostream &operator<<(std::ostream &s, CaloParticle const &tp);
 
-public:
-  typedef int Charge;                                       ///< electric charge type
-  typedef math::XYZTLorentzVectorD LorentzVector;           ///< Lorentz vector
-  typedef math::PtEtaPhiMLorentzVector PolarLorentzVector;  ///< Lorentz vector
-  typedef math::XYZPointD Point;                            ///< point in the space
-  typedef math::XYZVectorD Vector;                          ///< point in the space
+  public:
+    typedef int Charge;                                       ///< electric charge type
+    typedef math::XYZTLorentzVectorD LorentzVector;           ///< Lorentz vector
+    typedef math::PtEtaPhiMLorentzVector PolarLorentzVector;  ///< Lorentz vector
+    typedef math::XYZPointD Point;                            ///< point in the space
+    typedef math::XYZVectorD Vector;                          ///< point in the space
 
-  /// reference to reco::GenParticle
-  typedef reco::GenParticleRefVector::iterator genp_iterator;
-  typedef std::vector<SimTrack>::const_iterator g4t_iterator;
-  typedef SimClusterRefVector::iterator sc_iterator;
+    /// reference to reco::GenParticle
+    typedef reco::GenParticleRefVector::iterator genp_iterator;
+    typedef std::vector<SimTrack>::const_iterator g4t_iterator;
+    typedef SimClusterRefVector::iterator sc_iterator;
 
-  CaloParticle();
+    CaloParticle();
 
-  CaloParticle(const SimTrack &simtrk);
-  CaloParticle(EncodedEventId eventID, uint32_t particleID);  // for PU
+    CaloParticle(const SimTrack &simtrk);
+    CaloParticle(EncodedEventId eventID, uint32_t particleID);  // for PU
 
-  // destructor
-  ~CaloParticle();
+    // destructor
+    ~CaloParticle();
 
-  /** @brief PDG ID.
+    /** @brief PDG ID.
    *
    * Returns the PDG ID of the first associated gen particle. If there are no
    * gen particles associated then it returns type() from the first SimTrack. */
-  int pdgId() const {
-    if (genParticles_.empty())
-      return g4Tracks_[0].type();
-    else
-      return (*genParticles_.begin())->pdgId();
-  }
+    int pdgId() const {
+      if (genParticles_.empty())
+        return g4Tracks_[0].type();
+      else
+        return (*genParticles_.begin())->pdgId();
+    }
 
-  /** @brief Signal source, crossing number.
+    /** @brief Signal source, crossing number.
    *
    * Note this is taken from the first SimTrack only, but there shouldn't be any
    * SimTracks from different crossings in the CaloParticle. */
-  EncodedEventId eventId() const { return event_; }
+    EncodedEventId eventId() const { return event_; }
 
-  uint64_t particleId() const { return particleId_; }
+    uint64_t particleId() const { return particleId_; }
 
-  // Setters for G4 and reco::GenParticle
-  void addGenParticle(const reco::GenParticleRef &ref) { genParticles_.push_back(ref); }
-  void addSimCluster(const SimClusterRef &ref) { simClusters_.push_back(ref); }
-  void addG4Track(const SimTrack &t) { g4Tracks_.push_back(t); }
-  /// iterators
-  genp_iterator genParticle_begin() const { return genParticles_.begin(); }
-  genp_iterator genParticle_end() const { return genParticles_.end(); }
-  g4t_iterator g4Track_begin() const { return g4Tracks_.begin(); }
-  g4t_iterator g4Track_end() const { return g4Tracks_.end(); }
-  sc_iterator simCluster_begin() const { return simClusters_.begin(); }
-  sc_iterator simCluster_end() const { return simClusters_.end(); }
+    // Setters for G4 and reco::GenParticle
+    void addGenParticle(const reco::GenParticleRef &ref) { genParticles_.push_back(ref); }
+    void addSimCluster(const SimClusterRef &ref) { simClusters_.push_back(ref); }
+    void addG4Track(const SimTrack &t) { g4Tracks_.push_back(t); }
+    /// iterators
+    genp_iterator genParticle_begin() const { return genParticles_.begin(); }
+    genp_iterator genParticle_end() const { return genParticles_.end(); }
+    g4t_iterator g4Track_begin() const { return g4Tracks_.begin(); }
+    g4t_iterator g4Track_end() const { return g4Tracks_.end(); }
+    sc_iterator simCluster_begin() const { return simClusters_.begin(); }
+    sc_iterator simCluster_end() const { return simClusters_.end(); }
 
-  // Getters for Embd and Sim Tracks
-  const reco::GenParticleRefVector &genParticles() const { return genParticles_; }
-  const SimClusterRefVector &simClusters() const { return simClusters_; }
-  // Only for clusters from the signal vertex
-  const std::vector<SimTrack> &g4Tracks() const { return g4Tracks_; }
+    // Getters for Embd and Sim Tracks
+    const reco::GenParticleRefVector &genParticles() const { return genParticles_; }
+    const SimClusterRefVector &simClusters() const { return simClusters_; }
+    // Only for clusters from the signal vertex
+    const std::vector<SimTrack> &g4Tracks() const { return g4Tracks_; }
 
-  void clearSimClusters() { simClusters_.clear(); }
+    void clearSimClusters() { simClusters_.clear(); }
 
-  /// @brief Electric charge. Note this is taken from the first SimTrack only.
-  float charge() const { return g4Tracks_[0].charge(); }
-  /// Gives charge in unit of quark charge (should be 3 times "charge()")
-  int threeCharge() const { return lrintf(3.f * charge()); }
+    /// @brief Electric charge. Note this is taken from the first SimTrack only.
+    float charge() const { return g4Tracks_[0].charge(); }
+    /// Gives charge in unit of quark charge (should be 3 times "charge()")
+    int threeCharge() const { return lrintf(3.f * charge()); }
 
-  /// @brief Four-momentum Lorentz vector. Note this is taken from the first
-  /// SimTrack only.
-  const math::XYZTLorentzVectorF &p4() const { return theMomentum_; }
+    /// @brief Four-momentum Lorentz vector. Note this is taken from the first
+    /// SimTrack only.
+    const math::XYZTLorentzVectorF &p4() const { return theMomentum_; }
 
-  /// @brief spatial momentum vector
-  math::XYZVectorF momentum() const { return p4().Vect(); }
+    /// @brief spatial momentum vector
+    math::XYZVectorF momentum() const { return p4().Vect(); }
 
-  /// @brief Vector to boost to the particle centre of mass frame.
-  math::XYZVectorF boostToCM() const { return p4().BoostToCM(); }
+    /// @brief Vector to boost to the particle centre of mass frame.
+    math::XYZVectorF boostToCM() const { return p4().BoostToCM(); }
 
-  /// @brief Magnitude of momentum vector. Note this is taken from the first
-  /// SimTrack only.
-  float p() const { return p4().P(); }
+    /// @brief Magnitude of momentum vector. Note this is taken from the first
+    /// SimTrack only.
+    float p() const { return p4().P(); }
 
-  /// @brief Energy. Note this is taken from the first SimTrack only.
-  float energy() const { return p4().E(); }
+    /// @brief Energy. Note this is taken from the first SimTrack only.
+    float energy() const { return p4().E(); }
 
-  /// @brief Transverse energy. Note this is taken from the first SimTrack only.
-  float et() const { return p4().Et(); }
+    /// @brief Transverse energy. Note this is taken from the first SimTrack only.
+    float et() const { return p4().Et(); }
 
-  /// @brief Mass. Note this is taken from the first SimTrack only.
-  float mass() const { return p4().M(); }
+    /// @brief Mass. Note this is taken from the first SimTrack only.
+    float mass() const { return p4().M(); }
 
-  /// @brief Mass squared. Note this is taken from the first SimTrack only.
-  float massSqr() const { return pow(mass(), 2); }
+    /// @brief Mass squared. Note this is taken from the first SimTrack only.
+    float massSqr() const { return pow(mass(), 2); }
 
-  /// @brief Transverse mass. Note this is taken from the first SimTrack only.
-  float mt() const { return p4().Mt(); }
+    /// @brief Transverse mass. Note this is taken from the first SimTrack only.
+    float mt() const { return p4().Mt(); }
 
-  /// @brief Transverse mass squared. Note this is taken from the first SimTrack
-  /// only.
-  float mtSqr() const { return p4().Mt2(); }
+    /// @brief Transverse mass squared. Note this is taken from the first SimTrack
+    /// only.
+    float mtSqr() const { return p4().Mt2(); }
 
-  /// @brief x coordinate of momentum vector. Note this is taken from the first
-  /// SimTrack only.
-  float px() const { return p4().Px(); }
+    /// @brief x coordinate of momentum vector. Note this is taken from the first
+    /// SimTrack only.
+    float px() const { return p4().Px(); }
 
-  /// @brief y coordinate of momentum vector. Note this is taken from the first
-  /// SimTrack only.
-  float py() const { return p4().Py(); }
+    /// @brief y coordinate of momentum vector. Note this is taken from the first
+    /// SimTrack only.
+    float py() const { return p4().Py(); }
 
-  /// @brief z coordinate of momentum vector. Note this is taken from the first
-  /// SimTrack only.
-  float pz() const { return p4().Pz(); }
+    /// @brief z coordinate of momentum vector. Note this is taken from the first
+    /// SimTrack only.
+    float pz() const { return p4().Pz(); }
 
-  /// @brief Transverse momentum. Note this is taken from the first SimTrack
-  /// only.
-  float pt() const { return p4().Pt(); }
+    /// @brief Transverse momentum. Note this is taken from the first SimTrack
+    /// only.
+    float pt() const { return p4().Pt(); }
 
-  /// @brief Momentum azimuthal angle. Note this is taken from the first
-  /// SimTrack only.
-  float phi() const { return p4().Phi(); }
+    /// @brief Momentum azimuthal angle. Note this is taken from the first
+    /// SimTrack only.
+    float phi() const { return p4().Phi(); }
 
-  /// @brief Momentum polar angle. Note this is taken from the first SimTrack
-  /// only.
-  float theta() const { return p4().Theta(); }
+    /// @brief Momentum polar angle. Note this is taken from the first SimTrack
+    /// only.
+    float theta() const { return p4().Theta(); }
 
-  /// @brief Momentum pseudorapidity. Note this is taken from the simtrack
-  /// before the calorimeter
-  float eta() const { return p4().Eta(); }
+    /// @brief Momentum pseudorapidity. Note this is taken from the simtrack
+    /// before the calorimeter
+    float eta() const { return p4().Eta(); }
 
-  /// @brief Rapidity. Note this is taken from the simtrack before the
-  /// calorimeter
-  float rapidity() const { return p4().Rapidity(); }
+    /// @brief Rapidity. Note this is taken from the simtrack before the
+    /// calorimeter
+    float rapidity() const { return p4().Rapidity(); }
 
-  /// @brief Same as rapidity().
-  float y() const { return rapidity(); }
+    /// @brief Same as rapidity().
+    float y() const { return rapidity(); }
 
-  /** @brief Status word.
+    /** @brief Status word.
    *
    * Returns status() from the first gen particle, or -99 if there are no gen
    * particles attached. */
-  int status() const { return genParticles_.empty() ? -99 : (*genParticles_[0]).status(); }
+    int status() const { return genParticles_.empty() ? -99 : (*genParticles_[0]).status(); }
 
-  static const unsigned int longLivedTag;  ///< long lived flag
+    static const unsigned int longLivedTag;  ///< long lived flag
 
-  /// is long lived?
-  bool longLived() const { return status() & longLivedTag; }
+    /// is long lived?
+    bool longLived() const { return status() & longLivedTag; }
 
-  /** @brief Gives the total number of SimHits, in the cluster */
-  int numberOfSimHits() const { return nsimhits_; }
+    /** @brief Gives the total number of SimHits, in the cluster */
+    int numberOfSimHits() const { return nsimhits_; }
 
-  /** @brief Gives the total number of SimHits, in the cluster */
-  int numberOfRecHits() const { return hits_.size(); }
+    /** @brief Gives the total number of SimHits, in the cluster */
+    int numberOfRecHits() const { return hits_.size(); }
 
-  /** @brief returns the time in ns of the caloparticle */
-  float simTime() const { return time_; }
+    /** @brief returns the time in ns of the caloparticle */
+    float simTime() const { return time_; }
 
-  /** @brief add rechit with fraction */
-  void addRecHitAndFraction(uint32_t hit, float fraction) {
-    hits_.emplace_back(hit);
-    fractions_.emplace_back(fraction);
-  }
-
-  /** @brief Returns list of rechit IDs and fractions for this CaloParticle */
-  std::vector<std::pair<uint32_t, float>> hits_and_fractions() const {
-    std::vector<std::pair<uint32_t, float>> result;
-    result.reserve(hits_.size());
-    for (size_t i = 0; i < hits_.size(); ++i) {
-      result.emplace_back(hits_[i], fractions_[i]);
+    /** @brief add rechit with fraction */
+    void addRecHitAndFraction(uint32_t hit, float fraction) {
+      hits_.emplace_back(hit);
+      fractions_.emplace_back(fraction);
     }
-    return result;
-  }
 
-  /** @brief returns the accumulated sim energy in the cluster */
-  float simEnergy() const { return simhit_energy_; }
+    /** @brief Returns list of rechit IDs and fractions for this CaloParticle */
+    std::vector<std::pair<uint32_t, float>> hits_and_fractions() const {
+      std::vector<std::pair<uint32_t, float>> result;
+      result.reserve(hits_.size());
+      for (size_t i = 0; i < hits_.size(); ++i) {
+        result.emplace_back(hits_[i], fractions_[i]);
+      }
+      return result;
+    }
 
-  /** @brief add simhit's energy to cluster */
-  void addSimHit(const PCaloHit &hit) {
-    simhit_energy_ += hit.energy();
-    ++nsimhits_;
-  }
+    /** @brief returns the accumulated sim energy in the cluster */
+    float simEnergy() const { return simhit_energy_; }
 
-  /** @brief add vertex time to the caloparticle */
-  void setSimTime(const float time) { time_ = time; }
+    /** @brief add simhit's energy to cluster */
+    void addSimHit(const PCaloHit &hit) {
+      simhit_energy_ += hit.energy();
+      ++nsimhits_;
+    }
 
-protected:
-  uint64_t nsimhits_{0};
-  EncodedEventId event_;
+    /** @brief add vertex time to the caloparticle */
+    void setSimTime(const float time) { time_ = time; }
 
-  uint32_t particleId_{0};
-  float simhit_energy_{0.f};
-  float time_{std::numeric_limits<float>::lowest()};
-  std::vector<uint32_t> hits_;
-  std::vector<float> fractions_;
+  protected:
+    uint64_t nsimhits_{0};
+    EncodedEventId event_;
 
-  math::XYZTLorentzVectorF theMomentum_;
+    uint32_t particleId_{0};
+    float simhit_energy_{0.f};
+    float time_{std::numeric_limits<float>::lowest()};
+    std::vector<uint32_t> hits_;
+    std::vector<float> fractions_;
 
-  /// references to G4 and reco::GenParticle tracks
-  std::vector<SimTrack> g4Tracks_;
-  reco::GenParticleRefVector genParticles_;
+    math::XYZTLorentzVectorF theMomentum_;
 
-  SimClusterRefVector simClusters_;
-};
+    /// references to G4 and reco::GenParticle tracks
+    std::vector<SimTrack> g4Tracks_;
+    reco::GenParticleRefVector genParticles_;
+
+    SimClusterRefVector simClusters_;
+  };
+}  // namespace io_v1
+using CaloParticle = io_v1::CaloParticle;
 
 #endif  // SimDataFormats_CaloParticle_H

--- a/SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h
+++ b/SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h
@@ -5,8 +5,11 @@
 #include "DataFormats/Common/interface/RefVector.h"
 #include <vector>
 
-class CaloParticle;
-std::ostream &operator<<(std::ostream &s, CaloParticle const &tp);
+namespace io_v1 {
+  class CaloParticle;
+  std::ostream &operator<<(std::ostream &s, CaloParticle const &tp);
+}  // namespace io_v1
+using CaloParticle = io_v1::CaloParticle;
 
 typedef std::vector<CaloParticle> CaloParticleCollection;
 typedef edm::Ref<CaloParticleCollection> CaloParticleRef;

--- a/SimDataFormats/CaloAnalysis/interface/MtdCaloParticle.h
+++ b/SimDataFormats/CaloAnalysis/interface/MtdCaloParticle.h
@@ -9,37 +9,40 @@
 
 #include <vector>
 
-class MtdCaloParticle : public CaloParticle {
-  friend std::ostream &operator<<(std::ostream &s, MtdCaloParticle const &tp);
+namespace io_v1 {
+  class MtdCaloParticle : public CaloParticle {
+    friend std::ostream &operator<<(std::ostream &s, MtdCaloParticle const &tp);
 
-public:
-  typedef MtdSimClusterRefVector::iterator mtdsc_iterator;
+  public:
+    typedef MtdSimClusterRefVector::iterator mtdsc_iterator;
 
-  MtdCaloParticle();
+    MtdCaloParticle();
 
-  MtdCaloParticle(const SimTrack &simtrk);
-  MtdCaloParticle(EncodedEventId eventID, uint32_t particleID);  // for PU
+    MtdCaloParticle(const SimTrack &simtrk);
+    MtdCaloParticle(EncodedEventId eventID, uint32_t particleID);  // for PU
 
-  // destructor
-  ~MtdCaloParticle();
+    // destructor
+    ~MtdCaloParticle();
 
-  void addSimCluster(const MtdSimClusterRef &ref) { mtdsimClusters_.push_back(ref); }
+    void addSimCluster(const MtdSimClusterRef &ref) { mtdsimClusters_.push_back(ref); }
 
-  /// iterators
-  mtdsc_iterator simCluster_begin() const { return mtdsimClusters_.begin(); }
-  mtdsc_iterator simCluster_end() const { return mtdsimClusters_.end(); }
+    /// iterators
+    mtdsc_iterator simCluster_begin() const { return mtdsimClusters_.begin(); }
+    mtdsc_iterator simCluster_end() const { return mtdsimClusters_.end(); }
 
-  const MtdSimClusterRefVector &simClusters() const { return mtdsimClusters_; }
-  void clearSimClusters() { mtdsimClusters_.clear(); }
+    const MtdSimClusterRefVector &simClusters() const { return mtdsimClusters_; }
+    void clearSimClusters() { mtdsimClusters_.clear(); }
 
-  /** @brief add simhit's energy to cluster */
-  void addSimHit(PSimHit &hit) {
-    simhit_energy_ += hit.energyLoss();
-    ++nsimhits_;
-  }
+    /** @brief add simhit's energy to cluster */
+    void addSimHit(PSimHit &hit) {
+      simhit_energy_ += hit.energyLoss();
+      ++nsimhits_;
+    }
 
-private:
-  MtdSimClusterRefVector mtdsimClusters_;
-};
+  private:
+    MtdSimClusterRefVector mtdsimClusters_;
+  };
+}  // namespace io_v1
+using MtdCaloParticle = io_v1::MtdCaloParticle;
 
 #endif  // SimDataFormats_MtdCaloParticle_H

--- a/SimDataFormats/CaloAnalysis/interface/MtdCaloParticleFwd.h
+++ b/SimDataFormats/CaloAnalysis/interface/MtdCaloParticleFwd.h
@@ -5,8 +5,11 @@
 #include "DataFormats/Common/interface/RefVector.h"
 #include <vector>
 
-class MtdCaloParticle;
-std::ostream &operator<<(std::ostream &s, MtdCaloParticle const &tp);
+namespace io_v1 {
+  class MtdCaloParticle;
+  std::ostream &operator<<(std::ostream &s, MtdCaloParticle const &tp);
+}  // namespace io_v1
+using MtdCaloParticle = io_v1::MtdCaloParticle;
 
 typedef std::vector<MtdCaloParticle> MtdCaloParticleCollection;
 typedef edm::Ref<MtdCaloParticleCollection> MtdCaloParticleRef;

--- a/SimDataFormats/CaloAnalysis/interface/MtdSimCluster.h
+++ b/SimDataFormats/CaloAnalysis/interface/MtdSimCluster.h
@@ -9,122 +9,125 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include <vector>
 
-class MtdSimCluster : public SimCluster {
-  friend std::ostream &operator<<(std::ostream &s, MtdSimCluster const &tp);
+namespace io_v1 {
+  class MtdSimCluster : public SimCluster {
+    friend std::ostream &operator<<(std::ostream &s, MtdSimCluster const &tp);
 
-public:
-  MtdSimCluster();
-  MtdSimCluster(const SimTrack &simtrk);
-  MtdSimCluster(EncodedEventId eventID, uint32_t particleID);  // for PU
+  public:
+    MtdSimCluster();
+    MtdSimCluster(const SimTrack &simtrk);
+    MtdSimCluster(EncodedEventId eventID, uint32_t particleID);  // for PU
 
-  // destructor
-  ~MtdSimCluster();
+    // destructor
+    ~MtdSimCluster();
 
-  /** @brief add hit time */
-  void addHitTime(float time) {
-    times_.emplace_back(time);
-    ++nsimhits_;
-  }
-
-  /** @brief add hit with fraction */
-  void addHitAndFraction(uint64_t hit, float fraction) {
-    mtdHits_.emplace_back(hit);
-    fractions_.emplace_back(fraction);
-  }
-
-  /** @brief add hit position*/
-  void addHitPosition(LocalPoint pos) { positions_.emplace_back(pos); }
-
-  /** @brief Returns list of hit IDs and fractions for this SimCluster */
-  std::vector<std::pair<uint64_t, float>> hits_and_fractions() const {
-    assert(mtdHits_.size() == fractions_.size());
-    std::vector<std::pair<uint64_t, float>> result;
-    result.reserve(mtdHits_.size());
-    for (size_t i = 0; i < mtdHits_.size(); ++i) {
-      result.emplace_back(mtdHits_[i], fractions_[i]);
+    /** @brief add hit time */
+    void addHitTime(float time) {
+      times_.emplace_back(time);
+      ++nsimhits_;
     }
-    return result;
-  }
 
-  /** @brief Returns list of hit IDs and energies for this SimCluster */
-  std::vector<std::pair<uint64_t, float>> hits_and_energies() const {
-    assert(mtdHits_.size() == energies_.size());
-    std::vector<std::pair<uint64_t, float>> result;
-    result.reserve(mtdHits_.size());
-    for (size_t i = 0; i < mtdHits_.size(); ++i) {
-      result.emplace_back(mtdHits_[i], energies_[i]);
+    /** @brief add hit with fraction */
+    void addHitAndFraction(uint64_t hit, float fraction) {
+      mtdHits_.emplace_back(hit);
+      fractions_.emplace_back(fraction);
     }
-    return result;
-  }
 
-  /** @brief clear the hits and fractions list */
-  void clearHitsAndFractions() {
-    std::vector<uint64_t>().swap(mtdHits_);
-    std::vector<float>().swap(fractions_);
-  }
+    /** @brief add hit position*/
+    void addHitPosition(LocalPoint pos) { positions_.emplace_back(pos); }
 
-  /** @brief Returns list of hit IDs and times for this SimCluster */
-  std::vector<std::pair<uint64_t, float>> hits_and_times() const {
-    assert(mtdHits_.size() == times_.size());
-    std::vector<std::pair<uint64_t, float>> result;
-    result.reserve(mtdHits_.size());
-    for (size_t i = 0; i < mtdHits_.size(); ++i) {
-      result.emplace_back(mtdHits_[i], times_[i]);
+    /** @brief Returns list of hit IDs and fractions for this SimCluster */
+    std::vector<std::pair<uint64_t, float>> hits_and_fractions() const {
+      assert(mtdHits_.size() == fractions_.size());
+      std::vector<std::pair<uint64_t, float>> result;
+      result.reserve(mtdHits_.size());
+      for (size_t i = 0; i < mtdHits_.size(); ++i) {
+        result.emplace_back(mtdHits_[i], fractions_[i]);
+      }
+      return result;
     }
-    return result;
-  }
 
-  /** @brief Returns list of hit IDs and times for this SimCluster */
-  std::vector<std::pair<uint64_t, LocalPoint>> hits_and_positions() const {
-    assert(mtdHits_.size() == times_.size());
-    std::vector<std::pair<uint64_t, LocalPoint>> result;
-    result.reserve(mtdHits_.size());
-    for (size_t i = 0; i < mtdHits_.size(); ++i) {
-      result.emplace_back(mtdHits_[i], positions_[i]);
+    /** @brief Returns list of hit IDs and energies for this SimCluster */
+    std::vector<std::pair<uint64_t, float>> hits_and_energies() const {
+      assert(mtdHits_.size() == energies_.size());
+      std::vector<std::pair<uint64_t, float>> result;
+      result.reserve(mtdHits_.size());
+      for (size_t i = 0; i < mtdHits_.size(); ++i) {
+        result.emplace_back(mtdHits_[i], energies_[i]);
+      }
+      return result;
     }
-    return result;
-  }
 
-  /** @brief Returns list of detIds, rows and columns for this SimCluster */
-  std::vector<std::pair<uint32_t, std::pair<uint8_t, uint8_t>>> detIds_and_rows() const {
-    std::vector<std::pair<uint32_t, std::pair<uint8_t, uint8_t>>> result;
-    result.reserve(mtdHits_.size());
-    for (size_t i = 0; i < mtdHits_.size(); ++i) {
-      result.emplace_back(
-          mtdHits_[i] >> 32,
-          std::pair<uint8_t, uint8_t>(static_cast<uint8_t>(mtdHits_[i] >> 16), static_cast<uint8_t>(mtdHits_[i])));
+    /** @brief clear the hits and fractions list */
+    void clearHitsAndFractions() {
+      std::vector<uint64_t>().swap(mtdHits_);
+      std::vector<float>().swap(fractions_);
     }
-    return result;
-  }
 
-  /** @brief clear the times list */
-  void clearHitsTime() { std::vector<float>().swap(times_); }
+    /** @brief Returns list of hit IDs and times for this SimCluster */
+    std::vector<std::pair<uint64_t, float>> hits_and_times() const {
+      assert(mtdHits_.size() == times_.size());
+      std::vector<std::pair<uint64_t, float>> result;
+      result.reserve(mtdHits_.size());
+      for (size_t i = 0; i < mtdHits_.size(); ++i) {
+        result.emplace_back(mtdHits_[i], times_[i]);
+      }
+      return result;
+    }
 
-  /** @brief clear the positions list */
-  void clearHitsPosition() { std::vector<LocalPoint>().swap(positions_); }
+    /** @brief Returns list of hit IDs and times for this SimCluster */
+    std::vector<std::pair<uint64_t, LocalPoint>> hits_and_positions() const {
+      assert(mtdHits_.size() == times_.size());
+      std::vector<std::pair<uint64_t, LocalPoint>> result;
+      result.reserve(mtdHits_.size());
+      for (size_t i = 0; i < mtdHits_.size(); ++i) {
+        result.emplace_back(mtdHits_[i], positions_[i]);
+      }
+      return result;
+    }
 
-  void clear() {
-    clearHitsAndFractions();
-    clearHitsEnergy();
-    clearHitsTime();
-    clearHitsPosition();
-  }
+    /** @brief Returns list of detIds, rows and columns for this SimCluster */
+    std::vector<std::pair<uint32_t, std::pair<uint8_t, uint8_t>>> detIds_and_rows() const {
+      std::vector<std::pair<uint32_t, std::pair<uint8_t, uint8_t>>> result;
+      result.reserve(mtdHits_.size());
+      for (size_t i = 0; i < mtdHits_.size(); ++i) {
+        result.emplace_back(
+            mtdHits_[i] >> 32,
+            std::pair<uint8_t, uint8_t>(static_cast<uint8_t>(mtdHits_[i] >> 16), static_cast<uint8_t>(mtdHits_[i])));
+      }
+      return result;
+    }
 
-  /** @brief add simhit's energy to cluster */
-  void addSimHit(const PSimHit &hit) {
-    simhit_energy_ += hit.energyLoss();
-    ++nsimhits_;
-  }
+    /** @brief clear the times list */
+    void clearHitsTime() { std::vector<float>().swap(times_); }
 
-  void setTrackIdOffset(unsigned int offset) { idOffset_ = offset; }
+    /** @brief clear the positions list */
+    void clearHitsPosition() { std::vector<LocalPoint>().swap(positions_); }
 
-  unsigned int trackIdOffset() const { return idOffset_; }
+    void clear() {
+      clearHitsAndFractions();
+      clearHitsEnergy();
+      clearHitsTime();
+      clearHitsPosition();
+    }
 
-protected:
-  std::vector<uint64_t> mtdHits_;
-  std::vector<float> times_;
-  std::vector<LocalPoint> positions_;
-  unsigned int idOffset_{0};
-};
+    /** @brief add simhit's energy to cluster */
+    void addSimHit(const PSimHit &hit) {
+      simhit_energy_ += hit.energyLoss();
+      ++nsimhits_;
+    }
+
+    void setTrackIdOffset(unsigned int offset) { idOffset_ = offset; }
+
+    unsigned int trackIdOffset() const { return idOffset_; }
+
+  protected:
+    std::vector<uint64_t> mtdHits_;
+    std::vector<float> times_;
+    std::vector<LocalPoint> positions_;
+    unsigned int idOffset_{0};
+  };
+}  // namespace io_v1
+using MtdSimCluster = io_v1::MtdSimCluster;
 
 #endif

--- a/SimDataFormats/CaloAnalysis/interface/MtdSimClusterFwd.h
+++ b/SimDataFormats/CaloAnalysis/interface/MtdSimClusterFwd.h
@@ -5,8 +5,11 @@
 #include "DataFormats/Common/interface/RefVector.h"
 #include <vector>
 
-class MtdSimCluster;
-std::ostream &operator<<(std::ostream &s, MtdSimCluster const &tp);
+namespace io_v1 {
+  class MtdSimCluster;
+  std::ostream &operator<<(std::ostream &s, MtdSimCluster const &tp);
+}  // namespace io_v1
+using MtdSimCluster = io_v1::MtdSimCluster;
 
 typedef std::vector<MtdSimCluster> MtdSimClusterCollection;
 typedef edm::Ref<MtdSimClusterCollection> MtdSimClusterRef;

--- a/SimDataFormats/CaloAnalysis/interface/MtdSimLayerCluster.h
+++ b/SimDataFormats/CaloAnalysis/interface/MtdSimLayerCluster.h
@@ -8,57 +8,60 @@
 #include "SimDataFormats/CaloAnalysis/interface/MtdSimCluster.h"
 #include <vector>
 
-class MtdSimLayerCluster : public MtdSimCluster {
-  friend std::ostream &operator<<(std::ostream &s, MtdSimLayerCluster const &tp);
+namespace io_v1 {
+  class MtdSimLayerCluster : public MtdSimCluster {
+    friend std::ostream &operator<<(std::ostream &s, MtdSimLayerCluster const &tp);
 
-public:
-  MtdSimLayerCluster();
-  MtdSimLayerCluster(const SimTrack &simtrk);
-  MtdSimLayerCluster(EncodedEventId eventID, uint32_t particleID);  // for PU
+  public:
+    MtdSimLayerCluster();
+    MtdSimLayerCluster(const SimTrack &simtrk);
+    MtdSimLayerCluster(EncodedEventId eventID, uint32_t particleID);  // for PU
 
-  // destructor
-  ~MtdSimLayerCluster();
+    // destructor
+    ~MtdSimLayerCluster();
 
-  /** @brief computes the time of the cluster */
-  float computeClusterTime() {
-    simLC_time_ = 0.;
-    float tot_en = 0.;
-    for (uint32_t i = 0; i < times_.size(); i++) {
-      simLC_time_ += times_[i] * energies_[i];
-      tot_en += energies_[i];
+    /** @brief computes the time of the cluster */
+    float computeClusterTime() {
+      simLC_time_ = 0.;
+      float tot_en = 0.;
+      for (uint32_t i = 0; i < times_.size(); i++) {
+        simLC_time_ += times_[i] * energies_[i];
+        tot_en += energies_[i];
+      }
+      if (tot_en != 0.)
+        simLC_time_ = simLC_time_ / tot_en;
+      return simLC_time_;
     }
-    if (tot_en != 0.)
-      simLC_time_ = simLC_time_ / tot_en;
-    return simLC_time_;
-  }
 
-  /** @brief computes the energy of the cluster */
-  void addCluEnergy(float energy) { simLC_energy_ = energy; }
+    /** @brief computes the energy of the cluster */
+    void addCluEnergy(float energy) { simLC_energy_ = energy; }
 
-  /** @brief computes the position of the cluster */
-  void addCluLocalPos(LocalPoint pos) { simLC_pos_ = pos; }
+    /** @brief computes the position of the cluster */
+    void addCluLocalPos(LocalPoint pos) { simLC_pos_ = pos; }
 
-  /** @brief add the index of the simcluster */
-  void addCluIndex(const uint32_t index) { seedId_ = index; }
+    /** @brief add the index of the simcluster */
+    void addCluIndex(const uint32_t index) { seedId_ = index; }
 
-  /** @brief returns the time of the cluster */
-  float simLCTime() const { return simLC_time_; }
+    /** @brief returns the time of the cluster */
+    float simLCTime() const { return simLC_time_; }
 
-  /** @brief returns the local position of the cluster */
-  LocalPoint simLCPos() const { return simLC_pos_; }
+    /** @brief returns the local position of the cluster */
+    LocalPoint simLCPos() const { return simLC_pos_; }
 
-  /** @brief returns the accumulated sim energy in the cluster */
-  float simLCEnergy() const { return simLC_energy_; }
+    /** @brief returns the accumulated sim energy in the cluster */
+    float simLCEnergy() const { return simLC_energy_; }
 
-  uint32_t seedId() const { return seedId_; }
+    uint32_t seedId() const { return seedId_; }
 
-private:
-  // id of the simCluster it comes from
-  uint32_t seedId_;
+  private:
+    // id of the simCluster it comes from
+    uint32_t seedId_;
 
-  float simLC_time_{0.f};
-  float simLC_energy_{0.f};
-  LocalPoint simLC_pos_;
-};
+    float simLC_time_{0.f};
+    float simLC_energy_{0.f};
+    LocalPoint simLC_pos_;
+  };
+}  // namespace io_v1
+using MtdSimLayerCluster = io_v1::MtdSimLayerCluster;
 
 #endif

--- a/SimDataFormats/CaloAnalysis/interface/MtdSimLayerClusterFwd.h
+++ b/SimDataFormats/CaloAnalysis/interface/MtdSimLayerClusterFwd.h
@@ -13,6 +13,8 @@ typedef edm::RefVector<MtdSimLayerClusterCollection> MtdSimLayerClusterRefVector
 typedef edm::RefProd<MtdSimLayerClusterCollection> MtdSimLayerClusterRefProd;
 typedef edm::RefVector<MtdSimLayerClusterCollection> MtdSimLayerClusterContainer;
 
-std::ostream &operator<<(std::ostream &s, MtdSimLayerCluster const &tp);
+namespace io_v1 {
+  std::ostream &operator<<(std::ostream &s, MtdSimLayerCluster const &tp);
+}  // namespace io_v1
 
 #endif

--- a/SimDataFormats/CaloAnalysis/interface/MtdSimTrackster.h
+++ b/SimDataFormats/CaloAnalysis/interface/MtdSimTrackster.h
@@ -8,39 +8,42 @@
 #include "SimDataFormats/CaloAnalysis/interface/MtdSimCluster.h"
 #include <vector>
 
-class MtdSimTrackster : public MtdSimCluster {
-  friend std::ostream &operator<<(std::ostream &s, MtdSimTrackster const &tp);
+namespace io_v1 {
+  class MtdSimTrackster : public MtdSimCluster {
+    friend std::ostream &operator<<(std::ostream &s, MtdSimTrackster const &tp);
 
-public:
-  MtdSimTrackster();
+  public:
+    MtdSimTrackster();
 
-  MtdSimTrackster(const SimCluster &sc);
-  MtdSimTrackster(EncodedEventId eventID, uint32_t particleID);  // for PU
-  MtdSimTrackster(const SimCluster &sc, const std::vector<uint32_t> SCs, const float time, const GlobalPoint pos);
+    MtdSimTrackster(const SimCluster &sc);
+    MtdSimTrackster(EncodedEventId eventID, uint32_t particleID);  // for PU
+    MtdSimTrackster(const SimCluster &sc, const std::vector<uint32_t> SCs, const float time, const GlobalPoint pos);
 
-  // destructor
-  ~MtdSimTrackster();
+    // destructor
+    ~MtdSimTrackster();
 
-  /** @brief returns the position of the cluster */
-  GlobalPoint position() const { return posAtEntrance_; }
+    /** @brief returns the position of the cluster */
+    GlobalPoint position() const { return posAtEntrance_; }
 
-  /** @brief returns the time of the cluster */
-  float time() const { return timeAtEntrance_; }
+    /** @brief returns the time of the cluster */
+    float time() const { return timeAtEntrance_; }
 
-  /** @brief returns the layer clusters indexes in the sim trackster*/
-  std::vector<uint32_t> clusters() const { return clusters_; }
+    /** @brief returns the layer clusters indexes in the sim trackster*/
+    std::vector<uint32_t> clusters() const { return clusters_; }
 
-  /** @brief add simhit's energy to cluster */
-  void addCluster(const uint32_t sc) { clusters_.push_back(sc); }
+    /** @brief add simhit's energy to cluster */
+    void addCluster(const uint32_t sc) { clusters_.push_back(sc); }
 
-  /** @brief Gives the total number of SimHits, in the cluster */
-  int numberOfClusters() const { return clusters_.size(); }
+    /** @brief Gives the total number of SimHits, in the cluster */
+    int numberOfClusters() const { return clusters_.size(); }
 
-private:
-  float timeAtEntrance_{0.f};
-  GlobalPoint posAtEntrance_;
-  // indices of the MtdSimLayerClusters contained in the simTrackster
-  std::vector<uint32_t> clusters_;
-};
+  private:
+    float timeAtEntrance_{0.f};
+    GlobalPoint posAtEntrance_;
+    // indices of the MtdSimLayerClusters contained in the simTrackster
+    std::vector<uint32_t> clusters_;
+  };
+}  // namespace io_v1
+using MtdSimTrackster = io_v1::MtdSimTrackster;
 
 #endif  // SimDataFormats_MtdSimTrackster_H

--- a/SimDataFormats/CaloAnalysis/interface/MtdSimTracksterFwd.h
+++ b/SimDataFormats/CaloAnalysis/interface/MtdSimTracksterFwd.h
@@ -5,8 +5,11 @@
 #include "DataFormats/Common/interface/RefVector.h"
 #include <vector>
 
-class MtdSimTrackster;
-std::ostream &operator<<(std::ostream &s, MtdSimTrackster const &tp);
+namespace io_v1 {
+  class MtdSimTrackster;
+  std::ostream &operator<<(std::ostream &s, MtdSimTrackster const &tp);
+}  // namespace io_v1
+using MtdSimTrackster = io_v1::MtdSimTrackster;
 
 typedef std::vector<MtdSimTrackster> MtdSimTracksterCollection;
 typedef edm::Ref<MtdSimTracksterCollection> MtdSimTracksterRef;

--- a/SimDataFormats/CaloAnalysis/interface/SimCluster.h
+++ b/SimDataFormats/CaloAnalysis/interface/SimCluster.h
@@ -1,6 +1,7 @@
 #ifndef SimDataFormats_SimCluster_h
 #define SimDataFormats_SimCluster_h
 
+#include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 #include "DataFormats/Math/interface/Point3D.h"
@@ -15,7 +16,8 @@
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
-/** @brief Monte Carlo truth information used for tracking validation.
+namespace io_v1 {
+  /** @brief Monte Carlo truth information used for tracking validation.
  *
  * Object with references to the original SimTrack and parent and daughter
  * TrackingVertices. Simulation with high (~100) pileup was taking too much
@@ -26,227 +28,229 @@
  * (mark.grimes@bristol.ac.uk).
  * @date original date unknown, re-engineering Jan-May 2013
  */
-class SimCluster {
-  friend std::ostream &operator<<(std::ostream &s, SimCluster const &tp);
+  class SimCluster {
+    friend std::ostream &operator<<(std::ostream &s, SimCluster const &tp);
 
-public:
-  typedef int Charge;                                       ///< electric charge type
-  typedef math::XYZTLorentzVectorD LorentzVector;           ///< Lorentz vector
-  typedef math::PtEtaPhiMLorentzVector PolarLorentzVector;  ///< Lorentz vector
-  typedef math::XYZPointD Point;                            ///< point in the space
-  typedef math::XYZVectorD Vector;                          ///< point in the space
+  public:
+    typedef int Charge;                                       ///< electric charge type
+    typedef math::XYZTLorentzVectorD LorentzVector;           ///< Lorentz vector
+    typedef math::PtEtaPhiMLorentzVector PolarLorentzVector;  ///< Lorentz vector
+    typedef math::XYZPointD Point;                            ///< point in the space
+    typedef math::XYZVectorD Vector;                          ///< point in the space
 
-  /// reference to reco::GenParticle
-  typedef reco::GenParticleRefVector::iterator genp_iterator;
-  typedef std::vector<SimTrack>::const_iterator g4t_iterator;
+    /// reference to reco::GenParticle
+    typedef reco::GenParticleRefVector::iterator genp_iterator;
+    typedef std::vector<SimTrack>::const_iterator g4t_iterator;
 
-  SimCluster();
+    SimCluster();
 
-  SimCluster(const SimTrack &simtrk);
-  SimCluster(EncodedEventId eventID, uint32_t particleID);  // for PU
+    SimCluster(const SimTrack &simtrk);
+    SimCluster(EncodedEventId eventID, uint32_t particleID);  // for PU
 
-  // destructor
-  ~SimCluster();
+    // destructor
+    ~SimCluster();
 
-  /** @brief PDG ID.
+    /** @brief PDG ID.
    *
    * Returns the PDG ID of the first associated gen particle. If there are no
    * gen particles associated then it returns type() from the first SimTrack. */
-  int pdgId() const {
-    if (genParticles_.empty())
-      return g4Tracks_[0].type();
-    else
-      return (*genParticles_.begin())->pdgId();
-  }
+    int pdgId() const {
+      if (genParticles_.empty())
+        return g4Tracks_[0].type();
+      else
+        return (*genParticles_.begin())->pdgId();
+    }
 
-  /** @brief Signal source, crossing number.
+    /** @brief Signal source, crossing number.
    *
    * Note this is taken from the first SimTrack only, but there shouldn't be any
    * SimTracks from different crossings in the SimCluster. */
-  EncodedEventId eventId() const { return event_; }
+    EncodedEventId eventId() const { return event_; }
 
-  uint64_t particleId() const { return particleId_; }
+    uint64_t particleId() const { return particleId_; }
 
-  // Setters for G4 and reco::GenParticle
-  void addGenParticle(const reco::GenParticleRef &ref) { genParticles_.push_back(ref); }
-  void addG4Track(const SimTrack &t) { g4Tracks_.push_back(t); }
-  /// iterators
-  genp_iterator genParticle_begin() const { return genParticles_.begin(); }
-  genp_iterator genParticle_end() const { return genParticles_.end(); }
-  g4t_iterator g4Track_begin() const { return g4Tracks_.begin(); }
-  g4t_iterator g4Track_end() const { return g4Tracks_.end(); }
+    // Setters for G4 and reco::GenParticle
+    void addGenParticle(const reco::GenParticleRef &ref) { genParticles_.push_back(ref); }
+    void addG4Track(const SimTrack &t) { g4Tracks_.push_back(t); }
+    /// iterators
+    genp_iterator genParticle_begin() const { return genParticles_.begin(); }
+    genp_iterator genParticle_end() const { return genParticles_.end(); }
+    g4t_iterator g4Track_begin() const { return g4Tracks_.begin(); }
+    g4t_iterator g4Track_end() const { return g4Tracks_.end(); }
 
-  // Getters for Embd and Sim Tracks
-  const reco::GenParticleRefVector &genParticles() const { return genParticles_; }
-  // Only for clusters from the signal vertex
-  const std::vector<SimTrack> &g4Tracks() const { return g4Tracks_; }
+    // Getters for Embd and Sim Tracks
+    const reco::GenParticleRefVector &genParticles() const { return genParticles_; }
+    // Only for clusters from the signal vertex
+    const std::vector<SimTrack> &g4Tracks() const { return g4Tracks_; }
 
-  /// @brief Electric charge. Note this is taken from the first SimTrack only.
-  float charge() const { return g4Tracks_[0].charge(); }
-  /// Gives charge in unit of quark charge (should be 3 times "charge()")
-  int threeCharge() const { return lrintf(3.f * charge()); }
+    /// @brief Electric charge. Note this is taken from the first SimTrack only.
+    float charge() const { return g4Tracks_[0].charge(); }
+    /// Gives charge in unit of quark charge (should be 3 times "charge()")
+    int threeCharge() const { return lrintf(3.f * charge()); }
 
-  /// @brief Four-momentum Lorentz vector. Note this is taken from the first
-  /// SimTrack only.
-  const math::XYZTLorentzVectorF &p4() const { return theMomentum_; }
+    /// @brief Four-momentum Lorentz vector. Note this is taken from the first
+    /// SimTrack only.
+    const math::XYZTLorentzVectorF &p4() const { return theMomentum_; }
 
-  /// @brief spatial momentum vector
-  math::XYZVectorF momentum() const { return p4().Vect(); }
+    /// @brief spatial momentum vector
+    math::XYZVectorF momentum() const { return p4().Vect(); }
 
-  /// @brief Vector to boost to the particle centre of mass frame.
-  math::XYZVectorF boostToCM() const { return p4().BoostToCM(); }
+    /// @brief Vector to boost to the particle centre of mass frame.
+    math::XYZVectorF boostToCM() const { return p4().BoostToCM(); }
 
-  /// @brief Magnitude of momentum vector. Note this is taken from the first
-  /// SimTrack only.
-  float p() const { return p4().P(); }
+    /// @brief Magnitude of momentum vector. Note this is taken from the first
+    /// SimTrack only.
+    float p() const { return p4().P(); }
 
-  /// @brief Energy. Note this is taken from the first SimTrack only.
-  float energy() const { return p4().E(); }
+    /// @brief Energy. Note this is taken from the first SimTrack only.
+    float energy() const { return p4().E(); }
 
-  /// @brief Transverse energy. Note this is taken from the first SimTrack only.
-  float et() const { return p4().Et(); }
+    /// @brief Transverse energy. Note this is taken from the first SimTrack only.
+    float et() const { return p4().Et(); }
 
-  /// @brief Mass. Note this is taken from the first SimTrack only.
-  float mass() const { return p4().M(); }
+    /// @brief Mass. Note this is taken from the first SimTrack only.
+    float mass() const { return p4().M(); }
 
-  /// @brief Mass squared. Note this is taken from the first SimTrack only.
-  float massSqr() const { return pow(mass(), 2); }
+    /// @brief Mass squared. Note this is taken from the first SimTrack only.
+    float massSqr() const { return pow(mass(), 2); }
 
-  /// @brief Transverse mass. Note this is taken from the first SimTrack only.
-  float mt() const { return p4().Mt(); }
+    /// @brief Transverse mass. Note this is taken from the first SimTrack only.
+    float mt() const { return p4().Mt(); }
 
-  /// @brief Transverse mass squared. Note this is taken from the first SimTrack
-  /// only.
-  float mtSqr() const { return p4().Mt2(); }
+    /// @brief Transverse mass squared. Note this is taken from the first SimTrack
+    /// only.
+    float mtSqr() const { return p4().Mt2(); }
 
-  /// @brief x coordinate of momentum vector. Note this is taken from the first
-  /// SimTrack only.
-  float px() const { return p4().Px(); }
+    /// @brief x coordinate of momentum vector. Note this is taken from the first
+    /// SimTrack only.
+    float px() const { return p4().Px(); }
 
-  /// @brief y coordinate of momentum vector. Note this is taken from the first
-  /// SimTrack only.
-  float py() const { return p4().Py(); }
+    /// @brief y coordinate of momentum vector. Note this is taken from the first
+    /// SimTrack only.
+    float py() const { return p4().Py(); }
 
-  /// @brief z coordinate of momentum vector. Note this is taken from the first
-  /// SimTrack only.
-  float pz() const { return p4().Pz(); }
+    /// @brief z coordinate of momentum vector. Note this is taken from the first
+    /// SimTrack only.
+    float pz() const { return p4().Pz(); }
 
-  /// @brief Transverse momentum. Note this is taken from the first SimTrack
-  /// only.
-  float pt() const { return p4().Pt(); }
+    /// @brief Transverse momentum. Note this is taken from the first SimTrack
+    /// only.
+    float pt() const { return p4().Pt(); }
 
-  /// @brief Momentum azimuthal angle. Note this is taken from the first
-  /// SimTrack only.
-  float phi() const { return p4().Phi(); }
+    /// @brief Momentum azimuthal angle. Note this is taken from the first
+    /// SimTrack only.
+    float phi() const { return p4().Phi(); }
 
-  /// @brief Momentum polar angle. Note this is taken from the first SimTrack
-  /// only.
-  float theta() const { return p4().Theta(); }
+    /// @brief Momentum polar angle. Note this is taken from the first SimTrack
+    /// only.
+    float theta() const { return p4().Theta(); }
 
-  /// @brief Momentum pseudorapidity. Note this is taken from the simtrack
-  /// before the calorimeter
-  float eta() const { return p4().Eta(); }
+    /// @brief Momentum pseudorapidity. Note this is taken from the simtrack
+    /// before the calorimeter
+    float eta() const { return p4().Eta(); }
 
-  /// @brief Rapidity. Note this is taken from the simtrack before the
-  /// calorimeter
-  float rapidity() const { return p4().Rapidity(); }
+    /// @brief Rapidity. Note this is taken from the simtrack before the
+    /// calorimeter
+    float rapidity() const { return p4().Rapidity(); }
 
-  /// @brief Same as rapidity().
-  float y() const { return rapidity(); }
+    /// @brief Same as rapidity().
+    float y() const { return rapidity(); }
 
-  /** @brief Status word.
+    /** @brief Status word.
    *
    * Returns status() from the first gen particle, or -99 if there are no gen
    * particles attached. */
-  int status() const { return genParticles_.empty() ? -99 : (*genParticles_[0]).status(); }
+    int status() const { return genParticles_.empty() ? -99 : (*genParticles_[0]).status(); }
 
-  static const unsigned int longLivedTag;  ///< long lived flag
+    static const unsigned int longLivedTag;  ///< long lived flag
 
-  /// is long lived?
-  bool longLived() const { return status() & longLivedTag; }
+    /// is long lived?
+    bool longLived() const { return status() & longLivedTag; }
 
-  /** @brief Gives the total number of SimHits, in the cluster */
-  int numberOfSimHits() const { return nsimhits_; }
+    /** @brief Gives the total number of SimHits, in the cluster */
+    int numberOfSimHits() const { return nsimhits_; }
 
-  /** @brief Gives the total number of SimHits, in the cluster */
-  int numberOfRecHits() const { return hits_.size(); }
+    /** @brief Gives the total number of SimHits, in the cluster */
+    int numberOfRecHits() const { return hits_.size(); }
 
-  /** @brief add rechit with fraction */
-  void addRecHitAndFraction(uint32_t hit, float fraction) {
-    hits_.emplace_back(hit);
-    fractions_.emplace_back(fraction);
-  }
-
-  /** @brief add rechit energy */
-  void addHitEnergy(float energy) { energies_.emplace_back(energy); }
-
-  /** @brief Returns list of rechit IDs and fractions for this SimCluster */
-  std::vector<std::pair<uint32_t, float>> hits_and_fractions() const {
-    std::vector<std::pair<uint32_t, float>> result;
-    result.reserve(hits_.size());
-    for (size_t i = 0; i < hits_.size(); ++i) {
-      result.emplace_back(hits_[i], fractions_[i]);
+    /** @brief add rechit with fraction */
+    void addRecHitAndFraction(uint32_t hit, float fraction) {
+      hits_.emplace_back(hit);
+      fractions_.emplace_back(fraction);
     }
-    return result;
-  }
 
-  /** @brief Returns filtered list of rechit IDs and fractions for this SimCluster based on a predicate */
-  std::vector<std::pair<uint32_t, float>> filtered_hits_and_fractions(
-      const std::function<bool(const DetId &)> &predicate) const {
-    std::vector<std::pair<uint32_t, float>> result;
-    for (size_t i = 0; i < hits_.size(); ++i) {
-      DetId detid(hits_[i]);
-      if (predicate(detid)) {
+    /** @brief add rechit energy */
+    void addHitEnergy(float energy) { energies_.emplace_back(energy); }
+
+    /** @brief Returns list of rechit IDs and fractions for this SimCluster */
+    std::vector<std::pair<uint32_t, float>> hits_and_fractions() const {
+      std::vector<std::pair<uint32_t, float>> result;
+      result.reserve(hits_.size());
+      for (size_t i = 0; i < hits_.size(); ++i) {
         result.emplace_back(hits_[i], fractions_[i]);
       }
+      return result;
     }
-    return result;
-  }
 
-  /** @brief Returns list of rechit IDs and energies for this SimCluster */
-  std::vector<std::pair<uint32_t, float>> hits_and_energies() const {
-    assert(hits_.size() == energies_.size());
-    std::vector<std::pair<uint32_t, float>> result;
-    result.reserve(hits_.size());
-    for (size_t i = 0; i < hits_.size(); ++i) {
-      result.emplace_back(hits_[i], energies_[i]);
+    /** @brief Returns filtered list of rechit IDs and fractions for this SimCluster based on a predicate */
+    std::vector<std::pair<uint32_t, float>> filtered_hits_and_fractions(
+        const std::function<bool(const DetId &)> &predicate) const {
+      std::vector<std::pair<uint32_t, float>> result;
+      for (size_t i = 0; i < hits_.size(); ++i) {
+        DetId detid(hits_[i]);
+        if (predicate(detid)) {
+          result.emplace_back(hits_[i], fractions_[i]);
+        }
+      }
+      return result;
     }
-    return result;
-  }
 
-  /** @brief clear the hits and fractions list */
-  void clearHitsAndFractions() {
-    std::vector<uint32_t>().swap(hits_);
-    std::vector<float>().swap(fractions_);
-  }
+    /** @brief Returns list of rechit IDs and energies for this SimCluster */
+    std::vector<std::pair<uint32_t, float>> hits_and_energies() const {
+      assert(hits_.size() == energies_.size());
+      std::vector<std::pair<uint32_t, float>> result;
+      result.reserve(hits_.size());
+      for (size_t i = 0; i < hits_.size(); ++i) {
+        result.emplace_back(hits_[i], energies_[i]);
+      }
+      return result;
+    }
 
-  /** @brief clear the energies list */
-  void clearHitsEnergy() { std::vector<float>().swap(energies_); }
+    /** @brief clear the hits and fractions list */
+    void clearHitsAndFractions() {
+      std::vector<uint32_t>().swap(hits_);
+      std::vector<float>().swap(fractions_);
+    }
 
-  /** @brief returns the accumulated sim energy in the cluster */
-  float simEnergy() const { return simhit_energy_; }
+    /** @brief clear the energies list */
+    void clearHitsEnergy() { std::vector<float>().swap(energies_); }
 
-  /** @brief add simhit's energy to cluster */
-  void addSimHit(const PCaloHit &hit) {
-    simhit_energy_ += hit.energy();
-    ++nsimhits_;
-  }
+    /** @brief returns the accumulated sim energy in the cluster */
+    float simEnergy() const { return simhit_energy_; }
 
-protected:
-  uint64_t nsimhits_{0};
-  EncodedEventId event_;
+    /** @brief add simhit's energy to cluster */
+    void addSimHit(const PCaloHit &hit) {
+      simhit_energy_ += hit.energy();
+      ++nsimhits_;
+    }
 
-  uint32_t particleId_{0};
-  float simhit_energy_{0.f};
-  std::vector<uint32_t> hits_;
-  std::vector<float> fractions_;
-  std::vector<float> energies_;
+  protected:
+    uint64_t nsimhits_{0};
+    EncodedEventId event_;
 
-  math::XYZTLorentzVectorF theMomentum_;
+    uint32_t particleId_{0};
+    float simhit_energy_{0.f};
+    std::vector<uint32_t> hits_;
+    std::vector<float> fractions_;
+    std::vector<float> energies_;
 
-  /// references to G4 and reco::GenParticle tracks
-  std::vector<SimTrack> g4Tracks_;
-  reco::GenParticleRefVector genParticles_;
-};
+    math::XYZTLorentzVectorF theMomentum_;
+
+    /// references to G4 and reco::GenParticle tracks
+    std::vector<SimTrack> g4Tracks_;
+    reco::GenParticleRefVector genParticles_;
+  };
+}  // namespace io_v1
+using SimCluster = io_v1::SimCluster;
 
 #endif  // SimDataFormats_SimCluster_H

--- a/SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h
+++ b/SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h
@@ -5,8 +5,11 @@
 #include "DataFormats/Common/interface/RefVector.h"
 #include <vector>
 
-class SimCluster;
-std::ostream &operator<<(std::ostream &s, SimCluster const &tp);
+namespace io_v1 {
+  class SimCluster;
+  std::ostream &operator<<(std::ostream &s, SimCluster const &tp);
+}  // namespace io_v1
+using SimCluster = io_v1::SimCluster;
 
 typedef std::vector<SimCluster> SimClusterCollection;
 typedef edm::Ref<SimClusterCollection> SimClusterRef;

--- a/SimDataFormats/CaloAnalysis/interface/SimTauCPLink.h
+++ b/SimDataFormats/CaloAnalysis/interface/SimTauCPLink.h
@@ -7,158 +7,161 @@
 #include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-class SimTauCPLink {
-public:
-  SimTauCPLink() {}
-  ~SimTauCPLink() {}
-  struct DecayNav {
-    int pdgId_;
-    int resonance_idx_;
-    int calo_particle_idx_;
-    int gen_particle_idx_;
-    int pdgId() const { return pdgId_; }
-    int resonance_idx() const { return resonance_idx_; }
-    int calo_particle_idx() const { return calo_particle_idx_; }
-    int gen_particle_idx() const { return gen_particle_idx_; }
+namespace io_v1 {
+  class SimTauCPLink {
+  public:
+    SimTauCPLink() {}
+    ~SimTauCPLink() {}
+    struct DecayNav {
+      int pdgId_;
+      int resonance_idx_;
+      int calo_particle_idx_;
+      int gen_particle_idx_;
+      int pdgId() const { return pdgId_; }
+      int resonance_idx() const { return resonance_idx_; }
+      int calo_particle_idx() const { return calo_particle_idx_; }
+      int gen_particle_idx() const { return gen_particle_idx_; }
 
-  private:
-  };
+    private:
+    };
 
-  std::vector<std::pair<int, int>> resonances;
-  std::vector<DecayNav> leaves;
-  CaloParticleRefVector calo_particle_leaves;
-  int decayMode;
+    std::vector<std::pair<int, int>> resonances;
+    std::vector<DecayNav> leaves;
+    CaloParticleRefVector calo_particle_leaves;
+    int decayMode;
 
-  enum decayModes {
-    kNull = -1,
-    kOneProng0PiZero,    // 0
-    kOneProng1PiZero,    // 1
-    kOneProng2PiZero,    // 2
-    kOneProng3PiZero,    // 3
-    kOneProngNPiZero,    // 4
-    kTwoProng0PiZero,    // 5
-    kTwoProng1PiZero,    // 6
-    kTwoProng2PiZero,    // 7
-    kTwoProng3PiZero,    // 8
-    kTwoProngNPiZero,    // 9
-    kThreeProng0PiZero,  // 10
-    kThreeProng1PiZero,  // 11
-    kThreeProng2PiZero,  // 12
-    kThreeProng3PiZero,  // 13
-    kThreeProngNPiZero,  // 14
-    kRareDecayMode,      // 15
-    kElectron,           // 16
-    kMuon                // 17
-  };
+    enum decayModes {
+      kNull = -1,
+      kOneProng0PiZero,    // 0
+      kOneProng1PiZero,    // 1
+      kOneProng2PiZero,    // 2
+      kOneProng3PiZero,    // 3
+      kOneProngNPiZero,    // 4
+      kTwoProng0PiZero,    // 5
+      kTwoProng1PiZero,    // 6
+      kTwoProng2PiZero,    // 7
+      kTwoProng3PiZero,    // 8
+      kTwoProngNPiZero,    // 9
+      kThreeProng0PiZero,  // 10
+      kThreeProng1PiZero,  // 11
+      kThreeProng2PiZero,  // 12
+      kThreeProng3PiZero,  // 13
+      kThreeProngNPiZero,  // 14
+      kRareDecayMode,      // 15
+      kElectron,           // 16
+      kMuon                // 17
+    };
 
-  void dump(void) const {
-    LogDebug("SimTauProducer")
-        .format("Decay mode: {} ", buildDecayModes())
-        .format("Leaves: {} ", leaves.size())
-        .format("Resonances: {}", resonances.size());
-    for (auto const &l : leaves) {
+    void dump(void) const {
       LogDebug("SimTauProducer")
-          .format("L {} {} CP: {} GenP idx: {}",
-                  l.pdgId(),
-                  l.resonance_idx(),
-                  (int)((l.calo_particle_idx() == -1) ? -1 : calo_particle_leaves[l.calo_particle_idx()].key()),
-                  l.gen_particle_idx());
-    }
-    for (auto const &r : resonances) {
-      LogDebug("SimTauProducer").format("R {} {}", r.first, r.second);
-    }
-  }
-
-  void dumpDecay(const std::pair<int, int> &entry) const {
-    if (entry.second == -1) {  // No intermediate mother.
-      LogDebug("SimTauProducer").format("{} {}", entry.first, entry.second);
-    } else {
-      LogDebug("SimTauProducer").format("{} {} coming from: ", entry.first, entry.second);
-      auto const &mother = resonances[entry.second];
-      dumpDecay(mother);
-    }
-  }
-
-  void dumpFullDecay(void) const {
-    for (auto const &leaf : leaves) {
-      dumpDecay({leaf.pdgId(), leaf.resonance_idx()});
-    }
-  }
-
-  int buildDecayModes() const {
-    int numElectrons = 0;
-    int numMuons = 0;
-    int numHadrons = 0;
-    int numPhotons = 0;
-    for (auto leaf : leaves) {
-      int pdg_id = abs(leaf.pdgId());
-      switch (pdg_id) {
-        case 22:
-          numPhotons++;
-          break;
-        case 11:
-          numElectrons++;
-          break;
-        case 13:
-          numMuons++;
-          break;
-        case 16:
-          break;
-        default:
-          numHadrons++;
+          .format("Decay mode: {} ", buildDecayModes())
+          .format("Leaves: {} ", leaves.size())
+          .format("Resonances: {}", resonances.size());
+      for (auto const &l : leaves) {
+        LogDebug("SimTauProducer")
+            .format("L {} {} CP: {} GenP idx: {}",
+                    l.pdgId(),
+                    l.resonance_idx(),
+                    (int)((l.calo_particle_idx() == -1) ? -1 : calo_particle_leaves[l.calo_particle_idx()].key()),
+                    l.gen_particle_idx());
+      }
+      for (auto const &r : resonances) {
+        LogDebug("SimTauProducer").format("R {} {}", r.first, r.second);
       }
     }
 
-    if (numElectrons == 1)
-      return kElectron;
-    else if (numMuons == 1)
-      return kMuon;
-    switch (numHadrons) {
-      case 1:
-        switch (numPhotons) {
-          case 0:
-            return kOneProng0PiZero;
-          case 2:
-            return kOneProng1PiZero;
-          case 4:
-            return kOneProng2PiZero;
-          case 6:
-            return kOneProng3PiZero;
-          default:
-            return kOneProngNPiZero;
-        }
-      case 2:
-        switch (numPhotons) {
-          case 0:
-            return kTwoProng0PiZero;
-          case 2:
-            return kTwoProng1PiZero;
-          case 4:
-            return kTwoProng2PiZero;
-          case 6:
-            return kTwoProng3PiZero;
-          default:
-            return kTwoProngNPiZero;
-        }
-      case 3:
-        switch (numPhotons) {
-          case 0:
-            return kThreeProng0PiZero;
-          case 2:
-            return kThreeProng1PiZero;
-          case 4:
-            return kThreeProng2PiZero;
-          case 6:
-            return kThreeProng3PiZero;
-          default:
-            return kThreeProngNPiZero;
-        }
-      default:
-        return kRareDecayMode;
+    void dumpDecay(const std::pair<int, int> &entry) const {
+      if (entry.second == -1) {  // No intermediate mother.
+        LogDebug("SimTauProducer").format("{} {}", entry.first, entry.second);
+      } else {
+        LogDebug("SimTauProducer").format("{} {} coming from: ", entry.first, entry.second);
+        auto const &mother = resonances[entry.second];
+        dumpDecay(mother);
+      }
     }
-  }
 
-private:
-};
+    void dumpFullDecay(void) const {
+      for (auto const &leaf : leaves) {
+        dumpDecay({leaf.pdgId(), leaf.resonance_idx()});
+      }
+    }
+
+    int buildDecayModes() const {
+      int numElectrons = 0;
+      int numMuons = 0;
+      int numHadrons = 0;
+      int numPhotons = 0;
+      for (auto leaf : leaves) {
+        int pdg_id = abs(leaf.pdgId());
+        switch (pdg_id) {
+          case 22:
+            numPhotons++;
+            break;
+          case 11:
+            numElectrons++;
+            break;
+          case 13:
+            numMuons++;
+            break;
+          case 16:
+            break;
+          default:
+            numHadrons++;
+        }
+      }
+
+      if (numElectrons == 1)
+        return kElectron;
+      else if (numMuons == 1)
+        return kMuon;
+      switch (numHadrons) {
+        case 1:
+          switch (numPhotons) {
+            case 0:
+              return kOneProng0PiZero;
+            case 2:
+              return kOneProng1PiZero;
+            case 4:
+              return kOneProng2PiZero;
+            case 6:
+              return kOneProng3PiZero;
+            default:
+              return kOneProngNPiZero;
+          }
+        case 2:
+          switch (numPhotons) {
+            case 0:
+              return kTwoProng0PiZero;
+            case 2:
+              return kTwoProng1PiZero;
+            case 4:
+              return kTwoProng2PiZero;
+            case 6:
+              return kTwoProng3PiZero;
+            default:
+              return kTwoProngNPiZero;
+          }
+        case 3:
+          switch (numPhotons) {
+            case 0:
+              return kThreeProng0PiZero;
+            case 2:
+              return kThreeProng1PiZero;
+            case 4:
+              return kThreeProng2PiZero;
+            case 6:
+              return kThreeProng3PiZero;
+            default:
+              return kThreeProngNPiZero;
+          }
+        default:
+          return kRareDecayMode;
+      }
+    }
+
+  private:
+  };
+}  // namespace io_v1
+using SimTauCPLink = io_v1::SimTauCPLink;
 
 #endif  //SimTauCPLink

--- a/SimDataFormats/CaloAnalysis/src/CaloParticle.cc
+++ b/SimDataFormats/CaloAnalysis/src/CaloParticle.cc
@@ -6,47 +6,49 @@
 
 #include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
 
-const unsigned int CaloParticle::longLivedTag = 65536;
+namespace io_v1 {
+  const unsigned int CaloParticle::longLivedTag = 65536;
 
-CaloParticle::CaloParticle() {
-  // No operation
-}
-
-CaloParticle::CaloParticle(const SimTrack &simtrk) {
-  addG4Track(simtrk);
-  event_ = simtrk.eventId();
-  particleId_ = simtrk.trackId();
-  theMomentum_.SetPxPyPzE(
-      simtrk.momentum().px(), simtrk.momentum().py(), simtrk.momentum().pz(), simtrk.momentum().E());
-}
-
-CaloParticle::CaloParticle(EncodedEventId eventID, uint32_t particleID) {
-  event_ = eventID;
-  particleId_ = particleID;
-}
-
-CaloParticle::~CaloParticle() {}
-
-std::ostream &operator<<(std::ostream &s, CaloParticle const &tp) {
-  s << "Calo Particle:" << std::endl;
-  s << "CP momentum, q, ID, & Event #: " << tp.p4() << " " << tp.charge() << " " << tp.pdgId() << " "
-    << tp.eventId().bunchCrossing() << "." << tp.eventId().event() << std::endl;
-
-  for (CaloParticle::genp_iterator hepT = tp.genParticle_begin(); hepT != tp.genParticle_end(); ++hepT) {
-    s << " HepMC Track Momentum " << (*hepT)->momentum().rho() << std::endl;
+  CaloParticle::CaloParticle() {
+    // No operation
   }
 
-  for (CaloParticle::g4t_iterator g4T = tp.g4Track_begin(); g4T != tp.g4Track_end(); ++g4T) {
-    s << " Geant Track Momentum  " << g4T->momentum() << std::endl;
-    s << " Geant Track ID & type " << g4T->trackId() << " " << g4T->type() << std::endl;
-    if (g4T->type() != tp.pdgId()) {
-      s << " Mismatch b/t CaloParticle and Geant types" << std::endl;
+  CaloParticle::CaloParticle(const SimTrack &simtrk) {
+    addG4Track(simtrk);
+    event_ = simtrk.eventId();
+    particleId_ = simtrk.trackId();
+    theMomentum_.SetPxPyPzE(
+        simtrk.momentum().px(), simtrk.momentum().py(), simtrk.momentum().pz(), simtrk.momentum().E());
+  }
+
+  CaloParticle::CaloParticle(EncodedEventId eventID, uint32_t particleID) {
+    event_ = eventID;
+    particleId_ = particleID;
+  }
+
+  CaloParticle::~CaloParticle() {}
+
+  std::ostream &operator<<(std::ostream &s, CaloParticle const &tp) {
+    s << "Calo Particle:" << std::endl;
+    s << "CP momentum, q, ID, & Event #: " << tp.p4() << " " << tp.charge() << " " << tp.pdgId() << " "
+      << tp.eventId().bunchCrossing() << "." << tp.eventId().event() << std::endl;
+
+    for (CaloParticle::genp_iterator hepT = tp.genParticle_begin(); hepT != tp.genParticle_end(); ++hepT) {
+      s << " HepMC Track Momentum " << (*hepT)->momentum().rho() << std::endl;
     }
+
+    for (CaloParticle::g4t_iterator g4T = tp.g4Track_begin(); g4T != tp.g4Track_end(); ++g4T) {
+      s << " Geant Track Momentum  " << g4T->momentum() << std::endl;
+      s << " Geant Track ID & type " << g4T->trackId() << " " << g4T->type() << std::endl;
+      if (g4T->type() != tp.pdgId()) {
+        s << " Mismatch b/t CaloParticle and Geant types" << std::endl;
+      }
+    }
+    s << "SimClusters in this CaloParticle: " << std::endl;
+    for (auto itr = tp.simClusters_.begin(); itr != tp.simClusters_.end(); ++itr) {
+      s << **itr;
+    }
+    s << std::endl;
+    return s;
   }
-  s << "SimClusters in this CaloParticle: " << std::endl;
-  for (auto itr = tp.simClusters_.begin(); itr != tp.simClusters_.end(); ++itr) {
-    s << **itr;
-  }
-  s << std::endl;
-  return s;
-}
+}  // namespace io_v1

--- a/SimDataFormats/CaloAnalysis/src/MtdCaloParticle.cc
+++ b/SimDataFormats/CaloAnalysis/src/MtdCaloParticle.cc
@@ -6,45 +6,47 @@
 
 #include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
 
-MtdCaloParticle::MtdCaloParticle() {
-  // No operation
-}
-
-MtdCaloParticle::MtdCaloParticle(const SimTrack &simtrk) {
-  addG4Track(simtrk);
-  event_ = simtrk.eventId();
-  particleId_ = simtrk.trackId();
-  theMomentum_.SetPxPyPzE(
-      simtrk.momentum().px(), simtrk.momentum().py(), simtrk.momentum().pz(), simtrk.momentum().E());
-}
-
-MtdCaloParticle::MtdCaloParticle(EncodedEventId eventID, uint32_t particleID) {
-  event_ = eventID;
-  particleId_ = particleID;
-}
-
-MtdCaloParticle::~MtdCaloParticle() {}
-
-std::ostream &operator<<(std::ostream &s, MtdCaloParticle const &tp) {
-  s << "Calo Particle:" << std::endl;
-  s << "CP momentum, q, ID, & Event #: " << tp.p4() << " " << tp.charge() << " " << tp.pdgId() << " "
-    << tp.eventId().bunchCrossing() << "." << tp.eventId().event() << std::endl;
-
-  for (MtdCaloParticle::genp_iterator hepT = tp.genParticle_begin(); hepT != tp.genParticle_end(); ++hepT) {
-    s << " HepMC Track Momentum " << (*hepT)->momentum().rho() << std::endl;
+namespace io_v1 {
+  MtdCaloParticle::MtdCaloParticle() {
+    // No operation
   }
 
-  for (MtdCaloParticle::g4t_iterator g4T = tp.g4Track_begin(); g4T != tp.g4Track_end(); ++g4T) {
-    s << " Geant Track Momentum  " << g4T->momentum() << std::endl;
-    s << " Geant Track ID & type " << g4T->trackId() << " " << g4T->type() << std::endl;
-    if (g4T->type() != tp.pdgId()) {
-      s << " Mismatch b/t MtdCaloParticle and Geant types" << std::endl;
+  MtdCaloParticle::MtdCaloParticle(const SimTrack &simtrk) {
+    addG4Track(simtrk);
+    event_ = simtrk.eventId();
+    particleId_ = simtrk.trackId();
+    theMomentum_.SetPxPyPzE(
+        simtrk.momentum().px(), simtrk.momentum().py(), simtrk.momentum().pz(), simtrk.momentum().E());
+  }
+
+  MtdCaloParticle::MtdCaloParticle(EncodedEventId eventID, uint32_t particleID) {
+    event_ = eventID;
+    particleId_ = particleID;
+  }
+
+  MtdCaloParticle::~MtdCaloParticle() {}
+
+  std::ostream &operator<<(std::ostream &s, MtdCaloParticle const &tp) {
+    s << "Calo Particle:" << std::endl;
+    s << "CP momentum, q, ID, & Event #: " << tp.p4() << " " << tp.charge() << " " << tp.pdgId() << " "
+      << tp.eventId().bunchCrossing() << "." << tp.eventId().event() << std::endl;
+
+    for (MtdCaloParticle::genp_iterator hepT = tp.genParticle_begin(); hepT != tp.genParticle_end(); ++hepT) {
+      s << " HepMC Track Momentum " << (*hepT)->momentum().rho() << std::endl;
     }
+
+    for (MtdCaloParticle::g4t_iterator g4T = tp.g4Track_begin(); g4T != tp.g4Track_end(); ++g4T) {
+      s << " Geant Track Momentum  " << g4T->momentum() << std::endl;
+      s << " Geant Track ID & type " << g4T->trackId() << " " << g4T->type() << std::endl;
+      if (g4T->type() != tp.pdgId()) {
+        s << " Mismatch b/t MtdCaloParticle and Geant types" << std::endl;
+      }
+    }
+    s << "SimClusters in this MtdCaloParticle: " << std::endl;
+    for (auto itr = tp.simClusters_.begin(); itr != tp.simClusters_.end(); ++itr) {
+      s << **itr;
+    }
+    s << std::endl;
+    return s;
   }
-  s << "SimClusters in this MtdCaloParticle: " << std::endl;
-  for (auto itr = tp.simClusters_.begin(); itr != tp.simClusters_.end(); ++itr) {
-    s << **itr;
-  }
-  s << std::endl;
-  return s;
-}
+}  // namespace io_v1

--- a/SimDataFormats/CaloAnalysis/src/MtdSimCluster.cc
+++ b/SimDataFormats/CaloAnalysis/src/MtdSimCluster.cc
@@ -4,42 +4,44 @@
 
 #include <numeric>
 
-MtdSimCluster::MtdSimCluster() {
-  // No operation
-}
-
-MtdSimCluster::MtdSimCluster(const SimTrack &simtrk) {
-  addG4Track(simtrk);
-  event_ = simtrk.eventId();
-  particleId_ = simtrk.trackId();
-
-  theMomentum_.SetPxPyPzE(
-      simtrk.momentum().px(), simtrk.momentum().py(), simtrk.momentum().pz(), simtrk.momentum().E());
-}
-
-MtdSimCluster::MtdSimCluster(EncodedEventId eventID, uint32_t particleID) {
-  event_ = eventID;
-  particleId_ = particleID;
-}
-
-MtdSimCluster::~MtdSimCluster() {}
-
-std::ostream &operator<<(std::ostream &s, MtdSimCluster const &tp) {
-  s << "CP momentum, q, ID, & Event #: " << tp.p4() << " " << tp.charge() << " " << tp.pdgId() << " "
-    << tp.eventId().bunchCrossing() << "." << tp.eventId().event() << std::endl;
-
-  for (MtdSimCluster::genp_iterator hepT = tp.genParticle_begin(); hepT != tp.genParticle_end(); ++hepT) {
-    s << " HepMC Track Momentum " << (*hepT)->momentum().rho() << std::endl;
+namespace io_v1 {
+  MtdSimCluster::MtdSimCluster() {
+    // No operation
   }
 
-  for (MtdSimCluster::g4t_iterator g4T = tp.g4Track_begin(); g4T != tp.g4Track_end(); ++g4T) {
-    s << " Geant Track Momentum  " << g4T->momentum() << std::endl;
-    s << " Geant Track ID & type " << g4T->trackId() << " " << g4T->type() << std::endl;
-    if (g4T->type() != tp.pdgId()) {
-      s << " Mismatch b/t MtdSimCluster and Geant types" << std::endl;
+  MtdSimCluster::MtdSimCluster(const SimTrack &simtrk) {
+    addG4Track(simtrk);
+    event_ = simtrk.eventId();
+    particleId_ = simtrk.trackId();
+
+    theMomentum_.SetPxPyPzE(
+        simtrk.momentum().px(), simtrk.momentum().py(), simtrk.momentum().pz(), simtrk.momentum().E());
+  }
+
+  MtdSimCluster::MtdSimCluster(EncodedEventId eventID, uint32_t particleID) {
+    event_ = eventID;
+    particleId_ = particleID;
+  }
+
+  MtdSimCluster::~MtdSimCluster() {}
+
+  std::ostream &operator<<(std::ostream &s, MtdSimCluster const &tp) {
+    s << "CP momentum, q, ID, & Event #: " << tp.p4() << " " << tp.charge() << " " << tp.pdgId() << " "
+      << tp.eventId().bunchCrossing() << "." << tp.eventId().event() << std::endl;
+
+    for (MtdSimCluster::genp_iterator hepT = tp.genParticle_begin(); hepT != tp.genParticle_end(); ++hepT) {
+      s << " HepMC Track Momentum " << (*hepT)->momentum().rho() << std::endl;
     }
+
+    for (MtdSimCluster::g4t_iterator g4T = tp.g4Track_begin(); g4T != tp.g4Track_end(); ++g4T) {
+      s << " Geant Track Momentum  " << g4T->momentum() << std::endl;
+      s << " Geant Track ID & type " << g4T->trackId() << " " << g4T->type() << std::endl;
+      if (g4T->type() != tp.pdgId()) {
+        s << " Mismatch b/t MtdSimCluster and Geant types" << std::endl;
+      }
+    }
+    s << " # of cells = " << tp.hits_.size()
+      << ", effective cells = " << std::accumulate(tp.fractions_.begin(), tp.fractions_.end(), 0.f) << std::endl;
+    return s;
   }
-  s << " # of cells = " << tp.hits_.size()
-    << ", effective cells = " << std::accumulate(tp.fractions_.begin(), tp.fractions_.end(), 0.f) << std::endl;
-  return s;
-}
+}  // namespace io_v1

--- a/SimDataFormats/CaloAnalysis/src/MtdSimLayerCluster.cc
+++ b/SimDataFormats/CaloAnalysis/src/MtdSimLayerCluster.cc
@@ -4,44 +4,46 @@
 
 #include <numeric>
 
-MtdSimLayerCluster::MtdSimLayerCluster() {
-  // No operation
-}
-
-MtdSimLayerCluster::MtdSimLayerCluster(const SimTrack &simtrk) {
-  addG4Track(simtrk);
-  event_ = simtrk.eventId();
-  particleId_ = simtrk.trackId();
-
-  theMomentum_.SetPxPyPzE(
-      simtrk.momentum().px(), simtrk.momentum().py(), simtrk.momentum().pz(), simtrk.momentum().E());
-}
-
-MtdSimLayerCluster::MtdSimLayerCluster(EncodedEventId eventID, uint32_t particleID) {
-  event_ = eventID;
-  particleId_ = particleID;
-}
-
-MtdSimLayerCluster::~MtdSimLayerCluster() {}
-
-std::ostream &operator<<(std::ostream &s, MtdSimLayerCluster const &tp) {
-  s << "CP momentum, q, ID, & Event #: " << tp.p4() << " " << tp.charge() << " " << tp.pdgId() << " "
-    << tp.eventId().bunchCrossing() << "." << tp.eventId().event() << std::endl;
-  s << " Offset " << tp.trackIdOffset() << " "
-    << " LC time " << tp.simLCTime() << " LC energy " << tp.simLCEnergy() << std::endl;
-
-  for (MtdSimLayerCluster::genp_iterator hepT = tp.genParticle_begin(); hepT != tp.genParticle_end(); ++hepT) {
-    s << " HepMC Track Momentum " << (*hepT)->momentum().rho() << std::endl;
+namespace io_v1 {
+  MtdSimLayerCluster::MtdSimLayerCluster() {
+    // No operation
   }
 
-  for (MtdSimLayerCluster::g4t_iterator g4T = tp.g4Track_begin(); g4T != tp.g4Track_end(); ++g4T) {
-    s << " Geant Track Momentum  " << g4T->momentum() << std::endl;
-    s << " Geant Track ID & type " << g4T->trackId() << " " << g4T->type() << std::endl;
-    if (g4T->type() != tp.pdgId()) {
-      s << " Mismatch b/t MtdSimLayerCluster and Geant types" << std::endl;
+  MtdSimLayerCluster::MtdSimLayerCluster(const SimTrack &simtrk) {
+    addG4Track(simtrk);
+    event_ = simtrk.eventId();
+    particleId_ = simtrk.trackId();
+
+    theMomentum_.SetPxPyPzE(
+        simtrk.momentum().px(), simtrk.momentum().py(), simtrk.momentum().pz(), simtrk.momentum().E());
+  }
+
+  MtdSimLayerCluster::MtdSimLayerCluster(EncodedEventId eventID, uint32_t particleID) {
+    event_ = eventID;
+    particleId_ = particleID;
+  }
+
+  MtdSimLayerCluster::~MtdSimLayerCluster() {}
+
+  std::ostream &operator<<(std::ostream &s, MtdSimLayerCluster const &tp) {
+    s << "CP momentum, q, ID, & Event #: " << tp.p4() << " " << tp.charge() << " " << tp.pdgId() << " "
+      << tp.eventId().bunchCrossing() << "." << tp.eventId().event() << std::endl;
+    s << " Offset " << tp.trackIdOffset() << " "
+      << " LC time " << tp.simLCTime() << " LC energy " << tp.simLCEnergy() << std::endl;
+
+    for (MtdSimLayerCluster::genp_iterator hepT = tp.genParticle_begin(); hepT != tp.genParticle_end(); ++hepT) {
+      s << " HepMC Track Momentum " << (*hepT)->momentum().rho() << std::endl;
     }
+
+    for (MtdSimLayerCluster::g4t_iterator g4T = tp.g4Track_begin(); g4T != tp.g4Track_end(); ++g4T) {
+      s << " Geant Track Momentum  " << g4T->momentum() << std::endl;
+      s << " Geant Track ID & type " << g4T->trackId() << " " << g4T->type() << std::endl;
+      if (g4T->type() != tp.pdgId()) {
+        s << " Mismatch b/t MtdSimLayerCluster and Geant types" << std::endl;
+      }
+    }
+    s << " # of cells = " << tp.mtdHits_.size()
+      << ", effective cells = " << std::accumulate(tp.fractions_.begin(), tp.fractions_.end(), 0.f) << std::endl;
+    return s;
   }
-  s << " # of cells = " << tp.mtdHits_.size()
-    << ", effective cells = " << std::accumulate(tp.fractions_.begin(), tp.fractions_.end(), 0.f) << std::endl;
-  return s;
-}
+}  // namespace io_v1

--- a/SimDataFormats/CaloAnalysis/src/MtdSimTrackster.cc
+++ b/SimDataFormats/CaloAnalysis/src/MtdSimTrackster.cc
@@ -2,59 +2,61 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-MtdSimTrackster::MtdSimTrackster() {
-  // No operation
-}
-
-MtdSimTrackster::MtdSimTrackster(const SimCluster &sc) {
-  auto simtrk = sc.g4Tracks()[0];
-  addG4Track(simtrk);
-  event_ = simtrk.eventId();
-  particleId_ = simtrk.trackId();
-
-  theMomentum_.SetPxPyPzE(
-      simtrk.momentum().px(), simtrk.momentum().py(), simtrk.momentum().pz(), simtrk.momentum().E());
-}
-
-MtdSimTrackster::MtdSimTrackster(EncodedEventId eventID, uint32_t particleID) {
-  event_ = eventID;
-  particleId_ = particleID;
-}
-
-MtdSimTrackster::MtdSimTrackster(const SimCluster &sc,
-                                 const std::vector<uint32_t> SCs,
-                                 const float time,
-                                 const GlobalPoint pos) {
-  auto simtrk = sc.g4Tracks()[0];
-  addG4Track(simtrk);
-  event_ = simtrk.eventId();
-  particleId_ = simtrk.trackId();
-
-  theMomentum_.SetPxPyPzE(
-      simtrk.momentum().px(), simtrk.momentum().py(), simtrk.momentum().pz(), simtrk.momentum().E());
-
-  clusters_ = SCs;
-  timeAtEntrance_ = time;
-  posAtEntrance_ = pos;
-}
-
-MtdSimTrackster::~MtdSimTrackster() {}
-
-std::ostream &operator<<(std::ostream &s, MtdSimTrackster const &tp) {
-  s << "CP momentum, q, ID, & Event #: " << tp.p4() << " " << tp.charge() << " " << tp.pdgId() << " "
-    << tp.eventId().bunchCrossing() << "." << tp.eventId().event() << std::endl;
-
-  for (MtdSimTrackster::genp_iterator hepT = tp.genParticle_begin(); hepT != tp.genParticle_end(); ++hepT) {
-    s << " HepMC Track Momentum " << (*hepT)->momentum().rho() << std::endl;
+namespace io_v1 {
+  MtdSimTrackster::MtdSimTrackster() {
+    // No operation
   }
 
-  for (MtdSimTrackster::g4t_iterator g4T = tp.g4Track_begin(); g4T != tp.g4Track_end(); ++g4T) {
-    s << " Geant Track Momentum  " << g4T->momentum() << std::endl;
-    s << " Geant Track ID & type " << g4T->trackId() << " " << g4T->type() << std::endl;
-    if (g4T->type() != tp.pdgId()) {
-      s << " Mismatch b/t MtdSimTrackster and Geant types" << std::endl;
+  MtdSimTrackster::MtdSimTrackster(const SimCluster &sc) {
+    auto simtrk = sc.g4Tracks()[0];
+    addG4Track(simtrk);
+    event_ = simtrk.eventId();
+    particleId_ = simtrk.trackId();
+
+    theMomentum_.SetPxPyPzE(
+        simtrk.momentum().px(), simtrk.momentum().py(), simtrk.momentum().pz(), simtrk.momentum().E());
+  }
+
+  MtdSimTrackster::MtdSimTrackster(EncodedEventId eventID, uint32_t particleID) {
+    event_ = eventID;
+    particleId_ = particleID;
+  }
+
+  MtdSimTrackster::MtdSimTrackster(const SimCluster &sc,
+                                   const std::vector<uint32_t> SCs,
+                                   const float time,
+                                   const GlobalPoint pos) {
+    auto simtrk = sc.g4Tracks()[0];
+    addG4Track(simtrk);
+    event_ = simtrk.eventId();
+    particleId_ = simtrk.trackId();
+
+    theMomentum_.SetPxPyPzE(
+        simtrk.momentum().px(), simtrk.momentum().py(), simtrk.momentum().pz(), simtrk.momentum().E());
+
+    clusters_ = SCs;
+    timeAtEntrance_ = time;
+    posAtEntrance_ = pos;
+  }
+
+  MtdSimTrackster::~MtdSimTrackster() {}
+
+  std::ostream &operator<<(std::ostream &s, MtdSimTrackster const &tp) {
+    s << "CP momentum, q, ID, & Event #: " << tp.p4() << " " << tp.charge() << " " << tp.pdgId() << " "
+      << tp.eventId().bunchCrossing() << "." << tp.eventId().event() << std::endl;
+
+    for (MtdSimTrackster::genp_iterator hepT = tp.genParticle_begin(); hepT != tp.genParticle_end(); ++hepT) {
+      s << " HepMC Track Momentum " << (*hepT)->momentum().rho() << std::endl;
     }
+
+    for (MtdSimTrackster::g4t_iterator g4T = tp.g4Track_begin(); g4T != tp.g4Track_end(); ++g4T) {
+      s << " Geant Track Momentum  " << g4T->momentum() << std::endl;
+      s << " Geant Track ID & type " << g4T->trackId() << " " << g4T->type() << std::endl;
+      if (g4T->type() != tp.pdgId()) {
+        s << " Mismatch b/t MtdSimTrackster and Geant types" << std::endl;
+      }
+    }
+    s << " # of clusters = " << tp.clusters_.size() << std::endl;
+    return s;
   }
-  s << " # of clusters = " << tp.clusters_.size() << std::endl;
-  return s;
-}
+}  // namespace io_v1

--- a/SimDataFormats/CaloAnalysis/src/SimCluster.cc
+++ b/SimDataFormats/CaloAnalysis/src/SimCluster.cc
@@ -6,44 +6,46 @@
 
 #include <numeric>
 
-const unsigned int SimCluster::longLivedTag = 65536;
+namespace io_v1 {
+  const unsigned int SimCluster::longLivedTag = 65536;
 
-SimCluster::SimCluster() {
-  // No operation
-}
-
-SimCluster::SimCluster(const SimTrack &simtrk) {
-  addG4Track(simtrk);
-  event_ = simtrk.eventId();
-  particleId_ = simtrk.trackId();
-
-  theMomentum_.SetPxPyPzE(
-      simtrk.momentum().px(), simtrk.momentum().py(), simtrk.momentum().pz(), simtrk.momentum().E());
-}
-
-SimCluster::SimCluster(EncodedEventId eventID, uint32_t particleID) {
-  event_ = eventID;
-  particleId_ = particleID;
-}
-
-SimCluster::~SimCluster() {}
-
-std::ostream &operator<<(std::ostream &s, SimCluster const &tp) {
-  s << "CP momentum, q, ID, & Event #: " << tp.p4() << " " << tp.charge() << " " << tp.pdgId() << " "
-    << tp.eventId().bunchCrossing() << "." << tp.eventId().event() << std::endl;
-
-  for (SimCluster::genp_iterator hepT = tp.genParticle_begin(); hepT != tp.genParticle_end(); ++hepT) {
-    s << " HepMC Track Momentum " << (*hepT)->momentum().rho() << std::endl;
+  SimCluster::SimCluster() {
+    // No operation
   }
 
-  for (SimCluster::g4t_iterator g4T = tp.g4Track_begin(); g4T != tp.g4Track_end(); ++g4T) {
-    s << " Geant Track Momentum  " << g4T->momentum() << std::endl;
-    s << " Geant Track ID & type " << g4T->trackId() << " " << g4T->type() << std::endl;
-    if (g4T->type() != tp.pdgId()) {
-      s << " Mismatch b/t SimCluster and Geant types" << std::endl;
+  SimCluster::SimCluster(const SimTrack &simtrk) {
+    addG4Track(simtrk);
+    event_ = simtrk.eventId();
+    particleId_ = simtrk.trackId();
+
+    theMomentum_.SetPxPyPzE(
+        simtrk.momentum().px(), simtrk.momentum().py(), simtrk.momentum().pz(), simtrk.momentum().E());
+  }
+
+  SimCluster::SimCluster(EncodedEventId eventID, uint32_t particleID) {
+    event_ = eventID;
+    particleId_ = particleID;
+  }
+
+  SimCluster::~SimCluster() {}
+
+  std::ostream &operator<<(std::ostream &s, SimCluster const &tp) {
+    s << "CP momentum, q, ID, & Event #: " << tp.p4() << " " << tp.charge() << " " << tp.pdgId() << " "
+      << tp.eventId().bunchCrossing() << "." << tp.eventId().event() << std::endl;
+
+    for (SimCluster::genp_iterator hepT = tp.genParticle_begin(); hepT != tp.genParticle_end(); ++hepT) {
+      s << " HepMC Track Momentum " << (*hepT)->momentum().rho() << std::endl;
     }
+
+    for (SimCluster::g4t_iterator g4T = tp.g4Track_begin(); g4T != tp.g4Track_end(); ++g4T) {
+      s << " Geant Track Momentum  " << g4T->momentum() << std::endl;
+      s << " Geant Track ID & type " << g4T->trackId() << " " << g4T->type() << std::endl;
+      if (g4T->type() != tp.pdgId()) {
+        s << " Mismatch b/t SimCluster and Geant types" << std::endl;
+      }
+    }
+    s << " # of cells = " << tp.hits_.size()
+      << ", effective cells = " << std::accumulate(tp.fractions_.begin(), tp.fractions_.end(), 0.f) << std::endl;
+    return s;
   }
-  s << " # of cells = " << tp.hits_.size()
-    << ", effective cells = " << std::accumulate(tp.fractions_.begin(), tp.fractions_.end(), 0.f) << std::endl;
-  return s;
-}
+}  // namespace io_v1

--- a/SimDataFormats/CaloAnalysis/src/classes_def.xml
+++ b/SimDataFormats/CaloAnalysis/src/classes_def.xml
@@ -1,6 +1,6 @@
 <lcgdict>
-   <class name="CaloParticle"  ClassVersion="3">
-    <version ClassVersion="3" checksum="3832020818"/>
+   <class name="io_v1::CaloParticle"  ClassVersion="3">
+    <version ClassVersion="3" checksum="489431184"/>
   </class>
   <class name="CaloParticleCollection"/>
   <class name="edm::Wrapper<CaloParticleCollection>"/>
@@ -9,8 +9,8 @@
   <class name="CaloParticleRefProd"/>
   <class name="CaloParticleContainer"/>
 
-  <class name="MtdCaloParticle" ClassVersion="3">
-    <version ClassVersion="3" checksum="374264907"/>
+  <class name="io_v1::MtdCaloParticle"  ClassVersion="3">
+    <version ClassVersion="3" checksum="2823088021"/>
   </class>
   <class name="MtdCaloParticleCollection"/>
   <class name="edm::Wrapper<MtdCaloParticleCollection>"/>
@@ -19,8 +19,8 @@
   <class name="MtdCaloParticleRefProd"/>
   <class name="MtdCaloParticleContainer"/>
 
-  <class name="SimCluster"  ClassVersion="3">
-   <version ClassVersion="3" checksum="2937120977"/>
+  <class name="io_v1::SimCluster"  ClassVersion="3">
+   <version ClassVersion="3" checksum="2253109319"/>
   </class>
   <class name="SimClusterCollection"/>
   <class name="edm::Wrapper<SimClusterCollection>"/>
@@ -29,10 +29,10 @@
   <class name="SimClusterRefProd"/>
   <class name="SimClusterContainer"/>
 
-  <class name="std::pair<edm::RefProd<std::vector<SimCluster> >, edm::RefProd<std::vector<CaloParticle> > >"/>
+  <class name="std::pair<edm::RefProd<std::vector<io_v1::SimCluster> >, edm::RefProd<std::vector<io_v1::CaloParticle> > >"/>
 
-  <class name="MtdSimCluster" ClassVersion="3">
-    <version ClassVersion="3" checksum="348726692"/>
+  <class name="io_v1::MtdSimCluster" ClassVersion="3">
+    <version ClassVersion="3" checksum="3934609990"/>
   </class>
   <class name="MtdSimClusterCollection"/>
   <class name="edm::Wrapper<MtdSimClusterCollection>"/>
@@ -43,7 +43,7 @@
 
 
   <class name="MtdSimLayerCluster" ClassVersion="3">
-    <version ClassVersion="3" checksum="2390344788"/>
+    <version ClassVersion="3" checksum="3418591020"/>
   </class>
   <class name="MtdSimLayerClusterCollection"/>
   <class name="edm::Wrapper<MtdSimLayerClusterCollection>"/>
@@ -53,7 +53,7 @@
   <class name="MtdSimLayerClusterContainer"/>
 
   <class name="MtdSimTrackster" ClassVersion="3">
-    <version ClassVersion="3" checksum="2148606150"/>
+    <version ClassVersion="3" checksum="1528473350"/>
   </class>
   <class name="MtdSimTracksterCollection"/>
   <class name="edm::Wrapper<MtdSimTracksterCollection>"/>
@@ -62,11 +62,11 @@
   <class name="MtdSimTracksterRefProd"/>
   <class name="MtdSimTracksterContainer"/>
 
-  <class name="SimTauCPLink" ClassVersion="3">
-   <version ClassVersion="3" checksum="213448491"/>
+  <class name="io_v1::SimTauCPLink" ClassVersion="3">
+   <version ClassVersion="3" checksum="308068769"/>
   </class>
-  <class name="std::vector<SimTauCPLink>"/>
-  <class name="edm::Wrapper<std::vector<SimTauCPLink> >" />
+  <class name="std::vector<io_v1::SimTauCPLink>"/>
+  <class name="edm::Wrapper<std::vector<io_v1::SimTauCPLink> >" />
 
   <class name="std::pair<uint64_t,float>"/>
   <class name="std::vector<std::pair<uint64_t,float>>"/>

--- a/SimDataFormats/CaloHit/interface/PCaloHit.h
+++ b/SimDataFormats/CaloHit/interface/PCaloHit.h
@@ -7,73 +7,76 @@
 
 // Persistent Calorimeter hit
 
-class PCaloHit {
-public:
-  PCaloHit(float e = 0., float t = 0., int i = 0, float emFraction = 1., uint16_t d = 0)
-      : myEnergy(e), myEMFraction(emFraction), myTime(t), myItra(i), myDepth(d) {}
+namespace io_v1 {
+  class PCaloHit {
+  public:
+    PCaloHit(float e = 0., float t = 0., int i = 0, float emFraction = 1., uint16_t d = 0)
+        : myEnergy(e), myEMFraction(emFraction), myTime(t), myItra(i), myDepth(d) {}
 
-  PCaloHit(unsigned int id, float e = 0., float t = 0., int i = 0, float emFraction = 1., uint16_t d = 0)
-      : myEnergy(e), myEMFraction(emFraction), myTime(t), myItra(i), detId(id), myDepth(d) {}
-  PCaloHit(float eEM, float eHad, float t, int i = 0, uint16_t d = 0);
-  PCaloHit(unsigned int id, float eEM, float eHad, float t, int i = 0, uint16_t d = 0);
+    PCaloHit(unsigned int id, float e = 0., float t = 0., int i = 0, float emFraction = 1., uint16_t d = 0)
+        : myEnergy(e), myEMFraction(emFraction), myTime(t), myItra(i), detId(id), myDepth(d) {}
+    PCaloHit(float eEM, float eHad, float t, int i = 0, uint16_t d = 0);
+    PCaloHit(unsigned int id, float eEM, float eHad, float t, int i = 0, uint16_t d = 0);
 
-  //Names
-  static const char *name() { return "Hit"; }
+    //Names
+    static const char *name() { return "Hit"; }
 
-  const char *getName() const { return name(); }
+    const char *getName() const { return name(); }
 
-  //Energy deposit of the Hit
-  double energy() const { return myEnergy; }
-  double energyEM() const { return myEMFraction * myEnergy; }
-  double energyHad() const { return (1. - myEMFraction) * myEnergy; }
-  void setEnergy(double e) { myEnergy = e; }
+    //Energy deposit of the Hit
+    double energy() const { return myEnergy; }
+    double energyEM() const { return myEMFraction * myEnergy; }
+    double energyHad() const { return (1. - myEMFraction) * myEnergy; }
+    void setEnergy(double e) { myEnergy = e; }
 
-  //Time of the deposit
-  double time() const { return myTime; }
+    //Time of the deposit
+    double time() const { return myTime; }
 
-  //Geant track number
-  int geantTrackId() const { return myItra; }
+    //Geant track number
+    int geantTrackId() const { return myItra; }
 
-  //DetId where the Hit is recorded
-  void setID(unsigned int id) { detId = id; }
-  unsigned int id() const { return detId; }
+    //DetId where the Hit is recorded
+    void setID(unsigned int id) { detId = id; }
+    unsigned int id() const { return detId; }
 
-  //Encoded depth in the detector
-  //for ECAL: # radiation length, 30 == APD
-  //for HCAL:
-  void setDepth(uint16_t depth) { myDepth = depth; }
-  uint16_t depth() const { return myDepth; }
+    //Encoded depth in the detector
+    //for ECAL: # radiation length, 30 == APD
+    //for HCAL:
+    void setDepth(uint16_t depth) { myDepth = depth; }
+    uint16_t depth() const { return myDepth; }
 
-  //Event Id (for signal/pileup discrimination)
+    //Event Id (for signal/pileup discrimination)
 
-  void setEventId(EncodedEventId e) { theEventId = e; }
-  EncodedEventId eventId() const { return theEventId; }
+    void setEventId(EncodedEventId e) { theEventId = e; }
+    EncodedEventId eventId() const { return theEventId; }
 
-  // new method used by the new transient CF
-  void setTime(float t) { myTime = t; }
+    // new method used by the new transient CF
+    void setTime(float t) { myTime = t; }
 
-  //Comparisons
+    //Comparisons
 
-  bool operator<(const PCaloHit &d) const { return myEnergy < d.myEnergy; }
+    bool operator<(const PCaloHit &d) const { return myEnergy < d.myEnergy; }
 
-  //Same Hit (by value)
-  bool operator==(const PCaloHit &d) const { return (myEnergy == d.myEnergy && detId == d.detId); }
+    //Same Hit (by value)
+    bool operator==(const PCaloHit &d) const { return (myEnergy == d.myEnergy && detId == d.detId); }
 
-  static const int kEcalDepthIdMask = 0x3;
-  static const int kEcalDepthMask = 0x1FFF;
-  static const int kEcalDepthOffset = 3;
-  static const int kEcalDepthRefz = 0X4;
+    static const int kEcalDepthIdMask = 0x3;
+    static const int kEcalDepthMask = 0x1FFF;
+    static const int kEcalDepthOffset = 3;
+    static const int kEcalDepthRefz = 0X4;
 
-protected:
-  float myEnergy;
-  float myEMFraction;
-  float myTime;
-  int myItra;
-  unsigned int detId;
-  uint16_t myDepth;
-  EncodedEventId theEventId;
-};
+  protected:
+    float myEnergy;
+    float myEMFraction;
+    float myTime;
+    int myItra;
+    unsigned int detId;
+    uint16_t myDepth;
+    EncodedEventId theEventId;
+  };
 
-std::ostream &operator<<(std::ostream &, const PCaloHit &);
+  std::ostream &operator<<(std::ostream &, const PCaloHit &);
+}  // namespace io_v1
+using PCaloHit = io_v1::PCaloHit;
 
 #endif  // _SimDataFormats_SimCaloHit_PCaloHit_h_

--- a/SimDataFormats/CaloHit/interface/PCaloHitFwd.h
+++ b/SimDataFormats/CaloHit/interface/PCaloHitFwd.h
@@ -1,6 +1,9 @@
 #ifndef SimDataFormats_CaloHit_PCaloHitFwd_h
 #define SimDataFormats_CaloHit_PCaloHitFwd_h
 
-class PCaloHit;
+namespace io_v1 {
+  class PCaloHit;
+}  // namespace io_v1
+using PCaloHit = io_v1::PCaloHit;
 
 #endif

--- a/SimDataFormats/CaloHit/src/PCaloHit.cc
+++ b/SimDataFormats/CaloHit/src/PCaloHit.cc
@@ -1,22 +1,24 @@
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
 #include <iostream>
 
-PCaloHit::PCaloHit(float eEM, float eHad, float t, int i, uint16_t d) : myTime(t), myItra(i), myDepth(d) {
-  myEnergy = eEM + eHad;
-  myEMFraction = (myEnergy <= 0.f ? 1.f : eEM / myEnergy);
-}
+namespace io_v1 {
+  PCaloHit::PCaloHit(float eEM, float eHad, float t, int i, uint16_t d) : myTime(t), myItra(i), myDepth(d) {
+    myEnergy = eEM + eHad;
+    myEMFraction = (myEnergy <= 0.f ? 1.f : eEM / myEnergy);
+  }
 
-PCaloHit::PCaloHit(unsigned int id, float eEM, float eHad, float t, int i, uint16_t d)
-    : myTime(t), myItra(i), detId(id), myDepth(d) {
-  myEnergy = eEM + eHad;
-  myEMFraction = (myEnergy <= 0.f ? 1.f : eEM / myEnergy);
-}
+  PCaloHit::PCaloHit(unsigned int id, float eEM, float eHad, float t, int i, uint16_t d)
+      : myTime(t), myItra(i), detId(id), myDepth(d) {
+    myEnergy = eEM + eHad;
+    myEMFraction = (myEnergy <= 0.f ? 1.f : eEM / myEnergy);
+  }
 
-std::ostream& operator<<(std::ostream& o, const PCaloHit& hit) {
-  o << "0x" << std::hex << hit.id() << std::dec << ": Energy (EM) " << hit.energyEM() << " GeV "
-    << ": Energy (Had) " << hit.energyHad() << " GeV "
-    << " Tof " << hit.time() << " ns "
-    << " Geant track #" << hit.geantTrackId() << " Encoded depth " << hit.depth();
+  std::ostream& operator<<(std::ostream& o, const PCaloHit& hit) {
+    o << "0x" << std::hex << hit.id() << std::dec << ": Energy (EM) " << hit.energyEM() << " GeV "
+      << ": Energy (Had) " << hit.energyHad() << " GeV "
+      << " Tof " << hit.time() << " ns "
+      << " Geant track #" << hit.geantTrackId() << " Encoded depth " << hit.depth();
 
-  return o;
-}
+    return o;
+  }
+}  // namespace io_v1

--- a/SimDataFormats/CaloHit/src/classes_def.xml
+++ b/SimDataFormats/CaloHit/src/classes_def.xml
@@ -1,10 +1,10 @@
 <lcgdict>
-  <class name="PCaloHit" ClassVersion="10">
-   <version ClassVersion="10" checksum="682759659"/>
+  <class name="io_v1::PCaloHit" ClassVersion="3">
+   <version ClassVersion="3" checksum="2244110187"/>
   </class>
-  <class name="std::vector<PCaloHit>"/>
-  <class name="std::vector<const PCaloHit*>"/>
-  <class name="edm::Wrapper<std::vector<PCaloHit>>" splitLevel="0"/>
+  <class name="std::vector<io_v1::PCaloHit>"/>
+  <class name="std::vector<const io_v1::PCaloHit*>"/>
+  <class name="edm::Wrapper<std::vector<io_v1::PCaloHit>>" splitLevel="0"/>
   <class name="HFShowerPhoton" ClassVersion="10">
    <version ClassVersion="10" checksum="3736969110"/>
   </class>

--- a/SimDataFormats/Track/interface/SimTrack.h
+++ b/SimDataFormats/Track/interface/SimTrack.h
@@ -8,88 +8,91 @@
 
 #include <iosfwd>
 
-class SimTrack : public CoreSimTrack {
-public:
-  typedef CoreSimTrack Core;
+namespace io_v1 {
+  class SimTrack : public CoreSimTrack {
+  public:
+    typedef CoreSimTrack Core;
 
-  /// constructor
-  SimTrack();
-  SimTrack(int ipart, const math::XYZTLorentzVectorD& p);
+    /// constructor
+    SimTrack();
+    SimTrack(int ipart, const math::XYZTLorentzVectorD& p);
 
-  /// full constructor (pdg type, momentum, time,
-  /// index of parent vertex in final vector
-  /// index of corresponding gen part in final vector)
-  SimTrack(int ipart, const math::XYZTLorentzVectorD& p, int iv, int ig);
+    /// full constructor (pdg type, momentum, time,
+    /// index of parent vertex in final vector
+    /// index of corresponding gen part in final vector)
+    SimTrack(int ipart, const math::XYZTLorentzVectorD& p, int iv, int ig);
 
-  SimTrack(int ipart,
-           const math::XYZTLorentzVectorD& p,
-           int iv,
-           int ig,
-           const math::XYZVectorD& tkp,
-           const math::XYZTLorentzVectorD& tkm);
+    SimTrack(int ipart,
+             const math::XYZTLorentzVectorD& p,
+             int iv,
+             int ig,
+             const math::XYZVectorD& tkp,
+             const math::XYZTLorentzVectorD& tkm);
 
-  /// constructor from transient
-  SimTrack(const CoreSimTrack& t, int iv, int ig);
+    /// constructor from transient
+    SimTrack(const CoreSimTrack& t, int iv, int ig);
 
-  /// index of the vertex in the Event container (-1 if no vertex)
-  int vertIndex() const { return ivert; }
-  bool noVertex() const { return ivert == -1; }
+    /// index of the vertex in the Event container (-1 if no vertex)
+    int vertIndex() const { return ivert; }
+    bool noVertex() const { return ivert == -1; }
 
-  /// index of the corresponding Generator particle in the Event container (-1 if no Genpart)
-  bool isPrimary() const { return (trackInfo_ >> 1) & 1; }
-  int genpartIndex() const { return isPrimary() ? igenpart : -1; }
-  bool noGenpart() const { return isPrimary() ? igenpart == -1 : true; }
+    /// index of the corresponding Generator particle in the Event container (-1 if no Genpart)
+    bool isPrimary() const { return (trackInfo_ >> 1) & 1; }
+    int genpartIndex() const { return isPrimary() ? igenpart : -1; }
+    bool noGenpart() const { return isPrimary() ? igenpart == -1 : true; }
 
-  const math::XYZVectorD& trackerSurfacePosition() const { return tkposition; }
+    const math::XYZVectorD& trackerSurfacePosition() const { return tkposition; }
 
-  const math::XYZTLorentzVectorD& trackerSurfaceMomentum() const { return tkmomentum; }
+    const math::XYZTLorentzVectorD& trackerSurfaceMomentum() const { return tkmomentum; }
 
-  inline void setTkPosition(const math::XYZVectorD& pos) { tkposition = pos; }
+    inline void setTkPosition(const math::XYZVectorD& pos) { tkposition = pos; }
 
-  inline void setTkMomentum(const math::XYZTLorentzVectorD& mom) { tkmomentum = mom; }
+    inline void setTkMomentum(const math::XYZTLorentzVectorD& mom) { tkmomentum = mom; }
 
-  inline void setVertexIndex(const int v) { ivert = v; }
+    inline void setVertexIndex(const int v) { ivert = v; }
 
-  void setCrossedBoundaryVars(bool crossedBoundary,
-                              int idAtBoundary,
-                              math::XYZTLorentzVectorF positionAtBoundary,
-                              math::XYZTLorentzVectorF momentumAtBoundary) {
-    if (crossedBoundary)
-      trackInfo_ |= (1 << 2);
-    idAtBoundary_ = idAtBoundary;
-    positionAtBoundary_ = positionAtBoundary;
-    momentumAtBoundary_ = momentumAtBoundary;
-  }
-  bool crossedBoundary() const { return (trackInfo_ >> 2) & 1; }
-  const math::XYZTLorentzVectorF& getPositionAtBoundary() const { return positionAtBoundary_; }
-  const math::XYZTLorentzVectorF& getMomentumAtBoundary() const { return momentumAtBoundary_; }
-  int getIDAtBoundary() const { return idAtBoundary_; }
+    void setCrossedBoundaryVars(bool crossedBoundary,
+                                int idAtBoundary,
+                                math::XYZTLorentzVectorF positionAtBoundary,
+                                math::XYZTLorentzVectorF momentumAtBoundary) {
+      if (crossedBoundary)
+        trackInfo_ |= (1 << 2);
+      idAtBoundary_ = idAtBoundary;
+      positionAtBoundary_ = positionAtBoundary;
+      momentumAtBoundary_ = momentumAtBoundary;
+    }
+    bool crossedBoundary() const { return (trackInfo_ >> 2) & 1; }
+    const math::XYZTLorentzVectorF& getPositionAtBoundary() const { return positionAtBoundary_; }
+    const math::XYZTLorentzVectorF& getMomentumAtBoundary() const { return momentumAtBoundary_; }
+    int getIDAtBoundary() const { return idAtBoundary_; }
 
-  bool isFromBackScattering() const { return trackInfo_ & 1; }
-  void setFromBackScattering() { trackInfo_ |= 1; }
+    bool isFromBackScattering() const { return trackInfo_ & 1; }
+    void setFromBackScattering() { trackInfo_ |= 1; }
 
-  void setIsPrimary() { trackInfo_ |= (1 << 1); }
-  void setGenParticleID(const int idx) { igenpart = idx; }
-  int getPrimaryOrLastStoredID() const { return igenpart; }
-  uint8_t getTrackInfo() const { return trackInfo_; }
+    void setIsPrimary() { trackInfo_ |= (1 << 1); }
+    void setGenParticleID(const int idx) { igenpart = idx; }
+    int getPrimaryOrLastStoredID() const { return igenpart; }
+    uint8_t getTrackInfo() const { return trackInfo_; }
 
-private:
-  int ivert;
-  int igenpart;
+  private:
+    int ivert;
+    int igenpart;
 
-  math::XYZVectorD tkposition;
-  math::XYZTLorentzVectorD tkmomentum;
+    math::XYZVectorD tkposition;
+    math::XYZTLorentzVectorD tkmomentum;
 
-  int idAtBoundary_{-1};
-  math::XYZTLorentzVectorF positionAtBoundary_;
-  math::XYZTLorentzVectorF momentumAtBoundary_;
-  uint8_t trackInfo_;
-  // explanation of trackInfo bits:
-  // 00000001 = simTrack is from backscattering
-  // 00000010 = simTrack is of a primary particle
-  // 00000100 = simTrack crossed the boundary
-};
+    int idAtBoundary_{-1};
+    math::XYZTLorentzVectorF positionAtBoundary_;
+    math::XYZTLorentzVectorF momentumAtBoundary_;
+    uint8_t trackInfo_;
+    // explanation of trackInfo bits:
+    // 00000001 = simTrack is from backscattering
+    // 00000010 = simTrack is of a primary particle
+    // 00000100 = simTrack crossed the boundary
+  };
 
-std::ostream& operator<<(std::ostream& o, const SimTrack& t);
+  std::ostream& operator<<(std::ostream& o, const SimTrack& t);
+}  // namespace io_v1
+using SimTrack = io_v1::SimTrack;
 
 #endif

--- a/SimDataFormats/Track/interface/SimTrackFwd.h
+++ b/SimDataFormats/Track/interface/SimTrackFwd.h
@@ -1,6 +1,9 @@
 #ifndef SimDataFormats_Track_SimTrackFwd_h
 #define SimDataFormats_Track_SimTrackFwd_h
 
-class SimTrack;
+namespace io_v1 {
+  class SimTrack;
+}  // namespace io_v1
+using SimTrack = io_v1::SimTrack;
 
 #endif

--- a/SimDataFormats/Track/src/SimTrack.cc
+++ b/SimDataFormats/Track/src/SimTrack.cc
@@ -1,23 +1,25 @@
 #include "SimDataFormats/Track/interface/SimTrack.h"
 
-SimTrack::SimTrack() : ivert(-1), igenpart(-1), trackInfo_(0) {}
+namespace io_v1 {
+  SimTrack::SimTrack() : ivert(-1), igenpart(-1), trackInfo_(0) {}
 
-SimTrack::SimTrack(int ipart, const math::XYZTLorentzVectorD& p)
-    : Core(ipart, p), ivert(-1), igenpart(-1), trackInfo_(0) {}
+  SimTrack::SimTrack(int ipart, const math::XYZTLorentzVectorD& p)
+      : Core(ipart, p), ivert(-1), igenpart(-1), trackInfo_(0) {}
 
-SimTrack::SimTrack(int ipart, const math::XYZTLorentzVectorD& p, int iv, int ig)
-    : Core(ipart, p), ivert(iv), igenpart(ig), trackInfo_(0) {}
+  SimTrack::SimTrack(int ipart, const math::XYZTLorentzVectorD& p, int iv, int ig)
+      : Core(ipart, p), ivert(iv), igenpart(ig), trackInfo_(0) {}
 
-SimTrack::SimTrack(int ipart,
-                   const math::XYZTLorentzVectorD& p,
-                   int iv,
-                   int ig,
-                   const math::XYZVectorD& tkp,
-                   const math::XYZTLorentzVectorD& tkm)
-    : Core(ipart, p), ivert(iv), igenpart(ig), tkposition(tkp), tkmomentum(tkm), trackInfo_(0) {}
+  SimTrack::SimTrack(int ipart,
+                     const math::XYZTLorentzVectorD& p,
+                     int iv,
+                     int ig,
+                     const math::XYZVectorD& tkp,
+                     const math::XYZTLorentzVectorD& tkm)
+      : Core(ipart, p), ivert(iv), igenpart(ig), tkposition(tkp), tkmomentum(tkm), trackInfo_(0) {}
 
-SimTrack::SimTrack(const CoreSimTrack& t, int iv, int ig) : Core(t), ivert(iv), igenpart(ig), trackInfo_(0) {}
+  SimTrack::SimTrack(const CoreSimTrack& t, int iv, int ig) : Core(t), ivert(iv), igenpart(ig), trackInfo_(0) {}
 
-std::ostream& operator<<(std::ostream& o, const SimTrack& t) {
-  return o << (SimTrack::Core)(t) << ", " << t.vertIndex() << ", " << t.genpartIndex();
-}
+  std::ostream& operator<<(std::ostream& o, const SimTrack& t) {
+    return o << (SimTrack::Core)(t) << ", " << t.vertIndex() << ", " << t.genpartIndex();
+  }
+}  // namespace io_v1

--- a/SimDataFormats/Track/src/classes_def.xml
+++ b/SimDataFormats/Track/src/classes_def.xml
@@ -1,35 +1,14 @@
 <lcgdict>
-  <class name="std::vector<SimTrack>"/>
-  <class name="std::vector<const SimTrack*>"/>
-  <class name="CoreSimTrack" ClassVersion="10">
-   <version ClassVersion="10" checksum="3936841839"/>
+  <class name="std::vector<io_v1::SimTrack>"/>
+  <class name="std::vector<const io_v1::SimTrack*>"/>
+  <class name="CoreSimTrack" ClassVersion="3">
+   <version ClassVersion="3" checksum="3936841839"/>
   </class>
-  <class name="SimTrack" ClassVersion="13">
-   <version ClassVersion="13" checksum="1912247222"/>
-   <version ClassVersion="12" checksum="3470347245"/>
-   <version ClassVersion="11" checksum="1785575744"/>
-   <version ClassVersion="10" checksum="1430205451"/>
-   <ioread sourceClass = "SimTrack" version="[12]" targetClass="SimTrack" source="bool crossedBoundary_; int idAtBoundary_; math::XYZTLorentzVectorF positionAtBoundary_; math::XYZTLorentzVectorF momentumAtBoundary_; int igenpart" target="trackInfo_, idAtBoundary_, positionAtBoundary_, momentumAtBoundary_">
-    <![CDATA[
-        // set crossedBoundary infos
-        newObj->setCrossedBoundaryVars(onfile.crossedBoundary_, onfile.idAtBoundary_, onfile.positionAtBoundary_, onfile.momentumAtBoundary_);
-        // set isPrimary info of trackInfo_
-        if (onfile.igenpart != -1)
-          newObj->setIsPrimary();
-        // it's not possible to set the isFromBackScattering info for old simTracks
-    ]]>
-   </ioread>
-   <ioread sourceClass = "SimTrack" version="[-11]" targetClass="SimTrack" source="int igenpart" target="trackInfo_">
-    <![CDATA[
-        // set isPrimary info of trackInfo_
-        if (onfile.igenpart != -1)
-          newObj->setIsPrimary();
-        // it's not possible to set the isFromBackScattering and crossedBoundary info for old simTracks
-    ]]>
-   </ioread>
+  <class name="io_v1::SimTrack" ClassVersion="3">
+   <version ClassVersion="3" checksum="3720294710"/>
   </class>
-  <class name="edm::Wrapper<std::vector<SimTrack> >" />
-  <class name="edm::RefProd<std::vector<SimTrack> >"/>
-  <class name="edm::Ref<std::vector<SimTrack>,SimTrack,edm::refhelper::FindUsingAdvance<std::vector<SimTrack>,SimTrack> >"/>
-  <class name="edm::RefVector<std::vector<SimTrack>,SimTrack,edm::refhelper::FindUsingAdvance<std::vector<SimTrack>,SimTrack> >"/>
+  <class name="edm::Wrapper<std::vector<io_v1::SimTrack> >" />
+  <class name="edm::RefProd<std::vector<io_v1::SimTrack> >"/>
+  <class name="edm::Ref<std::vector<io_v1::SimTrack>,io_v1::SimTrack,edm::refhelper::FindUsingAdvance<std::vector<io_v1::SimTrack>,io_v1::SimTrack> >"/>
+  <class name="edm::RefVector<std::vector<io_v1::SimTrack>,io_v1::SimTrack,edm::refhelper::FindUsingAdvance<std::vector<io_v1::SimTrack>,io_v1::SimTrack> >"/>
 </lcgdict>

--- a/SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h
+++ b/SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h
@@ -2,11 +2,11 @@
 #define SimDataFormats_TrackingParticle_h
 
 #include <vector>
-#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 #include "DataFormats/Math/interface/Point3D.h"
 #include "DataFormats/Math/interface/Vector3D.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexFwd.h"
 #include "SimDataFormats/Track/interface/SimTrackFwd.h"
@@ -22,226 +22,229 @@
  * some tweaking and documentation by Mark Grimes (mark.grimes@bristol.ac.uk).
  * @date original date unknown, re-engineering Jan-May 2013
  */
-class TrackingParticle {
-  friend std::ostream& operator<<(std::ostream& s, TrackingParticle const& tp);
+namespace io_v1 {
+  class TrackingParticle {
+    friend std::ostream& operator<<(std::ostream& s, TrackingParticle const& tp);
 
-public:
-  typedef int Charge;                                       ///< electric charge type
-  typedef math::XYZTLorentzVectorD LorentzVector;           ///< Lorentz vector
-  typedef math::PtEtaPhiMLorentzVector PolarLorentzVector;  ///< Lorentz vector
-  typedef math::XYZPointD Point;                            ///< point in the space
-  typedef math::XYZVectorD Vector;                          ///< point in the space
+  public:
+    typedef int Charge;                                       ///< electric charge type
+    typedef math::XYZTLorentzVectorD LorentzVector;           ///< Lorentz vector
+    typedef math::PtEtaPhiMLorentzVector PolarLorentzVector;  ///< Lorentz vector
+    typedef math::XYZPointD Point;                            ///< point in the space
+    typedef math::XYZVectorD Vector;                          ///< point in the space
 
-  /// reference to reco::GenParticle
-  typedef reco::GenParticleRefVector::iterator genp_iterator;
-  typedef std::vector<SimTrack>::const_iterator g4t_iterator;
+    /// reference to reco::GenParticle
+    typedef reco::GenParticleRefVector::iterator genp_iterator;
+    typedef std::vector<SimTrack>::const_iterator g4t_iterator;
 
-  /** @brief Default constructor. Note that the object will be useless until it is provided
+    /** @brief Default constructor. Note that the object will be useless until it is provided
      * with a SimTrack and parent TrackingVertex.
      *
      * Most of the methods assume there is a SimTrack and parent TrackingVertex set, so will either
      * crash or give undefined results if this isn't true. This constructor should only be used to
      * create a placeholder until setParentVertex() and addG4Track() can be called.
      */
-  TrackingParticle();
+    TrackingParticle();
 
-  TrackingParticle(const SimTrack& simtrk, const TrackingVertexRef& parentVertex);
+    TrackingParticle(const SimTrack& simtrk, const TrackingVertexRef& parentVertex);
 
-  // destructor
-  ~TrackingParticle();
+    // destructor
+    ~TrackingParticle();
 
-  /** @brief PDG ID.
+    /** @brief PDG ID.
      *
      * Returns the PDG ID of the first associated gen particle. If there are no gen particles associated
      * then it returns type() from the first SimTrack. */
-  int pdgId() const {
-    if (genParticles_.empty())
-      return g4Tracks_[0].type();
-    else
-      return (*genParticles_.begin())->pdgId();
-  }
+    int pdgId() const {
+      if (genParticles_.empty())
+        return g4Tracks_[0].type();
+      else
+        return (*genParticles_.begin())->pdgId();
+    }
 
-  /** @brief Signal source, crossing number.
+    /** @brief Signal source, crossing number.
      *
      * Note this is taken from the first SimTrack only, but there shouldn't be any SimTracks from different
      * crossings in the TrackingParticle. */
-  EncodedEventId eventId() const { return g4Tracks_[0].eventId(); }
+    EncodedEventId eventId() const { return g4Tracks_[0].eventId(); }
 
-  // Setters for G4 and reco::GenParticle
-  void addGenParticle(const reco::GenParticleRef& ref);
-  void addG4Track(const SimTrack& t);
-  /// iterators
-  genp_iterator genParticle_begin() const;
-  genp_iterator genParticle_end() const;
-  g4t_iterator g4Track_begin() const;
-  g4t_iterator g4Track_end() const;
-  void setParentVertex(const TrackingVertexRef& ref);
-  void addDecayVertex(const TrackingVertexRef& ref);
-  void clearParentVertex();
-  void clearDecayVertices();
+    // Setters for G4 and reco::GenParticle
+    void addGenParticle(const reco::GenParticleRef& ref);
+    void addG4Track(const SimTrack& t);
+    /// iterators
+    genp_iterator genParticle_begin() const;
+    genp_iterator genParticle_end() const;
+    g4t_iterator g4Track_begin() const;
+    g4t_iterator g4Track_end() const;
+    void setParentVertex(const TrackingVertexRef& ref);
+    void addDecayVertex(const TrackingVertexRef& ref);
+    void clearParentVertex();
+    void clearDecayVertices();
 
-  // Getters for Embd and Sim Tracks
-  const reco::GenParticleRefVector& genParticles() const { return genParticles_; }
-  const std::vector<SimTrack>& g4Tracks() const { return g4Tracks_; }
-  const TrackingVertexRef& parentVertex() const { return parentVertex_; }
+    // Getters for Embd and Sim Tracks
+    const reco::GenParticleRefVector& genParticles() const { return genParticles_; }
+    const std::vector<SimTrack>& g4Tracks() const { return g4Tracks_; }
+    const TrackingVertexRef& parentVertex() const { return parentVertex_; }
 
-  // Accessors for vector of decay vertices
-  const TrackingVertexRefVector& decayVertices() const { return decayVertices_; }
-  tv_iterator decayVertices_begin() const { return decayVertices_.begin(); }
-  tv_iterator decayVertices_end() const { return decayVertices_.end(); }
+    // Accessors for vector of decay vertices
+    const TrackingVertexRefVector& decayVertices() const { return decayVertices_; }
+    tv_iterator decayVertices_begin() const { return decayVertices_.begin(); }
+    tv_iterator decayVertices_end() const { return decayVertices_.end(); }
 
-  /// @brief Electric charge. Note this is taken from the first SimTrack only.
-  float charge() const { return g4Tracks_[0].charge(); }
-  /// Gives charge in unit of quark charge (should be 3 times "charge()")
-  int threeCharge() const { return lrintf(3.f * charge()); }
+    /// @brief Electric charge. Note this is taken from the first SimTrack only.
+    float charge() const { return g4Tracks_[0].charge(); }
+    /// Gives charge in unit of quark charge (should be 3 times "charge()")
+    int threeCharge() const { return lrintf(3.f * charge()); }
 
-  /// @brief Four-momentum Lorentz vector. Note this is taken from the first SimTrack only.
-  const LorentzVector& p4() const { return g4Tracks_[0].momentum(); }
+    /// @brief Four-momentum Lorentz vector. Note this is taken from the first SimTrack only.
+    const LorentzVector& p4() const { return g4Tracks_[0].momentum(); }
 
-  /// @brief spatial momentum vector
-  Vector momentum() const { return p4().Vect(); }
+    /// @brief spatial momentum vector
+    Vector momentum() const { return p4().Vect(); }
 
-  /// @brief Vector to boost to the particle centre of mass frame.
-  Vector boostToCM() const { return p4().BoostToCM(); }
+    /// @brief Vector to boost to the particle centre of mass frame.
+    Vector boostToCM() const { return p4().BoostToCM(); }
 
-  /// @brief Magnitude of momentum vector. Note this is taken from the first SimTrack only.
-  double p() const { return p4().P(); }
+    /// @brief Magnitude of momentum vector. Note this is taken from the first SimTrack only.
+    double p() const { return p4().P(); }
 
-  /// @brief Quotient of the electric charge over the magnitude of the momentum vector. Note this is taken from the first SimTrack only.
-  double qoverp() const { return charge() / p(); }
+    /// @brief Quotient of the electric charge over the magnitude of the momentum vector. Note this is taken from the first SimTrack only.
+    double qoverp() const { return charge() / p(); }
 
-  /// @brief Energy. Note this is taken from the first SimTrack only.
-  double energy() const { return p4().E(); }
+    /// @brief Energy. Note this is taken from the first SimTrack only.
+    double energy() const { return p4().E(); }
 
-  /// @brief Transverse energy. Note this is taken from the first SimTrack only.
-  double et() const { return p4().Et(); }
+    /// @brief Transverse energy. Note this is taken from the first SimTrack only.
+    double et() const { return p4().Et(); }
 
-  /// @brief Mass. Note this is taken from the first SimTrack only.
-  double mass() const { return p4().M(); }
+    /// @brief Mass. Note this is taken from the first SimTrack only.
+    double mass() const { return p4().M(); }
 
-  /// @brief Mass squared. Note this is taken from the first SimTrack only.
-  double massSqr() const { return pow(mass(), 2); }
+    /// @brief Mass squared. Note this is taken from the first SimTrack only.
+    double massSqr() const { return pow(mass(), 2); }
 
-  /// @brief Transverse mass. Note this is taken from the first SimTrack only.
-  double mt() const { return p4().Mt(); }
+    /// @brief Transverse mass. Note this is taken from the first SimTrack only.
+    double mt() const { return p4().Mt(); }
 
-  /// @brief Transverse mass squared. Note this is taken from the first SimTrack only.
-  double mtSqr() const { return p4().Mt2(); }
+    /// @brief Transverse mass squared. Note this is taken from the first SimTrack only.
+    double mtSqr() const { return p4().Mt2(); }
 
-  /// @brief x coordinate of momentum vector. Note this is taken from the first SimTrack only.
-  double px() const { return p4().Px(); }
+    /// @brief x coordinate of momentum vector. Note this is taken from the first SimTrack only.
+    double px() const { return p4().Px(); }
 
-  /// @brief y coordinate of momentum vector. Note this is taken from the first SimTrack only.
-  double py() const { return p4().Py(); }
+    /// @brief y coordinate of momentum vector. Note this is taken from the first SimTrack only.
+    double py() const { return p4().Py(); }
 
-  /// @brief z coordinate of momentum vector. Note this is taken from the first SimTrack only.
-  double pz() const { return p4().Pz(); }
+    /// @brief z coordinate of momentum vector. Note this is taken from the first SimTrack only.
+    double pz() const { return p4().Pz(); }
 
-  /// @brief Transverse momentum. Note this is taken from the first SimTrack only.
-  double pt() const { return p4().Pt(); }
+    /// @brief Transverse momentum. Note this is taken from the first SimTrack only.
+    double pt() const { return p4().Pt(); }
 
-  /// @brief Momentum azimuthal angle. Note this is taken from the first SimTrack only.
-  double phi() const { return p4().Phi(); }
+    /// @brief Momentum azimuthal angle. Note this is taken from the first SimTrack only.
+    double phi() const { return p4().Phi(); }
 
-  /// @brief Momentum polar angle. Note this is taken from the first SimTrack only.
-  double theta() const { return p4().Theta(); }
+    /// @brief Momentum polar angle. Note this is taken from the first SimTrack only.
+    double theta() const { return p4().Theta(); }
 
-  /// @brief Momentum pseudorapidity. Note this is taken from the first SimTrack only.
-  double eta() const { return p4().Eta(); }
+    /// @brief Momentum pseudorapidity. Note this is taken from the first SimTrack only.
+    double eta() const { return p4().Eta(); }
 
-  /// @brief Lambda angle. Note this is taken from the first SimTrack only.
-  double lambda() const { return M_PI_2 - theta(); }
+    /// @brief Lambda angle. Note this is taken from the first SimTrack only.
+    double lambda() const { return M_PI_2 - theta(); }
 
-  /// @brief tangent of the lambda angle. Note this is taken from the first SimTrack only.
-  double tanl() const { return tan(lambda()); }
+    /// @brief tangent of the lambda angle. Note this is taken from the first SimTrack only.
+    double tanl() const { return tan(lambda()); }
 
-  /// @brief Rapidity. Note this is taken from the first SimTrack only.
-  double rapidity() const { return p4().Rapidity(); }
+    /// @brief Rapidity. Note this is taken from the first SimTrack only.
+    double rapidity() const { return p4().Rapidity(); }
 
-  /// @brief Same as rapidity().
-  double y() const { return rapidity(); }
+    /// @brief Same as rapidity().
+    double y() const { return rapidity(); }
 
-  /// @brief Parent vertex position
-  Point vertex() const {
-    const TrackingVertex::LorentzVector& p = (*parentVertex_).position();
-    return Point(p.x(), p.y(), p.z());
-  }
+    /// @brief Parent vertex position
+    Point vertex() const {
+      const TrackingVertex::LorentzVector& p = (*parentVertex_).position();
+      return Point(p.x(), p.y(), p.z());
+    }
 
-  /// @brief x coordinate of parent vertex position
-  double vx() const {
-    const TrackingVertex& r = (*parentVertex_);
-    return r.position().X();
-  }
+    /// @brief x coordinate of parent vertex position
+    double vx() const {
+      const TrackingVertex& r = (*parentVertex_);
+      return r.position().X();
+    }
 
-  /// @brief y coordinate of parent vertex position
-  double vy() const {
-    const TrackingVertex& r = (*parentVertex_);
-    return r.position().Y();
-  }
+    /// @brief y coordinate of parent vertex position
+    double vy() const {
+      const TrackingVertex& r = (*parentVertex_);
+      return r.position().Y();
+    }
 
-  /// @brief z coordinate of parent vertex position
-  double vz() const {
-    const TrackingVertex& r = (*parentVertex_);
-    return r.position().Z();
-  }
+    /// @brief z coordinate of parent vertex position
+    double vz() const {
+      const TrackingVertex& r = (*parentVertex_);
+      return r.position().Z();
+    }
 
-  /// @brief dxy parameter.
-  double dxy() const { return (-vx() * py() + vy() * px()) / pt(); }
+    /// @brief dxy parameter.
+    double dxy() const { return (-vx() * py() + vy() * px()) / pt(); }
 
-  /// @brief dxy parameter in perigee convention (d0 = -dxy)
-  double d0() const { return -dxy(); }
+    /// @brief dxy parameter in perigee convention (d0 = -dxy)
+    double d0() const { return -dxy(); }
 
-  /// @brief dz parameter (= dsz/cos(lambda)). This is the track z0 w.r.t (0,0,0) only if the refPoint is close to (0,0,0).
-  double dz() const { return vz() - (vx() * px() + vy() * py()) * pz() / p4().Perp2(); }
+    /// @brief dz parameter (= dsz/cos(lambda)). This is the track z0 w.r.t (0,0,0) only if the refPoint is close to (0,0,0).
+    double dz() const { return vz() - (vx() * px() + vy() * py()) * pz() / p4().Perp2(); }
 
-  /// @brief z0 parameter
-  double z0() const { return dz(); }
+    /// @brief z0 parameter
+    double z0() const { return dz(); }
 
-  /** @brief Status word.
+    /** @brief Status word.
      *
      * Returns status() from the first gen particle, or -99 if there are no gen particles attached. */
-  int status() const { return genParticles_.empty() ? -99 : (*genParticles_[0]).status(); }
+    int status() const { return genParticles_.empty() ? -99 : (*genParticles_[0]).status(); }
 
-  static const unsigned int longLivedTag;  ///< long lived flag
+    static const unsigned int longLivedTag;  ///< long lived flag
 
-  /// is long lived?
-  bool longLived() const { return status() & longLivedTag; }
+    /// is long lived?
+    bool longLived() const { return status() & longLivedTag; }
 
-  /** @brief Gives the total number of hits, including muon hits. Hits on overlaps in the same layer count separately.
+    /** @brief Gives the total number of hits, including muon hits. Hits on overlaps in the same layer count separately.
     *
     * Equivalent to trackPSimHit().size() in the old TrackingParticle implementation. */
-  int numberOfHits() const { return numberOfHits_; }
+    int numberOfHits() const { return numberOfHits_; }
 
-  /** @brief The number of hits in the tracker. Hits on overlaps in the same layer count separately.
+    /** @brief The number of hits in the tracker. Hits on overlaps in the same layer count separately.
     *
     * Equivalent to trackPSimHit(DetId::Tracker).size() in the old TrackingParticle implementation. */
-  int numberOfTrackerHits() const { return numberOfTrackerHits_; }
+    int numberOfTrackerHits() const { return numberOfTrackerHits_; }
 
-  /** @deprecated The number of hits in the tracker but taking account of overlaps.
+    /** @deprecated The number of hits in the tracker but taking account of overlaps.
     * Deprecated in favour of the more aptly named numberOfTrackerLayers(). */
-  int matchedHit() const;
+    int matchedHit() const;
 
-  /** @brief The number of tracker layers with a hit.
+    /** @brief The number of tracker layers with a hit.
     *
     * Different from numberOfTrackerHits because this method counts multiple hits on overlaps in the layer as one hit. */
-  int numberOfTrackerLayers() const { return numberOfTrackerLayers_; }
+    int numberOfTrackerLayers() const { return numberOfTrackerLayers_; }
 
-  void setNumberOfHits(int numberOfHits);
-  void setNumberOfTrackerHits(int numberOfTrackerHits);
-  void setNumberOfTrackerLayers(const int numberOfTrackerLayers);
+    void setNumberOfHits(int numberOfHits);
+    void setNumberOfTrackerHits(int numberOfTrackerHits);
+    void setNumberOfTrackerLayers(const int numberOfTrackerLayers);
 
-private:
-  int numberOfHits_;           ///< @brief The total number of hits
-  int numberOfTrackerHits_;    ///< @brief The number of tracker only hits
-  int numberOfTrackerLayers_;  ///< @brief The number of tracker layers with hits. Equivalent to the old matchedHit.
+  private:
+    int numberOfHits_;           ///< @brief The total number of hits
+    int numberOfTrackerHits_;    ///< @brief The number of tracker only hits
+    int numberOfTrackerLayers_;  ///< @brief The number of tracker layers with hits. Equivalent to the old matchedHit.
 
-  /// references to G4 and reco::GenParticle tracks
-  std::vector<SimTrack> g4Tracks_;
-  reco::GenParticleRefVector genParticles_;
+    /// references to G4 and reco::GenParticle tracks
+    std::vector<SimTrack> g4Tracks_;
+    reco::GenParticleRefVector genParticles_;
 
-  // Source and decay vertices
-  TrackingVertexRef parentVertex_;
-  TrackingVertexRefVector decayVertices_;
-};
+    // Source and decay vertices
+    TrackingVertexRef parentVertex_;
+    TrackingVertexRefVector decayVertices_;
+  };
+}  // namespace io_v1
+using TrackingParticle = io_v1::TrackingParticle;
 
 #endif  // SimDataFormats_TrackingParticle_H

--- a/SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h
+++ b/SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h
@@ -6,8 +6,11 @@
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/RefProd.h"
 
-class TrackingParticle;
-std::ostream& operator<<(std::ostream& s, TrackingParticle const& tp);
+namespace io_v1 {
+  class TrackingParticle;
+  std::ostream& operator<<(std::ostream& s, TrackingParticle const& tp);
+}  // namespace io_v1
+using TrackingParticle = io_v1::TrackingParticle;
 
 typedef std::vector<TrackingParticle> TrackingParticleCollection;
 typedef edm::Ptr<TrackingParticle> TrackingParticlePtr;

--- a/SimDataFormats/TrackingAnalysis/interface/TrackingVertex.h
+++ b/SimDataFormats/TrackingAnalysis/interface/TrackingVertex.h
@@ -19,70 +19,73 @@
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 
-class TrackingVertex {
-  friend std::ostream& operator<<(std::ostream& s, const TrackingVertex& tv);
+namespace io_v1 {
+  class TrackingVertex {
+    friend std::ostream& operator<<(std::ostream& s, const TrackingVertex& tv);
 
-public:
-  typedef edm::RefVector<edm::HepMCProduct, HepMC::GenVertex> GenVertexRefVector;
-  typedef edm::Ref<edm::HepMCProduct, HepMC::GenVertex> GenVertexRef;
-  typedef math::XYZTLorentzVectorD LorentzVector;
-  typedef GenVertexRefVector::iterator genv_iterator;
-  typedef std::vector<SimVertex>::const_iterator g4v_iterator;
-  typedef TrackingParticleRefVector::iterator tp_iterator;
+  public:
+    typedef edm::RefVector<edm::HepMCProduct, HepMC::GenVertex> GenVertexRefVector;
+    typedef edm::Ref<edm::HepMCProduct, HepMC::GenVertex> GenVertexRef;
+    typedef math::XYZTLorentzVectorD LorentzVector;
+    typedef GenVertexRefVector::iterator genv_iterator;
+    typedef std::vector<SimVertex>::const_iterator g4v_iterator;
+    typedef TrackingParticleRefVector::iterator tp_iterator;
 
-  // Default constructor and constructor from values
-  TrackingVertex();
-  TrackingVertex(const LorentzVector& position, const bool inVolume, const EncodedEventId e = EncodedEventId(0));
+    // Default constructor and constructor from values
+    TrackingVertex();
+    TrackingVertex(const LorentzVector& position, const bool inVolume, const EncodedEventId e = EncodedEventId(0));
 
-  // Setters
-  void setEventId(EncodedEventId e) { eId_ = e; };
+    // Setters
+    void setEventId(EncodedEventId e) { eId_ = e; };
 
-  // Track and vertex iterators
-  genv_iterator genVertices_begin() const;  // Ref's to HepMC and Geant4
-  genv_iterator genVertices_end() const;    // vertices associated with
-  g4v_iterator g4Vertices_begin() const;    // this vertex, respectively
-  g4v_iterator g4Vertices_end() const;      // ....
+    // Track and vertex iterators
+    genv_iterator genVertices_begin() const;  // Ref's to HepMC and Geant4
+    genv_iterator genVertices_end() const;    // vertices associated with
+    g4v_iterator g4Vertices_begin() const;    // this vertex, respectively
+    g4v_iterator g4Vertices_end() const;      // ....
 
-  tp_iterator daughterTracks_begin() const;  // Ref's to daughter and source
-  tp_iterator daughterTracks_end() const;    // tracks associated with
-  tp_iterator sourceTracks_begin() const;    // this vertex, respectively
-  tp_iterator sourceTracks_end() const;      // ....
+    tp_iterator daughterTracks_begin() const;  // Ref's to daughter and source
+    tp_iterator daughterTracks_end() const;    // tracks associated with
+    tp_iterator sourceTracks_begin() const;    // this vertex, respectively
+    tp_iterator sourceTracks_end() const;      // ....
 
-  unsigned int nG4Vertices() const { return g4Vertices_.size(); };
-  unsigned int nGenVertices() const { return genVertices_.size(); };
-  unsigned int nDaughterTracks() const { return daughterTracks_.size(); };
-  unsigned int nSourceTracks() const { return sourceTracks_.size(); };
+    unsigned int nG4Vertices() const { return g4Vertices_.size(); };
+    unsigned int nGenVertices() const { return genVertices_.size(); };
+    unsigned int nDaughterTracks() const { return daughterTracks_.size(); };
+    unsigned int nSourceTracks() const { return sourceTracks_.size(); };
 
-  // Add references to TrackingParticles, Geant4, and HepMC vertices to containers
-  void addG4Vertex(const SimVertex&);
-  void addGenVertex(const GenVertexRef&);
-  void addDaughterTrack(const TrackingParticleRef&);
-  void addParentTrack(const TrackingParticleRef&);
-  void clearDaughterTracks();
-  void clearParentTracks();
+    // Add references to TrackingParticles, Geant4, and HepMC vertices to containers
+    void addG4Vertex(const SimVertex&);
+    void addGenVertex(const GenVertexRef&);
+    void addDaughterTrack(const TrackingParticleRef&);
+    void addParentTrack(const TrackingParticleRef&);
+    void clearDaughterTracks();
+    void clearParentTracks();
 
-  // Getters for RefVectors
-  const std::vector<SimVertex>& g4Vertices() const;
-  const GenVertexRefVector& genVertices() const;
-  const TrackingParticleRefVector& sourceTracks() const;
-  const TrackingParticleRefVector& daughterTracks() const;
+    // Getters for RefVectors
+    const std::vector<SimVertex>& g4Vertices() const;
+    const GenVertexRefVector& genVertices() const;
+    const TrackingParticleRefVector& sourceTracks() const;
+    const TrackingParticleRefVector& daughterTracks() const;
 
-  // Getters for other info
-  const LorentzVector& position() const { return position_; };
-  const EncodedEventId& eventId() const { return eId_; };
-  const bool inVolume() const { return inVolume_; };
+    // Getters for other info
+    const LorentzVector& position() const { return position_; };
+    const EncodedEventId& eventId() const { return eId_; };
+    const bool inVolume() const { return inVolume_; };
 
-private:
-  LorentzVector position_;  // Vertex position and time
-  bool inVolume_;           // Is it inside tracker volume?
-  EncodedEventId eId_;
+  private:
+    LorentzVector position_;  // Vertex position and time
+    bool inVolume_;           // Is it inside tracker volume?
+    EncodedEventId eId_;
 
-  // References to G4 and generator vertices and TrackingParticles
+    // References to G4 and generator vertices and TrackingParticles
 
-  std::vector<SimVertex> g4Vertices_;
-  GenVertexRefVector genVertices_;
-  TrackingParticleRefVector daughterTracks_;
-  TrackingParticleRefVector sourceTracks_;
-};
+    std::vector<SimVertex> g4Vertices_;
+    GenVertexRefVector genVertices_;
+    TrackingParticleRefVector daughterTracks_;
+    TrackingParticleRefVector sourceTracks_;
+  };
+}  // namespace io_v1
+using TrackingVertex = io_v1::TrackingVertex;
 
 #endif

--- a/SimDataFormats/TrackingAnalysis/interface/TrackingVertexFwd.h
+++ b/SimDataFormats/TrackingAnalysis/interface/TrackingVertexFwd.h
@@ -1,6 +1,9 @@
 #ifndef SimDataFormats_TrackingAnalysis_TrackingVertexFwd_h
 #define SimDataFormats_TrackingAnalysis_TrackingVertexFwd_h
 
-class TrackingVertex;
+namespace io_v1 {
+  class TrackingVertex;
+}  // namespace io_v1
+using TrackingVertex = io_v1::TrackingVertex;
 
 #endif

--- a/SimDataFormats/TrackingAnalysis/interface/UniqueSimTrackId.h
+++ b/SimDataFormats/TrackingAnalysis/interface/UniqueSimTrackId.h
@@ -14,8 +14,11 @@ struct UniqueSimTrackIdHash {
   }
 };
 
-struct SimTrackToTPMap {
-  std::unordered_map<UniqueSimTrackId, TrackingParticleRef, UniqueSimTrackIdHash> mapping;
-};
+namespace io_v1 {
+  struct SimTrackToTPMap {
+    std::unordered_map<UniqueSimTrackId, TrackingParticleRef, UniqueSimTrackIdHash> mapping;
+  };
+}  // namespace io_v1
+using SimTrackToTPMap = io_v1::SimTrackToTPMap;
 
 #endif

--- a/SimDataFormats/TrackingAnalysis/src/TrackingParticle.cc
+++ b/SimDataFormats/TrackingAnalysis/src/TrackingParticle.cc
@@ -5,75 +5,77 @@
 
 #include <FWCore/MessageLogger/interface/MessageLogger.h>
 
-const unsigned int TrackingParticle::longLivedTag = 65536;
+namespace io_v1 {
+  const unsigned int TrackingParticle::longLivedTag = 65536;
 
-TrackingParticle::TrackingParticle() {
-  // No operation
-}
-
-TrackingParticle::TrackingParticle(const SimTrack& simtrk, const TrackingVertexRef& parentVertex) {
-  addG4Track(simtrk);
-  setParentVertex(parentVertex);
-}
-
-TrackingParticle::~TrackingParticle() {}
-
-void TrackingParticle::addGenParticle(const reco::GenParticleRef& ref) { genParticles_.push_back(ref); }
-
-void TrackingParticle::addG4Track(const SimTrack& t) { g4Tracks_.push_back(t); }
-
-TrackingParticle::genp_iterator TrackingParticle::genParticle_begin() const { return genParticles_.begin(); }
-
-TrackingParticle::genp_iterator TrackingParticle::genParticle_end() const { return genParticles_.end(); }
-
-TrackingParticle::g4t_iterator TrackingParticle::g4Track_begin() const { return g4Tracks_.begin(); }
-
-TrackingParticle::g4t_iterator TrackingParticle::g4Track_end() const { return g4Tracks_.end(); }
-
-void TrackingParticle::setParentVertex(const TrackingVertexRef& ref) { parentVertex_ = ref; }
-
-void TrackingParticle::addDecayVertex(const TrackingVertexRef& ref) { decayVertices_.push_back(ref); }
-
-void TrackingParticle::clearParentVertex() { parentVertex_ = TrackingVertexRef(); }
-
-void TrackingParticle::clearDecayVertices() { decayVertices_.clear(); }
-
-int TrackingParticle::matchedHit() const {
-  edm::LogWarning("TrackingParticle")
-      << "The method matchedHit() has been deprecated. Use numberOfTrackerLayers() instead.";
-  return numberOfTrackerLayers_;
-}
-
-void TrackingParticle::setNumberOfHits(int numberOfHits) { numberOfHits_ = numberOfHits; }
-
-void TrackingParticle::setNumberOfTrackerHits(int numberOfTrackerHits) { numberOfTrackerHits_ = numberOfTrackerHits; }
-
-void TrackingParticle::setNumberOfTrackerLayers(const int numberOfTrackerLayers) {
-  numberOfTrackerLayers_ = numberOfTrackerLayers;
-}
-
-std::ostream& operator<<(std::ostream& s, TrackingParticle const& tp) {
-  s << "TP momentum, q, ID, & Event #: " << tp.p4() << " " << tp.charge() << " " << tp.pdgId() << " "
-    << tp.eventId().bunchCrossing() << "." << tp.eventId().event() << std::endl;
-
-  for (TrackingParticle::genp_iterator hepT = tp.genParticle_begin(); hepT != tp.genParticle_end(); ++hepT) {
-    s << " HepMC Track Momentum " << (*hepT)->momentum().rho() << std::endl;
+  TrackingParticle::TrackingParticle() {
+    // No operation
   }
 
-  for (TrackingParticle::g4t_iterator g4T = tp.g4Track_begin(); g4T != tp.g4Track_end(); ++g4T) {
-    s << " Geant Track Momentum  " << g4T->momentum() << std::endl;
-    s << " Geant Track ID & type " << g4T->trackId() << " " << g4T->type() << std::endl;
-    if (g4T->type() != tp.pdgId()) {
-      s << " Mismatch b/t TrackingParticle and Geant types" << std::endl;
+  TrackingParticle::TrackingParticle(const SimTrack& simtrk, const TrackingVertexRef& parentVertex) {
+    addG4Track(simtrk);
+    setParentVertex(parentVertex);
+  }
+
+  TrackingParticle::~TrackingParticle() {}
+
+  void TrackingParticle::addGenParticle(const reco::GenParticleRef& ref) { genParticles_.push_back(ref); }
+
+  void TrackingParticle::addG4Track(const SimTrack& t) { g4Tracks_.push_back(t); }
+
+  TrackingParticle::genp_iterator TrackingParticle::genParticle_begin() const { return genParticles_.begin(); }
+
+  TrackingParticle::genp_iterator TrackingParticle::genParticle_end() const { return genParticles_.end(); }
+
+  TrackingParticle::g4t_iterator TrackingParticle::g4Track_begin() const { return g4Tracks_.begin(); }
+
+  TrackingParticle::g4t_iterator TrackingParticle::g4Track_end() const { return g4Tracks_.end(); }
+
+  void TrackingParticle::setParentVertex(const TrackingVertexRef& ref) { parentVertex_ = ref; }
+
+  void TrackingParticle::addDecayVertex(const TrackingVertexRef& ref) { decayVertices_.push_back(ref); }
+
+  void TrackingParticle::clearParentVertex() { parentVertex_ = TrackingVertexRef(); }
+
+  void TrackingParticle::clearDecayVertices() { decayVertices_.clear(); }
+
+  int TrackingParticle::matchedHit() const {
+    edm::LogWarning("TrackingParticle")
+        << "The method matchedHit() has been deprecated. Use numberOfTrackerLayers() instead.";
+    return numberOfTrackerLayers_;
+  }
+
+  void TrackingParticle::setNumberOfHits(int numberOfHits) { numberOfHits_ = numberOfHits; }
+
+  void TrackingParticle::setNumberOfTrackerHits(int numberOfTrackerHits) { numberOfTrackerHits_ = numberOfTrackerHits; }
+
+  void TrackingParticle::setNumberOfTrackerLayers(const int numberOfTrackerLayers) {
+    numberOfTrackerLayers_ = numberOfTrackerLayers;
+  }
+
+  std::ostream& operator<<(std::ostream& s, TrackingParticle const& tp) {
+    s << "TP momentum, q, ID, & Event #: " << tp.p4() << " " << tp.charge() << " " << tp.pdgId() << " "
+      << tp.eventId().bunchCrossing() << "." << tp.eventId().event() << std::endl;
+
+    for (TrackingParticle::genp_iterator hepT = tp.genParticle_begin(); hepT != tp.genParticle_end(); ++hepT) {
+      s << " HepMC Track Momentum " << (*hepT)->momentum().rho() << std::endl;
     }
-  }
-  // Loop over decay vertices
-  s << " TP Vertex " << tp.vertex() << std::endl;
-  s << " Source vertex: " << tp.parentVertex()->position() << std::endl;
-  s << " " << tp.decayVertices().size() << " Decay vertices" << std::endl;
-  for (tv_iterator iTV = tp.decayVertices_begin(); iTV != tp.decayVertices_end(); ++iTV) {
-    s << " Decay vertices:      " << (**iTV).position() << std::endl;
-  }
 
-  return s;
-}
+    for (TrackingParticle::g4t_iterator g4T = tp.g4Track_begin(); g4T != tp.g4Track_end(); ++g4T) {
+      s << " Geant Track Momentum  " << g4T->momentum() << std::endl;
+      s << " Geant Track ID & type " << g4T->trackId() << " " << g4T->type() << std::endl;
+      if (g4T->type() != tp.pdgId()) {
+        s << " Mismatch b/t TrackingParticle and Geant types" << std::endl;
+      }
+    }
+    // Loop over decay vertices
+    s << " TP Vertex " << tp.vertex() << std::endl;
+    s << " Source vertex: " << tp.parentVertex()->position() << std::endl;
+    s << " " << tp.decayVertices().size() << " Decay vertices" << std::endl;
+    for (tv_iterator iTV = tp.decayVertices_begin(); iTV != tp.decayVertices_end(); ++iTV) {
+      s << " Decay vertices:      " << (**iTV).position() << std::endl;
+    }
+
+    return s;
+  }
+}  // namespace io_v1

--- a/SimDataFormats/TrackingAnalysis/src/TrackingVertex.cc
+++ b/SimDataFormats/TrackingAnalysis/src/TrackingVertex.cc
@@ -5,88 +5,90 @@
 typedef edm::RefVector<edm::HepMCProduct, HepMC::GenVertex> GenVertexRefVector;
 typedef edm::Ref<edm::HepMCProduct, HepMC::GenVertex> GenVertexRef;
 
-// Constructors
+namespace io_v1 {
+  // Constructors
 
-TrackingVertex::TrackingVertex() : position_(LorentzVector(0, 0, 0, 0)), eId_(0) {
-  //  daughterTracks_.clear();
-}
-
-TrackingVertex::TrackingVertex(const LorentzVector& p, const bool inVolume, const EncodedEventId eId)
-    : position_(p), inVolume_(inVolume), eId_(eId) {
-  //  daughterTracks_.clear();
-}
-
-// Add a reference to vertex vectors
-
-void TrackingVertex::addG4Vertex(const SimVertex& v) { g4Vertices_.push_back(v); }
-
-void TrackingVertex::addGenVertex(const GenVertexRef& ref) { genVertices_.push_back(ref); }
-
-// Add a reference to track vectors
-
-void TrackingVertex::addDaughterTrack(const TrackingParticleRef& ref) { daughterTracks_.push_back(ref); }
-
-void TrackingVertex::addParentTrack(const TrackingParticleRef& ref) { sourceTracks_.push_back(ref); }
-
-void TrackingVertex::clearDaughterTracks() { daughterTracks_.clear(); }
-
-void TrackingVertex::clearParentTracks() { sourceTracks_.clear(); }
-
-// Iterators over vertices and tracks
-
-TrackingVertex::genv_iterator TrackingVertex::genVertices_begin() const { return genVertices_.begin(); }
-TrackingVertex::genv_iterator TrackingVertex::genVertices_end() const { return genVertices_.end(); }
-TrackingVertex::g4v_iterator TrackingVertex::g4Vertices_begin() const { return g4Vertices_.begin(); }
-TrackingVertex::g4v_iterator TrackingVertex::g4Vertices_end() const { return g4Vertices_.end(); }
-
-TrackingVertex::tp_iterator TrackingVertex::daughterTracks_begin() const { return daughterTracks_.begin(); }
-TrackingVertex::tp_iterator TrackingVertex::daughterTracks_end() const { return daughterTracks_.end(); }
-TrackingVertex::tp_iterator TrackingVertex::sourceTracks_begin() const { return sourceTracks_.begin(); }
-TrackingVertex::tp_iterator TrackingVertex::sourceTracks_end() const { return sourceTracks_.end(); }
-
-// Accessors for whole vectors
-
-const std::vector<SimVertex>& TrackingVertex::g4Vertices() const { return g4Vertices_; }
-const GenVertexRefVector& TrackingVertex::genVertices() const { return genVertices_; }
-const TrackingParticleRefVector& TrackingVertex::sourceTracks() const { return sourceTracks_; }
-const TrackingParticleRefVector& TrackingVertex::daughterTracks() const { return daughterTracks_; }
-
-std::ostream& operator<<(std::ostream& s, const TrackingVertex& v) {
-  using std::endl;
-  typedef GenVertexRefVector::iterator genv_iterator;
-  typedef std::vector<SimVertex>::const_iterator g4v_iterator;
-  typedef TrackingParticleRefVector::iterator tp_iterator;
-  typedef std::vector<SimTrack>::const_iterator g4t_iterator;
-
-  s << "Vertex Position & Event #" << v.position() << " " << v.eventId().bunchCrossing() << "." << v.eventId().event()
-    << endl;
-  s << " Associated with " << v.daughterTracks().size() << " tracks" << endl;
-  for (genv_iterator genV = v.genVertices_begin(); genV != v.genVertices_end(); ++genV) {
-    s << " HepMC vertex position " << (*(*genV)).position().x() << "," << (*(*genV)).position().y()
-      << (*(*genV)).position().z() << endl;
+  TrackingVertex::TrackingVertex() : position_(LorentzVector(0, 0, 0, 0)), eId_(0) {
+    //  daughterTracks_.clear();
   }
 
-  for (g4v_iterator g4V = v.g4Vertices_begin(); g4V != v.g4Vertices_end(); ++g4V) {
-    s << " Geant vertex position " << (*g4V).position() << endl;
-    // Probably empty all the time, currently
+  TrackingVertex::TrackingVertex(const LorentzVector& p, const bool inVolume, const EncodedEventId eId)
+      : position_(p), inVolume_(inVolume), eId_(eId) {
+    //  daughterTracks_.clear();
   }
 
-  // Loop over daughter track(s)
-  for (tp_iterator iTP = v.daughterTracks_begin(); iTP != v.daughterTracks_end(); ++iTP) {
-    s << " Daughter starts:      " << (*(*iTP)).vertex();
-    for (g4t_iterator g4T = (*(*iTP)).g4Track_begin(); g4T != (*(*iTP)).g4Track_end(); ++g4T) {
-      s << " p " << g4T->momentum();
+  // Add a reference to vertex vectors
+
+  void TrackingVertex::addG4Vertex(const SimVertex& v) { g4Vertices_.push_back(v); }
+
+  void TrackingVertex::addGenVertex(const GenVertexRef& ref) { genVertices_.push_back(ref); }
+
+  // Add a reference to track vectors
+
+  void TrackingVertex::addDaughterTrack(const TrackingParticleRef& ref) { daughterTracks_.push_back(ref); }
+
+  void TrackingVertex::addParentTrack(const TrackingParticleRef& ref) { sourceTracks_.push_back(ref); }
+
+  void TrackingVertex::clearDaughterTracks() { daughterTracks_.clear(); }
+
+  void TrackingVertex::clearParentTracks() { sourceTracks_.clear(); }
+
+  // Iterators over vertices and tracks
+
+  TrackingVertex::genv_iterator TrackingVertex::genVertices_begin() const { return genVertices_.begin(); }
+  TrackingVertex::genv_iterator TrackingVertex::genVertices_end() const { return genVertices_.end(); }
+  TrackingVertex::g4v_iterator TrackingVertex::g4Vertices_begin() const { return g4Vertices_.begin(); }
+  TrackingVertex::g4v_iterator TrackingVertex::g4Vertices_end() const { return g4Vertices_.end(); }
+
+  TrackingVertex::tp_iterator TrackingVertex::daughterTracks_begin() const { return daughterTracks_.begin(); }
+  TrackingVertex::tp_iterator TrackingVertex::daughterTracks_end() const { return daughterTracks_.end(); }
+  TrackingVertex::tp_iterator TrackingVertex::sourceTracks_begin() const { return sourceTracks_.begin(); }
+  TrackingVertex::tp_iterator TrackingVertex::sourceTracks_end() const { return sourceTracks_.end(); }
+
+  // Accessors for whole vectors
+
+  const std::vector<SimVertex>& TrackingVertex::g4Vertices() const { return g4Vertices_; }
+  const GenVertexRefVector& TrackingVertex::genVertices() const { return genVertices_; }
+  const TrackingParticleRefVector& TrackingVertex::sourceTracks() const { return sourceTracks_; }
+  const TrackingParticleRefVector& TrackingVertex::daughterTracks() const { return daughterTracks_; }
+
+  std::ostream& operator<<(std::ostream& s, const TrackingVertex& v) {
+    using std::endl;
+    typedef GenVertexRefVector::iterator genv_iterator;
+    typedef std::vector<SimVertex>::const_iterator g4v_iterator;
+    typedef TrackingParticleRefVector::iterator tp_iterator;
+    typedef std::vector<SimTrack>::const_iterator g4t_iterator;
+
+    s << "Vertex Position & Event #" << v.position() << " " << v.eventId().bunchCrossing() << "." << v.eventId().event()
+      << endl;
+    s << " Associated with " << v.daughterTracks().size() << " tracks" << endl;
+    for (genv_iterator genV = v.genVertices_begin(); genV != v.genVertices_end(); ++genV) {
+      s << " HepMC vertex position " << (*(*genV)).position().x() << "," << (*(*genV)).position().y()
+        << (*(*genV)).position().z() << endl;
     }
-    s << endl;
-  }
 
-  // Loop over source track(s) (can be multiple since vertices are collapsed)
-  for (tp_iterator iTP = v.sourceTracks_begin(); iTP != v.sourceTracks_end(); ++iTP) {
-    s << " Source   starts: " << (*(*iTP)).vertex();
-    for (g4t_iterator g4T = (*iTP)->g4Track_begin(); g4T != (*iTP)->g4Track_end(); ++g4T) {
-      s << ", p " << g4T->momentum();
+    for (g4v_iterator g4V = v.g4Vertices_begin(); g4V != v.g4Vertices_end(); ++g4V) {
+      s << " Geant vertex position " << (*g4V).position() << endl;
+      // Probably empty all the time, currently
     }
-    s << endl;
+
+    // Loop over daughter track(s)
+    for (tp_iterator iTP = v.daughterTracks_begin(); iTP != v.daughterTracks_end(); ++iTP) {
+      s << " Daughter starts:      " << (*(*iTP)).vertex();
+      for (g4t_iterator g4T = (*(*iTP)).g4Track_begin(); g4T != (*(*iTP)).g4Track_end(); ++g4T) {
+        s << " p " << g4T->momentum();
+      }
+      s << endl;
+    }
+
+    // Loop over source track(s) (can be multiple since vertices are collapsed)
+    for (tp_iterator iTP = v.sourceTracks_begin(); iTP != v.sourceTracks_end(); ++iTP) {
+      s << " Source   starts: " << (*(*iTP)).vertex();
+      for (g4t_iterator g4T = (*iTP)->g4Track_begin(); g4T != (*iTP)->g4Track_end(); ++g4T) {
+        s << ", p " << g4T->momentum();
+      }
+      s << endl;
+    }
+    return s;
   }
-  return s;
-}
+}  // namespace io_v1

--- a/SimDataFormats/TrackingAnalysis/src/classes_def.xml
+++ b/SimDataFormats/TrackingAnalysis/src/classes_def.xml
@@ -1,47 +1,47 @@
 <lcgdict>
-  <class name="TrackingVertex"  ClassVersion="3">
-   <version ClassVersion="3" checksum="1296296226"/>
+  <class name="io_v1::TrackingVertex"  ClassVersion="3">
+   <version ClassVersion="3" checksum="3766521220"/>
   </class>
-  <class name="std::vector<TrackingVertex>" />
-  <class name="std::vector<TrackingVertex>::iterator" />
-  <class name="std::vector<TrackingVertex>::const_iterator" />
-  <class name="edm::Wrapper<std::vector<TrackingVertex> >" />
+  <class name="std::vector<io_v1::TrackingVertex>" />
+  <class name="std::vector<io_v1::TrackingVertex>::iterator" />
+  <class name="std::vector<io_v1::TrackingVertex>::const_iterator" />
+  <class name="edm::Wrapper<std::vector<io_v1::TrackingVertex> >" />
   <class name="TrackingVertexRef" />
   <class name="TrackingVertexRefVector" />
-  <class name="edm::RefProd<std::vector<TrackingVertex> >" />
+  <class name="edm::RefProd<std::vector<io_v1::TrackingVertex> >" />
 
-  <class name="TrackingParticle" ClassVersion="3">
-   <version ClassVersion="3" checksum="3602175482"/>
+  <class name="io_v1::TrackingParticle" ClassVersion="3">
+   <version ClassVersion="3" checksum="1589723766"/>
   </class>
-  <class name="std::vector<TrackingParticle>" />
-  <class name="edm::Wrapper<std::vector<TrackingParticle> >" />
-  <class name="edm::RefProd<std::vector<TrackingParticle> >" />
+  <class name="std::vector<io_v1::TrackingParticle>" />
+  <class name="edm::Wrapper<std::vector<io_v1::TrackingParticle> >" />
+  <class name="edm::RefProd<std::vector<io_v1::TrackingParticle> >" />
   <class name="TrackingParticleRef" />
-  <class name="edm::Ptr<TrackingParticle>" />
-  <class name="std::vector<edm::Ptr<TrackingParticle>>" />
+  <class name="edm::Ptr<io_v1::TrackingParticle>" />
+  <class name="std::vector<edm::Ptr<io_v1::TrackingParticle>>" />
 
   <class name="TrackingParticleRefVector" />
   <class name="edm::Wrapper<TrackingParticleRefVector>"/>
 
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<TrackingParticle> >,edm::RefToBaseProd<reco::io_v1::Track> >" />
-  <class name="edm::helpers::KeyVal<edm::RefToBaseProd<reco::io_v1::Track>,edm::RefProd<std::vector<TrackingParticle> > >" />
-  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>,TrackingParticle> >,std::vector<std::pair<edm::RefToBase<reco::io_v1::Track>,double> > > >" />
-  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::RefToBase<reco::io_v1::Track>,std::vector<std::pair<edm::Ref<std::vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>,TrackingParticle> >,double> > > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<io_v1::TrackingParticle> >,edm::RefToBaseProd<reco::io_v1::Track> >" />
+  <class name="edm::helpers::KeyVal<edm::RefToBaseProd<reco::io_v1::Track>,edm::RefProd<std::vector<io_v1::TrackingParticle> > >" />
+  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<io_v1::TrackingParticle>,io_v1::TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<io_v1::TrackingParticle>,io_v1::TrackingParticle> >,std::vector<std::pair<edm::RefToBase<reco::io_v1::Track>,double> > > >" />
+  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::RefToBase<reco::io_v1::Track>,std::vector<std::pair<edm::Ref<std::vector<io_v1::TrackingParticle>,io_v1::TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<io_v1::TrackingParticle>,io_v1::TrackingParticle> >,double> > > >" />
 
-  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>,TrackingParticle> >,std::vector<std::pair<edm::RefToBase<reco::io_v1::Track>,double> > >" />
-  <class name="edm::helpers::KeyVal<edm::RefToBase<reco::io_v1::Track>,std::vector<std::pair<edm::Ref<std::vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>,TrackingParticle> >,double> > >" />
+  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<io_v1::TrackingParticle>,io_v1::TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<io_v1::TrackingParticle>,io_v1::TrackingParticle> >,std::vector<std::pair<edm::RefToBase<reco::io_v1::Track>,double> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefToBase<reco::io_v1::Track>,std::vector<std::pair<edm::Ref<std::vector<io_v1::TrackingParticle>,io_v1::TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<io_v1::TrackingParticle>,io_v1::TrackingParticle> >,double> > >" />
 
-  <class name="std::vector<std::pair<edm::Ref<std::vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>,TrackingParticle> >,double> >" />
-  <class name="std::pair<edm::Ref<std::vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>,TrackingParticle> >,double>" />
+  <class name="std::vector<std::pair<edm::Ref<std::vector<io_v1::TrackingParticle>,io_v1::TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<io_v1::TrackingParticle>,io_v1::TrackingParticle> >,double> >" />
+  <class name="std::pair<edm::Ref<std::vector<io_v1::TrackingParticle>,io_v1::TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<io_v1::TrackingParticle>,io_v1::TrackingParticle> >,double>" />
   <class name="UniqueSimTrackId"/>
-  <class name="std::pair<UniqueSimTrackId, edm::Ref<std::vector<TrackingParticle>, TrackingParticle, edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>, TrackingParticle> > >"/>
+  <class name="std::pair<UniqueSimTrackId, edm::Ref<std::vector<io_v1::TrackingParticle>, io_v1::TrackingParticle, edm::refhelper::FindUsingAdvance<std::vector<io_v1::TrackingParticle>, io_v1::TrackingParticle> > >"/>
   <class name="std::unordered_map<UniqueSimTrackId, TrackingParticleRef, UniqueSimTrackIdHash>"/>
   <class name="edm::Wrapper<std::unordered_map<UniqueSimTrackId, TrackingParticleRef, UniqueSimTrackIdHash>>"/>
-  <class name="SimTrackToTPMap" rntupleStreamerMode="true"/>
-  <class name="edm::Wrapper<SimTrackToTPMap>"/>
+  <class name="io_v1::SimTrackToTPMap" rntupleStreamerMode="true"/>
+  <class name="edm::Wrapper<io_v1::SimTrackToTPMap>"/>
 
   <class name="SimDoublets" ClassVersion="3">
-   <version ClassVersion="3" checksum="2009082523"/>
+   <version ClassVersion="3" checksum="1562824955"/>
   </class>
   <class name="std::vector<SimDoublets>"/>
   <class name="edm::Wrapper< std::vector<SimDoublets> >"/>

--- a/SimDataFormats/TrackingHit/interface/PSimHit.h
+++ b/SimDataFormats/TrackingHit/interface/PSimHit.h
@@ -12,75 +12,76 @@ class TrackingSlaveSD;  // for friend declaration only
  * Suitable for tracking detectors.
  */
 
-class PSimHit {
-public:
-  static constexpr unsigned int k_tidOffset = 200000000;
+namespace io_v1 {
+  class PSimHit {
+  public:
+    static constexpr unsigned int k_tidOffset = 200000000;
 
-  PSimHit() : theDetUnitId(0) {}
+    PSimHit() : theDetUnitId(0) {}
 
-  PSimHit(const Local3DPoint& entry,
-          const Local3DPoint& exit,
-          float pabs,
-          float tof,
-          float eloss,
-          int particleType,
-          unsigned int detId,
-          unsigned int trackId,
-          float theta,
-          float phi,
-          unsigned short processType = 0)
-      : theEntryPoint(entry),
-        theSegment(exit - entry),
-        thePabs(pabs),
-        theEnergyLoss(eloss),
-        theThetaAtEntry(theta),
-        thePhiAtEntry(phi),
-        theTof(tof),
-        theParticleType(particleType),
-        theProcessType(processType),
-        theDetUnitId(detId),
-        theTrackId(trackId) {}
+    PSimHit(const Local3DPoint& entry,
+            const Local3DPoint& exit,
+            float pabs,
+            float tof,
+            float eloss,
+            int particleType,
+            unsigned int detId,
+            unsigned int trackId,
+            float theta,
+            float phi,
+            unsigned short processType = 0)
+        : theEntryPoint(entry),
+          theSegment(exit - entry),
+          thePabs(pabs),
+          theEnergyLoss(eloss),
+          theThetaAtEntry(theta),
+          thePhiAtEntry(phi),
+          theTof(tof),
+          theParticleType(particleType),
+          theProcessType(processType),
+          theDetUnitId(detId),
+          theTrackId(trackId) {}
 
-  /// Entry point in the local Det frame
-  Local3DPoint entryPoint() const { return theEntryPoint; }
+    /// Entry point in the local Det frame
+    Local3DPoint entryPoint() const { return theEntryPoint; }
 
-  /// Exit point in the local Det frame
-  Local3DPoint exitPoint() const { return theEntryPoint + theSegment; }
+    /// Exit point in the local Det frame
+    Local3DPoint exitPoint() const { return theEntryPoint + theSegment; }
 
-  /** Local position in the Det frame.
+    /** Local position in the Det frame.
    *  Normally it is on the detection surface, but this is not
    *  checked. It is computed as the middle point between entry and exit.
    */
-  Local3DPoint localPosition() const { return theEntryPoint + 0.5 * theSegment; }
+    Local3DPoint localPosition() const { return theEntryPoint + 0.5 * theSegment; }
 
-  /// The momentum of the track that produced the hit, at entry point.
-  LocalVector momentumAtEntry() const { return LocalVector(thetaAtEntry(), phiAtEntry(), pabs()); }
+    /// The momentum of the track that produced the hit, at entry point.
+    LocalVector momentumAtEntry() const { return LocalVector(thetaAtEntry(), phiAtEntry(), pabs()); }
 
-  /// Obsolete. Same as momentumAtEntry().unit(), for backward compatibility.
-  LocalVector localDirection() const { return LocalVector(thetaAtEntry(), phiAtEntry(), 1.f); }
+    /// Obsolete. Same as momentumAtEntry().unit(), for backward compatibility.
+    LocalVector localDirection() const { return LocalVector(thetaAtEntry(), phiAtEntry(), 1.f); }
 
-  /// fast and more accurate access to momentumAtEntry().theta()
-  Geom::Theta<float> thetaAtEntry() const { return Geom::Theta<float>(theThetaAtEntry); }
+    /// fast and more accurate access to momentumAtEntry().theta()
+    Geom::Theta<float> thetaAtEntry() const { return Geom::Theta<float>(theThetaAtEntry); }
 
-  /// fast and more accurate access to momentumAtEntry().phi()
-  Geom::Phi<float> phiAtEntry() const { return Geom::Phi<float>(thePhiAtEntry); }
+    /// fast and more accurate access to momentumAtEntry().phi()
+    Geom::Phi<float> phiAtEntry() const { return Geom::Phi<float>(thePhiAtEntry); }
 
-  /// fast and more accurate access to momentumAtEntry().mag()
-  float pabs() const { return thePabs; }
+    /// fast and more accurate access to momentumAtEntry().mag()
+    float pabs() const { return thePabs; }
 
-  /** Time of flight in nanoseconds from the primary interaction
+    /** Time of flight in nanoseconds from the primary interaction
    *  to the entry point. Always positive in a PSimHit,
    *  but may become negative in a SimHit due to bunch assignment.
    */
-  float timeOfFlight() const { return tof(); }
+    float timeOfFlight() const { return tof(); }
 
-  /// deprecated name for timeOfFlight()
-  float tof() const { return theTof; }
+    /// deprecated name for timeOfFlight()
+    float tof() const { return theTof; }
 
-  /// The energy deposit in the PSimHit, in ???.
-  float energyLoss() const { return theEnergyLoss; }
+    /// The energy deposit in the PSimHit, in ???.
+    float energyLoss() const { return theEnergyLoss; }
 
-  /** The particle type of the track that produced this hit,
+    /** The particle type of the track that produced this hit,
    *  in standard PDG code. 
    *  NB: This differs from ORCA5 and earlier, where the code was Geant3.
    *  The particle type of the hit may differ from the particle type of
@@ -88,39 +89,39 @@ public:
    *  by a secondary track (e.g. a delta ray) originating from the 
    *  trackId() and not existing as a separate SimTrack.
    */
-  int particleType() const { return theParticleType; }
+    int particleType() const { return theParticleType; }
 
-  /** The DetUnit identifier, to be interpreted in the context of the
+    /** The DetUnit identifier, to be interpreted in the context of the
    *  detector system that produced the hit. E.g. in the Tracker
    *  this is index used with DetUnitNumbering<TrackerSimHitTag>.
    *  Currently the context is not deducible from the PSimHit and
    *  must be known when the PSimHit is created/accessed.
    */
-  unsigned int detUnitId() const { return theDetUnitId; }
+    unsigned int detUnitId() const { return theDetUnitId; }
 
-  /** The SimTrack ID of the "mother" track. This may be the actual
+    /** The SimTrack ID of the "mother" track. This may be the actual
    *  charged track that produced the hit, or a "mother" of this
    *  track, in case the track that produced the hit was not
    *  saved as a SimTrack.
    *  This ID must be interpreted in the context of the SimEvent
    *  to which the PSimHit belongs.
    */
-  unsigned int trackId() const { return theTrackId; }
+    unsigned int trackId() const { return theTrackId; }
 
-  /** In case te SimTrack ID is incremented by the k_tidOffset for hit category definition, this
+    /** In case te SimTrack ID is incremented by the k_tidOffset for hit category definition, this
    * methods returns the original theTrackId value directly.
    */
-  unsigned int originalTrackId() const { return theTrackId % k_tidOffset; }
+    unsigned int originalTrackId() const { return theTrackId % k_tidOffset; }
 
-  unsigned int offsetTrackId() const { return theTrackId / k_tidOffset; }
+    unsigned int offsetTrackId() const { return theTrackId / k_tidOffset; }
 
-  static unsigned int addTrackIdOffset(unsigned int tId, unsigned int offset) { return offset * k_tidOffset + tId; }
+    static unsigned int addTrackIdOffset(unsigned int tId, unsigned int offset) { return offset * k_tidOffset + tId; }
 
-  EncodedEventId eventId() const { return theEventId; }
+    EncodedEventId eventId() const { return theEventId; }
 
-  void setEventId(EncodedEventId e) { theEventId = e; }
+    void setEventId(EncodedEventId e) { theEventId = e; }
 
-  /** The ID of the physics process that created the track that produced 
+    /** The ID of the physics process that created the track that produced 
    *  the hit. This is useful for identifying hits from secondary interactions,
    *  especially in the case when the track that produced the hit was not saved 
    *  as a SimTrack.
@@ -128,32 +129,34 @@ public:
    *  value with special significance is zero (for "undefined"), so zero should
    *  not be the ID of any process.
    */
-  unsigned short processType() const { return theProcessType; }
+    unsigned short processType() const { return theProcessType; }
 
-  void setTof(float tof) { theTof = tof; }
+    void setTof(float tof) { theTof = tof; }
 
-protected:
-  // properties
-  Local3DPoint theEntryPoint;  // position at entry
-  Local3DVector theSegment;    // exitPos - entryPos
-  float thePabs;               // momentum
-  float theEnergyLoss;         // Energy loss
-  float theThetaAtEntry;
-  float thePhiAtEntry;
+  protected:
+    // properties
+    Local3DPoint theEntryPoint;  // position at entry
+    Local3DVector theSegment;    // exitPos - entryPos
+    float thePabs;               // momentum
+    float theEnergyLoss;         // Energy loss
+    float theThetaAtEntry;
+    float thePhiAtEntry;
 
-  float theTof;  // Time Of Flight
-  int theParticleType;
-  unsigned short theProcessType;  // ID of the process which created the track
-                                  // which created the PSimHit
+    float theTof;  // Time Of Flight
+    int theParticleType;
+    unsigned short theProcessType;  // ID of the process which created the track
+                                    // which created the PSimHit
 
-  // association
-  unsigned int theDetUnitId;
-  unsigned int theTrackId;
-  EncodedEventId theEventId;
+    // association
+    unsigned int theDetUnitId;
+    unsigned int theTrackId;
+    EncodedEventId theEventId;
 
-  friend class TrackingSlaveSD;
-};
+    friend class ::TrackingSlaveSD;
+  };
 
-std::ostream& operator<<(std::ostream& o, const PSimHit& hit);
+  std::ostream& operator<<(std::ostream& o, const PSimHit& hit);
+}  // namespace io_v1
+using PSimHit = io_v1::PSimHit;
 
 #endif  // PSimHit_H

--- a/SimDataFormats/TrackingHit/interface/PSimHitFwd.h
+++ b/SimDataFormats/TrackingHit/interface/PSimHitFwd.h
@@ -1,6 +1,9 @@
 #ifndef SimDataFormats_TrackingHit_PSimHitFwd_h
 #define SimDataFormats_TrackingHit_PSimHitFwd_h
 
-class PSimHit;
+namespace io_v1 {
+  class PSimHit;
+}  // namespace io_v1
+using PSimHit = io_v1::PSimHit;
 
 #endif

--- a/SimDataFormats/TrackingHit/src/PSimHit.cc
+++ b/SimDataFormats/TrackingHit/src/PSimHit.cc
@@ -1,6 +1,8 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include <ostream>
 
-std::ostream& operator<<(std::ostream& o, const PSimHit& hit) {
-  return o << hit.detUnitId() << " " << hit.entryPoint() << " " << hit.tof();
-}
+namespace io_v1 {
+  std::ostream& operator<<(std::ostream& o, const PSimHit& hit) {
+    return o << hit.detUnitId() << " " << hit.entryPoint() << " " << hit.tof();
+  }
+}  // namespace io_v1

--- a/SimDataFormats/TrackingHit/src/classes_def.xml
+++ b/SimDataFormats/TrackingHit/src/classes_def.xml
@@ -1,14 +1,14 @@
 <lcgdict>
-  <class name="PSimHit" ClassVersion="10">
-   <version ClassVersion="10" checksum="1181355938"/>
+  <class name="io_v1::PSimHit" ClassVersion="3">
+   <version ClassVersion="3" checksum="431431970"/>
   </class>
-  <class name="std::vector<PSimHit>"/>
-  <class name="edm::Wrapper<std::vector<PSimHit> >" splitLevel="0"/>
-  <class name="std::vector<const PSimHit*>"/>
-  <class name="edm::RefProd<std::vector<PSimHit> >"/>
-  <class name="edm::Ref<std::vector<PSimHit>,PSimHit,edm::refhelper::FindUsingAdvance<std::vector<PSimHit>,PSimHit> >"/>
+  <class name="std::vector<io_v1::PSimHit>"/>
+  <class name="edm::Wrapper<std::vector<io_v1::PSimHit> >" splitLevel="0"/>
+  <class name="std::vector<const io_v1::PSimHit*>"/>
+  <class name="edm::RefProd<std::vector<io_v1::PSimHit> >"/>
+  <class name="edm::Ref<std::vector<io_v1::PSimHit>,io_v1::PSimHit,edm::refhelper::FindUsingAdvance<std::vector<io_v1::PSimHit>,io_v1::PSimHit> >"/>
 
-  <class name="edm::reftobase::BaseHolder<PSimHit>"/>
-  <class name="edm::reftobase::Holder<PSimHit,edm::Ref<std::vector<PSimHit>,PSimHit,edm::refhelper::FindUsingAdvance<std::vector<PSimHit>,PSimHit> > >"/>
+  <class name="edm::reftobase::BaseHolder<io_v1::PSimHit>"/>
+  <class name="edm::reftobase::Holder<io_v1::PSimHit,edm::Ref<std::vector<io_v1::PSimHit>,io_v1::PSimHit,edm::refhelper::FindUsingAdvance<std::vector<io_v1::PSimHit>,io_v1::PSimHit> > >"/>
 
 </lcgdict>

--- a/SimDataFormats/Vertex/interface/SimVertex.h
+++ b/SimDataFormats/Vertex/interface/SimVertex.h
@@ -4,45 +4,48 @@
 #include "SimDataFormats/Vertex/interface/CoreSimVertex.h"
 #include <iosfwd>
 
-class SimVertex : public CoreSimVertex {
-public:
-  typedef CoreSimVertex Core;
-  /// constructor
-  SimVertex();
+namespace io_v1 {
+  class SimVertex : public CoreSimVertex {
+  public:
+    typedef CoreSimVertex Core;
+    /// constructor
+    SimVertex();
 
-  /// constructor from transient
-  SimVertex(const CoreSimVertex& t, int it);
+    /// constructor from transient
+    SimVertex(const CoreSimVertex& t, int it);
 
-  SimVertex(const math::XYZVectorD& v, float tof);
+    SimVertex(const math::XYZVectorD& v, float tof);
 
-  /// full constructor (position, time, index of parent in final vector)
-  SimVertex(const math::XYZVectorD& v, float tof, int it);
+    /// full constructor (position, time, index of parent in final vector)
+    SimVertex(const math::XYZVectorD& v, float tof, int it);
 
-  /// constructor from transient
-  SimVertex(const CoreSimVertex& t, int it, unsigned int vId);
+    /// constructor from transient
+    SimVertex(const CoreSimVertex& t, int it, unsigned int vId);
 
-  SimVertex(const math::XYZVectorD& v, float tof, unsigned int vId);
+    SimVertex(const math::XYZVectorD& v, float tof, unsigned int vId);
 
-  /// full constructor (position, time, index of parent in final vector)
-  SimVertex(const math::XYZVectorD& v, float tof, int it, unsigned int vId);
+    /// full constructor (position, time, index of parent in final vector)
+    SimVertex(const math::XYZVectorD& v, float tof, int it, unsigned int vId);
 
-  /// G4 TrackId of the parent in the Event SimTrack container (-1 if no parent)
-  /// BE CAREFUL this is not a vector index
-  int parentIndex() const { return itrack; }
-  bool noParent() const { return itrack == -1; }
+    /// G4 TrackId of the parent in the Event SimTrack container (-1 if no parent)
+    /// BE CAREFUL this is not a vector index
+    int parentIndex() const { return itrack; }
+    bool noParent() const { return itrack == -1; }
 
-  void setVertexId(unsigned int n) { vtxId = n; }
-  unsigned int vertexId() const { return vtxId; }
+    void setVertexId(unsigned int n) { vtxId = n; }
+    unsigned int vertexId() const { return vtxId; }
 
-  void setProcessType(unsigned int ty) { procType = ty; }
-  unsigned int processType() const { return procType; }
+    void setProcessType(unsigned int ty) { procType = ty; }
+    unsigned int processType() const { return procType; }
 
-private:
-  int itrack;
-  unsigned int vtxId;
-  unsigned int procType;
-};
+  private:
+    int itrack;
+    unsigned int vtxId;
+    unsigned int procType;
+  };
 
-std::ostream& operator<<(std::ostream& o, const SimVertex& v);
+  std::ostream& operator<<(std::ostream& o, const SimVertex& v);
+}  // namespace io_v1
+using SimVertex = io_v1::SimVertex;
 
 #endif

--- a/SimDataFormats/Vertex/interface/SimVertexFwd.h
+++ b/SimDataFormats/Vertex/interface/SimVertexFwd.h
@@ -1,6 +1,9 @@
 #ifndef SimDataFormats_Vertex_SimVertexFwd_h
 #define SimDataFormats_Vertex_SimVertexFwd_h
 
-class SimVertex;
+namespace io_v1 {
+  class SimVertex;
+}  // namespace io_v1
+using SimVertex = io_v1::SimVertex;
 
 #endif

--- a/SimDataFormats/Vertex/src/SimVertex.cc
+++ b/SimDataFormats/Vertex/src/SimVertex.cc
@@ -1,21 +1,25 @@
 #include "SimDataFormats/Vertex/interface/SimVertex.h"
 
-SimVertex::SimVertex() : itrack(-1), vtxId(0), procType(0) {}
+namespace io_v1 {
+  SimVertex::SimVertex() : itrack(-1), vtxId(0), procType(0) {}
 
-SimVertex::SimVertex(const math::XYZVectorD& v, float tof) : Core(v, tof), itrack(-1), vtxId(0), procType(0) {}
+  SimVertex::SimVertex(const math::XYZVectorD& v, float tof) : Core(v, tof), itrack(-1), vtxId(0), procType(0) {}
 
-SimVertex::SimVertex(const math::XYZVectorD& v, float tof, int it) : Core(v, tof), itrack(it), vtxId(0), procType(0) {}
+  SimVertex::SimVertex(const math::XYZVectorD& v, float tof, int it)
+      : Core(v, tof), itrack(it), vtxId(0), procType(0) {}
 
-SimVertex::SimVertex(const CoreSimVertex& v, int it) : Core(v), itrack(it), vtxId(0), procType(0) {}
+  SimVertex::SimVertex(const CoreSimVertex& v, int it) : Core(v), itrack(it), vtxId(0), procType(0) {}
 
-SimVertex::SimVertex(const math::XYZVectorD& v, float tof, unsigned int vId)
-    : Core(v, tof), itrack(-1), vtxId(vId), procType(0) {}
+  SimVertex::SimVertex(const math::XYZVectorD& v, float tof, unsigned int vId)
+      : Core(v, tof), itrack(-1), vtxId(vId), procType(0) {}
 
-SimVertex::SimVertex(const math::XYZVectorD& v, float tof, int it, unsigned int vId)
-    : Core(v, tof), itrack(it), vtxId(vId), procType(0) {}
+  SimVertex::SimVertex(const math::XYZVectorD& v, float tof, int it, unsigned int vId)
+      : Core(v, tof), itrack(it), vtxId(vId), procType(0) {}
 
-SimVertex::SimVertex(const CoreSimVertex& v, int it, unsigned int vId) : Core(v), itrack(it), vtxId(vId), procType(0) {}
+  SimVertex::SimVertex(const CoreSimVertex& v, int it, unsigned int vId)
+      : Core(v), itrack(it), vtxId(vId), procType(0) {}
 
-std::ostream& operator<<(std::ostream& o, const SimVertex& v) {
-  return o << (SimVertex::Core)(v) << ", " << v.parentIndex() << ", " << v.vertexId();
-}
+  std::ostream& operator<<(std::ostream& o, const SimVertex& v) {
+    return o << (SimVertex::Core)(v) << ", " << v.parentIndex() << ", " << v.vertexId();
+  }
+}  // namespace io_v1

--- a/SimDataFormats/Vertex/src/classes_def.xml
+++ b/SimDataFormats/Vertex/src/classes_def.xml
@@ -1,15 +1,14 @@
 <lcgdict>
-  <class name="std::vector<SimVertex>"/>
-  <class name="CoreSimVertex" ClassVersion="10">
-   <version ClassVersion="10" checksum="4012086828"/>
+  <class name="std::vector<io_v1::SimVertex>"/>
+  <class name="CoreSimVertex" ClassVersion="3">
+   <version ClassVersion="3" checksum="4012086828"/>
   </class>
-  <class name="SimVertex" ClassVersion="12">
-   <version ClassVersion="11" checksum="801220081"/>
-   <version ClassVersion="12" checksum="802888023"/>
+  <class name="io_v1::SimVertex" ClassVersion="3">
+   <version ClassVersion="3" checksum="2581611991"/>
   </class>
   <class name="edm::SimVertexRef"/>
-  <class name="std::vector<const SimVertex*>"/>
+  <class name="std::vector<const io_v1::SimVertex*>"/>
   <class name="edm::SimVertexRefVector"/>
-  <class name="edm::RefProd<std::vector<SimVertex> >" /> 
-  <class name="edm::Wrapper<std::vector<SimVertex> >" id="03CAAC2E-3EE1-ACA3-D11B-775772E05B18"/>
+  <class name="edm::RefProd<std::vector<io_v1::SimVertex> >" />
+  <class name="edm::Wrapper<std::vector<io_v1::SimVertex> >" id="03CAAC2E-3EE1-ACA3-D11B-775772E05B18"/>
 </lcgdict>


### PR DESCRIPTION
#### PR description:

This PR moves stored classes in the said `SimDataFormats` packages to the `io_v1` namespace

Resolves https://github.com/cms-sw/framework-team/issues/1980

#### PR validation:

Code compiles