### PR TITLE
L1S: fix value of `hwPhi` in CaloTower unpacker [`16_0_X`]

### DIFF
--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScCaloTowerRawToDigi.cc
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScCaloTowerRawToDigi.cc
@@ -144,6 +144,7 @@ void ScCaloTowerRawToDigi::unpackOrbit(const unsigned char* buf, size_t len, int
                   l1ScoutingRun3::calol1::masksCaloTowers::miscBits);
 
       phi = ((ct_raw >> l1ScoutingRun3::calol1::shiftsCaloTowers::phi) & l1ScoutingRun3::calol1::masksCaloTowers::phi);
+      phi += 1;
 
       eta = ((ct_raw >> l1ScoutingRun3::calol1::shiftsCaloTowers::eta) & l1ScoutingRun3::calol1::masksCaloTowers::eta);
       eta = eta >= 128 ? eta - 256 : eta;


### PR DESCRIPTION
backport of #50468

#### PR description:

From the description of #50468:
>While validating L1-Scouting data from recent runs, it was found that the CaloTower `hwPhi` value unpacked from Scouting-Raw-Data is in the range [0,71], so it needs to be shifted by 1 to match the `hwPhi` value of the L1T CaloTowers in standard raw data (a similar shift is applied in the L1T unpacker for CaloTowers, see [EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloTowerUnpacker.cc#L60](https://github.com/cms-sw/cmssw/blob/6d30470bc6ebdfbb9b0da66e3bd2c1ae42614360/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloTowerUnpacker.cc#L60)).
>
>This fix only affects L1-Scouting data-taking workflows. At the moment, the plugin in question is not tested in CMSSW IBs, so no changes are expected in the PR tests.

#### PR validation:

Private checks on 2026 L1-Scouting data.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#50468

Fix needed for L1-Scouting data-taking in 2026.