### PR TITLE
Phase2-hgx365W Add 2 additional materials to be used for the V20 version of HGCal geometry

### DIFF
--- a/Geometry/HGCalCommonData/data/hgcalMaterial/v4/hgcalMaterial.xml
+++ b/Geometry/HGCalCommonData/data/hgcalMaterial/v4/hgcalMaterial.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+<MaterialSection label="hgcalMaterial.xml">
+  <CompositeMaterial name="WCu" density="14.979*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.75">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HGC_G10-FR4" density="1.70*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.18077359">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.4056325">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.27804208">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.068442752">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.067109079">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="PyrexGlass" density="2.230*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.040061">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.539564">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028191">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.011644">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.377220">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.003321">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="LeadGlass" density="2.230*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.156453">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080866">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.008092">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.002651">
+    <rMaterial name="materials:Arsenic"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.751938">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HGC_EEConnector" density="1.214*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HGC_HEConnector" density="1.214*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HGC_Cables" density="2.68*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="materials:Cables"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HGC_EEServices" density="1.214*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HGC_HEServices" density="1.214*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HGC_LDservices" density="0.419*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.321">
+    <rMaterial name="materials:M_NEMA FR4 plate"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.679">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HGC_HDservices" density="0.453*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.511">
+    <rMaterial name="materials:M_NEMA FR4 plate"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.489">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HGC_TileServices" density="1.214*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HGC_Kapton_PDG" density="1.42*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0264">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0733">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2092">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.6911">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HGC_Kapton" density="1.681*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.422">
+    <rMaterial name="hgcalMaterial:HGC_Kapton_PDG"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.320">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.258">
+    <rMaterial name="materials:Epoxy"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HGC_Epoxy" density="1.30*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="materials:Epoxy"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HGC_Hexaboard" density="2.432*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.581">
+    <rMaterial name="materials:M_NEMA FR4 plate"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.419">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HGC_HEBasePlate" density="1.70*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="hgcalMaterial:HGC_G10-FR4"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HFN_EEConnector" density="1.214*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HFN_HEConnector" density="1.214*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HFN_CarbonFib" density="1.69*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.84491305">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042542086">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11254487">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+</MaterialSection>
+
+</DDDefinition>


### PR DESCRIPTION
#### PR description:

Add 2 additional materials to be used for the V20 version of HGCal geometry

#### PR validation:

Will be used in the definitions of HGCalWafers in the V20 version

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special