### PR TITLE
Use WatchRuns in alignment stream modules

### DIFF
--- a/Alignment/CommonAlignment/plugins/APVModeFilter.cc
+++ b/Alignment/CommonAlignment/plugins/APVModeFilter.cc
@@ -52,7 +52,7 @@
 // class declaration
 //
 
-class APVModeFilter : public edm::stream::EDFilter<> {
+class APVModeFilter : public edm::stream::EDFilter<edm::stream::WatchRuns> {
 public:
   explicit APVModeFilter(const edm::ParameterSet&);
   ~APVModeFilter() override = default;

--- a/Alignment/CommonAlignment/plugins/MagneticFieldFilter.cc
+++ b/Alignment/CommonAlignment/plugins/MagneticFieldFilter.cc
@@ -36,7 +36,7 @@
 // class declaration
 //
 
-class MagneticFieldFilter : public edm::stream::EDFilter<> {
+class MagneticFieldFilter : public edm::stream::EDFilter<edm::stream::WatchRuns> {
 public:
   explicit MagneticFieldFilter(const edm::ParameterSet&);
   ~MagneticFieldFilter() override = default;

--- a/Alignment/CommonAlignmentProducer/plugins/LSNumberFilter.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/LSNumberFilter.cc
@@ -11,7 +11,7 @@
 // class declaration
 //
 
-class LSNumberFilter : public edm::stream::EDFilter<> {
+class LSNumberFilter : public edm::stream::EDFilter<edm::stream::WatchRuns> {
 public:
   explicit LSNumberFilter(const edm::ParameterSet&);
   ~LSNumberFilter() override = default;


### PR DESCRIPTION
#### PR description:

- The framework is moving towards requiring the edm::stream::WatchRuns for stream modules using beginRun/endRun transitions.

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/2069