### PR TITLE
Pixel CPE Generic-only era modifier

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2026_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2026_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
+from Configuration.ProcessModifiers.PixelCPEGeneric_cff import PixelCPEGeneric
 
-Run3_2026 = cms.ModifierChain(Run3_2025)
+Run3_2026 = cms.ModifierChain(Run3_2025, PixelCPEGeneric)


### PR DESCRIPTION
#### PR description:
This PR adds a [modifier](https://github.com/cms-sw/cmssw/blob/master/Configuration/ProcessModifiers/python/PixelCPEGeneric_cff.py) to the Run 3 2026 era configuration that makes the PixelRecHits ESProducers use Generic CPE. The PR is created in case of a possible change in reconstruction during 2026 data-taking.

#### PR validation:

Tested at configuration level with

```
cmsDriver.py step3 --era Run3_2026 --conditions auto:run3_data --data -s RECO --no_exec -n 1 --python_filename test_Run3_SiPixelGenericCPE_2026.py
edmConfigDump test_Run3_SiPixelGenericCPE_2026.py >& alternative.txt
```

The full configuration, w.r.t. the unmodified configuration, only differs in the `PixelCPE` parameter for the two `TkTransientTrackingRecHitBuilderESProducer` for 

```
src$ diff alternative.txt central.txt 
85755c85755
<     PixelCPE = cms.string('PixelCPEGeneric'),
---
>     PixelCPE = cms.string('PixelCPEClusterRepair'),
85766c85766
<     PixelCPE = cms.string('PixelCPEGeneric'),
---
>     PixelCPE = cms.string('PixelCPEClusterRepairWithoutProbQ'),
```

The producers, with the change included, are shown below

```
process.TTRHBuilderAngleAndTemplate = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
    ComponentName = cms.string('WithAngleAndTemplate'),
    ComputeCoarseLocalPositionFromDisk = cms.bool(False),
    Matcher = cms.string('StandardMatcher'),
    Phase2StripCPE = cms.string(''),
    PixelCPE = cms.string('PixelCPEGeneric'),
    StripCPE = cms.string('StripCPEfromTrackAngle'),
    appendToDataLabel = cms.string('')
)


process.TTRHBuilderAngleAndTemplateWithoutProbQ = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
    ComponentName = cms.string('WithAngleAndTemplateWithoutProbQ'),
    ComputeCoarseLocalPositionFromDisk = cms.bool(False),
    Matcher = cms.string('StandardMatcher'),
    Phase2StripCPE = cms.string(''),
    PixelCPE = cms.string('PixelCPEGeneric'),
    StripCPE = cms.string('StripCPEfromTrackAngle'),
    appendToDataLabel = cms.string('')
)
```

Changes are expected in all workflows that use Run3 2026 era modifier.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 16.0.X