### PR TITLE
[MUO] Backport to remove selection on muon in custom MUO flavored NanoAOD in 15.0

### DIFF
--- a/PhysicsTools/NanoAOD/python/custom_muon_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_muon_cff.py
@@ -365,6 +365,13 @@ def IncreaseGenPrecesion(process):
     
     return process
 
+def ModifyMuonSelection(process):
+
+    process.finalMuons.cut = cms.string("pt > 2")
+
+    return process
+
+
 def PrepMuonCustomNanoAOD(process):
     
     process = Custom_Muon_Task(process)
@@ -372,6 +379,6 @@ def PrepMuonCustomNanoAOD(process):
     process = AddVariablesForMuon(process)
     process = AddTriggerObjectBits(process)
     process = IncreaseGenPrecesion(process)
-
+    process = ModifyMuonSelection(process)
 
     return process


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/50442 
to add a method to custom the selection of the muons entering in the MUO flavored NanoAOD in 15_0_X

This issue was presented in the last [PPD General meeting](https://indico.cern.ch/event/1653664/#3-muo-look-into-2025-data-with).

#### PR validation:

Same as original PR.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Original PR:  https://github.com/cms-sw/cmssw/pull/50442

We need this change to be ported in any release that will be used to process/re-process MUO flavored NanoAOD