### PR TITLE
Make the group index deterministic when using MPI configuration splitter

### DIFF
--- a/HeterogeneousCore/MPICore/python/configuration_splitter/module_dependency_analyzer.py
+++ b/HeterogeneousCore/MPICore/python/configuration_splitter/module_dependency_analyzer.py
@@ -5,24 +5,32 @@ from itertools import chain
 import FWCore.ParameterSet.Config as cms
 
 
-def flatten_all_to_module_set(process, user_args):
+def flatten_all_to_module_list(process, user_args):
     """
-    This function ensures that if one of the input arguments was path or sequence, 
-    it will be flattened to a module set for input consistency
+    Flatten input arguments into an ordered list of module names.
+    Preserves user-provided order and avoids duplicates.
     """
-    module_list = set()
+    module_list = []
+    seen = set()
+
     for name in user_args:
         if not hasattr(process, name):
             print(f"[WARN] process has no attribute named '{name}'")
             continue
-        obj_ = getattr(process, name)
-        if hasattr(obj_, "moduleNames"):
-            print("is sequence")
-            module_list.extend(obj_.moduleNames())
-        else:
-            module_list.add(name)
-    return module_list
 
+        obj_ = getattr(process, name)
+
+        if hasattr(obj_, "moduleNames"):
+            for mod in obj_.moduleNames():
+                if mod not in seen:
+                    module_list.append(mod)
+                    seen.add(mod)
+        else:
+            if name not in seen:
+                module_list.append(name)
+                seen.add(name)
+
+    return module_list
 
 class ModuleDependencyAnalyzer:
     def __init__(self, process):
@@ -74,7 +82,7 @@ class ModuleDependencyAnalyzer:
 
         return tags
 
-    def direct_dependencies(self, modules: Set[str]) -> Set[str]:
+    def direct_dependencies(self, modules: List[str]) -> Set[str]:
         """
         Get the modules whose products are needed
         """
@@ -89,7 +97,7 @@ class ModuleDependencyAnalyzer:
         """
         return self.producer_to_consumers.get(producer, set())
 
-    def _restricted_graph(self, modules: Set[str]) -> Dict[str, Set[str]]:
+    def _restricted_graph(self, modules: List[str]) -> Dict[str, Set[str]]:
         """
         Restricted dependency graph, reflecting the relationships between the modules to offload
         """
@@ -104,7 +112,11 @@ class ModuleDependencyAnalyzer:
 
         return graph
     
-    def _connected_groups(self, graph: Dict[str, Set[str]]) -> List[List[str]]:
+    def _connected_groups(
+        self,
+        graph: Dict[str, Set[str]],
+        module_order: List[str],
+    ) -> List[List[str]]:
         """
         Return list of weakly connected components.
         Each component is returned as a list of modules ordered
@@ -114,34 +126,35 @@ class ModuleDependencyAnalyzer:
         # ---- build undirected graph ----
         undirected = defaultdict(set)
 
-        for src, dsts in graph.items():
-            undirected[src]  # ensure node exists
-            for dst in dsts:
+        for src in graph:
+            undirected[src]
+            for dst in graph[src]:
                 undirected[src].add(dst)
                 undirected[dst].add(src)
 
         seen = set()
         components = []
 
-        # ---- find weakly connected components ----
-        for node in undirected:
-            if node in seen:
+        # ---- deterministic traversal using module_order ----
+        for node in module_order:
+            if node not in undirected or node in seen:
                 continue
 
             stack = [node]
-            comp = set()
+            comp = []
 
             while stack:
                 n = stack.pop()
                 if n in seen:
                     continue
                 seen.add(n)
-                comp.add(n)
+                comp.append(n)
+
                 stack.extend(undirected[n] - seen)
 
             components.append(comp)
 
-        # ---- order each component by dependencies ----
+         # ---- order each component by dependencies ----
         ordered_components = []
 
         for comp in components:
@@ -175,13 +188,13 @@ class ModuleDependencyAnalyzer:
             ordered_components.append(ordered)
 
         return ordered_components
-
-    def dependency_groups(self, modules: Set[str]) -> List[List[str]]:
+    
+    def dependency_groups(self, modules: List[str]) -> List[List[str]]:
         """
         Get dependency groups (ordered)
         """
         graph = self._restricted_graph(modules)
-        return self._connected_groups(graph)
+        return self._connected_groups(graph, modules)
 
     def grouped_external_dependencies(
         self,
@@ -222,7 +235,7 @@ class ModuleDependencyAnalyzer:
     def modules_to_send_back_by_group(
         self,
         groups: List[List[str]],
-        modules_to_run_on_both: Set[str],
+        modules_to_run_on_both: List[str],
     ):
         """
         Which offloaded modules must send products back, and which are not needed on local

--- a/HeterogeneousCore/MPICore/scripts/edmMpiSplitConfig
+++ b/HeterogeneousCore/MPICore/scripts/edmMpiSplitConfig
@@ -46,14 +46,14 @@ Optional arguments:
         Print debug outputs
 
 Example 1 (offloading GPU part of ECAL and HCAL):
-    python3 edmMpiSplitConfig hlt.py --remote-modules hltEcalDigisSoA hltEcalUncalibRecHitSoA \
+    edmMpiSplitConfig hlt.py --remote-modules hltEcalDigisSoA hltEcalUncalibRecHitSoA \
         hltHcalDigisSoA hltHbheRecoSoA hltParticleFlowRecHitHBHESoA hltParticleFlowClusterHBHESoA \
         --duplicate-modules hltHcalDigis \
         --output-local local.py \
         --output-remote remote.py
 
 Example 2 (offloading GPU part of ECAL, HCAL and pixels):
-    python3 edmMpiSplitConfig hlt.py --remote-modules hltEcalDigisSoA hltEcalUncalibRecHitSoA \
+    edmMpiSplitConfig hlt.py --remote-modules hltEcalDigisSoA hltEcalUncalibRecHitSoA \
         hltHcalDigisSoA hltHbheRecoSoA hltParticleFlowRecHitHBHESoA hltParticleFlowClusterHBHESoA \
         hltSiPixelClustersSoA hltSiPixelRecHitsSoA hltPixelTracksSoA hltPixelVerticesSoA \
         --duplicate-modules hltHcalDigis hltOnlineBeamSpot   hltOnlineBeamSpotDevice \
@@ -79,7 +79,7 @@ import os
 import sys
 
 from HeterogeneousCore.MPICore.configuration_splitter.cpp_name_getter import CPPNameGetter
-from HeterogeneousCore.MPICore.configuration_splitter.module_dependency_analyzer import ModuleDependencyAnalyzer, flatten_all_to_module_set
+from HeterogeneousCore.MPICore.configuration_splitter.module_dependency_analyzer import ModuleDependencyAnalyzer, flatten_all_to_module_list
 from HeterogeneousCore.MPICore.configuration_splitter.editor_functions import *
 from HeterogeneousCore.MPICore.configuration_splitter.path_state_helpers import *
 from FWCore.ParameterSet.processFromFile import processFromFile
@@ -97,7 +97,7 @@ def main():
         "Examples:\n"
         "\n"
         "Offload ECAL and HCAL GPU reconstruction modules:\n"
-        "  python3 edmMpiSplitConfig.py hlt.py --remote-modules \\\n"
+        "  edmMpiSplitConfig hlt.py --remote-modules \\\n"
         "      hltEcalDigisSoA hltEcalUncalibRecHitSoA \\\n"
         "      hltHcalDigisSoA hltHbheRecoSoA \\\n"
         "      hltParticleFlowRecHitHBHESoA hltParticleFlowClusterHBHESoA \\\n"
@@ -105,7 +105,7 @@ def main():
         "      --output-local local.py --output-remote remote.py\n"
         "\n"
         "Offload ECAL, HCAL and Pixel GPU reconstruction:\n"
-        "  python3 edmMpiSplitConfig.py hlt.py --remote-modules \\\n"
+        "  edmMpiSplitConfig hlt.py --remote-modules \\\n"
         "      hltEcalDigisSoA hltEcalUncalibRecHitSoA \\\n"
         "      hltHcalDigisSoA hltHbheRecoSoA \\\n"
         "      hltParticleFlowRecHitHBHESoA hltParticleFlowClusterHBHESoA \\\n"
@@ -177,11 +177,10 @@ def main():
 
     local_process = processFromFile(str(args.config))
 
-    modules_to_offload = flatten_all_to_module_set(local_process, args.remote_modules)
-    modules_to_run_on_both = flatten_all_to_module_set(local_process, args.duplicate_modules)
+    modules_to_offload = flatten_all_to_module_list(local_process, args.remote_modules)
+    modules_to_run_on_both = flatten_all_to_module_list(local_process, args.duplicate_modules)
     
-    # list of all modules to run on remote
-    modules_to_offload |= modules_to_run_on_both
+    modules_to_offload.extend(m for m in modules_to_run_on_both if m not in modules_to_offload)
 
     analyzer = ModuleDependencyAnalyzer(local_process)
 


### PR DESCRIPTION
#### PR description:

This pull request modifies edmMpiSplitConfig in a way that order of resulting groups in the remote process corresponds to the order in which the modules were added (by the earliest encounter of the module in user args).

This pr fixes the issue [#36](https://github.com/cms-ngt-hlt/ngt32/issues/36)

#### PR validation:

Run integration tests and verified on several different edmMpiSplitConfig commands
