### PR TITLE
update unit test for L1-Scouting data formats with files created using `CMSSW_16_1_0_pre3`

### DIFF
--- a/DataFormats/L1Scouting/test/TestL1ScoutingFormat.sh
+++ b/DataFormats/L1Scouting/test/TestL1ScoutingFormat.sh
@@ -8,35 +8,67 @@ cmsRun ${LOCAL_TEST_DIR}/create_L1Scouting_test_file_cfg.py || die 'Failure usin
 
 cmsRun ${LOCAL_TEST_DIR}/read_L1Scouting_cfg.py || die "Failure using read_L1Scouting_cfg.py" $?
 
-# The old files read below were generated as follows.
+# The input files used below were generated
+# using the CMSSW release specified in their names.
 #
-# Check out the release in the filename and use it without modification to make
-# files with split level 99 (maximum possible splitting for each product)
+# For every release in question, two files were created,
+# using either splitLevel=0 or splitLevel=99
+# in the configuration of the EDM output module.
+# More info on the rationale to test both split levels can be found in
+# https://github.com/cms-sw/cmssw/issues/45931
 #
-# Then execute:
+# Below, an example command to produce such files
+# (it assumes the existence of some directories).
 #
-#   cmsRun DataFormats/L1Scouting/test/create_L1Scouting_test_file_cfg.py
+#  for splitLevel in 0 99; do
+#    cmsRun DataFormats/L1Scouting/test/create_L1Scouting_test_file_cfg.py \
+#      -o DataFormats/L1Scouting/data/testL1Scouting_vA_vB_vC_vD_vE_vF_vG_vH_"${CMSSW_VERSION:6}"_split_"${splitLevel}".root \
+#      -s "${splitLevel}"
+#  done
 #
-# Rename the output file.
+# Every pair of files coincides with
+# (a) the introduction of new L1-Scouting data formats, and/or
+# (b) the update of some of the existing data formats.
+# The versioning of newly-introduced data formats starts at "v3".
 #
-# The versions of the classes are encoded in the filenames in
-# alphabetical order. This order is also the order the classes
-# appear in classes_def.xml.
+# The version number of the L1-Scouting data formats is specified
+# in the names of the input files, according to the following order.
 #
-# For the split level 0 files, do the exact same thing except
-# add the following to the output module configuration.
-#     "splitLevel = cms.untracked.int32(0)"
+#  l1ScoutingRun3::Muon
+#  l1ScoutingRun3::EGamma
+#  l1ScoutingRun3::Tau
+#  l1ScoutingRun3::Jet
+#  l1ScoutingRun3::BxSums
+#  l1ScoutingRun3::BMTFStub
+#  l1ScoutingRun3::CaloTower
+#  l1ScoutingRun3::CaloJet
+#
+# For files produced before the introduction of a given class,
+# only the versions of the previous classes are included in the name of the files.
 
 # test file for muon, jet, e/gamma, tau and energy sums data formats
 oldFiles="testL1Scouting_v3_v3_v3_v3_v3_14_0_0_split_99.root testL1Scouting_v3_v3_v3_v3_v3_14_0_0_split_0.root"
 for file in $oldFiles; do
   inputfile=$(edmFileInPath DataFormats/L1Scouting/data/$file) || die "Failure edmFileInPath DataFormats/L1Scouting/data/$file" $?
-  cmsRun ${LOCAL_TEST_DIR}/read_L1Scouting_cfg.py -i "$inputfile" --bmtfStubVersion 0 --caloTowerVersion 0 --caloJetVersion 0 || die "Failed to read old file $file" $?
+  cmsRunArgs="-i ${inputfile}"
+  cmsRunArgs+=" --bmtfStubVersion 0 --caloTowerVersion 0 --caloJetVersion 0"
+  cmsRun ${LOCAL_TEST_DIR}/read_L1Scouting_cfg.py ${cmsRunArgs} || die "Failed to read old file $file" $?
 done
 
 # added BMTF input stubs data format
 oldFiles="testL1Scouting_v3_v3_v3_v3_v3_v3_14_1_0_pre5_split_99.root testL1Scouting_v3_v3_v3_v3_v3_v3_14_1_0_pre5_split_0.root"
 for file in $oldFiles; do
   inputfile=$(edmFileInPath DataFormats/L1Scouting/data/$file) || die "Failure edmFileInPath DataFormats/L1Scouting/data/$file" $?
-  cmsRun ${LOCAL_TEST_DIR}/read_L1Scouting_cfg.py -i "$inputfile" --bmtfStubVersion 3 --caloTowerVersion 0 --caloJetVersion 0 || die "Failed to read old file $file" $?
+  cmsRunArgs="-i ${inputfile}"
+  cmsRunArgs+=" --bmtfStubVersion 3 --caloTowerVersion 0 --caloJetVersion 0"
+  cmsRun ${LOCAL_TEST_DIR}/read_L1Scouting_cfg.py ${cmsRunArgs} || die "Failed to read old file $file" $?
+done
+
+# added CaloTower and CaloJet data formats
+oldFiles="testL1Scouting_v3_v3_v3_v3_v3_v3_v3_v3_16_1_0_pre3_split_0.root testL1Scouting_v3_v3_v3_v3_v3_v3_v3_v3_16_1_0_pre3_split_99.root"
+for file in $oldFiles; do
+  inputfile=$(edmFileInPath DataFormats/L1Scouting/data/$file) || die "Failure edmFileInPath DataFormats/L1Scouting/data/$file" $?
+  cmsRunArgs="-i ${inputfile}"
+  cmsRunArgs+=" --bmtfStubVersion 3 --caloTowerVersion 3 --caloJetVersion 3"
+  cmsRun ${LOCAL_TEST_DIR}/read_L1Scouting_cfg.py ${cmsRunArgs} || die "Failed to read old file $file" $?
 done


### PR DESCRIPTION
#### PR description:

This is a routine update of the unit test in `DataFormats/L1Scouting/test/TestL1ScoutingFormat.sh`, given the introduction of two new L1-Scouting data formats in `CMSSW_16_1_0_pre3`, i.e.
 - `l1ScoutingRun3::CaloTower` ([cms-sw/cmssw#48093](https://github.com/cms-sw/cmssw/pull/48093)) and
 - `l1ScoutingRun3::CaloJet` ([cms-sw/cmssw#50304](https://github.com/cms-sw/cmssw/pull/50304)).

The comments inside the main executable of the unit test are improved accordingly.

This PR requires [cms-data/DataFormats-L1Scouting#6](https://github.com/cms-data/DataFormats-L1Scouting/pull/6).

#### PR validation:

The unit test in question passes.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A (no backports needed).
