### PR TITLE
[GCC15][SiPixelClusterizer] Disable array-bounds warning for alpaka/serial backend

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/BuildFile.xml
@@ -21,6 +21,8 @@
   <use name="FWCore/Framework"/>
   <use name="HeterogeneousCore/AlpakaCore"/>
   <use name="HeterogeneousCore/AlpakaInterface"/>
+  <!-- work around for cms-sw/cmssw#50400 -->
+  <use name="no-array-bounds-flag" for="alpaka/serial"/>
   <flags ALPAKA_BACKENDS="1"/>
   <flags EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
Just like https://github.com/cms-sw/cmssw/pull/45455, this is a workaround to disable the false-positive out of array bounds  warning.

strangely gcc 15 only generate these warnings for 
- https://github.com/cms-sw/cmssw/blob/master/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h#L337
- https://github.com/cms-sw/cmssw/blob/master/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h#L384-L385
 
but not for https://github.com/cms-sw/cmssw/blob/master/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h#L319-L321 

This should fix/hide the compilation warnings we are getting for GCC15 ( as reported in #50400)

