### PR TITLE
Customizer to turn off pixel cluster shape filter

### DIFF
--- a/RecoTracker/Configuration/python/customizePixelClusterShapeFilterOff.py
+++ b/RecoTracker/Configuration/python/customizePixelClusterShapeFilterOff.py
@@ -1,0 +1,6 @@
+from HLTrigger.Configuration.common import esproducers_by_type 
+
+def customizePixelClusterShapeFilterOff(process):
+    for prod in esproducers_by_type(process,'ClusterShapeHitFilterESProducer'):
+        setattr(prod,'doPixelShapeCut',False)
+    return process


### PR DESCRIPTION
#### PR description:

This PR adds a process customizer that can be used to switch off pixel cluster shape filter (cut). To be used for easier calibration of the cut values and to request (Re)Reco with the filter turned off ([example](https://gitlab.cern.ch/cms-ppd/dataset-management/data-reprocessing/-/issues/36#note_11083314)). No changes are expected in the output since it is not used in any workflows.

#### PR validation:

Tested with 
```
cmsDriver.py RECO --conditions 150X_dataRun3_Prompt_Candidate_2026_02_25_10_42_06 --customise RecoTracker/Configuration/customizePixelClusterShapeFilterOff.customizePixelClusterShapeFilterOff --datatier DQMIO --era Run3_2025 --eventcontent DQM --filein "file:dummy.root" --fileout "file:dummy_out.root" --nThreads 4 --no_exec --number 10 --python_filename "test_cfg.py" --scenario pp --step RAW2DIGI,L1Reco,RECO,PAT,$ALCA_STEP,DQM:@rerecoCommon+@hcal2 --no_exec
```

Corresponding config dump reports all PixelShapeCuts as false: `doPixelShapeCut = cms.bool(False)`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 16.0.X, 15.1.X, 15.0.X.

