### PR TITLE
[EVO] Moved GlobalObjectMapRecord back to global namespace

### DIFF
--- a/DataFormats/L1TGlobal/interface/GlobalObjectMapRecord.h
+++ b/DataFormats/L1TGlobal/interface/GlobalObjectMapRecord.h
@@ -25,60 +25,53 @@
 
 // forward declarations
 
-namespace io_v1 {
-  // class declaration
-  class GlobalObjectMapRecord {
-  public:
-    /// constructor(s)
-    GlobalObjectMapRecord() {}
+// class declaration
+class GlobalObjectMapRecord {
+public:
+  /// constructor(s)
+  GlobalObjectMapRecord() {}
 
-    /// destructor
-    ~GlobalObjectMapRecord() {}
+  /// destructor
+  ~GlobalObjectMapRecord() {}
 
-    void swap(GlobalObjectMapRecord& rh) { m_gtObjectMap.swap(rh.m_gtObjectMap); }
+  void swap(GlobalObjectMapRecord& rh) { m_gtObjectMap.swap(rh.m_gtObjectMap); }
 
-  public:
-    /// return the object map for the algorithm algoNameVal
-    const GlobalObjectMap* getObjectMap(const std::string& algoNameVal) const;
+public:
+  /// return the object map for the algorithm algoNameVal
+  const GlobalObjectMap* getObjectMap(const std::string& algoNameVal) const;
 
-    /// return the object map for the algorithm with bit number const int algoBitNumberVal
-    const GlobalObjectMap* getObjectMap(const int algoBitNumberVal) const;
+  /// return the object map for the algorithm with bit number const int algoBitNumberVal
+  const GlobalObjectMap* getObjectMap(const int algoBitNumberVal) const;
 
-    /// return all the combinations passing the requirements imposed in condition condNameVal
-    /// from algorithm with name algoNameVal
-    const CombinationsWithBxInCond* getCombinationsInCond(const std::string& algoNameVal,
-                                                          const std::string& condNameVal) const;
+  /// return all the combinations passing the requirements imposed in condition condNameVal
+  /// from algorithm with name algoNameVal
+  const CombinationsWithBxInCond* getCombinationsInCond(const std::string& algoNameVal,
+                                                        const std::string& condNameVal) const;
 
-    /// return all the combinations passing the requirements imposed in condition condNameVal
-    /// from algorithm with bit number algoBitNumberVal
-    const CombinationsWithBxInCond* getCombinationsInCond(const int algoBitNumberVal,
-                                                          const std::string& condNameVal) const;
+  /// return all the combinations passing the requirements imposed in condition condNameVal
+  /// from algorithm with bit number algoBitNumberVal
+  const CombinationsWithBxInCond* getCombinationsInCond(const int algoBitNumberVal,
+                                                        const std::string& condNameVal) const;
 
-    /// return the result for the condition condNameVal
-    /// from algorithm with name algoNameVal
-    bool getConditionResult(const std::string& algoNameVal, const std::string& condNameVal) const;
+  /// return the result for the condition condNameVal
+  /// from algorithm with name algoNameVal
+  bool getConditionResult(const std::string& algoNameVal, const std::string& condNameVal) const;
 
-    /// return the result for the condition condNameVal
-    /// from algorithm with bit number algoBitNumberVal
-    bool getConditionResult(const int algoBitNumberVal, const std::string& condNameVal) const;
+  /// return the result for the condition condNameVal
+  /// from algorithm with bit number algoBitNumberVal
+  bool getConditionResult(const int algoBitNumberVal, const std::string& condNameVal) const;
 
-  public:
-    /// get / set the vector of object maps
-    inline const std::vector<GlobalObjectMap>& gtObjectMap() const { return m_gtObjectMap; }
+public:
+  /// get / set the vector of object maps
+  inline const std::vector<GlobalObjectMap>& gtObjectMap() const { return m_gtObjectMap; }
 
-    inline void setGtObjectMap(const std::vector<GlobalObjectMap>& gtObjectMapValue) {
-      m_gtObjectMap = gtObjectMapValue;
-    }
+  inline void setGtObjectMap(const std::vector<GlobalObjectMap>& gtObjectMapValue) { m_gtObjectMap = gtObjectMapValue; }
 
-    inline void swapGtObjectMap(std::vector<GlobalObjectMap>& gtObjectMapValue) {
-      m_gtObjectMap.swap(gtObjectMapValue);
-    }
+  inline void swapGtObjectMap(std::vector<GlobalObjectMap>& gtObjectMapValue) { m_gtObjectMap.swap(gtObjectMapValue); }
 
-  private:
-    std::vector<GlobalObjectMap> m_gtObjectMap;
-  };
+private:
+  std::vector<GlobalObjectMap> m_gtObjectMap;
+};
 
-  inline void swap(GlobalObjectMapRecord& lh, GlobalObjectMapRecord& rh) { lh.swap(rh); }
-}  // namespace io_v1
-using GlobalObjectMapRecord = io_v1::GlobalObjectMapRecord;
+inline void swap(GlobalObjectMapRecord& lh, GlobalObjectMapRecord& rh) { lh.swap(rh); }
 #endif

--- a/DataFormats/L1TGlobal/interface/GlobalObjectMapRecordFwd.h
+++ b/DataFormats/L1TGlobal/interface/GlobalObjectMapRecordFwd.h
@@ -1,8 +1,6 @@
 #ifndef DataFormats_L1TGlobal_GlobalObjectMapRecordFwd_h
 #define DataFormats_L1TGlobal_GlobalObjectMapRecordFwd_h
 
-namespace io_v1 {
-  class GlobalObjectMapRecord;
-}
-using GlobalObjectMapRecord = io_v1::GlobalObjectMapRecord;
+class GlobalObjectMapRecord;
+
 #endif

--- a/DataFormats/L1TGlobal/src/classes_def.xml
+++ b/DataFormats/L1TGlobal/src/classes_def.xml
@@ -20,17 +20,39 @@
   <class name="edm::Wrapper<AXOL1TLScoreBxCollection>"/>
   <class name="std::vector<AXOL1TLScore>"/>
   
-  <class name="io_v1::GlobalObjectMapRecord" ClassVersion="3">
-   <version ClassVersion="3" checksum="1021045974"/>
+  <class name="GlobalObjectMapRecord" ClassVersion="10">
+   <version ClassVersion="10" checksum="1219328086"/>
   </class>
-  <class name="edm::Wrapper<io_v1::GlobalObjectMapRecord>"/>
+  <class name="edm::Wrapper<GlobalObjectMapRecord>"/>
 
-  <class name="GlobalObjectMap" ClassVersion="3">
-   <version ClassVersion="3" checksum="760424007"/>
+  <class name="GlobalObjectMap" ClassVersion="11">
+   <version ClassVersion="11" checksum="760424007"/>
+   <version ClassVersion="10" checksum="1899280385"/>
   </class>
   <class name="edm::Wrapper<GlobalObjectMap>"/>
   <class name="std::vector<GlobalObjectMap>"/>
   <class name="edm::Wrapper<std::vector<GlobalObjectMap> >"/>
+  <!-- Adding ioread rules for backwards compatibility -->
+  <ioread sourceClass="GlobalObjectMap" version="[3-10]"
+          source="std::vector<std::vector<std::vector<L1TObjIndexType>>> m_combinationVector;"
+          targetClass="GlobalObjectMap" target="m_combinationWithBxVector">
+    <![CDATA[
+             m_combinationWithBxVector.clear();
+             m_combinationWithBxVector.reserve(onfile.m_combinationVector.size());
+             for(auto const& a0 : onfile.m_combinationVector) {
+               CombinationsWithBxInCond b0;
+               b0.reserve(a0.size());
+               for(auto const& a1 : a0) {
+                 SingleCombWithBxInCond b1;
+                 b1.reserve(a1.size());
+                 for(auto const a2 : a1) {
+                   b1.emplace_back(0, a2);
+                 }
+                 b0.emplace_back(b1);
+               }
+               m_combinationWithBxVector.emplace_back(b0);
+             }]]>
+  </ioread>
 
   <class name="std::vector<l1t::GlobalObject>"/>
   <class name="std::vector<std::vector<l1t::GlobalObject> >"/>


### PR DESCRIPTION
#### PR description:

This type is stored in the RAW data format so must remain in the global namespace to allow reading old files.

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/2064