### PR TITLE
Add class versions to MtdSim{LayerCluster,Trackster}

### DIFF
--- a/SimDataFormats/CaloAnalysis/src/classes_def.xml
+++ b/SimDataFormats/CaloAnalysis/src/classes_def.xml
@@ -50,7 +50,9 @@
   <class name="MtdSimClusterContainer"/>
 
 
-  <class name="MtdSimLayerCluster"/>
+  <class name="MtdSimLayerCluster" ClassVersion="3">
+    <version ClassVersion="3" checksum="2285442532"/>
+  </class>
   <class name="MtdSimLayerClusterCollection"/>
   <class name="edm::Wrapper<MtdSimLayerClusterCollection>"/>
   <class name="MtdSimLayerClusterRef"/>
@@ -58,7 +60,9 @@
   <class name="MtdSimLayerClusterRefProd"/>
   <class name="MtdSimLayerClusterContainer"/>
 
-  <class name="MtdSimTrackster"/>
+  <class name="MtdSimTrackster" ClassVersion="3">
+    <version ClassVersion="3" checksum="1833899382"/>
+  </class>
   <class name="MtdSimTracksterCollection"/>
   <class name="edm::Wrapper<MtdSimTracksterCollection>"/>
   <class name="MtdSimTracksterRef"/>


### PR DESCRIPTION
#### PR description:

I noticed in https://github.com/cms-sw/cmssw/pull/50416#discussion_r2938956185 these two classes should have class versions in their dictionaries. 

Resolves https://github.com/cms-sw/framework-team/issues/2041

#### PR validation:

Code compiles
