### PR TITLE
Update HI MC and Run3 offline data GTs in autoCond - [CMSSW_16_0_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -108,7 +108,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2025, Strip tracker in DECO mode
     'phase1_2025_cosmics'          :    '150X_mcRun3_2025cosmics_realistic_deco_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2025 detector for Heavy Ion
-    'phase1_2025_realistic_hi'     :    '151X_mcRun3_2025_realistic_HI_v4',
+    'phase1_2025_realistic_hi'     :    '151X_mcRun3_2025_realistic_HI_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2026
     'phase1_2026_design'           :    '160X_mcRun3_2026_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2026
@@ -116,7 +116,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2026, Strip tracker in DECO mode
     'phase1_2026_cosmics'          :    '160X_mcRun3_2026cosmics_realistic_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2026 detector for Heavy Ion
-    'phase1_2026_realistic_hi'     :    '151X_mcRun3_2025_realistic_HI_v4',
+    'phase1_2026_realistic_hi'     :    '151X_mcRun3_2025_realistic_HI_v5',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '150X_mcRun4_realistic_v1'
 }

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -37,8 +37,8 @@ autoCond = {
     'run3_data_express'            :    '160X_dataRun3_Express_frozen260223_v1',
     # GlobalTag for Run3 data relvals (prompt GT): same as 160X_dataRun3_Prompt_v1 but with snapshot at 2026-02-23 14:53:19 (UTC)
     'run3_data_prompt'             :    '160X_dataRun3_Prompt_frozen260223_v1',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2025-11-11 14:11:48 (UTC)
-    'run3_data'                    :    '150X_dataRun3_v6',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2026-03-17 08:48:50 (UTC)
+    'run3_data'                    :    '150X_dataRun3_v7',
     # GlobalTag for Run3 offline data reprocessing with Prompt GT, currently for 2022FG - snapshot at 2024-05-31 08:53:25 (UTC)
     'run3_data_PromptAnalysis'     :    '140X_dataRun3_PromptAnalysis_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
@@ -108,7 +108,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2025, Strip tracker in DECO mode
     'phase1_2025_cosmics'          :    '150X_mcRun3_2025cosmics_realistic_deco_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2025 detector for Heavy Ion
-    'phase1_2025_realistic_hi'     :    '151X_mcRun3_2025_realistic_HI_v2',
+    'phase1_2025_realistic_hi'     :    '151X_mcRun3_2025_realistic_HI_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2026
     'phase1_2026_design'           :    '160X_mcRun3_2026_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2026
@@ -116,7 +116,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2026, Strip tracker in DECO mode
     'phase1_2026_cosmics'          :    '160X_mcRun3_2026cosmics_realistic_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2026 detector for Heavy Ion
-    'phase1_2026_realistic_hi'     :    '151X_mcRun3_2025_realistic_HI_v2',
+    'phase1_2026_realistic_hi'     :    '151X_mcRun3_2025_realistic_HI_v4',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '150X_mcRun4_realistic_v1'
 }


### PR DESCRIPTION
#### PR description:

Update the HI MC GT in autocond with all the conditions mentioned in [this cmsTalk](https://cms-talk.web.cern.ch/t/gt-mc-queue-request-for-a-pbpb-run-mc-queue-in-151x/128302/17?u=sayoo) and in [this presentation](https://indico.cern.ch/event/1655148/#5-follow-up-on-beamspot-condit) and with the DeDx calibration tag proposed in https://cms-talk.web.cern.ch/t/gt-mc-queue-request-for-a-pbpb-run-mc-queue-in-151x/128302/20
Furthermore, it was updated in the previous version of this HI MC GT also the PbPb Centrality calibration tag as requested [here](https://cms-talk.web.cern.ch/t/2024-pbpb-calibration/136052/31).

Update the Run3 data GT with a snapshot as of 2026-03-17 08:48:50 (UTC), in order to allow the most recent Tracker Alignment payloads listed in https://cms-talk.web.cern.ch/t/gt-offline-new-offline-gt-with-updated-tracker-alignment-conditions/141387

The new GTs in autocond are 
- [151X_mcRun3_2025_realistic_HI_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/151X_mcRun3_2025_realistic_HI_v5)
- [150X_dataRun3_v7](https://cms-conddb.cern.ch/cmsDbBrowser/search/Prod/150X_dataRun3_v7)

The differences with respect to their previous versions in autoCond are the following:
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/151X_mcRun3_2025_realistic_HI_v5/151X_mcRun3_2025_realistic_HI_v2
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/150X_dataRun3_v7/150X_dataRun3_v6

#### PR validation:

Master PR runs successfully

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #50443 and #50507