### PR TITLE
Rename api to MPIChannel

### DIFF
--- a/HeterogeneousCore/MPICore/interface/MPIChannel.h
+++ b/HeterogeneousCore/MPICore/interface/MPIChannel.h
@@ -1,5 +1,5 @@
-#ifndef HeterogeneousCore_MPICore_interface_api_h
-#define HeterogeneousCore_MPICore_interface_api_h
+#ifndef HeterogeneousCore_MPICore_interface_MPIChannel_h
+#define HeterogeneousCore_MPICore_interface_MPIChannel_h
 
 // C++ standard library headers
 #include <bitset>
@@ -209,4 +209,4 @@ private:
   bool sync_;
 };
 
-#endif  // HeterogeneousCore_MPICore_interface_api_h
+#endif  // HeterogeneousCore_MPICore_interface_MPIChannel_h

--- a/HeterogeneousCore/MPICore/plugins/MPIController.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPIController.cc
@@ -28,9 +28,9 @@
 #include "FWCore/Reflection/interface/TypeWithDict.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/Guid.h"
-#include "HeterogeneousCore/MPICore/interface/api.h"
-#include "HeterogeneousCore/MPICore/interface/messages.h"
+#include "HeterogeneousCore/MPICore/interface/MPIChannel.h"
 #include "HeterogeneousCore/MPICore/interface/MPIToken.h"
+#include "HeterogeneousCore/MPICore/interface/messages.h"
 #include "HeterogeneousCore/MPIServices/interface/MPIService.h"
 
 /* MPIController class

--- a/HeterogeneousCore/MPICore/plugins/MPIReceiver.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPIReceiver.cc
@@ -23,7 +23,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "HeterogeneousCore/MPICore/interface/api.h"
+#include "HeterogeneousCore/MPICore/interface/MPIChannel.h"
 #include "HeterogeneousCore/MPICore/interface/MPIToken.h"
 #include "HeterogeneousCore/TrivialSerialisation/interface/AnyBuffer.h"
 #include "HeterogeneousCore/TrivialSerialisation/interface/SerialiserBase.h"

--- a/HeterogeneousCore/MPICore/plugins/MPISender.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPISender.cc
@@ -30,7 +30,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "HeterogeneousCore/MPICore/interface/api.h"
+#include "HeterogeneousCore/MPICore/interface/MPIChannel.h"
 #include "HeterogeneousCore/MPICore/interface/MPIToken.h"
 #include "HeterogeneousCore/TrivialSerialisation/interface/AnyBuffer.h"
 #include "HeterogeneousCore/TrivialSerialisation/interface/SerialiserBase.h"

--- a/HeterogeneousCore/MPICore/plugins/MPISource.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPISource.cc
@@ -32,10 +32,10 @@
 #include "FWCore/Sources/interface/ProducerSourceBase.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/StreamID.h"
-#include "HeterogeneousCore/MPICore/interface/api.h"
+#include "HeterogeneousCore/MPICore/interface/MPIChannel.h"
+#include "HeterogeneousCore/MPICore/interface/MPIToken.h"
 #include "HeterogeneousCore/MPICore/interface/conversion.h"
 #include "HeterogeneousCore/MPICore/interface/messages.h"
-#include "HeterogeneousCore/MPICore/interface/MPIToken.h"
 #include "HeterogeneousCore/MPIServices/interface/MPIService.h"
 
 class MPISource : public edm::ProducerSourceBase {

--- a/HeterogeneousCore/MPICore/src/MPIChannel.cc
+++ b/HeterogeneousCore/MPICore/src/MPIChannel.cc
@@ -14,7 +14,7 @@
 #include "DataFormats/Provenance/interface/LuminosityBlockAuxiliary.h"
 #include "DataFormats/Provenance/interface/RunAuxiliary.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "HeterogeneousCore/MPICore/interface/api.h"
+#include "HeterogeneousCore/MPICore/interface/MPIChannel.h"
 #include "HeterogeneousCore/MPICore/interface/conversion.h"
 #include "HeterogeneousCore/MPICore/interface/messages.h"
 #include "HeterogeneousCore/TrivialSerialisation/interface/ReaderBase.h"


### PR DESCRIPTION
#### PR description:

Rename `api.{h,cc}` to `MPIChannel.{h,cc}` to follow the CMS coding rules.

#### PR validation:

None.