### PR TITLE
Backport #50449 - pede exit code

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.cc
@@ -828,8 +828,11 @@ int PedeSteerer::runPede(const std::string &masterSteer) const {
   // The real pede return flag is written into
   // a single-character 'millepede.end'
   // file. Read this here.
-  std::ifstream mpend("millepede.end");  // open the Pede exit code file
-  std::string statusMessage;
+  std::string mpExit = "millepede.end";
+  if (!myRunDirectory.empty())
+    mpExit = myRunDirectory + "/" + mpExit;
+  std::ifstream mpend(mpExit);  // open the Pede exit code file
+  std::string statusMessage = "";
 
   if (shellReturn != 0 || !mpend.is_open()) {
     edm::LogError("Alignment") << "@SUB=PedeSteerer::runPede"


### PR DESCRIPTION
#### PR description:

Backporting #50449 - the `PedeSteerer` was not accounting for a possible sub-directory when looking for the `pede` exit code, leading to error messages in jobs configured to run the fit in a subdirectory, regardless of the true outcome. 

#### PR validation:

- [ ✔️ ] Validation in `master` on parent PR 
- [ ✔️ ] check of PCL-style campaign in `16_0_X`:  Exit code now correctly found and information being printed as intended
- [ ✔️ ] unit tests in `16_0_X` pass
- [ ✔️ ] `runTheMatrix` WF 1000,1001,1001.2,1001.3,1001.4,1002.3,1002.4,1002.5 succeed in `16_0_X`  

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #50449 - requested by @mmusich, and needed to avoid spurious error / warning messages and to properly detect potential genuine failures in the PCL workflow. 

CC @lpnair for info