### PR TITLE
Added edm::stream::WatchRuns to FastSimulation modules

### DIFF
--- a/FastSimulation/CaloHitMakers/test/testEcalHitMaker.cc
+++ b/FastSimulation/CaloHitMakers/test/testEcalHitMaker.cc
@@ -53,7 +53,7 @@
 typedef math::XYZVector XYZVector;
 typedef math::XYZVector XYZPoint;
 
-class testEcalHitMaker : public edm::stream::EDAnalyzer<> {
+class testEcalHitMaker : public edm::stream::EDAnalyzer<edm::stream::WatchRuns> {
 public:
   explicit testEcalHitMaker(const edm::ParameterSet&);
   ~testEcalHitMaker();

--- a/FastSimulation/MuonSimHitProducer/plugins/MuonSimHitProducer.cc
+++ b/FastSimulation/MuonSimHitProducer/plugins/MuonSimHitProducer.cc
@@ -48,7 +48,7 @@
 #include "TrackingTools/GeomPropagators/interface/HelixArbitraryPlaneCrossing.h"
 #include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
 
-class MuonSimHitProducer : public edm::stream::EDProducer<> {
+class MuonSimHitProducer : public edm::stream::EDProducer<edm::stream::WatchRuns> {
 public:
   explicit MuonSimHitProducer(const edm::ParameterSet&);
 

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastTrackDeDxProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastTrackDeDxProducer.cc
@@ -64,7 +64,7 @@
 // class declaration
 //
 
-class FastTrackDeDxProducer : public edm::stream::EDProducer<> {
+class FastTrackDeDxProducer : public edm::stream::EDProducer<edm::stream::WatchRuns> {
 public:
   explicit FastTrackDeDxProducer(const edm::ParameterSet&);
   ~FastTrackDeDxProducer() override = default;

--- a/FastSimulation/TrackingRecHitProducer/plugins/TrackingRecHitProducer.cc
+++ b/FastSimulation/TrackingRecHitProducer/plugins/TrackingRecHitProducer.cc
@@ -40,7 +40,7 @@
 #include <memory>
 #include <vector>
 
-class TrackingRecHitProducer : public edm::stream::EDProducer<> {
+class TrackingRecHitProducer : public edm::stream::EDProducer<edm::stream::WatchRuns> {
 private:
   edm::EDGetTokenT<std::vector<PSimHit>> _simHitToken;
   std::vector<std::unique_ptr<TrackingRecHitAlgorithm>> _recHitAlgorithms;


### PR DESCRIPTION

#### PR description:

This is part of a campaign to add the attribute to modules which need it.

#### PR validation:

code compiles.

resolves https://github.com/cms-sw/framework-team/issues/2077