### PR TITLE
Fix: Add missing buffer flush for PCL to MillePedeAlignmentAlgorithm

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
@@ -742,8 +742,11 @@ void MillePedeAlignmentAlgorithm::beginLuminosityBlock(const edm::EventSetup &) 
 void MillePedeAlignmentAlgorithm::endLuminosityBlock(const edm::EventSetup &) {
   if (!runAtPCL_)
     return;
-  if (this->isMode(myMilleBit))
+  if (this->isMode(myMilleBit)) {
     theMille->flushOutputFile();
+    // GBL output has to be flushed also at end of LB - otherwise miss final LB of job.
+    theBinary.reset();
+  }
 }
 
 //____________________________________________________


### PR DESCRIPTION
#### PR description:

This PR adds a missing buffer flush call to `MillePedeAlignmentAlgorithm::endLuminosityBlock`. 
The missing call was resulting in the final dimuon track of a job to be truncated at the time the alignment FileBlob was written into the ALCARECO output, resulting in corrupted alignment data and failing high-granularity PCL alignment jobs.
Longer description below. 

#### PR validation:

[ :heavy_check_mark: ] Confirm that local re-running of PCL job with the change results in a succesful alignment
[ :heavy_check_mark: ] Unit tests pass 
[ :heavy_check_mark: ] `runTheMatrix` WF 1000,1001,1001.2,1001.3,1001.4,1002.3,1002.4,1002 (modulo 5 x "input file not found" - known and unrelated to the PR)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is only intended as a bugfix for `16_0_X` to fix the ongoing PCL high-granularity alignment involving dimuons. 
In `master` (already merged in #49963), a new writing pattern for `Mille` was adopted that also fixes this issue. 

CC @lpnair

### Detailed description of bug: 

- The MillePedeAlignmentAlgorithm has two separate Mille write buffers writing into the same file:
  - `theMille`: Used when a reference trajectory exists (MinBias)
  - `theBinary`: Used to talk to the GBL interface inside the algorithm, used for dimuon pairs
  - both write into the same file, but need separate calls to flush their buffers to disk.
- the sequence of calls at the end of a PCL job is : 
  1) `MillePedeAlignmentAlgorithm::endLuminosityBlock`
     - this flushes only `theMille`, but not `theBinary` 
  2) `MillePedeFileConverter::endLuminosityBlockProduce`
     - this reads the Mille binary file from disk and writes a 1:1 carbon copy as a `FileBlob` into the output ALCARECO file. 
  3) `MillePedeAlignmentAlgorithm::terminate`
     - this resets and closes both `theMille` and `theBinary` - leading to any remaining buffers being flushed to disk. 
- the bug: We are missing a final flush of the buffer from `theBinary` before producing the `FileBlob`
  - in our test example, the file at the time of file blob extraction is 46kB, but another 5kB (half of the final record) are written to the file after this call (in `terminate`) - and thus missed in the `FileBlob`. 

Consequence: 
 - The final record of the dimuon stream is truncated. 
 - The corresponding binary is corrupt 
    - from Mille's point of view - it is a valid file, but no complete Mille record can be decoded from it.

**Proposed Fix in this PR**: Make sure to flush the `theBinary` buffer to disk in `MillePedeAlignmentAlgorithm::endLuminosityBlock` with a minimal change. 