### PR TITLE
Add WatchRuns to calibration stream modules

### DIFF
--- a/CalibCalorimetry/CaloMiscalibTools/interface/HcalRecHitRecalib.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/HcalRecHitRecalib.h
@@ -34,7 +34,7 @@
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 
-class HcalRecHitRecalib : public edm::stream::EDProducer<> {
+class HcalRecHitRecalib : public edm::stream::EDProducer<edm::stream::WatchRuns> {
 public:
   explicit HcalRecHitRecalib(const edm::ParameterSet &);
   ~HcalRecHitRecalib() override;

--- a/CalibPPS/AlignmentRelative/plugins/PPSModifySingularModes.cc
+++ b/CalibPPS/AlignmentRelative/plugins/PPSModifySingularModes.cc
@@ -24,7 +24,7 @@
 /**
  *\brief Modifies the alignment modes unconstrained by the track-based alignment.
  **/
-class PPSModifySingularModes : public edm::stream::EDAnalyzer<> {
+class PPSModifySingularModes : public edm::stream::EDAnalyzer<edm::stream::WatchRuns> {
 public:
   PPSModifySingularModes(const edm::ParameterSet &ps);
 

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.h
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.h
@@ -66,7 +66,9 @@ class SiPixelStatusProducer :
                                    edm::RunCache<SiPixelTopoFinder>,
                                    edm::LuminosityBlockSummaryCache<std::vector<SiPixelDetectorStatus>>,
                                    edm::EndLuminosityBlockProducer,
-                                   edm::Accumulator> {
+                                   edm::Accumulator,
+                                   edm::stream::WatchRuns,
+                                   edm::stream::WatchLuminosityBlocks> {
 public:
   SiPixelStatusProducer(edm::ParameterSet const& iPSet, SiPixelStatusCache const*);
   ~SiPixelStatusProducer() override;

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaGammaJetSelector.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaGammaJetSelector.cc
@@ -60,10 +60,6 @@ public:
   static void globalEndJob(const alCaGammaJetSelector::Counters* counters);
 
 private:
-  void beginRun(edm::Run const&, edm::EventSetup const&) override {}
-  void endRun(edm::Run const&, edm::EventSetup const&) override {}
-  void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {}
-  void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {}
   bool select(const reco::PhotonCollection&, const reco::PFJetCollection&);
 
   // ----------member data ---------------------------

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaHBHEMuonFilter.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaHBHEMuonFilter.cc
@@ -45,7 +45,8 @@ namespace alCaHBHEMuonFilter {
   };
 }  // namespace alCaHBHEMuonFilter
 
-class AlCaHBHEMuonFilter : public edm::stream::EDFilter<edm::GlobalCache<alCaHBHEMuonFilter::Counters> > {
+class AlCaHBHEMuonFilter
+    : public edm::stream::EDFilter<edm::GlobalCache<alCaHBHEMuonFilter::Counters>, edm::stream::WatchRuns> {
 public:
   explicit AlCaHBHEMuonFilter(edm::ParameterSet const&, const alCaHBHEMuonFilter::Counters* count);
   ~AlCaHBHEMuonFilter() override = default;

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaHEMuonFilter.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaHEMuonFilter.cc
@@ -45,7 +45,8 @@ namespace alCaHEMuonFilter {
   };
 }  // namespace alCaHEMuonFilter
 
-class AlCaHEMuonFilter : public edm::stream::EDFilter<edm::GlobalCache<alCaHEMuonFilter::Counters> > {
+class AlCaHEMuonFilter
+    : public edm::stream::EDFilter<edm::GlobalCache<alCaHEMuonFilter::Counters>, edm::stream::WatchRuns> {
 public:
   explicit AlCaHEMuonFilter(edm::ParameterSet const&, const alCaHEMuonFilter::Counters* count);
   ~AlCaHEMuonFilter() override;

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaHcalHBHEMuonProducer.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaHcalHBHEMuonProducer.cc
@@ -78,7 +78,8 @@ namespace alcaHcalHBHEMuonProducer {
   };
 }  // namespace alcaHcalHBHEMuonProducer
 
-class AlCaHcalHBHEMuonProducer : public edm::stream::EDProducer<edm::GlobalCache<alcaHcalHBHEMuonProducer::Counters>> {
+class AlCaHcalHBHEMuonProducer
+    : public edm::stream::EDProducer<edm::GlobalCache<alcaHcalHBHEMuonProducer::Counters>, edm::stream::WatchRuns> {
 public:
   explicit AlCaHcalHBHEMuonProducer(const edm::ParameterSet&, const alcaHcalHBHEMuonProducer::Counters*);
   ~AlCaHcalHBHEMuonProducer() override = default;

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaHcalIsotrkProducer.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaHcalIsotrkProducer.cc
@@ -90,7 +90,8 @@ namespace alCaHcalIsotrkProducer {
   };
 }  // namespace alCaHcalIsotrkProducer
 
-class AlCaHcalIsotrkProducer : public edm::stream::EDProducer<edm::GlobalCache<alCaHcalIsotrkProducer::Counters>> {
+class AlCaHcalIsotrkProducer
+    : public edm::stream::EDProducer<edm::GlobalCache<alCaHcalIsotrkProducer::Counters>, edm::stream::WatchRuns> {
 public:
   explicit AlCaHcalIsotrkProducer(edm::ParameterSet const&, const alCaHcalIsotrkProducer::Counters*);
   ~AlCaHcalIsotrkProducer() override = default;

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksFilter.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksFilter.cc
@@ -69,7 +69,8 @@ namespace alCaIsoTracksFilter {
   };
 }  // namespace alCaIsoTracksFilter
 
-class AlCaIsoTracksFilter : public edm::stream::EDFilter<edm::GlobalCache<alCaIsoTracksFilter::Counters>> {
+class AlCaIsoTracksFilter
+    : public edm::stream::EDFilter<edm::GlobalCache<alCaIsoTracksFilter::Counters>, edm::stream::WatchRuns> {
 public:
   explicit AlCaIsoTracksFilter(edm::ParameterSet const&, const alCaIsoTracksFilter::Counters* count);
   ~AlCaIsoTracksFilter() override = default;

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksProducer.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksProducer.cc
@@ -83,7 +83,8 @@ namespace alCaIsoTracksProducer {
   };
 }  // namespace alCaIsoTracksProducer
 
-class AlCaIsoTracksProducer : public edm::stream::EDProducer<edm::GlobalCache<alCaIsoTracksProducer::Counters> > {
+class AlCaIsoTracksProducer
+    : public edm::stream::EDProducer<edm::GlobalCache<alCaIsoTracksProducer::Counters>, edm::stream::WatchRuns> {
 public:
   explicit AlCaIsoTracksProducer(edm::ParameterSet const&, const alCaIsoTracksProducer::Counters* count);
   ~AlCaIsoTracksProducer() override = default;

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksProducerFilter.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksProducerFilter.cc
@@ -36,7 +36,7 @@ namespace alCaIsoTracksProducerFilter {
 }  // namespace alCaIsoTracksProducerFilter
 
 class AlCaIsoTracksProducerFilter
-    : public edm::stream::EDFilter<edm::GlobalCache<alCaIsoTracksProducerFilter::Counters> > {
+    : public edm::stream::EDFilter<edm::GlobalCache<alCaIsoTracksProducerFilter::Counters>, edm::stream::WatchRuns> {
 public:
   explicit AlCaIsoTracksProducerFilter(edm::ParameterSet const&, const alCaIsoTracksProducerFilter::Counters* count);
   ~AlCaIsoTracksProducerFilter() override = default;

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsolatedBunchSelector.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsolatedBunchSelector.cc
@@ -34,7 +34,8 @@ namespace alCaIsolatedBunchSelector {
   };
 }  // namespace alCaIsolatedBunchSelector
 
-class AlCaIsolatedBunchSelector : public edm::stream::EDFilter<edm::GlobalCache<alCaIsolatedBunchSelector::Counters> > {
+class AlCaIsolatedBunchSelector
+    : public edm::stream::EDFilter<edm::GlobalCache<alCaIsolatedBunchSelector::Counters>, edm::stream::WatchRuns> {
 public:
   explicit AlCaIsolatedBunchSelector(edm::ParameterSet const&, const alCaIsolatedBunchSelector::Counters* count);
   ~AlCaIsolatedBunchSelector() override = default;

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaLowPUHBHEMuonFilter.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaLowPUHBHEMuonFilter.cc
@@ -45,7 +45,8 @@ namespace alCaLowPUHBHEMuonFilter {
   };
 }  // namespace alCaLowPUHBHEMuonFilter
 
-class AlCaLowPUHBHEMuonFilter : public edm::stream::EDFilter<edm::GlobalCache<alCaLowPUHBHEMuonFilter::Counters> > {
+class AlCaLowPUHBHEMuonFilter
+    : public edm::stream::EDFilter<edm::GlobalCache<alCaLowPUHBHEMuonFilter::Counters>, edm::stream::WatchRuns> {
 public:
   explicit AlCaLowPUHBHEMuonFilter(edm::ParameterSet const&, const alCaLowPUHBHEMuonFilter::Counters* count);
   ~AlCaLowPUHBHEMuonFilter() override;

--- a/Calibration/HcalIsolatedTrackReco/plugins/IsolatedPixelTrackCandidateL1TProducer.cc
+++ b/Calibration/HcalIsolatedTrackReco/plugins/IsolatedPixelTrackCandidateL1TProducer.cc
@@ -61,7 +61,7 @@
 
 //#define EDM_ML_DEBUG
 
-class IsolatedPixelTrackCandidateL1TProducer : public edm::stream::EDProducer<> {
+class IsolatedPixelTrackCandidateL1TProducer : public edm::stream::EDProducer<edm::stream::WatchRuns> {
 public:
   IsolatedPixelTrackCandidateL1TProducer(const edm::ParameterSet& ps);
   ~IsolatedPixelTrackCandidateL1TProducer() override;

--- a/Calibration/HcalIsolatedTrackReco/plugins/IsolatedPixelTrackCandidateProducer.cc
+++ b/Calibration/HcalIsolatedTrackReco/plugins/IsolatedPixelTrackCandidateProducer.cc
@@ -60,7 +60,7 @@
 
 //#define EDM_ML_DEBUG
 
-class IsolatedPixelTrackCandidateProducer : public edm::stream::EDProducer<> {
+class IsolatedPixelTrackCandidateProducer : public edm::stream::EDProducer<edm::stream::WatchRuns> {
 public:
   IsolatedPixelTrackCandidateProducer(const edm::ParameterSet& ps);
   ~IsolatedPixelTrackCandidateProducer() override;

--- a/Calibration/TkAlCaRecoProducers/plugins/CalibrationTrackSelectorFromDetIdList.cc
+++ b/Calibration/TkAlCaRecoProducers/plugins/CalibrationTrackSelectorFromDetIdList.cc
@@ -41,7 +41,7 @@ Tracker DetIds
 // class decleration
 //
 
-class dso_hidden CalibrationTrackSelectorFromDetIdList final : public edm::stream::EDProducer<> {
+class dso_hidden CalibrationTrackSelectorFromDetIdList final : public edm::stream::EDProducer<edm::stream::WatchRuns> {
 public:
   explicit CalibrationTrackSelectorFromDetIdList(const edm::ParameterSet &);
   ~CalibrationTrackSelectorFromDetIdList() override;


### PR DESCRIPTION
#### PR description:

This is part of a migration to add edm::stream::Watch* attributes.

#### PR validation:

resolves https://github.com/cms-sw/framework-team/issues/2070