### PR TITLE
[16.0.X] Customizer to turn off pixel cluster shape filter

### DIFF
--- a/RecoTracker/Configuration/python/customizePixelClusterShapeFilterOff.py
+++ b/RecoTracker/Configuration/python/customizePixelClusterShapeFilterOff.py
@@ -1,0 +1,6 @@
+from HLTrigger.Configuration.common import esproducers_by_type 
+
+def customizePixelClusterShapeFilterOff(process):
+    for prod in esproducers_by_type(process,'ClusterShapeHitFilterESProducer'):
+        setattr(prod,'doPixelShapeCut',False)
+    return process


### PR DESCRIPTION
**PR description:**

This PR adds a process customizer that can be used to switch off pixel cluster shape filter (cut). To be used for easier calibration of the cut values and to request (Re)Reco with the filter turned off ([example](https://gitlab.cern.ch/cms-ppd/dataset-management/data-reprocessing/-/issues/36#note_11083314)). No changes are expected in the output since it is not used in any workflows.

16.0.X backport of https://github.com/cms-sw/cmssw/pull/50421

