### PR TITLE
fix lookup of pede exit code

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.cc
@@ -828,8 +828,11 @@ int PedeSteerer::runPede(const std::string &masterSteer) const {
   // The real pede return flag is written into
   // a single-character 'millepede.end'
   // file. Read this here.
-  std::ifstream mpend("millepede.end");  // open the Pede exit code file
-  std::string statusMessage;
+  std::string mpExit = "millepede.end";
+  if (!myRunDirectory.empty())
+    mpExit = myRunDirectory + "/" + mpExit;
+  std::ifstream mpend(mpExit);  // open the Pede exit code file
+  std::string statusMessage = "";
 
   if (shellReturn != 0 || !mpend.is_open()) {
     edm::LogError("Alignment") << "@SUB=PedeSteerer::runPede"


### PR DESCRIPTION
#### PR description:

- The `PedeSteerer` was not correctly accounting for a possible sub-directory for running the `pede` alignment fit. As a result, in such cases, the exit code file would not be found and a severe error reported in spite of a successful job.
- This PR ensures the file is correctly located. 

#### PR validation:

- [ :heavy_check_mark: ]  Exit code is now correctly parsed in workflows where `pede` runs in a subdirectory. 
- [ :heavy_check_mark: ]   unit tests 
- [ :heavy_check_mark: ]  `runTheMatrix` tests - WF 1000,1001,1001.2,1001.3,1001.4,1002.3,1002.4,1002.5

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport to `16_0_X` requested by @mmusich (may want to confirm). 


CC @lpnair for information. 

