### PR TITLE
[EVOLUTION_X] Fix destructors of EtSum, L1Candidate, Muon, and MuonShower

### DIFF
--- a/DataFormats/L1Trigger/src/EtSum.cc
+++ b/DataFormats/L1Trigger/src/EtSum.cc
@@ -6,7 +6,7 @@ l1t::EtSum::EtSum(const LorentzVector& p4, EtSumType type, int pt, int eta, int 
 l1t::EtSum::EtSum(const PolarLorentzVector& p4, EtSumType type, int pt, int eta, int phi, int qual)
     : L1Candidate(p4, pt, eta, phi, qual, 0), type_(type) {}
 
-l1t::EtSum::~EtSum() {}
+l1t::io_v1::EtSum::~EtSum() {}
 
 void l1t::EtSum::setType(EtSumType type) { type_ = type; }
 

--- a/DataFormats/L1Trigger/src/L1Candidate.cc
+++ b/DataFormats/L1Trigger/src/L1Candidate.cc
@@ -9,7 +9,7 @@ l1t::L1Candidate::L1Candidate(const LorentzVector& p4, int pt, int eta, int phi,
 l1t::L1Candidate::L1Candidate(const PolarLorentzVector& p4, int pt, int eta, int phi, int qual, int iso)
     : LeafCandidate((char)0, p4), hwPt_(pt), hwEta_(eta), hwPhi_(phi), hwQual_(qual), hwIso_(iso) {}
 
-l1t::L1Candidate::~L1Candidate() {}
+l1t::io_v1::L1Candidate::~L1Candidate() {}
 
 bool l1t::L1Candidate::operator==(const l1t::L1Candidate& rhs) const {
   return hwPt_ == rhs.hwPt() && hwEta_ == rhs.hwEta() && hwPhi_ == rhs.hwPhi() && hwQual_ == rhs.hwQual() &&

--- a/DataFormats/L1Trigger/src/Muon.cc
+++ b/DataFormats/L1Trigger/src/Muon.cc
@@ -99,7 +99,7 @@ l1t::Muon::Muon(const PolarLorentzVector& p4,
       ptUnconstrained_(ptUnconstrained),
       hwDXY_(dXY) {}
 
-l1t::Muon::~Muon() {}
+l1t::io_v1::Muon::~Muon() {}
 
 bool l1t::Muon::operator==(const l1t::Muon& rhs) const {
   return l1t::L1Candidate::operator==(static_cast<const l1t::L1Candidate&>(rhs)) && hwCharge_ == rhs.hwCharge() &&

--- a/DataFormats/L1Trigger/src/MuonShower.cc
+++ b/DataFormats/L1Trigger/src/MuonShower.cc
@@ -16,7 +16,7 @@ l1t::MuonShower::MuonShower(bool oneNominalInTime,
       musOutOfTime0_(false),
       musOutOfTime1_(false) {}
 
-l1t::MuonShower::~MuonShower() {}
+l1t::io_v1::MuonShower::~MuonShower() {}
 
 bool l1t::MuonShower::isValid() const {
   return oneNominalInTime_ or oneTightInTime_ or twoLooseDiffSectorsInTime_ or musOutOfTime0_ or musOutOfTime1_;


### PR DESCRIPTION
#### PR description:

This PR should fix static analyzer errors like
```
src/DataFormats/L1Trigger/src/EtSum.cc:9:13: error: destructor cannot be declared using a type alias 'EtSum' (aka 'l1t::io_v1::EtSum') of the class name [-Wdtor-typedef]
    9 | l1t::EtSum::~EtSum() {}
      |             ^
1 error generated.
```

Resolves https://github.com/cms-sw/framework-team/issues/2051

#### PR validation:

None