### PR TITLE
[16.0.X] Introduce `SiStripDetVOff` comparison `TrackerMaps` and improve IOV handling

### DIFF
--- a/CommonTools/TrackerMap/interface/TrackerMap.h
+++ b/CommonTools/TrackerMap/interface/TrackerMap.h
@@ -83,6 +83,7 @@ public:
   void build();
   void init();
   void drawModule(TmModule* mod, int key, int layer, bool total, std::ofstream* file);
+  void setBackgroundColor(Color_t color = 38);
   void print(bool print_total = true, float minval = 0., float maxval = 0., std::string s = "svgmap");
   void printall(bool print_total = true,
                 float minval = 0.,
@@ -669,6 +670,7 @@ protected:
   bool temporary_file;
 
 private:
+  Color_t padColor_;
   float oldz;
   bool saveAsSingleLayer;
   bool addPixelFlag;

--- a/CommonTools/TrackerMap/src/TrackerMap.cc
+++ b/CommonTools/TrackerMap/src/TrackerMap.cc
@@ -1,32 +1,34 @@
-#include "CommonTools/TrackerMap/interface/TrackerMap.h"
-#include "CommonTools/TrackerMap/interface/TmModule.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSet/interface/FileInPath.h"
-#include "CondFormats/SiStripObjects/interface/FedChannelConnection.h"
-#include "CalibFormats/SiStripObjects/interface/SiStripFecCabling.h"
-#include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "CommonTools/TrackerMap/interface/TmApvPair.h"
-#include "CommonTools/TrackerMap/interface/TmCcu.h"
-#include "CommonTools/TrackerMap/interface/TmPsu.h"
-#include "FWCore/Utilities/interface/isFinite.h"
 #include <fstream>
-#include <vector>
 #include <iostream>
 #include <sstream>
-#include "TCanvas.h"
-#include "TPolyLine.h"
-#include "TStyle.h"
-#include "TColor.h"
-#include "TROOT.h"
-#include "TGaxis.h"
-#include "TLatex.h"
+#include <vector>
+
+#include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripFecCabling.h"
+#include "CommonTools/TrackerMap/interface/TmApvPair.h"
+#include "CommonTools/TrackerMap/interface/TmCcu.h"
+#include "CommonTools/TrackerMap/interface/TmModule.h"
+#include "CommonTools/TrackerMap/interface/TmPsu.h"
+#include "CommonTools/TrackerMap/interface/TrackerMap.h"
+#include "CondFormats/SiStripObjects/interface/FedChannelConnection.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/isFinite.h"
+
 #include "TArrow.h"
-#include "TLegend.h"
+#include "TCanvas.h"
+#include "TColor.h"
+#include "TGaxis.h"
+#include "TGraph.h"
 #include "TH1F.h"
 #include "TH2Poly.h"
-#include "TGraph.h"
+#include "TLatex.h"
+#include "TLegend.h"
 #include "TPaletteAxis.h"
+#include "TPolyLine.h"
+#include "TROOT.h"
+#include "TStyle.h"
 
 /**********************************************************
 Allocate all the modules in a map of TmModule
@@ -37,6 +39,7 @@ when the user starts to fill it.
 TrackerMap::TrackerMap(const edm::ParameterSet &tkmapPset,
                        const SiStripFedCabling *tkFed,
                        const TrackerTopology *const topology) {
+  padColor_ = 38;
   psetAvailable = true;
   xsize = 340;
   ysize = 200;
@@ -417,6 +420,7 @@ TrackerMap::TrackerMap(const edm::ParameterSet &tkmapPset,
 }
 
 TrackerMap::TrackerMap(const edm::ParameterSet &tkmapPset) {
+  padColor_ = 38;
   psetAvailable = true;
   xsize = 340;
   ysize = 200;
@@ -442,6 +446,7 @@ TrackerMap::TrackerMap(const edm::ParameterSet &tkmapPset) {
 }
 
 TrackerMap::TrackerMap(std::string s, int xsize1, int ysize1) {
+  padColor_ = 38;
   psetAvailable = false;
   xsize = xsize1;
   ysize = ysize1;
@@ -967,7 +972,7 @@ void TrackerMap::save(bool print_total, float minval, float maxval, std::string 
       double x[4], y[4];
       std::ifstream tempfile(tempfilename.c_str(), std::ios::in);
       TCanvas *MyC = new TCanvas("MyC", "TrackerMap", width, height);
-      gPad->SetFillColor(38);
+      gPad->SetFillColor(padColor_);
 
       if (addPixelFlag) {
         gPad->Range(0, 0, 3800, 1600);
@@ -3092,6 +3097,9 @@ void TrackerMap::load(std::string inputfilename) {
   inputfile->close();
   delete inputfile;
 }
+
+//sets the background color
+void TrackerMap::setBackgroundColor(Color_t color) { padColor_ = color; }
 
 //print in svg format tracker map
 //print_total = true represent in color the total stored in the module

--- a/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
@@ -56,10 +56,11 @@ namespace {
     SiStripDetVOff_TrackerMapBase() : PlotImage<SiStripDetVOff, SINGLE_IOV>("Tracker Map: Is Module VOff") {}
 
     bool fill() override {
-      auto tag = PlotBase::getTag<0>();
-      auto iov = tag.iovs.front();
-      auto tagname = tag.name;
-      unsigned long IOVsince = std::get<0>(iov);
+      const auto& tag = PlotBase::getTag<0>();
+      cond::Tag_t tagInfo = PlotBase::getTagInfo(tag.name);
+      const auto& iov = tag.iovs.front();
+      const auto& tagname = tag.name;
+      const auto& IOVsince = std::get<0>(iov);
       std::shared_ptr<SiStripDetVOff> payload = fetchPayload(std::get<1>(iov));
 
       std::unique_ptr<TrackerMap> tmap = std::make_unique<TrackerMap>("SiStripIsModuleVOff");
@@ -68,16 +69,18 @@ namespace {
 
       switch (my_type) {
         case SiStripDetVOffPI::t_LV: {
-          titleMap = fmt::sprintf("TrackerMap of LV VOff modules | Tag: %s | IOV: %s", tagname, getIOVsince(IOVsince));
+          titleMap = fmt::sprintf(
+              "TrackerMap of LV VOff modules | Tag: %s | IOV: %s", tagname, getIOVsince(tagInfo, IOVsince));
           break;
         }
         case SiStripDetVOffPI::t_HV: {
-          titleMap = fmt::sprintf("TrackerMap of HV VOff modules | Tag: %s | IOV: %s", tagname, getIOVsince(IOVsince));
+          titleMap = fmt::sprintf(
+              "TrackerMap of HV VOff modules | Tag: %s | IOV: %s", tagname, getIOVsince(tagInfo, IOVsince));
           break;
         }
         case SiStripDetVOffPI::t_V: {
-          titleMap =
-              fmt::sprintf("TrackerMap of VOff modules (HV or LV) | Tag: %s | IOV: %s", tagname, getIOVsince(IOVsince));
+          titleMap = fmt::sprintf(
+              "TrackerMap of VOff modules (HV or LV) | Tag: %s | IOV: %s", tagname, getIOVsince(tagInfo, IOVsince));
           break;
         }
         default:
@@ -106,21 +109,33 @@ namespace {
     }
 
   private:
-    const char* getIOVsince(const unsigned long IOV) {
-      int run = 0;
+    const char* getIOVsince(const cond::Tag_t& tagInfo, cond::Time_t IOV) {
       static char buf[256];
+      buf[0] = '\0';
 
-      if (IOV < 4294967296) {  // run type IOV
-        run = IOV;
-        std::sprintf(buf, "%d", run);
-      } else {  // time type IOV
-        run = IOV >> 32;
-        time_t t = run;
+      if (tagInfo.timeType == cond::runnumber) {
+        unsigned int run = static_cast<unsigned int>(IOV);
+        std::snprintf(buf, sizeof(buf), "%u", run);
+      }
+
+      else if (tagInfo.timeType == cond::lumiid) {
+        unsigned int run = IOV >> 32;
+        unsigned int lumi = IOV & 0xFFFFFFFF;
+        std::snprintf(buf, sizeof(buf), "%u:%u", run, lumi);
+      }
+
+      else if (tagInfo.timeType == cond::timestamp) {
+        time_t t = IOV >> 32;  // seconds part
         struct tm lt;
         localtime_r(&t, &lt);
-        strftime(buf, sizeof(buf), "%F %R:%S", &lt);
-        buf[sizeof(buf) - 1] = 0;
+        strftime(buf, sizeof(buf), "%F %T", &lt);
       }
+
+      else {
+        std::snprintf(buf, sizeof(buf), "%llu", (unsigned long long)IOV);
+      }
+
+      buf[sizeof(buf) - 1] = 0;
       return buf;
     }
   };
@@ -449,7 +464,7 @@ namespace {
   /************************************************
    TrackerMap of difference per Module L- H- L||V Voff
   *************************************************/
-  template <int ntags, IOVMultiplicity nIOVs>
+  template <int ntags, IOVMultiplicity nIOVs, SiStripDetVOffPI::type my_type>
   class SiStripDetVOffComparisonTrackerMapBase : public PlotImage<SiStripDetVOff, nIOVs, ntags> {
   public:
     SiStripDetVOffComparisonTrackerMapBase()
@@ -457,18 +472,21 @@ namespace {
 
     bool fill() override {
       // trick to deal with the multi-ioved tag and two tag case at the same time
-      auto theIOVs = PlotBase::getTag<0>().iovs;
-      auto tagname1 = PlotBase::getTag<0>().name;
+      const auto& theIOVs = PlotBase::getTag<0>().iovs;
+      const auto& tagname1 = PlotBase::getTag<0>().name;
       std::string tagname2 = "";
-      auto firstiov = theIOVs.front();
+      cond::Tag_t tagInfo1 = PlotBase::getTagInfo(tagname1);
+      cond::Tag_t tagInfo2 = tagInfo1;
+      const auto& firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
 
       // we don't support (yet) comparison with more than 2 tags
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
-        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        const auto& tag2iovs = PlotBase::getTag<1>().iovs;
         tagname2 = PlotBase::getTag<1>().name;
+        tagInfo2 = PlotBase::getTagInfo(tagname2);
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -480,14 +498,16 @@ namespace {
       if (!payload1 || !payload2)
         return false;
 
-      std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
-      std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
+      const auto& lastIOVsince = std::get<0>(lastiov);
+      const auto& firstIOVsince = std::get<0>(firstiov);
 
       std::stringstream title;
-      title << "SiStripDetVOff comparison\n"
-            << "IOV " << firstIOVsince << " -> " << lastIOVsince;
+      title << "SiStripDetVOff comparison (" << typeLabel(my_type) << ")\n"
+            << " IOV " << getIOVsince(tagInfo1, firstIOVsince) << " -> " << getIOVsince(tagInfo2, lastIOVsince);
 
       std::unique_ptr<TrackerMap> tmap = std::make_unique<TrackerMap>(title.str());
+      // change color background
+      tmap->setBackgroundColor(30);
 
       //---------------------------------------
       // build union of detids
@@ -521,9 +541,28 @@ namespace {
       // loop modules
       //---------------------------------------
 
+      bool off1, off2;
       for (auto detid : detids) {
-        bool off1 = payload1->IsModuleVOff(detid);
-        bool off2 = payload2->IsModuleVOff(detid);
+        switch (my_type) {
+          case SiStripDetVOffPI::t_LV: {
+            off1 = payload1->IsModuleLVOff(detid);
+            off2 = payload2->IsModuleLVOff(detid);
+            break;
+          }
+          case SiStripDetVOffPI::t_HV: {
+            off1 = payload1->IsModuleHVOff(detid);
+            off2 = payload2->IsModuleHVOff(detid);
+            break;
+          }
+          case SiStripDetVOffPI::t_V: {
+            off1 = payload1->IsModuleVOff(detid);
+            off2 = payload2->IsModuleVOff(detid);
+            break;
+          }
+          default:
+            edm::LogError("SiStripDetVOffComparisonTrackerMapBase") << "Unrecognized type: " << my_type << std::endl;
+            break;
+        }
 
         float value = 0;
 
@@ -591,21 +630,70 @@ namespace {
       // save
       //---------------------------------------
 
-      std::string fileName = "SiStripDetVOffComparisonTrackerMap.png";
-
-      tmap->setPalette(1);  // after setting palette ensure background not cyan
-      gStyle->SetCanvasColor(kWhite);
-      
+      std::string fileName(this->m_imageFileName);
       tmap->save(true, 0, 0, fileName);
-
-      this->m_imageFileName = fileName;
 
       return true;
     }
+
+  private:
+    const char* getIOVsince(const cond::Tag_t& tagInfo, cond::Time_t IOV) {
+      static char buf[256];
+      buf[0] = '\0';
+
+      if (tagInfo.timeType == cond::runnumber) {
+        unsigned int run = static_cast<unsigned int>(IOV);
+        std::snprintf(buf, sizeof(buf), "%u", run);
+      }
+
+      else if (tagInfo.timeType == cond::lumiid) {
+        unsigned int run = IOV >> 32;
+        unsigned int lumi = IOV & 0xFFFFFFFF;
+        std::snprintf(buf, sizeof(buf), "%u:%u", run, lumi);
+      }
+
+      else if (tagInfo.timeType == cond::timestamp) {
+        time_t t = IOV >> 32;  // seconds part
+        struct tm lt;
+        localtime_r(&t, &lt);
+        strftime(buf, sizeof(buf), "%F %T", &lt);
+      }
+
+      else {
+        std::snprintf(buf, sizeof(buf), "%llu", (unsigned long long)IOV);
+      }
+
+      buf[sizeof(buf) - 1] = 0;
+      return buf;
+    }
+
+    constexpr const char* typeLabel(SiStripDetVOffPI::type t) {
+      switch (t) {
+        case SiStripDetVOffPI::t_LV:
+          return "LV";
+        case SiStripDetVOffPI::t_HV:
+          return "HV";
+        case SiStripDetVOffPI::t_V:
+          return "LV OR HV";
+      }
+      return "";
+    }
   };
 
-  using SiStripDetVOffComparisonTrackerMapSingleTag = SiStripDetVOffComparisonTrackerMapBase<1, MULTI_IOV>;
-  using SiStripDetVOffComparisonTrackerMapTwoTags = SiStripDetVOffComparisonTrackerMapBase<2, SINGLE_IOV>;
+  using SiStripDetLVOffComparisonTrackerMapSingleTag =
+      SiStripDetVOffComparisonTrackerMapBase<1, MULTI_IOV, SiStripDetVOffPI::t_LV>;
+  using SiStripDetLVOffComparisonTrackerMapTwoTags =
+      SiStripDetVOffComparisonTrackerMapBase<2, SINGLE_IOV, SiStripDetVOffPI::t_LV>;
+
+  using SiStripDetHVOffComparisonTrackerMapSingleTag =
+      SiStripDetVOffComparisonTrackerMapBase<1, MULTI_IOV, SiStripDetVOffPI::t_HV>;
+  using SiStripDetHVOffComparisonTrackerMapTwoTags =
+      SiStripDetVOffComparisonTrackerMapBase<2, SINGLE_IOV, SiStripDetVOffPI::t_HV>;
+
+  using SiStripDetVOffComparisonTrackerMapSingleTag =
+      SiStripDetVOffComparisonTrackerMapBase<1, MULTI_IOV, SiStripDetVOffPI::t_V>;
+  using SiStripDetVOffComparisonTrackerMapTwoTags =
+      SiStripDetVOffComparisonTrackerMapBase<2, SINGLE_IOV, SiStripDetVOffPI::t_V>;
 
 }  // namespace
 
@@ -620,6 +708,10 @@ PAYLOAD_INSPECTOR_MODULE(SiStripDetVOff) {
   PAYLOAD_INSPECTOR_CLASS(SiStripLVOffListOfModules);
   PAYLOAD_INSPECTOR_CLASS(SiStripHVOffListOfModules);
   PAYLOAD_INSPECTOR_CLASS(SiStripDetVOffByRegion);
+  PAYLOAD_INSPECTOR_CLASS(SiStripDetLVOffComparisonTrackerMapSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiStripDetLVOffComparisonTrackerMapTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiStripDetHVOffComparisonTrackerMapSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiStripDetHVOffComparisonTrackerMapTwoTags);
   PAYLOAD_INSPECTOR_CLASS(SiStripDetVOffComparisonTrackerMapSingleTag);
   PAYLOAD_INSPECTOR_CLASS(SiStripDetVOffComparisonTrackerMapTwoTags);
 }

--- a/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
@@ -446,6 +446,167 @@ namespace {
     TrackerTopology m_trackerTopo;
   };
 
+  /************************************************
+   TrackerMap of difference per Module L- H- L||V Voff
+  *************************************************/
+  template <int ntags, IOVMultiplicity nIOVs>
+  class SiStripDetVOffComparisonTrackerMapBase : public PlotImage<SiStripDetVOff, nIOVs, ntags> {
+  public:
+    SiStripDetVOffComparisonTrackerMapBase()
+        : PlotImage<SiStripDetVOff, nIOVs, ntags>("SiStripDetVOff Comparison TrackerMap") {}
+
+    bool fill() override {
+      // trick to deal with the multi-ioved tag and two tag case at the same time
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
+      std::string tagname2 = "";
+      auto firstiov = theIOVs.front();
+      std::tuple<cond::Time_t, cond::Hash> lastiov;
+
+      // we don't support (yet) comparison with more than 2 tags
+      assert(this->m_plotAnnotations.ntags < 3);
+
+      if (this->m_plotAnnotations.ntags == 2) {
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
+        lastiov = tag2iovs.front();
+      } else {
+        lastiov = theIOVs.back();
+      }
+
+      std::shared_ptr<SiStripDetVOff> payload1 = this->fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<SiStripDetVOff> payload2 = this->fetchPayload(std::get<1>(firstiov));
+
+      if (!payload1 || !payload2)
+        return false;
+
+      std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
+      std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
+
+      std::stringstream title;
+      title << "SiStripDetVOff comparison\n"
+            << "IOV " << firstIOVsince << " -> " << lastIOVsince;
+
+      std::unique_ptr<TrackerMap> tmap = std::make_unique<TrackerMap>(title.str());
+
+      //---------------------------------------
+      // build union of detids
+      //---------------------------------------
+
+      std::vector<uint32_t> detids1;
+      payload1->getDetIds(detids1);
+      std::vector<uint32_t> detids2;
+      payload1->getDetIds(detids1);
+
+      std::set<uint32_t> detids;
+
+      for (auto const& d : detids1)
+        detids.insert(d);
+
+      for (auto const& d : detids2)
+        detids.insert(d);
+
+      //---------------------------------------
+      // statistics
+      //---------------------------------------
+
+      int becameOff = 0;
+      int becameOn = 0;
+      int unchangedOff = 0;
+      int unchangedOn = 0;
+
+      std::map<std::string, int> subdetStats;
+
+      //---------------------------------------
+      // loop modules
+      //---------------------------------------
+
+      for (auto detid : detids) {
+        bool off1 = payload1->IsModuleVOff(detid);
+        bool off2 = payload2->IsModuleVOff(detid);
+
+        float value = 0;
+
+        if (!off1 && off2) {
+          value = 1;
+          becameOff++;
+        } else if (off1 && !off2) {
+          value = -1;
+          becameOn++;
+        } else if (off1 && off2) {
+          value = 0.5;
+          unchangedOff++;
+        } else {
+          value = 0;
+          unchangedOn++;
+        }
+
+        tmap->fill(detid, value);
+
+        //-----------------------------------
+        // subdetector classification
+        //-----------------------------------
+
+        uint32_t subdet = DetId(detid).subdetId();
+
+        std::string label;
+
+        if (subdet == StripSubdetector::TIB)
+          label = "TIB";
+        if (subdet == StripSubdetector::TID)
+          label = "TID";
+        if (subdet == StripSubdetector::TOB)
+          label = "TOB";
+        if (subdet == StripSubdetector::TEC)
+          label = "TEC";
+
+        if (off2)
+          subdetStats[label]++;
+      }
+
+      //---------------------------------------
+      // configure color scale
+      //---------------------------------------
+
+      tmap->setRange(-1, 1);
+
+      //---------------------------------------
+      // summary text
+      //---------------------------------------
+
+      std::stringstream summary;
+
+      summary << "ON->OFF: " << becameOff << "  OFF->ON: " << becameOn << "  OFF->OFF: " << unchangedOff
+              << "  ON->ON: " << unchangedOn;
+
+      summary << "\n";
+
+      for (auto const& s : subdetStats)
+        summary << s.first << ":" << s.second << " ";
+
+      std::cout << summary.str() << std::endl;
+      //tmap->setTitle(summary.str());
+
+      //---------------------------------------
+      // save
+      //---------------------------------------
+
+      std::string fileName = "SiStripDetVOffComparisonTrackerMap.png";
+
+      tmap->setPalette(1);  // after setting palette ensure background not cyan
+      gStyle->SetCanvasColor(kWhite);
+      
+      tmap->save(true, 0, 0, fileName);
+
+      this->m_imageFileName = fileName;
+
+      return true;
+    }
+  };
+
+  using SiStripDetVOffComparisonTrackerMapSingleTag = SiStripDetVOffComparisonTrackerMapBase<1, MULTI_IOV>;
+  using SiStripDetVOffComparisonTrackerMapTwoTags = SiStripDetVOffComparisonTrackerMapBase<2, SINGLE_IOV>;
+
 }  // namespace
 
 PAYLOAD_INSPECTOR_MODULE(SiStripDetVOff) {
@@ -459,4 +620,6 @@ PAYLOAD_INSPECTOR_MODULE(SiStripDetVOff) {
   PAYLOAD_INSPECTOR_CLASS(SiStripLVOffListOfModules);
   PAYLOAD_INSPECTOR_CLASS(SiStripHVOffListOfModules);
   PAYLOAD_INSPECTOR_CLASS(SiStripDetVOffByRegion);
+  PAYLOAD_INSPECTOR_CLASS(SiStripDetVOffComparisonTrackerMapSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiStripDetVOffComparisonTrackerMapTwoTags);
 }

--- a/CondCore/SiStripPlugins/test/test.sh
+++ b/CondCore/SiStripPlugins/test/test.sh
@@ -116,6 +116,15 @@ getPayloadData.py \
     --db Prod \
     --test;
 
+getPayloadData.py \
+    --plugin pluginSiStripDetVOff_PayloadInspector \
+    --plot plot_SiStripDetVOffComparisonTrackerMapSingleTag \
+    --tag SiStripDetVOff_NGTDemonstrator \
+    --time_type Run \
+    --iovs '{"start_iov": "1725125154046333", "end_iov": "1726422234169390"}' \
+    --db Prod \
+    --test;
+
 ######################
 # Test dumping of switched off modules
 ######################


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/50435

#### PR description:

This PR adds configurable background colors to `TrackerMap` and introduces new comparison `TrackerMaps` for `SiStripDetVOff` payloads with enhanced IOV handling and state transition visualization.
This allows to monitor one class of payloads now introduced for the 3.4 "Optimal Calibration" NGT demonstrator [link](https://indico.cern.ch/event/1660953/contributions/6980348/subcontributions/604505/attachments/3235612/5769937/ProgressRun3Demonstrator.pdf).

- Add configurable background color support to `TrackerMap` via new `setBackgroundColor()` method and internal `padColor_` member (default preserved).
- Refactor `TrackerMap` includes and initialization for clarity while keeping existing behavior unchanged.
- Improve `SiStripDetVOff` payload inspector handling of IOV formatting by using `TagInfo` and supporting `runnumber`, `lumiid`, and `timestamp` time types.
- Introduce new comparison `TrackerMap` plots for `SiStripDetVOff` payloads (LV, HV, and combined V).
   - Comparison maps highlight module state transitions (ON→OFF, OFF→ON, unchanged states) with a dedicated color scale.
   - Support both single-tag multi-IOV and two-tag single-IOV comparisons.
   - Add summary statistics and per-subdetector counts during map generation.
   - Use a distinct background color for comparison maps to improve readability.
   - Register the new plots in the payload inspector plugin.
   - Extend the test script with a validation example for the new comparison plot.

#### PR validation:

Run this script:
```
getPayloadData.py \
    --plugin pluginSiStripDetVOff_PayloadInspector \
    --plot plot_SiStripDetVOffComparisonTrackerMapSingleTag \
    --tag SiStripDetVOff_NGTDemonstrator \
    --time_type Run \
    --iovs '{"start_iov": "1725125154046333", "end_iov": "1726422234169390"}' \
    --db Prod \
    --test;
```

and obtained the following plot:

<img width="1496" height="772" alt="b4c72683-3d7c-4a9f-87ee-a6f92e92d7d9" src="https://github.com/user-attachments/assets/36f44b44-edb0-4ab4-97f4-44312ff7a3f3" />

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/50435.