### PR TITLE
Update DeDx calibration tag in the 2025 HI MC GT - [CMSSW_15_1_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -108,7 +108,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2025, Strip tracker in DECO mode
     'phase1_2025_cosmics'          :    '150X_mcRun3_2025cosmics_realistic_deco_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2025 detector for Heavy Ion
-    'phase1_2025_realistic_hi'     :    '151X_mcRun3_2025_realistic_HI_v4',
+    'phase1_2025_realistic_hi'     :    '151X_mcRun3_2025_realistic_HI_v5',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '150X_mcRun4_realistic_v1'
 }


### PR DESCRIPTION
#### PR description:

Update the DeDx calibration tag in the 2025 HI MC GT in autoCond.py proposed in https://cms-talk.web.cern.ch/t/gt-mc-queue-request-for-a-pbpb-run-mc-queue-in-151x/128302/20

The new HI MC GT is 
[151X_mcRun3_2025_realistic_HI_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/151X_mcRun3_2025_realistic_HI_v5)
and  its difference with respect to the previous one is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/151X_mcRun3_2025_realistic_HI_v5/151X_mcRun3_2025_realistic_HI_v4) 


#### PR validation:

Rely on PR tests run in master

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #50507