### PR TITLE
[MUO] Remove selection on muon in custom MUO flavored NanoAOD

### DIFF
--- a/PhysicsTools/NanoAOD/python/custom_muon_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_muon_cff.py
@@ -365,6 +365,13 @@ def IncreaseGenPrecesion(process):
     
     return process
 
+def ModifyMuonSelection(process):
+
+    process.finalMuons.cut = cms.string("pt > 2")
+
+    return process
+
+
 def PrepMuonCustomNanoAOD(process):
     
     process = Custom_Muon_Task(process)
@@ -372,6 +379,6 @@ def PrepMuonCustomNanoAOD(process):
     process = AddVariablesForMuon(process)
     process = AddTriggerObjectBits(process)
     process = IncreaseGenPrecesion(process)
-
+    process = ModifyMuonSelection(process)
 
     return process


### PR DESCRIPTION
#### PR description:

This PR adds a method to custom the selection of the muons entering in the MUO flavored NanoAOD.
Specifically, it removes the selection applied on the ID of the muons that it's inherited from standard NanoAOD and saves all the muons with a pt of at least 2 GeV.

This change is needed to use the NanoAOD to measure **muon tracking efficiencies**, as well as **removing potential biases** arising from any preselection in other measurements at pt values below 15 GeV.

This issue was presented in the last [PPD General meeting](https://indico.cern.ch/event/1653664/#3-muo-look-into-2025-data-with), described [here](https://indico.cern.ch/event/1653664/contributions/6950834/attachments/3237560/5773384/CFM_PPD_trackingEfficiency.pdf#page=3).

We would like to have this change integrated in any release to be used in future NanoAOD processings (or re-processings of previously produced versions).

FYI: @bonanomi  @cms-sw/ppd-l2 

#### PR validation:

Checked out all dependencies, had a clean build, and standard tests succeed. Physics results and motivation presented in [PPD General meeting](https://indico.cern.ch/event/1653664/#3-muo-look-into-2025-data-with).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport.
