### PR TITLE
Add Phase 2 HLT CPU vs. GPU wf to the ph2_hlt PR tests

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -161,6 +161,7 @@ if __name__ == '__main__':
         'ph2_hlt' : [prefixDet+34.75,    # HLT phase-2 timing menu
                      prefixDet+34.7501,  # HLT phase-2 tracking-only menu
                      prefixDet+34.7502,  # HLT phase-2 tracking menu with tracking ntuple
+                     prefixDet+34.7503,  # HLT phase-2 menu, CPU vs. GPU validation
                      prefixDet+34.751,   # HLT phase-2 timing menu Alpaka variant
                      prefixDet+34.752,   # HLT phase-2 timing menu ticl_v5 variant
                      prefixDet+34.7521,  # HLT phase-2 timing menu ticlv5TrackLinkGNN variant   


### PR DESCRIPTION
Small follow up to #50336, adding the Phase 2 HLT CPU vs. GPU workflow to the list of `ph2_hlt` PR tests. To be tested during PR tests.

This PR can also be used to test https://github.com/cms-sw/cms-bot/pull/2710.