### PR TITLE
[Scouting Offline DQM] Fix error raised from RECO input

### DIFF
--- a/HLTriggerOffline/Scouting/plugins/PatElectronTagProbeAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/PatElectronTagProbeAnalyzer.cc
@@ -352,9 +352,14 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
     const auto pat_index = indexed_patElectrons[pat_local_index].first;
     const auto pat_el = indexed_patElectrons[pat_local_index].second;
 
-    edm::Ref<edm::View<pat::Electron>> electronRef(patEls, pat_index);
-    if (!((*tight_ele_id_decisions)[electronRef]))
+    const auto& ele = patEls->at(pat_index);
+    const auto& origRef = ele.originalObjectRef();
+
+    if (!(origRef.isNonnull() && origRef.isAvailable() && tight_ele_id_decisions->contains(origRef.id()) &&
+          (*tight_ele_id_decisions)[origRef])) {
       continue;
+    }
+
     ROOT::Math::PtEtaPhiMVector tag_pat_el(pat_el.pt(), pat_el.eta(), pat_el.phi(), pat_el.mass());
 
     // Probe electron: from pat electron
@@ -363,9 +368,14 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
          second_pat_local_index++) {
       const auto second_pat_index = indexed_patElectrons[second_pat_local_index].first;
       const auto pat_el_second = indexed_patElectrons[second_pat_local_index].second;
-      edm::Ref<edm::View<pat::Electron>> second_electronRef(patEls, second_pat_index);
-      if (!((*tight_ele_id_decisions)[second_electronRef]))
+
+      const auto& second_ele = patEls->at(second_pat_index);
+      const auto& second_origRef = second_ele.originalObjectRef();
+      if (!(second_origRef.isNonnull() && second_origRef.isAvailable() &&
+            tight_ele_id_decisions->contains(second_origRef.id()) && (*tight_ele_id_decisions)[second_origRef])) {
         continue;
+      }
+
       second_pat_pt_order += 1;
       if (pat_index == second_pat_index)
         continue;

--- a/HLTriggerOffline/Scouting/plugins/ScoutingEGammaCollectionMonitoring.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingEGammaCollectionMonitoring.cc
@@ -158,7 +158,14 @@ void ScoutingEGammaCollectionMonitoring::analyze(edm::Event const& iEvent, edm::
       histos.patElectron.electrons.h1Pt->Fill(el->pt());
       histos.patElectron.electrons.h1Eta->Fill(el->eta());
       histos.patElectron.electrons.h1Phi->Fill(el->phi());
-      if (((*tight_ele_id_decisions)[el]))
+      const auto& orig = el->originalObjectRef();
+
+      bool passTight = false;
+      if (orig.isNonnull() && orig.isAvailable() && tight_ele_id_decisions->contains(orig.id())) {
+        passTight = tight_ele_id_decisions->get(orig.id(), orig.key());
+      }
+
+      if (passTight)
         tight_patElectron_index.push_back(i);
     }
 

--- a/HLTriggerOffline/Scouting/plugins/ScoutingElectronTagProbeAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingElectronTagProbeAnalyzer.cc
@@ -197,6 +197,9 @@ void ScoutingElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
   if (useOfflineObject_) {
     edm::Handle<pat::TriggerObjectStandAloneCollection> triggerObjects;
     iEvent.getByToken(triggerObjects_, triggerObjects);
+    if (triggerObjects.failedToGet()) {
+      return;  // add protection against missing input
+    }
     for (size_t iteFilter = 0; iteFilter < filterToMatch_.size(); iteFilter++) {
       std::string filterTag = filterToMatch_.at(iteFilter);
       for (pat::TriggerObjectStandAlone obj : *triggerObjects) {

--- a/HLTriggerOffline/Scouting/python/HLTScoutingEGammaDqmOffline_cff.py
+++ b/HLTriggerOffline/Scouting/python/HLTScoutingEGammaDqmOffline_cff.py
@@ -7,7 +7,7 @@ from RecoEgamma.ElectronIdentification.egmGsfElectronIDs_cff import egmGsfElectr
 
 egmGsfElectronIDsForScoutingDQM = egmGsfElectronIDs.clone()
 egmGsfElectronIDsForScoutingDQM.physicsObjectsIDs = cms.VPSet()
-egmGsfElectronIDsForScoutingDQM.physicsObjectSrc = cms.InputTag('slimmedElectrons')
+egmGsfElectronIDsForScoutingDQM.physicsObjectSrc = cms.InputTag('gedGsfElectrons')
 #note: be careful here to when selecting new ids that the vid tools dont do extra setup for them
 #for example the HEEP cuts need an extra producer which vid tools automatically handles
 from PhysicsTools.SelectorUtils.tools.vid_id_tools import setupVIDSelection


### PR DESCRIPTION
#### PR description:

This PR addresses the issue reported in [CMSALCA-359](https://its.cern.ch/jira/browse/CMSALCA-359), where `dqmoffline` could not run successfully with the RECO/AOD format. At this moment, the solution is a temporary workaround that skips the relevant processing when PAT-level inputs are unavailable, so the corresponding outputs remain empty. This is intended as a quick fix; a follow-up PR will be submitted soon to provide full RECO/AOD compatibility.

#### Description of current change
- skip the relevant processing when PAT-level inputs are unavailable
- switch the VID producer input from `slimmedElectrons` (PAT-level) to `gedGsfElectrons` (RECO-level), with the necessary updates in the plugins to ensure the mapping is handled correctly

#### PR validation:

This PR is prepared from `CMSSW_16_1_0_pre3`
```bash
cmsrel CMSSW_16_1_0_pre3
cd CMSSW_16_1_0_pre3/src
cmsenv
git cms-addpkg HLTriggerOffline/Scouting
scram b && scram b code-checks && scram b code-format && scram b
```
Check the code dependcy
```bash
git cms-checkdeps -a -A
>> Checking HLTriggerOffline/Scouting CMSSW_16_1_0_pre3
   x HLTriggerOffline/Scouting/plugins/PatElectronTagProbeAnalyzer.cc
   x HLTriggerOffline/Scouting/plugins/ScoutingEGammaCollectionMonitoring.cc
   x HLTriggerOffline/Scouting/plugins/ScoutingElectronTagProbeAnalyzer.cc
   x HLTriggerOffline/Scouting/python/HLTScoutingEGammaDqmOffline_cff.py
Checking out these packages: 1
DQMOffline/HLTScouting (python)
```
And

```bash
dasgoclient --limit 0 --format json --query "lumi,file dataset=/ZeroBias/Run2026B-v1/RAW run=401919" | das-selected-lumis.py 625,650 | sort -u >> step1_files.txt
echo '{"401919": [[625, 650]]}' > step1_lumi_ranges.txt
cmsDriver.py step2 --conditions 160X_dataRun3_HLT_TkAl_Target_w12_v1 --data --datatier FEVTDEBUGHLT --era Run3_2026 --eventcontent FEVTDEBUGHLT --filein "filelist:step1_files.txt" --fileout "file:step2.root" --lumiToProcess "step1_lumi_ranges.txt" --nStreams 2 --nThreads 4 --number 50 --process reHLT --python_filename step_2_cfg.py --scenario pp --step L1REPACK:Full,HLT 

# Test both RAW2DIGI,L1Reco,RECO,DQM,PAT & RAW2DIGI,L1Reco,RECO,DQM
cmsDriver.py step3 --conditions 160X_dataRun3_Prompt_TkAl_Target_w12_v1 --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run3 --data --datatier RECO,DQMIO --era Run3_2026 --eventcontent RECO,DQM --filein "file:step2.root" --fileout "file:step3.root" --hltProcess reHLT --nStreams 2 --nThreads 1 --number 50 --process reRECO --python_filename step_3_cfg.py --scenario pp --step RAW2DIGI,L1Reco,RECO,DQM,PAT

cmsDriver.py step3 --conditions 160X_dataRun3_Prompt_TkAl_Target_w12_v1 --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run3 --data --datatier RECO,DQMIO --era Run3_2026 --eventcontent RECO,DQM --filein "file:step2.root" --fileout "file:step3.root" --hltProcess reHLT --nStreams 2 --nThreads 1 --number 50 --process reRECO --python_filename step_3_cfg.py --scenario pp --step RAW2DIGI,L1Reco,RECO,DQM

cmsDriver.py step4 --conditions 160X_dataRun3_Prompt_TkAl_Target_w12_v1 --data --era Run3_2026 --filein "file:step3_inDQM.root" --fileout "file:step4.root" --filetype DQM --nStreams 2  --number 50 --python_filename step_4_cfg.py --scenario pp --step HARVESTING:dqmHarvesting

```
#### Backport plan:
This is targeted to be backported to 16.0.X for 2026 data taking operations.

[c.c. @silviodonato @patinkaew @mmusich  ]
